### PR TITLE
agent: allow BYOS+S3 without --index-dsn

### DIFF
--- a/cmd/bintrail/agent.go
+++ b/cmd/bintrail/agent.go
@@ -190,12 +190,26 @@ func runAgent(cmd *cobra.Command, args []string) error {
 			slog.Info("server identity resolved", "bintrail_id", bintrailID)
 		}
 	} else if byosMode {
-		if agtS3Bucket != "" {
-			return fmt.Errorf("--index-dsn is required for BYOS with S3: cannot resolve stable bintrail_id for S3 partitioning without it")
-		}
-		slog.Warn("no --index-dsn provided; using numeric server-id for BYOS metadata",
+		// BYOS without --index-dsn: fall back to using --server-id as the
+		// stable identifier for metadata records, WebSocket heartbeats, and
+		// (when S3 is configured) the parquet partition key.  The fallback
+		// at line 218 (cmp.Or(bintrailID, fmt.Sprint(agtServerID))) wires
+		// this through to all consumers.
+		//
+		// We previously refused to start in BYOS+S3 mode without an index
+		// DB on the assumption that the numeric server-id would produce
+		// inconsistent partition keys across runs.  In practice the
+		// --server-id is stable by configuration (it's set in agent.env or
+		// the customer's runbook and doesn't change between restarts), so
+		// the partitions are stable too.  Forcing customers to provision
+		// a separate MySQL just for bintrail_id persistence was an
+		// onerous requirement that the BYOS_SETUP_INSTRUCTIONS in
+		// dbtrail-saas didn't even mention — see #1133 thread for the
+		// full design discussion and bintrail-saas-architecture.md §22.10
+		// for the canonical reference.
+		slog.Info("no --index-dsn provided; using --server-id as BYOS identity",
 			"server_id", fmt.Sprint(agtServerID),
-			"hint", "pass --index-dsn to enable stable bintrail_id resolution")
+			"s3_bucket", agtS3Bucket)
 	}
 
 	// BYOS streaming: start buffer + streaming goroutine.


### PR DESCRIPTION
## Summary

Removes the hard-fail check at `cmd/bintrail/agent.go:193-194` that blocks `bintrail agent` from starting when configured with `--s3-bucket` but without `--index-dsn`. The fallback at `agent.go:218` (`cmp.Or(bintrailID, fmt.Sprint(agtServerID))`) already handles this case correctly — it just couldn't be reached for BYOS+S3.

## Why

Customers following the BYOS setup instructions in dbtrail (the `BYOS_SETUP_INSTRUCTIONS` template in `bintrail-saas/frontend/src/pages/ServerDetail.tsx`) get this exact env file:

```
BINTRAIL_API_KEY=...
BINTRAIL_ENDPOINT=https://api.dbtrail.com
BINTRAIL_SOURCE_DSN=...
BINTRAIL_SERVER_ID=...
BINTRAIL_S3_BUCKET=your-bintrail-data
BINTRAIL_S3_REGION=us-east-1
```

**Notably absent**: `BINTRAIL_INDEX_DSN`. The customer-facing docs don't mention it. So every customer following those instructions hits this error on first start:

```
--index-dsn is required for BYOS with S3: cannot resolve stable bintrail_id
for S3 partitioning without it
```

That's the symptom. The reasoning behind the original check (per the comment at lines 181-186) was that without an index DB to persist the bintrail_id, falling back to the numeric `--server-id` would cause "S3 partitions that cannot be correlated with future runs that resolve a proper bintrail_id". In practice this is overly paranoid:

1. **The fallback at line 218 already wires `--server-id` through** to all consumers via `cmp.Or(bintrailID, fmt.Sprint(agtServerID))`. Both the S3 payload partition key (`agent.go:240`) and the WebSocket heartbeat `BintrailID` field (`agent.go:292`) accept it. The path WORKS — it's just gated.

2. **The `--server-id` is stable by configuration.** Customers set it in `agent.env` or a runbook and don't change it between restarts. Stable input → stable partition key.

3. **The dbtrail SaaS keys all per-server state by its own internal `registered_servers.id`** (a UUID generated at server registration time on the SaaS side), NOT by the customer-side `bintrail_id`. The two identifiers are independent — see `bintrail-saas-architecture.md §22.3` for the canonical reference on this asymmetry.

4. Forcing customers to provision a separate MySQL just for `bintrail_id` persistence is a high-friction requirement that the customer-facing docs don't even mention. It's a footgun.

## What's NOT changed

The companion check at `agent.go:184-186` (which fires when `sourceDB` AND `indexDB` are both set but `resolveServerIdentity` itself fails) is **left intact**. That case represents a degraded state where the customer explicitly requested bintrail_id resolution and something broke (e.g., MySQL connection lost mid-resolution, conflict detected, etc.). Failing fast there helps debugging.

The `serverid.go` package is **untouched**. The `id := uuid.NewString()` UUID generation at `serverid.go:245` stays as-is. This PR doesn't touch the identity resolution algorithm — it only allows the BYOS+S3 flow to take the existing fallback path that's been there all along.

## Where this was discovered

While trying to recover the `nethalo-byos-1` tenant in dbtrail after an aborted free→paid migration. The customer's bintrail agent on `i-01c4865e31844077e` was running in silent buffer-only mode (no `--s3-bucket` configured). When I tried to add `--s3-bucket` to fix that, the agent failed to start with this error. The recovery is blocked on this fix landing.

Full context in the dbtrail thread: nethalo/dbtrail#1133, #1151, #1152, #1155, #1156, #1159, #1160, #1163, #1164.

The canonical reference for BYOS architecture is now documented in `dbtrail/bintrail-saas-architecture.md §22` (added in nethalo/dbtrail#1164). §22.10 lists this specific issue under "Known Gotchas & Active Issues", and §22.11 proposes a follow-up improvement (BYOS identity propagation) that would close the identity gap entirely without needing customer-side state.

## Changes

- **`cmd/bintrail/agent.go:192-213`** — replace the hard-fail `else if byosMode` branch with an info log that documents the fallback. The comment explains the design reasoning so future readers don't re-add the check thinking it was missing. ~14 net new lines (the warning is replaced with a more detailed info log).

## Testing

- [x] `go test ./cmd/bintrail/... ./internal/serverid/...` — all green locally
- [ ] Cross-build for linux/arm64 via the Release workflow (this PR doesn't add a CI job; relies on the existing release.yaml triggered by `v*` tag push)
- [ ] Manual end-to-end test on `i-01c4865e31844077e` after release: configure agent with `--s3-bucket bintrail-byos-test --s3-region us-east-1` (no `--index-dsn`), restart, verify it starts and POSTs metadata events to dbtrail's `/v1/events` after a write to the source DB

## Release plan

Since the existing CI only runs on `v*` tag push, after merge:
1. Tag `v0.4.4` (or whatever the next version is) on `main`
2. Workflow `release.yaml` runs goreleaser → publishes `bintrail-linux-arm64` to GitHub releases
3. SCP / curl the new binary onto the test instance
4. Restart `bintrail-agent.service`
5. Verify recovery flow for `nethalo-byos-1`

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>