### PR TITLE
docs: document the 4th MCP tool (list_schema_changes) everywhere; time-travel doc gaps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ All commands load a `.bintrail.env` file (local) or `~/.config/bintrail/config.e
 
 ## MCP server
 
-`cmd/bintrail-mcp/` exposes three read-only tools (`query`, `recover`, `status`) via stdio (default, `.mcp.json`) or HTTP (`--http :8080`). DSN: `index_dsn` parameter overrides `BINTRAIL_INDEX_DSN` env var. All tools annotated `ReadOnlyHint: true`, `IdempotentHint: true`.
+`cmd/bintrail-mcp/` exposes four read-only tools (`query`, `recover`, `status`, `list_schema_changes`) via stdio (default, `.mcp.json`) or HTTP (`--http :8080`). DSN: `index_dsn` parameter overrides `BINTRAIL_INDEX_DSN` env var. All tools annotated `ReadOnlyHint: true`, `IdempotentHint: true`. `list_schema_changes` reads the `schema_changes` table directly; its `ddl_type` filter is prefix-matched (`ALTER` → `ALTER TABLE`).
 
 Key patterns:
 - `newServer() *mcp.Server` — extracted from `main()` for testability

--- a/cmd/bintrail-mcp/main.go
+++ b/cmd/bintrail-mcp/main.go
@@ -1,5 +1,6 @@
 // bintrail-mcp is an MCP (Model Context Protocol) server that exposes
-// read-only Bintrail operations as tools: query, recover, and status.
+// read-only Bintrail operations as tools: query, recover, status, and
+// list_schema_changes.
 //
 // By default it communicates over stdio (for use as a subprocess by Claude
 // Code, Cursor, etc.). Pass --http <addr> to start an HTTP server instead,

--- a/docs/connector-testing.md
+++ b/docs/connector-testing.md
@@ -206,7 +206,7 @@ Once connected, in the Inspector UI:
 
 **Test `tools/list`:**
 1. Click **Tools** in the sidebar
-2. You should see three tools: `query`, `recover`, `status`
+2. You should see four tools: `query`, `recover`, `status`, `list_schema_changes`
 
 **Test `tools/call`:**
 1. Click on the `status` tool
@@ -644,7 +644,7 @@ Verify the docs are complete and accurate:
 ## Summary: All Checks
 
 ### Integration Testing
-- [ ] Claude.ai: Add connector → OAuth flow → query/recover/status tools work
+- [ ] Claude.ai: Add connector → OAuth flow → query/recover/status/list_schema_changes tools work
 - [ ] Claude.ai: Token refresh (wait >1 hour, query again)
 - [ ] Claude.ai: Two-tenant data isolation
 - [ ] Claude Desktop: Add connector via UI → tools work → SSE streaming works

--- a/docs/ddl-tracking.md
+++ b/docs/ddl-tracking.md
@@ -181,11 +181,20 @@ Key fields:
 
 | Field | Description |
 |---|---|
-| `ddl_type` | One of `ALTER TABLE`, `CREATE TABLE`, `DROP TABLE`, `RENAME TABLE` |
+| `ddl_type` | One of `ALTER TABLE`, `CREATE TABLE`, `DROP TABLE`, `RENAME TABLE`, `TRUNCATE TABLE` |
 | `ddl_query` | The full DDL statement from the binlog |
 | `snapshot_id` | The snapshot taken after this DDL, or NULL if no source connection was available |
 
 This table is created by `bintrail init` and must exist in the index database. Older index databases (created before this feature) won't have it — the status command handles this gracefully by treating a missing table as zero schema changes.
+
+### Querying schema changes from AI (MCP)
+
+The MCP server exposes this table as the `list_schema_changes` tool, so an AI
+assistant can answer "what ALTERs hit the orders table this month?" directly.
+Filters: `schema`, `table`, `ddl_type` (prefix-matched — `ALTER` matches
+`ALTER TABLE`), `since`, `until`, `limit`. Each result carries the full DDL
+statement, binlog coordinates, and detection timestamp. See
+[mcp-server.md](./mcp-server.md).
 
 ---
 

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -102,9 +102,9 @@ row). It needs Docker and ~3 minutes; it is not part of `go test ./...`.
 
 ## Publishing notes (maintainers)
 
-`.github/workflows/demo.yml` builds and pushes
+`.github/workflows/demo-image.yml` builds and pushes
 `ghcr.io/dbtrail/bintrail-demo` (amd64, cosign-signed) on every `v*` tag
-push, separately from GoReleaser so an demo build failure never blocks a
+push, separately from GoReleaser so a demo build failure never blocks a
 release. (Not `release: published`: GoReleaser creates the release with the
 default `GITHUB_TOKEN`, whose events never trigger other workflows.) Manual
 runs take an explicit existing tag as a `workflow_dispatch` input. Like the main image, the GHCR package is created

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -285,6 +285,21 @@ Notes:
   baseline and "now" stays short. Old snapshots are plain directories — prune
   them by deleting `<timestamp>` dirs in the volume.
 
+### Time-travel SQL (`AS OF`) and the compose stack
+
+The console's Time-travel tab and time-travel **SQL** are different surfaces.
+`SELECT … AS OF` queries are answered by `bintrail shim` behind ProxySQL — a
+subcommand of the **core** `bintrail` binary that the console image
+deliberately does not ship — and the compose file includes no shim or ProxySQL
+service. To put `AS OF` SQL in front of this stack, run the core image
+(`ghcr.io/dbtrail/bintrail`) joined to the compose network with
+`shim --index-dsn` pointed at the bundled index (`index-mysql:3306`, password
+from the `bintrail-index-secret` volume — the boot `SOURCE_DSN` entry streams
+into `bintrail_index`), plus a ProxySQL loaded with `bintrail proxysql-config`
+output. The full shim + ProxySQL walkthrough is
+[time-travel-sql.md](./time-travel-sql.md); for a zero-setup taste of the SQL
+surface, use the demo image ([demo.md](./demo.md)).
+
 ## Environment variables
 
 | Variable | Used by | Description |

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -783,11 +783,12 @@ curl -s localhost:9090/metrics | grep bintrail_stream_replication_lag_seconds
 
 **Situation:** You want to use Claude Desktop (or Claude Code on another machine) to investigate database changes in natural language — without typing CLI commands.
 
-dbtrail ships an MCP server that exposes `query`, `recover`, and `status` as AI tools. Once configured, you can ask Claude things like:
+dbtrail ships an MCP server that exposes `query`, `recover`, `status`, and `list_schema_changes` as AI tools. Once configured, you can ask Claude things like:
 
 - "What got deleted in the last 10 minutes in the orders table?"
 - "Bring back customer 289"
 - "Which tables had the most activity today?"
+- "What schema changes happened this week?"
 
 Claude calls the tools automatically and presents the results.
 

--- a/docs/mcp-gateway.md
+++ b/docs/mcp-gateway.md
@@ -679,12 +679,13 @@ This is the easy part. Once the gateway is running:
 3. Enter the URL: `https://mcp.dbtrail.com/mcp`
 4. Claude auto-discovers the OAuth endpoints, registers itself, and opens a login page
 5. Enter your **tenant ID** (e.g. `acme-corp`) on the authorization page
-6. Done. Claude now has access to `query`, `recover`, and `status` tools.
+6. Done. Claude now has access to the `query`, `recover`, `status`, and `list_schema_changes` tools.
 
 From now on, you can ask Claude things like:
 - "What changed in the users table in the last 24 hours?"
 - "Show me all DELETEs on the orders table since Monday"
 - "Generate SQL to undo the last 5 updates to order 12345"
+- "Which ALTERs hit the orders table this month?"
 
 ---
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,6 +1,6 @@
 # How the MCP Server Works
 
-This page explains `bintrail-mcp` — the Model Context Protocol server that exposes dbtrail's `query`, `recover`, and `status` operations as tools for AI assistants like Claude.
+This page explains `bintrail-mcp` — the Model Context Protocol server that exposes dbtrail's `query`, `recover`, `status`, and `list_schema_changes` operations as tools for AI assistants like Claude.
 
 ---
 
@@ -16,17 +16,20 @@ Claude calls the `query` tool with the right parameters, gets the results back a
 
 ---
 
-## Three Read-Only Tools
+## Four Read-Only Tools
 
-The MCP server exposes three tools, all of which are read-only:
+The MCP server exposes four tools, all of which are read-only:
 
 | Tool | CLI equivalent | Description |
 |------|---------------|-------------|
 | `query` | `bintrail query` | Search indexed binlog events with filters |
 | `recover` | `bintrail recover --dry-run` | Generate reversal SQL (never executes it) |
 | `status` | `bintrail status` | Show indexed files, partitions, and summary |
+| `list_schema_changes` | — (reads the `schema_changes` table, see [DDL tracking](./ddl-tracking.md)) | List DDL changes recorded during indexing or streaming, with the full statement and binlog coordinates |
 
-All three tools are annotated with `ReadOnlyHint: true` and `IdempotentHint: true`. These hints tell the MCP client that it's safe to call them multiple times and that they don't modify any state.
+All four tools are annotated with `ReadOnlyHint: true` and `IdempotentHint: true`. These hints tell the MCP client that it's safe to call them multiple times and that they don't modify any state.
+
+`list_schema_changes` accepts `schema`, `table`, `ddl_type`, `since`, `until`, and `limit` (default 100). `ddl_type` takes `CREATE`, `ALTER`, `DROP`, `RENAME`, or `TRUNCATE` and is prefix-matched against the stored values (`ALTER` matches `ALTER TABLE`). Results come back as JSON, newest first (a plain "No schema changes found." when nothing matches).
 
 ---
 
@@ -39,17 +42,20 @@ cmd/bintrail-mcp/main.go
        │
        ├── queryTool  → resolveArchiveSources → Engine.Fetch + parquetquery.Fetch → MergeResults → Format
        ├── recoverTool → resolveArchiveSources → Engine.Fetch + parquetquery.Fetch → MergeResults → GenerateSQLFromRows
-       └── statusTool → internal/status.LoadIndexState + LoadPartitionStats + WriteStatus
+       ├── statusTool → internal/status.CollectStatus → StatusData.Write
+       └── schemaChangesTool → SELECT … FROM schema_changes (JSON output)
 ```
 
 Both `queryTool` and `recoverTool` automatically discover Parquet archive sources from `archive_state` in the index database (or from `BINTRAIL_ARCHIVE_S3` + `BINTRAIL_ID` env vars). When archives are found, results from MySQL and Parquet are merged, deduplicated, and sorted before formatting or SQL generation. The `no_archive` parameter disables this auto-routing.
+
+Beyond the basic filters (schema, table, pk, event_type, gtid, since, until), both tools accept `changed_column`, `column_eq` (repeatable `column=value` equality filters), `flag` (table/column flag filter), and `profile` (RBAC table-deny + column-redaction); `query` additionally takes `format` (`json`, `table`, or `csv`).
 
 `buildQueryOptions` in `cmd/bintrail-mcp/main.go` is the shared filter builder used by both `queryTool` and `recoverTool`. It calls the same `cliutil.ParseEventType` and `cliutil.ParseTime` helpers that the CLI uses:
 
 ```go
 // cmd/bintrail-mcp/main.go
 func buildQueryOptions(schema, table, pk, eventType, gtid, since, until, changedCol string,
-    limit, defaultLimit int) (query.Options, error) {
+    columnEq []string, flagVal string, limit, defaultLimit int) (query.Options, error) {
     // validate pk requires schema+table
     // validate changed_column requires schema+table
     et, err := cliutil.ParseEventType(eventType)
@@ -122,13 +128,20 @@ The server setup is in `newServer()` rather than `main()`:
 ```go
 // cmd/bintrail-mcp/main.go
 func newServer() *mcp.Server {
+    return newServerWithDSN("")
+}
+
+func newServerWithDSN(dsnOverride string) *mcp.Server {
     server := mcp.NewServer(&mcp.Implementation{...}, &mcp.ServerOptions{...})
-    mcp.AddTool(server, &mcp.Tool{Name: "query", ...}, queryTool)
-    mcp.AddTool(server, &mcp.Tool{Name: "recover", ...}, recoverTool)
-    mcp.AddTool(server, &mcp.Tool{Name: "status", ...}, statusTool)
+    mcp.AddTool(server, &mcp.Tool{Name: "query", ...}, makeQueryTool(connectFn))
+    mcp.AddTool(server, &mcp.Tool{Name: "recover", ...}, makeRecoverTool(connectFn))
+    mcp.AddTool(server, &mcp.Tool{Name: "status", ...}, makeStatusTool(resolveFn))
+    mcp.AddTool(server, &mcp.Tool{Name: "list_schema_changes", ...}, makeSchemaChangesTool(connectFn))
     return server
 }
 ```
+
+`newServer()` is a thin wrapper over `newServerWithDSN(dsnOverride)`: a non-empty override forces every tool to use that DSN, ignoring both the env var and the `index_dsn` parameter. Multi-tenant mode (`--tenant-dsns`, see [MCP Gateway](./mcp-gateway.md)) uses it to pin each session to the tenant's index.
 
 `main()` just calls `newServer()` and wires it to a transport. This means unit tests can call `newServer()` directly and pass it an in-memory transport, without starting a subprocess or dealing with stdio framing:
 
@@ -158,7 +171,7 @@ The easiest way to connect Claude to dbtrail. Requires the [MCP Gateway](./mcp-g
 3. Enter the gateway URL: `https://mcp.dbtrail.com/mcp`
 4. Claude auto-discovers the OAuth endpoints, opens the login page
 5. Enter your **tenant ID** and click **Authorize**
-6. Done — `query`, `recover`, and `status` tools are now available
+6. Done — the `query`, `recover`, `status`, and `list_schema_changes` tools are now available
 
 This works from the Claude web app, Claude Desktop, and Claude mobile. Token refresh happens automatically — sessions survive indefinitely without re-authenticating.
 

--- a/docs/streaming-101.md
+++ b/docs/streaming-101.md
@@ -645,7 +645,7 @@ If you're using Claude Code in the dbtrail project directory, the `.mcp.json` fi
    }
    ```
 
-2. Open a Claude Code session in the project directory. The bintrail tools (`query`, `recover`, `status`) are available immediately.
+2. Open a Claude Code session in the project directory. The bintrail tools (`query`, `recover`, `status`, `list_schema_changes`) are available immediately.
 
 3. Try asking:
 
@@ -720,7 +720,7 @@ Keep it running with systemd, launchd, or tmux.
    }
    ```
 
-4. Restart Claude Desktop. The `query`, `recover`, and `status` tools appear automatically.
+4. Restart Claude Desktop. The `query`, `recover`, `status`, and `list_schema_changes` tools appear automatically.
 
 ### Troubleshooting MCP
 

--- a/docs/time-travel-sql.md
+++ b/docs/time-travel-sql.md
@@ -227,7 +227,7 @@ Connect through ProxySQL:
 mysql -u app_user -p -h 127.0.0.1 -P 6033 myapp
 ```
 
-Five statement shapes are recognised:
+Six statement shapes are recognised:
 
 ```sql
 -- Row state at a point in time (point-lookup, fast):
@@ -236,6 +236,11 @@ SELECT * FROM _flashback.orders AS OF '2026-05-02 10:00:00' WHERE id = 12345;
 -- The same, on the REAL table name — the AS OF clause must END the
 -- statement (#385). Rewritten internally to _flashback (binlog-only):
 SELECT * FROM orders WHERE id = 12345 AS OF '2026-05-02 10:00:00';
+
+-- Optimizer-hint form on the real table name (ORM-friendly: survives query
+-- builders that would reject AS OF syntax). `*`-only — a column list here
+-- is a parse error:
+SELECT /*+ DBTRAIL_AT='2026-05-02 10:00:00' */ * FROM orders WHERE id = 12345;
 
 -- Full-table reconstruction at AS OF (no WHERE). Against _snapshot (with a
 -- baseline configured) this is every row that existed at that instant;
@@ -247,6 +252,8 @@ SELECT * FROM _flashback.orders AS OF '2026-05-02 10:00:00';
 -- All events for one row in a time window:
 SELECT * FROM _diff.orders BETWEEN '2026-05-01' AND '2026-05-02' WHERE id = 12345;
 ```
+
+Every quoted time literal — in `AS OF`, `DBTRAIL_AT`, and the `BETWEEN` bounds — accepts four absolute formats (`'2026-05-02 10:00:00'`, RFC 3339 `'2026-05-02T10:00:00Z'`, zone-less `'2026-05-02T10:00:00'`, and date-only `'2026-05-02'`), plus `'now'` and relative forms `'<n> seconds|minutes|hours|days ago'` (e.g. `AS OF '5 minutes ago'`), resolved against the wall clock at parse time. Larger units (weeks, months) are deliberately not parsed — spell them as days.
 
 On the `_flashback` / `_snapshot` shapes a column list may replace `*` and the optional `TIMESTAMP` keyword may follow `AS OF` (Oracle / SQL Server convention):
 


### PR DESCRIPTION
## Summary

A functional-verification pass over ProxySQL time-travel, the new console UI, and the MCP server (all three verified working against the released `0.13.2` artifacts and current main) surfaced 16 doc-staleness findings. This PR fixes all of them.

### MCP: three tools → four

`list_schema_changes` has been registered in `cmd/bintrail-mcp/main.go` for a while, but **every** doc enumeration still said three (`query`, `recover`, `status`) — verified live via stdio `tools/list` (returns 4). Updated:

- **docs/mcp-server.md** — headline, tool table (+ new row with `list_schema_changes` params: `schema`/`table`/`ddl_type` prefix-matched/`since`/`until`/`limit`), architecture diagram (+ `schemaChangesTool` branch, corrected stale `statusTool → CollectStatus → StatusData.Write` arrow), `buildQueryOptions` snippet (missing `columnEq []string, flagVal string`), new paragraph on `changed_column`/`column_eq`/`flag`/`profile`/`format` params, `newServer`/`newServerWithDSN` snippet (multi-tenant override), Connector step 6
- **docs/guide.md** Scenario K, **docs/streaming-101.md** ×2, **docs/mcp-gateway.md** step 6, **docs/connector-testing.md** Inspector step + summary checklist (a tester following the old checklist would flag a false failure on seeing 4 tools)
- **cmd/bintrail-mcp/main.go** package doc comment, **CLAUDE.md** MCP section
- **docs/ddl-tracking.md** — cross-link the MCP tool; `ddl_type` also stores `TRUNCATE TABLE`

### Time-travel SQL gaps

- **docs/time-travel-sql.md**: the `DBTRAIL_AT` optimizer-hint form was missing from the Step 6 grammar (it only appeared in troubleshooting, while demo.md advertises it as a primary form) — added with the `*`-only caveat; new time-literals paragraph (four absolute formats from `timeFormats`, `'now'`, relative `'N seconds|minutes|hours|days ago'` — the demo leans on these but the canonical walkthrough never mentioned them)
- **docs/docker.md**: new note clarifying the console Time-travel tab vs `AS OF` SQL split and how to get the shim+ProxySQL surface next to the compose stack (the console image deliberately lacks the `shim` subcommand) — previously documented nowhere
- **docs/demo.md**: publishing workflow is `demo-image.yml`, not `demo.yml`

## Verification

- All three time-travel forms (`_flashback`, bare `AS OF`, `DBTRAIL_AT` hint) + `_snapshot` degradation + `SHOW TABLES FROM _flashback` exercised live through ProxySQL on the released `ghcr.io/dbtrail/bintrail-demo:0.13.2`
- MCP: unit + integration suites green (48/48), live stdio JSON-RPC smoke (4 tools listed, `status`/`query`/`list_schema_changes` answering), plus a live call through Claude Code's `.mcp.json` registration
- Every new doc claim adversarially cross-checked against `internal/shim/parser.go`, `cmd/bintrail/proxysql_config.go`, `docker-compose.yml`, and the MCP arg structs
- `go build ./cmd/bintrail-mcp && go vet ./cmd/bintrail-mcp` clean (comment-only code change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)