### PR TITLE
shim: exponential backoff in Accept loop

### DIFF
--- a/cmd/bintrail/shim.go
+++ b/cmd/bintrail/shim.go
@@ -141,10 +141,17 @@ func runShim(cmd *cobra.Command, args []string) error {
 // connection runs in its own goroutine with its own Handler instance
 // (Handler holds per-connection state: the currently-selected
 // database).
+//
+// Accept errors that aren't shutdown signals (ctx cancellation, listener
+// closed) are retried with exponential backoff so a transient kernel
+// hiccup doesn't burn CPU and a permanent listener wedge doesn't fill
+// the log at ~10 lines/sec. The backoff resets to zero on every
+// successful Accept so a brief spike doesn't poison the steady state.
 func serveLoop(ctx context.Context, listener net.Listener, db *sql.DB, auth shim.TenantAuth, cfg shim.Config) {
 	var wg sync.WaitGroup
 	defer wg.Wait()
 
+	var backoff time.Duration
 	for {
 		conn, err := listener.Accept()
 		if err != nil {
@@ -154,18 +161,55 @@ func serveLoop(ctx context.Context, listener net.Listener, db *sql.DB, auth shim
 			if errors.Is(err, net.ErrClosed) {
 				return
 			}
-			slog.Error("accept failed", "err", err)
-			// Brief backoff so a persistent accept error doesn't
-			// burn CPU.
-			time.Sleep(100 * time.Millisecond)
+			backoff = nextAcceptBackoff(backoff)
+			slog.Error("accept failed", "err", err, "backoff", backoff)
+			// Sleep via select so SIGTERM can interrupt a long
+			// backoff — without this, a wedged listener at the
+			// 5s cap would keep the process alive for up to 5s
+			// after the operator pressed Ctrl+C.
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(backoff):
+			}
 			continue
 		}
+		backoff = 0
 		wg.Add(1)
 		go func(c net.Conn) {
 			defer wg.Done()
 			handleConn(c, db, auth, cfg)
 		}(conn)
 	}
+}
+
+const (
+	// initialAcceptBackoff is the first sleep after a non-fatal Accept
+	// error. Short enough that a single transient blip is invisible to
+	// callers; long enough that a flapping error doesn't spin.
+	initialAcceptBackoff = 100 * time.Millisecond
+	// maxAcceptBackoff caps the exponential growth. 5s is the longest
+	// we'll let an operator wait between "listener wedged" log lines
+	// and the longest a SIGTERM can be delayed waiting on the sleep.
+	maxAcceptBackoff = 5 * time.Second
+)
+
+// nextAcceptBackoff returns the next sleep interval given the current
+// one. Doubles up to maxAcceptBackoff; the zero value (steady state
+// after a successful Accept) seeds the first retry at
+// initialAcceptBackoff.
+//
+// Pure function so the doubling + cap behaviour can be unit-tested
+// without driving a real listener through error states.
+func nextAcceptBackoff(current time.Duration) time.Duration {
+	if current <= 0 {
+		return initialAcceptBackoff
+	}
+	next := current * 2
+	if next > maxAcceptBackoff {
+		return maxAcceptBackoff
+	}
+	return next
 }
 
 // isLoopbackAddr reports whether addr resolves to a loopback address.

--- a/cmd/bintrail/shim_test.go
+++ b/cmd/bintrail/shim_test.go
@@ -1,9 +1,14 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"net"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/dbtrail/bintrail/internal/shim"
 )
 
 // TestIsLoopbackAddr locks in the security-relevant guard that
@@ -81,4 +86,76 @@ func TestAcceptBackoffSequence(t *testing.T) {
 	if d != maxAcceptBackoff {
 		t.Errorf("after %d steps, got %v; want exactly %v", steps, d, maxAcceptBackoff)
 	}
+}
+
+// TestServeLoopExitsOnContextCancel locks in the operator-shutdown
+// guarantee: a ctx cancellation must interrupt the accept loop even
+// when it's mid-sleep waiting out a backoff. Without the cancellable
+// select inside the error branch (a plain time.Sleep would block for
+// up to maxAcceptBackoff), Ctrl+C against a wedged listener could
+// take up to 5 seconds to take effect.
+//
+// The test drives serveLoop with a synthetic listener whose Accept
+// always returns a non-net.ErrClosed error, so the loop is forced
+// down the backoff path on every iteration. We let it spin briefly
+// to accumulate a non-trivial backoff, then cancel the context, and
+// assert serveLoop returns well under maxAcceptBackoff.
+func TestServeLoopExitsOnContextCancel(t *testing.T) {
+	listener := &alwaysErrorListener{}
+	defer listener.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		// db / auth / cfg are unused on this path because Accept
+		// never returns a connection — handleConn is unreachable.
+		serveLoop(ctx, listener, nil, shim.TenantAuth{}, shim.Config{})
+		close(done)
+	}()
+
+	// Let the loop accumulate a couple of backoff doublings so the
+	// next sleep is meaningfully long (>= 200ms). This forces the
+	// cancel below to actually interrupt a sleep, rather than
+	// landing between iterations and exiting via the top-of-loop
+	// ctx check.
+	time.Sleep(150 * time.Millisecond)
+	cancel()
+
+	timeout := maxAcceptBackoff - time.Second
+	select {
+	case <-done:
+		// ok
+	case <-time.After(timeout):
+		t.Fatalf(
+			"serveLoop did not exit within %v of ctx cancel; "+
+				"the cancellable select must not have fired (a plain time.Sleep would block up to %v)",
+			timeout, maxAcceptBackoff,
+		)
+	}
+}
+
+// alwaysErrorListener is a minimal net.Listener whose Accept always
+// returns a synthetic non-net.ErrClosed error until Close is called.
+// Used by TestServeLoopExitsOnContextCancel to drive the accept
+// loop's error branch deterministically without binding a real port.
+type alwaysErrorListener struct {
+	closed atomic.Bool
+}
+
+func (l *alwaysErrorListener) Accept() (net.Conn, error) {
+	if l.closed.Load() {
+		return nil, net.ErrClosed
+	}
+	return nil, errors.New("synthetic accept failure")
+}
+
+func (l *alwaysErrorListener) Close() error {
+	l.closed.Store(true)
+	return nil
+}
+
+func (l *alwaysErrorListener) Addr() net.Addr {
+	return &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0}
 }

--- a/cmd/bintrail/shim_test.go
+++ b/cmd/bintrail/shim_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"net"
 	"testing"
+	"time"
 )
 
 // TestIsLoopbackAddr locks in the security-relevant guard that
@@ -31,5 +32,53 @@ func TestIsLoopbackAddr(t *testing.T) {
 				t.Errorf("isLoopbackAddr(%v) = %v, want %v", tc.addr, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestNextAcceptBackoff pins the doubling-with-cap behaviour. A
+// regression here matters because the backoff is what stops a wedged
+// listener from filling the log at ~10 lines/sec — and a buggy reset
+// (e.g. always returning initial) would silently re-spin.
+func TestNextAcceptBackoff(t *testing.T) {
+	cases := []struct {
+		name    string
+		current time.Duration
+		want    time.Duration
+	}{
+		{"zero seeds at initial", 0, initialAcceptBackoff},
+		{"negative seeds at initial", -1, initialAcceptBackoff},
+		{"100ms doubles to 200ms", 100 * time.Millisecond, 200 * time.Millisecond},
+		{"200ms doubles to 400ms", 200 * time.Millisecond, 400 * time.Millisecond},
+		{"2s doubles to 4s", 2 * time.Second, 4 * time.Second},
+		{"4s doubles to cap", 4 * time.Second, maxAcceptBackoff},
+		{"at cap stays at cap", maxAcceptBackoff, maxAcceptBackoff},
+		{"above cap clamps to cap", 30 * time.Second, maxAcceptBackoff},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := nextAcceptBackoff(tc.current); got != tc.want {
+				t.Errorf("nextAcceptBackoff(%v) = %v, want %v", tc.current, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAcceptBackoffSequence walks the steady-state usage: starting
+// from zero (post-success), each call models another consecutive
+// failure. Verifies the cap is reached in a bounded number of steps —
+// today's constants reach the 5s cap on the 7th failure (100, 200,
+// 400, 800, 1600, 3200, 5000ms).
+func TestAcceptBackoffSequence(t *testing.T) {
+	var d time.Duration
+	steps := 0
+	for d < maxAcceptBackoff {
+		d = nextAcceptBackoff(d)
+		steps++
+		if steps > 20 {
+			t.Fatalf("backoff did not reach cap after %d steps; got %v", steps, d)
+		}
+	}
+	if d != maxAcceptBackoff {
+		t.Errorf("after %d steps, got %v; want exactly %v", steps, d, maxAcceptBackoff)
 	}
 }

--- a/cmd/bintrail/shim_test.go
+++ b/cmd/bintrail/shim_test.go
@@ -88,24 +88,27 @@ func TestAcceptBackoffSequence(t *testing.T) {
 	}
 }
 
-// TestServeLoopExitsOnContextCancel locks in the operator-shutdown
-// guarantee: a ctx cancellation must interrupt the accept loop even
-// when it's mid-sleep waiting out a backoff. Without the cancellable
-// select inside the error branch (a plain time.Sleep would block for
-// up to maxAcceptBackoff), Ctrl+C against a wedged listener could
-// take up to 5 seconds to take effect.
+// TestServeLoopExitsOnContextCancel asserts that serveLoop returns
+// within 1 second of ctx cancellation when driven against a listener
+// whose Accept never succeeds. This catches the operator-visible
+// failure mode the cancellable select was added to defend against:
+// a regression that introduces a multi-second uninterruptible sleep
+// in the error branch (e.g. `time.Sleep(maxAcceptBackoff)`) would
+// block past the 1s bound and fail.
 //
-// The test drives serveLoop with a synthetic listener whose Accept
-// always returns a non-net.ErrClosed error, so the loop is forced
-// down the backoff path on every iteration. We let it spin briefly
-// to accumulate a non-trivial backoff, then cancel the context, and
-// assert serveLoop returns well under maxAcceptBackoff.
+// What this test does NOT catch: a regression to a short fixed sleep
+// (e.g. the literal `time.Sleep(100*time.Millisecond)` from before
+// this PR). With a short sleep, the top-of-loop ctx check at the next
+// iteration still exits within ~100ms of cancel — under the bound.
+// That's a deliberate scoping choice: a 100ms shutdown delay is not
+// the operator pain point this PR addresses; a 5s wedge is. Tightening
+// the bound below ~50ms would make the test flaky on slow CI without
+// catching a meaningfully worse regression.
 func TestServeLoopExitsOnContextCancel(t *testing.T) {
 	listener := &alwaysErrorListener{}
 	defer listener.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 
 	done := make(chan struct{})
 	go func() {
@@ -115,23 +118,29 @@ func TestServeLoopExitsOnContextCancel(t *testing.T) {
 		close(done)
 	}()
 
-	// Let the loop accumulate a couple of backoff doublings so the
-	// next sleep is meaningfully long (>= 200ms). This forces the
-	// cancel below to actually interrupt a sleep, rather than
-	// landing between iterations and exiting via the top-of-loop
-	// ctx check.
+	// Reap the goroutine deterministically on test failure so a
+	// regression that wedges serveLoop doesn't leak it past
+	// t.Fatalf into other tests.
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
+
+	// Brief spin so the loop is in a non-trivial state when cancel
+	// arrives — not load-bearing for correctness; cancellation works
+	// from any iteration.
 	time.Sleep(150 * time.Millisecond)
 	cancel()
 
-	timeout := maxAcceptBackoff - time.Second
+	const exitBound = 1 * time.Second
 	select {
 	case <-done:
 		// ok
-	case <-time.After(timeout):
+	case <-time.After(exitBound):
 		t.Fatalf(
 			"serveLoop did not exit within %v of ctx cancel; "+
-				"the cancellable select must not have fired (a plain time.Sleep would block up to %v)",
-			timeout, maxAcceptBackoff,
+				"a multi-second uninterruptible sleep regression in the error branch would block this long",
+			exitBound,
 		)
 	}
 }


### PR DESCRIPTION
Closes #247.

## Summary

- Replace the fixed 100ms sleep on Accept errors with exponential backoff: 100ms → 5s, doubling. Reset to zero on every successful Accept.
- Use `select { ctx.Done() / time.After }` instead of bare `time.Sleep` so SIGTERM during a long backoff returns immediately.
- Extract `nextAcceptBackoff(time.Duration) time.Duration` as a pure helper; cover with `TestNextAcceptBackoff` (8 cases) and `TestAcceptBackoffSequence` (steady-state walk to cap).

## Why backoff over the issue's circuit-breaker proposal

The issue proposed exiting after N=100 consecutive Accept errors so systemd's `Restart=on-failure` could recover. That fixes a real failure mode but introduces a magic threshold that needs tuning, documenting, and testing — for a behaviour the operator can already trigger manually (kill the process).

The actual operator pain is **runaway log volume** — ~10 error lines/sec under a permanent failure. Exponential backoff cuts that to one line every 0.5s rising to one every 5s, which is enough signal to alert on without burning CPU or spamming logs. No new tunable, no threshold to defend.

## Test plan

- [x] `go test ./cmd/bintrail/... -count=1 -run "TestNextAcceptBackoff|TestAcceptBackoffSequence" -v` — all subtests pass
- [x] `go test ./... -count=1` — full unit suite green
- [ ] Manual: SIGTERM during backoff returns within sleep tick, not after the full 5s
