### PR TITLE
byos: propagate source server identity to dbtrail

### DIFF
--- a/cmd/bintrail/agent.go
+++ b/cmd/bintrail/agent.go
@@ -169,6 +169,18 @@ func runAgent(cmd *cobra.Command, args []string) error {
 		handler.SourceDB = db
 	}
 
+	// Capture source server identity (architecture §22.11) for BYOS metadata
+	// records. Independent of indexDB so it works in fully stateless BYOS.
+	var sourceIdent byos.SourceIdentity
+	if sourceDB != nil {
+		ident, err := loadSourceIdentity(cmd.Context(), sourceDB, agtSourceDSN)
+		if err != nil {
+			slog.Warn("failed to capture source identity for BYOS metadata", "error", err)
+		} else {
+			sourceIdent = ident
+		}
+	}
+
 	// Resolve bintrail_id — the stable server identifier used for metadata
 	// records and WebSocket heartbeats. Requires both source and index DBs.
 	var bintrailID string
@@ -261,6 +273,7 @@ func runAgent(cmd *cobra.Command, args []string) error {
 				metaClient:    metaClient,
 				payloadWriter: payloadWriter,
 				serverID:      serverIDStr,
+				sourceIdent:   sourceIdent,
 				flushInterval: flushInterval,
 				state:         flushState,
 			})
@@ -357,6 +370,7 @@ type byosFlushConfig struct {
 	metaClient    *byos.MetadataClient
 	payloadWriter *byos.PayloadWriter
 	serverID      string
+	sourceIdent   byos.SourceIdentity
 	flushInterval time.Duration
 	state         *flushPipelineState
 }
@@ -590,7 +604,7 @@ func flushToSinks(ctx context.Context, batch []parser.Event, fc *byosFlushConfig
 	var payloadBatch []byos.PayloadRecord
 
 	for i := range batch {
-		meta, payload, err := byos.SplitEvent(batch[i], fc.serverID)
+		meta, payload, err := byos.SplitEvent(batch[i], fc.serverID, fc.sourceIdent)
 		if err != nil {
 			slog.Warn("BYOS split failed, skipping event",
 				"error", err,

--- a/cmd/bintrail/agent.go
+++ b/cmd/bintrail/agent.go
@@ -171,14 +171,17 @@ func runAgent(cmd *cobra.Command, args []string) error {
 
 	// Capture source server identity (architecture §22.11) for BYOS metadata
 	// records. Independent of indexDB so it works in fully stateless BYOS.
+	// Hard-fail on capture failure: silently emitting events with empty
+	// server_uuid would degrade dbtrail's identity resolution to the legacy
+	// NULL-bintrail_id path for the entire agent lifetime, with no operator
+	// signal until queries return wrong results.
 	var sourceIdent byos.SourceIdentity
 	if sourceDB != nil {
 		ident, err := loadSourceIdentity(cmd.Context(), sourceDB, agtSourceDSN)
 		if err != nil {
-			slog.Warn("failed to capture source identity for BYOS metadata", "error", err)
-		} else {
-			sourceIdent = ident
+			return fmt.Errorf("capture source identity for BYOS metadata: %w", err)
 		}
+		sourceIdent = ident
 	}
 
 	// Resolve bintrail_id — the stable server identifier used for metadata

--- a/cmd/bintrail/agent_test.go
+++ b/cmd/bintrail/agent_test.go
@@ -353,7 +353,7 @@ func splitBatch(batch []parser.Event, serverID string) ([]byos.MetadataRecord, [
 	var meta []byos.MetadataRecord
 	var payload []byos.PayloadRecord
 	for i := range batch {
-		m, p, err := byos.SplitEvent(batch[i], serverID)
+		m, p, err := byos.SplitEvent(batch[i], serverID, byos.SourceIdentity{})
 		if err != nil {
 			continue
 		}

--- a/cmd/bintrail/serverutil.go
+++ b/cmd/bintrail/serverutil.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 
+	"github.com/dbtrail/bintrail/internal/byos"
 	"github.com/dbtrail/bintrail/internal/serverid"
 )
 
@@ -12,13 +13,32 @@ import (
 // port, and username from sourceDSN, then resolves or registers the server in
 // the index database. Returns the stable bintrail_id.
 func resolveServerIdentity(ctx context.Context, sourceDB, indexDB *sql.DB, sourceDSN string) (string, error) {
-	var serverUUID string
-	if err := sourceDB.QueryRowContext(ctx, "SELECT @@server_uuid").Scan(&serverUUID); err != nil {
-		return "", fmt.Errorf("query server_uuid: %w", err)
-	}
-	host, port, user, _, err := parseSourceDSN(sourceDSN)
+	ident, err := loadSourceIdentity(ctx, sourceDB, sourceDSN)
 	if err != nil {
 		return "", err
 	}
-	return serverid.ResolveServer(ctx, indexDB, serverUUID, host, port, user)
+	return serverid.ResolveServer(ctx, indexDB, ident.ServerUUID, ident.Host, uint16(ident.Port), ident.User)
+}
+
+// loadSourceIdentity captures the source MySQL server's @@server_uuid plus
+// host/port/user parsed from sourceDSN. The result is stamped onto every
+// BYOS MetadataRecord so the dbtrail SaaS side can resolve a stable
+// bintrail_id against its own bintrail_servers table — see
+// bintrail-saas-architecture.md §22.11. Safe to call even when no index DB
+// is available locally (the agent is running in fully stateless BYOS mode).
+func loadSourceIdentity(ctx context.Context, sourceDB *sql.DB, sourceDSN string) (byos.SourceIdentity, error) {
+	var serverUUID string
+	if err := sourceDB.QueryRowContext(ctx, "SELECT @@server_uuid").Scan(&serverUUID); err != nil {
+		return byos.SourceIdentity{}, fmt.Errorf("query server_uuid: %w", err)
+	}
+	host, port, user, _, err := parseSourceDSN(sourceDSN)
+	if err != nil {
+		return byos.SourceIdentity{}, err
+	}
+	return byos.SourceIdentity{
+		ServerUUID: serverUUID,
+		Host:       host,
+		Port:       int(port),
+		User:       user,
+	}, nil
 }

--- a/cmd/bintrail/serverutil_test.go
+++ b/cmd/bintrail/serverutil_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestLoadSourceIdentityHappyPath(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT @@server_uuid").WillReturnRows(
+		sqlmock.NewRows([]string{"@@server_uuid"}).
+			AddRow("11111111-2222-3333-4444-555555555555"))
+
+	ident, err := loadSourceIdentity(context.Background(), db, "repluser:secret@tcp(10.0.0.5:3306)/")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ident.ServerUUID != "11111111-2222-3333-4444-555555555555" {
+		t.Errorf("ServerUUID = %q", ident.ServerUUID)
+	}
+	if ident.Host != "10.0.0.5" || ident.Port != 3306 || ident.User != "repluser" {
+		t.Errorf("identity = %+v, want host=10.0.0.5 port=3306 user=repluser", ident)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestLoadSourceIdentityServerUUIDQueryFails(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT @@server_uuid").WillReturnError(errors.New("connection refused"))
+
+	_, err = loadSourceIdentity(context.Background(), db, "u:p@tcp(h:3306)/")
+	if err == nil {
+		t.Fatal("expected error when @@server_uuid query fails")
+	}
+	if !strings.Contains(err.Error(), "server_uuid") {
+		t.Errorf("error %q should mention server_uuid", err)
+	}
+}
+
+func TestLoadSourceIdentityBadDSN(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT @@server_uuid").WillReturnRows(
+		sqlmock.NewRows([]string{"@@server_uuid"}).AddRow("uuid-x"))
+
+	// parseSourceDSN rejects unix sockets — use that as the easy bad-DSN trigger.
+	_, err = loadSourceIdentity(context.Background(), db, "u:p@unix(/tmp/sock)/")
+	if err == nil {
+		t.Fatal("expected error for unix-socket DSN")
+	}
+	if !strings.Contains(err.Error(), "unix socket") {
+		t.Errorf("error %q should mention unix socket", err)
+	}
+}

--- a/internal/byos/metadata_test.go
+++ b/internal/byos/metadata_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -102,6 +103,21 @@ func TestMetadataClientSend(t *testing.T) {
 	if decoded[1].ServerUUID != "" || decoded[1].SourceHost != "" {
 		t.Errorf("second record should have empty source identity (omitempty), got uuid=%q host=%q",
 			decoded[1].ServerUUID, decoded[1].SourceHost)
+	}
+
+	// Raw-bytes assertion: omitempty must keep the second record's source
+	// identity fields out of the wire payload entirely (not just empty).
+	// Catches a regression where someone removes `omitempty` and silently
+	// bloats every BYOS metadata batch.
+	bodyStr := string(receivedBody)
+	if !strings.Contains(bodyStr, `"server_uuid":"11111111-1111-1111-1111-111111111111"`) {
+		t.Errorf("first record should serialize server_uuid; body = %s", bodyStr)
+	}
+	if strings.Count(bodyStr, `"server_uuid"`) != 1 {
+		t.Errorf("server_uuid should appear exactly once (omitempty on record 2); body = %s", bodyStr)
+	}
+	if strings.Count(bodyStr, `"source_host"`) != 1 {
+		t.Errorf("source_host should appear exactly once (omitempty on record 2); body = %s", bodyStr)
 	}
 }
 

--- a/internal/byos/metadata_test.go
+++ b/internal/byos/metadata_test.go
@@ -44,6 +44,10 @@ func TestMetadataClientSend(t *testing.T) {
 			ServerID:       "srv-1",
 			GTID:           "aaa:1",
 			RowCount:       1,
+			ServerUUID:     "11111111-1111-1111-1111-111111111111",
+			SourceHost:     "10.0.0.5",
+			SourcePort:     3306,
+			SourceUser:     "repl",
 		},
 		{
 			PKHash:         "def456",
@@ -83,6 +87,21 @@ func TestMetadataClientSend(t *testing.T) {
 	}
 	if len(decoded[1].ChangedColumns) != 2 {
 		t.Errorf("second record changed_columns = %v, want [status updated_at]", decoded[1].ChangedColumns)
+	}
+
+	// Source identity fields (architecture §22.11) must round-trip on the
+	// wire. Older clients that omit them serialize as empty thanks to
+	// `omitempty`.
+	if decoded[0].ServerUUID != "11111111-1111-1111-1111-111111111111" {
+		t.Errorf("first record server_uuid = %q, want set", decoded[0].ServerUUID)
+	}
+	if decoded[0].SourceHost != "10.0.0.5" || decoded[0].SourcePort != 3306 || decoded[0].SourceUser != "repl" {
+		t.Errorf("first record source identity = %q:%d/%s, want 10.0.0.5:3306/repl",
+			decoded[0].SourceHost, decoded[0].SourcePort, decoded[0].SourceUser)
+	}
+	if decoded[1].ServerUUID != "" || decoded[1].SourceHost != "" {
+		t.Errorf("second record should have empty source identity (omitempty), got uuid=%q host=%q",
+			decoded[1].ServerUUID, decoded[1].SourceHost)
 	}
 }
 

--- a/internal/byos/split.go
+++ b/internal/byos/split.go
@@ -23,9 +23,26 @@ import (
 	"github.com/dbtrail/bintrail/internal/parser"
 )
 
+// SourceIdentity describes the source MySQL server that produced an event.
+// It is captured once at agent startup and stamped onto every MetadataRecord
+// so the dbtrail SaaS side can resolve a stable bintrail_id against its own
+// local bintrail_servers table — closing the identity-model asymmetry between
+// hosted and BYOS modes.  See bintrail-saas-architecture.md §22.11.
+type SourceIdentity struct {
+	ServerUUID string // @@server_uuid from the source DB
+	Host       string // host from --source-dsn
+	Port       int    // port from --source-dsn
+	User       string // user from --source-dsn
+}
+
 // MetadataRecord contains only indexing metadata — no row-level data.
 // It is sent to the dbtrail API so the hosted index can locate events
 // without ever seeing the actual row contents.
+//
+// The ServerUUID/SourceHost/SourcePort/SourceUser fields are populated from
+// SourceIdentity at SplitEvent time and let the SaaS-side ingest handler
+// resolve a stable bintrail_id (architecture §22.11). They are optional on
+// the wire so older bintrail clients remain compatible.
 type MetadataRecord struct {
 	PKHash         string    `json:"pk_hash"`
 	SchemaName     string    `json:"schema_name"`
@@ -37,6 +54,14 @@ type MetadataRecord struct {
 	ConnectionID   uint32    `json:"connection_id,omitempty"` // MySQL pseudo_thread_id; 0 = unknown
 	RowCount       int       `json:"row_count"`
 	ChangedColumns []string  `json:"changed_columns"` // nil for INSERT/DELETE
+
+	// Source identity (architecture §22.11). All four are optional; older
+	// bintrail clients omit them entirely and the SaaS side falls back to
+	// the legacy NULL-bintrail_id behavior.
+	ServerUUID string `json:"server_uuid,omitempty"`
+	SourceHost string `json:"source_host,omitempty"`
+	SourcePort int    `json:"source_port,omitempty"`
+	SourceUser string `json:"source_user,omitempty"`
 }
 
 // PayloadRecord contains full row data that stays in the customer's
@@ -63,11 +88,15 @@ func PKHash(pkValues string) string {
 
 // SplitEvent splits a parsed binlog event into a metadata record (for the
 // dbtrail API) and a payload record (for the customer's storage backend).
-// serverID identifies the source MySQL server.
+// serverID identifies the source MySQL server. ident carries the source
+// server's @@server_uuid + DSN host/port/user so the SaaS-side ingest can
+// resolve a stable bintrail_id (architecture §22.11). A zero-value ident is
+// permitted (older callers / tests) and produces a record without source
+// identity fields.
 //
 // Returns an error for unsupported event types (DDL, GTID). Callers should
 // filter these before calling SplitEvent.
-func SplitEvent(ev parser.Event, serverID string) (MetadataRecord, PayloadRecord, error) {
+func SplitEvent(ev parser.Event, serverID string, ident SourceIdentity) (MetadataRecord, PayloadRecord, error) {
 	typeName, err := eventTypeName(ev.EventType)
 	if err != nil {
 		return MetadataRecord{}, PayloadRecord{}, err
@@ -87,6 +116,10 @@ func SplitEvent(ev parser.Event, serverID string) (MetadataRecord, PayloadRecord
 		ConnectionID:   ev.ConnectionID,
 		RowCount:       1,
 		ChangedColumns: changed,
+		ServerUUID:     ident.ServerUUID,
+		SourceHost:     ident.Host,
+		SourcePort:     ident.Port,
+		SourceUser:     ident.User,
 	}
 
 	payload := PayloadRecord{

--- a/internal/byos/split_test.go
+++ b/internal/byos/split_test.go
@@ -50,7 +50,8 @@ func TestSplitEventInsert(t *testing.T) {
 		SchemaVersion: 5,
 	}
 
-	meta, payload, err := SplitEvent(ev, "server-1")
+	ident := SourceIdentity{ServerUUID: "uuid-1", Host: "10.0.0.5", Port: 3306, User: "repl"}
+	meta, payload, err := SplitEvent(ev, "server-1", ident)
 	if err != nil {
 		t.Fatalf("SplitEvent: %v", err)
 	}
@@ -85,6 +86,20 @@ func TestSplitEventInsert(t *testing.T) {
 		t.Errorf("meta.ChangedColumns = %v, want nil for INSERT", meta.ChangedColumns)
 	}
 
+	// Source identity propagation (architecture §22.11).
+	if meta.ServerUUID != "uuid-1" {
+		t.Errorf("meta.ServerUUID = %q, want %q", meta.ServerUUID, "uuid-1")
+	}
+	if meta.SourceHost != "10.0.0.5" {
+		t.Errorf("meta.SourceHost = %q, want %q", meta.SourceHost, "10.0.0.5")
+	}
+	if meta.SourcePort != 3306 {
+		t.Errorf("meta.SourcePort = %d, want 3306", meta.SourcePort)
+	}
+	if meta.SourceUser != "repl" {
+		t.Errorf("meta.SourceUser = %q, want %q", meta.SourceUser, "repl")
+	}
+
 	// Payload checks — must contain row data.
 	if payload.PKHash != wantHash {
 		t.Errorf("payload.PKHash = %q, want %q", payload.PKHash, wantHash)
@@ -116,7 +131,7 @@ func TestSplitEventDelete(t *testing.T) {
 		RowBefore: map[string]any{"id": 42, "name": "Alice"},
 	}
 
-	meta, payload, err := SplitEvent(ev, "srv")
+	meta, payload, err := SplitEvent(ev, "srv", SourceIdentity{})
 	if err != nil {
 		t.Fatalf("SplitEvent: %v", err)
 	}
@@ -146,7 +161,7 @@ func TestSplitEventUpdate(t *testing.T) {
 		RowAfter:  map[string]any{"id": 42, "name": "Alice", "email": "a@new.com"},
 	}
 
-	meta, payload, err := SplitEvent(ev, "srv")
+	meta, payload, err := SplitEvent(ev, "srv", SourceIdentity{})
 	if err != nil {
 		t.Fatalf("SplitEvent: %v", err)
 	}
@@ -180,7 +195,7 @@ func TestSplitEventUpdateMultipleChanges(t *testing.T) {
 		RowAfter:  map[string]any{"id": 42, "email": "a@new.com", "updated_at": "2026-03-31"},
 	}
 
-	meta, _, err := SplitEvent(ev, "srv")
+	meta, _, err := SplitEvent(ev, "srv", SourceIdentity{})
 	if err != nil {
 		t.Fatalf("SplitEvent: %v", err)
 	}
@@ -198,7 +213,7 @@ func TestSplitEventUnsupportedType(t *testing.T) {
 	ev := parser.Event{
 		EventType: parser.EventDDL,
 	}
-	_, _, err := SplitEvent(ev, "srv")
+	_, _, err := SplitEvent(ev, "srv", SourceIdentity{})
 	if err == nil {
 		t.Fatal("expected error for DDL event type")
 	}
@@ -217,7 +232,7 @@ func TestSplitEventMapIsolation(t *testing.T) {
 		RowAfter:  after,
 	}
 
-	_, payload, err := SplitEvent(ev, "srv")
+	_, payload, err := SplitEvent(ev, "srv", SourceIdentity{})
 	if err != nil {
 		t.Fatalf("SplitEvent: %v", err)
 	}


### PR DESCRIPTION
Companion to nethalo/dbtrail#1179 — together these PRs implement architecture §22.11 (BYOS identity propagation), which is tracked as nethalo/dbtrail#1165.

## Summary
- Extends `byos.MetadataRecord` with four optional fields: `ServerUUID`, `SourceHost`, `SourcePort`, `SourceUser`. All `omitempty`, so an older dbtrail backend without #1179 sees the same wire format it does today.
- New `byos.SourceIdentity` type carries the four values from agent startup down to `SplitEvent`. `SplitEvent` now takes a `SourceIdentity` argument and stamps the fields on every metadata record it produces.
- New `loadSourceIdentity()` helper in `cmd/bintrail/serverutil.go` queries `@@server_uuid` + parses `--source-dsn` once, *independently* of whether `--index-dsn` is set. The agent startup path captures it before resolving `bintrail_id` and threads it through `byosFlushConfig` into the flush pipeline.
- Existing `resolveServerIdentity → serverid.ResolveServer` flow is unchanged for the index-DB path; it now reuses `loadSourceIdentity` internally.
- Tests updated: `TestSplitEventInsert` asserts the four fields propagate; `TestMetadataClientSend` asserts they round-trip on the wire (and that `omitempty` records stay empty).

## Why
With these fields on the wire, the SaaS-side dbtrail handler can register the server in its own local `bintrail_servers` table and resolve a stable `bintrail_id` — closing the identity-model asymmetry between hosted and BYOS modes documented in §22.3 and §22.11. See nethalo/dbtrail#1165 for the full context and nethalo/dbtrail#1179 for the receiving end.

## Out of scope
- Removing the `--index-dsn` hard-fail at `cmd/bintrail/agent.go:192-198` — this becomes safe to remove only after #1179 is deployed and customers are running this version of the CLI. Tracked as PR 3 in #1165.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./internal/byos/... ./cmd/bintrail/...` — all green
- [x] `go vet ./...` clean
- [ ] After merge: build a CLI binary, point it at a test source MySQL with `--source-dsn` only (no `--index-dsn`), POST a batch to a dbtrail backend running #1179, verify the new fields land in the JSON body and the SaaS side creates the `bintrail_servers` row

🤖 Generated with [Claude Code](https://claude.com/claude-code)