### PR TITLE
test(ci): validate MySQL 8.4 caching_sha2 auth seam; CI matrix 8.0 + 8.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,16 @@ jobs:
   integration:
     runs-on: ubuntu-22.04
 
+    # Two supported cells: the BYO contract floor (8.0) and the bundled index
+    # engine (8.4, where mysql_native_password is disabled by default so every
+    # connection authenticates with caching_sha2_password over the plaintext
+    # network). fail-fast: false so a regression on one version still reports
+    # the other. See TestCachingSha2ColdAuthSeam for the focused auth guard.
+    strategy:
+      fail-fast: false
+      matrix:
+        mysql: ["8.0", "8.4"]
+
     env:
       # Matches internal/testutil.DefaultDSN — set explicitly to mirror the
       # SaaS repo's `agent/` job and make the wiring obvious in logs.
@@ -51,12 +61,12 @@ jobs:
       # provide (service containers get auto-generated names and can't take
       # command-line args). This mirrors the local setup in CONTRIBUTING.md so
       # CI and developer machines run against an identical container.
-      - name: Start MySQL (bintrail-test-mysql)
+      - name: Start MySQL (bintrail-test-mysql, ${{ matrix.mysql }})
         run: |
           docker run -d --name bintrail-test-mysql \
             -e MYSQL_ROOT_PASSWORD=testroot \
             -p 13306:3306 \
-            mysql:8.0 \
+            mysql:${{ matrix.mysql }} \
             --binlog-format=ROW \
             --binlog-row-image=FULL \
             --log-bin=binlog \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,11 @@ jobs:
     # Two supported cells: the BYO contract floor (8.0) and the bundled index
     # engine (8.4, where mysql_native_password is disabled by default so every
     # connection authenticates with caching_sha2_password over the plaintext
-    # network). fail-fast: false so a regression on one version still reports
-    # the other. See TestCachingSha2ColdAuthSeam for the focused auth guard.
+    # network). Running the whole suite on 8.4 is what proves the native_password-
+    # OFF default doesn't break the up→stream→query→shim pipeline; the focused
+    # TestCachingSha2ColdAuthSeam additionally guards the cold full-auth path on
+    # both cells. fail-fast: false so a regression on one version still reports
+    # the other.
     strategy:
       fail-fast: false
       matrix:

--- a/cmd/bintrail/auth_seam_integration_test.go
+++ b/cmd/bintrail/auth_seam_integration_test.go
@@ -22,16 +22,23 @@ import (
 // connection bintrail makes — the index connection (go-sql-driver, via
 // config.Connect) AND the source replication handshake (go-mysql, via
 // BinlogSyncer) — authenticates with caching_sha2_password over a plaintext
-// network, which requires the server's public key on a cold cache (full
-// auth). The rest of the integration suite primes root's cache on its first
-// connection and thereafter exercises only fast auth, so it would NOT catch a
-// regression in the cold full-auth / public-key path. This test creates a
-// FRESH caching_sha2 user per path (DROP+CREATE guarantees a cold server-side
-// cache) and proves cold full-auth completes for both libraries.
+// network, which on a cold cache requires the server's public key (full auth).
 //
-// It is meaningful on both MySQL 8.0 (caching_sha2 is already the default
-// plugin) and 8.4 (where it is also the only enabled one), so it guards both
-// CI matrix cells.
+// Why a FRESH user per path: caching_sha2's cache is per-account, and a
+// never-authenticated account has NO fast-auth fallback — its first connect
+// must complete full auth via public-key retrieval or fail. So a successful
+// plaintext connect by a fresh user (DROP+CREATE = empty server-side cache)
+// necessarily exercised the cold full-auth / public-key path; there is no
+// other way for it to succeed. The rest of the integration suite mostly runs
+// over already-primed (fast-auth) connections, so it does not deterministically
+// guard the cold path the way this test does. Each path uses its own fresh user
+// so neither primes the other.
+//
+// It is meaningful on both MySQL 8.0 (caching_sha2 is the default plugin since
+// 8.0.4) and 8.4 (where it is also the only enabled one). It is deliberately
+// version-independent — it explicitly creates a caching_sha2 user, so it guards
+// the cold-auth code path on both cells; the matrix's whole-suite run on 8.4 is
+// what additionally proves the 8.4 native_password-OFF default doesn't break us.
 func TestCachingSha2ColdAuthSeam(t *testing.T) {
 	testutil.SkipIfNoMySQL(t)
 
@@ -101,8 +108,11 @@ func TestCachingSha2ColdAuthSeam(t *testing.T) {
 			t.Fatalf("parseSourceDSN: %v", err)
 		}
 
-		// Mirrors stream.go's BinlogSyncerConfig: no TLSConfig → plaintext, so
-		// go-mysql must complete caching_sha2 full auth via public-key retrieval.
+		// Omit TLSConfig (nil → plaintext) to force the caching_sha2 full-auth
+		// path. NOTE stream.go defaults to --ssl-mode=preferred (a NON-nil
+		// TLSConfig) and reaches plaintext only via its TLS fallback
+		// (stream.go ~1234) or --ssl-mode=disabled; this mirrors that plaintext
+		// path, where go-mysql must complete full auth via public-key retrieval.
 		syncer := replication.NewBinlogSyncer(replication.BinlogSyncerConfig{
 			ServerID: 99123,
 			Flavor:   "mysql",

--- a/cmd/bintrail/auth_seam_integration_test.go
+++ b/cmd/bintrail/auth_seam_integration_test.go
@@ -1,0 +1,130 @@
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	drivermysql "github.com/go-sql-driver/mysql"
+
+	gomysql "github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/go-mysql-org/go-mysql/replication"
+
+	"github.com/dbtrail/bintrail/internal/config"
+	"github.com/dbtrail/bintrail/internal/testutil"
+)
+
+// TestCachingSha2ColdAuthSeam codifies the MySQL 8.4 auth-seam verification
+// (#421): on 8.4 mysql_native_password is disabled by default, so every
+// connection bintrail makes — the index connection (go-sql-driver, via
+// config.Connect) AND the source replication handshake (go-mysql, via
+// BinlogSyncer) — authenticates with caching_sha2_password over a plaintext
+// network, which requires the server's public key on a cold cache (full
+// auth). The rest of the integration suite primes root's cache on its first
+// connection and thereafter exercises only fast auth, so it would NOT catch a
+// regression in the cold full-auth / public-key path. This test creates a
+// FRESH caching_sha2 user per path (DROP+CREATE guarantees a cold server-side
+// cache) and proves cold full-auth completes for both libraries.
+//
+// It is meaningful on both MySQL 8.0 (caching_sha2 is already the default
+// plugin) and 8.4 (where it is also the only enabled one), so it guards both
+// CI matrix cells.
+func TestCachingSha2ColdAuthSeam(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+
+	rootDB, err := config.Connect(testutil.BaseDSN() + "/")
+	if err != nil {
+		t.Fatalf("connect as root: %v", err)
+	}
+	defer rootDB.Close()
+
+	// The server address (host:port) the suite is pointed at; the fresh users
+	// connect to the same server with different credentials.
+	baseCfg, err := drivermysql.ParseDSN(testutil.BaseDSN() + "/")
+	if err != nil {
+		t.Fatalf("parse base DSN: %v", err)
+	}
+
+	// makeColdUser DROP+CREATEs a caching_sha2 user (cold server-side cache)
+	// with replication grants, and returns a plaintext DSN for it.
+	makeColdUser := func(t *testing.T, name string) string {
+		t.Helper()
+		const pass = "Sha2-Cold-Pw-123!"
+		testutil.MustExec(t, rootDB, "DROP USER IF EXISTS '"+name+"'@'%'")
+		testutil.MustExec(t, rootDB, "CREATE USER '"+name+"'@'%' IDENTIFIED WITH caching_sha2_password BY '"+pass+"'")
+		testutil.MustExec(t, rootDB, "GRANT REPLICATION SLAVE, REPLICATION CLIENT, SELECT ON *.* TO '"+name+"'@'%'")
+		t.Cleanup(func() { rootDB.Exec("DROP USER IF EXISTS '" + name + "'@'%'") })
+
+		var plugin string
+		if err := rootDB.QueryRow(
+			"SELECT plugin FROM mysql.user WHERE user = ? AND host = '%'", name).Scan(&plugin); err != nil {
+			t.Fatalf("read auth plugin for %s: %v", name, err)
+		}
+		if plugin != "caching_sha2_password" {
+			t.Fatalf("user %s has plugin %q, want caching_sha2_password", name, plugin)
+		}
+		return fmt.Sprintf("%s:%s@tcp(%s)/", name, pass, baseCfg.Addr)
+	}
+
+	// ── Index path: go-sql-driver via config.Connect, cold full-auth ─────────
+	t.Run("index connection (go-sql-driver)", func(t *testing.T) {
+		dsn := makeColdUser(t, "bt_authseam_idx")
+		db, err := config.Connect(dsn)
+		if err != nil {
+			t.Fatalf("config.Connect with cold caching_sha2 over plaintext failed "+
+				"(public-key retrieval for full auth is broken?): %v", err)
+		}
+		defer db.Close()
+		var one int
+		if err := db.QueryRow("SELECT 1").Scan(&one); err != nil || one != 1 {
+			t.Fatalf("SELECT 1 after auth: got %d, err %v", one, err)
+		}
+	})
+
+	// ── Replication path: go-mysql BinlogSyncer, cold full-auth ──────────────
+	t.Run("replication handshake (go-mysql)", func(t *testing.T) {
+		var logBin string
+		if err := rootDB.QueryRow("SELECT @@log_bin").Scan(&logBin); err != nil || logBin != "1" {
+			t.Skip("skipping: binary logging not enabled on test MySQL")
+		}
+		file, pos, err := config.CurrentBinlogPosition(rootDB)
+		if err != nil {
+			t.Skipf("skipping: cannot read binlog position: %v", err)
+		}
+
+		dsn := makeColdUser(t, "bt_authseam_repl")
+		host, port, user, password, err := parseSourceDSN(dsn)
+		if err != nil {
+			t.Fatalf("parseSourceDSN: %v", err)
+		}
+
+		// Mirrors stream.go's BinlogSyncerConfig: no TLSConfig → plaintext, so
+		// go-mysql must complete caching_sha2 full auth via public-key retrieval.
+		syncer := replication.NewBinlogSyncer(replication.BinlogSyncerConfig{
+			ServerID: 99123,
+			Flavor:   "mysql",
+			Host:     host,
+			Port:     port,
+			User:     user,
+			Password: password,
+		})
+		defer syncer.Close()
+
+		streamer, err := syncer.StartSync(gomysql.Position{Name: file, Pos: pos})
+		if err != nil {
+			t.Fatalf("BinlogSyncer.StartSync with cold caching_sha2 over plaintext failed "+
+				"(go-mysql public-key retrieval for full auth is broken?): %v", err)
+		}
+
+		// The handshake already succeeded; reading one event confirms a live
+		// stream. A quiet source times out, which is fine.
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if _, err := streamer.GetEvent(ctx); err != nil && err != context.DeadlineExceeded {
+			t.Fatalf("GetEvent after handshake: %v", err)
+		}
+	})
+}

--- a/docs/time-travel-sql.md
+++ b/docs/time-travel-sql.md
@@ -179,7 +179,9 @@ The unit reads `BINTRAIL_INDEX_DSN` from `/etc/bintrail/.bintrail.env` (the same
 ExecStart=/usr/local/bin/bintrail shim --shim-config /etc/bintrail/shim.yaml --auth-method=caching_sha2_password
 ```
 
-Requires ProxySQL **2.7+** between the application and the shim — the LTS 2.6 line isn't verified to negotiate SHA2 against backends, so operators on 2.6 keep the default (`mysql_native_password`). The application user used by ProxySQL must match the chosen scheme: `IDENTIFIED WITH mysql_native_password BY '<password>'` for the default path, `IDENTIFIED WITH caching_sha2_password BY '<password>'` for the opt-in. `sha256_password` is also accepted by `--auth-method` if your environment requires it.
+Requires ProxySQL **2.7+** between the application and the shim — the LTS 2.6 line isn't verified to negotiate SHA2 against backends, so operators on 2.6 keep the default (`mysql_native_password`). The application user used by ProxySQL must match the chosen scheme: `IDENTIFIED WITH mysql_native_password BY '<password>'` for the default path, `IDENTIFIED WITH caching_sha2_password BY '<password>'` for the opt-in. `sha256_password` is also accepted by `--auth-method` if your environment requires it. The same 2.7+ requirement applies when ProxySQL fronts an **8.4 source** directly (its `caching_sha2_password` backend), set via `proxysql-config --backend-auth-plugin caching_sha2_password`.
+
+> **bintrail's own connections to MySQL 8.4 need no auth flag.** The ProxySQL requirement above is only about ProxySQL negotiating `caching_sha2_password` to a backend. bintrail's *index* connection (`--index-dsn`, go-sql-driver) and its *source replication* handshake (`bintrail stream`/`up`, go-mysql) both complete `caching_sha2_password` over a plaintext network on their own — the driver retrieves the server's public key for cold-cache full auth, with no flag, no TLS, and no ProxySQL in the path. This is what the bundled MySQL 8.4 index uses by default; CI exercises it against both 8.0 and 8.4.
 
 Enable and start:
 


### PR DESCRIPTION
closes #421

Part of epic #417 (release gate item — validate the 8.4 auth seam end-to-end).

## Summary
MySQL 8.4 disables `mysql_native_password` by default, so every connection bintrail makes to an 8.4 server authenticates with `caching_sha2_password` over the plaintext Docker network — cold-cache full auth that needs the server's public key. **Two different libraries** are involved, and both were verified against a real `mysql:8.4.9`:
- the **index** connection (go-sql-driver via `config.Connect`), and
- the **source replication** handshake (go-mysql via `BinlogSyncer`) — a path no prior test covered.

Both complete the handshake with **no flag, no TLS, no config change** (the drivers auto-retrieve the public key). **No production code changed.**

- **CI matrix**: the `integration` job now runs over `mysql: {8.0, 8.4}` — 8.0 is the BYO contract floor, 8.4 the bundled index engine. `fail-fast: false` so a regression on one version still reports the other. The whole suite (including the live `up→stream→query→shim` paths) runs against both cells.
- **`TestCachingSha2ColdAuthSeam`** (integration): a focused regression guard for the **cold full-auth** path the rest of the suite misses — the suite primes root's cache on its first connect and thereafter only exercises *fast* auth. It DROP+CREATEs a fresh `caching_sha2_password` user per path (guaranteeing a cold server-side cache) and asserts both `config.Connect` and `BinlogSyncer.StartSync` complete over plaintext. Meaningful on 8.0 and 8.4, so it guards both cells.
- **docs/time-travel-sql.md**: clarify that bintrail's own 8.4 connections need no auth flag — the ProxySQL **2.7+** requirement applies only when ProxySQL fronts a `caching_sha2_password` *backend* (an 8.4 source via `--backend-auth-plugin`, or the shim via `--auth-method`).

## Verification
- The two auth handshakes were proven empirically against a real `mysql:8.4.9` container before writing (go-sql-driver index path; go-mysql replication `StartSync` reading a live `RotateEvent`).
- `TestCachingSha2ColdAuthSeam` runs green against **both** a real 8.0 (13306) and a real 8.4 (13385); the full `cmd/bintrail` integration package is green on 8.0 (don't-break check); `internal/config` + `internal/shim` green on 8.4.
- The CI matrix is the comprehensive prover — **watching both cells go green** (not asserting it as fact pre-merge).

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] `TestCachingSha2ColdAuthSeam` green on real 8.0 and 8.4
- [ ] CI matrix: both `integration (8.0)` and `integration (8.4)` cells green

🤖 Generated with [Claude Code](https://claude.com/claude-code)