### PR TITLE
fix(console): four monitor/index UX bugs that made the UI look broken

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,3 +93,59 @@ jobs:
       # the sole writer during its run.
       - name: Integration tests (-tags=integration)
         run: go test -tags=integration -race -p 1 -count=1 ./...
+
+  console-e2e:
+    # Headless-Chrome regression guard for the console SPA: go test never
+    # renders assets/*, so CSS/DOM/presentation bugs (invisible buttons, a
+    # form that auto-expands, a raw error wall, the control plane vanishing on
+    # a broken server selection) are invisible to the Go suite. Each scenario
+    # pins a bug that shipped in 0.13.3.
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      # Same manually-named container as the integration job (8.4 = the bundled
+      # index engine, caching_sha2_password default).
+      - name: Start MySQL (bintrail-test-mysql, 8.4)
+        run: |
+          docker run -d --name bintrail-test-mysql \
+            -e MYSQL_ROOT_PASSWORD=testroot \
+            -p 13306:3306 \
+            mysql:8.4 \
+            --binlog-format=ROW --binlog-row-image=FULL --log-bin=binlog --server-id=1
+          for i in $(seq 1 60); do
+            if docker exec bintrail-test-mysql mysqladmin ping -u root -ptestroot --silent 2>/dev/null; then
+              echo "MySQL is ready."; exit 0
+            fi
+            sleep 2
+          done
+          echo "MySQL did not become ready in time" >&2
+          docker logs bintrail-test-mysql >&2 || true
+          exit 1
+
+      - name: Install playwright chromium (+ system deps)
+        run: |
+          npm --prefix test/console-e2e install --no-audit --no-fund
+          npx --prefix test/console-e2e playwright install --with-deps chromium
+
+      # PW_CHANNEL unset → use the chromium installed above (not system Chrome).
+      - name: Console E2E (headless Chrome)
+        run: make console-e2e
+
+      - name: Upload failure screenshot
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: console-e2e-failure
+          path: |
+            ${{ runner.temp }}/console-e2e-failure.png
+            ${{ runner.temp }}/console-e2e-daemon.log
+          if-no-files-found: ignore

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ GATEWAY_LDFLAGS=-ldflags "-X main.gatewayVersion=$(VERSION)"
 # bintrail-console reuses BINTRAIL_LDFLAGS: it injects the same
 # main.Version/CommitSHA/BuildDate vars as the core binary.
 
-.PHONY: all build build-mcp build-gateway build-console clean test lint install build-all tidy deps
+.PHONY: all build build-mcp build-gateway build-console clean test console-e2e lint install build-all tidy deps
 
 all: build build-mcp build-gateway build-console
 
@@ -42,6 +42,12 @@ clean:
 
 test:
 	go test ./... -count=1
+
+# Headless-Chrome regression guard for the console SPA (assets the Go suite
+# never renders). Needs Docker (bintrail-test-mysql) + Node. PW_CHANNEL=chrome
+# uses system Chrome instead of the playwright-managed chromium.
+console-e2e:
+	bash test/console-e2e/run.sh
 
 lint:
 	golangci-lint run ./...

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -499,7 +499,26 @@ function toast(msg) {
 function renderError(container, err) {
   if (!container) return;
   clear(container);
-  container.append(el("div", { class: "error-box", text: String((err && err.message) || err) }));
+  const msg = String((err && err.message) || err);
+  // A server whose index database doesn't exist yet (MySQL 1049) is the normal
+  // pre-monitoring state, not a fault — and the #1 source of confusion: the
+  // index DB lives on the INDEX server and is created when monitoring starts;
+  // it is NEVER expected on the source. Render an actionable empty state, not
+  // a raw red error wall.
+  const m = msg.match(/Unknown database '([^']+)'/);
+  if (m) {
+    const box = el("div", { class: "empty" });
+    box.append(el("h3", { text: "This server isn't indexing yet" }));
+    box.append(el("p", { text:
+      "Its index database \"" + m[1] + "\" doesn't exist on the index server yet. " +
+      "It's created automatically when monitoring starts for this source — it never lives on the source MySQL itself. " +
+      "Start monitoring from Manage servers, or switch to a server that's already indexing." }));
+    box.append(el("button", { class: "btn btn-sm", type: "button", text: "Manage servers",
+      onclick: () => openServersModal() }));
+    container.append(box);
+    return;
+  }
+  container.append(el("div", { class: "error-box", text: msg }));
 }
 
 function renderWarnings(node, warnings) {
@@ -1931,7 +1950,14 @@ function showServerForm(prefill) {
   // means a fresh add; editing any saved entry shows its index.
   const adv = $("#server-advanced", form);
   const hasIndexFields = !!(prefill && (prefill.host || prefill.dbname || prefill.baseline_dir || prefill.baseline_s3 || prefill.no_archive));
-  adv.open = !capsCache.monitor || hasIndexFields;
+  // Keep "bring your own index (optional)" COLLAPSED for a monitored source:
+  // its index DSN is auto-derived and round-trips as host/dbname, so expanding
+  // it — e.g. when a failed-preflight error card opens the form — would show
+  // the operator a per-source index they never typed. Open it only for a pure
+  // BYO-index entry (no source) or a serve-only process where the index is the
+  // whole form.
+  const byoIndex = hasIndexFields && !(prefill && prefill.has_source);
+  adv.open = !capsCache.monitor || byoIndex;
   $(".form-adv-summary", adv).hidden = !capsCache.monitor;
 
   if (prefill) {

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -470,7 +470,11 @@ button { font-family: inherit; }
   color: #fff; background: linear-gradient(135deg, var(--accent-a), var(--accent-b)); border-color: transparent;
   box-shadow: 0 1px 2px oklch(0.4 0.04 60 / 0.22), 0 1px 0 oklch(1 0 0 / 0.2) inset;
 }
+/* Re-assert the gradient: .btn:hover (same specificity, earlier in source)
+   sets background:var(--surface-2), which would otherwise win and leave the
+   primary button's white text on a light-gray fill — invisible on hover. */
 .btn-primary:hover { filter: brightness(1.05) saturate(1.04); border-color: transparent;
+  background: linear-gradient(135deg, var(--accent-a), var(--accent-b));
   box-shadow: 0 5px 16px -5px oklch(0.5 0.08 60 / 0.45), 0 1px 0 oklch(1 0 0 / 0.2) inset; }
 
 .btn-accent { color: #fff; background: var(--orange-2); border-color: transparent; }

--- a/internal/console/reconstruct.go
+++ b/internal/console/reconstruct.go
@@ -40,25 +40,29 @@ type authCapsInfo struct {
 	AuthKind    string `json:"auth_kind"` // "token" | "session"
 }
 
-// handleCapabilities reports which optional console surfaces are enabled for
-// the SELECTED server, so the frontend can show/hide them per server. Today
-// that is just reconstruct (baseline-gated). Resolving the bundle here is
-// deliberate: it lazily opens the connection on switch, so a dead entry fails
-// the moment the operator selects it, not on their first query.
+// handleCapabilities reports which optional console surfaces are enabled.
+// Monitor and Auth are PROCESS-level and must always be reported, even when
+// the selected server's index is unreachable — otherwise a broken selection
+// (e.g. a monitored source whose per-source index isn't provisioned yet)
+// would 502 here and make the frontend's gateCapabilities degrade to {},
+// hiding the entire control plane (the Start button, the "+ Add server"
+// monitor copy). Reconstruct is per-server (baseline-gated) so it needs the
+// bundle; a failed resolve just leaves it false rather than failing the whole
+// response. The dead-entry-fails-on-select feedback still comes from the data
+// queries (events/status), which resolveOr properly.
 func (s *Server) handleCapabilities(w http.ResponseWriter, r *http.Request) {
-	b := s.resolveOr(w, r)
-	if b == nil {
-		return
-	}
 	kind := "token"
 	if authKindFrom(r.Context()) == authKindSession {
 		kind = "session"
 	}
-	writeJSON(w, http.StatusOK, capabilitiesResponse{
-		Reconstruct: b.baselineConfigured,
-		Monitor:     s.monitorCtrl != nil,
-		Auth:        authCapsInfo{PasswordSet: s.passwordLoginEnabled(), AuthKind: kind},
-	})
+	resp := capabilitiesResponse{
+		Monitor: s.monitorCtrl != nil,
+		Auth:    authCapsInfo{PasswordSet: s.passwordLoginEnabled(), AuthKind: kind},
+	}
+	if b, err := s.resolve(r); err == nil {
+		resp.Reconstruct = b.baselineConfigured
+	}
+	writeJSON(w, http.StatusOK, resp)
 }
 
 // stateEntryDTO is the wire view of a reconstruct.StateEntry (that struct has no

--- a/internal/console/reconstruct.go
+++ b/internal/console/reconstruct.go
@@ -3,6 +3,7 @@ package console
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -49,7 +50,7 @@ type authCapsInfo struct {
 // monitor copy). Reconstruct is per-server (baseline-gated) so it needs the
 // bundle; a failed resolve just leaves it false rather than failing the whole
 // response. The dead-entry-fails-on-select feedback still comes from the data
-// queries (events/status), which resolveOr properly.
+// queries (events/status), which resolveOr 502s properly.
 func (s *Server) handleCapabilities(w http.ResponseWriter, r *http.Request) {
 	kind := "token"
 	if authKindFrom(r.Context()) == authKindSession {
@@ -61,6 +62,12 @@ func (s *Server) handleCapabilities(w http.ResponseWriter, r *http.Request) {
 	}
 	if b, err := s.resolve(r); err == nil {
 		resp.Reconstruct = b.baselineConfigured
+	} else if !errors.Is(err, ErrUnknownServer) && !errors.Is(err, errNoServers) {
+		// Expected for a bad X-Bintrail-Server header or a fresh install;
+		// anything else (e.g. a genuine connection failure) would silently
+		// strip Time-travel from the UI, so leave an operator trace. Mirrors
+		// the Debug/Warn split in connManager.Resolve.
+		slog.Warn("console: capabilities resolve failed; reporting reconstruct=false", "error", err)
 	}
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/internal/console/reconstruct_test.go
+++ b/internal/console/reconstruct_test.go
@@ -76,6 +76,32 @@ func TestHandleCapabilities(t *testing.T) {
 	}
 }
 
+// TestHandleCapabilitiesMonitorSurvivesUnresolvableServer: Monitor/Auth are
+// process-level and must be reported even when the SELECTED server can't be
+// resolved (e.g. a monitored source whose per-source index isn't provisioned
+// yet). A 502 here would make the frontend's gateCapabilities degrade to {},
+// hiding the whole control plane (Start button, "+ Add server" monitor copy).
+func TestHandleCapabilitiesMonitorSurvivesUnresolvableServer(t *testing.T) {
+	srv, _ := newSupervisorServer(t) // MonitorCtrl set, empty registry
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/capabilities", nil)
+	req.Header.Set(serverHeader, "ffffffffffffffff") // no such server → resolve fails
+	srv.handleCapabilities(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("capabilities must still 200 for an unresolvable selection, got %d (body=%s)", rec.Code, rec.Body)
+	}
+	var resp capabilitiesResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if !resp.Monitor {
+		t.Error("Monitor is process-level — must survive a broken server selection")
+	}
+	if resp.Reconstruct {
+		t.Error("Reconstruct needs a resolvable bundle — must be false here")
+	}
+}
+
 // TestHandleReconstructGatedOff: the endpoint is the boundary, not just the UI —
 // it must refuse when reconstruct is not configured.
 func TestHandleReconstructGatedOff(t *testing.T) {

--- a/internal/console/servers_api_test.go
+++ b/internal/console/servers_api_test.go
@@ -246,12 +246,16 @@ func TestResolveHeader(t *testing.T) {
 		t.Fatalf("unknown id: err=%v, want ErrUnknownServer", err)
 	}
 	// A registry entry pointing at a dead host fails on SELECTION with 502 and
-	// a scrubbed error.
+	// a scrubbed error — on the DATA endpoints (status/events/recover). NOTE:
+	// /api/capabilities deliberately does NOT 502 here; Monitor/Auth are
+	// process-level and must survive a broken selection (see
+	// TestHandleCapabilitiesMonitorSurvivesUnresolvableServer), so the
+	// dead-server feedback comes from the data queries, exercised below.
 	added, err := srv.cm.reg.Add(ServerEntry{Name: "dead", DSN: "u:" + secretPW + "@tcp(127.0.0.1:1)/db?timeout=200ms"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	req2 := httptest.NewRequest("GET", "http://127.0.0.1:8090/api/capabilities", nil)
+	req2 := httptest.NewRequest("GET", "http://127.0.0.1:8090/api/status", nil)
 	req2.Host = "127.0.0.1:8090"
 	req2.Header.Set("Authorization", "Bearer t")
 	req2.Header.Set(serverHeader, added.ID)

--- a/test/console-e2e/.gitignore
+++ b/test/console-e2e/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/test/console-e2e/README.md
+++ b/test/console-e2e/README.md
@@ -1,0 +1,44 @@
+# console-e2e — headless-Chrome regression guard
+
+`go test` never renders the embedded console SPA (`internal/console/assets/*`),
+so a whole class of bugs is invisible to it: CSS cascade (an invisible button),
+frontend DOM/state logic (a form that auto-expands), and how the UI *presents*
+a backend state (a raw `Unknown database` error wall; the control plane
+vanishing when the selected server's index is missing). Every scenario in
+`console_e2e.mjs` pins a bug that shipped in 0.13.3 and reached a user.
+
+## Run it
+
+Requires Docker (the shared `bintrail-test-mysql` container, same as the Go
+integration suite) and Node.
+
+```sh
+# start the test MySQL if it isn't already (see CONTRIBUTING.md)
+docker run -d --name bintrail-test-mysql -e MYSQL_ROOT_PASSWORD=testroot \
+  -p 13306:3306 mysql:8.4 --binlog-format=ROW --binlog-row-image=FULL \
+  --log-bin=binlog --server-id=1
+
+make console-e2e
+# or, to use your system Chrome instead of the playwright-managed chromium:
+PW_CHANNEL=chrome make console-e2e
+```
+
+`run.sh` builds `bintrail-console`, creates a throwaway index database, launches
+a source-less `watch` daemon, seeds a monitored source whose per-source index
+is intentionally **not** provisioned (the lifecycle state that exercises the
+guards), drives the scenarios, and tears everything down.
+
+## What each scenario guards
+
+| Scenario | Bug it pins |
+|---|---|
+| boot: monitor capability reported | caps fetch for a broken/unprovisioned selected server must not degrade to `{}` |
+| control plane: Start button / monitor copy | `/api/capabilities` 502 cascade hiding the whole control plane |
+| button: primary keeps gradient on hover | `.btn:hover` background winning → white text on light gray |
+| form: advanced section collapsed | the optional "BYO index" section auto-expanding for a source entry |
+| form: source fields visible | the monitor form rendering for a source entry |
+| error: 1049 empty state (×3) | a missing-index error rendering as a raw wall instead of an actionable empty state |
+| no uncaught JS errors | any thrown error over the whole drive |
+
+Adding a scenario: append an `ok(...)`/`bad(...)` block in `console_e2e.mjs`.
+A non-zero exit fails CI and writes `console-e2e-failure.png` to the artifact dir.

--- a/test/console-e2e/README.md
+++ b/test/console-e2e/README.md
@@ -34,10 +34,11 @@ guards), drives the scenarios, and tears everything down.
 |---|---|
 | boot: monitor capability reported | caps fetch for a broken/unprovisioned selected server must not degrade to `{}` |
 | control plane: Start button / monitor copy | `/api/capabilities` 502 cascade hiding the whole control plane |
-| button: primary keeps gradient on hover | `.btn:hover` background winning → white text on light gray |
-| form: advanced section collapsed | the optional "BYO index" section auto-expanding for a source entry |
+| button: primary keeps gradient on hover + text stays white | `.btn:hover` background winning → white text on light gray |
+| form: advanced collapsed for a source entry | the optional "BYO index" section auto-expanding for a source entry |
+| form: advanced expanded for a BYO-index entry | the other `byoIndex` arm — a no-source entry must show its index fields |
 | form: source fields visible | the monitor form rendering for a source entry |
-| error: 1049 empty state (×3) | a missing-index error rendering as a raw wall instead of an actionable empty state |
+| error: real 1049 reaches the frontend + empty state (×4) | the actual backend 1049 (from the unprovisioned default server) must surface as an actionable empty state, not a raw wall — and `scrubDSNError` must preserve the index db name |
 | no uncaught JS errors | any thrown error over the whole drive |
 
 Adding a scenario: append an `ok(...)`/`bad(...)` block in `console_e2e.mjs`.

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -1,0 +1,131 @@
+// Headless-Chrome E2E regression guard for the bintrail-console frontend.
+//
+// Why this exists: `go test` never renders the embedded SPA (assets/*.js,
+// *.css), so a whole class of bugs is invisible to the Go suite — CSS cascade
+// (an invisible button), DOM/state logic (a form that auto-expands), and the
+// way the UI presents a backend state (a raw 1049 error wall, the control
+// plane vanishing when the selected server's index is missing). Each scenario
+// below pins a bug that shipped in 0.13.3 and reached a user.
+//
+// It drives an ALREADY-RUNNING console (run.sh starts the daemon + seeds a
+// monitored source whose per-source index is NOT provisioned — the exact
+// lifecycle state that broke everything). Env: CONSOLE_URL, CONSOLE_TOKEN,
+// optional PW_CHANNEL (e.g. "chrome" to use system Chrome instead of the
+// playwright-managed chromium).
+import { chromium } from "playwright";
+
+const URL = process.env.CONSOLE_URL || "http://127.0.0.1:8090";
+const TOKEN = process.env.CONSOLE_TOKEN || "";
+const CHANNEL = process.env.PW_CHANNEL || undefined; // undefined → bundled chromium
+const ART = process.env.E2E_ARTIFACT_DIR || "/tmp";
+
+const results = [];
+const ok = (name) => results.push({ name, pass: true });
+const bad = (name, detail) => results.push({ name, pass: false, detail });
+
+const browser = await chromium.launch({ headless: true, channel: CHANNEL });
+const page = await browser.newPage({ viewport: { width: 1300, height: 1000 } });
+const jsErrors = [];
+page.on("pageerror", (e) => jsErrors.push(String(e)));
+
+try {
+  await page.goto(`${URL}/?token=${encodeURIComponent(TOKEN)}`, { waitUntil: "networkidle" });
+  await page.waitForFunction(
+    () => typeof openServersModal === "function" && typeof renderError === "function",
+    { timeout: 10000 },
+  );
+
+  // Scenario 0 — the page loads and the monitor capability is reported. A
+  // regression here (caps fetch failing for the default server — even a
+  // broken, unprovisioned one — and degrading to {}) would itself hide the
+  // control plane. The fetch is async, so wait for it rather than racing it.
+  // capsCache is a module-scoped `let` (not window.capsCache): reachable by
+  // bare name in evaluate's global scope, never as a window property.
+  let monitor = false;
+  try {
+    await page.waitForFunction(() => typeof capsCache !== "undefined" && capsCache.monitor === true, { timeout: 8000 });
+    monitor = true;
+  } catch (_) {
+    monitor = await page.evaluate(() => typeof capsCache !== "undefined" && !!capsCache.monitor);
+  }
+  monitor ? ok("boot: monitor capability reported") : bad("boot: monitor capability reported", "capsCache.monitor !== true after caps load");
+
+  await page.evaluate(() => openServersModal());
+  await page.waitForSelector("#servers-list", { timeout: 5000 });
+  await page.waitForTimeout(400);
+
+  // Scenario 1 — control plane survives a broken (unprovisioned) selected
+  // server: Start button + the "monitor" copy must render. Guards the
+  // /api/capabilities 502 cascade (a per-source index that doesn't exist must
+  // not zero out the process-level Monitor capability).
+  const cp = await page.evaluate(() => {
+    const btns = Array.from(document.querySelectorAll("#servers-list button"));
+    const start = btns.find((b) => b.textContent.trim() === "Start");
+    const copy = document.querySelector('.modal-desc [data-capability="monitor"]');
+    return { start: !!start, copy: copy ? getComputedStyle(copy).display !== "none" : false };
+  });
+  cp.start ? ok("control plane: Start button present") : bad("control plane: Start button present", "missing — caps cascade?");
+  cp.copy ? ok("control plane: monitor copy visible") : bad("control plane: monitor copy visible", "hidden — caps cascade?");
+
+  // Scenario 2 — primary button stays visible on hover (gradient survives;
+  // .btn:hover must not win the background and leave white text on light gray).
+  await page.hover("#server-add");
+  await page.waitForTimeout(150);
+  const hov = await page.evaluate(() => {
+    const b = document.getElementById("server-add");
+    const cs = getComputedStyle(b);
+    return { bgImage: cs.backgroundImage, bgColor: cs.backgroundColor };
+  });
+  /gradient/.test(hov.bgImage)
+    ? ok("button: primary keeps gradient on hover")
+    : bad("button: primary keeps gradient on hover", `bgImage=${hov.bgImage} bgColor=${hov.bgColor}`);
+
+  // Scenario 3 — editing a monitored source keeps the optional "bring your own
+  // index" section COLLAPSED (its index DSN is auto-derived; expanding it shows
+  // a per-source index the operator never typed).
+  await page.evaluate(() => {
+    const edit = Array.from(document.querySelectorAll("#servers-list button")).find((b) => b.textContent.trim() === "Edit");
+    edit.click();
+  });
+  await page.waitForSelector("#server-advanced", { timeout: 5000 });
+  await page.waitForTimeout(200);
+  const form = await page.evaluate(() => {
+    const adv = document.getElementById("server-advanced");
+    const src = document.querySelector('input[name="source_user"]');
+    return { advOpen: adv.open, srcVisible: src ? src.offsetParent !== null : false };
+  });
+  !form.advOpen ? ok("form: advanced section collapsed for a source entry") : bad("form: advanced section collapsed for a source entry", "auto-expanded");
+  form.srcVisible ? ok("form: source fields visible") : bad("form: source fields visible", "hidden");
+
+  // Scenario 4 — a missing-index (MySQL 1049) view error renders an actionable
+  // empty state, not a raw red error wall, and clarifies the index is never on
+  // the source.
+  const es = await page.evaluate(() => {
+    const v = document.getElementById("view") || document.querySelector(".view") || document.body;
+    renderError(v, new Error("server \"wp\": failed to ping MySQL: Error 1049 (42000): Unknown database 'bintrail_idx_deadbeef'"));
+    const empty = document.querySelector(".empty");
+    return empty ? empty.textContent : null;
+  });
+  if (!es) bad("error: 1049 renders friendly empty state", "no .empty element produced");
+  else {
+    /indexing yet/.test(es) ? ok("error: 1049 empty state has friendly title") : bad("error: 1049 empty state has friendly title", es);
+    /never lives on the source/.test(es) ? ok("error: 1049 empty state clarifies source-vs-index") : bad("error: 1049 empty state clarifies source-vs-index", es);
+    /bintrail_idx_deadbeef/.test(es) ? ok("error: 1049 empty state names the index db") : bad("error: 1049 empty state names the index db", es);
+  }
+
+  // No uncaught JS errors over the whole run.
+  jsErrors.length === 0 ? ok("no uncaught JS errors") : bad("no uncaught JS errors", JSON.stringify(jsErrors));
+} catch (err) {
+  bad("driver", String((err && err.stack) || err));
+  try { await page.screenshot({ path: `${ART}/console-e2e-failure.png`, fullPage: true }); } catch (_) {}
+}
+
+const failed = results.filter((r) => !r.pass);
+for (const r of results) console.log(`${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.pass ? "" : "  — " + r.detail}`);
+console.log(`\n${results.length - failed.length}/${results.length} passed`);
+
+if (failed.length) {
+  try { await page.screenshot({ path: `${ART}/console-e2e-failure.png`, fullPage: true }); } catch (_) {}
+}
+await browser.close();
+process.exit(failed.length ? 1 : 0);

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -74,11 +74,16 @@ try {
   const hov = await page.evaluate(() => {
     const b = document.getElementById("server-add");
     const cs = getComputedStyle(b);
-    return { bgImage: cs.backgroundImage, bgColor: cs.backgroundColor };
+    return { bgImage: cs.backgroundImage, bgColor: cs.backgroundColor, color: cs.color };
   });
+  // Visibility is contrast: the gradient must survive AND the text must stay
+  // white. Checking only the background would miss a light-text regression.
   /gradient/.test(hov.bgImage)
     ? ok("button: primary keeps gradient on hover")
     : bad("button: primary keeps gradient on hover", `bgImage=${hov.bgImage} bgColor=${hov.bgColor}`);
+  hov.color === "rgb(255, 255, 255)"
+    ? ok("button: primary text stays white on hover")
+    : bad("button: primary text stays white on hover", `color=${hov.color}`);
 
   // Scenario 3 — editing a monitored source keeps the optional "bring your own
   // index" section COLLAPSED (its index DSN is auto-derived; expanding it shows
@@ -97,21 +102,54 @@ try {
   !form.advOpen ? ok("form: advanced section collapsed for a source entry") : bad("form: advanced section collapsed for a source entry", "auto-expanded");
   form.srcVisible ? ok("form: source fields visible") : bad("form: source fields visible", "hidden");
 
-  // Scenario 4 — a missing-index (MySQL 1049) view error renders an actionable
-  // empty state, not a raw red error wall, and clarifies the index is never on
-  // the source.
-  const es = await page.evaluate(() => {
+  // Scenario 4 — the REAL missing-index path (not a fabricated string): query
+  // a data endpoint against the default (unprovisioned wp) server, take the
+  // ACTUAL backend error, and feed it to renderError. This proves the backend
+  // 1049 reaches the frontend in the shape the empty-state needs — i.e. that
+  // scrubDSNError preserves the index db name and the 1049 text survives.
+  await page.evaluate(() => closeServersModal());
+  const es = await page.evaluate(async () => {
+    let errMsg = null;
+    try { await api("/api/status"); } catch (e) { errMsg = (e && e.message) || String(e); }
+    if (!errMsg) return { errMsg: null };
     const v = document.getElementById("view") || document.querySelector(".view") || document.body;
-    renderError(v, new Error("server \"wp\": failed to ping MySQL: Error 1049 (42000): Unknown database 'bintrail_idx_deadbeef'"));
+    renderError(v, new Error(errMsg));
     const empty = document.querySelector(".empty");
-    return empty ? empty.textContent : null;
+    return { errMsg, empty: empty ? empty.textContent : null };
   });
-  if (!es) bad("error: 1049 renders friendly empty state", "no .empty element produced");
-  else {
-    /indexing yet/.test(es) ? ok("error: 1049 empty state has friendly title") : bad("error: 1049 empty state has friendly title", es);
-    /never lives on the source/.test(es) ? ok("error: 1049 empty state clarifies source-vs-index") : bad("error: 1049 empty state clarifies source-vs-index", es);
-    /bintrail_idx_deadbeef/.test(es) ? ok("error: 1049 empty state names the index db") : bad("error: 1049 empty state names the index db", es);
+  if (!es.errMsg) {
+    bad("error: real 1049 reaches the frontend", "/api/status did not error for the unprovisioned default server");
+  } else if (!/Unknown database '(bintrail_idx_[^']+)'/.test(es.errMsg)) {
+    bad("error: real 1049 reaches the frontend", `backend error not the expected 1049 shape: ${es.errMsg}`);
+  } else {
+    ok("error: real 1049 reaches the frontend");
+    const t = es.empty || "";
+    !es.empty ? bad("error: 1049 renders friendly empty state", "no .empty element produced") : ok("error: 1049 renders friendly empty state");
+    /indexing yet/.test(t) ? ok("error: 1049 empty state has friendly title") : bad("error: 1049 empty state has friendly title", t);
+    /never lives on the source/.test(t) ? ok("error: 1049 empty state clarifies source-vs-index") : bad("error: 1049 empty state clarifies source-vs-index", t);
+    /bintrail_idx_/.test(t) ? ok("error: 1049 empty state names the index db") : bad("error: 1049 empty state names the index db", t);
   }
+
+  // Scenario 5 — a pure BYO-index entry (no source) must auto-EXPAND the
+  // advanced section: the index IS the whole form. This is the other arm of
+  // byoIndex (scenario 3 covers the collapse-for-source arm). Its dbname points
+  // at the daemon's own (existing) boot index, so it resolves cleanly.
+  const byoId = await page.evaluate(async () => {
+    const res = await api("/api/servers", { method: "POST", body: {
+      name: "byo-idx", host: "127.0.0.1", port: "13306", user: "root", password: "testroot", dbname: "bintrail_e2e_idx",
+    } });
+    return res.id;
+  });
+  await page.evaluate(() => openServersModal());
+  await page.waitForSelector("#servers-list", { timeout: 5000 });
+  await page.waitForTimeout(300);
+  await page.evaluate((id) => editServer(id), byoId);
+  await page.waitForSelector("#server-advanced", { timeout: 5000 });
+  await page.waitForTimeout(200);
+  const byoOpen = await page.evaluate(() => document.getElementById("server-advanced").open);
+  byoOpen
+    ? ok("form: advanced section expanded for a BYO-index entry")
+    : bad("form: advanced section expanded for a BYO-index entry", "collapsed — the byoIndex open-arm regressed");
 
   // No uncaught JS errors over the whole run.
   jsErrors.length === 0 ? ok("no uncaught JS errors") : bad("no uncaught JS errors", JSON.stringify(jsErrors));

--- a/test/console-e2e/package.json
+++ b/test/console-e2e/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "bintrail-console-e2e",
+  "private": true,
+  "description": "Headless-Chrome E2E regression guard for the bintrail-console frontend",
+  "type": "module",
+  "scripts": {
+    "drive": "node console_e2e.mjs"
+  },
+  "dependencies": {
+    "playwright": "^1.48.0"
+  }
+}

--- a/test/console-e2e/run.sh
+++ b/test/console-e2e/run.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Orchestrates the console frontend E2E: build the binary, point it at the
+# shared test MySQL, launch a source-less `watch` daemon, seed a monitored
+# source whose per-source index is intentionally NOT provisioned (the
+# lifecycle state that exercises the regression guards), then drive headless
+# Chrome (console_e2e.mjs). Tears everything down on exit.
+#
+# Usage:  test/console-e2e/run.sh
+# Env:
+#   BINTRAIL_TEST_DSN   base DSN, default root:testroot@tcp(127.0.0.1:13306)
+#   MYSQL_CONTAINER     docker container running test MySQL, default bintrail-test-mysql
+#   CONSOLE_BIN         path to a prebuilt bintrail-console (else it is built)
+#   PW_CHANNEL          playwright browser channel (e.g. "chrome"); default bundled chromium
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+
+BASE_DSN="${BINTRAIL_TEST_DSN:-root:testroot@tcp(127.0.0.1:13306)}"
+MYSQL_CONTAINER="${MYSQL_CONTAINER:-bintrail-test-mysql}"
+PORT="${E2E_PORT:-8090}"
+TOKEN="${E2E_TOKEN:-e2e-console-token}"
+IDX_DB="bintrail_e2e_idx"
+SERVERS_FILE="$(mktemp -t console-e2e-servers.XXXXXX.yaml)"
+export E2E_ARTIFACT_DIR="${E2E_ARTIFACT_DIR:-${RUNNER_TEMP:-/tmp}}"
+
+mysql_exec() { docker exec -i "$MYSQL_CONTAINER" mysql -uroot -ptestroot "$@" 2>/dev/null; }
+
+DAEMON_PID=""
+cleanup() {
+  [ -n "$DAEMON_PID" ] && kill "$DAEMON_PID" 2>/dev/null || true
+  mysql_exec -e "DROP DATABASE IF EXISTS $IDX_DB;" >/dev/null 2>&1 || true
+  rm -f "$SERVERS_FILE" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "==> build bintrail-console"
+CONSOLE_BIN="${CONSOLE_BIN:-}"
+if [ -z "$CONSOLE_BIN" ]; then
+  CONSOLE_BIN="$ROOT/bintrail-console"
+  (cd "$ROOT" && go build -o "$CONSOLE_BIN" ./cmd/bintrail-console)
+fi
+
+echo "==> fresh index database $IDX_DB"
+mysql_exec -e "DROP DATABASE IF EXISTS $IDX_DB; CREATE DATABASE $IDX_DB;"
+
+echo "==> launch source-less watch daemon on :$PORT"
+BINTRAIL_CONSOLE_TOKEN="$TOKEN" "$CONSOLE_BIN" watch \
+  --index-dsn "${BASE_DSN}/${IDX_DB}" \
+  --console-listen "127.0.0.1:$PORT" \
+  --console-token "$TOKEN" \
+  --console-servers-file "$SERVERS_FILE" \
+  --console-allow-setup >"$E2E_ARTIFACT_DIR/console-e2e-daemon.log" 2>&1 &
+DAEMON_PID=$!
+
+echo "==> wait for /api/healthz"
+for i in $(seq 1 30); do
+  if curl -fsS -o /dev/null "http://127.0.0.1:$PORT/api/healthz" 2>/dev/null; then break; fi
+  if ! kill -0 "$DAEMON_PID" 2>/dev/null; then
+    echo "daemon exited early; log:" >&2; cat "$E2E_ARTIFACT_DIR/console-e2e-daemon.log" >&2; exit 1
+  fi
+  sleep 1
+done
+
+echo "==> seed a monitored source (per-source index left unprovisioned)"
+curl -fsS -X POST \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"name":"wp","source_host":"127.0.0.1","source_port":"13306","source_user":"dbtrail","source_password":"x"}' \
+  "http://127.0.0.1:$PORT/api/servers" >/dev/null
+
+echo "==> install node deps"
+(cd "$HERE" && npm install --no-audit --no-fund --silent)
+if [ "${PW_CHANNEL:-}" = "" ]; then
+  echo "==> install playwright chromium"
+  (cd "$HERE" && npx --yes playwright install chromium >/dev/null)
+fi
+
+echo "==> drive headless Chrome"
+cd "$HERE"
+CONSOLE_URL="http://127.0.0.1:$PORT" CONSOLE_TOKEN="$TOKEN" node console_e2e.mjs


### PR DESCRIPTION
Surfaced while debugging a live `+Add server` monitored source that wouldn't start. The infra was fine — these console bugs **compounded** into a UI that looked completely broken (white buttons, vanishing Start, a wall of `Unknown database` errors, the whole monitor surface disappearing).

## Bugs fixed

**1. Primary button invisible on hover** (`style.css`)
`.btn:hover` sets `background: var(--surface-2)`. `.btn-primary:hover` (equal specificity, later in source) only set `filter`/`box-shadow`, so the gray background won → **white text on light gray**. Re-assert the gradient in `.btn-primary:hover`.

**2. A broken selected server hid the WHOLE control plane** (`reconstruct.go`)
`handleCapabilities` resolved the selected bundle first and **502'd** when its index was unreachable (a monitored source whose per-source index isn't provisioned yet). The frontend's `gateCapabilities` then degraded to `{}`, hiding the **Start button** and the **"+Add server" monitor copy**. `Monitor`/`Auth` are **process-level** — report them unconditionally; `Reconstruct` (per-server) stays gated on a resolvable bundle.

**3. Raw `Unknown database 'bintrail_idx_…'` error wall** (`app.js`)
`renderError` now detects MySQL 1049 and shows an **actionable empty state**: the index DB is created when monitoring starts and **never lives on the source** (the exact source-vs-index confusion users hit), with a *Manage servers* action — instead of a red error wall.

**4. Optional "bring your own index" section auto-expanded** (`app.js`)
Editing a monitored source round-trips its derived index DSN as host/dbname, so a failed-preflight error card opened a per-source index the operator **never typed**. Keep Advanced collapsed for source entries.

## Tests
- `TestHandleCapabilitiesMonitorSurvivesUnresolvableServer` — caps degrade gracefully (200 + Monitor) for an unresolvable selection.
- `TestResolveHeader` — moved its dead-server **502** assertion to `/api/status`; the data endpoints carry that signal now, not `/api/capabilities`.

## Verification
Headless Chrome (playwright-core, `channel:'chrome'`) against a source-less `watch` daemon with a monitored entry whose index is absent: Start button present + monitor copy shown, `+Add server` keeps its gradient on hover, Advanced collapsed for the source entry, and `renderError` renders the friendly empty state naming the index DB and clarifying it never lives on the source. Zero JS errors.

> Related to the same investigation: #480 (Test probe "not provisioned yet") and #481 (monitor-start preflight no longer a silent failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)