### PR TITLE
feat(compose): one-shot `baseline` profile — Time-travel snapshots with zero installs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,9 +44,9 @@ volumes:
                           # datadir — back up / reset the two together).
   bintrail-state:         # bintrail runtime state (saved console servers,
                           # archive staging, baseline snapshots, …).
-  bintrail-dump:          # transient mydumper output for the `baseline` profile
-                          # (wiped at the start of every run — never store
-                          # anything else here).
+  bintrail-dump:          # transient mydumper output for the `baseline`
+                          # profile (its snapshot/ dir is recreated from
+                          # scratch every run — never store anything here).
 
 services:
 
@@ -179,7 +179,8 @@ services:
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-}
       AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN:-}
       AWS_REGION: ${AWS_REGION:-}
-      # Baselines for the boot (SOURCE_DSN) entry: set
+      # Baselines for the boot entry (the cli-seeded server backed by the
+      # index DSN — the one a SOURCE_DSN stream writes into): set
       # BASELINE_DIR=/var/lib/bintrail/baselines in .env after producing
       # snapshots with the `baseline` profile below — it enables the console's
       # Time-travel surface on that entry. Servers added from the UI configure
@@ -249,8 +250,8 @@ services:
   # BASELINE_DIR for the boot entry. See docs/docker.md.
   baseline-dump:
     profiles: ["baseline"]
-    # Pinned upstream image (mydumper >= 0.11 supports the light-locking
-    # flags below; distro-apt builds are older and would need heavier locks).
+    # Pinned upstream image (the light-locking flags below need mydumper
+    # >= 0.18; distro-apt builds are older and would reject them).
     image: mydumper/mydumper:v1.0.3-1
     environment:
       BASELINE_SOURCE_DSN: ${BASELINE_SOURCE_DSN:-${SOURCE_DSN:-}}
@@ -275,6 +276,10 @@ services:
         # containing "@" survive; the username cannot contain ":" in a Go DSN,
         # so the first ":" splits user from password.
         hostport="$${dsn##*@tcp(}"; hostport="$${hostport%%)*}"
+        case "$$hostport" in
+          *:*) ;;
+          *) echo "FATAL: the DSN must include host:port, e.g. @tcp(db.example.com:3306)" >&2; exit 1 ;;
+        esac
         host="$${hostport%%:*}"; port="$${hostport##*:}"
         creds="$${dsn%@tcp(*}"
         user="$${creds%%:*}"
@@ -287,15 +292,16 @@ services:
         rm -rf /dump/snapshot
         mkdir -p /dump/snapshot
         # Mirror `bintrail dump`'s mydumper invocation (cmd/bintrail/dump.go):
-        # light locking (>= 0.11), compressed protocol, complete INSERTs, and
+        # light locking (flags exist since mydumper 0.18), compressed
+        # protocol, complete INSERTs, and
         # --outputdir last. The metadata file it writes carries the binlog
         # coordinates `bintrail baseline` embeds in the Parquet.
         set -- --host "$$host" --port "$$port" --user "$$user" \
           --threads 4 --compress-protocol --complete-insert \
           --sync-thread-lock-mode NO_LOCK --trx-tables
         [ -n "$$pass" ] && set -- "$$@" --password "$$pass"
-        if [ -n "$$BASELINE_SCHEMAS" ]; then
-          schemas="$$(printf '%s' "$$BASELINE_SCHEMAS" | tr -d ' ')"
+        schemas="$$(printf '%s' "$$BASELINE_SCHEMAS" | tr -d ' ')"
+        if [ -n "$$schemas" ]; then
           case "$$schemas" in
             *,*) set -- "$$@" --regex "^($$(printf '%s' "$$schemas" | tr ',' '|'))\\." ;;
             *)   set -- "$$@" --database "$$schemas" ;;
@@ -303,6 +309,25 @@ services:
         fi
         set -- "$$@" --outputdir /dump/snapshot
         mydumper "$$@"
+        # GUARD: mydumper exits 0 for a --regex that matches nothing and for
+        # schemas the dump user cannot read — both yield a metadata-only or
+        # partial dump that `bintrail baseline` would happily convert into an
+        # incomplete baseline (silently wrong Time-travel reconstructions,
+        # the worst failure class). "exit 0" is NOT "the baseline is
+        # complete": verify table data actually landed, per schema when a
+        # filter was given.
+        if ! ls /dump/snapshot | grep -q -- '-schema\.sql'; then
+          echo "FATAL: the dump produced no tables — check BASELINE_SCHEMAS and the dump user's privileges" >&2
+          exit 1
+        fi
+        if [ -n "$$schemas" ]; then
+          for sc in $$(printf '%s' "$$schemas" | tr ',' ' '); do
+            if ! ls /dump/snapshot | grep -q "^$$sc\."; then
+              echo "FATAL: schema '$$sc' is missing from the dump — check the name and the dump user's SELECT privileges" >&2
+              exit 1
+            fi
+          done
+        fi
         # The convert step runs as the bintrail image's non-root uid 999:
         # hand it the dump, and pre-create the baselines dir in the state
         # volume (whose root may be root-owned when this profile runs before
@@ -310,7 +335,7 @@ services:
         chown -R 999:999 /dump/snapshot
         mkdir -p /state/baselines
         chown 999:999 /state/baselines
-        echo "Dump complete: $$(ls /dump/snapshot | wc -l) file(s)."
+        echo "Dump complete: $$(ls /dump/snapshot | grep -c -- '-schema\.sql') table(s)."
     volumes:
       - bintrail-dump:/dump
       - bintrail-state:/state

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,11 @@ volumes:
                           # server auto-upgrades an 8.0 datadir irreversibly).
   bintrail-index-secret:  # the generated index password (shares fate with the
                           # datadir — back up / reset the two together).
-  bintrail-state:         # bintrail runtime state (saved console servers, …).
+  bintrail-state:         # bintrail runtime state (saved console servers,
+                          # archive staging, baseline snapshots, …).
+  bintrail-dump:          # transient mydumper output for the `baseline` profile
+                          # (wiped at the start of every run — never store
+                          # anything else here).
 
 services:
 
@@ -175,6 +179,14 @@ services:
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-}
       AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN:-}
       AWS_REGION: ${AWS_REGION:-}
+      # Baselines for the boot (SOURCE_DSN) entry: set
+      # BASELINE_DIR=/var/lib/bintrail/baselines in .env after producing
+      # snapshots with the `baseline` profile below — it enables the console's
+      # Time-travel surface on that entry. Servers added from the UI configure
+      # it per server instead (Edit → Advanced → "Baseline dir", same path).
+      # Left empty by default: the gate is config-based, so setting it with no
+      # snapshots would show a Time-travel tab with nothing behind it.
+      BINTRAIL_CONSOLE_BASELINE_DIR: ${BASELINE_DIR:-}
       # Password login (persists next to the registry). On first run the
       # console serves a "create your password" screen; later visits sign in.
       # There is deliberately NO password env var: docker inspect must never
@@ -218,3 +230,100 @@ services:
       index-mysql:
         condition: service_healthy
     restart: unless-stopped
+
+  # ── Baselines (one-shot, opt-in `baseline` profile) ──────
+  # Produces the full-table Parquet snapshots Time-travel reconstructs from
+  # (baseline + binlog deltas → complete rows, not just rows with binlog
+  # activity). Two one-shot steps: the official mydumper image dumps the
+  # source over the network into a transient volume, then the core bintrail
+  # CLI image converts the dump to Parquet in the state volume. Run on demand
+  # (or from cron):
+  #
+  #   BASELINE_SOURCE_DSN="user:pass@tcp(db.example.com:3306)/" \
+  #     docker compose --profile baseline run --rm baseline
+  #
+  # BASELINE_SOURCE_DSN defaults to SOURCE_DSN, so the single-source stack
+  # needs no extra configuration. Snapshots land in
+  # /var/lib/bintrail/baselines (the bintrail-state volume); point the
+  # console at them per server (Edit → Advanced → "Baseline dir") or via
+  # BASELINE_DIR for the boot entry. See docs/docker.md.
+  baseline-dump:
+    profiles: ["baseline"]
+    # Pinned upstream image (mydumper >= 0.11 supports the light-locking
+    # flags below; distro-apt builds are older and would need heavier locks).
+    image: mydumper/mydumper:v1.0.3-1
+    environment:
+      BASELINE_SOURCE_DSN: ${BASELINE_SOURCE_DSN:-${SOURCE_DSN:-}}
+      # Comma-separated schemas to snapshot (defaults to SCHEMAS; empty =
+      # everything mydumper dumps by default).
+      BASELINE_SCHEMAS: ${BASELINE_SCHEMAS:-${SCHEMAS:-}}
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        set -e
+        dsn="$$BASELINE_SOURCE_DSN"
+        if [ -z "$$dsn" ]; then
+          echo "FATAL: set BASELINE_SOURCE_DSN (or SOURCE_DSN) to the source MySQL to snapshot, e.g." >&2
+          echo '  BASELINE_SOURCE_DSN="user:pass@tcp(db.example.com:3306)/" docker compose --profile baseline run --rm baseline' >&2
+          exit 1
+        fi
+        case "$$dsn" in
+          *"@tcp("*")"*) ;;
+          *) echo "FATAL: BASELINE_SOURCE_DSN must be a Go MySQL DSN like user:pass@tcp(host:3306)/" >&2; exit 1 ;;
+        esac
+        # Decompose the DSN in shell: split on the LAST "@tcp(" so passwords
+        # containing "@" survive; the username cannot contain ":" in a Go DSN,
+        # so the first ":" splits user from password.
+        hostport="$${dsn##*@tcp(}"; hostport="$${hostport%%)*}"
+        host="$${hostport%%:*}"; port="$${hostport##*:}"
+        creds="$${dsn%@tcp(*}"
+        user="$${creds%%:*}"
+        pass="$${creds#*:}"; [ "$$pass" = "$$creds" ] && pass=""
+        if [ -z "$$host" ] || [ -z "$$user" ]; then
+          echo "FATAL: could not parse host/user from BASELINE_SOURCE_DSN" >&2; exit 1
+        fi
+        # Fresh dump every run — mydumper refuses a non-empty output dir, and
+        # stale dumps must never be converted as if they were current.
+        rm -rf /dump/snapshot
+        mkdir -p /dump/snapshot
+        # Mirror `bintrail dump`'s mydumper invocation (cmd/bintrail/dump.go):
+        # light locking (>= 0.11), compressed protocol, complete INSERTs, and
+        # --outputdir last. The metadata file it writes carries the binlog
+        # coordinates `bintrail baseline` embeds in the Parquet.
+        set -- --host "$$host" --port "$$port" --user "$$user" \
+          --threads 4 --compress-protocol --complete-insert \
+          --sync-thread-lock-mode NO_LOCK --trx-tables
+        [ -n "$$pass" ] && set -- "$$@" --password "$$pass"
+        if [ -n "$$BASELINE_SCHEMAS" ]; then
+          schemas="$$(printf '%s' "$$BASELINE_SCHEMAS" | tr -d ' ')"
+          case "$$schemas" in
+            *,*) set -- "$$@" --regex "^($$(printf '%s' "$$schemas" | tr ',' '|'))\\." ;;
+            *)   set -- "$$@" --database "$$schemas" ;;
+          esac
+        fi
+        set -- "$$@" --outputdir /dump/snapshot
+        mydumper "$$@"
+        # The convert step runs as the bintrail image's non-root uid 999:
+        # hand it the dump, and pre-create the baselines dir in the state
+        # volume (whose root may be root-owned when this profile runs before
+        # the main stack ever initialized it).
+        chown -R 999:999 /dump/snapshot
+        mkdir -p /state/baselines
+        chown 999:999 /state/baselines
+        echo "Dump complete: $$(ls /dump/snapshot | wc -l) file(s)."
+    volumes:
+      - bintrail-dump:/dump
+      - bintrail-state:/state
+
+  baseline:
+    profiles: ["baseline"]
+    # The CORE CLI image — the console image deliberately ships without the
+    # dump/baseline commands.
+    image: ghcr.io/dbtrail/bintrail:${BINTRAIL_TAG:-latest}
+    command: ["baseline", "--input", "/dump/snapshot", "--output", "/var/lib/bintrail/baselines"]
+    volumes:
+      - bintrail-dump:/dump
+      - bintrail-state:/var/lib/bintrail
+    depends_on:
+      baseline-dump:
+        condition: service_completed_successfully

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -232,6 +232,52 @@ its sizing, backups, and upgrades are yours — see
 [SUPPORT.md](../SUPPORT.md). (The BYO contract floor stays MySQL **8.0+** —
 only the *bundled* index is 8.4.)
 
+### Baselines and Time-travel (the `baseline` profile)
+
+The console's **Time-travel** surface reconstructs complete rows (baseline
+snapshot + binlog deltas), so it needs **baseline Parquet snapshots** — and the
+console image deliberately ships without the `dump`/`baseline` commands. The
+compose file includes an opt-in one-shot profile that produces them with zero
+extra installs: the official `mydumper` image dumps the source over the
+network into a transient volume, then the core `bintrail` CLI image converts
+the dump to Parquet inside the `bintrail-state` volume.
+
+Run it on demand (or from cron on the host):
+
+```sh
+# Single-source stack (SOURCE_DSN set in .env): no extra config needed.
+docker compose --profile baseline run --rm baseline
+
+# Any other source (e.g. one you added from the console UI):
+BASELINE_SOURCE_DSN="repl:secret@tcp(db.example.com:3306)/" \
+BASELINE_SCHEMAS="shop,billing" \
+  docker compose --profile baseline run --rm baseline
+```
+
+Each run creates a new snapshot under
+`/var/lib/bintrail/baselines/<timestamp>/<schema>/<table>.parquet` (in the
+`bintrail-state` volume), with the source's binlog coordinates embedded so
+reconstruct knows where deltas begin. Then point the console at it:
+
+- **Servers added from the UI**: Manage servers → Edit → Advanced →
+  **Baseline dir** = `/var/lib/bintrail/baselines` (a *container* path — the
+  `watch` daemon reads it, not your host). The server's Time-travel tab and
+  Storage → Baseline snapshots panel light up.
+- **The boot `SOURCE_DSN` entry**: set `BASELINE_DIR=/var/lib/bintrail/baselines`
+  in `.env` and `docker compose up -d` again.
+
+Notes:
+
+- The dump uses mydumper ≥ 0.11 light locking (`--sync-thread-lock-mode
+  NO_LOCK --trx-tables`) — same flags as `bintrail dump`. It still reads every
+  row of the selected schemas; schedule it off-peak for large sources.
+- `BASELINE_SCHEMAS` defaults to `SCHEMAS`; empty dumps everything mydumper
+  covers by default. Snapshot only what you want to time-travel.
+- Take a fresh baseline after `ALTER TABLE` (reconstruct needs the snapshot
+  schema to match the deltas), and periodically so the binlog window between
+  baseline and "now" stays short. Old snapshots are plain directories — prune
+  them by deleting `<timestamp>` dirs in the volume.
+
 ## Environment variables
 
 | Variable | Used by | Description |
@@ -242,6 +288,9 @@ only the *bundled* index is 8.4.)
 | `CONSOLE_TOKEN` | compose (optional) | Opt-in static API-automation token (default: none — humans sign in with the console password) |
 | `INDEX_MYSQL_ROOT_PASSWORD` | compose (optional) | Pin the bundled index root password (set *before* first boot; default: randomly generated into the `bintrail-index-secret` volume) |
 | `BINTRAIL_TAG` | compose (optional) | Image tag to run (default `latest`) |
+| `BASELINE_SOURCE_DSN` | compose `baseline` profile | Source MySQL to snapshot (default: `SOURCE_DSN`) |
+| `BASELINE_SCHEMAS` | compose `baseline` profile | Comma-separated schemas to snapshot (default: `SCHEMAS`) |
+| `BASELINE_DIR` | compose (optional) | Baseline dir for the boot `SOURCE_DSN` entry — set `/var/lib/bintrail/baselines` after the first `baseline` profile run to enable Time-travel on it |
 | `BINTRAIL_INDEX_DSN` | bintrail-mcp | Index DSN for the MCP server |
 
 (`SERVER_ID` is no longer needed — `bintrail-console watch` derives a stable

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -261,16 +261,23 @@ reconstruct knows where deltas begin. Then point the console at it:
 
 - **Servers added from the UI**: Manage servers → Edit → Advanced →
   **Baseline dir** = `/var/lib/bintrail/baselines` (a *container* path — the
-  `watch` daemon reads it, not your host). The server's Time-travel tab and
-  Storage → Baseline snapshots panel light up.
+  `watch` daemon reads it, not your host). The server's Time-travel tab
+  lights up, and its row shows a TT chip under Manage servers.
 - **The boot `SOURCE_DSN` entry**: set `BASELINE_DIR=/var/lib/bintrail/baselines`
   in `.env` and `docker compose up -d` again.
 
 Notes:
 
-- The dump uses mydumper ≥ 0.11 light locking (`--sync-thread-lock-mode
-  NO_LOCK --trx-tables`) — same flags as `bintrail dump`. It still reads every
-  row of the selected schemas; schedule it off-peak for large sources.
+- The dump uses mydumper light locking (`--sync-thread-lock-mode NO_LOCK
+  --trx-tables`, available since mydumper 0.18 — the pinned image is recent)
+  — same flags as `bintrail dump`. It still reads every row of the selected
+  schemas; schedule it off-peak for large sources. On sources with
+  non-transactional tables (MyISAM), the binlog coordinates embedded in the
+  snapshot may not exactly match those tables' data — the same caveat as
+  `bintrail dump`.
+- If the run fails with `service "baseline-dump" didn't complete
+  successfully`, the cause (a mydumper error, a FATAL from the DSN/schema
+  guards) is in `docker compose --profile baseline logs baseline-dump`.
 - `BASELINE_SCHEMAS` defaults to `SCHEMAS`; empty dumps everything mydumper
   covers by default. Snapshot only what you want to time-travel.
 - Take a fresh baseline after `ALTER TABLE` (reconstruct needs the snapshot

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -281,6 +281,7 @@ bintrail status        ← check at any time
 | Want to... | Read... |
 |---|---|
 | Browse changes and generate undo SQL from a browser | [Web console](./console.md) |
+| Time-travel: reconstruct full rows as of a point in time | [Dump and Baseline](./dump-and-baseline.md) — or the compose [`baseline` profile](./docker.md#baselines-and-time-travel-the-baseline-profile) |
 | Use RDS, Aurora, or Cloud SQL | [Streaming](./streaming.md) |
 | Understand the query and recovery options in depth | [Query and Recovery](./query-and-recovery.md) |
 | Archive old events to S3 before dropping | [Rotation and Status](./rotation-and-status.md#archiving-partitions-to-parquet) |


### PR DESCRIPTION
## Why

The compose stack **cannot produce baselines today**, so Time-travel is dark in the default deployment:

- the `bintrail-console` image deliberately ships without the `dump`/`baseline` commands,
- `bintrail dump`'s Docker fallback execs the `docker` CLI (would need the socket; the container runs non-root uid 999),
- and `docker-compose.yml` sets no `BASELINE_*` anywhere.

## What

An opt-in `profiles: ["baseline"]` pair of one-shot services — **zero Go changes, no docker socket**:

1. **`baseline-dump`** — official `mydumper/mydumper:v1.0.3-1` (pinned; ≥ 0.11 so the light-locking flags apply — distro-apt mydumpers are 0.10.x) dumps the source over the network into a transient `bintrail-dump` volume. The Go DSN is decomposed in shell (split on the **last** `@tcp(` so passwords containing `@` survive; usernames can't contain `:`), and mydumper gets the same flags `bintrail dump` uses (`--compress-protocol --complete-insert --sync-thread-lock-mode NO_LOCK --trx-tables`, `--outputdir` last). The root one-shot also pre-creates/chowns `/state/baselines` so the non-root convert step works even on a never-initialized state volume (caught by the live E2E run).
2. **`baseline`** — the core `ghcr.io/dbtrail/bintrail` image runs `bintrail baseline` into `/var/lib/bintrail/baselines` on the **bintrail-state** volume, exactly where the `watch` daemon reads it.

```sh
# single-source stack: no extra config (defaults to SOURCE_DSN/SCHEMAS)
docker compose --profile baseline run --rm baseline

# any other source (e.g. added from the console UI)
BASELINE_SOURCE_DSN="repl:secret@tcp(db.example.com:3306)/" BASELINE_SCHEMAS="shop" \
  docker compose --profile baseline run --rm baseline
```

Wiring it to the console: per-server **Baseline dir** = `/var/lib/bintrail/baselines` (UI-added servers), or `BASELINE_DIR` in `.env` for the boot `SOURCE_DSN` entry (new `BINTRAIL_CONSOLE_BASELINE_DIR` passthrough — deliberately empty by default, since the reconstruct gate is config-based and would otherwise advertise an empty Time-travel tab).

**Docs**: new "Baselines and Time-travel" section in docker.md (flow, container-path gotcha, locking + re-baseline-after-ALTER notes, snapshot pruning) + env-var table rows; quickstart's Next Steps now mentions the Time-travel path (it never did).

## Verification (real run)

- `docker compose --profile baseline config` validates.
- Full E2E under an isolated project name against a real source MySQL: dump → convert chained via `service_completed_successfully`; snapshots landed as `baselines/2026-06-11T14-09-26Z/<schema>/<table>.parquet` (12 tables), **owned uid 999**, readable by the daemon.
- The first run intentionally exposed the fresh-volume permission failure; fixed by the root pre-step and re-verified green.

Pairs with #457 (the console's Storage page lists these snapshots via `GET /api/baselines`); both PRs are independent and mergeable in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)