### PR TITLE
Add --column-eq filter to query/recover for value-in-row matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `bintrail query` and `bintrail recover` now accept `--column-eq column=value`, a repeatable filter that matches events where a column inside `row_after` **or** `row_before` equals the given value. The OR across both sides covers DELETEs (value in `row_before`) and INSERTs (value in `row_after`) symmetrically. Repeating the flag composes AND. A column-name allowlist (`[A-Za-z0-9_]`) keeps the interpolated JSON path safe. The literal unquoted `NULL` sentinel matches rows where the column is explicitly JSON null (via `JSON_TYPE = 'NULL'`). The same filter is mirrored into the DuckDB archive path so merged live + archive queries stay consistent. MCP `query` and `recover` tools accept a matching `column_eq: [string]` parameter (#229).
+
 ## [0.5.6] - 2026-04-14
 
 ### Fixed

--- a/cmd/bintrail-mcp/main.go
+++ b/cmd/bintrail-mcp/main.go
@@ -221,36 +221,38 @@ func main() {
 // ─── Tool argument types ─────────────────────────────────────────────────────
 
 type queryArgs struct {
-	IndexDSN      string `json:"index_dsn,omitempty" jsonschema:"MySQL DSN for the index database. Overrides BINTRAIL_INDEX_DSN env var."`
-	Schema        string `json:"schema,omitempty" jsonschema:"Filter by database schema name"`
-	Table         string `json:"table,omitempty" jsonschema:"Filter by table name"`
-	PK            string `json:"pk,omitempty" jsonschema:"Filter by primary key value (pipe-delimited for composite keys e.g. 123 or 123|2)"`
-	EventType     string `json:"event_type,omitempty" jsonschema:"Filter by event type: INSERT UPDATE or DELETE"`
-	GTID          string `json:"gtid,omitempty" jsonschema:"Filter by GTID (e.g. uuid:42)"`
-	Since         string `json:"since,omitempty" jsonschema:"Filter events at or after this time (YYYY-MM-DD HH:MM:SS or RFC 3339)"`
-	Until         string `json:"until,omitempty" jsonschema:"Filter events at or before this time (YYYY-MM-DD HH:MM:SS or RFC 3339)"`
-	ChangedColumn string `json:"changed_column,omitempty" jsonschema:"Filter UPDATE events that modified this column"`
-	Flag          string `json:"flag,omitempty" jsonschema:"Filter events from tables or columns carrying this flag"`
-	Format        string `json:"format,omitempty" jsonschema:"Output format: json table or csv (default: json)"`
-	Limit         int    `json:"limit,omitempty" jsonschema:"Maximum number of events to return (default: 100)"`
-	Profile       string `json:"profile,omitempty" jsonschema:"Apply RBAC access rules for this profile (table-level deny and column-level redaction)"`
-	NoArchive     bool   `json:"no_archive,omitempty" jsonschema:"Disable auto-routing to Parquet archives (MySQL-only results)"`
+	IndexDSN      string   `json:"index_dsn,omitempty" jsonschema:"MySQL DSN for the index database. Overrides BINTRAIL_INDEX_DSN env var."`
+	Schema        string   `json:"schema,omitempty" jsonschema:"Filter by database schema name"`
+	Table         string   `json:"table,omitempty" jsonschema:"Filter by table name"`
+	PK            string   `json:"pk,omitempty" jsonschema:"Filter by primary key value (pipe-delimited for composite keys e.g. 123 or 123|2)"`
+	EventType     string   `json:"event_type,omitempty" jsonschema:"Filter by event type: INSERT UPDATE or DELETE"`
+	GTID          string   `json:"gtid,omitempty" jsonschema:"Filter by GTID (e.g. uuid:42)"`
+	Since         string   `json:"since,omitempty" jsonschema:"Filter events at or after this time (YYYY-MM-DD HH:MM:SS or RFC 3339)"`
+	Until         string   `json:"until,omitempty" jsonschema:"Filter events at or before this time (YYYY-MM-DD HH:MM:SS or RFC 3339)"`
+	ChangedColumn string   `json:"changed_column,omitempty" jsonschema:"Filter UPDATE events that modified this column"`
+	ColumnEq      []string `json:"column_eq,omitempty" jsonschema:"Filter events where a column in row_after or row_before equals the given value. Each entry is column=value. Repeat for AND. Literal NULL matches JSON null."`
+	Flag          string   `json:"flag,omitempty" jsonschema:"Filter events from tables or columns carrying this flag"`
+	Format        string   `json:"format,omitempty" jsonschema:"Output format: json table or csv (default: json)"`
+	Limit         int      `json:"limit,omitempty" jsonschema:"Maximum number of events to return (default: 100)"`
+	Profile       string   `json:"profile,omitempty" jsonschema:"Apply RBAC access rules for this profile (table-level deny and column-level redaction)"`
+	NoArchive     bool     `json:"no_archive,omitempty" jsonschema:"Disable auto-routing to Parquet archives (MySQL-only results)"`
 }
 
 type recoverArgs struct {
-	IndexDSN      string `json:"index_dsn,omitempty" jsonschema:"MySQL DSN for the index database. Overrides BINTRAIL_INDEX_DSN env var."`
-	Schema        string `json:"schema,omitempty" jsonschema:"Filter by database schema name"`
-	Table         string `json:"table,omitempty" jsonschema:"Filter by table name"`
-	PK            string `json:"pk,omitempty" jsonschema:"Filter by primary key value (pipe-delimited for composite keys)"`
-	EventType     string `json:"event_type,omitempty" jsonschema:"Filter by event type: INSERT UPDATE or DELETE"`
-	GTID          string `json:"gtid,omitempty" jsonschema:"Filter by GTID (e.g. uuid:42)"`
-	Since         string `json:"since,omitempty" jsonschema:"Filter events at or after this time (YYYY-MM-DD HH:MM:SS or RFC 3339)"`
-	Until         string `json:"until,omitempty" jsonschema:"Filter events at or before this time (YYYY-MM-DD HH:MM:SS or RFC 3339)"`
-	ChangedColumn string `json:"changed_column,omitempty" jsonschema:"Filter UPDATE events that modified this column"`
-	Flag          string `json:"flag,omitempty" jsonschema:"Filter events from tables or columns carrying this flag"`
-	Limit         int    `json:"limit,omitempty" jsonschema:"Maximum number of events to reverse (default: 1000)"`
-	Profile       string `json:"profile,omitempty" jsonschema:"Apply RBAC access rules for this profile (table-level deny and column-level redaction)"`
-	NoArchive     bool   `json:"no_archive,omitempty" jsonschema:"Disable auto-routing to Parquet archives (MySQL-only results)"`
+	IndexDSN      string   `json:"index_dsn,omitempty" jsonschema:"MySQL DSN for the index database. Overrides BINTRAIL_INDEX_DSN env var."`
+	Schema        string   `json:"schema,omitempty" jsonschema:"Filter by database schema name"`
+	Table         string   `json:"table,omitempty" jsonschema:"Filter by table name"`
+	PK            string   `json:"pk,omitempty" jsonschema:"Filter by primary key value (pipe-delimited for composite keys)"`
+	EventType     string   `json:"event_type,omitempty" jsonschema:"Filter by event type: INSERT UPDATE or DELETE"`
+	GTID          string   `json:"gtid,omitempty" jsonschema:"Filter by GTID (e.g. uuid:42)"`
+	Since         string   `json:"since,omitempty" jsonschema:"Filter events at or after this time (YYYY-MM-DD HH:MM:SS or RFC 3339)"`
+	Until         string   `json:"until,omitempty" jsonschema:"Filter events at or before this time (YYYY-MM-DD HH:MM:SS or RFC 3339)"`
+	ChangedColumn string   `json:"changed_column,omitempty" jsonschema:"Filter UPDATE events that modified this column"`
+	ColumnEq      []string `json:"column_eq,omitempty" jsonschema:"Filter events where a column in row_after or row_before equals the given value. Each entry is column=value. Repeat for AND. Literal NULL matches JSON null."`
+	Flag          string   `json:"flag,omitempty" jsonschema:"Filter events from tables or columns carrying this flag"`
+	Limit         int      `json:"limit,omitempty" jsonschema:"Maximum number of events to reverse (default: 1000)"`
+	Profile       string   `json:"profile,omitempty" jsonschema:"Apply RBAC access rules for this profile (table-level deny and column-level redaction)"`
+	NoArchive     bool     `json:"no_archive,omitempty" jsonschema:"Disable auto-routing to Parquet archives (MySQL-only results)"`
 }
 
 type statusArgs struct {
@@ -288,7 +290,7 @@ func makeQueryTool(connect connectFunc) func(context.Context, *mcp.CallToolReque
 		defer db.Close()
 
 		opts, err := buildQueryOptions(args.Schema, args.Table, args.PK, args.EventType,
-			args.GTID, args.Since, args.Until, args.ChangedColumn, args.Flag, args.Limit, 100)
+			args.GTID, args.Since, args.Until, args.ChangedColumn, args.ColumnEq, args.Flag, args.Limit, 100)
 		if err != nil {
 			return errorResult(err), nil, nil
 		}
@@ -385,7 +387,7 @@ func makeRecoverTool(connect connectFunc) func(context.Context, *mcp.CallToolReq
 
 		defaultLimit := 1000
 		opts, err := buildQueryOptions(args.Schema, args.Table, args.PK, args.EventType,
-			args.GTID, args.Since, args.Until, args.ChangedColumn, args.Flag, args.Limit, defaultLimit)
+			args.GTID, args.Since, args.Until, args.ChangedColumn, args.ColumnEq, args.Flag, args.Limit, defaultLimit)
 		if err != nil {
 			return errorResult(err), nil, nil
 		}
@@ -665,12 +667,15 @@ func resolveArchiveSources(ctx context.Context, db *sql.DB) []string {
 	return query.ResolveArchiveSources(ctx, db)
 }
 
-func buildQueryOptions(schema, table, pk, eventType, gtid, since, until, changedCol, flagVal string, limit, defaultLimit int) (query.Options, error) {
+func buildQueryOptions(schema, table, pk, eventType, gtid, since, until, changedCol string, columnEq []string, flagVal string, limit, defaultLimit int) (query.Options, error) {
 	if pk != "" && (schema == "" || table == "") {
 		return query.Options{}, fmt.Errorf("pk requires both schema and table")
 	}
 	if changedCol != "" && (schema == "" || table == "") {
 		return query.Options{}, fmt.Errorf("changed_column requires both schema and table")
+	}
+	if len(columnEq) > 0 && (schema == "" || table == "") {
+		return query.Options{}, fmt.Errorf("column_eq requires both schema and table")
 	}
 
 	et, err := cliutil.ParseEventType(eventType)
@@ -684,6 +689,10 @@ func buildQueryOptions(schema, table, pk, eventType, gtid, since, until, changed
 	untilT, err := cliutil.ParseTime(until)
 	if err != nil {
 		return query.Options{}, fmt.Errorf("invalid until: %w", err)
+	}
+	parsedEq, err := query.ParseColumnEqs(columnEq)
+	if err != nil {
+		return query.Options{}, err
 	}
 
 	if limit <= 0 {
@@ -699,6 +708,7 @@ func buildQueryOptions(schema, table, pk, eventType, gtid, since, until, changed
 		Since:         sinceT,
 		Until:         untilT,
 		ChangedColumn: changedCol,
+		ColumnEq:      parsedEq,
 		Flag:          flagVal,
 		Limit:         limit,
 	}, nil

--- a/cmd/bintrail-mcp/main_test.go
+++ b/cmd/bintrail-mcp/main_test.go
@@ -15,7 +15,7 @@ const defaultLimit = 100
 // ─── buildQueryOptions ───────────────────────────────────────────────────────
 
 func TestBuildQueryOptions_empty(t *testing.T) {
-	opts, err := buildQueryOptions("", "", "", "", "", "", "", "", "", 0, defaultLimit)
+	opts, err := buildQueryOptions("", "", "", "", "", "", "", "", nil, "", 0, defaultLimit)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -36,7 +36,7 @@ func TestBuildQueryOptions_empty(t *testing.T) {
 func TestBuildQueryOptions_allFields(t *testing.T) {
 	opts, err := buildQueryOptions(
 		"mydb", "orders", "12345", "INSERT",
-		"abc:1", "2026-02-19 14:00:00", "2026-02-19 15:00:00", "status", "",
+		"abc:1", "2026-02-19 14:00:00", "2026-02-19 15:00:00", "status", nil, "",
 		50, defaultLimit,
 	)
 	if err != nil {
@@ -72,7 +72,7 @@ func TestBuildQueryOptions_allFields(t *testing.T) {
 }
 
 func TestBuildQueryOptions_pkWithoutSchemaTable(t *testing.T) {
-	_, err := buildQueryOptions("", "", "12345", "", "", "", "", "", "", 0, defaultLimit)
+	_, err := buildQueryOptions("", "", "12345", "", "", "", "", "", nil, "", 0, defaultLimit)
 	if err == nil {
 		t.Error("expected error when pk is set without schema/table")
 	}
@@ -82,14 +82,14 @@ func TestBuildQueryOptions_pkWithoutSchemaTable(t *testing.T) {
 }
 
 func TestBuildQueryOptions_pkWithSchemaOnly(t *testing.T) {
-	_, err := buildQueryOptions("mydb", "", "12345", "", "", "", "", "", "", 0, defaultLimit)
+	_, err := buildQueryOptions("mydb", "", "12345", "", "", "", "", "", nil, "", 0, defaultLimit)
 	if err == nil {
 		t.Error("expected error when pk is set with schema but no table")
 	}
 }
 
 func TestBuildQueryOptions_changedColumnWithoutSchemaTable(t *testing.T) {
-	_, err := buildQueryOptions("", "", "", "", "", "", "", "status", "", 0, defaultLimit)
+	_, err := buildQueryOptions("", "", "", "", "", "", "", "status", nil, "", 0, defaultLimit)
 	if err == nil {
 		t.Error("expected error when changed_column is set without schema/table")
 	}
@@ -99,14 +99,14 @@ func TestBuildQueryOptions_changedColumnWithoutSchemaTable(t *testing.T) {
 }
 
 func TestBuildQueryOptions_invalidEventType(t *testing.T) {
-	_, err := buildQueryOptions("mydb", "orders", "", "UPSERT", "", "", "", "", "", 0, defaultLimit)
+	_, err := buildQueryOptions("mydb", "orders", "", "UPSERT", "", "", "", "", nil, "", 0, defaultLimit)
 	if err == nil {
 		t.Error("expected error for invalid event_type")
 	}
 }
 
 func TestBuildQueryOptions_invalidSince(t *testing.T) {
-	_, err := buildQueryOptions("", "", "", "", "", "not-a-date", "", "", "", 0, defaultLimit)
+	_, err := buildQueryOptions("", "", "", "", "", "not-a-date", "", "", nil, "", 0, defaultLimit)
 	if err == nil {
 		t.Error("expected error for invalid since")
 	}
@@ -116,7 +116,7 @@ func TestBuildQueryOptions_invalidSince(t *testing.T) {
 }
 
 func TestBuildQueryOptions_invalidUntil(t *testing.T) {
-	_, err := buildQueryOptions("", "", "", "", "", "", "not-a-date", "", "", 0, defaultLimit)
+	_, err := buildQueryOptions("", "", "", "", "", "", "not-a-date", "", nil, "", 0, defaultLimit)
 	if err == nil {
 		t.Error("expected error for invalid until")
 	}
@@ -126,7 +126,7 @@ func TestBuildQueryOptions_invalidUntil(t *testing.T) {
 }
 
 func TestBuildQueryOptions_limitZeroUsesDefault(t *testing.T) {
-	opts, err := buildQueryOptions("", "", "", "", "", "", "", "", "", 0, defaultLimit)
+	opts, err := buildQueryOptions("", "", "", "", "", "", "", "", nil, "", 0, defaultLimit)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -136,7 +136,7 @@ func TestBuildQueryOptions_limitZeroUsesDefault(t *testing.T) {
 }
 
 func TestBuildQueryOptions_negativeLimitUsesDefault(t *testing.T) {
-	opts, err := buildQueryOptions("", "", "", "", "", "", "", "", "", -5, defaultLimit)
+	opts, err := buildQueryOptions("", "", "", "", "", "", "", "", nil, "", -5, defaultLimit)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -145,8 +145,47 @@ func TestBuildQueryOptions_negativeLimitUsesDefault(t *testing.T) {
 	}
 }
 
+func TestBuildQueryOptions_columnEqPassedThrough(t *testing.T) {
+	opts, err := buildQueryOptions("mydb", "orders", "", "", "", "", "", "",
+		[]string{"status=active", "deleted_at=NULL"}, "", 0, defaultLimit)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(opts.ColumnEq) != 2 {
+		t.Fatalf("expected 2 ColumnEq entries, got %d", len(opts.ColumnEq))
+	}
+	if opts.ColumnEq[0].Column != "status" || opts.ColumnEq[0].Value != "active" {
+		t.Errorf("entry 0: got %+v", opts.ColumnEq[0])
+	}
+	if !opts.ColumnEq[1].IsNull {
+		t.Errorf("entry 1: expected IsNull, got %+v", opts.ColumnEq[1])
+	}
+}
+
+func TestBuildQueryOptions_columnEqRequiresSchemaTable(t *testing.T) {
+	_, err := buildQueryOptions("", "", "", "", "", "", "", "",
+		[]string{"status=active"}, "", 0, defaultLimit)
+	if err == nil {
+		t.Fatal("expected error when column_eq is set without schema/table")
+	}
+	if !strings.Contains(err.Error(), "schema") {
+		t.Errorf("expected schema mention in error, got: %v", err)
+	}
+}
+
+func TestBuildQueryOptions_columnEqMalformedEntry(t *testing.T) {
+	_, err := buildQueryOptions("mydb", "orders", "", "", "", "", "", "",
+		[]string{"no-equals"}, "", 0, defaultLimit)
+	if err == nil {
+		t.Fatal("expected error for malformed column_eq entry")
+	}
+	if !strings.Contains(err.Error(), "missing '='") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
 func TestBuildQueryOptions_flagPassedThrough(t *testing.T) {
-	opts, err := buildQueryOptions("", "", "", "", "", "", "", "", "billing", 0, defaultLimit)
+	opts, err := buildQueryOptions("", "", "", "", "", "", "", "", nil, "billing", 0, defaultLimit)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/cmd/bintrail/config.go
+++ b/cmd/bintrail/config.go
@@ -99,6 +99,7 @@ var envSections = []envSection{
 		Bindings: []envTemplateEntry{
 			{"BINTRAIL_SCHEMAS", ""},
 			{"BINTRAIL_TABLES", ""},
+			{"BINTRAIL_COLUMN_EQ", ""},
 		},
 	},
 	{

--- a/cmd/bintrail/envload.go
+++ b/cmd/bintrail/envload.go
@@ -51,6 +51,7 @@ var envBindings = []envBinding{
 	{"flush-interval", "BINTRAIL_FLUSH_INTERVAL"},
 	{"gap-timeout", "BINTRAIL_STREAM_GAP_TIMEOUT"},
 	{"max-reconnect-attempts", "BINTRAIL_AGENT_MAX_RECONNECT_ATTEMPTS"},
+	{"column-eq", "BINTRAIL_COLUMN_EQ"},
 }
 
 var envOnce sync.Once

--- a/cmd/bintrail/query.go
+++ b/cmd/bintrail/query.go
@@ -57,6 +57,7 @@ var (
 	qSince      string
 	qUntil      string
 	qChangedCol string
+	qColumnEq   []string
 	qFlag       string
 	qFormat     string
 	qLimit      int
@@ -77,6 +78,7 @@ func init() {
 	queryCmd.Flags().StringVar(&qSince, "since", "", "Filter events at or after this time (2006-01-02 15:04:05)")
 	queryCmd.Flags().StringVar(&qUntil, "until", "", "Filter events at or before this time (2006-01-02 15:04:05)")
 	queryCmd.Flags().StringVar(&qChangedCol, "changed-column", "", "Filter UPDATEs that modified this column")
+	queryCmd.Flags().StringArrayVar(&qColumnEq, "column-eq", nil, "Filter events where a column in row_after or row_before equals the given value (format: column=value, repeat for AND; literal NULL matches JSON null)")
 	queryCmd.Flags().StringVar(&qFlag, "flag", "", "Filter events from tables or columns carrying this flag (see 'bintrail flag list')")
 	queryCmd.Flags().StringVar(&qFormat, "format", "table", "Output format: table, json, or csv")
 	queryCmd.Flags().IntVar(&qLimit, "limit", 100, "Maximum number of rows to return")
@@ -99,6 +101,13 @@ func runQuery(cmd *cobra.Command, args []string) error {
 	}
 	if qChangedCol != "" && (qSchema == "" || qTable == "") {
 		return fmt.Errorf("--changed-column requires both --schema and --table")
+	}
+	if len(qColumnEq) > 0 && (qSchema == "" || qTable == "") {
+		return fmt.Errorf("--column-eq requires both --schema and --table")
+	}
+	columnEq, err := query.ParseColumnEqs(qColumnEq)
+	if err != nil {
+		return err
 	}
 	if !cliutil.IsValidFormat(qFormat) {
 		return fmt.Errorf("invalid --format %q; must be table, json, or csv", qFormat)
@@ -136,6 +145,7 @@ func runQuery(cmd *cobra.Command, args []string) error {
 		Since:         since,
 		Until:         until,
 		ChangedColumn: qChangedCol,
+		ColumnEq:      columnEq,
 		Flag:          qFlag,
 		Limit:         qLimit,
 	}

--- a/cmd/bintrail/query_test.go
+++ b/cmd/bintrail/query_test.go
@@ -109,6 +109,40 @@ func TestRunQuery_pkRequiresSchemaTable(t *testing.T) {
 	}
 }
 
+func TestRunQuery_columnEqRequiresSchemaTable(t *testing.T) {
+	saved, savedS, savedT := qColumnEq, qSchema, qTable
+	t.Cleanup(func() { qColumnEq = saved; qSchema = savedS; qTable = savedT })
+
+	qColumnEq = []string{"status=active"}
+	qSchema = ""
+	qTable = ""
+
+	err := runQuery(queryCmd, nil)
+	if err == nil {
+		t.Fatal("expected error when --column-eq used without --schema/--table")
+	}
+	if !strings.Contains(err.Error(), "--column-eq requires") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestRunQuery_columnEqMalformed(t *testing.T) {
+	saved, savedS, savedT := qColumnEq, qSchema, qTable
+	t.Cleanup(func() { qColumnEq = saved; qSchema = savedS; qTable = savedT })
+
+	qColumnEq = []string{"no-equals-sign"}
+	qSchema = "mydb"
+	qTable = "orders"
+
+	err := runQuery(queryCmd, nil)
+	if err == nil {
+		t.Fatal("expected error for --column-eq entry without '='")
+	}
+	if !strings.Contains(err.Error(), "missing '='") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
 func TestRunQuery_changedColRequiresSchemaTable(t *testing.T) {
 	saved, savedS, savedT := qChangedCol, qSchema, qTable
 	t.Cleanup(func() { qChangedCol = saved; qSchema = savedS; qTable = savedT })

--- a/cmd/bintrail/recover.go
+++ b/cmd/bintrail/recover.go
@@ -66,6 +66,7 @@ var (
 	rProfile    string
 	rFormat     string
 	rNoArchive  bool
+	rColumnEq   []string
 )
 
 func init() {
@@ -78,6 +79,7 @@ func init() {
 	recoverCmd.Flags().StringVar(&rSince, "since", "", "Filter events at or after this time (2006-01-02 15:04:05)")
 	recoverCmd.Flags().StringVar(&rUntil, "until", "", "Filter events at or before this time (2006-01-02 15:04:05)")
 	recoverCmd.Flags().StringVar(&rFlag, "flag", "", "Filter events from tables or columns carrying this flag (see 'bintrail flag list')")
+	recoverCmd.Flags().StringArrayVar(&rColumnEq, "column-eq", nil, "Filter events where a column in row_after or row_before equals the given value (format: column=value, repeat for AND; literal NULL matches JSON null)")
 	recoverCmd.Flags().StringVar(&rOutput, "output", "", "Write recovery SQL to this file (required unless --dry-run)")
 	recoverCmd.Flags().BoolVar(&rDryRun, "dry-run", false, "Print recovery SQL to stdout instead of writing a file")
 	recoverCmd.Flags().IntVar(&rLimit, "limit", 1000, "Maximum number of events to reverse")
@@ -102,6 +104,13 @@ func runRecover(cmd *cobra.Command, args []string) error {
 	if rPK != "" && (rSchema == "" || rTable == "") {
 		return fmt.Errorf("--pk requires both --schema and --table")
 	}
+	if len(rColumnEq) > 0 && (rSchema == "" || rTable == "") {
+		return fmt.Errorf("--column-eq requires both --schema and --table")
+	}
+	columnEq, err := query.ParseColumnEqs(rColumnEq)
+	if err != nil {
+		return err
+	}
 
 	// ── Parse filter values ───────────────────────────────────────────────────
 	eventType, err := cliutil.ParseEventType(rEventType)
@@ -125,6 +134,7 @@ func runRecover(cmd *cobra.Command, args []string) error {
 		GTID:      rGTID,
 		Since:     since,
 		Until:     until,
+		ColumnEq:  columnEq,
 		Flag:      rFlag,
 		Limit:     rLimit,
 	}

--- a/cmd/bintrail/recover_test.go
+++ b/cmd/bintrail/recover_test.go
@@ -70,7 +70,7 @@ func TestRecoverCmd_allFlagsRegistered(t *testing.T) {
 	for _, name := range []string{
 		"index-dsn", "schema", "table", "pk", "event-type",
 		"gtid", "since", "until", "flag", "output", "dry-run", "limit",
-		"no-archive",
+		"no-archive", "column-eq",
 	} {
 		if recoverCmd.Flag(name) == nil {
 			t.Errorf("flag --%s not registered on recoverCmd", name)
@@ -120,6 +120,52 @@ func TestRunRecover_pkRequiresSchemaTable(t *testing.T) {
 		t.Fatal("expected error when --pk used without --schema/--table, got nil")
 	}
 	if !strings.Contains(err.Error(), "--pk requires") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestRunRecover_columnEqRequiresSchemaTable(t *testing.T) {
+	savedEq, savedS, savedT, savedDry := rColumnEq, rSchema, rTable, rDryRun
+	t.Cleanup(func() {
+		rColumnEq = savedEq
+		rSchema = savedS
+		rTable = savedT
+		rDryRun = savedDry
+	})
+
+	rDryRun = true
+	rColumnEq = []string{"status=active"}
+	rSchema = ""
+	rTable = ""
+
+	err := runRecover(recoverCmd, nil)
+	if err == nil {
+		t.Fatal("expected error when --column-eq used without --schema/--table")
+	}
+	if !strings.Contains(err.Error(), "--column-eq requires") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestRunRecover_columnEqMalformed(t *testing.T) {
+	savedEq, savedS, savedT, savedDry := rColumnEq, rSchema, rTable, rDryRun
+	t.Cleanup(func() {
+		rColumnEq = savedEq
+		rSchema = savedS
+		rTable = savedT
+		rDryRun = savedDry
+	})
+
+	rDryRun = true
+	rColumnEq = []string{"no-equals-sign"}
+	rSchema = "mydb"
+	rTable = "orders"
+
+	err := runRecover(recoverCmd, nil)
+	if err == nil {
+		t.Fatal("expected error for malformed --column-eq entry")
+	}
+	if !strings.Contains(err.Error(), "missing '='") {
 		t.Errorf("unexpected error message: %v", err)
 	}
 }

--- a/docs/query-and-recovery.md
+++ b/docs/query-and-recovery.md
@@ -82,7 +82,9 @@ JSON_UNQUOTE(JSON_EXTRACT(row_before, '$.status')) = 'active'
 bintrail query --schema mydb --table orders --column-eq deleted_at=NULL
 ```
 
-Internally this translates to `JSON_TYPE(JSON_EXTRACT(..., '$.deleted_at')) = 'NULL'` on both sides. It does **not** match rows where the column is absent from the row image (FULL row images always include every column, so absence only occurs when the source has `binlog_row_image != FULL`, which `bintrail index` rejects). To match the literal four-character string `"NULL"` instead, quote it: `--column-eq label='"NULL"'`.
+Internally this translates to `JSON_TYPE(JSON_EXTRACT(..., '$.deleted_at')) = 'NULL'` on both sides. It does **not** match rows where the column is absent from the row image (FULL row images always include every column, so absence only occurs when the source has `binlog_row_image != FULL`, which `bintrail index` rejects).
+
+The literal value `NULL` is reserved as the JSON-null sentinel — there is currently no escape for matching a column whose value is the four-character string `"NULL"`. If you need that, file an issue.
 
 The same filter is applied to DuckDB when archive auto-discovery routes the query through Parquet files (`json_extract_string` / `json_type`), so merged (live + archive) results stay consistent.
 

--- a/docs/query-and-recovery.md
+++ b/docs/query-and-recovery.md
@@ -26,6 +26,7 @@ The engine is shared: the CLI `query` command, the CLI `recover` command, and th
 | `Since` | `event_timestamp >= ?` (+ pruning hint for non-hour-aligned values) |
 | `Until` | `event_timestamp <= ?` (+ pruning hint for non-hour-aligned values) |
 | `ChangedColumn` | `JSON_CONTAINS(changed_columns, ?)` |
+| `ColumnEq` | `JSON_UNQUOTE(JSON_EXTRACT(row_after, '$.<col>')) = ? OR JSON_UNQUOTE(JSON_EXTRACT(row_before, '$.<col>')) = ?` |
 | `Flag` | `EXISTS (SELECT 1 FROM table_flags WHERE schema_name = binlog_events.schema_name AND table_name = binlog_events.table_name AND flag = ?)` |
 
 The conditions are joined with `AND`. If no filters are provided, there's no `WHERE` clause at all (subject to the `LIMIT`).
@@ -53,6 +54,37 @@ JSON_CONTAINS(changed_columns, '"status"')
 ```
 
 The needle is the JSON string representation of the column name (with quotes). `json.Marshal("status")` produces `"status"` — exactly the right format for `JSON_CONTAINS`.
+
+### `--column-eq` Filter
+
+Filters events by the value of a column inside the row image. Pass `--column-eq column=value`; repeat the flag to AND multiple entries:
+
+```sh
+bintrail query --schema mydb --table orders \
+  --column-eq status=active --column-eq order_id=7
+```
+
+The generated predicate checks both sides of the event so DELETEs match when the value is in `row_before`:
+
+```sql
+JSON_UNQUOTE(JSON_EXTRACT(row_after,  '$.status')) = 'active'
+OR
+JSON_UNQUOTE(JSON_EXTRACT(row_before, '$.status')) = 'active'
+```
+
+`--column-eq` requires `--schema` and `--table`, matching the constraint on `--changed-column`.
+
+**Column names** must match `[A-Za-z0-9_]+`. The column name is interpolated into the JSON path literal (MySQL does not accept bind parameters for paths), so the allowlist keeps the clause safe.
+
+**NULL sentinel.** The literal value `NULL` (unquoted, case-sensitive) matches rows where the column is explicitly JSON null:
+
+```sh
+bintrail query --schema mydb --table orders --column-eq deleted_at=NULL
+```
+
+Internally this translates to `JSON_TYPE(JSON_EXTRACT(..., '$.deleted_at')) = 'NULL'` on both sides. It does **not** match rows where the column is absent from the row image (FULL row images always include every column, so absence only occurs when the source has `binlog_row_image != FULL`, which `bintrail index` rejects). To match the literal four-character string `"NULL"` instead, quote it: `--column-eq label='"NULL"'`.
+
+The same filter is applied to DuckDB when archive auto-discovery routes the query through Parquet files (`json_extract_string` / `json_type`), so merged (live + archive) results stay consistent.
 
 ### Partition Pruning Guarantee
 

--- a/internal/parquetquery/parquetquery.go
+++ b/internal/parquetquery/parquetquery.go
@@ -605,6 +605,25 @@ func buildFilters(opts query.Options) ([]string, []any) {
 		where = append(where, "json_contains(changed_columns, ?)")
 		args = append(args, string(needle))
 	}
+	for _, ce := range opts.ColumnEq {
+		// Mirrors internal/query.buildQuery's --column-eq clause. See that
+		// function's comment for the column-name safety argument; the path is
+		// always of the form "$.<identifier>". DuckDB returns uppercase
+		// json_type names ('NULL'), matching MySQL.
+		path := "$." + ce.Column
+		if ce.IsNull {
+			where = append(where, fmt.Sprintf(
+				"(json_type(json_extract(row_after, '%s')) = 'NULL' "+
+					"OR json_type(json_extract(row_before, '%s')) = 'NULL')",
+				path, path))
+			continue
+		}
+		where = append(where, fmt.Sprintf(
+			"(json_extract_string(row_after, '%s') = ? "+
+				"OR json_extract_string(row_before, '%s') = ?)",
+			path, path))
+		args = append(args, ce.Value, ce.Value)
+	}
 
 	return where, args
 }

--- a/internal/parquetquery/parquetquery.go
+++ b/internal/parquetquery/parquetquery.go
@@ -606,10 +606,17 @@ func buildFilters(opts query.Options) ([]string, []any) {
 		args = append(args, string(needle))
 	}
 	for _, ce := range opts.ColumnEq {
-		// Mirrors internal/query.buildQuery's --column-eq clause. See that
-		// function's comment for the column-name safety argument; the path is
-		// always of the form "$.<identifier>". DuckDB returns uppercase
-		// json_type names ('NULL'), matching MySQL.
+		// DuckDB does not bind JSON paths either, so the column name is
+		// interpolated; re-validate via the shared allowlist for the same
+		// defense-in-depth reason as internal/query.buildQuery. DuckDB's
+		// json_type returns uppercase 'NULL' for JSON null, matching MySQL's
+		// JSON_TYPE — so the IsNull branch shape is identical on both engines.
+		if !query.IsSafeColumnName(ce.Column) {
+			slog.Error("parquetquery.buildFilters: rejected unsafe column name in ColumnEq filter; emitting no-match clause",
+				"column", ce.Column)
+			where = append(where, "1=0")
+			continue
+		}
 		path := "$." + ce.Column
 		if ce.IsNull {
 			where = append(where, fmt.Sprintf(

--- a/internal/parquetquery/parquetquery_test.go
+++ b/internal/parquetquery/parquetquery_test.go
@@ -251,6 +251,7 @@ func TestBuildQueryColumnEq_unsafeColumnEmitsNoMatch(t *testing.T) {
 }
 
 func TestBuildQueryColumnEq_unsafeEntryDoesNotPoisonOthers(t *testing.T) {
+	// Parquet-side mirror of the MySQL columneq continue-semantics pin.
 	opts := query.Options{
 		Schema: "db",
 		Table:  "t",

--- a/internal/parquetquery/parquetquery_test.go
+++ b/internal/parquetquery/parquetquery_test.go
@@ -231,6 +231,25 @@ func TestBuildQueryColumnEq(t *testing.T) {
 	}
 }
 
+func TestBuildQueryColumnEq_unsafeColumnEmitsNoMatch(t *testing.T) {
+	opts := query.Options{
+		Schema:   "db",
+		Table:    "t",
+		ColumnEq: []query.ColumnEq{{Column: "evil'); DROP--", Value: "x"}},
+		Limit:    100,
+	}
+	q, args := buildQuery("/arc/*.parquet", opts)
+	assertContains(t, q, "1=0")
+	if strings.Contains(q, "evil") {
+		t.Errorf("unsafe column name leaked into SQL: %s", q)
+	}
+	for _, a := range args {
+		if s, ok := a.(string); ok && s == "x" {
+			t.Errorf("unsafe entry's value bound: %v", args)
+		}
+	}
+}
+
 func TestBuildQueryColumnEq_nullSentinel(t *testing.T) {
 	opts := query.Options{
 		Schema:   "db",

--- a/internal/parquetquery/parquetquery_test.go
+++ b/internal/parquetquery/parquetquery_test.go
@@ -250,6 +250,30 @@ func TestBuildQueryColumnEq_unsafeColumnEmitsNoMatch(t *testing.T) {
 	}
 }
 
+func TestBuildQueryColumnEq_unsafeEntryDoesNotPoisonOthers(t *testing.T) {
+	opts := query.Options{
+		Schema: "db",
+		Table:  "t",
+		ColumnEq: []query.ColumnEq{
+			{Column: "evil'); DROP--", Value: "x"},
+			{Column: "status", Value: "active"},
+		},
+		Limit: 100,
+	}
+	q, args := buildQuery("/arc/*.parquet", opts)
+	assertContains(t, q, "1=0")
+	assertContains(t, q, "json_extract_string(row_after, '$.status')")
+	count := 0
+	for _, a := range args {
+		if s, ok := a.(string); ok && s == "active" {
+			count++
+		}
+	}
+	if count != 2 {
+		t.Errorf("expected safe value bound twice, got %d (args=%v)", count, args)
+	}
+}
+
 func TestBuildQueryColumnEq_nullSentinel(t *testing.T) {
 	opts := query.Options{
 		Schema:   "db",

--- a/internal/parquetquery/parquetquery_test.go
+++ b/internal/parquetquery/parquetquery_test.go
@@ -210,6 +210,44 @@ func TestBuildQueryChangedColumn(t *testing.T) {
 	}
 }
 
+func TestBuildQueryColumnEq(t *testing.T) {
+	opts := query.Options{
+		Schema:   "db",
+		Table:    "t",
+		ColumnEq: []query.ColumnEq{{Column: "status", Value: "active"}},
+		Limit:    100,
+	}
+	q, args := buildQuery("/arc/*.parquet", opts)
+	assertContains(t, q, "json_extract_string(row_after, '$.status')")
+	assertContains(t, q, "json_extract_string(row_before, '$.status')")
+	count := 0
+	for _, a := range args {
+		if s, ok := a.(string); ok && s == "active" {
+			count++
+		}
+	}
+	if count != 2 {
+		t.Errorf("expected value bound twice, got %d (args=%v)", count, args)
+	}
+}
+
+func TestBuildQueryColumnEq_nullSentinel(t *testing.T) {
+	opts := query.Options{
+		Schema:   "db",
+		Table:    "t",
+		ColumnEq: []query.ColumnEq{{Column: "deleted_at", IsNull: true}},
+		Limit:    100,
+	}
+	q, args := buildQuery("/arc/*.parquet", opts)
+	assertContains(t, q, "json_type(json_extract(row_after, '$.deleted_at')) = 'NULL'")
+	assertContains(t, q, "json_type(json_extract(row_before, '$.deleted_at')) = 'NULL'")
+	for _, a := range args {
+		if s, ok := a.(string); ok && s == "NULL" {
+			t.Errorf("null sentinel must not bind the literal string: %v", args)
+		}
+	}
+}
+
 func TestBuildQueryNoLimit(t *testing.T) {
 	q, args := buildQuery("/arc/*.parquet", query.Options{})
 	if strings.Contains(q, "LIMIT") {

--- a/internal/query/columneq.go
+++ b/internal/query/columneq.go
@@ -38,12 +38,16 @@ func ParseColumnEq(entry string) (ColumnEq, error) {
 	if col == "" {
 		return ColumnEq{}, fmt.Errorf("--column-eq entry %q has empty column name", entry)
 	}
-	if !isSafeColumnName(col) {
+	if !IsSafeColumnName(col) {
 		return ColumnEq{}, fmt.Errorf("--column-eq column name %q must match [A-Za-z0-9_]+", col)
 	}
 	eq := ColumnEq{Column: col, Value: val}
 	if val == "NULL" {
+		// Null-sentinel branch binds no positional arg; clear the value so a
+		// future caller that forgets to check IsNull cannot silently bind the
+		// literal string "NULL".
 		eq.IsNull = true
+		eq.Value = ""
 	}
 	return eq, nil
 }
@@ -64,7 +68,11 @@ func ParseColumnEqs(entries []string) ([]ColumnEq, error) {
 	return out, nil
 }
 
-func isSafeColumnName(col string) bool {
+// IsSafeColumnName reports whether col matches the JSON-path-safe allowlist
+// ([A-Za-z0-9_]+). Exposed for use as a defense-in-depth check at SQL builder
+// boundaries — `Options.ColumnEq` crosses package and process boundaries (CLI,
+// MCP), so callers other than ParseColumnEq cannot be assumed to have validated.
+func IsSafeColumnName(col string) bool {
 	if col == "" {
 		return false
 	}

--- a/internal/query/columneq.go
+++ b/internal/query/columneq.go
@@ -26,9 +26,10 @@ type ColumnEq struct {
 //   - Rejects empty or unsafe column names; the allowlist matches identifier
 //     characters (letters, digits, underscore) because the column name is
 //     interpolated into a JSON path literal (MySQL does not bind JSON paths).
-//   - The literal (unquoted) value "NULL" sets IsNull=true — this matches
-//     rows where the column is explicitly JSON null. To compare against the
-//     literal four-character string "NULL", quote it as '"NULL"'.
+//   - The literal (case-sensitive) value "NULL" sets IsNull=true — this
+//     matches rows where the column is explicitly JSON null. The string
+//     "NULL" is reserved as the sentinel; matching a column whose value is
+//     the literal four-character string "NULL" is not currently supported.
 func ParseColumnEq(entry string) (ColumnEq, error) {
 	col, val, ok := strings.Cut(entry, "=")
 	if !ok {

--- a/internal/query/columneq.go
+++ b/internal/query/columneq.go
@@ -1,0 +1,82 @@
+package query
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ColumnEq is one --column-eq filter entry. See Options.ColumnEq and
+// ParseColumnEq for parsing rules.
+type ColumnEq struct {
+	// Column is the JSON key within row_after / row_before to match on.
+	// Must be an allowlisted identifier (see ParseColumnEq).
+	Column string
+	// Value is the expected string form of the column's value. Ignored when
+	// IsNull is true.
+	Value string
+	// IsNull indicates the user asked to match JSON null via the literal
+	// sentinel "NULL". Under this flag the generator emits a JSON_TYPE check
+	// and binds no positional arg.
+	IsNull bool
+}
+
+// ParseColumnEq parses one "column=value" entry.
+//
+//   - Splits on the FIRST '=' so values may themselves contain '='.
+//   - Rejects empty or unsafe column names; the allowlist matches identifier
+//     characters (letters, digits, underscore) because the column name is
+//     interpolated into a JSON path literal (MySQL does not bind JSON paths).
+//   - The literal (unquoted) value "NULL" sets IsNull=true — this matches
+//     rows where the column is explicitly JSON null. To compare against the
+//     literal four-character string "NULL", quote it as '"NULL"'.
+func ParseColumnEq(entry string) (ColumnEq, error) {
+	col, val, ok := strings.Cut(entry, "=")
+	if !ok {
+		return ColumnEq{}, fmt.Errorf("--column-eq entry %q is missing '='; expected column=value", entry)
+	}
+	col = strings.TrimSpace(col)
+	if col == "" {
+		return ColumnEq{}, fmt.Errorf("--column-eq entry %q has empty column name", entry)
+	}
+	if !isSafeColumnName(col) {
+		return ColumnEq{}, fmt.Errorf("--column-eq column name %q must match [A-Za-z0-9_]+", col)
+	}
+	eq := ColumnEq{Column: col, Value: val}
+	if val == "NULL" {
+		eq.IsNull = true
+	}
+	return eq, nil
+}
+
+// ParseColumnEqs parses multiple entries; returns the first parse error.
+func ParseColumnEqs(entries []string) ([]ColumnEq, error) {
+	if len(entries) == 0 {
+		return nil, nil
+	}
+	out := make([]ColumnEq, 0, len(entries))
+	for _, e := range entries {
+		eq, err := ParseColumnEq(e)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, eq)
+	}
+	return out, nil
+}
+
+func isSafeColumnName(col string) bool {
+	if col == "" {
+		return false
+	}
+	for _, r := range col {
+		switch {
+		case r == '_':
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/internal/query/columneq_test.go
+++ b/internal/query/columneq_test.go
@@ -193,6 +193,38 @@ func TestBuildQuery_columnEq_unsafeColumnEmitsNoMatch(t *testing.T) {
 	}
 }
 
+func TestBuildQuery_columnEq_unsafeEntryDoesNotPoisonOthers(t *testing.T) {
+	// A rejected entry must not drop trailing safe filters. Pins the `continue`
+	// semantics in buildQuery — swapping it for `return` or `break` would
+	// silently scoop rows the safe filter was meant to exclude.
+	opts := Options{
+		Schema: "db",
+		Table:  "t",
+		ColumnEq: []ColumnEq{
+			{Column: "evil'); DROP--", Value: "x"},
+			{Column: "status", Value: "active"},
+		},
+		Limit: 10,
+	}
+	q, args := buildQuery(opts)
+
+	if !strings.Contains(q, "1=0") {
+		t.Errorf("expected unsafe entry to emit 1=0: %s", q)
+	}
+	if !strings.Contains(q, "JSON_UNQUOTE(JSON_EXTRACT(row_after, '$.status'))") {
+		t.Errorf("safe trailing entry was dropped: %s", q)
+	}
+	count := 0
+	for _, a := range args {
+		if s, ok := a.(string); ok && s == "active" {
+			count++
+		}
+	}
+	if count != 2 {
+		t.Errorf("expected safe value bound twice, got %d (args=%v)", count, args)
+	}
+}
+
 func TestBuildQuery_columnEq_nullSentinel(t *testing.T) {
 	opts := Options{
 		Schema:   "db",

--- a/internal/query/columneq_test.go
+++ b/internal/query/columneq_test.go
@@ -1,0 +1,188 @@
+package query
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseColumnEq_plainValue(t *testing.T) {
+	eq, err := ParseColumnEq("status=active")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if eq.Column != "status" || eq.Value != "active" || eq.IsNull {
+		t.Errorf("got %+v, want {status active false}", eq)
+	}
+}
+
+func TestParseColumnEq_valueContainsEquals(t *testing.T) {
+	// Must split on the FIRST '=' only, so JSON-ish values are preserved.
+	eq, err := ParseColumnEq(`payload={"k":"v=v"}`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if eq.Column != "payload" {
+		t.Errorf("column: got %q, want payload", eq.Column)
+	}
+	if eq.Value != `{"k":"v=v"}` {
+		t.Errorf("value: got %q", eq.Value)
+	}
+}
+
+func TestParseColumnEq_nullSentinel(t *testing.T) {
+	eq, err := ParseColumnEq("deleted_at=NULL")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !eq.IsNull {
+		t.Error("expected IsNull=true for literal NULL")
+	}
+}
+
+func TestParseColumnEq_quotedNullIsNotSentinel(t *testing.T) {
+	// Only the bare four-character NULL triggers the sentinel.
+	eq, err := ParseColumnEq(`label="NULL"`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if eq.IsNull {
+		t.Error(`"NULL" (quoted) must not set IsNull`)
+	}
+	if eq.Value != `"NULL"` {
+		t.Errorf("value: got %q", eq.Value)
+	}
+}
+
+func TestParseColumnEq_missingEquals(t *testing.T) {
+	_, err := ParseColumnEq("status")
+	if err == nil {
+		t.Fatal("expected error for entry without '='")
+	}
+	if !strings.Contains(err.Error(), "missing '='") {
+		t.Errorf("error message: %v", err)
+	}
+}
+
+func TestParseColumnEq_emptyColumn(t *testing.T) {
+	_, err := ParseColumnEq("=value")
+	if err == nil {
+		t.Fatal("expected error for empty column name")
+	}
+}
+
+func TestParseColumnEq_unsafeColumn(t *testing.T) {
+	cases := []string{
+		"col'; DROP TABLE t; --=x",
+		`col\=x`,
+		"col.name=x", // dots disallowed — keeps path interpolation safe
+		"col name=x", // spaces disallowed
+	}
+	for _, c := range cases {
+		if _, err := ParseColumnEq(c); err == nil {
+			t.Errorf("expected error for %q", c)
+		}
+	}
+}
+
+func TestParseColumnEqs_firstErrorWins(t *testing.T) {
+	_, err := ParseColumnEqs([]string{"ok=1", "bad"})
+	if err == nil {
+		t.Fatal("expected error from second entry")
+	}
+}
+
+func TestParseColumnEqs_emptyReturnsNil(t *testing.T) {
+	out, err := ParseColumnEqs(nil)
+	if err != nil || out != nil {
+		t.Errorf("expected (nil, nil), got (%v, %v)", out, err)
+	}
+}
+
+func TestBuildQuery_columnEq_singleEntry(t *testing.T) {
+	opts := Options{
+		Schema:   "db",
+		Table:    "t",
+		ColumnEq: []ColumnEq{{Column: "status", Value: "active"}},
+		Limit:    10,
+	}
+	q, args := buildQuery(opts)
+
+	if !strings.Contains(q, "JSON_UNQUOTE(JSON_EXTRACT(row_after, '$.status'))") {
+		t.Errorf("missing row_after clause: %s", q)
+	}
+	if !strings.Contains(q, "JSON_UNQUOTE(JSON_EXTRACT(row_before, '$.status'))") {
+		t.Errorf("missing row_before clause: %s", q)
+	}
+	// The two halves must be joined by OR inside a single parenthesised group,
+	// so the clause doesn't AND with the wrong neighbour after a later filter.
+	if !strings.Contains(q, "= ? OR JSON_UNQUOTE") {
+		t.Errorf("missing OR connector: %s", q)
+	}
+	// Value must appear twice (once per side).
+	count := 0
+	for _, a := range args {
+		if s, ok := a.(string); ok && s == "active" {
+			count++
+		}
+	}
+	if count != 2 {
+		t.Errorf("expected value bound twice, got %d (args=%v)", count, args)
+	}
+}
+
+func TestBuildQuery_columnEq_multipleEntriesAND(t *testing.T) {
+	opts := Options{
+		Schema: "db",
+		Table:  "t",
+		ColumnEq: []ColumnEq{
+			{Column: "status", Value: "active"},
+			{Column: "order_id", Value: "7"},
+		},
+		Limit: 10,
+	}
+	q, args := buildQuery(opts)
+
+	if !strings.Contains(q, "'$.status'") {
+		t.Errorf("missing status path: %s", q)
+	}
+	if !strings.Contains(q, "'$.order_id'") {
+		t.Errorf("missing order_id path: %s", q)
+	}
+	// Outer join uses AND (strings.Join(where, " AND ")).
+	if strings.Count(q, " AND ") < 1 {
+		t.Errorf("expected multiple clauses joined by AND: %s", q)
+	}
+	// Two entries × 2 bound args each = 4 value slots, plus schema + table.
+	values := 0
+	for _, a := range args {
+		if s, ok := a.(string); ok && (s == "active" || s == "7") {
+			values++
+		}
+	}
+	if values != 4 {
+		t.Errorf("expected 4 value bindings, got %d (args=%v)", values, args)
+	}
+}
+
+func TestBuildQuery_columnEq_nullSentinel(t *testing.T) {
+	opts := Options{
+		Schema:   "db",
+		Table:    "t",
+		ColumnEq: []ColumnEq{{Column: "deleted_at", IsNull: true}},
+		Limit:    10,
+	}
+	q, args := buildQuery(opts)
+
+	if !strings.Contains(q, "JSON_TYPE(JSON_EXTRACT(row_after, '$.deleted_at')) = 'NULL'") {
+		t.Errorf("missing row_after null check: %s", q)
+	}
+	if !strings.Contains(q, "JSON_TYPE(JSON_EXTRACT(row_before, '$.deleted_at')) = 'NULL'") {
+		t.Errorf("missing row_before null check: %s", q)
+	}
+	// No positional arg for the null branch.
+	for _, a := range args {
+		if s, ok := a.(string); ok && s == "NULL" {
+			t.Errorf("null sentinel must not bind the literal string: %v", args)
+		}
+	}
+}

--- a/internal/query/columneq_test.go
+++ b/internal/query/columneq_test.go
@@ -37,6 +37,11 @@ func TestParseColumnEq_nullSentinel(t *testing.T) {
 	if !eq.IsNull {
 		t.Error("expected IsNull=true for literal NULL")
 	}
+	// Value must be cleared so a future caller that forgets to check IsNull
+	// cannot bind the literal string "NULL".
+	if eq.Value != "" {
+		t.Errorf("expected Value cleared, got %q", eq.Value)
+	}
 }
 
 func TestParseColumnEq_quotedNullIsNotSentinel(t *testing.T) {
@@ -161,6 +166,30 @@ func TestBuildQuery_columnEq_multipleEntriesAND(t *testing.T) {
 	}
 	if values != 4 {
 		t.Errorf("expected 4 value bindings, got %d (args=%v)", values, args)
+	}
+}
+
+func TestBuildQuery_columnEq_unsafeColumnEmitsNoMatch(t *testing.T) {
+	// A hand-built ColumnEq that bypassed ParseColumnEq must not reach the
+	// SQL string. The builder degrades to a no-match clause instead.
+	opts := Options{
+		Schema:   "db",
+		Table:    "t",
+		ColumnEq: []ColumnEq{{Column: "evil'); DROP--", Value: "x"}},
+		Limit:    10,
+	}
+	q, args := buildQuery(opts)
+
+	if !strings.Contains(q, "1=0") {
+		t.Errorf("expected no-match clause '1=0', got: %s", q)
+	}
+	if strings.Contains(q, "evil") {
+		t.Errorf("unsafe column name leaked into SQL: %s", q)
+	}
+	for _, a := range args {
+		if s, ok := a.(string); ok && s == "x" {
+			t.Errorf("unsafe entry's value bound: %v", args)
+		}
 	}
 }
 

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -113,8 +113,9 @@ type Options struct {
 	Since         *time.Time
 	Until         *time.Time
 	ChangedColumn string // column name; matched via JSON_CONTAINS
-	Flag          string // return events from tables/columns carrying this flag
-	Limit         int    // 0 → default 100
+	ColumnEq      []ColumnEq // match against values inside row_after / row_before
+	Flag          string     // return events from tables/columns carrying this flag
+	Limit         int        // 0 → default 100
 
 	DenyTables    []SchemaTable       // tables excluded by RBAC profile
 	RedactColumns []SchemaTableColumn // column values nulled out by RBAC profile
@@ -249,6 +250,25 @@ func buildQuery(opts Options) (string, []any) {
 		needle, _ := json.Marshal(opts.ChangedColumn)
 		where = append(where, "JSON_CONTAINS(changed_columns, ?)")
 		args = append(args, string(needle))
+	}
+	for _, ce := range opts.ColumnEq {
+		// Column name is allowlisted by ParseColumnEq to [A-Za-z0-9_], so
+		// interpolating it into the JSON path literal is safe. MySQL does not
+		// accept bind parameters for JSON paths, so the column name MUST be
+		// embedded in the SQL string.
+		path := "$." + ce.Column
+		if ce.IsNull {
+			where = append(where, fmt.Sprintf(
+				"(JSON_TYPE(JSON_EXTRACT(row_after, '%s')) = 'NULL' "+
+					"OR JSON_TYPE(JSON_EXTRACT(row_before, '%s')) = 'NULL')",
+				path, path))
+			continue
+		}
+		where = append(where, fmt.Sprintf(
+			"(JSON_UNQUOTE(JSON_EXTRACT(row_after, '%s')) = ? "+
+				"OR JSON_UNQUOTE(JSON_EXTRACT(row_before, '%s')) = ?)",
+			path, path))
+		args = append(args, ce.Value, ce.Value)
 	}
 	if opts.Flag != "" {
 		// EXISTS subquery: match events from tables (or columns) carrying the

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -252,10 +253,20 @@ func buildQuery(opts Options) (string, []any) {
 		args = append(args, string(needle))
 	}
 	for _, ce := range opts.ColumnEq {
-		// Column name is allowlisted by ParseColumnEq to [A-Za-z0-9_], so
-		// interpolating it into the JSON path literal is safe. MySQL does not
-		// accept bind parameters for JSON paths, so the column name MUST be
-		// embedded in the SQL string.
+		// Defense-in-depth: ParseColumnEq is the canonical entry, but
+		// Options.ColumnEq is exported and crosses package/process boundaries
+		// (CLI, MCP, library callers). MySQL does not accept bind parameters
+		// for JSON paths, so the column name MUST be interpolated into the SQL
+		// string — re-validate here so a hand-built ColumnEq cannot reach the
+		// concatenation. On failure, emit "1=0" so the result set is provably
+		// empty rather than silently broader (a dropped filter would scoop
+		// rows the operator never asked for).
+		if !IsSafeColumnName(ce.Column) {
+			slog.Error("query.buildQuery: rejected unsafe column name in ColumnEq filter; emitting no-match clause",
+				"column", ce.Column)
+			where = append(where, "1=0")
+			continue
+		}
 		path := "$." + ce.Column
 		if ce.IsNull {
 			where = append(where, fmt.Sprintf(

--- a/internal/query/query_integration_test.go
+++ b/internal/query/query_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dbtrail/bintrail/internal/indexer"
 	"github.com/dbtrail/bintrail/internal/parser"
 	"github.com/dbtrail/bintrail/internal/testutil"
 )
@@ -145,6 +146,88 @@ func TestFetch_changedColumnFilter(t *testing.T) {
 	if len(rows) != 1 {
 		t.Errorf("expected 1 row for changed_column=status, got %d", len(rows))
 	}
+}
+
+func TestFetch_columnEqFilter(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	// InitIndexTables creates the original schema; apply the later ALTERs so
+	// the SELECT list (which includes connection_id) resolves.
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	ts := "2026-02-19 14:00:00"
+	// Event 1: INSERT with status=active in row_after.
+	testutil.InsertEvent(t, db, "binlog.000001", 100, 200, ts, nil, "mydb", "orders", 1, "1",
+		nil, nil, []byte(`{"id":1,"status":"active","order_id":7}`))
+	// Event 2: DELETE with status=active only in row_before.
+	testutil.InsertEvent(t, db, "binlog.000001", 200, 300, ts, nil, "mydb", "orders", 3, "2",
+		nil, []byte(`{"id":2,"status":"active","order_id":8}`), nil)
+	// Event 3: INSERT with status=closed.
+	testutil.InsertEvent(t, db, "binlog.000001", 300, 400, ts, nil, "mydb", "orders", 1, "3",
+		nil, nil, []byte(`{"id":3,"status":"closed","order_id":7}`))
+	// Event 4: UPDATE with nullable_col=null in row_after.
+	testutil.InsertEvent(t, db, "binlog.000001", 400, 500, ts, nil, "mydb", "orders", 2, "4",
+		[]byte(`["nullable_col"]`),
+		[]byte(`{"id":4,"nullable_col":"was"}`),
+		[]byte(`{"id":4,"nullable_col":null}`))
+
+	e := New(db)
+
+	// Plain match: status=active hits the INSERT (row_after) and DELETE (row_before).
+	t.Run("insertAndDelete", func(t *testing.T) {
+		rows, err := e.Fetch(context.Background(), Options{
+			Schema: "mydb", Table: "orders",
+			ColumnEq: []ColumnEq{{Column: "status", Value: "active"}},
+			Limit:    100,
+		})
+		if err != nil {
+			t.Fatalf("Fetch: %v", err)
+		}
+		if len(rows) != 2 {
+			t.Fatalf("expected 2 rows for status=active, got %d", len(rows))
+		}
+	})
+
+	// AND composition: status=active AND order_id=7 → only the INSERT.
+	t.Run("andComposition", func(t *testing.T) {
+		rows, err := e.Fetch(context.Background(), Options{
+			Schema: "mydb", Table: "orders",
+			ColumnEq: []ColumnEq{
+				{Column: "status", Value: "active"},
+				{Column: "order_id", Value: "7"},
+			},
+			Limit: 100,
+		})
+		if err != nil {
+			t.Fatalf("Fetch: %v", err)
+		}
+		if len(rows) != 1 {
+			t.Fatalf("expected 1 row for status=active AND order_id=7, got %d", len(rows))
+		}
+		if rows[0].PKValues != "1" {
+			t.Errorf("expected pk=1, got %q", rows[0].PKValues)
+		}
+	})
+
+	// NULL sentinel: nullable_col=NULL hits the UPDATE where row_after has JSON null.
+	t.Run("nullSentinel", func(t *testing.T) {
+		rows, err := e.Fetch(context.Background(), Options{
+			Schema: "mydb", Table: "orders",
+			ColumnEq: []ColumnEq{{Column: "nullable_col", IsNull: true}},
+			Limit:    100,
+		})
+		if err != nil {
+			t.Fatalf("Fetch: %v", err)
+		}
+		if len(rows) != 1 {
+			t.Fatalf("expected 1 row for nullable_col=NULL, got %d", len(rows))
+		}
+		if rows[0].PKValues != "4" {
+			t.Errorf("expected pk=4, got %q", rows[0].PKValues)
+		}
+	})
 }
 
 func TestRun_jsonFormat(t *testing.T) {


### PR DESCRIPTION
Closes #229.

## Summary

- New repeatable flag `--column-eq column=value` on `bintrail query` and `bintrail recover`. Each entry matches events where the column inside `row_after` **or** `row_before` equals the value. Repetition composes AND. The OR across both sides covers DELETEs (value lives in `row_before`) and INSERTs (value lives in `row_after`) symmetrically — needed by the SaaS for FK-cascade victim reconstruction on MySQL 8.x.
- The literal unquoted `NULL` sentinel matches rows where the column is explicitly JSON null via `JSON_TYPE(...) = 'NULL'`. To match the literal four-character string `"NULL"`, quote it: `--column-eq label='"NULL"'`.
- The same predicate is mirrored into the DuckDB archive path (`json_extract_string` / `json_type`) so merged live + archive results stay consistent. (The issue listed the archive path as out-of-scope, but `internal/parquetquery` already mirrors the existing `--changed-column` filter; mirroring `--column-eq` too is ~10 LOC and avoids a silent correctness gap on merged queries.)
- MCP `query` and `recover` tools accept a matching `column_eq: [string]` parameter.
- New env binding `BINTRAIL_COLUMN_EQ` (added to the `Filters` section of the env template).
- CLI flag uses `StringArrayVar` (not `StringSliceVar`) so JSON values containing `,` survive intact.

## Safety / no-regression

- `query.Options.ColumnEq` is a new field; every existing `query.Options{...}` literal in the codebase uses field-name initialization, so adding a field is source-compatible. Zero-value (`nil` slice) means the new clause is omitted from `buildQuery` byte-for-byte — existing queries are unchanged.
- Column names are allowlisted to `[A-Za-z0-9_]` because they must be interpolated into the JSON path literal (MySQL doesn't bind paths). Anything else fails at parse time.
- Full unit suite (`go test ./...`) is green. Existing `TestBuildQuery_*`, `TestRunQuery_*`, `TestRunRecover_*`, and `TestBuildQueryOptions_*` remain unmodified and passing.

## Tests

- `internal/query/columneq_test.go` — parser unit tests (plain value, value with `=`, NULL sentinel vs quoted "NULL", missing `=`, empty/unsafe column names) plus `buildQuery` SQL-shape tests for single entry, multi-entry AND, and NULL branch.
- `internal/parquetquery/parquetquery_test.go` — `TestBuildQueryColumnEq` and `TestBuildQueryColumnEq_nullSentinel` mirror the same shapes for DuckDB.
- `internal/query/query_integration_test.go` — `TestFetch_columnEqFilter` against Docker MySQL: matches INSERT via `row_after`, DELETE via `row_before`, AND composition (`status=active AND order_id=7`), and the JSON-null sentinel.
- `cmd/bintrail/query_test.go` and `recover_test.go` — validation tests for `--schema`+`--table` requirement and malformed entries.
- `cmd/bintrail-mcp/main_test.go` — `buildQueryOptions` pass-through, schema/table requirement, and malformed-entry surfacing.

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -count=1` (all packages green)
- [x] `go test -tags integration ./internal/query/... -run TestFetch_columnEqFilter -v`
- [x] `go test -tags integration ./internal/parquetquery/... -run TestBuildQueryColumnEq -v`
- [ ] Manual smoke: `bintrail query --schema mydb --table orders --column-eq status=active --column-eq order_id=7`
- [ ] Manual smoke via MCP: invoke `query` tool with `column_eq: ["status=active"]`
