### PR TITLE
Add size-based eviction to BYOS buffer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ Per-command `--format`: most commands accept `text`/`json` (`IsValidOutputFormat
 | `baseline` | `baseline.go` | `--input` (req), `--output` (req), `--timestamp`, `--tables`, `--compression`, `--row-group-size`, `--upload`, `--upload-region`, `--encrypt`, `--encrypt-key` |
 | `generate-key` | `generate_key.go` | `--output` (default `~/.config/bintrail/dump.key`) |
 | `upload` | `upload.go` | `--source` (req), `--destination` (req), `--region`, `--retry`, `--index-dsn` |
-| `agent` | `agent.go` | `--api-key` (req), `--endpoint` (req), `--index-dsn`, `--source-dsn`, `--archive-dir`, `--archive-s3`, `--server-id`, `--buffer-retain` (default `6h`), `--batch-size`, `--schemas`, `--tables`, `--start-gtid`, `--s3-bucket`, `--s3-region`, `--s3-prefix` (default `bintrail/`), `--flush-interval` (default `5s`), `--max-reconnect-attempts` (default `10`), `--validate` |
+| `agent` | `agent.go` | `--api-key` (req), `--endpoint` (req), `--index-dsn`, `--source-dsn`, `--archive-dir`, `--archive-s3`, `--server-id`, `--buffer-retain` (default `6h`), `--buffer-max-events` (default `0`), `--buffer-max-bytes` (default `0`), `--batch-size`, `--schemas`, `--tables`, `--start-gtid`, `--s3-bucket`, `--s3-region`, `--s3-prefix` (default `bintrail/`), `--flush-interval` (default `5s`), `--max-reconnect-attempts` (default `10`), `--validate` |
 | `config init` | `config.go` | `--global` |
 
 Flag variable naming: prefixed by command abbreviation (e.g. `idxIndexDSN`, `qSchema`, `rDryRun`, `rotRetain`, `strmIndexDSN`, `dmpSourceDSN`, `bslInput`, `uplSource`, `cfgGlobal`, `agtAPIKey`).
@@ -202,19 +202,21 @@ Use `mysql.ParseDSN(dsn)` from `github.com/go-sql-driver/mysql`. Do not use `SEL
 
 ### In-memory event buffer (BYOS)
 - `internal/buffer/buffer.go`: `Buffer` type — thread-safe in-memory event store using `sync.RWMutex`.
-- `New(maxAge, logger)` creates a buffer that evicts events older than `maxAge`.
-- `Insert([]parser.Event)` converts parser events to `query.ResultRow` and appends under write lock. Computes `pkHash = SHA-256(pk_values)` per event.
+- `New(Config)` creates a buffer. `Config` fields: `MaxAge` (age-based eviction), `MaxEvents` (event count cap, 0=unlimited), `MaxBytes` (approx byte cap, 0=unlimited), `Logger`.
+- `Insert([]parser.Event)` converts parser events to `query.ResultRow` and appends under write lock. Computes `pkHash = SHA-256(pk_values)` per event. After appending, enforces size limits via FIFO eviction from the front.
 - `Fetch(ctx, query.Options)` filters events by schema, table, pk_values, event_type, time range, changed_column, limit. Returns `[]query.ResultRow` compatible with `query.MergeResults`.
 - `ResolvePK(hash, schema, table)` scans for matching pk_hash — used by agent handler for `resolve_pk` commands.
 - `Evict()` removes events older than `maxAge` from the front of the slice.
+- `ApproxBytes()` returns approximate in-memory byte usage; `SizeEvictions()` returns cumulative size-evicted count.
 - Event IDs use `idOffset = 1<<32` to avoid collisions with MySQL event_ids in `MergeResults` dedup.
 - `internal/buffer/parquet.go`: `WriteParquet(rows, path, compression)` writes `[]query.ResultRow` to Parquet using `archive.BinlogEventColumns` schema — compatible with `parquetquery.Fetch`.
 - Agent handler (`internal/agent/handler.go`): `DefaultHandler.Buffer` field. Query order: buffer → MySQL → S3 archives.
 - Agent BYOS streaming (`cmd/bintrail/agent.go`): when `--source-dsn` + `--server-id` are set, agent starts a streaming goroutine (`runBYOSStream`) that reads binlogs and populates the buffer. The `byosStreamLoop` function handles batching, periodic eviction, and flush pipeline.
 - **BYOS flush pipeline** (wired in `byosStreamLoop`): when `--s3-bucket` is set, each batch is split via `SplitEvent`, metadata sent to dbtrail via `MetadataClient`, payload written to customer S3 via `PayloadWriter`. Flush triggers on batch-full or `--flush-interval` timer (default 5s). Retry: 3 attempts with exponential backoff (1s, 2s, 4s); failures are logged but never block the stream.
 - `flushPipelineState`: mutex-protected struct tracking flush health (metadata/payload status, last flush timestamps, buffer size). Exposed to heartbeat via `agent.Channel.statusProvider` callback.
-- `agent.Heartbeat` includes flush status fields: `buffer_events`, `metadata_status`, `payload_status`, `last_metadata_flush`, `last_payload_flush` (omitted when not in BYOS mode).
+- `agent.Heartbeat` includes flush status fields: `buffer_events`, `buffer_bytes`, `size_evictions`, `metadata_status`, `payload_status`, `last_metadata_flush`, `last_payload_flush` (omitted when not in BYOS mode).
 - Agent flags for BYOS flush: `--s3-bucket`, `--s3-region`, `--s3-prefix` (default `bintrail/`), `--flush-interval` (default `5s`).
+- Agent flags for buffer caps: `--buffer-max-events` (default 0=unlimited), `--buffer-max-bytes` (e.g. `256MB`, `1GB`, default 0=unlimited).
 
 ## Testing conventions
 

--- a/cmd/bintrail/agent.go
+++ b/cmd/bintrail/agent.go
@@ -76,6 +76,8 @@ var (
 	agtS3Region             string
 	agtS3Prefix             string
 	agtFlushInterval        string
+	agtBufferMaxEvents      int
+	agtBufferMaxBytes       string
 	agtValidate             bool
 	agtMaxReconnectAttempts int
 )
@@ -97,6 +99,8 @@ func init() {
 	agentCmd.Flags().StringVar(&agtS3Region, "s3-region", "", "AWS region for the S3 bucket")
 	agentCmd.Flags().StringVar(&agtS3Prefix, "s3-prefix", "bintrail/", "Key prefix within the S3 bucket")
 	agentCmd.Flags().StringVar(&agtFlushInterval, "flush-interval", "5s", "Max time between metadata/payload flushes (e.g. 5s, 10s)")
+	agentCmd.Flags().IntVar(&agtBufferMaxEvents, "buffer-max-events", 0, "Max events in the in-memory buffer (0 = unlimited)")
+	agentCmd.Flags().StringVar(&agtBufferMaxBytes, "buffer-max-bytes", "0", "Max approximate buffer size, e.g. 256MB, 1GB (0 = unlimited)")
 	agentCmd.Flags().BoolVar(&agtValidate, "validate", false, "Run pre-flight checks and exit without starting the agent")
 	agentCmd.Flags().IntVar(&agtMaxReconnectAttempts, "max-reconnect-attempts", 10, "Exit (non-zero) after this many consecutive WebSocket reconnect failures so a process supervisor (e.g. systemd Restart=on-failure) can respawn the agent. The counter resets whenever a connection stays up longer than the heartbeat interval, so transient drops on a healthy long-running agent never trip the limit. Use 0 for unlimited retries.")
 	_ = agentCmd.MarkFlagRequired("api-key")
@@ -238,8 +242,17 @@ func runAgent(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("invalid --buffer-retain: %w", err)
 		}
+		maxBytes, err := parseByteSize(agtBufferMaxBytes)
+		if err != nil {
+			return fmt.Errorf("invalid --buffer-max-bytes: %w", err)
+		}
 
-		buf := buffer.New(retain, slog.Default())
+		buf := buffer.New(buffer.Config{
+			MaxAge:    retain,
+			MaxEvents: agtBufferMaxEvents,
+			MaxBytes:  maxBytes,
+			Logger:    slog.Default(),
+		})
 		handler.Buffer = buf
 
 		// Use bintrail_id as the server identifier when available, falling
@@ -249,7 +262,9 @@ func runAgent(cmd *cobra.Command, args []string) error {
 		slog.Info("BYOS mode enabled",
 			"source_dsn", maskDSN(agtSourceDSN),
 			"server_id", serverIDStr,
-			"buffer_retain", retain.String())
+			"buffer_retain", retain.String(),
+			"buffer_max_events", agtBufferMaxEvents,
+			"buffer_max_bytes", agtBufferMaxBytes)
 
 		// Initialize flush sinks if S3 bucket is configured.
 		var metaClient *byos.MetadataClient
@@ -407,6 +422,8 @@ type byosFlushConfig struct {
 type flushPipelineState struct {
 	mu                sync.Mutex
 	bufferEvents      int
+	bufferBytes       int64
+	sizeEvictions     int64
 	metadataStatus    string // "ok" or "degraded"
 	payloadStatus     string // "ok" or "degraded"
 	lastMetadataFlush *time.Time
@@ -431,9 +448,11 @@ func (s *flushPipelineState) updateFlush(metaOK, payloadOK bool) {
 	}
 }
 
-func (s *flushPipelineState) setBufferLen(n int) {
+func (s *flushPipelineState) setBufferStats(events int, bytes int64, evictions int64) {
 	s.mu.Lock()
-	s.bufferEvents = n
+	s.bufferEvents = events
+	s.bufferBytes = bytes
+	s.sizeEvictions = evictions
 	s.mu.Unlock()
 }
 
@@ -441,8 +460,12 @@ func (s *flushPipelineState) toFlushStatus() *agent.FlushStatus {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	n := s.bufferEvents
+	b := s.bufferBytes
+	e := s.sizeEvictions
 	return &agent.FlushStatus{
 		BufferEvents:      &n,
+		BufferBytes:       &b,
+		SizeEvictions:     &e,
 		MetadataStatus:    s.metadataStatus,
 		PayloadStatus:     s.payloadStatus,
 		LastMetadataFlush: s.lastMetadataFlush,
@@ -579,7 +602,7 @@ func byosStreamLoop(ctx context.Context, events <-chan parser.Event, buf *buffer
 			flushToSinks(ctx, batch, fc)
 		}
 		if fc != nil && fc.state != nil {
-			fc.state.setBufferLen(buf.Len())
+			fc.state.setBufferStats(buf.Len(), buf.ApproxBytes(), buf.SizeEvictions())
 		}
 
 		batch = batch[:0]
@@ -597,7 +620,7 @@ func byosStreamLoop(ctx context.Context, events <-chan parser.Event, buf *buffer
 				slog.Info("BYOS buffer eviction", "evicted", n, "remaining", buf.Len())
 			}
 			if fc != nil && fc.state != nil {
-				fc.state.setBufferLen(buf.Len())
+				fc.state.setBufferStats(buf.Len(), buf.ApproxBytes(), buf.SizeEvictions())
 			}
 
 		case <-flushTicker.C:
@@ -782,4 +805,34 @@ func buildResolverFromSource(sourceDB *sql.DB, schemas []string) (*metadata.Reso
 	}
 
 	return metadata.NewResolverFromTables(0, tables), nil
+}
+
+// parseByteSize parses a human-readable byte size string like "256MB" or "1GB".
+// Plain integers are treated as bytes. Returns 0 for "0" (unlimited).
+func parseByteSize(s string) (int64, error) {
+	s = strings.TrimSpace(s)
+	if s == "" || s == "0" {
+		return 0, nil
+	}
+
+	s = strings.ToUpper(s)
+
+	multiplier := int64(1)
+	switch {
+	case strings.HasSuffix(s, "GB"):
+		multiplier = 1 << 30
+		s = strings.TrimSuffix(s, "GB")
+	case strings.HasSuffix(s, "MB"):
+		multiplier = 1 << 20
+		s = strings.TrimSuffix(s, "MB")
+	case strings.HasSuffix(s, "KB"):
+		multiplier = 1 << 10
+		s = strings.TrimSuffix(s, "KB")
+	}
+
+	var n int64
+	if _, err := fmt.Sscanf(s, "%d", &n); err != nil || n < 0 {
+		return 0, fmt.Errorf("invalid byte size %q; expected a number with optional KB/MB/GB suffix, e.g. 256MB", s)
+	}
+	return n * multiplier, nil
 }

--- a/cmd/bintrail/agent.go
+++ b/cmd/bintrail/agent.go
@@ -7,7 +7,9 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -241,6 +243,9 @@ func runAgent(cmd *cobra.Command, args []string) error {
 		retain, err := parseRetain(agtBufferRetain)
 		if err != nil {
 			return fmt.Errorf("invalid --buffer-retain: %w", err)
+		}
+		if agtBufferMaxEvents < 0 {
+			return fmt.Errorf("invalid --buffer-max-events %d: must be >= 0", agtBufferMaxEvents)
 		}
 		maxBytes, err := parseByteSize(agtBufferMaxBytes)
 		if err != nil {
@@ -815,6 +820,7 @@ func parseByteSize(s string) (int64, error) {
 		return 0, nil
 	}
 
+	original := s
 	s = strings.ToUpper(s)
 
 	multiplier := int64(1)
@@ -830,9 +836,12 @@ func parseByteSize(s string) (int64, error) {
 		s = strings.TrimSuffix(s, "KB")
 	}
 
-	var n int64
-	if _, err := fmt.Sscanf(s, "%d", &n); err != nil || n < 0 {
-		return 0, fmt.Errorf("invalid byte size %q; expected a number with optional KB/MB/GB suffix, e.g. 256MB", s)
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil || n < 0 {
+		return 0, fmt.Errorf("invalid byte size %q; expected a number with optional KB/MB/GB suffix, e.g. 256MB", original)
+	}
+	if n > math.MaxInt64/multiplier {
+		return 0, fmt.Errorf("byte size %q overflows int64", original)
 	}
 	return n * multiplier, nil
 }

--- a/cmd/bintrail/agent_test.go
+++ b/cmd/bintrail/agent_test.go
@@ -86,7 +86,7 @@ func makeTestEvents(n int) []parser.Event {
 
 func TestByosStreamLoopBufferOnly(t *testing.T) {
 	// Without flush config, events should go to buffer only (hosted mode).
-	buf := buffer.New(time.Hour, nil)
+	buf := buffer.New(buffer.Config{MaxAge: time.Hour})
 	events := make(chan parser.Event, 10)
 
 	for _, ev := range makeTestEvents(3) {
@@ -104,7 +104,7 @@ func TestByosStreamLoopBufferOnly(t *testing.T) {
 }
 
 func TestByosStreamLoopFlushToSinks(t *testing.T) {
-	buf := buffer.New(time.Hour, nil)
+	buf := buffer.New(buffer.Config{MaxAge: time.Hour})
 	events := make(chan parser.Event, 10)
 
 	state := &flushPipelineState{}
@@ -180,7 +180,7 @@ func TestByosStreamLoopFlushToSinks(t *testing.T) {
 }
 
 func TestByosStreamLoopSkipsNonRowEvents(t *testing.T) {
-	buf := buffer.New(time.Hour, nil)
+	buf := buffer.New(buffer.Config{MaxAge: time.Hour})
 	events := make(chan parser.Event, 10)
 
 	events <- parser.Event{EventType: parser.EventGTID, GTID: "aaa:1"}
@@ -201,7 +201,7 @@ func TestByosStreamLoopSkipsNonRowEvents(t *testing.T) {
 }
 
 func TestByosStreamLoopFlushOnBatchSize(t *testing.T) {
-	buf := buffer.New(time.Hour, nil)
+	buf := buffer.New(buffer.Config{MaxAge: time.Hour})
 	events := make(chan parser.Event, 20)
 
 	// Send 5 events with batch size 3 — should flush twice (3 + 2).
@@ -220,7 +220,7 @@ func TestByosStreamLoopFlushOnBatchSize(t *testing.T) {
 }
 
 func TestByosStreamLoopContextCancellation(t *testing.T) {
-	buf := buffer.New(time.Hour, nil)
+	buf := buffer.New(buffer.Config{MaxAge: time.Hour})
 	events := make(chan parser.Event, 10)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -242,12 +242,18 @@ func TestByosStreamLoopContextCancellation(t *testing.T) {
 
 func TestFlushPipelineStateToFlushStatus(t *testing.T) {
 	state := &flushPipelineState{}
-	state.setBufferLen(42)
+	state.setBufferStats(42, 8192, 5)
 	state.updateFlush(true, false)
 
 	status := state.toFlushStatus()
 	if status.BufferEvents == nil || *status.BufferEvents != 42 {
 		t.Errorf("BufferEvents = %v, want 42", status.BufferEvents)
+	}
+	if status.BufferBytes == nil || *status.BufferBytes != 8192 {
+		t.Errorf("BufferBytes = %v, want 8192", status.BufferBytes)
+	}
+	if status.SizeEvictions == nil || *status.SizeEvictions != 5 {
+		t.Errorf("SizeEvictions = %v, want 5", status.SizeEvictions)
 	}
 	if status.MetadataStatus != "ok" {
 		t.Errorf("MetadataStatus = %q, want ok", status.MetadataStatus)
@@ -387,6 +393,7 @@ func TestAgentFlagRegistration(t *testing.T) {
 		"archive-dir", "archive-s3", "buffer-retain", "server-id",
 		"batch-size", "schemas", "tables", "start-gtid",
 		"s3-bucket", "s3-region", "s3-prefix", "flush-interval",
+		"buffer-max-events", "buffer-max-bytes",
 	} {
 		if agentCmd.Flag(name) == nil {
 			t.Errorf("flag --%s not registered on agent command", name)
@@ -403,6 +410,8 @@ func TestAgentFlagDefaults(t *testing.T) {
 		{"flush-interval", "5s"},
 		{"buffer-retain", "6h"},
 		{"batch-size", "1000"},
+		{"buffer-max-events", "0"},
+		{"buffer-max-bytes", "0"},
 	}
 	for _, tt := range tests {
 		f := agentCmd.Flag(tt.flag)
@@ -411,6 +420,41 @@ func TestAgentFlagDefaults(t *testing.T) {
 		}
 		if f.DefValue != tt.want {
 			t.Errorf("--%s default = %q, want %q", tt.flag, f.DefValue, tt.want)
+		}
+	}
+}
+
+func TestParseByteSize(t *testing.T) {
+	tests := []struct {
+		input string
+		want  int64
+	}{
+		{"0", 0},
+		{"", 0},
+		{"1024", 1024},
+		{"256MB", 256 << 20},
+		{"256mb", 256 << 20},
+		{"1GB", 1 << 30},
+		{"1gb", 1 << 30},
+		{"512KB", 512 << 10},
+	}
+	for _, tt := range tests {
+		got, err := parseByteSize(tt.input)
+		if err != nil {
+			t.Errorf("parseByteSize(%q): unexpected error: %v", tt.input, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("parseByteSize(%q) = %d, want %d", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestParseByteSize_invalid(t *testing.T) {
+	for _, input := range []string{"abc", "-1GB", "not_a_number"} {
+		_, err := parseByteSize(input)
+		if err == nil {
+			t.Errorf("parseByteSize(%q): expected error", input)
 		}
 	}
 }

--- a/cmd/bintrail/agent_test.go
+++ b/cmd/bintrail/agent_test.go
@@ -451,7 +451,7 @@ func TestParseByteSize(t *testing.T) {
 }
 
 func TestParseByteSize_invalid(t *testing.T) {
-	for _, input := range []string{"abc", "-1GB", "not_a_number"} {
+	for _, input := range []string{"abc", "-1GB", "not_a_number", "1.5GB", "9999999999GB"} {
 		_, err := parseByteSize(input)
 		if err == nil {
 			t.Errorf("parseByteSize(%q): expected error", input)

--- a/cmd/bintrail/config.go
+++ b/cmd/bintrail/config.go
@@ -153,6 +153,8 @@ var envSections = []envSection{
 		Header: "Local event buffer (BYOS mode)",
 		Bindings: []envTemplateEntry{
 			{"BINTRAIL_BUFFER_RETAIN", "6h"},
+			{"BINTRAIL_BUFFER_MAX_EVENTS", "0"},
+			{"BINTRAIL_BUFFER_MAX_BYTES", "0"},
 			{"BINTRAIL_START_GTID", ""},
 		},
 	},

--- a/cmd/bintrail/envload.go
+++ b/cmd/bintrail/envload.go
@@ -44,6 +44,8 @@ var envBindings = []envBinding{
 	{"api-key", "BINTRAIL_API_KEY"},
 	{"endpoint", "BINTRAIL_AGENT_ENDPOINT"},
 	{"buffer-retain", "BINTRAIL_BUFFER_RETAIN"},
+	{"buffer-max-events", "BINTRAIL_BUFFER_MAX_EVENTS"},
+	{"buffer-max-bytes", "BINTRAIL_BUFFER_MAX_BYTES"},
 	{"start-gtid", "BINTRAIL_START_GTID"},
 	{"s3-prefix", "BINTRAIL_S3_PREFIX"},
 	{"flush-interval", "BINTRAIL_FLUSH_INTERVAL"},

--- a/internal/agent/channel.go
+++ b/internal/agent/channel.go
@@ -87,6 +87,8 @@ type Channel struct {
 // reported in heartbeats so dbtrail can show degraded status.
 type FlushStatus struct {
 	BufferEvents      *int
+	BufferBytes       *int64
+	SizeEvictions     *int64
 	MetadataStatus    string // "ok" or "degraded"
 	PayloadStatus     string // "ok" or "degraded"
 	LastMetadataFlush *time.Time
@@ -319,6 +321,8 @@ func (ch *Channel) sendHeartbeat(ctx context.Context, conn *websocket.Conn) erro
 	if ch.statusProvider != nil {
 		if s := ch.statusProvider(); s != nil {
 			hb.BufferEvents = s.BufferEvents
+			hb.BufferBytes = s.BufferBytes
+			hb.SizeEvictions = s.SizeEvictions
 			hb.MetadataStatus = s.MetadataStatus
 			hb.PayloadStatus = s.PayloadStatus
 			hb.LastMetadataFlush = s.LastMetadataFlush

--- a/internal/agent/command.go
+++ b/internal/agent/command.go
@@ -40,6 +40,8 @@ type Heartbeat struct {
 
 	// Flush pipeline status (BYOS mode only).
 	BufferEvents      *int       `json:"buffer_events,omitempty"`
+	BufferBytes       *int64     `json:"buffer_bytes,omitempty"`
+	SizeEvictions     *int64     `json:"size_evictions,omitempty"`
 	MetadataStatus    string     `json:"metadata_status,omitempty"`    // "ok" or "degraded"
 	PayloadStatus     string     `json:"payload_status,omitempty"`     // "ok" or "degraded"
 	LastMetadataFlush *time.Time `json:"last_metadata_flush,omitempty"`

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"log/slog"
 	"slices"
 	"sync"
@@ -24,28 +25,44 @@ const idOffset = uint64(1) << 32
 
 // entry is a single event stored in the buffer.
 type entry struct {
-	row    query.ResultRow
-	pkHash string // SHA-256 hex of pk_values
+	row       query.ResultRow
+	pkHash    string // SHA-256 hex of pk_values
+	approxSize int64  // estimated heap bytes
+}
+
+// Config controls buffer capacity and eviction behavior.
+type Config struct {
+	MaxAge    time.Duration // age-based eviction threshold
+	MaxEvents int           // max event count; 0 = unlimited
+	MaxBytes  int64         // max approximate byte usage; 0 = unlimited
+	Logger    *slog.Logger
 }
 
 // Buffer is a thread-safe, in-memory event store for recent binlog events.
 type Buffer struct {
-	mu     sync.RWMutex
-	events []entry
-	nextID uint64
-	maxAge time.Duration
-	logger *slog.Logger
+	mu            sync.RWMutex
+	events        []entry
+	nextID        uint64
+	maxAge        time.Duration
+	maxEvents     int
+	maxBytes      int64
+	curBytes      int64 // running total of approxSize across all entries
+	sizeEvictions int64 // cumulative events evicted by size cap
+	logger        *slog.Logger
 }
 
-// New creates a Buffer that retains events for up to maxAge.
-func New(maxAge time.Duration, logger *slog.Logger) *Buffer {
-	if logger == nil {
-		logger = slog.Default()
+// New creates a Buffer with the given configuration. Zero values for
+// MaxEvents and MaxBytes mean unlimited (no cap).
+func New(cfg Config) *Buffer {
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
 	}
 	return &Buffer{
-		maxAge: maxAge,
-		nextID: 1,
-		logger: logger,
+		maxAge:    cfg.MaxAge,
+		maxEvents: cfg.MaxEvents,
+		maxBytes:  cfg.MaxBytes,
+		nextID:    1,
+		logger:    cfg.Logger,
 	}
 }
 
@@ -88,9 +105,11 @@ func (b *Buffer) Insert(events []parser.Event) {
 			SchemaVersion:  ev.SchemaVersion,
 		}
 
+		sz := estimateRowSize(&row)
 		entries = append(entries, entry{
-			row:    row,
-			pkHash: pkHash(ev.PKValues),
+			row:        row,
+			pkHash:     pkHash(ev.PKValues),
+			approxSize: sz,
 		})
 	}
 
@@ -98,8 +117,10 @@ func (b *Buffer) Insert(events []parser.Event) {
 	for i := range entries {
 		entries[i].row.EventID = b.nextID + idOffset
 		b.nextID++
+		b.curBytes += entries[i].approxSize
 	}
 	b.events = append(b.events, entries...)
+	b.enforceSizeLimits()
 	b.mu.Unlock()
 }
 
@@ -153,6 +174,7 @@ func (b *Buffer) Evict() int {
 	// Events are append-ordered by time, so find the first non-expired index.
 	idx := 0
 	for idx < len(b.events) && b.events[idx].row.EventTimestamp.Before(cutoff) {
+		b.curBytes -= b.events[idx].approxSize
 		idx++
 	}
 	if idx == 0 {
@@ -222,6 +244,115 @@ func matchesOpts(e *entry, opts query.Options) bool {
 		}
 	}
 	return true
+}
+
+// ApproxBytes returns the approximate in-memory byte usage of all buffered events.
+func (b *Buffer) ApproxBytes() int64 {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.curBytes
+}
+
+// SizeEvictions returns the cumulative count of events evicted due to size
+// caps (maxEvents or maxBytes) since the buffer was created.
+func (b *Buffer) SizeEvictions() int64 {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.sizeEvictions
+}
+
+// enforceSizeLimits evicts the oldest entries when maxEvents or maxBytes are
+// exceeded. Must be called with b.mu held for writing.
+func (b *Buffer) enforceSizeLimits() {
+	var evicted int
+
+	// Enforce event count cap.
+	if b.maxEvents > 0 && len(b.events) > b.maxEvents {
+		drop := len(b.events) - b.maxEvents
+		for _, e := range b.events[:drop] {
+			b.curBytes -= e.approxSize
+		}
+		b.events = append([]entry(nil), b.events[drop:]...)
+		evicted += drop
+	}
+
+	// Enforce byte cap.
+	if b.maxBytes > 0 && b.curBytes > b.maxBytes {
+		drop := 0
+		for drop < len(b.events) && b.curBytes > b.maxBytes {
+			b.curBytes -= b.events[drop].approxSize
+			drop++
+		}
+		if drop > 0 {
+			b.events = append([]entry(nil), b.events[drop:]...)
+			evicted += drop
+		}
+	}
+
+	if evicted > 0 {
+		b.sizeEvictions += int64(evicted)
+		b.logger.Warn("BYOS buffer size eviction",
+			"evicted", evicted,
+			"remaining", len(b.events),
+			"approx_bytes", b.curBytes,
+		)
+	}
+}
+
+// ─── Size estimation ────────────────────────────────────────────────────────
+
+// estimateRowSize returns an approximate byte cost for a ResultRow.
+// This is not exact — it sums string lengths and uses fixed estimates for
+// maps, pointers, and struct overhead. Good enough for backpressure decisions.
+func estimateRowSize(r *query.ResultRow) int64 {
+	const overhead = 200 // struct fields, pointers, slice headers
+	var n int64 = overhead
+
+	n += int64(len(r.BinlogFile))
+	n += int64(len(r.SchemaName))
+	n += int64(len(r.TableName))
+	n += int64(len(r.PKValues))
+	n += 64 // pkHash hex string
+
+	if r.GTID != nil {
+		n += int64(len(*r.GTID))
+	}
+	for _, c := range r.ChangedColumns {
+		n += int64(len(c))
+	}
+	n += estimateMapSize(r.RowBefore)
+	n += estimateMapSize(r.RowAfter)
+	return n
+}
+
+// estimateMapSize returns an approximate byte size for a map[string]any,
+// as typically found in RowBefore/RowAfter JSON column data.
+func estimateMapSize(m map[string]any) int64 {
+	if m == nil {
+		return 0
+	}
+	const perEntry = 64 // map bucket overhead per key
+	var n int64
+	for k, v := range m {
+		n += perEntry + int64(len(k))
+		n += estimateValueSize(v)
+	}
+	return n
+}
+
+func estimateValueSize(v any) int64 {
+	switch val := v.(type) {
+	case string:
+		return int64(len(val))
+	case []byte:
+		return int64(len(val))
+	case json.RawMessage:
+		return int64(len(val))
+	case nil:
+		return 0
+	default:
+		return 8 // numbers, bools
+	}
 }
 
 // pkHash computes the SHA-256 hex digest of pkValues, matching MySQL's

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -54,6 +54,12 @@ type Buffer struct {
 // New creates a Buffer with the given configuration. Zero values for
 // MaxEvents and MaxBytes mean unlimited (no cap).
 func New(cfg Config) *Buffer {
+	if cfg.MaxEvents < 0 {
+		panic("buffer.Config: MaxEvents must be non-negative")
+	}
+	if cfg.MaxBytes < 0 {
+		panic("buffer.Config: MaxBytes must be non-negative")
+	}
 	if cfg.Logger == nil {
 		cfg.Logger = slog.Default()
 	}
@@ -174,16 +180,23 @@ func (b *Buffer) Evict() int {
 	// Events are append-ordered by time, so find the first non-expired index.
 	idx := 0
 	for idx < len(b.events) && b.events[idx].row.EventTimestamp.Before(cutoff) {
-		b.curBytes -= b.events[idx].approxSize
 		idx++
 	}
 	if idx == 0 {
 		return 0
 	}
 
-	// Shift remaining events to the front to allow GC of evicted entries.
-	b.events = append([]entry(nil), b.events[idx:]...)
+	b.dropFront(idx)
 	return idx
+}
+
+// dropFront removes the first n entries from the buffer, adjusting curBytes.
+// Must be called with b.mu held for writing.
+func (b *Buffer) dropFront(n int) {
+	for _, e := range b.events[:n] {
+		b.curBytes -= e.approxSize
+	}
+	b.events = append([]entry(nil), b.events[n:]...)
 }
 
 // Snapshot returns a copy of all current events for archival purposes
@@ -264,35 +277,31 @@ func (b *Buffer) SizeEvictions() int64 {
 // enforceSizeLimits evicts the oldest entries when maxEvents or maxBytes are
 // exceeded. Must be called with b.mu held for writing.
 func (b *Buffer) enforceSizeLimits() {
-	var evicted int
+	drop := 0
 
 	// Enforce event count cap.
 	if b.maxEvents > 0 && len(b.events) > b.maxEvents {
-		drop := len(b.events) - b.maxEvents
-		for _, e := range b.events[:drop] {
-			b.curBytes -= e.approxSize
-		}
-		b.events = append([]entry(nil), b.events[drop:]...)
-		evicted += drop
+		drop = len(b.events) - b.maxEvents
 	}
 
-	// Enforce byte cap.
-	if b.maxBytes > 0 && b.curBytes > b.maxBytes {
-		drop := 0
-		for drop < len(b.events) && b.curBytes > b.maxBytes {
-			b.curBytes -= b.events[drop].approxSize
+	// Enforce byte cap — compute how many additional entries must go by
+	// simulating the curBytes decrease from the entries we already plan to drop.
+	if b.maxBytes > 0 {
+		simBytes := b.curBytes
+		for i := range drop {
+			simBytes -= b.events[i].approxSize
+		}
+		for drop < len(b.events) && simBytes > b.maxBytes {
+			simBytes -= b.events[drop].approxSize
 			drop++
 		}
-		if drop > 0 {
-			b.events = append([]entry(nil), b.events[drop:]...)
-			evicted += drop
-		}
 	}
 
-	if evicted > 0 {
-		b.sizeEvictions += int64(evicted)
+	if drop > 0 {
+		b.dropFront(drop)
+		b.sizeEvictions += int64(drop)
 		b.logger.Warn("BYOS buffer size eviction",
-			"evicted", evicted,
+			"evicted", drop,
 			"remaining", len(b.events),
 			"approx_bytes", b.curBytes,
 		)
@@ -348,6 +357,14 @@ func estimateValueSize(v any) int64 {
 		return int64(len(val))
 	case json.RawMessage:
 		return int64(len(val))
+	case map[string]any:
+		return estimateMapSize(val)
+	case []any:
+		var sz int64 = 24 // slice header
+		for _, elem := range val {
+			sz += estimateValueSize(elem)
+		}
+		return sz
 	case nil:
 		return 0
 	default:

--- a/internal/buffer/buffer_test.go
+++ b/internal/buffer/buffer_test.go
@@ -497,3 +497,51 @@ func TestInsert_maxEvents_multipleInserts(t *testing.T) {
 		t.Errorf("SizeEvictions = %d, want 2", buf.SizeEvictions())
 	}
 }
+
+func TestInsert_bothCapsActive(t *testing.T) {
+	// MaxEvents=10, MaxBytes=small — the tighter cap wins.
+	buf := New(Config{MaxAge: 6 * time.Hour, MaxEvents: 10, MaxBytes: 1000})
+	now := time.Now().UTC()
+	buf.Insert(makeEvents(10, "db", "t", now))
+
+	// Byte cap should have kicked in before event cap.
+	if buf.Len() >= 10 {
+		t.Errorf("Len = %d, expected < 10 (byte cap should be tighter)", buf.Len())
+	}
+	if buf.ApproxBytes() > 1000 {
+		t.Errorf("ApproxBytes = %d, should be <= 1000", buf.ApproxBytes())
+	}
+}
+
+func TestInsert_singleEventExceedsMaxBytes(t *testing.T) {
+	// A single event larger than maxBytes should result in an empty buffer.
+	buf := New(Config{MaxAge: 6 * time.Hour, MaxBytes: 1})
+	now := time.Now().UTC()
+	buf.Insert(makeEvents(1, "db", "t", now))
+
+	// The single event exceeds 1 byte, so the buffer should be empty.
+	if buf.Len() != 0 {
+		t.Errorf("Len = %d, want 0 (single event exceeds maxBytes)", buf.Len())
+	}
+	if buf.SizeEvictions() != 1 {
+		t.Errorf("SizeEvictions = %d, want 1", buf.SizeEvictions())
+	}
+}
+
+func TestNew_negativeMaxEventsPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for negative MaxEvents")
+		}
+	}()
+	New(Config{MaxAge: time.Hour, MaxEvents: -1})
+}
+
+func TestNew_negativeMaxBytesPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for negative MaxBytes")
+		}
+	}()
+	New(Config{MaxAge: time.Hour, MaxBytes: -1})
+}

--- a/internal/buffer/buffer_test.go
+++ b/internal/buffer/buffer_test.go
@@ -45,14 +45,14 @@ func makeUpdate(schema, table, pk string, ts time.Time) parser.Event {
 }
 
 func TestNew(t *testing.T) {
-	buf := New(6*time.Hour, nil)
+	buf := New(Config{MaxAge: 6 * time.Hour})
 	if buf.Len() != 0 {
 		t.Errorf("new buffer Len() = %d, want 0", buf.Len())
 	}
 }
 
 func TestInsert_empty(t *testing.T) {
-	buf := New(6*time.Hour, nil)
+	buf := New(Config{MaxAge: 6 * time.Hour})
 	buf.Insert(nil)
 	if buf.Len() != 0 {
 		t.Errorf("Len after nil insert = %d, want 0", buf.Len())
@@ -60,7 +60,7 @@ func TestInsert_empty(t *testing.T) {
 }
 
 func TestInsert_roundTrip(t *testing.T) {
-	buf := New(6*time.Hour, nil)
+	buf := New(Config{MaxAge: 6 * time.Hour})
 	now := time.Now().UTC().Truncate(time.Second)
 	events := makeEvents(3, "mydb", "users", now)
 
@@ -104,7 +104,7 @@ func TestInsert_roundTrip(t *testing.T) {
 }
 
 func TestInsert_emptyGTID(t *testing.T) {
-	buf := New(6*time.Hour, nil)
+	buf := New(Config{MaxAge: 6 * time.Hour})
 	ev := parser.Event{
 		BinlogFile: "binlog.000001",
 		Timestamp:  time.Now().UTC(),
@@ -125,7 +125,7 @@ func TestInsert_emptyGTID(t *testing.T) {
 }
 
 func TestInsert_connectionID(t *testing.T) {
-	buf := New(6*time.Hour, nil)
+	buf := New(Config{MaxAge: 6 * time.Hour})
 	ev := parser.Event{
 		BinlogFile:   "binlog.000001",
 		Timestamp:    time.Now().UTC(),
@@ -147,7 +147,7 @@ func TestInsert_connectionID(t *testing.T) {
 }
 
 func TestFetch_filterBySchema(t *testing.T) {
-	buf := New(6*time.Hour, nil)
+	buf := New(Config{MaxAge: 6 * time.Hour})
 	now := time.Now().UTC()
 	buf.Insert(makeEvents(2, "db1", "t1", now))
 	buf.Insert(makeEvents(2, "db2", "t1", now))
@@ -164,7 +164,7 @@ func TestFetch_filterBySchema(t *testing.T) {
 }
 
 func TestFetch_filterByTable(t *testing.T) {
-	buf := New(6*time.Hour, nil)
+	buf := New(Config{MaxAge: 6 * time.Hour})
 	now := time.Now().UTC()
 	buf.Insert(makeEvents(2, "db", "users", now))
 	buf.Insert(makeEvents(2, "db", "orders", now))
@@ -176,7 +176,7 @@ func TestFetch_filterByTable(t *testing.T) {
 }
 
 func TestFetch_filterByPKValues(t *testing.T) {
-	buf := New(6*time.Hour, nil)
+	buf := New(Config{MaxAge: 6 * time.Hour})
 	now := time.Now().UTC()
 	buf.Insert(makeEvents(5, "db", "t", now))
 
@@ -190,7 +190,7 @@ func TestFetch_filterByPKValues(t *testing.T) {
 }
 
 func TestFetch_filterByEventType(t *testing.T) {
-	buf := New(6*time.Hour, nil)
+	buf := New(Config{MaxAge: 6 * time.Hour})
 	now := time.Now().UTC()
 	buf.Insert(makeEvents(2, "db", "t", now))
 	buf.Insert([]parser.Event{makeUpdate("db", "t", "99", now)})
@@ -206,7 +206,7 @@ func TestFetch_filterByEventType(t *testing.T) {
 }
 
 func TestFetch_filterBySinceUntil(t *testing.T) {
-	buf := New(6*time.Hour, nil)
+	buf := New(Config{MaxAge: 6 * time.Hour})
 	base := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
 	buf.Insert(makeEvents(5, "db", "t", base))
 
@@ -219,7 +219,7 @@ func TestFetch_filterBySinceUntil(t *testing.T) {
 }
 
 func TestFetch_filterByChangedColumn(t *testing.T) {
-	buf := New(6*time.Hour, nil)
+	buf := New(Config{MaxAge: 6 * time.Hour})
 	now := time.Now().UTC()
 	buf.Insert([]parser.Event{makeUpdate("db", "t", "1", now)})
 	buf.Insert(makeEvents(1, "db", "t", now.Add(time.Second)))
@@ -234,7 +234,7 @@ func TestFetch_filterByChangedColumn(t *testing.T) {
 }
 
 func TestFetch_filterByGTID(t *testing.T) {
-	buf := New(6*time.Hour, nil)
+	buf := New(Config{MaxAge: 6 * time.Hour})
 	now := time.Now().UTC()
 
 	ev1 := parser.Event{
@@ -257,7 +257,7 @@ func TestFetch_filterByGTID(t *testing.T) {
 }
 
 func TestFetch_limit(t *testing.T) {
-	buf := New(6*time.Hour, nil)
+	buf := New(Config{MaxAge: 6 * time.Hour})
 	buf.Insert(makeEvents(10, "db", "t", time.Now().UTC()))
 
 	rows := buf.Fetch(context.Background(), query.Options{Limit: 3})
@@ -267,7 +267,7 @@ func TestFetch_limit(t *testing.T) {
 }
 
 func TestFetch_denyTables(t *testing.T) {
-	buf := New(6*time.Hour, nil)
+	buf := New(Config{MaxAge: 6 * time.Hour})
 	now := time.Now().UTC()
 	buf.Insert(makeEvents(2, "db", "public_t", now))
 	buf.Insert(makeEvents(2, "db", "secret_t", now))
@@ -286,7 +286,7 @@ func TestFetch_denyTables(t *testing.T) {
 }
 
 func TestResolvePK_found(t *testing.T) {
-	buf := New(6*time.Hour, nil)
+	buf := New(Config{MaxAge: 6 * time.Hour})
 	buf.Insert(makeEvents(3, "db", "t", time.Now().UTC()))
 
 	// The pk_values for the second event is "1" (rune '0'+1).
@@ -301,7 +301,7 @@ func TestResolvePK_found(t *testing.T) {
 }
 
 func TestResolvePK_notFound(t *testing.T) {
-	buf := New(6*time.Hour, nil)
+	buf := New(Config{MaxAge: 6 * time.Hour})
 	buf.Insert(makeEvents(3, "db", "t", time.Now().UTC()))
 
 	_, ok := buf.ResolvePK("nonexistent_hash", "db", "t")
@@ -311,7 +311,7 @@ func TestResolvePK_notFound(t *testing.T) {
 }
 
 func TestResolvePK_wrongSchemaTable(t *testing.T) {
-	buf := New(6*time.Hour, nil)
+	buf := New(Config{MaxAge: 6 * time.Hour})
 	buf.Insert(makeEvents(1, "db", "t", time.Now().UTC()))
 
 	hash := pkHash("0")
@@ -322,7 +322,7 @@ func TestResolvePK_wrongSchemaTable(t *testing.T) {
 }
 
 func TestEvict(t *testing.T) {
-	buf := New(1*time.Hour, nil)
+	buf := New(Config{MaxAge: 1 * time.Hour})
 	old := time.Now().UTC().Add(-2 * time.Hour)
 	recent := time.Now().UTC()
 
@@ -339,7 +339,7 @@ func TestEvict(t *testing.T) {
 }
 
 func TestEvict_nothingToEvict(t *testing.T) {
-	buf := New(6*time.Hour, nil)
+	buf := New(Config{MaxAge: 6 * time.Hour})
 	buf.Insert(makeEvents(3, "db", "t", time.Now().UTC()))
 
 	evicted := buf.Evict()
@@ -352,14 +352,14 @@ func TestEvict_nothingToEvict(t *testing.T) {
 }
 
 func TestEvict_empty(t *testing.T) {
-	buf := New(1*time.Hour, nil)
+	buf := New(Config{MaxAge: 1 * time.Hour})
 	if buf.Evict() != 0 {
 		t.Error("evict on empty buffer should return 0")
 	}
 }
 
 func TestSnapshot(t *testing.T) {
-	buf := New(6*time.Hour, nil)
+	buf := New(Config{MaxAge: 6 * time.Hour})
 	buf.Insert(makeEvents(5, "db", "t", time.Now().UTC()))
 
 	snap := buf.Snapshot()
@@ -375,7 +375,7 @@ func TestSnapshot(t *testing.T) {
 }
 
 func TestChangedColumns_computed(t *testing.T) {
-	buf := New(6*time.Hour, nil)
+	buf := New(Config{MaxAge: 6 * time.Hour})
 	buf.Insert([]parser.Event{makeUpdate("db", "t", "1", time.Now().UTC())})
 
 	rows := buf.Fetch(context.Background(), query.Options{})
@@ -384,5 +384,116 @@ func TestChangedColumns_computed(t *testing.T) {
 	}
 	if len(rows[0].ChangedColumns) != 1 || rows[0].ChangedColumns[0] != "email" {
 		t.Errorf("ChangedColumns = %v, want [email]", rows[0].ChangedColumns)
+	}
+}
+
+// ─── Size cap tests ─────────────────────────────────────────────────────────
+
+func TestInsert_maxEvents(t *testing.T) {
+	buf := New(Config{MaxAge: 6 * time.Hour, MaxEvents: 5})
+	now := time.Now().UTC()
+	buf.Insert(makeEvents(10, "db", "t", now))
+
+	if buf.Len() != 5 {
+		t.Fatalf("Len = %d, want 5 (capped)", buf.Len())
+	}
+
+	// The surviving events should be the last 5 (FIFO eviction from front).
+	rows := buf.Fetch(context.Background(), query.Options{})
+	if len(rows) != 5 {
+		t.Fatalf("Fetch got %d rows, want 5", len(rows))
+	}
+	// First surviving event is the one at index 5 from the original batch.
+	if rows[0].PKValues != string(rune('0'+5)) {
+		t.Errorf("first surviving PKValues = %q, want %q", rows[0].PKValues, string(rune('0'+5)))
+	}
+
+	if buf.SizeEvictions() != 5 {
+		t.Errorf("SizeEvictions = %d, want 5", buf.SizeEvictions())
+	}
+}
+
+func TestInsert_maxEvents_zero_unlimited(t *testing.T) {
+	buf := New(Config{MaxAge: 6 * time.Hour, MaxEvents: 0})
+	buf.Insert(makeEvents(100, "db", "t", time.Now().UTC()))
+	if buf.Len() != 100 {
+		t.Errorf("Len = %d, want 100 (unlimited)", buf.Len())
+	}
+	if buf.SizeEvictions() != 0 {
+		t.Errorf("SizeEvictions = %d, want 0", buf.SizeEvictions())
+	}
+}
+
+func TestInsert_maxBytes(t *testing.T) {
+	// Insert events and check that byte cap triggers eviction.
+	// Each event is at least ~200 bytes (overhead alone). Use a small cap.
+	buf := New(Config{MaxAge: 6 * time.Hour, MaxBytes: 1000})
+	now := time.Now().UTC()
+
+	// Insert 20 events — total bytes will exceed 1000.
+	buf.Insert(makeEvents(20, "db", "t", now))
+
+	if buf.Len() >= 20 {
+		t.Errorf("Len = %d, expected fewer than 20 due to byte cap", buf.Len())
+	}
+	if buf.ApproxBytes() > 1000 {
+		t.Errorf("ApproxBytes = %d, should be <= 1000", buf.ApproxBytes())
+	}
+	if buf.SizeEvictions() == 0 {
+		t.Error("expected SizeEvictions > 0")
+	}
+}
+
+func TestApproxBytes_tracksInsertAndEvict(t *testing.T) {
+	buf := New(Config{MaxAge: 1 * time.Hour})
+	if buf.ApproxBytes() != 0 {
+		t.Errorf("empty buffer ApproxBytes = %d, want 0", buf.ApproxBytes())
+	}
+
+	old := time.Now().UTC().Add(-2 * time.Hour)
+	buf.Insert(makeEvents(5, "db", "t", old))
+
+	bytesAfterInsert := buf.ApproxBytes()
+	if bytesAfterInsert <= 0 {
+		t.Fatalf("ApproxBytes after insert = %d, want > 0", bytesAfterInsert)
+	}
+
+	// Age-based eviction should reduce curBytes.
+	evicted := buf.Evict()
+	if evicted != 5 {
+		t.Fatalf("evicted = %d, want 5", evicted)
+	}
+	if buf.ApproxBytes() != 0 {
+		t.Errorf("ApproxBytes after full evict = %d, want 0", buf.ApproxBytes())
+	}
+}
+
+func TestSizeEvictions_notIncrementedByAgeEvict(t *testing.T) {
+	buf := New(Config{MaxAge: 1 * time.Hour})
+	old := time.Now().UTC().Add(-2 * time.Hour)
+	buf.Insert(makeEvents(5, "db", "t", old))
+	buf.Evict()
+
+	if buf.SizeEvictions() != 0 {
+		t.Errorf("SizeEvictions = %d, want 0 (age eviction should not count)", buf.SizeEvictions())
+	}
+}
+
+func TestInsert_maxEvents_multipleInserts(t *testing.T) {
+	buf := New(Config{MaxAge: 6 * time.Hour, MaxEvents: 5})
+	now := time.Now().UTC()
+
+	buf.Insert(makeEvents(3, "db", "t", now))
+	if buf.Len() != 3 {
+		t.Fatalf("Len = %d, want 3 after first insert", buf.Len())
+	}
+
+	// Second insert pushes over the cap.
+	buf.Insert(makeEvents(4, "db", "t", now.Add(10*time.Second)))
+	if buf.Len() != 5 {
+		t.Errorf("Len = %d, want 5 after second insert", buf.Len())
+	}
+	if buf.SizeEvictions() != 2 {
+		t.Errorf("SizeEvictions = %d, want 2", buf.SizeEvictions())
 	}
 }

--- a/internal/buffer/parquet_test.go
+++ b/internal/buffer/parquet_test.go
@@ -27,7 +27,7 @@ func TestWriteParquet_roundTrip(t *testing.T) {
 	outPath := filepath.Join(dir, "buffer.parquet")
 
 	// Build rows from buffer.
-	buf := New(6*time.Hour, nil)
+	buf := New(Config{MaxAge: 6 * time.Hour})
 	base := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
 	buf.Insert(makeEvents(3, "mydb", "users", base))
 	buf.Insert([]parser.Event{makeUpdate("mydb", "orders", "42", base)})


### PR DESCRIPTION
## Summary

The in-memory BYOS buffer previously only evicted by age (`--buffer-retain`), so a write burst within the retention window could grow RAM unbounded. This adds event count and byte size caps with FIFO eviction.

- **`--buffer-max-events`** — max event count in buffer (0 = unlimited, default)
- **`--buffer-max-bytes`** — max approximate byte usage, e.g. `256MB`, `1GB` (0 = unlimited, default)
- When a cap is exceeded after `Insert`, oldest entries are evicted from the front (same direction as age-based eviction), with `slog.Warn` for operator visibility
- New heartbeat fields: `buffer_bytes`, `size_evictions` — lets dbtrail show buffer pressure
- New env vars: `BINTRAIL_BUFFER_MAX_EVENTS`, `BINTRAIL_BUFFER_MAX_BYTES`
- `buffer.New` now takes a `Config` struct instead of positional params

Force-flush-to-Parquet before size eviction is intentionally not included — it couples the buffer to the flush pipeline and is a separate concern. The warning log gives operators visibility to tune caps or flush intervals.

Closes #194

## Test plan

- [x] `go test ./internal/buffer/ -count=1 -v` — all 30 tests pass including new size cap tests
- [x] `go test ./internal/agent/ -count=1 -v` — agent package tests pass
- [x] `go test ./cmd/bintrail/ -count=1 -v` — all cmd tests pass including parseByteSize and updated heartbeat tests
- [x] `go vet ./...` — clean
- [ ] Manual: run agent with `--buffer-max-events 1000` and verify WARN log on overflow
- [ ] Manual: verify `buffer_bytes` and `size_evictions` appear in heartbeat JSON