### PR TITLE
fix: pass --user to docker run so dump files are owned by invoking user

### DIFF
--- a/cmd/bintrail/dump.go
+++ b/cmd/bintrail/dump.go
@@ -115,6 +115,7 @@ func buildDockerArgs(image, outputDir, host string, mydumperArgs []string, encry
 
 	args := []string{
 		"run", "--rm",
+		"--user", fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()),
 		"-v", absOutput + ":" + absOutput,
 	}
 

--- a/cmd/bintrail/dump_test.go
+++ b/cmd/bintrail/dump_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -664,6 +665,12 @@ func TestBuildDockerArgs_encryptKeyMount(t *testing.T) {
 	if !found {
 		t.Error("expected key file bind mount with :ro in docker args")
 	}
+}
+
+func TestBuildDockerArgs_userFlag(t *testing.T) {
+	args := buildDockerArgs("mydumper/mydumper:latest", "/tmp/dump", "db.example.com", nil, "")
+	want := fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid())
+	assertArgsContainPair(t, args, "--user", want)
 }
 
 func TestBuildDockerArgs_noEncryptKeyMount(t *testing.T) {


### PR DESCRIPTION
closes #141

## Summary
- Add `--user <uid>:<gid>` to `buildDockerArgs` so the mydumper container creates files owned by the invoking user instead of root
- Unconditional on all platforms (harmless on macOS where Docker Desktop already maps ownership)
- Add unit test for the `--user` flag

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)
- [ ] Manual: run `bintrail dump` in Docker mode on Linux, verify output files are owned by current user

🤖 Generated with [Claude Code](https://claude.com/claude-code)