### PR TITLE
feat: fall back to Docker when mydumper binary is not installed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ Per-command `--format` flag (default `text`): every command accepts `--format te
 | `status` | `status.go` | `--index-dsn` (req), `--format` |
 | `stream` | `stream.go` | … + `--metrics-addr` (e.g. `:9090`; empty = disabled), `--format` |
 | `stream` | `stream.go` | `--index-dsn` (req), `--source-dsn` (req), `--server-id` (req), `--start-file`, `--start-pos`, `--start-gtid`, `--batch-size`, `--schemas`, `--tables`, `--checkpoint`, `--format` |
-| `dump` | `dump.go` | `--source-dsn` (req), `--output-dir` (req), `--schemas`, `--tables`, `--mydumper-path` (default `mydumper`), `--threads` (default 4), `--format` |
+| `dump` | `dump.go` | `--source-dsn` (req), `--output-dir` (req), `--schemas`, `--tables`, `--mydumper-path` (default `mydumper`), `--mydumper-image` (default `mydumper/mydumper:latest`), `--threads` (default 4), `--format` |
 | `baseline` | `baseline.go` | `--input` (req), `--output` (req), `--timestamp`, `--tables`, `--compression` (default `zstd`), `--row-group-size` (default 500000), `--upload` (S3 URL), `--upload-region`, `--format` |
 | `upload` | `upload.go` | `--source` (req), `--destination` (req), `--region`, `--retry`, `--index-dsn`, `--format` |
 
@@ -283,9 +283,21 @@ Use `mysql.ParseDSN(dsn)` from `github.com/go-sql-driver/mysql` — consistent w
 
 `config.Connect` also injects a 10-second TCP connect timeout (`cfg.Timeout`) when the DSN does not specify one. This prevents indefinite hangs when MySQL is unreachable. Users can override this with the `timeout=` DSN parameter (e.g. `user:pass@tcp(host:3306)/db?timeout=30s`).
 
-### dump command: lockfile and mydumper args
+### dump command: mydumper resolution, lockfile, and args
 
-`dump.go` enforces single-concurrency via a lockfile at `os.TempDir()/bintrail-dump.lock`:
+**mydumper resolution** (`resolveMydumper`): determines how to invoke mydumper using a priority chain:
+1. `--mydumper-path` explicitly set (`cmd.Flags().Changed("mydumper-path")`) → use that binary or fail
+2. `mydumper` found on `$PATH` → use local binary
+3. `docker` found on `$PATH` → use `docker run` with `--mydumper-image`
+4. None available → error with install instructions
+
+`dumpResolution` struct: `mode` (`dumpModeLocal`/`dumpModeDocker`), `path` (binary path), `image` (docker image for docker mode).
+
+`buildDockerArgs` wraps mydumper args in `docker run --rm -v <outputdir>:<outputdir> [--network host] <image> mydumper <args...>`. The output dir is bind-mounted at the same absolute path (no path translation needed). `--network host` is added automatically on Linux when the source host is localhost/127.0.0.1/::1; on macOS a warning is logged suggesting `host.docker.internal`.
+
+Flag variable prefix: `dmpMydumperImage` for `--mydumper-image`.
+
+**Lockfile**: `dump.go` enforces single-concurrency via a lockfile at `os.TempDir()/bintrail-dump.lock`:
 - `acquireDumpLock()` uses `O_CREATE|O_EXCL|O_WRONLY` for atomic creation and writes the current PID. On `ErrExist`, reads the PID, probes liveness with `syscall.Signal(0)`, removes stale locks, and retries once.
 - `releaseDumpLock(f)` closes and removes the file.
 - `var dumpLockDir = os.TempDir` stores the function (not its result) so tests can override it with a `t.TempDir()` closure.

--- a/cmd/bintrail/dump.go
+++ b/cmd/bintrail/dump.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -25,13 +26,14 @@ directory is removed before the dump begins.`,
 }
 
 var (
-	dmpSourceDSN    string
-	dmpOutputDir    string
-	dmpSchemas      string
-	dmpTables       string
-	dmpMydumperPath string
-	dmpThreads      int
-	dmpFormat       string
+	dmpSourceDSN     string
+	dmpOutputDir     string
+	dmpSchemas       string
+	dmpTables        string
+	dmpMydumperPath  string
+	dmpMydumperImage string
+	dmpThreads       int
+	dmpFormat        string
 )
 
 // dumpLockDir is a function returning the directory for the dump lockfile.
@@ -44,6 +46,7 @@ func init() {
 	dumpCmd.Flags().StringVar(&dmpSchemas, "schemas", "", "Comma-separated schema filter (e.g. mydb,otherdb)")
 	dumpCmd.Flags().StringVar(&dmpTables, "tables", "", "Comma-separated table filter (e.g. mydb.orders,mydb.items)")
 	dumpCmd.Flags().StringVar(&dmpMydumperPath, "mydumper-path", "mydumper", "Path to the mydumper binary")
+	dumpCmd.Flags().StringVar(&dmpMydumperImage, "mydumper-image", "mydumper/mydumper:latest", "Docker image for mydumper (used when no local binary is found)")
 	dumpCmd.Flags().IntVar(&dmpThreads, "threads", 4, "Number of mydumper dump threads")
 	dumpCmd.Flags().StringVar(&dmpFormat, "format", "text", "Output format: text or json")
 	_ = dumpCmd.MarkFlagRequired("source-dsn")
@@ -52,15 +55,88 @@ func init() {
 	rootCmd.AddCommand(dumpCmd)
 }
 
+// dumpMode indicates how mydumper will be invoked.
+type dumpMode int
+
+const (
+	dumpModeLocal  dumpMode = iota // local binary
+	dumpModeDocker                 // docker run
+)
+
+// dumpResolution holds the result of resolving how to invoke mydumper.
+type dumpResolution struct {
+	mode  dumpMode
+	path  string // binary path (local) or docker path (docker)
+	image string // docker image (only for dumpModeDocker)
+}
+
+// resolveMydumper determines how to invoke mydumper based on flag state.
+// Priority: explicit --mydumper-path → $PATH lookup → Docker → error.
+func resolveMydumper(cmd *cobra.Command) (dumpResolution, error) {
+	if cmd.Flags().Changed("mydumper-path") {
+		path, err := exec.LookPath(dmpMydumperPath)
+		if err != nil {
+			return dumpResolution{}, fmt.Errorf("mydumper not found at %q: %w", dmpMydumperPath, err)
+		}
+		return dumpResolution{mode: dumpModeLocal, path: path}, nil
+	}
+
+	if path, err := exec.LookPath("mydumper"); err == nil {
+		return dumpResolution{mode: dumpModeLocal, path: path}, nil
+	}
+
+	dockerPath, err := exec.LookPath("docker")
+	if err == nil {
+		return dumpResolution{mode: dumpModeDocker, path: dockerPath, image: dmpMydumperImage}, nil
+	}
+
+	return dumpResolution{}, fmt.Errorf("mydumper not found on $PATH and Docker is not available; " +
+		"install mydumper (https://github.com/mydumper/mydumper), install Docker, or use --mydumper-path")
+}
+
+// buildDockerArgs constructs the full argument slice for invoking mydumper via
+// docker run. The output directory is bind-mounted at the same absolute path so
+// downstream tools need no path translation.
+func buildDockerArgs(image, outputDir, host string, mydumperArgs []string) []string {
+	absOutput, err := filepath.Abs(outputDir)
+	if err != nil {
+		absOutput = outputDir
+	}
+
+	args := []string{
+		"run", "--rm",
+		"-v", absOutput + ":" + absOutput,
+	}
+
+	if isLocalhost(host) {
+		if runtime.GOOS == "linux" {
+			args = append(args, "--network", "host")
+		} else {
+			slog.Warn("source host is localhost but --network host only works on Linux; "+
+				"use the Docker host IP (e.g. host.docker.internal) or set --source-dsn accordingly",
+				"host", host, "os", runtime.GOOS)
+		}
+	}
+
+	args = append(args, image, "mydumper")
+	args = append(args, mydumperArgs...)
+	return args
+}
+
+// isLocalhost reports whether the host refers to the local machine.
+func isLocalhost(host string) bool {
+	return host == "localhost" || host == "127.0.0.1" || host == "::1"
+}
+
 func runDump(cmd *cobra.Command, args []string) error {
 	if !cliutil.IsValidOutputFormat(dmpFormat) {
 		return fmt.Errorf("invalid --format %q; must be text or json", dmpFormat)
 	}
 
-	// 1. Fail fast if mydumper is not installed.
-	path, err := exec.LookPath(dmpMydumperPath)
+	// 1. Resolve how to invoke mydumper.
+	res, err := resolveMydumper(cmd)
 	if err != nil {
-		return fmt.Errorf("mydumper not found (%q): %w", dmpMydumperPath, err)
+		return err
 	}
 
 	// 2. Parse source DSN.
@@ -88,9 +164,18 @@ func runDump(cmd *cobra.Command, args []string) error {
 	// 6. Build mydumper args.
 	mydumperArgs := buildMydumperArgs(host, port, user, password, dmpOutputDir, dmpThreads, schemas, tables)
 
-	// 7. Run mydumper, streaming output to the terminal.
-	slog.Info("starting dump", "path", path, "output_dir", dmpOutputDir)
-	c := exec.CommandContext(cmd.Context(), path, mydumperArgs...)
+	// 7. Build the final command depending on resolution mode.
+	var c *exec.Cmd
+	switch res.mode {
+	case dumpModeDocker:
+		dockerArgs := buildDockerArgs(res.image, dmpOutputDir, host, mydumperArgs)
+		c = exec.CommandContext(cmd.Context(), res.path, dockerArgs...)
+		slog.Info("starting dump via Docker", "image", res.image, "output_dir", dmpOutputDir)
+	default:
+		c = exec.CommandContext(cmd.Context(), res.path, mydumperArgs...)
+		slog.Info("starting dump", "path", res.path, "output_dir", dmpOutputDir)
+	}
+
 	if dmpFormat != "json" {
 		c.Stdout = os.Stdout
 		c.Stderr = os.Stderr

--- a/cmd/bintrail/dump_test.go
+++ b/cmd/bintrail/dump_test.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 // ─── Cobra command wiring ─────────────────────────────────────────────────────
@@ -57,7 +59,7 @@ func TestDumpCmd_defaults(t *testing.T) {
 
 func TestDumpCmd_allFlagsRegistered(t *testing.T) {
 	for _, name := range []string{
-		"source-dsn", "output-dir", "schemas", "tables", "mydumper-path", "threads",
+		"source-dsn", "output-dir", "schemas", "tables", "mydumper-path", "mydumper-image", "threads",
 	} {
 		if dumpCmd.Flag(name) == nil {
 			t.Errorf("flag --%s not registered on dumpCmd", name)
@@ -349,9 +351,14 @@ func TestExtractSchemasFromTables_empty(t *testing.T) {
 // ─── RunE validation ──────────────────────────────────────────────────────────
 
 func TestRunDump_mydumperNotFound(t *testing.T) {
+	// Use Flags().Set to mark --mydumper-path as Changed so resolveMydumper
+	// tries the explicit path branch.
 	savedPath := dmpMydumperPath
-	t.Cleanup(func() { dmpMydumperPath = savedPath })
-	dmpMydumperPath = "/nonexistent/path/to/mydumper"
+	t.Cleanup(func() {
+		dmpMydumperPath = savedPath
+		dumpCmd.Flags().Set("mydumper-path", savedPath)
+	})
+	dumpCmd.Flags().Set("mydumper-path", "/nonexistent/path/to/mydumper")
 
 	savedDSN := dmpSourceDSN
 	t.Cleanup(func() { dmpSourceDSN = savedDSN })
@@ -375,9 +382,13 @@ func TestRunDump_invalidSourceDSN(t *testing.T) {
 	}
 
 	savedPath, savedDSN := dmpMydumperPath, dmpSourceDSN
-	t.Cleanup(func() { dmpMydumperPath = savedPath; dmpSourceDSN = savedDSN })
+	t.Cleanup(func() {
+		dmpMydumperPath = savedPath
+		dumpCmd.Flags().Set("mydumper-path", savedPath)
+		dmpSourceDSN = savedDSN
+	})
 
-	dmpMydumperPath = fakeBin
+	dumpCmd.Flags().Set("mydumper-path", fakeBin)
 	dmpSourceDSN = "root@unix(/var/run/mysqld.sock)/" // unix socket → rejected by parseSourceDSN
 
 	err := runDump(dumpCmd, nil)
@@ -386,6 +397,188 @@ func TestRunDump_invalidSourceDSN(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "unix socket") {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// ─── resolveMydumper ──────────────────────────────────────────────────────────
+
+func TestResolveMydumper_explicitPathTakesPrecedence(t *testing.T) {
+	dir := t.TempDir()
+	fakeBin := filepath.Join(dir, "mydumper")
+	if err := os.WriteFile(fakeBin, []byte(""), 0o755); err != nil {
+		t.Fatalf("failed to create fake mydumper: %v", err)
+	}
+
+	saved := dmpMydumperPath
+	t.Cleanup(func() {
+		dmpMydumperPath = saved
+		dumpCmd.Flags().Set("mydumper-path", saved)
+	})
+	dumpCmd.Flags().Set("mydumper-path", fakeBin)
+
+	res, err := resolveMydumper(dumpCmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.mode != dumpModeLocal {
+		t.Errorf("expected dumpModeLocal, got %d", res.mode)
+	}
+	if res.path != fakeBin {
+		t.Errorf("expected path %q, got %q", fakeBin, res.path)
+	}
+}
+
+func TestResolveMydumper_explicitPathNotFound(t *testing.T) {
+	saved := dmpMydumperPath
+	t.Cleanup(func() {
+		dmpMydumperPath = saved
+		dumpCmd.Flags().Set("mydumper-path", saved)
+	})
+	dumpCmd.Flags().Set("mydumper-path", "/nonexistent/mydumper")
+
+	_, err := resolveMydumper(dumpCmd)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "mydumper not found") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestResolveMydumper_nothingAvailable(t *testing.T) {
+	// Ensure --mydumper-path is not Changed by resetting the flag.
+	saved := dmpMydumperPath
+	t.Cleanup(func() { dmpMydumperPath = saved })
+
+	// Create a fresh command with the same flags to avoid Changed state.
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("mydumper-path", "mydumper", "")
+
+	// Override PATH to exclude both mydumper and docker.
+	t.Setenv("PATH", t.TempDir())
+
+	_, err := resolveMydumper(cmd)
+	if err == nil {
+		t.Fatal("expected error when neither mydumper nor docker is available")
+	}
+	if !strings.Contains(err.Error(), "mydumper not found on $PATH") {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "Docker is not available") {
+		t.Errorf("expected Docker mentioned in error: %v", err)
+	}
+}
+
+func TestResolveMydumper_dockerFallback(t *testing.T) {
+	// Create a fake docker binary but no mydumper.
+	dir := t.TempDir()
+	fakeDocker := filepath.Join(dir, "docker")
+	if err := os.WriteFile(fakeDocker, []byte(""), 0o755); err != nil {
+		t.Fatalf("failed to create fake docker: %v", err)
+	}
+
+	// Override PATH to contain only the fake docker.
+	t.Setenv("PATH", dir)
+
+	saved := dmpMydumperImage
+	t.Cleanup(func() { dmpMydumperImage = saved })
+	dmpMydumperImage = "mydumper/mydumper:v0.16"
+
+	// Use a fresh command so --mydumper-path is not Changed.
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("mydumper-path", "mydumper", "")
+
+	res, err := resolveMydumper(cmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.mode != dumpModeDocker {
+		t.Errorf("expected dumpModeDocker, got %d", res.mode)
+	}
+	if res.path != fakeDocker {
+		t.Errorf("expected docker path %q, got %q", fakeDocker, res.path)
+	}
+	if res.image != "mydumper/mydumper:v0.16" {
+		t.Errorf("expected image %q, got %q", "mydumper/mydumper:v0.16", res.image)
+	}
+}
+
+// ─── buildDockerArgs ──────────────────────────────────────────────────────────
+
+func TestBuildDockerArgs_basic(t *testing.T) {
+	mydumperArgs := []string{"--host", "db.example.com", "--port", "3306", "--user", "root", "--outputdir", "/tmp/dump"}
+	args := buildDockerArgs("mydumper/mydumper:latest", "/tmp/dump", "db.example.com", mydumperArgs)
+
+	// Should start with docker run --rm
+	if len(args) < 3 || args[0] != "run" || args[1] != "--rm" {
+		t.Fatalf("expected args to start with [run --rm], got %v", args[:min(3, len(args))])
+	}
+
+	// Volume mount
+	assertArgsContainPair(t, args, "-v", "/tmp/dump:/tmp/dump")
+
+	// Should NOT have --network host for non-localhost
+	if argsContain(args, "--network") {
+		t.Error("expected no --network flag for non-localhost host")
+	}
+
+	// Image and mydumper command
+	imgIdx := argsIndex(args, "mydumper/mydumper:latest")
+	if imgIdx < 0 {
+		t.Fatal("expected image name in args")
+	}
+	if imgIdx+1 >= len(args) || args[imgIdx+1] != "mydumper" {
+		t.Error("expected 'mydumper' command after image name")
+	}
+
+	// mydumper args follow
+	if !argsContain(args, "--host") || !argsContain(args, "db.example.com") {
+		t.Error("expected mydumper args to be present after image + command")
+	}
+}
+
+func TestBuildDockerArgs_localhostNetworkHost(t *testing.T) {
+	for _, host := range []string{"localhost", "127.0.0.1", "::1"} {
+		args := buildDockerArgs("mydumper/mydumper:latest", "/tmp/dump", host, nil)
+
+		// On Linux, --network host should be added; on macOS it should not.
+		hasNetwork := argsContain(args, "--network")
+		if hasNetwork {
+			idx := argsIndex(args, "--network")
+			if idx+1 >= len(args) || args[idx+1] != "host" {
+				t.Errorf("host=%s: --network should be followed by 'host'", host)
+			}
+		}
+		// We can't assert the exact behavior since it depends on runtime.GOOS,
+		// but we can verify it doesn't panic and the structure is valid.
+	}
+}
+
+func TestIsLocalhost(t *testing.T) {
+	for _, tc := range []struct {
+		host string
+		want bool
+	}{
+		{"localhost", true},
+		{"127.0.0.1", true},
+		{"::1", true},
+		{"db.example.com", false},
+		{"192.168.1.1", false},
+		{"", false},
+	} {
+		if got := isLocalhost(tc.host); got != tc.want {
+			t.Errorf("isLocalhost(%q) = %v, want %v", tc.host, got, tc.want)
+		}
+	}
+}
+
+func TestDumpCmd_mydumperImageFlag(t *testing.T) {
+	f := dumpCmd.Flag("mydumper-image")
+	if f == nil {
+		t.Fatal("flag --mydumper-image not registered")
+	}
+	if f.DefValue != "mydumper/mydumper:latest" {
+		t.Errorf("expected default %q, got %q", "mydumper/mydumper:latest", f.DefValue)
 	}
 }
 

--- a/docs/dump-and-baseline.md
+++ b/docs/dump-and-baseline.md
@@ -2,7 +2,7 @@
 
 Bintrail uses [mydumper](https://github.com/mydumper/mydumper) to create logical dumps of MySQL databases. The dump output is then converted to Parquet files by `bintrail baseline`, producing a point-in-time snapshot of every table that can be stored alongside archived binlog event partitions for long-term audit reconstruction.
 
-This document covers installing mydumper, running dumps, converting to Parquet baselines, and scheduling.
+This document covers running dumps, converting to Parquet baselines, and scheduling.
 
 ---
 
@@ -19,9 +19,30 @@ mydumper is used instead of `mysqldump` because it:
 
 ---
 
-## Installing mydumper
+## Getting mydumper
 
-mydumper is a standalone binary — it is **not** bundled with bintrail. Install it before using `bintrail dump`.
+**No installation required** — if Docker is available on your system, `bintrail dump` will automatically use the [official mydumper Docker image](https://hub.docker.com/r/mydumper/mydumper) (`mydumper/mydumper`). This is the recommended zero-setup approach.
+
+The resolution order is:
+
+1. If `--mydumper-path` is explicitly set — use that binary
+2. If `mydumper` is found on `$PATH` — use that binary
+3. If Docker is available — invoke mydumper via `docker run`
+4. If none of the above — fail with a clear error message
+
+To pin a specific mydumper Docker image version:
+
+```sh
+bintrail dump \
+  --mydumper-image mydumper/mydumper:v0.16.7-3 \
+  --source-dsn "user:pass@tcp(source-db:3306)/" \
+  --output-dir /tmp/mydumper-output
+```
+
+<details>
+<summary>Manual mydumper installation (advanced)</summary>
+
+If you prefer to install mydumper as a local binary instead of using Docker:
 
 ### Ubuntu / Debian
 
@@ -63,6 +84,8 @@ bintrail dump --mydumper-path /opt/mydumper/bin/mydumper ...
 mydumper --version
 ```
 
+</details>
+
 ---
 
 ## The dump → baseline pipeline
@@ -101,7 +124,8 @@ This dumps all user schemas from the source server into `/tmp/mydumper-output`.
 | `--output-dir` | *(required)* | Directory for mydumper output (removed and recreated on each run) |
 | `--schemas` | *(all)* | Comma-separated schema filter (e.g. `mydb,otherdb`) |
 | `--tables` | *(all)* | Comma-separated table filter (e.g. `mydb.orders,mydb.items`) |
-| `--mydumper-path` | `mydumper` | Path to the mydumper binary |
+| `--mydumper-path` | `mydumper` | Path to the mydumper binary. When set, skips Docker fallback. |
+| `--mydumper-image` | `mydumper/mydumper:latest` | Docker image for mydumper. Used only when no local binary is found. |
 | `--threads` | `4` | Number of parallel dump threads |
 | `--format` | `text` | Output format: `text` or `json` |
 
@@ -308,8 +332,13 @@ The dump frequency depends on your recovery and audit requirements. Bintrail's b
 
 | Problem | Cause | Fix |
 |---------|-------|-----|
-| `mydumper not found ("mydumper")` | mydumper is not installed or not on `$PATH` | Install mydumper (see above) or use `--mydumper-path` |
+| `mydumper not found on $PATH and Docker is not available` | Neither mydumper nor Docker is installed | Install Docker (recommended) or install mydumper manually (see above) |
+| `mydumper not found at "/custom/path"` | Explicit `--mydumper-path` points to a missing binary | Verify the path is correct and the binary is executable |
 | `another dump is already running` | A previous dump is still running or crashed | Wait for it to finish, or check if the PID in `$TMPDIR/bintrail-dump.lock` is still alive. Stale locks from crashed processes are cleaned up automatically on the next run. |
 | `mydumper failed: exit status 2` | mydumper itself encountered an error (wrong credentials, unreachable host, etc.) | Check mydumper's stderr output for details. Verify the `--source-dsn` is correct. |
+| Docker: `permission denied` on `/var/run/docker.sock` | Current user is not in the `docker` group | Run `sudo usermod -aG docker $USER` and log out/in, or use `sudo bintrail dump ...` |
+| Docker: `Cannot connect to the Docker daemon` | Docker daemon is not running | Start Docker: `sudo systemctl start docker` (Linux) or open Docker Desktop (macOS) |
+| Docker: mydumper cannot reach MySQL on localhost | On macOS/Windows, `--network host` does not work as on Linux | Use `host.docker.internal` instead of `localhost` in `--source-dsn` (e.g. `user:pass@tcp(host.docker.internal:3306)/`) |
+| Docker: volume mount permission errors | Docker cannot write to the `--output-dir` path | Ensure the output directory's parent exists and is writable. On SELinux systems, add `:z` to the volume mount or use `--security-opt label=disable`. |
 | Baseline produces no files | mydumper output directory is empty or has no table data files | Verify the dump ran successfully and the `--schemas`/`--tables` filters match existing tables. |
 | `--timestamp: expected ISO 8601 format` | Invalid timestamp override format | Use `2026-03-02T14:30:00Z` or `2026-03-02 14:30:00` format. |


### PR DESCRIPTION
closes #105

## Summary
- `bintrail dump` now automatically falls back to the official mydumper Docker image (`mydumper/mydumper`) when no local mydumper binary is found
- Resolution order: explicit `--mydumper-path` → `$PATH` lookup → Docker → error with install instructions
- New `--mydumper-image` flag (default `mydumper/mydumper:latest`) for pinning the Docker image version
- Output directory is bind-mounted at the same absolute path so no path translation is needed
- Automatically adds `--network host` on Linux when source host is localhost; warns on macOS
- Documentation updated: Docker is now the recommended zero-setup approach, manual install collapsed into details block, Docker troubleshooting added

## Test plan
- [x] Unit tests pass (`GOCACHE=$TMPDIR/go-build go test ./cmd/bintrail/ -count=1`)
- [x] `TestResolveMydumper_explicitPathTakesPrecedence` — explicit `--mydumper-path` takes priority
- [x] `TestResolveMydumper_explicitPathNotFound` — clear error for missing explicit path
- [x] `TestResolveMydumper_dockerFallback` — Docker used when no local mydumper
- [x] `TestResolveMydumper_nothingAvailable` — clear error when neither available
- [x] `TestBuildDockerArgs_basic` — correct Docker args structure
- [x] `TestBuildDockerArgs_localhostNetworkHost` — `--network host` behavior
- [x] `TestIsLocalhost` — localhost detection
- [x] `TestDumpCmd_mydumperImageFlag` — flag registered with correct default
- [x] All existing dump tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)