### PR TITLE
fix(query): scan binlog_file as NullString to survive schema drift (#318)

### DIFF
--- a/cmd/bintrail/reconstruct.go
+++ b/cmd/bintrail/reconstruct.go
@@ -291,9 +291,10 @@ func runReconstruct(cmd *cobra.Command, args []string) error {
 	}
 	if bmeta.BinlogFile != "" && len(events) > 0 {
 		first := events[0]
-		// A NULL binlog_file on the first event (mapped to "" by scanRows
-		// after dbtrail/bintrail#318) has no comparable position — skip the
-		// gap check rather than silently degrade to "no gap".
+		// A NULL binlog_file on the first event has no comparable position —
+		// skip the gap check rather than silently degrade to "no gap"
+		// (mirrors the bmeta.BinlogFile == "" branch above).
+		// See dbtrail/bintrail#318.
 		if first.BinlogFile == "" {
 			slog.Warn("gap detection skipped — first indexed event lacks binlog_file metadata",
 				"event_id", first.EventID,

--- a/cmd/bintrail/reconstruct.go
+++ b/cmd/bintrail/reconstruct.go
@@ -291,15 +291,25 @@ func runReconstruct(cmd *cobra.Command, args []string) error {
 	}
 	if bmeta.BinlogFile != "" && len(events) > 0 {
 		first := events[0]
-		gap := first.BinlogFile > bmeta.BinlogFile ||
-			(first.BinlogFile == bmeta.BinlogFile && first.StartPos > uint64(bmeta.BinlogPos))
-		if gap {
-			slog.Warn("gap between baseline and first indexed event — reconstruction may be incomplete",
+		// A NULL binlog_file on the first event (mapped to "" by scanRows
+		// after dbtrail/bintrail#318) has no comparable position — skip the
+		// gap check rather than silently degrade to "no gap".
+		if first.BinlogFile == "" {
+			slog.Warn("gap detection skipped — first indexed event lacks binlog_file metadata",
+				"event_id", first.EventID,
 				"baseline_file", bmeta.BinlogFile,
-				"baseline_pos", bmeta.BinlogPos,
-				"baseline_gtid", bmeta.GTIDSet,
-				"first_event_file", first.BinlogFile,
-				"first_event_pos", first.StartPos)
+				"baseline_pos", bmeta.BinlogPos)
+		} else {
+			gap := first.BinlogFile > bmeta.BinlogFile ||
+				(first.BinlogFile == bmeta.BinlogFile && first.StartPos > uint64(bmeta.BinlogPos))
+			if gap {
+				slog.Warn("gap between baseline and first indexed event — reconstruction may be incomplete",
+					"baseline_file", bmeta.BinlogFile,
+					"baseline_pos", bmeta.BinlogPos,
+					"baseline_gtid", bmeta.GTIDSet,
+					"first_event_file", first.BinlogFile,
+					"first_event_pos", first.StartPos)
+			}
 		}
 	}
 

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -129,7 +129,7 @@ func ArchivePartition(ctx context.Context, db *sql.DB, dbName, partition, output
 		}
 		nulls := []bool{
 			false,
-			!binlogFile.Valid,
+			!binlogFile.Valid, // binlog_file: preserve NULL in Parquet (dbtrail/bintrail#318)
 			false, false, false,
 			!gtid.Valid,
 			!connID.Valid,

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -82,7 +82,7 @@ func ArchivePartition(ctx context.Context, db *sql.DB, dbName, partition, output
 	for rows.Next() {
 		var (
 			eventID        uint64
-			binlogFile     string
+			binlogFile     sql.NullString
 			startPos       uint64
 			endPos         uint64
 			eventTimestamp time.Time
@@ -112,7 +112,7 @@ func ArchivePartition(ctx context.Context, db *sql.DB, dbName, partition, output
 
 		values := []string{
 			strconv.FormatUint(eventID, 10),
-			binlogFile,
+			binlogFile.String,
 			strconv.FormatUint(startPos, 10),
 			strconv.FormatUint(endPos, 10),
 			eventTimestamp.UTC().Format("2006-01-02 15:04:05"),
@@ -128,7 +128,9 @@ func ArchivePartition(ctx context.Context, db *sql.DB, dbName, partition, output
 			strconv.FormatUint(uint64(schemaVersion), 10),
 		}
 		nulls := []bool{
-			false, false, false, false, false,
+			false,
+			!binlogFile.Valid,
+			false, false, false,
 			!gtid.Valid,
 			!connID.Valid,
 			false, false, false, false,

--- a/internal/archive/archive_integration_test.go
+++ b/internal/archive/archive_integration_test.go
@@ -4,8 +4,11 @@ package archive
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/parquet-go/parquet-go"
 
 	"github.com/dbtrail/bintrail/internal/testutil"
 )
@@ -45,5 +48,37 @@ func TestArchivePartition_nullBinlogFile(t *testing.T) {
 	}
 	if n != 2 {
 		t.Errorf("rowCount = %d, want 2", n)
+	}
+
+	// Verify NULL semantics at the Parquet layer: row 0 (the non-NULL row,
+	// inserted first → lower event_id → sorted first by ORDER BY event_id)
+	// must carry "binlog.000001"; row 1 must be a real Parquet NULL, not
+	// an empty string. The nulls[1]=!binlogFile.Valid line in archive.go
+	// is what makes this true — testing it specifically guards against a
+	// regression that smuggles "" into the column.
+	rf, err := os.Open(outPath)
+	if err != nil {
+		t.Fatalf("open archived parquet: %v", err)
+	}
+	defer rf.Close()
+	info, _ := rf.Stat()
+	pf, err := parquet.OpenFile(rf, info.Size())
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+	binlogFileIdx := parquetColumnIndex(t, pf, "binlog_file")
+	reader := parquet.NewReader(pf)
+	defer reader.Close()
+	parquetRows := make([]parquet.Row, 2)
+	if rn, err := reader.ReadRows(parquetRows); err != nil || rn != 2 {
+		t.Fatalf("ReadRows returned (%d, %v), want (2, nil)", rn, err)
+	}
+	if parquetRows[0][binlogFileIdx].IsNull() {
+		t.Errorf("row 0 binlog_file: got NULL, want \"binlog.000001\"")
+	} else if got := parquetRows[0][binlogFileIdx].String(); got != "binlog.000001" {
+		t.Errorf("row 0 binlog_file: got %q, want \"binlog.000001\"", got)
+	}
+	if !parquetRows[1][binlogFileIdx].IsNull() {
+		t.Errorf("row 1 binlog_file: got %q, want NULL", parquetRows[1][binlogFileIdx].String())
 	}
 }

--- a/internal/archive/archive_integration_test.go
+++ b/internal/archive/archive_integration_test.go
@@ -1,0 +1,49 @@
+//go:build integration
+
+package archive
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/dbtrail/bintrail/internal/testutil"
+)
+
+// TestArchivePartition_nullBinlogFile is the rotate-path counterpart to
+// query.TestFetch_nullBinlogFile (dbtrail/bintrail#318). Before the fix,
+// ArchivePartition crashed at Scan when any row in the partition had a NULL
+// binlog_file — same root cause as the query crash, but the consequence is
+// worse: rotate failures block partition pruning and grow the index
+// unbounded.
+func TestArchivePartition_nullBinlogFile(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	// Relax the NOT NULL on binlog_file to simulate a drifted customer schema.
+	if _, err := db.Exec(`ALTER TABLE binlog_events MODIFY binlog_file VARCHAR(255) NULL`); err != nil {
+		t.Fatalf("ALTER TABLE failed: %v", err)
+	}
+
+	ts := "2026-02-19 14:00:00"
+	testutil.InsertEvent(t, db, "binlog.000001", 100, 200, ts, nil, "mydb", "orders", 1, "1",
+		nil, nil, []byte(`{"id":1}`))
+	if _, err := db.Exec(`INSERT INTO binlog_events
+		(binlog_file, start_pos, end_pos, event_timestamp, gtid,
+		 schema_name, table_name, event_type, pk_values,
+		 changed_columns, row_before, row_after)
+		VALUES (NULL, 0, 0, ?, NULL, ?, ?, ?, ?, NULL, NULL, ?)`,
+		ts, "mydb", "orders", 1, "2", []byte(`{"id":2}`),
+	); err != nil {
+		t.Fatalf("insert NULL-binlog_file row failed: %v", err)
+	}
+
+	outPath := filepath.Join(t.TempDir(), "p_future.parquet")
+	n, err := ArchivePartition(context.Background(), db, dbName, "p_future", outPath, "none")
+	if err != nil {
+		t.Fatalf("ArchivePartition failed: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("rowCount = %d, want 2", n)
+	}
+}

--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -103,6 +103,24 @@ func TestWriteReadRoundTrip(t *testing.T) {
 		t.Fatalf("WriteRow 2: %v", err)
 	}
 
+	// Row 3: binlog_file is null (the dbtrail/bintrail#318 case — customer
+	// indexes that predate the NOT NULL constraint or rows from external
+	// pipelines). Confirms the Parquet writer accepts NULL at column index 1.
+	row3 := []string{
+		"3", "", "300", "400", "2026-02-19 10:00:02",
+		"def456:1", "67890", "mydb", "orders", "1", "44",
+		`["col1"]`, `{"id":44}`, `{"id":44,"v":1}`, "1",
+	}
+	nulls3 := []bool{
+		false,
+		true, // binlog_file null
+		false, false, false, false, false, false, false, false, false,
+		false, false, false, false,
+	}
+	if err := w.WriteRow(row3, nulls3); err != nil {
+		t.Fatalf("WriteRow 3: %v", err)
+	}
+
 	if err := w.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
@@ -119,8 +137,8 @@ func TestWriteReadRoundTrip(t *testing.T) {
 		t.Fatalf("OpenFile: %v", err)
 	}
 
-	if pf.NumRows() != 2 {
-		t.Errorf("NumRows = %d, want 2", pf.NumRows())
+	if pf.NumRows() != 3 {
+		t.Errorf("NumRows = %d, want 3", pf.NumRows())
 	}
 
 	// Verify key-value metadata was embedded.

--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -141,6 +141,30 @@ func TestWriteReadRoundTrip(t *testing.T) {
 		t.Errorf("NumRows = %d, want 3", pf.NumRows())
 	}
 
+	// Read back the rows and verify binlog_file NULL semantics: row 1 (the
+	// first non-NULL row written) carries "binlog.000001"; row 3 is the
+	// dbtrail/bintrail#318 case — must be a real Parquet NULL, not an
+	// empty string smuggled into the column. Without nulls[1]=!binlogFile.Valid
+	// in archive.go, the writer would emit "" and IsNull() would be false.
+	//
+	// parquet-go orders row values alphabetically by column name, not by
+	// schema declaration order — binlog_file sorts to index 0.
+	binlogFileIdx := parquetColumnIndex(t, pf, "binlog_file")
+	reader := parquet.NewReader(pf)
+	defer reader.Close()
+	parquetRows := make([]parquet.Row, 3)
+	if n, err := reader.ReadRows(parquetRows); err != nil || n != 3 {
+		t.Fatalf("ReadRows returned (%d, %v), want (3, nil)", n, err)
+	}
+	if parquetRows[0][binlogFileIdx].IsNull() {
+		t.Errorf("row 0 binlog_file: got NULL, want \"binlog.000001\"")
+	} else if got := parquetRows[0][binlogFileIdx].String(); got != "binlog.000001" {
+		t.Errorf("row 0 binlog_file: got %q, want \"binlog.000001\"", got)
+	}
+	if !parquetRows[2][binlogFileIdx].IsNull() {
+		t.Errorf("row 2 binlog_file: got %q, want NULL", parquetRows[2][binlogFileIdx].String())
+	}
+
 	// Verify key-value metadata was embedded.
 	got, ok := pf.Lookup("bintrail.archive.partition")
 	if !ok {
@@ -152,4 +176,20 @@ func TestWriteReadRoundTrip(t *testing.T) {
 	if _, ok := pf.Lookup("bintrail.archive.version"); !ok {
 		t.Error("expected bintrail.archive.version metadata key")
 	}
+}
+
+// parquetColumnIndex looks up the position of a column in the file's leaf
+// schema. parquet-go's NewReader returns rows whose values are ordered by
+// the schema's leaf walk (alphabetical for our flat schemas), not by the
+// order columns were passed to NewWriter — so callers that want to assert
+// on a specific column must look up its index dynamically.
+func parquetColumnIndex(t *testing.T, pf *parquet.File, name string) int {
+	t.Helper()
+	for i, col := range pf.Schema().Columns() {
+		if len(col) == 1 && col[0] == name {
+			return i
+		}
+	}
+	t.Fatalf("column %q not found in parquet schema", name)
+	return -1
 }

--- a/internal/parquetquery/parquetquery.go
+++ b/internal/parquetquery/parquetquery.go
@@ -776,7 +776,7 @@ func scanRows(rows *sql.Rows) ([]query.ResultRow, error) {
 	for rows.Next() {
 		var (
 			eventID        int64
-			binlogFile     string
+			binlogFile     sql.NullString
 			startPos       int64
 			endPos         int64
 			eventTimestamp time.Time
@@ -801,7 +801,7 @@ func scanRows(rows *sql.Rows) ([]query.ResultRow, error) {
 
 		r := query.ResultRow{
 			EventID:        uint64(eventID),
-			BinlogFile:     binlogFile,
+			BinlogFile:     binlogFile.String,
 			StartPos:       uint64(startPos),
 			EndPos:         uint64(endPos),
 			EventTimestamp: eventTimestamp,

--- a/internal/parquetquery/parquetquery_archive_integration_test.go
+++ b/internal/parquetquery/parquetquery_archive_integration_test.go
@@ -1,0 +1,69 @@
+//go:build integration
+
+package parquetquery_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/dbtrail/bintrail/internal/archive"
+	"github.com/dbtrail/bintrail/internal/parquetquery"
+	"github.com/dbtrail/bintrail/internal/query"
+	"github.com/dbtrail/bintrail/internal/testutil"
+)
+
+// TestFetch_archivedNullBinlogFile closes the dbtrail/bintrail#318 loop
+// end-to-end: drift in the MySQL index → bintrail rotate writes Parquet
+// containing a real NULL at column 1 → parquetquery.Fetch reads the
+// archive back via DuckDB and returns the rows without crashing. Before
+// the scanRows fix in this file, the consumer-side bug was latent
+// (archive.ArchivePartition crashed before producing a NULL-bearing
+// Parquet); the archive.go fix in this same PR turned it into a live
+// regression by correctly preserving the NULL through to the writer.
+func TestFetch_archivedNullBinlogFile(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	if _, err := db.Exec(`ALTER TABLE binlog_events MODIFY binlog_file VARCHAR(255) NULL`); err != nil {
+		t.Fatalf("ALTER TABLE failed: %v", err)
+	}
+
+	ts := "2026-02-19 14:00:00"
+	testutil.InsertEvent(t, db, "binlog.000001", 100, 200, ts, nil, "mydb", "orders", 1, "1",
+		nil, nil, []byte(`{"id":1}`))
+	if _, err := db.Exec(`INSERT INTO binlog_events
+		(binlog_file, start_pos, end_pos, event_timestamp, gtid,
+		 schema_name, table_name, event_type, pk_values,
+		 changed_columns, row_before, row_after)
+		VALUES (NULL, 0, 0, ?, NULL, ?, ?, ?, ?, NULL, NULL, ?)`,
+		ts, "mydb", "orders", 1, "2", []byte(`{"id":2}`),
+	); err != nil {
+		t.Fatalf("insert NULL-binlog_file row failed: %v", err)
+	}
+
+	outPath := filepath.Join(t.TempDir(), "p_future.parquet")
+	if _, err := archive.ArchivePartition(context.Background(), db, dbName, "p_future", outPath, "none"); err != nil {
+		t.Fatalf("ArchivePartition failed: %v", err)
+	}
+
+	rows, err := parquetquery.Fetch(context.Background(),
+		query.Options{Schema: "mydb", Table: "orders", Limit: 100},
+		outPath)
+	if err != nil {
+		t.Fatalf("parquetquery.Fetch failed: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(rows))
+	}
+
+	// Rows from parquetquery come back ordered by event_timestamp, event_id
+	// (matches the MySQL-side Fetch ordering). The non-NULL row was inserted
+	// first → lower event_id → first in results.
+	if rows[0].BinlogFile != "binlog.000001" {
+		t.Errorf("row 0: expected BinlogFile=binlog.000001, got %q", rows[0].BinlogFile)
+	}
+	if rows[1].BinlogFile != "" {
+		t.Errorf("row 1: expected BinlogFile=\"\" for NULL column, got %q", rows[1].BinlogFile)
+	}
+}

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -378,16 +378,24 @@ func scanRows(rows *sql.Rows) ([]ResultRow, error) {
 	var results []ResultRow
 	for rows.Next() {
 		var r ResultRow
+		// binlog_file is declared NOT NULL in the migrations, but customer
+		// databases that predate that constraint (or schema_change rows
+		// inserted by external pipelines) can still surface NULL. Scan into
+		// a NullString to stay robust to schema drift.
+		var binlogFile sql.NullString
 		var gtid sql.NullString
 		var connID sql.NullInt64
 		var changedCols, rowBefore, rowAfter []byte
 
 		if err := rows.Scan(
-			&r.EventID, &r.BinlogFile, &r.StartPos, &r.EndPos, &r.EventTimestamp,
+			&r.EventID, &binlogFile, &r.StartPos, &r.EndPos, &r.EventTimestamp,
 			&gtid, &connID, &r.SchemaName, &r.TableName, &r.EventType, &r.PKValues,
 			&changedCols, &rowBefore, &rowAfter, &r.SchemaVersion,
 		); err != nil {
 			return nil, fmt.Errorf("failed to scan result row: %w", err)
+		}
+		if binlogFile.Valid {
+			r.BinlogFile = binlogFile.String
 		}
 		if gtid.Valid {
 			r.GTID = &gtid.String

--- a/internal/query/query_integration_test.go
+++ b/internal/query/query_integration_test.go
@@ -308,3 +308,50 @@ func TestRun_tableFormat(t *testing.T) {
 		t.Errorf("expected INSERT in table output, got: %s", buf.String())
 	}
 }
+
+// TestFetch_nullBinlogFile reproduces the SaaS Explorer crash reported in
+// dbtrail/bintrail#318 / nethalo/dbtrail#1484: rows with NULL binlog_file
+// (from customer DBs that predate the NOT NULL migration, or from rows
+// inserted by external pipelines) used to fail Scan with
+// "converting NULL to string is unsupported".
+func TestFetch_nullBinlogFile(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	// Relax the NOT NULL on binlog_file to simulate a drifted customer schema.
+	if _, err := db.Exec(`ALTER TABLE binlog_events MODIFY binlog_file VARCHAR(255) NULL`); err != nil {
+		t.Fatalf("ALTER TABLE failed: %v", err)
+	}
+
+	ts := "2026-02-19 14:00:00"
+	// One row with binlog_file set, one with NULL.
+	testutil.InsertEvent(t, db, "binlog.000001", 100, 200, ts, nil, "mydb", "orders", 1, "1",
+		nil, nil, []byte(`{"id":1}`))
+	if _, err := db.Exec(`INSERT INTO binlog_events
+		(binlog_file, start_pos, end_pos, event_timestamp, gtid,
+		 schema_name, table_name, event_type, pk_values,
+		 changed_columns, row_before, row_after)
+		VALUES (NULL, 0, 0, ?, NULL, ?, ?, ?, ?, NULL, NULL, ?)`,
+		ts, "mydb", "orders", 1, "2", []byte(`{"id":2}`),
+	); err != nil {
+		t.Fatalf("insert NULL-binlog_file row failed: %v", err)
+	}
+
+	e := New(db)
+	rows, err := e.Fetch(context.Background(), Options{Schema: "mydb", Table: "orders", Limit: 100})
+	if err != nil {
+		t.Fatalf("Fetch failed: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(rows))
+	}
+
+	// Rows come back ordered by event_timestamp ASC, event_id ASC; the
+	// non-NULL row was inserted first so it gets the lower event_id.
+	if rows[0].BinlogFile != "binlog.000001" {
+		t.Errorf("row 0: expected BinlogFile=binlog.000001, got %q", rows[0].BinlogFile)
+	}
+	if rows[1].BinlogFile != "" {
+		t.Errorf("row 1: expected BinlogFile=\"\" for NULL column, got %q", rows[1].BinlogFile)
+	}
+}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -135,6 +135,7 @@ func InitIndexTables(t *testing.T, db *sql.DB) {
 		end_pos         BIGINT UNSIGNED  NOT NULL,
 		event_timestamp DATETIME         NOT NULL,
 		gtid            VARCHAR(255)     DEFAULT NULL,
+		connection_id   INT UNSIGNED     DEFAULT NULL,
 		schema_name     VARCHAR(64)      NOT NULL,
 		table_name      VARCHAR(64)      NOT NULL,
 		event_type      TINYINT UNSIGNED NOT NULL,


### PR DESCRIPTION
## Summary

End-to-end NULL-safe handling of `binlog_file` across every consumer of `binlog_events` rows. Fixes the SaaS Explorer crash reported as [nethalo/dbtrail#1484](https://github.com/nethalo/dbtrail/issues/1484) and closes the same root-cause bug at every layer of the pipeline where it surfaces. Two rounds of PR review (`pr-review-toolkit:code-reviewer` + `silent-failure-hunter` + `pr-test-analyzer` + `comment-analyzer`) expanded the scope twice — each layer's fix exposed the next.

## The pipeline

```
                    MySQL binlog_events  ──Fetch──▶  Explorer (#1484 crash)
                        │
                        └──ArchivePartition──▶  Parquet  ──parquetquery.Fetch──▶  Explorer (latent → live after archive fix)
```

Same root cause (`binlog_file` scanned into plain `string`, crashes on NULL) at all three Scan sites. Plus a degraded-warning silent-failure in `reconstruct.go`'s gap check that the NULL-scan fixes exposed.

## Changes

### Fix sites (3 production + 1 silent-failure guard)

| File | Bug | Fix |
|---|---|---|
| `internal/query/query.go` | `scanRows` crashes on NULL `binlog_file` from MySQL — the visible #1484 crash | `sql.NullString` + copy-on-`Valid`, matching `gtid`/`connection_id` pattern in the same Scan |
| `internal/archive/archive.go` | `ArchivePartition` (called by `bintrail rotate`) has identical bug — worse blast radius: blocks partition pruning, grows index unbounded | Same fix + propagate `!binlogFile.Valid` to `nulls[1]` so Parquet preserves true NULL instead of `""` |
| `internal/parquetquery/parquetquery.go` | DuckDB-backed reads of archived partitions crash on the Parquet NULL the archive fix now correctly emits | Same `sql.NullString` pattern |
| `cmd/bintrail/reconstruct.go` | Gap check `first.BinlogFile > bmeta.BinlogFile` silently degrades to "no gap" when `first.BinlogFile == ""` (was a loud crash before the query fix) | Warn-and-skip guard mirroring the existing `bmeta.BinlogFile == ""` branch above |
| `internal/testutil/testutil.go` | Side-fix: `InitIndexTables` missing `connection_id` column — every integration test in `internal/query/` was already broken | Add the column |

### Tests (5 new/strengthened)

| Test | What it proves |
|---|---|
| `query.TestFetch_nullBinlogFile` | MySQL Scan no longer crashes on NULL; NULL → `""` mapping. Verified to fail with the exact #318 error message when fix line is reverted |
| `archive.TestArchivePartition_nullBinlogFile` (integration) | `bintrail rotate` produces a Parquet file containing a real NULL (not smuggled `""`) at the binlog_file column. Reads back with parquet-go and asserts `IsNull()` |
| `archive.TestWriteReadRoundTrip` (unit, extended) | Pure writer-level: a row with `nulls[1]=true` round-trips as NULL through parquet-go, not as `""` |
| `parquetquery.TestFetch_archivedNullBinlogFile` (integration) | **End-to-end roundtrip**: drift → ArchivePartition → DuckDB Fetch returns rows with the right BinlogFile values. Verified to fail with the exact `scan parquet result: ... converting NULL to string is unsupported` error when fix is reverted — this single test protects every layer simultaneously |
| `parquetColumnIndex` test helper | Looks up column position in the parquet file's leaf schema (parquet-go's `NewReader` orders values alphabetically, not by `NewWriter` argument order — caught the hard way during development) |

## Schema-drift note

The migrations (`001_create_tables.sql:13`) and `cmd/bintrail/init.go:488` both declare `binlog_file VARCHAR(255) NOT NULL`. On a freshly-initialised index, the NULL case is unreachable — but the crash is real in production. Likely cause: customer indexes created before the `NOT NULL` constraint was added, or rows inserted by external pipelines. Defensive scanning is the right move regardless. Root-causing the production NULL source can be a follow-up.

## Accepted asymmetry

`gtid` and `connection_id` serialise as JSON `null` (pointer types in `ResultRow`); `binlog_file` now serialises as `""` for NULL. Accepted because `binlog_file = ""` was never a valid value in practice. Changing to `*string` cascades into ~5 sites for cosmetic parity — not worth it.

## Test plan

- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test ./...` (full unit sweep)
- [x] `go test -tags integration ./internal/{query,archive,parquetquery}/... ./cmd/bintrail/...`
- [x] Negative verification of `query.go` fix (mirrors #318 error)
- [x] Negative verification of `parquetquery.go` fix via the end-to-end roundtrip test (mirrors `scan parquet result` error)
- [x] Archive fix verified via Parquet read-back assertions (proves NULL preservation, not just "no crash")

## Downstream

Once a new `bintrail` release picks this up and the dbtrail agent is rolled out via `/deploy-agent`, [nethalo/dbtrail#1484](https://github.com/nethalo/dbtrail/issues/1484) resolves without any SaaS-side code change.

Closes #318.

🤖 Generated with [Claude Code](https://claude.com/claude-code)