### PR TITLE
fix: place --outputdir last in mydumper args for Docker wrapper compat

### DIFF
--- a/cmd/bintrail/dump.go
+++ b/cmd/bintrail/dump.go
@@ -248,7 +248,6 @@ func buildMydumperArgs(host string, port uint16, user, password, outputDir strin
 		"--host", host,
 		"--port", strconv.Itoa(int(port)),
 		"--user", user,
-		"--outputdir", outputDir,
 		"--threads", strconv.Itoa(threads),
 		"--compress-protocol",
 		"--complete-insert",
@@ -283,6 +282,10 @@ func buildMydumperArgs(host string, port uint16, user, password, outputDir strin
 			"--exec-per-thread", fmt.Sprintf("openssl enc -aes-256-cbc -pbkdf2 -pass file:%s", absKey),
 			"--exec-per-thread-extension", ".enc")
 	}
+
+	// --outputdir must be last: Docker wrapper scripts commonly use ${@: -1}
+	// (the last argument) for the volume mount path.
+	args = append(args, "--outputdir", outputDir)
 
 	return args
 }

--- a/cmd/bintrail/dump_test.go
+++ b/cmd/bintrail/dump_test.go
@@ -187,6 +187,37 @@ func TestBuildMydumperArgs_tables(t *testing.T) {
 	}
 }
 
+func TestBuildMydumperArgs_outputDirIsLast(t *testing.T) {
+	// Docker wrapper scripts use ${@: -1} for the volume mount, so
+	// --outputdir must always be the last flag pair.
+	cases := []struct {
+		name    string
+		schemas []string
+		tables  []string
+		encrypt string
+	}{
+		{"no filters", nil, nil, ""},
+		{"single schema", []string{"demo"}, nil, ""},
+		{"multiple schemas", []string{"db1", "db2"}, nil, ""},
+		{"tables", nil, []string{"db.t1", "db.t2"}, ""},
+		{"schema and tables", []string{"mydb"}, []string{"mydb.t1"}, ""},
+		{"encryption", nil, nil, "/path/to/key"},
+		{"all filters plus encryption", []string{"demo"}, []string{"demo.t1"}, "/path/to/key"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			args := buildMydumperArgs("127.0.0.1", 3306, "root", "pw", "/data/backup", 4, tc.schemas, tc.tables, tc.encrypt)
+			n := len(args)
+			if n < 2 {
+				t.Fatalf("args too short: %v", args)
+			}
+			if args[n-2] != "--outputdir" || args[n-1] != "/data/backup" {
+				t.Errorf("expected last two args to be [--outputdir /data/backup], got %v", args[n-2:])
+			}
+		})
+	}
+}
+
 // ─── Lock mechanism ───────────────────────────────────────────────────────────
 
 func TestAcquireReleaseDumpLock(t *testing.T) {


### PR DESCRIPTION
closes #120

## Summary
- Move `--outputdir` from the middle of `buildMydumperArgs` to the very end of the argument list
- Docker wrapper scripts commonly use `${@: -1}` (last argument) for volume mounting — with `--outputdir` in the middle, schema filters like `--database demo` ended up last, causing `docker: invalid volume specification: 'demo:demo'`
- PR #114 added shell-script detection to skip wrappers, but this is a belt-and-suspenders fix that addresses the root cause (arg ordering) so wrappers work even with explicit `--mydumper-path`
- Added table-driven test `TestBuildMydumperArgs_outputDirIsLast` covering 7 flag combinations

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] New test verifies `--outputdir` is last across all filter/encryption combinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)