### PR TITLE
refactor(deps): relocate deriveServerID to internal/serverid (decouple PR-B' slice A)

### DIFF
--- a/cmd/bintrail/doctor_test.go
+++ b/cmd/bintrail/doctor_test.go
@@ -70,54 +70,6 @@ func TestExtractGrantUser(t *testing.T) {
 	}
 }
 
-func TestDeriveServerID(t *testing.T) {
-	const dsn = "user:pass@tcp(source.example.com:3306)/mydb"
-	id1, err := deriveServerID(dsn)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	id2, err := deriveServerID(dsn)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if id1 != id2 {
-		t.Errorf("deriveServerID is not deterministic: %d vs %d", id1, id2)
-	}
-
-	// Range invariant: must be >= 100M to keep distance from the 1-1000 zone
-	// most production replicas use. The PR-review caught a typo that broke
-	// this — keep the assertion strict.
-	if id1 < 100000000 {
-		t.Errorf("deriveServerID produced %d, expected >= 100000000", id1)
-	}
-
-	// Distinct DSNs produce distinct IDs. With 100 generated inputs the
-	// probability of any collision in a 4.2B range is < 10^-15 — this catches
-	// regressions like a stub returning a constant, or a hash truncation bug
-	// that compresses into a 16-bit space.
-	seen := make(map[uint32]string, 100)
-	for i := range 100 {
-		gen := fmt.Sprintf("u:p@tcp(host%d.example.com:3306)/db", i)
-		id, err := deriveServerID(gen)
-		if err != nil {
-			t.Fatalf("deriveServerID(%q) error: %v", gen, err)
-		}
-		if id < 100000000 {
-			t.Errorf("deriveServerID(%q) = %d, below floor 100000000", gen, id)
-		}
-		if prev, dup := seen[id]; dup {
-			t.Errorf("collision: %q and %q both produced %d", prev, gen, id)
-		}
-		seen[id] = gen
-	}
-
-	// Bad DSN returns an error rather than silently substituting a
-	// non-deterministic value (the silent-failure fix).
-	if _, err := deriveServerID("not-a-dsn"); err == nil {
-		t.Error("expected error for unparseable DSN; got nil")
-	}
-}
-
 func TestDoctorReportAdd(t *testing.T) {
 	r := &doctorReport{}
 	r.add(checkResult{Name: "a", Status: statusPass})

--- a/cmd/bintrail/monitor.go
+++ b/cmd/bintrail/monitor.go
@@ -16,6 +16,7 @@ import (
 	"github.com/dbtrail/bintrail/internal/config"
 	"github.com/dbtrail/bintrail/internal/console"
 	"github.com/dbtrail/bintrail/internal/indexer"
+	"github.com/dbtrail/bintrail/internal/serverid"
 	"github.com/dbtrail/bintrail/internal/streamrun"
 )
 
@@ -367,7 +368,7 @@ func (m *monitorSupervisor) Start(ctx context.Context, e console.ServerEntry) er
 	// ── Launch the supervised stream ─────────────────────────────────────
 	serverID := e.SourceServerID
 	if serverID == 0 {
-		serverID, err = deriveServerID(e.SourceDSN)
+		serverID, err = serverid.DeriveServerID(e.SourceDSN)
 		if err != nil {
 			lockDB.Close()
 			return fail(fmt.Errorf("derive server id: %w", err))

--- a/cmd/bintrail/up.go
+++ b/cmd/bintrail/up.go
@@ -2,9 +2,7 @@ package main
 
 import (
 	"context"
-	"crypto/sha256"
 	"database/sql"
-	"encoding/binary"
 	"fmt"
 	"log/slog"
 	"os"
@@ -19,6 +17,7 @@ import (
 	"github.com/dbtrail/bintrail/internal/config"
 	"github.com/dbtrail/bintrail/internal/console"
 	"github.com/dbtrail/bintrail/internal/indexer"
+	"github.com/dbtrail/bintrail/internal/serverid"
 	"github.com/dbtrail/bintrail/internal/streamrun"
 )
 
@@ -326,7 +325,7 @@ func runUpInit(cmd *cobra.Command) error {
 func runUpStream(cmd *cobra.Command, args []string) error {
 	serverID := upServerID
 	if serverID == 0 {
-		id, err := deriveServerID(upSourceDSN)
+		id, err := serverid.DeriveServerID(upSourceDSN)
 		if err != nil {
 			return fmt.Errorf("cannot auto-derive --server-id from --source-dsn: %w (pass --server-id explicitly to bypass)", err)
 		}
@@ -546,30 +545,4 @@ func populateStreamFlags(serverID uint32) {
 	strmReset = false
 	strmNoGapFill = false
 	strmGapTimeout = 30
-}
-
-// deriveServerID returns a deterministic uint32 server-id by hashing the
-// source DSN's host:user:dbname triple. The same DSN always produces the same
-// ID, so `bintrail up` resumes cleanly across restarts without the user
-// remembering what server-id they used last time.
-//
-// Returns an error when the DSN cannot be parsed — callers must handle this
-// rather than silently substituting a non-deterministic value, because a
-// per-invocation ID breaks the resume-from-checkpoint contract (MySQL would
-// treat each restart as a new replica).
-func deriveServerID(dsn string) (uint32, error) {
-	cfg, err := mysql.ParseDSN(dsn)
-	if err != nil {
-		return 0, fmt.Errorf("parse DSN: %w", err)
-	}
-	seed := fmt.Sprintf("%s|%s|%s", cfg.Addr, cfg.User, cfg.DBName)
-	sum := sha256.Sum256([]byte(seed))
-	raw := binary.BigEndian.Uint32(sum[:4])
-	// Map into [100000000, 4294967294]: subtract floor from uint32 range, mod
-	// into the resulting width, then add the floor back. Keeps the value high
-	// enough that collisions with typical hand-picked replica server-ids are
-	// unlikely.
-	const floor = uint32(100000000)
-	const width = uint32(4294967295 - floor) // 4194967295
-	return (raw % width) + floor, nil
 }

--- a/internal/serverid/serverid.go
+++ b/internal/serverid/serverid.go
@@ -6,10 +6,13 @@ package serverid
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/binary"
 	"errors"
 	"fmt"
 
+	"github.com/go-sql-driver/mysql"
 	"github.com/google/uuid"
 )
 
@@ -268,4 +271,30 @@ func DecommissionServer(ctx context.Context, db *sql.DB, bintrailID string) erro
 		return fmt.Errorf("bintrail_id %q not found or already decommissioned", bintrailID)
 	}
 	return nil
+}
+
+// DeriveServerID returns a deterministic uint32 server-id by hashing the
+// source DSN's host:user:dbname triple. The same DSN always produces the same
+// ID, so `bintrail up` resumes cleanly across restarts without the user
+// remembering what server-id they used last time.
+//
+// Returns an error when the DSN cannot be parsed — callers must handle this
+// rather than silently substituting a non-deterministic value, because a
+// per-invocation ID breaks the resume-from-checkpoint contract (MySQL would
+// treat each restart as a new replica).
+func DeriveServerID(dsn string) (uint32, error) {
+	cfg, err := mysql.ParseDSN(dsn)
+	if err != nil {
+		return 0, fmt.Errorf("parse DSN: %w", err)
+	}
+	seed := fmt.Sprintf("%s|%s|%s", cfg.Addr, cfg.User, cfg.DBName)
+	sum := sha256.Sum256([]byte(seed))
+	raw := binary.BigEndian.Uint32(sum[:4])
+	// Map into [100000000, 4294967294]: subtract floor from uint32 range, mod
+	// into the resulting width, then add the floor back. Keeps the value high
+	// enough that collisions with typical hand-picked replica server-ids are
+	// unlikely.
+	const floor = uint32(100000000)
+	const width = uint32(4294967295 - floor) // 4194967295
+	return (raw % width) + floor, nil
 }

--- a/internal/serverid/serverid_test.go
+++ b/internal/serverid/serverid_test.go
@@ -1,6 +1,7 @@
 package serverid
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -123,5 +124,52 @@ func TestResolveIdentity_UsernameScope(t *testing.T) {
 	}
 	if matched == nil || matched.BintrailID != "bt-1" {
 		t.Errorf("expected bt-1, got %v", matched)
+	}
+}
+func TestDeriveServerID(t *testing.T) {
+	const dsn = "user:pass@tcp(source.example.com:3306)/mydb"
+	id1, err := DeriveServerID(dsn)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	id2, err := DeriveServerID(dsn)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id1 != id2 {
+		t.Errorf("DeriveServerID is not deterministic: %d vs %d", id1, id2)
+	}
+
+	// Range invariant: must be >= 100M to keep distance from the 1-1000 zone
+	// most production replicas use. The PR-review caught a typo that broke
+	// this — keep the assertion strict.
+	if id1 < 100000000 {
+		t.Errorf("DeriveServerID produced %d, expected >= 100000000", id1)
+	}
+
+	// Distinct DSNs produce distinct IDs. With 100 generated inputs the
+	// probability of any collision in a 4.2B range is < 10^-15 — this catches
+	// regressions like a stub returning a constant, or a hash truncation bug
+	// that compresses into a 16-bit space.
+	seen := make(map[uint32]string, 100)
+	for i := range 100 {
+		gen := fmt.Sprintf("u:p@tcp(host%d.example.com:3306)/db", i)
+		id, err := DeriveServerID(gen)
+		if err != nil {
+			t.Fatalf("DeriveServerID(%q) error: %v", gen, err)
+		}
+		if id < 100000000 {
+			t.Errorf("DeriveServerID(%q) = %d, below floor 100000000", gen, id)
+		}
+		if prev, dup := seen[id]; dup {
+			t.Errorf("collision: %q and %q both produced %d", prev, gen, id)
+		}
+		seen[id] = gen
+	}
+
+	// Bad DSN returns an error rather than silently substituting a
+	// non-deterministic value (the silent-failure fix).
+	if _, err := DeriveServerID("not-a-dsn"); err == nil {
+		t.Error("expected error for unparseable DSN; got nil")
 	}
 }


### PR DESCRIPTION
## What

First slice of relocating the **monitor/supervisor's** remaining `package main` dependencies into `internal/` — the precursor to the PR-D pivot that moves the supervisor + `bintrail up --console` into the new `cmd/bintrail-console` binary. (The `streamDeps` family is already done: #430/#431/#432/#434.)

This is the **leaf**: `deriveServerID` has zero `package main` dependencies (pure DSN→`uint32` hash), so it moves clean and first.

| helper | new home |
|---|---|
| `deriveServerID` | `serverid.DeriveServerID` |

## Pure relocation, zero behavior change

- Body **moved verbatim** and exported. `internal/serverid` gains `crypto/sha256`, `encoding/binary`, `go-sql-driver/mysql` imports — **no cycle**: `serverid` is a leaf imported BY `init`/`agent`/`up`/`monitor`, and imports none of them.
- Callers rewired: `up.go` (`runUpStream`), `monitor.go` (`monitorSupervisor.Start`).
- `up.go` drops the now-orphan `crypto/sha256` + `encoding/binary` imports (`mysql` stays — used by other `up.go` paths).
- `TestDeriveServerID` moved to `internal/serverid/serverid_test.go`.

## Verification

- `go build` / `go vet` clean (unit **and** `-tags integration`).
- Full unit suite green (incl. the moved `DeriveServerID` test).
- `monitor`/`supervisor` integration test passes against MySQL — exercises `serverid.DeriveServerID` end-to-end via `monitorSupervisor.Start`.

## Plan (PR-B' — the monitor's remaining deps; architect-blueprinted, leaf-first)

| slice | scope | status |
|---|---|---|
| **A (this)** | `deriveServerID` → serverid | this PR |
| B | DDL consts + `createIndexTables`/`ensureDatabase` + `partitionDate/Name` → indexer | next |
| C | `upRotationCfg` global → param on `monitorSupervisor` | after B |
| D | `buildDoctorReport` + capacity + diskfree → new `internal/doctor` | last (largest) |

After D, the supervisor's callees all live in `internal/` and the PR-D pivot (move supervisor + `up --console` to `cmd/bintrail-console`) is unblocked. Landmine already found for D: `hasReplPrivileges` (in `agent_validate.go`) is shared between the doctor subgraph and `agent --validate`, so it needs a neutral shared home, not `internal/doctor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)