### PR TITLE
docs: sync user-facing docs with last 72h of merged changes

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -716,15 +716,7 @@ GRANT REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'bintrail_repl'@'%';
 FLUSH PRIVILEGES;
 ```
 
-Get the current binlog position for the first run:
-
-```sql
-SHOW MASTER STATUS;
--- Example output:
--- File: binlog.000123  Position: 4  Executed_Gtid_Set: 3e11fa47-...:1-5000
-```
-
-**First run** — one-time setup:
+**First run** — one-time setup. `bintrail stream` auto-discovers the current binlog position from the source on first run, so no `--start-file`/`--start-gtid` is required by default:
 
 ```sh
 # Step 1: Create index tables
@@ -735,13 +727,21 @@ bintrail snapshot \
   --source-dsn "bintrail_repl:secret@tcp(mydb.us-east-1.rds.amazonaws.com:3306)/" \
   --index-dsn  "user:pass@tcp(127.0.0.1:3306)/binlog_index"
 
-# Step 3: Start streaming from the current GTID position
+# Step 3: Start streaming — auto-discovers the current binlog head
 bintrail stream \
   --index-dsn  "user:pass@tcp(127.0.0.1:3306)/binlog_index" \
   --source-dsn "bintrail_repl:secret@tcp(mydb.us-east-1.rds.amazonaws.com:3306)/" \
   --server-id  99999 \
-  --start-gtid "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-5000" \
   --metrics-addr :9090
+```
+
+To start from an earlier position (e.g. replay a known window), query the source explicitly and pass `--start-gtid` or `--start-file`/`--start-pos`:
+
+```sql
+SHOW BINARY LOG STATUS;   -- MySQL 8.4+
+SHOW MASTER STATUS;       -- pre-8.4
+-- Example output:
+-- File: binlog.000123  Position: 4  Executed_Gtid_Set: 3e11fa47-...:1-5000
 ```
 
 **Subsequent runs** — the checkpoint is resumed automatically:
@@ -956,7 +956,7 @@ bintrail status --index-dsn "user:pass@tcp(127.0.0.1:3306)/binlog_index"
 | Recovery SQL uses `WHERE col1 = ? AND col2 = ?` for all columns (verbose) | No schema snapshot available, so bintrail falls back to matching all columns | Run `bintrail snapshot` — once a snapshot is available, recovery uses the primary key only. |
 | `failed to connect to index database: ...` | Wrong DSN, MySQL not running, or network issue | Verify the DSN is correct and test connectivity: `mysql -u user -p -h host -P 3306 binlog_index`. |
 | Index files stuck as `in_progress` | Previous `index` run crashed or was killed | Re-run `bintrail index` — `in_progress` files are retried automatically. |
-| `no start position specified; provide --start-file or --start-gtid on the first run` | First `stream` run without a starting position | Run `SHOW MASTER STATUS` on the source and pass the result as `--start-gtid` (GTID mode) or `--start-file` (position mode). On subsequent runs the checkpoint is loaded automatically. |
+| `auto-discover binlog position: ...` on `bintrail stream` first run | The default auto-discovery (`SHOW BINARY LOG STATUS` / `SHOW MASTER STATUS`) failed — usually because `log_bin=OFF` on the source, or the user lacks `REPLICATION CLIENT` | Enable binary logging on the source (or override with an explicit `--start-file`/`--start-pos` or `--start-gtid`). On RDS, set `binlog_format=ROW` in the parameter group and ensure `backup-retention-period > 0`. |
 | Stream replication lag growing | High write rate on source, slow index DB, or large batches | Try increasing `--batch-size` (reduces round-trips), check index DB load, and monitor `bintrail_stream_replication_lag_seconds` via Prometheus. |
 | `unix socket; binlog replication requires TCP` | Source DSN uses a unix socket path | Switch `--source-dsn` to TCP format: `user:pass@tcp(host:3306)/`. The replication protocol does not work over unix sockets. |
 

--- a/docs/streaming-101.md
+++ b/docs/streaming-101.md
@@ -299,28 +299,21 @@ bintrail baseline \
 
 ## Step 7: Start the replication stream
 
-Get the current GTID position from the source:
-
-```sql
-SHOW MASTER STATUS;
--- Note the Executed_Gtid_Set value, e.g.:
--- 3e11fa47-71ca-11e1-9e33-c80aa9429562:1-50000
-```
-
-Start streaming (first run — provide the GTID):
+On the first run, `bintrail stream` auto-discovers the source's current binlog position via `SHOW BINARY LOG STATUS` (or `SHOW MASTER STATUS` on pre-8.4 MySQL). No flag required:
 
 ```bash
 bintrail stream \
   --index-dsn  "user:pass@tcp(127.0.0.1:3306)/binlog_index" \
   --source-dsn "bintrail_repl:a-strong-password@tcp(source-db:3306)/" \
   --server-id  99999 \
-  --start-gtid "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-50000" \
   --metrics-addr :9090
 ```
 
+To override (start from an earlier position to replay a known window) pass `--start-file mysql-bin.000001 --start-pos 4` or `--start-gtid '<gtid-set>'` explicitly.
+
 The stream runs indefinitely, indexing every row event as it happens. It saves a checkpoint every 10 seconds to `stream_state`, so it can resume from where it left off if stopped.
 
-**Subsequent runs** resume automatically from the checkpoint — no `--start-gtid` needed:
+**Subsequent runs** resume automatically from the checkpoint — no flags needed:
 
 ```bash
 bintrail stream \

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -264,7 +264,7 @@ aws rds modify-db-instance \
   --apply-immediately
 ```
 
-The modification reaches the instance in ~2 minutes. After that, `SELECT @@log_bin` reports `1` but `SHOW BINARY LOGS` may still return an empty set until RDS completes its first automated snapshot (another ~30s–1min). Wait for `SHOW BINARY LOGS` to return at least one row before launching `bintrail stream` — without a starting binlog file the streamer exits with `no start position specified`. Set `binlog retention hours` (see below) so RDS keeps binlogs long enough for bintrail to index them before purge:
+The modification reaches the instance in ~2 minutes. After that, `SELECT @@log_bin` reports `1` but `SHOW BINARY LOGS` may still return an empty set until RDS completes its first automated snapshot (another ~30s–1min). Wait for `SHOW BINARY LOGS` to return at least one row before launching `bintrail stream` — until then auto-discovery returns no row and the streamer exits with `auto-discover binlog position: ...`. Set `binlog retention hours` (see below) so RDS keeps binlogs long enough for bintrail to index them before purge:
 
 ```sql
 CALL mysql.rds_set_configuration('binlog retention hours', 48);

--- a/docs/time-travel-sql.md
+++ b/docs/time-travel-sql.md
@@ -240,6 +240,23 @@ SELECT * FROM _snapshot.orders  AS OF '2026-05-02 10:00:00';
 SELECT * FROM _diff.orders BETWEEN '2026-05-01' AND '2026-05-02' WHERE id = 12345;
 ```
 
+On the `_flashback` / `_snapshot` shapes a column list may replace `*` and the optional `TIMESTAMP` keyword may follow `AS OF` (Oracle / SQL Server convention):
+
+```sql
+SELECT id, email, name FROM _flashback.users AS OF TIMESTAMP '2026-05-02 10:00:00' WHERE id = 1;
+```
+
+The column list accepts bare identifiers only; backticks, schema-qualified columns (`users.id`), and aliases (`id AS user_id`) are not yet parsed and surface as `ER_PARSE_ERROR`. Columns the row image is missing (e.g. dropped post-event) come back as `NULL` — matching MySQL's behaviour after an `ALTER TABLE DROP COLUMN`.
+
+The WHERE column must match the table's primary key. A WHERE on a non-PK column is rejected with a parser error rather than silently returning the wrong row.
+
+`SHOW TABLES FROM _flashback / _diff / _snapshot` returns the indexed tables in the current schema (from the latest `schema_snapshots` row) so an interactive `mysql>` session can explore the virtual schemas:
+
+```sql
+USE myapp;
+SHOW TABLES FROM _flashback;
+```
+
 `_diff` returns the full per-PK event history within the requested window — there is no implicit row cap. If a single hot row produced thousands of events, you'll get all of them in one response; if that's too much for one query, narrow the `BETWEEN` range.
 
 Full-table `_flashback` / `_snapshot` queries are buffered and capped at 100,000 rows; exceeding the cap surfaces as `ER_TOO_BIG_SELECT` (code 1104) with a hint to narrow the AS OF range or add a PK filter. DELETE events are correctly suppressed — rows that did not exist at the AS OF instant don't appear in the resultset (same semantic as Oracle's `AS OF`). For ad-hoc filtering, joins, or aggregations, pipe the resultset to `duckdb`, `pandas`, or any tool that consumes a `SELECT *` stream — the shim deliberately stays a forensic point-lookup + full-table tool, not a SQL planner.


### PR DESCRIPTION
## Summary

Updates user-facing docs where the prose got contradicted by what shipped in the last 72h. No new sections — only edits.

- **\`docs/guide.md\`** + **\`docs/streaming-101.md\`**: remove the manual `SHOW MASTER STATUS` step from the first-run walkthrough (now auto-discovered, #312). Note `SHOW BINARY LOG STATUS` as the MySQL 8.4+ form. Troubleshooting row updated to reference the new error string the auto-discover path emits.
- **\`docs/streaming.md\`**: RDS-binlog-readiness section was referencing the old "no start position specified" error; updated to the new `auto-discover binlog position: ...` form.
- **\`docs/time-travel-sql.md\`**: adds the three new shim statement variants (column lists, \`AS OF TIMESTAMP\`, \`SHOW TABLES FROM _flashback / _diff / _snapshot\`) from #313/#314/#315, plus the WHERE-must-be-PK invariant from #296.

## Test plan
- [x] No build impact (Markdown only)
- [ ] Manual: read each updated section end-to-end to confirm prose flows naturally

🤖 Generated with [Claude Code](https://claude.com/claude-code)