### PR TITLE
fix(console): persist token in sessionStorage so a reload doesn't 401

### DIFF
--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -2,11 +2,18 @@
 
 // ── token bootstrap ────────────────────────────────────────────────────────
 // The page itself loads without a token; the API requires one. We read it from
-// the ?token= query param the CLI prints, keep it in memory, and strip it from
-// the visible URL so it isn't left sitting in the address bar / history.
-const TOKEN = new URLSearchParams(location.search).get("token") || "";
+// the ?token= query param the CLI prints, persist it in sessionStorage, and
+// strip it from the visible URL so it isn't left sitting in the address bar /
+// history. On a reload the param is gone, so we recover the token from
+// sessionStorage — otherwise a refresh would drop it and every request would
+// 401. sessionStorage is per-tab and cleared when the tab closes.
+const TOKEN_KEY = "bintrail_console_token";
+let TOKEN = new URLSearchParams(location.search).get("token") || "";
 if (TOKEN) {
+  try { sessionStorage.setItem(TOKEN_KEY, TOKEN); } catch (e) { /* storage unavailable */ }
   history.replaceState(null, "", location.pathname);
+} else {
+  try { TOKEN = sessionStorage.getItem(TOKEN_KEY) || ""; } catch (e) { TOKEN = ""; }
 }
 
 let lastSQL = "";


### PR DESCRIPTION
## Bug
The console reads its access token from the `?token=` query param and strips it from the URL via `history.replaceState` (so it isn't left in the address bar / history). But on a **page reload** the param is gone, so `TOKEN` becomes empty — every API request then sends `Authorization: Bearer ` (empty) and gets **401 "unauthorized: missing or invalid token"**.

Reported from the running UI: hitting refresh on any tab (e.g. Status) broke the console with the 401 error.

## Fix
Persist the token in `sessionStorage` on first load, and recover it from there when the URL has no `?token=`. A refresh now keeps working. The URL is still cleaned, and `sessionStorage` is per-tab and cleared when the tab closes — so there's no long-lived token sitting in `localStorage`.

```js
const TOKEN_KEY = "bintrail_console_token";
let TOKEN = new URLSearchParams(location.search).get("token") || "";
if (TOKEN) {
  try { sessionStorage.setItem(TOKEN_KEY, TOKEN); } catch (e) { /* storage unavailable */ }
  history.replaceState(null, "", location.pathname);
} else {
  try { TOKEN = sessionStorage.getItem(TOKEN_KEY) || ""; } catch (e) { TOKEN = ""; }
}
```

## Test plan
- [x] `make build` green (`//go:embed` re-embeds the fixed asset)
- [x] Manual: with the fixed binary serving, opening `…/?token=demo` once then reloading (URL now `127.0.0.1:8090`, no param) keeps the token and the tabs work — previously the reload 401'd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)