### PR TITLE
fix: add missing Archives section to MCP status tool

### DIFF
--- a/cmd/bintrail-mcp/main.go
+++ b/cmd/bintrail-mcp/main.go
@@ -377,39 +377,13 @@ func makeStatusTool(resolve resolveFunc) func(context.Context, *mcp.CallToolRequ
 		}
 		defer db.Close()
 
-		files, err := status.LoadIndexState(ctx, db)
+		data, err := status.CollectStatus(ctx, db, dbName)
 		if err != nil {
-			return errorResult(fmt.Errorf("failed to load index state: %w", err)), nil, nil
-		}
-
-		parts, err := status.LoadPartitionStats(ctx, db, dbName)
-		if err != nil {
-			return errorResult(fmt.Errorf("failed to load partition info: %w", err)), nil, nil
-		}
-
-		// Best-effort: servers info from bintrail_servers table.
-		servers, serversErr := status.LoadServers(ctx, db)
-		if serversErr != nil {
-			slog.Warn("could not load servers", "error", serversErr)
-			servers = nil
-		}
-
-		// Best-effort: stream state from stream_state table.
-		stream, streamErr := status.LoadStreamState(ctx, db)
-		if streamErr != nil {
-			slog.Warn("could not load stream state", "error", streamErr)
-			stream = nil
-		}
-
-		// Best-effort: coverage info from schema_changes table.
-		coverage, coverageErr := status.LoadCoverage(ctx, db)
-		if coverageErr != nil {
-			slog.Warn("could not load coverage info", "error", coverageErr)
-			coverage = nil
+			return errorResult(err), nil, nil
 		}
 
 		var buf bytes.Buffer
-		status.WriteStatus(&buf, files, parts, nil, coverage, servers, stream)
+		data.Write(&buf)
 
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{

--- a/cmd/bintrail/status.go
+++ b/cmd/bintrail/status.go
@@ -68,73 +68,16 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	defer db.Close()
 	slog.Debug("connected", "duration_ms", time.Since(t).Milliseconds())
 
-	ctx := cmd.Context()
-
-	slog.Debug("loading index state")
-	t = time.Now()
-	files, err := status.LoadIndexState(ctx, db)
+	data, err := status.CollectStatus(cmd.Context(), db, dbName)
 	if err != nil {
-		return fmt.Errorf("failed to load index state: %w", err)
-	}
-	slog.Debug("loaded index state", "files", len(files), "duration_ms", time.Since(t).Milliseconds())
-
-	slog.Debug("loading partition stats", "database", dbName)
-	t = time.Now()
-	partStats, err := status.LoadPartitionStats(ctx, db, dbName)
-	if err != nil {
-		return fmt.Errorf("failed to load partition info: %w", err)
-	}
-	slog.Debug("loaded partition stats", "partitions", len(partStats), "duration_ms", time.Since(t).Milliseconds())
-
-	// Best-effort: bintrail_servers may not exist in older index databases.
-	slog.Debug("loading servers")
-	t = time.Now()
-	servers, err := status.LoadServers(ctx, db)
-	if err != nil {
-		slog.Warn("could not load servers", "error", err)
-		servers = nil
-	} else {
-		slog.Debug("loaded servers", "count", len(servers), "duration_ms", time.Since(t).Milliseconds())
-	}
-
-	// Best-effort: stream_state may not exist in older index databases.
-	slog.Debug("loading stream state")
-	t = time.Now()
-	stream, err := status.LoadStreamState(ctx, db)
-	if err != nil {
-		slog.Warn("could not load stream state", "error", err)
-		stream = nil
-	} else if stream != nil {
-		slog.Debug("loaded stream state", "mode", stream.Mode, "events", stream.EventsIndexed, "duration_ms", time.Since(t).Milliseconds())
-	}
-
-	// Best-effort: archive_state may not exist in older index databases.
-	slog.Debug("loading archive stats")
-	t = time.Now()
-	archives, err := status.LoadArchiveStats(ctx, db)
-	if err != nil {
-		slog.Warn("could not load archive stats", "error", err)
-		archives = nil
-	} else {
-		slog.Debug("loaded archive stats", "files", archives.TotalFiles, "duration_ms", time.Since(t).Milliseconds())
-	}
-
-	// Best-effort: schema_changes may not exist in older index databases.
-	slog.Debug("loading coverage info")
-	t = time.Now()
-	coverage, err := status.LoadCoverage(ctx, db)
-	if err != nil {
-		slog.Warn("could not load coverage info", "error", err)
-		coverage = nil
-	} else {
-		slog.Debug("loaded coverage info", "events", coverage.TotalEvents, "schema_changes", coverage.SchemaChanges, "duration_ms", time.Since(t).Milliseconds())
+		return err
 	}
 
 	slog.Info("status complete", "duration_ms", time.Since(start).Milliseconds())
 
 	if stFormat == "json" {
-		return status.WriteStatusJSON(os.Stdout, files, partStats, archives, coverage, servers, stream)
+		return data.WriteJSON(os.Stdout)
 	}
-	status.WriteStatus(os.Stdout, files, partStats, archives, coverage, servers, stream)
+	data.Write(os.Stdout)
 	return nil
 }

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"strconv"
 	"strings"
 	"text/tabwriter"
@@ -279,6 +280,70 @@ func LoadStreamState(ctx context.Context, db *sql.DB) (*StreamStateInfo, error) 
 		return nil, err
 	}
 	return &s, nil
+}
+
+// StatusData holds all data sections loaded by CollectStatus.
+type StatusData struct {
+	Files    []IndexStateRow
+	Parts    []PartitionStat
+	Archives *ArchiveStats
+	Coverage *CoverageInfo
+	Servers  []ServerInfo
+	Stream   *StreamStateInfo
+}
+
+// CollectStatus loads all status data from the index database.
+// IndexState and PartitionStats are required (errors are returned).
+// Servers, StreamState, ArchiveStats, and Coverage are best-effort
+// (failures are logged as warnings and the field is left nil).
+func CollectStatus(ctx context.Context, db *sql.DB, dbName string) (*StatusData, error) {
+	files, err := LoadIndexState(ctx, db)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load index state: %w", err)
+	}
+
+	parts, err := LoadPartitionStats(ctx, db, dbName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load partition info: %w", err)
+	}
+
+	d := &StatusData{Files: files, Parts: parts}
+
+	if servers, err := LoadServers(ctx, db); err != nil {
+		slog.Warn("could not load servers", "error", err)
+	} else {
+		d.Servers = servers
+	}
+
+	if stream, err := LoadStreamState(ctx, db); err != nil {
+		slog.Warn("could not load stream state", "error", err)
+	} else {
+		d.Stream = stream
+	}
+
+	if archives, err := LoadArchiveStats(ctx, db); err != nil {
+		slog.Warn("could not load archive stats", "error", err)
+	} else {
+		d.Archives = archives
+	}
+
+	if coverage, err := LoadCoverage(ctx, db); err != nil {
+		slog.Warn("could not load coverage info", "error", err)
+	} else {
+		d.Coverage = coverage
+	}
+
+	return d, nil
+}
+
+// Write writes the status data as a human-readable report to w.
+func (d *StatusData) Write(w io.Writer) {
+	WriteStatus(w, d.Files, d.Parts, d.Archives, d.Coverage, d.Servers, d.Stream)
+}
+
+// WriteJSON writes the status data as JSON to w.
+func (d *StatusData) WriteJSON(w io.Writer) error {
+	return WriteStatusJSON(w, d.Files, d.Parts, d.Archives, d.Coverage, d.Servers, d.Stream)
 }
 
 // WriteStatus writes a multi-section status report (Servers, Stream, Indexed Files, Partitions, Archives, Coverage, Summary) to w.

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -901,3 +901,74 @@ func TestWriteStatusJSON_nilStream_omitsKey(t *testing.T) {
 		t.Error("expected no 'stream' key when stream is nil")
 	}
 }
+
+// ─── StatusData equivalence tests ───────────────────────────────────────────
+
+func TestStatusData_Write_equivalence(t *testing.T) {
+	ts := time.Date(2026, 2, 19, 14, 0, 0, 0, time.UTC)
+	files := []IndexStateRow{{
+		BinlogFile: "binlog.000042", Status: "completed", EventsIndexed: 1234,
+		FileSize: 1048576, LastPosition: 1048576, StartedAt: ts,
+		CompletedAt: sql.NullTime{Valid: true, Time: ts.Add(5 * time.Minute)},
+		BintrailID:  sql.NullString{Valid: true, String: "test-uuid"},
+	}}
+	parts := []PartitionStat{{
+		Name: "p_2026021914", Description: strconv.FormatInt(int64(62167219200)+ts.Add(time.Hour).Unix(), 10),
+		TableRows: 5000, Ordinal: 1,
+	}}
+	archives := &ArchiveStats{TotalFiles: 10, TotalRows: 5000, TotalSizeBytes: 1048576, LocalFiles: 10, S3Files: 3, S3Buckets: []string{"bucket-a"}}
+	coverage := &CoverageInfo{
+		EarliestEvent: sql.NullTime{Valid: true, Time: ts},
+		LatestEvent:   sql.NullTime{Valid: true, Time: ts.Add(24 * time.Hour)},
+		TotalEvents:   42000, SchemaChanges: 2,
+	}
+	servers := []ServerInfo{{
+		BintrailID: "aaaaaaaa-0000-0000-0000-000000000001", ServerUUID: "11111111-1111-1111-1111-111111111111",
+		Host: "db-primary", Port: 3306, Username: "repl", CreatedAt: ts,
+	}}
+	stream := &StreamStateInfo{
+		Mode: "gtid", BinlogFile: "binlog.000005", BinlogPosition: 12345,
+		GTIDSet: sql.NullString{Valid: true, String: "aaa-bbb:1-100"},
+		EventsIndexed: 267354, LastCheckpoint: ts, ServerID: 42,
+	}
+
+	// Direct call
+	var want bytes.Buffer
+	WriteStatus(&want, files, parts, archives, coverage, servers, stream)
+
+	// Via StatusData
+	data := &StatusData{Files: files, Parts: parts, Archives: archives, Coverage: coverage, Servers: servers, Stream: stream}
+	var got bytes.Buffer
+	data.Write(&got)
+
+	if got.String() != want.String() {
+		t.Errorf("StatusData.Write output differs from WriteStatus:\ngot:\n%s\nwant:\n%s", got.String(), want.String())
+	}
+}
+
+func TestStatusData_WriteJSON_equivalence(t *testing.T) {
+	ts := time.Date(2026, 2, 19, 14, 0, 0, 0, time.UTC)
+	files := []IndexStateRow{{
+		BinlogFile: "binlog.000042", Status: "completed", EventsIndexed: 1234,
+		FileSize: 1048576, LastPosition: 1048576, StartedAt: ts,
+	}}
+	parts := []PartitionStat{{Name: "p_future", Description: "MAXVALUE", TableRows: 0, Ordinal: 1}}
+	archives := &ArchiveStats{TotalFiles: 5, TotalRows: 1000, TotalSizeBytes: 5242880, LocalFiles: 5}
+
+	// Direct call
+	var want bytes.Buffer
+	if err := WriteStatusJSON(&want, files, parts, archives, nil, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// Via StatusData
+	data := &StatusData{Files: files, Parts: parts, Archives: archives}
+	var got bytes.Buffer
+	if err := data.WriteJSON(&got); err != nil {
+		t.Fatal(err)
+	}
+
+	if got.String() != want.String() {
+		t.Errorf("StatusData.WriteJSON output differs from WriteStatusJSON:\ngot:\n%s\nwant:\n%s", got.String(), want.String())
+	}
+}


### PR DESCRIPTION
## Summary

- **Fix**: MCP `status` tool was passing `nil` for archives to `WriteStatus`, so the Archives section never appeared in output
- **Refactor**: Extract shared `CollectStatus` function in `internal/status` to consolidate duplicated data-loading logic between CLI (`cmd/bintrail/status.go`) and MCP (`cmd/bintrail-mcp/main.go`), preventing future divergence
- **Tests**: Add equivalence tests verifying `StatusData.Write`/`WriteJSON` produce identical output to calling `WriteStatus`/`WriteStatusJSON` directly

## Test plan

- [x] `go build ./cmd/bintrail/ ./cmd/bintrail-mcp/`
- [x] `go test ./internal/status/ ./cmd/bintrail/ ./cmd/bintrail-mcp/ -count=1`
- [ ] Rebuild on EC2, restart both binaries, call MCP `status` tool — Archives section should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)