### PR TITLE
fix: allow hourly rotation by removing cutoff truncation

### DIFF
--- a/cmd/bintrail/rotate.go
+++ b/cmd/bintrail/rotate.go
@@ -201,7 +201,7 @@ func performRotation(ctx context.Context, db *sql.DB, dbName string, retainDur t
 	// ── Drop old partitions ───────────────────────────────────────────────────
 	var droppedCount int
 	if retainDur > 0 {
-		cutoff := time.Now().UTC().Add(-retainDur).Truncate(time.Hour)
+		cutoff := time.Now().UTC().Add(-retainDur)
 		var toDrop []string
 		for _, p := range partitions {
 			d, ok := partitionDate(p.Name)

--- a/cmd/bintrail/rotate_test.go
+++ b/cmd/bintrail/rotate_test.go
@@ -154,6 +154,42 @@ func TestNextPartitionStart_empty(t *testing.T) {
 	}
 }
 
+// ─── cutoff logic (hourly retain) ────────────────────────────────────────────
+
+// TestCutoffDropsHourlyPartition verifies that --retain 1h correctly selects
+// the previous-hour partition for dropping. This is the exact scenario from
+// GitHub issue #96: at 00:05 UTC, "p_2026030223" (hour 23) should be eligible
+// for dropping with --retain 1h, because its start time (23:00) is before the
+// cutoff (23:05).
+func TestCutoffDropsHourlyPartition(t *testing.T) {
+	// Simulate: current time = 2026-03-03 00:05:15 UTC, --retain 1h.
+	now := time.Date(2026, 3, 3, 0, 5, 15, 0, time.UTC)
+	retainDur := time.Hour
+	cutoff := now.Add(-retainDur) // 2026-03-02 23:05:15 UTC (no Truncate!)
+
+	partitions := []struct {
+		name     string
+		wantDrop bool
+	}{
+		{"p_2026030222", true},  // hour 22 → 22:00 < 23:05 → drop
+		{"p_2026030223", true},  // hour 23 → 23:00 < 23:05 → drop (the bug was here)
+		{"p_2026030300", false}, // hour 00 → 00:00 is NOT < 23:05 → keep
+		{"p_2026030301", false}, // hour 01 → keep
+	}
+
+	for _, p := range partitions {
+		d, ok := partitionDate(p.name)
+		if !ok {
+			t.Fatalf("partitionDate(%q) returned false", p.name)
+		}
+		dropped := d.Before(cutoff)
+		if dropped != p.wantDrop {
+			t.Errorf("partition %s (date %v): Before(cutoff %v) = %v, want %v",
+				p.name, d, cutoff, dropped, p.wantDrop)
+		}
+	}
+}
+
 // ─── addFuturePartitions SQL shape ────────────────────────────────────────────
 
 // TestPartitionSpec_shape verifies the generated DDL looks correct without


### PR DESCRIPTION
closes #96

## Summary
- Removed `.Truncate(time.Hour)` from the partition drop cutoff calculation in `rotate.go`
- The truncation aligned the cutoff exactly with partition boundaries, causing `Before()` (strict `<`) to skip partitions at the boundary — e.g. `--retain 1h` at 00:05 UTC wouldn't drop `p_2026030223` because `23:00 < 23:00` is false
- Without truncation, the cutoff retains full precision (23:05:15), so `23:00 < 23:05` correctly selects the partition

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] New `TestCutoffDropsHourlyPartition` reproduces the exact issue scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)