### PR TITLE
fix(demo-image): re-include demo/image in the docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,9 @@
 .claude
 .DS_Store
 demo
+# …but the published demo image's build files live under demo/image (the
+# rename from appliance/, #410) — re-include them in the build context.
+!demo/image
 dist
 docs
 *.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **The `bintrail-demo` image build was broken by its own rename**: `.dockerignore` excludes `demo/` (the dev stack never belonged in the main image's build context), and the rename moved the demo image's build files exactly there — the v0.8.3 `demo-image` workflow failed with `"/demo/image/my.cnf": not found`. Re-included via a `!demo/image` negation (verified against BuildKit: a negated child of an excluded directory is honored).
+
 ## [0.8.3] - 2026-06-06
 
 ### Changed


### PR DESCRIPTION
## Summary

The v0.8.3 `demo-image` workflow failed with `"/demo/image/my.cnf": not found`: `.dockerignore` excludes `demo/` (the dev stack never belonged in the main image's build context), and the appliance→demo rename (#410) moved the demo image's build files exactly there.

One-line fix: `!demo/image` negation. **Verified locally** by building a minimal Dockerfile with the same `COPY` lines over the same context — BuildKit honors a negated child of an excluded directory.

Unblocks publishing `ghcr.io/dbtrail/bintrail-demo` (needs a tag whose tree contains this fix → v0.8.4 after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)