### PR TITLE
Support mydumper 0.10.0 unchunked data-file naming in baseline (#221)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `bintrail baseline` now recognizes mydumper 0.10.0's unchunked data-file naming (`<db>.<table>.sql`) in addition to the chunked format (`<db>.<table>.<chunk>.sql`) used by mydumper >= 0.11.0. Ubuntu 24.04's apt package ships mydumper 0.10.0 which produces single data files without a numeric chunk suffix; `DiscoverTables` previously required the chunk number and silently skipped these files, producing zero Parquet output. Together with #219 (mydumper version probing in `bintrail dump`), this unblocks the entire `dump → baseline → reconstruct --output-format mydumper` pipeline on Ubuntu 24.04 (#221).
+
 ## [0.5.1] - 2026-04-12
 
 ### Fixed

--- a/internal/baseline/baseline_test.go
+++ b/internal/baseline/baseline_test.go
@@ -584,6 +584,85 @@ func TestDiscoverTables(t *testing.T) {
 	}
 }
 
+// TestDiscoverTables_noChunkSuffix verifies that mydumper 0.10.0's unchunked
+// file naming (<db>.<table>.sql without the .<chunk> number) is recognized by
+// DiscoverTables. Ubuntu 24.04's apt package ships mydumper 0.10.0 which uses
+// this format; the chunked format (<db>.<table>.00000.sql) was introduced in
+// 0.11.0. Both must work so the dump → baseline pipeline succeeds regardless
+// of which mydumper version the operator has installed (#221).
+func TestDiscoverTables_noChunkSuffix(t *testing.T) {
+	dir := t.TempDir()
+	files := []string{
+		"e2e_source.orders-schema.sql",
+		"e2e_source.orders.sql", // NO chunk number — mydumper 0.10.0 format
+		"e2e_source.users-schema.sql",
+		"e2e_source.users.sql", // same
+		"e2e_source-schema-create.sql",
+		"metadata",
+	}
+	for _, f := range files {
+		if err := os.WriteFile(filepath.Join(dir, f), []byte(""), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	tables, err := DiscoverTables(dir)
+	if err != nil {
+		t.Fatalf("DiscoverTables: %v", err)
+	}
+	if len(tables) != 2 {
+		t.Fatalf("got %d tables, want 2: %+v", len(tables), tables)
+	}
+	// Sorted alphabetically: orders before users
+	if tables[0].Database != "e2e_source" || tables[0].Table != "orders" {
+		t.Errorf("tables[0] = %q.%q, want e2e_source.orders", tables[0].Database, tables[0].Table)
+	}
+	if len(tables[0].DataFiles) != 1 {
+		t.Errorf("orders has %d data files, want 1", len(tables[0].DataFiles))
+	}
+	if tables[0].Format != "sql" {
+		t.Errorf("orders format = %q, want sql", tables[0].Format)
+	}
+	if tables[1].Database != "e2e_source" || tables[1].Table != "users" {
+		t.Errorf("tables[1] = %q.%q, want e2e_source.users", tables[1].Database, tables[1].Table)
+	}
+}
+
+// TestDiscoverTables_mixedChunkAndNoChunk verifies that if a directory somehow
+// contains both chunked and unchunked files for different tables, both are
+// discovered. This isn't a realistic mydumper output but guards against the
+// fallback path accidentally breaking the chunked path.
+func TestDiscoverTables_mixedChunkAndNoChunk(t *testing.T) {
+	dir := t.TempDir()
+	files := []string{
+		"shop.orders-schema.sql",
+		"shop.orders.00000.sql", // chunked (0.11.0+)
+		"shop.orders.00001.sql",
+		"shop.users-schema.sql",
+		"shop.users.sql", // unchunked (0.10.0)
+		"metadata",
+	}
+	for _, f := range files {
+		if err := os.WriteFile(filepath.Join(dir, f), []byte(""), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	tables, err := DiscoverTables(dir)
+	if err != nil {
+		t.Fatalf("DiscoverTables: %v", err)
+	}
+	if len(tables) != 2 {
+		t.Fatalf("got %d tables, want 2: %+v", len(tables), tables)
+	}
+	if tables[0].Table != "orders" || len(tables[0].DataFiles) != 2 {
+		t.Errorf("orders: want 2 chunked files, got %d", len(tables[0].DataFiles))
+	}
+	if tables[1].Table != "users" || len(tables[1].DataFiles) != 1 {
+		t.Errorf("users: want 1 unchunked file, got %d", len(tables[1].DataFiles))
+	}
+}
+
 // ─── Writer: convertValue, resolveCodec, sortColumnsForParquet ────────────────
 
 func TestConvertValueTypes(t *testing.T) {

--- a/internal/baseline/discover.go
+++ b/internal/baseline/discover.go
@@ -50,7 +50,11 @@ func DiscoverTables(inputDir string) ([]TableFiles, error) {
 			continue
 		}
 
-		// Data file: <db>.<table>.<chunk>.sql or <db>.<table>.<chunk>.dat
+		// Data file: <db>.<table>.<chunk>.sql, <db>.<table>.<chunk>.dat,
+		// or <db>.<table>.sql / <db>.<table>.dat (mydumper 0.10.0 — no
+		// chunk number; the table has a single data file). Both shapes
+		// must be recognized so bintrail baseline works with the
+		// apt-installed mydumper on Ubuntu 24.04 (#221).
 		var ext string
 		switch {
 		case strings.HasSuffix(name, ".sql"):
@@ -63,19 +67,24 @@ func DiscoverTables(inputDir string) ([]TableFiles, error) {
 			continue
 		}
 
-		// The remaining name should be <db>.<table>.<chunk>
+		// Try the chunked format first: <db>.<table>.<chunk>
+		// If the last dot-separated segment is numeric, split it off.
+		// Otherwise fall through to the unchunked format: <db>.<table>.
+		var db, table string
+		var ok bool
 		lastDot := strings.LastIndex(name, ".")
-		if lastDot < 0 {
-			continue
+		if lastDot >= 0 {
+			chunk := name[lastDot+1:]
+			if isNumericChunk(chunk) {
+				db, table, ok = splitDBTable(name[:lastDot])
+			}
 		}
-		chunk := name[lastDot+1:]
-		if !isNumericChunk(chunk) {
-			continue
-		}
-		dbTable := name[:lastDot]
-		db, table, ok := splitDBTable(dbTable)
 		if !ok {
-			continue
+			// Unchunked format (mydumper 0.10.0): name is just <db>.<table>.
+			db, table, ok = splitDBTable(name)
+			if !ok {
+				continue
+			}
 		}
 
 		k := tableKey{db, table}


### PR DESCRIPTION
closes #221\n\n## Summary\n\n- `DiscoverTables` in `internal/baseline/discover.go` required data files to have a numeric chunk suffix (`db.table.00000.sql`), which mydumper >= 0.11.0 produces. mydumper 0.10.0 (Ubuntu 24.04 apt) uses `db.table.sql` without a chunk number — these were silently skipped, producing 0 Parquet files from a valid dump.\n- The discovery loop now falls back to parsing the stripped filename as `<db>.<table>` when the last dot-separated segment is not numeric, so both formats are recognized.\n- Together with #219 (mydumper version probing in `bintrail dump`), this unblocks the entire `dump → baseline → reconstruct --output-format mydumper` pipeline on Ubuntu 24.04.\n\n## Test plan\n\n- [x] `go test ./... -count=1` — 22 packages green\n- [x] `TestDiscoverTables` — existing test (chunked format) still passes\n- [x] `TestDiscoverTables_noChunkSuffix` — new: verifies `e2e_source.orders.sql` (no chunk) is discovered\n- [x] `TestDiscoverTables_mixedChunkAndNoChunk` — new: chunked + unchunked tables coexist\n- [ ] E2E: re-run `/e2e-aws` after release to verify tests 18-21 pass\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)"}
