### PR TITLE
fix(shim): wire coverage-gap errors as ER_NO_PARTITION_FOR_GIVEN_VALUE (1526)

### DIFF
--- a/e2e/shim/e2e_test.go
+++ b/e2e/shim/e2e_test.go
@@ -277,6 +277,36 @@ func TestShimEndToEnd(t *testing.T) {
 		}
 	})
 
+	t.Run("coverage_gap_returns_1526_not_1105", func(t *testing.T) {
+		// Issue #283: a strict-mode query whose AS OF is outside what
+		// this index retains used to surface as ER_UNKNOWN_ERROR (1105),
+		// indistinguishable from a real shim crash. The shim now wraps
+		// the planner's *query.GapError as ER_NO_PARTITION_FOR_GIVEN_VALUE
+		// (1526) — MySQL's existing code for "no partition matches the
+		// value you queried", which is literally what a coverage gap is.
+		//
+		// The seed (e2e/shim/seed.sql) creates partitions covering 09:00
+		// to 16:00 on 2026-05-04. AS OF 18:00 lies outside that range,
+		// producing 3 gap hours (16:00, 17:00, 18:00) under default
+		// strict mode (--allow-gaps=false). Internal failures (DB down,
+		// resultset-build bug) keep emitting 1105 — see the unit tests
+		// in internal/shim/handler_test.go for that half of the contract.
+		_, err := clientDB.Query(
+			"SELECT * FROM _flashback.orders AS OF '2026-05-04 18:00:00' WHERE id = 42")
+		if err == nil {
+			t.Fatalf("expected coverage-gap error for AS OF outside partition range")
+		}
+		var mysqlErr *mysql.MySQLError
+		if !errors.As(err, &mysqlErr) {
+			t.Fatalf("expected *mysql.MySQLError, got %T: %v", err, err)
+		}
+		if mysqlErr.Number != 1526 {
+			t.Fatalf("expected error code 1526 (ER_NO_PARTITION_FOR_GIVEN_VALUE), got %d: %s\n"+
+				"if 1105, the shim regressed to fmt.Errorf for *query.GapError",
+				mysqlErr.Number, mysqlErr.Message)
+		}
+	})
+
 	t.Run("passthrough_query_hits_real_mysql_not_shim", func(t *testing.T) {
 		// `appdb.orders` (no virtual schema) must route to the
 		// passthrough hostgroup. The live row has marker values

--- a/internal/shim/handler.go
+++ b/internal/shim/handler.go
@@ -275,6 +275,24 @@ func (h *Handler) HandleQuery(qstr string) (*mysql.Result, error) {
 	))
 }
 
+// wrapFetchError translates an error from query.FetchMerged into the
+// right wire shape for HandleQuery to return. A coverage gap is a
+// client-input concern (the AS OF / time range is outside what this
+// index retains) and must be distinguishable from a real internal
+// failure (DB timeout, archive S3 outage, build-resultset bug). MySQL
+// itself uses ER_NO_PARTITION_FOR_GIVEN_VALUE (1526) for "no partition
+// matches the value you queried" — semantically identical to a bintrail
+// coverage gap. Anything else stays a plain Go error so go-mysql/server
+// emits the catch-all ER_UNKNOWN_ERROR (1105), preserving the
+// user-vs-server-fault distinction PR #282 (#277) established.
+func wrapFetchError(qType QueryType, err error) error {
+	var gapErr *query.GapError
+	if errors.As(err, &gapErr) {
+		return mysql.NewError(mysql.ER_NO_PARTITION_FOR_GIVEN_VALUE, gapErr.Error())
+	}
+	return fmt.Errorf("resolve %s: %w", qType, err)
+}
+
 // runPointInTime resolves a _flashback or _snapshot query against
 // the bintrail index + archives and reconstructs the row's state at
 // q.AsOf.
@@ -317,7 +335,7 @@ func (h *Handler) runPointInTime(q TimeTravelQuery) (*mysql.Result, error) {
 		ArchiveFetcher: h.archiveFetcher,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("resolve %s: %w", q.Type, err)
+		return nil, wrapFetchError(q.Type, err)
 	}
 
 	image := selectImage(rows)
@@ -449,7 +467,7 @@ func (h *Handler) runDiff(q TimeTravelQuery) (*mysql.Result, error) {
 		ArchiveFetcher: h.archiveFetcher,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("resolve %s: %w", q.Type, err)
+		return nil, wrapFetchError(q.Type, err)
 	}
 
 	// Compute the source-table column order once per query so the

--- a/internal/shim/handler.go
+++ b/internal/shim/handler.go
@@ -284,11 +284,16 @@ func (h *Handler) HandleQuery(qstr string) (*mysql.Result, error) {
 // matches the value you queried" — semantically identical to a bintrail
 // coverage gap. Anything else stays a plain Go error so go-mysql/server
 // emits the catch-all ER_UNKNOWN_ERROR (1105), preserving the
-// user-vs-server-fault distinction PR #282 (#277) established.
+// user-vs-server-fault distinction PR #282 established for issue #277.
+//
+// Both branches prefix qType so an operator with multiple concurrent
+// shim sessions can attribute the error to a _flashback / _diff /
+// _snapshot query without correlating logs.
 func wrapFetchError(qType QueryType, err error) error {
 	var gapErr *query.GapError
 	if errors.As(err, &gapErr) {
-		return mysql.NewError(mysql.ER_NO_PARTITION_FOR_GIVEN_VALUE, gapErr.Error())
+		return mysql.NewError(mysql.ER_NO_PARTITION_FOR_GIVEN_VALUE,
+			fmt.Sprintf("resolve %s: %s", qType, gapErr.Error()))
 	}
 	return fmt.Errorf("resolve %s: %w", qType, err)
 }

--- a/internal/shim/handler_test.go
+++ b/internal/shim/handler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net"
@@ -230,6 +231,69 @@ func TestHandlerInternalErrorsKeepDefaultWireCode(t *testing.T) {
 		t.Errorf("internal failure must NOT be wrapped in *mysql.MyError "+
 			"(go-mysql/server would then emit %d instead of the catch-all 1105); "+
 			"got code=%d msg=%q", myErr.Code, myErr.Code, myErr.Message)
+	}
+}
+
+// TestWrapFetchErrorClassifiesGapAsTyped pins the error-classification
+// contract that runPointInTime / runDiff use for FetchMerged failures
+// (issue #283). Coverage gaps are client-input concerns and must wire
+// as ER_NO_PARTITION_FOR_GIVEN_VALUE (1526); everything else stays a
+// plain Go error so go-mysql/server emits the catch-all 1105.
+//
+// Testing the helper directly (not via sqlmock + the planner) keeps
+// the contract pinned to the *classification rule*, not to whatever
+// query path happens to surface a GapError today.
+func TestWrapFetchErrorClassifiesGapAsTyped(t *testing.T) {
+	gap := &query.GapError{GapHours: []time.Time{time.Date(2026, 5, 4, 18, 0, 0, 0, time.UTC)}}
+
+	cases := []struct {
+		name     string
+		in       error
+		isTyped  bool
+		wantCode uint16
+	}{
+		{
+			name:     "bare_gap_error",
+			in:       gap,
+			isTyped:  true,
+			wantCode: gomysql.ER_NO_PARTITION_FOR_GIVEN_VALUE,
+		},
+		{
+			// errors.As must unwrap through %w wrappers — protects against
+			// a future refactor that wraps the planner's GapError before
+			// it reaches the shim.
+			name:     "wrapped_gap_error",
+			in:       fmt.Errorf("planner reported gaps: %w", gap),
+			isTyped:  true,
+			wantCode: gomysql.ER_NO_PARTITION_FOR_GIVEN_VALUE,
+		},
+		{
+			name:    "internal_db_failure_stays_untyped",
+			in:      errors.New("connection reset by peer"),
+			isTyped: false,
+		},
+		{
+			name:    "wrapped_internal_failure_stays_untyped",
+			in:      fmt.Errorf("planner failed: %w", errors.New("information_schema unavailable")),
+			isTyped: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := wrapFetchError(TypeFlashback, tc.in)
+			var myErr *gomysql.MyError
+			gotTyped := errors.As(out, &myErr)
+			if gotTyped != tc.isTyped {
+				t.Fatalf("isTyped = %v, want %v (out=%v)", gotTyped, tc.isTyped, out)
+			}
+			if !tc.isTyped {
+				return
+			}
+			if myErr.Code != tc.wantCode {
+				t.Errorf("wire code = %d, want %d (msg=%q)", myErr.Code, tc.wantCode, myErr.Message)
+			}
+		})
 	}
 }
 

--- a/internal/shim/handler_test.go
+++ b/internal/shim/handler_test.go
@@ -293,6 +293,12 @@ func TestWrapFetchErrorClassifiesGapAsTyped(t *testing.T) {
 			if myErr.Code != tc.wantCode {
 				t.Errorf("wire code = %d, want %d (msg=%q)", myErr.Code, tc.wantCode, myErr.Message)
 			}
+			// Pin the qType prefix on both branches: operators with
+			// concurrent shim sessions need to attribute the error to
+			// a specific query type without correlating logs.
+			if !strings.Contains(myErr.Message, "flashback") {
+				t.Errorf("wire message should include qType context; got %q", myErr.Message)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Closes #283.

## Summary

- `*query.GapError` from `runPointInTime` / `runDiff` now wires as **ER_NO_PARTITION_FOR_GIVEN_VALUE (1526)** — MySQL's existing code for "no partition matches the value you queried", semantically exact for a bintrail coverage gap.
- Real internal failures (DB timeout, archive S3 outage, build-resultset bug) keep emitting **ER_UNKNOWN_ERROR (1105)** — the inverse half of the contract PR #282 (#277) established.
- The two call-sites share one helper (`wrapFetchError`) so a future typed error class added to `FetchMerged` (e.g. `*ArchiveAuthError`) needs to be classified once, not twice.

## Why ER_NO_PARTITION_FOR_GIVEN_VALUE

| Candidate | Fit |
|---|---|
| **1526** ER_NO_PARTITION_FOR_GIVEN_VALUE | ✅ "table has no partition for value X" — literally what a coverage gap is |
| 1235 ER_NOT_SUPPORTED_YET | reused from the non-time-travel rejection; vague for this case |
| 1690 ER_DATA_OUT_OF_RANGE | too narrow (numeric overflow) |
| 1105 ER_UNKNOWN_ERROR | the regression we're fixing |

## Test plan

- [x] `go test -count=1 ./...` — full suite passes
- [x] `go vet -tags shim_e2e ./e2e/shim/` — clean
- [x] New unit test `TestWrapFetchErrorClassifiesGapAsTyped` covers four cases via `errors.As`:
  - bare `*query.GapError` → 1526
  - wrapped `*query.GapError` (through `%w`) → 1526
  - bare internal error → not `*mysql.MyError`
  - wrapped internal error → not `*mysql.MyError`
- [x] New e2e subtest `coverage_gap_returns_1526_not_1105` (gated by `SHIM_E2E=1`) queries `AS OF '2026-05-04 18:00:00'` against the existing seed (partitions cover 09:00-16:00) — produces 3 gap hours under strict mode → asserts wire code 1526. No rotate-archive cycle infrastructure needed.

## Why filed and done as a separate PR

Surfaced during round-2 review of PR #282 (silent-failure-hunter). PR #282 was scoped to the parser/router rejections (1064, 1235); classifying `*query.GapError` requires deciding the right code, threading it through both handlers, and adding e2e coverage — different review surface, kept separate so each PR stays small and focused.