### PR TITLE
Fix DuckDB glob() usage for S3 baseline discovery

### DIFF
--- a/internal/reconstruct/baseline.go
+++ b/internal/reconstruct/baseline.go
@@ -186,8 +186,8 @@ func findBaselineS3(ctx context.Context, s3URL, schema, table string, at time.Ti
 	globPat := prefix + "/*/" + schema + "/" + table + ".parquet"
 	safeGlob := strings.ReplaceAll(globPat, "'", "''")
 
-	// Use DuckDB's glob() to enumerate matching S3 paths without downloading data.
-	rows, err := db.QueryContext(ctx, "SELECT unnest(glob('"+safeGlob+"')) AS path")
+	// Use DuckDB's glob() table function to enumerate matching S3 paths without downloading data.
+	rows, err := db.QueryContext(ctx, "SELECT * FROM glob('"+safeGlob+"')")
 	if err != nil {
 		return "", time.Time{}, fmt.Errorf("list S3 baseline snapshots: %w", err)
 	}


### PR DESCRIPTION
## Summary

- DuckDB v1.4.4 changed `glob()` from a scalar function to a table function, breaking `findBaselineS3` in the reconstruct package
- Changed `SELECT unnest(glob(...))` to `SELECT * FROM glob(...)` which works across DuckDB versions
- This was the only remaining `glob()` scalar usage — `parquetquery` already uses AWS SDK `ListObjectsV2` (PR #155)

## Test plan

- [x] Verified `SELECT * FROM glob(...)` works on DuckDB v1.4.4 locally
- [x] `go build ./...` passes
- [x] `go test ./internal/reconstruct/ -count=1` passes
- [x] `go test ./... -count=1` — full unit test suite passes

Closes #223