### PR TITLE
Auto-replace dropped partitions with future hourly partitions on rotate

### DIFF
--- a/cmd/bintrail/rotate.go
+++ b/cmd/bintrail/rotate.go
@@ -25,7 +25,8 @@ var rotateCmd = &cobra.Command{
 Old partitions are dropped based on the --retain threshold. For every partition
 dropped, one new hourly partition is automatically added for the future so that
 the total partition count stays constant. Use --add-future to add extra partitions
-on top of the automatic replacements.
+on top of the automatic replacements. Use --no-replace to suppress auto-replacement
+and only add the explicit --add-future count (useful when storage is limited).
 
 Examples:
   # Drop partitions older than 7 days (auto-adds 168 future hourly partitions)
@@ -35,7 +36,13 @@ Examples:
   bintrail rotate --index-dsn "..." --retain 7d --add-future 3
 
   # Only add new future partitions (no drops)
-  bintrail rotate --index-dsn "..." --add-future 7`,
+  bintrail rotate --index-dsn "..." --add-future 7
+
+  # Drop without auto-replacing (pure drop, storage-conscious)
+  bintrail rotate --index-dsn "..." --retain 7d --no-replace
+
+  # Drop without auto-replacing but add 3 explicit extras
+  bintrail rotate --index-dsn "..." --retain 7d --no-replace --add-future 3`,
 	RunE: runRotate,
 }
 
@@ -43,6 +50,7 @@ var (
 	rotIndexDSN           string
 	rotRetain             string
 	rotAddFuture          int
+	rotNoReplace          bool
 	rotArchiveDir         string
 	rotArchiveCompression string
 )
@@ -51,6 +59,7 @@ func init() {
 	rotateCmd.Flags().StringVar(&rotIndexDSN, "index-dsn", "", "DSN for the index MySQL database (required)")
 	rotateCmd.Flags().StringVar(&rotRetain, "retain", "", "Drop partitions older than this duration (e.g. 7d, 24h)")
 	rotateCmd.Flags().IntVar(&rotAddFuture, "add-future", 0, "Extra hourly partitions to add beyond auto-replacements (0 = only add replacements for dropped partitions)")
+	rotateCmd.Flags().BoolVar(&rotNoReplace, "no-replace", false, "Do not auto-add future partitions to replace dropped ones")
 	rotateCmd.Flags().StringVar(&rotArchiveDir, "archive-dir", "", "Directory to write Parquet archives before dropping partitions (empty = no archiving)")
 	rotateCmd.Flags().StringVar(&rotArchiveCompression, "archive-compression", "zstd", "Compression for archive Parquet files (zstd, snappy, gzip, none)")
 	_ = rotateCmd.MarkFlagRequired("index-dsn")
@@ -153,7 +162,11 @@ func runRotate(cmd *cobra.Command, args []string) error {
 	// ── Add new future partitions ─────────────────────────────────────────────
 	// Auto-replace every dropped partition with a new future hourly partition,
 	// plus any extras requested via --add-future.
-	toAdd := droppedCount + rotAddFuture
+	// --no-replace suppresses the auto-replacement; only --add-future count is used.
+	toAdd := rotAddFuture
+	if !rotNoReplace {
+		toAdd += droppedCount
+	}
 	if toAdd > 0 {
 		startDate := nextPartitionStart(partitions)
 		if err := addFuturePartitions(ctx, db, dbName, startDate, toAdd); err != nil {

--- a/cmd/bintrail/rotate_test.go
+++ b/cmd/bintrail/rotate_test.go
@@ -189,25 +189,31 @@ func TestPartitionSpec_shape(t *testing.T) {
 
 // ─── autoAdd calculation ──────────────────────────────────────────────────────
 
-// TestAutoAddReplacesDropped verifies that the toAdd = droppedCount + rotAddFuture
-// formula produces the correct total for the auto-replacement behaviour.
+// TestAutoAddReplacesDropped verifies the toAdd formula for both default and
+// --no-replace modes.
 func TestAutoAddReplacesDropped(t *testing.T) {
 	cases := []struct {
 		dropped   int
 		addFuture int
+		noReplace bool
 		wantTotal int
 	}{
-		{dropped: 0, addFuture: 0, wantTotal: 0},
-		{dropped: 3, addFuture: 0, wantTotal: 3},  // pure retention: 3 dropped → 3 added
-		{dropped: 0, addFuture: 5, wantTotal: 5},  // only --add-future
-		{dropped: 4, addFuture: 2, wantTotal: 6},  // dropped + extra
-		{dropped: 168, addFuture: 0, wantTotal: 168}, // 7-day rotation (168 hourly partitions)
+		{dropped: 0, addFuture: 0, noReplace: false, wantTotal: 0},
+		{dropped: 3, addFuture: 0, noReplace: false, wantTotal: 3},   // pure retention: 3 dropped → 3 added
+		{dropped: 0, addFuture: 5, noReplace: false, wantTotal: 5},   // only --add-future
+		{dropped: 4, addFuture: 2, noReplace: false, wantTotal: 6},   // dropped + extra
+		{dropped: 168, addFuture: 0, noReplace: false, wantTotal: 168}, // 7-day rotation
+		{dropped: 3, addFuture: 0, noReplace: true, wantTotal: 0},    // --no-replace: pure drop, nothing added
+		{dropped: 3, addFuture: 2, noReplace: true, wantTotal: 2},    // --no-replace + --add-future: only explicit extras
 	}
 	for _, c := range cases {
-		got := c.dropped + c.addFuture
-		if got != c.wantTotal {
-			t.Errorf("dropped=%d addFuture=%d: expected toAdd=%d, got %d",
-				c.dropped, c.addFuture, c.wantTotal, got)
+		toAdd := c.addFuture
+		if !c.noReplace {
+			toAdd += c.dropped
+		}
+		if toAdd != c.wantTotal {
+			t.Errorf("dropped=%d addFuture=%d noReplace=%v: expected toAdd=%d, got %d",
+				c.dropped, c.addFuture, c.noReplace, c.wantTotal, toAdd)
 		}
 	}
 }
@@ -238,7 +244,7 @@ func TestRotateCmd_indexDSN_required(t *testing.T) {
 }
 
 func TestRotateCmd_allFlagsRegistered(t *testing.T) {
-	for _, name := range []string{"index-dsn", "retain", "add-future", "archive-dir", "archive-compression"} {
+	for _, name := range []string{"index-dsn", "retain", "add-future", "no-replace", "archive-dir", "archive-compression"} {
 		if rotateCmd.Flag(name) == nil {
 			t.Errorf("flag --%s not registered on rotateCmd", name)
 		}
@@ -248,8 +254,8 @@ func TestRotateCmd_allFlagsRegistered(t *testing.T) {
 // ─── runRotate validation (no DB required) ────────────────────────────────────
 
 func TestRunRotate_noFlagsError(t *testing.T) {
-	savedRetain, savedAdd := rotRetain, rotAddFuture
-	t.Cleanup(func() { rotRetain = savedRetain; rotAddFuture = savedAdd })
+	savedRetain, savedAdd, savedNoReplace := rotRetain, rotAddFuture, rotNoReplace
+	t.Cleanup(func() { rotRetain = savedRetain; rotAddFuture = savedAdd; rotNoReplace = savedNoReplace })
 
 	rotRetain = ""
 	rotAddFuture = 0
@@ -264,8 +270,8 @@ func TestRunRotate_noFlagsError(t *testing.T) {
 }
 
 func TestRunRotate_invalidRetain(t *testing.T) {
-	savedRetain, savedAdd := rotRetain, rotAddFuture
-	t.Cleanup(func() { rotRetain = savedRetain; rotAddFuture = savedAdd })
+	savedRetain, savedAdd, savedNoReplace := rotRetain, rotAddFuture, rotNoReplace
+	t.Cleanup(func() { rotRetain = savedRetain; rotAddFuture = savedAdd; rotNoReplace = savedNoReplace })
 
 	rotRetain = "5weeks" // invalid unit
 	rotAddFuture = 0

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -398,17 +398,26 @@ bintrail status --index-dsn "user:pass@tcp(127.0.0.1:3306)/binlog_index"
 
 The output shows each partition, its hour boundary, and estimated row counts. Identify how many hours of history you're holding.
 
-**Drop old partitions:**
+**Drop old partitions and reclaim space:**
 
 ```sh
-# Keep last 7 days (168 hours), add 48 new future partitions (2 days)
+# Drop partitions older than 7 days without auto-adding replacements
 bintrail rotate \
   --index-dsn  "user:pass@tcp(127.0.0.1:3306)/binlog_index" \
-  --retain     168h \
-  --add-future 48
+  --retain     7d \
+  --no-replace
 ```
 
-Partitions older than the retain threshold are dropped in a single `ALTER TABLE … DROP PARTITION` statement — much faster than `DELETE` on InnoDB.
+Partitions older than the retain threshold are dropped in a single `ALTER TABLE … DROP PARTITION` statement — much faster than `DELETE` on InnoDB. Use `--no-replace` when you genuinely want to reclaim space; without it, `--retain` automatically adds back the same number of future partitions to keep the rolling window size constant.
+
+**Maintain a rolling window (same partition count):**
+
+```sh
+# Drop old partitions, auto-add the same number of replacement future ones
+bintrail rotate \
+  --index-dsn  "user:pass@tcp(127.0.0.1:3306)/binlog_index" \
+  --retain     7d
+```
 
 **Extend the partition range** if the `p_future` catch-all is holding data:
 

--- a/docs/rotation-and-status.md
+++ b/docs/rotation-and-status.md
@@ -72,6 +72,12 @@ The `--retain` flag accepts a duration: `7d` (days) or `24h` (hours). The comman
 
 A single `ALTER TABLE DROP PARTITION` statement for multiple partitions is more efficient than separate statements — MySQL does it in one pass.
 
+After dropping, the command automatically adds the same number of future hourly partitions to keep the rolling window size constant (e.g. dropping 168 partitions adds 168 new ones). Use `--no-replace` to suppress this auto-replacement when you genuinely want to reclaim space:
+
+```sh
+bintrail rotate --index-dsn "..." --retain 7d --no-replace
+```
+
 After dropping, the command warns if `p_future` contains data. If events are landing in `p_future`, it means events are arriving with timestamps beyond all named partition boundaries — you need to add more future partitions.
 
 ---
@@ -206,9 +212,9 @@ bintrail index / bintrail stream
     └── parses events → inserts into binlog_events partitions
         tracks progress in index_state / stream_state
 
-bintrail rotate --retain 7d --add-future 14
+bintrail rotate --retain 7d
     └── drops old partitions (instant metadata operation)
-        adds future partitions (reorganize p_future)
+        auto-adds replacement future partitions (reorganize p_future)
 
 bintrail status
     └── reads index_state, information_schema.PARTITIONS
@@ -230,13 +236,28 @@ bintrail recover
 In production, run `bintrail rotate` from an hourly cron job or systemd timer. A typical setup:
 
 ```sh
-# Drop data older than 30 days (720 hours); ensure 48 hours of future partitions exist
+# Maintain a 30-day rolling window: drop old partitions and auto-add the same count back
+bintrail rotate \
+  --index-dsn "user:pass@tcp(127.0.0.1:3306)/binlog_index" \
+  --retain 720h
+```
+
+`--retain` automatically replaces every dropped partition with a new future hourly partition, keeping the total partition count constant. If you also want extra future partitions beyond the replacements (e.g. 48 hours of extra headroom), use `--add-future`:
+
+```sh
 bintrail rotate \
   --index-dsn "user:pass@tcp(127.0.0.1:3306)/binlog_index" \
   --retain 720h \
-  --add-future 48
+  --add-future 48   # adds 720 replacements + 48 extras = 768 new partitions total
 ```
 
-`--retain` and `--add-future` can be combined in one invocation. The command drops old partitions first, then adds new ones.
+To drop without adding anything back — useful when disk is critically full — use `--no-replace`:
+
+```sh
+bintrail rotate \
+  --index-dsn "user:pass@tcp(127.0.0.1:3306)/binlog_index" \
+  --retain 720h \
+  --no-replace
+```
 
 Schedule the timer to run once per hour. The drop operation is instant, but `REORGANIZE PARTITION` on a partition containing data does a full table scan of `p_future` to redistribute rows — if your `p_future` is empty (because you add future partitions frequently), the reorganize is also instant.


### PR DESCRIPTION
closes #9

## Summary
- When `--retain` drops N partitions, automatically add N new future hourly partitions so the total partition count stays constant (true rotation behavior)
- `--add-future` is now additive on top of auto-replacements (e.g. `--retain 7d --add-future 3` drops old, adds 168 replacements + 3 extras)
- Updated command help text to document the new auto-replacement behavior
- Added `TestAutoAddReplacesDropped` unit test covering the `toAdd = droppedCount + rotAddFuture` formula

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)