### PR TITLE
Pipeline S3 archive downloads with per-file early termination

### DIFF
--- a/internal/parquetquery/parquetquery.go
+++ b/internal/parquetquery/parquetquery.go
@@ -81,28 +81,53 @@ func Fetch(ctx context.Context, opts query.Options, source string) ([]query.Resu
 
 		dl := newS3Downloader(s3Client)
 
-		// Download and query in batches of 4 for concurrent S3 GETs.
-		// Peak disk usage: 4 temp files (~4-40MB). DuckDB queries each
-		// file, then we delete the batch before the next round.
-		const batchSize = 4
+		// Pipeline: prefetch up to maxInFlightDownloads files in parallel
+		// while DuckDB queries the current one. Queries remain strictly
+		// sequential — only one DuckDB query is active at a time, so peak
+		// RAM (DuckDB's per-query working set) is unchanged from a serial
+		// implementation. Peak temp files on disk: maxInFlightDownloads + 1
+		// (one being queried, the rest buffered as completed prefetches).
+		const maxInFlightDownloads = 2
+		slots := make([]chan dlResult, len(files))
+		for i := range slots {
+			slots[i] = make(chan dlResult, 1)
+		}
+		dlCtx, cancelDl := context.WithCancel(ctx)
+		defer cancelDl()
+		go dl.prefetchAll(dlCtx, files, slots, maxInFlightDownloads)
+
 		var results []query.ResultRow
-		for i := 0; i < len(files); i += batchSize {
-			end := min(i+batchSize, len(files))
-			batch := files[i:end]
-
-			batchResults, batchErr := dl.downloadAndQuery(ctx, db, batch, opts)
-			if batchErr != nil {
-				return nil, batchErr
+		for i := range files {
+			dr, ok := <-slots[i]
+			if !ok {
+				// Slot closed without a value (download canceled); stop.
+				break
 			}
-			results = append(results, batchResults...)
+			if dr.err != nil {
+				cancelDl()
+				drainSlots(slots[i+1:])
+				return nil, fmt.Errorf("download archive file %s: %w", dr.src, dr.err)
+			}
 
-			// Early termination: if we have enough results and all remaining
-			// files are from later hours, no future file can displace them.
-			if opts.Limit > 0 && len(results) >= opts.Limit && end < len(files) {
-				if canTerminateEarly(results, files[end:], opts.Limit) {
+			fileResults, qErr := queryLocalFile(ctx, db, dr.path, dr.src, opts)
+			removeTempFile(dr.path)
+			if qErr != nil {
+				cancelDl()
+				drainSlots(slots[i+1:])
+				return nil, qErr
+			}
+			results = append(results, fileResults...)
+			slog.Debug("queried archive file", "file", dr.src, "rows", len(fileResults))
+
+			// Per-file early termination: stop as soon as no remaining file
+			// can produce a row earlier than what we already have.
+			if opts.Limit > 0 && len(results) >= opts.Limit && i+1 < len(files) {
+				if canTerminateEarly(results, files[i+1:], opts.Limit) {
 					slog.Debug("early termination: collected enough results",
 						"collected", len(results), "limit", opts.Limit,
-						"remaining_files", len(files)-end)
+						"remaining_files", len(files)-i-1)
+					cancelDl()
+					drainSlots(slots[i+1:])
 					break
 				}
 			}
@@ -297,70 +322,85 @@ func (d *s3Downloader) download(ctx context.Context, s3URL string) (string, erro
 	return tmp.Name(), nil
 }
 
-// downloadAndQuery downloads a batch of S3 files concurrently, queries each
-// with DuckDB, and returns the combined results. Temp files are cleaned up
-// after querying regardless of success or failure.
-func (d *s3Downloader) downloadAndQuery(ctx context.Context, db *sql.DB, files []string, opts query.Options) ([]query.ResultRow, error) {
-	tmpPaths, dlErr := d.downloadBatch(ctx, files)
-	if dlErr != nil {
-		return nil, fmt.Errorf("download archive files: %w", dlErr)
-	}
-	defer removeTempFiles(tmpPaths)
-
-	var results []query.ResultRow
-	for j, tmpPath := range tmpPaths {
-		cols, colErr := parquetColumns(ctx, db, tmpPath)
-		if colErr != nil {
-			return nil, fmt.Errorf("read parquet schema %s: %w", files[j], colErr)
-		}
-		q, args := buildQueryForFile(tmpPath, opts, cols)
-		rows, err := db.QueryContext(ctx, q, args...)
-		if err != nil {
-			return nil, fmt.Errorf("parquet query %s: %w", files[j], err)
-		}
-		fileResults, scanErr := scanRows(rows)
-		rows.Close()
-		if scanErr != nil {
-			return nil, scanErr
-		}
-		results = append(results, fileResults...)
-		slog.Debug("queried archive file", "file", files[j], "rows", len(fileResults))
-	}
-	return results, nil
+// dlResult carries the outcome of a single S3 file download to the consumer.
+// path is the temp file path on disk (caller deletes); err is set when the
+// download itself failed.
+type dlResult struct {
+	path string
+	src  string
+	err  error
 }
 
-// downloadBatch downloads multiple S3 files concurrently and returns their
-// local temp paths. On error, cleans up all downloaded files. The caller
-// controls concurrency by limiting the batch size (typically 4).
-func (d *s3Downloader) downloadBatch(ctx context.Context, files []string) ([]string, error) {
-	paths := make([]string, len(files))
-	g, gctx := errgroup.WithContext(ctx)
+// prefetchAll downloads files into their slots with bounded parallelism.
+// Each slot is closed exactly once — by the per-file goroutine if it ran,
+// or by prefetchAll directly if cancellation prevented launch — so the
+// consumer's range/<-slots[i] always unblocks.
+func (d *s3Downloader) prefetchAll(ctx context.Context, files []string, slots []chan dlResult, maxInFlight int) {
+	sem := make(chan struct{}, maxInFlight)
+	var wg sync.WaitGroup
 	for i, f := range files {
-		g.Go(func() error {
-			p, err := d.download(gctx, f)
-			if err != nil {
-				return err
+		select {
+		case sem <- struct{}{}:
+		case <-ctx.Done():
+			// Close slots we never launched so the consumer doesn't block.
+			for k := i; k < len(slots); k++ {
+				close(slots[k])
 			}
-			paths[i] = p
-			return nil
-		})
+			wg.Wait()
+			return
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+			defer close(slots[i])
+			path, err := d.download(ctx, f)
+			if ctx.Err() != nil {
+				// Consumer is gone; clean up our temp file rather than send.
+				removeTempFile(path)
+				return
+			}
+			slots[i] <- dlResult{path: path, src: f, err: err}
+		}()
 	}
-	if err := g.Wait(); err != nil {
-		removeTempFiles(paths)
-		return nil, err
-	}
-	return paths, nil
+	wg.Wait()
 }
 
-// removeTempFiles deletes all non-empty paths in the slice.
-func removeTempFiles(paths []string) {
-	for _, p := range paths {
-		if p != "" {
-			if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
-				slog.Warn("failed to remove temp file", "path", p, "error", err)
-			}
+// drainSlots consumes any pending prefetched results and removes their temp
+// files. Called after the consumer stops reading (early termination or error)
+// so we don't leak files prefetched before cancellation took effect.
+func drainSlots(slots []chan dlResult) {
+	for _, ch := range slots {
+		if dr, ok := <-ch; ok {
+			removeTempFile(dr.path)
 		}
 	}
+}
+
+// removeTempFile deletes a single temp file path, ignoring missing-file errors.
+func removeTempFile(path string) {
+	if path == "" {
+		return
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		slog.Warn("failed to remove temp file", "path", path, "error", err)
+	}
+}
+
+// queryLocalFile runs a single DuckDB query against a downloaded parquet file
+// and returns the matching rows. The caller deletes the file after this returns.
+func queryLocalFile(ctx context.Context, db *sql.DB, path, srcURL string, opts query.Options) ([]query.ResultRow, error) {
+	cols, colErr := parquetColumns(ctx, db, path)
+	if colErr != nil {
+		return nil, fmt.Errorf("read parquet schema %s: %w", srcURL, colErr)
+	}
+	q, args := buildQueryForFile(path, opts, cols)
+	rows, err := db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("parquet query %s: %w", srcURL, err)
+	}
+	defer rows.Close()
+	return scanRows(rows)
 }
 
 // sortFilesByHour sorts S3 file paths chronologically by their Hive partition

--- a/internal/parquetquery/parquetquery.go
+++ b/internal/parquetquery/parquetquery.go
@@ -85,8 +85,9 @@ func Fetch(ctx context.Context, opts query.Options, source string) ([]query.Resu
 		// while DuckDB queries the current one. Queries remain strictly
 		// sequential — only one DuckDB query is active at a time, so peak
 		// RAM (DuckDB's per-query working set) is unchanged from a serial
-		// implementation. Peak temp files on disk: maxInFlightDownloads + 1
-		// (one being queried, the rest buffered as completed prefetches).
+		// implementation. Peak temp files on disk at any instant:
+		// maxInFlightDownloads + 1 (one being queried, the rest buffered
+		// as completed prefetches).
 		const maxInFlightDownloads = 2
 		slots := make([]chan dlResult, len(files))
 		for i := range slots {
@@ -94,7 +95,7 @@ func Fetch(ctx context.Context, opts query.Options, source string) ([]query.Resu
 		}
 		dlCtx, cancelDl := context.WithCancel(ctx)
 		defer cancelDl()
-		go dl.prefetchAll(dlCtx, files, slots, maxInFlightDownloads)
+		go prefetchAll(dlCtx, files, slots, maxInFlightDownloads, dl.download)
 
 		var results []query.ResultRow
 		for i := range files {
@@ -323,19 +324,24 @@ func (d *s3Downloader) download(ctx context.Context, s3URL string) (string, erro
 }
 
 // dlResult carries the outcome of a single S3 file download to the consumer.
-// path is the temp file path on disk (caller deletes); err is set when the
-// download itself failed.
+// path is the temp file path on disk (caller deletes); empty when err is set.
 type dlResult struct {
 	path string
 	src  string
 	err  error
 }
 
+// downloadFn fetches a remote file to a local temp path. The implementation
+// returns ("", err) on failure or (path, nil) on success. Abstracted as a
+// function (rather than a method on *s3Downloader) so tests can inject fakes.
+type downloadFn func(ctx context.Context, src string) (string, error)
+
 // prefetchAll downloads files into their slots with bounded parallelism.
 // Each slot is closed exactly once — by the per-file goroutine if it ran,
-// or by prefetchAll directly if cancellation prevented launch — so the
-// consumer's range/<-slots[i] always unblocks.
-func (d *s3Downloader) prefetchAll(ctx context.Context, files []string, slots []chan dlResult, maxInFlight int) {
+// by prefetchAll directly if cancellation prevented launch, or by the
+// goroutine's defer when cancellation arrives after download completes —
+// so the consumer's <-slots[i] always unblocks.
+func prefetchAll(ctx context.Context, files []string, slots []chan dlResult, maxInFlight int, download downloadFn) {
 	sem := make(chan struct{}, maxInFlight)
 	var wg sync.WaitGroup
 	for i, f := range files {
@@ -354,9 +360,15 @@ func (d *s3Downloader) prefetchAll(ctx context.Context, files []string, slots []
 			defer wg.Done()
 			defer func() { <-sem }()
 			defer close(slots[i])
-			path, err := d.download(ctx, f)
+			path, err := download(ctx, f)
 			if ctx.Err() != nil {
 				// Consumer is gone; clean up our temp file rather than send.
+				// Surface the underlying download error too — without this,
+				// a real failure (403, network) that races with cancellation
+				// would be invisible.
+				if err != nil {
+					slog.Debug("download error discarded after cancel", "src", f, "error", err)
+				}
 				removeTempFile(path)
 				return
 			}

--- a/internal/parquetquery/parquetquery.go
+++ b/internal/parquetquery/parquetquery.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -364,17 +363,14 @@ func prefetchAll(ctx context.Context, files []string, slots []chan dlResult, max
 			path, err := download(ctx, f)
 			if ctx.Err() != nil {
 				// Consumer is gone; clean up our temp file rather than send.
-				// Surface the underlying download error too — without this,
-				// a real failure (403, network) that races with cancellation
-				// would be invisible. Distinguish: a context error coinciding
-				// with cancellation is expected (Debug); any other error
-				// (403, DNS, throttling) is a real problem and warrants Warn.
+				// Any error here is downstream of cancellation — a real S3
+				// download error (closed connection, request canceled by the
+				// transport, etc.) often does NOT wrap context.Canceled, so
+				// classifying by error type produces false positives. Real
+				// persistent S3 problems will resurface on the consumer's
+				// next non-canceled query via dr.err.
 				if err != nil {
-					if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-						slog.Debug("download canceled", "src", f, "error", err)
-					} else {
-						slog.Warn("download error discarded after cancel", "src", f, "error", err)
-					}
+					slog.Debug("download discarded after cancel", "src", f, "error", err)
 				}
 				removeTempFile(path)
 				return

--- a/internal/parquetquery/parquetquery.go
+++ b/internal/parquetquery/parquetquery.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -365,9 +366,15 @@ func prefetchAll(ctx context.Context, files []string, slots []chan dlResult, max
 				// Consumer is gone; clean up our temp file rather than send.
 				// Surface the underlying download error too — without this,
 				// a real failure (403, network) that races with cancellation
-				// would be invisible.
+				// would be invisible. Distinguish: a context error coinciding
+				// with cancellation is expected (Debug); any other error
+				// (403, DNS, throttling) is a real problem and warrants Warn.
 				if err != nil {
-					slog.Debug("download error discarded after cancel", "src", f, "error", err)
+					if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+						slog.Debug("download canceled", "src", f, "error", err)
+					} else {
+						slog.Warn("download error discarded after cancel", "src", f, "error", err)
+					}
 				}
 				removeTempFile(path)
 				return

--- a/internal/parquetquery/parquetquery_test.go
+++ b/internal/parquetquery/parquetquery_test.go
@@ -842,6 +842,46 @@ func TestPrefetchAllInFlightDownloadsCleanedUp(t *testing.T) {
 	}
 }
 
+func TestPrefetchAllRespectsMaxInFlight(t *testing.T) {
+	// With maxInFlight=2, only 2 downloads should be in flight at any
+	// moment. We hold all downloads at preWriteGate; the 3rd attempt
+	// blocks on the semaphore inside prefetchAll, so its goroutine never
+	// launches and `started` stays at exactly 2 until the gate releases.
+	dir := t.TempDir()
+	gate := make(chan struct{})
+	fd := &fakeDownloader{dir: dir, preWriteGate: gate}
+
+	files := []string{"a", "b", "c", "d", "e"}
+	slots := makeSlots(len(files))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		prefetchAll(ctx, files, slots, 2, fd.fn())
+		close(done)
+	}()
+
+	// First two reach the gate; the rest are blocked at the semaphore.
+	// No settle delay is needed: the outer for loop in prefetchAll cannot
+	// launch goroutine 3 until a sem token is released, which cannot
+	// happen until the gate releases.
+	fd.waitForStarted(t, 2)
+	if got := fd.started.Load(); got != 2 {
+		t.Errorf("maxInFlight=2 violated: %d downloads started, want exactly 2", got)
+	}
+
+	// Wind down cleanly.
+	cancel()
+	close(gate)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("prefetchAll did not return")
+	}
+	drainSlots(slots)
+}
+
 func TestPrefetchAllPropagatesDownloadError(t *testing.T) {
 	// A failed download must surface to the consumer via dlResult.err so
 	// the consumer (Fetch) can abort and clean up. Earlier successful

--- a/internal/parquetquery/parquetquery_test.go
+++ b/internal/parquetquery/parquetquery_test.go
@@ -1,6 +1,8 @@
 package parquetquery
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -589,4 +591,45 @@ func TestCanTerminateEarly(t *testing.T) {
 			t.Error("should not terminate: no remaining files")
 		}
 	})
+}
+
+// ─── drainSlots / removeTempFile (pipeline cleanup) ─────────────────────────
+
+func TestDrainSlotsRemovesPrefetchedFiles(t *testing.T) {
+	dir := t.TempDir()
+	mkFile := func(name string) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	// Two slots: one with a prefetched file, one closed without value
+	// (simulates a download that was canceled before completing).
+	a, b := mkFile("a.parquet"), mkFile("b.parquet")
+	slots := []chan dlResult{
+		make(chan dlResult, 1),
+		make(chan dlResult, 1),
+		make(chan dlResult, 1),
+	}
+	slots[0] <- dlResult{path: a}
+	close(slots[0])
+	slots[1] <- dlResult{path: b}
+	close(slots[1])
+	close(slots[2]) // closed empty — no path to remove
+
+	drainSlots(slots)
+
+	for _, p := range []string{a, b} {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Errorf("expected %s removed, got err=%v", p, err)
+		}
+	}
+}
+
+func TestRemoveTempFileMissingIsNoOp(t *testing.T) {
+	// Should not warn or panic on missing files.
+	removeTempFile(filepath.Join(t.TempDir(), "does-not-exist.parquet"))
+	removeTempFile("") // empty path is also a no-op
 }

--- a/internal/parquetquery/parquetquery_test.go
+++ b/internal/parquetquery/parquetquery_test.go
@@ -1,9 +1,13 @@
 package parquetquery
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -632,4 +636,179 @@ func TestRemoveTempFileMissingIsNoOp(t *testing.T) {
 	// Should not warn or panic on missing files.
 	removeTempFile(filepath.Join(t.TempDir(), "does-not-exist.parquet"))
 	removeTempFile("") // empty path is also a no-op
+}
+
+// ─── prefetchAll (pipeline concurrency invariants) ─────────────────────────
+
+// fakeDownloader builds a downloadFn that creates real temp files in dir,
+// optionally blocking on a per-call basis to model slow downloads. Callers
+// can cancel mid-flight to exercise cleanup paths.
+type fakeDownloader struct {
+	dir     string
+	created atomic.Int32
+	gate    chan struct{} // closed → all calls return immediately; nil → no gating
+	failOn  string        // src that should return an error instead of a path
+}
+
+func (f *fakeDownloader) fn() downloadFn {
+	return func(ctx context.Context, src string) (string, error) {
+		if f.gate != nil {
+			select {
+			case <-f.gate:
+			case <-ctx.Done():
+				return "", ctx.Err()
+			}
+		}
+		if src == f.failOn {
+			return "", errors.New("simulated download failure")
+		}
+		path := filepath.Join(f.dir, fmt.Sprintf("dl-%d.parquet", f.created.Add(1)))
+		if err := os.WriteFile(path, []byte("data"), 0o600); err != nil {
+			return "", err
+		}
+		return path, nil
+	}
+}
+
+// remainingFiles returns the temp files in dir that haven't been deleted —
+// used to assert pipeline cleanup did its job.
+func remainingFiles(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var paths []string
+	for _, e := range entries {
+		paths = append(paths, e.Name())
+	}
+	return paths
+}
+
+func makeSlots(n int) []chan dlResult {
+	slots := make([]chan dlResult, n)
+	for i := range slots {
+		slots[i] = make(chan dlResult, 1)
+	}
+	return slots
+}
+
+func TestPrefetchAllClosesEverySlotOnCancel(t *testing.T) {
+	// Cancellation must close every slot so the consumer's <-slots[i] never
+	// blocks forever. Mix of launched-but-pending downloads (held by gate)
+	// and unlaunched slots (semaphore not yet acquired).
+	dir := t.TempDir()
+	gate := make(chan struct{}) // never closed; fake downloads will block
+	fd := &fakeDownloader{dir: dir, gate: gate}
+
+	files := []string{"a", "b", "c", "d", "e"}
+	slots := makeSlots(len(files))
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		prefetchAll(ctx, files, slots, 2, fd.fn())
+		close(done)
+	}()
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("prefetchAll did not return after cancel")
+	}
+
+	for i, ch := range slots {
+		select {
+		case _, ok := <-ch:
+			if ok {
+				// Receiving a value is fine (ok=true) iff a download had
+				// already completed before cancel; on the next read we'd
+				// see ok=false. The point is the channel is not blocking.
+			}
+		default:
+			t.Errorf("slot %d not closed (would block consumer)", i)
+		}
+	}
+}
+
+func TestPrefetchAllNoLeakWhenConsumerAbandonsMidStream(t *testing.T) {
+	// Simulates the consumer breaking on early termination: it reads one
+	// slot, then cancels and drains the rest. Every temp file the fake
+	// downloader created must be removed.
+	dir := t.TempDir()
+	fd := &fakeDownloader{dir: dir} // no gate — downloads complete immediately
+
+	files := []string{"a", "b", "c", "d", "e", "f"}
+	slots := makeSlots(len(files))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		prefetchAll(ctx, files, slots, 2, fd.fn())
+		close(done)
+	}()
+
+	// Consumer reads slot 0 and cleans up the temp file it received.
+	dr := <-slots[0]
+	if dr.err != nil {
+		t.Fatalf("unexpected error: %v", dr.err)
+	}
+	removeTempFile(dr.path)
+
+	// Mimic Fetch's early-termination path.
+	cancel()
+	drainSlots(slots[1:])
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("prefetchAll did not return after cancel")
+	}
+
+	if leftover := remainingFiles(t, dir); len(leftover) != 0 {
+		t.Errorf("temp files leaked: %v", leftover)
+	}
+}
+
+func TestPrefetchAllInFlightDownloadsCleanedUp(t *testing.T) {
+	// The trickiest race: a download that's still in flight when cancel
+	// fires. The goroutine's post-download ctx.Err() check must remove
+	// the temp file rather than send it. Use a gate that releases AFTER
+	// cancel to force this ordering.
+	dir := t.TempDir()
+	gate := make(chan struct{})
+	fd := &fakeDownloader{dir: dir, gate: gate}
+
+	files := []string{"a", "b", "c", "d"}
+	slots := makeSlots(len(files))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		prefetchAll(ctx, files, slots, 2, fd.fn())
+		close(done)
+	}()
+
+	// Cancel BEFORE releasing the gate so in-flight downloads observe
+	// ctx.Done in their fake impl AND the post-download check.
+	time.Sleep(20 * time.Millisecond) // let the first 2 enter the gate
+	cancel()
+	close(gate) // release whatever's waiting
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("prefetchAll did not return")
+	}
+
+	// Drain anything that managed to land in slots before cancel propagated.
+	drainSlots(slots)
+
+	if leftover := remainingFiles(t, dir); len(leftover) != 0 {
+		t.Errorf("temp files leaked from in-flight downloads: %v", leftover)
+	}
 }

--- a/internal/parquetquery/parquetquery_test.go
+++ b/internal/parquetquery/parquetquery_test.go
@@ -640,21 +640,30 @@ func TestRemoveTempFileMissingIsNoOp(t *testing.T) {
 
 // ─── prefetchAll (pipeline concurrency invariants) ─────────────────────────
 
-// fakeDownloader builds a downloadFn that creates real temp files in dir,
-// optionally blocking on a per-call basis to model slow downloads. Callers
-// can cancel mid-flight to exercise cleanup paths.
+// fakeDownloader builds a downloadFn that creates real temp files in dir.
+// Two optional gates control timing:
+//   - preWriteGate: blocks BEFORE creating the file and respects ctx.
+//     Models a stuck download that returns ctx.Err on cancel.
+//   - postWriteGate: blocks AFTER creating the file and ignores ctx.
+//     Models a download that completed just as the consumer canceled —
+//     the file exists and the caller must clean it up.
+//
+// `started` lets tests wait for N calls to be in flight without time.Sleep.
 type fakeDownloader struct {
-	dir     string
-	created atomic.Int32
-	gate    chan struct{} // closed → all calls return immediately; nil → no gating
-	failOn  string        // src that should return an error instead of a path
+	dir           string
+	created       atomic.Int32
+	started       atomic.Int32
+	preWriteGate  chan struct{}
+	postWriteGate chan struct{}
+	failOn        string // src that should return an error instead of a path
 }
 
 func (f *fakeDownloader) fn() downloadFn {
 	return func(ctx context.Context, src string) (string, error) {
-		if f.gate != nil {
+		f.started.Add(1)
+		if f.preWriteGate != nil {
 			select {
-			case <-f.gate:
+			case <-f.preWriteGate:
 			case <-ctx.Done():
 				return "", ctx.Err()
 			}
@@ -666,7 +675,23 @@ func (f *fakeDownloader) fn() downloadFn {
 		if err := os.WriteFile(path, []byte("data"), 0o600); err != nil {
 			return "", err
 		}
+		if f.postWriteGate != nil {
+			<-f.postWriteGate
+		}
 		return path, nil
+	}
+}
+
+// waitForStarted polls f.started until it reaches n or the deadline elapses.
+// Replaces time.Sleep-based synchronization to avoid CI flakes.
+func (f *fakeDownloader) waitForStarted(t *testing.T, n int32) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for f.started.Load() < n {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %d downloads to start (got %d)", n, f.started.Load())
+		}
+		time.Sleep(time.Millisecond)
 	}
 }
 
@@ -699,7 +724,7 @@ func TestPrefetchAllClosesEverySlotOnCancel(t *testing.T) {
 	// and unlaunched slots (semaphore not yet acquired).
 	dir := t.TempDir()
 	gate := make(chan struct{}) // never closed; fake downloads will block
-	fd := &fakeDownloader{dir: dir, gate: gate}
+	fd := &fakeDownloader{dir: dir, preWriteGate: gate}
 
 	files := []string{"a", "b", "c", "d", "e"}
 	slots := makeSlots(len(files))
@@ -719,14 +744,11 @@ func TestPrefetchAllClosesEverySlotOnCancel(t *testing.T) {
 		t.Fatal("prefetchAll did not return after cancel")
 	}
 
+	// Every slot must be readable without blocking — either it has a value
+	// (received before cancel) or it's closed.
 	for i, ch := range slots {
 		select {
-		case _, ok := <-ch:
-			if ok {
-				// Receiving a value is fine (ok=true) iff a download had
-				// already completed before cancel; on the next read we'd
-				// see ok=false. The point is the channel is not blocking.
-			}
+		case <-ch:
 		default:
 			t.Errorf("slot %d not closed (would block consumer)", i)
 		}
@@ -774,13 +796,17 @@ func TestPrefetchAllNoLeakWhenConsumerAbandonsMidStream(t *testing.T) {
 }
 
 func TestPrefetchAllInFlightDownloadsCleanedUp(t *testing.T) {
-	// The trickiest race: a download that's still in flight when cancel
-	// fires. The goroutine's post-download ctx.Err() check must remove
-	// the temp file rather than send it. Use a gate that releases AFTER
-	// cancel to force this ordering.
+	// The trickiest race: a download has already written its file when
+	// ctx is canceled. The goroutine's post-download ctx.Err() branch
+	// must remove the temp file rather than send it to the slot.
+	//
+	// The fake writes the file BEFORE waiting on `gate`, so when we
+	// cancel and then release the gate, both gated downloads return
+	// (path, nil) and prefetchAll's post-download check observes
+	// ctx.Err() != nil → must call removeTempFile(path).
 	dir := t.TempDir()
 	gate := make(chan struct{})
-	fd := &fakeDownloader{dir: dir, gate: gate}
+	fd := &fakeDownloader{dir: dir, postWriteGate: gate}
 
 	files := []string{"a", "b", "c", "d"}
 	slots := makeSlots(len(files))
@@ -793,11 +819,14 @@ func TestPrefetchAllInFlightDownloadsCleanedUp(t *testing.T) {
 		close(done)
 	}()
 
-	// Cancel BEFORE releasing the gate so in-flight downloads observe
-	// ctx.Done in their fake impl AND the post-download check.
-	time.Sleep(20 * time.Millisecond) // let the first 2 enter the gate
+	// Wait deterministically for both in-flight downloads to have written
+	// their temp files and parked at the gate.
+	fd.waitForStarted(t, 2)
+	if got := fd.created.Load(); got != 2 {
+		t.Fatalf("expected 2 temp files written, got %d", got)
+	}
 	cancel()
-	close(gate) // release whatever's waiting
+	close(gate)
 
 	select {
 	case <-done:
@@ -805,10 +834,60 @@ func TestPrefetchAllInFlightDownloadsCleanedUp(t *testing.T) {
 		t.Fatal("prefetchAll did not return")
 	}
 
-	// Drain anything that managed to land in slots before cancel propagated.
+	// Drain anything that landed in slots before cancel propagated.
 	drainSlots(slots)
 
 	if leftover := remainingFiles(t, dir); len(leftover) != 0 {
 		t.Errorf("temp files leaked from in-flight downloads: %v", leftover)
+	}
+}
+
+func TestPrefetchAllPropagatesDownloadError(t *testing.T) {
+	// A failed download must surface to the consumer via dlResult.err so
+	// the consumer (Fetch) can abort and clean up. Earlier successful
+	// downloads still arrive intact; later slots may still be in flight
+	// or unstarted depending on cancellation timing.
+	dir := t.TempDir()
+	fd := &fakeDownloader{dir: dir, failOn: "b"}
+
+	files := []string{"a", "b", "c"}
+	slots := makeSlots(len(files))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		prefetchAll(ctx, files, slots, 1, fd.fn())
+		close(done)
+	}()
+
+	// Slot 0 succeeds.
+	a := <-slots[0]
+	if a.err != nil {
+		t.Fatalf("slot 0: unexpected error: %v", a.err)
+	}
+	removeTempFile(a.path)
+
+	// Slot 1 carries the simulated download error.
+	b := <-slots[1]
+	if b.err == nil {
+		t.Fatal("slot 1: expected download error, got nil")
+	}
+	if b.path != "" {
+		t.Errorf("slot 1: expected empty path on error, got %q", b.path)
+	}
+
+	// Consumer would now cancel and drain.
+	cancel()
+	drainSlots(slots[2:])
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("prefetchAll did not return")
+	}
+
+	if leftover := remainingFiles(t, dir); len(leftover) != 0 {
+		t.Errorf("temp files leaked: %v", leftover)
 	}
 }


### PR DESCRIPTION
closes #225

## Summary
- Replaces the per-batch (size 4) download-then-query loop with a single-pass pipeline that prefetches up to 2 files in parallel while DuckDB queries the current one.
- Queries remain strictly sequential — only one DuckDB query is active at a time, so peak per-query RAM is unchanged from the prior implementation.
- Peak temp files on disk drops from 4 to 3 (2 prefetched + 1 active query).
- Early termination is now checked after every file instead of every batch boundary, so wide time-range queries with `--limit` can stop as soon as the collected results cannot be displaced by any later file.
- `ORDER BY event_timestamp, event_id` is preserved per-file to keep the "earliest N" semantics of `--limit`.

## Memory profile vs. previous
| | Before (batch=4) | After (pipeline=2) |
|---|---|---|
| Concurrent DuckDB queries | 1 | 1 |
| Peak temp files on disk | 4 | 3 |
| Concurrent S3 downloads | 4 | 2 |

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] Added `TestDrainSlotsRemovesPrefetchedFiles` to verify cleanup of prefetched files on early termination/error.
- [x] Added `TestRemoveTempFileMissingIsNoOp` to confirm cleanup is safe on missing/empty paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)