### PR TITLE
fix(console): kill the silent failure on monitor-start preflight

### DIFF
--- a/cmd/bintrail-console/monitor.go
+++ b/cmd/bintrail-console/monitor.go
@@ -240,6 +240,12 @@ func (m *monitorSupervisor) Doctor(ctx context.Context, e console.ServerEntry) (
 			Detail:      config.ScrubDSNText(c.Detail, e.SourceDSN, e.DSN),
 			Remediation: c.Remediation,
 		}
+		// Per-check trace so `--log-level debug` shows the full preflight from
+		// the host, not just the pass/fail tally returned to the browser.
+		slog.Debug("monitor: preflight check",
+			"server", e.Name, "id", e.ID,
+			"check", out.Checks[i].Name, "status", out.Checks[i].Status,
+			"detail", out.Checks[i].Detail)
 	}
 
 	// Replica/duplicate detection against the other monitored entries —

--- a/internal/console/servers_api.go
+++ b/internal/console/servers_api.go
@@ -373,12 +373,22 @@ func (s *Server) handleMonitorStart(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// A monitor start is an operator action whose outcome must be visible from
+	// the host (docker logs), not only in the browser that fired it — a
+	// preflight failure that travels solely over HTTP is a silent failure.
+	slog.Info("monitor: start requested", "server", e.Name, "id", e.ID)
+
 	report, err := s.monitorCtrl.Doctor(r.Context(), e)
 	if err != nil {
+		slog.Error("monitor: preflight could not run", "server", e.Name, "id", e.ID, "error", err.Error())
 		writeJSONError(w, http.StatusInternalServerError, "doctor: "+err.Error())
 		return
 	}
 	if report.Failed > 0 {
+		slog.Warn("monitor: preflight failed — not starting",
+			"server", e.Name, "id", e.ID,
+			"failed", report.Failed, "passed", report.Passed,
+			"failures", failedCheckSummary(report))
 		writeJSON(w, http.StatusOK, monitorStartResponse{
 			Doctor:  report,
 			Started: false,
@@ -390,20 +400,46 @@ func (s *Server) handleMonitorStart(w http.ResponseWriter, r *http.Request) {
 	// Doctor green → record intent first (the supervisor reconciles desired
 	// state at boot, so a crash right after this line still resumes), then
 	// launch.
+	slog.Info("monitor: preflight passed, starting stream", "server", e.Name, "id", e.ID)
 	e.MonitorDesired = true
 	if err := s.cm.reg.Update(e); err != nil {
 		writeJSONError(w, registryErrStatus(err), err.Error())
 		return
 	}
 	if err := s.monitorCtrl.Start(r.Context(), e); err != nil {
+		slog.Error("monitor: start failed after green preflight", "server", e.Name, "id", e.ID, "error", err.Error())
 		writeJSONError(w, http.StatusInternalServerError, "start monitoring: "+err.Error())
 		return
 	}
+	slog.Info("monitor: stream started", "server", e.Name, "id", e.ID)
 	writeJSON(w, http.StatusOK, monitorStartResponse{
 		Doctor:  report,
 		Started: true,
 		Monitor: s.monitorCtrl.Status(e.ID),
 	})
+}
+
+// failedCheckSummary joins a report's failed checks into one log-friendly
+// line ("Source MySQL connection: dial tcp …; Replication grants: …"). The
+// details are already DSN-scrubbed by the supervisor's Doctor, so this is safe
+// to log — it carries the host:port and error the operator needs without the
+// credentials.
+func failedCheckSummary(report *DoctorReport) string {
+	var b strings.Builder
+	for _, c := range report.Checks {
+		if c.Status != "fail" {
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteString("; ")
+		}
+		b.WriteString(c.Name)
+		if c.Detail != "" {
+			b.WriteString(": ")
+			b.WriteString(c.Detail)
+		}
+	}
+	return b.String()
 }
 
 // handleMonitorStop serves POST /api/servers/{id}/monitor/stop.

--- a/internal/console/servers_api_test.go
+++ b/internal/console/servers_api_test.go
@@ -1,10 +1,12 @@
 package console
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -698,6 +700,54 @@ func TestMonitorStartDoctorFailure(t *testing.T) {
 	}
 	if e, _ := srv.cm.reg.Get(created.ID); e.MonitorDesired {
 		t.Error("a failed doctor must not record monitoring intent")
+	}
+}
+
+// TestFailedCheckSummary: the log line joins only the failed checks, with
+// their (already-scrubbed) details, skipping passes.
+func TestFailedCheckSummary(t *testing.T) {
+	r := &DoctorReport{Checks: []DoctorCheck{
+		{Name: "Source MySQL connection", Status: "pass", Detail: "MySQL 8.4"},
+		{Name: "binlog_row_image", Status: "fail", Detail: "is MINIMAL, need FULL"},
+		{Name: "Replication grants", Status: "fail", Detail: ""},
+	}}
+	got := failedCheckSummary(r)
+	want := "binlog_row_image: is MINIMAL, need FULL; Replication grants"
+	if got != want {
+		t.Errorf("failedCheckSummary = %q, want %q", got, want)
+	}
+}
+
+// TestMonitorStartLogsPreflightFailure locks in the silent-failure fix: a
+// preflight failure must be visible from the host (docker logs), not only in
+// the browser that fired the request. Without the slog.Warn, an operator
+// running --log-level debug sees NOTHING when Start fails.
+func TestMonitorStartLogsPreflightFailure(t *testing.T) {
+	var buf bytes.Buffer
+	old := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer slog.SetDefault(old)
+
+	srv, ctrl := newSupervisorServer(t)
+	ctrl.report = &DoctorReport{
+		Failed: 1,
+		Checks: []DoctorCheck{{Name: "Source MySQL connection", Status: "fail",
+			Detail: "failed to ping MySQL: dial tcp 172.18.0.1:3306: connect: connection refused", Remediation: "x"}},
+	}
+	_, body := doServersReq(t, srv, "POST", "/api/servers",
+		`{"name":"wp","source_host":"db","source_user":"repl"}`)
+	var created serverDTO
+	if err := json.Unmarshal(body, &created); err != nil {
+		t.Fatal(err)
+	}
+	doServersReq(t, srv, "POST", "/api/servers/"+created.ID+"/monitor/start", "")
+
+	out := buf.String()
+	if !strings.Contains(out, "preflight failed") {
+		t.Errorf("a preflight failure must be logged (silent-failure fix); log was:\n%s", out)
+	}
+	if !strings.Contains(out, "172.18.0.1:3306") {
+		t.Errorf("the failure log must carry the actionable detail; log was:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
## The complaint (valid)

A user adding a source from the console clicked **Start**, got a generic `connection refused` card, and — critically — **`docker logs` had nothing**, even though the daemon runs `--log-level debug`. A monitored source that silently refuses to start, with no host-side trail to correlate the UI error, is a silent failure. (Diagnosing it required `tcpdump` + `nsenter` on the box — exactly the archaeology that logging exists to prevent.)

Root cause: `handleMonitorStart` ran the doctor preflight and, on failure, returned the report **only over HTTP to the browser**. The whole start path had zero `slog` calls — only the *success* and *crash-loop* paths logged.

## The fix

`handleMonitorStart` now logs the operator action and its outcome:
- `INFO  monitor: start requested`
- `WARN  monitor: preflight failed — not starting` with `failed`/`passed` counts and a `failedCheckSummary()` one-liner carrying each failed check's detail — e.g. `failures="Source MySQL connection: dial tcp 172.18.0.1:3306: connect: connection refused"`
- `INFO  preflight passed, starting stream` / `stream started`
- `ERROR` when the doctor can't run, or a start fails after a green preflight

The supervisor's `Doctor()` also emits a per-check `slog.Debug`, so `--log-level debug` shows the full preflight (every check + status) from the host, not just the tally.

Details are already DSN-scrubbed by `monitorSupervisor.Doctor` (`config.ScrubDSNText`), so logging them keeps the actionable `host:port` and error **without leaking credentials**.

## Tests

- `TestFailedCheckSummary` — joins only failed checks with their details, skips passes.
- `TestMonitorStartLogsPreflightFailure` — captures `slog`, asserts the failure line **and** the actionable detail (`172.18.0.1:3306`) are logged. Without the fix this test fails (empty log).

Example, now visible in `docker logs`:
```
WARN monitor: preflight failed — not starting server=wp id=… failed=1 passed=0 \
  failures="Source MySQL connection: failed to ping MySQL: dial tcp 172.18.0.1:3306: connect: connection refused"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)