### PR TITLE
Probe mydumper version before passing --sync-thread-lock-mode (#219)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `bintrail dump` no longer passes `--sync-thread-lock-mode` and `--trx-tables` to mydumper versions older than 0.11.0. These flags were introduced in mydumper 0.11.0 but were hardcoded in `buildMydumperArgs`, so `bintrail dump` failed immediately on Ubuntu 24.04's apt-installed mydumper 0.10.0 with `Unknown option --sync-thread-lock-mode`. The fix probes the local mydumper binary's version via `mydumper --version` and conditionally includes the flags only when the version is >= 0.11.0. Docker-mode invocations (`--mydumper-image`) always include the flags since the official Docker image ships a recent version. When the version cannot be determined, the flags are omitted conservatively with a `slog.Warn`. This unblocks the entire `dump → baseline → reconstruct --output-format mydumper` pipeline on Ubuntu 24.04 (#219).
+
 ## [0.5.0] - 2026-04-11
 
 ### Added

--- a/cmd/bintrail/dump.go
+++ b/cmd/bintrail/dump.go
@@ -211,14 +211,14 @@ func runDump(cmd *cobra.Command, args []string) error {
 	// to ship a recent enough version.
 	supportsLockMode := true
 	if res.mode == dumpModeLocal {
-		_, minor, _, verErr := mydumperVersion(res.path)
+		major, minor, patch, verErr := mydumperVersion(res.path)
 		if verErr != nil {
 			slog.Warn("could not determine mydumper version; omitting --sync-thread-lock-mode and --trx-tables for safety",
 				"error", verErr)
 			supportsLockMode = false
-		} else if minor < 11 {
+		} else if major == 0 && minor < 11 {
 			slog.Warn("mydumper version is older than 0.11.0; omitting --sync-thread-lock-mode and --trx-tables — the dump may hold heavier locks",
-				"version", fmt.Sprintf("0.%d", minor))
+				"version", fmt.Sprintf("%d.%d.%d", major, minor, patch))
 			supportsLockMode = false
 		}
 	}
@@ -254,17 +254,23 @@ func runDump(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// mydumperVersion runs `<path> --version` and parses the major.minor.patch
-// triple from the output (e.g. "mydumper 0.10.0, built against MySQL 8.0.36"
-// → 0, 10, 0). Returns (0, 0, 0, err) on any failure — the caller should
-// treat an unparseable version conservatively (assume oldest).
+// mydumperVersion runs `<path> --version` and parses the version triple via
+// parseMydumperVersion. Returns (0, 0, 0, err) on any failure — the caller
+// should treat an unparseable version conservatively (assume oldest).
 func mydumperVersion(path string) (major, minor, patch int, err error) {
 	out, err := exec.Command(path, "--version").CombinedOutput()
 	if err != nil {
 		return 0, 0, 0, fmt.Errorf("run %s --version: %w", path, err)
 	}
-	// First line: "mydumper X.Y.Z..." — extract the version triple.
-	line := strings.SplitN(string(out), "\n", 2)[0]
+	return parseMydumperVersion(string(out))
+}
+
+// parseMydumperVersion extracts the major.minor.patch triple from mydumper
+// --version output (e.g. "mydumper 0.10.0, built against MySQL 8.0.36"
+// → 0, 10, 0). Extracted from mydumperVersion so the parsing logic is
+// directly unit-testable without shelling out to a real binary.
+func parseMydumperVersion(output string) (major, minor, patch int, err error) {
+	line := strings.SplitN(output, "\n", 2)[0]
 	parts := strings.Fields(line)
 	if len(parts) < 2 {
 		return 0, 0, 0, fmt.Errorf("unexpected --version output: %q", line)

--- a/cmd/bintrail/dump.go
+++ b/cmd/bintrail/dump.go
@@ -204,8 +204,25 @@ func runDump(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to remove existing output directory %q: %w", dmpOutputDir, err)
 	}
 
-	// 6. Build mydumper args.
-	mydumperArgs := buildMydumperArgs(host, port, user, password, dmpOutputDir, dmpThreads, schemas, tables, encryptKeyPath)
+	// 6. Probe mydumper version and build args.
+	// --sync-thread-lock-mode and --trx-tables require mydumper >= 0.11.0.
+	// Ubuntu 24.04's apt package ships 0.10.0, so we must not pass them
+	// unconditionally or the dump fails (#219). Docker images are assumed
+	// to ship a recent enough version.
+	supportsLockMode := true
+	if res.mode == dumpModeLocal {
+		_, minor, _, verErr := mydumperVersion(res.path)
+		if verErr != nil {
+			slog.Warn("could not determine mydumper version; omitting --sync-thread-lock-mode and --trx-tables for safety",
+				"error", verErr)
+			supportsLockMode = false
+		} else if minor < 11 {
+			slog.Warn("mydumper version is older than 0.11.0; omitting --sync-thread-lock-mode and --trx-tables — the dump may hold heavier locks",
+				"version", fmt.Sprintf("0.%d", minor))
+			supportsLockMode = false
+		}
+	}
+	mydumperArgs := buildMydumperArgs(host, port, user, password, dmpOutputDir, dmpThreads, schemas, tables, encryptKeyPath, supportsLockMode)
 
 	// 7. Build the final command depending on resolution mode.
 	var c *exec.Cmd
@@ -237,14 +254,41 @@ func runDump(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// mydumperVersion runs `<path> --version` and parses the major.minor.patch
+// triple from the output (e.g. "mydumper 0.10.0, built against MySQL 8.0.36"
+// → 0, 10, 0). Returns (0, 0, 0, err) on any failure — the caller should
+// treat an unparseable version conservatively (assume oldest).
+func mydumperVersion(path string) (major, minor, patch int, err error) {
+	out, err := exec.Command(path, "--version").CombinedOutput()
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("run %s --version: %w", path, err)
+	}
+	// First line: "mydumper X.Y.Z..." — extract the version triple.
+	line := strings.SplitN(string(out), "\n", 2)[0]
+	parts := strings.Fields(line)
+	if len(parts) < 2 {
+		return 0, 0, 0, fmt.Errorf("unexpected --version output: %q", line)
+	}
+	ver := strings.TrimRight(parts[1], ",")
+	n, scanErr := fmt.Sscanf(ver, "%d.%d.%d", &major, &minor, &patch)
+	if scanErr != nil || n != 3 {
+		return 0, 0, 0, fmt.Errorf("cannot parse version %q from %q", ver, line)
+	}
+	return major, minor, patch, nil
+}
+
 // buildMydumperArgs constructs the argument slice for a mydumper invocation.
 // --compress-protocol and --complete-insert are always included.
+// When supportsLockMode is true (mydumper >= 0.11.0), --sync-thread-lock-mode
+// and --trx-tables are included for lighter locking. When false (mydumper
+// 0.10.x or older), they are omitted so the dump works on Ubuntu 24.04's
+// apt-installed mydumper without error (#219).
 // Schema filtering: single schema → --database; multiple → --regex.
 // Table filtering: --tables-list with a comma-joined list.
 // When encryptKeyPath is non-empty, --exec-per-thread and
 // --exec-per-thread-extension are added for AES-256-CBC encryption.
 func buildMydumperArgs(host string, port uint16, user, password, outputDir string,
-	threads int, schemas, tables []string, encryptKeyPath string) []string {
+	threads int, schemas, tables []string, encryptKeyPath string, supportsLockMode bool) []string {
 
 	args := []string{
 		"--host", host,
@@ -253,8 +297,10 @@ func buildMydumperArgs(host string, port uint16, user, password, outputDir strin
 		"--threads", strconv.Itoa(threads),
 		"--compress-protocol",
 		"--complete-insert",
-		"--sync-thread-lock-mode", "NO_LOCK",
-		"--trx-tables",
+	}
+
+	if supportsLockMode {
+		args = append(args, "--sync-thread-lock-mode", "NO_LOCK", "--trx-tables")
 	}
 
 	if password != "" {

--- a/cmd/bintrail/dump_test.go
+++ b/cmd/bintrail/dump_test.go
@@ -114,12 +114,12 @@ func TestBuildMydumperArgs_lockAndTrx_unsupported(t *testing.T) {
 	}
 }
 
-func TestMydumperVersion_parsing(t *testing.T) {
+func TestParseMydumperVersion(t *testing.T) {
 	cases := []struct {
-		name                  string
-		output                string
+		name                                string
+		output                              string
 		wantMajor, wantMinor, wantPatch int
-		wantErr               bool
+		wantErr                             bool
 	}{
 		{
 			name:      "standard_0.10.0",
@@ -132,9 +132,14 @@ func TestMydumperVersion_parsing(t *testing.T) {
 			wantMajor: 0, wantMinor: 11, wantPatch: 5,
 		},
 		{
-			name:      "standard_0.16.3",
+			name:      "standard_0.16.3_with_suffix",
 			output:    "mydumper 0.16.3-6, built against MySQL 8.4.3\n",
 			wantMajor: 0, wantMinor: 16, wantPatch: 3,
+		},
+		{
+			name:      "future_major_1",
+			output:    "mydumper 1.0.0, built against MySQL 9.0.0\n",
+			wantMajor: 1, wantMinor: 0, wantPatch: 0,
 		},
 		{
 			name:    "empty_output",
@@ -154,30 +159,15 @@ func TestMydumperVersion_parsing(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			// mydumperVersion shells out to `path --version`, so we can't
-			// directly unit-test the parsing without a real binary. Instead
-			// we test the parsing logic inline here by extracting the same
-			// algorithm the function uses.
-			line := strings.SplitN(tc.output, "\n", 2)[0]
-			parts := strings.Fields(line)
-			if len(parts) < 2 {
-				if !tc.wantErr {
-					t.Errorf("expected success but got too few fields in %q", line)
-				}
-				return
-			}
-			ver := strings.TrimRight(parts[1], ",")
-			var major, minor, patch int
-			n, err := fmt.Sscanf(ver, "%d.%d.%d", &major, &minor, &patch)
-			if err != nil || n != 3 {
-				if !tc.wantErr {
-					t.Errorf("expected success but parse failed: ver=%q err=%v", ver, err)
-				}
-				return
-			}
+			major, minor, patch, err := parseMydumperVersion(tc.output)
 			if tc.wantErr {
-				t.Error("expected error but parse succeeded")
+				if err == nil {
+					t.Errorf("expected error but got %d.%d.%d", major, minor, patch)
+				}
 				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
 			}
 			if major != tc.wantMajor || minor != tc.wantMinor || patch != tc.wantPatch {
 				t.Errorf("got %d.%d.%d, want %d.%d.%d", major, minor, patch, tc.wantMajor, tc.wantMinor, tc.wantPatch)

--- a/cmd/bintrail/dump_test.go
+++ b/cmd/bintrail/dump_test.go
@@ -71,7 +71,7 @@ func TestDumpCmd_allFlagsRegistered(t *testing.T) {
 // ─── buildMydumperArgs ────────────────────────────────────────────────────────
 
 func TestBuildMydumperArgs_basic(t *testing.T) {
-	args := buildMydumperArgs("127.0.0.1", 3306, "root", "secret", "/tmp/dump", 4, nil, nil, "")
+	args := buildMydumperArgs("127.0.0.1", 3306, "root", "secret", "/tmp/dump", 4, nil, nil, "", true)
 	assertArgsContainPair(t, args, "--host", "127.0.0.1")
 	assertArgsContainPair(t, args, "--port", "3306")
 	assertArgsContainPair(t, args, "--user", "root")
@@ -80,7 +80,7 @@ func TestBuildMydumperArgs_basic(t *testing.T) {
 }
 
 func TestBuildMydumperArgs_compressAndComplete(t *testing.T) {
-	args := buildMydumperArgs("127.0.0.1", 3306, "root", "", "/tmp/dump", 4, nil, nil, "")
+	args := buildMydumperArgs("127.0.0.1", 3306, "root", "", "/tmp/dump", 4, nil, nil, "", true)
 	if !argsContain(args, "--compress-protocol") {
 		t.Error("expected --compress-protocol in args")
 	}
@@ -89,23 +89,112 @@ func TestBuildMydumperArgs_compressAndComplete(t *testing.T) {
 	}
 }
 
-func TestBuildMydumperArgs_lockAndTrx(t *testing.T) {
-	args := buildMydumperArgs("127.0.0.1", 3306, "root", "", "/tmp/dump", 4, nil, nil, "")
+func TestBuildMydumperArgs_lockAndTrx_supported(t *testing.T) {
+	args := buildMydumperArgs("127.0.0.1", 3306, "root", "", "/tmp/dump", 4, nil, nil, "", true)
 	assertArgsContainPair(t, args, "--sync-thread-lock-mode", "NO_LOCK")
 	if !argsContain(args, "--trx-tables") {
-		t.Error("expected --trx-tables in args")
+		t.Error("expected --trx-tables in args when supportsLockMode=true")
+	}
+}
+
+func TestBuildMydumperArgs_lockAndTrx_unsupported(t *testing.T) {
+	args := buildMydumperArgs("127.0.0.1", 3306, "root", "", "/tmp/dump", 4, nil, nil, "", false)
+	if argsContain(args, "--sync-thread-lock-mode") {
+		t.Error("expected --sync-thread-lock-mode to be absent when supportsLockMode=false")
+	}
+	if argsContain(args, "--trx-tables") {
+		t.Error("expected --trx-tables to be absent when supportsLockMode=false")
+	}
+	// Other flags must still be present.
+	if !argsContain(args, "--compress-protocol") {
+		t.Error("--compress-protocol should still be present")
+	}
+	if !argsContain(args, "--complete-insert") {
+		t.Error("--complete-insert should still be present")
+	}
+}
+
+func TestMydumperVersion_parsing(t *testing.T) {
+	cases := []struct {
+		name                  string
+		output                string
+		wantMajor, wantMinor, wantPatch int
+		wantErr               bool
+	}{
+		{
+			name:      "standard_0.10.0",
+			output:    "mydumper 0.10.0, built against MySQL 8.0.36\n",
+			wantMajor: 0, wantMinor: 10, wantPatch: 0,
+		},
+		{
+			name:      "standard_0.11.5",
+			output:    "mydumper 0.11.5, built against MySQL 8.0.37\n",
+			wantMajor: 0, wantMinor: 11, wantPatch: 5,
+		},
+		{
+			name:      "standard_0.16.3",
+			output:    "mydumper 0.16.3-6, built against MySQL 8.4.3\n",
+			wantMajor: 0, wantMinor: 16, wantPatch: 3,
+		},
+		{
+			name:    "empty_output",
+			output:  "",
+			wantErr: true,
+		},
+		{
+			name:    "garbage",
+			output:  "not a version string at all\n",
+			wantErr: true,
+		},
+		{
+			name:    "single_word",
+			output:  "mydumper\n",
+			wantErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// mydumperVersion shells out to `path --version`, so we can't
+			// directly unit-test the parsing without a real binary. Instead
+			// we test the parsing logic inline here by extracting the same
+			// algorithm the function uses.
+			line := strings.SplitN(tc.output, "\n", 2)[0]
+			parts := strings.Fields(line)
+			if len(parts) < 2 {
+				if !tc.wantErr {
+					t.Errorf("expected success but got too few fields in %q", line)
+				}
+				return
+			}
+			ver := strings.TrimRight(parts[1], ",")
+			var major, minor, patch int
+			n, err := fmt.Sscanf(ver, "%d.%d.%d", &major, &minor, &patch)
+			if err != nil || n != 3 {
+				if !tc.wantErr {
+					t.Errorf("expected success but parse failed: ver=%q err=%v", ver, err)
+				}
+				return
+			}
+			if tc.wantErr {
+				t.Error("expected error but parse succeeded")
+				return
+			}
+			if major != tc.wantMajor || minor != tc.wantMinor || patch != tc.wantPatch {
+				t.Errorf("got %d.%d.%d, want %d.%d.%d", major, minor, patch, tc.wantMajor, tc.wantMinor, tc.wantPatch)
+			}
+		})
 	}
 }
 
 func TestBuildMydumperArgs_noPassword(t *testing.T) {
-	args := buildMydumperArgs("127.0.0.1", 3306, "root", "", "/tmp/dump", 4, nil, nil, "")
+	args := buildMydumperArgs("127.0.0.1", 3306, "root", "", "/tmp/dump", 4, nil, nil, "", true)
 	if argsContain(args, "--password") {
 		t.Error("expected --password to be absent when password is empty")
 	}
 }
 
 func TestBuildMydumperArgs_singleSchema(t *testing.T) {
-	args := buildMydumperArgs("127.0.0.1", 3306, "root", "", "/tmp/dump", 4, []string{"mydb"}, nil, "")
+	args := buildMydumperArgs("127.0.0.1", 3306, "root", "", "/tmp/dump", 4, []string{"mydb"}, nil, "", true)
 	assertArgsContainPair(t, args, "--database", "mydb")
 	if argsContain(args, "--regex") {
 		t.Error("expected --regex to be absent for single schema")
@@ -113,7 +202,7 @@ func TestBuildMydumperArgs_singleSchema(t *testing.T) {
 }
 
 func TestBuildMydumperArgs_multipleSchemas(t *testing.T) {
-	args := buildMydumperArgs("127.0.0.1", 3306, "root", "", "/tmp/dump", 4, []string{"db1", "db2"}, nil, "")
+	args := buildMydumperArgs("127.0.0.1", 3306, "root", "", "/tmp/dump", 4, []string{"db1", "db2"}, nil, "", true)
 	if argsContain(args, "--database") {
 		t.Error("expected --database to be absent for multiple schemas")
 	}
@@ -131,12 +220,12 @@ func TestBuildMydumperArgs_multipleSchemas(t *testing.T) {
 }
 
 func TestBuildMydumperArgs_withPassword(t *testing.T) {
-	args := buildMydumperArgs("127.0.0.1", 3306, "root", "s3cr3t", "/tmp/dump", 4, nil, nil, "")
+	args := buildMydumperArgs("127.0.0.1", 3306, "root", "s3cr3t", "/tmp/dump", 4, nil, nil, "", true)
 	assertArgsContainPair(t, args, "--password", "s3cr3t")
 }
 
 func TestBuildMydumperArgs_noSchemasOrTables(t *testing.T) {
-	args := buildMydumperArgs("127.0.0.1", 3306, "root", "", "/tmp/dump", 4, nil, nil, "")
+	args := buildMydumperArgs("127.0.0.1", 3306, "root", "", "/tmp/dump", 4, nil, nil, "", true)
 	for _, flag := range []string{"--database", "--regex", "--tables-list"} {
 		if argsContain(args, flag) {
 			t.Errorf("expected %s to be absent when no schemas or tables given", flag)
@@ -145,7 +234,7 @@ func TestBuildMydumperArgs_noSchemasOrTables(t *testing.T) {
 }
 
 func TestBuildMydumperArgs_regexAnchoredFormat(t *testing.T) {
-	args := buildMydumperArgs("127.0.0.1", 3306, "root", "", "/tmp/dump", 4, []string{"db1", "db2"}, nil, "")
+	args := buildMydumperArgs("127.0.0.1", 3306, "root", "", "/tmp/dump", 4, []string{"db1", "db2"}, nil, "", true)
 	idx := argsIndex(args, "--regex")
 	if idx < 0 || idx+1 >= len(args) {
 		t.Fatal("expected --regex in args")
@@ -162,7 +251,7 @@ func TestBuildMydumperArgs_regexAnchoredFormat(t *testing.T) {
 
 func TestBuildMydumperArgs_schemaAndTables(t *testing.T) {
 	args := buildMydumperArgs("127.0.0.1", 3306, "root", "", "/tmp/dump", 4,
-		[]string{"mydb"}, []string{"mydb.orders", "mydb.items"}, "")
+		[]string{"mydb"}, []string{"mydb.orders", "mydb.items"}, "", true)
 	assertArgsContainPair(t, args, "--database", "mydb")
 	idx := argsIndex(args, "--tables-list")
 	if idx < 0 || idx+1 >= len(args) {
@@ -174,7 +263,7 @@ func TestBuildMydumperArgs_schemaAndTables(t *testing.T) {
 }
 
 func TestBuildMydumperArgs_tables(t *testing.T) {
-	args := buildMydumperArgs("127.0.0.1", 3306, "root", "", "/tmp/dump", 4, nil, []string{"mydb.orders", "mydb.items"}, "")
+	args := buildMydumperArgs("127.0.0.1", 3306, "root", "", "/tmp/dump", 4, nil, []string{"mydb.orders", "mydb.items"}, "", true)
 	idx := argsIndex(args, "--tables-list")
 	if idx < 0 {
 		t.Fatal("expected --tables-list in args")
@@ -207,7 +296,7 @@ func TestBuildMydumperArgs_outputDirIsLast(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			args := buildMydumperArgs("127.0.0.1", 3306, "root", "pw", "/data/backup", 4, tc.schemas, tc.tables, tc.encrypt)
+			args := buildMydumperArgs("127.0.0.1", 3306, "root", "pw", "/data/backup", 4, tc.schemas, tc.tables, tc.encrypt, true)
 			n := len(args)
 			if n < 2 {
 				t.Fatalf("args too short: %v", args)
@@ -295,7 +384,7 @@ func TestAcquireDumpLock_staleLock(t *testing.T) {
 // TestBuildMydumperArgs_threeSchemas verifies that 3+ schemas all appear in the
 // --regex value, not just the first two.
 func TestBuildMydumperArgs_threeSchemas(t *testing.T) {
-	args := buildMydumperArgs("127.0.0.1", 3306, "root", "", "/tmp/dump", 4, []string{"db1", "db2", "db3"}, nil, "")
+	args := buildMydumperArgs("127.0.0.1", 3306, "root", "", "/tmp/dump", 4, []string{"db1", "db2", "db3"}, nil, "", true)
 	idx := argsIndex(args, "--regex")
 	if idx < 0 || idx+1 >= len(args) {
 		t.Fatal("expected --regex in args for 3 schemas")
@@ -625,7 +714,7 @@ func TestDumpCmd_encryptFlagsRegistered(t *testing.T) {
 }
 
 func TestBuildMydumperArgs_encrypt(t *testing.T) {
-	args := buildMydumperArgs("127.0.0.1", 3306, "root", "", "/tmp/dump", 4, nil, nil, "/path/to/key")
+	args := buildMydumperArgs("127.0.0.1", 3306, "root", "", "/tmp/dump", 4, nil, nil, "/path/to/key", true)
 	idx := argsIndex(args, "--exec-per-thread")
 	if idx < 0 {
 		t.Fatal("expected --exec-per-thread in args when encryption enabled")
@@ -644,7 +733,7 @@ func TestBuildMydumperArgs_encrypt(t *testing.T) {
 }
 
 func TestBuildMydumperArgs_noEncrypt(t *testing.T) {
-	args := buildMydumperArgs("127.0.0.1", 3306, "root", "", "/tmp/dump", 4, nil, nil, "")
+	args := buildMydumperArgs("127.0.0.1", 3306, "root", "", "/tmp/dump", 4, nil, nil, "", true)
 	if argsContain(args, "--exec-per-thread") {
 		t.Error("expected --exec-per-thread to be absent when encryption disabled")
 	}


### PR DESCRIPTION
closes #219\n\n## Summary\n\n- `bintrail dump` unconditionally passed `--sync-thread-lock-mode NO_LOCK` and `--trx-tables` to mydumper, but both flags require mydumper >= 0.11.0. Ubuntu 24.04's apt package ships 0.10.0, so the dump failed immediately on the most common Ubuntu install — blocking the entire `dump → baseline → reconstruct --output-format mydumper` pipeline.\n- Added `mydumperVersion(path)` which runs `mydumper --version` and parses the `X.Y.Z` version triple from the output.\n- `buildMydumperArgs` gains a `supportsLockMode bool` parameter. When true (mydumper >= 0.11.0 or Docker mode), both flags are included. When false (older mydumper or parse failure), they are omitted with a `slog.Warn` noting the dump may hold heavier locks.\n- Docker-mode invocations always include the flags since the official `mydumper/mydumper:latest` image ships a recent version.\n- Parse failure is treated conservatively as `supportsLockMode = false` to prevent breaking on any unexpected mydumper distribution.\n\n## Test plan\n\n- [x] `go test ./... -count=1` — 22 packages green\n- [x] `TestBuildMydumperArgs_lockAndTrx_supported` — flags present when `supportsLockMode=true`\n- [x] `TestBuildMydumperArgs_lockAndTrx_unsupported` — flags absent when `supportsLockMode=false`, other flags (`--compress-protocol`, `--complete-insert`) still present\n- [x] `TestMydumperVersion_parsing` — table-driven: standard 0.10.0, 0.11.5, 0.16.3-6 (with suffix), empty output, garbage, single word\n- [x] All existing `buildMydumperArgs` tests pass with `supportsLockMode=true` (backwards-compatible)\n- [ ] E2E: re-run `/e2e-aws 0.5.1` after release to verify tests 18-21 pass with Ubuntu 24.04's mydumper 0.10.0\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)"}
</invoke>