### PR TITLE
fix: preserve integers >2^53 on the row-image read path (#496)

### DIFF
--- a/internal/metadata/enumlabel.go
+++ b/internal/metadata/enumlabel.go
@@ -2,7 +2,9 @@ package metadata
 
 import (
 	"database/sql"
+	"encoding/json"
 	"math"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -237,6 +239,16 @@ func (s *EnumMapperSource) memoized(key mapperKey, r *Resolver) *EnumLabelMapper
 // honest call.
 func ordinalValue(v any) (uint64, bool) {
 	switch n := v.(type) {
+	case json.Number:
+		// Row images decoded by query.UnmarshalRowImage keep numbers as
+		// json.Number (#496). Parse the exact integer literal — no 2^53 float
+		// limit, so SET masks using high bits resolve correctly. A negative,
+		// fractional, or out-of-range value fails ParseUint → pass-through.
+		u, err := strconv.ParseUint(n.String(), 10, 64)
+		if err != nil {
+			return 0, false
+		}
+		return u, true
 	case float64:
 		if n < 0 || n != math.Trunc(n) || n > 1<<53 {
 			return 0, false

--- a/internal/metadata/enumlabel_test.go
+++ b/internal/metadata/enumlabel_test.go
@@ -1,11 +1,30 @@
 package metadata
 
 import (
+	"encoding/json"
 	"errors"
 	"reflect"
 	"testing"
 	"time"
 )
+
+func TestOrdinalValue_jsonNumber(t *testing.T) {
+	// Row images decoded by query.UnmarshalRowImage carry numbers as json.Number
+	// (#496); ENUM/SET label resolution must still extract the ordinal.
+	if u, ok := ordinalValue(json.Number("3")); !ok || u != 3 {
+		t.Errorf("ordinalValue(json.Number(\"3\")) = (%d,%v), want (3,true)", u, ok)
+	}
+	// Full 64-bit range (a SET mask using a high bit) — no 2^53 float cap.
+	if u, ok := ordinalValue(json.Number("9223372036854775808")); !ok || u != 9223372036854775808 {
+		t.Errorf("ordinalValue(high-bit) = (%d,%v), want (9223372036854775808,true)", u, ok)
+	}
+	// Negative, fractional, and non-numeric → pass-through (!ok).
+	for _, bad := range []json.Number{"-1", "1.5", "abc"} {
+		if _, ok := ordinalValue(bad); ok {
+			t.Errorf("ordinalValue(json.Number(%q)) reported ok, want !ok", bad)
+		}
+	}
+}
 
 func TestParseEnumSetLabels(t *testing.T) {
 	tests := []struct {

--- a/internal/parquetquery/parquetquery.go
+++ b/internal/parquetquery/parquetquery.go
@@ -904,10 +904,10 @@ func scanRows(rows *sql.Rows) ([]query.ResultRow, error) {
 			_ = json.Unmarshal([]byte(changedCols.String), &r.ChangedColumns)
 		}
 		if rowBefore.Valid && rowBefore.String != "" {
-			_ = json.Unmarshal([]byte(rowBefore.String), &r.RowBefore)
+			r.RowBefore = query.UnmarshalRowImage([]byte(rowBefore.String))
 		}
 		if rowAfter.Valid && rowAfter.String != "" {
-			_ = json.Unmarshal([]byte(rowAfter.String), &r.RowAfter)
+			r.RowAfter = query.UnmarshalRowImage([]byte(rowAfter.String))
 		}
 		results = append(results, r)
 	}

--- a/internal/parquetquery/parquetquery_archive_integration_test.go
+++ b/internal/parquetquery/parquetquery_archive_integration_test.go
@@ -4,6 +4,7 @@ package parquetquery_test
 
 import (
 	"context"
+	"encoding/json"
 	"path/filepath"
 	"testing"
 
@@ -12,6 +13,41 @@ import (
 	"github.com/dbtrail/dbtrail/internal/query"
 	"github.com/dbtrail/dbtrail/internal/testutil"
 )
+
+// TestFetch_archivedLargeUnsignedExact verifies the archived-Parquet read path
+// preserves a BIGINT UNSIGNED > 2^63 exactly: the archive writer stores the raw
+// JSON bytes, and parquetquery.scanRows now decodes via query.UnmarshalRowImage
+// (json.Number), so the value survives the round-trip without float64 rounding
+// (#496). This is a SEPARATE scanRows from the live-MySQL path.
+func TestFetch_archivedLargeUnsignedExact(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	testutil.InsertEvent(t, db, "binlog.000001", 100, 200, "2026-02-19 14:00:00", nil,
+		"mydb", "counters", 1, "1",
+		nil, nil, []byte(`{"id":1,"big":18446744073709551615}`))
+
+	outPath := filepath.Join(t.TempDir(), "p_future.parquet")
+	if _, err := archive.ArchivePartition(context.Background(), db, dbName, "p_future", outPath, "none"); err != nil {
+		t.Fatalf("ArchivePartition failed: %v", err)
+	}
+
+	rows, err := parquetquery.Fetch(context.Background(),
+		query.Options{Schema: "mydb", Table: "counters", Limit: 100}, outPath)
+	if err != nil {
+		t.Fatalf("parquetquery.Fetch failed: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	n, ok := rows[0].RowAfter["big"].(json.Number)
+	if !ok {
+		t.Fatalf("big should decode to json.Number, got %T", rows[0].RowAfter["big"])
+	}
+	if n.String() != "18446744073709551615" {
+		t.Errorf("archived BIGINT UNSIGNED = %q, want exact 18446744073709551615", n.String())
+	}
+}
 
 // TestFetch_archivedNullBinlogFile closes the dbtrail/bintrail#318 loop
 // end-to-end: drift in the MySQL index → bintrail rotate writes Parquet

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -486,10 +486,11 @@ func scanRows(rows *sql.Rows) ([]ResultRow, error) {
 // encoding/json turns every JSON number into a float64, which silently rounds
 // integers above 2^53 (BIGINT UNSIGNED > 2^63, large signed BIGINT) — so recover
 // SQL and query/CSV output would emit the wrong value even though storage was
-// exact (#496). json.Number preserves the exact literal; recovery.FormatSQLValue
-// and metadata.ordinalValue handle it. Returns nil on empty input or a decode
-// error (matching the prior best-effort behavior — a malformed blob yields no row
-// image rather than aborting the scan).
+// exact (#496). json.Number preserves the exact literal; the downstream
+// formatters handle it (recovery.FormatSQLValue, metadata.ordinalValue, the
+// shim's resultsetValue/fullTableTextCell). Returns nil on empty input or a
+// decode error — still best-effort: a malformed blob yields no row image rather
+// than aborting the scan.
 func UnmarshalRowImage(data []byte) map[string]any {
 	if len(data) == 0 {
 		return nil

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -4,6 +4,7 @@
 package query
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/csv"
@@ -470,14 +471,36 @@ func scanRows(rows *sql.Rows) ([]ResultRow, error) {
 			_ = json.Unmarshal(changedCols, &r.ChangedColumns)
 		}
 		if rowBefore != nil {
-			_ = json.Unmarshal(rowBefore, &r.RowBefore)
+			r.RowBefore = UnmarshalRowImage(rowBefore)
 		}
 		if rowAfter != nil {
-			_ = json.Unmarshal(rowAfter, &r.RowAfter)
+			r.RowAfter = UnmarshalRowImage(rowAfter)
 		}
 		results = append(results, r)
 	}
 	return results, rows.Err()
+}
+
+// UnmarshalRowImage decodes a row_before/row_after JSON blob into a named map,
+// keeping numbers as json.Number rather than coercing them to float64. Default
+// encoding/json turns every JSON number into a float64, which silently rounds
+// integers above 2^53 (BIGINT UNSIGNED > 2^63, large signed BIGINT) — so recover
+// SQL and query/CSV output would emit the wrong value even though storage was
+// exact (#496). json.Number preserves the exact literal; recovery.FormatSQLValue
+// and metadata.ordinalValue handle it. Returns nil on empty input or a decode
+// error (matching the prior best-effort behavior — a malformed blob yields no row
+// image rather than aborting the scan).
+func UnmarshalRowImage(data []byte) map[string]any {
+	if len(data) == 0 {
+		return nil
+	}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	var m map[string]any
+	if err := dec.Decode(&m); err != nil {
+		return nil
+	}
+	return m
 }
 
 // ─── Formatters ───────────────────────────────────────────────────────────────

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -13,6 +13,31 @@ import (
 
 // ─── buildQuery ───────────────────────────────────────────────────────────────
 
+func TestUnmarshalRowImage_preservesLargeIntegers(t *testing.T) {
+	// A BIGINT UNSIGNED max stored in row JSON must survive the read exactly —
+	// default json.Unmarshal would coerce it to float64 and round it (#496).
+	m := UnmarshalRowImage([]byte(`{"big":18446744073709551615,"dec":3.14,"s":"x"}`))
+	n, ok := m["big"].(json.Number)
+	if !ok {
+		t.Fatalf("big should decode to json.Number, got %T", m["big"])
+	}
+	if n.String() != "18446744073709551615" {
+		t.Errorf("big = %q, want exact 18446744073709551615", n.String())
+	}
+	if d, ok := m["dec"].(json.Number); !ok || d.String() != "3.14" {
+		t.Errorf("dec = %#v, want json.Number 3.14", m["dec"])
+	}
+	if s, ok := m["s"].(string); !ok || s != "x" {
+		t.Errorf("s = %#v, want string \"x\"", m["s"])
+	}
+	// Best-effort: nil/empty/malformed input returns nil (no scan abort).
+	for _, in := range [][]byte{nil, []byte(""), []byte("{bad")} {
+		if got := UnmarshalRowImage(in); got != nil {
+			t.Errorf("UnmarshalRowImage(%q) = %#v, want nil", in, got)
+		}
+	}
+}
+
 func TestBuildQuery_noFilters(t *testing.T) {
 	opts := Options{Limit: 50}
 	q, args := buildQuery(opts)

--- a/internal/reconstruct/mydumper_writer_test.go
+++ b/internal/reconstruct/mydumper_writer_test.go
@@ -1,6 +1,7 @@
 package reconstruct
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -144,7 +145,7 @@ func TestMydumperWriter_rotateByChunkSize(t *testing.T) {
 // (JSON column).
 func TestMydumperWriter_valueTypeMatrix(t *testing.T) {
 	dir := t.TempDir()
-	cols := []string{"c_int", "c_text", "c_null", "c_double", "c_time", "c_blob", "c_json"}
+	cols := []string{"c_int", "c_text", "c_null", "c_double", "c_time", "c_blob", "c_json", "c_bigu"}
 	w, err := NewMydumperWriter(dir, "mydb", "mixed", cols, 0)
 	if err != nil {
 		t.Fatalf("NewMydumperWriter: %v", err)
@@ -159,6 +160,7 @@ func TestMydumperWriter_valueTypeMatrix(t *testing.T) {
 		ts,
 		[]byte{0xde, 0xad, 0xbe, 0xef},
 		map[string]any{"k": "v"},
+		json.Number("18446744073709551615"), // BIGINT UNSIGNED max from a binlog delta (#496)
 	}
 	if err := w.WriteRow(row); err != nil {
 		t.Fatalf("WriteRow: %v", err)
@@ -181,11 +183,17 @@ func TestMydumperWriter_valueTypeMatrix(t *testing.T) {
 		"'2026-04-11 14:30:45.500000'",   // time.Time
 		"X'deadbeef'",                    // []byte
 		`'{"k":"v"}'`,                    // map[string]any (JSON column)
+		"18446744073709551615",           // json.Number: bare numeric literal, exact
 	}
 	for _, want := range wants {
 		if !strings.Contains(content, want) {
 			t.Errorf("chunk missing %q, content:\n%s", want, content)
 		}
+	}
+	// The json.Number must be a bare numeric literal, not quoted (the quoted form
+	// is what a regression to the default string case would produce).
+	if strings.Contains(content, `'18446744073709551615'`) {
+		t.Errorf("json.Number must not be quoted as a string:\n%s", content)
 	}
 }
 

--- a/internal/recovery/recovery.go
+++ b/internal/recovery/recovery.go
@@ -298,15 +298,16 @@ func allColsWhere(row map[string]any) []string {
 // mydumper writer in internal/reconstruct, #187) can reuse the exact same
 // formatting and escaping.
 //
-// Binlog-event values arrive here after a JSON round-trip
-// (row_before/row_after are stored as JSON and unmarshalled into
-// map[string]any), so all numeric values are float64. Whole-number float64s
-// are formatted as integers; fractional ones as decimals.
+// Binlog-event values arrive here after a JSON round-trip — row_before/row_after
+// are decoded via query.UnmarshalRowImage, so numeric values are json.Number
+// (the exact literal, no float64 rounding — #496); the json.Number case emits
+// them verbatim.
 //
-// DuckDB's database/sql driver (used by the full-table reconstruct path)
-// returns int64 / time.Time / []byte natively — those cases are also handled
-// here so the same function formats both JSON-round-tripped values from
-// binlog events and direct DuckDB scan values from baseline Parquet rows.
+// DuckDB's database/sql driver (used by the full-table reconstruct path) returns
+// int64 / float64 / time.Time / []byte natively — those cases are also handled
+// here so the same function formats both JSON-round-tripped binlog values and
+// direct DuckDB scan values from baseline Parquet rows. The float64 case is now
+// reached only by DuckDB-origin DOUBLE/FLOAT columns, not binlog integers.
 func FormatSQLValue(v any) string {
 	if v == nil {
 		return "NULL"
@@ -338,8 +339,10 @@ func FormatSQLValue(v any) string {
 		return string(val)
 
 	case float64:
-		// Detect integer-valued floats (JSON round-trip converts int→float64).
-		// math.Abs guard prevents int64 overflow for very large floats.
+		// DuckDB-origin DOUBLE/FLOAT columns (baseline reconstruct path). Whole
+		// numbers are emitted as integers, fractional ones as decimals. Binlog
+		// integers no longer reach here — they arrive as json.Number, handled
+		// above. math.Abs guard prevents int64 overflow for very large floats.
 		if !math.IsInf(val, 0) && !math.IsNaN(val) &&
 			val == math.Trunc(val) && math.Abs(val) < 1e15 {
 			return strconv.FormatInt(int64(val), 10)

--- a/internal/recovery/recovery.go
+++ b/internal/recovery/recovery.go
@@ -329,6 +329,14 @@ func FormatSQLValue(v any) string {
 	case uint32:
 		return strconv.FormatUint(uint64(val), 10)
 
+	case json.Number:
+		// Row images read from binlog_events JSON come back as json.Number
+		// (query.UnmarshalRowImage uses UseNumber), preserving the exact literal.
+		// Emit it verbatim as a SQL numeric literal — integers above 2^53 survive
+		// instead of being rounded through float64 (#496). JSON number syntax is a
+		// valid SQL numeric literal (integer, decimal, or exponent).
+		return string(val)
+
 	case float64:
 		// Detect integer-valued floats (JSON round-trip converts int→float64).
 		// math.Abs guard prevents int64 overflow for very large floats.

--- a/internal/recovery/recovery_integration_test.go
+++ b/internal/recovery/recovery_integration_test.go
@@ -108,6 +108,40 @@ func TestGenerateSQL_updateReverse(t *testing.T) {
 	assertContains(t, out, "'shipped'")
 }
 
+func TestGenerateSQL_updateLargeUnsignedExact(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	// UPDATE reversal with a BIGINT UNSIGNED max in both images. With a nil
+	// resolver the value lands in BOTH the SET clause (from row_before) and the
+	// all-columns WHERE clause (from row_after) — both via FormatSQLValue — so one
+	// event locks the large value on both clauses (#496).
+	testutil.InsertEvent(t, db,
+		"binlog.000001", 100, 200, "2026-02-19 14:00:00", nil,
+		"mydb", "counters", 2, "1",
+		[]byte(`["n"]`),
+		[]byte(`{"id":1,"big":18446744073709551615,"n":1}`),
+		[]byte(`{"id":1,"big":18446744073709551615,"n":2}`),
+	)
+
+	g := New(db, nil)
+	var buf bytes.Buffer
+	if _, err := g.GenerateSQL(context.Background(), query.Options{
+		Schema: "mydb", Table: "counters", Limit: 100,
+	}, &buf); err != nil {
+		t.Fatalf("GenerateSQL failed: %v", err)
+	}
+	out := buf.String()
+	assertContains(t, out, "UPDATE")
+	// Must appear exactly (SET and WHERE), never rounded to ...616.
+	if strings.Count(out, "18446744073709551615") < 2 {
+		t.Errorf("expected the exact BIGINT UNSIGNED value in SET and WHERE:\n%s", out)
+	}
+	if strings.Contains(out, "18446744073709551616") {
+		t.Errorf("BIGINT UNSIGNED was rounded through float64:\n%s", out)
+	}
+}
+
 func TestGenerateSQL_insertToDelete(t *testing.T) {
 	db, _ := testutil.CreateTestDB(t)
 	testutil.InitIndexTables(t, db)

--- a/internal/recovery/recovery_integration_test.go
+++ b/internal/recovery/recovery_integration_test.go
@@ -46,6 +46,35 @@ func TestGenerateSQL_deleteToInsert(t *testing.T) {
 	assertContains(t, out, "COMMIT;")
 }
 
+func TestGenerateSQL_largeUnsignedBigintExact(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	// DELETE whose before-image holds a BIGINT UNSIGNED max value. Reversing it
+	// emits an INSERT; the value must appear EXACTLY, not rounded through float64
+	// — this completes the #490 unsigned fix end-to-end through recover (#496).
+	testutil.InsertEvent(t, db,
+		"binlog.000001", 100, 200, "2026-02-19 14:00:00", nil,
+		"mydb", "counters", 3, "1",
+		nil,
+		[]byte(`{"id":1,"big":18446744073709551615}`),
+		nil,
+	)
+
+	g := New(db, nil)
+	var buf bytes.Buffer
+	if _, err := g.GenerateSQL(context.Background(), query.Options{
+		Schema: "mydb", Table: "counters", Limit: 100,
+	}, &buf); err != nil {
+		t.Fatalf("GenerateSQL failed: %v", err)
+	}
+	out := buf.String()
+	assertContains(t, out, "18446744073709551615")
+	if strings.Contains(out, "18446744073709551616") {
+		t.Errorf("BIGINT UNSIGNED max was rounded through float64 (got ...616):\n%s", out)
+	}
+}
+
 func TestGenerateSQL_updateReverse(t *testing.T) {
 	db, _ := testutil.CreateTestDB(t)
 	testutil.InitIndexTables(t, db)

--- a/internal/recovery/recovery_test.go
+++ b/internal/recovery/recovery_test.go
@@ -38,6 +38,29 @@ func TestFormatValue_boolFalse(t *testing.T) {
 	}
 }
 
+func TestFormatSQLValue_jsonNumber(t *testing.T) {
+	// Row images now come back as json.Number (query.UnmarshalRowImage), so large
+	// integers survive exactly instead of rounding through float64 (#496).
+	cases := []struct{ in, want string }{
+		{"18446744073709551615", "18446744073709551615"}, // BIGINT UNSIGNED max
+		{"9223372036854775807", "9223372036854775807"},   // BIGINT signed max
+		{"-9223372036854775808", "-9223372036854775808"}, // BIGINT signed min
+		{"1000000000000000007", "1000000000000000007"},   // > 2^53: float64 would round
+		{"3.14", "3.14"},                                 // decimal preserved verbatim
+		{"0", "0"},
+	}
+	for _, c := range cases {
+		if got := FormatSQLValue(json.Number(c.in)); got != c.want {
+			t.Errorf("FormatSQLValue(json.Number(%q)) = %q, want %q", c.in, got, c.want)
+		}
+	}
+	// Contrast: the float64 path silently rounds the same large value — this is
+	// exactly why the JSON read path must use json.Number.
+	if got := FormatSQLValue(float64(1000000000000000007)); got == "1000000000000000007" {
+		t.Errorf("float64 path unexpectedly exact for >2^53 (%q) — json.Number is required", got)
+	}
+}
+
 func TestFormatValue_integerFloat(t *testing.T) {
 	// JSON round-trip turns int64(12345) into float64(12345).
 	got := FormatSQLValue(float64(12345))

--- a/internal/shim/handler.go
+++ b/internal/shim/handler.go
@@ -1183,27 +1183,45 @@ func marshalImageOrdered(image map[string]any, ddlOrder []string) string {
 // ddlOrder=nil signals "no snapshot available"; in that case we
 // fall back to alphabetical key order, which is deterministic but
 // won't match the table's natural DDL order.
-// resultsetValue converts a row-image cell into a type go-mysql's resultset
-// builder accepts. Row images decoded by query.UnmarshalRowImage carry numbers
-// as json.Number (#496), which BuildSimpleTextResultset rejects. Map it to the
-// narrowest exact numeric type — int64, or uint64 for a BIGINT UNSIGNED above
-// 2^63 — so large integers render exactly; fall back to float64 for fractional
-// values and the literal string for anything out of numeric range.
-func resultsetValue(v any) any {
-	n, ok := v.(json.Number)
-	if !ok {
-		return v
-	}
+// numberToText renders a JSON-decoded numeric row-image value (#496) to the
+// SAME wire bytes go-mysql's FormatTextValue produces for the equivalent native
+// value. Two reasons it must pre-render to []byte rather than return a numeric:
+//   - BuildSimpleTextResultset fixes a column's wire type from its first row and
+//     rejects later rows of a different Go type ("row types aren't consistent").
+//     Returning int64 for an integral DOUBLE and float64 for a fractional one in
+//     the same column would crash the whole _flashback full-table query. A
+//     uniform []byte makes every such column VAR_STRING.
+//   - In the full-table _snapshot merge, baseline-origin cells (DuckDB-native,
+//     rendered via FormatTextValue) and event-origin cells must emit identical
+//     bytes; routing both through FormatTextValue guarantees that (a raw
+//     json.Number literal would diverge, e.g. "1e+21" vs "1000…0").
+// The exact numeric type is recovered first so a BIGINT UNSIGNED > 2^63 stays
+// exact (int64 → uint64 → float64), falling back to the literal text.
+func numberToText(n json.Number) []byte {
+	var v any
 	if i, err := n.Int64(); err == nil {
-		return i
+		v = i
+	} else if u, err := strconv.ParseUint(n.String(), 10, 64); err == nil {
+		v = u
+	} else if f, err := n.Float64(); err == nil {
+		v = f
+	} else {
+		return []byte(n.String())
 	}
-	if u, err := strconv.ParseUint(n.String(), 10, 64); err == nil {
-		return u
+	if b, err := mysql.FormatTextValue(v); err == nil {
+		return b
 	}
-	if f, err := n.Float64(); err == nil {
-		return f
+	return []byte(n.String())
+}
+
+// resultsetValue normalizes a row-image cell for BuildSimpleTextResultset. A
+// json.Number (#496) is pre-rendered to uniform text bytes via numberToText;
+// every other value passes through unchanged.
+func resultsetValue(v any) any {
+	if n, ok := v.(json.Number); ok {
+		return numberToText(n)
 	}
-	return n.String()
+	return v
 }
 
 func imageToResult(image map[string]any, ddlOrder []string) (*mysql.Result, error) {

--- a/internal/shim/handler.go
+++ b/internal/shim/handler.go
@@ -1172,17 +1172,6 @@ func marshalImageOrdered(image map[string]any, ddlOrder []string) string {
 	return sb.String()
 }
 
-// imageToResult turns a single-row JSON object into a mysql.Result
-// shaped for the wire protocol. Columns are emitted in ddlOrder
-// (the source table's column ordinal_position from the latest
-// schema_snapshots row) so a customer running
-// `SELECT * FROM _flashback.orders ...` gets the same column
-// ordering they'd get from a regular `SELECT * FROM orders` — no
-// surprising reshuffling between the two.
-//
-// ddlOrder=nil signals "no snapshot available"; in that case we
-// fall back to alphabetical key order, which is deterministic but
-// won't match the table's natural DDL order.
 // numberToText renders a JSON-decoded numeric row-image value (#496) to the
 // SAME wire bytes go-mysql's FormatTextValue produces for the equivalent native
 // value. Two reasons it must pre-render to []byte rather than return a numeric:
@@ -1191,10 +1180,11 @@ func marshalImageOrdered(image map[string]any, ddlOrder []string) string {
 //     Returning int64 for an integral DOUBLE and float64 for a fractional one in
 //     the same column would crash the whole _flashback full-table query. A
 //     uniform []byte makes every such column VAR_STRING.
-//   - In the full-table _snapshot merge, baseline-origin cells (DuckDB-native,
-//     rendered via FormatTextValue) and event-origin cells must emit identical
-//     bytes; routing both through FormatTextValue guarantees that (a raw
-//     json.Number literal would diverge, e.g. "1e+21" vs "1000…0").
+//   - In the full-table _snapshot merge, baseline-origin INT/DOUBLE cells
+//     (DuckDB-native, rendered via FormatTextValue) and event-origin cells emit
+//     identical bytes because both route through FormatTextValue (a raw
+//     json.Number literal would diverge, e.g. "1e+21" vs "1000…0"). FLOAT(32-bit)
+//     is the known exception — see runSnapshotFullTable.
 // The exact numeric type is recovered first so a BIGINT UNSIGNED > 2^63 stays
 // exact (int64 → uint64 → float64), falling back to the literal text.
 func numberToText(n json.Number) []byte {
@@ -1224,6 +1214,17 @@ func resultsetValue(v any) any {
 	return v
 }
 
+// imageToResult turns a single-row JSON object into a mysql.Result
+// shaped for the wire protocol. Columns are emitted in ddlOrder
+// (the source table's column ordinal_position from the latest
+// schema_snapshots row) so a customer running
+// `SELECT * FROM _flashback.orders ...` gets the same column
+// ordering they'd get from a regular `SELECT * FROM orders` — no
+// surprising reshuffling between the two.
+//
+// ddlOrder=nil signals "no snapshot available"; in that case we
+// fall back to alphabetical key order, which is deterministic but
+// won't match the table's natural DDL order.
 func imageToResult(image map[string]any, ddlOrder []string) (*mysql.Result, error) {
 	if len(image) == 0 {
 		return emptyResult(), nil

--- a/internal/shim/handler.go
+++ b/internal/shim/handler.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -498,7 +499,7 @@ func (h *Handler) runPointInTime(q TimeTravelQuery) (*mysql.Result, error) {
 func imageToResultVerbatim(image map[string]any, cols []string) (*mysql.Result, error) {
 	row := make([]any, len(cols))
 	for i, c := range cols {
-		row[i] = image[c] // nil for missing key → NULL on wire
+		row[i] = resultsetValue(image[c]) // nil for missing key → NULL on wire
 	}
 	rs, err := mysql.BuildSimpleTextResultset(cols, [][]any{row})
 	if err != nil {
@@ -706,7 +707,7 @@ func imagesToResult(images []map[string]any, ddlOrder []string) (*mysql.Result, 
 	for i, img := range images {
 		row := make([]any, len(cols))
 		for j, c := range cols {
-			row[j] = img[c]
+			row[j] = resultsetValue(img[c])
 		}
 		values[i] = row
 	}
@@ -1182,6 +1183,29 @@ func marshalImageOrdered(image map[string]any, ddlOrder []string) string {
 // ddlOrder=nil signals "no snapshot available"; in that case we
 // fall back to alphabetical key order, which is deterministic but
 // won't match the table's natural DDL order.
+// resultsetValue converts a row-image cell into a type go-mysql's resultset
+// builder accepts. Row images decoded by query.UnmarshalRowImage carry numbers
+// as json.Number (#496), which BuildSimpleTextResultset rejects. Map it to the
+// narrowest exact numeric type — int64, or uint64 for a BIGINT UNSIGNED above
+// 2^63 — so large integers render exactly; fall back to float64 for fractional
+// values and the literal string for anything out of numeric range.
+func resultsetValue(v any) any {
+	n, ok := v.(json.Number)
+	if !ok {
+		return v
+	}
+	if i, err := n.Int64(); err == nil {
+		return i
+	}
+	if u, err := strconv.ParseUint(n.String(), 10, 64); err == nil {
+		return u
+	}
+	if f, err := n.Float64(); err == nil {
+		return f
+	}
+	return n.String()
+}
+
 func imageToResult(image map[string]any, ddlOrder []string) (*mysql.Result, error) {
 	if len(image) == 0 {
 		return emptyResult(), nil
@@ -1190,7 +1214,7 @@ func imageToResult(image map[string]any, ddlOrder []string) (*mysql.Result, erro
 	cols := orderColumns(image, ddlOrder)
 	row := make([]any, len(cols))
 	for i, c := range cols {
-		row[i] = image[c]
+		row[i] = resultsetValue(image[c])
 	}
 
 	rs, err := mysql.BuildSimpleTextResultset(cols, [][]any{row})

--- a/internal/shim/handler_test.go
+++ b/internal/shim/handler_test.go
@@ -3,6 +3,7 @@ package shim
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -23,6 +24,38 @@ import (
 	"github.com/dbtrail/dbtrail/internal/parser"
 	"github.com/dbtrail/dbtrail/internal/query"
 )
+
+// TestResultsetValue_jsonNumber locks the json.Number → resultset conversion
+// (#496): BuildSimpleTextResultset rejects json.Number, so row-image numbers must
+// map to the narrowest exact numeric type, including uint64 for BIGINT UNSIGNED
+// above 2^63.
+func TestResultsetValue_jsonNumber(t *testing.T) {
+	cases := []struct {
+		in   json.Number
+		want any
+	}{
+		{"12345", int64(12345)},
+		{"-7", int64(-7)},
+		{"9223372036854775807", int64(9223372036854775807)},     // BIGINT signed max
+		{"18446744073709551615", uint64(18446744073709551615)},  // BIGINT UNSIGNED max
+		{"3.14", float64(3.14)},                                 // fractional → float64
+	}
+	for _, c := range cases {
+		if got := resultsetValue(c.in); got != c.want {
+			t.Errorf("resultsetValue(json.Number(%q)) = %#v (%T), want %#v (%T)", c.in, got, got, c.want, c.want)
+		}
+	}
+	// Non-json.Number values pass through unchanged.
+	if got := resultsetValue("hi"); got != "hi" {
+		t.Errorf("string passthrough = %#v, want \"hi\"", got)
+	}
+	if got := resultsetValue(nil); got != nil {
+		t.Errorf("nil passthrough = %#v, want nil", got)
+	}
+	if got := resultsetValue(int64(42)); got != int64(42) {
+		t.Errorf("int64 passthrough = %#v, want int64(42)", got)
+	}
+}
 
 // TestHandlerHandshakeNoise verifies the small allow-list for queries
 // MySQL clients send during connection setup — these shouldn't be

--- a/internal/shim/handler_test.go
+++ b/internal/shim/handler_test.go
@@ -25,25 +25,68 @@ import (
 	"github.com/dbtrail/dbtrail/internal/query"
 )
 
+func mustFormatText(t *testing.T, v any) string {
+	t.Helper()
+	b, err := gomysql.FormatTextValue(v)
+	if err != nil {
+		t.Fatalf("FormatTextValue(%#v): %v", v, err)
+	}
+	return string(b)
+}
+
+// parseRowCells parses every RowData in a BuildSimpleTextResultset result into
+// string cells (RowDatas are populated, not Values, so GetString can't be used).
+func parseRowCells(t *testing.T, rs *gomysql.Resultset) [][]string {
+	t.Helper()
+	out := make([][]string, 0, len(rs.RowDatas))
+	for _, rd := range rs.RowDatas {
+		fvs, err := rd.Parse(rs.Fields, false, nil)
+		if err != nil {
+			t.Fatalf("parse row data: %v", err)
+		}
+		cells := make([]string, len(fvs))
+		for i := range fvs {
+			switch v := fvs[i].Value().(type) {
+			case nil:
+				cells[i] = "NULL"
+			case []byte:
+				cells[i] = string(v)
+			default:
+				cells[i] = fmt.Sprintf("%v", v)
+			}
+		}
+		out = append(out, cells)
+	}
+	return out
+}
+
 // TestResultsetValue_jsonNumber locks the json.Number → resultset conversion
-// (#496): BuildSimpleTextResultset rejects json.Number, so row-image numbers must
-// map to the narrowest exact numeric type, including uint64 for BIGINT UNSIGNED
-// above 2^63.
+// (#496). BuildSimpleTextResultset rejects json.Number and fixes a column's wire
+// type from its first row, so numbers are pre-rendered to uniform text bytes via
+// FormatTextValue — exact for BIGINT UNSIGNED above 2^63.
 func TestResultsetValue_jsonNumber(t *testing.T) {
-	cases := []struct {
-		in   json.Number
-		want any
-	}{
-		{"12345", int64(12345)},
-		{"-7", int64(-7)},
-		{"9223372036854775807", int64(9223372036854775807)},     // BIGINT signed max
-		{"18446744073709551615", uint64(18446744073709551615)},  // BIGINT UNSIGNED max
-		{"3.14", float64(3.14)},                                 // fractional → float64
+	cases := []struct{ in, want string }{
+		{"12345", "12345"},
+		{"-7", "-7"},
+		{"9223372036854775807", "9223372036854775807"},   // 2^63-1 → int64 branch
+		{"9223372036854775808", "9223372036854775808"},   // exactly 2^63 → uint64 branch
+		{"18446744073709551615", "18446744073709551615"}, // BIGINT UNSIGNED max → uint64
+		{"3.14", "3.14"},                                 // fractional → float64
 	}
 	for _, c := range cases {
-		if got := resultsetValue(c.in); got != c.want {
-			t.Errorf("resultsetValue(json.Number(%q)) = %#v (%T), want %#v (%T)", c.in, got, got, c.want, c.want)
+		b, ok := resultsetValue(json.Number(c.in)).([]byte)
+		if !ok {
+			t.Errorf("resultsetValue(%q) = %T, want []byte", c.in, resultsetValue(json.Number(c.in)))
+			continue
 		}
+		if string(b) != c.want {
+			t.Errorf("resultsetValue(json.Number(%q)) = %q, want %q", c.in, b, c.want)
+		}
+	}
+	// json.Number renders byte-identically to FormatTextValue of the equivalent
+	// native value — the path baseline-origin cells take, so the two agree.
+	if got := string(resultsetValue(json.Number("18446744073709551615")).([]byte)); got != mustFormatText(t, uint64(18446744073709551615)) {
+		t.Errorf("json.Number vs native uint64 render diverge: %q", got)
 	}
 	// Non-json.Number values pass through unchanged.
 	if got := resultsetValue("hi"); got != "hi" {
@@ -52,8 +95,63 @@ func TestResultsetValue_jsonNumber(t *testing.T) {
 	if got := resultsetValue(nil); got != nil {
 		t.Errorf("nil passthrough = %#v, want nil", got)
 	}
-	if got := resultsetValue(int64(42)); got != int64(42) {
-		t.Errorf("int64 passthrough = %#v, want int64(42)", got)
+}
+
+// TestImagesToResult_jsonNumberMixedAndExact is the regression test for the
+// review-caught crash (#496/#505): a DOUBLE column with an integral value in one
+// row and a fractional in another must NOT trip "row types aren't consistent",
+// and a BIGINT UNSIGNED max must render exactly on the wire.
+func TestImagesToResult_jsonNumberMixedAndExact(t *testing.T) {
+	images := []map[string]any{
+		{"id": json.Number("1"), "score": json.Number("100"), "big": json.Number("18446744073709551615")},
+		{"id": json.Number("2"), "score": json.Number("100.5"), "big": json.Number("0")},
+	}
+	res, err := imagesToResult(images, []string{"id", "score", "big"})
+	if err != nil {
+		t.Fatalf("imagesToResult must not crash on a mixed integral/fractional column: %v", err)
+	}
+	got := parseRowCells(t, res.Resultset)
+	want := [][]string{
+		{"1", "100", "18446744073709551615"},
+		{"2", "100.5", "0"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("rows = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		for j := range want[i] {
+			if got[i][j] != want[i][j] {
+				t.Errorf("cell[%d][%d] = %q, want %q", i, j, got[i][j], want[i][j])
+			}
+		}
+	}
+}
+
+// TestFullTableTextCell_jsonNumberMatchesNative locks the baseline/event
+// consistency the silent-failure review flagged: a json.Number event cell must
+// render byte-identically to the DuckDB-native baseline cell of the same value,
+// including extreme doubles where the raw literal (1e+21) differs from
+// FormatTextValue's decimal form.
+func TestFullTableTextCell_jsonNumberMatchesNative(t *testing.T) {
+	h := NewHandler(nil, nil)
+	cases := []struct {
+		num    json.Number
+		native any
+	}{
+		{"18446744073709551615", uint64(18446744073709551615)}, // BIGINT UNSIGNED
+		{"100", int64(100)},
+		{"1e+21", float64(1e21)},   // extreme double: literal "1e+21" vs decimal
+		{"0.0000001", float64(1e-7)},
+		{"100.5", float64(100.5)},
+	}
+	for _, c := range cases {
+		event := h.fullTableTextCell("s", "t", "c", c.num)
+		baseline := h.fullTableTextCell("s", "t", "c", c.native)
+		eb, _ := event.([]byte)
+		bb, _ := baseline.([]byte)
+		if string(eb) != string(bb) {
+			t.Errorf("json.Number(%q) → %q, native %T → %q (must be identical)", c.num, eb, c.native, bb)
+		}
 	}
 }
 

--- a/internal/shim/handler_test.go
+++ b/internal/shim/handler_test.go
@@ -68,10 +68,12 @@ func TestResultsetValue_jsonNumber(t *testing.T) {
 	cases := []struct{ in, want string }{
 		{"12345", "12345"},
 		{"-7", "-7"},
+		{"-9223372036854775808", "-9223372036854775808"}, // BIGINT signed min → int64 branch
 		{"9223372036854775807", "9223372036854775807"},   // 2^63-1 → int64 branch
 		{"9223372036854775808", "9223372036854775808"},   // exactly 2^63 → uint64 branch
 		{"18446744073709551615", "18446744073709551615"}, // BIGINT UNSIGNED max → uint64
 		{"3.14", "3.14"},                                 // fractional → float64
+		{"1e1000", "1e1000"},                             // beyond float64 range → literal passthrough
 	}
 	for _, c := range cases {
 		b, ok := resultsetValue(json.Number(c.in)).([]byte)
@@ -128,30 +130,46 @@ func TestImagesToResult_jsonNumberMixedAndExact(t *testing.T) {
 }
 
 // TestFullTableTextCell_jsonNumberMatchesNative locks the baseline/event
-// consistency the silent-failure review flagged: a json.Number event cell must
-// render byte-identically to the DuckDB-native baseline cell of the same value,
-// including extreme doubles where the raw literal (1e+21) differs from
-// FormatTextValue's decimal form.
+// consistency the silent-failure review flagged: a json.Number event cell renders
+// byte-identically to FormatTextValue of the equivalent native Go value (the path
+// baseline-origin INT/DOUBLE cells take), including extreme doubles where the raw
+// literal (1e+21) differs from FormatTextValue's decimal form. FLOAT (float32) is
+// the documented exception (separate sub-test below).
 func TestFullTableTextCell_jsonNumberMatchesNative(t *testing.T) {
 	h := NewHandler(nil, nil)
 	cases := []struct {
 		num    json.Number
 		native any
 	}{
-		{"18446744073709551615", uint64(18446744073709551615)}, // BIGINT UNSIGNED
+		{"18446744073709551615", uint64(18446744073709551615)},   // BIGINT UNSIGNED max
 		{"100", int64(100)},
-		{"1e+21", float64(1e21)},   // extreme double: literal "1e+21" vs decimal
+		{"-9223372036854775808", int64(-9223372036854775808)},    // BIGINT signed min
+		{"1e+21", float64(1e21)},                                 // extreme double: "1e+21" vs decimal
+		{"-1e+21", float64(-1e21)},                               // negative extreme double
 		{"0.0000001", float64(1e-7)},
 		{"100.5", float64(100.5)},
 	}
 	for _, c := range cases {
-		event := h.fullTableTextCell("s", "t", "c", c.num)
-		baseline := h.fullTableTextCell("s", "t", "c", c.native)
-		eb, _ := event.([]byte)
-		bb, _ := baseline.([]byte)
-		if string(eb) != string(bb) {
-			t.Errorf("json.Number(%q) → %q, native %T → %q (must be identical)", c.num, eb, c.native, bb)
+		event, _ := h.fullTableTextCell("s", "t", "c", c.num).([]byte)
+		baseline, _ := h.fullTableTextCell("s", "t", "c", c.native).([]byte)
+		if string(event) != string(baseline) {
+			t.Errorf("json.Number(%q) → %q, native %T → %q (must be identical)", c.num, event, c.native, baseline)
 		}
+	}
+
+	// Documented KNOWN exception (pre-existing, baseline-side, tracked as a
+	// follow-up): a baseline FLOAT column is scanned by DuckDB as float32, which
+	// FormatTextValue widens — so it does NOT match the event side's shortest
+	// float32 literal. This locks the current behavior so a future baseline
+	// float32 fix has to update it deliberately.
+	eventFloat := string(h.fullTableTextCell("s", "t", "c", json.Number("0.1")).([]byte))
+	baselineFloat := string(h.fullTableTextCell("s", "t", "c", float32(0.1)).([]byte))
+	if eventFloat != "0.1" {
+		t.Errorf("event FLOAT 0.1 = %q, want \"0.1\"", eventFloat)
+	}
+	if eventFloat == baselineFloat {
+		t.Errorf("FLOAT baseline (float32) is expected to DIVERGE from the event side today; "+
+			"event=%q baseline=%q — if a baseline float32 fix made them match, update this test and the comments", eventFloat, baselineFloat)
 	}
 }
 

--- a/internal/shim/snapshot.go
+++ b/internal/shim/snapshot.go
@@ -164,13 +164,14 @@ func (h *Handler) runSnapshotFullTable(q TimeTravelQuery) (*mysql.Result, error)
 	// Buffer the merged rows, coercing every value to a uniform text cell
 	// (see fullTableTextCell). This is required, not cosmetic: a baseline row
 	// carries DuckDB-native types (an int column is int32 → LONGLONG) while a
-	// post-baseline event image is JSON-decoded (the same column is float64 →
-	// DOUBLE), and BuildSimpleTextResultset rejects a column whose non-NULL
-	// rows disagree on type ("row types aren't consistent"). Rendering every
-	// cell to its text bytes makes each column uniformly VAR_STRING, lossless
-	// for large integers (unlike the event path's float64), and identical on
-	// the wire to per-value formatting. Stop at cap+1 so overflow is
-	// detectable.
+	// post-baseline event image is JSON-decoded (the same column arrives as
+	// json.Number), and BuildSimpleTextResultset rejects a column whose non-NULL
+	// rows disagree on type ("row types aren't consistent"). Rendering every cell
+	// to its text bytes makes each column uniformly VAR_STRING and lossless for
+	// large integers — both origins now preserve them exactly (#496): fullTableTextCell
+	// routes json.Number through numberToText, the same FormatTextValue path the
+	// default branch uses for baseline values, so the bytes are identical on the
+	// wire. Stop at cap+1 so overflow is detectable.
 	images := make([]map[string]any, 0)
 	err = reconstruct.SnapshotFullTableImages(ctx, reconstruct.SnapshotFullTableInput{
 		BaselinePath: baselinePath,
@@ -250,9 +251,11 @@ func (h *Handler) fullTableTextCell(schema, table, column string, v any) any {
 	case string:
 		return []byte(x)
 	case json.Number:
-		// Post-baseline event images are JSON-decoded as json.Number (#496);
-		// render the exact literal so large integers stay lossless on the wire.
-		return []byte(x.String())
+		// Post-baseline event images are JSON-decoded as json.Number (#496).
+		// Render through numberToText (FormatTextValue) so event-origin cells emit
+		// byte-identical wire bytes to baseline-origin cells of the same value —
+		// the default branch below renders DuckDB-native values the same way.
+		return numberToText(x)
 	case time.Time:
 		return []byte(x.UTC().Format("2006-01-02 15:04:05"))
 	default:

--- a/internal/shim/snapshot.go
+++ b/internal/shim/snapshot.go
@@ -2,6 +2,7 @@ package shim
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -248,6 +249,10 @@ func (h *Handler) fullTableTextCell(schema, table, column string, v any) any {
 		return x
 	case string:
 		return []byte(x)
+	case json.Number:
+		// Post-baseline event images are JSON-decoded as json.Number (#496);
+		// render the exact literal so large integers stay lossless on the wire.
+		return []byte(x.String())
 	case time.Time:
 		return []byte(x.UTC().Format("2006-01-02 15:04:05"))
 	default:

--- a/internal/shim/snapshot.go
+++ b/internal/shim/snapshot.go
@@ -167,11 +167,16 @@ func (h *Handler) runSnapshotFullTable(q TimeTravelQuery) (*mysql.Result, error)
 	// post-baseline event image is JSON-decoded (the same column arrives as
 	// json.Number), and BuildSimpleTextResultset rejects a column whose non-NULL
 	// rows disagree on type ("row types aren't consistent"). Rendering every cell
-	// to its text bytes makes each column uniformly VAR_STRING and lossless for
-	// large integers — both origins now preserve them exactly (#496): fullTableTextCell
-	// routes json.Number through numberToText, the same FormatTextValue path the
-	// default branch uses for baseline values, so the bytes are identical on the
-	// wire. Stop at cap+1 so overflow is detectable.
+	// to its text bytes makes each column uniformly VAR_STRING. For INT and DOUBLE
+	// columns the two origins render byte-identically: fullTableTextCell routes
+	// json.Number through numberToText, the same FormatTextValue path the default
+	// branch uses for baseline values; and the #496 read-path fix keeps event-side
+	// integers exact (json.Number, no float64 rounding). Known pre-existing
+	// exceptions, both baseline-side and out of this path's control: FLOAT(32-bit)
+	// columns diverge (DuckDB scans baseline FLOAT as float32, which FormatTextValue
+	// widens — "0.10000000149011612" vs the event side's "0.1"), and a baseline
+	// BIGINT UNSIGNED > 2^63 can't round-trip (baseline stores bigint as signed
+	// Int64). Stop at cap+1 so overflow is detectable.
 	images := make([]map[string]any, 0)
 	err = reconstruct.SnapshotFullTableImages(ctx, reconstruct.SnapshotFullTableInput{
 		BaselinePath: baselinePath,
@@ -253,8 +258,9 @@ func (h *Handler) fullTableTextCell(schema, table, column string, v any) any {
 	case json.Number:
 		// Post-baseline event images are JSON-decoded as json.Number (#496).
 		// Render through numberToText (FormatTextValue) so event-origin cells emit
-		// byte-identical wire bytes to baseline-origin cells of the same value —
-		// the default branch below renders DuckDB-native values the same way.
+		// the same wire bytes as baseline-origin INT/DOUBLE cells (the default
+		// branch below renders DuckDB-native int64/float64 the same way). Baseline
+		// FLOAT (float32) is the known exception — see runSnapshotFullTable.
 		return numberToText(x)
 	case time.Time:
 		return []byte(x.UTC().Format("2006-01-02 15:04:05"))

--- a/internal/shim/snapshot_integration_test.go
+++ b/internal/shim/snapshot_integration_test.go
@@ -799,6 +799,77 @@ func TestSnapshotBaseline_FullTableHandleQueryWiring(t *testing.T) {
 	}
 }
 
+// TestSnapshotBaseline_FullTableDoubleMerge is the end-to-end proof for #496/#505:
+// a DOUBLE column whose rows mix a baseline-origin (DuckDB float64) integral value
+// and event-origin (json.Number) fractional values must (a) NOT trip
+// BuildSimpleTextResultset's "row types aren't consistent" (the crash the review
+// caught), and (b) render baseline-origin and event-origin cells of the same
+// value byte-identically (both via FormatTextValue).
+func TestSnapshotBaseline_FullTableDoubleMerge(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	hourTop := time.Now().UTC().Truncate(time.Hour)
+	addHourlyPartition(t, db, hourTop)
+	snapTime := hourTop.Add(1 * time.Minute)
+	asOfLit := hourTop.Add(10 * time.Minute).Format("2006-01-02 15:04:05")
+	ts := snapTime.UTC().Format("2006-01-02 15:04:05")
+	eventTS := hourTop.Add(5 * time.Minute).Format("2006-01-02 15:04:05")
+
+	testutil.InsertSnapshot(t, db, 1, ts, "myapp", "metrics", "id", 1, "PRI", "int", "NO")
+	testutil.InsertSnapshot(t, db, 1, ts, "myapp", "metrics", "score", 2, "", "double", "YES")
+
+	cols := []baseline.Column{
+		{Name: "id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
+		{Name: "score", MySQLType: "double", ParquetType: baseline.MysqlToParquetNode("double")},
+	}
+	// id=1 never touched (baseline-origin, integral double → "100"); id=2 updated
+	// after baseline (event-origin, fractional); id=3 never touched (baseline-origin
+	// fractional → must equal the event-origin 100.5).
+	baselineDir := writeBaselineSnapshot(t, snapTime, "myapp", "metrics", cols, [][]string{
+		{"1", "100"},
+		{"2", "999"},
+		{"3", "100.5"},
+	})
+	testutil.InsertEvent(t, db, "mysql-bin.000001", 100, 200, eventTS, nil,
+		"myapp", "metrics", 2 /*update*/, "2", nil,
+		[]byte(`{"id":2,"score":999}`),
+		[]byte(`{"id":2,"score":100.5}`))
+
+	h := NewHandlerWithConfig(db, Config{
+		AllowGaps: true, NoArchive: true, IndexDBName: dbName, BaselineDir: baselineDir,
+	}, slog.Default())
+	if err := h.UseDB("myapp"); err != nil {
+		t.Fatalf("UseDB: %v", err)
+	}
+
+	// Must NOT crash — the score column mixes integral ("100") and fractional
+	// ("100.5") rendered cells.
+	res, err := h.HandleQuery("SELECT * FROM _snapshot.metrics AS OF '" + asOfLit + "'")
+	if err != nil {
+		t.Fatalf("HandleQuery full-table _snapshot DOUBLE merge: %v", err)
+	}
+	score := map[string]string{}
+	for _, cells := range rowCells(t, res.Resultset) {
+		if len(cells) == 2 {
+			score[cells[0]] = cells[1]
+		}
+	}
+	if score["1"] != "100" {
+		t.Errorf("baseline-origin id=1 score = %q, want \"100\"", score["1"])
+	}
+	if score["2"] != "100.5" {
+		t.Errorf("event-origin id=2 score = %q, want \"100.5\"", score["2"])
+	}
+	// Baseline-origin (id=3) and event-origin (id=2) cells of 100.5 must match.
+	if score["3"] != score["2"] {
+		t.Errorf("baseline-origin id=3 (%q) and event-origin id=2 (%q) must render 100.5 identically", score["3"], score["2"])
+	}
+}
+
 // The three tests below close the coverage gap on the configured-but-degraded
 // full-table fallback branches of runSnapshotFullTable. Each configures a
 // baseline source (so we are past the no-source Debug branch) and asserts the


### PR DESCRIPTION
closes #496

## Summary
- `row_before`/`row_after` JSON was unmarshalled into `map[string]any` with default `encoding/json` → every number became `float64`, silently rounding integers above 2^53 (`BIGINT UNSIGNED > 2^63`, large signed `BIGINT`). `recover` SQL and `query`/CSV output emitted the wrong value even though storage was exact — leaving #490 incomplete end-to-end for BIGINT.
- New `query.UnmarshalRowImage` (`json.Decoder` + `UseNumber()`) used at **both** read sites: `internal/query` (live MySQL) and `internal/parquetquery` (archived Parquet — `recover` merges both). Numbers now arrive as `json.Number` (the exact literal).
- Consumers updated:
  - `recovery.FormatSQLValue`: emit `json.Number` verbatim (**additive** — `float64` case stays for genuine DOUBLEs from the DuckDB reconstruct path).
  - `metadata.ordinalValue`: parse `json.Number` for ENUM/SET label resolution (full 64-bit, no 2^53 cap).
  - **shim**: `BuildSimpleTextResultset` rejects `json.Number`, so `resultsetValue` maps it to `int64`/`uint64`/`float64` (exact, incl. `BIGINT UNSIGNED > 2^63`) at the three resultset sites; `fullTableTextCell` renders the exact literal.
- Unaffected (verified): `query` JSON/CSV, MCP, console, and the archive **write** path use `json.Marshal` or raw-JSON passthrough — `json.Number` marshals correctly.

## Note
This is the **read** half. Combined with #490 (the merged **write** fix — `marshalRow` stores `uint64`→exact-integer JSON), `BIGINT UNSIGNED` is now correct end-to-end through `recover`. The integration test below relies on that storage guarantee.

## Test plan
- [x] Unit: `FormatSQLValue(json.Number)`, `UnmarshalRowImage` (>2^53 exact), `ordinalValue(json.Number)`, `resultsetValue(json.Number)`.
- [x] Integration: `BIGINT UNSIGNED` max → `recover --dry-run` emits the exact value (not the rounded `...616`).
- [x] Full unit (28 pkgs) + integration: `recovery`/`query`/`parquetquery`/`reconstruct`/`metadata`/`shim`/`console`/`cmd/bintrail`/`cmd/bintrail-mcp` + E2E — all green. (The shim path initially broke with "unsupport type json.Number"; fixed and covered.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)