### PR TITLE
baseline: parse every row of multi-line mydumper INSERTs (fix #495 silent data loss)

### DIFF
--- a/internal/baseline/baseline_test.go
+++ b/internal/baseline/baseline_test.go
@@ -544,6 +544,133 @@ func TestReadSQLRowUnterminated(t *testing.T) {
 	}
 }
 
+func TestReadSQLRowMultiLineInsert(t *testing.T) {
+	// mydumper >= 1.0 emits one tuple per physical line with a leading comma.
+	// The old line-oriented parser captured only the first tuple of each
+	// INSERT and silently dropped every continuation row — issue #495. This
+	// asserts every row of a multi-line, multi-statement dump is returned.
+	const sqlData = "INSERT INTO `orders` (`id`,`name`) VALUES(1,'a')\n" +
+		",(2,'b')\n" +
+		",(3,'c')\n" +
+		",(4,'d');\n" +
+		"INSERT INTO `orders` (`id`,`name`) VALUES(5,'e')\n" +
+		",(6,'f');\n"
+	dir := t.TempDir()
+	path := filepath.Join(dir, "shop.orders.00000.sql")
+	if err := os.WriteFile(path, []byte(sqlData), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var rows [][]string
+	if err := ReadSQLFile(path, func(values []string, nulls []bool) error {
+		rows = append(rows, append([]string(nil), values...))
+		return nil
+	}); err != nil {
+		t.Fatalf("ReadSQLFile: %v", err)
+	}
+	// Two statements carrying 4 + 2 = 6 tuples total.
+	if len(rows) != 6 {
+		t.Fatalf("got %d rows, want 6 (multi-line continuation rows were dropped)", len(rows))
+	}
+	for i, want := range []string{"1", "2", "3", "4", "5", "6"} {
+		if rows[i][0] != want {
+			t.Errorf("row %d id = %q, want %q", i, rows[i][0], want)
+		}
+	}
+	// Spot-check continuation-row values, not just ids.
+	if rows[3][1] != "d" || rows[5][1] != "f" {
+		t.Errorf("continuation values wrong: row3=%v row5=%v", rows[3], rows[5])
+	}
+}
+
+func TestReadSQLRowMultiLineLayouts(t *testing.T) {
+	// Every comma/terminator placement mydumper variants emit must yield the
+	// same three rows.
+	layouts := map[string]string{
+		"leading-comma":      "INSERT INTO t VALUES(1)\n,(2)\n,(3);\n",
+		"trailing-comma":     "INSERT INTO t VALUES(1),\n(2),\n(3);\n",
+		"semicolon-own-line": "INSERT INTO t VALUES(1)\n,(2)\n,(3)\n;\n",
+		"values-then-tuples": "INSERT INTO t VALUES\n(1),\n(2),\n(3);\n",
+		"single-line":        "INSERT INTO t VALUES(1),(2),(3);\n",
+		"two-statements":     "INSERT INTO t VALUES(1);\nINSERT INTO t VALUES(2)\n,(3);\n",
+	}
+	for name, sql := range layouts {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "shop.t.00000.sql")
+			if err := os.WriteFile(path, []byte(sql), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			var ids []string
+			if err := ReadSQLFile(path, func(values []string, nulls []bool) error {
+				ids = append(ids, values[0])
+				return nil
+			}); err != nil {
+				t.Fatalf("ReadSQLFile: %v", err)
+			}
+			if got := strings.Join(ids, ","); got != "1,2,3" {
+				t.Errorf("ids = %q, want \"1,2,3\"", got)
+			}
+		})
+	}
+}
+
+func TestReadSQLRowUnexpectedToken(t *testing.T) {
+	// A stray token where a tuple or ';' is expected must surface as a loud
+	// error, not silently truncate the fragment. With cross-line state, a
+	// lenient skip would consume the FOLLOWING INSERT as a bogus continuation
+	// and drop its rows, while a later ';' clears inStatement so the EOF guard
+	// never fires — the exact silent-loss class #495 closes. Both review repros:
+	cases := map[string]string{
+		// stray token then a bare ';' line that would have hidden the loss
+		"junk-then-bare-semicolon": "INSERT INTO `t` VALUES(1) JUNK,(2)\n;\n",
+		// stray token desyncs, swallowing the next INSERT statement's rows
+		"junk-swallows-next-stmt": "INSERT INTO `t` VALUES(1) X\nINSERT INTO `t` VALUES(2)\n,(3);\n",
+	}
+	for name, sql := range cases {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "shop.t.00000.sql")
+			if err := os.WriteFile(path, []byte(sql), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			var count int
+			err := ReadSQLFile(path, func(values []string, nulls []bool) error {
+				count++
+				return nil
+			})
+			if err == nil {
+				t.Fatalf("expected error for unexpected token, got nil (parsed %d rows)", count)
+			}
+			if !strings.Contains(err.Error(), "unexpected token") {
+				t.Errorf("error = %v, want it to mention 'unexpected token'", err)
+			}
+		})
+	}
+}
+
+func TestReadSQLRowTruncated(t *testing.T) {
+	// A dump file that ends mid-statement (no terminating ';') is truncated.
+	// Fail loudly rather than silently return a short row count.
+	const sqlData = "INSERT INTO `orders` VALUES(1,'a')\n,(2,'b')\n,(3,'c')\n" // no ';'
+	dir := t.TempDir()
+	path := filepath.Join(dir, "shop.orders.00000.sql")
+	if err := os.WriteFile(path, []byte(sqlData), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var count int
+	err := ReadSQLFile(path, func(values []string, nulls []bool) error {
+		count++
+		return nil
+	})
+	if err == nil {
+		t.Fatalf("expected error for truncated (unterminated) INSERT, got nil (parsed %d rows)", count)
+	}
+	if !strings.Contains(err.Error(), "unterminated") {
+		t.Errorf("error = %v, want it to mention 'unterminated'", err)
+	}
+}
+
 // ─── DiscoverTables ───────────────────────────────────────────────────────────
 
 func TestDiscoverTables(t *testing.T) {

--- a/internal/baseline/reader_sql.go
+++ b/internal/baseline/reader_sql.go
@@ -8,7 +8,27 @@ import (
 )
 
 // ReadSQLFile reads a mydumper SQL (.sql) data file and calls fn for each row.
-// The file contains INSERT INTO `table` VALUES(...),(...),...; statements.
+//
+// Two INSERT layouts must be handled:
+//
+//	mysqldump-style, all tuples on one line:
+//	    INSERT INTO `t` VALUES (a),(b),(c);
+//
+//	mydumper >= 1.0, one tuple per physical line with a leading comma:
+//	    INSERT INTO `t` (...) VALUES(a)
+//	    ,(b)
+//	    ,(c);
+//
+// A naive line-oriented parser that only read the VALUES line would silently
+// drop every continuation row of the second layout — the catastrophic data
+// loss of issue #495. Instead this carries an "inside a not-yet-terminated
+// INSERT" state across lines: continuation lines are parsed as further tuples
+// until the ';' statement terminator is consumed.
+//
+// Splitting on physical lines is safe because mydumper escapes embedded
+// newlines inside string values as the two-character sequence `\n`, so a line
+// boundary always falls between tuples, never inside a quoted value.
+//
 // Values are returned as raw strings; NULL is returned as "" with nulls[i]=true.
 func ReadSQLFile(path string, fn func(values []string, nulls []bool) error) error {
 	f, err := os.Open(path)
@@ -20,53 +40,91 @@ func ReadSQLFile(path string, fn func(values []string, nulls []bool) error) erro
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 8<<20), 8<<20) // 8 MB per line
 	lineNum := 0
+	inStatement := false // inside an INSERT whose ';' terminator hasn't been seen
 	for scanner.Scan() {
 		lineNum++
-		line := scanner.Text()
-		trimmed := strings.TrimSpace(line)
-		if !strings.HasPrefix(strings.ToUpper(trimmed), "INSERT") {
+		trimmed := strings.TrimSpace(scanner.Text())
+		if trimmed == "" {
 			continue
 		}
-		// Find VALUES keyword
-		valIdx := strings.Index(strings.ToUpper(trimmed), " VALUES")
-		if valIdx < 0 {
-			continue
+
+		var fragment string
+		if inStatement {
+			// Continuation line of a multi-row INSERT: ",(...)" tuples, the
+			// last ending in ';'.
+			fragment = trimmed
+		} else {
+			if !strings.HasPrefix(strings.ToUpper(trimmed), "INSERT") {
+				continue
+			}
+			// Find VALUES keyword (after any column list).
+			valIdx := strings.Index(strings.ToUpper(trimmed), " VALUES")
+			if valIdx < 0 {
+				continue
+			}
+			fragment = strings.TrimSpace(trimmed[valIdx+7:])
 		}
-		valuesPart := strings.TrimSpace(trimmed[valIdx+7:])
-		// Parse all tuples from this line
-		if err := parseSQLTuples(valuesPart, fn); err != nil {
+
+		terminated, err := parseSQLTuples(fragment, fn)
+		if err != nil {
 			return fmt.Errorf("%s line %d: %w", path, lineNum, err)
 		}
+		inStatement = !terminated
 	}
-	return scanner.Err()
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	// A file that ends mid-statement (no ';') is truncated: fail loudly rather
+	// than report a silently short row count.
+	if inStatement {
+		return fmt.Errorf("%s: unterminated INSERT statement (missing ';') — dump file may be truncated", path)
+	}
+	return nil
 }
 
-// parseSQLTuples parses the values portion of an INSERT: "(v,v,...),(v,v,...);".
-func parseSQLTuples(s string, fn func(values []string, nulls []bool) error) error {
+// parseSQLTuples parses a fragment of an INSERT's values portion:
+// "(v,v,...),(v,v,...)" optionally ending with ";". A fragment is the part of
+// a single physical line that carries tuples — for a multi-line INSERT the same
+// statement is fed in across several calls. It returns terminated=true once it
+// consumes the ';' statement terminator, so ReadSQLFile knows the (possibly
+// multi-line) INSERT is complete.
+func parseSQLTuples(s string, fn func(values []string, nulls []bool) error) (bool, error) {
 	i := 0
 	for i < len(s) {
-		// Skip whitespace and commas between tuples
-		for i < len(s) && (s[i] == ' ' || s[i] == '\t' || s[i] == ',' || s[i] == ';') {
+		// Skip separators between tuples. NOT ';' — that is the statement
+		// terminator and must be detected, not skipped.
+		for i < len(s) && (s[i] == ' ' || s[i] == '\t' || s[i] == ',') {
 			i++
 		}
 		if i >= len(s) {
 			break
 		}
+		if s[i] == ';' {
+			return true, nil
+		}
 		if s[i] != '(' {
-			break
+			// An unexpected token where a tuple or terminator was expected means
+			// malformed or non-mydumper SQL. Fail loud: a lenient skip here would
+			// discard the rest of the fragment and — because inStatement now
+			// carries across lines — swallow the following statements as bogus
+			// continuations, silently dropping their rows. That is the exact
+			// silent-loss class #495 closes. (On valid mydumper output this is
+			// unreachable: after a tuple only ',', whitespace, or ';' appears,
+			// all consumed above.)
+			return false, fmt.Errorf("unexpected token %q at offset %d (expected '(' or ';')", s[i], i)
 		}
 		i++ // consume '('
 
 		values, nulls, end, err := parseTuple(s, i)
 		if err != nil {
-			return err
+			return false, err
 		}
 		i = end
 		if err := fn(values, nulls); err != nil {
-			return err
+			return false, err
 		}
 	}
-	return nil
+	return false, nil
 }
 
 // parseTuple parses a comma-separated list of SQL values starting at pos (after


### PR DESCRIPTION
closes #495

## Summary

`bintrail baseline` silently kept only the **first row of each multi-row `INSERT`** when converting a mydumper SQL dump. mydumper >= 1.0 emits one tuple per physical line:

```sql
INSERT INTO `orders` (...) VALUES(row1)
,(row2)
,(row3);
```

`ReadSQLFile` was line-oriented: for each line it required an `INSERT` prefix, found ` VALUES`, and parsed tuples **only from that one line**. The `,(rowN)` continuation lines don't start with `INSERT`, so they were skipped — a 1,000,000-row table produced a baseline with exactly one row per `INSERT` *statement* (159 in the report). Time-travel / `reconstruct` is built on the baseline, so this silently broke recovery while the command reported success.

## Fix

- **Stateful parse across lines** (`internal/baseline/reader_sql.go`): while inside a not-yet-terminated `INSERT`, continuation lines are parsed as further tuples until the `;` terminator is consumed. `parseSQLTuples` now returns `(terminated bool, err)` so `ReadSQLFile` knows when the (possibly multi-line) statement ends — this is exact regardless of where the `;` sits (own line, trailing a tuple, after whitespace), unlike a `HasSuffix(line, ";")` heuristic.
- Splitting on physical lines stays safe because mydumper escapes embedded newlines inside string values as the two chars `\n` (never a raw newline byte), so a line boundary always falls between tuples.
- **Fail loud on truncation**: a file that ends mid-statement (no `;`) now errors instead of reporting a silently short row count. This is defense-in-depth for genuine truncation — *not* the fix for #495 itself (the dropped rows came from terminated statements).

## Tests

New regression tests in `internal/baseline/baseline_test.go`, all **verified to fail on the pre-fix code**:
- `TestReadSQLRowMultiLineInsert` — the issue's exact format (2 statements × 4+2 tuples → 6 rows; old code returned 2).
- `TestReadSQLRowMultiLineLayouts` — leading-comma / trailing-comma / `;`-on-own-line / `VALUES`-then-tuples / single-line / two-statements all yield identical rows.
- `TestReadSQLRowTruncated` — unterminated file → error.

## Scope notes (from an adversarial probe of the parser)

- **Did NOT** implement the issue's suggested mydumper-metadata row-count cross-check: mydumper metadata has no reliable per-table count across versions, so a fail-on-mismatch would produce false failures. The parser fix + truncation detection address the silent-loss root cause directly.
- An adversarial sweep surfaced **separate, pre-existing** baseline-parser bugs unrelated to multi-row parsing — binary/`BLOB`/`BINARY(16)`/JSON columns are silently corrupted on default mydumper output (quote-blind value reader), and `REPLACE INTO` dumps are silently dropped. These are **out of scope here** and handled in a follow-up PR.
- The minor TSV `\N`-id fragility noted in the issue (the workaround path) is not addressed — not reproducible without the source data.

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] New regression tests proven to fail on pre-fix code
- [x] `gofmt` / `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)