### PR TITLE
fix(agent): support MySQL 8.4 by using SHOW BINARY LOG STATUS (#308)

### DIFF
--- a/cmd/bintrail/agent.go
+++ b/cmd/bintrail/agent.go
@@ -609,10 +609,9 @@ func startBYOSSyncer(sourceDB *sql.DB, syncer *replication.BinlogSyncer, startGT
 		return syncer.StartSyncGTID(gset)
 	}
 	// No start GTID — query current position from source and start there.
-	var file string
-	var pos uint32
-	if err := sourceDB.QueryRow("SHOW MASTER STATUS").Scan(&file, &pos, new(string), new(string), new(string)); err != nil {
-		return nil, fmt.Errorf("SHOW MASTER STATUS: %w", err)
+	file, pos, err := config.CurrentBinlogPosition(sourceDB)
+	if err != nil {
+		return nil, err
 	}
 	slog.Info("starting from current binlog position", "file", file, "pos", pos)
 	return syncer.StartSync(gomysql.Position{Name: file, Pos: pos})

--- a/cmd/bintrail/stream_integration_test.go
+++ b/cmd/bintrail/stream_integration_test.go
@@ -15,6 +15,7 @@ import (
 	gomysql "github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/go-mysql-org/go-mysql/replication"
 
+	"github.com/dbtrail/bintrail/internal/config"
 	"github.com/dbtrail/bintrail/internal/indexer"
 	"github.com/dbtrail/bintrail/internal/metadata"
 	"github.com/dbtrail/bintrail/internal/parser"
@@ -282,13 +283,9 @@ func TestStreamLoop_liveReplication(t *testing.T) {
 	}
 
 	// Capture current binlog position before any inserts.
-	var binlogFile string
-	var binlogPos uint32
-	var dummy sql.NullString
-	if err := sourceDB.QueryRow("SHOW MASTER STATUS").Scan(
-		&binlogFile, &binlogPos, &dummy, &dummy, &dummy,
-	); err != nil {
-		t.Skipf("skipping: SHOW MASTER STATUS failed: %v", err)
+	binlogFile, binlogPos, err := config.CurrentBinlogPosition(sourceDB)
+	if err != nil {
+		t.Skipf("skipping: cannot read binlog position: %v", err)
 	}
 
 	// Take schema snapshot into the index DB.

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/dbtrail/bintrail/internal/config"
 	"github.com/dbtrail/bintrail/internal/testutil"
 )
 
@@ -73,11 +74,9 @@ func TestEndToEnd_fullPipeline(t *testing.T) {
 	testutil.MustExec(t, sourceDB, "FLUSH BINARY LOGS")
 
 	// Note the current binlog file (the one that will receive our DML).
-	var currentBinlog, ignorePos, ignoreBinDo, ignoreBinIgn, ignoreGtid string
-	if err := sourceDB.QueryRow("SHOW MASTER STATUS").Scan(
-		&currentBinlog, &ignorePos, &ignoreBinDo, &ignoreBinIgn, &ignoreGtid,
-	); err != nil {
-		t.Fatalf("SHOW MASTER STATUS failed: %v", err)
+	currentBinlog, _, err := config.CurrentBinlogPosition(sourceDB)
+	if err != nil {
+		t.Fatalf("CurrentBinlogPosition failed: %v", err)
 	}
 
 	testutil.MustExec(t, sourceDB, "INSERT INTO orders (customer, status, amount) VALUES ('Alice', 'new', 99.99)")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,23 @@ import (
 	"github.com/go-sql-driver/mysql"
 )
 
+// CurrentBinlogPosition returns the current binlog file name and position
+// from the source server. It tries SHOW BINARY LOG STATUS first (MySQL 8.4+)
+// and falls back to SHOW MASTER STATUS for 5.7 / 8.0 / Percona <8.4 where the
+// new statement does not exist. When both fail, the wrapped error includes
+// both diagnostics so the operator does not chase the wrong syntax.
+func CurrentBinlogPosition(db *sql.DB) (file string, pos uint32, err error) {
+	scanArgs := []any{&file, &pos, new(string), new(string), new(string)}
+	if err = db.QueryRow("SHOW BINARY LOG STATUS").Scan(scanArgs...); err == nil {
+		return file, pos, nil
+	}
+	firstErr := err
+	if err = db.QueryRow("SHOW MASTER STATUS").Scan(scanArgs...); err != nil {
+		return "", 0, fmt.Errorf("SHOW BINARY LOG STATUS / SHOW MASTER STATUS: %w (fallback: %w)", firstErr, err)
+	}
+	return file, pos, nil
+}
+
 // defaultTimeout is the TCP connect timeout applied when the DSN does not
 // specify one. Prevents indefinite hangs when MySQL is unreachable.
 const defaultTimeout = 10 * time.Second

--- a/internal/parser/parser_integration_test.go
+++ b/internal/parser/parser_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/dbtrail/bintrail/internal/config"
 	"github.com/dbtrail/bintrail/internal/metadata"
 	"github.com/dbtrail/bintrail/internal/parser"
 	"github.com/dbtrail/bintrail/internal/testutil"
@@ -52,11 +53,9 @@ func setupBinlog(t *testing.T) (binlogDir, binlogFile, schemaName string, resolv
 	testutil.MustExec(t, sourceDB, "FLUSH BINARY LOGS")
 
 	// Note the current binlog file.
-	var currentBinlog, ignorePos, ignoreBinDo, ignoreBinIgn, ignoreGtid string
-	if err := sourceDB.QueryRow("SHOW MASTER STATUS").Scan(
-		&currentBinlog, &ignorePos, &ignoreBinDo, &ignoreBinIgn, &ignoreGtid,
-	); err != nil {
-		t.Fatalf("SHOW MASTER STATUS failed: %v", err)
+	currentBinlog, _, err := config.CurrentBinlogPosition(sourceDB)
+	if err != nil {
+		t.Fatalf("CurrentBinlogPosition failed: %v", err)
 	}
 
 	// Perform DML: 2 INSERTs, 1 UPDATE, 1 DELETE = 4 events.
@@ -234,11 +233,9 @@ func TestParseFiles_multiple(t *testing.T) {
 	for batch := range 2 {
 		testutil.MustExec(t, sourceDB, "FLUSH BINARY LOGS")
 
-		var currentBinlog, ignorePos, ignoreBinDo, ignoreBinIgn, ignoreGtid string
-		if err := sourceDB.QueryRow("SHOW MASTER STATUS").Scan(
-			&currentBinlog, &ignorePos, &ignoreBinDo, &ignoreBinIgn, &ignoreGtid,
-		); err != nil {
-			t.Fatalf("SHOW MASTER STATUS failed: %v", err)
+		currentBinlog, _, err := config.CurrentBinlogPosition(sourceDB)
+		if err != nil {
+			t.Fatalf("CurrentBinlogPosition failed: %v", err)
 		}
 
 		testutil.MustExec(t, sourceDB,


### PR DESCRIPTION
## Summary

- MySQL 8.4 removed `SHOW MASTER STATUS` (renamed to `SHOW BINARY LOG STATUS`). `bintrail agent` in BYOS mode crashed immediately on Percona 8.4 LTS / MySQL 8.4 with `Error 1064 ... 'MASTER STATUS' at line 1`, then systemd crash-looped.
- Add `config.CurrentBinlogPosition` that tries the new statement first and falls back to `SHOW MASTER STATUS` for 5.7 / 8.0 / Percona <8.4. Both errors are preserved in the wrapped diagnostic so operators are not misled when both fail.
- Replace the four call sites that hardcoded `SHOW MASTER STATUS` with the helper: `cmd/bintrail/agent.go` (production), `e2e_test.go`, `cmd/bintrail/stream_integration_test.go`, `internal/parser/parser_integration_test.go`.

Closes #308.

## Test plan

- [x] `go build ./... && go vet ./...` clean
- [x] `go build -tags integration ./... && go vet -tags integration ./...` clean
- [x] `go test ./internal/config/... -count=1` passes
- [ ] On reviewer side: integration tests on local MySQL 8.0 Docker still pass via fallback path
- [ ] On reviewer side: smoke test agent against MySQL 8.4 (issue reporter confirmed in repro)