### PR TITLE
shim: extract selectImage helper + table tests

### DIFF
--- a/internal/shim/handler.go
+++ b/internal/shim/handler.go
@@ -163,25 +163,49 @@ func (h *Handler) runPointInTime(q TimeTravelQuery) (*mysql.Result, error) {
 		return nil, fmt.Errorf("resolve %s: %w", q.Type, err)
 	}
 
-	if len(rows) == 0 {
+	image := selectImage(rows)
+	if image == nil {
 		return emptyResult(), nil
 	}
-
-	// LimitPerPK=1 returns at most one row per PK; we asked for one
-	// PK, so rows[0] is the answer.
-	latest := rows[0]
-
-	var image map[string]any
-	switch {
-	case len(latest.RowAfter) > 0:
-		image = latest.RowAfter
-	case len(latest.RowBefore) > 0:
-		image = latest.RowBefore
-	default:
-		return emptyResult(), nil
-	}
-
 	return imageToResult(image)
+}
+
+// selectImage picks the row image that represents the row's state at
+// the queried point in time, given the LimitPerPK=1 result of a
+// _flashback / _snapshot fetch.
+//
+// The caller passes whatever FetchMerged returned. Because we issue
+// the fetch with LimitPerPK=1 and a single PKValues filter, at most
+// one row reaches this helper — but selectImage tolerates an empty
+// or larger slice and only ever inspects rows[0], so a future caller
+// that loosens the limit cannot accidentally pick the wrong event.
+//
+// Priority: row_after wins when present (the post-image of an
+// INSERT/UPDATE is the row's state). Fall back to row_before for
+// DELETE events, where row_after is empty but row_before captures the
+// row's state at the moment of deletion. Returns nil to signal the
+// caller should respond with an empty resultset — either because
+// there were no rows, or because both images were empty (which would
+// indicate corrupted index data, treated as "no answer" rather than
+// fabricating one).
+//
+// Extracted as a pure helper specifically so the priority rule can
+// be unit-tested without spinning up a real MySQL: a future refactor
+// that swaps the row_after / row_before order would silently return
+// stale data on every UPDATE, with the regression invisible to any
+// test that doesn't exercise this exact branch.
+func selectImage(rows []query.ResultRow) map[string]any {
+	if len(rows) == 0 {
+		return nil
+	}
+	latest := rows[0]
+	if len(latest.RowAfter) > 0 {
+		return latest.RowAfter
+	}
+	if len(latest.RowBefore) > 0 {
+		return latest.RowBefore
+	}
+	return nil
 }
 
 // runDiff resolves a _diff query: every event for the given PK

--- a/internal/shim/handler_test.go
+++ b/internal/shim/handler_test.go
@@ -10,6 +10,9 @@ import (
 	_ "github.com/go-sql-driver/mysql" // database/sql driver registration
 	gomysql "github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/go-mysql-org/go-mysql/server"
+
+	"github.com/dbtrail/bintrail/internal/parser"
+	"github.com/dbtrail/bintrail/internal/query"
 )
 
 // TestHandlerHandshakeNoise verifies the small allow-list for queries
@@ -125,6 +128,76 @@ func TestImageToResultColumnOrder(t *testing.T) {
 	}
 }
 
+// TestSelectImage covers every branch of the row-image priority rule
+// used by runPointInTime. The function is intentionally pure so it
+// can be exercised without sqlmock or a real MySQL: the rest of the
+// _flashback / _snapshot pipeline (sort, LimitPerPK, archive merge)
+// is covered by the query package's own tests.
+//
+// A future refactor that swaps the row_after / row_before priority,
+// or that mishandles a DELETE event (row_after empty by definition),
+// would silently return wrong row state to the customer. The
+// "delete_fallback" case is the tripwire for that regression.
+func TestSelectImage(t *testing.T) {
+	after := map[string]any{"id": int64(1), "name": "after"}
+	before := map[string]any{"id": int64(1), "name": "before"}
+
+	cases := []struct {
+		name string
+		rows []query.ResultRow
+		want map[string]any
+	}{
+		{
+			name: "empty_input",
+			rows: nil,
+			want: nil,
+		},
+		{
+			name: "insert_returns_row_after",
+			rows: []query.ResultRow{{
+				EventType: parser.EventInsert,
+				RowAfter:  after,
+			}},
+			want: after,
+		},
+		{
+			name: "update_prefers_row_after",
+			rows: []query.ResultRow{{
+				EventType: parser.EventUpdate,
+				RowBefore: before,
+				RowAfter:  after,
+			}},
+			want: after,
+		},
+		{
+			name: "delete_fallback_to_row_before",
+			rows: []query.ResultRow{{
+				EventType: parser.EventDelete,
+				RowBefore: before,
+			}},
+			want: before,
+		},
+		{
+			name: "both_empty_returns_nil",
+			rows: []query.ResultRow{{
+				EventType: parser.EventUpdate,
+				RowBefore: map[string]any{},
+				RowAfter:  map[string]any{},
+			}},
+			want: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := selectImage(tc.rows)
+			if !equalMaps(got, tc.want) {
+				t.Errorf("selectImage = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestImageToResultEmpty — an empty image (zero-key map) should
 // produce a resultset with no rows.
 func TestImageToResultEmpty(t *testing.T) {
@@ -235,6 +308,26 @@ func equalStrings(a, b []string) bool {
 	}
 	for i := range a {
 		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// equalMaps compares two map[string]any by length and value identity
+// (==). Sufficient for the selectImage tests because they intentionally
+// pass the same map literal as both input and expected output, so a
+// pointer-equal value comparison detects "did selectImage return the
+// expected source map?". Returning a *different* map with equal contents
+// would fail this check — which is the correct outcome, since the
+// helper's contract is to hand back the input image unchanged, not a
+// copy.
+func equalMaps(a, b map[string]any) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, va := range a {
+		if vb, ok := b[k]; !ok || va != vb {
 			return false
 		}
 	}

--- a/internal/shim/handler_test.go
+++ b/internal/shim/handler_test.go
@@ -178,6 +178,23 @@ func TestSelectImage(t *testing.T) {
 			want: before,
 		},
 		{
+			// Pin the len() > 0 vs != nil distinction. A future
+			// refactor that swapped len() for a nil-check would
+			// silently regress DELETE handling if the indexer ever
+			// emitted an empty non-nil RowAfter (defensive map
+			// allocation upstream, redaction blanking every column,
+			// etc.). Without this case the regression slips through
+			// both "delete_fallback" (RowAfter is nil there) and
+			// "both_empty" (RowBefore is also empty there).
+			name: "row_after_empty_map_falls_back_to_row_before",
+			rows: []query.ResultRow{{
+				EventType: parser.EventDelete,
+				RowAfter:  map[string]any{},
+				RowBefore: before,
+			}},
+			want: before,
+		},
+		{
 			name: "both_empty_returns_nil",
 			rows: []query.ResultRow{{
 				EventType: parser.EventUpdate,


### PR DESCRIPTION
Closes #248.

## Summary

- Extract the row-image priority rule from `runPointInTime` into a pure `selectImage([]query.ResultRow) map[string]any` helper in `internal/shim/handler.go`.
- Add `TestSelectImage` with five table-driven cases: empty input, INSERT, UPDATE-prefers-row_after, DELETE fallback, both-images-empty.
- No new test deps; the helper is pure so sqlmock isn't needed.

## Why this scope (Occam over the issue's full plan)

The issue listed five test cases. Three (INSERT, DELETE fallback, pre-AsOf) are genuinely about the image-selection branch — that's the regression-prone, hand-coded logic worth pinning. The other two (UPDATE chain ordering, `event_id` tie-break) are about the SQL emitted by `query.FetchMerged` with `LimitPerPK=1`, which is already covered by the `query` package's own tests. Re-exercising them through the shim would require sqlmock for zero additional safety.

Equivalent coverage of the genuinely fragile branch — nothing more.

## Test plan

- [x] `go test ./internal/shim/... -count=1 -run TestSelectImage -v` — all 5 subtests pass
- [x] `go test ./... -count=1` — full unit suite green