### PR TITLE
feat(agent): accept --server-uuid for BYOS pre-registered servers (#317)

### DIFF
--- a/cmd/bintrail/agent.go
+++ b/cmd/bintrail/agent.go
@@ -96,7 +96,7 @@ func init() {
 	agentCmd.Flags().StringVar(&agtArchiveS3, "archive-s3", "", "S3 path to Parquet archives (e.g. s3://bucket/prefix/)")
 	agentCmd.Flags().StringVar(&agtBufferRetain, "buffer-retain", "6h", "How long to retain events in the in-memory buffer (e.g. 6h, 24h)")
 	agentCmd.Flags().Uint32Var(&agtServerID, "server-id", 0, "MySQL server ID for replication (required for BYOS streaming)")
-	agentCmd.Flags().StringVar(&agtServerUUID, "server-uuid", "", "UUID of a pre-registered BYOS server (POST /api/v1/servers). When set, the SaaS reconciles this agent's WebSocket connection to that record; when empty, the SaaS auto-creates a new byos-<server-id> record (back-compat).")
+	agentCmd.Flags().StringVar(&agtServerUUID, "server-uuid", "", "UUID of a pre-registered BYOS server (POST /api/v1/servers). When set, the SaaS reconciles this agent's WebSocket connection to that record; when empty, the SaaS auto-creates a new byos-<server-id> record (back-compat). WARNING: a UUID that doesn't match a pre-registered server — whether because of a typo or because the SaaS predates the matching reconciliation logic — is currently *silently ignored* and the SaaS still creates a byos-<server-id> duplicate. After first connect, verify in the dbtrail dashboard that no duplicate record was created.")
 	agentCmd.Flags().IntVar(&agtBatchSize, "batch-size", 1000, "Number of events per batch flush")
 	agentCmd.Flags().StringVar(&agtSchemas, "schemas", "", "Comma-separated list of schemas to index (empty = all)")
 	agentCmd.Flags().StringVar(&agtTables, "tables", "", "Comma-separated list of tables to index (empty = all)")
@@ -132,6 +132,14 @@ func runAgent(cmd *cobra.Command, args []string) error {
 	// the legacy auto-create-on-connect behavior (back-compat). See #317.
 	if err := validateServerUUID(agtServerUUID); err != nil {
 		return err
+	}
+	// Surface the effective UUID at startup so an env-file typo or accidental
+	// re-export is visible in the log right next to the connect line. The
+	// SaaS does not currently echo back the reconciled record, so this is the
+	// only place an operator can confirm what the agent will send. See #317
+	// silent-failure findings C2/C3.
+	if agtServerUUID != "" {
+		slog.Info("agent using --server-uuid", "server_uuid", agtServerUUID, "hint", "verify in dbtrail dashboard that no duplicate byos-<server-id> record was created after first connect")
 	}
 
 	start := time.Now()

--- a/cmd/bintrail/agent.go
+++ b/cmd/bintrail/agent.go
@@ -17,6 +17,7 @@ import (
 
 	gomysql "github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/go-mysql-org/go-mysql/replication"
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
 	"github.com/dbtrail/bintrail/internal/agent"
@@ -71,6 +72,7 @@ var (
 	agtArchiveS3            string
 	agtBufferRetain         string
 	agtServerID             uint32
+	agtServerUUID           string
 	agtBatchSize            int
 	agtSchemas              string
 	agtTables               string
@@ -94,6 +96,7 @@ func init() {
 	agentCmd.Flags().StringVar(&agtArchiveS3, "archive-s3", "", "S3 path to Parquet archives (e.g. s3://bucket/prefix/)")
 	agentCmd.Flags().StringVar(&agtBufferRetain, "buffer-retain", "6h", "How long to retain events in the in-memory buffer (e.g. 6h, 24h)")
 	agentCmd.Flags().Uint32Var(&agtServerID, "server-id", 0, "MySQL server ID for replication (required for BYOS streaming)")
+	agentCmd.Flags().StringVar(&agtServerUUID, "server-uuid", "", "UUID of a pre-registered BYOS server (POST /api/v1/servers). When set, the SaaS reconciles this agent's WebSocket connection to that record; when empty, the SaaS auto-creates a new byos-<server-id> record (back-compat).")
 	agentCmd.Flags().IntVar(&agtBatchSize, "batch-size", 1000, "Number of events per batch flush")
 	agentCmd.Flags().StringVar(&agtSchemas, "schemas", "", "Comma-separated list of schemas to index (empty = all)")
 	agentCmd.Flags().StringVar(&agtTables, "tables", "", "Comma-separated list of tables to index (empty = all)")
@@ -123,6 +126,12 @@ func runAgent(cmd *cobra.Command, args []string) error {
 	// expecting "give up fast". Make zero an explicit, intentional opt-in.
 	if agtMaxReconnectAttempts < 0 {
 		return fmt.Errorf("invalid --max-reconnect-attempts %d: must be >= 0 (use 0 explicitly for unlimited retries)", agtMaxReconnectAttempts)
+	}
+
+	// Validate --server-uuid format before any side effects. Empty preserves
+	// the legacy auto-create-on-connect behavior (back-compat). See #317.
+	if err := validateServerUUID(agtServerUUID); err != nil {
+		return err
 	}
 
 	start := time.Now()
@@ -384,6 +393,7 @@ func runAgent(cmd *cobra.Command, args []string) error {
 		// empty string would technically work but degrades dashboard
 		// display. cmp.Or keeps the label stable and operator-recognizable.
 		BintrailID:           cmp.Or(bintrailID, fmt.Sprint(agtServerID)),
+		ServerUUID:           agtServerUUID,
 		MaxReconnectAttempts: agtMaxReconnectAttempts,
 	}
 
@@ -970,6 +980,21 @@ func buildResolverFromSource(sourceDB *sql.DB, schemas []string) (*metadata.Reso
 	}
 
 	return metadata.NewResolverFromTables(0, tables), nil
+}
+
+// validateServerUUID enforces that --server-uuid (when supplied) is a
+// well-formed UUID. An empty string is allowed and preserves the legacy
+// auto-create-on-connect SaaS behavior (back-compat); a malformed value
+// is rejected up-front so the operator gets a clear error instead of a
+// silent mis-association on the SaaS side. See issue #317.
+func validateServerUUID(s string) error {
+	if s == "" {
+		return nil
+	}
+	if _, err := uuid.Parse(s); err != nil {
+		return fmt.Errorf("invalid --server-uuid %q: must be a valid UUID (e.g. 550e8400-e29b-41d4-a716-446655440000) or empty for back-compat: %w", s, err)
+	}
+	return nil
 }
 
 // validateBYOSFlushConfig enforces that a BYOS-mode agent has a configured

--- a/cmd/bintrail/agent_test.go
+++ b/cmd/bintrail/agent_test.go
@@ -570,6 +570,25 @@ func TestAgentCLI_RejectsInvalidServerUUID(t *testing.T) {
 	}
 }
 
+// TestAgentServerUUIDHelpWarnsAboutSilentIgnore guards the warning that
+// closes the SaaS-side silent-ignore window documented in #317. If the
+// dbtrail SaaS predates the matching reconciliation logic, sending a
+// --server-uuid does NOT prevent a duplicate byos-<server-id> record —
+// the help text must surface that explicitly so operators verify in the
+// dashboard rather than assuming success.
+func TestAgentServerUUIDHelpWarnsAboutSilentIgnore(t *testing.T) {
+	flag := agentCmd.Flag("server-uuid")
+	if flag == nil {
+		t.Fatal("--server-uuid flag not registered")
+	}
+	usage := flag.Usage
+	for _, want := range []string{"silently ignored", "dbtrail dashboard"} {
+		if !strings.Contains(usage, want) {
+			t.Errorf("--server-uuid help missing %q; full usage: %s", want, usage)
+		}
+	}
+}
+
 func TestParseByteSize(t *testing.T) {
 	tests := []struct {
 		input string

--- a/cmd/bintrail/agent_test.go
+++ b/cmd/bintrail/agent_test.go
@@ -392,6 +392,7 @@ func TestAgentFlagRegistration(t *testing.T) {
 	for _, name := range []string{
 		"api-key", "endpoint", "index-dsn", "source-dsn",
 		"archive-dir", "archive-s3", "buffer-retain", "server-id",
+		"server-uuid",
 		"batch-size", "schemas", "tables", "start-gtid",
 		"s3-bucket", "s3-region", "s3-prefix", "flush-interval",
 		"buffer-max-events", "buffer-max-bytes",
@@ -478,6 +479,94 @@ func TestValidateBYOSFlushConfig(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 		})
+	}
+}
+
+func TestValidateServerUUID(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name:    "empty is allowed for back-compat",
+			input:   "",
+			wantErr: false,
+		},
+		{
+			name:    "valid canonical UUID accepted",
+			input:   "550e8400-e29b-41d4-a716-446655440000",
+			wantErr: false,
+		},
+		{
+			name:    "valid lowercase UUID accepted",
+			input:   "183819c0-0000-0000-0000-000000000000",
+			wantErr: false,
+		},
+		{
+			name:      "malformed UUID rejected",
+			input:     "not-a-uuid",
+			wantErr:   true,
+			errSubstr: "invalid --server-uuid",
+		},
+		{
+			name:      "numeric server-id rejected",
+			input:     "202",
+			wantErr:   true,
+			errSubstr: "invalid --server-uuid",
+		},
+		{
+			name:      "truncated UUID rejected",
+			input:     "550e8400-e29b-41d4-a716",
+			wantErr:   true,
+			errSubstr: "invalid --server-uuid",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateServerUUID(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if tt.errSubstr != "" && !strings.Contains(err.Error(), tt.errSubstr) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.errSubstr)
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// TestAgentCLI_RejectsInvalidServerUUID verifies that the agent command
+// rejects a malformed --server-uuid passed through cobra's flag parser
+// before any side effects (DB connect, WebSocket dial) occur. Empty is
+// allowed and preserves the legacy auto-create-on-connect SaaS behavior.
+// See issue #317.
+func TestAgentCLI_RejectsInvalidServerUUID(t *testing.T) {
+	// Save and restore the package-level flag global so this test does
+	// not leak state into sibling tests that read agentCmd.
+	saved := agtServerUUID
+	t.Cleanup(func() { agtServerUUID = saved })
+
+	// Drive the flag through cobra's actual parser — this exercises the
+	// same code path a real `bintrail agent --server-uuid foo` invocation
+	// would hit (flag definition, name, type).
+	if err := agentCmd.ParseFlags([]string{"--server-uuid", "not-a-uuid"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	if agtServerUUID != "not-a-uuid" {
+		t.Fatalf("agtServerUUID = %q, want %q after ParseFlags", agtServerUUID, "not-a-uuid")
+	}
+
+	err := validateServerUUID(agtServerUUID)
+	if err == nil {
+		t.Fatal("expected error for invalid --server-uuid, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid --server-uuid") {
+		t.Errorf("error = %q, want it to contain 'invalid --server-uuid'", err.Error())
 	}
 }
 

--- a/cmd/bintrail/config.go
+++ b/cmd/bintrail/config.go
@@ -106,6 +106,12 @@ var envSections = []envSection{
 		Header: "Server identity",
 		Bindings: []envTemplateEntry{
 			{"BINTRAIL_ID", ""},
+			// Optional: UUID of a pre-registered BYOS server returned by
+			// POST /api/v1/servers. When set, the agent's WebSocket connect
+			// is reconciled to that server record; when unset, the SaaS
+			// auto-creates a new byos-<server-id> record (back-compat).
+			// See issue #317.
+			{"BINTRAIL_SERVER_UUID", ""},
 		},
 	},
 	{

--- a/cmd/bintrail/envload.go
+++ b/cmd/bintrail/envload.go
@@ -32,6 +32,7 @@ var envBindings = []envBinding{
 	{"archive-s3", "BINTRAIL_ARCHIVE_S3"},
 	{"archive-s3-region", "BINTRAIL_ARCHIVE_S3_REGION"},
 	{"server-id", "BINTRAIL_SERVER_ID"},
+	{"server-uuid", "BINTRAIL_SERVER_UUID"},
 	{"batch-size", "BINTRAIL_BATCH_SIZE"},
 	{"s3-bucket", "BINTRAIL_S3_BUCKET"},
 	{"s3-region", "BINTRAIL_S3_REGION"},

--- a/internal/agent/channel.go
+++ b/internal/agent/channel.go
@@ -30,6 +30,15 @@ type ChannelConfig struct {
 	// BintrailID is the server identity reported in heartbeats.
 	BintrailID string
 
+	// ServerUUID is the optional pre-registered server UUID supplied by the
+	// operator via `bintrail agent --server-uuid <uuid>`. When non-empty it
+	// is sent in the WebSocket dial as the `X-Bintrail-Server-UUID` header
+	// so the dbtrail backend can reconcile the connection to an existing
+	// server record (created via POST /api/v1/servers) instead of
+	// auto-creating a duplicate `byos-<server-id>` row. Empty preserves the
+	// legacy behavior. See issue #317.
+	ServerUUID string
+
 	// HeartbeatInterval controls how often heartbeats are sent.
 	// Zero defaults to 30 seconds.
 	HeartbeatInterval time.Duration
@@ -234,10 +243,17 @@ func (ch *Channel) connectAndListen(ctx context.Context) error {
 }
 
 // dial opens the WebSocket connection with the API key in the
-// Authorization header.
+// Authorization header. When ServerUUID is set, the pre-registered server
+// UUID is sent as X-Bintrail-Server-UUID so the SaaS reconciles to that
+// record instead of creating a duplicate byos-<server-id>. The header is
+// omitted entirely when ServerUUID is empty so an older backend isn't
+// confused by an empty value. See issue #317.
 func (ch *Channel) dial(ctx context.Context) (*websocket.Conn, error) {
 	header := http.Header{}
 	header.Set("Authorization", "Bearer "+ch.cfg.APIKey)
+	if ch.cfg.ServerUUID != "" {
+		header.Set("X-Bintrail-Server-UUID", ch.cfg.ServerUUID)
+	}
 
 	conn, _, err := websocket.Dial(ctx, ch.cfg.Endpoint, &websocket.DialOptions{
 		HTTPHeader: header,

--- a/internal/agent/channel_test.go
+++ b/internal/agent/channel_test.go
@@ -364,6 +364,111 @@ func TestChannel_authHeader(t *testing.T) {
 	cancel()
 }
 
+// TestChannel_serverUUIDHeader verifies that when ChannelConfig.ServerUUID
+// is set, the agent sends it in the X-Bintrail-Server-UUID header on the
+// initial WebSocket dial so the SaaS can reconcile the connection to a
+// pre-registered server record (issue #317).
+func TestChannel_serverUUIDHeader(t *testing.T) {
+	type captured struct {
+		auth     string
+		uuid     string
+		uuidSent bool
+	}
+	gotCh := make(chan captured, 1)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, uuidSent := r.Header["X-Bintrail-Server-Uuid"]
+		gotCh <- captured{
+			auth:     r.Header.Get("Authorization"),
+			uuid:     r.Header.Get("X-Bintrail-Server-UUID"),
+			uuidSent: uuidSent,
+		}
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		conn.Close(websocket.StatusNormalClosure, "")
+	}))
+	defer srv.Close()
+
+	cfg := ChannelConfig{
+		Endpoint:          "ws" + strings.TrimPrefix(srv.URL, "http"),
+		APIKey:            "test-key",
+		ServerUUID:        "550e8400-e29b-41d4-a716-446655440000",
+		HeartbeatInterval: time.Hour,
+		MaxReconnectDelay: 50 * time.Millisecond,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	go func() {
+		ch := NewChannel(cfg, &stubHandler{}, nil, nil)
+		ch.Run(ctx)
+	}()
+
+	select {
+	case got := <-gotCh:
+		if got.auth != "Bearer test-key" {
+			t.Errorf("auth = %q, want %q", got.auth, "Bearer test-key")
+		}
+		if !got.uuidSent {
+			t.Error("X-Bintrail-Server-UUID header was not sent")
+		}
+		if got.uuid != "550e8400-e29b-41d4-a716-446655440000" {
+			t.Errorf("X-Bintrail-Server-UUID = %q, want %q", got.uuid, "550e8400-e29b-41d4-a716-446655440000")
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for dial")
+	}
+	cancel()
+}
+
+// TestChannel_serverUUIDHeaderOmittedWhenEmpty verifies that an empty
+// ServerUUID does NOT add an X-Bintrail-Server-UUID header at all (rather
+// than sending an empty value), so older SaaS deployments that don't know
+// about the header are unaffected and back-compat is preserved.
+func TestChannel_serverUUIDHeaderOmittedWhenEmpty(t *testing.T) {
+	gotCh := make(chan bool, 1) // header present?
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, present := r.Header["X-Bintrail-Server-Uuid"]
+		gotCh <- present
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		conn.Close(websocket.StatusNormalClosure, "")
+	}))
+	defer srv.Close()
+
+	cfg := ChannelConfig{
+		Endpoint:          "ws" + strings.TrimPrefix(srv.URL, "http"),
+		APIKey:            "test-key",
+		ServerUUID:        "", // empty — header must be omitted
+		HeartbeatInterval: time.Hour,
+		MaxReconnectDelay: 50 * time.Millisecond,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	go func() {
+		ch := NewChannel(cfg, &stubHandler{}, nil, nil)
+		ch.Run(ctx)
+	}()
+
+	select {
+	case present := <-gotCh:
+		if present {
+			t.Error("X-Bintrail-Server-UUID header should be omitted when ServerUUID is empty")
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for dial")
+	}
+	cancel()
+}
+
 // ─── Handler tests ───────────────────────────────────────────────────────────
 
 func TestByosPKHash(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds `--server-uuid <uuid>` (and `BINTRAIL_SERVER_UUID` env var) to `bintrail agent`. When set, the agent sends an `X-Bintrail-Server-UUID` header on its WebSocket dial so the dbtrail SaaS can reconcile the connection to a pre-registered server record (created via `POST /api/v1/servers`) instead of auto-creating a duplicate `byos-<server-id>` row.

Before this change, the numeric `--server-id` (MySQL replica ID) was the only correlation key the SaaS had, so tenants who pre-registered servers ended up with N+1 server records and the pre-registered ones never transitioned past `onboarding_step=waiting_for_agent`.

### What changed

- New `--server-uuid` flag on `bintrail agent` (variable `agtServerUUID`)
- Bound to `BINTRAIL_SERVER_UUID` via `envBindings` in `cmd/bintrail/envload.go`
- Added to the "Server identity" section of `bintrail config init` template
- Validated up-front in `runAgent` — empty is allowed (back-compat); non-empty must be a valid UUID (rejected via `github.com/google/uuid`, already vendored, no new dep)
- New `ChannelConfig.ServerUUID` field forwarded into the WebSocket dial as `X-Bintrail-Server-UUID`. Header is omitted entirely when empty so an older SaaS isn't confused by a blank value.
- Help text on the flag now WARNS that an unmatched UUID is silently ignored (see below) and that operators must verify in the dbtrail dashboard
- Startup `slog.Info` line surfaces the effective `--server-uuid` (sourced from env or CLI) so env-file typos and accidental re-exports are visible right next to the connect line

## ⚠️ Known silent-ignore window — read before merging

Until the matching SaaS-side PR in nethalo/dbtrail lands, the `X-Bintrail-Server-UUID` header is sent but **not read** by the WebSocket handler. As a result:

1. An operator who deploys this build against the current SaaS sees `connected to dbtrail`, a green dashboard, and a freshly-created **duplicate `byos-<server-id>` record** — the exact failure mode this PR is supposed to fix, hidden behind apparent success.
2. A typo'd-but-syntactically-valid UUID (`…0001` instead of `…0000`) has the same outcome — the SaaS can't find the record, falls back to duplicate creation, no error surfaces.

The defenses in this PR (help-text warning, startup INFO log) make the window **visible** to operators but do **not** close it. Full closure requires:

- nethalo/dbtrail WebSocket handler to read the header and reconcile to a pre-registered record
- Ideally the SaaS echoes the resolved record ID back in the dial response or first heartbeat reply so the agent can log a hard "reconciled to server X" vs "server did not acknowledge UUID — backend may be pre-#317" — see follow-up issues recommended below

## Follow-ups recommended (not in this PR)

- Coordinate with SaaS PR to add `unknown_server_uuid` to `ClassifyClose` switch so a permanent UUID-mismatch close terminates the agent fast instead of reconnect-looping until `--max-reconnect-attempts`
- `internal/agent/channel.go` `dial()` discards `*http.Response` — capture it and classify 4xx as permanent so a future "SaaS rejects unknown UUID" doesn't loop on HTTP-upgrade errors
- Normalize the UUID to canonical lowercase-hyphenated form (`uuid.Parse(s).String()`) before forwarding so two operators registering the same logical server with different casing/braces don't send divergent header values

Closes #317

## Test plan

- [x] `go build ./...` — passes
- [x] `go vet ./...` — passes
- [x] `go test ./... -count=1` — full unit suite passes
- [x] `TestValidateServerUUID` covers empty (allowed), valid canonical UUID, valid lowercase UUID, malformed input, numeric input, truncated input
- [x] `TestAgentCLI_RejectsInvalidServerUUID` parses `--server-uuid not-a-uuid` through cobra
- [x] `TestChannel_serverUUIDHeader` asserts header is sent
- [x] `TestChannel_serverUUIDHeaderOmittedWhenEmpty` asserts header is absent (not blank) when empty
- [x] `TestAgentServerUUIDHelpWarnsAboutSilentIgnore` pins the help-text warning so it cannot rot
- [ ] Manual SaaS-side integration — gated on the matching nethalo/dbtrail PR landing

## Notes for reviewer

- PR #320 (fix for #308) also modifies `cmd/bintrail/agent.go` to use `config.CurrentBinlogPosition`. The regions touched are different — no real conflict, possibly a trivial resolution if both merge in sequence.
- The brief said `bindCommandEnv` would pick up the new flag automatically — it does not (it iterates an explicit `envBindings` table in `envload.go`). Added the entry there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)