### PR TITLE
fix: normalize shortened UUIDs in GTID sets from RDS

### DIFF
--- a/cmd/bintrail/stream.go
+++ b/cmd/bintrail/stream.go
@@ -262,6 +262,52 @@ func parseSourceDSN(dsn string) (host string, port uint16, user, password string
 	return h, uint16(portN), cfg.User, cfg.Passwd, nil
 }
 
+// normalizeGTIDSet zero-pads each UUID in a GTID set to the standard
+// 8-4-4-4-12 format. Some MySQL-compatible services (e.g. Amazon RDS) return
+// GTIDs with leading zeros stripped from UUID segments, producing UUIDs shorter
+// than 36 characters (e.g. "5512139-1432-11f1-8d8d-0693b428a89b" instead of
+// "05512139-1432-11f1-8d8d-0693b428a89b"). The go-mysql library requires
+// standard-length UUIDs, so this function normalizes before parsing.
+func normalizeGTIDSet(s string) string {
+	// Expected segment lengths in a UUID: 8-4-4-4-12.
+	segLens := [5]int{8, 4, 4, 4, 12}
+
+	// A GTID set is comma-separated entries like "uuid:intervals,uuid:intervals".
+	entries := strings.Split(s, ",")
+	for i, entry := range entries {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		// Split "uuid:intervals" at the first colon.
+		colon := strings.IndexByte(entry, ':')
+		if colon < 0 {
+			continue // malformed, let the parser handle it
+		}
+		uuid := entry[:colon]
+		rest := entry[colon:] // includes the ":"
+
+		parts := strings.Split(uuid, "-")
+		if len(parts) != 5 {
+			continue // not a UUID shape, let the parser handle it
+		}
+
+		changed := false
+		for j, seg := range parts {
+			if len(seg) < segLens[j] {
+				parts[j] = strings.Repeat("0", segLens[j]-len(seg)) + seg
+				changed = true
+			}
+		}
+		if changed {
+			entries[i] = strings.Join(parts, "-") + rest
+		} else {
+			entries[i] = entry
+		}
+	}
+	return strings.Join(entries, ",")
+}
+
 // resolveStart determines the start position for replication. It returns the
 // mode ("position" or "gtid"), file, GTID string, pos, and an optional
 // pre-parsed MysqlGTIDSet (non-nil only in GTID mode).
@@ -278,6 +324,7 @@ func resolveStart(
 			slog.Warn("--start-* flag provided; overriding saved stream state")
 		}
 		if startGTID != "" {
+			startGTID = normalizeGTIDSet(startGTID)
 			gs, parseErr := gomysql.ParseMysqlGTIDSet(startGTID)
 			if parseErr != nil {
 				return "", "", "", 0, nil, fmt.Errorf("invalid --start-gtid: %w", parseErr)
@@ -289,12 +336,13 @@ func resolveStart(
 
 	if saved != nil {
 		if saved.mode == "gtid" {
-			slog.Info("resuming from GTID set", "gtid_set", saved.gtidSet)
-			gs, parseErr := gomysql.ParseMysqlGTIDSet(saved.gtidSet)
+			normalized := normalizeGTIDSet(saved.gtidSet)
+			slog.Info("resuming from GTID set", "gtid_set", normalized)
+			gs, parseErr := gomysql.ParseMysqlGTIDSet(normalized)
 			if parseErr != nil {
 				return "", "", "", 0, nil, fmt.Errorf("invalid saved gtid_set %q: %w", saved.gtidSet, parseErr)
 			}
-			return "gtid", "", saved.gtidSet, 0, gs.(*gomysql.MysqlGTIDSet), nil
+			return "gtid", "", normalized, 0, gs.(*gomysql.MysqlGTIDSet), nil
 		}
 		slog.Info("resuming from position", "file", saved.binlogFile, "pos", saved.binlogPos)
 		return "position", saved.binlogFile, "", uint32(saved.binlogPos), nil, nil

--- a/cmd/bintrail/stream_test.go
+++ b/cmd/bintrail/stream_test.go
@@ -628,3 +628,70 @@ func TestResolveStart_gtidFlagOverridesSavedState(t *testing.T) {
 		t.Error("expected non-nil accGTID when flag GTID overrides saved state")
 	}
 }
+
+// ─── normalizeGTIDSet ────────────────────────────────────────────────────────
+
+func TestNormalizeGTIDSet_standard(t *testing.T) {
+	// Already standard 36-char UUID — no change expected.
+	input := "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-5"
+	got := normalizeGTIDSet(input)
+	if got != input {
+		t.Errorf("expected no change, got %q", got)
+	}
+}
+
+func TestNormalizeGTIDSet_rdsShortened(t *testing.T) {
+	// RDS-style shortened UUID (first segment 7 chars instead of 8).
+	input := "5512139-1432-11f1-8d8d-0693b428a89b:1-7594394"
+	want := "05512139-1432-11f1-8d8d-0693b428a89b:1-7594394"
+	got := normalizeGTIDSet(input)
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestNormalizeGTIDSet_multipleEntries(t *testing.T) {
+	input := "5512139-1432-11f1-8d8d-0693b428a89b:1-100,ab-cdef-1234-5678-abcdefabcdef:1-5"
+	want := "05512139-1432-11f1-8d8d-0693b428a89b:1-100,000000ab-cdef-1234-5678-abcdefabcdef:1-5"
+	got := normalizeGTIDSet(input)
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestNormalizeGTIDSet_parsesAfterNormalization(t *testing.T) {
+	// The RDS GTID should parse successfully after normalization.
+	input := "5512139-1432-11f1-8d8d-0693b428a89b:1-7594394"
+	normalized := normalizeGTIDSet(input)
+	_, err := gomysql.ParseMysqlGTIDSet(normalized)
+	if err != nil {
+		t.Fatalf("ParseMysqlGTIDSet failed after normalization: %v", err)
+	}
+}
+
+func TestNormalizeGTIDSet_empty(t *testing.T) {
+	got := normalizeGTIDSet("")
+	if got != "" {
+		t.Errorf("expected empty string, got %q", got)
+	}
+}
+
+func TestResolveStart_rdsShortGTID(t *testing.T) {
+	// Verify that resolveStart accepts an RDS-style shortened GTID.
+	rdsGTID := "5512139-1432-11f1-8d8d-0693b428a89b:1-7594394"
+	wantGTID := "05512139-1432-11f1-8d8d-0693b428a89b:1-7594394"
+
+	mode, _, gtidStr, _, accGTID, err := resolveStart("", rdsGTID, 0, nil)
+	if err != nil {
+		t.Fatalf("resolveStart with RDS GTID: %v", err)
+	}
+	if mode != "gtid" {
+		t.Errorf("expected mode=gtid, got %q", mode)
+	}
+	if gtidStr != wantGTID {
+		t.Errorf("expected normalized GTID %q, got %q", wantGTID, gtidStr)
+	}
+	if accGTID == nil {
+		t.Error("expected non-nil accGTID")
+	}
+}


### PR DESCRIPTION
closes #63\n\n## Summary\n- Add `normalizeGTIDSet()` that zero-pads each UUID segment to standard 8-4-4-4-12 format\n- Fixes \"invalid UUID length: 35\" error when using GTIDs from Amazon RDS (which strips leading zeros)\n- Applied to both `--start-gtid` flag input and saved checkpoint GTID sets in `resolveStart()`\n\n## Test plan\n- [x] Unit tests for `normalizeGTIDSet` (standard, RDS-shortened, multiple entries, empty, parse-after-normalize)\n- [x] Integration test: `resolveStart` with RDS-style shortened GTID\n- [x] All tests pass (`go test ./... -count=1`)\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)