### PR TITLE
query: add --include-snapshot to merge baseline Parquet as third source

### DIFF
--- a/cmd/bintrail/query.go
+++ b/cmd/bintrail/query.go
@@ -70,6 +70,8 @@ var (
 	qBintrailID  string
 	qProfile     string
 	qNoArchive   bool
+	qIncludeSnapshot bool
+	qBaseline        string
 )
 
 func init() {
@@ -93,6 +95,8 @@ func init() {
 	queryCmd.Flags().StringVar(&qBintrailID, "bintrail-id", "", "Server identity UUID (required when --archive-dir or --archive-s3 is set)")
 	queryCmd.Flags().StringVar(&qProfile, "profile", "", "Apply RBAC access rules for this profile (table-level deny and column-level redaction)")
 	queryCmd.Flags().BoolVar(&qNoArchive, "no-archive", false, "Disable auto-routing to Parquet archives (MySQL-only results)")
+	queryCmd.Flags().BoolVar(&qIncludeSnapshot, "include-snapshot", false, "Also scan the mydumper baseline Parquet and emit matching rows as SNAPSHOT events (requires --baseline, --schema, --table)")
+	queryCmd.Flags().StringVar(&qBaseline, "baseline", "", "Path to a baseline Parquet file or directory containing <schema>/<table>.parquet (local path or s3:// URL); used with --include-snapshot")
 	_ = queryCmd.MarkFlagRequired("index-dsn")
 	bindCommandEnv(queryCmd)
 
@@ -143,6 +147,19 @@ func runQuery(cmd *cobra.Command, args []string) error {
 	}
 	if qNoArchive && (qArchiveDir != "" || qArchiveS3 != "") {
 		return fmt.Errorf("--no-archive cannot be combined with --archive-dir or --archive-s3")
+	}
+	if qIncludeSnapshot {
+		if qBaseline == "" {
+			return fmt.Errorf("--include-snapshot requires --baseline")
+		}
+		if qSchema == "" || qTable == "" {
+			return fmt.Errorf("--include-snapshot requires both --schema and --table")
+		}
+		if qProfile != "" {
+			return fmt.Errorf("--profile cannot be combined with --include-snapshot")
+		}
+	} else if qBaseline != "" {
+		return fmt.Errorf("--baseline requires --include-snapshot")
 	}
 
 	// ── Parse filter values ───────────────────────────────────────────────────
@@ -225,7 +242,7 @@ func runQuery(cmd *cobra.Command, args []string) error {
 	// output for --pks needs a separate formatting step, so fall through to
 	// the merge path when it's active.
 	groupedJSON := len(qPKs) > 0 && qFormat == "json"
-	if len(archSources) == 0 && !groupedJSON {
+	if len(archSources) == 0 && !groupedJSON && !qIncludeSnapshot {
 		n, err := engine.Run(cmd.Context(), opts, qFormat, os.Stdout)
 		if err != nil {
 			return err
@@ -282,6 +299,15 @@ func runQuery(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		results = append(results, archResults...)
+	}
+
+	if qIncludeSnapshot {
+		snapPath := resolveSnapshotPath(qBaseline, qSchema, qTable)
+		snapRows, err := query.FetchSnapshot(cmd.Context(), snapPath, fetchOpts)
+		if err != nil {
+			return fmt.Errorf("snapshot query: %w", err)
+		}
+		results = append(results, snapRows...)
 	}
 
 	results = query.MergeAndTrim(results, opts.Limit, opts.LimitPerPK)
@@ -533,6 +559,8 @@ func eventTypeJSONName(t parser.EventType) string {
 		return "UPDATE"
 	case parser.EventDelete:
 		return "DELETE"
+	case parser.EventSnapshot:
+		return "SNAPSHOT"
 	default:
 		return "UNKNOWN"
 	}
@@ -567,6 +595,17 @@ func cleanPKList(pks []string) ([]string, error) {
 		out = append(out, trimmed)
 	}
 	return out, nil
+}
+
+// resolveSnapshotPath resolves the --baseline flag to a concrete <schema>/<table>.parquet
+// path. If the user passed a direct .parquet path, it's returned unchanged;
+// otherwise the baseline is treated as a directory (local or s3://) and
+// "/<schema>/<table>.parquet" is appended.
+func resolveSnapshotPath(baseline, schema, table string) string {
+	if strings.HasSuffix(baseline, ".parquet") {
+		return baseline
+	}
+	return strings.TrimSuffix(baseline, "/") + "/" + schema + "/" + table + ".parquet"
 }
 
 // archiveSources returns the Hive-scoped archive source paths for the current

--- a/cmd/bintrail/query.go
+++ b/cmd/bintrail/query.go
@@ -158,8 +158,19 @@ func runQuery(cmd *cobra.Command, args []string) error {
 		if qProfile != "" {
 			return fmt.Errorf("--profile cannot be combined with --include-snapshot")
 		}
+		// Snapshot rows are emitted with empty pk_values (this PR does not
+		// extract PK columns from the baseline CREATE TABLE metadata), so
+		// PK-keyed filters would silently return wrong results. Reject the
+		// combination explicitly instead. --limit-per-pk is transitively
+		// blocked because it already requires --pk or --pks.
+		if qPK != "" || len(qPKs) > 0 {
+			return fmt.Errorf("--pk and --pks are not supported with --include-snapshot (snapshot rows have no pk_values in this release)")
+		}
 	} else if qBaseline != "" {
 		return fmt.Errorf("--baseline requires --include-snapshot")
+	}
+	if qEventType != "" && strings.EqualFold(qEventType, "SNAPSHOT") && !qIncludeSnapshot {
+		return fmt.Errorf("--event-type SNAPSHOT requires --include-snapshot")
 	}
 
 	// ── Parse filter values ───────────────────────────────────────────────────

--- a/cmd/bintrail/query_test.go
+++ b/cmd/bintrail/query_test.go
@@ -1377,3 +1377,166 @@ func TestWriteGroupedJSON_preservesInputOrderAndEmits_emptyGroups(t *testing.T) 
 		t.Errorf("expected empty events for PK with no matches, got %d", len(got.Results[2].Events))
 	}
 }
+
+// ─── --include-snapshot flag validation ───────────────────────────────────────
+
+func TestRunQuery_includeSnapshotRequiresBaseline(t *testing.T) {
+	saved := qIncludeSnapshot
+	savedB := qBaseline
+	t.Cleanup(func() { qIncludeSnapshot = saved; qBaseline = savedB })
+
+	qIncludeSnapshot = true
+	qBaseline = ""
+
+	err := runQuery(queryCmd, nil)
+	if err == nil {
+		t.Fatal("expected error when --include-snapshot used without --baseline")
+	}
+	if !strings.Contains(err.Error(), "--include-snapshot requires --baseline") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestRunQuery_includeSnapshotRequiresSchemaTable(t *testing.T) {
+	saved := qIncludeSnapshot
+	savedB, savedS, savedT := qBaseline, qSchema, qTable
+	t.Cleanup(func() {
+		qIncludeSnapshot = saved
+		qBaseline = savedB
+		qSchema = savedS
+		qTable = savedT
+	})
+
+	qIncludeSnapshot = true
+	qBaseline = "/data/baseline.parquet"
+	qSchema = ""
+	qTable = ""
+
+	err := runQuery(queryCmd, nil)
+	if err == nil {
+		t.Fatal("expected error when --include-snapshot used without --schema/--table")
+	}
+	if !strings.Contains(err.Error(), "--schema and --table") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestRunQuery_includeSnapshotConflictsWithProfile(t *testing.T) {
+	saved := qIncludeSnapshot
+	savedB, savedS, savedT, savedP := qBaseline, qSchema, qTable, qProfile
+	t.Cleanup(func() {
+		qIncludeSnapshot = saved
+		qBaseline = savedB
+		qSchema = savedS
+		qTable = savedT
+		qProfile = savedP
+	})
+
+	qIncludeSnapshot = true
+	qBaseline = "/data/baseline.parquet"
+	qSchema = "db"
+	qTable = "t"
+	qProfile = "rbac1"
+
+	err := runQuery(queryCmd, nil)
+	if err == nil {
+		t.Fatal("expected error when --include-snapshot combined with --profile (silent RBAC bypass)")
+	}
+	if !strings.Contains(err.Error(), "--profile cannot be combined with --include-snapshot") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestRunQuery_includeSnapshotRejectsPKFilter(t *testing.T) {
+	saved := qIncludeSnapshot
+	savedB, savedS, savedT, savedPK := qBaseline, qSchema, qTable, qPK
+	t.Cleanup(func() {
+		qIncludeSnapshot = saved
+		qBaseline = savedB
+		qSchema = savedS
+		qTable = savedT
+		qPK = savedPK
+	})
+
+	qIncludeSnapshot = true
+	qBaseline = "/data/baseline.parquet"
+	qSchema = "db"
+	qTable = "t"
+	qPK = "42"
+
+	err := runQuery(queryCmd, nil)
+	if err == nil {
+		t.Fatal("expected error when --pk combined with --include-snapshot (snapshot rows have no pk_values)")
+	}
+	if !strings.Contains(err.Error(), "--pk and --pks are not supported with --include-snapshot") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestRunQuery_baselineRequiresIncludeSnapshot(t *testing.T) {
+	saved := qIncludeSnapshot
+	savedB := qBaseline
+	t.Cleanup(func() { qIncludeSnapshot = saved; qBaseline = savedB })
+
+	qIncludeSnapshot = false
+	qBaseline = "/data/baseline.parquet"
+
+	err := runQuery(queryCmd, nil)
+	if err == nil {
+		t.Fatal("expected error when --baseline used without --include-snapshot")
+	}
+	if !strings.Contains(err.Error(), "--baseline requires --include-snapshot") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestRunQuery_eventTypeSnapshotRequiresIncludeSnapshot(t *testing.T) {
+	saved := qEventType
+	savedIS := qIncludeSnapshot
+	t.Cleanup(func() { qEventType = saved; qIncludeSnapshot = savedIS })
+
+	qEventType = "SNAPSHOT"
+	qIncludeSnapshot = false
+
+	err := runQuery(queryCmd, nil)
+	if err == nil {
+		t.Fatal("expected error when --event-type SNAPSHOT set without --include-snapshot")
+	}
+	if !strings.Contains(err.Error(), "--event-type SNAPSHOT requires --include-snapshot") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+// ─── resolveSnapshotPath ──────────────────────────────────────────────────────
+
+func TestResolveSnapshotPath(t *testing.T) {
+	cases := []struct {
+		name     string
+		baseline string
+		schema   string
+		table    string
+		want     string
+	}{
+		{"direct .parquet path passes through", "/data/baseline.parquet", "db", "t", "/data/baseline.parquet"},
+		{"local dir appends schema/table", "/data/dir", "db", "t", "/data/dir/db/t.parquet"},
+		{"trailing slash collapsed", "/data/dir/", "db", "t", "/data/dir/db/t.parquet"},
+		{"s3 prefix appends schema/table", "s3://bucket/prefix/", "db", "t", "s3://bucket/prefix/db/t.parquet"},
+		{"s3 .parquet path passes through", "s3://bucket/file.parquet", "db", "t", "s3://bucket/file.parquet"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveSnapshotPath(tc.baseline, tc.schema, tc.table)
+			if got != tc.want {
+				t.Errorf("resolveSnapshotPath(%q,%q,%q) = %q, want %q", tc.baseline, tc.schema, tc.table, got, tc.want)
+			}
+		})
+	}
+}
+
+// ─── eventTypeJSONName ────────────────────────────────────────────────────────
+
+func TestEventTypeJSONName_snapshot(t *testing.T) {
+	if got := eventTypeJSONName(binparser.EventSnapshot); got != "SNAPSHOT" {
+		t.Errorf("eventTypeJSONName(EventSnapshot) = %q, want \"SNAPSHOT\"", got)
+	}
+}

--- a/internal/cliutil/cliutil.go
+++ b/internal/cliutil/cliutil.go
@@ -25,8 +25,11 @@ func ParseEventType(s string) (*parser.EventType, error) {
 	case "DELETE":
 		et := parser.EventDelete
 		return &et, nil
+	case "SNAPSHOT":
+		et := parser.EventSnapshot
+		return &et, nil
 	default:
-		return nil, fmt.Errorf("invalid event type %q; must be INSERT, UPDATE, or DELETE", s)
+		return nil, fmt.Errorf("invalid event type %q; must be INSERT, UPDATE, DELETE, or SNAPSHOT", s)
 	}
 }
 

--- a/internal/cliutil/cliutil_test.go
+++ b/internal/cliutil/cliutil_test.go
@@ -49,6 +49,42 @@ func TestParseEventType_delete(t *testing.T) {
 	}
 }
 
+func TestParseEventType_snapshot(t *testing.T) {
+	got, err := ParseEventType("SNAPSHOT")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil || *got != parser.EventSnapshot {
+		t.Errorf("expected EventSnapshot, got %v", got)
+	}
+}
+
+func TestParseEventType_invalidMentionsSnapshot(t *testing.T) {
+	_, err := ParseEventType("PICK")
+	if err == nil {
+		t.Fatal("expected error for unknown event type")
+	}
+	// The error message lists valid types; SNAPSHOT must appear so future
+	// contributors who add a type remember to update the message.
+	if !contains(err.Error(), "SNAPSHOT") {
+		t.Errorf("error message should list SNAPSHOT as a valid type; got %q", err.Error())
+	}
+}
+
+// contains is a tiny stdlib-avoiding helper kept local to this test to match
+// the existing style in this file (no strings import).
+func contains(haystack, needle string) bool {
+	if len(needle) == 0 {
+		return true
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}
+
 func TestParseEventType_caseInsensitive(t *testing.T) {
 	for _, input := range []string{"insert", "Insert", "iNsErT"} {
 		got, err := ParseEventType(input)

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -31,6 +31,11 @@ const (
 	EventDelete EventType = 3
 	EventDDL    EventType = 4
 	EventGTID   EventType = 5 // GTID-only tracking event (no row data)
+	// EventSnapshot is a synthetic event type emitted by query --include-snapshot
+	// for rows read from a mydumper baseline Parquet file. The parser never
+	// produces this type — it exists so baseline rows can flow through the
+	// same ResultRow pipeline as real binlog events.
+	EventSnapshot EventType = 6
 )
 
 // Event is a fully resolved binlog row event with column names attached.

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -10,6 +10,33 @@ import (
 	"github.com/dbtrail/bintrail/internal/metadata"
 )
 
+// ─── EventType wire-contract pin ──────────────────────────────────────────────
+
+// TestEventType_wireContract pins the integer values of every EventType
+// constant. SaaS-side consumers key off these integers across process
+// boundaries (dbtrail #1309/#1310), so a silent renumber would corrupt every
+// downstream consumer. Failure here means a contributor changed a constant —
+// re-check the SaaS ingestion before doing so.
+func TestEventType_wireContract(t *testing.T) {
+	cases := []struct {
+		name string
+		got  EventType
+		want uint8
+	}{
+		{"EventInsert", EventInsert, 1},
+		{"EventUpdate", EventUpdate, 2},
+		{"EventDelete", EventDelete, 3},
+		{"EventDDL", EventDDL, 4},
+		{"EventGTID", EventGTID, 5},
+		{"EventSnapshot", EventSnapshot, 6},
+	}
+	for _, tc := range cases {
+		if uint8(tc.got) != tc.want {
+			t.Errorf("%s = %d, want %d (wire contract: SaaS consumers key off this integer)", tc.name, tc.got, tc.want)
+		}
+	}
+}
+
 // ─── ChangedColumns ───────────────────────────────────────────────────────────
 
 func TestChangedColumns_noChange(t *testing.T) {

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -572,6 +572,8 @@ func eventTypeName(et parser.EventType) string {
 		return "UPDATE"
 	case parser.EventDelete:
 		return "DELETE"
+	case parser.EventSnapshot:
+		return "SNAPSHOT"
 	default:
 		return "UNKNOWN"
 	}

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -276,6 +276,7 @@ func TestEventTypeName(t *testing.T) {
 		{parser.EventInsert, "INSERT"},
 		{parser.EventUpdate, "UPDATE"},
 		{parser.EventDelete, "DELETE"},
+		{parser.EventSnapshot, "SNAPSHOT"},
 		{parser.EventType(99), "UNKNOWN"},
 	}
 	for _, tc := range cases {

--- a/internal/query/snapshot.go
+++ b/internal/query/snapshot.go
@@ -43,20 +43,8 @@ const snapshotEventIDBase uint64 = 1 << 62
 // error. An slog.Info line is emitted at each exclusion so operators who
 // pass --include-snapshot but see "No results" can tell why.
 func FetchSnapshot(ctx context.Context, path string, opts Options) ([]ResultRow, error) {
-	if opts.EventType != nil && *opts.EventType != parser.EventSnapshot {
-		slog.Info("snapshot source excluded by filter", "reason", "--event-type ≠ SNAPSHOT")
-		return nil, nil
-	}
-	if opts.GTID != "" {
-		slog.Info("snapshot source excluded by filter", "reason", "--gtid set (baseline rows carry no GTID)")
-		return nil, nil
-	}
-	if opts.ChangedColumn != "" {
-		slog.Info("snapshot source excluded by filter", "reason", "--changed-column set (baseline rows have no changed-columns metadata)")
-		return nil, nil
-	}
-	if opts.Flag != "" {
-		slog.Info("snapshot source excluded by filter", "reason", "--flag set (baseline rows do not carry table_flags)")
+	if reason, skip := shouldSkipSnapshot(opts); skip {
+		slog.Info("snapshot source excluded by filter", "reason", reason)
 		return nil, nil
 	}
 
@@ -140,6 +128,30 @@ func FetchSnapshot(ctx context.Context, path string, opts Options) ([]ResultRow,
 		return nil, fmt.Errorf("iterate snapshot rows: %w", err)
 	}
 	return results, nil
+}
+
+// shouldSkipSnapshot reports whether any filter in opts rules out the entire
+// snapshot source before the DuckDB query runs. It is the unit-testable
+// truth table for the four always-excluder filters: wrong event-type, gtid,
+// changed-column, flag. Extracted so the branches are testable without
+// standing up DuckDB.
+//
+// Returns (reason, true) when the source must be skipped, with a
+// human-readable reason for the slog message. Returns ("", false) otherwise.
+func shouldSkipSnapshot(opts Options) (string, bool) {
+	if opts.EventType != nil && *opts.EventType != parser.EventSnapshot {
+		return "--event-type ≠ SNAPSHOT", true
+	}
+	if opts.GTID != "" {
+		return "--gtid set (baseline rows carry no GTID)", true
+	}
+	if opts.ChangedColumn != "" {
+		return "--changed-column set (baseline rows have no changed-columns metadata)", true
+	}
+	if opts.Flag != "" {
+		return "--flag set (baseline rows do not carry table_flags)", true
+	}
+	return "", false
 }
 
 // readSnapshotTimestamp extracts bintrail.snapshot_timestamp from the Parquet

--- a/internal/query/snapshot.go
+++ b/internal/query/snapshot.go
@@ -1,0 +1,217 @@
+// Package query — snapshot.go: merges mydumper baseline Parquet rows as a
+// third source for `bintrail query --include-snapshot`.
+//
+// Baseline rows are emitted as synthetic events with EventType=EventSnapshot
+// and EventTimestamp=baseline_creation_ts (read from the Parquet file's
+// `bintrail.snapshot_timestamp` key-value metadata). They slot into the
+// existing MergeAndTrim pipeline alongside live-MySQL and archive events.
+package query
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	_ "github.com/duckdb/duckdb-go/v2"
+
+	"github.com/dbtrail/bintrail/internal/baseline"
+	"github.com/dbtrail/bintrail/internal/parser"
+)
+
+// snapshotEventIDBase is OR'd with the row index to synthesise a ResultRow
+// EventID that cannot collide with a real binlog event_id (always a binlog
+// byte offset, << 1<<62). MergeResults dedups by event_id, so uniqueness
+// across snapshot rows is enough.
+const snapshotEventIDBase uint64 = 1 << 62
+
+// FetchSnapshot reads a single mydumper baseline Parquet file and returns
+// matching rows as synthetic SNAPSHOT events. path must point at a
+// <schema>/<table>.parquet file produced by `bintrail baseline` (local or
+// s3:// URL).
+//
+// Filters that don't apply to baseline rows (gtid, changed-column, flag)
+// exclude the whole snapshot source. --event-type SNAPSHOT keeps only
+// snapshot rows; any other event-type filter excludes them. --since/--until
+// apply to the baseline's recorded creation timestamp.
+//
+// Returns nil, nil when filters exclude all snapshot rows — this is not an
+// error and callers should proceed with no-snapshot results.
+func FetchSnapshot(ctx context.Context, path string, opts Options) ([]ResultRow, error) {
+	// Short-circuit: filters that cannot match baseline rows.
+	if opts.EventType != nil && *opts.EventType != parser.EventSnapshot {
+		return nil, nil
+	}
+	if opts.GTID != "" || opts.ChangedColumn != "" || opts.Flag != "" {
+		return nil, nil
+	}
+
+	meta, err := baseline.ReadParquetMetadataAny(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("read baseline metadata %s: %w", path, err)
+	}
+	ts, err := readSnapshotTimestamp(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	// baseline_creation_ts filter per issue #234.
+	if opts.Since != nil && ts.Before(*opts.Since) {
+		return nil, nil
+	}
+	if opts.Until != nil && ts.After(*opts.Until) {
+		return nil, nil
+	}
+	_ = meta // reserved for future use (binlog file/pos surfacing)
+
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		return nil, fmt.Errorf("open duckdb: %w", err)
+	}
+	defer db.Close()
+	if strings.HasPrefix(path, "s3://") {
+		if _, err := db.ExecContext(ctx, "INSTALL httpfs; LOAD httpfs;"); err != nil {
+			return nil, fmt.Errorf("load httpfs: %w", err)
+		}
+	}
+
+	safePath := strings.ReplaceAll(path, "'", "''")
+	q := "SELECT * FROM parquet_scan('" + safePath + "')"
+	where, args := snapshotFilters(opts)
+	if len(where) > 0 {
+		q += " WHERE " + strings.Join(where, " AND ")
+	}
+	if opts.Limit > 0 {
+		q += fmt.Sprintf(" LIMIT %d", opts.Limit)
+	}
+
+	rows, err := db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot query: %w", err)
+	}
+	defer rows.Close()
+
+	cols, err := rows.Columns()
+	if err != nil {
+		return nil, fmt.Errorf("snapshot columns: %w", err)
+	}
+
+	var results []ResultRow
+	idx := uint64(0)
+	for rows.Next() {
+		vals := make([]any, len(cols))
+		ptrs := make([]any, len(cols))
+		for i := range vals {
+			ptrs[i] = &vals[i]
+		}
+		if err := rows.Scan(ptrs...); err != nil {
+			return nil, fmt.Errorf("scan snapshot row: %w", err)
+		}
+		rowAfter := make(map[string]any, len(cols))
+		for i, c := range cols {
+			rowAfter[c] = normalizeSnapshotValue(vals[i])
+		}
+		results = append(results, ResultRow{
+			EventID:        snapshotEventIDBase | idx,
+			EventTimestamp: ts,
+			SchemaName:     opts.Schema,
+			TableName:      opts.Table,
+			EventType:      parser.EventSnapshot,
+			RowAfter:       rowAfter,
+		})
+		idx++
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate snapshot rows: %w", err)
+	}
+	return results, nil
+}
+
+// readSnapshotTimestamp extracts bintrail.snapshot_timestamp from the Parquet
+// file metadata. Returns a non-nil error when the file lacks the key — the
+// caller cannot apply the --since/--until filter without it.
+func readSnapshotTimestamp(ctx context.Context, path string) (time.Time, error) {
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		return time.Time{}, fmt.Errorf("open duckdb: %w", err)
+	}
+	defer db.Close()
+	if strings.HasPrefix(path, "s3://") {
+		if _, err := db.ExecContext(ctx, "INSTALL httpfs; LOAD httpfs;"); err != nil {
+			return time.Time{}, fmt.Errorf("load httpfs: %w", err)
+		}
+	}
+	safePath := strings.ReplaceAll(path, "'", "''")
+	rows, err := db.QueryContext(ctx, "SELECT key, value FROM parquet_kv_metadata('"+safePath+"')")
+	if err != nil {
+		return time.Time{}, fmt.Errorf("read baseline metadata: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var keyBytes, valBytes []byte
+		if err := rows.Scan(&keyBytes, &valBytes); err != nil {
+			return time.Time{}, fmt.Errorf("scan metadata row: %w", err)
+		}
+		if string(keyBytes) != "bintrail.snapshot_timestamp" {
+			continue
+		}
+		t, err := time.Parse(time.RFC3339, string(valBytes))
+		if err != nil {
+			return time.Time{}, fmt.Errorf("parse snapshot_timestamp %q: %w", string(valBytes), err)
+		}
+		return t.UTC(), nil
+	}
+	if err := rows.Err(); err != nil {
+		return time.Time{}, fmt.Errorf("iterate metadata: %w", err)
+	}
+	return time.Time{}, fmt.Errorf("baseline %s missing bintrail.snapshot_timestamp metadata — re-run `bintrail baseline`", path)
+}
+
+// snapshotFilters returns WHERE fragments and bind args matching opts.ColumnEq
+// and opts.PKValues/PKValuesIn. Schema/table/since/until are not applied here
+// (they are validated against the baseline itself before the query runs).
+func snapshotFilters(opts Options) ([]string, []any) {
+	var where []string
+	var args []any
+	for _, ce := range opts.ColumnEq {
+		if !IsSafeColumnName(ce.Column) {
+			slog.Error("snapshot: rejected unsafe column name; emitting no-match clause", "column", ce.Column)
+			where = append(where, "1=0")
+			continue
+		}
+		ident := `"` + strings.ReplaceAll(ce.Column, `"`, `""`) + `"`
+		if ce.IsNull {
+			where = append(where, ident+" IS NULL")
+			continue
+		}
+		// Cast to VARCHAR so string-typed --column-eq values match typed
+		// Parquet columns (int, date, etc.) the same way the binlog index's
+		// JSON_EXTRACT_STRING path does.
+		where = append(where, "CAST("+ident+" AS VARCHAR) = ?")
+		args = append(args, ce.Value)
+	}
+	return where, args
+}
+
+// normalizeSnapshotValue converts DuckDB scan outputs into types that
+// encoding/json can marshal cleanly. Byte slices that aren't valid JSON are
+// stringified; time.Time is formatted MySQL-style; everything else passes
+// through.
+func normalizeSnapshotValue(v any) any {
+	switch x := v.(type) {
+	case []byte:
+		if json.Valid(x) {
+			var decoded any
+			if err := json.Unmarshal(x, &decoded); err == nil {
+				return decoded
+			}
+		}
+		return string(x)
+	case time.Time:
+		return x.UTC().Format("2006-01-02 15:04:05")
+	default:
+		return v
+	}
+}

--- a/internal/query/snapshot.go
+++ b/internal/query/snapshot.go
@@ -18,14 +18,15 @@ import (
 
 	_ "github.com/duckdb/duckdb-go/v2"
 
-	"github.com/dbtrail/bintrail/internal/baseline"
 	"github.com/dbtrail/bintrail/internal/parser"
 )
 
 // snapshotEventIDBase is OR'd with the row index to synthesise a ResultRow
-// EventID that cannot collide with a real binlog event_id (always a binlog
-// byte offset, << 1<<62). MergeResults dedups by event_id, so uniqueness
-// across snapshot rows is enough.
+// EventID high enough that collision with MySQL's AUTO_INCREMENT `event_id`
+// (BIGINT UNSIGNED — see internal/indexer) is effectively impossible in
+// practice: at 2^62 a real index would need to accumulate ~4.6e18 rows to
+// reach this range. MergeResults dedups by event_id, so uniqueness across
+// snapshot rows is enough.
 const snapshotEventIDBase uint64 = 1 << 62
 
 // FetchSnapshot reads a single mydumper baseline Parquet file and returns
@@ -39,32 +40,25 @@ const snapshotEventIDBase uint64 = 1 << 62
 // apply to the baseline's recorded creation timestamp.
 //
 // Returns nil, nil when filters exclude all snapshot rows — this is not an
-// error and callers should proceed with no-snapshot results.
+// error. An slog.Info line is emitted at each exclusion so operators who
+// pass --include-snapshot but see "No results" can tell why.
 func FetchSnapshot(ctx context.Context, path string, opts Options) ([]ResultRow, error) {
-	// Short-circuit: filters that cannot match baseline rows.
 	if opts.EventType != nil && *opts.EventType != parser.EventSnapshot {
+		slog.Info("snapshot source excluded by filter", "reason", "--event-type ≠ SNAPSHOT")
 		return nil, nil
 	}
-	if opts.GTID != "" || opts.ChangedColumn != "" || opts.Flag != "" {
+	if opts.GTID != "" {
+		slog.Info("snapshot source excluded by filter", "reason", "--gtid set (baseline rows carry no GTID)")
 		return nil, nil
 	}
-
-	meta, err := baseline.ReadParquetMetadataAny(ctx, path)
-	if err != nil {
-		return nil, fmt.Errorf("read baseline metadata %s: %w", path, err)
-	}
-	ts, err := readSnapshotTimestamp(ctx, path)
-	if err != nil {
-		return nil, err
-	}
-	// baseline_creation_ts filter per issue #234.
-	if opts.Since != nil && ts.Before(*opts.Since) {
+	if opts.ChangedColumn != "" {
+		slog.Info("snapshot source excluded by filter", "reason", "--changed-column set (baseline rows have no changed-columns metadata)")
 		return nil, nil
 	}
-	if opts.Until != nil && ts.After(*opts.Until) {
+	if opts.Flag != "" {
+		slog.Info("snapshot source excluded by filter", "reason", "--flag set (baseline rows do not carry table_flags)")
 		return nil, nil
 	}
-	_ = meta // reserved for future use (binlog file/pos surfacing)
 
 	db, err := sql.Open("duckdb", "")
 	if err != nil {
@@ -77,9 +71,25 @@ func FetchSnapshot(ctx context.Context, path string, opts Options) ([]ResultRow,
 		}
 	}
 
+	ts, err := readSnapshotTimestamp(ctx, db, path)
+	if err != nil {
+		return nil, err
+	}
+	if opts.Since != nil && ts.Before(*opts.Since) {
+		slog.Info("snapshot source excluded by filter", "reason", "baseline timestamp before --since", "snapshot_ts", ts, "since", *opts.Since)
+		return nil, nil
+	}
+	if opts.Until != nil && ts.After(*opts.Until) {
+		slog.Info("snapshot source excluded by filter", "reason", "baseline timestamp after --until", "snapshot_ts", ts, "until", *opts.Until)
+		return nil, nil
+	}
+
+	where, args, err := snapshotFilters(opts)
+	if err != nil {
+		return nil, err
+	}
 	safePath := strings.ReplaceAll(path, "'", "''")
 	q := "SELECT * FROM parquet_scan('" + safePath + "')"
-	where, args := snapshotFilters(opts)
 	if len(where) > 0 {
 		q += " WHERE " + strings.Join(where, " AND ")
 	}
@@ -101,6 +111,9 @@ func FetchSnapshot(ctx context.Context, path string, opts Options) ([]ResultRow,
 	var results []ResultRow
 	idx := uint64(0)
 	for rows.Next() {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		vals := make([]any, len(cols))
 		ptrs := make([]any, len(cols))
 		for i := range vals {
@@ -130,19 +143,10 @@ func FetchSnapshot(ctx context.Context, path string, opts Options) ([]ResultRow,
 }
 
 // readSnapshotTimestamp extracts bintrail.snapshot_timestamp from the Parquet
-// file metadata. Returns a non-nil error when the file lacks the key — the
-// caller cannot apply the --since/--until filter without it.
-func readSnapshotTimestamp(ctx context.Context, path string) (time.Time, error) {
-	db, err := sql.Open("duckdb", "")
-	if err != nil {
-		return time.Time{}, fmt.Errorf("open duckdb: %w", err)
-	}
-	defer db.Close()
-	if strings.HasPrefix(path, "s3://") {
-		if _, err := db.ExecContext(ctx, "INSTALL httpfs; LOAD httpfs;"); err != nil {
-			return time.Time{}, fmt.Errorf("load httpfs: %w", err)
-		}
-	}
+// file metadata using the shared db handle. Returns a non-nil error when the
+// file lacks the key — the caller cannot apply the --since/--until filter
+// without it.
+func readSnapshotTimestamp(ctx context.Context, db *sql.DB, path string) (time.Time, error) {
 	safePath := strings.ReplaceAll(path, "'", "''")
 	rows, err := db.QueryContext(ctx, "SELECT key, value FROM parquet_kv_metadata('"+safePath+"')")
 	if err != nil {
@@ -169,17 +173,21 @@ func readSnapshotTimestamp(ctx context.Context, path string) (time.Time, error) 
 	return time.Time{}, fmt.Errorf("baseline %s missing bintrail.snapshot_timestamp metadata — re-run `bintrail baseline`", path)
 }
 
-// snapshotFilters returns WHERE fragments and bind args matching opts.ColumnEq
-// and opts.PKValues/PKValuesIn. Schema/table/since/until are not applied here
-// (they are validated against the baseline itself before the query runs).
-func snapshotFilters(opts Options) ([]string, []any) {
+// snapshotFilters returns WHERE fragments and bind args matching opts.ColumnEq.
+// PKValues/PKValuesIn are NOT applied here — this PR does not build PK_values
+// for snapshot rows, and combining --pk/--pks with --include-snapshot is
+// rejected at the CLI validation layer. Schema/table/since/until are handled
+// against the baseline's own metadata before the query runs.
+//
+// A ColumnEq entry whose column fails IsSafeColumnName returns an error —
+// emitting a silent "1=0" clause would leave the operator seeing "No results"
+// with a reason that's only in structured logs.
+func snapshotFilters(opts Options) ([]string, []any, error) {
 	var where []string
 	var args []any
 	for _, ce := range opts.ColumnEq {
 		if !IsSafeColumnName(ce.Column) {
-			slog.Error("snapshot: rejected unsafe column name; emitting no-match clause", "column", ce.Column)
-			where = append(where, "1=0")
-			continue
+			return nil, nil, fmt.Errorf("snapshot: unsafe column name %q in --column-eq; must match [A-Za-z_][A-Za-z0-9_]*", ce.Column)
 		}
 		ident := `"` + strings.ReplaceAll(ce.Column, `"`, `""`) + `"`
 		if ce.IsNull {
@@ -188,21 +196,24 @@ func snapshotFilters(opts Options) ([]string, []any) {
 		}
 		// Cast to VARCHAR so string-typed --column-eq values match typed
 		// Parquet columns (int, date, etc.) the same way the binlog index's
-		// JSON_EXTRACT_STRING path does.
+		// JSON_UNQUOTE(JSON_EXTRACT(...)) path coerces stored values to
+		// strings before comparison.
 		where = append(where, "CAST("+ident+" AS VARCHAR) = ?")
 		args = append(args, ce.Value)
 	}
-	return where, args
+	return where, args, nil
 }
 
 // normalizeSnapshotValue converts DuckDB scan outputs into types that
-// encoding/json can marshal cleanly. Byte slices that aren't valid JSON are
-// stringified; time.Time is formatted MySQL-style; everything else passes
-// through.
+// encoding/json can marshal cleanly. Byte slices are parsed as JSON only when
+// the payload's first non-whitespace byte is '{' or '[' — this avoids silently
+// promoting a TEXT column containing the literal "null" to Go nil, or "123"
+// to a number, which would diverge from the binlog index's string-preserving
+// storage. time.Time is formatted MySQL-style; everything else passes through.
 func normalizeSnapshotValue(v any) any {
 	switch x := v.(type) {
 	case []byte:
-		if json.Valid(x) {
+		if looksLikeJSONContainer(x) && json.Valid(x) {
 			var decoded any
 			if err := json.Unmarshal(x, &decoded); err == nil {
 				return decoded
@@ -214,4 +225,22 @@ func normalizeSnapshotValue(v any) any {
 	default:
 		return v
 	}
+}
+
+// looksLikeJSONContainer reports whether b's first non-whitespace byte is
+// '{' or '[' — a cheap prefix test that distinguishes JSON object/array
+// payloads (which MySQL stores in JSON columns) from bare string/numeric
+// literals that json.Valid would also accept.
+func looksLikeJSONContainer(b []byte) bool {
+	for _, c := range b {
+		switch c {
+		case ' ', '\t', '\n', '\r':
+			continue
+		case '{', '[':
+			return true
+		default:
+			return false
+		}
+	}
+	return false
 }

--- a/internal/query/snapshot_test.go
+++ b/internal/query/snapshot_test.go
@@ -1,0 +1,143 @@
+package query
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/bintrail/internal/parser"
+)
+
+// TestSnapshotFilters_columnEq pins the WHERE shape: typed Parquet columns are
+// compared via CAST(... AS VARCHAR) = ? so the binlog index's
+// JSON_UNQUOTE(JSON_EXTRACT(...)) string-coercion parity is preserved.
+func TestSnapshotFilters_columnEq(t *testing.T) {
+	opts := Options{
+		ColumnEq: []ColumnEq{{Column: "status", Value: "active"}},
+	}
+	where, args, err := snapshotFilters(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(where) != 1 {
+		t.Fatalf("expected 1 WHERE clause, got %d: %v", len(where), where)
+	}
+	if !strings.Contains(where[0], `CAST("status" AS VARCHAR) = ?`) {
+		t.Errorf("expected CAST-based predicate; got %q", where[0])
+	}
+	if len(args) != 1 || args[0] != "active" {
+		t.Errorf("expected single bind arg \"active\"; got %v", args)
+	}
+}
+
+// TestSnapshotFilters_isNull pins the NULL path: emits IS NULL with no bind arg.
+func TestSnapshotFilters_isNull(t *testing.T) {
+	opts := Options{
+		ColumnEq: []ColumnEq{{Column: "deleted_at", IsNull: true}},
+	}
+	where, args, err := snapshotFilters(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(where) != 1 || !strings.Contains(where[0], "IS NULL") {
+		t.Errorf("expected IS NULL predicate; got %v", where)
+	}
+	if len(args) != 0 {
+		t.Errorf("expected no bind args for IS NULL; got %v", args)
+	}
+}
+
+// TestSnapshotFilters_unsafeColumnNameHardErrors pins the "hard error, not
+// silent 1=0" contract: a column name that fails the allowlist must raise a
+// visible error rather than silently returning zero rows. The CLI user runs
+// `--format table` and would otherwise see "No results" with the rejection
+// only in structured logs.
+func TestSnapshotFilters_unsafeColumnNameHardErrors(t *testing.T) {
+	opts := Options{
+		ColumnEq: []ColumnEq{{Column: "x;DROP", Value: "v"}},
+	}
+	_, _, err := snapshotFilters(opts)
+	if err == nil {
+		t.Fatal("expected hard error for unsafe column name")
+	}
+	if !strings.Contains(err.Error(), "unsafe column name") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+// TestSnapshotEventIDBase_aboveRealEventIDs documents the invariant that the
+// synthetic event-id base sits far above any realistic binlog event_id. The
+// indexer assigns event_ids via AUTO_INCREMENT BIGINT UNSIGNED, so in practice
+// values never come near 2^62. A failure here means someone lowered the
+// constant — reconsider MergeResults dedup safety before doing so.
+func TestSnapshotEventIDBase_aboveRealEventIDs(t *testing.T) {
+	if snapshotEventIDBase <= 1<<48 {
+		t.Errorf("snapshotEventIDBase=%d must be > 1<<48 to safely avoid collision with AUTO_INCREMENT event_ids", snapshotEventIDBase)
+	}
+}
+
+// TestLooksLikeJSONContainer guards the narrowed JSON promotion rule: only
+// object/array payloads are parsed as JSON. Bare "null", bare strings, and
+// bare numbers stay as strings so a TEXT column's literal "null" doesn't
+// silently disappear as Go nil.
+func TestLooksLikeJSONContainer(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{`{"a":1}`, true},
+		{`[1,2,3]`, true},
+		{`  {"a":1}`, true},
+		{`null`, false},
+		{`"foo"`, false},
+		{`123`, false},
+		{``, false},
+	}
+	for _, tc := range cases {
+		if got := looksLikeJSONContainer([]byte(tc.in)); got != tc.want {
+			t.Errorf("looksLikeJSONContainer(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestNormalizeSnapshotValue_bareJSONLiteralStaysString documents the
+// regression fix: DuckDB may return a VARCHAR column containing "null" or "123"
+// as []byte. Earlier revisions promoted these via json.Valid + Unmarshal,
+// which silently dropped the literal string into Go nil or a number. The
+// narrowed rule preserves the original string representation.
+func TestNormalizeSnapshotValue_bareJSONLiteralStaysString(t *testing.T) {
+	if got := normalizeSnapshotValue([]byte("null")); got != "null" {
+		t.Errorf("normalizeSnapshotValue(\"null\") = %v (%T), want \"null\" (string)", got, got)
+	}
+	if got := normalizeSnapshotValue([]byte(`"hello"`)); got != `"hello"` {
+		t.Errorf("normalizeSnapshotValue(quoted string) = %v, want verbatim passthrough", got)
+	}
+	if got := normalizeSnapshotValue([]byte("123")); got != "123" {
+		t.Errorf("normalizeSnapshotValue(\"123\") = %v (%T), want \"123\" (string)", got, got)
+	}
+}
+
+// TestNormalizeSnapshotValue_jsonContainerParses verifies that genuine JSON
+// object/array payloads (as MySQL stores in JSON columns) are still decoded
+// into map/slice so downstream JSON formatters don't double-escape them.
+func TestNormalizeSnapshotValue_jsonContainerParses(t *testing.T) {
+	got := normalizeSnapshotValue([]byte(`{"status":"open"}`))
+	m, ok := got.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map from JSON object payload; got %T", got)
+	}
+	if m["status"] != "open" {
+		t.Errorf("expected {status:open}; got %v", m)
+	}
+}
+
+// TestEventSnapshot_notParsed sanity-checks that EventSnapshot is distinct
+// from every real parser-emitted event type. A regression where the parser
+// starts producing EventSnapshot would leak synthetic rows into the indexer
+// pipeline.
+func TestEventSnapshot_notParsed(t *testing.T) {
+	for _, parsed := range []parser.EventType{parser.EventInsert, parser.EventUpdate, parser.EventDelete, parser.EventDDL, parser.EventGTID} {
+		if parsed == parser.EventSnapshot {
+			t.Errorf("EventSnapshot must not overlap with parser-emitted type %d", parsed)
+		}
+	}
+}

--- a/internal/query/snapshot_test.go
+++ b/internal/query/snapshot_test.go
@@ -3,6 +3,7 @@ package query
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/dbtrail/bintrail/internal/parser"
 )
@@ -164,6 +165,21 @@ func TestNormalizeSnapshotValue_jsonContainerParses(t *testing.T) {
 	}
 	if m["status"] != "open" {
 		t.Errorf("expected {status:open}; got %v", m)
+	}
+}
+
+// TestNormalizeSnapshotValue_timeFormatsUTC pins the UTC formatting contract:
+// TIMESTAMP/DATETIME columns scanned as time.Time must render as
+// "2006-01-02 15:04:05" UTC. A silent regression to time.Local (see the
+// earlier ParseTime UTC bug) would ship timezone-shifted strings in JSON
+// output.
+func TestNormalizeSnapshotValue_timeFormatsUTC(t *testing.T) {
+	// Non-UTC input should still format as UTC.
+	loc := time.FixedZone("UTC-5", -5*3600)
+	in := time.Date(2026, 4, 15, 13, 30, 45, 0, loc)
+	got := normalizeSnapshotValue(in)
+	if got != "2026-04-15 18:30:45" {
+		t.Errorf("normalizeSnapshotValue(non-UTC time) = %v, want \"2026-04-15 18:30:45\" (UTC-adjusted)", got)
 	}
 }
 

--- a/internal/query/snapshot_test.go
+++ b/internal/query/snapshot_test.go
@@ -7,6 +7,43 @@ import (
 	"github.com/dbtrail/bintrail/internal/parser"
 )
 
+// TestShouldSkipSnapshot is the unit-level truth table for the four always-
+// excluder filters. The DuckDB-backed FetchSnapshot path is integration-only,
+// but these branches are pure logic — this test pins them without needing a
+// real Parquet file.
+func TestShouldSkipSnapshot(t *testing.T) {
+	snapshotET := parser.EventSnapshot
+	insertET := parser.EventInsert
+
+	cases := []struct {
+		name       string
+		opts       Options
+		wantSkip   bool
+		wantReason string
+	}{
+		{"happy path — no excluders", Options{}, false, ""},
+		{"event-type SNAPSHOT keeps source", Options{EventType: &snapshotET}, false, ""},
+		{"event-type INSERT excludes", Options{EventType: &insertET}, true, "--event-type"},
+		{"gtid set excludes", Options{GTID: "uuid:42"}, true, "--gtid"},
+		{"changed-column excludes", Options{ChangedColumn: "status"}, true, "--changed-column"},
+		{"flag excludes", Options{Flag: "pii"}, true, "--flag"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reason, skip := shouldSkipSnapshot(tc.opts)
+			if skip != tc.wantSkip {
+				t.Fatalf("skip = %v, want %v (reason=%q)", skip, tc.wantSkip, reason)
+			}
+			if tc.wantSkip && !strings.Contains(reason, tc.wantReason) {
+				t.Errorf("reason = %q, want substring %q", reason, tc.wantReason)
+			}
+			if !tc.wantSkip && reason != "" {
+				t.Errorf("expected empty reason when not skipping; got %q", reason)
+			}
+		})
+	}
+}
+
 // TestSnapshotFilters_columnEq pins the WHERE shape: typed Parquet columns are
 // compared via CAST(... AS VARCHAR) = ? so the binlog index's
 // JSON_UNQUOTE(JSON_EXTRACT(...)) string-coercion parity is preserved.

--- a/internal/recovery/recovery.go
+++ b/internal/recovery/recovery.go
@@ -143,6 +143,13 @@ func (g *Generator) generateStatement(row query.ResultRow) (string, error) {
 		return g.generateUpdate(row) // UPDATE → reverse UPDATE (restore before state)
 	case parser.EventInsert:
 		return g.generateDelete(row) // INSERT → DELETE (remove the inserted row)
+	case parser.EventSnapshot:
+		// Snapshot rows are read-only baseline state, not change events, so
+		// reversal SQL is undefined for them. Reject with a clear message
+		// instead of falling through to the generic "unknown event type"
+		// error — this path is only reachable if future code wires snapshots
+		// into the recover pipeline.
+		return "", fmt.Errorf("cannot generate reversal SQL for SNAPSHOT event %d (baseline rows are read-only)", row.EventID)
 	default:
 		return "", fmt.Errorf("unknown event type %d", row.EventType)
 	}

--- a/internal/recovery/recovery_test.go
+++ b/internal/recovery/recovery_test.go
@@ -292,6 +292,33 @@ func TestGenerateSQL_noRows(t *testing.T) {
 	assertSQL(t, out, "COMMIT;")
 }
 
+// TestGenerateStatement_snapshotRejected pins the defense-in-depth guard:
+// if a ResultRow with EventType=EventSnapshot ever reaches the reversal
+// generator, the error message must be specific ("read-only baseline rows")
+// rather than the generic "unknown event type N" fallback. Future code that
+// wires snapshot rows into the recover pipeline will fail loudly.
+func TestGenerateStatement_snapshotRejected(t *testing.T) {
+	g := newGen()
+	row := query.ResultRow{
+		EventID:    99,
+		SchemaName: "db",
+		TableName:  "tbl",
+		EventType:  parser.EventSnapshot,
+		PKValues:   "1",
+		RowAfter:   map[string]any{"id": float64(1)},
+	}
+	_, err := g.generateStatement(row)
+	if err == nil {
+		t.Fatal("expected error for SNAPSHOT event; got nil")
+	}
+	if !strings.Contains(err.Error(), "SNAPSHOT") {
+		t.Errorf("error should mention SNAPSHOT explicitly (not the generic fallback); got %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "read-only") {
+		t.Errorf("error should explain baseline rows are read-only; got %q", err.Error())
+	}
+}
+
 // ─── Null / special value handling ───────────────────────────────────────────
 
 func TestFormatValue_nullInRow(t *testing.T) {


### PR DESCRIPTION
closes #234

## Summary
- New `--include-snapshot` + `--baseline` flags on `bintrail query` that scan a mydumper baseline Parquet via DuckDB and emit matching rows as synthetic `SNAPSHOT` events (new `parser.EventSnapshot = 6`).
- Snapshot rows flow through the existing `MergeAndTrim` pipeline alongside live-MySQL + archive events, keyed by the baseline's `bintrail.snapshot_timestamp` metadata.
- Filter semantics match the issue: `--column-eq` hits the typed Parquet column (no JSON_EXTRACT); `--event-type ≠ SNAPSHOT`, `--gtid`, `--changed-column`, `--flag` all exclude snapshot rows; `--since`/`--until` compare against the baseline timestamp.
- Unblocks the dbtrail SaaS Phase 2 FK-aware cascade victim reconstruction for rows that existed before streaming began (no binlog events to scan).

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)
- [ ] Smoke: `bintrail query --index-dsn … --schema mydb --table orders --include-snapshot --baseline /data/baselines/<ts>  --column-eq customer_id=42` returns both baseline and binlog rows merged, sorted by timestamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)