### PR TITLE
fix(dump): raise the light-locking version gate to mydumper 0.18

### DIFF
--- a/cmd/bintrail/dump.go
+++ b/cmd/bintrail/dump.go
@@ -209,10 +209,12 @@ func runDump(cmd *cobra.Command, args []string) error {
 
 	// 6. Probe mydumper version and build args.
 	// --sync-thread-lock-mode and --trx-tables require mydumper >= 0.18 (see
-	// mydumperSupportsLockMode). Distro apt packages ship older builds
-	// (Ubuntu 24.04: 0.10.0, Debian bookworm: 0.10.1), so we must not pass
-	// the flags unconditionally or the dump fails (#219, #460). Docker
-	// images are assumed to ship a recent enough version.
+	// mydumperSupportsLockMode). Distro apt packages ship older builds —
+	// Ubuntu 24.04 and Debian bookworm both package upstream 0.10.1, whose
+	// binary self-reports 0.10.0 — so we must not pass the flags
+	// unconditionally or the dump fails (#219, #460). Docker mode is NOT
+	// version-probed: a pinned --mydumper-image older than 0.18 fails with
+	// "unknown option", which is why the docs' pin examples stay >= 0.18.
 	supportsLockMode := true
 	if res.mode == dumpModeLocal {
 		major, minor, patch, verErr := mydumperVersion(res.path)
@@ -301,10 +303,12 @@ func parseMydumperVersion(output string) (major, minor, patch int, err error) {
 
 // mydumperSupportsLockMode reports whether a mydumper version understands
 // --sync-thread-lock-mode and --trx-tables. The flags landed in mydumper
-// 0.18.1 — NOT 0.11, whose light-locking options were --no-locks /
-// --trx-consistency-only, different flags entirely. The gate previously sat
-// at 0.11, handing 0.11–0.17 builds flags they reject with "unknown option"
-// (#460).
+// 0.18.1 — NOT 0.11, whose light-locking options were --less-locking /
+// --trx-consistency-only (which --trx-tables replaced; --no-locks survives
+// in modern versions). The gate previously sat at 0.11, handing 0.11–0.17
+// builds flags they reject with "unknown option" (#460). No 0.18.0 was ever
+// released — the 0.18 series starts at 0.18.1 — so gating on (major, minor)
+// alone is exact.
 func mydumperSupportsLockMode(major, minor int) bool {
 	return major > 0 || minor >= 18
 }

--- a/cmd/bintrail/dump.go
+++ b/cmd/bintrail/dump.go
@@ -208,10 +208,11 @@ func runDump(cmd *cobra.Command, args []string) error {
 	}
 
 	// 6. Probe mydumper version and build args.
-	// --sync-thread-lock-mode and --trx-tables require mydumper >= 0.11.0.
-	// Ubuntu 24.04's apt package ships 0.10.0, so we must not pass them
-	// unconditionally or the dump fails (#219). Docker images are assumed
-	// to ship a recent enough version.
+	// --sync-thread-lock-mode and --trx-tables require mydumper >= 0.18 (see
+	// mydumperSupportsLockMode). Distro apt packages ship older builds
+	// (Ubuntu 24.04: 0.10.0, Debian bookworm: 0.10.1), so we must not pass
+	// the flags unconditionally or the dump fails (#219, #460). Docker
+	// images are assumed to ship a recent enough version.
 	supportsLockMode := true
 	if res.mode == dumpModeLocal {
 		major, minor, patch, verErr := mydumperVersion(res.path)
@@ -219,8 +220,8 @@ func runDump(cmd *cobra.Command, args []string) error {
 			slog.Warn("could not determine mydumper version; omitting --sync-thread-lock-mode and --trx-tables for safety",
 				"error", verErr)
 			supportsLockMode = false
-		} else if major == 0 && minor < 11 {
-			slog.Warn("mydumper version is older than 0.11.0; omitting --sync-thread-lock-mode and --trx-tables — the dump may hold heavier locks",
+		} else if !mydumperSupportsLockMode(major, minor) {
+			slog.Warn("mydumper version is older than 0.18; omitting --sync-thread-lock-mode and --trx-tables — the dump may hold heavier locks",
 				"version", fmt.Sprintf("%d.%d.%d", major, minor, patch))
 			supportsLockMode = false
 		}
@@ -298,12 +299,22 @@ func parseMydumperVersion(output string) (major, minor, patch int, err error) {
 	return major, minor, patch, nil
 }
 
+// mydumperSupportsLockMode reports whether a mydumper version understands
+// --sync-thread-lock-mode and --trx-tables. The flags landed in mydumper
+// 0.18.1 — NOT 0.11, whose light-locking options were --no-locks /
+// --trx-consistency-only, different flags entirely. The gate previously sat
+// at 0.11, handing 0.11–0.17 builds flags they reject with "unknown option"
+// (#460).
+func mydumperSupportsLockMode(major, minor int) bool {
+	return major > 0 || minor >= 18
+}
+
 // buildMydumperArgs constructs the argument slice for a mydumper invocation.
 // --compress-protocol and --complete-insert are always included.
-// When supportsLockMode is true (mydumper >= 0.11.0), --sync-thread-lock-mode
-// and --trx-tables are included for lighter locking. When false (mydumper
-// 0.10.x or older), they are omitted so the dump works on Ubuntu 24.04's
-// apt-installed mydumper without error (#219).
+// When supportsLockMode is true (mydumper >= 0.18, see
+// mydumperSupportsLockMode), --sync-thread-lock-mode and --trx-tables are
+// included for lighter locking. When false (older builds, e.g. distro apt
+// packages), they are omitted so the dump works without error (#219, #460).
 // Schema filtering: single schema → --database; multiple → --regex.
 // Table filtering: --tables-list with a comma-joined list.
 // When encryptKeyPath is non-empty, --exec-per-thread and

--- a/cmd/bintrail/dump_test.go
+++ b/cmd/bintrail/dump_test.go
@@ -876,3 +876,22 @@ func assertArgsContainPair(t *testing.T, args []string, key, val string) {
 		t.Errorf("expected %q after %q, got %q", val, key, got)
 	}
 }
+
+func TestMydumperSupportsLockMode(t *testing.T) {
+	cases := []struct {
+		major, minor int
+		want         bool
+	}{
+		{0, 10, false}, // Ubuntu 24.04 / Debian bookworm apt builds
+		{0, 11, false}, // had --no-locks/--trx-consistency-only, NOT these flags
+		{0, 17, false}, // last minor before the flags landed
+		{0, 18, true},  // --sync-thread-lock-mode/--trx-tables introduced (0.18.1)
+		{0, 21, true},
+		{1, 0, true},
+	}
+	for _, tc := range cases {
+		if got := mydumperSupportsLockMode(tc.major, tc.minor); got != tc.want {
+			t.Errorf("mydumperSupportsLockMode(%d, %d) = %v, want %v", tc.major, tc.minor, got, tc.want)
+		}
+	}
+}

--- a/docs/dump-and-baseline.md
+++ b/docs/dump-and-baseline.md
@@ -36,7 +36,7 @@ To pin a specific mydumper Docker image version:
 
 ```sh
 bintrail dump \
-  --mydumper-image mydumper/mydumper:v0.16.7-3 \
+  --mydumper-image mydumper/mydumper:v1.0.3-1 \
   --source-dsn "user:pass@tcp(source-db:3306)/" \
   --output-dir /tmp/mydumper-output
 ```
@@ -51,7 +51,7 @@ If you prefer to install mydumper as a local binary instead of using Docker:
 ```sh
 # Download from the releases page — check for the latest version:
 # https://github.com/mydumper/mydumper/releases/latest
-wget https://github.com/mydumper/mydumper/releases/download/v0.16.7-3/mydumper_0.16.7-3.jammy_amd64.deb
+wget https://github.com/mydumper/mydumper/releases/download/v1.0.3-1/mydumper_1.0.3-1.jammy_amd64.deb
 sudo dpkg -i mydumper_*.deb
 
 # Or from the system repository (may be older)
@@ -62,7 +62,7 @@ sudo apt-get install mydumper
 
 ```sh
 # Check for the latest version: https://github.com/mydumper/mydumper/releases/latest
-wget https://github.com/mydumper/mydumper/releases/download/v0.16.7-3/mydumper-0.16.7-3.el8.x86_64.rpm
+wget https://github.com/mydumper/mydumper/releases/download/v1.0.3-1/mydumper-1.0.3-1.el9.x86_64.rpm
 sudo rpm -i mydumper-*.rpm
 ```
 


### PR DESCRIPTION
## Why

`--sync-thread-lock-mode`/`--trx-tables` landed in mydumper **0.18.1** — not 0.11 (whose light-locking options were `--no-locks`/`--trx-consistency-only`, different flags). Verified against upstream tags during the PR #458 review: the flags don't exist in v0.11.5, v0.16.9, or v0.17.1. The gate at `minor < 11` handed 0.12–0.17 builds flags they reject with "unknown option", hard-failing `bintrail dump` while the comments claimed support.

## What

- New `mydumperSupportsLockMode(major, minor)` helper (`major > 0 || minor >= 18`) — the decision was inline in `runDump` with no direct test.
- Boundary table test either side of 0.18 (0.10/0.11/0.17 → omit; 0.18/0.21/1.0 → include).
- Corrected the three comments carrying the false "≥ 0.11" floor; warn message now says 0.18.

Behavior for 0.11–0.17 is the same heavier-locks fallback already used for 0.10 — the safe degradation, now applied to the versions that actually need it.

Fixes #460

🤖 Generated with [Claude Code](https://claude.com/claude-code)