### PR TITLE
docs: execute the index-MySQL ownership board decisions — SUPPORT.md, eval-grade labels, production track

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Something in bintrail's binaries, schema, tooling, console, or docs misbehaves
+labels: bug
+---
+
+<!--
+Scope check (see SUPPORT.md): bintrail owns its schema, tooling, console,
+and images. The OPERATION of your index MySQL server — sizing, backups,
+disk-full, upgrades, corruption, managed-flavor quirks — is the operator's
+responsibility and out of scope here:
+https://github.com/dbtrail/bintrail/blob/main/SUPPORT.md
+-->
+
+**What happened**
+
+**What you expected**
+
+**How to reproduce**
+
+```sh
+# commands / compose setup
+```
+
+**Environment**
+- bintrail version (`bintrail --version`):
+- Install path (compose / docker / deb-rpm / source):
+- Source MySQL (version, self-managed or RDS/Aurora/Cloud SQL):
+- Index MySQL (bundled compose container or your own):
+
+**Logs**
+
+```
+relevant log lines (bintrail's, with --log-level debug if possible)
+```

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Support scope — what bintrail does and does not own
+    url: https://github.com/dbtrail/bintrail/blob/main/SUPPORT.md
+    about: >-
+      Bintrail installs only its schema — the index MySQL server's operation
+      (sizing, backups, disk-full, upgrades, corruption) is the operator's.
+      Read this before filing index-server operational issues.

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ __pycache__/
 
 # macOS
 .DS_Store
+docker-compose.override.yml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,3 +276,9 @@ Release: update CHANGELOG.md, commit, create annotated tag `vX.Y.Z`, push. GitHu
 - **`p_future` must always exist**: never drop it.
 - **`schema_snapshots` snapshot_id ≠ row id**: snapshot_id groups rows; id is auto-increment PK.
 - **go-mysql lowercases GTID UUIDs**: tests must use lowercase — never uppercase UUID literals.
+
+## Architectural red lines (board decision 2026-06-06, SUPPORT.md is the public artifact)
+
+- **Schema, never server**: bintrail installs databases/tables/migrations on an operator-supplied MySQL (`init`/`up`/control plane). It must NEVER install, embed, supervise, or operate a MySQL server process (no apt/yum mysql-server, no managed mysqld). The bundled compose `index-mysql` is evaluation-grade only and must never be positioned as production.
+- **Control plane holds at database-and-schema**: provisioning a database-per-source on the daemon's index server is in scope; provisioning/tuning/operating the SERVER is not. Any future step in that direction needs explicit sign-off (forecloses index-tier optionality; platform-trap risk — see drafts/board-index-mysql-2026-06-06.md).
+- **Support boundary**: the operator's index MySQL operation (sizing, backups, disk-full, upgrades, corruption, managed-flavor quirks) is out of scope for the free core — that is dbtrail's value proposition. Triage cites SUPPORT.md.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ streaming. No terminal needed after these four lines. The console binds to
 your machine only (`127.0.0.1`) and every request requires the token from
 the URL.
 
+> The bundled index MySQL is **evaluation-grade** (volume loss = re-index).
+> For production, point `INDEX_DSN` in `.env` at a MySQL you operate —
+> bintrail installs only its schema, never a database server. Boundary:
+> [SUPPORT.md](SUPPORT.md).
+>
 > **Other ways to install** — plain Docker, `.deb`/`.rpm`, `go install`,
 > source builds, and the binary quickstart: see **[docs/install.md](docs/install.md)**.
 >

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,66 @@
+# Support scope
+
+This document is the canonical statement of what the bintrail project does
+and does not support. Issue triage links here; reports outside this scope
+are closed with a pointer to this file.
+
+## The contract
+
+Bintrail's contract with your infrastructure is one line:
+
+> **A reachable MySQL 8.0+ via `--index-dsn`.**
+
+Bintrail installs and versions **its own schema** on that server — databases
+(`CREATE DATABASE IF NOT EXISTS`), tables, and idempotent migrations, via
+`init`, `up`, and the console control plane. It never installs, embeds,
+tunes, supervises, or operates a MySQL **server process**. That boundary is
+architectural and permanent.
+
+## In scope (we own this)
+
+- The bintrail binaries and their commands, flags, and documented behavior.
+- The index **schema**: its tables, migrations, and data correctness
+  (every row event, full before/after images).
+- Bintrail's own tooling for operating the index *data*: `rotate`, `status`,
+  `doctor`, `archive reconcile`, Parquet archives and their queries.
+- The web console, the MCP server, the time-travel shim.
+- The Docker images we publish and the bundled docker-compose **as an
+  evaluation/quickstart environment** (see below).
+
+## Out of scope (the operator owns this)
+
+The **operation of the index MySQL server** is the operator's responsibility
+in the free core — all of it:
+
+- Sizing, InnoDB tuning, and capacity planning (see
+  [deployment.md §3](docs/deployment.md)).
+- Backups and restore of the index server, and replication of the index
+  itself.
+- Disk-full conditions, corruption, and crash recovery of the server.
+- MySQL version upgrades, and distribution/managed-flavor quirks
+  (RDS, Aurora, Cloud SQL, MariaDB) of the **index** server.
+
+"Supported" means: MySQL 8.0+ reached via a DSN, tested against the pinned
+evaluation image and the versions our CI runs. The operator's index server
+is not part of our defect matrix.
+
+> Want the index hosted, sized, backed up, and operated for you? That is
+> exactly what [dbtrail](https://dbtrail.com) is.
+
+## The bundled compose MySQL is evaluation-grade
+
+The `index-mysql` container in the root `docker-compose.yml` exists so the
+four-line quickstart works with zero prerequisites. It is **not** a
+production system of record:
+
+- Single unreplicated volume, default credentials, no backup story.
+- **Volume loss = re-index.** Nothing in it is recoverable by us.
+- For production, bring your own index MySQL (`INDEX_DSN` in `.env`) and
+  operate it like the system of record it becomes.
+
+## Reporting issues
+
+Bugs in bintrail's binaries, schema, tooling, console, or docs: please open
+an issue with reproduction steps — those are always in scope. If your report
+is about the index MySQL server's own operation (disk, backups, upgrades,
+corruption), see the list above first.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,12 @@
 # schema snapshot → live binlog stream), and the web console published on
 # http://127.0.0.1:8090 with the access token printed in the logs.
 #
+# The bundled index-mysql is EVALUATION/QUICKSTART-GRADE: a single
+# unreplicated volume with default credentials and no backup story —
+# volume loss means re-indexing. For production, bring your own index
+# MySQL (set INDEX_DSN in .env) and operate it as the system of record
+# it becomes. Support boundary: SUPPORT.md.
+#
 # For the full interactive demo (traffic generator, Grafana, Prometheus),
 # see demo/compose.yml instead.
 
@@ -18,10 +24,11 @@ volumes:
 
 services:
 
-  # ── Index MySQL ──────────────────────────────────────────
-  # Stores binlog_events, schema_snapshots, and stream_state.
-  # Already have a MySQL you want to use as the index? Remove this service
-  # and point INDEX_DSN in .env at it instead.
+  # ── Index MySQL (evaluation/quickstart-grade) ────────────
+  # Stores binlog_events, schema_snapshots, and stream_state — the
+  # forensic record itself. This bundled container is for evaluation:
+  # volume loss = re-index. For production, bring your own index MySQL:
+  # remove this service and point INDEX_DSN in .env at yours.
   index-mysql:
     image: mysql:8.0
     environment:

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -155,11 +155,14 @@ Notes:
   building from a source checkout instead is a comment-toggle in the
   compose file (`build: .`).
 
-### Connecting to an external index MySQL
+### Connecting to an external index MySQL (the production track)
 
-If you already have a MySQL instance for the index, set `INDEX_DSN` in
-`.env` to point at it and remove the `index-mysql` service from the compose
-file.
+The bundled `index-mysql` container is evaluation-grade (single volume, no
+backups — volume loss = re-index). For production, set `INDEX_DSN` in
+`.env` to a MySQL 8.0+ you operate and remove the `index-mysql` service
+from the compose file. Bintrail installs only its schema there; the
+server's sizing, backups, and upgrades are yours — see
+[deployment.md](./deployment.md) and [SUPPORT.md](../SUPPORT.md).
 
 ## Environment variables
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -15,7 +15,7 @@ it's the first section — the same four lines as the README.
   bundles one).
 - Go 1.24+ — only when building from source.
 
-## Docker Compose (recommended)
+## Docker Compose (recommended for evaluation and first contact)
 
 One file, one line of config — an index MySQL (persisted in a volume),
 `bintrail up --console` (preflight → index tables → schema snapshot → live
@@ -43,8 +43,20 @@ From there you can **add more MySQL servers to monitor straight from the
 UI** — Servers → + Add server: paste a DSN, bintrail runs the preflight,
 provisions an index for it, and starts streaming.
 
-All the optional knobs (pinned console token, schema filter, bring-your-own
-index MySQL, image tag) live in
+**The bundled index MySQL is evaluation-grade**: a single unreplicated
+volume, default credentials, no backup story — volume loss means
+re-indexing. It exists so the four lines above need zero prerequisites.
+
+**Production track — bring your own index MySQL** (co-equal path, not an
+afterthought): set `INDEX_DSN` in `.env` to a MySQL 8.0+ you operate, and
+remove the bundled `index-mysql` service. The index becomes your system of
+record: sizing, InnoDB tuning, and backups are yours to run — see
+[deployment.md §3](./deployment.md) and the support boundary in
+[SUPPORT.md](../SUPPORT.md). Bintrail installs and migrates only its schema
+on whatever server you point it at.
+
+All the optional knobs (pinned console token, schema filter, image tag)
+live in
 [`.env.example`](https://github.com/dbtrail/bintrail/blob/main/.env.example);
 the full walkthrough is in [docker.md](./docker.md).
 


### PR DESCRIPTION
## Summary

Executes the action items from the leadership review on the question: *does bintrail provide / install / bundle the index MySQL?* Decision (unanimous on direction): **schema yes, server never; the compose bundle stays but explicitly evaluation-grade; BYO index is the co-equal production track.**

## Changes (docs/policy only — zero code)

| Artifact | What |
|---|---|
| **`SUPPORT.md`** (new) | The linkable support boundary: the one-line contract, in-scope vs operator-owned, eval-grade bundle disclosure, the dbtrail line |
| **Issue templates** (new) | Bug template with scope check + contact link to SUPPORT.md — triage cites the boundary instead of re-arguing it |
| `docker-compose.yml` | Bundled `index-mysql` labeled **evaluation/quickstart-grade** (header + service): "volume loss = re-index; BYO for production" |
| `docs/install.md` | "recommended" → "recommended for evaluation and first contact"; new **Production track** section (BYO via `INDEX_DSN`, deployment.md §3, SUPPORT.md) |
| `README.md` / `docs/docker.md` | Eval labeling mirrored; the 4-line quickstart **untouched** (decision: relabel ≠ lengthen) |
| `CLAUDE.md` | Architectural red lines recorded: schema-never-server; control plane holds at database-and-schema; support boundary |

Roadmap candidates from the review → #406 (doctor capacity check, quickstart retention). Messaging consistency pass: nothing in docs implies "bintrail ships a database". All relative links verified; `docker compose config` validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)