### PR TITLE
console: Phase 1 (MVP) — bintrail console command + read-only web UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Go version: 1.25.7 — uses `range N`, `min()`, `slices.Reverse`, `strings.Split
 ## Project structure
 
 ```
-cmd/bintrail/          # One file per command (init, snapshot, index, query, recover, rotate, status, stream, dump, baseline, upload, generate-key, config)
+cmd/bintrail/          # One file per command (init, snapshot, index, query, recover, rotate, status, console, stream, dump, baseline, upload, generate-key, config)
                        # envload.go: env file loading (.bintrail.env / ~/.config/bintrail/config.env) + bindCommandEnv
                        # Test files: *_test.go (unit), *_integration_test.go (//go:build integration)
 cmd/bintrail-mcp/      # MCP server: main.go, proxy.py, tests
@@ -38,7 +38,7 @@ internal/
 e2e_test.go            # Full CLI pipeline E2E test (//go:build integration), built with go build -cover
 .mcp.json              # MCP server registration (go run ./cmd/bintrail-mcp)
 migrations/            # Reference DDL (tables created by `bintrail init`, not this file)
-docs/                  # guide.md, indexing.md, query-and-recovery.md, streaming.md, rotation-and-status.md, mcp-server.md, upload.md, parquet-debugging.md, deployment.md, quickstart.md, dump-and-baseline.md, docker.md, server-identity.md, mcp-gateway.md, storage.md
+docs/                  # guide.md, indexing.md, query-and-recovery.md, streaming.md, rotation-and-status.md, mcp-server.md, upload.md, parquet-debugging.md, deployment.md, quickstart.md, dump-and-baseline.md, docker.md, server-identity.md, mcp-gateway.md, storage.md, console.md
 ```
 
 ## Commands
@@ -56,6 +56,7 @@ Per-command `--format`: most commands accept `text`/`json` (`IsValidOutputFormat
 | `recover` | `recover.go` | same filters as query + `--output`, `--dry-run`, `--limit` (default 1000), `--profile`, `--no-archive` |
 | `rotate` | `rotate.go` | `--index-dsn` (req), `--retain` (e.g. `7d`, `24h`), `--add-future`, `--archive-dir`, `--archive-compression` (default `zstd`) |
 | `status` | `status.go` | `--index-dsn` (req) |
+| `console` | `console.go` | `--index-dsn` (req), `--listen` (default `127.0.0.1:8090`), `--token` (auto-gen for loopback; required for non-loopback), `--no-archive`, `--profile` (forces `--no-archive`); read-only web UI over the index (events/recover/status) — the MCP server with a web face, implemented in `internal/console/` (server/api/auth/dto/assets + `//go:embed` vanilla frontend, zero JS deps). NEVER executes SQL. Open-core boundary: `eventDTO` omits `connection_id` (free `query_explorer` surface, not paid `forensics`). Env `BINTRAIL_CONSOLE_LISTEN`/`BINTRAIL_CONSOLE_TOKEN` are read directly in `runConsole`, NOT via the shared `envBindings` slice (`--listen` collides with `shim`/`init-shim`). Security: token in `Authorization: Bearer` (`subtle.ConstantTimeCompare`), Host-header allowlist (DNS-rebinding defense), no CORS, result caps (events 100/1000, recover 1000/10000), `/api/healthz` unauthenticated. |
 | `stream` | `stream.go` | `--index-dsn` (req), `--source-dsn` (req), `--server-id` (req), `--start-file`, `--start-pos`, `--start-gtid`, `--batch-size`, `--schemas`, `--tables`, `--checkpoint`, `--metrics-addr`, `--reset`, `--no-gap-fill`, `--gap-timeout` (default `30`s) |
 | `dump` | `dump.go` | `--source-dsn` (req), `--output-dir` (req), `--schemas`, `--tables`, `--mydumper-path`, `--mydumper-image`, `--threads`, `--encrypt`, `--encrypt-key` |
 | `baseline` | `baseline.go` | `--input` (req), `--output` (req), `--timestamp`, `--tables`, `--compression`, `--row-group-size`, `--upload`, `--upload-region`, `--encrypt`, `--encrypt-key` |

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ bintrail recover \
   --output recovery.sql
 ```
 
+> **Prefer a browser?** `bintrail console --index-dsn "user:pass@tcp(127.0.0.1:3306)/binlog_index"` opens a read-only web UI to browse changes with before/after diffs and generate undo SQL — no extra infrastructure. See [Web console](#web-console).
+
 > **Managed MySQL (RDS, Aurora, Cloud SQL)?** `bintrail up` connects over the replication protocol — no disk access to binlogs required. See [Streaming](docs/streaming.md).
 
 > **Want manual control of each step?** See [Step-by-step setup](#step-by-step-setup) below for the underlying `init` / `snapshot` / `stream` commands.
@@ -96,7 +98,29 @@ bintrail stream --source-dsn "$SRC" --index-dsn "$IDX" --server-id 12345
 bintrail index --binlog-dir /var/lib/mysql --source-dsn "$SRC" --index-dsn "$IDX" --all
 ```
 
-## Commands
+## Web console
+
+Prefer a browser to the CLI? `bintrail console` serves a **read-only, single-operator web UI** over your index — same single binary, no extra infrastructure. Think of it as the MCP server with a web face: browse every change, see before/after diffs, and generate undo SQL from a browser.
+
+```sh
+bintrail console --index-dsn "user:pass@tcp(127.0.0.1:3306)/binlog_index"
+```
+
+It prints a tokenized loopback URL to open:
+
+```
+Bintrail console (read-only) is running. Open:
+
+    http://127.0.0.1:8090/?token=ab12cd34ef56ab12cd34ef56ab12cd34
+```
+
+Three screens:
+
+- **Recover** — filter by schema / table / PK / time, preview the affected rows with before→after diffs, then generate undo SQL to copy or download.
+- **Events** — browse every indexed change with full before/after images.
+- **Status** — index health: partitions, coverage, stream lag, archives.
+
+It **never executes SQL** — recover produces a script you review and apply yourself, exactly like `bintrail recover --dry-run`. It binds to loopback with an auto-generated access token by default; binding to a non-loopback address requires an explicit `--token`. See [Web console](docs/console.md) for the security model and HTTP API.
 
 | Command | Description |
 |---|---|
@@ -108,6 +132,7 @@ bintrail index --binlog-dir /var/lib/mysql --source-dsn "$SRC" --index-dsn "$IDX
 | `stream` | Connect as a replica and index row events in real-time |
 | `query` | Search the index with flexible filters (schema, table, PK, time range, GTID) |
 | `recover` | Generate reversal SQL for matching events |
+| `console` | Serve a read-only web UI to browse changes and generate undo SQL from a browser |
 | `reconstruct` | Rebuild row state at a point in time from baselines + binlog events |
 | `rotate` | Drop old partitions, add new ones, optionally archive to Parquet |
 | `status` | Show indexed files, partition sizes, and event counts |
@@ -189,6 +214,7 @@ The index stores complete before and after row images for every event, so recove
 | [Streaming](docs/streaming.md) | Real-time replication indexing |
 | [Streaming 101](docs/streaming-101.md) | Getting started with stream |
 | [Query and Recovery](docs/query-and-recovery.md) | Filters, output formats, and recovery workflows |
+| [Web console](docs/console.md) | Read-only browser UI: browse changes, diffs, and generate undo SQL |
 | [Rotation and Status](docs/rotation-and-status.md) | Partition management and monitoring |
 | [Dump and Baseline](docs/dump-and-baseline.md) | mydumper workflow and Parquet baselines |
 | [DDL Tracking](docs/ddl-tracking.md) | Schema change detection and handling |

--- a/cmd/bintrail/config.go
+++ b/cmd/bintrail/config.go
@@ -178,6 +178,16 @@ var envSections = []envSection{
 			{"BINTRAIL_AUTH_METHOD", ""},
 		},
 	},
+	{
+		// These are read directly by `bintrail console` (see runConsole), not
+		// via the shared envBindings slice — --listen is also used by shim, so
+		// a global binding would cross-wire the commands.
+		Header: "Console (used by bintrail console)",
+		Bindings: []envTemplateEntry{
+			{"BINTRAIL_CONSOLE_LISTEN", "127.0.0.1:8090"},
+			{"BINTRAIL_CONSOLE_TOKEN", ""},
+		},
+	},
 }
 
 // generateEnvTemplate builds the .bintrail.env file content. Variables

--- a/cmd/bintrail/config_test.go
+++ b/cmd/bintrail/config_test.go
@@ -99,13 +99,26 @@ func TestEnvBindingsAndSectionsConsistency(t *testing.T) {
 			t.Errorf("envBindings has %s but envSections does not", b.EnvVar)
 		}
 	}
-	// Every envSection entry must appear in envBindings.
+	// Console env vars are intentionally template-only: `bintrail console` reads
+	// BINTRAIL_CONSOLE_LISTEN / BINTRAIL_CONSOLE_TOKEN directly in runConsole
+	// rather than via the shared bindCommandEnv. The --listen flag name is also
+	// used by shim/init-shim, so a global envBinding keyed on the flag name
+	// would cross-wire the console's address into those commands. They still
+	// belong in the generated template, hence this documented exception.
+	templateOnly := map[string]bool{
+		"BINTRAIL_CONSOLE_LISTEN": true,
+		"BINTRAIL_CONSOLE_TOKEN":  true,
+	}
+	// Every other envSection entry must appear in envBindings.
 	bindingVars := make(map[string]bool)
 	for _, b := range envBindings {
 		bindingVars[b.EnvVar] = true
 	}
 	for _, sec := range envSections {
 		for _, entry := range sec.Bindings {
+			if templateOnly[entry.EnvVar] {
+				continue
+			}
 			if !bindingVars[entry.EnvVar] {
 				t.Errorf("envSections has %s (in %q) but envBindings does not", entry.EnvVar, sec.Header)
 			}

--- a/cmd/bintrail/console.go
+++ b/cmd/bintrail/console.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/spf13/cobra"
+
+	"github.com/dbtrail/bintrail/internal/config"
+	"github.com/dbtrail/bintrail/internal/console"
+	"github.com/dbtrail/bintrail/internal/indexer"
+	"github.com/dbtrail/bintrail/internal/query"
+)
+
+var consoleCmd = &cobra.Command{
+	Use:   "console",
+	Short: "Serve a read-only web UI over the index (browse events, generate undo SQL)",
+	Long: `Starts a local, read-only, single-operator web console over the binlog index.
+
+It is the MCP server with a web face: browse indexed row events with full
+before/after diffs, and generate recovery (undo) SQL — all from a browser. The
+console NEVER executes SQL; recover produces a script you review and apply
+yourself.
+
+Security:
+  - Binds to loopback (127.0.0.1) by default and requires an access token.
+  - A token is auto-generated for loopback binds and printed in the URL.
+  - Binding to a non-loopback address REQUIRES an explicit --token.
+
+Example:
+  bintrail console --index-dsn "user:pass@tcp(127.0.0.1:3306)/binlog_index"`,
+	RunE: runConsole,
+}
+
+var (
+	conIndexDSN     string
+	conListen       string
+	conToken        string
+	conNoArchive    bool
+	conProfile      string
+	conAllowedHosts []string
+)
+
+func init() {
+	consoleCmd.Flags().StringVar(&conIndexDSN, "index-dsn", "", "DSN for the index MySQL database (required)")
+	consoleCmd.Flags().StringVar(&conListen, "listen", "127.0.0.1:8090", "Address to listen on (host:port)")
+	consoleCmd.Flags().StringVar(&conToken, "token", "", "Access token (auto-generated for loopback binds when empty)")
+	consoleCmd.Flags().BoolVar(&conNoArchive, "no-archive", false, "Disable Parquet archive auto-discovery (MySQL-only)")
+	consoleCmd.Flags().StringVar(&conProfile, "profile", "", "RBAC profile: deny tables / redact columns; forces --no-archive")
+	consoleCmd.Flags().StringSliceVar(&conAllowedHosts, "allowed-hosts", nil, "Extra hostnames allowed in the Host header (for reverse-proxy setups; IP literals and localhost are always allowed)")
+	_ = consoleCmd.MarkFlagRequired("index-dsn")
+	// bindCommandEnv wires the shared BINTRAIL_* env vars (notably
+	// BINTRAIL_INDEX_DSN). The console-specific BINTRAIL_CONSOLE_LISTEN /
+	// BINTRAIL_CONSOLE_TOKEN are handled in runConsole rather than added to the
+	// global envBindings slice: that slice matches by flag name, and --listen is
+	// also used by `shim`/`init-shim`, so a global binding would leak the
+	// console's listen address into those commands.
+	bindCommandEnv(consoleCmd)
+	rootCmd.AddCommand(consoleCmd)
+}
+
+func runConsole(cmd *cobra.Command, args []string) error {
+	// Console-specific env vars, with flag > env > default precedence.
+	if !cmd.Flags().Changed("listen") {
+		if v := os.Getenv("BINTRAIL_CONSOLE_LISTEN"); v != "" {
+			conListen = v
+		}
+	}
+	if !cmd.Flags().Changed("token") {
+		if v := os.Getenv("BINTRAIL_CONSOLE_TOKEN"); v != "" {
+			conToken = v
+		}
+	}
+
+	cfg, err := mysql.ParseDSN(conIndexDSN)
+	if err != nil {
+		return fmt.Errorf("invalid --index-dsn: %w", err)
+	}
+	dbName := cfg.DBName
+	if dbName == "" {
+		return fmt.Errorf("--index-dsn must include a database name (e.g. user:pass@tcp(host:3306)/binlog_index)")
+	}
+
+	db, err := config.Connect(conIndexDSN)
+	if err != nil {
+		return fmt.Errorf("failed to connect to index database: %w", err)
+	}
+	defer db.Close()
+
+	// Run startup migrations once here (not per request), keeping request
+	// handlers free of DDL — the recover path is then provably read-only.
+	if err := indexer.EnsureSchema(db); err != nil {
+		return fmt.Errorf("schema migration: %w", err)
+	}
+
+	// Resolve profile RBAC rules up front. Archives don't enforce RBAC, so a
+	// profile forces --no-archive to avoid leaking redacted columns.
+	var denyTables []query.SchemaTable
+	var redactCols []query.SchemaTableColumn
+	if conProfile != "" {
+		denyTables, redactCols, err = query.LoadProfileRules(cmd.Context(), db, conProfile)
+		if err != nil {
+			return fmt.Errorf("load profile %q: %w", conProfile, err)
+		}
+	}
+
+	srv, err := console.New(console.Config{
+		DB:            db,
+		DBName:        dbName,
+		Listen:        conListen,
+		Token:         conToken,
+		NoArchive:     conNoArchive || conProfile != "",
+		DenyTables:    denyTables,
+		RedactColumns: redactCols,
+		AllowedHosts:  conAllowedHosts,
+	})
+	if err != nil {
+		return err
+	}
+
+	ctx, stop := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	fmt.Fprintf(os.Stderr, "\nBintrail console (read-only) is running. Open:\n\n    %s\n\n", srv.URL())
+	slog.Info("console listening", "addr", conListen, "no_archive", conNoArchive || conProfile != "")
+
+	if err := srv.Run(ctx); err != nil {
+		return fmt.Errorf("console server: %w", err)
+	}
+	return nil
+}

--- a/docs/console.md
+++ b/docs/console.md
@@ -98,7 +98,7 @@ All endpoints return JSON. `/api/*` (except `healthz`) require
 | `GET /api/status` | Index status (same payload as `bintrail status --format json`). |
 | `GET /api/schemas` | Distinct schemas. `?schema=<name>` → that schema's tables. |
 | `GET /api/events` | Event browser. Query params: `schema, table, pk, event_type, gtid, since, until, changed_column, order, limit`. |
-| `POST /api/recover` | Undo-SQL generation. JSON body with the same filter fields (requires at least `schema`). Returns `{sql, statement_count, row_count, warnings}`. |
+| `POST /api/recover` | Undo-SQL generation. JSON body with the same filter fields (requires at least `schema`; an `order` field is accepted but ignored — recover always processes oldest-first). Returns `{sql, statement_count, row_count, warnings}`. |
 
 ### Coverage gaps and incomplete data
 
@@ -109,12 +109,15 @@ script. The recover screen renders those warnings prominently, so an
 incomplete-coverage undo is flagged to the operator rather than silently
 presented as complete.
 
-One residual limitation: when *several* archive sources are configured and only
-*some* fail to load, `query.FetchMerged` logs the failure server-side and
-continues with the rest (this too matches the CLI `recover`). The console cannot
-yet surface that per-source failure to the browser, because `FetchMerged`
-returns no per-source failure signal. Watch the server log if you run with
-multiple archive sources.
+One residual limitation: a few failure modes are logged server-side but not
+surfaced to the browser, because `query.FetchMerged` exposes no signal for them
+(this matches the CLI `recover`, which warns to stderr and continues):
+
+- some of several configured archive sources fail to load, and
+- the query planner itself fails to run (gap detection is skipped entirely).
+
+In both cases you get results without a coverage caveat in the response. Watch
+the server log when running with archives configured.
 
 ## Build
 

--- a/docs/console.md
+++ b/docs/console.md
@@ -1,0 +1,126 @@
+# bintrail console
+
+`bintrail console` serves an embedded, **read-only, single-operator** web UI over
+an existing index. It is the MCP server with a web face: the same query,
+recovery, and status engines, reached from a browser. Browse indexed row events
+with full before/after diffs, and generate recovery (undo) SQL — all without
+leaving the terminal that started it.
+
+The console **never executes SQL**. Recover produces a transaction-wrapped
+script you copy or download and apply yourself after review, exactly like
+`bintrail recover --dry-run`.
+
+> **Scope (MVP):** event browsing, recovery-SQL generation, and index status.
+> Point-in-time full-table reconstruction (baseline + deltas) is **not** part of
+> the console yet — use the offline `bintrail reconstruct` for that.
+
+## Usage
+
+```sh
+bintrail console --index-dsn "user:pass@tcp(127.0.0.1:3306)/binlog_index"
+```
+
+On start it prints a jupyter-style URL with an access token:
+
+```
+Bintrail console (read-only) is running. Open:
+
+    http://127.0.0.1:8090/?token=ab12cd34ef56ab12cd34ef56ab12cd34
+```
+
+Open that URL in a browser. Three tabs:
+
+1. **Recover** (landing) — filter schema / table / PK / time, preview the
+   affected rows with before→after diffs, then **Generate undo SQL** and
+   copy/download the script.
+2. **Events** — broader filters (event type, changed column, GTID, limit).
+3. **Status** — index health: partitions, coverage, stream lag, archives.
+
+## Flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `--index-dsn` | — (required) | DSN for the index MySQL database. |
+| `--listen` | `127.0.0.1:8090` | Bind address. `:8090` avoids the MCP server's `:8080`. |
+| `--token` | auto-generated | Access token. Auto-generated for loopback binds; **required** for non-loopback. |
+| `--no-archive` | `false` | Disable Parquet archive auto-discovery (MySQL-only results). |
+| `--profile` | — | RBAC profile: deny tables / redact columns. Forces `--no-archive`. |
+| `--allowed-hosts` | — | Extra hostnames accepted in the `Host` header (for reverse-proxy setups). IP literals and `localhost` are always allowed. |
+
+### Environment variables
+
+- `BINTRAIL_INDEX_DSN` — same as `--index-dsn` (shared with other commands).
+- `BINTRAIL_CONSOLE_LISTEN` — same as `--listen`.
+- `BINTRAIL_CONSOLE_TOKEN` — same as `--token`.
+
+Precedence is the usual CLI flag > environment variable > default.
+
+## Security model
+
+The binary has no Supabase/RBAC backend to lean on, so the console defends
+itself:
+
+- **Loopback by default + token required.** A random 128-bit token is generated
+  for loopback binds and printed in the URL. Binding to a non-loopback address
+  (`0.0.0.0`, a LAN IP, …) **requires** an explicit `--token` or the command
+  refuses to start.
+- **Constant-time token compare** (`crypto/subtle`).
+- **Bearer header on the API.** `/api/*` requires the token in the
+  `Authorization: Bearer …` header — never a cookie alone — so a cross-site
+  form POST cannot carry ambient credentials to `/api/recover`. The page shell
+  loads without a token (it reads the token from the URL to bootstrap its
+  requests).
+- **No CORS headers.** Requests are same-origin only.
+- **Host-header allowlist.** Requests whose `Host` is a domain name are
+  rejected (only IP literals and `localhost` pass), which defeats DNS-rebinding
+  attacks against the local bind.
+- **Result caps.** Every query is bounded — events default 100 (max 1000),
+  recover default 1000 (max 10000). Never unlimited.
+- **`/api/healthz`** is the only unauthenticated endpoint (a liveness probe).
+
+## Open-core boundary
+
+The console exposes only the free **query_explorer** surface (event query +
+recovery-SQL generation), available on every tier. It deliberately stays out of
+the paid **forensics** surface (who-changed / attribution): the events API drops
+`connection_id` — the MySQL `pseudo_thread_id` of the writing transaction — from
+every response. There is no gating, RBAC, or license code in the binary; the
+boundary is simply what the API chooses to serve.
+
+## API
+
+All endpoints return JSON. `/api/*` (except `healthz`) require
+`Authorization: Bearer <token>`.
+
+| Method & path | Purpose |
+|---|---|
+| `GET /api/healthz` | Liveness probe (no token). |
+| `GET /api/status` | Index status (same payload as `bintrail status --format json`). |
+| `GET /api/schemas` | Distinct schemas. `?schema=<name>` → that schema's tables. |
+| `GET /api/events` | Event browser. Query params: `schema, table, pk, event_type, gtid, since, until, changed_column, order, limit`. |
+| `POST /api/recover` | Undo-SQL generation. JSON body with the same filter fields (requires at least `schema`). Returns `{sql, statement_count, row_count, warnings}`. |
+
+### Coverage gaps and incomplete data
+
+The two surfaces treat missing coverage differently, on purpose:
+
+- **Events** browsing tolerates gaps: hours rotated out of MySQL with no archive
+  are reported in a `warnings` array, and the browser shows whatever could be
+  fetched.
+- **Recover** refuses to generate a partial undo: a detected coverage gap, or a
+  total archive-fetch failure, returns an error (HTTP 422 / 500) instead of a
+  silently-incomplete script. You can't accidentally apply half an undo.
+
+One residual limitation: when *several* archive sources are configured and only
+*some* fail to load, `query.FetchMerged` logs the failure server-side and
+continues with the rest (this matches the CLI `recover`). The console cannot yet
+surface that per-source failure to the browser, because `FetchMerged` returns no
+per-source failure signal. Watch the server log if you run with multiple archive
+sources.
+
+## Build
+
+The frontend is vanilla HTML/CSS/JS with **zero third-party assets** (see
+`internal/console/assets/VENDOR.md`) and is embedded via `//go:embed`. There is
+no Node build step; `make build` (CGO, required for DuckDB) produces a single
+self-contained binary.

--- a/docs/console.md
+++ b/docs/console.md
@@ -102,21 +102,19 @@ All endpoints return JSON. `/api/*` (except `healthz`) require
 
 ### Coverage gaps and incomplete data
 
-The two surfaces treat missing coverage differently, on purpose:
-
-- **Events** browsing tolerates gaps: hours rotated out of MySQL with no archive
-  are reported in a `warnings` array, and the browser shows whatever could be
-  fetched.
-- **Recover** refuses to generate a partial undo: a detected coverage gap, or a
-  total archive-fetch failure, returns an error (HTTP 422 / 500) instead of a
-  silently-incomplete script. You can't accidentally apply half an undo.
+Both `/api/events` and `/api/recover` report coverage gaps (hours rotated out of
+MySQL with no archive) in a `warnings` array rather than failing the request —
+matching the CLI `recover`, which warns and continues so a human can review the
+script. The recover screen renders those warnings prominently, so an
+incomplete-coverage undo is flagged to the operator rather than silently
+presented as complete.
 
 One residual limitation: when *several* archive sources are configured and only
 *some* fail to load, `query.FetchMerged` logs the failure server-side and
-continues with the rest (this matches the CLI `recover`). The console cannot yet
-surface that per-source failure to the browser, because `FetchMerged` returns no
-per-source failure signal. Watch the server log if you run with multiple archive
-sources.
+continues with the rest (this too matches the CLI `recover`). The console cannot
+yet surface that per-source failure to the browser, because `FetchMerged`
+returns no per-source failure signal. Watch the server log if you run with
+multiple archive sources.
 
 ## Build
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -179,6 +179,32 @@ The script is wrapped in `BEGIN`/`COMMIT` and reverses events in reverse chronol
 
 ---
 
+## Step 5½ — Or do steps 4–5 from a browser
+
+Steps 4 and 5 (query + recover) are also available as a read-only web UI — same binary, no extra setup:
+
+```sh
+bintrail console --index-dsn "$IDX"
+```
+
+It prints a tokenized loopback URL; open it in a browser:
+
+```
+Bintrail console (read-only) is running. Open:
+
+    http://127.0.0.1:8090/?token=ab12cd34ef56ab12cd34ef56ab12cd34
+```
+
+Three screens:
+
+- **Recover** — filter by schema / table / PK / time, preview the affected rows with before→after diffs, then generate undo SQL to copy or download.
+- **Events** — browse every indexed change with full before/after images.
+- **Status** — index health: partitions, coverage, stream lag, archives.
+
+Like `recover --dry-run`, the console **never executes SQL** — you review and apply the script yourself. It binds to loopback with an auto-generated access token by default; a non-loopback bind requires an explicit `--token`. See [Web console](./console.md) for the security model and HTTP API.
+
+---
+
 ## Step 6 — Keep the index clean
 
 The `binlog_events` table will keep growing. Drop old data with `rotate`:
@@ -245,12 +271,15 @@ bintrail rotate        ← run hourly to drop old partitions and stay clean
 bintrail status        ← check at any time
 ```
 
+> Prefer clicking to typing? `bintrail console` exposes the query + recover steps as a read-only web UI.
+
 ---
 
 ## Next Steps
 
 | Want to... | Read... |
 |---|---|
+| Browse changes and generate undo SQL from a browser | [Web console](./console.md) |
 | Use RDS, Aurora, or Cloud SQL | [Streaming](./streaming.md) |
 | Understand the query and recovery options in depth | [Query and Recovery](./query-and-recovery.md) |
 | Archive old events to S3 before dropping | [Rotation and Status](./rotation-and-status.md#archiving-partitions-to-parquet) |

--- a/internal/console/api.go
+++ b/internal/console/api.go
@@ -55,8 +55,11 @@ type recoverRequest struct {
 	Since         string `json:"since"`
 	Until         string `json:"until"`
 	ChangedColumn string `json:"changed_column"`
-	Order         string `json:"order"`
-	Limit         int    `json:"limit"`
+	// Order is accepted for request symmetry with /api/events but IGNORED by
+	// recover: handleRecover forces oldest-first (ASC) input, which the undo
+	// generator requires. A client-supplied value has no effect.
+	Order string `json:"order"`
+	Limit int    `json:"limit"`
 }
 
 type eventsResponse struct {
@@ -268,7 +271,9 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	_, _ = w.Write(buf.Bytes())
+	if _, err := w.Write(buf.Bytes()); err != nil {
+		slog.Error("console: status write failed", "error", err)
+	}
 }
 
 // handleSchemas serves GET /api/schemas. Without a ?schema= param it returns
@@ -348,13 +353,13 @@ func scanStrings(rows *sql.Rows) ([]string, error) {
 }
 
 // clampLimit enforces the default/maximum result caps: a non-positive request
-// becomes the default; an oversized request is capped at max.
-func clampLimit(n, def, max int) int {
+// becomes the default; an oversized request is capped at the maximum.
+func clampLimit(n, def, maxLimit int) int {
 	if n <= 0 {
 		return def
 	}
-	if n > max {
-		return max
+	if n > maxLimit {
+		return maxLimit
 	}
 	return n
 }

--- a/internal/console/api.go
+++ b/internal/console/api.go
@@ -133,22 +133,23 @@ func (s *Server) buildOptions(p filterParams, defaultLimit, maxLimit int) (query
 
 // fetch runs the shared cross-source fetch (live MySQL + Parquet archives).
 //
-// allowGaps trades safety for tolerance. Events browsing passes true: a coverage
-// gap (or an archive that fails to load) becomes a warning and the browser shows
-// whatever could be fetched. Recover passes false: a detected coverage gap or a
-// total archive failure becomes a hard error, because silently generating an
-// INCOMPLETE undo script and presenting it as success is worse than refusing.
+// AllowGaps is true for both events and recover, matching the CLI `recover`
+// (warn-and-continue — a human reviews the script). Coverage gaps the planner
+// detects are returned in the QueryPlan and surfaced to the caller as warnings
+// via gapWarnings(plan); the recover UI renders them prominently, so an
+// incomplete-coverage undo is never presented as a clean success.
 //
-// Note one residual case FetchMerged does not expose either way: when several
-// archive sources are configured and only SOME fail, it logs and continues
-// (matching the CLI `recover`). The console cannot surface that today because
-// FetchMerged returns no per-source failure signal; see docs/console.md.
-func (s *Server) fetch(ctx context.Context, opts query.Options, allowGaps bool) ([]query.ResultRow, *query.QueryPlan, error) {
+// One residual case FetchMerged does not expose: when several archive sources
+// are configured and only SOME fail to load, it logs the failure server-side
+// and continues (again, matching the CLI). The console cannot surface that to
+// the browser today because FetchMerged returns no per-source failure signal;
+// this limitation is documented in docs/console.md.
+func (s *Server) fetch(ctx context.Context, opts query.Options) ([]query.ResultRow, *query.QueryPlan, error) {
 	return query.FetchMerged(ctx, s.db, s.engine, query.FetchMergedOptions{
 		Opts:           opts,
 		DBName:         s.dbName,
 		NoArchive:      s.noArchive,
-		AllowGaps:      allowGaps,
+		AllowGaps:      true,
 		ArchiveFetcher: parquetquery.Fetch,
 	})
 }
@@ -173,8 +174,7 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	// Browsing tolerates gaps: surface them as warnings, don't fail.
-	rows, plan, err := s.fetch(r.Context(), opts, true)
+	rows, plan, err := s.fetch(r.Context(), opts)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -226,16 +226,11 @@ func (s *Server) handleRecover(w http.ResponseWriter, r *http.Request) {
 	// Forcing ASC here also makes the LIMIT select the oldest N, matching the CLI.
 	opts.Order = ""
 
-	// allowGaps=false: a coverage gap or total archive failure must abort with a
-	// clear error rather than silently producing an incomplete undo script.
-	rows, plan, err := s.fetch(r.Context(), opts, false)
+	// Coverage gaps come back in plan.GapHours and are surfaced as warnings
+	// below — the recover UI renders them, so an incomplete-coverage undo is
+	// flagged to the operator rather than silently presented as complete.
+	rows, plan, err := s.fetch(r.Context(), opts)
 	if err != nil {
-		var gapErr *query.GapError
-		if errors.As(err, &gapErr) {
-			writeJSONError(w, http.StatusUnprocessableEntity,
-				"refusing to generate an incomplete undo script — "+err.Error())
-			return
-		}
 		writeJSONError(w, http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/internal/console/api.go
+++ b/internal/console/api.go
@@ -1,0 +1,400 @@
+package console
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/dbtrail/bintrail/internal/cliutil"
+	"github.com/dbtrail/bintrail/internal/parquetquery"
+	"github.com/dbtrail/bintrail/internal/query"
+	"github.com/dbtrail/bintrail/internal/recovery"
+	"github.com/dbtrail/bintrail/internal/status"
+)
+
+// Result caps. Every endpoint applies a default and a hard maximum; the limit
+// is never 0/unlimited. A read-only browser must not be able to ask the index
+// for an unbounded result set.
+const (
+	eventsDefaultLimit  = 100
+	eventsMaxLimit      = 1000
+	recoverDefaultLimit = 1000
+	recoverMaxLimit     = 10000
+)
+
+// filterParams is the source-agnostic set of query filters parsed from either
+// a URL query string (events) or a JSON body (recover).
+type filterParams struct {
+	Schema        string
+	Table         string
+	PK            string
+	EventType     string
+	GTID          string
+	Since         string
+	Until         string
+	ChangedColumn string
+	Order         string
+	Limit         int
+}
+
+// recoverRequest is the JSON body accepted by POST /api/recover.
+type recoverRequest struct {
+	Schema        string `json:"schema"`
+	Table         string `json:"table"`
+	PK            string `json:"pk"`
+	EventType     string `json:"event_type"`
+	GTID          string `json:"gtid"`
+	Since         string `json:"since"`
+	Until         string `json:"until"`
+	ChangedColumn string `json:"changed_column"`
+	Order         string `json:"order"`
+	Limit         int    `json:"limit"`
+}
+
+type eventsResponse struct {
+	Events   []eventDTO `json:"events"`
+	Count    int        `json:"count"`
+	Limit    int        `json:"limit"`
+	Warnings []string   `json:"warnings,omitempty"`
+}
+
+type recoverResponse struct {
+	SQL            string   `json:"sql"`
+	StatementCount int      `json:"statement_count"`
+	RowCount       int      `json:"row_count"`
+	Warnings       []string `json:"warnings,omitempty"`
+}
+
+type schemasResponse struct {
+	Schemas []string `json:"schemas"`
+}
+
+type tablesResponse struct {
+	Schema string   `json:"schema"`
+	Tables []string `json:"tables"`
+}
+
+// buildOptions converts shared filter params into a query.Options, validating
+// cross-field requirements and clamping the limit. RBAC rules (deny tables /
+// redact columns) resolved at startup are always attached so every query the
+// console runs is bound by the operator's profile.
+func (s *Server) buildOptions(p filterParams, defaultLimit, maxLimit int) (query.Options, error) {
+	et, err := cliutil.ParseEventType(p.EventType)
+	if err != nil {
+		return query.Options{}, err
+	}
+	since, err := cliutil.ParseTime(p.Since)
+	if err != nil {
+		return query.Options{}, fmt.Errorf("invalid since: %w", err)
+	}
+	until, err := cliutil.ParseTime(p.Until)
+	if err != nil {
+		return query.Options{}, fmt.Errorf("invalid until: %w", err)
+	}
+
+	// A PK or changed-column filter is only meaningful when scoped to one
+	// table; mirror the MCP/CLI validation so the index isn't scanned blindly.
+	if p.PK != "" && (p.Schema == "" || p.Table == "") {
+		return query.Options{}, errors.New("pk filter requires both schema and table")
+	}
+	if p.ChangedColumn != "" && (p.Schema == "" || p.Table == "") {
+		return query.Options{}, errors.New("changed_column filter requires both schema and table")
+	}
+
+	// Default to newest-first, the natural order for a browsing UI.
+	order := strings.ToUpper(strings.TrimSpace(p.Order))
+	if order != "ASC" {
+		order = "DESC"
+	}
+
+	return query.Options{
+		Schema:        p.Schema,
+		Table:         p.Table,
+		PKValues:      p.PK,
+		EventType:     et,
+		GTID:          p.GTID,
+		Since:         since,
+		Until:         until,
+		ChangedColumn: p.ChangedColumn,
+		Limit:         clampLimit(p.Limit, defaultLimit, maxLimit),
+		Order:         order,
+		DenyTables:    s.denyTables,
+		RedactColumns: s.redactCols,
+	}, nil
+}
+
+// fetch runs the shared cross-source fetch (live MySQL + Parquet archives).
+//
+// allowGaps trades safety for tolerance. Events browsing passes true: a coverage
+// gap (or an archive that fails to load) becomes a warning and the browser shows
+// whatever could be fetched. Recover passes false: a detected coverage gap or a
+// total archive failure becomes a hard error, because silently generating an
+// INCOMPLETE undo script and presenting it as success is worse than refusing.
+//
+// Note one residual case FetchMerged does not expose either way: when several
+// archive sources are configured and only SOME fail, it logs and continues
+// (matching the CLI `recover`). The console cannot surface that today because
+// FetchMerged returns no per-source failure signal; see docs/console.md.
+func (s *Server) fetch(ctx context.Context, opts query.Options, allowGaps bool) ([]query.ResultRow, *query.QueryPlan, error) {
+	return query.FetchMerged(ctx, s.db, s.engine, query.FetchMergedOptions{
+		Opts:           opts,
+		DBName:         s.dbName,
+		NoArchive:      s.noArchive,
+		AllowGaps:      allowGaps,
+		ArchiveFetcher: parquetquery.Fetch,
+	})
+}
+
+// handleEvents serves GET /api/events — the events browser.
+func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	p := filterParams{
+		Schema:        q.Get("schema"),
+		Table:         q.Get("table"),
+		PK:            q.Get("pk"),
+		EventType:     q.Get("event_type"),
+		GTID:          q.Get("gtid"),
+		Since:         q.Get("since"),
+		Until:         q.Get("until"),
+		ChangedColumn: q.Get("changed_column"),
+		Order:         q.Get("order"),
+		Limit:         atoiDefault(q.Get("limit"), 0),
+	}
+	opts, err := s.buildOptions(p, eventsDefaultLimit, eventsMaxLimit)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	// Browsing tolerates gaps: surface them as warnings, don't fail.
+	rows, plan, err := s.fetch(r.Context(), opts, true)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, eventsResponse{
+		Events:   toEventDTOs(rows),
+		Count:    len(rows),
+		Limit:    opts.Limit,
+		Warnings: gapWarnings(plan),
+	})
+}
+
+// handleRecover serves POST /api/recover — generates undo SQL. It NEVER
+// executes the SQL: rows are fetched (read-only), reversed into a buffer, and
+// the script is returned as text for the operator to review and apply.
+func (s *Server) handleRecover(w http.ResponseWriter, r *http.Request) {
+	var body recoverRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil && !errors.Is(err, io.EOF) {
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		return
+	}
+	p := filterParams{
+		Schema:        body.Schema,
+		Table:         body.Table,
+		PK:            body.PK,
+		EventType:     body.EventType,
+		GTID:          body.GTID,
+		Since:         body.Since,
+		Until:         body.Until,
+		ChangedColumn: body.ChangedColumn,
+		Order:         body.Order,
+		Limit:         body.Limit,
+	}
+	opts, err := s.buildOptions(p, recoverDefaultLimit, recoverMaxLimit)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	// Refuse to generate an undo script for the entire index; a recovery must
+	// be scoped to at least one schema.
+	if opts.Schema == "" {
+		writeJSONError(w, http.StatusBadRequest, "recover requires at least a schema filter")
+		return
+	}
+
+	// Recovery requires chronological (oldest-first) input: GenerateSQLFromRows
+	// reverses internally so the most-recent event is undone first. The browsing
+	// default (DESC) would invert the undo order for a PK touched multiple times.
+	// Forcing ASC here also makes the LIMIT select the oldest N, matching the CLI.
+	opts.Order = ""
+
+	// allowGaps=false: a coverage gap or total archive failure must abort with a
+	// clear error rather than silently producing an incomplete undo script.
+	rows, plan, err := s.fetch(r.Context(), opts, false)
+	if err != nil {
+		var gapErr *query.GapError
+		if errors.As(err, &gapErr) {
+			writeJSONError(w, http.StatusUnprocessableEntity,
+				"refusing to generate an incomplete undo script — "+err.Error())
+			return
+		}
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	var buf bytes.Buffer
+	n, err := recovery.New(s.db, s.resolver).GenerateSQLFromRows(rows, &buf)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, recoverResponse{
+		SQL:            buf.String(),
+		StatementCount: n,
+		RowCount:       len(rows),
+		Warnings:       gapWarnings(plan),
+	})
+}
+
+// handleStatus serves GET /api/status — index health, partitions, coverage,
+// stream lag, archives. Reuses status.CollectStatus + WriteJSON verbatim;
+// that surface exposes only aggregate server metadata, never per-event actor
+// attribution, so it stays inside the free query_explorer boundary.
+func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
+	data, err := status.CollectStatus(r.Context(), s.db, s.dbName)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	// Encode into a buffer first: status data is already in memory, so this is
+	// free and avoids committing a 200 then emitting a truncated body if the
+	// encode fails partway (mirrors handleRecover).
+	var buf bytes.Buffer
+	if err := data.WriteJSON(&buf); err != nil {
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(buf.Bytes())
+}
+
+// handleSchemas serves GET /api/schemas. Without a ?schema= param it returns
+// the distinct schemas present in the index; with one it returns that schema's
+// tables (snapshot-authoritative, falling back to distinct observed tables).
+func (s *Server) handleSchemas(w http.ResponseWriter, r *http.Request) {
+	schema := r.URL.Query().Get("schema")
+	if schema == "" {
+		names, err := s.distinctSchemas(r.Context())
+		if err != nil {
+			writeJSONError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, schemasResponse{Schemas: names})
+		return
+	}
+	tables, err := s.tablesForSchema(r.Context(), schema)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, tablesResponse{Schema: schema, Tables: tables})
+}
+
+// handleHealthz serves GET /api/healthz — an unauthenticated liveness probe.
+func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// distinctSchemas lists the schemas observed in binlog_events.
+func (s *Server) distinctSchemas(ctx context.Context) ([]string, error) {
+	rows, err := s.db.QueryContext(ctx, "SELECT DISTINCT schema_name FROM binlog_events ORDER BY schema_name")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanStrings(rows)
+}
+
+// tablesForSchema lists the tables of one schema. It prefers the latest schema
+// snapshot (authoritative, includes tables with no recent events) and falls
+// back to the distinct tables observed in binlog_events when no snapshot covers
+// the schema.
+func (s *Server) tablesForSchema(ctx context.Context, schema string) ([]string, error) {
+	if s.resolver != nil {
+		if metas := s.resolver.Tables(schema); len(metas) > 0 {
+			out := make([]string, len(metas))
+			for i, m := range metas {
+				out[i] = m.Table
+			}
+			return out, nil
+		}
+	}
+	rows, err := s.db.QueryContext(ctx,
+		"SELECT DISTINCT table_name FROM binlog_events WHERE schema_name = ? ORDER BY table_name", schema)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanStrings(rows)
+}
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+// scanStrings collects a single-column string result set. The returned slice
+// is non-nil so it JSON-encodes as [] rather than null.
+func scanStrings(rows *sql.Rows) ([]string, error) {
+	out := []string{}
+	for rows.Next() {
+		var v string
+		if err := rows.Scan(&v); err != nil {
+			return nil, err
+		}
+		out = append(out, v)
+	}
+	return out, rows.Err()
+}
+
+// clampLimit enforces the default/maximum result caps: a non-positive request
+// becomes the default; an oversized request is capped at max.
+func clampLimit(n, def, max int) int {
+	if n <= 0 {
+		return def
+	}
+	if n > max {
+		return max
+	}
+	return n
+}
+
+// atoiDefault parses s as an int, returning def when s is empty or invalid.
+func atoiDefault(s string, def int) int {
+	if s == "" {
+		return def
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return def
+	}
+	return n
+}
+
+// gapWarnings renders coverage-gap hours from a query plan into a warning list
+// for the API response, or nil when there are none.
+func gapWarnings(plan *query.QueryPlan) []string {
+	if plan == nil || len(plan.GapHours) == 0 {
+		return nil
+	}
+	return []string{query.FormatGapWarning(plan.GapHours)}
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		slog.Error("console: JSON encode failed", "error", err)
+	}
+}
+
+func writeJSONError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}

--- a/internal/console/api_test.go
+++ b/internal/console/api_test.go
@@ -1,0 +1,153 @@
+package console
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/dbtrail/bintrail/internal/parser"
+	"github.com/dbtrail/bintrail/internal/query"
+)
+
+func TestClampLimit(t *testing.T) {
+	cases := []struct{ n, def, max, want int }{
+		{0, 100, 1000, 100},     // unset → default
+		{-5, 100, 1000, 100},    // negative → default
+		{50, 100, 1000, 50},     // in range → unchanged
+		{5000, 100, 1000, 1000}, // over max → capped
+		{1000, 100, 1000, 1000}, // at max → unchanged
+	}
+	for _, c := range cases {
+		if got := clampLimit(c.n, c.def, c.max); got != c.want {
+			t.Errorf("clampLimit(%d,%d,%d) = %d, want %d", c.n, c.def, c.max, got, c.want)
+		}
+	}
+}
+
+func TestBuildOptionsValidation(t *testing.T) {
+	s := &Server{}
+	bad := []struct {
+		name string
+		p    filterParams
+	}{
+		{"pk without schema/table", filterParams{PK: "1"}},
+		{"changed_column without schema/table", filterParams{ChangedColumn: "x"}},
+		{"invalid event type", filterParams{EventType: "BOGUS"}},
+		{"invalid since", filterParams{Since: "not-a-time"}},
+		{"invalid until", filterParams{Until: "nope"}},
+	}
+	for _, tc := range bad {
+		if _, err := s.buildOptions(tc.p, 100, 1000); err == nil {
+			t.Errorf("%s: expected error, got nil", tc.name)
+		}
+	}
+}
+
+func TestBuildOptionsValues(t *testing.T) {
+	s := &Server{}
+
+	opts, err := s.buildOptions(filterParams{
+		Schema: "app", Table: "users", PK: "42", EventType: "update", Limit: 0,
+	}, 100, 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opts.Limit != 100 {
+		t.Errorf("Limit = %d, want default 100", opts.Limit)
+	}
+	if opts.Order != "DESC" {
+		t.Errorf("Order = %q, want DESC (browsing default)", opts.Order)
+	}
+	if opts.PKValues != "42" {
+		t.Errorf("PKValues = %q, want 42", opts.PKValues)
+	}
+	if opts.EventType == nil || *opts.EventType != parser.EventUpdate {
+		t.Error("EventType not parsed to UPDATE")
+	}
+
+	capped, _ := s.buildOptions(filterParams{Schema: "app", Limit: 99999}, 100, 1000)
+	if capped.Limit != 1000 {
+		t.Errorf("Limit = %d, want capped 1000", capped.Limit)
+	}
+
+	asc, _ := s.buildOptions(filterParams{Order: "asc"}, 100, 1000)
+	if asc.Order != "ASC" {
+		t.Errorf("Order = %q, want ASC", asc.Order)
+	}
+}
+
+// TestRecoverIsReadOnly asserts the read-only invariant: the recover handler
+// fetches with a single SELECT and generates SQL text — it never executes any
+// statement. The sqlmock registers ONLY an ExpectQuery; any write the handler
+// attempted would fail (no matching expectation) and break the clean 200.
+func TestRecoverIsReadOnly(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	cols := []string{
+		"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp",
+		"gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values",
+		"changed_columns", "row_before", "row_after", "schema_version",
+	}
+	ts := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	// An INSERT event (event_type=1); its reversal is a DELETE built from
+	// row_after. schema_version=0 keeps recovery on the default resolver (nil),
+	// so no per-row resolver query touches the DB.
+	resultRows := sqlmock.NewRows(cols).AddRow(
+		int64(1), "bin.000001", int64(4), int64(40), ts,
+		nil, nil, "app", "users", int64(parser.EventInsert), "42",
+		nil, nil, []byte(`{"id":42,"email":"a@x"}`), int64(0),
+	)
+	mock.ExpectQuery("FROM binlog_events").WillReturnRows(resultRows)
+
+	s := &Server{
+		db:        db,
+		engine:    query.New(db),
+		dbName:    "", // empty disables the planner → no archive_state query
+		noArchive: true,
+		resolver:  nil,
+		token:     "t",
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/recover", strings.NewReader(`{"schema":"app","table":"users"}`))
+	s.handleRecover(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("recover status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var resp recoverResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v (body=%s)", err, rec.Body.String())
+	}
+	if !strings.Contains(resp.SQL, "DELETE FROM") {
+		t.Errorf("expected a DELETE in the undo SQL, got:\n%s", resp.SQL)
+	}
+	if !strings.Contains(resp.SQL, "BEGIN;") || !strings.Contains(resp.SQL, "COMMIT;") {
+		t.Errorf("expected a transaction-wrapped script, got:\n%s", resp.SQL)
+	}
+	if resp.StatementCount != 1 {
+		t.Errorf("StatementCount = %d, want 1", resp.StatementCount)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("read-only invariant violated — unexpected DB interaction: %v", err)
+	}
+}
+
+// TestRecoverRequiresSchema ensures recover refuses to undo the whole index.
+func TestRecoverRequiresSchema(t *testing.T) {
+	s := &Server{token: "t"}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/recover", strings.NewReader(`{}`))
+	s.handleRecover(rec, req)
+	if rec.Code != 400 {
+		t.Errorf("recover without schema: code = %d, want 400", rec.Code)
+	}
+}

--- a/internal/console/api_test.go
+++ b/internal/console/api_test.go
@@ -3,6 +3,7 @@ package console
 import (
 	"encoding/json"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -77,6 +78,87 @@ func TestBuildOptionsValues(t *testing.T) {
 	asc, _ := s.buildOptions(filterParams{Order: "asc"}, 100, 1000)
 	if asc.Order != "ASC" {
 		t.Errorf("Order = %q, want ASC", asc.Order)
+	}
+}
+
+// TestBuildOptionsAttachesRBAC guards that the server's profile rules (deny
+// tables / redact columns) are attached to every query.Options buildOptions
+// produces — a refactor that drops this wiring would silently bypass RBAC.
+func TestBuildOptionsAttachesRBAC(t *testing.T) {
+	deny := []query.SchemaTable{{Schema: "app", Table: "secrets"}}
+	redact := []query.SchemaTableColumn{{Schema: "app", Table: "users", Column: "ssn"}}
+	s := &Server{denyTables: deny, redactCols: redact}
+
+	opts, err := s.buildOptions(filterParams{Schema: "app"}, 100, 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(opts.DenyTables, deny) {
+		t.Errorf("DenyTables not attached to options: %+v", opts.DenyTables)
+	}
+	if !reflect.DeepEqual(opts.RedactColumns, redact) {
+		t.Errorf("RedactColumns not attached to options: %+v", opts.RedactColumns)
+	}
+}
+
+// TestEventsHandlerOmitsConnectionID exercises handleEvents at the HTTP layer
+// with sqlmock and asserts the open-core boundary holds over real data flow:
+// the source row carries connection_id, the response must not.
+func TestEventsHandlerOmitsConnectionID(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	cols := []string{
+		"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp",
+		"gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values",
+		"changed_columns", "row_before", "row_after", "schema_version",
+	}
+	ts := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	rows := sqlmock.NewRows(cols).AddRow(
+		int64(1), "bin.000001", int64(4), int64(40), ts,
+		nil, int64(4242), "app", "users", int64(parser.EventUpdate), "7",
+		[]byte(`["email"]`), []byte(`{"email":"a@x"}`), []byte(`{"email":"b@x"}`), int64(0),
+	)
+	mock.ExpectQuery("FROM binlog_events").WillReturnRows(rows)
+
+	s := &Server{db: db, engine: query.New(db), dbName: "", noArchive: true, token: "t"}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/events?schema=app&table=users", nil)
+	s.handleEvents(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("events status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, "connection_id") || strings.Contains(body, "4242") {
+		t.Errorf("events HTTP response leaked connection_id: %s", body)
+	}
+	var resp eventsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Count != 1 {
+		t.Errorf("count = %d, want 1", resp.Count)
+	}
+	if resp.Limit != eventsDefaultLimit {
+		t.Errorf("limit = %d, want default %d", resp.Limit, eventsDefaultLimit)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+// TestRecoverInvalidJSON: a malformed (non-empty) body is a 400, not a panic.
+func TestRecoverInvalidJSON(t *testing.T) {
+	s := &Server{token: "t"}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/recover", strings.NewReader(`{bad`))
+	s.handleRecover(rec, req)
+	if rec.Code != 400 {
+		t.Errorf("invalid JSON body: code = %d, want 400", rec.Code)
 	}
 }
 

--- a/internal/console/assets.go
+++ b/internal/console/assets.go
@@ -1,0 +1,26 @@
+package console
+
+import (
+	"embed"
+	"io/fs"
+	"net/http"
+)
+
+// assetsFS embeds the static frontend (HTML/CSS/JS). The console ships as a
+// single Go binary with no Node build step — these files are vanilla and
+// dependency-free (see assets/VENDOR.md). Only the three served files are
+// embedded; VENDOR.md stays as source-tree documentation and is not exposed.
+//
+//go:embed assets/index.html assets/app.js assets/style.css
+var assetsFS embed.FS
+
+// assetHandler serves the embedded frontend rooted at the assets/ directory,
+// so "/" resolves to index.html and "/app.js", "/style.css" resolve directly.
+func assetHandler() http.Handler {
+	sub, err := fs.Sub(assetsFS, "assets")
+	if err != nil {
+		// Unreachable: the embed directive guarantees the directory exists.
+		panic(err)
+	}
+	return http.FileServer(http.FS(sub))
+}

--- a/internal/console/assets/VENDOR.md
+++ b/internal/console/assets/VENDOR.md
@@ -1,0 +1,15 @@
+# Vendored frontend assets
+
+**None.**
+
+The bintrail console frontend (`index.html`, `app.js`, `style.css`) is written
+in vanilla HTML, CSS, and JavaScript with **zero third-party dependencies** — no
+frameworks, no bundler, no Node build step. The files are embedded directly into
+the Go binary via `//go:embed` (see `../assets.go`).
+
+This keeps `make build` a pure Go build (CGO for DuckDB, no JS toolchain) and
+keeps the supply chain trivial to audit: everything served to the browser lives
+in this directory and is reviewed in-tree.
+
+If a third-party asset is ever added, list it here with its name, version,
+license, and source URL, and confirm its license permits redistribution.

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -1,0 +1,332 @@
+"use strict";
+
+// ── token bootstrap ────────────────────────────────────────────────────────
+// The page itself loads without a token; the API requires one. We read it from
+// the ?token= query param the CLI prints, keep it in memory, and strip it from
+// the visible URL so it isn't left sitting in the address bar / history.
+const TOKEN = new URLSearchParams(location.search).get("token") || "";
+if (TOKEN) {
+  history.replaceState(null, "", location.pathname);
+}
+
+let lastSQL = "";
+
+// ── tiny DOM helper (builds nodes; never injects data as HTML) ───────────────
+function el(tag, attrs, ...kids) {
+  const n = document.createElement(tag);
+  if (attrs) {
+    for (const [k, v] of Object.entries(attrs)) {
+      if (v === null || v === undefined) continue;
+      if (k === "class") n.className = v;
+      else if (k === "text") n.textContent = v;
+      else if (k.startsWith("on")) n.addEventListener(k.slice(2), v);
+      else n.setAttribute(k, v);
+    }
+  }
+  for (const kid of kids) {
+    if (kid === null || kid === undefined) continue;
+    n.appendChild(typeof kid === "string" ? document.createTextNode(kid) : kid);
+  }
+  return n;
+}
+
+function opt(value, label) {
+  const o = el("option", { value });
+  o.textContent = label;
+  return o;
+}
+
+// clear removes all children of a node. Used instead of innerHTML="" so no
+// markup is ever assigned from a string.
+function clear(n) {
+  n.replaceChildren();
+}
+
+function valueToString(v) {
+  if (v === null || v === undefined) return "NULL";
+  if (typeof v === "object") return JSON.stringify(v);
+  return String(v);
+}
+
+function toast(msg) {
+  const t = document.getElementById("toast");
+  t.textContent = msg;
+  t.hidden = false;
+  clearTimeout(toast._t);
+  toast._t = setTimeout(() => { t.hidden = true; }, 2000);
+}
+
+// ── API wrapper ──────────────────────────────────────────────────────────────
+async function api(path, opts = {}) {
+  const headers = { Authorization: "Bearer " + TOKEN };
+  if (opts.body) headers["Content-Type"] = "application/json";
+  const res = await fetch(path, {
+    method: opts.method || "GET",
+    headers,
+    body: opts.body ? JSON.stringify(opts.body) : undefined,
+  });
+  const text = await res.text();
+  let data = null;
+  if (text) {
+    try { data = JSON.parse(text); } catch { data = { error: text }; }
+  }
+  if (!res.ok) {
+    throw new Error((data && data.error) || "HTTP " + res.status);
+  }
+  return data;
+}
+
+// ── shared rendering ─────────────────────────────────────────────────────────
+function renderError(container, err) {
+  clear(container);
+  container.appendChild(el("div", { class: "error-box" }, String(err.message || err)));
+}
+
+function renderWarnings(node, warnings) {
+  clear(node);
+  (warnings || []).forEach((w) => node.appendChild(el("div", { class: "warn-item" }, w)));
+}
+
+function formParams(form) {
+  const out = {};
+  for (const [k, v] of new FormData(form).entries()) {
+    if (String(v).trim() !== "") out[k] = v;
+  }
+  return out;
+}
+
+function renderDiff(ev) {
+  const before = ev.row_before || {};
+  const after = ev.row_after || {};
+  const cols = Array.from(new Set([...Object.keys(before), ...Object.keys(after)]));
+  const changed = new Set(ev.changed_columns || []);
+  const wholeRow = ev.event_type === "INSERT" || ev.event_type === "DELETE";
+  const grid = el("div", { class: "diff" },
+    el("div", { class: "dh" }, "column"),
+    el("div", { class: "dh" }, "before"),
+    el("div", { class: "dh" }, "after"),
+  );
+  if (cols.length === 0) {
+    grid.appendChild(el("div", { class: "col" }, "(no row image)"));
+    grid.appendChild(el("div", { class: "before" }, ""));
+    grid.appendChild(el("div", { class: "after" }, ""));
+  }
+  cols.forEach((c) => {
+    const isCh = wholeRow || changed.has(c);
+    const mark = isCh ? " changed" : "";
+    grid.appendChild(el("div", { class: "col" + mark }, c));
+    grid.appendChild(el("div", { class: "before" + mark }, c in before ? valueToString(before[c]) : ""));
+    grid.appendChild(el("div", { class: "after" + mark }, c in after ? valueToString(after[c]) : ""));
+  });
+  return grid;
+}
+
+function renderEvents(container, data) {
+  clear(container);
+  container.appendChild(el("div", { class: "meta-line" },
+    `${data.count} event(s) · limit ${data.limit}`));
+  if (!data.events || data.events.length === 0) {
+    container.appendChild(el("div", { class: "empty" }, "No events matched these filters."));
+    return;
+  }
+  const tbody = el("tbody");
+  data.events.forEach((ev) => {
+    const row = el("tr", { class: "event-row" },
+      el("td", null, ev.event_timestamp),
+      el("td", null, `${ev.schema_name}.${ev.table_name}`),
+      el("td", null, el("span", { class: "badge " + ev.event_type }, ev.event_type)),
+      el("td", null, ev.pk_values),
+      el("td", null, (ev.changed_columns || []).join(", ")),
+    );
+    const detail = el("tr", { class: "detail" }, el("td", { colspan: "5" }, renderDiff(ev)));
+    detail.hidden = true;
+    row.addEventListener("click", () => { detail.hidden = !detail.hidden; });
+    tbody.appendChild(row);
+    tbody.appendChild(detail);
+  });
+  const table = el("table", { class: "events" },
+    el("thead", null, el("tr", null,
+      el("th", null, "time"), el("th", null, "table"), el("th", null, "type"),
+      el("th", null, "pk"), el("th", null, "changed columns"))),
+    tbody,
+  );
+  container.appendChild(table);
+}
+
+// ── events tab ───────────────────────────────────────────────────────────────
+async function runEvents(e) {
+  e.preventDefault();
+  const container = document.getElementById("events-result");
+  const warns = document.getElementById("events-warnings");
+  try {
+    const params = new URLSearchParams(formParams(e.target));
+    const data = await api("/api/events?" + params.toString());
+    renderWarnings(warns, data.warnings);
+    renderEvents(container, data);
+  } catch (err) {
+    clear(warns);
+    renderError(container, err);
+  }
+}
+
+// ── recover tab ──────────────────────────────────────────────────────────────
+async function previewRecover() {
+  const container = document.getElementById("recover-preview");
+  try {
+    const params = new URLSearchParams(formParams(document.getElementById("recover-form")));
+    const data = await api("/api/events?" + params.toString());
+    renderEvents(container, data);
+  } catch (err) {
+    renderError(container, err);
+  }
+}
+
+async function generateUndo(e) {
+  e.preventDefault();
+  const warns = document.getElementById("recover-warnings");
+  const wrap = document.getElementById("recover-sql-wrap");
+  try {
+    const body = formParams(e.target);
+    if (body.limit) body.limit = Number(body.limit);
+    const data = await api("/api/recover", { method: "POST", body });
+    renderWarnings(warns, data.warnings);
+    lastSQL = data.sql || "";
+    document.getElementById("recover-sql").textContent = lastSQL;
+    document.getElementById("recover-meta").textContent =
+      `${data.statement_count} statement(s) from ${data.row_count} event(s)`;
+    wrap.hidden = false;
+  } catch (err) {
+    clear(warns);
+    wrap.hidden = true;
+    renderError(document.getElementById("recover-preview"), err);
+  }
+}
+
+function copySQL() {
+  navigator.clipboard.writeText(lastSQL)
+    .then(() => toast("SQL copied to clipboard"))
+    .catch(() => toast("copy failed"));
+}
+
+function downloadSQL() {
+  const blob = new Blob([lastSQL], { type: "application/sql" });
+  const a = el("a", { href: URL.createObjectURL(blob), download: "bintrail-undo.sql" });
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(a.href);
+}
+
+// ── status tab ───────────────────────────────────────────────────────────────
+function kv(k, v) {
+  return el("div", { class: "kv" },
+    el("span", { class: "k" }, k),
+    el("span", { class: "v" }, v === null || v === undefined ? "—" : String(v)));
+}
+
+async function refreshStatus() {
+  const c = document.getElementById("status-result");
+  try {
+    const s = await api("/api/status");
+    clear(c);
+    const grid = el("div", { class: "status-grid" });
+    grid.appendChild(el("div", { class: "card" },
+      el("h3", null, "Summary"),
+      kv("total events (est.)", s.total_events_estimate),
+      kv("indexed files", (s.files || []).length),
+      kv("partitions", (s.partitions || []).length)));
+    if (s.coverage) {
+      grid.appendChild(el("div", { class: "card" },
+        el("h3", null, "Coverage"),
+        kv("earliest event", s.coverage.earliest_event),
+        kv("latest event", s.coverage.latest_event),
+        kv("total events", s.coverage.total_events),
+        kv("schema changes", s.coverage.schema_changes)));
+    }
+    if (s.stream) {
+      grid.appendChild(el("div", { class: "card" },
+        el("h3", null, "Stream"),
+        kv("mode", s.stream.mode),
+        kv("binlog file", s.stream.binlog_file),
+        kv("position", s.stream.binlog_position),
+        kv("events indexed", s.stream.events_indexed)));
+    }
+    if (s.archives) {
+      grid.appendChild(el("div", { class: "card" },
+        el("h3", null, "Archives"),
+        kv("files", s.archives.total_files),
+        kv("rows", s.archives.total_rows),
+        kv("size", s.archives.total_size_human)));
+    }
+    c.appendChild(grid);
+  } catch (err) {
+    renderError(c, err);
+  }
+}
+
+// ── schema / table dropdowns ─────────────────────────────────────────────────
+async function populateSchemas() {
+  let schemas = [];
+  try {
+    const data = await api("/api/schemas");
+    schemas = data.schemas || [];
+  } catch (err) {
+    document.querySelectorAll(".schema-select").forEach((sel) => {
+      clear(sel);
+      sel.appendChild(opt("", "(error: " + (err.message || err) + ")"));
+    });
+    return;
+  }
+  document.querySelectorAll(".schema-select").forEach((sel) => {
+    clear(sel);
+    sel.appendChild(opt("", "— select —"));
+    schemas.forEach((s) => sel.appendChild(opt(s, s)));
+  });
+}
+
+async function loadTables(form) {
+  const schema = form.querySelector(".schema-select").value;
+  const tsel = form.querySelector(".table-select");
+  clear(tsel);
+  tsel.appendChild(opt("", "— any —"));
+  if (!schema) return;
+  try {
+    const data = await api("/api/schemas?schema=" + encodeURIComponent(schema));
+    (data.tables || []).forEach((t) => tsel.appendChild(opt(t, t)));
+  } catch (err) {
+    // Surface the failure (like populateSchemas) so an empty dropdown isn't
+    // mistaken for "this schema has no tables". Table is still optional.
+    tsel.appendChild(opt("", "(error loading tables)"));
+    toast("failed to load tables: " + (err.message || err));
+  }
+}
+
+// ── wiring ───────────────────────────────────────────────────────────────────
+function init() {
+  document.querySelectorAll(".tab").forEach((t) => {
+    t.addEventListener("click", () => {
+      document.querySelectorAll(".tab").forEach((x) => x.classList.remove("active"));
+      document.querySelectorAll(".panel").forEach((x) => x.classList.remove("active"));
+      t.classList.add("active");
+      document.getElementById(t.dataset.panel).classList.add("active");
+    });
+  });
+
+  document.getElementById("events-form").addEventListener("submit", runEvents);
+  document.getElementById("recover-form").addEventListener("submit", generateUndo);
+  document.querySelector("#recover-form .preview-btn").addEventListener("click", previewRecover);
+  document.getElementById("copy-sql").addEventListener("click", copySQL);
+  document.getElementById("download-sql").addEventListener("click", downloadSQL);
+  document.getElementById("status-refresh").addEventListener("click", refreshStatus);
+
+  document.querySelectorAll(".schema-select").forEach((sel) => {
+    sel.addEventListener("change", () => loadTables(sel.closest("form")));
+  });
+
+  if (!TOKEN) {
+    toast("No token in URL — open the link printed by `bintrail console`.");
+  }
+  populateSchemas();
+}
+
+document.addEventListener("DOMContentLoaded", init);

--- a/internal/console/assets/index.html
+++ b/internal/console/assets/index.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>bintrail console</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <div class="brand">
+      <span class="logo">bintrail</span>
+      <span class="sub">console</span>
+      <span class="readonly" title="This console never executes SQL.">read-only</span>
+    </div>
+    <nav id="tabs">
+      <button class="tab active" data-panel="recover">Recover</button>
+      <button class="tab" data-panel="events">Events</button>
+      <button class="tab" data-panel="status">Status</button>
+    </nav>
+  </header>
+
+  <main>
+    <!-- ── Recover ─────────────────────────────────────────────── -->
+    <section id="recover" class="panel active">
+      <p class="hint">Filter the changes you want to undo, preview the affected
+        rows, then generate reversal SQL. Nothing is ever executed — copy or
+        download the script and apply it yourself after review.</p>
+      <form id="recover-form" class="filters">
+        <label>Schema
+          <select name="schema" class="schema-select" required></select>
+        </label>
+        <label>Table
+          <select name="table" class="table-select"></select>
+        </label>
+        <label>PK <input name="pk" placeholder="e.g. 42 or 42|7"></label>
+        <label>Since <input name="since" placeholder="YYYY-MM-DD HH:MM:SS"></label>
+        <label>Until <input name="until" placeholder="YYYY-MM-DD HH:MM:SS"></label>
+        <div class="actions">
+          <button type="submit" class="primary">Generate undo SQL</button>
+          <button type="button" class="preview-btn">Preview affected rows</button>
+        </div>
+      </form>
+      <div id="recover-warnings" class="warnings"></div>
+      <div id="recover-preview"></div>
+      <div id="recover-sql-wrap" hidden>
+        <div class="sql-toolbar">
+          <span id="recover-meta"></span>
+          <span class="spacer"></span>
+          <button type="button" id="copy-sql">Copy</button>
+          <button type="button" id="download-sql">Download</button>
+        </div>
+        <pre id="recover-sql"></pre>
+      </div>
+    </section>
+
+    <!-- ── Events ──────────────────────────────────────────────── -->
+    <section id="events" class="panel">
+      <p class="hint">Browse indexed row events with full before/after images.</p>
+      <form id="events-form" class="filters">
+        <label>Schema
+          <select name="schema" class="schema-select"></select>
+        </label>
+        <label>Table
+          <select name="table" class="table-select"></select>
+        </label>
+        <label>PK <input name="pk" placeholder="e.g. 42"></label>
+        <label>Type
+          <select name="event_type">
+            <option value="">any</option>
+            <option>INSERT</option>
+            <option>UPDATE</option>
+            <option>DELETE</option>
+          </select>
+        </label>
+        <label>Changed column <input name="changed_column" placeholder="e.g. email"></label>
+        <label>GTID <input name="gtid" placeholder="uuid:1-100"></label>
+        <label>Since <input name="since" placeholder="YYYY-MM-DD HH:MM:SS"></label>
+        <label>Until <input name="until" placeholder="YYYY-MM-DD HH:MM:SS"></label>
+        <label>Limit <input name="limit" type="number" min="1" placeholder="100"></label>
+        <div class="actions">
+          <button type="submit" class="primary">Run</button>
+        </div>
+      </form>
+      <div id="events-warnings" class="warnings"></div>
+      <div id="events-result"></div>
+    </section>
+
+    <!-- ── Status ──────────────────────────────────────────────── -->
+    <section id="status" class="panel">
+      <div class="actions">
+        <button type="button" id="status-refresh" class="primary">Refresh status</button>
+      </div>
+      <div id="status-result"></div>
+    </section>
+  </main>
+
+  <div id="toast" class="toast" hidden></div>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -1,0 +1,242 @@
+:root {
+  --bg: #0f1117;
+  --panel: #171a23;
+  --panel-2: #1e222e;
+  --border: #2a2f3d;
+  --text: #d7dbe6;
+  --muted: #8b93a7;
+  --accent: #5b9dff;
+  --accent-2: #2b6fd6;
+  --ok: #4ec47a;
+  --warn: #e0b341;
+  --del: #e06c75;
+  --ins: #4ec47a;
+  --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+}
+
+header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 20px;
+  border-bottom: 1px solid var(--border);
+  background: var(--panel);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.brand { display: flex; align-items: baseline; gap: 8px; }
+.logo { font-weight: 700; font-size: 18px; letter-spacing: -0.3px; }
+.sub { color: var(--muted); font-size: 13px; }
+.readonly {
+  margin-left: 6px;
+  font-size: 11px;
+  color: var(--ok);
+  border: 1px solid var(--ok);
+  border-radius: 10px;
+  padding: 1px 8px;
+}
+
+nav#tabs { display: flex; gap: 4px; }
+.tab {
+  background: none;
+  border: none;
+  color: var(--muted);
+  padding: 16px 14px;
+  cursor: pointer;
+  font-size: 14px;
+  border-bottom: 2px solid transparent;
+}
+.tab:hover { color: var(--text); }
+.tab.active { color: var(--text); border-bottom-color: var(--accent); }
+
+main { padding: 20px; max-width: 1200px; margin: 0 auto; }
+.panel { display: none; }
+.panel.active { display: block; }
+
+.hint { color: var(--muted); margin-top: 0; max-width: 70ch; }
+
+.filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 16px;
+  align-items: flex-end;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 16px;
+}
+.filters label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--muted);
+}
+.filters input, .filters select {
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  color: var(--text);
+  border-radius: 6px;
+  padding: 7px 9px;
+  font-size: 13px;
+  min-width: 150px;
+}
+.filters input:focus, .filters select:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+.actions { display: flex; gap: 8px; align-items: flex-end; }
+
+button.primary, .preview-btn, .sql-toolbar button, #status-refresh {
+  cursor: pointer;
+  border-radius: 6px;
+  padding: 8px 14px;
+  font-size: 13px;
+  border: 1px solid var(--border);
+  background: var(--panel-2);
+  color: var(--text);
+}
+button.primary {
+  background: var(--accent-2);
+  border-color: var(--accent-2);
+  color: #fff;
+  font-weight: 600;
+}
+button.primary:hover { background: var(--accent); border-color: var(--accent); }
+.preview-btn:hover, .sql-toolbar button:hover { border-color: var(--accent); }
+
+.warnings { margin: 14px 0 0; }
+.warnings .warn-item {
+  background: rgba(224, 179, 65, 0.1);
+  border: 1px solid var(--warn);
+  color: var(--warn);
+  border-radius: 6px;
+  padding: 8px 12px;
+  margin-bottom: 8px;
+  font-size: 13px;
+}
+
+.error-box {
+  background: rgba(224, 108, 117, 0.1);
+  border: 1px solid var(--del);
+  color: var(--del);
+  border-radius: 6px;
+  padding: 10px 12px;
+  margin-top: 14px;
+  font-size: 13px;
+}
+
+table.events {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 16px;
+  font-size: 13px;
+}
+table.events th {
+  text-align: left;
+  color: var(--muted);
+  font-weight: 600;
+  border-bottom: 1px solid var(--border);
+  padding: 8px 10px;
+  position: sticky;
+  top: 53px;
+  background: var(--bg);
+}
+table.events td {
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+table.events tr.event-row { cursor: pointer; }
+table.events tr.event-row:hover td { background: var(--panel); }
+
+.badge {
+  font-size: 11px;
+  font-weight: 700;
+  border-radius: 4px;
+  padding: 1px 6px;
+}
+.badge.INSERT { color: var(--ins); border: 1px solid var(--ins); }
+.badge.UPDATE { color: var(--accent); border: 1px solid var(--accent); }
+.badge.DELETE { color: var(--del); border: 1px solid var(--del); }
+
+.detail { background: var(--panel); }
+.detail td { padding: 0; }
+.diff {
+  display: grid;
+  grid-template-columns: max-content 1fr 1fr;
+  gap: 1px;
+  background: var(--border);
+  margin: 0;
+  font-family: var(--mono);
+  font-size: 12px;
+}
+.diff > div { background: var(--panel); padding: 4px 10px; }
+.diff .dh { color: var(--muted); font-weight: 700; background: var(--panel-2); }
+.diff .col { color: var(--muted); }
+.diff .before { color: var(--del); white-space: pre-wrap; word-break: break-word; }
+.diff .after { color: var(--ins); white-space: pre-wrap; word-break: break-word; }
+.diff .changed { background: rgba(91, 157, 255, 0.07); }
+
+.meta-line { color: var(--muted); margin: 14px 0 4px; font-size: 13px; }
+
+.sql-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 18px;
+  padding-bottom: 8px;
+}
+.sql-toolbar .spacer { flex: 1; }
+#recover-meta { color: var(--muted); font-size: 13px; }
+pre#recover-sql {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 16px;
+  overflow: auto;
+  font-family: var(--mono);
+  font-size: 12.5px;
+  max-height: 60vh;
+  white-space: pre;
+}
+
+.status-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 16px; margin-top: 16px; }
+.card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 16px;
+}
+.card h3 { margin: 0 0 10px; font-size: 13px; color: var(--accent); text-transform: uppercase; letter-spacing: 0.4px; }
+.card .kv { display: flex; justify-content: space-between; gap: 12px; padding: 3px 0; border-bottom: 1px dotted var(--border); }
+.card .kv:last-child { border-bottom: none; }
+.card .kv .k { color: var(--muted); }
+.card .kv .v { font-family: var(--mono); font-size: 12.5px; }
+
+.empty { color: var(--muted); margin-top: 16px; font-style: italic; }
+
+.toast {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--panel-2);
+  border: 1px solid var(--accent);
+  color: var(--text);
+  padding: 10px 18px;
+  border-radius: 8px;
+  font-size: 13px;
+  z-index: 100;
+}

--- a/internal/console/auth.go
+++ b/internal/console/auth.go
@@ -51,7 +51,9 @@ func bearerToken(r *http.Request) string {
 }
 
 // tokenMiddleware requires a valid bearer token on every wrapped request.
-// The comparison is constant-time to avoid leaking the token via timing.
+// The comparison is constant-time for equal-length inputs (subtle returns 0
+// immediately on a length mismatch, so token *length* is not hidden — that's
+// fine here, the token is a fixed 32 hex chars).
 //
 // The token is required in the Authorization header specifically (not a
 // cookie): a browser fetch() must opt in to sending it, which keeps a

--- a/internal/console/auth.go
+++ b/internal/console/auth.go
@@ -1,0 +1,109 @@
+package console
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/hex"
+	"net"
+	"net/http"
+	"strings"
+)
+
+// generateToken returns a cryptographically random 128-bit token rendered as
+// 32 lowercase hex characters. It is used to gate the API when the operator
+// does not supply an explicit token.
+func generateToken() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// isLoopbackAddr reports whether a listen address binds only to the loopback
+// interface. An empty host or a wildcard (0.0.0.0 / ::) binds to every
+// interface and is NOT loopback — those require an explicit token.
+func isLoopbackAddr(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		// No port present; treat the whole string as the host.
+		host = addr
+	}
+	switch host {
+	case "localhost":
+		return true
+	case "", "0.0.0.0", "::":
+		return false
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+// bearerToken extracts the token from an "Authorization: Bearer <token>"
+// header. Returns "" when the header is missing or malformed.
+func bearerToken(r *http.Request) string {
+	h := r.Header.Get("Authorization")
+	const prefix = "Bearer "
+	if len(h) <= len(prefix) || !strings.EqualFold(h[:len(prefix)], prefix) {
+		return ""
+	}
+	return h[len(prefix):]
+}
+
+// tokenMiddleware requires a valid bearer token on every wrapped request.
+// The comparison is constant-time to avoid leaking the token via timing.
+//
+// The token is required in the Authorization header specifically (not a
+// cookie): a browser fetch() must opt in to sending it, which keeps a
+// cross-site form-POST from carrying ambient credentials to /api/recover.
+func (s *Server) tokenMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got := bearerToken(r)
+		if subtle.ConstantTimeCompare([]byte(got), []byte(s.token)) != 1 {
+			writeJSONError(w, http.StatusUnauthorized, "unauthorized: missing or invalid token")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// hostGuard rejects requests whose Host header is not in the allowlist. This
+// defeats DNS-rebinding: a malicious page on attacker.example whose DNS
+// rebinds to 127.0.0.1 still sends "Host: attacker.example", which is refused.
+// IP-literal and localhost Hosts are accepted because a rebinding attack needs
+// an attacker-controlled *domain name*, never a bare IP.
+func (s *Server) hostGuard(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !s.hostAllowed(r.Host) {
+			writeJSONError(w, http.StatusForbidden, "forbidden: host not allowed")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// hostAllowed reports whether the request Host header is acceptable. The host
+// is allowed when it is an IP literal, "localhost", or appears in the
+// configured allowlist (operator-supplied hostnames). Domain-name Hosts are
+// rejected.
+func (s *Server) hostAllowed(host string) bool {
+	if host == "" {
+		return false
+	}
+	h, _, err := net.SplitHostPort(host)
+	if err != nil {
+		h = host
+	}
+	if h == "" {
+		return false
+	}
+	for _, a := range s.allowedHosts {
+		if strings.EqualFold(h, a) {
+			return true
+		}
+	}
+	if strings.EqualFold(h, "localhost") {
+		return true
+	}
+	return net.ParseIP(h) != nil
+}

--- a/internal/console/auth_test.go
+++ b/internal/console/auth_test.go
@@ -1,0 +1,144 @@
+package console
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGenerateToken(t *testing.T) {
+	a, err := generateToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(a) != 32 {
+		t.Errorf("token length = %d, want 32 hex chars", len(a))
+	}
+	b, _ := generateToken()
+	if a == b {
+		t.Error("two generated tokens should differ")
+	}
+}
+
+func TestIsLoopbackAddr(t *testing.T) {
+	cases := map[string]bool{
+		"127.0.0.1:8090":   true,
+		"localhost:8090":   true,
+		"[::1]:8090":       true,
+		"127.0.0.1":        true,
+		"0.0.0.0:8090":     false,
+		":8090":            false,
+		"192.168.1.5:8090": false,
+		"[::]:8090":        false,
+		"example.com:8090": false,
+	}
+	for addr, want := range cases {
+		if got := isLoopbackAddr(addr); got != want {
+			t.Errorf("isLoopbackAddr(%q) = %v, want %v", addr, got, want)
+		}
+	}
+}
+
+// TestNewTokenPolicy verifies the bind/token security policy: non-loopback
+// binds demand an explicit token; loopback binds auto-generate one.
+func TestNewTokenPolicy(t *testing.T) {
+	if _, err := New(Config{Listen: "0.0.0.0:8090"}); err == nil {
+		t.Error("non-loopback bind without a token should be refused")
+	}
+
+	srv, err := New(Config{Listen: "127.0.0.1:8090"})
+	if err != nil {
+		t.Fatalf("loopback bind: %v", err)
+	}
+	if srv.Token() == "" {
+		t.Error("loopback bind should auto-generate a token")
+	}
+
+	srv2, err := New(Config{Listen: "0.0.0.0:9000", Token: "explicit-token"})
+	if err != nil {
+		t.Fatalf("non-loopback bind with token: %v", err)
+	}
+	if srv2.Token() != "explicit-token" {
+		t.Errorf("Token() = %q, want explicit-token", srv2.Token())
+	}
+}
+
+func TestTokenMiddleware(t *testing.T) {
+	srv := &Server{token: "secret"}
+	pass := func() (http.Handler, *bool) {
+		called := false
+		h := srv.tokenMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		return h, &called
+	}
+
+	t.Run("valid token passes", func(t *testing.T) {
+		h, called := pass()
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/api/x", nil)
+		req.Header.Set("Authorization", "Bearer secret")
+		h.ServeHTTP(rec, req)
+		if !*called || rec.Code != http.StatusNoContent {
+			t.Errorf("called=%v code=%d, want true/204", *called, rec.Code)
+		}
+	})
+
+	for _, tc := range []struct{ name, auth string }{
+		{"missing header", ""},
+		{"wrong token", "Bearer nope"},
+		{"not bearer", "secret"},
+	} {
+		t.Run(tc.name+" is rejected", func(t *testing.T) {
+			h, called := pass()
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest("GET", "/api/x", nil)
+			if tc.auth != "" {
+				req.Header.Set("Authorization", tc.auth)
+			}
+			h.ServeHTTP(rec, req)
+			if *called || rec.Code != http.StatusUnauthorized {
+				t.Errorf("called=%v code=%d, want false/401", *called, rec.Code)
+			}
+		})
+	}
+}
+
+func TestHostGuard(t *testing.T) {
+	srv := &Server{}
+	h := srv.hostGuard(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	cases := map[string]int{
+		"127.0.0.1:8090":    http.StatusNoContent,
+		"localhost:8090":    http.StatusNoContent,
+		"[::1]:8090":        http.StatusNoContent,
+		"evil.example:8090": http.StatusForbidden, // DNS-rebinding domain
+		"attacker.com":      http.StatusForbidden,
+		"":                  http.StatusForbidden,
+	}
+	for host, want := range cases {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Host = host
+		h.ServeHTTP(rec, req)
+		if rec.Code != want {
+			t.Errorf("hostGuard Host=%q code = %d, want %d", host, rec.Code, want)
+		}
+	}
+}
+
+func TestHostGuardAllowlist(t *testing.T) {
+	srv := &Server{allowedHosts: []string{"console.internal"}}
+	h := srv.hostGuard(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Host = "console.internal:8090"
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("allowlisted host code = %d, want 204", rec.Code)
+	}
+}

--- a/internal/console/console_integration_test.go
+++ b/internal/console/console_integration_test.go
@@ -155,6 +155,33 @@ func TestIntegrationRecoverMatchesGenerator(t *testing.T) {
 	}
 }
 
+// TestIntegrationRecoverWithTimeRangeSurfacesGap exercises the planner-active
+// recover path. testutil.InitIndexTables creates only the p_future partition,
+// so loadLivePartitionHours is empty and every hour in a bounded query range is
+// classified as a gap. Recover must still SUCCEED (200) with the undo
+// statements and surface the gap as a warning — never hard-fail. This locks in
+// AllowGaps=true for recover: a former AllowGaps=false would have returned 422
+// here, diverging from the CLI `recover` the issue requires it to match.
+func TestIntegrationRecoverWithTimeRangeSurfacesGap(t *testing.T) {
+	srv, _ := seedConsoleData(t)
+
+	body := `{"schema":"app","table":"users","since":"2026-06-01 00:00:00","until":"2026-06-02 00:00:00"}`
+	rec, raw := doReq(t, srv, "POST", "/api/recover", body)
+	if rec.Code != 200 {
+		t.Fatalf("recover with time range code = %d, body = %s", rec.Code, raw)
+	}
+	var resp recoverResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatementCount != 2 {
+		t.Errorf("statement_count = %d, want 2 (undo still generated despite gap)", resp.StatementCount)
+	}
+	if len(resp.Warnings) == 0 {
+		t.Error("expected a coverage-gap warning (only p_future exists, so the bounded range is all gap)")
+	}
+}
+
 // statements extracts the executable SQL lines (ignoring comments, blanks, and
 // the BEGIN/COMMIT wrapper) so two scripts can be compared without their
 // timestamped header comment.

--- a/internal/console/console_integration_test.go
+++ b/internal/console/console_integration_test.go
@@ -182,6 +182,52 @@ func TestIntegrationRecoverWithTimeRangeSurfacesGap(t *testing.T) {
 	}
 }
 
+// TestIntegrationProfileRBAC verifies end-to-end that profile RBAC rules are
+// enforced on the console's events surface: a denied table never appears, and a
+// redacted column's value is nulled while its siblings remain. It also confirms
+// New forces NoArchive when RBAC rules are present (archives don't apply RBAC).
+func TestIntegrationProfileRBAC(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	testutil.InsertEvent(t, db, "bin.000001", 4, 40, "2026-06-01 12:00:00", nil,
+		"app", "users", 1 /*INSERT*/, "1",
+		nil, nil, []byte(`{"id":1,"email":"alice@x","ssn":"111-22-3333"}`))
+	testutil.InsertEvent(t, db, "bin.000001", 40, 80, "2026-06-01 12:01:00", nil,
+		"app", "secrets", 1 /*INSERT*/, "1",
+		nil, nil, []byte(`{"id":1,"value":"topsecret"}`))
+
+	srv, err := New(Config{
+		DB:            db,
+		DBName:        dbName,
+		Listen:        "127.0.0.1:8090",
+		Token:         intToken,
+		DenyTables:    []query.SchemaTable{{Schema: "app", Table: "secrets"}},
+		RedactColumns: []query.SchemaTableColumn{{Schema: "app", Table: "users", Column: "ssn"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !srv.noArchive {
+		t.Error("New must force noArchive when RBAC rules are present (archives don't enforce RBAC)")
+	}
+
+	// Denied table: querying it returns nothing and never leaks its data.
+	_, body := doReq(t, srv, "GET", "/api/events?schema=app&table=secrets", "")
+	if strings.Contains(string(body), "topsecret") {
+		t.Errorf("denied table app.secrets leaked into the events response: %s", body)
+	}
+
+	// Redacted column nulled; non-redacted sibling still present.
+	_, body = doReq(t, srv, "GET", "/api/events?schema=app&table=users", "")
+	if strings.Contains(string(body), "111-22-3333") {
+		t.Errorf("redacted column ssn leaked: %s", body)
+	}
+	if !strings.Contains(string(body), "alice@x") {
+		t.Errorf("non-redacted column email should remain present: %s", body)
+	}
+}
+
 // statements extracts the executable SQL lines (ignoring comments, blanks, and
 // the BEGIN/COMMIT wrapper) so two scripts can be compared without their
 // timestamped header comment.

--- a/internal/console/console_integration_test.go
+++ b/internal/console/console_integration_test.go
@@ -1,0 +1,192 @@
+//go:build integration
+
+package console
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/bintrail/internal/query"
+	"github.com/dbtrail/bintrail/internal/recovery"
+	"github.com/dbtrail/bintrail/internal/testutil"
+)
+
+const intToken = "integration-token"
+
+func seedConsoleData(t *testing.T) (*Server, string) {
+	t.Helper()
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	// INSERT then UPDATE on app.users pk=1.
+	testutil.InsertEvent(t, db, "bin.000001", 4, 40, "2026-06-01 12:00:00", nil,
+		"app", "users", 1 /*INSERT*/, "1",
+		nil, nil, []byte(`{"id":1,"name":"alice"}`))
+	testutil.InsertEvent(t, db, "bin.000001", 40, 80, "2026-06-01 12:05:00", nil,
+		"app", "users", 2 /*UPDATE*/, "1",
+		[]byte(`["name"]`), []byte(`{"id":1,"name":"alice"}`), []byte(`{"id":1,"name":"alicia"}`))
+
+	srv, err := New(Config{
+		DB:        db,
+		DBName:    dbName,
+		Listen:    "127.0.0.1:8090",
+		Token:     intToken,
+		NoArchive: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return srv, dbName
+}
+
+func doReq(t *testing.T, srv *Server, method, path, body string) (*httptest.ResponseRecorder, []byte) {
+	t.Helper()
+	var r io.Reader
+	if body != "" {
+		r = strings.NewReader(body)
+	}
+	req := httptest.NewRequest(method, "http://127.0.0.1:8090"+path, r)
+	req.Host = "127.0.0.1:8090"
+	req.Header.Set("Authorization", "Bearer "+intToken)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	return rec, rec.Body.Bytes()
+}
+
+func TestIntegrationEventsAPI(t *testing.T) {
+	srv, _ := seedConsoleData(t)
+
+	rec, body := doReq(t, srv, "GET", "/api/events?schema=app&table=users", "")
+	if rec.Code != 200 {
+		t.Fatalf("events code = %d, body = %s", rec.Code, body)
+	}
+	if strings.Contains(string(body), "connection_id") {
+		t.Errorf("events response must not contain connection_id: %s", body)
+	}
+	var resp eventsResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Count != 2 {
+		t.Errorf("event count = %d, want 2", resp.Count)
+	}
+}
+
+func TestIntegrationSchemasAPI(t *testing.T) {
+	srv, _ := seedConsoleData(t)
+
+	_, body := doReq(t, srv, "GET", "/api/schemas", "")
+	var sr schemasResponse
+	if err := json.Unmarshal(body, &sr); err != nil {
+		t.Fatal(err)
+	}
+	if !contains(sr.Schemas, "app") {
+		t.Errorf("schemas = %v, want to include app", sr.Schemas)
+	}
+
+	_, body = doReq(t, srv, "GET", "/api/schemas?schema=app", "")
+	var tr tablesResponse
+	if err := json.Unmarshal(body, &tr); err != nil {
+		t.Fatal(err)
+	}
+	if !contains(tr.Tables, "users") {
+		t.Errorf("tables = %v, want to include users", tr.Tables)
+	}
+}
+
+func TestIntegrationStatusAPI(t *testing.T) {
+	srv, _ := seedConsoleData(t)
+	rec, body := doReq(t, srv, "GET", "/api/status", "")
+	if rec.Code != 200 {
+		t.Fatalf("status code = %d, body = %s", rec.Code, body)
+	}
+	var generic map[string]any
+	if err := json.Unmarshal(body, &generic); err != nil {
+		t.Fatalf("status is not valid JSON: %v", err)
+	}
+}
+
+// TestIntegrationRecoverMatchesGenerator is the issue's manual check, automated:
+// the console's undo SQL must match what the recovery generator produces for
+// the same filters.
+func TestIntegrationRecoverMatchesGenerator(t *testing.T) {
+	srv, _ := seedConsoleData(t)
+
+	rec, body := doReq(t, srv, "POST", "/api/recover", `{"schema":"app","table":"users"}`)
+	if rec.Code != 200 {
+		t.Fatalf("recover code = %d, body = %s", rec.Code, body)
+	}
+	var resp recoverResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatementCount != 2 {
+		t.Errorf("statement_count = %d, want 2", resp.StatementCount)
+	}
+	// Order correctness: the newest event (the UPDATE) must be undone first,
+	// then the INSERT. This anchors the fix for the DESC-vs-ASC ordering bug —
+	// a buggy DESC fetch would invert these two statements.
+	stmts := statements(resp.SQL)
+	if len(stmts) != 2 {
+		t.Fatalf("expected 2 undo statements, got %d: %v", len(stmts), stmts)
+	}
+	if !strings.HasPrefix(stmts[0], "UPDATE") {
+		t.Errorf("first undo statement should reverse the newest (UPDATE) event, got: %s", stmts[0])
+	}
+	if !strings.HasPrefix(stmts[1], "DELETE") {
+		t.Errorf("second undo statement should reverse the INSERT event, got: %s", stmts[1])
+	}
+
+	// Equivalence with the generator. Recovery always fetches oldest-first
+	// (ASC, the zero value), which is exactly what the console forces for the
+	// recover path — so the two scripts must match statement-for-statement.
+	var buf bytes.Buffer
+	opts := query.Options{Schema: "app", Table: "users", Order: "", Limit: recoverDefaultLimit}
+	if _, err := recovery.New(srv.db, srv.resolver).GenerateSQL(context.Background(), opts, &buf); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := stmts, statements(buf.String()); !equalStrings(got, want) {
+		t.Errorf("console recover SQL differs from generator:\nconsole: %v\ngenerator: %v", got, want)
+	}
+}
+
+// statements extracts the executable SQL lines (ignoring comments, blanks, and
+// the BEGIN/COMMIT wrapper) so two scripts can be compared without their
+// timestamped header comment.
+func statements(sql string) []string {
+	var out []string
+	for _, line := range strings.Split(sql, "\n") {
+		l := strings.TrimSpace(line)
+		if l == "" || strings.HasPrefix(l, "--") || l == "BEGIN;" || l == "COMMIT;" {
+			continue
+		}
+		out = append(out, l)
+	}
+	return out
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func contains(s []string, v string) bool {
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/console/dto.go
+++ b/internal/console/dto.go
@@ -1,0 +1,84 @@
+package console
+
+import (
+	"github.com/dbtrail/bintrail/internal/parser"
+	"github.com/dbtrail/bintrail/internal/query"
+)
+
+// consoleTSFormat is the timestamp layout used in API responses. It matches
+// the MySQL datetime format accepted by cliutil.ParseTime, so a timestamp
+// rendered here round-trips back into a filter unchanged.
+const consoleTSFormat = "2006-01-02 15:04:05"
+
+// eventDTO is the JSON-serialisable view of a query.ResultRow exposed by the
+// console's read-only API.
+//
+// It deliberately OMITS connection_id. That field — the MySQL pseudo_thread_id
+// of the transaction that produced the change — is actor-attribution data and
+// belongs to the paid "forensics" surface (who-changed / audit), not the free
+// "query_explorer" surface this console exposes. The omission is the entire
+// open-core boundary for the events API: query.ResultRow carries ConnectionID,
+// the package's own jsonRow serialises it, but this DTO drops it on the way out.
+// Do not add it here without crossing the licensing line.
+type eventDTO struct {
+	EventID        uint64         `json:"event_id"`
+	BinlogFile     string         `json:"binlog_file"`
+	StartPos       uint64         `json:"start_pos"`
+	EndPos         uint64         `json:"end_pos"`
+	EventTimestamp string         `json:"event_timestamp"`
+	GTID           *string        `json:"gtid"`
+	SchemaName     string         `json:"schema_name"`
+	TableName      string         `json:"table_name"`
+	EventType      string         `json:"event_type"`
+	PKValues       string         `json:"pk_values"`
+	ChangedColumns []string       `json:"changed_columns"`
+	RowBefore      map[string]any `json:"row_before"`
+	RowAfter       map[string]any `json:"row_after"`
+}
+
+// toEventDTO maps a query.ResultRow to the redacted wire view, dropping
+// connection_id and stringifying the event type and timestamp.
+func toEventDTO(r query.ResultRow) eventDTO {
+	return eventDTO{
+		EventID:        r.EventID,
+		BinlogFile:     r.BinlogFile,
+		StartPos:       r.StartPos,
+		EndPos:         r.EndPos,
+		EventTimestamp: r.EventTimestamp.Format(consoleTSFormat),
+		GTID:           r.GTID,
+		SchemaName:     r.SchemaName,
+		TableName:      r.TableName,
+		EventType:      eventTypeName(r.EventType),
+		PKValues:       r.PKValues,
+		ChangedColumns: r.ChangedColumns,
+		RowBefore:      r.RowBefore,
+		RowAfter:       r.RowAfter,
+	}
+}
+
+// toEventDTOs maps a slice of result rows. The returned slice is non-nil even
+// when rows is empty, so the JSON encodes as [] rather than null.
+func toEventDTOs(rows []query.ResultRow) []eventDTO {
+	out := make([]eventDTO, len(rows))
+	for i, r := range rows {
+		out[i] = toEventDTO(r)
+	}
+	return out
+}
+
+// eventTypeName renders a parser.EventType as its canonical SQL keyword,
+// matching the strings used elsewhere in the codebase (query, recovery).
+func eventTypeName(et parser.EventType) string {
+	switch et {
+	case parser.EventInsert:
+		return "INSERT"
+	case parser.EventUpdate:
+		return "UPDATE"
+	case parser.EventDelete:
+		return "DELETE"
+	case parser.EventSnapshot:
+		return "SNAPSHOT"
+	default:
+		return "UNKNOWN"
+	}
+}

--- a/internal/console/dto_test.go
+++ b/internal/console/dto_test.go
@@ -2,6 +2,8 @@ package console
 
 import (
 	"encoding/json"
+	"reflect"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -79,5 +81,45 @@ func TestEventTypeName(t *testing.T) {
 func TestToEventDTOsNonNil(t *testing.T) {
 	if got := toEventDTOs(nil); got == nil {
 		t.Error("toEventDTOs(nil) should return a non-nil empty slice (JSON []), got nil")
+	}
+}
+
+// TestEventDTOFieldAllowlist guards the open-core boundary as an allowlist
+// rather than a denylist: it pins the EXACT set of JSON keys the events surface
+// may expose. A new field added to eventDTO (or a future sensitive field on
+// query.ResultRow copied through toEventDTO) fails this test until the allowlist
+// is consciously updated — catching a leak that name-specific checks would miss.
+func TestEventDTOFieldAllowlist(t *testing.T) {
+	cid := uint32(1)
+	gtid := "g:1"
+	dto := toEventDTO(query.ResultRow{
+		GTID:           &gtid,
+		ConnectionID:   &cid,
+		ChangedColumns: []string{"a"},
+		RowBefore:      map[string]any{"a": 1},
+		RowAfter:       map[string]any{"a": 2},
+	})
+	b, err := json.Marshal(dto)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatal(err)
+	}
+	got := make([]string, 0, len(m))
+	for k := range m {
+		got = append(got, k)
+	}
+	sort.Strings(got)
+
+	want := []string{
+		"binlog_file", "changed_columns", "end_pos", "event_id",
+		"event_timestamp", "event_type", "gtid", "pk_values",
+		"row_after", "row_before", "schema_name", "start_pos", "table_name",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("eventDTO JSON keys = %v\nwant exactly %v\n"+
+			"(a new key here may cross the free/paid boundary — add it to the allowlist only on purpose)", got, want)
 	}
 }

--- a/internal/console/dto_test.go
+++ b/internal/console/dto_test.go
@@ -1,0 +1,83 @@
+package console
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/bintrail/internal/parser"
+	"github.com/dbtrail/bintrail/internal/query"
+)
+
+// TestEventDTOOmitsConnectionID is the load-bearing open-core test: the events
+// API must never expose connection_id (actor attribution = paid forensics).
+func TestEventDTOOmitsConnectionID(t *testing.T) {
+	cid := uint32(98765)
+	gtid := "uuid:1-10"
+	row := query.ResultRow{
+		EventID:        1,
+		EventTimestamp: time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC),
+		GTID:           &gtid,
+		ConnectionID:   &cid, // present on the source row…
+		SchemaName:     "app",
+		TableName:      "users",
+		EventType:      parser.EventUpdate,
+		PKValues:       "42",
+		ChangedColumns: []string{"email"},
+		RowBefore:      map[string]any{"email": "a@x"},
+		RowAfter:       map[string]any{"email": "b@x"},
+	}
+
+	b, err := json.Marshal(toEventDTO(row))
+	if err != nil {
+		t.Fatal(err)
+	}
+	js := string(b)
+
+	// …but must NOT cross into the redacted wire view.
+	if strings.Contains(js, "connection_id") {
+		t.Errorf("eventDTO JSON must not contain connection_id key: %s", js)
+	}
+	if strings.Contains(js, "98765") {
+		t.Errorf("eventDTO JSON must not leak the connection id value: %s", js)
+	}
+
+	for _, want := range []string{
+		"event_id", "schema_name", "table_name", "event_type",
+		"pk_values", "changed_columns", "row_before", "row_after", "gtid",
+	} {
+		if !strings.Contains(js, want) {
+			t.Errorf("eventDTO JSON missing expected field %q: %s", want, js)
+		}
+	}
+
+	dto := toEventDTO(row)
+	if dto.EventType != "UPDATE" {
+		t.Errorf("EventType = %q, want UPDATE", dto.EventType)
+	}
+	if dto.EventTimestamp != "2026-01-02 03:04:05" {
+		t.Errorf("EventTimestamp = %q, want 2026-01-02 03:04:05", dto.EventTimestamp)
+	}
+}
+
+func TestEventTypeName(t *testing.T) {
+	cases := map[parser.EventType]string{
+		parser.EventInsert:   "INSERT",
+		parser.EventUpdate:   "UPDATE",
+		parser.EventDelete:   "DELETE",
+		parser.EventSnapshot: "SNAPSHOT",
+		parser.EventDDL:      "UNKNOWN",
+	}
+	for et, want := range cases {
+		if got := eventTypeName(et); got != want {
+			t.Errorf("eventTypeName(%d) = %q, want %q", et, got, want)
+		}
+	}
+}
+
+func TestToEventDTOsNonNil(t *testing.T) {
+	if got := toEventDTOs(nil); got == nil {
+		t.Error("toEventDTOs(nil) should return a non-nil empty slice (JSON []), got nil")
+	}
+}

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -1,0 +1,201 @@
+// Package console serves an embedded, read-only, single-operator web UI over a
+// bintrail index. It is the MCP server with a web face: the same query,
+// recovery, status, and metadata engines, reached over HTTP from a browser.
+//
+// The console exposes only the free query_explorer surface — event browsing and
+// recovery-SQL generation. It deliberately stays out of the paid forensics
+// surface: see dto.go, where connection_id (actor attribution) is dropped on the
+// way out. No endpoint ever executes SQL; recover generates a script for the
+// operator to review and apply by hand.
+package console
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/dbtrail/bintrail/internal/metadata"
+	"github.com/dbtrail/bintrail/internal/query"
+)
+
+// Config configures a console Server. The caller (cmd/bintrail/console.go) is
+// responsible for connecting the DB, running EnsureSchema, and resolving the
+// profile's RBAC rules before constructing the server.
+type Config struct {
+	// DB is the index database. Required for a functional server; may be nil
+	// in unit tests that exercise only middleware/asset routes.
+	DB *sql.DB
+	// DBName is the index database name (from the DSN), used by the query
+	// planner and status collection.
+	DBName string
+	// Listen is the bind address (host:port). Default 127.0.0.1:8090.
+	Listen string
+	// Token gates the API. When empty and Listen is loopback, a random token
+	// is generated. When empty and Listen is non-loopback, New returns an
+	// error — exposing an unauthenticated console off-host is refused.
+	Token string
+	// NoArchive disables Parquet archive auto-discovery. The caller forces
+	// this true when a profile is active (archives do not enforce RBAC).
+	NoArchive bool
+	// DenyTables and RedactColumns are the resolved profile RBAC rules,
+	// applied to every query the console runs.
+	DenyTables    []query.SchemaTable
+	RedactColumns []query.SchemaTableColumn
+	// AllowedHosts is an optional allowlist of hostnames accepted in the Host
+	// header (in addition to IP literals and localhost), for operators who
+	// front the console with a DNS name.
+	AllowedHosts []string
+}
+
+// Server is a configured, ready-to-run console HTTP server.
+type Server struct {
+	db           *sql.DB
+	dbName       string
+	listen       string
+	token        string
+	noArchive    bool
+	denyTables   []query.SchemaTable
+	redactCols   []query.SchemaTableColumn
+	engine       *query.Engine
+	resolver     *metadata.Resolver
+	allowedHosts []string
+	mux          http.Handler
+}
+
+// New validates the config, loads the schema resolver, and assembles the
+// middleware/route tree. It does no network I/O — call Run to listen.
+func New(cfg Config) (*Server, error) {
+	listen := cfg.Listen
+	if listen == "" {
+		listen = "127.0.0.1:8090"
+	}
+
+	token := cfg.Token
+	if token == "" {
+		if !isLoopbackAddr(listen) {
+			return nil, fmt.Errorf("a token is required when binding to a non-loopback address %q: set --token or BINTRAIL_CONSOLE_TOKEN", listen)
+		}
+		t, err := generateToken()
+		if err != nil {
+			return nil, fmt.Errorf("generate token: %w", err)
+		}
+		token = t
+	}
+
+	s := &Server{
+		db:           cfg.DB,
+		dbName:       cfg.DBName,
+		listen:       listen,
+		token:        token,
+		noArchive:    cfg.NoArchive,
+		denyTables:   cfg.DenyTables,
+		redactCols:   cfg.RedactColumns,
+		engine:       query.New(cfg.DB),
+		allowedHosts: cfg.AllowedHosts,
+	}
+
+	// Load the latest schema snapshot for recovery WHERE-clause generation.
+	// Best-effort: a missing snapshot just means recovery falls back to
+	// all-column WHERE clauses, which is correct (if more verbose).
+	if cfg.DB != nil {
+		r, err := metadata.NewResolver(cfg.DB, 0)
+		switch {
+		case err == nil:
+			s.resolver = r
+		case errors.Is(err, metadata.ErrNoSnapshots):
+			slog.Debug("console: no schema snapshots; recovery will use all-column WHERE clauses")
+		default:
+			slog.Warn("console: failed to load schema resolver; recovery will use all-column WHERE clauses", "error", err)
+		}
+	}
+
+	s.mux = s.buildHandler()
+	return s, nil
+}
+
+// buildHandler wires the route tree and middleware chain:
+//   - host guard on EVERY request (DNS-rebinding defense)
+//   - the static shell and assets are served without a token, so a browser
+//     can load the page and read its bootstrap token from the URL
+//   - every /api/* route except healthz requires a bearer token
+func (s *Server) buildHandler() http.Handler {
+	api := http.NewServeMux()
+	api.HandleFunc("GET /api/status", s.handleStatus)
+	api.HandleFunc("GET /api/schemas", s.handleSchemas)
+	api.HandleFunc("GET /api/events", s.handleEvents)
+	api.HandleFunc("POST /api/recover", s.handleRecover)
+
+	root := http.NewServeMux()
+	root.HandleFunc("GET /api/healthz", s.handleHealthz) // unauthenticated liveness
+	root.Handle("/api/", s.tokenMiddleware(api))         // token on all other /api/*
+	root.Handle("/", assetHandler())                     // static shell + assets
+
+	return s.hostGuard(root)
+}
+
+// Handler returns the fully assembled HTTP handler. Exposed for tests.
+func (s *Server) Handler() http.Handler { return s.mux }
+
+// Token returns the active access token (supplied or generated).
+func (s *Server) Token() string { return s.token }
+
+// URL returns the jupyter-style bootstrap URL, including the token, that the
+// operator opens in a browser.
+func (s *Server) URL() string {
+	return fmt.Sprintf("http://%s/?token=%s", displayHost(s.listen), s.token)
+}
+
+// Run starts the HTTP server and blocks until ctx is cancelled, then shuts the
+// server down gracefully (5s drain). Returns the listen error, or nil on a
+// clean shutdown.
+func (s *Server) Run(ctx context.Context) error {
+	srv := &http.Server{
+		Addr:              s.listen,
+		Handler:           s.mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
+			return
+		}
+		errCh <- nil
+	}()
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		shutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		return srv.Shutdown(shutCtx)
+	}
+}
+
+// displayHost turns a bind address into a browser-reachable host:port,
+// rewriting wildcard binds to a concrete loopback address and bracketing IPv6.
+func displayHost(listen string) string {
+	host, port, err := net.SplitHostPort(listen)
+	if err != nil {
+		return listen
+	}
+	switch host {
+	case "", "0.0.0.0":
+		host = "127.0.0.1"
+	case "::":
+		host = "[::1]"
+	default:
+		if ip := net.ParseIP(host); ip != nil && strings.Contains(host, ":") {
+			host = "[" + host + "]" // bracket IPv6 literals
+		}
+	}
+	return host + ":" + port
+}

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -100,6 +100,16 @@ func New(cfg Config) (*Server, error) {
 		allowedHosts: cfg.AllowedHosts,
 	}
 
+	// Safety coupling enforced here so it holds for every caller, not just the
+	// CLI: Parquet archives do not apply RBAC rules, so the presence of any
+	// deny-table / redact-column rule must also disable archive auto-discovery
+	// — otherwise redacted data could leak in from archives. cmd/bintrail also
+	// sets NoArchive when a profile is active; this makes the invariant
+	// structural rather than caller-dependent.
+	if len(s.denyTables) > 0 || len(s.redactCols) > 0 {
+		s.noArchive = true
+	}
+
 	// Load the latest schema snapshot for recovery WHERE-clause generation.
 	// Best-effort: a missing snapshot just means recovery falls back to
 	// all-column WHERE clauses, which is correct (if more verbose).

--- a/internal/console/server_test.go
+++ b/internal/console/server_test.go
@@ -40,6 +40,17 @@ func TestMuxAPIRequiresToken(t *testing.T) {
 			t.Errorf("%s without token: code = %d, want 401", path, rec.Code)
 		}
 	}
+
+	// POST /api/recover must also require the token — the bearer-header
+	// requirement exists specifically to stop a cross-site form POST from
+	// reaching it with ambient credentials (see auth.go).
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "http://127.0.0.1:8090/api/recover",
+		strings.NewReader(`{"schema":"app"}`))
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != 401 {
+		t.Errorf("POST /api/recover without token: code = %d, want 401", rec.Code)
+	}
 }
 
 func TestMuxServesAssets(t *testing.T) {
@@ -89,9 +100,11 @@ func TestURLContainsToken(t *testing.T) {
 
 func TestDisplayHostRewritesWildcard(t *testing.T) {
 	cases := map[string]string{
-		"0.0.0.0:8090":   "127.0.0.1:8090",
-		"127.0.0.1:8090": "127.0.0.1:8090",
-		"::":             "::", // no port → returned as-is
+		"0.0.0.0:8090":      "127.0.0.1:8090",
+		"127.0.0.1:8090":    "127.0.0.1:8090",
+		"[::]:8090":         "[::1]:8090",        // wildcard IPv6 → loopback
+		"[2001:db8::1]:443": "[2001:db8::1]:443", // IPv6 literal kept, bracketed
+		"::":                "::",                // no port → returned as-is
 	}
 	for in, want := range cases {
 		if got := displayHost(in); got != want {

--- a/internal/console/server_test.go
+++ b/internal/console/server_test.go
@@ -1,0 +1,101 @@
+package console
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newTestServer(t *testing.T) *Server {
+	t.Helper()
+	// DB is nil: these tests exercise routing/middleware/assets only, never a
+	// data handler.
+	srv, err := New(Config{Listen: "127.0.0.1:8090", Token: "secret"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return srv
+}
+
+func TestMuxHealthzUnauthenticated(t *testing.T) {
+	srv := newTestServer(t)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "http://127.0.0.1:8090/api/healthz", nil)
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != 200 {
+		t.Errorf("healthz code = %d, want 200 (no token required)", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "ok") {
+		t.Errorf("healthz body = %q", rec.Body.String())
+	}
+}
+
+func TestMuxAPIRequiresToken(t *testing.T) {
+	srv := newTestServer(t)
+	for _, path := range []string{"/api/status", "/api/events", "/api/schemas"} {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "http://127.0.0.1:8090"+path, nil)
+		srv.Handler().ServeHTTP(rec, req)
+		if rec.Code != 401 {
+			t.Errorf("%s without token: code = %d, want 401", path, rec.Code)
+		}
+	}
+}
+
+func TestMuxServesAssets(t *testing.T) {
+	srv := newTestServer(t)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "http://127.0.0.1:8090/", nil)
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("/ code = %d, want 200", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "bintrail console") {
+		t.Error("index.html (with 'bintrail console') was not served at /")
+	}
+}
+
+func TestMuxRejectsForeignHost(t *testing.T) {
+	srv := newTestServer(t)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "http://127.0.0.1:8090/", nil)
+	req.Host = "attacker.example" // DNS-rebinding attempt
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != 403 {
+		t.Errorf("foreign Host code = %d, want 403", rec.Code)
+	}
+}
+
+func TestMuxNoCORSHeaders(t *testing.T) {
+	srv := newTestServer(t)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "http://127.0.0.1:8090/api/healthz", nil)
+	srv.Handler().ServeHTTP(rec, req)
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want empty (no CORS)", got)
+	}
+}
+
+func TestURLContainsToken(t *testing.T) {
+	srv, err := New(Config{Listen: "127.0.0.1:8090", Token: "abc123"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "http://127.0.0.1:8090/?token=abc123"
+	if srv.URL() != want {
+		t.Errorf("URL() = %q, want %q", srv.URL(), want)
+	}
+}
+
+func TestDisplayHostRewritesWildcard(t *testing.T) {
+	cases := map[string]string{
+		"0.0.0.0:8090":   "127.0.0.1:8090",
+		"127.0.0.1:8090": "127.0.0.1:8090",
+		"::":             "::", // no port → returned as-is
+	}
+	for in, want := range cases {
+		if got := displayHost(in); got != want {
+			t.Errorf("displayHost(%q) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
closes #371

## Summary
Adds `bintrail console` — an embedded, **read-only, single-operator** web UI over the index. It's the MCP server with a web face: the same `query` / `recovery` / `status` / `metadata` engines, reached from a browser. Browse indexed row events with full before/after diffs, and generate recovery (undo) SQL. **No endpoint ever executes SQL.**

- **`internal/console/`** — `server.go` (Config/New/Run + middleware chain), `api.go` (JSON handlers), `auth.go` (token + host guard), `dto.go` (redacting event DTO), `assets.go` + `assets/` (`//go:embed` vanilla-JS frontend, **zero deps, no Node build**).
- **`cmd/bintrail/console.go`** — cobra command; `config.go` template entry; `docs/console.md`; `CLAUDE.md`.
- Purely additive: a new command + package consuming existing engines. The only edits to existing code are the `config.go` env template and a documented exception in `config_test.go`; `envload.go` is untouched.

## Open-core boundary
Exposes only the free **`query_explorer`** surface (event query + recovery-SQL). `eventDTO` **omits `connection_id`** — actor attribution belongs to the paid **`forensics`** surface. No gating/RBAC/license code in the binary; the boundary is simply what the API serves.

## Security
- Loopback default + auto-generated token (jupyter-style URL); **non-loopback bind requires an explicit `--token`** or refuses to start.
- Token via `Authorization: Bearer` with `subtle.ConstantTimeCompare`; `/api/*` gated except `/api/healthz`; static shell loads tokenless (bootstraps token from the URL).
- **No CORS**; **Host-header allowlist** defeats DNS-rebinding (IP literals + localhost + optional `--allowed-hosts`).
- Result caps never unlimited (events 100/1000, recover 1000/10000).
- A `--profile` forces `--no-archive` (Parquet archives don't enforce RBAC).
- **recover** forces ASC fetch order so the undo reverses newest-first (a PK touched by multiple UPDATEs is rolled back correctly). Coverage gaps are returned as response `warnings` and rendered in the recover UI (matching `bintrail recover --dry-run`), so incomplete coverage is flagged rather than silently presented as complete.

## Review
Built with a recon pass (verify every reuse signature) → implement → adversarial multi-agent review (security / bugs / silent-failures / conventions, each finding independently verified). Five confirmed findings were fixed (undo-order bug, status buffering, `--allowed-hosts` wiring, frontend error surfacing, and an initial recover gap-handling change). A follow-up advisor pass caught that the gap-handling change (hard-failing recover on planner gaps) diverged from the CLI and regressed the visible-warning path; it was reverted to `AllowGaps=true` and the planner-active recover path is now covered by a test.

### Known limitation (pre-existing, shared with CLI `recover` + MCP)
When multiple Parquet archive sources are configured and only *some* fail to load, `query.FetchMerged` logs the failure server-side and continues; it exposes no per-source failure signal, so the browser can't surface it. Documented in `docs/console.md`. Fully closing it needs a `FetchMerged` signature change (affects recover/reconstruct/shim/MCP) — out of scope for this MVP, candidate follow-up.

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] Integration tests pass (`go test -tags integration ./internal/console/...`, Docker MySQL :13306) — events/schemas/status APIs, recover read-only via sqlmock, DTO redaction, host/token guards, recover SQL equivalence + newest-first ordering vs the `recovery` generator, and planner-active recover surfacing a gap as a warning (200, not a hard fail)
- [x] `make build` green (CGO, no Node; `//go:embed` compiles and serves)
- [x] gofmt + go vet clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)