### PR TITLE
feat(console): make username+password the only login path (first-run browser setup)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,10 +15,10 @@
 # Optional — comma-separated schemas to track (empty = all user schemas).
 SCHEMAS=
 
-# Optional — pin your own console access token. When empty, a token is
-# generated on first boot, persisted in the bintrail-state volume (stable
-# across restarts), and printed in the logs. Prefer a username+password
-# login? Run: docker compose exec -it bintrail bintrail-console user set-password
+# Optional — an opt-in static token for API automation (scripts/curl against
+# the console API). Humans don't need it: on first run the console asks you to
+# create a username and password in the browser. Leave empty unless a script
+# needs the API.
 CONSOLE_TOKEN=
 
 # Optional — pin the bundled index MySQL root password. Leave commented to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **BREAKING (console auth) — username+password is now the only login path; the access token is opt-in automation only.** This supersedes the additive token-or-password model from 0.11.0. On a fresh console the **first browser visit creates the password** (a loopback-only, self-disabling `POST /api/auth/setup` endpoint); every later visit signs in. **No access token is generated anymore** — set `--token` / `CONSOLE_TOKEN` explicitly only if a script needs the console API. A non-loopback bind with no credential is refused unless you set a password, a token, or `--allow-setup` (asserting the bind is access-controlled — what the Docker stack does, since it binds `0.0.0.0` in the container but publishes on the host's loopback). The Docker Compose entrypoint no longer generates or persists a token; on first `up` you create the password in the browser.
+  - **Upgrading from 0.11.0?** If you used a password, nothing changes (you get the login form). If you relied on the auto-generated compose token (a bookmarked `?token=` URL, or token-based API automation with no explicit `CONSOLE_TOKEN`), that token is gone after this upgrade: the browser lands on the create-password screen instead, and automation must now pin `CONSOLE_TOKEN` in `.env`. Reset a forgotten password from the host shell: `docker compose exec -it bintrail bintrail-console user set-password`.
+- New flag/env `--allow-setup` / `BINTRAIL_CONSOLE_ALLOW_SETUP` (on `serve` and `watch`) permits browser first-run setup on a non-loopback bind that is access-controlled by other means; a loud startup warning fires while setup is open off-loopback.
+
 ### Fixed
-- **The console sign-in overlay no longer renders with its text clipped** (#452). The login gate and password dialog (new in 0.11.0) appended their content directly to a panel whose padding lived on sub-elements they didn't use, so the text jammed against the edges and `overflow: hidden` clipped it. The panel now carries its own padding, and a 401 in token mode reads "This access token is no longer valid." instead of the session-flavored "Session expired — sign in again" (token mode has no session).
+- **The console sign-in overlay no longer renders with its text clipped, and the login form is tightened** (#452, #453). The login gate and password dialog (new in 0.11.0) appended their content directly to a panel whose padding lived on sub-elements they didn't use, so the text jammed against the edges and `overflow: hidden` clipped it; the panel now carries its own padding. The submit button is full-width and the status message uses the UI font (not the servers-form monospace), and a 401 in token mode reads "This access token is no longer valid." instead of the session-flavored "Session expired" (token mode has no session).
 
 ## [0.11.0] - 2026-06-10
 

--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ docker compose exec -it bintrail bintrail-console user set-password
 ```
 
 To reach the console from another machine, **set the password from the shell
-first** (off-loopback browser setup is refused), then publish the port —
-ideally behind TLS. The [console guide](docs/console.md#password-login) has the
-full auth, TLS, and reverse-proxy options (plus an opt-in API token for
-automation).
+first** — until one exists, exposing the port would expose the create-password
+screen — then publish the port, ideally behind TLS. The
+[console guide](docs/console.md#password-login) has the full auth, TLS, and
+reverse-proxy options (plus an opt-in API token for automation).
 
 > The compose stack ships a pinned **MySQL 8.4** container as the index store.
 > That index holds the forensic record — **it is your system of record, so

--- a/README.md
+++ b/README.md
@@ -45,36 +45,31 @@ exact fix for anything missing.
 ```sh
 curl -fsSLO https://raw.githubusercontent.com/dbtrail/dbtrail/main/docker-compose.yml
 docker compose up -d
-docker compose logs -f bintrail
 ```
 
-Nothing to configure. The logs end with your console URL:
+Open **http://127.0.0.1:8090** — on first run the console asks you to **create
+a username and password**. That's your login from now on.
 
-```
-Console is running — open it and add the MySQL servers to watch:
+Then click **+ Add server**: paste the MySQL you want to watch — host, user,
+password — and dbtrail runs the preflight checks (failures come back as
+fix-this cards), provisions an index for it, and starts streaming. Watching
+events within the minute, and the terminal is already behind you.
 
-    http://127.0.0.1:8090/?token=ab12cd34…
-```
+The console binds to your machine only (`127.0.0.1`); your password persists in
+the stack's volume, so every later visit is a normal sign-in.
 
-Open it and click **+ Add server**: paste the MySQL you want to watch —
-host, user, password — and dbtrail runs the preflight checks (failures come
-back as fix-this cards), provisions an index for it, and starts streaming.
-Watching events within the minute, and the terminal is already behind you.
-
-The console binds to your machine only (`127.0.0.1`) and every request needs
-the access token — generated once and kept in the stack's volume, so the URL
-stays valid across restarts. Prefer signing in with a username and password?
-Set one and a login form replaces the token URL on your next visit (no
-restart needed):
+**Forgot the password?** Reset it from the host shell — re-running this
+overwrites it, no data lost:
 
 ```sh
 docker compose exec -it bintrail bintrail-console user set-password
 ```
 
-To reach the console from another machine, set a credential (the password
-above — ideally behind TLS) and publish the port; the
-[console guide](docs/console.md#password-login) has the full auth, TLS, and
-reverse-proxy options.
+To reach the console from another machine, **set the password from the shell
+first** (off-loopback browser setup is refused), then publish the port —
+ideally behind TLS. The [console guide](docs/console.md#password-login) has the
+full auth, TLS, and reverse-proxy options (plus an opt-in API token for
+automation).
 
 > The compose stack ships a pinned **MySQL 8.4** container as the index store.
 > That index holds the forensic record — **it is your system of record, so

--- a/cmd/bintrail-console/serve.go
+++ b/cmd/bintrail-console/serve.go
@@ -51,6 +51,7 @@ var (
 	conAuthFile     string
 	conTLSCert      string
 	conTLSKey       string
+	conAllowSetup   bool
 )
 
 func init() {
@@ -66,6 +67,7 @@ func init() {
 	serveCmd.Flags().StringVar(&conAuthFile, "auth-file", "", "Path to the console auth file enabling password login (default ~/.config/bintrail/console-auth.yaml; created with `bintrail-console user set-password`)")
 	serveCmd.Flags().StringVar(&conTLSCert, "tls-cert", "", "TLS certificate file (PEM); serve the console over HTTPS (requires --tls-key)")
 	serveCmd.Flags().StringVar(&conTLSKey, "tls-key", "", "TLS private key file (PEM; requires --tls-cert)")
+	serveCmd.Flags().BoolVar(&conAllowSetup, "allow-setup", false, "Allow browser first-run password setup on a non-loopback bind (assert the bind is access-controlled, e.g. published only on the host loopback)")
 	rootCmd.AddCommand(serveCmd)
 }
 
@@ -127,6 +129,11 @@ func runServe(cmd *cobra.Command, args []string) error {
 	if !cmd.Flags().Changed("allowed-hosts") {
 		if v := os.Getenv("BINTRAIL_CONSOLE_ALLOWED_HOSTS"); v != "" {
 			conAllowedHosts = strings.Split(v, ",")
+		}
+	}
+	if !cmd.Flags().Changed("allow-setup") {
+		if v := os.Getenv("BINTRAIL_CONSOLE_ALLOW_SETUP"); v == "1" || v == "true" {
+			conAllowSetup = true
 		}
 	}
 
@@ -214,6 +221,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		AuthPath:      conAuthFile,
 		TLSCert:       conTLSCert,
 		TLSKey:        conTLSKey,
+		AllowSetup:    conAllowSetup,
 		// MonitorCtrl is intentionally left nil: bintrail-console serve is the
 		// read-only standalone console. A write-capable control-plane daemon
 		// wires a supervisor here instead; with nil, /api/capabilities reports
@@ -235,14 +243,17 @@ func runServe(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// printConsoleBanner prints the startup URL. In password mode the URL carries
-// no ?token= (URL() already omits it — a live credential does not belong in
-// logs or shell history) and the sign-in hint is printed instead; an
-// explicitly configured token stays valid for automation but its value is
-// never echoed.
+// printConsoleBanner prints the startup URL plus a credential hint keyed to
+// the console's mode. The URL never carries a ?token= unless an explicit token
+// is the only credential (URL() handles that); a live credential does not
+// belong in logs or shell history.
 func printConsoleBanner(srv *console.Server, headline string) {
 	fmt.Fprintf(os.Stderr, "\n%s\n\n    %s\n\n", headline, srv.URL())
-	if srv.PasswordLogin() {
+	switch {
+	case srv.NeedsSetup():
+		// First run, loopback, no credential: the browser creates the password.
+		fmt.Fprintf(os.Stderr, "First run — open the URL and create your console username and password.\n\n")
+	case srv.PasswordLogin():
 		fmt.Fprintf(os.Stderr, "Sign in with your console username and password.\n")
 		if srv.Token() != "" {
 			fmt.Fprintf(os.Stderr, "(The configured access token also remains valid, for API automation.)\n")

--- a/cmd/bintrail-console/serve.go
+++ b/cmd/bintrail-console/serve.go
@@ -29,9 +29,12 @@ console NEVER executes SQL; recover produces a script you review and apply
 yourself.
 
 Security:
-  - Binds to loopback (127.0.0.1) by default and requires an access token.
-  - A token is auto-generated for loopback binds and printed in the URL.
-  - Binding to a non-loopback address REQUIRES an explicit --token.
+  - Binds to loopback (127.0.0.1) by default. Username+password login is the
+    primary credential: on a fresh loopback console the first visit creates
+    the password in the browser (or set it up front with 'user set-password').
+  - A non-loopback bind needs a credential: a configured password, an explicit
+    --token (opt-in automation), or --allow-setup (assert the bind is
+    access-controlled) — otherwise it is refused.
 
 Example:
   bintrail-console serve --index-dsn "user:pass@tcp(127.0.0.1:3306)/binlog_index"`,
@@ -57,7 +60,7 @@ var (
 func init() {
 	serveCmd.Flags().StringVar(&conIndexDSN, "index-dsn", "", "DSN for the index MySQL database (required unless the server registry has entries)")
 	serveCmd.Flags().StringVar(&conListen, "listen", "127.0.0.1:8090", "Address to listen on (host:port)")
-	serveCmd.Flags().StringVar(&conToken, "token", "", "Access token (auto-generated for loopback binds when empty)")
+	serveCmd.Flags().StringVar(&conToken, "token", "", "Opt-in static token for API automation (never generated; humans use the console password)")
 	serveCmd.Flags().BoolVar(&conNoArchive, "no-archive", false, "Disable Parquet archive auto-discovery (MySQL-only)")
 	serveCmd.Flags().StringVar(&conProfile, "profile", "", "RBAC profile: deny tables / redact columns; forces --no-archive")
 	serveCmd.Flags().StringSliceVar(&conAllowedHosts, "allowed-hosts", nil, "Extra hostnames allowed in the Host header (for reverse-proxy setups; IP literals and localhost are always allowed)")

--- a/cmd/bintrail-console/user_test.go
+++ b/cmd/bintrail-console/user_test.go
@@ -194,3 +194,37 @@ func TestWatchAllowedHostsEnvFallback(t *testing.T) {
 		t.Errorf("allowed-hosts from env = %v, want [console.internal proxy.example]", upConsoleAllowedHost)
 	}
 }
+
+// TestAllowSetupEnvFallback covers BINTRAIL_CONSOLE_ALLOW_SETUP on both serve
+// and watch (the compose sets it so first-run setup works behind the
+// container's 0.0.0.0 bind / host-loopback publish).
+func TestAllowSetupEnvFallback(t *testing.T) {
+	t.Run("serve", func(t *testing.T) {
+		conIndexDSN, conProfile, conBaselineDir, conBaselineS3 = "", "", "", ""
+		conAllowSetup = false
+		conServersFile = filepath.Join(t.TempDir(), "servers.yaml")
+		t.Cleanup(func() { conIndexDSN, conServersFile, conAllowSetup = "", "", false })
+		t.Setenv("BINTRAIL_INDEX_DSN", "")
+		t.Setenv("BINTRAIL_CONSOLE_SERVERS", "")
+		t.Setenv("BINTRAIL_CONSOLE_ALLOW_SETUP", "1")
+		_ = runServe(serveCmd, nil) // errors on the empty-DSN guard; env runs first
+		if !conAllowSetup {
+			t.Error("BINTRAIL_CONSOLE_ALLOW_SETUP=1 not consumed by runServe")
+		}
+	})
+	t.Run("watch", func(t *testing.T) {
+		saved := upConsoleAllowSetup
+		t.Cleanup(func() { upConsoleAllowSetup = saved })
+		if watchCmd.Flags().Lookup("console-allow-setup") == nil {
+			t.Fatal("flag --console-allow-setup not registered on watchCmd")
+		}
+		cmd := &cobra.Command{}
+		cmd.Flags().BoolVar(&upConsoleAllowSetup, "console-allow-setup", false, "")
+		t.Setenv("BINTRAIL_CONSOLE_ALLOW_SETUP", "true")
+		upConsoleAllowSetup = false
+		resolveUpConsoleEnv(cmd)
+		if !upConsoleAllowSetup {
+			t.Error("BINTRAIL_CONSOLE_ALLOW_SETUP=true not consumed by resolveUpConsoleEnv")
+		}
+	})
+}

--- a/cmd/bintrail-console/watch.go
+++ b/cmd/bintrail-console/watch.go
@@ -72,6 +72,7 @@ var (
 	upConsoleTLSCert     string
 	upConsoleTLSKey      string
 	upConsoleAllowedHost []string
+	upConsoleAllowSetup  bool
 
 	upRotateRetain    string
 	upRotateInterval  string
@@ -148,6 +149,7 @@ func init() {
 	watchCmd.Flags().StringVar(&upConsoleTLSCert, "console-tls-cert", "", "TLS certificate file (PEM); serve the console over HTTPS (requires --console-tls-key)")
 	watchCmd.Flags().StringVar(&upConsoleTLSKey, "console-tls-key", "", "TLS private key file (PEM; requires --console-tls-cert)")
 	watchCmd.Flags().StringSliceVar(&upConsoleAllowedHost, "console-allowed-hosts", nil, "Extra hostnames allowed in the Host header (for a TLS-terminating reverse proxy); IP literals and localhost are always allowed")
+	watchCmd.Flags().BoolVar(&upConsoleAllowSetup, "console-allow-setup", false, "Allow browser first-run password setup on a non-loopback bind (assert the bind is access-controlled, e.g. published only on the host loopback)")
 	watchCmd.Flags().StringVar(&upRotateRetain, "rotate-retain", "30d", "Built-in rotation: drop index partitions older than this (Nd/Nh; \"off\" disables)")
 	watchCmd.Flags().StringVar(&upRotateInterval, "rotate-interval", "1h", "Built-in rotation: how often to run a rotation cycle")
 	watchCmd.Flags().IntVar(&upRotateAddFuture, "rotate-add-future", 3, "Built-in rotation: keep at least N future hourly partitions ready")
@@ -570,6 +572,11 @@ func resolveUpConsoleEnv(cmd *cobra.Command) {
 			upConsoleAllowedHost = strings.Split(v, ",")
 		}
 	}
+	if !cmd.Flags().Changed("console-allow-setup") {
+		if v := os.Getenv("BINTRAIL_CONSOLE_ALLOW_SETUP"); v == "1" || v == "true" {
+			upConsoleAllowSetup = true
+		}
+	}
 }
 
 // consoleOpts carries watch's console-surface settings into upConsoleConfig —
@@ -584,6 +591,7 @@ type consoleOpts struct {
 	TLSCert      string
 	TLSKey       string
 	AllowedHosts []string
+	AllowSetup   bool
 }
 
 // upConsoleOpts snapshots the resolved upConsole* globals.
@@ -597,6 +605,7 @@ func upConsoleOpts() consoleOpts {
 		TLSCert:      upConsoleTLSCert,
 		TLSKey:       upConsoleTLSKey,
 		AllowedHosts: upConsoleAllowedHost,
+		AllowSetup:   upConsoleAllowSetup,
 	}
 }
 
@@ -627,6 +636,7 @@ func upConsoleConfig(db *sql.DB, indexDSN string, opts consoleOpts) (console.Con
 		TLSCert:      opts.TLSCert,
 		TLSKey:       opts.TLSKey,
 		AllowedHosts: opts.AllowedHosts,
+		AllowSetup:   opts.AllowSetup,
 		// MonitorCtrl (the control-plane supervisor) is wired by the caller —
 		// runUpStreamWithConsole / runUpConsoleOnly — because it needs the
 		// registry and the daemon lifecycle context, which this config builder

--- a/cmd/bintrail-console/watch.go
+++ b/cmd/bintrail-console/watch.go
@@ -141,7 +141,7 @@ func init() {
 	watchCmd.Flags().BoolVar(&upSkipDoctor, "skip-doctor", false, "Skip the preflight checks (useful when you've already verified with `bintrail doctor`)")
 	watchCmd.Flags().StringVar(&upFormat, "format", "text", "Output format: text or json")
 	watchCmd.Flags().StringVar(&upConsoleListen, "console-listen", "127.0.0.1:8090", "Console bind address")
-	watchCmd.Flags().StringVar(&upConsoleToken, "console-token", "", "Console access token (auto-generated for loopback binds when empty)")
+	watchCmd.Flags().StringVar(&upConsoleToken, "console-token", "", "Opt-in static token for API automation (never generated; humans use the console password)")
 	watchCmd.Flags().StringVar(&upConsoleBaselineDir, "baseline-dir", "", "Local directory of baseline Parquet snapshots; enables the console's point-in-time Reconstruct surface")
 	watchCmd.Flags().StringVar(&upConsoleBaselineS3, "baseline-s3", "", "S3 prefix of baseline Parquet snapshots (s3://bucket/prefix/); enables Reconstruct")
 	watchCmd.Flags().StringVar(&upConsoleServersFile, "console-servers-file", "", "Path to the console server registry YAML (default ~/.config/bintrail/console-servers.yaml)")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,22 @@
 # Bintrail Docker Compose — the zero-friction quickstart.
 #
 #   1. docker compose up -d
-#   2. docker compose logs -f bintrail   # open the printed console URL
+#   2. Open http://127.0.0.1:8090 and create your console username + password
 #   3. In the console: "+ Add server" — paste the MySQL to watch; bintrail
 #      runs the preflight, provisions an index for it, and starts streaming.
 #
-# No .env needed. Optionally set SOURCE_DSN (start streaming one source
-# immediately) or CONSOLE_TOKEN (pin your own token) in a .env. The generated
-# token persists in the bintrail-state volume, so it is stable across
-# restarts either way. Prefer a username+password login instead? Run:
+# No .env needed. On first run the console asks you to create a username and
+# password (it persists in the bintrail-state volume); every later visit is a
+# normal sign-in. Forgot it? Reset from the host shell:
 #   docker compose exec -it bintrail bintrail-console user set-password
+# Optionally set SOURCE_DSN (start streaming one source immediately) in a .env.
+# CONSOLE_TOKEN is an opt-in API-automation credential — set it only if a
+# script needs the console API; humans sign in with the password.
 #
 # What you get: a bundled MySQL 8.4 index (persisted in a volume), the
 # `bintrail-console watch` daemon against your source (preflight → index
 # tables → schema snapshot → live binlog stream → built-in rotation), and the
-# web console on http://127.0.0.1:8090 with the access token printed in the
-# logs.
+# web console on http://127.0.0.1:8090.
 #
 # === THE INDEX VOLUME IS YOUR SYSTEM OF RECORD ===
 # The bundled index holds the forensic record (binlog_events with full
@@ -138,11 +139,12 @@ services:
     #   context: .
     #   dockerfile: Dockerfile.bintrail-console
     ports:
-      # Console on the host loopback only. To reach it from another machine,
-      # change to "8090:8090" AND set a credential: a console password
+      # Console on the host loopback only — first-run password setup is allowed
+      # because reaching loopback already implies local access. To reach it from
+      # another machine, first create the password from the host shell
       # (docker compose exec -it bintrail bintrail-console user set-password —
-      # ideally behind TLS or a TLS-terminating proxy) or a stable
-      # CONSOLE_TOKEN in .env.
+      # off-loopback setup is refused), THEN change to "8090:8090", ideally
+      # behind TLS or a TLS-terminating proxy.
       - "127.0.0.1:8090:8090"
     environment:
       # Optional: a source MySQL to start watching immediately. Leave unset
@@ -160,12 +162,18 @@ services:
       BINTRAIL_CONSOLE_TOKEN: ${CONSOLE_TOKEN:-}
       # Saved console connections persist across container recreations.
       BINTRAIL_CONSOLE_SERVERS: /var/lib/bintrail/console-servers.yaml
-      # Optional password login (persists next to the registry). Enable it
-      # with: docker compose exec -it bintrail bintrail-console user set-password
-      # The running daemon honors it on the next login — no restart needed.
+      # Password login (persists next to the registry). On first run the
+      # console serves a "create your password" screen; later visits sign in.
       # There is deliberately NO password env var: docker inspect must never
       # be able to print a credential.
       BINTRAIL_CONSOLE_AUTH: /var/lib/bintrail/console-auth.yaml
+      # The console binds 0.0.0.0 INSIDE the container, but the `ports` mapping
+      # above publishes it on the host's loopback only — so first-run setup is
+      # access-controlled in the default stack. The container can't see the
+      # host mapping, so we assert it here. If you change `ports` to expose the
+      # console (e.g. "8090:8090"), set the password from the host shell FIRST
+      # (docker compose exec … user set-password) before exposing it.
+      BINTRAIL_CONSOLE_ALLOW_SETUP: "1"
     volumes:
       - bintrail-state:/var/lib/bintrail
       - bintrail-index-secret:/run/secret:ro
@@ -181,29 +189,12 @@ services:
         if [ -z "$$INDEX_DSN" ]; then
           INDEX_DSN="root:$$(cat /run/secret/index_password)@tcp(index-mysql:3306)/bintrail_index"
         fi
-        # A non-loopback console bind requires a credential. When CONSOLE_TOKEN
-        # isn't pinned in .env, generate a token ONCE and persist it in the
-        # bintrail-state volume — restarts and recreations keep the same token,
-        # so bookmarked ?token= URLs and automation survive redeploys. (umask
-        # before the write: the file must never be world-readable, even
-        # pre-chmod. The -s guard copies index-init's dash-has-no-pipefail
-        # defense: an empty token file must abort, not 401 everything.)
-        if [ -z "$$BINTRAIL_CONSOLE_TOKEN" ]; then
-          tf=/var/lib/bintrail/console_token
-          if [ ! -s "$$tf" ]; then
-            (umask 077; od -An -N16 -tx1 /dev/urandom | tr -d ' \n' > "$$tf")
-            if [ ! -s "$$tf" ]; then echo "FATAL: failed to generate the console token" >&2; rm -f "$$tf"; exit 1; fi
-            echo "Generated console token (persisted in the bintrail-state volume; set CONSOLE_TOKEN in .env to override)"
-          fi
-          # Plain assignment, like the INDEX_DSN block above: under `set -e` it
-          # propagates a failed `cat` (e.g. an unreadable root-owned token file
-          # after a user: override) and aborts loud. `export VAR="$(cat …)"`
-          # would discard the substitution's exit status and export an EMPTY
-          # token — which boots password-only or crash-loops, never naming the
-          # culprit.
-          BINTRAIL_CONSOLE_TOKEN="$$(cat "$$tf")"
-          export BINTRAIL_CONSOLE_TOKEN
-        fi
+        # No token is generated: the console binds to loopback, so first run is
+        # password SETUP — open the printed URL and create your console
+        # username and password (it persists in the bintrail-state volume next
+        # to the server registry). CONSOLE_TOKEN in .env is an opt-in API
+        # automation credential, passed through via the environment above; it
+        # is not generated for you.
         if [ -n "$$SOURCE_DSN" ] && [ -n "$$SCHEMAS" ]; then
           exec bintrail-console watch --source-dsn "$$SOURCE_DSN" --index-dsn "$$INDEX_DSN" --schemas "$$SCHEMAS"
         elif [ -n "$$SOURCE_DSN" ]; then

--- a/docs/console.md
+++ b/docs/console.md
@@ -197,7 +197,7 @@ the `monitor` capability is false and the verbs return 403 there.
 |---|---|---|
 | `--index-dsn` | — | DSN for the index MySQL database. Becomes the ephemeral `default` entry. Required only when the server registry is empty. |
 | `--listen` | `127.0.0.1:8090` | Bind address. `:8090` avoids the MCP server's `:8080`. |
-| `--token` | auto-generated | Access token. Auto-generated for loopback binds; **required** for non-loopback. |
+| `--token` | — (none) | Opt-in static token for API automation. **Never generated** — humans sign in with the console password. One of the credentials that makes a non-loopback bind legal. |
 | `--no-archive` | `false` | Disable Parquet archive auto-discovery (MySQL-only results). Also **disables Time-travel** — reconstruct needs archive access to verify coverage. |
 | `--profile` | — | RBAC profile: deny tables / redact columns. Forces `--no-archive` and **disables Time-travel** (baseline reads bypass redaction). |
 | `--allowed-hosts` | — | Extra hostnames accepted in the `Host` header (for reverse-proxy setups). IP literals and `localhost` are always allowed. |

--- a/docs/console.md
+++ b/docs/console.md
@@ -25,12 +25,16 @@ script you copy or download and apply yourself after review, exactly like
 bintrail-console serve --index-dsn "user:pass@tcp(127.0.0.1:3306)/binlog_index"
 ```
 
-On start it prints a jupyter-style URL with an access token:
+On start it prints the URL to open. On a fresh console the first visit is a
+**"create your password"** screen (see [Password login](#password-login));
+after that, you sign in:
 
 ```
 Bintrail console (read-only) is running. Open:
 
-    http://127.0.0.1:8090/?token=ab12cd34ef56ab12cd34ef56ab12cd34
+    http://127.0.0.1:8090/
+
+First run — open the URL and create your console username and password.
 ```
 
 Or serve it **alongside a live stream** in one process with
@@ -202,6 +206,7 @@ the `monitor` capability is false and the verbs return 403 there.
 | `--servers-file` | `~/.config/bintrail/console-servers.yaml` | Path to the server registry YAML managed from the UI. |
 | `--auth-file` | `~/.config/bintrail/console-auth.yaml` | Console credential file enabling password login (see below). Created with `bintrail-console user set-password`, never by the server on its own. |
 | `--tls-cert` / `--tls-key` | — | Serve the console over HTTPS (PEM files, both-or-neither). Rotation = restart; no ACME. |
+| `--allow-setup` | `false` | Allow browser first-run password setup on a non-loopback bind (assert the bind is access-controlled, e.g. host-loopback published). Loopback always allows setup. |
 
 ### Environment variables
 
@@ -214,6 +219,7 @@ the `monitor` capability is false and the verbs return 403 there.
 - `BINTRAIL_CONSOLE_AUTH` — same as `--auth-file`.
 - `BINTRAIL_CONSOLE_TLS_CERT` / `BINTRAIL_CONSOLE_TLS_KEY` — same as `--tls-cert` / `--tls-key`.
 - `BINTRAIL_CONSOLE_ALLOWED_HOSTS` — comma-separated, same as `--allowed-hosts`.
+- `BINTRAIL_CONSOLE_ALLOW_SETUP` — `1`/`true`, same as `--allow-setup`.
 
 There is deliberately **no** environment variable for the password itself —
 env vars leak through `docker inspect`, `ps e`, and `/proc`; the password is
@@ -223,12 +229,16 @@ Precedence is the usual CLI flag > environment variable > default. The
 `BINTRAIL_CONSOLE_*` variables apply equally to `bintrail-console watch` (where
 the matching flags are `--console-listen`, `--console-token`, `--baseline-dir`,
 `--baseline-s3`, `--console-servers-file`, `--console-auth-file`,
-`--console-tls-cert`, `--console-tls-key`, `--console-allowed-hosts`).
+`--console-tls-cert`, `--console-tls-key`, `--console-allowed-hosts`,
+`--console-allow-setup`).
 
 ## Password login
 
-The token is the zero-config default, but it can be paired with (or, for
-humans, replaced by) a username+password login:
+**Username + password is the primary way in.** On a fresh loopback console
+with no credential, the first browser visit shows a **"create your password"**
+screen; you set it once and you're signed in. Every later visit is a normal
+sign-in. (Prefer the terminal, or setting it up before first launch? Run
+`bintrail-console user set-password`.)
 
 ```console
 $ bintrail-console user set-password
@@ -238,29 +248,39 @@ Console password set for user "admin" (~/.config/bintrail/console-auth.yaml).
 A running server accepts it on the next login — no restart needed.
 ```
 
+- **First-run setup is loopback-only.** The unauthenticated `POST
+  /api/auth/setup` endpoint (which the "create your password" screen calls)
+  is enabled only on a loopback bind — where reaching it already implies local
+  access — and **self-disables the instant a password exists**. It is also
+  enabled by `--allow-setup` (`BINTRAIL_CONSOLE_ALLOW_SETUP`), the assertion
+  the Docker stack makes because it binds `0.0.0.0` inside the container but
+  publishes the port on the host's loopback only. A non-loopback bind with no
+  credential and no `--allow-setup` is refused — set the password from the
+  shell first.
 - The credential lives in a 0600 YAML file (`version`, `username`, a
   bcrypt-cost-12 `password_bcrypt`, `updated_at`) — same envelope and atomic
   write as the server registry. One user; multi-user/RBAC/SSO is dbtrail.
-- A successful `POST /api/auth/login` mints an **in-memory session token**
+- A successful login (or first-run setup) mints an **in-memory session token**
   (24 h absolute, 8 h idle, max 16 concurrent) the SPA uses as its Bearer
   credential. Sessions die on logout, on password change (which revokes all
   of them), and on process restart — nothing session-shaped touches disk.
-- **The static `--token` keeps working unchanged** as the automation
-  credential (scripts, curl, CI). With a password configured and no explicit
-  token, no token is auto-generated and the startup banner prints a clean URL
-  — sign in at the login form instead. Non-loopback binds become legal with
-  either credential.
-- Login and password-change are throttled (per-IP 5 failures/min and
+- **An opt-in static token** for automation: set `--token` /
+  `BINTRAIL_CONSOLE_TOKEN` explicitly and scripts/curl/CI can call the API with
+  it. It is never generated for you, and it is not the human path — when a
+  token *is* set, the browser never sees the setup screen (the token is the
+  credential).
+- Login, setup, and password-change are throttled (per-IP 5 failures/min and
   20/15 min, 30/min globally, `Retry-After` on 429) and bcrypt-verified in
   constant time with no username enumeration. There is no lockout — locking
   the single user out would hand an attacker a denial-of-service against the
   operator.
-- Rotate from the UI (⌘K → "Change console password", revokes every other
-  session immediately) or re-run `user set-password` (applies on the next
-  login; live sessions ride out their TTL). `user remove` deletes the file
-  and reverts to token-only auth; `user status` shows what is configured
-  without printing secrets. Forgot the password? Shell access is the
-  recovery path: re-run `user set-password`.
+- **Rotate or reset:** from the UI (⌘K → "Change console password", revokes
+  every other session immediately) or re-run `user set-password` (overwrites;
+  applies on the next login, live sessions ride out their TTL). **Forgot the
+  password?** Shell access is the recovery path — re-run `user set-password`.
+  `user remove` deletes the file (a loopback console then returns to first-run
+  setup; a non-loopback one refuses its next restart until a credential is set
+  again). `user status` shows what is configured without printing secrets.
 - Off-loopback password logins over plain HTTP are warned about at startup:
   use `--tls-cert`/`--tls-key` or terminate TLS at a reverse proxy (with
   `--allowed-hosts`).
@@ -300,7 +320,8 @@ itself:
   recover default 1000 (max 10000). Never unlimited.
 - **Unauthenticated endpoints**: `/api/healthz` (liveness), `GET /api/auth`
   (does password login exist — what the login form's presence would reveal
-  anyway), and `POST /api/auth/login` itself. Everything else needs a Bearer
+  anyway), `POST /api/auth/login`, and — only during first-run setup —
+  `POST /api/auth/setup`. Everything else needs a Bearer
   credential.
 
 ## Open-core boundary
@@ -320,8 +341,9 @@ All endpoints return JSON. `/api/*` (except `healthz`) require
 | Method & path | Purpose |
 |---|---|
 | `GET /api/healthz` | Liveness probe (no token). |
-| `GET /api/auth` | Whether password login is enabled (no token): `{"password_login": bool}`. |
+| `GET /api/auth` | Auth mode (no token): `{"password_login": bool, "setup": bool}` — `setup` true means first-run create-password is open. |
 | `POST /api/auth/login` | Exchange `{username, password}` for a session: `{token, expires_at}`. Rate-limited; requires `Content-Type: application/json`. |
+| `POST /api/auth/setup` | First-run only (loopback / `--allow-setup`, self-disables once a password exists): create the password, returns a session. |
 | `POST /api/auth/logout` | Revoke the presented session (static token → 204 no-op). |
 | `POST /api/auth/password` | Set (first time; requires static-token auth) or rotate (`current_password` verified) the console password. Revokes all sessions and returns a fresh one. |
 | `GET /api/status` | Index status (same payload as `bintrail status --format json`). |

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -149,11 +149,13 @@ Notes:
   same machine is reachable from inside Docker as `host.docker.internal`.
 - The console is published on the **host loopback only** (`127.0.0.1:8090`),
   which is why first-run browser setup is allowed (the compose sets
-  `BINTRAIL_CONSOLE_ALLOW_SETUP` because the container itself binds
-  `0.0.0.0`). To reach it from another machine, **set the password from the
-  shell first** (`docker compose exec -it bintrail bintrail-console
-  user set-password` — off-loopback browser setup is refused), then change the
-  port mapping to `"8090:8090"`, ideally behind TLS
+  `BINTRAIL_CONSOLE_ALLOW_SETUP` because the container itself binds `0.0.0.0`).
+  The setup screen self-disables the moment a password exists. To reach the
+  console from another machine, **set the password from the host shell first**
+  (`docker compose exec -it bintrail bintrail-console user set-password`) —
+  until you do, the compose stack would serve the create-password screen on
+  whatever you publish (a loud startup warning fires while it is open). Then
+  change the port mapping to `"8090:8090"`, ideally behind TLS
   (`BINTRAIL_CONSOLE_TLS_CERT`/`_TLS_KEY` or a TLS-terminating proxy).
 - The credential file lives at `/var/lib/bintrail/console-auth.yaml` in the
   `bintrail-state` volume. **Forgot the password?** Reset it with

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -130,46 +130,36 @@ to watch are added from the console UI afterwards:
 ```bash
 curl -fsSLO https://raw.githubusercontent.com/dbtrail/dbtrail/main/docker-compose.yml
 docker compose up -d
-docker compose logs -f bintrail
 ```
+
+Open **http://127.0.0.1:8090** — on first run the console serves a **"create
+your console password"** screen. Set it once; every later visit is a normal
+sign-in.
 
 Optional knobs go in a `.env` next to the file: `SOURCE_DSN` to start
-streaming one source immediately at boot, `CONSOLE_TOKEN` to pin your own
-access token, `INDEX_DSN` to bring your own index MySQL. (From a source
-checkout, `cp .env.example .env` gives you the annotated template.)
-
-The logs print the console URL, access token included:
-
-```
-Console is running — open it and add the MySQL servers to watch:
-
-    http://127.0.0.1:8090/?token=ab12cd34…
-```
-
-The generated token persists in the `bintrail-state` volume, so it stays
-stable across restarts and recreations. Prefer signing in with a username and
-password instead of a token URL? Set one — the login form appears on the next
-visit, no restart needed:
-
-```bash
-docker compose exec -it bintrail bintrail-console user set-password
-```
+streaming one source immediately at boot, `INDEX_DSN` to bring your own index
+MySQL, `CONSOLE_TOKEN` for an opt-in API-automation token (humans use the
+password). (From a source checkout, `cp .env.example .env` gives you the
+annotated template.)
 
 Notes:
 
 - `SOURCE_DSN` is the MySQL you want to watch. The user needs
   `REPLICATION SLAVE`, `REPLICATION CLIENT`, and `SELECT`. A MySQL on the
   same machine is reachable from inside Docker as `host.docker.internal`.
-- The console is published on the **host loopback only**
-  (`127.0.0.1:8090`). To reach it from another machine, change the port
-  mapping to `"8090:8090"` and set a credential: a console password (above —
-  ideally behind TLS: `BINTRAIL_CONSOLE_TLS_CERT`/`_TLS_KEY`, or a
-  TLS-terminating proxy) or a pinned `CONSOLE_TOKEN`.
+- The console is published on the **host loopback only** (`127.0.0.1:8090`),
+  which is why first-run browser setup is allowed (the compose sets
+  `BINTRAIL_CONSOLE_ALLOW_SETUP` because the container itself binds
+  `0.0.0.0`). To reach it from another machine, **set the password from the
+  shell first** (`docker compose exec -it bintrail bintrail-console
+  user set-password` — off-loopback browser setup is refused), then change the
+  port mapping to `"8090:8090"`, ideally behind TLS
+  (`BINTRAIL_CONSOLE_TLS_CERT`/`_TLS_KEY` or a TLS-terminating proxy).
 - The credential file lives at `/var/lib/bintrail/console-auth.yaml` in the
-  `bintrail-state` volume. Remove password login with
-  `docker compose exec bintrail bintrail-console user remove --yes`. There is
-  deliberately no password environment variable — `docker inspect` must never
-  print a credential.
+  `bintrail-state` volume. **Forgot the password?** Reset it with
+  `docker compose exec -it bintrail bintrail-console user set-password`
+  (overwrites, no data lost). There is deliberately no password environment
+  variable — `docker inspect` must never print a credential.
 - `bintrail-console watch` is idempotent: restarts resume the stream from
   its saved checkpoint. The preflight (`doctor`) failing prints
   copy-pasteable remediation in the logs and the container retries.
@@ -196,7 +186,7 @@ dbtrail read it from there. The password is baked into the datadir at init,
 so `bintrail-index-data` and `bintrail-index-secret` are a pair: back them up
 together, and changing the password later means resetting both volumes.
 
-**Troubleshooting** — if `docker compose up` never prints the console URL,
+**Troubleshooting** — if `docker compose up` never gets the console listening,
 the index MySQL likely isn't healthy yet (the `bintrail` service waits for it
 via `depends_on`, so its own log stays empty until then). Check the index
 directly: `docker compose logs index-init index-mysql`. A "password" or
@@ -247,7 +237,7 @@ only the *bundled* index is 8.4.)
 | `SOURCE_DSN` | compose (optional) | DSN for a source MySQL to start watching at boot (empty = add servers from the console UI) |
 | `INDEX_DSN` | compose (optional) | Bring-your-own index MySQL (default: the bundled container) |
 | `SCHEMAS` | compose (optional) | Comma-separated schemas to track (empty = all user schemas) |
-| `CONSOLE_TOKEN` | compose (optional) | Pin your own console access token (default: generated once and persisted in the `bintrail-state` volume) |
+| `CONSOLE_TOKEN` | compose (optional) | Opt-in static API-automation token (default: none — humans sign in with the console password) |
 | `INDEX_MYSQL_ROOT_PASSWORD` | compose (optional) | Pin the bundled index root password (set *before* first boot; default: randomly generated into the `bintrail-index-secret` volume) |
 | `BINTRAIL_TAG` | compose (optional) | Image tag to run (default `latest`) |
 | `BINTRAIL_INDEX_DSN` | bintrail-mcp | Index DSN for the MCP server |

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -205,12 +205,14 @@ async function handleUnauthorized() {
   if (unauthorizedHandled) return;
   unauthorizedHandled = true;
   clearAuthState();
-  let pw = false;
-  try { pw = !!(await fetchAuthInfo()).password_login; } catch (_) {}
+  let auth = {};
+  try { auth = await fetchAuthInfo(); } catch (_) {}
+  // After a `user remove` the console can be back in first-run setup.
+  if (auth.setup) { showLoginOverlay({ setup: true }); return; }
   // Token mode has no session to expire and no form to "sign in" to — say what
   // actually happened (the stored token is no longer accepted).
-  const msg = pw ? "Session expired — sign in again." : "This access token is no longer valid.";
-  showLoginOverlay({ passwordLogin: pw, message: msg });
+  const msg = auth.password_login ? "Session expired — sign in again." : "This access token is no longer valid.";
+  showLoginOverlay({ passwordLogin: !!auth.password_login, message: msg });
 }
 
 // clearAuthState drops every credential-scoped cache on sign-out. capsCache
@@ -230,10 +232,11 @@ function clearAuthState() {
   applyAuthGate();
 }
 
-// showLoginOverlay raises the sign-in gate in #login-mount. With password
-// login enabled it renders the form; without, a persistent (non-toast)
-// pointer at the printed ?token= URL. The scrim deliberately does NOT close
-// on outside-click — it is a gate, not a dialog.
+// showLoginOverlay raises the sign-in gate in #login-mount. Three modes:
+//   - setup: true        → first-run "create your password" form (no auth yet)
+//   - passwordLogin: true → the username/password sign-in form
+//   - passwordLogin: false → a pointer at the printed ?token= URL (token mode)
+// The scrim deliberately does NOT close on outside-click — it is a gate.
 function showLoginOverlay(opts) {
   opts = opts || { passwordLogin: true };
   loginGateRaised = true;
@@ -243,8 +246,33 @@ function showLoginOverlay(opts) {
   clear(VIEW());
   const mount = document.getElementById("login-mount");
   const scrim = el("div", { class: "modal-scrim show" });
-  const panel = el("div", { class: "modal login-panel", role: "dialog", "aria-label": "Sign in" });
+  const panel = el("div", { class: "modal login-panel", role: "dialog", "aria-label": opts.setup ? "Set up console" : "Sign in" });
   panel.append(el("h2", { class: "modal-title", text: "dbtrail console" }));
+
+  if (opts.setup) {
+    panel.append(el("p", { class: "modal-desc", text: "First run — create a username and password to access this console." }));
+    const form = el("form", { class: "login-form", id: "login-form" });
+    form.append(el("label", { class: "field" },
+      el("span", { class: "field-label", text: "Username" }),
+      el("input", { class: "input", name: "username", value: "admin", autocomplete: "username", spellcheck: "false" })));
+    form.append(el("label", { class: "field" },
+      el("span", { class: "field-label", text: "Password" }),
+      el("input", { class: "input", name: "password", type: "password", autocomplete: "new-password" })));
+    form.append(el("label", { class: "field" },
+      el("span", { class: "field-label", text: "Confirm password" }),
+      el("input", { class: "input", name: "confirm", type: "password", autocomplete: "new-password" })));
+    const msg = el("div", { class: "form-msg", id: "login-msg" });
+    const foot = el("div", { class: "modal-foot" });
+    foot.append(el("button", { class: "btn btn-primary", type: "submit", text: "Create & sign in" }));
+    form.append(foot);
+    form.append(msg);
+    form.addEventListener("submit", (e) => { e.preventDefault(); submitSetup(form, msg); });
+    panel.append(form);
+    scrim.append(panel);
+    mount.replaceChildren(scrim);
+    form.elements.password.focus();
+    return;
+  }
 
   if (!opts.passwordLogin) {
     panel.append(el("p", { class: "modal-desc", text: opts.message || "" }));
@@ -274,6 +302,37 @@ function showLoginOverlay(opts) {
   scrim.append(panel);
   mount.replaceChildren(scrim);
   form.elements.password.focus();
+}
+
+// submitSetup posts the first-run credential to /api/auth/setup (raw fetch:
+// no bearer yet) and, on success, drops the gate on the returned session.
+async function submitSetup(form, msg) {
+  const password = form.elements.password.value;
+  if (password !== form.elements.confirm.value) { loginMsg(msg, "Passwords do not match."); return; }
+  const body = { username: form.elements.username.value.trim(), password };
+  let res;
+  try {
+    res = await fetch("/api/auth/setup", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  } catch (_) { loginMsg(msg, "Network error — is the console still running?"); return; }
+  if (!res.ok) {
+    let m = "Could not set the password.";
+    try { m = (await res.json()).error || m; } catch (_) {}
+    if (res.status === 429) m = "Too many attempts — wait " + (res.headers.get("Retry-After") || "60") + "s.";
+    loginMsg(msg, m);
+    return;
+  }
+  let data;
+  try { data = await res.json(); } catch (_) { loginMsg(msg, "Malformed response."); return; }
+  TOKEN = data.token || "";
+  try { sessionStorage.setItem(TOKEN_KEY, TOKEN); } catch (_) {}
+  unauthorizedHandled = false;
+  loginGateRaised = false;
+  closeLoginOverlay();
+  await bootSequence();
 }
 
 // closeLoginOverlay empties the #login-mount slot. It is used both to dismiss
@@ -1851,11 +1910,14 @@ async function init() {
   window.addEventListener("popstate", renderRoute);
 
   // Pre-auth gate: ask the (unauthenticated) probe how this console
-  // authenticates BEFORE firing data fetches that are guaranteed 401s.
+  // authenticates BEFORE firing data fetches that are guaranteed 401s. First
+  // run with no credential → create-password screen; password configured →
+  // sign-in form; token mode → the printed-link hint.
   if (!TOKEN) {
-    let pw = false;
-    try { pw = !!(await fetchAuthInfo()).password_login; } catch (_) { /* server down — fall through, the view will surface it */ }
-    if (pw) { showLoginOverlay({ passwordLogin: true }); return; }
+    let auth = {};
+    try { auth = await fetchAuthInfo(); } catch (_) { /* server down — fall through, the view will surface it */ }
+    if (auth.setup) { showLoginOverlay({ setup: true }); return; }
+    if (auth.password_login) { showLoginOverlay({ passwordLogin: true }); return; }
     toast("No token in URL — open the link printed by `bintrail-console`.");
   }
 

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -318,6 +318,16 @@ async function submitSetup(form, msg) {
       body: JSON.stringify(body),
     });
   } catch (_) { loginMsg(msg, "Network error — is the console still running?"); return; }
+  if (res.status === 403) {
+    // Setup closed under us (a concurrent `user set-password`, another tab, or
+    // a CLI set it first). Unlike login, the setup endpoint self-disables —
+    // re-probe and switch the gate to the sign-in form instead of leaving the
+    // operator stuck re-posting to a now-closed endpoint.
+    let pw = false;
+    try { pw = !!(await fetchAuthInfo()).password_login; } catch (_) {}
+    showLoginOverlay({ passwordLogin: pw, message: "A password was already created — sign in." });
+    return;
+  }
   if (!res.ok) {
     let m = "Could not set the password.";
     try { m = (await res.json()).error || m; } catch (_) {}

--- a/internal/console/auth.go
+++ b/internal/console/auth.go
@@ -2,24 +2,11 @@ package console
 
 import (
 	"context"
-	"crypto/rand"
 	"crypto/subtle"
-	"encoding/hex"
 	"net"
 	"net/http"
 	"strings"
 )
-
-// generateToken returns a cryptographically random 128-bit token rendered as
-// 32 lowercase hex characters. It is used to gate the API when the operator
-// does not supply an explicit token.
-func generateToken() (string, error) {
-	b := make([]byte, 16)
-	if _, err := rand.Read(b); err != nil {
-		return "", err
-	}
-	return hex.EncodeToString(b), nil
-}
 
 // isLoopbackAddr reports whether a listen address binds only to the loopback
 // interface. An empty host or a wildcard (0.0.0.0 / ::) binds to every

--- a/internal/console/auth_api.go
+++ b/internal/console/auth_api.go
@@ -76,14 +76,17 @@ func (s *Server) setupAllowed() bool {
 	return s.token == "" && !s.passwordLoginEnabled() && (isLoopbackAddr(s.listen) || s.allowSetup)
 }
 
-// handleSetup serves POST /api/auth/setup — the first-run, unauthenticated,
-// loopback-only password creation. It self-disables once a password exists.
+// handleSetup serves POST /api/auth/setup — the first-run, unauthenticated
+// password creation. It is gated by setupAllowed() (a loopback bind, OR a
+// non-loopback bind the operator asserted is access-controlled via
+// AllowSetup — the compose case) and self-disables the instant a password
+// exists.
 func (s *Server) handleSetup(w http.ResponseWriter, r *http.Request) {
 	if !s.setupAllowed() {
-		// Either a credential already exists or this is a non-loopback bind:
-		// creating the password is then a CLI (`user set-password`) or
-		// authenticated (change-password) action, never an open endpoint.
-		writeJSONError(w, http.StatusForbidden, "console setup is not available (a credential is already configured, or this bind is not loopback)")
+		// Either a credential already exists, or this bind is neither loopback
+		// nor marked --allow-setup. Creating the password is then a CLI
+		// (`user set-password`) or authenticated (change-password) action.
+		writeJSONError(w, http.StatusForbidden, "console setup is not available (a credential is already configured, or this bind is neither loopback nor marked --allow-setup)")
 		return
 	}
 	if !requireJSONBody(w, r) {
@@ -102,6 +105,7 @@ func (s *Server) handleSetup(w http.ResponseWriter, r *http.Request) {
 		Password string `json:"password"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.loginLimiter.Fail(ip)
 		status := http.StatusBadRequest
 		var tooLarge *http.MaxBytesError
 		if errors.As(err, &tooLarge) {
@@ -111,6 +115,7 @@ func (s *Server) handleSetup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := ValidateNewPassword(req.Password); err != nil {
+		s.loginLimiter.Fail(ip)
 		writeJSONError(w, http.StatusUnprocessableEntity, err.Error())
 		return
 	}
@@ -119,6 +124,10 @@ func (s *Server) handleSetup(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusInternalServerError, "failed to write the auth file; see server log")
 		return
 	}
+	// A successful setup closes the endpoint anyway, but clear the IP's
+	// counters for parity with login/change-password (Allow() above only
+	// throttles when Fail() has populated the per-IP windows).
+	s.loginLimiter.Success(ip)
 	token, expires, err := s.sessions.Issue()
 	if err != nil {
 		slog.Error("console session issue failed after setup", "error", err)

--- a/internal/console/auth_api.go
+++ b/internal/console/auth_api.go
@@ -41,12 +41,16 @@ func requireJSONBody(w http.ResponseWriter, r *http.Request) bool {
 }
 
 // handleAuthInfo serves GET /api/auth — unauthenticated (root mux, like
-// healthz; hostGuard still applies). It reveals only whether password login
-// exists, which the login form's existence would reveal anyway. The file is
-// statted per request so `user set-password` against a live server lights the
-// login form up without a restart.
+// healthz; hostGuard still applies). It reveals whether password login exists
+// (which the login form's existence would reveal anyway) and whether the
+// console is in first-run setup, so the SPA shows the create-password screen.
+// The file is statted per request so `user set-password` against a live server
+// lights the login form up without a restart.
 func (s *Server) handleAuthInfo(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, http.StatusOK, map[string]bool{"password_login": s.passwordLoginEnabled()})
+	writeJSON(w, http.StatusOK, map[string]bool{
+		"password_login": s.passwordLoginEnabled(),
+		"setup":          s.setupAllowed(),
+	})
 }
 
 // passwordLoginEnabled re-checks the auth file at call time. A corrupt file
@@ -58,6 +62,74 @@ func (s *Server) passwordLoginEnabled() bool {
 	}
 	a, err := LoadAuthFile(s.authPath)
 	return err != nil || a != nil
+}
+
+// setupAllowed reports whether first-run setup is open: no static token, no
+// password yet, and either a loopback bind or an explicit AllowSetup assertion
+// (the compose case — 0.0.0.0 inside the container, host-loopback published).
+// Re-evaluated live (passwordLoginEnabled stats the file), so the moment a
+// password exists — set in the browser or via the CLI — the unauthenticated
+// /api/auth/setup endpoint self-disables. The loopback-or-AllowSetup gate is
+// the load-bearing guard: an unauthenticated set-password endpoint is only
+// safe where reaching it already implies trusted (local) access.
+func (s *Server) setupAllowed() bool {
+	return s.token == "" && !s.passwordLoginEnabled() && (isLoopbackAddr(s.listen) || s.allowSetup)
+}
+
+// handleSetup serves POST /api/auth/setup — the first-run, unauthenticated,
+// loopback-only password creation. It self-disables once a password exists.
+func (s *Server) handleSetup(w http.ResponseWriter, r *http.Request) {
+	if !s.setupAllowed() {
+		// Either a credential already exists or this is a non-loopback bind:
+		// creating the password is then a CLI (`user set-password`) or
+		// authenticated (change-password) action, never an open endpoint.
+		writeJSONError(w, http.StatusForbidden, "console setup is not available (a credential is already configured, or this bind is not loopback)")
+		return
+	}
+	if !requireJSONBody(w, r) {
+		return
+	}
+	ip := clientIP(r)
+	if ok, retry := s.loginLimiter.Allow(ip); !ok {
+		secs := int(retry.Seconds()) + 1
+		w.Header().Set("Retry-After", strconv.Itoa(secs))
+		writeJSONError(w, http.StatusTooManyRequests, fmt.Sprintf("too many attempts; retry in %ds", secs))
+		return
+	}
+
+	var req struct {
+		Username string `json:"username"`
+		Password string `json:"password"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		status := http.StatusBadRequest
+		var tooLarge *http.MaxBytesError
+		if errors.As(err, &tooLarge) {
+			status = http.StatusRequestEntityTooLarge
+		}
+		writeJSONError(w, status, "invalid JSON body")
+		return
+	}
+	if err := ValidateNewPassword(req.Password); err != nil {
+		writeJSONError(w, http.StatusUnprocessableEntity, err.Error())
+		return
+	}
+	if err := SetAuthPassword(s.authPath, req.Username, req.Password); err != nil {
+		slog.Error("console setup write failed", "path", s.authPath, "error", err)
+		writeJSONError(w, http.StatusInternalServerError, "failed to write the auth file; see server log")
+		return
+	}
+	token, expires, err := s.sessions.Issue()
+	if err != nil {
+		slog.Error("console session issue failed after setup", "error", err)
+		writeJSONError(w, http.StatusInternalServerError, "password set, but failed to issue a session — sign in")
+		return
+	}
+	slog.Info("console password created via first-run setup", "remote", ip)
+	writeJSON(w, http.StatusOK, map[string]string{
+		"token":      token,
+		"expires_at": expires.UTC().Format(time.RFC3339),
+	})
 }
 
 // handleLogin serves POST /api/auth/login — unauthenticated, rate-limited,

--- a/internal/console/auth_setup_test.go
+++ b/internal/console/auth_setup_test.go
@@ -1,0 +1,117 @@
+package console
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// authInfo fetches the unauthenticated GET /api/auth probe.
+func authInfo(t *testing.T, srv *Server) map[string]bool {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "http://127.0.0.1:8090/api/auth", nil)
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("GET /api/auth = %d", rec.Code)
+	}
+	var out map[string]bool
+	json.Unmarshal(rec.Body.Bytes(), &out)
+	return out
+}
+
+func TestSetupCreatesPasswordAndSession(t *testing.T) {
+	// Loopback, no credential → setup is open.
+	path := filepath.Join(t.TempDir(), "auth.yaml")
+	srv, err := New(Config{Listen: "127.0.0.1:8090", AuthPath: path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info := authInfo(t, srv); !info["setup"] || info["password_login"] {
+		t.Fatalf("fresh loopback console: setup=%v password_login=%v, want true/false", info["setup"], info["password_login"])
+	}
+
+	rec := postJSON(t, srv, "/api/auth/setup", "", `{"username":"admin","password":"first-run-pass-1"}`)
+	if rec.Code != 200 {
+		t.Fatalf("setup = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct{ Token string }
+	json.Unmarshal(rec.Body.Bytes(), &resp)
+	if !strings.HasPrefix(resp.Token, sessionPrefix) {
+		t.Errorf("setup did not return a session token: %q", resp.Token)
+	}
+	// The returned session authenticates.
+	if r := postJSON(t, srv, "/api/auth/logout", resp.Token, `{}`); r.Code != 204 {
+		t.Errorf("setup session does not authenticate: %d", r.Code)
+	}
+	// The credential was written and verifies.
+	a, err := LoadAuthFile(path)
+	if err != nil || !a.VerifyPassword("admin", "first-run-pass-1") {
+		t.Errorf("setup credential does not verify (err=%v)", err)
+	}
+}
+
+func TestSetupSelfDisablesOncePasswordExists(t *testing.T) {
+	srv, _ := newPasswordServer(t, "", "admin", "already-set-pass") // no token, password configured
+	// A password exists → setup must be closed, login open.
+	if info := authInfo(t, srv); info["setup"] || !info["password_login"] {
+		t.Fatalf("configured console: setup=%v password_login=%v, want false/true", info["setup"], info["password_login"])
+	}
+	if rec := postJSON(t, srv, "/api/auth/setup", "", `{"username":"admin","password":"hijack-attempt"}`); rec.Code != 403 {
+		t.Errorf("setup on a configured console = %d, want 403", rec.Code)
+	}
+}
+
+func TestSetupRefusedWithToken(t *testing.T) {
+	// A static token is a credential → no setup (token mode).
+	srv, err := New(Config{Listen: "127.0.0.1:8090", Token: "tok", AuthPath: filepath.Join(t.TempDir(), "auth.yaml")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if authInfo(t, srv)["setup"] {
+		t.Error("token-configured console should not be in setup")
+	}
+	if rec := postJSON(t, srv, "/api/auth/setup", "", `{"password":"whatever-pass"}`); rec.Code != 403 {
+		t.Errorf("setup with a token configured = %d, want 403", rec.Code)
+	}
+}
+
+func TestSetupPolicyEnforced(t *testing.T) {
+	srv, err := New(Config{Listen: "127.0.0.1:8090", AuthPath: filepath.Join(t.TempDir(), "auth.yaml")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rec := postJSON(t, srv, "/api/auth/setup", "", `{"password":"short"}`); rec.Code != 422 {
+		t.Errorf("short setup password = %d, want 422", rec.Code)
+	}
+	// urlencoded body (a cross-site form) is rejected before any write.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "http://127.0.0.1:8090/api/auth/setup", strings.NewReader("password=x"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != 415 {
+		t.Errorf("form-encoded setup = %d, want 415", rec.Code)
+	}
+}
+
+func TestSetupAllowSetupNonLoopback(t *testing.T) {
+	// Non-loopback + AllowSetup (the compose case) → setup is open.
+	path := filepath.Join(t.TempDir(), "auth.yaml")
+	srv, err := New(Config{Listen: "0.0.0.0:8090", AuthPath: path, AllowSetup: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !authInfo(t, srv)["setup"] {
+		t.Fatal("non-loopback + AllowSetup should be in setup")
+	}
+	if rec := postJSON(t, srv, "/api/auth/setup", "", `{"password":"compose-setup-1"}`); rec.Code != 200 {
+		t.Errorf("setup with AllowSetup = %d, want 200", rec.Code)
+	}
+
+	// Without AllowSetup, the same bind is refused at construction.
+	if _, err := New(Config{Listen: "0.0.0.0:8090", AuthPath: filepath.Join(t.TempDir(), "x.yaml")}); err == nil {
+		t.Error("non-loopback + no credential + no AllowSetup should be refused")
+	}
+}

--- a/internal/console/auth_setup_test.go
+++ b/internal/console/auth_setup_test.go
@@ -96,6 +96,62 @@ func TestSetupPolicyEnforced(t *testing.T) {
 	}
 }
 
+func TestSetupRateLimited(t *testing.T) {
+	srv, err := New(Config{Listen: "127.0.0.1:8090", AuthPath: filepath.Join(t.TempDir(), "auth.yaml")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Rejected setup attempts must populate the per-IP window (handleSetup calls
+	// Fail) so the limiter actually throttles — otherwise Allow() is a no-op.
+	for i := 0; i < ipShortMax; i++ {
+		if rec := postJSON(t, srv, "/api/auth/setup", "", `{"password":"short"}`); rec.Code != 422 {
+			t.Fatalf("attempt %d = %d, want 422", i, rec.Code)
+		}
+	}
+	rec := postJSON(t, srv, "/api/auth/setup", "", `{"password":"short"}`)
+	if rec.Code != 429 {
+		t.Fatalf("throttled setup attempt = %d, want 429 (handleSetup must call loginLimiter.Fail)", rec.Code)
+	}
+	if rec.Header().Get("Retry-After") == "" {
+		t.Error("429 without a Retry-After header")
+	}
+}
+
+func TestSetupOversizedBody(t *testing.T) {
+	srv, err := New(Config{Listen: "127.0.0.1:8090", AuthPath: filepath.Join(t.TempDir(), "auth.yaml")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	huge := `{"password":"` + strings.Repeat("a", maxLoginBody) + `"}`
+	if rec := postJSON(t, srv, "/api/auth/setup", "", huge); rec.Code != 413 {
+		t.Errorf("oversized setup body = %d, want 413", rec.Code)
+	}
+}
+
+func TestSetupSelfDisablesOnLiveFileWrite(t *testing.T) {
+	// Pins the no-restart claim: a fresh setup-mode server that has a password
+	// written out-of-band (CLI `user set-password` against a running server)
+	// closes setup on the NEXT request — passwordLoginEnabled() stats the file
+	// live, not at New() time.
+	path := filepath.Join(t.TempDir(), "auth.yaml")
+	srv, err := New(Config{Listen: "127.0.0.1:8090", AuthPath: path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !authInfo(t, srv)["setup"] {
+		t.Fatal("fresh server should be in setup")
+	}
+	if err := SetAuthPassword(path, "admin", "out-of-band-pass"); err != nil {
+		t.Fatal(err)
+	}
+	if authInfo(t, srv)["setup"] {
+		t.Error("setup did not self-disable after the file appeared (no live re-stat)")
+	}
+	if rec := postJSON(t, srv, "/api/auth/setup", "", `{"password":"too-late-pass"}`); rec.Code != 403 {
+		t.Errorf("setup after out-of-band password = %d, want 403", rec.Code)
+	}
+}
+
 func TestSetupAllowSetupNonLoopback(t *testing.T) {
 	// Non-loopback + AllowSetup (the compose case) → setup is open.
 	path := filepath.Join(t.TempDir(), "auth.yaml")

--- a/internal/console/auth_test.go
+++ b/internal/console/auth_test.go
@@ -6,20 +6,6 @@ import (
 	"testing"
 )
 
-func TestGenerateToken(t *testing.T) {
-	a, err := generateToken()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(a) != 32 {
-		t.Errorf("token length = %d, want 32 hex chars", len(a))
-	}
-	b, _ := generateToken()
-	if a == b {
-		t.Error("two generated tokens should differ")
-	}
-}
-
 func TestIsLoopbackAddr(t *testing.T) {
 	cases := map[string]bool{
 		"127.0.0.1:8090":   true,

--- a/internal/console/auth_test.go
+++ b/internal/console/auth_test.go
@@ -39,19 +39,24 @@ func TestIsLoopbackAddr(t *testing.T) {
 	}
 }
 
-// TestNewTokenPolicy verifies the bind/token security policy: non-loopback
-// binds demand an explicit token; loopback binds auto-generate one.
+// TestNewTokenPolicy verifies the bind/credential policy: a non-loopback bind
+// with no credential is refused; a loopback bind with no credential enters
+// first-run setup (NO token is generated — password is the primary path); an
+// explicit token always stands.
 func TestNewTokenPolicy(t *testing.T) {
 	if _, err := New(Config{Listen: "0.0.0.0:8090"}); err == nil {
-		t.Error("non-loopback bind without a token should be refused")
+		t.Error("non-loopback bind without a credential should be refused")
 	}
 
 	srv, err := New(Config{Listen: "127.0.0.1:8090"})
 	if err != nil {
 		t.Fatalf("loopback bind: %v", err)
 	}
-	if srv.Token() == "" {
-		t.Error("loopback bind should auto-generate a token")
+	if srv.Token() != "" {
+		t.Errorf("loopback bind with no credential auto-generated a token %q — should enter setup instead", srv.Token())
+	}
+	if !srv.NeedsSetup() {
+		t.Error("loopback bind with no credential should report NeedsSetup")
 	}
 
 	srv2, err := New(Config{Listen: "0.0.0.0:9000", Token: "explicit-token"})
@@ -60,6 +65,18 @@ func TestNewTokenPolicy(t *testing.T) {
 	}
 	if srv2.Token() != "explicit-token" {
 		t.Errorf("Token() = %q, want explicit-token", srv2.Token())
+	}
+	if srv2.NeedsSetup() {
+		t.Error("a token-configured server is not in setup")
+	}
+
+	// AllowSetup makes a non-loopback bind legal and puts it in setup mode.
+	srv3, err := New(Config{Listen: "0.0.0.0:9001", AllowSetup: true})
+	if err != nil {
+		t.Fatalf("non-loopback bind with AllowSetup: %v", err)
+	}
+	if !srv3.NeedsSetup() {
+		t.Error("AllowSetup non-loopback bind should report NeedsSetup")
 	}
 }
 

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -151,9 +151,9 @@ func New(cfg Config) (*Server, error) {
 	// token is an opt-in automation credential (set explicitly, never
 	// generated). With neither a token nor a password:
 	//   - loopback → first-run SETUP: no token is generated, and the
-	//     unauthenticated, loopback-only /api/auth/setup endpoint lets the
-	//     operator create the password in the browser. The rest of the API
-	//     stays locked (token "" + no session ⇒ 401) until they do.
+	//     unauthenticated /api/auth/setup endpoint lets the operator create the
+	//     password in the browser. The rest of the API stays locked (token "" +
+	//     no session ⇒ 401) until they do.
 	//   - non-loopback → refused: an unauthenticated setup endpoint off-host
 	//     would let the first stranger to reach it claim the password.
 	// An explicit token always stands; a configured password makes
@@ -327,10 +327,10 @@ func (s *Server) Token() string { return s.token }
 func (s *Server) PasswordLogin() bool { return s.passwordCfg }
 
 // NeedsSetup reports whether the console is in first-run setup: no credential
-// at all on a loopback bind, so the operator must create a password in the
-// browser (via the unauthenticated, loopback-only /api/auth/setup endpoint).
-// The cmd layer uses it to print "create your password" instead of a URL with
-// a token.
+// at all, on a loopback bind (or a non-loopback bind the operator marked
+// access-controlled via --allow-setup), so the operator must create a password
+// in the browser (via the unauthenticated /api/auth/setup endpoint). The cmd
+// layer uses it to print "create your password" instead of a URL with a token.
 func (s *Server) NeedsSetup() bool { return s.setupAllowed() }
 
 // URL returns the bootstrap URL the operator opens in a browser. Token mode

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -45,9 +45,10 @@ type Config struct {
 	Registry *Registry
 	// Listen is the bind address (host:port). Default 127.0.0.1:8090.
 	Listen string
-	// Token gates the API. When empty and Listen is loopback, a random token
-	// is generated. When empty and Listen is non-loopback, New returns an
-	// error — exposing an unauthenticated console off-host is refused.
+	// Token is an OPT-IN static automation credential — set it explicitly for
+	// scripts/curl. It is never generated. Password login is the primary path:
+	// with no token and no password, a loopback bind (or AllowSetup) enters
+	// first-run setup, and a non-loopback bind is refused.
 	Token string
 	// NoArchive disables Parquet archive auto-discovery on the boot entry.
 	// The caller forces this true when a profile is active (archives do not
@@ -82,6 +83,14 @@ type Config struct {
 	// files only — rotation is a restart; ACME is out of scope.
 	TLSCert string
 	TLSKey  string
+	// AllowSetup permits browser first-run password setup on a NON-loopback
+	// bind — an assertion that the bind is access-controlled by other means.
+	// The compose stack sets it because it binds 0.0.0.0 inside the container
+	// but publishes the port on the host's loopback only; the container can't
+	// see that host mapping, so the operator asserts it. Loopback binds always
+	// allow setup regardless. Off by default: an unguarded setup endpoint on a
+	// truly public bind would let the first stranger claim the password.
+	AllowSetup bool
 }
 
 // Server is a configured, ready-to-run console HTTP server. It holds only
@@ -104,6 +113,7 @@ type Server struct {
 	// boot-time existence, which drives the bind gate and the printed banner.
 	authPath     string
 	passwordCfg  bool
+	allowSetup   bool // assert a non-loopback bind is access-controlled (compose)
 	sessions     *sessionStore
 	loginLimiter *loginLimiter
 	tlsConf      *tls.Config
@@ -136,26 +146,32 @@ func New(cfg Config) (*Server, error) {
 		return nil, err
 	}
 	passwordCfg := authFile != nil
-	if explicitAuthPath && !passwordCfg {
-		slog.Warn("console auth file not found — password login disabled until it is created with `bintrail-console user set-password`", "path", authPath)
-	}
 
-	// Bind/credential policy: an explicit token always stands. With a
-	// password configured and no token, NO token is auto-generated (the
-	// printed ?token= URL would leak a live credential into logs and shell
-	// history for nothing) and non-loopback binds are legal — the password is
-	// the auth. With neither credential, the pre-auth behavior is unchanged:
-	// loopback auto-generates, non-loopback refuses.
+	// Bind/credential policy. Password login is the primary path; the static
+	// token is an opt-in automation credential (set explicitly, never
+	// generated). With neither a token nor a password:
+	//   - loopback → first-run SETUP: no token is generated, and the
+	//     unauthenticated, loopback-only /api/auth/setup endpoint lets the
+	//     operator create the password in the browser. The rest of the API
+	//     stays locked (token "" + no session ⇒ 401) until they do.
+	//   - non-loopback → refused: an unauthenticated setup endpoint off-host
+	//     would let the first stranger to reach it claim the password.
+	// An explicit token always stands; a configured password makes
+	// non-loopback binds legal. A non-loopback bind with no credential is
+	// refused UNLESS the operator asserts the bind is access-controlled
+	// (AllowSetup) — then it enters setup like a loopback bind would.
 	token := cfg.Token
-	if token == "" && !passwordCfg {
-		if !isLoopbackAddr(listen) {
-			return nil, fmt.Errorf("authentication is required when binding to a non-loopback address %q: set --token / BINTRAIL_CONSOLE_TOKEN, or set a console password with `bintrail-console user set-password`", listen)
-		}
-		t, err := generateToken()
-		if err != nil {
-			return nil, fmt.Errorf("generate token: %w", err)
-		}
-		token = t
+	noCredential := token == "" && !passwordCfg
+	willSetup := noCredential && (isLoopbackAddr(listen) || cfg.AllowSetup)
+	if noCredential && !willSetup {
+		return nil, fmt.Errorf("authentication is required when binding to a non-loopback address %q: set a console password with `bintrail-console user set-password`, set --token / BINTRAIL_CONSOLE_TOKEN for automation, or pass --allow-setup if this bind is access-controlled (e.g. published only on the host's loopback)", listen)
+	}
+	// A missing auth file is the EXPECTED first-run state (browser setup creates
+	// it). Only warn about a missing explicit --auth-file when setup is NOT the
+	// path — i.e. a token is configured (password login genuinely disabled until
+	// the file exists), which usually means a typo'd path.
+	if explicitAuthPath && !passwordCfg && !willSetup {
+		slog.Warn("console auth file not found — password login disabled until it is created with `bintrail-console user set-password`", "path", authPath)
 	}
 
 	var tlsConf *tls.Config
@@ -177,6 +193,12 @@ func New(cfg Config) (*Server, error) {
 	if passwordCfg && tlsConf == nil && !isLoopbackAddr(listen) {
 		slog.Warn("the console password will transit plain HTTP on a non-loopback address — set --tls-cert/--tls-key or terminate TLS at a reverse proxy", "listen", listen)
 	}
+	// First-run setup is open until a password exists. On a non-loopback bind
+	// that means anyone who can reach this port could claim the password — a
+	// one-time, first-run-only message (it stops once the password is set).
+	if noCredential && !isLoopbackAddr(listen) && cfg.AllowSetup {
+		slog.Warn("first-run password setup is OPEN — create the console password before this port is reachable from untrusted networks", "listen", listen)
+	}
 
 	// Safety coupling enforced here so it holds for every caller, not just the
 	// CLI: Parquet archives do not apply RBAC rules, so the presence of any
@@ -196,6 +218,7 @@ func New(cfg Config) (*Server, error) {
 		cm:           newConnManager(cfg.Registry, profileActive),
 		authPath:     authPath,
 		passwordCfg:  passwordCfg,
+		allowSetup:   cfg.AllowSetup,
 		sessions:     newSessionStore(),
 		loginLimiter: newLoginLimiter(),
 		tlsConf:      tlsConf,
@@ -285,8 +308,9 @@ func (s *Server) buildHandler() http.Handler {
 	// boots from, and login itself.
 	root.HandleFunc("GET /api/auth", s.handleAuthInfo)
 	root.HandleFunc("POST /api/auth/login", s.handleLogin)
-	root.Handle("/api/", s.tokenMiddleware(api)) // credential on all other /api/*
-	root.Handle("/", assetHandler())             // static shell + assets
+	root.HandleFunc("POST /api/auth/setup", s.handleSetup) // first-run, loopback-only, self-disables
+	root.Handle("/api/", s.tokenMiddleware(api))           // credential on all other /api/*
+	root.Handle("/", assetHandler())                       // static shell + assets
 
 	return s.hostGuard(securityHeaders(root))
 }
@@ -301,6 +325,13 @@ func (s *Server) Token() string { return s.token }
 // PasswordLogin reports whether a console password was configured at boot —
 // the cmd layer keys its banner wording on it.
 func (s *Server) PasswordLogin() bool { return s.passwordCfg }
+
+// NeedsSetup reports whether the console is in first-run setup: no credential
+// at all on a loopback bind, so the operator must create a password in the
+// browser (via the unauthenticated, loopback-only /api/auth/setup endpoint).
+// The cmd layer uses it to print "create your password" instead of a URL with
+// a token.
+func (s *Server) NeedsSetup() bool { return s.setupAllowed() }
 
 // URL returns the bootstrap URL the operator opens in a browser. Token mode
 // includes the jupyter-style ?token=; password mode omits it (printing a live


### PR DESCRIPTION
Per the product decision: **password is the only way in**, with a smooth first-run and a documented reset. The static token becomes opt-in automation only.

## What changes

- **First-run browser setup.** A fresh loopback console with no credential serves a **"create your username + password"** screen on first visit (new unauthenticated `POST /api/auth/setup`, root mux). It mints a session and signs you in. Every later visit is a normal sign-in.
- **The setup endpoint is loopback-gated and self-disabling.** `setupAllowed()` = no token AND no password AND (loopback OR `--allow-setup`); it re-reads the credential file live, so the instant a password exists it 403s. The loopback requirement is the load-bearing guard (reaching it implies local access).
- **`--allow-setup` / `BINTRAIL_CONSOLE_ALLOW_SETUP`** bridges the container reality: the compose binds `0.0.0.0` inside the container but publishes on the host's loopback, so it asserts the bind is access-controlled. A loud startup warning fires while setup is open off-loopback.
- **No token is generated anymore.** `--token` / `CONSOLE_TOKEN` is opt-in automation; the compose entrypoint dropped the token-generation block.
- **Reset for a forgotten password:** `docker compose exec -it bintrail bintrail-console user set-password` (overwrites, no data lost). `user remove` returns a loopback console to first-run setup.

## Bind/credential matrix (all tested)

| token | password | bind | result |
|---|---|---|---|
| — | — | loopback | first-run setup |
| — | — | non-loopback | refused (unless `--allow-setup` → setup) |
| — | set | any | login form |
| set | any | any | token mode (no setup screen) |

## Upgrade from 0.11.0

Password users: unaffected (login form). Anyone who relied on the auto-generated compose token (bookmarked `?token=` URL, or token automation with no explicit `CONSOLE_TOKEN`): the token is gone → the bookmarked URL lands on the create-password screen after one graceful 401 (verified), and automation must pin `CONSOLE_TOKEN`. **BREAKING-flagged in the CHANGELOG** with the upgrade path. This reverses 0.11.0's token-persistence behavior, so it warrants a minor bump (0.12.0).

## Tests & verification

- Go: `auth_setup_test.go` (setup creates password+session, self-disables to 403, refused with a token, policy/415 enforced, AllowSetup non-loopback), rewritten `TestNewTokenPolicy` (loopback no-cred → setup, no token generated), `--allow-setup` env fallback on serve+watch. Full unit + `-race` + integration (8.0/8.4) green.
- Headless-Chrome (12 assertions): fresh setup screen → confirm-mismatch error → short-password policy error → create → logged-in Overview → setup self-disables (403) → returning visit shows the **login** form. Visual screenshot confirms the setup card.
- Adversarial review (4 lenses × 2 refuters): the unauthenticated-setup **TOCTOU race was refuted** (inside the trust boundary — only loopback/host-loopback callers reach it). 3 confirmed findings, all doc/help accuracy, fixed in the second commit (stale `--token` help in serve/watch, the docs flags-table row, the missing CHANGELOG entry, and a tightened "off-loopback setup" wording).

Docs swept: README, docs/console.md, docs/docker.md, compose comments, `.env.example`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)