### PR TITLE
fix: defensive Scan for every NOT NULL column in binlog_events

### DIFF
--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -80,22 +80,28 @@ func ArchivePartition(ctx context.Context, db *sql.DB, dbName, partition, output
 
 	var rowCount int64
 	for rows.Next() {
+		// Every NOT NULL column is scanned defensively and its
+		// Valid bit is propagated into the nulls[] slice so the Parquet
+		// writer preserves true NULL. See dbtrail/bintrail#318 for the
+		// production observation that "NOT NULL" cannot be trusted in
+		// drifted/external-pipeline-fed indexes. event_id stays a bare
+		// uint64 since AUTO_INCREMENT cannot return NULL.
 		var (
 			eventID        uint64
 			binlogFile     sql.NullString
-			startPos       uint64
-			endPos         uint64
-			eventTimestamp time.Time
+			startPos       sql.NullInt64
+			endPos         sql.NullInt64
+			eventTimestamp sql.NullTime
 			gtid           sql.NullString
 			connID         sql.NullInt64
-			schemaName     string
-			tableName      string
-			eventType      uint8
-			pkValues       string
+			schemaName     sql.NullString
+			tableName      sql.NullString
+			eventType      sql.NullInt32
+			pkValues       sql.NullString
 			changedColumns []byte // nil = NULL
 			rowBefore      []byte // nil = NULL
 			rowAfter       []byte // nil = NULL
-			schemaVersion  uint32
+			schemaVersion  sql.NullInt32
 		)
 		if err := rows.Scan(
 			&eventID, &binlogFile, &startPos, &endPos, &eventTimestamp,
@@ -109,35 +115,44 @@ func ArchivePartition(ctx context.Context, db *sql.DB, dbName, partition, output
 		if connID.Valid {
 			connIDStr = strconv.FormatInt(connID.Int64, 10)
 		}
+		eventTimestampStr := ""
+		if eventTimestamp.Valid {
+			eventTimestampStr = eventTimestamp.Time.UTC().Format("2006-01-02 15:04:05")
+		}
 
 		values := []string{
 			strconv.FormatUint(eventID, 10),
 			binlogFile.String,
-			strconv.FormatUint(startPos, 10),
-			strconv.FormatUint(endPos, 10),
-			eventTimestamp.UTC().Format("2006-01-02 15:04:05"),
+			strconv.FormatInt(startPos.Int64, 10),
+			strconv.FormatInt(endPos.Int64, 10),
+			eventTimestampStr,
 			gtid.String,
 			connIDStr,
-			schemaName,
-			tableName,
-			strconv.FormatUint(uint64(eventType), 10),
-			pkValues,
+			schemaName.String,
+			tableName.String,
+			strconv.FormatInt(int64(eventType.Int32), 10),
+			pkValues.String,
 			string(changedColumns),
 			string(rowBefore),
 			string(rowAfter),
-			strconv.FormatUint(uint64(schemaVersion), 10),
+			strconv.FormatInt(int64(schemaVersion.Int32), 10),
 		}
 		nulls := []bool{
-			false,
-			!binlogFile.Valid, // binlog_file: preserve NULL in Parquet (dbtrail/bintrail#318)
-			false, false, false,
+			false, // event_id (AUTO_INCREMENT, cannot be NULL)
+			!binlogFile.Valid,
+			!startPos.Valid,
+			!endPos.Valid,
+			!eventTimestamp.Valid,
 			!gtid.Valid,
 			!connID.Valid,
-			false, false, false, false,
+			!schemaName.Valid,
+			!tableName.Valid,
+			!eventType.Valid,
+			!pkValues.Valid,
 			changedColumns == nil,
 			rowBefore == nil,
 			rowAfter == nil,
-			false, // schema_version is NOT NULL
+			!schemaVersion.Valid,
 		}
 
 		if err := w.WriteRow(values, nulls); err != nil {

--- a/internal/parquetquery/parquetquery.go
+++ b/internal/parquetquery/parquetquery.go
@@ -774,22 +774,27 @@ func parseFileHour(path string) (time.Time, bool) {
 func scanRows(rows *sql.Rows) ([]query.ResultRow, error) {
 	var results []query.ResultRow
 	for rows.Next() {
+		// Every NOT NULL column is scanned defensively. The Parquet
+		// writer in internal/archive now correctly preserves NULL for
+		// every column its Scan saw as NULL, so the consumer side must
+		// handle the same set. See dbtrail/bintrail#318. event_id stays
+		// a bare int64 since AUTO_INCREMENT cannot be NULL.
 		var (
 			eventID        int64
 			binlogFile     sql.NullString
-			startPos       int64
-			endPos         int64
-			eventTimestamp time.Time
+			startPos       sql.NullInt64
+			endPos         sql.NullInt64
+			eventTimestamp sql.NullTime
 			gtid           sql.NullString
 			connID         sql.NullInt64
-			schemaName     string
-			tableName      string
-			eventType      int32
-			pkValues       string
+			schemaName     sql.NullString
+			tableName      sql.NullString
+			eventType      sql.NullInt32
+			pkValues       sql.NullString
 			changedCols    sql.NullString
 			rowBefore      sql.NullString
 			rowAfter       sql.NullString
-			schemaVersion  int32
+			schemaVersion  sql.NullInt32
 		)
 		if err := rows.Scan(
 			&eventID, &binlogFile, &startPos, &endPos, &eventTimestamp,
@@ -802,14 +807,14 @@ func scanRows(rows *sql.Rows) ([]query.ResultRow, error) {
 		r := query.ResultRow{
 			EventID:        uint64(eventID),
 			BinlogFile:     binlogFile.String,
-			StartPos:       uint64(startPos),
-			EndPos:         uint64(endPos),
-			EventTimestamp: eventTimestamp,
-			SchemaName:     schemaName,
-			TableName:      tableName,
-			EventType:      parser.EventType(eventType),
-			PKValues:       pkValues,
-			SchemaVersion:  uint32(schemaVersion),
+			StartPos:       uint64(startPos.Int64),
+			EndPos:         uint64(endPos.Int64),
+			EventTimestamp: eventTimestamp.Time,
+			SchemaName:     schemaName.String,
+			TableName:      tableName.String,
+			EventType:      parser.EventType(eventType.Int32),
+			PKValues:       pkValues.String,
+			SchemaVersion:  uint32(schemaVersion.Int32),
 		}
 		if gtid.Valid {
 			r.GTID = &gtid.String

--- a/internal/parquetquery/parquetquery.go
+++ b/internal/parquetquery/parquetquery.go
@@ -448,9 +448,21 @@ func canTerminateEarly(results []query.ResultRow, remainingFiles []string, limit
 	if len(results) < limit || len(remainingFiles) == 0 {
 		return false
 	}
-	// Sort results to find the limit-th by (event_timestamp, event_id).
-	sorted := make([]query.ResultRow, len(results))
-	copy(sorted, results)
+	// Filter out drift rows with zero timestamp (dbtrail/bintrail#318).
+	// They sort to year 0001 and would otherwise pin cutoff to the past,
+	// making every remaining file's hour appear after it → early
+	// termination silently drops all later real data.
+	sorted := make([]query.ResultRow, 0, len(results))
+	for _, r := range results {
+		if !r.EventTimestamp.IsZero() {
+			sorted = append(sorted, r)
+		}
+	}
+	if len(sorted) < limit {
+		// After filtering, we don't have enough real-timestamp rows to
+		// ground a cutoff — keep reading.
+		return false
+	}
 	slices.SortFunc(sorted, func(a, b query.ResultRow) int {
 		if c := a.EventTimestamp.Compare(b.EventTimestamp); c != 0 {
 			return c

--- a/internal/parquetquery/parquetquery_test.go
+++ b/internal/parquetquery/parquetquery_test.go
@@ -765,6 +765,41 @@ func TestCanTerminateEarly(t *testing.T) {
 			t.Error("should not terminate: no remaining files")
 		}
 	})
+
+	t.Run("drift rows with zero timestamp do not pin cutoff (dbtrail/bintrail#318)", func(t *testing.T) {
+		// Drift rows from defensive scanRows have time.Time{} (year 0001).
+		// Before the guard, if limit drift rows arrived from an early file,
+		// cutoff was year 0001 → every later file appeared fully after cutoff
+		// → silent early-termination dropped real data.
+		results := []query.ResultRow{
+			mkRow(time.Time{}, 100),                                          // drift
+			mkRow(time.Time{}, 101),                                          // drift
+			mkRow(time.Date(2026, 3, 9, 13, 30, 0, 0, time.UTC), 1),          // real
+		}
+		remaining := []string{"s3://b/event_date=2026-03-09/event_hour=11/e.parquet"}
+		// limit=3 means we'd need 3 real-timestamp rows to ground a cutoff,
+		// but we only have 1. Must not terminate.
+		if canTerminateEarly(results, remaining, 3) {
+			t.Error("should not terminate: only 1 non-drift row, cannot ground cutoff")
+		}
+	})
+
+	t.Run("drift rows do not poison cutoff when enough real rows exist", func(t *testing.T) {
+		// limit=2, three real rows + two drift rows. Cutoff must be based
+		// on the real rows alone: sorted real rows at limit-th=2 is 10:30.
+		// Next file is hour=11 → can terminate.
+		results := []query.ResultRow{
+			mkRow(time.Time{}, 100),                                  // drift
+			mkRow(time.Date(2026, 3, 9, 10, 30, 0, 0, time.UTC), 2),
+			mkRow(time.Time{}, 101),                                  // drift
+			mkRow(time.Date(2026, 3, 9, 10, 15, 0, 0, time.UTC), 1),
+			mkRow(time.Date(2026, 3, 9, 10, 45, 0, 0, time.UTC), 3),
+		}
+		remaining := []string{"s3://b/event_date=2026-03-09/event_hour=11/e.parquet"}
+		if !canTerminateEarly(results, remaining, 2) {
+			t.Error("expected early termination: 2nd real row (10:30) is before hour=11, drift rows filtered out")
+		}
+	})
 }
 
 // ─── drainSlots / removeTempFile (pipeline cleanup) ─────────────────────────

--- a/internal/query/merge.go
+++ b/internal/query/merge.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"cmp"
+	"fmt"
 	"slices"
 )
 
@@ -75,6 +76,15 @@ func LimitPerPK(rows []ResultRow, n int) []ResultRow {
 	// Walk in reverse so the latest events per PK are seen first and kept.
 	for i := len(rows) - 1; i >= 0; i-- {
 		pk := rows[i].PKValues
+		// Drift rows (PKValues == "" from defensive scan of NULL
+		// pk_values, dbtrail/bintrail#318) would otherwise all collapse
+		// onto bucket "" and silently drop beyond the cap, AND collide
+		// with any legitimate empty-PK rows. Give each its own per-row
+		// bucket so they pass through unconditionally — the \x00
+		// prefix can never appear in a real user-supplied PK string.
+		if pk == "" {
+			pk = fmt.Sprintf("\x00drift:%d", rows[i].EventID)
+		}
 		if counts[pk] < n {
 			counts[pk]++
 			keep[i] = true

--- a/internal/query/merge_test.go
+++ b/internal/query/merge_test.go
@@ -150,3 +150,36 @@ func TestMergeAndTrim_crossSourceDedup(t *testing.T) {
 		t.Errorf("expected events [2,3] (latest 2 in ASC order), got %v", []uint64{got[0].EventID, got[1].EventID})
 	}
 }
+
+// TestLimitPerPK_driftRowsBucketIndependently pins the dbtrail/bintrail#318
+// guard: drift rows from the defensive scanRows have PKValues=="" and would,
+// under the original bucket-by-PK logic, all collapse onto bucket "" — the
+// first n in reverse are kept, the rest silently dropped, and they collide
+// with any legitimate empty-PK rows. The fix gives each empty-PK row its own
+// per-row bucket so all pass through, regardless of n.
+func TestLimitPerPK_driftRowsBucketIndependently(t *testing.T) {
+	ts := time.Date(2026, 5, 23, 14, 0, 0, 0, time.UTC)
+	rows := []ResultRow{
+		{EventID: 1, EventTimestamp: ts, PKValues: ""}, // drift
+		{EventID: 2, EventTimestamp: ts, PKValues: ""}, // drift
+		{EventID: 3, EventTimestamp: ts, PKValues: ""}, // drift
+		{EventID: 4, EventTimestamp: ts, PKValues: "a"},
+		{EventID: 5, EventTimestamp: ts, PKValues: "a"},
+		{EventID: 6, EventTimestamp: ts, PKValues: "a"},
+	}
+	// LimitPerPK=1 caps real PK "a" to 1, but every drift row must
+	// survive because each gets its own bucket.
+	got := LimitPerPK(rows, 1)
+	if len(got) != 4 {
+		t.Fatalf("expected 4 rows (3 drift + 1 capped real PK), got %d: %+v", len(got), got)
+	}
+	driftCount := 0
+	for _, r := range got {
+		if r.PKValues == "" {
+			driftCount++
+		}
+	}
+	if driftCount != 3 {
+		t.Errorf("expected all 3 drift rows preserved, got %d", driftCount)
+	}
+}

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -378,24 +378,48 @@ func scanRows(rows *sql.Rows) ([]ResultRow, error) {
 	var results []ResultRow
 	for rows.Next() {
 		var r ResultRow
-		// binlog_file is declared NOT NULL in the migrations, but customer
-		// databases that predate that constraint (or schema_change rows
-		// inserted by external pipelines) can still surface NULL. Scan into
-		// a NullString to stay robust to schema drift.
-		var binlogFile sql.NullString
-		var gtid sql.NullString
-		var connID sql.NullInt64
+		// Every NOT NULL column is scanned defensively. The migrations
+		// declare them NOT NULL, but production has shown that customer
+		// indexes can carry NULL in multiple columns simultaneously —
+		// likely from external pipelines, partial-write paths, or
+		// pre-constraint backfills. The first sighting (#318) was
+		// binlog_file; #1484's deploy verification surfaced start_pos
+		// on the same byos-202 tenant. Defending the entire Scan closes
+		// the pattern. event_id stays a bare uint64 because
+		// AUTO_INCREMENT cannot return NULL on read.
+		var (
+			binlogFile     sql.NullString
+			startPos       sql.NullInt64
+			endPos         sql.NullInt64
+			eventTimestamp sql.NullTime
+			gtid           sql.NullString
+			connID         sql.NullInt64
+			schemaName     sql.NullString
+			tableName      sql.NullString
+			eventType      sql.NullInt32
+			pkValues       sql.NullString
+			schemaVersion  sql.NullInt32
+		)
 		var changedCols, rowBefore, rowAfter []byte
 
 		if err := rows.Scan(
-			&r.EventID, &binlogFile, &r.StartPos, &r.EndPos, &r.EventTimestamp,
-			&gtid, &connID, &r.SchemaName, &r.TableName, &r.EventType, &r.PKValues,
-			&changedCols, &rowBefore, &rowAfter, &r.SchemaVersion,
+			&r.EventID, &binlogFile, &startPos, &endPos, &eventTimestamp,
+			&gtid, &connID, &schemaName, &tableName, &eventType, &pkValues,
+			&changedCols, &rowBefore, &rowAfter, &schemaVersion,
 		); err != nil {
 			return nil, fmt.Errorf("failed to scan result row: %w", err)
 		}
 		if binlogFile.Valid {
 			r.BinlogFile = binlogFile.String
+		}
+		if startPos.Valid {
+			r.StartPos = uint64(startPos.Int64)
+		}
+		if endPos.Valid {
+			r.EndPos = uint64(endPos.Int64)
+		}
+		if eventTimestamp.Valid {
+			r.EventTimestamp = eventTimestamp.Time
 		}
 		if gtid.Valid {
 			r.GTID = &gtid.String
@@ -403,6 +427,21 @@ func scanRows(rows *sql.Rows) ([]ResultRow, error) {
 		if connID.Valid {
 			v := uint32(connID.Int64)
 			r.ConnectionID = &v
+		}
+		if schemaName.Valid {
+			r.SchemaName = schemaName.String
+		}
+		if tableName.Valid {
+			r.TableName = tableName.String
+		}
+		if eventType.Valid {
+			r.EventType = parser.EventType(eventType.Int32)
+		}
+		if pkValues.Valid {
+			r.PKValues = pkValues.String
+		}
+		if schemaVersion.Valid {
+			r.SchemaVersion = uint32(schemaVersion.Int32)
 		}
 		if changedCols != nil {
 			_ = json.Unmarshal(changedCols, &r.ChangedColumns)

--- a/internal/query/query_integration_test.go
+++ b/internal/query/query_integration_test.go
@@ -355,3 +355,80 @@ func TestFetch_nullBinlogFile(t *testing.T) {
 		t.Errorf("row 1: expected BinlogFile=\"\" for NULL column, got %q", rows[1].BinlogFile)
 	}
 }
+
+// TestFetch_allNullableNotNullColumns is the dbtrail/bintrail#1484 deploy
+// verification follow-up: byos-202 surfaced NULL not just in binlog_file
+// (#318) but also in start_pos — proof that production indexes can carry
+// NULL across MANY "NOT NULL" columns simultaneously, not just one. This
+// test relaxes every defended-against column to NULL, inserts a row with
+// NULL in all of them, and asserts Fetch returns it without crashing. A
+// regression that re-introduces a bare-type scan for any one column will
+// fail with the column-specific "converting NULL to X is unsupported".
+//
+// event_timestamp is excluded because it's part of the PRIMARY KEY in
+// the partition definition — MySQL rejects NULL there regardless of the
+// column's own constraint. event_id is excluded because AUTO_INCREMENT
+// cannot return NULL on read. schema_version has DEFAULT 0 so MySQL fills
+// 0 instead of NULL on omission, but is still defended at the scan layer.
+func TestFetch_allNullableNotNullColumns(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	// Relax the NOT NULL on every column that the defensive scanner is
+	// supposed to handle (matches the set of sql.Null* locals in scanRows).
+	for _, alter := range []string{
+		`ALTER TABLE binlog_events MODIFY binlog_file VARCHAR(255) NULL`,
+		`ALTER TABLE binlog_events MODIFY start_pos BIGINT UNSIGNED NULL`,
+		`ALTER TABLE binlog_events MODIFY end_pos BIGINT UNSIGNED NULL`,
+		`ALTER TABLE binlog_events MODIFY schema_name VARCHAR(64) NULL`,
+		`ALTER TABLE binlog_events MODIFY table_name VARCHAR(64) NULL`,
+		`ALTER TABLE binlog_events MODIFY event_type TINYINT UNSIGNED NULL`,
+		`ALTER TABLE binlog_events MODIFY pk_values VARCHAR(512) NULL`,
+		`ALTER TABLE binlog_events MODIFY schema_version INT UNSIGNED NULL`,
+	} {
+		if _, err := db.Exec(alter); err != nil {
+			t.Fatalf("ALTER TABLE failed (%q): %v", alter, err)
+		}
+	}
+
+	// Insert one row populated for sorting + Fetch filter, and one row with
+	// NULL in every defended column. event_timestamp must be set on the
+	// drifted row because it's in the PK.
+	ts := "2026-02-19 14:00:00"
+	testutil.InsertEvent(t, db, "binlog.000001", 100, 200, ts, nil, "mydb", "orders", 1, "1",
+		nil, nil, []byte(`{"id":1}`))
+	if _, err := db.Exec(`INSERT INTO binlog_events
+		(binlog_file, start_pos, end_pos, event_timestamp, gtid,
+		 schema_name, table_name, event_type, pk_values,
+		 changed_columns, row_before, row_after, schema_version)
+		VALUES (NULL, NULL, NULL, ?, NULL,
+		        NULL, NULL, NULL, NULL,
+		        NULL, NULL, NULL, NULL)`,
+		ts,
+	); err != nil {
+		t.Fatalf("insert all-NULL row failed: %v", err)
+	}
+
+	// Fetch without schema/table filters since the drifted row has NULL
+	// schema_name and table_name.
+	e := New(db)
+	rows, err := e.Fetch(context.Background(), Options{Limit: 100})
+	if err != nil {
+		t.Fatalf("Fetch failed: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(rows))
+	}
+
+	// rows[0] is the non-NULL row (lower event_id), rows[1] is the all-NULL
+	// drift row. NULL → zero-value mapping is the documented behavior.
+	if rows[0].BinlogFile != "binlog.000001" || rows[0].SchemaName != "mydb" {
+		t.Errorf("row 0: unexpected values %+v", rows[0])
+	}
+	got := rows[1]
+	if got.BinlogFile != "" || got.StartPos != 0 || got.EndPos != 0 ||
+		got.SchemaName != "" || got.TableName != "" || got.PKValues != "" ||
+		got.EventType != 0 || got.SchemaVersion != 0 {
+		t.Errorf("row 1 (all-NULL drift): expected all zero values, got %+v", got)
+	}
+}

--- a/internal/reconstruct/drift_test.go
+++ b/internal/reconstruct/drift_test.go
@@ -1,0 +1,28 @@
+package reconstruct
+
+import (
+	"testing"
+
+	"github.com/dbtrail/bintrail/internal/query"
+)
+
+// TestApplyEvent_driftRowPreservesState pins the dbtrail/bintrail#318 guard:
+// rows with EventType==0 (the zero value, produced by defensive scanRows
+// when the row's event_type column is NULL) must NOT mutate reconstructed
+// state. The case is wired explicitly so a future refactor that changes the
+// default-branch semantics (e.g. to "treat unknown as a delete") cannot
+// silently produce wrong PITR state for drift rows.
+func TestApplyEvent_driftRowPreservesState(t *testing.T) {
+	initial := map[string]any{"id": 1, "name": "Alice"}
+	drift := query.ResultRow{EventID: 99, EventType: 0}
+
+	got := applyEvent(initial, drift)
+	if len(got) != len(initial) {
+		t.Fatalf("expected state preserved, got %d keys vs %d initial", len(got), len(initial))
+	}
+	for k, v := range initial {
+		if got[k] != v {
+			t.Errorf("key %q: got %v, want %v", k, got[k], v)
+		}
+	}
+}

--- a/internal/reconstruct/reconstruct.go
+++ b/internal/reconstruct/reconstruct.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"slices"
 	"strings"
 	"text/tabwriter"
@@ -292,6 +293,18 @@ func applyEvent(state map[string]any, ev query.ResultRow) map[string]any {
 		return copyMap(ev.RowAfter)
 	case parser.EventDelete:
 		return nil
+	case 0:
+		// EventType==0 is the zero value, produced by the defensive
+		// scanRows in internal/query and internal/parquetquery when the
+		// row's event_type column is NULL (dbtrail/bintrail#318 drift).
+		// Without an explicit case the default branch would silently
+		// no-op, producing wrong PITR state with no operator signal.
+		slog.Warn("reconstruct: skipping drift row with NULL event_type — PITR state may be incomplete",
+			"event_id", ev.EventID,
+			"schema", ev.SchemaName,
+			"table", ev.TableName,
+			"timestamp", ev.EventTimestamp)
+		return state
 	default:
 		return state
 	}


### PR DESCRIPTION
## Summary

Follow-up to #319 / v0.7.8. Deploy verification on byos-202 surfaced the same bug class one column over: after v0.7.8 fixed the `binlog_file` crash, the Explorer crashed with `Scan error on column index 2, name "start_pos": converting NULL to uint64 is unsupported`. Production has NULL in multiple "NOT NULL" columns simultaneously, so the entire Scan must defend.

Reviewed by `silent-failure-hunter` (the agent whose YAGNI call in #319 we're explicitly correcting). The review surfaced 3 NEW silent failures introduced by the defensive scan; those are fixed in the same PR rather than shipped as known-bad.

## What changed

### Defensive scan (commit `cf250a9`)
Every NOT NULL column except `event_id` (AUTO_INCREMENT, cannot return NULL) is now scanned into a local `sql.Null*` and assigned to the result struct only when `.Valid`. Applied to all three Scan sites:

| File | Path |
|---|---|
| `internal/query/query.go` | `Fetch` against MySQL index |
| `internal/archive/archive.go` | `ArchivePartition` writes Parquet for `bintrail rotate` |
| `internal/parquetquery/parquetquery.go` | `Fetch` reads archived Parquet via DuckDB |

`archive.go` additionally propagates each column's `!Valid` into the `nulls[]` slice so the Parquet writer preserves real NULL instead of the zero value.

Columns now defended: `binlog_file` (already in #319), `start_pos`, `end_pos`, `event_timestamp`, `schema_name`, `table_name`, `event_type`, `pk_values`, `schema_version`.

### Downstream silent-failure guards (commit `75b5207`)
The review correctly identified that mapping NULL → zero-value across more columns converts three downstream sites from fail-loud to fail-silent:

1. **`reconstruct.go:applyEvent`** — `EventType==0` hit the `default` branch and silently no-op'd, producing wrong PITR state with no signal. Now: explicit `case 0` that preserves state AND logs a `Warn` naming the affected row.
2. **`merge.go:LimitPerPK`** — drift rows with `PKValues==""` collapsed onto bucket `""`; only n survived, rest silently dropped. Now: empty-PK rows get a per-row bucket (`\x00drift:<event_id>`) so all pass through.
3. **`parquetquery.go:canTerminateEarly`** — drift rows have `time.Time{}` (year 0001), pinned cutoff to the past, silently early-terminated multi-file scans dropping later real data. Now: zero-time rows are filtered before computing cutoff; if too few real rows remain, returns false ("keep reading").

## Why this scope (and why the prior review was wrong)

PR #319's `silent-failure-hunter` reviewer explicitly argued against the broader defense:

> Other Scan targets are event_id/start_pos/end_pos (BIGINT UNSIGNED NOT NULL — drift to NULL would be a much louder migration mistake). Targeted fix is the right scope.

Production proved that wrong. `byos-202` has NULL in both `binlog_file` AND `start_pos` simultaneously — that rules out "ancestral schema-drift" alone and points at an active partial-write source (external pipeline, schema_change rows with empty position fields, or an indexer path that doesn't set every field).

## Test plan

- [x] `go vet ./...`
- [x] `go test ./...` (full unit sweep) — all green
- [x] **New test** `TestFetch_allNullableNotNullColumns`: ALTERs every defended column to allow NULL, inserts a row with NULL in all of them, asserts Fetch returns it without crashing
- [x] **Negative verification**: with `start_pos` defense reverted, the test fails with the EXACT production error from #1484 deploy verification
- [x] **New test** `TestApplyEvent_driftRowPreservesState`: pins that `EventType==0` preserves state explicitly
- [x] **New test** `TestLimitPerPK_driftRowsBucketIndependently`: 3 drift + 3 real-PK rows with cap=1 → 4 rows back (3 drift + 1 capped real)
- [x] **New subtests** in `TestCanTerminateEarly`: zero-time drift rows do not pin cutoff

## Public API note

`ResultRow` fields stay plain (`string`, `uint64`, `time.Time`, etc.) — accepted asymmetry from #319 carried forward. NULL → zero value.

## Follow-up worth filing separately

Investigate the **producer** side. Defensive scanning unblocks consumers but doesn't address how partial rows reach a NOT NULL schema in the first place.

## Downstream

Cuts release v0.7.9, deploys via `/deploy-agent`, then [nethalo/dbtrail#1484](https://github.com/nethalo/dbtrail/issues/1484) actually resolves end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)