### PR TITLE
docs: document how to query Parquet archives with DuckDB CLI

### DIFF
--- a/docs/parquet-debugging.md
+++ b/docs/parquet-debugging.md
@@ -30,7 +30,7 @@ Archive Parquet files contain 14 columns (the `pk_hash` stored generated column 
 | `gtid` | VARCHAR | GTID if available (nullable) |
 | `schema_name` | VARCHAR | Database name |
 | `table_name` | VARCHAR | Table name |
-| `event_type` | TINYINT | 0 = INSERT, 1 = UPDATE, 2 = DELETE |
+| `event_type` | TINYINT | 1 = INSERT, 2 = UPDATE, 3 = DELETE |
 | `pk_values` | VARCHAR | Pipe-delimited primary key values |
 | `changed_columns` | VARCHAR | JSON array of changed column names (nullable) |
 | `row_before` | VARCHAR | JSON object of the row before the event (nullable) |
@@ -240,7 +240,7 @@ ORDER BY hour;
 ```sql
 SELECT event_id, event_timestamp, pk_values, row_before
 FROM parquet_scan('/mnt/archives/**/*.parquet', hive_partitioning=true)
-WHERE event_type = 2  -- DELETE
+WHERE event_type = 3  -- DELETE
   AND schema_name = 'mydb'
   AND table_name = 'users'
 ORDER BY event_timestamp DESC


### PR DESCRIPTION
closes #139

## Summary
- Add `docs/parquet-debugging.md` covering interactive DuckDB CLI usage against Parquet archive files
- Documents local and S3 query setup (httpfs extension, credential config)
- Covers file inspection with `parquet_metadata()` and `parquet_schema()`
- Explains Hive partition pruning with `hive_partitioning=true`
- Documents `EXPLAIN ANALYZE` profiling and filter pushdown behavior
- Includes practical example queries (event listing, PK lookup, hourly volume, DELETE inspection)

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)
- [ ] Review doc for accuracy against actual Parquet schema and DuckDB behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)