### PR TITLE
fix(cli): bintrail dump now includes mydumper stderr in error output

### DIFF
--- a/cmd/bintrail/dump.go
+++ b/cmd/bintrail/dump.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -236,11 +238,23 @@ func runDump(cmd *cobra.Command, args []string) error {
 		slog.Info("starting dump", "path", res.path, "output_dir", dmpOutputDir)
 	}
 
+	// Always capture stderr into a buffer so the error message can include
+	// the actual diagnostic — "exit status 1" by itself hides why mydumper
+	// failed (auth plugin mismatch, missing privilege, full disk, etc.).
+	// In text mode we ALSO passthrough to the user's terminal so they see
+	// progress live; in JSON mode the caller is parsing stdout so we keep
+	// stderr buffered only.
+	var stderrBuf bytes.Buffer
 	if dmpFormat != "json" {
 		c.Stdout = os.Stdout
-		c.Stderr = os.Stderr
+		c.Stderr = io.MultiWriter(os.Stderr, &stderrBuf)
+	} else {
+		c.Stderr = &stderrBuf
 	}
 	if runErr := c.Run(); runErr != nil {
+		if stderr := strings.TrimSpace(stderrBuf.String()); stderr != "" {
+			return fmt.Errorf("mydumper failed: %w; stderr: %s", runErr, stderr)
+		}
 		return fmt.Errorf("mydumper failed: %w", runErr)
 	}
 

--- a/cmd/bintrail/dump_test.go
+++ b/cmd/bintrail/dump_test.go
@@ -511,6 +511,58 @@ func TestRunDump_invalidSourceDSN(t *testing.T) {
 	}
 }
 
+// TestRunDump_capturesStderrOnFailure verifies the fix for the issue where
+// every mydumper failure surfaced as the opaque "mydumper failed: exit
+// status 1" message, hiding the real diagnostic (auth plugin mismatch,
+// missing privilege, full disk, etc.) emitted by mydumper on stderr.
+func TestRunDump_capturesStderrOnFailure(t *testing.T) {
+	dir := t.TempDir()
+	fakeBin := filepath.Join(dir, "mydumper")
+	// Fake mydumper that prints a recognizable diagnostic to stderr and
+	// exits non-zero. The --version probe returns a valid version so the
+	// caller doesn't bail out before invoking the dump.
+	script := `#!/bin/bash
+if [ "$1" = "--version" ]; then
+  echo "mydumper 0.15.0 (built with foo)"
+  exit 0
+fi
+echo "CRITICAL: simulated mydumper failure (auth plugin caching_sha2_password)" >&2
+exit 1
+`
+	if err := os.WriteFile(fakeBin, []byte(script), 0o755); err != nil {
+		t.Fatalf("failed to create fake mydumper: %v", err)
+	}
+
+	saved := struct {
+		path, dsn, outDir, format string
+	}{dmpMydumperPath, dmpSourceDSN, dmpOutputDir, dmpFormat}
+	t.Cleanup(func() {
+		dmpMydumperPath = saved.path
+		dumpCmd.Flags().Set("mydumper-path", saved.path)
+		dmpSourceDSN = saved.dsn
+		dmpOutputDir = saved.outDir
+		dmpFormat = saved.format
+	})
+
+	dumpCmd.Flags().Set("mydumper-path", fakeBin)
+	dmpSourceDSN = "root:rootpw@tcp(127.0.0.1:3306)/"
+	dmpOutputDir = filepath.Join(dir, "out")
+	dmpFormat = "text"
+
+	err := runDump(dumpCmd, nil)
+	if err == nil {
+		t.Fatal("expected error from failing mydumper, got nil")
+	}
+	if !strings.Contains(err.Error(), "mydumper failed") {
+		t.Errorf("expected error to mention 'mydumper failed', got: %v", err)
+	}
+	// The whole point of the fix: stderr from mydumper must be in the
+	// returned error so the operator can debug without re-running by hand.
+	if !strings.Contains(err.Error(), "CRITICAL") || !strings.Contains(err.Error(), "caching_sha2_password") {
+		t.Errorf("expected error to include mydumper stderr ('CRITICAL ... caching_sha2_password'), got: %v", err)
+	}
+}
+
 // ─── resolveMydumper ──────────────────────────────────────────────────────────
 
 func TestResolveMydumper_explicitPathTakesPrecedence(t *testing.T) {


### PR DESCRIPTION
closes #290

## Summary

Every `bintrail dump` failure was surfacing as the opaque "mydumper failed: exit status 1" message — hiding the real diagnostic mydumper emitted on stderr (auth plugin mismatch, missing privilege, full disk, etc.). Operators had to re-run mydumper directly with the same args to see why it failed.

## What changed

- Capture mydumper's stderr into a buffer; include the captured content in the wrapped error message.
- Text mode: stderr still passes through to the user's terminal via `io.MultiWriter` so progress/warnings are visible live.
- JSON mode: stderr is buffered only (caller is parsing stdout), and surfaces in the JSON `error` field via `main.go`'s existing error encoder.

New error shape:
```
mydumper failed: exit status 1; stderr: CRITICAL: Error connecting to database: ...
```

## Test

`TestRunDump_capturesStderrOnFailure`: drops a fake mydumper script that emits a recognizable stderr line and exits non-zero. Asserts the returned error contains both "mydumper failed" and the fake stderr content. Doesn't require a real mydumper or MySQL.

## Notes

- Local Go isn't installed on the dev machine — CI will verify build + tests.
- Imports added: `bytes`, `io` (both stdlib).

🤖 Generated with [Claude Code](https://claude.com/claude-code)