### PR TITLE
release: attach dbtrail-shim binaries to GitHub releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,3 +37,22 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Attach dbtrail-shim binaries to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHIM_VERSION: ${{ github.ref_name }}
+          SHIM_BUCKET_URL: https://my-bintrail-archives.s3.amazonaws.com/binary
+        run: |
+          set -euo pipefail
+          mkdir -p shim-dist
+          for target in linux_amd64 linux_arm64 darwin_amd64 darwin_arm64; do
+            src="dbtrail-shim_${SHIM_VERSION}_${target}"
+            dst="shim-dist/dbtrail-shim-${target/_/-}"
+            echo "Downloading ${SHIM_BUCKET_URL}/${src}"
+            curl --fail --silent --show-error --location \
+              --output "${dst}" \
+              "${SHIM_BUCKET_URL}/${src}"
+            chmod +x "${dst}"
+          done
+          gh release upload "${SHIM_VERSION}" shim-dist/dbtrail-shim-*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,18 +41,26 @@ jobs:
       - name: Attach dbtrail-shim binaries to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SHIM_VERSION: ${{ github.ref_name }}
+          RELEASE_TAG: ${{ github.ref_name }}
           SHIM_BUCKET_URL: https://my-bintrail-archives.s3.amazonaws.com/binary
         run: |
           set -euo pipefail
+          shim_version="${RELEASE_TAG#v}"
           mkdir -p shim-dist
           for target in linux_amd64 linux_arm64 darwin_amd64 darwin_arm64; do
-            src="dbtrail-shim_${SHIM_VERSION}_${target}"
+            src="dbtrail-shim_${shim_version}_${target}"
             dst="shim-dist/dbtrail-shim-${target/_/-}"
             echo "Downloading ${SHIM_BUCKET_URL}/${src}"
             curl --fail --silent --show-error --location \
+              --connect-timeout 10 --max-time 120 \
+              --retry 3 --retry-delay 2 \
               --output "${dst}" \
               "${SHIM_BUCKET_URL}/${src}"
             chmod +x "${dst}"
           done
-          gh release upload "${SHIM_VERSION}" shim-dist/dbtrail-shim-*
+          count=$(find shim-dist -name 'dbtrail-shim-*' -type f | wc -l)
+          if [ "${count}" -ne 4 ]; then
+            echo "expected 4 shim binaries, found ${count}" >&2
+            exit 1
+          fi
+          gh release upload "${RELEASE_TAG}" shim-dist/dbtrail-shim-* --clobber

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- GitHub releases now include `dbtrail-shim` binaries (`dbtrail-shim-linux-amd64`, `dbtrail-shim-linux-arm64`, `dbtrail-shim-darwin-amd64`, `dbtrail-shim-darwin-arm64`) alongside the existing bintrail archives. The shim enables BYOS time-travel SQL via ProxySQL routing; binaries are pulled from the canonical SaaS build pipeline and re-published as release assets, so customers can `curl -LO https://github.com/dbtrail/bintrail/releases/latest/download/dbtrail-shim-linux-amd64` (#236).
+
 ## [0.5.8] - 2026-04-15
 
 ### Added


### PR DESCRIPTION
closes #236

## Summary
- Adds a post-GoReleaser step that pulls the four `dbtrail-shim` binaries (linux/darwin × amd64/arm64) from the canonical SaaS S3 build location (`my-bintrail-archives/binary/dbtrail-shim_<tag>_<os>_<arch>`) and re-uploads them as release assets via `gh release upload`.
- Renames on the way in: bucket uses underscores (`linux_amd64`), release assets use the issue's hyphenated form (`dbtrail-shim-linux-amd64`), so the documented `releases/latest/download/dbtrail-shim-linux-amd64` URL works.
- Step runs *after* GoReleaser, so a missing shim binary fails the workflow loudly without disturbing the bintrail archives that have already been published.
- CHANGELOG `[Unreleased]` entry added; no `.goreleaser.yaml` changes (zero risk of breaking existing builds).

## Design notes
- **Option B from the issue (pull from S3)** — avoids cross-repo source coupling and keeps the SaaS pipeline as the single canonical shim build.
- Shim version defaults to the bintrail release tag (`${{ github.ref_name }}`). If a tag is cut without a matching shim build in S3, `curl --fail` errors out with a clear 404; the bintrail release itself is unaffected.
- Bucket assumed public (symmetric with how bintrail binaries are distributed today). If it turns out to be private, swap the `curl` for `aws s3 cp` + `aws-actions/configure-aws-credentials`.
- README intentionally untouched: linking to the not-yet-existing `docs/byos-time-travel-sql.md` (#239) would create a broken link. The doc PR can add the README pointer.

## Test plan
- [x] `go test ./... -count=1` passes (no Go code changed; sanity check)
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` parses the workflow
- [ ] Real validation only happens on the next `v*` tag push: confirm the four assets appear on the GitHub release and `curl -LO https://github.com/dbtrail/bintrail/releases/latest/download/dbtrail-shim-linux-amd64` returns a working binary that prints a version with `--version`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)