### PR TITLE
fix(console): tighten the login/password dialog layout and message font

### DIFF
--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -1112,6 +1112,13 @@ button { font-family: inherit; }
 .login-panel .modal-desc + .modal-desc { margin-top: 10px; }
 .login-form { display: flex; flex-direction: column; gap: 14px; margin-top: 18px; }
 .login-form .field { width: auto; }
+/* The login/password dialogs are compact: drop the wide servers-modal foot
+   spacing, make the submit full-width (it reads as intentional, not stranded),
+   and give the message the UI font — the mono .form-msg is for the servers
+   form's technical/DSN errors, not a friendly "Signed out." here. */
+.login-form .modal-foot { margin-top: 4px; }
+.login-form .modal-foot .btn { flex: 1; }
+.login-panel .form-msg { font-family: var(--f-ui); font-size: 13px; margin-top: 6px; }
 
 /* result/meta lines reused across Events, Recover, Reconstruct */
 .meta-line {


### PR DESCRIPTION
Follow-up polish to #452 (which fixed the panel padding/clipping). The login form still had two rough edges visible once it rendered:

1. **Too much vertical air.** It reused the wide servers-modal `.modal-foot` spacing (`margin-top: 22px`) stacked on the form's `14px` gap — a ~36px gulf between the password field and the Sign in button.
2. **The status message was monospace.** `.form-msg` uses the mono font (right for the servers form's DSN/technical errors), so "Signed out." / "Invalid username or password." read like a terminal error in the login card.

## Fix (CSS only, scoped to `.login-panel`/`.login-form`)

- Drop the foot margin so the button sits close to the fields.
- Make the submit **full-width** — it reads as intentional rather than stranded on the left with empty space beside it.
- Give the message the UI font.

## Verification

Headless-Chrome drive: full-width blue submit (confirmed by a tight button clip — the full-page capture washes the oklch gradient under the scrim's `backdrop-filter`, a known headless compositing artifact, not a real render bug), message in the UI font, and tight gaps (password→button 18px, button→message 20px). The wrong-password error renders correctly. `internal/console` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)