### PR TITLE
fix(console): pad the login/password overlay so its text isn't clipped

### DIFF
--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -207,7 +207,10 @@ async function handleUnauthorized() {
   clearAuthState();
   let pw = false;
   try { pw = !!(await fetchAuthInfo()).password_login; } catch (_) {}
-  showLoginOverlay({ passwordLogin: pw, message: "Session expired — sign in again." });
+  // Token mode has no session to expire and no form to "sign in" to — say what
+  // actually happened (the stored token is no longer accepted).
+  const msg = pw ? "Session expired — sign in again." : "This access token is no longer valid.";
+  showLoginOverlay({ passwordLogin: pw, message: msg });
 }
 
 // clearAuthState drops every credential-scoped cache on sign-out. capsCache

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -1102,9 +1102,15 @@ button { font-family: inherit; }
    session — a static token has nothing to log out of. */
 [data-auth]:not(.auth-on) { display: none !important; }
 
-/* login overlay + password dialog (mounted in #login-mount) */
-.login-panel { max-width: 380px; }
-.login-form { display: flex; flex-direction: column; gap: 14px; margin-top: 16px; }
+/* login overlay + password dialog (mounted in #login-mount). Unlike the
+   servers modal these panels hold their content DIRECTLY (no .modal-head/
+   .modal-body), so the panel itself carries the padding — without it .modal's
+   overflow:hidden clips the text against the edges. */
+.login-panel { max-width: 400px; padding: 30px 32px; }
+.login-panel .modal-title { margin-bottom: 12px; }
+.login-panel .modal-desc { max-width: none; }
+.login-panel .modal-desc + .modal-desc { margin-top: 10px; }
+.login-form { display: flex; flex-direction: column; gap: 14px; margin-top: 18px; }
 .login-form .field { width: auto; }
 
 /* result/meta lines reused across Events, Recover, Reconstruct */


### PR DESCRIPTION
## Problem

A user reloaded the console with a stale token and got the token-mode sign-in gate — rendered as a cramped, ugly box with the body text clipped against the panel edges (the leading glyph of "the token this page needs" was cut off).

**Root cause:** the login overlay and password dialog (`showLoginOverlay`/`showPasswordDialog`, from #451) append their content *directly* to a `.modal` panel. But `.modal` keeps all its padding on `.modal-head`/`.modal-body` — which these panels don't use — and sets `overflow: hidden`. So the content had zero padding and any text reaching the edge was clipped. Affected all three overlay states: the token-mode gate, the password login form, and the change-password dialog.

## Fix

- **CSS** (`style.css`): `.login-panel` now carries its own padding (`30px 32px`) plus title/paragraph spacing, since it holds content directly rather than through `.modal-head`/`.modal-body`.
- **Copy** (`app.js`): a 401 in token mode showed "Session expired — sign in again", but token mode has no session and no sign-in form. It now reads "This access token is no longer valid."

## Verification

Headless-Chrome drive across all three overlay states asserts: horizontal + top padding present (≥20px), no overflow/clipping under `overflow:hidden` (`scrollWidth ≤ clientWidth`), correct copy, and the password form's two inputs. Visually confirmed via screenshot — properly padded centered card, no clipped text. `internal/console` suite green.

Before: bare box, text against the edges, "t" of "the token" clipped.
After: padded card, text breathes, sensible message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)