### PR TITLE
fix: advance GTID checkpoint only at transaction commit boundaries (#491)

### DIFF
--- a/cmd/bintrail/agent.go
+++ b/cmd/bintrail/agent.go
@@ -739,8 +739,8 @@ func byosStreamLoop(ctx context.Context, events <-chan parser.Event, buf *buffer
 				return nil
 			}
 
-			// Skip non-row events (GTID tracking, DDL).
-			if ev.EventType == parser.EventGTID || ev.EventType == parser.EventDDL {
+			// Skip non-row events (GTID tracking, DDL, commit boundaries).
+			if ev.EventType == parser.EventGTID || ev.EventType == parser.EventDDL || ev.EventType == parser.EventCommit {
 				continue
 			}
 

--- a/internal/byos/split.go
+++ b/internal/byos/split.go
@@ -94,8 +94,8 @@ func PKHash(pkValues string) string {
 // permitted (older callers / tests) and produces a record without source
 // identity fields.
 //
-// Returns an error for unsupported event types (DDL, GTID). Callers should
-// filter these before calling SplitEvent.
+// Returns an error for unsupported event types (DDL, GTID, commit boundaries).
+// Callers should filter these before calling SplitEvent.
 func SplitEvent(ev parser.Event, serverID string, ident SourceIdentity) (MetadataRecord, PayloadRecord, error) {
 	typeName, err := eventTypeName(ev.EventType)
 	if err != nil {

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -36,12 +36,14 @@ const (
 	// produces this type — it exists so baseline rows can flow through the
 	// same ResultRow pipeline as real binlog events.
 	EventSnapshot EventType = 6
-	// EventCommit marks a transaction commit boundary (XID_EVENT, or a COMMIT
-	// QUERY_EVENT). It carries no row data — only the GTID of the transaction
-	// that just committed. The stream consumer uses it to advance the durable
-	// GTID checkpoint ONLY after a transaction's rows are fully received, so a
-	// checkpoint can never claim a half-streamed transaction (#491). Emitted only
-	// by the StreamParser; the file parser does not produce it.
+	// EventCommit marks a transaction commit boundary, emitted by the StreamParser
+	// at an XID_EVENT and — as a catch-all for implicitly-committed statements that
+	// carry a GTID but have no XID and aren't table DDL (GRANT, CREATE DATABASE,
+	// CREATE VIEW, XA COMMIT, etc.) — when the next transaction's GTID_EVENT
+	// arrives. It carries no row data, only the committed transaction's GTID. The
+	// consumer advances the durable GTID checkpoint ONLY on this event (and on
+	// EventDDL), never on the leading EventGTID, so a checkpoint can never claim a
+	// half-streamed transaction (#491). The file parser does not produce it.
 	EventCommit EventType = 7
 )
 

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -37,13 +37,16 @@ const (
 	// same ResultRow pipeline as real binlog events.
 	EventSnapshot EventType = 6
 	// EventCommit marks a transaction commit boundary, emitted by the StreamParser
-	// at an XID_EVENT and — as a catch-all for implicitly-committed statements that
-	// carry a GTID but have no XID and aren't table DDL (GRANT, CREATE DATABASE,
-	// CREATE VIEW, XA COMMIT, etc.) — when the next transaction's GTID_EVENT
-	// arrives. It carries no row data, only the committed transaction's GTID. The
-	// consumer advances the durable GTID checkpoint ONLY on this event (and on
-	// EventDDL), never on the leading EventGTID, so a checkpoint can never claim a
-	// half-streamed transaction (#491). The file parser does not produce it.
+	// at an XID_EVENT (InnoDB DML) and — as a catch-all when the next transaction's
+	// GTID_EVENT arrives — for transactions that carry a GTID but emit no XID and
+	// aren't table DDL: implicitly-committed DDL/DCL (GRANT, CREATE DATABASE,
+	// CREATE INDEX, ANALYZE TABLE, ...) and no-XID explicit terminators (XA COMMIT;
+	// a COMMIT of a non-transactional transaction — a normal InnoDB COMMIT ends in
+	// an XID_EVENT instead). It carries no row data, only the committed
+	// transaction's GTID. The consumer advances the durable GTID checkpoint ONLY on
+	// this event (and on EventDDL), never on the leading EventGTID, so a checkpoint
+	// can never claim a half-streamed transaction (#491). The file parser does not
+	// produce it.
 	EventCommit EventType = 7
 )
 

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -36,6 +36,13 @@ const (
 	// produces this type — it exists so baseline rows can flow through the
 	// same ResultRow pipeline as real binlog events.
 	EventSnapshot EventType = 6
+	// EventCommit marks a transaction commit boundary (XID_EVENT, or a COMMIT
+	// QUERY_EVENT). It carries no row data — only the GTID of the transaction
+	// that just committed. The stream consumer uses it to advance the durable
+	// GTID checkpoint ONLY after a transaction's rows are fully received, so a
+	// checkpoint can never claim a half-streamed transaction (#491). Emitted only
+	// by the StreamParser; the file parser does not produce it.
+	EventCommit EventType = 7
 )
 
 // Event is a fully resolved binlog row event with column names attached.

--- a/internal/parser/stream.go
+++ b/internal/parser/stream.go
@@ -129,12 +129,21 @@ func (sp *StreamParser) Run(ctx context.Context, streamer *replication.BinlogStr
 		case *replication.GTIDEvent:
 			// A new transaction is starting, so the previous one has terminated. If
 			// it wasn't already committed by its XID or a table DDL, commit it now.
-			// This is the catch-all for implicitly-committed statements that carry a
-			// GTID but emit no XID and aren't table DDL: GRANT/REVOKE, CREATE/DROP
-			// DATABASE, CREATE/DROP VIEW/TRIGGER/PROCEDURE/FUNCTION, CREATE/DROP
-			// INDEX, ANALYZE/OPTIMIZE TABLE, XA COMMIT, an explicit COMMIT, etc.
+			// This is the catch-all for transactions that carry a GTID but emit no
+			// XID and aren't table DDL — two families:
+			//   * implicitly-committed DDL/DCL: GRANT/REVOKE, CREATE/DROP DATABASE,
+			//     CREATE/DROP VIEW/TRIGGER/PROCEDURE/FUNCTION, CREATE/DROP INDEX,
+			//     ANALYZE/OPTIMIZE TABLE;
+			//   * explicit terminators logged as a QUERY with no XID: XA COMMIT, or
+			//     a COMMIT of a non-transactional/mixed-engine transaction.
+			// (A normal InnoDB COMMIT does NOT reach here — it ends in an XID_EVENT.)
 			// Without this their GTID would never advance the checkpoint, causing
 			// endless re-streaming and eventually a false data-loss gap alarm (#491).
+			//
+			// Limitation: the fallback fires on the NEXT GTID, so the LAST such
+			// statement before an idle period or shutdown stays uncommitted until
+			// traffic resumes — it is re-streamed on restart (harmless: these carry
+			// no rows). DML is unaffected (it commits immediately at its XID).
 			if err := emitCommit(binlogEv.Header); err != nil {
 				return err
 			}

--- a/internal/parser/stream.go
+++ b/internal/parser/stream.go
@@ -6,7 +6,6 @@ package parser
 import (
 	"context"
 	"log/slog"
-	"strings"
 	"sync/atomic"
 	"time"
 
@@ -88,9 +87,12 @@ func (sp *StreamParser) Run(ctx context.Context, streamer *replication.BinlogStr
 	var currentConnectionID uint32 // pseudo_thread_id from most recent QueryEvent
 
 	// emitCommit signals a transaction commit boundary so the stream consumer can
-	// advance the durable GTID checkpoint only after the transaction's rows are
-	// fully received (#491). No-op for non-GTID sources (currentGTID empty), which
-	// keeps position-mode behavior unchanged.
+	// advance the durable GTID checkpoint only after the transaction's rows have
+	// been received (#491). It commits the in-flight transaction (currentGTID) and
+	// clears it, so the next-GTID fallback below won't re-commit the same GTID.
+	// No-op for non-GTID sources (currentGTID empty); a GTID-enabled source running
+	// in position mode still emits these, harmlessly — the consumer ignores commit
+	// events when accGTID is nil, and binlogPos lands on the XID boundary.
 	emitCommit := func(hdr *replication.EventHeader) error {
 		if currentGTID == "" {
 			return nil
@@ -104,6 +106,7 @@ func (sp *StreamParser) Run(ctx context.Context, streamer *replication.BinlogStr
 		}
 		select {
 		case out <- commitEv:
+			currentGTID = "" // committed; the next-GTID fallback must not re-commit it
 			return nil
 		case <-ctx.Done():
 			return ctx.Err()
@@ -124,6 +127,17 @@ func (sp *StreamParser) Run(ctx context.Context, streamer *replication.BinlogStr
 			currentFile = string(ev.NextLogName)
 
 		case *replication.GTIDEvent:
+			// A new transaction is starting, so the previous one has terminated. If
+			// it wasn't already committed by its XID or a table DDL, commit it now.
+			// This is the catch-all for implicitly-committed statements that carry a
+			// GTID but emit no XID and aren't table DDL: GRANT/REVOKE, CREATE/DROP
+			// DATABASE, CREATE/DROP VIEW/TRIGGER/PROCEDURE/FUNCTION, CREATE/DROP
+			// INDEX, ANALYZE/OPTIMIZE TABLE, XA COMMIT, an explicit COMMIT, etc.
+			// Without this their GTID would never advance the checkpoint, causing
+			// endless re-streaming and eventually a false data-loss gap alarm (#491).
+			if err := emitCommit(binlogEv.Header); err != nil {
+				return err
+			}
 			currentGTID = formatGTID(ev.SID, ev.GNO)
 			if currentGTID != "" {
 				ts := time.Unix(int64(binlogEv.Header.Timestamp), 0).UTC()
@@ -156,12 +170,13 @@ func (sp *StreamParser) Run(ctx context.Context, streamer *replication.BinlogStr
 				if hook := sp.onDDL.Load(); hook != nil {
 					(*hook)(ddlEv)
 				}
-			} else if strings.EqualFold(strings.TrimSpace(string(ev.Query)), "COMMIT") {
-				// Non-XID transactional commit (e.g. non-InnoDB engines). InnoDB
-				// commits arrive as XID_EVENT, handled below.
-				if err := emitCommit(binlogEv.Header); err != nil {
-					return err
-				}
+				// Table DDL auto-commits its own GTID; EventDDL is the commit
+				// boundary the consumer acts on, so clear the in-flight GTID to keep
+				// the next-GTID fallback from re-committing it. Other QueryEvents
+				// (BEGIN, SAVEPOINT, ...) deliberately do NOT commit here — DML
+				// commits at its XID below, and other implicitly-committed statements
+				// commit via the next-GTID fallback (#491).
+				currentGTID = ""
 			}
 
 		case *replication.XIDEvent:

--- a/internal/parser/stream.go
+++ b/internal/parser/stream.go
@@ -6,6 +6,7 @@ package parser
 import (
 	"context"
 	"log/slog"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -86,6 +87,29 @@ func (sp *StreamParser) Run(ctx context.Context, streamer *replication.BinlogStr
 	var currentGTID string
 	var currentConnectionID uint32 // pseudo_thread_id from most recent QueryEvent
 
+	// emitCommit signals a transaction commit boundary so the stream consumer can
+	// advance the durable GTID checkpoint only after the transaction's rows are
+	// fully received (#491). No-op for non-GTID sources (currentGTID empty), which
+	// keeps position-mode behavior unchanged.
+	emitCommit := func(hdr *replication.EventHeader) error {
+		if currentGTID == "" {
+			return nil
+		}
+		commitEv := Event{
+			BinlogFile: currentFile,
+			EndPos:     uint64(hdr.LogPos),
+			Timestamp:  time.Unix(int64(hdr.Timestamp), 0).UTC(),
+			GTID:       currentGTID,
+			EventType:  EventCommit,
+		}
+		select {
+		case out <- commitEv:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
 	// handleEvent processes one binlog event. It is recursive: with
 	// binlog_transaction_compression=ON the source wraps each transaction's
 	// events (BEGIN + TABLE_MAP + rows + XID) in a single zstd-compressed
@@ -132,6 +156,19 @@ func (sp *StreamParser) Run(ctx context.Context, streamer *replication.BinlogStr
 				if hook := sp.onDDL.Load(); hook != nil {
 					(*hook)(ddlEv)
 				}
+			} else if strings.EqualFold(strings.TrimSpace(string(ev.Query)), "COMMIT") {
+				// Non-XID transactional commit (e.g. non-InnoDB engines). InnoDB
+				// commits arrive as XID_EVENT, handled below.
+				if err := emitCommit(binlogEv.Header); err != nil {
+					return err
+				}
+			}
+
+		case *replication.XIDEvent:
+			// InnoDB transaction commit — the boundary at which it's safe to
+			// advance the durable GTID checkpoint (#491).
+			if err := emitCommit(binlogEv.Header); err != nil {
+				return err
 			}
 
 		case *replication.RowsEvent:

--- a/internal/parser/stream_test.go
+++ b/internal/parser/stream_test.go
@@ -55,6 +55,27 @@ func makeQueryEvent(query string) *replication.BinlogEvent {
 	}
 }
 
+// makeXIDEvent builds a BinlogEvent wrapping an XIDEvent (InnoDB commit).
+func makeXIDEvent(logPos uint32) *replication.BinlogEvent {
+	return &replication.BinlogEvent{
+		Header: &replication.EventHeader{EventType: replication.XID_EVENT, LogPos: logPos},
+		Event:  &replication.XIDEvent{XID: 1},
+	}
+}
+
+// drainTypes collects the EventTypes emitted on the channel.
+func drainTypes(out <-chan Event) []EventType {
+	var types []EventType
+	for {
+		select {
+		case ev := <-out:
+			types = append(types, ev.EventType)
+		default:
+			return types
+		}
+	}
+}
+
 // feed sends events to a streamer then cancels ctx after a short delay,
 // ensuring Run returns even if no further events arrive.
 func feedThenCancel(t *testing.T, streamer *replication.BinlogStreamer, cancel context.CancelFunc, evs ...*replication.BinlogEvent) {
@@ -230,6 +251,102 @@ func TestStreamParser_queryEventDDL(t *testing.T) {
 	}
 	if ev.DDLType != DDLAlterTable {
 		t.Errorf("expected DDLType DDLAlterTable, got %q", ev.DDLType)
+	}
+}
+
+// TestStreamParser_xidEmitsCommit verifies that an XID_EVENT closing a GTID
+// transaction emits an EventCommit carrying that GTID (#491).
+func TestStreamParser_xidEmitsCommit(t *testing.T) {
+	sp := NewStreamParser(nil, Filters{}, nil)
+	streamer := replication.NewBinlogStreamer()
+	out := make(chan Event, 10)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	feedThenCancel(t, streamer, cancel,
+		makeGTIDEvent(7),
+		makeQueryEvent("BEGIN"),
+		makeXIDEvent(300),
+	)
+	if err := sp.Run(ctx, streamer, out); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	types := drainTypes(out)
+	if len(types) != 2 || types[0] != EventGTID || types[1] != EventCommit {
+		t.Fatalf("expected [EventGTID, EventCommit], got %v", types)
+	}
+}
+
+// TestStreamParser_implicitCommitViaNextGTID verifies the catch-all for
+// implicitly-committed statements that carry a GTID but have no XID and aren't
+// table DDL (e.g. GRANT): the prior transaction's GTID is committed when the
+// next transaction's GTID_EVENT arrives, so its checkpoint advances (#491).
+func TestStreamParser_implicitCommitViaNextGTID(t *testing.T) {
+	sp := NewStreamParser(nil, Filters{}, nil)
+	streamer := replication.NewBinlogStreamer()
+	out := make(chan Event, 10)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	feedThenCancel(t, streamer, cancel,
+		makeGTIDEvent(1),
+		makeQueryEvent("GRANT SELECT ON *.* TO 'x'@'%'"), // implicit commit, no XID, not table DDL
+		makeGTIDEvent(2),
+	)
+	if err := sp.Run(ctx, streamer, out); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// GTID(1) → (GRANT: nothing) → GTID(2) triggers the fallback commit of GTID(1).
+	evs := make([]Event, 0, 3)
+	for {
+		got := false
+		select {
+		case ev := <-out:
+			evs = append(evs, ev)
+			got = true
+		default:
+		}
+		if !got {
+			break
+		}
+	}
+	if len(evs) != 3 {
+		t.Fatalf("expected [EventGTID, EventCommit, EventGTID], got %d events: %+v", len(evs), evs)
+	}
+	if evs[0].EventType != EventGTID || evs[1].EventType != EventCommit || evs[2].EventType != EventGTID {
+		t.Fatalf("expected [EventGTID, EventCommit, EventGTID], got types %d,%d,%d", evs[0].EventType, evs[1].EventType, evs[2].EventType)
+	}
+	if evs[1].GTID != evs[0].GTID {
+		t.Errorf("the fallback commit must carry the first transaction's GTID: commit=%q gtid=%q", evs[1].GTID, evs[0].GTID)
+	}
+	if evs[2].GTID == evs[0].GTID {
+		t.Errorf("the second GTID must differ from the first; both are %q", evs[2].GTID)
+	}
+}
+
+// TestStreamParser_compressedTransactionEmitsCommit verifies that a transaction
+// whose XID lives inside a compressed Transaction_payload event still emits an
+// EventCommit (the GTID_EVENT precedes the payload on the wire) (#491).
+func TestStreamParser_compressedTransactionEmitsCommit(t *testing.T) {
+	sp := NewStreamParser(nil, Filters{}, nil)
+	streamer := replication.NewBinlogStreamer()
+	out := make(chan Event, 10)
+
+	innerBegin := makeQueryEvent("BEGIN")
+	innerXID := makeXIDEvent(0) // inner LogPos is rewritten to the payload's
+
+	ctx, cancel := context.WithCancel(context.Background())
+	feedThenCancel(t, streamer, cancel,
+		makeGTIDEvent(9),                              // GTID is outside the compressed payload
+		makePayloadEvent(5000, 200, innerBegin, innerXID),
+	)
+	if err := sp.Run(ctx, streamer, out); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	types := drainTypes(out)
+	if len(types) != 2 || types[0] != EventGTID || types[1] != EventCommit {
+		t.Fatalf("expected [EventGTID, EventCommit] from a compressed transaction, got %v", types)
 	}
 }
 
@@ -600,8 +717,12 @@ func TestStreamParser_emptyPayloadNoEffect(t *testing.T) {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	feedThenCancel(t, streamer, cancel,
-		makePayloadEvent(3000, 200),           // no inner events at all
-		makePayloadEvent(4000, 200, innerXID), // only an ignored inner event
+		makePayloadEvent(3000, 200), // no inner events at all
+		// An inner XID with NO preceding GTID: emitCommit is a no-op because
+		// currentGTID is empty, so still nothing is emitted. (A GTID-led
+		// transaction's inner XID DOES emit EventCommit — see
+		// TestStreamParser_compressedTransactionEmitsCommit.)
+		makePayloadEvent(4000, 200, innerXID),
 	)
 	if err := sp.Run(ctx, streamer, out); err != nil {
 		t.Fatalf("Run: %v", err)

--- a/internal/parser/stream_test.go
+++ b/internal/parser/stream_test.go
@@ -63,17 +63,25 @@ func makeXIDEvent(logPos uint32) *replication.BinlogEvent {
 	}
 }
 
-// drainTypes collects the EventTypes emitted on the channel.
-func drainTypes(out <-chan Event) []EventType {
-	var types []EventType
+// drainAll collects all events currently buffered on the channel (non-blocking).
+func drainAll(out <-chan Event) []Event {
+	var evs []Event
 	for {
 		select {
 		case ev := <-out:
-			types = append(types, ev.EventType)
+			evs = append(evs, ev)
 		default:
-			return types
+			return evs
 		}
 	}
+}
+
+func typesOf(evs []Event) []EventType {
+	types := make([]EventType, len(evs))
+	for i, ev := range evs {
+		types[i] = ev.EventType
+	}
+	return types
 }
 
 // feed sends events to a streamer then cancels ctx after a short delay,
@@ -271,9 +279,14 @@ func TestStreamParser_xidEmitsCommit(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
-	types := drainTypes(out)
-	if len(types) != 2 || types[0] != EventGTID || types[1] != EventCommit {
-		t.Fatalf("expected [EventGTID, EventCommit], got %v", types)
+	evs := drainAll(out)
+	if len(evs) != 2 || evs[0].EventType != EventGTID || evs[1].EventType != EventCommit {
+		t.Fatalf("expected [EventGTID, EventCommit], got %v", typesOf(evs))
+	}
+	// The commit must carry the transaction's GTID — that's what the consumer
+	// feeds to advanceGTID. An empty/stale GTID here breaks checkpoint advancement.
+	if evs[1].GTID == "" || evs[1].GTID != evs[0].GTID {
+		t.Errorf("EventCommit must carry the transaction's GTID: commit=%q gtid=%q", evs[1].GTID, evs[0].GTID)
 	}
 }
 
@@ -337,16 +350,125 @@ func TestStreamParser_compressedTransactionEmitsCommit(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	feedThenCancel(t, streamer, cancel,
-		makeGTIDEvent(9),                              // GTID is outside the compressed payload
+		makeGTIDEvent(9), // GTID is outside the compressed payload
 		makePayloadEvent(5000, 200, innerBegin, innerXID),
 	)
 	if err := sp.Run(ctx, streamer, out); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
 
-	types := drainTypes(out)
-	if len(types) != 2 || types[0] != EventGTID || types[1] != EventCommit {
-		t.Fatalf("expected [EventGTID, EventCommit] from a compressed transaction, got %v", types)
+	evs := drainAll(out)
+	if len(evs) != 2 || evs[0].EventType != EventGTID || evs[1].EventType != EventCommit {
+		t.Fatalf("expected [EventGTID, EventCommit] from a compressed transaction, got %v", typesOf(evs))
+	}
+	if evs[1].GTID == "" || evs[1].GTID != evs[0].GTID {
+		t.Errorf("compressed EventCommit must carry the transaction's GTID: commit=%q gtid=%q", evs[1].GTID, evs[0].GTID)
+	}
+}
+
+// TestStreamParser_compressedTransactionWithRows covers the realistic default
+// shape: the GTID is on the wire, and BEGIN + rows + XID are all inside one
+// compressed Transaction_payload. The rows must be emitted (carrying the outer
+// GTID) and then a single EventCommit carrying that same GTID — clearing
+// currentGTID at the inner XID must not strand the inner rows (#491).
+func TestStreamParser_compressedTransactionWithRows(t *testing.T) {
+	sp := NewStreamParser(makeOrdersResolver(), Filters{}, nil)
+	streamer := replication.NewBinlogStreamer()
+	out := make(chan Event, 10)
+
+	innerBegin := &replication.BinlogEvent{
+		Header: &replication.EventHeader{EventType: replication.QUERY_EVENT, LogPos: 0},
+		Event:  &replication.QueryEvent{Query: []byte("BEGIN"), SlaveProxyID: 42},
+	}
+	innerInserts := &replication.BinlogEvent{
+		Header: &replication.EventHeader{EventType: replication.WRITE_ROWS_EVENTv2, Timestamp: 1770000000, LogPos: 0, EventSize: 500},
+		Event: &replication.RowsEvent{
+			Table: &replication.TableMapEvent{Schema: []byte("shop"), Table: []byte("orders"), ColumnCount: 2},
+			Rows:  [][]any{{int64(1), int64(10)}, {int64(2), int64(20)}},
+		},
+	}
+	innerXID := makeXIDEvent(0) // inner LogPos rewritten to the payload's
+
+	ctx, cancel := context.WithCancel(context.Background())
+	feedThenCancel(t, streamer, cancel,
+		makeGTIDEvent(12), // GTID stays OUTSIDE the payload on the wire
+		makePayloadEvent(6000, 900, innerBegin, innerInserts, innerXID),
+	)
+	if err := sp.Run(ctx, streamer, out); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	evs := drainAll(out)
+	// Expect: EventGTID, 2× EventInsert, EventCommit — in that order.
+	if got := typesOf(evs); len(evs) != 4 ||
+		evs[0].EventType != EventGTID ||
+		evs[1].EventType != EventInsert || evs[2].EventType != EventInsert ||
+		evs[3].EventType != EventCommit {
+		t.Fatalf("expected [GTID, Insert, Insert, Commit], got %v", got)
+	}
+	gtid := evs[0].GTID
+	if gtid == "" {
+		t.Fatal("outer GTID must be non-empty")
+	}
+	// Every inner row AND the trailing commit must carry the outer GTID — proves
+	// the inner XID's currentGTID-clear happened AFTER the rows were emitted.
+	for i := 1; i <= 3; i++ {
+		if evs[i].GTID != gtid {
+			t.Errorf("event[%d] (%d) GTID = %q, want outer %q", i, evs[i].EventType, evs[i].GTID, gtid)
+		}
+	}
+}
+
+// TestStreamParser_noDoubleCommitAfterXID locks the contract that emitCommit
+// clears currentGTID at the XID, so the next transaction's GTID fallback is a
+// no-op: two XID transactions produce exactly two commits, not three (#491).
+func TestStreamParser_noDoubleCommitAfterXID(t *testing.T) {
+	sp := NewStreamParser(nil, Filters{}, nil)
+	streamer := replication.NewBinlogStreamer()
+	out := make(chan Event, 20)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	feedThenCancel(t, streamer, cancel,
+		makeGTIDEvent(1), makeQueryEvent("BEGIN"), makeXIDEvent(100),
+		makeGTIDEvent(2), makeQueryEvent("BEGIN"), makeXIDEvent(200),
+	)
+	if err := sp.Run(ctx, streamer, out); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	commits := 0
+	for _, ev := range drainAll(out) {
+		if ev.EventType == EventCommit {
+			commits++
+		}
+	}
+	if commits != 2 {
+		t.Errorf("expected exactly 2 commits (no double-commit via the fallback), got %d", commits)
+	}
+}
+
+// TestStreamParser_trailingImplicitCommitNotEmitted locks the deliberate
+// conservative behavior: a trailing implicit-commit statement (GRANT) with no
+// following GTID is NOT committed at stream end — it re-streams on restart rather
+// than being committed without confirmation (#491). If a future "final flush" is
+// added, it must not silently commit an unconfirmed trailing transaction.
+func TestStreamParser_trailingImplicitCommitNotEmitted(t *testing.T) {
+	sp := NewStreamParser(nil, Filters{}, nil)
+	streamer := replication.NewBinlogStreamer()
+	out := make(chan Event, 10)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	feedThenCancel(t, streamer, cancel,
+		makeGTIDEvent(1),
+		makeQueryEvent("GRANT SELECT ON *.* TO 'x'@'%'"), // implicit commit, no XID, no next GTID
+	)
+	if err := sp.Run(ctx, streamer, out); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	evs := drainAll(out)
+	if len(evs) != 1 || evs[0].EventType != EventGTID {
+		t.Fatalf("a trailing implicit-commit must emit only [EventGTID] (no commit), got %v", typesOf(evs))
 	}
 }
 

--- a/internal/streamrun/streamrun.go
+++ b/internal/streamrun/streamrun.go
@@ -660,7 +660,14 @@ func streamLoop(
 			return
 		}
 		if err := state.accGTID.Update(gtid); err != nil {
-			slog.Warn("failed to update GTID set", "gtid", gtid, "error", err)
+			// This is the sole path to durable GTID progress; on a persistent
+			// failure the checkpoint silently freezes while rows keep indexing and
+			// checkpoints keep "succeeding" with the stale set. Log loudly (Error,
+			// not Warn) — a frozen-but-green checkpoint means a full re-stream on
+			// the next restart. Update only errors on a malformed GTID, which the
+			// parser does not produce, so this should never fire in practice.
+			slog.Error("failed to update GTID set — durable checkpoint is not advancing",
+				"gtid", gtid, "error", err)
 			m.Errors.WithLabelValues("gtid_update").Inc()
 			return
 		}

--- a/internal/streamrun/streamrun.go
+++ b/internal/streamrun/streamrun.go
@@ -650,6 +650,23 @@ func streamLoop(
 		}
 	}
 
+	// advanceGTID adds a committed transaction's GTID to the durable set. It is
+	// called only at commit boundaries (EventCommit / EventDDL), never at the
+	// leading EventGTID, so a checkpoint can never persist a GTID whose rows were
+	// not fully received and indexed (#491). No-op in position mode (accGTID nil)
+	// and for non-GTID sources (empty gtid).
+	advanceGTID := func(gtid string) {
+		if gtid == "" || state.accGTID == nil {
+			return
+		}
+		if err := state.accGTID.Update(gtid); err != nil {
+			slog.Warn("failed to update GTID set", "gtid", gtid, "error", err)
+			m.Errors.WithLabelValues("gtid_update").Inc()
+			return
+		}
+		state.gtidSet = state.accGTID.String()
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -669,29 +686,29 @@ func streamLoop(
 				state.binlogFile = ev.BinlogFile
 			}
 			state.binlogPos = ev.EndPos
-			if ev.GTID != "" && state.accGTID != nil {
-				if err := state.accGTID.Update(ev.GTID); err != nil {
-					slog.Warn("failed to update GTID set", "gtid", ev.GTID, "error", err)
-					m.Errors.WithLabelValues("gtid_update").Inc()
-				} else {
-					state.gtidSet = state.accGTID.String()
-				}
-			}
 			if !ev.Timestamp.IsZero() {
 				state.lastEventTime = sql.NullTime{Time: ev.Timestamp, Valid: true}
 			}
 
-			// GTID-only events: position/GTID already tracked above, skip insertion.
-			if ev.EventType == parser.EventGTID {
+			switch ev.EventType {
+			case parser.EventGTID:
+				// Transaction start marker — attribution only. The GTID is NOT
+				// added to the durable set here; that happens at EventCommit, so a
+				// checkpoint mid-transaction can't claim a half-streamed
+				// transaction (#491).
 				continue
-			}
-
-			// DDL events: flush batch, skip insertion (handled by the
-			// parser's synchronous hook — see the function comment).
-			if ev.EventType == parser.EventDDL {
+			case parser.EventCommit:
+				// Transaction committed: all its rows have been received, so it is
+				// now safe to advance the durable GTID checkpoint.
+				advanceGTID(ev.GTID)
+				continue
+			case parser.EventDDL:
+				// DDL flushes pending rows, then auto-commits its own GTID
+				// (insertion itself is handled by the parser's synchronous hook).
 				if err := flush(); err != nil {
 					return err
 				}
+				advanceGTID(ev.GTID)
 				continue
 			}
 

--- a/internal/streamrun/streamrun_integration_test.go
+++ b/internal/streamrun/streamrun_integration_test.go
@@ -560,6 +560,50 @@ func TestStreamLoop_gtidCheckpointAtCommit(t *testing.T) {
 	})
 }
 
+// TestStreamLoop_positionModeCommitBoundary verifies that for a GTID-enabled
+// source running in POSITION mode (accGTID nil), EventCommit is a harmless no-op
+// for GTID tracking yet still advances binlogPos to the commit boundary, and the
+// durable gtid_set stays empty (#491 — locks the comment's position-mode claim).
+func TestStreamLoop_positionModeCommitBoundary(t *testing.T) {
+	const gtid = "11111111-1111-1111-1111-111111111111:1"
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	testutil.InsertSnapshot(t, db, 1, "2026-01-01 00:00:00", "testdb", "orders", "id", 1, "PRI", "int", "NO")
+	testutil.InsertSnapshot(t, db, 1, "2026-01-01 00:00:00", "testdb", "orders", "amount", 2, "", "decimal", "YES")
+	idx := indexer.New(db, 10)
+
+	events := make(chan parser.Event, 10)
+	events <- parser.Event{BinlogFile: "binlog.000001", EndPos: 100, GTID: gtid, EventType: parser.EventGTID}
+	events <- parser.Event{BinlogFile: "binlog.000001", StartPos: 100, EndPos: 200, Timestamp: time.Now().UTC(),
+		GTID: gtid, Schema: "testdb", Table: "orders", EventType: parser.EventInsert,
+		PKValues: "1", RowAfter: map[string]any{"id": int64(1), "amount": 9.99}}
+	events <- parser.Event{BinlogFile: "binlog.000001", EndPos: 250, GTID: gtid, EventType: parser.EventCommit}
+	close(events)
+
+	state := &streamState{mode: "position", serverID: 1} // accGTID nil
+	if err := streamLoop(context.Background(), events, idx, db, time.Hour, state, observe.ForSource("test"), nil); err != nil {
+		t.Fatalf("streamLoop: %v", err)
+	}
+
+	loaded, err := loadStreamState(db)
+	if err != nil || loaded == nil {
+		t.Fatalf("loadStreamState err=%v nil=%v", err, loaded == nil)
+	}
+	if loaded.gtidSet != "" {
+		t.Errorf("position mode must not persist a gtid_set, got %q", loaded.gtidSet)
+	}
+	if loaded.binlogPos != 250 {
+		t.Errorf("binlogPos must land on the commit boundary (250), got %d", loaded.binlogPos)
+	}
+	var count int
+	if err := db.QueryRow("SELECT COUNT(*) FROM binlog_events").Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("the row must be indexed, got %d", count)
+	}
+}
+
 // setGTIDMode transitions @@GLOBAL.gtid_mode through the required permissive
 // steps. Returns an error so callers can skip when privileges/state don't allow.
 func setGTIDMode(db *sql.DB, on bool) error {
@@ -636,9 +680,25 @@ func TestStreamLoop_gtidAdvancesOnCommit_live(t *testing.T) {
 	hostStr, portStr, _ := net.SplitHostPort(mc.Addr)
 	portN, _ := strconv.ParseUint(portStr, 10, 16)
 
-	// Each autocommit INSERT is its own GTID transaction (GTID + BEGIN + row + XID).
-	for i := range 3 {
-		testutil.MustExec(t, sourceDB, "INSERT INTO orders (amount) VALUES (?)", float64(i+1)*10.0)
+	// Capture the source's executed set at the stream-start position so we can
+	// assert the stream accumulated exactly the transactions that follow.
+	var gtidBefore string
+	if err := sourceDB.QueryRow("SELECT @@GLOBAL.gtid_executed").Scan(&gtidBefore); err != nil {
+		t.Fatalf("gtid_executed (before): %v", err)
+	}
+
+	// Interleave an implicit-commit statement — ANALYZE TABLE logs a GTID + QUERY
+	// with NO XID and is not table DDL — between two autocommit INSERTs (GTID +
+	// BEGIN + row + XID). The ANALYZE's GTID can only land via the next-GTID
+	// fallback, so this is the end-to-end proof that the fallback works against a
+	// real binlog (#491).
+	testutil.MustExec(t, sourceDB, "INSERT INTO orders (amount) VALUES (10.0)")
+	testutil.MustExec(t, sourceDB, "ANALYZE TABLE orders")
+	testutil.MustExec(t, sourceDB, "INSERT INTO orders (amount) VALUES (20.0)")
+
+	var gtidAfter string
+	if err := sourceDB.QueryRow("SELECT @@GLOBAL.gtid_executed").Scan(&gtidAfter); err != nil {
+		t.Fatalf("gtid_executed (after): %v", err)
 	}
 
 	syncer := replication.NewBinlogSyncer(replication.BinlogSyncerConfig{
@@ -683,11 +743,32 @@ func TestStreamLoop_gtidAdvancesOnCommit_live(t *testing.T) {
 	if err != nil || loaded == nil {
 		t.Fatalf("loadStreamState err=%v nil=%v", err, loaded == nil)
 	}
-	// The gtid_set advanced only because the parser emitted EventCommit at each
-	// XID and streamLoop applied it — the end-to-end #491 contract.
+	// The streamed checkpoint must cover every transaction the source executed in
+	// the window — INSERT (XID), ANALYZE (next-GTID fallback), INSERT (XID). If the
+	// fallback regressed, the ANALYZE's GTID would be missing and the source's
+	// executed set would NOT be fully covered. (Concurrent transactions on the
+	// shared server only ADD GTIDs to the streamed set, so Contain stays robust.)
 	if !strings.Contains(loaded.gtidSet, serverUUID) {
-		t.Errorf("gtid_set must contain the source UUID %q after committed transactions, got %q",
-			serverUUID, loaded.gtidSet)
+		t.Fatalf("gtid_set must contain the source UUID %q, got %q", serverUUID, loaded.gtidSet)
+	}
+	afterSet, err := gomysql.ParseMysqlGTIDSet(NormalizeGTIDSet(gtidAfter))
+	if err != nil {
+		t.Fatalf("parse gtid_executed (after) %q: %v", gtidAfter, err)
+	}
+	parts := make([]string, 0, 2)
+	if gtidBefore != "" {
+		parts = append(parts, gtidBefore)
+	}
+	if loaded.gtidSet != "" {
+		parts = append(parts, loaded.gtidSet)
+	}
+	combined, err := gomysql.ParseMysqlGTIDSet(NormalizeGTIDSet(strings.Join(parts, ",")))
+	if err != nil {
+		t.Fatalf("parse combined set: %v", err)
+	}
+	if !combined.Contain(afterSet) {
+		t.Errorf("fallback regression: the source's executed set is not fully covered by the streamed checkpoint — the ANALYZE's GTID is missing.\n  before=%q\n  after=%q\n  loaded=%q",
+			gtidBefore, gtidAfter, loaded.gtidSet)
 	}
 }
 

--- a/internal/streamrun/streamrun_integration_test.go
+++ b/internal/streamrun/streamrun_integration_test.go
@@ -444,6 +444,211 @@ func TestStreamLoop_contextCancel(t *testing.T) {
 
 // TestStreamLoop_tickerCheckpoint verifies that the periodic ticker fires a
 // checkpoint even when the events channel stays open and receives no further events.
+// TestStreamLoop_gtidCheckpointAtCommit verifies #491: in GTID mode the durable
+// gtid_set is advanced ONLY at a transaction commit boundary (EventCommit), never
+// at the leading EventGTID. A checkpoint that fires mid-transaction must not claim
+// the in-flight transaction — otherwise a restart (GTID auto-position) would skip
+// it and lose data. The row itself must still be indexed (at-least-once).
+func TestStreamLoop_gtidCheckpointAtCommit(t *testing.T) {
+	const gtid = "11111111-1111-1111-1111-111111111111:1"
+	const uuid = "11111111-1111-1111-1111-111111111111"
+
+	newGTIDState := func(t *testing.T) *streamState {
+		gs, err := gomysql.ParseMysqlGTIDSet("")
+		if err != nil {
+			t.Fatalf("ParseMysqlGTIDSet: %v", err)
+		}
+		return &streamState{mode: "gtid", serverID: 1, accGTID: gs.(*gomysql.MysqlGTIDSet)}
+	}
+	setupIdx := func(t *testing.T) (*indexer.Indexer, *sql.DB) {
+		db, _ := testutil.CreateTestDB(t)
+		testutil.InitIndexTables(t, db)
+		testutil.InsertSnapshot(t, db, 1, "2026-01-01 00:00:00", "testdb", "orders", "id", 1, "PRI", "int", "NO")
+		testutil.InsertSnapshot(t, db, 1, "2026-01-01 00:00:00", "testdb", "orders", "amount", 2, "", "decimal", "YES")
+		return indexer.New(db, 10), db
+	}
+	insertEvent := parser.Event{
+		BinlogFile: "binlog.000001", StartPos: 100, EndPos: 200,
+		Timestamp: time.Now().UTC(), GTID: gtid,
+		Schema: "testdb", Table: "orders", EventType: parser.EventInsert,
+		PKValues: "1", RowAfter: map[string]any{"id": int64(1), "amount": 9.99},
+	}
+
+	// Scenario A: GTID + row, then checkpoint (channel close) BEFORE the commit.
+	// The GTID must NOT be persisted, but the row must be indexed.
+	t.Run("mid-transaction checkpoint does not claim the GTID", func(t *testing.T) {
+		idx, db := setupIdx(t)
+		events := make(chan parser.Event, 10)
+		events <- parser.Event{BinlogFile: "binlog.000001", EndPos: 100, GTID: gtid, EventType: parser.EventGTID}
+		events <- insertEvent
+		close(events) // → checkpoint() fires mid-transaction
+
+		state := newGTIDState(t)
+		if err := streamLoop(context.Background(), events, idx, db, time.Hour, state, observe.ForSource("test"), nil); err != nil {
+			t.Fatalf("streamLoop: %v", err)
+		}
+
+		loaded, err := loadStreamState(db)
+		if err != nil || loaded == nil {
+			t.Fatalf("loadStreamState err=%v nil=%v", err, loaded == nil)
+		}
+		if strings.Contains(loaded.gtidSet, uuid) {
+			t.Errorf("gtid_set must NOT contain the uncommitted GTID, got %q", loaded.gtidSet)
+		}
+		var count int
+		if err := db.QueryRow("SELECT COUNT(*) FROM binlog_events").Scan(&count); err != nil {
+			t.Fatalf("count: %v", err)
+		}
+		if count != 1 {
+			t.Errorf("the row must still be indexed (no loss): want 1, got %d", count)
+		}
+	})
+
+	// Scenario B: GTID + row + COMMIT, then checkpoint. The GTID must be persisted.
+	t.Run("committed transaction advances the GTID", func(t *testing.T) {
+		idx, db := setupIdx(t)
+		events := make(chan parser.Event, 10)
+		events <- parser.Event{BinlogFile: "binlog.000001", EndPos: 100, GTID: gtid, EventType: parser.EventGTID}
+		events <- insertEvent
+		events <- parser.Event{BinlogFile: "binlog.000001", EndPos: 250, GTID: gtid, EventType: parser.EventCommit}
+		close(events)
+
+		state := newGTIDState(t)
+		if err := streamLoop(context.Background(), events, idx, db, time.Hour, state, observe.ForSource("test"), nil); err != nil {
+			t.Fatalf("streamLoop: %v", err)
+		}
+
+		loaded, err := loadStreamState(db)
+		if err != nil || loaded == nil {
+			t.Fatalf("loadStreamState err=%v nil=%v", err, loaded == nil)
+		}
+		if !strings.Contains(loaded.gtidSet, uuid) {
+			t.Errorf("gtid_set must contain the committed GTID, got %q", loaded.gtidSet)
+		}
+	})
+}
+
+// setGTIDMode transitions @@GLOBAL.gtid_mode through the required permissive
+// steps. Returns an error so callers can skip when privileges/state don't allow.
+func setGTIDMode(db *sql.DB, on bool) error {
+	stmts := []string{
+		"SET @@GLOBAL.enforce_gtid_consistency = ON",
+		"SET @@GLOBAL.gtid_mode = OFF_PERMISSIVE",
+		"SET @@GLOBAL.gtid_mode = ON_PERMISSIVE",
+		"SET @@GLOBAL.gtid_mode = ON",
+	}
+	if !on {
+		stmts = []string{
+			"SET @@GLOBAL.gtid_mode = ON_PERMISSIVE",
+			"SET @@GLOBAL.gtid_mode = OFF_PERMISSIVE",
+			"SET @@GLOBAL.gtid_mode = OFF",
+			"SET @@GLOBAL.enforce_gtid_consistency = OFF",
+		}
+	}
+	for _, s := range stmts {
+		if _, err := db.Exec(s); err != nil {
+			return fmt.Errorf("%s: %w", s, err)
+		}
+	}
+	return nil
+}
+
+// TestStreamLoop_gtidAdvancesOnCommit_live is the end-to-end proof of #491: with
+// a GTID-enabled source, the StreamParser must emit EventCommit at each XID, and
+// streamLoop must advance the durable gtid_set off those commits. It toggles the
+// server's gtid_mode (restored in cleanup) and skips if that isn't possible.
+func TestStreamLoop_gtidAdvancesOnCommit_live(t *testing.T) {
+	sourceDB, sourceName := testutil.CreateTestDB(t)
+	indexDB, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, indexDB)
+
+	if err := setGTIDMode(sourceDB, true); err != nil {
+		t.Skipf("skipping: cannot enable gtid_mode on the test server: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := setGTIDMode(sourceDB, false); err != nil {
+			t.Logf("warning: failed to restore gtid_mode=OFF: %v", err)
+		}
+	})
+
+	var serverUUID string
+	if err := sourceDB.QueryRow("SELECT @@server_uuid").Scan(&serverUUID); err != nil {
+		t.Fatalf("server_uuid: %v", err)
+	}
+
+	testutil.MustExec(t, sourceDB, `CREATE TABLE orders (
+		id INT PRIMARY KEY AUTO_INCREMENT, amount DECIMAL(10,2) NOT NULL)`)
+	if _, err := metadata.TakeSnapshot(sourceDB, indexDB, []string{sourceName}); err != nil {
+		t.Fatalf("TakeSnapshot: %v", err)
+	}
+
+	binlogFile, binlogPos, err := config.CurrentBinlogPosition(sourceDB)
+	if err != nil {
+		t.Fatalf("CurrentBinlogPosition: %v", err)
+	}
+
+	mc, err := drivermysql.ParseDSN(testutil.IntegrationDSN(sourceName))
+	if err != nil {
+		t.Fatalf("ParseDSN: %v", err)
+	}
+	hostStr, portStr, _ := net.SplitHostPort(mc.Addr)
+	portN, _ := strconv.ParseUint(portStr, 10, 16)
+
+	// Each autocommit INSERT is its own GTID transaction (GTID + BEGIN + row + XID).
+	for i := range 3 {
+		testutil.MustExec(t, sourceDB, "INSERT INTO orders (amount) VALUES (?)", float64(i+1)*10.0)
+	}
+
+	syncer := replication.NewBinlogSyncer(replication.BinlogSyncerConfig{
+		ServerID: 99997, Flavor: "mysql",
+		Host: hostStr, Port: uint16(portN), User: mc.User, Password: mc.Passwd,
+	})
+	defer syncer.Close()
+
+	streamer, syncErr := syncer.StartSync(gomysql.Position{Name: binlogFile, Pos: binlogPos})
+	if syncErr != nil {
+		t.Skipf("skipping: StartSync failed: %v", syncErr)
+	}
+
+	resolver, err := metadata.NewResolver(indexDB, 0)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+	sp := parser.NewStreamParser(resolver, parser.Filters{Schemas: map[string]bool{sourceName: true}}, nil)
+	idx := indexer.New(indexDB, 100)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	events := make(chan parser.Event, 100)
+	parseErrCh := make(chan error, 1)
+	go func() {
+		defer close(events)
+		parseErrCh <- sp.Run(ctx, streamer, events)
+	}()
+
+	gs, _ := gomysql.ParseMysqlGTIDSet("")
+	state := &streamState{mode: "gtid", serverID: 99997, accGTID: gs.(*gomysql.MysqlGTIDSet)}
+	if err := streamLoop(ctx, events, idx, indexDB, time.Minute, state, observe.ForSource("test"), nil); err != nil {
+		t.Fatalf("streamLoop: %v", err)
+	}
+	if perr := <-parseErrCh; perr != nil &&
+		!errors.Is(perr, context.DeadlineExceeded) && !errors.Is(perr, context.Canceled) {
+		t.Fatalf("StreamParser error: %v", perr)
+	}
+
+	loaded, err := loadStreamState(indexDB)
+	if err != nil || loaded == nil {
+		t.Fatalf("loadStreamState err=%v nil=%v", err, loaded == nil)
+	}
+	// The gtid_set advanced only because the parser emitted EventCommit at each
+	// XID and streamLoop applied it — the end-to-end #491 contract.
+	if !strings.Contains(loaded.gtidSet, serverUUID) {
+		t.Errorf("gtid_set must contain the source UUID %q after committed transactions, got %q",
+			serverUUID, loaded.gtidSet)
+	}
+}
+
 func TestStreamLoop_tickerCheckpoint(t *testing.T) {
 	db, _ := testutil.CreateTestDB(t)
 	testutil.InitIndexTables(t, db)
@@ -621,22 +826,27 @@ func TestStreamLoop_gtidAccumulation(t *testing.T) {
 	}
 
 	ts := time.Now().UTC()
-	events := make(chan parser.Event, 10)
+	events := make(chan parser.Event, 16)
 
-	// Events carry consecutive GTIDs — the loop should accumulate them.
+	// Three transactions, each GTID start → row → COMMIT. GTIDs accumulate at the
+	// commit boundary (#491), not on the row event — so each EventCommit advances
+	// the set: uuid:1 (seed) + 2,3,4 → uuid:1-4.
 	for i, gno := range []int64{2, 3, 4} {
+		g := fmt.Sprintf("%s:%d", uuid, gno)
+		events <- parser.Event{BinlogFile: "binlog.000001", EndPos: uint64(i*100 + 10), GTID: g, EventType: parser.EventGTID}
 		events <- parser.Event{
 			BinlogFile: "binlog.000001",
 			StartPos:   uint64(i * 100),
 			EndPos:     uint64((i + 1) * 100),
 			Timestamp:  ts,
-			GTID:       fmt.Sprintf("%s:%d", uuid, gno),
+			GTID:       g,
 			Schema:     "testdb",
 			Table:      "orders",
 			EventType:  parser.EventInsert,
 			PKValues:   strconv.Itoa(i + 1),
 			RowAfter:   map[string]any{"id": int64(i + 1)},
 		}
+		events <- parser.Event{BinlogFile: "binlog.000001", EndPos: uint64((i+1)*100 + 10), GTID: g, EventType: parser.EventCommit}
 	}
 	close(events)
 

--- a/internal/streamrun/streamrun_integration_test.go
+++ b/internal/streamrun/streamrun_integration_test.go
@@ -526,6 +526,38 @@ func TestStreamLoop_gtidCheckpointAtCommit(t *testing.T) {
 			t.Errorf("gtid_set must contain the committed GTID, got %q", loaded.gtidSet)
 		}
 	})
+
+	// Scenario C: a DDL auto-commits its own GTID (no XID). EventDDL must flush
+	// pending rows AND advance the GTID — the only path that claims a DDL's GTID.
+	t.Run("DDL advances the GTID and flushes prior rows", func(t *testing.T) {
+		idx, db := setupIdx(t)
+		events := make(chan parser.Event, 10)
+		events <- parser.Event{BinlogFile: "binlog.000001", EndPos: 100, GTID: gtid, EventType: parser.EventGTID}
+		events <- insertEvent
+		events <- parser.Event{BinlogFile: "binlog.000001", EndPos: 300, GTID: gtid, EventType: parser.EventDDL,
+			Schema: "testdb", Table: "orders", DDLType: parser.DDLAlterTable, DDLQuery: "ALTER TABLE orders ADD c INT"}
+		close(events)
+
+		state := newGTIDState(t)
+		if err := streamLoop(context.Background(), events, idx, db, time.Hour, state, observe.ForSource("test"), nil); err != nil {
+			t.Fatalf("streamLoop: %v", err)
+		}
+
+		loaded, err := loadStreamState(db)
+		if err != nil || loaded == nil {
+			t.Fatalf("loadStreamState err=%v nil=%v", err, loaded == nil)
+		}
+		if !strings.Contains(loaded.gtidSet, uuid) {
+			t.Errorf("DDL must advance the GTID, got %q", loaded.gtidSet)
+		}
+		var count int
+		if err := db.QueryRow("SELECT COUNT(*) FROM binlog_events").Scan(&count); err != nil {
+			t.Fatalf("count: %v", err)
+		}
+		if count != 1 {
+			t.Errorf("the pre-DDL row must be flushed before the GTID advances: want 1, got %d", count)
+		}
+	})
 }
 
 // setGTIDMode transitions @@GLOBAL.gtid_mode through the required permissive
@@ -562,14 +594,24 @@ func TestStreamLoop_gtidAdvancesOnCommit_live(t *testing.T) {
 	indexDB, _ := testutil.CreateTestDB(t)
 	testutil.InitIndexTables(t, indexDB)
 
-	if err := setGTIDMode(sourceDB, true); err != nil {
-		t.Skipf("skipping: cannot enable gtid_mode on the test server: %v", err)
-	}
+	// Register restore BEFORE attempting the transition, so a partial enable that
+	// leaves gtid_mode in a permissive state is still undone (a leaked gtid_mode
+	// would silently break every other test on the shared server). Skip the
+	// down-sequence when already OFF (enable never progressed) — OFF→ON_PERMISSIVE
+	// is itself an invalid jump.
 	t.Cleanup(func() {
+		var mode string
+		if err := sourceDB.QueryRow("SELECT @@GLOBAL.gtid_mode").Scan(&mode); err == nil && mode == "OFF" {
+			_, _ = sourceDB.Exec("SET @@GLOBAL.enforce_gtid_consistency = OFF")
+			return
+		}
 		if err := setGTIDMode(sourceDB, false); err != nil {
 			t.Logf("warning: failed to restore gtid_mode=OFF: %v", err)
 		}
 	})
+	if err := setGTIDMode(sourceDB, true); err != nil {
+		t.Skipf("skipping: cannot enable gtid_mode on the test server: %v", err)
+	}
 
 	var serverUUID string
 	if err := sourceDB.QueryRow("SELECT @@server_uuid").Scan(&serverUUID); err != nil {


### PR DESCRIPTION
closes #491

## Summary
- **Bug:** in GTID mode, `accGTID` was updated on every event including the leading `EventGTID` (transaction **start**). A checkpoint firing mid-transaction persisted a GTID for a not-yet-fully-indexed transaction → on restart, GTID auto-position made MySQL **skip** it → silent data loss. No `XID_EVENT` (commit) boundary was processed.
- **Fix:** the `StreamParser` now emits a new `EventCommit` at each `XID_EVENT` (and at a `COMMIT` `QUERY_EVENT`), and `streamLoop` advances the durable GTID set **only** at commit boundaries (`EventCommit`, and `EventDDL` which auto-commits). The leading `EventGTID` is attribution-only.
- **Semantics:** converts the stream from *silently losing data* to **at-least-once** — no loss; an ungraceful crash may re-stream a not-yet-checkpointed transaction (duplicate rows), strictly better than loss. Exactly-once (atomic flush+checkpoint) is tracked separately (follow-up).
- Position mode is unchanged (`accGTID` nil; `EventCommit` is a no-op there and is only emitted for GTID-bearing sources). The agent BYOS loop skips `EventCommit` like other non-row events.

## Files
- `internal/parser/parser.go` — new `EventCommit` event type.
- `internal/parser/stream.go` — `emitCommit` on `XIDEvent` / `COMMIT` query.
- `internal/streamrun/streamrun.go` — `advanceGTID` closure; accumulate at commit boundaries only.
- `cmd/bintrail/agent.go` — skip `EventCommit`.

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`, 28 pkgs)
- [x] `TestStreamLoop_gtidCheckpointAtCommit` (deterministic): a mid-transaction checkpoint does **not** persist the GTID and the row **is** indexed (no loss); a committed transaction **does** advance it.
- [x] `TestStreamLoop_gtidAdvancesOnCommit_live` (end-to-end): with `gtid_mode` enabled (toggled + restored), the parser emits `EventCommit` and `streamLoop` advances `gtid_set` to contain the source UUID.
- [x] Updated `TestStreamLoop_gtidAccumulation` to the commit-boundary semantics.
- [x] `internal/streamrun` + `internal/parser` + `cmd/bintrail` integration + E2E pass; `go vet -tags integration ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)