### PR TITLE
ux(console): collapse the BYO index section behind an Advanced toggle

### DIFF
--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -1080,7 +1080,9 @@ function wireSchemaCascade(root) {
 async function gateCapabilities() {
   const gen = serverGen;
   let caps = {};
-  try { caps = await api("/api/capabilities"); } catch (_) { caps = {}; }
+  // Degrading to {} hides capability-gated UI (Time-travel tab, the source
+  // section of the server form) — warn so a wrongly-shaped UI is diagnosable.
+  try { caps = await api("/api/capabilities"); } catch (err) { console.warn("capabilities check failed; UI degrades to no-capability gating", err); caps = {}; }
   if (gen !== serverGen) return;
   capsCache = caps || {};
   $all("[data-capability]").forEach((node) => node.classList.toggle("cap-on", !!capsCache[node.dataset.capability]));
@@ -1224,7 +1226,7 @@ function buildServerForm() {
 
   const mon = el("fieldset", { class: "form-section", "data-capability": "monitor" });
   mon.append(el("legend", { class: "form-legend", text: "Monitor a source MySQL" }));
-  mon.append(el("p", { class: "form-hint", text: "Paste the server to watch — dbtrail runs the preflight checks, provisions an index database for it automatically, and starts streaming. Nothing else to fill in." }));
+  mon.append(el("p", { class: "form-hint", text: "Paste the server to watch — dbtrail runs the preflight checks, provisions an index database for it automatically, and starts streaming. Nothing else to fill in beyond a name." }));
   const monGrid = el("div", { class: "form-grid" });
   monGrid.append(srvField("Source host", "source_host", { placeholder: "db.example.com" }));
   monGrid.append(srvField("Source port", "source_port", { placeholder: "3306" }));
@@ -1234,9 +1236,9 @@ function buildServerForm() {
   mon.append(monGrid);
   form.append(mon);
 
-  // BYO index is the advanced path: collapsed by default where monitoring is
-  // available; showServerForm opens it in serve-only mode (where it is the
-  // whole form) and when editing an entry that already carries index fields.
+  // BYO index is the advanced path — collapsed behind a <details> so the
+  // monitor-first form stays one field + source. Open/close rules live in
+  // showServerForm.
   const adv = el("details", { class: "form-advanced", id: "server-advanced" });
   adv.append(el("summary", { class: "form-adv-summary", text: "Advanced — bring your own index (optional)" }));
   const idx = el("fieldset", { class: "form-section" });
@@ -1276,9 +1278,12 @@ function showServerForm(prefill) {
   form.addEventListener("submit", (e) => { e.preventDefault(); saveServer(form); });
 
   // Where the index connection is the whole form (serve-only process: no
-  // monitor capability), or the entry being edited already carries index
-  // fields, the "advanced" block must start expanded — and in serve-only
-  // mode there is nothing to collapse it back to, so the toggle hides.
+  // monitor capability), or the entry being edited carries index fields,
+  // the "advanced" block must start expanded — and in serve-only mode
+  // there is nothing to collapse it back to, so the toggle hides. Note a
+  // monitor-first save also ends with index fields (the derived index DSN
+  // round-trips as host/dbname in the DTO), so "collapsed by default"
+  // means a fresh add; editing any saved entry shows its index.
   const adv = $("#server-advanced", form);
   const hasIndexFields = !!(prefill && (prefill.host || prefill.dbname || prefill.baseline_dir || prefill.baseline_s3 || prefill.no_archive));
   adv.open = !capsCache.monitor || hasIndexFields;
@@ -1325,11 +1330,13 @@ function serverFormBody(form) {
 }
 
 async function editServer(id) {
-  try {
-    const s = await api("/api/servers/" + encodeURIComponent(id));
-    showServerForm(s);
-    return true;
-  } catch (err) { toast("failed to load server: " + ((err && err.message) || err)); return false; }
+  // Catch only the fetch: a render throw from showServerForm must surface
+  // as an uncaught error, not masquerade as "failed to load server".
+  let s;
+  try { s = await api("/api/servers/" + encodeURIComponent(id)); }
+  catch (err) { toast("failed to load server: " + ((err && err.message) || err)); return false; }
+  showServerForm(s);
+  return true;
 }
 
 async function saveServer(form) {

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -1216,9 +1216,15 @@ function buildServerForm() {
   const form = el("form", { class: "filters", id: "server-form", style: "display:block;margin-top:18px" });
   form.append(el("input", { type: "hidden", name: "id" }));
 
+  // Name is the one field every entry needs, whatever the path — keep it out
+  // of both sections so the index section reads as fully optional.
+  const top = el("div", { class: "form-grid" });
+  top.append(srvField("Name", "name", { placeholder: "prod-db-01" }));
+  form.append(top);
+
   const mon = el("fieldset", { class: "form-section", "data-capability": "monitor" });
   mon.append(el("legend", { class: "form-legend", text: "Monitor a source MySQL" }));
-  mon.append(el("p", { class: "form-hint", text: "Paste the server to watch — dbtrail runs the preflight checks, provisions an index for it, and starts streaming. Leave the index section empty; it is created automatically." }));
+  mon.append(el("p", { class: "form-hint", text: "Paste the server to watch — dbtrail runs the preflight checks, provisions an index database for it automatically, and starts streaming. Nothing else to fill in." }));
   const monGrid = el("div", { class: "form-grid" });
   monGrid.append(srvField("Source host", "source_host", { placeholder: "db.example.com" }));
   monGrid.append(srvField("Source port", "source_port", { placeholder: "3306" }));
@@ -1228,10 +1234,14 @@ function buildServerForm() {
   mon.append(monGrid);
   form.append(mon);
 
+  // BYO index is the advanced path: collapsed by default where monitoring is
+  // available; showServerForm opens it in serve-only mode (where it is the
+  // whole form) and when editing an entry that already carries index fields.
+  const adv = el("details", { class: "form-advanced", id: "server-advanced" });
+  adv.append(el("summary", { class: "form-adv-summary", text: "Advanced — bring your own index (optional)" }));
   const idx = el("fieldset", { class: "form-section" });
   idx.append(el("legend", { class: "form-legend", text: "Index connection" }));
   const idxGrid = el("div", { class: "form-grid" });
-  idxGrid.append(srvField("Name", "name", { placeholder: "prod-db-01" }));
   idxGrid.append(srvField("Host", "host", { placeholder: "127.0.0.1" }));
   idxGrid.append(srvField("Port", "port", { placeholder: "3306" }));
   idxGrid.append(srvField("User", "user", { placeholder: "bintrail" }));
@@ -1242,7 +1252,8 @@ function buildServerForm() {
   idx.append(idxGrid);
   idx.append(el("label", { class: "check", style: "margin-top:10px" },
     el("input", { type: "checkbox", name: "no_archive" }), el("span", { text: "Disable archive auto-discovery" })));
-  form.append(idx);
+  adv.append(idx);
+  form.append(adv);
 
   const foot = el("div", { class: "modal-foot filter-actions" });
   foot.append(el("button", { class: "btn btn-primary", type: "submit", text: "Save" }));
@@ -1263,6 +1274,15 @@ function showServerForm(prefill) {
   $("#server-cancel", form).addEventListener("click", hideServerForm);
   $("#server-test", form).addEventListener("click", () => testServerForm(form));
   form.addEventListener("submit", (e) => { e.preventDefault(); saveServer(form); });
+
+  // Where the index connection is the whole form (serve-only process: no
+  // monitor capability), or the entry being edited already carries index
+  // fields, the "advanced" block must start expanded — and in serve-only
+  // mode there is nothing to collapse it back to, so the toggle hides.
+  const adv = $("#server-advanced", form);
+  const hasIndexFields = !!(prefill && (prefill.host || prefill.dbname || prefill.baseline_dir || prefill.baseline_s3 || prefill.no_archive));
+  adv.open = !capsCache.monitor || hasIndexFields;
+  $(".form-adv-summary", adv).hidden = !capsCache.monitor;
 
   if (prefill) {
     form.elements.id.value = prefill.id || "";

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -825,6 +825,14 @@ button { font-family: inherit; }
   color: var(--blue); padding: 0 6px; margin-left: 6px;
 }
 .form-hint { color: var(--ink-2); font-size: 12.5px; margin: 4px 0 16px; }
+.form-advanced { margin-top: 18px; }
+.form-adv-summary {
+  cursor: pointer; user-select: none;
+  font-family: var(--f-mono); font-size: 11px; font-weight: 600;
+  letter-spacing: 0.06em; text-transform: uppercase; color: var(--ink-2);
+}
+.form-adv-summary:hover, .form-advanced[open] > .form-adv-summary { color: var(--blue); }
+.form-adv-summary[hidden] { display: none; }
 .form-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
 .form-grid .field { width: auto; }
 .form-grid.two { grid-template-columns: repeat(2, 1fr); }


### PR DESCRIPTION
## Problem

In the add-server form, the optional "Index connection" section had the same visual weight as the source section — and the always-required **Name** field lived *inside* it, with focus landing there on open. The zero-terminal path ("+ Add server" → paste a source → dbtrail provisions a per-source index automatically, `deriveIndex` in `servers_api.go`) read as if it required filling in index connection details, defeating the point of the bundled index.

## Change (frontend only — no API/backend changes)

- **Name** moves to the top of the form as its own field (it applies to every path).
- The index section collapses into a native `<details>` labeled **"Advanced — bring your own index (optional)"**.
- It auto-expands where it is the real content:
  - serve-only processes (no monitor capability) — and the toggle hides, since there is nothing to collapse back to;
  - editing an entry that already carries index fields (host/dbname/baselines/no_archive).
- Source-section hint updated: "…provisions an index database for it automatically… Nothing else to fill in."

| watch (default) | expanded on demand |
|---|---|
| Name + source fields, index collapsed | `▼ Advanced` reveals the BYO fieldset |

## Verification

Headless-Chrome (playwright-core) drive against live `watch` and `serve` processes, 12 assertions all passing:
- **watch**: Name outside the advanced block and focused on open; index section collapsed; toggle visible and expands on click; editing a BYO entry (created via API, 201) auto-expands.
- **serve**: index section open, toggle hidden, source section hidden, index fields usable.
- `node --check` + full `internal/console` / `cmd/bintrail-console` Go suites green (assets are embedded — recompiled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)