### PR TITLE
fix: include archive data in status restore coverage

### DIFF
--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -91,6 +91,10 @@ type CoverageInfo struct {
 	TotalEvents       int64
 	SchemaChanges     int
 	UncoveredDDLs     int // DDLs without a snapshot (file mode, or failed auto-snapshot in stream mode)
+
+	// Archive-derived fields (from archive_state partition names and row counts).
+	ArchiveEarliestHour sql.NullTime // earliest hour derived from MIN(partition_name)
+	ArchiveTotalRows    int64
 }
 
 // TSFmt is the timestamp format used in status output.
@@ -184,7 +188,10 @@ func LoadArchiveStats(ctx context.Context, db *sql.DB) (*ArchiveStats, error) {
 	return &a, nil
 }
 
-// LoadCoverage loads restore coverage info from binlog_events and schema_changes.
+// LoadCoverage loads restore coverage info from binlog_events, schema_changes,
+// and archive_state. Archive coverage is derived from partition names stored in
+// archive_state (e.g. "p_2026021914" → 2026-02-19 14:00 UTC) without reading
+// Parquet files.
 func LoadCoverage(ctx context.Context, db *sql.DB) (*CoverageInfo, error) {
 	var c CoverageInfo
 	err := db.QueryRowContext(ctx, `
@@ -207,7 +214,36 @@ func LoadCoverage(ctx context.Context, db *sql.DB) (*CoverageInfo, error) {
 		return nil, fmt.Errorf("query uncovered DDLs: %w", err)
 	}
 
+	// Extend coverage with archived partition data.
+	var minPartition sql.NullString
+	err = db.QueryRowContext(ctx, `
+		SELECT MIN(partition_name), COALESCE(SUM(row_count), 0)
+		FROM archive_state`).Scan(&minPartition, &c.ArchiveTotalRows)
+	if err != nil {
+		// archive_state may not exist in older indexes — treat as non-fatal.
+		slog.Warn("could not load archive coverage", "error", err)
+		return &c, nil
+	}
+	if minPartition.Valid {
+		if t, ok := parsePartitionName(minPartition.String); ok {
+			c.ArchiveEarliestHour = sql.NullTime{Time: t, Valid: true}
+		}
+	}
+
 	return &c, nil
+}
+
+// parsePartitionName converts a partition name like "p_2026021914" to the
+// corresponding UTC hour. Returns false for "p_future" or malformed names.
+func parsePartitionName(name string) (time.Time, bool) {
+	if len(name) != 12 || !strings.HasPrefix(name, "p_") {
+		return time.Time{}, false
+	}
+	t, err := time.ParseInLocation("p_2006010215", name, time.UTC)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
 }
 
 // LoadSchemaChanges loads all schema changes ordered by detection time.
@@ -459,8 +495,19 @@ func WriteStatus(w io.Writer, files []IndexStateRow, parts []PartitionStat, arch
 	if coverage != nil {
 		fmt.Fprintln(w)
 		fmt.Fprintln(w, "=== Restore Coverage ===")
-		if coverage.EarliestEvent.Valid {
-			fmt.Fprintf(w, "  Earliest event: %s\n", coverage.EarliestEvent.Time.Format(TSFmt))
+
+		// Determine the effective earliest event: archive may extend further back.
+		earliest := coverage.EarliestEvent
+		hasArchive := coverage.ArchiveEarliestHour.Valid
+		if hasArchive && (!earliest.Valid || coverage.ArchiveEarliestHour.Time.Before(earliest.Time)) {
+			earliest = coverage.ArchiveEarliestHour
+		}
+		if earliest.Valid {
+			label := earliest.Time.Format(TSFmt)
+			if hasArchive {
+				label += " (includes archives)"
+			}
+			fmt.Fprintf(w, "  Earliest event: %s\n", label)
 		} else {
 			fmt.Fprintln(w, "  Earliest event: (none)")
 		}
@@ -469,7 +516,14 @@ func WriteStatus(w io.Writer, files []IndexStateRow, parts []PartitionStat, arch
 		} else {
 			fmt.Fprintln(w, "  Latest event:   (none)")
 		}
-		fmt.Fprintf(w, "  Total events:   %d\n", coverage.TotalEvents)
+
+		totalEvents := coverage.TotalEvents + coverage.ArchiveTotalRows
+		if coverage.ArchiveTotalRows > 0 {
+			fmt.Fprintf(w, "  Total events:   %d (%d live + %d archived)\n",
+				totalEvents, coverage.TotalEvents, coverage.ArchiveTotalRows)
+		} else {
+			fmt.Fprintf(w, "  Total events:   %d\n", totalEvents)
+		}
 		fmt.Fprintf(w, "  Schema changes: %d\n", coverage.SchemaChanges)
 		if coverage.UncoveredDDLs > 0 {
 			fmt.Fprintf(w, "  Warning: %d DDL(s) detected without auto-snapshot (file mode) — recovery across these DDLs may require manual snapshot\n",
@@ -583,11 +637,14 @@ func WriteStatusJSON(w io.Writer, files []IndexStateRow, parts []PartitionStat, 
 		S3Buckets      []string `json:"s3_buckets"`
 	}
 	type jsonCoverage struct {
-		EarliestEvent *string `json:"earliest_event"`
-		LatestEvent   *string `json:"latest_event"`
-		TotalEvents   int64   `json:"total_events"`
-		SchemaChanges int     `json:"schema_changes"`
-		UncoveredDDLs int     `json:"uncovered_ddls"`
+		EarliestEvent        *string `json:"earliest_event"`
+		LatestEvent          *string `json:"latest_event"`
+		TotalEvents          int64   `json:"total_events"`
+		LiveEvents           int64   `json:"live_events"`
+		ArchivedEvents       int64   `json:"archived_events"`
+		ArchiveEarliestEvent *string `json:"archive_earliest_event,omitempty"`
+		SchemaChanges        int     `json:"schema_changes"`
+		UncoveredDDLs        int     `json:"uncovered_ddls"`
 	}
 	type jsonServer struct {
 		BintrailID       string  `json:"bintrail_id"`
@@ -704,17 +761,30 @@ func WriteStatusJSON(w io.Writer, files []IndexStateRow, parts []PartitionStat, 
 	}
 	if coverage != nil {
 		jc := &jsonCoverage{
-			TotalEvents:   coverage.TotalEvents,
-			SchemaChanges: coverage.SchemaChanges,
-			UncoveredDDLs: coverage.UncoveredDDLs,
+			TotalEvents:    coverage.TotalEvents + coverage.ArchiveTotalRows,
+			LiveEvents:     coverage.TotalEvents,
+			ArchivedEvents: coverage.ArchiveTotalRows,
+			SchemaChanges:  coverage.SchemaChanges,
+			UncoveredDDLs:  coverage.UncoveredDDLs,
 		}
-		if coverage.EarliestEvent.Valid {
-			s := coverage.EarliestEvent.Time.Format(TSFmt)
+
+		// Effective earliest: archive may extend further back than live data.
+		earliest := coverage.EarliestEvent
+		if coverage.ArchiveEarliestHour.Valid &&
+			(!earliest.Valid || coverage.ArchiveEarliestHour.Time.Before(earliest.Time)) {
+			earliest = coverage.ArchiveEarliestHour
+		}
+		if earliest.Valid {
+			s := earliest.Time.Format(TSFmt)
 			jc.EarliestEvent = &s
 		}
 		if coverage.LatestEvent.Valid {
 			s := coverage.LatestEvent.Time.Format(TSFmt)
 			jc.LatestEvent = &s
+		}
+		if coverage.ArchiveEarliestHour.Valid {
+			s := coverage.ArchiveEarliestHour.Time.Format(TSFmt)
+			jc.ArchiveEarliestEvent = &s
 		}
 		out.Coverage = jc
 	}

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -620,11 +620,13 @@ func TestWriteStatusJSON_withCoverage(t *testing.T) {
 
 	var result struct {
 		Coverage *struct {
-			EarliestEvent string `json:"earliest_event"`
-			LatestEvent   string `json:"latest_event"`
-			TotalEvents   int64  `json:"total_events"`
-			SchemaChanges int    `json:"schema_changes"`
-			UncoveredDDLs int    `json:"uncovered_ddls"`
+			EarliestEvent  string `json:"earliest_event"`
+			LatestEvent    string `json:"latest_event"`
+			TotalEvents    int64  `json:"total_events"`
+			LiveEvents     int64  `json:"live_events"`
+			ArchivedEvents int64  `json:"archived_events"`
+			SchemaChanges  int    `json:"schema_changes"`
+			UncoveredDDLs  int    `json:"uncovered_ddls"`
 		} `json:"coverage"`
 	}
 	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
@@ -635,6 +637,12 @@ func TestWriteStatusJSON_withCoverage(t *testing.T) {
 	}
 	if result.Coverage.TotalEvents != 42000 {
 		t.Errorf("wrong total_events: %d", result.Coverage.TotalEvents)
+	}
+	if result.Coverage.LiveEvents != 42000 {
+		t.Errorf("wrong live_events: %d", result.Coverage.LiveEvents)
+	}
+	if result.Coverage.ArchivedEvents != 0 {
+		t.Errorf("wrong archived_events: %d", result.Coverage.ArchivedEvents)
 	}
 	if result.Coverage.SchemaChanges != 3 {
 		t.Errorf("wrong schema_changes: %d", result.Coverage.SchemaChanges)
@@ -656,6 +664,149 @@ func TestWriteStatusJSON_nilCoverage_omitsKey(t *testing.T) {
 	}
 	if _, ok := raw["coverage"]; ok {
 		t.Error("expected no 'coverage' key when coverage is nil")
+	}
+}
+
+// ─── parsePartitionName ─────────────────────────────────────────────────────
+
+func TestParsePartitionName_valid(t *testing.T) {
+	got, ok := parsePartitionName("p_2026030114")
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	want := time.Date(2026, 3, 1, 14, 0, 0, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestParsePartitionName_future(t *testing.T) {
+	_, ok := parsePartitionName("p_future")
+	if ok {
+		t.Error("expected false for p_future")
+	}
+}
+
+func TestParsePartitionName_malformed(t *testing.T) {
+	for _, name := range []string{"", "p_abc", "p_20260301", "notapartition"} {
+		if _, ok := parsePartitionName(name); ok {
+			t.Errorf("expected false for %q", name)
+		}
+	}
+}
+
+// ─── WriteStatus: coverage with archives ────────────────────────────────────
+
+func TestWriteStatus_coverageWithArchives(t *testing.T) {
+	// Live data starts at March 4, but archives go back to March 1.
+	coverage := &CoverageInfo{
+		EarliestEvent:       sql.NullTime{Valid: true, Time: time.Date(2026, 3, 4, 2, 0, 0, 0, time.UTC)},
+		LatestEvent:         sql.NullTime{Valid: true, Time: time.Date(2026, 3, 4, 10, 51, 50, 0, time.UTC)},
+		TotalEvents:         10000,
+		ArchiveEarliestHour: sql.NullTime{Valid: true, Time: time.Date(2026, 3, 1, 14, 0, 0, 0, time.UTC)},
+		ArchiveTotalRows:    5000,
+	}
+
+	var buf bytes.Buffer
+	WriteStatus(&buf, nil, nil, nil, coverage, nil, nil)
+	out := buf.String()
+
+	// Earliest should show the archive time, not the live time.
+	assertContains(t, out, "2026-03-01 14:00:00")
+	assertContains(t, out, "includes archives")
+	// Total should be live + archived.
+	assertContains(t, out, "15000")
+	assertContains(t, out, "10000 live")
+	assertContains(t, out, "5000 archived")
+}
+
+func TestWriteStatus_coverageArchiveOnly(t *testing.T) {
+	// No live events, only archives.
+	coverage := &CoverageInfo{
+		EarliestEvent:       sql.NullTime{Valid: false},
+		LatestEvent:         sql.NullTime{Valid: false},
+		TotalEvents:         0,
+		ArchiveEarliestHour: sql.NullTime{Valid: true, Time: time.Date(2026, 2, 28, 10, 0, 0, 0, time.UTC)},
+		ArchiveTotalRows:    3000,
+	}
+
+	var buf bytes.Buffer
+	WriteStatus(&buf, nil, nil, nil, coverage, nil, nil)
+	out := buf.String()
+
+	assertContains(t, out, "2026-02-28 10:00:00")
+	assertContains(t, out, "includes archives")
+	assertContains(t, out, "3000")
+}
+
+func TestWriteStatus_coverageNoArchives(t *testing.T) {
+	// No archives — should display without the "includes archives" label.
+	coverage := &CoverageInfo{
+		EarliestEvent: sql.NullTime{Valid: true, Time: time.Date(2026, 3, 4, 2, 0, 0, 0, time.UTC)},
+		LatestEvent:   sql.NullTime{Valid: true, Time: time.Date(2026, 3, 4, 10, 0, 0, 0, time.UTC)},
+		TotalEvents:   8000,
+	}
+
+	var buf bytes.Buffer
+	WriteStatus(&buf, nil, nil, nil, coverage, nil, nil)
+	out := buf.String()
+
+	assertContains(t, out, "2026-03-04 02:00:00")
+	if strings.Contains(out, "includes archives") {
+		t.Error("should not say 'includes archives' when no archive data")
+	}
+	if strings.Contains(out, "live") {
+		t.Error("should not show live/archived breakdown when no archives")
+	}
+}
+
+// ─── WriteStatusJSON: coverage with archives ────────────────────────────────
+
+func TestWriteStatusJSON_coverageWithArchives(t *testing.T) {
+	coverage := &CoverageInfo{
+		EarliestEvent:       sql.NullTime{Valid: true, Time: time.Date(2026, 3, 4, 2, 0, 0, 0, time.UTC)},
+		LatestEvent:         sql.NullTime{Valid: true, Time: time.Date(2026, 3, 4, 10, 51, 50, 0, time.UTC)},
+		TotalEvents:         10000,
+		ArchiveEarliestHour: sql.NullTime{Valid: true, Time: time.Date(2026, 3, 1, 14, 0, 0, 0, time.UTC)},
+		ArchiveTotalRows:    5000,
+	}
+
+	var buf bytes.Buffer
+	if err := WriteStatusJSON(&buf, nil, nil, nil, coverage, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	var result struct {
+		Coverage *struct {
+			EarliestEvent        string  `json:"earliest_event"`
+			LatestEvent          string  `json:"latest_event"`
+			TotalEvents          int64   `json:"total_events"`
+			LiveEvents           int64   `json:"live_events"`
+			ArchivedEvents       int64   `json:"archived_events"`
+			ArchiveEarliestEvent *string `json:"archive_earliest_event"`
+		} `json:"coverage"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, buf.String())
+	}
+	if result.Coverage == nil {
+		t.Fatal("expected coverage key in JSON")
+	}
+	// Effective earliest should be the archive time.
+	if result.Coverage.EarliestEvent != "2026-03-01 14:00:00" {
+		t.Errorf("wrong earliest_event: %s", result.Coverage.EarliestEvent)
+	}
+	if result.Coverage.TotalEvents != 15000 {
+		t.Errorf("wrong total_events: %d", result.Coverage.TotalEvents)
+	}
+	if result.Coverage.LiveEvents != 10000 {
+		t.Errorf("wrong live_events: %d", result.Coverage.LiveEvents)
+	}
+	if result.Coverage.ArchivedEvents != 5000 {
+		t.Errorf("wrong archived_events: %d", result.Coverage.ArchivedEvents)
+	}
+	if result.Coverage.ArchiveEarliestEvent == nil || *result.Coverage.ArchiveEarliestEvent != "2026-03-01 14:00:00" {
+		t.Errorf("wrong archive_earliest_event: %v", result.Coverage.ArchiveEarliestEvent)
 	}
 }
 


### PR DESCRIPTION
closes #133

## Summary
- `LoadCoverage` now queries `archive_state` to derive the earliest archived hour from `MIN(partition_name)` and adds `SUM(row_count)` to total events
- Text output shows `(includes archives)` annotation and `live + archived` breakdown when archives exist
- JSON output adds `live_events`, `archived_events`, and `archive_earliest_event` fields
- Archive coverage query is non-fatal — older indexes without `archive_state` still work

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] New tests for `parsePartitionName`, text output with/without archives, JSON output with archives

🤖 Generated with [Claude Code](https://claude.com/claude-code)