### PR TITLE
fix(baseline): zero converted tables is an error, not a silent success

### DIFF
--- a/cmd/bintrail/baseline_test.go
+++ b/cmd/bintrail/baseline_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -222,8 +223,14 @@ func TestRunBaseline_invalidUploadURL(t *testing.T) {
 		bslUpload = origUpload
 	})
 
-	bslInput = t.TempDir() // empty dir → 0 tables → baseline.Run succeeds
+	// A minimal 1-table dump: an EMPTY input dir no longer reaches the
+	// upload validation — zero discovered tables is an error since #461.
+	bslInput = t.TempDir()
+	writeMinimalDump(t, bslInput)
 	bslOutput = t.TempDir()
+	// Outside cobra's Execute the command context is nil, and baseline.Run's
+	// workers (now actually reached — the dump has a table) call ctx.Err().
+	baselineCmd.SetContext(context.Background())
 	bslTimestamp = "2025-02-28T00:00:00Z"
 	bslUpload = "http://not-s3.example.com/bucket" // invalid: not s3://
 
@@ -333,5 +340,20 @@ func TestDecryptDumpFiles_roundTrip(t *testing.T) {
 	cleanup()
 	if _, err := os.Stat(plainFile); !os.IsNotExist(err) {
 		t.Error("cleanup should have removed the decrypted file")
+	}
+}
+
+// writeMinimalDump writes the smallest mydumper output that converts: one
+// table with a schema file and a single-row INSERT.
+func writeMinimalDump(t *testing.T, dir string) {
+	t.Helper()
+	schema := "CREATE TABLE `orders` (\n  `id` int NOT NULL,\n  PRIMARY KEY (`id`)\n);\n"
+	for name, content := range map[string]string{
+		"shop.orders-schema.sql": schema,
+		"shop.orders.00000.sql":  "INSERT INTO `orders` VALUES(1);\n",
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
 	}
 }

--- a/cmd/bintrail/baseline_test.go
+++ b/cmd/bintrail/baseline_test.go
@@ -124,8 +124,9 @@ func TestRunBaselineTimestampParsing(t *testing.T) {
 		bslTimestamp = origTS
 	})
 
-	// Use real directories so Run gets past DiscoverTables with 0 tables found,
-	// avoiding any interaction with the filesystem beyond what's needed.
+	// Real (empty) directories: post-#461 a dump with zero tables is an
+	// error, so the valid-timestamp cases below assert exactly that error —
+	// which doubles as the cmd-level propagation check for it.
 	bslInput = t.TempDir()
 	bslOutput = t.TempDir()
 
@@ -135,9 +136,8 @@ func TestRunBaselineTimestampParsing(t *testing.T) {
 		t.Errorf("invalid timestamp: want ISO 8601 error, got: %v", err)
 	}
 
-	// Valid formats: each should parse without the ISO 8601 error.
-	// With an empty input dir, DiscoverTables returns 0 tables → Run returns
-	// Stats{} with no error, so runBaseline succeeds overall.
+	// Valid formats: each must get past timestamp parsing and surface the
+	// zero-tables refusal from baseline.Run instead.
 	validCases := []struct {
 		name string
 		ts   string
@@ -149,8 +149,8 @@ func TestRunBaselineTimestampParsing(t *testing.T) {
 	for _, tc := range validCases {
 		bslTimestamp = tc.ts
 		err := runBaseline(baselineCmd, nil)
-		if err != nil && strings.Contains(err.Error(), "expected ISO 8601") {
-			t.Errorf("%s: timestamp should parse without ISO 8601 error, got: %v", tc.name, err)
+		if err == nil || !strings.Contains(err.Error(), "no tables found") {
+			t.Errorf("%s: want the zero-tables error after a parsed timestamp, got: %v", tc.name, err)
 		}
 	}
 }
@@ -211,8 +211,9 @@ func TestRunBaselineMissingInput(t *testing.T) {
 // TestRunBaseline_invalidUploadURL verifies that an invalid --upload value
 // (not starting with s3://) is caught by parseS3URL inside uploadBaselineToS3
 // and surfaces as an "S3 upload" error — without requiring AWS credentials.
-// baseline.Run with an empty input dir and a valid timestamp succeeds (0 tables),
-// so execution reaches the upload block before the URL validation fires.
+// A minimal real dump carries execution past baseline.Run (post-#461 an
+// empty input dir errors on zero tables) so the upload block's URL
+// validation is what fires.
 func TestRunBaseline_invalidUploadURL(t *testing.T) {
 	origInput, origOutput, origTS, origUpload :=
 		bslInput, bslOutput, bslTimestamp, bslUpload
@@ -231,6 +232,7 @@ func TestRunBaseline_invalidUploadURL(t *testing.T) {
 	// Outside cobra's Execute the command context is nil, and baseline.Run's
 	// workers (now actually reached — the dump has a table) call ctx.Err().
 	baselineCmd.SetContext(context.Background())
+	t.Cleanup(func() { baselineCmd.SetContext(nil) })
 	bslTimestamp = "2025-02-28T00:00:00Z"
 	bslUpload = "http://not-s3.example.com/bucket" // invalid: not s3://
 

--- a/internal/baseline/baseline.go
+++ b/internal/baseline/baseline.go
@@ -63,14 +63,22 @@ func Run(ctx context.Context, cfg Config) (Stats, error) {
 	if err != nil {
 		return Stats{}, fmt.Errorf("discover tables: %w", err)
 	}
+	if len(tables) == 0 {
+		// A metadata-only dump is easy to produce with mydumper itself exiting
+		// 0 (a --regex that matches nothing, a dump user lacking SELECT on the
+		// requested schemas). Returning success here converted that into a
+		// missing baseline that surfaces weeks later as ErrNoBaseline — or as
+		// Time-travel silently reconstructing from an older snapshot (#461).
+		return Stats{}, fmt.Errorf("no tables found in %s — the dump contains no table data; check the dump's schema filter and the dump user's SELECT privileges", cfg.InputDir)
+	}
 
 	// Apply table filter.
 	if len(cfg.Tables) > 0 {
+		discovered := len(tables)
 		tables = filterTables(tables, cfg.Tables)
-	}
-
-	if len(tables) == 0 {
-		return Stats{}, nil
+		if len(tables) == 0 {
+			return Stats{}, fmt.Errorf("--tables filter %v matched none of the %d table(s) in the dump", cfg.Tables, discovered)
+		}
 	}
 
 	// Timestamp string for directory name and metadata (colons → dashes for

--- a/internal/baseline/baseline.go
+++ b/internal/baseline/baseline.go
@@ -189,8 +189,17 @@ func Run(ctx context.Context, cfg Config) (Stats, error) {
 	}
 	wg.Wait()
 
+	// A cancelled run skipped tables without recording errors (workers just
+	// return on ctx.Err()) — succeeding here would publish a partial snapshot
+	// indistinguishable from a complete one.
+	if err := ctx.Err(); err != nil {
+		return stats, err
+	}
 	if len(errs) > 0 {
-		return stats, errs[0] // return first error; others are logged
+		if len(errs) > 1 {
+			return stats, fmt.Errorf("%d of %d tables failed (others logged); first: %w", len(errs), len(tables), errs[0])
+		}
+		return stats, errs[0]
 	}
 	return stats, nil
 }

--- a/internal/baseline/baseline_test.go
+++ b/internal/baseline/baseline_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -1109,12 +1110,14 @@ func TestFilterTablesNoMatch(t *testing.T) {
 		RowGroupSize: 100,
 	}
 
-	stats, err := Run(context.Background(), cfg)
-	if err != nil {
-		t.Fatalf("Run: %v", err)
+	// Pre-#461 this returned success with 0 tables processed — a typo'd
+	// filter silently produced no baseline. It is now an error.
+	_, err := Run(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("Run with a filter matching nothing succeeded; want an error")
 	}
-	if stats.TablesProcessed != 0 {
-		t.Errorf("TablesProcessed = %d, want 0 (filter matched nothing)", stats.TablesProcessed)
+	if !strings.Contains(err.Error(), "matched none") {
+		t.Errorf("error = %v, want the filter-matched-nothing message", err)
 	}
 }
 
@@ -1446,5 +1449,60 @@ func TestDiscoverBaselines_emptyDir(t *testing.T) {
 	}
 	if len(results) != 0 {
 		t.Errorf("got %d baselines, want 0", len(results))
+	}
+}
+
+// ─── zero-table refusals (#461) ──────────────────────────────────────────────
+
+// TestRun_zeroTablesIsError: a metadata-only dump (mydumper exits 0 for a
+// no-match --regex or missing SELECT privileges) must NOT convert into a
+// silent "success" with no baseline.
+func TestRun_zeroTablesIsError(t *testing.T) {
+	inputDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(inputDir, "metadata"), []byte(sampleMetadata), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Run(context.Background(), Config{
+		InputDir:     inputDir,
+		OutputDir:    t.TempDir(),
+		Compression:  "none",
+		RowGroupSize: 100,
+	})
+	if err == nil {
+		t.Fatal("Run on a metadata-only dump succeeded; want an error")
+	}
+	if !strings.Contains(err.Error(), "no tables found") {
+		t.Fatalf("error = %v, want the no-tables message", err)
+	}
+}
+
+// TestRun_filterMatchesNothingIsError: a --tables filter that eliminates every
+// discovered table is a caller mistake (typo'd schema.table), not a no-op.
+func TestRun_filterMatchesNothingIsError(t *testing.T) {
+	inputDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(inputDir, "metadata"), []byte(sampleMetadata), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(inputDir, "shop.orders-schema.sql"), []byte(sampleSchema), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(inputDir, "shop.orders.00000.sql"),
+		[]byte("INSERT INTO `orders` VALUES(1,10,'9.99','note','2025-01-01 00:00:00','2025-01-15');\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Run(context.Background(), Config{
+		InputDir:     inputDir,
+		OutputDir:    t.TempDir(),
+		Tables:       []string{"shop.nope"},
+		Compression:  "none",
+		RowGroupSize: 100,
+	})
+	if err == nil {
+		t.Fatal("Run with a filter matching nothing succeeded; want an error")
+	}
+	if !strings.Contains(err.Error(), "matched none") {
+		t.Fatalf("error = %v, want the filter-matched-nothing message", err)
 	}
 }

--- a/internal/reconstruct/baseline.go
+++ b/internal/reconstruct/baseline.go
@@ -341,6 +341,10 @@ func findBaselineLocal(baselineDir, schema, table string, at time.Time) (string,
 
 // ─── S3 ───────────────────────────────────────────────────────────────────────
 
+// NOTE(#461): unlike findBaselineLocal, this path CANNOT warn when the table
+// is absent from the newest snapshot — the glob below is table-scoped, so
+// snapshots lacking the table are invisible without a broader (and costlier)
+// listing. S3 lookups therefore still fall back to older snapshots silently.
 func findBaselineS3(ctx context.Context, s3URL, schema, table string, at time.Time) (string, time.Time, error) {
 	db, err := sql.Open("duckdb", "")
 	if err != nil {

--- a/internal/reconstruct/baseline.go
+++ b/internal/reconstruct/baseline.go
@@ -302,6 +302,7 @@ func findBaselineLocal(baselineDir, schema, table string, at time.Time) (string,
 		path string
 	}
 	var candidates []candidate
+	var newestSnap time.Time // newest eligible snapshot, whether or not it has the table
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
@@ -309,6 +310,9 @@ func findBaselineLocal(baselineDir, schema, table string, at time.Time) (string,
 		t, ok := parseDirTimestamp(entry.Name())
 		if !ok || t.After(at) {
 			continue
+		}
+		if t.After(newestSnap) {
+			newestSnap = t
 		}
 		p := filepath.Join(baselineDir, entry.Name(), schema, table+".parquet")
 		if _, err := os.Stat(p); err != nil {
@@ -321,7 +325,18 @@ func findBaselineLocal(baselineDir, schema, table string, at time.Time) (string,
 			ErrNoBaseline, schema, table, at.UTC().Format(time.RFC3339), baselineDir)
 	}
 	slices.SortFunc(candidates, func(a, b candidate) int { return b.t.Compare(a.t) })
-	return candidates[0].path, candidates[0].t, nil
+	best := candidates[0]
+	if newestSnap.After(best.t) {
+		// The table dropped out of newer snapshots (dump filter change, lost
+		// SELECT privilege, rename): falling back to an older snapshot is the
+		// designed behavior, but doing it silently means reconstructing from
+		// ever-staler data with no signal anywhere (#461).
+		slog.Warn("baseline: table is absent from the newest snapshot; using an older one — re-dump to refresh it",
+			"schema", schema, "table", table,
+			"using", best.t.UTC().Format(time.RFC3339),
+			"newest_snapshot", newestSnap.UTC().Format(time.RFC3339))
+	}
+	return best.path, best.t, nil
 }
 
 // ─── S3 ───────────────────────────────────────────────────────────────────────

--- a/internal/reconstruct/baseline_find_test.go
+++ b/internal/reconstruct/baseline_find_test.go
@@ -1,0 +1,70 @@
+package reconstruct
+
+import (
+	"bytes"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func writeFindFixture(t *testing.T, dir string, parts ...string) {
+	t.Helper()
+	p := filepath.Join(append([]string{dir}, parts...)...)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// captureWarns routes the default slog logger into a buffer for the test.
+// Process-global (slog.SetDefault) — do not t.Parallel() tests using it.
+func captureWarns(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return &buf
+}
+
+// TestFindBaselineLocal_staleSnapshotWarns pins the #461 staleness signal:
+// when the requested table is absent from the newest eligible snapshot and an
+// older one is used, findBaselineLocal must warn — and must NOT warn when the
+// chosen snapshot IS the newest. It also pins the selection invariants the
+// warn depends on: newest-eligible wins, and snapshots after `at` are
+// excluded from both selection and the newest-snapshot comparison.
+func TestFindBaselineLocal_staleSnapshotWarns(t *testing.T) {
+	dir := t.TempDir()
+	writeFindFixture(t, dir, "2026-01-01T00-00-00Z", "shop", "orders.parquet")
+	writeFindFixture(t, dir, "2026-02-01T00-00-00Z", "shop", "users.parquet")  // newest eligible, NO orders
+	writeFindFixture(t, dir, "2026-03-01T00-00-00Z", "shop", "orders.parquet") // after `at` — must be invisible
+
+	at := time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC)
+
+	buf := captureWarns(t)
+	path, ts, err := findBaselineLocal(dir, "shop", "orders", at)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantTS := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	if !ts.Equal(wantTS) || filepath.Base(filepath.Dir(filepath.Dir(path))) != "2026-01-01T00-00-00Z" {
+		t.Fatalf("selected %s (%s), want the 2026-01-01 snapshot (newer eligible snapshot lacks the table; 2026-03-01 is after `at`)", path, ts)
+	}
+	if !bytes.Contains(buf.Bytes(), []byte("absent from the newest snapshot")) {
+		t.Fatalf("want the staleness warn, got log output: %q", buf.String())
+	}
+
+	// Chosen snapshot IS the newest eligible → no warn.
+	buf2 := captureWarns(t)
+	at2 := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+	if _, ts2, err := findBaselineLocal(dir, "shop", "orders", at2); err != nil || !ts2.Equal(wantTS) {
+		t.Fatalf("selection at %s: ts=%s err=%v", at2, ts2, err)
+	}
+	if bytes.Contains(buf2.Bytes(), []byte("absent from the newest snapshot")) {
+		t.Fatalf("spurious staleness warn when the chosen snapshot is the newest eligible: %q", buf2.String())
+	}
+}


### PR DESCRIPTION
## Why

`baseline.Run` returned `Stats{}, nil` for a dump with no table data. A metadata-only dump is easy to produce **with mydumper itself exiting 0** (a `--regex` matching nothing; a dump user lacking `SELECT` on the requested schemas — both verified live during the PR #458 review). The result is a missing baseline that surfaces weeks later as `ErrNoBaseline` — or worse, Time-travel silently reconstructing from an **older** snapshot when a table drops out of newer dumps.

## What

- **Zero discovered tables → error** naming the input dir and the two likely causes (dump schema filter, `SELECT` privileges). `bintrail baseline` now exits non-zero instead of printing `tables: 0` in green.
- **`--tables` filter eliminating everything → error** naming the filter and the discovered count (a typo'd `schema.table` was a silent no-op).
- **`findBaselineLocal` staleness warn**: when the requested table is absent from the newest eligible snapshot and an older one is used, it now `slog.Warn`s with both timestamps — the fallback is by design, but it was invisible.

Two pre-existing tests encoded the silent behavior and were updated: `TestFilterTablesNoMatch` asserts the new error, and `TestRunBaseline_invalidUploadURL` gets a minimal real dump (an empty input dir no longer reaches the upload validation) plus a command context — outside cobra's `Execute` it is nil, and `Run`'s workers (now actually reached) call `ctx.Err()`.

Complements the compose-level guard from #458 (which protects only the compose profile); this closes the hole for everyone calling `bintrail dump` + `bintrail baseline` directly.

Fixes #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)