### PR TITLE
docs(agent): refresh --server-uuid help and cross-ref from --server-id (#337 #336)

### DIFF
--- a/cmd/bintrail/agent.go
+++ b/cmd/bintrail/agent.go
@@ -95,8 +95,8 @@ func init() {
 	agentCmd.Flags().StringVar(&agtArchiveDir, "archive-dir", "", "Local directory containing Parquet archives")
 	agentCmd.Flags().StringVar(&agtArchiveS3, "archive-s3", "", "S3 path to Parquet archives (e.g. s3://bucket/prefix/)")
 	agentCmd.Flags().StringVar(&agtBufferRetain, "buffer-retain", "6h", "How long to retain events in the in-memory buffer (e.g. 6h, 24h)")
-	agentCmd.Flags().Uint32Var(&agtServerID, "server-id", 0, "MySQL server ID for replication (required for BYOS streaming)")
-	agentCmd.Flags().StringVar(&agtServerUUID, "server-uuid", "", "UUID of a pre-registered BYOS server (POST /api/v1/servers). When set, the SaaS reconciles this agent's WebSocket connection to that record; when empty, the SaaS auto-creates a new byos-<server-id> record (back-compat). WARNING: a UUID that doesn't match a pre-registered server — whether because of a typo or because the SaaS predates the matching reconciliation logic — is currently *silently ignored* and the SaaS still creates a byos-<server-id> duplicate. After first connect, verify in the dbtrail dashboard that no duplicate record was created.")
+	agentCmd.Flags().Uint32Var(&agtServerID, "server-id", 0, "MySQL server ID for replication, numeric uint32 (required for BYOS streaming). If you have a pre-registered UUID from the dbtrail dashboard, pass it to --server-uuid instead — this flag does NOT accept UUIDs and will reject them with strconv.ParseUint.")
+	agentCmd.Flags().StringVar(&agtServerUUID, "server-uuid", "", "UUID of a pre-registered BYOS server (POST /api/v1/servers). When set, the SaaS reconciles this agent's WebSocket connection to that record; when empty, the SaaS auto-creates a new byos-<server-id> record (back-compat). A UUID that doesn't match a pre-registered server (typo, stale config, cross-tenant) is logged server-side as a WARNING with the UUID + tenant ID; the SaaS will NOT bind your agent to any record in that case. Verify in the dashboard that the expected pre-registered server is showing the connection.")
 	agentCmd.Flags().IntVar(&agtBatchSize, "batch-size", 1000, "Number of events per batch flush")
 	agentCmd.Flags().StringVar(&agtSchemas, "schemas", "", "Comma-separated list of schemas to index (empty = all)")
 	agentCmd.Flags().StringVar(&agtTables, "tables", "", "Comma-separated list of tables to index (empty = all)")
@@ -145,7 +145,7 @@ func runAgent(cmd *cobra.Command, args []string) error {
 	// only place an operator can confirm what the agent will send. See #317
 	// silent-failure findings C2/C3.
 	if agtServerUUID != "" {
-		slog.Info("agent using --server-uuid", "server_uuid", agtServerUUID, "hint", "verify in dbtrail dashboard that no duplicate byos-<server-id> record was created after first connect")
+		slog.Info("agent using --server-uuid", "server_uuid", agtServerUUID, "hint", "verify in dbtrail dashboard that the expected pre-registered server is showing this connection; a UUID mismatch will be logged server-side as a WARNING and the SaaS will not bind to any record")
 	}
 
 	start := time.Now()


### PR DESCRIPTION
closes #337
closes #336

## Summary

Two related docs follow-ups from the `--server-uuid` cluster (PR #324). Bundled because both touch `cmd/bintrail/agent.go` lines 98-99.

- **#337**: Replace the stale WARNING on `--server-uuid` ("silently ignored / SaaS still creates a byos-<server-id> duplicate") with the post-hardening text. After dbtrail#1490 + f06d939 the SaaS logs a WARNING and does NOT bind to any record when the header UUID doesn't match.
- **#336**: Add a cross-reference in the `--server-id` help text pointing operators at `--server-uuid` when they have a pre-registered UUID. Minimal scope — does NOT unify the two flags.

While here, the matching `slog.Info` hint at `runAgent` (line 148) carried the same stale "no duplicate byos-<server-id> record" framing — refreshed to match the new SaaS behavior.

## Why one PR

Both changes touch the same two lines of the same file. Two separate PRs would conflict on rebase or force one to wait on the other. The two `closes` directives still auto-close both issues.

## Out of scope (worth filing separately)

- Real unification of `--server-id` / `--server-uuid` (option 1 from #336). Larger surface — would need detection of type, payload encoding, SaaS coordination on `bintrail_id` semantics.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [ ] Manual: `bintrail agent --help | grep -A2 "server-id\|server-uuid"` — confirm help text reads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)