### PR TITLE
fix(stream): scope FK cascade pre-flight away from bintrail-internal schemas

### DIFF
--- a/cmd/bintrail/cmd_integration_test.go
+++ b/cmd/bintrail/cmd_integration_test.go
@@ -277,8 +277,8 @@ func TestValidateNoFKCascades_otherSchemaIgnored(t *testing.T) {
 // bt_<prefix> convention; testutil names every test DB bt_<TestName>). When no
 // --schemas filter is given, FK cascades inside such a schema must be ignored —
 // otherwise a second bintrail agent sharing the source MySQL fatal-fails on the
-// first agent's internal cascade (#347). This also exercises the LEFT(...)='bt_'
-// prefix match against real MySQL.
+// first agent's internal cascade (#347). This also exercises the
+// LEFT(CONSTRAINT_SCHEMA, 3) <> 'bt_' prefix match against real MySQL.
 func TestValidateNoFKCascades_internalSchemaIgnoredWhenUnscoped(t *testing.T) {
 	db, dbName := testutil.CreateTestDB(t)
 
@@ -298,6 +298,29 @@ func TestValidateNoFKCascades_internalSchemaIgnoredWhenUnscoped(t *testing.T) {
 	// But when the operator explicitly names that schema, we still police it.
 	if err := validateNoFKCascades(db, []string{dbName}); err == nil {
 		t.Fatalf("expected error when %q is explicitly targeted despite being bt_-prefixed", dbName)
+	}
+}
+
+// The inverse of the exclusion, and the load-bearing direction: an unscoped
+// scan must still CATCH a real CASCADE FK in an ordinary user schema (no bt_
+// prefix, not an index-DB name). This guards against a regression that
+// broadens the exclusion until the unscoped branch matches nothing. testutil
+// only makes bt_-prefixed DBs, so the non-internal schema is created by hand.
+func TestValidateNoFKCascades_userSchemaCaughtWhenUnscoped(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
+
+	const userSchema = "fkcascade_user"
+	testutil.MustExec(t, db, "DROP DATABASE IF EXISTS `"+userSchema+"`")
+	testutil.MustExec(t, db, "CREATE DATABASE `"+userSchema+"`")
+	t.Cleanup(func() { _, _ = db.Exec("DROP DATABASE IF EXISTS `" + userSchema + "`") })
+
+	testutil.MustExec(t, db, "CREATE TABLE `"+userSchema+"`.parents (id INT PRIMARY KEY)")
+	testutil.MustExec(t, db, "CREATE TABLE `"+userSchema+"`.children ("+
+		"id INT PRIMARY KEY, parent_id INT NOT NULL, "+
+		"CONSTRAINT fk_parent FOREIGN KEY (parent_id) REFERENCES `"+userSchema+"`.parents(id) ON DELETE CASCADE)")
+
+	if err := validateNoFKCascades(db, nil); err == nil {
+		t.Fatalf("expected unscoped scan to catch the CASCADE FK in non-internal schema %q, got nil", userSchema)
 	}
 }
 

--- a/cmd/bintrail/cmd_integration_test.go
+++ b/cmd/bintrail/cmd_integration_test.go
@@ -277,8 +277,8 @@ func TestValidateNoFKCascades_otherSchemaIgnored(t *testing.T) {
 // bt_<prefix> convention; testutil names every test DB bt_<TestName>). When no
 // --schemas filter is given, FK cascades inside such a schema must be ignored —
 // otherwise a second bintrail agent sharing the source MySQL fatal-fails on the
-// first agent's internal cascade (#347). This also exercises the `bt\_%` LIKE
-// escape against real MySQL.
+// first agent's internal cascade (#347). This also exercises the LEFT(...)='bt_'
+// prefix match against real MySQL.
 func TestValidateNoFKCascades_internalSchemaIgnoredWhenUnscoped(t *testing.T) {
 	db, dbName := testutil.CreateTestDB(t)
 

--- a/cmd/bintrail/cmd_integration_test.go
+++ b/cmd/bintrail/cmd_integration_test.go
@@ -273,6 +273,34 @@ func TestValidateNoFKCascades_otherSchemaIgnored(t *testing.T) {
 	}
 }
 
+// A bt_-prefixed schema is one of bintrail's own internal schemas (the SaaS
+// bt_<prefix> convention; testutil names every test DB bt_<TestName>). When no
+// --schemas filter is given, FK cascades inside such a schema must be ignored —
+// otherwise a second bintrail agent sharing the source MySQL fatal-fails on the
+// first agent's internal cascade (#347). This also exercises the `bt\_%` LIKE
+// escape against real MySQL.
+func TestValidateNoFKCascades_internalSchemaIgnoredWhenUnscoped(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+
+	testutil.MustExec(t, db, `CREATE TABLE profiles (id INT PRIMARY KEY)`)
+	testutil.MustExec(t, db, `CREATE TABLE access_rules (
+		id         INT PRIMARY KEY,
+		profile_id INT NOT NULL,
+		CONSTRAINT fk_access_rules_profile FOREIGN KEY (profile_id) REFERENCES profiles(id) ON DELETE CASCADE
+	)`)
+
+	// Unscoped: the cascade lives in a bt_-prefixed (bintrail-internal) schema,
+	// so the pre-flight must skip it and pass.
+	if err := validateNoFKCascades(db, nil); err != nil {
+		t.Fatalf("expected nil for FK cascade in bintrail-internal schema %q when unscoped, got: %v", dbName, err)
+	}
+
+	// But when the operator explicitly names that schema, we still police it.
+	if err := validateNoFKCascades(db, []string{dbName}); err == nil {
+		t.Fatalf("expected error when %q is explicitly targeted despite being bt_-prefixed", dbName)
+	}
+}
+
 // ─── ensureResolver ──────────────────────────────────────────────────────────────────
 
 func TestEnsureResolver_autoSnapshot(t *testing.T) {

--- a/cmd/bintrail/index.go
+++ b/cmd/bintrail/index.go
@@ -412,11 +412,17 @@ func validateBinlogRowImage(db *sql.DB) error {
 	return nil
 }
 
-// validateNoFKCascades checks that none of the targeted schemas contain foreign
-// key constraints with CASCADE rules. When schemas is empty, all non-system
-// schemas are checked. FK cascades produce invisible side-effect row changes
-// that make reversal SQL unreliable.
-func validateNoFKCascades(db *sql.DB, schemas []string) error {
+// buildFKCascadeQuery returns the REFERENTIAL_CONSTRAINTS query (and its args)
+// used to find CASCADE foreign keys. When schemas is non-empty the scan is
+// scoped to exactly those schemas — the operator explicitly asked us to index
+// them, so we police them as named. When schemas is empty we scan everything
+// except (a) MySQL's own system schemas and (b) bintrail's internal schemas
+// (the default `bintrail_index` and the SaaS `bt_<prefix>` convention). The
+// latter exclusion matters when two bintrail agents share one source MySQL:
+// without it, a second agent's pre-flight trips over the first agent's
+// internal FK cascades and fatal-fails on a schema it was never asked to index
+// (#347).
+func buildFKCascadeQuery(schemas []string) (string, []any) {
 	query := `SELECT CONSTRAINT_SCHEMA, CONSTRAINT_NAME, DELETE_RULE, UPDATE_RULE
 		FROM information_schema.REFERENTIAL_CONSTRAINTS
 		WHERE (DELETE_RULE = 'CASCADE' OR UPDATE_RULE = 'CASCADE')`
@@ -429,8 +435,21 @@ func validateNoFKCascades(db *sql.DB, schemas []string) error {
 			args = append(args, s)
 		}
 	} else {
-		query += " AND CONSTRAINT_SCHEMA NOT IN ('mysql','information_schema','performance_schema','sys')"
+		// `bt\_%` matches the literal `bt_` prefix (backslash is MySQL's default
+		// LIKE escape, so `\_` is a literal underscore rather than any char).
+		query += " AND CONSTRAINT_SCHEMA NOT IN ('mysql','information_schema','performance_schema','sys','bintrail_index')" +
+			` AND CONSTRAINT_SCHEMA NOT LIKE 'bt\_%'`
 	}
+	return query, args
+}
+
+// validateNoFKCascades checks that none of the targeted schemas contain foreign
+// key constraints with CASCADE rules. When schemas is empty, all non-system,
+// non-bintrail-internal schemas are checked (see buildFKCascadeQuery). FK
+// cascades produce invisible side-effect row changes that make reversal SQL
+// unreliable.
+func validateNoFKCascades(db *sql.DB, schemas []string) error {
+	query, args := buildFKCascadeQuery(schemas)
 
 	rows, err := db.Query(query, args...)
 	if err != nil {
@@ -453,8 +472,8 @@ func validateNoFKCascades(db *sql.DB, schemas []string) error {
 
 	if len(found) > 0 {
 		for _, c := range found {
-			slog.Warn("FK cascade constraint found",
-				"schema", c.schema, "constraint", c.name,
+			slog.Warn("FK cascade constraint found on source",
+				"source_schema", c.schema, "constraint", c.name,
 				"delete_rule", c.deleteRule, "update_rule", c.updateRule)
 		}
 		return fmt.Errorf("%d FK cascade constraint(s) found in indexed schemas; reversal SQL from `recover` may not correctly handle cascade side-effects", len(found))

--- a/cmd/bintrail/index.go
+++ b/cmd/bintrail/index.go
@@ -416,12 +416,20 @@ func validateBinlogRowImage(db *sql.DB) error {
 // used to find CASCADE foreign keys. When schemas is non-empty the scan is
 // scoped to exactly those schemas — the operator explicitly asked us to index
 // them, so we police them as named. When schemas is empty we scan everything
-// except (a) MySQL's own system schemas and (b) bintrail's internal schemas
-// (the default `bintrail_index` and the SaaS `bt_<prefix>` convention). The
-// latter exclusion matters when two bintrail agents share one source MySQL:
-// without it, a second agent's pre-flight trips over the first agent's
-// internal FK cascades and fatal-fails on a schema it was never asked to index
-// (#347).
+// except (a) MySQL's own system schemas and (b) bintrail's internal schemas:
+// the index DB (named `binlog_index` in every DSN example, occasionally
+// `bintrail_index`) and the SaaS `bt_<prefix>` convention. The latter exclusion
+// matters when an agent shares one source MySQL with another agent (or with its
+// own co-located index DB): without it, the pre-flight trips over bintrail's own
+// `access_rules`→`profiles` ON DELETE CASCADE and fatal-fails on a schema it was
+// never asked to index (#347).
+//
+// This is a name-based heuristic, so it has a known hole: a user schema that
+// happens to match these names (e.g. a real `bt_orders`) has its genuine
+// cascades silently skipped here. The robust fix is to recognise a
+// bintrail-internal schema by its signature tables rather than its name —
+// tracked as a follow-up. We keep the heuristic because it covers the reported
+// topologies and the issue endorsed it.
 func buildFKCascadeQuery(schemas []string) (string, []any) {
 	query := `SELECT CONSTRAINT_SCHEMA, CONSTRAINT_NAME, DELETE_RULE, UPDATE_RULE
 		FROM information_schema.REFERENTIAL_CONSTRAINTS
@@ -435,10 +443,12 @@ func buildFKCascadeQuery(schemas []string) (string, []any) {
 			args = append(args, s)
 		}
 	} else {
-		// `bt\_%` matches the literal `bt_` prefix (backslash is MySQL's default
-		// LIKE escape, so `\_` is a literal underscore rather than any char).
-		query += " AND CONSTRAINT_SCHEMA NOT IN ('mysql','information_schema','performance_schema','sys','bintrail_index')" +
-			` AND CONSTRAINT_SCHEMA NOT LIKE 'bt\_%'`
+		// LEFT(...) <> 'bt_' rather than LIKE 'bt\_%' so the prefix match is
+		// independent of sql_mode: a backslash LIKE escape syntax-errors under
+		// the default mode and breaks under NO_BACKSLASH_ESCAPES, whereas LEFT
+		// has no escaping to get wrong.
+		query += " AND CONSTRAINT_SCHEMA NOT IN ('mysql','information_schema','performance_schema','sys','binlog_index','bintrail_index')" +
+			" AND LEFT(CONSTRAINT_SCHEMA, 3) <> 'bt_'"
 	}
 	return query, args
 }
@@ -476,7 +486,7 @@ func validateNoFKCascades(db *sql.DB, schemas []string) error {
 				"source_schema", c.schema, "constraint", c.name,
 				"delete_rule", c.deleteRule, "update_rule", c.updateRule)
 		}
-		return fmt.Errorf("%d FK cascade constraint(s) found in indexed schemas; reversal SQL from `recover` may not correctly handle cascade side-effects", len(found))
+		return fmt.Errorf("%d FK cascade constraint(s) found on source; reversal SQL from `recover` may not correctly handle cascade side-effects", len(found))
 	}
 	return nil
 }

--- a/cmd/bintrail/index.go
+++ b/cmd/bintrail/index.go
@@ -417,19 +417,20 @@ func validateBinlogRowImage(db *sql.DB) error {
 // scoped to exactly those schemas — the operator explicitly asked us to index
 // them, so we police them as named. When schemas is empty we scan everything
 // except (a) MySQL's own system schemas and (b) bintrail's internal schemas:
-// the index DB (named `binlog_index` in every DSN example, occasionally
-// `bintrail_index`) and the SaaS `bt_<prefix>` convention. The latter exclusion
-// matters when an agent shares one source MySQL with another agent (or with its
-// own co-located index DB): without it, the pre-flight trips over bintrail's own
-// `access_rules`→`profiles` ON DELETE CASCADE and fatal-fails on a schema it was
-// never asked to index (#347).
+// the index DB (named `binlog_index` or `bintrail_index` across our docs and
+// deploy tooling — the #347 incident itself used `bintrail_index`) and the SaaS
+// `bt_<prefix>` convention. The latter exclusion matters when an agent shares
+// one source MySQL with another agent (or with its own co-located index DB):
+// without it, the pre-flight trips over bintrail's own `access_rules`→`profiles`
+// ON DELETE CASCADE and fatal-fails on a schema it was never asked to index
+// (#347).
 //
 // This is a name-based heuristic, so it has a known hole: a user schema that
 // happens to match these names (e.g. a real `bt_orders`) has its genuine
-// cascades silently skipped here. The robust fix is to recognise a
-// bintrail-internal schema by its signature tables rather than its name —
-// tracked as a follow-up. We keep the heuristic because it covers the reported
-// topologies and the issue endorsed it.
+// cascades silently skipped here, and a custom-named index DB is not excluded.
+// The robust fix is to recognise a bintrail-internal schema by its signature
+// tables rather than its name — tracked in #365. We keep the heuristic because
+// it covers the reported topologies and the issue endorsed it.
 func buildFKCascadeQuery(schemas []string) (string, []any) {
 	query := `SELECT CONSTRAINT_SCHEMA, CONSTRAINT_NAME, DELETE_RULE, UPDATE_RULE
 		FROM information_schema.REFERENTIAL_CONSTRAINTS
@@ -443,10 +444,12 @@ func buildFKCascadeQuery(schemas []string) (string, []any) {
 			args = append(args, s)
 		}
 	} else {
-		// LEFT(...) <> 'bt_' rather than LIKE 'bt\_%' so the prefix match is
-		// independent of sql_mode: a backslash LIKE escape syntax-errors under
-		// the default mode and breaks under NO_BACKSLASH_ESCAPES, whereas LEFT
-		// has no escaping to get wrong.
+		// LEFT(...) <> 'bt_' rather than LIKE 'bt\_%': under the
+		// NO_BACKSLASH_ESCAPES sql_mode the `\_` stops being an escaped literal
+		// underscore, so a LIKE pattern silently stops matching bt_-prefixed
+		// schemas. (And the obvious fix — an explicit ESCAPE '\' clause —
+		// syntax-errors under the default mode.) LEFT has no escaping to get
+		// wrong, so it behaves identically under any sql_mode.
 		query += " AND CONSTRAINT_SCHEMA NOT IN ('mysql','information_schema','performance_schema','sys','binlog_index','bintrail_index')" +
 			" AND LEFT(CONSTRAINT_SCHEMA, 3) <> 'bt_'"
 	}
@@ -460,6 +463,15 @@ func buildFKCascadeQuery(schemas []string) (string, []any) {
 // unreliable.
 func validateNoFKCascades(db *sql.DB, schemas []string) error {
 	query, args := buildFKCascadeQuery(schemas)
+
+	// The unscoped scan deliberately skips bintrail's own internal schemas by
+	// name (see buildFKCascadeQuery). Unlike the system-schema exclusions, this
+	// is a heuristic that can wrongly skip a user schema sharing those names, so
+	// disclose it: a "no FK cascades" pass below does not cover excluded schemas.
+	if len(schemas) == 0 {
+		slog.Info("FK cascade pre-flight excludes bintrail-internal schemas from the unscoped scan",
+			"excluded", "binlog_index, bintrail_index, bt_*")
+	}
 
 	rows, err := db.Query(query, args...)
 	if err != nil {

--- a/cmd/bintrail/index_test.go
+++ b/cmd/bintrail/index_test.go
@@ -373,7 +373,7 @@ func TestBuildFKCascadeQuery_withSchemas(t *testing.T) {
 	if !strings.Contains(query, "CONSTRAINT_SCHEMA IN (?,?)") {
 		t.Errorf("expected parameterized IN list, got query:\n%s", query)
 	}
-	if strings.Contains(query, "NOT IN") || strings.Contains(query, "NOT LIKE") {
+	if strings.Contains(query, "NOT IN") || strings.Contains(query, "LEFT(") {
 		t.Errorf("explicit --schemas must not add internal-schema exclusions, got query:\n%s", query)
 	}
 	if len(args) != 2 || args[0] != "iotcore" || args[1] != "billing" {
@@ -382,21 +382,24 @@ func TestBuildFKCascadeQuery_withSchemas(t *testing.T) {
 }
 
 // With no schemas filter the scan excludes MySQL system schemas AND bintrail's
-// own internal schemas (bintrail_index + the bt_<prefix> convention), so a
-// second agent sharing the source MySQL does not fatal-fail on the first
-// agent's internal FK cascades (#347).
+// own internal schemas (the binlog_index/bintrail_index index DB + the
+// bt_<prefix> convention), so an agent sharing the source MySQL does not
+// fatal-fail on bintrail's internal FK cascades (#347). binlog_index is the
+// name used in every DSN example, so it must be in the list.
 func TestBuildFKCascadeQuery_noSchemasExcludesInternal(t *testing.T) {
 	query, args := buildFKCascadeQuery(nil)
 
 	if len(args) != 0 {
 		t.Errorf("expected no args for unscoped query, got %v", args)
 	}
-	for _, want := range []string{"'mysql'", "'information_schema'", "'performance_schema'", "'sys'", "'bintrail_index'"} {
+	for _, want := range []string{"'mysql'", "'information_schema'", "'performance_schema'", "'sys'", "'binlog_index'", "'bintrail_index'"} {
 		if !strings.Contains(query, want) {
 			t.Errorf("expected unscoped query to exclude %s, got query:\n%s", want, query)
 		}
 	}
-	if !strings.Contains(query, `CONSTRAINT_SCHEMA NOT LIKE 'bt\_%'`) {
-		t.Errorf("expected unscoped query to exclude the bt_ prefix, got query:\n%s", query)
+	// Escape-free prefix match so it is independent of the source's sql_mode
+	// (a backslash LIKE escape is fragile under NO_BACKSLASH_ESCAPES).
+	if !strings.Contains(query, "LEFT(CONSTRAINT_SCHEMA, 3) <> 'bt_'") {
+		t.Errorf("expected unscoped query to exclude the bt_ prefix via LEFT(), got query:\n%s", query)
 	}
 }

--- a/cmd/bintrail/index_test.go
+++ b/cmd/bintrail/index_test.go
@@ -384,8 +384,9 @@ func TestBuildFKCascadeQuery_withSchemas(t *testing.T) {
 // With no schemas filter the scan excludes MySQL system schemas AND bintrail's
 // own internal schemas (the binlog_index/bintrail_index index DB + the
 // bt_<prefix> convention), so an agent sharing the source MySQL does not
-// fatal-fail on bintrail's internal FK cascades (#347). binlog_index is the
-// name used in every DSN example, so it must be in the list.
+// fatal-fail on bintrail's internal FK cascades (#347). binlog_index and
+// bintrail_index are both used as the index DB name across docs/deploy tooling,
+// so both must be in the list.
 func TestBuildFKCascadeQuery_noSchemasExcludesInternal(t *testing.T) {
 	query, args := buildFKCascadeQuery(nil)
 

--- a/cmd/bintrail/index_test.go
+++ b/cmd/bintrail/index_test.go
@@ -361,3 +361,42 @@ func TestNullOrStringVal_nonEmpty(t *testing.T) {
 		t.Errorf("expected 'uuid:42', got %v", got)
 	}
 }
+
+// ─── buildFKCascadeQuery ─────────────────────────────────────────────────────
+
+// When schemas are named explicitly, the scan is scoped to exactly those
+// schemas via a parameterized IN list — and the bintrail-internal exclusions
+// are NOT added (an explicitly named internal schema is still policed).
+func TestBuildFKCascadeQuery_withSchemas(t *testing.T) {
+	query, args := buildFKCascadeQuery([]string{"iotcore", "billing"})
+
+	if !strings.Contains(query, "CONSTRAINT_SCHEMA IN (?,?)") {
+		t.Errorf("expected parameterized IN list, got query:\n%s", query)
+	}
+	if strings.Contains(query, "NOT IN") || strings.Contains(query, "NOT LIKE") {
+		t.Errorf("explicit --schemas must not add internal-schema exclusions, got query:\n%s", query)
+	}
+	if len(args) != 2 || args[0] != "iotcore" || args[1] != "billing" {
+		t.Errorf("expected args [iotcore billing], got %v", args)
+	}
+}
+
+// With no schemas filter the scan excludes MySQL system schemas AND bintrail's
+// own internal schemas (bintrail_index + the bt_<prefix> convention), so a
+// second agent sharing the source MySQL does not fatal-fail on the first
+// agent's internal FK cascades (#347).
+func TestBuildFKCascadeQuery_noSchemasExcludesInternal(t *testing.T) {
+	query, args := buildFKCascadeQuery(nil)
+
+	if len(args) != 0 {
+		t.Errorf("expected no args for unscoped query, got %v", args)
+	}
+	for _, want := range []string{"'mysql'", "'information_schema'", "'performance_schema'", "'sys'", "'bintrail_index'"} {
+		if !strings.Contains(query, want) {
+			t.Errorf("expected unscoped query to exclude %s, got query:\n%s", want, query)
+		}
+	}
+	if !strings.Contains(query, `CONSTRAINT_SCHEMA NOT LIKE 'bt\_%'`) {
+		t.Errorf("expected unscoped query to exclude the bt_ prefix, got query:\n%s", query)
+	}
+}


### PR DESCRIPTION
closes #347

## Summary
- `bintrail stream`/`index` without `--schemas` scanned **every** non-system schema on the source MySQL for CASCADE foreign keys. When two bintrail agents share one source (a supported BYOS + cloud-SSH-tunnel topology), the second agent's pre-flight tripped over the **first** agent's internal `bintrail_index` / `bt_<prefix>` FK cascade and fatal-failed (status 1 → systemd restart-loop → `StartLimitBurst`) on a schema it was never asked to index.
- Fix: in the unscoped branch, also exclude bintrail's own internal schemas — add `bintrail_index` to the `NOT IN (...)` list and `CONSTRAINT_SCHEMA NOT LIKE 'bt\_%'`. The explicit-`--schemas` branch is unchanged, so an explicitly named schema (even an internal one) is still policed.
- Extracted `buildFKCascadeQuery(schemas)` as a pure function so the query logic is unit-testable without a database.
- Log clarity (issue part 2): `schema=` → `source_schema=` and message → `FK cascade constraint found on source`, so operators don't confuse the source-side schema with the local index schema (which cost the reporter an incorrect hotfix attempt).

Out of scope (per issue): the optional `--allow-fk-cascade` override flag (lower priority; the incident is fully resolved by the above), and the related backend `stream_start` schema-propagation bug tracked separately in `nethalo/dbtrail`.

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] New DB-free unit tests on `buildFKCascadeQuery`: unscoped query excludes the 4 system schemas + `bintrail_index` + `bt\_%`; explicit `--schemas` uses a parameterized `IN (?)` list and adds **no** internal exclusions.
- [x] Integration test against real MySQL 8.0 (`-tags=integration`): a CASCADE FK in a `bt_`-prefixed schema is **ignored** when unscoped, but **still caught** when that schema is named explicitly — confirming the `bt\_%` LIKE-escape behaves as intended on the server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)