### PR TITLE
fix(ci): publish the appliance as a plain manifest so ARM Macs fall back to Rosetta

### DIFF
--- a/.github/workflows/appliance.yml
+++ b/.github/workflows/appliance.yml
@@ -73,6 +73,14 @@ jobs:
           # amd64-only: MySQL's apt repo ships no arm64 packages for
           # Debian. Apple Silicon evaluators run it via Rosetta/QEMU.
           platforms: linux/amd64
+          # No provenance attestation: it turns the pushed artifact into
+          # an OCI *index* (image + attestation manifest), and on an ARM
+          # host `docker run` resolves the index, finds no arm64 entry,
+          # and errors with "no matching manifest" instead of falling
+          # back to Rosetta. A plain single-platform manifest emulates
+          # with just a warning — which is the README's promised UX.
+          # Supply-chain integrity still comes from the cosign signature.
+          provenance: false
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
- Running the **published** `ghcr.io/dbtrail/bintrail-appliance:latest` on an ARM Mac failed with `no matching manifest for linux/arm64/v8` — breaking the README's zero-flag `docker run` promise for every Apple Silicon evaluator.
- Root cause (verified via the registry API): build-push-action's default **provenance attestation** wraps the amd64 image in an OCI **index** (amd64 + `unknown/unknown` attestation manifest). Docker only falls back to Rosetta/QEMU emulation for **plain single-platform manifests**; for an index with no arm64 entry it hard-fails.
- `provenance: false` publishes the plain manifest. Supply-chain integrity still comes from the cosign keyless signature.
- Post-merge: re-dispatch `appliance.yml -f tag=v0.8.0` to republish `:0.8.0`/`:latest`, then re-verify with the smoke test against GHCR on this ARM host.

## Test plan
- [x] Registry API confirms current artifact is `application/vnd.oci.image.index.v1+json` with amd64 + attestation entries (the failing shape)
- [ ] Post-republish: `IMAGE=ghcr.io/dbtrail/bintrail-appliance:latest SKIP_BUILD=1 appliance/smoke-test.sh` passes on an arm64 host (pull + Rosetta + time-travel query)

🤖 Generated with [Claude Code](https://claude.com/claude-code)