### PR TITLE
fix(mcp): clean client disconnect exits 0 instead of ERROR + exit 1

### DIFF
--- a/cmd/bintrail-mcp/build_test.go
+++ b/cmd/bintrail-mcp/build_test.go
@@ -39,3 +39,32 @@ func TestMakeBuildMCP(t *testing.T) {
 		t.Errorf("expected --help output to mention -http flag, got:\n%s", output)
 	}
 }
+
+// TestStdioCleanDisconnectExitsZero pins #473 end-to-end: a client
+// closing stdin after initialize is the normal end of an MCP stdio
+// session, so the server must exit 0 with no ERROR log line —
+// supervisors and exit-code checks must not record a failure for
+// every normal disconnect.
+func TestStdioCleanDisconnectExitsZero(t *testing.T) {
+	projectRoot := filepath.Join("..", "..")
+	binPath := filepath.Join(t.TempDir(), "bintrail-mcp")
+
+	makeCmd := exec.Command("make", "build-mcp", "MCP_BINARY="+binPath)
+	makeCmd.Dir = projectRoot
+	if out, err := makeCmd.CombinedOutput(); err != nil {
+		t.Fatalf("make build-mcp failed: %v\n%s", err, out)
+	}
+
+	cmd := exec.Command(binPath)
+	cmd.Stdin = strings.NewReader(
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"disconnect-test","version":"1.0"}}}` + "\n" +
+			`{"jsonrpc":"2.0","method":"notifications/initialized"}` + "\n",
+	) // reader drains → stdin closes → clean client disconnect
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("clean disconnect must exit 0, got %v\n%s", err, out)
+	}
+	if strings.Contains(string(out), "ERROR") {
+		t.Errorf("clean disconnect must not log ERROR, got:\n%s", out)
+	}
+}

--- a/cmd/bintrail-mcp/build_test.go
+++ b/cmd/bintrail-mcp/build_test.go
@@ -64,7 +64,40 @@ func TestStdioCleanDisconnectExitsZero(t *testing.T) {
 	if err != nil {
 		t.Fatalf("clean disconnect must exit 0, got %v\n%s", err, out)
 	}
+	// NOTE: the SDK's own Run logs Error("server session ended with
+	// error") on this exact path, currently discarded because
+	// ServerOptions.Logger defaults to a discard logger. If someone
+	// wires a real logger into newServerWithDSN, this assertion starts
+	// failing — that's a TRUE positive for #473's spirit (clean
+	// disconnects must not emit error noise), not test brittleness.
 	if strings.Contains(string(out), "ERROR") {
 		t.Errorf("clean disconnect must not log ERROR, got:\n%s", out)
+	}
+}
+
+// TestStdioGarbageInputExitsNonZero pins the other side of the #473
+// boundary: a real transport fault (undecodable stdin) must still log
+// ERROR and exit non-zero. The clean-disconnect swallow is allowed to
+// catch ONLY the -32004 client-went-away shape — if an SDK bump ever
+// rewired decode errors through that code, this test catches the new
+// silent swallow.
+func TestStdioGarbageInputExitsNonZero(t *testing.T) {
+	projectRoot := filepath.Join("..", "..")
+	binPath := filepath.Join(t.TempDir(), "bintrail-mcp")
+
+	makeCmd := exec.Command("make", "build-mcp", "MCP_BINARY="+binPath)
+	makeCmd.Dir = projectRoot
+	if out, err := makeCmd.CombinedOutput(); err != nil {
+		t.Fatalf("make build-mcp failed: %v\n%s", err, out)
+	}
+
+	cmd := exec.Command(binPath)
+	cmd.Stdin = strings.NewReader("this is not json\n")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("garbage stdin must exit non-zero, got exit 0\n%s", out)
+	}
+	if !strings.Contains(string(out), "ERROR") {
+		t.Errorf("garbage stdin must log ERROR, got:\n%s", out)
 	}
 }

--- a/cmd/bintrail-mcp/main.go
+++ b/cmd/bintrail-mcp/main.go
@@ -217,8 +217,11 @@ func main() {
 		if isClientDisconnect(err) {
 			// The client closing stdin is the normal end of an MCP stdio
 			// session, not a failure — exit 0 so supervisors and scripts
-			// checking exit codes don't record an error (#473).
-			slog.Info("MCP client disconnected; shutting down")
+			// checking exit codes don't record an error (#473). The cause
+			// is kept in the log so anything misclassified as a disconnect
+			// (e.g. an SDK bump re-purposing the wire code) stays
+			// diagnosable.
+			slog.Info("MCP client disconnected; shutting down", "cause", err)
 			return
 		}
 		slog.Error("MCP server error", "error", err)
@@ -239,11 +242,18 @@ const errCodeServerClosing = -32004
 // client closed the connection — as opposed to a transport fault.
 //
 // On a clean stdin EOF, Run (go-sdk v1.3.1, verified empirically)
-// returns "server is closing: EOF": jsonrpc2.ErrServerClosing wrapping
-// the EOF as TEXT — errors.Is(err, io.EOF) is false. Hard transport
-// faults are safe from this check: the SDK's Connection.wait returns
-// non-EOF read/write errors raw (never wrapped in -32004), so they
-// still reach the Error + exit-1 path.
+// returns "server is closing: EOF": after the read side hits EOF the
+// SDK rejects the pending response write, storing
+// jsonrpc2.ErrServerClosing (-32004) wrapping the EOF as TEXT — so
+// errors.Is(err, io.EOF) is false. Real faults cannot arrive wearing
+// -32004: Connection.wait returns a non-EOF readErr RAW with priority
+// over that stored wrapper, and a real write fault claims the writeErr
+// slot first (the SDK stores only the first write error) — both still
+// reach the Error + exit-1 path. The one other -32004 construction (a
+// bare "server is closing" from ss.Close) is unreachable because the
+// stdio path uses context.Background() (no signal cancellation) and
+// sets no ServerOptions.KeepAlive — re-verify this classification if
+// either of those changes.
 func isClientDisconnect(err error) bool {
 	var wireErr *jsonrpc.Error
 	return errors.As(err, &wireErr) && wireErr.Code == errCodeServerClosing

--- a/cmd/bintrail-mcp/main.go
+++ b/cmd/bintrail-mcp/main.go
@@ -38,6 +38,7 @@ import (
 	"time"
 
 	mysqldriver "github.com/go-sql-driver/mysql"
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/dbtrail/dbtrail/internal/cliutil"
@@ -213,9 +214,36 @@ func main() {
 	}
 
 	if err := newServer().Run(ctx, &mcp.StdioTransport{}); err != nil {
+		if isClientDisconnect(err) {
+			// The client closing stdin is the normal end of an MCP stdio
+			// session, not a failure — exit 0 so supervisors and scripts
+			// checking exit codes don't record an error (#473).
+			slog.Info("MCP client disconnected; shutting down")
+			return
+		}
 		slog.Error("MCP server error", "error", err)
 		os.Exit(1)
 	}
+}
+
+// errCodeServerClosing is the JSON-RPC error code of the SDK's
+// jsonrpc2.ErrServerClosing sentinel. The sentinel itself lives in the
+// SDK's internal/jsonrpc2 package, so the wire code is the stable
+// importable handle.
+const errCodeServerClosing = -32004
+
+// isClientDisconnect reports whether a stdio session ended because the
+// client closed the connection — as opposed to a transport fault.
+//
+// On a clean stdin EOF, Run (go-sdk v1.3.1, verified empirically)
+// returns "server is closing: EOF": jsonrpc2.ErrServerClosing wrapping
+// the EOF as TEXT — errors.Is(err, io.EOF) is false. Hard transport
+// faults are safe from this check: the SDK's Connection.wait returns
+// non-EOF read/write errors raw (never wrapped in -32004), so they
+// still reach the Error + exit-1 path.
+func isClientDisconnect(err error) bool {
+	var wireErr *jsonrpc.Error
+	return errors.As(err, &wireErr) && wireErr.Code == errCodeServerClosing
 }
 
 // ─── Tool argument types ─────────────────────────────────────────────────────

--- a/cmd/bintrail-mcp/main.go
+++ b/cmd/bintrail-mcp/main.go
@@ -227,9 +227,12 @@ func main() {
 }
 
 // errCodeServerClosing is the JSON-RPC error code of the SDK's
-// jsonrpc2.ErrServerClosing sentinel. The sentinel itself lives in the
-// SDK's internal/jsonrpc2 package, so the wire code is the stable
-// importable handle.
+// jsonrpc2.ErrServerClosing sentinel. The sentinel lives in the SDK's
+// internal/jsonrpc2 package and the code is NOT re-exported by the
+// public jsonrpc package, so this is a verified-against-v1.3.1 value,
+// not an API promise. If an SDK bump ever renumbers it, the failure
+// mode is benign: clean disconnects revert to the old noisy
+// ERROR + exit 1 — a real fault is never swallowed.
 const errCodeServerClosing = -32004
 
 // isClientDisconnect reports whether a stdio session ended because the

--- a/cmd/bintrail-mcp/main_test.go
+++ b/cmd/bintrail-mcp/main_test.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 
 	"github.com/dbtrail/dbtrail/internal/parser"
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -387,5 +390,34 @@ func TestSchemaChangesArgs_validDDLTypes(t *testing.T) {
 		if strings.Contains(tc.Text, "invalid ddl_type") {
 			t.Errorf("ddl_type %q should be valid, got: %s", ddlType, tc.Text)
 		}
+	}
+}
+
+// ─── isClientDisconnect ──────────────────────────────────────────────────────
+
+func TestIsClientDisconnect(t *testing.T) {
+	// The shape Run returns on a clean stdin EOF (go-sdk v1.3.1):
+	// jsonrpc2.ErrServerClosing (*jsonrpc.Error, code -32004) wrapped
+	// with the EOF rendered as text.
+	closing := fmt.Errorf("%w: %v", &jsonrpc.Error{Code: -32004, Message: "server is closing"}, io.EOF)
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"clean disconnect (wrapped ErrServerClosing)", closing, true},
+		{"bare ErrServerClosing", &jsonrpc.Error{Code: -32004, Message: "server is closing"}, true},
+		{"nil error", nil, false},
+		{"plain transport fault", errors.New("read /dev/stdin: input/output error"), false},
+		{"raw io.EOF (never -32004-wrapped)", io.EOF, false},
+		{"other wire error code", &jsonrpc.Error{Code: -32603, Message: "internal error"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isClientDisconnect(tt.err); got != tt.want {
+				t.Errorf("isClientDisconnect(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
closes #473

## Summary

- A client closing stdin is the normal end of an MCP stdio session, but the server logged `ERROR MCP server error error="server is closing: EOF"` and exited 1 — anything supervising the process (systemd, scripts, log alerting) recorded a failure on every normal disconnect.
- New `isClientDisconnect(err)`: matches the public `*jsonrpc.Error` wire code `-32004` (`jsonrpc2.ErrServerClosing`) via `errors.As`. Probed empirically against go-sdk v1.3.1: the returned error is the `-32004` sentinel wrapping the EOF **as text** (`errors.Is(err, io.EOF)` is false), and the sentinel itself lives in the SDK's internal package — the wire code is the stable importable handle.
- Hard transport faults keep failing loud: the SDK's `Connection.wait` returns non-EOF read/write errors **raw** (never `-32004`-wrapped), so they still hit the `ERROR` + exit-1 path. Unit test covers the classification table; a new integration test builds the real binary, pipes `initialize` + closes stdin, and asserts exit 0 with no ERROR line.

## Test plan

- [x] `go test ./cmd/bintrail-mcp/ -count=1` (unit, incl. the new classification table)
- [x] `go test -tags integration ./cmd/bintrail-mcp/ -count=1` — full suite green, incl. new `TestStdioCleanDisconnectExitsZero`

🤖 Generated with [Claude Code](https://claude.com/claude-code)