### PR TITLE
feat: add --profile RBAC filter to query/recover/MCP tools

### DIFF
--- a/cmd/bintrail-mcp/main.go
+++ b/cmd/bintrail-mcp/main.go
@@ -127,6 +127,7 @@ type queryArgs struct {
 	Flag          string `json:"flag,omitempty" jsonschema:"Filter events from tables or columns carrying this flag"`
 	Format        string `json:"format,omitempty" jsonschema:"Output format: json table or csv (default: json)"`
 	Limit         int    `json:"limit,omitempty" jsonschema:"Maximum number of events to return (default: 100)"`
+	Profile       string `json:"profile,omitempty" jsonschema:"Apply RBAC access rules for this profile (table-level deny and column-level redaction)"`
 }
 
 type recoverArgs struct {
@@ -141,6 +142,7 @@ type recoverArgs struct {
 	ChangedColumn string `json:"changed_column,omitempty" jsonschema:"Filter UPDATE events that modified this column"`
 	Flag          string `json:"flag,omitempty" jsonschema:"Filter events from tables or columns carrying this flag"`
 	Limit         int    `json:"limit,omitempty" jsonschema:"Maximum number of events to reverse (default: 1000)"`
+	Profile       string `json:"profile,omitempty" jsonschema:"Apply RBAC access rules for this profile (table-level deny and column-level redaction)"`
 }
 
 type statusArgs struct {
@@ -160,6 +162,15 @@ func queryTool(ctx context.Context, req *mcp.CallToolRequest, args queryArgs) (*
 		args.GTID, args.Since, args.Until, args.ChangedColumn, args.Flag, args.Limit, 100)
 	if err != nil {
 		return errorResult(err), nil, nil
+	}
+
+	if args.Profile != "" {
+		denyTables, redactCols, err := query.LoadProfileRules(ctx, db, args.Profile)
+		if err != nil {
+			return errorResult(fmt.Errorf("load profile rules: %w", err)), nil, nil
+		}
+		opts.DenyTables = denyTables
+		opts.RedactColumns = redactCols
 	}
 
 	format := args.Format
@@ -201,6 +212,15 @@ func recoverTool(ctx context.Context, req *mcp.CallToolRequest, args recoverArgs
 		args.GTID, args.Since, args.Until, args.ChangedColumn, args.Flag, args.Limit, defaultLimit)
 	if err != nil {
 		return errorResult(err), nil, nil
+	}
+
+	if args.Profile != "" {
+		denyTables, redactCols, err := query.LoadProfileRules(ctx, db, args.Profile)
+		if err != nil {
+			return errorResult(fmt.Errorf("load profile rules: %w", err)), nil, nil
+		}
+		opts.DenyTables = denyTables
+		opts.RedactColumns = redactCols
 	}
 
 	// Load schema resolver best-effort for PK-only WHERE clauses.

--- a/cmd/bintrail/query.go
+++ b/cmd/bintrail/query.go
@@ -60,6 +60,7 @@ var (
 	qArchiveDir string
 	qArchiveS3  string
 	qBintrailID string
+	qProfile    string
 )
 
 func init() {
@@ -78,6 +79,7 @@ func init() {
 	queryCmd.Flags().StringVar(&qArchiveDir, "archive-dir", "", "Local root directory of Parquet archives (requires --bintrail-id)")
 	queryCmd.Flags().StringVar(&qArchiveS3, "archive-s3", "", "S3 root URL prefix of Parquet archives (requires --bintrail-id; e.g. s3://bucket/prefix/); uses the standard AWS credential chain")
 	queryCmd.Flags().StringVar(&qBintrailID, "bintrail-id", "", "Server identity UUID (required when --archive-dir or --archive-s3 is set)")
+	queryCmd.Flags().StringVar(&qProfile, "profile", "", "Apply RBAC access rules for this profile (table-level deny and column-level redaction)")
 	_ = queryCmd.MarkFlagRequired("index-dsn")
 
 	rootCmd.AddCommand(queryCmd)
@@ -97,6 +99,9 @@ func runQuery(cmd *cobra.Command, args []string) error {
 	}
 	if (qArchiveDir != "" || qArchiveS3 != "") && qBintrailID == "" {
 		return fmt.Errorf("--bintrail-id is required when --archive-dir or --archive-s3 is set")
+	}
+	if qProfile != "" && (qArchiveDir != "" || qArchiveS3 != "") {
+		return fmt.Errorf("--profile cannot be combined with --archive-dir or --archive-s3")
 	}
 
 	// ── Parse filter values ───────────────────────────────────────────────────
@@ -132,6 +137,15 @@ func runQuery(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to connect to index database: %w", err)
 	}
 	defer db.Close()
+
+	if qProfile != "" {
+		denyTables, redactCols, err := query.LoadProfileRules(cmd.Context(), db, qProfile)
+		if err != nil {
+			return fmt.Errorf("load profile rules for %q: %w", qProfile, err)
+		}
+		opts.DenyTables = denyTables
+		opts.RedactColumns = redactCols
+	}
 
 	engine := query.New(db)
 

--- a/cmd/bintrail/recover.go
+++ b/cmd/bintrail/recover.go
@@ -59,6 +59,7 @@ var (
 	rOutput    string
 	rDryRun    bool
 	rLimit     int
+	rProfile   string
 )
 
 func init() {
@@ -74,6 +75,7 @@ func init() {
 	recoverCmd.Flags().StringVar(&rOutput, "output", "", "Write recovery SQL to this file (required unless --dry-run)")
 	recoverCmd.Flags().BoolVar(&rDryRun, "dry-run", false, "Print recovery SQL to stdout instead of writing a file")
 	recoverCmd.Flags().IntVar(&rLimit, "limit", 1000, "Maximum number of events to reverse")
+	recoverCmd.Flags().StringVar(&rProfile, "profile", "", "Apply RBAC access rules for this profile (table-level deny and column-level redaction)")
 	_ = recoverCmd.MarkFlagRequired("index-dsn")
 
 	rootCmd.AddCommand(recoverCmd)
@@ -121,6 +123,15 @@ func runRecover(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to connect to index database: %w", err)
 	}
 	defer db.Close()
+
+	if rProfile != "" {
+		denyTables, redactCols, err := query.LoadProfileRules(cmd.Context(), db, rProfile)
+		if err != nil {
+			return fmt.Errorf("load profile rules for %q: %w", rProfile, err)
+		}
+		opts.DenyTables = denyTables
+		opts.RedactColumns = redactCols
+	}
 
 	// ── Load schema resolver (best-effort; non-fatal) ─────────────────────────
 	// The resolver enables PK-only WHERE clauses in recovery SQL.

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -36,6 +36,76 @@ func isHourAligned(t time.Time) bool {
 	return t.Minute() == 0 && t.Second() == 0 && t.Nanosecond() == 0
 }
 
+// ─── RBAC types ───────────────────────────────────────────────────────────────
+
+// SchemaTable identifies a schema+table pair used in RBAC deny rules.
+type SchemaTable struct {
+	Schema string
+	Table  string
+}
+
+// SchemaTableColumn identifies a specific column used in RBAC redaction rules.
+type SchemaTableColumn struct {
+	Schema string
+	Table  string
+	Column string
+}
+
+// LoadProfileRules loads the RBAC deny rules for a named profile and returns
+// the set of tables whose events should be excluded (table-level deny) and the
+// set of columns whose values should be nulled out in query results (column-level deny).
+func LoadProfileRules(ctx context.Context, db *sql.DB, profile string) ([]SchemaTable, []SchemaTableColumn, error) {
+	// Table-level deny rules: tables flagged for 'deny' by this profile.
+	tableRows, err := db.QueryContext(ctx, `
+		SELECT DISTINCT tf.schema_name, tf.table_name
+		FROM access_rules ar
+		JOIN profiles p ON ar.profile_id = p.id
+		JOIN table_flags tf ON tf.flag = ar.flag AND tf.column_name = ''
+		WHERE p.name = ? AND ar.permission = 'deny'`, profile)
+	if err != nil {
+		return nil, nil, fmt.Errorf("load table deny rules: %w", err)
+	}
+	defer tableRows.Close()
+
+	var denyTables []SchemaTable
+	for tableRows.Next() {
+		var st SchemaTable
+		if err := tableRows.Scan(&st.Schema, &st.Table); err != nil {
+			return nil, nil, err
+		}
+		denyTables = append(denyTables, st)
+	}
+	if err := tableRows.Err(); err != nil {
+		return nil, nil, err
+	}
+
+	// Column-level deny rules: specific columns to redact in query results.
+	colRows, err := db.QueryContext(ctx, `
+		SELECT DISTINCT tf.schema_name, tf.table_name, tf.column_name
+		FROM access_rules ar
+		JOIN profiles p ON ar.profile_id = p.id
+		JOIN table_flags tf ON tf.flag = ar.flag AND tf.column_name != ''
+		WHERE p.name = ? AND ar.permission = 'deny'`, profile)
+	if err != nil {
+		return nil, nil, fmt.Errorf("load column redact rules: %w", err)
+	}
+	defer colRows.Close()
+
+	var redactCols []SchemaTableColumn
+	for colRows.Next() {
+		var stc SchemaTableColumn
+		if err := colRows.Scan(&stc.Schema, &stc.Table, &stc.Column); err != nil {
+			return nil, nil, err
+		}
+		redactCols = append(redactCols, stc)
+	}
+	if err := colRows.Err(); err != nil {
+		return nil, nil, err
+	}
+
+	return denyTables, redactCols, nil
+}
+
 // ─── Options ─────────────────────────────────────────────────────────────────
 
 // Options specifies the filter criteria for querying binlog_events.
@@ -51,6 +121,9 @@ type Options struct {
 	ChangedColumn string // column name; matched via JSON_CONTAINS
 	Flag          string // return events from tables/columns carrying this flag
 	Limit         int    // 0 → default 100
+
+	DenyTables    []SchemaTable       // tables excluded by RBAC profile
+	RedactColumns []SchemaTableColumn // column values nulled out by RBAC profile
 }
 
 // ─── ResultRow ────────────────────────────────────────────────────────────────
@@ -91,7 +164,14 @@ func (e *Engine) Fetch(ctx context.Context, opts Options) ([]ResultRow, error) {
 		return nil, fmt.Errorf("query failed: %w", err)
 	}
 	defer rows.Close()
-	return scanRows(rows)
+	results, err := scanRows(rows)
+	if err != nil {
+		return nil, err
+	}
+	if len(opts.RedactColumns) > 0 {
+		applyRedaction(results, opts.RedactColumns)
+	}
+	return results, nil
 }
 
 // Run executes the query and writes formatted results to w.
@@ -188,6 +268,10 @@ func buildQuery(opts Options) (string, []any) {
 			  AND table_flags.flag        = ?)`)
 		args = append(args, opts.Flag)
 	}
+	for _, dt := range opts.DenyTables {
+		where = append(where, "NOT (schema_name = ? AND table_name = ?)")
+		args = append(args, dt.Schema, dt.Table)
+	}
 
 	q := `SELECT event_id, binlog_file, start_pos, end_pos, event_timestamp,
 	             gtid, schema_name, table_name, event_type, pk_values,
@@ -203,6 +287,28 @@ func buildQuery(opts Options) (string, []any) {
 	}
 
 	return q, args
+}
+
+// applyRedaction nulls out denied column values in RowBefore and RowAfter maps.
+func applyRedaction(rows []ResultRow, redact []SchemaTableColumn) {
+	type colKey struct{ schema, table, column string }
+	set := make(map[colKey]struct{}, len(redact))
+	for _, r := range redact {
+		set[colKey{r.Schema, r.Table, r.Column}] = struct{}{}
+	}
+	for i := range rows {
+		r := &rows[i]
+		for col := range r.RowBefore {
+			if _, ok := set[colKey{r.SchemaName, r.TableName, col}]; ok {
+				r.RowBefore[col] = nil
+			}
+		}
+		for col := range r.RowAfter {
+			if _, ok := set[colKey{r.SchemaName, r.TableName, col}]; ok {
+				r.RowAfter[col] = nil
+			}
+		}
+	}
 }
 
 // ─── Row scanner ─────────────────────────────────────────────────────────────

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -433,3 +433,96 @@ func TestWriteCSV_headersAndRow(t *testing.T) {
 		t.Errorf("expected DELETE in data row, got: %s", lines[1])
 	}
 }
+
+// ─── RBAC: buildQuery DenyTables ─────────────────────────────────────────────
+
+func TestBuildQuery_denyTables(t *testing.T) {
+	opts := Options{
+		DenyTables: []SchemaTable{{Schema: "mydb", Table: "secrets"}},
+		Limit:      10,
+	}
+	q, args := buildQuery(opts)
+
+	if !strings.Contains(q, "NOT (schema_name = ? AND table_name = ?)") {
+		t.Errorf("expected NOT deny clause in query: %s", q)
+	}
+	// Schema and table must appear as consecutive args.
+	found := false
+	for i, a := range args {
+		if a == "mydb" && i+1 < len(args) && args[i+1] == "secrets" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected mydb/secrets in args, got %v", args)
+	}
+}
+
+func TestBuildQuery_multipleDenyTables(t *testing.T) {
+	opts := Options{
+		DenyTables: []SchemaTable{
+			{Schema: "db1", Table: "t1"},
+			{Schema: "db2", Table: "t2"},
+		},
+	}
+	q, args := buildQuery(opts)
+
+	count := strings.Count(q, "NOT (schema_name = ? AND table_name = ?)")
+	if count != 2 {
+		t.Errorf("expected 2 NOT deny clauses, got %d: %s", count, q)
+	}
+	if len(args) != 4 {
+		t.Errorf("expected 4 args for 2 deny tables, got %d: %v", len(args), args)
+	}
+}
+
+// ─── RBAC: applyRedaction ─────────────────────────────────────────────────────
+
+func TestApplyRedaction(t *testing.T) {
+	rows := []ResultRow{{
+		SchemaName: "mydb",
+		TableName:  "orders",
+		RowBefore:  map[string]any{"amount": float64(100), "status": "paid"},
+		RowAfter:   map[string]any{"amount": float64(200), "status": "refunded"},
+	}}
+	redact := []SchemaTableColumn{
+		{Schema: "mydb", Table: "orders", Column: "amount"},
+	}
+	applyRedaction(rows, redact)
+
+	if rows[0].RowBefore["amount"] != nil {
+		t.Errorf("expected RowBefore[amount] to be nil, got %v", rows[0].RowBefore["amount"])
+	}
+	if rows[0].RowAfter["amount"] != nil {
+		t.Errorf("expected RowAfter[amount] to be nil, got %v", rows[0].RowAfter["amount"])
+	}
+	// Non-redacted column must be preserved.
+	if rows[0].RowBefore["status"] != "paid" {
+		t.Errorf("expected RowBefore[status]=paid, got %v", rows[0].RowBefore["status"])
+	}
+	if rows[0].RowAfter["status"] != "refunded" {
+		t.Errorf("expected RowAfter[status]=refunded, got %v", rows[0].RowAfter["status"])
+	}
+}
+
+func TestApplyRedaction_wrongTable(t *testing.T) {
+	rows := []ResultRow{{
+		SchemaName: "mydb",
+		TableName:  "products", // different table
+		RowBefore:  map[string]any{"amount": float64(50)},
+		RowAfter:   map[string]any{"amount": float64(60)},
+	}}
+	redact := []SchemaTableColumn{
+		{Schema: "mydb", Table: "orders", Column: "amount"}, // different table
+	}
+	applyRedaction(rows, redact)
+
+	// Values must be unchanged — redaction only applies to the matching table.
+	if rows[0].RowBefore["amount"] != float64(50) {
+		t.Errorf("expected RowBefore[amount]=50, got %v", rows[0].RowBefore["amount"])
+	}
+	if rows[0].RowAfter["amount"] != float64(60) {
+		t.Errorf("expected RowAfter[amount]=60, got %v", rows[0].RowAfter["amount"])
+	}
+}


### PR DESCRIPTION
closes #44

## Summary
- Added `--profile` flag to `bintrail query` and `bintrail recover` to enforce RBAC access rules
- SQL-level table deny: appends `NOT (schema_name = ? AND table_name = ?)` clauses via `DenyTables` in `query.Options`
- Go-level column redaction: `applyRedaction` nulls JSON map keys in `RowBefore`/`RowAfter` for denied columns via `RedactColumns` in `query.Options`
- `LoadProfileRules(ctx, db, profile)` in `internal/query` queries `access_rules JOIN profiles JOIN table_flags` for both table and column deny rules
- MCP: added `profile` parameter to `queryTool` and `recoverTool`
- Security: `--profile` cannot be combined with `--archive-dir` or `--archive-s3` (archive sources don't enforce RBAC)
- 4 new unit tests in `internal/query/query_test.go`

## Test plan
- [ ] Unit tests pass (`go test ./... -count=1`)
- [ ] `--profile` with `--archive-dir` returns validation error
- [ ] Table-level deny adds WHERE NOT clause to SQL
- [ ] Column redaction nulls correct keys in result rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)