### PR TITLE
feat: add NO_LOCK and --trx-tables to mydumper dump

### DIFF
--- a/cmd/bintrail/dump.go
+++ b/cmd/bintrail/dump.go
@@ -124,6 +124,8 @@ func buildMydumperArgs(host string, port uint16, user, password, outputDir strin
 		"--threads", strconv.Itoa(threads),
 		"--compress-protocol",
 		"--complete-insert",
+		"--sync-thread-lock-mode", "NO_LOCK",
+		"--trx-tables",
 	}
 
 	if password != "" {

--- a/cmd/bintrail/dump_test.go
+++ b/cmd/bintrail/dump_test.go
@@ -86,6 +86,14 @@ func TestBuildMydumperArgs_compressAndComplete(t *testing.T) {
 	}
 }
 
+func TestBuildMydumperArgs_lockAndTrx(t *testing.T) {
+	args := buildMydumperArgs("127.0.0.1", 3306, "root", "", "/tmp/dump", 4, nil, nil)
+	assertArgsContainPair(t, args, "--sync-thread-lock-mode", "NO_LOCK")
+	if !argsContain(args, "--trx-tables") {
+		t.Error("expected --trx-tables in args")
+	}
+}
+
 func TestBuildMydumperArgs_noPassword(t *testing.T) {
 	args := buildMydumperArgs("127.0.0.1", 3306, "root", "", "/tmp/dump", 4, nil, nil)
 	if argsContain(args, "--password") {


### PR DESCRIPTION
closes #93

## Summary
- Always pass `--sync-thread-lock-mode NO_LOCK` and `--trx-tables` to mydumper in `buildMydumperArgs`
- Enables lock-free, transactionally consistent InnoDB dumps
- Added unit test verifying both flags are present

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)