### PR TITLE
feat: add debug logging to status command

### DIFF
--- a/cmd/bintrail/status.go
+++ b/cmd/bintrail/status.go
@@ -108,10 +108,11 @@ func runStatus(cmd *cobra.Command, args []string) error {
 		slog.Debug("loaded coverage info", "events", coverage.TotalEvents, "schema_changes", coverage.SchemaChanges, "duration_ms", time.Since(t).Milliseconds())
 	}
 
+	slog.Info("status complete", "duration_ms", time.Since(start).Milliseconds())
+
 	if stFormat == "json" {
 		return status.WriteStatusJSON(os.Stdout, files, partStats, archives, coverage)
 	}
 	status.WriteStatus(os.Stdout, files, partStats, archives, coverage)
-	slog.Info("status complete", "duration_ms", time.Since(start).Milliseconds())
 	return nil
 }


### PR DESCRIPTION
closes #109

## Summary
- Add `slog.Debug` calls with `duration_ms` timing at each stage of `runStatus` (connect, load index state, load partitions, load archives, load coverage)
- Add `slog.Info("status complete", ...)` completion log matching other commands
- `bintrail status --log-level debug` now produces useful diagnostic output

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)