### PR TITLE
feat(console): Settings nav group — Storage page, visible Rotation, demoted boot entry

### DIFF
--- a/cmd/bintrail-console/watch.go
+++ b/cmd/bintrail-console/watch.go
@@ -339,6 +339,11 @@ func runUpConsoleOnly(cmd *cobra.Command) error {
 		return err
 	}
 	cfg.Registry = registry
+	// Source-less daemon: nothing ever streams into the boot index (each
+	// "+ Add server" source gets its own per-source database), so prefer a
+	// registry server — where events actually land — as the browser default.
+	// The boot entry stays listed and selectable.
+	cfg.DemoteBoot = true
 
 	ctx, stop := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()

--- a/docs/console.md
+++ b/docs/console.md
@@ -111,9 +111,10 @@ How it behaves:
   added source gets its own per-source database), so it legitimately shows 0
   events with a full set of provisioned partitions. For that reason a
   source-less `watch` daemon **demotes** it: fresh tabs land on the first
-  monitored registry server instead, and the cli entry sorts last in the
-  switcher (still selectable — its Status shows the boot index and the
-  rotation that maintains it).
+  monitored registry server (or the first saved server when none is
+  monitored). The cli entry always sorts last in the switcher regardless of
+  mode, and stays selectable — its Status shows the boot index and the
+  rotation that maintains it.
 - **Lazy connections.** Saved servers connect on first selection (with an
   eager ping, so a dead server fails the moment you switch to it, not on your
   first query). Editing a server's connection details closes and reopens its
@@ -261,10 +262,12 @@ across the rotation dialog and the per-server edit form):
 - **AWS credentials** — which ambient credential signals the daemon process
   can see: env keys (presence only, never values), `AWS_PROFILE`,
   `AWS_REGION`, a shared `~/.aws` config, ECS task-role / EKS IRSA markers.
-  **The console never stores AWS keys** — uploads and reads use the AWS
-  default credential chain of the daemon (environment, shared profile incl.
-  SSO, or an IAM role; EC2/ECS/EKS roles work even when nothing shows as set,
-  since instance roles are not detectable without a metadata call).
+  **The console never stores AWS keys.** S3 *uploads* and archived-event
+  *reads* use the AWS default credential chain of the daemon (environment,
+  shared profile incl. SSO, or an IAM role; EC2/ECS/EKS roles work even when
+  nothing shows as set, since instance roles are not detectable without a
+  metadata call). Baseline listings/reads from `s3://` ride DuckDB httpfs and
+  currently support environment keys only (dbtrail/dbtrail#459).
 
 ## Flags
 
@@ -445,8 +448,9 @@ All endpoints return JSON. `/api/*` (except `healthz`) require
 | `GET /api/storage` | Process-global storage context: `{aws: {access_key_env, profile, region_env, shared_config, container_creds, web_identity}}` — presence booleans and non-secret names only, never credential values. |
 
 Every data endpoint (`status`, `schemas`, `events`, `recover`, `capabilities`,
-`reconstruct`) targets the server named by the `X-Bintrail-Server` request
-header; without the header they target the default entry. Selection is
+`reconstruct`, `baselines`) targets the server named by the
+`X-Bintrail-Server` request header; without the header they target the
+default entry (`storage` is the one process-global exception). Selection is
 stateless — concurrent clients can each target a different server.
 
 ### Time-travel (reconstruct)

--- a/docs/console.md
+++ b/docs/console.md
@@ -102,10 +102,18 @@ under `watch` — see the control plane below).
 How it behaves:
 
 - **The command-line entry.** `--index-dsn` (or `watch`'s stream index)
-  appears as an ephemeral `default (cli)` entry: it is the initial selection,
-  is never written to the registry file, and cannot be edited or deleted from
-  the UI. With at least one saved server, `--index-dsn` becomes optional — the
-  console can start registry-only.
+  appears as an ephemeral entry labeled by its database name, e.g.
+  `bintrail_index (cli)`: it is never written to the registry file and cannot
+  be edited or deleted from the UI. With at least one saved server,
+  `--index-dsn` becomes optional — the console can start registry-only.
+  **It is a connection to the daemon's own index database, not a monitored
+  source** — under source-less `watch` nothing ever streams into it (each
+  added source gets its own per-source database), so it legitimately shows 0
+  events with a full set of provisioned partitions. For that reason a
+  source-less `watch` daemon **demotes** it: fresh tabs land on the first
+  monitored registry server instead, and the cli entry sorts last in the
+  switcher (still selectable — its Status shows the boot index and the
+  rotation that maintains it).
 - **Lazy connections.** Saved servers connect on first selection (with an
   eager ping, so a dead server fails the moment you switch to it, not on your
   first query). Editing a server's connection details closes and reopens its
@@ -215,8 +223,9 @@ the `monitor` capability is false and the verbs return 403 there.
 `bintrail-console watch` runs the built-in rotation loop that keeps the index
 from growing without bound: it drops binlog partitions older than a **retention
 window** every **interval**, keeping a few **future partitions** ready. Under
-`watch` you can tune that policy from the console — **⌘K → "Configure
-rotation…"** — without editing flags or restarting:
+`watch` you can tune that policy from the console — the sidebar's
+**Settings → Rotation** entry, or **⌘K → "Configure rotation…"** — without
+editing flags or restarting:
 
 - **Live:** changes apply on the loop's next cycle. Retention and future-partition
   count take effect immediately; a changed interval re-tunes the schedule.
@@ -232,6 +241,30 @@ rotation…"** — without editing flags or restarting:
   off. A retain like `off` is rejected at save.
 - The standalone `bintrail-console serve` hides the panel and refuses the write
   (HTTP 403) — only the daemon running the loop consumes the policy.
+
+### The Storage page
+
+Under `watch` the sidebar grows a **Settings → Storage** page that gathers
+everything S3/baseline-related in one place (it was previously scattered
+across the rotation dialog and the per-server edit form):
+
+- **Rotation** — the effective policy (override vs daemon defaults) with an
+  edit shortcut to the rotation dialog.
+- **S3 archiving per source** — every monitored server with its
+  `Archive to S3` destination (or `drop-only` when none), with a shortcut into
+  that server's edit form. The boot (cli) index always rotates drop-only.
+- **Baseline snapshots** — a read-only listing of the **selected server's**
+  baseline source (`baseline_dir` / `baseline_s3`): each snapshot's timestamp,
+  age, table count, and (local sources) the binlog coordinates its deltas
+  start from. The empty states explain how to produce a first baseline
+  (`bintrail dump` → `bintrail baseline`).
+- **AWS credentials** — which ambient credential signals the daemon process
+  can see: env keys (presence only, never values), `AWS_PROFILE`,
+  `AWS_REGION`, a shared `~/.aws` config, ECS task-role / EKS IRSA markers.
+  **The console never stores AWS keys** — uploads and reads use the AWS
+  default credential chain of the daemon (environment, shared profile incl.
+  SSO, or an IAM role; EC2/ECS/EKS roles work even when nothing shows as set,
+  since instance roles are not detectable without a metadata call).
 
 ## Flags
 
@@ -408,6 +441,8 @@ All endpoints return JSON. `/api/*` (except `healthz`) require
 | `GET /api/servers/{id}/monitor` | Supervisor only: `{monitor: {state, last_error, since}}` — `stopped\|pending\|running\|stalled\|lost_position\|failed`. |
 | `GET /api/rotation` | Effective global rotation policy: `{retain, interval, add_future, source, enabled}` — `source` is `"override"` (console-saved) or `"default"` (daemon `--rotate-*`). |
 | `PUT /api/rotation` | Supervisor only (403 on the standalone console): save a global rotation override `{retain, interval, add_future}` (validated; `off` rejected). Applies live on the next cycle. |
+| `GET /api/baselines` | Read-only listing of the **selected server's** baseline snapshots, grouped per snapshot: `{configured, source, kind, reconstruct, snapshots: [{time, age_hours, tables, binlog_file, binlog_pos, gtid_set}]}` (coordinates local-only, capped at 50 snapshots). `502` when the configured source is unreadable. |
+| `GET /api/storage` | Process-global storage context: `{aws: {access_key_env, profile, region_env, shared_config, container_creds, web_identity}}` — presence booleans and non-secret names only, never credential values. |
 
 Every data endpoint (`status`, `schemas`, `events`, `recover`, `capabilities`,
 `reconstruct`) targets the server named by the `X-Bintrail-Server` request

--- a/docs/query-and-recovery.md
+++ b/docs/query-and-recovery.md
@@ -260,6 +260,17 @@ UPDATE id=5: status=published→deleted (at 14:03)
 
 Reversed: undo the 14:03 UPDATE first, then the 14:02 UPDATE, then the 14:01 INSERT. This is the correct rollback order for any sequence of operations on the same row.
 
+> **Foreign keys are NOT handled.** Reverse-chronological ordering is the only
+> ordering `bintrail recover` applies — there is no FK-graph analysis, no
+> topological reordering across tables, and the generated script never emits
+> `SET FOREIGN_KEY_CHECKS`. Tables with `ON DELETE/UPDATE CASCADE` produce
+> side-effect row changes that reversal SQL cannot reliably undo
+> (`bintrail doctor` warns about them, and ingestion refuses to start against
+> a source that has them). The FK-aware recovery described on dbtrail.com
+> (parent resolution via `resolve_fk`, dependent ordering) is a dbtrail
+> platform feature, not part of this binary — even though the hosted `recover`
+> tool shares its name with the CLI command and the console tab.
+
 ### WHERE Clause Strategy
 
 For `UPDATE` and `DELETE` reversals, the generator needs a `WHERE` clause to identify the correct row in the current database state.

--- a/docs/query-and-recovery.md
+++ b/docs/query-and-recovery.md
@@ -265,8 +265,9 @@ Reversed: undo the 14:03 UPDATE first, then the 14:02 UPDATE, then the 14:01 INS
 > topological reordering across tables, and the generated script never emits
 > `SET FOREIGN_KEY_CHECKS`. Tables with `ON DELETE/UPDATE CASCADE` produce
 > side-effect row changes that reversal SQL cannot reliably undo
-> (`bintrail doctor` warns about them, and ingestion refuses to start against
-> a source that has them). The FK-aware recovery described on dbtrail.com
+> (`bintrail doctor` warns about them, and `stream`/`watch` — plus `index`
+> runs given a `--source-dsn` to validate against — refuse to start when the
+> source has them). The FK-aware recovery described on dbtrail.com
 > (parent resolution via `resolve_fk`, dependent ordering) is a dbtrail
 > platform feature, not part of this binary — even though the hosted `recover`
 > tool shares its name with the CLI command and the console tab.

--- a/internal/baseline/baselines.go
+++ b/internal/baseline/baselines.go
@@ -26,6 +26,9 @@ type BaselineInfo struct {
 //
 // where <timestamp> is an RFC3339 string with colons replaced by hyphens
 // (e.g. "2025-02-28T00-00-00Z"). Files that cannot be parsed are skipped.
+// internal/reconstruct.ListBaselines walks the same layout (local + S3,
+// path-only) for the console's listing — keep the two in sync if the layout
+// ever changes.
 func DiscoverBaselines(dir string) ([]BaselineInfo, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -1343,17 +1343,29 @@ async function renderStorage() {
   // Each fetch degrades independently: a panel renders its own failure note
   // instead of one error wiping the whole page. (A 401 inside api() raises the
   // sign-in gate and bumps serverGen, so the stale-render guard below bails.)
+  const asErr = (err) => ({ error: (err && err.message) || String(err) });
   const [serversRes, rotation, storage, baselines] = await Promise.all([
-    api("/api/servers").catch(() => null),
-    api("/api/rotation").catch(() => null),
-    api("/api/storage").catch(() => null),
-    api("/api/baselines").catch((err) => ({ error: (err && err.message) || String(err) })),
+    api("/api/servers").catch(asErr),
+    api("/api/rotation").catch(asErr),
+    api("/api/storage").catch(asErr),
+    api("/api/baselines").catch(asErr),
   ]);
   if (gen !== serverGen) return;
-  buildStorage((serversRes && serversRes.servers) || [], rotation, storage, baselines);
+  // Same guard as renderOverview: a throw inside the build must show an
+  // error, never leave the "Loading…" skeleton up forever.
+  try {
+    buildStorage(serversRes, rotation, storage, baselines);
+  } catch (err) {
+    const v = VIEW(); clear(v); v.append(pageHead("Storage", null)); renderError(v, err);
+  }
 }
 
-function buildStorage(servers, rotation, storage, baselines) {
+function buildStorage(serversRes, rotation, storage, baselines) {
+  // serversRes is the raw /api/servers payload or {error} — archivingPanel
+  // must be able to tell "failed to load" from "genuinely no sources", or a
+  // transient 500 would render the affirmative "No monitored sources yet" lie.
+  const servers = (serversRes && serversRes.servers) || [];
+  const serversErr = serversRes && serversRes.error;
   const v = VIEW(); clear(v);
   const sub = el("p", { class: "page-sub" },
     "Where captured history lives beyond the index — per-source S3 archiving, the rotation that feeds it, and the baselines Time-travel reads. ",
@@ -1362,13 +1374,14 @@ function buildStorage(servers, rotation, storage, baselines) {
   v.append(pageHead("Storage", sub));
 
   const cards = el("div", { class: "cards" });
+  const cur = servers.find((s) => s.id === (currentServer || defaultServerId));
   cards.append(rotationCard(rotation));
   cards.append(credentialsCard(storage));
-  cards.append(baselineSummaryCard(baselines));
+  cards.append(baselineSummaryCard(baselines, cur));
   v.append(cards);
 
   const grid = el("div", { class: "ov-grid", style: "margin-top:18px" });
-  grid.append(archivingPanel(servers));
+  grid.append(archivingPanel(servers, serversErr));
   grid.append(baselinesPanel(baselines, servers));
   v.append(grid);
   viewEnter();
@@ -1382,8 +1395,8 @@ function kvRow(card, k, val) {
 
 function rotationCard(rot) {
   const card = el("div", { class: "card" }, el("div", { class: "card-title", text: "Rotation" }));
-  if (!rot) {
-    card.append(el("p", { class: "form-hint", text: "Could not load the rotation policy." }));
+  if (!rot || rot.error) {
+    card.append(el("p", { class: "form-hint", text: "Could not load the rotation policy" + (rot && rot.error ? ": " + rot.error : ".") }));
     return card;
   }
   kvRow(card, "retention", rot.retain);
@@ -1400,7 +1413,7 @@ function credentialsCard(storage) {
   const card = el("div", { class: "card" }, el("div", { class: "card-title", text: "AWS credentials" }));
   const aws = storage && storage.aws;
   if (!aws) {
-    card.append(el("p", { class: "form-hint", text: "Could not read the daemon's credential signals." }));
+    card.append(el("p", { class: "form-hint", text: "Could not read the daemon's credential signals" + (storage && storage.error ? ": " + storage.error : ".") }));
     return card;
   }
   kvRow(card, "access keys (env)", aws.access_key_env ? "set" : "not set");
@@ -1410,11 +1423,11 @@ function credentialsCard(storage) {
   if (aws.container_creds) kvRow(card, "ECS task role", "detected");
   if (aws.web_identity) kvRow(card, "EKS IRSA", "detected");
   card.append(el("p", { class: "form-hint stg-hint", text:
-    "S3 access uses the AWS default credential chain of the daemon process — environment keys, a shared profile (incl. SSO), or an IAM role. EC2/ECS/EKS roles work even when nothing shows as set here. The console never stores keys." }));
+    "S3 uploads and archive reads use the AWS default credential chain of the daemon process — environment keys, a shared profile (incl. SSO), or an IAM role; roles work even when nothing shows as set here. Baseline listings from s3:// currently support environment keys only. The console never stores keys." }));
   return card;
 }
 
-function baselineSummaryCard(b) {
+function baselineSummaryCard(b, cur) {
   const card = el("div", { class: "card" }, el("div", { class: "card-title", text: "Baselines" }));
   if (!b || b.error) {
     card.append(el("p", { class: "form-hint", text: "Could not list baselines: " + ((b && b.error) || "unavailable") }));
@@ -1422,8 +1435,7 @@ function baselineSummaryCard(b) {
   }
   if (!b.configured) {
     kvRow(card, "source", "not configured");
-    card.append(el("p", { class: "form-hint stg-hint", text:
-      "Set a Baseline dir / S3 on the server (Manage servers → Edit → Advanced) to enable Time-travel." }));
+    card.append(el("p", { class: "form-hint stg-hint", text: baselineConfigHint(cur) }));
     return card;
   }
   const snaps = b.snapshots || [];
@@ -1435,6 +1447,17 @@ function baselineSummaryCard(b) {
   return card;
 }
 
+// baselineConfigHint: the boot (cli) entry is not editable from the UI — its
+// baseline comes only from --baseline-dir/--baseline-s3 (or the BINTRAIL_
+// CONSOLE_BASELINE_DIR/_S3 env; BASELINE_DIR in the compose stack) — so the
+// "edit the server" instruction would point it at a dead end.
+function baselineConfigHint(cur) {
+  if (cur && cur.kind === "ephemeral") {
+    return "This is the command-line (cli) entry — restart the daemon with --baseline-dir / --baseline-s3 (compose: BASELINE_DIR in .env) to enable Time-travel on it.";
+  }
+  return "Set a Baseline dir / S3 on the server (Manage servers → Edit → Advanced) to enable Time-travel.";
+}
+
 function formatAge(hours) {
   if (hours == null) return "—";
   if (hours < 1) return Math.max(1, Math.round(hours * 60)) + " min";
@@ -1442,14 +1465,16 @@ function formatAge(hours) {
   return Math.round(hours / 24) + " day(s)";
 }
 
-function archivingPanel(servers) {
+function archivingPanel(servers, serversErr) {
   const panel = el("section", { class: "ov-panel" });
   panel.append(el("div", { class: "ov-panel-head" },
     el("h2", { class: "ov-panel-title", text: "S3 archiving per source" }),
     el("a", { class: "btn btn-sm btn-ghost", text: "Manage servers ›", onclick: openServersModal })));
   const list = el("div", { class: "stg-list" });
   const sources = servers.filter((s) => s.has_source);
-  if (!sources.length) {
+  if (serversErr) {
+    list.append(el("div", { class: "ev-empty", text: "Could not load servers: " + serversErr }));
+  } else if (!sources.length) {
     list.append(el("div", { class: "ev-empty", text: "No monitored sources yet — add one under Manage servers." }));
   } else {
     sources.forEach((s) => {
@@ -1478,10 +1503,10 @@ function baselinesPanel(b, servers) {
     list.append(el("div", { class: "ev-empty", text: "Could not list baselines: " + ((b && b.error) || "unavailable") }));
   } else if (!b.configured) {
     list.append(el("div", { class: "ev-empty", text:
-      "No baseline source configured for this server. Baselines are full-table Parquet snapshots (bintrail dump → bintrail baseline); with one configured, Time-travel reconstructs complete rows — not just rows with binlog activity." }));
+      "No baseline source configured for this server. Baselines are full-table Parquet snapshots (bintrail dump → bintrail baseline); with one configured, Time-travel reconstructs complete rows — not just rows with binlog activity. " + baselineConfigHint(cur) }));
   } else if (!(b.snapshots || []).length) {
     list.append(el("div", { class: "ev-empty", text:
-      "Source configured (" + b.source + ") but no snapshots found yet — run bintrail dump + bintrail baseline to create the first one." }));
+      "Source configured (" + b.source + ") but no snapshots matched the expected <timestamp>/<schema>/<table>.parquet layout — run bintrail dump + bintrail baseline to create the first one, and check the path points at the snapshots' PARENT directory." }));
   } else {
     b.snapshots.forEach((sn) => {
       const row = el("div", { class: "stg-row" });
@@ -1601,13 +1626,15 @@ async function loadServers() {
   const sel = document.getElementById("server-select");
   if (sel) {
     clear(sel);
-    // Registry servers first; the ephemeral boot entry goes last — it is the
-    // daemon's anchor index, not where a monitored source's events land.
+    // Registry servers first; the ephemeral boot entry goes last (in every
+    // mode — it is the connection the operator least often switches to; under
+    // source-ful watch it does carry the main stream's events and stays one
+    // click away).
     const ordered = servers.filter((s) => s.kind !== "ephemeral")
       .concat(servers.filter((s) => s.kind === "ephemeral"));
     ordered.forEach((s) => {
       const o = opt(s.id, serverLabel(s));
-      if (s.kind === "ephemeral") o.title = "The daemon's own index database (from --index-dsn) — not a monitored source";
+      if (s.kind === "ephemeral") o.title = "The daemon's own index database (from --index-dsn); managed by the command line";
       sel.append(o);
     });
     sel.value = currentServer || defaultServerId;

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -39,7 +39,7 @@ const EVENT_CSV_COLUMNS = [
 const BADGE_CLASS = { UPDATE: "b-update", INSERT: "b-insert", DELETE: "b-delete" };
 function badgeClass(t) { return BADGE_CLASS[t] || "b-baseline"; }
 
-const ROUTES = ["overview", "events", "timetravel", "recover", "status"];
+const ROUTES = ["overview", "events", "timetravel", "recover", "status", "storage"];
 
 const MON_STATE_TITLES = {
   failed: "stream failing — retrying with backoff; press Start for details",
@@ -538,6 +538,8 @@ function navigate(route, params, push = true) {
   if (!ROUTES.includes(route)) route = "overview";
   // Reconstruct surface is gated; never navigate to a disabled Time-travel.
   if (route === "timetravel" && !capsCache.reconstruct) route = "overview";
+  // Storage is a watch-daemon surface (rotation + archiving live there).
+  if (route === "storage" && !capsCache.monitor) route = "overview";
   const qs = params && Object.keys(params).length
     ? "?" + new URLSearchParams(params).toString() : "";
   if (push) history.pushState({ route }, "", "/" + route + qs);
@@ -555,6 +557,7 @@ function renderRoute() {
     case "timetravel": return renderTimetravel(params);
     case "recover": return renderRecover(params);
     case "status": return renderStatus();
+    case "storage": return renderStorage();
     default: return renderOverview();
   }
 }
@@ -1329,6 +1332,171 @@ function updateSideMeta(status) {
   }
 }
 
+// ── Storage (rotation · S3 archiving · baselines · credentials) ──────────────
+
+async function renderStorage() {
+  // Gated like Time-travel: a direct URL / Back with the capability off must
+  // REWRITE the URL (replaceState) before re-dispatching — see renderTimetravel.
+  if (!capsCache.monitor) { history.replaceState({}, "", "/overview"); renderRoute(); return; }
+  const gen = serverGen;
+  viewLoading();
+  // Each fetch degrades independently: a panel renders its own failure note
+  // instead of one error wiping the whole page. (A 401 inside api() raises the
+  // sign-in gate and bumps serverGen, so the stale-render guard below bails.)
+  const [serversRes, rotation, storage, baselines] = await Promise.all([
+    api("/api/servers").catch(() => null),
+    api("/api/rotation").catch(() => null),
+    api("/api/storage").catch(() => null),
+    api("/api/baselines").catch((err) => ({ error: (err && err.message) || String(err) })),
+  ]);
+  if (gen !== serverGen) return;
+  buildStorage((serversRes && serversRes.servers) || [], rotation, storage, baselines);
+}
+
+function buildStorage(servers, rotation, storage, baselines) {
+  const v = VIEW(); clear(v);
+  const sub = el("p", { class: "page-sub" },
+    "Where captured history lives beyond the index — per-source S3 archiving, the rotation that feeds it, and the baselines Time-travel reads. ",
+    el("b", { text: "No credentials are stored here" }),
+    " — uploads use the daemon's ambient AWS identity.");
+  v.append(pageHead("Storage", sub));
+
+  const cards = el("div", { class: "cards" });
+  cards.append(rotationCard(rotation));
+  cards.append(credentialsCard(storage));
+  cards.append(baselineSummaryCard(baselines));
+  v.append(cards);
+
+  const grid = el("div", { class: "ov-grid", style: "margin-top:18px" });
+  grid.append(archivingPanel(servers));
+  grid.append(baselinesPanel(baselines, servers));
+  v.append(grid);
+  viewEnter();
+}
+
+function kvRow(card, k, val) {
+  card.append(el("div", { class: "kv" },
+    el("span", { class: "kv-k", text: k }),
+    el("span", { class: "kv-v", text: val === null || val === undefined || val === "" ? "—" : String(val) })));
+}
+
+function rotationCard(rot) {
+  const card = el("div", { class: "card" }, el("div", { class: "card-title", text: "Rotation" }));
+  if (!rot) {
+    card.append(el("p", { class: "form-hint", text: "Could not load the rotation policy." }));
+    return card;
+  }
+  kvRow(card, "retention", rot.retain);
+  kvRow(card, "interval", rot.interval);
+  kvRow(card, "future partitions", rot.add_future);
+  kvRow(card, "policy", rot.source === "override" ? "console override (live)" : "daemon defaults");
+  if (!rot.enabled) card.append(el("p", { class: "form-hint", text: "Rotation is OFF at the daemon (--rotate-retain off) — saved changes need a restart." }));
+  card.append(el("div", { class: "stg-cardfoot" },
+    el("button", { class: "btn btn-sm", type: "button", text: "Edit rotation…", onclick: showRotationDialog })));
+  return card;
+}
+
+function credentialsCard(storage) {
+  const card = el("div", { class: "card" }, el("div", { class: "card-title", text: "AWS credentials" }));
+  const aws = storage && storage.aws;
+  if (!aws) {
+    card.append(el("p", { class: "form-hint", text: "Could not read the daemon's credential signals." }));
+    return card;
+  }
+  kvRow(card, "access keys (env)", aws.access_key_env ? "set" : "not set");
+  kvRow(card, "profile (env)", aws.profile || "—");
+  kvRow(card, "region (env)", aws.region_env || "—");
+  kvRow(card, "~/.aws config", aws.shared_config ? "present" : "absent");
+  if (aws.container_creds) kvRow(card, "ECS task role", "detected");
+  if (aws.web_identity) kvRow(card, "EKS IRSA", "detected");
+  card.append(el("p", { class: "form-hint stg-hint", text:
+    "S3 access uses the AWS default credential chain of the daemon process — environment keys, a shared profile (incl. SSO), or an IAM role. EC2/ECS/EKS roles work even when nothing shows as set here. The console never stores keys." }));
+  return card;
+}
+
+function baselineSummaryCard(b) {
+  const card = el("div", { class: "card" }, el("div", { class: "card-title", text: "Baselines" }));
+  if (!b || b.error) {
+    card.append(el("p", { class: "form-hint", text: "Could not list baselines: " + ((b && b.error) || "unavailable") }));
+    return card;
+  }
+  if (!b.configured) {
+    kvRow(card, "source", "not configured");
+    card.append(el("p", { class: "form-hint stg-hint", text:
+      "Set a Baseline dir / S3 on the server (Manage servers → Edit → Advanced) to enable Time-travel." }));
+    return card;
+  }
+  const snaps = b.snapshots || [];
+  kvRow(card, "source", b.source);
+  kvRow(card, "snapshots", String(snaps.length) + (b.truncated ? "+" : ""));
+  kvRow(card, "latest", snaps.length ? snaps[0].time : "none yet");
+  if (snaps.length) kvRow(card, "age", formatAge(snaps[0].age_hours));
+  kvRow(card, "time-travel", b.reconstruct ? "enabled" : "off (archives disabled)");
+  return card;
+}
+
+function formatAge(hours) {
+  if (hours == null) return "—";
+  if (hours < 1) return Math.max(1, Math.round(hours * 60)) + " min";
+  if (hours < 48) return Math.round(hours) + " h";
+  return Math.round(hours / 24) + " day(s)";
+}
+
+function archivingPanel(servers) {
+  const panel = el("section", { class: "ov-panel" });
+  panel.append(el("div", { class: "ov-panel-head" },
+    el("h2", { class: "ov-panel-title", text: "S3 archiving per source" }),
+    el("a", { class: "btn btn-sm btn-ghost", text: "Manage servers ›", onclick: openServersModal })));
+  const list = el("div", { class: "stg-list" });
+  const sources = servers.filter((s) => s.has_source);
+  if (!sources.length) {
+    list.append(el("div", { class: "ev-empty", text: "No monitored sources yet — add one under Manage servers." }));
+  } else {
+    sources.forEach((s) => {
+      const row = el("div", { class: "stg-row" });
+      row.append(el("span", { class: "stg-name", text: s.name }));
+      row.append(el("span", { class: "stg-dest" + (s.archive_s3 ? "" : " muted"), text: s.archive_s3 || "drop-only (no S3 destination)" }));
+      if (s.monitor_state) row.append(el("span", { class: "chip chip-mon", text: s.monitor_state.replace("_", " ").toUpperCase(), title: MON_STATE_TITLES[s.monitor_state] || ("monitoring " + s.monitor_state) }));
+      row.append(el("button", { class: "btn btn-sm btn-ghost", type: "button", text: "Configure",
+        onclick: () => { openServersModal(); editServer(s.id); } }));
+      list.append(row);
+    });
+  }
+  panel.append(list);
+  panel.append(el("p", { class: "form-hint stg-foot", text:
+    "Rotated index partitions upload to the source's bucket as Parquet before they are dropped — history survives retention and stays queryable. The boot (cli) index rotates drop-only." }));
+  return panel;
+}
+
+function baselinesPanel(b, servers) {
+  const panel = el("section", { class: "ov-panel" });
+  const cur = (servers || []).find((s) => s.id === (currentServer || defaultServerId));
+  panel.append(el("div", { class: "ov-panel-head" },
+    el("h2", { class: "ov-panel-title", text: "Baseline snapshots" + (cur ? " — " + serverLabel(cur) : "") })));
+  const list = el("div", { class: "stg-list" });
+  if (!b || b.error) {
+    list.append(el("div", { class: "ev-empty", text: "Could not list baselines: " + ((b && b.error) || "unavailable") }));
+  } else if (!b.configured) {
+    list.append(el("div", { class: "ev-empty", text:
+      "No baseline source configured for this server. Baselines are full-table Parquet snapshots (bintrail dump → bintrail baseline); with one configured, Time-travel reconstructs complete rows — not just rows with binlog activity." }));
+  } else if (!(b.snapshots || []).length) {
+    list.append(el("div", { class: "ev-empty", text:
+      "Source configured (" + b.source + ") but no snapshots found yet — run bintrail dump + bintrail baseline to create the first one." }));
+  } else {
+    b.snapshots.forEach((sn) => {
+      const row = el("div", { class: "stg-row" });
+      row.append(el("span", { class: "stg-name mono", text: sn.time }));
+      row.append(el("span", { class: "stg-dest", text:
+        (sn.tables || []).length + " table(s)" + (sn.binlog_file ? " · " + sn.binlog_file + ":" + sn.binlog_pos : "") }));
+      row.append(el("span", { class: "stg-age", text: formatAge(sn.age_hours) + " ago" }));
+      list.append(row);
+    });
+    if (b.truncated) list.append(el("div", { class: "ev-empty", text: "…older snapshots not shown." }));
+  }
+  panel.append(list);
+  return panel;
+}
+
 // ── schemas / tables cascade ──────────────────────────────────────────────────
 
 async function loadSchemas() {
@@ -1416,7 +1584,13 @@ async function gateCapabilities() {
 
 // ── server registry: switcher + modal CRUD ──────────────────────────────────
 
-function serverLabel(s) { return s.kind === "ephemeral" ? s.name + " (cli)" : s.name; }
+// serverLabel: the ephemeral boot entry's name is the reserved id "default",
+// which reads as meaningless in the switcher — label it by its database name
+// (what the entry actually is: the daemon's own index DB from --index-dsn).
+function serverLabel(s) {
+  if (s.kind === "ephemeral") return (s.dbname || s.name) + " (cli)";
+  return s.name;
+}
 
 async function loadServers() {
   const data = await api("/api/servers");
@@ -1427,7 +1601,15 @@ async function loadServers() {
   const sel = document.getElementById("server-select");
   if (sel) {
     clear(sel);
-    servers.forEach((s) => sel.append(opt(s.id, serverLabel(s))));
+    // Registry servers first; the ephemeral boot entry goes last — it is the
+    // daemon's anchor index, not where a monitored source's events land.
+    const ordered = servers.filter((s) => s.kind !== "ephemeral")
+      .concat(servers.filter((s) => s.kind === "ephemeral"));
+    ordered.forEach((s) => {
+      const o = opt(s.id, serverLabel(s));
+      if (s.kind === "ephemeral") o.title = "The daemon's own index database (from --index-dsn) — not a monitored source";
+      sel.append(o);
+    });
     sel.value = currentServer || defaultServerId;
   }
   return servers;
@@ -1869,6 +2051,7 @@ function cmdkCommands() {
     { group: "Navigate", label: "Status", run: () => navigate("status") },
   ];
   if (capsCache.reconstruct) cmds.push({ group: "Navigate", label: "Time-travel", run: () => navigate("timetravel") });
+  if (capsCache.monitor) cmds.push({ group: "Navigate", label: "Storage", run: () => navigate("storage") });
   cmds.push({ group: "Actions", label: "Manage servers", run: () => { closeCmdk(); openServersModal(); } });
   if (capsCache.monitor) cmds.push({ group: "Actions", label: "Configure rotation…", run: () => { closeCmdk(); showRotationDialog(); } });
   if (capsCache.auth) {
@@ -1995,7 +2178,16 @@ async function init() {
   // fresh — clear any carried "Undo" context so the sidebar's Recover link
   // never shows a stale banner (the undoEvent bridge sets it and navigates
   // directly, bypassing this handler, so its context survives).
-  $all(".nav-item").forEach((a) => a.addEventListener("click", (e) => { e.preventDefault(); pendingRecover = null; navigate(a.dataset.route); }));
+  $all(".nav-item").forEach((a) => a.addEventListener("click", (e) => {
+    e.preventDefault();
+    // Route-less nav items are modal triggers (e.g. #nav-rotation) with their
+    // own bindings — navigate(undefined) would coerce to /overview and repaint
+    // the view behind the modal.
+    if (!a.dataset.route) return;
+    pendingRecover = null;
+    navigate(a.dataset.route);
+  }));
+  document.getElementById("nav-rotation").addEventListener("click", showRotationDialog);
   window.addEventListener("popstate", renderRoute);
 
   // Pre-auth gate: ask the (unauthenticated) probe how this console

--- a/internal/console/assets/index.html
+++ b/internal/console/assets/index.html
@@ -78,6 +78,22 @@
             <span>Status</span>
           </a>
         </div>
+        <!-- Settings exists only on the watch daemon (the process that runs
+             rotation and archiving) — gated like the Time-travel item. The
+             Rotation entry is a modal trigger, not a route: it has no
+             data-route, and init() binds it separately (the generic .nav-item
+             handler skips route-less items). -->
+        <div class="nav-group" data-capability="monitor">
+          <div class="nav-label">Settings</div>
+          <a class="nav-item" data-route="storage" href="/storage">
+            <span class="ni-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="5" rx="8" ry="3"/><path d="M4 5v14c0 1.66 3.58 3 8 3s8-1.34 8-3V5"/><path d="M4 12c0 1.66 3.58 3 8 3s8-1.34 8-3"/></svg></span>
+            <span>Storage</span>
+          </a>
+          <button class="nav-item" id="nav-rotation" type="button">
+            <span class="ni-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 0 1 15.5-6.2L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-15.5 6.2L3 16"/><path d="M3 21v-5h5"/></svg></span>
+            <span>Rotation</span>
+          </button>
+        </div>
       </nav>
 
       <div class="side-foot">

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -1212,3 +1212,23 @@ button { font-family: inherit; }
 
 /* loading shimmer for #view while a screen fetches */
 .view-loading { font-family: var(--f-mono); font-size: 12.5px; color: var(--ink-4); padding: 20px 2px; }
+
+/* ── Storage page (Settings) ── */
+.stg-list { display: flex; flex-direction: column; padding: 2px 14px 10px; }
+.stg-row {
+  display: flex; align-items: center; gap: 10px;
+  padding: 9px 0; border-bottom: 1px solid var(--line-soft);
+  font-size: 13px;
+}
+.stg-row:last-child { border-bottom: none; }
+.stg-name { font-weight: 600; color: var(--ink); white-space: nowrap; }
+.stg-name.mono { font-family: var(--f-mono); font-weight: 500; font-size: 12.5px; }
+.stg-dest {
+  color: var(--ink-2); flex: 1; min-width: 0;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.stg-dest.muted { color: var(--ink-3); }
+.stg-age { color: var(--ink-3); font-size: 12px; white-space: nowrap; }
+.stg-foot { padding: 0 14px 12px; margin: 6px 0 0; }
+.stg-hint { margin-bottom: 0; }
+.stg-cardfoot { margin-top: 12px; }

--- a/internal/console/baselines_api.go
+++ b/internal/console/baselines_api.go
@@ -1,0 +1,104 @@
+package console
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/baseline"
+	"github.com/dbtrail/dbtrail/internal/reconstruct"
+)
+
+// baselinesMaxSnapshots caps the snapshots GET /api/baselines returns — the
+// Storage panel is a recency view ("do I have a usable baseline, how stale is
+// it"), not an inventory dump.
+const baselinesMaxSnapshots = 50
+
+// baselineSnapshotDTO is one snapshot (one timestamped dump) in the listing:
+// the grouped view of its per-table Parquet files.
+type baselineSnapshotDTO struct {
+	Time     string  `json:"time"`
+	AgeHours float64 `json:"age_hours"`
+	// Tables lists schema.table, sorted (the lister's stable order).
+	Tables []string `json:"tables"`
+	// Binlog coordinates from Parquet metadata — where this snapshot's deltas
+	// start. Local sources only: reading per-snapshot Parquet footers over S3
+	// is not worth the listing latency.
+	BinlogFile string `json:"binlog_file,omitempty"`
+	BinlogPos  int64  `json:"binlog_pos,omitempty"`
+	GTIDSet    string `json:"gtid_set,omitempty"`
+}
+
+type baselinesResponse struct {
+	// Configured reports whether the selected server has a baseline source at
+	// all (dir or s3). Reconstruct additionally requires archives enabled and
+	// no RBAC profile (the bundle's gate) — a server can list baselines that
+	// Time-travel still refuses to use.
+	Configured  bool                  `json:"configured"`
+	Source      string                `json:"source,omitempty"`
+	Kind        string                `json:"kind,omitempty"` // "dir" | "s3"
+	Reconstruct bool                  `json:"reconstruct"`
+	Snapshots   []baselineSnapshotDTO `json:"snapshots"`
+	Truncated   bool                  `json:"truncated,omitempty"`
+}
+
+// handleBaselines serves GET /api/baselines: a read-only listing of the
+// selected server's baseline snapshots (the inputs Time-travel reconstructs
+// from), grouped per snapshot timestamp, newest first. The listing is
+// path-derived; only local sources additionally read one Parquet footer per
+// snapshot for its binlog coordinates (best-effort — a missing/corrupt footer
+// just omits them).
+func (s *Server) handleBaselines(w http.ResponseWriter, r *http.Request) {
+	b := s.resolveOr(w, r)
+	if b == nil {
+		return
+	}
+	resp := baselinesResponse{Reconstruct: b.baselineConfigured, Snapshots: []baselineSnapshotDTO{}}
+	if b.baselineSrc == "" {
+		writeJSON(w, http.StatusOK, resp)
+		return
+	}
+	resp.Configured = true
+	resp.Source = b.baselineSrc
+	resp.Kind = "dir"
+	if strings.HasPrefix(b.baselineSrc, "s3://") {
+		resp.Kind = "s3"
+	}
+
+	files, err := reconstruct.ListBaselines(r.Context(), b.baselineSrc)
+	if err != nil {
+		// The source is configured but unreadable (missing dir, unreachable
+		// bucket) — an upstream fault from the console's point of view, and an
+		// actionable message for the operator.
+		writeJSONError(w, http.StatusBadGateway, "list baselines: "+err.Error())
+		return
+	}
+
+	now := time.Now().UTC()
+	var cur *baselineSnapshotDTO
+	var curTime time.Time
+	for _, f := range files {
+		if cur == nil || !f.SnapshotTime.Equal(curTime) {
+			if len(resp.Snapshots) >= baselinesMaxSnapshots {
+				resp.Truncated = true
+				break
+			}
+			curTime = f.SnapshotTime
+			dto := baselineSnapshotDTO{
+				Time:     f.SnapshotTime.Format(consoleTSFormat),
+				AgeHours: now.Sub(f.SnapshotTime).Hours(),
+			}
+			if resp.Kind == "dir" {
+				if meta, err := baseline.ReadParquetMetadata(f.Path); err == nil {
+					dto.BinlogFile = meta.BinlogFile
+					dto.BinlogPos = meta.BinlogPos
+					dto.GTIDSet = meta.GTIDSet
+				}
+			}
+			resp.Snapshots = append(resp.Snapshots, dto)
+			cur = &resp.Snapshots[len(resp.Snapshots)-1]
+		}
+		cur.Tables = append(cur.Tables, f.Schema+"."+f.Table)
+	}
+	writeJSON(w, http.StatusOK, resp)
+}

--- a/internal/console/baselines_api.go
+++ b/internal/console/baselines_api.go
@@ -1,6 +1,7 @@
 package console
 
 import (
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -93,6 +94,12 @@ func (s *Server) handleBaselines(w http.ResponseWriter, r *http.Request) {
 					dto.BinlogFile = meta.BinlogFile
 					dto.BinlogPos = meta.BinlogPos
 					dto.GTIDSet = meta.GTIDSet
+				} else {
+					// Tolerated (the listing must not die on one bad footer), but
+					// never silent: a corrupt snapshot rendered as merely
+					// "coordinate-less" would look identical to a healthy
+					// pre-metadata baseline.
+					slog.Warn("console: baseline Parquet metadata unreadable", "path", f.Path, "error", err)
 				}
 			}
 			resp.Snapshots = append(resp.Snapshots, dto)

--- a/internal/console/baselines_api_test.go
+++ b/internal/console/baselines_api_test.go
@@ -5,6 +5,11 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
+
+	"github.com/parquet-go/parquet-go"
+
+	"github.com/dbtrail/dbtrail/internal/baseline"
 )
 
 // newBaselineServer builds a Server whose boot bundle points at a baseline
@@ -93,5 +98,93 @@ func TestBaselinesAPI_missingDirFailsLoud(t *testing.T) {
 	rec, body := doServersReq(t, srv, "GET", "/api/baselines", "")
 	if rec.Code != 502 {
 		t.Fatalf("code = %d (body %s), want 502 for an unreadable configured source", rec.Code, body)
+	}
+}
+
+// TestBaselinesAPI_truncation: the listing is a recency view — beyond the cap
+// it must keep the NEWEST snapshots and say so, and exactly-at-cap must not
+// claim truncation.
+func TestBaselinesAPI_truncation(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	mkDir := func(n int) string {
+		dir := t.TempDir()
+		for i := range n {
+			name := base.Add(time.Duration(i) * time.Hour).Format("2006-01-02T15-04-05Z")
+			writeBaselineFixture(t, dir, name, "shop", "orders.parquet")
+		}
+		return dir
+	}
+
+	srv := newBaselineServer(t, mkDir(baselinesMaxSnapshots+1), true)
+	rec, body := doServersReq(t, srv, "GET", "/api/baselines", "")
+	if rec.Code != 200 {
+		t.Fatalf("code = %d, body = %s", rec.Code, body)
+	}
+	var got baselinesResponse
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Snapshots) != baselinesMaxSnapshots || !got.Truncated {
+		t.Fatalf("snapshots = %d truncated = %v, want exactly %d truncated", len(got.Snapshots), got.Truncated, baselinesMaxSnapshots)
+	}
+	wantNewest := base.Add(time.Duration(baselinesMaxSnapshots) * time.Hour).Format("2006-01-02 15:04:05")
+	if got.Snapshots[0].Time != wantNewest {
+		t.Fatalf("snapshots[0] = %s, want the NEWEST %s — truncation must drop the oldest", got.Snapshots[0].Time, wantNewest)
+	}
+
+	srv = newBaselineServer(t, mkDir(baselinesMaxSnapshots), true)
+	_, body = doServersReq(t, srv, "GET", "/api/baselines", "")
+	// Fresh struct: truncated is omitempty, so a false response would leave
+	// the first subtest's stale true in place through Unmarshal.
+	got = baselinesResponse{}
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Snapshots) != baselinesMaxSnapshots || got.Truncated {
+		t.Fatalf("at exactly the cap: snapshots = %d truncated = %v, want %d untruncated", len(got.Snapshots), got.Truncated, baselinesMaxSnapshots)
+	}
+}
+
+// TestBaselinesAPI_metadataEnrichment: a real Parquet footer's binlog
+// coordinates must surface in the DTO (the happy half of the best-effort
+// enrichment — the error half is covered by the empty-file fixtures above).
+func TestBaselinesAPI_metadataEnrichment(t *testing.T) {
+	dir := t.TempDir()
+	snap := filepath.Join(dir, "2026-06-10T12-00-00Z", "shop")
+	if err := os.MkdirAll(snap, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	w, err := baseline.NewWriter(filepath.Join(snap, "orders.parquet"),
+		[]baseline.Column{{Name: "id", MySQLType: "int", ParquetType: parquet.Leaf(parquet.Int32Type)}},
+		baseline.WriterConfig{Compression: "none", RowGroupSize: 100, Metadata: map[string]string{
+			baseline.MetaKeyBinlogFile: "binlog.000042",
+			baseline.MetaKeyBinlogPos:  "12345",
+			baseline.MetaKeyGTIDSet:    "3e11fa47-bee9-11e4-9716-8f2e7c74b0e5:1-100",
+		}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := w.WriteRow([]string{"1"}, []bool{false}); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := newBaselineServer(t, dir, true)
+	rec, body := doServersReq(t, srv, "GET", "/api/baselines", "")
+	if rec.Code != 200 {
+		t.Fatalf("code = %d, body = %s", rec.Code, body)
+	}
+	var got baselinesResponse
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Snapshots) != 1 {
+		t.Fatalf("snapshots = %+v, want 1", got.Snapshots)
+	}
+	sn := got.Snapshots[0]
+	if sn.BinlogFile != "binlog.000042" || sn.BinlogPos != 12345 || sn.GTIDSet != "3e11fa47-bee9-11e4-9716-8f2e7c74b0e5:1-100" {
+		t.Fatalf("coords = %s:%d gtid=%s, want the written footer metadata", sn.BinlogFile, sn.BinlogPos, sn.GTIDSet)
 	}
 }

--- a/internal/console/baselines_api_test.go
+++ b/internal/console/baselines_api_test.go
@@ -1,0 +1,97 @@
+package console
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// newBaselineServer builds a Server whose boot bundle points at a baseline
+// source, without a DB (the baselines endpoint never touches the index).
+func newBaselineServer(t *testing.T, src string, configured bool) *Server {
+	t.Helper()
+	s := &Server{token: "t", cm: newConnManager(nil, false)}
+	s.cm.boot = &bundle{baselineSrc: src, baselineConfigured: configured}
+	s.mux = s.buildHandler()
+	return s
+}
+
+// writeBaselineFixture creates <dir>/<ts>/<schema>/<table>.parquet as an empty
+// file — the lister is path-derived, and the (local-only) metadata enrichment
+// must tolerate an unreadable Parquet footer by omitting the coordinates.
+func writeBaselineFixture(t *testing.T, dir string, parts ...string) {
+	t.Helper()
+	p := filepath.Join(append([]string{dir}, parts...)...)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBaselinesAPI_listsGroupedSnapshots(t *testing.T) {
+	dir := t.TempDir()
+	writeBaselineFixture(t, dir, "2026-06-01T00-00-00Z", "shop", "orders.parquet")
+	writeBaselineFixture(t, dir, "2026-06-10T12-00-00Z", "shop", "orders.parquet")
+	writeBaselineFixture(t, dir, "2026-06-10T12-00-00Z", "shop", "users.parquet")
+	writeBaselineFixture(t, dir, "not-a-timestamp", "shop", "junk.parquet") // skipped
+	writeBaselineFixture(t, dir, "2026-06-10T12-00-00Z", "shop", "README")  // not .parquet
+
+	srv := newBaselineServer(t, dir, true)
+	rec, body := doServersReq(t, srv, "GET", "/api/baselines", "")
+	if rec.Code != 200 {
+		t.Fatalf("code = %d, body = %s", rec.Code, body)
+	}
+	var got baselinesResponse
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatal(err)
+	}
+	if !got.Configured || got.Kind != "dir" || got.Source != dir || !got.Reconstruct {
+		t.Fatalf("header = %+v, want configured dir source with reconstruct on", got)
+	}
+	if len(got.Snapshots) != 2 {
+		t.Fatalf("snapshots = %d (%+v), want 2", len(got.Snapshots), got.Snapshots)
+	}
+	newest, oldest := got.Snapshots[0], got.Snapshots[1]
+	if newest.Time != "2026-06-10 12:00:00" || oldest.Time != "2026-06-01 00:00:00" {
+		t.Fatalf("order = %s, %s — want newest first", newest.Time, oldest.Time)
+	}
+	if len(newest.Tables) != 2 || newest.Tables[0] != "shop.orders" || newest.Tables[1] != "shop.users" {
+		t.Fatalf("newest tables = %v, want [shop.orders shop.users]", newest.Tables)
+	}
+	if len(oldest.Tables) != 1 || oldest.Tables[0] != "shop.orders" {
+		t.Fatalf("oldest tables = %v, want [shop.orders]", oldest.Tables)
+	}
+	if newest.AgeHours <= 0 {
+		t.Fatalf("age_hours = %v, want > 0", newest.AgeHours)
+	}
+	// Empty fixture files have no readable Parquet footer — coordinates omitted.
+	if newest.BinlogFile != "" || newest.BinlogPos != 0 {
+		t.Fatalf("binlog coords = %s:%d, want omitted for unreadable footers", newest.BinlogFile, newest.BinlogPos)
+	}
+}
+
+func TestBaselinesAPI_notConfigured(t *testing.T) {
+	srv := newBaselineServer(t, "", false)
+	rec, body := doServersReq(t, srv, "GET", "/api/baselines", "")
+	if rec.Code != 200 {
+		t.Fatalf("code = %d, body = %s", rec.Code, body)
+	}
+	var got baselinesResponse
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Configured || got.Reconstruct || got.Snapshots == nil || len(got.Snapshots) != 0 {
+		t.Fatalf("got %+v, want unconfigured with an empty (non-null) snapshot list", got)
+	}
+}
+
+func TestBaselinesAPI_missingDirFailsLoud(t *testing.T) {
+	srv := newBaselineServer(t, filepath.Join(t.TempDir(), "nope"), true)
+	rec, body := doServersReq(t, srv, "GET", "/api/baselines", "")
+	if rec.Code != 502 {
+		t.Fatalf("code = %d (body %s), want 502 for an unreadable configured source", rec.Code, body)
+	}
+}

--- a/internal/console/manager.go
+++ b/internal/console/manager.go
@@ -56,6 +56,14 @@ type connManager struct {
 	// nor baseline reads apply RBAC redaction.
 	profileActive bool
 
+	// demoteBoot prefers a registry entry over the boot entry as the default
+	// (no-header) selection when registry entries exist. Set by source-less
+	// `bintrail-console watch`: its boot index is only the control plane's
+	// anchor database — no stream ever writes to it — so landing new tabs
+	// there shows a permanently empty index. The boot entry stays listed and
+	// selectable. Written once before serving (console.New); read under mu.
+	demoteBoot bool
+
 	mu      sync.Mutex
 	bundles map[string]*bundle
 	locks   map[string]*sync.Mutex // per-id single-flight for lazy opens
@@ -86,24 +94,23 @@ func newConnManager(reg *Registry, profileActive bool) *connManager {
 // fan-out a tab switch fires (capabilities + schemas + events) opens ONE
 // connection, not four.
 func (cm *connManager) Resolve(ctx context.Context, id string) (*bundle, error) {
+	if id == "" {
+		// The no-header default must match defaultID() exactly — /api/servers
+		// reports that id as default_id and the switcher renders it selected,
+		// so resolving "" anywhere else would render one server while
+		// querying another.
+		if id = cm.defaultID(); id == "" {
+			return nil, errNoServers
+		}
+	}
 	cm.mu.Lock()
-	if id == "" || id == bootServerID {
-		if cm.boot != nil {
-			b := cm.boot
+	if id == bootServerID {
+		if b := cm.boot; b != nil {
 			cm.mu.Unlock()
 			return b, nil
 		}
-		if id == bootServerID {
-			cm.mu.Unlock()
-			return nil, ErrUnknownServer
-		}
-		// Registry-only console: default to the first entry.
-		entries := cm.reg.List()
-		if len(entries) == 0 {
-			cm.mu.Unlock()
-			return nil, errNoServers
-		}
-		id = entries[0].ID
+		cm.mu.Unlock()
+		return nil, ErrUnknownServer
 	}
 	if b, ok := cm.bundles[id]; ok {
 		cm.mu.Unlock()
@@ -305,15 +312,29 @@ func (cm *connManager) capability(entry ServerEntry) bool {
 }
 
 // defaultID returns the id the browser falls back to with no header: the boot
-// entry when present, else the first registry entry, else "".
+// entry when present, else the first registry entry, else "". Under demoteBoot
+// the preference inverts when registry entries exist: the first entry with a
+// source (a monitored server — where events actually land), else the first
+// entry. The boot entry stays selectable; it just stops being the landing
+// default for fresh tabs.
 func (cm *connManager) defaultID() string {
 	cm.mu.Lock()
 	boot := cm.boot
+	demote := cm.demoteBoot
 	cm.mu.Unlock()
+	entries := cm.reg.List()
 	if boot != nil {
-		return bootServerID
+		if !demote || len(entries) == 0 {
+			return bootServerID
+		}
+		for _, e := range entries {
+			if e.SourceDSN != "" {
+				return e.ID
+			}
+		}
+		return entries[0].ID
 	}
-	if entries := cm.reg.List(); len(entries) > 0 {
+	if len(entries) > 0 {
 		return entries[0].ID
 	}
 	return ""

--- a/internal/console/manager.go
+++ b/internal/console/manager.go
@@ -334,6 +334,9 @@ func (cm *connManager) defaultID() string {
 		}
 		return entries[0].ID
 	}
+	// boot == nil: registry-only console. demoteBoot is unreachable here
+	// today (only watch sets it, and watch always seeds a boot bundle), so the
+	// sourced-entry preference deliberately does not apply.
 	if len(entries) > 0 {
 		return entries[0].ID
 	}

--- a/internal/console/manager_test.go
+++ b/internal/console/manager_test.go
@@ -1,0 +1,81 @@
+package console
+
+import (
+	"context"
+	"testing"
+)
+
+// TestDefaultIDDemoteBoot: under demoteBoot (source-less watch) the no-header
+// default prefers a registry entry — first a monitored one, else the first —
+// while an empty registry or demoteBoot=false keeps the boot entry as default.
+func TestDefaultIDDemoteBoot(t *testing.T) {
+	reg, err := LoadRegistry("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cm := newConnManager(reg, false)
+	cm.boot = &bundle{}
+	cm.demoteBoot = true
+
+	if got := cm.defaultID(); got != bootServerID {
+		t.Fatalf("empty registry: defaultID = %q, want %q (nothing to demote to)", got, bootServerID)
+	}
+
+	viewOnly, err := reg.Add(ServerEntry{Name: "view-only", DSN: "u:p@tcp(h:3306)/idx"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := cm.defaultID(); got != viewOnly.ID {
+		t.Fatalf("demoted, only view-only entries: defaultID = %q, want %q", got, viewOnly.ID)
+	}
+
+	monitored, err := reg.Add(ServerEntry{Name: "prod", DSN: "u:p@tcp(h:3306)/idx2", SourceDSN: "r:p@tcp(src:3306)/"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := cm.defaultID(); got != monitored.ID {
+		t.Fatalf("demoted: defaultID = %q, want the monitored entry %q", got, monitored.ID)
+	}
+
+	cm.demoteBoot = false
+	if got := cm.defaultID(); got != bootServerID {
+		t.Fatalf("not demoted: defaultID = %q, want %q", got, bootServerID)
+	}
+}
+
+// TestResolveEmptyFollowsDemotedDefault: Resolve("") must land on the same
+// entry defaultID() reports — the switcher renders default_id as selected, so
+// resolving "" anywhere else would render one server while querying another.
+func TestResolveEmptyFollowsDemotedDefault(t *testing.T) {
+	reg, err := LoadRegistry("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cm := newConnManager(reg, false)
+	cm.boot = &bundle{}
+	cm.demoteBoot = true
+
+	entry, err := reg.Add(ServerEntry{Name: "prod", DSN: "u:p@tcp(h:3306)/idx", SourceDSN: "r:p@tcp(s:3306)/"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := &bundle{}
+	cm.bundles[entry.ID] = want // pre-cached so Resolve never dials
+
+	got, err := cm.Resolve(context.Background(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf(`Resolve("") did not follow the demoted default %q`, entry.ID)
+	}
+
+	// The boot entry stays selectable by id even while demoted.
+	b, err := cm.Resolve(context.Background(), bootServerID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b != cm.boot {
+		t.Fatal("boot entry must stay reachable by its id while demoted")
+	}
+}

--- a/internal/console/manager_test.go
+++ b/internal/console/manager_test.go
@@ -2,6 +2,7 @@ package console
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 )
 
@@ -77,5 +78,52 @@ func TestResolveEmptyFollowsDemotedDefault(t *testing.T) {
 	}
 	if b != cm.boot {
 		t.Fatal("boot entry must stay reachable by its id while demoted")
+	}
+}
+
+// TestServersAPIDemoteBootWire: the DemoteBoot wiring end to end — Config flag
+// → connManager → /api/servers default_id. Guards the one-line
+// s.cm.demoteBoot assignment in New(): drop it and source-less watch silently
+// lands fresh tabs back on the permanently-empty boot index (the exact bug
+// DemoteBoot exists to fix) while the white-box tests above keep passing.
+func TestServersAPIDemoteBootWire(t *testing.T) {
+	db, _, closeFn := newSQLMock(t)
+	defer closeFn()
+	reg, err := LoadRegistry(t.TempDir() + "/console-servers.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry, err := reg.Add(ServerEntry{Name: "prod", DSN: "u:p@tcp(h:3306)/idx", SourceDSN: "r:p@tcp(s:3306)/"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv, err := New(Config{
+		Listen: "127.0.0.1:8090", Token: "t", Registry: reg,
+		DB: db, DBName: "binlog_index", BootDSN: "cli:pw@tcp(127.0.0.1:3306)/binlog_index",
+		DemoteBoot: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rec, body := doServersReq(t, srv, "GET", "/api/servers", "")
+	if rec.Code != 200 {
+		t.Fatalf("list code = %d, body = %s", rec.Code, body)
+	}
+	var resp serversResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.DefaultID != entry.ID {
+		t.Fatalf("default_id = %q, want the monitored registry entry %q (DemoteBoot wiring broken?)", resp.DefaultID, entry.ID)
+	}
+	hasBoot := false
+	for _, sv := range resp.Servers {
+		if sv.ID == bootServerID {
+			hasBoot = true
+		}
+	}
+	if !hasBoot {
+		t.Fatal("the boot entry must stay listed while demoted")
 	}
 }

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -40,6 +40,13 @@ type Config struct {
 	// BootDSN is the boot entry's DSN, used ONLY to render the masked
 	// host/user/dbname view in /api/servers. Optional.
 	BootDSN string
+	// DemoteBoot prefers a registry entry over the boot entry as the default
+	// (no-header) selection when registry entries exist. Set by source-less
+	// `bintrail-console watch`: its boot index is only the control plane's
+	// anchor database — no stream ever writes to it — so landing new tabs
+	// there would show a permanently empty index. The boot entry stays
+	// listed and selectable.
+	DemoteBoot bool
 	// Registry is the named-server store (a local YAML file — the only thing
 	// the console ever writes). nil means an empty in-memory registry.
 	Registry *Registry
@@ -245,6 +252,7 @@ func New(cfg Config) (*Server, error) {
 		loginLimiter:     newLoginLimiter(),
 		tlsConf:          tlsConf,
 	}
+	s.cm.demoteBoot = cfg.DemoteBoot
 
 	// Seed the ephemeral boot bundle when the caller supplied a command-line
 	// connection (or baseline config for it). Its derived state — noArchive
@@ -303,6 +311,11 @@ func (s *Server) buildHandler() http.Handler {
 	api.HandleFunc("POST /api/recover", s.handleRecover)
 	api.HandleFunc("GET /api/capabilities", s.handleCapabilities)
 	api.HandleFunc("GET /api/reconstruct", s.handleReconstruct)
+	// Storage surfaces (read-only): the selected server's baseline snapshot
+	// listing, and the process's ambient AWS credential signals (presence
+	// booleans and non-secret names — never values).
+	api.HandleFunc("GET /api/baselines", s.handleBaselines)
+	api.HandleFunc("GET /api/storage", s.handleStorageInfo)
 	// Server management: CRUD over the local registry file (never a DB write)
 	// plus a write-free test-connection probe. Same token + host guard as the
 	// data endpoints.

--- a/internal/console/storage_api.go
+++ b/internal/console/storage_api.go
@@ -1,0 +1,69 @@
+package console
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+)
+
+// awsCredsDTO reports which ambient AWS credential signals are visible to THIS
+// process — presence booleans plus the two non-secret names (profile, region).
+// Values are never serialized. An EC2 instance-profile role is invisible
+// without an IMDS network call, so "nothing set" here does NOT mean uploads
+// will fail — the Storage panel says so.
+type awsCredsDTO struct {
+	AccessKeyEnv   bool   `json:"access_key_env"`       // AWS_ACCESS_KEY_ID is set
+	Profile        string `json:"profile,omitempty"`    // AWS_PROFILE (a name, non-secret)
+	RegionEnv      string `json:"region_env,omitempty"` // AWS_REGION / AWS_DEFAULT_REGION
+	SharedConfig   bool   `json:"shared_config"`        // ~/.aws/credentials or config exists
+	ContainerCreds bool   `json:"container_creds"`      // ECS task-role endpoint configured
+	WebIdentity    bool   `json:"web_identity"`         // EKS IRSA token file configured
+}
+
+type storageInfoResponse struct {
+	AWS awsCredsDTO `json:"aws"`
+}
+
+// handleStorageInfo serves GET /api/storage: process-global storage context
+// for the console's Storage page. Like GET /api/rotation it is authenticated
+// but not monitor-gated — it reads environment presence, nothing per-server.
+func (s *Server) handleStorageInfo(w http.ResponseWriter, r *http.Request) {
+	region := os.Getenv("AWS_REGION")
+	if region == "" {
+		region = os.Getenv("AWS_DEFAULT_REGION")
+	}
+	writeJSON(w, http.StatusOK, storageInfoResponse{AWS: awsCredsDTO{
+		AccessKeyEnv: os.Getenv("AWS_ACCESS_KEY_ID") != "",
+		Profile:      os.Getenv("AWS_PROFILE"),
+		RegionEnv:    region,
+		SharedConfig: hasSharedAWSConfig(),
+		ContainerCreds: os.Getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI") != "" ||
+			os.Getenv("AWS_CONTAINER_CREDENTIALS_FULL_URI") != "",
+		WebIdentity: os.Getenv("AWS_WEB_IDENTITY_TOKEN_FILE") != "",
+	}})
+}
+
+// hasSharedAWSConfig reports whether a shared AWS credentials/config file
+// exists where the SDK default chain will look, honoring the SDK's own
+// path-override env vars.
+func hasSharedAWSConfig() bool {
+	cred := os.Getenv("AWS_SHARED_CREDENTIALS_FILE")
+	conf := os.Getenv("AWS_CONFIG_FILE")
+	if home, err := os.UserHomeDir(); err == nil {
+		if cred == "" {
+			cred = filepath.Join(home, ".aws", "credentials")
+		}
+		if conf == "" {
+			conf = filepath.Join(home, ".aws", "config")
+		}
+	}
+	return regularFileExists(cred) || regularFileExists(conf)
+}
+
+func regularFileExists(p string) bool {
+	if p == "" {
+		return false
+	}
+	st, err := os.Stat(p)
+	return err == nil && st.Mode().IsRegular()
+}

--- a/internal/console/storage_api_test.go
+++ b/internal/console/storage_api_test.go
@@ -1,0 +1,85 @@
+package console
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func newStorageServer(t *testing.T) *Server {
+	t.Helper()
+	s := &Server{token: "t", cm: newConnManager(nil, false)}
+	s.mux = s.buildHandler()
+	return s
+}
+
+// TestStorageAPI_reportsPresenceNeverValues: the endpoint reports which
+// credential signals are set (plus the two non-secret names) and must never
+// serialize the key material itself.
+func TestStorageAPI_reportsPresenceNeverValues(t *testing.T) {
+	const secretKey = "AKIAEXAMPLESECRETID"
+	tmp := t.TempDir()
+	credPath := filepath.Join(tmp, "credentials")
+	if err := os.WriteFile(credPath, []byte("[default]\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("AWS_ACCESS_KEY_ID", secretKey)
+	t.Setenv("AWS_PROFILE", "prod-admin")
+	t.Setenv("AWS_REGION", "eu-west-1")
+	t.Setenv("AWS_DEFAULT_REGION", "")
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", credPath)
+	t.Setenv("AWS_CONFIG_FILE", filepath.Join(tmp, "missing"))
+	t.Setenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "")
+	t.Setenv("AWS_CONTAINER_CREDENTIALS_FULL_URI", "")
+	t.Setenv("AWS_WEB_IDENTITY_TOKEN_FILE", "")
+
+	srv := newStorageServer(t)
+	rec, body := doServersReq(t, srv, "GET", "/api/storage", "")
+	if rec.Code != 200 {
+		t.Fatalf("code = %d, body = %s", rec.Code, body)
+	}
+	if strings.Contains(string(body), secretKey) {
+		t.Fatalf("response leaked the access key value: %s", body)
+	}
+	var got storageInfoResponse
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatal(err)
+	}
+	if !got.AWS.AccessKeyEnv || got.AWS.Profile != "prod-admin" || got.AWS.RegionEnv != "eu-west-1" {
+		t.Fatalf("aws = %+v, want access_key_env + profile + region from env", got.AWS)
+	}
+	if !got.AWS.SharedConfig {
+		t.Fatal("shared_config = false, want true (credentials file exists)")
+	}
+	if got.AWS.ContainerCreds || got.AWS.WebIdentity {
+		t.Fatalf("aws = %+v, want no container/web-identity signals", got.AWS)
+	}
+}
+
+func TestStorageAPI_nothingSet(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_PROFILE", "")
+	t.Setenv("AWS_REGION", "")
+	t.Setenv("AWS_DEFAULT_REGION", "")
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", filepath.Join(tmp, "nope"))
+	t.Setenv("AWS_CONFIG_FILE", filepath.Join(tmp, "also-nope"))
+	t.Setenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "")
+	t.Setenv("AWS_CONTAINER_CREDENTIALS_FULL_URI", "")
+	t.Setenv("AWS_WEB_IDENTITY_TOKEN_FILE", "")
+
+	srv := newStorageServer(t)
+	rec, body := doServersReq(t, srv, "GET", "/api/storage", "")
+	if rec.Code != 200 {
+		t.Fatalf("code = %d, body = %s", rec.Code, body)
+	}
+	var got storageInfoResponse
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.AWS.AccessKeyEnv || got.AWS.Profile != "" || got.AWS.RegionEnv != "" || got.AWS.SharedConfig {
+		t.Fatalf("aws = %+v, want all signals absent", got.AWS)
+	}
+}

--- a/internal/reconstruct/baseline.go
+++ b/internal/reconstruct/baseline.go
@@ -145,6 +145,137 @@ func ExecSQL(ctx context.Context, source, sqlStr string) ([]map[string]any, []st
 	return results, cols, rows.Err()
 }
 
+// ─── listing ──────────────────────────────────────────────────────────────────
+
+// BaselineFile is one table's Parquet file discovered in a baseline source
+// listing. Path-derived only — no file contents are read — so listing stays
+// cheap over both a local directory and an s3:// prefix. Binlog coordinates
+// live in Parquet metadata and are the caller's (optional) enrichment step.
+type BaselineFile struct {
+	SnapshotTime time.Time
+	Schema       string
+	Table        string
+	Path         string
+}
+
+// ListBaselines enumerates every baseline snapshot file under source (a local
+// directory or an s3:// prefix), newest snapshot first (then schema/table for
+// a stable render order). Entries that don't match the
+// <timestamp>/<schema>/<table>.parquet layout are skipped, mirroring
+// FindBaseline's tolerance.
+func ListBaselines(ctx context.Context, source string) ([]BaselineFile, error) {
+	if strings.HasPrefix(source, "s3://") {
+		return listBaselinesS3(ctx, source)
+	}
+	return listBaselinesLocal(source)
+}
+
+func listBaselinesLocal(baselineDir string) ([]BaselineFile, error) {
+	entries, err := os.ReadDir(baselineDir)
+	if err != nil {
+		return nil, fmt.Errorf("read baseline directory %q: %w", baselineDir, err)
+	}
+	var out []BaselineFile
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		ts, ok := parseDirTimestamp(entry.Name())
+		if !ok {
+			continue
+		}
+		snapDir := filepath.Join(baselineDir, entry.Name())
+		dbDirs, err := os.ReadDir(snapDir)
+		if err != nil {
+			continue
+		}
+		for _, dbDir := range dbDirs {
+			if !dbDir.IsDir() {
+				continue
+			}
+			files, err := os.ReadDir(filepath.Join(snapDir, dbDir.Name()))
+			if err != nil {
+				continue
+			}
+			for _, f := range files {
+				if f.IsDir() || !strings.HasSuffix(f.Name(), ".parquet") {
+					continue
+				}
+				out = append(out, BaselineFile{
+					SnapshotTime: ts,
+					Schema:       dbDir.Name(),
+					Table:        strings.TrimSuffix(f.Name(), ".parquet"),
+					Path:         filepath.Join(snapDir, dbDir.Name(), f.Name()),
+				})
+			}
+		}
+	}
+	sortBaselineFiles(out)
+	return out, nil
+}
+
+func listBaselinesS3(ctx context.Context, s3URL string) ([]BaselineFile, error) {
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		return nil, fmt.Errorf("open duckdb: %w", err)
+	}
+	defer db.Close()
+	if err := pinDuckDBSessionUTC(ctx, db); err != nil {
+		return nil, err
+	}
+	if _, err := db.ExecContext(ctx, "INSTALL httpfs; LOAD httpfs;"); err != nil {
+		return nil, fmt.Errorf("load httpfs extension: %w", err)
+	}
+
+	prefix := strings.TrimSuffix(s3URL, "/")
+	safeGlob := strings.ReplaceAll(prefix+"/*/*/*.parquet", "'", "''")
+	rows, err := db.QueryContext(ctx, "SELECT * FROM glob('"+safeGlob+"')")
+	if err != nil {
+		return nil, fmt.Errorf("list S3 baseline snapshots: %w", err)
+	}
+	defer rows.Close()
+
+	var out []BaselineFile
+	for rows.Next() {
+		var path string
+		if err := rows.Scan(&path); err != nil {
+			continue
+		}
+		rest := strings.TrimPrefix(path, prefix+"/")
+		parts := strings.Split(rest, "/")
+		if len(parts) != 3 || !strings.HasSuffix(parts[2], ".parquet") {
+			continue
+		}
+		ts, ok := parseDirTimestamp(parts[0])
+		if !ok {
+			continue
+		}
+		out = append(out, BaselineFile{
+			SnapshotTime: ts,
+			Schema:       parts[1],
+			Table:        strings.TrimSuffix(parts[2], ".parquet"),
+			Path:         path,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate S3 baseline list: %w", err)
+	}
+	sortBaselineFiles(out)
+	return out, nil
+}
+
+func sortBaselineFiles(files []BaselineFile) {
+	slices.SortFunc(files, func(a, b BaselineFile) int {
+		if c := b.SnapshotTime.Compare(a.SnapshotTime); c != 0 {
+			return c
+		}
+		if c := strings.Compare(a.Schema, b.Schema); c != 0 {
+			return c
+		}
+		return strings.Compare(a.Table, b.Table)
+	})
+}
+
 // ─── local ────────────────────────────────────────────────────────────────────
 
 func findBaselineLocal(baselineDir, schema, table string, at time.Time) (string, time.Time, error) {

--- a/internal/reconstruct/baseline.go
+++ b/internal/reconstruct/baseline.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"slices"
@@ -162,7 +163,12 @@ type BaselineFile struct {
 // directory or an s3:// prefix), newest snapshot first (then schema/table for
 // a stable render order). Entries that don't match the
 // <timestamp>/<schema>/<table>.parquet layout are skipped, mirroring
-// FindBaseline's tolerance.
+// FindBaseline's tolerance; unreadable snapshot subdirectories are skipped
+// WITH a warning — the listing is an observability surface, and a silently
+// shrunken one would misreport "latest baseline" with nothing in any log.
+// internal/baseline.DiscoverBaselines walks the same local layout (plus
+// Parquet footers) for `bintrail status`; keep the two in sync if the layout
+// ever changes.
 func ListBaselines(ctx context.Context, source string) ([]BaselineFile, error) {
 	if strings.HasPrefix(source, "s3://") {
 		return listBaselinesS3(ctx, source)
@@ -187,14 +193,17 @@ func listBaselinesLocal(baselineDir string) ([]BaselineFile, error) {
 		snapDir := filepath.Join(baselineDir, entry.Name())
 		dbDirs, err := os.ReadDir(snapDir)
 		if err != nil {
+			slog.Warn("baseline listing: skipping unreadable snapshot directory", "path", snapDir, "error", err)
 			continue
 		}
 		for _, dbDir := range dbDirs {
 			if !dbDir.IsDir() {
 				continue
 			}
-			files, err := os.ReadDir(filepath.Join(snapDir, dbDir.Name()))
+			schemaDir := filepath.Join(snapDir, dbDir.Name())
+			files, err := os.ReadDir(schemaDir)
 			if err != nil {
+				slog.Warn("baseline listing: skipping unreadable schema directory", "path", schemaDir, "error", err)
 				continue
 			}
 			for _, f := range files {
@@ -205,7 +214,7 @@ func listBaselinesLocal(baselineDir string) ([]BaselineFile, error) {
 					SnapshotTime: ts,
 					Schema:       dbDir.Name(),
 					Table:        strings.TrimSuffix(f.Name(), ".parquet"),
-					Path:         filepath.Join(snapDir, dbDir.Name(), f.Name()),
+					Path:         filepath.Join(schemaDir, f.Name()),
 				})
 			}
 		}
@@ -239,7 +248,11 @@ func listBaselinesS3(ctx context.Context, s3URL string) ([]BaselineFile, error) 
 	for rows.Next() {
 		var path string
 		if err := rows.Scan(&path); err != nil {
-			continue
+			// The glob returns exactly one VARCHAR column; a Scan failure is a
+			// driver/DuckDB fault, never an expected layout condition — and
+			// rows.Err() below would NOT catch it. Fail loud rather than let a
+			// listing whose purpose is observability silently drop snapshots.
+			return nil, fmt.Errorf("scan S3 baseline path: %w", err)
 		}
 		rest := strings.TrimPrefix(path, prefix+"/")
 		parts := strings.Split(rest, "/")

--- a/internal/reconstruct/baseline_list_test.go
+++ b/internal/reconstruct/baseline_list_test.go
@@ -1,0 +1,73 @@
+package reconstruct
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func writeListFixture(t *testing.T, dir string, parts ...string) {
+	t.Helper()
+	p := filepath.Join(append([]string{dir}, parts...)...)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestListBaselinesLocal: path-derived listing, newest snapshot first, stable
+// schema/table order within a snapshot, layout strangers skipped.
+func TestListBaselinesLocal(t *testing.T) {
+	dir := t.TempDir()
+	writeListFixture(t, dir, "2026-06-01T00-00-00Z", "shop", "orders.parquet")
+	writeListFixture(t, dir, "2026-06-10T12-00-00Z", "shop", "users.parquet")
+	writeListFixture(t, dir, "2026-06-10T12-00-00Z", "shop", "orders.parquet")
+	writeListFixture(t, dir, "2026-06-10T12-00-00Z", "billing", "invoices.parquet")
+	writeListFixture(t, dir, "2026-06-10T12-00-00Z", "shop", "notes.txt")                 // not parquet
+	writeListFixture(t, dir, "not-a-timestamp", "shop", "junk.parquet")                   // bad snapshot dir
+	if err := os.WriteFile(filepath.Join(dir, "stray.parquet"), nil, 0o644); err != nil { // file at top level
+		t.Fatal(err)
+	}
+
+	files, err := ListBaselines(context.Background(), dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 4 {
+		t.Fatalf("len = %d (%+v), want 4", len(files), files)
+	}
+
+	wantNewest := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+	wantOldest := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	wantOrder := []struct {
+		ts     time.Time
+		schema string
+		table  string
+	}{
+		{wantNewest, "billing", "invoices"},
+		{wantNewest, "shop", "orders"},
+		{wantNewest, "shop", "users"},
+		{wantOldest, "shop", "orders"},
+	}
+	for i, w := range wantOrder {
+		f := files[i]
+		if !f.SnapshotTime.Equal(w.ts) || f.Schema != w.schema || f.Table != w.table {
+			t.Fatalf("files[%d] = %s %s.%s, want %s %s.%s", i,
+				f.SnapshotTime.Format(time.RFC3339), f.Schema, f.Table,
+				w.ts.Format(time.RFC3339), w.schema, w.table)
+		}
+		if _, err := os.Stat(f.Path); err != nil {
+			t.Fatalf("files[%d].Path does not exist: %v", i, err)
+		}
+	}
+}
+
+func TestListBaselinesLocal_missingDir(t *testing.T) {
+	if _, err := ListBaselines(context.Background(), filepath.Join(t.TempDir(), "nope")); err == nil {
+		t.Fatal("want an error for a missing baseline directory")
+	}
+}


### PR DESCRIPTION
## Why

Three UX complaints from real use of the v0.13.0 console:

1. **The rotation editor (#456) was invisible** — its only entry point was the ⌘K palette.
2. **S3/baseline configuration was scattered** — `Archive to S3` hides inside the server edit form's monitor fieldset; baseline dir/S3 behind the Advanced toggle; no single place answers "where does my history live and can the daemon reach S3?".
3. **`default (cli)` confused operators** — on source-less `watch` nothing ever streams into the boot index (each added source gets its own `bintrail_idx_<id>` database), yet `defaultID()` always preferred it and selection is per-tab `sessionStorage`, so **every fresh tab landed on a permanently empty Status page** (0 events / 49 partitions).

## What

**Settings nav group** (gated `data-capability="monitor"` — watch only, hidden on read-only `serve`):
- **Storage** route: rotation policy card (+ edit shortcut), per-source S3 archiving overview (+ configure shortcut into the server form), read-only **Baseline snapshots** panel for the selected server, and an **AWS credentials** card reporting ambient-chain signals (presence booleans + non-secret names only — the console still never stores keys).
- **Rotation** entry opening the existing dialog. The generic `.nav-item` binding now skips route-less items, so the modal trigger can't double-fire `navigate(undefined)`.

**New read-only endpoints**
- `GET /api/baselines` — path-derived snapshot listing for the selected server via new `reconstruct.ListBaselines` (local dir + `s3://` glob), grouped per snapshot, newest first, capped at 50; local snapshots enriched with binlog coordinates from Parquet metadata (best-effort). `502` on an unreadable configured source.
- `GET /api/storage` — `{aws: {access_key_env, profile, region_env, shared_config, container_creds, web_identity}}`.

**Boot-entry demotion** (`console.Config.DemoteBoot`, set only by source-less `watch`): the no-header default becomes the first monitored registry entry (else first entry); `Resolve("")` now follows `defaultID()` exactly so the rendered selection and the queried server can never diverge. The boot entry stays listed and selectable — relabeled by its database name (`bintrail_index (cli)`), sorted last, with a tooltip. `serve` behavior is unchanged.

**Docs**: console.md (Storage page, demotion, API table) + a query-and-recovery.md callout that OSS `recover` is **not** FK-aware (the FK-aware recovery on dbtrail.com is a platform feature that shares the tool name).

## Verification

- Unit suite + `-race` green (`internal/console`, `internal/reconstruct`); new tests for `defaultID` demotion, `Resolve("")` parity, the baselines grouping/error paths, the storage endpoint (asserts key **values** never serialize), and `ListBaselines` ordering/skips.
- Headless-Chrome drive against a live source-less `watch` on the Docker test MySQL: Settings group visible under watch and hidden under `serve` (direct `/storage` bounces to overview), Storage page renders all cards/panels from live data, Rotation nav opens the dialog **without** navigating, palette lists Storage, `default_id` demotes after adding a server and a fresh tab lands on it, cli entry sorted last with the dbname label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)