### PR TITLE
fix(ci): make integration tests pass in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,19 +32,6 @@ jobs:
   integration:
     runs-on: ubuntu-22.04
 
-    services:
-      mysql:
-        image: mysql:8.0
-        env:
-          MYSQL_ROOT_PASSWORD: testroot
-        ports:
-          - 13306:3306
-        options: >-
-          --health-cmd "mysqladmin ping -h localhost -uroot -ptestroot"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 10
-
     env:
       # Matches internal/testutil.DefaultDSN — set explicitly to mirror the
       # SaaS repo's `agent/` job and make the wiring obvious in logs.
@@ -57,5 +44,39 @@ jobs:
         with:
           go-version-file: go.mod
 
+      # Start MySQL as a manually-named container rather than a `services:`
+      # block. The integration tests `docker cp` raw binlog files out of a
+      # container named exactly `bintrail-test-mysql`, and they need ROW-format
+      # binlogs with a known basename — neither of which a `services:` block can
+      # provide (service containers get auto-generated names and can't take
+      # command-line args). This mirrors the local setup in CONTRIBUTING.md so
+      # CI and developer machines run against an identical container.
+      - name: Start MySQL (bintrail-test-mysql)
+        run: |
+          docker run -d --name bintrail-test-mysql \
+            -e MYSQL_ROOT_PASSWORD=testroot \
+            -p 13306:3306 \
+            mysql:8.0 \
+            --binlog-format=ROW \
+            --binlog-row-image=FULL \
+            --log-bin=binlog \
+            --server-id=1
+          echo "Waiting for MySQL to accept connections..."
+          for i in $(seq 1 60); do
+            if docker exec bintrail-test-mysql mysqladmin ping -u root -ptestroot --silent 2>/dev/null; then
+              echo "MySQL is ready."
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "MySQL did not become ready in time" >&2
+          docker logs bintrail-test-mysql >&2 || true
+          exit 1
+
+      # -p 1 serializes package execution. Integration tests share one MySQL
+      # instance with a single server-wide binlog; running packages in parallel
+      # lets one package's DDL/DML leak into another's binlog window (the binlog
+      # parser tests assert exact event counts). Serializing keeps each package
+      # the sole writer during its run.
       - name: Integration tests (-tags=integration)
-        run: go test -tags=integration -race -count=1 ./...
+        run: go test -tags=integration -race -p 1 -count=1 ./...

--- a/cmd/bintrail-mcp/e2e_test.go
+++ b/cmd/bintrail-mcp/e2e_test.go
@@ -104,8 +104,8 @@ func TestMCPE2E(t *testing.T) {
 		t.Fatalf("tools/list: expected result object, got: %v", listResp)
 	}
 	tools, _ := listResult["tools"].([]any)
-	if len(tools) != 3 {
-		t.Errorf("tools/list: expected 3 tools, got %d", len(tools))
+	if len(tools) != 4 {
+		t.Errorf("tools/list: expected 4 tools, got %d", len(tools))
 	}
 
 	toolNames := make(map[string]bool)
@@ -114,7 +114,7 @@ func TestMCPE2E(t *testing.T) {
 			toolNames[m["name"].(string)] = true
 		}
 	}
-	for _, want := range []string{"query", "recover", "status"} {
+	for _, want := range []string{"query", "recover", "status", "list_schema_changes"} {
 		if !toolNames[want] {
 			t.Errorf("tool %q not found in list", want)
 		}

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -346,10 +346,15 @@ func TestEndToEnd_fullPipeline(t *testing.T) {
 	if err := os.MkdirAll(archiveDir, 0755); err != nil {
 		t.Fatalf("failed to create archive dir: %v", err)
 	}
+	// --add-future is declarative: it tops up to at least N future partitions
+	// rather than always adding N. `init --partitions 48` already leaves 47
+	// future partitions, so the target must exceed that to add anything and
+	// exercise the partition-add path. 100 > 48 guarantees a top-up here.
 	rotateOut := run(t, binPath, coverDir, "rotate",
 		"--index-dsn", indexDSN,
-		"--add-future", "3",
+		"--add-future", "100",
 		"--archive-dir", archiveDir,
+		"--bintrail-id", "00000000-0000-0000-0000-000000000001",
 		"--archive-compression", "none",
 	)
 	// rotate writes "added partition p_YYYYMMDD" lines to stdout.


### PR DESCRIPTION
## Problem

The `integration` CI job has been **red on `main` for weeks** (every recent run failed). Surfaced while merging #354 — turned out to be entirely pre-existing, not caused by that PR.

## Root cause + the chain it unmasked

The tests `docker cp` raw binlog files out of a container named **`bintrail-test-mysql`**. A GitHub Actions `services:` block creates an auto-named container and **can't pass command-line args** (`--binlog-format=ROW --log-bin=...`). So the `docker cp` failed immediately — which masked three more latent failures:

1. **Container name (the visible failure)** — replace the `services:` block with a manual `docker run --name bintrail-test-mysql ...` mirroring CONTRIBUTING.md, so CI and local dev use an identical container.
2. **Parser binlog tests / shared binlog** — `internal/parser` asserts exact event counts, but all integration tests share **one server-wide binlog**, and `go test ./...` runs packages in parallel, so another package's `CREATE TABLE` DDL leaked into the parser's binlog window. Fix: run the integration job with **`-p 1`** (serialize package execution). DDL events are *intentionally* emitted regardless of schema filter (that powers `schema_changes` / `list_schema_changes`), so the right fix is test isolation, not the parser.
3. **`TestEndToEnd` rotate** — missing `--bintrail-id`, now required when `--archive-dir` is set.
4. **`TestEndToEnd` rotate assertion** — expected `"added partition"` with `--add-future 3`, but `--add-future` is **declarative** (top-up to N) and `init --partitions 48` already leaves 47 future partitions → adds nothing. Use `--add-future 100` to actually exercise the add path.

Plus the MCP e2e fix: a 4th tool (`list_schema_changes`) was added but `cmd/bintrail-mcp/e2e_test.go` still asserted **3** (its sibling `integration_test.go` already expected 4).

## Verification

Both run locally against the `bintrail-test-mysql` container, green:
- `go test ./... -race -count=1` (unit)
- `go test -tags=integration -race -p 1 -count=1 ./...` (integration — exact new CI command)

🤖 Generated with [Claude Code](https://claude.com/claude-code)