### PR TITLE
refactor(deps): relocate partition name helpers to internal/indexer (decouple PR-B' slice B1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,7 +162,7 @@ After `json.Unmarshal` into `map[string]any`, **all numbers are `float64`**. `fo
 Pipe-delimited with `|` → `\|` and `\` → `\\` escaping. See `BuildPKValues` in `parser/parser.go`.
 
 ### Partition management
-- `partitionName(d)` → `"p_YYYYMMDDHH"` (Go format `"p_2006010215"`); `partitionDate(name)` parses back.
+- `indexer.PartitionName(d)` → `"p_YYYYMMDDHH"` (Go format `"p_2006010215"`); `indexer.PartitionDate(name)` parses back.
 - Add: `REORGANIZE PARTITION p_future INTO (... new ..., PARTITION p_future VALUES LESS THAN MAXVALUE)`. **Never leave out p_future.**
 - Drop: `ALTER TABLE … DROP PARTITION p1, p2` — single statement.
 - `DescriptionToHuman`: `time.Unix(secs-62167219200, 0)` (since `TO_SECONDS('1970-01-01') = 62167219200`).

--- a/cmd/bintrail/archive_integration_test.go
+++ b/cmd/bintrail/archive_integration_test.go
@@ -38,14 +38,14 @@ func TestArchiveReconcileRebuild(t *testing.T) {
 
 	archiveDir := t.TempDir()
 	const bintrailID = "deadbeef-dead-beef-dead-beefdeadbeef" // 36 chars, matches archivePathRe
-	outPath, err := hiveArchivePath(archiveDir, bintrailID, partitionName(h1))
+	outPath, err := hiveArchivePath(archiveDir, bintrailID, indexer.PartitionName(h1))
 	if err != nil {
 		t.Fatalf("hiveArchivePath: %v", err)
 	}
 	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	n, err := archive.ArchivePartition(ctx, db, dbName, partitionName(h1), outPath, "zstd")
+	n, err := archive.ArchivePartition(ctx, db, dbName, indexer.PartitionName(h1), outPath, "zstd")
 	if err != nil {
 		t.Fatalf("ArchivePartition: %v", err)
 	}
@@ -62,7 +62,7 @@ func TestArchiveReconcileRebuild(t *testing.T) {
 	if len(files) != 1 {
 		t.Fatalf("expected 1 scanned file, got %d: %+v", len(files), files)
 	}
-	if files[0].BintrailID != bintrailID || files[0].PartitionName != partitionName(h1) {
+	if files[0].BintrailID != bintrailID || files[0].PartitionName != indexer.PartitionName(h1) {
 		t.Fatalf("scan derivation wrong: %+v", files[0])
 	}
 	if !files[0].RowCount.Valid || files[0].RowCount.Int64 != 1 {
@@ -99,7 +99,7 @@ func TestArchiveReconcileRebuild(t *testing.T) {
 	if err := db.QueryRowContext(ctx, `
 		SELECT local_path, file_size_bytes, row_count, s3_bucket, s3_uploaded_at
 		FROM archive_state WHERE partition_name = ? AND bintrail_id = ?`,
-		partitionName(h1), bintrailID).
+		indexer.PartitionName(h1), bintrailID).
 		Scan(&localPath, &fileSize, &rowCount, &s3Bucket, &s3UploadedAt); err != nil {
 		t.Fatalf("rebuilt row missing: %v", err)
 	}
@@ -219,13 +219,13 @@ func TestParseArchivePathRoundTrip(t *testing.T) {
 		time.Date(2026, 12, 31, 23, 0, 0, 0, time.UTC),
 	}
 	for _, h := range hours {
-		p, err := hiveArchivePath("/var/archives", id, partitionName(h))
+		p, err := hiveArchivePath("/var/archives", id, indexer.PartitionName(h))
 		if err != nil {
 			t.Fatalf("hiveArchivePath(%v): %v", h, err)
 		}
 		gotID, gotPart := parseArchivePath(p)
-		if gotID != id || gotPart != partitionName(h) {
-			t.Errorf("round-trip(%s): got (%s, %s), want (%s, %s)", p, gotID, gotPart, id, partitionName(h))
+		if gotID != id || gotPart != indexer.PartitionName(h) {
+			t.Errorf("round-trip(%s): got (%s, %s), want (%s, %s)", p, gotID, gotPart, id, indexer.PartitionName(h))
 		}
 	}
 }

--- a/cmd/bintrail/cmd_integration_test.go
+++ b/cmd/bintrail/cmd_integration_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/parquet-go/parquet-go"
 
 	"github.com/dbtrail/bintrail/internal/archive"
+	"github.com/dbtrail/bintrail/internal/indexer"
 	"github.com/dbtrail/bintrail/internal/serverid"
 	"github.com/dbtrail/bintrail/internal/status"
 	"github.com/dbtrail/bintrail/internal/testutil"
@@ -418,7 +419,7 @@ func TestAddFuturePartitions(t *testing.T) {
 
 	// First 3 should be hourly partitions.
 	for i := range 3 {
-		expected := partitionName(startDate.Add(time.Duration(i) * time.Hour))
+		expected := indexer.PartitionName(startDate.Add(time.Duration(i) * time.Hour))
 		if parts[i].Name != expected {
 			t.Errorf("partition %d: expected %s, got %s", i, expected, parts[i].Name)
 		}

--- a/cmd/bintrail/doctor_capacity.go
+++ b/cmd/bintrail/doctor_capacity.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dbtrail/bintrail/internal/indexer"
 	"github.com/go-sql-driver/mysql"
 )
 
@@ -274,7 +275,7 @@ func loadPartitionSamples(ctx context.Context, db *sql.DB, dbName string) ([]cap
 		if err := rows.Scan(&name, &s.rows, &s.bytes); err != nil {
 			return nil, err
 		}
-		d, ok := partitionDate(name)
+		d, ok := indexer.PartitionDate(name)
 		if !ok {
 			continue // p_future and unrecognised names carry no hour
 		}

--- a/cmd/bintrail/reconstruct_fulltable_integration_test.go
+++ b/cmd/bintrail/reconstruct_fulltable_integration_test.go
@@ -115,23 +115,23 @@ func TestRunReconstruct_fullTableRoundTrip(t *testing.T) {
 	// ── 4. Archive h1 and drop it from live MySQL ────────────────────────
 	archiveDir := t.TempDir()
 	bintrailID := "test-187-roundtrip"
-	outPath, err := hiveArchivePath(archiveDir, bintrailID, partitionName(h1))
+	outPath, err := hiveArchivePath(archiveDir, bintrailID, indexer.PartitionName(h1))
 	if err != nil {
 		t.Fatalf("hiveArchivePath: %v", err)
 	}
 	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
 		t.Fatalf("mkdir archive: %v", err)
 	}
-	if _, err := archive.ArchivePartition(context.Background(), db, dbName, partitionName(h1), outPath, "zstd"); err != nil {
+	if _, err := archive.ArchivePartition(context.Background(), db, dbName, indexer.PartitionName(h1), outPath, "zstd"); err != nil {
 		t.Fatalf("ArchivePartition: %v", err)
 	}
 	testutil.MustExec(t, db, `INSERT INTO archive_state
 		(partition_name, bintrail_id, local_path, row_count, s3_bucket, s3_key, s3_uploaded_at)
 		VALUES (?, ?, ?, 2, NULL, NULL, NULL)`,
-		partitionName(h1), bintrailID, outPath)
+		indexer.PartitionName(h1), bintrailID, outPath)
 	testutil.MustExec(t, db, fmt.Sprintf(
 		"ALTER TABLE `%s`.`binlog_events` DROP PARTITION `%s`",
-		dbName, partitionName(h1),
+		dbName, indexer.PartitionName(h1),
 	))
 
 	// ── 5. Drive runReconstructFullTable via flag vars ───────────────────

--- a/cmd/bintrail/reconstruct_integration_test.go
+++ b/cmd/bintrail/reconstruct_integration_test.go
@@ -67,14 +67,14 @@ func TestFetchMerged_archiveAware(t *testing.T) {
 	// directory layout is required for query.ResolveArchiveSources to find it.
 	archiveDir := t.TempDir()
 	bintrailID := "test-209-reconstruct"
-	outPath, err := hiveArchivePath(archiveDir, bintrailID, partitionName(h1))
+	outPath, err := hiveArchivePath(archiveDir, bintrailID, indexer.PartitionName(h1))
 	if err != nil {
 		t.Fatalf("hiveArchivePath: %v", err)
 	}
 	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
-	archivedRows, err := archive.ArchivePartition(context.Background(), db, dbName, partitionName(h1), outPath, "zstd")
+	archivedRows, err := archive.ArchivePartition(context.Background(), db, dbName, indexer.PartitionName(h1), outPath, "zstd")
 	if err != nil {
 		t.Fatalf("ArchivePartition: %v", err)
 	}
@@ -86,13 +86,13 @@ func TestFetchMerged_archiveAware(t *testing.T) {
 	testutil.MustExec(t, db, `INSERT INTO archive_state
 		(partition_name, bintrail_id, local_path, row_count, s3_bucket, s3_key, s3_uploaded_at)
 		VALUES (?, ?, ?, 1, NULL, NULL, NULL)`,
-		partitionName(h1), bintrailID, outPath)
+		indexer.PartitionName(h1), bintrailID, outPath)
 
 	// Drop h1 so its event is gone from live MySQL. FetchMerged now has to
 	// read it from the Parquet archive or miss it entirely.
 	testutil.MustExec(t, db, fmt.Sprintf(
 		"ALTER TABLE `%s`.`binlog_events` DROP PARTITION `%s`",
-		dbName, partitionName(h1),
+		dbName, indexer.PartitionName(h1),
 	))
 
 	engine := query.New(db)
@@ -188,7 +188,7 @@ func TestFetchMerged_gapAbort(t *testing.T) {
 	testutil.MustExec(t, db, `INSERT INTO archive_state
 		(partition_name, bintrail_id, local_path, row_count)
 		VALUES (?, 'dummy', '/tmp/dummy/bintrail_id=dummy/events.parquet', 0)`,
-		partitionName(far))
+		indexer.PartitionName(far))
 
 	_, _, err := query.FetchMerged(context.Background(), db, engine, query.FetchMergedOptions{
 		Opts:           opts,
@@ -309,7 +309,7 @@ func TestFetchMerged_allArchiveSourcesFailStrict(t *testing.T) {
 	testutil.MustExec(t, db, `INSERT INTO archive_state
 		(partition_name, bintrail_id, local_path, row_count)
 		VALUES (?, 'stub-failer', ?, 1)`,
-		partitionName(h1), fakeParquet)
+		indexer.PartitionName(h1), fakeParquet)
 
 	stubErr := errors.New("stub archive failure (intentional)")
 	stubFetcher := func(_ context.Context, _ query.Options, _ string) ([]query.ResultRow, error) {
@@ -398,11 +398,11 @@ func TestFetchMerged_partialArchiveFailureAbortsStrict(t *testing.T) {
 	testutil.MustExec(t, db, `INSERT INTO archive_state
 		(partition_name, bintrail_id, local_path, row_count)
 		VALUES (?, 'healthy', ?, 0)`,
-		partitionName(h1), filepath.Join(healthyBase, "events.parquet"))
+		indexer.PartitionName(h1), filepath.Join(healthyBase, "events.parquet"))
 	testutil.MustExec(t, db, `INSERT INTO archive_state
 		(partition_name, bintrail_id, local_path, row_count)
 		VALUES (?, 'broken', ?, 0)`,
-		partitionName(h1), filepath.Join(brokenBase, "events.parquet"))
+		indexer.PartitionName(h1), filepath.Join(brokenBase, "events.parquet"))
 
 	brokenErr := errors.New("stub: broken archive (intentional)")
 	stubFetcher := func(_ context.Context, _ query.Options, src string) ([]query.ResultRow, error) {
@@ -588,23 +588,23 @@ func TestRunReconstruct_archiveAwareE2E(t *testing.T) {
 	// ── 3. Archive h1 and drop it from live MySQL ──────────────────────────
 	archiveDir := t.TempDir()
 	bintrailID := "test-209-e2e"
-	outPath, err := hiveArchivePath(archiveDir, bintrailID, partitionName(h1))
+	outPath, err := hiveArchivePath(archiveDir, bintrailID, indexer.PartitionName(h1))
 	if err != nil {
 		t.Fatalf("hiveArchivePath: %v", err)
 	}
 	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
 		t.Fatalf("mkdir archive: %v", err)
 	}
-	if _, err := archive.ArchivePartition(context.Background(), db, dbName, partitionName(h1), outPath, "zstd"); err != nil {
+	if _, err := archive.ArchivePartition(context.Background(), db, dbName, indexer.PartitionName(h1), outPath, "zstd"); err != nil {
 		t.Fatalf("ArchivePartition: %v", err)
 	}
 	testutil.MustExec(t, db, `INSERT INTO archive_state
 		(partition_name, bintrail_id, local_path, row_count, s3_bucket, s3_key, s3_uploaded_at)
 		VALUES (?, ?, ?, 1, NULL, NULL, NULL)`,
-		partitionName(h1), bintrailID, outPath)
+		indexer.PartitionName(h1), bintrailID, outPath)
 	testutil.MustExec(t, db, fmt.Sprintf(
 		"ALTER TABLE `%s`.`binlog_events` DROP PARTITION `%s`",
-		dbName, partitionName(h1),
+		dbName, indexer.PartitionName(h1),
 	))
 
 	// ── 4. Drive runReconstruct via package-level flag vars ────────────────

--- a/cmd/bintrail/reconstruct_pk_types_integration_test.go
+++ b/cmd/bintrail/reconstruct_pk_types_integration_test.go
@@ -119,23 +119,23 @@ func TestRunReconstruct_fullTableRoundTrip_datetimePK(t *testing.T) {
 	// ── 4. Archive h1 and drop it from live MySQL ───────────────────────
 	archiveDir := t.TempDir()
 	bintrailID := "test-212-datetime-pk"
-	outPath, err := hiveArchivePath(archiveDir, bintrailID, partitionName(h1))
+	outPath, err := hiveArchivePath(archiveDir, bintrailID, indexer.PartitionName(h1))
 	if err != nil {
 		t.Fatalf("hiveArchivePath: %v", err)
 	}
 	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
 		t.Fatalf("mkdir archive: %v", err)
 	}
-	if _, err := archive.ArchivePartition(context.Background(), db, dbName, partitionName(h1), outPath, "zstd"); err != nil {
+	if _, err := archive.ArchivePartition(context.Background(), db, dbName, indexer.PartitionName(h1), outPath, "zstd"); err != nil {
 		t.Fatalf("ArchivePartition: %v", err)
 	}
 	testutil.MustExec(t, db, `INSERT INTO archive_state
 		(partition_name, bintrail_id, local_path, row_count, s3_bucket, s3_key, s3_uploaded_at)
 		VALUES (?, ?, ?, 2, NULL, NULL, NULL)`,
-		partitionName(h1), bintrailID, outPath)
+		indexer.PartitionName(h1), bintrailID, outPath)
 	testutil.MustExec(t, db, fmt.Sprintf(
 		"ALTER TABLE `%s`.`binlog_events` DROP PARTITION `%s`",
-		dbName, partitionName(h1),
+		dbName, indexer.PartitionName(h1),
 	))
 
 	// ── 5. Run full-table reconstruct ───────────────────────────────────
@@ -309,23 +309,23 @@ func TestRunReconstruct_fullTableRoundTrip_varcharPK(t *testing.T) {
 
 	archiveDir := t.TempDir()
 	bintrailID := "test-212-varchar-pk"
-	outPath, err := hiveArchivePath(archiveDir, bintrailID, partitionName(h1))
+	outPath, err := hiveArchivePath(archiveDir, bintrailID, indexer.PartitionName(h1))
 	if err != nil {
 		t.Fatalf("hiveArchivePath: %v", err)
 	}
 	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
 		t.Fatalf("mkdir archive: %v", err)
 	}
-	if _, err := archive.ArchivePartition(context.Background(), db, dbName, partitionName(h1), outPath, "zstd"); err != nil {
+	if _, err := archive.ArchivePartition(context.Background(), db, dbName, indexer.PartitionName(h1), outPath, "zstd"); err != nil {
 		t.Fatalf("ArchivePartition: %v", err)
 	}
 	testutil.MustExec(t, db, `INSERT INTO archive_state
 		(partition_name, bintrail_id, local_path, row_count, s3_bucket, s3_key, s3_uploaded_at)
 		VALUES (?, ?, ?, 1, NULL, NULL, NULL)`,
-		partitionName(h1), bintrailID, outPath)
+		indexer.PartitionName(h1), bintrailID, outPath)
 	testutil.MustExec(t, db, fmt.Sprintf(
 		"ALTER TABLE `%s`.`binlog_events` DROP PARTITION `%s`",
-		dbName, partitionName(h1),
+		dbName, indexer.PartitionName(h1),
 	))
 
 	orig := captureRecFlags()
@@ -525,23 +525,23 @@ func TestRunReconstruct_fullTableRoundTrip_decimalPK(t *testing.T) {
 	// ── 4. Archive h1 and drop it from live MySQL ───────────────────────
 	archiveDir := t.TempDir()
 	bintrailID := "test-214-decimal-pk"
-	outPath, err := hiveArchivePath(archiveDir, bintrailID, partitionName(h1))
+	outPath, err := hiveArchivePath(archiveDir, bintrailID, indexer.PartitionName(h1))
 	if err != nil {
 		t.Fatalf("hiveArchivePath: %v", err)
 	}
 	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
 		t.Fatalf("mkdir archive: %v", err)
 	}
-	if _, err := archive.ArchivePartition(context.Background(), db, dbName, partitionName(h1), outPath, "zstd"); err != nil {
+	if _, err := archive.ArchivePartition(context.Background(), db, dbName, indexer.PartitionName(h1), outPath, "zstd"); err != nil {
 		t.Fatalf("ArchivePartition: %v", err)
 	}
 	testutil.MustExec(t, db, `INSERT INTO archive_state
 		(partition_name, bintrail_id, local_path, row_count, s3_bucket, s3_key, s3_uploaded_at)
 		VALUES (?, ?, ?, 2, NULL, NULL, NULL)`,
-		partitionName(h1), bintrailID, outPath)
+		indexer.PartitionName(h1), bintrailID, outPath)
 	testutil.MustExec(t, db, fmt.Sprintf(
 		"ALTER TABLE `%s`.`binlog_events` DROP PARTITION `%s`",
-		dbName, partitionName(h1),
+		dbName, indexer.PartitionName(h1),
 	))
 
 	// ── 5. Run full-table reconstruct ───────────────────────────────────
@@ -872,23 +872,23 @@ func TestRunReconstruct_fullTableRoundTrip_datetime6PK(t *testing.T) {
 
 	archiveDir := t.TempDir()
 	bintrailID := "test-212-datetime6-pk"
-	outPath, err := hiveArchivePath(archiveDir, bintrailID, partitionName(h1))
+	outPath, err := hiveArchivePath(archiveDir, bintrailID, indexer.PartitionName(h1))
 	if err != nil {
 		t.Fatalf("hiveArchivePath: %v", err)
 	}
 	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
 		t.Fatalf("mkdir archive: %v", err)
 	}
-	if _, err := archive.ArchivePartition(context.Background(), db, dbName, partitionName(h1), outPath, "zstd"); err != nil {
+	if _, err := archive.ArchivePartition(context.Background(), db, dbName, indexer.PartitionName(h1), outPath, "zstd"); err != nil {
 		t.Fatalf("ArchivePartition: %v", err)
 	}
 	testutil.MustExec(t, db, `INSERT INTO archive_state
 		(partition_name, bintrail_id, local_path, row_count, s3_bucket, s3_key, s3_uploaded_at)
 		VALUES (?, ?, ?, 2, NULL, NULL, NULL)`,
-		partitionName(h1), bintrailID, outPath)
+		indexer.PartitionName(h1), bintrailID, outPath)
 	testutil.MustExec(t, db, fmt.Sprintf(
 		"ALTER TABLE `%s`.`binlog_events` DROP PARTITION `%s`",
-		dbName, partitionName(h1),
+		dbName, indexer.PartitionName(h1),
 	))
 
 	orig := captureRecFlags()

--- a/cmd/bintrail/rotate.go
+++ b/cmd/bintrail/rotate.go
@@ -229,7 +229,7 @@ func performRotation(ctx context.Context, db *sql.DB, dbName string, retainDur t
 		cutoff := time.Now().UTC().Add(-retainDur)
 		var toDrop []string
 		for _, p := range partitions {
-			d, ok := partitionDate(p.Name)
+			d, ok := indexer.PartitionDate(p.Name)
 			if !ok {
 				continue // skip p_future and any unrecognised names
 			}
@@ -501,7 +501,7 @@ func performRotation(ctx context.Context, db *sql.DB, dbName string, retainDur t
 		}
 		for i := range toAdd {
 			if rotFormat != "json" {
-				fmt.Fprintf(os.Stdout, "added partition %s\n", partitionName(startDate.Add(time.Duration(i)*time.Hour)))
+				fmt.Fprintf(os.Stdout, "added partition %s\n", indexer.PartitionName(startDate.Add(time.Duration(i)*time.Hour)))
 			}
 		}
 	}
@@ -585,7 +585,7 @@ func fileExists(path string) bool {
 // Each hourly partition maps to exactly one file. The event_hour= directory level
 // enables DuckDB Hive partition pruning on hour-scoped queries.
 func hiveArchivePath(archiveDir, bintrailID, partitionName string) (string, error) {
-	d, ok := partitionDate(partitionName)
+	d, ok := indexer.PartitionDate(partitionName)
 	if !ok {
 		return "", fmt.Errorf("cannot parse partition date from %q", partitionName)
 	}
@@ -651,24 +651,6 @@ func listPartitions(ctx context.Context, db *sql.DB, dbName string) ([]partition
 	return partitions, rows.Err()
 }
 
-// partitionDate parses the hour from a partition name like "p_2026021914".
-// Returns the time and true on success; zero and false for p_future or other names.
-func partitionDate(name string) (time.Time, bool) {
-	if len(name) != 12 || !strings.HasPrefix(name, "p_") {
-		return time.Time{}, false
-	}
-	t, err := time.ParseInLocation("p_2006010215", name, time.UTC)
-	if err != nil {
-		return time.Time{}, false
-	}
-	return t, true
-}
-
-// partitionName returns the partition name for a given hour ("p_YYYYMMDDHH").
-func partitionName(d time.Time) string {
-	return d.UTC().Format("p_2006010215")
-}
-
 // dropPartitions drops one or more named partitions in a single ALTER TABLE statement.
 func dropPartitions(ctx context.Context, db *sql.DB, dbName string, names []string) error {
 	q := fmt.Sprintf("ALTER TABLE `%s`.`binlog_events` DROP PARTITION %s",
@@ -714,7 +696,7 @@ func computeToAdd(target, futureCount, dropped int, noReplace bool) int {
 func countFuturePartitions(partitions []partitionInfo, ref time.Time) int {
 	n := 0
 	for _, p := range partitions {
-		d, ok := partitionDate(p.Name)
+		d, ok := indexer.PartitionDate(p.Name)
 		if !ok {
 			continue
 		}
@@ -731,7 +713,7 @@ func countFuturePartitions(partitions []partitionInfo, ref time.Time) int {
 func nextPartitionStart(partitions []partitionInfo) time.Time {
 	var maxDate time.Time
 	for _, p := range partitions {
-		d, ok := partitionDate(p.Name)
+		d, ok := indexer.PartitionDate(p.Name)
 		if !ok {
 			continue
 		}
@@ -754,7 +736,7 @@ func addFuturePartitions(ctx context.Context, db *sql.DB, dbName string, startDa
 		nextHour := d.Add(time.Hour)
 		parts = append(parts, fmt.Sprintf(
 			"PARTITION %s VALUES LESS THAN (TO_SECONDS('%s'))",
-			partitionName(d),
+			indexer.PartitionName(d),
 			nextHour.UTC().Format("2006-01-02 15:04:05"),
 		))
 	}

--- a/cmd/bintrail/rotate_integration_test.go
+++ b/cmd/bintrail/rotate_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dbtrail/bintrail/internal/indexer"
 	"github.com/dbtrail/bintrail/internal/testutil"
 )
 
@@ -117,7 +118,7 @@ func setupPartitionedTable(t *testing.T, db *sql.DB, dbName string, hours []time
 		}
 		parts += fmt.Sprintf(
 			"PARTITION %s VALUES LESS THAN (TO_SECONDS('%s'))",
-			partitionName(h),
+			indexer.PartitionName(h),
 			nextHour.UTC().Format("2006-01-02 15:04:05"),
 		)
 	}
@@ -168,8 +169,8 @@ func TestPerformRotation_PendingS3BlocksDrop(t *testing.T) {
 	rotNoReplace = true
 	rotAddFuture = 0
 
-	outPath1, _ := hiveArchivePath(archiveDir, rotBintrailID, partitionName(h1))
-	outPath2, _ := hiveArchivePath(archiveDir, rotBintrailID, partitionName(h2))
+	outPath1, _ := hiveArchivePath(archiveDir, rotBintrailID, indexer.PartitionName(h1))
+	outPath2, _ := hiveArchivePath(archiveDir, rotBintrailID, indexer.PartitionName(h2))
 	os.MkdirAll(filepath.Dir(outPath1), 0o755)
 	os.MkdirAll(filepath.Dir(outPath2), 0o755)
 	os.WriteFile(outPath1, []byte("parquet-data"), 0o644)
@@ -179,11 +180,11 @@ func TestPerformRotation_PendingS3BlocksDrop(t *testing.T) {
 	testutil.MustExec(t, db, `INSERT INTO archive_state
 		(partition_name, bintrail_id, local_path, row_count, s3_bucket, s3_key)
 		VALUES (?, ?, ?, 1, 'my-bucket', 'archives/p1.parquet')`,
-		partitionName(h1), rotBintrailID, outPath1)
+		indexer.PartitionName(h1), rotBintrailID, outPath1)
 	testutil.MustExec(t, db, `INSERT INTO archive_state
 		(partition_name, bintrail_id, local_path, row_count, s3_bucket, s3_key, s3_uploaded_at)
 		VALUES (?, ?, ?, 1, 'my-bucket', 'archives/p2.parquet', UTC_TIMESTAMP())`,
-		partitionName(h2), rotBintrailID, outPath2)
+		indexer.PartitionName(h2), rotBintrailID, outPath2)
 
 	// Run rotation WITHOUT --archive-s3, WITH --retry (so it skips re-archiving).
 	rotArchiveS3 = ""
@@ -205,8 +206,8 @@ func TestPerformRotation_PendingS3BlocksDrop(t *testing.T) {
 	if err != nil {
 		t.Fatalf("listPartitions: %v", err)
 	}
-	p1Name := partitionName(h1)
-	p2Name := partitionName(h2)
+	p1Name := indexer.PartitionName(h1)
+	p2Name := indexer.PartitionName(h2)
 	var foundP1, foundP2 bool
 	for _, p := range partitions {
 		if p.Name == p1Name {
@@ -277,7 +278,7 @@ func TestPerformRotation_BulkDropSkipsPendingS3(t *testing.T) {
 	testutil.MustExec(t, db, `INSERT INTO archive_state
 		(partition_name, bintrail_id, local_path, row_count, s3_bucket, s3_key)
 		VALUES (?, 'prev-uuid', '/data/test.parquet', 1, 'my-bucket', 'archives/p1.parquet')`,
-		partitionName(h1))
+		indexer.PartitionName(h1))
 
 	savedVars := saveRotateVars()
 	t.Cleanup(func() { restoreRotateVars(savedVars) })
@@ -305,7 +306,7 @@ func TestPerformRotation_BulkDropSkipsPendingS3(t *testing.T) {
 	if err != nil {
 		t.Fatalf("listPartitions: %v", err)
 	}
-	p1Name := partitionName(h1)
+	p1Name := indexer.PartitionName(h1)
 	var foundP1 bool
 	for _, p := range partitions {
 		if p.Name == p1Name {
@@ -359,11 +360,11 @@ func TestPerformRotation_ProtectUnarchivedDefers(t *testing.T) {
 	testutil.MustExec(t, db, `INSERT INTO archive_state
 		(partition_name, bintrail_id, local_path, row_count, s3_bucket, s3_key)
 		VALUES (?, 'cron-uuid', '/archives/p2.parquet', 1, 'my-bucket', 'archives/p2.parquet')`,
-		partitionName(h2))
+		indexer.PartitionName(h2))
 	testutil.MustExec(t, db, `INSERT INTO archive_state
 		(partition_name, bintrail_id, local_path, row_count, s3_bucket, s3_key, s3_uploaded_at)
 		VALUES (?, 'cron-uuid', '/archives/p3.parquet', 1, 'my-bucket', 'archives/p3.parquet', UTC_TIMESTAMP())`,
-		partitionName(h3))
+		indexer.PartitionName(h3))
 
 	res, err := performRotation(context.Background(), db, dbName, 24*time.Hour)
 	if err != nil {
@@ -384,14 +385,14 @@ func TestPerformRotation_ProtectUnarchivedDefers(t *testing.T) {
 	for _, p := range partitions {
 		remaining[p.Name] = true
 	}
-	if !remaining[partitionName(h1)] {
-		t.Errorf("partition %s should NOT have been dropped (past retention but unarchived)", partitionName(h1))
+	if !remaining[indexer.PartitionName(h1)] {
+		t.Errorf("partition %s should NOT have been dropped (past retention but unarchived)", indexer.PartitionName(h1))
 	}
-	if !remaining[partitionName(h2)] {
-		t.Errorf("partition %s should NOT have been dropped (archived but S3 upload pending)", partitionName(h2))
+	if !remaining[indexer.PartitionName(h2)] {
+		t.Errorf("partition %s should NOT have been dropped (archived but S3 upload pending)", indexer.PartitionName(h2))
 	}
-	if remaining[partitionName(h3)] {
-		t.Errorf("partition %s should have been dropped (archived and uploaded)", partitionName(h3))
+	if remaining[indexer.PartitionName(h3)] {
+		t.Errorf("partition %s should have been dropped (archived and uploaded)", indexer.PartitionName(h3))
 	}
 }
 

--- a/cmd/bintrail/rotate_test.go
+++ b/cmd/bintrail/rotate_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/dbtrail/bintrail/internal/indexer"
 )
 
 // ─── parseRetain ───────────────────────────────────────────────────────────────
@@ -53,68 +55,6 @@ func TestParseRetain_invalid(t *testing.T) {
 		if _, err := parseRetain(c); err == nil {
 			t.Errorf("expected error for %q, got nil", c)
 		}
-	}
-}
-
-// ─── partitionDate ──────────────────────────────────────────────────────────────
-
-func TestPartitionDate_valid(t *testing.T) {
-	d, ok := partitionDate("p_2026021900")
-	if !ok {
-		t.Fatal("expected ok=true for p_2026021900")
-	}
-	if d.Year() != 2026 || d.Month() != 2 || d.Day() != 19 || d.Hour() != 0 {
-		t.Errorf("unexpected time: %v", d)
-	}
-}
-
-func TestPartitionDate_firstOfMonth(t *testing.T) {
-	d, ok := partitionDate("p_2026020114")
-	if !ok {
-		t.Fatal("expected ok=true for p_2026020114")
-	}
-	if d.Year() != 2026 || d.Month() != 2 || d.Day() != 1 || d.Hour() != 14 {
-		t.Errorf("unexpected time: %v", d)
-	}
-}
-
-func TestPartitionDate_invalid(t *testing.T) {
-	cases := []string{
-		"p_future",      // MAXVALUE catch-all
-		"p_",            // too short
-		"p_202602",      // incomplete
-		"p_20260219",    // missing hour (10 chars, old daily format)
-		"p_20260219000", // one digit too many (13 chars)
-		"binlog_events",
-		"",
-	}
-	for _, c := range cases {
-		if _, ok := partitionDate(c); ok {
-			t.Errorf("expected ok=false for %q", c)
-		}
-	}
-}
-
-// ─── partitionName ──────────────────────────────────────────────────────────────
-
-func TestPartitionName(t *testing.T) {
-	d := time.Date(2026, 2, 19, 0, 0, 0, 0, time.UTC)
-	if got := partitionName(d); got != "p_2026021900" {
-		t.Errorf("expected p_2026021900, got %s", got)
-	}
-}
-
-func TestPartitionName_roundTrip(t *testing.T) {
-	// partitionName and partitionDate must round-trip correctly.
-	original := time.Date(2026, 12, 31, 14, 30, 0, 0, time.UTC)
-	name := partitionName(original)
-	got, ok := partitionDate(name)
-	if !ok {
-		t.Fatalf("partitionDate(%q) returned ok=false", name)
-	}
-	// partitionDate parses to the top of the hour; year/month/day/hour must match.
-	if got.Year() != original.Year() || got.Month() != original.Month() || got.Day() != original.Day() || got.Hour() != original.Hour() {
-		t.Errorf("round-trip mismatch: original=%v, got=%v", original, got)
 	}
 }
 
@@ -178,9 +118,9 @@ func TestCutoffDropsHourlyPartition(t *testing.T) {
 	}
 
 	for _, p := range partitions {
-		d, ok := partitionDate(p.name)
+		d, ok := indexer.PartitionDate(p.name)
 		if !ok {
-			t.Fatalf("partitionDate(%q) returned false", p.name)
+			t.Fatalf("indexer.PartitionDate(%q) returned false", p.name)
 		}
 		dropped := d.Before(cutoff)
 		if dropped != p.wantDrop {
@@ -201,7 +141,7 @@ func TestPartitionSpec_shape(t *testing.T) {
 	for i := range 3 {
 		d := start.Add(time.Duration(i) * time.Hour)
 		nextHour := d.Add(time.Hour)
-		parts = append(parts, "PARTITION "+partitionName(d)+
+		parts = append(parts, "PARTITION "+indexer.PartitionName(d)+
 			" VALUES LESS THAN (TO_SECONDS('"+
 			nextHour.UTC().Format("2006-01-02 15:04:05")+"'))")
 	}
@@ -286,7 +226,7 @@ func TestAutoAddDeclarative_48CycleSimulation(t *testing.T) {
 	now := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
 	parts := []partitionInfo{}
 	for i := -11; i <= 1; i++ { // 12 past/current hours + 1 future
-		parts = append(parts, partitionInfo{Name: partitionName(now.Add(time.Duration(i) * time.Hour))})
+		parts = append(parts, partitionInfo{Name: indexer.PartitionName(now.Add(time.Duration(i) * time.Hour))})
 	}
 	parts = append(parts, partitionInfo{Name: "p_future", Description: "MAXVALUE"})
 
@@ -301,7 +241,7 @@ func TestAutoAddDeclarative_48CycleSimulation(t *testing.T) {
 		dropped := 0
 		kept := parts[:0]
 		for _, p := range parts {
-			d, ok := partitionDate(p.Name)
+			d, ok := indexer.PartitionDate(p.Name)
 			if ok && d.Before(cutoff) {
 				dropped++
 				continue
@@ -326,7 +266,7 @@ func TestAutoAddDeclarative_48CycleSimulation(t *testing.T) {
 		}
 		parts = withoutFuture
 		for i := 0; i < toAdd; i++ {
-			parts = append(parts, partitionInfo{Name: partitionName(startDate.Add(time.Duration(i) * time.Hour))})
+			parts = append(parts, partitionInfo{Name: indexer.PartitionName(startDate.Add(time.Duration(i) * time.Hour))})
 		}
 		parts = append(parts, partitionInfo{Name: "p_future", Description: "MAXVALUE"})
 	}
@@ -351,7 +291,7 @@ func TestAutoAddDeclarative_48CycleSimulation(t *testing.T) {
 		dropped := 0
 		kept := parts[:0]
 		for _, p := range parts {
-			d, ok := partitionDate(p.Name)
+			d, ok := indexer.PartitionDate(p.Name)
 			if ok && d.Before(cutoff) {
 				dropped++
 				continue
@@ -371,7 +311,7 @@ func TestAutoAddDeclarative_48CycleSimulation(t *testing.T) {
 		}
 		parts = withoutFuture
 		for i := 0; i < toAdd; i++ {
-			parts = append(parts, partitionInfo{Name: partitionName(startDate.Add(time.Duration(i) * time.Hour))})
+			parts = append(parts, partitionInfo{Name: indexer.PartitionName(startDate.Add(time.Duration(i) * time.Hour))})
 		}
 		parts = append(parts, partitionInfo{Name: "p_future", Description: "MAXVALUE"})
 	}

--- a/cmd/bintrail/up_rotation.go
+++ b/cmd/bintrail/up_rotation.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-sql-driver/mysql"
 
 	"github.com/dbtrail/bintrail/internal/config"
+	"github.com/dbtrail/bintrail/internal/indexer"
 )
 
 // upRotationSettings is the parsed configuration of `up`'s built-in rotation —
@@ -265,7 +266,7 @@ func upgradeGuardTrips(ctx context.Context, db *sql.DB, dbName string, retain ti
 func guardTrips(partitions []partitionInfo, retain time.Duration, now time.Time) (bool, time.Time) {
 	var oldest time.Time
 	for _, p := range partitions {
-		d, ok := partitionDate(p.Name)
+		d, ok := indexer.PartitionDate(p.Name)
 		if !ok {
 			continue
 		}

--- a/cmd/bintrail/up_rotation_integration_test.go
+++ b/cmd/bintrail/up_rotation_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dbtrail/bintrail/internal/indexer"
 	"github.com/dbtrail/bintrail/internal/testutil"
 )
 
@@ -60,15 +61,15 @@ func TestRotateOneIndex_UpgradeGuard(t *testing.T) {
 	found, future := false, 0
 	nowHour := time.Now().UTC().Truncate(time.Hour)
 	for _, p := range partitions {
-		if p.Name == partitionName(old) {
+		if p.Name == indexer.PartitionName(old) {
 			found = true
 		}
-		if d, ok := partitionDate(p.Name); ok && d.After(nowHour) {
+		if d, ok := indexer.PartitionDate(p.Name); ok && d.After(nowHour) {
 			future++
 		}
 	}
 	if !found {
-		t.Fatalf("partition %s was dropped under the IMPLICIT default — the upgrade guard failed", partitionName(old))
+		t.Fatalf("partition %s was dropped under the IMPLICIT default — the upgrade guard failed", indexer.PartitionName(old))
 	}
 	if !logs.has(slog.LevelError, "refusing to drop it without an explicit choice") {
 		t.Error("upgrade guard did not log its Error explaining the refusal")
@@ -90,8 +91,8 @@ func TestRotateOneIndex_UpgradeGuard(t *testing.T) {
 		t.Fatalf("listPartitions: %v", err)
 	}
 	for _, p := range partitions {
-		if p.Name == partitionName(old) {
-			t.Errorf("partition %s should have been dropped once retention was explicit", partitionName(old))
+		if p.Name == indexer.PartitionName(old) {
+			t.Errorf("partition %s should have been dropped once retention was explicit", indexer.PartitionName(old))
 		}
 	}
 }
@@ -154,7 +155,7 @@ func TestStartUpRotation_escalatesOnPersistentDeferral(t *testing.T) {
 	}
 	found := false
 	for _, p := range partitions {
-		if p.Name == partitionName(h1) {
+		if p.Name == indexer.PartitionName(h1) {
 			found = true
 		}
 	}

--- a/cmd/bintrail/up_rotation_test.go
+++ b/cmd/bintrail/up_rotation_test.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/dbtrail/bintrail/internal/indexer"
 )
 
 // logCapture is a slog.Handler that records every emitted record, so tests
@@ -188,7 +190,7 @@ func TestStartUpRotation_escalatesAfterConsecutiveFailures(t *testing.T) {
 func TestGuardTrips(t *testing.T) {
 	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
 	retain := 30 * 24 * time.Hour
-	name := func(age time.Duration) string { return partitionName(now.Add(-age)) }
+	name := func(age time.Duration) string { return indexer.PartitionName(now.Add(-age)) }
 
 	cases := []struct {
 		desc       string

--- a/cmd/bintrail/upload.go
+++ b/cmd/bintrail/upload.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/dbtrail/bintrail/internal/cliutil"
 	"github.com/dbtrail/bintrail/internal/config"
+	"github.com/dbtrail/bintrail/internal/indexer"
 )
 
 var uploadCmd = &cobra.Command{
@@ -107,7 +108,7 @@ func parseArchivePath(path string) (bintrailID, partName string) {
 	h := 0
 	fmt.Sscanf(hour, "%d", &h)
 	t = t.Add(time.Duration(h) * time.Hour)
-	return id, partitionName(t)
+	return id, indexer.PartitionName(t)
 }
 
 func runUpload(cmd *cobra.Command, args []string) error {

--- a/docs/rotation-and-status.md
+++ b/docs/rotation-and-status.md
@@ -66,7 +66,7 @@ The `--retain` flag accepts a duration: `7d` (days) or `24h` (hours). The comman
 
 1. Computes `cutoff = now - retain_duration` (truncated to the current hour UTC).
 2. Lists all partitions from `information_schema.PARTITIONS`.
-3. Parses the hour from each `p_YYYYMMDDHH` name (`p_future` is skipped automatically because `partitionDate` returns `false` for it).
+3. Parses the hour from each `p_YYYYMMDDHH` name (`p_future` is skipped automatically because `indexer.PartitionDate` returns `false` for it).
 4. Collects all partitions whose date is before the cutoff.
 5. Issues a single `ALTER TABLE binlog_events DROP PARTITION p1, p2, p3` statement.
 
@@ -111,12 +111,12 @@ REORGANIZE PARTITION p_future INTO (
 Two functions handle the hour ↔ name mapping:
 
 ```go
-// cmd/bintrail/rotate.go
-func partitionName(d time.Time) string {
+// internal/indexer/partitions.go (package indexer)
+func PartitionName(d time.Time) string {
     return d.UTC().Format("p_2006010215")  // Go reference time for YYYYMMDDHH
 }
 
-func partitionDate(name string) (time.Time, bool) {
+func PartitionDate(name string) (time.Time, bool) {
     if len(name) != 12 || !strings.HasPrefix(name, "p_") {
         return time.Time{}, false  // rejects p_future and anything malformed
     }
@@ -125,7 +125,7 @@ func partitionDate(name string) (time.Time, bool) {
 }
 ```
 
-These two functions round-trip correctly: `partitionName(partitionDate("p_2026021914"))` → `"p_2026021914"`. Tests in `rotate_test.go` verify this.
+These two functions round-trip correctly: `indexer.PartitionName(indexer.PartitionDate("p_2026021914"))` → `"p_2026021914"`. Tests in `internal/indexer/partitions_test.go` verify this.
 
 ---
 

--- a/internal/indexer/partitions.go
+++ b/internal/indexer/partitions.go
@@ -1,0 +1,24 @@
+package indexer
+
+import (
+	"strings"
+	"time"
+)
+
+// PartitionDate parses the hour from a partition name like "p_2026021914".
+// Returns the time and true on success; zero and false for p_future or other names.
+func PartitionDate(name string) (time.Time, bool) {
+	if len(name) != 12 || !strings.HasPrefix(name, "p_") {
+		return time.Time{}, false
+	}
+	t, err := time.ParseInLocation("p_2006010215", name, time.UTC)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
+}
+
+// PartitionName returns the partition name for a given hour ("p_YYYYMMDDHH").
+func PartitionName(d time.Time) string {
+	return d.UTC().Format("p_2006010215")
+}

--- a/internal/indexer/partitions_test.go
+++ b/internal/indexer/partitions_test.go
@@ -1,0 +1,68 @@
+package indexer
+
+import (
+	"testing"
+	"time"
+)
+
+// ─── PartitionDate ──────────────────────────────────────────────────────────────
+
+func TestPartitionDate_valid(t *testing.T) {
+	d, ok := PartitionDate("p_2026021900")
+	if !ok {
+		t.Fatal("expected ok=true for p_2026021900")
+	}
+	if d.Year() != 2026 || d.Month() != 2 || d.Day() != 19 || d.Hour() != 0 {
+		t.Errorf("unexpected time: %v", d)
+	}
+}
+
+func TestPartitionDate_firstOfMonth(t *testing.T) {
+	d, ok := PartitionDate("p_2026020114")
+	if !ok {
+		t.Fatal("expected ok=true for p_2026020114")
+	}
+	if d.Year() != 2026 || d.Month() != 2 || d.Day() != 1 || d.Hour() != 14 {
+		t.Errorf("unexpected time: %v", d)
+	}
+}
+
+func TestPartitionDate_invalid(t *testing.T) {
+	cases := []string{
+		"p_future",      // MAXVALUE catch-all
+		"p_",            // too short
+		"p_202602",      // incomplete
+		"p_20260219",    // missing hour (10 chars, old daily format)
+		"p_20260219000", // one digit too many (13 chars)
+		"binlog_events",
+		"",
+	}
+	for _, c := range cases {
+		if _, ok := PartitionDate(c); ok {
+			t.Errorf("expected ok=false for %q", c)
+		}
+	}
+}
+
+// ─── PartitionName ──────────────────────────────────────────────────────────────
+
+func TestPartitionName(t *testing.T) {
+	d := time.Date(2026, 2, 19, 0, 0, 0, 0, time.UTC)
+	if got := PartitionName(d); got != "p_2026021900" {
+		t.Errorf("expected p_2026021900, got %s", got)
+	}
+}
+
+func TestPartitionName_roundTrip(t *testing.T) {
+	// PartitionName and PartitionDate must round-trip correctly.
+	original := time.Date(2026, 12, 31, 14, 30, 0, 0, time.UTC)
+	name := PartitionName(original)
+	got, ok := PartitionDate(name)
+	if !ok {
+		t.Fatalf("PartitionDate(%q) returned ok=false", name)
+	}
+	// PartitionDate parses to the top of the hour; year/month/day/hour must match.
+	if got.Year() != original.Year() || got.Month() != original.Month() || got.Day() != original.Day() || got.Hour() != original.Hour() {
+		t.Errorf("round-trip mismatch: original=%v, got=%v", original, got)
+	}
+}


### PR DESCRIPTION
## What

Slice **B1** of relocating the monitor/supervisor's remaining `package main` deps to `internal/`. `partitionDate`/`partitionName` are pure partition-name helpers (parse/format `p_YYYYMMDDHH`) with **zero** `package main` dependencies — a clean leaf, split out from the heavier provisioning bundle (B2) per advisor: `buildPartitionDefs` formats inline and never calls them, so they're code-independent and touch disjoint files.

| helper | new home |
|---|---|
| `partitionDate` | `indexer.PartitionDate` |
| `partitionName` | `indexer.PartitionName` |

## Pure relocation, zero behavior change

- Verbatim bodies, exported, in new file `internal/indexer/partitions.go` (imports only `strings` + `time` — no cycle; `indexer` is a low-level leaf).
- **~50 call sites** rewired across cmd (`rotate`/`up_rotation`/`upload`/`doctor_capacity` + the archive/reconstruct/rotate/up_rotation integration tests). The `hiveArchivePath(…, partitionName string)` **parameter** is untouched — only function calls were rewired.
- The 5 dedicated unit tests (`TestPartitionDate_*`/`TestPartitionName*`) moved to `internal/indexer/partitions_test.go`; tests that merely *use* the helpers stay in cmd and call `indexer.*`.

## Why now

Needed before the doctor extraction (B2/D): `internal/doctor`'s capacity check (`loadPartitionSamples`) calls `PartitionDate`, and a future `cmd/bintrail-console` supervisor reaches partition logic through `internal/`.

## Verification

- `go build` / `go vet` clean (unit **and** `-tags integration`).
- Full unit suite green (incl. the moved `Partition` tests in `internal/indexer`).
- rotate / up_rotation / reconstruct / archive integration tests pass against MySQL — they exercise `indexer.PartitionDate/Name` through real rotation + reconstruction flows.

## PR-B' plan (monitor's remaining deps; leaf-first)

| slice | scope | status |
|---|---|---|
| A | `deriveServerID` → serverid | ✅ merged (#436) |
| **B1 (this)** | partition helpers → indexer | this PR |
| B2 | DDL + `createIndexTables`/`ensureDatabase` → indexer (incl. `EnsureDatabase` gains a `log func(string)` — a real signature change; monitor goes silent) | next |
| C | `upRotationCfg` global → param | after B2 |
| D | `buildDoctorReport` + capacity + diskfree → new `internal/doctor` | last |

B1 + B2 branch from `main`, disjoint files, no stacking. Landmine for D already found: `hasReplPrivileges` (in `agent_validate.go`) is shared by doctor + `agent --validate`, so it needs a neutral home, not `internal/doctor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)