### PR TITLE
docs: document --retry, --reset, archive stats, and archive_state

### DIFF
--- a/docs/dump-and-baseline.md
+++ b/docs/dump-and-baseline.md
@@ -167,6 +167,7 @@ bintrail baseline \
 | `--row-group-size` | `500000` | Rows per Parquet row group |
 | `--upload` | *(disabled)* | S3 URL to upload Parquet files after generation |
 | `--upload-region` | *(from AWS env)* | AWS region for `--upload` |
+| `--retry` | `false` | Skip tables whose Parquet file already exists and S3 objects already uploaded |
 | `--format` | `text` | Output format: `text` or `json` |
 
 ### Output structure
@@ -199,6 +200,25 @@ bintrail baseline \
 ```
 
 See [Scenario I in the Practical Guide](guide.md#scenario-i-uploading-baseline-parquet-files-to-s3) for full S3 setup instructions.
+
+### Retrying after a failure
+
+If a baseline run fails partway through (e.g. network error during S3 upload, disk full), re-run with `--retry` to skip work that already completed:
+
+```sh
+bintrail baseline \
+  --input         /tmp/mydumper-output \
+  --output        /tmp/baselines \
+  --upload        s3://my-bucket/baselines/ \
+  --upload-region us-east-1 \
+  --retry
+```
+
+With `--retry`:
+- **Local Parquet files**: Tables whose output `.parquet` file already exists are skipped.
+- **S3 uploads**: Files that already exist in S3 (checked via `HeadObject`) are skipped.
+
+This makes the command safe to re-run without duplicating work.
 
 ### No database connection required
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -508,6 +508,20 @@ bintrail rotate \
 
 `--archive-dir` is still required with `--archive-s3` — files are written locally first, then uploaded. Point it at a temporary directory if you don't need local copies after upload. Archives are stored in a Hive-partitioned layout: `bintrail_id=<uuid>/event_date=<YYYY-MM-DD>/events_<HH>.parquet`, compatible with Athena, Glue, and DuckDB.
 
+**Retry after a partial failure:** If archiving or S3 upload fails partway through (network error, disk full, etc.), re-run with `--retry` to pick up where it left off:
+
+```sh
+bintrail rotate \
+  --index-dsn         "user:pass@tcp(127.0.0.1:3306)/binlog_index" \
+  --retain            7d \
+  --archive-dir       /tmp/rotate-staging \
+  --archive-s3        s3://my-bintrail-archives/events/ \
+  --archive-s3-region us-east-1 \
+  --retry
+```
+
+`--retry` skips partitions whose local Parquet file already exists and S3 uploads that already succeeded (tracked in the `archive_state` table).
+
 **Query archived events** using `--archive-s3` on the `query` command. Provide `--bintrail-id` to scope the archive path to your server's UUID (shown in `bintrail status`):
 
 ```sh
@@ -578,6 +592,17 @@ bintrail baseline \
 ```
 
 `--upload` writes Parquet files to `--output` first, then uploads every file to S3 preserving the relative directory structure (`timestamp/database/table.parquet`). Uses the standard AWS credential chain — environment variables, `~/.aws/credentials`, or EC2/ECS instance metadata. `--upload-region` is optional if `AWS_REGION` is already set in your environment or `~/.aws/config`.
+
+If the upload fails partway through, re-run with `--retry` to skip files that already exist locally and in S3:
+
+```bash
+bintrail baseline \
+  --input         /path/to/mydumper-output \
+  --output        /tmp/baselines \
+  --upload        s3://bintrail-audit-baselines/baselines/ \
+  --upload-region us-east-1 \
+  --retry
+```
 
 **Option 2 — Generate locally, upload separately with the AWS CLI:**
 
@@ -705,6 +730,19 @@ bintrail stream \
   --server-id  99999
 # No --start-gtid needed — resumed from stream_state checkpoint
 ```
+
+**Force a new start position** — use `--reset` to clear the saved checkpoint and start from a specific position:
+
+```sh
+bintrail stream \
+  --index-dsn  "user:pass@tcp(127.0.0.1:3306)/binlog_index" \
+  --source-dsn "bintrail_repl:secret@tcp(mydb.us-east-1.rds.amazonaws.com:3306)/" \
+  --server-id  99999 \
+  --start-gtid "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-8000" \
+  --reset
+```
+
+`--reset` is useful when switching between position mode and GTID mode, or when you need to skip ahead past corrupted events. Without `--reset`, the saved checkpoint always takes precedence over `--start-*` flags.
 
 **Monitor** replication lag and throughput:
 

--- a/docs/rotation-and-status.md
+++ b/docs/rotation-and-status.md
@@ -149,6 +149,44 @@ Each archived partition becomes a single Parquet file: `<archive-dir>/p_YYYYMMDD
 
 `--archive-compression` accepts `zstd` (default), `snappy`, `gzip`, or `none`.
 
+### Retrying after a failure
+
+If archiving or S3 upload fails partway through, re-run with `--retry` to skip work that already completed:
+
+```sh
+bintrail rotate \
+  --index-dsn           "user:pass@tcp(127.0.0.1:3306)/binlog_index" \
+  --retain              7d \
+  --archive-dir         /mnt/archives \
+  --archive-s3          s3://my-bintrail-archives/events/ \
+  --archive-compression zstd \
+  --retry
+```
+
+With `--retry`:
+- **Local Parquet files**: Partitions whose Parquet file already exists on disk are skipped.
+- **S3 uploads**: Partitions whose `s3_uploaded_at` is already recorded in the `archive_state` table are skipped.
+
+This makes the command safe to re-run without re-archiving or re-uploading partitions that already succeeded.
+
+### Archive state tracking
+
+Each archived partition is recorded in the `archive_state` table (created by `bintrail init`). This table tracks:
+
+| Column | Description |
+|--------|-------------|
+| `partition_name` | The partition that was archived (e.g. `p_2026021300`) |
+| `bintrail_id` | Server identity UUID |
+| `local_path` | Filesystem path of the Parquet file |
+| `file_size_bytes` | Size of the Parquet file |
+| `row_count` | Number of rows written |
+| `s3_bucket` | S3 bucket (when uploaded) |
+| `s3_key` | S3 object key (when uploaded) |
+| `s3_uploaded_at` | When the S3 upload completed |
+| `archived_at` | When the archive was created |
+
+The `--retry` flag on rotate uses this table to determine which S3 uploads can be skipped.
+
 ### Archiving directly to S3
 
 Pass `--archive-s3` alongside `--archive-dir` to upload each Parquet file to S3 after writing it locally:
@@ -201,13 +239,13 @@ Results from the live MySQL index and from Parquet archives are merged, deduplic
 
 ---
 
-## Status Command: Three Sections
+## Status Command
 
 ```sh
 bintrail status --index-dsn "..."
 ```
 
-The status command produces a three-section report, implemented in `internal/status/status.go`:
+The status command produces a multi-section report, implemented in `internal/status/status.go`:
 
 **Section 1 — Indexed Files**: Shows every row in `index_state`. The `BINTRAIL_ID` column identifies which bintrail server instance indexed each file:
 
@@ -249,6 +287,17 @@ Server (unknown)
 ```
 
 Files with a NULL `bintrail_id` are grouped under `Server (unknown)`. This is common when a shared index database receives files from multiple bintrail instances (e.g. one per replica), or when upgrading from a version predating the server identity feature.
+
+**Section 4 — Archives** (shown when `archive_state` contains data): Displays archive and S3 upload statistics:
+
+```
+=== Archives ===
+Total archived: 168 partitions
+Total size:     4.2 GB (local)
+S3 uploaded:    168 partitions
+```
+
+This section is loaded best-effort — if the `archive_state` table does not exist (older index databases created before the archiving feature), the section is silently omitted.
 
 The row counts in the partitions section are **estimates** from `information_schema.PARTITIONS.TABLE_ROWS`. InnoDB doesn't maintain exact row counts, so these are good approximations for capacity planning but not for exact totals.
 
@@ -296,12 +345,13 @@ bintrail index / bintrail stream
 
 bintrail rotate --retain 7d [--archive-s3 s3://...]
     └── (optional) archives each partition to Parquet → uploads to S3
+        records archive metadata in archive_state
         drops old partitions (instant metadata operation)
         auto-adds replacement future partitions (reorganize p_future)
 
 bintrail status
-    └── reads index_state, information_schema.PARTITIONS
-        prints three-section report (with per-server Summary)
+    └── reads index_state, information_schema.PARTITIONS, archive_state
+        prints multi-section report (files, partitions, summary, archives)
 
 bintrail query [--archive-s3 s3://...]
     └── partition pruning: only reads relevant partitions

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -157,6 +157,29 @@ if ev.GTID != "" && state.accGTID != nil {
 
 **Checkpoint interval**: Default 10 seconds, configurable via `--checkpoint`. This is the maximum amount of data you'd need to re-index if the process crashes — events between the last checkpoint and the crash are re-indexed on restart (they're deduplicated naturally because the same GTID/position is just re-received from MySQL).
 
+### Mode switching
+
+The stream command supports seamless switching between position mode and GTID mode. If a saved checkpoint exists in `stream_state`, the saved mode is used regardless of which `--start-*` flags are passed on the command line. This makes restarts idempotent — you can always pass the same flags without worrying about overriding the saved state.
+
+To explicitly switch modes (e.g. from position to GTID after enabling GTIDs on the source), use the `--reset` flag:
+
+```sh
+# Switch from position mode to GTID mode
+bintrail stream \
+  --index-dsn  "..." \
+  --source-dsn "..." \
+  --server-id  99999 \
+  --start-gtid "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-5000" \
+  --reset
+```
+
+`--reset` clears the saved checkpoint in `stream_state` before starting, forcing the command to use the `--start-file`/`--start-gtid` flags from the command line. Without `--reset`, the saved checkpoint always takes precedence.
+
+**When to use `--reset`:**
+- Switching from position mode to GTID mode (or vice versa)
+- Forcing a restart from a known position after a disaster recovery
+- Skipping ahead past corrupted binlog events
+
 ---
 
 ## Graceful Shutdown


### PR DESCRIPTION
closes #50\n\n## Summary\n- **docs/streaming.md**: Added `--reset` flag documentation and mode switching behavior (PRs #82, #83)\n- **docs/dump-and-baseline.md**: Added `--retry` flag to baseline flags table + retry section with examples (PRs #84, #85)\n- **docs/rotation-and-status.md**: Added `--retry` flag + retry section, `archive_state` table reference, archive stats in status output (PRs #78, #81, #84, #85)\n- **docs/guide.md**: Added `--retry` examples to Scenarios G and I, `--reset` to Scenario J (PRs #83, #84, #85)\n\n## Test plan\n- [x] Unit tests pass (`go test ./... -count=1`)\n- [x] Documentation only — no code changes\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)