### PR TITLE
feat: show stream_state in status output including bintrail-id

### DIFF
--- a/cmd/bintrail-mcp/main.go
+++ b/cmd/bintrail-mcp/main.go
@@ -309,6 +309,13 @@ func statusTool(ctx context.Context, req *mcp.CallToolRequest, args statusArgs) 
 		servers = nil
 	}
 
+	// Best-effort: stream state from stream_state table.
+	stream, streamErr := status.LoadStreamState(ctx, db)
+	if streamErr != nil {
+		slog.Warn("could not load stream state", "error", streamErr)
+		stream = nil
+	}
+
 	// Best-effort: coverage info from schema_changes table.
 	coverage, coverageErr := status.LoadCoverage(ctx, db)
 	if coverageErr != nil {
@@ -318,7 +325,7 @@ func statusTool(ctx context.Context, req *mcp.CallToolRequest, args statusArgs) 
 
 	var buf bytes.Buffer
 	// Archive stats omitted for now — can be added in a follow-up.
-	status.WriteStatus(&buf, files, parts, nil, coverage, servers)
+	status.WriteStatus(&buf, files, parts, nil, coverage, servers, stream)
 
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{

--- a/cmd/bintrail/status.go
+++ b/cmd/bintrail/status.go
@@ -97,6 +97,17 @@ func runStatus(cmd *cobra.Command, args []string) error {
 		slog.Debug("loaded servers", "count", len(servers), "duration_ms", time.Since(t).Milliseconds())
 	}
 
+	// Best-effort: stream_state may not exist in older index databases.
+	slog.Debug("loading stream state")
+	t = time.Now()
+	stream, err := status.LoadStreamState(ctx, db)
+	if err != nil {
+		slog.Warn("could not load stream state", "error", err)
+		stream = nil
+	} else if stream != nil {
+		slog.Debug("loaded stream state", "mode", stream.Mode, "events", stream.EventsIndexed, "duration_ms", time.Since(t).Milliseconds())
+	}
+
 	// Best-effort: archive_state may not exist in older index databases.
 	slog.Debug("loading archive stats")
 	t = time.Now()
@@ -122,8 +133,8 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	slog.Info("status complete", "duration_ms", time.Since(start).Milliseconds())
 
 	if stFormat == "json" {
-		return status.WriteStatusJSON(os.Stdout, files, partStats, archives, coverage, servers)
+		return status.WriteStatusJSON(os.Stdout, files, partStats, archives, coverage, servers, stream)
 	}
-	status.WriteStatus(os.Stdout, files, partStats, archives, coverage, servers)
+	status.WriteStatus(os.Stdout, files, partStats, archives, coverage, servers, stream)
 	return nil
 }

--- a/internal/status/load_servers_integration_test.go
+++ b/internal/status/load_servers_integration_test.go
@@ -1,0 +1,128 @@
+//go:build integration
+
+package status_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/bintrail/bintrail/internal/serverid"
+	"github.com/bintrail/bintrail/internal/status"
+	"github.com/bintrail/bintrail/internal/testutil"
+)
+
+func TestLoadServers_integration(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	db, _ := testutil.CreateTestDB(t)
+
+	_, err := db.Exec(serverid.DDLBintrailServers)
+	if err != nil {
+		t.Fatalf("create bintrail_servers: %v", err)
+	}
+
+	_, err = db.Exec(`INSERT INTO bintrail_servers (bintrail_id, server_uuid, host, port, username)
+		VALUES ('97adaf56-fe9e-4c1b-9794-b042f7faf197', '55512139-1432-11f1-8d8d-0693b428a89b', 'testhost.rds.amazonaws.com', 3306, 'admin')`)
+	if err != nil {
+		t.Fatalf("insert test server: %v", err)
+	}
+
+	servers, err := status.LoadServers(context.Background(), db)
+	if err != nil {
+		t.Fatalf("LoadServers failed: %v", err)
+	}
+
+	if len(servers) != 1 {
+		t.Fatalf("expected 1 server, got %d", len(servers))
+	}
+	if servers[0].BintrailID != "97adaf56-fe9e-4c1b-9794-b042f7faf197" {
+		t.Errorf("wrong bintrail_id: %s", servers[0].BintrailID)
+	}
+	if servers[0].Port != 3306 {
+		t.Errorf("wrong port: %d", servers[0].Port)
+	}
+
+	// Verify WriteStatus actually renders the Servers section
+	var buf bytes.Buffer
+	status.WriteStatus(&buf, nil, nil, nil, nil, servers, nil)
+	out := buf.String()
+	if !strings.Contains(out, "=== Servers ===") {
+		t.Errorf("expected Servers section in output:\n%s", out)
+	}
+	if !strings.Contains(out, "97adaf56-fe9e-4c1b-9794-b042f7faf197") {
+		t.Errorf("expected bintrail_id in output:\n%s", out)
+	}
+}
+
+func TestLoadStreamState_integration(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	ctx := context.Background()
+
+	// Empty table → nil, no error
+	stream, err := status.LoadStreamState(ctx, db)
+	if err != nil {
+		t.Fatalf("LoadStreamState on empty table: %v", err)
+	}
+	if stream != nil {
+		t.Fatal("expected nil for empty stream_state")
+	}
+
+	// Insert a stream state row
+	_, err = db.Exec(`INSERT INTO stream_state
+		(id, mode, binlog_file, binlog_position, gtid_set,
+		 events_indexed, last_event_time, last_checkpoint, server_id, bintrail_id)
+		VALUES (1, 'gtid', 'binlog.000005', 12345, 'aaa-bbb:1-100',
+		        267354, '2026-03-03 16:56:40', '2026-03-03 16:56:45', 42, '97adaf56-fe9e-4c1b-9794-b042f7faf197')`)
+	if err != nil {
+		t.Fatalf("insert stream_state: %v", err)
+	}
+
+	stream, err = status.LoadStreamState(ctx, db)
+	if err != nil {
+		t.Fatalf("LoadStreamState failed: %v", err)
+	}
+	if stream == nil {
+		t.Fatal("expected non-nil stream state")
+	}
+
+	if stream.Mode != "gtid" {
+		t.Errorf("wrong mode: %s", stream.Mode)
+	}
+	if stream.BinlogFile != "binlog.000005" {
+		t.Errorf("wrong binlog_file: %s", stream.BinlogFile)
+	}
+	if stream.BinlogPosition != 12345 {
+		t.Errorf("wrong binlog_position: %d", stream.BinlogPosition)
+	}
+	if !stream.GTIDSet.Valid || stream.GTIDSet.String != "aaa-bbb:1-100" {
+		t.Errorf("wrong gtid_set: %v", stream.GTIDSet)
+	}
+	if stream.EventsIndexed != 267354 {
+		t.Errorf("wrong events_indexed: %d", stream.EventsIndexed)
+	}
+	if stream.ServerID != 42 {
+		t.Errorf("wrong server_id: %d", stream.ServerID)
+	}
+	if !stream.BintrailID.Valid || stream.BintrailID.String != "97adaf56-fe9e-4c1b-9794-b042f7faf197" {
+		t.Errorf("wrong bintrail_id: %v", stream.BintrailID)
+	}
+
+	// Verify WriteStatus renders the Stream section with bintrail-id
+	var buf bytes.Buffer
+	status.WriteStatus(&buf, nil, nil, nil, nil, nil, stream)
+	out := buf.String()
+	if !strings.Contains(out, "=== Stream ===") {
+		t.Errorf("expected Stream section in output:\n%s", out)
+	}
+	if !strings.Contains(out, "97adaf56-fe9e-4c1b-9794-b042f7faf197") {
+		t.Errorf("expected bintrail_id in output:\n%s", out)
+	}
+	if !strings.Contains(out, "267354") {
+		t.Errorf("expected events_indexed in output:\n%s", out)
+	}
+}

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"strconv"
@@ -67,6 +68,19 @@ type SchemaChange struct {
 	TableName  string
 	DDLType    string
 	SnapshotID sql.NullInt32
+}
+
+// StreamStateInfo holds the single row from the stream_state table.
+type StreamStateInfo struct {
+	Mode           string // "position" or "gtid"
+	BinlogFile     string
+	BinlogPosition uint64
+	GTIDSet        sql.NullString
+	EventsIndexed  int64
+	LastEventTime  sql.NullTime
+	LastCheckpoint time.Time
+	ServerID       uint32
+	BintrailID     sql.NullString
 }
 
 // CoverageInfo summarizes the restore coverage of the index.
@@ -244,8 +258,31 @@ func LoadServers(ctx context.Context, db *sql.DB) ([]ServerInfo, error) {
 	return servers, rows.Err()
 }
 
-// WriteStatus writes a multi-section status report (Servers, Indexed Files, Partitions, Archives, Coverage, Summary) to w.
-func WriteStatus(w io.Writer, files []IndexStateRow, parts []PartitionStat, archives *ArchiveStats, coverage *CoverageInfo, servers []ServerInfo) {
+// LoadStreamState loads the single row from stream_state (if any).
+// Returns nil with no error when the table is empty (no active stream).
+func LoadStreamState(ctx context.Context, db *sql.DB) (*StreamStateInfo, error) {
+	var s StreamStateInfo
+	err := db.QueryRowContext(ctx, `
+		SELECT mode, binlog_file, binlog_position, gtid_set,
+		       events_indexed, last_event_time, last_checkpoint,
+		       server_id, bintrail_id
+		FROM stream_state
+		WHERE id = 1`).Scan(
+		&s.Mode, &s.BinlogFile, &s.BinlogPosition, &s.GTIDSet,
+		&s.EventsIndexed, &s.LastEventTime, &s.LastCheckpoint,
+		&s.ServerID, &s.BintrailID,
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &s, nil
+}
+
+// WriteStatus writes a multi-section status report (Servers, Stream, Indexed Files, Partitions, Archives, Coverage, Summary) to w.
+func WriteStatus(w io.Writer, files []IndexStateRow, parts []PartitionStat, archives *ArchiveStats, coverage *CoverageInfo, servers []ServerInfo, stream *StreamStateInfo) {
 	// ── Section 0: Servers ───────────────────────────────────────────────────
 	if len(servers) > 0 {
 		fmt.Fprintln(w, "=== Servers ===")
@@ -263,6 +300,30 @@ func WriteStatus(w io.Writer, files []IndexStateRow, parts []PartitionStat, arch
 			)
 		}
 		tw.Flush()
+		fmt.Fprintln(w)
+	}
+
+	// ── Section 0b: Stream ──────────────────────────────────────────────────
+	if stream != nil {
+		fmt.Fprintln(w, "=== Stream ===")
+		bintrailID := "(none)"
+		if stream.BintrailID.Valid && stream.BintrailID.String != "" {
+			bintrailID = stream.BintrailID.String
+		}
+		fmt.Fprintf(w, "  Bintrail ID:     %s\n", bintrailID)
+		fmt.Fprintf(w, "  Mode:            %s\n", stream.Mode)
+		if stream.BinlogFile != "" {
+			fmt.Fprintf(w, "  Position:        %s:%d\n", stream.BinlogFile, stream.BinlogPosition)
+		}
+		if stream.GTIDSet.Valid && stream.GTIDSet.String != "" {
+			fmt.Fprintf(w, "  GTID set:        %s\n", stream.GTIDSet.String)
+		}
+		fmt.Fprintf(w, "  Events indexed:  %d\n", stream.EventsIndexed)
+		if stream.LastEventTime.Valid {
+			fmt.Fprintf(w, "  Last event:      %s\n", stream.LastEventTime.Time.Format(TSFmt))
+		}
+		fmt.Fprintf(w, "  Last checkpoint: %s\n", stream.LastCheckpoint.Format(TSFmt))
+		fmt.Fprintf(w, "  Server ID:       %d\n", stream.ServerID)
 		fmt.Fprintln(w)
 	}
 
@@ -430,7 +491,7 @@ func Truncate(s string, n int) string {
 }
 
 // WriteStatusJSON writes the status data as a JSON object to w.
-func WriteStatusJSON(w io.Writer, files []IndexStateRow, parts []PartitionStat, archives *ArchiveStats, coverage *CoverageInfo, servers []ServerInfo) error {
+func WriteStatusJSON(w io.Writer, files []IndexStateRow, parts []PartitionStat, archives *ArchiveStats, coverage *CoverageInfo, servers []ServerInfo, stream *StreamStateInfo) error {
 	type jsonFile struct {
 		BinlogFile    string  `json:"binlog_file"`
 		Status        string  `json:"status"`
@@ -472,8 +533,20 @@ func WriteStatusJSON(w io.Writer, files []IndexStateRow, parts []PartitionStat, 
 		CreatedAt        string  `json:"created_at"`
 		DecommissionedAt *string `json:"decommissioned_at"`
 	}
+	type jsonStream struct {
+		BintrailID     *string `json:"bintrail_id"`
+		Mode           string  `json:"mode"`
+		BinlogFile     string  `json:"binlog_file,omitempty"`
+		BinlogPosition uint64  `json:"binlog_position,omitempty"`
+		GTIDSet        *string `json:"gtid_set,omitempty"`
+		EventsIndexed  int64   `json:"events_indexed"`
+		LastEventTime  *string `json:"last_event_time"`
+		LastCheckpoint string  `json:"last_checkpoint"`
+		ServerID       uint32  `json:"server_id"`
+	}
 	type jsonSummary struct {
 		Servers  []jsonServer    `json:"servers,omitempty"`
+		Stream   *jsonStream     `json:"stream,omitempty"`
 		Files    []jsonFile      `json:"files"`
 		Parts    []jsonPartition `json:"partitions"`
 		Total    int64           `json:"total_events_estimate"`
@@ -532,6 +605,27 @@ func WriteStatusJSON(w io.Writer, files []IndexStateRow, parts []PartitionStat, 
 	}
 
 	out := jsonSummary{Servers: js, Files: jf, Parts: jp, Total: total}
+	if stream != nil {
+		jstr := &jsonStream{
+			Mode:           stream.Mode,
+			BinlogFile:     stream.BinlogFile,
+			BinlogPosition: stream.BinlogPosition,
+			EventsIndexed:  stream.EventsIndexed,
+			LastCheckpoint: stream.LastCheckpoint.Format(TSFmt),
+			ServerID:       stream.ServerID,
+		}
+		if stream.BintrailID.Valid && stream.BintrailID.String != "" {
+			jstr.BintrailID = &stream.BintrailID.String
+		}
+		if stream.GTIDSet.Valid && stream.GTIDSet.String != "" {
+			jstr.GTIDSet = &stream.GTIDSet.String
+		}
+		if stream.LastEventTime.Valid {
+			s := stream.LastEventTime.Time.Format(TSFmt)
+			jstr.LastEventTime = &s
+		}
+		out.Stream = jstr
+	}
 	if archives != nil && archives.TotalFiles > 0 {
 		out.Archives = &jsonArchives{
 			TotalFiles:     archives.TotalFiles,

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -90,7 +90,7 @@ func TestTruncate_longString(t *testing.T) {
 
 func TestWriteStatus_noFiles_noPartitions(t *testing.T) {
 	var buf bytes.Buffer
-	WriteStatus(&buf, nil, nil, nil, nil, nil)
+	WriteStatus(&buf, nil, nil, nil, nil, nil, nil)
 	out := buf.String()
 
 	assertContains(t, out, "=== Indexed Files ===")
@@ -129,7 +129,7 @@ func TestWriteStatus_withFiles(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	WriteStatus(&buf, files, nil, nil, nil, nil)
+	WriteStatus(&buf, files, nil, nil, nil, nil, nil)
 	out := buf.String()
 
 	assertContains(t, out, "binlog.000042")
@@ -157,7 +157,7 @@ func TestWriteStatus_withPartitions(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	WriteStatus(&buf, nil, parts, nil, nil, nil)
+	WriteStatus(&buf, nil, parts, nil, nil, nil, nil)
 	out := buf.String()
 
 	assertContains(t, out, "=== Partitions ===")
@@ -179,7 +179,7 @@ func TestWriteStatus_errorTruncation(t *testing.T) {
 	}}
 
 	var buf bytes.Buffer
-	WriteStatus(&buf, files, nil, nil, nil, nil)
+	WriteStatus(&buf, files, nil, nil, nil, nil, nil)
 	out := buf.String()
 
 	// The error should be truncated — full 100-char string should not appear.
@@ -211,7 +211,7 @@ func TestWriteStatus_bintrailIDColumn(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	WriteStatus(&buf, files, nil, nil, nil, nil)
+	WriteStatus(&buf, files, nil, nil, nil, nil, nil)
 	out := buf.String()
 
 	// BINTRAIL_ID column header must appear.
@@ -234,7 +234,7 @@ func TestWriteStatus_perServerSummary_multipleServers(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	WriteStatus(&buf, files, nil, nil, nil, nil)
+	WriteStatus(&buf, files, nil, nil, nil, nil, nil)
 	out := buf.String()
 
 	assertContains(t, out, "=== Summary ===")
@@ -256,7 +256,7 @@ func TestWriteStatus_perServerSummary_unknownID(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	WriteStatus(&buf, files, nil, nil, nil, nil)
+	WriteStatus(&buf, files, nil, nil, nil, nil, nil)
 	out := buf.String()
 
 	// Null bintrail_id must be grouped under "(unknown)".
@@ -277,7 +277,7 @@ func assertContains(t *testing.T, s, want string) {
 
 func TestWriteStatusJSON_empty(t *testing.T) {
 	var buf bytes.Buffer
-	if err := WriteStatusJSON(&buf, nil, nil, nil, nil, nil); err != nil {
+	if err := WriteStatusJSON(&buf, nil, nil, nil, nil, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 	var result struct {
@@ -316,7 +316,7 @@ func TestWriteStatusJSON_withData(t *testing.T) {
 	}}
 
 	var buf bytes.Buffer
-	if err := WriteStatusJSON(&buf, files, parts, nil, nil, nil); err != nil {
+	if err := WriteStatusJSON(&buf, files, parts, nil, nil, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -370,7 +370,7 @@ func TestWriteStatusJSON_nullFields(t *testing.T) {
 	}}
 
 	var buf bytes.Buffer
-	if err := WriteStatusJSON(&buf, files, nil, nil, nil, nil); err != nil {
+	if err := WriteStatusJSON(&buf, files, nil, nil, nil, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -432,7 +432,7 @@ func TestWriteStatus_withArchives(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	WriteStatus(&buf, nil, nil, archives, nil, nil)
+	WriteStatus(&buf, nil, nil, archives, nil, nil, nil)
 	out := buf.String()
 
 	assertContains(t, out, "=== Archives ===")
@@ -446,7 +446,7 @@ func TestWriteStatus_withArchives(t *testing.T) {
 
 func TestWriteStatus_nilArchives_omitsSection(t *testing.T) {
 	var buf bytes.Buffer
-	WriteStatus(&buf, nil, nil, nil, nil, nil)
+	WriteStatus(&buf, nil, nil, nil, nil, nil, nil)
 	out := buf.String()
 
 	if strings.Contains(out, "=== Archives ===") {
@@ -456,7 +456,7 @@ func TestWriteStatus_nilArchives_omitsSection(t *testing.T) {
 
 func TestWriteStatus_zeroArchives_omitsSection(t *testing.T) {
 	var buf bytes.Buffer
-	WriteStatus(&buf, nil, nil, &ArchiveStats{}, nil, nil)
+	WriteStatus(&buf, nil, nil, &ArchiveStats{}, nil, nil, nil)
 	out := buf.String()
 
 	if strings.Contains(out, "=== Archives ===") {
@@ -474,7 +474,7 @@ func TestWriteStatus_archives_noS3(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	WriteStatus(&buf, nil, nil, archives, nil, nil)
+	WriteStatus(&buf, nil, nil, archives, nil, nil, nil)
 	out := buf.String()
 
 	assertContains(t, out, "=== Archives ===")
@@ -497,7 +497,7 @@ func TestWriteStatusJSON_withArchives(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	if err := WriteStatusJSON(&buf, nil, nil, archives, nil, nil); err != nil {
+	if err := WriteStatusJSON(&buf, nil, nil, archives, nil, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -537,7 +537,7 @@ func TestWriteStatusJSON_withArchives(t *testing.T) {
 
 func TestWriteStatusJSON_nilArchives_omitsKey(t *testing.T) {
 	var buf bytes.Buffer
-	if err := WriteStatusJSON(&buf, nil, nil, nil, nil, nil); err != nil {
+	if err := WriteStatusJSON(&buf, nil, nil, nil, nil, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -564,7 +564,7 @@ func TestWriteStatus_withCoverage(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	WriteStatus(&buf, nil, nil, nil, coverage, nil)
+	WriteStatus(&buf, nil, nil, nil, coverage, nil, nil)
 	out := buf.String()
 
 	assertContains(t, out, "=== Restore Coverage ===")
@@ -577,7 +577,7 @@ func TestWriteStatus_withCoverage(t *testing.T) {
 
 func TestWriteStatus_nilCoverage_omitsSection(t *testing.T) {
 	var buf bytes.Buffer
-	WriteStatus(&buf, nil, nil, nil, nil, nil)
+	WriteStatus(&buf, nil, nil, nil, nil, nil, nil)
 	out := buf.String()
 
 	if strings.Contains(out, "=== Restore Coverage ===") {
@@ -593,7 +593,7 @@ func TestWriteStatus_zeroCoverage_noWarning(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	WriteStatus(&buf, nil, nil, nil, coverage, nil)
+	WriteStatus(&buf, nil, nil, nil, coverage, nil, nil)
 	out := buf.String()
 
 	assertContains(t, out, "=== Restore Coverage ===")
@@ -614,7 +614,7 @@ func TestWriteStatusJSON_withCoverage(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	if err := WriteStatusJSON(&buf, nil, nil, nil, coverage, nil); err != nil {
+	if err := WriteStatusJSON(&buf, nil, nil, nil, coverage, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -646,7 +646,7 @@ func TestWriteStatusJSON_withCoverage(t *testing.T) {
 
 func TestWriteStatusJSON_nilCoverage_omitsKey(t *testing.T) {
 	var buf bytes.Buffer
-	if err := WriteStatusJSON(&buf, nil, nil, nil, nil, nil); err != nil {
+	if err := WriteStatusJSON(&buf, nil, nil, nil, nil, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -674,7 +674,7 @@ func TestWriteStatus_withServers(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	WriteStatus(&buf, nil, nil, nil, nil, servers)
+	WriteStatus(&buf, nil, nil, nil, nil, servers, nil)
 	out := buf.String()
 
 	assertContains(t, out, "=== Servers ===")
@@ -698,7 +698,7 @@ func TestWriteStatus_withDecommissionedServer(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	WriteStatus(&buf, nil, nil, nil, nil, servers)
+	WriteStatus(&buf, nil, nil, nil, nil, servers, nil)
 	out := buf.String()
 
 	assertContains(t, out, "decommissioned")
@@ -706,7 +706,7 @@ func TestWriteStatus_withDecommissionedServer(t *testing.T) {
 
 func TestWriteStatus_nilServers_omitsSection(t *testing.T) {
 	var buf bytes.Buffer
-	WriteStatus(&buf, nil, nil, nil, nil, nil)
+	WriteStatus(&buf, nil, nil, nil, nil, nil, nil)
 	out := buf.String()
 
 	if strings.Contains(out, "=== Servers ===") {
@@ -729,7 +729,7 @@ func TestWriteStatusJSON_withServers(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	if err := WriteStatusJSON(&buf, nil, nil, nil, nil, servers); err != nil {
+	if err := WriteStatusJSON(&buf, nil, nil, nil, nil, servers, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -764,7 +764,7 @@ func TestWriteStatusJSON_withServers(t *testing.T) {
 
 func TestWriteStatusJSON_nilServers_omitsKey(t *testing.T) {
 	var buf bytes.Buffer
-	if err := WriteStatusJSON(&buf, nil, nil, nil, nil, nil); err != nil {
+	if err := WriteStatusJSON(&buf, nil, nil, nil, nil, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -774,5 +774,130 @@ func TestWriteStatusJSON_nilServers_omitsKey(t *testing.T) {
 	}
 	if _, ok := raw["servers"]; ok {
 		t.Error("expected no 'servers' key when servers is nil")
+	}
+}
+
+// ─── WriteStatus: stream section ────────────────────────────────────────────
+
+func TestWriteStatus_withStream(t *testing.T) {
+	stream := &StreamStateInfo{
+		Mode:           "gtid",
+		BinlogFile:     "binlog.000005",
+		BinlogPosition: 12345,
+		GTIDSet:        sql.NullString{Valid: true, String: "aaa-bbb:1-100"},
+		EventsIndexed:  267354,
+		LastEventTime:  sql.NullTime{Valid: true, Time: time.Date(2026, 3, 3, 16, 56, 40, 0, time.UTC)},
+		LastCheckpoint: time.Date(2026, 3, 3, 16, 56, 45, 0, time.UTC),
+		ServerID:       42,
+		BintrailID:     sql.NullString{Valid: true, String: "97adaf56-fe9e-4c1b-9794-b042f7faf197"},
+	}
+
+	var buf bytes.Buffer
+	WriteStatus(&buf, nil, nil, nil, nil, nil, stream)
+	out := buf.String()
+
+	assertContains(t, out, "=== Stream ===")
+	assertContains(t, out, "97adaf56-fe9e-4c1b-9794-b042f7faf197")
+	assertContains(t, out, "gtid")
+	assertContains(t, out, "binlog.000005:12345")
+	assertContains(t, out, "aaa-bbb:1-100")
+	assertContains(t, out, "267354")
+	assertContains(t, out, "42")
+}
+
+func TestWriteStatus_nilStream_omitsSection(t *testing.T) {
+	var buf bytes.Buffer
+	WriteStatus(&buf, nil, nil, nil, nil, nil, nil)
+	out := buf.String()
+
+	if strings.Contains(out, "=== Stream ===") {
+		t.Error("expected no Stream section when stream is nil")
+	}
+}
+
+func TestWriteStatus_streamNoBintrailID(t *testing.T) {
+	stream := &StreamStateInfo{
+		Mode:           "position",
+		BinlogFile:     "binlog.000001",
+		BinlogPosition: 4,
+		EventsIndexed:  0,
+		LastCheckpoint: time.Date(2026, 3, 3, 16, 0, 0, 0, time.UTC),
+		ServerID:       1,
+	}
+
+	var buf bytes.Buffer
+	WriteStatus(&buf, nil, nil, nil, nil, nil, stream)
+	out := buf.String()
+
+	assertContains(t, out, "=== Stream ===")
+	assertContains(t, out, "(none)")
+	assertContains(t, out, "position")
+}
+
+// ─── WriteStatusJSON: stream ────────────────────────────────────────────────
+
+func TestWriteStatusJSON_withStream(t *testing.T) {
+	stream := &StreamStateInfo{
+		Mode:           "gtid",
+		BinlogFile:     "binlog.000005",
+		BinlogPosition: 12345,
+		GTIDSet:        sql.NullString{Valid: true, String: "aaa-bbb:1-100"},
+		EventsIndexed:  267354,
+		LastEventTime:  sql.NullTime{Valid: true, Time: time.Date(2026, 3, 3, 16, 56, 40, 0, time.UTC)},
+		LastCheckpoint: time.Date(2026, 3, 3, 16, 56, 45, 0, time.UTC),
+		ServerID:       42,
+		BintrailID:     sql.NullString{Valid: true, String: "97adaf56-fe9e-4c1b-9794-b042f7faf197"},
+	}
+
+	var buf bytes.Buffer
+	if err := WriteStatusJSON(&buf, nil, nil, nil, nil, nil, stream); err != nil {
+		t.Fatal(err)
+	}
+
+	var result struct {
+		Stream *struct {
+			BintrailID     *string `json:"bintrail_id"`
+			Mode           string  `json:"mode"`
+			BinlogFile     string  `json:"binlog_file"`
+			BinlogPosition uint64  `json:"binlog_position"`
+			GTIDSet        *string `json:"gtid_set"`
+			EventsIndexed  int64   `json:"events_indexed"`
+			LastEventTime  *string `json:"last_event_time"`
+			LastCheckpoint string  `json:"last_checkpoint"`
+			ServerID       uint32  `json:"server_id"`
+		} `json:"stream"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, buf.String())
+	}
+	if result.Stream == nil {
+		t.Fatal("expected stream key in JSON")
+	}
+	if result.Stream.BintrailID == nil || *result.Stream.BintrailID != "97adaf56-fe9e-4c1b-9794-b042f7faf197" {
+		t.Errorf("wrong bintrail_id: %v", result.Stream.BintrailID)
+	}
+	if result.Stream.Mode != "gtid" {
+		t.Errorf("wrong mode: %s", result.Stream.Mode)
+	}
+	if result.Stream.EventsIndexed != 267354 {
+		t.Errorf("wrong events_indexed: %d", result.Stream.EventsIndexed)
+	}
+	if result.Stream.ServerID != 42 {
+		t.Errorf("wrong server_id: %d", result.Stream.ServerID)
+	}
+}
+
+func TestWriteStatusJSON_nilStream_omitsKey(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteStatusJSON(&buf, nil, nil, nil, nil, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &raw); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if _, ok := raw["stream"]; ok {
+		t.Error("expected no 'stream' key when stream is nil")
 	}
 }


### PR DESCRIPTION
closes #122

## Summary
- Add `StreamStateInfo` type and `LoadStreamState()` to `internal/status/` to query `stream_state`
- Add a new "=== Stream ===" section to `WriteStatus()` text output showing Bintrail ID, mode, position/GTID, events indexed, last event time, last checkpoint, and server ID
- Add `stream` key to `WriteStatusJSON()` JSON output (omitted when nil)
- Update both callers (`cmd/bintrail/status.go` and `cmd/bintrail-mcp/main.go`) to load stream state best-effort
- Add integration tests for `LoadServers` and `LoadStreamState` against real MySQL to catch scan bugs

## Context
PR #115 added the Servers section from `bintrail_servers`, but streaming users may not always see it (table creation timing, identity resolution failures, etc.). The `stream_state` table is the authoritative source for the bintrail-id in streaming mode, and the status command never read it. This adds `stream_state` as a second path to the bintrail-id.

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] New unit tests: `TestWriteStatus_withStream`, `TestWriteStatus_nilStream_omitsSection`, `TestWriteStatus_streamNoBintrailID`, `TestWriteStatusJSON_withStream`, `TestWriteStatusJSON_nilStream_omitsKey`
- [x] New integration tests: `TestLoadServers_integration`, `TestLoadStreamState_integration`

🤖 Generated with [Claude Code](https://claude.com/claude-code)