### PR TITLE
fix: parse mydumper 0.16+ metadata format

### DIFF
--- a/internal/baseline/baseline_test.go
+++ b/internal/baseline/baseline_test.go
@@ -62,6 +62,43 @@ func TestParseMetadataFields(t *testing.T) {
 	}
 }
 
+// sampleMetadataNew is the format produced by mydumper 0.16+ (TOML-like with
+// # prefixes and KEY = "value" assignments).
+const sampleMetadataNew = `# Started dump at: 2026-03-02 23:45:20
+[config]
+quote-character = BACKTICK
+
+[source]
+# executed_gtid_set = "55512139-1432-11f1-8d8d-0693b428a89b:1-11490596"
+# SOURCE_LOG_FILE = "mysql-bin-changelog.000879"
+# SOURCE_LOG_POS = 4504702
+# Finished dump at: 2026-03-02 23:45:21
+`
+
+func TestParseMetadataNewFormat(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "metadata"), []byte(sampleMetadataNew), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m, err := ParseMetadata(dir)
+	if err != nil {
+		t.Fatalf("ParseMetadata: %v", err)
+	}
+	wantTime := time.Date(2026, 3, 2, 23, 45, 20, 0, time.UTC)
+	if !m.StartedAt.Equal(wantTime) {
+		t.Errorf("StartedAt = %v, want %v", m.StartedAt, wantTime)
+	}
+	if m.BinlogFile != "mysql-bin-changelog.000879" {
+		t.Errorf("BinlogFile = %q, want %q", m.BinlogFile, "mysql-bin-changelog.000879")
+	}
+	if m.BinlogPos != 4504702 {
+		t.Errorf("BinlogPos = %d, want 4504702", m.BinlogPos)
+	}
+	if m.GTIDSet != "55512139-1432-11f1-8d8d-0693b428a89b:1-11490596" {
+		t.Errorf("GTIDSet = %q, want %q", m.GTIDSet, "55512139-1432-11f1-8d8d-0693b428a89b:1-11490596")
+	}
+}
+
 func TestParseMetadataMissingTimestamp(t *testing.T) {
 	const content = "SHOW MASTER STATUS:\n\tLog: binlog.000001\n\tPos: 100\n"
 	dir := t.TempDir()

--- a/internal/baseline/metadata.go
+++ b/internal/baseline/metadata.go
@@ -41,7 +41,11 @@ func ParseMetadata(inputDir string) (DumpMetadata, error) {
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		line := scanner.Text()
-		if after, ok := strings.CutPrefix(line, "Started dump at: "); ok {
+
+		// New mydumper format (0.16+) prefixes lines with "# ".
+		trimmed := strings.TrimPrefix(line, "# ")
+
+		if after, ok := strings.CutPrefix(trimmed, "Started dump at: "); ok {
 			t, err := time.ParseInLocation("2006-01-02 15:04:05", strings.TrimSpace(after), time.UTC)
 			if err != nil {
 				return DumpMetadata{}, fmt.Errorf("parse dump timestamp %q: %w", after, err)
@@ -56,6 +60,15 @@ func ParseMetadata(inputDir string) (DumpMetadata, error) {
 			}
 		} else if after, ok := strings.CutPrefix(line, "\tGTID: "); ok {
 			m.GTIDSet = strings.TrimSpace(after)
+		} else if after, ok := strings.CutPrefix(trimmed, "SOURCE_LOG_FILE = "); ok {
+			m.BinlogFile = unquote(strings.TrimSpace(after))
+		} else if after, ok := strings.CutPrefix(trimmed, "SOURCE_LOG_POS = "); ok {
+			pos, err := strconv.ParseInt(strings.TrimSpace(after), 10, 64)
+			if err == nil {
+				m.BinlogPos = pos
+			}
+		} else if after, ok := strings.CutPrefix(trimmed, "executed_gtid_set = "); ok {
+			m.GTIDSet = unquote(strings.TrimSpace(after))
 		}
 	}
 	if err := scanner.Err(); err != nil {
@@ -65,4 +78,12 @@ func ParseMetadata(inputDir string) (DumpMetadata, error) {
 		return DumpMetadata{}, fmt.Errorf("metadata file missing 'Started dump at:' line")
 	}
 	return m, nil
+}
+
+// unquote strips surrounding double quotes from s, if present.
+func unquote(s string) string {
+	if len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"' {
+		return s[1 : len(s)-1]
+	}
+	return s
 }


### PR DESCRIPTION
closes #94

## Summary
- `ParseMetadata` now handles the new mydumper 0.16+ metadata format where lines are prefixed with `# ` and binlog position info uses `KEY = "value"` syntax (`SOURCE_LOG_FILE`, `SOURCE_LOG_POS`, `executed_gtid_set`)
- Old format continues to work unchanged
- Added `TestParseMetadataNewFormat` with the exact metadata from the bug report

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] New test covers the exact metadata format from the bug report

🤖 Generated with [Claude Code](https://claude.com/claude-code)