### PR TITLE
fix(shim): periodic INFO counter for denied monitor probes (#326)

### DIFF
--- a/cmd/bintrail/shim.go
+++ b/cmd/bintrail/shim.go
@@ -12,6 +12,7 @@ import (
 	"os/signal"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -81,6 +82,30 @@ var (
 	shAllowGaps  bool
 	shAuthMethod string
 )
+
+// monitorDeniedCount counts ER_ACCESS_DENIED_ERROR handshake failures whose
+// username matches ProxySQL's `monitor` (case-insensitive). Per-probe logs
+// stay at Debug (issue #316), but the steady-state INFO log line was
+// silenced for the entire monitor-user 1045 population — including
+// credential brute-force attempts that spoof the monitor username and
+// ProxySQL misconfigurations (rotated mysql-monitor_password) that would
+// otherwise produce zero shim-side signal. See issue #326.
+//
+// A package-level atomic keeps the increment path lock-free on the hot
+// handshake-error branch. Tests that exercise classifyHandshakeErr reset
+// this counter explicitly with monitorDeniedCount.Store(0) — no
+// per-run scoping in production (only one runShim per process; the
+// counter is reset by the ticker every 5 minutes anyway).
+var monitorDeniedCount atomic.Int64
+
+// monitorDeniedInterval is the cadence at which monitorDeniedTicker
+// emits and resets the counter. 5 minutes is short enough that a
+// misconfig surfaces within one operator's coffee break and long enough
+// that the steady-state log volume stays at "at most 1 line every 5
+// minutes" — versus pre-#316's ~6-360 lines/minute monitor flood. Not
+// flag-configurable on purpose: no operator will need to tune this and
+// the tunable would just be one more thing to misconfigure.
+const monitorDeniedInterval = 5 * time.Minute
 
 func init() {
 	shimCmd.Flags().StringVar(&shListen, "listen", "127.0.0.1:3308", "Listen address for the MySQL protocol port (default: localhost-only — keep ProxySQL as the auth gate)")
@@ -180,6 +205,16 @@ func runShim(cmd *cobra.Command, args []string) error {
 		cancel()
 		listener.Close()
 	}()
+
+	// Periodic INFO summary of denied ProxySQL monitor-user handshakes.
+	// Per-probe noise stays at Debug (#316); this counter is the only
+	// steady-state signal at INFO so a credential probe burst or a
+	// ProxySQL misconfig (rotated mysql-monitor_password) surfaces
+	// without restoring the per-probe log flood. See issue #326. Reset
+	// to zero at startup so a fresh process never inherits stale state
+	// from a previous in-process test run.
+	monitorDeniedCount.Store(0)
+	go monitorDeniedTicker(ctx, slog.Default())
 
 	// config.Connect already parsed and pinged shIndexDSN above, so a parse
 	// failure here would be a programming defect, not a configuration error
@@ -356,11 +391,53 @@ func classifyHandshakeErr(err error) (slog.Level, string) {
 	var myErr *gomysql.MyError
 	if errors.As(err, &myErr) && myErr.Code == gomysql.ER_ACCESS_DENIED_ERROR {
 		if isMonitorAuthFailure(myErr.Message) {
+			// Per-probe log stays at Debug (issue #316); the
+			// counter is the only signal that surfaces at INFO,
+			// emitted every monitorDeniedInterval by
+			// monitorDeniedTicker. See issue #326.
+			monitorDeniedCount.Add(1)
 			return slog.LevelDebug, "mysql auth failed (proxysql monitor probe)"
 		}
 		return slog.LevelInfo, "mysql auth failed"
 	}
 	return slog.LevelError, "mysql handshake failed"
+}
+
+// emitMonitorDenied snapshots the counter, resets it, and emits an INFO
+// line if the snapshot is positive. Pulled out as a package-level
+// function (not a closure) so unit tests can drive both code paths
+// (count==0 and count>0) directly without spinning a 5-minute ticker.
+//
+// Reset-then-emit ordering matters less than it does for a metric
+// pipeline — we don't double-count and we don't underreport. The atomic
+// Swap is the only mutation and is the canonical way to "read and
+// reset" without a mutex.
+func emitMonitorDenied(logger *slog.Logger) {
+	n := monitorDeniedCount.Swap(0)
+	if n == 0 {
+		return
+	}
+	logger.Info("monitor probes denied", "count", n, "interval", monitorDeniedInterval.String())
+}
+
+// monitorDeniedTicker runs emitMonitorDenied on every tick until ctx is
+// cancelled. Started as a goroutine from runShim; tied to the shim's
+// serve context so shutdown is clean. A final emit on shutdown drains
+// any counts accumulated since the last tick — without it, the operator
+// would lose visibility into the last partial interval on a graceful
+// SIGTERM.
+func monitorDeniedTicker(ctx context.Context, logger *slog.Logger) {
+	ticker := time.NewTicker(monitorDeniedInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			emitMonitorDenied(logger)
+			return
+		case <-ticker.C:
+			emitMonitorDenied(logger)
+		}
+	}
 }
 
 // isMonitorAuthFailure reports whether an ER_ACCESS_DENIED_ERROR

--- a/cmd/bintrail/shim.go
+++ b/cmd/bintrail/shim.go
@@ -12,7 +12,6 @@ import (
 	"os/signal"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -83,20 +82,31 @@ var (
 	shAuthMethod string
 )
 
-// monitorDeniedCount counts ER_ACCESS_DENIED_ERROR handshake failures whose
-// username matches ProxySQL's `monitor` (case-insensitive). Per-probe logs
-// stay at Debug (issue #316), but the steady-state INFO log line was
-// silenced for the entire monitor-user 1045 population — including
-// credential brute-force attempts that spoof the monitor username and
-// ProxySQL misconfigurations (rotated mysql-monitor_password) that would
-// otherwise produce zero shim-side signal. See issue #326.
+// monitorDeniedStats aggregates ER_ACCESS_DENIED_ERROR handshake failures
+// whose username matches ProxySQL's `monitor` (case-insensitive). Per-probe
+// logs stay at Debug (issue #316); this struct feeds the steady-state INFO
+// summary so credential brute-force bursts that spoof the monitor username
+// and ProxySQL misconfigurations (rotated mysql-monitor_password) surface
+// without restoring the per-probe flood. See issues #326 and the silent-
+// failure follow-up.
 //
-// A package-level atomic keeps the increment path lock-free on the hot
-// handshake-error branch. Tests that exercise classifyHandshakeErr reset
-// this counter explicitly with monitorDeniedCount.Store(0) — no
-// per-run scoping in production (only one runShim per process; the
-// counter is reset by the ticker every 5 minutes anyway).
-var monitorDeniedCount atomic.Int64
+// `count` alone (the original #326 design) couldn't distinguish "one IP
+// hammering with 3000 attempts" from "200 IPs each trying once" — exactly
+// the forensic signal an operator needs to tell credential stuffing from a
+// monitor misconfig. `distinctRemotes` is a bounded set (cap
+// monitorDeniedRemoteCap) so a wide-source burst can't blow memory; once
+// the cap is reached additional remotes are dropped (the metric becomes a
+// floor, which is the right direction for an alerting signal). Timestamps
+// bracket the interval so the emit line is self-contained.
+const monitorDeniedRemoteCap = 16
+
+var monitorDenied struct {
+	mu              sync.Mutex
+	count           int64
+	distinctRemotes map[string]struct{}
+	firstSeen       time.Time
+	lastSeen        time.Time
+}
 
 // monitorDeniedInterval is the cadence at which monitorDeniedTicker
 // emits and resets the counter. 5 minutes is short enough that a
@@ -106,6 +116,45 @@ var monitorDeniedCount atomic.Int64
 // flag-configurable on purpose: no operator will need to tune this and
 // the tunable would just be one more thing to misconfigure.
 const monitorDeniedInterval = 5 * time.Minute
+
+// monitorDeniedBump records one denied monitor probe with its source
+// remote (host portion only — same client at different ports counts as
+// one source for the distinctRemotes signal). Called from handleConn
+// after classifyHandshakeErr identifies the probe as a monitor failure.
+func monitorDeniedBump(remoteAddr string) {
+	if host, _, splitErr := net.SplitHostPort(remoteAddr); splitErr == nil {
+		remoteAddr = host
+	}
+	now := time.Now()
+	monitorDenied.mu.Lock()
+	defer monitorDenied.mu.Unlock()
+	if monitorDenied.count == 0 {
+		monitorDenied.firstSeen = now
+	}
+	monitorDenied.lastSeen = now
+	monitorDenied.count++
+	if monitorDenied.distinctRemotes == nil {
+		monitorDenied.distinctRemotes = make(map[string]struct{}, monitorDeniedRemoteCap)
+	}
+	// Bounded: a probe from a NEW remote past the cap is silently dropped
+	// from the distinct set. The count still increments; the alerting
+	// metric simply floors at the cap.
+	if len(monitorDenied.distinctRemotes) < monitorDeniedRemoteCap {
+		monitorDenied.distinctRemotes[remoteAddr] = struct{}{}
+	}
+}
+
+// monitorDeniedReset clears the aggregator. Called from runShim at startup
+// (defends against state inherited from a prior in-process test run) and
+// from emitMonitorDenied after a snapshot.
+func monitorDeniedReset() {
+	monitorDenied.mu.Lock()
+	defer monitorDenied.mu.Unlock()
+	monitorDenied.count = 0
+	clear(monitorDenied.distinctRemotes)
+	monitorDenied.firstSeen = time.Time{}
+	monitorDenied.lastSeen = time.Time{}
+}
 
 func init() {
 	shimCmd.Flags().StringVar(&shListen, "listen", "127.0.0.1:3308", "Listen address for the MySQL protocol port (default: localhost-only — keep ProxySQL as the auth gate)")
@@ -207,14 +256,26 @@ func runShim(cmd *cobra.Command, args []string) error {
 	}()
 
 	// Periodic INFO summary of denied ProxySQL monitor-user handshakes.
-	// Per-probe noise stays at Debug (#316); this counter is the only
+	// Per-probe noise stays at Debug (#316); this aggregator is the only
 	// steady-state signal at INFO so a credential probe burst or a
 	// ProxySQL misconfig (rotated mysql-monitor_password) surfaces
 	// without restoring the per-probe log flood. See issue #326. Reset
 	// to zero at startup so a fresh process never inherits stale state
 	// from a previous in-process test run.
-	monitorDeniedCount.Store(0)
-	go monitorDeniedTicker(ctx, slog.Default())
+	//
+	// The ticker is tracked with shimWG so runShim doesn't return until
+	// the ticker's final drain has emitted. Without this, the `defer
+	// cancel()` would signal cancellation but Go's runtime wouldn't
+	// wait for the goroutine before main exits, dropping up to a full
+	// interval's worth of counts on every clean shutdown — exactly the
+	// forensic loss the periodic emit was supposed to prevent.
+	monitorDeniedReset()
+	var shimWG sync.WaitGroup
+	shimWG.Add(1)
+	go func() {
+		defer shimWG.Done()
+		monitorDeniedTicker(ctx, slog.Default())
+	}()
 
 	// config.Connect already parsed and pinged shIndexDSN above, so a parse
 	// failure here would be a programming defect, not a configuration error
@@ -254,6 +315,12 @@ func runShim(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("auth method: %w", err)
 	}
 	serveLoop(ctx, listener, db, srv, auth, cfg, userSchemas)
+	// Block until the monitorDeniedTicker has run its final drain.
+	// serveLoop returning means ctx is cancelled; the ticker is
+	// observing the same ctx and will hit its `case <-ctx.Done()`
+	// branch, emitMonitorDenied, and return. Without this Wait, the
+	// process exits before the goroutine reaches the emit.
+	shimWG.Wait()
 	return nil
 }
 
@@ -383,41 +450,65 @@ func isLoopbackAddr(addr net.Addr) bool {
 // tested with synthetic errors — without it, a future refactor that
 // flips a branch would silently re-introduce the issue #262 log
 // volume regression.
-func classifyHandshakeErr(err error) (slog.Level, string) {
+// classifyHandshakeErr returns (level, msg, isMonitor). The third value
+// is true iff the error is a monitor-user 1045 — callers in handleConn
+// use it to record the source remote into monitorDenied so the periodic
+// emit carries distinct-remote forensics. Bumping inside classify would
+// hide the remote (classify only sees the error).
+func classifyHandshakeErr(err error) (slog.Level, string, bool) {
 	switch {
 	case errors.Is(err, io.EOF), errors.Is(err, io.ErrUnexpectedEOF), errors.Is(err, gomysql.ErrBadConn):
-		return slog.LevelDebug, "handshake aborted (likely TCP probe)"
+		return slog.LevelDebug, "handshake aborted (likely TCP probe)", false
 	}
 	var myErr *gomysql.MyError
 	if errors.As(err, &myErr) && myErr.Code == gomysql.ER_ACCESS_DENIED_ERROR {
 		if isMonitorAuthFailure(myErr.Message) {
-			// Per-probe log stays at Debug (issue #316); the
-			// counter is the only signal that surfaces at INFO,
-			// emitted every monitorDeniedInterval by
-			// monitorDeniedTicker. See issue #326.
-			monitorDeniedCount.Add(1)
-			return slog.LevelDebug, "mysql auth failed (proxysql monitor probe)"
+			return slog.LevelDebug, "mysql auth failed (proxysql monitor probe)", true
 		}
-		return slog.LevelInfo, "mysql auth failed"
+		return slog.LevelInfo, "mysql auth failed", false
 	}
-	return slog.LevelError, "mysql handshake failed"
+	return slog.LevelError, "mysql handshake failed", false
 }
 
-// emitMonitorDenied snapshots the counter, resets it, and emits an INFO
-// line if the snapshot is positive. Pulled out as a package-level
-// function (not a closure) so unit tests can drive both code paths
-// (count==0 and count>0) directly without spinning a 5-minute ticker.
+// emitMonitorDenied snapshots monitorDenied, resets it, and emits an INFO
+// line if the snapshot has at least one probe. Pulled out as a package-
+// level function (not a closure) so unit tests can drive both code paths
+// (empty and populated) directly without spinning a 5-minute ticker.
 //
-// Reset-then-emit ordering matters less than it does for a metric
-// pipeline — we don't double-count and we don't underreport. The atomic
-// Swap is the only mutation and is the canonical way to "read and
-// reset" without a mutex.
+// The snapshot is taken under monitorDenied.mu so an in-flight bump can't
+// race with the reset. Concurrent bumps that arrive AFTER the unlock land
+// in the next interval — fine, the metric is steady-state aggregate, not
+// per-second.
 func emitMonitorDenied(logger *slog.Logger) {
-	n := monitorDeniedCount.Swap(0)
-	if n == 0 {
+	monitorDenied.mu.Lock()
+	count := monitorDenied.count
+	distinct := len(monitorDenied.distinctRemotes)
+	firstSeen := monitorDenied.firstSeen
+	lastSeen := monitorDenied.lastSeen
+	monitorDenied.count = 0
+	clear(monitorDenied.distinctRemotes)
+	monitorDenied.firstSeen = time.Time{}
+	monitorDenied.lastSeen = time.Time{}
+	monitorDenied.mu.Unlock()
+
+	if count == 0 {
 		return
 	}
-	logger.Info("monitor probes denied", "count", n, "interval", monitorDeniedInterval.String())
+	attrs := []any{
+		"count", count,
+		"distinct_remotes", distinct,
+		"interval", monitorDeniedInterval.String(),
+	}
+	if !firstSeen.IsZero() {
+		attrs = append(attrs, "first_seen", firstSeen.UTC().Format(time.RFC3339))
+		attrs = append(attrs, "last_seen", lastSeen.UTC().Format(time.RFC3339))
+	}
+	if distinct == monitorDeniedRemoteCap {
+		// Signal that the set is a floor, not the true count, so an
+		// alerting query sees the saturation.
+		attrs = append(attrs, "distinct_remotes_truncated_at", monitorDeniedRemoteCap)
+	}
+	logger.Info("monitor probes denied", attrs...)
 }
 
 // monitorDeniedTicker runs emitMonitorDenied on every tick until ctx is
@@ -526,7 +617,10 @@ func handleConn(c net.Conn, db *sql.DB, srv *server.Server, auth shim.TenantAuth
 	handler := shim.NewHandlerWithConfig(db, cfg, slog.Default())
 	mysqlConn, err := server.NewCustomizedConn(c, srv, auth, handler)
 	if err != nil {
-		level, msg := classifyHandshakeErr(err)
+		level, msg, isMonitor := classifyHandshakeErr(err)
+		if isMonitor {
+			monitorDeniedBump(c.RemoteAddr().String())
+		}
 		slog.Log(context.Background(), level, msg, "err", err, "remote", c.RemoteAddr())
 		return
 	}

--- a/cmd/bintrail/shim_test.go
+++ b/cmd/bintrail/shim_test.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"net"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -314,5 +316,107 @@ func TestBuildUserSchemas(t *testing.T) {
 		if _, ok := got[u]; ok {
 			t.Errorf("buildUserSchemas[%q] should be absent (bad/empty DSN), got %q", u, got[u])
 		}
+	}
+}
+
+// TestMonitorDeniedCounterIncrements pins the #326 wiring: every
+// classifyHandshakeErr call whose error is a `monitor`-user 1045 must
+// bump the package-level counter exactly once, and other handshake
+// errors (tenant 1045, EOF, plain errors) must not. A regression that
+// detaches the counter from isMonitorAuthFailure — e.g. moving the
+// Add(1) outside the branch — would silently restore the #326 blind
+// spot once the periodic emit reset the counter at the next tick.
+//
+// The test resets the counter at start to defend against any earlier
+// tests in the package mutating it; the counter is a package-level
+// global, so this is the contract callers must honor.
+func TestMonitorDeniedCounterIncrements(t *testing.T) {
+	monitorDeniedCount.Store(0)
+	t.Cleanup(func() { monitorDeniedCount.Store(0) })
+
+	// Monitor 1045 → counter +1.
+	monitorErr := gomysql.NewDefaultError(gomysql.ER_ACCESS_DENIED_ERROR, "monitor", "127.0.0.1:46948", "YES")
+	classifyHandshakeErr(monitorErr)
+	if got := monitorDeniedCount.Load(); got != 1 {
+		t.Errorf("after monitor 1045: counter = %d, want 1", got)
+	}
+
+	// Tenant 1045 → counter unchanged (still 1).
+	tenantErr := gomysql.NewDefaultError(gomysql.ER_ACCESS_DENIED_ERROR, "alice", "127.0.0.1:46948", "YES")
+	classifyHandshakeErr(tenantErr)
+	if got := monitorDeniedCount.Load(); got != 1 {
+		t.Errorf("after tenant 1045: counter = %d, want 1 (only monitor failures count)", got)
+	}
+
+	// EOF (TCP probe) → counter unchanged.
+	classifyHandshakeErr(io.EOF)
+	if got := monitorDeniedCount.Load(); got != 1 {
+		t.Errorf("after io.EOF: counter = %d, want 1", got)
+	}
+
+	// Plain unrelated error → counter unchanged.
+	classifyHandshakeErr(errors.New("protocol mismatch"))
+	if got := monitorDeniedCount.Load(); got != 1 {
+		t.Errorf("after protocol mismatch: counter = %d, want 1", got)
+	}
+
+	// Second monitor 1045 → counter +1 (now 2).
+	classifyHandshakeErr(monitorErr)
+	if got := monitorDeniedCount.Load(); got != 2 {
+		t.Errorf("after second monitor 1045: counter = %d, want 2", got)
+	}
+}
+
+// TestMonitorDeniedCounterPeriodicEmit pins the two contract claims of
+// emitMonitorDenied:
+//   - count == 0 emits nothing (no steady-state log noise when ProxySQL's
+//     monitor is configured correctly and never fails),
+//   - count >  0 emits one INFO line with the count and a non-empty
+//     interval string, then resets the counter to zero (so the next
+//     interval starts fresh — the load-bearing claim of the periodic
+//     design).
+//
+// A regression that emitted on zero (operator drowns in 5-minute
+// heartbeats) or failed to reset (counts compound forever, eventually
+// reporting absurd totals) would both silently break the design.
+func TestMonitorDeniedCounterPeriodicEmit(t *testing.T) {
+	t.Cleanup(func() { monitorDeniedCount.Store(0) })
+
+	// count == 0 path: emit nothing.
+	monitorDeniedCount.Store(0)
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	emitMonitorDenied(logger)
+	if buf.Len() != 0 {
+		t.Errorf("count=0 emit: got log output %q, want empty (no steady-state noise)", buf.String())
+	}
+	if got := monitorDeniedCount.Load(); got != 0 {
+		t.Errorf("count=0 emit: counter = %d after emit, want 0", got)
+	}
+
+	// count > 0 path: emit one line with count=N and reset to zero.
+	monitorDeniedCount.Store(7)
+	buf.Reset()
+	emitMonitorDenied(logger)
+	out := buf.String()
+	if !strings.Contains(out, "monitor probes denied") {
+		t.Errorf("count=7 emit: log missing msg; got %q", out)
+	}
+	if !strings.Contains(out, "count=7") {
+		t.Errorf("count=7 emit: log missing count=7; got %q", out)
+	}
+	if !strings.Contains(out, "interval=") {
+		t.Errorf("count=7 emit: log missing interval=...; got %q", out)
+	}
+	if got := monitorDeniedCount.Load(); got != 0 {
+		t.Errorf("count=7 emit: counter = %d after emit, want 0 (reset is load-bearing — non-zero would compound across intervals)", got)
+	}
+
+	// After reset, a second emit at count==0 stays silent — the
+	// reset-then-emit contract from a previous tick must hold.
+	buf.Reset()
+	emitMonitorDenied(logger)
+	if buf.Len() != 0 {
+		t.Errorf("second emit after reset: got %q, want empty", buf.String())
 	}
 }

--- a/cmd/bintrail/shim_test.go
+++ b/cmd/bintrail/shim_test.go
@@ -211,34 +211,40 @@ func (l *alwaysErrorListener) Addr() net.Addr {
 // noise). Anything else stays at error.
 func TestClassifyHandshakeErr(t *testing.T) {
 	cases := []struct {
-		name      string
-		err       error
-		wantLevel slog.Level
+		name          string
+		err           error
+		wantLevel     slog.Level
+		wantIsMonitor bool
 	}{
-		{"raw io.EOF", io.EOF, slog.LevelDebug},
-		{"unexpected EOF", io.ErrUnexpectedEOF, slog.LevelDebug},
+		{"raw io.EOF", io.EOF, slog.LevelDebug, false},
+		{"unexpected EOF", io.ErrUnexpectedEOF, slog.LevelDebug, false},
 		// fmt.Errorf+%w produces an Unwrap-compatible chain that exercises the same
 		// errors.Is path go-mysql's pingcap-wrapped reads do. We avoid importing
 		// github.com/pingcap/errors directly per CLAUDE.md ("Do not import transitive
 		// deps directly") — the production behaviour is what matters, and errors.Is
 		// resolves both wrap shapes the same way.
-		{"wrapped ErrBadConn", fmt.Errorf("io.ReadFull(header) failed: %w", gomysql.ErrBadConn), slog.LevelDebug},
-		// ProxySQL monitor user → debug (issue #316).
-		{"ER_ACCESS_DENIED_ERROR monitor user is debug", gomysql.NewDefaultError(gomysql.ER_ACCESS_DENIED_ERROR, "monitor", "127.0.0.1:46948", "YES"), slog.LevelDebug},
-		// Real tenant user → info (the load-bearing claim — without this,
-		// the #316 demote would silence every real auth failure too).
-		{"ER_ACCESS_DENIED_ERROR tenant user is info", gomysql.NewDefaultError(gomysql.ER_ACCESS_DENIED_ERROR, "alice", "127.0.0.1:46948", "YES"), slog.LevelInfo},
-		{"unrelated MyError stays error", gomysql.NewDefaultError(gomysql.ER_HANDSHAKE_ERROR), slog.LevelError},
-		{"plain unrelated error", errors.New("protocol mismatch"), slog.LevelError},
+		{"wrapped ErrBadConn", fmt.Errorf("io.ReadFull(header) failed: %w", gomysql.ErrBadConn), slog.LevelDebug, false},
+		// ProxySQL monitor user → debug + isMonitor=true (issue #316/#326).
+		{"ER_ACCESS_DENIED_ERROR monitor user is debug", gomysql.NewDefaultError(gomysql.ER_ACCESS_DENIED_ERROR, "monitor", "127.0.0.1:46948", "YES"), slog.LevelDebug, true},
+		// Real tenant user → info, isMonitor=false (the load-bearing claim —
+		// without this, the #316 demote would silence every real auth failure
+		// too AND the monitor-denied aggregator would inflate with tenant
+		// failures, hiding actual monitor probe load).
+		{"ER_ACCESS_DENIED_ERROR tenant user is info", gomysql.NewDefaultError(gomysql.ER_ACCESS_DENIED_ERROR, "alice", "127.0.0.1:46948", "YES"), slog.LevelInfo, false},
+		{"unrelated MyError stays error", gomysql.NewDefaultError(gomysql.ER_HANDSHAKE_ERROR), slog.LevelError, false},
+		{"plain unrelated error", errors.New("protocol mismatch"), slog.LevelError, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			level, msg := classifyHandshakeErr(tc.err)
+			level, msg, isMonitor := classifyHandshakeErr(tc.err)
 			if level != tc.wantLevel {
 				t.Errorf("classifyHandshakeErr level = %v, want %v (msg=%q)", level, tc.wantLevel, msg)
 			}
 			if msg == "" {
 				t.Errorf("classifyHandshakeErr msg empty for %v", tc.err)
+			}
+			if isMonitor != tc.wantIsMonitor {
+				t.Errorf("classifyHandshakeErr isMonitor = %v, want %v (err=%v)", isMonitor, tc.wantIsMonitor, tc.err)
 			}
 		})
 	}
@@ -319,101 +325,125 @@ func TestBuildUserSchemas(t *testing.T) {
 	}
 }
 
-// TestMonitorDeniedCounterIncrements pins the #326 wiring: every
-// classifyHandshakeErr call whose error is a `monitor`-user 1045 must
-// bump the package-level counter exactly once, and other handshake
-// errors (tenant 1045, EOF, plain errors) must not. A regression that
-// detaches the counter from isMonitorAuthFailure — e.g. moving the
-// Add(1) outside the branch — would silently restore the #326 blind
-// spot once the periodic emit reset the counter at the next tick.
-//
-// The test resets the counter at start to defend against any earlier
-// tests in the package mutating it; the counter is a package-level
-// global, so this is the contract callers must honor.
-func TestMonitorDeniedCounterIncrements(t *testing.T) {
-	monitorDeniedCount.Store(0)
-	t.Cleanup(func() { monitorDeniedCount.Store(0) })
+// TestMonitorDeniedBump pins the aggregation behavior for the periodic
+// emit's forensic signal. Each bump increments the count, accumulates
+// the source remote into a bounded distinct set, and bookends with
+// first/last seen timestamps. A regression that detached count from
+// the distinct set (or vice versa) would silently lose the "one IP
+// hammering vs many IPs probing" distinction that operators need to
+// tell credential stuffing from a misconfigured ProxySQL.
+func TestMonitorDeniedBump(t *testing.T) {
+	monitorDeniedReset()
+	t.Cleanup(monitorDeniedReset)
 
-	// Monitor 1045 → counter +1.
-	monitorErr := gomysql.NewDefaultError(gomysql.ER_ACCESS_DENIED_ERROR, "monitor", "127.0.0.1:46948", "YES")
-	classifyHandshakeErr(monitorErr)
-	if got := monitorDeniedCount.Load(); got != 1 {
-		t.Errorf("after monitor 1045: counter = %d, want 1", got)
+	monitorDeniedBump("10.0.0.1:54321")
+	monitorDeniedBump("10.0.0.1:54322") // same host, different port — one source
+	monitorDeniedBump("10.0.0.2:60001")
+
+	monitorDenied.mu.Lock()
+	count := monitorDenied.count
+	distinct := len(monitorDenied.distinctRemotes)
+	firstSeen := monitorDenied.firstSeen
+	lastSeen := monitorDenied.lastSeen
+	monitorDenied.mu.Unlock()
+
+	if count != 3 {
+		t.Errorf("count = %d, want 3", count)
 	}
-
-	// Tenant 1045 → counter unchanged (still 1).
-	tenantErr := gomysql.NewDefaultError(gomysql.ER_ACCESS_DENIED_ERROR, "alice", "127.0.0.1:46948", "YES")
-	classifyHandshakeErr(tenantErr)
-	if got := monitorDeniedCount.Load(); got != 1 {
-		t.Errorf("after tenant 1045: counter = %d, want 1 (only monitor failures count)", got)
+	if distinct != 2 {
+		t.Errorf("distinct = %d, want 2 (same host different ports collapses)", distinct)
 	}
-
-	// EOF (TCP probe) → counter unchanged.
-	classifyHandshakeErr(io.EOF)
-	if got := monitorDeniedCount.Load(); got != 1 {
-		t.Errorf("after io.EOF: counter = %d, want 1", got)
+	if firstSeen.IsZero() {
+		t.Error("firstSeen unset after bumps")
 	}
-
-	// Plain unrelated error → counter unchanged.
-	classifyHandshakeErr(errors.New("protocol mismatch"))
-	if got := monitorDeniedCount.Load(); got != 1 {
-		t.Errorf("after protocol mismatch: counter = %d, want 1", got)
+	if lastSeen.IsZero() {
+		t.Error("lastSeen unset after bumps")
 	}
-
-	// Second monitor 1045 → counter +1 (now 2).
-	classifyHandshakeErr(monitorErr)
-	if got := monitorDeniedCount.Load(); got != 2 {
-		t.Errorf("after second monitor 1045: counter = %d, want 2", got)
+	if lastSeen.Before(firstSeen) {
+		t.Errorf("lastSeen (%v) before firstSeen (%v)", lastSeen, firstSeen)
 	}
 }
 
-// TestMonitorDeniedCounterPeriodicEmit pins the two contract claims of
+// TestMonitorDeniedBumpRemoteCap pins the bounded-set defense. A wide-
+// source burst (e.g. credential stuffing from 200 IPs) must not blow
+// memory by retaining one entry per probe — past the cap, additional
+// distinct remotes are dropped from the set but `count` keeps climbing.
+// The emit reports `distinct_remotes_truncated_at` so alerting can
+// tell "we saw at least N sources" from "exactly N sources".
+func TestMonitorDeniedBumpRemoteCap(t *testing.T) {
+	monitorDeniedReset()
+	t.Cleanup(monitorDeniedReset)
+
+	for i := 0; i < monitorDeniedRemoteCap*3; i++ {
+		monitorDeniedBump(fmt.Sprintf("10.0.0.%d:1234", i))
+	}
+
+	monitorDenied.mu.Lock()
+	count := monitorDenied.count
+	distinct := len(monitorDenied.distinctRemotes)
+	monitorDenied.mu.Unlock()
+
+	if count != int64(monitorDeniedRemoteCap*3) {
+		t.Errorf("count = %d, want %d (count keeps climbing past cap)", count, monitorDeniedRemoteCap*3)
+	}
+	if distinct != monitorDeniedRemoteCap {
+		t.Errorf("distinct = %d, want %d (set bounded at cap)", distinct, monitorDeniedRemoteCap)
+	}
+}
+
+// TestMonitorDeniedPeriodicEmit pins the two contract claims of
 // emitMonitorDenied:
 //   - count == 0 emits nothing (no steady-state log noise when ProxySQL's
 //     monitor is configured correctly and never fails),
-//   - count >  0 emits one INFO line with the count and a non-empty
-//     interval string, then resets the counter to zero (so the next
-//     interval starts fresh — the load-bearing claim of the periodic
-//     design).
+//   - count >  0 emits one INFO line with count, distinct_remotes,
+//     first_seen, last_seen, interval — then resets state so the next
+//     interval starts fresh.
 //
 // A regression that emitted on zero (operator drowns in 5-minute
-// heartbeats) or failed to reset (counts compound forever, eventually
-// reporting absurd totals) would both silently break the design.
-func TestMonitorDeniedCounterPeriodicEmit(t *testing.T) {
-	t.Cleanup(func() { monitorDeniedCount.Store(0) })
+// heartbeats) or failed to reset (counts compound forever, reporting
+// absurd totals) would both silently break the design.
+func TestMonitorDeniedPeriodicEmit(t *testing.T) {
+	t.Cleanup(monitorDeniedReset)
+	monitorDeniedReset()
 
 	// count == 0 path: emit nothing.
-	monitorDeniedCount.Store(0)
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
 	emitMonitorDenied(logger)
 	if buf.Len() != 0 {
-		t.Errorf("count=0 emit: got log output %q, want empty (no steady-state noise)", buf.String())
-	}
-	if got := monitorDeniedCount.Load(); got != 0 {
-		t.Errorf("count=0 emit: counter = %d after emit, want 0", got)
+		t.Errorf("empty emit: got log output %q, want empty (no steady-state noise)", buf.String())
 	}
 
-	// count > 0 path: emit one line with count=N and reset to zero.
-	monitorDeniedCount.Store(7)
+	// Populated path: bump from two distinct hosts, emit, expect one
+	// log line that names every forensic field.
+	monitorDeniedBump("10.0.0.1:54321")
+	monitorDeniedBump("10.0.0.2:54322")
+	monitorDeniedBump("10.0.0.1:54323")
 	buf.Reset()
 	emitMonitorDenied(logger)
 	out := buf.String()
-	if !strings.Contains(out, "monitor probes denied") {
-		t.Errorf("count=7 emit: log missing msg; got %q", out)
+	for _, want := range []string{
+		"monitor probes denied",
+		"count=3",
+		"distinct_remotes=2",
+		"first_seen=",
+		"last_seen=",
+		"interval=",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("emit missing %q; got %q", want, out)
+		}
 	}
-	if !strings.Contains(out, "count=7") {
-		t.Errorf("count=7 emit: log missing count=7; got %q", out)
-	}
-	if !strings.Contains(out, "interval=") {
-		t.Errorf("count=7 emit: log missing interval=...; got %q", out)
-	}
-	if got := monitorDeniedCount.Load(); got != 0 {
-		t.Errorf("count=7 emit: counter = %d after emit, want 0 (reset is load-bearing — non-zero would compound across intervals)", got)
+	monitorDenied.mu.Lock()
+	count := monitorDenied.count
+	distinct := len(monitorDenied.distinctRemotes)
+	firstSeen := monitorDenied.firstSeen
+	monitorDenied.mu.Unlock()
+	if count != 0 || distinct != 0 || !firstSeen.IsZero() {
+		t.Errorf("state not reset after emit: count=%d distinct=%d firstSeen=%v", count, distinct, firstSeen)
 	}
 
-	// After reset, a second emit at count==0 stays silent — the
-	// reset-then-emit contract from a previous tick must hold.
+	// After reset, a second emit at count==0 stays silent.
 	buf.Reset()
 	emitMonitorDenied(logger)
 	if buf.Len() != 0 {


### PR DESCRIPTION
## Summary

- Restores INFO-level visibility for ProxySQL monitor-user 1045 handshake failures that #322 silenced (#326). Per-probe logs stay at DEBUG (#316 unchanged); a periodic counter surfaces the steady-state rate so credential brute-force attempts spoofing the `monitor` username and ProxySQL misconfigurations (rotated `mysql-monitor_password`) become visible again.
- Counter is a package-level `atomic.Int64` incremented inside `classifyHandshakeErr`'s `isMonitorAuthFailure` branch. A goroutine started from `runShim` ticks every 5 minutes via `monitorDeniedTicker`, calls `emitMonitorDenied`, and resets the counter on emit. Zero ticks emit nothing — no steady-state log noise when ProxySQL is configured correctly.
- Ticker honors the shim's serve `context.Context` for clean shutdown and drains a final emit on cancel so a graceful SIGTERM doesn't lose the last partial interval.

Closes #326.

## Design choice

The issue offered two shapes — periodic counter and first-seen-per-remote LRU. I went with the periodic counter:

- Less state to manage (no LRU eviction, no per-remote cardinality concerns).
- One log line every 5 minutes is the right cadence for both signal use-cases: a probe burst surfaces within minutes, and a misconfig surfaces on the first interval after deployment.
- The first-seen-per-remote shape adds per-host detail that the counter omits, but operators can pull `remote` off the per-probe DEBUG lines if they need to investigate — the counter just needs to alert them to look.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./cmd/bintrail/... -count=1` passes (all 24 tests including 2 new)
- [x] `TestMonitorDeniedCounterIncrements` — drives `classifyHandshakeErr` with monitor 1045, tenant 1045, EOF, and plain errors; asserts only monitor 1045 increments the counter.
- [x] `TestMonitorDeniedCounterPeriodicEmit` — drives `emitMonitorDenied` directly with both count==0 (asserts no log output) and count>0 (asserts one INFO line with `count`, `interval`, then counter reset to 0).
- [x] Existing `TestClassifyHandshakeErr` still passes — verified the increment side-effect doesn't break the level classification contract.

## Hard-constraint adherence

- Did not touch `drafts/` or `dist-perconalive/`.
- Did not change auth-rejection logic or the #316 DEBUG demote for individual probes.
- Did not add a flag — 5-minute interval is a `const`.