### PR TITLE
fix(query): handle NULL binlog_file in result Scan (#318)

### DIFF
--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -378,16 +378,24 @@ func scanRows(rows *sql.Rows) ([]ResultRow, error) {
 	var results []ResultRow
 	for rows.Next() {
 		var r ResultRow
+		// binlog_file is nullable in practice: snapshot baseline rows,
+		// schema_change records propagated from other sources, and manually
+		// imported events have no binlog origin. Scan into NullString and copy
+		// on Valid so the empty string is preserved as "" in ResultRow / JSON.
+		var binlogFile sql.NullString
 		var gtid sql.NullString
 		var connID sql.NullInt64
 		var changedCols, rowBefore, rowAfter []byte
 
 		if err := rows.Scan(
-			&r.EventID, &r.BinlogFile, &r.StartPos, &r.EndPos, &r.EventTimestamp,
+			&r.EventID, &binlogFile, &r.StartPos, &r.EndPos, &r.EventTimestamp,
 			&gtid, &connID, &r.SchemaName, &r.TableName, &r.EventType, &r.PKValues,
 			&changedCols, &rowBefore, &rowAfter, &r.SchemaVersion,
 		); err != nil {
 			return nil, fmt.Errorf("failed to scan result row: %w", err)
+		}
+		if binlogFile.Valid {
+			r.BinlogFile = binlogFile.String
 		}
 		if gtid.Valid {
 			r.GTID = &gtid.String

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -2,12 +2,14 @@ package query
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/dbtrail/bintrail/internal/parser"
 )
 
@@ -577,6 +579,98 @@ func TestLimitPerPK_zero_passthrough(t *testing.T) {
 	got := LimitPerPK(rows, 0)
 	if len(got) != 2 {
 		t.Errorf("LimitPerPK(_, 0) should be a passthrough, got %d rows", len(got))
+	}
+}
+
+// ─── scanRows: NULL handling ─────────────────────────────────────────────────
+
+// scanRowColumns must mirror the SELECT list in buildQuery; sqlmock matches by
+// column name. Keep this in sync with the cols string in query.go.
+var scanRowColumns = []string{
+	"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp",
+	"gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values",
+	"changed_columns", "row_before", "row_after", "schema_version",
+}
+
+// TestFetch_nullBinlogFile is the regression guard for issue #318. NULL
+// binlog_file values are legitimate (snapshot baseline rows, schema_change
+// records propagated from other sources, manually-imported events) and must
+// not break the Scan with "converting NULL to string is unsupported".
+func TestFetch_nullBinlogFile(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	ts := time.Date(2026, 2, 19, 14, 0, 0, 0, time.UTC)
+	rows := sqlmock.NewRows(scanRowColumns).
+		// Row 1: NULL binlog_file (the bug case). Other nullables also NULL.
+		AddRow(uint64(1), nil, uint64(0), uint64(0), ts,
+			nil, nil, "mydb", "orders", uint8(parser.EventSnapshot), "1",
+			nil, nil, []byte(`{"id":1}`), uint32(0)).
+		// Row 2: non-NULL binlog_file to confirm the happy path still works.
+		AddRow(uint64(2), "binlog.000042", uint64(100), uint64(200), ts,
+			nil, nil, "mydb", "orders", uint8(parser.EventInsert), "2",
+			nil, nil, []byte(`{"id":2}`), uint32(0))
+
+	mock.ExpectQuery("SELECT .* FROM binlog_events").WillReturnRows(rows)
+
+	e := New(db)
+	got, err := e.Fetch(context.Background(), Options{})
+	if err != nil {
+		t.Fatalf("Fetch failed on NULL binlog_file: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(got))
+	}
+	if got[0].BinlogFile != "" {
+		t.Errorf("expected empty BinlogFile for NULL row, got %q", got[0].BinlogFile)
+	}
+	if got[0].EventID != 1 {
+		t.Errorf("expected event_id=1 for first row, got %d", got[0].EventID)
+	}
+	if got[1].BinlogFile != "binlog.000042" {
+		t.Errorf("expected BinlogFile=binlog.000042 for second row, got %q", got[1].BinlogFile)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// TestFetch_nullBinlogFile_jsonOutput confirms the JSON formatter still
+// produces a clean empty string for a NULL binlog_file — no Go zero-value
+// leakage like "null" or sql.NullString-style {"String":"","Valid":false}.
+func TestFetch_nullBinlogFile_jsonOutput(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	ts := time.Date(2026, 2, 19, 14, 0, 0, 0, time.UTC)
+	rows := sqlmock.NewRows(scanRowColumns).
+		AddRow(uint64(1), nil, uint64(0), uint64(0), ts,
+			nil, nil, "mydb", "orders", uint8(parser.EventSnapshot), "1",
+			nil, nil, []byte(`{"id":1}`), uint32(0))
+
+	mock.ExpectQuery("SELECT .* FROM binlog_events").WillReturnRows(rows)
+
+	e := New(db)
+	var buf bytes.Buffer
+	n, err := e.Run(context.Background(), Options{}, "json", &buf)
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("expected 1 row, got %d", n)
+	}
+	var out []map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, buf.String())
+	}
+	if out[0]["binlog_file"] != "" {
+		t.Errorf("expected binlog_file=\"\" in JSON, got %v", out[0]["binlog_file"])
 	}
 }
 


### PR DESCRIPTION
## Summary

- `internal/query/query.go` scanned `binlog_file` directly into a plain `string`, which crashed every query the moment the index contained a row with `NULL binlog_file` (snapshot baseline rows, schema_change records propagated from other sources, manually-imported events).
- Fix follows Option B from the issue: scan into a local `sql.NullString` and copy on `Valid`, mirroring the existing pattern for `gtid` and `connection_id`. `ResultRow.BinlogFile` stays plain `string` so JSON / CSV / table output is unchanged (empty string instead of `null`).
- Adds a `sqlmock`-based unit regression test covering the failing Scan path and a second test confirming the JSON formatter emits `""` for NULL rows.

Closes #318

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/query/... -count=1`
- [ ] `go test -tags integration ./internal/query/... -count=1` (not run — no MySQL container available in this worktree; unit test fully exercises the fix via sqlmock)