### PR TITLE
refactor(deps): relocate 4 shared leaf helpers to internal/ (PR-D1, console decouple prep)

### DIFF
--- a/cmd/bintrail/agent.go
+++ b/cmd/bintrail/agent.go
@@ -288,7 +288,7 @@ func runAgent(cmd *cobra.Command, args []string) error {
 	var flushState *flushPipelineState
 
 	if byosMode {
-		retain, err := parseRetain(agtBufferRetain)
+		retain, err := cliutil.ParseRetain(agtBufferRetain)
 		if err != nil {
 			return fmt.Errorf("invalid --buffer-retain: %w", err)
 		}

--- a/cmd/bintrail/archive.go
+++ b/cmd/bintrail/archive.go
@@ -19,6 +19,7 @@ import (
 	"github.com/dbtrail/bintrail/internal/archive"
 	"github.com/dbtrail/bintrail/internal/cliutil"
 	"github.com/dbtrail/bintrail/internal/config"
+	"github.com/dbtrail/bintrail/internal/storage"
 )
 
 // archiveCmd is the parent for archive-maintenance subcommands (the
@@ -234,11 +235,11 @@ func localParquetRowCount(path string, size int64) (int64, error) {
 // LastModified come free with the listing; row counts cost one metadata
 // read per object and are only fetched under --deep.
 func scanS3Archive(ctx context.Context, s3URL, region string, deep bool) ([]archive.ScannedFile, error) {
-	bucket, prefix, err := parseS3URL(s3URL)
+	bucket, prefix, err := storage.ParseS3URL(s3URL)
 	if err != nil {
 		return nil, err
 	}
-	client, err := newS3Client(ctx, region)
+	client, err := storage.NewS3Client(ctx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/bintrail/baseline.go
+++ b/cmd/bintrail/baseline.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io/fs"
 	"log/slog"
@@ -12,15 +11,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
-	awsconfig "github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/aws/aws-sdk-go-v2/service/s3/types"
-	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/spf13/cobra"
 
 	"github.com/dbtrail/bintrail/internal/baseline"
 	"github.com/dbtrail/bintrail/internal/cliutil"
+	"github.com/dbtrail/bintrail/internal/storage"
 )
 
 var baselineCmd = &cobra.Command{
@@ -169,63 +164,18 @@ func runBaseline(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// parseS3URL parses an S3 URL of the form s3://bucket or s3://bucket/prefix
-// and returns the bucket name and prefix (without leading slash).
-func parseS3URL(u string) (bucket, prefix string, err error) {
-	if !strings.HasPrefix(u, "s3://") {
-		return "", "", fmt.Errorf("must start with s3://, got %q", u)
-	}
-	rest := strings.TrimPrefix(u, "s3://")
-	bucket, prefix, _ = strings.Cut(rest, "/")
-	if bucket == "" {
-		return "", "", fmt.Errorf("bucket name is empty in %q", u)
-	}
-	return bucket, prefix, nil
-}
-
-// newS3Client creates an S3 client using the default AWS credential chain.
-// region is optional — if empty, the SDK resolves it from AWS_REGION env var
-// or ~/.aws/config.
-func newS3Client(ctx context.Context, region string) (*s3.Client, error) {
-	opts := []func(*awsconfig.LoadOptions) error{}
-	if region != "" {
-		opts = append(opts, awsconfig.WithRegion(region))
-	}
-	awsCfg, err := awsconfig.LoadDefaultConfig(ctx, opts...)
-	if err != nil {
-		return nil, fmt.Errorf("load AWS config: %w", err)
-	}
-	return s3.NewFromConfig(awsCfg), nil
-}
-
-// buildS3Key constructs the S3 object key for a file by computing its path
-// relative to baseDir and prepending prefix (if non-empty). This is the
-// shared key-building logic used by both uploadBaselineToS3 and the rotate
-// archive loop.
-func buildS3Key(baseDir, filePath, prefix string) (string, error) {
-	rel, err := filepath.Rel(baseDir, filePath)
-	if err != nil {
-		return "", err
-	}
-	key := filepath.ToSlash(rel)
-	if prefix != "" {
-		key = strings.TrimSuffix(prefix, "/") + "/" + key
-	}
-	return key, nil
-}
-
 // uploadBaselineToS3 walks outputDir and uploads every file to the S3 URL,
 // preserving the relative directory structure under the prefix. region is
 // optional — if empty, the AWS SDK resolves it from AWS_REGION env var or
 // ~/.aws/config. When retry is true, files that already exist in S3 are
 // skipped (checked via HeadObject). Returns the number of files uploaded.
 func uploadBaselineToS3(ctx context.Context, outputDir, s3URL, region string, retry bool) (int, error) {
-	bucket, prefix, err := parseS3URL(s3URL)
+	bucket, prefix, err := storage.ParseS3URL(s3URL)
 	if err != nil {
 		return 0, fmt.Errorf("invalid --upload URL: %w", err)
 	}
 
-	client, err := newS3Client(ctx, region)
+	client, err := storage.NewS3Client(ctx, region)
 	if err != nil {
 		return 0, err
 	}
@@ -235,12 +185,12 @@ func uploadBaselineToS3(ctx context.Context, outputDir, s3URL, region string, re
 		if walkErr != nil || d.IsDir() {
 			return walkErr
 		}
-		key, err := buildS3Key(outputDir, path, prefix)
+		key, err := storage.BuildS3Key(outputDir, path, prefix)
 		if err != nil {
 			return err
 		}
 		if retry {
-			exists, err := s3ObjectExists(ctx, client, bucket, key)
+			exists, err := storage.S3ObjectExists(ctx, client, bucket, key)
 			if err != nil {
 				return err
 			}
@@ -249,7 +199,7 @@ func uploadBaselineToS3(ctx context.Context, outputDir, s3URL, region string, re
 				return nil
 			}
 		}
-		if err := uploadFile(ctx, client, path, bucket, key); err != nil {
+		if err := storage.UploadFile(ctx, client, path, bucket, key); err != nil {
 			return err
 		}
 		slog.Debug("uploaded", "file", path, "bucket", bucket, "key", key)
@@ -257,53 +207,6 @@ func uploadBaselineToS3(ctx context.Context, outputDir, s3URL, region string, re
 		return nil
 	})
 	return count, err
-}
-
-// s3ObjectExists checks whether an object already exists in S3 by issuing a
-// HeadObject request. Returns true when the object is found, false on 404,
-// and an error for any other failure.
-func s3ObjectExists(ctx context.Context, client *s3.Client, bucket, key string) (bool, error) {
-	_, err := client.HeadObject(ctx, &s3.HeadObjectInput{
-		Bucket: aws.String(bucket),
-		Key:    aws.String(key),
-	})
-	if err != nil {
-		// The SDK wraps NotFound as a modeled error type.
-		var nf *types.NotFound
-		if errors.As(err, &nf) {
-			return false, nil
-		}
-		// HeadObject also surfaces 404 as a generic HTTP 404 response error
-		// when the bucket itself has no matching key (some S3-compatible
-		// backends use this path).
-		var re *smithyhttp.ResponseError
-		if errors.As(err, &re) && re.Response.StatusCode == 404 {
-			return false, nil
-		}
-		return false, fmt.Errorf("head s3://%s/%s: %w", bucket, key, err)
-	}
-	return true, nil
-}
-
-// uploadFile opens a single local file and uploads it to S3. It is a separate
-// function so that defer f.Close() runs when uploadFile returns — not when the
-// WalkDir callback returns — preventing file descriptor accumulation over
-// large directory trees.
-func uploadFile(ctx context.Context, client *s3.Client, path, bucket, key string) error {
-	f, err := os.Open(path)
-	if err != nil {
-		return fmt.Errorf("open %s: %w", path, err)
-	}
-	defer f.Close()
-
-	if _, err := client.PutObject(ctx, &s3.PutObjectInput{
-		Bucket: aws.String(bucket),
-		Key:    aws.String(key),
-		Body:   f,
-	}); err != nil {
-		return fmt.Errorf("upload %s → s3://%s/%s: %w", path, bucket, key, err)
-	}
-	return nil
 }
 
 // decryptDumpFiles walks inputDir and decrypts every .enc file using openssl,

--- a/cmd/bintrail/baseline_test.go
+++ b/cmd/bintrail/baseline_test.go
@@ -154,37 +154,6 @@ func TestRunBaselineTimestampParsing(t *testing.T) {
 	}
 }
 
-func TestParseS3URL(t *testing.T) {
-	cases := []struct {
-		input      string
-		wantBucket string
-		wantPrefix string
-		wantErr    bool
-	}{
-		{"s3://my-bucket", "my-bucket", "", false},
-		{"s3://my-bucket/", "my-bucket", "", false},
-		{"s3://my-bucket/baselines/", "my-bucket", "baselines/", false},
-		{"s3://my-bucket/prefix/sub", "my-bucket", "prefix/sub", false},
-		{"http://my-bucket/prefix", "", "", true},
-		{"s3://", "", "", true},
-	}
-	for _, tc := range cases {
-		bucket, prefix, err := parseS3URL(tc.input)
-		if (err != nil) != tc.wantErr {
-			t.Errorf("parseS3URL(%q) error = %v, wantErr %v", tc.input, err, tc.wantErr)
-			continue
-		}
-		if !tc.wantErr {
-			if bucket != tc.wantBucket {
-				t.Errorf("parseS3URL(%q) bucket = %q, want %q", tc.input, bucket, tc.wantBucket)
-			}
-			if prefix != tc.wantPrefix {
-				t.Errorf("parseS3URL(%q) prefix = %q, want %q", tc.input, prefix, tc.wantPrefix)
-			}
-		}
-	}
-}
-
 // TestParseTableFilter_onlyCommasAndSpaces verifies that a string containing
 // only commas and whitespace (no actual table names) returns nil — the same
 // result as an empty string, but via a different code path (SplitSeq iterates
@@ -217,32 +186,6 @@ func TestParseTableFilter_trailingComma(t *testing.T) {
 	got := parseTableFilter("db.orders,")
 	if len(got) != 1 || got[0] != "db.orders" {
 		t.Errorf("expected [db.orders], got %v", got)
-	}
-}
-
-// TestParseS3URL_emptyBucketWithPath verifies that s3:///path (three slashes,
-// empty bucket name) is rejected — strings.Cut on "/" gives bucket="" which
-// hits the "bucket name is empty" guard.
-func TestParseS3URL_emptyBucketWithPath(t *testing.T) {
-	_, _, err := parseS3URL("s3:///some/path")
-	if err == nil {
-		t.Fatal("expected error for s3:///some/path (empty bucket), got nil")
-	}
-	if !strings.Contains(err.Error(), "bucket") {
-		t.Errorf("expected 'bucket' in error, got: %v", err)
-	}
-}
-
-// TestParseS3URL_prefixRetainsTrailingSlash verifies that a prefix that ends
-// with "/" is returned as-is (the function does not strip it — callers like
-// uploadBaselineToS3 handle normalisation with TrimSuffix).
-func TestParseS3URL_prefixRetainsTrailingSlash(t *testing.T) {
-	_, prefix, err := parseS3URL("s3://my-bucket/baselines/2026/")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if prefix != "baselines/2026/" {
-		t.Errorf("expected prefix %q, got %q", "baselines/2026/", prefix)
 	}
 }
 

--- a/cmd/bintrail/doctor.go
+++ b/cmd/bintrail/doctor.go
@@ -72,7 +72,7 @@ func parseDocRetain(s string) (time.Duration, error) {
 	case "off", "0", "":
 		return 0, nil
 	}
-	retain, err := parseRetain(s)
+	retain, err := cliutil.ParseRetain(s)
 	if err != nil {
 		return 0, fmt.Errorf("--retain: %w (or \"off\" if you don't rotate)", err)
 	}

--- a/cmd/bintrail/monitor.go
+++ b/cmd/bintrail/monitor.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"log/slog"
 	"regexp"
-	"strings"
 	"sync"
 	"time"
 
@@ -18,6 +17,7 @@ import (
 	"github.com/dbtrail/bintrail/internal/doctor"
 	"github.com/dbtrail/bintrail/internal/indexer"
 	"github.com/dbtrail/bintrail/internal/serverid"
+	"github.com/dbtrail/bintrail/internal/streamdeps"
 	"github.com/dbtrail/bintrail/internal/streamrun"
 )
 
@@ -209,7 +209,7 @@ func (m *monitorSupervisor) DeriveIndexDSN(entryID string) (string, error) {
 	}
 	cfg, err := mysql.ParseDSN(m.bootIndexDSN)
 	if err != nil {
-		return "", fmt.Errorf("daemon index DSN: %s", scrubMonitorErr(err, m.bootIndexDSN))
+		return "", fmt.Errorf("daemon index DSN: %s", config.ScrubDSNError(err, m.bootIndexDSN))
 	}
 	cfg.DBName = "bintrail_idx_" + entryID
 	return cfg.FormatDSN(), nil
@@ -237,7 +237,7 @@ func (m *monitorSupervisor) Doctor(ctx context.Context, e console.ServerEntry) (
 		out.Checks[i] = console.DoctorCheck{
 			Name:        c.Name,
 			Status:      string(c.Status),
-			Detail:      scrubMonitorErrText(c.Detail, e.SourceDSN, e.DSN),
+			Detail:      config.ScrubDSNText(c.Detail, e.SourceDSN, e.DSN),
 			Remediation: c.Remediation,
 		}
 	}
@@ -247,7 +247,7 @@ func (m *monitorSupervisor) Doctor(ctx context.Context, e console.ServerEntry) (
 	// block. Supervisor-only: the standalone `bintrail doctor` has no
 	// registry to compare against.
 	if c := m.replicaOverlapCheck(ctx, e); c != nil {
-		c.Detail = scrubMonitorErrText(c.Detail, e.SourceDSN, e.DSN)
+		c.Detail = config.ScrubDSNText(c.Detail, e.SourceDSN, e.DSN)
 		out.Checks = append(out.Checks, *c)
 		switch c.Status {
 		case "warn":
@@ -297,7 +297,7 @@ func (m *monitorSupervisor) Start(ctx context.Context, e console.ServerEntry) er
 	m.mu.Unlock()
 
 	fail := func(err error) error {
-		scrubbed := scrubMonitorErr(err, e.SourceDSN, e.DSN)
+		scrubbed := config.ScrubDSNError(err, e.SourceDSN, e.DSN)
 		job.set("failed", scrubbed)
 		cancel()
 		close(job.done)
@@ -342,7 +342,7 @@ func (m *monitorSupervisor) Start(ctx context.Context, e console.ServerEntry) er
 		job.markLostPosition(gapDetail.String)
 	case err != nil && !errors.Is(err, sql.ErrNoRows):
 		slog.Warn("could not re-hydrate gap-loss record; a recorded data loss may not be re-surfaced this run",
-			"entry", e.ID, "error", scrubMonitorErr(err, e.SourceDSN, e.DSN))
+			"entry", e.ID, "error", config.ScrubDSNError(err, e.SourceDSN, e.DSN))
 	}
 	idxDB.Close()
 
@@ -395,7 +395,7 @@ func (m *monitorSupervisor) Start(ctx context.Context, e console.ServerEntry) er
 		Format:        "text",
 		GapTimeout:    30,
 		Hooks:         job.streamHooks(),
-		Deps:          streamDeps(),
+		Deps:          streamdeps.Default(),
 	}
 
 	m.wg.Add(1)
@@ -438,7 +438,7 @@ func (m *monitorSupervisor) run(ctx context.Context, job *monitorJob, e console.
 		if crashLoopSince.IsZero() {
 			crashLoopSince = started
 		}
-		scrubbed := scrubMonitorErr(err, e.SourceDSN, e.DSN)
+		scrubbed := config.ScrubDSNError(err, e.SourceDSN, e.DSN)
 		if looping := time.Since(crashLoopSince); looping > monitorGiveUpAfter {
 			slog.Error("monitored stream crash-looped past the give-up threshold; not retrying",
 				"server", e.Name, "entry", e.ID, "looping_for", looping.Round(time.Minute), "error", scrubbed)
@@ -483,11 +483,11 @@ func (m *monitorSupervisor) Stop(ctx context.Context, entryID string) error {
 	// which fails safe: a real past loss is re-surfaced, never dropped.
 	if job.indexDSN != "" {
 		if db, err := config.Connect(job.indexDSN); err != nil {
-			slog.Warn("could not clear gap-loss record on stop", "entry", entryID, "error", scrubMonitorErrText(err.Error(), job.indexDSN))
+			slog.Warn("could not clear gap-loss record on stop", "entry", entryID, "error", config.ScrubDSNText(err.Error(), job.indexDSN))
 		} else {
 			if _, err := db.ExecContext(ctx, `UPDATE stream_state
 				SET gap_lost_at = NULL, gap_lost_detail = NULL WHERE id = 1`); err != nil {
-				slog.Warn("could not clear gap-loss record on stop", "entry", entryID, "error", scrubMonitorErrText(err.Error(), job.indexDSN))
+				slog.Warn("could not clear gap-loss record on stop", "entry", entryID, "error", config.ScrubDSNText(err.Error(), job.indexDSN))
 			}
 			db.Close()
 		}
@@ -559,24 +559,4 @@ func (m *monitorSupervisor) Shutdown() {
 	}
 	m.mu.Unlock()
 	m.wg.Wait()
-}
-
-// scrubMonitorErr strips every DSN (and its password) from an error before it
-// is stored on a job or returned to the console — monitor errors travel to
-// the browser.
-func scrubMonitorErr(err error, dsns ...string) string {
-	return scrubMonitorErrText(err.Error(), dsns...)
-}
-
-func scrubMonitorErrText(msg string, dsns ...string) string {
-	for _, dsn := range dsns {
-		if dsn == "" {
-			continue
-		}
-		msg = strings.ReplaceAll(msg, dsn, "<dsn>")
-		if cfg, err := mysql.ParseDSN(dsn); err == nil && cfg.Passwd != "" {
-			msg = strings.ReplaceAll(msg, cfg.Passwd, "***")
-		}
-	}
-	return msg
 }

--- a/cmd/bintrail/rotate.go
+++ b/cmd/bintrail/rotate.go
@@ -22,6 +22,7 @@ import (
 	"github.com/dbtrail/bintrail/internal/cliutil"
 	"github.com/dbtrail/bintrail/internal/config"
 	"github.com/dbtrail/bintrail/internal/indexer"
+	"github.com/dbtrail/bintrail/internal/storage"
 )
 
 var rotateCmd = &cobra.Command{
@@ -126,7 +127,7 @@ func runRotate(cmd *cobra.Command, args []string) error {
 	var retainDur time.Duration
 	if rotRetain != "" {
 		var err error
-		retainDur, err = parseRetain(rotRetain)
+		retainDur, err = cliutil.ParseRetain(rotRetain)
 		if err != nil {
 			return fmt.Errorf("--retain: %w", err)
 		}
@@ -251,11 +252,11 @@ func performRotation(ctx context.Context, db *sql.DB, dbName string, retainDur t
 				var s3Client *s3.Client
 				var s3Bucket, s3Prefix string
 				if rotArchiveS3 != "" {
-					s3Bucket, s3Prefix, err = parseS3URL(rotArchiveS3)
+					s3Bucket, s3Prefix, err = storage.ParseS3URL(rotArchiveS3)
 					if err != nil {
 						return rotationResult{}, fmt.Errorf("invalid --archive-s3: %w", err)
 					}
-					s3Client, err = newS3Client(ctx, rotArchiveS3Region)
+					s3Client, err = storage.NewS3Client(ctx, rotArchiveS3Region)
 					if err != nil {
 						return rotationResult{}, fmt.Errorf("init S3 client: %w", err)
 					}
@@ -290,7 +291,7 @@ func performRotation(ctx context.Context, db *sql.DB, dbName string, retainDur t
 					// in archive_state before the actual upload.
 					var s3Key string
 					if s3Client != nil {
-						s3Key, err = buildS3Key(rotArchiveDir, outPath, s3Prefix)
+						s3Key, err = storage.BuildS3Key(rotArchiveDir, outPath, s3Prefix)
 						if err != nil {
 							return rotationResult{}, fmt.Errorf("build S3 key for %s: %w", name, err)
 						}
@@ -517,7 +518,7 @@ func performRotation(ctx context.Context, db *sql.DB, dbName string, retainDur t
 
 // uploadFileFunc is the function used to upload a file to S3. It defaults to
 // uploadFile and can be overridden in tests to simulate S3 failures.
-var uploadFileFunc = uploadFile
+var uploadFileFunc = storage.UploadFile
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -596,28 +597,6 @@ func hiveArchivePath(archiveDir, bintrailID, partitionName string) (string, erro
 		fmt.Sprintf("event_hour=%02d", d.UTC().Hour()),
 		"events.parquet",
 	), nil
-}
-
-// parseRetain parses a retain string like "7d" or "24h" into a time.Duration.
-// Supported units: 'd' (days), 'h' (hours). The number must be a positive integer.
-func parseRetain(s string) (time.Duration, error) {
-	if len(s) < 2 {
-		return 0, fmt.Errorf("invalid format %q; expected Nd (days) or Nh (hours), e.g. 7d", s)
-	}
-	unit := s[len(s)-1]
-	numStr := s[:len(s)-1]
-	var n int
-	if _, err := fmt.Sscanf(numStr, "%d", &n); err != nil || n <= 0 {
-		return 0, fmt.Errorf("invalid format %q; expected Nd (days) or Nh (hours), e.g. 7d", s)
-	}
-	switch unit {
-	case 'd':
-		return time.Duration(n) * 24 * time.Hour, nil
-	case 'h':
-		return time.Duration(n) * time.Hour, nil
-	default:
-		return 0, fmt.Errorf("invalid unit %q in %q; use 'd' for days or 'h' for hours", unit, s)
-	}
 }
 
 // partitionInfo holds metadata for a single table partition.

--- a/cmd/bintrail/rotate_test.go
+++ b/cmd/bintrail/rotate_test.go
@@ -9,55 +9,6 @@ import (
 	"github.com/dbtrail/bintrail/internal/indexer"
 )
 
-// ─── parseRetain ───────────────────────────────────────────────────────────────
-
-func TestParseRetain_days(t *testing.T) {
-	d, err := parseRetain("7d")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if d != 7*24*time.Hour {
-		t.Errorf("expected 168h, got %v", d)
-	}
-}
-
-func TestParseRetain_hours(t *testing.T) {
-	d, err := parseRetain("24h")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if d != 24*time.Hour {
-		t.Errorf("expected 24h, got %v", d)
-	}
-}
-
-func TestParseRetain_largeDays(t *testing.T) {
-	d, err := parseRetain("365d")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if d != 365*24*time.Hour {
-		t.Errorf("expected 365*24h, got %v", d)
-	}
-}
-
-func TestParseRetain_invalid(t *testing.T) {
-	cases := []string{
-		"",    // too short
-		"d",   // no number
-		"7x",  // unknown unit
-		"7",   // no unit
-		"-1d", // negative
-		"0d",  // zero
-		"0h",  // zero hours
-	}
-	for _, c := range cases {
-		if _, err := parseRetain(c); err == nil {
-			t.Errorf("expected error for %q, got nil", c)
-		}
-	}
-}
-
 // ─── nextPartitionStart ─────────────────────────────────────────────────────────────
 
 func TestNextPartitionStart_withNamedPartitions(t *testing.T) {
@@ -470,28 +421,6 @@ func TestRunRotate_missingDBName(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "--index-dsn must include a database name") {
 		t.Errorf("unexpected error: %v", err)
-	}
-}
-
-// ─── parseRetain boundary values ─────────────────────────────────────────────────
-
-func TestParseRetain_minimumHour(t *testing.T) {
-	d, err := parseRetain("1h")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if d != time.Hour {
-		t.Errorf("expected 1h, got %v", d)
-	}
-}
-
-func TestParseRetain_minimumDay(t *testing.T) {
-	d, err := parseRetain("1d")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if d != 24*time.Hour {
-		t.Errorf("expected 24h, got %v", d)
 	}
 }
 

--- a/cmd/bintrail/stream.go
+++ b/cmd/bintrail/stream.go
@@ -9,11 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/dbtrail/bintrail/internal/byos"
-	"github.com/dbtrail/bintrail/internal/cliutil"
-	"github.com/dbtrail/bintrail/internal/config"
-	"github.com/dbtrail/bintrail/internal/indexer"
-	"github.com/dbtrail/bintrail/internal/metadata"
+	"github.com/dbtrail/bintrail/internal/streamdeps"
 	"github.com/dbtrail/bintrail/internal/streamrun"
 )
 
@@ -103,24 +99,6 @@ func init() {
 	rootCmd.AddCommand(streamCmd)
 }
 
-// streamDeps wires the package-main helper functions into a streamrun.Deps —
-// the host side of streamrun's dependency seam. Shared by streamConfigFromFlags
-// and the control-plane supervisor so both build identical engine deps.
-func streamDeps() streamrun.Deps {
-	return streamrun.Deps{
-		ValidateBinlogFormat:   metadata.ValidateBinlogFormat,
-		ValidateBinlogRowImage: metadata.ValidateBinlogRowImage,
-		ValidateNoFKCascades:   metadata.ValidateNoFKCascades,
-		ParseSchemaList:        cliutil.ParseSchemaList,
-		ResolveServerIdentity:  byos.ResolveServerIdentity,
-		EnsureResolver:         metadata.EnsureResolver,
-		BuildIndexFilters:      cliutil.BuildIndexFilters,
-		InsertSchemaChange:     indexer.InsertSchemaChange,
-		ParseSourceDSN:         config.ParseSourceDSN,
-		OutputJSON:             cliutil.OutputJSON,
-	}
-}
-
 // streamConfigFromFlags snapshots the strm* package globals into a
 // streamrun.Config. The globals remain the cobra flag targets (and up.go's
 // populateStreamFlags fan-out target); this is the single seam where they
@@ -146,7 +124,7 @@ func streamConfigFromFlags() streamrun.Config {
 		Reset:       strmReset,
 		NoGapFill:   strmNoGapFill,
 		GapTimeout:  strmGapTimeout,
-		Deps:        streamDeps(),
+		Deps:        streamdeps.Default(),
 	}
 }
 

--- a/cmd/bintrail/stream_test.go
+++ b/cmd/bintrail/stream_test.go
@@ -194,9 +194,9 @@ func TestStreamConfigFromFlags(t *testing.T) {
 	got := streamConfigFromFlags()
 	// The Deps seam must be wired (else streamrun.One nil-panics at runtime, and
 	// only the Docker-gated monitor integration test would catch a dropped
-	// streamDeps() call). Spot-check two fields here so a unit run flags it.
+	// streamdeps.Default() call). Spot-check two fields here so a unit run flags it.
 	if got.Deps.BuildIndexFilters == nil || got.Deps.OutputJSON == nil {
-		t.Error("streamConfigFromFlags did not wire Deps (streamDeps())")
+		t.Error("streamConfigFromFlags did not wire Deps (streamdeps.Default())")
 	}
 	// Deps holds func values (not comparable / not == ); this test checks the
 	// strm* → field snapshot, so zero it before the struct comparison.

--- a/cmd/bintrail/up_rotation.go
+++ b/cmd/bintrail/up_rotation.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-sql-driver/mysql"
 
+	"github.com/dbtrail/bintrail/internal/cliutil"
 	"github.com/dbtrail/bintrail/internal/config"
 	"github.com/dbtrail/bintrail/internal/indexer"
 )
@@ -47,7 +48,7 @@ func parseUpRotation(retain, interval string, addFuture int, explicit bool) (upR
 	case "off", "0", "":
 		return upRotationSettings{}, nil
 	}
-	dur, err := parseRetain(retain)
+	dur, err := cliutil.ParseRetain(retain)
 	if err != nil {
 		return upRotationSettings{}, fmt.Errorf("--rotate-retain: %w (or \"off\" to disable)", err)
 	}
@@ -198,7 +199,7 @@ func rotateOneIndex(ctx context.Context, dsn string, s upRotationSettings) (int,
 	cfg, err := mysql.ParseDSN(dsn)
 	if err != nil {
 		slog.Warn("built-in rotation: skipping unparseable index DSN",
-			"error", scrubMonitorErrText(err.Error(), dsn))
+			"error", config.ScrubDSNText(err.Error(), dsn))
 		return 0, fmt.Errorf("parse index DSN: %w", err)
 	}
 	if cfg.DBName == "" {
@@ -208,7 +209,7 @@ func rotateOneIndex(ctx context.Context, dsn string, s upRotationSettings) (int,
 	db, err := config.Connect(dsn)
 	if err != nil {
 		slog.Warn("built-in rotation: cannot connect to index database",
-			"db", cfg.DBName, "error", scrubMonitorErrText(err.Error(), dsn))
+			"db", cfg.DBName, "error", config.ScrubDSNText(err.Error(), dsn))
 		return 0, err
 	}
 	defer db.Close()
@@ -225,7 +226,7 @@ func rotateOneIndex(ctx context.Context, dsn string, s upRotationSettings) (int,
 		guarded, oldest, err := upgradeGuardTrips(ctx, db, cfg.DBName, s.retain)
 		if err != nil {
 			slog.Warn("built-in rotation: could not evaluate the upgrade guard; skipping drops this cycle",
-				"db", cfg.DBName, "error", scrubMonitorErrText(err.Error(), dsn))
+				"db", cfg.DBName, "error", config.ScrubDSNText(err.Error(), dsn))
 			return 0, err
 		}
 		if guarded {
@@ -241,7 +242,7 @@ func rotateOneIndex(ctx context.Context, dsn string, s upRotationSettings) (int,
 	res, err := performRotation(ctx, db, cfg.DBName, retain)
 	if err != nil && ctx.Err() == nil {
 		slog.Warn("built-in rotation cycle failed",
-			"db", cfg.DBName, "error", scrubMonitorErrText(err.Error(), dsn))
+			"db", cfg.DBName, "error", config.ScrubDSNText(err.Error(), dsn))
 		return res.deferred, err
 	}
 	return res.deferred, nil

--- a/cmd/bintrail/upload.go
+++ b/cmd/bintrail/upload.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dbtrail/bintrail/internal/cliutil"
 	"github.com/dbtrail/bintrail/internal/config"
 	"github.com/dbtrail/bintrail/internal/indexer"
+	"github.com/dbtrail/bintrail/internal/storage"
 )
 
 var uploadCmd = &cobra.Command{
@@ -116,7 +117,7 @@ func runUpload(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid --format %q; must be text or json", uplFormat)
 	}
 
-	bucket, prefix, err := parseS3URL(uplDestination)
+	bucket, prefix, err := storage.ParseS3URL(uplDestination)
 	if err != nil {
 		return fmt.Errorf("invalid --destination: %w", err)
 	}
@@ -132,7 +133,7 @@ func runUpload(cmd *cobra.Command, args []string) error {
 
 	ctx := cmd.Context()
 
-	client, err := newS3Client(ctx, uplRegion)
+	client, err := storage.NewS3Client(ctx, uplRegion)
 	if err != nil {
 		return err
 	}
@@ -156,13 +157,13 @@ func runUpload(cmd *cobra.Command, args []string) error {
 			return nil
 		}
 
-		key, err := buildS3Key(uplSource, path, prefix)
+		key, err := storage.BuildS3Key(uplSource, path, prefix)
 		if err != nil {
 			return err
 		}
 
 		if uplRetry {
-			exists, err := s3ObjectExists(ctx, client, bucket, key)
+			exists, err := storage.S3ObjectExists(ctx, client, bucket, key)
 			if err != nil {
 				return err
 			}
@@ -173,7 +174,7 @@ func runUpload(cmd *cobra.Command, args []string) error {
 			}
 		}
 
-		if err := uploadFile(ctx, client, path, bucket, key); err != nil {
+		if err := storage.UploadFile(ctx, client, path, bucket, key); err != nil {
 			return err
 		}
 		slog.Debug("uploaded", "file", path, "bucket", bucket, "key", key)

--- a/internal/cliutil/retain.go
+++ b/internal/cliutil/retain.go
@@ -1,0 +1,28 @@
+package cliutil
+
+import (
+	"fmt"
+	"time"
+)
+
+// ParseRetain parses a retain string like "7d" or "24h" into a time.Duration.
+// Supported units: 'd' (days), 'h' (hours). The number must be a positive integer.
+func ParseRetain(s string) (time.Duration, error) {
+	if len(s) < 2 {
+		return 0, fmt.Errorf("invalid format %q; expected Nd (days) or Nh (hours), e.g. 7d", s)
+	}
+	unit := s[len(s)-1]
+	numStr := s[:len(s)-1]
+	var n int
+	if _, err := fmt.Sscanf(numStr, "%d", &n); err != nil || n <= 0 {
+		return 0, fmt.Errorf("invalid format %q; expected Nd (days) or Nh (hours), e.g. 7d", s)
+	}
+	switch unit {
+	case 'd':
+		return time.Duration(n) * 24 * time.Hour, nil
+	case 'h':
+		return time.Duration(n) * time.Hour, nil
+	default:
+		return 0, fmt.Errorf("invalid unit %q in %q; use 'd' for days or 'h' for hours", unit, s)
+	}
+}

--- a/internal/cliutil/retain_test.go
+++ b/internal/cliutil/retain_test.go
@@ -1,0 +1,73 @@
+package cliutil
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseRetain_days(t *testing.T) {
+	d, err := ParseRetain("7d")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if d != 7*24*time.Hour {
+		t.Errorf("expected 168h, got %v", d)
+	}
+}
+
+func TestParseRetain_hours(t *testing.T) {
+	d, err := ParseRetain("24h")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if d != 24*time.Hour {
+		t.Errorf("expected 24h, got %v", d)
+	}
+}
+
+func TestParseRetain_largeDays(t *testing.T) {
+	d, err := ParseRetain("365d")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if d != 365*24*time.Hour {
+		t.Errorf("expected 365*24h, got %v", d)
+	}
+}
+
+func TestParseRetain_invalid(t *testing.T) {
+	cases := []string{
+		"",    // too short
+		"d",   // no number
+		"7x",  // unknown unit
+		"7",   // no unit
+		"-1d", // negative
+		"0d",  // zero
+		"0h",  // zero hours
+	}
+	for _, c := range cases {
+		if _, err := ParseRetain(c); err == nil {
+			t.Errorf("expected error for %q, got nil", c)
+		}
+	}
+}
+
+func TestParseRetain_minimumHour(t *testing.T) {
+	d, err := ParseRetain("1h")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if d != time.Hour {
+		t.Errorf("expected 1h, got %v", d)
+	}
+}
+
+func TestParseRetain_minimumDay(t *testing.T) {
+	d, err := ParseRetain("1d")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if d != 24*time.Hour {
+		t.Errorf("expected 24h, got %v", d)
+	}
+}

--- a/internal/config/scrub.go
+++ b/internal/config/scrub.go
@@ -1,0 +1,29 @@
+package config
+
+import (
+	"strings"
+
+	"github.com/go-sql-driver/mysql"
+)
+
+// ScrubDSNError strips every DSN (and its password) from an error before the
+// message travels somewhere a DSN must not appear — a stored job state, the
+// console browser, a daemon log line. A convenience wrapper over ScrubDSNText.
+func ScrubDSNError(err error, dsns ...string) string {
+	return ScrubDSNText(err.Error(), dsns...)
+}
+
+// ScrubDSNText replaces every occurrence of each DSN with "<dsn>" and each
+// DSN's password with "***" in msg. Empty DSNs are ignored.
+func ScrubDSNText(msg string, dsns ...string) string {
+	for _, dsn := range dsns {
+		if dsn == "" {
+			continue
+		}
+		msg = strings.ReplaceAll(msg, dsn, "<dsn>")
+		if cfg, err := mysql.ParseDSN(dsn); err == nil && cfg.Passwd != "" {
+			msg = strings.ReplaceAll(msg, cfg.Passwd, "***")
+		}
+	}
+	return msg
+}

--- a/internal/storage/s3url.go
+++ b/internal/storage/s3url.go
@@ -1,0 +1,108 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+)
+
+// ParseS3URL parses an S3 URL of the form s3://bucket or s3://bucket/prefix
+// and returns the bucket name and prefix (without leading slash).
+func ParseS3URL(u string) (bucket, prefix string, err error) {
+	if !strings.HasPrefix(u, "s3://") {
+		return "", "", fmt.Errorf("must start with s3://, got %q", u)
+	}
+	rest := strings.TrimPrefix(u, "s3://")
+	bucket, prefix, _ = strings.Cut(rest, "/")
+	if bucket == "" {
+		return "", "", fmt.Errorf("bucket name is empty in %q", u)
+	}
+	return bucket, prefix, nil
+}
+
+// NewS3Client creates an S3 client using the default AWS credential chain.
+// region is optional — if empty, the SDK resolves it from AWS_REGION env var
+// or ~/.aws/config.
+func NewS3Client(ctx context.Context, region string) (*s3.Client, error) {
+	opts := []func(*awsconfig.LoadOptions) error{}
+	if region != "" {
+		opts = append(opts, awsconfig.WithRegion(region))
+	}
+	awsCfg, err := awsconfig.LoadDefaultConfig(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("load AWS config: %w", err)
+	}
+	return s3.NewFromConfig(awsCfg), nil
+}
+
+// BuildS3Key constructs the S3 object key for a file by computing its path
+// relative to baseDir and prepending prefix (if non-empty). This is the
+// shared key-building logic used by both the baseline upload and the rotate
+// archive loop.
+func BuildS3Key(baseDir, filePath, prefix string) (string, error) {
+	rel, err := filepath.Rel(baseDir, filePath)
+	if err != nil {
+		return "", err
+	}
+	key := filepath.ToSlash(rel)
+	if prefix != "" {
+		key = strings.TrimSuffix(prefix, "/") + "/" + key
+	}
+	return key, nil
+}
+
+// S3ObjectExists checks whether an object already exists in S3 by issuing a
+// HeadObject request. Returns true when the object is found, false on 404,
+// and an error for any other failure.
+func S3ObjectExists(ctx context.Context, client *s3.Client, bucket, key string) (bool, error) {
+	_, err := client.HeadObject(ctx, &s3.HeadObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		// The SDK wraps NotFound as a modeled error type.
+		var nf *types.NotFound
+		if errors.As(err, &nf) {
+			return false, nil
+		}
+		// HeadObject also surfaces 404 as a generic HTTP 404 response error
+		// when the bucket itself has no matching key (some S3-compatible
+		// backends use this path).
+		var re *smithyhttp.ResponseError
+		if errors.As(err, &re) && re.Response.StatusCode == 404 {
+			return false, nil
+		}
+		return false, fmt.Errorf("head s3://%s/%s: %w", bucket, key, err)
+	}
+	return true, nil
+}
+
+// UploadFile opens a single local file and uploads it to S3. It is a separate
+// function so that defer f.Close() runs when UploadFile returns — not when a
+// WalkDir callback returns — preventing file descriptor accumulation over
+// large directory trees.
+func UploadFile(ctx context.Context, client *s3.Client, path, bucket, key string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", path, err)
+	}
+	defer f.Close()
+
+	if _, err := client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+		Body:   f,
+	}); err != nil {
+		return fmt.Errorf("upload %s → s3://%s/%s: %w", path, bucket, key, err)
+	}
+	return nil
+}

--- a/internal/storage/s3url_test.go
+++ b/internal/storage/s3url_test.go
@@ -1,0 +1,63 @@
+package storage
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseS3URL(t *testing.T) {
+	cases := []struct {
+		input      string
+		wantBucket string
+		wantPrefix string
+		wantErr    bool
+	}{
+		{"s3://my-bucket", "my-bucket", "", false},
+		{"s3://my-bucket/", "my-bucket", "", false},
+		{"s3://my-bucket/baselines/", "my-bucket", "baselines/", false},
+		{"s3://my-bucket/prefix/sub", "my-bucket", "prefix/sub", false},
+		{"http://my-bucket/prefix", "", "", true},
+		{"s3://", "", "", true},
+	}
+	for _, tc := range cases {
+		bucket, prefix, err := ParseS3URL(tc.input)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("ParseS3URL(%q) error = %v, wantErr %v", tc.input, err, tc.wantErr)
+			continue
+		}
+		if !tc.wantErr {
+			if bucket != tc.wantBucket {
+				t.Errorf("ParseS3URL(%q) bucket = %q, want %q", tc.input, bucket, tc.wantBucket)
+			}
+			if prefix != tc.wantPrefix {
+				t.Errorf("ParseS3URL(%q) prefix = %q, want %q", tc.input, prefix, tc.wantPrefix)
+			}
+		}
+	}
+}
+
+// TestParseS3URL_emptyBucketWithPath verifies that s3:///path (three slashes,
+// empty bucket name) is rejected — strings.Cut on "/" gives bucket="" which
+// hits the "bucket name is empty" guard.
+func TestParseS3URL_emptyBucketWithPath(t *testing.T) {
+	_, _, err := ParseS3URL("s3:///some/path")
+	if err == nil {
+		t.Fatal("expected error for s3:///some/path (empty bucket), got nil")
+	}
+	if !strings.Contains(err.Error(), "bucket") {
+		t.Errorf("expected 'bucket' in error, got: %v", err)
+	}
+}
+
+// TestParseS3URL_prefixRetainsTrailingSlash verifies that a prefix that ends
+// with "/" is returned as-is (the function does not strip it — callers like
+// uploadBaselineToS3 handle normalisation with TrimSuffix).
+func TestParseS3URL_prefixRetainsTrailingSlash(t *testing.T) {
+	_, prefix, err := ParseS3URL("s3://my-bucket/baselines/2026/")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if prefix != "baselines/2026/" {
+		t.Errorf("expected prefix %q, got %q", "baselines/2026/", prefix)
+	}
+}

--- a/internal/streamdeps/streamdeps.go
+++ b/internal/streamdeps/streamdeps.go
@@ -1,0 +1,34 @@
+// Package streamdeps wires the production helper functions into a
+// streamrun.Deps — the host side of streamrun's dependency-injection seam.
+//
+// It is kept OUT of streamrun itself on purpose: streamrun must not import
+// metadata/cliutil/byos/config/indexer, or the Deps seam (which exists so
+// streamrun stays decoupled from those packages) would be defeated. Both the
+// `stream`/`up` commands and the control-plane supervisor call Default() so
+// they build identical engine deps.
+package streamdeps
+
+import (
+	"github.com/dbtrail/bintrail/internal/byos"
+	"github.com/dbtrail/bintrail/internal/cliutil"
+	"github.com/dbtrail/bintrail/internal/config"
+	"github.com/dbtrail/bintrail/internal/indexer"
+	"github.com/dbtrail/bintrail/internal/metadata"
+	"github.com/dbtrail/bintrail/internal/streamrun"
+)
+
+// Default returns the streamrun.Deps used in production.
+func Default() streamrun.Deps {
+	return streamrun.Deps{
+		ValidateBinlogFormat:   metadata.ValidateBinlogFormat,
+		ValidateBinlogRowImage: metadata.ValidateBinlogRowImage,
+		ValidateNoFKCascades:   metadata.ValidateNoFKCascades,
+		ParseSchemaList:        cliutil.ParseSchemaList,
+		ResolveServerIdentity:  byos.ResolveServerIdentity,
+		EnsureResolver:         metadata.EnsureResolver,
+		BuildIndexFilters:      cliutil.BuildIndexFilters,
+		InsertSchemaChange:     indexer.InsertSchemaChange,
+		ParseSourceDSN:         config.ParseSourceDSN,
+		OutputJSON:             cliutil.OutputJSON,
+	}
+}


### PR DESCRIPTION
## What

**PR-D1 of the console decouple** (the clean-extraction path the board approved): verbatim relocation of four shared leaf helpers from `cmd/bintrail` (`package main`) into `internal/`, so the rotation engine (PR-D2) and the soon-to-move console supervisor (PR-D3) can reach helpers the core CLI also keeps. **No behavior change.**

This is PR-B-slice-1 style — heterogeneous leaf moves to their natural internal homes, one PR, verbatim, adversarially verified.

## Relocations

- **S3 helpers** `parseS3URL`/`newS3Client`/`buildS3Key`/`s3ObjectExists`/`uploadFile` → **`internal/storage`** (`ParseS3URL`/`NewS3Client`/`BuildS3Key`/`S3ObjectExists`/`UploadFile`). Rewired `archive`/`baseline`/`upload`/`rotate`. The `rotate` `uploadFileFunc` test-override seam now points at `storage.UploadFile` and stays in cmd (the engine moves in PR-D2).
- **`parseRetain`** → **`cliutil.ParseRetain`** (generic `Nd`/`Nh` duration parser; also used by `agent` + `doctor`).
- **`scrubMonitorErr`/`scrubMonitorErrText`** → **`config.ScrubDSNError`/`config.ScrubDSNText`** (both surviving consumers — the supervisor and the up-rotation loop — already import `config`; the loop needs it before it moves to `internal/rotation`).
- **`streamDeps`** → **`internal/streamdeps.Default()`** — kept **out** of `streamrun` on purpose, to preserve PR-A's Deps DI seam (streamrun must not import metadata/cliutil/byos/config/indexer). Rewired `stream` + `monitor`.

Tests `TestParseRetain*` / `TestParseS3URL*` moved to their new homes.

## Verification

- `go build ./...`, `go vet ./...` + `go vet -tags integration ./...`, full unit suite, and the rewired-package integration tests (rotate/monitor/supervisor/up-rotation/archive, against MySQL) all **green**.
- **Scope is exactly** the rewired `cmd/bintrail/*` files + the new `internal/{storage,cliutil,config,streamdeps}` files — nothing else.
- **Adversarial 2-agent byte-identical review** (each helper diffed against its original, call-site arg parity, the `uploadFileFunc` indirection) → `verbatim_clean`, zero findings.

## Next (decouple sequence)

PR-D2: extract the rotation engine + loop → `internal/rotation` (`rot*` globals → `Options`). PR-D3: the atomic pivot (move supervisor + `watch` to `bintrail-console`, delete core `console.go`/`monitor.go`, strip `up --console`, `uifree_test.go` guard, goreleaser 3rd build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)