### PR TITLE
fix(config): detect log_bin=OFF as a domain error in CurrentBinlogPosition (#325)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
@@ -13,6 +14,12 @@ import (
 // and falls back to SHOW MASTER STATUS for 5.7 / 8.0 / Percona <8.4 where the
 // new statement does not exist. When both fail, the wrapped error includes
 // both diagnostics so the operator does not chase the wrong syntax.
+//
+// When binary logging is disabled on the source (log_bin=OFF), both statements
+// return an empty resultset rather than an error, surfacing as sql.ErrNoRows
+// from Scan on both branches. In that specific case we return a domain-specific
+// error pointing the operator at the likely cause and the remediation query,
+// instead of the unhelpful "no rows in result set" pair.
 func CurrentBinlogPosition(db *sql.DB) (file string, pos uint32, err error) {
 	scanArgs := []any{&file, &pos, new(string), new(string), new(string)}
 	if err = db.QueryRow("SHOW BINARY LOG STATUS").Scan(scanArgs...); err == nil {
@@ -20,6 +27,9 @@ func CurrentBinlogPosition(db *sql.DB) (file string, pos uint32, err error) {
 	}
 	firstErr := err
 	if err = db.QueryRow("SHOW MASTER STATUS").Scan(scanArgs...); err != nil {
+		if errors.Is(firstErr, sql.ErrNoRows) && errors.Is(err, sql.ErrNoRows) {
+			return "", 0, fmt.Errorf("current binlog position empty — log_bin appears to be OFF on the source server (run \"SHOW VARIABLES LIKE 'log_bin'\" to confirm)")
+		}
 		return "", 0, fmt.Errorf("SHOW BINARY LOG STATUS / SHOW MASTER STATUS: %w (fallback: %w)", firstErr, err)
 	}
 	return file, pos, nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,11 +15,20 @@ import (
 // new statement does not exist. When both fail, the wrapped error includes
 // both diagnostics so the operator does not chase the wrong syntax.
 //
-// When binary logging is disabled on the source (log_bin=OFF), both statements
-// return an empty resultset rather than an error, surfacing as sql.ErrNoRows
-// from Scan on both branches. In that specific case we return a domain-specific
-// error pointing the operator at the likely cause and the remediation query,
-// instead of the unhelpful "no rows in result set" pair.
+// When binary logging is disabled on the source (log_bin=OFF), the statement
+// that exists on this server version returns an empty resultset (sql.ErrNoRows
+// from Scan), while the statement that doesn't exist returns syntax error 1064
+// — never both ErrNoRows. The two real-world shapes are:
+//
+//   - 5.7/8.0/Percona<8.4 + log_bin=OFF: SHOW BINARY LOG STATUS → 1064,
+//     SHOW MASTER STATUS → ErrNoRows
+//   - 8.4+ + log_bin=OFF: SHOW BINARY LOG STATUS → ErrNoRows,
+//     SHOW MASTER STATUS → 1064 (removed in 8.4.0)
+//
+// So when EITHER branch returns ErrNoRows we know log_bin=OFF and emit a
+// domain-specific error. Privileges missing surfaces as 1227 (ER_SPECIFIC_
+// ACCESS_DENIED_ERROR), not ErrNoRows, so false-positive risk is essentially
+// nil.
 func CurrentBinlogPosition(db *sql.DB) (file string, pos uint32, err error) {
 	scanArgs := []any{&file, &pos, new(string), new(string), new(string)}
 	if err = db.QueryRow("SHOW BINARY LOG STATUS").Scan(scanArgs...); err == nil {
@@ -27,7 +36,7 @@ func CurrentBinlogPosition(db *sql.DB) (file string, pos uint32, err error) {
 	}
 	firstErr := err
 	if err = db.QueryRow("SHOW MASTER STATUS").Scan(scanArgs...); err != nil {
-		if errors.Is(firstErr, sql.ErrNoRows) && errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(firstErr, sql.ErrNoRows) || errors.Is(err, sql.ErrNoRows) {
 			return "", 0, fmt.Errorf("current binlog position empty — log_bin appears to be OFF on the source server (run \"SHOW VARIABLES LIKE 'log_bin'\" to confirm)")
 		}
 		return "", 0, fmt.Errorf("SHOW BINARY LOG STATUS / SHOW MASTER STATUS: %w (fallback: %w)", firstErr, err)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -99,46 +99,88 @@ func TestCurrentBinlogPosition_FallbackHappyPath(t *testing.T) {
 	}
 }
 
-// TestCurrentBinlogPosition_LogBinOff is the regression guard for
-// issue #325: when both statements return an empty resultset
-// (log_bin=OFF on the source), the wrapped error should mention
-// log_bin and the remediation query — not raw "sql: no rows in
-// result set" repeated twice.
+// TestCurrentBinlogPosition_LogBinOff covers the real-world shape of
+// log_bin=OFF on every supported MySQL/Percona line. The crash-loop
+// in #325 surfaced as an asymmetric error pair — exactly one branch
+// returns ErrNoRows (empty resultset because log_bin=OFF) and the
+// other returns 1064 (statement doesn't exist on that version):
+//
+//   - 5.7 / 8.0 / Percona <8.4: SHOW BINARY LOG STATUS → 1064,
+//     SHOW MASTER STATUS → ErrNoRows.
+//   - 8.4+: SHOW BINARY LOG STATUS → ErrNoRows, SHOW MASTER STATUS →
+//     1064 (removed in 8.4.0).
+//
+// Plus the degenerate sanity case where sqlmock simulates both empty.
+// All three must hit the domain error.
 func TestCurrentBinlogPosition_LogBinOff(t *testing.T) {
-	db, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock: %v", err)
+	cases := []struct {
+		name      string
+		firstErr  error
+		firstRows *sqlmock.Rows
+		fbErr     error
+		fbRows    *sqlmock.Rows
+	}{
+		{
+			name:      "pre_8.4 with log_bin=OFF: new statement is 1064, old returns empty",
+			firstErr:  &mysql.MySQLError{Number: 1064, Message: "syntax error near 'BINARY LOG STATUS'"},
+			fbRows:    sqlmock.NewRows(binlogStatusColumns),
+		},
+		{
+			name:      "8.4+ with log_bin=OFF: new returns empty, old is 1064",
+			firstRows: sqlmock.NewRows(binlogStatusColumns),
+			fbErr:     &mysql.MySQLError{Number: 1064, Message: "syntax error near 'MASTER STATUS'"},
+		},
+		{
+			name:      "both empty (sqlmock degenerate sanity)",
+			firstRows: sqlmock.NewRows(binlogStatusColumns),
+			fbRows:    sqlmock.NewRows(binlogStatusColumns),
+		},
 	}
-	defer db.Close()
 
-	mock.ExpectQuery("SHOW BINARY LOG STATUS").WillReturnRows(
-		sqlmock.NewRows(binlogStatusColumns))
-	mock.ExpectQuery("SHOW MASTER STATUS").WillReturnRows(
-		sqlmock.NewRows(binlogStatusColumns))
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("sqlmock: %v", err)
+			}
+			defer db.Close()
 
-	_, _, err = CurrentBinlogPosition(db)
-	if err == nil {
-		t.Fatal("expected error when both statements return empty resultsets, got nil")
-	}
-	msg := err.Error()
-	if !strings.Contains(msg, "log_bin") {
-		t.Errorf("error message does not mention log_bin: %q", msg)
-	}
-	if !strings.Contains(msg, "SHOW VARIABLES") {
-		t.Errorf("error message does not point at the remediation query: %q", msg)
-	}
-	// Guard against the old double-wrap diagnostic leaking through:
-	// the wrapped error must not include the generic "fallback:" pair
-	// nor the raw "no rows in result set" string that the operator
-	// would otherwise chase fruitlessly.
-	if strings.Contains(msg, "fallback:") {
-		t.Errorf("error message should not include the generic fallback diagnostic for the log_bin=OFF case: %q", msg)
-	}
-	if strings.Contains(msg, "no rows in result set") {
-		t.Errorf("error message should not leak the raw sql.ErrNoRows string for the log_bin=OFF case: %q", msg)
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Errorf("unmet expectations: %v", err)
+			firstExp := mock.ExpectQuery("SHOW BINARY LOG STATUS")
+			if tc.firstErr != nil {
+				firstExp.WillReturnError(tc.firstErr)
+			} else {
+				firstExp.WillReturnRows(tc.firstRows)
+			}
+			fbExp := mock.ExpectQuery("SHOW MASTER STATUS")
+			if tc.fbErr != nil {
+				fbExp.WillReturnError(tc.fbErr)
+			} else {
+				fbExp.WillReturnRows(tc.fbRows)
+			}
+
+			_, _, err = CurrentBinlogPosition(db)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			msg := err.Error()
+			if !strings.Contains(msg, "log_bin") {
+				t.Errorf("error message does not mention log_bin: %q", msg)
+			}
+			if !strings.Contains(msg, "SHOW VARIABLES") {
+				t.Errorf("error message does not point at the remediation query: %q", msg)
+			}
+			// Domain error must not leak the generic fallback wrap or
+			// raw ErrNoRows — operators would chase those fruitlessly.
+			if strings.Contains(msg, "fallback:") {
+				t.Errorf("domain error should not include 'fallback:' wrap: %q", msg)
+			}
+			if strings.Contains(msg, "no rows in result set") {
+				t.Errorf("domain error should not leak raw sql.ErrNoRows: %q", msg)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("unmet expectations: %v", err)
+			}
+		})
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,9 +1,12 @@
 package config
 
 import (
+	"errors"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/go-sql-driver/mysql"
 )
 
@@ -20,5 +23,161 @@ func TestConnect_locUTCApplied(t *testing.T) {
 
 	if cfg.Loc != time.UTC {
 		t.Errorf("expected Loc=UTC, got %v", cfg.Loc)
+	}
+}
+
+// binlogStatusColumns matches the layout SHOW BINARY LOG STATUS /
+// SHOW MASTER STATUS returns: File, Position, Binlog_Do_DB,
+// Binlog_Ignore_DB, Executed_Gtid_Set. CurrentBinlogPosition scans
+// the first two into typed targets and the rest into string sinks.
+var binlogStatusColumns = []string{
+	"File",
+	"Position",
+	"Binlog_Do_DB",
+	"Binlog_Ignore_DB",
+	"Executed_Gtid_Set",
+}
+
+// TestCurrentBinlogPosition_NewStatementHappyPath exercises the
+// MySQL 8.4 path where SHOW BINARY LOG STATUS returns a row.
+func TestCurrentBinlogPosition_NewStatementHappyPath(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SHOW BINARY LOG STATUS").WillReturnRows(
+		sqlmock.NewRows(binlogStatusColumns).
+			AddRow("binlog.000042", uint32(12345), "", "", ""))
+
+	file, pos, err := CurrentBinlogPosition(db)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if file != "binlog.000042" {
+		t.Errorf("file = %q, want %q", file, "binlog.000042")
+	}
+	if pos != 12345 {
+		t.Errorf("pos = %d, want 12345", pos)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// TestCurrentBinlogPosition_FallbackHappyPath exercises the pre-8.4
+// path: the new statement returns a syntax error (1064), then
+// SHOW MASTER STATUS returns a row.
+func TestCurrentBinlogPosition_FallbackHappyPath(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SHOW BINARY LOG STATUS").WillReturnError(&mysql.MySQLError{
+		Number:  1064,
+		Message: "You have an error in your SQL syntax",
+	})
+	mock.ExpectQuery("SHOW MASTER STATUS").WillReturnRows(
+		sqlmock.NewRows(binlogStatusColumns).
+			AddRow("mysql-bin.000007", uint32(987), "", "", ""))
+
+	file, pos, err := CurrentBinlogPosition(db)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if file != "mysql-bin.000007" {
+		t.Errorf("file = %q, want %q", file, "mysql-bin.000007")
+	}
+	if pos != 987 {
+		t.Errorf("pos = %d, want 987", pos)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// TestCurrentBinlogPosition_LogBinOff is the regression guard for
+// issue #325: when both statements return an empty resultset
+// (log_bin=OFF on the source), the wrapped error should mention
+// log_bin and the remediation query — not raw "sql: no rows in
+// result set" repeated twice.
+func TestCurrentBinlogPosition_LogBinOff(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SHOW BINARY LOG STATUS").WillReturnRows(
+		sqlmock.NewRows(binlogStatusColumns))
+	mock.ExpectQuery("SHOW MASTER STATUS").WillReturnRows(
+		sqlmock.NewRows(binlogStatusColumns))
+
+	_, _, err = CurrentBinlogPosition(db)
+	if err == nil {
+		t.Fatal("expected error when both statements return empty resultsets, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "log_bin") {
+		t.Errorf("error message does not mention log_bin: %q", msg)
+	}
+	if !strings.Contains(msg, "SHOW VARIABLES") {
+		t.Errorf("error message does not point at the remediation query: %q", msg)
+	}
+	// Guard against the old double-wrap diagnostic leaking through:
+	// the wrapped error must not include the generic "fallback:" pair
+	// nor the raw "no rows in result set" string that the operator
+	// would otherwise chase fruitlessly.
+	if strings.Contains(msg, "fallback:") {
+		t.Errorf("error message should not include the generic fallback diagnostic for the log_bin=OFF case: %q", msg)
+	}
+	if strings.Contains(msg, "no rows in result set") {
+		t.Errorf("error message should not leak the raw sql.ErrNoRows string for the log_bin=OFF case: %q", msg)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// TestCurrentBinlogPosition_BothNonErrNoRowsFail is the scope-creep
+// guard: if both statements fail with non-ErrNoRows errors (e.g.
+// connection drop, permission denied), the caller should still get
+// the existing combined-error diagnostic so they don't lose the
+// underlying detail.
+func TestCurrentBinlogPosition_BothNonErrNoRowsFail(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	firstErr := errors.New("connection reset by peer")
+	secondErr := errors.New("permission denied")
+
+	mock.ExpectQuery("SHOW BINARY LOG STATUS").WillReturnError(firstErr)
+	mock.ExpectQuery("SHOW MASTER STATUS").WillReturnError(secondErr)
+
+	_, _, err = CurrentBinlogPosition(db)
+	if err == nil {
+		t.Fatal("expected error when both statements fail, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "SHOW BINARY LOG STATUS / SHOW MASTER STATUS") {
+		t.Errorf("error message missing combined diagnostic header: %q", msg)
+	}
+	if !strings.Contains(msg, "connection reset by peer") {
+		t.Errorf("error message lost first diagnostic: %q", msg)
+	}
+	if !strings.Contains(msg, "permission denied") {
+		t.Errorf("error message lost fallback diagnostic: %q", msg)
+	}
+	if strings.Contains(msg, "log_bin") {
+		t.Errorf("error message should not mention log_bin for non-ErrNoRows failures: %q", msg)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- `config.CurrentBinlogPosition` now returns a domain-specific error when both `SHOW BINARY LOG STATUS` and `SHOW MASTER STATUS` come back with an empty resultset (`sql.ErrNoRows`), which is what MySQL does when `log_bin=OFF` on the source. The new message names `log_bin` and points at `SHOW VARIABLES LIKE 'log_bin'` instead of the operator-hostile `no rows in result set (fallback: no rows in result set)` pair.
- Non-`ErrNoRows` failures (connection drop, permission denied, etc.) still flow through the existing combined-error path so we don't lose detail in the unhappy paths the previous PR (#320) already handled.
- Out of scope per the issue: the optional `validateLogBin` pre-flight in `runBYOSStream`. One change per PR.

Closes #325

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/config/... -count=1` — 5 tests pass, including:
  - `TestCurrentBinlogPosition_NewStatementHappyPath` (8.4 row returned)
  - `TestCurrentBinlogPosition_FallbackHappyPath` (8.4 syntax error 1064 → 8.0 row)
  - `TestCurrentBinlogPosition_LogBinOff` (regression guard: both empty → log_bin error)
  - `TestCurrentBinlogPosition_BothNonErrNoRowsFail` (scope-creep guard: combined diagnostic preserved)

Generated with Claude Code