### PR TITLE
refactor(deps): relocate index provisioning + DDL to internal/indexer (decouple PR-B' slice B2)

### DIFF
--- a/cmd/bintrail/cmd_integration_test.go
+++ b/cmd/bintrail/cmd_integration_test.go
@@ -210,7 +210,7 @@ func TestLoadPartitionStats(t *testing.T) {
 	db, dbName := testutil.CreateTestDB(t)
 
 	// Create table with 3 daily partitions + p_future.
-	if err := createBinlogEventsTable(db, 3, false); err != nil {
+	if err := indexer.CreateBinlogEventsTable(db, 3, false); err != nil {
 		t.Fatalf("createBinlogEventsTable failed: %v", err)
 	}
 
@@ -254,7 +254,7 @@ func TestEnsureDatabase(t *testing.T) {
 		rootDB.Exec("DROP DATABASE IF EXISTS `" + dbName + "`")
 	})
 
-	if err := ensureDatabase(cfg, dbName); err != nil {
+	if err := indexer.EnsureDatabase(cfg, dbName, nil); err != nil {
 		t.Fatalf("ensureDatabase failed: %v", err)
 	}
 
@@ -265,7 +265,7 @@ func TestEnsureDatabase(t *testing.T) {
 	}
 
 	// Calling again should succeed (idempotent).
-	if err := ensureDatabase(cfg, dbName); err != nil {
+	if err := indexer.EnsureDatabase(cfg, dbName, nil); err != nil {
 		t.Fatalf("second ensureDatabase call failed: %v", err)
 	}
 }
@@ -275,7 +275,7 @@ func TestEnsureDatabase(t *testing.T) {
 func TestCreateBinlogEventsTable(t *testing.T) {
 	db, dbName := testutil.CreateTestDB(t)
 
-	if err := createBinlogEventsTable(db, 3, false); err != nil {
+	if err := indexer.CreateBinlogEventsTable(db, 3, false); err != nil {
 		t.Fatalf("createBinlogEventsTable failed: %v", err)
 	}
 
@@ -297,7 +297,7 @@ func TestCreateBinlogEventsTable(t *testing.T) {
 func TestListPartitions(t *testing.T) {
 	db, dbName := testutil.CreateTestDB(t)
 
-	if err := createBinlogEventsTable(db, 3, false); err != nil {
+	if err := indexer.CreateBinlogEventsTable(db, 3, false); err != nil {
 		t.Fatalf("createBinlogEventsTable failed: %v", err)
 	}
 
@@ -328,7 +328,7 @@ func TestListPartitions(t *testing.T) {
 func TestDropPartitions(t *testing.T) {
 	db, dbName := testutil.CreateTestDB(t)
 
-	if err := createBinlogEventsTable(db, 5, false); err != nil {
+	if err := indexer.CreateBinlogEventsTable(db, 5, false); err != nil {
 		t.Fatalf("createBinlogEventsTable failed: %v", err)
 	}
 
@@ -514,8 +514,8 @@ func TestArchivePartition_empty(t *testing.T) {
 // initServerTables creates bintrail_servers and bintrail_server_changes in db.
 func initServerTables(t *testing.T, db *sql.DB) {
 	t.Helper()
-	testutil.MustExec(t, db, ddlBintrailServers)
-	testutil.MustExec(t, db, ddlBintrailServerChanges)
+	testutil.MustExec(t, db, serverid.DDLBintrailServers)
+	testutil.MustExec(t, db, serverid.DDLBintrailServerChanges)
 }
 
 // countChanges returns the number of rows in bintrail_server_changes for the given bintrail_id.

--- a/cmd/bintrail/cmd_integration_test.go
+++ b/cmd/bintrail/cmd_integration_test.go
@@ -210,8 +210,8 @@ func TestLoadPartitionStats(t *testing.T) {
 	db, dbName := testutil.CreateTestDB(t)
 
 	// Create table with 3 daily partitions + p_future.
-	if err := indexer.CreateBinlogEventsTable(db, 3, false); err != nil {
-		t.Fatalf("indexer.CreateBinlogEventsTable failed: %v", err)
+	if err := indexer.CreateIndexTables(context.Background(), db, 3, false, nil); err != nil {
+		t.Fatalf("indexer.CreateIndexTables failed: %v", err)
 	}
 
 	stats, err := status.LoadPartitionStats(context.Background(), db, dbName)
@@ -270,35 +270,13 @@ func TestEnsureDatabase(t *testing.T) {
 	}
 }
 
-// ─── indexer.CreateBinlogEventsTable ─────────────────────────────────────────────────────────────
-
-func TestCreateBinlogEventsTable(t *testing.T) {
-	db, dbName := testutil.CreateTestDB(t)
-
-	if err := indexer.CreateBinlogEventsTable(db, 3, false); err != nil {
-		t.Fatalf("indexer.CreateBinlogEventsTable failed: %v", err)
-	}
-
-	// Verify the table has 4 partitions (3 hourly + p_future).
-	var count int
-	if err := db.QueryRow(`
-		SELECT COUNT(*) FROM information_schema.PARTITIONS
-		WHERE TABLE_SCHEMA = ? AND TABLE_NAME = 'binlog_events'`,
-		dbName).Scan(&count); err != nil {
-		t.Fatalf("query partitions failed: %v", err)
-	}
-	if count != 4 {
-		t.Errorf("expected 4 partitions, got %d", count)
-	}
-}
-
 // ─── listPartitions ──────────────────────────────────────────────────────────────────
 
 func TestListPartitions(t *testing.T) {
 	db, dbName := testutil.CreateTestDB(t)
 
-	if err := indexer.CreateBinlogEventsTable(db, 3, false); err != nil {
-		t.Fatalf("indexer.CreateBinlogEventsTable failed: %v", err)
+	if err := indexer.CreateIndexTables(context.Background(), db, 3, false, nil); err != nil {
+		t.Fatalf("indexer.CreateIndexTables failed: %v", err)
 	}
 
 	parts, err := listPartitions(context.Background(), db, dbName)
@@ -328,8 +306,8 @@ func TestListPartitions(t *testing.T) {
 func TestDropPartitions(t *testing.T) {
 	db, dbName := testutil.CreateTestDB(t)
 
-	if err := indexer.CreateBinlogEventsTable(db, 5, false); err != nil {
-		t.Fatalf("indexer.CreateBinlogEventsTable failed: %v", err)
+	if err := indexer.CreateIndexTables(context.Background(), db, 5, false, nil); err != nil {
+		t.Fatalf("indexer.CreateIndexTables failed: %v", err)
 	}
 
 	// List the first partition to drop.

--- a/cmd/bintrail/cmd_integration_test.go
+++ b/cmd/bintrail/cmd_integration_test.go
@@ -211,7 +211,7 @@ func TestLoadPartitionStats(t *testing.T) {
 
 	// Create table with 3 daily partitions + p_future.
 	if err := indexer.CreateBinlogEventsTable(db, 3, false); err != nil {
-		t.Fatalf("createBinlogEventsTable failed: %v", err)
+		t.Fatalf("indexer.CreateBinlogEventsTable failed: %v", err)
 	}
 
 	stats, err := status.LoadPartitionStats(context.Background(), db, dbName)
@@ -234,7 +234,7 @@ func TestLoadPartitionStats(t *testing.T) {
 	}
 }
 
-// ─── ensureDatabase ────────────────────────────────────────────────────────────────
+// ─── indexer.EnsureDatabase ────────────────────────────────────────────────────────────────
 
 func TestEnsureDatabase(t *testing.T) {
 	testutil.SkipIfNoMySQL(t)
@@ -255,7 +255,7 @@ func TestEnsureDatabase(t *testing.T) {
 	})
 
 	if err := indexer.EnsureDatabase(cfg, dbName, nil); err != nil {
-		t.Fatalf("ensureDatabase failed: %v", err)
+		t.Fatalf("indexer.EnsureDatabase failed: %v", err)
 	}
 
 	// Verify database exists.
@@ -270,13 +270,13 @@ func TestEnsureDatabase(t *testing.T) {
 	}
 }
 
-// ─── createBinlogEventsTable ─────────────────────────────────────────────────────────────
+// ─── indexer.CreateBinlogEventsTable ─────────────────────────────────────────────────────────────
 
 func TestCreateBinlogEventsTable(t *testing.T) {
 	db, dbName := testutil.CreateTestDB(t)
 
 	if err := indexer.CreateBinlogEventsTable(db, 3, false); err != nil {
-		t.Fatalf("createBinlogEventsTable failed: %v", err)
+		t.Fatalf("indexer.CreateBinlogEventsTable failed: %v", err)
 	}
 
 	// Verify the table has 4 partitions (3 hourly + p_future).
@@ -298,7 +298,7 @@ func TestListPartitions(t *testing.T) {
 	db, dbName := testutil.CreateTestDB(t)
 
 	if err := indexer.CreateBinlogEventsTable(db, 3, false); err != nil {
-		t.Fatalf("createBinlogEventsTable failed: %v", err)
+		t.Fatalf("indexer.CreateBinlogEventsTable failed: %v", err)
 	}
 
 	parts, err := listPartitions(context.Background(), db, dbName)
@@ -329,7 +329,7 @@ func TestDropPartitions(t *testing.T) {
 	db, dbName := testutil.CreateTestDB(t)
 
 	if err := indexer.CreateBinlogEventsTable(db, 5, false); err != nil {
-		t.Fatalf("createBinlogEventsTable failed: %v", err)
+		t.Fatalf("indexer.CreateBinlogEventsTable failed: %v", err)
 	}
 
 	// List the first partition to drop.

--- a/cmd/bintrail/doctor.go
+++ b/cmd/bintrail/doctor.go
@@ -142,8 +142,8 @@ func isUnknownDatabaseErr(err error) bool {
 }
 
 // connectWithoutDB reconnects to the DSN's server with the database name
-// stripped (the same DBName="" + FormatDSN pattern as init.go's
-// ensureDatabase, but routed through config.Connect to keep parseTime and
+// stripped (the same DBName="" + FormatDSN pattern as
+// indexer.EnsureDatabase, but routed through config.Connect to keep parseTime and
 // the connect timeout), for checks that must run before the index database
 // exists.
 func connectWithoutDB(dsn string) (*sql.DB, error) {

--- a/cmd/bintrail/init.go
+++ b/cmd/bintrail/init.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
@@ -17,7 +16,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/dbtrail/bintrail/internal/cliutil"
-	"github.com/dbtrail/bintrail/internal/serverid"
+	"github.com/dbtrail/bintrail/internal/indexer"
 )
 
 var initCmd = &cobra.Command{
@@ -84,7 +83,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 	// Step 1: Connect to the server without a database to CREATE DATABASE IF NOT EXISTS.
 	// We avoid using the pooled connection for USE statements — reconnect with the DB
 	// name baked into the DSN instead.
-	if err := ensureDatabase(cfg, dbName); err != nil {
+	if err := indexer.EnsureDatabase(cfg, dbName, func(s string) { fmt.Println(s) }); err != nil {
 		return err
 	}
 
@@ -110,7 +109,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 
 	// Create the full index table set (shared with the control-plane
 	// supervisor, which provisions a per-source index DB the same way).
-	if err := createIndexTables(cmd.Context(), db, initPartitions, initEncrypt, logTable); err != nil {
+	if err := indexer.CreateIndexTables(cmd.Context(), db, initPartitions, initEncrypt, logTable); err != nil {
 		return err
 	}
 
@@ -353,310 +352,3 @@ func s3Instructions(bucket, region string) string {
 // control-plane supervisor, which provisions a per-source index database with
 // the same set. logTable is invoked per table for progress output; nil is
 // allowed (no output).
-func createIndexTables(ctx context.Context, db *sql.DB, partitions int, encrypt bool, logTable func(string)) error {
-	if logTable == nil {
-		logTable = func(string) {}
-	}
-
-	// Create binlog_events with dynamic hourly partitions.
-	if err := createBinlogEventsTable(db, partitions, encrypt); err != nil {
-		return fmt.Errorf("failed to create binlog_events: %w", err)
-	}
-	logTable("binlog_events")
-
-	// If encryption was requested, verify that the table actually has it
-	// enabled. CREATE TABLE IF NOT EXISTS is a no-op when the table already
-	// exists, so a pre-existing unencrypted table will silently remain
-	// unencrypted. Warn the operator so they can encrypt it manually.
-	if encrypt {
-		var createOpts string
-		row := db.QueryRowContext(ctx,
-			`SELECT COALESCE(CREATE_OPTIONS, '') FROM information_schema.TABLES
-			 WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'binlog_events'`)
-		if err := row.Scan(&createOpts); err == nil &&
-			!strings.Contains(strings.ToUpper(createOpts), "ENCRYPTION=Y") {
-			fmt.Fprintf(os.Stderr, "Warning: binlog_events already exists without encryption.\n"+
-				"To encrypt it, run: ALTER TABLE binlog_events ENCRYPTION='Y'\n")
-		}
-	}
-
-	ddls := []struct {
-		name string
-		ddl  string
-	}{
-		{"schema_snapshots", ddlSchemaSnapshots},
-		{"index_state", ddlIndexState},
-		{"stream_state", ddlStreamState},
-		{"bintrail_servers", ddlBintrailServers},
-		{"bintrail_server_changes", ddlBintrailServerChanges},
-		{"table_flags", ddlTableFlags},
-		{"profiles", ddlProfiles},
-		{"access_rules", ddlAccessRules},
-		{"archive_state", ddlArchiveState},
-		{"schema_changes", ddlSchemaChanges},
-		{"fk_constraints", ddlFKConstraints},
-	}
-	for _, t := range ddls {
-		if _, err := db.Exec(t.ddl); err != nil {
-			return fmt.Errorf("failed to create %s: %w", t.name, err)
-		}
-		logTable(t.name)
-	}
-	return nil
-}
-
-func ensureDatabase(cfg *mysql.Config, dbName string) error {
-	serverCfg := *cfg
-	serverCfg.DBName = ""
-
-	db, err := sql.Open("mysql", serverCfg.FormatDSN())
-	if err != nil {
-		return fmt.Errorf("failed to open server connection: %w", err)
-	}
-	defer db.Close()
-
-	if err := db.Ping(); err != nil {
-		return fmt.Errorf("failed to connect to MySQL server: %w", err)
-	}
-
-	q := fmt.Sprintf(
-		"CREATE DATABASE IF NOT EXISTS `%s` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci",
-		dbName,
-	)
-	if _, err := db.Exec(q); err != nil {
-		return fmt.Errorf("failed to create database %q: %w", dbName, err)
-	}
-
-	fmt.Printf("Database %q ready.\n", dbName)
-	return nil
-}
-
-// buildPartitionDefs returns numPartitions hourly partition clauses ending at
-// the current hour (truncated from now), followed by a p_future catch-all.
-//
-// Partitions span forward from the current hour so that incoming events
-// land in named partitions rather than accumulating in p_future.
-// With numPartitions=48 (the
-// default), the range covers the current hour through the next 47 hours.
-// New events arriving beyond that range fall into p_future until rotate adds
-// more named partitions.
-func buildPartitionDefs(now time.Time, numPartitions int) []string {
-	now = now.UTC().Truncate(time.Hour)
-	start := now
-
-	parts := make([]string, 0, numPartitions+1)
-	for i := range numPartitions {
-		hour := start.Add(time.Duration(i) * time.Hour)
-		nextHour := hour.Add(time.Hour)
-		parts = append(parts, fmt.Sprintf(
-			"    PARTITION p_%s VALUES LESS THAN (TO_SECONDS('%s'))",
-			hour.Format("2006010215"),
-			nextHour.UTC().Format("2006-01-02 15:04:05"),
-		))
-	}
-	parts = append(parts, "    PARTITION p_future VALUES LESS THAN MAXVALUE")
-	return parts
-}
-
-// buildBinlogEventsDDL assembles the full CREATE TABLE statement for
-// binlog_events. When encrypt is true, ENCRYPTION='Y' is added to the table
-// options so MySQL uses InnoDB tablespace encryption (requires a keyring
-// plugin on the server).
-func buildBinlogEventsDDL(parts []string, encrypt bool) string {
-	encryptClause := ""
-	if encrypt {
-		encryptClause = " ENCRYPTION='Y'"
-	}
-	return `CREATE TABLE IF NOT EXISTS binlog_events (
-    event_id        BIGINT UNSIGNED AUTO_INCREMENT,
-    binlog_file     VARCHAR(255)     NOT NULL,
-    start_pos       BIGINT UNSIGNED  NOT NULL,
-    end_pos         BIGINT UNSIGNED  NOT NULL,
-    event_timestamp DATETIME         NOT NULL,
-    gtid            VARCHAR(255)     DEFAULT NULL,
-    connection_id   INT UNSIGNED     DEFAULT NULL COMMENT 'MySQL connection ID (pseudo_thread_id) that produced this event',
-    schema_name     VARCHAR(64)      NOT NULL,
-    table_name      VARCHAR(64)      NOT NULL,
-    event_type      TINYINT UNSIGNED NOT NULL COMMENT '1=INSERT, 2=UPDATE, 3=DELETE',
-    pk_values       VARCHAR(512)     NOT NULL COMMENT 'PK values in ordinal order, pipe-delimited. e.g. 12345 or 12345|2',
-    pk_hash         VARCHAR(64)      AS (SHA2(pk_values, 256)) STORED,
-    changed_columns JSON             DEFAULT NULL COMMENT 'list of columns that changed (UPDATEs only)',
-    row_before      JSON             DEFAULT NULL COMMENT 'full row before image (UPDATE, DELETE)',
-    row_after       JSON             DEFAULT NULL COMMENT 'full row after image (INSERT, UPDATE)',
-    schema_version  INT UNSIGNED     NOT NULL DEFAULT 0 COMMENT 'snapshot_id from schema_snapshots at index time; enables per-row resolver lookup for recovery',
-    PRIMARY KEY (event_id, event_timestamp),
-    INDEX idx_row_lookup (schema_name, table_name, event_timestamp),
-    INDEX idx_pk_hash    (schema_name, table_name, pk_hash, event_timestamp),
-    INDEX idx_gtid       (gtid)
-) ENGINE=InnoDB` + encryptClause + `
-  PARTITION BY RANGE (TO_SECONDS(event_timestamp)) (
-` + strings.Join(parts, ",\n") + `
-)`
-}
-
-// createBinlogEventsTable generates the CREATE TABLE with N hourly partitions
-// spanning from (N-1) hours ago to the current hour (UTC), plus a p_future
-// catch-all partition for any events arriving in subsequent hours.
-//
-// Each partition p_YYYYMMDDHH covers events where TO_SECONDS(event_timestamp)
-// is less than TO_SECONDS of the following hour (timezone-independent).
-// When encrypt is true, ENCRYPTION='Y' is added to enable InnoDB tablespace
-// encryption (requires a keyring plugin on the MySQL server).
-func createBinlogEventsTable(db *sql.DB, numPartitions int, encrypt bool) error {
-	parts := buildPartitionDefs(time.Now(), numPartitions)
-	ddl := buildBinlogEventsDDL(parts, encrypt)
-	_, err := db.Exec(ddl)
-	return err
-}
-
-// ---------------------------------------------------------------------------
-// Static DDL — no partition logic needed for these tables.
-// ---------------------------------------------------------------------------
-
-const ddlSchemaSnapshots = `CREATE TABLE IF NOT EXISTS schema_snapshots (
-    id               INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-    snapshot_id      INT UNSIGNED NOT NULL,
-    snapshot_time    DATETIME     NOT NULL,
-    schema_name      VARCHAR(64)  NOT NULL,
-    table_name       VARCHAR(64)  NOT NULL,
-    column_name      VARCHAR(64)  NOT NULL,
-    ordinal_position INT UNSIGNED NOT NULL,
-    column_key       VARCHAR(3)   NOT NULL COMMENT 'PRI, UNI, MUL, or empty',
-    data_type        VARCHAR(64)  NOT NULL,
-    column_type      VARCHAR(128) NOT NULL DEFAULT '' COMMENT 'full type from information_schema.COLUMNS.COLUMN_TYPE, e.g. "datetime(6)" or "int unsigned"; needed by full-table reconstruct for DATETIME precision',
-    is_nullable      VARCHAR(3)   NOT NULL,
-    column_default   TEXT         DEFAULT NULL,
-    is_generated     TINYINT(1)   NOT NULL DEFAULT 0 COMMENT '1 if STORED or VIRTUAL generated column',
-    INDEX idx_snapshot_id    (snapshot_id),
-    INDEX idx_snapshot_table (snapshot_id, schema_name, table_name)
-) ENGINE=InnoDB`
-
-const ddlStreamState = `CREATE TABLE IF NOT EXISTS stream_state (
-    id               INT UNSIGNED    PRIMARY KEY DEFAULT 1,
-    mode             ENUM('position','gtid') NOT NULL,
-    binlog_file      VARCHAR(255)    NOT NULL DEFAULT '',
-    binlog_position  BIGINT UNSIGNED NOT NULL DEFAULT 0,
-    gtid_set         TEXT            DEFAULT NULL,
-    events_indexed   BIGINT UNSIGNED NOT NULL DEFAULT 0,
-    last_event_time  DATETIME        DEFAULT NULL,
-    last_checkpoint  DATETIME        NOT NULL,
-    server_id        INT UNSIGNED    NOT NULL,
-    bintrail_id      CHAR(36)        NULL DEFAULT NULL,
-    gap_lost_at      DATETIME        DEFAULT NULL COMMENT 'when an unfillable binlog gap forced an auto-advance (events permanently lost); cleared by an explicit monitor Stop or --reset',
-    gap_lost_detail  TEXT            DEFAULT NULL COMMENT 'human-readable description of the lost gap',
-    CONSTRAINT single_row CHECK (id = 1)
-) ENGINE=InnoDB`
-
-const ddlIndexState = `CREATE TABLE IF NOT EXISTS index_state (
-    binlog_file    VARCHAR(255) PRIMARY KEY,
-    file_size      BIGINT UNSIGNED NOT NULL,
-    last_position  BIGINT UNSIGNED NOT NULL COMMENT 'last parsed position',
-    events_indexed BIGINT UNSIGNED NOT NULL DEFAULT 0,
-    status         ENUM('in_progress','completed','failed') NOT NULL,
-    started_at     DATETIME NOT NULL,
-    completed_at   DATETIME DEFAULT NULL,
-    error_message  TEXT     DEFAULT NULL,
-    bintrail_id    CHAR(36) NULL DEFAULT NULL,
-    INDEX idx_bintrail_id (bintrail_id)
-) ENGINE=InnoDB`
-
-// ddlBintrailServers and ddlBintrailServerChanges are the canonical DDL
-// statements for the server identity tables. They live in internal/serverid
-// so that testutil and init share a single source of truth.
-var (
-	ddlBintrailServers       = serverid.DDLBintrailServers
-	ddlBintrailServerChanges = serverid.DDLBintrailServerChanges
-)
-
-// ─── Archive tracking ─────────────────────────────────────────────────────────
-
-const ddlArchiveState = `CREATE TABLE IF NOT EXISTS archive_state (
-    id              INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-    partition_name  VARCHAR(20) NOT NULL,
-    bintrail_id     VARCHAR(36),
-    local_path      VARCHAR(1024),
-    file_size_bytes BIGINT UNSIGNED,
-    row_count       BIGINT UNSIGNED,
-    s3_bucket       VARCHAR(255),
-    s3_key          VARCHAR(1024),
-    s3_uploaded_at  DATETIME,
-    archived_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    UNIQUE KEY uq_partition (partition_name, bintrail_id)
-) ENGINE=InnoDB`
-
-// ─── RBAC tables ─────────────────────────────────────────────────────────────
-
-// ddlTableFlags stores named flags on tables or individual columns.
-// column_name = ” means the flag applies to the whole table; a non-empty
-// value names the specific column that carries the flag.
-// This two-level design lets access_rules express both "deny the billing
-// table" (table-level flag) and "redact the amount column" (column-level flag)
-// using the same flag name with different column_name values.
-const ddlTableFlags = `CREATE TABLE IF NOT EXISTS table_flags (
-    id          INT UNSIGNED  AUTO_INCREMENT PRIMARY KEY,
-    schema_name VARCHAR(64)   NOT NULL,
-    table_name  VARCHAR(64)   NOT NULL,
-    column_name VARCHAR(64)   NOT NULL DEFAULT '' COMMENT 'empty = table-level flag; non-empty = column-level flag',
-    flag        VARCHAR(255)  NOT NULL,
-    created_at  DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    UNIQUE KEY idx_unique (schema_name, table_name, column_name, flag),
-    INDEX idx_flag (flag)
-) ENGINE=InnoDB`
-
-// ddlProfiles stores named access profiles (e.g. "dev", "marketing").
-// Profiles are referenced by access_rules to define what flags each profile
-// may or may not access. Management is typically done from the web panel;
-// the CLI provides the 'bintrail flag' command for DBA use.
-const ddlProfiles = `CREATE TABLE IF NOT EXISTS profiles (
-    id          INT UNSIGNED  AUTO_INCREMENT PRIMARY KEY,
-    name        VARCHAR(255)  NOT NULL,
-    description TEXT          DEFAULT NULL,
-    created_at  DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    UNIQUE KEY idx_name (name)
-) ENGINE=InnoDB`
-
-// ddlAccessRules maps a profile to a flag with an allow/deny permission.
-// Combined with table_flags this enables RBAC:
-//   - profile "dev" DENY flag "billing"  → dev users cannot see billing table events
-//   - profile "marketing" DENY flag "pii" → marketing users see events but pii columns are redacted
-const ddlAccessRules = `CREATE TABLE IF NOT EXISTS access_rules (
-    id          INT UNSIGNED  AUTO_INCREMENT PRIMARY KEY,
-    profile_id  INT UNSIGNED  NOT NULL,
-    flag        VARCHAR(255)  NOT NULL,
-    permission  ENUM('allow','deny') NOT NULL,
-    created_at  DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    UNIQUE KEY idx_profile_flag (profile_id, flag),
-    CONSTRAINT fk_access_rules_profile FOREIGN KEY (profile_id) REFERENCES profiles (id) ON DELETE CASCADE
-) ENGINE=InnoDB`
-
-// ─── FK constraints ───────────────────────────────────────────────────────────
-
-const ddlFKConstraints = `CREATE TABLE IF NOT EXISTS fk_constraints (
-    snapshot_id              INT UNSIGNED NOT NULL,
-    constraint_name          VARCHAR(64)  NOT NULL,
-    schema_name              VARCHAR(64)  NOT NULL,
-    table_name               VARCHAR(64)  NOT NULL,
-    column_name              VARCHAR(64)  NOT NULL,
-    ordinal_position         INT          NOT NULL,
-    referenced_schema_name   VARCHAR(64)  NOT NULL,
-    referenced_table_name    VARCHAR(64)  NOT NULL,
-    referenced_column_name   VARCHAR(64)  NOT NULL,
-    PRIMARY KEY (snapshot_id, schema_name, constraint_name, ordinal_position)
-) ENGINE=InnoDB`
-
-// ─── DDL tracking ─────────────────────────────────────────────────────────────
-
-const ddlSchemaChanges = `CREATE TABLE IF NOT EXISTS schema_changes (
-    id              INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-    detected_at     DATETIME NOT NULL,
-    binlog_file     VARCHAR(255) NOT NULL,
-    binlog_pos      BIGINT UNSIGNED NOT NULL,
-    gtid            VARCHAR(255) DEFAULT NULL,
-    schema_name     VARCHAR(64) NOT NULL,
-    table_name      VARCHAR(64) NOT NULL,
-    ddl_type        VARCHAR(50) NOT NULL,
-    ddl_query       TEXT NOT NULL,
-    snapshot_id     INT UNSIGNED DEFAULT NULL COMMENT 'auto-snapshot after DDL; NULL when not taken (file mode or snapshot failure)',
-    INDEX idx_detected_at (detected_at),
-    INDEX idx_schema_table (schema_name, table_name)
-) ENGINE=InnoDB`

--- a/cmd/bintrail/init.go
+++ b/cmd/bintrail/init.go
@@ -344,11 +344,3 @@ func s3Instructions(bucket, region string) string {
 
 	return sb.String()
 }
-
-// ensureDatabase creates the target database if it does not already exist.
-// It connects without a database name so the CREATE DATABASE always succeeds.
-// createIndexTables creates every index table (idempotent — all DDL is
-// CREATE TABLE IF NOT EXISTS). Shared by `bintrail init` and the
-// control-plane supervisor, which provisions a per-source index database with
-// the same set. logTable is invoked per table for progress output; nil is
-// allowed (no output).

--- a/cmd/bintrail/init_test.go
+++ b/cmd/bintrail/init_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"strings"
 	"testing"
-	"time"
 )
 
 // ─── Cobra command wiring ─────────────────────────────────────────────────────
@@ -92,54 +91,6 @@ func TestInitCmd_defaults(t *testing.T) {
 	}
 }
 
-// ─── buildBinlogEventsDDL ───────────────────────────────────────────────────
-
-func TestBuildBinlogEventsDDL_noEncrypt(t *testing.T) {
-	parts := []string{"    PARTITION p_2026022814 VALUES LESS THAN (TO_SECONDS('2026-02-28 15:00:00'))",
-		"    PARTITION p_future VALUES LESS THAN MAXVALUE"}
-	ddl := buildBinlogEventsDDL(parts, false)
-
-	if strings.Contains(ddl, "ENCRYPTION") {
-		t.Error("expected no ENCRYPTION clause when encrypt=false")
-	}
-	if !strings.Contains(ddl, "ENGINE=InnoDB") {
-		t.Error("expected ENGINE=InnoDB in DDL")
-	}
-	if !strings.Contains(ddl, "p_future") {
-		t.Error("expected p_future partition in DDL")
-	}
-	if !strings.Contains(ddl, "schema_version") {
-		t.Error("expected schema_version column in DDL")
-	}
-}
-
-func TestBuildBinlogEventsDDL_withEncrypt(t *testing.T) {
-	parts := []string{"    PARTITION p_2026022814 VALUES LESS THAN (TO_SECONDS('2026-02-28 15:00:00'))",
-		"    PARTITION p_future VALUES LESS THAN MAXVALUE"}
-	ddl := buildBinlogEventsDDL(parts, true)
-
-	if !strings.Contains(ddl, "ENCRYPTION='Y'") {
-		t.Error("expected ENCRYPTION='Y' in DDL when encrypt=true")
-	}
-	if !strings.Contains(ddl, "p_future") {
-		t.Error("expected p_future partition in DDL")
-	}
-	if !strings.Contains(ddl, "schema_version") {
-		t.Error("expected schema_version column in DDL")
-	}
-	// Encryption clause must appear after ENGINE=InnoDB and before PARTITION BY.
-	engineIdx := strings.Index(ddl, "ENGINE=InnoDB")
-	encryptIdx := strings.Index(ddl, "ENCRYPTION='Y'")
-	partitionIdx := strings.Index(ddl, "PARTITION BY RANGE")
-	if engineIdx < 0 || encryptIdx < 0 || partitionIdx < 0 {
-		t.Fatal("DDL missing ENGINE=InnoDB, ENCRYPTION='Y', or PARTITION BY RANGE")
-	}
-	if !(engineIdx < encryptIdx && encryptIdx < partitionIdx) {
-		t.Errorf("expected ENGINE < ENCRYPTION < PARTITION BY in DDL, got positions %d, %d, %d",
-			engineIdx, encryptIdx, partitionIdx)
-	}
-}
-
 // ─── parseS3ARN ──────────────────────────────────────────────────────────────
 
 func TestParseS3ARN_validARNs(t *testing.T) {
@@ -217,69 +168,6 @@ func TestS3IAMInstructions_usesCorrectPartition(t *testing.T) {
 	}
 	if strings.Contains(out, "arn:aws:s3:::china-bucket") {
 		t.Error("should not contain standard aws partition for aws-cn bucket")
-	}
-}
-
-// ─── buildPartitionDefs ───────────────────────────────────────────────────────────
-
-func TestBuildPartitionDefs_countAndFuture(t *testing.T) {
-	now := time.Date(2026, 2, 28, 14, 30, 0, 0, time.UTC)
-	parts := buildPartitionDefs(now, 48)
-
-	// 48 named hourly partitions + p_future = 49
-	if len(parts) != 49 {
-		t.Fatalf("expected 49 partition defs, got %d", len(parts))
-	}
-	if !strings.Contains(parts[48], "p_future") {
-		t.Errorf("last def should be p_future, got %q", parts[48])
-	}
-}
-
-func TestBuildPartitionDefs_spansFromCurrentHourForward(t *testing.T) {
-	// now truncated to 14:00; with 48 partitions: start = 14:00, end = 14:00 + 47h = 2026-03-02 13:00 UTC
-	now := time.Date(2026, 2, 28, 14, 30, 0, 0, time.UTC)
-	parts := buildPartitionDefs(now, 48)
-
-	// First partition starts at the current hour
-	if !strings.Contains(parts[0], "p_2026022814") {
-		t.Errorf("expected first partition p_2026022814 (current hour), got %q", parts[0])
-	}
-	// Last named partition covers 47 hours from now
-	if !strings.Contains(parts[47], "p_2026030213") {
-		t.Errorf("expected last named partition p_2026030213 (+47h), got %q", parts[47])
-	}
-}
-
-func TestBuildPartitionDefs_boundaryValues(t *testing.T) {
-	now := time.Date(2026, 2, 28, 14, 30, 0, 0, time.UTC)
-	parts := buildPartitionDefs(now, 3)
-
-	// 3 partitions: p_2026022814, p_2026022815, p_2026022816, p_future
-	if !strings.Contains(parts[0], "p_2026022814") {
-		t.Errorf("expected p_2026022814 (current hour), got %q", parts[0])
-	}
-	if !strings.Contains(parts[1], "p_2026022815") {
-		t.Errorf("expected p_2026022815, got %q", parts[1])
-	}
-	if !strings.Contains(parts[2], "p_2026022816") {
-		t.Errorf("expected p_2026022816, got %q", parts[2])
-	}
-	// p_2026022814 boundary: LESS THAN TO_SECONDS('2026-02-28 15:00:00')
-	if !strings.Contains(parts[0], "2026-02-28 15:00:00") {
-		t.Errorf("expected boundary at 2026-02-28 15:00:00, got %q", parts[0])
-	}
-}
-
-func TestBuildPartitionDefs_singlePartition(t *testing.T) {
-	now := time.Date(2026, 2, 28, 10, 0, 0, 0, time.UTC)
-	parts := buildPartitionDefs(now, 1)
-
-	// 1 named + p_future = 2
-	if len(parts) != 2 {
-		t.Fatalf("expected 2 defs, got %d", len(parts))
-	}
-	if !strings.Contains(parts[0], "p_2026022810") {
-		t.Errorf("expected p_2026022810 (current hour), got %q", parts[0])
 	}
 }
 
@@ -397,98 +285,5 @@ func TestRunInit_missingDBName(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "--index-dsn must include a database name") {
 		t.Errorf("unexpected error: %v", err)
-	}
-}
-
-// ─── DDL content: bintrail_id columns ─────────────────────────────────────────────
-
-func TestDDLIndexState_hasBintrailID(t *testing.T) {
-	if !strings.Contains(ddlIndexState, "bintrail_id") {
-		t.Error("ddlIndexState must contain bintrail_id column")
-	}
-	if !strings.Contains(ddlIndexState, "idx_bintrail_id") {
-		t.Error("ddlIndexState must contain idx_bintrail_id index")
-	}
-	if !strings.Contains(ddlIndexState, "CHAR(36)") {
-		t.Error("ddlIndexState bintrail_id must be CHAR(36)")
-	}
-	if !strings.Contains(ddlIndexState, "NULL DEFAULT NULL") {
-		t.Error("ddlIndexState bintrail_id must be nullable (NULL DEFAULT NULL)")
-	}
-}
-
-func TestDDLStreamState_hasBintrailID(t *testing.T) {
-	if !strings.Contains(ddlStreamState, "bintrail_id") {
-		t.Error("ddlStreamState must contain bintrail_id column")
-	}
-	if !strings.Contains(ddlStreamState, "CHAR(36)") {
-		t.Error("ddlStreamState bintrail_id must be CHAR(36)")
-	}
-	if !strings.Contains(ddlStreamState, "NULL DEFAULT NULL") {
-		t.Error("ddlStreamState bintrail_id must be nullable (NULL DEFAULT NULL)")
-	}
-}
-
-// ─── DDL content: archive_state ───────────────────────────────────────────────
-
-func TestDDLArchiveState_hasExpectedColumns(t *testing.T) {
-	for _, col := range []string{
-		"partition_name", "bintrail_id", "local_path",
-		"file_size_bytes", "row_count",
-		"s3_bucket", "s3_key", "s3_uploaded_at", "archived_at",
-	} {
-		if !strings.Contains(ddlArchiveState, col) {
-			t.Errorf("ddlArchiveState must contain %s column", col)
-		}
-	}
-}
-
-func TestDDLArchiveState_hasUniqueKey(t *testing.T) {
-	if !strings.Contains(ddlArchiveState, "uq_partition") {
-		t.Error("ddlArchiveState must contain uq_partition unique key")
-	}
-	if !strings.Contains(ddlArchiveState, "partition_name, bintrail_id") {
-		t.Error("uq_partition must be on (partition_name, bintrail_id)")
-	}
-}
-
-func TestDDLConstants_noUTCTimestampDefault(t *testing.T) {
-	ddls := map[string]string{
-		"ddlSchemaSnapshots": ddlSchemaSnapshots,
-		"ddlStreamState":     ddlStreamState,
-		"ddlIndexState":      ddlIndexState,
-		"ddlArchiveState":    ddlArchiveState,
-		"ddlTableFlags":      ddlTableFlags,
-		"ddlProfiles":        ddlProfiles,
-		"ddlAccessRules":     ddlAccessRules,
-		"ddlSchemaChanges":   ddlSchemaChanges,
-	}
-	for name, ddl := range ddls {
-		if strings.Contains(strings.ToUpper(ddl), "DEFAULT UTC_TIMESTAMP") {
-			t.Errorf("%s must not use UTC_TIMESTAMP() as a DEFAULT — MySQL rejects it in DDL; use CURRENT_TIMESTAMP instead", name)
-		}
-	}
-}
-
-// ─── ddlSchemaChanges ───────────────────────────────────────────────────────
-
-func TestDDLSchemaChanges_hasRequiredColumns(t *testing.T) {
-	for _, col := range []string{
-		"id", "detected_at", "binlog_file", "binlog_pos",
-		"gtid", "schema_name", "table_name", "ddl_type",
-		"ddl_query", "snapshot_id",
-	} {
-		if !strings.Contains(ddlSchemaChanges, col) {
-			t.Errorf("ddlSchemaChanges must contain %s column", col)
-		}
-	}
-}
-
-func TestDDLSchemaChanges_hasIndex(t *testing.T) {
-	if !strings.Contains(ddlSchemaChanges, "idx_detected_at") {
-		t.Error("ddlSchemaChanges must contain idx_detected_at index")
-	}
-	if !strings.Contains(ddlSchemaChanges, "idx_schema_table") {
-		t.Error("ddlSchemaChanges must contain idx_schema_table index")
 	}
 }

--- a/cmd/bintrail/monitor.go
+++ b/cmd/bintrail/monitor.go
@@ -306,14 +306,14 @@ func (m *monitorSupervisor) Start(ctx context.Context, e console.ServerEntry) er
 	if idxCfg.DBName == "" || !dbNameRE.MatchString(idxCfg.DBName) {
 		return fail(fmt.Errorf("index database name %q is not provisionable", idxCfg.DBName))
 	}
-	if err := ensureDatabase(idxCfg, idxCfg.DBName); err != nil {
+	if err := indexer.EnsureDatabase(idxCfg, idxCfg.DBName, nil); err != nil {
 		return fail(err)
 	}
 	idxDB, err := config.Connect(e.DSN)
 	if err != nil {
 		return fail(fmt.Errorf("connect provisioned index: %w", err))
 	}
-	if err := createIndexTables(ctx, idxDB, 48, false, nil); err != nil {
+	if err := indexer.CreateIndexTables(ctx, idxDB, 48, false, nil); err != nil {
 		idxDB.Close()
 		return fail(err)
 	}

--- a/internal/indexer/provision.go
+++ b/internal/indexer/provision.go
@@ -1,0 +1,46 @@
+package indexer
+
+import (
+	"database/sql"
+	"fmt"
+
+	mysql "github.com/go-sql-driver/mysql"
+)
+
+// EnsureDatabase creates the index database if it does not already exist. cfg is
+// a parsed DSN config pointing at the MySQL server (its DBName is ignored — the
+// connection is opened without a database so CREATE DATABASE can run); dbName is
+// created with utf8mb4/utf8mb4_unicode_ci.
+//
+// The optional log callback receives a human-readable "ready" line. Pass nil for
+// silent provisioning (e.g. the monitor supervisor); the CLI passes a closure
+// that prints to stdout.
+func EnsureDatabase(cfg *mysql.Config, dbName string, log func(string)) error {
+	if log == nil {
+		log = func(string) {}
+	}
+
+	serverCfg := *cfg
+	serverCfg.DBName = ""
+
+	db, err := sql.Open("mysql", serverCfg.FormatDSN())
+	if err != nil {
+		return fmt.Errorf("failed to open server connection: %w", err)
+	}
+	defer db.Close()
+
+	if err := db.Ping(); err != nil {
+		return fmt.Errorf("failed to connect to MySQL server: %w", err)
+	}
+
+	q := fmt.Sprintf(
+		"CREATE DATABASE IF NOT EXISTS `%s` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci",
+		dbName,
+	)
+	if _, err := db.Exec(q); err != nil {
+		return fmt.Errorf("failed to create database %q: %w", dbName, err)
+	}
+
+	log(fmt.Sprintf("Database %q ready.", dbName))
+	return nil
+}

--- a/internal/indexer/schema.go
+++ b/internal/indexer/schema.go
@@ -11,6 +11,10 @@ import (
 	"github.com/dbtrail/bintrail/internal/serverid"
 )
 
+// CreateIndexTables creates every index table (idempotent — all DDL is
+// CREATE TABLE IF NOT EXISTS). Shared by `bintrail init` and the control-plane
+// supervisor, which provisions a per-source index database with the same set.
+// logTable is invoked per table for progress output; nil is allowed (no output).
 func CreateIndexTables(ctx context.Context, db *sql.DB, partitions int, encrypt bool, logTable func(string)) error {
 	if logTable == nil {
 		logTable = func(string) {}
@@ -126,7 +130,7 @@ func buildBinlogEventsDDL(parts []string, encrypt bool) string {
 )`
 }
 
-// createBinlogEventsTable generates the CREATE TABLE with N hourly partitions
+// CreateBinlogEventsTable generates the CREATE TABLE with N hourly partitions
 // spanning from (N-1) hours ago to the current hour (UTC), plus a p_future
 // catch-all partition for any events arriving in subsequent hours.
 //

--- a/internal/indexer/schema.go
+++ b/internal/indexer/schema.go
@@ -1,0 +1,282 @@
+package indexer
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/dbtrail/bintrail/internal/serverid"
+)
+
+func CreateIndexTables(ctx context.Context, db *sql.DB, partitions int, encrypt bool, logTable func(string)) error {
+	if logTable == nil {
+		logTable = func(string) {}
+	}
+
+	// Create binlog_events with dynamic hourly partitions.
+	if err := CreateBinlogEventsTable(db, partitions, encrypt); err != nil {
+		return fmt.Errorf("failed to create binlog_events: %w", err)
+	}
+	logTable("binlog_events")
+
+	// If encryption was requested, verify that the table actually has it
+	// enabled. CREATE TABLE IF NOT EXISTS is a no-op when the table already
+	// exists, so a pre-existing unencrypted table will silently remain
+	// unencrypted. Warn the operator so they can encrypt it manually.
+	if encrypt {
+		var createOpts string
+		row := db.QueryRowContext(ctx,
+			`SELECT COALESCE(CREATE_OPTIONS, '') FROM information_schema.TABLES
+			 WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'binlog_events'`)
+		if err := row.Scan(&createOpts); err == nil &&
+			!strings.Contains(strings.ToUpper(createOpts), "ENCRYPTION=Y") {
+			fmt.Fprintf(os.Stderr, "Warning: binlog_events already exists without encryption.\n"+
+				"To encrypt it, run: ALTER TABLE binlog_events ENCRYPTION='Y'\n")
+		}
+	}
+
+	ddls := []struct {
+		name string
+		ddl  string
+	}{
+		{"schema_snapshots", ddlSchemaSnapshots},
+		{"index_state", ddlIndexState},
+		{"stream_state", ddlStreamState},
+		{"bintrail_servers", serverid.DDLBintrailServers},
+		{"bintrail_server_changes", serverid.DDLBintrailServerChanges},
+		{"table_flags", ddlTableFlags},
+		{"profiles", ddlProfiles},
+		{"access_rules", ddlAccessRules},
+		{"archive_state", ddlArchiveState},
+		{"schema_changes", ddlSchemaChanges},
+		{"fk_constraints", ddlFKConstraints},
+	}
+	for _, t := range ddls {
+		if _, err := db.Exec(t.ddl); err != nil {
+			return fmt.Errorf("failed to create %s: %w", t.name, err)
+		}
+		logTable(t.name)
+	}
+	return nil
+}
+
+// buildPartitionDefs returns numPartitions hourly partition clauses ending at
+// the current hour (truncated from now), followed by a p_future catch-all.
+//
+// Partitions span forward from the current hour so that incoming events
+// land in named partitions rather than accumulating in p_future.
+// With numPartitions=48 (the
+// default), the range covers the current hour through the next 47 hours.
+// New events arriving beyond that range fall into p_future until rotate adds
+// more named partitions.
+func buildPartitionDefs(now time.Time, numPartitions int) []string {
+	now = now.UTC().Truncate(time.Hour)
+	start := now
+
+	parts := make([]string, 0, numPartitions+1)
+	for i := range numPartitions {
+		hour := start.Add(time.Duration(i) * time.Hour)
+		nextHour := hour.Add(time.Hour)
+		parts = append(parts, fmt.Sprintf(
+			"    PARTITION p_%s VALUES LESS THAN (TO_SECONDS('%s'))",
+			hour.Format("2006010215"),
+			nextHour.UTC().Format("2006-01-02 15:04:05"),
+		))
+	}
+	parts = append(parts, "    PARTITION p_future VALUES LESS THAN MAXVALUE")
+	return parts
+}
+
+// buildBinlogEventsDDL assembles the full CREATE TABLE statement for
+// binlog_events. When encrypt is true, ENCRYPTION='Y' is added to the table
+// options so MySQL uses InnoDB tablespace encryption (requires a keyring
+// plugin on the server).
+func buildBinlogEventsDDL(parts []string, encrypt bool) string {
+	encryptClause := ""
+	if encrypt {
+		encryptClause = " ENCRYPTION='Y'"
+	}
+	return `CREATE TABLE IF NOT EXISTS binlog_events (
+    event_id        BIGINT UNSIGNED AUTO_INCREMENT,
+    binlog_file     VARCHAR(255)     NOT NULL,
+    start_pos       BIGINT UNSIGNED  NOT NULL,
+    end_pos         BIGINT UNSIGNED  NOT NULL,
+    event_timestamp DATETIME         NOT NULL,
+    gtid            VARCHAR(255)     DEFAULT NULL,
+    connection_id   INT UNSIGNED     DEFAULT NULL COMMENT 'MySQL connection ID (pseudo_thread_id) that produced this event',
+    schema_name     VARCHAR(64)      NOT NULL,
+    table_name      VARCHAR(64)      NOT NULL,
+    event_type      TINYINT UNSIGNED NOT NULL COMMENT '1=INSERT, 2=UPDATE, 3=DELETE',
+    pk_values       VARCHAR(512)     NOT NULL COMMENT 'PK values in ordinal order, pipe-delimited. e.g. 12345 or 12345|2',
+    pk_hash         VARCHAR(64)      AS (SHA2(pk_values, 256)) STORED,
+    changed_columns JSON             DEFAULT NULL COMMENT 'list of columns that changed (UPDATEs only)',
+    row_before      JSON             DEFAULT NULL COMMENT 'full row before image (UPDATE, DELETE)',
+    row_after       JSON             DEFAULT NULL COMMENT 'full row after image (INSERT, UPDATE)',
+    schema_version  INT UNSIGNED     NOT NULL DEFAULT 0 COMMENT 'snapshot_id from schema_snapshots at index time; enables per-row resolver lookup for recovery',
+    PRIMARY KEY (event_id, event_timestamp),
+    INDEX idx_row_lookup (schema_name, table_name, event_timestamp),
+    INDEX idx_pk_hash    (schema_name, table_name, pk_hash, event_timestamp),
+    INDEX idx_gtid       (gtid)
+) ENGINE=InnoDB` + encryptClause + `
+  PARTITION BY RANGE (TO_SECONDS(event_timestamp)) (
+` + strings.Join(parts, ",\n") + `
+)`
+}
+
+// createBinlogEventsTable generates the CREATE TABLE with N hourly partitions
+// spanning from (N-1) hours ago to the current hour (UTC), plus a p_future
+// catch-all partition for any events arriving in subsequent hours.
+//
+// Each partition p_YYYYMMDDHH covers events where TO_SECONDS(event_timestamp)
+// is less than TO_SECONDS of the following hour (timezone-independent).
+// When encrypt is true, ENCRYPTION='Y' is added to enable InnoDB tablespace
+// encryption (requires a keyring plugin on the MySQL server).
+func CreateBinlogEventsTable(db *sql.DB, numPartitions int, encrypt bool) error {
+	parts := buildPartitionDefs(time.Now(), numPartitions)
+	ddl := buildBinlogEventsDDL(parts, encrypt)
+	_, err := db.Exec(ddl)
+	return err
+}
+
+const ddlSchemaSnapshots = `CREATE TABLE IF NOT EXISTS schema_snapshots (
+    id               INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    snapshot_id      INT UNSIGNED NOT NULL,
+    snapshot_time    DATETIME     NOT NULL,
+    schema_name      VARCHAR(64)  NOT NULL,
+    table_name       VARCHAR(64)  NOT NULL,
+    column_name      VARCHAR(64)  NOT NULL,
+    ordinal_position INT UNSIGNED NOT NULL,
+    column_key       VARCHAR(3)   NOT NULL COMMENT 'PRI, UNI, MUL, or empty',
+    data_type        VARCHAR(64)  NOT NULL,
+    column_type      VARCHAR(128) NOT NULL DEFAULT '' COMMENT 'full type from information_schema.COLUMNS.COLUMN_TYPE, e.g. "datetime(6)" or "int unsigned"; needed by full-table reconstruct for DATETIME precision',
+    is_nullable      VARCHAR(3)   NOT NULL,
+    column_default   TEXT         DEFAULT NULL,
+    is_generated     TINYINT(1)   NOT NULL DEFAULT 0 COMMENT '1 if STORED or VIRTUAL generated column',
+    INDEX idx_snapshot_id    (snapshot_id),
+    INDEX idx_snapshot_table (snapshot_id, schema_name, table_name)
+) ENGINE=InnoDB`
+
+const ddlStreamState = `CREATE TABLE IF NOT EXISTS stream_state (
+    id               INT UNSIGNED    PRIMARY KEY DEFAULT 1,
+    mode             ENUM('position','gtid') NOT NULL,
+    binlog_file      VARCHAR(255)    NOT NULL DEFAULT '',
+    binlog_position  BIGINT UNSIGNED NOT NULL DEFAULT 0,
+    gtid_set         TEXT            DEFAULT NULL,
+    events_indexed   BIGINT UNSIGNED NOT NULL DEFAULT 0,
+    last_event_time  DATETIME        DEFAULT NULL,
+    last_checkpoint  DATETIME        NOT NULL,
+    server_id        INT UNSIGNED    NOT NULL,
+    bintrail_id      CHAR(36)        NULL DEFAULT NULL,
+    gap_lost_at      DATETIME        DEFAULT NULL COMMENT 'when an unfillable binlog gap forced an auto-advance (events permanently lost); cleared by an explicit monitor Stop or --reset',
+    gap_lost_detail  TEXT            DEFAULT NULL COMMENT 'human-readable description of the lost gap',
+    CONSTRAINT single_row CHECK (id = 1)
+) ENGINE=InnoDB`
+
+const ddlIndexState = `CREATE TABLE IF NOT EXISTS index_state (
+    binlog_file    VARCHAR(255) PRIMARY KEY,
+    file_size      BIGINT UNSIGNED NOT NULL,
+    last_position  BIGINT UNSIGNED NOT NULL COMMENT 'last parsed position',
+    events_indexed BIGINT UNSIGNED NOT NULL DEFAULT 0,
+    status         ENUM('in_progress','completed','failed') NOT NULL,
+    started_at     DATETIME NOT NULL,
+    completed_at   DATETIME DEFAULT NULL,
+    error_message  TEXT     DEFAULT NULL,
+    bintrail_id    CHAR(36) NULL DEFAULT NULL,
+    INDEX idx_bintrail_id (bintrail_id)
+) ENGINE=InnoDB`
+
+// ─── Archive tracking ─────────────────────────────────────────────────────────
+
+const ddlArchiveState = `CREATE TABLE IF NOT EXISTS archive_state (
+    id              INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    partition_name  VARCHAR(20) NOT NULL,
+    bintrail_id     VARCHAR(36),
+    local_path      VARCHAR(1024),
+    file_size_bytes BIGINT UNSIGNED,
+    row_count       BIGINT UNSIGNED,
+    s3_bucket       VARCHAR(255),
+    s3_key          VARCHAR(1024),
+    s3_uploaded_at  DATETIME,
+    archived_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_partition (partition_name, bintrail_id)
+) ENGINE=InnoDB`
+
+// ─── RBAC tables ─────────────────────────────────────────────────────────────
+
+// ddlTableFlags stores named flags on tables or individual columns.
+// column_name = ” means the flag applies to the whole table; a non-empty
+// value names the specific column that carries the flag.
+// This two-level design lets access_rules express both "deny the billing
+// table" (table-level flag) and "redact the amount column" (column-level flag)
+// using the same flag name with different column_name values.
+const ddlTableFlags = `CREATE TABLE IF NOT EXISTS table_flags (
+    id          INT UNSIGNED  AUTO_INCREMENT PRIMARY KEY,
+    schema_name VARCHAR(64)   NOT NULL,
+    table_name  VARCHAR(64)   NOT NULL,
+    column_name VARCHAR(64)   NOT NULL DEFAULT '' COMMENT 'empty = table-level flag; non-empty = column-level flag',
+    flag        VARCHAR(255)  NOT NULL,
+    created_at  DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY idx_unique (schema_name, table_name, column_name, flag),
+    INDEX idx_flag (flag)
+) ENGINE=InnoDB`
+
+// ddlProfiles stores named access profiles (e.g. "dev", "marketing").
+// Profiles are referenced by access_rules to define what flags each profile
+// may or may not access. Management is typically done from the web panel;
+// the CLI provides the 'bintrail flag' command for DBA use.
+const ddlProfiles = `CREATE TABLE IF NOT EXISTS profiles (
+    id          INT UNSIGNED  AUTO_INCREMENT PRIMARY KEY,
+    name        VARCHAR(255)  NOT NULL,
+    description TEXT          DEFAULT NULL,
+    created_at  DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY idx_name (name)
+) ENGINE=InnoDB`
+
+// ddlAccessRules maps a profile to a flag with an allow/deny permission.
+// Combined with table_flags this enables RBAC:
+//   - profile "dev" DENY flag "billing"  → dev users cannot see billing table events
+//   - profile "marketing" DENY flag "pii" → marketing users see events but pii columns are redacted
+const ddlAccessRules = `CREATE TABLE IF NOT EXISTS access_rules (
+    id          INT UNSIGNED  AUTO_INCREMENT PRIMARY KEY,
+    profile_id  INT UNSIGNED  NOT NULL,
+    flag        VARCHAR(255)  NOT NULL,
+    permission  ENUM('allow','deny') NOT NULL,
+    created_at  DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY idx_profile_flag (profile_id, flag),
+    CONSTRAINT fk_access_rules_profile FOREIGN KEY (profile_id) REFERENCES profiles (id) ON DELETE CASCADE
+) ENGINE=InnoDB`
+
+// ─── FK constraints ───────────────────────────────────────────────────────────
+
+const ddlFKConstraints = `CREATE TABLE IF NOT EXISTS fk_constraints (
+    snapshot_id              INT UNSIGNED NOT NULL,
+    constraint_name          VARCHAR(64)  NOT NULL,
+    schema_name              VARCHAR(64)  NOT NULL,
+    table_name               VARCHAR(64)  NOT NULL,
+    column_name              VARCHAR(64)  NOT NULL,
+    ordinal_position         INT          NOT NULL,
+    referenced_schema_name   VARCHAR(64)  NOT NULL,
+    referenced_table_name    VARCHAR(64)  NOT NULL,
+    referenced_column_name   VARCHAR(64)  NOT NULL,
+    PRIMARY KEY (snapshot_id, schema_name, constraint_name, ordinal_position)
+) ENGINE=InnoDB`
+
+// ─── DDL tracking ─────────────────────────────────────────────────────────────
+
+const ddlSchemaChanges = `CREATE TABLE IF NOT EXISTS schema_changes (
+    id              INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    detected_at     DATETIME NOT NULL,
+    binlog_file     VARCHAR(255) NOT NULL,
+    binlog_pos      BIGINT UNSIGNED NOT NULL,
+    gtid            VARCHAR(255) DEFAULT NULL,
+    schema_name     VARCHAR(64) NOT NULL,
+    table_name      VARCHAR(64) NOT NULL,
+    ddl_type        VARCHAR(50) NOT NULL,
+    ddl_query       TEXT NOT NULL,
+    snapshot_id     INT UNSIGNED DEFAULT NULL COMMENT 'auto-snapshot after DDL; NULL when not taken (file mode or snapshot failure)',
+    INDEX idx_detected_at (detected_at),
+    INDEX idx_schema_table (schema_name, table_name)
+) ENGINE=InnoDB`

--- a/internal/indexer/schema.go
+++ b/internal/indexer/schema.go
@@ -21,7 +21,7 @@ func CreateIndexTables(ctx context.Context, db *sql.DB, partitions int, encrypt 
 	}
 
 	// Create binlog_events with dynamic hourly partitions.
-	if err := CreateBinlogEventsTable(db, partitions, encrypt); err != nil {
+	if err := createBinlogEventsTable(db, partitions, encrypt); err != nil {
 		return fmt.Errorf("failed to create binlog_events: %w", err)
 	}
 	logTable("binlog_events")
@@ -130,7 +130,7 @@ func buildBinlogEventsDDL(parts []string, encrypt bool) string {
 )`
 }
 
-// CreateBinlogEventsTable generates the CREATE TABLE with N hourly partitions
+// createBinlogEventsTable generates the CREATE TABLE with N hourly partitions
 // spanning from the current hour (UTC) forward through the next N-1 hours, plus
 // a p_future catch-all partition for any events arriving beyond that range.
 //
@@ -138,7 +138,7 @@ func buildBinlogEventsDDL(parts []string, encrypt bool) string {
 // is less than TO_SECONDS of the following hour (timezone-independent).
 // When encrypt is true, ENCRYPTION='Y' is added to enable InnoDB tablespace
 // encryption (requires a keyring plugin on the MySQL server).
-func CreateBinlogEventsTable(db *sql.DB, numPartitions int, encrypt bool) error {
+func createBinlogEventsTable(db *sql.DB, numPartitions int, encrypt bool) error {
 	parts := buildPartitionDefs(time.Now(), numPartitions)
 	ddl := buildBinlogEventsDDL(parts, encrypt)
 	_, err := db.Exec(ddl)

--- a/internal/indexer/schema.go
+++ b/internal/indexer/schema.go
@@ -67,7 +67,7 @@ func CreateIndexTables(ctx context.Context, db *sql.DB, partitions int, encrypt 
 	return nil
 }
 
-// buildPartitionDefs returns numPartitions hourly partition clauses ending at
+// buildPartitionDefs returns numPartitions hourly partition clauses starting at
 // the current hour (truncated from now), followed by a p_future catch-all.
 //
 // Partitions span forward from the current hour so that incoming events
@@ -131,8 +131,8 @@ func buildBinlogEventsDDL(parts []string, encrypt bool) string {
 }
 
 // CreateBinlogEventsTable generates the CREATE TABLE with N hourly partitions
-// spanning from (N-1) hours ago to the current hour (UTC), plus a p_future
-// catch-all partition for any events arriving in subsequent hours.
+// spanning from the current hour (UTC) forward through the next N-1 hours, plus
+// a p_future catch-all partition for any events arriving beyond that range.
 //
 // Each partition p_YYYYMMDDHH covers events where TO_SECONDS(event_timestamp)
 // is less than TO_SECONDS of the following hour (timezone-independent).

--- a/internal/indexer/schema_integration_test.go
+++ b/internal/indexer/schema_integration_test.go
@@ -1,0 +1,29 @@
+//go:build integration
+
+package indexer
+
+import (
+	"testing"
+
+	"github.com/dbtrail/bintrail/internal/testutil"
+)
+
+func TestCreateBinlogEventsTable(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+
+	if err := createBinlogEventsTable(db, 3, false); err != nil {
+		t.Fatalf("createBinlogEventsTable failed: %v", err)
+	}
+
+	// Verify the table has 4 partitions (3 hourly + p_future).
+	var count int
+	if err := db.QueryRow(`
+		SELECT COUNT(*) FROM information_schema.PARTITIONS
+		WHERE TABLE_SCHEMA = ? AND TABLE_NAME = 'binlog_events'`,
+		dbName).Scan(&count); err != nil {
+		t.Fatalf("query partitions failed: %v", err)
+	}
+	if count != 4 {
+		t.Errorf("expected 4 partitions, got %d", count)
+	}
+}

--- a/internal/indexer/schema_test.go
+++ b/internal/indexer/schema_test.go
@@ -1,0 +1,211 @@
+package indexer
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// ─── buildBinlogEventsDDL ───────────────────────────────────────────────────
+
+func TestBuildBinlogEventsDDL_noEncrypt(t *testing.T) {
+	parts := []string{"    PARTITION p_2026022814 VALUES LESS THAN (TO_SECONDS('2026-02-28 15:00:00'))",
+		"    PARTITION p_future VALUES LESS THAN MAXVALUE"}
+	ddl := buildBinlogEventsDDL(parts, false)
+
+	if strings.Contains(ddl, "ENCRYPTION") {
+		t.Error("expected no ENCRYPTION clause when encrypt=false")
+	}
+	if !strings.Contains(ddl, "ENGINE=InnoDB") {
+		t.Error("expected ENGINE=InnoDB in DDL")
+	}
+	if !strings.Contains(ddl, "p_future") {
+		t.Error("expected p_future partition in DDL")
+	}
+	if !strings.Contains(ddl, "schema_version") {
+		t.Error("expected schema_version column in DDL")
+	}
+}
+
+func TestBuildBinlogEventsDDL_withEncrypt(t *testing.T) {
+	parts := []string{"    PARTITION p_2026022814 VALUES LESS THAN (TO_SECONDS('2026-02-28 15:00:00'))",
+		"    PARTITION p_future VALUES LESS THAN MAXVALUE"}
+	ddl := buildBinlogEventsDDL(parts, true)
+
+	if !strings.Contains(ddl, "ENCRYPTION='Y'") {
+		t.Error("expected ENCRYPTION='Y' in DDL when encrypt=true")
+	}
+	if !strings.Contains(ddl, "p_future") {
+		t.Error("expected p_future partition in DDL")
+	}
+	if !strings.Contains(ddl, "schema_version") {
+		t.Error("expected schema_version column in DDL")
+	}
+	// Encryption clause must appear after ENGINE=InnoDB and before PARTITION BY.
+	engineIdx := strings.Index(ddl, "ENGINE=InnoDB")
+	encryptIdx := strings.Index(ddl, "ENCRYPTION='Y'")
+	partitionIdx := strings.Index(ddl, "PARTITION BY RANGE")
+	if engineIdx < 0 || encryptIdx < 0 || partitionIdx < 0 {
+		t.Fatal("DDL missing ENGINE=InnoDB, ENCRYPTION='Y', or PARTITION BY RANGE")
+	}
+	if !(engineIdx < encryptIdx && encryptIdx < partitionIdx) {
+		t.Errorf("expected ENGINE < ENCRYPTION < PARTITION BY in DDL, got positions %d, %d, %d",
+			engineIdx, encryptIdx, partitionIdx)
+	}
+}
+
+// ─── buildPartitionDefs ───────────────────────────────────────────────────────────
+
+func TestBuildPartitionDefs_countAndFuture(t *testing.T) {
+	now := time.Date(2026, 2, 28, 14, 30, 0, 0, time.UTC)
+	parts := buildPartitionDefs(now, 48)
+
+	// 48 named hourly partitions + p_future = 49
+	if len(parts) != 49 {
+		t.Fatalf("expected 49 partition defs, got %d", len(parts))
+	}
+	if !strings.Contains(parts[48], "p_future") {
+		t.Errorf("last def should be p_future, got %q", parts[48])
+	}
+}
+
+func TestBuildPartitionDefs_spansFromCurrentHourForward(t *testing.T) {
+	// now truncated to 14:00; with 48 partitions: start = 14:00, end = 14:00 + 47h = 2026-03-02 13:00 UTC
+	now := time.Date(2026, 2, 28, 14, 30, 0, 0, time.UTC)
+	parts := buildPartitionDefs(now, 48)
+
+	// First partition starts at the current hour
+	if !strings.Contains(parts[0], "p_2026022814") {
+		t.Errorf("expected first partition p_2026022814 (current hour), got %q", parts[0])
+	}
+	// Last named partition covers 47 hours from now
+	if !strings.Contains(parts[47], "p_2026030213") {
+		t.Errorf("expected last named partition p_2026030213 (+47h), got %q", parts[47])
+	}
+}
+
+func TestBuildPartitionDefs_boundaryValues(t *testing.T) {
+	now := time.Date(2026, 2, 28, 14, 30, 0, 0, time.UTC)
+	parts := buildPartitionDefs(now, 3)
+
+	// 3 partitions: p_2026022814, p_2026022815, p_2026022816, p_future
+	if !strings.Contains(parts[0], "p_2026022814") {
+		t.Errorf("expected p_2026022814 (current hour), got %q", parts[0])
+	}
+	if !strings.Contains(parts[1], "p_2026022815") {
+		t.Errorf("expected p_2026022815, got %q", parts[1])
+	}
+	if !strings.Contains(parts[2], "p_2026022816") {
+		t.Errorf("expected p_2026022816, got %q", parts[2])
+	}
+	// p_2026022814 boundary: LESS THAN TO_SECONDS('2026-02-28 15:00:00')
+	if !strings.Contains(parts[0], "2026-02-28 15:00:00") {
+		t.Errorf("expected boundary at 2026-02-28 15:00:00, got %q", parts[0])
+	}
+}
+
+func TestBuildPartitionDefs_singlePartition(t *testing.T) {
+	now := time.Date(2026, 2, 28, 10, 0, 0, 0, time.UTC)
+	parts := buildPartitionDefs(now, 1)
+
+	// 1 named + p_future = 2
+	if len(parts) != 2 {
+		t.Fatalf("expected 2 defs, got %d", len(parts))
+	}
+	if !strings.Contains(parts[0], "p_2026022810") {
+		t.Errorf("expected p_2026022810 (current hour), got %q", parts[0])
+	}
+}
+
+// ─── DDL content: bintrail_id columns ─────────────────────────────────────────────
+
+func TestDDLIndexState_hasBintrailID(t *testing.T) {
+	if !strings.Contains(ddlIndexState, "bintrail_id") {
+		t.Error("ddlIndexState must contain bintrail_id column")
+	}
+	if !strings.Contains(ddlIndexState, "idx_bintrail_id") {
+		t.Error("ddlIndexState must contain idx_bintrail_id index")
+	}
+	if !strings.Contains(ddlIndexState, "CHAR(36)") {
+		t.Error("ddlIndexState bintrail_id must be CHAR(36)")
+	}
+	if !strings.Contains(ddlIndexState, "NULL DEFAULT NULL") {
+		t.Error("ddlIndexState bintrail_id must be nullable (NULL DEFAULT NULL)")
+	}
+}
+
+func TestDDLStreamState_hasBintrailID(t *testing.T) {
+	if !strings.Contains(ddlStreamState, "bintrail_id") {
+		t.Error("ddlStreamState must contain bintrail_id column")
+	}
+	if !strings.Contains(ddlStreamState, "CHAR(36)") {
+		t.Error("ddlStreamState bintrail_id must be CHAR(36)")
+	}
+	if !strings.Contains(ddlStreamState, "NULL DEFAULT NULL") {
+		t.Error("ddlStreamState bintrail_id must be nullable (NULL DEFAULT NULL)")
+	}
+}
+
+// ─── DDL content: archive_state ───────────────────────────────────────────────
+
+func TestDDLArchiveState_hasExpectedColumns(t *testing.T) {
+	for _, col := range []string{
+		"partition_name", "bintrail_id", "local_path",
+		"file_size_bytes", "row_count",
+		"s3_bucket", "s3_key", "s3_uploaded_at", "archived_at",
+	} {
+		if !strings.Contains(ddlArchiveState, col) {
+			t.Errorf("ddlArchiveState must contain %s column", col)
+		}
+	}
+}
+
+func TestDDLArchiveState_hasUniqueKey(t *testing.T) {
+	if !strings.Contains(ddlArchiveState, "uq_partition") {
+		t.Error("ddlArchiveState must contain uq_partition unique key")
+	}
+	if !strings.Contains(ddlArchiveState, "partition_name, bintrail_id") {
+		t.Error("uq_partition must be on (partition_name, bintrail_id)")
+	}
+}
+
+func TestDDLConstants_noUTCTimestampDefault(t *testing.T) {
+	ddls := map[string]string{
+		"ddlSchemaSnapshots": ddlSchemaSnapshots,
+		"ddlStreamState":     ddlStreamState,
+		"ddlIndexState":      ddlIndexState,
+		"ddlArchiveState":    ddlArchiveState,
+		"ddlTableFlags":      ddlTableFlags,
+		"ddlProfiles":        ddlProfiles,
+		"ddlAccessRules":     ddlAccessRules,
+		"ddlSchemaChanges":   ddlSchemaChanges,
+	}
+	for name, ddl := range ddls {
+		if strings.Contains(strings.ToUpper(ddl), "DEFAULT UTC_TIMESTAMP") {
+			t.Errorf("%s must not use UTC_TIMESTAMP() as a DEFAULT — MySQL rejects it in DDL; use CURRENT_TIMESTAMP instead", name)
+		}
+	}
+}
+
+// ─── ddlSchemaChanges ───────────────────────────────────────────────────────
+
+func TestDDLSchemaChanges_hasRequiredColumns(t *testing.T) {
+	for _, col := range []string{
+		"id", "detected_at", "binlog_file", "binlog_pos",
+		"gtid", "schema_name", "table_name", "ddl_type",
+		"ddl_query", "snapshot_id",
+	} {
+		if !strings.Contains(ddlSchemaChanges, col) {
+			t.Errorf("ddlSchemaChanges must contain %s column", col)
+		}
+	}
+}
+
+func TestDDLSchemaChanges_hasIndex(t *testing.T) {
+	if !strings.Contains(ddlSchemaChanges, "idx_detected_at") {
+		t.Error("ddlSchemaChanges must contain idx_detected_at index")
+	}
+	if !strings.Contains(ddlSchemaChanges, "idx_schema_table") {
+		t.Error("ddlSchemaChanges must contain idx_schema_table index")
+	}
+}


### PR DESCRIPTION
## What

Slice **B2** of relocating the monitor/supervisor's `package main` deps to `internal/`. Moves the index **schema + provisioning** out of `cmd/bintrail` so the future `cmd/bintrail-console` supervisor can provision a per-source index DB.

Moved `init.go` → `internal/indexer` (new `schema.go` + `provision.go`):

| symbol | disposition |
|---|---|
| 9 DDL consts (`ddlSchemaSnapshots`…`ddlSchemaChanges`) | **private** in indexer (grep-checked: only `createIndexTables` + their unit tests used them) |
| `buildPartitionDefs`, `buildBinlogEventsDDL` | **private** |
| `createBinlogEventsTable` | **export** `CreateBinlogEventsTable` (cmd integration tests call it) |
| `createIndexTables` | **export** `CreateIndexTables` |
| `ensureDatabase` | **export** `EnsureDatabase` |

## ⚠️ Not a pure relocation — one deliberate behavior change

`EnsureDatabase` gains a `log func(string)` param (same `nil`→no-op idiom as `CreateIndexTables`'s `logTable`). The old body always did `fmt.Printf("Database %q ready")`; now the **caller** decides:
- `bintrail init` passes a stdout closure → output preserved verbatim (incl. its pre-existing unconditional print, even in `--format json`).
- The monitor supervisor passes `nil` → the daemon provisions **silently** (intended — no stray stdout from a long-running process).

## Other notes

- The cmd-local `ddlBintrailServers`/`ddlBintrailServerChanges` var aliases are **deleted**; the moved `CreateIndexTables` references `serverid.DDLBintrailServers/Changes` directly (new `indexer→serverid` edge, cycle-free — `serverid` is a leaf).
- `testutil.InitIndexTables` keeps its own forked DDL **by design** (separate package, can't reference the consts; unifying = test-behavior risk + scope creep).
- 13 tests moved `init_test.go` → `internal/indexer/schema_test.go` (buildPartitionDefs/buildBinlogEventsDDL/DDL-content — verbatim, bare names since now in-package). cmd `init_test.go` keeps its cobra/parseS3ARN/s3Instructions/runInit tests.

## Verification

- `go build` / `go vet` clean (unit **and** `-tags integration`).
- Full unit suite green (incl. the 13 moved indexer tests).
- Supervisor integration (`indexer.EnsureDatabase` + `CreateIndexTables` via `monitorSupervisor.Start`) + cmd provisioning integration + the **full E2E pipeline** (real `bintrail init`) all pass against MySQL.

## PR-B' plan

| slice | status |
|---|---|
| A `deriveServerID`→serverid | ✅ merged #436 |
| B1 partition helpers→indexer | ✅ merged #437 |
| **B2 (this)** provisioning+DDL→indexer | this PR |
| C `upRotationCfg` global→param | next |
| D `buildDoctorReport`+capacity+diskfree→new `internal/doctor` | last |

🤖 Generated with [Claude Code](https://claude.com/claude-code)