### PR TITLE
Add --reset flag to bintrail stream

### DIFF
--- a/cmd/bintrail/stream.go
+++ b/cmd/bintrail/stream.go
@@ -45,6 +45,12 @@ Start position must be specified on the first run via --start-file or
 even if --start-file/--start-gtid are still present on the command line. This
 makes re-running the same command idempotent.
 
+Use --reset to clear the saved checkpoint and force a new start position:
+
+  bintrail stream --reset --start-file mysql-bin.000500 ...
+
+Without --reset, the checkpoint always wins (idempotent behavior is preserved).
+
 Graceful shutdown: send SIGINT or SIGTERM to flush the current batch and write
 a checkpoint before exiting.`,
 	RunE: runStream,
@@ -67,6 +73,7 @@ var (
 	strmSSLCert     string
 	strmSSLKey      string
 	strmFormat      string
+	strmReset       bool
 )
 
 func init() {
@@ -86,6 +93,7 @@ func init() {
 	streamCmd.Flags().StringVar(&strmSSLCert, "ssl-cert", "", "Path to client certificate file for mutual TLS")
 	streamCmd.Flags().StringVar(&strmSSLKey, "ssl-key", "", "Path to client private key file for mutual TLS")
 	streamCmd.Flags().StringVar(&strmFormat, "format", "text", "Output format: text or json")
+	streamCmd.Flags().BoolVar(&strmReset, "reset", false, "Clear saved checkpoint before starting (forces use of --start-file/--start-gtid)")
 	_ = streamCmd.MarkFlagRequired("index-dsn")
 	_ = streamCmd.MarkFlagRequired("source-dsn")
 	_ = streamCmd.MarkFlagRequired("server-id")
@@ -550,6 +558,19 @@ func runStream(cmd *cobra.Command, args []string) error {
 	saved, err := loadStreamState(indexDB)
 	if err != nil {
 		return fmt.Errorf("failed to load stream state: %w", err)
+	}
+
+	if strmReset {
+		if saved != nil {
+			if _, err := indexDB.Exec(`DELETE FROM stream_state WHERE id = 1`); err != nil {
+				return fmt.Errorf("failed to reset stream state: %w", err)
+			}
+			slog.Warn("cleared saved checkpoint (--reset)", "old_mode", saved.mode,
+				"old_file", saved.binlogFile, "old_pos", saved.binlogPos)
+			saved = nil
+		} else {
+			slog.Info("--reset specified but no saved checkpoint exists; ignoring")
+		}
 	}
 
 	mode, startFile, startGTIDStr, startPos, accGTID, err := resolveStart(

--- a/cmd/bintrail/stream_test.go
+++ b/cmd/bintrail/stream_test.go
@@ -476,10 +476,22 @@ func TestStreamCmd_allFlagsRegistered(t *testing.T) {
 		"start-file", "start-pos", "start-gtid",
 		"batch-size", "schemas", "tables", "checkpoint", "metrics-addr",
 		"ssl-mode", "ssl-ca", "ssl-cert", "ssl-key",
+		"reset",
 	} {
 		if streamCmd.Flag(name) == nil {
 			t.Errorf("flag --%s not registered on streamCmd", name)
 		}
+	}
+}
+
+// TestStreamCmd_resetDefaultFalse verifies the --reset flag defaults to false.
+func TestStreamCmd_resetDefaultFalse(t *testing.T) {
+	f := streamCmd.Flag("reset")
+	if f == nil {
+		t.Fatal("flag --reset not registered")
+	}
+	if f.DefValue != "false" {
+		t.Errorf("expected default reset=false, got %q", f.DefValue)
 	}
 }
 


### PR DESCRIPTION
closes #75

## Summary
- Adds `--reset` boolean flag to `bintrail stream` that clears the saved `stream_state` checkpoint before resolving the start position
- When `--reset` is used, the saved checkpoint is deleted from MySQL and start position flags (`--start-file`/`--start-gtid`) take effect
- Without `--reset`, idempotent behavior from #65 is fully preserved
- Logs the old checkpoint state when clearing, and handles the no-op case (no saved state) gracefully

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] `--reset` flag registered with default `false`
- [x] Flag included in `allFlagsRegistered` test

🤖 Generated with [Claude Code](https://claude.com/claude-code)