### PR TITLE
refactor(stream): extract streamOne(ctx, streamConfig) — control plane phase 1

### DIFF
--- a/cmd/bintrail/stream.go
+++ b/cmd/bintrail/stream.go
@@ -821,25 +821,115 @@ func streamLoop(
 	}
 }
 
-// ─── runStream ───────────────────────────────────────────────────────────────────
+// ─── streamConfig / streamOne ───────────────────────────────────────────────
 
+// streamConfig carries everything ONE replication stream needs — the by-value
+// equivalent of the strm* package globals. It exists so the future control
+// plane can run N streams concurrently in one process (each with its own
+// config), while `bintrail stream` keeps wiring its flags through a single
+// instance unchanged. Plain data, no behavior: the zero value is invalid;
+// build it from flags via streamConfigFromFlags or populate it explicitly.
+type streamConfig struct {
+	IndexDSN    string
+	SourceDSN   string
+	ServerID    uint32
+	StartFile   string
+	StartPos    uint32
+	StartGTID   string
+	BatchSize   int
+	Schemas     string
+	Tables      string
+	Checkpoint  int // seconds
+	MetricsAddr string
+	SSLMode     string
+	SSLCA       string
+	SSLCert     string
+	SSLKey      string
+	Format      string
+	Reset       bool
+	NoGapFill   bool
+	GapTimeout  int // seconds
+}
+
+// streamConfigFromFlags snapshots the strm* package globals into a config.
+// The globals remain the cobra flag targets (and up.go's populateStreamFlags
+// fan-out target); this is the single seam where they become values.
+func streamConfigFromFlags() streamConfig {
+	return streamConfig{
+		IndexDSN:    strmIndexDSN,
+		SourceDSN:   strmSourceDSN,
+		ServerID:    strmServerID,
+		StartFile:   strmStartFile,
+		StartPos:    strmStartPos,
+		StartGTID:   strmStartGTID,
+		BatchSize:   strmBatchSize,
+		Schemas:     strmSchemas,
+		Tables:      strmTables,
+		Checkpoint:  strmCheckpoint,
+		MetricsAddr: strmMetricsAddr,
+		SSLMode:     strmSSLMode,
+		SSLCA:       strmSSLCA,
+		SSLCert:     strmSSLCert,
+		SSLKey:      strmSSLKey,
+		Format:      strmFormat,
+		Reset:       strmReset,
+		NoGapFill:   strmNoGapFill,
+		GapTimeout:  strmGapTimeout,
+	}
+}
+
+// runStream is the `bintrail stream` entrypoint: it owns the PROCESS concerns
+// (signal handling) and delegates the actual streaming to streamOne with a
+// config snapshotted from the flags. The split exists so a supervisor can run
+// several streamOne instances under its own lifecycle without inheriting
+// per-process signal wiring.
 func runStream(cmd *cobra.Command, args []string) error {
-	if !cliutil.IsValidOutputFormat(strmFormat) {
-		return fmt.Errorf("invalid --format %q; must be text or json", strmFormat)
+	ctx, cancel := context.WithCancel(cmd.Context())
+	defer cancel()
+
+	// Graceful shutdown on SIGINT/SIGTERM: cancel the context so streamOne
+	// flushes its batch and writes a final checkpoint. (Installed before
+	// startup rather than after StartSync as it historically was — a signal
+	// during the connect/snapshot phase now also exits cleanly.)
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+	go func() {
+		select {
+		case sig := <-sigCh:
+			slog.Info("received signal — shutting down gracefully", "signal", sig.String())
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	return streamOne(ctx, streamConfigFromFlags())
+}
+
+// streamOne runs one complete replication stream — connect, validate,
+// resolve identity, snapshot, gap-check, sync, index, checkpoint — until ctx
+// is cancelled or a fatal error occurs. It is self-contained by design: no
+// package globals, no signal handling, safe to run N instances concurrently
+// (each against its own index database).
+func streamOne(ctx context.Context, cfg streamConfig) error {
+	if !cliutil.IsValidOutputFormat(cfg.Format) {
+		return fmt.Errorf("invalid --format %q; must be text or json", cfg.Format)
 	}
 	// Reject non-positive --gap-timeout values: a zero or negative timeout
 	// would produce an immediately-cancelled context inside detectPositionGap
 	// / detectGTIDGap, surfacing as a misleading "context deadline exceeded"
 	// error whose recovery hint (`--reset`) discards the saved checkpoint.
-	if strmGapTimeout <= 0 {
-		return fmt.Errorf("invalid --gap-timeout %d: must be a positive number of seconds", strmGapTimeout)
+	if cfg.GapTimeout <= 0 {
+		return fmt.Errorf("invalid --gap-timeout %d: must be a positive number of seconds", cfg.GapTimeout)
 	}
 
-	ctx, cancel := context.WithCancel(cmd.Context())
+	// Derived cancel: internal failures (e.g. the stream loop erroring) must
+	// stop the parser goroutine even when the caller's ctx stays live.
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	// ── 1. Connect to index database ─────────────────────────────────────────
-	indexDB, err := config.Connect(strmIndexDSN)
+	indexDB, err := config.Connect(cfg.IndexDSN)
 	if err != nil {
 		return fmt.Errorf("failed to connect to index database: %w", err)
 	}
@@ -850,7 +940,7 @@ func runStream(cmd *cobra.Command, args []string) error {
 	}
 
 	// ── 2. Connect to source database: validate binlog_row_image ─────────────
-	sourceDB, err := config.Connect(strmSourceDSN)
+	sourceDB, err := config.Connect(cfg.SourceDSN)
 	if err != nil {
 		return fmt.Errorf("failed to connect to source MySQL: %w", err)
 	}
@@ -866,13 +956,13 @@ func runStream(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Println("Source: binlog_row_image=FULL \u2713")
 
-	if err := validateNoFKCascades(sourceDB, parseSchemaList(strmSchemas)); err != nil {
+	if err := validateNoFKCascades(sourceDB, parseSchemaList(cfg.Schemas)); err != nil {
 		return err
 	}
 	fmt.Println("Source: no FK cascades \u2713")
 
 	// ── 3. Resolve server identity ────────────────────────────────────────────
-	bintrailID, err := resolveServerIdentity(ctx, sourceDB, indexDB, strmSourceDSN)
+	bintrailID, err := resolveServerIdentity(ctx, sourceDB, indexDB, cfg.SourceDSN)
 	if err != nil {
 		if errors.Is(err, serverid.ErrConflict) {
 			return fmt.Errorf("cannot stream: %w", err)
@@ -883,14 +973,14 @@ func runStream(cmd *cobra.Command, args []string) error {
 	}
 
 	// ── 4. Schema snapshot + resolver ─────────────────────────────────────────
-	resolver, err := ensureResolver(indexDB, sourceDB, parseSchemaList(strmSchemas))
+	resolver, err := ensureResolver(indexDB, sourceDB, parseSchemaList(cfg.Schemas))
 	if err != nil {
 		return err
 	}
 	fmt.Printf("Snapshot: id=%d, tables=%d\n", resolver.SnapshotID(), resolver.TableCount())
 
 	// ── 5. Filters ────────────────────────────────────────────────────────────
-	filters := buildIndexFilters(strmSchemas, strmTables)
+	filters := buildIndexFilters(cfg.Schemas, cfg.Tables)
 
 	// ── 6. Determine start position ───────────────────────────────────────────
 	saved, err := loadStreamState(indexDB)
@@ -898,7 +988,7 @@ func runStream(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to load stream state: %w", err)
 	}
 
-	if strmReset {
+	if cfg.Reset {
 		if saved != nil {
 			if _, err := indexDB.Exec(`DELETE FROM stream_state WHERE id = 1`); err != nil {
 				return fmt.Errorf("failed to reset stream state: %w", err)
@@ -912,14 +1002,14 @@ func runStream(cmd *cobra.Command, args []string) error {
 	}
 
 	mode, startFile, startGTIDStr, startPos, accGTID, err := resolveStartWithAutoDiscover(
-		strmStartFile, strmStartGTID, strmStartPos, saved,
+		cfg.StartFile, cfg.StartGTID, cfg.StartPos, saved,
 		func() (string, uint32, error) { return config.CurrentBinlogPosition(sourceDB) })
 	if err != nil {
 		return err
 	}
 	// Surface the auto-discovered position when this was a first-run, no-flags
 	// invocation. Mirrors the agent BYOS startup checkmark style.
-	if saved == nil && strmStartFile == "" && strmStartGTID == "" && mode == "position" {
+	if saved == nil && cfg.StartFile == "" && cfg.StartGTID == "" && mode == "position" {
 		slog.Info("auto-discovered current binlog position", "file", startFile, "pos", startPos)
 		fmt.Printf("Start position: auto-discovered %s:%d ✓\n", startFile, startPos)
 	}
@@ -930,7 +1020,7 @@ func runStream(cmd *cobra.Command, args []string) error {
 		var gap *gapResult
 		var gapErr error
 
-		gapTimeout := time.Duration(strmGapTimeout) * time.Second
+		gapTimeout := time.Duration(cfg.GapTimeout) * time.Second
 
 		switch mode {
 		case "position":
@@ -954,7 +1044,7 @@ func runStream(cmd *cobra.Command, args []string) error {
 				// Unfillable gap — binlogs/GTIDs have been purged.
 				slog.Warn(gap.Message)
 
-				if strmNoGapFill {
+				if cfg.NoGapFill {
 					return fmt.Errorf("binlog gap detected and --no-gap-fill is set: %s", gap.Message)
 				}
 
@@ -997,7 +1087,7 @@ func runStream(cmd *cobra.Command, args []string) error {
 					binlogFile:    startFile,
 					binlogPos:     uint64(startPos),
 					gtidSet:       startGTIDStr,
-					serverID:      strmServerID,
+					serverID:      cfg.ServerID,
 					bintrailID:    bintrailID,
 					eventsIndexed: saved.eventsIndexed,
 					lastEventTime: saved.lastEventTime,
@@ -1013,7 +1103,7 @@ func runStream(cmd *cobra.Command, args []string) error {
 
 	state := &streamState{
 		mode:       mode,
-		serverID:   strmServerID,
+		serverID:   cfg.ServerID,
 		accGTID:    accGTID,
 		bintrailID: bintrailID,
 	}
@@ -1025,20 +1115,20 @@ func runStream(cmd *cobra.Command, args []string) error {
 	}
 
 	// ── 7. Parse source DSN for BinlogSyncer ─────────────────────────────
-	host, port, user, password, err := parseSourceDSN(strmSourceDSN)
+	host, port, user, password, err := parseSourceDSN(cfg.SourceDSN)
 	if err != nil {
 		return err
 	}
 
 	// ── 6b. Build TLS config ──────────────────────────────────────────────────
-	tlsCfg, err := buildTLSConfig(strmSSLMode, strmSSLCA, strmSSLCert, strmSSLKey, host)
+	tlsCfg, err := buildTLSConfig(cfg.SSLMode, cfg.SSLCA, cfg.SSLCert, cfg.SSLKey, host)
 	if err != nil {
 		return err
 	}
 
 	// ── 7. Create BinlogSyncer ────────────────────────────────────────────────────
 	syncerCfg := replication.BinlogSyncerConfig{
-		ServerID:             strmServerID,
+		ServerID:             cfg.ServerID,
 		Flavor:               "mysql",
 		Host:                 host,
 		Port:                 port,
@@ -1087,7 +1177,7 @@ func runStream(cmd *cobra.Command, args []string) error {
 
 	// ── 8. Start sync ───────────────────────────────────────────────────────────────
 	streamer, startErr := startStreamer()
-	if startErr != nil && strmSSLMode == "preferred" {
+	if startErr != nil && cfg.SSLMode == "preferred" {
 		// preferred: TLS attempt failed — retry without TLS.
 		slog.Warn("initial connection failed; retrying without TLS (--ssl-mode preferred)", "error", startErr)
 		syncer.Close()
@@ -1108,25 +1198,17 @@ func runStream(cmd *cobra.Command, args []string) error {
 		fmt.Printf("Streaming from GTID set: %s\n", startGTIDStr)
 	}
 
-	// ── 9. Signal handler ────────────────────────────────────────────────────────────
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
-	go func() {
-		select {
-		case sig := <-sigCh:
-			slog.Info("received signal — shutting down gracefully", "signal", sig.String())
-			cancel()
-		case <-ctx.Done():
-		}
-	}()
+	// (Signal handling lives in runStream — the process owner. streamOne only
+	// honors ctx, so a supervisor can run several instances under one
+	// lifecycle without competing signal handlers.)
 
-	// ── 9b. Optional Prometheus metrics HTTP server ─────────────────────────
-	if strmMetricsAddr != "" {
+	// ── 9. Optional Prometheus metrics HTTP server ─────────────────────────
+	if cfg.MetricsAddr != "" {
 		mux := http.NewServeMux()
 		mux.Handle("/metrics", promhttp.Handler())
-		metricsServer := &http.Server{Addr: strmMetricsAddr, Handler: mux}
+		metricsServer := &http.Server{Addr: cfg.MetricsAddr, Handler: mux}
 		go func() {
-			slog.Info("metrics server starting", "addr", strmMetricsAddr)
+			slog.Info("metrics server starting", "addr", cfg.MetricsAddr)
 			if err := metricsServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 				slog.Error("metrics server error", "error", err)
 			}
@@ -1140,7 +1222,7 @@ func runStream(cmd *cobra.Command, args []string) error {
 
 	// ── 10. Launch StreamParser in a goroutine ──────────────────────────────────
 	sp := parser.NewStreamParser(resolver, filters, nil)
-	idx := indexer.New(indexDB, strmBatchSize)
+	idx := indexer.New(indexDB, cfg.BatchSize)
 
 	events := make(chan parser.Event, 1000)
 	parseErrCh := make(chan error, 1)
@@ -1151,7 +1233,7 @@ func runStream(cmd *cobra.Command, args []string) error {
 	}()
 
 	// ── 11. DDL auto-snapshot handler ────────────────────────────────────────────
-	schemas := parseSchemaList(strmSchemas)
+	schemas := parseSchemaList(cfg.Schemas)
 	// ddlHandler performs best-effort snapshot + recording. It always returns nil
 	// so that streaming continues even if the snapshot or recording fails.
 	// TRUNCATE does not change schema structure, so skip snapshot for it.
@@ -1196,9 +1278,9 @@ func runStream(cmd *cobra.Command, args []string) error {
 	}
 
 	// ── 12. Run stream loop with checkpointing ──────────────────────────────────
-	fmt.Printf("Streaming started (server-id=%d, checkpoint=%ds)\n", strmServerID, strmCheckpoint)
+	fmt.Printf("Streaming started (server-id=%d, checkpoint=%ds)\n", cfg.ServerID, cfg.Checkpoint)
 	loopErr := streamLoop(ctx, events, idx, indexDB,
-		time.Duration(strmCheckpoint)*time.Second, state, ddlHandler)
+		time.Duration(cfg.Checkpoint)*time.Second, state, ddlHandler)
 
 	parseErr := <-parseErrCh
 
@@ -1210,7 +1292,7 @@ func runStream(cmd *cobra.Command, args []string) error {
 		return parseErr
 	}
 
-	if strmFormat == "json" {
+	if cfg.Format == "json" {
 		return outputJSON(struct {
 			EventsIndexed int64  `json:"events_indexed"`
 			LastFile      string `json:"last_file"`

--- a/cmd/bintrail/stream_test.go
+++ b/cmd/bintrail/stream_test.go
@@ -1359,3 +1359,95 @@ func TestResolveStartWithAutoDiscover_mutuallyExclusiveFlagsErrorPropagates(t *t
 		t.Errorf("expected mutually-exclusive error, got: %v", err)
 	}
 }
+
+// TestStreamConfigFromFlags asserts the strm* → streamConfig snapshot — the
+// single seam where the flag globals become a by-value config that streamOne
+// (and, later, the control-plane supervisor) consumes. A flag added to stream
+// but not wired through here would silently read its zero value inside
+// streamOne, so every field is checked with a distinctive value. Mirrors
+// TestPopulateStreamFlags' save-and-restore discipline: no t.Parallel().
+func TestStreamConfigFromFlags(t *testing.T) {
+	orig := struct {
+		src, idx, file, gtid, sch, tbl, met, fmtv, ssl, ca, cert, key string
+		sid, pos                                                      uint32
+		batch, chk, gap                                               int
+		reset, noGap                                                  bool
+	}{
+		src: strmSourceDSN, idx: strmIndexDSN, file: strmStartFile,
+		gtid: strmStartGTID, sch: strmSchemas, tbl: strmTables,
+		met: strmMetricsAddr, fmtv: strmFormat, ssl: strmSSLMode,
+		ca: strmSSLCA, cert: strmSSLCert, key: strmSSLKey,
+		sid: strmServerID, pos: strmStartPos,
+		batch: strmBatchSize, chk: strmCheckpoint, gap: strmGapTimeout,
+		reset: strmReset, noGap: strmNoGapFill,
+	}
+	t.Cleanup(func() {
+		strmSourceDSN, strmIndexDSN, strmStartFile = orig.src, orig.idx, orig.file
+		strmStartGTID, strmSchemas, strmTables = orig.gtid, orig.sch, orig.tbl
+		strmMetricsAddr, strmFormat, strmSSLMode = orig.met, orig.fmtv, orig.ssl
+		strmSSLCA, strmSSLCert, strmSSLKey = orig.ca, orig.cert, orig.key
+		strmServerID, strmStartPos = orig.sid, orig.pos
+		strmBatchSize, strmCheckpoint, strmGapTimeout = orig.batch, orig.chk, orig.gap
+		strmReset, strmNoGapFill = orig.reset, orig.noGap
+	})
+
+	strmIndexDSN = "ix:pw@tcp(127.0.0.1:3306)/binlog_index"
+	strmSourceDSN = "user:pass@tcp(source.example.com:3306)/src"
+	strmServerID = 424242
+	strmStartFile = "mysql-bin.000777"
+	strmStartPos = 1234
+	strmStartGTID = "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-5"
+	strmBatchSize = 333
+	strmSchemas = "mydb,otherdb"
+	strmTables = "mydb.orders"
+	strmCheckpoint = 17
+	strmMetricsAddr = ":9191"
+	strmSSLMode = "verify-ca"
+	strmSSLCA = "/tmp/ca.pem"
+	strmSSLCert = "/tmp/cert.pem"
+	strmSSLKey = "/tmp/key.pem"
+	strmFormat = "json"
+	strmReset = true
+	strmNoGapFill = true
+	strmGapTimeout = 99
+
+	got := streamConfigFromFlags()
+	want := streamConfig{
+		IndexDSN:    "ix:pw@tcp(127.0.0.1:3306)/binlog_index",
+		SourceDSN:   "user:pass@tcp(source.example.com:3306)/src",
+		ServerID:    424242,
+		StartFile:   "mysql-bin.000777",
+		StartPos:    1234,
+		StartGTID:   "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-5",
+		BatchSize:   333,
+		Schemas:     "mydb,otherdb",
+		Tables:      "mydb.orders",
+		Checkpoint:  17,
+		MetricsAddr: ":9191",
+		SSLMode:     "verify-ca",
+		SSLCA:       "/tmp/ca.pem",
+		SSLCert:     "/tmp/cert.pem",
+		SSLKey:      "/tmp/key.pem",
+		Format:      "json",
+		Reset:       true,
+		NoGapFill:   true,
+		GapTimeout:  99,
+	}
+	if got != want {
+		t.Errorf("streamConfigFromFlags mismatch:\n got: %+v\nwant: %+v", got, want)
+	}
+}
+
+// TestStreamOneRejectsBadConfig: streamOne owns its own validation (it must
+// not depend on cobra/flag-layer checks once a supervisor builds configs
+// programmatically).
+func TestStreamOneRejectsBadConfig(t *testing.T) {
+	if err := streamOne(t.Context(), streamConfig{Format: "bogus", GapTimeout: 30}); err == nil ||
+		!strings.Contains(err.Error(), "invalid --format") {
+		t.Errorf("bad format: err = %v, want invalid --format", err)
+	}
+	if err := streamOne(t.Context(), streamConfig{Format: "text", GapTimeout: 0}); err == nil ||
+		!strings.Contains(err.Error(), "gap-timeout") {
+		t.Errorf("bad gap-timeout: err = %v, want gap-timeout error", err)
+	}
+}


### PR DESCRIPTION
## Summary

Phase 1 of the approved control-plane blueprint (`drafts/control-plane-blueprint.md`, local): the `runStream` body becomes **`streamOne(ctx, streamConfig)`** — self-contained, no package-global reads, no signal handling. This is the exact shape the upcoming supervisor needs to run N replication streams concurrently in one `bintrail up --console` process (one per monitored source, each into its own auto-created index DB per the approved per-source architecture).

## Changes

- **`streamConfig`**: by-value equivalent of the `strm*` globals. The globals remain the cobra flag targets and `up.go`'s `populateStreamFlags` fan-out — `streamConfigFromFlags()` is the single seam where they become values.
- **Signal handling lifts into `runStream`** (the process owner). `streamOne` only honors `ctx`, so a supervisor composes N instances under one lifecycle. One deliberate refinement: signals are caught from startup rather than only after `StartSync`, so SIGINT during the connect/snapshot phase now exits gracefully too.
- **`streamOne` keeps its own validation** (format, gap-timeout): programmatically-built configs get the same checks as flags.
- Behavior of `bintrail stream` / `bintrail up` otherwise unchanged.

## The risk this PR manages

A missed `strm*` reference inside `streamOne` **compiles fine** (the globals still exist) but would silently couple N future streams to one flag value. Mitigations:
- grep-verified **zero** `strm` references inside `streamOne`;
- `TestStreamConfigFromFlags` locks every field of the seam with a distinctive value (mirror of `TestPopulateStreamFlags`);
- `TestStreamOneRejectsBadConfig` covers the validation now owned by `streamOne`.

## Verification

- Full unit suite green; stream integration tests green; **full `TestEndToEnd` pipeline green** (Docker MySQL).

Part of the friction roadmap: #397 (compose quickstart) is the deployment face; this starts the "+ Add server = monitor it" backend. Next phases per blueprint: registry source fields → supervisor + doctor-in-flow + monitor verbs → N sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)