### PR TITLE
feat(stream): auto-discover binlog position on first run (#312)

### DIFF
--- a/cmd/bintrail/stream.go
+++ b/cmd/bintrail/stream.go
@@ -41,10 +41,13 @@ indexes binlog row events in real-time into binlog_events.
 Unlike 'bintrail index', this command does not require access to binlog files
 on disk and works with managed MySQL (RDS, Aurora, Cloud SQL).
 
-Start position must be specified on the first run via --start-file or
---start-gtid. On subsequent runs the saved checkpoint is resumed automatically,
-even if --start-file/--start-gtid are still present on the command line. This
-makes re-running the same command idempotent.
+Start position on the first run: by default bintrail auto-discovers the
+source's current binlog position via SHOW BINARY LOG STATUS (falling back to
+SHOW MASTER STATUS on pre-8.4 MySQL). Pass --start-file/--start-pos or
+--start-gtid to override and start from a specific earlier position. On
+subsequent runs the saved checkpoint is resumed automatically, even if
+--start-file/--start-gtid are still present on the command line. This makes
+re-running the same command idempotent.
 
 Use --reset to clear the saved checkpoint and force a new start position:
 
@@ -404,6 +407,40 @@ func resolveStart(
 	return "", "", "", 0, nil, fmt.Errorf(
 		"no start position specified and no saved stream state found; " +
 			"provide --start-file or --start-gtid to begin streaming")
+}
+
+// resolveStartWithAutoDiscover wraps resolveStart with an auto-discover
+// fallback for the first-run, no-flags case. When neither --start-file nor
+// --start-gtid is set AND no checkpoint exists yet, the provided autoDiscover
+// callback is invoked to query the source's current binlog position (matching
+// the behavior of `bintrail agent` BYOS mode). The callback is typically
+// config.CurrentBinlogPosition(sourceDB).
+//
+// All other paths (saved checkpoint, explicit flags, mutually-exclusive flags,
+// invalid GTID, etc.) delegate to resolveStart unchanged. The wrapper exists
+// so the discovery side-effect can be unit-tested without a real *sql.DB —
+// callers pass a stub function.
+func resolveStartWithAutoDiscover(
+	startFile, startGTID string, startPos uint32,
+	saved *streamState,
+	autoDiscover func() (string, uint32, error),
+) (mode, file, gtidStr string, pos uint32, accGTID *gomysql.MysqlGTIDSet, err error) {
+	mode, file, gtidStr, pos, accGTID, err = resolveStart(startFile, startGTID, startPos, saved)
+	if err == nil {
+		return
+	}
+	// Only fall back to auto-discover when the failure is the specific
+	// "no start position" case (saved == nil and no flags). Other errors
+	// (mutually-exclusive flags, invalid GTID, corrupt saved state) must
+	// propagate so the operator sees the real problem.
+	if autoDiscover == nil || saved != nil || startFile != "" || startGTID != "" {
+		return
+	}
+	af, ap, dErr := autoDiscover()
+	if dErr != nil {
+		return "", "", "", 0, nil, fmt.Errorf("auto-discover binlog position: %w", dErr)
+	}
+	return "position", af, "", ap, nil, nil
 }
 
 // ─── Gap detection ──────────────────────────────────────────────────────────────
@@ -874,10 +911,17 @@ func runStream(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	mode, startFile, startGTIDStr, startPos, accGTID, err := resolveStart(
-		strmStartFile, strmStartGTID, strmStartPos, saved)
+	mode, startFile, startGTIDStr, startPos, accGTID, err := resolveStartWithAutoDiscover(
+		strmStartFile, strmStartGTID, strmStartPos, saved,
+		func() (string, uint32, error) { return config.CurrentBinlogPosition(sourceDB) })
 	if err != nil {
 		return err
+	}
+	// Surface the auto-discovered position when this was a first-run, no-flags
+	// invocation. Mirrors the agent BYOS startup checkmark style.
+	if saved == nil && strmStartFile == "" && strmStartGTID == "" && mode == "position" {
+		slog.Info("auto-discovered current binlog position", "file", startFile, "pos", startPos)
+		fmt.Printf("Start position: auto-discovered %s:%d ✓\n", startFile, startPos)
 	}
 
 	// ── 6b. Detect binlog gap ────────────────────────────────────────────

--- a/cmd/bintrail/stream_test.go
+++ b/cmd/bintrail/stream_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"errors"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -1203,5 +1204,127 @@ func TestStreamCmd_noGapFillFlagRegistered(t *testing.T) {
 	}
 	if f.DefValue != "false" {
 		t.Errorf("expected default no-gap-fill=false, got %q", f.DefValue)
+	}
+}
+
+// ─── resolveStartWithAutoDiscover ────────────────────────────────────────────
+
+// TestResolveStartWithAutoDiscover_firesOnFirstRun verifies that the
+// auto-discover callback is invoked when saved is nil and no flags are set,
+// and that its result becomes the start position.
+func TestResolveStartWithAutoDiscover_firesOnFirstRun(t *testing.T) {
+	called := false
+	mode, file, _, pos, _, err := resolveStartWithAutoDiscover("", "", 4, nil,
+		func() (string, uint32, error) {
+			called = true
+			return "mysql-bin.000042", 1234, nil
+		})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Error("expected autoDiscover to be called")
+	}
+	if mode != "position" || file != "mysql-bin.000042" || pos != 1234 {
+		t.Errorf("got mode=%q file=%q pos=%d, want position/mysql-bin.000042/1234",
+			mode, file, pos)
+	}
+}
+
+// TestResolveStartWithAutoDiscover_skippedWhenFlagSet verifies that an
+// explicit --start-file bypasses auto-discover (preserves operator override).
+func TestResolveStartWithAutoDiscover_skippedWhenFlagSet(t *testing.T) {
+	called := false
+	mode, file, _, pos, _, err := resolveStartWithAutoDiscover("binlog.000001", "", 100, nil,
+		func() (string, uint32, error) {
+			called = true
+			return "should-not-be-used", 999, nil
+		})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if called {
+		t.Error("autoDiscover should not be called when --start-file is set")
+	}
+	if mode != "position" || file != "binlog.000001" || pos != 100 {
+		t.Errorf("got mode=%q file=%q pos=%d, want position/binlog.000001/100",
+			mode, file, pos)
+	}
+}
+
+// TestResolveStartWithAutoDiscover_skippedWhenSavedExists verifies that
+// a saved checkpoint bypasses auto-discover (preserves resume behavior).
+func TestResolveStartWithAutoDiscover_skippedWhenSavedExists(t *testing.T) {
+	saved := &streamState{
+		mode: "position", binlogFile: "saved.000007", binlogPos: 500,
+	}
+	called := false
+	mode, file, _, pos, _, err := resolveStartWithAutoDiscover("", "", 4, saved,
+		func() (string, uint32, error) {
+			called = true
+			return "should-not-be-used", 999, nil
+		})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if called {
+		t.Error("autoDiscover should not be called when a saved checkpoint exists")
+	}
+	if mode != "position" || file != "saved.000007" || pos != 500 {
+		t.Errorf("got mode=%q file=%q pos=%d, want position/saved.000007/500",
+			mode, file, pos)
+	}
+}
+
+// TestResolveStartWithAutoDiscover_nilCallbackPreservesOriginalError verifies
+// that when no callback is wired and no flags/saved exist, the original
+// "no start position" error still surfaces (back-compat).
+func TestResolveStartWithAutoDiscover_nilCallbackPreservesOriginalError(t *testing.T) {
+	_, _, _, _, _, err := resolveStartWithAutoDiscover("", "", 4, nil, nil)
+	if err == nil {
+		t.Fatal("expected error when nil callback and no flags/saved, got nil")
+	}
+	if !strings.Contains(err.Error(), "no start position specified") {
+		t.Errorf("expected original 'no start position' error, got: %v", err)
+	}
+}
+
+// TestResolveStartWithAutoDiscover_discoveryErrorWrapped verifies that an
+// auto-discover failure is surfaced (wrapped) rather than silently masked.
+func TestResolveStartWithAutoDiscover_discoveryErrorWrapped(t *testing.T) {
+	stubErr := errors.New("SHOW BINARY LOG STATUS returned no rows")
+	_, _, _, _, _, err := resolveStartWithAutoDiscover("", "", 4, nil,
+		func() (string, uint32, error) {
+			return "", 0, stubErr
+		})
+	if err == nil {
+		t.Fatal("expected discovery error to surface, got nil")
+	}
+	if !errors.Is(err, stubErr) {
+		t.Errorf("expected wrapped stubErr via errors.Is, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "auto-discover binlog position") {
+		t.Errorf("expected error wrap prefix, got: %v", err)
+	}
+}
+
+// TestResolveStartWithAutoDiscover_mutuallyExclusiveFlagsErrorPropagates
+// verifies the wrapper does NOT swallow a real resolveStart error and try
+// auto-discover instead.
+func TestResolveStartWithAutoDiscover_mutuallyExclusiveFlagsErrorPropagates(t *testing.T) {
+	called := false
+	_, _, _, _, _, err := resolveStartWithAutoDiscover("binlog.000001", "uuid:1", 4, nil,
+		func() (string, uint32, error) {
+			called = true
+			return "", 0, nil
+		})
+	if err == nil {
+		t.Fatal("expected mutually-exclusive error, got nil")
+	}
+	if called {
+		t.Error("autoDiscover must not be called when flags are mutually exclusive")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("expected mutually-exclusive error, got: %v", err)
 	}
 }

--- a/cmd/bintrail/stream_test.go
+++ b/cmd/bintrail/stream_test.go
@@ -1252,6 +1252,37 @@ func TestResolveStartWithAutoDiscover_skippedWhenFlagSet(t *testing.T) {
 	}
 }
 
+// TestResolveStartWithAutoDiscover_skippedWhenGTIDFlagSet verifies the
+// symmetric guard: an explicit --start-gtid bypasses auto-discover. The
+// wrapper checks `startFile != "" || startGTID != ""` — a future
+// refactor that asymmetrically drops the startGTID check would silently
+// invoke discovery on GTID-mode first runs and overwrite the operator's
+// declared base GTID. This test catches that.
+func TestResolveStartWithAutoDiscover_skippedWhenGTIDFlagSet(t *testing.T) {
+	gtidSet := "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-5"
+	called := false
+	mode, _, returnedGTID, _, accGTID, err := resolveStartWithAutoDiscover("", gtidSet, 4, nil,
+		func() (string, uint32, error) {
+			called = true
+			return "should-not-be-used", 999, nil
+		})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if called {
+		t.Error("autoDiscover should not be called when --start-gtid is set")
+	}
+	if mode != "gtid" {
+		t.Errorf("mode = %q, want gtid", mode)
+	}
+	if returnedGTID != gtidSet {
+		t.Errorf("returnedGTID = %q, want %q", returnedGTID, gtidSet)
+	}
+	if accGTID == nil {
+		t.Error("expected non-nil accGTID in gtid mode")
+	}
+}
+
 // TestResolveStartWithAutoDiscover_skippedWhenSavedExists verifies that
 // a saved checkpoint bypasses auto-discover (preserves resume behavior).
 func TestResolveStartWithAutoDiscover_skippedWhenSavedExists(t *testing.T) {


### PR DESCRIPTION
closes #312

## Summary

`bintrail stream` now auto-discovers the source's current binlog position via `SHOW BINARY LOG STATUS` (falling back to `SHOW MASTER STATUS` on pre-8.4 MySQL) when neither `--start-file` nor `--start-gtid` is set and no `stream_state` checkpoint exists yet. Mirrors the behavior `bintrail agent` BYOS mode has had since `config.CurrentBinlogPosition` landed in `internal/config/`.

The helper was already shared between agent and config — the only missing piece was the wiring. New `resolveStartWithAutoDiscover` wrapper around `resolveStart` keeps existing tests intact while making the auto-discover path independently unit-testable via a stub callback.

## What's preserved

- Explicit \`--start-file\`/\`--start-pos\` or \`--start-gtid\` bypass auto-discover.
- Saved checkpoint takes priority (resume semantics).
- Mutually-exclusive flag errors / invalid GTID errors propagate — auto-discover does NOT swallow real errors.

## What's new

- First-run with no flags/checkpoint: auto-discover and log `auto-discovered current binlog position` + a `Start position: auto-discovered <file>:<pos> ✓` checkmark line for UX parity with BYOS.

## Implementation notes (issue body was stale)

The original issue suggested factoring into `internal/agent/byos/` and reusing the auto-discovery from agent. That path doesn't exist — `config.CurrentBinlogPosition` is the helper, already in `internal/config/`, already called from `cmd/bintrail/agent.go:636`. This PR just wires it into `bintrail stream`'s first-run path.

## Test plan

- [x] Unit tests pass (\`go test ./... -count=1\`)
- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] 5 new unit tests for \`resolveStartWithAutoDiscover\`:
  - fires on first run (no flags, no saved)
  - skipped when \`--start-file\` is set
  - skipped when saved checkpoint exists
  - nil callback preserves original \"no start position\" error (back-compat)
  - discovery error is wrapped (not silently masked)
  - mutually-exclusive-flags error propagates, callback NOT invoked
- [ ] Manual: \`bintrail stream --source-dsn ... --index-dsn ... --server-id 42\` against a fresh source — confirm it picks up current position and logs the checkmark line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)