### PR TITLE
query/recover: add --pks for batched multi-PK lookups

### DIFF
--- a/cmd/bintrail/query.go
+++ b/cmd/bintrail/query.go
@@ -111,6 +111,11 @@ func runQuery(cmd *cobra.Command, args []string) error {
 	if qPK != "" && len(qPKs) > 0 {
 		return fmt.Errorf("--pk and --pks are mutually exclusive; use one or the other")
 	}
+	cleanedPKs, err := cleanPKList(qPKs)
+	if err != nil {
+		return err
+	}
+	qPKs = cleanedPKs
 	if qLimitPerPK < 0 {
 		return fmt.Errorf("--limit-per-pk must be >= 0")
 	}
@@ -279,10 +284,7 @@ func runQuery(cmd *cobra.Command, args []string) error {
 		results = append(results, archResults...)
 	}
 
-	results = query.MergeResults(results, opts.Limit)
-	if opts.LimitPerPK > 0 {
-		results = query.LimitPerPK(results, opts.LimitPerPK)
-	}
+	results = query.MergeAndTrim(results, opts.Limit, opts.LimitPerPK)
 
 	var n int
 	if groupedJSON {
@@ -534,6 +536,37 @@ func eventTypeJSONName(t parser.EventType) string {
 	default:
 		return "UNKNOWN"
 	}
+}
+
+// cleanPKList normalizes the values collected from a --pks StringSliceVar flag:
+// trims surrounding whitespace, rejects empty entries, and deduplicates while
+// preserving input order. Duplicates are common when callers programmatically
+// compose the list (e.g. dbtrail SaaS batching N pending PKs with repeats from
+// retries); an unfiltered list would produce duplicate groups in grouped JSON
+// output and waste bind-parameter slots in the SQL IN clause.
+//
+// Returns an error on empty entries rather than silently dropping them — a
+// --pks=,, invocation almost certainly indicates a shell interpolation bug,
+// and silently treating it as --pks with zero values would return "0 rows"
+// success output for a broken command.
+func cleanPKList(pks []string) ([]string, error) {
+	if len(pks) == 0 {
+		return nil, nil
+	}
+	seen := make(map[string]struct{}, len(pks))
+	out := make([]string, 0, len(pks))
+	for _, pk := range pks {
+		trimmed := strings.TrimSpace(pk)
+		if trimmed == "" {
+			return nil, fmt.Errorf("--pks: empty or whitespace-only PK value (after comma-split); check for stray commas")
+		}
+		if _, dup := seen[trimmed]; dup {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		out = append(out, trimmed)
+	}
+	return out, nil
 }
 
 // archiveSources returns the Hive-scoped archive source paths for the current

--- a/cmd/bintrail/query.go
+++ b/cmd/bintrail/query.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -18,6 +19,7 @@ import (
 	"github.com/dbtrail/bintrail/internal/config"
 	"github.com/dbtrail/bintrail/internal/indexer"
 	"github.com/dbtrail/bintrail/internal/parquetquery"
+	"github.com/dbtrail/bintrail/internal/parser"
 	"github.com/dbtrail/bintrail/internal/query"
 )
 
@@ -48,24 +50,26 @@ Examples:
 }
 
 var (
-	qIndexDSN   string
-	qSchema     string
-	qTable      string
-	qPK         string
-	qEventType  string
-	qGTID       string
-	qSince      string
-	qUntil      string
-	qChangedCol string
-	qColumnEq   []string
-	qFlag       string
-	qFormat     string
-	qLimit      int
-	qArchiveDir string
-	qArchiveS3  string
-	qBintrailID string
-	qProfile    string
-	qNoArchive  bool
+	qIndexDSN    string
+	qSchema      string
+	qTable       string
+	qPK          string
+	qPKs         []string
+	qLimitPerPK  int
+	qEventType   string
+	qGTID        string
+	qSince       string
+	qUntil       string
+	qChangedCol  string
+	qColumnEq    []string
+	qFlag        string
+	qFormat      string
+	qLimit       int
+	qArchiveDir  string
+	qArchiveS3   string
+	qBintrailID  string
+	qProfile     string
+	qNoArchive   bool
 )
 
 func init() {
@@ -73,6 +77,8 @@ func init() {
 	queryCmd.Flags().StringVar(&qSchema, "schema", "", "Filter by schema name")
 	queryCmd.Flags().StringVar(&qTable, "table", "", "Filter by table name")
 	queryCmd.Flags().StringVar(&qPK, "pk", "", "Filter by primary key value(s), pipe-delimited for composite PKs")
+	queryCmd.Flags().StringSliceVar(&qPKs, "pks", nil, "Filter by multiple primary key values (comma-separated, or repeat the flag); requires --schema and --table; mutually exclusive with --pk")
+	queryCmd.Flags().IntVar(&qLimitPerPK, "limit-per-pk", 0, "Cap returned events per pk_values to the latest N (0 = unlimited); requires --pk or --pks")
 	queryCmd.Flags().StringVar(&qEventType, "event-type", "", "Filter by event type: INSERT, UPDATE, or DELETE")
 	queryCmd.Flags().StringVar(&qGTID, "gtid", "", "Filter by GTID (e.g. uuid:42)")
 	queryCmd.Flags().StringVar(&qSince, "since", "", "Filter events at or after this time (2006-01-02 15:04:05)")
@@ -98,6 +104,18 @@ func runQuery(cmd *cobra.Command, args []string) error {
 	// ── Validate flag combinations ────────────────────────────────────────────
 	if qPK != "" && (qSchema == "" || qTable == "") {
 		return fmt.Errorf("--pk requires both --schema and --table")
+	}
+	if len(qPKs) > 0 && (qSchema == "" || qTable == "") {
+		return fmt.Errorf("--pks requires both --schema and --table")
+	}
+	if qPK != "" && len(qPKs) > 0 {
+		return fmt.Errorf("--pk and --pks are mutually exclusive; use one or the other")
+	}
+	if qLimitPerPK < 0 {
+		return fmt.Errorf("--limit-per-pk must be >= 0")
+	}
+	if qLimitPerPK > 0 && qPK == "" && len(qPKs) == 0 {
+		return fmt.Errorf("--limit-per-pk requires --pk or --pks")
 	}
 	if qChangedCol != "" && (qSchema == "" || qTable == "") {
 		return fmt.Errorf("--changed-column requires both --schema and --table")
@@ -140,6 +158,7 @@ func runQuery(cmd *cobra.Command, args []string) error {
 		Schema:        qSchema,
 		Table:         qTable,
 		PKValues:      qPK,
+		PKValuesIn:    qPKs,
 		EventType:     eventType,
 		GTID:          qGTID,
 		Since:         since,
@@ -148,6 +167,7 @@ func runQuery(cmd *cobra.Command, args []string) error {
 		ColumnEq:      columnEq,
 		Flag:          qFlag,
 		Limit:         qLimit,
+		LimitPerPK:    qLimitPerPK,
 	}
 
 	// ── Connect and fetch from the index ─────────────────────────────────────
@@ -196,8 +216,11 @@ func runQuery(cmd *cobra.Command, args []string) error {
 	}
 
 	// When no archive sources are configured, take the fast path (fetch + format
-	// in one step, same as before this feature was added).
-	if len(archSources) == 0 {
+	// in one step, same as before this feature was added). The grouped JSON
+	// output for --pks needs a separate formatting step, so fall through to
+	// the merge path when it's active.
+	groupedJSON := len(qPKs) > 0 && qFormat == "json"
+	if len(archSources) == 0 && !groupedJSON {
 		n, err := engine.Run(cmd.Context(), opts, qFormat, os.Stdout)
 		if err != nil {
 			return err
@@ -242,21 +265,31 @@ func runQuery(cmd *cobra.Command, args []string) error {
 	// partial rows on timeout), it belongs here at the call site, not inside
 	// the helper. The helper's doc comment documents its own half of this
 	// contract.
-	archResults, err := queryArchiveSources(
-		cmd.Context(),
-		archSources,
-		fetchOpts,
-		parquetquery.Fetch,
-		os.Stderr,
-	)
-	if err != nil {
-		return err
+	if len(archSources) > 0 {
+		archResults, err := queryArchiveSources(
+			cmd.Context(),
+			archSources,
+			fetchOpts,
+			parquetquery.Fetch,
+			os.Stderr,
+		)
+		if err != nil {
+			return err
+		}
+		results = append(results, archResults...)
 	}
-	results = append(results, archResults...)
 
 	results = query.MergeResults(results, opts.Limit)
+	if opts.LimitPerPK > 0 {
+		results = query.LimitPerPK(results, opts.LimitPerPK)
+	}
 
-	n, err := query.Format(results, qFormat, os.Stdout)
+	var n int
+	if groupedJSON {
+		n, err = writeGroupedJSON(qPKs, results, os.Stdout)
+	} else {
+		n, err = query.Format(results, qFormat, os.Stdout)
+	}
 	if err != nil {
 		return err
 	}
@@ -414,6 +447,93 @@ var lineBreakReplacer = strings.NewReplacer(
 // independently of the archive fetch loop.
 func sanitizeArchiveErrorMessage(err error) string {
 	return lineBreakReplacer.Replace(err.Error())
+}
+
+// writeGroupedJSON renders results as a JSON object grouping events by their
+// pk_values, in the order requested via --pks. PKs with no matching events
+// appear as empty groups so callers can correlate inputs to outputs without a
+// separate lookup. Returns the total number of events written across all
+// groups (matching the row-count semantic of query.Format for the truncation
+// warning at the call site).
+func writeGroupedJSON(pks []string, rows []query.ResultRow, w io.Writer) (int, error) {
+	type groupedEvent struct {
+		EventID        uint64         `json:"event_id"`
+		BinlogFile     string         `json:"binlog_file"`
+		StartPos       uint64         `json:"start_pos"`
+		EndPos         uint64         `json:"end_pos"`
+		EventTimestamp string         `json:"event_timestamp"`
+		GTID           *string        `json:"gtid"`
+		ConnectionID   *uint32        `json:"connection_id"`
+		SchemaName     string         `json:"schema_name"`
+		TableName      string         `json:"table_name"`
+		EventType      string         `json:"event_type"`
+		PKValues       string         `json:"pk_values"`
+		ChangedColumns []string       `json:"changed_columns"`
+		RowBefore      map[string]any `json:"row_before"`
+		RowAfter       map[string]any `json:"row_after"`
+	}
+	type group struct {
+		PK     string         `json:"pk"`
+		Events []groupedEvent `json:"events"`
+	}
+	type out struct {
+		Results []group `json:"results"`
+	}
+
+	byPK := make(map[string][]groupedEvent, len(pks))
+	for _, r := range rows {
+		ev := groupedEvent{
+			EventID:        r.EventID,
+			BinlogFile:     r.BinlogFile,
+			StartPos:       r.StartPos,
+			EndPos:         r.EndPos,
+			EventTimestamp: r.EventTimestamp.Format("2006-01-02 15:04:05"),
+			GTID:           r.GTID,
+			ConnectionID:   r.ConnectionID,
+			SchemaName:     r.SchemaName,
+			TableName:      r.TableName,
+			EventType:      eventTypeJSONName(r.EventType),
+			PKValues:       r.PKValues,
+			ChangedColumns: r.ChangedColumns,
+			RowBefore:      r.RowBefore,
+			RowAfter:       r.RowAfter,
+		}
+		byPK[r.PKValues] = append(byPK[r.PKValues], ev)
+	}
+
+	groups := make([]group, 0, len(pks))
+	total := 0
+	for _, pk := range pks {
+		evs := byPK[pk]
+		if evs == nil {
+			evs = []groupedEvent{}
+		}
+		groups = append(groups, group{PK: pk, Events: evs})
+		total += len(evs)
+	}
+
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(out{Results: groups}); err != nil {
+		return 0, fmt.Errorf("JSON encode failed: %w", err)
+	}
+	return total, nil
+}
+
+// eventTypeJSONName mirrors internal/query.eventTypeName (unexported) so the
+// grouped JSON output uses the same INSERT/UPDATE/DELETE strings as the flat
+// JSON formatter.
+func eventTypeJSONName(t parser.EventType) string {
+	switch t {
+	case parser.EventInsert:
+		return "INSERT"
+	case parser.EventUpdate:
+		return "UPDATE"
+	case parser.EventDelete:
+		return "DELETE"
+	default:
+		return "UNKNOWN"
+	}
 }
 
 // archiveSources returns the Hive-scoped archive source paths for the current

--- a/cmd/bintrail/query_test.go
+++ b/cmd/bintrail/query_test.go
@@ -1290,6 +1290,57 @@ func TestSanitizeArchiveErrorMessage(t *testing.T) {
 	}
 }
 
+// ─── cleanPKList ─────────────────────────────────────────────────────────────
+
+func TestCleanPKList_dedupAndTrim(t *testing.T) {
+	got, err := cleanPKList([]string{"1", " 2 ", "1", "3", "2"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"1", "2", "3"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+	for i, v := range want {
+		if got[i] != v {
+			t.Errorf("index %d: want %q got %q", i, v, got[i])
+		}
+	}
+}
+
+func TestCleanPKList_rejectsEmpty(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   []string
+	}{
+		{"empty string", []string{""}},
+		{"whitespace only", []string{"   "}},
+		{"empty in middle", []string{"1", "", "2"}},
+		{"trailing comma artifact", []string{"1", "2", ""}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := cleanPKList(tc.in)
+			if err == nil {
+				t.Fatalf("expected error for input %v", tc.in)
+			}
+			if !strings.Contains(err.Error(), "--pks") {
+				t.Errorf("expected error to mention --pks, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestCleanPKList_nilAndEmpty(t *testing.T) {
+	got, err := cleanPKList(nil)
+	if err != nil || got != nil {
+		t.Errorf("expected (nil, nil) for nil input, got (%v, %v)", got, err)
+	}
+	got, err = cleanPKList([]string{})
+	if err != nil || len(got) != 0 {
+		t.Errorf("expected empty result for empty input, got (%v, %v)", got, err)
+	}
+}
+
 // ─── writeGroupedJSON ────────────────────────────────────────────────────────
 
 func TestWriteGroupedJSON_preservesInputOrderAndEmits_emptyGroups(t *testing.T) {

--- a/cmd/bintrail/query_test.go
+++ b/cmd/bintrail/query_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"go/ast"
@@ -15,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	binparser "github.com/dbtrail/bintrail/internal/parser"
 	"github.com/dbtrail/bintrail/internal/query"
 )
 
@@ -80,13 +82,65 @@ func TestQueryCmd_emptyStringDefaults(t *testing.T) {
 
 func TestQueryCmd_allFlagsRegistered(t *testing.T) {
 	for _, name := range []string{
-		"index-dsn", "schema", "table", "pk", "event-type",
+		"index-dsn", "schema", "table", "pk", "pks", "limit-per-pk", "event-type",
 		"gtid", "since", "until", "changed-column", "flag", "format", "limit",
 		"no-archive",
 	} {
 		if queryCmd.Flag(name) == nil {
 			t.Errorf("flag --%s not registered on queryCmd", name)
 		}
+	}
+}
+
+func TestRunQuery_pksRequiresSchemaTable(t *testing.T) {
+	saved, savedS, savedT := qPKs, qSchema, qTable
+	t.Cleanup(func() { qPKs = saved; qSchema = savedS; qTable = savedT })
+
+	qPKs = []string{"1", "2"}
+	qSchema = ""
+	qTable = ""
+
+	err := runQuery(queryCmd, nil)
+	if err == nil {
+		t.Fatal("expected error when --pks used without --schema/--table")
+	}
+	if !strings.Contains(err.Error(), "--pks requires") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestRunQuery_pkAndPksMutuallyExclusive(t *testing.T) {
+	savedPK, savedPKs, savedS, savedT := qPK, qPKs, qSchema, qTable
+	t.Cleanup(func() { qPK = savedPK; qPKs = savedPKs; qSchema = savedS; qTable = savedT })
+
+	qPK = "42"
+	qPKs = []string{"1", "2"}
+	qSchema = "db"
+	qTable = "t"
+
+	err := runQuery(queryCmd, nil)
+	if err == nil {
+		t.Fatal("expected error when both --pk and --pks are set")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestRunQuery_limitPerPKRequiresPK(t *testing.T) {
+	savedLPP, savedPK, savedPKs := qLimitPerPK, qPK, qPKs
+	t.Cleanup(func() { qLimitPerPK = savedLPP; qPK = savedPK; qPKs = savedPKs })
+
+	qLimitPerPK = 1
+	qPK = ""
+	qPKs = nil
+
+	err := runQuery(queryCmd, nil)
+	if err == nil {
+		t.Fatal("expected error when --limit-per-pk set without --pk/--pks")
+	}
+	if !strings.Contains(err.Error(), "--limit-per-pk requires") {
+		t.Errorf("unexpected error message: %v", err)
 	}
 }
 
@@ -1233,5 +1287,42 @@ func TestSanitizeArchiveErrorMessage(t *testing.T) {
 				t.Errorf("sanitizeArchiveErrorMessage(%q): got %q, want %q", tc.in, got, tc.want)
 			}
 		})
+	}
+}
+
+// ─── writeGroupedJSON ────────────────────────────────────────────────────────
+
+func TestWriteGroupedJSON_preservesInputOrderAndEmits_emptyGroups(t *testing.T) {
+	rows := []query.ResultRow{
+		{EventID: 1, SchemaName: "db", TableName: "t", PKValues: "b", EventType: binparser.EventDelete},
+		{EventID: 2, SchemaName: "db", TableName: "t", PKValues: "a", EventType: binparser.EventDelete},
+	}
+	var buf bytes.Buffer
+	n, err := writeGroupedJSON([]string{"a", "b", "c"}, rows, &buf)
+	if err != nil {
+		t.Fatalf("writeGroupedJSON: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("expected total=2 (one event per matched PK), got %d", n)
+	}
+
+	var got struct {
+		Results []struct {
+			PK     string           `json:"pk"`
+			Events []map[string]any `json:"events"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v\noutput: %s", err, buf.String())
+	}
+	if len(got.Results) != 3 {
+		t.Fatalf("expected 3 groups (one per input PK), got %d", len(got.Results))
+	}
+	// Input order preserved.
+	if got.Results[0].PK != "a" || got.Results[1].PK != "b" || got.Results[2].PK != "c" {
+		t.Errorf("group order mismatch: %v", []string{got.Results[0].PK, got.Results[1].PK, got.Results[2].PK})
+	}
+	if len(got.Results[2].Events) != 0 {
+		t.Errorf("expected empty events for PK with no matches, got %d", len(got.Results[2].Events))
 	}
 }

--- a/cmd/bintrail/recover.go
+++ b/cmd/bintrail/recover.go
@@ -51,22 +51,24 @@ Examples:
 }
 
 var (
-	rIndexDSN   string
-	rSchema     string
-	rTable      string
-	rPK         string
-	rEventType  string
-	rGTID       string
-	rSince      string
-	rUntil      string
-	rFlag       string
-	rOutput     string
-	rDryRun     bool
-	rLimit      int
-	rProfile    string
-	rFormat     string
-	rNoArchive  bool
-	rColumnEq   []string
+	rIndexDSN    string
+	rSchema      string
+	rTable       string
+	rPK          string
+	rPKs         []string
+	rLimitPerPK  int
+	rEventType   string
+	rGTID        string
+	rSince       string
+	rUntil       string
+	rFlag        string
+	rOutput      string
+	rDryRun      bool
+	rLimit       int
+	rProfile     string
+	rFormat      string
+	rNoArchive   bool
+	rColumnEq    []string
 )
 
 func init() {
@@ -74,6 +76,8 @@ func init() {
 	recoverCmd.Flags().StringVar(&rSchema, "schema", "", "Filter by schema name")
 	recoverCmd.Flags().StringVar(&rTable, "table", "", "Filter by table name")
 	recoverCmd.Flags().StringVar(&rPK, "pk", "", "Filter by primary key value(s), pipe-delimited for composite PKs")
+	recoverCmd.Flags().StringSliceVar(&rPKs, "pks", nil, "Filter by multiple primary key values (comma-separated, or repeat the flag); requires --schema and --table; mutually exclusive with --pk")
+	recoverCmd.Flags().IntVar(&rLimitPerPK, "limit-per-pk", 0, "Cap reversed events per pk_values to the latest N (0 = unlimited); requires --pk or --pks")
 	recoverCmd.Flags().StringVar(&rEventType, "event-type", "", "Filter by event type: INSERT, UPDATE, or DELETE")
 	recoverCmd.Flags().StringVar(&rGTID, "gtid", "", "Filter by GTID (e.g. uuid:42)")
 	recoverCmd.Flags().StringVar(&rSince, "since", "", "Filter events at or after this time (2006-01-02 15:04:05)")
@@ -104,6 +108,18 @@ func runRecover(cmd *cobra.Command, args []string) error {
 	if rPK != "" && (rSchema == "" || rTable == "") {
 		return fmt.Errorf("--pk requires both --schema and --table")
 	}
+	if len(rPKs) > 0 && (rSchema == "" || rTable == "") {
+		return fmt.Errorf("--pks requires both --schema and --table")
+	}
+	if rPK != "" && len(rPKs) > 0 {
+		return fmt.Errorf("--pk and --pks are mutually exclusive; use one or the other")
+	}
+	if rLimitPerPK < 0 {
+		return fmt.Errorf("--limit-per-pk must be >= 0")
+	}
+	if rLimitPerPK > 0 && rPK == "" && len(rPKs) == 0 {
+		return fmt.Errorf("--limit-per-pk requires --pk or --pks")
+	}
 	if len(rColumnEq) > 0 && (rSchema == "" || rTable == "") {
 		return fmt.Errorf("--column-eq requires both --schema and --table")
 	}
@@ -127,16 +143,18 @@ func runRecover(cmd *cobra.Command, args []string) error {
 	}
 
 	opts := query.Options{
-		Schema:    rSchema,
-		Table:     rTable,
-		PKValues:  rPK,
-		EventType: eventType,
-		GTID:      rGTID,
-		Since:     since,
-		Until:     until,
-		ColumnEq:  columnEq,
-		Flag:      rFlag,
-		Limit:     rLimit,
+		Schema:     rSchema,
+		Table:      rTable,
+		PKValues:   rPK,
+		PKValuesIn: rPKs,
+		EventType:  eventType,
+		GTID:       rGTID,
+		Since:      since,
+		Until:      until,
+		ColumnEq:   columnEq,
+		Flag:       rFlag,
+		Limit:      rLimit,
+		LimitPerPK: rLimitPerPK,
 	}
 
 	// ── Connect to index database ─────────────────────────────────────────────

--- a/cmd/bintrail/recover.go
+++ b/cmd/bintrail/recover.go
@@ -114,6 +114,11 @@ func runRecover(cmd *cobra.Command, args []string) error {
 	if rPK != "" && len(rPKs) > 0 {
 		return fmt.Errorf("--pk and --pks are mutually exclusive; use one or the other")
 	}
+	cleanedPKs, err := cleanPKList(rPKs)
+	if err != nil {
+		return err
+	}
+	rPKs = cleanedPKs
 	if rLimitPerPK < 0 {
 		return fmt.Errorf("--limit-per-pk must be >= 0")
 	}

--- a/cmd/bintrail/recover_test.go
+++ b/cmd/bintrail/recover_test.go
@@ -327,6 +327,72 @@ func TestRunRecover_pkWithBothSchemaAndTablePassesGuard(t *testing.T) {
 	}
 }
 
+func TestRunRecover_pksRequiresSchemaTable(t *testing.T) {
+	savedPKs, savedS, savedT, savedDry := rPKs, rSchema, rTable, rDryRun
+	t.Cleanup(func() { rPKs = savedPKs; rSchema = savedS; rTable = savedT; rDryRun = savedDry })
+
+	rDryRun = true
+	rPKs = []string{"1", "2"}
+	rSchema = ""
+	rTable = ""
+
+	err := runRecover(recoverCmd, nil)
+	if err == nil {
+		t.Fatal("expected error when --pks used without --schema/--table")
+	}
+	if !strings.Contains(err.Error(), "--pks requires") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestRunRecover_pkAndPksMutuallyExclusive(t *testing.T) {
+	savedPK, savedPKs, savedS, savedT, savedDry := rPK, rPKs, rSchema, rTable, rDryRun
+	t.Cleanup(func() {
+		rPK = savedPK
+		rPKs = savedPKs
+		rSchema = savedS
+		rTable = savedT
+		rDryRun = savedDry
+	})
+
+	rDryRun = true
+	rPK = "42"
+	rPKs = []string{"1", "2"}
+	rSchema = "db"
+	rTable = "t"
+
+	err := runRecover(recoverCmd, nil)
+	if err == nil {
+		t.Fatal("expected error when both --pk and --pks are set")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestRunRecover_limitPerPKRequiresPK(t *testing.T) {
+	savedLPP, savedPK, savedPKs, savedDry := rLimitPerPK, rPK, rPKs, rDryRun
+	t.Cleanup(func() {
+		rLimitPerPK = savedLPP
+		rPK = savedPK
+		rPKs = savedPKs
+		rDryRun = savedDry
+	})
+
+	rDryRun = true
+	rLimitPerPK = 1
+	rPK = ""
+	rPKs = nil
+
+	err := runRecover(recoverCmd, nil)
+	if err == nil {
+		t.Fatal("expected error when --limit-per-pk set without --pk/--pks")
+	}
+	if !strings.Contains(err.Error(), "--limit-per-pk requires") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
 // TestRunRecover_validEventTypes verifies that INSERT, UPDATE, and DELETE are
 // all accepted by ParseEventType and do not trigger the event-type error.
 func TestRunRecover_validEventTypes(t *testing.T) {

--- a/internal/parquetquery/parquetquery.go
+++ b/internal/parquetquery/parquetquery.go
@@ -503,6 +503,10 @@ func buildQueryFromFiles(files []string, opts query.Options) (string, []any) {
 	if len(where) > 0 {
 		q += " WHERE " + strings.Join(where, " AND ")
 	}
+	if qual, qArgs := limitPerPKClause(opts); qual != "" {
+		q += qual
+		args = append(args, qArgs...)
+	}
 	q += " ORDER BY event_timestamp, event_id"
 	if opts.Limit > 0 {
 		q += " LIMIT ?"
@@ -538,6 +542,10 @@ func buildUnsortedQuery(path string, opts query.Options) (string, []any) {
 	if len(where) > 0 {
 		q += " WHERE " + strings.Join(where, " AND ")
 	}
+	if qual, qArgs := limitPerPKClause(opts); qual != "" {
+		q += qual
+		args = append(args, qArgs...)
+	}
 
 	return q, args
 }
@@ -558,6 +566,10 @@ func buildQuery(glob string, opts query.Options) (string, []any) {
 	if len(where) > 0 {
 		q += " WHERE " + strings.Join(where, " AND ")
 	}
+	if qual, qArgs := limitPerPKClause(opts); qual != "" {
+		q += qual
+		args = append(args, qArgs...)
+	}
 	q += " ORDER BY event_timestamp, event_id"
 	if opts.Limit > 0 {
 		q += " LIMIT ?"
@@ -565,6 +577,19 @@ func buildQuery(glob string, opts query.Options) (string, []any) {
 	}
 
 	return q, args
+}
+
+// limitPerPKClause returns the DuckDB QUALIFY fragment that caps the result
+// to the latest LimitPerPK events per pk_values, plus the bind argument.
+// Returns ("", nil) when LimitPerPK is unset. Inner ORDER BY DESC mirrors
+// the MySQL ROW_NUMBER ordering in internal/query so both engines pick the
+// same events for a given filter.
+func limitPerPKClause(opts query.Options) (string, []any) {
+	if opts.LimitPerPK <= 0 {
+		return "", nil
+	}
+	return " QUALIFY ROW_NUMBER() OVER (PARTITION BY pk_values" +
+		" ORDER BY event_timestamp DESC, event_id DESC) <= ?", []any{opts.LimitPerPK}
 }
 
 // buildFilters extracts WHERE clause fragments and bind args from query options.
@@ -583,6 +608,13 @@ func buildFilters(opts query.Options) ([]string, []any) {
 	if opts.PKValues != "" {
 		where = append(where, "pk_values = ?")
 		args = append(args, opts.PKValues)
+	} else if len(opts.PKValuesIn) > 0 {
+		placeholders := make([]string, len(opts.PKValuesIn))
+		for i, v := range opts.PKValuesIn {
+			placeholders[i] = "?"
+			args = append(args, v)
+		}
+		where = append(where, "pk_values IN ("+strings.Join(placeholders, ",")+")")
 	}
 	if opts.EventType != nil {
 		where = append(where, "event_type = ?")
@@ -676,6 +708,10 @@ func buildQueryForFile(path string, opts query.Options, cols map[string]bool) (s
 		" FROM parquet_scan('" + safePath + "', hive_partitioning=true, union_by_name=true)"
 	if len(where) > 0 {
 		q += " WHERE " + strings.Join(where, " AND ")
+	}
+	if qual, qArgs := limitPerPKClause(opts); qual != "" {
+		q += qual
+		args = append(args, qArgs...)
 	}
 	q += " ORDER BY event_timestamp, event_id"
 	if opts.Limit > 0 {

--- a/internal/parquetquery/parquetquery_test.go
+++ b/internal/parquetquery/parquetquery_test.go
@@ -182,6 +182,73 @@ func TestBuildQueryLimitPerPK(t *testing.T) {
 	}
 }
 
+// TestLimitPerPK_appliedToEveryBuilder pins the invariant that every DuckDB
+// query builder in this package emits the QUALIFY clause when LimitPerPK is
+// set. A regression here (someone adds a new builder for a schema variant and
+// forgets limitPerPKClause, or removes it from one of the existing branches)
+// would silently skip the per-PK cap for that path while the other builders
+// still enforce it — the kind of inconsistent partial-coverage bug that's
+// hardest to reproduce in production.
+func TestLimitPerPK_appliedToEveryBuilder(t *testing.T) {
+	opts := query.Options{PKValuesIn: []string{"1", "2"}, LimitPerPK: 3, Limit: 50}
+	cols := map[string]bool{"connection_id": true}
+
+	cases := []struct {
+		name string
+		q    string
+	}{
+		{"buildQuery (glob)", mustBuildQuery(opts)},
+		{"buildQueryForFile", mustBuildQueryForFile(opts, cols)},
+		{"buildQueryFromFiles", mustBuildQueryFromFiles(opts)},
+		{"buildUnsortedQuery", mustBuildUnsorted(opts)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assertContains(t, tc.q, "QUALIFY ROW_NUMBER() OVER (PARTITION BY pk_values")
+			assertContains(t, tc.q, "ORDER BY event_timestamp DESC, event_id DESC")
+		})
+	}
+}
+
+// TestLimitPerPK_omittedWhenZero is the negative counterpart: every builder
+// must NOT emit QUALIFY when LimitPerPK is 0. A spurious QUALIFY would force
+// DuckDB to allocate a window over every row for queries that don't need it.
+func TestLimitPerPK_omittedWhenZero(t *testing.T) {
+	opts := query.Options{Schema: "db", Table: "t", Limit: 50}
+	cols := map[string]bool{"connection_id": true}
+
+	for _, q := range []string{
+		mustBuildQuery(opts),
+		mustBuildQueryForFile(opts, cols),
+		mustBuildQueryFromFiles(opts),
+		mustBuildUnsorted(opts),
+	} {
+		if strings.Contains(q, "QUALIFY") {
+			t.Errorf("QUALIFY must not appear when LimitPerPK=0: %s", q)
+		}
+	}
+}
+
+func mustBuildQuery(opts query.Options) string {
+	q, _ := buildQuery("/arc/*.parquet", opts)
+	return q
+}
+
+func mustBuildQueryForFile(opts query.Options, cols map[string]bool) string {
+	q, _ := buildQueryForFile("/tmp/x.parquet", opts, cols)
+	return q
+}
+
+func mustBuildQueryFromFiles(opts query.Options) string {
+	q, _ := buildQueryFromFiles([]string{"s3://b/x.parquet"}, opts)
+	return q
+}
+
+func mustBuildUnsorted(opts query.Options) string {
+	q, _ := buildUnsortedQuery("/tmp/x.parquet", opts)
+	return q
+}
+
 func TestBuildQueryEventType(t *testing.T) {
 	et := parser.EventDelete
 	opts := query.Options{EventType: &et, Limit: 100}

--- a/internal/parquetquery/parquetquery_test.go
+++ b/internal/parquetquery/parquetquery_test.go
@@ -161,6 +161,27 @@ func TestBuildQueryPK(t *testing.T) {
 	}
 }
 
+func TestBuildQueryPKValuesIn(t *testing.T) {
+	opts := query.Options{PKValuesIn: []string{"1", "2", "3"}, Limit: 100}
+	q, args := buildQuery("/arc/*.parquet", opts)
+	assertContains(t, q, "pk_values IN (?,?,?)")
+	if got := args[:3]; got[0] != "1" || got[1] != "2" || got[2] != "3" {
+		t.Errorf("expected first three args [1 2 3], got %v", got)
+	}
+}
+
+func TestBuildQueryLimitPerPK(t *testing.T) {
+	opts := query.Options{PKValuesIn: []string{"1", "2"}, LimitPerPK: 1, Limit: 100}
+	q, args := buildQuery("/arc/*.parquet", opts)
+	assertContains(t, q, "QUALIFY ROW_NUMBER() OVER (PARTITION BY pk_values")
+	assertContains(t, q, "ORDER BY event_timestamp DESC, event_id DESC")
+	// Args order: pk1, pk2, limitPerPK, limit
+	wantTail := []any{1, 100}
+	if args[len(args)-2] != wantTail[0] || args[len(args)-1] != wantTail[1] {
+		t.Errorf("expected tail args [1 100], got %v", args[len(args)-2:])
+	}
+}
+
 func TestBuildQueryEventType(t *testing.T) {
 	et := parser.EventDelete
 	opts := query.Options{EventType: &et, Limit: 100}

--- a/internal/query/fetchmerged.go
+++ b/internal/query/fetchmerged.go
@@ -217,5 +217,10 @@ func FetchMerged(
 	}
 
 	rows = MergeResults(rows, o.Opts.Limit)
+	// Each source applied LimitPerPK independently. After dedup+sort, enforce
+	// the cap globally so the union does not exceed N events per pk_values.
+	if o.Opts.LimitPerPK > 0 {
+		rows = LimitPerPK(rows, o.Opts.LimitPerPK)
+	}
 	return rows, plan, nil
 }

--- a/internal/query/fetchmerged.go
+++ b/internal/query/fetchmerged.go
@@ -216,11 +216,6 @@ func FetchMerged(
 		return nil, plan, fmt.Errorf("all %d archive source(s) failed, cannot verify coverage: %w", len(archSources), lastArchiveErr)
 	}
 
-	rows = MergeResults(rows, o.Opts.Limit)
-	// Each source applied LimitPerPK independently. After dedup+sort, enforce
-	// the cap globally so the union does not exceed N events per pk_values.
-	if o.Opts.LimitPerPK > 0 {
-		rows = LimitPerPK(rows, o.Opts.LimitPerPK)
-	}
+	rows = MergeAndTrim(rows, o.Opts.Limit, o.Opts.LimitPerPK)
 	return rows, plan, nil
 }

--- a/internal/query/merge.go
+++ b/internal/query/merge.go
@@ -28,3 +28,35 @@ func MergeResults(rows []ResultRow, limit int) []ResultRow {
 	}
 	return unique
 }
+
+// LimitPerPK trims rows to keep at most n events per pk_values value, keeping
+// the latest n (by event_timestamp, event_id). Input is expected to be sorted
+// ascending by (event_timestamp, event_id) — the shape produced by
+// MergeResults — and the output preserves that ordering. n <= 0 returns rows
+// unchanged.
+//
+// Used after MergeResults when each source has applied its own per-PK cap
+// independently: the union can still exceed n per PK across sources, so a
+// final post-merge trim enforces the contract.
+func LimitPerPK(rows []ResultRow, n int) []ResultRow {
+	if n <= 0 || len(rows) == 0 {
+		return rows
+	}
+	counts := make(map[string]int, len(rows))
+	keep := make([]bool, len(rows))
+	// Walk in reverse so the latest events per PK are seen first and kept.
+	for i := len(rows) - 1; i >= 0; i-- {
+		pk := rows[i].PKValues
+		if counts[pk] < n {
+			counts[pk]++
+			keep[i] = true
+		}
+	}
+	out := rows[:0]
+	for i, r := range rows {
+		if keep[i] {
+			out = append(out, r)
+		}
+	}
+	return out
+}

--- a/internal/query/merge.go
+++ b/internal/query/merge.go
@@ -29,11 +29,39 @@ func MergeResults(rows []ResultRow, limit int) []ResultRow {
 	return unique
 }
 
-// LimitPerPK trims rows to keep at most n events per pk_values value, keeping
-// the latest n (by event_timestamp, event_id). Input is expected to be sorted
-// ascending by (event_timestamp, event_id) — the shape produced by
-// MergeResults — and the output preserves that ordering. n <= 0 returns rows
-// unchanged.
+// MergeAndTrim runs the full post-fetch pipeline: dedup+sort via MergeResults,
+// then the per-PK cap, then the global cap. The order is load-bearing —
+// applying the global cap before the per-PK cap can truncate ASC-sorted early
+// events for one PK and starve others before the per-PK trim runs.
+//
+// Used by FetchMerged and by the CLI merge path. Exposing this as a helper
+// lets unit tests pin the ordering: a future refactor that swaps the sequence
+// or drops the per-PK re-trim will fail TestMergeAndTrim_perPKBeforeGlobal.
+func MergeAndTrim(rows []ResultRow, limit, limitPerPK int) []ResultRow {
+	rows = MergeResults(rows, 0)
+	if limitPerPK > 0 {
+		rows = LimitPerPK(rows, limitPerPK)
+	}
+	if limit > 0 && len(rows) > limit {
+		rows = rows[:limit]
+	}
+	return rows
+}
+
+// LimitPerPK trims rows to keep at most n per pk_values, preserving the input
+// ordering. Implementation: walk in reverse and keep the last n positional
+// occurrences per PK, so the helper only returns the timestamp-latest events
+// when the caller has already sorted the input ascending by
+// (event_timestamp, event_id) — the shape produced by MergeResults.
+//
+// Precondition: input must be sorted ascending by (event_timestamp, event_id).
+// When violated, the function still returns at most n rows per PK, but the
+// kept rows are the last n *positionally*, not the timestamp-latest. The
+// helper does not validate the sort order: the happy-path callers in this
+// repo all feed it post-MergeResults output where the sort is guaranteed,
+// and adding a sort check would hide a caller bug under a silent re-sort.
+//
+// n <= 0 returns rows unchanged.
 //
 // Used after MergeResults when each source has applied its own per-PK cap
 // independently: the union can still exceed n per PK across sources, so a

--- a/internal/query/merge_test.go
+++ b/internal/query/merge_test.go
@@ -120,19 +120,33 @@ func TestMergeAndTrim_perPKBeforeGlobal(t *testing.T) {
 	}
 }
 
+// TestMergeAndTrim_crossSourceDedup exercises the two-step contract: dedup
+// collapses cross-source duplicates, and LimitPerPK then trims the deduped
+// set to the cap. The scenario is specifically constructed so that dedup
+// alone is NOT sufficient — PK "a" has 3 distinct events after dedup
+// (event IDs 1, 2, 3) plus duplicates of each from the archive source, and
+// LimitPerPK=2 must still fire to trim the deduped result down to 2. A
+// regression that drops LimitPerPK would leave len(got)==3 and fail this
+// test, whereas a regression that keeps the duplicates without running
+// LimitPerPK would leave len(got)==6.
 func TestMergeAndTrim_crossSourceDedup(t *testing.T) {
 	ts := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
-	// Same PK appears in both sources with the same event_id (MySQL + archive
-	// overlap). After MergeAndTrim with LimitPerPK=2 we expect the duplicate
-	// to be collapsed so the PK has at most 2 events, not 4.
 	rows := []ResultRow{
-		{EventID: 1, EventTimestamp: ts, PKValues: "a"},             // MySQL
-		{EventID: 2, EventTimestamp: ts.Add(time.Second), PKValues: "a"}, // MySQL
-		{EventID: 1, EventTimestamp: ts, PKValues: "a"},             // archive dup of 1
-		{EventID: 2, EventTimestamp: ts.Add(time.Second), PKValues: "a"}, // archive dup of 2
+		// MySQL side — three distinct events for PK "a".
+		{EventID: 1, EventTimestamp: ts, PKValues: "a"},
+		{EventID: 2, EventTimestamp: ts.Add(time.Second), PKValues: "a"},
+		{EventID: 3, EventTimestamp: ts.Add(2 * time.Second), PKValues: "a"},
+		// Archive side — duplicates of the same three events (overlap window).
+		{EventID: 1, EventTimestamp: ts, PKValues: "a"},
+		{EventID: 2, EventTimestamp: ts.Add(time.Second), PKValues: "a"},
+		{EventID: 3, EventTimestamp: ts.Add(2 * time.Second), PKValues: "a"},
 	}
 	got := MergeAndTrim(rows, 0, 2)
 	if len(got) != 2 {
-		t.Fatalf("expected 2 rows after dedup + per-PK trim, got %d", len(got))
+		t.Fatalf("expected 2 rows after dedup (3 unique) + LimitPerPK=2 trim, got %d", len(got))
+	}
+	// Latest two events kept: IDs 2 and 3 in ASC order.
+	if got[0].EventID != 2 || got[1].EventID != 3 {
+		t.Errorf("expected events [2,3] (latest 2 in ASC order), got %v", []uint64{got[0].EventID, got[1].EventID})
 	}
 }

--- a/internal/query/merge_test.go
+++ b/internal/query/merge_test.go
@@ -78,3 +78,61 @@ func TestMergeResults_empty(t *testing.T) {
 		t.Fatalf("expected 0 rows, got %d", len(got))
 	}
 }
+
+// TestMergeAndTrim_perPKBeforeGlobal pins the load-bearing ordering invariant
+// between LimitPerPK and Limit. With three PKs each having three ASC-sorted
+// events, a naive "MergeResults(..., Limit) then LimitPerPK" ordering would
+// truncate the union to Limit=6 rows (rows for "c" lost entirely) and then
+// trim per-PK to 1 each — final: only 2 rows for "a" and "b", 0 for "c".
+// The correct ordering (per-PK first, global last) keeps 1 row per PK for all
+// three PKs — final: 3 rows total. If someone swaps the sequence in a future
+// refactor this test fails immediately.
+func TestMergeAndTrim_perPKBeforeGlobal(t *testing.T) {
+	ts := func(m int) time.Time {
+		return time.Date(2026, 3, 1, 12, m, 0, 0, time.UTC)
+	}
+	// Events ordered so that all of "a"'s events come before all of "b"'s,
+	// and all of "b"'s before all of "c"'s — a worst-case for the ordering bug.
+	rows := []ResultRow{
+		{EventID: 1, EventTimestamp: ts(1), PKValues: "a"},
+		{EventID: 2, EventTimestamp: ts(2), PKValues: "a"},
+		{EventID: 3, EventTimestamp: ts(3), PKValues: "a"},
+		{EventID: 4, EventTimestamp: ts(4), PKValues: "b"},
+		{EventID: 5, EventTimestamp: ts(5), PKValues: "b"},
+		{EventID: 6, EventTimestamp: ts(6), PKValues: "b"},
+		{EventID: 7, EventTimestamp: ts(7), PKValues: "c"},
+		{EventID: 8, EventTimestamp: ts(8), PKValues: "c"},
+		{EventID: 9, EventTimestamp: ts(9), PKValues: "c"},
+	}
+	got := MergeAndTrim(rows, 6, 1)
+	if len(got) != 3 {
+		t.Fatalf("expected 3 rows (1 per PK) after correct trim ordering, got %d: %+v", len(got), got)
+	}
+	seen := map[string]bool{}
+	for _, r := range got {
+		if seen[r.PKValues] {
+			t.Errorf("duplicate PK %q in output — LimitPerPK not enforced", r.PKValues)
+		}
+		seen[r.PKValues] = true
+	}
+	if !seen["a"] || !seen["b"] || !seen["c"] {
+		t.Errorf("expected all three PKs represented, got %v", seen)
+	}
+}
+
+func TestMergeAndTrim_crossSourceDedup(t *testing.T) {
+	ts := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+	// Same PK appears in both sources with the same event_id (MySQL + archive
+	// overlap). After MergeAndTrim with LimitPerPK=2 we expect the duplicate
+	// to be collapsed so the PK has at most 2 events, not 4.
+	rows := []ResultRow{
+		{EventID: 1, EventTimestamp: ts, PKValues: "a"},             // MySQL
+		{EventID: 2, EventTimestamp: ts.Add(time.Second), PKValues: "a"}, // MySQL
+		{EventID: 1, EventTimestamp: ts, PKValues: "a"},             // archive dup of 1
+		{EventID: 2, EventTimestamp: ts.Add(time.Second), PKValues: "a"}, // archive dup of 2
+	}
+	got := MergeAndTrim(rows, 0, 2)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 rows after dedup + per-PK trim, got %d", len(got))
+	}
+}

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -109,6 +109,7 @@ type Options struct {
 	Schema        string
 	Table         string
 	PKValues      string            // pipe-delimited PK, e.g. "12345" or "12345|2"
+	PKValuesIn    []string          // multi-PK lookup (mutually exclusive with PKValues)
 	EventType     *parser.EventType // nil = all types
 	GTID          string
 	Since         *time.Time
@@ -117,6 +118,13 @@ type Options struct {
 	ColumnEq      []ColumnEq // match against values inside row_after / row_before
 	Flag          string     // return events from tables/columns carrying this flag
 	Limit         int        // 0 → default 100
+	// LimitPerPK caps the number of latest events returned per pk_values value.
+	// 0 = unlimited. Applied via ROW_NUMBER OVER (PARTITION BY pk_values
+	// ORDER BY event_timestamp DESC, event_id DESC) so the kept events are
+	// the most recent ones per PK. Only meaningful with PKValuesIn (or a
+	// single PKValues value). The outer ORDER BY remains ASC for stable
+	// global output.
+	LimitPerPK int
 
 	DenyTables    []SchemaTable       // tables excluded by RBAC profile
 	RedactColumns []SchemaTableColumn // column values nulled out by RBAC profile
@@ -215,6 +223,17 @@ func buildQuery(opts Options) (string, []any) {
 		// Use pk_hash for the index scan; pk_values for the collision guard.
 		where = append(where, "pk_hash = SHA2(?, 256) AND pk_values = ?")
 		args = append(args, opts.PKValues, opts.PKValues)
+	} else if len(opts.PKValuesIn) > 0 {
+		// Multi-PK lookup. The pk_hash generated column index can't help with
+		// IN-lists, so the planner falls back to per-partition scans pruned by
+		// (schema_name, table_name, event_timestamp). Callers supply schema
+		// and table to keep the scan bounded.
+		placeholders := make([]string, len(opts.PKValuesIn))
+		for i, v := range opts.PKValuesIn {
+			placeholders[i] = "?"
+			args = append(args, v)
+		}
+		where = append(where, "pk_values IN ("+strings.Join(placeholders, ",")+")")
 	}
 	if opts.EventType != nil {
 		where = append(where, "event_type = ?")
@@ -298,14 +317,31 @@ func buildQuery(opts Options) (string, []any) {
 		args = append(args, dt.Schema, dt.Table)
 	}
 
-	q := `SELECT event_id, binlog_file, start_pos, end_pos, event_timestamp,
-	             gtid, connection_id, schema_name, table_name, event_type, pk_values,
-	             changed_columns, row_before, row_after, schema_version
-	      FROM binlog_events`
-	if len(where) > 0 {
-		q += " WHERE " + strings.Join(where, " AND ")
+	cols := `event_id, binlog_file, start_pos, end_pos, event_timestamp,
+	         gtid, connection_id, schema_name, table_name, event_type, pk_values,
+	         changed_columns, row_before, row_after, schema_version`
+
+	var q string
+	if opts.LimitPerPK > 0 {
+		// Per-PK cap via ROW_NUMBER. Inner ORDER BY DESC selects the latest
+		// events per pk_values; outer ORDER BY ASC keeps the global output
+		// shape identical to the no-cap path so callers don't see ordering
+		// drift between runs.
+		inner := "SELECT " + cols + ", ROW_NUMBER() OVER (PARTITION BY pk_values" +
+			" ORDER BY event_timestamp DESC, event_id DESC) AS bt_rn FROM binlog_events"
+		if len(where) > 0 {
+			inner += " WHERE " + strings.Join(where, " AND ")
+		}
+		q = "SELECT " + cols + " FROM (" + inner + ") AS t WHERE bt_rn <= ?"
+		args = append(args, opts.LimitPerPK)
+		q += " ORDER BY event_timestamp, event_id"
+	} else {
+		q = "SELECT " + cols + " FROM binlog_events"
+		if len(where) > 0 {
+			q += " WHERE " + strings.Join(where, " AND ")
+		}
+		q += " ORDER BY event_timestamp, event_id"
 	}
-	q += " ORDER BY event_timestamp, event_id"
 	if opts.Limit > 0 {
 		q += " LIMIT ?"
 		args = append(args, opts.Limit)

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -495,6 +495,90 @@ func TestApplyRedaction(t *testing.T) {
 	}
 }
 
+func TestBuildQuery_pkValuesIn(t *testing.T) {
+	opts := Options{Schema: "db", Table: "t", PKValuesIn: []string{"1", "2", "3"}, Limit: 10}
+	q, args := buildQuery(opts)
+
+	if !strings.Contains(q, "pk_values IN (?,?,?)") {
+		t.Errorf("expected pk_values IN (?,?,?) in query: %s", q)
+	}
+	if strings.Contains(q, "SHA2") {
+		t.Errorf("PKValuesIn must not use the SHA2 single-PK path: %s", q)
+	}
+	// Args order: schema, table, pk1, pk2, pk3, limit
+	wantArgs := []any{"db", "t", "1", "2", "3", 10}
+	if fmt.Sprintf("%v", args) != fmt.Sprintf("%v", wantArgs) {
+		t.Errorf("args mismatch: got %v want %v", args, wantArgs)
+	}
+}
+
+func TestBuildQuery_pkValues_winsOver_pkValuesIn(t *testing.T) {
+	// PKValues takes precedence so callers that set both (defensive callers)
+	// keep the SHA2-indexed fast path. PKValuesIn is silently ignored.
+	opts := Options{Schema: "db", Table: "t", PKValues: "42", PKValuesIn: []string{"1", "2"}, Limit: 5}
+	q, _ := buildQuery(opts)
+	if !strings.Contains(q, "pk_hash = SHA2(?, 256)") {
+		t.Errorf("PKValues must take precedence over PKValuesIn: %s", q)
+	}
+	if strings.Contains(q, "pk_values IN") {
+		t.Errorf("PKValuesIn must be ignored when PKValues is set: %s", q)
+	}
+}
+
+func TestBuildQuery_limitPerPK(t *testing.T) {
+	opts := Options{Schema: "db", Table: "t", PKValuesIn: []string{"1", "2"}, LimitPerPK: 1, Limit: 100}
+	q, args := buildQuery(opts)
+
+	if !strings.Contains(q, "ROW_NUMBER() OVER (PARTITION BY pk_values") {
+		t.Errorf("expected ROW_NUMBER window in query: %s", q)
+	}
+	if !strings.Contains(q, "ORDER BY event_timestamp DESC, event_id DESC") {
+		t.Errorf("expected DESC ordering inside window so latest events are kept: %s", q)
+	}
+	if !strings.Contains(q, "WHERE bt_rn <= ?") {
+		t.Errorf("expected outer WHERE bt_rn <= ?: %s", q)
+	}
+	// Outer ORDER BY remains ASC for stable global output.
+	if !strings.HasSuffix(strings.TrimSpace(strings.Split(q, "ORDER BY event_timestamp,")[1]), "event_id LIMIT ?") {
+		t.Errorf("expected outer ORDER BY event_timestamp, event_id ASC: %s", q)
+	}
+	// Args: schema, table, pk1, pk2, limitPerPK, limit
+	wantArgs := []any{"db", "t", "1", "2", 1, 100}
+	if fmt.Sprintf("%v", args) != fmt.Sprintf("%v", wantArgs) {
+		t.Errorf("args mismatch: got %v want %v", args, wantArgs)
+	}
+}
+
+func TestLimitPerPK_helper(t *testing.T) {
+	ts := func(s string) time.Time {
+		t, _ := time.Parse("2006-01-02 15:04:05", s)
+		return t
+	}
+	rows := []ResultRow{
+		{EventID: 1, EventTimestamp: ts("2026-04-15 10:00:00"), PKValues: "a"},
+		{EventID: 2, EventTimestamp: ts("2026-04-15 10:01:00"), PKValues: "b"},
+		{EventID: 3, EventTimestamp: ts("2026-04-15 10:02:00"), PKValues: "a"},
+		{EventID: 4, EventTimestamp: ts("2026-04-15 10:03:00"), PKValues: "a"},
+		{EventID: 5, EventTimestamp: ts("2026-04-15 10:04:00"), PKValues: "b"},
+	}
+	got := LimitPerPK(rows, 1)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 rows after limit-per-pk=1, got %d", len(got))
+	}
+	// Latest per PK: a→4, b→5; ordering preserved (ASC).
+	if got[0].EventID != 4 || got[1].EventID != 5 {
+		t.Errorf("expected events [4,5] (latest per PK in ASC order), got %v", []uint64{got[0].EventID, got[1].EventID})
+	}
+}
+
+func TestLimitPerPK_zero_passthrough(t *testing.T) {
+	rows := []ResultRow{{EventID: 1, PKValues: "a"}, {EventID: 2, PKValues: "a"}}
+	got := LimitPerPK(rows, 0)
+	if len(got) != 2 {
+		t.Errorf("LimitPerPK(_, 0) should be a passthrough, got %d rows", len(got))
+	}
+}
+
 func TestApplyRedaction_wrongTable(t *testing.T) {
 	rows := []ResultRow{{
 		SchemaName: "mydb",


### PR DESCRIPTION
closes #231

## Summary
- Add `--pks` (comma-separated or repeatable) and `--limit-per-pk N` to `bintrail query` and `bintrail recover`. Collapses N shell-outs into 1; on the archive path, one DuckDB pass with `WHERE pk_values IN (...)` + `QUALIFY ROW_NUMBER() OVER (PARTITION BY pk_values ORDER BY event_timestamp DESC, event_id DESC) <= N` replaces N scans of the same parquet files.
- MySQL side uses a `ROW_NUMBER()` subquery for the per-PK cap; outer `ORDER BY event_timestamp, event_id` stays ASC so global output shape is unchanged.
- After cross-source merge, `query.LimitPerPK` re-enforces the cap so the union of independently-trimmed MySQL + archive results cannot exceed N per PK.
- `query --format=json --pks=...` emits `{"results": [{"pk": "X", "events": [...]}, ...]}` preserving input PK order, with empty groups for PKs that matched nothing.
- `--pk` keeps its SHA2-indexed fast path. `--pk` and `--pks` are mutually exclusive; `--limit-per-pk` requires one of them.

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] New unit tests cover: MySQL `buildQuery` with `PKValuesIn` / `LimitPerPK` / precedence of `PKValues` over `PKValuesIn`; `LimitPerPK` post-merge helper; DuckDB `buildQuery` with `PKValuesIn` + QUALIFY; CLI flag validation (`--pks` requires schema/table, `--pk` and `--pks` mutually exclusive, `--limit-per-pk` requires `--pk` or `--pks`); grouped JSON output shape and empty-group handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)