### PR TITLE
fix: replace UTC_TIMESTAMP() with CURRENT_TIMESTAMP in archive_state DDL

### DIFF
--- a/cmd/bintrail/init.go
+++ b/cmd/bintrail/init.go
@@ -587,7 +587,7 @@ const ddlArchiveState = `CREATE TABLE IF NOT EXISTS archive_state (
     s3_bucket       VARCHAR(255),
     s3_key          VARCHAR(1024),
     s3_uploaded_at  DATETIME,
-    archived_at     DATETIME NOT NULL DEFAULT UTC_TIMESTAMP(),
+    archived_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     UNIQUE KEY uq_partition (partition_name, bintrail_id)
 ) ENGINE=InnoDB`
 

--- a/cmd/bintrail/init_test.go
+++ b/cmd/bintrail/init_test.go
@@ -452,6 +452,24 @@ func TestDDLArchiveState_hasUniqueKey(t *testing.T) {
 	}
 }
 
+func TestDDLConstants_noUTCTimestampDefault(t *testing.T) {
+	ddls := map[string]string{
+		"ddlSchemaSnapshots": ddlSchemaSnapshots,
+		"ddlStreamState":     ddlStreamState,
+		"ddlIndexState":      ddlIndexState,
+		"ddlArchiveState":    ddlArchiveState,
+		"ddlTableFlags":      ddlTableFlags,
+		"ddlProfiles":        ddlProfiles,
+		"ddlAccessRules":     ddlAccessRules,
+		"ddlSchemaChanges":   ddlSchemaChanges,
+	}
+	for name, ddl := range ddls {
+		if strings.Contains(strings.ToUpper(ddl), "DEFAULT UTC_TIMESTAMP") {
+			t.Errorf("%s must not use UTC_TIMESTAMP() as a DEFAULT — MySQL rejects it in DDL; use CURRENT_TIMESTAMP instead", name)
+		}
+	}
+}
+
 // ─── ddlSchemaChanges ───────────────────────────────────────────────────────
 
 func TestDDLSchemaChanges_hasRequiredColumns(t *testing.T) {

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -242,7 +242,7 @@ func InitIndexTables(t *testing.T, db *sql.DB) {
 		s3_bucket       VARCHAR(255),
 		s3_key          VARCHAR(1024),
 		s3_uploaded_at  DATETIME,
-		archived_at     DATETIME NOT NULL DEFAULT UTC_TIMESTAMP(),
+		archived_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
 		UNIQUE KEY uq_partition (partition_name, bintrail_id)
 	) ENGINE=InnoDB`)
 


### PR DESCRIPTION
## Summary
- Replace `DEFAULT UTC_TIMESTAMP()` with `DEFAULT CURRENT_TIMESTAMP` in `archive_state` DDL — MySQL rejects `UTC_TIMESTAMP()` in column defaults (Error 1064)
- Apply same fix in `testutil.InitIndexTables` to keep test DDL in sync
- Add regression test guarding all 8 DDL constants against `UTC_TIMESTAMP` in defaults

Closes #91

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1` passes (all 16 packages)
- [x] New `TestDDLConstants_noUTCTimestampDefault` verifies no DDL constant uses `UTC_TIMESTAMP` as a default

🤖 Generated with [Claude Code](https://claude.com/claude-code)