### PR TITLE
fix(console): Test probe reports "not provisioned yet" for a stopped source

### DIFF
--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -2022,6 +2022,10 @@ async function deleteServer(s) {
 // test / doctor / monitor -----------------------------------------------------
 
 function testResultText(res) {
+  // provision_pending: a monitored source whose per-source index isn't created
+  // yet (Start creates it). Reachable server, normal pre-Start state — render
+  // it as a neutral hint, not a red failure.
+  if (res.provision_pending) return "○ " + (res.error || "index not provisioned yet — click Start");
   if (!res.ok) return "✗ " + (res.error || "unreachable");
   let s = "✓ ok · " + res.latency_ms + " ms";
   if (res.server_version) s += " · MySQL " + res.server_version;
@@ -2039,7 +2043,7 @@ async function testServerForm(form) {
   formMsg("testing…", false);
   try {
     const res = await api(id ? "/api/servers/" + encodeURIComponent(id) + "/test" : "/api/servers/test", { method: "POST", body });
-    formMsg(testResultText(res), !res.ok);
+    formMsg(testResultText(res), !res.ok && !res.provision_pending);
   } catch (err) { formMsg((err && err.message) || String(err), true); }
 }
 
@@ -2048,7 +2052,7 @@ async function testServerRow(id) {
   if (slot) { slot.className = "srv-status"; slot.textContent = "testing…"; }
   try {
     const res = await api("/api/servers/" + encodeURIComponent(id) + "/test", { method: "POST", body: {} });
-    if (slot) { slot.className = "srv-status " + (res.ok ? "ok" : "err"); slot.textContent = testResultText(res); }
+    if (slot) { slot.className = "srv-status " + (res.provision_pending ? "pending" : (res.ok ? "ok" : "err")); slot.textContent = testResultText(res); }
   } catch (err) { if (slot) { slot.className = "srv-status err"; slot.textContent = "✗ " + ((err && err.message) || err); } }
 }
 

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -1170,6 +1170,7 @@ button { font-family: inherit; }
 .srv-status { font-family: var(--f-mono); font-size: 11px; }
 .srv-status.ok { color: var(--insert); }
 .srv-status.err { color: var(--delete); }
+.srv-status.pending { color: var(--ink-2); }
 .chip.chip-mon {
   color: var(--orange-2); border-color: var(--ochre); background: var(--ochre-bg);
 }

--- a/internal/console/console_integration_test.go
+++ b/internal/console/console_integration_test.go
@@ -411,6 +411,36 @@ func TestIntegrationRegistryServerNeverMigrated(t *testing.T) {
 	}
 }
 
+// TestIntegrationProbeProvisionPending: a monitored source whose per-source
+// index DB does not exist yet probes as ProvisionPending (reachable server,
+// pre-Start state) rather than a hard failure — but only when monitored=true.
+// An unmonitored entry pointing at a missing DB is a genuine error.
+func TestIntegrationProbeProvisionPending(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	// A reachable server, but a database name that does not exist.
+	missingDSN := testutil.DefaultDSN + "/bintrail_idx_doesnotexist00"
+	req := httptest.NewRequest("POST", "http://127.0.0.1:8090/api/servers/x/test", strings.NewReader(""))
+
+	pending := probeServer(req, missingDSN, true)
+	if !pending.ProvisionPending {
+		t.Errorf("monitored probe of a missing index DB: ProvisionPending=false, want true (resp=%+v)", pending)
+	}
+	if pending.OK {
+		t.Errorf("a not-yet-provisioned index is not OK: %+v", pending)
+	}
+	if !strings.Contains(pending.Error, "not provisioned yet") {
+		t.Errorf("pending error must be actionable, got %q", pending.Error)
+	}
+
+	hard := probeServer(req, missingDSN, false)
+	if hard.ProvisionPending {
+		t.Errorf("unmonitored probe must NOT be ProvisionPending: %+v", hard)
+	}
+	if hard.OK || hard.Error == "" {
+		t.Errorf("unmonitored probe of a missing DB must be a hard error: %+v", hard)
+	}
+}
+
 // TestIntegrationEvictOnDSNEdit: editing an entry's DSN closes the cached
 // connection; a baseline-only edit keeps it open.
 func TestIntegrationEvictOnDSNEdit(t *testing.T) {

--- a/internal/console/servers_api.go
+++ b/internal/console/servers_api.go
@@ -121,6 +121,11 @@ type testResponse struct {
 	// command-line DSN), so a stale index must be migrated by a writer command
 	// (index/stream/agent) before this console can query it.
 	SchemaCurrent *bool `json:"schema_current,omitempty"`
+	// ProvisionPending: the probe target is a monitored source whose per-source
+	// index database does not exist yet (MySQL 1049) — it is CREATEd inside
+	// Start, so this is the normal pre-Start state, not a connection failure.
+	// The frontend renders it neutrally (a hint, not a red error).
+	ProvisionPending bool `json:"provision_pending,omitempty"`
 }
 
 // handleServersList serves GET /api/servers.
@@ -444,6 +449,10 @@ func (s *Server) handleMonitorStatus(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleServersTest(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	stored := ""
+	// monitored: the entry is a source dbtrail provisions an index for. Its
+	// per-source index DB only exists after a successful Start, so an
+	// Unknown-database probe error is "not started yet", not "unreachable".
+	monitored := false
 	if id != "" && id != bootServerID {
 		e, ok := s.cm.reg.Get(id)
 		if !ok {
@@ -451,6 +460,7 @@ func (s *Server) handleServersTest(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		stored = e.DSN
+		monitored = e.SourceDSN != ""
 	}
 	if id == bootServerID {
 		_, stored = s.cm.bootInfo()
@@ -476,11 +486,21 @@ func (s *Server) handleServersTest(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusBadRequest, "nothing to test: no stored DSN and no candidate supplied")
 		return
 	}
-	writeJSON(w, http.StatusOK, probeServer(r, dsn))
+	writeJSON(w, http.StatusOK, probeServer(r, dsn, monitored))
 }
 
-// probeServer runs the write-free reachability probe against one DSN.
-func probeServer(r *http.Request, dsn string) testResponse {
+// isUnknownDatabase reports whether err is MySQL 1049 (ER_BAD_DB_ERROR) —
+// the server is reachable but the named database does not exist.
+func isUnknownDatabase(err error) bool {
+	var me *mysql.MySQLError
+	return errors.As(err, &me) && me.Number == 1049
+}
+
+// probeServer runs the write-free reachability probe against one DSN. When
+// monitored is true, an Unknown-database error means the per-source index has
+// not been provisioned yet (Start creates it) rather than an unreachable
+// server, so it is reported as a pending state instead of a hard failure.
+func probeServer(r *http.Request, dsn string, monitored bool) testResponse {
 	short, dbName, err := shortTimeoutDSN(dsn)
 	if err != nil {
 		return testResponse{Error: scrubDSNError(err, dsn)}
@@ -489,6 +509,13 @@ func probeServer(r *http.Request, dsn string) testResponse {
 	db, err := config.Connect(short)
 	latency := time.Since(start).Milliseconds()
 	if err != nil {
+		if monitored && isUnknownDatabase(err) {
+			return testResponse{
+				ProvisionPending: true,
+				Error:            fmt.Sprintf("index database %q not provisioned yet — click Start to create it and begin streaming", dbName),
+				LatencyMS:        latency,
+			}
+		}
 		return testResponse{Error: scrubDSNError(err, dsn), LatencyMS: latency}
 	}
 	defer db.Close()

--- a/internal/console/servers_api_test.go
+++ b/internal/console/servers_api_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -28,6 +29,34 @@ func newRegistryServer(t *testing.T) *Server {
 	}
 	return srv
 }
+
+// TestIsUnknownDatabase: the probe distinguishes "server reachable but the
+// named DB doesn't exist" (MySQL 1049) from any other failure, through wraps —
+// this is what reclassifies a monitored source's pre-Start probe as pending
+// rather than a hard connection error.
+func TestIsUnknownDatabase(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"direct 1049", &mysql.MySQLError{Number: 1049, Message: "Unknown database 'x'"}, true},
+		{"wrapped 1049", errors.New("failed to ping MySQL: "), false}, // placeholder, replaced below
+		{"other mysql error", &mysql.MySQLError{Number: 1045, Message: "Access denied"}, false},
+		{"plain error", errors.New("dial tcp: connection refused"), false},
+		{"nil", nil, false},
+	}
+	// The wrapped case mirrors config.Connect's fmt.Errorf("...: %w", err).
+	cases[1].err = errwrap(&mysql.MySQLError{Number: 1049, Message: "Unknown database 'bintrail_idx_x'"})
+	cases[1].want = true
+	for _, tc := range cases {
+		if got := isUnknownDatabase(tc.err); got != tc.want {
+			t.Errorf("%s: isUnknownDatabase = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func errwrap(err error) error { return fmt.Errorf("failed to ping MySQL: %w", err) }
 
 func doServersReq(t *testing.T, srv *Server, method, path, body string) (*httptest.ResponseRecorder, []byte) {
 	t.Helper()


### PR DESCRIPTION
## The bug

A monitored source's **per-source index database** (`bintrail_idx_<id>`) is only `CREATE`d inside monitor **Start** (`monitorSupervisor.Start` → `EnsureDatabase` → `CreateIndexTables`). Before Start — a freshly-added source, or one whose preflight failed (e.g. source unreachable) — that database doesn't exist. The **Test** button pings the entry's DSN, which *is* that not-yet-created index DB, so it surfaced a raw, alarming error:

> ✗ failed to ping MySQL: Error 1049 (42000): Unknown database 'bintrail_idx_56bac20a98a7da3f'

read as a connection failure when the real state is just *"not started yet."* (Reported from the UI: a stopped `wordpress` source whose Test showed exactly this.)

## The fix

The probe now distinguishes MySQL **1049** (`ER_BAD_DB_ERROR`) for a **monitored** entry (`SourceDSN` set) and returns a neutral, actionable result instead of a hard failure:

> ○ index database "bintrail_idx_…" not provisioned yet — click Start to create it and begin streaming

- `servers_api.go`: `isUnknownDatabase(err)` (`errors.As` on `*mysql.MySQLError` #1049, through `config.Connect`'s `%w` wrap); `probeServer` takes a `monitored` flag; new `testResponse.provision_pending`. An **unmonitored** entry pointing at a missing DB stays a hard error — the reclassification is gated on `SourceDSN`, so a genuinely wrong index DSN is never masked.
- `app.js` / `style.css`: `provision_pending` renders neutrally (`○` + gray `.srv-status.pending`), never the red `✗`. Both the row Test and the form Test-connection paths updated.

## Tests

- `TestIsUnknownDatabase` (unit) — direct/wrapped 1049 → true; other code, plain error, nil → false.
- `TestIntegrationProbeProvisionPending` — monitored probe of a missing index DB → `provision_pending`; unmonitored → hard error.

## Verification

Headless Chrome (playwright-core, `channel:'chrome'`): seeded a stopped monitored source whose index DB is absent (reproducing the report), clicked **Test** — the status slot renders the neutral pending hint with `.srv-status.pending` styling (gray, `○`), **not** a red error. API confirms `{"provision_pending":true, ...}`.

> Note: not a fix for *why* a source won't start (that's the doctor preflight — e.g. source unreachable / missing `REPLICATION` grant). This only stops **Test** from mislabeling the normal pre-Start state as a connection failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)