### PR TITLE
shim: fix auth error code + seed default schema from source_dsn

### DIFF
--- a/cmd/bintrail/shim.go
+++ b/cmd/bintrail/shim.go
@@ -10,11 +10,11 @@ import (
 	"net"
 	"os"
 	"os/signal"
-	"strings"
 	"sync"
 	"syscall"
 	"time"
 
+	gomysql "github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/go-mysql-org/go-mysql/server"
 	mysqldriver "github.com/go-sql-driver/mysql"
 	"github.com/spf13/cobra"
@@ -97,36 +97,21 @@ func runShim(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	users := make(map[string]string, len(tenantCfgs))
-	// userSchemas seeds Handler.db at handshake time so fully qualified
-	// time-travel queries like `SELECT * FROM _flashback.orders` work
-	// without a prior `USE <db>` (issue #263). The source DSN is already
-	// in shim.yaml; deriving the schema from its /<db> path is
-	// unambiguous. If a tenant's DSN is missing that path, we leave
-	// userSchemas[user] empty — the user falls back to the old "issue
-	// USE first" behaviour rather than failing startup over a
-	// configuration we can't repair for them.
-	userSchemas := make(map[string]string, len(tenantCfgs))
 	for _, t := range tenantCfgs {
 		users[t.MySQLUser] = t.MySQLPassword
-		if t.SourceDSN == "" {
-			continue
-		}
-		cfg, perr := mysqldriver.ParseDSN(t.SourceDSN)
-		if perr != nil {
-			slog.Warn(
-				"shim.yaml: source_dsn is unparseable; fully qualified time-travel queries from this tenant will still require `USE <db>`",
-				"mysql_user", t.MySQLUser, "err", perr,
-			)
-			continue
-		}
-		if cfg.DBName == "" {
-			slog.Warn(
-				"shim.yaml: source_dsn has no database path; fully qualified time-travel queries from this tenant will still require `USE <db>`",
-				"mysql_user", t.MySQLUser,
-			)
-			continue
-		}
-		userSchemas[t.MySQLUser] = cfg.DBName
+	}
+	// userSchemas seeds Handler.db at handshake time so fully qualified
+	// time-travel queries like `SELECT * FROM _flashback.orders` work
+	// without a prior `USE <db>` (issue #263). Per-tenant warnings are
+	// emitted by buildUserSchemas; the partial-degradation summary
+	// below catches the more interesting case where so many tenants
+	// have unusable DSNs that the operator should notice at startup.
+	userSchemas := buildUserSchemas(tenantCfgs)
+	if missing := len(tenantCfgs) - len(userSchemas); missing > 0 {
+		slog.Warn(
+			"shim: some tenants have no usable default schema; queries from those tenants will require explicit `USE <db>`",
+			"tenants", len(tenantCfgs), "with_default_schema", len(userSchemas), "missing", missing,
+		)
 	}
 	auth, err := shim.NewTenantAuth(users)
 	if err != nil {
@@ -163,7 +148,11 @@ func runShim(cmd *cobra.Command, args []string) error {
 		)
 	}
 
-	slog.Info("shim listening", "addr", listener.Addr().String(), "tenants", len(tenantCfgs))
+	slog.Info("shim listening",
+		"addr", listener.Addr().String(),
+		"tenants", len(tenantCfgs),
+		"tenants_with_default_schema", len(userSchemas),
+	)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -288,6 +277,79 @@ func isLoopbackAddr(addr net.Addr) bool {
 	return tcp.IP.IsLoopback()
 }
 
+// classifyHandshakeErr maps an error returned by go-mysql/server's
+// handshake into the slog level and message we want to log it at.
+//
+// ProxySQL's monitor opens a TCP socket on the shim's listen port,
+// reads nothing, then closes — go-mysql wraps the resulting EOF read
+// with mysql.ErrBadConn (via pingcap/errors.Wrapf, whose Unwrap chain
+// is errors.Is-compatible). Treat that as the expected probe shape
+// and demote to Debug so the steady-state log isn't a stack trace per
+// probe.
+//
+// Auth failures from TenantAuth.GetCredential propagate as a
+// *mysql.MyError with code ER_ACCESS_DENIED_ERROR (1045, see the
+// translation in (*Conn).handshake). Log those at Info so an
+// operator can correlate ProxySQL alerts with the shim's view of the
+// failure without an alarming ERROR line per monitor probe.
+//
+// Anything else is unexpected (bad packet, protocol mismatch, …) and
+// stays at Error so it surfaces in alerting.
+//
+// Extracted as a pure function so the classification can be unit-
+// tested with synthetic errors — without it, a future refactor that
+// flips a branch would silently re-introduce the issue #262 log
+// volume regression.
+func classifyHandshakeErr(err error) (slog.Level, string) {
+	switch {
+	case errors.Is(err, io.EOF), errors.Is(err, io.ErrUnexpectedEOF), errors.Is(err, gomysql.ErrBadConn):
+		return slog.LevelDebug, "handshake aborted (likely TCP probe)"
+	}
+	var myErr *gomysql.MyError
+	if errors.As(err, &myErr) && myErr.Code == gomysql.ER_ACCESS_DENIED_ERROR {
+		return slog.LevelInfo, "mysql auth failed"
+	}
+	return slog.LevelError, "mysql handshake failed"
+}
+
+// buildUserSchemas derives the per-tenant default schema for shim
+// connections by parsing each tenant's source_dsn /<db> path. The
+// returned map is keyed by mysql_user — handleConn looks the schema
+// up after handshake and seeds Handler.db so fully qualified
+// time-travel queries work without a prior `USE <db>` (issue #263).
+//
+// A tenant whose source_dsn is empty, unparseable, or missing the
+// /<db> path is omitted from the returned map (with a warning log).
+// That keeps a single misconfigured tenant from blocking the rest;
+// the affected user simply falls back to the pre-#263 behaviour of
+// requiring an explicit USE. runShim emits a summary if the count of
+// tenants-with-default-schema is below the total.
+func buildUserSchemas(tenantCfgs []shim.TenantConfig) map[string]string {
+	out := make(map[string]string, len(tenantCfgs))
+	for _, t := range tenantCfgs {
+		if t.SourceDSN == "" {
+			continue
+		}
+		cfg, err := mysqldriver.ParseDSN(t.SourceDSN)
+		if err != nil {
+			slog.Warn(
+				"shim.yaml: source_dsn is unparseable; fully qualified time-travel queries from this tenant will still require `USE <db>`",
+				"mysql_user", t.MySQLUser, "err", err,
+			)
+			continue
+		}
+		if cfg.DBName == "" {
+			slog.Warn(
+				"shim.yaml: source_dsn has no database path; fully qualified time-travel queries from this tenant will still require `USE <db>`",
+				"mysql_user", t.MySQLUser,
+			)
+			continue
+		}
+		out[t.MySQLUser] = cfg.DBName
+	}
+	return out
+}
+
 // handleConn wraps one accepted TCP connection in go-mysql/server's
 // Conn (which performs the MySQL handshake + auth) and dispatches
 // every COM_QUERY through our Handler.
@@ -306,22 +368,8 @@ func handleConn(c net.Conn, db *sql.DB, auth shim.TenantAuth, cfg shim.Config, u
 	srv := server.NewDefaultServer()
 	mysqlConn, err := server.NewCustomizedConn(c, srv, auth, handler)
 	if err != nil {
-		// EOF during the handshake is ProxySQL's monitor TCP probe (it
-		// connects, reads nothing, closes). Demoting it to debug keeps
-		// the steady-state log free of stack traces while a real
-		// handshake error (bad packet, protocol mismatch) still surfaces
-		// as ERROR. Auth failures arrive here as ER_ACCESS_DENIED_ERROR
-		// (1045, see TenantAuth.GetCredential) — log them at INFO so
-		// operators can correlate ProxySQL alerts with shim activity
-		// without a stack trace per probe.
-		switch {
-		case errors.Is(err, io.EOF), strings.Contains(err.Error(), "EOF"):
-			slog.Debug("handshake aborted (likely TCP probe)", "remote", c.RemoteAddr())
-		case strings.Contains(err.Error(), "Access denied"):
-			slog.Info("mysql auth failed", "err", err, "remote", c.RemoteAddr())
-		default:
-			slog.Error("mysql handshake failed", "err", err, "remote", c.RemoteAddr())
-		}
+		level, msg := classifyHandshakeErr(err)
+		slog.Log(context.Background(), level, msg, "err", err, "remote", c.RemoteAddr())
 		return
 	}
 	if schema, ok := userSchemas[mysqlConn.GetUser()]; ok && schema != "" {

--- a/cmd/bintrail/shim.go
+++ b/cmd/bintrail/shim.go
@@ -5,10 +5,12 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -21,9 +23,9 @@ import (
 	"github.com/dbtrail/bintrail/internal/shim"
 )
 
-// shimCmd serves the BYOS time-travel SQL endpoint as an in-process
-// MySQL-protocol server. Customers run this alongside the bintrail
-// agent on the same host; ProxySQL routes _flashback / _diff /
+// shimCmd serves the time-travel SQL endpoint as an in-process
+// MySQL-protocol server. Operators run this alongside the streamer
+// (stream or agent) on the same host; ProxySQL routes _flashback / _diff /
 // _snapshot virtual-schema queries to its --listen address.
 //
 // Recognised statement shapes (handled by internal/shim/parser.go):
@@ -46,11 +48,11 @@ import (
 // unreachable from the network anyway.
 var shimCmd = &cobra.Command{
 	Use:   "shim",
-	Short: "Run the BYOS time-travel SQL MySQL-protocol server",
-	Long: `Run an in-process MySQL-protocol server that answers BYOS
+	Short: "Run the time-travel SQL MySQL-protocol server",
+	Long: `Run an in-process MySQL-protocol server that answers
 time-travel SQL queries against the three virtual schemas
 _flashback / _snapshot / _diff. Intended to sit behind ProxySQL on the
-same host — see docs/byos-time-travel-sql.md for the end-to-end setup.
+same host — see docs/time-travel-sql.md for the end-to-end setup.
 
 The shim auto-discovers S3 archives via archive_state, so queries that
 reach back beyond the live MySQL index's retention window resolve
@@ -90,11 +92,43 @@ func init() {
 }
 
 func runShim(cmd *cobra.Command, args []string) error {
-	tenants, err := shim.LoadTenants(shShimConfig)
+	tenantCfgs, err := shim.LoadTenantConfigs(shShimConfig)
 	if err != nil {
 		return err
 	}
-	auth, err := shim.NewTenantAuth(tenants)
+	users := make(map[string]string, len(tenantCfgs))
+	// userSchemas seeds Handler.db at handshake time so fully qualified
+	// time-travel queries like `SELECT * FROM _flashback.orders` work
+	// without a prior `USE <db>` (issue #263). The source DSN is already
+	// in shim.yaml; deriving the schema from its /<db> path is
+	// unambiguous. If a tenant's DSN is missing that path, we leave
+	// userSchemas[user] empty — the user falls back to the old "issue
+	// USE first" behaviour rather than failing startup over a
+	// configuration we can't repair for them.
+	userSchemas := make(map[string]string, len(tenantCfgs))
+	for _, t := range tenantCfgs {
+		users[t.MySQLUser] = t.MySQLPassword
+		if t.SourceDSN == "" {
+			continue
+		}
+		cfg, perr := mysqldriver.ParseDSN(t.SourceDSN)
+		if perr != nil {
+			slog.Warn(
+				"shim.yaml: source_dsn is unparseable; fully qualified time-travel queries from this tenant will still require `USE <db>`",
+				"mysql_user", t.MySQLUser, "err", perr,
+			)
+			continue
+		}
+		if cfg.DBName == "" {
+			slog.Warn(
+				"shim.yaml: source_dsn has no database path; fully qualified time-travel queries from this tenant will still require `USE <db>`",
+				"mysql_user", t.MySQLUser,
+			)
+			continue
+		}
+		userSchemas[t.MySQLUser] = cfg.DBName
+	}
+	auth, err := shim.NewTenantAuth(users)
 	if err != nil {
 		return err
 	}
@@ -129,7 +163,7 @@ func runShim(cmd *cobra.Command, args []string) error {
 		)
 	}
 
-	slog.Info("shim listening", "addr", listener.Addr().String(), "tenants", len(tenants))
+	slog.Info("shim listening", "addr", listener.Addr().String(), "tenants", len(tenantCfgs))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -160,7 +194,7 @@ func runShim(cmd *cobra.Command, args []string) error {
 	}
 
 	cfg := shim.Config{AllowGaps: shAllowGaps, NoArchive: shNoArchive, IndexDBName: dsnCfg.DBName}
-	serveLoop(ctx, listener, db, auth, cfg)
+	serveLoop(ctx, listener, db, auth, cfg, userSchemas)
 	return nil
 }
 
@@ -174,7 +208,7 @@ func runShim(cmd *cobra.Command, args []string) error {
 // hiccup doesn't burn CPU and a permanent listener wedge doesn't fill
 // the log at ~10 lines/sec. The backoff resets to zero on every
 // successful Accept so a brief spike doesn't poison the steady state.
-func serveLoop(ctx context.Context, listener net.Listener, db *sql.DB, auth shim.TenantAuth, cfg shim.Config) {
+func serveLoop(ctx context.Context, listener net.Listener, db *sql.DB, auth shim.TenantAuth, cfg shim.Config, userSchemas map[string]string) {
 	var wg sync.WaitGroup
 	defer wg.Wait()
 
@@ -205,7 +239,7 @@ func serveLoop(ctx context.Context, listener net.Listener, db *sql.DB, auth shim
 		wg.Add(1)
 		go func(c net.Conn) {
 			defer wg.Done()
-			handleConn(c, db, auth, cfg)
+			handleConn(c, db, auth, cfg, userSchemas)
 		}(conn)
 	}
 }
@@ -257,15 +291,41 @@ func isLoopbackAddr(addr net.Addr) bool {
 // handleConn wraps one accepted TCP connection in go-mysql/server's
 // Conn (which performs the MySQL handshake + auth) and dispatches
 // every COM_QUERY through our Handler.
-func handleConn(c net.Conn, db *sql.DB, auth shim.TenantAuth, cfg shim.Config) {
+//
+// userSchemas seeds the handler's default DB from the authenticated
+// tenant's source_dsn so fully qualified time-travel queries
+// (`_flashback.<table>`) succeed without a prior `USE <db>` (issue
+// #263). The seed runs only after a successful handshake — pre-auth
+// we don't know the tenant — and an explicit `USE` from the client
+// still wins because UseDB is called sequentially and overwrites the
+// seeded value.
+func handleConn(c net.Conn, db *sql.DB, auth shim.TenantAuth, cfg shim.Config, userSchemas map[string]string) {
 	defer c.Close()
 
 	handler := shim.NewHandlerWithConfig(db, cfg, slog.Default())
 	srv := server.NewDefaultServer()
 	mysqlConn, err := server.NewCustomizedConn(c, srv, auth, handler)
 	if err != nil {
-		slog.Error("mysql handshake failed", "err", err, "remote", c.RemoteAddr())
+		// EOF during the handshake is ProxySQL's monitor TCP probe (it
+		// connects, reads nothing, closes). Demoting it to debug keeps
+		// the steady-state log free of stack traces while a real
+		// handshake error (bad packet, protocol mismatch) still surfaces
+		// as ERROR. Auth failures arrive here as ER_ACCESS_DENIED_ERROR
+		// (1045, see TenantAuth.GetCredential) — log them at INFO so
+		// operators can correlate ProxySQL alerts with shim activity
+		// without a stack trace per probe.
+		switch {
+		case errors.Is(err, io.EOF), strings.Contains(err.Error(), "EOF"):
+			slog.Debug("handshake aborted (likely TCP probe)", "remote", c.RemoteAddr())
+		case strings.Contains(err.Error(), "Access denied"):
+			slog.Info("mysql auth failed", "err", err, "remote", c.RemoteAddr())
+		default:
+			slog.Error("mysql handshake failed", "err", err, "remote", c.RemoteAddr())
+		}
 		return
+	}
+	if schema, ok := userSchemas[mysqlConn.GetUser()]; ok && schema != "" {
+		_ = handler.UseDB(schema)
 	}
 	for {
 		if err := mysqlConn.HandleCommand(); err != nil {

--- a/cmd/bintrail/shim.go
+++ b/cmd/bintrail/shim.go
@@ -108,9 +108,20 @@ func runShim(cmd *cobra.Command, args []string) error {
 	// have unusable DSNs that the operator should notice at startup.
 	userSchemas := buildUserSchemas(tenantCfgs)
 	if missing := len(tenantCfgs) - len(userSchemas); missing > 0 {
+		// Name the affected users so a 50-tenant deployment doesn't
+		// force the operator to grep the prior per-tenant warnings.
+		missingUsers := make([]string, 0, missing)
+		for _, t := range tenantCfgs {
+			if _, ok := userSchemas[t.MySQLUser]; !ok {
+				missingUsers = append(missingUsers, t.MySQLUser)
+			}
+		}
 		slog.Warn(
 			"shim: some tenants have no usable default schema; queries from those tenants will require explicit `USE <db>`",
-			"tenants", len(tenantCfgs), "with_default_schema", len(userSchemas), "missing", missing,
+			"tenants", len(tenantCfgs),
+			"with_default_schema", len(userSchemas),
+			"missing", missing,
+			"missing_users", missingUsers,
 		)
 	}
 	auth, err := shim.NewTenantAuth(users)
@@ -281,15 +292,20 @@ func isLoopbackAddr(addr net.Addr) bool {
 // handshake into the slog level and message we want to log it at.
 //
 // ProxySQL's monitor opens a TCP socket on the shim's listen port,
-// reads nothing, then closes — go-mysql wraps the resulting EOF read
-// with mysql.ErrBadConn (via pingcap/errors.Wrapf, whose Unwrap chain
-// is errors.Is-compatible). Treat that as the expected probe shape
-// and demote to Debug so the steady-state log isn't a stack trace per
-// probe.
+// reads nothing, then closes. go-mysql surfaces the resulting read
+// failure as either a raw io.EOF / io.ErrUnexpectedEOF (rare paths
+// outside packet/conn.go) or a pingcap-wrapped mysql.ErrBadConn (the
+// usual case — every read in packet/conn.go is wrapped this way, and
+// pingcap's Unwrap chain is errors.Is-compatible). Treat all three
+// as the expected probe shape and demote to Debug so the steady-
+// state log isn't a stack trace per probe.
 //
 // Auth failures from TenantAuth.GetCredential propagate as a
-// *mysql.MyError with code ER_ACCESS_DENIED_ERROR (1045, see the
-// translation in (*Conn).handshake). Log those at Info so an
+// *mysql.MyError with code ER_ACCESS_DENIED_ERROR (1045). Note that
+// (*Conn).handshake also rewrites ErrAccessDeniedNoPassword (1698)
+// into 1045 before returning, so checking the single 1045 code
+// covers both no-password and bad-password cases — adding a 1698
+// branch here would be dead code. Log auth failures at Info so an
 // operator can correlate ProxySQL alerts with the shim's view of the
 // failure without an alarming ERROR line per monitor probe.
 //

--- a/cmd/bintrail/shim_test.go
+++ b/cmd/bintrail/shim_test.go
@@ -3,10 +3,15 @@ package main
 import (
 	"context"
 	"errors"
+	"io"
+	"log/slog"
 	"net"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	gomysql "github.com/go-mysql-org/go-mysql/mysql"
+	pingcaperrors "github.com/pingcap/errors"
 
 	"github.com/dbtrail/bintrail/internal/shim"
 )
@@ -186,4 +191,78 @@ func (l *alwaysErrorListener) Close() error {
 
 func (l *alwaysErrorListener) Addr() net.Addr {
 	return &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0}
+}
+
+// TestClassifyHandshakeErr pins the #262 log-volume invariants. A
+// future refactor that flips the cases — e.g. demoting "real" errors
+// to debug, or promoting access-denied back to ERROR — would silently
+// re-introduce either the noisy probe stack traces or the SHUNN
+// alarm storm.
+//
+// EOF / mysql.ErrBadConn are go-mysql's wrapped read errors when
+// ProxySQL's monitor opens a TCP socket and closes it; they must be
+// debug. ER_ACCESS_DENIED_ERROR is what TenantAuth.GetCredential
+// causes go-mysql/server to return — info, never error. Anything
+// else stays at error.
+func TestClassifyHandshakeErr(t *testing.T) {
+	cases := []struct {
+		name      string
+		err       error
+		wantLevel slog.Level
+	}{
+		{"raw io.EOF", io.EOF, slog.LevelDebug},
+		{"unexpected EOF", io.ErrUnexpectedEOF, slog.LevelDebug},
+		{"go-mysql wrapped ErrBadConn", pingcaperrors.Wrapf(gomysql.ErrBadConn, "io.ReadFull(header) failed. err %v", io.EOF), slog.LevelDebug},
+		{"ER_ACCESS_DENIED_ERROR", gomysql.NewDefaultError(gomysql.ER_ACCESS_DENIED_ERROR, "monitor", "127.0.0.1:46948", "YES"), slog.LevelInfo},
+		{"unrelated MyError stays error", gomysql.NewDefaultError(gomysql.ER_HANDSHAKE_ERROR), slog.LevelError},
+		{"plain unrelated error", errors.New("protocol mismatch"), slog.LevelError},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			level, msg := classifyHandshakeErr(tc.err)
+			if level != tc.wantLevel {
+				t.Errorf("classifyHandshakeErr level = %v, want %v (msg=%q)", level, tc.wantLevel, msg)
+			}
+			if msg == "" {
+				t.Errorf("classifyHandshakeErr msg empty for %v", tc.err)
+			}
+		})
+	}
+}
+
+// TestBuildUserSchemas pins the #263 plumbing. Each branch of the
+// extraction is the regression surface for the original bug: a typo
+// in the DSN parse, dropping the empty-DBName guard, or skipping the
+// empty-SourceDSN early-out would all silently re-introduce the
+// "USE <db> required" failure mode for some tenant subset.
+func TestBuildUserSchemas(t *testing.T) {
+	cfgs := []shim.TenantConfig{
+		{MySQLUser: "alice", MySQLPassword: "p", SourceDSN: "u:p@tcp(db:3306)/source_a"},
+		{MySQLUser: "bob", MySQLPassword: "p", SourceDSN: "u:p@tcp(db:3306)/"}, // no DB name
+		{MySQLUser: "carol", MySQLPassword: "p", SourceDSN: ""},                // empty DSN
+		{MySQLUser: "dave", MySQLPassword: "p", SourceDSN: "::not-a-dsn::"},    // unparseable
+		{MySQLUser: "eve", MySQLPassword: "p", SourceDSN: "u:p@tcp(db:3306)/source_e?parseTime=true"},
+	}
+	got := buildUserSchemas(cfgs)
+	want := map[string]string{
+		"alice": "source_a",
+		"eve":   "source_e",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for u, schema := range want {
+		if got[u] != schema {
+			t.Errorf("buildUserSchemas[%q] = %q, want %q", u, got[u], schema)
+		}
+	}
+	// Tenants with bad/empty DSN must be ABSENT, not present-with-empty:
+	// handleConn keys off `ok` membership in the map; an empty-string
+	// entry would seed `Handler.UseDB("")` which silently breaks the
+	// pre-#263 fallback path.
+	for _, u := range []string{"bob", "carol", "dave"} {
+		if _, ok := got[u]; ok {
+			t.Errorf("buildUserSchemas[%q] should be absent (bad/empty DSN), got %q", u, got[u])
+		}
+	}
 }

--- a/cmd/bintrail/shim_test.go
+++ b/cmd/bintrail/shim_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net"
@@ -11,7 +12,6 @@ import (
 	"time"
 
 	gomysql "github.com/go-mysql-org/go-mysql/mysql"
-	pingcaperrors "github.com/pingcap/errors"
 
 	"github.com/dbtrail/bintrail/internal/shim"
 )
@@ -196,7 +196,7 @@ func (l *alwaysErrorListener) Addr() net.Addr {
 // TestClassifyHandshakeErr pins the #262 log-volume invariants. A
 // future refactor that flips the cases — e.g. demoting "real" errors
 // to debug, or promoting access-denied back to ERROR — would silently
-// re-introduce either the noisy probe stack traces or the SHUNN
+// re-introduce either the noisy probe stack traces or the SHUNNED
 // alarm storm.
 //
 // EOF / mysql.ErrBadConn are go-mysql's wrapped read errors when
@@ -212,7 +212,12 @@ func TestClassifyHandshakeErr(t *testing.T) {
 	}{
 		{"raw io.EOF", io.EOF, slog.LevelDebug},
 		{"unexpected EOF", io.ErrUnexpectedEOF, slog.LevelDebug},
-		{"go-mysql wrapped ErrBadConn", pingcaperrors.Wrapf(gomysql.ErrBadConn, "io.ReadFull(header) failed. err %v", io.EOF), slog.LevelDebug},
+		// fmt.Errorf+%w produces an Unwrap-compatible chain that exercises the same
+		// errors.Is path go-mysql's pingcap-wrapped reads do. We avoid importing
+		// github.com/pingcap/errors directly per CLAUDE.md ("Do not import transitive
+		// deps directly") — the production behaviour is what matters, and errors.Is
+		// resolves both wrap shapes the same way.
+		{"wrapped ErrBadConn", fmt.Errorf("io.ReadFull(header) failed: %w", gomysql.ErrBadConn), slog.LevelDebug},
 		{"ER_ACCESS_DENIED_ERROR", gomysql.NewDefaultError(gomysql.ER_ACCESS_DENIED_ERROR, "monitor", "127.0.0.1:46948", "YES"), slog.LevelInfo},
 		{"unrelated MyError stays error", gomysql.NewDefaultError(gomysql.ER_HANDSHAKE_ERROR), slog.LevelError},
 		{"plain unrelated error", errors.New("protocol mismatch"), slog.LevelError},

--- a/cmd/bintrail/shim_test.go
+++ b/cmd/bintrail/shim_test.go
@@ -133,7 +133,7 @@ func TestServeLoopExitsOnContextCancel(t *testing.T) {
 	go func() {
 		// db / auth / cfg are unused on this path because Accept
 		// never returns a connection — handleConn is unreachable.
-		serveLoop(ctx, listener, nil, shim.TenantAuth{}, shim.Config{})
+		serveLoop(ctx, listener, nil, shim.TenantAuth{}, shim.Config{}, nil)
 		close(done)
 	}()
 

--- a/internal/shim/auth.go
+++ b/internal/shim/auth.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 
+	"github.com/go-mysql-org/go-mysql/server"
 	yaml "go.yaml.in/yaml/v2"
 )
 
@@ -76,21 +77,62 @@ func (a TenantAuth) CheckUsername(u string) (bool, error) {
 // GetCredential implements server.CredentialProvider. Returns the
 // stored cleartext password so go-mysql/server's mysql_native_password
 // handshake can validate the client's scrambled response against it.
+//
+// Unknown usernames return server.ErrAccessDenied rather than
+// (found=false, err=nil). The library translates ErrAccessDenied into
+// ER_ACCESS_DENIED_ERROR (1045) inside (*Conn).handshake; a plain
+// found=false instead surfaces ER_NO_SUCH_USER (1449), which ProxySQL
+// reads as "backend broken" and SHUNNs the hostgroup (issue #262).
+// Returning the error explicitly routes us through the 1045 path so
+// ProxySQL's monitor probes look like normal auth failures and the
+// backend stays ONLINE.
 func (a TenantAuth) GetCredential(u string) (password string, found bool, err error) {
 	p, ok := a.users[u]
+	if !ok {
+		return "", false, server.ErrAccessDenied
+	}
 	return p, ok, nil
 }
 
+// TenantConfig is the validated form of one entry in shim.yaml's
+// tenants block. Used by `bintrail shim` so callers can recover the
+// per-tenant source_dsn (and from it, the source schema) in addition
+// to the credentials needed for TenantAuth.
+type TenantConfig struct {
+	ServerID      string
+	SourceDSN     string
+	MySQLUser     string
+	MySQLPassword string
+}
+
 // LoadTenants reads shim.yaml from path and returns username →
-// cleartext password for each tenant. Used by `bintrail shim` to
-// construct a TenantAuth at startup.
+// cleartext password for each tenant. Thin wrapper over
+// LoadTenantConfigs that exists so older callers (and the existing
+// auth tests) keep working unchanged.
+func LoadTenants(path string) (map[string]string, error) {
+	cfgs, err := LoadTenantConfigs(path)
+	if err != nil {
+		return nil, err
+	}
+	users := make(map[string]string, len(cfgs))
+	for _, t := range cfgs {
+		users[t.MySQLUser] = t.MySQLPassword
+	}
+	return users, nil
+}
+
+// LoadTenantConfigs reads shim.yaml from path and returns the full
+// validated tenants block. Used by `bintrail shim` so the per-tenant
+// source DSN reaches the connection handler — without it, fully
+// qualified time-travel queries like `SELECT * FROM _flashback.orders`
+// would still need an explicit `USE <db>` first (issue #263).
 //
 // Strict YAML parsing rejects unknown fields, so legacy fields kept
 // in the struct (agent_url, agent_token from < 0.7.0; mysql_pass_sha1
 // from < 0.7.2) parse cleanly even though they are no longer
 // load-bearing. Operators upgrading from 0.7.1 see a runtime warning
 // pointing at mysql_password.
-func LoadTenants(path string) (map[string]string, error) {
+func LoadTenantConfigs(path string) ([]TenantConfig, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("read %s: %w", path, err)
@@ -113,7 +155,7 @@ func LoadTenants(path string) (map[string]string, error) {
 	if len(cfg.Tenants) == 0 {
 		return nil, fmt.Errorf("%s has no tenants", path)
 	}
-	users := make(map[string]string, len(cfg.Tenants))
+	out := make([]TenantConfig, 0, len(cfg.Tenants))
 	for i, t := range cfg.Tenants {
 		if t.MySQLUser == "" {
 			return nil, fmt.Errorf("%s tenant #%d: mysql_user is empty (uncomment and fill in the TODO line)", path, i+1)
@@ -133,7 +175,12 @@ func LoadTenants(path string) (map[string]string, error) {
 				"tenant", i+1, "mysql_user", t.MySQLUser,
 			)
 		}
-		users[t.MySQLUser] = t.MySQLPassword
+		out = append(out, TenantConfig{
+			ServerID:      t.ServerID,
+			SourceDSN:     t.SourceDSN,
+			MySQLUser:     t.MySQLUser,
+			MySQLPassword: t.MySQLPassword,
+		})
 	}
-	return users, nil
+	return out, nil
 }

--- a/internal/shim/auth.go
+++ b/internal/shim/auth.go
@@ -98,10 +98,30 @@ func (a TenantAuth) GetCredential(u string) (password string, found bool, err er
 // tenants block. Used by `bintrail shim` so callers can recover the
 // per-tenant source_dsn (and from it, the source schema) in addition
 // to the credentials needed for TenantAuth.
+//
+// Returned only by LoadTenantConfigs — instances obtained through
+// that function carry the invariants below. Direct struct-literal
+// construction (TenantConfig{...}) bypasses validation; consumers
+// should treat that as a programmer error rather than a recoverable
+// configuration shape.
 type TenantConfig struct {
-	ServerID      string
-	SourceDSN     string
-	MySQLUser     string
+	// ServerID is the bintrail stream/agent server_id. May be empty
+	// (the shim does not require it; only the streamer does).
+	ServerID string
+	// SourceDSN is the upstream MySQL DSN for the tenant's source
+	// database. May be empty: when set with a /<db> path, `bintrail
+	// shim` derives the schema from it and pre-seeds Handler.db so
+	// fully qualified time-travel queries work without `USE <db>`
+	// (issue #263). When empty or path-less, that tenant's clients
+	// fall back to issuing `USE` themselves.
+	SourceDSN string
+	// MySQLUser is the cleartext username the application connects
+	// with through ProxySQL. Guaranteed non-empty by LoadTenantConfigs.
+	MySQLUser string
+	// MySQLPassword is the cleartext password
+	// `mysql_native_password` validates against. Guaranteed non-empty
+	// by LoadTenantConfigs — empty here is the #254 silent-auth
+	// regression and is rejected at the loader boundary.
 	MySQLPassword string
 }
 

--- a/internal/shim/auth_test.go
+++ b/internal/shim/auth_test.go
@@ -228,6 +228,58 @@ func TestLoadTenantConfigsReturnsSourceDSN(t *testing.T) {
 	}
 }
 
+// TestLoadTenantConfigsRejectsEmptyCredentials pins the construction-
+// time invariant that LoadTenantConfigs guarantees non-empty MySQLUser
+// and MySQLPassword. The struct fields are exported, so a future
+// caller could in principle build a TenantConfig{} directly and
+// bypass these checks — but the loader must remain the sole producer
+// of "trusted" instances, and downgrading any of these errors to a
+// warning would silently reopen the #254 empty-password regression.
+func TestLoadTenantConfigsRejectsEmptyCredentials(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("empty mysql_user", func(t *testing.T) {
+		path := filepath.Join(dir, "user.yaml")
+		if err := os.WriteFile(path, []byte("tenants:\n  - mysql_password: 'p'\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		_, err := LoadTenantConfigs(path)
+		if err == nil || !strings.Contains(err.Error(), "mysql_user is empty") {
+			t.Errorf("expected mysql_user error, got %v", err)
+		}
+	})
+
+	t.Run("empty mysql_password", func(t *testing.T) {
+		path := filepath.Join(dir, "pw.yaml")
+		if err := os.WriteFile(path, []byte("tenants:\n  - mysql_user: alice\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		_, err := LoadTenantConfigs(path)
+		if err == nil || !strings.Contains(err.Error(), "mysql_password is empty") {
+			t.Errorf("expected mysql_password error, got %v", err)
+		}
+	})
+
+	t.Run("empty source_dsn round-trips empty (not validated)", func(t *testing.T) {
+		// SourceDSN being empty is a legitimate runtime configuration
+		// (the tenant's clients will issue USE explicitly). Pinning
+		// this lets us evolve the loader without accidentally
+		// mandating a non-empty DSN.
+		path := filepath.Join(dir, "nodsn.yaml")
+		body := "tenants:\n  - mysql_user: alice\n    mysql_password: 'p'\n"
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cfgs, err := LoadTenantConfigs(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(cfgs) != 1 || cfgs[0].SourceDSN != "" {
+			t.Errorf("got %+v, want one tenant with empty SourceDSN", cfgs)
+		}
+	})
+}
+
 // TestLoadTenantsBothFieldsSet pins the contract that when an operator
 // has both `mysql_password` (new) and `mysql_pass_sha1` (legacy) in
 // shim.yaml — typically during a half-completed migration — the

--- a/internal/shim/auth_test.go
+++ b/internal/shim/auth_test.go
@@ -1,10 +1,13 @@
 package shim
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/go-mysql-org/go-mysql/server"
 )
 
 func TestNewTenantAuthEmpty(t *testing.T) {
@@ -70,6 +73,24 @@ func TestTenantAuthGetCredentialReturnsCleartext(t *testing.T) {
 	_, found, _ = a.GetCredential("eve")
 	if found {
 		t.Error("GetCredential(eve) should not be found")
+	}
+}
+
+// TestTenantAuthGetCredentialUnknownUserReturnsAccessDenied pins the
+// #262 fix: an unknown user must surface server.ErrAccessDenied so
+// (*Conn).handshake translates it to ER_ACCESS_DENIED_ERROR (1045).
+// Returning (found=false, err=nil) instead would let go-mysql/server
+// raise ER_NO_SUCH_USER (1449) — ProxySQL reads that as "backend
+// broken" and SHUNNs the hostgroup. A future refactor that drops the
+// explicit error here would silently re-introduce the SHUNN bug.
+func TestTenantAuthGetCredentialUnknownUserReturnsAccessDenied(t *testing.T) {
+	a, _ := NewTenantAuth(map[string]string{"alice": "alicepw"})
+	_, found, err := a.GetCredential("monitor")
+	if found {
+		t.Fatal("GetCredential(monitor) should not be found")
+	}
+	if !errors.Is(err, server.ErrAccessDenied) {
+		t.Fatalf("GetCredential(monitor) err = %v, want server.ErrAccessDenied", err)
 	}
 }
 
@@ -172,6 +193,39 @@ func TestLoadTenantsErrors(t *testing.T) {
 			t.Errorf("error should name the unknown field, got %v", err)
 		}
 	})
+}
+
+// TestLoadTenantConfigsReturnsSourceDSN pins the #263 plumbing: the
+// per-tenant source_dsn must round-trip through LoadTenantConfigs so
+// `bintrail shim` can derive the schema and seed it as the default
+// database for fully qualified time-travel queries. A future refactor
+// that drops SourceDSN from the returned struct would silently
+// re-introduce the "USE <db> required" failure mode.
+func TestLoadTenantConfigsReturnsSourceDSN(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "shim.yaml")
+	body := `tenants:
+  - server_id: '1'
+    source_dsn: 'u:p@tcp(db:3306)/source_schema'
+    mysql_user: alice
+    mysql_password: 'alicepw'
+`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfgs, err := LoadTenantConfigs(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfgs) != 1 {
+		t.Fatalf("got %d tenants, want 1", len(cfgs))
+	}
+	if cfgs[0].SourceDSN != "u:p@tcp(db:3306)/source_schema" {
+		t.Errorf("SourceDSN = %q, want round-trip", cfgs[0].SourceDSN)
+	}
+	if cfgs[0].MySQLUser != "alice" || cfgs[0].MySQLPassword != "alicepw" {
+		t.Errorf("creds round-trip mismatch: %+v", cfgs[0])
+	}
 }
 
 // TestLoadTenantsBothFieldsSet pins the contract that when an operator


### PR DESCRIPTION
## Summary

Fixes two ProxySQL-deployment bugs surfaced by `/proxysql-e2e` on v0.7.3.

### Closes #262 — wrong MySQL error class on auth failure
`TenantAuth.GetCredential` now returns `server.ErrAccessDenied` for unknown users so go-mysql/server's `(*Conn).handshake` translates it into `ER_ACCESS_DENIED_ERROR` (1045). Previously the library raised `ER_NO_SUCH_USER` (1449) — ProxySQL reads that as "backend broken" and SHUNNs the hostgroup, making time-travel queries appear to silently return empty for ~N seconds at a time.

`handleConn` also demotes EOF (ProxySQL's TCP probe) and access-denied to `Debug`/`Info` so the steady-state log isn't a stack-trace per probe.

### Closes #263 — fully qualified `_flashback.<table>` requires `USE <db>`
The shim now derives each tenant's source schema from `source_dsn` (via `mysqldriver.ParseDSN`) and seeds `Handler.db` after a successful handshake, so `SELECT * FROM _flashback.orders ...` works without a prior `USE <db>`. An explicit later `USE` from the client still wins (UseDB just overwrites the seed).

## Implementation notes

- New `shim.LoadTenantConfigs` returns `[]TenantConfig` including `SourceDSN`. The existing `shim.LoadTenants` is kept as a thin wrapper so older callers and tests are unchanged (additive shape).
- `serveLoop` / `handleConn` take an extra `userSchemas map[string]string` so the per-tenant schema reaches the connection at handshake time. The auth path stays unchanged.
- If a tenant's `source_dsn` is unparseable or has no `/<db>` path, we log a warning and leave that user requiring `USE` — non-fatal so a misconfigured tenant doesn't block the others.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (unit tier) — all green
- [x] New regression tests:
  - `TestTenantAuthGetCredentialUnknownUserReturnsAccessDenied` pins the 1045 invariant
  - `TestLoadTenantConfigsReturnsSourceDSN` pins that `SourceDSN` round-trips through the loader
- [ ] Verify end-to-end via `/proxysql-e2e` on v0.7.4: ProxySQL hg 991 stays ONLINE under monitor probes; `mysql -h ... -P 6033 -e "SELECT * FROM _flashback.orders AS OF '...' WHERE id = 1"` (no `-D`, no `USE`) returns a row.