### PR TITLE
chore(shim-e2e): pin proxysql to 2.6.6 (LTS line)

### DIFF
--- a/e2e/shim/docker-compose.yml
+++ b/e2e/shim/docker-compose.yml
@@ -43,7 +43,12 @@ services:
       retries: 30
 
   proxysql:
-    image: proxysql/proxysql:2.7.1
+    # 2.6.x is the recommended LTS line per the ProxySQL maintainers.
+    # Docker Hub does not publish a floating `2.6` tag, so we pin to
+    # the latest 2.6 patch and bump on a security release. Bump
+    # cadence is fine to be manual since the test rig isn't on the
+    # critical path.
+    image: proxysql/proxysql:2.6.6
     # `--initial` wipes any volume-resident SQLite config from a
     # prior run so we start each test from a clean slate. Routing
     # config (mysql_servers / mysql_users / mysql_query_rules) is


### PR DESCRIPTION
## Why

The shim e2e was tracking `proxysql/proxysql:2.7.1`, picked arbitrarily during the initial rig. ProxySQL's maintainers recommend the **2.6.x LTS line** for production. Switch the test stack to follow it so the version we exercise matches what we'd recommend.

## How

Docker Hub doesn't publish a floating `2.6` tag — only patch-pinned releases — so pin to the latest 2.6 patch (`2.6.6` at time of writing). Bump on security releases; the test rig isn't on the critical path, manual cadence is fine.

## Test plan

- [x] `docker pull proxysql/proxysql:2.6.6` succeeds
- [x] `SHIM_E2E=1 go test -tags shim_e2e -v ./e2e/shim/...` — **6/6 subtests pass** in 48s

🤖 Generated with [Claude Code](https://claude.com/claude-code)