### PR TITLE
fix: skip shell script wrappers when resolving mydumper on PATH

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,8 +286,8 @@ Use `mysql.ParseDSN(dsn)` from `github.com/go-sql-driver/mysql` — consistent w
 ### dump command: mydumper resolution, lockfile, and args
 
 **mydumper resolution** (`resolveMydumper`): determines how to invoke mydumper using a priority chain:
-1. `--mydumper-path` explicitly set (`cmd.Flags().Changed("mydumper-path")`) → use that binary or fail
-2. `mydumper` found on `$PATH` → use local binary
+1. `--mydumper-path` explicitly set (`cmd.Flags().Changed("mydumper-path")`) → use that binary or fail (no validation)
+2. `mydumper` found on `$PATH` **and is a compiled binary** → use local binary (shell scripts detected by `#!` shebang are skipped with a warning)
 3. `docker` found on `$PATH` → use `docker run` with `--mydumper-image`
 4. None available → error with install instructions
 

--- a/cmd/bintrail/dump.go
+++ b/cmd/bintrail/dump.go
@@ -82,7 +82,12 @@ func resolveMydumper(cmd *cobra.Command) (dumpResolution, error) {
 	}
 
 	if path, err := exec.LookPath("mydumper"); err == nil {
-		return dumpResolution{mode: dumpModeLocal, path: path}, nil
+		if isShellScript(path) {
+			slog.Warn("found mydumper on $PATH but it appears to be a shell script wrapper; skipping in favor of Docker",
+				"path", path)
+		} else {
+			return dumpResolution{mode: dumpModeLocal, path: path}, nil
+		}
 	}
 
 	dockerPath, err := exec.LookPath("docker")
@@ -121,6 +126,19 @@ func buildDockerArgs(image, outputDir, host string, mydumperArgs []string) []str
 	args = append(args, image, "mydumper")
 	args = append(args, mydumperArgs...)
 	return args
+}
+
+// isShellScript reports whether the file at path starts with a shebang (#!),
+// indicating it is a script rather than a compiled binary.
+func isShellScript(path string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	var buf [2]byte
+	n, err := f.Read(buf[:])
+	return n == 2 && err == nil && buf[0] == '#' && buf[1] == '!'
 }
 
 // isLocalhost reports whether the host refers to the local machine.

--- a/cmd/bintrail/dump_test.go
+++ b/cmd/bintrail/dump_test.go
@@ -582,6 +582,79 @@ func TestDumpCmd_mydumperImageFlag(t *testing.T) {
 	}
 }
 
+// ─── isShellScript ────────────────────────────────────────────────────────────
+
+func TestIsShellScript(t *testing.T) {
+	dir := t.TempDir()
+
+	// A file starting with #! is a script.
+	script := filepath.Join(dir, "wrapper.sh")
+	if err := os.WriteFile(script, []byte("#!/bin/bash\nexec mydumper \"$@\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if !isShellScript(script) {
+		t.Error("expected isShellScript=true for a file starting with #!")
+	}
+
+	// A file with arbitrary binary content is not a script.
+	bin := filepath.Join(dir, "mydumper")
+	if err := os.WriteFile(bin, []byte{0x7f, 'E', 'L', 'F'}, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if isShellScript(bin) {
+		t.Error("expected isShellScript=false for an ELF binary")
+	}
+
+	// An empty file is not a script.
+	empty := filepath.Join(dir, "empty")
+	if err := os.WriteFile(empty, []byte{}, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if isShellScript(empty) {
+		t.Error("expected isShellScript=false for an empty file")
+	}
+
+	// A nonexistent file is not a script.
+	if isShellScript(filepath.Join(dir, "nonexistent")) {
+		t.Error("expected isShellScript=false for a nonexistent file")
+	}
+}
+
+func TestResolveMydumper_shellScriptSkipped(t *testing.T) {
+	dir := t.TempDir()
+
+	// Place a shell script named "mydumper" and a fake "docker" on PATH.
+	script := filepath.Join(dir, "mydumper")
+	if err := os.WriteFile(script, []byte("#!/bin/bash\nexec docker run mydumper \"$@\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fakeDocker := filepath.Join(dir, "docker")
+	if err := os.WriteFile(fakeDocker, []byte{0x7f, 'E', 'L', 'F'}, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PATH", dir)
+
+	saved := dmpMydumperImage
+	t.Cleanup(func() { dmpMydumperImage = saved })
+	dmpMydumperImage = "mydumper/mydumper:latest"
+
+	// Use a fresh command so --mydumper-path is not Changed.
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("mydumper-path", "mydumper", "")
+
+	res, err := resolveMydumper(cmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.mode != dumpModeDocker {
+		t.Errorf("expected dumpModeDocker when mydumper on PATH is a script, got %d", res.mode)
+	}
+	if res.path != fakeDocker {
+		t.Errorf("expected docker path %q, got %q", fakeDocker, res.path)
+	}
+}
+
 // ─── helpers ─────────────────────────────────────────────────────────────────
 
 // argsContain reports whether args contains the string s.

--- a/docs/dump-and-baseline.md
+++ b/docs/dump-and-baseline.md
@@ -25,10 +25,12 @@ mydumper is used instead of `mysqldump` because it:
 
 The resolution order is:
 
-1. If `--mydumper-path` is explicitly set — use that binary
-2. If `mydumper` is found on `$PATH` — use that binary
+1. If `--mydumper-path` is explicitly set — use that binary (no validation)
+2. If a **compiled** `mydumper` binary is found on `$PATH` — use it (shell script wrappers are skipped automatically)
 3. If Docker is available — invoke mydumper via `docker run`
 4. If none of the above — fail with a clear error message
+
+> **Note:** Do not place a shell script wrapper named `mydumper` on your PATH. Bintrail detects scripts (files starting with `#!`) and skips them to avoid argument-handling issues with volume mounts. If you need to force a specific binary, use `--mydumper-path`.
 
 To pin a specific mydumper Docker image version:
 
@@ -334,6 +336,7 @@ The dump frequency depends on your recovery and audit requirements. Bintrail's b
 |---------|-------|-----|
 | `mydumper not found on $PATH and Docker is not available` | Neither mydumper nor Docker is installed | Install Docker (recommended) or install mydumper manually (see above) |
 | `mydumper not found at "/custom/path"` | Explicit `--mydumper-path` points to a missing binary | Verify the path is correct and the binary is executable |
+| `found mydumper on $PATH but it appears to be a shell script wrapper` | A shell script named `mydumper` is on your PATH (e.g. a Docker wrapper) | Remove the wrapper script — bintrail handles Docker invocation automatically. Or use `--mydumper-path` to point to the real binary. |
 | `another dump is already running` | A previous dump is still running or crashed | Wait for it to finish, or check if the PID in `$TMPDIR/bintrail-dump.lock` is still alive. Stale locks from crashed processes are cleaned up automatically on the next run. |
 | `mydumper failed: exit status 2` | mydumper itself encountered an error (wrong credentials, unreachable host, etc.) | Check mydumper's stderr output for details. Verify the `--source-dsn` is correct. |
 | Docker: `permission denied` on `/var/run/docker.sock` | Current user is not in the `docker` group | Run `sudo usermod -aG docker $USER` and log out/in, or use `sudo bintrail dump ...` |

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -542,7 +542,7 @@ Results from the live MySQL index and from Parquet archives are merged, deduplic
 
 **Situation:** You're setting up bintrail for the first time and want to capture the current state of your tables before you start indexing binlog events. Or you need a periodic full snapshot for audit purposes.
 
-**Prerequisites:** mydumper must be installed — see the [Dump and Baseline guide](dump-and-baseline.md#installing-mydumper) for installation instructions.
+**Prerequisites:** Either mydumper or Docker must be available. If Docker is installed, no separate mydumper installation is needed — bintrail invokes it automatically via `docker run`. See the [Dump and Baseline guide](dump-and-baseline.md#getting-mydumper) for details.
 
 **Step 1 — Dump the source database:**
 


### PR DESCRIPTION
closes #110

## Summary
- `resolveMydumper` now detects shell script wrappers (files starting with `#!`) on `$PATH` and skips them, falling through to bintrail's built-in Docker invocation
- Adds `isShellScript(path)` helper that reads the first 2 bytes to check for a shebang
- Explicit `--mydumper-path` is unchanged — no validation, user's choice is trusted
- Updated `docs/dump-and-baseline.md` (resolution order, troubleshooting table), `docs/guide.md` (prerequisites), and `CLAUDE.md`

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] `TestIsShellScript` — verifies detection of scripts, ELF binaries, empty files, and nonexistent files
- [x] `TestResolveMydumper_shellScriptSkipped` — places a script + fake docker on PATH, verifies Docker fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)