### PR TITLE
control plane F4: multi-source hardening — per-source metrics, replica detection, richer states

### DIFF
--- a/cmd/bintrail/doctor.go
+++ b/cmd/bintrail/doctor.go
@@ -523,6 +523,22 @@ func checkSchemaVisibility(ctx context.Context, db *sql.DB, schemas []string) ch
 		if len(schemas) > 0 {
 			filter = strings.Join(schemas, ", ")
 		}
+		// Zero tables has two very different causes: the schema genuinely
+		// has no tables yet (fix: create one) vs. bintrail cannot see it at
+		// all (fix: grants / schema-name typo). Telling the operator to
+		// GRANT when the schema is simply empty sends them down the wrong
+		// path (#402).
+		if n, err := countVisibleSchemas(ctx, db, schemas); err == nil && n > 0 {
+			return checkResult{
+				Name:   "Schema visibility",
+				Status: statusFail,
+				Detail: "schema visible but contains no tables yet: " + filter,
+				Remediation: "Bintrail snapshots table schemas when monitoring starts and cannot monitor\n" +
+					"an empty schema. Create at least one table first:\n\n" +
+					"  CREATE TABLE <schema>.<table> (id INT PRIMARY KEY, ...);\n\n" +
+					"Then start monitoring again.",
+			}
+		}
 		return checkResult{
 			Name:   "Schema visibility",
 			Status: statusFail,
@@ -531,7 +547,8 @@ func checkSchemaVisibility(ctx context.Context, db *sql.DB, schemas []string) ch
 				"Grant minimum read access:\n\n" +
 				"  GRANT SELECT ON *.* TO <bintrail-user>;\n\n" +
 				"Or scope to the schemas you want indexed:\n\n" +
-				"  GRANT SELECT ON <schema>.* TO <bintrail-user>;",
+				"  GRANT SELECT ON <schema>.* TO <bintrail-user>;\n\n" +
+				"Also double-check the schema names for typos.",
 		}
 	}
 	return checkResult{
@@ -539,6 +556,29 @@ func checkSchemaVisibility(ctx context.Context, db *sql.DB, schemas []string) ch
 		Status: statusPass,
 		Detail: fmt.Sprintf("%d tables across %d schemas", tableCount, schemaCount),
 	}
+}
+
+// countVisibleSchemas reports how many of the requested schemas exist and are
+// visible to the doctor's connection (all non-system schemas when the filter
+// is empty). It distinguishes "schema is empty" from "schema is invisible"
+// in checkSchemaVisibility.
+func countVisibleSchemas(ctx context.Context, db *sql.DB, schemas []string) (int, error) {
+	var query string
+	var args []any
+	if len(schemas) > 0 {
+		placeholders := strings.TrimRight(strings.Repeat("?,", len(schemas)), ",")
+		query = fmt.Sprintf(`SELECT COUNT(*) FROM information_schema.SCHEMATA
+			WHERE SCHEMA_NAME IN (%s)`, placeholders)
+		for _, s := range schemas {
+			args = append(args, s)
+		}
+	} else {
+		query = `SELECT COUNT(*) FROM information_schema.SCHEMATA
+			WHERE SCHEMA_NAME NOT IN ('information_schema','performance_schema','mysql','sys')`
+	}
+	var n int
+	err := db.QueryRowContext(ctx, query, args...).Scan(&n)
+	return n, err
 }
 
 func checkIndexConnection(ctx context.Context, dsn, dbName string) checkResult {

--- a/cmd/bintrail/doctor_test.go
+++ b/cmd/bintrail/doctor_test.go
@@ -607,3 +607,84 @@ func TestDoctorReportWriteText(t *testing.T) {
 		}
 	}
 }
+
+// TestCheckSchemaVisibility_emptyVsInvisible pins the #402 discrimination:
+// zero tables because the schema is EMPTY routes the operator to "create a
+// table", zero tables because the schema is INVISIBLE routes to grants — the
+// wrong remediation sends a 3am operator down the wrong path.
+func TestCheckSchemaVisibility_emptyVsInvisible(t *testing.T) {
+	ctx := t.Context()
+	countRows := func(tables, schemas int) *sqlmock.Rows {
+		return sqlmock.NewRows([]string{"COUNT(*)", "COUNT(DISTINCT TABLE_SCHEMA)"}).AddRow(tables, schemas)
+	}
+	schemataRows := func(n int) *sqlmock.Rows {
+		return sqlmock.NewRows([]string{"COUNT(*)"}).AddRow(n)
+	}
+
+	cases := []struct {
+		name            string
+		setup           func(sqlmock.Sqlmock)
+		wantStatus      checkStatus
+		wantDetail      string
+		wantRemediation string
+	}{
+		{
+			name: "schema exists but is empty → create-a-table",
+			setup: func(m sqlmock.Sqlmock) {
+				m.ExpectQuery("SELECT COUNT").WillReturnRows(countRows(0, 0))
+				m.ExpectQuery("SELECT COUNT").WillReturnRows(schemataRows(1))
+			},
+			wantStatus:      statusFail,
+			wantDetail:      "no tables yet",
+			wantRemediation: "Create at least one table",
+		},
+		{
+			name: "schema invisible → grants",
+			setup: func(m sqlmock.Sqlmock) {
+				m.ExpectQuery("SELECT COUNT").WillReturnRows(countRows(0, 0))
+				m.ExpectQuery("SELECT COUNT").WillReturnRows(schemataRows(0))
+			},
+			wantStatus:      statusFail,
+			wantDetail:      "no tables visible",
+			wantRemediation: "GRANT SELECT",
+		},
+		{
+			name: "SCHEMATA probe fails → degrade to grants, never crash",
+			setup: func(m sqlmock.Sqlmock) {
+				m.ExpectQuery("SELECT COUNT").WillReturnRows(countRows(0, 0))
+				m.ExpectQuery("SELECT COUNT").WillReturnError(errors.New("denied"))
+			},
+			wantStatus:      statusFail,
+			wantDetail:      "no tables visible",
+			wantRemediation: "GRANT SELECT",
+		},
+		{
+			name: "tables visible → pass",
+			setup: func(m sqlmock.Sqlmock) {
+				m.ExpectQuery("SELECT COUNT").WillReturnRows(countRows(5, 2))
+			},
+			wantStatus: statusPass,
+			wantDetail: "5 tables across 2 schemas",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("sqlmock: %v", err)
+			}
+			defer db.Close()
+			c.setup(mock)
+			got := checkSchemaVisibility(ctx, db, []string{"shop"})
+			if got.Status != c.wantStatus {
+				t.Errorf("status = %q, want %q (detail=%q)", got.Status, c.wantStatus, got.Detail)
+			}
+			if !strings.Contains(got.Detail, c.wantDetail) {
+				t.Errorf("Detail = %q, want it to contain %q", got.Detail, c.wantDetail)
+			}
+			if c.wantRemediation != "" && !strings.Contains(got.Remediation, c.wantRemediation) {
+				t.Errorf("Remediation = %q, want it to contain %q", got.Remediation, c.wantRemediation)
+			}
+		})
+	}
+}

--- a/cmd/bintrail/init.go
+++ b/cmd/bintrail/init.go
@@ -542,6 +542,8 @@ const ddlStreamState = `CREATE TABLE IF NOT EXISTS stream_state (
     last_checkpoint  DATETIME        NOT NULL,
     server_id        INT UNSIGNED    NOT NULL,
     bintrail_id      CHAR(36)        NULL DEFAULT NULL,
+    gap_lost_at      DATETIME        DEFAULT NULL COMMENT 'when an unfillable binlog gap forced an auto-advance (events permanently lost); cleared by an explicit monitor Stop or --reset',
+    gap_lost_detail  TEXT            DEFAULT NULL COMMENT 'human-readable description of the lost gap',
     CONSTRAINT single_row CHECK (id = 1)
 ) ENGINE=InnoDB`
 

--- a/cmd/bintrail/monitor.go
+++ b/cmd/bintrail/monitor.go
@@ -66,14 +66,28 @@ var (
 	// a permanent "failed" — the circuit breaker against a misconfigured
 	// source retrying forever. Press Start (or restart the daemon) to re-arm.
 	monitorGiveUpAfter = 6 * time.Hour
+	// Crash-loop backoff: retry delay doubles from base to cap; a run that
+	// survives monitorHealthyReset resets both the attempt counter and the
+	// circuit-breaker clock.
+	monitorBackoffBase  = 15 * time.Second
+	monitorBackoffCap   = 5 * time.Minute
+	monitorHealthyReset = 10 * time.Minute
 )
 
 // monitorJob is one supervised stream.
 type monitorJob struct {
 	cancel context.CancelFunc
 	done   chan struct{}
+	// indexDSN is the entry's per-source index database — set once at job
+	// creation (before the job is published), immutable after. Stop uses it
+	// to clear the durable gap-loss record with its own short-lived
+	// connection (lockDB belongs to the run goroutine; sharing it from Stop
+	// would race Start's provisioning window).
+	indexDSN string
 	// lockDB's single dedicated connection holds the advisory lock for this
-	// entry; closing it releases the lock.
+	// entry; closing it releases the lock. Written by Start before the run
+	// goroutine launches and read only by run's teardown — never from other
+	// goroutines.
 	lockDB *sql.DB
 
 	mu      sync.Mutex
@@ -96,6 +110,15 @@ func (j *monitorJob) set(state, lastErr string) {
 	j.mu.Lock()
 	j.state, j.lastErr, j.since = state, lastErr, time.Now().UTC()
 	j.mu.Unlock()
+}
+
+// storedState returns the raw state-machine value (pending|running|failed|
+// stopped) without the derived stalled/lost_position presentation — for
+// callers that need goroutine liveness, not operator-facing health.
+func (j *monitorJob) storedState() string {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	return j.state
 }
 
 // progress records stream liveness and performs the pending→running flip:
@@ -242,11 +265,14 @@ func (m *monitorSupervisor) Start(ctx context.Context, e console.ServerEntry) er
 
 	m.mu.Lock()
 	if j, ok := m.jobs[e.ID]; ok {
-		switch j.snapshot().State {
-		// Live stream (stalled/lost_position are running variants — the
-		// goroutine still holds the advisory lock; superseding it would
-		// deadlock on our own lock). Restart a stalled stream via Stop+Start.
-		case "running", "pending", "stalled", "lost_position":
+		// Gate on the STORED state, not the derived presentation: stalled
+		// and lost_position are running variants (the goroutine still holds
+		// the advisory lock; superseding it would deadlock on our own lock —
+		// restart a stalled stream via Stop+Start), and checking the stored
+		// machine means new derived states can never fall through to the
+		// cancel below by omission.
+		switch j.storedState() {
+		case "running", "pending":
 			m.mu.Unlock()
 			return nil // idempotent
 		}
@@ -255,7 +281,7 @@ func (m *monitorSupervisor) Start(ctx context.Context, e console.ServerEntry) er
 	}
 	// Reserve the slot as pending while provisioning runs outside the lock.
 	jobCtx, cancel := context.WithCancel(m.baseCtx)
-	job := &monitorJob{cancel: cancel, done: make(chan struct{})}
+	job := &monitorJob{cancel: cancel, done: make(chan struct{}), indexDSN: e.DSN}
 	job.set("pending", "")
 	m.jobs[e.ID] = job
 	m.mu.Unlock()
@@ -295,12 +321,18 @@ func (m *monitorSupervisor) Start(ctx context.Context, e console.ServerEntry) er
 	// its advanced checkpoint, a restarted daemon sees no gap and the hook
 	// never re-fires — the lost_position state must be restored from
 	// stream_state or the data loss silently un-surfaces. Cleared only by an
-	// explicit Stop (the operator's acknowledgment).
+	// explicit Stop (the operator's acknowledgment). ErrNoRows is the normal
+	// fresh-start case; any other error means a recorded loss may go
+	// un-surfaced this run, which deserves a breadcrumb.
 	var gapDetail sql.NullString
-	if err := idxDB.QueryRowContext(ctx,
-		`SELECT gap_lost_detail FROM stream_state WHERE id = 1`).Scan(&gapDetail); err == nil &&
-		gapDetail.Valid && gapDetail.String != "" {
+	err = idxDB.QueryRowContext(ctx,
+		`SELECT gap_lost_detail FROM stream_state WHERE id = 1`).Scan(&gapDetail)
+	switch {
+	case err == nil && gapDetail.Valid && gapDetail.String != "":
 		job.markLostPosition(gapDetail.String)
+	case err != nil && !errors.Is(err, sql.ErrNoRows):
+		slog.Warn("could not re-hydrate gap-loss record; a recorded data loss may not be re-surfaced this run",
+			"entry", e.ID, "error", scrubMonitorErr(err, e.SourceDSN, e.DSN))
 	}
 	idxDB.Close()
 
@@ -378,11 +410,6 @@ func (m *monitorSupervisor) run(ctx context.Context, job *monitorJob, e console.
 		}
 	}()
 
-	const (
-		backoffBase  = 15 * time.Second
-		backoffCap   = 5 * time.Minute
-		healthyReset = 10 * time.Minute
-	)
 	attempt := 0
 	var crashLoopSince time.Time // first failure of the current loop; zero = healthy
 	for {
@@ -393,7 +420,7 @@ func (m *monitorSupervisor) run(ctx context.Context, job *monitorJob, e console.
 			job.set("stopped", "")
 			return
 		}
-		if time.Since(started) > healthyReset {
+		if time.Since(started) > monitorHealthyReset {
 			attempt = 0
 			crashLoopSince = time.Time{}
 		}
@@ -408,7 +435,7 @@ func (m *monitorSupervisor) run(ctx context.Context, job *monitorJob, e console.
 				scrubbed, looping.Round(time.Minute)))
 			return
 		}
-		delay := min(backoffBase<<attempt, backoffCap)
+		delay := min(monitorBackoffBase<<attempt, monitorBackoffCap)
 		attempt++
 		slog.Warn("monitored stream failed; retrying with backoff",
 			"server", e.Name, "entry", e.ID, "delay", delay, "error", scrubbed)
@@ -438,10 +465,20 @@ func (m *monitorSupervisor) Stop(ctx context.Context, entryID string) error {
 	if !ok {
 		return nil
 	}
-	if job.lockDB != nil {
-		if _, err := job.lockDB.ExecContext(ctx, `UPDATE stream_state
-			SET gap_lost_at = NULL, gap_lost_detail = NULL WHERE id = 1`); err != nil {
-			slog.Warn("could not clear gap-loss record on stop", "entry", entryID, "error", err)
+	// Clear with a short-lived connection of our own: lockDB belongs to the
+	// run goroutine (reading it here would race Start's provisioning window,
+	// and it is already closed when the stream gave up or exited). On
+	// failure the record survives — the next Start re-raises lost_position,
+	// which fails safe: a real past loss is re-surfaced, never dropped.
+	if job.indexDSN != "" {
+		if db, err := config.Connect(job.indexDSN); err != nil {
+			slog.Warn("could not clear gap-loss record on stop", "entry", entryID, "error", scrubMonitorErrText(err.Error(), job.indexDSN))
+		} else {
+			if _, err := db.ExecContext(ctx, `UPDATE stream_state
+				SET gap_lost_at = NULL, gap_lost_detail = NULL WHERE id = 1`); err != nil {
+				slog.Warn("could not clear gap-loss record on stop", "entry", entryID, "error", scrubMonitorErrText(err.Error(), job.indexDSN))
+			}
+			db.Close()
 		}
 	}
 	job.cancel()

--- a/cmd/bintrail/monitor.go
+++ b/cmd/bintrail/monitor.go
@@ -41,11 +41,32 @@ type monitorSupervisor struct {
 	// databases are derived from it (same server, same credentials,
 	// different DBName).
 	bootIndexDSN string
+	// registry lists the other monitored entries — Doctor compares a
+	// candidate source against them for replica/duplicate detection. May be
+	// nil (tests); the check is skipped then.
+	registry *console.Registry
+	// streamFn runs one supervised stream; a seam for unit tests, streamOne
+	// in production.
+	streamFn func(ctx context.Context, cfg streamConfig) error
 
 	mu   sync.Mutex
 	jobs map[string]*monitorJob
 	wg   sync.WaitGroup
 }
+
+// Supervisor health thresholds. Vars, not consts, so tests can shrink them.
+var (
+	// monitorStalledAfter: a running stream that has neither saved a
+	// checkpoint nor flushed a batch for this long is reported "stalled".
+	// The checkpoint ticker fires even with zero events, so an idle-but-
+	// healthy source never trips this — only a genuinely wedged loop does.
+	monitorStalledAfter = 5 * time.Minute
+	// monitorGiveUpAfter: a stream that has been crash-looping continuously
+	// for this long (no healthy run in between) stops retrying and reports
+	// a permanent "failed" — the circuit breaker against a misconfigured
+	// source retrying forever. Press Start (or restart the daemon) to re-arm.
+	monitorGiveUpAfter = 6 * time.Hour
+)
 
 // monitorJob is one supervised stream.
 type monitorJob struct {
@@ -56,9 +77,17 @@ type monitorJob struct {
 	lockDB *sql.DB
 
 	mu      sync.Mutex
-	state   string // pending|running|failed|stopped
+	state   string // stored: pending|running|failed|stopped
 	lastErr string
 	since   time.Time
+	// lastProgress is when the stream last proved liveness (checkpoint saved
+	// or batch flushed) — feeds the derived "stalled" state.
+	lastProgress time.Time
+	// lostPosition, when non-empty, records that an unfillable binlog gap
+	// forced an auto-advance: events were permanently lost. Sticky for the
+	// job's lifetime (cleared by Stop + Start) — feeds the derived
+	// "lost_position" state.
+	lostPosition string
 }
 
 func (j *monitorJob) set(state, lastErr string) {
@@ -67,20 +96,69 @@ func (j *monitorJob) set(state, lastErr string) {
 	j.mu.Unlock()
 }
 
+// progress records stream liveness and performs the pending→running flip:
+// the supervisor reports "pending" from launch until the stream saves its
+// first checkpoint (or flushes its first batch) — before that the goroutine
+// is still connecting/snapshotting and a RUNNING badge would lie (#407).
+func (j *monitorJob) progress() {
+	j.mu.Lock()
+	j.lastProgress = time.Now().UTC()
+	if j.state == "pending" {
+		j.state, j.lastErr, j.since = "running", "", j.lastProgress
+	}
+	j.mu.Unlock()
+}
+
+func (j *monitorJob) markLostPosition(detail string) {
+	j.mu.Lock()
+	j.lostPosition = detail
+	j.mu.Unlock()
+}
+
+// streamHooks wires this job as its stream's liveness observer.
+func (j *monitorJob) streamHooks() *streamHooks {
+	return &streamHooks{
+		OnCheckpoint:     j.progress,
+		OnIndexed:        func(int64) { j.progress() },
+		OnGapAutoAdvance: j.markLostPosition,
+	}
+}
+
+// snapshot reports the job's state, deriving the two "running but not
+// healthy" presentations at read time (the stored state machine stays
+// pending|running|failed|stopped):
+//   - "stalled":       running, but no checkpoint/flush for monitorStalledAfter
+//   - "lost_position": running, but a gap auto-advance lost events
+//
+// A wedged stream beats a historical data-loss note, so stalled wins when
+// both apply.
 func (j *monitorJob) snapshot() console.MonitorStatus {
 	j.mu.Lock()
 	defer j.mu.Unlock()
 	st := console.MonitorStatus{State: j.state, LastError: j.lastErr}
+	if j.state == "running" {
+		if idle := time.Since(j.lastProgress); !j.lastProgress.IsZero() && idle > monitorStalledAfter {
+			st.State = "stalled"
+			st.LastError = fmt.Sprintf("no progress for %s: no events indexed and no checkpoint saved — the stream is connected but not advancing", idle.Round(time.Second))
+		} else if j.lostPosition != "" {
+			st.State = "lost_position"
+			st.LastError = j.lostPosition
+		}
+	}
 	if !j.since.IsZero() {
 		st.Since = j.since.Format(time.RFC3339)
 	}
 	return st
 }
 
-func newMonitorSupervisor(baseCtx context.Context, bootIndexDSN string) *monitorSupervisor {
+// newMonitorSupervisor builds the control plane. reg may be nil (tests) —
+// Doctor's replica/duplicate detection is skipped then.
+func newMonitorSupervisor(baseCtx context.Context, bootIndexDSN string, reg *console.Registry) *monitorSupervisor {
 	return &monitorSupervisor{
 		baseCtx:      baseCtx,
 		bootIndexDSN: bootIndexDSN,
+		registry:     reg,
+		streamFn:     streamOne,
 		jobs:         map[string]*monitorJob{},
 	}
 }
@@ -128,6 +206,23 @@ func (m *monitorSupervisor) Doctor(ctx context.Context, e console.ServerEntry) (
 			Remediation: c.Remediation,
 		}
 	}
+
+	// Replica/duplicate detection against the other monitored entries —
+	// warn-only per the approved decision (#402): an amber card, never a
+	// block. Supervisor-only: the standalone `bintrail doctor` has no
+	// registry to compare against.
+	if c := m.replicaOverlapCheck(ctx, e); c != nil {
+		c.Detail = scrubMonitorErrText(c.Detail, e.SourceDSN, e.DSN)
+		out.Checks = append(out.Checks, *c)
+		switch c.Status {
+		case "warn":
+			out.Warnings++
+		case "skip":
+			out.Skipped++
+		default:
+			out.Passed++
+		}
+	}
 	return out, nil
 }
 
@@ -145,8 +240,11 @@ func (m *monitorSupervisor) Start(ctx context.Context, e console.ServerEntry) er
 
 	m.mu.Lock()
 	if j, ok := m.jobs[e.ID]; ok {
-		st := j.snapshot().State
-		if st == "running" || st == "pending" {
+		switch j.snapshot().State {
+		// Live stream (stalled/lost_position are running variants — the
+		// goroutine still holds the advisory lock; superseding it would
+		// deadlock on our own lock). Restart a stalled stream via Stop+Start.
+		case "running", "pending", "stalled", "lost_position":
 			m.mu.Unlock()
 			return nil // idempotent
 		}
@@ -228,15 +326,20 @@ func (m *monitorSupervisor) Start(ctx context.Context, e console.ServerEntry) er
 		}
 	}
 	cfg := streamConfig{
-		IndexDSN:   e.DSN,
-		SourceDSN:  e.SourceDSN,
-		ServerID:   serverID,
-		BatchSize:  1000,
-		Schemas:    e.Schemas,
-		Checkpoint: 10,
-		SSLMode:    "preferred",
-		Format:     "text",
-		GapTimeout: 30,
+		IndexDSN:  e.DSN,
+		SourceDSN: e.SourceDSN,
+		ServerID:  serverID,
+		BatchSize: 1000,
+		Schemas:   e.Schemas,
+		// MetricsSource keys this stream's Prometheus series; MetricsAddr
+		// stays empty on purpose — the daemon serves ONE /metrics endpoint
+		// for all supervised streams (per-stream binds would conflict).
+		MetricsSource: e.ID,
+		Checkpoint:    10,
+		SSLMode:       "preferred",
+		Format:        "text",
+		GapTimeout:    30,
+		Hooks:         job.streamHooks(),
 	}
 
 	m.wg.Add(1)
@@ -247,7 +350,12 @@ func (m *monitorSupervisor) Start(ctx context.Context, e console.ServerEntry) er
 // run supervises one stream with crash-loop backoff: a stream that errors is
 // restarted (15s doubling to a 5m cap, counter reset after 10 healthy
 // minutes); the job reports "failed" with the scrubbed error between
-// attempts. Cancellation (stop verb / daemon shutdown) exits cleanly.
+// attempts. The job stays "pending" from launch until the stream's first
+// checkpoint/flush flips it to "running" via the liveness hooks. A stream
+// that crash-loops continuously for monitorGiveUpAfter trips the circuit
+// breaker: permanent "failed", no more retries, advisory lock released —
+// Start (or a daemon restart) re-arms it. Cancellation (stop verb / daemon
+// shutdown) exits cleanly.
 func (m *monitorSupervisor) run(ctx context.Context, job *monitorJob, e console.ServerEntry, cfg streamConfig) {
 	defer m.wg.Done()
 	defer close(job.done)
@@ -263,20 +371,32 @@ func (m *monitorSupervisor) run(ctx context.Context, job *monitorJob, e console.
 		healthyReset = 10 * time.Minute
 	)
 	attempt := 0
+	var crashLoopSince time.Time // first failure of the current loop; zero = healthy
 	for {
-		job.set("running", "")
+		job.set("pending", "")
 		started := time.Now()
-		err := streamOne(ctx, cfg)
+		err := m.streamFn(ctx, cfg)
 		if ctx.Err() != nil || err == nil {
 			job.set("stopped", "")
 			return
 		}
 		if time.Since(started) > healthyReset {
 			attempt = 0
+			crashLoopSince = time.Time{}
+		}
+		if crashLoopSince.IsZero() {
+			crashLoopSince = started
+		}
+		scrubbed := scrubMonitorErr(err, e.SourceDSN, e.DSN)
+		if looping := time.Since(crashLoopSince); looping > monitorGiveUpAfter {
+			slog.Error("monitored stream crash-looped past the give-up threshold; not retrying",
+				"server", e.Name, "entry", e.ID, "looping_for", looping.Round(time.Minute), "error", scrubbed)
+			job.set("failed", fmt.Sprintf("%s (gave up after %s of crash-looping — fix the issue, then press Start to retry)",
+				scrubbed, looping.Round(time.Minute)))
+			return
 		}
 		delay := min(backoffBase<<attempt, backoffCap)
 		attempt++
-		scrubbed := scrubMonitorErr(err, e.SourceDSN, e.DSN)
 		slog.Warn("monitored stream failed; retrying with backoff",
 			"server", e.Name, "entry", e.ID, "delay", delay, "error", scrubbed)
 		job.set("failed", scrubbed+" (retrying)")

--- a/cmd/bintrail/monitor.go
+++ b/cmd/bintrail/monitor.go
@@ -84,8 +84,10 @@ type monitorJob struct {
 	// or batch flushed) — feeds the derived "stalled" state.
 	lastProgress time.Time
 	// lostPosition, when non-empty, records that an unfillable binlog gap
-	// forced an auto-advance: events were permanently lost. Sticky for the
-	// job's lifetime (cleared by Stop + Start) — feeds the derived
+	// forced an auto-advance: events were permanently lost. The fact is
+	// also persisted in stream_state (gap_lost_at/_detail) and re-hydrated
+	// by Start, so it survives daemon restarts; only an explicit Stop (the
+	// operator's acknowledgment) clears it — feeds the derived
 	// "lost_position" state.
 	lostPosition string
 }
@@ -289,6 +291,17 @@ func (m *monitorSupervisor) Start(ctx context.Context, e console.ServerEntry) er
 		idxDB.Close()
 		return fail(fmt.Errorf("schema migration: %w", err))
 	}
+	// Re-hydrate a durable gap-loss record (#402): once the stream persisted
+	// its advanced checkpoint, a restarted daemon sees no gap and the hook
+	// never re-fires — the lost_position state must be restored from
+	// stream_state or the data loss silently un-surfaces. Cleared only by an
+	// explicit Stop (the operator's acknowledgment).
+	var gapDetail sql.NullString
+	if err := idxDB.QueryRowContext(ctx,
+		`SELECT gap_lost_detail FROM stream_state WHERE id = 1`).Scan(&gapDetail); err == nil &&
+		gapDetail.Valid && gapDetail.String != "" {
+		job.markLostPosition(gapDetail.String)
+	}
 	idxDB.Close()
 
 	// ── Advisory lock: refuse to double-stream one entry ─────────────────
@@ -410,7 +423,11 @@ func (m *monitorSupervisor) run(ctx context.Context, job *monitorJob, e console.
 }
 
 // Stop implements console.MonitorController. Idempotent; waits briefly for
-// the stream to flush its final checkpoint.
+// the stream to flush its final checkpoint. An explicit Stop is also the
+// operator's acknowledgment of a recorded data loss: it clears the durable
+// gap-loss record so the next Start begins clean. Daemon shutdown does NOT
+// come through here (Shutdown cancels jobs directly), so a restart preserves
+// the record.
 func (m *monitorSupervisor) Stop(ctx context.Context, entryID string) error {
 	m.mu.Lock()
 	job, ok := m.jobs[entryID]
@@ -420,6 +437,12 @@ func (m *monitorSupervisor) Stop(ctx context.Context, entryID string) error {
 	m.mu.Unlock()
 	if !ok {
 		return nil
+	}
+	if job.lockDB != nil {
+		if _, err := job.lockDB.ExecContext(ctx, `UPDATE stream_state
+			SET gap_lost_at = NULL, gap_lost_detail = NULL WHERE id = 1`); err != nil {
+			slog.Warn("could not clear gap-loss record on stop", "entry", entryID, "error", err)
+		}
 	}
 	job.cancel()
 	select {

--- a/cmd/bintrail/monitor_integration_test.go
+++ b/cmd/bintrail/monitor_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dbtrail/bintrail/internal/config"
 	"github.com/dbtrail/bintrail/internal/console"
 	"github.com/dbtrail/bintrail/internal/testutil"
 )
@@ -410,5 +411,102 @@ func TestIntegrationLostPositionDurable(t *testing.T) {
 	waitState("running", 30*time.Second)
 	if st := sup.Status(entry.ID); st.State != "running" || st.LastError != "" {
 		t.Errorf("post-ack status = %+v, want clean running", st)
+	}
+}
+
+// TestIntegrationReplicaOverlapSQL exercises the replica-detection SQL
+// against real MySQL — the unit tests cover only the pure GTID helpers. The
+// shared test container runs gtid_mode=OFF, so the full warn path is not
+// reproducible here; what this test proves is (a) the supervisor-side flow
+// up to and including the gtid_mode gate (registry peers → source connect →
+// skip card), and (b) loadPeerIdentity's queries against a provisioned
+// per-source index DB (bintrail_servers + stream_state scan shapes).
+func TestIntegrationReplicaOverlapSQL(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, bootName := testutil.CreateTestDB(t)
+	bootDSN := testutil.IntegrationDSN(bootName)
+
+	// A registry with TWO source-bearing entries so Doctor(A) has peer B.
+	regPath := t.TempDir() + "/servers.yaml"
+	reg, err := console.LoadRegistry(regPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entryA, err := reg.Add(console.ServerEntry{Name: "cand", SourceDSN: testutil.BaseDSN() + "/", DSN: bootDSN})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sup := newMonitorSupervisor(ctx, bootDSN, reg)
+
+	// Peer B's per-source index DB, provisioned with the real tables and
+	// seeded with an identity + an accumulated GTID set.
+	peerDB, peerName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, peerDB)
+	const peerUUID = "3e11fa47-71ca-11e1-9e33-c80aa9429562"
+	if _, err := peerDB.Exec(`INSERT INTO bintrail_servers
+		(bintrail_id, server_uuid, host, port, username)
+		VALUES (UUID(), ?, 'peer-host', 3306, 'rep')`, peerUUID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := peerDB.Exec(`INSERT INTO stream_state
+		(id, mode, gtid_set, last_checkpoint, server_id)
+		VALUES (1, 'gtid', ?, UTC_TIMESTAMP(), 12345)`, peerUUID+":1-100"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := reg.Add(console.ServerEntry{
+		Name: "peer", SourceDSN: testutil.BaseDSN() + "/", DSN: testutil.IntegrationDSN(peerName),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// (a) Doctor on the candidate: container runs gtid_mode=OFF, so the
+	// check must surface as an explicit skip card — not vanish, not warn.
+	report, err := sup.Doctor(ctx, entryA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var card *console.DoctorCheck
+	for i := range report.Checks {
+		if report.Checks[i].Name == "Replica / duplicate detection" {
+			card = &report.Checks[i]
+		}
+	}
+	if card == nil {
+		t.Fatalf("replica check card missing from doctor report: %+v", report.Checks)
+	}
+	if card.Status != "skip" || !strings.Contains(card.Detail, "gtid_mode") {
+		t.Fatalf("card = %+v, want skip mentioning gtid_mode (container runs GTID off)", *card)
+	}
+
+	// (b) loadPeerIdentity's SQL against the seeded per-source DB.
+	gotUUID, gotSet, err := loadPeerIdentity(ctx, testutil.IntegrationDSN(peerName))
+	if err != nil {
+		t.Fatalf("loadPeerIdentity: %v", err)
+	}
+	if gotUUID != peerUUID {
+		t.Errorf("peer uuid = %q, want %q", gotUUID, peerUUID)
+	}
+	if gotSet != peerUUID+":1-100" {
+		t.Errorf("peer gtid set = %q, want %q", gotSet, peerUUID+":1-100")
+	}
+
+	// (c) The candidate-side identity query shape (unreachable above because
+	// of the gtid_mode gate): must scan into two strings even with GTID off.
+	srcDB, err := config.Connect(testutil.BaseDSN() + "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srcDB.Close()
+	var candUUID, candExecuted string
+	if err := srcDB.QueryRowContext(ctx,
+		"SELECT @@server_uuid, @@global.gtid_executed").Scan(&candUUID, &candExecuted); err != nil {
+		t.Fatalf("candidate identity query: %v", err)
+	}
+	if candUUID == "" {
+		t.Error("candidate server_uuid came back empty")
 	}
 }

--- a/cmd/bintrail/monitor_integration_test.go
+++ b/cmd/bintrail/monitor_integration_test.go
@@ -415,12 +415,14 @@ func TestIntegrationLostPositionDurable(t *testing.T) {
 }
 
 // TestIntegrationReplicaOverlapSQL exercises the replica-detection SQL
-// against real MySQL — the unit tests cover only the pure GTID helpers. The
-// shared test container runs gtid_mode=OFF, so the full warn path is not
-// reproducible here; what this test proves is (a) the supervisor-side flow
-// up to and including the gtid_mode gate (registry peers → source connect →
-// skip card), and (b) loadPeerIdentity's queries against a provisioned
-// per-source index DB (bintrail_servers + stream_state scan shapes).
+// against real MySQL — the unit tests cover the pure GTID helpers and the
+// card assembly (evaluateReplicaOverlap). The shared test container runs
+// gtid_mode=OFF, so the full warn path is not reproducible here; what this
+// test proves is (a) the supervisor-side flow up to and including the
+// gtid_mode gate (registry peers → source connect → skip card), (b)
+// loadPeerIdentity's queries against a provisioned per-source index DB
+// (bintrail_servers + stream_state scan shapes), and (c)
+// loadCandidateIdentity's query shapes, unreachable in (a) past the gate.
 func TestIntegrationReplicaOverlapSQL(t *testing.T) {
 	testutil.SkipIfNoMySQL(t)
 
@@ -494,17 +496,19 @@ func TestIntegrationReplicaOverlapSQL(t *testing.T) {
 		t.Errorf("peer gtid set = %q, want %q", gotSet, peerUUID+":1-100")
 	}
 
-	// (c) The candidate-side identity query shape (unreachable above because
-	// of the gtid_mode gate): must scan into two strings even with GTID off.
-	srcDB, err := config.Connect(testutil.BaseDSN() + "/")
+	// (c) The candidate-side identity queries (unreachable above because of
+	// the gtid_mode gate) — exercise the production helper directly.
+	srcConn, err := config.Connect(testutil.BaseDSN() + "/")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer srcDB.Close()
-	var candUUID, candExecuted string
-	if err := srcDB.QueryRowContext(ctx,
-		"SELECT @@server_uuid, @@global.gtid_executed").Scan(&candUUID, &candExecuted); err != nil {
-		t.Fatalf("candidate identity query: %v", err)
+	defer srcConn.Close()
+	gtidMode, candUUID, _, err := loadCandidateIdentity(ctx, srcConn)
+	if err != nil {
+		t.Fatalf("loadCandidateIdentity: %v", err)
+	}
+	if !strings.EqualFold(gtidMode, "OFF") {
+		t.Errorf("gtid_mode = %q, want OFF on the shared test container", gtidMode)
 	}
 	if candUUID == "" {
 		t.Error("candidate server_uuid came back empty")

--- a/cmd/bintrail/monitor_integration_test.go
+++ b/cmd/bintrail/monitor_integration_test.go
@@ -290,3 +290,125 @@ func TestIntegrationDDLThenImmediateInserts(t *testing.T) {
 		t.Errorf("schema_changes must record the CREATE TABLE, got %d rows", changes)
 	}
 }
+
+// TestIntegrationLostPositionDurable verifies the #402 lost-position cycle
+// end to end: a recorded gap loss survives a supervisor restart (re-hydrated
+// from stream_state at Start), is presented as the derived "lost_position"
+// state, and is cleared only by an explicit Stop — the operator's
+// acknowledgment. The gap record itself is simulated (real binlog purging is
+// not reproducible on the shared test container); the streamOne write path
+// for it is the same UPDATE this test issues.
+func TestIntegrationLostPositionDurable(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, bootName := testutil.CreateTestDB(t)
+	bootDSN := testutil.IntegrationDSN(bootName)
+
+	srcDB, err := sql.Open("mysql", testutil.BaseDSN()+"/?parseTime=true")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srcDB.Close()
+	srcSchema := fmt.Sprintf("cp_lp_%d", time.Now().UnixNano()%1e9)
+	if _, err := srcDB.Exec("CREATE DATABASE " + srcSchema); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _, _ = srcDB.Exec("DROP DATABASE IF EXISTS " + srcSchema) })
+	if _, err := srcDB.Exec("CREATE TABLE " + srcSchema + ".items (id INT PRIMARY KEY, qty INT)"); err != nil {
+		t.Fatal(err)
+	}
+
+	sup := newMonitorSupervisor(ctx, bootDSN, nil)
+	entry := console.ServerEntry{
+		ID:        fmt.Sprintf("lptest%d", time.Now().UnixNano()%1e9),
+		Name:      "lost-position",
+		SourceDSN: testutil.BaseDSN() + "/",
+		Schemas:   srcSchema,
+	}
+	derived, err := sup.DeriveIndexDSN(entry.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry.DSN = derived
+	t.Cleanup(func() { _, _ = srcDB.Exec("DROP DATABASE IF EXISTS bintrail_idx_" + entry.ID) })
+
+	waitState := func(want string, timeout time.Duration) {
+		t.Helper()
+		deadline := time.Now().Add(timeout)
+		for time.Now().Before(deadline) {
+			if sup.Status(entry.ID).State == want {
+				return
+			}
+			time.Sleep(200 * time.Millisecond)
+		}
+		t.Fatalf("state = %+v, want %s", sup.Status(entry.ID), want)
+	}
+
+	// Run 1: healthy start, then stop (creates the per-source DB and its
+	// stream_state checkpoint row).
+	if err := sup.Start(ctx, entry); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = sup.Stop(context.Background(), entry.ID) })
+	waitState("running", 30*time.Second)
+
+	idxDB, err := sql.Open("mysql", derived)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer idxDB.Close()
+	// The flip to running can come from an indexed batch before the first
+	// checkpoint write — wait for the stream_state row itself.
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		var n int
+		if err := idxDB.QueryRow("SELECT COUNT(*) FROM stream_state WHERE id = 1").Scan(&n); err == nil && n == 1 {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	if err := sup.Stop(ctx, entry.ID); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	// Simulate what streamOne persists on an unfillable-gap auto-advance.
+	const gapDetail = "simulated: binlogs purged past saved position; events lost"
+	if _, err := idxDB.Exec(`UPDATE stream_state
+		SET gap_lost_at = UTC_TIMESTAMP(), gap_lost_detail = ? WHERE id = 1`, gapDetail); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run 2 (the "daemon restart"): Start must re-hydrate the record and the
+	// derived state must surface it instead of a clean RUNNING badge.
+	if err := sup.Start(ctx, entry); err != nil {
+		t.Fatalf("Start (run 2): %v", err)
+	}
+	waitState("lost_position", 30*time.Second)
+	if st := sup.Status(entry.ID); st.LastError != gapDetail {
+		t.Errorf("LastError = %q, want the hydrated gap detail", st.LastError)
+	}
+
+	// Explicit Stop acknowledges: the durable record must be cleared.
+	if err := sup.Stop(ctx, entry.ID); err != nil {
+		t.Fatalf("Stop (ack): %v", err)
+	}
+	var at, detail sql.NullString
+	if err := idxDB.QueryRow("SELECT gap_lost_at, gap_lost_detail FROM stream_state WHERE id = 1").Scan(&at, &detail); err != nil {
+		t.Fatal(err)
+	}
+	if at.Valid || detail.Valid {
+		t.Errorf("gap record not cleared on explicit Stop: at=%v detail=%v", at, detail)
+	}
+
+	// Run 3: a fresh start after acknowledgment is plain running again.
+	if err := sup.Start(ctx, entry); err != nil {
+		t.Fatalf("Start (run 3): %v", err)
+	}
+	waitState("running", 30*time.Second)
+	if st := sup.Status(entry.ID); st.State != "running" || st.LastError != "" {
+		t.Errorf("post-ack status = %+v, want clean running", st)
+	}
+}

--- a/cmd/bintrail/monitor_integration_test.go
+++ b/cmd/bintrail/monitor_integration_test.go
@@ -79,7 +79,7 @@ func TestIntegrationMonitorSupervisor(t *testing.T) {
 	t.Cleanup(func() { _, _ = srcDB.Exec("DROP DATABASE IF EXISTS " + srcSchema) })
 	mustExec("CREATE TABLE " + srcSchema + ".items (id INT PRIMARY KEY, qty INT)")
 
-	sup := newMonitorSupervisor(ctx, bootDSN)
+	sup := newMonitorSupervisor(ctx, bootDSN, nil)
 	entry := console.ServerEntry{
 		ID:        fmt.Sprintf("itest%d", time.Now().UnixNano()%1e9),
 		Name:      "integration",
@@ -139,7 +139,7 @@ func TestIntegrationMonitorSupervisor(t *testing.T) {
 	waitStreamLive(t, srcDB, idxDB, srcSchema, "items", "id")
 
 	// The advisory lock: a second supervisor (second daemon) must refuse.
-	sup2 := newMonitorSupervisor(ctx, bootDSN)
+	sup2 := newMonitorSupervisor(ctx, bootDSN, nil)
 	if err := sup2.Start(ctx, entry); err == nil || !strings.Contains(err.Error(), "already monitoring") {
 		t.Fatalf("second daemon Start: err=%v, want advisory-lock refusal", err)
 	}
@@ -209,7 +209,7 @@ func TestIntegrationDDLThenImmediateInserts(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sup := newMonitorSupervisor(ctx, bootDSN)
+	sup := newMonitorSupervisor(ctx, bootDSN, nil)
 	entry := console.ServerEntry{
 		ID:        fmt.Sprintf("ddlrace%d", time.Now().UnixNano()%1e9),
 		Name:      "ddl-race",

--- a/cmd/bintrail/monitor_replica.go
+++ b/cmd/bintrail/monitor_replica.go
@@ -70,6 +70,12 @@ func (m *monitorSupervisor) replicaOverlapCheck(ctx context.Context, e console.S
 		return &console.DoctorCheck{Name: checkName, Status: "skip",
 			Detail: "could not read server_uuid / gtid_executed: " + err.Error()}
 	}
+	// A malformed candidate set would silently disable the main (replica-of)
+	// direction inside gtidSetContainsUUID — surface it as skip instead.
+	if candExecuted != "" && !gtidSetParseable(candExecuted) {
+		return &console.DoctorCheck{Name: checkName, Status: "skip",
+			Detail: "could not parse the source's gtid_executed set — replica detection unavailable"}
+	}
 
 	var findings []string
 	unverified := 0
@@ -83,6 +89,13 @@ func (m *monitorSupervisor) replicaOverlapCheck(ctx context.Context, e console.S
 		}
 		if rel := classifyReplicaOverlap(candUUID, candExecuted, peerUUID, peerExecuted); rel != "" {
 			findings = append(findings, fmt.Sprintf("%s %q", rel, p.Name))
+			continue
+		}
+		// A peer set that does not parse silently disables the primary-of-
+		// monitored-replica direction — count it as unverified so the pass
+		// card stays honest.
+		if peerExecuted != "" && !gtidSetParseable(peerExecuted) {
+			unverified++
 		}
 	}
 
@@ -93,8 +106,9 @@ func (m *monitorSupervisor) replicaOverlapCheck(ctx context.Context, e console.S
 			Detail: "this server " + strings.Join(findings, "; "),
 			Remediation: "Monitoring a primary and its replica (or the same server twice) indexes every\n" +
 				"row change once per entry — duplicate history, duplicate storage.\n\n" +
-				"If that is not intentional, monitor only one of them (usually the primary).\n" +
-				"This is a WARN, not a hard fail — press Start again to proceed anyway.",
+				"This is a WARN, not a hard fail: monitoring has already started. If the\n" +
+				"overlap is unintentional, press Stop on one of the entries (usually keep\n" +
+				"the primary).",
 		}
 	}
 	detail := fmt.Sprintf("no replica relationship detected among %d monitored source(s)", len(peers))
@@ -149,6 +163,13 @@ func classifyReplicaOverlap(candUUID, candExecuted, peerUUID, peerExecuted strin
 		return "appears to be the primary of already-monitored replica"
 	}
 	return ""
+}
+
+// gtidSetParseable reports whether a stored GTID set parses — callers use it
+// to tell "no overlap" apart from "could not even look".
+func gtidSetParseable(gtidSet string) bool {
+	_, err := gomysql.ParseMysqlGTIDSet(normalizeGTIDSet(gtidSet))
+	return err == nil
 }
 
 // gtidSetContainsUUID reports whether the GTID set contains any transactions

--- a/cmd/bintrail/monitor_replica.go
+++ b/cmd/bintrail/monitor_replica.go
@@ -21,26 +21,43 @@ import (
 // already stores that entry's server_uuid (bintrail_servers) and accumulated
 // executed set (stream_state.gtid_set). Warn-only per the approved decision —
 // an amber card in the add-server doctor flow, never a hard block.
+//
+// Split for testability: replicaOverlapCheck does the IO (registry walk,
+// candidate + peer reads); evaluateReplicaOverlap is the pure card builder.
 
 // replicaOverlapTimeout bounds the whole check — it runs inside the
 // interactive doctor flow and must not hang on a dead peer index DB.
 const replicaOverlapTimeout = 15 * time.Second
 
+const replicaCheckName = "Replica / duplicate detection"
+
+// peerIdentity is one monitored entry's recorded identity, as the pure
+// evaluator consumes it.
+type peerIdentity struct {
+	name string
+	uuid string
+	// executed is the peer's accumulated GTID set from stream_state; empty
+	// when never streamed in GTID mode.
+	executed string
+	// unreadable marks a peer whose index DB could not be read — counted as
+	// unverified, never silently dropped.
+	unreadable bool
+}
+
 // replicaOverlapCheck compares the candidate entry's source against every
 // other monitored registry entry. Returns nil when there is nothing to
 // compare (no registry, no peers) — no card is shown then.
 func (m *monitorSupervisor) replicaOverlapCheck(ctx context.Context, e console.ServerEntry) *console.DoctorCheck {
-	const checkName = "Replica / duplicate detection"
 	if m.registry == nil {
 		return nil
 	}
-	var peers []console.ServerEntry
+	var entries []console.ServerEntry
 	for _, p := range m.registry.List() {
 		if p.ID != e.ID && p.SourceDSN != "" && p.DSN != "" {
-			peers = append(peers, p)
+			entries = append(entries, p)
 		}
 	}
-	if len(peers) == 0 {
+	if len(entries) == 0 {
 		return nil
 	}
 
@@ -49,73 +66,46 @@ func (m *monitorSupervisor) replicaOverlapCheck(ctx context.Context, e console.S
 
 	srcDB, err := config.Connect(e.SourceDSN)
 	if err != nil {
-		return &console.DoctorCheck{Name: checkName, Status: "skip",
+		return &console.DoctorCheck{Name: replicaCheckName, Status: "skip",
 			Detail: "could not connect to the source to compare GTID lineage: " + err.Error()}
 	}
 	defer srcDB.Close()
 
-	var gtidMode string
-	if err := srcDB.QueryRowContext(ctx, "SELECT @@gtid_mode").Scan(&gtidMode); err != nil {
-		return &console.DoctorCheck{Name: checkName, Status: "skip",
-			Detail: "could not read @@gtid_mode: " + err.Error()}
+	gtidMode, candUUID, candExecuted, err := loadCandidateIdentity(ctx, srcDB)
+	if err != nil {
+		return &console.DoctorCheck{Name: replicaCheckName, Status: "skip",
+			Detail: "could not read gtid_mode / server_uuid / gtid_executed: " + err.Error()}
 	}
 	if !strings.EqualFold(gtidMode, "ON") {
-		return &console.DoctorCheck{Name: checkName, Status: "skip",
+		return &console.DoctorCheck{Name: replicaCheckName, Status: "skip",
 			Detail: fmt.Sprintf("gtid_mode is %s on this source — replica detection needs GTID; a position-mode duplicate cannot be detected", gtidMode)}
 	}
 
-	var candUUID, candExecuted string
-	if err := srcDB.QueryRowContext(ctx,
-		"SELECT @@server_uuid, @@global.gtid_executed").Scan(&candUUID, &candExecuted); err != nil {
-		return &console.DoctorCheck{Name: checkName, Status: "skip",
-			Detail: "could not read server_uuid / gtid_executed: " + err.Error()}
-	}
-	// A malformed candidate set would silently disable the main (replica-of)
-	// direction inside gtidSetContainsUUID — surface it as skip instead.
-	if candExecuted != "" && !gtidSetParseable(candExecuted) {
-		return &console.DoctorCheck{Name: checkName, Status: "skip",
-			Detail: "could not parse the source's gtid_executed set — replica detection unavailable"}
+	peers := make([]peerIdentity, 0, len(entries))
+	for _, p := range entries {
+		uuid, executed, err := loadPeerIdentity(ctx, p.DSN)
+		// Best-effort: a peer whose index DB is unreadable (never started,
+		// dropped, server down) is unverified, not a failure.
+		peers = append(peers, peerIdentity{
+			name: p.Name, uuid: uuid, executed: executed, unreadable: err != nil,
+		})
 	}
 
-	var findings []string
-	unverified := 0
-	for _, p := range peers {
-		peerUUID, peerExecuted, err := loadPeerIdentity(ctx, p.DSN)
-		if err != nil {
-			// Best-effort: a peer whose index DB is unreadable (never
-			// started, dropped, server down) is unverified, not a failure.
-			unverified++
-			continue
-		}
-		if rel := classifyReplicaOverlap(candUUID, candExecuted, peerUUID, peerExecuted); rel != "" {
-			findings = append(findings, fmt.Sprintf("%s %q", rel, p.Name))
-			continue
-		}
-		// A peer set that does not parse silently disables the primary-of-
-		// monitored-replica direction — count it as unverified so the pass
-		// card stays honest.
-		if peerExecuted != "" && !gtidSetParseable(peerExecuted) {
-			unverified++
-		}
-	}
+	return evaluateReplicaOverlap(candUUID, candExecuted, peers)
+}
 
-	if len(findings) > 0 {
-		return &console.DoctorCheck{
-			Name:   checkName,
-			Status: "warn",
-			Detail: "this server " + strings.Join(findings, "; "),
-			Remediation: "Monitoring a primary and its replica (or the same server twice) indexes every\n" +
-				"row change once per entry — duplicate history, duplicate storage.\n\n" +
-				"This is a WARN, not a hard fail: monitoring has already started. If the\n" +
-				"overlap is unintentional, press Stop on one of the entries (usually keep\n" +
-				"the primary).",
-		}
+// loadCandidateIdentity reads the GTID-lineage identity of the source being
+// added. Separate from replicaOverlapCheck so integration tests can exercise
+// the exact production queries.
+func loadCandidateIdentity(ctx context.Context, db *sql.DB) (gtidMode, serverUUID, gtidExecuted string, err error) {
+	if err := db.QueryRowContext(ctx, "SELECT @@gtid_mode").Scan(&gtidMode); err != nil {
+		return "", "", "", err
 	}
-	detail := fmt.Sprintf("no replica relationship detected among %d monitored source(s)", len(peers))
-	if unverified > 0 {
-		detail += fmt.Sprintf(" (%d could not be verified)", unverified)
+	if err := db.QueryRowContext(ctx,
+		"SELECT @@server_uuid, @@global.gtid_executed").Scan(&serverUUID, &gtidExecuted); err != nil {
+		return "", "", "", err
 	}
-	return &console.DoctorCheck{Name: checkName, Status: "pass", Detail: detail}
+	return gtidMode, serverUUID, gtidExecuted, nil
 }
 
 // loadPeerIdentity reads a monitored entry's recorded server_uuid and
@@ -142,6 +132,54 @@ func loadPeerIdentity(ctx context.Context, indexDSN string) (peerUUID, peerExecu
 		peerExecuted = gtidSet.String
 	}
 	return peerUUID, peerExecuted, nil
+}
+
+// evaluateReplicaOverlap builds the doctor card from pre-resolved identities.
+// Pure — unit-testable without MySQL.
+func evaluateReplicaOverlap(candUUID, candExecuted string, peers []peerIdentity) *console.DoctorCheck {
+	// A malformed candidate set would silently disable the main (replica-of)
+	// direction inside gtidSetContainsUUID — surface it as skip instead.
+	if candExecuted != "" && !gtidSetParseable(candExecuted) {
+		return &console.DoctorCheck{Name: replicaCheckName, Status: "skip",
+			Detail: "could not parse the source's gtid_executed set — replica detection unavailable"}
+	}
+
+	var findings []string
+	unverified := 0
+	for _, p := range peers {
+		if p.unreadable {
+			unverified++
+			continue
+		}
+		if rel := classifyReplicaOverlap(candUUID, candExecuted, p.uuid, p.executed); rel != "" {
+			findings = append(findings, fmt.Sprintf("%s %q", rel, p.name))
+			continue
+		}
+		// A peer set that does not parse silently disables the primary-of-
+		// monitored-replica direction — count it as unverified so the pass
+		// card stays honest.
+		if p.executed != "" && !gtidSetParseable(p.executed) {
+			unverified++
+		}
+	}
+
+	if len(findings) > 0 {
+		return &console.DoctorCheck{
+			Name:   replicaCheckName,
+			Status: "warn",
+			Detail: "this server " + strings.Join(findings, "; "),
+			Remediation: "Monitoring a primary and its replica (or the same server twice) indexes every\n" +
+				"row change once per entry — duplicate history, duplicate storage.\n\n" +
+				"This is a WARN, not a hard fail: monitoring has already started. If the\n" +
+				"overlap is unintentional, press Stop on one of the entries (usually keep\n" +
+				"the primary).",
+		}
+	}
+	detail := fmt.Sprintf("no replica relationship detected among %d monitored source(s)", len(peers))
+	if unverified > 0 {
+		detail += fmt.Sprintf(" (%d could not be verified)", unverified)
+	}
+	return &console.DoctorCheck{Name: replicaCheckName, Status: "pass", Detail: detail}
 }
 
 // classifyReplicaOverlap describes the GTID-lineage relationship between a

--- a/cmd/bintrail/monitor_replica.go
+++ b/cmd/bintrail/monitor_replica.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	gomysql "github.com/go-mysql-org/go-mysql/mysql"
+
+	"github.com/dbtrail/bintrail/internal/config"
+	"github.com/dbtrail/bintrail/internal/console"
+)
+
+// Replica / duplicate detection (#402): adding a replica of an already-
+// monitored server double-indexes the same logical writes silently. GTID
+// lineage makes the relationship detectable without touching the other
+// sources: a replica's @@gtid_executed contains transactions originated at
+// its primary's server_uuid, and each monitored entry's per-source index DB
+// already stores that entry's server_uuid (bintrail_servers) and accumulated
+// executed set (stream_state.gtid_set). Warn-only per the approved decision —
+// an amber card in the add-server doctor flow, never a hard block.
+
+// replicaOverlapTimeout bounds the whole check — it runs inside the
+// interactive doctor flow and must not hang on a dead peer index DB.
+const replicaOverlapTimeout = 15 * time.Second
+
+// replicaOverlapCheck compares the candidate entry's source against every
+// other monitored registry entry. Returns nil when there is nothing to
+// compare (no registry, no peers) — no card is shown then.
+func (m *monitorSupervisor) replicaOverlapCheck(ctx context.Context, e console.ServerEntry) *console.DoctorCheck {
+	const checkName = "Replica / duplicate detection"
+	if m.registry == nil {
+		return nil
+	}
+	var peers []console.ServerEntry
+	for _, p := range m.registry.List() {
+		if p.ID != e.ID && p.SourceDSN != "" && p.DSN != "" {
+			peers = append(peers, p)
+		}
+	}
+	if len(peers) == 0 {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, replicaOverlapTimeout)
+	defer cancel()
+
+	srcDB, err := config.Connect(e.SourceDSN)
+	if err != nil {
+		return &console.DoctorCheck{Name: checkName, Status: "skip",
+			Detail: "could not connect to the source to compare GTID lineage: " + err.Error()}
+	}
+	defer srcDB.Close()
+
+	var gtidMode string
+	if err := srcDB.QueryRowContext(ctx, "SELECT @@gtid_mode").Scan(&gtidMode); err != nil {
+		return &console.DoctorCheck{Name: checkName, Status: "skip",
+			Detail: "could not read @@gtid_mode: " + err.Error()}
+	}
+	if !strings.EqualFold(gtidMode, "ON") {
+		return &console.DoctorCheck{Name: checkName, Status: "skip",
+			Detail: fmt.Sprintf("gtid_mode is %s on this source — replica detection needs GTID; a position-mode duplicate cannot be detected", gtidMode)}
+	}
+
+	var candUUID, candExecuted string
+	if err := srcDB.QueryRowContext(ctx,
+		"SELECT @@server_uuid, @@global.gtid_executed").Scan(&candUUID, &candExecuted); err != nil {
+		return &console.DoctorCheck{Name: checkName, Status: "skip",
+			Detail: "could not read server_uuid / gtid_executed: " + err.Error()}
+	}
+
+	var findings []string
+	unverified := 0
+	for _, p := range peers {
+		peerUUID, peerExecuted, err := loadPeerIdentity(ctx, p.DSN)
+		if err != nil {
+			// Best-effort: a peer whose index DB is unreadable (never
+			// started, dropped, server down) is unverified, not a failure.
+			unverified++
+			continue
+		}
+		if rel := classifyReplicaOverlap(candUUID, candExecuted, peerUUID, peerExecuted); rel != "" {
+			findings = append(findings, fmt.Sprintf("%s %q", rel, p.Name))
+		}
+	}
+
+	if len(findings) > 0 {
+		return &console.DoctorCheck{
+			Name:   checkName,
+			Status: "warn",
+			Detail: "this server " + strings.Join(findings, "; "),
+			Remediation: "Monitoring a primary and its replica (or the same server twice) indexes every\n" +
+				"row change once per entry — duplicate history, duplicate storage.\n\n" +
+				"If that is not intentional, monitor only one of them (usually the primary).\n" +
+				"This is a WARN, not a hard fail — press Start again to proceed anyway.",
+		}
+	}
+	detail := fmt.Sprintf("no replica relationship detected among %d monitored source(s)", len(peers))
+	if unverified > 0 {
+		detail += fmt.Sprintf(" (%d could not be verified)", unverified)
+	}
+	return &console.DoctorCheck{Name: checkName, Status: "pass", Detail: detail}
+}
+
+// loadPeerIdentity reads a monitored entry's recorded server_uuid and
+// accumulated executed GTID set from its per-source index database.
+func loadPeerIdentity(ctx context.Context, indexDSN string) (peerUUID, peerExecuted string, err error) {
+	db, err := config.Connect(indexDSN)
+	if err != nil {
+		return "", "", err
+	}
+	defer db.Close()
+
+	if err := db.QueryRowContext(ctx, `
+		SELECT server_uuid FROM bintrail_servers
+		WHERE decommissioned_at IS NULL
+		ORDER BY updated_at DESC LIMIT 1`).Scan(&peerUUID); err != nil {
+		return "", "", err
+	}
+	// stream_state may not exist yet (monitoring never started) or hold no
+	// GTID set (position mode) — both leave peerExecuted empty, which only
+	// disables the primary-of-monitored-replica direction.
+	var gtidSet sql.NullString
+	if err := db.QueryRowContext(ctx,
+		`SELECT gtid_set FROM stream_state WHERE id = 1`).Scan(&gtidSet); err == nil && gtidSet.Valid {
+		peerExecuted = gtidSet.String
+	}
+	return peerUUID, peerExecuted, nil
+}
+
+// classifyReplicaOverlap describes the GTID-lineage relationship between a
+// candidate server and one monitored peer, or "" when none is detected.
+// Pure — unit-testable without MySQL.
+func classifyReplicaOverlap(candUUID, candExecuted, peerUUID, peerExecuted string) string {
+	if strings.EqualFold(candUUID, peerUUID) {
+		return "is the same server as already-monitored"
+	}
+	// The peer's UUID appears in the candidate's executed set: the candidate
+	// has applied transactions originated on the peer — it is (or was) a
+	// replica of it.
+	if gtidSetContainsUUID(candExecuted, peerUUID) {
+		return "appears to be a replica of already-monitored"
+	}
+	// The candidate's UUID appears in the monitored peer's executed set: the
+	// peer replicates from the candidate — the candidate is its primary.
+	if gtidSetContainsUUID(peerExecuted, candUUID) {
+		return "appears to be the primary of already-monitored replica"
+	}
+	return ""
+}
+
+// gtidSetContainsUUID reports whether the GTID set contains any transactions
+// originated at the given server UUID. Malformed input is never a match —
+// the caller treats this as best-effort detection. Comparison is
+// case-insensitive (go-mysql lowercases UUIDs).
+func gtidSetContainsUUID(gtidSet, serverUUID string) bool {
+	if gtidSet == "" || serverUUID == "" {
+		return false
+	}
+	parsed, err := gomysql.ParseMysqlGTIDSet(normalizeGTIDSet(gtidSet))
+	if err != nil {
+		return false
+	}
+	set, ok := parsed.(*gomysql.MysqlGTIDSet)
+	if !ok {
+		return false
+	}
+	want := strings.ToLower(serverUUID)
+	for sid := range set.Sets {
+		if strings.ToLower(sid) == want {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/bintrail/monitor_test.go
+++ b/cmd/bintrail/monitor_test.go
@@ -246,3 +246,104 @@ func TestClassifyReplicaOverlap(t *testing.T) {
 		t.Errorf("no peer set, unrelated: got %q, want empty", rel)
 	}
 }
+
+func TestEvaluateReplicaOverlap_cardAssembly(t *testing.T) {
+	const (
+		primary = "3e11fa47-71ca-11e1-9e33-c80aa9429562"
+		cand    = "9f3829a2-3c4d-11ee-be56-0242ac120002"
+		other   = "11111111-2222-3333-4444-555555555555"
+	)
+
+	// Two findings + one clean peer → warn card naming both, no unverified.
+	card := evaluateReplicaOverlap(cand, primary+":1-100,"+cand+":1-5", []peerIdentity{
+		{name: "prod", uuid: primary, executed: primary + ":1-100"},
+		{name: "same", uuid: cand, executed: cand + ":1-5"},
+		{name: "unrelated", uuid: other, executed: other + ":1-3"},
+	})
+	if card.Status != "warn" {
+		t.Fatalf("status = %q, want warn", card.Status)
+	}
+	if !strings.Contains(card.Detail, `replica of already-monitored "prod"`) ||
+		!strings.Contains(card.Detail, `same server as already-monitored "same"`) {
+		t.Errorf("Detail = %q, want both findings named", card.Detail)
+	}
+	if !strings.Contains(card.Remediation, "monitoring has already started") {
+		t.Errorf("Remediation = %q, must reflect that warns never block", card.Remediation)
+	}
+
+	// No findings, one unreadable peer + one unparseable peer set → pass
+	// card with an honest unverified count.
+	card = evaluateReplicaOverlap(cand, cand+":1-5", []peerIdentity{
+		{name: "down", unreadable: true},
+		{name: "corrupt", uuid: other, executed: "not-a-gtid-set"},
+		{name: "clean", uuid: primary, executed: primary + ":1-100"},
+	})
+	if card.Status != "pass" {
+		t.Fatalf("status = %q, want pass", card.Status)
+	}
+	if !strings.Contains(card.Detail, "3 monitored source(s)") ||
+		!strings.Contains(card.Detail, "(2 could not be verified)") {
+		t.Errorf("Detail = %q, want 3 peers with 2 unverified", card.Detail)
+	}
+
+	// A peer found via the replica direction does NOT count as unverified
+	// even if its own set is unparseable — the relationship WAS detected.
+	card = evaluateReplicaOverlap(cand, primary+":1-100", []peerIdentity{
+		{name: "prod", uuid: primary, executed: "garbage"},
+	})
+	if card.Status != "warn" || strings.Contains(card.Detail, "could not be verified") {
+		t.Errorf("card = %+v, want warn without unverified", *card)
+	}
+
+	// Unparseable candidate set → explicit skip, never a silent pass.
+	card = evaluateReplicaOverlap(cand, "garbage", []peerIdentity{{name: "p", uuid: primary}})
+	if card.Status != "skip" || !strings.Contains(card.Detail, "could not parse") {
+		t.Errorf("card = %+v, want skip on unparseable candidate set", *card)
+	}
+}
+
+func TestMonitorRun_healthyRunResetsBreaker(t *testing.T) {
+	oldGiveUp, oldBase, oldCap, oldHealthy := monitorGiveUpAfter, monitorBackoffBase, monitorBackoffCap, monitorHealthyReset
+	monitorGiveUpAfter = 60 * time.Millisecond
+	monitorBackoffBase = time.Millisecond
+	monitorBackoffCap = 2 * time.Millisecond
+	monitorHealthyReset = 5 * time.Millisecond
+	defer func() {
+		monitorGiveUpAfter, monitorBackoffBase, monitorBackoffCap, monitorHealthyReset = oldGiveUp, oldBase, oldCap, oldHealthy
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Every run is "healthy" (outlives monitorHealthyReset) before failing —
+	// the breaker clock must keep resetting and never trip, no matter how
+	// long the flapping goes on in total.
+	m := &monitorSupervisor{
+		baseCtx: ctx,
+		jobs:    map[string]*monitorJob{},
+		streamFn: func(c context.Context, _ streamConfig) error {
+			select {
+			case <-time.After(10 * time.Millisecond): // > monitorHealthyReset
+				return errors.New("flap")
+			case <-c.Done():
+				return c.Err()
+			}
+		},
+	}
+	job := &monitorJob{cancel: cancel, done: make(chan struct{})}
+	job.set("pending", "")
+
+	m.wg.Add(1)
+	go m.run(ctx, job, console.ServerEntry{ID: "e3", Name: "flappy"}, streamConfig{})
+
+	// Let it flap well past monitorGiveUpAfter in wall-clock time.
+	time.Sleep(150 * time.Millisecond)
+	if st := job.snapshot(); strings.Contains(st.LastError, "gave up") {
+		t.Fatalf("breaker tripped despite healthy runs in between: %+v", st)
+	}
+	cancel()
+	<-job.done
+	if st := job.snapshot(); st.State != "stopped" {
+		t.Fatalf("state = %q, want stopped after cancel", st.State)
+	}
+}

--- a/cmd/bintrail/monitor_test.go
+++ b/cmd/bintrail/monitor_test.go
@@ -1,0 +1,248 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/bintrail/internal/console"
+)
+
+// ─── derived monitor states (#402) ───────────────────────────────────────────
+
+func TestMonitorJobSnapshot_stalledDerivation(t *testing.T) {
+	job := &monitorJob{}
+	job.set("running", "")
+
+	// Fresh progress: plain running.
+	job.progress()
+	if st := job.snapshot(); st.State != "running" {
+		t.Fatalf("state = %q, want running", st.State)
+	}
+
+	// Progress older than the threshold: derived stalled, stored state intact.
+	job.mu.Lock()
+	job.lastProgress = time.Now().UTC().Add(-monitorStalledAfter - time.Minute)
+	job.mu.Unlock()
+	st := job.snapshot()
+	if st.State != "stalled" {
+		t.Fatalf("state = %q, want stalled", st.State)
+	}
+	if !strings.Contains(st.LastError, "no progress") {
+		t.Errorf("LastError = %q, want a no-progress explanation", st.LastError)
+	}
+	job.mu.Lock()
+	if job.state != "running" {
+		t.Errorf("stored state mutated to %q — derivation must be read-only", job.state)
+	}
+	job.mu.Unlock()
+}
+
+func TestMonitorJobSnapshot_lostPosition(t *testing.T) {
+	job := &monitorJob{}
+	job.set("running", "")
+	job.progress()
+	job.markLostPosition("binlog gap: events between A and B were purged")
+
+	st := job.snapshot()
+	if st.State != "lost_position" {
+		t.Fatalf("state = %q, want lost_position", st.State)
+	}
+	if st.LastError != "binlog gap: events between A and B were purged" {
+		t.Errorf("LastError = %q, want the gap detail", st.LastError)
+	}
+
+	// A wedged stream beats a historical data-loss note.
+	job.mu.Lock()
+	job.lastProgress = time.Now().UTC().Add(-monitorStalledAfter - time.Minute)
+	job.mu.Unlock()
+	if st := job.snapshot(); st.State != "stalled" {
+		t.Errorf("state = %q, want stalled to take precedence over lost_position", st.State)
+	}
+}
+
+func TestMonitorJobSnapshot_noDerivationOutsideRunning(t *testing.T) {
+	for _, base := range []string{"pending", "failed", "stopped"} {
+		job := &monitorJob{}
+		job.set(base, "")
+		job.markLostPosition("gap detail")
+		job.mu.Lock()
+		job.lastProgress = time.Now().UTC().Add(-time.Hour)
+		job.mu.Unlock()
+		if st := job.snapshot(); st.State != base {
+			t.Errorf("state = %q, want %q (no derivation outside running)", st.State, base)
+		}
+	}
+
+	// Running with zero lastProgress (not reachable via the normal flow, but
+	// must not divide-by-zero into stalled).
+	job := &monitorJob{}
+	job.set("running", "")
+	if st := job.snapshot(); st.State != "running" {
+		t.Errorf("state = %q, want running when lastProgress is unset", st.State)
+	}
+}
+
+func TestMonitorJobHooks_pendingFlipsToRunning(t *testing.T) {
+	job := &monitorJob{}
+	job.set("pending", "")
+	hooks := job.streamHooks()
+
+	if st := job.snapshot(); st.State != "pending" {
+		t.Fatalf("state = %q, want pending before first checkpoint", st.State)
+	}
+
+	hooks.OnCheckpoint()
+	if st := job.snapshot(); st.State != "running" {
+		t.Fatalf("state = %q, want running after first checkpoint", st.State)
+	}
+
+	// OnIndexed is the equivalent attach signal.
+	job2 := &monitorJob{}
+	job2.set("pending", "")
+	job2.streamHooks().OnIndexed(42)
+	if st := job2.snapshot(); st.State != "running" {
+		t.Fatalf("state = %q, want running after first indexed batch", st.State)
+	}
+
+	// OnGapAutoAdvance alone must NOT flip pending (it fires during startup,
+	// before the stream is attached).
+	job3 := &monitorJob{}
+	job3.set("pending", "")
+	job3.streamHooks().OnGapAutoAdvance("gap")
+	if st := job3.snapshot(); st.State != "pending" {
+		t.Fatalf("state = %q, want pending after gap auto-advance only", st.State)
+	}
+}
+
+// ─── circuit breaker (#402) ──────────────────────────────────────────────────
+
+func TestMonitorRun_circuitBreakerGivesUp(t *testing.T) {
+	old := monitorGiveUpAfter
+	monitorGiveUpAfter = 0 // any continuous crash-looping trips it immediately
+	defer func() { monitorGiveUpAfter = old }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	m := &monitorSupervisor{
+		baseCtx: ctx,
+		jobs:    map[string]*monitorJob{},
+		streamFn: func(context.Context, streamConfig) error {
+			return errors.New("boom: cannot connect")
+		},
+	}
+	job := &monitorJob{cancel: cancel, done: make(chan struct{})}
+	job.set("pending", "")
+	m.jobs["e1"] = job
+
+	m.wg.Add(1)
+	m.run(ctx, job, console.ServerEntry{ID: "e1", Name: "prod"}, streamConfig{})
+
+	select {
+	case <-job.done:
+	default:
+		t.Fatal("run returned but job.done is not closed")
+	}
+	st := job.snapshot()
+	if st.State != "failed" {
+		t.Fatalf("state = %q, want permanent failed", st.State)
+	}
+	if !strings.Contains(st.LastError, "gave up") {
+		t.Errorf("LastError = %q, want a gave-up explanation", st.LastError)
+	}
+	if !strings.Contains(st.LastError, "boom") {
+		t.Errorf("LastError = %q, want the underlying error preserved", st.LastError)
+	}
+}
+
+func TestMonitorRun_cleanStopBypassesBreaker(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already-cancelled daemon: streamFn returns, run must report stopped
+
+	m := &monitorSupervisor{
+		baseCtx:  ctx,
+		jobs:     map[string]*monitorJob{},
+		streamFn: func(c context.Context, _ streamConfig) error { return c.Err() },
+	}
+	job := &monitorJob{cancel: func() {}, done: make(chan struct{})}
+	job.set("pending", "")
+
+	m.wg.Add(1)
+	m.run(ctx, job, console.ServerEntry{ID: "e2", Name: "x"}, streamConfig{})
+
+	if st := job.snapshot(); st.State != "stopped" {
+		t.Fatalf("state = %q, want stopped on cancellation", st.State)
+	}
+}
+
+// ─── replica / duplicate detection (#402) ────────────────────────────────────
+
+func TestGTIDSetContainsUUID(t *testing.T) {
+	const (
+		uuidA = "3e11fa47-71ca-11e1-9e33-c80aa9429562"
+		uuidB = "9f3829a2-3c4d-11ee-be56-0242ac120002"
+	)
+	set := uuidA + ":1-5,\n" + uuidB + ":1-30:40-44"
+
+	tests := []struct {
+		name string
+		set  string
+		uuid string
+		want bool
+	}{
+		{"present", set, uuidA, true},
+		{"present second entry", set, uuidB, true},
+		{"case-insensitive (go-mysql lowercases)", set, strings.ToUpper(uuidA), true},
+		{"absent", set, "00000000-0000-0000-0000-000000000000", false},
+		{"empty set", "", uuidA, false},
+		{"empty uuid", set, "", false},
+		{"malformed set is never a match", "not-a-gtid-set", uuidA, false},
+	}
+	for _, tt := range tests {
+		if got := gtidSetContainsUUID(tt.set, tt.uuid); got != tt.want {
+			t.Errorf("%s: gtidSetContainsUUID(%q, %q) = %v, want %v", tt.name, tt.set, tt.uuid, got, tt.want)
+		}
+	}
+}
+
+func TestClassifyReplicaOverlap(t *testing.T) {
+	const (
+		primary = "3e11fa47-71ca-11e1-9e33-c80aa9429562" // monitored peer
+		replica = "9f3829a2-3c4d-11ee-be56-0242ac120002" // candidate
+		other   = "11111111-2222-3333-4444-555555555555"
+	)
+
+	// Candidate is a replica of the monitored peer: its executed set carries
+	// transactions originated at the peer.
+	rel := classifyReplicaOverlap(replica, primary+":1-100,"+replica+":1-5", primary, primary+":1-100")
+	if !strings.Contains(rel, "replica of") {
+		t.Errorf("replica direction: got %q", rel)
+	}
+
+	// Candidate is the primary of a monitored replica: the peer's
+	// accumulated set carries the candidate's transactions.
+	rel = classifyReplicaOverlap(primary, primary+":1-100", replica, primary+":1-90,"+replica+":1-5")
+	if !strings.Contains(rel, "primary of") {
+		t.Errorf("primary direction: got %q", rel)
+	}
+
+	// Same server added twice (case differs — go-mysql lowercases UUIDs).
+	rel = classifyReplicaOverlap(strings.ToUpper(primary), primary+":1-10", primary, primary+":1-10")
+	if !strings.Contains(rel, "same server") {
+		t.Errorf("same-server: got %q", rel)
+	}
+
+	// Unrelated servers: no finding.
+	if rel = classifyReplicaOverlap(other, other+":1-3", primary, primary+":1-100"); rel != "" {
+		t.Errorf("unrelated: got %q, want empty", rel)
+	}
+
+	// Peer with no recorded executed set (position mode / never streamed):
+	// only the replica direction can fire.
+	if rel = classifyReplicaOverlap(other, other+":1-3", primary, ""); rel != "" {
+		t.Errorf("no peer set, unrelated: got %q, want empty", rel)
+	}
+}

--- a/cmd/bintrail/stream.go
+++ b/cmd/bintrail/stream.go
@@ -715,6 +715,8 @@ func streamLoop(
 	db *sql.DB,
 	checkpointInterval time.Duration,
 	state *streamState,
+	m *observe.StreamMetrics,
+	hooks *streamHooks,
 ) error {
 	batch := make([]parser.Event, 0, idx.BatchSize())
 	ticker := time.NewTicker(checkpointInterval)
@@ -724,16 +726,20 @@ func streamLoop(
 		if len(batch) == 0 {
 			return nil
 		}
-		observe.StreamBatchSize.Observe(float64(len(batch)))
+		m.BatchSize.Observe(float64(len(batch)))
 		n, err := idx.InsertBatch(batch)
 		state.eventsIndexed += n
-		observe.StreamEventsIndexed.Add(float64(n))
-		observe.StreamBatchFlushes.Inc()
+		m.EventsIndexed.Add(float64(n))
+		m.BatchFlushes.Inc()
 		batch = batch[:0]
 		if err != nil {
-			observe.StreamErrors.WithLabelValues("batch_flush").Inc()
+			m.Errors.WithLabelValues("batch_flush").Inc()
+			return err
 		}
-		return err
+		if n > 0 && hooks != nil && hooks.OnIndexed != nil {
+			hooks.OnIndexed(n)
+		}
+		return nil
 	}
 
 	checkpoint := func() {
@@ -743,9 +749,12 @@ func streamLoop(
 		}
 		if err := saveCheckpoint(db, state); err != nil {
 			slog.Warn("saveCheckpoint failed", "error", err)
-			observe.StreamErrors.WithLabelValues("checkpoint").Inc()
+			m.Errors.WithLabelValues("checkpoint").Inc()
 		} else {
-			observe.StreamCheckpointSaves.Inc()
+			m.CheckpointSaves.Inc()
+			if hooks != nil && hooks.OnCheckpoint != nil {
+				hooks.OnCheckpoint()
+			}
 			slog.Info("checkpoint saved",
 				"file", state.binlogFile,
 				"pos", state.binlogPos,
@@ -775,7 +784,7 @@ func streamLoop(
 			if ev.GTID != "" && state.accGTID != nil {
 				if err := state.accGTID.Update(ev.GTID); err != nil {
 					slog.Warn("failed to update GTID set", "gtid", ev.GTID, "error", err)
-					observe.StreamErrors.WithLabelValues("gtid_update").Inc()
+					m.Errors.WithLabelValues("gtid_update").Inc()
 				} else {
 					state.gtidSet = state.accGTID.String()
 				}
@@ -798,11 +807,11 @@ func streamLoop(
 				continue
 			}
 
-			observe.StreamEventsReceived.Inc()
+			m.EventsReceived.Inc()
 			if !ev.Timestamp.IsZero() {
 				ts := float64(ev.Timestamp.Unix())
-				observe.StreamLastEventTimestamp.Set(ts)
-				observe.StreamReplicationLag.Set(float64(time.Now().Unix()) - ts)
+				m.LastEventTimestamp.Set(ts)
+				m.ReplicationLag.Set(float64(time.Now().Unix()) - ts)
 			}
 			slog.Debug("event received",
 				"schema", ev.Schema,
@@ -823,11 +832,12 @@ func streamLoop(
 // ─── streamConfig / streamOne ───────────────────────────────────────────────
 
 // streamConfig carries everything ONE replication stream needs — the by-value
-// equivalent of the strm* package globals. It exists so the future control
-// plane can run N streams concurrently in one process (each with its own
-// config), while `bintrail stream` keeps wiring its flags through a single
-// instance unchanged. Plain data, no behavior: the zero value is invalid;
-// build it from flags via streamConfigFromFlags or populate it explicitly.
+// equivalent of the strm* package globals. It exists so the control plane can
+// run N streams concurrently in one process (each with its own config), while
+// `bintrail stream` keeps wiring its flags through a single instance
+// unchanged. Plain data plus optional observer hooks: the zero value is
+// invalid; build it from flags via streamConfigFromFlags or populate it
+// explicitly.
 type streamConfig struct {
 	IndexDSN    string
 	SourceDSN   string
@@ -840,14 +850,37 @@ type streamConfig struct {
 	Tables      string
 	Checkpoint  int // seconds
 	MetricsAddr string
-	SSLMode     string
-	SSLCA       string
-	SSLCert     string
-	SSLKey      string
-	Format      string
-	Reset       bool
-	NoGapFill   bool
-	GapTimeout  int // seconds
+	// MetricsSource is the value of the Prometheus "source" label for this
+	// stream — the supervisor sets it to the registry entry ID so N
+	// concurrent streams stay distinguishable on one /metrics endpoint.
+	// Empty = fall back to the resolved bintrail_id (or "default").
+	MetricsSource string
+	SSLMode       string
+	SSLCA         string
+	SSLCert       string
+	SSLKey        string
+	Format        string
+	Reset         bool
+	NoGapFill     bool
+	GapTimeout    int // seconds
+	// Hooks, when non-nil, lets a supervisor observe this stream's liveness
+	// without polling. Plain `bintrail stream` leaves it nil.
+	Hooks *streamHooks
+}
+
+// streamHooks are liveness callbacks a supervisor attaches to one stream.
+// All fields are optional. They are invoked synchronously from the stream
+// loop — implementations must be fast and non-blocking.
+type streamHooks struct {
+	// OnCheckpoint fires after every successful checkpoint save — the
+	// "attached and healthy" signal (the ticker checkpoints even with zero
+	// events, so an idle source still reports progress).
+	OnCheckpoint func()
+	// OnIndexed fires after every successful batch flush with rows written.
+	OnIndexed func(n int64)
+	// OnGapAutoAdvance fires when an unfillable binlog gap forced the stream
+	// to advance past purged events — data in the gap is permanently lost.
+	OnGapAutoAdvance func(detail string)
 }
 
 // streamConfigFromFlags snapshots the strm* package globals into a config.
@@ -1096,12 +1129,24 @@ func streamOne(ctx context.Context, cfg streamConfig) error {
 				}
 				slog.Info("saved advanced checkpoint after gap auto-advance",
 					"file", startFile, "pos", startPos, "gtid_set", startGTIDStr)
+				// Tell the supervisor events were lost — without this the
+				// auto-advance is only a log line and the console shows a
+				// healthy RUNNING badge over a stream that silently skipped
+				// data (#402).
+				if cfg.Hooks != nil && cfg.Hooks.OnGapAutoAdvance != nil {
+					cfg.Hooks.OnGapAutoAdvance(gap.Message)
+				}
 			}
 		}
 	}
 
 	state := &streamState{
-		mode:       mode,
+		mode: mode,
+		// Seed the position with the resolved start so the first ticker
+		// checkpoint (which fires even before any event arrives) persists a
+		// valid resume point instead of an empty file / position 0.
+		binlogFile: startFile,
+		binlogPos:  uint64(startPos),
 		serverID:   cfg.ServerID,
 		accGTID:    accGTID,
 		bintrailID: bintrailID,
@@ -1202,22 +1247,20 @@ func streamOne(ctx context.Context, cfg streamConfig) error {
 	// lifecycle without competing signal handlers.)
 
 	// ── 9. Optional Prometheus metrics HTTP server ─────────────────────────
+	// Under `up --console` the daemon serves one endpoint for all streams
+	// instead (cfg.MetricsAddr is empty there) — the registry is process-
+	// global, so one handler exposes every per-source series.
 	if cfg.MetricsAddr != "" {
-		mux := http.NewServeMux()
-		mux.Handle("/metrics", promhttp.Handler())
-		metricsServer := &http.Server{Addr: cfg.MetricsAddr, Handler: mux}
-		go func() {
-			slog.Info("metrics server starting", "addr", cfg.MetricsAddr)
-			if err := metricsServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-				slog.Error("metrics server error", "error", err)
-			}
-		}()
-		defer func() {
-			shutCtx, shutCancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer shutCancel()
-			_ = metricsServer.Shutdown(shutCtx)
-		}()
+		defer startMetricsServer(cfg.MetricsAddr)()
 	}
+
+	// All stream metrics carry a "source" label: the supervisor's entry ID
+	// when monitored, else the resolved bintrail_id ("default" if unknown).
+	metricsSource := cfg.MetricsSource
+	if metricsSource == "" {
+		metricsSource = bintrailID
+	}
+	metrics := observe.ForSource(metricsSource)
 
 	// ── 10. StreamParser + its synchronous DDL hook ──────────────────────────
 	sp := parser.NewStreamParser(resolver, filters, nil)
@@ -1283,7 +1326,7 @@ func streamOne(ctx context.Context, cfg streamConfig) error {
 	// ── 12. Run stream loop with checkpointing ──────────────────────────────────
 	fmt.Printf("Streaming started (server-id=%d, checkpoint=%ds)\n", cfg.ServerID, cfg.Checkpoint)
 	loopErr := streamLoop(ctx, events, idx, indexDB,
-		time.Duration(cfg.Checkpoint)*time.Second, state)
+		time.Duration(cfg.Checkpoint)*time.Second, state, metrics, cfg.Hooks)
 
 	parseErr := <-parseErrCh
 
@@ -1310,4 +1353,26 @@ func streamOne(ctx context.Context, cfg streamConfig) error {
 	fmt.Printf("\nEvents indexed: %d\n", state.eventsIndexed)
 	fmt.Printf("Last position:  %s:%d\n", state.binlogFile, state.binlogPos)
 	return nil
+}
+
+// startMetricsServer binds the Prometheus /metrics endpoint asynchronously
+// and returns a shutdown func. Serve errors are logged, never fatal — metrics
+// are observability, not the data path. Shared by `bintrail stream` (one
+// endpoint per stream process) and the `up --console` daemon (one endpoint
+// for all supervised streams; the default registry is process-global).
+func startMetricsServer(addr string) (shutdown func()) {
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+	srv := &http.Server{Addr: addr, Handler: mux}
+	go func() {
+		slog.Info("metrics server starting", "addr", addr)
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			slog.Error("metrics server error", "error", err)
+		}
+	}()
+	return func() {
+		shutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutCtx)
+	}
 }

--- a/cmd/bintrail/stream.go
+++ b/cmd/bintrail/stream.go
@@ -1129,6 +1129,16 @@ func streamOne(ctx context.Context, cfg streamConfig) error {
 				}
 				slog.Info("saved advanced checkpoint after gap auto-advance",
 					"file", startFile, "pos", startPos, "gtid_set", startGTIDStr)
+				// Record the data loss DURABLY: the advanced checkpoint means
+				// the next start sees no gap, so without this row the only
+				// trace of the permanently lost events would be an in-memory
+				// flag (or a log line) that a restart silently discards.
+				// Cleared by an explicit monitor Stop or --reset.
+				if _, err := indexDB.Exec(`UPDATE stream_state
+					SET gap_lost_at = UTC_TIMESTAMP(), gap_lost_detail = ?
+					WHERE id = 1`, gap.Message); err != nil {
+					slog.Warn("failed to persist gap-loss record; the lost_position state will not survive a restart", "error", err)
+				}
 				// Tell the supervisor events were lost — without this the
 				// auto-advance is only a log line and the console shows a
 				// healthy RUNNING badge over a stream that silently skipped
@@ -1251,7 +1261,11 @@ func streamOne(ctx context.Context, cfg streamConfig) error {
 	// instead (cfg.MetricsAddr is empty there) — the registry is process-
 	// global, so one handler exposes every per-source series.
 	if cfg.MetricsAddr != "" {
-		defer startMetricsServer(cfg.MetricsAddr)()
+		stopMetrics, err := startMetricsServer(cfg.MetricsAddr)
+		if err != nil {
+			return err
+		}
+		defer stopMetrics()
 	}
 
 	// All stream metrics carry a "source" label: the supervisor's entry ID
@@ -1355,24 +1369,30 @@ func streamOne(ctx context.Context, cfg streamConfig) error {
 	return nil
 }
 
-// startMetricsServer binds the Prometheus /metrics endpoint asynchronously
-// and returns a shutdown func. Serve errors are logged, never fatal — metrics
-// are observability, not the data path. Shared by `bintrail stream` (one
-// endpoint per stream process) and the `up --console` daemon (one endpoint
-// for all supervised streams; the default registry is process-global).
-func startMetricsServer(addr string) (shutdown func()) {
+// startMetricsServer binds the Prometheus /metrics endpoint and returns a
+// shutdown func. The bind is SYNCHRONOUS so a bad --metrics-addr fails the
+// command fast — the operator explicitly asked for metrics; silently running
+// without them (scrapes getting connection-refused) is worse than refusing
+// to start. Shared by `bintrail stream` (one endpoint per stream process)
+// and the `up --console` daemon (one endpoint for all supervised streams;
+// the default registry is process-global).
+func startMetricsServer(addr string) (shutdown func(), err error) {
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
-	srv := &http.Server{Addr: addr, Handler: mux}
+	srv := &http.Server{Handler: mux}
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("metrics server: cannot bind %s: %w", addr, err)
+	}
 	go func() {
 		slog.Info("metrics server starting", "addr", addr)
-		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			slog.Error("metrics server error", "error", err)
+		if serveErr := srv.Serve(ln); serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
+			slog.Error("metrics server error", "error", serveErr)
 		}
 	}()
 	return func() {
 		shutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		_ = srv.Shutdown(shutCtx)
-	}
+	}, nil
 }

--- a/cmd/bintrail/stream_integration_test.go
+++ b/cmd/bintrail/stream_integration_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/dbtrail/bintrail/internal/config"
 	"github.com/dbtrail/bintrail/internal/indexer"
 	"github.com/dbtrail/bintrail/internal/metadata"
+	"github.com/dbtrail/bintrail/internal/observe"
 	"github.com/dbtrail/bintrail/internal/parser"
 	"github.com/dbtrail/bintrail/internal/testutil"
 )
@@ -229,7 +230,7 @@ func TestStreamLoop_flushAndCheckpoint(t *testing.T) {
 		serverID: 1,
 	}
 
-	if err := streamLoop(context.Background(), events, idx, db, time.Hour, state); err != nil {
+	if err := streamLoop(context.Background(), events, idx, db, time.Hour, state, observe.ForSource("test"), nil); err != nil {
 		t.Fatalf("streamLoop: %v", err)
 	}
 
@@ -343,7 +344,7 @@ func TestStreamLoop_liveReplication(t *testing.T) {
 	}()
 
 	state := &streamState{mode: "position", serverID: 99998}
-	if err := streamLoop(ctx, events, idx, indexDB, time.Minute, state); err != nil {
+	if err := streamLoop(ctx, events, idx, indexDB, time.Minute, state, observe.ForSource("test"), nil); err != nil {
 		t.Fatalf("streamLoop: %v", err)
 	}
 
@@ -406,7 +407,7 @@ func TestStreamLoop_contextCancel(t *testing.T) {
 		cancel()
 	}()
 
-	if err := streamLoop(ctx, events, idx, db, time.Hour, state); err != nil {
+	if err := streamLoop(ctx, events, idx, db, time.Hour, state, observe.ForSource("test"), nil); err != nil {
 		t.Fatalf("streamLoop: %v", err)
 	}
 
@@ -457,7 +458,7 @@ func TestStreamLoop_tickerCheckpoint(t *testing.T) {
 	done := make(chan error, 1)
 	go func() {
 		// 5 ms interval guarantees the ticker fires well before the 50 ms sleep.
-		done <- streamLoop(ctx, events, idx, db, 5*time.Millisecond, state)
+		done <- streamLoop(ctx, events, idx, db, 5*time.Millisecond, state, observe.ForSource("test"), nil)
 	}()
 
 	// Wait for: (1) event consumed, (2) ticker to fire and save checkpoint.
@@ -516,7 +517,7 @@ func TestStreamLoop_positionTracking(t *testing.T) {
 
 	state := &streamState{mode: "position", serverID: 1}
 
-	if err := streamLoop(context.Background(), events, idx, db, time.Hour, state); err != nil {
+	if err := streamLoop(context.Background(), events, idx, db, time.Hour, state, observe.ForSource("test"), nil); err != nil {
 		t.Fatalf("streamLoop: %v", err)
 	}
 
@@ -563,7 +564,7 @@ func TestStreamLoop_batchOverflow(t *testing.T) {
 
 	state := &streamState{mode: "position", serverID: 1}
 
-	if err := streamLoop(context.Background(), events, idx, db, time.Hour, state); err != nil {
+	if err := streamLoop(context.Background(), events, idx, db, time.Hour, state, observe.ForSource("test"), nil); err != nil {
 		t.Fatalf("streamLoop: %v", err)
 	}
 
@@ -624,7 +625,7 @@ func TestStreamLoop_gtidAccumulation(t *testing.T) {
 	}
 	close(events)
 
-	if err := streamLoop(context.Background(), events, idx, db, time.Hour, state); err != nil {
+	if err := streamLoop(context.Background(), events, idx, db, time.Hour, state, observe.ForSource("test"), nil); err != nil {
 		t.Fatalf("streamLoop: %v", err)
 	}
 

--- a/cmd/bintrail/up.go
+++ b/cmd/bintrail/up.go
@@ -217,7 +217,7 @@ func runUpConsoleOnly(cmd *cobra.Command) error {
 	ctx, stop := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	supervisor := newMonitorSupervisor(ctx, upIndexDSN)
+	supervisor := newMonitorSupervisor(ctx, upIndexDSN, registry)
 	cfg.MonitorCtrl = supervisor
 
 	srv, err := console.New(cfg)
@@ -227,6 +227,14 @@ func runUpConsoleOnly(cmd *cobra.Command) error {
 	ln, err := srv.Listen()
 	if err != nil {
 		return fmt.Errorf("console: cannot bind %s: %w", upConsoleListen, err)
+	}
+
+	// One daemon-level /metrics endpoint for ALL supervised streams — the
+	// Prometheus registry is process-global and every stream metric carries
+	// a "source" label (the entry ID), so per-stream servers are unnecessary
+	// (and would fight over the bind).
+	if upMetricsAddr != "" {
+		defer startMetricsServer(upMetricsAddr)()
 	}
 
 	fmt.Fprintf(os.Stderr, "\nConsole is running — open it and add the MySQL servers to watch:\n\n    %s\n\n", srv.URL())
@@ -324,8 +332,17 @@ func runUpStreamWithConsole(cmd *cobra.Command, args []string) error {
 	// The control-plane supervisor: "+ Add server" in the console starts real
 	// monitoring through it. Streams live on the daemon context (ctx), not on
 	// the HTTP requests that start them.
-	supervisor := newMonitorSupervisor(ctx, upIndexDSN)
+	supervisor := newMonitorSupervisor(ctx, upIndexDSN, registry)
 	cfg.MonitorCtrl = supervisor
+
+	// With the console comes the multi-stream control plane, so /metrics is
+	// served once at the daemon level (per-source "source" labels keep the
+	// series apart). Clear the flag fan-out so the main stream does not
+	// double-bind the same address inside streamOne.
+	if upMetricsAddr != "" {
+		defer startMetricsServer(upMetricsAddr)()
+		strmMetricsAddr = ""
+	}
 
 	srv, err := console.New(cfg)
 	if err != nil {

--- a/cmd/bintrail/up.go
+++ b/cmd/bintrail/up.go
@@ -232,9 +232,14 @@ func runUpConsoleOnly(cmd *cobra.Command) error {
 	// One daemon-level /metrics endpoint for ALL supervised streams — the
 	// Prometheus registry is process-global and every stream metric carries
 	// a "source" label (the entry ID), so per-stream servers are unnecessary
-	// (and would fight over the bind).
+	// (and would fight over the bind). Synchronous bind: fails fast, like
+	// the console bind.
 	if upMetricsAddr != "" {
-		defer startMetricsServer(upMetricsAddr)()
+		stopMetrics, err := startMetricsServer(upMetricsAddr)
+		if err != nil {
+			return err
+		}
+		defer stopMetrics()
 	}
 
 	fmt.Fprintf(os.Stderr, "\nConsole is running — open it and add the MySQL servers to watch:\n\n    %s\n\n", srv.URL())
@@ -338,9 +343,14 @@ func runUpStreamWithConsole(cmd *cobra.Command, args []string) error {
 	// With the console comes the multi-stream control plane, so /metrics is
 	// served once at the daemon level (per-source "source" labels keep the
 	// series apart). Clear the flag fan-out so the main stream does not
-	// double-bind the same address inside streamOne.
+	// double-bind the same address inside streamOne. Synchronous bind:
+	// fails fast, like the console bind below.
 	if upMetricsAddr != "" {
-		defer startMetricsServer(upMetricsAddr)()
+		stopMetrics, err := startMetricsServer(upMetricsAddr)
+		if err != nil {
+			return err
+		}
+		defer stopMetrics()
 		strmMetricsAddr = ""
 	}
 

--- a/docs/console.md
+++ b/docs/console.md
@@ -140,9 +140,27 @@ immediately; warnings (e.g. short binlog retention) show but don't block.
   stream's saved checkpoint.
 - A per-entry **advisory lock** (`GET_LOCK`) on the index server makes a
   second daemon refuse to double-stream the same entry.
+- **Stream states**: `PENDING` covers launch through the stream's first
+  checkpoint (connecting, snapshotting, finding the start position) — the
+  badge only says `RUNNING` once the stream has proven it is attached and
+  writing. Two unhealthy-but-alive variants surface what used to be silent:
+  `STALLED` (connected but no checkpoint/batch progress for 5+ minutes) and
+  `LOST POSITION` (binlogs were purged past the saved position while
+  monitoring was down — the stream auto-advanced and events in the gap are
+  permanently lost; sticky until you Stop + Start the entry).
 - A failing stream is retried with exponential backoff (15s → 5m) and shows
   as `FAILED` with the scrubbed error; `Stop` requires an explicit click, and
   deleting or re-pointing a *running* entry is refused (409) until stopped.
+  A stream that crash-loops continuously for 6 hours stops retrying
+  (permanent `FAILED`, the message says it gave up) — press Start to re-arm
+  it after fixing the cause.
+- The add-server preflight warns (amber, never blocks) when the new source
+  **looks like a replica or duplicate of an already-monitored one** — GTID
+  lineage comparison; monitoring both would double-index the same changes.
+  Detection needs `gtid_mode=ON`; in position mode the check is skipped.
+- With `--metrics-addr`, the daemon serves one Prometheus `/metrics` endpoint
+  for all supervised streams; every series carries a `source` label set to
+  the entry ID (see [streaming.md](streaming.md)).
 - Registry fields: `source_dsn` (replication credentials — a secret with the
   same masking/keep-password discipline as the index DSN; `source_dsn: ""`
   clears it), `source_server_id` (0 = derived), `schemas`, `monitor_desired`.
@@ -232,7 +250,7 @@ All endpoints return JSON. `/api/*` (except `healthz`) require
 | `POST /api/servers/{id}/test`, `POST /api/servers/test` | Write-free reachability probe (short timeout): `{ok, server_version, dbname, latency_ms, has_index, schema_current}`. Accepts an unsaved candidate body; with `{id}`, a blank password merges the stored one. |
 | `POST /api/servers/{id}/monitor/start` | Supervisor only (403 on the standalone console): doctor preflight → on green, record intent + provision + stream. Returns `{doctor, started, monitor}`. |
 | `POST /api/servers/{id}/monitor/stop` | Supervisor only: clear intent, drain the stream (final checkpoint), release the advisory lock. |
-| `GET /api/servers/{id}/monitor` | Supervisor only: `{monitor: {state, last_error, since}}` — `stopped\|pending\|running\|failed`. |
+| `GET /api/servers/{id}/monitor` | Supervisor only: `{monitor: {state, last_error, since}}` — `stopped\|pending\|running\|stalled\|lost_position\|failed`. |
 
 Every data endpoint (`status`, `schemas`, `events`, `recover`, `capabilities`,
 `reconstruct`) targets the server named by the `X-Bintrail-Server` request

--- a/docs/console.md
+++ b/docs/console.md
@@ -145,9 +145,10 @@ immediately; warnings (e.g. short binlog retention) show but don't block.
   badge only says `RUNNING` once the stream has proven it is attached and
   writing. Two unhealthy-but-alive variants surface what used to be silent:
   `STALLED` (connected but no checkpoint/batch progress for 5+ minutes) and
-  `LOST POSITION` (binlogs were purged past the saved position while
-  monitoring was down — the stream auto-advanced and events in the gap are
-  permanently lost; sticky until you Stop + Start the entry).
+  `LOST POSITION` (binlogs were purged past the saved position while the
+  stream was behind or stopped — it auto-advanced and events in the gap are
+  permanently lost; the record is durable, survives daemon restarts, and is
+  cleared only by an explicit Stop on the entry).
 - A failing stream is retried with exponential backoff (15s → 5m) and shows
   as `FAILED` with the scrubbed error; `Stop` requires an explicit click, and
   deleting or re-pointing a *running* entry is refused (409) until stopped.

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -324,7 +324,13 @@ When `--metrics-addr :9090` is set, a Prometheus HTTP endpoint starts at `/metri
 | `bintrail_stream_errors_total{type}` | Counter | Errors by type: `batch_flush`, `checkpoint`, `gtid_update` |
 | `bintrail_stream_batch_size` | Histogram | Distribution of events per batch flush |
 
-`replication_lag_seconds` is the most useful metric for monitoring — it tells you how far behind the stream is relative to real time. If it grows steadily, the index database can't keep up with the write rate.
+Every metric carries a `source` label so concurrent streams in one process stay
+distinguishable. For a standalone `bintrail stream` it is the server's resolved
+`bintrail_id` (`default` if unresolved); under `bintrail up --console` it is the
+monitored entry's ID, and the **daemon** serves one `/metrics` endpoint covering
+all supervised streams (per-stream endpoints would fight over the bind).
+
+`replication_lag_seconds` is the most useful metric for monitoring — it tells you how far behind the stream is relative to real time. If it grows steadily, the index database can't keep up with the write rate. With multiple sources, alert per label: `bintrail_stream_replication_lag_seconds{source="<entry-id>"}`.
 
 The metrics HTTP server shuts down gracefully (5-second timeout) on command exit.
 

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -321,7 +321,7 @@ When `--metrics-addr :9090` is set, a Prometheus HTTP endpoint starts at `/metri
 | `bintrail_stream_checkpoint_saves_total` | Counter | Successful checkpoint writes |
 | `bintrail_stream_last_event_timestamp_seconds` | Gauge | Unix timestamp of the last received event |
 | `bintrail_stream_replication_lag_seconds` | Gauge | `now() - last_event_timestamp` in seconds |
-| `bintrail_stream_errors_total{type}` | Counter | Errors by type: `batch_flush`, `checkpoint`, `gtid_update` |
+| `bintrail_stream_errors_total{source,type}` | Counter | Errors by type: `batch_flush`, `checkpoint`, `gtid_update` |
 | `bintrail_stream_batch_size` | Histogram | Distribution of events per batch flush |
 
 Every metric carries a `source` label so concurrent streams in one process stay

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -564,6 +564,19 @@ function closeServersModal() {
   document.getElementById("servers-modal").hidden = true;
 }
 
+// isLiveMonitorState: states where the stream goroutine is alive (Stop is the
+// applicable verb). "stalled" and "lost_position" are unhealthy running
+// variants — the supervisor still owns the stream and its advisory lock.
+function isLiveMonitorState(st) {
+  return st === "running" || st === "pending" || st === "stalled" || st === "lost_position";
+}
+
+const MON_STATE_TITLES = {
+  failed: "stream failing — retrying with backoff; press Start for details",
+  stalled: "stream is connected but has made no progress for several minutes",
+  lost_position: "binlogs were purged past the saved position — events in the gap are permanently lost; current changes are still streaming",
+};
+
 async function refreshServersList() {
   const list = document.getElementById("servers-list");
   let servers = [];
@@ -583,7 +596,7 @@ async function refreshServersList() {
       ? `watching ${s.source_user}@${s.source_host}:${s.source_port || "3306"}${s.schemas ? " [" + s.schemas + "]" : ""}`
       : (s.host ? `${s.user}@${s.host}:${s.port || "3306"}/${s.dbname}` : s.dbname || "");
     const monitorable = capsCache.monitor && s.has_source && s.kind !== "ephemeral";
-    const running = s.monitor_state === "running" || s.monitor_state === "pending";
+    const running = isLiveMonitorState(s.monitor_state);
     const row = el("div", { class: "server-row" },
       el("span", { class: "health-dot" + (s.connected ? " ok" : ""), title: s.connected ? "connected" : "not connected yet" }),
       el("span", { class: "srv-name" }, serverLabel(s)),
@@ -591,8 +604,8 @@ async function refreshServersList() {
       s.reconstruct ? el("span", { class: "badge tt", title: "Baseline configured: Time-travel available" }, "TT") : null,
       s.monitor_state ? el("span", {
         class: "badge mon-" + s.monitor_state,
-        title: s.monitor_state === "failed" ? "stream failing — retrying with backoff; press Start for details" : "monitoring " + s.monitor_state,
-      }, s.monitor_state.toUpperCase()) : null,
+        title: MON_STATE_TITLES[s.monitor_state] || ("monitoring " + s.monitor_state),
+      }, s.monitor_state.replace("_", " ").toUpperCase()) : null,
       el("span", { class: "srv-desc" }, desc),
       el("span", { class: "srv-status", id: "srv-status-" + s.id }),
       monitorable ? el("button", {
@@ -752,7 +765,7 @@ async function saveServer(e) {
   // The zero-terminal flow: a saved server with a source goes straight into
   // doctor → stream (auto-start on green). The form stays open on a failed
   // preflight so the remediation cards are right there.
-  if (capsCache.monitor && saved.has_source && saved.monitor_state !== "running") {
+  if (capsCache.monitor && saved.has_source && !isLiveMonitorState(saved.monitor_state)) {
     formMsg("running preflight checks…", false);
     const res = await startMonitor(saved.id);
     await refreshServersList();

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -657,17 +657,23 @@ async function startMonitorRow(id) {
     if (doctorWarnings(res.doctor)) {
       // Warnings never block (started already), but they must be SEEN —
       // e.g. "this looks like a replica of an already-monitored server".
-      await editServer(id);
-      renderDoctor(res.doctor);
-      formMsg("monitoring started — review the warnings below", false);
+      // If the editor cannot open (server deleted concurrently), don't
+      // render into a hidden form — degrade to a toast.
+      if (await editServer(id)) {
+        renderDoctor(res.doctor);
+        formMsg("monitoring started — review the warnings below", false);
+      } else {
+        toast("Monitoring started with warnings — edit the server to review them");
+      }
     } else {
       toast("Monitoring started");
     }
   } else {
     // Preflight failed — open the editor so the remediation cards are visible.
-    await editServer(id);
-    renderDoctor(res.doctor);
-    formMsg("preflight failed — fix the items below, Save, and Start again", true);
+    if (await editServer(id)) {
+      renderDoctor(res.doctor);
+      formMsg("preflight failed — fix the items below, Save, and Start again", true);
+    }
   }
 }
 
@@ -727,12 +733,17 @@ function hideServerForm() {
   document.getElementById("server-add-wrap").hidden = false;
 }
 
+// editServer opens the editor form for a server; returns true when the form
+// is actually showing (callers that render into it must not assume success —
+// the server may have been deleted concurrently).
 async function editServer(id) {
   try {
     const s = await api("/api/servers/" + encodeURIComponent(id));
     showServerForm(s);
+    return true;
   } catch (err) {
     toast("failed to load server: " + (err.message || err));
+    return false;
   }
 }
 

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -654,13 +654,26 @@ async function startMonitorRow(id) {
   await refreshServersList();
   if (!res) return;
   if (res.started) {
-    toast("Monitoring started");
+    if (doctorWarnings(res.doctor)) {
+      // Warnings never block (started already), but they must be SEEN —
+      // e.g. "this looks like a replica of an already-monitored server".
+      await editServer(id);
+      renderDoctor(res.doctor);
+      formMsg("monitoring started — review the warnings below", false);
+    } else {
+      toast("Monitoring started");
+    }
   } else {
     // Preflight failed — open the editor so the remediation cards are visible.
     await editServer(id);
     renderDoctor(res.doctor);
     formMsg("preflight failed — fix the items below, Save, and Start again", true);
   }
+}
+
+// doctorWarnings: does the preflight report carry warn cards worth showing?
+function doctorWarnings(report) {
+  return !!(report && report.warnings > 0);
 }
 
 async function stopMonitorRow(id) {
@@ -769,9 +782,14 @@ async function saveServer(e) {
     formMsg("running preflight checks…", false);
     const res = await startMonitor(saved.id);
     await refreshServersList();
-    if (res && res.started) {
+    if (res && res.started && !doctorWarnings(res.doctor)) {
       hideServerForm();
       toast("Monitoring started — events will appear within a minute");
+    } else if (res && res.started) {
+      // Started, but with warn cards (e.g. replica-of-monitored) — keep the
+      // form open so the operator actually sees them.
+      renderDoctor(res.doctor);
+      formMsg("monitoring started — review the warnings below", false);
     } else if (res) {
       renderDoctor(res.doctor);
       formMsg("preflight failed — fix the items below and Save again", true);

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -439,6 +439,8 @@ table.statetable td { font-family: var(--mono); white-space: pre-wrap; word-brea
 .badge.mon-pending { color: var(--warn); border: 1px solid var(--warn); }
 .badge.mon-failed { color: var(--del); border: 1px solid var(--del); }
 .badge.mon-stopped { color: var(--muted); border: 1px solid var(--muted); }
+.badge.mon-stalled { color: var(--warn); border: 1px solid var(--warn); }
+.badge.mon-lost_position { color: var(--del); border: 1px solid var(--del); }
 
 .row-btn.primaryish { border-color: var(--accent-2); color: var(--accent); }
 

--- a/internal/console/monitor.go
+++ b/internal/console/monitor.go
@@ -30,9 +30,20 @@ type DoctorReport struct {
 
 // MonitorStatus is the supervisor's view of one entry's stream.
 type MonitorStatus struct {
-	// State: "stopped" | "pending" | "running" | "failed".
-	// "failed" carries LastError and the supervisor keeps retrying with
-	// backoff — it is "unhealthy, recovering", not terminal.
+	// State: "stopped" | "pending" | "running" | "stalled" | "lost_position"
+	// | "failed".
+	//   - "pending" covers launch through the stream's first checkpoint —
+	//     connecting, snapshotting, discovering the start position. Only a
+	//     saved checkpoint (or indexed batch) flips it to "running" (#407).
+	//   - "stalled" and "lost_position" are running variants derived at read
+	//     time: the stream goroutine is alive, but it has made no progress
+	//     for several minutes (stalled) or an unfillable binlog gap forced
+	//     it to skip permanently lost events (lost_position, sticky until
+	//     the entry is stopped and started again).
+	//   - "failed" carries LastError; the supervisor keeps retrying with
+	//     backoff — "unhealthy, recovering", not terminal — unless the
+	//     circuit breaker gave up after hours of continuous crash-looping
+	//     (the message says so; Start re-arms it).
 	State     string `json:"state"`
 	LastError string `json:"last_error,omitempty"`
 	// Since is when the state was entered (RFC3339), empty for stopped.

--- a/internal/console/monitor.go
+++ b/internal/console/monitor.go
@@ -46,7 +46,10 @@ type MonitorStatus struct {
 	//     (the message says so; Start re-arms it).
 	State     string `json:"state"`
 	LastError string `json:"last_error,omitempty"`
-	// Since is when the state was entered (RFC3339), empty for stopped.
+	// Since is when the underlying STORED state was entered (RFC3339), empty
+	// for stopped. For the derived stalled/lost_position presentations it
+	// still reflects the running transition, not when the stream stalled or
+	// lost its position.
 	Since string `json:"since,omitempty"`
 }
 

--- a/internal/console/monitor.go
+++ b/internal/console/monitor.go
@@ -38,8 +38,9 @@ type MonitorStatus struct {
 	//   - "stalled" and "lost_position" are running variants derived at read
 	//     time: the stream goroutine is alive, but it has made no progress
 	//     for several minutes (stalled) or an unfillable binlog gap forced
-	//     it to skip permanently lost events (lost_position, sticky until
-	//     the entry is stopped and started again).
+	//     it to skip permanently lost events (lost_position — durable,
+	//     persisted in stream_state, re-hydrated on Start, cleared only by
+	//     an explicit Stop).
 	//   - "failed" carries LastError; the supervisor keeps retrying with
 	//     backoff — "unhealthy, recovering", not terminal — unless the
 	//     circuit breaker gave up after hours of continuous crash-looping

--- a/internal/console/servers_api.go
+++ b/internal/console/servers_api.go
@@ -50,7 +50,8 @@ type serverDTO struct {
 	Schemas           string `json:"schemas,omitempty"`
 	MonitorDesired    bool   `json:"monitor_desired"`
 	// MonitorState is the supervisor's live view (stopped|pending|running|
-	// failed); present only on a supervisor process for entries with a source.
+	// stalled|lost_position|failed — see console.MonitorStatus); present only
+	// on a supervisor process for entries with a source.
 	MonitorState string `json:"monitor_state,omitempty"`
 	// Reconstruct is the per-server Time-travel capability, derived from pure
 	// config (no connection is opened to compute it).

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -201,8 +201,8 @@ func nullOrUint32(v uint32) any {
 }
 
 // EnsureSchema adds any columns introduced after the initial schema to
-// binlog_events and schema_snapshots. It is idempotent — safe to call on
-// every startup.
+// binlog_events, schema_snapshots, and stream_state. It is idempotent — safe
+// to call on every startup.
 func EnsureSchema(db *sql.DB) error {
 	if err := ensureColumn(db, "binlog_events", "connection_id",
 		`ALTER TABLE binlog_events ADD COLUMN connection_id INT UNSIGNED DEFAULT NULL COMMENT 'MySQL connection ID (pseudo_thread_id) that produced this event' AFTER gtid`,
@@ -219,7 +219,18 @@ func EnsureSchema(db *sql.DB) error {
 	); err != nil {
 		return err
 	}
-	return nil
+	// gap_lost_at/_detail record an unfillable-gap auto-advance durably
+	// (#402): the advanced checkpoint is persisted, so without these columns
+	// the only trace of the permanently lost events would be an in-memory
+	// flag that a daemon restart silently discards.
+	if err := ensureColumn(db, "stream_state", "gap_lost_at",
+		`ALTER TABLE stream_state ADD COLUMN gap_lost_at DATETIME DEFAULT NULL COMMENT 'when an unfillable binlog gap forced an auto-advance (events permanently lost); cleared by an explicit monitor Stop or --reset' AFTER bintrail_id`,
+	); err != nil {
+		return err
+	}
+	return ensureColumn(db, "stream_state", "gap_lost_detail",
+		`ALTER TABLE stream_state ADD COLUMN gap_lost_detail TEXT DEFAULT NULL COMMENT 'human-readable description of the lost gap' AFTER gap_lost_at`,
+	)
 }
 
 // ensureColumn runs an idempotent ALTER TABLE ADD COLUMN: checks

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -293,7 +293,8 @@ func TakeSnapshot(sourceDB, indexDB *sql.DB, schemas []string) (SnapshotStats, e
 
 	if len(columns) == 0 {
 		return SnapshotStats{}, fmt.Errorf(
-			"no columns found for the requested schemas; check --schemas and source server permissions")
+			"no columns found for the requested schemas — if the schema has no tables yet, " +
+				"create at least one table first; otherwise check --schemas and source server permissions")
 	}
 
 	// ── 1b. Validate: all tables must be InnoDB with explicit PKs ────────────

--- a/internal/observe/metrics.go
+++ b/internal/observe/metrics.go
@@ -6,70 +6,104 @@ import (
 )
 
 // Stream metrics — all in the bintrail_stream namespace.
-// These are only meaningful for the long-running `bintrail stream` command.
+//
+// Every metric carries a "source" label so N concurrent streams in one
+// process (the `up --console` control plane) stay distinguishable: without
+// it the counters of different sources conflate and the gauges clobber each
+// other last-writer-wins. The label value is the supervisor's entry ID for
+// monitored streams and the resolved bintrail_id (or "default") for a
+// standalone `bintrail stream`. Call ForSource to obtain handles curried to
+// one source; the underlying vectors are deliberately unexported.
 var (
-	// StreamEventsReceived counts every binlog row event received from the source.
-	StreamEventsReceived = promauto.NewCounter(prometheus.CounterOpts{
+	streamEventsReceived = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "bintrail",
 		Subsystem: "stream",
 		Name:      "events_received_total",
 		Help:      "Total number of binlog row events received from the replication stream.",
-	})
+	}, []string{"source"})
 
-	// StreamEventsIndexed counts events successfully written to the index database.
-	StreamEventsIndexed = promauto.NewCounter(prometheus.CounterOpts{
+	streamEventsIndexed = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "bintrail",
 		Subsystem: "stream",
 		Name:      "events_indexed_total",
 		Help:      "Total number of binlog row events written to binlog_events.",
-	})
+	}, []string{"source"})
 
-	// StreamBatchFlushes counts batch INSERT operations.
-	StreamBatchFlushes = promauto.NewCounter(prometheus.CounterOpts{
+	streamBatchFlushes = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "bintrail",
 		Subsystem: "stream",
 		Name:      "batch_flushes_total",
 		Help:      "Total number of batch INSERT operations executed.",
-	})
+	}, []string{"source"})
 
-	// StreamCheckpointSaves counts successful checkpoint writes.
-	StreamCheckpointSaves = promauto.NewCounter(prometheus.CounterOpts{
+	streamCheckpointSaves = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "bintrail",
 		Subsystem: "stream",
 		Name:      "checkpoint_saves_total",
 		Help:      "Total number of successful checkpoint saves to stream_state.",
-	})
+	}, []string{"source"})
 
-	// StreamLastEventTimestamp is a Unix timestamp of the last processed event.
-	StreamLastEventTimestamp = promauto.NewGauge(prometheus.GaugeOpts{
+	streamLastEventTimestamp = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "bintrail",
 		Subsystem: "stream",
 		Name:      "last_event_timestamp_seconds",
 		Help:      "Unix timestamp of the last binlog event processed.",
-	})
+	}, []string{"source"})
 
-	// StreamReplicationLag is the wall-clock age of the last processed event in seconds.
-	StreamReplicationLag = promauto.NewGauge(prometheus.GaugeOpts{
+	streamReplicationLag = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "bintrail",
 		Subsystem: "stream",
 		Name:      "replication_lag_seconds",
 		Help:      "Seconds between now and the timestamp of the last processed binlog event.",
-	})
+	}, []string{"source"})
 
-	// StreamErrors counts errors by type.
-	StreamErrors = promauto.NewCounterVec(prometheus.CounterOpts{
+	streamErrors = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "bintrail",
 		Subsystem: "stream",
 		Name:      "errors_total",
 		Help:      "Total number of errors encountered, partitioned by type.",
-	}, []string{"type"})
+	}, []string{"source", "type"})
 
-	// StreamBatchSize observes the number of events in each batch flush.
-	StreamBatchSize = promauto.NewHistogram(prometheus.HistogramOpts{
+	streamBatchSize = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "bintrail",
 		Subsystem: "stream",
 		Name:      "batch_size",
 		Help:      "Distribution of batch sizes (events per INSERT batch).",
 		Buckets:   prometheus.ExponentialBuckets(1, 2, 11), // 1, 2, 4, ..., 1024
-	})
+	}, []string{"source"})
 )
+
+// StreamMetrics is the full set of stream metrics curried to one source
+// label — call sites keep the ergonomics of plain counters/gauges.
+type StreamMetrics struct {
+	EventsReceived     prometheus.Counter
+	EventsIndexed      prometheus.Counter
+	BatchFlushes       prometheus.Counter
+	CheckpointSaves    prometheus.Counter
+	LastEventTimestamp prometheus.Gauge
+	ReplicationLag     prometheus.Gauge
+	// Errors keeps its remaining "type" dimension (batch_flush, checkpoint,
+	// gtid_update).
+	Errors *prometheus.CounterVec
+	// BatchSize is the per-source histogram handle.
+	BatchSize prometheus.Observer
+}
+
+// ForSource returns the stream metrics curried to the given source label.
+// An empty source falls back to "default" so a standalone stream without a
+// resolved identity still produces well-formed series.
+func ForSource(source string) *StreamMetrics {
+	if source == "" {
+		source = "default"
+	}
+	return &StreamMetrics{
+		EventsReceived:     streamEventsReceived.WithLabelValues(source),
+		EventsIndexed:      streamEventsIndexed.WithLabelValues(source),
+		BatchFlushes:       streamBatchFlushes.WithLabelValues(source),
+		CheckpointSaves:    streamCheckpointSaves.WithLabelValues(source),
+		LastEventTimestamp: streamLastEventTimestamp.WithLabelValues(source),
+		ReplicationLag:     streamReplicationLag.WithLabelValues(source),
+		Errors:             streamErrors.MustCurryWith(prometheus.Labels{"source": source}),
+		BatchSize:          streamBatchSize.WithLabelValues(source),
+	}
+}

--- a/internal/observe/metrics_test.go
+++ b/internal/observe/metrics_test.go
@@ -9,9 +9,13 @@ import (
 	"github.com/dbtrail/bintrail/internal/observe"
 )
 
-func TestStreamMetrics_registration(t *testing.T) {
-	// promauto registers metrics in the default registry at init time.
-	// Gathering should produce at least one metric family for our namespace.
+func TestForSource_registration(t *testing.T) {
+	// promauto registers the vectors in the default registry at init time,
+	// but a labeled vector only emits families once a child exists — touch
+	// one source first.
+	m := observe.ForSource("reg-test")
+	m.EventsReceived.Inc()
+
 	mfs, err := prometheus.DefaultGatherer.Gather()
 	if err != nil {
 		t.Fatalf("Gather: %v", err)
@@ -27,25 +31,67 @@ func TestStreamMetrics_registration(t *testing.T) {
 	}
 }
 
-func TestStreamEventsReceived_increment(t *testing.T) {
-	before := testutil.ToFloat64(observe.StreamEventsReceived)
-	observe.StreamEventsReceived.Add(3)
-	after := testutil.ToFloat64(observe.StreamEventsReceived)
-	if after-before != 3 {
-		t.Errorf("expected counter to increase by 3, got %v", after-before)
+func TestForSource_isolatesSources(t *testing.T) {
+	a := observe.ForSource("src-a")
+	b := observe.ForSource("src-b")
+
+	a.EventsReceived.Add(3)
+	b.EventsReceived.Add(7)
+
+	if got := testutil.ToFloat64(a.EventsReceived); got != 3 {
+		t.Errorf("src-a events_received = %v, want 3", got)
+	}
+	if got := testutil.ToFloat64(b.EventsReceived); got != 7 {
+		t.Errorf("src-b events_received = %v, want 7", got)
+	}
+
+	// Gauges must not clobber across sources — the whole point of the label.
+	a.ReplicationLag.Set(1)
+	b.ReplicationLag.Set(99)
+	if got := testutil.ToFloat64(a.ReplicationLag); got != 1 {
+		t.Errorf("src-a replication_lag = %v, want 1", got)
 	}
 }
 
-func TestStreamErrors_labelValues(t *testing.T) {
-	// Incrementing with label values should not panic.
-	observe.StreamErrors.WithLabelValues("batch_flush").Inc()
-	observe.StreamErrors.WithLabelValues("checkpoint").Inc()
-	observe.StreamErrors.WithLabelValues("gtid_update").Inc()
+func TestForSource_sameSourceAccumulates(t *testing.T) {
+	first := observe.ForSource("src-acc")
+	second := observe.ForSource("src-acc")
+
+	first.EventsIndexed.Add(2)
+	second.EventsIndexed.Add(5)
+
+	if got := testutil.ToFloat64(second.EventsIndexed); got != 7 {
+		t.Errorf("events_indexed = %v, want 7 (same source must share the child)", got)
+	}
 }
 
-func TestStreamBatchSize_observe(t *testing.T) {
+func TestForSource_emptyFallsBackToDefault(t *testing.T) {
+	anon := observe.ForSource("")
+	named := observe.ForSource("default")
+
+	before := testutil.ToFloat64(named.BatchFlushes)
+	anon.BatchFlushes.Inc()
+	if got := testutil.ToFloat64(named.BatchFlushes); got != before+1 {
+		t.Errorf(`ForSource("") must alias ForSource("default"): got %v, want %v`, got, before+1)
+	}
+}
+
+func TestForSource_errorsKeepTypeLabel(t *testing.T) {
+	m := observe.ForSource("src-err")
+	// Incrementing with the remaining "type" label must not panic.
+	m.Errors.WithLabelValues("batch_flush").Inc()
+	m.Errors.WithLabelValues("checkpoint").Inc()
+	m.Errors.WithLabelValues("gtid_update").Inc()
+
+	if got := testutil.ToFloat64(m.Errors.WithLabelValues("checkpoint")); got != 1 {
+		t.Errorf("errors{type=checkpoint} = %v, want 1", got)
+	}
+}
+
+func TestForSource_batchSizeObserve(t *testing.T) {
+	m := observe.ForSource("src-hist")
 	// Observing histogram values should not panic.
-	observe.StreamBatchSize.Observe(10)
-	observe.StreamBatchSize.Observe(500)
-	observe.StreamBatchSize.Observe(1000)
+	m.BatchSize.Observe(10)
+	m.BatchSize.Observe(500)
+	m.BatchSize.Observe(1000)
 }

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -196,6 +196,8 @@ func InitIndexTables(t *testing.T, db *sql.DB) {
 		last_checkpoint  DATETIME        NOT NULL,
 		server_id        INT UNSIGNED    NOT NULL,
 		bintrail_id      CHAR(36)        NULL DEFAULT NULL,
+		gap_lost_at      DATETIME        DEFAULT NULL,
+		gap_lost_detail  TEXT            DEFAULT NULL,
 		CONSTRAINT single_row CHECK (id = 1)
 	) ENGINE=InnoDB`)
 


### PR DESCRIPTION
closes #402

## Summary

Phase 4 of the approved control-plane blueprint — all five issue items plus the `pending`-state fix from the #407 postmortem comment:

- **Per-source Prometheus metrics** — every `bintrail_stream_*` metric now carries a `source` label (`observe.ForSource`: entry ID when supervised, resolved `bintrail_id` for standalone `stream`). Under `up --console` the **daemon serves one `/metrics` endpoint** for all supervised streams; the main stream's per-process bind is cleared there to avoid a double-bind. Unlabeled gauges previously clobbered each other last-writer-wins with N streams.
- **Replica/duplicate detection (warn-only, amber card)** — the supervisor's doctor reads the candidate's `@@server_uuid` / `@@gtid_executed` and compares against every other monitored entry's recorded identity (`bintrail_servers`) and accumulated executed set (`stream_state.gtid_set`) — no connection to the other sources needed. Catches *replica-of-monitored*, *primary-of-monitored-replica*, and *same-server-added-twice*. Needs `gtid_mode=ON`; skipped otherwise. Never blocks (per the approved decision).
- **Richer monitor states** — `pending` now covers launch→first checkpoint (flip happens via stream liveness hooks: first successful checkpoint save or batch flush); `stalled` (alive but no progress for 5 min — the checkpoint ticker fires even with zero events, so an idle-healthy source never trips it) and `lost_position` (gap auto-advance skipped purged events; sticky until Stop+Start) are **derived at read time** — the stored state machine stays `pending|running|failed|stopped`.
- **Circuit breaker** — continuous crash-looping for 6 h → permanent `failed (gave up …)`, goroutine exits, advisory lock released; Start (or daemon restart) re-arms. Also: the stream seeds its first checkpoint with the resolved start position instead of persisting an empty file/pos 0.
- **Empty-schema UX** — doctor's schema-visibility check now distinguishes *"schema exists but has no tables yet → create at least one table first"* from *"not visible → grants/typo"*; `TakeSnapshot`'s no-columns error gives the same guidance.

UI: new `STALLED` / `LOST POSITION` badges (amber/red), state-aware tooltips, and the Stop/Start verb logic treats the new states as live.

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`, 23 packages)
- [x] Integration suite green against Docker MySQL (`go test -tags integration ./cmd/bintrail/ ./internal/metadata/`), including `TestIntegrationMonitorSupervisor` with the new pending→running semantics
- [x] New unit coverage: derived states + precedence, pending-flip hooks, circuit breaker (gave-up + clean-stop), `gtidSetContainsUUID` / `classifyReplicaOverlap` (incl. lowercase-UUID gotcha), per-source metric isolation
- [x] Console frontend verified with a real headless-Chrome render (state classification, badge CSS, modal flow — screenshot in session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)