### PR TITLE
Store baseline binlog position in Parquet metadata and validate during reconstruction

### DIFF
--- a/cmd/bintrail/reconstruct.go
+++ b/cmd/bintrail/reconstruct.go
@@ -216,6 +216,9 @@ func runReconstruct(cmd *cobra.Command, args []string) error {
 
 	// Warn if there is a gap between the baseline binlog position and the
 	// first indexed event — events in that gap are missing from the reconstruction.
+	if bmeta.BinlogFile == "" && len(events) > 0 {
+		slog.Info("gap detection skipped — baseline lacks binlog position metadata; consider re-running 'bintrail baseline' to embed position data")
+	}
 	if bmeta.BinlogFile != "" && len(events) > 0 {
 		first := events[0]
 		gap := first.BinlogFile > bmeta.BinlogFile ||

--- a/cmd/bintrail/reconstruct.go
+++ b/cmd/bintrail/reconstruct.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/dbtrail/bintrail/internal/baseline"
 	"github.com/dbtrail/bintrail/internal/cliutil"
 	"github.com/dbtrail/bintrail/internal/config"
 	"github.com/dbtrail/bintrail/internal/query"
@@ -159,6 +160,19 @@ func runReconstruct(cmd *cobra.Command, args []string) error {
 	}
 	slog.Debug("found baseline snapshot", "path", baselinePath, "snapshot_time", snapshotTime.UTC().Format(time.RFC3339))
 
+	// Read baseline binlog position metadata (local files only).
+	var bmeta baseline.DumpMetadata
+	if !strings.HasPrefix(baselinePath, "s3://") {
+		var metaErr error
+		bmeta, metaErr = baseline.ReadParquetMetadata(baselinePath)
+		if metaErr != nil {
+			slog.Warn("could not read baseline metadata", "error", metaErr)
+		} else if bmeta.BinlogFile != "" {
+			slog.Debug("baseline binlog position",
+				"file", bmeta.BinlogFile, "pos", bmeta.BinlogPos, "gtid", bmeta.GTIDSet)
+		}
+	}
+
 	baselineRow, err := reconstruct.ReadBaselineRow(cmd.Context(), baselinePath, pkFilter)
 	if err != nil {
 		return fmt.Errorf("read baseline: %w", err)
@@ -199,6 +213,22 @@ func runReconstruct(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("fetch binlog events: %w", err)
 	}
 	slog.Debug("fetched binlog events", "count", len(events))
+
+	// Warn if there is a gap between the baseline binlog position and the
+	// first indexed event — events in that gap are missing from the reconstruction.
+	if bmeta.BinlogFile != "" && len(events) > 0 {
+		first := events[0]
+		gap := first.BinlogFile > bmeta.BinlogFile ||
+			(first.BinlogFile == bmeta.BinlogFile && first.StartPos > uint64(bmeta.BinlogPos))
+		if gap {
+			slog.Warn("gap between baseline and first indexed event — reconstruction may be incomplete",
+				"baseline_file", bmeta.BinlogFile,
+				"baseline_pos", bmeta.BinlogPos,
+				"baseline_gtid", bmeta.GTIDSet,
+				"first_event_file", first.BinlogFile,
+				"first_event_pos", first.StartPos)
+		}
+	}
 
 	// ── Reconstruct and format output ──────────────────────────────────────────
 	if err := writeReconstructOutput(baselineRow, events, snapshotTime, at, recHistory, recFormat, os.Stdout); err != nil {

--- a/cmd/bintrail/status.go
+++ b/cmd/bintrail/status.go
@@ -91,6 +91,7 @@ func runStatus(cmd *cobra.Command, args []string) error {
 					BinlogFile:   b.BinlogFile,
 					BinlogPos:    b.BinlogPos,
 					GTIDSet:      b.GTIDSet,
+					Path:         b.Path,
 				})
 			}
 		}

--- a/cmd/bintrail/status.go
+++ b/cmd/bintrail/status.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-sql-driver/mysql"
 	"github.com/spf13/cobra"
 
+	"github.com/dbtrail/bintrail/internal/baseline"
 	"github.com/dbtrail/bintrail/internal/cliutil"
 	"github.com/dbtrail/bintrail/internal/config"
 	"github.com/dbtrail/bintrail/internal/status"
@@ -31,13 +32,15 @@ Example:
 }
 
 var (
-	stIndexDSN string
-	stFormat   string
+	stIndexDSN    string
+	stFormat      string
+	stBaselineDir string
 )
 
 func init() {
 	statusCmd.Flags().StringVar(&stIndexDSN, "index-dsn", "", "DSN for the index MySQL database (required)")
 	statusCmd.Flags().StringVar(&stFormat, "format", "text", "Output format: text or json")
+	statusCmd.Flags().StringVar(&stBaselineDir, "baseline-dir", "", "Local directory of baseline Parquet snapshots (optional, shows baseline binlog positions)")
 	_ = statusCmd.MarkFlagRequired("index-dsn")
 	bindCommandEnv(statusCmd)
 
@@ -72,6 +75,25 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	data, err := status.CollectStatus(cmd.Context(), db, dbName)
 	if err != nil {
 		return err
+	}
+
+	// Discover baseline Parquet files if --baseline-dir is provided.
+	if stBaselineDir != "" {
+		baselines, bErr := baseline.DiscoverBaselines(stBaselineDir)
+		if bErr != nil {
+			slog.Warn("could not discover baselines", "dir", stBaselineDir, "error", bErr)
+		} else {
+			for _, b := range baselines {
+				data.Baselines = append(data.Baselines, status.BaselineInfo{
+					SnapshotTime: b.SnapshotTime,
+					Database:     b.Database,
+					Table:        b.Table,
+					BinlogFile:   b.BinlogFile,
+					BinlogPos:    b.BinlogPos,
+					GTIDSet:      b.GTIDSet,
+				})
+			}
+		}
 	}
 
 	slog.Info("status complete", "duration_ms", time.Since(start).Milliseconds())

--- a/internal/baseline/baseline.go
+++ b/internal/baseline/baseline.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -37,14 +38,19 @@ type Stats struct {
 
 // Run converts a mydumper output directory into Parquet files.
 func Run(ctx context.Context, cfg Config) (Stats, error) {
-	// Resolve timestamp.
+	// Resolve timestamp and binlog position from mydumper metadata.
+	var meta DumpMetadata
 	ts := cfg.Timestamp
 	if ts.IsZero() {
-		meta, err := ParseMetadata(cfg.InputDir)
+		var err error
+		meta, err = ParseMetadata(cfg.InputDir)
 		if err != nil {
 			return Stats{}, fmt.Errorf("parse mydumper metadata: %w", err)
 		}
 		ts = meta.StartedAt
+	} else {
+		// Best-effort: try to get binlog position even with timestamp override.
+		meta, _ = ParseMetadata(cfg.InputDir)
 	}
 
 	// Discover tables.
@@ -116,16 +122,26 @@ func Run(ctx context.Context, cfg Config) (Stats, error) {
 				}
 			}
 
+			md := map[string]string{
+				"bintrail.snapshot_timestamp": tsStr,
+				"bintrail.source_database":    tf.Database,
+				"bintrail.source_table":       tf.Table,
+				"bintrail.mydumper_format":    tf.Format,
+				"bintrail.bintrail_version":   Version,
+			}
+			if meta.BinlogFile != "" {
+				md[MetaKeyBinlogFile] = meta.BinlogFile
+			}
+			if meta.BinlogPos != 0 {
+				md[MetaKeyBinlogPos] = strconv.FormatInt(meta.BinlogPos, 10)
+			}
+			if meta.GTIDSet != "" {
+				md[MetaKeyGTIDSet] = meta.GTIDSet
+			}
 			writerCfg := WriterConfig{
 				Compression:  compression,
 				RowGroupSize: rowGroupSize,
-				Metadata: map[string]string{
-					"bintrail.snapshot_timestamp": tsStr,
-					"bintrail.source_database":    tf.Database,
-					"bintrail.source_table":       tf.Table,
-					"bintrail.mydumper_format":    tf.Format,
-					"bintrail.bintrail_version":   Version,
-				},
+				Metadata:     md,
 			}
 
 			n, err := processTable(ctx, tf, outPath, writerCfg)

--- a/internal/baseline/baseline.go
+++ b/internal/baseline/baseline.go
@@ -50,7 +50,12 @@ func Run(ctx context.Context, cfg Config) (Stats, error) {
 		ts = meta.StartedAt
 	} else {
 		// Best-effort: try to get binlog position even with timestamp override.
-		meta, _ = ParseMetadata(cfg.InputDir)
+		var metaErr error
+		meta, metaErr = ParseMetadata(cfg.InputDir)
+		if metaErr != nil {
+			slog.Info("could not read mydumper metadata for binlog position — Parquet files will lack baseline position",
+				"input_dir", cfg.InputDir, "error", metaErr)
+		}
 	}
 
 	// Discover tables.

--- a/internal/baseline/baseline_test.go
+++ b/internal/baseline/baseline_test.go
@@ -1170,3 +1170,113 @@ func TestReadParquetMetadata_noPosition(t *testing.T) {
 		t.Errorf("GTIDSet = %q, want empty", m.GTIDSet)
 	}
 }
+
+// ─── parseBaselineDirTimestamp ────────────────────────────────────────────────
+
+func TestParseBaselineDirTimestamp(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  time.Time
+		ok    bool
+	}{
+		{"valid UTC", "2025-02-28T00-00-00Z", time.Date(2025, 2, 28, 0, 0, 0, 0, time.UTC), true},
+		{"valid with time", "2026-03-15T14-30-00Z", time.Date(2026, 3, 15, 14, 30, 0, 0, time.UTC), true},
+		{"no T separator", "2025-02-28", time.Time{}, false},
+		{"empty", "", time.Time{}, false},
+		{"malformed time", "2025-02-28Tnot-a-time", time.Time{}, false},
+		{"random folder", "some-folder", time.Time{}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := parseBaselineDirTimestamp(tc.input)
+			if ok != tc.ok {
+				t.Errorf("ok = %v, want %v", ok, tc.ok)
+			}
+			if ok && !got.Equal(tc.want) {
+				t.Errorf("time = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// ─── DiscoverBaselines ───────────────────────────────────────────────────────
+
+func TestDiscoverBaselines(t *testing.T) {
+	baseDir := t.TempDir()
+
+	// Create a well-formed baseline directory structure with a Parquet file.
+	snapshotDir := filepath.Join(baseDir, "2025-02-28T00-00-00Z", "mydb")
+	if err := os.MkdirAll(snapshotDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a minimal Parquet file with binlog metadata.
+	parquetPath := filepath.Join(snapshotDir, "orders.parquet")
+	cols := []Column{
+		{Name: "id", MySQLType: "int", ParquetType: parquet.Leaf(parquet.Int32Type)},
+	}
+	w, err := NewWriter(parquetPath, cols, WriterConfig{
+		Compression:  "none",
+		RowGroupSize: 100,
+		Metadata: map[string]string{
+			MetaKeyBinlogFile: "binlog.000042",
+			MetaKeyBinlogPos:  "12345",
+			MetaKeyGTIDSet:    "abc:1-100",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := w.WriteRow([]string{"1"}, []bool{false}); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Also create a non-timestamp directory (should be skipped).
+	if err := os.MkdirAll(filepath.Join(baseDir, "not-a-timestamp"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Discover baselines.
+	results, err := DiscoverBaselines(baseDir)
+	if err != nil {
+		t.Fatalf("DiscoverBaselines: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d baselines, want 1", len(results))
+	}
+
+	b := results[0]
+	wantTime := time.Date(2025, 2, 28, 0, 0, 0, 0, time.UTC)
+	if !b.SnapshotTime.Equal(wantTime) {
+		t.Errorf("SnapshotTime = %v, want %v", b.SnapshotTime, wantTime)
+	}
+	if b.Database != "mydb" {
+		t.Errorf("Database = %q, want %q", b.Database, "mydb")
+	}
+	if b.Table != "orders" {
+		t.Errorf("Table = %q, want %q", b.Table, "orders")
+	}
+	if b.BinlogFile != "binlog.000042" {
+		t.Errorf("BinlogFile = %q, want %q", b.BinlogFile, "binlog.000042")
+	}
+	if b.BinlogPos != 12345 {
+		t.Errorf("BinlogPos = %d, want 12345", b.BinlogPos)
+	}
+	if b.GTIDSet != "abc:1-100" {
+		t.Errorf("GTIDSet = %q, want %q", b.GTIDSet, "abc:1-100")
+	}
+}
+
+func TestDiscoverBaselines_emptyDir(t *testing.T) {
+	results, err := DiscoverBaselines(t.TempDir())
+	if err != nil {
+		t.Fatalf("DiscoverBaselines: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("got %d baselines, want 0", len(results))
+	}
+}

--- a/internal/baseline/baseline_test.go
+++ b/internal/baseline/baseline_test.go
@@ -824,16 +824,43 @@ func TestRun(t *testing.T) {
 		t.Errorf("RowsWritten = %d, want 2", stats.RowsWritten)
 	}
 
-	// Verify at least one .parquet file exists under the output dir
-	found := false
+	// Find the output .parquet file and verify metadata.
+	var parquetPath string
 	_ = filepath.Walk(outputDir, func(path string, info os.FileInfo, err error) error {
 		if err == nil && filepath.Ext(path) == ".parquet" {
-			found = true
+			parquetPath = path
 		}
 		return nil
 	})
-	if !found {
-		t.Error("no .parquet file found in output directory")
+	if parquetPath == "" {
+		t.Fatal("no .parquet file found in output directory")
+	}
+
+	// Verify binlog position metadata was written.
+	rf, err := os.Open(parquetPath)
+	if err != nil {
+		t.Fatalf("open parquet: %v", err)
+	}
+	defer rf.Close()
+	info, err := rf.Stat()
+	if err != nil {
+		t.Fatalf("stat parquet: %v", err)
+	}
+	pf, err := parquet.OpenFile(rf, info.Size())
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+	for key, want := range map[string]string{
+		MetaKeyBinlogFile: "binlog.000042",
+		MetaKeyBinlogPos:  "12345",
+		MetaKeyGTIDSet:    "3e11fa47-bee9-11e4-9716-8f2e7c74b0e5:1-100",
+	} {
+		got, ok := pf.Lookup(key)
+		if !ok {
+			t.Errorf("metadata key %q not found", key)
+		} else if got != want {
+			t.Errorf("metadata[%q] = %q, want %q", key, got, want)
+		}
 	}
 }
 
@@ -1058,5 +1085,88 @@ func TestRunRetrySkipsExistingFiles(t *testing.T) {
 	}
 	if stats2.FilesWritten != 1 {
 		t.Errorf("retry Run: FilesWritten = %d, want 1 (counted as existing)", stats2.FilesWritten)
+	}
+}
+
+// ─── ReadParquetMetadata ─────────────────────────────────────────────────────
+
+func TestReadParquetMetadata(t *testing.T) {
+	// Create a Parquet file with binlog position metadata via NewWriter.
+	outPath := filepath.Join(t.TempDir(), "test.parquet")
+	cols := []Column{
+		{Name: "id", MySQLType: "int", ParquetType: parquet.Leaf(parquet.Int32Type)},
+	}
+	cfg := WriterConfig{
+		Compression:  "none",
+		RowGroupSize: 100,
+		Metadata: map[string]string{
+			MetaKeyBinlogFile: "binlog.000042",
+			MetaKeyBinlogPos:  "12345",
+			MetaKeyGTIDSet:    "3e11fa47-bee9-11e4-9716-8f2e7c74b0e5:1-100",
+		},
+	}
+	w, err := NewWriter(outPath, cols, cfg)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	if err := w.WriteRow([]string{"1"}, []bool{false}); err != nil {
+		t.Fatalf("WriteRow: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Read metadata back.
+	m, err := ReadParquetMetadata(outPath)
+	if err != nil {
+		t.Fatalf("ReadParquetMetadata: %v", err)
+	}
+	if m.BinlogFile != "binlog.000042" {
+		t.Errorf("BinlogFile = %q, want %q", m.BinlogFile, "binlog.000042")
+	}
+	if m.BinlogPos != 12345 {
+		t.Errorf("BinlogPos = %d, want 12345", m.BinlogPos)
+	}
+	if m.GTIDSet != "3e11fa47-bee9-11e4-9716-8f2e7c74b0e5:1-100" {
+		t.Errorf("GTIDSet = %q, want %q", m.GTIDSet, "3e11fa47-bee9-11e4-9716-8f2e7c74b0e5:1-100")
+	}
+}
+
+func TestReadParquetMetadata_noPosition(t *testing.T) {
+	// Create a Parquet file without binlog position metadata.
+	outPath := filepath.Join(t.TempDir(), "test.parquet")
+	cols := []Column{
+		{Name: "id", MySQLType: "int", ParquetType: parquet.Leaf(parquet.Int32Type)},
+	}
+	cfg := WriterConfig{
+		Compression:  "none",
+		RowGroupSize: 100,
+		Metadata: map[string]string{
+			"bintrail.source_database": "testdb",
+		},
+	}
+	w, err := NewWriter(outPath, cols, cfg)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	if err := w.WriteRow([]string{"1"}, []bool{false}); err != nil {
+		t.Fatalf("WriteRow: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	m, err := ReadParquetMetadata(outPath)
+	if err != nil {
+		t.Fatalf("ReadParquetMetadata: %v", err)
+	}
+	if m.BinlogFile != "" {
+		t.Errorf("BinlogFile = %q, want empty", m.BinlogFile)
+	}
+	if m.BinlogPos != 0 {
+		t.Errorf("BinlogPos = %d, want 0", m.BinlogPos)
+	}
+	if m.GTIDSet != "" {
+		t.Errorf("GTIDSet = %q, want empty", m.GTIDSet)
 	}
 }

--- a/internal/baseline/baselines.go
+++ b/internal/baseline/baselines.go
@@ -78,6 +78,8 @@ func DiscoverBaselines(dir string) ([]BaselineInfo, error) {
 					info.BinlogFile = meta.BinlogFile
 					info.BinlogPos = meta.BinlogPos
 					info.GTIDSet = meta.GTIDSet
+				} else {
+					slog.Warn("could not read Parquet metadata for baseline", "path", filePath, "error", err)
 				}
 
 				results = append(results, info)

--- a/internal/baseline/baselines.go
+++ b/internal/baseline/baselines.go
@@ -1,6 +1,7 @@
 package baseline
 
 import (
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -44,6 +45,7 @@ func DiscoverBaselines(dir string) ([]BaselineInfo, error) {
 		snapshotDir := filepath.Join(dir, entry.Name())
 		dbEntries, err := os.ReadDir(snapshotDir)
 		if err != nil {
+			slog.Warn("could not read baseline snapshot directory", "path", snapshotDir, "error", err)
 			continue
 		}
 		for _, dbEntry := range dbEntries {
@@ -54,6 +56,7 @@ func DiscoverBaselines(dir string) ([]BaselineInfo, error) {
 			tableDir := filepath.Join(snapshotDir, dbName)
 			tableFiles, err := os.ReadDir(tableDir)
 			if err != nil {
+				slog.Warn("could not read baseline table directory", "path", tableDir, "error", err)
 				continue
 			}
 			for _, tf := range tableFiles {

--- a/internal/baseline/baselines.go
+++ b/internal/baseline/baselines.go
@@ -1,0 +1,101 @@
+package baseline
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// BaselineInfo holds metadata about a discovered baseline Parquet file.
+type BaselineInfo struct {
+	SnapshotTime time.Time
+	Database     string
+	Table        string
+	BinlogFile   string
+	BinlogPos    int64
+	GTIDSet      string
+	Path         string
+}
+
+// DiscoverBaselines walks a baseline directory and returns metadata for each
+// Parquet file found. The expected layout is:
+//
+//	<dir>/<timestamp>/<database>/<table>.parquet
+//
+// where <timestamp> is an RFC3339 string with colons replaced by hyphens
+// (e.g. "2025-02-28T00-00-00Z"). Files that cannot be parsed are skipped.
+func DiscoverBaselines(dir string) ([]BaselineInfo, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	var results []BaselineInfo
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		ts, ok := parseBaselineDirTimestamp(entry.Name())
+		if !ok {
+			continue
+		}
+
+		snapshotDir := filepath.Join(dir, entry.Name())
+		dbEntries, err := os.ReadDir(snapshotDir)
+		if err != nil {
+			continue
+		}
+		for _, dbEntry := range dbEntries {
+			if !dbEntry.IsDir() {
+				continue
+			}
+			dbName := dbEntry.Name()
+			tableDir := filepath.Join(snapshotDir, dbName)
+			tableFiles, err := os.ReadDir(tableDir)
+			if err != nil {
+				continue
+			}
+			for _, tf := range tableFiles {
+				if tf.IsDir() || !strings.HasSuffix(tf.Name(), ".parquet") {
+					continue
+				}
+				tableName := strings.TrimSuffix(tf.Name(), ".parquet")
+				filePath := filepath.Join(tableDir, tf.Name())
+
+				info := BaselineInfo{
+					SnapshotTime: ts,
+					Database:     dbName,
+					Table:        tableName,
+					Path:         filePath,
+				}
+
+				// Best-effort: read binlog position from Parquet metadata.
+				if meta, err := ReadParquetMetadata(filePath); err == nil {
+					info.BinlogFile = meta.BinlogFile
+					info.BinlogPos = meta.BinlogPos
+					info.GTIDSet = meta.GTIDSet
+				}
+
+				results = append(results, info)
+			}
+		}
+	}
+	return results, nil
+}
+
+// parseBaselineDirTimestamp converts a baseline directory name like
+// "2025-02-28T00-00-00Z" to a time.Time. The format is RFC3339 with colons
+// in the time portion replaced by hyphens for filesystem compatibility.
+func parseBaselineDirTimestamp(name string) (time.Time, bool) {
+	idx := strings.IndexByte(name, 'T')
+	if idx < 0 {
+		return time.Time{}, false
+	}
+	rfc := name[:idx+1] + strings.ReplaceAll(name[idx+1:], "-", ":")
+	t, err := time.Parse(time.RFC3339, rfc)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t.UTC(), true
+}

--- a/internal/baseline/metadata.go
+++ b/internal/baseline/metadata.go
@@ -3,6 +3,7 @@ package baseline
 import (
 	"bufio"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -114,7 +115,13 @@ func ReadParquetMetadata(path string) (DumpMetadata, error) {
 		m.BinlogFile = v
 	}
 	if v, ok := pf.Lookup(MetaKeyBinlogPos); ok {
-		m.BinlogPos, _ = strconv.ParseInt(v, 10, 64)
+		pos, parseErr := strconv.ParseInt(v, 10, 64)
+		if parseErr != nil {
+			slog.Warn("corrupt baseline_binlog_position in Parquet metadata",
+				"path", path, "raw_value", v, "error", parseErr)
+		} else {
+			m.BinlogPos = pos
+		}
 	}
 	if v, ok := pf.Lookup(MetaKeyGTIDSet); ok {
 		m.GTIDSet = v

--- a/internal/baseline/metadata.go
+++ b/internal/baseline/metadata.go
@@ -8,6 +8,15 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/parquet-go/parquet-go"
+)
+
+// Parquet metadata keys for baseline binlog position.
+const (
+	MetaKeyBinlogFile = "bintrail.baseline_binlog_file"
+	MetaKeyBinlogPos  = "bintrail.baseline_binlog_position"
+	MetaKeyGTIDSet    = "bintrail.baseline_gtid_set"
 )
 
 // DumpMetadata contains information parsed from a mydumper metadata file.
@@ -76,6 +85,39 @@ func ParseMetadata(inputDir string) (DumpMetadata, error) {
 	}
 	if m.StartedAt.IsZero() {
 		return DumpMetadata{}, fmt.Errorf("metadata file missing 'Started dump at:' line")
+	}
+	return m, nil
+}
+
+// ReadParquetMetadata opens a local Parquet file and extracts the baseline
+// binlog position from its file-level key-value metadata. Returns a zero-value
+// DumpMetadata (no error) when the file lacks position metadata (older baselines).
+func ReadParquetMetadata(path string) (DumpMetadata, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return DumpMetadata{}, fmt.Errorf("open baseline file: %w", err)
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return DumpMetadata{}, fmt.Errorf("stat baseline file: %w", err)
+	}
+
+	pf, err := parquet.OpenFile(f, info.Size())
+	if err != nil {
+		return DumpMetadata{}, fmt.Errorf("open parquet file: %w", err)
+	}
+
+	var m DumpMetadata
+	if v, ok := pf.Lookup(MetaKeyBinlogFile); ok {
+		m.BinlogFile = v
+	}
+	if v, ok := pf.Lookup(MetaKeyBinlogPos); ok {
+		m.BinlogPos, _ = strconv.ParseInt(v, 10, 64)
+	}
+	if v, ok := pf.Lookup(MetaKeyGTIDSet); ok {
+		m.GTIDSet = v
 	}
 	return m, nil
 }

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -318,14 +318,26 @@ func LoadStreamState(ctx context.Context, db *sql.DB) (*StreamStateInfo, error) 
 	return &s, nil
 }
 
+// BaselineInfo holds metadata about a discovered baseline Parquet file.
+// Populated externally (from baseline.DiscoverBaselines) and attached to StatusData.
+type BaselineInfo struct {
+	SnapshotTime time.Time
+	Database     string
+	Table        string
+	BinlogFile   string
+	BinlogPos    int64
+	GTIDSet      string
+}
+
 // StatusData holds all data sections loaded by CollectStatus.
 type StatusData struct {
-	Files    []IndexStateRow
-	Parts    []PartitionStat
-	Archives *ArchiveStats
-	Coverage *CoverageInfo
-	Servers  []ServerInfo
-	Stream   *StreamStateInfo
+	Files     []IndexStateRow
+	Parts     []PartitionStat
+	Archives  *ArchiveStats
+	Coverage  *CoverageInfo
+	Servers   []ServerInfo
+	Stream    *StreamStateInfo
+	Baselines []BaselineInfo
 }
 
 // CollectStatus loads all status data from the index database.
@@ -375,11 +387,12 @@ func CollectStatus(ctx context.Context, db *sql.DB, dbName string) (*StatusData,
 // Write writes the status data as a human-readable report to w.
 func (d *StatusData) Write(w io.Writer) {
 	WriteStatus(w, d.Files, d.Parts, d.Archives, d.Coverage, d.Servers, d.Stream)
+	writeBaselines(w, d.Baselines)
 }
 
 // WriteJSON writes the status data as JSON to w.
 func (d *StatusData) WriteJSON(w io.Writer) error {
-	return WriteStatusJSON(w, d.Files, d.Parts, d.Archives, d.Coverage, d.Servers, d.Stream)
+	return writeStatusJSONFull(w, d.Files, d.Parts, d.Archives, d.Coverage, d.Servers, d.Stream, d.Baselines)
 }
 
 // WriteStatus writes a multi-section status report (Servers, Stream, Indexed Files, Partitions, Archives, Coverage, Summary) to w.
@@ -611,6 +624,10 @@ func Truncate(s string, n int) string {
 
 // WriteStatusJSON writes the status data as a JSON object to w.
 func WriteStatusJSON(w io.Writer, files []IndexStateRow, parts []PartitionStat, archives *ArchiveStats, coverage *CoverageInfo, servers []ServerInfo, stream *StreamStateInfo) error {
+	return writeStatusJSONFull(w, files, parts, archives, coverage, servers, stream, nil)
+}
+
+func writeStatusJSONFull(w io.Writer, files []IndexStateRow, parts []PartitionStat, archives *ArchiveStats, coverage *CoverageInfo, servers []ServerInfo, stream *StreamStateInfo, baselines []BaselineInfo) error {
 	type jsonFile struct {
 		BinlogFile    string  `json:"binlog_file"`
 		Status        string  `json:"status"`
@@ -666,14 +683,23 @@ func WriteStatusJSON(w io.Writer, files []IndexStateRow, parts []PartitionStat, 
 		LastCheckpoint string  `json:"last_checkpoint"`
 		ServerID       uint32  `json:"server_id"`
 	}
+	type jsonBaseline struct {
+		SnapshotTime string  `json:"snapshot_time"`
+		Database     string  `json:"database"`
+		Table        string  `json:"table"`
+		BinlogFile   *string `json:"binlog_file,omitempty"`
+		BinlogPos    *int64  `json:"binlog_position,omitempty"`
+		GTIDSet      *string `json:"gtid_set,omitempty"`
+	}
 	type jsonSummary struct {
-		Servers  []jsonServer    `json:"servers,omitempty"`
-		Stream   *jsonStream     `json:"stream,omitempty"`
-		Files    []jsonFile      `json:"files"`
-		Parts    []jsonPartition `json:"partitions"`
-		Total    int64           `json:"total_events_estimate"`
-		Archives *jsonArchives   `json:"archives,omitempty"`
-		Coverage *jsonCoverage   `json:"coverage,omitempty"`
+		Servers   []jsonServer    `json:"servers,omitempty"`
+		Stream    *jsonStream     `json:"stream,omitempty"`
+		Files     []jsonFile      `json:"files"`
+		Parts     []jsonPartition `json:"partitions"`
+		Total     int64           `json:"total_events_estimate"`
+		Archives  *jsonArchives   `json:"archives,omitempty"`
+		Coverage  *jsonCoverage   `json:"coverage,omitempty"`
+		Baselines []jsonBaseline  `json:"baselines,omitempty"`
 	}
 
 	jf := make([]jsonFile, len(files))
@@ -789,7 +815,56 @@ func WriteStatusJSON(w io.Writer, files []IndexStateRow, parts []PartitionStat, 
 		out.Coverage = jc
 	}
 
+	for _, b := range baselines {
+		jb := jsonBaseline{
+			SnapshotTime: b.SnapshotTime.Format(TSFmt),
+			Database:     b.Database,
+			Table:        b.Table,
+		}
+		if b.BinlogFile != "" {
+			jb.BinlogFile = &b.BinlogFile
+		}
+		if b.BinlogPos != 0 {
+			jb.BinlogPos = &b.BinlogPos
+		}
+		if b.GTIDSet != "" {
+			jb.GTIDSet = &b.GTIDSet
+		}
+		out.Baselines = append(out.Baselines, jb)
+	}
+
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	return enc.Encode(out)
+}
+
+// writeBaselines writes the baselines section to a text status report.
+func writeBaselines(w io.Writer, baselines []BaselineInfo) {
+	if len(baselines) == 0 {
+		return
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "=== Baselines ===")
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "SNAPSHOT\tDATABASE\tTABLE\tBINLOG_FILE\tBINLOG_POS\tGTID")
+	fmt.Fprintln(tw, "────────\t────────\t─────\t───────────\t──────────\t────")
+	for _, b := range baselines {
+		binlogFile := "-"
+		if b.BinlogFile != "" {
+			binlogFile = b.BinlogFile
+		}
+		binlogPos := "-"
+		if b.BinlogPos != 0 {
+			binlogPos = strconv.FormatInt(b.BinlogPos, 10)
+		}
+		gtid := "-"
+		if b.GTIDSet != "" {
+			gtid = Truncate(b.GTIDSet, 40)
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			b.SnapshotTime.Format(TSFmt),
+			b.Database, b.Table,
+			binlogFile, binlogPos, gtid)
+	}
+	tw.Flush()
 }

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -318,17 +318,6 @@ func LoadStreamState(ctx context.Context, db *sql.DB) (*StreamStateInfo, error) 
 	return &s, nil
 }
 
-// BaselineInfo holds metadata about a discovered baseline Parquet file.
-// Populated externally (from baseline.DiscoverBaselines) and attached to StatusData.
-type BaselineInfo struct {
-	SnapshotTime time.Time
-	Database     string
-	Table        string
-	BinlogFile   string
-	BinlogPos    int64
-	GTIDSet      string
-}
-
 // StatusData holds all data sections loaded by CollectStatus.
 type StatusData struct {
 	Files     []IndexStateRow
@@ -338,6 +327,18 @@ type StatusData struct {
 	Servers   []ServerInfo
 	Stream    *StreamStateInfo
 	Baselines []BaselineInfo
+}
+
+// BaselineInfo holds metadata about a discovered baseline Parquet file.
+// Populated externally (from baseline.DiscoverBaselines) and attached to StatusData.
+type BaselineInfo struct {
+	SnapshotTime time.Time
+	Database     string
+	Table        string
+	BinlogFile   string
+	BinlogPos    int64
+	GTIDSet      string
+	Path         string // filesystem path; ignored by display/JSON output
 }
 
 // CollectStatus loads all status data from the index database.


### PR DESCRIPTION
## Summary

Closes #166.

- Baseline Parquet files now include `bintrail.baseline_binlog_file`, `bintrail.baseline_binlog_position`, and `bintrail.baseline_gtid_set` in file-level key-value metadata
- `bintrail reconstruct` reads the baseline's binlog position and warns when a gap exists between it and the first indexed event
- `bintrail status --baseline-dir <dir>` discovers baselines and displays their binlog positions alongside index coverage
- Older baselines without position metadata are handled gracefully (validation skipped, no error)

## Test plan

- [x] `TestRun` verifies the 3 new metadata keys are written to Parquet output
- [x] `TestReadParquetMetadata` round-trips metadata through write → read
- [x] `TestReadParquetMetadata_noPosition` confirms graceful handling of old baselines
- [x] `TestRunWithTimestampOverride` still passes (best-effort metadata when no metadata file)
- [x] All existing reconstruct flag validation tests pass
- [x] Full unit suite passes (`go test ./... -count=1` — 21 packages)