### PR TITLE
test(shim): add docker-compose-driven wire-protocol e2e

### DIFF
--- a/e2e/shim/Dockerfile.shim
+++ b/e2e/shim/Dockerfile.shim
@@ -1,0 +1,28 @@
+# Build the bintrail binary (CGO + DuckDB) for the e2e/shim test rig.
+#
+# Multi-stage so the runtime image only carries the binary and its
+# minimal libc + libstdc++ deps — DuckDB's pre-compiled C++ libraries
+# are statically linked into the binary by duckdb-go's build, but
+# libstdc++ at runtime is still required.
+FROM golang:1.25-bookworm AS build
+
+WORKDIR /src
+
+# go.mod / go.sum first to keep the layer cached across source edits.
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+ENV CGO_ENABLED=1
+RUN go build -o /out/bintrail ./cmd/bintrail
+
+FROM debian:bookworm-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates libstdc++6 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /out/bintrail /usr/local/bin/bintrail
+
+ENTRYPOINT ["/usr/local/bin/bintrail"]

--- a/e2e/shim/README.md
+++ b/e2e/shim/README.md
@@ -34,19 +34,25 @@ test also skips.
   - `appdb` — the simulated production DB. `orders` table holds a
     live row with marker values (`sku=LIVE-SKU`, `qty=999`) so the
     passthrough subtest can prove ProxySQL routed there and not to
-    the shim.
+    the shim. `testuser` is granted SELECT on `appdb.*` so
+    ProxySQL can forward passthrough queries with the same
+    credentials the client uses.
   - `bintrail_index` — the bintrail row-event index. `binlog_events`
     is hand-seeded with a synthetic `INSERT → UPDATE → DELETE`
     sequence for `appdb.orders` id=42 at known timestamps
     (10:00 / 12:00 / 14:00 UTC on 2026-05-04).
-- `bintrail-shim` (built from local source): runs `bintrail shim`
-  against `bintrail_index`. Authenticates one tenant
-  (`testuser` / `testpw`).
 - `proxysql` (official 2.7 image): configured at test startup by
   applying the SQL emitted by `bintrail proxysql-config` to the
   admin port. Three rules route `_flashback`/`_diff`/`_snapshot`
   to the shim hostgroup; everything else hits the passthrough
   hostgroup pointed at the same `mysql` container.
+- `bintrail-shim`: runs `bintrail shim` against `bintrail_index`,
+  authenticating one tenant (`testuser` / `testpw`). Shares
+  `proxysql`'s network namespace (`network_mode: service:proxysql`)
+  — a sidecar pattern that mirrors the canonical prod deployment
+  and makes the `'127.0.0.1'` shim hostname that
+  `bintrail proxysql-config` hardcodes resolve correctly without
+  post-processing the SQL.
 
 The test exposes ProxySQL on host ports `127.0.0.1:16032` (admin)
 and `127.0.0.1:16033` (client) so it doesn't collide with
@@ -76,23 +82,13 @@ locally-running MySQL or ProxySQL.
   under `internal/parser` and `internal/indexer`.
 - The Parquet archive read path. `archive_state` is empty here;
   `internal/parquetquery` covers DuckDB-backed archive reads.
-- The `DBTRAIL_AT` SQL hint mentioned in issue #265. That feature
-  was part of the standalone `dbtrail-shim` PoC and was not ported
-  to the integrated `bintrail shim` subcommand. Adding it is a
-  separate piece of work.
+- A `/*+ DBTRAIL_AT='<ts>' */` hint form. The shim's parser
+  doesn't recognise it; if support is added, this test should
+  grow a subtest.
 
-## Why no fake HTTP agent
+## Why the data layer is seeded directly
 
-Issue #265 was filed when the shim was a standalone proof of
-concept that called out to a `/api/v1/{query,recover}` agent over
-HTTP. The integrated `bintrail shim` (since v0.7.0) reads directly
-from the MySQL index via `query.FetchMerged` and from S3/local
-Parquet via `parquetquery.Fetch` — no agent involved. The test
-seeds the index directly instead.
-
-## CI
-
-Not yet wired into a CI workflow — the repo has only
-`.github/workflows/release.yaml` today (no `ci.yml`). Adding the
-test-CI scaffolding is tracked as a follow-up so this PR stays
-focused on the test rig itself.
+`bintrail shim` reads from the MySQL index via `query.FetchMerged`
+and from S3/local Parquet via `parquetquery.Fetch` — there is no
+"agent" intermediary. So this test seeds `binlog_events` directly
+rather than mocking an HTTP API.

--- a/e2e/shim/README.md
+++ b/e2e/shim/README.md
@@ -1,0 +1,98 @@
+# `bintrail shim` end-to-end test
+
+Wire-protocol-level test for the full deployed chain:
+
+```
+go test (mysql client) → ProxySQL → bintrail shim → MySQL (bintrail_index)
+```
+
+Every other shim test is in-process — this one is the only place we
+catch regressions in the MySQL wire-protocol layer, ProxySQL routing
+rules, and shim ↔ index DB cooperation as a single integrated unit.
+
+## Running it
+
+```sh
+cd e2e/shim
+./run.sh
+```
+
+`run.sh` sets `SHIM_E2E=1` and runs `go test -tags shim_e2e`. The
+test owns the docker-compose lifecycle (build, up, down) so you can
+also run it directly:
+
+```sh
+SHIM_E2E=1 go test -tags shim_e2e -v ./e2e/shim/...
+```
+
+Without `SHIM_E2E=1` the test skips. Without Docker on `PATH` the
+test also skips.
+
+## What the stack looks like
+
+- `mysql` (8.0): one container, two schemas:
+  - `appdb` — the simulated production DB. `orders` table holds a
+    live row with marker values (`sku=LIVE-SKU`, `qty=999`) so the
+    passthrough subtest can prove ProxySQL routed there and not to
+    the shim.
+  - `bintrail_index` — the bintrail row-event index. `binlog_events`
+    is hand-seeded with a synthetic `INSERT → UPDATE → DELETE`
+    sequence for `appdb.orders` id=42 at known timestamps
+    (10:00 / 12:00 / 14:00 UTC on 2026-05-04).
+- `bintrail-shim` (built from local source): runs `bintrail shim`
+  against `bintrail_index`. Authenticates one tenant
+  (`testuser` / `testpw`).
+- `proxysql` (official 2.7 image): configured at test startup by
+  applying the SQL emitted by `bintrail proxysql-config` to the
+  admin port. Three rules route `_flashback`/`_diff`/`_snapshot`
+  to the shim hostgroup; everything else hits the passthrough
+  hostgroup pointed at the same `mysql` container.
+
+The test exposes ProxySQL on host ports `127.0.0.1:16032` (admin)
+and `127.0.0.1:16033` (client) so it doesn't collide with
+locally-running MySQL or ProxySQL.
+
+## What we cover
+
+- `_flashback.<table> AS OF '<ts>'` returns the right post-image
+  for the queried instant (multi-event history, mid-stream).
+- `_flashback.<table> AS OF '<ts>'` returns zero rows when the
+  AS OF instant is before any event.
+- `_diff.<table> BETWEEN '<t1>' AND '<t2>'` returns the full
+  event stream in order with the right event_type and image
+  shape (INSERT lacks row_before, DELETE lacks row_after).
+- `_snapshot.<table>` behaves like `_flashback`. (Today they
+  share an implementation; pinning the contract here keeps a
+  future split deliberate.)
+- A non-virtual-schema query (`SELECT * FROM orders WHERE id = 42`)
+  is routed to the passthrough hostgroup and returns the live row,
+  not the shim's reconstruction. Marker values prove the routing.
+
+## What we deliberately do NOT cover
+
+- The binlog parser → indexer pipeline. `seed.sql` writes the
+  `binlog_events` rows by hand so we can pin a deterministic time
+  series; the parser/indexer have their own integration tests
+  under `internal/parser` and `internal/indexer`.
+- The Parquet archive read path. `archive_state` is empty here;
+  `internal/parquetquery` covers DuckDB-backed archive reads.
+- The `DBTRAIL_AT` SQL hint mentioned in issue #265. That feature
+  was part of the standalone `dbtrail-shim` PoC and was not ported
+  to the integrated `bintrail shim` subcommand. Adding it is a
+  separate piece of work.
+
+## Why no fake HTTP agent
+
+Issue #265 was filed when the shim was a standalone proof of
+concept that called out to a `/api/v1/{query,recover}` agent over
+HTTP. The integrated `bintrail shim` (since v0.7.0) reads directly
+from the MySQL index via `query.FetchMerged` and from S3/local
+Parquet via `parquetquery.Fetch` — no agent involved. The test
+seeds the index directly instead.
+
+## CI
+
+Not yet wired into a CI workflow — the repo has only
+`.github/workflows/release.yaml` today (no `ci.yml`). Adding the
+test-CI scaffolding is tracked as a follow-up so this PR stays
+focused on the test rig itself.

--- a/e2e/shim/doc.go
+++ b/e2e/shim/doc.go
@@ -1,0 +1,9 @@
+// Package shim_e2e holds the docker-compose-driven end-to-end test
+// for `bintrail shim`. The test itself lives in e2e_test.go and is
+// gated behind the `shim_e2e` build tag plus an explicit SHIM_E2E=1
+// env var. See README.md for the run instructions.
+//
+// This file exists solely so `go list ./e2e/shim/...` reports a
+// valid (empty) package when the build tag is not set — without it,
+// IDEs and `go vet ./...` flag the directory as "no Go files".
+package shim_e2e

--- a/e2e/shim/docker-compose.yml
+++ b/e2e/shim/docker-compose.yml
@@ -1,18 +1,23 @@
 # Docker Compose stack for the bintrail shim end-to-end test.
 #
-# Topology:
+# Topology — sidecar pattern (mirrors the canonical prod deployment
+# where ProxySQL and the shim run on the same host):
 #
 #   go test (host) ──6033──► proxysql ──┬──990──► mysql:3306 (appdb, passthrough)
 #                          ┌─6032─admin │
-#                          │            └──991──► bintrail-shim:3308 ──► mysql:3306 (bintrail_index)
+#                          │            └──991──► 127.0.0.1:3308
+#                                                     │
+#                                                     └─ bintrail-shim
+#                                                        (network_mode: service:proxysql)
+#                                                        ──► mysql:3306 (bintrail_index)
 #
-# - mysql holds two schemas in one container: appdb (the simulated
-#   "production" DB the customer's app would target) and bintrail_index
-#   (the bintrail row-event index, hand-seeded by seed.sql so we don't
-#   need to run a real binlog stream just to exercise the shim).
-# - bintrail-shim runs `bintrail shim` against bintrail_index.
-# - proxysql is configured at test runtime via the SQL emitted by
-#   `bintrail proxysql-config` (see e2e_test.go).
+# bintrail-shim shares ProxySQL's network namespace (`network_mode:
+# service:proxysql`). This makes ProxySQL's `127.0.0.1:3308` reach
+# the shim — which matters because `bintrail proxysql-config` hard-
+# codes `'127.0.0.1'` as the shim hostname (the prod assumption is
+# same-host shim+ProxySQL). Sidecar > separate containers here:
+# we exercise the actual proxysql-config output unmodified, instead
+# of post-processing it to swap hostnames.
 
 services:
   mysql:
@@ -37,13 +42,27 @@ services:
       timeout: 3s
       retries: 30
 
+  proxysql:
+    image: proxysql/proxysql:2.7.1
+    ports:
+      - "127.0.0.1:16032:6032"
+      - "127.0.0.1:16033:6033"
+    depends_on:
+      mysql:
+        condition: service_healthy
+
   bintrail-shim:
     build:
       context: ../..
       dockerfile: e2e/shim/Dockerfile.shim
+    # Sidecar — share proxysql's network namespace so the shim's
+    # 127.0.0.1:3308 IS the address the proxysql-config SQL points
+    # at. Cannot declare its own `ports:` — the network is owned by
+    # proxysql.
+    network_mode: "service:proxysql"
     command:
       - shim
-      - --listen=0.0.0.0:3308
+      - --listen=127.0.0.1:3308
       - --index-dsn=root:testroot@tcp(mysql:3306)/bintrail_index
       - --shim-config=/etc/bintrail/shim.yaml
       - --allow-gaps
@@ -52,22 +71,6 @@ services:
     depends_on:
       mysql:
         condition: service_healthy
-    # No container-side healthcheck: the slim runtime image has neither
-    # bash (so /dev/tcp is unavailable — that's a bash-only feature)
-    # nor netcat, and adding either just to satisfy a probe is wasted
-    # bytes. The test's waitForPort owns the readiness signal — it
-    # dials the published host port directly, which is the only
-    # readiness signal that actually matters for the test's purposes.
-
-  proxysql:
-    image: proxysql/proxysql:2.7.1
-    ports:
-      - "127.0.0.1:16032:6032"
-      - "127.0.0.1:16033:6033"
-    depends_on:
-      bintrail-shim:
-        # service_started — not service_healthy — because we removed
-        # the shim's container-side healthcheck (see above). ProxySQL
-        # itself shrugs at backend unavailability at boot; the test's
-        # waitForPort gives the real readiness signal.
+      proxysql:
+        # network_mode:service:X requires X to be running first.
         condition: service_started

--- a/e2e/shim/docker-compose.yml
+++ b/e2e/shim/docker-compose.yml
@@ -1,0 +1,75 @@
+# Docker Compose stack for the bintrail shim end-to-end test.
+#
+# Topology:
+#
+#   go test (host) ──6033──► proxysql ──┬──990──► mysql:3306 (appdb, passthrough)
+#                          ┌─6032─admin │
+#                          │            └──991──► bintrail-shim:3308 ──► mysql:3306 (bintrail_index)
+#
+# - mysql holds two schemas in one container: appdb (the simulated
+#   "production" DB the customer's app would target) and bintrail_index
+#   (the bintrail row-event index, hand-seeded by seed.sql so we don't
+#   need to run a real binlog stream just to exercise the shim).
+# - bintrail-shim runs `bintrail shim` against bintrail_index.
+# - proxysql is configured at test runtime via the SQL emitted by
+#   `bintrail proxysql-config` (see e2e_test.go).
+
+services:
+  mysql:
+    image: mysql:8.0
+    command:
+      - --default-authentication-plugin=mysql_native_password
+      - --gtid-mode=ON
+      - --enforce-gtid-consistency=ON
+      - --log-bin=mysql-bin
+      - --binlog-format=ROW
+      - --binlog-row-image=FULL
+      - --server-id=1
+    environment:
+      MYSQL_ROOT_PASSWORD: testroot
+    ports:
+      - "127.0.0.1:13307:3306"
+    volumes:
+      - ./seed.sql:/docker-entrypoint-initdb.d/01-seed.sql:ro
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-uroot", "-ptestroot"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+
+  bintrail-shim:
+    build:
+      context: ../..
+      dockerfile: e2e/shim/Dockerfile.shim
+    command:
+      - shim
+      - --listen=0.0.0.0:3308
+      - --index-dsn=root:testroot@tcp(mysql:3306)/bintrail_index
+      - --shim-config=/etc/bintrail/shim.yaml
+      - --allow-gaps
+    volumes:
+      - ./shim.yaml:/etc/bintrail/shim.yaml:ro
+    depends_on:
+      mysql:
+        condition: service_healthy
+    # The shim has no built-in healthcheck endpoint; we probe the MySQL
+    # protocol port from the proxysql side via depends_on instead.
+    healthcheck:
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/127.0.0.1/3308 && exit 0 || exit 1"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+
+  proxysql:
+    image: proxysql/proxysql:2.7.1
+    ports:
+      - "127.0.0.1:16032:6032"
+      - "127.0.0.1:16033:6033"
+    depends_on:
+      bintrail-shim:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/127.0.0.1/6032 && exit 0 || exit 1"]
+      interval: 2s
+      timeout: 3s
+      retries: 30

--- a/e2e/shim/docker-compose.yml
+++ b/e2e/shim/docker-compose.yml
@@ -52,13 +52,12 @@ services:
     depends_on:
       mysql:
         condition: service_healthy
-    # The shim has no built-in healthcheck endpoint; we probe the MySQL
-    # protocol port from the proxysql side via depends_on instead.
-    healthcheck:
-      test: ["CMD-SHELL", "exec 3<>/dev/tcp/127.0.0.1/3308 && exit 0 || exit 1"]
-      interval: 2s
-      timeout: 3s
-      retries: 30
+    # No container-side healthcheck: the slim runtime image has neither
+    # bash (so /dev/tcp is unavailable — that's a bash-only feature)
+    # nor netcat, and adding either just to satisfy a probe is wasted
+    # bytes. The test's waitForPort owns the readiness signal — it
+    # dials the published host port directly, which is the only
+    # readiness signal that actually matters for the test's purposes.
 
   proxysql:
     image: proxysql/proxysql:2.7.1
@@ -67,9 +66,8 @@ services:
       - "127.0.0.1:16033:6033"
     depends_on:
       bintrail-shim:
-        condition: service_healthy
-    healthcheck:
-      test: ["CMD-SHELL", "exec 3<>/dev/tcp/127.0.0.1/6032 && exit 0 || exit 1"]
-      interval: 2s
-      timeout: 3s
-      retries: 30
+        # service_started — not service_healthy — because we removed
+        # the shim's container-side healthcheck (see above). ProxySQL
+        # itself shrugs at backend unavailability at boot; the test's
+        # waitForPort gives the real readiness signal.
+        condition: service_started

--- a/e2e/shim/docker-compose.yml
+++ b/e2e/shim/docker-compose.yml
@@ -44,8 +44,11 @@ services:
 
   proxysql:
     image: proxysql/proxysql:2.7.1
-    # `--initial` discards any in-volume state so the mounted
-    # proxysql.cnf is the source of truth on every run.
+    # `--initial` wipes any volume-resident SQLite config from a
+    # prior run so we start each test from a clean slate. Routing
+    # config (mysql_servers / mysql_users / mysql_query_rules) is
+    # not in proxysql.cnf — it's applied at test runtime via the
+    # SQL emitted by `bintrail proxysql-config`.
     command: ["proxysql", "-f", "--idle-threads", "-c", "/etc/proxysql.cnf", "--initial"]
     ports:
       - "127.0.0.1:16032:6032"

--- a/e2e/shim/docker-compose.yml
+++ b/e2e/shim/docker-compose.yml
@@ -44,9 +44,14 @@ services:
 
   proxysql:
     image: proxysql/proxysql:2.7.1
+    # `--initial` discards any in-volume state so the mounted
+    # proxysql.cnf is the source of truth on every run.
+    command: ["proxysql", "-f", "--idle-threads", "-c", "/etc/proxysql.cnf", "--initial"]
     ports:
       - "127.0.0.1:16032:6032"
       - "127.0.0.1:16033:6033"
+    volumes:
+      - ./proxysql.cnf:/etc/proxysql.cnf:ro
     depends_on:
       mysql:
         condition: service_healthy

--- a/e2e/shim/e2e_test.go
+++ b/e2e/shim/e2e_test.go
@@ -1,0 +1,454 @@
+//go:build shim_e2e
+
+// Package shim_e2e is the wire-protocol-level end-to-end test for
+// bintrail shim. It exercises the full chain a deployed setup uses:
+//
+//	go test (mysql client) → ProxySQL → bintrail shim → MySQL (bintrail_index)
+//
+// The companion docker-compose.yml brings up the three containers;
+// run.sh wraps `docker compose up --build` + `go test` so an operator
+// can reproduce a CI failure with a single command.
+//
+// The test is gated behind the `shim_e2e` build tag (so default
+// `go test ./...` skips it) and an explicit Docker availability
+// probe (so a developer who runs `go test -tags shim_e2e ./...`
+// without Docker gets a clear skip rather than a confusing
+// connection-refused error).
+//
+// What this test does NOT cover (deliberately):
+//   - The binlog parser → indexer pipeline. seed.sql hand-writes the
+//     binlog_events rows so we can pin a deterministic time series.
+//     The parser/indexer have their own integration tests under
+//     internal/parser and internal/indexer.
+//   - The Parquet archive read path. archive_state is empty here;
+//     archives are exercised by internal/parquetquery's tests.
+package shim_e2e
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+const (
+	proxysqlAdminAddr  = "127.0.0.1:16032"
+	proxysqlClientAddr = "127.0.0.1:16033"
+
+	// proxysqlBackendDSN is the host-side view of the MySQL backend
+	// for the SQL emitted by `bintrail proxysql-config`. The host is
+	// the docker-compose service name (`mysql`) because the SQL is
+	// loaded into ProxySQL, which resolves it inside the compose
+	// network — not on the host.
+	proxysqlBackendDSN = "root:testroot@tcp(mysql:3306)/appdb"
+
+	// readyDeadline caps how long we wait for ProxySQL admin + client
+	// ports to be reachable after `compose up`. Long enough to absorb
+	// a slow image pull on a cold runner; short enough that a real
+	// failure surfaces in under a minute.
+	readyDeadline = 90 * time.Second
+)
+
+// TestShimEndToEnd asserts the four cases promised by the issue:
+//
+//  1. _flashback returns the row's state at-or-before the AS OF
+//     timestamp (selecting the right post-image from a multi-event
+//     history).
+//  2. _diff returns every event in the time window in chronological
+//     order, with the right metadata.
+//  3. _snapshot behaves like _flashback (reserved for future
+//     baseline-lookup support).
+//  4. A non-virtual-schema query is routed to the passthrough
+//     backend — verified by the row content (the live row has
+//     a marker value that no binlog event contains).
+//
+// All four go through the real ProxySQL routing layer, so a
+// regression in the regex rules emitted by `bintrail proxysql-config`
+// surfaces as a routing-class failure here (e.g. _flashback query
+// would hit the passthrough and return a "table doesn't exist"
+// error from MySQL instead of a reconstructed image).
+func TestShimEndToEnd(t *testing.T) {
+	if os.Getenv("SHIM_E2E") == "" {
+		t.Skip("set SHIM_E2E=1 to run the shim wire-protocol e2e (requires Docker)")
+	}
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skip("docker not on PATH; skipping shim e2e")
+	}
+
+	bintrailBin := buildBintrailBinary(t)
+
+	// Compose lifecycle is owned by the test (not run.sh) so a
+	// developer running `go test -tags shim_e2e ./e2e/shim/...`
+	// directly still gets the full setup + teardown.
+	composeUp(t)
+	t.Cleanup(func() { composeDown(t) })
+
+	waitForPort(t, proxysqlAdminAddr, readyDeadline)
+	waitForPort(t, proxysqlClientAddr, readyDeadline)
+
+	applyProxySQLConfig(t, bintrailBin)
+
+	// Wait for the freshly-loaded mysql_users to propagate so the
+	// first client login doesn't race ProxySQL's internal LOAD.
+	clientDB := openClientWithRetry(t, "testuser:testpw@tcp("+proxysqlClientAddr+")/appdb", 30*time.Second)
+	t.Cleanup(func() { clientDB.Close() })
+
+	t.Run("flashback_returns_post_image_at_asof", func(t *testing.T) {
+		// AS OF 13:00 → after the 12:00 UPDATE (qty=2), before the
+		// 14:00 DELETE. Expect qty=2.
+		row := queryRow(t, clientDB,
+			"SELECT id, sku, qty, note FROM _flashback.orders AS OF '2026-05-04 13:00:00' WHERE id = 42")
+		got := scanOrder(t, row)
+		want := orderRow{id: "42", sku: "ABC-1", qty: "2", note: "initial"}
+		if got != want {
+			t.Errorf("flashback row mismatch:\n  got:  %+v\n  want: %+v", got, want)
+		}
+	})
+
+	t.Run("flashback_pre_insert_returns_empty", func(t *testing.T) {
+		// AS OF 09:00 → before the 10:00 INSERT. Expect zero rows.
+		// emptyResult uses the literal "_flashback" column header,
+		// so a column-shape mismatch from a future refactor would
+		// show up as a Scan error, not a silent pass.
+		rows, err := clientDB.Query(
+			"SELECT id, sku, qty, note FROM _flashback.orders AS OF '2026-05-04 09:00:00' WHERE id = 42")
+		if err != nil {
+			t.Fatalf("query: %v", err)
+		}
+		defer rows.Close()
+		if rows.Next() {
+			t.Fatalf("expected zero rows for AS OF before INSERT, got at least one")
+		}
+	})
+
+	t.Run("diff_returns_event_history", func(t *testing.T) {
+		rows, err := clientDB.Query(
+			"SELECT event_id, event_timestamp, event_type, gtid, row_before, row_after " +
+				"FROM _diff.orders BETWEEN '2026-05-04 09:00:00' AND '2026-05-04 16:00:00' " +
+				"WHERE id = 42")
+		if err != nil {
+			t.Fatalf("diff query: %v", err)
+		}
+		defer rows.Close()
+
+		var got []diffRow
+		for rows.Next() {
+			var d diffRow
+			if err := rows.Scan(&d.eventID, &d.timestamp, &d.eventType, &d.gtid, &d.rowBefore, &d.rowAfter); err != nil {
+				t.Fatalf("scan diff: %v", err)
+			}
+			got = append(got, d)
+		}
+		if err := rows.Err(); err != nil {
+			t.Fatalf("rows err: %v", err)
+		}
+
+		if len(got) != 3 {
+			t.Fatalf("expected 3 diff rows (INSERT, UPDATE, DELETE), got %d: %+v", len(got), got)
+		}
+
+		assertDiff(t, got[0], "2026-05-04 10:00:00", "INSERT", "", `"qty": 1`)
+		assertDiff(t, got[1], "2026-05-04 12:00:00", "UPDATE", `"qty": 1`, `"qty": 2`)
+		assertDiff(t, got[2], "2026-05-04 14:00:00", "DELETE", `"qty": 2`, "")
+	})
+
+	t.Run("snapshot_matches_flashback", func(t *testing.T) {
+		// _snapshot today is implemented as an alias of _flashback;
+		// asserting that here pins the contract so a future split
+		// (baseline-lookup support) can be reviewed deliberately.
+		row := queryRow(t, clientDB,
+			"SELECT id, sku, qty, note FROM _snapshot.orders AS OF '2026-05-04 11:00:00' WHERE id = 42")
+		got := scanOrder(t, row)
+		want := orderRow{id: "42", sku: "ABC-1", qty: "1", note: "initial"}
+		if got != want {
+			t.Errorf("snapshot row mismatch:\n  got:  %+v\n  want: %+v", got, want)
+		}
+	})
+
+	t.Run("passthrough_query_hits_real_mysql_not_shim", func(t *testing.T) {
+		// `appdb.orders` (no virtual schema) must route to the
+		// passthrough hostgroup. The live row has marker values
+		// (sku=LIVE-SKU, qty=999) that no binlog event in the seed
+		// contains — so an accidental shim route would either
+		// error ("this server only handles _flashback / _snapshot
+		// / _diff …") or return the historical image, neither of
+		// which match these markers.
+		row := queryRow(t, clientDB,
+			"SELECT id, sku, qty, note FROM orders WHERE id = 42")
+		got := scanOrder(t, row)
+		want := orderRow{id: "42", sku: "LIVE-SKU", qty: "999", note: "live-row-from-passthrough"}
+		if got != want {
+			t.Errorf("passthrough row mismatch:\n  got:  %+v\n  want: %+v\n"+
+				"if this looks like a shim error, the regex in `bintrail proxysql-config` "+
+				"is over-matching", got, want)
+		}
+	})
+}
+
+type orderRow struct {
+	id, sku, qty, note string
+}
+
+type diffRow struct {
+	eventID   int64
+	timestamp string
+	eventType string
+	gtid      string
+	rowBefore string
+	rowAfter  string
+}
+
+func scanOrder(t *testing.T, row *sql.Row) orderRow {
+	t.Helper()
+	var o orderRow
+	if err := row.Scan(&o.id, &o.sku, &o.qty, &o.note); err != nil {
+		t.Fatalf("scan order: %v", err)
+	}
+	return o
+}
+
+func assertDiff(t *testing.T, d diffRow, wantTS, wantType, wantBeforeContains, wantAfterContains string) {
+	t.Helper()
+	if d.timestamp != wantTS {
+		t.Errorf("diff[%s]: timestamp got %q, want %q", wantType, d.timestamp, wantTS)
+	}
+	if d.eventType != wantType {
+		t.Errorf("diff[%s]: event_type got %q, want %q", wantType, d.eventType, wantType)
+	}
+	if wantBeforeContains == "" {
+		if d.rowBefore != "" {
+			t.Errorf("diff[%s]: row_before should be empty, got %q", wantType, d.rowBefore)
+		}
+	} else if !strings.Contains(d.rowBefore, wantBeforeContains) {
+		t.Errorf("diff[%s]: row_before %q does not contain %q", wantType, d.rowBefore, wantBeforeContains)
+	}
+	if wantAfterContains == "" {
+		if d.rowAfter != "" {
+			t.Errorf("diff[%s]: row_after should be empty, got %q", wantType, d.rowAfter)
+		}
+	} else if !strings.Contains(d.rowAfter, wantAfterContains) {
+		t.Errorf("diff[%s]: row_after %q does not contain %q", wantType, d.rowAfter, wantAfterContains)
+	}
+}
+
+// queryRow wraps QueryRow with a slightly clearer failure path for
+// the multi-statement subtests — sql.QueryRow defers errors to Scan
+// time, but if the connection itself is bad (e.g. ProxySQL hasn't
+// reloaded users yet) we want the failure to point at the right
+// subtest, not at "scan: bad connection".
+func queryRow(t *testing.T, db *sql.DB, q string) *sql.Row {
+	t.Helper()
+	if err := db.PingContext(context.Background()); err != nil {
+		t.Fatalf("ping before query: %v", err)
+	}
+	return db.QueryRow(q)
+}
+
+// buildBintrailBinary builds a host-side `bintrail` binary so the
+// test can call `proxysql-config` to produce the ProxySQL setup SQL.
+// We could shell out via `go run` instead, but `go run` recompiles
+// every invocation and the build cache hit on a real binary is
+// faster overall.
+func buildBintrailBinary(t *testing.T) string {
+	t.Helper()
+	out := filepath.Join(t.TempDir(), "bintrail")
+	cmd := exec.Command("go", "build", "-o", out, "../../cmd/bintrail")
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("build bintrail: %v", err)
+	}
+	return out
+}
+
+func composeUp(t *testing.T) {
+	t.Helper()
+	cmd := exec.Command("docker", "compose", "up", "-d", "--build", "--wait")
+	cmd.Dir = "."
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		// Best-effort dump of container logs so a CI failure is
+		// debuggable from the test output alone — without this,
+		// `compose up failed` would leave the diagnostics inside
+		// containers that compose down then deletes.
+		dumpComposeLogs(t)
+		t.Fatalf("compose up: %v", err)
+	}
+}
+
+func composeDown(t *testing.T) {
+	t.Helper()
+	if t.Failed() {
+		dumpComposeLogs(t)
+	}
+	cmd := exec.Command("docker", "compose", "down", "-v")
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	_ = cmd.Run() // best effort
+}
+
+func dumpComposeLogs(t *testing.T) {
+	t.Helper()
+	cmd := exec.Command("docker", "compose", "logs", "--no-color", "--tail", "200")
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	_ = cmd.Run()
+}
+
+func waitForPort(t *testing.T, addr string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", addr, 1*time.Second)
+		if err == nil {
+			conn.Close()
+			return
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Fatalf("port %s not reachable after %s", addr, timeout)
+}
+
+// applyProxySQLConfig runs `bintrail proxysql-config` to generate
+// the setup SQL, then pipes it into ProxySQL's admin port. This
+// exercises the actual command instead of carrying a hand-rolled
+// duplicate — a regression in proxysql-config's output (renamed
+// rule, dropped LOAD line) surfaces here as a no-route failure
+// in the subsequent subtests.
+func applyProxySQLConfig(t *testing.T, bintrailBin string) {
+	t.Helper()
+
+	gen := exec.Command(bintrailBin, "proxysql-config",
+		"--shim-config", "shim.yaml",
+		"--mysql-port", "3306",
+		"--shim-port", "3308",
+		"--out", "-")
+	gen.Env = append(os.Environ(), "BINTRAIL_SOURCE_DSN="+proxysqlBackendDSN)
+	var setupSQL bytes.Buffer
+	gen.Stdout = &setupSQL
+	gen.Stderr = os.Stderr
+	if err := gen.Run(); err != nil {
+		t.Fatalf("generate proxysql-setup.sql: %v", err)
+	}
+
+	// ProxySQL admin uses the MySQL protocol; the default credentials
+	// for the official image are admin/admin on port 6032. The setup
+	// script is idempotent (DELETE then INSERT in a transaction),
+	// so a transient retry on a not-yet-ready admin port is safe.
+	adminDB := openAdminWithRetry(t, "admin:admin@tcp("+proxysqlAdminAddr+")/", 30*time.Second)
+	defer adminDB.Close()
+
+	for _, stmt := range splitSQL(setupSQL.String()) {
+		if _, err := adminDB.Exec(stmt); err != nil {
+			t.Fatalf("apply admin stmt %q: %v", abbreviate(stmt, 80), err)
+		}
+	}
+}
+
+// splitSQL splits a multi-statement script into individual statements
+// for sequential Exec. ProxySQL's admin parser doesn't accept
+// multi-statement Exec calls; running them one at a time is the
+// supported path. Comments and blank lines are dropped so they don't
+// turn into empty Exec calls.
+func splitSQL(s string) []string {
+	var out []string
+	for _, raw := range strings.Split(s, ";") {
+		line := strings.TrimSpace(raw)
+		if line == "" {
+			continue
+		}
+		// Strip leading "-- " comment lines but keep statements
+		// that have a trailing inline comment.
+		filtered := make([]string, 0)
+		for _, l := range strings.Split(line, "\n") {
+			if strings.HasPrefix(strings.TrimSpace(l), "--") {
+				continue
+			}
+			filtered = append(filtered, l)
+		}
+		joined := strings.TrimSpace(strings.Join(filtered, "\n"))
+		if joined == "" {
+			continue
+		}
+		out = append(out, joined)
+	}
+	return out
+}
+
+func abbreviate(s string, n int) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}
+
+func openAdminWithRetry(t *testing.T, dsn string, timeout time.Duration) *sql.DB {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		db, err := sql.Open("mysql", dsn)
+		if err == nil {
+			if pingErr := db.Ping(); pingErr == nil {
+				return db
+			} else {
+				lastErr = pingErr
+				db.Close()
+			}
+		} else {
+			lastErr = err
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Fatalf("connect to ProxySQL admin: %v", lastErr)
+	return nil
+}
+
+// openClientWithRetry distinguishes "auth not yet loaded" (retry) from
+// "wrong password" (fail fast). ProxySQL takes a beat to honour LOAD
+// MYSQL USERS TO RUNTIME and the first few logins after applyProxySQLConfig
+// can race that load — without this distinction the flake would look
+// like a permanent auth failure.
+func openClientWithRetry(t *testing.T, dsn string, timeout time.Duration) *sql.DB {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		db, err := sql.Open("mysql", dsn)
+		if err != nil {
+			lastErr = err
+		} else if pingErr := db.Ping(); pingErr == nil {
+			return db
+		} else {
+			lastErr = pingErr
+			db.Close()
+			// Permanent rejection — surface it now rather than
+			// burning the rest of the deadline on a doomed retry.
+			if isAuthError(pingErr) {
+				t.Fatalf("ProxySQL rejected client credentials: %v", pingErr)
+			}
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Fatalf("connect as client: %v", lastErr)
+	return nil
+}
+
+// isAuthError matches the go-sql-driver "Error 1045" wire-protocol
+// access-denied response by message substring. Using the message
+// keeps this helper from depending on the driver's typed error,
+// which is fine here because we only need to distinguish "definitely
+// permanent" from "still warming up".
+func isAuthError(err error) bool {
+	return strings.Contains(strings.ToLower(err.Error()), "access denied")
+}

--- a/e2e/shim/e2e_test.go
+++ b/e2e/shim/e2e_test.go
@@ -155,9 +155,13 @@ func TestShimEndToEnd(t *testing.T) {
 			t.Fatalf("expected 3 diff rows (INSERT, UPDATE, DELETE), got %d: %+v", len(got), got)
 		}
 
-		assertDiff(t, got[0], "2026-05-04 10:00:00", "INSERT", "", `"qty": 1`)
-		assertDiff(t, got[1], "2026-05-04 12:00:00", "UPDATE", `"qty": 1`, `"qty": 2`)
-		assertDiff(t, got[2], "2026-05-04 14:00:00", "DELETE", `"qty": 2`, "")
+		// json.Marshal(map[string]any) emits no whitespace between
+		// keys and values, so the substring matchers must use the
+		// compact form `"qty":1` — `"qty": 1` (with space) would
+		// silently never match.
+		assertDiff(t, got[0], "2026-05-04 10:00:00", "INSERT", "", `"qty":1`)
+		assertDiff(t, got[1], "2026-05-04 12:00:00", "UPDATE", `"qty":1`, `"qty":2`)
+		assertDiff(t, got[2], "2026-05-04 14:00:00", "DELETE", `"qty":2`, "")
 	})
 
 	t.Run("snapshot_matches_flashback", func(t *testing.T) {
@@ -341,14 +345,26 @@ func applyProxySQLConfig(t *testing.T, bintrailBin string) {
 	}
 
 	// ProxySQL admin uses the MySQL protocol; the default credentials
-	// for the official image are admin/admin on port 6032. The setup
-	// script is idempotent (DELETE then INSERT in a transaction),
-	// so a transient retry on a not-yet-ready admin port is safe.
+	// for the official image are admin/admin on port 6032.
 	adminDB := openAdminWithRetry(t, "admin:admin@tcp("+proxysqlAdminAddr+")/", 30*time.Second)
 	defer adminDB.Close()
 
+	// Pin to a single connection so the BEGIN/COMMIT pair emitted by
+	// proxysql-config actually wraps the inner DELETE/INSERTs. Without
+	// this each Exec may pull a different conn from the pool, which
+	// silently demotes the transaction to a sequence of independent
+	// statements — and a half-applied script leaves the next run with
+	// a primary-key collision on the INSERT-after-DELETE pattern.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	conn, err := adminDB.Conn(ctx)
+	if err != nil {
+		t.Fatalf("acquire admin conn: %v", err)
+	}
+	defer conn.Close()
+
 	for _, stmt := range splitSQL(setupSQL.String()) {
-		if _, err := adminDB.Exec(stmt); err != nil {
+		if _, err := conn.ExecContext(ctx, stmt); err != nil {
 			t.Fatalf("apply admin stmt %q: %v", abbreviate(stmt, 80), err)
 		}
 	}
@@ -359,6 +375,12 @@ func applyProxySQLConfig(t *testing.T, bintrailBin string) {
 // multi-statement Exec calls; running them one at a time is the
 // supported path. Comments and blank lines are dropped so they don't
 // turn into empty Exec calls.
+//
+// This is a naive split-on-`;`: it would mangle a statement
+// containing a `;` inside a string literal. proxysql-config's output
+// happens to contain no such literals today (the only single-quoted
+// strings are hostnames, usernames, regex patterns, and the SHA1
+// hash) — if that ever changes, replace this with a real tokenizer.
 func splitSQL(s string) []string {
 	var out []string
 	for _, raw := range strings.Split(s, ";") {

--- a/e2e/shim/e2e_test.go
+++ b/e2e/shim/e2e_test.go
@@ -28,6 +28,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"errors"
 	"net"
 	"os"
 	"os/exec"
@@ -36,7 +37,7 @@ import (
 	"testing"
 	"time"
 
-	_ "github.com/go-sql-driver/mysql"
+	"github.com/go-sql-driver/mysql"
 )
 
 const (
@@ -101,25 +102,28 @@ func TestShimEndToEnd(t *testing.T) {
 	clientDB := openClientWithRetry(t, "testuser:testpw@tcp("+proxysqlClientAddr+")/appdb", 30*time.Second)
 	t.Cleanup(func() { clientDB.Close() })
 
+	// All time-travel queries use SELECT * — the shim's parser
+	// (internal/shim/parser.go) hard-requires a literal star;
+	// `SELECT id, sku, ...` falls through to "this server only
+	// handles _flashback / _snapshot / _diff" rejection.
 	t.Run("flashback_returns_post_image_at_asof", func(t *testing.T) {
 		// AS OF 13:00 → after the 12:00 UPDATE (qty=2), before the
 		// 14:00 DELETE. Expect qty=2.
-		row := queryRow(t, clientDB,
-			"SELECT id, sku, qty, note FROM _flashback.orders AS OF '2026-05-04 13:00:00' WHERE id = 42")
-		got := scanOrder(t, row)
-		want := orderRow{id: "42", sku: "ABC-1", qty: "2", note: "initial"}
-		if got != want {
+		got := queryRowMap(t, clientDB,
+			"SELECT * FROM _flashback.orders AS OF '2026-05-04 13:00:00' WHERE id = 42")
+		want := map[string]string{"id": "42", "sku": "ABC-1", "qty": "2", "note": "initial"}
+		if !mapsEqual(got, want) {
 			t.Errorf("flashback row mismatch:\n  got:  %+v\n  want: %+v", got, want)
 		}
 	})
 
 	t.Run("flashback_pre_insert_returns_empty", func(t *testing.T) {
 		// AS OF 09:00 → before the 10:00 INSERT. Expect zero rows.
-		// emptyResult uses the literal "_flashback" column header,
-		// so a column-shape mismatch from a future refactor would
-		// show up as a Scan error, not a silent pass.
+		// The shim's emptyResult returns a one-column resultset
+		// with the literal header "_flashback"; we don't scan, just
+		// verify Next() returns false.
 		rows, err := clientDB.Query(
-			"SELECT id, sku, qty, note FROM _flashback.orders AS OF '2026-05-04 09:00:00' WHERE id = 42")
+			"SELECT * FROM _flashback.orders AS OF '2026-05-04 09:00:00' WHERE id = 42")
 		if err != nil {
 			t.Fatalf("query: %v", err)
 		}
@@ -131,14 +135,17 @@ func TestShimEndToEnd(t *testing.T) {
 
 	t.Run("diff_returns_event_history", func(t *testing.T) {
 		rows, err := clientDB.Query(
-			"SELECT event_id, event_timestamp, event_type, gtid, row_before, row_after " +
-				"FROM _diff.orders BETWEEN '2026-05-04 09:00:00' AND '2026-05-04 16:00:00' " +
+			"SELECT * FROM _diff.orders BETWEEN '2026-05-04 09:00:00' AND '2026-05-04 16:00:00' " +
 				"WHERE id = 42")
 		if err != nil {
 			t.Fatalf("diff query: %v", err)
 		}
 		defer rows.Close()
 
+		// _diff's resultset shape is fixed by handler.runDiff:
+		// (event_id, event_timestamp, event_type, gtid, row_before, row_after)
+		// so positional scan is safe here — unlike the flashback
+		// case where column order is JSON-key-sorted.
 		var got []diffRow
 		for rows.Next() {
 			var d diffRow
@@ -155,24 +162,25 @@ func TestShimEndToEnd(t *testing.T) {
 			t.Fatalf("expected 3 diff rows (INSERT, UPDATE, DELETE), got %d: %+v", len(got), got)
 		}
 
-		// json.Marshal(map[string]any) emits no whitespace between
-		// keys and values, so the substring matchers must use the
-		// compact form `"qty":1` — `"qty": 1` (with space) would
-		// silently never match.
-		assertDiff(t, got[0], "2026-05-04 10:00:00", "INSERT", "", `"qty":1`)
-		assertDiff(t, got[1], "2026-05-04 12:00:00", "UPDATE", `"qty":1`, `"qty":2`)
-		assertDiff(t, got[2], "2026-05-04 14:00:00", "DELETE", `"qty":2`, "")
+		// Substring match on JSON includes a delimiter (`,` or `}`)
+		// so `"qty":1` doesn't accidentally match `"qty":10` or
+		// `"qty":100`. json.Marshal of map[string]any sorts keys
+		// alphabetically, so id < note < qty < sku — qty is never
+		// the last key here, hence the `,` boundary.
+		assertDiff(t, got[0], "2026-05-04 10:00:00", "INSERT", "", `"qty":1,`)
+		assertDiff(t, got[1], "2026-05-04 12:00:00", "UPDATE", `"qty":1,`, `"qty":2,`)
+		assertDiff(t, got[2], "2026-05-04 14:00:00", "DELETE", `"qty":2,`, "")
 	})
 
 	t.Run("snapshot_matches_flashback", func(t *testing.T) {
-		// _snapshot today is implemented as an alias of _flashback;
-		// asserting that here pins the contract so a future split
-		// (baseline-lookup support) can be reviewed deliberately.
-		row := queryRow(t, clientDB,
-			"SELECT id, sku, qty, note FROM _snapshot.orders AS OF '2026-05-04 11:00:00' WHERE id = 42")
-		got := scanOrder(t, row)
-		want := orderRow{id: "42", sku: "ABC-1", qty: "1", note: "initial"}
-		if got != want {
+		// _snapshot must return the same row image as _flashback
+		// for the same AS OF. They share an implementation today
+		// (handler.runPointInTime); pinning the contract here
+		// keeps a future split (baseline-lookup support) deliberate.
+		got := queryRowMap(t, clientDB,
+			"SELECT * FROM _snapshot.orders AS OF '2026-05-04 11:00:00' WHERE id = 42")
+		want := map[string]string{"id": "42", "sku": "ABC-1", "qty": "1", "note": "initial"}
+		if !mapsEqual(got, want) {
 			t.Errorf("snapshot row mismatch:\n  got:  %+v\n  want: %+v", got, want)
 		}
 	})
@@ -185,20 +193,15 @@ func TestShimEndToEnd(t *testing.T) {
 		// error ("this server only handles _flashback / _snapshot
 		// / _diff …") or return the historical image, neither of
 		// which match these markers.
-		row := queryRow(t, clientDB,
-			"SELECT id, sku, qty, note FROM orders WHERE id = 42")
-		got := scanOrder(t, row)
-		want := orderRow{id: "42", sku: "LIVE-SKU", qty: "999", note: "live-row-from-passthrough"}
-		if got != want {
+		got := queryRowMap(t, clientDB,
+			"SELECT * FROM orders WHERE id = 42")
+		want := map[string]string{"id": "42", "sku": "LIVE-SKU", "qty": "999", "note": "live-row-from-passthrough"}
+		if !mapsEqual(got, want) {
 			t.Errorf("passthrough row mismatch:\n  got:  %+v\n  want: %+v\n"+
 				"if this looks like a shim error, the regex in `bintrail proxysql-config` "+
 				"is over-matching", got, want)
 		}
 	})
-}
-
-type orderRow struct {
-	id, sku, qty, note string
 }
 
 type diffRow struct {
@@ -210,13 +213,73 @@ type diffRow struct {
 	rowAfter  string
 }
 
-func scanOrder(t *testing.T, row *sql.Row) orderRow {
+// queryRowMap runs a single-row SELECT and returns the result as a
+// {column → value} map. Both the shim and the passthrough backend
+// answer SELECT *, but they pick column orders that disagree:
+//   - real MySQL returns DDL order (id, sku, qty, note)
+//   - the shim's imageToResult sorts JSON keys alphabetically
+//     (id, note, qty, sku)
+//
+// Positional Scan would silently swap fields between the two paths
+// and pass with the wrong values. Map-based comparison is the only
+// safe option until imageToResult learns to honour the source DDL
+// column order.
+func queryRowMap(t *testing.T, db *sql.DB, q string) map[string]string {
 	t.Helper()
-	var o orderRow
-	if err := row.Scan(&o.id, &o.sku, &o.qty, &o.note); err != nil {
-		t.Fatalf("scan order: %v", err)
+	if err := db.PingContext(context.Background()); err != nil {
+		t.Fatalf("ping before query: %v", err)
 	}
-	return o
+	rows, err := db.Query(q)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer rows.Close()
+
+	cols, err := rows.Columns()
+	if err != nil {
+		t.Fatalf("columns: %v", err)
+	}
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			t.Fatalf("rows err: %v", err)
+		}
+		t.Fatalf("expected exactly one row, got zero (cols=%v)", cols)
+	}
+
+	raw := make([]sql.RawBytes, len(cols))
+	dest := make([]any, len(cols))
+	for i := range raw {
+		dest[i] = &raw[i]
+	}
+	if err := rows.Scan(dest...); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+
+	out := make(map[string]string, len(cols))
+	for i, c := range cols {
+		if raw[i] == nil {
+			out[c] = "<nil>"
+			continue
+		}
+		out[c] = string(raw[i])
+	}
+
+	if rows.Next() {
+		t.Fatalf("expected exactly one row, got at least two")
+	}
+	return out
+}
+
+func mapsEqual(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
 }
 
 func assertDiff(t *testing.T, d diffRow, wantTS, wantType, wantBeforeContains, wantAfterContains string) {
@@ -241,19 +304,6 @@ func assertDiff(t *testing.T, d diffRow, wantTS, wantType, wantBeforeContains, w
 	} else if !strings.Contains(d.rowAfter, wantAfterContains) {
 		t.Errorf("diff[%s]: row_after %q does not contain %q", wantType, d.rowAfter, wantAfterContains)
 	}
-}
-
-// queryRow wraps QueryRow with a slightly clearer failure path for
-// the multi-statement subtests — sql.QueryRow defers errors to Scan
-// time, but if the connection itself is bad (e.g. ProxySQL hasn't
-// reloaded users yet) we want the failure to point at the right
-// subtest, not at "scan: bad connection".
-func queryRow(t *testing.T, db *sql.DB, q string) *sql.Row {
-	t.Helper()
-	if err := db.PingContext(context.Background()); err != nil {
-		t.Fatalf("ping before query: %v", err)
-	}
-	return db.QueryRow(q)
 }
 
 // buildBintrailBinary builds a host-side `bintrail` binary so the
@@ -466,11 +516,14 @@ func openClientWithRetry(t *testing.T, dsn string, timeout time.Duration) *sql.D
 	return nil
 }
 
-// isAuthError matches the go-sql-driver "Error 1045" wire-protocol
-// access-denied response by message substring. Using the message
-// keeps this helper from depending on the driver's typed error,
-// which is fine here because we only need to distinguish "definitely
-// permanent" from "still warming up".
+// isAuthError reports whether err is a permanent auth-rejection
+// (vs. "ProxySQL is still warming up"). Type-checks for go-sql-driver's
+// MySQLError with code 1045 (ER_ACCESS_DENIED_ERROR) — the wire
+// code is stable across MySQL/ProxySQL wording changes, unlike a
+// substring match on "access denied" which could miss future
+// ProxySQL-specific messages or false-positive on unrelated errors
+// that happen to contain that phrase.
 func isAuthError(err error) bool {
-	return strings.Contains(strings.ToLower(err.Error()), "access denied")
+	var mysqlErr *mysql.MySQLError
+	return errors.As(err, &mysqlErr) && mysqlErr.Number == 1045
 }

--- a/e2e/shim/e2e_test.go
+++ b/e2e/shim/e2e_test.go
@@ -146,12 +146,23 @@ func TestShimEndToEnd(t *testing.T) {
 		// (event_id, event_timestamp, event_type, gtid, row_before, row_after)
 		// so positional scan is safe here — unlike the flashback
 		// case where column order is JSON-key-sorted.
+		//
+		// row_before and row_after scan into sql.NullString because
+		// go-mysql's BuildSimpleTextResultset encodes the empty
+		// string as a NULL on the wire, and the shim deliberately
+		// emits "" for INSERTs (no before-image) and DELETEs (no
+		// after-image). diffRow normalises both back to "".
 		var got []diffRow
 		for rows.Next() {
-			var d diffRow
-			if err := rows.Scan(&d.eventID, &d.timestamp, &d.eventType, &d.gtid, &d.rowBefore, &d.rowAfter); err != nil {
+			var (
+				d                  diffRow
+				rowBefore, rowAft  sql.NullString
+			)
+			if err := rows.Scan(&d.eventID, &d.timestamp, &d.eventType, &d.gtid, &rowBefore, &rowAft); err != nil {
 				t.Fatalf("scan diff: %v", err)
 			}
+			d.rowBefore = rowBefore.String // "" when invalid (NULL on the wire)
+			d.rowAfter = rowAft.String
 			got = append(got, d)
 		}
 		if err := rows.Err(); err != nil {
@@ -394,9 +405,11 @@ func applyProxySQLConfig(t *testing.T, bintrailBin string) {
 		t.Fatalf("generate proxysql-setup.sql: %v", err)
 	}
 
-	// ProxySQL admin uses the MySQL protocol; the default credentials
-	// for the official image are admin/admin on port 6032.
-	adminDB := openAdminWithRetry(t, "admin:admin@tcp("+proxysqlAdminAddr+")/", 30*time.Second)
+	// ProxySQL admin uses the MySQL protocol on port 6032. The
+	// stock `admin:admin` user is loopback-only, so we connect as
+	// the `radminuser:radminpw` extra credential declared in
+	// proxysql.cnf (see proxysql.cnf for the rationale).
+	adminDB := openAdminWithRetry(t, "radminuser:radminpw@tcp("+proxysqlAdminAddr+")/", 30*time.Second)
 	defer adminDB.Close()
 
 	// Pin to a single connection so the BEGIN/COMMIT pair emitted by

--- a/e2e/shim/e2e_test.go
+++ b/e2e/shim/e2e_test.go
@@ -29,6 +29,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"maps"
 	"net"
 	"os"
 	"os/exec"
@@ -112,7 +113,7 @@ func TestShimEndToEnd(t *testing.T) {
 		got := queryRowMap(t, clientDB,
 			"SELECT * FROM _flashback.orders AS OF '2026-05-04 13:00:00' WHERE id = 42")
 		want := map[string]string{"id": "42", "sku": "ABC-1", "qty": "2", "note": "initial"}
-		if !mapsEqual(got, want) {
+		if !maps.Equal(got, want) {
 			t.Errorf("flashback row mismatch:\n  got:  %+v\n  want: %+v", got, want)
 		}
 	})
@@ -155,14 +156,14 @@ func TestShimEndToEnd(t *testing.T) {
 		var got []diffRow
 		for rows.Next() {
 			var (
-				d                  diffRow
-				rowBefore, rowAft  sql.NullString
+				d                   diffRow
+				rowBefore, rowAfter sql.NullString
 			)
-			if err := rows.Scan(&d.eventID, &d.timestamp, &d.eventType, &d.gtid, &rowBefore, &rowAft); err != nil {
+			if err := rows.Scan(&d.eventID, &d.timestamp, &d.eventType, &d.gtid, &rowBefore, &rowAfter); err != nil {
 				t.Fatalf("scan diff: %v", err)
 			}
 			d.rowBefore = rowBefore.String // "" when invalid (NULL on the wire)
-			d.rowAfter = rowAft.String
+			d.rowAfter = rowAfter.String
 			got = append(got, d)
 		}
 		if err := rows.Err(); err != nil {
@@ -185,14 +186,44 @@ func TestShimEndToEnd(t *testing.T) {
 
 	t.Run("snapshot_matches_flashback", func(t *testing.T) {
 		// _snapshot must return the same row image as _flashback
-		// for the same AS OF. They share an implementation today
+		// for the same AS OF. They share an implementation
 		// (handler.runPointInTime); pinning the contract here
 		// keeps a future split (baseline-lookup support) deliberate.
 		got := queryRowMap(t, clientDB,
 			"SELECT * FROM _snapshot.orders AS OF '2026-05-04 11:00:00' WHERE id = 42")
 		want := map[string]string{"id": "42", "sku": "ABC-1", "qty": "1", "note": "initial"}
-		if !mapsEqual(got, want) {
+		if !maps.Equal(got, want) {
 			t.Errorf("snapshot row mismatch:\n  got:  %+v\n  want: %+v", got, want)
+		}
+	})
+
+	t.Run("auth_rejection_returns_1045_not_1449", func(t *testing.T) {
+		// Guards against the issue #262 / v0.7.4 regression
+		// class: TenantAuth must surface bad credentials as
+		// ER_ACCESS_DENIED_ERROR (1045), not ER_NO_SUCH_USER
+		// (1449) or a generic conn-reset. ProxySQL's monitor
+		// probe SHUNNs the shim hostgroup if it sees anything
+		// other than 1045 — leaving the routing silently broken.
+		// Unit tests cannot catch this because the wire-shape
+		// rewriting happens inside go-mysql/server's handshake
+		// rather than in TenantAuth itself.
+		badDB, err := sql.Open("mysql", "wronguser:wrongpw@tcp("+proxysqlClientAddr+")/appdb")
+		if err != nil {
+			t.Fatalf("open with bad creds: %v", err)
+		}
+		defer badDB.Close()
+
+		err = badDB.Ping()
+		if err == nil {
+			t.Fatalf("expected ping with bad creds to fail, got nil")
+		}
+		var mysqlErr *mysql.MySQLError
+		if !errors.As(err, &mysqlErr) {
+			t.Fatalf("expected *mysql.MySQLError, got %T: %v", err, err)
+		}
+		if mysqlErr.Number != 1045 {
+			t.Fatalf("expected error code 1045 (ER_ACCESS_DENIED_ERROR), got %d: %s",
+				mysqlErr.Number, mysqlErr.Message)
 		}
 	})
 
@@ -207,7 +238,7 @@ func TestShimEndToEnd(t *testing.T) {
 		got := queryRowMap(t, clientDB,
 			"SELECT * FROM orders WHERE id = 42")
 		want := map[string]string{"id": "42", "sku": "LIVE-SKU", "qty": "999", "note": "live-row-from-passthrough"}
-		if !mapsEqual(got, want) {
+		if !maps.Equal(got, want) {
 			t.Errorf("passthrough row mismatch:\n  got:  %+v\n  want: %+v\n"+
 				"if this looks like a shim error, the regex in `bintrail proxysql-config` "+
 				"is over-matching", got, want)
@@ -254,7 +285,11 @@ func queryRowMap(t *testing.T, db *sql.DB, q string) map[string]string {
 		if err := rows.Err(); err != nil {
 			t.Fatalf("rows err: %v", err)
 		}
-		t.Fatalf("expected exactly one row, got zero (cols=%v)", cols)
+		// cols=[_flashback] means the shim returned its
+		// emptyResult (no matching event); cols=[id sku qty note]
+		// means the passthrough hostgroup ran the query against
+		// real MySQL and matched nothing — different bugs.
+		t.Fatalf("expected exactly one row, got zero (query=%q, cols=%v)", q, cols)
 	}
 
 	raw := make([]sql.RawBytes, len(cols))
@@ -279,18 +314,6 @@ func queryRowMap(t *testing.T, db *sql.DB, q string) map[string]string {
 		t.Fatalf("expected exactly one row, got at least two")
 	}
 	return out
-}
-
-func mapsEqual(a, b map[string]string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for k, v := range a {
-		if b[k] != v {
-			return false
-		}
-	}
-	return true
 }
 
 func assertDiff(t *testing.T, d diffRow, wantTS, wantType, wantBeforeContains, wantAfterContains string) {
@@ -428,6 +451,12 @@ func applyProxySQLConfig(t *testing.T, bintrailBin string) {
 
 	for _, stmt := range splitSQL(setupSQL.String()) {
 		if _, err := conn.ExecContext(ctx, stmt); err != nil {
+			// Dump container logs first — ProxySQL's admin
+			// rejection messages often clarify *why* a stmt
+			// failed (typo in regex, bad hostgroup id) and
+			// they live in proxysql's stdout, not in the
+			// MySQL wire error we get back here.
+			dumpComposeLogs(t)
 			t.Fatalf("apply admin stmt %q: %v", abbreviate(stmt, 80), err)
 		}
 	}

--- a/e2e/shim/proxysql.cnf
+++ b/e2e/shim/proxysql.cnf
@@ -1,0 +1,31 @@
+# Minimal ProxySQL config for the e2e test.
+#
+# The reason this file exists: ProxySQL's default admin_credentials
+# of "admin:admin" is only accepted from 127.0.0.1, so the host-side
+# Go test gets back `Error 1040 (42000): User 'admin' can only
+# connect locally` when it tries to apply the proxysql-config SQL
+# via the published 16032 port. The convention in admin_credentials
+# is that the FIRST user is loopback-only and any SUBSEQUENT users
+# may connect from anywhere — so we keep "admin:admin" for backward
+# compat (anything inside the container can still use it) and add
+# "radminuser:radminpw" for the host-side test to use.
+#
+# mysql_ifaces is bound to 0.0.0.0:6033 (the client-facing port) so
+# the test runner can reach it through the published 16033.
+
+datadir="/var/lib/proxysql"
+
+admin_variables=
+{
+    admin_credentials="admin:admin;radminuser:radminpw"
+    mysql_ifaces="0.0.0.0:6032"
+}
+
+mysql_variables=
+{
+    interfaces="0.0.0.0:6033"
+    server_version="8.0.0"
+    monitor_username="monitor"
+    monitor_password="monitor"
+    default_authentication_plugin="mysql_native_password"
+}

--- a/e2e/shim/proxysql.cnf
+++ b/e2e/shim/proxysql.cnf
@@ -1,17 +1,21 @@
 # Minimal ProxySQL config for the e2e test.
 #
-# The reason this file exists: ProxySQL's default admin_credentials
-# of "admin:admin" is only accepted from 127.0.0.1, so the host-side
-# Go test gets back `Error 1040 (42000): User 'admin' can only
-# connect locally` when it tries to apply the proxysql-config SQL
-# via the published 16032 port. The convention in admin_credentials
-# is that the FIRST user is loopback-only and any SUBSEQUENT users
-# may connect from anywhere — so we keep "admin:admin" for backward
-# compat (anything inside the container can still use it) and add
-# "radminuser:radminpw" for the host-side test to use.
+# Carries only admin reachability and protocol bind addresses; the
+# routing config (mysql_servers / mysql_users / mysql_query_rules)
+# is loaded at test runtime by piping the SQL emitted by
+# `bintrail proxysql-config` into the admin port — that's the
+# whole point of running it through this rig.
 #
-# mysql_ifaces is bound to 0.0.0.0:6033 (the client-facing port) so
-# the test runner can reach it through the published 16033.
+# Why a custom cnf at all: ProxySQL hardcodes the literal username
+# `admin` as loopback-only, so the host-side Go test connecting
+# from the docker bridge gets `Error 1040 (42000): User 'admin'
+# can only connect locally`. Any non-`admin` username in
+# admin_credentials is accepted from wherever admin_variables.
+# mysql_ifaces listens — order in the credentials list does not
+# matter, only the literal name `admin` is special. We add
+# `radminuser:radminpw` for the host-side test and keep the
+# stock `admin:admin` so anything inside the container still
+# works the canonical way.
 
 datadir="/var/lib/proxysql"
 

--- a/e2e/shim/run.sh
+++ b/e2e/shim/run.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Wrapper that runs the bintrail shim end-to-end test.
+#
+# The test itself owns the docker-compose lifecycle (so a developer
+# can also run `SHIM_E2E=1 go test -tags shim_e2e ./e2e/shim/...`
+# directly from any directory and get the same setup + teardown).
+# This script just sets the gating env var and pins the working
+# directory so docker-compose finds its yaml.
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "docker not found on PATH; install Docker (with the compose plugin) and retry" >&2
+    exit 1
+fi
+
+SHIM_E2E=1 go test -tags shim_e2e -v -count=1 ./...

--- a/e2e/shim/seed.sql
+++ b/e2e/shim/seed.sql
@@ -1,0 +1,122 @@
+-- Seed for the e2e/shim Docker stack.
+--
+-- Creates two schemas in one MySQL container:
+--
+--   appdb           — the simulated "production" database the customer's
+--                     app would target. Holds the live `orders` table
+--                     so passthrough queries (no virtual schema) have
+--                     a real backend to land on.
+--
+--   bintrail_index  — the bintrail row-event index. binlog_events is
+--                     hand-seeded with a synthetic sequence for
+--                     appdb.orders id=42 (INSERT → UPDATE → DELETE).
+--                     This bypasses parser+indexer on purpose: the
+--                     shim e2e is about the wire-protocol + ProxySQL
+--                     routing path, not the binlog ingestion path
+--                     which the integration suite already covers.
+--
+-- All event timestamps are anchored on 2026-05-04 (UTC) so the
+-- expected results are deterministic regardless of when the test
+-- runs. Partitions cover that day's relevant hours plus p_future.
+
+CREATE DATABASE IF NOT EXISTS appdb CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+USE appdb;
+
+CREATE TABLE orders (
+    id    INT PRIMARY KEY,
+    sku   VARCHAR(64)  NOT NULL,
+    qty   INT          NOT NULL,
+    note  VARCHAR(255) DEFAULT NULL
+) ENGINE=InnoDB;
+
+-- A live row that the passthrough hostgroup returns. Its values
+-- intentionally differ from any of the binlog images below so the
+-- e2e test can distinguish "ProxySQL routed to passthrough"
+-- (returns this row) from "ProxySQL routed to shim" (returns a
+-- reconstructed historical image).
+INSERT INTO orders (id, sku, qty, note) VALUES
+    (42, 'LIVE-SKU', 999, 'live-row-from-passthrough');
+
+CREATE DATABASE IF NOT EXISTS bintrail_index CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+USE bintrail_index;
+
+-- DDL mirrors `bintrail init`'s output for binlog_events. The shim's
+-- planner reads information_schema.PARTITIONS scoped to this schema,
+-- so the partition list must cover every hour we insert into.
+CREATE TABLE binlog_events (
+    event_id        BIGINT UNSIGNED AUTO_INCREMENT,
+    binlog_file     VARCHAR(255)     NOT NULL,
+    start_pos       BIGINT UNSIGNED  NOT NULL,
+    end_pos         BIGINT UNSIGNED  NOT NULL,
+    event_timestamp DATETIME         NOT NULL,
+    gtid            VARCHAR(255)     DEFAULT NULL,
+    connection_id   INT UNSIGNED     DEFAULT NULL,
+    schema_name     VARCHAR(64)      NOT NULL,
+    table_name      VARCHAR(64)      NOT NULL,
+    event_type      TINYINT UNSIGNED NOT NULL,
+    pk_values       VARCHAR(512)     NOT NULL,
+    pk_hash         VARCHAR(64)      AS (SHA2(pk_values, 256)) STORED,
+    changed_columns JSON             DEFAULT NULL,
+    row_before      JSON             DEFAULT NULL,
+    row_after       JSON             DEFAULT NULL,
+    schema_version  INT UNSIGNED     NOT NULL DEFAULT 0,
+    PRIMARY KEY (event_id, event_timestamp),
+    INDEX idx_row_lookup (schema_name, table_name, event_timestamp),
+    INDEX idx_pk_hash    (schema_name, table_name, pk_hash, event_timestamp),
+    INDEX idx_gtid       (gtid)
+) ENGINE=InnoDB
+  PARTITION BY RANGE (TO_SECONDS(event_timestamp)) (
+    PARTITION p_2026050409 VALUES LESS THAN (TO_SECONDS('2026-05-04 10:00:00')),
+    PARTITION p_2026050410 VALUES LESS THAN (TO_SECONDS('2026-05-04 11:00:00')),
+    PARTITION p_2026050411 VALUES LESS THAN (TO_SECONDS('2026-05-04 12:00:00')),
+    PARTITION p_2026050412 VALUES LESS THAN (TO_SECONDS('2026-05-04 13:00:00')),
+    PARTITION p_2026050413 VALUES LESS THAN (TO_SECONDS('2026-05-04 14:00:00')),
+    PARTITION p_2026050414 VALUES LESS THAN (TO_SECONDS('2026-05-04 15:00:00')),
+    PARTITION p_2026050415 VALUES LESS THAN (TO_SECONDS('2026-05-04 16:00:00')),
+    PARTITION p_future VALUES LESS THAN MAXVALUE
+);
+
+-- archive_state is read by query.Plan and query.ResolveArchiveSources.
+-- An empty table is fine — the shim runs with --allow-gaps so a
+-- planner-detected gap would only warn, but here the live partitions
+-- cover everything anyway.
+CREATE TABLE archive_state (
+    id              INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    partition_name  VARCHAR(20) NOT NULL,
+    bintrail_id     VARCHAR(36),
+    local_path      VARCHAR(1024),
+    file_size_bytes BIGINT UNSIGNED,
+    row_count       BIGINT UNSIGNED,
+    s3_bucket       VARCHAR(255),
+    s3_key          VARCHAR(1024),
+    s3_uploaded_at  DATETIME,
+    archived_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_partition (partition_name, bintrail_id)
+) ENGINE=InnoDB;
+
+-- Synthetic event sequence for appdb.orders id=42:
+--
+--   10:00 → INSERT  (sku=ABC-1, qty=1)
+--   12:00 → UPDATE  (qty 1 → 2)
+--   14:00 → DELETE
+--
+-- pk_hash is omitted (STORED generated column derives it from
+-- pk_values). row_before is empty for INSERT, row_after is empty
+-- for DELETE — matches the parser's output shape.
+INSERT INTO binlog_events
+    (binlog_file, start_pos, end_pos, event_timestamp, gtid, schema_name, table_name, event_type, pk_values, changed_columns, row_before, row_after)
+VALUES
+    ('mysql-bin.000001',  100,  200, '2026-05-04 10:00:00', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee:1', 'appdb', 'orders', 1, '42',
+        NULL,
+        NULL,
+        JSON_OBJECT('id', 42, 'sku', 'ABC-1', 'qty', 1, 'note', 'initial')),
+    ('mysql-bin.000001',  300,  400, '2026-05-04 12:00:00', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee:2', 'appdb', 'orders', 2, '42',
+        JSON_ARRAY('qty'),
+        JSON_OBJECT('id', 42, 'sku', 'ABC-1', 'qty', 1, 'note', 'initial'),
+        JSON_OBJECT('id', 42, 'sku', 'ABC-1', 'qty', 2, 'note', 'initial')),
+    ('mysql-bin.000001',  500,  600, '2026-05-04 14:00:00', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee:3', 'appdb', 'orders', 3, '42',
+        NULL,
+        JSON_OBJECT('id', 42, 'sku', 'ABC-1', 'qty', 2, 'note', 'initial'),
+        NULL);

--- a/e2e/shim/seed.sql
+++ b/e2e/shim/seed.sql
@@ -38,6 +38,15 @@ CREATE TABLE orders (
 INSERT INTO orders (id, sku, qty, note) VALUES
     (42, 'LIVE-SKU', 999, 'live-row-from-passthrough');
 
+-- testuser is the credential the wire-protocol client uses when it
+-- talks to ProxySQL. ProxySQL forwards the same username/password
+-- to backends — so for the passthrough hostgroup to actually reach
+-- appdb.orders, MySQL has to recognise testuser too.
+-- The shim's own backend connection uses root (--index-dsn), not
+-- testuser, so this grant is scoped to appdb only.
+CREATE USER 'testuser'@'%' IDENTIFIED WITH mysql_native_password BY 'testpw';
+GRANT SELECT ON appdb.* TO 'testuser'@'%';
+
 CREATE DATABASE IF NOT EXISTS bintrail_index CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 USE bintrail_index;
@@ -79,9 +88,10 @@ CREATE TABLE binlog_events (
 );
 
 -- archive_state is read by query.Plan and query.ResolveArchiveSources.
--- An empty table is fine — the shim runs with --allow-gaps so a
--- planner-detected gap would only warn, but here the live partitions
--- cover everything anyway.
+-- Empty: the live partitions above already cover every event hour,
+-- so the planner finds no gap. --allow-gaps on the shim command is
+-- defensive belt-and-braces in case a future seed change widens
+-- the time range without extending the partition list.
 CREATE TABLE archive_state (
     id              INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
     partition_name  VARCHAR(20) NOT NULL,

--- a/e2e/shim/shim.yaml
+++ b/e2e/shim/shim.yaml
@@ -1,0 +1,14 @@
+# Shim tenant config for the e2e test.
+#
+# The single tenant binds the wire-protocol login (testuser / testpw)
+# to the appdb schema — the shim derives the default schema from
+# source_dsn's /<db> path and seeds it into the connection at
+# handshake time, so `SELECT * FROM _flashback.orders` resolves
+# without an explicit `USE appdb`.
+listen: 0.0.0.0:3308
+
+tenants:
+  - server_id: "1"
+    source_dsn: "root:testroot@tcp(mysql:3306)/appdb"
+    mysql_user: "testuser"
+    mysql_password: "testpw"

--- a/e2e/shim/shim.yaml
+++ b/e2e/shim/shim.yaml
@@ -5,7 +5,7 @@
 # source_dsn's /<db> path and seeds it into the connection at
 # handshake time, so `SELECT * FROM _flashback.orders` resolves
 # without an explicit `USE appdb`.
-listen: 0.0.0.0:3308
+listen: 127.0.0.1:3308
 
 tenants:
   - server_id: "1"


### PR DESCRIPTION
closes #265

## Summary

- Adds `e2e/shim/` — a build-tagged (`shim_e2e`) Go test that brings up `mysql` + `bintrail-shim` + `proxysql` via docker-compose and exercises the full wire-protocol chain end-to-end.
- ProxySQL is configured at test runtime by piping the SQL emitted by `bintrail proxysql-config` into the admin port, so a regression in the routing rules surfaces as a no-route failure.
- Test cases mirror the four scenarios from the issue, adapted to the **integrated** v0.7+ architecture:
  - `_flashback` returns the right post-image at AS OF mid-stream.
  - `_flashback` before any event returns zero rows.
  - `_diff` returns the full event history in chronological order.
  - `_snapshot` mirrors `_flashback` (today they share an impl).
  - A non-virtual-schema query is routed to the passthrough hostgroup, not the shim — proven by marker values (`sku=LIVE-SKU`, `qty=999`) on the live row that no binlog event in the seed contains.

## Deviations from the issue body

Documented in `e2e/shim/README.md`. The issue was filed against the standalone `dbtrail-shim` PoC; the integrated `bintrail shim` (since v0.7.0) has a different shape:

- **No fake HTTP agent.** The integrated shim queries the MySQL index directly via `query.FetchMerged` — there is no `/api/v1/*` agent in the current architecture, so the test seeds `binlog_events` directly instead.
- **`DBTRAIL_AT` hint case skipped.** The hint is not implemented in the integrated shim parser. Adding it is a separate piece of work.
- **No CI workflow wired in.** The repo has only `release.yaml` today (no `ci.yml`). Adding the test-CI scaffolding is tracked as a follow-up so this PR stays focused on the test rig.

## Test plan

- [x] Unit tests pass (`go test ./... -count=1`)
- [ ] Reviewer runs `cd e2e/shim && ./run.sh` locally (requires Docker + the compose plugin) — expect ~3–5 min for the first build, faster on warm cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)