### PR TITLE
fix(console): serve the SPA shell for pushState routes instead of 404

### DIFF
--- a/internal/console/assets.go
+++ b/internal/console/assets.go
@@ -23,9 +23,11 @@ var assetsFS embed.FS
 // The SPA routes with history.pushState ("/events", "/recover", …), so a
 // reload or deep link arrives here as a path that is not an embedded file.
 // Those get the index.html shell and the frontend router restores the view
-// (routeFromLocation in app.js). The fallback is limited to extensionless
-// paths: a missing real asset ("/favicon.ico", a stale "/app.js.map") must
-// stay a 404, not silently become HTML.
+// (routeFromLocation in app.js). The fallback is limited to paths whose last
+// segment has no extension: a missing real asset ("/favicon.ico", a stale
+// "/app.js.map") must stay a 404, not silently become HTML. Treating any
+// Stat error as "not a file" is safe only on embed.FS, which has no
+// ErrPermission/transient-IO class — revisit if sub ever comes from disk.
 func assetHandler() http.Handler {
 	sub, err := fs.Sub(assetsFS, "assets")
 	if err != nil {

--- a/internal/console/assets.go
+++ b/internal/console/assets.go
@@ -4,6 +4,8 @@ import (
 	"embed"
 	"io/fs"
 	"net/http"
+	"path"
+	"strings"
 )
 
 // assetsFS embeds the static frontend (HTML/CSS/JS + brand images). The
@@ -17,11 +19,28 @@ var assetsFS embed.FS
 
 // assetHandler serves the embedded frontend rooted at the assets/ directory,
 // so "/" resolves to index.html and "/app.js", "/style.css" resolve directly.
+//
+// The SPA routes with history.pushState ("/events", "/recover", …), so a
+// reload or deep link arrives here as a path that is not an embedded file.
+// Those get the index.html shell and the frontend router restores the view
+// (routeFromLocation in app.js). The fallback is limited to extensionless
+// paths: a missing real asset ("/favicon.ico", a stale "/app.js.map") must
+// stay a 404, not silently become HTML.
 func assetHandler() http.Handler {
 	sub, err := fs.Sub(assetsFS, "assets")
 	if err != nil {
 		// Unreachable: the embed directive guarantees the directory exists.
 		panic(err)
 	}
-	return http.FileServer(http.FS(sub))
+	files := http.FileServer(http.FS(sub))
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p := strings.TrimPrefix(path.Clean(r.URL.Path), "/")
+		if p != "" && !strings.Contains(path.Base(p), ".") {
+			if _, err := fs.Stat(sub, p); err != nil {
+				http.ServeFileFS(w, r, sub, "index.html")
+				return
+			}
+		}
+		files.ServeHTTP(w, r)
+	})
 }

--- a/internal/console/server_test.go
+++ b/internal/console/server_test.go
@@ -98,8 +98,9 @@ func TestMuxServesAssets(t *testing.T) {
 
 func TestMuxSPAFallback(t *testing.T) {
 	srv := newTestServer(t)
-	// pushState routes must reload/deep-link to the shell, not 404.
-	for _, p := range []string{"/overview", "/events", "/timetravel", "/recover", "/status", "/events?q=pk:1"} {
+	// pushState routes must reload/deep-link to the shell, not 404. The
+	// trailing-slash form rides on path.Clean — a URL shape users produce.
+	for _, p := range []string{"/overview", "/events", "/timetravel", "/recover", "/status", "/events/", "/events?q=pk:1"} {
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "http://127.0.0.1:8090"+p, nil)
 		srv.Handler().ServeHTTP(rec, req)
@@ -126,6 +127,17 @@ func TestMuxSPAFallback(t *testing.T) {
 		if rec.Code != 404 {
 			t.Errorf("%s code = %d, want 404", p, rec.Code)
 		}
+	}
+	// An unknown /api/* path must NEVER receive the shell: today the API
+	// lives on its own inner mux registered ahead of "/", but a refactor
+	// that flattens the muxes (or makes the fallback a NotFound handler)
+	// would turn every API 404 into 200 text/html and break API consumers.
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "http://127.0.0.1:8090/api/nonexistent", nil)
+	req.Header.Set("Authorization", "Bearer secret")
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != 404 || strings.Contains(rec.Body.String(), "<!DOCTYPE html") {
+		t.Errorf("/api/nonexistent code = %d, shell = %v; want 404 without HTML", rec.Code, strings.Contains(rec.Body.String(), "<!DOCTYPE html"))
 	}
 }
 

--- a/internal/console/server_test.go
+++ b/internal/console/server_test.go
@@ -96,6 +96,39 @@ func TestMuxServesAssets(t *testing.T) {
 	}
 }
 
+func TestMuxSPAFallback(t *testing.T) {
+	srv := newTestServer(t)
+	// pushState routes must reload/deep-link to the shell, not 404.
+	for _, p := range []string{"/overview", "/events", "/timetravel", "/recover", "/status", "/events?q=pk:1"} {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "http://127.0.0.1:8090"+p, nil)
+		srv.Handler().ServeHTTP(rec, req)
+		if rec.Code != 200 {
+			t.Errorf("%s code = %d, want 200", p, rec.Code)
+		}
+		if !strings.Contains(rec.Body.String(), "dbtrail console") {
+			t.Errorf("%s did not serve the index.html shell", p)
+		}
+	}
+	// Real assets still resolve as themselves, not as the shell.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "http://127.0.0.1:8090/app.js", nil)
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != 200 || strings.Contains(rec.Body.String(), "<!DOCTYPE html") {
+		t.Errorf("/app.js code = %d, shell = %v; want the JS file itself", rec.Code, strings.Contains(rec.Body.String(), "<!DOCTYPE html"))
+	}
+	// Missing files with an extension stay 404 — the fallback must not mask
+	// broken asset references by serving them HTML.
+	for _, p := range []string{"/favicon.ico", "/app.js.map", "/missing/deep.css"} {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "http://127.0.0.1:8090"+p, nil)
+		srv.Handler().ServeHTTP(rec, req)
+		if rec.Code != 404 {
+			t.Errorf("%s code = %d, want 404", p, rec.Code)
+		}
+	}
+}
+
 func TestMuxRejectsForeignHost(t *testing.T) {
 	srv := newTestServer(t)
 	rec := httptest.NewRecorder()


### PR DESCRIPTION
## Problem

Since the UI redesign (#429) the console routes with `history.pushState` — the sidebar links are real anchors (`/overview`, `/events`, …) and in-app navigation rewrites the URL. But `assetHandler()` remained a plain `http.FileServer` over the embedded assets, so any **reload, deep link, or open-in-new-tab** on a view path hit the file server and returned Go's raw `404 page not found`. Invisible in happy-path use (pushState never touches the server), guaranteed on refresh.

## Fix

`assetHandler` now serves the `index.html` shell for **extensionless** paths that don't match an embedded file; the frontend router (`routeFromLocation` in `app.js`) already restores the view from the path, and unknown routes fall back to Overview. Paths with an extension (`/favicon.ico`, a stale `/app.js.map`) still 404 so the fallback never masks a broken asset reference. `/api/*` is unaffected (registered ahead of `/` on the mux).

## Verification

- `TestMuxSPAFallback`: all five view paths (+ query-string variant) serve the shell with 200; `/app.js` still serves itself; missing extension-ful paths stay 404.
- Headless-Chrome drive (playwright-core against a live `bintrail-console serve` on the Docker test MySQL): deep link to `/events` renders the Events view; in-app nav to `/recover` + **reload** restores Recover; unknown path falls back to Overview; `?token=` is stripped from the URL after bootstrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)