### PR TITLE
agent: send X-Bintrail-Server-UUID header on every /v1/events POST

### DIFF
--- a/cmd/bintrail/agent.go
+++ b/cmd/bintrail/agent.go
@@ -323,7 +323,11 @@ func runAgent(cmd *cobra.Command, args []string) error {
 		var payloadWriter *byos.PayloadWriter
 
 		if agtS3Bucket != "" {
-			metaClient = byos.NewMetadataClient(wsEndpointToHTTP(agtEndpoint), agtAPIKey)
+			// Pass the canonicalized --server-uuid so the metadata client sets
+			// X-Bintrail-Server-UUID on every /v1/events POST, mirroring the
+			// WS-dial reconcile path (issue #317). Empty preserves legacy
+			// behavior. See dbtrail/bintrail#341 + dbtrail/dbtrail#1495.
+			metaClient = byos.NewMetadataClient(wsEndpointToHTTP(agtEndpoint), agtAPIKey, agtServerUUID)
 
 			s3Backend, err := storage.NewS3Backend(ctx, storage.S3Config{
 				Bucket: agtS3Bucket,

--- a/internal/byos/metadata.go
+++ b/internal/byos/metadata.go
@@ -12,20 +12,30 @@ import (
 
 // MetadataClient sends metadata records to the dbtrail API.
 type MetadataClient struct {
-	endpoint string // base URL, e.g. "https://api.dbtrail.io"
-	apiKey   string
-	http     *http.Client
+	endpoint   string // base URL, e.g. "https://api.dbtrail.io"
+	apiKey     string
+	serverUUID string // pre-registered server UUID (empty for legacy back-compat)
+	http       *http.Client
 }
 
 // NewMetadataClient creates a client that sends metadata to the given
 // dbtrail API endpoint. The endpoint should be a base URL without a
 // trailing slash (e.g. "https://api.dbtrail.io"). The apiKey is sent
 // as a Bearer token in the Authorization header.
-func NewMetadataClient(endpoint, apiKey string) *MetadataClient {
+//
+// serverUUID mirrors the value the agent's WebSocket channel already
+// sends in X-Bintrail-Server-UUID on dial (see internal/agent/channel.go,
+// issue #317). When non-empty it is also sent in the same header on
+// every POST /v1/events, so the dbtrail backend can resolve a
+// dashboard-pre-registered row by UUID instead of creating a duplicate
+// byos-<server-id> on the first ingest. Empty preserves legacy behavior.
+// See issue #341.
+func NewMetadataClient(endpoint, apiKey, serverUUID string) *MetadataClient {
 	return &MetadataClient{
-		endpoint: endpoint,
-		apiKey:   apiKey,
-		http:     &http.Client{Timeout: 30 * time.Second},
+		endpoint:   endpoint,
+		apiKey:     apiKey,
+		serverUUID: serverUUID,
+		http:       &http.Client{Timeout: 30 * time.Second},
 	}
 }
 
@@ -45,6 +55,13 @@ func (c *MetadataClient) Send(ctx context.Context, records []MetadataRecord) err
 	req.Header.Set("Content-Type", "application/json")
 	if c.apiKey != "" {
 		req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	}
+	// Mirror the WS-handshake header so the SaaS resolves pre-registered
+	// rows by UUID on first ingest (#341). Omit entirely when empty so an
+	// older backend isn't confused by an empty value, matching the WS dial
+	// pattern in internal/agent/channel.go.
+	if c.serverUUID != "" {
+		req.Header.Set("X-Bintrail-Server-UUID", c.serverUUID)
 	}
 
 	resp, err := c.http.Do(req)

--- a/internal/byos/metadata_test.go
+++ b/internal/byos/metadata_test.go
@@ -34,7 +34,7 @@ func TestMetadataClientSend(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewMetadataClient(srv.URL, "test-key")
+	client := NewMetadataClient(srv.URL, "test-key", "")
 	records := []MetadataRecord{
 		{
 			PKHash:         "abc123",
@@ -127,7 +127,7 @@ func TestMetadataClientSendError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewMetadataClient(srv.URL, "test-key")
+	client := NewMetadataClient(srv.URL, "test-key", "")
 	err := client.Send(context.Background(), []MetadataRecord{{PKHash: "x"}})
 	if err == nil {
 		t.Fatal("expected error for 500 response")
@@ -140,7 +140,7 @@ func TestMetadataClientSendContext(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewMetadataClient(srv.URL, "test-key")
+	client := NewMetadataClient(srv.URL, "test-key", "")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel immediately
@@ -148,5 +148,61 @@ func TestMetadataClientSendContext(t *testing.T) {
 	err := client.Send(ctx, []MetadataRecord{{PKHash: "x"}})
 	if err == nil {
 		t.Fatal("expected error for cancelled context")
+	}
+}
+
+// TestMetadataClientSendsServerUUIDHeader confirms that when NewMetadataClient
+// receives a non-empty serverUUID, every POST /v1/events carries
+// X-Bintrail-Server-UUID. Mirrors the WS-dial reconcile pattern in
+// internal/agent/channel.go (issue #317) so the SaaS resolves a
+// pre-registered server row by UUID on first ingest instead of creating
+// a duplicate byos-<server-id>. See issue #341 + dbtrail/dbtrail#1495.
+func TestMetadataClientSendsServerUUIDHeader(t *testing.T) {
+	const wantUUID = "550e8400-e29b-41d4-a716-446655440000"
+	var receivedUUID string
+	var headerPresent bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Header keys are canonicalized by net/http, look up via canonical form
+		_, headerPresent = r.Header["X-Bintrail-Server-Uuid"]
+		receivedUUID = r.Header.Get("X-Bintrail-Server-UUID")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := NewMetadataClient(srv.URL, "test-key", wantUUID)
+	if err := client.Send(context.Background(), []MetadataRecord{{PKHash: "x"}}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	if !headerPresent {
+		t.Error("X-Bintrail-Server-UUID header was not sent")
+	}
+	if receivedUUID != wantUUID {
+		t.Errorf("X-Bintrail-Server-UUID = %q, want %q", receivedUUID, wantUUID)
+	}
+}
+
+// TestMetadataClientOmitsServerUUIDHeaderWhenEmpty confirms that the header
+// is omitted entirely (not sent with empty value) when serverUUID is empty.
+// An older backend would not understand the new header; sending it empty
+// could be misinterpreted as "explicitly no server" rather than "agent
+// version doesn't carry one yet". Matches the WS-dial omission pattern.
+func TestMetadataClientOmitsServerUUIDHeaderWhenEmpty(t *testing.T) {
+	var headerPresent bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, headerPresent = r.Header["X-Bintrail-Server-Uuid"]
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := NewMetadataClient(srv.URL, "test-key", "")
+	if err := client.Send(context.Background(), []MetadataRecord{{PKHash: "x"}}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	if headerPresent {
+		t.Error("X-Bintrail-Server-UUID header should be omitted when serverUUID is empty")
 	}
 }


### PR DESCRIPTION
closes #341

## Summary

Companion to [dbtrail/dbtrail#1504](https://github.com/nethalo/dbtrail/pull/1504) (closes dbtrail/dbtrail#1495).

The SaaS ingest endpoint now reads `X-Bintrail-Server-UUID` and resolves the server by UUID before falling back to `bintrail_id`. A dashboard-pre-registered row whose `bintrail_id` is still NULL is found on first ingest instead of triggering a duplicate `byos-<server-id>` insert. Without this agent change, the SaaS fix is dormant — backwards-compatible but inert.

## Change

Mirrors the WS-dial reconcile pattern from issue #317 (`internal/agent/channel.go`): the canonicalized `--server-uuid` flag value is now plumbed through `byos.NewMetadataClient` and sent on every `POST /v1/events` as `X-Bintrail-Server-UUID`.

Empty preserves legacy behavior — the header is omitted entirely (not sent with an empty value) so an older backend isn't confused. Same omission rule as the WS dial path.

### Files
- `internal/byos/metadata.go` — `NewMetadataClient` accepts `serverUUID`; `Send` sets the header when non-empty.
- `cmd/bintrail/agent.go:326` — pass `agtServerUUID` (already validated/canonicalized at startup).
- `internal/byos/metadata_test.go` — 2 new tests + back-compat update of existing callers.

## Tests

- `TestMetadataClientSendsServerUUIDHeader` — non-empty UUID → header present and equal.
- `TestMetadataClientOmitsServerUUIDHeaderWhenEmpty` — empty UUID → header completely absent (not present with empty value). Regression guard for the omission contract.
- Existing `TestMetadataClientSend`, `TestMetadataClientSendError`, `TestMetadataClientSendContext` updated to pass `""` for the new param — all still pass.

Full `go test ./...` passes across all 24 packages. `go vet ./...` clean. `go build ./...` clean.

## Activation flow

1. This PR ships → agents on `--server-uuid X` start sending the header on every ingest POST.
2. SaaS (dbtrail/dbtrail#1504, already merged in main) resolves by UUID → finds pre-registered row → no duplicate created.
3. SaaS also backfills `bintrail_id` so future ingests via the legacy path (older agents or transient header loss) still resolve to the same row.

Existing duplicate `byos-<server-id>` rows from before the fix are **not** cleaned up by this PR — separate cleanup task if/when needed.

## Cross-repo
- SaaS issue: https://github.com/nethalo/dbtrail/issues/1495
- SaaS PR: https://github.com/nethalo/dbtrail/pull/1504
- Filed from the dbtrail-saas grooming session 2026-05-24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)