### PR TITLE
Detect BYOS source identity drift and S3 partition-key cutover

### DIFF
--- a/cmd/bintrail/agent.go
+++ b/cmd/bintrail/agent.go
@@ -639,32 +639,39 @@ func byosStreamLoop(ctx context.Context, events <-chan parser.Event, buf *buffer
 	}
 	identityFailures := 0
 
-	flushBatch := func() {
+	// flushBatch drains the pending batch to the in-memory buffer and, if
+	// sinks are configured, to the metadata/payload destinations.
+	//
+	// Returns an error only for programmer errors detected during the sink
+	// flush (nil sourceIdent pointer). Transient sink failures are logged
+	// inside flushToSinks and surfaced via flushPipelineState.
+	flushBatch := func() error {
 		if len(batch) == 0 {
-			return
+			return nil
 		}
 
-		// Always insert into buffer.
 		buf.Insert(batch)
 		slog.Debug("BYOS batch flushed to buffer", "events", len(batch), "buffer_size", buf.Len())
 
 		// Split and flush to sinks if configured. Skip on shutdown —
 		// the sinks would fail immediately with context.Canceled and
 		// produce misleading error logs.
+		var flushErr error
 		if fc != nil && (fc.metaClient != nil || fc.payloadWriter != nil) && ctx.Err() == nil {
-			flushToSinks(ctx, batch, fc)
+			flushErr = flushToSinks(ctx, batch, fc)
 		}
 		if fc != nil && fc.state != nil {
 			fc.state.setBufferStats(buf.Len(), buf.ApproxBytes(), buf.SizeEvictions())
 		}
 
 		batch = batch[:0]
+		return flushErr
 	}
 
 	for {
 		select {
 		case <-ctx.Done():
-			flushBatch()
+			_ = flushBatch()
 			return nil
 
 		case <-evictTicker.C:
@@ -677,18 +684,19 @@ func byosStreamLoop(ctx context.Context, events <-chan parser.Event, buf *buffer
 			}
 
 		case <-flushTicker.C:
-			// Timer-based flush to bound metadata latency.
-			flushBatch()
+			if err := flushBatch(); err != nil {
+				return err
+			}
 
 		case <-identityTickerC:
 			if err := checkSourceIdentity(ctx, fc.sourceDB, fc.sourceIdent, &identityFailures); err != nil {
-				flushBatch()
+				_ = flushBatch()
 				return err
 			}
 
 		case ev, ok := <-events:
 			if !ok {
-				flushBatch()
+				_ = flushBatch()
 				return nil
 			}
 
@@ -699,7 +707,9 @@ func byosStreamLoop(ctx context.Context, events <-chan parser.Event, buf *buffer
 
 			batch = append(batch, ev)
 			if len(batch) >= batchSize {
-				flushBatch()
+				if err := flushBatch(); err != nil {
+					return err
+				}
 			}
 		}
 	}
@@ -707,30 +717,18 @@ func byosStreamLoop(ctx context.Context, events <-chan parser.Event, buf *buffer
 
 // flushToSinks splits events via byos.SplitEvent and sends metadata to
 // dbtrail and payload to S3. Retries each sink up to 3 times with
-// exponential backoff. Failures are logged but never block the stream.
-func flushToSinks(ctx context.Context, batch []parser.Event, fc *byosFlushConfig) {
-	// Snapshot the identity pointer once per flush so every record in this
-	// batch uses the same value. A nil pointer or a nil snapshot would
-	// result in metadata records going out with an empty @@server_uuid —
-	// silently misattributing events at the SaaS side. That's a programmer
-	// error, not a runtime condition; abort the flush and mark the pipeline
-	// degraded so the heartbeat surfaces the stuck state.
+// exponential backoff. Transient sink failures are logged but never block
+// the stream. Returns an error only for programmer-error conditions (nil
+// sourceIdent pointer) so the caller can tear down the stream rather than
+// run forever with a degraded heartbeat — consistent with how
+// checkSourceIdentity handles its "BUG" case.
+func flushToSinks(ctx context.Context, batch []parser.Event, fc *byosFlushConfig) error {
 	if fc.sourceIdent == nil {
-		slog.Error("BYOS flush: sourceIdent pointer is nil — refusing to emit metadata with empty server_uuid",
-			"batch_size", len(batch))
-		if fc.state != nil {
-			fc.state.updateFlush(false, false)
-		}
-		return
+		return fmt.Errorf("BUG: sourceIdent pointer is nil — refusing to emit metadata with empty server_uuid (batch_size=%d)", len(batch))
 	}
 	p := fc.sourceIdent.Load()
 	if p == nil {
-		slog.Error("BYOS flush: sourceIdent not initialized — refusing to emit metadata with empty server_uuid",
-			"batch_size", len(batch))
-		if fc.state != nil {
-			fc.state.updateFlush(false, false)
-		}
-		return
+		return fmt.Errorf("BUG: sourceIdent pointer not initialized — refusing to emit metadata with empty server_uuid (batch_size=%d)", len(batch))
 	}
 	ident := *p
 
@@ -752,7 +750,7 @@ func flushToSinks(ctx context.Context, batch []parser.Event, fc *byosFlushConfig
 	}
 
 	if len(metaBatch) == 0 {
-		return
+		return nil
 	}
 
 	metaOK := true
@@ -783,6 +781,7 @@ func flushToSinks(ctx context.Context, batch []parser.Event, fc *byosFlushConfig
 	if fc.state != nil {
 		fc.state.updateFlush(metaOK, payloadOK)
 	}
+	return nil
 }
 
 // maxIdentityFailures is the number of consecutive failed re-captures that
@@ -806,6 +805,13 @@ const maxIdentityFailures = 10
 //     (logged as warning); after that, returns the error so the stream tears
 //     down rather than running forever with a possibly-stale identity.
 //   - context.Canceled: nil, no log (the loop is shutting down).
+//
+// The failure counter tracks STRICT consecutive failures — a single successful
+// query resets it. A source that flaps (succeeds at least once per
+// maxIdentityFailures ticks) will log repeated warnings but never trip the
+// threshold. Permanent failures (revoked creds, dropped user) still do.
+// Rolling-window detection is out of scope; if flapping becomes a real
+// failure mode, revisit this function.
 func checkSourceIdentity(ctx context.Context, sourceDB *sql.DB, prev *atomic.Pointer[byos.SourceIdentity], failures *int) error {
 	var uuid string
 	err := sourceDB.QueryRowContext(ctx, "SELECT @@server_uuid").Scan(&uuid)

--- a/cmd/bintrail/agent.go
+++ b/cmd/bintrail/agent.go
@@ -233,17 +233,15 @@ func runAgent(cmd *cobra.Command, args []string) error {
 			"server_uuid", sourceIdent.ServerUUID,
 			"local_server_id", fmt.Sprint(agtServerID))
 
-		// If S3 is configured, the partition key falls back to the numeric
-		// --server-id. A prior agent run that had --index-dsn would have used
-		// a UUID instead — objects would live under a different S3 prefix
-		// (issue #198). EnsurePartitionKey (called below when S3 is set up)
-		// will hard-fail if a mismatched marker is found, but log ahead of
-		// time so the operator sees the chosen key in the startup banner.
+		// Log the chosen S3 partition key so it shows in the startup banner
+		// regardless of whether the marker check that follows passes.
+		// EnsurePartitionKey refuses to start the agent if a marker already
+		// exists under a different server_id (issue #198), so contrary to
+		// what an older CLI version would do, prior objects cannot be
+		// silently orphaned here — the agent will fail fast and surface a
+		// migration message instead.
 		if agtS3Bucket != "" {
-			slog.Warn("BYOS+S3 without --index-dsn: S3 partition key uses numeric --server-id; "+
-				"if this agent previously ran with --index-dsn, prior objects live under the "+
-				"resolved bintrail_id prefix and will not be queried under this configuration "+
-				"unless manually migrated",
+			slog.Info("BYOS+S3 without --index-dsn: S3 partition key set to numeric --server-id",
 				"partition_key", fmt.Sprint(agtServerID))
 		}
 	}
@@ -341,7 +339,6 @@ func runAgent(cmd *cobra.Command, args []string) error {
 				serverID:      serverIDStr,
 				sourceIdent:   identPtr,
 				sourceDB:      handler.SourceDB,
-				sourceDSN:     agtSourceDSN,
 				flushInterval: flushInterval,
 				state:         flushState,
 			})
@@ -445,16 +442,16 @@ func maskDSN(dsn string) string {
 // All fields are optional — when metaClient and payloadWriter are nil,
 // the stream loop runs in buffer-only mode (hosted mode).
 //
-// sourceIdent is an atomic pointer so the stream loop can re-capture source
-// MySQL identity on a periodic ticker (see issue #196) without racing with
-// the flush goroutine that stamps identity on every MetadataRecord.
+// sourceIdent is an atomic pointer so the per-flush load and the periodic
+// re-capture in byosStreamLoop never observe a torn SourceIdentity value.
+// Today both operations share the stream-loop goroutine, but the atomic
+// keeps the invariant intact if flushing moves to its own goroutine later.
 type byosFlushConfig struct {
 	metaClient       *byos.MetadataClient
 	payloadWriter    *byos.PayloadWriter
 	serverID         string
 	sourceIdent      *atomic.Pointer[byos.SourceIdentity]
 	sourceDB         *sql.DB       // for periodic @@server_uuid re-capture
-	sourceDSN        string        // for re-parsing host/port/user on re-capture
 	identityInterval time.Duration // re-identity cadence; 0 => default 60s
 	flushInterval    time.Duration
 	state            *flushPipelineState
@@ -629,8 +626,7 @@ func byosStreamLoop(ctx context.Context, events <-chan parser.Event, buf *buffer
 	flushTicker := time.NewTicker(flushInterval)
 	defer flushTicker.Stop()
 
-	// Periodic source-identity re-capture (issue #196). Disabled when fc has
-	// no sourceDB (hosted mode or tests that don't wire the sourceDB path).
+	// Periodic source-identity re-capture (issue #196).
 	identityInterval := 60 * time.Second
 	if fc != nil && fc.identityInterval > 0 {
 		identityInterval = fc.identityInterval
@@ -641,6 +637,7 @@ func byosStreamLoop(ctx context.Context, events <-chan parser.Event, buf *buffer
 		defer t.Stop()
 		identityTickerC = t.C
 	}
+	identityFailures := 0
 
 	flushBatch := func() {
 		if len(batch) == 0 {
@@ -684,10 +681,7 @@ func byosStreamLoop(ctx context.Context, events <-chan parser.Event, buf *buffer
 			flushBatch()
 
 		case <-identityTickerC:
-			// Re-capture source identity. Hard-fail on @@server_uuid
-			// change (operator intervention required); tolerate transient
-			// DB errors (the next tick will retry).
-			if err := checkSourceIdentity(ctx, fc.sourceDB, fc.sourceDSN, fc.sourceIdent); err != nil {
+			if err := checkSourceIdentity(ctx, fc.sourceDB, fc.sourceIdent, &identityFailures); err != nil {
 				flushBatch()
 				return err
 			}
@@ -715,16 +709,33 @@ func byosStreamLoop(ctx context.Context, events <-chan parser.Event, buf *buffer
 // dbtrail and payload to S3. Retries each sink up to 3 times with
 // exponential backoff. Failures are logged but never block the stream.
 func flushToSinks(ctx context.Context, batch []parser.Event, fc *byosFlushConfig) {
+	// Snapshot the identity pointer once per flush so every record in this
+	// batch uses the same value. A nil pointer or a nil snapshot would
+	// result in metadata records going out with an empty @@server_uuid —
+	// silently misattributing events at the SaaS side. That's a programmer
+	// error, not a runtime condition; abort the flush and mark the pipeline
+	// degraded so the heartbeat surfaces the stuck state.
+	if fc.sourceIdent == nil {
+		slog.Error("BYOS flush: sourceIdent pointer is nil — refusing to emit metadata with empty server_uuid",
+			"batch_size", len(batch))
+		if fc.state != nil {
+			fc.state.updateFlush(false, false)
+		}
+		return
+	}
+	p := fc.sourceIdent.Load()
+	if p == nil {
+		slog.Error("BYOS flush: sourceIdent not initialized — refusing to emit metadata with empty server_uuid",
+			"batch_size", len(batch))
+		if fc.state != nil {
+			fc.state.updateFlush(false, false)
+		}
+		return
+	}
+	ident := *p
+
 	var metaBatch []byos.MetadataRecord
 	var payloadBatch []byos.PayloadRecord
-
-	// Load the current source identity once per flush. The stream loop may
-	// atomically replace this pointer when it detects an identity change on
-	// the periodic re-capture ticker (issue #196).
-	var ident byos.SourceIdentity
-	if p := fc.sourceIdent.Load(); p != nil {
-		ident = *p
-	}
 
 	for i := range batch {
 		meta, payload, err := byos.SplitEvent(batch[i], fc.serverID, ident)
@@ -774,35 +785,67 @@ func flushToSinks(ctx context.Context, batch []parser.Event, fc *byosFlushConfig
 	}
 }
 
+// maxIdentityFailures is the number of consecutive failed re-captures that
+// will be tolerated before tearing down the stream. At the default 60s
+// cadence this is ~10 minutes — long enough to ride out a network blip
+// but short enough to surface permanent failures (revoked credentials,
+// dropped user) instead of logging WARN forever.
+const maxIdentityFailures = 10
+
 // checkSourceIdentity re-reads @@server_uuid from sourceDB and compares it to
-// the identity currently stored in prev. Returns an error when the ServerUUID
-// has changed (operator intervention required, see issue #196) and nil
-// otherwise — including on transient DB failures, which are logged as a
-// warning so the next tick can retry without tearing down the agent.
-func checkSourceIdentity(ctx context.Context, sourceDB *sql.DB, sourceDSN string, prev *atomic.Pointer[byos.SourceIdentity]) error {
-	ident, err := loadSourceIdentity(ctx, sourceDB, sourceDSN)
+// the identity currently stored in prev.
+//
+// Host/port/user are not re-derived here: they come from the startup DSN
+// flag and cannot change without an agent restart, so parsing the DSN on
+// every tick would only hide real DSN-misconfiguration errors as transient.
+//
+// Return values:
+//   - UUID unchanged: nil, failures counter reset.
+//   - UUID changed:   error naming both UUIDs (operator intervention required).
+//   - DB query fails: nil for the first maxIdentityFailures consecutive calls
+//     (logged as warning); after that, returns the error so the stream tears
+//     down rather than running forever with a possibly-stale identity.
+//   - context.Canceled: nil, no log (the loop is shutting down).
+func checkSourceIdentity(ctx context.Context, sourceDB *sql.DB, prev *atomic.Pointer[byos.SourceIdentity], failures *int) error {
+	var uuid string
+	err := sourceDB.QueryRowContext(ctx, "SELECT @@server_uuid").Scan(&uuid)
 	if err != nil {
-		slog.Warn("BYOS source identity re-capture failed; will retry on next tick", "error", err)
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil
+		}
+		*failures++
+		slog.Warn("BYOS source identity re-capture failed",
+			"error", err, "consecutive_failures", *failures, "max", maxIdentityFailures)
+		if *failures >= maxIdentityFailures {
+			return fmt.Errorf(
+				"source identity re-capture failed %d consecutive times: %w. "+
+					"This usually indicates revoked credentials, a dropped user, or a "+
+					"permanently unreachable source. The agent cannot confirm identity "+
+					"stability and is aborting rather than silently stamping metadata "+
+					"with a possibly-stale @@server_uuid",
+				*failures, err)
+		}
 		return nil
 	}
+	*failures = 0
+
 	current := prev.Load()
 	if current == nil {
-		prev.Store(&ident)
-		return nil
+		// Programmer error: the pointer must be seeded before the stream
+		// goroutine dispatches. Tear down rather than silently stamping
+		// metadata with an empty server_uuid.
+		return fmt.Errorf("BUG: sourceIdent pointer was not initialized at agent startup")
 	}
-	if ident.ServerUUID != current.ServerUUID {
+	if uuid != current.ServerUUID {
 		return fmt.Errorf(
 			"source server identity changed: @@server_uuid was %s, now %s. "+
 				"The source MySQL was restarted with a regenerated auto.cnf, failed "+
 				"over behind a VIP, or the DSN host now resolves to a different "+
 				"instance. Continuing would silently misattribute events to the prior "+
 				"server's bintrail_id. Verify the source and restart the agent",
-			current.ServerUUID, ident.ServerUUID,
+			current.ServerUUID, uuid,
 		)
 	}
-	// UUID stable; store the fresh value so host/port/user updates (via
-	// resolveServerIdentity rule 2) propagate even when the UUID didn't move.
-	prev.Store(&ident)
 	return nil
 }
 

--- a/cmd/bintrail/agent.go
+++ b/cmd/bintrail/agent.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	gomysql "github.com/go-mysql-org/go-mysql/mysql"
@@ -231,6 +232,20 @@ func runAgent(cmd *cobra.Command, args []string) error {
 		slog.Info("BYOS without --index-dsn; SaaS will resolve bintrail_id via source identity propagation",
 			"server_uuid", sourceIdent.ServerUUID,
 			"local_server_id", fmt.Sprint(agtServerID))
+
+		// If S3 is configured, the partition key falls back to the numeric
+		// --server-id. A prior agent run that had --index-dsn would have used
+		// a UUID instead — objects would live under a different S3 prefix
+		// (issue #198). EnsurePartitionKey (called below when S3 is set up)
+		// will hard-fail if a mismatched marker is found, but log ahead of
+		// time so the operator sees the chosen key in the startup banner.
+		if agtS3Bucket != "" {
+			slog.Warn("BYOS+S3 without --index-dsn: S3 partition key uses numeric --server-id; "+
+				"if this agent previously ran with --index-dsn, prior objects live under the "+
+				"resolved bintrail_id prefix and will not be queried under this configuration "+
+				"unless manually migrated",
+				"partition_key", fmt.Sprint(agtServerID))
+		}
 	}
 
 	// BYOS streaming: start buffer + streaming goroutine.
@@ -286,6 +301,17 @@ func runAgent(cmd *cobra.Command, args []string) error {
 			if err != nil {
 				return fmt.Errorf("initialize S3 backend: %w", err)
 			}
+
+			// Detect the silent partition-key cutover described in #198:
+			// upgrading from BYOS+S3+--index-dsn (UUID partition key) to
+			// BYOS+S3 without --index-dsn (numeric partition key) would
+			// split objects across two prefixes with no operator signal.
+			// The marker file is written on first run and validated on
+			// every subsequent run; a mismatch hard-fails with guidance.
+			if err := byos.EnsurePartitionKey(ctx, s3Backend, serverIDStr); err != nil {
+				return err
+			}
+
 			payloadWriter = byos.NewPayloadWriter(s3Backend, serverIDStr)
 
 			slog.Info("BYOS flush pipeline initialized",
@@ -304,13 +330,18 @@ func runAgent(cmd *cobra.Command, args []string) error {
 			payloadStatus:  "ok",
 		}
 
+		identPtr := &atomic.Pointer[byos.SourceIdentity]{}
+		identPtr.Store(&sourceIdent)
+
 		streamErrCh := make(chan error, 1)
 		go func() {
 			streamErrCh <- runBYOSStream(ctx, handler.SourceDB, buf, &byosFlushConfig{
 				metaClient:    metaClient,
 				payloadWriter: payloadWriter,
 				serverID:      serverIDStr,
-				sourceIdent:   sourceIdent,
+				sourceIdent:   identPtr,
+				sourceDB:      handler.SourceDB,
+				sourceDSN:     agtSourceDSN,
 				flushInterval: flushInterval,
 				state:         flushState,
 			})
@@ -413,13 +444,20 @@ func maskDSN(dsn string) string {
 // byosFlushConfig holds the sinks and settings for the BYOS flush pipeline.
 // All fields are optional — when metaClient and payloadWriter are nil,
 // the stream loop runs in buffer-only mode (hosted mode).
+//
+// sourceIdent is an atomic pointer so the stream loop can re-capture source
+// MySQL identity on a periodic ticker (see issue #196) without racing with
+// the flush goroutine that stamps identity on every MetadataRecord.
 type byosFlushConfig struct {
-	metaClient    *byos.MetadataClient
-	payloadWriter *byos.PayloadWriter
-	serverID      string
-	sourceIdent   byos.SourceIdentity
-	flushInterval time.Duration
-	state         *flushPipelineState
+	metaClient       *byos.MetadataClient
+	payloadWriter    *byos.PayloadWriter
+	serverID         string
+	sourceIdent      *atomic.Pointer[byos.SourceIdentity]
+	sourceDB         *sql.DB       // for periodic @@server_uuid re-capture
+	sourceDSN        string        // for re-parsing host/port/user on re-capture
+	identityInterval time.Duration // re-identity cadence; 0 => default 60s
+	flushInterval    time.Duration
+	state            *flushPipelineState
 }
 
 // flushPipelineState tracks the health of metadata/payload flushes.
@@ -591,6 +629,19 @@ func byosStreamLoop(ctx context.Context, events <-chan parser.Event, buf *buffer
 	flushTicker := time.NewTicker(flushInterval)
 	defer flushTicker.Stop()
 
+	// Periodic source-identity re-capture (issue #196). Disabled when fc has
+	// no sourceDB (hosted mode or tests that don't wire the sourceDB path).
+	identityInterval := 60 * time.Second
+	if fc != nil && fc.identityInterval > 0 {
+		identityInterval = fc.identityInterval
+	}
+	var identityTickerC <-chan time.Time
+	if fc != nil && fc.sourceDB != nil && fc.sourceIdent != nil {
+		t := time.NewTicker(identityInterval)
+		defer t.Stop()
+		identityTickerC = t.C
+	}
+
 	flushBatch := func() {
 		if len(batch) == 0 {
 			return
@@ -632,6 +683,15 @@ func byosStreamLoop(ctx context.Context, events <-chan parser.Event, buf *buffer
 			// Timer-based flush to bound metadata latency.
 			flushBatch()
 
+		case <-identityTickerC:
+			// Re-capture source identity. Hard-fail on @@server_uuid
+			// change (operator intervention required); tolerate transient
+			// DB errors (the next tick will retry).
+			if err := checkSourceIdentity(ctx, fc.sourceDB, fc.sourceDSN, fc.sourceIdent); err != nil {
+				flushBatch()
+				return err
+			}
+
 		case ev, ok := <-events:
 			if !ok {
 				flushBatch()
@@ -658,8 +718,16 @@ func flushToSinks(ctx context.Context, batch []parser.Event, fc *byosFlushConfig
 	var metaBatch []byos.MetadataRecord
 	var payloadBatch []byos.PayloadRecord
 
+	// Load the current source identity once per flush. The stream loop may
+	// atomically replace this pointer when it detects an identity change on
+	// the periodic re-capture ticker (issue #196).
+	var ident byos.SourceIdentity
+	if p := fc.sourceIdent.Load(); p != nil {
+		ident = *p
+	}
+
 	for i := range batch {
-		meta, payload, err := byos.SplitEvent(batch[i], fc.serverID, fc.sourceIdent)
+		meta, payload, err := byos.SplitEvent(batch[i], fc.serverID, ident)
 		if err != nil {
 			slog.Warn("BYOS split failed, skipping event",
 				"error", err,
@@ -704,6 +772,38 @@ func flushToSinks(ctx context.Context, batch []parser.Event, fc *byosFlushConfig
 	if fc.state != nil {
 		fc.state.updateFlush(metaOK, payloadOK)
 	}
+}
+
+// checkSourceIdentity re-reads @@server_uuid from sourceDB and compares it to
+// the identity currently stored in prev. Returns an error when the ServerUUID
+// has changed (operator intervention required, see issue #196) and nil
+// otherwise — including on transient DB failures, which are logged as a
+// warning so the next tick can retry without tearing down the agent.
+func checkSourceIdentity(ctx context.Context, sourceDB *sql.DB, sourceDSN string, prev *atomic.Pointer[byos.SourceIdentity]) error {
+	ident, err := loadSourceIdentity(ctx, sourceDB, sourceDSN)
+	if err != nil {
+		slog.Warn("BYOS source identity re-capture failed; will retry on next tick", "error", err)
+		return nil
+	}
+	current := prev.Load()
+	if current == nil {
+		prev.Store(&ident)
+		return nil
+	}
+	if ident.ServerUUID != current.ServerUUID {
+		return fmt.Errorf(
+			"source server identity changed: @@server_uuid was %s, now %s. "+
+				"The source MySQL was restarted with a regenerated auto.cnf, failed "+
+				"over behind a VIP, or the DSN host now resolves to a different "+
+				"instance. Continuing would silently misattribute events to the prior "+
+				"server's bintrail_id. Verify the source and restart the agent",
+			current.ServerUUID, ident.ServerUUID,
+		)
+	}
+	// UUID stable; store the fresh value so host/port/user updates (via
+	// resolveServerIdentity rule 2) propagate even when the UUID didn't move.
+	prev.Store(&ident)
+	return nil
 }
 
 // retryFlush retries fn up to maxAttempts times with exponential backoff

--- a/cmd/bintrail/agent_identity_test.go
+++ b/cmd/bintrail/agent_identity_test.go
@@ -6,14 +6,16 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 
+	"github.com/dbtrail/bintrail/internal/buffer"
 	"github.com/dbtrail/bintrail/internal/byos"
+	"github.com/dbtrail/bintrail/internal/parser"
 )
 
 const (
-	testDSN  = "repluser:secret@tcp(10.0.0.5:3306)/"
 	testUUID = "11111111-2222-3333-4444-555555555555"
 	altUUID  = "66666666-7777-8888-9999-aaaaaaaaaaaa"
 )
@@ -35,9 +37,13 @@ func TestCheckSourceIdentity_Stable(t *testing.T) {
 		sqlmock.NewRows([]string{"@@server_uuid"}).AddRow(testUUID))
 
 	prev := newIdentPtr(byos.SourceIdentity{ServerUUID: testUUID, Host: "10.0.0.5", Port: 3306, User: "repluser"})
+	failures := 0
 
-	if err := checkSourceIdentity(context.Background(), db, testDSN, prev); err != nil {
+	if err := checkSourceIdentity(context.Background(), db, prev, &failures); err != nil {
 		t.Fatalf("unexpected error on stable identity: %v", err)
+	}
+	if failures != 0 {
+		t.Errorf("failures = %d, want 0 on success", failures)
 	}
 	if got := prev.Load().ServerUUID; got != testUUID {
 		t.Errorf("ServerUUID after stable check = %q, want %q", got, testUUID)
@@ -58,8 +64,9 @@ func TestCheckSourceIdentity_ChangeDetected(t *testing.T) {
 		sqlmock.NewRows([]string{"@@server_uuid"}).AddRow(altUUID))
 
 	prev := newIdentPtr(byos.SourceIdentity{ServerUUID: testUUID, Host: "10.0.0.5", Port: 3306, User: "repluser"})
+	failures := 0
 
-	err = checkSourceIdentity(context.Background(), db, testDSN, prev)
+	err = checkSourceIdentity(context.Background(), db, prev, &failures)
 	if err == nil {
 		t.Fatal("expected error on UUID change, got nil")
 	}
@@ -75,9 +82,12 @@ func TestCheckSourceIdentity_ChangeDetected(t *testing.T) {
 	if got := prev.Load().ServerUUID; got != testUUID {
 		t.Errorf("ServerUUID after change detection = %q, want previous %q (not overwritten)", got, testUUID)
 	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
 }
 
-func TestCheckSourceIdentity_TransientError(t *testing.T) {
+func TestCheckSourceIdentity_TransientErrorTolerated(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock: %v", err)
@@ -86,20 +96,86 @@ func TestCheckSourceIdentity_TransientError(t *testing.T) {
 
 	mock.ExpectQuery("SELECT @@server_uuid").WillReturnError(errors.New("connection reset by peer"))
 
-	prev := newIdentPtr(byos.SourceIdentity{ServerUUID: testUUID, Host: "10.0.0.5", Port: 3306, User: "repluser"})
+	prev := newIdentPtr(byos.SourceIdentity{ServerUUID: testUUID})
+	failures := 0
 
-	if err := checkSourceIdentity(context.Background(), db, testDSN, prev); err != nil {
-		t.Fatalf("transient DB error should not abort the stream; got: %v", err)
+	if err := checkSourceIdentity(context.Background(), db, prev, &failures); err != nil {
+		t.Fatalf("transient DB error should not abort at first failure; got: %v", err)
+	}
+	if failures != 1 {
+		t.Errorf("failures = %d, want 1 after one failed call", failures)
 	}
 	if got := prev.Load().ServerUUID; got != testUUID {
 		t.Errorf("ServerUUID after transient error = %q, want previous %q", got, testUUID)
 	}
 }
 
-func TestCheckSourceIdentity_HostUpdateStable(t *testing.T) {
-	// UUID unchanged but host/port/user shift (e.g. a CNAME move). The
-	// captured identity must refresh so metadata records reflect the new
-	// connection attributes on the next flush.
+func TestCheckSourceIdentity_BoundedRetryAborts(t *testing.T) {
+	// After maxIdentityFailures consecutive failures, the helper should
+	// abort the stream instead of logging WARN forever (as would happen
+	// under revoked credentials or a dropped user).
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	// Expect exactly maxIdentityFailures failing queries.
+	for range maxIdentityFailures {
+		mock.ExpectQuery("SELECT @@server_uuid").WillReturnError(errors.New("access denied"))
+	}
+
+	prev := newIdentPtr(byos.SourceIdentity{ServerUUID: testUUID})
+	failures := 0
+
+	var lastErr error
+	for i := 0; i < maxIdentityFailures; i++ {
+		lastErr = checkSourceIdentity(context.Background(), db, prev, &failures)
+		if i < maxIdentityFailures-1 && lastErr != nil {
+			t.Fatalf("checkSourceIdentity aborted too early at iteration %d: %v", i, lastErr)
+		}
+	}
+	if lastErr == nil {
+		t.Fatal("expected error after maxIdentityFailures consecutive failures, got nil")
+	}
+	if !strings.Contains(lastErr.Error(), "consecutive times") {
+		t.Errorf("error should mention consecutive failures; got: %v", lastErr)
+	}
+	if !strings.Contains(lastErr.Error(), "access denied") {
+		t.Errorf("error should wrap the underlying DB error; got: %v", lastErr)
+	}
+}
+
+func TestCheckSourceIdentity_ContextCanceledSilent(t *testing.T) {
+	// On shutdown the ctx is canceled mid-query. That should not be
+	// counted as a failure and should not log a spurious warning.
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT @@server_uuid").WillReturnError(context.Canceled)
+
+	prev := newIdentPtr(byos.SourceIdentity{ServerUUID: testUUID})
+	failures := 0
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := checkSourceIdentity(ctx, db, prev, &failures); err != nil {
+		t.Fatalf("canceled ctx should not produce an error; got: %v", err)
+	}
+	if failures != 0 {
+		t.Errorf("canceled ctx should not increment failures; got %d", failures)
+	}
+}
+
+func TestCheckSourceIdentity_NilPointerIsBug(t *testing.T) {
+	// prev is a non-nil atomic pointer with no value stored. This is a
+	// programmer error (the agent always seeds the identity at startup);
+	// the helper must refuse to proceed rather than silently stamping
+	// empty metadata.
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock: %v", err)
@@ -109,13 +185,80 @@ func TestCheckSourceIdentity_HostUpdateStable(t *testing.T) {
 	mock.ExpectQuery("SELECT @@server_uuid").WillReturnRows(
 		sqlmock.NewRows([]string{"@@server_uuid"}).AddRow(testUUID))
 
-	prev := newIdentPtr(byos.SourceIdentity{ServerUUID: testUUID, Host: "old-host", Port: 3306, User: "repluser"})
+	prev := &atomic.Pointer[byos.SourceIdentity]{} // no Store
+	failures := 0
 
-	newDSN := "repluser:secret@tcp(new-host:3306)/"
-	if err := checkSourceIdentity(context.Background(), db, newDSN, prev); err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	err = checkSourceIdentity(context.Background(), db, prev, &failures)
+	if err == nil {
+		t.Fatal("expected BUG error for uninitialized pointer, got nil")
 	}
-	if got := prev.Load().Host; got != "new-host" {
-		t.Errorf("Host after CNAME update = %q, want new-host", got)
+	if !strings.Contains(err.Error(), "BUG") {
+		t.Errorf("error should flag the programmer error; got: %v", err)
+	}
+}
+
+// TestByosStreamLoop_IdentityChangeAbortsLoop exercises the full integration
+// path: the identityTicker arm in byosStreamLoop must invoke
+// checkSourceIdentity, drain any pending batch to the buffer before
+// returning, and surface the error to the caller.
+func TestByosStreamLoop_IdentityChangeAbortsLoop(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	// First tick returns a different UUID → the loop should abort.
+	mock.ExpectQuery("SELECT @@server_uuid").WillReturnRows(
+		sqlmock.NewRows([]string{"@@server_uuid"}).AddRow(altUUID))
+
+	buf := buffer.New(buffer.Config{})
+	events := make(chan parser.Event, 4)
+	// Push an event so we can assert the final flushBatch drained it.
+	events <- parser.Event{
+		Schema:    "mydb",
+		Table:     "t",
+		EventType: parser.EventInsert,
+		Timestamp: time.Now().UTC(),
+		PKValues:  "1",
+	}
+
+	fc := &byosFlushConfig{
+		serverID:         "srv-A",
+		sourceIdent:      newIdentPtr(byos.SourceIdentity{ServerUUID: testUUID}),
+		sourceDB:         db,
+		identityInterval: 10 * time.Millisecond,
+		flushInterval:    time.Hour, // disable flush-ticker so only identity-ticker fires
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- byosStreamLoop(ctx, events, buf, 100, fc)
+	}()
+
+	select {
+	case got := <-errCh:
+		if got == nil {
+			t.Fatal("byosStreamLoop returned nil; want identity-change error")
+		}
+		if !strings.Contains(got.Error(), "identity changed") {
+			t.Errorf("returned error = %v, want one containing 'identity changed'", got)
+		}
+	case <-time.After(400 * time.Millisecond):
+		t.Fatal("byosStreamLoop did not return within deadline after identity change")
+	}
+
+	// The pending event must have been drained by the final flushBatch
+	// before the loop returned — otherwise the operator loses events
+	// captured after the last regular flush tick.
+	if got := buf.Len(); got != 1 {
+		t.Errorf("buffer len after abort = %d, want 1 (pending event drained)", got)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
 	}
 }

--- a/cmd/bintrail/agent_identity_test.go
+++ b/cmd/bintrail/agent_identity_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/dbtrail/bintrail/internal/byos"
+)
+
+const (
+	testDSN  = "repluser:secret@tcp(10.0.0.5:3306)/"
+	testUUID = "11111111-2222-3333-4444-555555555555"
+	altUUID  = "66666666-7777-8888-9999-aaaaaaaaaaaa"
+)
+
+func newIdentPtr(ident byos.SourceIdentity) *atomic.Pointer[byos.SourceIdentity] {
+	p := &atomic.Pointer[byos.SourceIdentity]{}
+	p.Store(&ident)
+	return p
+}
+
+func TestCheckSourceIdentity_Stable(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT @@server_uuid").WillReturnRows(
+		sqlmock.NewRows([]string{"@@server_uuid"}).AddRow(testUUID))
+
+	prev := newIdentPtr(byos.SourceIdentity{ServerUUID: testUUID, Host: "10.0.0.5", Port: 3306, User: "repluser"})
+
+	if err := checkSourceIdentity(context.Background(), db, testDSN, prev); err != nil {
+		t.Fatalf("unexpected error on stable identity: %v", err)
+	}
+	if got := prev.Load().ServerUUID; got != testUUID {
+		t.Errorf("ServerUUID after stable check = %q, want %q", got, testUUID)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestCheckSourceIdentity_ChangeDetected(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT @@server_uuid").WillReturnRows(
+		sqlmock.NewRows([]string{"@@server_uuid"}).AddRow(altUUID))
+
+	prev := newIdentPtr(byos.SourceIdentity{ServerUUID: testUUID, Host: "10.0.0.5", Port: 3306, User: "repluser"})
+
+	err = checkSourceIdentity(context.Background(), db, testDSN, prev)
+	if err == nil {
+		t.Fatal("expected error on UUID change, got nil")
+	}
+	if !strings.Contains(err.Error(), testUUID) || !strings.Contains(err.Error(), altUUID) {
+		t.Errorf("error should mention both UUIDs; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "identity changed") {
+		t.Errorf("error should contain 'identity changed'; got: %v", err)
+	}
+	// Pointer should not be updated with the new UUID — the operator must
+	// restart the agent, and downstream records in the current process
+	// should continue using the last known-good identity.
+	if got := prev.Load().ServerUUID; got != testUUID {
+		t.Errorf("ServerUUID after change detection = %q, want previous %q (not overwritten)", got, testUUID)
+	}
+}
+
+func TestCheckSourceIdentity_TransientError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT @@server_uuid").WillReturnError(errors.New("connection reset by peer"))
+
+	prev := newIdentPtr(byos.SourceIdentity{ServerUUID: testUUID, Host: "10.0.0.5", Port: 3306, User: "repluser"})
+
+	if err := checkSourceIdentity(context.Background(), db, testDSN, prev); err != nil {
+		t.Fatalf("transient DB error should not abort the stream; got: %v", err)
+	}
+	if got := prev.Load().ServerUUID; got != testUUID {
+		t.Errorf("ServerUUID after transient error = %q, want previous %q", got, testUUID)
+	}
+}
+
+func TestCheckSourceIdentity_HostUpdateStable(t *testing.T) {
+	// UUID unchanged but host/port/user shift (e.g. a CNAME move). The
+	// captured identity must refresh so metadata records reflect the new
+	// connection attributes on the next flush.
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT @@server_uuid").WillReturnRows(
+		sqlmock.NewRows([]string{"@@server_uuid"}).AddRow(testUUID))
+
+	prev := newIdentPtr(byos.SourceIdentity{ServerUUID: testUUID, Host: "old-host", Port: 3306, User: "repluser"})
+
+	newDSN := "repluser:secret@tcp(new-host:3306)/"
+	if err := checkSourceIdentity(context.Background(), db, newDSN, prev); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := prev.Load().Host; got != "new-host" {
+		t.Errorf("Host after CNAME update = %q, want new-host", got)
+	}
+}

--- a/cmd/bintrail/agent_identity_test.go
+++ b/cmd/bintrail/agent_identity_test.go
@@ -146,6 +146,29 @@ func TestCheckSourceIdentity_BoundedRetryAborts(t *testing.T) {
 	}
 }
 
+func TestCheckSourceIdentity_DeadlineExceededSilent(t *testing.T) {
+	// Query timeouts from config.Connect's 10s ctx budget must not count
+	// against the consecutive-failure budget or log a warning — they're
+	// routine and would otherwise trigger teardown during normal load spikes.
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT @@server_uuid").WillReturnError(context.DeadlineExceeded)
+
+	prev := newIdentPtr(byos.SourceIdentity{ServerUUID: testUUID})
+	failures := 0
+
+	if err := checkSourceIdentity(context.Background(), db, prev, &failures); err != nil {
+		t.Fatalf("DeadlineExceeded should not produce an error; got: %v", err)
+	}
+	if failures != 0 {
+		t.Errorf("DeadlineExceeded should not increment failures; got %d", failures)
+	}
+}
+
 func TestCheckSourceIdentity_ContextCanceledSilent(t *testing.T) {
 	// On shutdown the ctx is canceled mid-query. That should not be
 	// counted as a failure and should not log a spurious warning.
@@ -194,6 +217,43 @@ func TestCheckSourceIdentity_NilPointerIsBug(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "BUG") {
 		t.Errorf("error should flag the programmer error; got: %v", err)
+	}
+}
+
+func TestFlushToSinks_NilSourceIdentPointer(t *testing.T) {
+	// Programmer error: fc.sourceIdent is nil. flushToSinks must refuse
+	// to emit metadata with an empty server_uuid and return a BUG-flagged
+	// error so the stream loop can tear down, rather than log-and-continue
+	// forever with a degraded heartbeat.
+	fc := &byosFlushConfig{
+		serverID:    "srv-A",
+		sourceIdent: nil,
+	}
+	err := flushToSinks(context.Background(), []parser.Event{{}}, fc)
+	if err == nil {
+		t.Fatal("flushToSinks with nil sourceIdent returned nil, want BUG error")
+	}
+	if !strings.Contains(err.Error(), "BUG") {
+		t.Errorf("error should flag programmer error with 'BUG'; got: %v", err)
+	}
+}
+
+func TestFlushToSinks_NilIdentSnapshot(t *testing.T) {
+	// Programmer error: fc.sourceIdent is a non-nil pointer with no Store
+	// call yet. Same treatment as the nil-pointer case.
+	fc := &byosFlushConfig{
+		serverID:    "srv-A",
+		sourceIdent: &atomic.Pointer[byos.SourceIdentity]{},
+	}
+	err := flushToSinks(context.Background(), []parser.Event{{}}, fc)
+	if err == nil {
+		t.Fatal("flushToSinks with unseeded sourceIdent returned nil, want BUG error")
+	}
+	if !strings.Contains(err.Error(), "BUG") {
+		t.Errorf("error should flag programmer error with 'BUG'; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "not initialized") {
+		t.Errorf("error should distinguish unseeded from nil pointer; got: %v", err)
 	}
 }
 

--- a/internal/byos/partition_key.go
+++ b/internal/byos/partition_key.go
@@ -11,13 +11,24 @@ import (
 	"github.com/dbtrail/bintrail/internal/storage"
 )
 
-// PartitionKeyMarker is the key (relative to the storage backend's prefix)
-// where the partition-key marker file lives.
-const PartitionKeyMarker = ".bintrail-partition-key"
+// partitionKeyMarker is the key (relative to the storage backend's prefix)
+// where the partition-key marker file lives. The leading dot keeps it out
+// of `ls`-style listings and typical `*.parquet` lifecycle filters.
+const partitionKeyMarker = ".bintrail-partition-key"
 
+// partitionKeyMarkerVersion is the current wire format version for the marker
+// record. Bump when adding fields that older readers cannot ignore.
+const partitionKeyMarkerVersion = 1
+
+// partitionKeyRecord is the JSON wire format for the marker file. Only
+// ServerID is load-bearing for the mismatch check; Version and FirstSeen
+// are informational (Version is reserved for future forward-compatibility;
+// FirstSeen is surfaced in the mismatch error to help operators correlate
+// with install history).
 type partitionKeyRecord struct {
+	Version   int       `json:"version"`
 	ServerID  string    `json:"server_id"`
-	FirstSeen time.Time `json:"first_seen"`
+	FirstSeen time.Time `json:"first_seen"` // always UTC on write
 }
 
 // EnsurePartitionKey reads or writes a marker file that freezes the S3
@@ -31,12 +42,13 @@ type partitionKeyRecord struct {
 // key, from --server-id). Pre-upgrade objects live under a different S3
 // prefix and would not be queried under the new layout — see issue #198.
 func EnsurePartitionKey(ctx context.Context, b storage.Backend, serverID string) error {
-	ok, err := b.Exists(ctx, PartitionKeyMarker)
+	ok, err := b.Exists(ctx, partitionKeyMarker)
 	if err != nil {
 		return fmt.Errorf("check partition-key marker: %w", err)
 	}
 	if !ok {
 		rec := partitionKeyRecord{
+			Version:   partitionKeyMarkerVersion,
 			ServerID:  serverID,
 			FirstSeen: time.Now().UTC(),
 		}
@@ -44,24 +56,48 @@ func EnsurePartitionKey(ctx context.Context, b storage.Backend, serverID string)
 		if err != nil {
 			return fmt.Errorf("marshal partition-key marker: %w", err)
 		}
-		if err := b.Put(ctx, PartitionKeyMarker, bytes.NewReader(body)); err != nil {
+		if err := b.Put(ctx, partitionKeyMarker, bytes.NewReader(body)); err != nil {
 			return fmt.Errorf("write partition-key marker: %w", err)
 		}
 		return nil
 	}
 
-	rc, err := b.Get(ctx, PartitionKeyMarker)
+	rc, err := b.Get(ctx, partitionKeyMarker)
 	if err != nil {
 		return fmt.Errorf("read partition-key marker: %w", err)
 	}
 	defer rc.Close()
-	body, err := io.ReadAll(rc)
+	// Cap the read so a replaced or corrupt marker can't exhaust memory.
+	// The real marker is well under 1 KiB; 64 KiB is a generous ceiling.
+	body, err := io.ReadAll(io.LimitReader(rc, 64*1024))
 	if err != nil {
 		return fmt.Errorf("read partition-key marker body: %w", err)
 	}
+	if len(body) == 0 {
+		return fmt.Errorf(
+			"partition-key marker at %q is empty (likely a partial upload). "+
+				"Verify which server_id the existing objects under this S3 prefix belong "+
+				"to before deleting the marker — removing a valid marker silently re-arms "+
+				"the cutover described in #198",
+			partitionKeyMarker)
+	}
 	var rec partitionKeyRecord
 	if err := json.Unmarshal(body, &rec); err != nil {
-		return fmt.Errorf("parse partition-key marker: %w", err)
+		return fmt.Errorf(
+			"partition-key marker at %q is unparseable (%d bytes: %w). "+
+				"This usually means a partial upload or manual edit. Verify which "+
+				"server_id the existing objects under this S3 prefix belong to before "+
+				"deleting the marker — removing a valid marker silently re-arms the "+
+				"cutover described in #198",
+			partitionKeyMarker, len(body), err)
+	}
+	if rec.ServerID == "" {
+		return fmt.Errorf(
+			"partition-key marker at %q has empty server_id (corrupt). "+
+				"Verify which server_id the existing objects under this S3 prefix belong "+
+				"to before deleting the marker — removing a valid marker silently re-arms "+
+				"the cutover described in #198",
+			partitionKeyMarker)
 	}
 	if rec.ServerID != serverID {
 		return fmt.Errorf(

--- a/internal/byos/partition_key.go
+++ b/internal/byos/partition_key.go
@@ -99,6 +99,14 @@ func EnsurePartitionKey(ctx context.Context, b storage.Backend, serverID string)
 				"the cutover described in #198",
 			partitionKeyMarker)
 	}
+	if rec.Version > partitionKeyMarkerVersion {
+		return fmt.Errorf(
+			"partition-key marker at %q was written by a newer agent "+
+				"(marker version %d, this agent supports up to %d). Upgrade this agent "+
+				"before continuing — proceeding could misinterpret fields the newer "+
+				"format relies on and silently re-arm the cutover described in #198",
+			partitionKeyMarker, rec.Version, partitionKeyMarkerVersion)
+	}
 	if rec.ServerID != serverID {
 		return fmt.Errorf(
 			"partition key mismatch: prior agent runs used server_id=%q (since %s), "+

--- a/internal/byos/partition_key.go
+++ b/internal/byos/partition_key.go
@@ -1,0 +1,79 @@
+package byos
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/dbtrail/bintrail/internal/storage"
+)
+
+// PartitionKeyMarker is the key (relative to the storage backend's prefix)
+// where the partition-key marker file lives.
+const PartitionKeyMarker = ".bintrail-partition-key"
+
+type partitionKeyRecord struct {
+	ServerID  string    `json:"server_id"`
+	FirstSeen time.Time `json:"first_seen"`
+}
+
+// EnsurePartitionKey reads or writes a marker file that freezes the S3
+// partition key used for BYOS payloads. On first call the marker is created
+// with serverID. On subsequent calls the marker is read and compared: if it
+// matches, no-op; if it differs, returns an error explaining the divergence.
+//
+// This catches the silent partition-key cutover that happens when a BYOS+S3
+// agent is upgraded from a configuration that had --index-dsn (UUID partition
+// key, from the resolved bintrail_id) to one without it (numeric partition
+// key, from --server-id). Pre-upgrade objects live under a different S3
+// prefix and would not be queried under the new layout — see issue #198.
+func EnsurePartitionKey(ctx context.Context, b storage.Backend, serverID string) error {
+	ok, err := b.Exists(ctx, PartitionKeyMarker)
+	if err != nil {
+		return fmt.Errorf("check partition-key marker: %w", err)
+	}
+	if !ok {
+		rec := partitionKeyRecord{
+			ServerID:  serverID,
+			FirstSeen: time.Now().UTC(),
+		}
+		body, err := json.Marshal(rec)
+		if err != nil {
+			return fmt.Errorf("marshal partition-key marker: %w", err)
+		}
+		if err := b.Put(ctx, PartitionKeyMarker, bytes.NewReader(body)); err != nil {
+			return fmt.Errorf("write partition-key marker: %w", err)
+		}
+		return nil
+	}
+
+	rc, err := b.Get(ctx, PartitionKeyMarker)
+	if err != nil {
+		return fmt.Errorf("read partition-key marker: %w", err)
+	}
+	defer rc.Close()
+	body, err := io.ReadAll(rc)
+	if err != nil {
+		return fmt.Errorf("read partition-key marker body: %w", err)
+	}
+	var rec partitionKeyRecord
+	if err := json.Unmarshal(body, &rec); err != nil {
+		return fmt.Errorf("parse partition-key marker: %w", err)
+	}
+	if rec.ServerID != serverID {
+		return fmt.Errorf(
+			"partition key mismatch: prior agent runs used server_id=%q (since %s), "+
+				"current run would use server_id=%q. This happens when upgrading a BYOS+S3 "+
+				"agent from a configuration with --index-dsn (UUID partition key from resolved "+
+				"bintrail_id) to one without it (numeric partition key from --server-id). "+
+				"Pre-upgrade objects live under a different S3 prefix and would not be "+
+				"queried under the new layout. Either migrate existing objects to the new "+
+				"prefix, or restore the previous configuration so the partition key matches",
+			rec.ServerID, rec.FirstSeen.Format(time.RFC3339), serverID,
+		)
+	}
+	return nil
+}

--- a/internal/byos/partition_key_test.go
+++ b/internal/byos/partition_key_test.go
@@ -1,8 +1,10 @@
 package byos
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"strings"
 	"testing"
@@ -16,9 +18,11 @@ func TestEnsurePartitionKey_FirstRun(t *testing.T) {
 		t.Fatalf("EnsurePartitionKey first run: %v", err)
 	}
 
-	rc, err := b.Get(ctx, PartitionKeyMarker)
+	// The marker key is a wire contract — if this assertion fails, existing
+	// customer installations would silently re-initialize on upgrade.
+	rc, err := b.Get(ctx, ".bintrail-partition-key")
 	if err != nil {
-		t.Fatalf("Get marker: %v", err)
+		t.Fatalf("marker not written at expected key: %v", err)
 	}
 	defer rc.Close()
 	body, err := io.ReadAll(rc)
@@ -28,6 +32,9 @@ func TestEnsurePartitionKey_FirstRun(t *testing.T) {
 	var rec partitionKeyRecord
 	if err := json.Unmarshal(body, &rec); err != nil {
 		t.Fatalf("unmarshal marker: %v", err)
+	}
+	if rec.Version != partitionKeyMarkerVersion {
+		t.Errorf("Version = %d, want %d", rec.Version, partitionKeyMarkerVersion)
 	}
 	if rec.ServerID != "srv-A" {
 		t.Errorf("ServerID = %q, want srv-A", rec.ServerID)
@@ -45,8 +52,7 @@ func TestEnsurePartitionKey_Match(t *testing.T) {
 		t.Fatalf("first call: %v", err)
 	}
 
-	// Capture the written bytes to verify the marker isn't overwritten.
-	rc, _ := b.Get(ctx, PartitionKeyMarker)
+	rc, _ := b.Get(ctx, partitionKeyMarker)
 	original, _ := io.ReadAll(rc)
 	rc.Close()
 
@@ -54,7 +60,7 @@ func TestEnsurePartitionKey_Match(t *testing.T) {
 		t.Fatalf("second call with matching serverID: %v", err)
 	}
 
-	rc, _ = b.Get(ctx, PartitionKeyMarker)
+	rc, _ = b.Get(ctx, partitionKeyMarker)
 	after, _ := io.ReadAll(rc)
 	rc.Close()
 
@@ -80,4 +86,153 @@ func TestEnsurePartitionKey_Mismatch(t *testing.T) {
 	if !strings.Contains(err.Error(), "partition key mismatch") {
 		t.Errorf("error should contain 'partition key mismatch'; got: %v", err)
 	}
+}
+
+func TestEnsurePartitionKey_MalformedMarker(t *testing.T) {
+	b := newMemBackend()
+	ctx := context.Background()
+
+	// Pre-populate a corrupted marker body — e.g. a partial upload that
+	// left non-JSON bytes behind. The code must hard-fail, NOT silently
+	// overwrite with a new marker (which would re-arm the #198 cutover).
+	if err := b.Put(ctx, partitionKeyMarker, bytes.NewReader([]byte("not json{"))); err != nil {
+		t.Fatalf("seed marker: %v", err)
+	}
+	before, _ := io.ReadAll(mustGet(ctx, b))
+
+	err := EnsurePartitionKey(ctx, b, "srv-A")
+	if err == nil {
+		t.Fatal("EnsurePartitionKey with malformed marker returned nil, want error")
+	}
+	if !strings.Contains(err.Error(), "unparseable") {
+		t.Errorf("error should call out 'unparseable'; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "#198") {
+		t.Errorf("error should reference issue #198 so operators find the context; got: %v", err)
+	}
+
+	after, _ := io.ReadAll(mustGet(ctx, b))
+	if !bytes.Equal(before, after) {
+		t.Error("malformed marker was silently overwritten; want it preserved so operator can inspect")
+	}
+}
+
+func TestEnsurePartitionKey_EmptyMarker(t *testing.T) {
+	b := newMemBackend()
+	ctx := context.Background()
+
+	if err := b.Put(ctx, partitionKeyMarker, bytes.NewReader(nil)); err != nil {
+		t.Fatalf("seed marker: %v", err)
+	}
+
+	err := EnsurePartitionKey(ctx, b, "srv-A")
+	if err == nil {
+		t.Fatal("EnsurePartitionKey with empty marker returned nil, want error")
+	}
+	if !strings.Contains(err.Error(), "empty") {
+		t.Errorf("error should call out 'empty'; got: %v", err)
+	}
+}
+
+func TestEnsurePartitionKey_EmptyServerIDInMarker(t *testing.T) {
+	b := newMemBackend()
+	ctx := context.Background()
+
+	// A marker that round-trips through json.Unmarshal but carries
+	// ServerID="" should be rejected as corrupt rather than trigger
+	// a misleading "mismatch" message against the current serverID.
+	body, _ := json.Marshal(partitionKeyRecord{Version: 1, ServerID: ""})
+	if err := b.Put(ctx, partitionKeyMarker, bytes.NewReader(body)); err != nil {
+		t.Fatalf("seed marker: %v", err)
+	}
+
+	err := EnsurePartitionKey(ctx, b, "srv-A")
+	if err == nil {
+		t.Fatal("EnsurePartitionKey with empty server_id returned nil, want error")
+	}
+	if !strings.Contains(err.Error(), "empty server_id") {
+		t.Errorf("error should call out 'empty server_id'; got: %v", err)
+	}
+}
+
+// failingBackend wraps a memBackend and injects errors on a named operation.
+type failingBackend struct {
+	*memBackend
+	failOp  string // "Exists", "Get", "Put"
+	failErr error
+}
+
+func (f *failingBackend) Exists(ctx context.Context, key string) (bool, error) {
+	if f.failOp == "Exists" {
+		return false, f.failErr
+	}
+	return f.memBackend.Exists(ctx, key)
+}
+
+func (f *failingBackend) Get(ctx context.Context, key string) (io.ReadCloser, error) {
+	if f.failOp == "Get" {
+		return nil, f.failErr
+	}
+	return f.memBackend.Get(ctx, key)
+}
+
+func (f *failingBackend) Put(ctx context.Context, key string, r io.Reader) error {
+	if f.failOp == "Put" {
+		return f.failErr
+	}
+	return f.memBackend.Put(ctx, key, r)
+}
+
+func TestEnsurePartitionKey_BackendErrors(t *testing.T) {
+	ctx := context.Background()
+	sentinel := errors.New("s3 throttled")
+
+	t.Run("Exists fails", func(t *testing.T) {
+		b := &failingBackend{memBackend: newMemBackend(), failOp: "Exists", failErr: sentinel}
+		err := EnsurePartitionKey(ctx, b, "srv-A")
+		if err == nil || !errors.Is(err, sentinel) {
+			t.Fatalf("want wrapped sentinel, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "check partition-key marker") {
+			t.Errorf("error should name the operation; got: %v", err)
+		}
+	})
+
+	t.Run("Put fails on first run", func(t *testing.T) {
+		b := &failingBackend{memBackend: newMemBackend(), failOp: "Put", failErr: sentinel}
+		err := EnsurePartitionKey(ctx, b, "srv-A")
+		if err == nil || !errors.Is(err, sentinel) {
+			t.Fatalf("want wrapped sentinel, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "write partition-key marker") {
+			t.Errorf("error should name the operation; got: %v", err)
+		}
+	})
+
+	t.Run("Get fails on subsequent run", func(t *testing.T) {
+		mem := newMemBackend()
+		if err := EnsurePartitionKey(ctx, mem, "srv-A"); err != nil {
+			t.Fatalf("seed first run: %v", err)
+		}
+		b := &failingBackend{memBackend: mem, failOp: "Get", failErr: sentinel}
+		err := EnsurePartitionKey(ctx, b, "srv-A")
+		if err == nil || !errors.Is(err, sentinel) {
+			t.Fatalf("want wrapped sentinel, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "read partition-key marker") {
+			t.Errorf("error should name the operation; got: %v", err)
+		}
+	})
+}
+
+func mustGet(ctx context.Context, b storageBackendGetter) io.ReadCloser {
+	rc, err := b.Get(ctx, partitionKeyMarker)
+	if err != nil {
+		panic(err)
+	}
+	return rc
+}
+
+type storageBackendGetter interface {
+	Get(ctx context.Context, key string) (io.ReadCloser, error)
 }

--- a/internal/byos/partition_key_test.go
+++ b/internal/byos/partition_key_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestEnsurePartitionKey_FirstRun(t *testing.T) {
@@ -131,6 +132,34 @@ func TestEnsurePartitionKey_EmptyMarker(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "empty") {
 		t.Errorf("error should call out 'empty'; got: %v", err)
+	}
+}
+
+func TestEnsurePartitionKey_NewerVersionRejected(t *testing.T) {
+	b := newMemBackend()
+	ctx := context.Background()
+
+	// A marker written by a future agent with a higher Version must be
+	// refused — otherwise this agent might silently ignore fields the
+	// newer format relies on and re-arm the #198 cutover.
+	body, _ := json.Marshal(partitionKeyRecord{
+		Version:   partitionKeyMarkerVersion + 1,
+		ServerID:  "srv-A",
+		FirstSeen: time.Now().UTC(),
+	})
+	if err := b.Put(ctx, partitionKeyMarker, bytes.NewReader(body)); err != nil {
+		t.Fatalf("seed marker: %v", err)
+	}
+
+	err := EnsurePartitionKey(ctx, b, "srv-A")
+	if err == nil {
+		t.Fatal("EnsurePartitionKey with future-version marker returned nil, want error")
+	}
+	if !strings.Contains(err.Error(), "newer agent") {
+		t.Errorf("error should call out 'newer agent'; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "Upgrade this agent") {
+		t.Errorf("error should direct the operator to upgrade; got: %v", err)
 	}
 }
 

--- a/internal/byos/partition_key_test.go
+++ b/internal/byos/partition_key_test.go
@@ -1,0 +1,83 @@
+package byos
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestEnsurePartitionKey_FirstRun(t *testing.T) {
+	b := newMemBackend()
+	ctx := context.Background()
+
+	if err := EnsurePartitionKey(ctx, b, "srv-A"); err != nil {
+		t.Fatalf("EnsurePartitionKey first run: %v", err)
+	}
+
+	rc, err := b.Get(ctx, PartitionKeyMarker)
+	if err != nil {
+		t.Fatalf("Get marker: %v", err)
+	}
+	defer rc.Close()
+	body, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("read marker: %v", err)
+	}
+	var rec partitionKeyRecord
+	if err := json.Unmarshal(body, &rec); err != nil {
+		t.Fatalf("unmarshal marker: %v", err)
+	}
+	if rec.ServerID != "srv-A" {
+		t.Errorf("ServerID = %q, want srv-A", rec.ServerID)
+	}
+	if rec.FirstSeen.IsZero() {
+		t.Error("FirstSeen is zero, want non-zero timestamp")
+	}
+}
+
+func TestEnsurePartitionKey_Match(t *testing.T) {
+	b := newMemBackend()
+	ctx := context.Background()
+
+	if err := EnsurePartitionKey(ctx, b, "srv-A"); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+
+	// Capture the written bytes to verify the marker isn't overwritten.
+	rc, _ := b.Get(ctx, PartitionKeyMarker)
+	original, _ := io.ReadAll(rc)
+	rc.Close()
+
+	if err := EnsurePartitionKey(ctx, b, "srv-A"); err != nil {
+		t.Fatalf("second call with matching serverID: %v", err)
+	}
+
+	rc, _ = b.Get(ctx, PartitionKeyMarker)
+	after, _ := io.ReadAll(rc)
+	rc.Close()
+
+	if string(original) != string(after) {
+		t.Errorf("marker was rewritten on matching call:\n  before = %s\n  after  = %s", original, after)
+	}
+}
+
+func TestEnsurePartitionKey_Mismatch(t *testing.T) {
+	b := newMemBackend()
+	ctx := context.Background()
+
+	if err := EnsurePartitionKey(ctx, b, "srv-A"); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	err := EnsurePartitionKey(ctx, b, "srv-B")
+	if err == nil {
+		t.Fatal("EnsurePartitionKey with mismatched serverID returned nil, want error")
+	}
+	if !strings.Contains(err.Error(), "srv-A") || !strings.Contains(err.Error(), "srv-B") {
+		t.Errorf("error should mention both server IDs; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "partition key mismatch") {
+		t.Errorf("error should contain 'partition key mismatch'; got: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #196, closes #198.

## Summary

Two sibling integrity gaps in the BYOS agent — both cause events to be silently misattributed to the wrong `bintrail_id`:

- **#196**: `SourceIdentity` was captured once at agent startup. If the source MySQL restarted with a regenerated `auto.cnf`, failed over behind a VIP, or its DSN resolved to a different instance, the agent kept stamping the stale `@@server_uuid` on every `MetadataRecord`. The SaaS then resolved events to the prior `bintrail_servers` row and blended two servers under one `bintrail_id` with no operator signal.
- **#198**: `serverIDStr` used as the S3 partition key is the UUID `bintrailID` when `--index-dsn` is set and the numeric `--server-id` otherwise. An upgrade across that cutover silently splits payload objects across two S3 prefixes; queries that span the upgrade miss pre-upgrade data.

## Changes

### #196 — periodic identity re-capture with hard-fail
- `byosFlushConfig.sourceIdent` is now `*atomic.Pointer[byos.SourceIdentity]` (concurrent-safe between the stream goroutine that re-captures and the flush goroutine that stamps records).
- `byosStreamLoop` runs a 60s `identityTicker` that calls the new `checkSourceIdentity`:
  - UUID stable → refresh the pointer (host/port/user may shift under CNAME changes).
  - UUID changed → return an actionable error; stream loop exits, agent exits non-zero.
  - Transient DB error → `slog.Warn` and let the next tick retry; do not tear down the stream.

### #198 — partition-key freeze marker
- New `byos.EnsurePartitionKey(ctx, backend, serverID)`. On first run it writes `.bintrail-partition-key` (JSON: `server_id` + `first_seen`) to the storage backend. On subsequent runs it reads the marker: match → no-op, mismatch → hard-fail with a message that explains the cutover and the operator's options (migrate S3 objects to the new prefix, or restore the prior config).
- Wired into `runAgent` right after the S3 backend is constructed, before `NewPayloadWriter`.
- Additional `slog.Warn` in the BYOS-without-`--index-dsn`+S3 path so the chosen partition key appears in the startup banner (defense in depth when no marker exists yet).

### Tests
- `cmd/bintrail/agent_identity_test.go` (sqlmock): stable, change-detected, transient-error-tolerated, host-only-update.
- `internal/byos/partition_key_test.go` (reuses the in-memory `memBackend` from `payload_test.go`): first-run, match no-op, mismatch error.

## Out of scope
- Retry-with-backoff inside `loadSourceIdentity` — called out in #196 as an independent improvement.
- Sentinel "identity discontinuity" records for the SaaS side (requires coordinated change in `nethalo/dbtrail`).
- Automatic migration of S3 objects between prefixes — the error message points the operator at the options.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -count=1` (full unit suite, all packages green)
- [x] New sqlmock tests for `checkSourceIdentity` pass
- [x] New `memBackend` tests for `EnsurePartitionKey` pass
- [ ] Manual #198 repro (optional): run agent with `serverID=A` against S3 → marker written; restart with `serverID=B` → agent hard-fails at startup with the mismatch message
- [ ] Manual #196 repro (optional): run agent with a short `identityInterval`, `rm auto.cnf` + restart source MySQL → agent exits cleanly with the change-detected error within one tick