### PR TITLE
fix: suppress usage output on command errors

### DIFF
--- a/cmd/bintrail/main.go
+++ b/cmd/bintrail/main.go
@@ -34,6 +34,7 @@ binlog files still existing on disk.`,
 		return nil
 	},
 	SilenceErrors: true, // we handle error output ourselves in main()
+	SilenceUsage:  true, // don't print usage/help on errors — users can use --help
 }
 
 func init() {


### PR DESCRIPTION
closes #62\n\n## Summary\n- Set `SilenceUsage: true` on rootCmd so cobra does not print the full flags/usage text when a command returns an error\n- Users can still access help via `--help` or `bintrail help <command>`\n\n## Test plan\n- [x] All tests pass (`go test ./... -count=1`)\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)