### PR TITLE
feat: add profile and access-rule CLI commands

### DIFF
--- a/cmd/bintrail/access.go
+++ b/cmd/bintrail/access.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bintrail/bintrail/internal/config"
+)
+
+// ─── Parent command ───────────────────────────────────────────────────────────
+
+var accessCmd = &cobra.Command{
+	Use:   "access",
+	Short: "Manage access rules for profiles",
+	Long: `Add, remove, or list access rules in the index database.
+
+Access rules map a profile to a flag with allow or deny permission:
+  bintrail access add --profile dev --flag billing --permission deny --index-dsn "..."
+  bintrail access add --profile marketing --flag pii --permission deny --index-dsn "..."`,
+}
+
+var (
+	aclIndexDSN    string
+	aclProfile     string
+	aclFlag        string
+	aclPermission  string
+	aclListProfile string
+)
+
+func init() {
+	accessCmd.PersistentFlags().StringVar(&aclIndexDSN, "index-dsn", "", "DSN for the index MySQL database (required)")
+	_ = accessCmd.MarkPersistentFlagRequired("index-dsn")
+
+	accessCmd.AddCommand(accessAddCmd, accessRemoveCmd, accessListCmd)
+	rootCmd.AddCommand(accessCmd)
+}
+
+// ─── access add ──────────────────────────────────────────────────────────────
+
+var accessAddCmd = &cobra.Command{
+	Use:   "add",
+	Short: "Add an access rule",
+	Args:  cobra.NoArgs,
+	RunE:  runAccessAdd,
+}
+
+func init() {
+	accessAddCmd.Flags().StringVar(&aclProfile, "profile", "", "Profile name (required)")
+	accessAddCmd.Flags().StringVar(&aclFlag, "flag", "", "Flag name (required)")
+	accessAddCmd.Flags().StringVar(&aclPermission, "permission", "", "Permission: allow or deny (required)")
+	_ = accessAddCmd.MarkFlagRequired("profile")
+	_ = accessAddCmd.MarkFlagRequired("flag")
+	_ = accessAddCmd.MarkFlagRequired("permission")
+}
+
+func runAccessAdd(cmd *cobra.Command, args []string) error {
+	if aclPermission != "allow" && aclPermission != "deny" {
+		return fmt.Errorf("--permission must be \"allow\" or \"deny\", got %q", aclPermission)
+	}
+
+	db, err := config.Connect(aclIndexDSN)
+	if err != nil {
+		return fmt.Errorf("failed to connect to index database: %w", err)
+	}
+	defer db.Close()
+
+	var profileID int64
+	err = db.QueryRowContext(cmd.Context(), `SELECT id FROM profiles WHERE name = ?`, aclProfile).Scan(&profileID)
+	if err == sql.ErrNoRows {
+		return fmt.Errorf("profile %q not found", aclProfile)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to look up profile: %w", err)
+	}
+
+	_, err = db.ExecContext(cmd.Context(), `
+		INSERT INTO access_rules (profile_id, flag, permission)
+		VALUES (?, ?, ?)
+		ON DUPLICATE KEY UPDATE permission = VALUES(permission)`,
+		profileID, aclFlag, aclPermission,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to add access rule: %w", err)
+	}
+
+	fmt.Printf("Access rule added: profile=%q flag=%q permission=%s\n", aclProfile, aclFlag, aclPermission)
+	return nil
+}
+
+// ─── access remove ────────────────────────────────────────────────────────────
+
+var accessRemoveCmd = &cobra.Command{
+	Use:   "remove",
+	Short: "Remove an access rule",
+	Args:  cobra.NoArgs,
+	RunE:  runAccessRemove,
+}
+
+func init() {
+	accessRemoveCmd.Flags().StringVar(&aclProfile, "profile", "", "Profile name (required)")
+	accessRemoveCmd.Flags().StringVar(&aclFlag, "flag", "", "Flag name (required)")
+	_ = accessRemoveCmd.MarkFlagRequired("profile")
+	_ = accessRemoveCmd.MarkFlagRequired("flag")
+}
+
+func runAccessRemove(cmd *cobra.Command, args []string) error {
+	db, err := config.Connect(aclIndexDSN)
+	if err != nil {
+		return fmt.Errorf("failed to connect to index database: %w", err)
+	}
+	defer db.Close()
+
+	res, err := db.ExecContext(cmd.Context(), `
+		DELETE ar FROM access_rules ar
+		JOIN profiles p ON ar.profile_id = p.id
+		WHERE p.name = ? AND ar.flag = ?`,
+		aclProfile, aclFlag,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to remove access rule: %w", err)
+	}
+
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		fmt.Printf("Access rule not found: profile=%q flag=%q\n", aclProfile, aclFlag)
+		return nil
+	}
+
+	fmt.Printf("Access rule removed: profile=%q flag=%q\n", aclProfile, aclFlag)
+	return nil
+}
+
+// ─── access list ─────────────────────────────────────────────────────────────
+
+var accessListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List access rules",
+	Args:  cobra.NoArgs,
+	RunE:  runAccessList,
+}
+
+func init() {
+	accessListCmd.Flags().StringVar(&aclListProfile, "profile", "", "Filter by profile name")
+}
+
+func runAccessList(cmd *cobra.Command, args []string) error {
+	db, err := config.Connect(aclIndexDSN)
+	if err != nil {
+		return fmt.Errorf("failed to connect to index database: %w", err)
+	}
+	defer db.Close()
+
+	q := `SELECT p.name, ar.flag, ar.permission, ar.created_at
+	      FROM access_rules ar
+	      JOIN profiles p ON ar.profile_id = p.id`
+	var qargs []any
+	if aclListProfile != "" {
+		q += " WHERE p.name = ?"
+		qargs = append(qargs, aclListProfile)
+	}
+	q += " ORDER BY p.name, ar.flag"
+
+	rows, err := db.QueryContext(cmd.Context(), q, qargs...)
+	if err != nil {
+		return fmt.Errorf("failed to list access rules: %w", err)
+	}
+	defer rows.Close()
+
+	tw := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+	defer tw.Flush()
+	fmt.Fprintln(tw, "PROFILE\tFLAG\tPERMISSION\tCREATED")
+	fmt.Fprintln(tw, "───────\t────\t──────────\t───────")
+
+	n := 0
+	for rows.Next() {
+		var profile, flag, permission string
+		var created time.Time
+		if err := rows.Scan(&profile, &flag, &permission, &created); err != nil {
+			return fmt.Errorf("failed to scan row: %w", err)
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", profile, flag, permission, created.UTC().Format("2006-01-02 15:04:05"))
+		n++
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("row iteration error: %w", err)
+	}
+	if n == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "No access rules found.")
+	}
+	return nil
+}

--- a/cmd/bintrail/access_test.go
+++ b/cmd/bintrail/access_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// ─── Cobra command wiring ─────────────────────────────────────────────────────
+
+func TestAccessCmd_registered(t *testing.T) {
+	found := false
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Use == "access" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'access' command to be registered under rootCmd")
+	}
+}
+
+func TestAccessCmd_subcommandsRegistered(t *testing.T) {
+	subNames := make(map[string]bool)
+	for _, sub := range accessCmd.Commands() {
+		subNames[sub.Use] = true
+	}
+	for _, want := range []string{"add", "remove", "list"} {
+		if !subNames[want] {
+			t.Errorf("expected subcommand %q registered under accessCmd", want)
+		}
+	}
+}
+
+func TestAccessCmd_indexDSNRequired(t *testing.T) {
+	f := accessCmd.PersistentFlags().Lookup("index-dsn")
+	if f == nil {
+		t.Fatal("persistent flag --index-dsn not registered on accessCmd")
+	}
+	if f.Annotations["cobra_annotation_bash_completion_one_required_flag"] == nil {
+		t.Error("--index-dsn should be marked required on accessCmd")
+	}
+}
+
+// ─── access add ──────────────────────────────────────────────────────────────
+
+func TestAccessAddCmd_flagsRegistered(t *testing.T) {
+	for _, name := range []string{"profile", "flag", "permission"} {
+		if accessAddCmd.Flag(name) == nil {
+			t.Errorf("flag --%s not registered on accessAddCmd", name)
+		}
+	}
+}
+
+func TestAccessAddCmd_requiredFlags(t *testing.T) {
+	for _, name := range []string{"profile", "flag", "permission"} {
+		f := accessAddCmd.Flag(name)
+		if f == nil {
+			t.Fatalf("flag --%s not registered on accessAddCmd", name)
+		}
+		if f.Annotations["cobra_annotation_bash_completion_one_required_flag"] == nil {
+			t.Errorf("--%s should be required on accessAddCmd", name)
+		}
+	}
+}
+
+// ─── access remove ────────────────────────────────────────────────────────────
+
+func TestAccessRemoveCmd_flagsRegistered(t *testing.T) {
+	for _, name := range []string{"profile", "flag"} {
+		if accessRemoveCmd.Flag(name) == nil {
+			t.Errorf("flag --%s not registered on accessRemoveCmd", name)
+		}
+	}
+}
+
+func TestAccessRemoveCmd_requiredFlags(t *testing.T) {
+	for _, name := range []string{"profile", "flag"} {
+		f := accessRemoveCmd.Flag(name)
+		if f == nil {
+			t.Fatalf("flag --%s not registered on accessRemoveCmd", name)
+		}
+		if f.Annotations["cobra_annotation_bash_completion_one_required_flag"] == nil {
+			t.Errorf("--%s should be required on accessRemoveCmd", name)
+		}
+	}
+}
+
+// ─── access list ─────────────────────────────────────────────────────────────
+
+func TestAccessListCmd_profileOptional(t *testing.T) {
+	f := accessListCmd.Flag("profile")
+	if f == nil {
+		t.Fatal("flag --profile not registered on accessListCmd")
+	}
+	if f.Annotations["cobra_annotation_bash_completion_one_required_flag"] != nil {
+		t.Error("--profile should not be required on accessListCmd")
+	}
+}
+
+// ─── Validation ──────────────────────────────────────────────────────────────
+
+func TestRunAccessAdd_invalidPermission(t *testing.T) {
+	old := aclPermission
+	t.Cleanup(func() { aclPermission = old })
+	aclPermission = "readwrite"
+
+	err := runAccessAdd(accessAddCmd, nil)
+	if err == nil {
+		t.Fatal("expected error for invalid permission value")
+	}
+	if !strings.Contains(err.Error(), "--permission must be") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}

--- a/cmd/bintrail/profile.go
+++ b/cmd/bintrail/profile.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"fmt"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bintrail/bintrail/internal/config"
+)
+
+// ─── Parent command ───────────────────────────────────────────────────────────
+
+var profileCmd = &cobra.Command{
+	Use:   "profile",
+	Short: "Manage access profiles",
+	Long: `Add, remove, or list named access profiles in the index database.
+
+Profiles are named groups (e.g. "dev", "marketing") used by RBAC access rules.
+Each profile can have any number of access rules that allow or deny specific flags.`,
+}
+
+var (
+	proIndexDSN    string
+	proDescription string
+)
+
+func init() {
+	profileCmd.PersistentFlags().StringVar(&proIndexDSN, "index-dsn", "", "DSN for the index MySQL database (required)")
+	_ = profileCmd.MarkPersistentFlagRequired("index-dsn")
+
+	profileCmd.AddCommand(profileAddCmd, profileRemoveCmd, profileListCmd)
+	rootCmd.AddCommand(profileCmd)
+}
+
+// ─── profile add ─────────────────────────────────────────────────────────────
+
+var profileAddCmd = &cobra.Command{
+	Use:   "add <name>",
+	Short: "Add a profile",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runProfileAdd,
+}
+
+func init() {
+	profileAddCmd.Flags().StringVar(&proDescription, "description", "", "Optional description for the profile")
+}
+
+func runProfileAdd(cmd *cobra.Command, args []string) error {
+	name := args[0]
+
+	db, err := config.Connect(proIndexDSN)
+	if err != nil {
+		return fmt.Errorf("failed to connect to index database: %w", err)
+	}
+	defer db.Close()
+
+	_, err = db.ExecContext(cmd.Context(), `
+		INSERT INTO profiles (name, description)
+		VALUES (?, ?)
+		ON DUPLICATE KEY UPDATE description = VALUES(description)`,
+		name, proDescription,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to add profile: %w", err)
+	}
+
+	fmt.Printf("Profile %q added.\n", name)
+	return nil
+}
+
+// ─── profile remove ───────────────────────────────────────────────────────────
+
+var profileRemoveCmd = &cobra.Command{
+	Use:   "remove <name>",
+	Short: "Remove a profile and its access rules",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runProfileRemove,
+}
+
+func runProfileRemove(cmd *cobra.Command, args []string) error {
+	name := args[0]
+
+	db, err := config.Connect(proIndexDSN)
+	if err != nil {
+		return fmt.Errorf("failed to connect to index database: %w", err)
+	}
+	defer db.Close()
+
+	res, err := db.ExecContext(cmd.Context(), `DELETE FROM profiles WHERE name = ?`, name)
+	if err != nil {
+		return fmt.Errorf("failed to remove profile: %w", err)
+	}
+
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		fmt.Printf("Profile %q not found.\n", name)
+		return nil
+	}
+
+	fmt.Printf("Profile %q removed.\n", name)
+	return nil
+}
+
+// ─── profile list ─────────────────────────────────────────────────────────────
+
+var profileListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List profiles",
+	Args:  cobra.NoArgs,
+	RunE:  runProfileList,
+}
+
+func runProfileList(cmd *cobra.Command, args []string) error {
+	db, err := config.Connect(proIndexDSN)
+	if err != nil {
+		return fmt.Errorf("failed to connect to index database: %w", err)
+	}
+	defer db.Close()
+
+	rows, err := db.QueryContext(cmd.Context(), `
+		SELECT name, COALESCE(description, ''), created_at
+		FROM profiles
+		ORDER BY name`)
+	if err != nil {
+		return fmt.Errorf("failed to list profiles: %w", err)
+	}
+	defer rows.Close()
+
+	tw := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+	defer tw.Flush()
+	fmt.Fprintln(tw, "NAME\tDESCRIPTION\tCREATED")
+	fmt.Fprintln(tw, "────\t───────────\t───────")
+
+	n := 0
+	for rows.Next() {
+		var name, description string
+		var created time.Time
+		if err := rows.Scan(&name, &description, &created); err != nil {
+			return fmt.Errorf("failed to scan row: %w", err)
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\n", name, description, created.UTC().Format("2006-01-02 15:04:05"))
+		n++
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("row iteration error: %w", err)
+	}
+	if n == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "No profiles found.")
+	}
+	return nil
+}

--- a/cmd/bintrail/profile_test.go
+++ b/cmd/bintrail/profile_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"testing"
+)
+
+// ─── Cobra command wiring ─────────────────────────────────────────────────────
+
+func TestProfileCmd_registered(t *testing.T) {
+	found := false
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Use == "profile" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'profile' command to be registered under rootCmd")
+	}
+}
+
+func TestProfileCmd_subcommandsRegistered(t *testing.T) {
+	subNames := make(map[string]bool)
+	for _, sub := range profileCmd.Commands() {
+		subNames[sub.Use] = true
+	}
+	for _, want := range []string{"add <name>", "remove <name>", "list"} {
+		if !subNames[want] {
+			t.Errorf("expected subcommand %q registered under profileCmd", want)
+		}
+	}
+}
+
+func TestProfileCmd_indexDSNRequired(t *testing.T) {
+	f := profileCmd.PersistentFlags().Lookup("index-dsn")
+	if f == nil {
+		t.Fatal("persistent flag --index-dsn not registered on profileCmd")
+	}
+	if f.Annotations["cobra_annotation_bash_completion_one_required_flag"] == nil {
+		t.Error("--index-dsn should be marked required on profileCmd")
+	}
+}
+
+// ─── profile add ─────────────────────────────────────────────────────────────
+
+func TestProfileAddCmd_descriptionOptional(t *testing.T) {
+	f := profileAddCmd.Flag("description")
+	if f == nil {
+		t.Fatal("flag --description not registered on profileAddCmd")
+	}
+	if f.Annotations["cobra_annotation_bash_completion_one_required_flag"] != nil {
+		t.Error("--description should not be required on profileAddCmd")
+	}
+	if f.DefValue != "" {
+		t.Errorf("--description default should be empty, got %q", f.DefValue)
+	}
+}


### PR DESCRIPTION
closes #42

## Summary
- `bintrail profile add/remove/list` — manage rows in the `profiles` table; `add` is idempotent via `ON DUPLICATE KEY UPDATE description`; `remove` cascades to `access_rules` via FK
- `bintrail access add/remove/list` — manage rows in `access_rules`; `add` validates `--permission allow|deny` before hitting the DB, looks up `profile_id` by name, upserts with `ON DUPLICATE KEY UPDATE permission`; `remove` uses a `JOIN` DELETE to match by profile name + flag; `list` accepts optional `--profile` filter and JOINs `profiles` to display the profile name
- Flag variable prefixes: `pro` (profile), `acl` (access) per convention
- Unit tests: cobra wiring, required-flag annotations, `--description`/`--profile` optional flags, invalid `--permission` validation

## Test plan
- [ ] Unit tests pass (`go test ./... -count=1`)
- [ ] `bintrail profile add dev --description "Developers" --index-dsn ...` creates a profile
- [ ] `bintrail access add --profile dev --flag billing --permission deny --index-dsn ...` creates a rule
- [ ] `bintrail access list --index-dsn ...` shows the rule with profile name
- [ ] `bintrail profile remove dev --index-dsn ...` removes profile and cascades to rules
- [ ] `bintrail access add --permission invalid` returns a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)