### PR TITLE
shim: remove silent _diff truncation cap

### DIFF
--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -117,7 +117,7 @@ type Options struct {
 	ChangedColumn string // column name; matched via JSON_CONTAINS
 	ColumnEq      []ColumnEq // match against values inside row_after / row_before
 	Flag          string     // return events from tables/columns carrying this flag
-	Limit         int        // 0 → default 100
+	Limit         int        // 0 → no limit (no LIMIT clause emitted)
 	// LimitPerPK caps the number of latest events returned per pk_values value.
 	// 0 = unlimited. Applied via ROW_NUMBER OVER (PARTITION BY pk_values
 	// ORDER BY event_timestamp DESC, event_id DESC) so the kept events are

--- a/internal/shim/handler.go
+++ b/internal/shim/handler.go
@@ -196,6 +196,12 @@ func (h *Handler) runDiff(q TimeTravelQuery) (*mysql.Result, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	// No row cap: a _diff query is already PK-scoped + time-windowed, so the
+	// upper bound on returned events is bounded by how often that one row
+	// actually changes within the window. A silent truncation here would
+	// hand the customer a partial audit history with no signal — worse than
+	// the rare cost of a few thousand rows for an unusually hot row.
+	// Customers needing pagination can narrow the BETWEEN range.
 	engine := query.New(h.indexDB)
 	rows, _, err := query.FetchMerged(ctx, h.indexDB, engine, query.FetchMergedOptions{
 		Opts: query.Options{
@@ -204,7 +210,6 @@ func (h *Handler) runDiff(q TimeTravelQuery) (*mysql.Result, error) {
 			PKValues: q.PKValue,
 			Since:    &q.Since,
 			Until:    &q.Until,
-			Limit:    diffMaxRows,
 		},
 		DBName:    q.Schema,
 		NoArchive: h.cfg.NoArchive,
@@ -236,12 +241,6 @@ func (h *Handler) runDiff(q TimeTravelQuery) (*mysql.Result, error) {
 	}
 	return &mysql.Result{Resultset: rs}, nil
 }
-
-// diffMaxRows caps a single _diff response. 1000 events is enough
-// for any realistic per-PK history within a customer-facing window;
-// a hot row that exceeded this would still be queryable via repeated
-// narrower-range calls.
-const diffMaxRows = 1000
 
 // eventTypeName turns parser.EventType (a uint8) into a human-readable
 // string for the _diff resultset. The parser package does not export a


### PR DESCRIPTION
Closes #245.

## Summary

- Remove the arbitrary `diffMaxRows = 1000` cap on `_diff` responses in `internal/shim/handler.go`.
- A `_diff` query is already PK-scoped AND time-windowed via `BETWEEN`; the practical upper bound is "how often did this one row change in this window". No DoS vector.
- Silently truncating an audit-history endpoint at 1000 rows hands the customer a partial result with zero signal — strictly worse than letting through the occasional large response. Customers who hit a real problem can narrow the `BETWEEN` range.

## Why Occam over the issue's three options

The issue proposed (a) sentinel row, (b) `SHOW WARNINGS`, or (c) hard error. All three add complexity to defend a constant the issue itself describes as having "no specific rationale". Removing the cap is the smaller, safer change.

## Test plan

- [x] `go test ./internal/shim/... -count=1` passes
- [x] `go build ./...` clean (no stragglers referencing `diffMaxRows`)
- [ ] Manual: `_diff` against a hot PK with >1000 events in window now returns the full set