### PR TITLE
fix: index BIT(64) with the high bit set as its correct unsigned value (#497)

### DIFF
--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -253,6 +253,9 @@ func coerceUnsigned(v any, col ColumnMeta) any {
 		if i, ok := v.(int64); ok {
 			return uint64(i)
 		}
+		// go-mysql always decodes BIT as int64, so this never fires today. If a
+		// future go-mysql/MariaDB path ever delivered BIT as []byte/string, leave
+		// it uninterpreted rather than mis-coerce — the original value, not a bug.
 		return v
 	}
 	if !strings.Contains(strings.ToLower(col.ColumnType), "unsigned") {

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -242,10 +242,19 @@ func (r *Resolver) MapRow(schema, table string, row []any) (map[string]any, erro
 // snapshots can't express signedness — NewResolver warns once in that case), or
 // when the value is not a signed integer (NULL, string, and DECIMAL/FLOAT/DOUBLE
 // UNSIGNED — which go-mysql returns as string/float — are returned unchanged).
-// BIT is intentionally gated out: it is a distinct type, never declared
-// "unsigned". (BIT(64) with the high bit set has the same underlying corruption,
-// since go-mysql decodes BIT as int64, but is tracked separately.)
+// BIT is also reinterpreted here: go-mysql decodes it as a signed int64, so a
+// BIT(64) with the high bit set comes back negative; it's mapped to uint64 (#497).
 func coerceUnsigned(v any, col ColumnMeta) any {
+	// BIT is an unsigned bit string. go-mysql decodes BIT(N) as int64, so BIT(64)
+	// with the high bit set comes back negative; reinterpret as uint64 — identity
+	// for BIT(1..63) (always positive within int64). BIT's ColumnType is "bit(N)"
+	// (no "unsigned"), so handle it before the unsigned gate below.
+	if strings.ToLower(col.DataType) == "bit" {
+		if i, ok := v.(int64); ok {
+			return uint64(i)
+		}
+		return v
+	}
 	if !strings.Contains(strings.ToLower(col.ColumnType), "unsigned") {
 		return v
 	}

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -247,15 +247,17 @@ func (r *Resolver) MapRow(schema, table string, row []any) (map[string]any, erro
 func coerceUnsigned(v any, col ColumnMeta) any {
 	// BIT is an unsigned bit string. go-mysql decodes BIT(N) as int64, so BIT(64)
 	// with the high bit set comes back negative; reinterpret as uint64 — identity
-	// for BIT(1..63) (always positive within int64). BIT's ColumnType is "bit(N)"
-	// (no "unsigned"), so handle it before the unsigned gate below.
+	// for BIT(1..63) (the value is non-negative as int64, so uint64() preserves
+	// it). BIT's ColumnType is "bit(N)" (no "unsigned"), so handle it before the
+	// unsigned gate below.
 	if strings.ToLower(col.DataType) == "bit" {
 		if i, ok := v.(int64); ok {
 			return uint64(i)
 		}
-		// go-mysql always decodes BIT as int64, so this never fires today. If a
-		// future go-mysql/MariaDB path ever delivered BIT as []byte/string, leave
-		// it uninterpreted rather than mis-coerce — the original value, not a bug.
+		// A NULL BIT arrives as nil and passes through here. Otherwise go-mysql
+		// always decodes BIT as int64, so a non-nil non-int64 value can't occur
+		// today; if a future go-mysql/MariaDB path delivered BIT as []byte/string,
+		// leave it uninterpreted rather than mis-coerce — the original value.
 		return v
 	}
 	if !strings.Contains(strings.ToLower(col.ColumnType), "unsigned") {

--- a/internal/metadata/metadata_test.go
+++ b/internal/metadata/metadata_test.go
@@ -103,6 +103,13 @@ func TestCoerceUnsigned(t *testing.T) {
 		// (DataType "enum" ∉ integer widths) — which must leave it untouched. This
 		// locks that load-bearing default so a future refactor can't coerce it.
 		{"enum value list contains 'unsigned'", int64(2), ColumnMeta{DataType: "enum", ColumnType: "enum('signed','unsigned')"}, int64(2)},
+		// BIT: go-mysql decodes it as int64, so BIT(64) with the high bit set is
+		// negative; reinterpret as uint64 (#497). BIT(<64) values are already
+		// positive (identity); NULL passes through.
+		{"bit(64) all bits set", int64(-1), ColumnMeta{DataType: "bit", ColumnType: "bit(64)"}, maxU64},
+		{"bit(64) high bit only", int64(-9223372036854775808), ColumnMeta{DataType: "bit", ColumnType: "bit(64)"}, uint64(9223372036854775808)},
+		{"bit(8) positive unchanged", int64(200), ColumnMeta{DataType: "bit", ColumnType: "bit(8)"}, uint64(200)},
+		{"bit null passthrough", nil, ColumnMeta{DataType: "bit", ColumnType: "bit(64)"}, nil},
 	}
 
 	for _, tc := range cases {

--- a/internal/parser/bit_integration_test.go
+++ b/internal/parser/bit_integration_test.go
@@ -1,0 +1,95 @@
+//go:build integration
+
+package parser_test
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/config"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/parser"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestParseFile_bitColumns verifies the end-to-end fix for #497: BIT columns are
+// decoded by go-mysql as a signed int64, so a BIT(64) with the high bit set comes
+// back negative; it must be indexed as the correct unsigned value. BIT(<64) values
+// are already positive and must be unchanged.
+func TestParseFile_bitColumns(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	ctx := context.Background()
+
+	sourceDB, sourceName := testutil.CreateTestDB(t)
+	indexDB, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, indexDB)
+
+	testutil.MustExec(t, sourceDB, `CREATE TABLE bt (
+		id   INT PRIMARY KEY,
+		b64  BIT(64) NOT NULL,
+		b8   BIT(8)  NOT NULL
+	)`)
+
+	stats, err := metadata.TakeSnapshot(sourceDB, indexDB, []string{sourceName})
+	if err != nil {
+		t.Fatalf("TakeSnapshot failed: %v", err)
+	}
+	res, err := metadata.NewResolver(indexDB, stats.SnapshotID)
+	if err != nil {
+		t.Fatalf("NewResolver failed: %v", err)
+	}
+
+	testutil.MustExec(t, sourceDB, "FLUSH BINARY LOGS")
+	currentBinlog, _, err := config.CurrentBinlogPosition(sourceDB)
+	if err != nil {
+		t.Fatalf("CurrentBinlogPosition failed: %v", err)
+	}
+
+	// b64 = all 64 bits set (18446744073709551615): the high bit is set, so an
+	// unfixed decoder returns int64(-1). b8 = 255 (positive; must be unchanged).
+	testutil.MustExec(t, sourceDB,
+		`INSERT INTO bt (id, b64, b8) VALUES (1, b'1111111111111111111111111111111111111111111111111111111111111111', b'11111111')`)
+
+	testutil.MustExec(t, sourceDB, "FLUSH BINARY LOGS")
+
+	tmpDir := t.TempDir()
+	cpCmd := exec.Command("docker", "cp",
+		fmt.Sprintf("bintrail-test-mysql:/var/lib/mysql/%s", currentBinlog),
+		filepath.Join(tmpDir, currentBinlog),
+	)
+	if out, err := cpCmd.CombinedOutput(); err != nil {
+		t.Fatalf("docker cp %s failed: %v\n%s", currentBinlog, err, out)
+	}
+
+	p := parser.New(tmpDir, res, parser.Filters{Schemas: map[string]bool{sourceName: true}}, nil)
+	events := make(chan parser.Event, 50)
+	errCh := make(chan error, 1)
+	go func() {
+		defer close(events)
+		errCh <- p.ParseFile(ctx, currentBinlog, events)
+	}()
+
+	var ins []parser.Event
+	for ev := range events {
+		if ev.Table == "bt" && ev.EventType == parser.EventInsert {
+			ins = append(ins, ev)
+		}
+	}
+	if err := <-errCh; err != nil {
+		t.Fatalf("ParseFile returned error: %v", err)
+	}
+	if len(ins) != 1 {
+		t.Fatalf("expected 1 INSERT for table bt, got %d", len(ins))
+	}
+
+	ev := ins[0]
+	if got := ev.RowAfter["b64"]; got != uint64(18446744073709551615) {
+		t.Errorf("b64 BIT(64) all bits set: want uint64 max, got %#v (%T)", got, got)
+	}
+	if got := ev.RowAfter["b8"]; got != uint64(255) {
+		t.Errorf("b8 BIT(8) = 255: want uint64(255), got %#v (%T)", got, got)
+	}
+}


### PR DESCRIPTION
closes #497

## Summary
- go-mysql decodes `BIT(N)` as a signed `int64`, so a `BIT(64)` with the high bit (bit 63) set comes back **negative** and was indexed verbatim.
- `coerceUnsigned` now reinterprets a BIT column's `int64` as `uint64` — identity for `BIT(1..63)` (always positive within `int64`), fixing `BIT(64)`. The BIT branch runs **before** the unsigned-substring gate (a BIT column's `ColumnType` is `bit(N)`, no "unsigned").
- Stored as numeric `uint64`: `recover` emits it as an integer literal (valid for a BIT column) and the shim renders the integer. Combined with **#496** (json.Number read path, now in `main`), a `BIT(64)` value > 2⁵³ survives **exactly** end-to-end.

## Test plan
- [x] Unit: `coerceUnsigned` BIT cases (all-bits-set → `uint64` max, high-bit-only, `BIT(8)` positive unchanged, NULL passthrough); existing unsigned cases unaffected.
- [x] Integration: index a real `BIT(64)`/`BIT(8)` row through the parser → `RowAfter` is `uint64` (not negative).
- [x] Full unit (28 pkgs) + integration `metadata`/`parser`/`recovery`/`shim` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)