### PR TITLE
feat(up): zero-config install — source-less up --console, 3-line quickstart

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,10 +5,11 @@
 #   docker compose up -d
 #   docker compose logs bintrail    # open the printed console URL
 
-# REQUIRED — your application MySQL (the server to watch).
+# OPTIONAL — a source MySQL to start watching immediately at boot.
+# Leave unset and add servers from the console UI instead (zero-config path).
 # The user needs REPLICATION SLAVE, REPLICATION CLIENT, and SELECT.
 # `host.docker.internal` reaches a MySQL on this machine from inside Docker.
-SOURCE_DSN=user:password@tcp(host.docker.internal:3306)/
+# SOURCE_DSN=user:password@tcp(host.docker.internal:3306)/
 
 # Optional — comma-separated schemas to track (empty = all user schemas).
 SCHEMAS=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Zero-config install — `SOURCE_DSN` is no longer required to get started.** `bintrail up --console` now starts **source-less**: index init + web console + control plane, with sources added afterwards from the UI ("+ Add server" runs the preflight, provisions a per-source index, and starts streaming — and resumes them on restart). The Docker Compose quickstart drops to three commands with nothing to edit (`curl` the compose, `up -d`, open the URL from the logs); `SOURCE_DSN` and `CONSOLE_TOKEN` become optional `.env` knobs instead of prerequisites. On a fresh supervisor with nothing watched, the console opens the Servers screen automatically so "+ Add server" is the first thing the operator sees. Boot robustness: under `--console`, `up` now waits (up to 90s, with progress) for the index MySQL to accept connections instead of dying into a restart loop — the official mysql image briefly accepts-then-drops connections during first initialization, which previously caused ~5 container restarts and a new console token per restart on a cold compose boot.
+
 ## [0.8.1] - 2026-06-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -41,27 +41,24 @@ both and prints the exact fix for anything missing.
 
 ```sh
 curl -fsSLO https://raw.githubusercontent.com/dbtrail/bintrail/main/docker-compose.yml
-echo 'SOURCE_DSN=USER:PASSWORD@tcp(YOUR_MYSQL_HOST:3306)/' > .env
 docker compose up -d
 docker compose logs -f bintrail
 ```
 
-Change one thing: `USER`, `PASSWORD`, and `YOUR_MYSQL_HOST` — the MySQL you
-want to watch (`host.docker.internal` reaches a MySQL on this same machine).
-The logs end with your console URL:
+Nothing to configure. The logs end with your console URL:
 
 ```
-Console (read-only) is running. Open:
+Console is running — open it and add the MySQL servers to watch:
 
     http://127.0.0.1:8090/?token=ab12cd34…
 ```
 
-Open it. Browse every row change, generate undo SQL, watch stream health —
-and add more MySQL servers to monitor straight from the UI: paste a DSN,
-bintrail runs the preflight checks, provisions an index, and starts
-streaming. No terminal needed after these four lines. The console binds to
-your machine only (`127.0.0.1`) and every request requires the token from
-the URL.
+Open it and click **+ Add server**: paste the MySQL you want to watch —
+host, user, password — and bintrail runs the preflight checks (failures come
+back as fix-this cards), provisions an index for it, and starts streaming.
+Watching events within the minute, and the terminal is already behind you.
+The console binds to your machine only (`127.0.0.1`) and every request
+requires the token from the URL.
 
 > The bundled index MySQL is **evaluation-grade** (volume loss = re-index).
 > For production, point `INDEX_DSN` in `.env` at a MySQL you operate —

--- a/cmd/bintrail/up.go
+++ b/cmd/bintrail/up.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/sha256"
 	"database/sql"
 	"encoding/binary"
@@ -9,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/spf13/cobra"
@@ -84,7 +86,9 @@ func init() {
 	upCmd.Flags().StringVar(&upConsoleBaselineDir, "baseline-dir", "", "Local directory of baseline Parquet snapshots; enables the console's point-in-time Reconstruct surface when --console is set")
 	upCmd.Flags().StringVar(&upConsoleBaselineS3, "baseline-s3", "", "S3 prefix of baseline Parquet snapshots (s3://bucket/prefix/); enables Reconstruct when --console is set")
 	upCmd.Flags().StringVar(&upConsoleServersFile, "console-servers-file", "", "Path to the console server registry YAML when --console is set (default ~/.config/bintrail/console-servers.yaml)")
-	_ = upCmd.MarkFlagRequired("source-dsn")
+	// --source-dsn is validated in runUp instead of MarkFlagRequired: with
+	// --console the daemon may start source-less (zero-config install) and
+	// sources are added from the UI.
 	_ = upCmd.MarkFlagRequired("index-dsn")
 	bindCommandEnv(upCmd)
 	rootCmd.AddCommand(upCmd)
@@ -94,9 +98,33 @@ func runUp(cmd *cobra.Command, args []string) error {
 	if !cliutil.IsValidOutputFormat(upFormat) {
 		return fmt.Errorf("invalid --format %q; must be text or json", upFormat)
 	}
+	// --source-dsn is required for the classic single-stream `up`, but with
+	// --console the daemon can start with NO source at all: it serves the
+	// console + control plane, and sources are added from the UI ("+ Add
+	// server" runs the preflight, provisions a per-source index, and starts
+	// streaming). That is the zero-config install path.
+	if upSourceDSN == "" && !upConsole {
+		return fmt.Errorf("--source-dsn is required (or pass --console to start source-less and add servers from the UI)")
+	}
+
+	// Containerized installs start bintrail and the index MySQL together, and
+	// the official mysql image briefly accepts-then-drops connections during
+	// its first initialization — a single connect attempt turns first boot
+	// into a restart loop (regenerating the console token each time). Under
+	// --console (the compose path), wait for the index instead of dying;
+	// plain CLI runs keep today's fail-fast behavior.
+	if upConsole {
+		if err := waitForIndexMySQL(cmd.Context(), upIndexDSN, 90*time.Second); err != nil {
+			return fmt.Errorf("index MySQL did not become reachable: %w", err)
+		}
+	}
 
 	// ── Phase 1: Preflight ──────────────────────────────────────────────────
-	if !upSkipDoctor {
+	if upSourceDSN == "" {
+		fmt.Fprintln(os.Stderr, "=== Phase 1/3: Preflight checks ===")
+		fmt.Fprintln(os.Stderr, "No source configured yet — the preflight runs when you add a server from the console.")
+		fmt.Fprintln(os.Stderr)
+	} else if !upSkipDoctor {
 		fmt.Fprintln(os.Stderr, "=== Phase 1/3: Preflight checks ===")
 		if err := runDoctorTo(cmd.Context(), os.Stderr, "text", upSourceDSN, upIndexDSN, upSchemas); err != nil {
 			return fmt.Errorf("preflight failed (use --skip-doctor to bypass at your own risk): %w", err)
@@ -111,9 +139,102 @@ func runUp(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Fprintln(os.Stderr)
 
-	// ── Phase 3: Stream ─────────────────────────────────────────────────────
+	// ── Phase 3: Stream (or console-only daemon when no source yet) ─────────
+	if upSourceDSN == "" {
+		fmt.Fprintln(os.Stderr, "=== Phase 3/3: Console + control plane ===")
+		return runUpConsoleOnly(cmd)
+	}
 	fmt.Fprintln(os.Stderr, "=== Phase 3/3: Streaming ===")
 	return runUpStream(cmd, args)
+}
+
+// waitForIndexMySQL retries a server-level connection (database name
+// stripped — init may not have created it yet) until the index MySQL accepts
+// connections or the timeout elapses. Progress is logged so a compose
+// first-boot reads as "waiting for MySQL", not as a crash loop.
+func waitForIndexMySQL(ctx context.Context, dsn string, timeout time.Duration) error {
+	cfg, err := mysql.ParseDSN(dsn)
+	if err != nil {
+		return fmt.Errorf("invalid --index-dsn: %w", err)
+	}
+	cfg.DBName = ""
+	serverDSN := cfg.FormatDSN()
+
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for attempt := 0; ; attempt++ {
+		db, err := config.Connect(serverDSN)
+		if err == nil {
+			db.Close()
+			return nil
+		}
+		lastErr = err
+		if time.Now().After(deadline) {
+			return lastErr
+		}
+		if attempt%5 == 0 {
+			fmt.Fprintf(os.Stderr, "Waiting for index MySQL at %s…\n", cfg.Addr)
+		}
+		select {
+		case <-time.After(2 * time.Second):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+// runUpConsoleOnly is the zero-config daemon: no initial source, just the
+// index, the console, and the control-plane supervisor. Every source is added
+// (and resumed at boot, via Reconcile) from the UI. Mirrors
+// runUpStreamWithConsole minus the main stream.
+func runUpConsoleOnly(cmd *cobra.Command) error {
+	resolveUpConsoleEnv(cmd)
+
+	db, err := config.Connect(upIndexDSN)
+	if err != nil {
+		return fmt.Errorf("console: connect index database: %w", err)
+	}
+	defer db.Close()
+	if err := indexer.EnsureSchema(db); err != nil {
+		return fmt.Errorf("console: schema migration: %w", err)
+	}
+
+	serversPath := upConsoleServersFile
+	if serversPath == "" {
+		serversPath = console.DefaultRegistryPath()
+	}
+	registry, err := console.LoadRegistry(serversPath)
+	if err != nil {
+		return fmt.Errorf("console: %w", err)
+	}
+
+	cfg, err := upConsoleConfig(db, upIndexDSN, upConsoleListen, upConsoleToken, upConsoleBaselineDir, upConsoleBaselineS3)
+	if err != nil {
+		return err
+	}
+	cfg.Registry = registry
+
+	ctx, stop := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	supervisor := newMonitorSupervisor(ctx, upIndexDSN)
+	cfg.MonitorCtrl = supervisor
+
+	srv, err := console.New(cfg)
+	if err != nil {
+		return err
+	}
+	ln, err := srv.Listen()
+	if err != nil {
+		return fmt.Errorf("console: cannot bind %s: %w", upConsoleListen, err)
+	}
+
+	fmt.Fprintf(os.Stderr, "\nConsole is running — open it and add the MySQL servers to watch:\n\n    %s\n\n", srv.URL())
+	go supervisor.Reconcile(registry)
+
+	serveErr := srv.Serve(ctx, ln)
+	supervisor.Shutdown() // final checkpoints for every monitored stream
+	return serveErr
 }
 
 // runUpInit calls runInit with up's flag values. We share the parent context

--- a/cmd/bintrail/up_test.go
+++ b/cmd/bintrail/up_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -236,4 +237,33 @@ func TestResolveUpConsoleEnv(t *testing.T) {
 	assertStr(t, "upConsoleToken (empty env)", upConsoleToken, "tok")
 	assertStr(t, "upConsoleBaselineDir (empty env)", upConsoleBaselineDir, "/dir")
 	assertStr(t, "upConsoleBaselineS3 (empty env)", upConsoleBaselineS3, "s3://b/p/")
+}
+
+// TestRunUpSourceDSNValidation: --source-dsn is required for the classic
+// single-stream up, but --console may start source-less (the zero-config
+// install — sources are then added from the UI).
+func TestRunUpSourceDSNValidation(t *testing.T) {
+	origSrc, origIdx, origConsole, origFmt := upSourceDSN, upIndexDSN, upConsole, upFormat
+	t.Cleanup(func() {
+		upSourceDSN, upIndexDSN, upConsole, upFormat = origSrc, origIdx, origConsole, origFmt
+	})
+	upFormat = "text"
+
+	// Without --console: refused up front with the actionable hint.
+	upSourceDSN, upConsole = "", false
+	upIndexDSN = "u:p@tcp(127.0.0.1:3306)/idx"
+	err := runUp(upCmd, nil)
+	if err == nil || !strings.Contains(err.Error(), "--source-dsn is required") {
+		t.Fatalf("source-less up without --console: err = %v, want the --source-dsn requirement", err)
+	}
+
+	// With --console: validation passes; the run proceeds into init and fails
+	// THERE on the deliberately unparseable index DSN — proving the
+	// source-dsn gate did not fire.
+	upSourceDSN, upConsole = "", true
+	upIndexDSN = "not-a-dsn"
+	err = runUp(upCmd, nil)
+	if err == nil || strings.Contains(err.Error(), "--source-dsn is required") {
+		t.Fatalf("source-less up WITH --console must pass the source gate, got: %v", err)
+	}
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,12 @@
 # Bintrail Docker Compose — the zero-friction quickstart.
 #
-#   1. cp .env.example .env       # set SOURCE_DSN to your MySQL
-#   2. docker compose up -d
-#   3. docker compose logs bintrail   # open the printed console URL
+#   1. docker compose up -d
+#   2. docker compose logs -f bintrail   # open the printed console URL
+#   3. In the console: "+ Add server" — paste the MySQL to watch; bintrail
+#      runs the preflight, provisions an index for it, and starts streaming.
+#
+# No .env needed. Optionally set SOURCE_DSN (start streaming one source
+# immediately) or CONSOLE_TOKEN (stable token across restarts) in a .env.
 #
 # What you get: an index MySQL (persisted in a volume), bintrail running
 # `up --console` against your source (preflight checks → index tables →
@@ -57,8 +61,9 @@ services:
       # change to "8090:8090" AND set a stable CONSOLE_TOKEN in .env.
       - "127.0.0.1:8090:8090"
     environment:
-      # Your application MySQL — the server to watch (set in .env).
-      SOURCE_DSN: ${SOURCE_DSN:?Set SOURCE_DSN in .env (e.g. user:pass@tcp(host.docker.internal:3306)/)}
+      # Optional: a source MySQL to start watching immediately. Leave unset
+      # and add servers from the console UI instead (the zero-config path).
+      SOURCE_DSN: ${SOURCE_DSN:-}
       # The index MySQL above; swap for your own instance if you removed it.
       INDEX_DSN: ${INDEX_DSN:-root:${INDEX_MYSQL_ROOT_PASSWORD:-changeme}@tcp(index-mysql:3306)/bintrail_index}
       # Optional comma-separated schema filter (empty = all user schemas).
@@ -82,10 +87,12 @@ services:
           export BINTRAIL_CONSOLE_TOKEN="$$(od -An -N16 -tx1 /dev/urandom | tr -d ' \n')"
           echo "Generated console token (set CONSOLE_TOKEN in .env to keep it stable across restarts)"
         fi
-        if [ -n "$$SCHEMAS" ]; then
+        if [ -n "$$SOURCE_DSN" ] && [ -n "$$SCHEMAS" ]; then
           exec bintrail up --source-dsn "$$SOURCE_DSN" --index-dsn "$$INDEX_DSN" --schemas "$$SCHEMAS" --console
+        elif [ -n "$$SOURCE_DSN" ]; then
+          exec bintrail up --source-dsn "$$SOURCE_DSN" --index-dsn "$$INDEX_DSN" --console
         fi
-        exec bintrail up --source-dsn "$$SOURCE_DSN" --index-dsn "$$INDEX_DSN" --console
+        exec bintrail up --index-dsn "$$INDEX_DSN" --console
     depends_on:
       index-mysql:
         condition: service_healthy

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -116,17 +116,19 @@ stream, **and the web console**, in one `up -d`. It pulls the published
 
 ### Quick start
 
-No clone needed — the compose file is self-contained:
+No clone, no config — the compose file is self-contained and the servers
+to watch are added from the console UI afterwards:
 
 ```bash
 curl -fsSLO https://raw.githubusercontent.com/dbtrail/bintrail/main/docker-compose.yml
-echo 'SOURCE_DSN=USER:PASSWORD@tcp(YOUR_MYSQL_HOST:3306)/' > .env
 docker compose up -d
 docker compose logs -f bintrail
 ```
 
-(From a source checkout, `cp .env.example .env` gives you the annotated
-template with every optional knob instead.)
+Optional knobs go in a `.env` next to the file: `SOURCE_DSN` to start
+streaming one source immediately at boot, `CONSOLE_TOKEN` to pin the access
+token across restarts, `INDEX_DSN` to bring your own index MySQL. (From a
+source checkout, `cp .env.example .env` gives you the annotated template.)
 
 The logs print the console URL, access token included:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -17,21 +17,17 @@ it's the first section — the same four lines as the README.
 
 ## Docker Compose (recommended for evaluation and first contact)
 
-One file, one line of config — an index MySQL (persisted in a volume),
-`bintrail up --console` (preflight → index tables → schema snapshot → live
-binlog stream), and the web console:
+One file, zero config — an index MySQL (persisted in a volume) and
+`bintrail up --console` in source-less daemon mode: the console plus the
+control plane, waiting for you to add servers from the UI:
 
 ```sh
 curl -fsSLO https://raw.githubusercontent.com/dbtrail/bintrail/main/docker-compose.yml
-echo 'SOURCE_DSN=USER:PASSWORD@tcp(YOUR_MYSQL_HOST:3306)/' > .env
 docker compose up -d
 docker compose logs -f bintrail
 ```
 
-Replace `USER`, `PASSWORD`, and `YOUR_MYSQL_HOST` with the MySQL you want to
-watch (`host.docker.internal` reaches a MySQL on the same machine from inside
-Docker — the placeholders are deliberately not a working value, so a missed
-edit fails the preflight loudly instead of half-connecting). The logs print the console URL with its access token:
+The logs print the console URL with its access token:
 
 ```
 Console (read-only) is running. Open:
@@ -39,9 +35,16 @@ Console (read-only) is running. Open:
     http://127.0.0.1:8090/?token=ab12cd34…
 ```
 
-From there you can **add more MySQL servers to monitor straight from the
-UI** — Servers → + Add server: paste a DSN, bintrail runs the preflight,
-provisions an index for it, and starts streaming.
+Open it and use **+ Add server** (the Servers screen opens itself on a
+fresh install): paste the MySQL to watch — host, user, password, optional
+schema filter (`host.docker.internal` reaches a MySQL on this same machine
+from inside Docker). Bintrail runs the preflight (failures come back as
+remediation cards), provisions a dedicated index for that source, and starts
+streaming. Repeat per server; everything you add resumes automatically when
+the container restarts.
+
+Prefer to start streaming one source immediately at boot? Set `SOURCE_DSN`
+in a `.env` next to the compose file — that's optional now, not required.
 
 **The bundled index MySQL is evaluation-grade**: a single unreplicated
 volume, default credentials, no backup story — volume loss means

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -879,9 +879,18 @@ function init() {
   // Load the server list first so a stale per-tab selection is reconciled
   // before the capability gate and schema dropdowns fire against it.
   (async () => {
-    try { await loadServers(); } catch (e) { /* default server still works */ }
-    gateCapabilities();
+    let servers = [];
+    try { servers = await loadServers(); } catch (e) { /* default server still works */ }
+    await gateCapabilities();
     populateSchemas();
+    // First-run onboarding: on a supervisor with nothing watched yet, the
+    // Servers screen IS the next step — open it so "+ Add server" is the
+    // first thing the operator sees (once per tab).
+    const ONBOARD_KEY = "bintrail_console_onboarded";
+    if (capsCache.monitor && servers.every((s) => !s.has_source) && !sessionStorage.getItem(ONBOARD_KEY)) {
+      try { sessionStorage.setItem(ONBOARD_KEY, "1"); } catch (e) { /* storage unavailable */ }
+      openServersModal();
+    }
   })();
 }
 


### PR DESCRIPTION
## Summary

> "¿Por qué tengo que pasar info del MySQL que quiero monitorear durante la instalación?" — you don't anymore.

The control plane (#400) already does doctor → provision → stream from the UI; requiring `SOURCE_DSN` at install was a leftover from the morning the compose shipped (#397), hours before the control plane did. The quickstart is now:

```sh
curl -fsSLO https://raw.githubusercontent.com/dbtrail/bintrail/main/docker-compose.yml
docker compose up -d
docker compose logs -f bintrail     # → open the URL → "+ Add server"
```

**Nothing to configure.** The DSN moves to the UI — where it gets doctor remediation cards instead of a blind `.env` edit.

## Changes

- **`bintrail up --console` starts source-less**: index init + console + supervisor + boot `Reconcile`; the preflight runs per-server when added from the UI. Classic `up` (no `--console`) still requires `--source-dsn`, with an actionable hint.
- **Compose**: `SOURCE_DSN` becomes an optional `.env` knob (stream one source at boot); command branches to the source-less daemon when unset.
- **First-boot robustness**: under `--console`, `up` waits (≤90s, logged) for the index MySQL — the official mysql image briefly accepts-then-drops connections during first init, which previously caused **5 container restarts and 5 regenerated console tokens** on a cold boot. After: **0 restarts, 1 token** (measured).
- **Onboarding**: a fresh supervisor with nothing watched auto-opens the Servers screen (once per tab), so "+ Add server" is the first thing the operator sees.
- README/install.md/docker.md/.env.example → the 3-line story.

## Verification

- Cold isolated compose with **no `.env`**: clean boot (`Waiting for index MySQL…` → single token), add-server via API (doctor 0 failed → started), events flowing from the UI-added source.
- Headless-Chrome drive: onboarding modal auto-opens on fresh boot, gated by the `monitor` capability, not re-opened after reload.
- `TestRunUpSourceDSNValidation` covers the new flag semantics; full unit + integration suites green.

## Note

The README's 3-line promise activates for `ghcr :latest` users with the **next release** (current `latest` = v0.8.1 still requires SOURCE_DSN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)