### PR TITLE
docs+console: surface the source MySQL user GRANT where it's needed

### DIFF
--- a/docs/console.md
+++ b/docs/console.md
@@ -171,6 +171,12 @@ console's request handlers still never migrate anything), and starts a
 supervised binlog stream. Auto-start: a green preflight starts streaming
 immediately; warnings (e.g. short binlog retention) show but don't block.
 
+The **source user** you paste into the form needs `REPLICATION SLAVE,
+REPLICATION CLIENT, SELECT` on the source MySQL — the form spells out the
+exact `CREATE USER` / `GRANT` to copy. dbtrail never writes to or locks the
+source. Full per-privilege breakdown and the least-privilege (schema-scoped
+`SELECT`) variant: [streaming.md](streaming.md#the-source-mysql-user).
+
 - Each monitored source gets **its own index database** — per-source state
   (checkpoints, snapshots) stays structurally isolated, and the server
   switcher lists it like any other connection.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -13,6 +13,18 @@ You need:
 - MySQL with `binlog_format = ROW` and `binlog_row_image = FULL` (check with `SHOW VARIABLES LIKE 'binlog_%';`)
 - A MySQL database to use as the index (can be on the same server — call it `binlog_index`)
 - The `bintrail` binary installed and on your `$PATH`
+- A user on the source MySQL for dbtrail to read from (see below)
+
+### The source MySQL user
+
+dbtrail reads the source over the replication protocol, so it needs a user with replication + read access. Create one on the **source** server:
+
+```sql
+CREATE USER 'dbtrail'@'%' IDENTIFIED BY 'strong-password';
+GRANT REPLICATION SLAVE, REPLICATION CLIENT, SELECT ON *.* TO 'dbtrail'@'%';
+```
+
+`REPLICATION SLAVE`/`REPLICATION CLIENT` drive the binlog stream; `SELECT` lets dbtrail snapshot the schema (columns, primary keys, foreign keys). dbtrail never writes to or locks the source. For the least-privilege variant (scoping `SELECT` to specific schemas) and a per-privilege breakdown, see [streaming.md](streaming.md#the-source-mysql-user).
 
 Set a shorthand for your index DSN so you don't retype it:
 

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -4,6 +4,39 @@ This page explains `bintrail stream` — the real-time indexing mode that connec
 
 ---
 
+## The Source MySQL User
+
+Before streaming (or monitoring a source from the console "+ Add server" form), create a user on the **source** MySQL with the privileges dbtrail needs. Run this on the source:
+
+```sql
+CREATE USER 'dbtrail'@'%' IDENTIFIED BY 'strong-password';
+GRANT REPLICATION SLAVE, REPLICATION CLIENT, SELECT ON *.* TO 'dbtrail'@'%';
+```
+
+That is the complete, minimal set. Each privilege maps to exactly one thing dbtrail does:
+
+| Privilege | Why dbtrail needs it |
+|---|---|
+| `REPLICATION SLAVE` | Consume the binlog event stream — dbtrail registers as a replica (`COM_BINLOG_DUMP`). |
+| `REPLICATION CLIENT` | Discover the start position and detect gaps: `SHOW BINARY LOG STATUS` / `SHOW MASTER STATUS`, `SHOW BINARY LOGS`, `@@gtid_purged`, `@@gtid_executed`. |
+| `SELECT` | Snapshot the schema (column types, primary keys, foreign keys) from `information_schema`, and run the preflight checks. |
+
+dbtrail **never** writes to the source and never locks it. It does not need `RELOAD`, `LOCK TABLES`, `PROCESS`, `SHOW VIEW`, or `EXECUTE`.
+
+**Least-privilege variant** — `SELECT` is the only privilege you can scope to specific schemas (the two `REPLICATION` grants are global-only in MySQL):
+
+```sql
+CREATE USER 'dbtrail'@'%' IDENTIFIED BY 'strong-password';
+GRANT REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'dbtrail'@'%';
+GRANT SELECT ON shop.* TO 'dbtrail'@'%';        -- repeat per monitored schema
+```
+
+If you scope `SELECT`, it must cover **every column of every monitored table**, or the schema snapshot fails with `no columns found for the requested schemas`.
+
+> The source must also have `binlog_format = ROW` and `binlog_row_image = FULL`. The preflight check (and `bintrail doctor`) refuses to start otherwise — verify with `SHOW VARIABLES LIKE 'binlog_%';`.
+
+---
+
 ## The Problem
 
 `bintrail index` reads binlog files from disk. That works well for self-managed MySQL where you have filesystem access, but it doesn't work for managed MySQL services (Amazon RDS, Aurora, Cloud SQL). Those services don't give you file access to the binlog directory.

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -1878,6 +1878,17 @@ function buildServerForm() {
   monGrid.append(srvField("Schemas", "schemas", { placeholder: "(optional) shop,billing" }));
   monGrid.append(srvField("Archive to S3", "archive_s3", { placeholder: "(optional) s3://bucket/prefix/" }));
   mon.append(monGrid);
+  // The source user is the #1 friction point — spell out the grant inline,
+  // never behind a <details>. REPLICATION SLAVE/CLIENT drive the stream;
+  // SELECT covers the information_schema snapshot of columns/PKs/FKs.
+  const grantHint = el("p", { class: "form-hint", style: "margin-top:10px" });
+  grantHint.append("Source user needs ");
+  grantHint.append(el("code", { text: "REPLICATION SLAVE, REPLICATION CLIENT, SELECT" }));
+  grantHint.append(". Create one on the source MySQL — copy and run:");
+  mon.append(grantHint);
+  mon.append(el("pre", { class: "form-code", text:
+    "CREATE USER 'dbtrail'@'%' IDENTIFIED BY 'strong-password';\n" +
+    "GRANT REPLICATION SLAVE, REPLICATION CLIENT, SELECT ON *.* TO 'dbtrail'@'%';" }));
   mon.append(el("p", { class: "form-hint", style: "margin-top:10px", text: "Archive to S3: rotated partitions upload here as Parquet before they're dropped, so the history survives retention and stays queryable. Needs AWS credentials on the daemon (env / role)." }));
   form.append(mon);
 

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -835,6 +835,17 @@ button { font-family: inherit; }
   color: var(--blue); padding: 0 6px; margin-left: 6px;
 }
 .form-hint { color: var(--ink-2); font-size: 12.5px; margin: 4px 0 16px; }
+.form-hint code { font-family: var(--f-mono); font-size: 12px; }
+/* Copy-pasteable SQL inside a form (e.g. the source-user GRANT). Always
+   visible — never tuck the grant behind a <details>; it is the first thing
+   a user hunting for "what do I put in Source user" needs. */
+.form-code {
+  margin: 6px 0 14px; padding: 12px 14px;
+  font-family: var(--f-mono); font-size: 12px; line-height: 1.65;
+  color: var(--ink); white-space: pre; overflow-x: auto;
+  background: var(--surface-2); border: 1px solid var(--line);
+  border-radius: var(--radius); user-select: all;
+}
 .form-advanced { margin-top: 18px; }
 .form-adv-summary {
   cursor: pointer; user-select: none;


### PR DESCRIPTION
## Why

The privileges a **source MySQL user** needs were documented nowhere — a real friction point when filling in **"Source user"** in the console "+ Add server" form, or when starting `bintrail stream`. A user asking "what do I put here?" had no answer in any doc.

## What

The required grant is minimal and maps 1:1 to what dbtrail actually does against the source (verified against every statement the code runs): `REPLICATION SLAVE` (consume the stream), `REPLICATION CLIENT` (find start position / detect gaps), `SELECT` (snapshot schema from `information_schema`). No `RELOAD`/`LOCK TABLES`/`PROCESS` — dbtrail never writes to or locks the source.

```sql
CREATE USER 'dbtrail'@'%' IDENTIFIED BY 'strong-password';
GRANT REPLICATION SLAVE, REPLICATION CLIENT, SELECT ON *.* TO 'dbtrail'@'%';
```

- **Console modal** (`assets/app.js` + `style.css`): an **always-visible** (never behind `<details>`) copy-pasteable `CREATE USER` / `GRANT` block, rendered inside the monitor fieldset right under the source fields — so it inherits the `data-capability="monitor"` gating and stays hidden in serve-only mode where there's no source. New `.form-code` style.
- **`docs/streaming.md`**: new **"The Source MySQL User"** section up top — per-privilege table, no-write/no-lock guarantee, and the least-privilege (schema-scoped `SELECT`) variant. Single source of truth.
- **`docs/quickstart.md`**: grant added to "Before You Start" with a link.
- **`docs/console.md`**: control-plane section references the grant + links.

## Verification

Headless Chrome (playwright-core, `channel:'chrome'`) against a source-less `bintrail-console watch` daemon (`monitor:true`): the `.form-code` block renders **visible** (`display:block`, `offsetParent` non-null), the fieldset is `cap-on`, the GRANT text matches, **zero JS errors**.

![modal screenshot](attached in PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)