### PR TITLE
shim: scope planner to index DB, not query schema (closes #259, #260)

### DIFF
--- a/cmd/bintrail/shim.go
+++ b/cmd/bintrail/shim.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/go-mysql-org/go-mysql/server"
+	mysqldriver "github.com/go-sql-driver/mysql"
 	"github.com/spf13/cobra"
 
 	"github.com/dbtrail/bintrail/internal/config"
@@ -143,7 +144,22 @@ func runShim(cmd *cobra.Command, args []string) error {
 		listener.Close()
 	}()
 
-	cfg := shim.Config{AllowGaps: shAllowGaps, NoArchive: shNoArchive}
+	// config.Connect already parsed and pinged shIndexDSN above, so a parse
+	// failure here would be a programming defect, not a configuration error
+	// — surface it loud rather than degrading silently. The empty-DBName
+	// check catches the more common operator mistake of pointing the shim
+	// at a DSN with no database path; without it, every customer query
+	// would fail at FetchMerged.validate() with an opaque wire-protocol
+	// error or, under AllowGaps=true, silently skip gap detection.
+	dsnCfg, err := mysqldriver.ParseDSN(shIndexDSN)
+	if err != nil {
+		return fmt.Errorf("parse index DSN: %w", err)
+	}
+	if dsnCfg.DBName == "" {
+		return fmt.Errorf("index DSN must include the database name (e.g. /bintrail_index)")
+	}
+
+	cfg := shim.Config{AllowGaps: shAllowGaps, NoArchive: shNoArchive, IndexDBName: dsnCfg.DBName}
 	serveLoop(ctx, listener, db, auth, cfg)
 	return nil
 }

--- a/internal/shim/handler.go
+++ b/internal/shim/handler.go
@@ -65,6 +65,10 @@ type Config struct {
 	// loop, even if archive_state has rows. Defaults to false (archives
 	// are queried). Independent of AllowGaps.
 	NoArchive bool
+	// IndexDBName is the schema where binlog_events lives. The planner
+	// scopes information_schema.PARTITIONS to it; the user query's
+	// schema is the wrong answer (every hour misclassified as a gap).
+	IndexDBName string
 }
 
 // NewHandler constructs a Handler bound to a bintrail index DSN with
@@ -168,7 +172,7 @@ func (h *Handler) runPointInTime(q TimeTravelQuery) (*mysql.Result, error) {
 			Until:      &q.AsOf,
 			LimitPerPK: 1,
 		},
-		DBName:         q.Schema,
+		DBName:         h.cfg.IndexDBName,
 		NoArchive:      h.cfg.NoArchive,
 		AllowGaps:      h.cfg.AllowGaps,
 		ArchiveFetcher: h.archiveFetcher,
@@ -249,7 +253,7 @@ func (h *Handler) runDiff(q TimeTravelQuery) (*mysql.Result, error) {
 			Since:    &q.Since,
 			Until:    &q.Until,
 		},
-		DBName:         q.Schema,
+		DBName:         h.cfg.IndexDBName,
 		NoArchive:      h.cfg.NoArchive,
 		AllowGaps:      h.cfg.AllowGaps,
 		ArchiveFetcher: h.archiveFetcher,

--- a/internal/shim/handler_integration_test.go
+++ b/internal/shim/handler_integration_test.go
@@ -1,0 +1,151 @@
+//go:build integration
+
+package shim
+
+import (
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/go-mysql-org/go-mysql/mysql"
+
+	"github.com/dbtrail/bintrail/internal/indexer"
+	"github.com/dbtrail/bintrail/internal/testutil"
+)
+
+// TestRunPointInTime_PlannerCoversCurrentHour pins issue #259: planner
+// must not classify the current hour as a coverage gap. The sqlmock
+// counterpart in handler_test.go can't catch information_schema.PARTITIONS
+// shape drift.
+func TestRunPointInTime_PlannerCoversCurrentHour(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Hour)
+	addHourlyPartition(t, db, now)
+
+	// Seed previous-hour archive so buildPlan doesn't short-circuit to
+	// nil (runPointInTime passes only Until). Without this, the
+	// regression hides — engine.Fetch answers from binlog_events
+	// regardless of the planner's DBName.
+	prev := now.Add(-time.Hour).Format("p_2006010215")
+	testutil.MustExec(t, db,
+		"INSERT INTO archive_state (partition_name, archived_at) VALUES (?, NOW())",
+		prev)
+
+	eventTS := now.Add(5 * time.Minute).Format("2006-01-02 15:04:05")
+	testutil.InsertEvent(t, db, "mysql-bin.000001", 100, 200, eventTS, nil,
+		"myapp", "users", 1, "1", nil, nil, []byte(`{"id":1,"name":"alice"}`))
+
+	h := NewHandlerWithConfig(db, Config{
+		AllowGaps:   false,
+		NoArchive:   true,
+		IndexDBName: dbName,
+	}, slog.Default())
+
+	result, err := h.runPointInTime(TimeTravelQuery{
+		Type:    TypeFlashback,
+		Schema:  "myapp",
+		Table:   "users",
+		PKValue: "1",
+		AsOf:    now.Add(10 * time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("runPointInTime: %v", err)
+	}
+	if result == nil || result.Resultset == nil {
+		t.Fatal("expected non-nil resultset")
+	}
+	// Server-built resultsets populate RowDatas, not Values; RowNumber()
+	// reads len(Values) and is always 0.
+	if got := len(result.Resultset.RowDatas); got != 1 {
+		t.Errorf("expected 1 row, got %d", got)
+	}
+	// Field shape distinguishes a real row from emptyResult's
+	// `[_flashback]` sentinel. imageToResult sorts JSON keys, so the
+	// row we inserted ({"id","name"}) yields exactly these two fields.
+	gotFields := fieldNames(result.Resultset.Fields)
+	if want := []string{"id", "name"}; !slices.Equal(gotFields, want) {
+		t.Errorf("fields = %v, want %v", gotFields, want)
+	}
+}
+
+// TestRunDiff_PlannerCoversCurrentHour pins #259 for runDiff, which
+// fails loud (*query.GapError) where runPointInTime fails silent —
+// distinct guards for distinct shapes.
+func TestRunDiff_PlannerCoversCurrentHour(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Hour)
+	addHourlyPartition(t, db, now)
+
+	eventTS := now.Add(5 * time.Minute).Format("2006-01-02 15:04:05")
+	testutil.InsertEvent(t, db, "mysql-bin.000001", 100, 200, eventTS, nil,
+		"myapp", "users", 1, "1", nil, nil, []byte(`{"id":1,"name":"alice"}`))
+
+	h := NewHandlerWithConfig(db, Config{
+		AllowGaps:   false,
+		NoArchive:   true,
+		IndexDBName: dbName,
+	}, slog.Default())
+
+	// Keep window inside the partitioned hour: planner expands rangeEnd
+	// to until.Truncate(Hour)+1h, so until=hour+30m won't hit the next hour.
+	result, err := h.runDiff(TimeTravelQuery{
+		Type:    TypeDiff,
+		Schema:  "myapp",
+		Table:   "users",
+		PKValue: "1",
+		Since:   now.Add(time.Minute),
+		Until:   now.Add(30 * time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("runDiff: %v", err)
+	}
+	if result == nil || result.Resultset == nil {
+		t.Fatal("expected non-nil resultset")
+	}
+	if got := len(result.Resultset.RowDatas); got != 1 {
+		t.Errorf("expected 1 row, got %d", got)
+	}
+	// runDiff hardcodes its 6-column shape; verifying the field set
+	// guards against the empty-result fallback being silently returned.
+	gotFields := fieldNames(result.Resultset.Fields)
+	want := []string{"event_id", "event_timestamp", "event_type", "gtid", "row_before", "row_after"}
+	if !slices.Equal(gotFields, want) {
+		t.Errorf("fields = %v, want %v", gotFields, want)
+	}
+}
+
+// addHourlyPartition reorganizes p_future into one named hourly partition
+// + fresh p_future, matching the layout `bintrail init` produces.
+// Format args come from time.Format so injection is impossible.
+func addHourlyPartition(t *testing.T, db *sql.DB, h time.Time) {
+	t.Helper()
+	pName := h.Format("p_2006010215")
+	upper := h.Add(time.Hour).Format("2006-01-02 15:04:05")
+	testutil.MustExec(t, db, fmt.Sprintf(
+		"ALTER TABLE binlog_events REORGANIZE PARTITION p_future INTO ("+
+			"PARTITION %s VALUES LESS THAN (TO_SECONDS('%s')), "+
+			"PARTITION p_future VALUES LESS THAN MAXVALUE)",
+		pName, upper,
+	))
+}
+
+func fieldNames(fields []*mysql.Field) []string {
+	out := make([]string, len(fields))
+	for i, f := range fields {
+		out[i] = string(f.Name)
+	}
+	return out
+}

--- a/internal/shim/handler_test.go
+++ b/internal/shim/handler_test.go
@@ -293,7 +293,7 @@ func TestRunPointInTimeInvokesArchiveFetcher(t *testing.T) {
 
 	h := &Handler{
 		indexDB:        db,
-		cfg:            Config{AllowGaps: true},
+		cfg:            Config{AllowGaps: true, IndexDBName: "bintrail_index"},
 		logger:         slog.Default(),
 		archiveFetcher: fakeFetcher,
 	}
@@ -361,7 +361,7 @@ func TestRunPointInTimeStrictModePropagatesArchiveError(t *testing.T) {
 
 	h := &Handler{
 		indexDB:        db,
-		cfg:            Config{AllowGaps: false},
+		cfg:            Config{AllowGaps: false, IndexDBName: "bintrail_index"},
 		logger:         slog.Default(),
 		archiveFetcher: failingFetcher,
 	}
@@ -385,6 +385,105 @@ func TestRunPointInTimeStrictModePropagatesArchiveError(t *testing.T) {
 	// not the contract this test is here to enforce.
 	if !errors.Is(err, archiveErr) {
 		t.Errorf("expected wrapped archiveErr sentinel, got %v", err)
+	}
+}
+
+// TestPlannerScopesPartitionsToIndexDB pins issue #259: the planner
+// must scope information_schema.PARTITIONS to the index DB, not the
+// user query's schema. A regression that re-passes q.Schema causes
+// _flashback/_snapshot to return 0 rows (every hour misclassified as
+// a coverage gap) and _diff to abort under strict mode.
+func TestPlannerScopesPartitionsToIndexDB(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	mock.MatchExpectationsInOrder(false)
+	mock.ExpectQuery("FROM archive_state").
+		WillReturnRows(sqlmock.NewRows([]string{"bintrail_id", "sample_local", "sample_bucket", "sample_key"}))
+	mock.ExpectQuery("information_schema.PARTITIONS").
+		WithArgs("bintrail_index").
+		WillReturnRows(sqlmock.NewRows([]string{"PARTITION_NAME"}).
+			AddRow("p_2026050415"))
+	mock.ExpectQuery("FROM binlog_events").
+		WillReturnRows(sqlmock.NewRows([]string{"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp", "gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values", "changed_columns", "row_before", "row_after", "schema_version"}))
+
+	h := &Handler{
+		indexDB: db,
+		cfg: Config{
+			AllowGaps:   false,
+			NoArchive:   false,
+			IndexDBName: "bintrail_index",
+		},
+		logger:         slog.Default(),
+		archiveFetcher: func(ctx context.Context, opts query.Options, src string) ([]query.ResultRow, error) { return nil, nil },
+	}
+
+	q := TimeTravelQuery{
+		Type:    TypeFlashback,
+		Schema:  "e2e_source",
+		Table:   "orders",
+		PKValue: "1",
+		AsOf:    time.Date(2026, 5, 4, 15, 17, 52, 0, time.UTC),
+	}
+	if _, err := h.runPointInTime(q); err != nil {
+		t.Fatalf("runPointInTime: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("sqlmock expectations not met (the planner likely scoped to %q instead of %q): %v",
+			q.Schema, h.cfg.IndexDBName, err)
+	}
+}
+
+// TestRunDiffScopesPartitionsToIndexDB is the runDiff sibling of
+// TestPlannerScopesPartitionsToIndexDB. The two call sites do the same
+// thing today, but a future refactor that splits Config could re-break
+// _diff in isolation while leaving _flashback working — pinning each
+// call site independently catches that.
+func TestRunDiffScopesPartitionsToIndexDB(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	mock.MatchExpectationsInOrder(false)
+	mock.ExpectQuery("FROM archive_state").
+		WillReturnRows(sqlmock.NewRows([]string{"bintrail_id", "sample_local", "sample_bucket", "sample_key"}))
+	mock.ExpectQuery("information_schema.PARTITIONS").
+		WithArgs("bintrail_index").
+		WillReturnRows(sqlmock.NewRows([]string{"PARTITION_NAME"}).
+			AddRow("p_2026050415"))
+	mock.ExpectQuery("FROM binlog_events").
+		WillReturnRows(sqlmock.NewRows([]string{"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp", "gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values", "changed_columns", "row_before", "row_after", "schema_version"}))
+
+	h := &Handler{
+		indexDB: db,
+		cfg: Config{
+			AllowGaps:   false,
+			NoArchive:   false,
+			IndexDBName: "bintrail_index",
+		},
+		logger:         slog.Default(),
+		archiveFetcher: func(ctx context.Context, opts query.Options, src string) ([]query.ResultRow, error) { return nil, nil },
+	}
+
+	q := TimeTravelQuery{
+		Type:    TypeDiff,
+		Schema:  "e2e_source",
+		Table:   "orders",
+		PKValue: "1",
+		Since:   time.Date(2026, 5, 4, 15, 17, 0, 0, time.UTC),
+		Until:   time.Date(2026, 5, 4, 15, 18, 0, 0, time.UTC),
+	}
+	if _, err := h.runDiff(q); err != nil {
+		t.Fatalf("runDiff: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("sqlmock expectations not met (the planner likely scoped to %q instead of %q): %v",
+			q.Schema, h.cfg.IndexDBName, err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fix #259: `runPointInTime` / `runDiff` were passing `q.Schema` (the user query's schema, e.g. `e2e_source`) to `query.FetchMerged`'s planner instead of the **index** DB. The planner queries `information_schema.PARTITIONS WHERE TABLE_SCHEMA = ?`; with the wrong arg it returned zero partitions and falsely classified every queried hour as a coverage gap. `_flashback`/`_snapshot` then silently returned 0 rows and `_diff` aborted under strict mode.

- Plumb a new `shim.Config.IndexDBName` field — extracted from the index DSN at startup via `mysqldriver.ParseDSN` — through both call sites. Same pattern `cmd/bintrail/query.go` already uses for the CLI planner path.

- Closes #260: add real-MySQL integration tests that catch the regression class the existing sqlmock tests can't (e.g. `information_schema.PARTITIONS` shape drift, the `PARTITION_NAME != 'p_future'` filter, ordering).

## Why fail-loud at startup

Bonus hardening surfaced during review: `cmd/bintrail/shim.go` now refuses to start if the index DSN fails to parse **or** omits the database name. Both conditions previously degraded silently — under `AllowGaps=false` (the production default since #258), every customer query would 1105-error with internal field names leaked to the wire-protocol client; under `AllowGaps=true`, gap detection silently disabled. Detected via `silent-failure-hunter` in PR review.

## Test plan

- [x] `go test ./...` — full unit suite passes
- [x] `go test -tags integration -run 'TestRunPointInTime_PlannerCoversCurrentHour|TestRunDiff_PlannerCoversCurrentHour' ./internal/shim/` — both new integration tests pass
- [x] Toggle the fix off, re-run integration tests — **both fail** with the gap-detection error, confirming each test independently pins the regression
- [x] Restore fix — both pass again
- [x] PR review (4 specialised agents) — all critical/important findings addressed; comments trimmed; field-name assertions added; injection-safety note on `addHourlyPartition`

## Files

| File | Change |
|---|---|
| `cmd/bintrail/shim.go` | Parse index DSN at startup; fail loud on parse error or empty DB name |
| `internal/shim/handler.go` | New `Config.IndexDBName` field; both `FetchMerged` call sites use it |
| `internal/shim/handler_test.go` | sqlmock regression tests for both call sites (`WithArgs("bintrail_index")`) |
| `internal/shim/handler_integration_test.go` | New: real-MySQL end-to-end pins for both `runPointInTime` and `runDiff` |

## Notes

- `internal/query/planner.go` and `internal/query/fetchmerged.go` are unchanged — the planner's logic is correct; the bug was only in how the shim called it.
- Side-finding noted in #259 (ProxySQL regex doesn't match backquoted schemas like `` `_flashback`.orders ``) is intentionally **out of scope** here. That belongs to `cmd/bintrail/proxysql_config*.go`; will file separately if it's worth addressing — most clients don't backquote.
- Found via `/proxysql-e2e` on AWS against the published v0.7.2 release. The integration test added here would have caught it in CI.