### PR TITLE
feat: add --ultrafast DuckDB tuning to query/recover/reconstruct

### DIFF
--- a/cmd/bintrail/config.go
+++ b/cmd/bintrail/config.go
@@ -186,6 +186,14 @@ var envSections = []envSection{
 			{"BINTRAIL_ROTATE_ADD_FUTURE", "3"},
 		},
 	},
+	{
+		Header: "DuckDB tuning (query/recover/reconstruct: trade memory-safety for speed)",
+		Bindings: []envTemplateEntry{
+			{"BINTRAIL_ULTRAFAST", ""},
+			{"BINTRAIL_DUCKDB_THREADS", ""},
+			{"BINTRAIL_DUCKDB_MEMORY_LIMIT", ""},
+		},
+	},
 	// The BINTRAIL_CONSOLE_* vars moved with the web console to the standalone
 	// bintrail-console binary (serve/watch), which reads the same env file —
 	// they are no longer advertised in the core CLI's template.

--- a/cmd/bintrail/duckdbtuning.go
+++ b/cmd/bintrail/duckdbtuning.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"regexp"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -9,6 +12,16 @@ import (
 	"github.com/dbtrail/dbtrail/internal/parquetquery"
 	"github.com/dbtrail/dbtrail/internal/query"
 )
+
+// duckDBMemoryLimitRE accepts the DuckDB memory_limit forms an operator would
+// pass: a positive size with an optional decimal or binary unit (16GB, 2.5GB,
+// 16GiB, a bare byte count) or a percentage (80%). It deliberately rejects a
+// leading '-': DuckDB SILENTLY accepts a negative memory_limit and treats it as
+// effectively unlimited (no error, so the best-effort WARN never fires), which
+// would invert the whole point of a memory cap. Garbage (typos) is rejected too
+// so an operator gets a clear error instead of a silent fall-back to the
+// conservative default.
+var duckDBMemoryLimitRE = regexp.MustCompile(`(?i)^(\d+(\.\d+)?\s*(b|kb|mb|gb|tb|pb|kib|mib|gib|tib|pib)?|\d+%)$`)
 
 // addDuckDBTuningFlags registers the shared DuckDB resource flags on the
 // offline query/recover/reconstruct commands. They lift the conservative,
@@ -33,7 +46,13 @@ func addDuckDBTuningFlags(cmd *cobra.Command) {
 // Precedence: an explicit --duckdb-* flag wins over --ultrafast, which wins
 // over the conservative default. The granular flags let an operator tune to
 // their box without the all-or-nothing --ultrafast switch.
-func duckDBTuningFromFlags(cmd *cobra.Command) duckdbutil.Tuning {
+//
+// An operator-supplied --duckdb-memory-limit is validated here, at the CLI
+// boundary, and a bad value is a hard error — DuckDB's SET memory_limit is
+// best-effort downstream and would either silently fall back to the default
+// (a typo) or silently uncap on a negative value, neither of which an operator
+// who explicitly asked for a budget should get without being told.
+func duckDBTuningFromFlags(cmd *cobra.Command) (duckdbutil.Tuning, error) {
 	t := duckdbutil.DefaultTuning()
 	if ultrafast, _ := cmd.Flags().GetBool("ultrafast"); ultrafast {
 		t = duckdbutil.Ultrafast()
@@ -42,9 +61,12 @@ func duckDBTuningFromFlags(cmd *cobra.Command) duckdbutil.Tuning {
 		t.Threads = threads
 	}
 	if mem, _ := cmd.Flags().GetString("duckdb-memory-limit"); mem != "" {
+		if !duckDBMemoryLimitRE.MatchString(strings.TrimSpace(mem)) {
+			return duckdbutil.Tuning{}, fmt.Errorf("invalid --duckdb-memory-limit %q: expected a positive size like 16GB / 512MB / 16GiB or a percentage like 80%%", mem)
+		}
 		t.MemoryLimit = mem
 	}
-	return t
+	return t, nil
 }
 
 // tunedArchiveFetcher adapts a DuckDB Tuning into a query.ArchiveFetcher so the

--- a/cmd/bintrail/duckdbtuning.go
+++ b/cmd/bintrail/duckdbtuning.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dbtrail/dbtrail/internal/duckdbutil"
+	"github.com/dbtrail/dbtrail/internal/parquetquery"
+	"github.com/dbtrail/dbtrail/internal/query"
+)
+
+// addDuckDBTuningFlags registers the shared DuckDB resource flags on the
+// offline query/recover/reconstruct commands. They lift the conservative,
+// container-safe DuckDB budget (threads=2, memory_limit=4GB) that
+// parquetquery.Fetch applies by default — useful on a dedicated box with
+// plenty of RAM where the small-container defaults leave performance on the
+// table (#510). The long-lived shim/console daemons never register these, so
+// their archive reads keep the safe default (#509 non-goal).
+//
+// --duckdb-threads default -1 (not 0) so 0 stays a meaningful explicit value:
+// "let DuckDB pick one thread per core". --duckdb-memory-limit "" means unset.
+func addDuckDBTuningFlags(cmd *cobra.Command) {
+	cmd.Flags().Bool("ultrafast", false,
+		"trade DuckDB memory-safety for speed: let DuckDB self-tune to the host (all cores, ~80% RAM) instead of the container-safe 2 threads / 4GB cap — for big boxes, not small containers")
+	cmd.Flags().Int("duckdb-threads", -1,
+		"override DuckDB thread count (0 = one per CPU core); -1 keeps the mode default")
+	cmd.Flags().String("duckdb-memory-limit", "",
+		"override DuckDB memory limit, e.g. 16GB (empty keeps the mode default)")
+}
+
+// duckDBTuningFromFlags resolves the effective DuckDB tuning for a command.
+// Precedence: an explicit --duckdb-* flag wins over --ultrafast, which wins
+// over the conservative default. The granular flags let an operator tune to
+// their box without the all-or-nothing --ultrafast switch.
+func duckDBTuningFromFlags(cmd *cobra.Command) duckdbutil.Tuning {
+	t := duckdbutil.DefaultTuning()
+	if ultrafast, _ := cmd.Flags().GetBool("ultrafast"); ultrafast {
+		t = duckdbutil.Ultrafast()
+	}
+	if threads, _ := cmd.Flags().GetInt("duckdb-threads"); threads >= 0 {
+		t.Threads = threads
+	}
+	if mem, _ := cmd.Flags().GetString("duckdb-memory-limit"); mem != "" {
+		t.MemoryLimit = mem
+	}
+	return t
+}
+
+// tunedArchiveFetcher adapts a DuckDB Tuning into a query.ArchiveFetcher so the
+// CLI commands can inject their budget without changing parquetquery.Fetch's
+// signature (which other packages pass as a function value).
+func tunedArchiveFetcher(t duckdbutil.Tuning) query.ArchiveFetcher {
+	return func(ctx context.Context, opts query.Options, source string) ([]query.ResultRow, error) {
+		return parquetquery.FetchWithTuning(ctx, opts, source, t)
+	}
+}

--- a/cmd/bintrail/duckdbtuning.go
+++ b/cmd/bintrail/duckdbtuning.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -13,15 +14,31 @@ import (
 	"github.com/dbtrail/dbtrail/internal/query"
 )
 
-// duckDBMemoryLimitRE accepts the DuckDB memory_limit forms an operator would
-// pass: a positive size with an optional decimal or binary unit (16GB, 2.5GB,
-// 16GiB, a bare byte count) or a percentage (80%). It deliberately rejects a
-// leading '-': DuckDB SILENTLY accepts a negative memory_limit and treats it as
-// effectively unlimited (no error, so the best-effort WARN never fires), which
-// would invert the whole point of a memory cap. Garbage (typos) is rejected too
-// so an operator gets a clear error instead of a silent fall-back to the
-// conservative default.
-var duckDBMemoryLimitRE = regexp.MustCompile(`(?i)^(\d+(\.\d+)?\s*(b|kb|mb|gb|tb|pb|kib|mib|gib|tib|pib)?|\d+%)$`)
+// duckDBMemoryLimitRE matches a number with a REQUIRED unit from the exact set
+// the linked DuckDB accepts as a memory_limit — decimal B/KB/MB/GB/TB or binary
+// KiB/MiB/GiB/TiB (verified empirically; DuckDB rejects PB/PiB, '%', and a
+// bare unitless number). Matching only what DuckDB honors is the whole point:
+// a value the regex accepts but DuckDB rejects (e.g. '80%') would pass this CLI
+// gate and then hit Apply's best-effort SET, which logs a WARN and silently
+// falls back to the default — the exact silent-fallback this validation exists
+// to prevent. A leading '-' has no match (DuckDB SILENTLY accepts a negative
+// limit as effectively unlimited), and a zero magnitude is rejected separately
+// in validateDuckDBMemoryLimit (DuckDB accepts e.g. '0GB' and uncaps).
+var duckDBMemoryLimitRE = regexp.MustCompile(`(?i)^(\d+(?:\.\d+)?)\s*(b|kb|mb|gb|tb|kib|mib|gib|tib)$`)
+
+// validateDuckDBMemoryLimit rejects an operator-supplied --duckdb-memory-limit
+// that DuckDB would mishandle, turning a typo or a footgun into a clear CLI
+// error instead of a silent fall-back to the default (or a silent uncap).
+func validateDuckDBMemoryLimit(s string) error {
+	m := duckDBMemoryLimitRE.FindStringSubmatch(strings.TrimSpace(s))
+	if m == nil {
+		return fmt.Errorf("invalid --duckdb-memory-limit %q: expected a positive size with a unit, e.g. 16GB, 512MB, or 16GiB (units: B/KB/MB/GB/TB or KiB/MiB/GiB/TiB)", s)
+	}
+	if v, err := strconv.ParseFloat(m[1], 64); err != nil || v <= 0 {
+		return fmt.Errorf("invalid --duckdb-memory-limit %q: must be greater than zero (DuckDB treats a zero limit as unlimited)", s)
+	}
+	return nil
+}
 
 // addDuckDBTuningFlags registers the shared DuckDB resource flags on the
 // offline query/recover/reconstruct commands. They lift the conservative,
@@ -61,8 +78,8 @@ func duckDBTuningFromFlags(cmd *cobra.Command) (duckdbutil.Tuning, error) {
 		t.Threads = threads
 	}
 	if mem, _ := cmd.Flags().GetString("duckdb-memory-limit"); mem != "" {
-		if !duckDBMemoryLimitRE.MatchString(strings.TrimSpace(mem)) {
-			return duckdbutil.Tuning{}, fmt.Errorf("invalid --duckdb-memory-limit %q: expected a positive size like 16GB / 512MB / 16GiB or a percentage like 80%%", mem)
+		if err := validateDuckDBMemoryLimit(mem); err != nil {
+			return duckdbutil.Tuning{}, err
 		}
 		t.MemoryLimit = mem
 	}

--- a/cmd/bintrail/duckdbtuning_test.go
+++ b/cmd/bintrail/duckdbtuning_test.go
@@ -45,9 +45,9 @@ func TestDuckDBTuningFromFlags(t *testing.T) {
 			want:  duckdbutil.Tuning{Threads: 2, MemoryLimit: "16GiB"},
 		},
 		{
-			name:  "percentage memory-limit accepted",
-			flags: map[string]string{"duckdb-memory-limit": "80%"},
-			want:  duckdbutil.Tuning{Threads: 2, MemoryLimit: "80%"},
+			name:  "decimal memory-limit accepted",
+			flags: map[string]string{"duckdb-memory-limit": "2.5GB"},
+			want:  duckdbutil.Tuning{Threads: 2, MemoryLimit: "2.5GB"},
 		},
 		{
 			name:  "explicit threads=0 means one-per-core, overriding default 2",
@@ -65,10 +65,30 @@ func TestDuckDBTuningFromFlags(t *testing.T) {
 			want:  duckdbutil.Tuning{Threads: 0, MemoryLimit: "16GB"},
 		},
 		{
-			// Negative is the dangerous case: DuckDB silently accepts it and
+			// Negative is a dangerous case: DuckDB silently accepts it and
 			// uncaps memory, so the CLI must reject it up front.
 			name:    "negative memory-limit → error",
 			flags:   map[string]string{"duckdb-memory-limit": "-4GB"},
+			wantErr: true,
+		},
+		{
+			// Zero is the other silent-uncap: DuckDB accepts e.g. '0GB' and
+			// treats it as unlimited.
+			name:    "zero memory-limit → error",
+			flags:   map[string]string{"duckdb-memory-limit": "0GB"},
+			wantErr: true,
+		},
+		{
+			// A percentage / a bare unitless number are NOT accepted by the
+			// linked DuckDB — rejecting them at the CLI avoids a silent
+			// fall-back to the default at Apply time.
+			name:    "percentage memory-limit → error",
+			flags:   map[string]string{"duckdb-memory-limit": "80%"},
+			wantErr: true,
+		},
+		{
+			name:    "bare unitless number → error",
+			flags:   map[string]string{"duckdb-memory-limit": "1024"},
 			wantErr: true,
 		},
 		{

--- a/cmd/bintrail/duckdbtuning_test.go
+++ b/cmd/bintrail/duckdbtuning_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dbtrail/dbtrail/internal/duckdbutil"
+)
+
+// TestDuckDBTuningFromFlags pins the precedence contract: an explicit --duckdb-*
+// flag wins over --ultrafast, which wins over the conservative default. The
+// no-flags row guards the "don't break anything" invariant — with the feature
+// off, callers get exactly the budget parquetquery.Fetch used before #510.
+func TestDuckDBTuningFromFlags(t *testing.T) {
+	tests := []struct {
+		name  string
+		flags map[string]string
+		want  duckdbutil.Tuning
+	}{
+		{
+			name:  "no flags → conservative default",
+			flags: nil,
+			want:  duckdbutil.Tuning{Threads: 2, MemoryLimit: "4GB"},
+		},
+		{
+			name:  "ultrafast → DuckDB self-tunes (both unset)",
+			flags: map[string]string{"ultrafast": "true"},
+			want:  duckdbutil.Tuning{},
+		},
+		{
+			name:  "explicit threads overrides the default base",
+			flags: map[string]string{"duckdb-threads": "8"},
+			want:  duckdbutil.Tuning{Threads: 8, MemoryLimit: "4GB"},
+		},
+		{
+			name:  "explicit memory-limit overrides the default base",
+			flags: map[string]string{"duckdb-memory-limit": "16GB"},
+			want:  duckdbutil.Tuning{Threads: 2, MemoryLimit: "16GB"},
+		},
+		{
+			name:  "explicit threads=0 means one-per-core, overriding default 2",
+			flags: map[string]string{"duckdb-threads": "0"},
+			want:  duckdbutil.Tuning{Threads: 0, MemoryLimit: "4GB"},
+		},
+		{
+			name:  "ultrafast + explicit threads → threads applied, memory stays unset",
+			flags: map[string]string{"ultrafast": "true", "duckdb-threads": "8"},
+			want:  duckdbutil.Tuning{Threads: 8, MemoryLimit: ""},
+		},
+		{
+			name:  "ultrafast + explicit memory-limit → memory applied, threads stays unset",
+			flags: map[string]string{"ultrafast": "true", "duckdb-memory-limit": "16GB"},
+			want:  duckdbutil.Tuning{Threads: 0, MemoryLimit: "16GB"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{Use: "test"}
+			addDuckDBTuningFlags(cmd)
+			for flag, val := range tt.flags {
+				if err := cmd.Flags().Set(flag, val); err != nil {
+					t.Fatalf("set --%s=%s: %v", flag, val, err)
+				}
+			}
+			if got := duckDBTuningFromFlags(cmd); got != tt.want {
+				t.Fatalf("duckDBTuningFromFlags() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestTunedArchiveFetcherNonNil: the adapter must always return a usable
+// fetcher (it is passed where a nil ArchiveFetcher is a hard error).
+func TestTunedArchiveFetcherNonNil(t *testing.T) {
+	if tunedArchiveFetcher(duckdbutil.DefaultTuning()) == nil {
+		t.Fatal("tunedArchiveFetcher returned nil")
+	}
+}

--- a/cmd/bintrail/duckdbtuning_test.go
+++ b/cmd/bintrail/duckdbtuning_test.go
@@ -14,9 +14,10 @@ import (
 // off, callers get exactly the budget parquetquery.Fetch used before #510.
 func TestDuckDBTuningFromFlags(t *testing.T) {
 	tests := []struct {
-		name  string
-		flags map[string]string
-		want  duckdbutil.Tuning
+		name    string
+		flags   map[string]string
+		want    duckdbutil.Tuning
+		wantErr bool
 	}{
 		{
 			name:  "no flags → conservative default",
@@ -39,6 +40,16 @@ func TestDuckDBTuningFromFlags(t *testing.T) {
 			want:  duckdbutil.Tuning{Threads: 2, MemoryLimit: "16GB"},
 		},
 		{
+			name:  "binary-unit memory-limit accepted",
+			flags: map[string]string{"duckdb-memory-limit": "16GiB"},
+			want:  duckdbutil.Tuning{Threads: 2, MemoryLimit: "16GiB"},
+		},
+		{
+			name:  "percentage memory-limit accepted",
+			flags: map[string]string{"duckdb-memory-limit": "80%"},
+			want:  duckdbutil.Tuning{Threads: 2, MemoryLimit: "80%"},
+		},
+		{
 			name:  "explicit threads=0 means one-per-core, overriding default 2",
 			flags: map[string]string{"duckdb-threads": "0"},
 			want:  duckdbutil.Tuning{Threads: 0, MemoryLimit: "4GB"},
@@ -53,6 +64,18 @@ func TestDuckDBTuningFromFlags(t *testing.T) {
 			flags: map[string]string{"ultrafast": "true", "duckdb-memory-limit": "16GB"},
 			want:  duckdbutil.Tuning{Threads: 0, MemoryLimit: "16GB"},
 		},
+		{
+			// Negative is the dangerous case: DuckDB silently accepts it and
+			// uncaps memory, so the CLI must reject it up front.
+			name:    "negative memory-limit → error",
+			flags:   map[string]string{"duckdb-memory-limit": "-4GB"},
+			wantErr: true,
+		},
+		{
+			name:    "garbage memory-limit → error",
+			flags:   map[string]string{"duckdb-memory-limit": "lots"},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -64,7 +87,17 @@ func TestDuckDBTuningFromFlags(t *testing.T) {
 					t.Fatalf("set --%s=%s: %v", flag, val, err)
 				}
 			}
-			if got := duckDBTuningFromFlags(cmd); got != tt.want {
+			got, err := duckDBTuningFromFlags(cmd)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("duckDBTuningFromFlags() = %+v, want error", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("duckDBTuningFromFlags() unexpected error: %v", err)
+			}
+			if got != tt.want {
 				t.Fatalf("duckDBTuningFromFlags() = %+v, want %+v", got, tt.want)
 			}
 		})

--- a/cmd/bintrail/envload.go
+++ b/cmd/bintrail/envload.go
@@ -57,6 +57,9 @@ var envBindings = []envBinding{
 	{"rotate-retain", "BINTRAIL_ROTATE_RETAIN"},
 	{"rotate-interval", "BINTRAIL_ROTATE_INTERVAL"},
 	{"rotate-add-future", "BINTRAIL_ROTATE_ADD_FUTURE"},
+	{"ultrafast", "BINTRAIL_ULTRAFAST"},
+	{"duckdb-threads", "BINTRAIL_DUCKDB_THREADS"},
+	{"duckdb-memory-limit", "BINTRAIL_DUCKDB_MEMORY_LIMIT"},
 }
 
 var envOnce sync.Once

--- a/cmd/bintrail/query.go
+++ b/cmd/bintrail/query.go
@@ -18,7 +18,6 @@ import (
 	"github.com/dbtrail/dbtrail/internal/cliutil"
 	"github.com/dbtrail/dbtrail/internal/config"
 	"github.com/dbtrail/dbtrail/internal/indexer"
-	"github.com/dbtrail/dbtrail/internal/parquetquery"
 	"github.com/dbtrail/dbtrail/internal/parser"
 	"github.com/dbtrail/dbtrail/internal/query"
 )
@@ -99,6 +98,7 @@ func init() {
 	queryCmd.Flags().BoolVar(&qNoArchive, "no-archive", false, "Disable auto-routing to Parquet archives (MySQL-only results)")
 	queryCmd.Flags().BoolVar(&qIncludeSnapshot, "include-snapshot", false, "Also scan the mydumper baseline Parquet and emit matching rows as SNAPSHOT events (requires --baseline, --schema, --table)")
 	queryCmd.Flags().StringVar(&qBaseline, "baseline", "", "Path to a baseline Parquet file or directory containing <schema>/<table>.parquet (local path or s3:// URL); used with --include-snapshot")
+	addDuckDBTuningFlags(queryCmd)
 	_ = queryCmd.MarkFlagRequired("index-dsn")
 	bindCommandEnv(queryCmd)
 
@@ -318,7 +318,7 @@ func runQuery(cmd *cobra.Command, args []string) error {
 			cmd.Context(),
 			archSources,
 			fetchOpts,
-			parquetquery.Fetch,
+			tunedArchiveFetcher(duckDBTuningFromFlags(cmd)),
 			os.Stderr,
 		)
 		if err != nil {

--- a/cmd/bintrail/query.go
+++ b/cmd/bintrail/query.go
@@ -153,6 +153,10 @@ func runQuery(cmd *cobra.Command, args []string) error {
 	if qNoArchive && (qArchiveDir != "" || qArchiveS3 != "") {
 		return fmt.Errorf("--no-archive cannot be combined with --archive-dir or --archive-s3")
 	}
+	duckTuning, err := duckDBTuningFromFlags(cmd)
+	if err != nil {
+		return err
+	}
 	if qIncludeSnapshot {
 		if qBaseline == "" {
 			return fmt.Errorf("--include-snapshot requires --baseline")
@@ -318,7 +322,7 @@ func runQuery(cmd *cobra.Command, args []string) error {
 			cmd.Context(),
 			archSources,
 			fetchOpts,
-			tunedArchiveFetcher(duckDBTuningFromFlags(cmd)),
+			tunedArchiveFetcher(duckTuning),
 			os.Stderr,
 		)
 		if err != nil {

--- a/cmd/bintrail/reconstruct.go
+++ b/cmd/bintrail/reconstruct.go
@@ -266,12 +266,16 @@ func runReconstruct(cmd *cobra.Command, args []string) error {
 		Since:    &snapshotTime,
 		Until:    &at,
 	}
+	duckTuning, err := duckDBTuningFromFlags(cmd)
+	if err != nil {
+		return err
+	}
 	events, _, err := query.FetchMerged(cmd.Context(), db, engine, query.FetchMergedOptions{
 		Opts:           opts,
 		DBName:         dbName,
 		NoArchive:      recNoArchive,
 		AllowGaps:      recAllowGaps,
-		ArchiveFetcher: tunedArchiveFetcher(duckDBTuningFromFlags(cmd)),
+		ArchiveFetcher: tunedArchiveFetcher(duckTuning),
 	})
 	if err != nil {
 		// Surface CLI hints only at the CLI layer; the library types
@@ -465,6 +469,11 @@ func runReconstructFullTable(cmd *cobra.Command, start time.Time) error {
 		baselineSrc = recBaselineS3
 	}
 
+	duckTuning, err := duckDBTuningFromFlags(cmd)
+	if err != nil {
+		return err
+	}
+
 	// ── Run ────────────────────────────────────────────────────────────────
 	cfg := reconstruct.FullTableConfig{
 		IndexDSN:       recIndexDSN,
@@ -475,7 +484,7 @@ func runReconstructFullTable(cmd *cobra.Command, start time.Time) error {
 		ChunkSize:      chunkSize,
 		Parallelism:    recParallelism,
 		AllowGaps:      recAllowGaps,
-		ArchiveFetcher: tunedArchiveFetcher(duckDBTuningFromFlags(cmd)),
+		ArchiveFetcher: tunedArchiveFetcher(duckTuning),
 	}
 	reports, err := reconstruct.ReconstructTables(cmd.Context(), cfg)
 	if err != nil {

--- a/cmd/bintrail/reconstruct.go
+++ b/cmd/bintrail/reconstruct.go
@@ -15,7 +15,6 @@ import (
 	"github.com/dbtrail/dbtrail/internal/baseline"
 	"github.com/dbtrail/dbtrail/internal/cliutil"
 	"github.com/dbtrail/dbtrail/internal/config"
-	"github.com/dbtrail/dbtrail/internal/parquetquery"
 	"github.com/dbtrail/dbtrail/internal/query"
 	"github.com/dbtrail/dbtrail/internal/reconstruct"
 )
@@ -119,6 +118,7 @@ func init() {
 	reconstructCmd.Flags().StringVar(&recTables, "tables", "", "Comma-separated schema.table list for --output-format=mydumper (e.g. mydb.orders,mydb.users)")
 	reconstructCmd.Flags().StringVar(&recChunkSize, "chunk-size", "256MB", "Max size per SQL chunk file in full-table mode (e.g. 64MB, 1GB)")
 	reconstructCmd.Flags().IntVar(&recParallelism, "parallelism", 0, "Max tables to reconstruct concurrently in full-table mode (default: runtime.NumCPU())")
+	addDuckDBTuningFlags(reconstructCmd)
 	bindCommandEnv(reconstructCmd)
 
 	rootCmd.AddCommand(reconstructCmd)
@@ -271,7 +271,7 @@ func runReconstruct(cmd *cobra.Command, args []string) error {
 		DBName:         dbName,
 		NoArchive:      recNoArchive,
 		AllowGaps:      recAllowGaps,
-		ArchiveFetcher: parquetquery.Fetch,
+		ArchiveFetcher: tunedArchiveFetcher(duckDBTuningFromFlags(cmd)),
 	})
 	if err != nil {
 		// Surface CLI hints only at the CLI layer; the library types
@@ -467,14 +467,15 @@ func runReconstructFullTable(cmd *cobra.Command, start time.Time) error {
 
 	// ── Run ────────────────────────────────────────────────────────────────
 	cfg := reconstruct.FullTableConfig{
-		IndexDSN:    recIndexDSN,
-		BaselineSrc: baselineSrc,
-		Tables:      tables,
-		At:          at,
-		OutputDir:   recOutputDir,
-		ChunkSize:   chunkSize,
-		Parallelism: recParallelism,
-		AllowGaps:   recAllowGaps,
+		IndexDSN:       recIndexDSN,
+		BaselineSrc:    baselineSrc,
+		Tables:         tables,
+		At:             at,
+		OutputDir:      recOutputDir,
+		ChunkSize:      chunkSize,
+		Parallelism:    recParallelism,
+		AllowGaps:      recAllowGaps,
+		ArchiveFetcher: tunedArchiveFetcher(duckDBTuningFromFlags(cmd)),
 	}
 	reports, err := reconstruct.ReconstructTables(cmd.Context(), cfg)
 	if err != nil {

--- a/cmd/bintrail/recover.go
+++ b/cmd/bintrail/recover.go
@@ -209,12 +209,16 @@ func runRecover(cmd *cobra.Command, args []string) error {
 		dbName = cfg.DBName
 	}
 
+	duckTuning, err := duckDBTuningFromFlags(cmd)
+	if err != nil {
+		return err
+	}
 	rows, _, err := query.FetchMerged(cmd.Context(), db, engine, query.FetchMergedOptions{
 		Opts:           opts,
 		DBName:         dbName,
 		NoArchive:      rNoArchive || rProfile != "",
 		AllowGaps:      true, // preserve recover's warn-and-continue behavior
-		ArchiveFetcher: tunedArchiveFetcher(duckDBTuningFromFlags(cmd)),
+		ArchiveFetcher: tunedArchiveFetcher(duckTuning),
 	})
 	if err != nil {
 		return err

--- a/cmd/bintrail/recover.go
+++ b/cmd/bintrail/recover.go
@@ -15,7 +15,6 @@ import (
 	"github.com/dbtrail/dbtrail/internal/config"
 	"github.com/dbtrail/dbtrail/internal/indexer"
 	"github.com/dbtrail/dbtrail/internal/metadata"
-	"github.com/dbtrail/dbtrail/internal/parquetquery"
 	"github.com/dbtrail/dbtrail/internal/query"
 	"github.com/dbtrail/dbtrail/internal/recovery"
 )
@@ -90,6 +89,7 @@ func init() {
 	recoverCmd.Flags().StringVar(&rProfile, "profile", "", "Apply RBAC access rules for this profile (table-level deny and column-level redaction)")
 	recoverCmd.Flags().StringVar(&rFormat, "format", "text", "Output format: text or json")
 	recoverCmd.Flags().BoolVar(&rNoArchive, "no-archive", false, "Disable auto-routing to Parquet archives (MySQL-only results)")
+	addDuckDBTuningFlags(recoverCmd)
 	_ = recoverCmd.MarkFlagRequired("index-dsn")
 	bindCommandEnv(recoverCmd)
 
@@ -214,7 +214,7 @@ func runRecover(cmd *cobra.Command, args []string) error {
 		DBName:         dbName,
 		NoArchive:      rNoArchive || rProfile != "",
 		AllowGaps:      true, // preserve recover's warn-and-continue behavior
-		ArchiveFetcher: parquetquery.Fetch,
+		ArchiveFetcher: tunedArchiveFetcher(duckDBTuningFromFlags(cmd)),
 	})
 	if err != nil {
 		return err

--- a/docs/query-and-recovery.md
+++ b/docs/query-and-recovery.md
@@ -143,6 +143,15 @@ That strictness deliberately includes stale registrations: an `archive_state` ro
 
 The merge path loads **all matching rows** from all sources into memory before applying the limit. Filters (schema, table, time range, etc.) bound the result set in practice. For extremely broad queries against large archives, memory usage could be significant — apply at least a `--since`/`--until` range to keep the result set manageable.
 
+### DuckDB resource tuning (`--ultrafast`)
+
+When `query`, `recover`, or `reconstruct` scan Parquet archives, DuckDB runs under a conservative, container-safe budget by default: **2 threads and a 4 GB memory limit**, spilling to the OS temp directory when exceeded. These defaults keep bintrail alive in small shared containers; on a dedicated box with plenty of RAM they leave performance on the table.
+
+- `--ultrafast` lets DuckDB self-tune to the host: it uses **all CPU cores** and **~80% of physical RAM**, still spilling to the temp directory before hitting the limit. This trades memory-safety for speed — use it for offline recovery on a big machine, **not** in a small container. It does **not** remove the memory limit (which would invite the OOM-killer instead of a graceful spill); it lets DuckDB pick its own RAM-aware limit.
+- `--duckdb-threads N` and `--duckdb-memory-limit SIZE` (e.g. `16GB`) override either knob independently. An explicit flag wins over `--ultrafast`, which wins over the default — so you can tune to your box without the all-or-nothing switch.
+
+Equivalent env vars: `BINTRAIL_ULTRAFAST=1`, `BINTRAIL_DUCKDB_THREADS`, `BINTRAIL_DUCKDB_MEMORY_LIMIT`. These flags affect only the offline CLI commands; the long-lived `shim` and `bintrail-console` daemons always use the safe default.
+
 ### S3 Prerequisites
 
 - **Archived events** (`--archive-s3`): objects are listed and downloaded with the **AWS SDK** — the full default credential chain applies (env keys, `~/.aws` profiles incl. SSO, EC2/ECS/EKS IAM roles). DuckDB then scans the downloaded files locally; its `httpfs` extension is not involved on this path.

--- a/internal/duckdbutil/tuning.go
+++ b/internal/duckdbutil/tuning.go
@@ -1,0 +1,68 @@
+package duckdbutil
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"strings"
+)
+
+// Tuning holds the two DuckDB resource knobs bintrail sets on its Parquet query
+// session (threads + memory budget). A zero-valued field means "leave it
+// unset", so DuckDB applies its own native default: threads = one per CPU core,
+// memory_limit = ~80% of physical RAM. Both spill to temp_directory when
+// exceeded, so leaving them unset is "let DuckDB use more RAM before spilling",
+// not "unbounded" — the temp_directory backstop still prevents the OOM-killer.
+//
+// bintrail's shipped default (DefaultTuning) caps both low for small-container
+// safety. Ultrafast lifts the cap by leaving them unset and letting DuckDB
+// self-tune to the host (#509). Apply only emits a SET for a non-zero field, so
+// these two constructors are not special-cased anywhere — the same struct
+// expresses "default", "ultrafast", and any explicit operator override.
+//
+// temp_directory and preserve_insertion_order are deliberately NOT in this
+// struct: they are not memory-for-speed trade-offs (the former is the spill
+// backstop, the latter is a win-win that is safe under our explicit ORDER BY),
+// so parquetquery sets them unconditionally regardless of Tuning.
+type Tuning struct {
+	// Threads is the DuckDB thread count (SET threads = N). 0 leaves it unset,
+	// so DuckDB defaults to one thread per CPU core.
+	Threads int
+	// MemoryLimit is the DuckDB memory budget (SET memory_limit = '...'), e.g.
+	// "4GB". Empty leaves it unset, so DuckDB defaults to ~80% of physical RAM.
+	MemoryLimit string
+}
+
+// DefaultTuning is bintrail's conservative, container-safe DuckDB budget — the
+// exact values parquetquery.Fetch hardcoded before this struct existed (#510).
+// Used by every long-lived/shared caller (shim, console, agent) and as the
+// base the CLI tuning flags build on.
+func DefaultTuning() Tuning { return Tuning{Threads: 2, MemoryLimit: "4GB"} }
+
+// Ultrafast trades the container-safe cap for speed: both knobs unset, so
+// DuckDB self-tunes to the host (all cores, ~80% RAM, spilling to
+// temp_directory). For big boxes running the offline query/recover/reconstruct
+// commands, not the small shared containers the shim runs in. See #509.
+func Ultrafast() Tuning { return Tuning{} }
+
+// Apply emits the SET statements for the non-zero fields on db. Best-effort,
+// matching the rest of duckdbutil: a failed SET is logged at WARN and the
+// session falls back to DuckDB's default for that knob rather than aborting the
+// query. Call it on a freshly opened DuckDB session.
+func (t Tuning) Apply(ctx context.Context, db *sql.DB) {
+	if t.Threads > 0 {
+		applyTuningStmt(ctx, db, fmt.Sprintf("SET threads = %d", t.Threads))
+	}
+	if t.MemoryLimit != "" {
+		// Mirror parquetquery's temp_directory concatenation; escape single
+		// quotes so an operator-supplied value can't break out of the literal.
+		applyTuningStmt(ctx, db, "SET memory_limit = '"+strings.ReplaceAll(t.MemoryLimit, "'", "''")+"'")
+	}
+}
+
+func applyTuningStmt(ctx context.Context, db *sql.DB, stmt string) {
+	if _, err := db.ExecContext(ctx, stmt); err != nil {
+		slog.Warn("could not configure DuckDB", "statement", stmt, "error", err)
+	}
+}

--- a/internal/duckdbutil/tuning.go
+++ b/internal/duckdbutil/tuning.go
@@ -21,6 +21,10 @@ import (
 // these two constructors are not special-cased anywhere — the same struct
 // expresses "default", "ultrafast", and any explicit operator override.
 //
+// Note the polarity: the whole-struct zero value Tuning{} equals Ultrafast()
+// (host-greedy), NOT the container-safe budget. A caller that wants the safe
+// default must call DefaultTuning() explicitly rather than rely on a zero value.
+//
 // temp_directory and preserve_insertion_order are deliberately NOT in this
 // struct: they are not memory-for-speed trade-offs (the former is the spill
 // backstop, the latter is a win-win that is safe under our explicit ORDER BY),

--- a/internal/duckdbutil/tuning_test.go
+++ b/internal/duckdbutil/tuning_test.go
@@ -1,0 +1,100 @@
+package duckdbutil
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	_ "github.com/duckdb/duckdb-go/v2"
+)
+
+// TestTuningConstructors pins the two named budgets so renaming or retuning
+// them is a deliberate, test-visible change. DefaultTuning must reproduce the
+// values parquetquery.Fetch hardcoded before this struct existed; Ultrafast
+// must be the zero value (both knobs unset → DuckDB self-tunes).
+func TestTuningConstructors(t *testing.T) {
+	if got := DefaultTuning(); got.Threads != 2 || got.MemoryLimit != "4GB" {
+		t.Fatalf("DefaultTuning() = %+v, want {Threads:2 MemoryLimit:4GB}", got)
+	}
+	if got := Ultrafast(); got != (Tuning{}) {
+		t.Fatalf("Ultrafast() = %+v, want zero Tuning{}", got)
+	}
+}
+
+// TestTuningApplyDefault: the conservative budget reaches DuckDB. threads is
+// the clean deterministic signal; memory_limit is only checked for presence
+// here because DuckDB renders it in base-2 units ('4GB' = 4×10^9 B → "3.7 GiB"),
+// which is awkward to pin — the override test below proves the value wires
+// through with a clean GiB unit.
+func TestTuningApplyDefault(t *testing.T) {
+	db := openDuckDB(t)
+	DefaultTuning().Apply(context.Background(), db)
+
+	if got := currentSetting(t, db, "threads"); got != "2" {
+		t.Fatalf("threads after DefaultTuning = %q, want 2", got)
+	}
+	if mem := currentSetting(t, db, "memory_limit"); mem == "" {
+		t.Fatal("memory_limit empty after DefaultTuning; want it set")
+	}
+	assertUsable(t, db)
+}
+
+// TestTuningApplyUltrafastIsNoOp: an empty Tuning must emit no SET at all, so
+// DuckDB keeps its own native defaults. Proven by capturing the threads
+// setting before and after Apply and asserting it is unchanged — this does not
+// assume how many cores the test host has.
+func TestTuningApplyUltrafastIsNoOp(t *testing.T) {
+	db := openDuckDB(t)
+
+	before := currentSetting(t, db, "threads")
+	Ultrafast().Apply(context.Background(), db)
+	after := currentSetting(t, db, "threads")
+
+	if before != after {
+		t.Fatalf("Ultrafast().Apply changed threads %q → %q; want it left at DuckDB's default", before, after)
+	}
+	assertUsable(t, db)
+}
+
+// TestTuningApplyExplicitOverride: an operator-supplied Tuning (the --duckdb-*
+// flags) takes effect verbatim. Uses a base-2 GiB value so DuckDB's rendered
+// form is exact and unit-stable ("2.0 GiB"), unlike a base-10 GB suffix.
+func TestTuningApplyExplicitOverride(t *testing.T) {
+	db := openDuckDB(t)
+	Tuning{Threads: 8, MemoryLimit: "2GiB"}.Apply(context.Background(), db)
+
+	if got := currentSetting(t, db, "threads"); got != "8" {
+		t.Fatalf("threads after override = %q, want 8", got)
+	}
+	if mem := currentSetting(t, db, "memory_limit"); mem != "2.0 GiB" {
+		t.Fatalf("memory_limit after override = %q, want \"2.0 GiB\"", mem)
+	}
+	assertUsable(t, db)
+}
+
+func openDuckDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func currentSetting(t *testing.T, db *sql.DB, name string) string {
+	t.Helper()
+	var v string
+	if err := db.QueryRow("SELECT current_setting('" + name + "')").Scan(&v); err != nil {
+		t.Fatalf("read current_setting(%q): %v", name, err)
+	}
+	return v
+}
+
+func assertUsable(t *testing.T, db *sql.DB) {
+	t.Helper()
+	var one int
+	if err := db.QueryRow("SELECT 1").Scan(&one); err != nil || one != 1 {
+		t.Fatalf("session unusable after Apply: %v (got %d)", err, one)
+	}
+}

--- a/internal/duckdbutil/tuning_test.go
+++ b/internal/duckdbutil/tuning_test.go
@@ -46,12 +46,15 @@ func TestTuningApplyDefault(t *testing.T) {
 func TestTuningApplyUltrafastIsNoOp(t *testing.T) {
 	db := openDuckDB(t)
 
-	before := currentSetting(t, db, "threads")
+	threadsBefore := currentSetting(t, db, "threads")
+	memBefore := currentSetting(t, db, "memory_limit")
 	Ultrafast().Apply(context.Background(), db)
-	after := currentSetting(t, db, "threads")
 
-	if before != after {
-		t.Fatalf("Ultrafast().Apply changed threads %q → %q; want it left at DuckDB's default", before, after)
+	if after := currentSetting(t, db, "threads"); after != threadsBefore {
+		t.Fatalf("Ultrafast().Apply changed threads %q → %q; want it left at DuckDB's default", threadsBefore, after)
+	}
+	if after := currentSetting(t, db, "memory_limit"); after != memBefore {
+		t.Fatalf("Ultrafast().Apply changed memory_limit %q → %q; want it left at DuckDB's default", memBefore, after)
 	}
 	assertUsable(t, db)
 }

--- a/internal/parquetquery/parquetquery.go
+++ b/internal/parquetquery/parquetquery.go
@@ -22,6 +22,7 @@ import (
 	_ "github.com/duckdb/duckdb-go/v2"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/dbtrail/dbtrail/internal/duckdbutil"
 	"github.com/dbtrail/dbtrail/internal/parser"
 	"github.com/dbtrail/dbtrail/internal/query"
 )
@@ -30,7 +31,19 @@ import (
 // source is either a local directory path or an S3 URL prefix (s3://bucket/prefix/).
 // Archives follow the Hive-partitioned layout written by bintrail rotate
 // (event_date=YYYY-MM-DD/event_hour=HH/events.parquet).
+//
+// It applies bintrail's conservative, container-safe DuckDB budget
+// (duckdbutil.DefaultTuning). Long-lived/shared callers (shim, console, agent)
+// use this. The offline CLI commands that can afford more resources call
+// FetchWithTuning to lift the cap (#510).
 func Fetch(ctx context.Context, opts query.Options, source string) ([]query.ResultRow, error) {
+	return FetchWithTuning(ctx, opts, source, duckdbutil.DefaultTuning())
+}
+
+// FetchWithTuning is Fetch with an explicit DuckDB resource budget. See Tuning:
+// the conservative DefaultTuning (threads=2, memory_limit=4GB) is for small
+// containers; duckdbutil.Ultrafast lets DuckDB self-tune to the host.
+func FetchWithTuning(ctx context.Context, opts query.Options, source string, tuning duckdbutil.Tuning) ([]query.ResultRow, error) {
 	db, err := sql.Open("duckdb", "")
 	if err != nil {
 		return nil, fmt.Errorf("open duckdb: %w", err)
@@ -39,25 +52,26 @@ func Fetch(ctx context.Context, opts query.Options, source string) ([]query.Resu
 
 	// Use the OS temp directory for DuckDB scratch files. By default DuckDB
 	// creates a .tmp directory in the CWD, which fails in containers where
-	// the working directory (often /) is read-only.
+	// the working directory (often /) is read-only. Set unconditionally: it is
+	// the spill backstop, not a memory-for-speed knob, so it stays on even
+	// under ultrafast — exceeding the memory budget spills here instead of
+	// inviting the OOM-killer.
 	if _, err := db.ExecContext(ctx, "SET temp_directory = '"+os.TempDir()+"'"); err != nil {
 		slog.Warn("could not set DuckDB temp_directory", "error", err)
 	}
 
-	// Constrain DuckDB resource usage for container environments.
-	// DuckDB requires ~125MB per thread; 2 threads allows parallelism
-	// across row groups while staying within container memory limits.
-	// preserve_insertion_order is safe to disable because our queries
-	// have explicit ORDER BY.
-	for _, stmt := range []string{
-		"SET threads = 2",
-		"SET memory_limit = '4GB'",
-		"SET preserve_insertion_order = false",
-	} {
-		if _, err := db.ExecContext(ctx, stmt); err != nil {
-			slog.Warn("could not configure DuckDB", "statement", stmt, "error", err)
-		}
+	// preserve_insertion_order is safe to disable because our queries have
+	// explicit ORDER BY; disabling it lets DuckDB stream without buffering the
+	// whole result set to reorder. It saves memory AND is faster, so it stays
+	// on unconditionally — it is not part of the tunable trade-off.
+	if _, err := db.ExecContext(ctx, "SET preserve_insertion_order = false"); err != nil {
+		slog.Warn("could not configure DuckDB", "statement", "SET preserve_insertion_order = false", "error", err)
 	}
+
+	// Constrain DuckDB thread count and memory. DuckDB requires ~125MB per
+	// thread; the conservative default (2 threads, 4GB) keeps small containers
+	// alive, while ultrafast leaves both unset so DuckDB self-tunes to the host.
+	tuning.Apply(ctx, db)
 
 	// For S3, download each file locally via the AWS SDK and query with
 	// DuckDB from disk. This avoids DuckDB's httpfs extension which holds

--- a/internal/reconstruct/fulltable.go
+++ b/internal/reconstruct/fulltable.go
@@ -68,6 +68,12 @@ type FullTableConfig struct {
 	ChunkSize   int64     // per-chunk SQL file size (0 → 256 MiB)
 	Parallelism int       // max concurrent tables (0 → runtime.NumCPU())
 	AllowGaps   bool      // false = strict abort on gaps (default for reconstruct)
+
+	// ArchiveFetcher fetches archived binlog events for a table. nil →
+	// parquetquery.Fetch (the container-safe DuckDB budget). The CLI sets it
+	// to a tuned fetcher under --ultrafast so the flag is honored on the
+	// full-table path, not just single-row reconstruct (#510).
+	ArchiveFetcher query.ArchiveFetcher
 }
 
 // TableReport carries the per-table outcome stats that the CLI summary prints.
@@ -342,6 +348,13 @@ func ReconstructTable(
 		Until:  &cfg.At,
 		// No PKValues filter — we want every event for this table.
 	}
+	// nil ArchiveFetcher → the container-safe parquetquery.Fetch. Resolved here
+	// at the point of use so both ReconstructTables and any direct
+	// ReconstructTable caller get the default (#510).
+	fetcher := cfg.ArchiveFetcher
+	if fetcher == nil {
+		fetcher = parquetquery.Fetch
+	}
 	// Pass NoArchive=false unconditionally and let query.FetchMerged decide
 	// whether to query archives — it already handles the empty-archive case
 	// in its fast path. The previous `len(archSources)==0` gate was wrong:
@@ -352,7 +365,7 @@ func ReconstructTable(
 		DBName:         dbName,
 		NoArchive:      false,
 		AllowGaps:      cfg.AllowGaps,
-		ArchiveFetcher: parquetquery.Fetch,
+		ArchiveFetcher: fetcher,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("fetch events: %w", err)


### PR DESCRIPTION
closes #510

## Summary
Tier 1 of #509 — an opt-in mode that lifts the conservative, container-safe DuckDB budget on the offline archive-query paths, for operators running on a big box where the small-container defaults leave performance on the table.

- **Centralizes the tunable knobs** into `duckdbutil.Tuning{Threads, MemoryLimit}` + `Apply()`:
  - `DefaultTuning()` = `{2, "4GB"}` — reproduces what `parquetquery.Fetch` hardcoded, so **behavior is byte-identical when the feature is off**.
  - `Ultrafast()` = zero value — emits no `SET`, so DuckDB self-tunes to the host (all cores, ~80% RAM). It is **not** "unbounded": `temp_directory` stays on as the spill backstop, so exceeding RAM spills to disk instead of inviting the OOM-killer.
- **`temp_directory` and `preserve_insertion_order=false` stay unconditional** — the former is the spill backstop (correctness), the latter is a win-win that's safe under our explicit `ORDER BY`. Neither is part of the memory-for-speed trade-off, so neither moves under ultrafast.
- **`parquetquery.Fetch` keeps its signature** (passed as a function value by shim/console/agent — all untouched). The offline CLI commands wire a tuned `ArchiveFetcher` via the new `FetchWithTuning`.
- **Flags** on `query`/`recover`/`reconstruct`: `--ultrafast` plus granular `--duckdb-threads` / `--duckdb-memory-limit` escape hatches. Precedence: explicit flag > `--ultrafast` > default. Env: `BINTRAIL_ULTRAFAST`, `BINTRAIL_DUCKDB_THREADS`, `BINTRAIL_DUCKDB_MEMORY_LIMIT`.
- **Full-table reconstruct** honors the flag via a new optional `FullTableConfig.ArchiveFetcher` (nil → safe default, resolved at point of use so direct `ReconstructTable` callers are unaffected).
- Docs note in `docs/query-and-recovery.md`.

## Out of scope (deliberately)
- The long-lived **shim / `bintrail-console`** daemons — they keep the safe default (#509 non-goal: an OOM there kills a shared daemon, not a retryable one-shot query).
- **Tier 2** (#511): S3 httpfs-direct + parallel per-file queries (real OOM risk).

## Design note
The issue originally proposed detecting host RAM via syscall (~75%) with a 4GB fallback. Instead, ultrafast leaves `threads`/`memory_limit` **unset** so DuckDB applies its own native defaults (one thread per core, ~80% RAM, spilling to `temp_directory`). DuckDB already does the RAM-aware computation — this drops the syscall, platform build-tags, and fallback code entirely (Occam's razor) while keeping the spill backstop the reviewer required.

## Test plan
- [x] Unit tests pass (`go test ./... -count=1` → exit 0, 28 packages ok)
- [x] `go build ./...` + `go vet ./...` clean
- [x] `duckdbutil.Tuning.Apply` verified against a real in-process DuckDB (threads exact; memory via clean GiB unit — DuckDB renders `'4GB'` base-10 input as base-2 `"3.7 GiB"`, so the override test uses `2GiB`)
- [x] `duckDBTuningFromFlags` precedence table (default / ultrafast / each override / combinations)
- [x] `config_test` envBindings↔envSections sync passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)