### PR TITLE
Fix parquet_scan glob on Hive-partitioned S3 paths

### DIFF
--- a/internal/parquetquery/parquetquery.go
+++ b/internal/parquetquery/parquetquery.go
@@ -106,7 +106,7 @@ func buildQuery(glob string, opts query.Options) (string, []any) {
 	q := "SELECT event_id, binlog_file, start_pos, end_pos, event_timestamp," +
 		" gtid, schema_name, table_name, event_type, pk_values," +
 		" changed_columns, row_before, row_after, schema_version" +
-		" FROM parquet_scan('" + safeGlob + "')"
+		" FROM parquet_scan('" + safeGlob + "', hive_partitioning=true)"
 	if len(where) > 0 {
 		q += " WHERE " + strings.Join(where, " AND ")
 	}

--- a/internal/parquetquery/parquetquery_test.go
+++ b/internal/parquetquery/parquetquery_test.go
@@ -46,7 +46,7 @@ func assertContains(t *testing.T, s, want string) {
 
 func TestBuildQueryNoFilters(t *testing.T) {
 	q, args := buildQuery("/archives/*.parquet", query.Options{Limit: 50})
-	assertContains(t, q, "FROM parquet_scan('/archives/*.parquet')")
+	assertContains(t, q, "FROM parquet_scan('/archives/*.parquet', hive_partitioning=true)")
 	assertContains(t, q, "ORDER BY event_timestamp, event_id")
 	assertContains(t, q, "LIMIT ?")
 	// Only arg is the limit.
@@ -158,5 +158,5 @@ func TestBuildQueryNoLimit(t *testing.T) {
 func TestBuildQueryGlobEscaping(t *testing.T) {
 	// A single quote in the path must be escaped as '' to prevent SQL injection.
 	q, _ := buildQuery("/it's/archives/*.parquet", query.Options{})
-	assertContains(t, q, "/it''s/archives/*.parquet")
+	assertContains(t, q, "parquet_scan('/it''s/archives/*.parquet', hive_partitioning=true)")
 }


### PR DESCRIPTION
closes nethalo/dbtrail#261

## Summary
- Add `hive_partitioning=true` to the `parquet_scan()` call in `buildQuery`
- DuckDB's glob resolution fails on S3 paths containing `=` signs (Hive-partitioned directories like `event_date=2026-03-09/`). This parameter tells DuckDB to treat these as Hive partitions, fixing the "No files found" error
- Updated tests to match the new SQL output

## Test plan
- [x] Unit tests pass (`go test ./internal/parquetquery/ -v`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)