### PR TITLE
feat(console): redesign web UI — sidebar shell, Overview, smart search, ⌘K

### DIFF
--- a/docs/console.md
+++ b/docs/console.md
@@ -50,27 +50,37 @@ With an S3 baseline (`--baseline-s3`), the `up` process reads S3 at request
 time using the ambient AWS credential chain — same as the standalone console,
 but note `up` didn't need AWS credentials before.
 
-Open that URL in a browser. Four tabs (Time-travel appears only when a baseline
-is configured), plus a **server switcher** in the header (see
-[Managing servers](#managing-servers)):
+Open that URL in a browser. A left **sidebar** groups the views (Time-travel
+appears only when a baseline is configured), with a **server switcher** at the
+top (see [Managing servers](#managing-servers)) and a **⌘K command palette**
+(also reachable from the "Search & commands" button) for jumping between views
+and searching events:
 
-1. **Recover** (landing) — filter schema / table / PK / time, preview the
-   affected rows with before→after diffs, then **Generate undo SQL** and
-   copy/download the script.
-2. **Events** — broader filters (event type, changed column, GTID, limit).
-   Results carry **Download JSON / Download CSV** buttons (also on the Recover
-   preview). Export is client-side over the rows already on screen, so it stays
-   within the result caps and — like the on-screen rows — never includes
-   `connection_id`.
-3. **Status** — index health: partitions, coverage, stream lag, archives.
-4. **Time-travel** — single-row point-in-time reconstruct. Appears **only when a
-   baseline is configured** (`--baseline-dir`/`--baseline-s3`); otherwise the tab
-   is hidden, never shown empty. See [Time-travel](#time-travel-reconstruct).
+1. **Overview** (landing) — what changed recently and where: headline counts
+   (changes indexed, deletes, tables touched, most recent change), a **Recent
+   changes** list (each row opens Events, with an inline **Undo**), and an
+   **Activity by table** breakdown. The starting point for "what happened?".
+2. **Events** — a smart search box (free text plus `type:`, `pk:`, `col:`, and
+   `schema.table` tokens) with an expandable **Filters** panel. Each row expands
+   in place to a before→after diff; `j`/`k` move the cursor, `↵` expands, `u`
+   jumps to Recover. Results carry **JSON / CSV** export — client-side over the
+   rows already on screen, so it stays within the result caps and — like the
+   on-screen rows — never includes `connection_id`.
+3. **Time-travel** — single-row point-in-time reconstruct, drawn as a timeline
+   (baseline snapshot → each change, with a **Restore to this state** jump to
+   Recover). Appears **only when a baseline is configured**
+   (`--baseline-dir`/`--baseline-s3`); otherwise it is hidden, never shown
+   empty. See [Time-travel](#time-travel-reconstruct).
+4. **Recover** — filter schema / table / PK / time, preview the affected rows
+   with before→after diffs, then **Generate undo SQL** and copy/download the
+   script. Arriving via an **Undo** action scopes it to that row and shows a
+   context banner. **Nothing is ever executed.**
+5. **Status** — index health: partitions, coverage, stream lag, archives.
 
 ## Managing servers
 
 The header has a server switcher and a **Servers** button: add, edit, and
-remove named connections to bintrail index databases, and switch every tab
+remove named connections to bintrail index databases, and switch every view
 between them. The registry is a **local YAML file on the console host**
 (`~/.config/bintrail/console-servers.yaml` by default, override with
 `--servers-file` / `BINTRAIL_CONSOLE_SERVERS`) — adding a server registers a
@@ -92,7 +102,7 @@ How it behaves:
   `X-Bintrail-Server` header on each request — there is no server-side "active
   server" — so two browser tabs can watch two different servers.
 - **Per-server Time-travel.** The reconstruct gate (baseline configured, no
-  RBAC profile, archives enabled) is evaluated per server; the Time-travel tab
+  RBAC profile, archives enabled) is evaluated per server; the Time-travel view
   appears and disappears as you switch.
 - **Test connection.** Each server (saved or being typed) has a write-free
   probe: ping, MySQL version, latency, whether the database looks like a

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -13,7 +13,9 @@
 //  3. Every async render captures `serverGen` before its await and bails if a
 //     server switch happened mid-flight (no cross-server repaint).
 //  4. Capability gating toggles the `.cap-on` class on [data-capability] nodes.
-//  5. Exports stay connection_id-free (EVENT_CSV_COLUMNS) — the open-core line.
+//  5. Exports stay connection_id-free: CSV via the EVENT_CSV_COLUMNS allowlist;
+//     JSON only because the server's eventDTO omits connection_id (it serializes
+//     rows as-is). The open-core line is enforced server-side — don't add it.
 //  6. The DOM is built with el()/textContent only — no innerHTML anywhere. The
 //     one string→DOM path is svgEl(), which DOMParses STATIC icon constants
 //     (never data) into SVG nodes. No value from the API touches markup.
@@ -147,7 +149,18 @@ async function api(path, opts = {}) {
   });
   const text = await res.text();
   let data = null;
-  try { data = text ? JSON.parse(text) : null; } catch (_) { data = { error: text }; }
+  if (text) {
+    try {
+      data = JSON.parse(text);
+    } catch (_) {
+      // A non-JSON body is the server's error text on a non-OK response, or a
+      // server malfunction on an OK one — surface it; never let a stray HTML
+      // error page render as an empty success. (An EMPTY body stays null: the
+      // 204 from DELETE /api/servers/{id} is a legitimate no-content success.)
+      if (!res.ok) throw new Error(text || "HTTP " + res.status);
+      throw new Error("malformed response from " + path);
+    }
+  }
   if (!res.ok) throw new Error((data && data.error) || "HTTP " + res.status);
   return data;
 }
@@ -236,23 +249,28 @@ function setActiveNav(route) {
 async function renderOverview() {
   const gen = serverGen;
   viewLoading();
-  let status = null, eventsData = null;
   try {
-    [status, eventsData] = await Promise.all([
+    const [status, eventsData] = await Promise.all([
       api("/api/status").catch(() => null),
       api("/api/events?limit=200&order=DESC"),
     ]);
+    if (gen !== serverGen) return;
+    buildOverview(status, eventsData); // render INSIDE the try: a throw here shows an error, never a stuck "Loading…"
   } catch (err) {
     if (gen !== serverGen) return;
     const v = VIEW(); clear(v); v.append(pageHead("Overview", null)); renderError(v, err);
-    return;
   }
-  if (gen !== serverGen) return;
+}
+
+// buildOverview renders the dashboard from the two fetched payloads. status may
+// be null (its fetch is best-effort); when it is, we do NOT claim a global
+// total — `events` is only the fetched window (limit 200), never the index size.
+function buildOverview(status, eventsData) {
   if (status) updateSideMeta(status);
 
-  const events = eventsData.events || [];
+  const events = (eventsData && eventsData.events) || [];
   const cov = (status && status.coverage) || {};
-  const total = (status && status.total_events_estimate) || cov.total_events || events.length;
+  const total = status ? (status.total_events_estimate || cov.total_events || "—") : "—";
   const deletes = events.filter((e) => e.event_type === "DELETE").length;
 
   // Aggregate the fetched window by table.
@@ -694,6 +712,7 @@ function renderRecover(params) {
 // loads its tables and runs cb. Lets the undo-bridge prefill survive the async
 // schema fetch without racing it.
 function setSelectWhenReady(form, name, value, cb) {
+  const gen = serverGen;
   const sel = form.elements[name];
   const tryset = () => {
     if (Array.from(sel.options).some((o) => o.value === value)) {
@@ -705,7 +724,12 @@ function setSelectWhenReady(form, name, value, cb) {
   };
   if (tryset()) return;
   let n = 0;
-  const iv = setInterval(() => { if (tryset() || ++n > 40) clearInterval(iv); }, 50);
+  const iv = setInterval(() => {
+    // Bail if the operator switched servers or navigated away — otherwise a
+    // late tick would auto-generate undo SQL against a detached/other form.
+    if (gen !== serverGen || !document.contains(form)) { clearInterval(iv); return; }
+    if (tryset() || ++n > 40) clearInterval(iv);
+  }, 50);
 }
 
 async function previewRecover(form) {
@@ -990,9 +1014,14 @@ function updateSideMeta(status) {
 
 async function loadSchemas() {
   if (schemaCache) return schemaCache;
+  const gen = serverGen;
   const data = await api("/api/schemas");
-  schemaCache = data.schemas || [];
-  return schemaCache;
+  const schemas = data.schemas || [];
+  // Guard the cache WRITE, not just the render: a response in flight when the
+  // operator switches servers must not poison the freshly-cleared cache with
+  // the previous server's schemas.
+  if (gen === serverGen) schemaCache = schemas;
+  return schemas;
 }
 
 async function populateSchemas(root) {
@@ -1027,7 +1056,11 @@ async function loadTables(form) {
   if (!schema) return;
   let tables = tablesCache.get(schema);
   try {
-    if (!tables) { const data = await api("/api/schemas?schema=" + encodeURIComponent(schema)); tables = data.tables || []; tablesCache.set(schema, tables); }
+    if (!tables) {
+      const data = await api("/api/schemas?schema=" + encodeURIComponent(schema));
+      tables = data.tables || [];
+      if (gen === serverGen) tablesCache.set(schema, tables); // don't cache under a server we've since switched away from
+    }
   } catch (err) {
     if (gen !== serverGen) return;
     tsel.append(opt("", "(error loading tables)"));
@@ -1296,6 +1329,7 @@ async function saveServer(form) {
     if (res && res.started && !doctorWarnings(res.doctor)) { hideServerForm(); toast("Monitoring started — events will appear within a minute"); }
     else if (res && res.started) { renderDoctor(res.doctor); formMsg("monitoring started — review the warnings below", false); }
     else if (res) { renderDoctor(res.doctor); formMsg("preflight failed — fix the items below and Save again", true); }
+    else { formMsg("could not start monitoring — see the error toast and try again", true); } // startMonitor returned null (transport error)
     return;
   }
   hideServerForm();
@@ -1497,7 +1531,10 @@ async function init() {
 
   // Startup order is load-bearing: servers (reconcile selection) → caps → route.
   let servers = [];
-  try { servers = await loadServers(); } catch (err) { renderError(VIEW(), err); }
+  // renderRoute() below clears #view, so an in-view error here would be wiped;
+  // toast it instead. If the backend is down, the chosen view surfaces its own
+  // error when its fetch fails.
+  try { servers = await loadServers(); } catch (err) { toast("couldn't load servers: " + ((err && err.message) || err)); }
   await gateCapabilities();
   renderRoute();
 

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -1,53 +1,101 @@
+// bintrail console — vanilla-JS SPA over the read-only JSON API.
+//
+// No frameworks, no bundler, no third-party code (see assets/VENDOR.md). The
+// design system lives in style.css; this file renders the sidebar-shell UI into
+// #view, talks to /api/* with a bearer token, and selects a server per-request
+// via the X-Bintrail-Server header.
+//
+// Security invariants kept from the prior frontend (do not regress):
+//  1. The token comes from ?token= on first load, is stashed in sessionStorage,
+//     and is stripped from the URL — it never lingers in the address bar.
+//  2. The X-Bintrail-Server header is captured INSIDE api() at dispatch time, so
+//     an in-flight request keeps the server it was fired for.
+//  3. Every async render captures `serverGen` before its await and bails if a
+//     server switch happened mid-flight (no cross-server repaint).
+//  4. Capability gating toggles the `.cap-on` class on [data-capability] nodes.
+//  5. Exports stay connection_id-free (EVENT_CSV_COLUMNS) — the open-core line.
+//  6. The DOM is built with el()/textContent only — no innerHTML anywhere. The
+//     one string→DOM path is svgEl(), which DOMParses STATIC icon constants
+//     (never data) into SVG nodes. No value from the API touches markup.
 "use strict";
 
-// ── token bootstrap ────────────────────────────────────────────────────────
-// The page itself loads without a token; the API requires one. We read it from
-// the ?token= query param the CLI prints, persist it in sessionStorage, and
-// strip it from the visible URL so it isn't left sitting in the address bar /
-// history. On a reload the param is gone, so we recover the token from
-// sessionStorage — otherwise a refresh would drop it and every request would
-// 401. sessionStorage is per-tab and cleared when the tab closes.
+// ── constants ──────────────────────────────────────────────────────────────
+
 const TOKEN_KEY = "bintrail_console_token";
-let TOKEN = new URLSearchParams(location.search).get("token") || "";
-if (TOKEN) {
-  try { sessionStorage.setItem(TOKEN_KEY, TOKEN); } catch (e) { /* storage unavailable */ }
-  history.replaceState(null, "", location.pathname);
-} else {
-  try { TOKEN = sessionStorage.getItem(TOKEN_KEY) || ""; } catch (e) { TOKEN = ""; }
-}
-
-let lastSQL = "";
-
-// ── server selection ─────────────────────────────────────────────────────────
-// currentServer is the id of the server every API call targets, sent as the
-// X-Bintrail-Server header (captured at dispatch time inside api(), so an
-// in-flight request keeps the server it was fired for even if the operator
-// switches mid-flight). Empty = the backend's default (the --index-dsn entry,
-// else the first saved server). Persisted per-tab like the token, so two tabs
-// can watch two different servers.
 const SERVER_KEY = "bintrail_console_server";
-let currentServer = "";
-try { currentServer = sessionStorage.getItem(SERVER_KEY) || ""; } catch (e) { /* storage unavailable */ }
+const ONBOARD_KEY = "bintrail_console_onboarded";
+
+// Export columns. connection_id is DELIBERATELY ABSENT — it is paid-forensics
+// data and the console (query_explorer surface) never exposes it.
+const EVENT_CSV_COLUMNS = [
+  "event_id", "event_timestamp", "schema_name", "table_name", "event_type",
+  "pk_values", "changed_columns", "gtid", "binlog_file", "start_pos", "end_pos",
+  "row_before", "row_after",
+];
+
+// event_type → badge modifier class.
+const BADGE_CLASS = { UPDATE: "b-update", INSERT: "b-insert", DELETE: "b-delete" };
+function badgeClass(t) { return BADGE_CLASS[t] || "b-baseline"; }
+
+const ROUTES = ["overview", "events", "timetravel", "recover", "status"];
+
+const MON_STATE_TITLES = {
+  failed: "stream failing — retrying with backoff; press Start for details",
+  stalled: "stream is connected but has made no progress for several minutes",
+  lost_position: "binlogs were purged past the saved position — events in the gap are permanently lost; current changes are still streaming",
+};
+
+// Static decorative SVGs (module constants — parsed by svgEl via DOMParser).
+const ICONS = {
+  search: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round"><circle cx="11" cy="11" r="7"></circle><path d="M21 21l-4.3-4.3"></path></svg>`,
+  caret: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6l6 6-6 6"></path></svg>`,
+  file: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" style="width:16px;height:16px"><path d="M14 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8z"></path><path d="M14 3v5h5"></path></svg>`,
+  warn: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" style="width:15px;height:15px"><path d="M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z"/><path d="M12 9v4M12 17h.01"/></svg>`,
+};
+
+// ── module state ─────────────────────────────────────────────────────────────
+
+let TOKEN = "";
+let currentServer = "";       // X-Bintrail-Server target ("" = backend default)
 let defaultServerId = "";
+let serverGen = 0;            // bumped on every server switch (staleness guard)
+let capsCache = {};           // last /api/capabilities for the selected server
+let lastSQL = "";             // last generated undo SQL (for copy/download)
+let lastEvents = [];          // last rendered (filtered, capped) event page
+let pendingRecover = null;    // event context carried into Recover via "Undo"
+let schemaCache = null;       // cached schema list for the selected server
+const tablesCache = new Map();// schema → tables[]
+let cursorIdx = -1;           // keyboard cursor row on Events
+
+// ── token bootstrap ────────────────────────────────────────────────────────
+
+(function bootstrapToken() {
+  try {
+    const urlToken = new URLSearchParams(location.search).get("token");
+    if (urlToken) {
+      sessionStorage.setItem(TOKEN_KEY, urlToken);
+      // Strip the token from the URL so it never sits in the address bar/history.
+      history.replaceState(null, "", location.pathname);
+      TOKEN = urlToken;
+    } else {
+      TOKEN = sessionStorage.getItem(TOKEN_KEY) || "";
+    }
+    currentServer = sessionStorage.getItem(SERVER_KEY) || "";
+  } catch (_) { /* storage may be unavailable; degrade to in-memory */ }
+})();
 
 function setCurrentServer(id) {
   currentServer = id || "";
-  try { sessionStorage.setItem(SERVER_KEY, currentServer); } catch (e) { /* storage unavailable */ }
+  try { sessionStorage.setItem(SERVER_KEY, currentServer); } catch (_) {}
 }
 
-// serverGen invalidates in-flight renders across server switches. api()
-// captures the header at dispatch, so a slow request keeps QUERYING the right
-// server — but its response must not repaint a panel that now shows another
-// server. Handlers snapshot the generation before awaiting and drop the render
-// when a switch happened underneath them.
-let serverGen = 0;
+// ── tiny DOM helpers (no data ever assigned as HTML) ─────────────────────────
 
-// ── tiny DOM helper (builds nodes; never injects data as HTML) ───────────────
 function el(tag, attrs, ...kids) {
   const n = document.createElement(tag);
   if (attrs) {
     for (const [k, v] of Object.entries(attrs)) {
-      if (v === null || v === undefined) continue;
+      if (v == null || v === false) continue;
       if (k === "class") n.className = v;
       else if (k === "text") n.textContent = v;
       else if (k.startsWith("on")) n.addEventListener(k.slice(2), v);
@@ -55,22 +103,27 @@ function el(tag, attrs, ...kids) {
     }
   }
   for (const kid of kids) {
-    if (kid === null || kid === undefined) continue;
-    n.appendChild(typeof kid === "string" ? document.createTextNode(kid) : kid);
+    if (kid == null) continue;
+    n.append(kid.nodeType ? kid : document.createTextNode(String(kid)));
   }
   return n;
 }
-
-function opt(value, label) {
-  const o = el("option", { value });
-  o.textContent = label;
-  return o;
+function opt(value, label) { const o = el("option", { value }); o.textContent = label; return o; }
+function clear(n) { if (n) n.replaceChildren(); }
+function $(sel, root = document) { return root.querySelector(sel); }
+function $all(sel, root = document) { return Array.from(root.querySelectorAll(sel)); }
+// svgEl parses a STATIC, trusted SVG constant into a detached SVG node. It is
+// NOT an innerHTML sink: image/svg+xml parsing never executes script, and the
+// argument is always a module constant — never server or user data.
+function svgEl(s) {
+  const doc = new DOMParser().parseFromString(s, "image/svg+xml");
+  return document.importNode(doc.documentElement, true);
 }
-
-// clear removes all children of a node. Used instead of innerHTML="" so no
-// markup is ever assigned from a string.
-function clear(n) {
-  n.replaceChildren();
+// icon(name) → a <span> wrapping the named static SVG.
+function icon(name, cls) {
+  const span = el("span", { class: cls || "" });
+  if (ICONS[name]) span.append(svgEl(ICONS[name]));
+  return span;
 }
 
 function valueToString(v) {
@@ -79,18 +132,13 @@ function valueToString(v) {
   return String(v);
 }
 
-function toast(msg) {
-  const t = document.getElementById("toast");
-  t.textContent = msg;
-  t.hidden = false;
-  clearTimeout(toast._t);
-  toast._t = setTimeout(() => { t.hidden = true; }, 2000);
-}
+const VIEW = () => document.getElementById("view");
 
-// ── API wrapper ──────────────────────────────────────────────────────────────
+// ── api ──────────────────────────────────────────────────────────────────────
+
 async function api(path, opts = {}) {
   const headers = { Authorization: "Bearer " + TOKEN };
-  if (currentServer) headers["X-Bintrail-Server"] = currentServer;
+  if (currentServer) headers["X-Bintrail-Server"] = currentServer; // captured at dispatch
   if (opts.body) headers["Content-Type"] = "application/json";
   const res = await fetch(path, {
     method: opts.method || "GET",
@@ -99,841 +147,1369 @@ async function api(path, opts = {}) {
   });
   const text = await res.text();
   let data = null;
-  if (text) {
-    try { data = JSON.parse(text); } catch { data = { error: text }; }
-  }
-  if (!res.ok) {
-    throw new Error((data && data.error) || "HTTP " + res.status);
-  }
+  try { data = text ? JSON.parse(text) : null; } catch (_) { data = { error: text }; }
+  if (!res.ok) throw new Error((data && data.error) || "HTTP " + res.status);
   return data;
 }
 
-// ── shared rendering ─────────────────────────────────────────────────────────
+// ── toast / errors / warnings ─────────────────────────────────────────────────
+
+function toast(msg) {
+  const t = document.getElementById("toast");
+  if (!t) return;
+  t.textContent = msg;
+  t.hidden = false;
+  clearTimeout(toast._t);
+  toast._t = setTimeout(() => { t.hidden = true; }, 2200);
+}
+
 function renderError(container, err) {
+  if (!container) return;
   clear(container);
-  container.appendChild(el("div", { class: "error-box" }, String(err.message || err)));
+  container.append(el("div", { class: "error-box", text: String((err && err.message) || err) }));
 }
 
 function renderWarnings(node, warnings) {
+  if (!node) return;
   clear(node);
-  (warnings || []).forEach((w) => node.appendChild(el("div", { class: "warn-item" }, w)));
+  (warnings || []).forEach((w) => node.append(
+    el("div", { class: "warn-item" }, icon("warn"), el("span", { text: w }))
+  ));
 }
 
-function formParams(form) {
-  const out = {};
-  for (const [k, v] of new FormData(form).entries()) {
-    if (String(v).trim() !== "") out[k] = v;
+// ── badge / page-head builders ────────────────────────────────────────────────
+
+function badge(type) { return el("span", { class: "badge " + badgeClass(type), text: type }); }
+
+function pageHead(title, subNode) {
+  const head = el("div", { class: "page-head" }, el("h1", { class: "page-title", text: title }));
+  if (subNode) head.append(subNode);
+  return head;
+}
+
+function viewLoading() {
+  const v = VIEW();
+  clear(v);
+  v.append(el("div", { class: "view-loading", text: "Loading…" }));
+  v.classList.remove("view-enter");
+}
+function viewEnter() { const v = VIEW(); v.classList.remove("view-enter"); void v.offsetWidth; v.classList.add("view-enter"); }
+
+// ── router ─────────────────────────────────────────────────────────────────
+
+function routeFromLocation() {
+  const path = location.pathname.replace(/^\//, "").split("/")[0] || "overview";
+  return ROUTES.includes(path) ? path : "overview";
+}
+
+function navigate(route, params, push = true) {
+  if (!ROUTES.includes(route)) route = "overview";
+  // Reconstruct surface is gated; never navigate to a disabled Time-travel.
+  if (route === "timetravel" && !capsCache.reconstruct) route = "overview";
+  const qs = params && Object.keys(params).length
+    ? "?" + new URLSearchParams(params).toString() : "";
+  if (push) history.pushState({ route }, "", "/" + route + qs);
+  renderRoute();
+}
+
+function renderRoute() {
+  const route = routeFromLocation();
+  setActiveNav(route);
+  cursorIdx = -1;
+  const params = Object.fromEntries(new URLSearchParams(location.search));
+  switch (route) {
+    case "overview": return renderOverview();
+    case "events": return renderEvents(params);
+    case "timetravel": return renderTimetravel(params);
+    case "recover": return renderRecover(params);
+    case "status": return renderStatus();
+    default: return renderOverview();
   }
+}
+
+function setActiveNav(route) {
+  $all(".nav-item").forEach((a) => a.classList.toggle("active", a.dataset.route === route));
+}
+
+// ── Overview ─────────────────────────────────────────────────────────────────
+
+async function renderOverview() {
+  const gen = serverGen;
+  viewLoading();
+  let status = null, eventsData = null;
+  try {
+    [status, eventsData] = await Promise.all([
+      api("/api/status").catch(() => null),
+      api("/api/events?limit=200&order=DESC"),
+    ]);
+  } catch (err) {
+    if (gen !== serverGen) return;
+    const v = VIEW(); clear(v); v.append(pageHead("Overview", null)); renderError(v, err);
+    return;
+  }
+  if (gen !== serverGen) return;
+  if (status) updateSideMeta(status);
+
+  const events = eventsData.events || [];
+  const cov = (status && status.coverage) || {};
+  const total = (status && status.total_events_estimate) || cov.total_events || events.length;
+  const deletes = events.filter((e) => e.event_type === "DELETE").length;
+
+  // Aggregate the fetched window by table.
+  const byTable = new Map();
+  for (const e of events) {
+    const k = e.schema_name + "." + e.table_name;
+    let s = byTable.get(k);
+    if (!s) { s = { key: k, insert: 0, update: 0, delete: 0, total: 0 }; byTable.set(k, s); }
+    s.total++;
+    if (e.event_type === "INSERT") s.insert++;
+    else if (e.event_type === "UPDATE") s.update++;
+    else if (e.event_type === "DELETE") s.delete++;
+  }
+  const tables = Array.from(byTable.values()).sort((a, b) => b.total - a.total);
+  const latest = cov.latest_event || (events[0] && events[0].event_timestamp) || "—";
+  const earliest = cov.earliest_event || (events.length ? events[events.length - 1].event_timestamp : "—");
+
+  const v = VIEW(); clear(v);
+
+  const sub = el("p", { class: "page-sub" },
+    "What changed recently, and where — your starting point. ",
+    el("b", { text: deletes + " delete(s)" }),
+    " in the latest window: the ones worth a look first.");
+  v.append(pageHead("Overview", sub));
+
+  // stats
+  const stats = el("div", { class: "ov-stats" });
+  stats.append(ovStat(String(total), "changes indexed"));
+  stats.append(ovStat(String(deletes), "deletes", deletes > 0 ? "danger" : ""));
+  stats.append(ovStat(String(tables.length), "tables touched"));
+  const wide = el("div", { class: "ov-stat" },
+    el("div", { class: "ov-stat-v small", text: latest }),
+    el("div", { class: "ov-stat-k", text: "most recent change" }));
+  stats.append(wide);
+  v.append(stats);
+
+  // grid
+  const grid = el("div", { class: "ov-grid" });
+
+  // recent changes
+  const recentPanel = el("section", { class: "ov-panel" });
+  const rHead = el("div", { class: "ov-panel-head" },
+    el("h2", { class: "ov-panel-title", text: "Recent changes" }),
+    el("a", { class: "btn btn-sm btn-ghost", href: "/events",
+      onclick: (e) => { e.preventDefault(); navigate("events"); }, text: "Browse all events ›" }));
+  recentPanel.append(rHead);
+  const evlist = el("div", { class: "ov-evlist" });
+  if (!events.length) {
+    evlist.append(el("div", { class: "ev-empty", text: "No changes indexed yet." }));
+  } else {
+    events.slice(0, 8).forEach((e) => evlist.append(ovEventRow(e)));
+  }
+  recentPanel.append(evlist);
+  grid.append(recentPanel);
+
+  // activity by table
+  const tablesPanel = el("section", { class: "ov-panel" });
+  tablesPanel.append(el("div", { class: "ov-panel-head" },
+    el("h2", { class: "ov-panel-title", text: "Activity by table" })));
+  const tbox = el("div", { class: "ov-tables" });
+  tables.slice(0, 12).forEach((s) => tbox.append(ovTableRow(s)));
+  tablesPanel.append(tbox);
+  tablesPanel.append(el("div", { class: "ov-coverage" },
+    el("span", { text: "coverage" }), " ",
+    el("b", { text: earliest }), " → ", el("b", { text: latest })));
+  grid.append(tablesPanel);
+
+  v.append(grid);
+  viewEnter();
+}
+
+function ovStat(value, key, mod) {
+  return el("div", { class: "ov-stat" },
+    el("div", { class: "ov-stat-v" + (mod ? " " + mod : ""), text: value }),
+    el("div", { class: "ov-stat-k", text: key }));
+}
+
+function colsSummary(cols, highlight) {
+  cols = cols || [];
+  if (cols.length > 2) return [el("span", { text: cols.length + " cols" })];
+  const out = [];
+  cols.forEach((c, i) => {
+    if (i) out.push(document.createTextNode(", "));
+    out.push(highlight ? el("span", { class: "hl", text: c }) : el("span", { text: c }));
+  });
   return out;
+}
+
+function ovEventRow(e) {
+  const row = el("div", { class: "ov-ev",
+    onclick: () => navigate("events", { q: "pk:" + e.pk_values }) });
+  row.append(el("span", { class: "ov-ev-time", text: e.event_timestamp }));
+  row.append(badge(e.event_type));
+  const tbl = el("span", { class: "ov-ev-tbl", text: e.schema_name + "." + e.table_name + " " });
+  tbl.append(el("span", { class: "ov-ev-pk", text: "#" + e.pk_values }));
+  row.append(tbl);
+  row.append(el("span", { class: "ov-ev-cols" }, ...colsSummary(e.changed_columns, false)));
+  const undo = el("a", { class: "btn btn-sm ov-ev-undo", text: "Undo",
+    onclick: (ev) => { ev.stopPropagation(); undoEvent(e); } });
+  row.append(undo);
+  return row;
+}
+
+function ovTableRow(s) {
+  const row = el("a", { class: "ov-tablerow",
+    onclick: () => navigate("events", { q: s.key }) });
+  row.append(el("span", { class: "ov-tname", text: s.key }));
+  const bar = el("span", { class: "ov-bar" });
+  if (s.insert) bar.append(el("span", { class: "ov-seg i", style: "flex:" + s.insert }));
+  if (s.update) bar.append(el("span", { class: "ov-seg u", style: "flex:" + s.update }));
+  if (s.delete) bar.append(el("span", { class: "ov-seg d", style: "flex:" + s.delete }));
+  row.append(bar);
+  row.append(el("span", { class: "ov-total", text: String(s.total) }));
+  return row;
+}
+
+// ── Events ─────────────────────────────────────────────────────────────────
+
+function renderEvents(params) {
+  const v = VIEW(); clear(v);
+  v.append(pageHead("Events", el("p", { class: "page-sub", text: "Browse indexed row events with full before / after images." })));
+
+  const form = el("form", { id: "ev-form" });
+  // search bar
+  const searchwrap = el("div", { class: "ev-searchwrap" });
+  searchwrap.append(icon("search", "ev-search-ic"));
+  const search = el("input", { class: "ev-search", id: "ev-search", name: "q",
+    autocomplete: "off", spellcheck: "false",
+    placeholder: 'Search changes — try "orders", "type:delete", "pk:1006", "col:email"' });
+  if (params && params.q) search.value = params.q;
+  searchwrap.append(search);
+  const advBtn = el("button", { class: "ev-advbtn", type: "button", text: "Filters",
+    onclick: () => { const a = $("#ev-advanced", VIEW()); a.toggleAttribute("hidden"); advBtn.classList.toggle("on"); } });
+  searchwrap.append(advBtn);
+  form.append(searchwrap);
+
+  // advanced panel
+  const adv = el("div", { class: "ev-advanced", id: "ev-advanced", hidden: "" });
+  adv.append(fieldSelect("Schema", "schema", "md", true));
+  adv.append(fieldSelect("Table", "table", "md", false, true));
+  adv.append(fieldInput("PK", "pk", "sm", "1006"));
+  adv.append(fieldSelect("Type", "event_type", "sm", false, false, ["", "INSERT", "UPDATE", "DELETE"], "any"));
+  adv.append(fieldInput("Changed column", "changed_column", "md", "email"));
+  adv.append(fieldInput("Since", "since", "md", "YYYY-MM-DD HH:MM"));
+  adv.append(fieldInput("Until", "until", "md", "YYYY-MM-DD HH:MM"));
+  adv.append(fieldInput("Limit", "limit", "sm", "100"));
+  form.append(adv);
+  v.append(form);
+
+  // result bar
+  const bar = el("div", { class: "result-bar" });
+  bar.append(el("span", { class: "result-count" }, el("b", { id: "ev-count", text: "…" }), " event(s)"));
+  bar.append(el("span", { class: "spacer" }));
+  bar.append(el("span", { class: "kbd-hint" },
+    el("b", { text: "j" }), "/", el("b", { text: "k" }), " move · ",
+    el("b", { text: "↵" }), " expand · ", el("b", { text: "u" }), " undo"));
+  bar.append(el("button", { class: "btn btn-sm btn-ghost", type: "button", text: "JSON",
+    onclick: () => downloadEventsJSON(lastEvents) }));
+  bar.append(el("button", { class: "btn btn-sm btn-ghost", type: "button", text: "CSV",
+    onclick: () => downloadEventsCSV(lastEvents) }));
+  v.append(bar);
+
+  // events list
+  const list = el("div", { class: "events", id: "events-list" });
+  const head = el("div", { class: "ev-head" });
+  ["time", "table", "type", "pk", "changed columns"].forEach((h) => head.append(el("span", { text: h })));
+  list.append(head);
+  list.append(el("div", { id: "ev-rows" }));
+  v.append(list);
+
+  // wire search (debounced)
+  let t = null;
+  const run = () => runEventsQuery(form);
+  form.addEventListener("input", () => { clearTimeout(t); t = setTimeout(run, 200); });
+  form.addEventListener("change", run);
+  form.addEventListener("submit", (e) => { e.preventDefault(); run(); });
+  wireSchemaCascade(form);
+
+  populateSchemas(form);
+  run();
+  viewEnter();
+}
+
+function fieldInput(label, name, size, placeholder) {
+  return el("div", { class: "field field--" + size },
+    el("label", { class: "field-label", text: label }),
+    el("input", { class: "input", name, placeholder: placeholder || "" }));
+}
+function fieldSelect(label, name, size, isSchema, isTable, options, anyLabel) {
+  const sel = el("select", { class: "select" + (isSchema ? " schema-select" : "") + (isTable ? " table-select" : ""), name });
+  if (options) options.forEach((o) => sel.append(opt(o, o === "" ? (anyLabel || "any") : o)));
+  else sel.append(opt("", "any"));
+  return el("div", { class: "field field--" + size },
+    el("label", { class: "field-label", text: label }), sel);
+}
+
+// parseSmartQuery turns "type:delete pk:1006 orders" into structured filters +
+// leftover free terms. Mirrors the prototype's parseQuery intent.
+function parseSmartQuery(q) {
+  const c = { terms: [] };
+  const known = { table: 1, pk: 1, type: 1, col: 1, column: 1, schema: 1, since: 1, until: 1, gtid: 1, limit: 1 };
+  for (const tok of (q || "").trim().split(/\s+/).filter(Boolean)) {
+    const i = tok.indexOf(":");
+    const k = i > 0 ? tok.slice(0, i).toLowerCase() : "";
+    if (k && known[k]) {
+      const val = tok.slice(i + 1);
+      if (k === "col" || k === "column") c.changed_column = val;
+      else if (k === "type") c.event_type = val.toUpperCase();
+      else c[k] = val;
+    } else if (tok.includes(".") && !c.schema && !c.table) {
+      const [s, tb] = tok.split(".");
+      if (s) c.schema = s;
+      if (tb) c.table = tb;
+    } else {
+      // A bare word is a free-text term, refined client-side over the fetched
+      // page (like the prototype). We do NOT map it to an exact table filter —
+      // that would silently return 0 rows for a value/column search.
+      c.terms.push(tok.toLowerCase());
+    }
+  }
+  return c;
+}
+
+async function runEventsQuery(form) {
+  const gen = serverGen;
+  const rowsEl = $("#ev-rows", VIEW());
+  const countEl = $("#ev-count", VIEW());
+  if (!rowsEl) return;
+
+  // Merge smart-search tokens with the advanced panel (structured fields win).
+  const parsed = parseSmartQuery(form.elements.q ? form.elements.q.value : "");
+  const f = Object.fromEntries(new FormData(form).entries());
+  const merged = Object.assign({}, parsed);
+  ["schema", "table", "pk", "event_type", "changed_column", "since", "until", "gtid", "limit"].forEach((k) => {
+    if (f[k] && f[k].trim() && f[k] !== "any") merged[k] = f[k].trim();
+  });
+
+  // Build API params. pk / changed_column require schema+table server-side, so
+  // when they are not both present we apply them client-side instead of 400ing.
+  const apiParams = {};
+  const hasScope = merged.schema && merged.table;
+  ["schema", "table", "event_type", "since", "until", "gtid", "limit"].forEach((k) => {
+    if (merged[k]) apiParams[k] = merged[k];
+  });
+  if (hasScope) {
+    if (merged.pk) apiParams.pk = merged.pk;
+    if (merged.changed_column) apiParams.changed_column = merged.changed_column;
+  }
+
+  let data;
+  try {
+    data = await api("/api/events?" + new URLSearchParams(apiParams).toString());
+  } catch (err) {
+    if (gen !== serverGen) return;
+    clear(rowsEl); renderError(rowsEl, err);
+    if (countEl) countEl.textContent = "0";
+    return;
+  }
+  if (gen !== serverGen) return;
+
+  // Client-side refine: unscoped pk/col + free terms.
+  let events = data.events || [];
+  const refine = [];
+  if (!hasScope && merged.pk) refine.push(merged.pk.toLowerCase());
+  if (!hasScope && merged.changed_column) refine.push(merged.changed_column.toLowerCase());
+  refine.push(...parsed.terms);
+  if (refine.length) {
+    events = events.filter((e) => {
+      const hay = (e.schema_name + "." + e.table_name + " " + e.event_type + " " + e.pk_values + " " +
+        (e.changed_columns || []).join(" ") + " " +
+        valueToString(e.row_before) + " " + valueToString(e.row_after)).toLowerCase();
+      return refine.every((t) => hay.includes(t));
+    });
+  }
+
+  lastEvents = events;
+  if (countEl) countEl.textContent = String(events.length);
+  buildEventRows(rowsEl, events);
+}
+
+function buildEventRows(container, events) {
+  clear(container);
+  if (!events.length) {
+    const empty = el("div", { class: "ev-empty" }, "No changes match your search. ",
+      el("b", { text: "Clear it", style: "cursor:pointer",
+        onclick: () => { const s = $("#ev-search", VIEW()); if (s) { s.value = ""; runEventsQuery($("#ev-form", VIEW())); } } }),
+      " to see everything.");
+    container.append(empty);
+    return;
+  }
+  events.forEach((e, i) => {
+    const row = el("div", { class: "ev-row", "data-ev": i, tabindex: "0" });
+    row.append(icon("caret", "ev-caret"));
+    row.append(el("span", { class: "ev-time", text: e.event_timestamp }));
+    row.append(el("span", { class: "ev-table", text: e.schema_name + "." + e.table_name }));
+    row.append(el("span", {}, badge(e.event_type)));
+    row.append(el("span", { class: "ev-pk", text: e.pk_values }));
+    row.append(el("span", { class: "ev-cols" }, ...colsSummary(e.changed_columns, true)));
+    const wrap = el("div", { class: "diff-wrap", id: "diff-" + i });
+    let loaded = false;
+    row.addEventListener("click", () => {
+      const open = row.classList.toggle("open");
+      if (open && !loaded) { clear(wrap); wrap.append(renderDiff(e)); loaded = true; }
+    });
+    container.append(row);
+    container.append(wrap);
+  });
 }
 
 function renderDiff(ev) {
   const before = ev.row_before || {};
   const after = ev.row_after || {};
-  const cols = Array.from(new Set([...Object.keys(before), ...Object.keys(after)]));
+  const cols = Array.from(new Set([...Object.keys(before), ...Object.keys(after)])).sort();
   const changed = new Set(ev.changed_columns || []);
   const wholeRow = ev.event_type === "INSERT" || ev.event_type === "DELETE";
-  const grid = el("div", { class: "diff" },
-    el("div", { class: "dh" }, "column"),
-    el("div", { class: "dh" }, "before"),
-    el("div", { class: "dh" }, "after"),
-  );
-  if (cols.length === 0) {
-    grid.appendChild(el("div", { class: "col" }, "(no row image)"));
-    grid.appendChild(el("div", { class: "before" }, ""));
-    grid.appendChild(el("div", { class: "after" }, ""));
+
+  const grid = el("div", { class: "diff-grid" });
+  grid.append(el("div", { class: "diff-h", text: "column" }));
+  grid.append(el("div", { class: "diff-h", text: "before" }));
+  grid.append(el("div", { class: "diff-h", text: "after" }));
+  if (!cols.length) {
+    grid.append(el("div", { class: "diff-col", text: "(no row image)" }));
+    grid.append(el("div", { class: "diff-before" }));
+    grid.append(el("div", { class: "diff-after" }));
+  } else {
+    cols.forEach((c) => {
+      const isCh = wholeRow || changed.has(c);
+      const m = isCh ? " diff-row-changed" : "";
+      grid.append(el("div", { class: "diff-col" + m, text: c }));
+      grid.append(el("div", { class: "diff-before" + m, text: c in before ? valueToString(before[c]) : "∅" }));
+      grid.append(el("div", { class: "diff-after" + m, text: c in after ? valueToString(after[c]) : "∅" }));
+    });
   }
-  cols.forEach((c) => {
-    const isCh = wholeRow || changed.has(c);
-    const mark = isCh ? " changed" : "";
-    grid.appendChild(el("div", { class: "col" + mark }, c));
-    grid.appendChild(el("div", { class: "before" + mark }, c in before ? valueToString(before[c]) : ""));
-    grid.appendChild(el("div", { class: "after" + mark }, c in after ? valueToString(after[c]) : ""));
-  });
-  return grid;
+
+  const foot = el("div", { class: "diff-foot" });
+  foot.append(el("span", { class: "diff-foot-note", text: "Generates reversal SQL — nothing runs automatically." }));
+  const label = ev.event_type === "DELETE" ? "Restore this row" : ev.event_type === "INSERT" ? "Undo this insert" : "Undo this change";
+  foot.append(el("a", { class: "btn btn-sm btn-primary", text: label, onclick: () => undoEvent(ev) }));
+
+  return el("div", { class: "diff" }, grid, foot);
 }
 
-function renderEvents(container, data) {
-  clear(container);
-  const meta = el("div", { class: "meta-line" }, `${data.count} event(s) · limit ${data.limit}`);
-  if (!data.events || data.events.length === 0) {
-    container.appendChild(meta);
-    container.appendChild(el("div", { class: "empty" }, "No events matched these filters."));
-    return;
-  }
-  // Export toolbar — client-side, over the already-fetched (redacted) DTOs, so
-  // it carries no connection_id and only the capped result set.
-  meta.appendChild(el("span", { class: "export-bar" },
-    el("button", { type: "button", class: "export-btn", onclick: () => downloadEventsJSON(data.events) }, "Download JSON"),
-    el("button", { type: "button", class: "export-btn", onclick: () => downloadEventsCSV(data.events) }, "Download CSV")));
-  container.appendChild(meta);
-  const tbody = el("tbody");
-  data.events.forEach((ev) => {
-    const row = el("tr", { class: "event-row" },
-      el("td", null, ev.event_timestamp),
-      el("td", null, `${ev.schema_name}.${ev.table_name}`),
-      el("td", null, el("span", { class: "badge " + ev.event_type }, ev.event_type)),
-      el("td", null, ev.pk_values),
-      el("td", null, (ev.changed_columns || []).join(", ")),
-    );
-    const detail = el("tr", { class: "detail" }, el("td", { colspan: "5" }, renderDiff(ev)));
-    detail.hidden = true;
-    row.addEventListener("click", () => { detail.hidden = !detail.hidden; });
-    tbody.appendChild(row);
-    tbody.appendChild(detail);
-  });
-  const table = el("table", { class: "events" },
-    el("thead", null, el("tr", null,
-      el("th", null, "time"), el("th", null, "table"), el("th", null, "type"),
-      el("th", null, "pk"), el("th", null, "changed columns"))),
-    tbody,
-  );
-  container.appendChild(table);
+// ── keyboard cursor on Events (j/k/↵/u) ──────────────────────────────────────
+
+function moveCursor(delta) {
+  const rows = $all(".ev-row", VIEW());
+  if (!rows.length) return;
+  if (cursorIdx >= 0 && rows[cursorIdx]) rows[cursorIdx].classList.remove("cursor");
+  cursorIdx = Math.max(0, Math.min(rows.length - 1, cursorIdx + delta));
+  const row = rows[cursorIdx];
+  row.classList.add("cursor");
+  row.scrollIntoView({ block: "nearest" });
 }
 
-// ── events tab ───────────────────────────────────────────────────────────────
-async function runEvents(e) {
-  e.preventDefault();
-  const gen = serverGen;
-  const container = document.getElementById("events-result");
-  const warns = document.getElementById("events-warnings");
-  try {
-    const params = new URLSearchParams(formParams(e.target));
-    const data = await api("/api/events?" + params.toString());
-    if (gen !== serverGen) return; // switched servers mid-flight
-    renderWarnings(warns, data.warnings);
-    renderEvents(container, data);
-  } catch (err) {
-    if (gen !== serverGen) return;
-    clear(warns);
-    renderError(container, err);
-  }
-}
+// ── exports (connection_id-free) ──────────────────────────────────────────────
 
-// ── recover tab ──────────────────────────────────────────────────────────────
-async function previewRecover() {
-  const gen = serverGen;
-  const container = document.getElementById("recover-preview");
-  try {
-    const params = new URLSearchParams(formParams(document.getElementById("recover-form")));
-    const data = await api("/api/events?" + params.toString());
-    if (gen !== serverGen) return; // switched servers mid-flight
-    renderEvents(container, data);
-  } catch (err) {
-    if (gen !== serverGen) return;
-    renderError(container, err);
-  }
-}
-
-async function generateUndo(e) {
-  e.preventDefault();
-  const gen = serverGen;
-  const warns = document.getElementById("recover-warnings");
-  const wrap = document.getElementById("recover-sql-wrap");
-  try {
-    const body = formParams(e.target);
-    if (body.limit) body.limit = Number(body.limit);
-    const data = await api("/api/recover", { method: "POST", body });
-    if (gen !== serverGen) return; // an undo script must never show under another server
-    renderWarnings(warns, data.warnings);
-    lastSQL = data.sql || "";
-    document.getElementById("recover-sql").textContent = lastSQL;
-    document.getElementById("recover-meta").textContent =
-      `${data.statement_count} statement(s) from ${data.row_count} event(s)`;
-    wrap.hidden = false;
-  } catch (err) {
-    if (gen !== serverGen) return;
-    clear(warns);
-    wrap.hidden = true;
-    renderError(document.getElementById("recover-preview"), err);
-  }
-}
-
-function copySQL() {
-  navigator.clipboard.writeText(lastSQL)
-    .then(() => toast("SQL copied to clipboard"))
-    .catch(() => toast("copy failed"));
-}
-
-// downloadBlob triggers a client-side file download, surfacing failures as a
-// toast (parity with copySQL) rather than only an uncaught console exception.
 function downloadBlob(filename, content, mime) {
   try {
-    const a = el("a", {
-      href: URL.createObjectURL(new Blob([content], { type: mime })),
-      download: filename,
-    });
-    document.body.appendChild(a);
-    a.click();
-    a.remove();
-    URL.revokeObjectURL(a.href);
-  } catch (err) {
-    toast("download failed: " + (err.message || err));
-  }
+    const url = URL.createObjectURL(new Blob([content], { type: mime }));
+    const a = el("a", { href: url, download: filename });
+    document.body.append(a); a.click(); a.remove();
+    URL.revokeObjectURL(url);
+  } catch (err) { toast("download failed: " + ((err && err.message) || err)); }
 }
-
-function downloadSQL() {
-  downloadBlob("bintrail-undo.sql", lastSQL, "application/sql");
-}
-
-// ── events export (client-side, over the redacted eventDTOs) ──────────────────
-// Flat CSV columns; row_before/row_after and changed_columns are emitted as JSON
-// strings. connection_id is intentionally absent — these DTOs never carried it.
-const EVENT_CSV_COLUMNS = [
-  "event_id", "event_timestamp", "schema_name", "table_name", "event_type",
-  "pk_values", "changed_columns", "gtid", "binlog_file", "start_pos", "end_pos",
-  "row_before", "row_after",
-];
-
 function csvCell(v) {
-  let s;
-  if (v === null || v === undefined) s = "";
-  else if (typeof v === "object") s = JSON.stringify(v); // arrays + maps
-  else s = String(v);
-  if (/[",\r\n]/.test(s)) s = '"' + s.replace(/"/g, '""') + '"';
-  return s;
+  if (v === null || v === undefined) return "";
+  const s = typeof v === "object" ? JSON.stringify(v) : String(v);
+  return /[",\r\n]/.test(s) ? '"' + s.replace(/"/g, '""') + '"' : s;
 }
-
 function downloadEventsJSON(events) {
-  downloadBlob("bintrail-events.json", JSON.stringify(events, null, 2), "application/json");
+  downloadBlob("bintrail-events.json", JSON.stringify(events || [], null, 2), "application/json");
 }
-
 function downloadEventsCSV(events) {
   const lines = [EVENT_CSV_COLUMNS.join(",")];
-  events.forEach((ev) => lines.push(EVENT_CSV_COLUMNS.map((c) => csvCell(ev[c])).join(",")));
+  (events || []).forEach((ev) => lines.push(EVENT_CSV_COLUMNS.map((c) => csvCell(ev[c])).join(",")));
   downloadBlob("bintrail-events.csv", lines.join("\r\n"), "text/csv");
 }
 
-// ── status tab ───────────────────────────────────────────────────────────────
-function kv(k, v) {
-  return el("div", { class: "kv" },
-    el("span", { class: "k" }, k),
-    el("span", { class: "v" }, v === null || v === undefined ? "—" : String(v)));
-}
+// ── Recover ────────────────────────────────────────────────────────────────
 
-async function refreshStatus() {
-  const gen = serverGen;
-  const c = document.getElementById("status-result");
-  try {
-    const s = await api("/api/status");
-    if (gen !== serverGen) return; // switched servers mid-flight
-    clear(c);
-    const grid = el("div", { class: "status-grid" });
-    grid.appendChild(el("div", { class: "card" },
-      el("h3", null, "Summary"),
-      kv("total events (est.)", s.total_events_estimate),
-      kv("indexed files", (s.files || []).length),
-      kv("partitions", (s.partitions || []).length)));
-    if (s.coverage) {
-      grid.appendChild(el("div", { class: "card" },
-        el("h3", null, "Coverage"),
-        kv("earliest event", s.coverage.earliest_event),
-        kv("latest event", s.coverage.latest_event),
-        kv("total events", s.coverage.total_events),
-        kv("schema changes", s.coverage.schema_changes)));
-    }
-    if (s.stream) {
-      grid.appendChild(el("div", { class: "card" },
-        el("h3", null, "Stream"),
-        kv("mode", s.stream.mode),
-        kv("binlog file", s.stream.binlog_file),
-        kv("position", s.stream.binlog_position),
-        kv("events indexed", s.stream.events_indexed)));
-    }
-    if (s.archives) {
-      grid.appendChild(el("div", { class: "card" },
-        el("h3", null, "Archives"),
-        kv("files", s.archives.total_files),
-        kv("rows", s.archives.total_rows),
-        kv("size", s.archives.total_size_human)));
-    }
-    c.appendChild(grid);
-  } catch (err) {
-    if (gen !== serverGen) return;
-    renderError(c, err);
+function renderRecover(params) {
+  const v = VIEW(); clear(v);
+  const sub = el("p", { class: "page-sub" },
+    "Filter the changes you want to undo, preview the affected rows, then generate reversal SQL. ",
+    el("b", { text: "Nothing is ever executed" }),
+    " — copy or download the script and apply it yourself after review.");
+  v.append(pageHead("Recover", sub));
+
+  // Context banner when arriving via an event "Undo" (pendingRecover).
+  const ctx = pendingRecover;
+  if (ctx) {
+    const banner = el("div", { class: "ctx-banner" });
+    banner.append(el("span", { class: "badge " + badgeClass(ctx.type), text: ctx.type }));
+    banner.append(el("div", { class: "ctx-main" },
+      el("span", { class: "ctx-eyebrow", text: "Reverting this row to before this point" }),
+      el("span", { class: "ctx-title", text: ctx.schema + "." + ctx.table + " · pk " + ctx.pk }),
+      el("span", { class: "ctx-detail", text: "undoing changes up to " + ctx.type + " at " + ctx.time })));
+    banner.append(el("span", { class: "spacer" }));
+    banner.append(el("a", { class: "btn btn-sm btn-ghost", text: "Clear",
+      onclick: () => { pendingRecover = null; navigate("recover"); } }));
+    v.append(banner);
   }
-}
 
-// ── schema / table dropdowns ─────────────────────────────────────────────────
-async function populateSchemas() {
-  const gen = serverGen;
-  let schemas = [];
-  try {
-    const data = await api("/api/schemas");
-    schemas = data.schemas || [];
-  } catch (err) {
-    if (gen !== serverGen) return;
-    document.querySelectorAll(".schema-select").forEach((sel) => {
-      clear(sel);
-      sel.appendChild(opt("", "(error: " + (err.message || err) + ")"));
+  // Manual filter form
+  const form = el("form", { class: "filters", id: "recover-form" });
+  form.append(fieldSelect("Schema", "schema", "md", true, false, null, "— select —"));
+  form.append(fieldInput("Table", "table", "md", "orders"));
+  form.append(fieldInput("PK", "pk", "sm", "42 or 42|7"));
+  form.append(fieldInput("Since", "since", "md", "YYYY-MM-DD HH:MM"));
+  form.append(fieldInput("Until", "until", "md", "YYYY-MM-DD HH:MM"));
+  const actions = el("div", { class: "filter-actions" });
+  actions.append(el("button", { class: "btn btn-ghost", type: "button", text: "Preview rows",
+    onclick: () => previewRecover(form) }));
+  actions.append(el("button", { class: "btn btn-primary", type: "submit", text: "Generate undo SQL" }));
+  form.append(actions);
+  v.append(form);
+
+  v.append(el("div", { id: "recover-warnings", class: "warnings" }));
+  v.append(el("div", { id: "recover-preview" }));
+  v.append(el("div", { id: "recover-out" }));
+
+  form.addEventListener("submit", (e) => { e.preventDefault(); generateUndo(form); });
+  wireSchemaCascade(form);
+  populateSchemas(form);
+
+  // Prefill from context and auto-generate.
+  if (ctx) {
+    setSelectWhenReady(form, "schema", ctx.schema, () => {
+      form.elements.table.value = ctx.table;
+      form.elements.pk.value = ctx.pk;
+      if (ctx.time) form.elements.until.value = ctx.time;
+      generateUndo(form);
     });
-    return;
   }
-  if (gen !== serverGen) return; // a newer switch's populateSchemas owns the dropdowns
-  document.querySelectorAll(".schema-select").forEach((sel) => {
-    clear(sel);
-    sel.appendChild(opt("", "— select —"));
-    schemas.forEach((s) => sel.appendChild(opt(s, s)));
-  });
+  viewEnter();
 }
 
-async function loadTables(form) {
-  const gen = serverGen;
-  const schema = form.querySelector(".schema-select").value;
-  const tsel = form.querySelector(".table-select");
-  clear(tsel);
-  tsel.appendChild(opt("", "— any —"));
-  if (!schema) return;
-  try {
-    const data = await api("/api/schemas?schema=" + encodeURIComponent(schema));
-    if (gen !== serverGen) return; // switched servers mid-flight
-    (data.tables || []).forEach((t) => tsel.appendChild(opt(t, t)));
-  } catch (err) {
-    if (gen !== serverGen) return;
-    // Surface the failure (like populateSchemas) so an empty dropdown isn't
-    // mistaken for "this schema has no tables". Table is still optional.
-    tsel.appendChild(opt("", "(error loading tables)"));
-    toast("failed to load tables: " + (err.message || err));
-  }
+// setSelectWhenReady fills a schema select once its options have loaded, then
+// loads its tables and runs cb. Lets the undo-bridge prefill survive the async
+// schema fetch without racing it.
+function setSelectWhenReady(form, name, value, cb) {
+  const sel = form.elements[name];
+  const tryset = () => {
+    if (Array.from(sel.options).some((o) => o.value === value)) {
+      sel.value = value;
+      loadTables(form).then(() => cb && cb());
+      return true;
+    }
+    return false;
+  };
+  if (tryset()) return;
+  let n = 0;
+  const iv = setInterval(() => { if (tryset() || ++n > 40) clearInterval(iv); }, 50);
 }
 
-// ── reconstruct (time-travel) tab ────────────────────────────────────────────
-async function runReconstruct(history) {
-  const form = document.getElementById("reconstruct-form");
-  const warns = document.getElementById("reconstruct-warnings");
-  const container = document.getElementById("reconstruct-result");
-  const p = formParams(form);
-  if (!p.schema || !p.table || !p.pk) {
-    clear(warns);
-    renderError(container, new Error("schema, table, and pk are required"));
-    return;
-  }
-  const params = new URLSearchParams({ schema: p.schema, table: p.table, pk: p.pk });
-  if (p.at) params.set("at", p.at);
-  if (p.allow_gaps) params.set("allow_gaps", "true");
-  if (history) params.set("history", "true");
+async function previewRecover(form) {
   const gen = serverGen;
+  const container = $("#recover-preview", VIEW());
+  const f = Object.fromEntries(new FormData(form).entries());
+  const params = {};
+  ["schema", "table", "pk", "since", "until"].forEach((k) => { if (f[k] && f[k].trim()) params[k] = f[k].trim(); });
   try {
-    const data = await api("/api/reconstruct?" + params.toString());
-    if (gen !== serverGen) return; // switched servers mid-flight
-    renderWarnings(warns, data.warnings);
-    if (history) renderReconstructHistory(container, data);
-    else renderReconstructState(container, data);
+    const data = await api("/api/events?" + new URLSearchParams(params).toString());
+    if (gen !== serverGen) return;
+    clear(container);
+    container.append(el("div", { class: "meta-line" }, el("b", { text: String(data.count) }), " affected event(s) · limit " + data.limit));
+    const list = el("div", { class: "events" });
+    const head = el("div", { class: "ev-head" });
+    ["time", "table", "type", "pk", "changed columns"].forEach((h) => head.append(el("span", { text: h })));
+    list.append(head);
+    const rows = el("div");
+    buildEventRows(rows, data.events || []);
+    list.append(rows);
+    container.append(list);
   } catch (err) {
     if (gen !== serverGen) return;
-    clear(warns);
     renderError(container, err);
+  }
+}
+
+async function generateUndo(form) {
+  const gen = serverGen;
+  const warns = $("#recover-warnings", VIEW());
+  const out = $("#recover-out", VIEW());
+  const f = Object.fromEntries(new FormData(form).entries());
+  const body = {};
+  ["schema", "table", "pk", "since", "until"].forEach((k) => { if (f[k] && f[k].trim()) body[k] = f[k].trim(); });
+  if (!body.schema) { renderError(out, "recover requires at least a schema filter"); return; }
+  try {
+    const data = await api("/api/recover", { method: "POST", body });
+    if (gen !== serverGen) return;
+    renderWarnings(warns, data.warnings);
+    lastSQL = data.sql || "";
+    clear(out);
+    out.append(codePanel(lastSQL, data.statement_count + " statement(s) from " + data.row_count + " event(s)"));
+  } catch (err) {
+    if (gen !== serverGen) return;
+    clear(warns); renderError(out, err);
+  }
+}
+
+function codePanel(sql, metaLabel) {
+  const panel = el("div", { class: "codepanel", id: "sql-panel" });
+  const head = el("div", { class: "code-head" });
+  head.append(icon("file"));
+  const lbl = el("span", { class: "lbl" }, el("b", { text: "reversal.sql" }), " · " + (metaLabel || "read-only preview"));
+  head.append(lbl);
+  head.append(el("span", { class: "spacer" }));
+  head.append(el("button", { class: "btn btn-sm", type: "button", text: "Copy", onclick: copySQL }));
+  head.append(el("button", { class: "btn btn-sm", type: "button", text: "Download", onclick: downloadSQL }));
+  panel.append(head);
+  panel.append(el("pre", { class: "code", text: sql }));
+  return panel;
+}
+function copySQL() {
+  navigator.clipboard.writeText(lastSQL).then(() => toast("SQL copied to clipboard"), () => toast("copy failed"));
+}
+function downloadSQL() { downloadBlob("bintrail-undo.sql", lastSQL, "application/sql"); }
+
+// Bridge: an event → Recover, scoped to that row up to the event's timestamp.
+function undoEvent(e) {
+  pendingRecover = {
+    schema: e.schema_name, table: e.table_name, pk: e.pk_values,
+    type: e.event_type, time: e.event_timestamp,
+  };
+  navigate("recover");
+}
+
+// ── Time-travel (reconstruct) ─────────────────────────────────────────────────
+
+function renderTimetravel(params) {
+  // Landed on /timetravel but reconstruct is gated off (direct URL or Back).
+  // Redirect by REWRITING the URL (replaceState) then re-dispatching — calling
+  // navigate(push=false) here would leave the URL on /timetravel and re-resolve
+  // straight back into this guard (infinite recursion).
+  if (!capsCache.reconstruct) { history.replaceState({}, "", "/overview"); renderRoute(); return; }
+  const v = VIEW(); clear(v);
+  const sub = el("p", { class: "page-sub" },
+    "Reconstruct a single row's full state as of a point in time — baseline snapshot + binlog deltas. Pick a row and a moment; see its value then, or its complete change history.");
+  v.append(pageHead("Time-travel", sub));
+
+  const form = el("form", { class: "filters", id: "tt-form" });
+  form.append(fieldSelect("Schema", "schema", "md", true, false, null, "— select —"));
+  form.append(fieldSelect("Table", "table", "md", false, true));
+  form.append(fieldInput("PK", "pk", "sm", "42 or 42|7"));
+  form.append(fieldInput("As of", "at", "md", "YYYY-MM-DD HH:MM (default: now)"));
+  const gapsField = el("div", { class: "field", style: "justify-content:flex-end" },
+    el("label", { class: "check" }, el("input", { type: "checkbox", name: "allow_gaps" }), el("span", { text: "Allow coverage gaps" })));
+  form.append(gapsField);
+  const actions = el("div", { class: "filter-actions" });
+  actions.append(el("button", { class: "btn btn-ghost", type: "button", text: "Full history", onclick: () => runReconstruct(form, true) }));
+  actions.append(el("button", { class: "btn btn-primary", type: "submit", text: "Value as of T" }));
+  form.append(actions);
+  v.append(form);
+
+  v.append(el("div", { id: "tt-warnings", class: "warnings" }));
+  const out = el("div", { id: "tt-out" });
+  out.append(el("div", { class: "tt-meta", text: "Run a query to reconstruct this row's state." }));
+  v.append(out);
+
+  form.addEventListener("submit", (e) => { e.preventDefault(); runReconstruct(form, false); });
+  wireSchemaCascade(form);
+  populateSchemas(form);
+  viewEnter();
+}
+
+async function runReconstruct(form, history) {
+  const gen = serverGen;
+  const warns = $("#tt-warnings", VIEW());
+  const out = $("#tt-out", VIEW());
+  const f = Object.fromEntries(new FormData(form).entries());
+  if (!f.schema || !f.table || !f.pk) { clear(warns); renderError(out, "schema, table, and pk are required"); return; }
+  const params = { schema: f.schema, table: f.table, pk: f.pk };
+  if (f.at && f.at.trim()) params.at = f.at.trim();
+  if (form.elements.allow_gaps && form.elements.allow_gaps.checked) params.allow_gaps = "true";
+  if (history) params.history = "true";
+  try {
+    const data = await api("/api/reconstruct?" + new URLSearchParams(params).toString());
+    if (gen !== serverGen) return;
+    renderWarnings(warns, data.warnings);
+    clear(out);
+    if (history) renderTimeline(out, data);
+    else renderStateAt(out, data);
+  } catch (err) {
+    if (gen !== serverGen) return;
+    clear(warns); renderError(out, err);
   }
 }
 
 function reconstructMeta(data, label) {
   return el("div", { class: "meta-line" },
-    `${data.schema}.${data.table} pk=${data.pk} · ${label} · baseline ${data.baseline_time} · ${data.event_count} event(s)`);
+    el("b", { text: data.schema + "." + data.table + " pk=" + data.pk }),
+    " · " + label + " · baseline " + data.baseline_time + " · " + data.event_count + " event(s)");
+}
+
+function renderStateAt(container, data) {
+  container.append(reconstructMeta(data, "as of " + data.at));
+  if (!data.found) { container.append(el("div", { class: "deleted-note", text: "No row with this primary key existed at or before the selected time." })); return; }
+  if (data.deleted) { container.append(el("div", { class: "deleted-note", text: "Row was deleted as of " + data.at + "." })); return; }
+  container.append(stateTable(data.state || {}));
 }
 
 function stateTable(state) {
-  const tbody = el("tbody");
-  Object.keys(state || {}).forEach((k) => {
-    tbody.appendChild(el("tr", null, el("th", null, k), el("td", null, valueToString(state[k]))));
+  const table = el("table", { class: "statetable" });
+  Object.keys(state).forEach((k) => {
+    table.append(el("tr", {}, el("th", { text: k }), el("td", { text: valueToString(state[k]) })));
   });
-  return el("table", { class: "statetable" }, tbody);
+  return table;
 }
 
-function renderReconstructState(container, data) {
-  clear(container);
-  container.appendChild(reconstructMeta(data, "as of " + data.at));
-  if (!data.found) {
-    container.appendChild(el("div", { class: "deleted-note" },
-      "No row with this primary key existed at or before the selected time."));
-    return;
-  }
-  if (data.deleted) {
-    container.appendChild(el("div", { class: "deleted-note" }, "Row was deleted as of " + data.at + "."));
-    return;
-  }
-  container.appendChild(stateTable(data.state));
-}
-
-function compactState(state) {
-  return Object.keys(state || {}).map((k) => `${k}=${valueToString(state[k])}`).join("   ");
-}
-
-function renderReconstructHistory(container, data) {
-  clear(container);
+function renderTimeline(container, data) {
   const entries = data.history || [];
-  container.appendChild(reconstructMeta(data, `history through ${data.at} · ${entries.length} state(s)`));
-  if (!data.found) {
-    container.appendChild(el("div", { class: "deleted-note" },
-      "No row with this primary key existed at or before the selected time."));
-    return;
-  }
-  const tl = el("div", { class: "timeline" });
+  container.append(reconstructMeta(data, "history through " + data.at + " · " + entries.length + " state(s)"));
+  if (!entries.length) { container.append(el("div", { class: "deleted-note", text: "No history for this primary key in the covered window." })); return; }
+
+  const tl = el("div", { class: "timeline", id: "timeline" });
+  let prev = null;
   entries.forEach((e) => {
-    const badgeClass = "badge " + (e.source === "baseline" ? "baseline" : e.source);
-    const head = el("div", { class: "tl-head" },
-      el("span", { class: badgeClass }, e.source),
-      el("span", { class: "tl-time" }, e.time));
-    const body = e.deleted
-      ? el("div", { class: "tl-state" }, "(row deleted)")
-      : el("div", { class: "tl-state" }, compactState(e.state));
-    tl.appendChild(el("div", { class: "tl-entry" }, head, body));
+    const node = el("div", { class: "tl-node" });
+    const kind = e.source === "baseline" ? "baseline" : e.source.toLowerCase();
+    node.append(el("span", { class: "tl-dot " + kind }));
+    const head = el("div", { class: "tl-head" });
+    head.append(el("span", { class: "badge " + (e.source === "baseline" ? "b-baseline" : badgeClass(e.source)), text: e.source }));
+    head.append(el("span", { class: "tl-time", text: e.time }));
+    node.append(head);
+
+    const body = el("div", { class: "tl-body" });
+    if (e.deleted || !e.state) {
+      body.append(el("span", { class: "pair" }, el("span", { class: "pk", text: "(row deleted)" })));
+    } else {
+      const changed = new Set();
+      if (prev) for (const k of Object.keys(e.state)) if (valueToString(e.state[k]) !== valueToString(prev[k])) changed.add(k);
+      Object.keys(e.state).forEach((k) => {
+        body.append(el("span", { class: "pair" },
+          el("span", { class: "pk", text: k + "=" }),
+          el("span", { class: "pv" + (e.source !== "baseline" && changed.has(k) ? " changed" : ""), text: valueToString(e.state[k]) })));
+      });
+      prev = e.state;
+    }
+    node.append(body);
+
+    if (e.source !== "baseline") {
+      const acts = el("div", { class: "tl-actions" });
+      acts.append(el("a", { class: "btn btn-sm tl-restore", text: "Restore to this state",
+        onclick: () => undoEvent({ schema_name: data.schema, table_name: data.table, pk_values: data.pk, event_type: e.source, event_timestamp: e.time }) }));
+      node.append(acts);
+    }
+    tl.append(node);
   });
-  container.appendChild(tl);
+  container.append(tl);
+
+  // "draws itself" — progressive-enhancement reveal (decorative).
+  requestAnimationFrame(() => {
+    tl.classList.add("drawn");
+    $all(".tl-node", tl).forEach((n, i) => setTimeout(() => n.classList.add("in"), 60 + i * 55));
+  });
 }
 
-// gateCapabilities toggles capability-gated tabs/panels per the SELECTED
-// server's report. Gated elements keep their data-capability attribute and are
-// shown/hidden via the cap-on class, so the gate re-evaluates on every server
-// switch (a server with Time-travel can be followed by one without). Anything
-// not enabled stays hidden (display:none via CSS), so an un-configured surface
-// never flashes on screen.
-// capsCache holds the last capability report (per selected server) so the
-// servers modal can gate monitor controls without refetching.
-let capsCache = {};
+// ── Status ─────────────────────────────────────────────────────────────────
+
+async function renderStatus() {
+  const gen = serverGen;
+  viewLoading();
+  let data;
+  try { data = await api("/api/status"); }
+  catch (err) { if (gen !== serverGen) return; const v = VIEW(); clear(v); v.append(pageHead("Status", null)); renderError(v, err); return; }
+  if (gen !== serverGen) return;
+  updateSideMeta(data);
+
+  const v = VIEW(); clear(v);
+  const sub = el("p", { class: "page-sub", text: "Index health at a glance — coverage window, stream position, and what's been captured." });
+  v.append(pageHead("Status", sub));
+
+  const cards = el("div", { class: "cards" });
+  const cov = data.coverage || {};
+  const stream = data.stream || null;
+  const arch = data.archives || null;
+
+  cards.append(statusCard("Summary", [
+    ["total events (est.)", data.total_events_estimate, true],
+    ["indexed files", (data.files || []).length],
+    ["partitions", (data.partitions || []).length],
+  ]));
+  cards.append(statusCard("Coverage", [
+    ["earliest event", cov.earliest_event],
+    ["latest event", cov.latest_event],
+    ["total events", cov.total_events],
+    ["schema changes", cov.schema_changes],
+  ]));
+  if (stream) cards.append(statusCard("Stream", [
+    ["mode", stream.mode],
+    ["binlog file", stream.binlog_file],
+    ["position", stream.binlog_position],
+    ["events indexed", stream.events_indexed],
+  ]));
+  if (arch) cards.append(statusCard("Archives", [
+    ["files", arch.total_files],
+    ["rows", arch.total_rows],
+    ["size", arch.total_size_human],
+  ]));
+  v.append(cards);
+  viewEnter();
+}
+
+function statusCard(title, rows) {
+  const card = el("div", { class: "card" }, el("div", { class: "card-title", text: title }));
+  rows.forEach(([k, val, big]) => {
+    card.append(el("div", { class: "kv" },
+      el("span", { class: "kv-k", text: k }),
+      el("span", { class: "kv-v" + (big ? " big" : ""), text: val === null || val === undefined ? "—" : String(val) })));
+  });
+  return card;
+}
+
+function updateSideMeta(status) {
+  const servers = status.servers || [];
+  const s0 = servers[0];
+  const conn = s0 ? (s0.username + "@" + s0.host + ":" + s0.port) : "—";
+  const connEl = document.getElementById("meta-conn");
+  if (connEl) connEl.textContent = conn;
+  const streamEl = document.getElementById("meta-stream");
+  if (streamEl) {
+    clear(streamEl);
+    streamEl.append("stream ");
+    if (status.stream) {
+      streamEl.append(el("b", { text: status.stream.mode }));
+      if (status.stream.binlog_file) streamEl.append(" · " + status.stream.binlog_file);
+    } else {
+      streamEl.append(el("b", { text: "—" }));
+    }
+  }
+}
+
+// ── schemas / tables cascade ──────────────────────────────────────────────────
+
+async function loadSchemas() {
+  if (schemaCache) return schemaCache;
+  const data = await api("/api/schemas");
+  schemaCache = data.schemas || [];
+  return schemaCache;
+}
+
+async function populateSchemas(root) {
+  const gen = serverGen;
+  const selects = $all(".schema-select", root || document);
+  if (!selects.length) return;
+  let schemas;
+  try { schemas = await loadSchemas(); }
+  catch (err) {
+    if (gen !== serverGen) return;
+    selects.forEach((sel) => { const keep = sel.value; clear(sel); sel.append(opt("", "(error: " + ((err && err.message) || err) + ")")); sel.value = keep; });
+    return;
+  }
+  if (gen !== serverGen) return;
+  selects.forEach((sel) => {
+    const keep = sel.value;
+    clear(sel);
+    sel.append(opt("", "— select —"));
+    schemas.forEach((s) => sel.append(opt(s, s)));
+    if (keep) sel.value = keep;
+  });
+}
+
+async function loadTables(form) {
+  const gen = serverGen;
+  const sel = form.querySelector(".schema-select");
+  const tsel = form.querySelector(".table-select");
+  if (!tsel) return;
+  const schema = sel ? sel.value : "";
+  clear(tsel);
+  tsel.append(opt("", "— any —"));
+  if (!schema) return;
+  let tables = tablesCache.get(schema);
+  try {
+    if (!tables) { const data = await api("/api/schemas?schema=" + encodeURIComponent(schema)); tables = data.tables || []; tablesCache.set(schema, tables); }
+  } catch (err) {
+    if (gen !== serverGen) return;
+    tsel.append(opt("", "(error loading tables)"));
+    toast("failed to load tables: " + ((err && err.message) || err));
+    return;
+  }
+  if (gen !== serverGen) return;
+  tables.forEach((t) => tsel.append(opt(t, t)));
+}
+
+function wireSchemaCascade(root) {
+  $all(".schema-select", root).forEach((sel) => sel.addEventListener("change", () => loadTables(sel.closest("form"))));
+}
+
+// ── capabilities gating ────────────────────────────────────────────────────
 
 async function gateCapabilities() {
   const gen = serverGen;
   let caps = {};
-  try {
-    caps = await api("/api/capabilities");
-  } catch {
-    caps = {}; // unreachable/unknown server → no optional surfaces
-  }
-  if (gen !== serverGen) return; // a newer switch's gate owns the tabs
-  capsCache = caps;
-  document.querySelectorAll("[data-capability]").forEach((node) => {
-    node.classList.toggle("cap-on", !!caps[node.dataset.capability]);
-  });
-  // If the active tab just lost its capability on a switch, fall back to the
-  // landing tab rather than leaving a blank main area.
-  const active = document.querySelector(".tab.active");
-  if (active && active.dataset.capability && !caps[active.dataset.capability]) {
-    const home = document.querySelector('.tab[data-panel="recover"]');
-    if (home) home.click();
-  }
+  try { caps = await api("/api/capabilities"); } catch (_) { caps = {}; }
+  if (gen !== serverGen) return;
+  capsCache = caps || {};
+  $all("[data-capability]").forEach((node) => node.classList.toggle("cap-on", !!capsCache[node.dataset.capability]));
 }
 
-// ── server switcher + management modal ───────────────────────────────────────
-function serverLabel(s) {
-  return s.kind === "ephemeral" ? s.name + " (cli)" : s.name;
-}
+// ── server registry: switcher + modal CRUD ──────────────────────────────────
 
-// loadServers refreshes the header dropdown from /api/servers and reconciles a
-// stale per-tab selection (e.g. the server was deleted from another tab).
+function serverLabel(s) { return s.kind === "ephemeral" ? s.name + " (cli)" : s.name; }
+
 async function loadServers() {
   const data = await api("/api/servers");
   defaultServerId = data.default_id || "";
   const servers = data.servers || [];
-  if (currentServer && !servers.some((s) => s.id === currentServer)) {
-    setCurrentServer(""); // deleted under us → fall back to the default
-  }
+  // Reconcile a stale selection (server deleted elsewhere).
+  if (currentServer && !servers.some((s) => s.id === currentServer)) setCurrentServer("");
   const sel = document.getElementById("server-select");
-  clear(sel);
-  servers.forEach((s) => sel.appendChild(opt(s.id, serverLabel(s))));
-  sel.value = currentServer || defaultServerId;
+  if (sel) {
+    clear(sel);
+    servers.forEach((s) => sel.append(opt(s.id, serverLabel(s))));
+    sel.value = currentServer || defaultServerId;
+  }
   return servers;
-}
-
-// clearResults wipes every per-server result so nothing from the previous
-// server lingers after a switch (stale rows would read as the new server's).
-function clearResults() {
-  ["events-result", "events-warnings", "recover-preview", "recover-warnings",
-    "reconstruct-result", "reconstruct-warnings", "status-result"].forEach((id) => {
-    const n = document.getElementById(id);
-    if (n) clear(n);
-  });
-  document.getElementById("recover-sql-wrap").hidden = true;
-  lastSQL = "";
 }
 
 async function switchServer(id) {
   setCurrentServer(id);
-  serverGen++; // anything still in flight for the previous server must not render
-  clearResults();
+  serverGen++;
+  schemaCache = null;
+  tablesCache.clear();
+  // A switch is a fresh context: drop any carried undo-context and SQL so they
+  // can never be auto-applied against a different server's index.
+  pendingRecover = null;
+  lastSQL = "";
   await gateCapabilities();
-  populateSchemas();
+  renderRoute(); // re-render the current screen for the new server
+}
+
+// modal -----------------------------------------------------------------------
+
+function buildServersModal() {
+  const scrim = el("div", { class: "modal-scrim show" });
+  const modal = el("div", { class: "modal", role: "dialog", "aria-label": "Servers" });
+
+  const head = el("div", { class: "modal-head" });
+  head.append(el("h2", { class: "modal-title", text: "Servers" }));
+  const desc = el("p", { class: "modal-desc" },
+    "Named connections to bintrail index databases, stored in a local file on the console host. ");
+  desc.append(el("span", { "data-capability": "monitor" },
+    "This process can also ", el("b", { text: "monitor" }),
+    " a source MySQL: add one below and bintrail runs the preflight checks, provisions an index for it, and starts streaming — no terminal needed."));
+  head.append(desc);
+  head.append(el("button", { class: "modal-x", type: "button", text: "✕", onclick: closeServersModal }));
+  modal.append(head);
+
+  const body = el("div", { class: "modal-body" });
+  body.append(el("div", { class: "srv-list", id: "servers-list" }));
+  body.append(el("div", { id: "server-add-wrap", style: "margin-top:18px" },
+    el("button", { class: "btn btn-primary", type: "button", id: "server-add", text: "+ Add server", onclick: () => showServerForm(null) })));
+  body.append(el("div", { id: "server-form-mount" }));
+  modal.append(body);
+
+  scrim.append(modal);
+  scrim.addEventListener("click", (e) => { if (e.target === scrim) closeServersModal(); });
+  return scrim;
 }
 
 function openServersModal() {
-  document.getElementById("servers-modal").hidden = false;
-  hideServerForm();
+  const mount = document.getElementById("modal");
+  clear(mount);
+  mount.append(buildServersModal());
+  // re-apply capability gating to the freshly-mounted [data-capability] nodes
+  $all("[data-capability]", mount).forEach((n) => n.classList.toggle("cap-on", !!capsCache[n.dataset.capability]));
   refreshServersList();
 }
-
-function closeServersModal() {
-  document.getElementById("servers-modal").hidden = true;
-}
-
-// isLiveMonitorState: states where the stream goroutine is alive (Stop is the
-// applicable verb). "stalled" and "lost_position" are unhealthy running
-// variants — the supervisor still owns the stream and its advisory lock.
-function isLiveMonitorState(st) {
-  return st === "running" || st === "pending" || st === "stalled" || st === "lost_position";
-}
-
-const MON_STATE_TITLES = {
-  failed: "stream failing — retrying with backoff; press Start for details",
-  stalled: "stream is connected but has made no progress for several minutes",
-  lost_position: "binlogs were purged past the saved position — events in the gap are permanently lost; current changes are still streaming",
-};
+function closeServersModal() { document.getElementById("modal").replaceChildren(); }
 
 async function refreshServersList() {
   const list = document.getElementById("servers-list");
-  let servers = [];
-  try {
-    servers = await loadServers();
-  } catch (err) {
-    renderError(list, err);
-    return;
-  }
+  if (!list) return;
+  let servers;
+  try { servers = await loadServers(); }
+  catch (err) { renderError(list, err); return; }
   clear(list);
-  if (servers.length === 0) {
-    list.appendChild(el("div", { class: "empty" }, "No servers yet — add your first connection."));
-    return;
-  }
-  servers.forEach((s) => {
-    const desc = s.has_source && s.source_host
-      ? `watching ${s.source_user}@${s.source_host}:${s.source_port || "3306"}${s.schemas ? " [" + s.schemas + "]" : ""}`
-      : (s.host ? `${s.user}@${s.host}:${s.port || "3306"}/${s.dbname}` : s.dbname || "");
-    const monitorable = capsCache.monitor && s.has_source && s.kind !== "ephemeral";
+  if (!servers.length) { list.append(el("div", { class: "ev-empty", text: "No servers yet — add your first connection." })); return; }
+  servers.forEach((s) => list.append(serverRow(s)));
+}
+
+function isLiveMonitorState(st) { return st === "running" || st === "pending" || st === "stalled" || st === "lost_position"; }
+
+function serverRow(s) {
+  const item = el("div", { class: "srv-item" });
+  const nm = el("span", { class: "nm" },
+    el("span", { class: "health-dot" + (s.connected ? " ok" : ""), title: s.connected ? "connected" : "not connected yet" }),
+    serverLabel(s));
+  item.append(nm);
+  if (s.kind === "ephemeral") item.append(el("span", { class: "chip chip-cli", text: "CLI", title: "From --index-dsn; managed by the command line" }));
+  if (s.reconstruct) item.append(el("span", { class: "chip chip-tt", text: "TT", title: "Baseline configured: Time-travel available" }));
+  if (s.monitor_state) item.append(el("span", { class: "chip chip-mon", text: s.monitor_state.replace("_", " ").toUpperCase(), title: MON_STATE_TITLES[s.monitor_state] || ("monitoring " + s.monitor_state) }));
+
+  let desc;
+  if (s.has_source && s.source_host) desc = "watching " + s.source_user + "@" + s.source_host + ":" + (s.source_port || "3306") + (s.schemas ? " [" + s.schemas + "]" : "");
+  else if (s.host) desc = s.user + "@" + s.host + ":" + (s.port || "3306") + "/" + s.dbname;
+  else desc = s.dbname || "";
+  item.append(el("span", { class: "srv-desc conn", text: desc }));
+
+  item.append(el("span", { class: "srv-status", id: "srv-status-" + s.id }));
+
+  const acts = el("span", { class: "acts row-acts" });
+  const monitorable = capsCache.monitor && s.has_source && s.kind !== "ephemeral";
+  if (monitorable) {
     const running = isLiveMonitorState(s.monitor_state);
-    const row = el("div", { class: "server-row" },
-      el("span", { class: "health-dot" + (s.connected ? " ok" : ""), title: s.connected ? "connected" : "not connected yet" }),
-      el("span", { class: "srv-name" }, serverLabel(s)),
-      s.kind === "ephemeral" ? el("span", { class: "badge cli", title: "From --index-dsn; managed by the command line" }, "CLI") : null,
-      s.reconstruct ? el("span", { class: "badge tt", title: "Baseline configured: Time-travel available" }, "TT") : null,
-      s.monitor_state ? el("span", {
-        class: "badge mon-" + s.monitor_state,
-        title: MON_STATE_TITLES[s.monitor_state] || ("monitoring " + s.monitor_state),
-      }, s.monitor_state.replace("_", " ").toUpperCase()) : null,
-      el("span", { class: "srv-desc" }, desc),
-      el("span", { class: "srv-status", id: "srv-status-" + s.id }),
-      monitorable ? el("button", {
-        type: "button", class: "row-btn" + (running ? "" : " primaryish"),
-        onclick: () => (running ? stopMonitorRow(s.id) : startMonitorRow(s.id)),
-      }, running ? "Stop" : "Start") : null,
-      el("button", { type: "button", class: "row-btn", onclick: () => testServerRow(s.id) }, "Test"),
-      el("button", { type: "button", class: "row-btn", disabled: s.editable ? null : "", onclick: () => editServer(s.id) }, "Edit"),
-      el("button", { type: "button", class: "row-btn danger", disabled: s.deletable ? null : "", onclick: () => deleteServer(s) }, "Delete"),
-    );
-    list.appendChild(row);
-  });
-}
-
-// renderDoctor paints the preflight report as remediation cards inside the
-// form — the 3am operator gets the exact fix, not a log pointer.
-function renderDoctor(report) {
-  const c = document.getElementById("doctor-cards");
-  clear(c);
-  if (!report || !report.checks) return;
-  report.checks.forEach((chk) => {
-    const mark = chk.status === "pass" ? "✓" : chk.status === "fail" ? "✗" : chk.status === "warn" ? "!" : "–";
-    c.appendChild(el("div", { class: "doctor-card " + chk.status },
-      el("span", { class: "dc-mark" }, mark),
-      el("div", { class: "dc-body" },
-        el("div", { class: "dc-name" }, chk.name + (chk.detail ? " — " + chk.detail : "")),
-        chk.remediation ? el("pre", { class: "dc-rem" }, chk.remediation) : null)));
-  });
-}
-
-// startMonitor runs the doctor-then-stream flow for one entry and reports the
-// outcome. Returns the start response (or null on transport error).
-async function startMonitor(id) {
-  try {
-    return await api("/api/servers/" + encodeURIComponent(id) + "/monitor/start", { method: "POST", body: {} });
-  } catch (err) {
-    toast("start failed: " + (err.message || err));
-    return null;
+    acts.append(el("button", { class: "btn btn-sm" + (running ? "" : " btn-primary"), type: "button", text: running ? "Stop" : "Start",
+      onclick: () => running ? stopMonitorRow(s.id) : startMonitorRow(s.id) }));
   }
+  acts.append(el("button", { class: "btn btn-sm", type: "button", text: "Test", onclick: () => testServerRow(s.id) }));
+  acts.append(el("button", { class: "btn btn-sm btn-ghost", type: "button", text: "Edit", disabled: !s.editable, onclick: () => editServer(s.id) }));
+  acts.append(el("button", { class: "btn btn-sm btn-ghost", type: "button", text: "Delete", disabled: !s.deletable, onclick: () => deleteServer(s) }));
+  item.append(acts);
+  return item;
 }
 
-async function startMonitorRow(id) {
-  const slot = document.getElementById("srv-status-" + id);
-  if (slot) slot.textContent = "running checks…";
-  const res = await startMonitor(id);
-  await refreshServersList();
-  if (!res) return;
-  if (res.started) {
-    if (doctorWarnings(res.doctor)) {
-      // Warnings never block (started already), but they must be SEEN —
-      // e.g. "this looks like a replica of an already-monitored server".
-      // If the editor cannot open (server deleted concurrently), don't
-      // render into a hidden form — degrade to a toast.
-      if (await editServer(id)) {
-        renderDoctor(res.doctor);
-        formMsg("monitoring started — review the warnings below", false);
-      } else {
-        toast("Monitoring started with warnings — edit the server to review them");
-      }
-    } else {
-      toast("Monitoring started");
-    }
-  } else {
-    // Preflight failed — open the editor so the remediation cards are visible.
-    if (await editServer(id)) {
-      renderDoctor(res.doctor);
-      formMsg("preflight failed — fix the items below, Save, and Start again", true);
-    }
-  }
+// server form (add/edit) ------------------------------------------------------
+
+// srvField builds a labeled input row: <label class="field"><span/><input/></label>.
+function srvField(label, name, opts) {
+  opts = opts || {};
+  return el("label", { class: "field" },
+    el("span", { class: "field-label", text: label }),
+    el("input", { class: "input", name, type: opts.type || "text", placeholder: opts.placeholder || "", autocomplete: opts.autocomplete }));
 }
 
-// doctorWarnings: does the preflight report carry warn cards worth showing?
-function doctorWarnings(report) {
-  return !!(report && report.warnings > 0);
-}
+function buildServerForm() {
+  const form = el("form", { class: "filters", id: "server-form", style: "display:block;margin-top:18px" });
+  form.append(el("input", { type: "hidden", name: "id" }));
 
-async function stopMonitorRow(id) {
-  try {
-    await api("/api/servers/" + encodeURIComponent(id) + "/monitor/stop", { method: "POST", body: {} });
-    toast("Monitoring stopped");
-  } catch (err) {
-    toast("stop failed: " + (err.message || err));
-  }
-  await refreshServersList();
-}
+  const mon = el("fieldset", { class: "form-section", "data-capability": "monitor" });
+  mon.append(el("legend", { class: "form-legend", text: "Monitor a source MySQL" }));
+  mon.append(el("p", { class: "form-hint", text: "Paste the server to watch — bintrail runs the preflight checks, provisions an index for it, and starts streaming. Leave the index section empty; it is created automatically." }));
+  const monGrid = el("div", { class: "form-grid" });
+  monGrid.append(srvField("Source host", "source_host", { placeholder: "db.example.com" }));
+  monGrid.append(srvField("Source port", "source_port", { placeholder: "3306" }));
+  monGrid.append(srvField("Source user", "source_user", { placeholder: "repl" }));
+  monGrid.append(srvField("Source password", "source_password", { type: "password", autocomplete: "new-password" }));
+  monGrid.append(srvField("Schemas", "schemas", { placeholder: "(optional) shop,billing" }));
+  mon.append(monGrid);
+  form.append(mon);
 
-function formMsg(text, isError) {
-  const n = document.getElementById("server-form-msg");
-  n.className = "form-msg " + (isError ? "err" : "ok");
-  n.textContent = text;
+  const idx = el("fieldset", { class: "form-section" });
+  idx.append(el("legend", { class: "form-legend", text: "Index connection" }));
+  const idxGrid = el("div", { class: "form-grid" });
+  idxGrid.append(srvField("Name", "name", { placeholder: "prod-db-01" }));
+  idxGrid.append(srvField("Host", "host", { placeholder: "127.0.0.1" }));
+  idxGrid.append(srvField("Port", "port", { placeholder: "3306" }));
+  idxGrid.append(srvField("User", "user", { placeholder: "bintrail" }));
+  idxGrid.append(srvField("Password", "password", { type: "password", autocomplete: "new-password" }));
+  idxGrid.append(srvField("Index database", "dbname", { placeholder: "binlog_index" }));
+  idxGrid.append(srvField("Baseline dir", "baseline_dir", { placeholder: "(optional) enables Time-travel" }));
+  idxGrid.append(srvField("Baseline S3", "baseline_s3", { placeholder: "s3://bucket/prefix/" }));
+  idx.append(idxGrid);
+  idx.append(el("label", { class: "check", style: "margin-top:10px" },
+    el("input", { type: "checkbox", name: "no_archive" }), el("span", { text: "Disable archive auto-discovery" })));
+  form.append(idx);
+
+  const foot = el("div", { class: "modal-foot filter-actions" });
+  foot.append(el("button", { class: "btn btn-primary", type: "submit", text: "Save" }));
+  foot.append(el("button", { class: "btn", type: "button", id: "server-test", text: "Test connection" }));
+  foot.append(el("button", { class: "btn btn-ghost", type: "button", id: "server-cancel", text: "Cancel" }));
+  form.append(foot);
+  form.append(el("div", { id: "server-form-msg", class: "form-msg" }));
+  form.append(el("div", { id: "doctor-cards", class: "doctor-cards" }));
+  return form;
 }
 
 function showServerForm(prefill) {
-  const f = document.getElementById("server-form");
-  f.reset();
-  formMsg("", false);
-  clear(document.getElementById("doctor-cards"));
-  f.elements.id.value = prefill ? prefill.id : "";
-  if (prefill) {
-    f.elements.name.value = prefill.name || "";
-    f.elements.host.value = prefill.host || "";
-    f.elements.port.value = prefill.port || "";
-    f.elements.user.value = prefill.user || "";
-    f.elements.dbname.value = prefill.dbname || "";
-    f.elements.baseline_dir.value = prefill.baseline_dir || "";
-    f.elements.baseline_s3.value = prefill.baseline_s3 || "";
-    f.elements.no_archive.checked = !!prefill.no_archive;
-    f.elements.password.placeholder = prefill.has_password ? "(unchanged — leave blank to keep)" : "(none)";
-    f.elements.source_host.value = prefill.source_host || "";
-    f.elements.source_port.value = prefill.source_port || "";
-    f.elements.source_user.value = prefill.source_user || "";
-    f.elements.schemas.value = prefill.schemas || "";
-    f.elements.source_password.placeholder = prefill.has_source_password ? "(unchanged — leave blank to keep)" : "";
-  } else {
-    f.elements.password.placeholder = "";
-    f.elements.source_password.placeholder = "";
-  }
   document.getElementById("server-add-wrap").hidden = true;
-  f.hidden = false;
-  f.elements.name.focus();
-}
+  const mountEl = document.getElementById("server-form-mount");
+  const form = buildServerForm();
+  mountEl.replaceChildren(form);
+  $all("[data-capability]", form).forEach((n) => n.classList.toggle("cap-on", !!capsCache[n.dataset.capability]));
+  $("#server-cancel", form).addEventListener("click", hideServerForm);
+  $("#server-test", form).addEventListener("click", () => testServerForm(form));
+  form.addEventListener("submit", (e) => { e.preventDefault(); saveServer(form); });
 
+  if (prefill) {
+    form.elements.id.value = prefill.id || "";
+    ["name", "host", "port", "user", "dbname", "baseline_dir", "baseline_s3", "source_host", "source_port", "source_user", "schemas"].forEach((k) => {
+      if (form.elements[k] && prefill[k] != null) form.elements[k].value = prefill[k];
+    });
+    if (form.elements.no_archive) form.elements.no_archive.checked = !!prefill.no_archive;
+    form.elements.password.placeholder = prefill.has_password ? "(unchanged — leave blank to keep)" : "(none)";
+    form.elements.source_password.placeholder = prefill.has_source_password ? "(unchanged — leave blank to keep)" : "";
+  }
+  form.elements.name.focus();
+}
 function hideServerForm() {
-  document.getElementById("server-form").hidden = true;
-  document.getElementById("server-add-wrap").hidden = false;
+  document.getElementById("server-form-mount").replaceChildren();
+  const addWrap = document.getElementById("server-add-wrap");
+  if (addWrap) addWrap.hidden = false;
 }
 
-// editServer opens the editor form for a server; returns true when the form
-// is actually showing (callers that render into it must not assume success —
-// the server may have been deleted concurrently).
+function formMsg(text, isError) {
+  const m = document.getElementById("server-form-msg");
+  if (!m) return;
+  m.className = "form-msg " + (isError ? "err" : "ok");
+  m.textContent = text;
+}
+
+// keep-password semantics: omit password fields when blank (= keep stored).
+function serverFormBody(form) {
+  const f = form.elements;
+  const body = {
+    name: f.name.value.trim(),
+    host: f.host.value.trim(), port: f.port.value.trim(), user: f.user.value.trim(), dbname: f.dbname.value.trim(),
+    baseline_dir: f.baseline_dir.value.trim(), baseline_s3: f.baseline_s3.value.trim(),
+    no_archive: !!f.no_archive.checked,
+    source_host: f.source_host.value.trim(), source_port: f.source_port.value.trim(),
+    source_user: f.source_user.value.trim(), schemas: f.schemas.value.trim(),
+  };
+  if (f.password.value !== "") body.password = f.password.value;
+  if (f.source_password.value !== "") body.source_password = f.source_password.value;
+  return body;
+}
+
 async function editServer(id) {
   try {
     const s = await api("/api/servers/" + encodeURIComponent(id));
     showServerForm(s);
     return true;
-  } catch (err) {
-    toast("failed to load server: " + (err.message || err));
-    return false;
-  }
+  } catch (err) { toast("failed to load server: " + ((err && err.message) || err)); return false; }
 }
 
-// serverFormBody collects the form into a request body. The password is only
-// included when the operator typed one — an omitted password means "keep the
-// stored secret" on edit (the server merges it; the browser never sees it).
-function serverFormBody(f) {
-  const body = {
-    name: f.elements.name.value.trim(),
-    host: f.elements.host.value.trim(),
-    port: f.elements.port.value.trim(),
-    user: f.elements.user.value.trim(),
-    dbname: f.elements.dbname.value.trim(),
-    baseline_dir: f.elements.baseline_dir.value.trim(),
-    baseline_s3: f.elements.baseline_s3.value.trim(),
-    no_archive: f.elements.no_archive.checked,
-    source_host: f.elements.source_host.value.trim(),
-    source_port: f.elements.source_port.value.trim(),
-    source_user: f.elements.source_user.value.trim(),
-    schemas: f.elements.schemas.value.trim(),
-  };
-  if (f.elements.password.value !== "") body.password = f.elements.password.value;
-  if (f.elements.source_password.value !== "") body.source_password = f.elements.source_password.value;
-  return body;
-}
-
-async function saveServer(e) {
-  e.preventDefault();
-  const f = e.target;
-  const id = f.elements.id.value;
+async function saveServer(form) {
+  const id = form.elements.id.value;
+  const body = serverFormBody(form);
   let saved;
   try {
-    if (id) {
-      saved = await api("/api/servers/" + encodeURIComponent(id), { method: "PUT", body: serverFormBody(f) });
-    } else {
-      saved = await api("/api/servers", { method: "POST", body: serverFormBody(f) });
-    }
-  } catch (err) {
-    formMsg(err.message || String(err), true);
-    return;
-  }
+    saved = await api(id ? "/api/servers/" + encodeURIComponent(id) : "/api/servers", { method: id ? "PUT" : "POST", body });
+  } catch (err) { formMsg((err && err.message) || String(err), true); return; }
 
-  // The zero-terminal flow: a saved server with a source goes straight into
-  // doctor → stream (auto-start on green). The form stays open on a failed
-  // preflight so the remediation cards are right there.
+  // Zero-terminal auto-start: a monitor-capable process with a source DSN starts
+  // streaming on save (after preflight). Doctor warnings keep the form open.
   if (capsCache.monitor && saved.has_source && !isLiveMonitorState(saved.monitor_state)) {
     formMsg("running preflight checks…", false);
     const res = await startMonitor(saved.id);
     await refreshServersList();
-    if (res && res.started && !doctorWarnings(res.doctor)) {
-      hideServerForm();
-      toast("Monitoring started — events will appear within a minute");
-    } else if (res && res.started) {
-      // Started, but with warn cards (e.g. replica-of-monitored) — keep the
-      // form open so the operator actually sees them.
-      renderDoctor(res.doctor);
-      formMsg("monitoring started — review the warnings below", false);
-    } else if (res) {
-      renderDoctor(res.doctor);
-      formMsg("preflight failed — fix the items below and Save again", true);
-    }
+    if (res && res.started && !doctorWarnings(res.doctor)) { hideServerForm(); toast("Monitoring started — events will appear within a minute"); }
+    else if (res && res.started) { renderDoctor(res.doctor); formMsg("monitoring started — review the warnings below", false); }
+    else if (res) { renderDoctor(res.doctor); formMsg("preflight failed — fix the items below and Save again", true); }
     return;
   }
-
   hideServerForm();
   await refreshServersList();
   toast(id ? "Server updated" : "Server added");
 }
 
 async function deleteServer(s) {
-  if (!window.confirm(`Remove server "${s.name}"? This only removes the saved connection — nothing happens to the server itself.`)) return;
-  try {
-    await api("/api/servers/" + encodeURIComponent(s.id), { method: "DELETE" });
-    if (currentServer === s.id) {
-      await switchServer(""); // deleted the selected server → back to default
-      document.getElementById("server-select").value = defaultServerId;
-    }
-    await refreshServersList();
-    toast("Server removed");
-  } catch (err) {
-    toast("delete failed: " + (err.message || err));
-  }
+  if (!window.confirm('Remove server "' + s.name + '"? This only removes the saved connection — nothing happens to the server itself.')) return;
+  try { await api("/api/servers/" + encodeURIComponent(s.id), { method: "DELETE" }); }
+  catch (err) { toast("delete failed: " + ((err && err.message) || err)); return; }
+  if (currentServer === s.id) { await switchServer(""); const sel = document.getElementById("server-select"); if (sel) sel.value = defaultServerId; }
+  await refreshServersList();
+  toast("Server removed");
 }
+
+// test / doctor / monitor -----------------------------------------------------
 
 function testResultText(res) {
   if (!res.ok) return "✗ " + (res.error || "unreachable");
-  let txt = `✓ ok · ${res.latency_ms} ms`;
-  if (res.server_version) txt += " · MySQL " + res.server_version;
-  // has_index/schema_current are tri-state: absent means the metadata lookup
-  // itself failed (unknown) — never render that as the confident negative.
-  if (res.has_index === false) txt += " · no binlog_events table (not a bintrail index?)";
-  else if (res.has_index === undefined || res.schema_current === undefined) txt += " · index metadata unavailable";
-  else if (res.schema_current === false) txt += " · index schema outdated (run bintrail index/stream once)";
-  return txt;
+  let s = "✓ ok · " + res.latency_ms + " ms";
+  if (res.server_version) s += " · MySQL " + res.server_version;
+  // has_index/schema_current are tri-state: absent = the metadata lookup itself
+  // failed (unknown) — never render that as the confident negative.
+  if (res.has_index === false) s += " · no binlog_events table (not a bintrail index?)";
+  else if (res.has_index === undefined || res.schema_current === undefined) s += " · index metadata unavailable";
+  else if (res.schema_current === false) s += " · index schema outdated (run bintrail index/stream once)";
+  return s;
 }
 
-// testServerForm probes the (possibly unsaved) form values; with an id the
-// backend merges the stored password when the field was left blank.
-async function testServerForm() {
-  const f = document.getElementById("server-form");
-  const id = f.elements.id.value;
-  const path = id ? "/api/servers/" + encodeURIComponent(id) + "/test" : "/api/servers/test";
+async function testServerForm(form) {
+  const id = form.elements.id.value;
+  const body = serverFormBody(form);
   formMsg("testing…", false);
   try {
-    const res = await api(path, { method: "POST", body: serverFormBody(f) });
+    const res = await api(id ? "/api/servers/" + encodeURIComponent(id) + "/test" : "/api/servers/test", { method: "POST", body });
     formMsg(testResultText(res), !res.ok);
-  } catch (err) {
-    formMsg(err.message || String(err), true);
-  }
+  } catch (err) { formMsg((err && err.message) || String(err), true); }
 }
 
-// testServerRow probes a saved entry as-is (no body → stored DSN).
 async function testServerRow(id) {
   const slot = document.getElementById("srv-status-" + id);
-  if (slot) slot.textContent = "testing…";
+  if (slot) { slot.className = "srv-status"; slot.textContent = "testing…"; }
   try {
     const res = await api("/api/servers/" + encodeURIComponent(id) + "/test", { method: "POST", body: {} });
-    if (slot) {
-      slot.textContent = testResultText(res);
-      slot.className = "srv-status " + (res.ok ? "ok" : "err");
-    }
-  } catch (err) {
-    if (slot) {
-      slot.textContent = "✗ " + (err.message || err);
-      slot.className = "srv-status err";
-    }
-  }
+    if (slot) { slot.className = "srv-status " + (res.ok ? "ok" : "err"); slot.textContent = testResultText(res); }
+  } catch (err) { if (slot) { slot.className = "srv-status err"; slot.textContent = "✗ " + ((err && err.message) || err); } }
 }
 
-// ── wiring ───────────────────────────────────────────────────────────────────
-function init() {
-  document.querySelectorAll(".tab").forEach((t) => {
-    t.addEventListener("click", () => {
-      document.querySelectorAll(".tab").forEach((x) => x.classList.remove("active"));
-      document.querySelectorAll(".panel").forEach((x) => x.classList.remove("active"));
-      t.classList.add("active");
-      document.getElementById(t.dataset.panel).classList.add("active");
-    });
-  });
+function doctorWarnings(report) { return !!(report && report.warnings > 0); }
 
-  document.getElementById("events-form").addEventListener("submit", runEvents);
-  document.getElementById("recover-form").addEventListener("submit", generateUndo);
-  document.querySelector("#recover-form .preview-btn").addEventListener("click", previewRecover);
-  document.getElementById("copy-sql").addEventListener("click", copySQL);
-  document.getElementById("download-sql").addEventListener("click", downloadSQL);
-  document.getElementById("status-refresh").addEventListener("click", refreshStatus);
-
-  document.getElementById("reconstruct-form").addEventListener("submit", (e) => {
-    e.preventDefault();
-    runReconstruct(false);
+function renderDoctor(report) {
+  const box = document.getElementById("doctor-cards");
+  if (!box) return;
+  clear(box);
+  if (!report || !report.checks) return;
+  report.checks.forEach((chk) => {
+    const status = ["pass", "fail", "warn"].includes(chk.status) ? chk.status : "skip";
+    const mark = { pass: "✓", fail: "✗", warn: "!", skip: "–" }[status];
+    const card = el("div", { class: "doctor-card " + status });
+    card.append(el("span", { class: "dc-mark", text: mark }));
+    const bodyEl = el("div", { class: "dc-body" }, el("div", { class: "dc-name", text: chk.name + (chk.detail ? " — " + chk.detail : "") }));
+    if (chk.remediation) bodyEl.append(el("pre", { class: "dc-rem", text: chk.remediation }));
+    card.append(bodyEl);
+    box.append(card);
   });
-  document.querySelector("#reconstruct-form .preview-btn").addEventListener("click", () => runReconstruct(true));
+}
 
-  document.querySelectorAll(".schema-select").forEach((sel) => {
-    sel.addEventListener("change", () => loadTables(sel.closest("form")));
-  });
+async function startMonitor(id) {
+  try { return await api("/api/servers/" + encodeURIComponent(id) + "/monitor/start", { method: "POST", body: {} }); }
+  catch (err) { toast("start failed: " + ((err && err.message) || err)); return null; }
+}
 
-  // Server switcher + management modal.
-  document.getElementById("server-select").addEventListener("change", (e) => {
-    switchServer(e.target.value);
+async function startMonitorRow(id) {
+  const slot = document.getElementById("srv-status-" + id);
+  if (slot) { slot.className = "srv-status"; slot.textContent = "running checks…"; }
+  const res = await startMonitor(id);
+  await refreshServersList();
+  if (!res) return;
+  if (res.started && !doctorWarnings(res.doctor)) { toast("Monitoring started"); return; }
+  const opened = await editServer(id);
+  if (opened) {
+    renderDoctor(res.doctor);
+    formMsg(res.started ? "monitoring started — review the warnings below" : "preflight failed — fix the items below, Save, and Start again", !res.started);
+  } else { toast(res.started ? "Monitoring started — with warnings" : "Preflight failed"); }
+}
+
+async function stopMonitorRow(id) {
+  try { await api("/api/servers/" + encodeURIComponent(id) + "/monitor/stop", { method: "POST", body: {} }); toast("Monitoring stopped"); }
+  catch (err) { toast("stop failed: " + ((err && err.message) || err)); }
+  await refreshServersList();
+}
+
+// ── command palette (⌘K) ──────────────────────────────────────────────────
+
+let cmdkSel = 0, cmdkItems = [];
+
+function cmdkCommands() {
+  const cmds = [
+    { group: "Navigate", label: "Overview", run: () => navigate("overview") },
+    { group: "Navigate", label: "Events", run: () => navigate("events") },
+    { group: "Navigate", label: "Recover", run: () => navigate("recover") },
+    { group: "Navigate", label: "Status", run: () => navigate("status") },
+  ];
+  if (capsCache.reconstruct) cmds.push({ group: "Navigate", label: "Time-travel", run: () => navigate("timetravel") });
+  cmds.push({ group: "Actions", label: "Manage servers", run: () => { closeCmdk(); openServersModal(); } });
+  cmds.push({ group: "Actions", label: "Search events for…", hint: "type then ↵", search: true });
+  return cmds;
+}
+
+function openCmdk() {
+  const mount = document.getElementById("cmdk-mount");
+  clear(mount);
+  const scrim = el("div", { class: "cmdk-scrim open" });
+  const panel = el("div", { class: "cmdk", role: "dialog", "aria-label": "Commands" });
+  const top = el("div", { class: "cmdk-top" });
+  top.append(icon("search"));
+  const q = el("input", { class: "cmdk-q", id: "cmdk-q", placeholder: "Search commands, or type to find events…", autocomplete: "off", spellcheck: "false" });
+  top.append(q);
+  top.append(el("span", { class: "cmdk-escpill", text: "esc" }));
+  panel.append(top);
+  panel.append(el("div", { class: "cmdk-list", id: "cmdk-list" }));
+  scrim.append(panel);
+  scrim.addEventListener("click", (e) => { if (e.target === scrim) closeCmdk(); });
+  mount.append(scrim);
+  q.addEventListener("input", () => renderCmdk(q.value));
+  q.addEventListener("keydown", cmdkKeydown);
+  renderCmdk("");
+  q.focus();
+}
+function closeCmdk() { document.getElementById("cmdk-mount").replaceChildren(); }
+
+function renderCmdk(query) {
+  const list = document.getElementById("cmdk-list");
+  if (!list) return;
+  const q = (query || "").toLowerCase().trim();
+  let cmds = cmdkCommands();
+  if (q) cmds = cmds.filter((c) => c.search || c.label.toLowerCase().includes(q));
+  cmdkItems = cmds; cmdkSel = 0;
+  clear(list);
+  if (!cmds.length) { list.append(el("div", { class: "cmdk-empty", text: "No commands match." })); return; }
+  let group = null;
+  cmds.forEach((c, i) => {
+    if (c.group !== group) { group = c.group; list.append(el("div", { class: "cmdk-group", text: group })); }
+    const item = el("button", { class: "cmdk-item" + (i === cmdkSel ? " sel" : ""), type: "button",
+      "data-idx": i, onclick: () => runCmdk(c, query) });
+    item.append(icon("search", "cmdk-ic"));
+    item.append(el("span", { class: "cmdk-label", text: c.search && q ? 'Search events: "' + query.trim() + '"' : c.label }));
+    if (c.hint) item.append(el("span", { class: "cmdk-hint", text: c.hint }));
+    list.append(item);
   });
+}
+function runCmdk(c, query) {
+  if (c.search) { closeCmdk(); navigate("events", query && query.trim() ? { q: query.trim() } : null); return; }
+  closeCmdk(); c.run();
+}
+function cmdkKeydown(e) {
+  const list = document.getElementById("cmdk-list");
+  if (e.key === "Escape") { closeCmdk(); return; }
+  if (e.key === "ArrowDown") { e.preventDefault(); cmdkSel = Math.min(cmdkItems.length - 1, cmdkSel + 1); }
+  else if (e.key === "ArrowUp") { e.preventDefault(); cmdkSel = Math.max(0, cmdkSel - 1); }
+  else if (e.key === "Enter") { e.preventDefault(); const c = cmdkItems[cmdkSel]; if (c) runCmdk(c, e.target.value); return; }
+  else return;
+  $all(".cmdk-item", list).forEach((n) => n.classList.toggle("sel", Number(n.dataset.idx) === cmdkSel));
+  const sel = $(".cmdk-item.sel", list); if (sel) sel.scrollIntoView({ block: "nearest" });
+}
+
+// ── global keyboard ──────────────────────────────────────────────────────────
+
+function globalKeydown(e) {
+  // ⌘K / Ctrl+K opens the palette anywhere.
+  if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") { e.preventDefault(); openCmdk(); return; }
+  // j/k/↵/u row nav — only on Events, only when not typing in a field.
+  const typing = /^(INPUT|TEXTAREA|SELECT)$/.test(document.activeElement && document.activeElement.tagName);
+  if (typing || routeFromLocation() !== "events") return;
+  const rows = $all(".ev-row", VIEW());
+  if (e.key === "j") { e.preventDefault(); moveCursor(1); }
+  else if (e.key === "k") { e.preventDefault(); moveCursor(-1); }
+  else if (e.key === "Enter") { if (cursorIdx >= 0 && rows[cursorIdx]) { e.preventDefault(); rows[cursorIdx].click(); } }
+  else if (e.key === "u") { if (cursorIdx >= 0 && lastEvents[cursorIdx]) { e.preventDefault(); undoEvent(lastEvents[cursorIdx]); } }
+}
+
+// ── init ─────────────────────────────────────────────────────────────────────
+
+async function init() {
+  document.getElementById("server-select").addEventListener("change", (e) => switchServer(e.target.value));
   document.getElementById("manage-servers").addEventListener("click", openServersModal);
-  document.getElementById("servers-close").addEventListener("click", closeServersModal);
-  document.getElementById("servers-modal").addEventListener("click", (e) => {
-    if (e.target === e.currentTarget) closeServersModal(); // click on the backdrop
-  });
-  document.getElementById("server-add").addEventListener("click", () => showServerForm(null));
-  document.getElementById("server-form").addEventListener("submit", saveServer);
-  document.getElementById("server-cancel").addEventListener("click", hideServerForm);
-  document.getElementById("server-test").addEventListener("click", testServerForm);
+  document.getElementById("open-cmdk").addEventListener("click", openCmdk);
+  document.addEventListener("keydown", globalKeydown);
 
-  if (!TOKEN) {
-    toast("No token in URL — open the link printed by `bintrail console`.");
-  }
-  // Load the server list first so a stale per-tab selection is reconciled
-  // before the capability gate and schema dropdowns fire against it.
-  (async () => {
-    let servers = [];
-    try { servers = await loadServers(); } catch (e) { /* default server still works */ }
-    await gateCapabilities();
-    populateSchemas();
-    // First-run onboarding: on a supervisor with nothing watched yet, the
-    // Servers screen IS the next step — open it so "+ Add server" is the
-    // first thing the operator sees (once per tab).
-    const ONBOARD_KEY = "bintrail_console_onboarded";
+  // Sidebar nav (real hrefs upgraded to in-place swaps). A manual nav starts
+  // fresh — clear any carried "Undo" context so the sidebar's Recover link
+  // never shows a stale banner (the undoEvent bridge sets it and navigates
+  // directly, bypassing this handler, so its context survives).
+  $all(".nav-item").forEach((a) => a.addEventListener("click", (e) => { e.preventDefault(); pendingRecover = null; navigate(a.dataset.route); }));
+  window.addEventListener("popstate", renderRoute);
+
+  if (!TOKEN) toast("No token in URL — open the link printed by `bintrail console`.");
+
+  // Startup order is load-bearing: servers (reconcile selection) → caps → route.
+  let servers = [];
+  try { servers = await loadServers(); } catch (err) { renderError(VIEW(), err); }
+  await gateCapabilities();
+  renderRoute();
+
+  // First-run onboarding: a monitor-capable process with no source yet opens the
+  // servers modal once per tab so the operator can add one without a terminal.
+  try {
     if (capsCache.monitor && servers.every((s) => !s.has_source) && !sessionStorage.getItem(ONBOARD_KEY)) {
-      try { sessionStorage.setItem(ONBOARD_KEY, "1"); } catch (e) { /* storage unavailable */ }
+      sessionStorage.setItem(ONBOARD_KEY, "1");
       openServersModal();
     }
-  })();
+  } catch (_) {}
 }
 
-document.addEventListener("DOMContentLoaded", init);
+if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", init);
+else init();

--- a/internal/console/assets/index.html
+++ b/internal/console/assets/index.html
@@ -1,183 +1,111 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-dir="studio" data-accent="blue">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>bintrail console</title>
   <link rel="icon" type="image/png" href="favicon.png">
   <link rel="stylesheet" href="style.css">
+  <style>
+    /* Row click toggles .open on the .ev-row to reveal its adjacent diff.
+       Kept as CSS (not JS style toggling) so the caret rotation and the
+       reveal stay declarative. */
+    .diff-wrap { display: none; }
+    .ev-row.open + .diff-wrap { display: block; }
+  </style>
 </head>
 <body>
-  <header>
-    <div class="brand">
-      <img class="logo" src="logo.png" alt="bintrail">
-      <span class="sub">console</span>
-      <span class="readonly" title="This console never executes SQL against your data.">read-only</span>
-      <div class="server-ctl">
-        <select id="server-select" title="Active server"></select>
-        <button type="button" id="manage-servers" title="Add, edit, or remove servers">Servers</button>
-      </div>
-    </div>
-    <nav id="tabs">
-      <button class="tab active" data-panel="recover">Recover</button>
-      <button class="tab" data-panel="events">Events</button>
-      <button class="tab" data-panel="status">Status</button>
-      <button class="tab" data-panel="reconstruct" data-capability="reconstruct">Time-travel</button>
-    </nav>
-  </header>
-
-  <main>
-    <!-- ── Recover ─────────────────────────────────────────────── -->
-    <section id="recover" class="panel active">
-      <p class="hint">Filter the changes you want to undo, preview the affected
-        rows, then generate reversal SQL. Nothing is ever executed — copy or
-        download the script and apply it yourself after review.</p>
-      <form id="recover-form" class="filters">
-        <label>Schema
-          <select name="schema" class="schema-select" required></select>
-        </label>
-        <label>Table
-          <select name="table" class="table-select"></select>
-        </label>
-        <label>PK <input name="pk" placeholder="e.g. 42 or 42|7"></label>
-        <label>Since <input name="since" placeholder="YYYY-MM-DD HH:MM:SS"></label>
-        <label>Until <input name="until" placeholder="YYYY-MM-DD HH:MM:SS"></label>
-        <div class="actions">
-          <button type="submit" class="primary">Generate undo SQL</button>
-          <button type="button" class="preview-btn">Preview affected rows</button>
+  <div id="app">
+    <aside class="side">
+      <div class="brand">
+        <div class="brand-mark">
+          <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor">
+            <rect x="3" y="14" width="5" height="5" rx="1"></rect>
+            <rect x="9.5" y="9.5" width="5" height="5" rx="1"></rect>
+            <rect x="16" y="5" width="5" height="5" rx="1"></rect>
+          </svg>
         </div>
-      </form>
-      <div id="recover-warnings" class="warnings"></div>
-      <div id="recover-preview"></div>
-      <div id="recover-sql-wrap" hidden>
-        <div class="sql-toolbar">
-          <span id="recover-meta"></span>
-          <span class="spacer"></span>
-          <button type="button" id="copy-sql">Copy</button>
-          <button type="button" id="download-sql">Download</button>
+        <div>
+          <div class="brand-name">bintrail</div>
+          <div class="brand-sub">console</div>
         </div>
-        <pre id="recover-sql"></pre>
+        <span class="ro-pill" title="This console never executes SQL against your data.">read-only</span>
       </div>
-    </section>
 
-    <!-- ── Events ──────────────────────────────────────────────── -->
-    <section id="events" class="panel">
-      <p class="hint">Browse indexed row events with full before/after images.</p>
-      <form id="events-form" class="filters">
-        <label>Schema
-          <select name="schema" class="schema-select"></select>
-        </label>
-        <label>Table
-          <select name="table" class="table-select"></select>
-        </label>
-        <label>PK <input name="pk" placeholder="e.g. 42"></label>
-        <label>Type
-          <select name="event_type">
-            <option value="">any</option>
-            <option>INSERT</option>
-            <option>UPDATE</option>
-            <option>DELETE</option>
-          </select>
-        </label>
-        <label>Changed column <input name="changed_column" placeholder="e.g. email"></label>
-        <label>GTID <input name="gtid" placeholder="uuid:1-100"></label>
-        <label>Since <input name="since" placeholder="YYYY-MM-DD HH:MM:SS"></label>
-        <label>Until <input name="until" placeholder="YYYY-MM-DD HH:MM:SS"></label>
-        <label>Limit <input name="limit" type="number" min="1" placeholder="100"></label>
-        <div class="actions">
-          <button type="submit" class="primary">Run</button>
+      <button class="cmdk-trigger" id="open-cmdk" type="button">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round"><circle cx="11" cy="11" r="7"></circle><path d="M21 21l-4.3-4.3"></path></svg>
+        <span>Search &amp; commands</span>
+        <span class="cmdk-kbd">⌘K</span>
+      </button>
+
+      <div class="srv-block">
+        <div class="nav-label" style="padding-bottom:0">Server</div>
+        <div class="srv-wrap">
+          <span class="srv-dot"></span>
+          <select class="srv-select" id="server-select" title="Active server"></select>
         </div>
-      </form>
-      <div id="events-warnings" class="warnings"></div>
-      <div id="events-result"></div>
-    </section>
-
-    <!-- ── Status ──────────────────────────────────────────────── -->
-    <section id="status" class="panel">
-      <div class="actions">
-        <button type="button" id="status-refresh" class="primary">Refresh status</button>
+        <button class="srv-manage" id="manage-servers" type="button">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" style="width:14px;height:14px"><path d="M12 2v4M12 18v4M4.9 4.9l2.8 2.8M16.3 16.3l2.8 2.8M2 12h4M18 12h4M4.9 19.1l2.8-2.8M16.3 7.7l2.8-2.8"></path><circle cx="12" cy="12" r="3"></circle></svg>
+          <span>Manage servers</span>
+        </button>
       </div>
-      <div id="status-result"></div>
-    </section>
 
-    <!-- ── Time-travel (reconstruct) — only shown when a baseline is configured ── -->
-    <section id="reconstruct" class="panel" data-capability="reconstruct">
-      <p class="hint">Reconstruct a single row's full state as of a point in time
-        — baseline snapshot + binlog deltas. Pick a row and a moment; see its
-        value then, or its complete change history.</p>
-      <form id="reconstruct-form" class="filters">
-        <label>Schema
-          <select name="schema" class="schema-select" required></select>
-        </label>
-        <label>Table
-          <select name="table" class="table-select" required></select>
-        </label>
-        <label>PK <input name="pk" placeholder="e.g. 42 or 42|7" required></label>
-        <label>As of <input name="at" placeholder="YYYY-MM-DD HH:MM:SS (default: now)"></label>
-        <label class="checkbox"><input type="checkbox" name="allow_gaps"> Allow coverage gaps</label>
-        <div class="actions">
-          <button type="submit" class="primary" data-mode="at">Value as of T</button>
-          <button type="button" class="preview-btn" data-mode="history">Full history</button>
+      <nav class="nav" id="nav">
+        <div class="nav-group">
+          <a class="nav-item" data-route="overview" href="/overview">
+            <span class="ni-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="9" rx="1.5"/><rect x="14" y="3" width="7" height="5" rx="1.5"/><rect x="14" y="12" width="7" height="9" rx="1.5"/><rect x="3" y="16" width="7" height="5" rx="1.5"/></svg></span>
+            <span>Overview</span>
+          </a>
         </div>
-      </form>
-      <div id="reconstruct-warnings" class="warnings"></div>
-      <div id="reconstruct-result"></div>
-    </section>
-  </main>
-
-  <!-- ── Servers modal — manage the local connection registry ── -->
-  <div id="servers-modal" class="modal" hidden>
-    <div class="modal-dialog">
-      <div class="modal-head">
-        <h2>Servers</h2>
-        <span class="spacer"></span>
-        <button type="button" id="servers-close" class="modal-close" title="Close">&times;</button>
-      </div>
-      <p class="hint">Named connections to bintrail index databases, stored in a
-        local file on the console host.
-        <span data-capability="monitor">This process can also <strong>monitor</strong>
-        a source MySQL: add one below and bintrail runs the preflight checks,
-        provisions an index for it, and starts streaming — no terminal
-        needed.</span></p>
-      <div id="servers-list"></div>
-      <div class="actions" id="server-add-wrap">
-        <button type="button" id="server-add" class="primary">+ Add server</button>
-      </div>
-      <form id="server-form" class="filters server-form" hidden>
-        <input type="hidden" name="id">
-        <label>Name <input name="name" required placeholder="prod-db-01"></label>
-        <fieldset class="form-fieldset" data-capability="monitor">
-          <legend>Monitor a source MySQL</legend>
-          <p class="fieldset-hint">Paste the server to watch — bintrail runs the
-            preflight checks, provisions an index for it, and starts streaming.
-            Leave the index section empty; it is created automatically.</p>
-          <label>Source host <input name="source_host" placeholder="db.example.com"></label>
-          <label>Source port <input name="source_port" type="number" min="1" max="65535" placeholder="3306"></label>
-          <label>Source user <input name="source_user" placeholder="repl"></label>
-          <label>Source password <input name="source_password" type="password" autocomplete="new-password"></label>
-          <label>Schemas <input name="schemas" placeholder="(optional) shop,billing"></label>
-        </fieldset>
-        <fieldset class="form-fieldset">
-          <legend>Index connection</legend>
-          <label>Host <input name="host" placeholder="127.0.0.1"></label>
-          <label>Port <input name="port" type="number" min="1" max="65535" placeholder="3306"></label>
-          <label>User <input name="user" placeholder="bintrail"></label>
-          <label>Password <input name="password" type="password" autocomplete="new-password"></label>
-          <label>Index database <input name="dbname" placeholder="binlog_index"></label>
-          <label>Baseline dir <input name="baseline_dir" placeholder="(optional) enables Time-travel"></label>
-          <label>Baseline S3 <input name="baseline_s3" placeholder="s3://bucket/prefix/"></label>
-          <label class="checkbox"><input type="checkbox" name="no_archive"> Disable archive auto-discovery</label>
-        </fieldset>
-        <div class="actions">
-          <button type="submit" class="primary">Save</button>
-          <button type="button" id="server-test">Test connection</button>
-          <button type="button" id="server-cancel">Cancel</button>
+        <div class="nav-group">
+          <div class="nav-label">Investigate</div>
+          <a class="nav-item" data-route="events" href="/events">
+            <span class="ni-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 6h13M8 12h13M8 18h13"/><circle cx="3.5" cy="6" r="1.2"/><circle cx="3.5" cy="12" r="1.2"/><circle cx="3.5" cy="18" r="1.2"/></svg></span>
+            <span>Events</span>
+          </a>
+          <a class="nav-item" data-route="timetravel" href="/timetravel" data-capability="reconstruct">
+            <span class="ni-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 5v5h5"/><path d="M3.5 10a9 9 0 1 1-.7 4"/><path d="M12 8v4l3 2"/></svg></span>
+            <span>Time-travel</span>
+          </a>
         </div>
-        <div id="server-form-msg" class="form-msg"></div>
-        <div id="doctor-cards"></div>
-      </form>
-    </div>
+        <div class="nav-group">
+          <div class="nav-label">Resolve</div>
+          <a class="nav-item" data-route="recover" href="/recover">
+            <span class="ni-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7v6h6"/><path d="M3 13a9 9 0 1 0 3-7.7L3 8"/></svg></span>
+            <span>Recover</span>
+          </a>
+        </div>
+        <div class="nav-group">
+          <div class="nav-label">Monitor</div>
+          <a class="nav-item" data-route="status" href="/status">
+            <span class="ni-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12h4l2.5 7 5-14L17 12h4"/></svg></span>
+            <span>Status</span>
+          </a>
+        </div>
+      </nav>
+
+      <div class="side-foot">
+        <a class="side-docs" href="https://www.dbtrail.com/docs/guides/recovery/" target="_blank" rel="noopener">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M4 5a2 2 0 0 1 2-2h13v16H6a2 2 0 0 0-2 2z"></path><path d="M19 17H6a2 2 0 0 0-2 2"></path></svg>
+          <span>Docs · Recovery guide</span>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M14 4h6v6"></path><path d="M20 4l-9 9"></path><path d="M19 14v4a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2h4"></path></svg>
+        </a>
+        <div class="side-meta" id="side-meta">
+          <div><b id="meta-conn">—</b></div>
+          <div id="meta-stream">stream <b>—</b></div>
+        </div>
+      </div>
+    </aside>
+
+    <main class="main">
+      <div class="view" id="view"></div>
+    </main>
   </div>
+
+  <!-- Servers modal mount (built by app.js into a .modal-scrim) -->
+  <div id="modal"></div>
+  <!-- Command palette mount (⌘K) -->
+  <div id="cmdk-mount"></div>
 
   <div id="toast" class="toast" hidden></div>
   <script src="app.js"></script>

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -1,500 +1,1175 @@
+/* ============================================================
+   bintrail console — light, warm redesign
+   Type:  Bricolage Grotesque (display) · Hanken Grotesk (UI) · IBM Plex Mono (data)
+   Accent system: blue (primary) + orange + ochre, on white, warm neutrals.
+   Three directions via [data-dir="paper" | "studio" | "trail"].
+   ============================================================ */
+
 :root {
-  --bg: #0f1117;
-  --panel: #171a23;
-  --panel-2: #1e222e;
-  --border: #2a2f3d;
-  --text: #d7dbe6;
-  --muted: #8b93a7;
-  --accent: #5b9dff;
-  --accent-2: #2b6fd6;
-  --ok: #4ec47a;
-  --warn: #e0b341;
-  --del: #e06c75;
-  --ins: #4ec47a;
-  --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  /* warm neutral surfaces — white-led, never cream */
+  --bg:        #ffffff;
+  --surface:   #ffffff;
+  --surface-2: oklch(0.985 0.003 70);
+  --surface-3: oklch(0.972 0.004 70);
+  --line:      oklch(0.918 0.004 70);
+  --line-soft: oklch(0.948 0.003 70);
+
+  /* warm ink ramp */
+  --ink:   oklch(0.255 0.012 60);
+  --ink-2: oklch(0.46 0.012 60);
+  --ink-3: oklch(0.605 0.010 65);
+  --ink-4: oklch(0.72 0.008 70);
+
+  /* accents */
+  --blue:    oklch(0.575 0.158 252);
+  --blue-2:  oklch(0.515 0.16 252);
+  --blue-bg: oklch(0.962 0.024 252);
+  --orange:  oklch(0.70 0.155 52);
+  --orange-2:oklch(0.635 0.15 48);
+  --orange-bg: oklch(0.965 0.03 60);
+  --ochre:   oklch(0.715 0.105 78);
+  --ochre-bg: oklch(0.97 0.03 85);
+
+  /* semantic (badges + diff) — sacred */
+  --insert:  oklch(0.60 0.135 152);
+  --insert-bg: oklch(0.965 0.04 152);
+  --update:  oklch(0.575 0.155 252);
+  --update-bg: oklch(0.963 0.028 252);
+  --delete:  oklch(0.585 0.185 25);
+  --delete-bg: oklch(0.966 0.03 25);
+
+  --diff-del: oklch(0.555 0.17 22);
+  --diff-add: oklch(0.52 0.12 152);
+
+  /* fonts */
+  --f-display: "Bricolage Grotesque", system-ui, sans-serif;
+  --f-ui: "Hanken Grotesk", system-ui, sans-serif;
+  --f-mono: "IBM Plex Mono", ui-monospace, monospace;
+
+  /* tunables (direction + tweaks drive these) */
+  --radius: 12px;
+  --radius-sm: 8px;
+  --panel-bg: var(--surface-2);
+  --panel-border: var(--line);
+  --panel-shadow: 0 1px 2px oklch(0.6 0.02 60 / 0.04);
+  --accent: var(--blue);
+  --accent-2: var(--blue-2);
+  --accent-bg: var(--blue-bg);
+  --accent-a: var(--blue);
+  --accent-b: oklch(0.60 0.16 268);
+  --title-font: var(--f-display);
+  --title-weight: 600;
+  --title-tracking: -0.02em;
+  --motion: 1;
+  --rail: var(--line);
+
+  --shell-w: 248px;
+  --ease: cubic-bezier(.22, .61, .36, 1);
+  --ease-out: cubic-bezier(.16, 1, .3, 1);
+}
+
+/* ---------- direction: paper (editorial calm) ---------- */
+[data-dir="paper"] {
+  --radius: 5px; --radius-sm: 4px;
+  --panel-bg: transparent;
+  --panel-border: transparent;
+  --panel-shadow: none;
+  --title-tracking: -0.025em;
+}
+/* ---------- direction: studio (warm workstation — default) ---------- */
+[data-dir="studio"] {
+  --radius: 12px; --radius-sm: 8px;
+  --panel-bg: var(--surface-2);
+  --panel-border: var(--line);
+}
+/* ---------- direction: trail (expressive) ---------- */
+[data-dir="trail"] {
+  --radius: 16px; --radius-sm: 11px;
+  --panel-bg: var(--surface);
+  --panel-border: var(--line);
+  --panel-shadow: 0 6px 24px -14px oklch(0.5 0.04 60 / 0.28);
+  --title-weight: 700;
+  --title-tracking: -0.03em;
 }
 
 * { box-sizing: border-box; }
-
-/* The hidden attribute must always win. The UA sheet's [hidden]{display:none}
-   loses to any class that sets display (.modal's flex, .filters' flex, ...) —
-   without this rule a "hidden" full-viewport modal still swallows every click
-   on the page, and a "hidden" form stays on screen. */
-[hidden] { display: none !important; }
-
+html, body { height: 100%; }
+svg { width: 16px; height: 16px; display: block; flex: none; }
+.brand-mark svg { width: 18px; height: 18px; }
+.ni-icon svg { width: 17px; height: 17px; }
+.tt-warn svg, .empty-ic svg { width: 18px; height: 18px; }
 body {
   margin: 0;
-  background: var(--bg);
-  color: var(--text);
-  font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-}
-
-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0 20px;
-  border-bottom: 1px solid var(--border);
-  background: var(--panel);
-  position: sticky;
-  top: 0;
-  z-index: 10;
-}
-
-.brand { display: flex; align-items: center; gap: 8px; }
-.logo { height: 26px; display: block; }
-.sub { color: var(--muted); font-size: 13px; }
-.readonly {
-  margin-left: 6px;
-  font-size: 11px;
-  color: var(--ok);
-  border: 1px solid var(--ok);
-  border-radius: 10px;
-  padding: 1px 8px;
-}
-
-nav#tabs { display: flex; gap: 4px; }
-.tab {
-  background: none;
-  border: none;
-  color: var(--muted);
-  padding: 16px 14px;
-  cursor: pointer;
+  font-family: var(--f-ui);
   font-size: 14px;
-  border-bottom: 2px solid transparent;
+  line-height: 1.5;
+  color: var(--ink);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
 }
-.tab:hover { color: var(--text); }
-.tab.active { color: var(--text); border-bottom-color: var(--accent); }
+button { font-family: inherit; }
+::selection { background: oklch(0.575 0.158 252 / 0.18); }
 
-main { padding: 20px; max-width: 1200px; margin: 0 auto; }
-.panel { display: none; }
-.panel.active { display: block; }
-
-.hint { color: var(--muted); margin-top: 0; max-width: 70ch; }
-
-.filters {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px 16px;
-  align-items: flex-end;
-  background: var(--panel);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 16px;
+/* ============================================================
+   shell: sidebar + main
+   ============================================================ */
+#app {
+  display: grid;
+  grid-template-columns: var(--shell-w) 1fr;
+  height: 100vh;
+  overflow: hidden;
 }
-.filters label {
+
+.side {
+  position: relative;
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  font-size: 12px;
-  color: var(--muted);
+  border-right: 1px solid var(--line);
+  background: var(--surface);
+  padding: 22px 18px 16px;
+  gap: 22px;
+  z-index: 5;
 }
-.filters input, .filters select {
-  background: var(--panel-2);
-  border: 1px solid var(--border);
-  color: var(--text);
-  border-radius: 6px;
-  padding: 7px 9px;
-  font-size: 13px;
-  min-width: 150px;
+[data-dir="studio"] .side { background: oklch(0.991 0.003 70); }
+[data-dir="trail"] .side {
+  background:
+    radial-gradient(120% 60% at -10% -5%, var(--blue-bg), transparent 60%),
+    var(--surface);
 }
-.filters input:focus, .filters select:focus {
-  outline: none;
-  border-color: var(--accent);
-}
-.actions { display: flex; gap: 8px; align-items: flex-end; }
 
-button.primary, .preview-btn, .sql-toolbar button, #status-refresh {
-  cursor: pointer;
-  border-radius: 6px;
-  padding: 8px 14px;
-  font-size: 13px;
-  border: 1px solid var(--border);
-  background: var(--panel-2);
-  color: var(--text);
-}
-button.primary {
-  background: var(--accent-2);
-  border-color: var(--accent-2);
+/* brand */
+.brand { display: flex; align-items: center; gap: 11px; }
+.brand-mark {
+  width: 30px; height: 30px; flex: none;
+  border-radius: 8px;
+  display: grid; place-items: center;
   color: #fff;
-  font-weight: 600;
+  background: linear-gradient(150deg, var(--ink) 0%, oklch(0.32 0.02 60) 100%);
+  box-shadow: 0 1px 0 oklch(1 0 0 / 0.4) inset, 0 2px 6px oklch(0.3 0.02 60 / 0.18);
 }
-button.primary:hover { background: var(--accent); border-color: var(--accent); }
-.preview-btn:hover, .sql-toolbar button:hover { border-color: var(--accent); }
-
-.warnings { margin: 14px 0 0; }
-.warnings .warn-item {
-  background: rgba(224, 179, 65, 0.1);
-  border: 1px solid var(--warn);
-  color: var(--warn);
-  border-radius: 6px;
-  padding: 8px 12px;
-  margin-bottom: 8px;
-  font-size: 13px;
+[data-dir="trail"] .brand-mark,
+[data-accent="warm"] .brand-mark {
+  background: linear-gradient(150deg, var(--accent-a) 0%, var(--accent-b) 130%);
 }
-
-.error-box {
-  background: rgba(224, 108, 117, 0.1);
-  border: 1px solid var(--del);
-  color: var(--del);
-  border-radius: 6px;
-  padding: 10px 12px;
-  margin-top: 14px;
-  font-size: 13px;
-}
-
-table.events {
-  width: 100%;
-  border-collapse: collapse;
-  margin-top: 16px;
-  font-size: 13px;
-}
-table.events th {
-  text-align: left;
-  color: var(--muted);
-  font-weight: 600;
-  border-bottom: 1px solid var(--border);
-  padding: 8px 10px;
-  position: sticky;
-  top: 53px;
-  background: var(--bg);
-}
-table.events td {
-  padding: 8px 10px;
-  border-bottom: 1px solid var(--border);
-  vertical-align: top;
-}
-table.events tr.event-row { cursor: pointer; }
-table.events tr.event-row:hover td { background: var(--panel); }
-
-.badge {
-  font-size: 11px;
+.brand-name {
+  font-family: var(--f-display);
   font-weight: 700;
-  border-radius: 4px;
-  padding: 1px 6px;
-}
-.badge.INSERT { color: var(--ins); border: 1px solid var(--ins); }
-.badge.UPDATE { color: var(--accent); border: 1px solid var(--accent); }
-.badge.DELETE { color: var(--del); border: 1px solid var(--del); }
-
-.detail { background: var(--panel); }
-.detail td { padding: 0; }
-.diff {
-  display: grid;
-  grid-template-columns: max-content 1fr 1fr;
-  gap: 1px;
-  background: var(--border);
-  margin: 0;
-  font-family: var(--mono);
-  font-size: 12px;
-}
-.diff > div { background: var(--panel); padding: 4px 10px; }
-.diff .dh { color: var(--muted); font-weight: 700; background: var(--panel-2); }
-.diff .col { color: var(--muted); }
-.diff .before { color: var(--del); white-space: pre-wrap; word-break: break-word; }
-.diff .after { color: var(--ins); white-space: pre-wrap; word-break: break-word; }
-.diff .changed { background: rgba(91, 157, 255, 0.07); }
-
-.meta-line { color: var(--muted); margin: 14px 0 4px; font-size: 13px; }
-.export-bar { display: inline-flex; gap: 8px; margin-left: 16px; }
-.export-btn {
-  font-size: 12px;
-  padding: 3px 10px;
-  border-radius: 6px;
-  border: 1px solid var(--border);
-  background: var(--panel-2);
-  color: var(--text);
-  cursor: pointer;
-}
-.export-btn:hover { border-color: var(--accent); }
-
-.sql-toolbar {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-top: 18px;
-  padding-bottom: 8px;
-}
-.sql-toolbar .spacer { flex: 1; }
-#recover-meta { color: var(--muted); font-size: 13px; }
-pre#recover-sql {
-  background: var(--panel);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 16px;
-  overflow: auto;
-  font-family: var(--mono);
-  font-size: 12.5px;
-  max-height: 60vh;
-  white-space: pre;
-}
-
-.status-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 16px; margin-top: 16px; }
-.card {
-  background: var(--panel);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 16px;
-}
-.card h3 { margin: 0 0 10px; font-size: 13px; color: var(--accent); text-transform: uppercase; letter-spacing: 0.4px; }
-.card .kv { display: flex; justify-content: space-between; gap: 12px; padding: 3px 0; border-bottom: 1px dotted var(--border); }
-.card .kv:last-child { border-bottom: none; }
-.card .kv .k { color: var(--muted); }
-.card .kv .v { font-family: var(--mono); font-size: 12.5px; }
-
-.empty { color: var(--muted); margin-top: 16px; font-style: italic; }
-
-.toast {
-  position: fixed;
-  bottom: 24px;
-  left: 50%;
-  transform: translateX(-50%);
-  background: var(--panel-2);
-  border: 1px solid var(--accent);
-  color: var(--text);
-  padding: 10px 18px;
-  border-radius: 8px;
-  font-size: 13px;
-  z-index: 100;
-}
-
-/* Capability gating: elements are hidden until JS confirms the capability is
-   enabled for the SELECTED server (it then adds the cap-on class). The
-   attribute is kept so the gate re-evaluates on every server switch — a server
-   with Time-travel can be followed by one without. !important outranks
-   .panel.active, so switching away from a capable server hides an open tab. */
-[data-capability]:not(.cap-on) { display: none !important; }
-
-.filters label.checkbox {
-  flex-direction: row;
-  align-items: center;
-  gap: 6px;
-  font-size: 13px;
-  color: var(--text);
-}
-
-/* ── Reconstruct: as-of state table + history timeline ── */
-table.statetable {
-  border-collapse: collapse;
-  margin-top: 16px;
-  font-size: 13px;
-  min-width: 360px;
-}
-table.statetable th, table.statetable td {
-  text-align: left;
-  padding: 6px 12px;
-  border-bottom: 1px solid var(--border);
-}
-table.statetable th { color: var(--muted); font-weight: 600; width: 1%; white-space: nowrap; }
-table.statetable td { font-family: var(--mono); white-space: pre-wrap; word-break: break-word; }
-
-.deleted-note {
-  margin-top: 16px;
-  color: var(--del);
-  border: 1px solid var(--del);
-  border-radius: 6px;
-  padding: 10px 12px;
-  font-size: 13px;
-}
-
-/* ── Server switcher (header) + management modal ── */
-.server-ctl { display: flex; align-items: center; gap: 6px; margin-left: 18px; }
-.server-ctl select {
-  background: var(--panel-2);
-  border: 1px solid var(--border);
-  color: var(--text);
-  border-radius: 6px;
-  padding: 5px 8px;
-  font-size: 12.5px;
-  max-width: 220px;
-}
-.server-ctl select:focus { outline: none; border-color: var(--accent); }
-.server-ctl button {
-  cursor: pointer;
-  border-radius: 6px;
-  padding: 5px 10px;
-  font-size: 12px;
-  border: 1px solid var(--border);
-  background: var(--panel-2);
-  color: var(--text);
-}
-.server-ctl button:hover { border-color: var(--accent); }
-
-.modal {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.55);
-  z-index: 50;
-  display: flex;
-  align-items: flex-start;
-  justify-content: center;
-  padding: 60px 16px;
-  overflow-y: auto;
-}
-.modal-dialog {
-  background: var(--panel);
-  border: 1px solid var(--border);
-  border-radius: 10px;
-  width: 760px;
-  max-width: 100%;
-  padding: 20px;
-}
-.modal-head { display: flex; align-items: center; gap: 8px; }
-.modal-head h2 { margin: 0; font-size: 16px; }
-.modal-head .spacer { flex: 1; }
-.modal-close {
-  background: none;
-  border: none;
-  color: var(--muted);
-  font-size: 22px;
+  font-size: 19px;
+  letter-spacing: -0.03em;
+  color: var(--ink);
   line-height: 1;
-  cursor: pointer;
-  padding: 0 4px;
 }
-.modal-close:hover { color: var(--text); }
-.modal .hint code {
-  font-family: var(--mono);
-  font-size: 12px;
-  background: var(--panel-2);
-  border-radius: 4px;
-  padding: 1px 4px;
+.brand-sub {
+  font-size: 11px;
+  color: var(--ink-3);
+  letter-spacing: 0.02em;
+  margin-top: 2px;
 }
-
-.server-row {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 10px 0;
-  border-bottom: 1px solid var(--border);
-  font-size: 13px;
-}
-.server-row .srv-name { font-weight: 600; }
-.server-row .srv-desc {
-  color: var(--muted);
-  font-family: var(--mono);
-  font-size: 12px;
-  flex: 1;
-  overflow: hidden;
-  text-overflow: ellipsis;
+.ro-pill {
+  margin-left: auto;
+  align-self: flex-start;
+  font-family: var(--f-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--insert);
+  background: var(--insert-bg);
+  border: 1px solid oklch(0.60 0.135 152 / 0.25);
+  padding: 3px 7px 2px;
+  border-radius: 999px;
   white-space: nowrap;
 }
-.server-row .srv-status { font-size: 12px; color: var(--muted); }
-.server-row .srv-status.ok { color: var(--ok); }
-.server-row .srv-status.err { color: var(--del); }
 
-.health-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  display: inline-block;
-  flex: none;
-  background: var(--muted);
-}
-.health-dot.ok { background: var(--ok); }
-
-.badge.cli { color: var(--warn); border: 1px solid var(--warn); }
-.badge.tt { color: var(--accent); border: 1px solid var(--accent); }
-
-.row-btn {
-  font-size: 12px;
-  padding: 3px 10px;
-  border-radius: 6px;
-  border: 1px solid var(--border);
-  background: var(--panel-2);
-  color: var(--text);
-  cursor: pointer;
-}
-.row-btn:hover:not(:disabled) { border-color: var(--accent); }
-.row-btn.danger:hover:not(:disabled) { border-color: var(--del); color: var(--del); }
-.row-btn:disabled { opacity: 0.4; cursor: not-allowed; }
-
-.server-form { margin-top: 14px; }
-
-.form-fieldset {
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 10px 12px 14px;
-  margin: 0;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px 16px;
+/* server switcher */
+.srv-block { display: flex; flex-direction: column; gap: 8px; }
+.srv-select {
+  appearance: none;
   width: 100%;
-}
-.form-fieldset legend {
-  font-size: 12px;
-  color: var(--accent);
-  text-transform: uppercase;
-  letter-spacing: 0.4px;
-  padding: 0 6px;
-}
-.fieldset-hint {
-  width: 100%;
-  margin: 0;
-  font-size: 12px;
-  color: var(--muted);
-}
-
-/* Monitor state badges (server rows) */
-.badge.mon-running { color: var(--ok); border: 1px solid var(--ok); }
-.badge.mon-pending { color: var(--warn); border: 1px solid var(--warn); }
-.badge.mon-failed { color: var(--del); border: 1px solid var(--del); }
-.badge.mon-stopped { color: var(--muted); border: 1px solid var(--muted); }
-.badge.mon-stalled { color: var(--warn); border: 1px solid var(--warn); }
-.badge.mon-lost_position { color: var(--del); border: 1px solid var(--del); }
-
-.row-btn.primaryish { border-color: var(--accent-2); color: var(--accent); }
-
-/* Doctor preflight cards */
-#doctor-cards { width: 100%; }
-.doctor-card {
-  display: flex;
-  gap: 10px;
-  align-items: flex-start;
-  border: 1px solid var(--border);
-  border-left: 3px solid var(--muted);
-  border-radius: 6px;
-  padding: 8px 10px;
-  margin-top: 8px;
+  font-family: var(--f-mono);
   font-size: 12.5px;
+  color: var(--ink);
+  background: var(--surface)
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6'><path fill='%239a9590' d='M0 0h10L5 6z'/></svg>")
+    no-repeat right 12px center;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  padding: 9px 30px 9px 30px;
+  cursor: pointer;
+  transition: border-color .15s, box-shadow .15s;
+  position: relative;
 }
-.doctor-card.pass { border-left-color: var(--ok); }
-.doctor-card.fail { border-left-color: var(--del); }
-.doctor-card.warn { border-left-color: var(--warn); }
-.doctor-card .dc-mark { font-weight: 700; }
-.doctor-card.pass .dc-mark { color: var(--ok); }
-.doctor-card.fail .dc-mark { color: var(--del); }
-.doctor-card.warn .dc-mark { color: var(--warn); }
-.doctor-card .dc-body { flex: 1; min-width: 0; }
-.doctor-card .dc-rem {
-  font-family: var(--mono);
-  font-size: 11.5px;
-  background: var(--panel-2);
-  border-radius: 4px;
-  padding: 6px 8px;
-  margin: 6px 0 0;
+.srv-wrap { position: relative; }
+.srv-dot {
+  position: absolute; left: 12px; top: 50%; transform: translateY(-50%);
+  width: 7px; height: 7px; border-radius: 50%;
+  background: var(--insert);
+  box-shadow: 0 0 0 3px oklch(0.60 0.135 152 / 0.16);
+}
+.srv-select:hover { border-color: var(--ink-4); }
+.srv-select:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-bg); }
+
+.srv-manage {
+  display: flex; align-items: center; gap: 8px;
+  font-size: 12.5px; color: var(--ink-2);
+  background: none; border: 1px dashed var(--line);
+  border-radius: var(--radius-sm);
+  padding: 8px 12px; cursor: pointer; width: 100%;
+  transition: background .15s, border-color .15s, color .15s;
+}
+.srv-manage:hover { background: var(--surface-2); color: var(--ink); border-color: var(--ink-4); }
+.srv-manage svg { color: var(--ink-3); }
+
+/* nav */
+.nav { display: flex; flex-direction: column; gap: 0; margin-top: 2px; }
+.nav-group { display: flex; flex-direction: column; gap: 2px; }
+.nav-group + .nav-group { margin-top: 16px; }
+.nav-label {
+  font-size: 10px; letter-spacing: 0.09em; text-transform: uppercase;
+  color: var(--ink-4); font-weight: 600; padding: 0 10px 8px;
+}
+.nav-item {
+  position: relative;
+  display: flex; align-items: center; gap: 11px;
+  padding: 9px 11px;
+  border-radius: var(--radius-sm);
+  color: var(--ink-2);
+  font-size: 14px; font-weight: 500;
+  cursor: pointer; border: none; background: none;
+  text-align: left; width: 100%;
+  transition: color .18s var(--ease), background .18s var(--ease);
+}
+.nav-item .ni-icon {
+  width: 17px; height: 17px; flex: none; color: var(--ink-4);
+  transition: color .18s, transform .25s var(--ease-out);
+}
+.nav-item:hover { background: var(--surface-2); color: var(--ink); }
+.nav-item:hover .ni-icon { color: var(--ink-2); }
+.nav-item.active { color: var(--ink); font-weight: 600; background: var(--accent-bg); }
+.nav-item.active .ni-icon { color: var(--accent); }
+.nav-item.active .ni-icon { transform: translateX(1px); }
+/* active rail accent */
+.nav-item.active::before {
+  content: ""; position: absolute; left: -18px; top: 50%; transform: translateY(-50%);
+  width: 3px; height: 18px; border-radius: 0 3px 3px 0;
+  background: linear-gradient(var(--accent-a), var(--accent-b));
+  animation: railpop .3s var(--ease-out);
+}
+[data-dir="trail"] .nav-item.active::before {
+  height: 26px; width: 4px;
+  background: linear-gradient(var(--accent-a), var(--accent-b));
+}
+[data-dir="paper"] .nav-item.active { background: transparent; }
+[data-dir="paper"] .nav-item.active::before { left: -2px; }
+@keyframes railpop { from { height: 0; opacity: 0; } to { opacity: 1; } }
+
+.nav-kbd {
+  margin-left: auto; font-family: var(--f-mono); font-size: 10.5px;
+  color: var(--ink-4); opacity: 0; transition: opacity .15s;
+}
+.nav-item:hover .nav-kbd, .nav-item.active .nav-kbd { opacity: 1; }
+
+.side-foot {
+  margin-top: auto;
+  display: flex; flex-direction: column; gap: 3px;
+  font-family: var(--f-mono); font-size: 11px; color: var(--ink-4);
+  padding: 12px 10px 2px; border-top: 1px solid var(--line-soft);
+}
+.side-foot b { color: var(--ink-3); font-weight: 500; }
+.side-docs {
+  display: flex; align-items: center; gap: 9px;
+  font-family: var(--f-ui); font-size: 13px; color: var(--ink-2);
+  text-decoration: none; padding: 8px 8px; margin: -4px -6px 8px; border-radius: var(--radius-sm);
+  transition: background .15s, color .15s;
+}
+.side-docs svg { width: 15px; height: 15px; color: var(--ink-4); }
+.side-docs span { flex: 1; }
+.side-docs:hover { background: var(--accent-bg); color: var(--accent); }
+.side-docs:hover svg { color: var(--accent); }
+[data-accent="warm"] .side-docs:hover { color: var(--orange-2); }
+[data-accent="warm"] .side-docs:hover svg { color: var(--orange-2); }
+.side-meta { display: flex; flex-direction: column; gap: 3px; }
+
+/* ============================================================
+   main / workspace
+   ============================================================ */
+.main { overflow-y: auto; overflow-x: hidden; position: relative; }
+.main::-webkit-scrollbar { width: 11px; }
+.main::-webkit-scrollbar-thumb { background: var(--line); border-radius: 6px; border: 3px solid var(--bg); background-clip: content-box; }
+.main::-webkit-scrollbar-thumb:hover { background: var(--ink-4); border: 3px solid var(--bg); background-clip: content-box; }
+
+.view { max-width: 1180px; margin: 0 auto; padding: 40px 48px 96px; }
+
+.page-head { margin-bottom: 30px; }
+.page-title {
+  font-family: var(--title-font);
+  font-weight: var(--title-weight);
+  letter-spacing: var(--title-tracking);
+  font-size: 30px; line-height: 1.05; color: var(--ink);
+  margin: 0 0 10px; display: flex; align-items: center; gap: 12px;
+}
+.page-sub { color: var(--ink-2); font-size: 14.5px; max-width: 62ch; margin: 0; }
+.page-sub b { color: var(--ink); font-weight: 600; }
+
+/* enter animation for views — transform-only so content is ALWAYS visible
+   (the preview's animation clock can freeze at t=0; opacity-from-0 would blank it) */
+@keyframes rise { from { transform: translateY(var(--rise, 10px)); } to { transform: none; } }
+@media (prefers-reduced-motion: no-preference) {
+  .view-enter > * { animation: rise calc(.45s * var(--motion)) var(--ease-out) both; }
+  .view-enter > *:nth-child(2) { animation-delay: calc(.04s * var(--motion)); }
+  .view-enter > *:nth-child(3) { animation-delay: calc(.08s * var(--motion)); }
+  .view-enter > *:nth-child(4) { animation-delay: calc(.12s * var(--motion)); }
+}
+
+/* ============================================================
+   filter bar
+   ============================================================ */
+.filters {
+  display: flex; flex-wrap: wrap; gap: 16px 18px; align-items: flex-end;
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--radius);
+  padding: 20px;
+  box-shadow: var(--panel-shadow);
+  margin-bottom: 26px;
+}
+[data-dir="paper"] .filters {
+  padding: 0 0 22px; border-radius: 0;
+  border-bottom: 1px solid var(--line);
+  gap: 14px 26px;
+}
+[data-dir="trail"] .filters {
+  position: relative; overflow: hidden;
+  border: 1px solid var(--panel-border);
+  padding-left: 26px;
+}
+[data-dir="trail"] .filters::before {
+  content: ""; position: absolute; left: 0; top: 0; bottom: 0; width: 5px;
+  background: linear-gradient(var(--accent-a), var(--accent-b));
+}
+
+.field { display: flex; flex-direction: column; gap: 6px; min-width: 0; }
+.field-label {
+  font-size: 11px; font-weight: 600; letter-spacing: 0.03em;
+  color: var(--ink-3); text-transform: none;
+}
+.input, .select {
+  appearance: none;
+  font-family: var(--f-mono); font-size: 13px;
+  color: var(--ink);
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  padding: 9px 11px; height: 38px;
+  transition: border-color .15s, box-shadow .15s, background .15s;
+}
+.select {
+  padding-right: 30px; cursor: pointer;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6'><path fill='%239a9590' d='M0 0h10L5 6z'/></svg>");
+  background-repeat: no-repeat; background-position: right 11px center;
+}
+.input::placeholder { color: var(--ink-4); }
+.input:hover, .select:hover { border-color: var(--ink-4); }
+.input:focus, .select:focus {
+  outline: none; border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-bg);
+}
+[data-dir="paper"] .input, [data-dir="paper"] .select {
+  border: none; border-bottom: 1.5px solid var(--line);
+  border-radius: 0; padding-left: 0; background-color: transparent;
+}
+[data-dir="paper"] .select { background-position: right 2px center; padding-right: 22px; }
+[data-dir="paper"] .input:focus, [data-dir="paper"] .select:focus {
+  box-shadow: none; border-bottom-color: var(--accent);
+}
+.field--sm { width: 116px; }
+.field--md { width: 168px; }
+.field--lg { width: 210px; }
+.field--grow { flex: 1 1 150px; }
+
+.filter-actions { display: flex; gap: 10px; align-items: flex-end; flex-wrap: wrap; }
+[data-dir="paper"] .filter-actions { width: 100%; padding-top: 4px; }
+
+/* ============================================================
+   smart search (Events)
+   ============================================================ */
+.ev-searchwrap {
+  display: flex; align-items: center; gap: 8px;
+  border: 1px solid var(--line); border-radius: var(--radius);
+  background: var(--surface); padding: 5px 6px 5px 14px;
+  margin-bottom: 14px; box-shadow: var(--panel-shadow);
+  transition: border-color .15s, box-shadow .15s;
+}
+.ev-searchwrap:focus-within { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-bg); }
+.ev-search-ic { display: grid; place-items: center; flex: none; }
+.ev-search-ic svg { width: 17px; height: 17px; color: var(--ink-4); }
+.ev-search {
+  flex: 1; border: none; outline: none; background: none;
+  font-family: var(--f-mono); font-size: 14px; color: var(--ink); padding: 9px 4px;
+}
+.ev-search::placeholder { color: var(--ink-4); font-family: var(--f-ui); }
+.ev-search-x {
+  border: none; background: none; cursor: pointer; flex: none;
+  width: 30px; height: 30px; border-radius: var(--radius-sm); color: var(--ink-3);
+  display: grid; place-items: center;
+}
+.ev-search-x svg { width: 14px; height: 14px; }
+.ev-search-x:hover { background: var(--surface-2); color: var(--ink); }
+.ev-advbtn {
+  display: inline-flex; align-items: center; gap: 7px; flex: none;
+  height: 34px; padding: 0 13px; cursor: pointer;
+  font-family: var(--f-ui); font-size: 13px; font-weight: 600; color: var(--ink-2);
+  background: var(--surface-2); border: 1px solid var(--line); border-radius: var(--radius-sm);
+  transition: background .15s, color .15s, border-color .15s;
+}
+.ev-advbtn svg { width: 15px; height: 15px; }
+.ev-advbtn:hover { color: var(--ink); border-color: var(--ink-4); }
+.ev-advbtn.on { background: var(--accent-bg); color: var(--accent); border-color: transparent; }
+[data-accent="warm"] .ev-advbtn.on { color: var(--orange-2); }
+
+.ev-advanced {
+  display: flex; flex-wrap: wrap; gap: 14px 18px; align-items: flex-end;
+  border: 1px solid var(--line); border-radius: var(--radius);
+  padding: 18px 20px; margin-bottom: 16px; background: var(--surface-2);
+}
+[data-dir="paper"] .ev-advanced { background: transparent; }
+.ev-advanced[hidden] { display: none; }
+
+.ev-empty { padding: 44px 24px; text-align: center; color: var(--ink-3); font-size: 14px; }
+.ev-empty b { color: var(--ink); font-weight: 600; }
+
+/* ============================================================
+   buttons
+   ============================================================ */
+.btn {
+  --bw: 1px;
+  display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+  height: 38px; padding: 0 16px;
+  font-size: 13.5px; font-weight: 600; letter-spacing: -0.005em;
+  color: var(--ink); background: var(--surface);
+  border: var(--bw) solid var(--line); border-radius: var(--radius-sm);
+  cursor: pointer; white-space: nowrap;
+  transition: transform .12s var(--ease), box-shadow .15s, background .15s, border-color .15s, color .15s;
+}
+.btn:hover { border-color: var(--ink-4); background: var(--surface-2); }
+.btn:active { transform: translateY(1px); }
+.btn svg { width: 15px; height: 15px; }
+
+.btn-primary {
+  color: #fff; background: linear-gradient(135deg, var(--accent-a), var(--accent-b)); border-color: transparent;
+  box-shadow: 0 1px 2px oklch(0.4 0.04 60 / 0.22), 0 1px 0 oklch(1 0 0 / 0.2) inset;
+}
+.btn-primary:hover { filter: brightness(1.05) saturate(1.04); border-color: transparent;
+  box-shadow: 0 5px 16px -5px oklch(0.5 0.08 60 / 0.45), 0 1px 0 oklch(1 0 0 / 0.2) inset; }
+
+.btn-accent { color: #fff; background: var(--orange-2); border-color: transparent; }
+.btn-accent:hover { background: oklch(0.585 0.15 46); border-color: transparent; }
+
+.btn-sm { height: 32px; padding: 0 12px; font-size: 12.5px; }
+.btn-ghost { background: transparent; border-color: transparent; color: var(--ink-2); }
+.btn-ghost:hover { background: var(--surface-2); color: var(--ink); border-color: transparent; }
+.btn[disabled] { opacity: .45; pointer-events: none; }
+
+/* ============================================================
+   badges (type) — SACRED outlined look
+   ============================================================ */
+.badge {
+  display: inline-flex; align-items: center;
+  font-family: var(--f-mono); font-size: 10.5px; font-weight: 600;
+  letter-spacing: 0.06em; text-transform: uppercase;
+  padding: 3px 8px 2px; border-radius: 6px;
+  border: 1px solid currentColor; line-height: 1.1;
+}
+.badge::before { content: ""; }
+.b-update { color: var(--update); background: var(--update-bg); }
+.b-insert { color: var(--insert); background: var(--insert-bg); }
+.b-delete { color: var(--delete); background: var(--delete-bg); }
+.b-baseline { color: var(--ink-3); background: var(--surface-2); }
+[data-dir="trail"] .badge { color: #fff; border-color: transparent; }
+[data-dir="trail"] .b-update { background: var(--update); }
+[data-dir="trail"] .b-insert { background: var(--insert); }
+[data-dir="trail"] .b-delete { background: var(--delete); }
+[data-dir="trail"] .b-baseline { background: var(--ink-3); color: #fff; }
+
+.chip {
+  display: inline-flex; align-items: center; gap: 5px;
+  font-family: var(--f-mono); font-size: 10px; font-weight: 600;
+  letter-spacing: 0.04em; padding: 2px 6px; border-radius: 5px;
+  border: 1px solid currentColor;
+}
+.chip-cli { color: var(--orange-2); background: var(--orange-bg); }
+.chip-tt { color: var(--blue); background: var(--blue-bg); }
+
+/* ============================================================
+   results / tables
+   ============================================================ */
+.result-bar {
+  display: flex; align-items: center; gap: 14px; margin-bottom: 14px;
+  font-size: 13px; color: var(--ink-2);
+}
+.result-count { font-family: var(--f-mono); }
+.result-count b { color: var(--ink); font-weight: 600; }
+.result-bar .spacer { flex: 1; }
+
+.events { width: 100%; }
+.ev-head, .ev-row {
+  display: grid;
+  grid-template-columns: 200px 1fr 116px 88px 1.2fr;
+  align-items: center; gap: 12px;
+}
+.ev-head {
+  font-family: var(--f-mono); font-size: 11px; letter-spacing: 0.04em;
+  color: var(--ink-4); text-transform: lowercase;
+  padding: 0 14px 10px; border-bottom: 1px solid var(--line);
+}
+.ev-row {
+  padding: 13px 14px; border-bottom: 1px solid var(--line-soft);
+  cursor: pointer; position: relative;
+  transition: background .14s;
+}
+.ev-row:hover { background: var(--surface-2); }
+.ev-row.open { background: var(--surface-2); }
+[data-dir="trail"] .ev-row.open { background: var(--accent-bg); }
+.ev-time { font-family: var(--f-mono); font-size: 12.5px; color: var(--ink); }
+.ev-table { font-family: var(--f-mono); font-size: 12.5px; color: var(--ink-2); }
+.ev-pk { font-family: var(--f-mono); font-size: 12.5px; color: var(--ink); }
+.ev-cols { font-family: var(--f-mono); font-size: 12px; color: var(--ink-3); }
+.ev-cols .hl { color: var(--orange-2); }
+.ev-caret {
+  position: absolute; left: -2px; top: 50%; transform: translateY(-50%);
+  color: var(--ink-4); transition: transform .2s var(--ease); opacity: 0;
+}
+.ev-row:hover .ev-caret { opacity: 1; }
+.ev-row.open .ev-caret { transform: translateY(-50%) rotate(90deg); color: var(--accent); opacity: 1; }
+
+/* diff panel (expand) */
+.diff-wrap { overflow: hidden; }
+.diff {
+  margin: 2px 14px 16px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  background: var(--surface);
+  animation: diffin calc(.32s * var(--motion)) var(--ease-out);
+}
+@keyframes diffin { from { transform: translateY(-6px); } to { transform: none; } }
+.diff-grid { display: grid; grid-template-columns: 150px 1fr 1fr; }
+.diff-grid > div {
+  padding: 8px 14px; font-family: var(--f-mono); font-size: 12.5px;
+  border-bottom: 1px solid var(--line-soft);
+}
+.diff-h {
+  color: var(--ink-4); font-size: 11px; letter-spacing: 0.04em;
+  background: var(--surface-2); text-transform: lowercase;
+}
+.diff-col { color: var(--ink-2); }
+.diff-before { color: var(--diff-del); }
+.diff-after { color: var(--diff-add); }
+.diff-row-changed .diff-col { color: var(--ink); }
+.diff-row-changed { position: relative; }
+.diff-row-changed .diff-before { background: oklch(0.96 0.04 22 / 0.6); }
+.diff-row-changed .diff-after  { background: oklch(0.955 0.045 152 / 0.6); }
+.diff-grid > div:nth-last-child(-n+3) { border-bottom: none; }
+.diff-same { color: var(--ink-3); }
+
+/* diff footer — the "deshazlo" moment, right where you understood the change */
+.diff-foot {
+  display: flex; align-items: center; gap: 14px;
+  padding: 11px 14px; border-top: 1px solid var(--line-soft);
+  background: var(--surface-2);
+}
+.diff-foot-note { font-size: 12px; color: var(--ink-3); margin-right: auto; }
+[data-dir="trail"] .diff-foot { background: var(--accent-bg); }
+
+/* ============================================================
+   recover context banner — scope made unmissable
+   ============================================================ */
+.ctx-banner {
+  display: flex; align-items: center; gap: 14px;
+  border: 1px solid var(--line); border-left: 3px solid var(--accent);
+  border-radius: var(--radius); padding: 15px 16px 15px 17px;
+  margin-bottom: 22px; background: var(--accent-bg);
+}
+[data-accent="warm"] .ctx-banner { border-left-color: var(--orange-2); }
+.ctx-banner .badge { flex: none; align-self: flex-start; margin-top: 1px; }
+.ctx-banner .ctx-main { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.ctx-eyebrow {
+  font-family: var(--f-mono); font-size: 10px; font-weight: 600;
+  letter-spacing: 0.07em; text-transform: uppercase; color: var(--accent);
+}
+[data-accent="warm"] .ctx-eyebrow { color: var(--orange-2); }
+.ctx-title { font-family: var(--f-mono); font-size: 14.5px; font-weight: 600; color: var(--ink); }
+.ctx-detail { font-family: var(--f-mono); font-size: 12.5px; color: var(--ink-2); }
+.ctx-banner .spacer { flex: 1; }
+.ctx-banner #ctx-clear { flex: none; }
+
+/* ============================================================
+   status cards
+   ============================================================ */
+.cards { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+.card {
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--radius);
+  padding: 22px 22px 8px;
+  box-shadow: var(--panel-shadow);
+  position: relative; overflow: hidden;
+}
+[data-dir="paper"] .card { background: transparent; border-color: var(--line); padding-left: 0; padding-right: 22px; }
+[data-dir="trail"] .card::before {
+  content: ""; position: absolute; inset: 0 auto 0 0; width: 3px;
+  background: linear-gradient(var(--accent-a), var(--accent-b));
+}
+.card-title {
+  font-family: var(--f-mono); font-size: 11px; font-weight: 600;
+  letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--accent); margin-bottom: 16px;
+}
+.kv {
+  display: flex; align-items: baseline; justify-content: space-between;
+  gap: 12px; padding: 11px 0; border-bottom: 1px dotted var(--line);
+}
+.kv:last-child { border-bottom: none; }
+.kv-k { font-size: 13px; color: var(--ink-2); }
+.kv-v {
+  font-family: var(--f-mono); font-size: 14px; color: var(--ink);
+  font-weight: 500; font-variant-numeric: tabular-nums; text-align: right;
+}
+.kv-v.big { font-size: 22px; font-weight: 600; }
+.kv-v.muted { color: var(--ink-3); }
+
+/* ============================================================
+   code / SQL output
+   ============================================================ */
+.codepanel {
+  border: 1px solid var(--line); border-radius: var(--radius);
+  overflow: hidden; background: var(--surface);
+  box-shadow: var(--panel-shadow);
+}
+.code-head {
+  display: flex; align-items: center; gap: 12px;
+  padding: 11px 16px; border-bottom: 1px solid var(--line);
+  background: var(--surface-2);
+}
+.code-head .lbl { font-family: var(--f-mono); font-size: 12px; color: var(--ink-2); }
+.code-head .lbl b { color: var(--ink); }
+.code-head .spacer { flex: 1; }
+.code {
+  margin: 0; padding: 18px 20px; overflow-x: auto;
+  font-family: var(--f-mono); font-size: 13px; line-height: 1.7;
+  color: var(--ink); tab-size: 2;
+  counter-reset: ln;
+}
+.code .cl { display: block; white-space: pre; }
+.code .tok-kw { color: var(--blue-2); font-weight: 600; }
+.code .tok-fn { color: var(--orange-2); }
+.code .tok-str { color: var(--insert); }
+.code .tok-num { color: var(--delete); }
+.code .tok-com { color: var(--ink-4); font-style: italic; }
+.code .tok-id { color: var(--ink); }
+
+/* ============================================================
+   empty / placeholder states
+   ============================================================ */
+.empty {
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
+  text-align: center; padding: 64px 24px; gap: 14px;
+  border: 1px dashed var(--line); border-radius: var(--radius);
+  color: var(--ink-3); background: var(--surface);
+}
+.empty-ic { color: var(--ink-4); }
+.empty h3 { font-family: var(--title-font); font-weight: 600; color: var(--ink-2); margin: 0; font-size: 17px; letter-spacing: -0.01em; }
+.empty p { margin: 0; max-width: 42ch; font-size: 13.5px; }
+
+/* ============================================================
+   time-travel timeline — the star
+   ============================================================ */
+.tt-meta {
+  font-family: var(--f-mono); font-size: 12.5px; color: var(--ink-3);
+  margin-bottom: 24px;
+}
+.tt-meta b { color: var(--ink); font-weight: 500; }
+
+.tt-warn {
+  display: flex; align-items: center; gap: 11px;
+  font-size: 13px; color: var(--orange-2);
+  background: var(--orange-bg);
+  border: 1px solid oklch(0.70 0.155 52 / 0.3);
+  border-radius: var(--radius-sm);
+  padding: 12px 16px; margin-bottom: 24px;
+}
+.tt-warn svg { flex: none; }
+.tt-warn .mono { font-family: var(--f-mono); }
+
+.timeline { position: relative; padding-left: 30px; margin-top: 8px; }
+/* the rail that draws itself */
+.timeline::before {
+  content: ""; position: absolute; left: 5px; top: 6px; bottom: 8px;
+  width: 2px; border-radius: 2px;
+  background: linear-gradient(var(--accent-a), var(--accent-b));
+  transform-origin: top;
+  transform: scaleY(1);
+}
+@media (prefers-reduced-motion: no-preference) {
+  .timeline.drawn::before { animation: railgrow .9s var(--ease-out); }
+}
+@keyframes railgrow { from { transform: scaleY(0); } to { transform: scaleY(1); } }
+/* keep the spine calm-gray only for the default blue accent; any warm/color accent paints it */
+[data-accent="blue"][data-dir="studio"] .timeline::before { background: var(--line); }
+[data-accent="blue"][data-dir="paper"] .timeline::before { background: var(--line); width: 1.5px; }
+
+@keyframes fadeup { from { opacity: 0; transform: translateY(9px); } to { opacity: 1; transform: none; } }
+
+.tl-node {
+  position: relative; padding: 0 0 26px 4px;
+  transform: translateX(10px);
+}
+.tl-node.in { transform: none; transition: transform .45s var(--ease-out); }
+.tl-node:last-child { padding-bottom: 4px; }
+.tl-dot {
+  position: absolute; left: -29px; top: 3px;
+  width: 12px; height: 12px; border-radius: 50%;
+  background: var(--surface); border: 2px solid var(--accent);
+  box-shadow: 0 0 0 4px var(--bg);
+  transition: transform .3s var(--ease-out);
+}
+.tl-node.in .tl-dot { animation: dotpop .4s var(--ease-out) both; }
+@keyframes dotpop { 0% { transform: scale(0); } 60% { transform: scale(1.3); } 100% { transform: scale(1); } }
+.tl-dot.insert { border-color: var(--insert); }
+.tl-dot.update { border-color: var(--update); }
+.tl-dot.baseline { border-color: var(--ink-4); background: var(--ink-4); }
+.tl-dot.delete { border-color: var(--delete); }
+
+.tl-head { display: flex; align-items: center; gap: 11px; margin-bottom: 7px; }
+.tl-time { font-family: var(--f-mono); font-size: 12.5px; color: var(--ink-2); white-space: nowrap; }
+.tl-body {
+  font-family: var(--f-mono); font-size: 13px; color: var(--ink);
+  display: flex; flex-wrap: wrap; gap: 7px 20px;
+}
+.tl-body .pair { display: inline-flex; gap: 6px; }
+.tl-body .pk { color: var(--ink-3); }
+.tl-body .pv { color: var(--ink); }
+.tl-body .pv.changed { color: var(--orange-2); font-weight: 600; position: relative; }
+.tl-body .pv.changed::after {
+  content: ""; position: absolute; left: 0; right: 0; bottom: -2px; height: 2px;
+  background: var(--orange); border-radius: 2px; transform: scaleX(0); transform-origin: left;
+  animation: ul .4s .2s var(--ease-out) forwards;
+}
+@keyframes ul { to { transform: scaleX(1); } }
+
+/* restore action on each timeline node */
+.tl-actions { margin-top: 10px; }
+.tl-restore {
+  height: 28px; padding: 0 11px; font-size: 12px;
+  color: var(--ink-2); background: var(--surface); border: 1px solid var(--line);
+}
+.tl-restore svg { width: 13px; height: 13px; }
+.tl-restore:hover { border-color: var(--accent); color: var(--accent); background: var(--accent-bg); }
+[data-accent="warm"] .tl-restore:hover { border-color: var(--orange-2); color: var(--orange-2); }
+
+/* ============================================================
+   modal — servers
+   ============================================================ */
+.modal-scrim {
+  position: fixed; inset: 0; z-index: 50;
+  background: oklch(0.3 0.02 60 / 0.32);
+  -webkit-backdrop-filter: blur(3px); backdrop-filter: blur(3px);
+  display: none; align-items: flex-start; justify-content: center;
+  padding: 56px 24px; overflow-y: auto;
+}
+.modal-scrim.show { display: flex; }
+.modal {
+  width: 100%; max-width: 760px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  box-shadow: 0 30px 80px -24px oklch(0.3 0.03 60 / 0.45);
+  overflow: hidden;
+}
+@media (prefers-reduced-motion: no-preference) {
+  .modal-scrim.show .modal { animation: modalin .32s var(--ease-out); }
+}
+@keyframes modalin { from { transform: translateY(16px) scale(.99); } to { transform: none; } }
+.modal-head { padding: 26px 28px 8px; position: relative; }
+.modal-title { font-family: var(--title-font); font-weight: 600; font-size: 22px; letter-spacing: -0.02em; margin: 0 0 8px; }
+.modal-desc { color: var(--ink-2); font-size: 13.5px; margin: 0; max-width: 60ch; }
+.modal-desc b { color: var(--ink); font-weight: 600; }
+.modal-x {
+  position: absolute; right: 20px; top: 22px;
+  width: 32px; height: 32px; border-radius: 8px;
+  display: grid; place-items: center; cursor: pointer;
+  border: none; background: transparent; color: var(--ink-3);
+  transition: background .15s, color .15s;
+}
+.modal-x:hover { background: var(--surface-2); color: var(--ink); }
+.modal-body { padding: 18px 28px 28px; }
+
+.srv-list { display: flex; flex-direction: column; }
+.srv-item {
+  display: flex; align-items: center; gap: 12px;
+  padding: 16px 4px; border-bottom: 1px solid var(--line-soft);
+}
+.srv-item .nm { font-weight: 600; font-size: 14.5px; color: var(--ink); display: flex; align-items: center; gap: 9px; }
+.srv-item .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--insert); box-shadow: 0 0 0 3px var(--insert-bg); flex: none; }
+.srv-item .conn { font-family: var(--f-mono); font-size: 12.5px; color: var(--ink-3); }
+.srv-item .acts { margin-left: auto; display: flex; gap: 7px; }
+
+.form-section {
+  border: 1px solid var(--line); border-radius: var(--radius);
+  padding: 18px 18px 20px; margin-top: 18px; position: relative;
+}
+.form-section > legend, .form-legend {
+  font-family: var(--f-mono); font-size: 11px; font-weight: 600;
+  letter-spacing: 0.06em; text-transform: uppercase;
+  color: var(--blue); padding: 0 6px; margin-left: 6px;
+}
+.form-hint { color: var(--ink-2); font-size: 12.5px; margin: 4px 0 16px; }
+.form-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
+.form-grid .field { width: auto; }
+.form-grid.two { grid-template-columns: repeat(2, 1fr); }
+.check { display: flex; align-items: center; gap: 10px; font-size: 13.5px; color: var(--ink); cursor: pointer; }
+.check input { width: 18px; height: 18px; accent-color: var(--accent); }
+.modal-foot { display: flex; gap: 10px; margin-top: 22px; align-items: center; }
+
+/* ============================================================
+   tweaks panel (vanilla)
+   ============================================================ */
+#tweaks {
+  position: fixed; right: 18px; bottom: 18px; z-index: 9000;
+  width: 268px;
+  background: oklch(1 0 0 / 0.82);
+  -webkit-backdrop-filter: blur(22px) saturate(160%); backdrop-filter: blur(22px) saturate(160%);
+  border: 1px solid var(--line); border-radius: 15px;
+  box-shadow: 0 18px 50px -20px oklch(0.3 0.03 60 / 0.4), 0 1px 0 oklch(1 0 0 / 0.6) inset;
+  font-family: var(--f-ui); color: var(--ink);
+  display: none; flex-direction: column; overflow: hidden;
+}
+#tweaks.open { display: flex; animation: twkin .28s var(--ease-out); }
+@keyframes twkin { from { transform: translateY(10px) scale(.98); } to { transform: none; } }
+.twk-h { display: flex; align-items: center; justify-content: space-between; padding: 13px 12px 11px 16px; border-bottom: 1px solid var(--line-soft); }
+.twk-h b { font-family: var(--f-display); font-size: 14px; font-weight: 600; letter-spacing: -0.01em; }
+.twk-h .x { border: none; background: none; color: var(--ink-3); cursor: pointer; width: 24px; height: 24px; border-radius: 6px; font-size: 15px; }
+.twk-h .x:hover { background: var(--surface-2); color: var(--ink); }
+.twk-b { padding: 14px 16px 16px; display: flex; flex-direction: column; gap: 15px; max-height: 70vh; overflow-y: auto; }
+.twk-grp { display: flex; flex-direction: column; gap: 8px; }
+.twk-lab { font-size: 11px; font-weight: 600; letter-spacing: 0.04em; color: var(--ink-3); }
+.seg { display: flex; gap: 3px; background: var(--surface-2); border-radius: 9px; padding: 3px; }
+.seg button {
+  flex: 1; border: none; background: none; cursor: pointer;
+  font-family: inherit; font-size: 12px; font-weight: 500; color: var(--ink-2);
+  padding: 6px 4px; border-radius: 6px; transition: background .15s, color .15s, box-shadow .15s;
+}
+.seg button.on { background: var(--surface); color: var(--ink); box-shadow: 0 1px 2px oklch(0.4 0.02 60 / 0.12); font-weight: 600; }
+.swatches { display: flex; gap: 7px; }
+.swatches button { width: 30px; height: 30px; border-radius: 8px; border: 2px solid transparent; cursor: pointer; padding: 0; position: relative; transition: transform .12s; }
+.swatches button:hover { transform: scale(1.08); }
+.swatches button.on { border-color: var(--ink); }
+.swatches button.on::after { content: "✓"; position: absolute; inset: 0; display: grid; place-items: center; color: #fff; font-size: 13px; text-shadow: 0 1px 2px rgba(0,0,0,.4); }
+.twk-toggle { display: flex; align-items: center; justify-content: space-between; }
+.tg { width: 38px; height: 22px; border-radius: 999px; background: var(--line); border: none; cursor: pointer; position: relative; transition: background .2s; flex: none; }
+.tg.on { background: var(--accent); }
+.tg::after { content: ""; position: absolute; left: 2px; top: 2px; width: 18px; height: 18px; border-radius: 50%; background: #fff; box-shadow: 0 1px 3px rgba(0,0,0,.25); transition: transform .2s var(--ease-out); }
+.tg.on::after { transform: translateX(16px); }
+.twk-note { font-size: 11px; color: var(--ink-4); line-height: 1.45; }
+
+/* ============================================================
+   density — compact tightens the data surfaces
+   ============================================================ */
+[data-density="compact"] .view { padding-top: 28px; }
+[data-density="compact"] .filters { padding: 14px 16px; margin-bottom: 18px; gap: 12px 16px; }
+[data-dir="paper"][data-density="compact"] .filters { padding: 0 0 14px; }
+[data-density="compact"] .input, [data-density="compact"] .select { height: 34px; }
+[data-density="compact"] .btn { height: 34px; }
+[data-density="compact"] .ev-row { padding-top: 8px; padding-bottom: 8px; }
+[data-density="compact"] .ev-head { padding-bottom: 8px; }
+[data-density="compact"] .result-bar { margin-bottom: 10px; }
+[data-density="compact"] .kv { padding: 7px 0; }
+[data-density="compact"] .card { padding-top: 16px; }
+[data-density="compact"] .card-title { margin-bottom: 11px; }
+[data-density="compact"] .tl-node { padding-bottom: 16px; }
+[data-density="compact"] .diff-grid > div { padding-top: 6px; padding-bottom: 6px; }
+[data-density="compact"] .page-head { margin-bottom: 22px; }
+
+/* ============================================================
+   overview / dashboard
+   ============================================================ */
+.ov-stats { display: grid; grid-template-columns: repeat(3, 1fr) 1.4fr; gap: 16px; margin-bottom: 24px; }
+.ov-stat {
+  background: var(--panel-bg); border: 1px solid var(--panel-border);
+  border-radius: var(--radius); padding: 18px 20px; box-shadow: var(--panel-shadow);
+}
+[data-dir="paper"] .ov-stat { background: transparent; border-color: var(--line); }
+.ov-stat-v { font-family: var(--f-display); font-size: 32px; font-weight: 600; letter-spacing: -0.02em; line-height: 1; color: var(--ink); }
+.ov-stat-v.small { font-family: var(--f-mono); font-size: 19px; font-weight: 500; }
+.ov-stat-v.danger { color: var(--delete); }
+.ov-stat-day { color: var(--ink-4); font-size: 13px; }
+.ov-stat-k { font-size: 12px; color: var(--ink-3); margin-top: 8px; letter-spacing: 0.01em; }
+
+.ov-grid { display: grid; grid-template-columns: 1.35fr 1fr; gap: 18px; align-items: start; }
+.ov-panel {
+  background: var(--panel-bg); border: 1px solid var(--panel-border);
+  border-radius: var(--radius); padding: 6px 6px 8px; box-shadow: var(--panel-shadow);
+}
+[data-dir="paper"] .ov-panel { background: transparent; border-color: var(--line); }
+.ov-panel-head { display: flex; align-items: center; justify-content: space-between; padding: 14px 14px 10px; }
+.ov-panel-title { font-family: var(--title-font); font-weight: 600; font-size: 15px; letter-spacing: -0.01em; margin: 0; color: var(--ink); }
+#ov-browse svg { width: 13px; height: 13px; }
+
+.ov-evlist { display: flex; flex-direction: column; }
+.ov-ev {
+  display: grid; grid-template-columns: 64px auto 1fr auto auto; align-items: center; gap: 11px;
+  padding: 9px 12px; border-radius: var(--radius-sm); cursor: pointer;
+  border-top: 1px solid var(--line-soft); transition: background .14s;
+}
+.ov-ev:first-child { border-top: none; }
+.ov-ev:hover { background: var(--surface-2); }
+.ov-ev-time { font-family: var(--f-mono); font-size: 12px; color: var(--ink-2); }
+.ov-ev-tbl { font-family: var(--f-mono); font-size: 12.5px; color: var(--ink); min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ov-ev-pk { color: var(--ink-3); }
+.ov-ev-cols { font-family: var(--f-mono); font-size: 11.5px; color: var(--ink-3); text-align: right; white-space: nowrap; }
+.ov-ev-undo { height: 27px; padding: 0 9px; font-size: 11.5px; opacity: 0; transition: opacity .14s; }
+.ov-ev-undo svg { width: 12px; height: 12px; }
+.ov-ev:hover .ov-ev-undo { opacity: 1; }
+
+.ov-tables { display: flex; flex-direction: column; }
+.ov-tablerow {
+  display: grid; grid-template-columns: 1fr 56px auto; align-items: center; gap: 12px;
+  width: 100%; text-align: left; background: none; border: none; cursor: pointer;
+  padding: 11px 14px; border-top: 1px solid var(--line-soft); transition: background .14s;
+}
+.ov-tablerow:first-child { border-top: none; }
+.ov-tablerow:hover { background: var(--surface-2); }
+.ov-tname { font-family: var(--f-mono); font-size: 13px; color: var(--ink); }
+.ov-bar { display: flex; height: 7px; border-radius: 4px; overflow: hidden; background: var(--surface-3); gap: 1.5px; }
+.ov-seg { display: block; }
+.ov-seg.i { background: var(--insert); }
+.ov-seg.u { background: var(--update); }
+.ov-seg.d { background: var(--delete); }
+.ov-pills { display: none; }
+.ov-total { font-family: var(--f-mono); font-size: 13px; font-weight: 600; color: var(--ink); text-align: right; font-variant-numeric: tabular-nums; }
+.ov-coverage {
+  display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
+  padding: 13px 14px 8px; margin-top: 4px; border-top: 1px solid var(--line-soft);
+  font-family: var(--f-mono); font-size: 11.5px; color: var(--ink-3);
+}
+.ov-coverage span { text-transform: uppercase; letter-spacing: 0.06em; font-size: 10px; }
+.ov-coverage b { color: var(--ink); font-weight: 500; }
+
+/* filter chip on Events */
+.filter-chip {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--f-mono); font-size: 12px; color: var(--accent);
+  background: var(--accent-bg); border: 1px solid transparent; border-radius: 999px;
+  padding: 3px 6px 3px 11px; cursor: pointer; margin-left: 12px;
+}
+[data-accent="warm"] .filter-chip { color: var(--orange-2); }
+.filter-chip svg { width: 12px; height: 12px; }
+.filter-chip:hover { border-color: currentColor; }
+
+/* ============================================================
+   command palette (⌘K) + sidebar trigger
+   ============================================================ */
+.cmdk-trigger {
+  display: flex; align-items: center; gap: 9px;
+  width: 100%; padding: 9px 11px; cursor: pointer;
+  border: 1px solid var(--line); border-radius: var(--radius-sm);
+  background: var(--surface); color: var(--ink-3);
+  font-family: var(--f-ui); font-size: 13px;
+  transition: border-color .15s, background .15s, color .15s;
+}
+.cmdk-trigger:hover { border-color: var(--ink-4); color: var(--ink-2); background: var(--surface-2); }
+.cmdk-trigger svg { width: 15px; height: 15px; color: var(--ink-4); }
+.cmdk-trigger > span:first-of-type { flex: 1; text-align: left; }
+.cmdk-kbd {
+  font-family: var(--f-mono); font-size: 10.5px; color: var(--ink-3);
+  border: 1px solid var(--line); border-radius: 5px; padding: 1px 6px 0;
+  background: var(--surface-2);
+}
+
+.cmdk-scrim {
+  position: fixed; inset: 0; z-index: 60;
+  background: oklch(0.3 0.02 60 / 0.34);
+  -webkit-backdrop-filter: blur(4px); backdrop-filter: blur(4px);
+  display: none; align-items: flex-start; justify-content: center;
+  padding: 12vh 24px 24px;
+}
+.cmdk-scrim.open { display: flex; }
+.cmdk {
+  width: 100%; max-width: 580px;
+  background: var(--surface); border: 1px solid var(--line);
+  border-radius: 16px; overflow: hidden;
+  box-shadow: 0 32px 80px -28px oklch(0.3 0.03 60 / 0.5), 0 1px 0 oklch(1 0 0 / 0.6) inset;
+}
+@media (prefers-reduced-motion: no-preference) {
+  .cmdk-scrim.open .cmdk { animation: cmdkin .26s var(--ease-out); }
+}
+@keyframes cmdkin { from { transform: translateY(-10px) scale(.985); } to { transform: none; } }
+.cmdk-top {
+  display: flex; align-items: center; gap: 11px;
+  padding: 16px 16px 14px; border-bottom: 1px solid var(--line-soft);
+}
+.cmdk-top svg { width: 18px; height: 18px; color: var(--ink-3); flex: none; }
+.cmdk-q {
+  flex: 1; border: none; outline: none; background: none;
+  font-family: var(--f-ui); font-size: 16px; color: var(--ink);
+}
+.cmdk-q::placeholder { color: var(--ink-4); }
+.cmdk-escpill {
+  font-family: var(--f-mono); font-size: 10.5px; color: var(--ink-3);
+  border: 1px solid var(--line); border-radius: 5px; padding: 2px 6px 1px; flex: none;
+}
+.cmdk-list { max-height: 50vh; overflow-y: auto; padding: 8px; }
+.cmdk-group {
+  font-family: var(--f-mono); font-size: 10px; font-weight: 600;
+  letter-spacing: 0.07em; text-transform: uppercase; color: var(--ink-4);
+  padding: 12px 10px 6px;
+}
+.cmdk-group:first-child { padding-top: 6px; }
+.cmdk-item {
+  display: flex; align-items: center; gap: 12px; width: 100%;
+  padding: 10px 11px; border: none; border-radius: 9px; cursor: pointer;
+  background: none; text-align: left; color: var(--ink);
+  font-family: var(--f-ui); font-size: 14px;
+}
+.cmdk-item .cmdk-ic { width: 17px; height: 17px; flex: none; color: var(--ink-3); display: grid; place-items: center; }
+.cmdk-item .cmdk-ic svg { width: 17px; height: 17px; }
+.cmdk-label { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.cmdk-hint {
+  font-family: var(--f-mono); font-size: 10.5px; color: var(--ink-3);
+  border: 1px solid var(--line); border-radius: 5px; padding: 1px 6px 0; flex: none;
+}
+.cmdk-item.sel { background: var(--accent-bg); color: var(--ink); }
+.cmdk-item.sel .cmdk-ic { color: var(--accent); }
+[data-accent="warm"] .cmdk-item.sel .cmdk-ic { color: var(--orange-2); }
+.cmdk-empty { padding: 28px; text-align: center; color: var(--ink-4); font-size: 13.5px; }
+
+/* keyboard hint + row cursor on Events */
+.kbd-hint { font-family: var(--f-mono); font-size: 10.5px; color: var(--ink-4); margin-right: 4px; }
+.kbd-hint b { color: var(--ink-3); font-weight: 600; }
+.ev-row.cursor { background: var(--accent-bg); box-shadow: inset 2px 0 0 var(--accent); }
+[data-accent="warm"] .ev-row.cursor { box-shadow: inset 2px 0 0 var(--orange-2); }
+.ev-row.cursor .ev-caret { opacity: 1; color: var(--accent); }
+
+/* responsive-ish */
+@media (max-width: 880px) {
+  #app { grid-template-columns: 1fr; }
+  .side { display: none; }
+  .cards { grid-template-columns: 1fr; }
+  .form-grid { grid-template-columns: 1fr 1fr; }
+}
+
+/* ============================================================
+   bintrail console — functional additions
+   The prototype above is a design scaffold. These rules style the
+   real-app pieces it omitted (server management depth, doctor cards,
+   capability gating, toast, errors/warnings, exports), using ONLY the
+   design tokens declared in :root so they stay on-system.
+   ============================================================ */
+
+/* The hidden attribute must always win. The new design hides overlays
+   via state classes (.show/.open), but the console also toggles the
+   [hidden] attribute (advanced filters, sql panel); an element whose
+   class sets display:flex/grid would otherwise beat [hidden]. */
+[hidden] { display: none !important; }
+
+/* Capability gating: a [data-capability] surface (Time-travel nav,
+   monitor fieldset/hint) stays hidden until gateCapabilities() adds
+   .cap-on. The :not() + !important hides by default and restores the
+   element's own display once gated on — no flash, no per-element value. */
+[data-capability]:not(.cap-on) { display: none !important; }
+
+/* result/meta lines reused across Events, Recover, Reconstruct */
+.meta-line {
+  display: flex; align-items: center; gap: 12px; flex-wrap: wrap;
+  font-family: var(--f-mono); font-size: 11.5px; color: var(--ink-3);
+  margin: 4px 0 14px;
+}
+.meta-line b { color: var(--ink); font-weight: 600; }
+
+/* generic empty / deleted notes */
+.deleted-note {
+  font-family: var(--f-mono); font-size: 12.5px; color: var(--ink-2);
+  background: var(--surface-2); border: 1px solid var(--line);
+  border-radius: var(--radius-sm); padding: 14px 16px;
+}
+
+/* error + warning surfaces (mapped onto the warm palette) */
+.error-box {
+  font-family: var(--f-mono); font-size: 12.5px; color: var(--delete);
+  background: var(--delete-bg); border: 1px solid var(--delete);
+  border-radius: var(--radius-sm); padding: 12px 14px; margin: 8px 0;
   white-space: pre-wrap;
-  word-break: break-word;
 }
-.form-msg { width: 100%; font-size: 12.5px; min-height: 1em; }
-.form-msg.err { color: var(--del); }
-.form-msg.ok { color: var(--ok); }
-
-#server-add-wrap { margin-top: 12px; }
-
-.timeline { margin-top: 16px; border-left: 2px solid var(--border); padding-left: 18px; }
-.tl-entry { position: relative; padding: 8px 0 14px; }
-.tl-entry::before {
-  content: "";
-  position: absolute;
-  left: -25px;
-  top: 12px;
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  background: var(--accent);
-  border: 2px solid var(--bg);
+.warnings:empty { display: none; }
+.warn-item {
+  display: flex; gap: 8px; align-items: flex-start;
+  font-family: var(--f-mono); font-size: 12px; color: var(--orange-2);
+  background: var(--orange-bg); border: 1px solid var(--ochre);
+  border-radius: var(--radius-sm); padding: 9px 12px; margin: 6px 0;
 }
-.tl-head { display: flex; align-items: center; gap: 10px; margin-bottom: 4px; }
-.tl-time { color: var(--muted); font-family: var(--mono); font-size: 12px; }
-.tl-state { font-family: var(--mono); font-size: 12px; color: var(--text); white-space: pre-wrap; word-break: break-word; }
-.badge.baseline { color: var(--muted); border: 1px solid var(--muted); }
+
+/* export buttons in the events result bar */
+.export-bar { display: inline-flex; gap: 7px; margin-left: auto; }
+
+/* point-in-time state table (Time-travel "Value as of T") */
+.statetable { width: 100%; border-collapse: collapse; font-family: var(--f-mono); font-size: 12.5px; }
+.statetable th, .statetable td {
+  text-align: left; padding: 7px 12px; border-bottom: 1px solid var(--line-soft);
+  vertical-align: top;
+}
+.statetable th { color: var(--ink-3); font-weight: 600; width: 200px; }
+.statetable td { color: var(--ink); }
+
+/* ---- servers modal: management depth ---- */
+.srv-item .row-acts { display: inline-flex; gap: 7px; margin-left: auto; }
+.health-dot {
+  width: 8px; height: 8px; border-radius: 50%; flex: none;
+  background: var(--ink-4); box-shadow: 0 0 0 3px var(--surface-3);
+}
+.health-dot.ok { background: var(--insert); }
+.srv-desc { font-family: var(--f-mono); font-size: 11.5px; color: var(--ink-3); }
+.srv-status { font-family: var(--f-mono); font-size: 11px; }
+.srv-status.ok { color: var(--insert); }
+.srv-status.err { color: var(--delete); }
+.chip.chip-mon {
+  color: var(--orange-2); border-color: var(--ochre); background: var(--ochre-bg);
+}
+
+/* add/edit server form messages */
+.form-msg { font-family: var(--f-mono); font-size: 12px; margin-top: 10px; min-height: 1em; }
+.form-msg.ok { color: var(--insert); }
+.form-msg.err { color: var(--delete); }
+
+/* doctor preflight cards (monitor start) */
+.doctor-cards { display: flex; flex-direction: column; gap: 8px; margin-top: 14px; }
+.doctor-card {
+  display: flex; gap: 10px; align-items: flex-start;
+  border: 1px solid var(--line); border-radius: var(--radius-sm);
+  padding: 10px 12px; background: var(--surface-2);
+}
+.doctor-card.pass { border-color: var(--insert); }
+.doctor-card.fail { border-color: var(--delete); }
+.doctor-card.warn { border-color: var(--ochre); }
+.dc-mark { font-family: var(--f-mono); font-weight: 700; line-height: 1.4; flex: none; }
+.doctor-card.pass .dc-mark { color: var(--insert); }
+.doctor-card.fail .dc-mark { color: var(--delete); }
+.doctor-card.warn .dc-mark { color: var(--orange-2); }
+.dc-body { flex: 1; min-width: 0; }
+.dc-name { font-family: var(--f-ui); font-size: 13px; color: var(--ink); }
+.dc-rem {
+  font-family: var(--f-mono); font-size: 11.5px; color: var(--ink-2);
+  background: var(--surface-3); border-radius: 4px; padding: 8px 10px;
+  margin: 6px 0 0; white-space: pre-wrap; overflow-x: auto;
+}
+
+/* toast — absent from the design system; small, unobtrusive */
+.toast {
+  position: fixed; left: 50%; bottom: 28px; transform: translateX(-50%);
+  z-index: 60; max-width: 80vw;
+  font-family: var(--f-ui); font-size: 13px; color: var(--bg);
+  background: var(--ink); border-radius: var(--radius-sm);
+  padding: 11px 18px; box-shadow: 0 8px 28px -10px oklch(0.3 0.02 60 / 0.5);
+}
+
+/* loading shimmer for #view while a screen fetches */
+.view-loading { font-family: var(--f-mono); font-size: 12.5px; color: var(--ink-4); padding: 20px 2px; }

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -1068,8 +1068,8 @@ button { font-family: inherit; }
 
 /* The hidden attribute must always win. The new design hides overlays
    via state classes (.show/.open), but the console also toggles the
-   [hidden] attribute (advanced filters, sql panel); an element whose
-   class sets display:flex/grid would otherwise beat [hidden]. */
+   [hidden] attribute (advanced filters, toast, the add-server wrap); an
+   element whose class sets display:flex/grid would otherwise beat [hidden]. */
 [hidden] { display: none !important; }
 
 /* Capability gating: a [data-capability] surface (Time-travel nav,
@@ -1107,9 +1107,6 @@ button { font-family: inherit; }
   background: var(--orange-bg); border: 1px solid var(--ochre);
   border-radius: var(--radius-sm); padding: 9px 12px; margin: 6px 0;
 }
-
-/* export buttons in the events result bar */
-.export-bar { display: inline-flex; gap: 7px; margin-left: auto; }
 
 /* point-in-time state table (Time-travel "Value as of T") */
 .statetable { width: 100%; border-collapse: collapse; font-family: var(--f-mono); font-size: 12.5px; }


### PR DESCRIPTION
## What

Reskin the embedded `bintrail console` web UI to the editorial design system from the UI handoff (`bintrail_ui.zip`). **The look and flows are the prototype's; the backend is untouched** — same JSON API, Bearer auth, multi-server, RBAC, and reconstruct/monitor gating, zero backend churn.

### Why a reskin (and not the handoff's htmx stack)

The handoff was authored as Go `html/template` + htmx. We kept the vanilla-JS SPA instead, by design:

- Preserves the documented **zero-third-party-deps / single-binary** guarantee (`VENDOR.md`) — no htmx, no bundler.
- Keeps all the hard-won backend correctness (auth, multi-server, RBAC, capability gating, reconstruct, monitor) with **no changes**.
- It's the **better base for adding real auth later**: the seam stays the one-line `tokenMiddleware` (`auth.go`) — swap the validation for login/OIDC/per-user-RBAC and the `Authorization: Bearer` transport is unchanged. htmx would lean on cookies and reopen the CSRF surface the custom-header design deliberately closes.

## Changed files

- **`internal/console/assets/style.css`** — the design system verbatim + a small "functional additions" block for the pieces the prototype scaffold omitted (capability gating `[data-capability]:not(.cap-on)`, the defensive `[hidden]{display:none!important}`, toast, doctor cards, errors/warnings, export), built only from the design tokens.
- **`internal/console/assets/index.html`** — sidebar shell with nav groups (Overview / Investigate / Resolve / Monitor), server switcher, ⌘K trigger, footer. **No web-font CDN** — `system-ui` fallback keeps the zero-deps guarantee and avoids an external request from an airgapped/forensic host.
- **`internal/console/assets/app.js`** — rewritten as a routed SPA. New surfaces: **Overview** landing (client-side aggregation over `/api/status` + an `/api/events` page — no new endpoint), **smart search** with tokens (`type:`/`pk:`/`col:`/`schema.table`), inline before/after **diff**, an **Undo** bridge to Recover with a context banner, a **Time-travel timeline**, a **⌘K command palette**, and **j/k** row navigation. All prior security/behavior invariants preserved (token bootstrap+strip, `X-Bintrail-Server` captured at dispatch, `serverGen` staleness guard on every async render, `.cap-on` gating, keep-password PUT semantics, exports that stay `connection_id`-free). The DOM is built with `el()`/`textContent` only — **no `innerHTML`**; static SVG icons are parsed via `DOMParser`.
- **`docs/console.md`** — UI walkthrough updated to the sidebar/Overview/⌘K structure (was "four tabs").

## Verification

Real headless-Chrome drive against a mock backend in **both** configs:

- Full-capability (`reconstruct:true, monitor:true`): **29/29**, no JS errors.
- Common gated config (`reconstruct:false, monitor:false`): **9/9** — caught and fixed an **infinite recursion** in the gated Time-travel redirect (a `push:false` redirect left the URL stale and re-resolved into itself).

Adversarial review (behavior-preservation + security): all 15 prior behaviors preserved; `connection_id` open-core omission intact; no HTML-injection path. `go build`, `go vet`, and `go test ./internal/console/...` green.

## Two semantic notes (reviewer decisions, not surprises)

1. **Smart search** treats a bare word as a free-text term filtered client-side over the fetched page (like the prototype) — it does **not** map to an exact `table=` filter, which would silently return 0 rows for a value/column search. Precise table filtering is still available via the **Filters** panel or the `table:` token.
2. **"Undo this change"** uses the filter-based recover API, so it reverses **all of that row's changes up to the event's timestamp**, not a single event (the API has no per-event recover). It's read-only — the operator reviews the SQL — and the banner reads "reverting this row to before this point".

**Pre-existing, unchanged:** `csvCell` does not neutralize spreadsheet formula injection (`= + - @`). Identical to the prior code; left as-is for forensic export fidelity. Happy to harden if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
