### PR TITLE
docs(streaming): note RDS backup-retention requirement for binlog (#300)

### DIFF
--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -237,6 +237,29 @@ bintrail stream --gap-timeout 60 --index-dsn "..." --source-dsn "..." --server-i
 
 Reducing binlog retention is also a valid mitigation, but loses the ability to fill larger gaps.
 
+### RDS: backup retention enables binlog
+
+**Important for AWS RDS users:** RDS for MySQL only enables binary logging when `backup-retention-period >= 1`. Even with a custom parameter group setting `binlog_format=ROW` and `binlog_row_image=FULL`, `@@log_bin` stays `0` if backup retention is `0`, and `bintrail stream` / `bintrail index` will fail with:
+
+```
+ERROR 1381 (HY000): You are not using binary logging
+```
+
+`SHOW VARIABLES` happily reports the custom parameter-group values, which makes this easy to miss. Enable binlog by raising backup retention to at least 1 day:
+
+```sh
+aws rds modify-db-instance \
+  --db-instance-identifier <id> \
+  --backup-retention-period 1 \
+  --apply-immediately
+```
+
+Wait ~2 minutes for the modification to take effect. After that, also set `binlog retention hours` (see below) so RDS keeps binlogs long enough for bintrail to index them before purge:
+
+```sql
+CALL mysql.rds_set_configuration('binlog retention hours', 48);
+```
+
 ### Binlog retention requirement
 
 **Important:** Configure your MySQL server's binlog retention to be **at least 2 days**. This gives bintrail enough time to fill gaps after planned maintenance, restarts, or brief outages. With very short retention (seconds or minutes), binlogs may be purged before bintrail has a chance to replay them, resulting in permanent data loss.


### PR DESCRIPTION
## Summary

AWS RDS for MySQL only enables binary logging when `backup-retention-period >= 1`. A user provisioning an RDS instance with `--backup-retention-period 0` — and an otherwise correct custom parameter group setting `binlog_format=ROW` and `binlog_row_image=FULL` — gets `@@log_bin=0` and `bintrail stream` / `bintrail index` fails with `ERROR 1381 (HY000): You are not using binary logging`. `SHOW VARIABLES` reports the param-group values happily, which makes this easy to miss.

This PR adds a short subsection in `docs/streaming.md` documenting the requirement, the `aws rds modify-db-instance --backup-retention-period 1 --apply-immediately` fix, and a forward pointer to the existing `binlog retention hours` guidance.

Fixes #300

## Test plan

- [x] Manual review of rendered markdown (heading nesting, fences, lists OK)
- [x] Repro confirmed in the original walkthrough: RDS with `--backup-retention-period 0` returns 1381 from `SHOW BINARY LOGS`; raising backup-retention to 1 enables binlog within ~2 min

## Out of scope

A one-line forward pointer from `docs/time-travel-sql.md` Prerequisites would be nice but is deliberately out of scope here — #301 is touching the same file in parallel and adding it here would create a conflict. If the user wants the cross-link, it can land in a tiny follow-up PR after both this and #301 merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)