### PR TITLE
fix: index UNSIGNED integers with the high bit set as their correct value (#490)

### DIFF
--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -199,9 +199,63 @@ func (r *Resolver) MapRow(schema, table string, row []any) (map[string]any, erro
 	}
 	named := make(map[string]any, len(row))
 	for i, col := range tm.Columns {
-		named[col.Name] = row[i]
+		named[col.Name] = coerceUnsigned(row[i], col)
 	}
 	return named, nil
+}
+
+// coerceUnsigned reinterprets an integer value decoded by go-mysql into the
+// correct unsigned value. go-mysql always decodes INT-family columns as SIGNED
+// (int8/int16/int32/int64) — it parses the TABLE_MAP SIGNEDNESS bitmap but never
+// applies it (UnsignedMap is used only in its Dump output). So a column declared
+// UNSIGNED whose value has the high bit set comes back negative (e.g.
+// BIGINT UNSIGNED 18446744073709551615 → int64(-1)). Left uncorrected, the wrong
+// value lands in the index and, for unsigned PKs, corrupts pk_values/pk_hash.
+//
+// Signedness is taken from the snapshot's ColumnType ("... unsigned"), NOT the
+// TABLE_MAP bitmap, because the bitmap is only present under
+// binlog_row_metadata=FULL (not the default), whereas ColumnType is always
+// loaded by the resolver. Width is taken from DataType so the reinterpretation
+// masks to the column's real size — MEDIUMINT is 3 bytes but go-mysql returns it
+// as int32, so it must be masked to 24 bits (else MEDIUMINT UNSIGNED -1 would
+// become 2^32-1 instead of 2^24-1).
+//
+// No-op when the column is not unsigned, when ColumnType is empty (pre-#212
+// snapshots can't express signedness), or when the value is not a signed integer
+// (NULL, string, decimal, time, etc. are returned unchanged). BIT columns are
+// intentionally not handled here — BIT is a distinct type, not declared
+// "unsigned", and has its own representation.
+func coerceUnsigned(v any, col ColumnMeta) any {
+	if !strings.Contains(strings.ToLower(col.ColumnType), "unsigned") {
+		return v
+	}
+	var signed int64
+	switch x := v.(type) {
+	case int8:
+		signed = int64(x)
+	case int16:
+		signed = int64(x)
+	case int32:
+		signed = int64(x)
+	case int64:
+		signed = x
+	default:
+		return v // not a signed integer (NULL/string/decimal/...) — leave as-is
+	}
+	switch strings.ToLower(col.DataType) {
+	case "tinyint":
+		return uint8(signed)
+	case "smallint":
+		return uint16(signed)
+	case "mediumint":
+		return uint32(signed) & 0xFFFFFF
+	case "int":
+		return uint32(signed)
+	case "bigint":
+		return uint64(signed)
+	default:
+		return v
+	}
 }
 
 // ─── TakeSnapshot ────────────────────────────────────────────────────────────

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -101,6 +101,7 @@ func NewResolver(db *sql.DB, snapshotID int) (*Resolver, error) {
 	defer rows.Close()
 
 	r := &Resolver{snapshotID: snapshotID, tables: make(map[string]*TableMeta)}
+	sawColumnType := false
 
 	for rows.Next() {
 		var schemaName, tableName, columnName, columnKey, dataType, columnType string
@@ -126,6 +127,9 @@ func NewResolver(db *sql.DB, snapshotID int) (*Resolver, error) {
 			ColumnType:      columnType,
 			IsGenerated:     isGenerated,
 		}
+		if columnType != "" {
+			sawColumnType = true
+		}
 		tm.Columns = append(tm.Columns, col)
 		if col.IsPK {
 			tm.PKColumns = append(tm.PKColumns, columnName)
@@ -134,6 +138,18 @@ func NewResolver(db *sql.DB, snapshotID int) (*Resolver, error) {
 
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("failed to iterate snapshot rows: %w", err)
+	}
+
+	// Pre-#212 snapshots have no column_type, so coerceUnsigned cannot tell which
+	// integer columns are UNSIGNED and silently indexes them as-is. Warn once (not
+	// per row) so an operator who upgraded for the unsigned fix (#490) isn't misled
+	// into thinking a stale snapshot is corrected.
+	if len(r.tables) > 0 && !sawColumnType {
+		slog.Warn("snapshot predates column_type capture (#212); UNSIGNED integer "+
+			"columns cannot be sign-corrected and are indexed with the wrong value when "+
+			"the high bit is set (unsigned PKs also corrupt pk_hash) — re-run "+
+			"`bintrail snapshot` to enable the fix",
+			"snapshot_id", snapshotID)
 	}
 
 	return r, nil
@@ -213,18 +229,22 @@ func (r *Resolver) MapRow(schema, table string, row []any) (map[string]any, erro
 // value lands in the index and, for unsigned PKs, corrupts pk_values/pk_hash.
 //
 // Signedness is taken from the snapshot's ColumnType ("... unsigned"), NOT the
-// TABLE_MAP bitmap, because the bitmap is only present under
-// binlog_row_metadata=FULL (not the default), whereas ColumnType is always
-// loaded by the resolver. Width is taken from DataType so the reinterpretation
-// masks to the column's real size — MEDIUMINT is 3 bytes but go-mysql returns it
-// as int32, so it must be masked to 24 bits (else MEDIUMINT UNSIGNED -1 would
-// become 2^32-1 instead of 2^24-1).
+// TABLE_MAP SIGNEDNESS bitmap: coerceUnsigned runs inside MapRow, which works
+// only off the resolver's snapshot and never sees the live TableMapEvent, so the
+// bitmap is not reachable at this layer (and go-mysql would not apply it anyway —
+// see above). ColumnType is always loaded by the resolver, independent of the
+// source's binlog_row_metadata setting. Width is taken from DataType so the
+// reinterpretation masks to the column's real size — MEDIUMINT is 3 bytes but
+// go-mysql returns it as int32, so it must be masked to 24 bits (else
+// MEDIUMINT UNSIGNED -1 would become 2^32-1 instead of 2^24-1).
 //
 // No-op when the column is not unsigned, when ColumnType is empty (pre-#212
-// snapshots can't express signedness), or when the value is not a signed integer
-// (NULL, string, decimal, time, etc. are returned unchanged). BIT columns are
-// intentionally not handled here — BIT is a distinct type, not declared
-// "unsigned", and has its own representation.
+// snapshots can't express signedness — NewResolver warns once in that case), or
+// when the value is not a signed integer (NULL, string, and DECIMAL/FLOAT/DOUBLE
+// UNSIGNED — which go-mysql returns as string/float — are returned unchanged).
+// BIT is intentionally gated out: it is a distinct type, never declared
+// "unsigned". (BIT(64) with the high bit set has the same underlying corruption,
+// since go-mysql decodes BIT as int64, but is tracked separately.)
 func coerceUnsigned(v any, col ColumnMeta) any {
 	if !strings.Contains(strings.ToLower(col.ColumnType), "unsigned") {
 		return v

--- a/internal/metadata/metadata_test.go
+++ b/internal/metadata/metadata_test.go
@@ -73,6 +73,70 @@ func TestMapRow_success(t *testing.T) {
 	}
 }
 
+func TestCoerceUnsigned(t *testing.T) {
+	const maxU64 = uint64(18446744073709551615) // 2^64-1; int64(-1) bit pattern
+
+	cases := []struct {
+		name string
+		v    any
+		col  ColumnMeta
+		want any
+	}{
+		// Unsigned columns with the high bit set: reinterpret to the correct width.
+		{"bigint unsigned max", int64(-1), ColumnMeta{DataType: "bigint", ColumnType: "bigint unsigned"}, maxU64},
+		{"int unsigned max", int32(-1), ColumnMeta{DataType: "int", ColumnType: "int unsigned"}, uint32(4294967295)},
+		{"mediumint unsigned max (24-bit mask)", int32(-1), ColumnMeta{DataType: "mediumint", ColumnType: "mediumint unsigned"}, uint32(16777215)},
+		{"smallint unsigned max", int16(-1), ColumnMeta{DataType: "smallint", ColumnType: "smallint unsigned"}, uint16(65535)},
+		{"tinyint unsigned max", int8(-1), ColumnMeta{DataType: "tinyint", ColumnType: "tinyint unsigned"}, uint8(255)},
+		// Unsigned but value below the threshold: numerically unchanged (still converted type).
+		{"int unsigned small positive", int32(1000000), ColumnMeta{DataType: "int", ColumnType: "int unsigned"}, uint32(1000000)},
+		{"tinyint unsigned 200", int8(-56), ColumnMeta{DataType: "tinyint", ColumnType: "tinyint unsigned"}, uint8(200)},
+		// Signed column: never touched.
+		{"signed bigint negative", int64(-1), ColumnMeta{DataType: "bigint", ColumnType: "bigint(20)"}, int64(-1)},
+		// Pre-#212 snapshot: ColumnType empty → cannot know signedness → no-op.
+		{"empty column type", int64(-1), ColumnMeta{DataType: "bigint", ColumnType: ""}, int64(-1)},
+		// NULL and non-integer values on an unsigned column are returned unchanged.
+		{"null on unsigned", nil, ColumnMeta{DataType: "bigint", ColumnType: "bigint unsigned"}, nil},
+		{"string on unsigned", "x", ColumnMeta{DataType: "bigint", ColumnType: "bigint unsigned"}, "x"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := coerceUnsigned(tc.v, tc.col)
+			if got != tc.want {
+				t.Errorf("coerceUnsigned(%#v, %q) = %#v (%T); want %#v (%T)",
+					tc.v, tc.col.ColumnType, got, got, tc.want, tc.want)
+			}
+		})
+	}
+}
+
+func TestMapRow_unsignedCoercion(t *testing.T) {
+	r := buildTestResolver(map[string]*TableMeta{
+		"mydb.counters": {
+			Schema: "mydb", Table: "counters",
+			Columns: []ColumnMeta{
+				{Name: "id", OrdinalPosition: 1, IsPK: true, DataType: "bigint", ColumnType: "bigint unsigned"},
+				{Name: "n", OrdinalPosition: 2, DataType: "int", ColumnType: "int unsigned"},
+			},
+			PKColumns: []string{"id"},
+		},
+	})
+
+	// go-mysql would hand us these signed values for an unsigned PK and column.
+	row := []any{int64(-1), int32(-1)}
+	named, err := r.MapRow("mydb", "counters", row)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if named["id"] != uint64(18446744073709551615) {
+		t.Errorf("id: want uint64 max, got %#v (%T)", named["id"], named["id"])
+	}
+	if named["n"] != uint32(4294967295) {
+		t.Errorf("n: want uint32 max, got %#v (%T)", named["n"], named["n"])
+	}
+}
+
 func TestMapRow_columnCountMismatch(t *testing.T) {
 	r := buildTestResolver(map[string]*TableMeta{
 		"mydb.orders": {

--- a/internal/metadata/metadata_test.go
+++ b/internal/metadata/metadata_test.go
@@ -98,6 +98,11 @@ func TestCoerceUnsigned(t *testing.T) {
 		// NULL and non-integer values on an unsigned column are returned unchanged.
 		{"null on unsigned", nil, ColumnMeta{DataType: "bigint", ColumnType: "bigint unsigned"}, nil},
 		{"string on unsigned", "x", ColumnMeta{DataType: "bigint", ColumnType: "bigint unsigned"}, "x"},
+		// ENUM whose value list literally contains "unsigned" matches the substring
+		// gate, but go-mysql decodes ENUM as int64, so it reaches the DataType switch
+		// (DataType "enum" ∉ integer widths) — which must leave it untouched. This
+		// locks that load-bearing default so a future refactor can't coerce it.
+		{"enum value list contains 'unsigned'", int64(2), ColumnMeta{DataType: "enum", ColumnType: "enum('signed','unsigned')"}, int64(2)},
 	}
 
 	for _, tc := range cases {

--- a/internal/parser/unsigned_integration_test.go
+++ b/internal/parser/unsigned_integration_test.go
@@ -1,0 +1,102 @@
+//go:build integration
+
+package parser_test
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/config"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/parser"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestParseFile_unsignedIntegers verifies the end-to-end fix for #490: UNSIGNED
+// integer columns whose value has the high bit set (which go-mysql decodes as a
+// negative signed int) are indexed as the correct unsigned value, including when
+// the column is the primary key.
+func TestParseFile_unsignedIntegers(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	ctx := context.Background()
+
+	sourceDB, sourceName := testutil.CreateTestDB(t)
+	indexDB, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, indexDB)
+
+	testutil.MustExec(t, sourceDB, `CREATE TABLE u (
+		id  BIGINT UNSIGNED PRIMARY KEY,
+		n   INT UNSIGNED NOT NULL,
+		m   MEDIUMINT UNSIGNED NOT NULL
+	)`)
+
+	stats, err := metadata.TakeSnapshot(sourceDB, indexDB, []string{sourceName})
+	if err != nil {
+		t.Fatalf("TakeSnapshot failed: %v", err)
+	}
+	res, err := metadata.NewResolver(indexDB, stats.SnapshotID)
+	if err != nil {
+		t.Fatalf("NewResolver failed: %v", err)
+	}
+
+	testutil.MustExec(t, sourceDB, "FLUSH BINARY LOGS")
+	currentBinlog, _, err := config.CurrentBinlogPosition(sourceDB)
+	if err != nil {
+		t.Fatalf("CurrentBinlogPosition failed: %v", err)
+	}
+
+	// Max values for each width: the high bit is set, so an unfixed decoder
+	// would return these as negative.
+	testutil.MustExec(t, sourceDB,
+		`INSERT INTO u (id, n, m) VALUES (18446744073709551615, 4294967295, 16777215)`)
+
+	testutil.MustExec(t, sourceDB, "FLUSH BINARY LOGS")
+
+	tmpDir := t.TempDir()
+	cpCmd := exec.Command("docker", "cp",
+		fmt.Sprintf("bintrail-test-mysql:/var/lib/mysql/%s", currentBinlog),
+		filepath.Join(tmpDir, currentBinlog),
+	)
+	if out, err := cpCmd.CombinedOutput(); err != nil {
+		t.Fatalf("docker cp %s failed: %v\n%s", currentBinlog, err, out)
+	}
+
+	p := parser.New(tmpDir, res, parser.Filters{Schemas: map[string]bool{sourceName: true}}, nil)
+	events := make(chan parser.Event, 50)
+	errCh := make(chan error, 1)
+	go func() {
+		defer close(events)
+		errCh <- p.ParseFile(ctx, currentBinlog, events)
+	}()
+
+	var ins []parser.Event
+	for ev := range events {
+		if ev.Table == "u" && ev.EventType == parser.EventInsert {
+			ins = append(ins, ev)
+		}
+	}
+	if err := <-errCh; err != nil {
+		t.Fatalf("ParseFile returned error: %v", err)
+	}
+	if len(ins) != 1 {
+		t.Fatalf("expected 1 INSERT for table u, got %d", len(ins))
+	}
+
+	ev := ins[0]
+	if got := ev.RowAfter["id"]; got != uint64(18446744073709551615) {
+		t.Errorf("id (BIGINT UNSIGNED): want uint64 max, got %#v (%T)", got, got)
+	}
+	if got := ev.RowAfter["n"]; got != uint32(4294967295) {
+		t.Errorf("n (INT UNSIGNED): want uint32 max, got %#v (%T)", got, got)
+	}
+	if got := ev.RowAfter["m"]; got != uint32(16777215) {
+		t.Errorf("m (MEDIUMINT UNSIGNED): want 16777215, got %#v (%T)", got, got)
+	}
+	// The unsigned PK must serialize to the correct value, not a negative one.
+	if ev.PKValues != "18446744073709551615" {
+		t.Errorf("PKValues: want 18446744073709551615, got %q", ev.PKValues)
+	}
+}

--- a/internal/parser/unsigned_integration_test.go
+++ b/internal/parser/unsigned_integration_test.go
@@ -52,6 +52,10 @@ func TestParseFile_unsignedIntegers(t *testing.T) {
 	// would return these as negative.
 	testutil.MustExec(t, sourceDB,
 		`INSERT INTO u (id, n, m) VALUES (18446744073709551615, 4294967295, 16777215)`)
+	// Update a non-PK column so the UPDATE before-image carries the unsigned PK —
+	// this is what `recover` keys on, so the before-image PK must be correct too.
+	testutil.MustExec(t, sourceDB,
+		`UPDATE u SET n = 1 WHERE id = 18446744073709551615`)
 
 	testutil.MustExec(t, sourceDB, "FLUSH BINARY LOGS")
 
@@ -72,10 +76,16 @@ func TestParseFile_unsignedIntegers(t *testing.T) {
 		errCh <- p.ParseFile(ctx, currentBinlog, events)
 	}()
 
-	var ins []parser.Event
+	var ins, upd []parser.Event
 	for ev := range events {
-		if ev.Table == "u" && ev.EventType == parser.EventInsert {
+		if ev.Table != "u" {
+			continue
+		}
+		switch ev.EventType {
+		case parser.EventInsert:
 			ins = append(ins, ev)
+		case parser.EventUpdate:
+			upd = append(upd, ev)
 		}
 	}
 	if err := <-errCh; err != nil {
@@ -98,5 +108,18 @@ func TestParseFile_unsignedIntegers(t *testing.T) {
 	// The unsigned PK must serialize to the correct value, not a negative one.
 	if ev.PKValues != "18446744073709551615" {
 		t.Errorf("PKValues: want 18446744073709551615, got %q", ev.PKValues)
+	}
+
+	// UPDATE before-image: the unsigned PK that recover keys on must be correct,
+	// both in RowBefore and in the PKValues built from the before-image.
+	if len(upd) != 1 {
+		t.Fatalf("expected 1 UPDATE for table u, got %d", len(upd))
+	}
+	u := upd[0]
+	if got := u.RowBefore["id"]; got != uint64(18446744073709551615) {
+		t.Errorf("UPDATE RowBefore id: want uint64 max, got %#v (%T)", got, got)
+	}
+	if u.PKValues != "18446744073709551615" {
+		t.Errorf("UPDATE PKValues (from before-image): want 18446744073709551615, got %q", u.PKValues)
 	}
 }


### PR DESCRIPTION
closes #490

## Summary
- go-mysql decodes every INT-family column as **signed** and never applies the TABLE_MAP `SIGNEDNESS` bitmap, so an `UNSIGNED` value with the high bit set was indexed as a negative number (e.g. `BIGINT UNSIGNED 18446744073709551615` → `int64(-1)`). For unsigned PKs this also corrupted `pk_values`/`pk_hash`.
- Fix reinterprets the value at the single choke point `metadata.MapRow`, via a new `coerceUnsigned(v, col)`:
  - **Signedness** from the snapshot's `ColumnType` (`"... unsigned"`) — not the TABLE_MAP bitmap, which is only present under `binlog_row_metadata=FULL` (not the default); `ColumnType` is always loaded by the resolver.
  - **Width** from `DataType`: `tinyint→uint8`, `smallint→uint16`, `mediumint→uint32 & 0xFFFFFF`, `int→uint32`, `bigint→uint64`. MEDIUMINT is masked to 24 bits because go-mysql returns it as `int32`.
- No-op when the column isn't unsigned, when `ColumnType` is empty (pre-#212 snapshots), or when the value isn't a signed integer (NULL/string/decimal/…).

## Scope / notes
- Fixing `MapRow` also fixes **unsigned primary keys**, since `pk_values` is built from its output.
- **Out of scope:** `BIT(64)` top-bit (distinct type, not declared `unsigned`); read-side `float64` precision for values >2^53 (separate finding). This PR makes the *stored* value correct — fully correct end-to-end for the common range and strictly better for the huge range.

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] New unit tests: `TestCoerceUnsigned` (per-width boundaries incl. the MEDIUMINT 24-bit case, signed unaffected, empty-ColumnType no-op, NULL no-op) and `TestMapRow_unsignedCoercion`
- [x] New integration test `TestParseFile_unsignedIntegers` (real binlog): `BIGINT/INT/MEDIUMINT UNSIGNED` and an unsigned PK index to the correct value
- [x] `internal/parser` + `internal/metadata` integration tests pass (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)