### PR TITLE
feat(console): publish bintrail-console as its own image + package; compose runs `watch` (decouple PR-E)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,3 +15,5 @@ bintrail
 bintrail-mcp
 cover.out
 tmp
+bintrail-console
+mcp-gateway

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Bintrail Docker Compose configuration.
-# Copy to .env and set SOURCE_DSN — everything else has working defaults.
+# Everything is optional — `docker compose up -d` works with no .env at all
+# (add servers from the console UI). Copy to .env to pin any of the knobs.
 #
 #   cp .env.example .env
 #   docker compose up -d
@@ -28,5 +29,7 @@ CONSOLE_TOKEN=
 # (then you can delete the index-mysql service from docker-compose.yml).
 # INDEX_DSN=user:pass@tcp(my-index-host:3306)/bintrail_index
 
-# Optional — pin the bintrail image tag (default: latest).
-# BINTRAIL_TAG=v0.8.2
+# Optional — pin the image tag (default: latest). Tags of
+# ghcr.io/dbtrail/bintrail-console; the console image exists from the first
+# release after the console split onward.
+# BINTRAIL_TAG=v0.9.0

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -47,8 +47,9 @@ builds:
 
   # bintrail-console links DuckDB (console → query → parquetquery), so it is
   # CGO like the core binary — and uses the SAME main.* ldflags var names, so
-  # the version block mirrors bintrail's verbatim. Archives only for now; the
-  # Docker image and deb/rpm packaging land in a follow-up (decouple PR-E).
+  # the version block mirrors bintrail's verbatim. Ships in the release
+  # archives, as its own deb/rpm (nfpms below), and as its own image
+  # (ghcr.io/dbtrail/bintrail-console — dockers/docker_manifests below).
   - id: bintrail-console
     binary: bintrail-console
     main: ./cmd/bintrail-console
@@ -113,6 +114,26 @@ nfpms:
     dependencies:
       - ca-certificates
 
+  # Separate package, mirroring the binary split: the core CLI stays UI-free
+  # and the web console installs only where an operator wants it.
+  - id: bintrail-console
+    package_name: bintrail-console
+    ids:
+      - bintrail-console
+    vendor: dbtrail
+    homepage: https://github.com/dbtrail/bintrail
+    maintainer: Daniel <daniel@dbtrail.com>
+    description: >-
+      Web console for the bintrail binlog index — read-only event browser,
+      recovery SQL generation, and the combined stream+console watch daemon.
+    license: Apache-2.0
+    formats:
+      - deb
+      - rpm
+    bindir: /usr/bin
+    dependencies:
+      - ca-certificates
+
 # ── Docker images (multi-arch, published to GHCR) ──────────
 # One image per arch, then a manifest stitching them into a single
 # multi-arch tag. The arm64 image's RUN step executes under QEMU on the
@@ -161,6 +182,44 @@ dockers:
       - "--label=org.opencontainers.image.source=https://github.com/dbtrail/bintrail"
       - "--label=org.opencontainers.image.licenses=Apache-2.0"
 
+  # bintrail-console: its own single-binary image (PMM-style split — the
+  # compose quickstart runs `bintrail-console watch` from this image).
+  - id: bintrail-console-amd64
+    goos: linux
+    goarch: amd64
+    ids:
+      - bintrail-console
+    dockerfile: Dockerfile.bintrail-console.goreleaser
+    use: buildx
+    image_templates:
+      - "ghcr.io/dbtrail/bintrail-console:{{ .Version }}-amd64"
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.title=bintrail-console"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.source=https://github.com/dbtrail/bintrail"
+      - "--label=org.opencontainers.image.licenses=Apache-2.0"
+
+  - id: bintrail-console-arm64
+    goos: linux
+    goarch: arm64
+    ids:
+      - bintrail-console
+    dockerfile: Dockerfile.bintrail-console.goreleaser
+    use: buildx
+    image_templates:
+      - "ghcr.io/dbtrail/bintrail-console:{{ .Version }}-arm64"
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.title=bintrail-console"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.source=https://github.com/dbtrail/bintrail"
+      - "--label=org.opencontainers.image.licenses=Apache-2.0"
+
 docker_manifests:
   - name_template: "ghcr.io/dbtrail/bintrail:{{ .Version }}"
     image_templates:
@@ -175,6 +234,17 @@ docker_manifests:
     image_templates:
       - "ghcr.io/dbtrail/bintrail:{{ .Version }}-amd64"
       - "ghcr.io/dbtrail/bintrail:{{ .Version }}-arm64"
+
+  - name_template: "ghcr.io/dbtrail/bintrail-console:{{ .Version }}"
+    image_templates:
+      - "ghcr.io/dbtrail/bintrail-console:{{ .Version }}-amd64"
+      - "ghcr.io/dbtrail/bintrail-console:{{ .Version }}-arm64"
+  # skip_push: auto — same prerelease gating as the core image's :latest.
+  - name_template: "ghcr.io/dbtrail/bintrail-console:latest"
+    skip_push: "auto"
+    image_templates:
+      - "ghcr.io/dbtrail/bintrail-console:{{ .Version }}-amd64"
+      - "ghcr.io/dbtrail/bintrail-console:{{ .Version }}-arm64"
 
 # ── Homebrew tap (DEFERRED — do not uncomment until prerequisites exist) ──
 # Requires BOTH:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@
 Bintrail is a Go CLI that parses MySQL ROW-format binary logs, indexes every row event into MySQL with full before/after images, and generates reversal SQL for recovery. The index is self-contained — recovery never requires the original binlog files.
 
 Module: `github.com/dbtrail/bintrail`
-Go version: 1.25.7 — uses `range N`, `min()`, `slices.Reverse`, `strings.SplitSeq`, `any` (not `interface{}`).
+Go version: 1.24.7 (go.mod; the source Dockerfiles pin golang:1.24.7-bookworm to match) — uses `range N`, `min()`, `slices.Reverse`, `strings.SplitSeq`, `any` (not `interface{}`).
 
 ## Project structure
 
@@ -21,6 +21,8 @@ cmd/bintrail/          # One file per command (init, snapshot, index, query, rec
 cmd/bintrail-console/  # Standalone web-console binary (decouple PR-C/PR-D3): `serve` (read-only console, ex `bintrail console`) +
                        # `watch` (stream + console + control-plane supervisor in one daemon, ex `bintrail up --console`; monitor.go/
                        # monitor_replica.go = the supervisor, moved verbatim from cmd/bintrail). CGO (DuckDB via console→query→parquetquery).
+                       # Own image ghcr.io/dbtrail/bintrail-console (PR-E; Dockerfile.bintrail-console = source build, *.goreleaser = staged)
+                       # + separate bintrail-console deb/rpm; the root docker-compose.yml runs `bintrail-console watch` from it.
 cmd/bintrail-mcp/      # MCP server: main.go, proxy.py, tests
 internal/
   cliutil/             # Shared filter-parsing + output helpers: ParseEventType, ParseTime, IsValidFormat, IsValidOutputFormat, ParseSchemaList, BuildIndexFilters, OutputJSON

--- a/Dockerfile.bintrail-console
+++ b/Dockerfile.bintrail-console
@@ -1,0 +1,47 @@
+# bintrail-console — source-build image (for `docker build` / the compose
+# `build:` fallback). The GoReleaser-published image copies prebuilt binaries
+# instead; see Dockerfile.bintrail-console.goreleaser.
+#
+# One binary per image (PMM-style): this image carries ONLY the web-console
+# daemon (`serve` = read-only console, `watch` = stream + console + control
+# plane). The core CLI ships separately as ghcr.io/dbtrail/bintrail.
+
+# ── Stage 1: build ─────────────────────────────────────────
+# Debian-based image required — DuckDB's pre-compiled static libs need glibc.
+FROM golang:1.24.7-bookworm AS builder
+
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG BUILD_DATE=unknown
+
+WORKDIR /src
+
+# Cache dependency downloads separately from source changes.
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=1 go build \
+    -ldflags="-s -w -X main.Version=${VERSION} -X main.CommitSHA=${COMMIT} -X main.BuildDate=${BUILD_DATE}" \
+    -o /bintrail-console ./cmd/bintrail-console
+
+# ── Stage 2: runtime ───────────────────────────────────────
+# Debian slim for glibc compatibility with DuckDB.
+FROM debian:bookworm-slim
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates && \
+    rm -rf /var/lib/apt/lists/* && \
+    # Pin uid 999: the bundled compose chowns the index password secret to
+    # uid 999 (mode 0600) for this process to read — see docker-compose.yml.
+    useradd --system --no-create-home --uid 999 bintrail && \
+    # Writable state dir (console server registry, etc.). Pre-created and
+    # chowned in the image so a named volume mounted here inherits the
+    # ownership — the container runs as the non-root bintrail user.
+    mkdir -p /var/lib/bintrail && chown bintrail /var/lib/bintrail
+
+COPY --from=builder /bintrail-console /usr/local/bin/bintrail-console
+
+USER bintrail
+ENTRYPOINT ["bintrail-console"]

--- a/Dockerfile.bintrail-console.goreleaser
+++ b/Dockerfile.bintrail-console.goreleaser
@@ -1,0 +1,26 @@
+# GoReleaser-only Dockerfile for the bintrail-console image.
+#
+# Unlike Dockerfile.bintrail-console (which builds from source for
+# `docker build`), this image just copies the binary GoReleaser already
+# cross-compiled. The build context root contains `bintrail-console` for the
+# target arch — GoReleaser stages it there before invoking `docker build`.
+#
+# Runtime base matches Dockerfile.bintrail-console (debian:bookworm-slim):
+# glibc for DuckDB's static libs and a shell for debugging. One binary per
+# image (PMM-style) — the core CLI ships as ghcr.io/dbtrail/bintrail.
+FROM debian:bookworm-slim
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates && \
+    rm -rf /var/lib/apt/lists/* && \
+    # Pin uid 999: the bundled compose chowns the index password secret to
+    # uid 999 (mode 0600) for this process to read — see docker-compose.yml.
+    useradd --system --no-create-home --uid 999 bintrail && \
+    # Writable state dir (console server registry, etc.) — a named volume
+    # mounted here inherits the ownership; the container runs as uid 999.
+    mkdir -p /var/lib/bintrail && chown bintrail /var/lib/bintrail
+
+COPY bintrail-console /usr/local/bin/bintrail-console
+
+USER bintrail
+ENTRYPOINT ["bintrail-console"]

--- a/cmd/bintrail-console/main.go
+++ b/cmd/bintrail-console/main.go
@@ -8,7 +8,7 @@
 //
 //	bintrail-console serve --index-dsn "user:pass@tcp(127.0.0.1:3306)/binlog_index"
 //
-// Configuration mirrors `bintrail console`: a .bintrail.env (or
+// Configuration mirrors the core CLI: a .bintrail.env (or
 // ~/.config/bintrail/config.env) file is loaded on startup and the
 // BINTRAIL_INDEX_DSN / BINTRAIL_CONSOLE_* env vars are honored with
 // flag > env > default precedence.
@@ -44,9 +44,10 @@ var rootCmd = &cobra.Command{
 browse indexed row events with full before/after diffs, generate recovery
 (undo) SQL, and run point-in-time reconstruct when baselines are configured.
 
-It is the standalone form of "bintrail console", shipped as its own binary so
-the core bintrail CLI carries no web UI. The console NEVER executes SQL;
-recover produces a script you review and apply yourself.`,
+It is the web console's own binary (formerly the core CLI's "console"
+command), shipped separately so the core bintrail CLI carries no web UI. The
+console NEVER executes SQL; recover produces a script you review and apply
+yourself.`,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		observe.Setup(os.Stderr, logFormat, logLevel)
 		return nil

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,10 +8,11 @@
 # No .env needed. Optionally set SOURCE_DSN (start streaming one source
 # immediately) or CONSOLE_TOKEN (stable token across restarts) in a .env.
 #
-# What you get: a bundled MySQL 8.4 index (persisted in a volume), bintrail
-# running `up --console` against your source (preflight → index tables →
-# schema snapshot → live binlog stream → built-in rotation), and the web
-# console on http://127.0.0.1:8090 with the access token printed in the logs.
+# What you get: a bundled MySQL 8.4 index (persisted in a volume), the
+# `bintrail-console watch` daemon against your source (preflight → index
+# tables → schema snapshot → live binlog stream → built-in rotation), and the
+# web console on http://127.0.0.1:8090 with the access token printed in the
+# logs.
 #
 # === THE INDEX VOLUME IS YOUR SYSTEM OF RECORD ===
 # The bundled index holds the forensic record (binlog_events with full
@@ -48,7 +49,15 @@ services:
   # index MySQL and bintrail read it from the secret volume, so there is no
   # static default password on a volume holding the forensic record.
   index-init:
-    image: ghcr.io/dbtrail/bintrail:${BINTRAIL_TAG:-latest}
+    # Reuses the console image (already pulled for the main service below) —
+    # this step only needs a shell + od to seed the password file.
+    image: ghcr.io/dbtrail/bintrail-console:${BINTRAIL_TAG:-latest}
+    # Building from a source checkout instead? Uncomment here AND on the
+    # bintrail service below (keep the image: lines — `docker compose build`
+    # tags the local build with that name, so nothing is pulled):
+    # build:
+    #   context: .
+    #   dockerfile: Dockerfile.bintrail-console
     # Runs as root: a freshly-created named volume is root-owned, and the
     # bintrail image otherwise runs as a non-root user that couldn't write it.
     # The secret is then chowned to uid 999 mode 0600 FOR the bintrail process
@@ -114,13 +123,17 @@ services:
     restart: unless-stopped
 
   # ── Bintrail: stream + web console ───────────────────────
-  # `bintrail up --console` = doctor preflight + init + auto-snapshot +
-  # binlog stream + built-in rotation + the read-only web console.
+  # `bintrail-console watch` = doctor preflight + init + auto-snapshot +
+  # binlog stream + built-in rotation + the read-only web console (the
+  # daemon formerly known as `bintrail up --console`).
   bintrail:
-    image: ghcr.io/dbtrail/bintrail:${BINTRAIL_TAG:-latest}
-    # Building from a source checkout instead? Comment the line above and
-    # uncomment:
-    # build: .
+    image: ghcr.io/dbtrail/bintrail-console:${BINTRAIL_TAG:-latest}
+    # Building from a source checkout instead? Uncomment here AND on
+    # index-init above (keep the image: lines — `docker compose build` tags
+    # the local build with that name, so nothing is pulled):
+    # build:
+    #   context: .
+    #   dockerfile: Dockerfile.bintrail-console
     ports:
       # Console on the host loopback only. To reach it from another machine,
       # change to "8090:8090" AND set a stable CONSOLE_TOKEN in .env.
@@ -164,11 +177,11 @@ services:
           echo "Generated console token (set CONSOLE_TOKEN in .env to keep it stable across restarts)"
         fi
         if [ -n "$$SOURCE_DSN" ] && [ -n "$$SCHEMAS" ]; then
-          exec bintrail up --source-dsn "$$SOURCE_DSN" --index-dsn "$$INDEX_DSN" --schemas "$$SCHEMAS" --console
+          exec bintrail-console watch --source-dsn "$$SOURCE_DSN" --index-dsn "$$INDEX_DSN" --schemas "$$SCHEMAS"
         elif [ -n "$$SOURCE_DSN" ]; then
-          exec bintrail up --source-dsn "$$SOURCE_DSN" --index-dsn "$$INDEX_DSN" --console
+          exec bintrail-console watch --source-dsn "$$SOURCE_DSN" --index-dsn "$$INDEX_DSN"
         fi
-        exec bintrail up --index-dsn "$$INDEX_DSN" --console
+        exec bintrail-console watch --index-dsn "$$INDEX_DSN"
     depends_on:
       index-mysql:
         condition: service_healthy

--- a/docs/console.md
+++ b/docs/console.md
@@ -1,10 +1,14 @@
-# bintrail console
+# bintrail-console
 
-`bintrail console` serves an embedded, **read-only, single-operator** web UI over
-an existing index. It is the MCP server with a web face: the same query,
+`bintrail-console serve` serves an embedded, **read-only, single-operator** web
+UI over an existing index. It is the MCP server with a web face: the same query,
 recovery, and status engines, reached from a browser. Browse indexed row events
 with full before/after diffs, and generate recovery (undo) SQL — all without
 leaving the terminal that started it.
+
+The console ships as its own binary (and Docker image,
+`ghcr.io/dbtrail/bintrail-console`), separate from the core `bintrail` CLI —
+install it only where an operator wants the UI.
 
 The console **never executes SQL**. Recover produces a transaction-wrapped
 script you copy or download and apply yourself after review, exactly like
@@ -18,7 +22,7 @@ script you copy or download and apply yourself after review, exactly like
 ## Usage
 
 ```sh
-bintrail console --index-dsn "user:pass@tcp(127.0.0.1:3306)/binlog_index"
+bintrail-console serve --index-dsn "user:pass@tcp(127.0.0.1:3306)/binlog_index"
 ```
 
 On start it prints a jupyter-style URL with an access token:
@@ -29,10 +33,13 @@ Bintrail console (read-only) is running. Open:
     http://127.0.0.1:8090/?token=ab12cd34ef56ab12cd34ef56ab12cd34
 ```
 
-Or serve it **alongside a live stream** in one process with `bintrail up --console`:
+Or serve it **alongside a live stream** in one process with
+`bintrail-console watch` (the daemon formerly known as `bintrail up
+--console` — `up`'s preflight + init + stream plus the console and the
+multi-server control plane):
 
 ```sh
-bintrail up --source-dsn "$SRC" --index-dsn "$IDX" --console
+bintrail-console watch --source-dsn "$SRC" --index-dsn "$IDX"
 ```
 
 `--console-listen` / `--console-token` (or `BINTRAIL_CONSOLE_LISTEN` /
@@ -43,12 +50,12 @@ the baseline-gated Time-travel surface here too, so one process serves the live
 stream **and** point-in-time reconstruct:
 
 ```sh
-bintrail up --source-dsn "$SRC" --index-dsn "$IDX" --console --baseline-dir /var/bintrail/baselines
+bintrail-console watch --source-dsn "$SRC" --index-dsn "$IDX" --baseline-dir /var/bintrail/baselines
 ```
 
-With an S3 baseline (`--baseline-s3`), the `up` process reads S3 at request
+With an S3 baseline (`--baseline-s3`), the `watch` process reads S3 at request
 time using the ambient AWS credential chain — same as the standalone console,
-but note `up` didn't need AWS credentials before.
+but note the plain stream daemon didn't need AWS credentials before.
 
 Open that URL in a browser. A left **sidebar** groups the views (Time-travel
 appears only when a baseline is configured), with a **server switcher** at the
@@ -85,11 +92,12 @@ between them. The registry is a **local YAML file on the console host**
 (`~/.config/bintrail/console-servers.yaml` by default, override with
 `--servers-file` / `BINTRAIL_CONSOLE_SERVERS`) — adding a server registers a
 connection for browsing; it does **not** start monitoring. Monitoring still
-starts with `bintrail up` / `stream` against that server, as always.
+starts with `bintrail up` / `stream` against that server (or from the UI
+under `watch` — see the control plane below).
 
 How it behaves:
 
-- **The command-line entry.** `--index-dsn` (or `up --console`'s stream index)
+- **The command-line entry.** `--index-dsn` (or `watch`'s stream index)
   appears as an ephemeral `default (cli)` entry: it is the initial selection,
   is never written to the registry file, and cannot be edited or deleted from
   the UI. With at least one saved server, `--index-dsn` becomes optional — the
@@ -132,7 +140,7 @@ rewritten lossily.
 
 ### Monitoring a source from the UI (the control plane)
 
-Under **`bintrail up --console`** — and only there — the console is also a
+Under **`bintrail-console watch`** — and only there — the console is also a
 control plane: "+ Add server" with a **source MySQL** (host/user/password,
 optional schema filter) runs the `bintrail doctor` preflight inline
 (failures come back as remediation cards), provisions a dedicated index
@@ -176,8 +184,8 @@ immediately; warnings (e.g. short binlog retention) show but don't block.
   same masking/keep-password discipline as the index DSN; `source_dsn: ""`
   clears it), `source_server_id` (0 = derived), `schemas`, `monitor_desired`.
 
-The standalone read-only `bintrail console` never offers any of this: the
-`monitor` capability is false and the verbs return 403 there.
+The standalone read-only `bintrail-console serve` never offers any of this:
+the `monitor` capability is false and the verbs return 403 there.
 
 ## Flags
 
@@ -203,7 +211,7 @@ The standalone read-only `bintrail console` never offers any of this: the
 - `BINTRAIL_CONSOLE_SERVERS` — same as `--servers-file`.
 
 Precedence is the usual CLI flag > environment variable > default. The five
-`BINTRAIL_CONSOLE_*` variables apply equally to `bintrail up --console` (where
+`BINTRAIL_CONSOLE_*` variables apply equally to `bintrail-console watch` (where
 the matching flags are `--console-listen`, `--console-token`, `--baseline-dir`,
 `--baseline-s3`, `--console-servers-file`).
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -36,9 +36,16 @@ docker buildx build \
 Each tagged release publishes a multi-arch image (`linux/amd64` + `linux/arm64`) to GitHub Container Registry, so you don't need a Go toolchain or a local build:
 
 ```bash
-docker pull ghcr.io/dbtrail/bintrail:latest        # latest release
-docker pull ghcr.io/dbtrail/bintrail:v0.7.12       # a specific version
+docker pull ghcr.io/dbtrail/bintrail:latest          # core CLI + MCP server
+docker pull ghcr.io/dbtrail/bintrail-console:latest  # web console (serve/watch)
+docker pull ghcr.io/dbtrail/bintrail:v0.7.12         # a specific version
 ```
+
+`bintrail-console` is its own image (and GHCR package — it needs the same
+one-time public-visibility flip described below): a single binary with
+entrypoint `bintrail-console`, used by the Compose quickstart to run `watch`.
+The cosign verification below applies to it equally
+(`cosign verify ghcr.io/dbtrail/bintrail-console:latest …`).
 
 The images and the release checksums are signed with [cosign](https://github.com/sigstore/cosign) (keyless, via GitHub OIDC). Verify an image before running it:
 
@@ -109,10 +116,11 @@ docker run -d \
 ## Docker Compose
 
 The `docker-compose.yml` at the repository root is the zero-friction setup:
-an index MySQL (persisted in a named volume) plus `bintrail up --console` —
+an index MySQL (persisted in a named volume) plus `bintrail-console watch` —
 preflight checks, index tables, automatic schema snapshot, the live binlog
 stream, **and the web console**, in one `up -d`. It pulls the published
-`ghcr.io/dbtrail/bintrail` image; no Go toolchain or local build needed.
+`ghcr.io/dbtrail/bintrail-console` image; no Go toolchain or local build
+needed.
 
 ### Quick start
 
@@ -133,7 +141,7 @@ source checkout, `cp .env.example .env` gives you the annotated template.)
 The logs print the console URL, access token included:
 
 ```
-Console (read-only) is running. Open:
+Console is running — open it and add the MySQL servers to watch:
 
     http://127.0.0.1:8090/?token=ab12cd34…
 ```
@@ -148,14 +156,14 @@ Notes:
   mapping to `"8090:8090"` and pin a stable `CONSOLE_TOKEN` in `.env`
   (without a pinned token a fresh one is generated per boot and printed in
   the logs).
-- `bintrail up` is idempotent: restarts resume the stream from its saved
-  checkpoint. The preflight (`doctor`) failing prints copy-pasteable
-  remediation in the logs and the container retries.
+- `bintrail-console watch` is idempotent: restarts resume the stream from
+  its saved checkpoint. The preflight (`doctor`) failing prints
+  copy-pasteable remediation in the logs and the container retries.
 - Saved console connections (the Servers menu) persist in the
   `bintrail-state` volume.
 - `BINTRAIL_TAG` in `.env` pins the image version (default `latest`);
   building from a source checkout instead is a comment-toggle in the
-  compose file (`build: .`).
+  compose file (`build:` with `dockerfile: Dockerfile.bintrail-console`).
 
 ### The bundled index MySQL 8.4
 
@@ -196,6 +204,16 @@ source's binlogs (the bundled index was always "volume loss = re-index").
 > dump/restore, not an in-place datadir upgrade), or point `INDEX_DSN` at a BYO
 > index instead.
 
+**Upgrading a compose stack from before the console split** — older
+`docker-compose.yml` files ran `bintrail up --console` from the
+`ghcr.io/dbtrail/bintrail` image. That flag no longer exists (the combined
+daemon is now `bintrail-console watch`, in its own image), so a
+`docker compose pull && up -d` on the OLD file crash-loops with
+`unknown flag: --console`. The fix is to re-download `docker-compose.yml`
+(the curl in the Quick start) — image and command changed, but your `.env`
+and all data volumes (`bintrail-index-data`, `bintrail-index-secret`,
+`bintrail-state`, including saved console servers) carry over unchanged.
+
 ### Connecting to an external index MySQL (bring your own)
 
 To run your own index instead of the bundled 8.4, set `INDEX_DSN` in `.env` to a MySQL 8.0+ you operate and
@@ -212,7 +230,7 @@ only the *bundled* index is 8.4.)
 
 | Variable | Used by | Description |
 |----------|---------|-------------|
-| `SOURCE_DSN` | compose (required) | DSN for the source MySQL database to watch |
+| `SOURCE_DSN` | compose (optional) | DSN for a source MySQL to start watching at boot (empty = add servers from the console UI) |
 | `INDEX_DSN` | compose (optional) | Bring-your-own index MySQL (default: the bundled container) |
 | `SCHEMAS` | compose (optional) | Comma-separated schemas to track (empty = all user schemas) |
 | `CONSOLE_TOKEN` | compose (optional) | Pin the console access token (default: generated per boot) |
@@ -220,8 +238,8 @@ only the *bundled* index is 8.4.)
 | `BINTRAIL_TAG` | compose (optional) | Image tag to run (default `latest`) |
 | `BINTRAIL_INDEX_DSN` | bintrail-mcp | Index DSN for the MCP server |
 
-(`SERVER_ID` is no longer needed — `bintrail up` derives a stable one from the
-source DSN.)
+(`SERVER_ID` is no longer needed — `bintrail-console watch` derives a stable
+one from the source DSN.)
 
 ## Image details
 
@@ -229,6 +247,12 @@ source DSN.)
 - **Binaries**: `/usr/local/bin/bintrail`, `/usr/local/bin/bintrail-mcp`
 - **Entrypoint**: `bintrail` (pass subcommands as arguments)
 - **No shell scripts or init systems** — the container runs a single binary
+
+The `ghcr.io/dbtrail/bintrail-console` image follows the same contract with
+one binary: entrypoint `bintrail-console`, uid 999 pinned (the compose secret
+volume is chowned to it), `/var/lib/bintrail` pre-created for the server
+registry. Build it from source with
+`docker build -f Dockerfile.bintrail-console -t bintrail-console .`
 
 ### Why not Alpine?
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -18,7 +18,7 @@ it's the first section — the same four lines as the README.
 ## Docker Compose (the bundled default)
 
 One file, zero config — an index MySQL (persisted in a volume) and
-`bintrail up --console` in source-less daemon mode: the console plus the
+`bintrail-console watch` in source-less daemon mode: the console plus the
 control plane, waiting for you to add servers from the UI:
 
 ```sh
@@ -30,7 +30,7 @@ docker compose logs -f bintrail
 The logs print the console URL with its access token:
 
 ```
-Console (read-only) is running. Open:
+Console is running — open it and add the MySQL servers to watch:
 
     http://127.0.0.1:8090/?token=ab12cd34…
 ```
@@ -97,9 +97,11 @@ docker run --rm ghcr.io/dbtrail/bintrail:latest --version
 ```
 
 Multi-arch (`linux/amd64` + `linux/arm64`), signed with cosign, SBOM attached
-to every release. The image bundles both `bintrail` and `bintrail-mcp`. See
-[docker.md](./docker.md) for signature verification, `docker run` recipes,
-and the long-running stream container.
+to every release. The image bundles both `bintrail` and `bintrail-mcp`; the
+web console ships as its own image, `ghcr.io/dbtrail/bintrail-console`
+(`serve` = read-only console, `watch` = stream + console daemon — what the
+Compose stack runs). See [docker.md](./docker.md) for signature verification,
+`docker run` recipes, and the long-running stream container.
 
 ## Linux packages
 
@@ -117,6 +119,10 @@ sudo rpm -i bintrail_VERSION_linux_amd64.rpm
 
 (Replace `VERSION` with the release version; `checksums.txt` is cosign-signed.)
 
+The `bintrail` package carries the core CLI + `bintrail-mcp`; the web console
+is a separate `bintrail-console` package — install it only where an operator
+wants the UI.
+
 ## Go install
 
 ```sh
@@ -133,7 +139,8 @@ cd bintrail
 go build ./cmd/bintrail
 ```
 
-`make build` builds both `bintrail` and `bintrail-mcp` with version metadata.
+`make build` builds both `bintrail` and `bintrail-mcp` with version metadata;
+`make build-console` builds the `bintrail-console` web-console binary.
 
 > macOS binaries and a Homebrew tap are tracked in
 > [#349](https://github.com/dbtrail/bintrail/issues/349) — today the
@@ -158,8 +165,9 @@ bintrail up \
 
 `bintrail up` runs preflight + creates index tables + auto-snapshots + starts
 streaming, all in one. It resumes from the last checkpoint on restart and
-auto-derives a unique `server-id` from your source DSN. Add `--console` to
-serve the web UI from the same process.
+auto-derives a unique `server-id` from your source DSN. Want the web UI in
+the same process? Run `bintrail-console watch` (same flags) instead — it is
+`up` plus the console and the multi-server control plane.
 
 Once it's running, query and recover:
 
@@ -217,7 +225,6 @@ For cron, systemd units, and Ansible recipes, see [deployment.md](./deployment.m
 | `stream` | Connect as a replica and index row events in real-time |
 | `query` | Search the index with flexible filters (schema, table, PK, time range, GTID) |
 | `recover` | Generate reversal SQL for matching events |
-| `console` | Serve a read-only web UI to browse changes and generate undo SQL from a browser |
 | `reconstruct` | Rebuild row state at a point in time from baselines + binlog events |
 | `rotate` | Drop old partitions, add new ones, optionally archive to Parquet |
 | `status` | Show indexed files, partition sizes, and event counts |
@@ -235,6 +242,10 @@ For cron, systemd units, and Ansible recipes, see [deployment.md](./deployment.m
 
 All commands accept `--log-level` (default `info`) and `--log-format`
 (default `text`). See each command's `--help` for flags and usage.
+
+The web console lives in the separate `bintrail-console` binary —
+`serve` (read-only UI over an index) and `watch` (stream + console +
+control plane in one daemon). See [console.md](./console.md).
 
 ## Appendix: agent exit codes
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -181,10 +181,11 @@ The script is wrapped in `BEGIN`/`COMMIT` and reverses events in reverse chronol
 
 ## Step 5½ — Or do steps 4–5 from a browser
 
-Steps 4 and 5 (query + recover) are also available as a read-only web UI — same binary, no extra setup:
+Steps 4 and 5 (query + recover) are also available as a read-only web UI,
+served by the companion `bintrail-console` binary (same release archive):
 
 ```sh
-bintrail console --index-dsn "$IDX"
+bintrail-console serve --index-dsn "$IDX"
 ```
 
 It prints a tokenized loopback URL; open it in a browser:
@@ -271,7 +272,7 @@ bintrail rotate        ← run hourly to drop old partitions and stay clean
 bintrail status        ← check at any time
 ```
 
-> Prefer clicking to typing? `bintrail console` exposes the query + recover steps as a read-only web UI.
+> Prefer clicking to typing? `bintrail-console serve` exposes the query + recover steps as a read-only web UI.
 
 ---
 

--- a/docs/rotation-and-status.md
+++ b/docs/rotation-and-status.md
@@ -412,7 +412,7 @@ bintrail recover
 
 ## Built-in Rotation in `bintrail up`
 
-`bintrail up` runs a built-in rotation loop **by default**: every hour it drops index partitions older than 30 days and keeps 3 future hourly partitions ready. It covers the boot index database *and* every per-source database the console control plane provisions (`bintrail_idx_<entry>`), so an unattended quickstart can never grow until the disk fills. The settings are announced loudly at boot.
+`bintrail up` runs a built-in rotation loop **by default**: every hour it drops index partitions older than 30 days and keeps 3 future hourly partitions ready, so an unattended quickstart can never grow until the disk fills. The settings are announced loudly at boot. Under `bintrail-console watch` (the stream + console daemon — same `--rotate-*` flags and env vars) the loop additionally covers every per-source database the console control plane provisions (`bintrail_idx_<entry>`).
 
 ```sh
 bintrail up ... --rotate-retain 90d        # keep more history

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -326,7 +326,7 @@ When `--metrics-addr :9090` is set, a Prometheus HTTP endpoint starts at `/metri
 
 Every metric carries a `source` label so concurrent streams in one process stay
 distinguishable. For a standalone `bintrail stream` it is the server's resolved
-`bintrail_id` (`default` if unresolved); under `bintrail up --console` it is the
+`bintrail_id` (`default` if unresolved); under `bintrail-console watch` it is the
 monitored entry's ID, and the **daemon** serves one `/metrics` endpoint covering
 all supervised streams (per-stream endpoints would fight over the bind).
 

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -1527,7 +1527,7 @@ async function init() {
   $all(".nav-item").forEach((a) => a.addEventListener("click", (e) => { e.preventDefault(); pendingRecover = null; navigate(a.dataset.route); }));
   window.addEventListener("popstate", renderRoute);
 
-  if (!TOKEN) toast("No token in URL — open the link printed by `bintrail console`.");
+  if (!TOKEN) toast("No token in URL — open the link printed by `bintrail-console`.");
 
   // Startup order is load-bearing: servers (reconcile selection) → caps → route.
   let servers = [];


### PR DESCRIPTION
## Summary

The last PR of the console-decouple epic. PR-D3 (#445) made the core binary UI-free and left a release gate: the compose quickstart and docs still invoked the removed `bintrail up --console` / `bintrail console`. This PR adds the publishing artifacts and lifts that gate:

- **NEW `ghcr.io/dbtrail/bintrail-console` image** (single-binary, PMM-style split): `Dockerfile.bintrail-console` (source build — the compose `build:` fallback) + `Dockerfile.bintrail-console.goreleaser` (prebuilt copy). Both pin uid 999 (the compose secret contract) and pre-create `/var/lib/bintrail` (server-registry volume ownership).
- **goreleaser**: two `dockers` entries (amd64/arm64) + version/`latest` manifests (`skip_push: auto` on `:latest`, same prerelease gating as the core image) + a **separate `bintrail-console` deb/rpm** — the core `bintrail` package stays UI-free. cosign/SBOM cover the new artifacts with zero changes (`docker_signs: manifests`, `sboms: archive`); release.yaml needs no changes (image-name-agnostic).
- **docker-compose.yml**: the quickstart service now runs **`bintrail-console watch`** from the new image; `index-init` reuses it (one image pull total); source-build toggle documented on both services.
- **Docs rename sweep** (console.md, docker.md, install.md, quickstart.md, streaming.md, rotation-and-status.md, .env.example): `bintrail console` → `bintrail-console serve`, `up --console` → `bintrail-console watch`; install.md documents the separate image/package/make target and drops `console` from the core command table; docker.md gains the new image's GHCR/cosign/image-details coverage **and a migration note for existing compose stacks** (old compose crash-loops after the next pull — re-download the file; volumes carry over).
- Adversarial-review fixes folded in: stale `bintrail console` toast in the console UI (app.js), `bintrail-console --help` tense, goreleaser comment rot, `.dockerignore` (local `bintrail-console`/`mcp-gateway` artifacts), CLAUDE.md Go-version line corrected to go.mod's 1.24.7.

## ⚠️ Release sequencing (read before tagging)

1. Merge this PR → **cut a stable release tag promptly** (the raw-main compose now references `ghcr.io/dbtrail/bintrail-console`, which doesn't exist until GoReleaser pushes it). An RC tag is NOT enough for the quickstart: `skip_push: auto` keeps `:latest` off prereleases.
2. **First publish creates a PRIVATE GHCR package** — flip `ghcr.io/dbtrail/bintrail-console` to public (org → Packages → settings), like `bintrail` was. Until both happen, anonymous `docker compose pull` fails.
3. Release notes should carry the compose migration note (docs/docker.md §Upgrading).

## Verification

- `goreleaser check` (config valid; the `dockers_v2` deprecation warning pre-dates this PR), `docker compose config` clean, build/vet/tests green.
- The image **builds from source** and runs (`--version`, `watch --help` in-container).
- **End-to-end compose boot** with the locally-built image tagged as the ghcr name: password seeding → bundled MySQL 8.4 healthy → all 3 `watch` phases → live stream attached and indexing → console `healthz=200` through the published port; stack torn down cleanly.
- Adversarial 2-agent workflow (consistency + completeness): artifact plumbing confirmed solid (Dockerfile parity incl. the Go-toolchain match with go.mod, goreleaser internal consistency, compose↔watch flag/env semantics, banner accuracy); all important/minor findings fixed in this PR; the two release-sequencing constraints are documented above rather than code-fixable.

Closes the decouple epic (PR-A…PR-E). Follow-ups tracked separately: auth/TLS for bintrail-console, env-loader dedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)