### PR TITLE
fix: always emit TO_SECONDS partition pruning hints

### DIFF
--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -30,12 +30,6 @@ func mysqlToSeconds(t time.Time) int64 {
 	return t.UTC().Unix() + mysqlToSecondsConst
 }
 
-// isHourAligned reports whether t falls exactly on an hour boundary
-// (zero minutes, seconds, and nanoseconds).
-func isHourAligned(t time.Time) bool {
-	return t.Minute() == 0 && t.Second() == 0 && t.Nanosecond() == 0
-}
-
 // ─── RBAC types ───────────────────────────────────────────────────────────────
 
 // SchemaTable identifies a schema+table pair used in RBAC deny rules.
@@ -228,24 +222,22 @@ func buildQuery(opts Options) (string, []any) {
 	}
 	if opts.Since != nil {
 		since := *opts.Since
-		if !isHourAligned(since) {
-			// Add an outer hour-aligned lower bound as a TO_SECONDS integer literal so
-			// MySQL can prune to the correct partition(s) at parse time, without relying
-			// on optimizer inference from a parameterised datetime comparison.
-			outerSince := mysqlToSeconds(since.Truncate(time.Hour))
-			where = append(where, fmt.Sprintf("TO_SECONDS(event_timestamp) >= %d", outerSince))
-		}
+		// Add an hour-aligned lower bound as a TO_SECONDS integer literal so
+		// MySQL can prune to the correct partition(s) at parse time. This hint
+		// is always required — MySQL cannot infer partition pruning from
+		// parameterised datetime comparisons, even when the value is hour-aligned.
+		outerSince := mysqlToSeconds(since.Truncate(time.Hour))
+		where = append(where, fmt.Sprintf("TO_SECONDS(event_timestamp) >= %d", outerSince))
 		where = append(where, "event_timestamp >= ?")
 		args = append(args, since)
 	}
 	if opts.Until != nil {
 		until := *opts.Until
-		if !isHourAligned(until) {
-			// Outer upper bound: truncate until to the hour, then advance one hour
-			// (exclusive). E.g. 15:13 → 16:00.
-			outerUntil := mysqlToSeconds(until.Truncate(time.Hour).Add(time.Hour))
-			where = append(where, fmt.Sprintf("TO_SECONDS(event_timestamp) < %d", outerUntil))
-		}
+		// Add an hour-aligned upper bound (exclusive) as a TO_SECONDS literal
+		// for partition pruning. Truncate to the hour, then advance one hour.
+		// E.g. 15:13 → 16:00, 15:00 → 16:00.
+		outerUntil := mysqlToSeconds(until.Truncate(time.Hour).Add(time.Hour))
+		where = append(where, fmt.Sprintf("TO_SECONDS(event_timestamp) < %d", outerUntil))
 		where = append(where, "event_timestamp <= ?")
 		args = append(args, until)
 	}

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -137,9 +137,15 @@ func TestBuildQuery_sinceUntil(t *testing.T) {
 	if !strings.Contains(q, "event_timestamp <= ?") {
 		t.Errorf("expected event_timestamp <= ? in query: %s", q)
 	}
-	// Hour-aligned: no TO_SECONDS() pruning hints should be added.
-	if strings.Contains(q, "TO_SECONDS") {
-		t.Errorf("unexpected TO_SECONDS in hour-aligned query: %s", q)
+	// TO_SECONDS pruning hints must always be present, even for hour-aligned values,
+	// because MySQL cannot infer partition pruning from parameterised datetime comparisons.
+	outerSince := mysqlToSeconds(time.Date(2026, 2, 19, 14, 0, 0, 0, time.UTC))
+	outerUntil := mysqlToSeconds(time.Date(2026, 2, 19, 16, 0, 0, 0, time.UTC))
+	if !strings.Contains(q, fmt.Sprintf("TO_SECONDS(event_timestamp) >= %d", outerSince)) {
+		t.Errorf("expected lower-bound TO_SECONDS hint in query: %s", q)
+	}
+	if !strings.Contains(q, fmt.Sprintf("TO_SECONDS(event_timestamp) < %d", outerUntil)) {
+		t.Errorf("expected upper-bound TO_SECONDS hint in query: %s", q)
 	}
 	// since and until should both appear in args.
 	if args[0] != since || args[1] != until {
@@ -223,8 +229,9 @@ func TestBuildQuery_sinceNonAligned_untilAligned(t *testing.T) {
 	if !strings.Contains(q, "TO_SECONDS(event_timestamp) >=") {
 		t.Errorf("expected lower-bound TO_SECONDS hint: %s", q)
 	}
-	if strings.Contains(q, "TO_SECONDS(event_timestamp) <") {
-		t.Errorf("unexpected upper-bound TO_SECONDS hint for aligned until: %s", q)
+	// Even hour-aligned until must produce a TO_SECONDS hint.
+	if !strings.Contains(q, "TO_SECONDS(event_timestamp) <") {
+		t.Errorf("expected upper-bound TO_SECONDS hint: %s", q)
 	}
 }
 
@@ -234,30 +241,12 @@ func TestBuildQuery_sinceAligned_untilNonAligned(t *testing.T) {
 	opts := Options{Since: &since, Until: &until}
 	q, _ := buildQuery(opts)
 
-	if strings.Contains(q, "TO_SECONDS(event_timestamp) >=") {
-		t.Errorf("unexpected lower-bound TO_SECONDS hint for aligned since: %s", q)
+	// Even hour-aligned since must produce a TO_SECONDS hint.
+	if !strings.Contains(q, "TO_SECONDS(event_timestamp) >=") {
+		t.Errorf("expected lower-bound TO_SECONDS hint: %s", q)
 	}
 	if !strings.Contains(q, "TO_SECONDS(event_timestamp) <") {
 		t.Errorf("expected upper-bound TO_SECONDS hint: %s", q)
-	}
-}
-
-func TestIsHourAligned(t *testing.T) {
-	cases := []struct {
-		t    time.Time
-		want bool
-	}{
-		{time.Date(2026, 2, 19, 14, 0, 0, 0, time.UTC), true},
-		{time.Date(2026, 2, 19, 0, 0, 0, 0, time.UTC), true},
-		{time.Date(2026, 2, 19, 14, 45, 0, 0, time.UTC), false},
-		{time.Date(2026, 2, 19, 14, 0, 30, 0, time.UTC), false},
-		{time.Date(2026, 2, 19, 14, 0, 0, 1000, time.UTC), false},
-	}
-	for _, tc := range cases {
-		got := isHourAligned(tc.t)
-		if got != tc.want {
-			t.Errorf("isHourAligned(%v) = %v, want %v", tc.t, got, tc.want)
-		}
 	}
 }
 


### PR DESCRIPTION
closes #136

## Summary
- MySQL cannot infer partition pruning from parameterised `event_timestamp >= ?` comparisons, even when the value falls on an exact hour boundary
- The previous code skipped the `TO_SECONDS()` literal hint for hour-aligned times (via `isHourAligned` check), causing full table scans across all partitions
- On large tables (~13M+ rows), these unoptimized queries timed out, producing the generic "Error occurred during tool execution" error
- Fix: always emit the `TO_SECONDS()` partition pruning hint regardless of hour alignment

## Root cause
Reproduced by calling `query` with `since: "2026-03-04 12:00:00"` (hour-aligned) — times out. With `since: "2026-03-04 12:00:01"` (not hour-aligned) — works instantly. The `isHourAligned` guard incorrectly assumed MySQL could infer pruning from the parameterised datetime comparison.

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] Updated tests to expect TO_SECONDS hints for hour-aligned values
- [x] Removed `isHourAligned` helper and its tests (no longer needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)