### PR TITLE
fix(shim): wire-correct error codes (1064 / 1235) instead of ER_UNKNOWN_ERROR (1105)

### DIFF
--- a/e2e/shim/e2e_test.go
+++ b/e2e/shim/e2e_test.go
@@ -253,6 +253,30 @@ func TestShimEndToEnd(t *testing.T) {
 		}
 	})
 
+	t.Run("malformed_time_travel_returns_1064_not_1105", func(t *testing.T) {
+		// Issue #277: a virtual-schema query that doesn't match any
+		// supported shape used to surface as ER_UNKNOWN_ERROR (1105),
+		// the catch-all "server is broken" code. ORMs and monitoring
+		// can't distinguish that from a real shim crash. The shim now
+		// emits ER_PARSE_ERROR (1064) — the same code MySQL returns
+		// for any SQL syntax error — so user typos vs. server faults
+		// are operationally distinct on the wire.
+		_, err := clientDB.Query(
+			"SELECT * FROM _flashback.orders WHERE id = 42")
+		if err == nil {
+			t.Fatalf("expected error for malformed _flashback query (no AS OF)")
+		}
+		var mysqlErr *mysql.MySQLError
+		if !errors.As(err, &mysqlErr) {
+			t.Fatalf("expected *mysql.MySQLError, got %T: %v", err, err)
+		}
+		if mysqlErr.Number != 1064 {
+			t.Fatalf("expected error code 1064 (ER_PARSE_ERROR), got %d: %s\n"+
+				"if 1105, the shim regressed to fmt.Errorf for malformed time-travel",
+				mysqlErr.Number, mysqlErr.Message)
+		}
+	})
+
 	t.Run("passthrough_query_hits_real_mysql_not_shim", func(t *testing.T) {
 		// `appdb.orders` (no virtual schema) must route to the
 		// passthrough hostgroup. The live row has marker values

--- a/internal/shim/handler.go
+++ b/internal/shim/handler.go
@@ -253,17 +253,22 @@ func (h *Handler) HandleQuery(qstr string) (*mysql.Result, error) {
 		}
 	}
 	if !errors.Is(perr, ErrNotTimeTravel) {
-		return nil, perr
+		// Parser recognised a virtual-schema query but rejected its shape
+		// (or its AS OF literal, or the missing USE <db>). Wire it as
+		// ER_PARSE_ERROR (1064) — the same code MySQL uses for any SQL
+		// syntax error — so ORMs and monitoring can tell user input from
+		// a server crash. Internal errors below keep the default 1105.
+		return nil, mysql.NewError(mysql.ER_PARSE_ERROR, perr.Error())
 	}
 
 	if isHandshakeNoise(qstr) {
 		return &mysql.Result{Status: 2}, nil
 	}
 
-	return nil, fmt.Errorf(
+	return nil, mysql.NewError(mysql.ER_NOT_SUPPORTED_YET, fmt.Sprintf(
 		"this server only handles _flashback / _snapshot / _diff virtual-schema queries; got: %s",
 		strings.TrimSpace(qstr),
-	)
+	))
 }
 
 // runPointInTime resolves a _flashback or _snapshot query against

--- a/internal/shim/handler.go
+++ b/internal/shim/handler.go
@@ -257,7 +257,11 @@ func (h *Handler) HandleQuery(qstr string) (*mysql.Result, error) {
 		// (or its AS OF literal, or the missing USE <db>). Wire it as
 		// ER_PARSE_ERROR (1064) — the same code MySQL uses for any SQL
 		// syntax error — so ORMs and monitoring can tell user input from
-		// a server crash. Internal errors below keep the default 1105.
+		// a server crash. Failures from runPointInTime / runDiff (DB
+		// timeouts, FetchMerged errors, resultset-build bugs) keep
+		// returning plain fmt.Errorf so go-mysql/server emits 1105 —
+		// that is the inverse half of the contract and #277 explicitly
+		// asks to preserve it.
 		return nil, mysql.NewError(mysql.ER_PARSE_ERROR, perr.Error())
 	}
 

--- a/internal/shim/handler_test.go
+++ b/internal/shim/handler_test.go
@@ -142,6 +142,72 @@ func TestHandlerWireErrorCodes(t *testing.T) {
 			}
 		})
 	}
+
+	// The "no USE <db>" path is structurally distinct: parser sees a
+	// virtual schema prefix but no default DB and returns its own
+	// error before even attempting the regex match. Pin this case
+	// separately so a future split between "syntax error" (1064) and
+	// "session-state error" (e.g. 1046) is a deliberate decision, not
+	// a silent regression.
+	t.Run("missing_use_db_returns_1064", func(t *testing.T) {
+		h := NewHandler(nil, nil) // deliberately no UseDB
+		_, err := h.HandleQuery("SELECT * FROM _flashback.orders AS OF '2026-01-01' WHERE id = 1")
+		if err == nil {
+			t.Fatal("expected error when no schema is selected")
+		}
+		var myErr *gomysql.MyError
+		if !errors.As(err, &myErr) {
+			t.Fatalf("expected *mysql.MyError, got %T: %v", err, err)
+		}
+		if myErr.Code != gomysql.ER_PARSE_ERROR {
+			t.Errorf("wire code = %d, want %d (msg=%q)", myErr.Code, gomysql.ER_PARSE_ERROR, myErr.Message)
+		}
+	})
+}
+
+// TestHandlerInternalErrorsKeepDefaultWireCode pins the *inverse* half
+// of #277's contract: failures inside runPointInTime / runDiff (DB
+// timeouts, FetchMerged errors, archive_state lookup failures) must
+// NOT be wrapped in *mysql.MyError so go-mysql/server emits the
+// catch-all ER_UNKNOWN_ERROR (1105). A future refactor that wraps
+// these in mysql.NewError(ER_PARSE_ERROR, ...) would silently flip
+// "the server is broken" into "your query is malformed" — exactly
+// the user-vs-server-fault confusion #277 was filed to eliminate.
+func TestHandlerInternalErrorsKeepDefaultWireCode(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	// archive_state lookup is the first DB hop runPointInTime takes
+	// via FetchMerged → ResolveArchiveSources. Make it fail and the
+	// failure propagates back through runPointInTime as a plain
+	// fmt.Errorf("resolve %s: %w", ...).
+	mock.MatchExpectationsInOrder(false)
+	mock.ExpectQuery("FROM archive_state").
+		WillReturnError(errors.New("simulated archive_state lookup failure"))
+
+	h := &Handler{
+		indexDB: db,
+		cfg:     Config{IndexDBName: "bintrail_index"},
+		logger:  slog.Default(),
+		archiveFetcher: func(ctx context.Context, opts query.Options, src string) ([]query.ResultRow, error) {
+			return nil, nil
+		},
+	}
+	h.UseDB("myapp")
+
+	_, err = h.HandleQuery("SELECT * FROM _flashback.orders AS OF '2026-01-01 00:00:00' WHERE id = 1")
+	if err == nil {
+		t.Fatal("expected error from failing archive_state lookup")
+	}
+	var myErr *gomysql.MyError
+	if errors.As(err, &myErr) {
+		t.Errorf("internal failure must NOT be wrapped in *mysql.MyError "+
+			"(go-mysql/server would then emit %d instead of the catch-all 1105); "+
+			"got code=%d msg=%q", myErr.Code, myErr.Code, myErr.Message)
+	}
 }
 
 // TestHandlerUseDBStoresSchema — the schema set via UseDB is held

--- a/internal/shim/handler_test.go
+++ b/internal/shim/handler_test.go
@@ -162,6 +162,12 @@ func TestHandlerWireErrorCodes(t *testing.T) {
 		if myErr.Code != gomysql.ER_PARSE_ERROR {
 			t.Errorf("wire code = %d, want %d (msg=%q)", myErr.Code, gomysql.ER_PARSE_ERROR, myErr.Message)
 		}
+		// The operator hint ("USE <database>") is the actionable
+		// part of this error — without it the 1064 is correctly
+		// typed but useless to the human reading it.
+		if !strings.Contains(myErr.Message, "USE") {
+			t.Errorf("error should hint at USE <database>; got %q", myErr.Message)
+		}
 	})
 }
 
@@ -180,18 +186,35 @@ func TestHandlerInternalErrorsKeepDefaultWireCode(t *testing.T) {
 	}
 	defer db.Close()
 
-	// archive_state lookup is the first DB hop runPointInTime takes
-	// via FetchMerged → ResolveArchiveSources. Make it fail and the
-	// failure propagates back through runPointInTime as a plain
-	// fmt.Errorf("resolve %s: %w", ...).
+	// We force *some* internal failure inside FetchMerged by failing
+	// the archive_state lookup. The exact propagation path is
+	// implementation detail (ResolveArchiveSources may swallow the
+	// first hit; the planner's archive_state re-query may carry it;
+	// an unmocked information_schema query may surface it instead).
+	// What matters for the contract is that whatever error reaches
+	// HandleQuery's caller is a plain Go error, not a pre-typed
+	// *mysql.MyError. The ExpectationsWereMet check below ensures
+	// the archive_state query was actually issued — a refactor that
+	// stops touching FetchMerged would fail the test loudly rather
+	// than silently keeping a passing assertion.
 	mock.MatchExpectationsInOrder(false)
 	mock.ExpectQuery("FROM archive_state").
 		WillReturnError(errors.New("simulated archive_state lookup failure"))
+	t.Cleanup(func() {
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Errorf("sqlmock expectation not met — the FetchMerged path "+
+				"this test pins is no longer being exercised: %v", err)
+		}
+	})
 
 	h := &Handler{
 		indexDB: db,
-		cfg:     Config{IndexDBName: "bintrail_index"},
-		logger:  slog.Default(),
+		// AllowGaps=false is the production default and is the mode
+		// that propagates archive errors rather than degrading to a
+		// Warn. Pin it explicitly so a flip in the zero-value default
+		// doesn't quietly change which path this test exercises.
+		cfg:    Config{IndexDBName: "bintrail_index", AllowGaps: false},
+		logger: slog.Default(),
 		archiveFetcher: func(ctx context.Context, opts query.Options, src string) ([]query.ResultRow, error) {
 			return nil, nil
 		},

--- a/internal/shim/handler_test.go
+++ b/internal/shim/handler_test.go
@@ -94,6 +94,56 @@ func TestHandlerRejectsNonFlashbackQuery(t *testing.T) {
 	}
 }
 
+// TestHandlerWireErrorCodes pins the wire codes the shim returns to
+// MySQL clients. ORMs and monitoring rely on these to tell user input
+// errors apart from server crashes; an untyped `fmt.Errorf` collapses
+// to ER_UNKNOWN_ERROR (1105) which is the wrong signal.
+//
+//   - malformed time-travel (recognised virtual schema, bad shape) → 1064
+//   - non-time-travel routed to the shim                            → 1235
+func TestHandlerWireErrorCodes(t *testing.T) {
+	h := NewHandler(nil, nil)
+	h.UseDB("myapp")
+
+	cases := []struct {
+		name    string
+		query   string
+		wantErr uint16
+	}{
+		{
+			name:    "malformed_flashback_missing_as_of",
+			query:   "SELECT * FROM _flashback.orders WHERE id = 1",
+			wantErr: gomysql.ER_PARSE_ERROR,
+		},
+		{
+			name:    "malformed_diff_bad_between",
+			query:   "SELECT * FROM _diff.orders WHERE id = 1",
+			wantErr: gomysql.ER_PARSE_ERROR,
+		},
+		{
+			name:    "non_time_travel_query",
+			query:   "SELECT * FROM orders WHERE id = 1",
+			wantErr: gomysql.ER_NOT_SUPPORTED_YET,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := h.HandleQuery(tc.query)
+			if err == nil {
+				t.Fatalf("expected error for %q", tc.query)
+			}
+			var myErr *gomysql.MyError
+			if !errors.As(err, &myErr) {
+				t.Fatalf("expected *mysql.MyError so server emits a typed wire code, got %T: %v", err, err)
+			}
+			if myErr.Code != tc.wantErr {
+				t.Errorf("wire code = %d, want %d (msg=%q)", myErr.Code, tc.wantErr, myErr.Message)
+			}
+		})
+	}
+}
+
 // TestHandlerUseDBStoresSchema — the schema set via UseDB is held
 // for use by subsequent HandleQuery calls. The end-to-end coverage
 // for "UseDB then run flashback" lives in TestEndToEndHandshake; here


### PR DESCRIPTION
Closes #277.

## Summary

- Malformed time-travel queries (recognised virtual schema, unsupported shape / bad AS OF / missing USE `<db>`) now wire as **ER_PARSE_ERROR (1064)**.
- Non-time-travel queries routed to the shim wire as **ER_NOT_SUPPORTED_YET (1235)**.
- Real internal errors (DB failures, resultset-build bugs) keep their default **ER_UNKNOWN_ERROR (1105)** — the distinction #277 explicitly asked to preserve.

Parser stays free of the wire-protocol import; the translation is centralised in `handler.HandleQuery` where the wire boundary lives.

## Why

`go-mysql/server` collapses any plain Go error returned from `HandleQuery` into ER_UNKNOWN_ERROR (1105). That's "the server is broken" to every MySQL tool, ORM, and monitoring system — same code as a real shim crash. Customer typos paged operators; ORM retry logic couldn't tell user-input errors from server faults.

This PR is the ~5-line mechanical fix described in #277 (plus tests).

## Test plan

- [x] `go test -count=1 ./...` — all unit/integration suites pass
- [x] `go vet -tags shim_e2e ./e2e/shim/` — clean
- [x] New unit subtests `TestHandlerWireErrorCodes` cover:
  - malformed `_flashback` (no AS OF) → 1064
  - malformed `_diff` (no BETWEEN) → 1064
  - non-time-travel query → 1235
  - assertion is on `mysql.MyError.Code` (wire shape), not message text
- [x] New e2e subtest `malformed_time_travel_returns_1064_not_1105` (in `TestShimEndToEnd`, gated by `SHIM_E2E=1`) sends a malformed query through ProxySQL → shim and asserts wire code 1064 — mirrors the pattern from the existing `auth_rejection_returns_1045_not_1449` subtest.