### PR TITLE
refactor(deps): thread rotation retain into monitorSupervisor instead of the upRotationCfg global (decouple PR-B' slice C)

### DIFF
--- a/cmd/bintrail/monitor.go
+++ b/cmd/bintrail/monitor.go
@@ -47,6 +47,10 @@ type monitorSupervisor struct {
 	// candidate source against them for replica/duplicate detection. May be
 	// nil (tests); the check is skipped then.
 	registry *console.Registry
+	// rotateRetain is the rotation window the daemon's built-in loop uses; the
+	// Doctor capacity projection assumes it (0 = rotation disabled). Set at
+	// construction so the supervisor never reads the cmd-layer upRotationCfg global.
+	rotateRetain time.Duration
 	// streamFn runs one supervised stream; a seam for unit tests, streamrun.One
 	// in production.
 	streamFn func(ctx context.Context, cfg streamrun.Config) error
@@ -180,11 +184,12 @@ func (j *monitorJob) snapshot() console.MonitorStatus {
 
 // newMonitorSupervisor builds the control plane. reg may be nil (tests) —
 // Doctor's replica/duplicate detection is skipped then.
-func newMonitorSupervisor(baseCtx context.Context, bootIndexDSN string, reg *console.Registry) *monitorSupervisor {
+func newMonitorSupervisor(baseCtx context.Context, bootIndexDSN string, reg *console.Registry, retain time.Duration) *monitorSupervisor {
 	return &monitorSupervisor{
 		baseCtx:      baseCtx,
 		bootIndexDSN: bootIndexDSN,
 		registry:     reg,
+		rotateRetain: retain,
 		streamFn:     streamrun.One,
 		jobs:         map[string]*monitorJob{},
 	}
@@ -219,7 +224,7 @@ func (m *monitorSupervisor) Doctor(ctx context.Context, e console.ServerEntry) (
 	}
 	// The per-source databases are rotated by the daemon's built-in loop, so
 	// the capacity projection uses its window (0 when rotation is disabled).
-	r := buildDoctorReport(ctx, e.SourceDSN, e.DSN, e.Schemas, upRotationCfg.retain)
+	r := buildDoctorReport(ctx, e.SourceDSN, e.DSN, e.Schemas, m.rotateRetain)
 	out := &console.DoctorReport{
 		Passed:   r.Passed,
 		Failed:   r.Failed,

--- a/cmd/bintrail/monitor_integration_test.go
+++ b/cmd/bintrail/monitor_integration_test.go
@@ -80,7 +80,7 @@ func TestIntegrationMonitorSupervisor(t *testing.T) {
 	t.Cleanup(func() { _, _ = srcDB.Exec("DROP DATABASE IF EXISTS " + srcSchema) })
 	mustExec("CREATE TABLE " + srcSchema + ".items (id INT PRIMARY KEY, qty INT)")
 
-	sup := newMonitorSupervisor(ctx, bootDSN, nil)
+	sup := newMonitorSupervisor(ctx, bootDSN, nil, 0)
 	entry := console.ServerEntry{
 		ID:        fmt.Sprintf("itest%d", time.Now().UnixNano()%1e9),
 		Name:      "integration",
@@ -140,7 +140,7 @@ func TestIntegrationMonitorSupervisor(t *testing.T) {
 	waitStreamLive(t, srcDB, idxDB, srcSchema, "items", "id")
 
 	// The advisory lock: a second supervisor (second daemon) must refuse.
-	sup2 := newMonitorSupervisor(ctx, bootDSN, nil)
+	sup2 := newMonitorSupervisor(ctx, bootDSN, nil, 0)
 	if err := sup2.Start(ctx, entry); err == nil || !strings.Contains(err.Error(), "already monitoring") {
 		t.Fatalf("second daemon Start: err=%v, want advisory-lock refusal", err)
 	}
@@ -210,7 +210,7 @@ func TestIntegrationDDLThenImmediateInserts(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sup := newMonitorSupervisor(ctx, bootDSN, nil)
+	sup := newMonitorSupervisor(ctx, bootDSN, nil, 0)
 	entry := console.ServerEntry{
 		ID:        fmt.Sprintf("ddlrace%d", time.Now().UnixNano()%1e9),
 		Name:      "ddl-race",
@@ -322,7 +322,7 @@ func TestIntegrationLostPositionDurable(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sup := newMonitorSupervisor(ctx, bootDSN, nil)
+	sup := newMonitorSupervisor(ctx, bootDSN, nil, 0)
 	entry := console.ServerEntry{
 		ID:        fmt.Sprintf("lptest%d", time.Now().UnixNano()%1e9),
 		Name:      "lost-position",
@@ -442,7 +442,7 @@ func TestIntegrationReplicaOverlapSQL(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	sup := newMonitorSupervisor(ctx, bootDSN, reg)
+	sup := newMonitorSupervisor(ctx, bootDSN, reg, 0)
 
 	// Peer B's per-source index DB, provisioned with the real tables and
 	// seeded with an identity + an accumulated GTID set.

--- a/cmd/bintrail/up.go
+++ b/cmd/bintrail/up.go
@@ -262,7 +262,7 @@ func runUpConsoleOnly(cmd *cobra.Command) error {
 	ctx, stop := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	supervisor := newMonitorSupervisor(ctx, upIndexDSN, registry)
+	supervisor := newMonitorSupervisor(ctx, upIndexDSN, registry, upRotationCfg.retain)
 	cfg.MonitorCtrl = supervisor
 
 	// Built-in rotation covers the boot index plus every per-source database
@@ -399,7 +399,7 @@ func runUpStreamWithConsole(cmd *cobra.Command, args []string) error {
 	// The control-plane supervisor: "+ Add server" in the console starts real
 	// monitoring through it. Streams live on the daemon context (ctx), not on
 	// the HTTP requests that start them.
-	supervisor := newMonitorSupervisor(ctx, upIndexDSN, registry)
+	supervisor := newMonitorSupervisor(ctx, upIndexDSN, registry, upRotationCfg.retain)
 	cfg.MonitorCtrl = supervisor
 
 	// Built-in rotation: boot index + every per-source database the control


### PR DESCRIPTION
## What

Slice **C** of decoupling the monitor/supervisor from `cmd`-layer `package main` state — the precursor to the PR-D pivot that moves the supervisor + `bintrail up --console` into `cmd/bintrail-console`.

`monitorSupervisor.Doctor` read the `upRotationCfg` **package global** directly (for the capacity projection's retention window) — a global it can't reach once it lives in a different `package main`.

- Add `rotateRetain time.Duration` field to `monitorSupervisor`, set at construction.
- `newMonitorSupervisor` gains a `retain time.Duration` param.
- `Doctor` uses `m.rotateRetain` instead of `upRotationCfg.retain`.
- The two `up.go` construction sites pass `upRotationCfg.retain` — **the global STAYS in `cmd/bintrail`** (it's a cobra-flag accumulator); it just no longer escapes into the supervisor. Monitor integration tests pass `0`.

## No behavior change

The daemon's Doctor capacity projection still uses the same retain window; it's **injected** rather than read from a global. The supervisor now reads **zero** cmd-layer globals.

## Verification

- `go build` / `go vet` clean (unit **and** `-tags integration`).
- Full unit suite green.
- monitor/supervisor integration (Doctor via `m.rotateRetain`) + up_rotation integration (still uses the cmd global) pass against MySQL.

## PR-B' plan

| slice | status |
|---|---|
| A `deriveServerID`→serverid | ✅ merged #436 |
| B1 partition helpers→indexer | ✅ merged #437 |
| B2 provisioning+DDL→indexer | ✅ merged #438 |
| **C (this)** `upRotationCfg`→param | this PR |
| D `buildDoctorReport`+capacity+diskfree→new `internal/doctor` | last (largest) |

After D, the supervisor's callees all live in `internal/` and it reads no cmd globals → the PR-D pivot (move supervisor + `up --console` to `cmd/bintrail-console`) is unblocked. Landmine for D already found: `hasReplPrivileges` (in `agent_validate.go`) is shared by the doctor subgraph and `agent --validate` → needs a neutral home, not `internal/doctor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)