### PR TITLE
Refactor rotate to archive-and-drop one partition at a time

### DIFF
--- a/cmd/bintrail/rotate.go
+++ b/cmd/bintrail/rotate.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -287,16 +288,20 @@ func performRotation(ctx context.Context, db *sql.DB, dbName string, retainDur t
 						skipUpload := false
 						if rotRetry {
 							var uploadedAt sql.NullTime
-							if err := db.QueryRowContext(ctx,
+							err := db.QueryRowContext(ctx,
 								`SELECT s3_uploaded_at FROM archive_state
 								WHERE partition_name = ? AND bintrail_id = ?`,
 								name, rotBintrailID,
-							).Scan(&uploadedAt); err == nil && uploadedAt.Valid {
+							).Scan(&uploadedAt)
+							switch {
+							case err == nil && uploadedAt.Valid:
 								slog.Info("skipping existing S3 upload (--retry)", "partition", name)
 								if rotFormat != "json" {
 									fmt.Fprintf(os.Stdout, "skipped S3 upload for %s (already uploaded)\n", name)
 								}
 								skipUpload = true
+							case err != nil && !errors.Is(err, sql.ErrNoRows):
+								return 0, 0, fmt.Errorf("check S3 upload state for %s: %w", name, err)
 							}
 						}
 
@@ -327,6 +332,7 @@ func performRotation(ctx context.Context, db *sql.DB, dbName string, retainDur t
 					if err := dropPartitions(ctx, db, dbName, []string{name}); err != nil {
 						return 0, 0, fmt.Errorf("failed to drop partition %s: %w", name, err)
 					}
+					slog.Info("dropped partition", "partition", name)
 					if rotFormat != "json" {
 						fmt.Fprintf(os.Stdout, "dropped partition %s\n", name)
 					}


### PR DESCRIPTION
closes #151

## Summary
- Each partition is now dropped immediately after archiving (and optional S3 upload), instead of archiving all partitions first and then dropping them in a single bulk `ALTER TABLE`
- Replaced the S3 retry `continue` with a `skipUpload` boolean so the per-partition drop always executes, even when the upload is skipped via `--retry`
- Non-archive path (no `--archive-dir`) retains the bulk drop since there is no preceding per-partition work to interleave

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)