### PR TITLE
feat(console): add standalone bintrail-console binary (decouple PR-C)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ deploy/.env
 /bintrail
 /bintrail-mcp
 /mcp-gateway
+/bintrail-console
 /dist/
 
 # Test coverage

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 BINARY_NAME=bintrail
 MCP_BINARY=bintrail-mcp
 GATEWAY_BINARY=mcp-gateway
+CONSOLE_BINARY=bintrail-console
 VERSION=$(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 COMMIT=$(shell git rev-parse --short HEAD 2>/dev/null || echo "none")
 BUILD_DATE=$(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
@@ -8,10 +9,12 @@ BUILD_DATE=$(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
 BINTRAIL_LDFLAGS=-ldflags "-X main.Version=$(VERSION) -X main.CommitSHA=$(COMMIT) -X main.BuildDate=$(BUILD_DATE)"
 MCP_LDFLAGS=-ldflags "-X main.mcpVersion=$(VERSION)"
 GATEWAY_LDFLAGS=-ldflags "-X main.gatewayVersion=$(VERSION)"
+# bintrail-console reuses BINTRAIL_LDFLAGS: it injects the same
+# main.Version/CommitSHA/BuildDate vars as the core binary.
 
-.PHONY: all build build-mcp build-gateway clean test lint install build-all tidy deps
+.PHONY: all build build-mcp build-gateway build-console clean test lint install build-all tidy deps
 
-all: build build-mcp build-gateway
+all: build build-mcp build-gateway build-console
 
 build:
 	go build $(BINTRAIL_LDFLAGS) -o $(BINARY_NAME) ./cmd/bintrail
@@ -22,13 +25,19 @@ build-mcp:
 build-gateway:
 	go build $(GATEWAY_LDFLAGS) -o $(GATEWAY_BINARY) ./cmd/mcp-gateway
 
+# bintrail-console links DuckDB (console → query → parquetquery), so it
+# requires CGO_ENABLED=1 like the core bintrail binary.
+build-console:
+	go build $(BINTRAIL_LDFLAGS) -o $(CONSOLE_BINARY) ./cmd/bintrail-console
+
 install:
 	go install $(BINTRAIL_LDFLAGS) ./cmd/bintrail
 	go install $(MCP_LDFLAGS) ./cmd/bintrail-mcp
 	go install $(GATEWAY_LDFLAGS) ./cmd/mcp-gateway
+	go install $(BINTRAIL_LDFLAGS) ./cmd/bintrail-console
 
 clean:
-	rm -f $(BINARY_NAME) $(MCP_BINARY) $(GATEWAY_BINARY)
+	rm -f $(BINARY_NAME) $(MCP_BINARY) $(GATEWAY_BINARY) $(CONSOLE_BINARY)
 	go clean
 
 test:
@@ -49,6 +58,10 @@ build-all:
 	GOOS=linux   GOARCH=arm64 CGO_ENABLED=1 CC=aarch64-linux-gnu-gcc go build $(MCP_LDFLAGS) -o dist/$(MCP_BINARY)-linux-arm64 ./cmd/bintrail-mcp
 	GOOS=darwin  GOARCH=amd64 CGO_ENABLED=1 go build $(MCP_LDFLAGS) -o dist/$(MCP_BINARY)-darwin-amd64 ./cmd/bintrail-mcp
 	GOOS=darwin  GOARCH=arm64 CGO_ENABLED=1 go build $(MCP_LDFLAGS) -o dist/$(MCP_BINARY)-darwin-arm64 ./cmd/bintrail-mcp
+	GOOS=linux   GOARCH=amd64 CGO_ENABLED=1 go build $(BINTRAIL_LDFLAGS) -o dist/$(CONSOLE_BINARY)-linux-amd64 ./cmd/bintrail-console
+	GOOS=linux   GOARCH=arm64 CGO_ENABLED=1 CC=aarch64-linux-gnu-gcc go build $(BINTRAIL_LDFLAGS) -o dist/$(CONSOLE_BINARY)-linux-arm64 ./cmd/bintrail-console
+	GOOS=darwin  GOARCH=amd64 CGO_ENABLED=1 go build $(BINTRAIL_LDFLAGS) -o dist/$(CONSOLE_BINARY)-darwin-amd64 ./cmd/bintrail-console
+	GOOS=darwin  GOARCH=arm64 CGO_ENABLED=1 go build $(BINTRAIL_LDFLAGS) -o dist/$(CONSOLE_BINARY)-darwin-arm64 ./cmd/bintrail-console
 	GOOS=linux   GOARCH=amd64 CGO_ENABLED=0 go build $(GATEWAY_LDFLAGS) -o dist/$(GATEWAY_BINARY)-linux-amd64 ./cmd/mcp-gateway
 	GOOS=linux   GOARCH=arm64 CGO_ENABLED=0 go build $(GATEWAY_LDFLAGS) -o dist/$(GATEWAY_BINARY)-linux-arm64 ./cmd/mcp-gateway
 	GOOS=darwin  GOARCH=amd64 CGO_ENABLED=0 go build $(GATEWAY_LDFLAGS) -o dist/$(GATEWAY_BINARY)-darwin-amd64 ./cmd/mcp-gateway

--- a/cmd/bintrail-console/env.go
+++ b/cmd/bintrail-console/env.go
@@ -19,13 +19,13 @@ var envOnce sync.Once
 //  1. .bintrail.env in the current directory
 //  2. ~/.config/bintrail/config.env
 //
-// This is a verbatim copy of the core bintrail loader (cmd/bintrail/envload.go).
-// PR-C keeps the core binary unchanged, so the file→env reader is replicated
-// here rather than extracted to internal/; deduping belongs to a later PR where
-// core is already being restructured. bintrail-console reads only a handful of
-// BINTRAIL_INDEX_DSN / BINTRAIL_CONSOLE_* vars (see serve.go), so it does NOT
-// need the core's full bindCommandEnv/envBindings machinery — only the file
-// loader, which the console-specific vars are read out of in runServe.
+// loadEnvFile/parseAndSetEnv mirror the core bintrail loader in
+// cmd/bintrail/envload.go. The console decouple keeps the core binary
+// unchanged, so the file→env reader is replicated here rather than shared via
+// internal/ (deduping waits until the console is fully split out). The console
+// reads only BINTRAIL_INDEX_DSN / BINTRAIL_CONSOLE_* (see serve.go), so it needs
+// just the file loader — not the core's full bindCommandEnv/envBindings
+// machinery, out of which the console-specific vars are read in runServe.
 func loadEnvFile() {
 	paths := []string{".bintrail.env"}
 	if home, err := os.UserHomeDir(); err == nil {

--- a/cmd/bintrail-console/env.go
+++ b/cmd/bintrail-console/env.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// envOnce guards loadEnvFile so the env file is read at most once per process.
+var envOnce sync.Once
+
+// loadEnvFile reads the first found env file and loads its key=value pairs
+// into the process environment without overwriting already-set variables.
+// Locations tried in order:
+//  1. .bintrail.env in the current directory
+//  2. ~/.config/bintrail/config.env
+//
+// This is a verbatim copy of the core bintrail loader (cmd/bintrail/envload.go).
+// PR-C keeps the core binary unchanged, so the file→env reader is replicated
+// here rather than extracted to internal/; deduping belongs to a later PR where
+// core is already being restructured. bintrail-console reads only a handful of
+// BINTRAIL_INDEX_DSN / BINTRAIL_CONSOLE_* vars (see serve.go), so it does NOT
+// need the core's full bindCommandEnv/envBindings machinery — only the file
+// loader, which the console-specific vars are read out of in runServe.
+func loadEnvFile() {
+	paths := []string{".bintrail.env"}
+	if home, err := os.UserHomeDir(); err == nil {
+		paths = append(paths, filepath.Join(home, ".config", "bintrail", "config.env"))
+	}
+	for _, p := range paths {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				fmt.Fprintf(os.Stderr, "warning: found %s but could not read it: %v\n", p, err)
+			}
+			continue
+		}
+		parseAndSetEnv(string(data))
+		return // use first found
+	}
+}
+
+// parseAndSetEnv parses key=value lines from data and sets them as
+// environment variables. Blank lines and lines whose first non-whitespace
+// character is # are skipped. Lines without an = sign produce a warning.
+// Values may be surrounded by single or double quotes (stripped).
+// Variables already set in the environment are not overwritten.
+func parseAndSetEnv(data string) {
+	scanner := bufio.NewScanner(strings.NewReader(data))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || line[0] == '#' {
+			continue
+		}
+		key, val, ok := strings.Cut(line, "=")
+		if !ok {
+			fmt.Fprintf(os.Stderr, "warning: skipping malformed line in env file (no '='): %s\n", line)
+			continue
+		}
+		key = strings.TrimSpace(key)
+		val = strings.TrimSpace(val)
+
+		// Strip surrounding quotes.
+		if len(val) >= 2 {
+			if (val[0] == '"' && val[len(val)-1] == '"') ||
+				(val[0] == '\'' && val[len(val)-1] == '\'') {
+				val = val[1 : len(val)-1]
+			}
+		}
+
+		// Don't overwrite already-set env vars.
+		if _, exists := os.LookupEnv(key); !exists {
+			os.Setenv(key, val)
+		}
+	}
+}

--- a/cmd/bintrail-console/main.go
+++ b/cmd/bintrail-console/main.go
@@ -1,0 +1,69 @@
+// Command bintrail-console serves the read-only Bintrail web console as a
+// standalone binary, decoupled from the core `bintrail` CLI.
+//
+// It is the MCP server with a web face: browse indexed MySQL row events with
+// full before/after diffs, generate recovery (undo) SQL, and — when baselines
+// are configured — run point-in-time reconstruct, all from a browser. The
+// console NEVER executes SQL; recover produces a script you review and apply.
+//
+//	bintrail-console serve --index-dsn "user:pass@tcp(127.0.0.1:3306)/binlog_index"
+//
+// Configuration mirrors `bintrail console`: a .bintrail.env (or
+// ~/.config/bintrail/config.env) file is loaded on startup and the
+// BINTRAIL_INDEX_DSN / BINTRAIL_CONSOLE_* env vars are honored with
+// flag > env > default precedence.
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dbtrail/bintrail/internal/observe"
+)
+
+// Build-time variables injected via -ldflags. The names are deliberately the
+// same as the bintrail binary's (main.Version/CommitSHA/BuildDate) so the
+// Makefile's BINTRAIL_LDFLAGS applies to this binary verbatim.
+var (
+	Version   = "dev"
+	CommitSHA = "none"
+	BuildDate = "unknown"
+)
+
+var (
+	logLevel  string
+	logFormat string
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "bintrail-console",
+	Short: "Read-only web console over the Bintrail binlog index",
+	Long: `bintrail-console serves a local, read-only web UI over the binlog index:
+browse indexed row events with full before/after diffs, generate recovery
+(undo) SQL, and run point-in-time reconstruct when baselines are configured.
+
+It is the standalone form of "bintrail console", shipped as its own binary so
+the core bintrail CLI carries no web UI. The console NEVER executes SQL;
+recover produces a script you review and apply yourself.`,
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		observe.Setup(os.Stderr, logFormat, logLevel)
+		return nil
+	},
+	SilenceErrors: true, // we handle error output ourselves in main()
+	SilenceUsage:  true, // don't print usage/help on errors — users can use --help
+}
+
+func init() {
+	rootCmd.Version = fmt.Sprintf("%s (commit %s, built %s)", Version, CommitSHA, BuildDate)
+	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "Log level: debug, info, warn, error")
+	rootCmd.PersistentFlags().StringVar(&logFormat, "log-format", "text", "Log format: text or json")
+}
+
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/cmd/bintrail-console/serve.go
+++ b/cmd/bintrail-console/serve.go
@@ -185,9 +185,9 @@ func runServe(cmd *cobra.Command, args []string) error {
 		BaselineDir:   conBaselineDir,
 		BaselineS3:    conBaselineS3,
 		// MonitorCtrl is intentionally left nil: bintrail-console serve is the
-		// read-only standalone console. The write-capable control-plane daemon
-		// (today `bintrail up --console`) wires a supervisor; that path moves
-		// into this binary as a separate command in PR-D.
+		// read-only standalone console. A write-capable control-plane daemon
+		// wires a supervisor here instead; with nil, /api/capabilities reports
+		// monitor:false and every monitor verb refuses at the endpoint with 403.
 	})
 	if err != nil {
 		return err

--- a/cmd/bintrail-console/serve.go
+++ b/cmd/bintrail-console/serve.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/spf13/cobra"
+
+	"github.com/dbtrail/bintrail/internal/config"
+	"github.com/dbtrail/bintrail/internal/console"
+	"github.com/dbtrail/bintrail/internal/indexer"
+	"github.com/dbtrail/bintrail/internal/query"
+)
+
+var serveCmd = &cobra.Command{
+	Use:   "serve",
+	Short: "Serve a read-only web UI over the index (browse events, generate undo SQL)",
+	Long: `Starts a local, read-only, single-operator web console over the binlog index.
+
+It is the MCP server with a web face: browse indexed row events with full
+before/after diffs, and generate recovery (undo) SQL — all from a browser. The
+console NEVER executes SQL; recover produces a script you review and apply
+yourself.
+
+Security:
+  - Binds to loopback (127.0.0.1) by default and requires an access token.
+  - A token is auto-generated for loopback binds and printed in the URL.
+  - Binding to a non-loopback address REQUIRES an explicit --token.
+
+Example:
+  bintrail-console serve --index-dsn "user:pass@tcp(127.0.0.1:3306)/binlog_index"`,
+	RunE: runServe,
+}
+
+var (
+	conIndexDSN     string
+	conListen       string
+	conToken        string
+	conNoArchive    bool
+	conProfile      string
+	conAllowedHosts []string
+	conBaselineDir  string
+	conBaselineS3   string
+	conServersFile  string
+)
+
+func init() {
+	serveCmd.Flags().StringVar(&conIndexDSN, "index-dsn", "", "DSN for the index MySQL database (required unless the server registry has entries)")
+	serveCmd.Flags().StringVar(&conListen, "listen", "127.0.0.1:8090", "Address to listen on (host:port)")
+	serveCmd.Flags().StringVar(&conToken, "token", "", "Access token (auto-generated for loopback binds when empty)")
+	serveCmd.Flags().BoolVar(&conNoArchive, "no-archive", false, "Disable Parquet archive auto-discovery (MySQL-only)")
+	serveCmd.Flags().StringVar(&conProfile, "profile", "", "RBAC profile: deny tables / redact columns; forces --no-archive")
+	serveCmd.Flags().StringSliceVar(&conAllowedHosts, "allowed-hosts", nil, "Extra hostnames allowed in the Host header (for reverse-proxy setups; IP literals and localhost are always allowed)")
+	serveCmd.Flags().StringVar(&conBaselineDir, "baseline-dir", "", "Local directory of baseline Parquet snapshots; enables the point-in-time Reconstruct surface")
+	serveCmd.Flags().StringVar(&conBaselineS3, "baseline-s3", "", "S3 prefix of baseline Parquet snapshots (s3://bucket/prefix/); enables Reconstruct")
+	serveCmd.Flags().StringVar(&conServersFile, "servers-file", "", "Path to the server registry YAML managed by the UI (default ~/.config/bintrail/console-servers.yaml)")
+	rootCmd.AddCommand(serveCmd)
+}
+
+func runServe(cmd *cobra.Command, args []string) error {
+	// Load .bintrail.env / config.env once, mirroring the core CLI. The core
+	// bintrail binary does this in each command's init() via bindCommandEnv;
+	// this standalone binary loads it here, then reads the relevant vars below
+	// with flag > env > default precedence.
+	envOnce.Do(loadEnvFile)
+
+	// index-dsn falls back to BINTRAIL_INDEX_DSN, the one shared binding the
+	// console uses (core bintrail wires this via bindCommandEnv/envBindings).
+	if !cmd.Flags().Changed("index-dsn") {
+		if v := os.Getenv("BINTRAIL_INDEX_DSN"); v != "" {
+			conIndexDSN = v
+		}
+	}
+	// Console-specific env vars, with flag > env > default precedence.
+	if !cmd.Flags().Changed("listen") {
+		if v := os.Getenv("BINTRAIL_CONSOLE_LISTEN"); v != "" {
+			conListen = v
+		}
+	}
+	if !cmd.Flags().Changed("token") {
+		if v := os.Getenv("BINTRAIL_CONSOLE_TOKEN"); v != "" {
+			conToken = v
+		}
+	}
+	if !cmd.Flags().Changed("baseline-dir") {
+		if v := os.Getenv("BINTRAIL_CONSOLE_BASELINE_DIR"); v != "" {
+			conBaselineDir = v
+		}
+	}
+	if !cmd.Flags().Changed("baseline-s3") {
+		if v := os.Getenv("BINTRAIL_CONSOLE_BASELINE_S3"); v != "" {
+			conBaselineS3 = v
+		}
+	}
+	if !cmd.Flags().Changed("servers-file") {
+		if v := os.Getenv("BINTRAIL_CONSOLE_SERVERS"); v != "" {
+			conServersFile = v
+		}
+	}
+
+	// The server registry: the named connections managed from the UI. A
+	// corrupt file fails loud — silently starting without the operator's
+	// saved servers would look like data loss.
+	serversPath := conServersFile
+	if serversPath == "" {
+		serversPath = console.DefaultRegistryPath()
+	}
+	registry, err := console.LoadRegistry(serversPath)
+	if err != nil {
+		return err
+	}
+
+	// Either a command-line DSN or at least one saved server must exist.
+	if conIndexDSN == "" && registry.Len() == 0 {
+		return fmt.Errorf("either --index-dsn (or BINTRAIL_INDEX_DSN) or at least one server in %s is required", serversPath)
+	}
+	// Profile rules are loaded from the command-line index; without one there
+	// is no DB to read them from.
+	if conProfile != "" && conIndexDSN == "" {
+		return fmt.Errorf("--profile requires --index-dsn: the profile's rules are loaded from that index database")
+	}
+	// The baseline flags describe the command-line entry; without a DSN there
+	// is no boot index to merge deltas from (baseline + deltas → state), and
+	// seeding a DB-less boot entry would crash its first query. Registry
+	// servers carry their own per-server baseline settings instead.
+	if (conBaselineDir != "" || conBaselineS3 != "") && conIndexDSN == "" {
+		return fmt.Errorf("--baseline-dir/--baseline-s3 require --index-dsn: reconstruct merges the baseline with binlog deltas from that index (registry servers configure their baseline per entry in the UI)")
+	}
+
+	// The command-line DSN becomes the ephemeral "default" entry: connected
+	// eagerly (fail-fast preserved) and schema-migrated here, at startup, on
+	// the one DSN the operator typed in their shell. Servers added in the UI
+	// are NEVER migrated — request handlers stay free of DDL, so the recover
+	// path remains provably read-only.
+	var db *sql.DB
+	var dbName string
+	if conIndexDSN != "" {
+		cfg, err := mysql.ParseDSN(conIndexDSN)
+		if err != nil {
+			return fmt.Errorf("invalid --index-dsn: %w", err)
+		}
+		dbName = cfg.DBName
+		if dbName == "" {
+			return fmt.Errorf("--index-dsn must include a database name (e.g. user:pass@tcp(host:3306)/binlog_index)")
+		}
+
+		db, err = config.Connect(conIndexDSN)
+		if err != nil {
+			return fmt.Errorf("failed to connect to index database: %w", err)
+		}
+		defer db.Close()
+
+		if err := indexer.EnsureSchema(db); err != nil {
+			return fmt.Errorf("schema migration: %w", err)
+		}
+	}
+
+	// Resolve profile RBAC rules up front. Archives don't enforce RBAC, so a
+	// profile forces --no-archive to avoid leaking redacted columns.
+	var denyTables []query.SchemaTable
+	var redactCols []query.SchemaTableColumn
+	if conProfile != "" {
+		denyTables, redactCols, err = query.LoadProfileRules(cmd.Context(), db, conProfile)
+		if err != nil {
+			return fmt.Errorf("load profile %q: %w", conProfile, err)
+		}
+	}
+
+	srv, err := console.New(console.Config{
+		DB:            db,
+		DBName:        dbName,
+		BootDSN:       conIndexDSN,
+		Registry:      registry,
+		Listen:        conListen,
+		Token:         conToken,
+		NoArchive:     conNoArchive || conProfile != "",
+		DenyTables:    denyTables,
+		RedactColumns: redactCols,
+		AllowedHosts:  conAllowedHosts,
+		BaselineDir:   conBaselineDir,
+		BaselineS3:    conBaselineS3,
+		// MonitorCtrl is intentionally left nil: bintrail-console serve is the
+		// read-only standalone console. The write-capable control-plane daemon
+		// (today `bintrail up --console`) wires a supervisor; that path moves
+		// into this binary as a separate command in PR-D.
+	})
+	if err != nil {
+		return err
+	}
+
+	ctx, stop := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	fmt.Fprintf(os.Stderr, "\nBintrail console (read-only) is running. Open:\n\n    %s\n\n", srv.URL())
+	slog.Info("console listening", "addr", conListen, "no_archive", conNoArchive || conProfile != "")
+
+	if err := srv.Run(ctx); err != nil {
+		return fmt.Errorf("console server: %w", err)
+	}
+	return nil
+}

--- a/cmd/bintrail-console/serve_test.go
+++ b/cmd/bintrail-console/serve_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRunServeStartupGuards covers the three pre-connect guards in runServe —
+// they all return before config.Connect, so they are unit-testable without a
+// database. A regression in the --profile/--baseline guards would crash later
+// against a nil DB (LoadProfileRules / a DB-less boot bundle). This mirrors
+// TestRunConsoleStartupGuards on the core `bintrail console` command: the two
+// commands must stay behaviorally identical during the transition.
+func TestRunServeStartupGuards(t *testing.T) {
+	reset := func() {
+		conIndexDSN, conProfile, conBaselineDir, conBaselineS3, conServersFile = "", "", "", "", ""
+	}
+
+	emptyReg := filepath.Join(t.TempDir(), "servers.yaml") // never created
+	popReg := filepath.Join(t.TempDir(), "servers.yaml")
+	if err := os.WriteFile(popReg,
+		[]byte("version: 1\nservers:\n  - id: abcd\n    name: x\n    index_dsn: u:p@tcp(h:3306)/db\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name    string
+		setup   func()
+		wantSub string
+	}{
+		{
+			"no dsn and empty registry",
+			func() { conServersFile = emptyReg },
+			"either --index-dsn",
+		},
+		{
+			"profile requires index-dsn",
+			func() { conServersFile = popReg; conProfile = "dev" },
+			"--profile requires --index-dsn",
+		},
+		{
+			"baseline requires index-dsn",
+			func() { conServersFile = popReg; conBaselineDir = "/tmp/b" },
+			"require --index-dsn",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reset()
+			t.Cleanup(reset)
+			// Neutralize ambient env: runServe falls back to these when the flag
+			// was not Changed (we set the package globals directly). Unlike the
+			// core console — which binds BINTRAIL_INDEX_DSN once at init() —
+			// runServe reads it per-call, so it must be neutralized too or a dev
+			// shell with BINTRAIL_INDEX_DSN set would defeat the empty-DSN guard.
+			t.Setenv("BINTRAIL_INDEX_DSN", "")
+			t.Setenv("BINTRAIL_CONSOLE_SERVERS", "")
+			tc.setup()
+			err := runServe(serveCmd, nil)
+			if err == nil || !strings.Contains(err.Error(), tc.wantSub) {
+				t.Fatalf("err = %v, want error containing %q", err, tc.wantSub)
+			}
+		})
+	}
+}
+
+// TestRunServeCorruptRegistryFailsLoud: a corrupt registry file aborts startup
+// — silently starting without the operator's saved servers would look like
+// data loss.
+func TestRunServeCorruptRegistryFailsLoud(t *testing.T) {
+	conIndexDSN, conProfile, conBaselineDir, conBaselineS3 = "", "", "", ""
+	corrupt := filepath.Join(t.TempDir(), "servers.yaml")
+	if err := os.WriteFile(corrupt, []byte("{{{ not yaml"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	conServersFile = corrupt
+	t.Cleanup(func() { conServersFile = "" })
+	t.Setenv("BINTRAIL_INDEX_DSN", "")
+	t.Setenv("BINTRAIL_CONSOLE_SERVERS", "")
+
+	err := runServe(serveCmd, nil)
+	if err == nil || !strings.Contains(err.Error(), "parse server registry") {
+		t.Fatalf("err = %v, want a loud registry-parse failure", err)
+	}
+}

--- a/cmd/bintrail-console/serve_test.go
+++ b/cmd/bintrail-console/serve_test.go
@@ -85,3 +85,26 @@ func TestRunServeCorruptRegistryFailsLoud(t *testing.T) {
 		t.Fatalf("err = %v, want a loud registry-parse failure", err)
 	}
 }
+
+// TestRunServeIndexDSNFromEnv asserts the POSITIVE env-fallback path — the one
+// behavior unique to runServe with no parity baseline in runConsole (the core
+// binds BINTRAIL_INDEX_DSN once at init() via bindCommandEnv; runServe reads it
+// per-call). A decouple regression here — wrong var name, inverted Changed
+// check, a dropped block — would pass every mirrored guard test silently, so it
+// needs its own assertion. We give a DSN with NO database name: when the env is
+// consumed, conIndexDSN becomes non-empty, the empty-registry guard is bypassed,
+// and the db-name check fires ("must include a database name"); if the env were
+// ignored, conIndexDSN stays "" and the "either --index-dsn" guard fires
+// instead — so the error substring discriminates the two outcomes without a DB.
+func TestRunServeIndexDSNFromEnv(t *testing.T) {
+	conIndexDSN, conProfile, conBaselineDir, conBaselineS3 = "", "", "", ""
+	conServersFile = filepath.Join(t.TempDir(), "servers.yaml") // empty registry
+	t.Cleanup(func() { conIndexDSN, conServersFile = "", "" })
+	t.Setenv("BINTRAIL_CONSOLE_SERVERS", "")
+	t.Setenv("BINTRAIL_INDEX_DSN", "u:p@tcp(h:3306)/") // present, no db name
+
+	err := runServe(serveCmd, nil)
+	if err == nil || !strings.Contains(err.Error(), "must include a database name") {
+		t.Fatalf("err = %v, want the env DSN consumed (db-name guard)", err)
+	}
+}


### PR DESCRIPTION
## What

PR-C of the console decouple ([project memory], blueprint phase 3): a new
`cmd/bintrail-console` binary that serves today's standalone read-only web
console as **`bintrail-console serve`**, separate from the core `bintrail` CLI.

**Additive — the core binary is unchanged.** Both `bintrail console` and
`bintrail-console serve` work during the transition. The supervisor +
`up --console` daemon path moves into this binary, and the core
`console.go`/`monitor.go` are deleted, in PR-D.

## Files

- **`main.go`** — root cobra command with its own `Version/CommitSHA/BuildDate`
  ldflags (same `main.*` var names as `bintrail`, so `BINTRAIL_LDFLAGS` applies
  verbatim — no separate ldflags var needed).
- **`serve.go`** — `runServe` replicates `runConsole` exactly: identical flags,
  the same `flag > env > default` precedence for `BINTRAIL_INDEX_DSN` and the
  five `BINTRAIL_CONSOLE_*` vars, the same three startup guards (with identical
  error text/order), nil-safe registry-only mode, and a field-for-field
  identical `console.Config` — `MonitorCtrl` left **nil** (read-only standalone;
  the write-capable supervisor is PR-D).
- **`env.go`** — verbatim copy of the `.bintrail.env` / `config.env` loader.
  PR-C keeps core untouched, so the loader is replicated rather than extracted
  to `internal/` (the dedup belongs to PR-D, where core is already being
  restructured — same call the project made for testutil's forked DDL). The
  console needs only the file loader, not `bindCommandEnv`'s full `envBindings`
  machinery (its only shared binding is `index-dsn`).
- **`serve_test.go`** — mirrors `TestRunConsoleStartupGuards` over the new
  binary so the two commands cannot drift on the validation guards before PR-D.
- **`Makefile`** — `build-console` (reuses `BINTRAIL_LDFLAGS`), wired into
  `all`/`install`/`clean`/`build-all` (`CGO_ENABLED=1` — console links DuckDB)
  + `.PHONY`.
- **`.gitignore`** — ignore the `/bintrail-console` build artifact, like its
  siblings.

## Verification

- `go build ./...`, `go vet ./...`, **full unit suite**, and the new package
  tests all green. `make build-console` + `--version` + `serve --help` work.
- **"Core unchanged" contract holds**: `git diff` touches only
  `Makefile`/`.gitignore` and adds `cmd/bintrail-console/`. Nothing under
  `cmd/bintrail/` or `internal/` is modified — the manual stand-in for the
  `uifree_test.go` guard PR-D will add.
- An **adversarial 2-agent parity review** of `runServe` vs `runConsole`
  (field-by-field + adversarial lens) returned `parity_holds` with **zero real
  drift** across all 10 checklist items.

## Not in this PR (per blueprint)

PR-D (atomic pivot: move supervisor + `up --console`, delete core
`console.go`/`monitor.go`, `uifree_test.go` guard, goreleaser 3rd CGO build,
move console integration tests) and PR-E (`Dockerfile.bintrail-console` + GHCR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)