### PR TITLE
docs: document binlog_row_image=FULL (server-wide) + no-PARTIAL_JSON source requirements (#492)

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -83,9 +83,31 @@ The boundary triage cites:
   and remove the bundled `index-init` + `index-mysql` services (see
   [docker.md](docs/docker.md)) — same ship-vs-operate split, your server.
 
+## Source server configuration (required for correct capture)
+
+dbtrail reads ROW-format binary logs from your **source** MySQL. Faithful capture
+requires the source to be configured **server-wide** (not just per-session):
+
+- `binlog_format = ROW`.
+- `binlog_row_image = FULL`. Partial images (`MINIMAL`/`NOBLOB`) — **including from
+  a per-session `SET SESSION binlog_row_image = MINIMAL`** while the global is `FULL`
+  — are **out of scope**: dbtrail indexes incomplete before/after images as if
+  complete, so `recover` emits NULLs for unchanged columns and its `WHERE` clause
+  matches nothing.
+- `binlog_row_value_options` must **not** include `PARTIAL_JSON` — partial JSON
+  updates log only a diff, leaving no complete after-image to recover from.
+
+dbtrail's startup preflight and `bintrail doctor` validate the **global**
+`binlog_row_image`; preventing per-session overrides is the operator's
+responsibility. Data captured while the source violated these requirements is out
+of scope — configure the source (see
+[deployment.md → Source MySQL Requirements](docs/deployment.md#2-source-mysql-requirements))
+and re-index.
+
 ## Reporting issues
 
 Bugs in dbtrail's binaries, schema, tooling, console, or docs: please open
 an issue with reproduction steps — those are always in scope. If your report
 is about the index MySQL server's own operation (disk, backups, upgrades,
-corruption), see the list above first.
+corruption), or about data captured under an unsupported source configuration
+(non-`FULL` row image, `PARTIAL_JSON`), see the lists above first.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -97,8 +97,9 @@ requires the source to be configured **server-wide** (not just per-session):
 - `binlog_row_value_options` must **not** include `PARTIAL_JSON` — partial JSON
   updates log only a diff, leaving no complete after-image to recover from.
 
-dbtrail's startup preflight and `bintrail doctor` validate the **global**
-`binlog_row_image`; preventing per-session overrides is the operator's
+dbtrail's startup preflight and `bintrail doctor` validate the `binlog_row_image`
+they see on bintrail's own connection; bintrail can't observe what other
+application sessions set, so preventing per-session overrides is the operator's
 responsibility. Data captured while the source violated these requirements is out
 of scope — configure the source (see
 [deployment.md → Source MySQL Requirements](docs/deployment.md#2-source-mysql-requirements))

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -53,12 +53,26 @@ On-demand (DBA workstation):
 
 - MySQL 8.0 or later
 - `binlog_format = ROW` (required — dbtrail refuses to index non-ROW binlogs)
-- `binlog_row_image = FULL` (required — dbtrail validates this on startup)
+- `binlog_row_image = FULL` (required — dbtrail validates this on startup).
+  This must be set **server-wide**, not just at the session level. The startup
+  check reads the global variable, but `binlog_row_image` is also settable
+  per-session: an application that runs `SET SESSION binlog_row_image = MINIMAL`
+  (or `NOBLOB`) writes partial row images that dbtrail will index as if complete —
+  unchanged columns and the after-image primary key come back as NULL, so
+  `recover` destroys data and its `WHERE` clause matches nothing. Keep every
+  session on `FULL`.
+- `binlog_row_value_options` must **not** include `PARTIAL_JSON`. With partial
+  JSON updates enabled, an `UPDATE` logs only a JSON *diff*, not the full
+  document, so there is no complete after-image to recover from.
 - GTID mode strongly recommended for reliable resume after restarts:
   ```
   gtid_mode = ON
   enforce_gtid_consistency = ON
   ```
+
+> These are source-configuration requirements you own. Data captured under a
+> non-`FULL` row image or `PARTIAL_JSON` is **out of support** — see
+> [SUPPORT.md](../SUPPORT.md).
 
 ### Replication user
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -55,12 +55,14 @@ On-demand (DBA workstation):
 - `binlog_format = ROW` (required — dbtrail refuses to index non-ROW binlogs)
 - `binlog_row_image = FULL` (required — dbtrail validates this on startup).
   This must be set **server-wide**, not just at the session level. The startup
-  check reads the global variable, but `binlog_row_image` is also settable
-  per-session: an application that runs `SET SESSION binlog_row_image = MINIMAL`
-  (or `NOBLOB`) writes partial row images that dbtrail will index as if complete —
-  unchanged columns and the after-image primary key come back as NULL, so
-  `recover` destroys data and its `WHERE` clause matches nothing. Keep every
-  session on `FULL`.
+  check reads the value on bintrail's own connection, but `binlog_row_image` is
+  settable per-session, and bintrail can't see what other application sessions
+  do. A session that runs `SET SESSION binlog_row_image = MINIMAL` writes partial
+  images that dbtrail indexes as if complete: under `MINIMAL`, unchanged columns
+  are absent and the after-image primary key is omitted, so `recover` emits NULLs
+  for unchanged columns and its `WHERE` clause matches nothing. `NOBLOB` is
+  likewise unsupported — it drops unchanged `BLOB`/`TEXT` columns, so a reversal
+  can overwrite them with NULL. Keep every session on `FULL`.
 - `binlog_row_value_options` must **not** include `PARTIAL_JSON`. With partial
   JSON updates enabled, an `UPDATE` logs only a JSON *diff*, not the full
   document, so there is no complete after-image to recover from.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -26,7 +26,7 @@ Use both together if you like: `index` to backfill old files, then `stream` for 
 
 Before you start:
 
-- [ ] Source MySQL server has `binlog_format = ROW` and `binlog_row_image = FULL`
+- [ ] Source MySQL server has `binlog_format = ROW` and `binlog_row_image = FULL` **server-wide** (a per-session `SET SESSION binlog_row_image = MINIMAL`/`NOBLOB` writes partial images that aren't supported), and `binlog_row_value_options` does **not** include `PARTIAL_JSON`
 - [ ] A separate database (or schema) is available for the dbtrail index — it can be on the same server or a different one
 - [ ] `bintrail` binary is installed and on your `$PATH`
 - [ ] Your index DSN includes the database name: `user:pass@tcp(host:3306)/binlog_index`

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -33,7 +33,7 @@ GRANT SELECT ON shop.* TO 'dbtrail'@'%';        -- repeat per monitored schema
 
 If you scope `SELECT`, it must cover **every column of every monitored table**, or the schema snapshot fails with `no columns found for the requested schemas`.
 
-> The source must also have `binlog_format = ROW` and `binlog_row_image = FULL`. The preflight check (and `bintrail doctor`) refuses to start otherwise — verify with `SHOW VARIABLES LIKE 'binlog_%';`. Set `binlog_row_image = FULL` **server-wide**: the preflight reads the global, but a per-session `SET SESSION binlog_row_image = MINIMAL`/`NOBLOB` still writes partial images that index as incomplete (unsupported — see [SUPPORT.md](../SUPPORT.md)). Also keep `binlog_row_value_options` clear of `PARTIAL_JSON`, which logs only a JSON diff.
+> The source must also have `binlog_format = ROW` and `binlog_row_image = FULL`. The preflight check (and `bintrail doctor`) refuses to start otherwise — verify with `SHOW VARIABLES LIKE 'binlog_%';`. Set `binlog_row_image = FULL` **server-wide**: the preflight only sees its own connection, so a per-session `SET SESSION binlog_row_image = MINIMAL`/`NOBLOB` on another connection still writes partial images that index as incomplete (unsupported — see [SUPPORT.md](../SUPPORT.md)). Also keep `binlog_row_value_options` clear of `PARTIAL_JSON`, which logs only a JSON diff.
 
 ---
 

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -33,7 +33,7 @@ GRANT SELECT ON shop.* TO 'dbtrail'@'%';        -- repeat per monitored schema
 
 If you scope `SELECT`, it must cover **every column of every monitored table**, or the schema snapshot fails with `no columns found for the requested schemas`.
 
-> The source must also have `binlog_format = ROW` and `binlog_row_image = FULL`. The preflight check (and `bintrail doctor`) refuses to start otherwise — verify with `SHOW VARIABLES LIKE 'binlog_%';`.
+> The source must also have `binlog_format = ROW` and `binlog_row_image = FULL`. The preflight check (and `bintrail doctor`) refuses to start otherwise — verify with `SHOW VARIABLES LIKE 'binlog_%';`. Set `binlog_row_image = FULL` **server-wide**: the preflight reads the global, but a per-session `SET SESSION binlog_row_image = MINIMAL`/`NOBLOB` still writes partial images that index as incomplete (unsupported — see [SUPPORT.md](../SUPPORT.md)). Also keep `binlog_row_value_options` clear of `PARTIAL_JSON`, which logs only a JSON diff.
 
 ---
 


### PR DESCRIPTION
closes #492

## Summary
Two source-config facts were missing from the docs and silently produce inaccurate captures (surfaced by the binlog-fidelity audit):

- **`binlog_row_image=FULL` must be server-wide.** The preflight/`doctor` read the *global*, but it's session-settable — a per-session `SET SESSION binlog_row_image=MINIMAL`/`NOBLOB` writes partial images that dbtrail indexes as if complete (unchanged columns and the after-image PK come back NULL → `recover` destroys data / matches nothing).
- **`binlog_row_value_options` must not include `PARTIAL_JSON`** (logs only a JSON diff, no full after-image) — was undocumented anywhere.

Added to the canonical operator spots only (no redundancy across the ~6 places FULL is mentioned in passing):
- `docs/deployment.md` "Source MySQL Requirements" (detailed)
- `docs/streaming.md` (the requirement note)
- `docs/guide.md` (pre-start checklist)
- `SUPPORT.md` — new "Source server configuration" section making partial images / `PARTIAL_JSON` explicitly **out of scope**, so triage can cite it.

## Test plan
- [x] Docs-only — no code changed; `go test ./... -count=1` passes (28 pkgs).
- [x] Cross-doc links resolve; `#2-source-mysql-requirements` anchor matches the heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)