### PR TITLE
fix(stream): detect bintrail-internal schemas structurally, not by name

### DIFF
--- a/cmd/bintrail/cmd_integration_test.go
+++ b/cmd/bintrail/cmd_integration_test.go
@@ -364,6 +364,34 @@ func TestValidateNoFKCascades_userSchemaCaughtWhenUnscoped(t *testing.T) {
 	}
 }
 
+// A schema with only SOME of the signature tables (here 2 of 3) is NOT a
+// bintrail index — its real CASCADE must still be CAUGHT when unscoped. This
+// pins the exactness of HAVING COUNT(DISTINCT TABLE_NAME) = 3: a regression to
+// >= 1 (or a shorter IN-list) would silently skip this real user cascade,
+// reopening the #347-class silent-skip bug. (The existing "caught" test above
+// uses zero signature tables, so it would not detect such a loosening.)
+func TestValidateNoFKCascades_partialSignatureCaughtWhenUnscoped(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
+
+	const userSchema = "fkcascade_partial"
+	testutil.MustExec(t, db, "DROP DATABASE IF EXISTS `"+userSchema+"`")
+	testutil.MustExec(t, db, "CREATE DATABASE `"+userSchema+"`")
+	t.Cleanup(func() { _, _ = db.Exec("DROP DATABASE IF EXISTS `" + userSchema + "`") })
+
+	// Two of the three signature names, but not all three.
+	testutil.MustExec(t, db, "CREATE TABLE `"+userSchema+"`.binlog_events (id INT PRIMARY KEY)")
+	testutil.MustExec(t, db, "CREATE TABLE `"+userSchema+"`.stream_state (id INT PRIMARY KEY)")
+	// ...plus a genuine cascade that must be caught.
+	testutil.MustExec(t, db, "CREATE TABLE `"+userSchema+"`.parents (id INT PRIMARY KEY)")
+	testutil.MustExec(t, db, "CREATE TABLE `"+userSchema+"`.children ("+
+		"id INT PRIMARY KEY, parent_id INT NOT NULL, "+
+		"CONSTRAINT fk_parent FOREIGN KEY (parent_id) REFERENCES `"+userSchema+"`.parents(id) ON DELETE CASCADE)")
+
+	if !unscopedFKCascadeSchemas(t, db)[userSchema] {
+		t.Fatalf("expected partial-signature schema %q (2 of 3 signature tables) to be flagged by the unscoped scan, but it was not", userSchema)
+	}
+}
+
 // ─── ensureResolver ──────────────────────────────────────────────────────────────────
 
 func TestEnsureResolver_autoSnapshot(t *testing.T) {

--- a/cmd/bintrail/cmd_integration_test.go
+++ b/cmd/bintrail/cmd_integration_test.go
@@ -273,31 +273,40 @@ func TestValidateNoFKCascades_otherSchemaIgnored(t *testing.T) {
 	}
 }
 
-// A bt_-prefixed schema is one of bintrail's own internal schemas (the SaaS
-// bt_<prefix> convention; testutil names every test DB bt_<TestName>). When no
-// --schemas filter is given, FK cascades inside such a schema must be ignored —
-// otherwise a second bintrail agent sharing the source MySQL fatal-fails on the
-// first agent's internal cascade (#347). This also exercises the
-// LEFT(CONSTRAINT_SCHEMA, 3) <> 'bt_' prefix match against real MySQL.
-func TestValidateNoFKCascades_internalSchemaIgnoredWhenUnscoped(t *testing.T) {
-	db, dbName := testutil.CreateTestDB(t)
+// The unscoped pre-flight skips a bintrail index schema regardless of its name:
+// it is recognised by its signature tables (binlog_events, schema_snapshots,
+// stream_state), not by a name pattern. Here the index DB has a non-bintrail
+// name (`audit_index`) yet carries the access_rules→profiles cascade — the scan
+// must skip it (the #347 fix, now name-independent, closing the custom-name
+// under-exclusion hole, #365). When the operator names it explicitly, it is
+// still policed.
+func TestValidateNoFKCascades_customNamedIndexSkippedWhenUnscoped(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
 
-	testutil.MustExec(t, db, `CREATE TABLE profiles (id INT PRIMARY KEY)`)
-	testutil.MustExec(t, db, `CREATE TABLE access_rules (
-		id         INT PRIMARY KEY,
-		profile_id INT NOT NULL,
-		CONSTRAINT fk_access_rules_profile FOREIGN KEY (profile_id) REFERENCES profiles(id) ON DELETE CASCADE
-	)`)
+	const idxSchema = "audit_index" // not bt_-prefixed, not the default index name
+	testutil.MustExec(t, db, "DROP DATABASE IF EXISTS `"+idxSchema+"`")
+	testutil.MustExec(t, db, "CREATE DATABASE `"+idxSchema+"`")
+	t.Cleanup(func() { _, _ = db.Exec("DROP DATABASE IF EXISTS `" + idxSchema + "`") })
 
-	// Unscoped: the cascade lives in a bt_-prefixed (bintrail-internal) schema,
-	// so the pre-flight must skip it and pass.
+	// The signature tables that mark the schema as a bintrail index...
+	for _, tbl := range []string{"binlog_events", "schema_snapshots", "stream_state"} {
+		testutil.MustExec(t, db, "CREATE TABLE `"+idxSchema+"`.`"+tbl+"` (id INT PRIMARY KEY)")
+	}
+	// ...plus the access_rules→profiles ON DELETE CASCADE the pre-flight trips on.
+	testutil.MustExec(t, db, "CREATE TABLE `"+idxSchema+"`.profiles (id INT PRIMARY KEY)")
+	testutil.MustExec(t, db, "CREATE TABLE `"+idxSchema+"`.access_rules ("+
+		"id INT PRIMARY KEY, profile_id INT NOT NULL, "+
+		"CONSTRAINT fk_access_rules_profile FOREIGN KEY (profile_id) REFERENCES `"+idxSchema+"`.profiles(id) ON DELETE CASCADE)")
+
+	// Unscoped: skipped because it is structurally a bintrail index, despite the
+	// non-bintrail name.
 	if err := validateNoFKCascades(db, nil); err != nil {
-		t.Fatalf("expected nil for FK cascade in bintrail-internal schema %q when unscoped, got: %v", dbName, err)
+		t.Fatalf("expected nil for structurally-internal schema %q when unscoped, got: %v", idxSchema, err)
 	}
 
-	// But when the operator explicitly names that schema, we still police it.
-	if err := validateNoFKCascades(db, []string{dbName}); err == nil {
-		t.Fatalf("expected error when %q is explicitly targeted despite being bt_-prefixed", dbName)
+	// Explicitly named: still policed.
+	if err := validateNoFKCascades(db, []string{idxSchema}); err == nil {
+		t.Fatalf("expected error when %q is explicitly targeted", idxSchema)
 	}
 }
 

--- a/cmd/bintrail/cmd_integration_test.go
+++ b/cmd/bintrail/cmd_integration_test.go
@@ -288,10 +288,14 @@ func TestValidateNoFKCascades_customNamedIndexSkippedWhenUnscoped(t *testing.T) 
 	testutil.MustExec(t, db, "CREATE DATABASE `"+idxSchema+"`")
 	t.Cleanup(func() { _, _ = db.Exec("DROP DATABASE IF EXISTS `" + idxSchema + "`") })
 
-	// The signature tables that mark the schema as a bintrail index...
-	for _, tbl := range []string{"binlog_events", "schema_snapshots", "stream_state"} {
-		testutil.MustExec(t, db, "CREATE TABLE `"+idxSchema+"`.`"+tbl+"` (id INT PRIMARY KEY)")
-	}
+	// The signature tables that mark the schema as a bintrail index. binlog_events
+	// is RANGE-partitioned in production, so partition it here too — this confirms
+	// the subquery's TABLE_TYPE = 'BASE TABLE' filter matches a partitioned table.
+	testutil.MustExec(t, db, "CREATE TABLE `"+idxSchema+"`.binlog_events ("+
+		"id INT, event_timestamp DATETIME NOT NULL, PRIMARY KEY (id, event_timestamp)) "+
+		"PARTITION BY RANGE (TO_SECONDS(event_timestamp)) (PARTITION p_future VALUES LESS THAN MAXVALUE)")
+	testutil.MustExec(t, db, "CREATE TABLE `"+idxSchema+"`.schema_snapshots (id INT PRIMARY KEY)")
+	testutil.MustExec(t, db, "CREATE TABLE `"+idxSchema+"`.stream_state (id INT PRIMARY KEY)")
 	// ...plus the access_rules→profiles ON DELETE CASCADE the pre-flight trips on.
 	testutil.MustExec(t, db, "CREATE TABLE `"+idxSchema+"`.profiles (id INT PRIMARY KEY)")
 	testutil.MustExec(t, db, "CREATE TABLE `"+idxSchema+"`.access_rules ("+
@@ -299,15 +303,42 @@ func TestValidateNoFKCascades_customNamedIndexSkippedWhenUnscoped(t *testing.T) 
 		"CONSTRAINT fk_access_rules_profile FOREIGN KEY (profile_id) REFERENCES `"+idxSchema+"`.profiles(id) ON DELETE CASCADE)")
 
 	// Unscoped: skipped because it is structurally a bintrail index, despite the
-	// non-bintrail name.
-	if err := validateNoFKCascades(db, nil); err != nil {
-		t.Fatalf("expected nil for structurally-internal schema %q when unscoped, got: %v", idxSchema, err)
+	// non-bintrail name. Assert audit_index specifically is absent from the scan
+	// rather than that the whole server-wide scan is clean — that keeps the test
+	// robust to unrelated cascades that may exist on a shared/dev MySQL server.
+	if schemas := unscopedFKCascadeSchemas(t, db); schemas[idxSchema] {
+		t.Fatalf("expected structurally-internal schema %q to be excluded from the unscoped scan, but it was flagged", idxSchema)
 	}
 
 	// Explicitly named: still policed.
 	if err := validateNoFKCascades(db, []string{idxSchema}); err == nil {
 		t.Fatalf("expected error when %q is explicitly targeted", idxSchema)
 	}
+}
+
+// unscopedFKCascadeSchemas runs the unscoped FK-cascade query and returns the
+// set of schemas it flags. Lets a test assert that a specific schema is (or is
+// not) excluded without depending on the rest of the server being cascade-free.
+func unscopedFKCascadeSchemas(t *testing.T, db *sql.DB) map[string]bool {
+	t.Helper()
+	q, args := buildFKCascadeQuery(nil)
+	rows, err := db.Query(q, args...)
+	if err != nil {
+		t.Fatalf("unscoped FK-cascade query: %v", err)
+	}
+	defer rows.Close()
+	got := map[string]bool{}
+	for rows.Next() {
+		var schema, name, del, upd string
+		if err := rows.Scan(&schema, &name, &del, &upd); err != nil {
+			t.Fatalf("scan FK-cascade row: %v", err)
+		}
+		got[schema] = true
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate FK-cascade rows: %v", err)
+	}
+	return got
 }
 
 // The inverse of the exclusion, and the load-bearing direction: an unscoped

--- a/cmd/bintrail/index.go
+++ b/cmd/bintrail/index.go
@@ -415,22 +415,17 @@ func validateBinlogRowImage(db *sql.DB) error {
 // buildFKCascadeQuery returns the REFERENTIAL_CONSTRAINTS query (and its args)
 // used to find CASCADE foreign keys. When schemas is non-empty the scan is
 // scoped to exactly those schemas — the operator explicitly asked us to index
-// them, so we police them as named. When schemas is empty we scan everything
-// except (a) MySQL's own system schemas and (b) bintrail's internal schemas:
-// the index DB (named `binlog_index` or `bintrail_index` across our docs and
-// deploy tooling — the #347 incident itself used `bintrail_index`) and the SaaS
-// `bt_<prefix>` convention. The latter exclusion matters when an agent shares
-// one source MySQL with another agent (or with its own co-located index DB):
-// without it, the pre-flight trips over bintrail's own `access_rules`→`profiles`
-// ON DELETE CASCADE and fatal-fails on a schema it was never asked to index
-// (#347).
+// them, so we police them as named. When schemas is empty we scan every schema
+// except (a) MySQL's own system schemas and (b) bintrail's own index schemas.
 //
-// This is a name-based heuristic, so it has a known hole: a user schema that
-// happens to match these names (e.g. a real `bt_orders`) has its genuine
-// cascades silently skipped here, and a custom-named index DB is not excluded.
-// The robust fix is to recognise a bintrail-internal schema by its signature
-// tables rather than its name — tracked in #365. We keep the heuristic because
-// it covers the reported topologies and the issue endorsed it.
+// A bintrail index schema is recognised structurally — by the signature tables
+// `bintrail init` creates (binlog_events, schema_snapshots and stream_state must
+// all be present) — not by name. This is what lets the pre-flight skip
+// bintrail's own `access_rules`→`profiles` ON DELETE CASCADE so an agent does
+// not fatal-fail on its own (or another agent's) index DB sharing the source
+// MySQL (#347), while still flagging a genuine user schema whatever it is named
+// (#365). The signature tables are created before access_rules, so any schema
+// carrying that cascade necessarily carries the signature too.
 func buildFKCascadeQuery(schemas []string) (string, []any) {
 	query := `SELECT CONSTRAINT_SCHEMA, CONSTRAINT_NAME, DELETE_RULE, UPDATE_RULE
 		FROM information_schema.REFERENTIAL_CONSTRAINTS
@@ -444,14 +439,17 @@ func buildFKCascadeQuery(schemas []string) (string, []any) {
 			args = append(args, s)
 		}
 	} else {
-		// LEFT(...) <> 'bt_' rather than LIKE 'bt\_%': under the
-		// NO_BACKSLASH_ESCAPES sql_mode the `\_` stops being an escaped literal
-		// underscore, so a LIKE pattern silently stops matching bt_-prefixed
-		// schemas. (And the obvious fix — an explicit ESCAPE '\' clause —
-		// syntax-errors under the default mode.) LEFT has no escaping to get
-		// wrong, so it behaves identically under any sql_mode.
-		query += " AND CONSTRAINT_SCHEMA NOT IN ('mysql','information_schema','performance_schema','sys','binlog_index','bintrail_index')" +
-			" AND LEFT(CONSTRAINT_SCHEMA, 3) <> 'bt_'"
+		// Skip bintrail's own index schemas, identified by their signature tables
+		// rather than by name: a schema counts as bintrail-internal only if it
+		// holds ALL of binlog_events, schema_snapshots and stream_state (HAVING
+		// = 3), so a user schema that merely shares one of those names is still
+		// scanned.
+		query += " AND CONSTRAINT_SCHEMA NOT IN ('mysql','information_schema','performance_schema','sys')" +
+			" AND CONSTRAINT_SCHEMA NOT IN (" +
+			"SELECT TABLE_SCHEMA FROM information_schema.TABLES" +
+			" WHERE TABLE_TYPE = 'BASE TABLE'" +
+			" AND TABLE_NAME IN ('binlog_events','schema_snapshots','stream_state')" +
+			" GROUP BY TABLE_SCHEMA HAVING COUNT(DISTINCT TABLE_NAME) = 3)"
 	}
 	return query, args
 }
@@ -464,13 +462,11 @@ func buildFKCascadeQuery(schemas []string) (string, []any) {
 func validateNoFKCascades(db *sql.DB, schemas []string) error {
 	query, args := buildFKCascadeQuery(schemas)
 
-	// The unscoped scan deliberately skips bintrail's own internal schemas by
-	// name (see buildFKCascadeQuery). Unlike the system-schema exclusions, this
-	// is a heuristic that can wrongly skip a user schema sharing those names, so
-	// disclose it: a "no FK cascades" pass below does not cover excluded schemas.
+	// The unscoped scan skips bintrail's own index schemas (recognised by their
+	// signature tables; see buildFKCascadeQuery), so a "no FK cascades" pass below
+	// does not cover them. Disclose it.
 	if len(schemas) == 0 {
-		slog.Info("FK cascade pre-flight excludes bintrail-internal schemas from the unscoped scan",
-			"excluded", "binlog_index, bintrail_index, bt_*")
+		slog.Info("FK cascade pre-flight skips bintrail's own index schemas (identified by signature tables)")
 	}
 
 	rows, err := db.Query(query, args...)

--- a/cmd/bintrail/index.go
+++ b/cmd/bintrail/index.go
@@ -462,11 +462,15 @@ func buildFKCascadeQuery(schemas []string) (string, []any) {
 func validateNoFKCascades(db *sql.DB, schemas []string) error {
 	query, args := buildFKCascadeQuery(schemas)
 
-	// The unscoped scan skips bintrail's own index schemas (recognised by their
-	// signature tables; see buildFKCascadeQuery), so a "no FK cascades" pass below
-	// does not cover them. Disclose it.
+	// The unscoped scan skips schemas that look like a bintrail index — those
+	// holding all of bintrail's signature tables (see buildFKCascadeQuery) — so a
+	// clean result does not cover them. Disclose the rule, naming the signature
+	// tables rather than asserting the skipped schemas are definitely bintrail's:
+	// a user schema that replicated those table names would be skipped too, and
+	// the operator should be able to recognise that case.
 	if len(schemas) == 0 {
-		slog.Info("FK cascade pre-flight skips bintrail's own index schemas (identified by signature tables)")
+		slog.Info("FK cascade pre-flight skips schemas that look like a bintrail index DB " +
+			"(those containing binlog_events, schema_snapshots and stream_state); a clean result does not cover them")
 	}
 
 	rows, err := db.Query(query, args...)

--- a/cmd/bintrail/index_test.go
+++ b/cmd/bintrail/index_test.go
@@ -365,16 +365,16 @@ func TestNullOrStringVal_nonEmpty(t *testing.T) {
 // ─── buildFKCascadeQuery ─────────────────────────────────────────────────────
 
 // When schemas are named explicitly, the scan is scoped to exactly those
-// schemas via a parameterized IN list — and the bintrail-internal exclusions
-// are NOT added (an explicitly named internal schema is still policed).
+// schemas via a parameterized IN list — and the bintrail-internal exclusion is
+// NOT added (an explicitly named internal schema is still policed).
 func TestBuildFKCascadeQuery_withSchemas(t *testing.T) {
 	query, args := buildFKCascadeQuery([]string{"iotcore", "billing"})
 
 	if !strings.Contains(query, "CONSTRAINT_SCHEMA IN (?,?)") {
 		t.Errorf("expected parameterized IN list, got query:\n%s", query)
 	}
-	if strings.Contains(query, "NOT IN") || strings.Contains(query, "LEFT(") {
-		t.Errorf("explicit --schemas must not add internal-schema exclusions, got query:\n%s", query)
+	if strings.Contains(query, "NOT IN") || strings.Contains(query, "information_schema.TABLES") {
+		t.Errorf("explicit --schemas must not add the internal-schema exclusion, got query:\n%s", query)
 	}
 	if len(args) != 2 || args[0] != "iotcore" || args[1] != "billing" {
 		t.Errorf("expected args [iotcore billing], got %v", args)
@@ -382,25 +382,30 @@ func TestBuildFKCascadeQuery_withSchemas(t *testing.T) {
 }
 
 // With no schemas filter the scan excludes MySQL system schemas AND bintrail's
-// own internal schemas (the binlog_index/bintrail_index index DB + the
-// bt_<prefix> convention), so an agent sharing the source MySQL does not
-// fatal-fail on bintrail's internal FK cascades (#347). binlog_index and
-// bintrail_index are both used as the index DB name across docs/deploy tooling,
-// so both must be in the list.
+// own index schemas. The latter are recognised structurally — a schema is
+// bintrail-internal only if it holds all of binlog_events, schema_snapshots and
+// stream_state — not by name, so an agent does not fatal-fail on bintrail's own
+// index FK cascades regardless of how the index DB is named (#347/#365).
 func TestBuildFKCascadeQuery_noSchemasExcludesInternal(t *testing.T) {
 	query, args := buildFKCascadeQuery(nil)
 
 	if len(args) != 0 {
 		t.Errorf("expected no args for unscoped query, got %v", args)
 	}
-	for _, want := range []string{"'mysql'", "'information_schema'", "'performance_schema'", "'sys'", "'binlog_index'", "'bintrail_index'"} {
+	for _, want := range []string{"'mysql'", "'information_schema'", "'performance_schema'", "'sys'"} {
 		if !strings.Contains(query, want) {
-			t.Errorf("expected unscoped query to exclude %s, got query:\n%s", want, query)
+			t.Errorf("expected unscoped query to exclude system schema %s, got query:\n%s", want, query)
 		}
 	}
-	// Escape-free prefix match so it is independent of the source's sql_mode
-	// (a backslash LIKE escape is fragile under NO_BACKSLASH_ESCAPES).
-	if !strings.Contains(query, "LEFT(CONSTRAINT_SCHEMA, 3) <> 'bt_'") {
-		t.Errorf("expected unscoped query to exclude the bt_ prefix via LEFT(), got query:\n%s", query)
+	// Structural detection: subquery over information_schema.TABLES requiring all
+	// three signature tables (HAVING COUNT(DISTINCT TABLE_NAME) = 3).
+	for _, want := range []string{
+		"information_schema.TABLES",
+		"'binlog_events'", "'schema_snapshots'", "'stream_state'",
+		"GROUP BY TABLE_SCHEMA HAVING COUNT(DISTINCT TABLE_NAME) = 3",
+	} {
+		if !strings.Contains(query, want) {
+			t.Errorf("expected unscoped query to contain %q, got query:\n%s", want, query)
+		}
 	}
 }


### PR DESCRIPTION
closes #365

## Summary
Follow-up to #347. Replaces the name heuristic in the unscoped FK-cascade pre-flight (`buildFKCascadeQuery`) with **structural detection**: a schema is treated as bintrail-internal only if it contains all of bintrail's signature index tables — `binlog_events`, `schema_snapshots`, `stream_state` — via a `NOT IN` subquery over `information_schema.TABLES` with `HAVING COUNT(DISTINCT TABLE_NAME) = 3`.

This closes both holes the `binlog_index`/`bintrail_index`/`bt_` name heuristic left open:

- **Under-exclusion fixed:** a custom-named index DB (operator-chosen via `--index-dsn`) is now recognised and skipped — it no longer re-triggers the #347 fatal pre-flight on bintrail's own `access_rules→profiles` cascade.
- **Over-exclusion fixed:** a real user schema that merely shares a bintrail-ish name (e.g. `bt_orders`) is no longer silently skipped — without the signature tables it is scanned and its genuine cascades flagged.

The signature tables are created *before* `access_rules` in `bintrail init`, so any schema carrying that cascade necessarily carries the signature too. The explicit-`--schemas` path is unchanged (an explicitly named schema is always policed).

Occam'd scope: one SQL change + comment/disclosure updates + test updates. **Deferred** (separate concern, as the issue allowed splitting): the `doctor`/`metadata.TakeSnapshot` exclusion-list divergence and the duplicated system-schema literal across ~8 files.

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] Unit assertions updated to the structural subquery (signature tables + `HAVING = 3`); explicit-`--schemas` path asserts no subquery.
- [x] Integration test against real MySQL 8.0: `audit_index` (signature tables + cascade, **non-bintrail name**) is skipped unscoped (under-exclusion fix); `fkcascade_user` (cascade, **no signature tables**) is still caught (over-exclusion fix); explicitly named schemas still policed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)