### PR TITLE
Prevent partition drop when S3 upload is pending

### DIFF
--- a/cmd/bintrail/rotate.go
+++ b/cmd/bintrail/rotate.go
@@ -334,6 +334,11 @@ func performRotation(ctx context.Context, db *sql.DB, dbName string, retainDur t
 
 						if !skipUpload {
 							if err := uploadFileFunc(ctx, s3Client, outPath, s3Bucket, s3Key); err != nil {
+								// Propagate context cancellation (e.g. SIGINT in daemon mode)
+								// instead of logging a misleading S3 warning for every remaining partition.
+								if ctx.Err() != nil {
+									return 0, 0, fmt.Errorf("upload %s to S3: %w", name, err)
+								}
 								slog.Warn("S3 upload failed; partition will not be dropped",
 									"partition", name, "error", err)
 								if rotFormat != "json" {
@@ -465,10 +470,11 @@ var uploadFileFunc = uploadFile
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-// hasPendingS3Upload reports whether archive_state records an S3 destination
-// for the given partition that has not yet been uploaded (s3_uploaded_at IS NULL).
-// When bintrailID is empty, it checks across all bintrail_ids for that partition.
-// Returns false if no archive_state row exists or if the row has no S3 bucket.
+// hasPendingS3Upload reports whether archive_state records a non-empty S3
+// destination (s3_bucket) for the given partition that has not yet been uploaded
+// (s3_uploaded_at IS NULL). When bintrailID is empty, it checks across all
+// bintrail_ids for that partition. Returns false if no archive_state row exists
+// or if the row has no S3 bucket (NULL or empty).
 func hasPendingS3Upload(ctx context.Context, db *sql.DB, partition, bintrailID string) (bool, error) {
 	var pending bool
 	var err error

--- a/cmd/bintrail/rotate.go
+++ b/cmd/bintrail/rotate.go
@@ -269,22 +269,43 @@ func performRotation(ctx context.Context, db *sql.DB, dbName string, retainDur t
 						}
 					}
 
+					// Compute S3 key early so we can record the upload intent
+					// in archive_state before the actual upload.
+					var s3Key string
+					if s3Client != nil {
+						s3Key, err = buildS3Key(rotArchiveDir, outPath, s3Prefix)
+						if err != nil {
+							return 0, 0, fmt.Errorf("build S3 key for %s: %w", name, err)
+						}
+					}
+
 					// Record archive in archive_state (skip when retrying —
 					// the row already exists with the correct row_count).
+					// When S3 is configured, s3_bucket and s3_key are recorded
+					// immediately so that future runs (even without --archive-s3)
+					// know that an S3 upload is expected before the partition can
+					// be dropped.
 					if !skipped {
 						var fileSize int64
 						if fi, statErr := os.Stat(outPath); statErr == nil {
 							fileSize = fi.Size()
 						}
+						var insertBucket, insertKey any
+						if s3Client != nil {
+							insertBucket = s3Bucket
+							insertKey = s3Key
+						}
 						if _, err := db.ExecContext(ctx,
 							`INSERT INTO archive_state
-								(partition_name, bintrail_id, local_path, file_size_bytes, row_count)
-							VALUES (?, ?, ?, ?, ?)
+								(partition_name, bintrail_id, local_path, file_size_bytes, row_count, s3_bucket, s3_key)
+							VALUES (?, ?, ?, ?, ?, ?, ?)
 							ON DUPLICATE KEY UPDATE
 								local_path = VALUES(local_path),
 								file_size_bytes = VALUES(file_size_bytes),
-								row_count = VALUES(row_count)`,
-							name, rotBintrailID, outPath, fileSize, n,
+								row_count = VALUES(row_count),
+								s3_bucket = COALESCE(VALUES(s3_bucket), s3_bucket),
+								s3_key = COALESCE(VALUES(s3_key), s3_key)`,
+							name, rotBintrailID, outPath, fileSize, n, insertBucket, insertKey,
 						); err != nil {
 							return 0, 0, fmt.Errorf("record archive state for %s: %w", name, err)
 						}
@@ -312,32 +333,51 @@ func performRotation(ctx context.Context, db *sql.DB, dbName string, retainDur t
 						}
 
 						if !skipUpload {
-							key, err := buildS3Key(rotArchiveDir, outPath, s3Prefix)
-							if err != nil {
-								return 0, 0, fmt.Errorf("build S3 key for %s: %w", name, err)
-							}
-							if err := uploadFile(ctx, s3Client, outPath, s3Bucket, key); err != nil {
-								return 0, 0, fmt.Errorf("upload %s to S3: %w", name, err)
+							if err := uploadFileFunc(ctx, s3Client, outPath, s3Bucket, s3Key); err != nil {
+								slog.Warn("S3 upload failed; partition will not be dropped",
+									"partition", name, "error", err)
+								if rotFormat != "json" {
+									fmt.Fprintf(os.Stdout, "warning: S3 upload failed for %s: %v\n", name, err)
+									fmt.Fprintf(os.Stdout, "  run 'bintrail rotate --retry --archive-s3 ...' to retry\n")
+								}
+								continue
 							}
 							if _, err := db.ExecContext(ctx,
 								`UPDATE archive_state
 									SET s3_bucket = ?, s3_key = ?, s3_uploaded_at = UTC_TIMESTAMP()
 								WHERE partition_name = ? AND bintrail_id = ?`,
-								s3Bucket, key, name, rotBintrailID,
+								s3Bucket, s3Key, name, rotBintrailID,
 							); err != nil {
 								return 0, 0, fmt.Errorf("update archive state S3 info for %s: %w", name, err)
 							}
-							slog.Info("uploaded archive to S3", "partition", name, "bucket", s3Bucket, "key", key)
+							slog.Info("uploaded archive to S3", "partition", name, "bucket", s3Bucket, "key", s3Key)
 							if rotFormat != "json" {
-								fmt.Fprintf(os.Stdout, "uploaded %s → s3://%s/%s\n", name, s3Bucket, key)
+								fmt.Fprintf(os.Stdout, "uploaded %s → s3://%s/%s\n", name, s3Bucket, s3Key)
 							}
 						}
+					}
+
+					// Safety check: never drop a partition that has a pending S3 upload,
+					// even if the current run does not have --archive-s3 configured.
+					pending, err := hasPendingS3Upload(ctx, db, name, rotBintrailID)
+					if err != nil {
+						return 0, 0, fmt.Errorf("check pending S3 upload for %s: %w", name, err)
+					}
+					if pending {
+						slog.Warn("partition archived locally but not yet uploaded to S3; skipping drop",
+							"partition", name)
+						if rotFormat != "json" {
+							fmt.Fprintf(os.Stdout, "skipped drop for %s (pending S3 upload)\n", name)
+							fmt.Fprintf(os.Stdout, "  run 'bintrail rotate --retry --archive-s3 ...' to retry\n")
+						}
+						continue
 					}
 
 					// Drop this partition immediately after archiving.
 					if err := dropPartitions(ctx, db, dbName, []string{name}); err != nil {
 						return 0, 0, fmt.Errorf("failed to drop partition %s: %w", name, err)
 					}
+					droppedCount++
 					slog.Info("dropped partition", "partition", name)
 					if rotFormat != "json" {
 						fmt.Fprintf(os.Stdout, "dropped partition %s\n", name)
@@ -345,16 +385,36 @@ func performRotation(ctx context.Context, db *sql.DB, dbName string, retainDur t
 				}
 			} else {
 				// No archiving — drop all expired partitions at once.
-				if err := dropPartitions(ctx, db, dbName, toDrop); err != nil {
-					return 0, 0, fmt.Errorf("failed to drop partitions: %w", err)
-				}
+				// Filter out any partition that has a pending S3 upload from
+				// a previous archived rotation run.
+				var safeToDrop []string
 				for _, name := range toDrop {
+					pending, err := hasPendingS3Upload(ctx, db, name, rotBintrailID)
+					if err != nil {
+						return 0, 0, fmt.Errorf("check pending S3 upload for %s: %w", name, err)
+					}
+					if pending {
+						slog.Warn("partition has pending S3 upload from a previous run; skipping drop",
+							"partition", name)
+						if rotFormat != "json" {
+							fmt.Fprintf(os.Stdout, "skipped drop for %s (pending S3 upload)\n", name)
+						}
+						continue
+					}
+					safeToDrop = append(safeToDrop, name)
+				}
+				if len(safeToDrop) > 0 {
+					if err := dropPartitions(ctx, db, dbName, safeToDrop); err != nil {
+						return 0, 0, fmt.Errorf("failed to drop partitions: %w", err)
+					}
+				}
+				for _, name := range safeToDrop {
 					if rotFormat != "json" {
 						fmt.Fprintf(os.Stdout, "dropped partition %s\n", name)
 					}
 				}
+				droppedCount = len(safeToDrop)
 			}
-			droppedCount = len(toDrop)
 			// Refresh list so nextPartitionStart sees current state.
 			partitions, err = listPartitions(ctx, db, dbName)
 			if err != nil {
@@ -399,7 +459,41 @@ func performRotation(ctx context.Context, db *sql.DB, dbName string, retainDur t
 	return droppedCount, toAdd, nil
 }
 
+// uploadFileFunc is the function used to upload a file to S3. It defaults to
+// uploadFile and can be overridden in tests to simulate S3 failures.
+var uploadFileFunc = uploadFile
+
 // ─── Helpers ─────────────────────────────────────────────────────────────────
+
+// hasPendingS3Upload reports whether archive_state records an S3 destination
+// for the given partition that has not yet been uploaded (s3_uploaded_at IS NULL).
+// When bintrailID is empty, it checks across all bintrail_ids for that partition.
+// Returns false if no archive_state row exists or if the row has no S3 bucket.
+func hasPendingS3Upload(ctx context.Context, db *sql.DB, partition, bintrailID string) (bool, error) {
+	var pending bool
+	var err error
+	if bintrailID != "" {
+		err = db.QueryRowContext(ctx,
+			`SELECT COUNT(*) > 0 FROM archive_state
+			WHERE partition_name = ? AND bintrail_id = ?
+			  AND s3_bucket IS NOT NULL AND s3_bucket != ''
+			  AND s3_uploaded_at IS NULL`,
+			partition, bintrailID,
+		).Scan(&pending)
+	} else {
+		err = db.QueryRowContext(ctx,
+			`SELECT COUNT(*) > 0 FROM archive_state
+			WHERE partition_name = ?
+			  AND s3_bucket IS NOT NULL AND s3_bucket != ''
+			  AND s3_uploaded_at IS NULL`,
+			partition,
+		).Scan(&pending)
+	}
+	if err != nil {
+		return false, err
+	}
+	return pending, nil
+}
 
 // fileExists reports whether a file exists and has a size greater than zero.
 func fileExists(path string) bool {

--- a/cmd/bintrail/rotate_integration_test.go
+++ b/cmd/bintrail/rotate_integration_test.go
@@ -11,8 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/service/s3"
-
 	"github.com/dbtrail/bintrail/internal/testutil"
 )
 
@@ -131,7 +129,17 @@ func setupPartitionedTable(t *testing.T, db *sql.DB, dbName string, hours []time
 	))
 }
 
-func TestPerformRotation_S3FailureSkipsDropContinuesLoop(t *testing.T) {
+// TestPerformRotation_PendingS3BlocksDrop verifies that when a previous
+// rotation run recorded S3 upload intent (s3_bucket set) but the upload
+// did not complete (s3_uploaded_at NULL), a subsequent rotation run — even
+// without --archive-s3 — refuses to drop that partition.
+//
+// Note: the S3-upload-failure continue path (uploadFileFunc returning an error)
+// is not directly integration-tested here because performRotation creates its
+// own S3 client internally from --archive-s3 flags. The safety check tested
+// here is the defense-in-depth layer that catches any scenario where the
+// partition reaches the drop step with a pending upload.
+func TestPerformRotation_PendingS3BlocksDrop(t *testing.T) {
 	db, dbName := testutil.CreateTestDB(t)
 	testutil.InitIndexTables(t, db)
 
@@ -146,7 +154,9 @@ func TestPerformRotation_S3FailureSkipsDropContinuesLoop(t *testing.T) {
 	testutil.InsertEvent(t, db, "binlog.000001", 100, 200, ts1, nil, "testdb", "users", 1, "1", nil, nil, []byte(`{"id":1}`))
 	testutil.InsertEvent(t, db, "binlog.000001", 200, 300, ts2, nil, "testdb", "users", 1, "2", nil, nil, []byte(`{"id":2}`))
 
-	// Set up flags for archiving with S3.
+	// Pre-archive: create local Parquet files and archive_state rows
+	// simulating a previous run where S3 upload failed for h1 but
+	// succeeded for h2.
 	archiveDir := t.TempDir()
 	savedVars := saveRotateVars()
 	t.Cleanup(func() { restoreRotateVars(savedVars) })
@@ -154,40 +164,9 @@ func TestPerformRotation_S3FailureSkipsDropContinuesLoop(t *testing.T) {
 	rotArchiveDir = archiveDir
 	rotBintrailID = "test-uuid-167"
 	rotArchiveCompression = "none"
-	rotArchiveS3 = "s3://fake-bucket/archives/"
 	rotFormat = "text"
-	rotRetry = false
 	rotNoReplace = true
 	rotAddFuture = 0
-
-	// Mock uploadFile to fail on first call, succeed on second.
-	callCount := 0
-	saved := uploadFileFunc
-	t.Cleanup(func() { uploadFileFunc = saved })
-	uploadFileFunc = func(ctx context.Context, client *s3.Client, path, bucket, key string) error {
-		callCount++
-		if callCount == 1 {
-			return fmt.Errorf("simulated S3 failure")
-		}
-		return nil
-	}
-
-	// Create a dummy S3 client (won't actually be used since we mock uploadFileFunc).
-	var dummyS3 s3.Client
-
-	// Manually call the inner loop section. We need to do this at a lower level
-	// since performRotation creates its own S3 client from flags.
-	// Instead, let's test via performRotation with the mocked uploadFileFunc.
-	// The S3 client is created inside performRotation from rotArchiveS3.
-	// Since we can't inject a real S3 client, we'll test differently:
-	// We verify the hasPendingS3Upload safety check works by pre-populating
-	// archive_state and running performRotation without --archive-s3.
-	_ = dummyS3
-
-	// Reset the mock approach — test the safety check path instead.
-	// Pre-archive: create local Parquet files and archive_state rows with
-	// pending S3 upload (s3_bucket set, s3_uploaded_at NULL).
-	uploadFileFunc = saved // restore original
 
 	outPath1, _ := hiveArchivePath(archiveDir, rotBintrailID, partitionName(h1))
 	outPath2, _ := hiveArchivePath(archiveDir, rotBintrailID, partitionName(h2))

--- a/cmd/bintrail/rotate_integration_test.go
+++ b/cmd/bintrail/rotate_integration_test.go
@@ -1,0 +1,383 @@
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+
+	"github.com/dbtrail/bintrail/internal/testutil"
+)
+
+// ─── hasPendingS3Upload ──────────────────────────────────────────────────────
+
+func TestHasPendingS3Upload_noRow(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	pending, err := hasPendingS3Upload(context.Background(), db, "p_2026030100", "test-uuid")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pending {
+		t.Error("expected false when no archive_state row exists")
+	}
+}
+
+func TestHasPendingS3Upload_localOnly(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	// Row exists but s3_bucket is NULL — no S3 intent recorded.
+	testutil.MustExec(t, db, `INSERT INTO archive_state
+		(partition_name, bintrail_id, local_path, row_count)
+		VALUES ('p_2026030100', 'test-uuid', '/data/test.parquet', 42)`)
+
+	pending, err := hasPendingS3Upload(context.Background(), db, "p_2026030100", "test-uuid")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pending {
+		t.Error("expected false when s3_bucket is NULL (no S3 intent)")
+	}
+}
+
+func TestHasPendingS3Upload_pendingUpload(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	// Row with s3_bucket set but s3_uploaded_at NULL — pending upload.
+	testutil.MustExec(t, db, `INSERT INTO archive_state
+		(partition_name, bintrail_id, local_path, row_count, s3_bucket, s3_key)
+		VALUES ('p_2026030100', 'test-uuid', '/data/test.parquet', 42, 'my-bucket', 'archives/test.parquet')`)
+
+	pending, err := hasPendingS3Upload(context.Background(), db, "p_2026030100", "test-uuid")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !pending {
+		t.Error("expected true when s3_bucket is set but s3_uploaded_at is NULL")
+	}
+}
+
+func TestHasPendingS3Upload_completed(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	// Row with s3_uploaded_at set — upload complete.
+	testutil.MustExec(t, db, `INSERT INTO archive_state
+		(partition_name, bintrail_id, local_path, row_count, s3_bucket, s3_key, s3_uploaded_at)
+		VALUES ('p_2026030100', 'test-uuid', '/data/test.parquet', 42, 'my-bucket', 'archives/test.parquet', UTC_TIMESTAMP())`)
+
+	pending, err := hasPendingS3Upload(context.Background(), db, "p_2026030100", "test-uuid")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pending {
+		t.Error("expected false when s3_uploaded_at is set")
+	}
+}
+
+func TestHasPendingS3Upload_emptyBintrailID(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	// Row with a specific bintrail_id but query uses empty string — should still detect.
+	testutil.MustExec(t, db, `INSERT INTO archive_state
+		(partition_name, bintrail_id, local_path, row_count, s3_bucket, s3_key)
+		VALUES ('p_2026030100', 'some-uuid', '/data/test.parquet', 42, 'my-bucket', 'archives/test.parquet')`)
+
+	pending, err := hasPendingS3Upload(context.Background(), db, "p_2026030100", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !pending {
+		t.Error("expected true when bintrailID is empty and any row has pending S3")
+	}
+}
+
+// ─── performRotation S3 safety ───────────────────────────────────────────────
+
+// setupPartitionedTable creates partitions that cover the given hours so we can
+// insert test data and then rotate them away.
+func setupPartitionedTable(t *testing.T, db *sql.DB, dbName string, hours []time.Time) {
+	t.Helper()
+	// Drop existing partitioning and recreate with specific partitions.
+	// First, drop all non-future partitions by reorganizing.
+	parts := ""
+	for i, h := range hours {
+		nextHour := h.Add(time.Hour)
+		if i > 0 {
+			parts += ",\n"
+		}
+		parts += fmt.Sprintf(
+			"PARTITION %s VALUES LESS THAN (TO_SECONDS('%s'))",
+			partitionName(h),
+			nextHour.UTC().Format("2006-01-02 15:04:05"),
+		)
+	}
+	parts += ",\nPARTITION p_future VALUES LESS THAN MAXVALUE"
+
+	testutil.MustExec(t, db, fmt.Sprintf(
+		"ALTER TABLE `%s`.`binlog_events` REORGANIZE PARTITION p_future INTO (\n%s\n)",
+		dbName, parts,
+	))
+}
+
+func TestPerformRotation_S3FailureSkipsDropContinuesLoop(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	// Create two old partitions.
+	h1 := time.Now().UTC().Add(-48 * time.Hour).Truncate(time.Hour)
+	h2 := h1.Add(time.Hour)
+	setupPartitionedTable(t, db, dbName, []time.Time{h1, h2})
+
+	// Insert a row into each partition so archiving has data.
+	ts1 := h1.Add(30 * time.Minute).Format("2006-01-02 15:04:05")
+	ts2 := h2.Add(30 * time.Minute).Format("2006-01-02 15:04:05")
+	testutil.InsertEvent(t, db, "binlog.000001", 100, 200, ts1, nil, "testdb", "users", 1, "1", nil, nil, []byte(`{"id":1}`))
+	testutil.InsertEvent(t, db, "binlog.000001", 200, 300, ts2, nil, "testdb", "users", 1, "2", nil, nil, []byte(`{"id":2}`))
+
+	// Set up flags for archiving with S3.
+	archiveDir := t.TempDir()
+	savedVars := saveRotateVars()
+	t.Cleanup(func() { restoreRotateVars(savedVars) })
+
+	rotArchiveDir = archiveDir
+	rotBintrailID = "test-uuid-167"
+	rotArchiveCompression = "none"
+	rotArchiveS3 = "s3://fake-bucket/archives/"
+	rotFormat = "text"
+	rotRetry = false
+	rotNoReplace = true
+	rotAddFuture = 0
+
+	// Mock uploadFile to fail on first call, succeed on second.
+	callCount := 0
+	saved := uploadFileFunc
+	t.Cleanup(func() { uploadFileFunc = saved })
+	uploadFileFunc = func(ctx context.Context, client *s3.Client, path, bucket, key string) error {
+		callCount++
+		if callCount == 1 {
+			return fmt.Errorf("simulated S3 failure")
+		}
+		return nil
+	}
+
+	// Create a dummy S3 client (won't actually be used since we mock uploadFileFunc).
+	var dummyS3 s3.Client
+
+	// Manually call the inner loop section. We need to do this at a lower level
+	// since performRotation creates its own S3 client from flags.
+	// Instead, let's test via performRotation with the mocked uploadFileFunc.
+	// The S3 client is created inside performRotation from rotArchiveS3.
+	// Since we can't inject a real S3 client, we'll test differently:
+	// We verify the hasPendingS3Upload safety check works by pre-populating
+	// archive_state and running performRotation without --archive-s3.
+	_ = dummyS3
+
+	// Reset the mock approach — test the safety check path instead.
+	// Pre-archive: create local Parquet files and archive_state rows with
+	// pending S3 upload (s3_bucket set, s3_uploaded_at NULL).
+	uploadFileFunc = saved // restore original
+
+	outPath1, _ := hiveArchivePath(archiveDir, rotBintrailID, partitionName(h1))
+	outPath2, _ := hiveArchivePath(archiveDir, rotBintrailID, partitionName(h2))
+	os.MkdirAll(filepath.Dir(outPath1), 0o755)
+	os.MkdirAll(filepath.Dir(outPath2), 0o755)
+	os.WriteFile(outPath1, []byte("parquet-data"), 0o644)
+	os.WriteFile(outPath2, []byte("parquet-data"), 0o644)
+
+	// Insert archive_state: first partition has pending S3, second is complete.
+	testutil.MustExec(t, db, `INSERT INTO archive_state
+		(partition_name, bintrail_id, local_path, row_count, s3_bucket, s3_key)
+		VALUES (?, ?, ?, 1, 'my-bucket', 'archives/p1.parquet')`,
+		partitionName(h1), rotBintrailID, outPath1)
+	testutil.MustExec(t, db, `INSERT INTO archive_state
+		(partition_name, bintrail_id, local_path, row_count, s3_bucket, s3_key, s3_uploaded_at)
+		VALUES (?, ?, ?, 1, 'my-bucket', 'archives/p2.parquet', UTC_TIMESTAMP())`,
+		partitionName(h2), rotBintrailID, outPath2)
+
+	// Run rotation WITHOUT --archive-s3, WITH --retry (so it skips re-archiving).
+	rotArchiveS3 = ""
+	rotRetry = true
+
+	dropped, _, err := performRotation(context.Background(), db, dbName, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("performRotation failed: %v", err)
+	}
+
+	// First partition should NOT be dropped (pending S3 upload).
+	// Second partition should be dropped (S3 upload complete).
+	if dropped != 1 {
+		t.Errorf("expected 1 partition dropped, got %d", dropped)
+	}
+
+	// Verify partition h1 still exists.
+	partitions, err := listPartitions(context.Background(), db, dbName)
+	if err != nil {
+		t.Fatalf("listPartitions: %v", err)
+	}
+	p1Name := partitionName(h1)
+	p2Name := partitionName(h2)
+	var foundP1, foundP2 bool
+	for _, p := range partitions {
+		if p.Name == p1Name {
+			foundP1 = true
+		}
+		if p.Name == p2Name {
+			foundP2 = true
+		}
+	}
+	if !foundP1 {
+		t.Errorf("partition %s should NOT have been dropped (pending S3 upload)", p1Name)
+	}
+	if foundP2 {
+		t.Errorf("partition %s should have been dropped (S3 upload complete)", p2Name)
+	}
+}
+
+func TestPerformRotation_NoPendingS3DropsAll(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	// Create two old partitions.
+	h1 := time.Now().UTC().Add(-48 * time.Hour).Truncate(time.Hour)
+	h2 := h1.Add(time.Hour)
+	setupPartitionedTable(t, db, dbName, []time.Time{h1, h2})
+
+	ts1 := h1.Add(30 * time.Minute).Format("2006-01-02 15:04:05")
+	ts2 := h2.Add(30 * time.Minute).Format("2006-01-02 15:04:05")
+	testutil.InsertEvent(t, db, "binlog.000001", 100, 200, ts1, nil, "testdb", "users", 1, "1", nil, nil, []byte(`{"id":1}`))
+	testutil.InsertEvent(t, db, "binlog.000001", 200, 300, ts2, nil, "testdb", "users", 1, "2", nil, nil, []byte(`{"id":2}`))
+
+	savedVars := saveRotateVars()
+	t.Cleanup(func() { restoreRotateVars(savedVars) })
+
+	rotArchiveDir = ""
+	rotBintrailID = ""
+	rotArchiveS3 = ""
+	rotFormat = "text"
+	rotRetry = false
+	rotNoReplace = true
+	rotAddFuture = 0
+
+	// No archive_state rows at all — partitions should be dropped freely.
+	dropped, _, err := performRotation(context.Background(), db, dbName, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("performRotation failed: %v", err)
+	}
+	if dropped != 2 {
+		t.Errorf("expected 2 partitions dropped, got %d", dropped)
+	}
+}
+
+func TestPerformRotation_BulkDropSkipsPendingS3(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	// Create two old partitions.
+	h1 := time.Now().UTC().Add(-48 * time.Hour).Truncate(time.Hour)
+	h2 := h1.Add(time.Hour)
+	setupPartitionedTable(t, db, dbName, []time.Time{h1, h2})
+
+	ts1 := h1.Add(30 * time.Minute).Format("2006-01-02 15:04:05")
+	ts2 := h2.Add(30 * time.Minute).Format("2006-01-02 15:04:05")
+	testutil.InsertEvent(t, db, "binlog.000001", 100, 200, ts1, nil, "testdb", "users", 1, "1", nil, nil, []byte(`{"id":1}`))
+	testutil.InsertEvent(t, db, "binlog.000001", 200, 300, ts2, nil, "testdb", "users", 1, "2", nil, nil, []byte(`{"id":2}`))
+
+	// Insert archive_state with pending S3 for h1 only.
+	testutil.MustExec(t, db, `INSERT INTO archive_state
+		(partition_name, bintrail_id, local_path, row_count, s3_bucket, s3_key)
+		VALUES (?, 'prev-uuid', '/data/test.parquet', 1, 'my-bucket', 'archives/p1.parquet')`,
+		partitionName(h1))
+
+	savedVars := saveRotateVars()
+	t.Cleanup(func() { restoreRotateVars(savedVars) })
+
+	// No --archive-dir on this run (bulk-drop path).
+	rotArchiveDir = ""
+	rotBintrailID = ""
+	rotArchiveS3 = ""
+	rotFormat = "text"
+	rotRetry = false
+	rotNoReplace = true
+	rotAddFuture = 0
+
+	dropped, _, err := performRotation(context.Background(), db, dbName, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("performRotation failed: %v", err)
+	}
+
+	// h1 should be skipped (pending S3), h2 dropped.
+	if dropped != 1 {
+		t.Errorf("expected 1 partition dropped (h2 only), got %d", dropped)
+	}
+
+	partitions, err := listPartitions(context.Background(), db, dbName)
+	if err != nil {
+		t.Fatalf("listPartitions: %v", err)
+	}
+	p1Name := partitionName(h1)
+	var foundP1 bool
+	for _, p := range partitions {
+		if p.Name == p1Name {
+			foundP1 = true
+		}
+	}
+	if !foundP1 {
+		t.Errorf("partition %s should NOT have been dropped (pending S3 from previous run)", p1Name)
+	}
+}
+
+// ─── test helpers ────────────────────────────────────────────────────────────
+
+type rotateVarSnapshot struct {
+	indexDSN, retain, archiveDir, archiveCompression string
+	bintrailID, archiveS3, archiveS3Region          string
+	format, interval                                 string
+	addFuture                                        int
+	noReplace, daemon, retry                         bool
+}
+
+func saveRotateVars() rotateVarSnapshot {
+	return rotateVarSnapshot{
+		indexDSN:           rotIndexDSN,
+		retain:             rotRetain,
+		archiveDir:         rotArchiveDir,
+		archiveCompression: rotArchiveCompression,
+		bintrailID:         rotBintrailID,
+		archiveS3:          rotArchiveS3,
+		archiveS3Region:    rotArchiveS3Region,
+		format:             rotFormat,
+		interval:           rotInterval,
+		addFuture:          rotAddFuture,
+		noReplace:          rotNoReplace,
+		daemon:             rotDaemon,
+		retry:              rotRetry,
+	}
+}
+
+func restoreRotateVars(s rotateVarSnapshot) {
+	rotIndexDSN = s.indexDSN
+	rotRetain = s.retain
+	rotArchiveDir = s.archiveDir
+	rotArchiveCompression = s.archiveCompression
+	rotBintrailID = s.bintrailID
+	rotArchiveS3 = s.archiveS3
+	rotArchiveS3Region = s.archiveS3Region
+	rotFormat = s.format
+	rotInterval = s.interval
+	rotAddFuture = s.addFuture
+	rotNoReplace = s.noReplace
+	rotDaemon = s.daemon
+	rotRetry = s.retry
+}


### PR DESCRIPTION
## Summary

Closes #167.

- Record S3 upload intent (`s3_bucket`, `s3_key`) in `archive_state` at INSERT time so subsequent rotation runs — even without `--archive-s3` — know an upload is expected before the partition can be dropped
- Add `hasPendingS3Upload()` safety check before every `dropPartitions()` call (both per-partition archive path and bulk-drop path)
- Make S3 upload failure non-fatal per partition: log a warning, skip the drop, and continue processing remaining partitions (fixes daemon-mode blockage)
- Propagate context cancellation immediately on S3 upload failure instead of logging misleading warnings
- Fix `droppedCount` to reflect only partitions actually dropped

## Test plan

- [x] All existing unit tests pass (`go test ./cmd/bintrail/ -count=1`)
- [x] Full project unit suite passes (`go test ./... -count=1`)
- [x] `go vet` clean on both normal and integration builds
- [x] New integration tests pass (`go test -tags integration ./cmd/bintrail/ -run "TestHasPendingS3Upload|TestPerformRotation" -v`):
  - `TestHasPendingS3Upload_noRow` — no archive_state row → not pending
  - `TestHasPendingS3Upload_localOnly` — local-only archive → not pending
  - `TestHasPendingS3Upload_pendingUpload` — s3_bucket set, s3_uploaded_at NULL → pending
  - `TestHasPendingS3Upload_completed` — s3_uploaded_at set → not pending
  - `TestHasPendingS3Upload_emptyBintrailID` — wildcard bintrail_id lookup
  - `TestPerformRotation_PendingS3BlocksDrop` — pending S3 blocks drop, completed S3 allows drop
  - `TestPerformRotation_NoPendingS3DropsAll` — no archive_state → all partitions dropped normally
  - `TestPerformRotation_BulkDropSkipsPendingS3` — bulk-drop path respects pending S3 from previous run