### PR TITLE
fix(shim): time-travel SELECT * returns columns in DDL order

### DIFF
--- a/e2e/shim/e2e_test.go
+++ b/e2e/shim/e2e_test.go
@@ -34,6 +34,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -110,11 +111,24 @@ func TestShimEndToEnd(t *testing.T) {
 	t.Run("flashback_returns_post_image_at_asof", func(t *testing.T) {
 		// AS OF 13:00 → after the 12:00 UPDATE (qty=2), before the
 		// 14:00 DELETE. Expect qty=2.
-		got := queryRowMap(t, clientDB,
+		gotCols, gotRow := queryRowMapWithCols(t, clientDB,
 			"SELECT * FROM _flashback.orders AS OF '2026-05-04 13:00:00' WHERE id = 42")
-		want := map[string]string{"id": "42", "sku": "ABC-1", "qty": "2", "note": "initial"}
-		if !maps.Equal(got, want) {
-			t.Errorf("flashback row mismatch:\n  got:  %+v\n  want: %+v", got, want)
+		wantRow := map[string]string{"id": "42", "sku": "ABC-1", "qty": "2", "note": "initial"}
+		if !maps.Equal(gotRow, wantRow) {
+			t.Errorf("flashback row mismatch:\n  got:  %+v\n  want: %+v", gotRow, wantRow)
+		}
+		// Column order must match the source table's DDL
+		// (id, sku, qty, note) so a side-by-side comparison
+		// with `SELECT * FROM appdb.orders` lines up — this
+		// is the schema_snapshots → handler.columnOrderFor
+		// path. A regression where the resolver stops being
+		// consulted would silently revert to alphabetical
+		// (id, note, qty, sku) and the row map check above
+		// would still pass.
+		wantCols := []string{"id", "sku", "qty", "note"}
+		if !slices.Equal(gotCols, wantCols) {
+			t.Errorf("flashback column order = %v, want %v\n"+
+				"if alphabetical, schema_snapshots lookup is broken", gotCols, wantCols)
 		}
 	})
 
@@ -255,18 +269,26 @@ type diffRow struct {
 	rowAfter  string
 }
 
-// queryRowMap runs a single-row SELECT and returns the result as a
-// {column → value} map. Both the shim and the passthrough backend
-// answer SELECT *, but they pick column orders that disagree:
-//   - real MySQL returns DDL order (id, sku, qty, note)
-//   - the shim's imageToResult sorts JSON keys alphabetically
-//     (id, note, qty, sku)
-//
-// Positional Scan would silently swap fields between the two paths
-// and pass with the wrong values. Map-based comparison is the only
-// safe option until imageToResult learns to honour the source DDL
-// column order.
+// queryRowMap runs a single-row SELECT and returns just the
+// {column → value} map. Use queryRowMapWithCols when the test
+// also needs to assert column ORDER (the shim now honours the
+// source DDL via schema_snapshots, so order differences across
+// shim vs passthrough are themselves a regression to catch).
 func queryRowMap(t *testing.T, db *sql.DB, q string) map[string]string {
+	t.Helper()
+	_, row := queryRowMapWithCols(t, db, q)
+	return row
+}
+
+// queryRowMapWithCols is the underlying single-row SELECT helper.
+// Returns (column-order, {column → value} map) so callers can
+// assert both shape and content. Map-based scan is mandatory:
+// positional Scan would silently swap fields between the shim
+// (DDL order via schema_snapshots) and the passthrough (DDL order
+// from MySQL itself) the moment those orders diverge — e.g. if a
+// future ALTER TABLE rebuilds the table in a different physical
+// order than the snapshot reflects.
+func queryRowMapWithCols(t *testing.T, db *sql.DB, q string) ([]string, map[string]string) {
 	t.Helper()
 	if err := db.PingContext(context.Background()); err != nil {
 		t.Fatalf("ping before query: %v", err)
@@ -313,7 +335,7 @@ func queryRowMap(t *testing.T, db *sql.DB, q string) map[string]string {
 	if rows.Next() {
 		t.Fatalf("expected exactly one row, got at least two")
 	}
-	return out
+	return cols, out
 }
 
 func assertDiff(t *testing.T, d diffRow, wantTS, wantType, wantBeforeContains, wantAfterContains string) {

--- a/e2e/shim/e2e_test.go
+++ b/e2e/shim/e2e_test.go
@@ -197,16 +197,16 @@ func TestShimEndToEnd(t *testing.T) {
 		assertDiff(t, got[1], "2026-05-04 12:00:00", "UPDATE", `"qty":1,`, `"qty":2,`)
 		assertDiff(t, got[2], "2026-05-04 14:00:00", "DELETE", `"qty":2,`, "")
 
-		// Pin the JSON key ordering. Without this, a regression
-		// where marshalImageOrdered reverts to json.Marshal(map)
-		// would alphabetise keys (id, note, qty, sku) and the
-		// substring asserts above would still pass — they only
-		// check that "qty":N appears, not where it sits.
-		const wantPrefix = `{"id":42,"sku":"ABC-1",`
-		if !strings.HasPrefix(got[1].rowAfter, wantPrefix) {
-			t.Errorf("_diff JSON key order regression: row_after=%q does not start with %q\n"+
-				"if alphabetical, the marshalImageOrdered path is broken",
-				got[1].rowAfter, wantPrefix)
+		// Pin the full JSON key ordering. A prefix-only check
+		// (e.g. `{"id":42,"sku":"ABC-1",`) would only prove
+		// id < sku, leaving "alphabetised the tail" regressions
+		// undetected. Full-string equality eliminates the entire
+		// reorder-class bug.
+		const wantRowAfter = `{"id":42,"sku":"ABC-1","qty":2,"note":"initial"}`
+		if got[1].rowAfter != wantRowAfter {
+			t.Errorf("_diff JSON key order regression:\n  got:  %s\n  want: %s\n"+
+				"if columns alphabetise, the marshalImageOrdered path is broken",
+				got[1].rowAfter, wantRowAfter)
 		}
 	})
 

--- a/e2e/shim/e2e_test.go
+++ b/e2e/shim/e2e_test.go
@@ -190,12 +190,24 @@ func TestShimEndToEnd(t *testing.T) {
 
 		// Substring match on JSON includes a delimiter (`,` or `}`)
 		// so `"qty":1` doesn't accidentally match `"qty":10` or
-		// `"qty":100`. json.Marshal of map[string]any sorts keys
-		// alphabetically, so id < note < qty < sku — qty is never
-		// the last key here, hence the `,` boundary.
+		// `"qty":100`. The shim emits keys in DDL order
+		// (id, sku, qty, note) so qty is never the last key — the
+		// trailing `,` is always a stable delimiter here.
 		assertDiff(t, got[0], "2026-05-04 10:00:00", "INSERT", "", `"qty":1,`)
 		assertDiff(t, got[1], "2026-05-04 12:00:00", "UPDATE", `"qty":1,`, `"qty":2,`)
 		assertDiff(t, got[2], "2026-05-04 14:00:00", "DELETE", `"qty":2,`, "")
+
+		// Pin the JSON key ordering. Without this, a regression
+		// where marshalImageOrdered reverts to json.Marshal(map)
+		// would alphabetise keys (id, note, qty, sku) and the
+		// substring asserts above would still pass — they only
+		// check that "qty":N appears, not where it sits.
+		const wantPrefix = `{"id":42,"sku":"ABC-1",`
+		if !strings.HasPrefix(got[1].rowAfter, wantPrefix) {
+			t.Errorf("_diff JSON key order regression: row_after=%q does not start with %q\n"+
+				"if alphabetical, the marshalImageOrdered path is broken",
+				got[1].rowAfter, wantPrefix)
+		}
 	})
 
 	t.Run("snapshot_matches_flashback", func(t *testing.T) {

--- a/e2e/shim/seed.sql
+++ b/e2e/shim/seed.sql
@@ -87,6 +87,40 @@ CREATE TABLE binlog_events (
     PARTITION p_future VALUES LESS THAN MAXVALUE
 );
 
+-- schema_snapshots tells the shim what the source table's column
+-- ordinal_position is, so SELECT * against _flashback / _snapshot
+-- returns columns in DDL order (id, sku, qty, note) instead of
+-- the alphabetical fallback (id, note, qty, sku).
+--
+-- Without a snapshot the shim degrades silently to alphabetical
+-- key order — wire output is still valid SQL, just doesn't match
+-- what `SELECT * FROM appdb.orders` directly would return.
+CREATE TABLE schema_snapshots (
+    id               INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    snapshot_id      INT UNSIGNED NOT NULL,
+    snapshot_time    DATETIME     NOT NULL,
+    schema_name      VARCHAR(64)  NOT NULL,
+    table_name       VARCHAR(64)  NOT NULL,
+    column_name      VARCHAR(64)  NOT NULL,
+    ordinal_position INT UNSIGNED NOT NULL,
+    column_key       VARCHAR(3)   NOT NULL,
+    data_type        VARCHAR(64)  NOT NULL,
+    column_type      VARCHAR(128) NOT NULL DEFAULT '',
+    is_nullable      VARCHAR(3)   NOT NULL,
+    column_default   TEXT         DEFAULT NULL,
+    is_generated     TINYINT(1)   NOT NULL DEFAULT 0,
+    INDEX idx_snapshot_id    (snapshot_id),
+    INDEX idx_snapshot_table (snapshot_id, schema_name, table_name)
+) ENGINE=InnoDB;
+
+INSERT INTO schema_snapshots
+    (snapshot_id, snapshot_time, schema_name, table_name, column_name, ordinal_position, column_key, data_type, column_type, is_nullable)
+VALUES
+    (1, '2026-05-04 09:00:00', 'appdb', 'orders', 'id',   1, 'PRI', 'int',     'int',         'NO'),
+    (1, '2026-05-04 09:00:00', 'appdb', 'orders', 'sku',  2, '',    'varchar', 'varchar(64)', 'NO'),
+    (1, '2026-05-04 09:00:00', 'appdb', 'orders', 'qty',  3, '',    'int',     'int',         'NO'),
+    (1, '2026-05-04 09:00:00', 'appdb', 'orders', 'note', 4, '',    'varchar', 'varchar(255)','YES');
+
 -- archive_state is read by query.Plan and query.ResolveArchiveSources.
 -- Empty: the live partitions above already cover every event hour,
 -- so the planner finds no gap. --allow-gaps on the shim command is

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -2,12 +2,23 @@ package metadata
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sort"
 	"strings"
 	"time"
 )
+
+// ErrNoSnapshots signals "schema_snapshots is queryable but empty"
+// — a benign first-install state, not a real failure. Callers that
+// degrade gracefully when no snapshot exists (e.g. the shim's
+// columnOrderFor falling back to alphabetical column ordering) can
+// errors.Is against this sentinel to distinguish "operator hasn't
+// run `bintrail snapshot` yet" from a genuine DB-side failure
+// (table dropped post-upgrade, permissions revoked, connection
+// lost) — which deserve a louder log channel.
+var ErrNoSnapshots = errors.New("no snapshots found; run `bintrail snapshot` first")
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -68,7 +79,7 @@ func NewResolver(db *sql.DB, snapshotID int) (*Resolver, error) {
 			return nil, fmt.Errorf("failed to query latest snapshot ID: %w", err)
 		}
 		if snapshotID == 0 {
-			return nil, fmt.Errorf("no snapshots found; run `bintrail snapshot` first")
+			return nil, ErrNoSnapshots
 		}
 	}
 

--- a/internal/shim/handler.go
+++ b/internal/shim/handler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/go-mysql-org/go-mysql/server"
 
+	"github.com/dbtrail/bintrail/internal/metadata"
 	"github.com/dbtrail/bintrail/internal/parquetquery"
 	"github.com/dbtrail/bintrail/internal/parser"
 	"github.com/dbtrail/bintrail/internal/query"
@@ -39,6 +40,14 @@ type Handler struct {
 	// `bintrail query` and `bintrail recover` use) — exposed as a field
 	// so tests can inject a fake without DuckDB or real S3.
 	archiveFetcher query.ArchiveFetcher
+	// resolverFn returns a metadata.Resolver loaded from the latest
+	// schema_snapshots row. Production wires this to
+	// metadata.NewResolver(indexDB, 0); tests inject a fake to exercise
+	// the column-ordering paths without an indexDB. Called per query
+	// (cheap — a single SELECT against schema_snapshots) so a fresh
+	// snapshot taken after the shim started is picked up automatically
+	// without explicit cache-invalidation logic.
+	resolverFn func() (*metadata.Resolver, error)
 
 	mu sync.Mutex
 	db string // currently selected database (per COM_INIT_DB)
@@ -88,6 +97,7 @@ func NewHandlerWithConfig(indexDB *sql.DB, cfg Config, logger *slog.Logger) *Han
 		cfg:            cfg,
 		logger:         logger,
 		archiveFetcher: parquetquery.Fetch,
+		resolverFn:     func() (*metadata.Resolver, error) { return metadata.NewResolver(indexDB, 0) },
 	}
 }
 
@@ -185,7 +195,42 @@ func (h *Handler) runPointInTime(q TimeTravelQuery) (*mysql.Result, error) {
 	if image == nil {
 		return emptyResult(), nil
 	}
-	return imageToResult(image)
+	return imageToResult(image, h.columnOrderFor(q.Schema, q.Table))
+}
+
+// columnOrderFor returns the column names of schema.table in DDL
+// (ordinal_position) order so the wire-protocol resultset matches
+// what a regular MySQL `SELECT *` would emit. Returns nil when the
+// latest schema_snapshots row is missing, fails to load, or doesn't
+// know about this table — the caller falls back to alphabetical
+// ordering of the JSON image keys.
+//
+// We swallow lookup errors at Debug level rather than failing the
+// query: missing-snapshot is a real possibility (operator hasn't
+// run `bintrail snapshot` yet, snapshot lags a brand-new ALTER
+// TABLE, etc.) and a janky-but-deterministic fallback is strictly
+// better than a hard failure on what is otherwise a working query.
+func (h *Handler) columnOrderFor(schema, table string) []string {
+	if h.resolverFn == nil {
+		return nil
+	}
+	r, err := h.resolverFn()
+	if err != nil {
+		h.logger.Debug("shim: schema_snapshots lookup failed; falling back to alphabetical column order",
+			"err", err, "schema", schema, "table", table)
+		return nil
+	}
+	tm, err := r.Resolve(schema, table)
+	if err != nil {
+		h.logger.Debug("shim: table not in latest snapshot; falling back to alphabetical column order",
+			"err", err, "schema", schema, "table", table)
+		return nil
+	}
+	cols := make([]string, 0, len(tm.Columns))
+	for _, c := range tm.Columns {
+		cols = append(cols, c.Name)
+	}
+	return cols
 }
 
 // selectImage picks the row image that represents the row's state at
@@ -316,21 +361,22 @@ func marshalImage(image map[string]any) string {
 }
 
 // imageToResult turns a single-row JSON object into a mysql.Result
-// shaped for the wire protocol. Column order is the JSON key order
-// after sorting alphabetically — deterministic, and good enough for
-// the MVP. A future revision can pick the order from the schema
-// snapshot to match the source table's DDL.
-func imageToResult(image map[string]any) (*mysql.Result, error) {
+// shaped for the wire protocol. Columns are emitted in ddlOrder
+// (the source table's column ordinal_position from the latest
+// schema_snapshots row) so a customer running
+// `SELECT * FROM _flashback.orders ...` gets the same column
+// ordering they'd get from a regular `SELECT * FROM orders` — no
+// surprising reshuffling between the two.
+//
+// ddlOrder=nil signals "no snapshot available"; in that case we
+// fall back to alphabetical key order, which is deterministic but
+// won't match the table's natural DDL order.
+func imageToResult(image map[string]any, ddlOrder []string) (*mysql.Result, error) {
 	if len(image) == 0 {
 		return emptyResult(), nil
 	}
 
-	cols := make([]string, 0, len(image))
-	for k := range image {
-		cols = append(cols, k)
-	}
-	sort.Strings(cols)
-
+	cols := orderColumns(image, ddlOrder)
 	row := make([]any, len(cols))
 	for i, c := range cols {
 		row[i] = image[c]
@@ -341,6 +387,47 @@ func imageToResult(image map[string]any) (*mysql.Result, error) {
 		return nil, fmt.Errorf("build resultset: %w", err)
 	}
 	return &mysql.Result{Resultset: rs}, nil
+}
+
+// orderColumns returns the column emission order for a row image:
+//
+//  1. Columns from ddlOrder that are present in image, in
+//     ddlOrder sequence — this is the canonical case.
+//  2. Then any columns present in image but not in ddlOrder, sorted
+//     alphabetically. Catches the edge case where the binlog event
+//     pre-dates a recent ALTER TABLE captured by the next snapshot,
+//     so the image carries a column the snapshot doesn't know about
+//     (or vice versa). Better to surface it at the end than to drop
+//     it silently.
+//
+// Pure function — extracted from imageToResult specifically so the
+// ordering rules can be unit-tested without spinning up MySQL.
+func orderColumns(image map[string]any, ddlOrder []string) []string {
+	if len(ddlOrder) == 0 {
+		cols := make([]string, 0, len(image))
+		for k := range image {
+			cols = append(cols, k)
+		}
+		sort.Strings(cols)
+		return cols
+	}
+
+	cols := make([]string, 0, len(image))
+	seen := make(map[string]bool, len(image))
+	for _, c := range ddlOrder {
+		if _, ok := image[c]; ok {
+			cols = append(cols, c)
+			seen[c] = true
+		}
+	}
+	var extras []string
+	for k := range image {
+		if !seen[k] {
+			extras = append(extras, k)
+		}
+	}
+	sort.Strings(extras)
+	return append(cols, extras...)
 }
 
 // emptyResult is the wire-protocol "zero rows" reply. We still need a

--- a/internal/shim/handler.go
+++ b/internal/shim/handler.go
@@ -74,47 +74,102 @@ type Handler struct {
 // resolverCache memoises the latest metadata.Resolver across shim
 // queries. The zero value is ready to use.
 //
-// Caching policy: on a hit-within-TTL we return the cached resolver
-// without invoking the loader. On a miss-or-expired we invoke the
-// loader; if it succeeds we replace the cache; if it fails AND we
-// still hold a valid prior resolver, we return the stale resolver
-// rather than the error — sticky fallback prevents transient
-// index-DB blips from oscillating wire-protocol column order
-// between DDL and alphabetical across consecutive customer queries.
+// Caching policy:
+//   - Hit-within-TTL → return cached resolver, no loader call.
+//   - Miss-or-expired → run loader OUTSIDE the mutex (so a slow
+//     index DB does not serialise concurrent shim queries),
+//     then re-acquire to publish.
+//   - Loader fails AND a prior resolver is cached → sticky
+//     fallback: return the stale resolver rather than the error
+//     so transient index-DB blips don't oscillate wire-protocol
+//     column order between DDL and alphabetical across consecutive
+//     customer queries. Logged at Warn (rate-limited to once per
+//     TTL window) so a *persistent* outage is still operator-
+//     visible — without rate limiting a hot shim would spam the
+//     log; without warning at all the outage is invisible
+//     because the wire response still looks healthy.
+//   - Loader fails AND no prior resolver → surface the error so
+//     columnOrderFor can apply its sentinel-vs-real-error split.
 //
-// We do NOT extend the timestamp on a sticky-fallback hit: the next
-// query still tries to refresh, so a recovered DB picks up the new
-// snapshot at the next attempt rather than waiting another full TTL.
+// We do NOT extend the timestamp on a sticky-fallback hit: the
+// next query still tries to refresh, so a recovered DB picks up
+// the new snapshot at the next attempt rather than waiting
+// another full TTL.
+//
+// Thundering-herd note: N concurrent cache misses do N redundant
+// loads (instead of singleflight collapsing to 1+N-1 waits). The
+// trade-off is intentional — TTL bounds miss frequency to once
+// per 30s and shim QPS is interactive (customer-driven), so the
+// extra load cost is bounded; in exchange we avoid serialising
+// every query behind one slow loader. Add singleflight if
+// profiling shows the redundant loads matter.
 type resolverCache struct {
-	mu       sync.Mutex
-	loaded   *metadata.Resolver
-	loadedAt time.Time
+	mu           sync.Mutex
+	loaded       *metadata.Resolver
+	loadedAt     time.Time
+	lastWarnedAt time.Time // sticky-fallback Warn rate-limiter
 }
 
-// get returns a Resolver from the cache when fresh, otherwise calls
-// load. On load error: returns the stale Resolver if we have one
-// (sticky fallback) plus a nil error so the caller treats it as a
-// successful refresh; or surfaces the error when no prior resolver
-// exists so the caller can decide between sentinel-vs-real-failure
-// handling.
+// get returns the cached Resolver when fresh, otherwise invokes
+// load (outside the mutex). On load error: returns the stale
+// Resolver if cached + emits a rate-limited Warn; or surfaces the
+// error when no prior resolver exists.
 //
 // `now` is injected for deterministic tests; production passes
-// time.Now.
-func (c *resolverCache) get(now func() time.Time, ttl time.Duration, load func() (*metadata.Resolver, error)) (*metadata.Resolver, error) {
+// time.Now. logger receives the sticky-fallback Warn — pass
+// slog.Default() if you don't have a per-handler logger.
+func (c *resolverCache) get(
+	now func() time.Time,
+	ttl time.Duration,
+	load func() (*metadata.Resolver, error),
+	logger *slog.Logger,
+) (*metadata.Resolver, error) {
+	// Snapshot under lock so the publish below races with us only
+	// to its own benefit (we'd see the fresher resolver on relock).
+	c.mu.Lock()
+	cached := c.loaded
+	cachedAt := c.loadedAt
+	c.mu.Unlock()
+
+	if cached != nil && now().Sub(cachedAt) < ttl {
+		return cached, nil
+	}
+
+	r, loadErr := load()
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if c.loaded != nil && now().Sub(c.loadedAt) < ttl {
-		return c.loaded, nil
-	}
-	r, err := load()
-	if err != nil {
+
+	if loadErr != nil {
+		// Distinguish three sub-cases on the relock:
+		//   (a) another goroutine refreshed during our load → use
+		//       the fresh resolver, no warn (it's not actually
+		//       stale).
+		//   (b) cache was empty when we started AND another
+		//       goroutine populated it → same as (a).
+		//   (c) nothing changed → genuine sticky fallback. Warn
+		//       rate-limited so the operator sees a persistent
+		//       outage but the log isn't spammed at shim QPS.
+		if c.loaded != nil && !c.loadedAt.Equal(cachedAt) {
+			return c.loaded, nil // (a) or (b)
+		}
 		if c.loaded != nil {
+			if now().Sub(c.lastWarnedAt) >= ttl {
+				logger.Warn(
+					"shim: resolver refresh failed; serving stale snapshot",
+					"err", loadErr,
+					"stale_age", now().Sub(c.loadedAt).Round(time.Second),
+				)
+				c.lastWarnedAt = now()
+			}
 			return c.loaded, nil
 		}
-		return nil, err
+		return nil, loadErr
 	}
+
 	c.loaded = r
 	c.loadedAt = now()
+	c.lastWarnedAt = time.Time{} // recovered — reset rate-limit so next outage warns immediately
 	return r, nil
 }
 
@@ -290,7 +345,7 @@ func (h *Handler) columnOrderFor(schema, table string) []string {
 	if h.resolverFn == nil {
 		return nil
 	}
-	r, err := h.resolverCache.get(time.Now, resolverCacheTTL, h.resolverFn)
+	r, err := h.resolverCache.get(time.Now, resolverCacheTTL, h.resolverFn, h.logger)
 	if err != nil {
 		if errors.Is(err, metadata.ErrNoSnapshots) {
 			h.logger.Debug("shim: no snapshots yet; falling back to alphabetical column order",
@@ -446,10 +501,21 @@ func eventTypeName(t parser.EventType) string {
 //
 // Built by hand rather than via json.Marshal(map) because the stdlib
 // encoder sorts map keys alphabetically with no override hook. The
-// per-key json.Marshal calls reuse the stdlib encoder for both the
-// quoted key and the value so escaping (quotes, control chars,
-// non-printable bytes inside strings) stays correct without a
-// custom escaper here.
+// per-key json.Marshal calls reuse the stdlib encoder for the
+// quoted key and the value, so string escaping (quotes, control
+// chars, non-printable bytes) stays correct without a custom
+// escaper here.
+//
+// Failure modes (all return ""):
+//   - nil image (the documented "no image" sentinel).
+//   - any inner json.Marshal error — e.g. a value of type chan,
+//     func, NaN/Inf float, or a custom type whose MarshalJSON
+//     returns an error. None of these can appear in a row image
+//     decoded from MySQL JSON columns (parser rejects them on
+//     INSERT, json.Unmarshal rejects them on read), so the failure
+//     path is theoretical for production data; if it ever fires
+//     the customer sees a missing row image rather than a partial
+//     one, matching the original marshalImage behaviour.
 func marshalImageOrdered(image map[string]any, ddlOrder []string) string {
 	if image == nil {
 		return ""

--- a/internal/shim/handler.go
+++ b/internal/shim/handler.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/go-mysql-org/go-mysql/server"
@@ -19,6 +20,16 @@ import (
 	"github.com/dbtrail/bintrail/internal/parser"
 	"github.com/dbtrail/bintrail/internal/query"
 )
+
+// resolverCacheTTL bounds how long a stale schema_snapshots view
+// can serve column-ordering lookups. 30s is short enough that a
+// fresh `bintrail snapshot` is visible within ops-monitoring time
+// (the typical "I just ran snapshot, why don't I see my new
+// column?" reaction window) and long enough to absorb any
+// reasonable shim QPS without re-loading the entire snapshot per
+// query — the previous per-query reload measurably loaded
+// information_schema-style data on every customer query.
+const resolverCacheTTL = 30 * time.Second
 
 // Handler implements server.Handler. It serves the small subset of
 // MySQL protocol the time-travel SQL story needs: USE <db>,
@@ -40,17 +51,71 @@ type Handler struct {
 	// `bintrail query` and `bintrail recover` use) — exposed as a field
 	// so tests can inject a fake without DuckDB or real S3.
 	archiveFetcher query.ArchiveFetcher
-	// resolverFn returns a metadata.Resolver loaded from the latest
+	// resolverFn loads a metadata.Resolver from the latest
 	// schema_snapshots row. Production wires this to
-	// metadata.NewResolver(indexDB, 0); tests inject a fake to exercise
-	// the column-ordering paths without an indexDB. Called per query
-	// (cheap — a single SELECT against schema_snapshots) so a fresh
-	// snapshot taken after the shim started is picked up automatically
-	// without explicit cache-invalidation logic.
-	resolverFn func() (*metadata.Resolver, error)
+	// metadata.NewResolver(indexDB, 0), which issues a MAX(snapshot_id)
+	// lookup plus a full per-snapshot row scan that materialises every
+	// table's column metadata into memory — non-trivial under load.
+	// Tests inject a fake to exercise the column-ordering paths without
+	// an indexDB.
+	//
+	// Wrapped by resolverCache below so successive queries share one
+	// load for up to resolverCacheTTL; a fresh `bintrail snapshot`
+	// becomes visible at the next cache miss without explicit
+	// invalidation. Use resolver() (not resolverFn directly) from
+	// production code so the cache + sticky-fallback policy applies.
+	resolverFn    func() (*metadata.Resolver, error)
+	resolverCache resolverCache
 
 	mu sync.Mutex
 	db string // currently selected database (per COM_INIT_DB)
+}
+
+// resolverCache memoises the latest metadata.Resolver across shim
+// queries. The zero value is ready to use.
+//
+// Caching policy: on a hit-within-TTL we return the cached resolver
+// without invoking the loader. On a miss-or-expired we invoke the
+// loader; if it succeeds we replace the cache; if it fails AND we
+// still hold a valid prior resolver, we return the stale resolver
+// rather than the error — sticky fallback prevents transient
+// index-DB blips from oscillating wire-protocol column order
+// between DDL and alphabetical across consecutive customer queries.
+//
+// We do NOT extend the timestamp on a sticky-fallback hit: the next
+// query still tries to refresh, so a recovered DB picks up the new
+// snapshot at the next attempt rather than waiting another full TTL.
+type resolverCache struct {
+	mu       sync.Mutex
+	loaded   *metadata.Resolver
+	loadedAt time.Time
+}
+
+// get returns a Resolver from the cache when fresh, otherwise calls
+// load. On load error: returns the stale Resolver if we have one
+// (sticky fallback) plus a nil error so the caller treats it as a
+// successful refresh; or surfaces the error when no prior resolver
+// exists so the caller can decide between sentinel-vs-real-failure
+// handling.
+//
+// `now` is injected for deterministic tests; production passes
+// time.Now.
+func (c *resolverCache) get(now func() time.Time, ttl time.Duration, load func() (*metadata.Resolver, error)) (*metadata.Resolver, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.loaded != nil && now().Sub(c.loadedAt) < ttl {
+		return c.loaded, nil
+	}
+	r, err := load()
+	if err != nil {
+		if c.loaded != nil {
+			return c.loaded, nil
+		}
+		return nil, err
+	}
+	c.loaded = r
+	c.loadedAt = now()
+	return r, nil
 }
 
 // Config tunes the shim's data-fetch behaviour.
@@ -200,24 +265,40 @@ func (h *Handler) runPointInTime(q TimeTravelQuery) (*mysql.Result, error) {
 
 // columnOrderFor returns the column names of schema.table in DDL
 // (ordinal_position) order so the wire-protocol resultset matches
-// what a regular MySQL `SELECT *` would emit. Returns nil when the
-// latest schema_snapshots row is missing, fails to load, or doesn't
-// know about this table — the caller falls back to alphabetical
-// ordering of the JSON image keys.
+// what a regular MySQL `SELECT *` would emit. Returns nil when no
+// snapshot is available or the table is missing from the latest
+// snapshot — the caller falls back to alphabetical ordering of the
+// JSON image keys.
 //
-// We swallow lookup errors at Debug level rather than failing the
-// query: missing-snapshot is a real possibility (operator hasn't
-// run `bintrail snapshot` yet, snapshot lags a brand-new ALTER
-// TABLE, etc.) and a janky-but-deterministic fallback is strictly
-// better than a hard failure on what is otherwise a working query.
+// Logging policy is split deliberately so operators can tell
+// "first-install with no snapshot yet" apart from real DB-side
+// failure:
+//
+//   - metadata.ErrNoSnapshots → Debug. Benign first-install state;
+//     the operator just hasn't run `bintrail snapshot` yet.
+//   - any other resolver-load error → Warn. Index DB is unreachable
+//     or schema_snapshots is unreadable — a real config/infra
+//     problem the operator should see at default --log-level info.
+//   - table not in snapshot → Debug. Common for tables created
+//     after the latest snapshot was taken; benign and self-fixing
+//     once a fresh snapshot runs.
+//
+// A janky-but-deterministic fallback is strictly better than a
+// hard failure on what is otherwise a working query — but the
+// fallback should be loud when it's hiding a real outage.
 func (h *Handler) columnOrderFor(schema, table string) []string {
 	if h.resolverFn == nil {
 		return nil
 	}
-	r, err := h.resolverFn()
+	r, err := h.resolverCache.get(time.Now, resolverCacheTTL, h.resolverFn)
 	if err != nil {
-		h.logger.Debug("shim: schema_snapshots lookup failed; falling back to alphabetical column order",
-			"err", err, "schema", schema, "table", table)
+		if errors.Is(err, metadata.ErrNoSnapshots) {
+			h.logger.Debug("shim: no snapshots yet; falling back to alphabetical column order",
+				"schema", schema, "table", table)
+		} else {
+			h.logger.Warn("shim: schema_snapshots lookup failed; falling back to alphabetical column order",
+				"err", err, "schema", schema, "table", table)
+		}
 		return nil
 	}
 	tm, err := r.Resolve(schema, table)
@@ -307,6 +388,13 @@ func (h *Handler) runDiff(q TimeTravelQuery) (*mysql.Result, error) {
 		return nil, fmt.Errorf("resolve %s: %w", q.Type, err)
 	}
 
+	// Compute the source-table column order once per query so the
+	// per-row JSON images encode keys in DDL order (matching what
+	// _flashback / _snapshot return for SELECT *). Without this the
+	// row_before / row_after JSON keys would alphabetise — surprising
+	// when a customer compares _diff output side by side with the
+	// reconstructed flashback row.
+	ddlOrder := h.columnOrderFor(q.Schema, q.Table)
 	cols := []string{"event_id", "event_timestamp", "event_type", "gtid", "row_before", "row_after"}
 	values := make([][]any, 0, len(rows))
 	for _, r := range rows {
@@ -319,8 +407,8 @@ func (h *Handler) runDiff(q TimeTravelQuery) (*mysql.Result, error) {
 			r.EventTimestamp.UTC().Format("2006-01-02 15:04:05"),
 			eventTypeName(r.EventType),
 			gtid,
-			marshalImage(r.RowBefore),
-			marshalImage(r.RowAfter),
+			marshalImageOrdered(r.RowBefore, ddlOrder),
+			marshalImageOrdered(r.RowAfter, ddlOrder),
 		})
 	}
 	rs, err := mysql.BuildSimpleTextResultset(cols, values)
@@ -345,19 +433,55 @@ func eventTypeName(t parser.EventType) string {
 	return fmt.Sprintf("type_%d", t)
 }
 
-// marshalImage renders a row image as a JSON string for the _diff
-// resultset. nil maps render as the empty string so customers can
-// distinguish "no image" (INSERT lacks row_before, DELETE lacks
-// row_after) from "empty image".
-func marshalImage(image map[string]any) string {
+// marshalImageOrdered renders a row image as a JSON string for the
+// _diff resultset, emitting keys in ddlOrder so the JSON column
+// order matches what _flashback / _snapshot return. nil maps render
+// as the empty string so customers can distinguish "no image"
+// (INSERT lacks row_before, DELETE lacks row_after) from "empty
+// image".
+//
+// ddlOrder=nil falls back to encoding/json's default
+// alphabetical-key marshalling — same degraded path as
+// imageToResult when no snapshot is available.
+//
+// Built by hand rather than via json.Marshal(map) because the stdlib
+// encoder sorts map keys alphabetically with no override hook. The
+// per-key json.Marshal calls reuse the stdlib encoder for both the
+// quoted key and the value so escaping (quotes, control chars,
+// non-printable bytes inside strings) stays correct without a
+// custom escaper here.
+func marshalImageOrdered(image map[string]any, ddlOrder []string) string {
 	if image == nil {
 		return ""
 	}
-	b, err := json.Marshal(image)
-	if err != nil {
-		return ""
+	if len(ddlOrder) == 0 {
+		b, err := json.Marshal(image)
+		if err != nil {
+			return ""
+		}
+		return string(b)
 	}
-	return string(b)
+	cols := orderColumns(image, ddlOrder)
+	var sb strings.Builder
+	sb.WriteByte('{')
+	for i, c := range cols {
+		if i > 0 {
+			sb.WriteByte(',')
+		}
+		keyJSON, err := json.Marshal(c)
+		if err != nil {
+			return ""
+		}
+		sb.Write(keyJSON)
+		sb.WriteByte(':')
+		valJSON, err := json.Marshal(image[c])
+		if err != nil {
+			return ""
+		}
+		sb.Write(valJSON)
+	}
+	sb.WriteByte('}')
+	return sb.String()
 }
 
 // imageToResult turns a single-row JSON object into a mysql.Result

--- a/internal/shim/handler_test.go
+++ b/internal/shim/handler_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -417,7 +418,7 @@ func TestColumnOrderForFallsBackOnResolverError(t *testing.T) {
 	}
 }
 
-// TestResolverCacheBehaviour pins three properties of the resolver
+// TestResolverCacheBehaviour pins five properties of the resolver
 // cache that columnOrderFor relies on. Each is documented in
 // handler.go's resolverCache type comment; this test enforces them.
 //
@@ -432,6 +433,12 @@ func TestColumnOrderForFallsBackOnResolverError(t *testing.T) {
 //     prevents transient index-DB blips from oscillating wire-
 //     protocol column order between DDL and alphabetical for the
 //     same customer connection.
+//  4. Sticky-fallback emits a Warn the first time it fires, so a
+//     persistent index-DB outage is operator-visible. Without this,
+//     a 2-hour outage is invisible because the wire response still
+//     looks healthy.
+//  5. Sticky-fallback Warns are rate-limited to one per TTL window
+//     so a hot shim doesn't spam the log under sustained outage.
 func TestResolverCacheBehaviour(t *testing.T) {
 	tableMeta := metadata.NewResolverFromTables(1, map[string]*metadata.TableMeta{
 		"appdb.orders": {
@@ -442,6 +449,7 @@ func TestResolverCacheBehaviour(t *testing.T) {
 			},
 		},
 	})
+	silentLogger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
 	t.Run("hit_within_ttl_skips_loader", func(t *testing.T) {
 		now := time.Unix(1_700_000_000, 0)
@@ -449,10 +457,10 @@ func TestResolverCacheBehaviour(t *testing.T) {
 		c := resolverCache{}
 		load := func() (*metadata.Resolver, error) { calls++; return tableMeta, nil }
 
-		if _, err := c.get(func() time.Time { return now }, time.Minute, load); err != nil {
+		if _, err := c.get(func() time.Time { return now }, time.Minute, load, silentLogger); err != nil {
 			t.Fatalf("first get: %v", err)
 		}
-		if _, err := c.get(func() time.Time { return now.Add(30 * time.Second) }, time.Minute, load); err != nil {
+		if _, err := c.get(func() time.Time { return now.Add(30 * time.Second) }, time.Minute, load, silentLogger); err != nil {
 			t.Fatalf("second get: %v", err)
 		}
 		if calls != 1 {
@@ -466,10 +474,10 @@ func TestResolverCacheBehaviour(t *testing.T) {
 		c := resolverCache{}
 		load := func() (*metadata.Resolver, error) { calls++; return tableMeta, nil }
 
-		if _, err := c.get(func() time.Time { return now }, time.Minute, load); err != nil {
+		if _, err := c.get(func() time.Time { return now }, time.Minute, load, silentLogger); err != nil {
 			t.Fatalf("first get: %v", err)
 		}
-		if _, err := c.get(func() time.Time { return now.Add(2 * time.Minute) }, time.Minute, load); err != nil {
+		if _, err := c.get(func() time.Time { return now.Add(2 * time.Minute) }, time.Minute, load, silentLogger); err != nil {
 			t.Fatalf("second get: %v", err)
 		}
 		if calls != 2 {
@@ -483,10 +491,10 @@ func TestResolverCacheBehaviour(t *testing.T) {
 		ok := func() (*metadata.Resolver, error) { return tableMeta, nil }
 		fail := func() (*metadata.Resolver, error) { return nil, errors.New("transient db blip") }
 
-		if _, err := c.get(func() time.Time { return now }, time.Minute, ok); err != nil {
+		if _, err := c.get(func() time.Time { return now }, time.Minute, ok, silentLogger); err != nil {
 			t.Fatalf("warm-up: %v", err)
 		}
-		got, err := c.get(func() time.Time { return now.Add(2 * time.Minute) }, time.Minute, fail)
+		got, err := c.get(func() time.Time { return now.Add(2 * time.Minute) }, time.Minute, fail, silentLogger)
 		if err != nil {
 			t.Fatalf("expected sticky fallback to mask error, got: %v", err)
 		}
@@ -498,9 +506,67 @@ func TestResolverCacheBehaviour(t *testing.T) {
 	t.Run("error_with_no_prior_cache_surfaces", func(t *testing.T) {
 		c := resolverCache{}
 		want := errors.New("first-time db unreachable")
-		_, err := c.get(time.Now, time.Minute, func() (*metadata.Resolver, error) { return nil, want })
+		_, err := c.get(time.Now, time.Minute, func() (*metadata.Resolver, error) { return nil, want }, silentLogger)
 		if !errors.Is(err, want) {
 			t.Errorf("expected first-time error to surface, got: %v", err)
+		}
+	})
+
+	t.Run("sticky_fallback_warns_first_time", func(t *testing.T) {
+		now := time.Unix(1_700_000_000, 0)
+		c := resolverCache{}
+		ok := func() (*metadata.Resolver, error) { return tableMeta, nil }
+		fail := func() (*metadata.Resolver, error) { return nil, errors.New("db gone") }
+		rec := newRecordingHandler()
+		logger := slog.New(rec)
+
+		// Warm the cache so the next failure triggers sticky fallback.
+		if _, err := c.get(func() time.Time { return now }, time.Minute, ok, logger); err != nil {
+			t.Fatalf("warm-up: %v", err)
+		}
+		// Push past TTL with a failing load. Expect Warn.
+		if _, err := c.get(func() time.Time { return now.Add(2 * time.Minute) }, time.Minute, fail, logger); err != nil {
+			t.Fatalf("get during outage: %v", err)
+		}
+
+		warns := rec.atLevel(slog.LevelWarn)
+		if len(warns) != 1 {
+			t.Fatalf("expected 1 Warn record on first sticky-fallback, got %d: %v", len(warns), rec.records)
+		}
+		if !strings.Contains(warns[0].Message, "stale snapshot") {
+			t.Errorf("expected Warn about stale snapshot, got %q", warns[0].Message)
+		}
+	})
+
+	t.Run("sticky_fallback_warn_is_rate_limited_to_one_per_ttl", func(t *testing.T) {
+		now := time.Unix(1_700_000_000, 0)
+		c := resolverCache{}
+		ok := func() (*metadata.Resolver, error) { return tableMeta, nil }
+		fail := func() (*metadata.Resolver, error) { return nil, errors.New("db gone") }
+		rec := newRecordingHandler()
+		logger := slog.New(rec)
+		ttl := time.Minute
+
+		if _, err := c.get(func() time.Time { return now }, ttl, ok, logger); err != nil {
+			t.Fatalf("warm-up: %v", err)
+		}
+		// Three failing gets close together — only the first should Warn.
+		for i, dt := range []time.Duration{2 * time.Minute, 2*time.Minute + 5*time.Second, 2*time.Minute + 30*time.Second} {
+			if _, err := c.get(func() time.Time { return now.Add(dt) }, ttl, fail, logger); err != nil {
+				t.Fatalf("get #%d during outage: %v", i, err)
+			}
+		}
+
+		if got := len(rec.atLevel(slog.LevelWarn)); got != 1 {
+			t.Errorf("expected 1 Warn within TTL window, got %d", got)
+		}
+
+		// Push past the rate-limit window — expect a second Warn.
+		if _, err := c.get(func() time.Time { return now.Add(2*time.Minute + 70*time.Second) }, ttl, fail, logger); err != nil {
+			t.Fatalf("get past rate-limit: %v", err)
+		}
+		if got := len(rec.atLevel(slog.LevelWarn)); got != 2 {
+			t.Errorf("expected 2 Warns after TTL window expires, got %d", got)
 		}
 	})
 }
@@ -513,35 +579,88 @@ func TestResolverCacheBehaviour(t *testing.T) {
 //
 // Without this test a future refactor that collapsed both error
 // paths back into the same Debug log would silently un-fix the
-// observability gap that motivated the sentinel.
+// observability gap that motivated the sentinel — the recording
+// handler asserts on the actual emitted level rather than reading
+// the source.
 func TestColumnOrderForDistinguishesNoSnapshotFromRealError(t *testing.T) {
 	cases := []struct {
 		name      string
 		err       error
 		wantLevel slog.Level
+		wantMsg   string
 	}{
-		{"no_snapshots_logs_debug", metadata.ErrNoSnapshots, slog.LevelDebug},
-		{"real_error_logs_warn", errors.New("connection refused"), slog.LevelWarn},
+		{
+			name:      "no_snapshots_logs_debug",
+			err:       metadata.ErrNoSnapshots,
+			wantLevel: slog.LevelDebug,
+			wantMsg:   "no snapshots",
+		},
+		{
+			name:      "real_error_logs_warn",
+			err:       errors.New("connection refused"),
+			wantLevel: slog.LevelWarn,
+			wantMsg:   "schema_snapshots lookup failed",
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			rec := newRecordingHandler()
 			h := &Handler{
-				logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+				logger:     slog.New(rec),
 				resolverFn: func() (*metadata.Resolver, error) { return nil, tc.err },
 			}
 			if got := h.columnOrderFor("appdb", "orders"); got != nil {
 				t.Errorf("expected nil fallback, got %v", got)
 			}
-			// Behavioural correctness covered by the above assertion;
-			// the log-level claim is verified by reading the
-			// columnOrderFor source. We can't easily intercept slog
-			// records without rebuilding the logger machinery, and
-			// the level-split is so small (one if/else branch) that
-			// a code review catches a regression as easily as a test
-			// would. This test exists to assert the *fallback* still
-			// happens regardless of which error class fires.
+			records := rec.atLevel(tc.wantLevel)
+			if len(records) != 1 {
+				t.Fatalf("expected exactly 1 record at level %s, got %d (all records: %v)",
+					tc.wantLevel, len(records), rec.records)
+			}
+			if !strings.Contains(records[0].Message, tc.wantMsg) {
+				t.Errorf("expected message containing %q, got %q", tc.wantMsg, records[0].Message)
+			}
 		})
+	}
+}
+
+// TestColumnOrderForUsesCache pins the wiring between columnOrderFor
+// and resolverCache. Without this test, a refactor that bypassed the
+// cache (e.g. called h.resolverFn() directly) would invalidate every
+// property TestResolverCacheBehaviour pins — the cache subtests would
+// still pass because they exercise the cache type directly, not the
+// integration. The test counts loader invocations across two
+// columnOrderFor calls within the TTL window and asserts the count
+// is exactly 1.
+func TestColumnOrderForUsesCache(t *testing.T) {
+	calls := 0
+	tableMeta := metadata.NewResolverFromTables(1, map[string]*metadata.TableMeta{
+		"appdb.orders": {
+			Schema: "appdb", Table: "orders",
+			Columns: []metadata.ColumnMeta{
+				{Name: "id", OrdinalPosition: 1},
+				{Name: "sku", OrdinalPosition: 2},
+			},
+		},
+	})
+	h := &Handler{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		resolverFn: func() (*metadata.Resolver, error) {
+			calls++
+			return tableMeta, nil
+		},
+	}
+
+	if got := h.columnOrderFor("appdb", "orders"); !slices.Equal(got, []string{"id", "sku"}) {
+		t.Fatalf("first call: %v", got)
+	}
+	if got := h.columnOrderFor("appdb", "orders"); !slices.Equal(got, []string{"id", "sku"}) {
+		t.Fatalf("second call: %v", got)
+	}
+	if calls != 1 {
+		t.Errorf("expected resolverFn to be invoked exactly once across two columnOrderFor calls "+
+			"within the TTL window (cache wiring regression?), got %d calls", calls)
 	}
 }
 
@@ -960,6 +1079,45 @@ func equalMaps(a, b map[string]any) bool {
 		}
 	}
 	return true
+}
+
+// recordingHandler is a minimal slog.Handler that captures every
+// emitted record into an in-memory slice. Used by tests that need
+// to assert log levels and messages — without it we'd have to
+// either parse a TextHandler's stringly output or skip log-level
+// verification entirely (which is what the prior weakened test
+// resorted to). Concurrent-safe so it can sit behind a logger
+// shared across goroutines if a future test exercises that path.
+type recordingHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func newRecordingHandler() *recordingHandler { return &recordingHandler{} }
+
+func (h *recordingHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+
+func (h *recordingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r.Clone())
+	return nil
+}
+
+func (h *recordingHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+func (h *recordingHandler) WithGroup(_ string) slog.Handler      { return h }
+
+// atLevel returns all captured records at exactly the given level.
+func (h *recordingHandler) atLevel(level slog.Level) []slog.Record {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	var out []slog.Record
+	for _, r := range h.records {
+		if r.Level == level {
+			out = append(out, r)
+		}
+	}
+	return out
 }
 
 // Compile-time check: TenantAuth implements the credential provider

--- a/internal/shim/handler_test.go
+++ b/internal/shim/handler_test.go
@@ -15,6 +15,7 @@ import (
 	gomysql "github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/go-mysql-org/go-mysql/server"
 
+	"github.com/dbtrail/bintrail/internal/metadata"
 	"github.com/dbtrail/bintrail/internal/parser"
 	"github.com/dbtrail/bintrail/internal/query"
 )
@@ -107,15 +108,15 @@ func TestHandlerUseDBStoresSchema(t *testing.T) {
 	}
 }
 
-// TestImageToResultColumnOrder — column order in the resultset must
-// be deterministic (alphabetical) so customers comparing two rows
-// across runs see consistent column positions.
+// TestImageToResultColumnOrder — when no DDL order is supplied
+// (snapshot missing or table unknown), columns fall back to
+// alphabetical order so the wire output stays deterministic.
 func TestImageToResultColumnOrder(t *testing.T) {
 	res, err := imageToResult(map[string]any{
 		"name":  "alice",
 		"id":    int64(42),
 		"email": "a@b.com",
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -129,6 +130,91 @@ func TestImageToResultColumnOrder(t *testing.T) {
 	}
 	if !equalStrings(got, want) {
 		t.Errorf("column order = %v, want %v", got, want)
+	}
+}
+
+// TestImageToResultRespectsDDLOrder — when ddlOrder is supplied,
+// the wire output emits columns in DDL position so customers see
+// the same column ordering they'd get from a regular `SELECT *`.
+// Without this the time-travel queries return alphabetised columns
+// which mismatches the source table's natural order, surprising
+// any side-by-side comparison the user might run.
+func TestImageToResultRespectsDDLOrder(t *testing.T) {
+	res, err := imageToResult(
+		map[string]any{
+			"id":   int64(42),
+			"sku":  "ABC-1",
+			"qty":  int64(2),
+			"note": "initial",
+		},
+		[]string{"id", "sku", "qty", "note"},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"id", "sku", "qty", "note"}
+	got := make([]string, len(res.Resultset.Fields))
+	for i, f := range res.Resultset.Fields {
+		got[i] = string(f.Name)
+	}
+	if !equalStrings(got, want) {
+		t.Errorf("column order = %v, want %v", got, want)
+	}
+}
+
+// TestOrderColumnsEdgeCases pins the merge behaviour for the
+// "image and snapshot disagree" cases. Each branch is a real
+// path the production code can hit when an ALTER TABLE happens
+// between the binlog event being indexed and the snapshot being
+// taken (or vice versa).
+func TestOrderColumnsEdgeCases(t *testing.T) {
+	cases := []struct {
+		name     string
+		image    map[string]any
+		ddlOrder []string
+		want     []string
+	}{
+		{
+			name:     "nil_ddl_order_falls_back_to_alphabetical",
+			image:    map[string]any{"sku": 1, "id": 2, "qty": 3},
+			ddlOrder: nil,
+			want:     []string{"id", "qty", "sku"},
+		},
+		{
+			name:     "empty_ddl_order_falls_back_to_alphabetical",
+			image:    map[string]any{"b": 1, "a": 2},
+			ddlOrder: []string{},
+			want:     []string{"a", "b"},
+		},
+		{
+			name:     "ddl_columns_missing_from_image_are_skipped",
+			image:    map[string]any{"id": 1, "qty": 3},
+			ddlOrder: []string{"id", "sku", "qty", "note"},
+			want:     []string{"id", "qty"},
+		},
+		{
+			name: "image_columns_missing_from_ddl_are_appended_alphabetically",
+			image: map[string]any{
+				"id": 1, "sku": 2, "qty": 3, "added_after": 4, "another_new": 5,
+			},
+			ddlOrder: []string{"id", "sku", "qty"},
+			want:     []string{"id", "sku", "qty", "added_after", "another_new"},
+		},
+		{
+			name:     "exact_match_preserves_ddl_order",
+			image:    map[string]any{"note": 4, "id": 1, "qty": 3, "sku": 2},
+			ddlOrder: []string{"id", "sku", "qty", "note"},
+			want:     []string{"id", "sku", "qty", "note"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := orderColumns(tc.image, tc.ddlOrder)
+			if !equalStrings(got, tc.want) {
+				t.Errorf("orderColumns = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }
 
@@ -222,7 +308,7 @@ func TestSelectImage(t *testing.T) {
 // TestImageToResultEmpty — an empty image (zero-key map) should
 // produce a resultset with no rows.
 func TestImageToResultEmpty(t *testing.T) {
-	res, err := imageToResult(map[string]any{})
+	res, err := imageToResult(map[string]any{}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -252,6 +338,80 @@ func TestNewHandlerWiresArchiveFetcher(t *testing.T) {
 	h2 := NewHandlerWithConfig(nil, Config{}, nil)
 	if h2.archiveFetcher == nil {
 		t.Error("NewHandlerWithConfig must wire a non-nil archiveFetcher; got nil")
+	}
+}
+
+// TestNewHandlerWiresResolverFn — same boundary check as for the
+// archive fetcher: both constructors must install a non-nil
+// resolverFn or every time-travel query falls back to alphabetical
+// column order silently. A failure here means a refactor dropped
+// the schema_snapshots wiring; the e2e/shim test would catch it
+// end-to-end but at much higher cost.
+func TestNewHandlerWiresResolverFn(t *testing.T) {
+	if h := NewHandler(nil, nil); h.resolverFn == nil {
+		t.Error("NewHandler must wire a non-nil resolverFn; got nil")
+	}
+	if h := NewHandlerWithConfig(nil, Config{}, nil); h.resolverFn == nil {
+		t.Error("NewHandlerWithConfig must wire a non-nil resolverFn; got nil")
+	}
+}
+
+// TestColumnOrderForFallsBackOnResolverError pins the resilience
+// contract: when the resolver fails to load (no snapshot yet, DB
+// blip, ALTER TABLE the snapshot doesn't know about), columnOrderFor
+// returns nil so imageToResult silently degrades to alphabetical
+// order rather than failing the customer's query. The opposite
+// behaviour (hard-failing on resolver error) would make brand-new
+// installs that haven't run `bintrail snapshot` yet unable to
+// answer any time-travel query.
+func TestColumnOrderForFallsBackOnResolverError(t *testing.T) {
+	cases := []struct {
+		name       string
+		resolverFn func() (*metadata.Resolver, error)
+		want       []string
+	}{
+		{
+			name:       "resolver_load_fails",
+			resolverFn: func() (*metadata.Resolver, error) { return nil, errors.New("snapshot table missing") },
+			want:       nil,
+		},
+		{
+			name: "resolver_loads_but_table_unknown",
+			resolverFn: func() (*metadata.Resolver, error) {
+				return metadata.NewResolverFromTables(1, map[string]*metadata.TableMeta{}), nil
+			},
+			want: nil,
+		},
+		{
+			name: "resolver_returns_table_in_ddl_order",
+			resolverFn: func() (*metadata.Resolver, error) {
+				return metadata.NewResolverFromTables(1, map[string]*metadata.TableMeta{
+					"appdb.orders": {
+						Schema: "appdb", Table: "orders",
+						Columns: []metadata.ColumnMeta{
+							{Name: "id", OrdinalPosition: 1},
+							{Name: "sku", OrdinalPosition: 2},
+							{Name: "qty", OrdinalPosition: 3},
+							{Name: "note", OrdinalPosition: 4},
+						},
+					},
+				}), nil
+			},
+			want: []string{"id", "sku", "qty", "note"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := &Handler{
+				logger:     slog.Default(),
+				resolverFn: tc.resolverFn,
+			}
+			got := h.columnOrderFor("appdb", "orders")
+			if !equalStrings(got, tc.want) {
+				t.Errorf("columnOrderFor = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/shim/handler_test.go
+++ b/internal/shim/handler_test.go
@@ -4,16 +4,18 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"io"
 	"log/slog"
 	"net"
+	"slices"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	_ "github.com/go-sql-driver/mysql" // database/sql driver registration
 	gomysql "github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/go-mysql-org/go-mysql/server"
+	_ "github.com/go-sql-driver/mysql" // database/sql driver registration
 
 	"github.com/dbtrail/bintrail/internal/metadata"
 	"github.com/dbtrail/bintrail/internal/parser"
@@ -128,7 +130,7 @@ func TestImageToResultColumnOrder(t *testing.T) {
 	for i, f := range res.Resultset.Fields {
 		got[i] = string(f.Name)
 	}
-	if !equalStrings(got, want) {
+	if !slices.Equal(got, want) {
 		t.Errorf("column order = %v, want %v", got, want)
 	}
 }
@@ -157,7 +159,7 @@ func TestImageToResultRespectsDDLOrder(t *testing.T) {
 	for i, f := range res.Resultset.Fields {
 		got[i] = string(f.Name)
 	}
-	if !equalStrings(got, want) {
+	if !slices.Equal(got, want) {
 		t.Errorf("column order = %v, want %v", got, want)
 	}
 }
@@ -211,7 +213,7 @@ func TestOrderColumnsEdgeCases(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := orderColumns(tc.image, tc.ddlOrder)
-			if !equalStrings(got, tc.want) {
+			if !slices.Equal(got, tc.want) {
 				t.Errorf("orderColumns = %v, want %v", got, tc.want)
 			}
 		})
@@ -408,8 +410,184 @@ func TestColumnOrderForFallsBackOnResolverError(t *testing.T) {
 				resolverFn: tc.resolverFn,
 			}
 			got := h.columnOrderFor("appdb", "orders")
-			if !equalStrings(got, tc.want) {
+			if !slices.Equal(got, tc.want) {
 				t.Errorf("columnOrderFor = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResolverCacheBehaviour pins three properties of the resolver
+// cache that columnOrderFor relies on. Each is documented in
+// handler.go's resolverCache type comment; this test enforces them.
+//
+//  1. Hit-within-TTL: a second columnOrderFor call within the TTL
+//     window must NOT invoke resolverFn — the resolver load is the
+//     expensive operation we're caching.
+//  2. Expiry-triggers-reload: a call after the TTL window invokes
+//     resolverFn again, so a fresh `bintrail snapshot` is picked up
+//     without restarting the shim.
+//  3. Sticky-fallback: when a refresh fails AND the cache holds a
+//     prior good resolver, we keep serving the stale resolver. This
+//     prevents transient index-DB blips from oscillating wire-
+//     protocol column order between DDL and alphabetical for the
+//     same customer connection.
+func TestResolverCacheBehaviour(t *testing.T) {
+	tableMeta := metadata.NewResolverFromTables(1, map[string]*metadata.TableMeta{
+		"appdb.orders": {
+			Schema: "appdb", Table: "orders",
+			Columns: []metadata.ColumnMeta{
+				{Name: "id", OrdinalPosition: 1},
+				{Name: "sku", OrdinalPosition: 2},
+			},
+		},
+	})
+
+	t.Run("hit_within_ttl_skips_loader", func(t *testing.T) {
+		now := time.Unix(1_700_000_000, 0)
+		calls := 0
+		c := resolverCache{}
+		load := func() (*metadata.Resolver, error) { calls++; return tableMeta, nil }
+
+		if _, err := c.get(func() time.Time { return now }, time.Minute, load); err != nil {
+			t.Fatalf("first get: %v", err)
+		}
+		if _, err := c.get(func() time.Time { return now.Add(30 * time.Second) }, time.Minute, load); err != nil {
+			t.Fatalf("second get: %v", err)
+		}
+		if calls != 1 {
+			t.Errorf("expected exactly 1 loader call within TTL, got %d", calls)
+		}
+	})
+
+	t.Run("ttl_expiry_triggers_reload", func(t *testing.T) {
+		now := time.Unix(1_700_000_000, 0)
+		calls := 0
+		c := resolverCache{}
+		load := func() (*metadata.Resolver, error) { calls++; return tableMeta, nil }
+
+		if _, err := c.get(func() time.Time { return now }, time.Minute, load); err != nil {
+			t.Fatalf("first get: %v", err)
+		}
+		if _, err := c.get(func() time.Time { return now.Add(2 * time.Minute) }, time.Minute, load); err != nil {
+			t.Fatalf("second get: %v", err)
+		}
+		if calls != 2 {
+			t.Errorf("expected 2 loader calls after TTL expiry, got %d", calls)
+		}
+	})
+
+	t.Run("sticky_fallback_on_load_error", func(t *testing.T) {
+		now := time.Unix(1_700_000_000, 0)
+		c := resolverCache{}
+		ok := func() (*metadata.Resolver, error) { return tableMeta, nil }
+		fail := func() (*metadata.Resolver, error) { return nil, errors.New("transient db blip") }
+
+		if _, err := c.get(func() time.Time { return now }, time.Minute, ok); err != nil {
+			t.Fatalf("warm-up: %v", err)
+		}
+		got, err := c.get(func() time.Time { return now.Add(2 * time.Minute) }, time.Minute, fail)
+		if err != nil {
+			t.Fatalf("expected sticky fallback to mask error, got: %v", err)
+		}
+		if got != tableMeta {
+			t.Errorf("expected sticky fallback to return prior resolver, got %v", got)
+		}
+	})
+
+	t.Run("error_with_no_prior_cache_surfaces", func(t *testing.T) {
+		c := resolverCache{}
+		want := errors.New("first-time db unreachable")
+		_, err := c.get(time.Now, time.Minute, func() (*metadata.Resolver, error) { return nil, want })
+		if !errors.Is(err, want) {
+			t.Errorf("expected first-time error to surface, got: %v", err)
+		}
+	})
+}
+
+// TestColumnOrderForDistinguishesNoSnapshotFromRealError pins the
+// log-level split documented in columnOrderFor: ErrNoSnapshots is
+// the benign first-install state (Debug log only) while any other
+// resolver-load error is a real config/infra problem (Warn log).
+// Both still return nil so the alphabetical fallback path runs.
+//
+// Without this test a future refactor that collapsed both error
+// paths back into the same Debug log would silently un-fix the
+// observability gap that motivated the sentinel.
+func TestColumnOrderForDistinguishesNoSnapshotFromRealError(t *testing.T) {
+	cases := []struct {
+		name      string
+		err       error
+		wantLevel slog.Level
+	}{
+		{"no_snapshots_logs_debug", metadata.ErrNoSnapshots, slog.LevelDebug},
+		{"real_error_logs_warn", errors.New("connection refused"), slog.LevelWarn},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := &Handler{
+				logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+				resolverFn: func() (*metadata.Resolver, error) { return nil, tc.err },
+			}
+			if got := h.columnOrderFor("appdb", "orders"); got != nil {
+				t.Errorf("expected nil fallback, got %v", got)
+			}
+			// Behavioural correctness covered by the above assertion;
+			// the log-level claim is verified by reading the
+			// columnOrderFor source. We can't easily intercept slog
+			// records without rebuilding the logger machinery, and
+			// the level-split is so small (one if/else branch) that
+			// a code review catches a regression as easily as a test
+			// would. This test exists to assert the *fallback* still
+			// happens regardless of which error class fires.
+		})
+	}
+}
+
+// TestMarshalImageOrderedDDL pins the contract that _diff JSON keys
+// follow the source table's DDL order — without this, runDiff's
+// row_before/row_after columns alphabetise (the json.Marshal(map)
+// default), creating an inconsistency with _flashback's reconstructed
+// row.
+func TestMarshalImageOrderedDDL(t *testing.T) {
+	cases := []struct {
+		name     string
+		image    map[string]any
+		ddlOrder []string
+		want     string
+	}{
+		{
+			name:     "ddl_order_respected",
+			image:    map[string]any{"id": 42, "sku": "ABC", "qty": 1, "note": "init"},
+			ddlOrder: []string{"id", "sku", "qty", "note"},
+			want:     `{"id":42,"sku":"ABC","qty":1,"note":"init"}`,
+		},
+		{
+			name:     "nil_image_renders_empty_string",
+			image:    nil,
+			ddlOrder: []string{"id"},
+			want:     "",
+		},
+		{
+			name:     "nil_ddl_order_falls_back_to_alphabetical",
+			image:    map[string]any{"id": 42, "sku": "ABC"},
+			ddlOrder: nil,
+			want:     `{"id":42,"sku":"ABC"}`,
+		},
+		{
+			name:     "image_columns_not_in_ddl_appended_alphabetically",
+			image:    map[string]any{"id": 1, "sku": "X", "added": "new"},
+			ddlOrder: []string{"id", "sku"},
+			want:     `{"id":1,"sku":"X","added":"new"}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := marshalImageOrdered(tc.image, tc.ddlOrder)
+			if got != tc.want {
+				t.Errorf("marshalImageOrdered = %s, want %s", got, tc.want)
 			}
 		})
 	}
@@ -762,19 +940,6 @@ func driveClient(addr, user, password string) error {
 		return err
 	}
 	return nil
-}
-
-// Avoid pulling fmt for simple equality.
-func equalStrings(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
 }
 
 // equalMaps compares two map[string]any by length and value identity


### PR DESCRIPTION
## Summary

Closes the TODO in `internal/shim/handler.go:319-322`. Time-travel queries (`_flashback`, `_snapshot`) reconstruct rows from the JSON image stored in `binlog_events.row_after` and were emitting columns in alphabetical key order. So a customer running:

```sql
SELECT * FROM _flashback.orders AS OF '...' WHERE id = 42;
```

got back `(id, note, qty, sku)` instead of the source table's natural `(id, sku, qty, note)`. Side-by-side comparisons with a regular `SELECT *` looked janky and broke any positional client-side row mapping.

### Before

```
mysql> SELECT * FROM orders WHERE id = 42;
+----+----------+-----+---------------------------+
| id | sku      | qty | note                      |
+----+----------+-----+---------------------------+
| 42 | LIVE-SKU | 999 | live-row-from-passthrough |
+----+----------+-----+---------------------------+

mysql> SELECT * FROM _flashback.orders AS OF '2026-05-04 13:00:00' WHERE id = 42;
+----+---------+-----+-------+
| id | note    | qty | sku   |     ← columns reshuffled alphabetically
+----+---------+-----+-------+
| 42 | initial |   2 | ABC-1 |
+----+---------+-----+-------+
```

### After

```
mysql> SELECT * FROM _flashback.orders AS OF '2026-05-04 13:00:00' WHERE id = 42;
+----+-------+-----+---------+
| id | sku   | qty | note    |     ← matches the DDL
+----+-------+-----+---------+
| 42 | ABC-1 |   2 | initial |
+----+-------+-----+---------+
```

## How it works

`Handler` gains a `resolverFn` field that returns a `metadata.Resolver` loaded from the latest `schema_snapshots` row. `imageToResult` now takes a `ddlOrder []string` and emits columns in that order; falls back to alphabetical when the resolver fails or the table is unknown so brand-new installs that haven't run `bintrail snapshot` yet still work — just without DDL-aware ordering.

Edge case: image columns not present in the snapshot (e.g. binlog event captured before a recent `ALTER TABLE`) are appended at the end in alphabetical order rather than dropped.

The `orderColumns` helper is a pure function so the merge rules can be unit-tested. Five sub-cases pin the contract (nil/empty fallback, ddl-only, image-only, exact match, mixed).

## Test plan

- [x] Unit tests pass (`go test ./... -count=1`)
- [x] E2E passes locally (`SHIM_E2E=1 go test -tags shim_e2e -v ./e2e/shim/...`) — 6/6 subtests, including a new column-order assertion in `flashback_returns_post_image_at_asof` that catches the regression where the resolver stops being consulted.
- [x] Verified by hand against the live docker-compose stack — `_flashback`, `_snapshot`, and passthrough now all emit columns in the same order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)