### PR TITLE
fix(agent): treat 4xx WebSocket-upgrade errors as permanent (#328)

### DIFF
--- a/internal/agent/channel.go
+++ b/internal/agent/channel.go
@@ -248,6 +248,15 @@ func (ch *Channel) connectAndListen(ctx context.Context) error {
 // record instead of creating a duplicate byos-<server-id>. The header is
 // omitted entirely when ServerUUID is empty so an older backend isn't
 // confused by an empty value. See issue #317.
+//
+// On HTTP error responses (4xx) the upgrade fails before any WebSocket
+// close frame is exchanged, so the standard close-code path in
+// isTemporary cannot see them. A 4xx is the SaaS's "your request is
+// permanently wrong" signal (missing auth header, revoked key, unknown
+// server UUID once #328's SaaS side lands, etc.) — retrying without
+// operator intervention just spins the reconnect loop. dial wraps the
+// raw handshake error in a *PermanentDialError so isTemporary can
+// classify it as permanent. See issue #328.
 func (ch *Channel) dial(ctx context.Context) (*websocket.Conn, error) {
 	header := http.Header{}
 	header.Set("Authorization", "Bearer "+ch.cfg.APIKey)
@@ -255,10 +264,22 @@ func (ch *Channel) dial(ctx context.Context) (*websocket.Conn, error) {
 		header.Set("X-Bintrail-Server-UUID", ch.cfg.ServerUUID)
 	}
 
-	conn, _, err := websocket.Dial(ctx, ch.cfg.Endpoint, &websocket.DialOptions{
+	conn, resp, err := websocket.Dial(ctx, ch.cfg.Endpoint, &websocket.DialOptions{
 		HTTPHeader: header,
 	})
+	// coder/websocket replaces resp.Body with an io.NopCloser on the
+	// error path (dial.go ~line 161) and documents "you never need to
+	// close resp.Body yourself", so this Close is a defensive no-op —
+	// but it's the standard net/http contract and survives a future lib
+	// change that re-introduces a real ReadCloser. Cheap insurance
+	// against an FD leak per failed dial.
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
+		if resp != nil && resp.StatusCode >= 400 && resp.StatusCode < 500 {
+			return nil, &PermanentDialError{StatusCode: resp.StatusCode, Err: err}
+		}
 		return nil, err
 	}
 	return conn, nil
@@ -465,9 +486,49 @@ func (e *FatalCloseError) Error() string {
 
 func (e *FatalCloseError) Unwrap() error { return e.Err }
 
+// PermanentDialError wraps a WebSocket-upgrade failure that came back
+// with an HTTP 4xx response. 4xx during the upgrade means the SaaS
+// permanently rejected the request (bad/missing/revoked API key,
+// unknown server UUID, malformed headers, etc.) — retrying without
+// operator intervention just spins the reconnect loop until the
+// MaxReconnectAttempts budget exhausts.
+//
+// dial() returns this from the agent's WebSocket dial path so
+// isTemporary can short-circuit the reconnect loop the same way it
+// short-circuits on a permanent close-code rejection. See issue #328.
+//
+// Note this is independent of FatalCloseError: FatalCloseError covers
+// the post-handshake "server closed the WebSocket with a fatal reason
+// string" case (close code 1008 / 44xx), while PermanentDialError
+// covers the pre-handshake "server never accepted the upgrade" case.
+// Both stop the reconnect loop but only the close-code path carries a
+// FatalReason — a raw 4xx has no canonical reason category yet.
+type PermanentDialError struct {
+	StatusCode int
+	Err        error
+}
+
+func (e *PermanentDialError) Error() string {
+	if e.Err == nil {
+		return fmt.Sprintf("permanent dial error: HTTP %d", e.StatusCode)
+	}
+	return fmt.Sprintf("permanent dial error (HTTP %d): %s", e.StatusCode, e.Err.Error())
+}
+
+func (e *PermanentDialError) Unwrap() error { return e.Err }
+
 // isTemporary reports whether err is a connection-level error that should
 // trigger a reconnect (as opposed to a permanent auth failure).
 func isTemporary(err error) bool {
+	// 4xx on the HTTP upgrade is a permanent rejection — see
+	// PermanentDialError docs and issue #328. Checked first because a
+	// pre-handshake failure cannot also carry a CloseError, and putting
+	// the permanent classifier ahead of the existing switch keeps the
+	// existing close-code branches byte-identical.
+	var pde *PermanentDialError
+	if errors.As(err, &pde) {
+		return false
+	}
 	var closeErr websocket.CloseError
 	if errors.As(err, &closeErr) {
 		switch closeErr.Code {

--- a/internal/agent/channel_test.go
+++ b/internal/agent/channel_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -922,5 +923,153 @@ func TestChannelConfig_maxReconnectAttempts(t *testing.T) {
 				t.Errorf("maxReconnectAttempts() = %d, want %d", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestPermanentDialError_ErrorAndUnwrap pins the wrapper-type contract so a
+// refactor (e.g. inlining the StatusCode formatting) doesn't accidentally
+// break errors.Is / errors.Unwrap callers — isTemporary uses errors.As, and
+// connectAndListen wraps with `fmt.Errorf("dial: %w", err)`, so an unwrap
+// regression would silently re-enable the reconnect loop on 4xx.
+func TestPermanentDialError_ErrorAndUnwrap(t *testing.T) {
+	inner := fmt.Errorf("upgrade rejected by server")
+	pde := &PermanentDialError{StatusCode: 401, Err: inner}
+	if !errors.Is(pde, inner) {
+		t.Errorf("errors.Is(pde, inner) = false, want true")
+	}
+	if !strings.Contains(pde.Error(), "401") {
+		t.Errorf("Error() = %q, want it to contain status code", pde.Error())
+	}
+	if !strings.Contains(pde.Error(), "upgrade rejected") {
+		t.Errorf("Error() = %q, want it to contain wrapped error", pde.Error())
+	}
+	// Nil-inner branch.
+	bare := &PermanentDialError{StatusCode: 403}
+	if got := bare.Error(); !strings.Contains(got, "403") {
+		t.Errorf("Error() = %q, want it to contain status code", got)
+	}
+}
+
+// TestIsTemporary_permanentDialError verifies that a *PermanentDialError —
+// even one wrapped by `fmt.Errorf("dial: %w", ...)` the way
+// connectAndListen does — is classified as permanent. This is the core
+// isTemporary contract used by Run to decide whether to reconnect.
+func TestIsTemporary_permanentDialError(t *testing.T) {
+	direct := &PermanentDialError{StatusCode: 401, Err: fmt.Errorf("nope")}
+	if isTemporary(direct) {
+		t.Errorf("isTemporary(direct PermanentDialError) = true, want false")
+	}
+	// Matches the production wrap site in connectAndListen.
+	wrapped := fmt.Errorf("dial: %w", direct)
+	if isTemporary(wrapped) {
+		t.Errorf("isTemporary(wrapped PermanentDialError) = true, want false")
+	}
+}
+
+// TestDial_4xxResponseIsPermanent exercises the dial path end-to-end against
+// an httptest.Server that rejects the WebSocket upgrade with 401. The
+// returned error must be a *PermanentDialError carrying the status code,
+// and isTemporary must classify it as permanent so the reconnect loop
+// stops.
+func TestDial_4xxResponseIsPermanent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Reject the upgrade — no websocket.Accept call, just a plain
+		// 401. coder/websocket will see a non-101 status and return an
+		// error with the *http.Response still populated.
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	cfg := ChannelConfig{
+		Endpoint: "ws" + strings.TrimPrefix(srv.URL, "http"),
+		APIKey:   "bad-key",
+	}
+	ch := NewChannel(cfg, &stubHandler{}, nil, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	_, err := ch.dial(ctx)
+	if err == nil {
+		t.Fatal("expected error from dial against 401 endpoint")
+	}
+	var pde *PermanentDialError
+	if !errors.As(err, &pde) {
+		t.Fatalf("expected *PermanentDialError, got %T: %v", err, err)
+	}
+	if pde.StatusCode != http.StatusUnauthorized {
+		t.Errorf("StatusCode = %d, want %d", pde.StatusCode, http.StatusUnauthorized)
+	}
+	if isTemporary(err) {
+		t.Error("isTemporary(401 dial error) = true, want false")
+	}
+}
+
+// TestDial_5xxResponseIsTemporary verifies the current behavior on 5xx
+// (treat as transient → reconnect) is preserved. 5xx means the SaaS is
+// having a bad time but a retry might succeed; we must NOT wrap it in
+// PermanentDialError.
+func TestDial_5xxResponseIsTemporary(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	cfg := ChannelConfig{
+		Endpoint: "ws" + strings.TrimPrefix(srv.URL, "http"),
+		APIKey:   "any",
+	}
+	ch := NewChannel(cfg, &stubHandler{}, nil, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	_, err := ch.dial(ctx)
+	if err == nil {
+		t.Fatal("expected error from dial against 500 endpoint")
+	}
+	var pde *PermanentDialError
+	if errors.As(err, &pde) {
+		t.Fatalf("did not expect *PermanentDialError for 5xx, got: %v", err)
+	}
+	if !isTemporary(err) {
+		t.Error("isTemporary(500 dial error) = false, want true")
+	}
+}
+
+// TestDial_NetworkErrorIsTemporary verifies that a pre-HTTP transport
+// failure (closed listener, connection refused, etc.) stays classified as
+// temporary. The *http.Response is nil in this case so dial() must not
+// dereference it.
+func TestDial_NetworkErrorIsTemporary(t *testing.T) {
+	// Bind a port, then close the listener so connection attempts to
+	// that port are refused. Using a discovered-then-closed port avoids
+	// hard-coding a hopefully-unused port number.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := l.Addr().String()
+	l.Close()
+
+	cfg := ChannelConfig{
+		Endpoint: "ws://" + addr + "/",
+		APIKey:   "any",
+	}
+	ch := NewChannel(cfg, &stubHandler{}, nil, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	_, err = ch.dial(ctx)
+	if err == nil {
+		t.Fatal("expected error from dial against closed listener")
+	}
+	var pde *PermanentDialError
+	if errors.As(err, &pde) {
+		t.Fatalf("did not expect *PermanentDialError for network error, got: %v", err)
+	}
+	if !isTemporary(err) {
+		t.Error("isTemporary(network error) = false, want true")
 	}
 }


### PR DESCRIPTION
## Summary

- `dial()` now captures the `*http.Response` from `websocket.Dial`. When the handshake fails with an HTTP 4xx status (bad/missing/revoked API key, malformed headers, future SaaS rejections such as unknown server UUID, etc.), the error is wrapped in a new `*PermanentDialError` carrying the status code.
- `isTemporary` recognizes `*PermanentDialError` via `errors.As` (matching the `fmt.Errorf("dial: %w", ...)` wrap that `connectAndListen` already applies) and returns `false`, so the reconnect loop fails fast instead of grinding through `MaxReconnectAttempts` retries.
- 5xx and pre-HTTP transport errors (connection refused, EOF mid-handshake, etc.) stay classified as transient — current reconnect behavior is preserved.
- The response body is closed defensively. coder/websocket replaces `resp.Body` with an `io.NopCloser` on the error path so the `Close()` is currently a no-op, but the contract is the standard `net/http` one and survives a future lib change.

## Scope

**Partially addresses #328** — implements only the defensive item 2 from the issue (4xx-permanent classification in the dial path). Leaving the issue open for the follow-up PR.

Item 1 from the issue (mapping a specific `unknown_server_uuid` close-reason string in `ClassifyClose`) **awaits SaaS-side spec** — shipping a guessed reason string would either need a fix-up PR or constrain the SaaS team's design space. Once the close-reason string is agreed in the SaaS PR, a follow-up PR will add it to the `ClassifyClose` switch.

## Design notes

- New exported `*PermanentDialError` type (vs adding a field to an existing error) — matches the existing `FatalCloseError` next to it and keeps the close-code path and the pre-handshake path orthogonal. A 4xx during upgrade cannot also carry a `websocket.CloseError`, so the two classifiers don't overlap.
- `isTemporary`'s new `errors.As(&pde)` check is placed **before** the existing `CloseError` switch. The two paths are independent, but ordering the new branch first makes intent obvious and keeps the close-code branches byte-identical.
- The `TestDial_4xxBodyClosed` test the prompt suggested was dropped: coder/websocket replaces `resp.Body` with an `io.NopCloser` on the error path (`dial.go:161`), so asserting "the body was closed" has nothing real to assert against. The defensive `defer resp.Body.Close()` is still in the code path; coverage of the 4xx error type itself is provided by `TestDial_4xxResponseIsPermanent`.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./internal/agent/... -count=1` — all pass (existing + 5 new tests)
- [x] New tests:
  - `TestPermanentDialError_ErrorAndUnwrap` — wrapper-type `Error()`/`Unwrap()`/`errors.Is` contract
  - `TestIsTemporary_permanentDialError` — both direct and `fmt.Errorf("dial: %w", ...)`-wrapped forms classified as permanent
  - `TestDial_4xxResponseIsPermanent` — httptest server returning 401 produces `*PermanentDialError` with StatusCode=401 and `isTemporary(err) == false`
  - `TestDial_5xxResponseIsTemporary` — 500 stays transient, not wrapped
  - `TestDial_NetworkErrorIsTemporary` — closed listener (nil `*http.Response`) stays transient, no nil-deref
- [ ] Manual verification on a real SaaS endpoint once the matching reconciliation PR lands (the whole point of landing this first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)