### PR TITLE
feat(console): configure per-source S3 archiving from the UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Configure S3 archiving for a monitored source from the console UI.** A new "Archive to S3" field on a monitored server (under `bintrail-console watch`) takes an `s3://bucket/prefix/` destination; the daemon's built-in rotation then uploads that source's rotated partitions as Parquet **before** dropping them, so the forensic record survives the retention window and the console auto-discovers it on the next query — no extra setup. Partitions are staged locally (`--archive-staging-dir` / `BINTRAIL_CONSOLE_ARCHIVE_STAGING`), uploaded with the ambient AWS credential chain (`AWS_*` / `~/.aws` / instance role), then pruned. Archiving begins once a source's identity is resolved; until then it rotates drop-only and the protect-unarchived guard never drops un-uploaded data. The Docker Compose stack now passes `AWS_*` through from `.env` and stages under the state volume. (Archive S3 is the write side; the existing `Baseline S3` field is the read-side Time-travel input — they are distinct.)
+
 ## [0.12.0] - 2026-06-10
 
 ### Changed

--- a/cmd/bintrail-console/monitor.go
+++ b/cmd/bintrail-console/monitor.go
@@ -513,12 +513,32 @@ func (m *monitorSupervisor) Stop(ctx context.Context, entryID string) error {
 // warning until superseded or stopped — deliberate: the broken entry should
 // stay loud, and Stop() removes it from the map.
 func (m *monitorSupervisor) ActiveIndexDSNs() []string {
+	jobs := m.ActiveJobs()
+	out := make([]string, 0, len(jobs))
+	for _, j := range jobs {
+		out = append(out, j.IndexDSN)
+	}
+	return out
+}
+
+// ActiveJob pairs a supervised entry's id with its per-source index DSN, so the
+// rotation provider can look the entry up in the registry (for its ArchiveS3)
+// and read its resolved bintrail_id.
+type ActiveJob struct {
+	EntryID  string
+	IndexDSN string
+}
+
+// ActiveJobs returns one ActiveJob per supervised job with a known index DSN —
+// the per-source databases the built-in rotation covers alongside the boot
+// index. Same inclusion rules as ActiveIndexDSNs (every job state).
+func (m *monitorSupervisor) ActiveJobs() []ActiveJob {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	out := make([]string, 0, len(m.jobs))
-	for _, j := range m.jobs {
+	out := make([]ActiveJob, 0, len(m.jobs))
+	for id, j := range m.jobs {
 		if j.indexDSN != "" {
-			out = append(out, j.indexDSN)
+			out = append(out, ActiveJob{EntryID: id, IndexDSN: j.indexDSN})
 		}
 	}
 	return out

--- a/cmd/bintrail-console/monitor.go
+++ b/cmd/bintrail-console/monitor.go
@@ -503,24 +503,6 @@ func (m *monitorSupervisor) Stop(ctx context.Context, entryID string) error {
 	return nil
 }
 
-// ActiveIndexDSNs returns the per-source index DSNs of every supervised job.
-// The built-in `up` rotation uses it to cover the databases the control plane
-// provisions (bintrail_idx_<entry>) in addition to the boot index DB. Jobs in
-// every state are included: a crash-looping stream's database still ages past
-// retention, and a DSN whose database is mid-provisioning logs one transient
-// rotation warning and self-heals next tick. A job whose provisioning failed
-// TERMINALLY (bad perms, DDL error) keeps producing a per-cycle rotation
-// warning until superseded or stopped — deliberate: the broken entry should
-// stay loud, and Stop() removes it from the map.
-func (m *monitorSupervisor) ActiveIndexDSNs() []string {
-	jobs := m.ActiveJobs()
-	out := make([]string, 0, len(jobs))
-	for _, j := range jobs {
-		out = append(out, j.IndexDSN)
-	}
-	return out
-}
-
 // ActiveJob pairs a supervised entry's id with its per-source index DSN, so the
 // rotation provider can look the entry up in the registry (for its ArchiveS3)
 // and read its resolved bintrail_id.
@@ -531,7 +513,12 @@ type ActiveJob struct {
 
 // ActiveJobs returns one ActiveJob per supervised job with a known index DSN —
 // the per-source databases the built-in rotation covers alongside the boot
-// index. Same inclusion rules as ActiveIndexDSNs (every job state).
+// index. Jobs in every state are included: a crash-looping stream's database
+// still ages past retention, and a DSN whose database is mid-provisioning logs
+// one transient rotation warning and self-heals next tick. A job whose
+// provisioning failed TERMINALLY (bad perms, DDL error) keeps producing a
+// per-cycle rotation warning until superseded or stopped — deliberate: the
+// broken entry should stay loud, and Stop() removes it from the map.
 func (m *monitorSupervisor) ActiveJobs() []ActiveJob {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/cmd/bintrail-console/monitor_test.go
+++ b/cmd/bintrail-console/monitor_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/dbtrail/dbtrail/internal/streamrun"
 )
 
-// ─── built-in rotation DSN provider (#420) ───────────────────────────────────
+// ─── built-in rotation job provider (#420) ───────────────────────────────────
 
-func TestActiveIndexDSNs(t *testing.T) {
+func TestActiveJobs(t *testing.T) {
 	m := &monitorSupervisor{
 		jobs: map[string]*monitorJob{
 			"a": {indexDSN: "root@tcp(idx:3306)/bintrail_idx_a"},
@@ -21,16 +21,19 @@ func TestActiveIndexDSNs(t *testing.T) {
 			"c": {indexDSN: ""}, // never published a DSN — skipped
 		},
 	}
-	got := m.ActiveIndexDSNs()
+	got := m.ActiveJobs()
 	if len(got) != 2 {
-		t.Fatalf("ActiveIndexDSNs returned %d DSNs, want 2: %v", len(got), got)
+		t.Fatalf("ActiveJobs returned %d jobs, want 2: %v", len(got), got)
 	}
-	seen := map[string]bool{}
-	for _, dsn := range got {
-		seen[dsn] = true
+	seen := map[string]string{}
+	for _, j := range got {
+		seen[j.EntryID] = j.IndexDSN
 	}
-	if !seen["root@tcp(idx:3306)/bintrail_idx_a"] || !seen["root@tcp(idx:3306)/bintrail_idx_b"] {
-		t.Errorf("ActiveIndexDSNs missing expected DSNs: %v", got)
+	if seen["a"] != "root@tcp(idx:3306)/bintrail_idx_a" || seen["b"] != "root@tcp(idx:3306)/bintrail_idx_b" {
+		t.Errorf("ActiveJobs missing expected entry→DSN pairs: %v", got)
+	}
+	if _, ok := seen["c"]; ok {
+		t.Error("ActiveJobs must skip a job with an empty index DSN")
 	}
 }
 

--- a/cmd/bintrail-console/watch.go
+++ b/cmd/bintrail-console/watch.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -73,6 +74,7 @@ var (
 	upConsoleTLSKey      string
 	upConsoleAllowedHost []string
 	upConsoleAllowSetup  bool
+	upArchiveStageDir    string
 
 	upRotateRetain    string
 	upRotateInterval  string
@@ -150,6 +152,7 @@ func init() {
 	watchCmd.Flags().StringVar(&upConsoleTLSKey, "console-tls-key", "", "TLS private key file (PEM; requires --console-tls-cert)")
 	watchCmd.Flags().StringSliceVar(&upConsoleAllowedHost, "console-allowed-hosts", nil, "Extra hostnames allowed in the Host header (for a TLS-terminating reverse proxy); IP literals and localhost are always allowed")
 	watchCmd.Flags().BoolVar(&upConsoleAllowSetup, "console-allow-setup", false, "Allow browser first-run password setup on a non-loopback bind (assert the bind is access-controlled, e.g. published only on the host loopback)")
+	watchCmd.Flags().StringVar(&upArchiveStageDir, "archive-staging-dir", "", "Local staging directory for S3 archive uploads (default: OS temp dir). Rotated Parquet is written here, uploaded to a source's configured Archive S3 bucket, then pruned.")
 	watchCmd.Flags().StringVar(&upRotateRetain, "rotate-retain", "30d", "Built-in rotation: drop index partitions older than this (Nd/Nh; \"off\" disables)")
 	watchCmd.Flags().StringVar(&upRotateInterval, "rotate-interval", "1h", "Built-in rotation: how often to run a rotation cycle")
 	watchCmd.Flags().IntVar(&upRotateAddFuture, "rotate-add-future", 3, "Built-in rotation: keep at least N future hourly partitions ready")
@@ -345,8 +348,8 @@ func runUpConsoleOnly(cmd *cobra.Command) error {
 	// Built-in rotation covers the boot index plus every per-source database
 	// the control plane provisions — the unattended quickstart's real data
 	// lives in the latter.
-	rotation.StartLoop(ctx, upRotationCfg, func() []string {
-		return append([]string{upIndexDSN}, supervisor.ActiveIndexDSNs()...)
+	rotation.StartLoop(ctx, upRotationCfg, func() []rotation.RotateTarget {
+		return rotateTargets(upIndexDSN, supervisor, registry, archiveStagingDir())
 	})
 
 	srv, err := console.New(cfg)
@@ -441,8 +444,8 @@ func runUpStreamWithConsole(cmd *cobra.Command, args []string) error {
 
 	// Built-in rotation: boot index + every per-source database the control
 	// plane provisions, on the daemon lifecycle.
-	rotation.StartLoop(ctx, upRotationCfg, func() []string {
-		return append([]string{upIndexDSN}, supervisor.ActiveIndexDSNs()...)
+	rotation.StartLoop(ctx, upRotationCfg, func() []rotation.RotateTarget {
+		return rotateTargets(upIndexDSN, supervisor, registry, archiveStagingDir())
 	})
 
 	// With the console comes the multi-stream control plane, so /metrics is
@@ -577,6 +580,11 @@ func resolveUpConsoleEnv(cmd *cobra.Command) {
 			upConsoleAllowSetup = true
 		}
 	}
+	if !cmd.Flags().Changed("archive-staging-dir") {
+		if v := os.Getenv("BINTRAIL_CONSOLE_ARCHIVE_STAGING"); v != "" {
+			upArchiveStageDir = v
+		}
+	}
 }
 
 // consoleOpts carries watch's console-surface settings into upConsoleConfig —
@@ -642,4 +650,62 @@ func upConsoleConfig(db *sql.DB, indexDSN string, opts consoleOpts) (console.Con
 		// registry and the daemon lifecycle context, which this config builder
 		// doesn't have.
 	}, nil
+}
+
+// archiveStagingDir resolves the local staging base for S3 archive uploads
+// (--archive-staging-dir / BINTRAIL_CONSOLE_ARCHIVE_STAGING). A lost staging
+// dir self-heals: an un-uploaded partition is never dropped, so the next cycle
+// re-archives it from the still-present partition. Default: a temp subdir.
+func archiveStagingDir() string {
+	if upArchiveStageDir != "" {
+		return upArchiveStageDir
+	}
+	return filepath.Join(os.TempDir(), "bintrail-archive-staging")
+}
+
+// rotateTargets assembles the built-in rotation's per-cycle targets: the boot
+// index (drop-only — the ephemeral default entry has no registry archive
+// config) plus every supervised source. A source whose registry entry carries
+// an Archive S3 bucket archives-then-drops to it, but ONLY once its bintrail_id
+// is resolved (read from stream_state) — until then it rotates drop-only and
+// the engine's protect-unarchived guard keeps it from losing data.
+func rotateTargets(bootDSN string, sup *monitorSupervisor, reg *console.Registry, stagingBase string) []rotation.RotateTarget {
+	targets := []rotation.RotateTarget{{DSN: bootDSN}}
+	for _, j := range sup.ActiveJobs() {
+		t := rotation.RotateTarget{DSN: j.IndexDSN}
+		if entry, ok := reg.Get(j.EntryID); ok && entry.ArchiveS3 != "" {
+			if id := resolveBintrailIDFunc(j.IndexDSN); id != "" {
+				t.ArchiveS3 = entry.ArchiveS3
+				t.ArchiveDir = filepath.Join(stagingBase, j.EntryID)
+				t.BintrailID = id
+				t.ArchiveCompression = "zstd"
+			} else {
+				slog.Debug("archive-to-S3 configured but the source's bintrail_id is not yet resolved; rotating drop-only this cycle", "entry", j.EntryID)
+			}
+		}
+		targets = append(targets, t)
+	}
+	return targets
+}
+
+// resolveBintrailIDFunc is the seam tests stub to avoid a real DB.
+var resolveBintrailIDFunc = resolveBintrailID
+
+// resolveBintrailID reads a source's resolved server identity from its index
+// stream_state — the UUID archives are partitioned under (bintrail_id=<uuid>).
+// Returns "" when unreadable or not yet resolved (the stream sets it after its
+// first connect), in which case archiving for that source waits a cycle.
+func resolveBintrailID(indexDSN string) string {
+	db, err := config.Connect(indexDSN)
+	if err != nil {
+		return ""
+	}
+	defer db.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var id sql.NullString
+	if err := db.QueryRowContext(ctx, "SELECT bintrail_id FROM stream_state WHERE id = 1").Scan(&id); err != nil {
+		return ""
+	}
+	return id.String
 }

--- a/cmd/bintrail-console/watch.go
+++ b/cmd/bintrail-console/watch.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -674,13 +675,23 @@ func rotateTargets(bootDSN string, sup *monitorSupervisor, reg *console.Registry
 	for _, j := range sup.ActiveJobs() {
 		t := rotation.RotateTarget{DSN: j.IndexDSN}
 		if entry, ok := reg.Get(j.EntryID); ok && entry.ArchiveS3 != "" {
-			if id := resolveBintrailIDFunc(j.IndexDSN); id != "" {
+			id, err := resolveBintrailIDFunc(j.IndexDSN)
+			switch {
+			case err != nil:
+				// A real DB error reading stream_state must not masquerade as
+				// "identity not yet resolved": that would let a permanently
+				// stalled archive (bad perms, unreachable index) rotate drop-only
+				// forever with only a Debug line. Surface it at Warn so an
+				// operator can tell archiving stalled from archiving being off.
+				slog.Warn("archive-to-S3 configured but reading the source's bintrail_id failed; rotating drop-only this cycle",
+					"entry", j.EntryID, "error", err)
+			case id == "":
+				slog.Debug("archive-to-S3 configured but the source's bintrail_id is not yet resolved; rotating drop-only this cycle", "entry", j.EntryID)
+			default:
 				t.ArchiveS3 = entry.ArchiveS3
 				t.ArchiveDir = filepath.Join(stagingBase, j.EntryID)
 				t.BintrailID = id
 				t.ArchiveCompression = "zstd"
-			} else {
-				slog.Debug("archive-to-S3 configured but the source's bintrail_id is not yet resolved; rotating drop-only this cycle", "entry", j.EntryID)
 			}
 		}
 		targets = append(targets, t)
@@ -693,19 +704,25 @@ var resolveBintrailIDFunc = resolveBintrailID
 
 // resolveBintrailID reads a source's resolved server identity from its index
 // stream_state — the UUID archives are partitioned under (bintrail_id=<uuid>).
-// Returns "" when unreadable or not yet resolved (the stream sets it after its
-// first connect), in which case archiving for that source waits a cycle.
-func resolveBintrailID(indexDSN string) string {
+// Returns ("", nil) when the stream has not resolved its identity yet (no
+// stream_state row, or a NULL/empty bintrail_id) — archiving waits a cycle.
+// Returns ("", err) on a genuine failure (connect or query error) so the caller
+// can distinguish a transient/persistent fault from "not yet resolved" and log
+// it loudly rather than letting a stalled archive look like a normal wait.
+func resolveBintrailID(indexDSN string) (string, error) {
 	db, err := config.Connect(indexDSN)
 	if err != nil {
-		return ""
+		return "", fmt.Errorf("connect: %w", err)
 	}
 	defer db.Close()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	var id sql.NullString
 	if err := db.QueryRowContext(ctx, "SELECT bintrail_id FROM stream_state WHERE id = 1").Scan(&id); err != nil {
-		return ""
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", nil // no checkpoint row yet — identity not resolved, not a fault
+		}
+		return "", fmt.Errorf("read stream_state: %w", err)
 	}
-	return id.String
+	return id.String, nil
 }

--- a/cmd/bintrail-console/watch_test.go
+++ b/cmd/bintrail-console/watch_test.go
@@ -295,15 +295,18 @@ func TestRotateTargets(t *testing.T) {
 			arch.ID:      {indexDSN: "dsn-arch"},
 			plain.ID:     {indexDSN: "dsn-plain"},
 			pendingID.ID: {indexDSN: "dsn-pending"},
+			// A job whose registry entry was deleted between cycles (reg.Get
+			// returns !ok). It must still rotate — drop-only — never vanish.
+			"ghost": {indexDSN: "dsn-ghost"},
 		},
 	}
 
 	prev := resolveBintrailIDFunc
-	resolveBintrailIDFunc = func(dsn string) string {
+	resolveBintrailIDFunc = func(dsn string) (string, error) {
 		if dsn == "dsn-pending" {
-			return "" // identity not yet resolved → archive waits
+			return "", nil // identity not yet resolved → archive waits
 		}
-		return "uuid-" + dsn
+		return "uuid-" + dsn, nil
 	}
 	t.Cleanup(func() { resolveBintrailIDFunc = prev })
 
@@ -331,6 +334,11 @@ func TestRotateTargets(t *testing.T) {
 	}
 	if pend := byDSN["dsn-pending"]; pend.ArchiveS3 != "" {
 		t.Errorf("unresolved-bintrail_id source must rotate drop-only until resolved, got %+v", pend)
+	}
+	if ghost, ok := byDSN["dsn-ghost"]; !ok {
+		t.Error("a job whose registry entry was deleted must still produce a (drop-only) target, not vanish")
+	} else if ghost.ArchiveS3 != "" {
+		t.Errorf("deleted-entry job must rotate drop-only, got %+v", ghost)
 	}
 }
 

--- a/cmd/bintrail-console/watch_test.go
+++ b/cmd/bintrail-console/watch_test.go
@@ -4,6 +4,9 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+
+	"github.com/dbtrail/dbtrail/internal/console"
+	"github.com/dbtrail/dbtrail/internal/rotation"
 )
 
 // This file mutates up* package globals via save-and-restore. DO NOT add
@@ -262,4 +265,87 @@ func TestResolveUpConsoleEnvAuthTLS(t *testing.T) {
 	assertStr(t, "upConsoleAuthFile (flag)", upConsoleAuthFile, "/flag/auth.yaml")
 	assertStr(t, "upConsoleTLSCert (flag)", upConsoleTLSCert, "/flag/cert.pem")
 	assertStr(t, "upConsoleTLSKey (flag)", upConsoleTLSKey, "/flag/key.pem")
+}
+
+// TestRotateTargets covers the per-source archive wiring: the boot index is
+// drop-only; a source whose registry entry has an Archive S3 bucket archives
+// to it (with a per-entry staging dir + resolved bintrail_id); a source with
+// no bucket, or whose bintrail_id is unresolved, rotates drop-only.
+func TestRotateTargets(t *testing.T) {
+	reg, err := console.LoadRegistry("") // in-memory
+	if err != nil {
+		t.Fatal(err)
+	}
+	arch, err := reg.Add(console.ServerEntry{Name: "src-archived", ArchiveS3: "s3://bucket/prefix/"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	plain, err := reg.Add(console.ServerEntry{Name: "src-plain"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pendingID, err := reg.Add(console.ServerEntry{Name: "src-archived-pending", ArchiveS3: "s3://bucket/pending/"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sup := &monitorSupervisor{
+		registry: reg,
+		jobs: map[string]*monitorJob{
+			arch.ID:      {indexDSN: "dsn-arch"},
+			plain.ID:     {indexDSN: "dsn-plain"},
+			pendingID.ID: {indexDSN: "dsn-pending"},
+		},
+	}
+
+	prev := resolveBintrailIDFunc
+	resolveBintrailIDFunc = func(dsn string) string {
+		if dsn == "dsn-pending" {
+			return "" // identity not yet resolved → archive waits
+		}
+		return "uuid-" + dsn
+	}
+	t.Cleanup(func() { resolveBintrailIDFunc = prev })
+
+	targets := rotateTargets("boot-dsn", sup, reg, "/stage")
+	byDSN := map[string]rotation.RotateTarget{}
+	for _, tg := range targets {
+		byDSN[tg.DSN] = tg
+	}
+
+	if boot := byDSN["boot-dsn"]; boot.ArchiveS3 != "" {
+		t.Errorf("boot index must be drop-only, got ArchiveS3=%q", boot.ArchiveS3)
+	}
+	a := byDSN["dsn-arch"]
+	if a.ArchiveS3 != "s3://bucket/prefix/" || a.BintrailID != "uuid-dsn-arch" {
+		t.Errorf("archived source target wrong: %+v", a)
+	}
+	if a.ArchiveDir != "/stage/"+arch.ID {
+		t.Errorf("staging dir = %q, want /stage/%s", a.ArchiveDir, arch.ID)
+	}
+	if a.ArchiveCompression != "zstd" {
+		t.Errorf("compression = %q, want zstd", a.ArchiveCompression)
+	}
+	if p := byDSN["dsn-plain"]; p.ArchiveS3 != "" {
+		t.Errorf("no-bucket source must be drop-only, got %+v", p)
+	}
+	if pend := byDSN["dsn-pending"]; pend.ArchiveS3 != "" {
+		t.Errorf("unresolved-bintrail_id source must rotate drop-only until resolved, got %+v", pend)
+	}
+}
+
+func TestArchiveStagingEnvFallback(t *testing.T) {
+	saved := upArchiveStageDir
+	t.Cleanup(func() { upArchiveStageDir = saved })
+	if watchCmd.Flags().Lookup("archive-staging-dir") == nil {
+		t.Fatal("flag --archive-staging-dir not registered on watchCmd")
+	}
+	cmd := &cobra.Command{}
+	cmd.Flags().StringVar(&upArchiveStageDir, "archive-staging-dir", "", "")
+	t.Setenv("BINTRAIL_CONSOLE_ARCHIVE_STAGING", "/env/staging")
+	upArchiveStageDir = ""
+	resolveUpConsoleEnv(cmd)
+	if upArchiveStageDir != "/env/staging" {
+		t.Errorf("archive-staging-dir from env = %q, want /env/staging", upArchiveStageDir)
+	}
 }

--- a/cmd/bintrail/up.go
+++ b/cmd/bintrail/up.go
@@ -193,8 +193,10 @@ func runUpStream(cmd *cobra.Command, args []string) error {
 	// when the stream starts draining.
 	rotCtx, rotStop := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
 	defer rotStop()
-	rotation.StartLoop(rotCtx, upRotationCfg, func() []string {
-		return []string{upIndexDSN}
+	// Core `up` is single-source and has no control plane / registry, so its
+	// rotation is drop-only (no per-source S3 archive config).
+	rotation.StartLoop(rotCtx, upRotationCfg, func() []rotation.RotateTarget {
+		return []rotation.RotateTarget{{DSN: upIndexDSN}}
 	})
 	return runStream(cmd, args)
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -162,6 +162,19 @@ services:
       BINTRAIL_CONSOLE_TOKEN: ${CONSOLE_TOKEN:-}
       # Saved console connections persist across container recreations.
       BINTRAIL_CONSOLE_SERVERS: /var/lib/bintrail/console-servers.yaml
+      # Local staging for the "Archive to S3" feature (a source's rotated
+      # Parquet is written here, uploaded to its configured bucket, then
+      # pruned). Lives in the state volume so an interrupted upload survives a
+      # restart.
+      BINTRAIL_CONSOLE_ARCHIVE_STAGING: /var/lib/bintrail/archives
+      # AWS credentials for "Archive to S3" (the bucket is set per-source from
+      # the console UI). Passed through from .env; leave empty to rely on an
+      # IAM role (EC2/EKS) or a mounted ~/.aws. Needed for BOTH the upload and
+      # the console querying the archived Parquet back from S3.
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-}
+      AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN:-}
+      AWS_REGION: ${AWS_REGION:-}
       # Password login (persists next to the registry). On first run the
       # console serves a "create your password" screen; later visits sign in.
       # There is deliberately NO password env var: docker inspect must never

--- a/docs/console.md
+++ b/docs/console.md
@@ -184,9 +184,28 @@ immediately; warnings (e.g. short binlog retention) show but don't block.
 - With `--metrics-addr`, the daemon serves one Prometheus `/metrics` endpoint
   for all supervised streams; every series carries a `source` label set to
   the entry ID (see [streaming.md](streaming.md)).
+- **Archive to S3** (the `Archive to S3` field on a monitored source): set an
+  `s3://bucket/prefix/` destination and the daemon's built-in rotation
+  **uploads that source's rotated partitions as Parquet before dropping them**,
+  so the forensic record survives the retention window and stays queryable —
+  the console auto-discovers the archive on the next query, no extra config.
+  Partitions are staged locally (`--archive-staging-dir` /
+  `BINTRAIL_CONSOLE_ARCHIVE_STAGING`, default a temp dir), uploaded, then
+  pruned. The S3 upload uses the **ambient AWS credential chain** (`AWS_*`
+  env, `~/.aws`, or an instance/role) — the same credentials the console needs
+  to read the archive back; there is no per-source credential. Archiving for a
+  source begins once its identity (`bintrail_id`) is resolved (right after its
+  first stream connect); until then it rotates drop-only, and the
+  protect-unarchived guard never drops un-uploaded data. A persistently failing
+  upload (bad bucket/credentials) keeps partitions undropped and escalates to a
+  loud Error after a few cycles — the index does not silently lose data, but it
+  does stop shrinking, so fix the bucket/credentials. The archived Parquet is
+  unencrypted; rely on bucket-level SSE/policy. Archive to S3 ≠ Baseline S3
+  (the latter is read-side Time-travel input).
 - Registry fields: `source_dsn` (replication credentials — a secret with the
   same masking/keep-password discipline as the index DSN; `source_dsn: ""`
-  clears it), `source_server_id` (0 = derived), `schemas`, `monitor_desired`.
+  clears it), `source_server_id` (0 = derived), `schemas`, `monitor_desired`,
+  `archive_s3` (the bucket above — non-secret, round-trips in the masked DTO).
 
 The standalone read-only `bintrail-console serve` never offers any of this:
 the `monitor` capability is false and the verbs return 403 there.
@@ -220,6 +239,9 @@ the `monitor` capability is false and the verbs return 403 there.
 - `BINTRAIL_CONSOLE_TLS_CERT` / `BINTRAIL_CONSOLE_TLS_KEY` — same as `--tls-cert` / `--tls-key`.
 - `BINTRAIL_CONSOLE_ALLOWED_HOSTS` — comma-separated, same as `--allowed-hosts`.
 - `BINTRAIL_CONSOLE_ALLOW_SETUP` — `1`/`true`, same as `--allow-setup`.
+- `BINTRAIL_CONSOLE_ARCHIVE_STAGING` (`watch` only) — local staging dir for the
+  Archive-to-S3 feature, same as `--archive-staging-dir`. AWS credentials for
+  the upload come from the ambient chain (`AWS_*` / `~/.aws` / role).
 
 There is deliberately **no** environment variable for the password itself —
 env vars leak through `docker inspect`, `ps e`, and `/proc`; the password is

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -1562,7 +1562,9 @@ function buildServerForm() {
   monGrid.append(srvField("Source user", "source_user", { placeholder: "repl" }));
   monGrid.append(srvField("Source password", "source_password", { type: "password", autocomplete: "new-password" }));
   monGrid.append(srvField("Schemas", "schemas", { placeholder: "(optional) shop,billing" }));
+  monGrid.append(srvField("Archive to S3", "archive_s3", { placeholder: "(optional) s3://bucket/prefix/" }));
   mon.append(monGrid);
+  mon.append(el("p", { class: "form-hint", style: "margin-top:10px", text: "Archive to S3: rotated partitions upload here as Parquet before they're dropped, so the history survives retention and stays queryable. Needs AWS credentials on the daemon (env / role)." }));
   form.append(mon);
 
   // BYO index is the advanced path — collapsed behind a <details> so the
@@ -1620,7 +1622,7 @@ function showServerForm(prefill) {
 
   if (prefill) {
     form.elements.id.value = prefill.id || "";
-    ["name", "host", "port", "user", "dbname", "baseline_dir", "baseline_s3", "source_host", "source_port", "source_user", "schemas"].forEach((k) => {
+    ["name", "host", "port", "user", "dbname", "baseline_dir", "baseline_s3", "archive_s3", "source_host", "source_port", "source_user", "schemas"].forEach((k) => {
       if (form.elements[k] && prefill[k] != null) form.elements[k].value = prefill[k];
     });
     if (form.elements.no_archive) form.elements.no_archive.checked = !!prefill.no_archive;
@@ -1650,6 +1652,7 @@ function serverFormBody(form) {
     host: f.host.value.trim(), port: f.port.value.trim(), user: f.user.value.trim(), dbname: f.dbname.value.trim(),
     baseline_dir: f.baseline_dir.value.trim(), baseline_s3: f.baseline_s3.value.trim(),
     no_archive: !!f.no_archive.checked,
+    archive_s3: f.archive_s3.value.trim(),
     source_host: f.source_host.value.trim(), source_port: f.source_port.value.trim(),
     source_user: f.source_user.value.trim(), schemas: f.schemas.value.trim(),
   };

--- a/internal/console/registry.go
+++ b/internal/console/registry.go
@@ -66,6 +66,14 @@ type ServerEntry struct {
 	SourceServerID uint32 `yaml:"source_server_id,omitempty"`
 	// Schemas is the optional comma-separated schema filter for monitoring.
 	Schemas string `yaml:"schemas,omitempty"`
+	// ArchiveS3 is the S3 destination (s3://bucket/prefix/) the daemon's
+	// built-in rotation uploads this source's rotated Parquet partitions to
+	// BEFORE dropping them — so the forensic record survives retention and
+	// stays queryable (the console auto-discovers it). Empty = drop-only.
+	// Region/credentials come from the ambient AWS chain (env / ~/.aws / IAM
+	// role); a local staging dir is used transiently. Non-secret (a bucket
+	// URL): unlike DSNs it is serialized to the masked HTTP responses.
+	ArchiveS3 string `yaml:"archive_s3,omitempty"`
 	// MonitorDesired records the operator's intent to monitor this source.
 	// The supervisor reconciles running streams against it at boot and on
 	// every edit; nothing reads it until phase 3.

--- a/internal/console/servers_api.go
+++ b/internal/console/servers_api.go
@@ -38,6 +38,7 @@ type serverDTO struct {
 	BaselineDir string            `json:"baseline_dir,omitempty"`
 	BaselineS3  string            `json:"baseline_s3,omitempty"`
 	NoArchive   bool              `json:"no_archive"`
+	ArchiveS3   string            `json:"archive_s3,omitempty"`
 	// Source-monitoring config (control plane). HasSource reports whether a
 	// source DSN is configured at all; the parts are its masked view — the
 	// source DSN itself (replication credentials) never leaves the process.
@@ -89,6 +90,7 @@ type serverRequest struct {
 	BaselineDir string  `json:"baseline_dir"`
 	BaselineS3  string  `json:"baseline_s3"`
 	NoArchive   bool    `json:"no_archive"`
+	ArchiveS3   string  `json:"archive_s3"`
 
 	SourceDSN      *string `json:"source_dsn"`
 	SourceHost     string  `json:"source_host"`
@@ -189,6 +191,7 @@ func (s *Server) handleServersCreate(w http.ResponseWriter, r *http.Request) {
 		BaselineDir:    req.BaselineDir,
 		BaselineS3:     req.BaselineS3,
 		NoArchive:      req.NoArchive,
+		ArchiveS3:      strings.TrimSpace(req.ArchiveS3),
 		SourceDSN:      sourceDSN,
 		SourceServerID: req.SourceServerID,
 		Schemas:        req.Schemas,
@@ -260,6 +263,7 @@ func (s *Server) handleServersUpdate(w http.ResponseWriter, r *http.Request) {
 		BaselineDir: req.BaselineDir,
 		BaselineS3:  req.BaselineS3,
 		NoArchive:   req.NoArchive,
+		ArchiveS3:   strings.TrimSpace(req.ArchiveS3),
 		SourceDSN:   sourceDSN,
 		// The verbs that flip monitoring intent arrive with the supervisor
 		// (phase 3); a plain edit must not silently start or stop anything.
@@ -696,6 +700,7 @@ func (s *Server) entryDTO(e ServerEntry) serverDTO {
 		BaselineDir:    e.BaselineDir,
 		BaselineS3:     e.BaselineS3,
 		NoArchive:      e.NoArchive,
+		ArchiveS3:      e.ArchiveS3,
 		Reconstruct:    s.cm.capability(e),
 		Editable:       !s.cm.reg.ReadOnly(),
 		Deletable:      !s.cm.reg.ReadOnly(),
@@ -748,6 +753,7 @@ func (s *Server) bootDTO() (serverDTO, bool) {
 		Reconstruct: boot.baselineConfigured,
 		BaselineDir: "",
 		BaselineS3:  "",
+		ArchiveS3:   "",
 		Editable:    false,
 		Deletable:   false,
 		Connected:   true,

--- a/internal/rotation/loop.go
+++ b/internal/rotation/loop.go
@@ -67,14 +67,30 @@ func ParseSettings(retain, interval string, addFuture int, explicit bool) (Setti
 	}, nil
 }
 
+// RotateTarget is one index database the loop rotates this cycle, plus its
+// optional per-source archive config. ArchiveS3 == "" means drop-only (the
+// historical behavior). When ArchiveS3 is set, the cycle archives each expired
+// partition to ArchiveDir (a local staging dir) under bintrail_id=BintrailID,
+// uploads it to ArchiveS3, then drops it — and prunes the local copy. The
+// provider (cmd/bintrail-console) is responsible for only setting the archive
+// fields once BintrailID is known (resolved from the source's stream_state).
+type RotateTarget struct {
+	DSN                string
+	ArchiveDir         string
+	ArchiveS3          string
+	ArchiveS3Region    string
+	BintrailID         string
+	ArchiveCompression string
+}
+
 // StartLoop announces and launches the built-in rotation loop: one
-// cycle immediately, then one every interval, each cycle rotating the boot
-// index database plus every DSN the provider returns (the control plane's
-// per-source databases). Rotation is the secondary job — failures are logged,
-// never fatal to the stream. Returns immediately; the loop stops when ctx is
-// cancelled, and the returned channel closes when it has fully exited (used
-// by tests for deterministic shutdown; production callers may ignore it).
-func StartLoop(ctx context.Context, s Settings, dsns func() []string) <-chan struct{} {
+// cycle immediately, then one every interval, each cycle rotating every target
+// the provider returns (the boot index plus the control plane's per-source
+// databases). Rotation is the secondary job — failures are logged, never fatal
+// to the stream. Returns immediately; the loop stops when ctx is cancelled, and
+// the returned channel closes when it has fully exited (used by tests for
+// deterministic shutdown; production callers may ignore it).
+func StartLoop(ctx context.Context, s Settings, targets func() []RotateTarget) <-chan struct{} {
 	done := make(chan struct{})
 	if !s.Enabled {
 		fmt.Fprintln(os.Stderr, "Built-in rotation: off — the index grows until you rotate it yourself (see `bintrail rotate`)")
@@ -109,7 +125,7 @@ func StartLoop(ctx context.Context, s Settings, dsns func() []string) <-chan str
 					slog.Error("built-in rotation cycle panicked; rotation continues next tick", "panic", r)
 				}
 			}()
-			deferred, failed := runCycle(ctx, s, dsns)
+			deferred, failed := runCycle(ctx, s, targets)
 			if failed || deferred > 0 {
 				unhealthyStreak++
 			} else {
@@ -143,12 +159,12 @@ func StartLoop(ctx context.Context, s Settings, dsns func() []string) <-chan str
 var escalateAfter = 3
 
 // runCycle rotates each index database once. Errors are logged and
-// the cycle moves to the next DSN — a transient failure self-heals on the
+// the cycle moves to the next target — a transient failure self-heals on the
 // next tick. Returns the total number of partitions the protect-unarchived
 // guard deferred this cycle, and whether any database's rotation failed.
-func runCycle(ctx context.Context, s Settings, dsns func() []string) (deferred int, failed bool) {
-	for _, dsn := range dedupeDSNs(dsns()) {
-		d, err := rotateOneIndex(ctx, dsn, s)
+func runCycle(ctx context.Context, s Settings, targets func() []RotateTarget) (deferred int, failed bool) {
+	for _, t := range dedupeTargets(targets()) {
+		d, err := rotateOneIndex(ctx, t, s)
 		deferred += d
 		if err != nil {
 			failed = true
@@ -157,29 +173,29 @@ func runCycle(ctx context.Context, s Settings, dsns func() []string) (deferred i
 	return deferred, failed
 }
 
-// dedupeDSNs drops empty strings and duplicates, preserving order.
-func dedupeDSNs(in []string) []string {
+// dedupeTargets drops empty-DSN and duplicate-DSN targets, preserving order.
+func dedupeTargets(in []RotateTarget) []RotateTarget {
 	seen := make(map[string]bool, len(in))
-	out := make([]string, 0, len(in))
-	for _, dsn := range in {
-		if dsn == "" || seen[dsn] {
+	out := make([]RotateTarget, 0, len(in))
+	for _, t := range in {
+		if t.DSN == "" || seen[t.DSN] {
 			continue
 		}
-		seen[dsn] = true
-		out = append(out, dsn)
+		seen[t.DSN] = true
+		out = append(out, t)
 	}
 	return out
 }
 
-// loopOptions builds the Perform Options for one built-in-rotation cycle.
-// Built-in rotation never archives (ArchiveDir empty) — it drops and tops up
-// only — and ALWAYS arms ProtectUnarchived so it can never be the first to
-// destroy data an external archiving flow would preserve; Format "json"
-// suppresses per-partition stdout (slog carries the per-cycle signal). The
-// data-loss safety of `up`'s rotation reduces to this one constructor, so it is
-// kept pure and unit-tested (it replaces the old rot*-global fan-out).
-func loopOptions(retain time.Duration, s Settings) Options {
-	return Options{
+// loopOptions builds the Perform Options for one built-in-rotation cycle. It
+// ALWAYS arms ProtectUnarchived so the loop can never be the first to destroy
+// data an external archiving flow would preserve; Format "json" suppresses
+// per-partition stdout (slog carries the per-cycle signal). When the target
+// carries an ArchiveS3 bucket, the cycle archives-then-drops (and prunes the
+// local staging copy after upload); otherwise ArchiveDir is empty and it
+// drops-and-tops-up only — the historical behavior.
+func loopOptions(retain time.Duration, s Settings, t RotateTarget) Options {
+	o := Options{
 		RetainDur:         retain,
 		RetainRaw:         s.RetainRaw,
 		AddFuture:         s.AddFuture,
@@ -187,12 +203,23 @@ func loopOptions(retain time.Duration, s Settings) Options {
 		Format:            "json",
 		ProtectUnarchived: true,
 	}
+	if t.ArchiveS3 != "" {
+		o.ArchiveDir = t.ArchiveDir
+		o.ArchiveS3 = t.ArchiveS3
+		o.ArchiveS3Region = t.ArchiveS3Region
+		o.BintrailID = t.BintrailID
+		o.ArchiveCompression = t.ArchiveCompression
+		o.Retry = true                 // skip re-archiving/re-uploading what a prior cycle already did
+		o.PruneLocalAfterUpload = true // unattended daemon: don't grow the staging dir
+	}
+	return o
 }
 
-// rotateOneIndex runs one Perform cycle against a single index DSN,
+// rotateOneIndex runs one Perform cycle against a single target's index DSN,
 // returning the guard-deferred partition count and any failure. Log messages
 // are scrubbed: DSNs (and their passwords) never reach the log.
-func rotateOneIndex(ctx context.Context, dsn string, s Settings) (int, error) {
+func rotateOneIndex(ctx context.Context, t RotateTarget, s Settings) (int, error) {
+	dsn := t.DSN
 	cfg, err := mysql.ParseDSN(dsn)
 	if err != nil {
 		slog.Warn("built-in rotation: skipping unparseable index DSN",
@@ -236,7 +263,7 @@ func rotateOneIndex(ctx context.Context, dsn string, s Settings) (int, error) {
 		}
 	}
 
-	res, err := Perform(ctx, db, cfg.DBName, loopOptions(retain, s))
+	res, err := Perform(ctx, db, cfg.DBName, loopOptions(retain, s, t))
 	if err != nil && ctx.Err() == nil {
 		slog.Warn("built-in rotation cycle failed",
 			"db", cfg.DBName, "error", config.ScrubDSNText(err.Error(), dsn))

--- a/internal/rotation/loop_integration_test.go
+++ b/internal/rotation/loop_integration_test.go
@@ -40,7 +40,7 @@ func TestRotateOneIndex_UpgradeGuard(t *testing.T) {
 	}
 
 	// Implicit default: the guard must refuse the drop and say so loudly.
-	if _, err := rotateOneIndex(context.Background(), dsn, s); err != nil {
+	if _, err := rotateOneIndex(context.Background(), RotateTarget{DSN: dsn}, s); err != nil {
 		t.Fatalf("rotateOneIndex (implicit): %v", err)
 	}
 	partitions, err := listPartitions(context.Background(), db, dbName)
@@ -72,7 +72,7 @@ func TestRotateOneIndex_UpgradeGuard(t *testing.T) {
 
 	// Explicit choice: the same retention now drops the old history.
 	s.Explicit = true
-	if _, err := rotateOneIndex(context.Background(), dsn, s); err != nil {
+	if _, err := rotateOneIndex(context.Background(), RotateTarget{DSN: dsn}, s); err != nil {
 		t.Fatalf("rotateOneIndex (explicit): %v", err)
 	}
 	partitions, err = listPartitions(context.Background(), db, dbName)
@@ -118,8 +118,8 @@ func TestStartLoop_escalatesOnPersistentDeferral(t *testing.T) {
 		Explicit: true, // h1 is only 30h old; guard wouldn't trip, but be unambiguous
 	}
 	ctx, cancel := context.WithCancel(context.Background())
-	done := StartLoop(ctx, s, func() []string {
-		return []string{testutil.IntegrationDSN(dbName)}
+	done := StartLoop(ctx, s, func() []RotateTarget {
+		return []RotateTarget{{DSN: testutil.IntegrationDSN(dbName)}}
 	})
 
 	deadline := time.After(30 * time.Second)

--- a/internal/rotation/loop_test.go
+++ b/internal/rotation/loop_test.go
@@ -57,7 +57,8 @@ func captureSlog(t *testing.T) *logCapture {
 // which guarded the rot*-global fan-out that loopOptions superseded.
 func TestLoopOptions(t *testing.T) {
 	s := Settings{Enabled: true, Retain: 30 * 24 * time.Hour, RetainRaw: "30d", AddFuture: 3}
-	o := loopOptions(7*24*time.Hour, s)
+	// A drop-only target (no ArchiveS3) is the default, data-loss-safe shape.
+	o := loopOptions(7*24*time.Hour, s, RotateTarget{DSN: "x"})
 
 	if !o.ProtectUnarchived {
 		t.Error("ProtectUnarchived must be armed — without it the built-in rotation drops unarchived data")
@@ -66,11 +67,11 @@ func TestLoopOptions(t *testing.T) {
 		t.Error("NoReplace must be false (dropped partitions are replaced)")
 	}
 	if o.ArchiveDir != "" || o.ArchiveS3 != "" || o.BintrailID != "" {
-		t.Errorf("archive fields must be empty (built-in rotation never archives): dir=%q s3=%q id=%q",
+		t.Errorf("a drop-only target must leave archive fields empty: dir=%q s3=%q id=%q",
 			o.ArchiveDir, o.ArchiveS3, o.BintrailID)
 	}
 	if o.Retry {
-		t.Error("Retry must be false")
+		t.Error("Retry must be false for a drop-only target")
 	}
 	if o.Format != "json" {
 		t.Errorf("Format = %q, want json (suppresses per-partition stdout chatter)", o.Format)
@@ -86,11 +87,41 @@ func TestLoopOptions(t *testing.T) {
 	}
 }
 
+// TestLoopOptionsArchive: a target carrying an ArchiveS3 bucket flips the cycle
+// into archive-then-drop with the staging dir, bintrail_id, retry, and local
+// prune all wired through from the target.
+func TestLoopOptionsArchive(t *testing.T) {
+	s := Settings{Enabled: true, Retain: 30 * 24 * time.Hour, RetainRaw: "30d", AddFuture: 3}
+	o := loopOptions(s.Retain, s, RotateTarget{
+		DSN:                "x",
+		ArchiveDir:         "/staging/abc",
+		ArchiveS3:          "s3://bucket/prefix/",
+		ArchiveS3Region:    "us-east-1",
+		BintrailID:         "uuid-123",
+		ArchiveCompression: "zstd",
+	})
+	if o.ArchiveDir != "/staging/abc" || o.ArchiveS3 != "s3://bucket/prefix/" || o.BintrailID != "uuid-123" {
+		t.Errorf("archive config not threaded through: %+v", o)
+	}
+	if o.ArchiveS3Region != "us-east-1" || o.ArchiveCompression != "zstd" {
+		t.Errorf("region/compression not threaded: region=%q codec=%q", o.ArchiveS3Region, o.ArchiveCompression)
+	}
+	if !o.Retry {
+		t.Error("Retry must be true when archiving (skip what a prior cycle already did)")
+	}
+	if !o.PruneLocalAfterUpload {
+		t.Error("PruneLocalAfterUpload must be true for the unattended loop")
+	}
+	if !o.ProtectUnarchived {
+		t.Error("ProtectUnarchived stays armed")
+	}
+}
+
 // TestStartLoop_disabledIsInert verifies the disabled path starts no loop and
 // never consults the DSN provider.
 func TestStartLoop_disabledIsInert(t *testing.T) {
 	called := false
-	done := StartLoop(context.Background(), Settings{}, func() []string {
+	done := StartLoop(context.Background(), Settings{}, func() []RotateTarget {
 		called = true
 		return nil
 	})
@@ -125,8 +156,8 @@ func TestStartLoop_escalatesAfterConsecutiveFailures(t *testing.T) {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	// Port 1 on loopback: connection refused immediately, every cycle fails.
-	done := StartLoop(ctx, s, func() []string {
-		return []string{"root:x@tcp(127.0.0.1:1)/nope"}
+	done := StartLoop(ctx, s, func() []RotateTarget {
+		return []RotateTarget{{DSN: "root:x@tcp(127.0.0.1:1)/nope"}}
 	})
 
 	deadline := time.After(15 * time.Second)
@@ -199,8 +230,8 @@ func TestRunCycle_reportsFailure(t *testing.T) {
 		Enabled: true, Retain: 24 * time.Hour, RetainRaw: "24h",
 		Interval: time.Hour, Explicit: true,
 	}
-	deferred, failed := runCycle(context.Background(), s, func() []string {
-		return []string{"root:x@tcp(127.0.0.1:1)/nope", "not-a-dsn"}
+	deferred, failed := runCycle(context.Background(), s, func() []RotateTarget {
+		return []RotateTarget{{DSN: "root:x@tcp(127.0.0.1:1)/nope"}, {DSN: "not-a-dsn"}}
 	})
 	if !failed {
 		t.Error("cycle with unreachable DSNs must report failed=true")
@@ -270,16 +301,16 @@ func TestParseSettings_negativeAddFuture(t *testing.T) {
 	}
 }
 
-func TestDedupeDSNs(t *testing.T) {
-	in := []string{"a", "", "b", "a", "c", "b"}
-	got := dedupeDSNs(in)
+func TestDedupeTargets(t *testing.T) {
+	in := []RotateTarget{{DSN: "a"}, {DSN: ""}, {DSN: "b"}, {DSN: "a"}, {DSN: "c"}, {DSN: "b"}}
+	got := dedupeTargets(in)
 	want := []string{"a", "b", "c"}
 	if len(got) != len(want) {
-		t.Fatalf("dedupeDSNs = %v, want %v", got, want)
+		t.Fatalf("dedupeTargets = %v, want DSNs %v", got, want)
 	}
 	for i := range want {
-		if got[i] != want[i] {
-			t.Fatalf("dedupeDSNs = %v, want %v", got, want)
+		if got[i].DSN != want[i] {
+			t.Fatalf("dedupeTargets[%d].DSN = %q, want %q", i, got[i].DSN, want[i])
 		}
 	}
 }

--- a/internal/rotation/rotation.go
+++ b/internal/rotation/rotation.go
@@ -59,6 +59,13 @@ type Options struct {
 	// built-in rotation must not be the first to destroy data an archiving flow
 	// would preserve. The explicit rotate command leaves this false.
 	ProtectUnarchived bool
+	// PruneLocalAfterUpload removes the local staging Parquet once it has been
+	// uploaded to S3 and the partition dropped. The unattended built-in loop
+	// sets this so a container's staging dir doesn't grow without bound; the
+	// read side falls back to S3 when the local copy is gone. Requires
+	// ArchiveS3 (a local-only archive IS the durable copy — never pruned). The
+	// explicit rotate command leaves this false (operator keeps both copies).
+	PruneLocalAfterUpload bool
 }
 
 // Perform executes one full rotation cycle against an open DB connection,
@@ -254,6 +261,15 @@ func Perform(ctx context.Context, db *sql.DB, dbName string, opts Options) (Resu
 					slog.Info("dropped partition", "partition", name)
 					if opts.Format != "json" {
 						fmt.Fprintf(os.Stdout, "dropped partition %s\n", name)
+					}
+
+					// We only reach the drop once the S3 copy is confirmed (the
+					// pending-upload guard above), so removing the local staging
+					// Parquet is safe — reads fall back to S3. Best-effort.
+					if opts.PruneLocalAfterUpload && opts.ArchiveS3 != "" {
+						if err := os.Remove(outPath); err != nil && !os.IsNotExist(err) {
+							slog.Warn("could not prune local archive after S3 upload", "partition", name, "error", err)
+						}
 					}
 				}
 			} else {

--- a/internal/rotation/rotation.go
+++ b/internal/rotation/rotation.go
@@ -18,10 +18,14 @@ import (
 	"github.com/dbtrail/dbtrail/internal/storage"
 )
 
-// Result is one rotation cycle's outcome. deferred counts partitions
-// past retention that the opts.ProtectUnarchived guard refused to drop (always
-// 0 for the explicit rotate command). A named struct, not a positional tuple:
-// three same-typed ints invite silent misordering at call sites.
+// Result is one rotation cycle's outcome. Deferred counts partitions past
+// retention that this cycle did NOT drop to avoid data loss: the
+// ProtectUnarchived guard refusing an unarchived partition, OR (in the archive
+// path) an S3 upload that failed or is still pending. The built-in loop sums it
+// across targets to drive escalation. The explicit `rotate` command surfaces
+// only Dropped/Added, but can still produce Deferred>0 when its --archive-s3
+// uploads fail. A named struct, not a positional tuple: three same-typed ints
+// invite silent misordering at call sites.
 type Result struct {
 	Dropped, Added, Deferred int
 }
@@ -74,6 +78,15 @@ type Options struct {
 func Perform(ctx context.Context, db *sql.DB, dbName string, opts Options) (Result, error) {
 	retainDur := opts.RetainDur
 	start := time.Now()
+
+	// An S3 target without a local staging dir is a misconfiguration: archiving
+	// keys off ArchiveDir, so this would silently fall through to the no-archive
+	// bulk-drop branch and drop partitions that were never uploaded. Fail loud
+	// instead — the field invariant (ArchiveS3 requires ArchiveDir) is enforced
+	// here, not just documented on Options.
+	if opts.ArchiveS3 != "" && opts.ArchiveDir == "" {
+		return Result{}, fmt.Errorf("ArchiveS3 set without ArchiveDir: cannot upload to S3 without a local staging path")
+	}
 
 	// ── Load current partition list ─────────────────────────────────────────────
 	partitions, err := listPartitions(ctx, db, dbName)

--- a/internal/rotation/rotation.go
+++ b/internal/rotation/rotation.go
@@ -220,6 +220,11 @@ func Perform(ctx context.Context, db *sql.DB, dbName string, opts Options) (Resu
 									fmt.Fprintf(os.Stdout, "warning: S3 upload failed for %s: %v\n", name, err)
 									fmt.Fprintf(os.Stdout, "  run 'bintrail rotate --retry --archive-s3 ...' to retry\n")
 								}
+								// Count it deferred so the built-in loop's unhealthy-streak
+								// escalation fires: a persistently failing upload keeps the
+								// index (and staging dir) growing, the exact condition the
+								// streak detector exists to surface above per-cycle warnings.
+								deferredCount++
 								continue
 							}
 							if _, err := db.ExecContext(ctx,
@@ -250,6 +255,9 @@ func Perform(ctx context.Context, db *sql.DB, dbName string, opts Options) (Resu
 							fmt.Fprintf(os.Stdout, "skipped drop for %s (pending S3 upload)\n", name)
 							fmt.Fprintf(os.Stdout, "  run 'bintrail rotate --retry --archive-s3 ...' to retry\n")
 						}
+						// A still-pending upload is an undropped partition too — count it
+						// so the loop escalates rather than reporting a healthy cycle.
+						deferredCount++
 						continue
 					}
 

--- a/internal/rotation/rotation_integration_test.go
+++ b/internal/rotation/rotation_integration_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+
 	"github.com/dbtrail/dbtrail/internal/indexer"
 	"github.com/dbtrail/dbtrail/internal/testutil"
 )
@@ -507,5 +509,61 @@ func TestAddFuturePartitions(t *testing.T) {
 		if parts[i].Name != expected {
 			t.Errorf("partition %d: expected %s, got %s", i, expected, parts[i].Name)
 		}
+	}
+}
+
+// TestPerformRotation_S3UploadFailureDefers covers the path the review flagged:
+// when archiving to S3 and the upload persistently fails, the partition is NOT
+// dropped (data safe) AND the failure is counted into Result.Deferred so the
+// built-in loop's unhealthy-streak escalation fires — instead of reporting a
+// healthy cycle while the index grows unbounded.
+func TestPerformRotation_S3UploadFailureDefers(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	h1 := time.Now().UTC().Add(-48 * time.Hour).Truncate(time.Hour)
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{h1})
+	ts1 := h1.Add(30 * time.Minute).Format("2006-01-02 15:04:05")
+	testutil.InsertEvent(t, db, "binlog.000001", 100, 200, ts1, nil, "testdb", "users", 1, "1", nil, nil, []byte(`{"id":1}`))
+
+	// Stub the uploader to always fail, simulating a bad bucket / missing creds.
+	prev := uploadFileFunc
+	uploadFileFunc = func(ctx context.Context, client *s3.Client, path, bucket, key string) error {
+		return fmt.Errorf("simulated S3 upload failure")
+	}
+	t.Cleanup(func() { uploadFileFunc = prev })
+
+	res, err := Perform(context.Background(), db, dbName, Options{
+		RetainDur:          24 * time.Hour,
+		ArchiveDir:         t.TempDir(),
+		ArchiveS3:          "s3://fake-bucket/prefix/",
+		ArchiveS3Region:    "us-east-1",
+		BintrailID:         "test-uuid-upload-fail",
+		ArchiveCompression: "zstd",
+		Format:             "json",
+		NoReplace:          true,
+	})
+	if err != nil {
+		t.Fatalf("Perform must not error on an upload failure (it defers): %v", err)
+	}
+	if res.Dropped != 0 {
+		t.Errorf("Dropped = %d, want 0 (an un-uploaded partition must never be dropped)", res.Dropped)
+	}
+	if res.Deferred < 1 {
+		t.Errorf("Deferred = %d, want >=1 — a failed upload must count as deferred so the loop escalates", res.Deferred)
+	}
+	// The partition must still be present.
+	partitions, err := listPartitions(context.Background(), db, dbName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, p := range partitions {
+		if p.Name == indexer.PartitionName(h1) {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("partition was dropped despite a failed S3 upload — data loss")
 	}
 }

--- a/internal/rotation/rotation_integration_test.go
+++ b/internal/rotation/rotation_integration_test.go
@@ -4,6 +4,7 @@ package rotation
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -171,6 +172,13 @@ func TestPerformRotation_PendingS3BlocksDrop(t *testing.T) {
 	// Second partition should be dropped (S3 upload complete).
 	if res.Dropped != 1 {
 		t.Errorf("expected 1 partition dropped, got %d", res.Dropped)
+	}
+	// h1's still-pending upload must register as Deferred (the archive-branch
+	// pending-skip increment). Asserting only Dropped would let that count
+	// regress silently — a stalled archive would then read as a healthy cycle
+	// and the built-in loop's escalation streak would never fire.
+	if res.Deferred != 1 {
+		t.Errorf("expected 1 partition deferred (h1 pending S3 upload), got %d", res.Deferred)
 	}
 
 	// Verify partition h1 still exists.
@@ -565,5 +573,118 @@ func TestPerformRotation_S3UploadFailureDefers(t *testing.T) {
 	}
 	if !found {
 		t.Error("partition was dropped despite a failed S3 upload — data loss")
+	}
+}
+
+// TestPerformRotation_S3UploadSuccessPrunesAndDrops covers the success path that
+// no other test exercises: a confirmed S3 upload must stamp s3_uploaded_at, drop
+// the partition, and (with PruneLocalAfterUpload) remove the local staging copy.
+// A regression that stamped before the upload returned, or pruned the durable
+// copy on the wrong branch, would be data loss this test catches.
+func TestPerformRotation_S3UploadSuccessPrunesAndDrops(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	h1 := time.Now().UTC().Add(-48 * time.Hour).Truncate(time.Hour)
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{h1})
+	ts1 := h1.Add(30 * time.Minute).Format("2006-01-02 15:04:05")
+	testutil.InsertEvent(t, db, "binlog.000001", 100, 200, ts1, nil, "testdb", "users", 1, "1", nil, nil, []byte(`{"id":1}`))
+
+	// Stub the uploader to succeed (no real S3); Perform then stamps
+	// s3_uploaded_at, drops the partition, and prunes the local staging copy.
+	prev := uploadFileFunc
+	uploadFileFunc = func(ctx context.Context, client *s3.Client, path, bucket, key string) error {
+		return nil
+	}
+	t.Cleanup(func() { uploadFileFunc = prev })
+
+	archiveDir := t.TempDir()
+	bintrailID := "test-uuid-upload-ok"
+	outPath, _ := HiveArchivePath(archiveDir, bintrailID, indexer.PartitionName(h1))
+
+	res, err := Perform(context.Background(), db, dbName, Options{
+		RetainDur:             24 * time.Hour,
+		ArchiveDir:            archiveDir,
+		ArchiveS3:             "s3://fake-bucket/prefix/",
+		ArchiveS3Region:       "us-east-1",
+		BintrailID:            bintrailID,
+		ArchiveCompression:    "zstd",
+		Format:                "json",
+		NoReplace:             true,
+		PruneLocalAfterUpload: true,
+	})
+	if err != nil {
+		t.Fatalf("Perform: %v", err)
+	}
+	if res.Dropped != 1 {
+		t.Errorf("Dropped = %d, want 1 (a successfully uploaded partition is dropped)", res.Dropped)
+	}
+	if res.Deferred != 0 {
+		t.Errorf("Deferred = %d, want 0", res.Deferred)
+	}
+
+	// s3_uploaded_at must be stamped so a later drop-only cycle sees the S3 copy
+	// as durable (hasPendingS3Upload → false).
+	var uploadedAt sql.NullTime
+	if err := db.QueryRow(
+		`SELECT s3_uploaded_at FROM archive_state WHERE partition_name = ? AND bintrail_id = ?`,
+		indexer.PartitionName(h1), bintrailID,
+	).Scan(&uploadedAt); err != nil {
+		t.Fatalf("read s3_uploaded_at: %v", err)
+	}
+	if !uploadedAt.Valid {
+		t.Error("s3_uploaded_at must be set after a successful upload")
+	}
+
+	// PruneLocalAfterUpload removed the local staging Parquet (reads fall back to S3).
+	if _, err := os.Stat(outPath); !os.IsNotExist(err) {
+		t.Errorf("local archive %s must be pruned after a confirmed upload; stat err = %v", outPath, err)
+	}
+
+	// The partition itself is gone.
+	partitions, err := listPartitions(context.Background(), db, dbName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range partitions {
+		if p.Name == indexer.PartitionName(h1) {
+			t.Error("partition should have been dropped after a successful upload")
+		}
+	}
+}
+
+// TestPerformRotation_LocalOnlyArchiveNotPruned pins the inverse invariant: with
+// no ArchiveS3 the local Parquet IS the durable copy, so PruneLocalAfterUpload
+// must be a no-op even when set. Deleting it would be silent data loss.
+func TestPerformRotation_LocalOnlyArchiveNotPruned(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	h1 := time.Now().UTC().Add(-48 * time.Hour).Truncate(time.Hour)
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{h1})
+	ts1 := h1.Add(30 * time.Minute).Format("2006-01-02 15:04:05")
+	testutil.InsertEvent(t, db, "binlog.000001", 100, 200, ts1, nil, "testdb", "users", 1, "1", nil, nil, []byte(`{"id":1}`))
+
+	archiveDir := t.TempDir()
+	bintrailID := "test-uuid-local-only"
+	outPath, _ := HiveArchivePath(archiveDir, bintrailID, indexer.PartitionName(h1))
+
+	res, err := Perform(context.Background(), db, dbName, Options{
+		RetainDur:             24 * time.Hour,
+		ArchiveDir:            archiveDir, // local archive, no S3
+		BintrailID:            bintrailID,
+		ArchiveCompression:    "zstd",
+		Format:                "json",
+		NoReplace:             true,
+		PruneLocalAfterUpload: true, // must be ignored without ArchiveS3
+	})
+	if err != nil {
+		t.Fatalf("Perform: %v", err)
+	}
+	if res.Dropped != 1 {
+		t.Errorf("Dropped = %d, want 1", res.Dropped)
+	}
+	if _, err := os.Stat(outPath); err != nil {
+		t.Errorf("local-only archive %s must survive (it is the durable copy); stat err = %v", outPath, err)
 	}
 }


### PR DESCRIPTION
Lets an operator set an **"Archive to S3"** bucket on a monitored source from the console UI (under `bintrail-console watch`). The daemon's built-in rotation then **uploads that source's rotated partitions as Parquet to S3 before dropping them**, so the forensic record survives the retention window — and the console auto-discovers the archive on the next query (the read side already worked; this is the write/config side).

## How it works

- **UI**: an "Archive to S3" field in the monitor section of "+ Add server" (`s3://bucket/prefix/`), hidden on serve-only processes. Round-trips through the registry (`archive_s3`, additive yaml + forward-compat `Extra`), the masked DTO (it's a non-secret bucket URL), and the edit-form prefill.
- **Engine**: `rotation.Perform` already archived-then-dropped; this PR feeds it per-source config. The loop widened from `func() []string` to `func() []rotation.RotateTarget` (DSN + archive bucket + resolved bintrail_id + staging). The boot index stays drop-only.
- **Identity**: the Hive path / `archive_state` use the source's resolved `bintrail_id` (read from its `stream_state`), **not** the registry entry id — they differ (`bintrail_idx_<entryID>` is the DB name; the archive UUID is separate). Archiving for a source begins once that id resolves (after its first connect); until then it rotates drop-only and the protect-unarchived guard never drops un-uploaded data.
- **Disk**: a new `PruneLocalAfterUpload` option removes the local staging Parquet after a confirmed upload+drop (the read side falls back to S3), so the unattended daemon's staging dir doesn't grow. Staging dir via `--archive-staging-dir` / `BINTRAIL_CONSOLE_ARCHIVE_STAGING`.
- **AWS creds**: the ambient chain (`AWS_*` env / `~/.aws` / instance role) — no per-source credentials. The Compose stack passes `AWS_*` through from `.env` (empty default → works with static keys OR an EC2/EKS role) and stages under the state volume.

## Safety

A failed/pending S3 upload **never drops** the partition (no data loss). And — per the adversarial review — a *persistently* failing upload now counts the un-uploaded partitions into `Result.Deferred`, so the rotation loop's unhealthy-streak **escalates to a loud Error** instead of silently growing the index (this was the one important review finding, fixed in the second commit). Archived Parquet is unencrypted; rely on bucket-level SSE/policy (documented).

## Tests & verification

- Go: `TestRotateTargets` (the per-source assembly: boot drop-only, bucket-set archives, unresolved-id waits), `TestLoopOptions`/`TestLoopOptionsArchive` (drop-only vs archive Options), `TestArchiveStagingEnvFallback`, plus the loop-signature update across all callers/tests. Integration: `TestPerformRotation_S3UploadFailureDefers` (the new escalation-feeding path), existing archive tests green. Full unit + `-race` + rotation integration green.
- Headless-Chrome: the Archive S3 field renders in the monitor section and round-trips (create via API → edit form prefills). Screenshot confirmed.
- Adversarial review (4 lenses × 2 refuters): 1 important finding (escalation gap) fixed; 1 refuted.

## Notes

Branches from `main`, **independent of #454** (password-mandatory). When both merge, the second needs a small rebase (overlap in `app.js`/`watch.go`, mechanical). An accidental `gofmt` of `cmd/mcp-gateway` was reverted; the diff is feature-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)