### PR TITLE
feat(shim): full-table AS OF reconstruction for _flashback / _snapshot

### DIFF
--- a/cmd/bintrail/shim_wire_test.go
+++ b/cmd/bintrail/shim_wire_test.go
@@ -225,8 +225,14 @@ func TestShim_MalformedTimeTravelReturnsWireError(t *testing.T) {
 			wantErrSubstr: "BETWEEN bounds out of order",
 		},
 		{
-			name:          "snapshot missing WHERE",
-			sql:           "SELECT * FROM _snapshot.users AS OF '2026-01-01 00:00:00'",
+			// Pre-#276 this case was "_snapshot AS OF without WHERE";
+			// since #276 that's now the valid full-table shape. Use
+			// _snapshot without AS OF so the regex still rejects the
+			// query and the malformed-time-travel branch fires —
+			// keeps all three virtual schemas exercised in the wire
+			// path.
+			name:          "snapshot missing AS OF",
+			sql:           "SELECT * FROM _snapshot.users WHERE id = 1",
 			wantErrSubstr: "malformed time-travel",
 		},
 	}

--- a/e2e/shim/e2e_test.go
+++ b/e2e/shim/e2e_test.go
@@ -253,6 +253,59 @@ func TestShimEndToEnd(t *testing.T) {
 		}
 	})
 
+	t.Run("flashback_full_table_no_where_at_pre_delete", func(t *testing.T) {
+		// Issue #276: SELECT * FROM _flashback.orders AS OF '...' (no
+		// WHERE) reconstructs the table's full row state at AS OF.
+		// AS OF 13:00 → after the 12:00 UPDATE (qty=2), before the
+		// 14:00 DELETE. The seed has exactly one row (id=42), so the
+		// resultset must contain exactly one row with the post-UPDATE
+		// image — pinning both the row count (full-table works) and
+		// the content (it's the right reconstructed image).
+		gotCols, rows := queryAllRowsWithCols(t, clientDB,
+			"SELECT * FROM _flashback.orders AS OF '2026-05-04 13:00:00'")
+		if len(rows) != 1 {
+			t.Fatalf("expected 1 row at AS OF 13:00, got %d: %+v", len(rows), rows)
+		}
+		want := map[string]string{"id": "42", "sku": "ABC-1", "qty": "2", "note": "initial"}
+		if !maps.Equal(rows[0], want) {
+			t.Errorf("full-table row mismatch:\n  got:  %+v\n  want: %+v", rows[0], want)
+		}
+		// DDL order must hold for the multi-row resultset shape too —
+		// alphabetical (id, note, qty, sku) would be a regression.
+		wantCols := []string{"id", "sku", "qty", "note"}
+		if !slices.Equal(gotCols, wantCols) {
+			t.Errorf("full-table column order = %v, want %v", gotCols, wantCols)
+		}
+	})
+
+	t.Run("flashback_full_table_at_post_delete", func(t *testing.T) {
+		// AS OF 15:00 → after the 14:00 DELETE. id=42 must be SKIPPED
+		// (didn't exist at AS OF), distinguishing full-table semantics
+		// from point-lookup which would return the DELETE's row_before.
+		_, rows := queryAllRowsWithCols(t, clientDB,
+			"SELECT * FROM _flashback.orders AS OF '2026-05-04 15:00:00'")
+		if len(rows) != 0 {
+			t.Fatalf("expected 0 rows after DELETE, got %d: %+v\n"+
+				"if 1 row, the full-table path is leaking row_before from DELETEs",
+				len(rows), rows)
+		}
+	})
+
+	t.Run("flashback_full_table_at_pre_update", func(t *testing.T) {
+		// AS OF 11:00 → after the 10:00 INSERT (qty=1), before the
+		// 12:00 UPDATE. Pins that the windowed query picks the latest
+		// event ≤ AS OF, not the most recent of all time.
+		_, rows := queryAllRowsWithCols(t, clientDB,
+			"SELECT * FROM _flashback.orders AS OF '2026-05-04 11:00:00'")
+		if len(rows) != 1 {
+			t.Fatalf("expected 1 row at AS OF 11:00, got %d", len(rows))
+		}
+		want := map[string]string{"id": "42", "sku": "ABC-1", "qty": "1", "note": "initial"}
+		if !maps.Equal(rows[0], want) {
+			t.Errorf("pre-UPDATE row mismatch:\n  got:  %+v\n  want: %+v", rows[0], want)
+		}
+	})
+
 	t.Run("malformed_time_travel_returns_1064_not_1105", func(t *testing.T) {
 		// Issue #277: a virtual-schema query that doesn't match any
 		// supported shape used to surface as ER_UNKNOWN_ERROR (1105),
@@ -400,6 +453,54 @@ func queryRowMapWithCols(t *testing.T, db *sql.DB, q string) ([]string, map[stri
 
 	if rows.Next() {
 		t.Fatalf("expected exactly one row, got at least two")
+	}
+	return cols, out
+}
+
+// queryAllRowsWithCols is the multi-row sibling of queryRowMapWithCols
+// for full-table _flashback queries (#276). Returns column order
+// (must match DDL) and a slice of {column → value} maps, one per
+// row. Zero rows is a valid return — the caller decides whether
+// that's correct (e.g. AS OF after DELETE) or a bug (no events
+// matched a query that should have hit data).
+func queryAllRowsWithCols(t *testing.T, db *sql.DB, q string) ([]string, []map[string]string) {
+	t.Helper()
+	if err := db.PingContext(context.Background()); err != nil {
+		t.Fatalf("ping before query: %v", err)
+	}
+	rows, err := db.Query(q)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer rows.Close()
+
+	cols, err := rows.Columns()
+	if err != nil {
+		t.Fatalf("columns: %v", err)
+	}
+
+	var out []map[string]string
+	for rows.Next() {
+		raw := make([]sql.RawBytes, len(cols))
+		dest := make([]any, len(cols))
+		for i := range raw {
+			dest[i] = &raw[i]
+		}
+		if err := rows.Scan(dest...); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		row := make(map[string]string, len(cols))
+		for i, c := range cols {
+			if raw[i] == nil {
+				row[c] = "<nil>"
+				continue
+			}
+			row[c] = string(raw[i])
+		}
+		out = append(out, row)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows err: %v", err)
 	}
 	return cols, out
 }

--- a/e2e/shim/e2e_test.go
+++ b/e2e/shim/e2e_test.go
@@ -306,6 +306,24 @@ func TestShimEndToEnd(t *testing.T) {
 		}
 	})
 
+	t.Run("snapshot_full_table_matches_flashback", func(t *testing.T) {
+		// _snapshot must produce the same full-table reconstruction
+		// as _flashback for the same AS OF — they share runPointInTime
+		// + runFullTable. Pinning the contract here keeps a future
+		// _snapshot baseline-lookup branch (out-of-scope today)
+		// deliberate rather than a silent divergence. Issue #276's
+		// AC explicitly required _snapshot full-table coverage.
+		_, rows := queryAllRowsWithCols(t, clientDB,
+			"SELECT * FROM _snapshot.orders AS OF '2026-05-04 13:00:00'")
+		if len(rows) != 1 {
+			t.Fatalf("expected 1 row at _snapshot AS OF 13:00, got %d", len(rows))
+		}
+		want := map[string]string{"id": "42", "sku": "ABC-1", "qty": "2", "note": "initial"}
+		if !maps.Equal(rows[0], want) {
+			t.Errorf("snapshot full-table row mismatch:\n  got:  %+v\n  want: %+v", rows[0], want)
+		}
+	})
+
 	t.Run("malformed_time_travel_returns_1064_not_1105", func(t *testing.T) {
 		// Issue #277: a virtual-schema query that doesn't match any
 		// supported shape used to surface as ER_UNKNOWN_ERROR (1105),

--- a/internal/shim/handler.go
+++ b/internal/shim/handler.go
@@ -21,26 +21,26 @@ import (
 	"github.com/dbtrail/bintrail/internal/query"
 )
 
-// fullTableRowCap bounds the buffered resultset for the full-table
-// AS OF path (issue #276) so a query against a hot table with millions
-// of distinct PKs cannot OOM the shim. 100k rows at a rough estimate
-// of ~512 bytes per JSON row image ≈ 50 MB worst-case (k=1 archive
-// source — multi-archive deployments multiply the transient pre-merge
-// memory by the source count, but the post-merge enforcement still
-// caps the resultset). A forensic shim instance can absorb that;
-// exceeding it surfaces as ER_TOO_BIG_SELECT (1104) so monitoring
-// can distinguish it from a real shim crash, and operators narrow
-// the AS OF range or fall back to PK-filtered queries.
+// defaultFullTableRowCap bounds the buffered resultset for the
+// full-table AS OF path (issue #276) so a query against a hot table
+// with millions of distinct PKs cannot OOM the shim. 100k rows at a
+// rough estimate of ~512 bytes per JSON row image ≈ 50 MB worst-case
+// (k=1 archive source — multi-archive deployments multiply the
+// transient pre-merge memory by the source count, but the post-merge
+// enforcement still caps the resultset). A forensic shim instance can
+// absorb that; exceeding it surfaces as ER_TOO_BIG_SELECT (1104) so
+// monitoring can distinguish it from a real shim crash, and operators
+// narrow the AS OF range or fall back to PK-filtered queries.
 //
 // Streaming the resultset (Conn.WriteFieldList + WriteRow per row,
 // removing the cap) is deferred per the scoping comment on #276;
 // cap+buffered is the bounded substitute for the MVP.
 //
-// Declared as a var rather than a const so unit tests can lower it
-// to seed the overflow path without materialising 100k rows. Not
-// part of the configurable surface — production callers must not
-// mutate it.
-var fullTableRowCap = 100_000
+// Per-Handler override lives on Config.FullTableRowCap (zero =
+// inherit this default) so unit tests can lower it without mutating
+// global state, and a future per-tenant override is one struct field
+// away.
+const defaultFullTableRowCap = 100_000
 
 // resolverCacheTTL bounds how long a stale schema_snapshots view
 // can serve column-ordering lookups. 30s is short enough that a
@@ -219,6 +219,13 @@ type Config struct {
 	// scopes information_schema.PARTITIONS to it; the user query's
 	// schema is the wrong answer (every hour misclassified as a gap).
 	IndexDBName string
+	// FullTableRowCap caps the buffered resultset for the full-table
+	// AS OF path (issue #276). Zero (default) inherits
+	// defaultFullTableRowCap (100k). Set non-zero to override per
+	// Handler — primarily for unit tests that want to seed the
+	// overflow path without materialising 100k rows. A future
+	// per-tenant override would plumb through here.
+	FullTableRowCap int
 }
 
 // NewHandler constructs a Handler bound to a bintrail index DSN with
@@ -412,6 +419,11 @@ func (h *Handler) runFullTable(q TimeTravelQuery) (*mysql.Result, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	cap := h.cfg.FullTableRowCap
+	if cap <= 0 {
+		cap = defaultFullTableRowCap
+	}
+
 	engine := query.New(h.indexDB)
 	rows, _, err := query.FetchMerged(ctx, h.indexDB, engine, query.FetchMergedOptions{
 		Opts: query.Options{
@@ -419,7 +431,7 @@ func (h *Handler) runFullTable(q TimeTravelQuery) (*mysql.Result, error) {
 			Table:      q.Table,
 			Until:      &q.AsOf,
 			LimitPerPK: 1,
-			Limit:      fullTableRowCap + 1,
+			Limit:      cap + 1,
 		},
 		DBName:         h.cfg.IndexDBName,
 		NoArchive:      h.cfg.NoArchive,
@@ -430,10 +442,10 @@ func (h *Handler) runFullTable(q TimeTravelQuery) (*mysql.Result, error) {
 		return nil, wrapFetchError(q.Type, err)
 	}
 
-	if len(rows) > fullTableRowCap {
+	if len(rows) > cap {
 		return nil, mysql.NewError(mysql.ER_TOO_BIG_SELECT, fmt.Sprintf(
 			"resolve %s: %s.%s at %s would return more than %d rows; narrow the AS OF range or filter by PK",
-			q.Type, q.Schema, q.Table, q.AsOf.Format("2006-01-02 15:04:05"), fullTableRowCap,
+			q.Type, q.Schema, q.Table, q.AsOf.Format("2006-01-02 15:04:05"), cap,
 		))
 	}
 
@@ -474,10 +486,11 @@ func extractFullTableImages(rows []query.ResultRow) []map[string]any {
 // present, even if no image carries every column — missing values
 // become NULL on the wire, matching how MySQL itself returns rows
 // from a table that was ALTER'd to add a column. When ddlOrder is
-// empty (first install before any `bintrail snapshot`), we fall
-// back to the *union* of every image's keys (sorted) — using the
-// first image alone would silently elide columns that appeared
-// only in later events of the same query.
+// empty (no resolved snapshot for this table — first install, or
+// a snapshot that doesn't cover this schema/table), we fall back
+// to the *union* of every image's keys (sorted) — using the first
+// image alone would silently elide columns that appeared only in
+// later events of the same query.
 //
 // Empty input → empty resultset.
 func imagesToResult(images []map[string]any, ddlOrder []string) (*mysql.Result, error) {

--- a/internal/shim/handler.go
+++ b/internal/shim/handler.go
@@ -23,16 +23,24 @@ import (
 
 // fullTableRowCap bounds the buffered resultset for the full-table
 // AS OF path (issue #276) so a query against a hot table with millions
-// of distinct PKs cannot OOM the shim. 100k rows × ~512 bytes per
-// row image ≈ 50 MB worst-case, which a forensic shim instance can
-// absorb. Exceeding the cap surfaces as ER_TOO_BIG_SELECT (1104) so
-// monitoring can distinguish it from a real shim crash; operators
-// narrow the AS OF range or fall back to PK-filtered queries.
+// of distinct PKs cannot OOM the shim. 100k rows at a rough estimate
+// of ~512 bytes per JSON row image ≈ 50 MB worst-case (k=1 archive
+// source — multi-archive deployments multiply the transient pre-merge
+// memory by the source count, but the post-merge enforcement still
+// caps the resultset). A forensic shim instance can absorb that;
+// exceeding it surfaces as ER_TOO_BIG_SELECT (1104) so monitoring
+// can distinguish it from a real shim crash, and operators narrow
+// the AS OF range or fall back to PK-filtered queries.
 //
 // Streaming the resultset (Conn.WriteFieldList + WriteRow per row,
 // removing the cap) is deferred per the scoping comment on #276;
 // cap+buffered is the bounded substitute for the MVP.
-const fullTableRowCap = 100_000
+//
+// Declared as a var rather than a const so unit tests can lower it
+// to seed the overflow path without materialising 100k rows. Not
+// part of the configurable surface — production callers must not
+// mutate it.
+var fullTableRowCap = 100_000
 
 // resolverCacheTTL bounds how long a stale schema_snapshots view
 // can serve column-ordering lookups. 30s is short enough that a
@@ -316,25 +324,30 @@ func wrapFetchError(qType QueryType, err error) error {
 // q.AsOf.
 //
 // Two shapes are recognised, sharing this entry point:
-//   - q.PKValue != "": single-row point-lookup. Returns the latest
+//   - q.PKColumn != "": single-row point-lookup. Returns the latest
 //     event's image (row_after for INSERT/UPDATE, row_before for
 //     DELETE — "last known state").
-//   - q.PKValue == "": full-table reconstruction (issue #276).
+//   - q.PKColumn == "": full-table reconstruction (issue #276).
 //     Dispatches to runFullTable.
+//
+// Dispatch is on PKColumn, not PKValue, so a literal `WHERE id = ''`
+// (legitimate against a NOT-NULL VARCHAR column) stays a single-row
+// point-lookup instead of silently flipping to a 100k-row table scan.
 //
 // The DELETE semantics intentionally diverge between the two paths:
 // point-lookup keeps the DELETE's row_before so a forensic operator
 // asking "what was this row?" gets an answer even past its deletion;
 // full-table SKIPS DELETEs because the row didn't exist at AS OF
 // and its presence in a `SELECT *` resultset would be wrong. The
-// split is load-bearing — see TestSelectImagePinsDeleteSemantics.
+// split is load-bearing — see TestSelectImage and
+// TestExtractFullTableImagesPinsDivergence.
 //
 // _flashback and _snapshot share this implementation today. _snapshot
 // is intended to grow baseline-lookup support (querying the
 // dump/baseline pipeline for rows that never appeared in binlog
 // events) — that's a future iteration.
 func (h *Handler) runPointInTime(q TimeTravelQuery) (*mysql.Result, error) {
-	if q.PKValue == "" {
+	if q.PKColumn == "" {
 		return h.runFullTable(q)
 	}
 
@@ -452,15 +465,40 @@ func extractFullTableImages(rows []query.ResultRow) []map[string]any {
 }
 
 // imagesToResult is the multi-row sibling of imageToResult. The
-// column list is computed once for the whole resultset (from the
-// first non-empty image and ddlOrder) so every row in the wire
-// resultset has the same shape, with NULLs where a row's image is
-// missing a column. Empty input → empty resultset.
+// column list is computed once for the whole resultset so every row
+// in the wire resultset has the same shape, with NULL where a row's
+// image is missing a column.
+//
+// Column selection is snapshot-driven when possible: ddlOrder (taken
+// from the latest schema_snapshots row) is used verbatim when
+// present, even if no image carries every column — missing values
+// become NULL on the wire, matching how MySQL itself returns rows
+// from a table that was ALTER'd to add a column. When ddlOrder is
+// empty (first install before any `bintrail snapshot`), we fall
+// back to the *union* of every image's keys (sorted) — using the
+// first image alone would silently elide columns that appeared
+// only in later events of the same query.
+//
+// Empty input → empty resultset.
 func imagesToResult(images []map[string]any, ddlOrder []string) (*mysql.Result, error) {
 	if len(images) == 0 {
 		return emptyResult(), nil
 	}
-	cols := orderColumns(images[0], ddlOrder)
+
+	cols := ddlOrder
+	if len(cols) == 0 {
+		seen := make(map[string]struct{})
+		for _, img := range images {
+			for k := range img {
+				seen[k] = struct{}{}
+			}
+		}
+		cols = make([]string, 0, len(seen))
+		for k := range seen {
+			cols = append(cols, k)
+		}
+		sort.Strings(cols)
+	}
 
 	values := make([][]any, len(images))
 	for i, img := range images {

--- a/internal/shim/handler.go
+++ b/internal/shim/handler.go
@@ -21,6 +21,19 @@ import (
 	"github.com/dbtrail/bintrail/internal/query"
 )
 
+// fullTableRowCap bounds the buffered resultset for the full-table
+// AS OF path (issue #276) so a query against a hot table with millions
+// of distinct PKs cannot OOM the shim. 100k rows × ~512 bytes per
+// row image ≈ 50 MB worst-case, which a forensic shim instance can
+// absorb. Exceeding the cap surfaces as ER_TOO_BIG_SELECT (1104) so
+// monitoring can distinguish it from a real shim crash; operators
+// narrow the AS OF range or fall back to PK-filtered queries.
+//
+// Streaming the resultset (Conn.WriteFieldList + WriteRow per row,
+// removing the cap) is deferred per the scoping comment on #276;
+// cap+buffered is the bounded substitute for the MVP.
+const fullTableRowCap = 100_000
+
 // resolverCacheTTL bounds how long a stale schema_snapshots view
 // can serve column-ordering lookups. 30s is short enough that a
 // fresh `bintrail snapshot` is visible within ops-monitoring time
@@ -302,19 +315,29 @@ func wrapFetchError(qType QueryType, err error) error {
 // the bintrail index + archives and reconstructs the row's state at
 // q.AsOf.
 //
-// Semantics: returns the row_after of the most recent event for that
-// PK at-or-before q.AsOf. That's the right answer for INSERT/UPDATE
-// (the post-image is the row's state). For a DELETE, we fall back to
-// the DELETE's row_before — the row's state captured at the moment
-// of deletion. A future revision could distinguish "row didn't exist
-// at AsOf" from "row was just deleted" using event_type, but the
-// MVP treats both as "here's the most recent known state".
+// Two shapes are recognised, sharing this entry point:
+//   - q.PKValue != "": single-row point-lookup. Returns the latest
+//     event's image (row_after for INSERT/UPDATE, row_before for
+//     DELETE — "last known state").
+//   - q.PKValue == "": full-table reconstruction (issue #276).
+//     Dispatches to runFullTable.
+//
+// The DELETE semantics intentionally diverge between the two paths:
+// point-lookup keeps the DELETE's row_before so a forensic operator
+// asking "what was this row?" gets an answer even past its deletion;
+// full-table SKIPS DELETEs because the row didn't exist at AS OF
+// and its presence in a `SELECT *` resultset would be wrong. The
+// split is load-bearing — see TestSelectImagePinsDeleteSemantics.
 //
 // _flashback and _snapshot share this implementation today. _snapshot
 // is intended to grow baseline-lookup support (querying the
 // dump/baseline pipeline for rows that never appeared in binlog
 // events) — that's a future iteration.
 func (h *Handler) runPointInTime(q TimeTravelQuery) (*mysql.Result, error) {
+	if q.PKValue == "" {
+		return h.runFullTable(q)
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -348,6 +371,111 @@ func (h *Handler) runPointInTime(q TimeTravelQuery) (*mysql.Result, error) {
 		return emptyResult(), nil
 	}
 	return imageToResult(image, h.columnOrderFor(q.Schema, q.Table))
+}
+
+// runFullTable reconstructs the full row state of a table at q.AsOf
+// (issue #276). The SQL it issues is identical to the point-lookup
+// path — query.Engine with LimitPerPK=1 and Until=q.AsOf — except
+// PKValues is empty so the windowed query returns the latest event
+// per PK across the whole table.
+//
+// DELETE handling diverges from the point-lookup path: rows whose
+// latest event is a DELETE are SKIPPED because the row did not exist
+// at q.AsOf. Including them in a `SELECT *` resultset would be
+// indistinguishable from rows that did exist, breaking the
+// "AS OF returns the table's state at that instant" contract.
+//
+// Cost guardrail: queries are capped at fullTableRowCap rows. We
+// fetch one extra row (cap+1) so the overflow is detectable; if the
+// cap is exceeded we return ER_TOO_BIG_SELECT (1104). Operators
+// narrow the AS OF range or fall back to PK-filtered queries.
+//
+// Cross-row column handling: column order is taken from the latest
+// schema_snapshots row (same DDL order as point-lookup and _diff).
+// Rows whose images carry columns missing from that snapshot get
+// those columns dropped — same behaviour as a regular MySQL
+// `SELECT *` after an ALTER TABLE that removed a column.
+func (h *Handler) runFullTable(q TimeTravelQuery) (*mysql.Result, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	engine := query.New(h.indexDB)
+	rows, _, err := query.FetchMerged(ctx, h.indexDB, engine, query.FetchMergedOptions{
+		Opts: query.Options{
+			Schema:     q.Schema,
+			Table:      q.Table,
+			Until:      &q.AsOf,
+			LimitPerPK: 1,
+			Limit:      fullTableRowCap + 1,
+		},
+		DBName:         h.cfg.IndexDBName,
+		NoArchive:      h.cfg.NoArchive,
+		AllowGaps:      h.cfg.AllowGaps,
+		ArchiveFetcher: h.archiveFetcher,
+	})
+	if err != nil {
+		return nil, wrapFetchError(q.Type, err)
+	}
+
+	if len(rows) > fullTableRowCap {
+		return nil, mysql.NewError(mysql.ER_TOO_BIG_SELECT, fmt.Sprintf(
+			"resolve %s: %s.%s at %s would return more than %d rows; narrow the AS OF range or filter by PK",
+			q.Type, q.Schema, q.Table, q.AsOf.Format("2006-01-02 15:04:05"), fullTableRowCap,
+		))
+	}
+
+	return imagesToResult(extractFullTableImages(rows), h.columnOrderFor(q.Schema, q.Table))
+}
+
+// extractFullTableImages picks the post-image of every non-DELETE
+// event in rows. The DELETE skip is what makes full-table
+// reconstruction's contract (rows that existed at AS OF) diverge from
+// selectImage's contract (last known state, including the row_before
+// of a DELETE). The two contracts are intentionally different — see
+// TestSelectImage and TestExtractFullTableImagesPinsDivergence for
+// the regression tripwires.
+func extractFullTableImages(rows []query.ResultRow) []map[string]any {
+	images := make([]map[string]any, 0, len(rows))
+	for _, r := range rows {
+		if r.EventType == parser.EventDelete {
+			continue
+		}
+		// Empty row_after (rare — corrupted index) is dropped silently
+		// rather than emitting a row of nulls that would overstate the
+		// table's row count.
+		if len(r.RowAfter) == 0 {
+			continue
+		}
+		images = append(images, r.RowAfter)
+	}
+	return images
+}
+
+// imagesToResult is the multi-row sibling of imageToResult. The
+// column list is computed once for the whole resultset (from the
+// first non-empty image and ddlOrder) so every row in the wire
+// resultset has the same shape, with NULLs where a row's image is
+// missing a column. Empty input → empty resultset.
+func imagesToResult(images []map[string]any, ddlOrder []string) (*mysql.Result, error) {
+	if len(images) == 0 {
+		return emptyResult(), nil
+	}
+	cols := orderColumns(images[0], ddlOrder)
+
+	values := make([][]any, len(images))
+	for i, img := range images {
+		row := make([]any, len(cols))
+		for j, c := range cols {
+			row[j] = img[c]
+		}
+		values[i] = row
+	}
+
+	rs, err := mysql.BuildSimpleTextResultset(cols, values)
+	if err != nil {
+		return nil, fmt.Errorf("build resultset: %w", err)
+	}
+	return &mysql.Result{Resultset: rs}, nil
 }
 
 // columnOrderFor returns the column names of schema.table in DDL

--- a/internal/shim/handler_test.go
+++ b/internal/shim/handler_test.go
@@ -561,50 +561,122 @@ func TestExtractFullTableImagesPinsDivergence(t *testing.T) {
 	}
 }
 
-// TestRunPointInTimeDispatchesOnPKColumnNotPKValue pins the fix for
-// the empty-string PK collision: `WHERE id = ''` is a legitimate
-// single-row query against a NOT-NULL VARCHAR column with empty
-// default, and dispatching on q.PKValue would silently flip it into
-// a 100k-row table scan. Dispatch must use q.PKColumn instead.
+// TestRunPointInTimeDispatchesByPKColumn pins the fix for the empty-
+// string PK collision: `WHERE id = ''` is a legitimate single-row
+// query against a NOT-NULL VARCHAR with empty default, and a dispatch
+// on q.PKValue would silently flip it into a 100k-row table scan.
 //
-// Without a real DB we can't run runPointInTime end-to-end, but we
-// can pin the dispatch contract: a TimeTravelQuery with PKColumn
-// set and PKValue empty must be classified as point-lookup, not
-// full-table. The test builds the same TimeTravelQuery shapes the
-// parser produces and asserts the dispatch path via a probe handler
-// whose runFullTable replacement would only be reached on the wrong
-// branch.
-func TestRunPointInTimeDispatchesOnPKColumnNotPKValue(t *testing.T) {
-	cases := []struct {
-		name     string
-		q        TimeTravelQuery
-		fullPath bool
-	}{
-		{
-			name: "no_where_dispatches_full_table",
-			q:    TimeTravelQuery{Type: TypeFlashback, Schema: "myapp", Table: "orders", PKColumn: "", PKValue: ""},
-			fullPath: true,
-		},
-		{
-			name: "where_with_empty_string_pk_stays_point_lookup",
-			q:    TimeTravelQuery{Type: TypeFlashback, Schema: "myapp", Table: "orders", PKColumn: "id", PKValue: ""},
-			fullPath: false,
-		},
-		{
-			name: "where_with_nonempty_pk_stays_point_lookup",
-			q:    TimeTravelQuery{Type: TypeFlashback, Schema: "myapp", Table: "orders", PKColumn: "id", PKValue: "42"},
-			fullPath: false,
-		},
+// The previous version of this test re-implemented `q.PKColumn == ""`
+// inline and asserted the predicate against itself — a tautology that
+// would still pass even if runPointInTime ignored its argument
+// entirely. This rewrite drives runPointInTime through sqlmock and
+// observes which SQL pattern reaches the index DB, which is the
+// only thing that proves the dispatch is correct.
+//
+// Path detection:
+//   - Point-lookup SQL contains `pk_hash = SHA2` (the hash + value
+//     guard the SQL builder emits when Options.PKValues != "").
+//   - Full-table SQL omits that filter entirely. We detect it via
+//     the cost-cap behavioural signature: only runFullTable performs
+//     the >cap check, so seeding cap+1 rows surfaces 1104 iff
+//     dispatch reached runFullTable.
+func TestRunPointInTimeDispatchesByPKColumn(t *testing.T) {
+	t.Run("PKColumn_set_runs_point_lookup_sql", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+		mock.MatchExpectationsInOrder(false)
+		mock.ExpectQuery("information_schema.PARTITIONS").
+			WillReturnRows(sqlmock.NewRows([]string{"PARTITION_NAME", "PARTITION_DESCRIPTION"}))
+		// Anchor on `pk_hash = SHA2` — unique to the point-lookup SQL.
+		// If runPointInTime wrongly dispatched to runFullTable, the
+		// emitted SQL would lack pk_hash and ExpectationsWereMet would
+		// fail with "expected query was not matched".
+		mock.ExpectQuery("pk_hash = SHA2").
+			WillReturnRows(emptyBinlogEventsRows())
+
+		h := &Handler{
+			indexDB: db,
+			cfg:     Config{AllowGaps: true, IndexDBName: "bintrail_index", NoArchive: true},
+			logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+			archiveFetcher: func(ctx context.Context, _ query.Options, _ string) ([]query.ResultRow, error) {
+				return nil, nil
+			},
+		}
+		h.UseDB("myapp")
+
+		q := TimeTravelQuery{Type: TypeFlashback, Schema: "myapp", Table: "orders",
+			PKColumn: "id", PKValue: "42", AsOf: time.Now().UTC()}
+		_, _ = h.runPointInTime(q) // result irrelevant; mock matching is the assertion
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Errorf("expected point-lookup SQL with pk_hash filter; got: %v", err)
+		}
+	})
+
+	t.Run("empty_PKColumn_dispatches_to_full_table", func(t *testing.T) {
+		// Behavioural proof of dispatch: only runFullTable performs
+		// the cap check. Lower the cap to 1 via Config (no global
+		// state), seed 2 rows, expect ER_TOO_BIG_SELECT. If
+		// runPointInTime stayed on the point-lookup branch despite
+		// PKColumn="", no cap check would fire and the test would
+		// fail loud.
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+		mock.MatchExpectationsInOrder(false)
+		mock.ExpectQuery("information_schema.PARTITIONS").
+			WillReturnRows(sqlmock.NewRows([]string{"PARTITION_NAME", "PARTITION_DESCRIPTION"}))
+		rows := sqlmock.NewRows(binlogEventsColumns())
+		now := time.Now().UTC()
+		for i := 0; i < 2; i++ {
+			rows.AddRow(int64(i+1), "binlog.000001", int64(100), int64(200), now,
+				nil, nil, "myapp", "orders", parser.EventInsert,
+				fmt.Sprintf("%d", i+1), nil, nil,
+				fmt.Sprintf(`{"id":%d,"sku":"X"}`, i+1), 0)
+		}
+		mock.ExpectQuery("FROM binlog_events").WillReturnRows(rows)
+
+		h := &Handler{
+			indexDB: db,
+			cfg: Config{AllowGaps: true, IndexDBName: "bintrail_index",
+				NoArchive: true, FullTableRowCap: 1},
+			logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+			archiveFetcher: func(ctx context.Context, _ query.Options, _ string) ([]query.ResultRow, error) {
+				return nil, nil
+			},
+		}
+		h.UseDB("myapp")
+
+		q := TimeTravelQuery{Type: TypeFlashback, Schema: "myapp", Table: "orders",
+			AsOf: now} // PKColumn / PKValue both empty
+		_, err = h.runPointInTime(q)
+		if err == nil {
+			t.Fatal("expected ER_TOO_BIG_SELECT (proves dispatch reached runFullTable); got nil")
+		}
+		var myErr *gomysql.MyError
+		if !errors.As(err, &myErr) || myErr.Code != gomysql.ER_TOO_BIG_SELECT {
+			t.Errorf("expected ER_TOO_BIG_SELECT (1104), got %v", err)
+		}
+	})
+}
+
+// binlogEventsColumns is the column list scanned by query.Engine.Fetch.
+// Extracted so the cap-overflow tests don't duplicate the literal.
+func binlogEventsColumns() []string {
+	return []string{
+		"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp",
+		"gtid", "connection_id", "schema_name", "table_name", "event_type",
+		"pk_values", "changed_columns", "row_before", "row_after", "schema_version",
 	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			isFull := tc.q.PKColumn == ""
-			if isFull != tc.fullPath {
-				t.Errorf("dispatch on PKColumn=%q PKValue=%q → fullPath=%v, want %v",
-					tc.q.PKColumn, tc.q.PKValue, isFull, tc.fullPath)
-			}
-		})
-	}
+}
+
+// emptyBinlogEventsRows is the empty-resultset stub for query.Engine.Fetch.
+func emptyBinlogEventsRows() *sqlmock.Rows {
+	return sqlmock.NewRows(binlogEventsColumns())
 }
 
 // TestImagesToResultColumnsFromUnionWhenNoDDLOrder pins the union-
@@ -1193,20 +1265,22 @@ func TestRunPointInTimeInvokesArchiveFetcher(t *testing.T) {
 }
 
 // TestRunFullTableEnforcesCostCap exercises the load-bearing OOM
-// guardrail: when FetchMerged returns more rows than fullTableRowCap,
-// runFullTable must surface ER_TOO_BIG_SELECT (1104) on the wire,
-// not silently truncate (which would hand the customer a partial,
-// unverifiable resultset) and not crash. The cap is a `var` (not a
-// const) precisely so this test can lower it to seed the overflow
-// path without materialising 100k rows.
+// guardrail: when FetchMerged returns more rows than the configured
+// cap, runFullTable must surface ER_TOO_BIG_SELECT (1104) on the
+// wire, not silently truncate (which would hand the customer a
+// partial, unverifiable resultset) and not crash.
+//
+// The cap is configured per-Handler via Config.FullTableRowCap so
+// this test can lower it to 3 on a local Handler instance without
+// touching a global var — that keeps the test parallel-safe and
+// matches the production path (a future per-tenant override would
+// flow through the same field).
 //
 // A regression that drops the +1 sentinel on Limit (e.g. `Limit:
-// fullTableRowCap` without the +1) silently turns the cap into
-// "exactly cap rows accepted, no error." This test catches that.
+// cap` without the +1) silently turns the cap into "exactly cap
+// rows accepted, no error." This test catches that.
 func TestRunFullTableEnforcesCostCap(t *testing.T) {
-	prevCap := fullTableRowCap
-	fullTableRowCap = 3
-	t.Cleanup(func() { fullTableRowCap = prevCap })
+	const testCap = 3
 
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -1227,13 +1301,9 @@ func TestRunFullTableEnforcesCostCap(t *testing.T) {
 	// the scan path produces a non-DELETE non-empty image — ensures
 	// extractFullTableImages doesn't filter them out before the cap
 	// check sees them.
-	rows := sqlmock.NewRows([]string{
-		"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp",
-		"gtid", "connection_id", "schema_name", "table_name", "event_type",
-		"pk_values", "changed_columns", "row_before", "row_after", "schema_version",
-	})
+	rows := sqlmock.NewRows(binlogEventsColumns())
 	now := time.Now().UTC()
-	for i := 0; i < fullTableRowCap+1; i++ {
+	for i := 0; i < testCap+1; i++ {
 		rows.AddRow(
 			int64(i+1), "binlog.000001", int64(100), int64(200), now,
 			nil, nil, "myapp", "orders", parser.EventInsert,
@@ -1245,8 +1315,9 @@ func TestRunFullTableEnforcesCostCap(t *testing.T) {
 
 	h := &Handler{
 		indexDB: db,
-		cfg:     Config{AllowGaps: true, IndexDBName: "bintrail_index", NoArchive: true},
-		logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+		cfg: Config{AllowGaps: true, IndexDBName: "bintrail_index",
+			NoArchive: true, FullTableRowCap: testCap},
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
 		archiveFetcher: func(ctx context.Context, _ query.Options, _ string) ([]query.ResultRow, error) {
 			return nil, nil
 		},

--- a/internal/shim/handler_test.go
+++ b/internal/shim/handler_test.go
@@ -517,6 +517,110 @@ func TestSelectImage(t *testing.T) {
 	}
 }
 
+// TestExtractFullTableImagesPinsDivergence locks in the contract
+// divergence between full-table reconstruction (#276) and the existing
+// point-lookup path. Given the SAME DELETE event:
+//   - selectImage returns the row_before — the row's last known state.
+//   - extractFullTableImages skips it — the row didn't exist at AS OF.
+//
+// A future refactor that "unifies" the two paths would silently break
+// either point-lookup forensics or full-table correctness. Pinning
+// both behaviors against the same input here turns that into a loud
+// test failure.
+func TestExtractFullTableImagesPinsDivergence(t *testing.T) {
+	deleteRow := query.ResultRow{
+		EventType: parser.EventDelete,
+		RowBefore: map[string]any{"id": int64(1), "qty": int64(5)},
+	}
+	insertRow := query.ResultRow{
+		EventType: parser.EventInsert,
+		RowAfter:  map[string]any{"id": int64(2), "qty": int64(7)},
+	}
+
+	if got := selectImage([]query.ResultRow{deleteRow}); got == nil {
+		t.Errorf("selectImage([DELETE]) must keep row_before for point-lookup; got nil")
+	}
+	if got := extractFullTableImages([]query.ResultRow{deleteRow}); len(got) != 0 {
+		t.Errorf("extractFullTableImages([DELETE]) must skip the row; got %v", got)
+	}
+
+	mixed := []query.ResultRow{insertRow, deleteRow, insertRow}
+	images := extractFullTableImages(mixed)
+	if len(images) != 2 {
+		t.Errorf("extractFullTableImages: DELETE must be skipped, kept rows = %d, want 2", len(images))
+	}
+}
+
+// TestImagesToResultBuildsResultset covers the multi-row resultset
+// builder added for #276. The single-row imageToResult path is
+// covered by TestImageToResultColumnOrder / TestImageToResultRespectsDDLOrder.
+func TestImagesToResultBuildsResultset(t *testing.T) {
+	cases := []struct {
+		name     string
+		images   []map[string]any
+		ddlOrder []string
+		wantRows int
+		wantCols []string
+	}{
+		{
+			name:     "empty_input_returns_empty_resultset",
+			images:   nil,
+			wantRows: 0,
+			wantCols: []string{"_flashback"},
+		},
+		{
+			name:     "single_row_uses_ddl_order",
+			images:   []map[string]any{{"id": 1, "sku": "ABC", "qty": 3}},
+			ddlOrder: []string{"id", "sku", "qty"},
+			wantRows: 1,
+			wantCols: []string{"id", "sku", "qty"},
+		},
+		{
+			name: "multi_row_uses_first_image_for_columns",
+			images: []map[string]any{
+				{"id": 1, "sku": "A", "qty": 1},
+				{"id": 2, "sku": "B", "qty": 2},
+				{"id": 3, "sku": "C", "qty": 3},
+			},
+			ddlOrder: []string{"id", "sku", "qty"},
+			wantRows: 3,
+			wantCols: []string{"id", "sku", "qty"},
+		},
+		{
+			// A row missing a column known to ddlOrder gets a NULL
+			// in that position rather than failing the whole query —
+			// this mirrors how MySQL itself handles a column added
+			// after some rows already existed.
+			name: "row_missing_column_yields_null",
+			images: []map[string]any{
+				{"id": 1, "sku": "A", "qty": 1},
+				{"id": 2, "sku": "B"},
+			},
+			ddlOrder: []string{"id", "sku", "qty"},
+			wantRows: 2,
+			wantCols: []string{"id", "sku", "qty"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := imagesToResult(tc.images, tc.ddlOrder)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := len(res.Resultset.RowDatas); got != tc.wantRows {
+				t.Errorf("rows = %d, want %d", got, tc.wantRows)
+			}
+			gotCols := make([]string, len(res.Resultset.Fields))
+			for i, f := range res.Resultset.Fields {
+				gotCols[i] = string(f.Name)
+			}
+			if !slices.Equal(gotCols, tc.wantCols) {
+				t.Errorf("cols = %v, want %v", gotCols, tc.wantCols)
+			}
+		})
+	}
+}
+
 // TestImageToResultEmpty — an empty image (zero-key map) should
 // produce a resultset with no rows.
 func TestImageToResultEmpty(t *testing.T) {

--- a/internal/shim/handler_test.go
+++ b/internal/shim/handler_test.go
@@ -536,6 +536,13 @@ func TestExtractFullTableImagesPinsDivergence(t *testing.T) {
 		EventType: parser.EventInsert,
 		RowAfter:  map[string]any{"id": int64(2), "qty": int64(7)},
 	}
+	// Empty row_after is the "rare — corrupted index" branch. Drop
+	// it so the resultset doesn't overstate the row count with an
+	// all-null phantom row.
+	emptyAfterRow := query.ResultRow{
+		EventType: parser.EventInsert,
+		RowAfter:  nil,
+	}
 
 	if got := selectImage([]query.ResultRow{deleteRow}); got == nil {
 		t.Errorf("selectImage([DELETE]) must keep row_before for point-lookup; got nil")
@@ -543,11 +550,109 @@ func TestExtractFullTableImagesPinsDivergence(t *testing.T) {
 	if got := extractFullTableImages([]query.ResultRow{deleteRow}); len(got) != 0 {
 		t.Errorf("extractFullTableImages([DELETE]) must skip the row; got %v", got)
 	}
+	if got := extractFullTableImages([]query.ResultRow{emptyAfterRow}); len(got) != 0 {
+		t.Errorf("extractFullTableImages([INSERT with empty row_after]) must skip the row; got %v", got)
+	}
 
-	mixed := []query.ResultRow{insertRow, deleteRow, insertRow}
+	mixed := []query.ResultRow{insertRow, deleteRow, emptyAfterRow, insertRow}
 	images := extractFullTableImages(mixed)
 	if len(images) != 2 {
-		t.Errorf("extractFullTableImages: DELETE must be skipped, kept rows = %d, want 2", len(images))
+		t.Errorf("extractFullTableImages: DELETE + empty_after must both be skipped, kept rows = %d, want 2", len(images))
+	}
+}
+
+// TestRunPointInTimeDispatchesOnPKColumnNotPKValue pins the fix for
+// the empty-string PK collision: `WHERE id = ''` is a legitimate
+// single-row query against a NOT-NULL VARCHAR column with empty
+// default, and dispatching on q.PKValue would silently flip it into
+// a 100k-row table scan. Dispatch must use q.PKColumn instead.
+//
+// Without a real DB we can't run runPointInTime end-to-end, but we
+// can pin the dispatch contract: a TimeTravelQuery with PKColumn
+// set and PKValue empty must be classified as point-lookup, not
+// full-table. The test builds the same TimeTravelQuery shapes the
+// parser produces and asserts the dispatch path via a probe handler
+// whose runFullTable replacement would only be reached on the wrong
+// branch.
+func TestRunPointInTimeDispatchesOnPKColumnNotPKValue(t *testing.T) {
+	cases := []struct {
+		name     string
+		q        TimeTravelQuery
+		fullPath bool
+	}{
+		{
+			name: "no_where_dispatches_full_table",
+			q:    TimeTravelQuery{Type: TypeFlashback, Schema: "myapp", Table: "orders", PKColumn: "", PKValue: ""},
+			fullPath: true,
+		},
+		{
+			name: "where_with_empty_string_pk_stays_point_lookup",
+			q:    TimeTravelQuery{Type: TypeFlashback, Schema: "myapp", Table: "orders", PKColumn: "id", PKValue: ""},
+			fullPath: false,
+		},
+		{
+			name: "where_with_nonempty_pk_stays_point_lookup",
+			q:    TimeTravelQuery{Type: TypeFlashback, Schema: "myapp", Table: "orders", PKColumn: "id", PKValue: "42"},
+			fullPath: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			isFull := tc.q.PKColumn == ""
+			if isFull != tc.fullPath {
+				t.Errorf("dispatch on PKColumn=%q PKValue=%q → fullPath=%v, want %v",
+					tc.q.PKColumn, tc.q.PKValue, isFull, tc.fullPath)
+			}
+		})
+	}
+}
+
+// TestImagesToResultColumnsFromUnionWhenNoDDLOrder pins the union-
+// across-images behavior for the no-snapshot fallback. Using only
+// images[0]'s keys would silently drop a column added by a later
+// event in the same query (e.g. a row captured pre-ALTER followed
+// by a row captured post-ALTER).
+func TestImagesToResultColumnsFromUnionWhenNoDDLOrder(t *testing.T) {
+	images := []map[string]any{
+		{"id": 1, "sku": "A"},                           // pre-ALTER
+		{"id": 2, "sku": "B", "added_after_alter": "X"}, // post-ALTER
+	}
+	res, err := imagesToResult(images, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotCols := make([]string, len(res.Resultset.Fields))
+	for i, f := range res.Resultset.Fields {
+		gotCols[i] = string(f.Name)
+	}
+	wantCols := []string{"added_after_alter", "id", "sku"}
+	if !slices.Equal(gotCols, wantCols) {
+		t.Errorf("cols = %v, want %v (no-ddlOrder fallback must union image keys, "+
+			"not pick from images[0])", gotCols, wantCols)
+	}
+}
+
+// TestImagesToResultDDLOrderStrictWhenSnapshotPresent pins the
+// snapshot-driven semantic the docstring describes: when ddlOrder is
+// supplied, every column in it appears in the resultset even if no
+// image carries it (NULL on the wire). A future refactor that
+// reverted to "intersect ddlOrder with images[0] keys" would silently
+// elide post-ALTER columns from queries that span the ALTER.
+func TestImagesToResultDDLOrderStrictWhenSnapshotPresent(t *testing.T) {
+	images := []map[string]any{
+		{"id": 1, "sku": "A"}, // missing the post-ALTER column
+	}
+	ddlOrder := []string{"id", "sku", "qty", "note"}
+	res, err := imagesToResult(images, ddlOrder)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotCols := make([]string, len(res.Resultset.Fields))
+	for i, f := range res.Resultset.Fields {
+		gotCols[i] = string(f.Name)
+	}
+	if !slices.Equal(gotCols, ddlOrder) {
+		t.Errorf("cols = %v, want %v (ddlOrder must be honored verbatim)", gotCols, ddlOrder)
 	}
 }
 
@@ -1084,6 +1189,89 @@ func TestRunPointInTimeInvokesArchiveFetcher(t *testing.T) {
 	}
 	if !called {
 		t.Error("expected archiveFetcher to be invoked when archive_state has rows; was not called")
+	}
+}
+
+// TestRunFullTableEnforcesCostCap exercises the load-bearing OOM
+// guardrail: when FetchMerged returns more rows than fullTableRowCap,
+// runFullTable must surface ER_TOO_BIG_SELECT (1104) on the wire,
+// not silently truncate (which would hand the customer a partial,
+// unverifiable resultset) and not crash. The cap is a `var` (not a
+// const) precisely so this test can lower it to seed the overflow
+// path without materialising 100k rows.
+//
+// A regression that drops the +1 sentinel on Limit (e.g. `Limit:
+// fullTableRowCap` without the +1) silently turns the cap into
+// "exactly cap rows accepted, no error." This test catches that.
+func TestRunFullTableEnforcesCostCap(t *testing.T) {
+	prevCap := fullTableRowCap
+	fullTableRowCap = 3
+	t.Cleanup(func() { fullTableRowCap = prevCap })
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	// Planner queries information_schema.PARTITIONS; stub empty so
+	// the planner returns nil. AllowGaps=true below disables strict
+	// gap enforcement so the planner-empty path doesn't short-circuit
+	// with a *GapError before runFullTable gets a chance to evaluate
+	// the cap.
+	mock.MatchExpectationsInOrder(false)
+	mock.ExpectQuery("information_schema.PARTITIONS").
+		WillReturnRows(sqlmock.NewRows([]string{"PARTITION_NAME", "PARTITION_DESCRIPTION"}))
+
+	// Return cap+1 binlog_events rows. row_after is a JSON image so
+	// the scan path produces a non-DELETE non-empty image — ensures
+	// extractFullTableImages doesn't filter them out before the cap
+	// check sees them.
+	rows := sqlmock.NewRows([]string{
+		"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp",
+		"gtid", "connection_id", "schema_name", "table_name", "event_type",
+		"pk_values", "changed_columns", "row_before", "row_after", "schema_version",
+	})
+	now := time.Now().UTC()
+	for i := 0; i < fullTableRowCap+1; i++ {
+		rows.AddRow(
+			int64(i+1), "binlog.000001", int64(100), int64(200), now,
+			nil, nil, "myapp", "orders", parser.EventInsert,
+			fmt.Sprintf("%d", i+1), nil, nil,
+			fmt.Sprintf(`{"id":%d,"sku":"X"}`, i+1), 0,
+		)
+	}
+	mock.ExpectQuery("FROM binlog_events").WillReturnRows(rows)
+
+	h := &Handler{
+		indexDB: db,
+		cfg:     Config{AllowGaps: true, IndexDBName: "bintrail_index", NoArchive: true},
+		logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+		archiveFetcher: func(ctx context.Context, _ query.Options, _ string) ([]query.ResultRow, error) {
+			return nil, nil
+		},
+	}
+	h.UseDB("myapp")
+
+	q := TimeTravelQuery{
+		Type:   TypeFlashback,
+		Schema: "myapp",
+		Table:  "orders",
+		AsOf:   now,
+		// PKColumn deliberately empty — that's how runPointInTime
+		// dispatches into runFullTable.
+	}
+	_, err = h.runFullTable(q)
+	if err == nil {
+		t.Fatal("expected ER_TOO_BIG_SELECT for rows > cap; got nil")
+	}
+	var myErr *gomysql.MyError
+	if !errors.As(err, &myErr) {
+		t.Fatalf("expected *mysql.MyError, got %T: %v", err, err)
+	}
+	if myErr.Code != gomysql.ER_TOO_BIG_SELECT {
+		t.Errorf("wire code = %d, want %d (ER_TOO_BIG_SELECT, msg=%q)",
+			myErr.Code, gomysql.ER_TOO_BIG_SELECT, myErr.Message)
 	}
 }
 

--- a/internal/shim/parser.go
+++ b/internal/shim/parser.go
@@ -73,17 +73,34 @@ type TimeTravelQuery struct {
 
 var (
 	// flashbackRE / snapshotRE share the same shape; they differ only
-	// in the schema-prefix literal.
-	flashbackRE = mustCompileTT(`_flashback`, `\s+AS\s+OF\s+'([^']+)'`)
-	snapshotRE  = mustCompileTT(`_snapshot`, `\s+AS\s+OF\s+'([^']+)'`)
-	diffRE      = mustCompileTT(`_diff`, `\s+BETWEEN\s+'([^']+)'\s+AND\s+'([^']+)'`)
+	// in the schema-prefix literal. WHERE is optional for AS OF queries
+	// (full-table reconstruction, issue #276); the _diff path keeps it
+	// mandatory because a PK-less _diff against a hot row would be a
+	// DoS in a wire-protocol response.
+	flashbackRE = mustCompileAsOf(`_flashback`)
+	snapshotRE  = mustCompileAsOf(`_snapshot`)
+	diffRE      = mustCompileDiff()
 )
 
-func mustCompileTT(schemaPrefix, timeClause string) *regexp.Regexp {
-	pattern := `(?i)^\s*SELECT\s+\*\s+FROM\s+` + schemaPrefix + `\.([A-Za-z_][A-Za-z0-9_]*)` +
-		timeClause +
-		`\s+WHERE\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*('[^']*'|-?\d+)\s*;?\s*$`
-	return regexp.MustCompile(pattern)
+// mustCompileAsOf builds a regex for `_flashback` / `_snapshot` shapes.
+// Capture groups: 1=table, 2=timestamp, 3=col (or empty), 4=value (or empty).
+// The trailing WHERE clause is in an optional non-capturing group so the
+// PK-filtered fast path and the full-table path go through the same matcher.
+func mustCompileAsOf(schemaPrefix string) *regexp.Regexp {
+	return regexp.MustCompile(
+		`(?i)^\s*SELECT\s+\*\s+FROM\s+` + schemaPrefix + `\.([A-Za-z_][A-Za-z0-9_]*)` +
+			`\s+AS\s+OF\s+'([^']+)'` +
+			`(?:\s+WHERE\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*('[^']*'|-?\d+))?` +
+			`\s*;?\s*$`,
+	)
+}
+
+func mustCompileDiff() *regexp.Regexp {
+	return regexp.MustCompile(
+		`(?i)^\s*SELECT\s+\*\s+FROM\s+_diff\.([A-Za-z_][A-Za-z0-9_]*)` +
+			`\s+BETWEEN\s+'([^']+)'\s+AND\s+'([^']+)'` +
+			`\s+WHERE\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*('[^']*'|-?\d+)\s*;?\s*$`,
+	)
 }
 
 // timeFormats are the formats accepted in time literals. Order

--- a/internal/shim/parser_test.go
+++ b/internal/shim/parser_test.go
@@ -31,7 +31,7 @@ func TestParseFlashbackHappyPath(t *testing.T) {
 
 // TestParseFlashbackFullTable pins the WHERE-less shape introduced
 // for full-table reconstruction (issue #276). The PK fields are empty
-// so the handler can dispatch on q.PKValue == "" without parsing the
+// so the handler can dispatch on q.PKColumn == "" without parsing the
 // SQL again.
 func TestParseFlashbackFullTable(t *testing.T) {
 	cases := []struct {

--- a/internal/shim/parser_test.go
+++ b/internal/shim/parser_test.go
@@ -29,6 +29,37 @@ func TestParseFlashbackHappyPath(t *testing.T) {
 	}
 }
 
+// TestParseFlashbackFullTable pins the WHERE-less shape introduced
+// for full-table reconstruction (issue #276). The PK fields are empty
+// so the handler can dispatch on q.PKValue == "" without parsing the
+// SQL again.
+func TestParseFlashbackFullTable(t *testing.T) {
+	cases := []struct {
+		name string
+		sql  string
+	}{
+		{"bare", "SELECT * FROM _flashback.orders AS OF '2026-05-02 10:00:00'"},
+		{"trailing_semicolon", "SELECT * FROM _flashback.orders AS OF '2026-05-02 10:00:00';"},
+		{"lower_case", "select * from _flashback.orders as of '2026-05-02 10:00:00'"},
+		{"snapshot_variant", "SELECT * FROM _snapshot.orders AS OF '2026-05-02 10:00:00'"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			q, err := Parse(tc.sql, "myapp")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if q.Table != "orders" {
+				t.Errorf("Table = %q, want %q", q.Table, "orders")
+			}
+			if q.PKColumn != "" || q.PKValue != "" {
+				t.Errorf("PKColumn/PKValue must be empty for full-table shape; got col=%q val=%q",
+					q.PKColumn, q.PKValue)
+			}
+		})
+	}
+}
+
 func TestParseFlashbackCaseInsensitive(t *testing.T) {
 	q, err := Parse(
 		"select * from _flashback.users as of '2026-01-01' where email = 'a@b.com'",


### PR DESCRIPTION
Closes #276.

## Summary

`SELECT * FROM _flashback.<table> AS OF '<ts>'` (no WHERE) now reconstructs the table's full row state at AS OF. Same for `_snapshot`. The PK-filtered point-lookup path is unchanged.

This closes the asterisk on the time-travel SQL marketing claim (Oracle's `AS OF` works on a bare `SELECT *`; bintrail's was point-lookup-only until now).

## Design choices

| Decision | Rationale |
|---|---|
| Reuse `query.FetchMerged` with `PKValues="" + LimitPerPK=1` | The SQL builder already produces exactly the windowed query the issue prescribed. No new SQL surface. |
| `runFullTable` as separate method on `Handler`, dispatched by `q.PKValue == ""` | Keeps the point-lookup path verbatim — Ockham, no rewrites. |
| Skip DELETEs in full-table; keep DELETE.row_before in point-lookup | Different contracts: full-table = "rows that existed at AS OF"; point-lookup = "last known state". Pinned in `TestExtractFullTableImagesPinsDivergence`. |
| Cap 100k rows → `ER_TOO_BIG_SELECT (1104)` | ≈50MB worst case, fits forensic deployments. Distinguishable on the wire from 1105 (crash), 1064 (syntax), 1526 (gap). |
| Streaming **deferred** | Per the scoping comment on #276. Cap+buffered is the bounded MVP; streaming when an OOM is reported. |
| Cross-row columns: `ddlOrder` strict, drop image keys not in snapshot | Matches MySQL's own `SELECT *` post-ALTER behavior. |

## Acceptance criteria

- [x] `SELECT * FROM _flashback.<table> AS OF '<ts>'` returns the table's full row state at `<ts>`
- [x] `SELECT * FROM _snapshot.<table> AS OF '<ts>'` returns the same
- [x] DELETE events correctly suppress the row (e2e: AS OF 15:00 → 0 rows after the 14:00 DELETE)
- [x] Column order matches DDL (e2e asserts `id, sku, qty, note`)
- [ ] Results stream rather than buffering — **deferred** per scoping comment; cap+buffered substitutes
- [x] New e2e subtest covers the path end-to-end
- [x] Cost-guardrail strategy documented (`fullTableRowCap` constant + comment)

## Risk: regex change

The change to `flashbackRE` / `snapshotRE` (making the `WHERE` clause optional) is the most fragile line in the diff. Verified by running `TestParse*` immediately after the regex edit — all existing point-lookup parser tests pass without modification.

One regression caught and fixed: `cmd/bintrail/shim_wire_test.go::TestShim_MalformedTimeTravelReturnsWireError/snapshot_missing_WHERE` previously expected `_snapshot ... AS OF ... ` (no WHERE) to be malformed. With #276 that's now valid. Replaced with `_snapshot ... WHERE ...` (no AS OF) to keep all three virtual schemas exercised in the wire-error path.

## Test plan

- [x] `go test -count=1 ./...` — full suite passes
- [x] `go vet -tags shim_e2e ./e2e/shim/` — clean
- [x] New unit tests:
  - `TestParseFlashbackFullTable` — 4 cases (bare, trailing semicolon, lower case, snapshot variant)
  - `TestExtractFullTableImagesPinsDivergence` — DELETE-skip vs DELETE-keep contracts pinned in the same file
  - `TestImagesToResultBuildsResultset` — 4 cases (empty, single-row, multi-row, missing-column NULL)
- [x] New e2e subtests (gated by `SHIM_E2E=1`):
  - `flashback_full_table_no_where_at_pre_delete` — AS OF 13:00 → 1 row, qty=2, DDL column order
  - `flashback_full_table_at_post_delete` — AS OF 15:00 → 0 rows
  - `flashback_full_table_at_pre_update` — AS OF 11:00 → 1 row, qty=1

## What this unblocks

PR #276's scoping comment closed #278 / #279 / #280 (secondary filters / JOINs / aggregations) on the premise that a user with `SELECT * FROM _flashback.t AS OF ...` can pipe to duckdb / pandas / awk for the rest. That premise now holds.