### PR TITLE
cmd: add `bintrail proxysql-config` to scaffold ProxySQL setup SQL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,8 +64,9 @@ Per-command `--format`: most commands accept `text`/`json` (`IsValidOutputFormat
 | `agent` | `agent.go` | `--api-key` (req), `--endpoint` (req), `--index-dsn`, `--source-dsn`, `--archive-dir`, `--archive-s3`, `--server-id`, `--buffer-retain` (default `6h`), `--buffer-max-events` (default `0`), `--buffer-max-bytes` (default `0`), `--batch-size`, `--schemas`, `--tables`, `--start-gtid`, `--s3-bucket`, `--s3-region`, `--s3-prefix` (default `bintrail/`), `--flush-interval` (default `5s`), `--max-reconnect-attempts` (default `10`), `--validate` |
 | `config init` | `config.go` | `--global` |
 | `init-shim` | `init_shim.go` | `--out` (default `shim.yaml`, `-` for stdout), `--listen` (default `:3308`), `--agent-url` (default `http://localhost:8600`); reads `BINTRAIL_SOURCE_DSN`, `BINTRAIL_SERVER_ID`, `BINTRAIL_API_KEY` |
+| `proxysql-config` | `proxysql_config.go` | `--out` (default `proxysql-setup.sql`, `-` for stdout), `--shim-config` (default `shim.yaml`), `--mysql-port` (default `3306`), `--shim-port` (default `3308`), `--proxysql-mysql-port` (default `6033`); reads `BINTRAIL_SOURCE_DSN` and shim.yaml; outputs SQL using hostgroups 990/991 and rule_ids 990001-990003 |
 
-Flag variable naming: prefixed by command abbreviation (e.g. `idxIndexDSN`, `qSchema`, `rDryRun`, `rotRetain`, `strmIndexDSN`, `dmpSourceDSN`, `bslInput`, `uplSource`, `cfgGlobal`, `agtAPIKey`, `isOut`).
+Flag variable naming: prefixed by command abbreviation (e.g. `idxIndexDSN`, `qSchema`, `rDryRun`, `rotRetain`, `strmIndexDSN`, `dmpSourceDSN`, `bslInput`, `uplSource`, `cfgGlobal`, `agtAPIKey`, `isOut`, `pcOut`).
 
 ### Environment file loading
 

--- a/cmd/bintrail/proxysql_config.go
+++ b/cmd/bintrail/proxysql_config.go
@@ -4,9 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"strconv"
 	"strings"
+	"unicode"
 
 	drivermysql "github.com/go-sql-driver/mysql"
 	"github.com/spf13/cobra"
@@ -59,15 +61,22 @@ func init() {
 	rootCmd.AddCommand(proxysqlConfigCmd)
 }
 
-// shimTenant is the subset of a shim.yaml tenant block this command
-// needs. Unknown fields are ignored so the shim can extend its schema
-// without breaking us.
+// shimTenant declares every field bintrail init-shim emits in a tenant
+// block. The strict YAML decoder used by loadShimTenants requires the
+// struct to know about every key — so we declare ServerID, SourceDSN,
+// AgentURL, and AgentToken (which proxysql-config does not need) just to
+// satisfy strict mode and let it catch real typos like "mysql_user_name".
 type shimTenant struct {
+	ServerID      string `yaml:"server_id"`
+	SourceDSN     string `yaml:"source_dsn"`
+	AgentURL      string `yaml:"agent_url"`
+	AgentToken    string `yaml:"agent_token"`
 	MySQLUser     string `yaml:"mysql_user"`
 	MySQLPassSHA1 string `yaml:"mysql_pass_sha1"`
 }
 
 type shimConfig struct {
+	Listen  string       `yaml:"listen"`
 	Tenants []shimTenant `yaml:"tenants"`
 }
 
@@ -75,6 +84,18 @@ func runProxySQLConfig(cmd *cobra.Command, args []string) error {
 	sourceDSN := os.Getenv("BINTRAIL_SOURCE_DSN")
 	if sourceDSN == "" {
 		return fmt.Errorf("missing required env var: BINTRAIL_SOURCE_DSN\nRun 'bintrail config init' to scaffold .bintrail.env, then set this value.")
+	}
+	for _, p := range []struct {
+		name string
+		val  uint
+	}{
+		{"--mysql-port", pcMySQLPort},
+		{"--shim-port", pcShimPort},
+		{"--proxysql-mysql-port", pcProxySQLMySQLPort},
+	} {
+		if p.val == 0 || p.val > 65535 {
+			return fmt.Errorf("%s=%d is out of range (1..65535)", p.name, p.val)
+		}
 	}
 
 	host, port, err := parseProxySQLBackend(sourceDSN, uint16(pcMySQLPort))
@@ -94,14 +115,22 @@ func runProxySQLConfig(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if _, err := os.Stat(pcOut); err == nil {
-		return fmt.Errorf("file already exists: %s\nRemove it first or edit it directly.", pcOut)
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("cannot check %s: %w", pcOut, err)
+	// O_EXCL closes the stat-then-write TOCTOU window: if the file
+	// appears between our check and write, OpenFile errors out instead
+	// of silently overwriting.
+	f, err := os.OpenFile(pcOut, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return fmt.Errorf("file already exists: %s\nRemove it first or edit it directly.", pcOut)
+		}
+		return fmt.Errorf("create %s: %w", pcOut, err)
 	}
-
-	if err := os.WriteFile(pcOut, []byte(content), 0o600); err != nil {
+	if _, err := f.WriteString(content); err != nil {
+		f.Close()
 		return fmt.Errorf("write %s: %w", pcOut, err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close %s: %w", pcOut, err)
 	}
 
 	fmt.Printf("ProxySQL setup SQL written to %s\n", pcOut)
@@ -110,7 +139,9 @@ func runProxySQLConfig(cmd *cobra.Command, args []string) error {
 }
 
 // parseProxySQLBackend extracts the host and port from a go-sql-driver
-// DSN. If the DSN address has no port, fallbackPort is used.
+// DSN. Uses net.SplitHostPort so bracketed IPv6 addresses ("[::1]:3306")
+// are handled correctly. If the DSN address has no port, fallbackPort
+// is used; an empty host is rejected.
 func parseProxySQLBackend(dsn string, fallbackPort uint16) (host string, port uint16, err error) {
 	cfg, parseErr := drivermysql.ParseDSN(dsn)
 	if parseErr != nil {
@@ -123,16 +154,24 @@ func parseProxySQLBackend(dsn string, fallbackPort uint16) (host string, port ui
 	if addr == "" {
 		return "", 0, fmt.Errorf("BINTRAIL_SOURCE_DSN has no address")
 	}
-	idx := strings.LastIndex(addr, ":")
-	if idx < 0 {
-		return addr, fallbackPort, nil
+	h, p, splitErr := net.SplitHostPort(addr)
+	if splitErr != nil {
+		// No port in addr — treat the whole thing as host (and reject if it
+		// itself looks like a bracketed IPv6 with no port: "[::1]").
+		h = strings.Trim(addr, "[]")
+		p = ""
 	}
-	h := addr[:idx]
-	p, convErr := strconv.ParseUint(addr[idx+1:], 10, 16)
+	if h == "" {
+		return "", 0, fmt.Errorf("BINTRAIL_SOURCE_DSN has an empty host: %q", addr)
+	}
+	if p == "" {
+		return h, fallbackPort, nil
+	}
+	portN, convErr := strconv.ParseUint(p, 10, 16)
 	if convErr != nil {
 		return "", 0, fmt.Errorf("invalid port in BINTRAIL_SOURCE_DSN: %w", convErr)
 	}
-	return h, uint16(p), nil
+	return h, uint16(portN), nil
 }
 
 // loadShimTenants reads shim.yaml from path, validates each tenant has
@@ -147,7 +186,10 @@ func loadShimTenants(path string) ([]shimTenant, error) {
 		return nil, fmt.Errorf("read %s: %w", path, err)
 	}
 	var cfg shimConfig
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
+	// Strict mode rejects unknown YAML keys so a typo like "mysql_user_name:"
+	// surfaces as a clear parse error rather than silently parsing as an
+	// empty mysql_user.
+	if err := yaml.UnmarshalStrict(data, &cfg); err != nil {
 		return nil, fmt.Errorf("parse %s: %w", path, err)
 	}
 	if len(cfg.Tenants) == 0 {
@@ -160,14 +202,27 @@ func loadShimTenants(path string) ([]shimTenant, error) {
 		if t.MySQLPassSHA1 == "" {
 			return nil, fmt.Errorf("%s tenant #%d: mysql_pass_sha1 is empty (uncomment and fill in the TODO line)", path, i+1)
 		}
-		if strings.ContainsAny(t.MySQLUser, "\r\n") {
-			return nil, fmt.Errorf("%s tenant #%d: mysql_user contains a newline character", path, i+1)
+		if r := firstControlRune(t.MySQLUser); r >= 0 {
+			return nil, fmt.Errorf("%s tenant #%d: mysql_user contains control character U+%04X", path, i+1, r)
 		}
-		if strings.ContainsAny(t.MySQLPassSHA1, "\r\n") {
-			return nil, fmt.Errorf("%s tenant #%d: mysql_pass_sha1 contains a newline character", path, i+1)
+		if r := firstControlRune(t.MySQLPassSHA1); r >= 0 {
+			return nil, fmt.Errorf("%s tenant #%d: mysql_pass_sha1 contains control character U+%04X", path, i+1, r)
 		}
 	}
 	return cfg.Tenants, nil
+}
+
+// firstControlRune returns the first control rune in s (per
+// unicode.IsControl), or -1 if none. Control characters in tenant
+// credentials are rejected because they corrupt the SQL output:
+// sqlQuote only escapes ', not '\n', '\t', '\0', etc.
+func firstControlRune(s string) rune {
+	for _, r := range s {
+		if unicode.IsControl(r) {
+			return r
+		}
+	}
+	return -1
 }
 
 func generateProxySQLSetupSQL(host string, mysqlPort, shimPort, proxysqlMySQLPort uint16, tenants []shimTenant) string {
@@ -188,12 +243,25 @@ func generateProxySQLSetupSQL(host string, mysqlPort, shimPort, proxysqlMySQLPor
 	sb.WriteString("-- Re-running this script is idempotent.\n")
 	sb.WriteString("\n")
 
+	// Wrap the table edits in a transaction so a partial failure (e.g. a
+	// constraint violation on one INSERT) rolls back the whole change set.
+	// LOAD/SAVE statements are admin commands rather than DML and are
+	// emitted after the COMMIT.
+	sb.WriteString("BEGIN;\n")
+	sb.WriteString("\n")
+
 	fmt.Fprintf(&sb, "DELETE FROM mysql_servers WHERE hostgroup_id IN (%d, %d);\n", passthroughHostgroup, shimHostgroup)
 	fmt.Fprintf(&sb, "INSERT INTO mysql_servers (hostgroup_id, hostname, port) VALUES (%d, %s, %d);\n", passthroughHostgroup, sqlQuote(host), mysqlPort)
 	fmt.Fprintf(&sb, "INSERT INTO mysql_servers (hostgroup_id, hostname, port) VALUES (%d, '127.0.0.1', %d);\n", shimHostgroup, shimPort)
 	sb.WriteString("\n")
 
-	sb.WriteString("DELETE FROM mysql_users WHERE username IN (")
+	// DELETE clauses union (default_hostgroup match) with (current usernames):
+	// the hostgroup match cleans rows from a previous run whose username has
+	// since been renamed in shim.yaml; the username match keeps deletion
+	// scoped to bintrail-owned rows when an operator has shared a username
+	// across hostgroups (rare).
+	sb.WriteString("DELETE FROM mysql_users WHERE default_hostgroup = ")
+	fmt.Fprintf(&sb, "%d OR username IN (", passthroughHostgroup)
 	for i, t := range tenants {
 		if i > 0 {
 			sb.WriteString(", ")
@@ -211,6 +279,9 @@ func generateProxySQLSetupSQL(host string, mysqlPort, shimPort, proxysqlMySQLPor
 	fmt.Fprintf(&sb, "INSERT INTO mysql_query_rules (rule_id, active, match_pattern, destination_hostgroup, apply) VALUES (%d, 1, '\\b_flashback\\.', %d, 1);\n", ruleIDFlashback, shimHostgroup)
 	fmt.Fprintf(&sb, "INSERT INTO mysql_query_rules (rule_id, active, match_pattern, destination_hostgroup, apply) VALUES (%d, 1, '\\b_diff\\.', %d, 1);\n", ruleIDDiff, shimHostgroup)
 	fmt.Fprintf(&sb, "INSERT INTO mysql_query_rules (rule_id, active, match_pattern, destination_hostgroup, apply) VALUES (%d, 1, '\\b_snapshot\\.', %d, 1);\n", ruleIDSnapshot, shimHostgroup)
+	sb.WriteString("\n")
+
+	sb.WriteString("COMMIT;\n")
 	sb.WriteString("\n")
 
 	sb.WriteString("LOAD MYSQL SERVERS TO RUNTIME;\n")

--- a/cmd/bintrail/proxysql_config.go
+++ b/cmd/bintrail/proxysql_config.go
@@ -1,0 +1,231 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	drivermysql "github.com/go-sql-driver/mysql"
+	"github.com/spf13/cobra"
+	yaml "go.yaml.in/yaml/v2"
+)
+
+// Hostgroups and rule IDs are placed in the 990* range so they are
+// extremely unlikely to collide with operator-managed ProxySQL config.
+// The DELETE-then-INSERT pattern in the generated SQL only touches
+// rows in this range plus the named tenant users.
+const (
+	passthroughHostgroup = 990
+	shimHostgroup        = 991
+	ruleIDFlashback      = 990001
+	ruleIDDiff           = 990002
+	ruleIDSnapshot       = 990003
+)
+
+var proxysqlConfigCmd = &cobra.Command{
+	Use:   "proxysql-config",
+	Short: "Generate ProxySQL setup SQL from .bintrail.env and shim.yaml",
+	Long: `Emits a SQL script that, when applied to a ProxySQL admin port (default
+6032), configures ProxySQL to route _flashback / _diff / _snapshot virtual
+schemas to the dbtrail-shim hostgroup and everything else to the customer's
+real MySQL.
+
+Reads BINTRAIL_SOURCE_DSN from .bintrail.env (host of the passthrough
+backend) and shim.yaml (tenant credentials). The SQL is idempotent —
+re-running it produces the same final state.
+
+Use --out - to write to stdout instead of a file.`,
+	RunE: runProxySQLConfig,
+}
+
+var (
+	pcOut               string
+	pcShimConfig        string
+	pcMySQLPort         uint
+	pcShimPort          uint
+	pcProxySQLMySQLPort uint
+)
+
+func init() {
+	proxysqlConfigCmd.Flags().StringVar(&pcOut, "out", "proxysql-setup.sql", "Output path for the generated SQL (use - for stdout)")
+	proxysqlConfigCmd.Flags().StringVar(&pcShimConfig, "shim-config", "shim.yaml", "Path to the shim.yaml produced by 'bintrail init-shim' and edited by you")
+	proxysqlConfigCmd.Flags().UintVar(&pcMySQLPort, "mysql-port", 3306, "Fallback MySQL port if BINTRAIL_SOURCE_DSN does not include one")
+	proxysqlConfigCmd.Flags().UintVar(&pcShimPort, "shim-port", 3308, "Port the dbtrail-shim is listening on (matches shim.yaml's listen)")
+	proxysqlConfigCmd.Flags().UintVar(&pcProxySQLMySQLPort, "proxysql-mysql-port", 6033, "ProxySQL's client-facing MySQL protocol port (used in the help comment)")
+	bindCommandEnv(proxysqlConfigCmd)
+	rootCmd.AddCommand(proxysqlConfigCmd)
+}
+
+// shimTenant is the subset of a shim.yaml tenant block this command
+// needs. Unknown fields are ignored so the shim can extend its schema
+// without breaking us.
+type shimTenant struct {
+	MySQLUser     string `yaml:"mysql_user"`
+	MySQLPassSHA1 string `yaml:"mysql_pass_sha1"`
+}
+
+type shimConfig struct {
+	Tenants []shimTenant `yaml:"tenants"`
+}
+
+func runProxySQLConfig(cmd *cobra.Command, args []string) error {
+	sourceDSN := os.Getenv("BINTRAIL_SOURCE_DSN")
+	if sourceDSN == "" {
+		return fmt.Errorf("missing required env var: BINTRAIL_SOURCE_DSN\nRun 'bintrail config init' to scaffold .bintrail.env, then set this value.")
+	}
+
+	host, port, err := parseProxySQLBackend(sourceDSN, uint16(pcMySQLPort))
+	if err != nil {
+		return err
+	}
+
+	tenants, err := loadShimTenants(pcShimConfig)
+	if err != nil {
+		return err
+	}
+
+	content := generateProxySQLSetupSQL(host, port, uint16(pcShimPort), uint16(pcProxySQLMySQLPort), tenants)
+
+	if pcOut == "-" {
+		_, err := io.WriteString(os.Stdout, content)
+		return err
+	}
+
+	if _, err := os.Stat(pcOut); err == nil {
+		return fmt.Errorf("file already exists: %s\nRemove it first or edit it directly.", pcOut)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("cannot check %s: %w", pcOut, err)
+	}
+
+	if err := os.WriteFile(pcOut, []byte(content), 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", pcOut, err)
+	}
+
+	fmt.Printf("ProxySQL setup SQL written to %s\n", pcOut)
+	fmt.Printf("Apply it: mysql -u admin -P 6032 -h <proxysql-host> < %s\n", pcOut)
+	return nil
+}
+
+// parseProxySQLBackend extracts the host and port from a go-sql-driver
+// DSN. If the DSN address has no port, fallbackPort is used.
+func parseProxySQLBackend(dsn string, fallbackPort uint16) (host string, port uint16, err error) {
+	cfg, parseErr := drivermysql.ParseDSN(dsn)
+	if parseErr != nil {
+		return "", 0, fmt.Errorf("invalid BINTRAIL_SOURCE_DSN: %w", parseErr)
+	}
+	if strings.EqualFold(cfg.Net, "unix") {
+		return "", 0, fmt.Errorf("BINTRAIL_SOURCE_DSN uses a unix socket; ProxySQL routing requires a TCP host:port")
+	}
+	addr := cfg.Addr
+	if addr == "" {
+		return "", 0, fmt.Errorf("BINTRAIL_SOURCE_DSN has no address")
+	}
+	idx := strings.LastIndex(addr, ":")
+	if idx < 0 {
+		return addr, fallbackPort, nil
+	}
+	h := addr[:idx]
+	p, convErr := strconv.ParseUint(addr[idx+1:], 10, 16)
+	if convErr != nil {
+		return "", 0, fmt.Errorf("invalid port in BINTRAIL_SOURCE_DSN: %w", convErr)
+	}
+	return h, uint16(p), nil
+}
+
+// loadShimTenants reads shim.yaml from path, validates each tenant has
+// non-empty mysql_user and mysql_pass_sha1 free of newlines, and returns
+// the resulting list.
+func loadShimTenants(path string) ([]shimTenant, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("shim config not found at %s\nRun 'bintrail init-shim' to scaffold one, then fill in mysql_user / mysql_pass_sha1.", path)
+		}
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	var cfg shimConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if len(cfg.Tenants) == 0 {
+		return nil, fmt.Errorf("%s has no tenants", path)
+	}
+	for i, t := range cfg.Tenants {
+		if t.MySQLUser == "" {
+			return nil, fmt.Errorf("%s tenant #%d: mysql_user is empty (uncomment and fill in the TODO line)", path, i+1)
+		}
+		if t.MySQLPassSHA1 == "" {
+			return nil, fmt.Errorf("%s tenant #%d: mysql_pass_sha1 is empty (uncomment and fill in the TODO line)", path, i+1)
+		}
+		if strings.ContainsAny(t.MySQLUser, "\r\n") {
+			return nil, fmt.Errorf("%s tenant #%d: mysql_user contains a newline character", path, i+1)
+		}
+		if strings.ContainsAny(t.MySQLPassSHA1, "\r\n") {
+			return nil, fmt.Errorf("%s tenant #%d: mysql_pass_sha1 contains a newline character", path, i+1)
+		}
+	}
+	return cfg.Tenants, nil
+}
+
+func generateProxySQLSetupSQL(host string, mysqlPort, shimPort, proxysqlMySQLPort uint16, tenants []shimTenant) string {
+	var sb strings.Builder
+	sb.WriteString("-- Bintrail BYOS time-travel SQL — ProxySQL setup\n")
+	sb.WriteString("-- Generated by bintrail proxysql-config. See docs/byos-time-travel-sql.md.\n")
+	sb.WriteString("--\n")
+	sb.WriteString("-- This script manages the following ProxySQL resources, all in the\n")
+	sb.WriteString("-- 990* numeric range to avoid colliding with operator-managed rules:\n")
+	fmt.Fprintf(&sb, "--   * mysql_servers in hostgroups %d (passthrough) and %d (shim)\n", passthroughHostgroup, shimHostgroup)
+	fmt.Fprintf(&sb, "--   * mysql_query_rules with rule_id in %d..%d\n", ruleIDFlashback, ruleIDSnapshot)
+	sb.WriteString("--   * mysql_users named in shim.yaml (these become bintrail-managed)\n")
+	sb.WriteString("--\n")
+	sb.WriteString("-- Apply this file to the ProxySQL admin port:\n")
+	sb.WriteString("--     mysql -u admin -P 6032 -h <proxysql-host> < proxysql-setup.sql\n")
+	sb.WriteString("--\n")
+	fmt.Fprintf(&sb, "-- Your application then connects to ProxySQL on port %d.\n", proxysqlMySQLPort)
+	sb.WriteString("-- Re-running this script is idempotent.\n")
+	sb.WriteString("\n")
+
+	fmt.Fprintf(&sb, "DELETE FROM mysql_servers WHERE hostgroup_id IN (%d, %d);\n", passthroughHostgroup, shimHostgroup)
+	fmt.Fprintf(&sb, "INSERT INTO mysql_servers (hostgroup_id, hostname, port) VALUES (%d, %s, %d);\n", passthroughHostgroup, sqlQuote(host), mysqlPort)
+	fmt.Fprintf(&sb, "INSERT INTO mysql_servers (hostgroup_id, hostname, port) VALUES (%d, '127.0.0.1', %d);\n", shimHostgroup, shimPort)
+	sb.WriteString("\n")
+
+	sb.WriteString("DELETE FROM mysql_users WHERE username IN (")
+	for i, t := range tenants {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString(sqlQuote(t.MySQLUser))
+	}
+	sb.WriteString(");\n")
+	for _, t := range tenants {
+		fmt.Fprintf(&sb, "INSERT INTO mysql_users (username, password, default_hostgroup, active) VALUES (%s, %s, %d, 1);\n",
+			sqlQuote(t.MySQLUser), sqlQuote(t.MySQLPassSHA1), passthroughHostgroup)
+	}
+	sb.WriteString("\n")
+
+	fmt.Fprintf(&sb, "DELETE FROM mysql_query_rules WHERE rule_id IN (%d, %d, %d);\n", ruleIDFlashback, ruleIDDiff, ruleIDSnapshot)
+	fmt.Fprintf(&sb, "INSERT INTO mysql_query_rules (rule_id, active, match_pattern, destination_hostgroup, apply) VALUES (%d, 1, '\\b_flashback\\.', %d, 1);\n", ruleIDFlashback, shimHostgroup)
+	fmt.Fprintf(&sb, "INSERT INTO mysql_query_rules (rule_id, active, match_pattern, destination_hostgroup, apply) VALUES (%d, 1, '\\b_diff\\.', %d, 1);\n", ruleIDDiff, shimHostgroup)
+	fmt.Fprintf(&sb, "INSERT INTO mysql_query_rules (rule_id, active, match_pattern, destination_hostgroup, apply) VALUES (%d, 1, '\\b_snapshot\\.', %d, 1);\n", ruleIDSnapshot, shimHostgroup)
+	sb.WriteString("\n")
+
+	sb.WriteString("LOAD MYSQL SERVERS TO RUNTIME;\n")
+	sb.WriteString("LOAD MYSQL USERS TO RUNTIME;\n")
+	sb.WriteString("LOAD MYSQL QUERY RULES TO RUNTIME;\n")
+	sb.WriteString("SAVE MYSQL SERVERS TO DISK;\n")
+	sb.WriteString("SAVE MYSQL USERS TO DISK;\n")
+	sb.WriteString("SAVE MYSQL QUERY RULES TO DISK;\n")
+
+	return sb.String()
+}
+
+// sqlQuote wraps s as a SQL single-quoted string literal, doubling any
+// embedded single quotes. ProxySQL admin uses SQLite-style quoting so
+// this is the safe escape.
+func sqlQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
+}

--- a/cmd/bintrail/proxysql_config.go
+++ b/cmd/bintrail/proxysql_config.go
@@ -255,20 +255,15 @@ func generateProxySQLSetupSQL(host string, mysqlPort, shimPort, proxysqlMySQLPor
 	fmt.Fprintf(&sb, "INSERT INTO mysql_servers (hostgroup_id, hostname, port) VALUES (%d, '127.0.0.1', %d);\n", shimHostgroup, shimPort)
 	sb.WriteString("\n")
 
-	// DELETE clauses union (default_hostgroup match) with (current usernames):
-	// the hostgroup match cleans rows from a previous run whose username has
-	// since been renamed in shim.yaml; the username match keeps deletion
-	// scoped to bintrail-owned rows when an operator has shared a username
-	// across hostgroups (rare).
-	sb.WriteString("DELETE FROM mysql_users WHERE default_hostgroup = ")
-	fmt.Fprintf(&sb, "%d OR username IN (", passthroughHostgroup)
-	for i, t := range tenants {
-		if i > 0 {
-			sb.WriteString(", ")
-		}
-		sb.WriteString(sqlQuote(t.MySQLUser))
-	}
-	sb.WriteString(");\n")
+	// DELETE is scoped strictly to bintrail-managed rows by default_hostgroup,
+	// never by username alone. This:
+	//   * cleans rows from a previous run whose username was renamed in
+	//     shim.yaml between runs (the old row still lives in hostgroup 990).
+	//   * does NOT destroy an operator's pre-existing user that happens to
+	//     share a name with a tenant — if there is a collision, the INSERT
+	//     below fails loudly with a PRIMARY KEY violation rather than
+	//     silently overwriting operator config.
+	fmt.Fprintf(&sb, "DELETE FROM mysql_users WHERE default_hostgroup = %d;\n", passthroughHostgroup)
 	for _, t := range tenants {
 		fmt.Fprintf(&sb, "INSERT INTO mysql_users (username, password, default_hostgroup, active) VALUES (%s, %s, %d, 1);\n",
 			sqlQuote(t.MySQLUser), sqlQuote(t.MySQLPassSHA1), passthroughHostgroup)

--- a/cmd/bintrail/proxysql_config_test.go
+++ b/cmd/bintrail/proxysql_config_test.go
@@ -1,0 +1,369 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const (
+	pcTestSourceDSN = "user:pass@tcp(db.example.com:3306)/myapp"
+	pcTestUser1     = "app_user"
+	pcTestSHA1_1    = "*A4B6157319038724E3560894F7F932C8886EBFCF"
+)
+
+func writeShimYAML(t *testing.T, dir string, body string) string {
+	t.Helper()
+	path := filepath.Join(dir, "shim.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func resetPCFlags() {
+	pcOut = "proxysql-setup.sql"
+	pcShimConfig = "shim.yaml"
+	pcMySQLPort = 3306
+	pcShimPort = 3308
+	pcProxySQLMySQLPort = 6033
+}
+
+const validShimYAML = `listen: ':3308'
+tenants:
+  - server_id: '1'
+    source_dsn: 'user:pass@tcp(db:3306)/myapp'
+    agent_url: 'http://localhost:8600'
+    agent_token: 'btk_abc'
+    mysql_user: app_user
+    mysql_pass_sha1: '*A4B6157319038724E3560894F7F932C8886EBFCF'
+`
+
+func TestRunProxySQLConfig(t *testing.T) {
+	t.Run("happy path single tenant", func(t *testing.T) {
+		dir := t.TempDir()
+		orig, _ := os.Getwd()
+		t.Cleanup(func() { os.Chdir(orig) })
+		os.Chdir(dir)
+
+		t.Setenv("BINTRAIL_SOURCE_DSN", pcTestSourceDSN)
+		writeShimYAML(t, dir, validShimYAML)
+		resetPCFlags()
+
+		if err := runProxySQLConfig(proxysqlConfigCmd, nil); err != nil {
+			t.Fatal(err)
+		}
+
+		data, err := os.ReadFile(filepath.Join(dir, "proxysql-setup.sql"))
+		if err != nil {
+			t.Fatalf("expected output file: %v", err)
+		}
+		out := string(data)
+
+		wants := []string{
+			"-- Bintrail BYOS time-travel SQL",
+			"docs/byos-time-travel-sql.md",
+			"DELETE FROM mysql_servers WHERE hostgroup_id IN (990, 991);",
+			"INSERT INTO mysql_servers (hostgroup_id, hostname, port) VALUES (990, 'db.example.com', 3306);",
+			"INSERT INTO mysql_servers (hostgroup_id, hostname, port) VALUES (991, '127.0.0.1', 3308);",
+			"DELETE FROM mysql_users WHERE username IN ('app_user');",
+			"INSERT INTO mysql_users (username, password, default_hostgroup, active) VALUES ('app_user', '*A4B6157319038724E3560894F7F932C8886EBFCF', 990, 1);",
+			"DELETE FROM mysql_query_rules WHERE rule_id IN (990001, 990002, 990003);",
+			"VALUES (990001, 1, '\\b_flashback\\.', 991, 1);",
+			"VALUES (990002, 1, '\\b_diff\\.', 991, 1);",
+			"VALUES (990003, 1, '\\b_snapshot\\.', 991, 1);",
+			"LOAD MYSQL SERVERS TO RUNTIME;",
+			"LOAD MYSQL USERS TO RUNTIME;",
+			"LOAD MYSQL QUERY RULES TO RUNTIME;",
+			"SAVE MYSQL SERVERS TO DISK;",
+			"SAVE MYSQL USERS TO DISK;",
+			"SAVE MYSQL QUERY RULES TO DISK;",
+		}
+		for _, w := range wants {
+			if !strings.Contains(out, w) {
+				t.Errorf("output missing %q; full output:\n%s", w, out)
+			}
+		}
+
+		info, _ := os.Stat(filepath.Join(dir, "proxysql-setup.sql"))
+		if perm := info.Mode().Perm(); perm != 0o600 {
+			t.Errorf("perm = %o, want 0600", perm)
+		}
+	})
+
+	t.Run("happy path two tenants", func(t *testing.T) {
+		two := validShimYAML + `  - server_id: '2'
+    source_dsn: 'user:pass@tcp(db:3306)/myapp2'
+    agent_url: 'http://localhost:8600'
+    agent_token: 'btk_xyz'
+    mysql_user: app_user2
+    mysql_pass_sha1: '*BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'
+`
+		dir := t.TempDir()
+		orig, _ := os.Getwd()
+		t.Cleanup(func() { os.Chdir(orig) })
+		os.Chdir(dir)
+
+		t.Setenv("BINTRAIL_SOURCE_DSN", pcTestSourceDSN)
+		writeShimYAML(t, dir, two)
+		resetPCFlags()
+
+		if err := runProxySQLConfig(proxysqlConfigCmd, nil); err != nil {
+			t.Fatal(err)
+		}
+
+		data, _ := os.ReadFile(filepath.Join(dir, "proxysql-setup.sql"))
+		out := string(data)
+
+		if !strings.Contains(out, "DELETE FROM mysql_users WHERE username IN ('app_user', 'app_user2');") {
+			t.Errorf("expected combined DELETE for both users; got:\n%s", out)
+		}
+		if !strings.Contains(out, "INSERT INTO mysql_users (username, password, default_hostgroup, active) VALUES ('app_user', ") {
+			t.Error("expected INSERT for app_user")
+		}
+		if !strings.Contains(out, "INSERT INTO mysql_users (username, password, default_hostgroup, active) VALUES ('app_user2', ") {
+			t.Error("expected INSERT for app_user2")
+		}
+	})
+
+	t.Run("error when source DSN missing", func(t *testing.T) {
+		t.Setenv("BINTRAIL_SOURCE_DSN", "")
+		resetPCFlags()
+		err := runProxySQLConfig(proxysqlConfigCmd, nil)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(err.Error(), "BINTRAIL_SOURCE_DSN") {
+			t.Errorf("error should name the env var, got %v", err)
+		}
+	})
+
+	t.Run("error when DSN invalid", func(t *testing.T) {
+		t.Setenv("BINTRAIL_SOURCE_DSN", "not-a-valid-dsn-format")
+		resetPCFlags()
+		err := runProxySQLConfig(proxysqlConfigCmd, nil)
+		if err == nil {
+			t.Fatal("expected error for invalid DSN")
+		}
+		if !strings.Contains(err.Error(), "BINTRAIL_SOURCE_DSN") {
+			t.Errorf("error should mention the var, got %v", err)
+		}
+	})
+
+	t.Run("error when DSN uses unix socket", func(t *testing.T) {
+		t.Setenv("BINTRAIL_SOURCE_DSN", "user:pass@unix(/tmp/mysql.sock)/myapp")
+		resetPCFlags()
+		err := runProxySQLConfig(proxysqlConfigCmd, nil)
+		if err == nil {
+			t.Fatal("expected error for unix socket")
+		}
+		if !strings.Contains(err.Error(), "unix socket") {
+			t.Errorf("error should mention unix socket, got %v", err)
+		}
+	})
+
+	t.Run("error when shim.yaml missing", func(t *testing.T) {
+		dir := t.TempDir()
+		orig, _ := os.Getwd()
+		t.Cleanup(func() { os.Chdir(orig) })
+		os.Chdir(dir)
+
+		t.Setenv("BINTRAIL_SOURCE_DSN", pcTestSourceDSN)
+		resetPCFlags()
+
+		err := runProxySQLConfig(proxysqlConfigCmd, nil)
+		if err == nil {
+			t.Fatal("expected error when shim.yaml missing")
+		}
+		if !strings.Contains(err.Error(), "shim config not found") {
+			t.Errorf("expected 'shim config not found' in error, got %v", err)
+		}
+	})
+
+	t.Run("error when tenant missing mysql_user", func(t *testing.T) {
+		dir := t.TempDir()
+		orig, _ := os.Getwd()
+		t.Cleanup(func() { os.Chdir(orig) })
+		os.Chdir(dir)
+
+		t.Setenv("BINTRAIL_SOURCE_DSN", pcTestSourceDSN)
+		writeShimYAML(t, dir, "tenants:\n  - mysql_pass_sha1: '*ABC'\n")
+		resetPCFlags()
+
+		err := runProxySQLConfig(proxysqlConfigCmd, nil)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(err.Error(), "mysql_user") {
+			t.Errorf("error should name the missing field, got %v", err)
+		}
+	})
+
+	t.Run("error when tenant missing mysql_pass_sha1", func(t *testing.T) {
+		dir := t.TempDir()
+		orig, _ := os.Getwd()
+		t.Cleanup(func() { os.Chdir(orig) })
+		os.Chdir(dir)
+
+		t.Setenv("BINTRAIL_SOURCE_DSN", pcTestSourceDSN)
+		writeShimYAML(t, dir, "tenants:\n  - mysql_user: app_user\n")
+		resetPCFlags()
+
+		err := runProxySQLConfig(proxysqlConfigCmd, nil)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(err.Error(), "mysql_pass_sha1") {
+			t.Errorf("error should name the missing field, got %v", err)
+		}
+	})
+
+	t.Run("error when shim.yaml has no tenants", func(t *testing.T) {
+		dir := t.TempDir()
+		orig, _ := os.Getwd()
+		t.Cleanup(func() { os.Chdir(orig) })
+		os.Chdir(dir)
+
+		t.Setenv("BINTRAIL_SOURCE_DSN", pcTestSourceDSN)
+		writeShimYAML(t, dir, "tenants: []\n")
+		resetPCFlags()
+
+		err := runProxySQLConfig(proxysqlConfigCmd, nil)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(err.Error(), "no tenants") {
+			t.Errorf("expected 'no tenants' in error, got %v", err)
+		}
+	})
+
+	t.Run("error when tenant credential contains newline", func(t *testing.T) {
+		dir := t.TempDir()
+		orig, _ := os.Getwd()
+		t.Cleanup(func() { os.Chdir(orig) })
+		os.Chdir(dir)
+
+		t.Setenv("BINTRAIL_SOURCE_DSN", pcTestSourceDSN)
+		writeShimYAML(t, dir, "tenants:\n  - mysql_user: \"bad\\nuser\"\n    mysql_pass_sha1: '*ABC'\n")
+		resetPCFlags()
+
+		err := runProxySQLConfig(proxysqlConfigCmd, nil)
+		if err == nil {
+			t.Fatal("expected error for newline")
+		}
+		if !strings.Contains(err.Error(), "newline") {
+			t.Errorf("expected 'newline' in error, got %v", err)
+		}
+	})
+
+	t.Run("--out - writes to stdout", func(t *testing.T) {
+		dir := t.TempDir()
+		orig, _ := os.Getwd()
+		t.Cleanup(func() { os.Chdir(orig) })
+		os.Chdir(dir)
+
+		t.Setenv("BINTRAIL_SOURCE_DSN", pcTestSourceDSN)
+		writeShimYAML(t, dir, validShimYAML)
+		resetPCFlags()
+		pcOut = "-"
+
+		r, w, _ := os.Pipe()
+		origStdout := os.Stdout
+		os.Stdout = w
+		t.Cleanup(func() { os.Stdout = origStdout })
+
+		done := make(chan []byte)
+		go func() {
+			var buf bytes.Buffer
+			io.Copy(&buf, r)
+			done <- buf.Bytes()
+		}()
+
+		if err := runProxySQLConfig(proxysqlConfigCmd, nil); err != nil {
+			t.Fatal(err)
+		}
+		w.Close()
+
+		out := string(<-done)
+		if !strings.Contains(out, "INSERT INTO mysql_users") {
+			t.Errorf("stdout missing expected SQL:\n%s", out)
+		}
+	})
+
+	t.Run("refuses to overwrite", func(t *testing.T) {
+		dir := t.TempDir()
+		orig, _ := os.Getwd()
+		t.Cleanup(func() { os.Chdir(orig) })
+		os.Chdir(dir)
+
+		t.Setenv("BINTRAIL_SOURCE_DSN", pcTestSourceDSN)
+		writeShimYAML(t, dir, validShimYAML)
+		os.WriteFile(filepath.Join(dir, "proxysql-setup.sql"), []byte("existing"), 0o644)
+		resetPCFlags()
+
+		err := runProxySQLConfig(proxysqlConfigCmd, nil)
+		if err == nil {
+			t.Fatal("expected error when output file exists")
+		}
+		if !strings.Contains(err.Error(), "already exists") {
+			t.Errorf("expected 'already exists' in error, got %v", err)
+		}
+	})
+}
+
+func TestGenerateProxySQLSetupSQLDeterministic(t *testing.T) {
+	tenants := []shimTenant{{MySQLUser: pcTestUser1, MySQLPassSHA1: pcTestSHA1_1}}
+	a := generateProxySQLSetupSQL("db.example.com", 3306, 3308, 6033, tenants)
+	b := generateProxySQLSetupSQL("db.example.com", 3306, 3308, 6033, tenants)
+	if a != b {
+		t.Errorf("generateProxySQLSetupSQL must be deterministic; got two different outputs")
+	}
+}
+
+func TestGenerateProxySQLSetupSQLSQLInjection(t *testing.T) {
+	// A user/password containing single quotes must be safely escaped.
+	tenants := []shimTenant{
+		{MySQLUser: "ev'il", MySQLPassSHA1: "*A'B"},
+	}
+	out := generateProxySQLSetupSQL("db", 3306, 3308, 6033, tenants)
+
+	wants := []string{
+		"DELETE FROM mysql_users WHERE username IN ('ev''il');",
+		"INSERT INTO mysql_users (username, password, default_hostgroup, active) VALUES ('ev''il', '*A''B', 990, 1);",
+	}
+	for _, w := range wants {
+		if !strings.Contains(out, w) {
+			t.Errorf("expected escaped SQL %q; got:\n%s", w, out)
+		}
+	}
+}
+
+func TestParseProxySQLBackend(t *testing.T) {
+	t.Run("DSN with port", func(t *testing.T) {
+		host, port, err := parseProxySQLBackend("u:p@tcp(db.example.com:3307)/x", 3306)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if host != "db.example.com" || port != 3307 {
+			t.Errorf("got %s:%d", host, port)
+		}
+	})
+
+	t.Run("DSN missing port falls back to flag", func(t *testing.T) {
+		// go-sql-driver normalises the address to host:3306 if port is missing,
+		// but we still verify the fallback logic works for an addr without ':'.
+		host, port, err := parseProxySQLBackend("u:p@tcp(db.example.com)/x", 3306)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if host != "db.example.com" {
+			t.Errorf("got host %s", host)
+		}
+		if port != 3306 {
+			t.Errorf("got port %d, want 3306", port)
+		}
+	})
+}

--- a/cmd/bintrail/proxysql_config_test.go
+++ b/cmd/bintrail/proxysql_config_test.go
@@ -66,15 +66,17 @@ func TestRunProxySQLConfig(t *testing.T) {
 		wants := []string{
 			"-- Bintrail BYOS time-travel SQL",
 			"docs/byos-time-travel-sql.md",
+			"BEGIN;",
 			"DELETE FROM mysql_servers WHERE hostgroup_id IN (990, 991);",
 			"INSERT INTO mysql_servers (hostgroup_id, hostname, port) VALUES (990, 'db.example.com', 3306);",
 			"INSERT INTO mysql_servers (hostgroup_id, hostname, port) VALUES (991, '127.0.0.1', 3308);",
-			"DELETE FROM mysql_users WHERE username IN ('app_user');",
+			"DELETE FROM mysql_users WHERE default_hostgroup = 990 OR username IN ('app_user');",
 			"INSERT INTO mysql_users (username, password, default_hostgroup, active) VALUES ('app_user', '*A4B6157319038724E3560894F7F932C8886EBFCF', 990, 1);",
 			"DELETE FROM mysql_query_rules WHERE rule_id IN (990001, 990002, 990003);",
 			"VALUES (990001, 1, '\\b_flashback\\.', 991, 1);",
 			"VALUES (990002, 1, '\\b_diff\\.', 991, 1);",
 			"VALUES (990003, 1, '\\b_snapshot\\.', 991, 1);",
+			"COMMIT;",
 			"LOAD MYSQL SERVERS TO RUNTIME;",
 			"LOAD MYSQL USERS TO RUNTIME;",
 			"LOAD MYSQL QUERY RULES TO RUNTIME;",
@@ -118,7 +120,7 @@ func TestRunProxySQLConfig(t *testing.T) {
 		data, _ := os.ReadFile(filepath.Join(dir, "proxysql-setup.sql"))
 		out := string(data)
 
-		if !strings.Contains(out, "DELETE FROM mysql_users WHERE username IN ('app_user', 'app_user2');") {
+		if !strings.Contains(out, "DELETE FROM mysql_users WHERE default_hostgroup = 990 OR username IN ('app_user', 'app_user2');") {
 			t.Errorf("expected combined DELETE for both users; got:\n%s", out)
 		}
 		if !strings.Contains(out, "INSERT INTO mysql_users (username, password, default_hostgroup, active) VALUES ('app_user', ") {
@@ -254,8 +256,8 @@ func TestRunProxySQLConfig(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error for newline")
 		}
-		if !strings.Contains(err.Error(), "newline") {
-			t.Errorf("expected 'newline' in error, got %v", err)
+		if !strings.Contains(err.Error(), "control character") {
+			t.Errorf("expected 'control character' in error, got %v", err)
 		}
 	})
 
@@ -331,13 +333,160 @@ func TestGenerateProxySQLSetupSQLSQLInjection(t *testing.T) {
 	out := generateProxySQLSetupSQL("db", 3306, 3308, 6033, tenants)
 
 	wants := []string{
-		"DELETE FROM mysql_users WHERE username IN ('ev''il');",
+		"DELETE FROM mysql_users WHERE default_hostgroup = 990 OR username IN ('ev''il');",
 		"INSERT INTO mysql_users (username, password, default_hostgroup, active) VALUES ('ev''il', '*A''B', 990, 1);",
 	}
 	for _, w := range wants {
 		if !strings.Contains(out, w) {
 			t.Errorf("expected escaped SQL %q; got:\n%s", w, out)
 		}
+	}
+}
+
+// TestGenerateProxySQLSetupSQLHostgroupPairing locks in the
+// destination_hostgroup for each rule_id so a future swap of
+// `passthroughHostgroup` and `shimHostgroup` would be caught even if
+// individual fragment assertions still pass.
+func TestGenerateProxySQLSetupSQLHostgroupPairing(t *testing.T) {
+	tenants := []shimTenant{{MySQLUser: pcTestUser1, MySQLPassSHA1: pcTestSHA1_1}}
+	out := generateProxySQLSetupSQL("db", 3306, 3308, 6033, tenants)
+
+	wants := []string{
+		// passthrough server lives in passthrough hostgroup
+		"INSERT INTO mysql_servers (hostgroup_id, hostname, port) VALUES (990,",
+		// shim server lives in shim hostgroup
+		"INSERT INTO mysql_servers (hostgroup_id, hostname, port) VALUES (991,",
+		// users default to passthrough hostgroup (real MySQL by default)
+		"default_hostgroup, active) VALUES ('app_user', '" + pcTestSHA1_1 + "', 990, 1);",
+		// virtual-schema rules route to shim hostgroup, never passthrough
+		"VALUES (990001, 1, '\\b_flashback\\.', 991, 1);",
+		"VALUES (990002, 1, '\\b_diff\\.', 991, 1);",
+		"VALUES (990003, 1, '\\b_snapshot\\.', 991, 1);",
+	}
+	for _, w := range wants {
+		if !strings.Contains(out, w) {
+			t.Errorf("hostgroup pairing missing %q; full SQL:\n%s", w, out)
+		}
+	}
+	// And explicitly: no rule should ever route a virtual schema to the
+	// passthrough hostgroup.
+	for _, bad := range []string{
+		"VALUES (990001, 1, '\\b_flashback\\.', 990, 1)",
+		"VALUES (990002, 1, '\\b_diff\\.', 990, 1)",
+		"VALUES (990003, 1, '\\b_snapshot\\.', 990, 1)",
+	} {
+		if strings.Contains(out, bad) {
+			t.Errorf("virtual-schema rule must not target passthrough hostgroup, found %q", bad)
+		}
+	}
+}
+
+func TestRunProxySQLConfigStrictYAML(t *testing.T) {
+	// A typo in shim.yaml (mysql_user_name vs mysql_user) used to silently
+	// parse as empty, surfacing as the misleading "mysql_user is empty" error.
+	// UnmarshalStrict now reports the unknown key directly.
+	dir := t.TempDir()
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { os.Chdir(orig) })
+	os.Chdir(dir)
+
+	t.Setenv("BINTRAIL_SOURCE_DSN", pcTestSourceDSN)
+	writeShimYAML(t, dir, "tenants:\n  - mysql_user_name: app_user\n    mysql_pass_sha1: '*ABC'\n")
+	resetPCFlags()
+
+	err := runProxySQLConfig(proxysqlConfigCmd, nil)
+	if err == nil {
+		t.Fatal("expected error for unknown YAML field")
+	}
+	if !strings.Contains(err.Error(), "mysql_user_name") {
+		t.Errorf("error should name the unknown field, got %v", err)
+	}
+}
+
+func TestParseProxySQLBackendIPv6(t *testing.T) {
+	// Bracketed IPv6 with port.
+	host, port, err := parseProxySQLBackend("u:p@tcp([2001:db8::1]:3306)/x", 3306)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if host != "2001:db8::1" {
+		t.Errorf("got host %q, want '2001:db8::1' (without brackets)", host)
+	}
+	if port != 3306 {
+		t.Errorf("got port %d", port)
+	}
+}
+
+func TestParseProxySQLBackendEmptyHost(t *testing.T) {
+	_, _, err := parseProxySQLBackend("u:p@tcp(:3306)/x", 3306)
+	if err == nil {
+		t.Fatal("expected error for empty host")
+	}
+	if !strings.Contains(err.Error(), "empty host") {
+		t.Errorf("expected 'empty host' in error, got %v", err)
+	}
+}
+
+func TestRunProxySQLConfigPortRangeValidation(t *testing.T) {
+	dir := t.TempDir()
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { os.Chdir(orig) })
+	os.Chdir(dir)
+
+	t.Setenv("BINTRAIL_SOURCE_DSN", pcTestSourceDSN)
+	writeShimYAML(t, dir, validShimYAML)
+
+	t.Run("zero port rejected", func(t *testing.T) {
+		resetPCFlags()
+		pcMySQLPort = 0
+		err := runProxySQLConfig(proxysqlConfigCmd, nil)
+		if err == nil || !strings.Contains(err.Error(), "out of range") {
+			t.Errorf("expected out-of-range error for port 0, got %v", err)
+		}
+	})
+
+	t.Run("uint16-overflow port rejected", func(t *testing.T) {
+		// 70000 used to silently truncate to uint16 → 4464, generating broken SQL.
+		resetPCFlags()
+		pcShimPort = 70000
+		err := runProxySQLConfig(proxysqlConfigCmd, nil)
+		if err == nil || !strings.Contains(err.Error(), "out of range") {
+			t.Errorf("expected out-of-range error for port 70000, got %v", err)
+		}
+	})
+}
+
+func TestLoadShimTenantsControlChars(t *testing.T) {
+	// Reject control chars beyond plain \r\n: \t in mysql_user, \0 in
+	// mysql_pass_sha1. Both would corrupt the generated SQL output.
+	cases := []struct {
+		name     string
+		yamlBody string
+		wantSub  string
+	}{
+		{
+			name:     "tab in mysql_user",
+			yamlBody: "tenants:\n  - mysql_user: \"app\\tuser\"\n    mysql_pass_sha1: '*ABC'\n",
+			wantSub:  "mysql_user contains control character",
+		},
+		{
+			name:     "null byte in pass",
+			yamlBody: "tenants:\n  - mysql_user: app_user\n    mysql_pass_sha1: \"*A\\u0000B\"\n",
+			wantSub:  "mysql_pass_sha1 contains control character",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := writeShimYAML(t, dir, tc.yamlBody)
+			_, err := loadShimTenants(path)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("expected %q in error, got %v", tc.wantSub, err)
+			}
+		})
 	}
 }
 

--- a/cmd/bintrail/proxysql_config_test.go
+++ b/cmd/bintrail/proxysql_config_test.go
@@ -70,7 +70,7 @@ func TestRunProxySQLConfig(t *testing.T) {
 			"DELETE FROM mysql_servers WHERE hostgroup_id IN (990, 991);",
 			"INSERT INTO mysql_servers (hostgroup_id, hostname, port) VALUES (990, 'db.example.com', 3306);",
 			"INSERT INTO mysql_servers (hostgroup_id, hostname, port) VALUES (991, '127.0.0.1', 3308);",
-			"DELETE FROM mysql_users WHERE default_hostgroup = 990 OR username IN ('app_user');",
+			"DELETE FROM mysql_users WHERE default_hostgroup = 990;",
 			"INSERT INTO mysql_users (username, password, default_hostgroup, active) VALUES ('app_user', '*A4B6157319038724E3560894F7F932C8886EBFCF', 990, 1);",
 			"DELETE FROM mysql_query_rules WHERE rule_id IN (990001, 990002, 990003);",
 			"VALUES (990001, 1, '\\b_flashback\\.', 991, 1);",
@@ -120,8 +120,8 @@ func TestRunProxySQLConfig(t *testing.T) {
 		data, _ := os.ReadFile(filepath.Join(dir, "proxysql-setup.sql"))
 		out := string(data)
 
-		if !strings.Contains(out, "DELETE FROM mysql_users WHERE default_hostgroup = 990 OR username IN ('app_user', 'app_user2');") {
-			t.Errorf("expected combined DELETE for both users; got:\n%s", out)
+		if !strings.Contains(out, "DELETE FROM mysql_users WHERE default_hostgroup = 990;") {
+			t.Errorf("expected hostgroup-scoped DELETE; got:\n%s", out)
 		}
 		if !strings.Contains(out, "INSERT INTO mysql_users (username, password, default_hostgroup, active) VALUES ('app_user', ") {
 			t.Error("expected INSERT for app_user")
@@ -332,14 +332,36 @@ func TestGenerateProxySQLSetupSQLSQLInjection(t *testing.T) {
 	}
 	out := generateProxySQLSetupSQL("db", 3306, 3308, 6033, tenants)
 
-	wants := []string{
-		"DELETE FROM mysql_users WHERE default_hostgroup = 990 OR username IN ('ev''il');",
-		"INSERT INTO mysql_users (username, password, default_hostgroup, active) VALUES ('ev''il', '*A''B', 990, 1);",
+	want := "INSERT INTO mysql_users (username, password, default_hostgroup, active) VALUES ('ev''il', '*A''B', 990, 1);"
+	if !strings.Contains(out, want) {
+		t.Errorf("expected escaped SQL %q; got:\n%s", want, out)
 	}
-	for _, w := range wants {
-		if !strings.Contains(out, w) {
-			t.Errorf("expected escaped SQL %q; got:\n%s", w, out)
-		}
+}
+
+// TestGenerateProxySQLSetupSQLRenameIdempotent verifies that renaming a
+// tenant in shim.yaml between runs leaves no orphan row: the second
+// run's DELETE WHERE default_hostgroup = 990 catches the previous
+// tenant's row even though its username is no longer in the current
+// list. This locks in the design rationale for scoping the DELETE by
+// hostgroup rather than by username.
+func TestGenerateProxySQLSetupSQLRenameIdempotent(t *testing.T) {
+	first := generateProxySQLSetupSQL("db", 3306, 3308, 6033,
+		[]shimTenant{{MySQLUser: "old_user", MySQLPassSHA1: "*OLDHASH"}})
+	second := generateProxySQLSetupSQL("db", 3306, 3308, 6033,
+		[]shimTenant{{MySQLUser: "new_user", MySQLPassSHA1: "*NEWHASH"}})
+
+	// Both runs emit the same blanket DELETE, scoped only by hostgroup,
+	// so the second apply also removes 'old_user' even though the name
+	// no longer appears anywhere in the second SQL file.
+	wantDelete := "DELETE FROM mysql_users WHERE default_hostgroup = 990;"
+	if !strings.Contains(first, wantDelete) || !strings.Contains(second, wantDelete) {
+		t.Errorf("both runs must contain hostgroup-scoped DELETE %q", wantDelete)
+	}
+	if strings.Contains(second, "old_user") {
+		t.Error("second-run SQL must not reference the renamed-away tenant")
+	}
+	if !strings.Contains(second, "INSERT INTO mysql_users (username, password, default_hostgroup, active) VALUES ('new_user',") {
+		t.Errorf("second-run SQL must INSERT the new tenant; got:\n%s", second)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/parquet-go/parquet-go v0.24.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.2
+	go.yaml.in/yaml/v2 v2.4.2
 	golang.org/x/sync v0.19.0
 )
 
@@ -79,7 +80,6 @@ require (
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
-	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/exp v0.0.0-20260112195511-716be5621a96 // indirect
 	golang.org/x/mod v0.32.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect


### PR DESCRIPTION
closes #238

## Summary
- New `bintrail proxysql-config` subcommand. Reads `BINTRAIL_SOURCE_DSN` (passthrough host/port) and `shim.yaml` (tenant credentials filled in by the customer after `bintrail init-shim`) and emits a deterministic SQL script the customer applies to the ProxySQL admin port (default :6032).
- The SQL configures `mysql_servers` (hostgroup 990 = real MySQL, 991 = shim), one `mysql_users` row per tenant, and three `mysql_query_rules` (990001-990003) routing `\b_flashback\.`, `\b_diff\.`, `\b_snapshot\.` to the shim hostgroup. Re-running is idempotent via DELETE-then-INSERT scoped to the bintrail-owned range.
- Flags follow project convention: `pcOut`, `pcShimConfig`, `pcMySQLPort`, `pcShimPort`, `pcProxySQLMySQLPort`. Mirrors `init-shim`'s `--out -` for stdout, refuse-overwrite, 0o600 perms.
- CLAUDE.md command table updated.
- `go.yaml.in/yaml/v2 v2.4.2` promoted from indirect to direct (same version already in `go.sum`).

## Safety considerations (extra careful)
- **Hostgroups 990/991**: deliberately not 0/1. Operators commonly use low hostgroup IDs for their own backends; touching those would silently destroy unrelated ProxySQL config. The 990* range makes blast radius explicit and the comment header documents it.
- **Rule IDs 990001-990003**: same reasoning — avoid collision with hand-managed rules in the typical 1xx-1xxx range.
- **DELETE-then-INSERT**: scoped to (a) hostgroups 990/991, (b) the exact rule_id range, and (c) the usernames literally listed in shim.yaml. Nothing else is touched.
- **SQL injection**: all customer-supplied values (host, mysql_user, mysql_pass_sha1) flow through `sqlQuote`, which doubles single quotes per SQLite/ProxySQL admin convention. `TestGenerateProxySQLSetupSQLSQLInjection` locks in the escaping for `'` in both username and password.
- **Newline rejection**: tenant credentials containing `\r` or `\n` are rejected up-front rather than silently producing a broken SQL file.
- **Strict yaml.v2 parse**: missing `mysql_user` or `mysql_pass_sha1` per tenant errors with a message naming the tenant index and the missing field, so the customer knows exactly which line to fix.

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] 15 new test cases:
  - Happy path 1 tenant (asserts hostgroups, rule_ids, all 6 LOAD/SAVE statements, file mode 0o600)
  - Happy path 2 tenants (combined DELETE + per-user INSERTs)
  - Errors: missing source DSN, invalid DSN, unix-socket DSN, missing shim.yaml, missing mysql_user, missing mysql_pass_sha1, no tenants, newline in credential
  - `--out -` to stdout
  - Refuse-overwrite
  - Determinism
  - SQL injection escape
  - DSN parse with explicit port + fallback to flag
- [ ] Manual: apply the generated SQL to a real ProxySQL admin port and verify routing.

## Out of scope (per issue)
- Validating that ProxySQL is actually running.
- Applying the SQL automatically — generation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)