### PR TITLE
feat: add --daemon mode to bintrail rotate

### DIFF
--- a/cmd/bintrail/rotate.go
+++ b/cmd/bintrail/rotate.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -42,8 +44,11 @@ Examples:
   # Drop without auto-replacing (pure drop, storage-conscious)
   bintrail rotate --index-dsn "..." --retain 7d --no-replace
 
-  # Drop without auto-replacing but add 3 explicit extras
-  bintrail rotate --index-dsn "..." --retain 7d --no-replace --add-future 3`,
+  # Run as a daemon, rotating every hour
+  bintrail rotate --index-dsn "..." --retain 7d --daemon
+
+  # Run as a daemon with a custom interval
+  bintrail rotate --index-dsn "..." --retain 7d --daemon --interval 6h`,
 	RunE: runRotate,
 }
 
@@ -57,6 +62,8 @@ var (
 	rotBintrailID         string
 	rotArchiveS3          string
 	rotArchiveS3Region    string
+	rotDaemon             bool
+	rotInterval           string
 )
 
 func init() {
@@ -69,14 +76,14 @@ func init() {
 	rotateCmd.Flags().StringVar(&rotBintrailID, "bintrail-id", "", "Server identity UUID (required when --archive-dir is set); archives are written under bintrail_id=<uuid>/event_date=<date>/")
 	rotateCmd.Flags().StringVar(&rotArchiveS3, "archive-s3", "", "S3 destination URL to upload Parquet archives after writing (requires --archive-dir; e.g. s3://my-bucket/archives/)")
 	rotateCmd.Flags().StringVar(&rotArchiveS3Region, "archive-s3-region", "", "AWS region for --archive-s3 (default: from AWS_REGION env var or ~/.aws/config)")
+	rotateCmd.Flags().BoolVar(&rotDaemon, "daemon", false, "Run continuously, repeating rotation on the --interval schedule until SIGINT/SIGTERM")
+	rotateCmd.Flags().StringVar(&rotInterval, "interval", "1h", "How often to run rotation in daemon mode (e.g. 1h, 30m)")
 	_ = rotateCmd.MarkFlagRequired("index-dsn")
 
 	rootCmd.AddCommand(rotateCmd)
 }
 
 func runRotate(cmd *cobra.Command, args []string) error {
-	start := time.Now()
-
 	if rotRetain == "" && rotAddFuture == 0 {
 		return fmt.Errorf("at least one of --retain or --add-future is required")
 	}
@@ -105,15 +112,56 @@ func runRotate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("--index-dsn must include a database name (e.g. user:pass@tcp(host:3306)/binlog_index)")
 	}
 
-	db, err := config.Connect(rotIndexDSN)
-	if err != nil {
-		return fmt.Errorf("failed to connect to index database: %w", err)
+	if rotDaemon {
+		if _, err := time.ParseDuration(rotInterval); err != nil {
+			return fmt.Errorf("--interval: %w", err)
+		}
 	}
-	defer db.Close()
 
-	ctx := cmd.Context()
+	doRotation := func(ctx context.Context) error {
+		db, err := config.Connect(rotIndexDSN)
+		if err != nil {
+			return fmt.Errorf("failed to connect to index database: %w", err)
+		}
+		defer db.Close()
+		return performRotation(ctx, db, dbName, retainDur)
+	}
 
-	// ── Load current partition list ───────────────────────────────────────────
+	if !rotDaemon {
+		return doRotation(cmd.Context())
+	}
+
+	interval, _ := time.ParseDuration(rotInterval) // already validated above
+	ctx, stop := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	slog.Info("rotate daemon started", "interval", interval)
+	if err := doRotation(ctx); err != nil && ctx.Err() == nil {
+		slog.Error("rotation failed", "error", err)
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			slog.Info("rotate daemon stopping")
+			return nil
+		case <-ticker.C:
+			if err := doRotation(ctx); err != nil && ctx.Err() == nil {
+				slog.Error("rotation failed", "error", err)
+			}
+		}
+	}
+}
+
+// performRotation executes one full rotation cycle against an open DB connection.
+// It uses the package-level flag vars (rotRetain, rotAddFuture, rotNoReplace, etc.)
+// so that daemon and one-shot modes share identical rotation logic.
+func performRotation(ctx context.Context, db *sql.DB, dbName string, retainDur time.Duration) error {
+	start := time.Now()
+
+	// ── Load current partition list ─────────────────────────────────────────────
 	partitions, err := listPartitions(ctx, db, dbName)
 	if err != nil {
 		return fmt.Errorf("failed to list partitions: %w", err)
@@ -121,7 +169,7 @@ func runRotate(cmd *cobra.Command, args []string) error {
 
 	// ── Drop old partitions ───────────────────────────────────────────────────
 	var droppedCount int
-	if rotRetain != "" {
+	if retainDur > 0 {
 		cutoff := time.Now().UTC().Add(-retainDur).Truncate(time.Hour)
 		var toDrop []string
 		for _, p := range partitions {
@@ -165,7 +213,7 @@ func runRotate(cmd *cobra.Command, args []string) error {
 					if err != nil {
 						return fmt.Errorf("archive partition %s: %w", name, err)
 					}
-					fmt.Fprintf(os.Stdout, "archived partition %s (%d rows) → %s\n", name, n, outPath)
+					fmt.Fprintf(os.Stdout, "archived partition %s (%d rows) \u2192 %s\n", name, n, outPath)
 
 					if s3Client != nil {
 						key, err := buildS3Key(rotArchiveDir, outPath, s3Prefix)
@@ -200,7 +248,7 @@ func runRotate(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		slog.Warn("could not check p_future data", "error", err)
 	} else if hasFutureData {
-		slog.Warn("p_future partition contains data — events are arriving outside all named partition ranges; consider adding more future partitions with --add-future")
+		slog.Warn("p_future partition contains data \u2014 events are arriving outside all named partition ranges; consider adding more future partitions with --add-future")
 	}
 
 	// ── Add new future partitions ─────────────────────────────────────────────

--- a/cmd/bintrail/rotate_test.go
+++ b/cmd/bintrail/rotate_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-// ─── parseRetain ─────────────────────────────────────────────────────────────
+// ─── parseRetain ───────────────────────────────────────────────────────────────
 
 func TestParseRetain_days(t *testing.T) {
 	d, err := parseRetain("7d")
@@ -55,7 +55,7 @@ func TestParseRetain_invalid(t *testing.T) {
 	}
 }
 
-// ─── partitionDate ────────────────────────────────────────────────────────────
+// ─── partitionDate ──────────────────────────────────────────────────────────────
 
 func TestPartitionDate_valid(t *testing.T) {
 	d, ok := partitionDate("p_2026021900")
@@ -94,7 +94,7 @@ func TestPartitionDate_invalid(t *testing.T) {
 	}
 }
 
-// ─── partitionName ───────────────────────────────────────────────────────────
+// ─── partitionName ──────────────────────────────────────────────────────────────
 
 func TestPartitionName(t *testing.T) {
 	d := time.Date(2026, 2, 19, 0, 0, 0, 0, time.UTC)
@@ -117,7 +117,7 @@ func TestPartitionName_roundTrip(t *testing.T) {
 	}
 }
 
-// ─── nextPartitionStart ───────────────────────────────────────────────────────
+// ─── nextPartitionStart ─────────────────────────────────────────────────────────────
 
 func TestNextPartitionStart_withNamedPartitions(t *testing.T) {
 	partitions := []partitionInfo{
@@ -153,7 +153,7 @@ func TestNextPartitionStart_empty(t *testing.T) {
 	}
 }
 
-// ─── addFuturePartitions SQL shape ───────────────────────────────────────────
+// ─── addFuturePartitions SQL shape ────────────────────────────────────────────
 
 // TestPartitionSpec_shape verifies the generated DDL looks correct without
 // needing a live database.
@@ -187,7 +187,7 @@ func TestPartitionSpec_shape(t *testing.T) {
 	}
 }
 
-// ─── autoAdd calculation ──────────────────────────────────────────────────────
+// ─── autoAdd calculation ────────────────────────────────────────────────────
 
 // TestAutoAddReplacesDropped verifies the toAdd formula for both default and
 // --no-replace modes.
@@ -218,7 +218,7 @@ func TestAutoAddReplacesDropped(t *testing.T) {
 	}
 }
 
-// ─── cobra command wiring ─────────────────────────────────────────────────────
+// ─── cobra command wiring ────────────────────────────────────────────────────
 
 func TestRotateCmd_registered(t *testing.T) {
 	found := false
@@ -254,7 +254,7 @@ func TestRotateCmd_allFlagsRegistered(t *testing.T) {
 	}
 }
 
-// ─── runRotate validation (no DB required) ────────────────────────────────────
+// ─── runRotate validation (no DB required) ──────────────────────────────────
 
 func TestRunRotate_archiveS3RequiresArchiveDir(t *testing.T) {
 	savedRetain, savedAdd, savedDSN, savedArchiveDir, savedArchiveS3 :=
@@ -331,7 +331,7 @@ func TestRunRotate_missingDBName(t *testing.T) {
 	}
 }
 
-// ─── parseRetain boundary values ─────────────────────────────────────────────
+// ─── parseRetain boundary values ─────────────────────────────────────────────────
 
 func TestParseRetain_minimumHour(t *testing.T) {
 	d, err := parseRetain("1h")
@@ -353,7 +353,7 @@ func TestParseRetain_minimumDay(t *testing.T) {
 	}
 }
 
-// ─── cobra flag defaults ──────────────────────────────────────────────────────
+// ─── cobra flag defaults ────────────────────────────────────────────────────
 
 func TestRotateCmd_defaults(t *testing.T) {
 	cases := []struct{ flag, want string }{
@@ -384,7 +384,7 @@ func TestRotateCmd_emptyStringDefaults(t *testing.T) {
 	}
 }
 
-// ─── runRotate positive-path guard tests ──────────────────────────────────────
+// ─── runRotate positive-path guard tests ────────────────────────────────────────
 
 // TestRunRotate_addFutureAlonePassesFirstGuard verifies that providing only
 // --add-future (no --retain) passes the "at least one of" guard.
@@ -421,7 +421,7 @@ func TestRunRotate_retainAlonePassesFirstGuard(t *testing.T) {
 	}
 }
 
-// ─── nextPartitionStart unsorted input ────────────────────────────────────────
+// ─── nextPartitionStart unsorted input ───────────────────────────────────────────
 
 func TestNextPartitionStart_unsortedOrder(t *testing.T) {
 	// Deliberately out of order — must find the maximum date, not the last element.
@@ -434,5 +434,53 @@ func TestNextPartitionStart_unsortedOrder(t *testing.T) {
 	next := nextPartitionStart(partitions)
 	if next.Year() != 2026 || next.Month() != 2 || next.Day() != 19 || next.Hour() != 1 {
 		t.Errorf("expected 2026-02-19 01:00 (max+1h), got %v", next)
+	}
+}
+
+// ─── daemon flag wiring ─────────────────────────────────────────────────────────
+
+func TestRotateCmd_daemonFlagRegistered(t *testing.T) {
+	f := rotateCmd.Flag("daemon")
+	if f == nil {
+		t.Fatal("flag --daemon not registered on rotateCmd")
+	}
+	if f.DefValue != "false" {
+		t.Errorf("expected default false, got %q", f.DefValue)
+	}
+}
+
+func TestRotateCmd_intervalDefault(t *testing.T) {
+	f := rotateCmd.Flag("interval")
+	if f == nil {
+		t.Fatal("flag --interval not registered on rotateCmd")
+	}
+	if f.DefValue != "1h" {
+		t.Errorf("expected default 1h, got %q", f.DefValue)
+	}
+}
+
+func TestRunRotate_daemonInvalidInterval(t *testing.T) {
+	savedRetain, savedAdd, savedDSN, savedDaemon, savedInterval :=
+		rotRetain, rotAddFuture, rotIndexDSN, rotDaemon, rotInterval
+	t.Cleanup(func() {
+		rotRetain = savedRetain
+		rotAddFuture = savedAdd
+		rotIndexDSN = savedDSN
+		rotDaemon = savedDaemon
+		rotInterval = savedInterval
+	})
+
+	rotRetain = "7d"
+	rotAddFuture = 0
+	rotIndexDSN = "user:pass@tcp(localhost:3306)/binlog_index"
+	rotDaemon = true
+	rotInterval = "notaduration"
+
+	err := runRotate(rotateCmd, nil)
+	if err == nil {
+		t.Fatal("expected error for invalid --interval, got nil")
+	}
+	if !strings.Contains(err.Error(), "--interval") {
+		t.Errorf("expected '--interval' in error, got: %v", err)
 	}
 }


### PR DESCRIPTION
closes #20

## Summary
- Added `--daemon` flag to `bintrail rotate` to run as a long-running daemon
- Added `--interval` flag (default `1h`) controlling how often rotation runs
- Extracted rotation body into `performRotation(ctx, db, dbName, retainDur)` helper
- Daemon reconnects to DB on each iteration for resilience (connection errors don't kill the daemon)
- Runs immediately on start, then on ticker
- Graceful shutdown on `SIGINT`/`SIGTERM` via `signal.NotifyContext`
- Invalid `--interval` fails eagerly before any rotation attempt
- 3 new unit tests in `cmd/bintrail/rotate_test.go`

## Test plan
- [ ] Unit tests pass (`go test ./... -count=1`)
- [ ] `--daemon` flag registered with default `false`
- [ ] `--interval` flag registered with default `1h`
- [ ] Invalid `--interval` returns clear error mentioning `--interval`
- [ ] Daemon stops cleanly on SIGINT

🤖 Generated with [Claude Code](https://claude.com/claude-code)