### PR TITLE
test(parser): immunize integration tests against cross-package DDL leakage

### DIFF
--- a/internal/parser/parser_integration_test.go
+++ b/internal/parser/parser_integration_test.go
@@ -99,8 +99,10 @@ func drainEvents(ch <-chan parser.Event) []parser.Event {
 // these tests must ignore DDL: under parallel `go test -tags integration ./...`
 // runs, concurrent test packages' setup DDL (CREATE TABLE index_state, ...)
 // lands in the shared container's binlog window, and DDL events bypass the
-// schema filter by design (#415). Row events ARE schema-filtered and each
-// test owns its schema, so DML counts stay exact.
+// schema filter by design — DDL is emitted unconditionally for audit and
+// auto-snapshot purposes (#415; contract pinned by
+// TestStreamParser_ddlBypassesSchemaFilter). Row events ARE schema-filtered
+// and each test owns its schema, so DML counts stay exact.
 func dmlEvents(events []parser.Event) []parser.Event {
 	var dml []parser.Event
 	for _, ev := range events {
@@ -289,7 +291,8 @@ func TestParseFiles_multiple(t *testing.T) {
 		errCh <- p.ParseFiles(context.Background(), binlogFiles, events)
 	}()
 
-	got := dmlEvents(drainEvents(events))
+	raw := drainEvents(events)
+	got := dmlEvents(raw)
 
 	if err := <-errCh; err != nil {
 		t.Fatalf("ParseFiles returned error: %v", err)
@@ -298,9 +301,10 @@ func TestParseFiles_multiple(t *testing.T) {
 	// Each batch has 1 INSERT, so 2 DML events total.
 	if len(got) != 2 {
 		t.Errorf("expected 2 DML events from 2 binlog files, got %d", len(got))
-		for i, ev := range got {
-			t.Logf("  event[%d]: type=%d file=%s table=%s pk=%s",
-				i, ev.EventType, ev.BinlogFile, ev.Table, ev.PKValues)
+		// Dump the RAW set so the failure shows what dmlEvents filtered out.
+		for i, ev := range raw {
+			t.Logf("  event[%d]: type=%d file=%s schema=%s table=%s pk=%s",
+				i, ev.EventType, ev.BinlogFile, ev.Schema, ev.Table, ev.PKValues)
 		}
 	}
 

--- a/internal/parser/parser_integration_test.go
+++ b/internal/parser/parser_integration_test.go
@@ -95,6 +95,23 @@ func drainEvents(ch <-chan parser.Event) []parser.Event {
 	return events
 }
 
+// dmlEvents returns only the INSERT/UPDATE/DELETE events. Count assertions in
+// these tests must ignore DDL: under parallel `go test -tags integration ./...`
+// runs, concurrent test packages' setup DDL (CREATE TABLE index_state, ...)
+// lands in the shared container's binlog window, and DDL events bypass the
+// schema filter by design (#415). Row events ARE schema-filtered and each
+// test owns its schema, so DML counts stay exact.
+func dmlEvents(events []parser.Event) []parser.Event {
+	var dml []parser.Event
+	for _, ev := range events {
+		switch ev.EventType {
+		case parser.EventInsert, parser.EventUpdate, parser.EventDelete:
+			dml = append(dml, ev)
+		}
+	}
+	return dml
+}
+
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
 func TestParseFile_realBinlog(t *testing.T) {
@@ -114,15 +131,15 @@ func TestParseFile_realBinlog(t *testing.T) {
 		errCh <- p.ParseFile(context.Background(), binlogFile, events)
 	}()
 
-	got := drainEvents(events)
+	got := dmlEvents(drainEvents(events))
 
 	if err := <-errCh; err != nil {
 		t.Fatalf("ParseFile returned error: %v", err)
 	}
 
-	// Expect 4 events: 2 INSERT + 1 UPDATE + 1 DELETE.
+	// Expect 4 DML events: 2 INSERT + 1 UPDATE + 1 DELETE.
 	if len(got) != 4 {
-		t.Fatalf("expected 4 events, got %d", len(got))
+		t.Fatalf("expected 4 DML events, got %d", len(got))
 	}
 
 	// Count by type.
@@ -199,14 +216,14 @@ func TestParseFile_withFilters(t *testing.T) {
 		errCh <- p.ParseFile(context.Background(), binlogFile, events)
 	}()
 
-	got := drainEvents(events)
+	got := dmlEvents(drainEvents(events))
 
 	if err := <-errCh; err != nil {
 		t.Fatalf("ParseFile returned error: %v", err)
 	}
 
 	if len(got) != 0 {
-		t.Errorf("expected 0 events with nonexistent schema filter, got %d", len(got))
+		t.Errorf("expected 0 DML events with nonexistent schema filter, got %d", len(got))
 	}
 }
 
@@ -272,15 +289,15 @@ func TestParseFiles_multiple(t *testing.T) {
 		errCh <- p.ParseFiles(context.Background(), binlogFiles, events)
 	}()
 
-	got := drainEvents(events)
+	got := dmlEvents(drainEvents(events))
 
 	if err := <-errCh; err != nil {
 		t.Fatalf("ParseFiles returned error: %v", err)
 	}
 
-	// Each batch has 1 INSERT, so 2 events total.
+	// Each batch has 1 INSERT, so 2 DML events total.
 	if len(got) != 2 {
-		t.Errorf("expected 2 events from 2 binlog files, got %d", len(got))
+		t.Errorf("expected 2 DML events from 2 binlog files, got %d", len(got))
 		for i, ev := range got {
 			t.Logf("  event[%d]: type=%d file=%s table=%s pk=%s",
 				i, ev.EventType, ev.BinlogFile, ev.Table, ev.PKValues)
@@ -423,20 +440,12 @@ func TestParseFile_compressedTransactions(t *testing.T) {
 		t.Fatalf("ParseFile returned error: %v", err)
 	}
 
-	// Count DML events only: under parallel `./...` runs, concurrent test
-	// packages' DDL (CREATE TABLE index_state, ...) leaks into the shared
-	// container's binlog window, and DDL events bypass the schema filter by
-	// design. Row events ARE schema-filtered, so the DML counts are exact.
 	// 20 INSERT + 1 UPDATE + 1 DELETE — the positive count IS the regression
-	// guard (the bug produced exactly zero).
-	var dml []parser.Event
+	// guard (the bug produced exactly zero). DML-only via dmlEvents (#415).
+	dml := dmlEvents(got)
 	typeCounts := map[parser.EventType]int{}
-	for _, ev := range got {
-		switch ev.EventType {
-		case parser.EventInsert, parser.EventUpdate, parser.EventDelete:
-			dml = append(dml, ev)
-			typeCounts[ev.EventType]++
-		}
+	for _, ev := range dml {
+		typeCounts[ev.EventType]++
 	}
 	if typeCounts[parser.EventInsert] != 20 || typeCounts[parser.EventUpdate] != 1 || typeCounts[parser.EventDelete] != 1 {
 		t.Fatalf("event mix = %d INSERT / %d UPDATE / %d DELETE, want 20/1/1",

--- a/internal/parser/stream_test.go
+++ b/internal/parser/stream_test.go
@@ -233,6 +233,36 @@ func TestStreamParser_queryEventDDL(t *testing.T) {
 	}
 }
 
+// TestStreamParser_ddlBypassesSchemaFilter pins the contract that DDL events
+// are emitted UNCONDITIONALLY — even for schemas excluded by the filter — for
+// audit and auto-snapshot purposes. The integration tests' dmlEvents helper
+// (#415) depends on this: it strips cross-package DDL leakage from count
+// assertions precisely because DDL ignores the filter. If a future change
+// made DDL respect filters, that flake fix would become a silent no-op and
+// the audit trail would lose foreign-schema DDL — this test fails first.
+func TestStreamParser_ddlBypassesSchemaFilter(t *testing.T) {
+	sp := NewStreamParser(nil, Filters{Schemas: map[string]bool{"prod": true}}, nil)
+	streamer := replication.NewBinlogStreamer()
+	out := make(chan Event, 10)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	feedThenCancel(t, streamer, cancel, makeQueryEvent("CREATE TABLE staging.t (id INT)"))
+
+	if err := sp.Run(ctx, streamer, out); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("expected 1 EventDDL for a filtered-out schema, got %d", len(out))
+	}
+	ev := <-out
+	if ev.EventType != EventDDL {
+		t.Errorf("expected EventDDL (%d), got %d", EventDDL, ev.EventType)
+	}
+	if ev.Schema != "staging" {
+		t.Errorf("expected schema 'staging' (excluded by filter, still emitted), got %q", ev.Schema)
+	}
+}
+
 // ─── RowsEvent filtering ──────────────────────────────────────────────────────
 
 // TestStreamParser_filteredRowsEvent verifies that a RowsEvent for a schema


### PR DESCRIPTION
closes #415

## Summary
- Adds a shared `dmlEvents` helper to `parser_integration_test.go` and switches all event-count assertions to DML-only (INSERT/UPDATE/DELETE).
- Root cause: under parallel `go test -tags integration ./...` runs, concurrent test packages' setup DDL (`CREATE TABLE index_state`, ...) lands in the shared container's binlog window, and DDL events bypass the schema filter by design — inflating counts in `TestParseFile_realBinlog`, `TestParseFiles_multiple`, and `TestParseFile_withFilters` (also exposed, same class).
- Assertions keep full strength: row events ARE schema-filtered and each test owns its schema, so DML counts are exact.
- `TestParseFile_compressedTransactions` refactored onto the same helper (its inline filtering predates this PR; no behavior change).
- Alternatives rejected per the issue: serializing packages (`-p 1`) punishes the whole suite; schema-filtering DDL emission changes production behavior for a test concern.

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] The 4-package combination that reproduced the flake on clean main (`parser+indexer+query+console`) passes 3/3 runs
- [x] Full parallel `go test -tags integration ./... -count=1` green (failed with 3 tests before this fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)