### PR TITLE
refactor(deps): relocate server-identity helpers to byos (decouple PR-B slice 3)

### DIFF
--- a/cmd/bintrail/agent.go
+++ b/cmd/bintrail/agent.go
@@ -219,7 +219,7 @@ func runAgent(cmd *cobra.Command, args []string) error {
 	// signal until queries return wrong results.
 	var sourceIdent byos.SourceIdentity
 	if sourceDB != nil {
-		ident, err := loadSourceIdentity(cmd.Context(), sourceDB, agtSourceDSN)
+		ident, err := byos.LoadSourceIdentity(cmd.Context(), sourceDB, agtSourceDSN)
 		if err != nil {
 			return fmt.Errorf("capture source identity for BYOS metadata: %w", err)
 		}
@@ -230,7 +230,7 @@ func runAgent(cmd *cobra.Command, args []string) error {
 	// records and WebSocket heartbeats. Requires both source and index DBs.
 	var bintrailID string
 	if sourceDB != nil && indexDB != nil {
-		id, err := resolveServerIdentity(cmd.Context(), sourceDB, indexDB, agtSourceDSN)
+		id, err := byos.ResolveServerIdentity(cmd.Context(), sourceDB, indexDB, agtSourceDSN)
 		if err != nil {
 			if errors.Is(err, serverid.ErrConflict) {
 				return fmt.Errorf("cannot start agent: %w", err)
@@ -249,7 +249,7 @@ func runAgent(cmd *cobra.Command, args []string) error {
 	} else if byosMode {
 		// BYOS without --index-dsn: the SaaS now resolves a stable
 		// bintrail_id server-side from the @@server_uuid + host/port/user
-		// fields that `loadSourceIdentity` captured above and that
+		// fields that `byos.LoadSourceIdentity` captured above and that
 		// `SplitEvent` stamps on every metadata record (architecture §22.11,
 		// implemented in nethalo/dbtrail#1179). The customer agent no
 		// longer needs a local index DB — the SaaS bt_<prefix>.bintrail_servers

--- a/cmd/bintrail/index.go
+++ b/cmd/bintrail/index.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/dbtrail/bintrail/internal/byos"
 	"github.com/dbtrail/bintrail/internal/cliutil"
 	"github.com/dbtrail/bintrail/internal/config"
 	"github.com/dbtrail/bintrail/internal/indexer"
@@ -115,7 +116,7 @@ func runIndex(cmd *cobra.Command, args []string) error {
 	var bintrailID string
 	if sourceDB != nil {
 		var idErr error
-		bintrailID, idErr = resolveServerIdentity(ctx, sourceDB, indexDB, idxSourceDSN)
+		bintrailID, idErr = byos.ResolveServerIdentity(ctx, sourceDB, indexDB, idxSourceDSN)
 		if idErr != nil {
 			if errors.Is(idErr, serverid.ErrConflict) {
 				return fmt.Errorf("cannot index: %w", idErr)

--- a/cmd/bintrail/snapshot.go
+++ b/cmd/bintrail/snapshot.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/dbtrail/bintrail/internal/byos"
 	"github.com/dbtrail/bintrail/internal/cliutil"
 	"github.com/dbtrail/bintrail/internal/config"
 	"github.com/dbtrail/bintrail/internal/metadata"
@@ -64,7 +65,7 @@ func runSnapshot(cmd *cobra.Command, args []string) error {
 	defer indexDB.Close()
 
 	// Resolve server identity before doing any index work.
-	bintrailID, err := resolveServerIdentity(cmd.Context(), sourceDB, indexDB, snapshotSourceDSN)
+	bintrailID, err := byos.ResolveServerIdentity(cmd.Context(), sourceDB, indexDB, snapshotSourceDSN)
 	if err != nil {
 		if errors.Is(err, serverid.ErrConflict) {
 			return fmt.Errorf("cannot snapshot: %w", err)

--- a/cmd/bintrail/stream.go
+++ b/cmd/bintrail/stream.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/dbtrail/bintrail/internal/byos"
 	"github.com/dbtrail/bintrail/internal/cliutil"
 	"github.com/dbtrail/bintrail/internal/config"
 	"github.com/dbtrail/bintrail/internal/indexer"
@@ -111,7 +112,7 @@ func streamDeps() streamrun.Deps {
 		ValidateBinlogRowImage: metadata.ValidateBinlogRowImage,
 		ValidateNoFKCascades:   metadata.ValidateNoFKCascades,
 		ParseSchemaList:        cliutil.ParseSchemaList,
-		ResolveServerIdentity:  resolveServerIdentity,
+		ResolveServerIdentity:  byos.ResolveServerIdentity,
 		EnsureResolver:         metadata.EnsureResolver,
 		BuildIndexFilters:      cliutil.BuildIndexFilters,
 		InsertSchemaChange:     indexer.InsertSchemaChange,

--- a/internal/byos/identity.go
+++ b/internal/byos/identity.go
@@ -1,42 +1,41 @@
-package main
+package byos
 
 import (
 	"context"
 	"database/sql"
 	"fmt"
 
-	"github.com/dbtrail/bintrail/internal/byos"
 	"github.com/dbtrail/bintrail/internal/config"
 	"github.com/dbtrail/bintrail/internal/serverid"
 )
 
-// resolveServerIdentity queries @@server_uuid from sourceDB, parses the host,
+// ResolveServerIdentity queries @@server_uuid from sourceDB, parses the host,
 // port, and username from sourceDSN, then resolves or registers the server in
 // the index database. Returns the stable bintrail_id.
-func resolveServerIdentity(ctx context.Context, sourceDB, indexDB *sql.DB, sourceDSN string) (string, error) {
-	ident, err := loadSourceIdentity(ctx, sourceDB, sourceDSN)
+func ResolveServerIdentity(ctx context.Context, sourceDB, indexDB *sql.DB, sourceDSN string) (string, error) {
+	ident, err := LoadSourceIdentity(ctx, sourceDB, sourceDSN)
 	if err != nil {
 		return "", err
 	}
 	return serverid.ResolveServer(ctx, indexDB, ident.ServerUUID, ident.Host, uint16(ident.Port), ident.User)
 }
 
-// loadSourceIdentity captures the source MySQL server's @@server_uuid plus
+// LoadSourceIdentity captures the source MySQL server's @@server_uuid plus
 // host/port/user parsed from sourceDSN. The result is stamped onto every
 // BYOS MetadataRecord so the dbtrail SaaS side can resolve a stable
 // bintrail_id against its own bintrail_servers table — see
 // bintrail-saas-architecture.md §22.11. Safe to call even when no index DB
 // is available locally (the agent is running in fully stateless BYOS mode).
-func loadSourceIdentity(ctx context.Context, sourceDB *sql.DB, sourceDSN string) (byos.SourceIdentity, error) {
+func LoadSourceIdentity(ctx context.Context, sourceDB *sql.DB, sourceDSN string) (SourceIdentity, error) {
 	var serverUUID string
 	if err := sourceDB.QueryRowContext(ctx, "SELECT @@server_uuid").Scan(&serverUUID); err != nil {
-		return byos.SourceIdentity{}, fmt.Errorf("query server_uuid: %w", err)
+		return SourceIdentity{}, fmt.Errorf("query server_uuid: %w", err)
 	}
 	host, port, user, _, err := config.ParseSourceDSN(sourceDSN)
 	if err != nil {
-		return byos.SourceIdentity{}, err
+		return SourceIdentity{}, err
 	}
-	return byos.SourceIdentity{
+	return SourceIdentity{
 		ServerUUID: serverUUID,
 		Host:       host,
 		Port:       int(port),

--- a/internal/byos/identity_test.go
+++ b/internal/byos/identity_test.go
@@ -1,4 +1,4 @@
-package main
+package byos
 
 import (
 	"context"
@@ -20,7 +20,7 @@ func TestLoadSourceIdentityHappyPath(t *testing.T) {
 		sqlmock.NewRows([]string{"@@server_uuid"}).
 			AddRow("11111111-2222-3333-4444-555555555555"))
 
-	ident, err := loadSourceIdentity(context.Background(), db, "repluser:secret@tcp(10.0.0.5:3306)/")
+	ident, err := LoadSourceIdentity(context.Background(), db, "repluser:secret@tcp(10.0.0.5:3306)/")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -45,7 +45,7 @@ func TestLoadSourceIdentityServerUUIDQueryFails(t *testing.T) {
 
 	mock.ExpectQuery("SELECT @@server_uuid").WillReturnError(errors.New("connection refused"))
 
-	_, err = loadSourceIdentity(context.Background(), db, "u:p@tcp(h:3306)/")
+	_, err = LoadSourceIdentity(context.Background(), db, "u:p@tcp(h:3306)/")
 	if err == nil {
 		t.Fatal("expected error when @@server_uuid query fails")
 	}
@@ -65,7 +65,7 @@ func TestLoadSourceIdentityBadDSN(t *testing.T) {
 		sqlmock.NewRows([]string{"@@server_uuid"}).AddRow("uuid-x"))
 
 	// config.ParseSourceDSN rejects unix sockets — use that as the easy bad-DSN trigger.
-	_, err = loadSourceIdentity(context.Background(), db, "u:p@unix(/tmp/sock)/")
+	_, err = LoadSourceIdentity(context.Background(), db, "u:p@unix(/tmp/sock)/")
 	if err == nil {
 		t.Fatal("expected error for unix-socket DSN")
 	}


### PR DESCRIPTION
> Supersedes #433 (GitHub auto-closed that one when its stacked base branch `decouple-deps-slice2` was deleted on #432's merge). Same commit, rebased onto `main` (slice 2 is already merged via #432). The review on #433 applies verbatim — this is byte-identical content.

## What

**PR-B slice 3 (final)** of relocating the `streamDeps` helpers to `internal/` (so a future `bintrail-console` binary can reach them). Moves the server-identity pair out of `cmd/bintrail` (package main) into `internal/byos`:

| helper | new home |
|---|---|
| `loadSourceIdentity` | `byos.LoadSourceIdentity` |
| `resolveServerIdentity` | `byos.ResolveServerIdentity` |

`cmd/bintrail/serverutil.go` + `serverutil_test.go` are **deleted** (git tracks both as renames into `internal/byos/identity.go` + `identity_test.go`).

## Why byos

These two helpers already operated on `byos.SourceIdentity` (defined in `byos/split.go`) — they were the only thing about server identity living *outside* `byos`. Moving them home means `LoadSourceIdentity` references `SourceIdentity` un-qualified, and the cmd layer no longer owns identity logic at all.

## Pure relocation, zero behavior change

- Bodies **moved verbatim** and exported. Only edits: `package main`→`byos`, the export-casing of the two names, and dropping the `byos.` qualifier off `SourceIdentity` (now in-package).
- Callers (`snapshot`/`index`/`agent` + `stream`'s `streamDeps`) rewired to `byos.*`; the now-stale `loadSourceIdentity` comment in `agent.go` updated.
- **Import edges added:** `byos→config` (`ParseSourceDSN`), `byos→serverid` (`ResolveServer`). Both safe — `config` and `serverid` do **not** import `byos` (grep-verified), so the package graph stays acyclic. `internal/streamrun` untouched.

## Verification

- `go build` / `go vet` clean (unit **and** `-tags integration`).
- Full unit suite green — incl. the three `TestLoadSourceIdentity_*` relocated to `internal/byos` (package byos).
- `monitor`/`supervisor` integration tests pass against MySQL — they exercise the relocated helper **end-to-end** (`streamDeps()` → `streamrun.One` runs `byos.ResolveServerIdentity`).

## PR-B complete after this

Every `streamDeps` helper now lives in `internal/` (slices 1 #431, 2 #432, 3 this). Deferred follow-up (separate PR on clean main, per review): unexport `metadata.BuildFKCascadeQuery` + relocate the metadata integration tests home + minor comment scrubs. Still TODO before the PR-D supervisor move: `doctor`/`ensureDatabase`/`createIndexTables`/`deriveServerID` + the `upRotationCfg` global → `internal/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
