### PR TITLE
fix(shim): lower ProxySQL monitor user auth-failure log to DEBUG (#316)

### DIFF
--- a/cmd/bintrail/shim.go
+++ b/cmd/bintrail/shim.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -332,6 +333,14 @@ func isLoopbackAddr(addr net.Addr) bool {
 // operator can correlate ProxySQL alerts with the shim's view of the
 // failure without an alarming ERROR line per monitor probe.
 //
+// Exception: ProxySQL's built-in MySQL Monitor module opens a
+// handshake every ~1-10s against every backend in its hostgroups
+// (including the shim) using the username `monitor`. The shim does
+// not — and must not — recognise this user, so the handshake fails
+// with the same 1045 every probe interval, drowning real auth
+// failures in the steady-state log. Demote `monitor` ER_ACCESS_DENIED
+// to Debug; everything else stays at Info. See issue #316.
+//
 // Anything else is unexpected (bad packet, protocol mismatch, …) and
 // stays at Error so it surfaces in alerting.
 //
@@ -346,9 +355,43 @@ func classifyHandshakeErr(err error) (slog.Level, string) {
 	}
 	var myErr *gomysql.MyError
 	if errors.As(err, &myErr) && myErr.Code == gomysql.ER_ACCESS_DENIED_ERROR {
+		if isMonitorAuthFailure(myErr.Message) {
+			return slog.LevelDebug, "mysql auth failed (proxysql monitor probe)"
+		}
 		return slog.LevelInfo, "mysql auth failed"
 	}
 	return slog.LevelError, "mysql handshake failed"
+}
+
+// isMonitorAuthFailure reports whether an ER_ACCESS_DENIED_ERROR
+// message names ProxySQL's monitor user. The 1045 message is
+// formatted as `Access denied for user '<user>'@'<host>' (using
+// password: ...)` — see mysql.MySQLErrName[ER_ACCESS_DENIED_ERROR]
+// in go-mysql v1.13.0. We extract the substring between the first
+// pair of single quotes and compare case-insensitively against
+// "monitor".
+//
+// The (*Conn).handshake path is the only producer of this exact
+// message in the shim, so the format is stable — go-mysql doesn't
+// localise mysql.MySQLErrName. A go-mysql upgrade that changes the
+// format would silently route monitor failures back through the Info
+// branch; the unit test below pins the parsing against the literal
+// error go-mysql constructs today.
+//
+// Returns false on any parse failure — we'd rather over-log a probe
+// than mistakenly silence a real auth failure for a tenant whose name
+// happens to contain quote-adjacent metacharacters.
+func isMonitorAuthFailure(msg string) bool {
+	openQuote := strings.IndexByte(msg, '\'')
+	if openQuote < 0 {
+		return false
+	}
+	rest := msg[openQuote+1:]
+	closeQuote := strings.IndexByte(rest, '\'')
+	if closeQuote < 0 {
+		return false
+	}
+	return strings.EqualFold(rest[:closeQuote], "monitor")
 }
 
 // buildUserSchemas derives the per-tenant default schema for shim

--- a/cmd/bintrail/shim_test.go
+++ b/cmd/bintrail/shim_test.go
@@ -201,9 +201,12 @@ func (l *alwaysErrorListener) Addr() net.Addr {
 //
 // EOF / mysql.ErrBadConn are go-mysql's wrapped read errors when
 // ProxySQL's monitor opens a TCP socket and closes it; they must be
-// debug. ER_ACCESS_DENIED_ERROR is what TenantAuth.GetCredential
-// causes go-mysql/server to return — info, never error. Anything
-// else stays at error.
+// debug. ER_ACCESS_DENIED_ERROR for a real tenant user is what
+// TenantAuth.GetCredential causes go-mysql/server to return — info,
+// never error. ER_ACCESS_DENIED_ERROR for the ProxySQL `monitor`
+// user is demoted to debug per issue #316 (the monitor probes every
+// ~1-10s and would otherwise drown real auth failures in info-level
+// noise). Anything else stays at error.
 func TestClassifyHandshakeErr(t *testing.T) {
 	cases := []struct {
 		name      string
@@ -218,7 +221,11 @@ func TestClassifyHandshakeErr(t *testing.T) {
 		// deps directly") — the production behaviour is what matters, and errors.Is
 		// resolves both wrap shapes the same way.
 		{"wrapped ErrBadConn", fmt.Errorf("io.ReadFull(header) failed: %w", gomysql.ErrBadConn), slog.LevelDebug},
-		{"ER_ACCESS_DENIED_ERROR", gomysql.NewDefaultError(gomysql.ER_ACCESS_DENIED_ERROR, "monitor", "127.0.0.1:46948", "YES"), slog.LevelInfo},
+		// ProxySQL monitor user → debug (issue #316).
+		{"ER_ACCESS_DENIED_ERROR monitor user is debug", gomysql.NewDefaultError(gomysql.ER_ACCESS_DENIED_ERROR, "monitor", "127.0.0.1:46948", "YES"), slog.LevelDebug},
+		// Real tenant user → info (the load-bearing claim — without this,
+		// the #316 demote would silence every real auth failure too).
+		{"ER_ACCESS_DENIED_ERROR tenant user is info", gomysql.NewDefaultError(gomysql.ER_ACCESS_DENIED_ERROR, "alice", "127.0.0.1:46948", "YES"), slog.LevelInfo},
 		{"unrelated MyError stays error", gomysql.NewDefaultError(gomysql.ER_HANDSHAKE_ERROR), slog.LevelError},
 		{"plain unrelated error", errors.New("protocol mismatch"), slog.LevelError},
 	}
@@ -230,6 +237,44 @@ func TestClassifyHandshakeErr(t *testing.T) {
 			}
 			if msg == "" {
 				t.Errorf("classifyHandshakeErr msg empty for %v", tc.err)
+			}
+		})
+	}
+}
+
+// TestIsMonitorAuthFailure pins the parser against the literal
+// ER_ACCESS_DENIED_ERROR message go-mysql v1.13.0 emits. A go-mysql
+// upgrade that changes the format would silently route monitor
+// failures back through the info branch — issue #316 would regress.
+// The case-insensitive match is deliberate: ProxySQL ships with the
+// lowercase form, but a tenant deliberately named `Monitor` would
+// also probe at the same cadence, so robust matching wins over
+// surgical case-sensitivity.
+func TestIsMonitorAuthFailure(t *testing.T) {
+	// Build the exact message classifyHandshakeErr unwraps — this is
+	// what (*Conn).handshake constructs via mysql.NewDefaultError when
+	// TenantAuth.GetCredential returns ErrAccessDenied.
+	monitorErr := gomysql.NewDefaultError(gomysql.ER_ACCESS_DENIED_ERROR, "monitor", "127.0.0.1:46948", "YES")
+	tenantErr := gomysql.NewDefaultError(gomysql.ER_ACCESS_DENIED_ERROR, "alice", "127.0.0.1:46948", "YES")
+
+	cases := []struct {
+		name string
+		msg  string
+		want bool
+	}{
+		{"production go-mysql format with monitor", monitorErr.Message, true},
+		{"production go-mysql format with tenant", tenantErr.Message, false},
+		{"uppercase monitor matches", "Access denied for user 'MONITOR'@'127.0.0.1' (using password: YES)", true},
+		{"mixed-case monitor matches", "Access denied for user 'Monitor'@'127.0.0.1' (using password: YES)", true},
+		{"monitor-prefixed user does not match", "Access denied for user 'monitor_special'@'127.0.0.1' (using password: YES)", false},
+		{"no quotes returns false (cannot parse)", "Access denied for user monitor", false},
+		{"single quote without close returns false", "Access denied for user 'monitor", false},
+		{"empty string returns false", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isMonitorAuthFailure(tc.msg); got != tc.want {
+				t.Errorf("isMonitorAuthFailure(%q) = %v, want %v", tc.msg, got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- ProxySQL's built-in MySQL Monitor module probes every backend in its hostgroups (including the shim) every ~1-10s using the username `monitor`. Each probe fails 1045 against the shim — drowning real auth failures in the steady-state log during the Percona Live demo.
- `classifyHandshakeErr` now extracts the username from the 1045 message and demotes `monitor` failures to `slog.LevelDebug`. Real auth failures for non-monitor users still log at `slog.LevelInfo`.
- Pure log-level change. Auth response is unchanged — the shim still rejects the monitor login (no credentials configured). No ProxySQL-side config change.

Closes #316

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./cmd/bintrail/... -count=1` — pass (~12s)
- [x] `go test ./... -count=1` — all packages pass
- [x] Updated `TestClassifyHandshakeErr` to cover both monitor (DEBUG) and tenant (INFO) paths
- [x] Added `TestIsMonitorAuthFailure` to pin the message-parser against the literal go-mysql v1.13.0 format (so a go-mysql upgrade that changes the message format would surface as a failing test rather than a silent regression of #316)

🤖 Generated with [Claude Code](https://claude.com/claude-code)