### PR TITLE
docs: add streaming 101 guide

### DIFF
--- a/docs/streaming-101.md
+++ b/docs/streaming-101.md
@@ -406,7 +406,7 @@ bintrail status --index-dsn "user:pass@tcp(127.0.0.1:3306)/binlog_index"
 Or query it directly:
 
 ```sql
-SELECT server_uuid FROM bintrail_servers LIMIT 1;
+SELECT bintrail_id FROM bintrail_servers LIMIT 1;
 ```
 
 ### Run rotation as a daemon


### PR DESCRIPTION
closes #103

## Summary
- New `docs/streaming-101.md` — step-by-step guide covering the complete streaming happy path
- Covers all 11 items from the issue: init, AWS access setup, S3 bucket creation, mydumper via Docker, snapshot, full backup to S3, stream setup, rotation daemon, local Parquet querying, S3 Parquet querying, and MCP client configuration
- Follows the existing docs style (matches `guide.md` formatting and conventions)

## Test plan
- [ ] Unit tests pass (`go test ./... -count=1`)
- [ ] Documentation renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)