### PR TITLE
schema: drop dead idx_file_pos from binlog_events

### DIFF
--- a/migrations/002_drop_idx_file_pos.sql
+++ b/migrations/002_drop_idx_file_pos.sql
@@ -1,5 +1,13 @@
 -- 002_drop_idx_file_pos.sql
 --
+-- OPERATOR-FACING ONLY. This file is NOT auto-applied by `bintrail init`,
+-- the agent, or `indexer.EnsureSchema(db)`. Apply manually per tenant
+-- against the index database with the bintrail DB selected, e.g.:
+--
+--   mysql -u<user> -p<pass> -h<host> <index_db> < 002_drop_idx_file_pos.sql
+--
+-- Same convention as 001_create_tables.sql (see header on that file).
+--
 -- Removes the dead idx_file_pos index from binlog_events. The index was
 -- declared at project inception (bintrail-spec.md:215, mid-Mar 2026) but
 -- the query/recover paths shipped using gtid, event_timestamp, and pk_hash


### PR DESCRIPTION
closes nethalo/dbtrail#1199 (Phase 2)

## Summary
`idx_file_pos (binlog_file, start_pos)` is dead code on `binlog_events`. Confirmed by two independent methods on 2026-04-08:

- **performance_schema fetch counts** — 0 fetches over 23.6 days on a production tenant with normal traffic (vs `idx_gtid` which also shows 0 fetches but is actively used by query/recover paths and zero just means no GTID-based recovery in the window).
- **Exhaustive grep across `nethalo/dbtrail` + `dbtrail/bintrail`** — zero queries filter `binlog_events` by `binlog_file` or `start_pos`. The query/recover paths shipped using `gtid`, `event_timestamp`, and `pk_hash`. The index has been orphaned since project inception.

## Changes
- `cmd/bintrail/init.go` — remove `INDEX idx_file_pos` from the runtime DDL emitted by `bintrail init`.
- `migrations/001_create_tables.sql` — remove from the reference schema.
- `internal/testutil/testutil.go` — remove from the test fixture.
- `bintrail-spec.md` — remove from the spec.
- `migrations/002_drop_idx_file_pos.sql` — new idempotent migration that physically drops the index on existing tenants. The `information_schema.statistics` guard makes it a no-op on tenants where Phase 4 has already been applied manually or where the index was never created.

## Phasing context
- Phase 1 (mark INVISIBLE on demo tenant) — applied 2026-04-08, soaked clean for 25 days.
- Phase 2 (this PR).
- Phase 3 (mark INVISIBLE on remaining production tenants) — manual SQL, runs in parallel with Phase 2 review.
- Phase 4 (physical DROP across the fleet) — apply `002_drop_idx_file_pos.sql` to each tenant after a 1-week soak.

## Win
- ~40 bytes/row reclaimed (≈250 MB on a 6.3M-row tenant, ~1-2 GB fleet-wide).
- One fewer secondary index touched on every INSERT (~30 k inserts/min on demo = ~1.8 M fewer B-tree writes/hour per tenant).
- ALTER TABLE ops (partition add/drop/reorg) touch one less index tree.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./... -short` — full bintrail suite passes (no regressions)
- [ ] Apply `002_drop_idx_file_pos.sql` against a copy of the demo tenant — verify it succeeds when the index is INVISIBLE-but-present (current state) and is a clean no-op on a re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
