### PR TITLE
feat: rate limiting, request logging, and integration testing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,15 +359,22 @@ Events: 21246 indexed
 
 ## MCP Server
 
-Bintrail ships an [MCP](https://modelcontextprotocol.io) server that exposes the same query, recover, and status operations as read-only tools — letting Claude Code (or any MCP-compatible client) explore your binlog index conversationally.
+Bintrail ships an [MCP](https://modelcontextprotocol.io) server that exposes the same query, recover, and status operations as read-only tools — letting Claude (or any MCP-compatible client) explore your binlog index conversationally.
 
-**Build:**
+### Claude Connector (recommended)
 
-```sh
-go build ./cmd/bintrail-mcp
-```
+The easiest way to connect — works from claude.ai, Claude Desktop, and Claude mobile:
 
-**Register with Claude Code** — the project ships `.mcp.json` which pre-registers the server using `go run` (no pre-build required):
+1. Deploy the [MCP Gateway](docs/mcp-gateway.md) (handles OAuth + tenant routing)
+2. In Claude, go to **Settings** → **Integrations** → **Add custom integration**
+3. Enter your gateway URL (e.g. `https://mcp.dbtrail.com/mcp`)
+4. Authorize with your tenant ID — done
+
+See [MCP Server docs](docs/mcp-server.md) for details and [Connector Testing](docs/connector-testing.md) for a complete integration checklist.
+
+### Claude Code (local)
+
+For local development, the project ships `.mcp.json` which pre-registers the server using `go run` (no pre-build required):
 
 ```json
 {

--- a/cmd/mcp-gateway/logging.go
+++ b/cmd/mcp-gateway/logging.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type requestIDKey struct{}
+
+// RequestIDFromContext returns the request ID from the context, or empty string.
+func RequestIDFromContext(ctx context.Context) string {
+	id, _ := ctx.Value(requestIDKey{}).(string)
+	return id
+}
+
+// RequestIDMiddleware generates a unique request ID for each request, adds it
+// to the response headers (X-Request-Id), and injects it into the context.
+// If the client already sent an X-Request-Id header, it is preserved.
+func RequestIDMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := r.Header.Get("X-Request-Id")
+		if id == "" {
+			id = uuid.New().String()
+		}
+		w.Header().Set("X-Request-Id", id)
+		ctx := context.WithValue(r.Context(), requestIDKey{}, id)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// LoggingMiddleware logs every request with method, path, status, duration,
+// client IP, and request ID. It should be placed after RequestIDMiddleware.
+func LoggingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		sw := &statusWriter{ResponseWriter: w, status: http.StatusOK}
+
+		next.ServeHTTP(sw, r)
+
+		reqID := RequestIDFromContext(r.Context())
+		slog.Info("request",
+			"method", r.Method,
+			"path", r.URL.Path,
+			"status", sw.status,
+			"duration_ms", time.Since(start).Milliseconds(),
+			"client_ip", clientIP(r),
+			"request_id", reqID,
+		)
+	})
+}
+
+// statusWriter wraps http.ResponseWriter to capture the status code.
+type statusWriter struct {
+	http.ResponseWriter
+	status      int
+	wroteHeader bool
+}
+
+func (w *statusWriter) WriteHeader(code int) {
+	if !w.wroteHeader {
+		w.status = code
+		w.wroteHeader = true
+	}
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *statusWriter) Write(b []byte) (int, error) {
+	if !w.wroteHeader {
+		w.wroteHeader = true
+	}
+	return w.ResponseWriter.Write(b)
+}
+
+// Unwrap supports http.ResponseController and middleware that need
+// access to the underlying ResponseWriter (e.g. for Flusher).
+func (w *statusWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}

--- a/cmd/mcp-gateway/logging_test.go
+++ b/cmd/mcp-gateway/logging_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRequestIDMiddleware_generatesID(t *testing.T) {
+	var gotID string
+	handler := RequestIDMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotID = RequestIDFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if gotID == "" {
+		t.Fatal("expected request ID in context")
+	}
+	if rec.Header().Get("X-Request-Id") == "" {
+		t.Fatal("expected X-Request-Id response header")
+	}
+	if rec.Header().Get("X-Request-Id") != gotID {
+		t.Errorf("header %q != context %q", rec.Header().Get("X-Request-Id"), gotID)
+	}
+}
+
+func TestRequestIDMiddleware_preservesClientID(t *testing.T) {
+	var gotID string
+	handler := RequestIDMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotID = RequestIDFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Request-Id", "client-provided-id")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if gotID != "client-provided-id" {
+		t.Errorf("expected client-provided-id, got %s", gotID)
+	}
+	if rec.Header().Get("X-Request-Id") != "client-provided-id" {
+		t.Errorf("expected client-provided-id in response header, got %s", rec.Header().Get("X-Request-Id"))
+	}
+}
+
+func TestLoggingMiddleware_capturesStatus(t *testing.T) {
+	handler := LoggingMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte("ok"))
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Errorf("expected 201, got %d", rec.Code)
+	}
+}
+
+func TestStatusWriter_defaultsTo200(t *testing.T) {
+	rec := httptest.NewRecorder()
+	sw := &statusWriter{ResponseWriter: rec, status: http.StatusOK}
+	sw.Write([]byte("hello"))
+
+	if sw.status != http.StatusOK {
+		t.Errorf("expected 200, got %d", sw.status)
+	}
+}

--- a/cmd/mcp-gateway/main.go
+++ b/cmd/mcp-gateway/main.go
@@ -11,11 +11,14 @@
 //
 // Configuration:
 //
-//	--addr              Listen address (default :8443)
-//	--allowed-origins   Comma-separated allowed CORS origins
-//	--backend-url       Default backend URL (single-backend mode)
-//	--table-prefix      DynamoDB table name prefix (default "bintrail-oauth")
-//	--issuer            OAuth issuer URL (default "https://mcp.dbtrail.com")
+//	--addr                  Listen address (default :8443)
+//	--allowed-origins       Comma-separated allowed CORS origins
+//	--backend-url           Default backend URL (single-backend mode)
+//	--table-prefix          DynamoDB table name prefix (default "bintrail-oauth")
+//	--issuer                OAuth issuer URL (default "https://mcp.dbtrail.com")
+//	--rate-limit-register   Per-IP requests/min for /oauth/register (default 10, 0=off)
+//	--rate-limit-token      Per-IP requests/min for /oauth/token (default 30, 0=off)
+//	--rate-limit-authorize  Per-IP requests/min for POST /oauth/authorize (default 20, 0=off)
 package main
 
 import (
@@ -44,6 +47,9 @@ func main() {
 	adminToken := flag.String("admin-token", "", "Bearer token for admin API (required for /admin/* endpoints)")
 	healthInterval := flag.Duration("health-interval", 30*time.Second, "Backend health check interval (0 to disable)")
 	healthThreshold := flag.Int("health-threshold", 3, "Consecutive failures before marking a backend unhealthy")
+	rateLimitRegister := flag.Int("rate-limit-register", 10, "Per-IP requests/min for /oauth/register (0 to disable)")
+	rateLimitToken := flag.Int("rate-limit-token", 30, "Per-IP requests/min for /oauth/token (0 to disable)")
+	rateLimitAuthorize := flag.Int("rate-limit-authorize", 20, "Per-IP requests/min for POST /oauth/authorize (0 to disable)")
 	flag.Parse()
 
 	origins := parseOrigins(*allowedOrigins)
@@ -59,14 +65,21 @@ func main() {
 		Store:  store,
 	}
 
+	// Rate limiter for OAuth endpoints.
+	rateLimiter := NewRateLimiter(1 * time.Minute)
+	defer rateLimiter.Stop()
+
 	mux := http.NewServeMux()
 
-	// OAuth endpoints (no auth required).
+	// OAuth endpoints (no auth required, rate-limited).
 	mux.HandleFunc("GET /.well-known/oauth-authorization-server", oauthCfg.MetadataHandler)
-	mux.HandleFunc("POST /oauth/register", oauthCfg.RegisterHandler)
+	mux.Handle("POST /oauth/register", RateLimitMiddleware(rateLimiter, *rateLimitRegister,
+		http.HandlerFunc(oauthCfg.RegisterHandler)))
 	mux.HandleFunc("GET /oauth/authorize", oauthCfg.AuthorizeHandler)
-	mux.HandleFunc("POST /oauth/authorize", oauthCfg.AuthorizeSubmitHandler)
-	mux.HandleFunc("POST /oauth/token", oauthCfg.TokenHandler)
+	mux.Handle("POST /oauth/authorize", RateLimitMiddleware(rateLimiter, *rateLimitAuthorize,
+		http.HandlerFunc(oauthCfg.AuthorizeSubmitHandler)))
+	mux.Handle("POST /oauth/token", RateLimitMiddleware(rateLimiter, *rateLimitToken,
+		http.HandlerFunc(oauthCfg.TokenHandler)))
 
 	// Health checker for backend monitoring.
 	checker := NewHealthChecker(*healthInterval, *healthThreshold)
@@ -95,8 +108,10 @@ func main() {
 	proxy := NewReverseProxy(store, *backendURL, checker)
 	mux.Handle("/mcp", AuthMiddleware(store, proxy))
 
-	// Wrap everything with CORS and origin validation.
-	handler := CORSMiddleware(origins, OriginMiddleware(origins, mux))
+	// Wrap everything with logging, request IDs, CORS, and origin validation.
+	handler := RequestIDMiddleware(
+		LoggingMiddleware(
+			CORSMiddleware(origins, OriginMiddleware(origins, mux))))
 
 	srv := &http.Server{Addr: *addr, Handler: handler}
 

--- a/cmd/mcp-gateway/ratelimit.go
+++ b/cmd/mcp-gateway/ratelimit.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"net"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// RateLimiter tracks per-IP request counts in fixed one-minute windows.
+// Expired entries are cleaned up periodically.
+type RateLimiter struct {
+	mu      sync.Mutex
+	entries map[string]*rateLimitEntry
+	window  time.Duration
+	done    chan struct{}
+}
+
+type rateLimitEntry struct {
+	count    int
+	windowAt time.Time // start of the current window
+}
+
+// NewRateLimiter creates a rate limiter with the given window duration.
+// Call Stop when done to release the cleanup goroutine.
+func NewRateLimiter(window time.Duration) *RateLimiter {
+	rl := &RateLimiter{
+		entries: make(map[string]*rateLimitEntry),
+		window:  window,
+		done:    make(chan struct{}),
+	}
+	go rl.cleanup()
+	return rl
+}
+
+// Allow checks whether the given key has remaining capacity. If so it
+// increments the counter and returns true. Otherwise it returns false.
+func (rl *RateLimiter) Allow(key string, limit int) bool {
+	if limit <= 0 {
+		return true // disabled
+	}
+
+	now := time.Now()
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	e, ok := rl.entries[key]
+	if !ok || now.Sub(e.windowAt) >= rl.window {
+		rl.entries[key] = &rateLimitEntry{count: 1, windowAt: now}
+		return true
+	}
+
+	if e.count >= limit {
+		return false
+	}
+	e.count++
+	return true
+}
+
+// Stop shuts down the background cleanup goroutine.
+func (rl *RateLimiter) Stop() {
+	close(rl.done)
+}
+
+func (rl *RateLimiter) cleanup() {
+	ticker := time.NewTicker(1 * time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-rl.done:
+			return
+		case <-ticker.C:
+			rl.evict()
+		}
+	}
+}
+
+func (rl *RateLimiter) evict() {
+	now := time.Now()
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	for key, e := range rl.entries {
+		if now.Sub(e.windowAt) >= 2*rl.window {
+			delete(rl.entries, key)
+		}
+	}
+}
+
+// RateLimitMiddleware wraps an http.Handler with per-IP rate limiting.
+// When the limit is exceeded, it returns 429 Too Many Requests with a
+// Retry-After header.
+func RateLimitMiddleware(rl *RateLimiter, limit int, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if limit <= 0 {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		ip := clientIP(r)
+		if !rl.Allow(ip, limit) {
+			retryAfter := int(rl.window.Seconds())
+			w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
+			jsonError(w, "rate_limit_exceeded", "too many requests, try again later", http.StatusTooManyRequests)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// clientIP extracts the client IP from the request. It prefers
+// X-Forwarded-For (set by ALB/reverse proxy) and falls back to RemoteAddr.
+func clientIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		// X-Forwarded-For can contain multiple IPs; the first is the client.
+		for i := range len(xff) {
+			if xff[i] == ',' {
+				return xff[:i]
+			}
+		}
+		return xff
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}

--- a/cmd/mcp-gateway/ratelimit_test.go
+++ b/cmd/mcp-gateway/ratelimit_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestRateLimiter_Allow(t *testing.T) {
+	rl := NewRateLimiter(1 * time.Minute)
+	defer rl.Stop()
+
+	// First 3 requests should pass.
+	for i := range 3 {
+		if !rl.Allow("192.168.1.1", 3) {
+			t.Fatalf("request %d should be allowed", i+1)
+		}
+	}
+
+	// 4th should be denied.
+	if rl.Allow("192.168.1.1", 3) {
+		t.Fatal("4th request should be denied")
+	}
+
+	// Different IP should be independent.
+	if !rl.Allow("10.0.0.1", 3) {
+		t.Fatal("different IP should be allowed")
+	}
+}
+
+func TestRateLimiter_disabledWhenZero(t *testing.T) {
+	rl := NewRateLimiter(1 * time.Minute)
+	defer rl.Stop()
+
+	for range 100 {
+		if !rl.Allow("1.2.3.4", 0) {
+			t.Fatal("limit=0 should allow all requests")
+		}
+	}
+}
+
+func TestRateLimitMiddleware_returns429(t *testing.T) {
+	rl := NewRateLimiter(1 * time.Minute)
+	defer rl.Stop()
+
+	handler := RateLimitMiddleware(rl, 1, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// First request passes.
+	req := httptest.NewRequest(http.MethodPost, "/oauth/register", nil)
+	req.RemoteAddr = "192.168.1.1:12345"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	// Second request is rate-limited.
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429, got %d", rec.Code)
+	}
+	if rec.Header().Get("Retry-After") == "" {
+		t.Error("expected Retry-After header")
+	}
+}
+
+func TestRateLimitMiddleware_disabledWhenZero(t *testing.T) {
+	rl := NewRateLimiter(1 * time.Minute)
+	defer rl.Stop()
+
+	handler := RateLimitMiddleware(rl, 0, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	for range 10 {
+		req := httptest.NewRequest(http.MethodPost, "/test", nil)
+		req.RemoteAddr = "1.2.3.4:1234"
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", rec.Code)
+		}
+	}
+}
+
+func TestClientIP_xForwardedFor(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-For", "203.0.113.50, 70.41.3.18, 150.172.238.178")
+	if got := clientIP(req); got != "203.0.113.50" {
+		t.Errorf("expected 203.0.113.50, got %s", got)
+	}
+}
+
+func TestClientIP_remoteAddr(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.0.0.1:54321"
+	if got := clientIP(req); got != "10.0.0.1" {
+		t.Errorf("expected 10.0.0.1, got %s", got)
+	}
+}

--- a/docs/connector-testing.md
+++ b/docs/connector-testing.md
@@ -1,0 +1,673 @@
+# Claude Connector — Integration Testing & Hardening Checklist
+
+This is a step-by-step guide for manually testing the Bintrail Claude Connector before GA. Follow each section in order. Every step has exact commands or click paths — no assumed knowledge.
+
+---
+
+## Prerequisites
+
+Before you start, you need:
+
+- [ ] The MCP gateway running at `https://mcp.dbtrail.com` (or your domain)
+- [ ] At least one `bintrail-mcp` backend running with indexed data
+- [ ] Two test tenants provisioned (e.g. `tenant-a` and `tenant-b`) — see [gateway docs](./mcp-gateway.md#5-add-your-tenants)
+- [ ] A Claude Pro/Team account (for claude.ai and mobile testing)
+- [ ] Claude Desktop installed (macOS or Windows)
+- [ ] A phone with Claude mobile (iOS or Android)
+- [ ] Node.js installed (for MCP Inspector)
+
+---
+
+## 1. Claude.ai (Web Browser)
+
+### 1.1 Add the Connector
+
+1. Open **https://claude.ai** in your browser
+2. Click your profile icon (bottom-left) → **Settings**
+3. Click **Integrations** in the left sidebar (may also be called **Connectors** depending on your version)
+4. Click **Add custom integration** (or **Add custom connector**)
+5. In the URL field, enter: `https://mcp.dbtrail.com/mcp`
+6. Click **Add** (or **Save**)
+
+**What should happen:** Claude discovers the OAuth endpoints automatically (via `/.well-known/oauth-authorization-server`), opens a browser tab to the Bintrail authorization page.
+
+**If it fails:**
+- Check that `https://mcp.dbtrail.com/.well-known/oauth-authorization-server` returns JSON in your browser
+- Check the gateway logs for errors
+
+### 1.2 Complete the OAuth Flow
+
+1. On the Bintrail authorization page, enter your **tenant ID** (e.g. `tenant-a`)
+2. Click **Authorize**
+
+**What should happen:** The page redirects back to Claude. The connector shows as "Connected" in Settings.
+
+**If it fails:**
+- "unknown or inactive tenant" → your tenant ID doesn't exist or its status isn't `active`. Check:
+  ```sh
+  curl https://mcp.dbtrail.com/admin/tenants/tenant-a \
+    -H 'Authorization: Bearer YOUR_ADMIN_TOKEN'
+  ```
+- "redirect_uri not registered" → this is a bug in the gateway's DCR flow. Check gateway logs.
+
+### 1.3 Test the `query` Tool
+
+1. Open a new conversation in Claude
+2. Type: **"What tables are indexed in my binlog index?"**
+3. Claude should call the `status` tool and list your tables
+
+4. Then try: **"Show me all DELETEs from the last 24 hours"**
+5. Claude should call the `query` tool with `event_type: DELETE` and `since` set to 24 hours ago
+
+**What to verify:**
+- [ ] Claude shows the tool call (you can expand it to see parameters)
+- [ ] Results come back with actual data from your index
+- [ ] No "backend unavailable" or "token expired" errors
+
+### 1.4 Test the `recover` Tool
+
+1. In the same conversation, type: **"Generate SQL to undo those deletes"**
+2. Claude should call the `recover` tool with matching filters
+
+**What to verify:**
+- [ ] Claude returns a SQL script with `BEGIN`/`COMMIT` wrapper
+- [ ] The SQL contains `INSERT INTO` statements (reversing the DELETEs)
+
+### 1.5 Test the `status` Tool
+
+1. Type: **"Show me the status of my binlog index"**
+
+**What to verify:**
+- [ ] Shows indexed files, partitions, and event counts
+- [ ] Numbers match what you'd see from `bintrail status` on the CLI
+
+### 1.6 Test Token Refresh (Long Session)
+
+This tests that sessions survive beyond the 1-hour access token TTL.
+
+1. Open a conversation and verify tools work (make any query)
+2. Note the time
+3. **Wait 65 minutes** (or at least until the access token expires — TTL is 1 hour)
+4. In the same conversation, make another query: **"Show me the latest events"**
+
+**What should happen:** Claude silently refreshes the access token using the refresh token. The query works without re-authenticating.
+
+**If it fails:**
+- Claude shows an error about invalid/expired token → the refresh flow isn't working
+- Check gateway logs for `consume refresh token` errors
+- Verify refresh tokens are stored in DynamoDB: `aws dynamodb scan --table-name bintrail-oauth-refresh`
+
+### 1.7 Test Data Isolation (Two Tenants)
+
+This verifies that tenant A cannot see tenant B's data.
+
+1. **In browser 1** (or incognito): Connect with `tenant-a`
+2. **In browser 2** (or different incognito): Connect with `tenant-b`
+3. In browser 1, query a table that exists in tenant-a's index
+4. In browser 2, query the same table name
+
+**What to verify:**
+- [ ] Each browser sees only its own tenant's data
+- [ ] tenant-a cannot see tenant-b's rows and vice versa
+
+---
+
+## 2. Claude Desktop
+
+### 2.1 Add the Connector
+
+1. Open **Claude Desktop**
+2. Click your profile icon → **Settings**
+3. Go to **Integrations** (or **Connectors**)
+4. Click **Add custom integration**
+5. Enter URL: `https://mcp.dbtrail.com/mcp`
+6. Complete the OAuth flow (same as web — enter your tenant ID)
+
+> **Important:** Add the connector through the UI, NOT by editing `claude_desktop_config.json`. The JSON config method is the old `proxy.py` approach. The connector UI handles OAuth automatically.
+
+### 2.2 Verify Tools Work
+
+1. Open a new conversation
+2. Ask: **"What's in my binlog index?"**
+
+**What to verify:**
+- [ ] Tools are listed and callable
+- [ ] Results come back correctly
+
+### 2.3 Verify SSE Streaming
+
+1. Ask a query that returns many rows: **"Show me the last 50 events in table format"**
+
+**What to verify:**
+- [ ] Response appears incrementally (not all at once after a long wait)
+- [ ] If the response takes more than a few seconds, you should see partial text appearing
+- [ ] No timeout errors
+
+**If streaming appears buffered (all at once):**
+- This might be an ALB idle timeout issue. Check that the ALB has `idle_timeout.timeout_seconds=120`:
+  ```sh
+  aws elbv2 describe-load-balancer-attributes --load-balancer-arn YOUR_ALB_ARN \
+    | jq '.Attributes[] | select(.Key == "idle_timeout.timeout_seconds")'
+  ```
+
+---
+
+## 3. Claude Mobile (iOS/Android)
+
+### 3.1 Sync from Web
+
+Connectors added on claude.ai should sync to mobile automatically.
+
+1. Open the Claude app on your phone
+2. Go to **Settings** → check that the Bintrail connector appears
+
+**If it doesn't appear:**
+- Force-close and reopen the app
+- Make sure you're logged into the same account as the web version
+- Try pulling down to refresh on the settings page
+
+### 3.2 Verify Tools Work
+
+1. Open a new conversation on mobile
+2. Ask: **"Show me the status of my binlog index"**
+
+**What to verify:**
+- [ ] The `status` tool is called successfully
+- [ ] Results render correctly on the small screen
+
+---
+
+## 4. MCP Inspector
+
+The MCP Inspector is a developer tool that tests the raw MCP protocol without Claude.
+
+### 4.1 Run the Inspector
+
+```sh
+npx @modelcontextprotocol/inspector https://mcp.dbtrail.com/mcp
+```
+
+This opens a browser UI.
+
+### 4.2 Test the OAuth Flow
+
+1. The Inspector should detect the OAuth requirement and show a "Connect" button
+2. Click **Connect**
+3. Complete the OAuth flow (enter your tenant ID)
+4. You should see "Connected" status
+
+### 4.3 Test Protocol Messages
+
+Once connected, in the Inspector UI:
+
+**Test `initialize`:**
+1. This happens automatically on connect
+2. Verify the response shows `serverInfo` with the bintrail server name and version
+
+**Test `tools/list`:**
+1. Click **Tools** in the sidebar
+2. You should see three tools: `query`, `recover`, `status`
+
+**Test `tools/call`:**
+1. Click on the `status` tool
+2. Click **Call** (no parameters needed, unless your server requires `index_dsn`)
+3. Verify the response contains indexed files and partition info
+
+4. Click on the `query` tool
+5. Fill in parameters: `schema` = your schema, `table` = your table
+6. Click **Call**
+7. Verify results come back
+
+---
+
+## 5. Rate Limiting Verification
+
+The gateway now rate-limits OAuth endpoints to prevent abuse. Verify the limits work.
+
+### 5.1 Test `/oauth/register` Rate Limit
+
+Default: 10 requests/minute per IP.
+
+```sh
+# Send 11 register requests rapidly. The 11th should get 429.
+for i in $(seq 1 11); do
+  STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X POST https://mcp.dbtrail.com/oauth/register \
+    -H 'Content-Type: application/json' \
+    -d '{"client_name":"test-'$i'","redirect_uris":["http://localhost/cb"]}')
+  echo "Request $i: HTTP $STATUS"
+done
+```
+
+**Expected:** Requests 1–10 return `201`. Request 11 returns `429` with a `Retry-After` header.
+
+### 5.2 Test `/oauth/token` Rate Limit
+
+Default: 30 requests/minute per IP.
+
+```sh
+# Send 31 token requests. All will fail (bad grant), but only the 31st should be 429.
+for i in $(seq 1 31); do
+  STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X POST https://mcp.dbtrail.com/oauth/token \
+    -H 'Content-Type: application/x-www-form-urlencoded' \
+    -d 'grant_type=authorization_code&code=fake&client_id=fake&client_secret=fake&code_verifier=fake')
+  echo "Request $i: HTTP $STATUS"
+done
+```
+
+**Expected:** Requests 1–30 return `400` (bad grant). Request 31 returns `429`.
+
+### 5.3 Test `/oauth/authorize` POST Rate Limit
+
+Default: 20 requests/minute per IP.
+
+```sh
+for i in $(seq 1 21); do
+  STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X POST https://mcp.dbtrail.com/oauth/authorize \
+    -H 'Content-Type: application/x-www-form-urlencoded' \
+    -d 'client_id=fake&redirect_uri=http://localhost&code_challenge=test&tenant_id=fake')
+  echo "Request $i: HTTP $STATUS"
+done
+```
+
+**Expected:** Requests 1–20 return `400` or `401`. Request 21 returns `429`.
+
+### 5.4 Verify Normal Usage Isn't Affected
+
+After the rate limit window resets (wait 1 minute), verify that a normal OAuth flow still works:
+
+```sh
+# Should succeed (201)
+curl -X POST https://mcp.dbtrail.com/oauth/register \
+  -H 'Content-Type: application/json' \
+  -d '{"client_name":"normal-test","redirect_uris":["http://localhost/cb"]}'
+```
+
+---
+
+## 6. Request Logging & Correlation IDs
+
+The gateway now logs every request with a unique `X-Request-Id`.
+
+### 6.1 Verify Correlation IDs in Responses
+
+```sh
+curl -v https://mcp.dbtrail.com/health 2>&1 | grep -i x-request-id
+```
+
+**Expected:** Response includes `X-Request-Id: <uuid>` header.
+
+### 6.2 Verify Client-Provided IDs Are Preserved
+
+```sh
+curl -v -H 'X-Request-Id: my-custom-trace-123' \
+  https://mcp.dbtrail.com/health 2>&1 | grep -i x-request-id
+```
+
+**Expected:** Response header is `X-Request-Id: my-custom-trace-123` (preserved, not overwritten).
+
+### 6.3 Verify Structured Logs
+
+Check the gateway's log output (stderr, or wherever your log aggregator reads from):
+
+```sh
+# If running locally:
+./mcp-gateway --addr :8443 ... 2>&1 | jq 'select(.msg == "request")'
+```
+
+**Expected log fields:**
+```json
+{
+  "msg": "request",
+  "method": "GET",
+  "path": "/health",
+  "status": 200,
+  "duration_ms": 1,
+  "client_ip": "203.0.113.50",
+  "request_id": "abc123-..."
+}
+```
+
+---
+
+## 7. Security Review Checklist
+
+These are manual verification steps. Check each item and mark it off.
+
+### 7.1 Tokens Are Stored as SHA-256 Hashes
+
+```sh
+# Look at the raw DynamoDB tokens table. Values should be hex hashes, not raw tokens.
+aws dynamodb scan --table-name bintrail-oauth-tokens --limit 3 \
+  | jq '.Items[].access_token_hash.S'
+```
+
+**Expected:** 64-character hex strings like `"a1b2c3d4e5..."`  — NOT the raw Bearer token value.
+
+### 7.2 Authorization Codes Are Single-Use
+
+1. Register a test client:
+   ```sh
+   CLIENT=$(curl -s -X POST https://mcp.dbtrail.com/oauth/register \
+     -H 'Content-Type: application/json' \
+     -d '{"client_name":"security-test","redirect_uris":["http://localhost:9999/cb"]}')
+   CLIENT_ID=$(echo $CLIENT | jq -r .client_id)
+   CLIENT_SECRET=$(echo $CLIENT | jq -r .client_secret)
+   echo "client_id=$CLIENT_ID"
+   echo "client_secret=$CLIENT_SECRET"
+   ```
+
+2. Start the authorization flow manually:
+   ```sh
+   # Generate a PKCE verifier and challenge
+   VERIFIER=$(openssl rand -hex 32)
+   CHALLENGE=$(echo -n $VERIFIER | openssl dgst -sha256 -binary | openssl base64 -A | tr '+/' '-_' | tr -d '=')
+   echo "verifier=$VERIFIER"
+   echo "challenge=$CHALLENGE"
+
+   # Open this URL in a browser:
+   echo "https://mcp.dbtrail.com/oauth/authorize?client_id=$CLIENT_ID&redirect_uri=http://localhost:9999/cb&code_challenge=$CHALLENGE&code_challenge_method=S256&state=test123"
+   ```
+
+3. Submit the form with a valid tenant ID. The redirect will fail (localhost:9999 isn't running), but grab the `code` from the URL bar:
+   ```
+   http://localhost:9999/cb?code=THE_CODE_HERE&state=test123
+   ```
+
+4. Exchange the code for tokens:
+   ```sh
+   CODE="THE_CODE_HERE"
+   curl -X POST https://mcp.dbtrail.com/oauth/token \
+     -H 'Content-Type: application/x-www-form-urlencoded' \
+     -d "grant_type=authorization_code&code=$CODE&client_id=$CLIENT_ID&client_secret=$CLIENT_SECRET&code_verifier=$VERIFIER&redirect_uri=http://localhost:9999/cb"
+   ```
+   **Expected:** Returns access_token and refresh_token.
+
+5. Try to use the same code again:
+   ```sh
+   curl -X POST https://mcp.dbtrail.com/oauth/token \
+     -H 'Content-Type: application/x-www-form-urlencoded' \
+     -d "grant_type=authorization_code&code=$CODE&client_id=$CLIENT_ID&client_secret=$CLIENT_SECRET&code_verifier=$VERIFIER&redirect_uri=http://localhost:9999/cb"
+   ```
+   **Expected:** Returns `{"error":"invalid_grant","error_description":"invalid or expired authorization code"}`.
+
+### 7.3 Authorization Codes Expire After 10 Minutes
+
+1. Get a new authorization code (repeat steps 2–3 above with a new PKCE challenge)
+2. **Wait 11 minutes**
+3. Try to exchange the code
+
+**Expected:** Same `invalid_grant` error.
+
+### 7.4 PKCE S256 Is Enforced
+
+Try exchanging a code with a **wrong** verifier:
+
+```sh
+curl -X POST https://mcp.dbtrail.com/oauth/token \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -d "grant_type=authorization_code&code=$CODE&client_id=$CLIENT_ID&client_secret=$CLIENT_SECRET&code_verifier=wrong-verifier&redirect_uri=http://localhost:9999/cb"
+```
+
+**Expected:** `{"error":"invalid_grant","error_description":"PKCE verification failed"}`.
+
+### 7.5 Refresh Token Rotation (Old Tokens Invalidated)
+
+1. Get tokens from a successful code exchange (step 4 above)
+2. Save the `refresh_token` value
+3. Use the refresh token to get new tokens:
+   ```sh
+   REFRESH_TOKEN="the_refresh_token"
+   curl -X POST https://mcp.dbtrail.com/oauth/token \
+     -H 'Content-Type: application/x-www-form-urlencoded' \
+     -d "grant_type=refresh_token&refresh_token=$REFRESH_TOKEN&client_id=$CLIENT_ID&client_secret=$CLIENT_SECRET"
+   ```
+   **Expected:** Returns new access_token AND new refresh_token.
+
+4. Try to use the **old** refresh token again:
+   ```sh
+   curl -X POST https://mcp.dbtrail.com/oauth/token \
+     -H 'Content-Type: application/x-www-form-urlencoded' \
+     -d "grant_type=refresh_token&refresh_token=$REFRESH_TOKEN&client_id=$CLIENT_ID&client_secret=$CLIENT_SECRET"
+   ```
+   **Expected:** `{"error":"invalid_grant","error_description":"invalid or expired refresh token"}`.
+
+### 7.6 Origin Header Validation
+
+```sh
+# Allowed origin — should work (200 or 4xx from the endpoint, but not 403 from origin check)
+curl -H 'Origin: https://claude.ai' https://mcp.dbtrail.com/health
+
+# Disallowed origin — should get 403 Forbidden
+curl -s -o /dev/null -w "%{http_code}" \
+  -H 'Origin: https://evil-site.com' https://mcp.dbtrail.com/health
+```
+
+**Expected:** Second request returns `403`.
+
+### 7.7 CORS Headers Only Allow Claude Origins
+
+```sh
+curl -v -X OPTIONS https://mcp.dbtrail.com/mcp \
+  -H 'Origin: https://claude.ai' \
+  -H 'Access-Control-Request-Method: POST' 2>&1 | grep -i access-control
+```
+
+**Expected:** `Access-Control-Allow-Origin: https://claude.ai` (NOT `*`).
+
+```sh
+curl -v -X OPTIONS https://mcp.dbtrail.com/mcp \
+  -H 'Origin: https://random-site.com' \
+  -H 'Access-Control-Request-Method: POST' 2>&1 | grep -i access-control
+```
+
+**Expected:** No `Access-Control-Allow-Origin` header (origin not in allow list).
+
+---
+
+## 8. Monitoring Setup (AWS CloudWatch)
+
+These steps set up monitoring and alerting. They require AWS Console or CLI access.
+
+### 8.1 Enable ALB Access Logs
+
+```sh
+# Create an S3 bucket for ALB logs
+aws s3 mb s3://bintrail-alb-logs-YOUR_ACCOUNT_ID
+
+# Enable access logging on the ALB
+aws elbv2 modify-load-balancer-attributes \
+  --load-balancer-arn YOUR_ALB_ARN \
+  --attributes \
+    Key=access_logs.s3.enabled,Value=true \
+    Key=access_logs.s3.bucket,Value=bintrail-alb-logs-YOUR_ACCOUNT_ID \
+    Key=access_logs.s3.prefix,Value=mcp-gateway
+```
+
+> Note: The S3 bucket needs a specific bucket policy for ALB to write logs. See [AWS docs](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/enable-access-logging.html).
+
+### 8.2 Create CloudWatch Metric Filters
+
+If the gateway runs on ECS/EC2 with CloudWatch Logs agent, create metric filters on the log group:
+
+**Auth failures (401/403):**
+
+```sh
+aws logs put-metric-filter \
+  --log-group-name /ecs/mcp-gateway \
+  --filter-name AuthFailures \
+  --filter-pattern '{ $.status = 401 || $.status = 403 }' \
+  --metric-transformations \
+    metricName=AuthFailures,metricNamespace=Bintrail/Gateway,metricValue=1,defaultValue=0
+```
+
+**Proxy errors (502):**
+
+```sh
+aws logs put-metric-filter \
+  --log-group-name /ecs/mcp-gateway \
+  --filter-name ProxyErrors \
+  --filter-transformations \
+  --filter-pattern '{ $.status = 502 }' \
+  --metric-transformations \
+    metricName=ProxyErrors,metricNamespace=Bintrail/Gateway,metricValue=1,defaultValue=0
+```
+
+**Rate limit hits (429):**
+
+```sh
+aws logs put-metric-filter \
+  --log-group-name /ecs/mcp-gateway \
+  --filter-name RateLimitHits \
+  --filter-pattern '{ $.status = 429 }' \
+  --metric-transformations \
+    metricName=RateLimitHits,metricNamespace=Bintrail/Gateway,metricValue=1,defaultValue=0
+```
+
+**Request latency:**
+
+```sh
+aws logs put-metric-filter \
+  --log-group-name /ecs/mcp-gateway \
+  --filter-name RequestLatency \
+  --filter-pattern '{ $.msg = "request" }' \
+  --metric-transformations \
+    metricName=RequestLatencyMs,metricNamespace=Bintrail/Gateway,metricValue=$.duration_ms,defaultValue=0
+```
+
+### 8.3 Create CloudWatch Alarms
+
+**Alarm: High auth failure rate (potential token leak)**
+
+```sh
+aws cloudwatch put-metric-alarm \
+  --alarm-name mcp-gateway-auth-failures \
+  --alarm-description "High rate of 401/403 responses — possible token leak or brute force" \
+  --namespace Bintrail/Gateway \
+  --metric-name AuthFailures \
+  --statistic Sum \
+  --period 300 \
+  --evaluation-periods 1 \
+  --threshold 50 \
+  --comparison-operator GreaterThanThreshold \
+  --alarm-actions YOUR_SNS_TOPIC_ARN \
+  --treat-missing-data notBreaching
+```
+
+**Alarm: High proxy error rate (backend issues)**
+
+```sh
+aws cloudwatch put-metric-alarm \
+  --alarm-name mcp-gateway-proxy-errors \
+  --alarm-description "High rate of 502 responses — backend may be down" \
+  --namespace Bintrail/Gateway \
+  --metric-name ProxyErrors \
+  --statistic Sum \
+  --period 300 \
+  --evaluation-periods 1 \
+  --threshold 10 \
+  --comparison-operator GreaterThanThreshold \
+  --alarm-actions YOUR_SNS_TOPIC_ARN \
+  --treat-missing-data notBreaching
+```
+
+**Alarm: High rate limit hits (potential abuse)**
+
+```sh
+aws cloudwatch put-metric-alarm \
+  --alarm-name mcp-gateway-rate-limits \
+  --alarm-description "High rate of 429 responses — possible abuse" \
+  --namespace Bintrail/Gateway \
+  --metric-name RateLimitHits \
+  --statistic Sum \
+  --period 300 \
+  --evaluation-periods 2 \
+  --threshold 100 \
+  --comparison-operator GreaterThanThreshold \
+  --alarm-actions YOUR_SNS_TOPIC_ARN \
+  --treat-missing-data notBreaching
+```
+
+### 8.4 Create an SNS Topic for Alerts
+
+If you don't have one yet:
+
+```sh
+# Create the topic
+aws sns create-topic --name bintrail-gateway-alerts
+# → returns TopicArn — use this in the alarm-actions above
+
+# Subscribe your email
+aws sns subscribe \
+  --topic-arn YOUR_SNS_TOPIC_ARN \
+  --protocol email \
+  --notification-endpoint you@example.com
+
+# Confirm the subscription by clicking the link in the email
+```
+
+### 8.5 Verify Monitoring Works
+
+1. Trigger a few auth failures:
+   ```sh
+   for i in $(seq 1 5); do
+     curl -s https://mcp.dbtrail.com/mcp -H 'Authorization: Bearer invalid-token'
+   done
+   ```
+
+2. Check CloudWatch metrics (allow 5 minutes for data to appear):
+   ```sh
+   aws cloudwatch get-metric-statistics \
+     --namespace Bintrail/Gateway \
+     --metric-name AuthFailures \
+     --start-time $(date -u -v-10M +%Y-%m-%dT%H:%M:%S) \
+     --end-time $(date -u +%Y-%m-%dT%H:%M:%S) \
+     --period 300 \
+     --statistics Sum
+   ```
+
+---
+
+## 9. Documentation Checklist
+
+Verify the docs are complete and accurate:
+
+- [ ] `docs/mcp-server.md` documents both the connector method (recommended) and the proxy method (legacy fallback)
+- [ ] `docs/mcp-gateway.md` has complete deployment instructions
+- [ ] `README.md` mentions the Claude Connector in the MCP Server section
+- [ ] `proxy.py` docstring/comments mention it's an optional legacy fallback
+
+---
+
+## Summary: All Checks
+
+### Integration Testing
+- [ ] Claude.ai: Add connector → OAuth flow → query/recover/status tools work
+- [ ] Claude.ai: Token refresh (wait >1 hour, query again)
+- [ ] Claude.ai: Two-tenant data isolation
+- [ ] Claude Desktop: Add connector via UI → tools work → SSE streaming works
+- [ ] Claude Mobile: Connector syncs from web → tools work
+- [ ] MCP Inspector: Full protocol works (initialize → tools/list → tools/call)
+
+### Rate Limiting
+- [ ] `/oauth/register` — 429 after 10 requests/min
+- [ ] `/oauth/token` — 429 after 30 requests/min
+- [ ] `POST /oauth/authorize` — 429 after 20 requests/min
+- [ ] Normal usage unaffected after window resets
+
+### Monitoring
+- [ ] CloudWatch metric filters created (auth failures, proxy errors, rate limits, latency)
+- [ ] CloudWatch alarms created with SNS notifications
+- [ ] Request logs include correlation IDs (`request_id` field)
+- [ ] `X-Request-Id` header present in all responses
+
+### Security
+- [ ] Tokens stored as SHA-256 hashes (not plaintext)
+- [ ] Authorization codes are single-use
+- [ ] Authorization codes expire after 10 minutes
+- [ ] PKCE S256 enforced on all code exchanges
+- [ ] Refresh token rotation (old tokens invalidated)
+- [ ] Origin header validation blocks unknown origins
+- [ ] CORS headers only allow `claude.ai` and `claude.com`

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -139,7 +139,28 @@ go newServer().Connect(ctx, t1, nil)
 
 ---
 
-## Two Transport Modes
+## Three Ways to Connect Claude
+
+| Method | Works from | Auth | Setup |
+|---|---|---|---|
+| **Claude Connector** (recommended) | claude.ai, Claude Desktop, Claude mobile | OAuth 2.1 (automatic) | Add URL in Claude Settings |
+| **stdio** | Claude Code (local) | None (trusts local user) | `.mcp.json` at project root |
+| **proxy.py** (legacy) | Claude Desktop only | None (trusts local user) | Edit `claude_desktop_config.json` |
+
+### Claude Connector (recommended — for claude.ai, Desktop, and mobile)
+
+The easiest way to connect Claude to bintrail. Requires the [MCP Gateway](./mcp-gateway.md) running at a public URL.
+
+1. Open **claude.ai** → **Settings** → **Integrations**
+2. Click **Add custom integration**
+3. Enter the gateway URL: `https://mcp.dbtrail.com/mcp`
+4. Claude auto-discovers the OAuth endpoints, opens the login page
+5. Enter your **tenant ID** and click **Authorize**
+6. Done — `query`, `recover`, and `status` tools are now available
+
+This works from the Claude web app, Claude Desktop, and Claude mobile. Token refresh happens automatically — sessions survive indefinitely without re-authenticating.
+
+For setup and deployment of the gateway itself, see [MCP Gateway docs](./mcp-gateway.md). For a comprehensive integration testing checklist, see [Connector Testing](./connector-testing.md).
 
 ### stdio (default — for Claude Code)
 
@@ -187,9 +208,11 @@ This is useful when Claude Desktop runs on your laptop but the bintrail server r
 
 ---
 
-## `proxy.py`: Bridging Claude Desktop to Remote HTTP
+## `proxy.py`: Legacy Bridge for Claude Desktop
 
-Claude Desktop only supports MCP servers via stdio (a subprocess it starts locally). To connect Claude Desktop to a remote `bintrail-mcp --http` server, `cmd/bintrail-mcp/proxy.py` acts as a bridge:
+> **Note:** For new setups, use the [Claude Connector](#claude-connector-recommended--for-claudeai-desktop-and-mobile) method instead — it's simpler, works from more clients, and supports OAuth. `proxy.py` is still available as a fallback for environments that can't use the gateway.
+
+`proxy.py` bridges Claude Desktop (which speaks stdio) to a remote `bintrail-mcp --http` server:
 
 ```
 Claude Desktop  →  proxy.py (stdio, runs locally)  →  bintrail-mcp --http :8080  →  MySQL


### PR DESCRIPTION
closes #128

## Summary
- **Rate limiting middleware** for OAuth endpoints (`/oauth/register` 10/min, `/oauth/token` 30/min, `POST /oauth/authorize` 20/min) — per-IP fixed-window counters with configurable `--rate-limit-*` flags and automatic cleanup
- **Request logging middleware** with UUID correlation IDs (`X-Request-Id` header) and structured slog output (method, path, status, duration, client IP, request ID)
- **Comprehensive integration testing guide** (`docs/connector-testing.md`) — step-by-step instructions for manually testing Claude.ai, Claude Desktop, Claude Mobile, MCP Inspector, rate limiting, security review, and CloudWatch monitoring setup
- **Updated docs** — `docs/mcp-server.md` now documents the Claude Connector method alongside legacy proxy.py; `README.md` has connector setup blurb

## New files
| File | Purpose |
|---|---|
| `cmd/mcp-gateway/ratelimit.go` | Per-IP rate limiting middleware |
| `cmd/mcp-gateway/ratelimit_test.go` | Tests (6 tests) |
| `cmd/mcp-gateway/logging.go` | Request ID + structured logging middleware |
| `cmd/mcp-gateway/logging_test.go` | Tests (4 tests) |
| `docs/connector-testing.md` | Full manual testing & hardening checklist |

## Test plan
- [x] Unit tests pass (`go test ./... -count=1` — all 18 packages pass)
- [ ] Follow `docs/connector-testing.md` sections 1–9 manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)