### PR TITLE
feat: MariaDB as a replication source (alpha)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,11 @@ jobs:
     env:
       BINTRAIL_TEST_DSN: "root:testroot@tcp(127.0.0.1:13306)"
       BINTRAIL_TEST_MARIADB_DSN: "root:testroot@tcp(127.0.0.1:13307)"
+      # A MariaDB source is guaranteed present in this job, so the MariaDB tests
+      # must FAIL (not silently skip) if they can't run — otherwise a handshake
+      # regression would pass as green-via-skip. The 8.0/8.4 matrix leaves this
+      # unset, so the same tests skip politely there.
+      BINTRAIL_REQUIRE_MARIADB: "1"
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,69 @@ jobs:
       - name: Integration tests (-tags=integration)
         run: go test -tags=integration -race -p 1 -count=1 ./...
 
+  integration-mariadb-source:
+    # MariaDB-as-source alpha. A MariaDB-source test pairs a NEW MariaDB SOURCE
+    # container (13307) with the existing MySQL INDEX container (13306) — two
+    # containers a single matrix cell of the `integration` job cannot host, and
+    # bolting MariaDB into that job would also perturb the shared-binlog window
+    # the parser count-assertions depend on (#415). So it gets its own job, and
+    # the 8.0/8.4 matrix above stays byte-identical. Runs only the MariaDB-named
+    # tests (-run); the MySQL-only MariaDB tests (sqlmock/index-side) also run in
+    # the matrix job, where the live-replication test skips for lack of a source.
+    runs-on: ubuntu-22.04
+
+    env:
+      BINTRAIL_TEST_DSN: "root:testroot@tcp(127.0.0.1:13306)"
+      BINTRAIL_TEST_MARIADB_DSN: "root:testroot@tcp(127.0.0.1:13307)"
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Start MySQL index (bintrail-test-mysql, 8.4)
+        run: |
+          docker run -d --name bintrail-test-mysql \
+            -e MYSQL_ROOT_PASSWORD=testroot \
+            -p 13306:3306 \
+            mysql:8.4 \
+            --binlog-format=ROW --binlog-row-image=FULL --log-bin=binlog --server-id=1
+          for i in $(seq 1 60); do
+            if docker exec bintrail-test-mysql mysqladmin ping -u root -ptestroot --silent 2>/dev/null; then
+              echo "MySQL index is ready."; exit 0
+            fi
+            sleep 2
+          done
+          echo "MySQL did not become ready in time" >&2
+          docker logs bintrail-test-mysql >&2 || true
+          exit 1
+
+      - name: Start MariaDB source (bintrail-test-mariadb, 11.4)
+        run: |
+          docker run -d --name bintrail-test-mariadb \
+            -e MARIADB_ROOT_PASSWORD=testroot \
+            -p 13307:3306 \
+            mariadb:11.4 \
+            --log-bin=mariadb-bin --binlog-format=ROW --binlog-row-image=FULL \
+            --server-id=2 --gtid-strict-mode=ON
+          for i in $(seq 1 60); do
+            if docker exec bintrail-test-mariadb mariadb-admin ping -u root -ptestroot --silent 2>/dev/null; then
+              echo "MariaDB source is ready."; exit 0
+            fi
+            sleep 2
+          done
+          echo "MariaDB did not become ready in time" >&2
+          docker logs bintrail-test-mariadb >&2 || true
+          exit 1
+
+      # -run selects the MariaDB-named tests across all packages; -p 1 serializes
+      # so the shared binlog window stays single-writer (same rationale as the
+      # MySQL integration job).
+      - name: MariaDB-source integration tests
+        run: go test -tags=integration -race -p 1 -count=1 -run 'MariaDB|Mariadb|mariadb|Flavor|FourColumns' ./...
+
   console-e2e:
     # Headless-Chrome regression guard for the console SPA: go test never
     # renders assets/*, so CSS/DOM/presentation bugs (invisible buttons, a

--- a/cmd/bintrail/config.go
+++ b/cmd/bintrail/config.go
@@ -92,6 +92,7 @@ var envSections = []envSection{
 		Bindings: []envTemplateEntry{
 			{"BINTRAIL_INDEX_DSN", "user:pass@tcp(host:3306)/binlog_index"},
 			{"BINTRAIL_SOURCE_DSN", "user:pass@tcp(host:3306)/myapp"},
+			{"BINTRAIL_SOURCE_FLAVOR", "mysql"},
 		},
 	},
 	{

--- a/cmd/bintrail/envload.go
+++ b/cmd/bintrail/envload.go
@@ -25,6 +25,7 @@ type envBinding struct {
 var envBindings = []envBinding{
 	{"index-dsn", "BINTRAIL_INDEX_DSN"},
 	{"source-dsn", "BINTRAIL_SOURCE_DSN"},
+	{"source-flavor", "BINTRAIL_SOURCE_FLAVOR"},
 	{"schemas", "BINTRAIL_SCHEMAS"},
 	{"tables", "BINTRAIL_TABLES"},
 	{"bintrail-id", "BINTRAIL_ID"},

--- a/cmd/bintrail/stream.go
+++ b/cmd/bintrail/stream.go
@@ -52,6 +52,7 @@ a checkpoint before exiting.`,
 var (
 	strmIndexDSN    string
 	strmSourceDSN   string
+	strmFlavor      string
 	strmServerID    uint32
 	strmStartFile   string
 	strmStartPos    uint32
@@ -74,6 +75,7 @@ var (
 func init() {
 	streamCmd.Flags().StringVar(&strmIndexDSN, "index-dsn", "", "DSN for the index MySQL database (required)")
 	streamCmd.Flags().StringVar(&strmSourceDSN, "source-dsn", "", "DSN for the source MySQL server (required)")
+	streamCmd.Flags().StringVar(&strmFlavor, "source-flavor", "mysql", "Source database flavor: mysql or mariadb (MariaDB source support is alpha; prefer position mode for resume)")
 	streamCmd.Flags().Uint32Var(&strmServerID, "server-id", 0, "Unique replica server ID (required, must differ from all other servers)")
 	streamCmd.Flags().StringVar(&strmStartFile, "start-file", "", "Initial binlog file (mutually exclusive with --start-gtid)")
 	streamCmd.Flags().Uint32Var(&strmStartPos, "start-pos", 4, "Initial position within start file")
@@ -107,6 +109,7 @@ func streamConfigFromFlags() streamrun.Config {
 	return streamrun.Config{
 		IndexDSN:    strmIndexDSN,
 		SourceDSN:   strmSourceDSN,
+		Flavor:      strmFlavor,
 		ServerID:    strmServerID,
 		StartFile:   strmStartFile,
 		StartPos:    strmStartPos,

--- a/cmd/bintrail/stream_test.go
+++ b/cmd/bintrail/stream_test.go
@@ -45,7 +45,7 @@ func TestStreamCmd_requiredFlags(t *testing.T) {
 // TestStreamCmd_allFlagsRegistered verifies that all expected flags are wired up.
 func TestStreamCmd_allFlagsRegistered(t *testing.T) {
 	for _, name := range []string{
-		"index-dsn", "source-dsn", "server-id",
+		"index-dsn", "source-dsn", "source-flavor", "server-id",
 		"start-file", "start-pos", "start-gtid",
 		"batch-size", "schemas", "tables", "checkpoint", "metrics-addr",
 		"ssl-mode", "ssl-ca", "ssl-cert", "ssl-key",
@@ -54,6 +54,18 @@ func TestStreamCmd_allFlagsRegistered(t *testing.T) {
 		if streamCmd.Flag(name) == nil {
 			t.Errorf("flag --%s not registered on streamCmd", name)
 		}
+	}
+}
+
+// TestStreamCmd_sourceFlavorDefault verifies --source-flavor defaults to mysql,
+// so every existing MySQL invocation is unchanged.
+func TestStreamCmd_sourceFlavorDefault(t *testing.T) {
+	f := streamCmd.Flag("source-flavor")
+	if f == nil {
+		t.Fatal("flag --source-flavor not registered")
+	}
+	if f.DefValue != "mysql" {
+		t.Errorf("expected default source-flavor=mysql, got %q", f.DefValue)
 	}
 }
 
@@ -148,15 +160,15 @@ func TestStreamCmd_noGapFillFlagRegistered(t *testing.T) {
 // TestPopulateStreamFlags' save-and-restore discipline: no t.Parallel().
 func TestStreamConfigFromFlags(t *testing.T) {
 	orig := struct {
-		src, idx, file, gtid, sch, tbl, met, fmtv, ssl, ca, cert, key string
-		sid, pos                                                      uint32
-		batch, chk, gap                                               int
-		reset, noGap                                                  bool
+		src, idx, file, gtid, sch, tbl, met, fmtv, ssl, ca, cert, key, flavor string
+		sid, pos                                                              uint32
+		batch, chk, gap                                                       int
+		reset, noGap                                                          bool
 	}{
 		src: strmSourceDSN, idx: strmIndexDSN, file: strmStartFile,
 		gtid: strmStartGTID, sch: strmSchemas, tbl: strmTables,
 		met: strmMetricsAddr, fmtv: strmFormat, ssl: strmSSLMode,
-		ca: strmSSLCA, cert: strmSSLCert, key: strmSSLKey,
+		ca: strmSSLCA, cert: strmSSLCert, key: strmSSLKey, flavor: strmFlavor,
 		sid: strmServerID, pos: strmStartPos,
 		batch: strmBatchSize, chk: strmCheckpoint, gap: strmGapTimeout,
 		reset: strmReset, noGap: strmNoGapFill,
@@ -169,10 +181,12 @@ func TestStreamConfigFromFlags(t *testing.T) {
 		strmServerID, strmStartPos = orig.sid, orig.pos
 		strmBatchSize, strmCheckpoint, strmGapTimeout = orig.batch, orig.chk, orig.gap
 		strmReset, strmNoGapFill = orig.reset, orig.noGap
+		strmFlavor = orig.flavor
 	})
 
 	strmIndexDSN = "ix:pw@tcp(127.0.0.1:3306)/binlog_index"
 	strmSourceDSN = "user:pass@tcp(source.example.com:3306)/src"
+	strmFlavor = "mariadb"
 	strmServerID = 424242
 	strmStartFile = "mysql-bin.000777"
 	strmStartPos = 1234
@@ -204,6 +218,7 @@ func TestStreamConfigFromFlags(t *testing.T) {
 	want := streamrun.Config{
 		IndexDSN:    "ix:pw@tcp(127.0.0.1:3306)/binlog_index",
 		SourceDSN:   "user:pass@tcp(source.example.com:3306)/src",
+		Flavor:      "mariadb",
 		ServerID:    424242,
 		StartFile:   "mysql-bin.000777",
 		StartPos:    1234,

--- a/cmd/bintrail/stream_test.go
+++ b/cmd/bintrail/stream_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/dbtrail/dbtrail/internal/streamdeps"
 	"github.com/dbtrail/dbtrail/internal/streamrun"
 )
 
@@ -253,5 +254,11 @@ func TestStreamOneRejectsBadConfig(t *testing.T) {
 	if err := streamrun.One(t.Context(), streamrun.Config{Format: "text", GapTimeout: 0}); err == nil ||
 		!strings.Contains(err.Error(), "gap-timeout") {
 		t.Errorf("bad gap-timeout: err = %v, want gap-timeout error", err)
+	}
+	// An unsupported --source-flavor is rejected before any connection is opened.
+	// Deps must be wired because the flavor check runs after Deps.validate().
+	if err := streamrun.One(t.Context(), streamrun.Config{Deps: streamdeps.Default(), Format: "text", GapTimeout: 30, Flavor: "postgres"}); err == nil ||
+		!strings.Contains(err.Error(), "invalid source flavor") {
+		t.Errorf("bad flavor: err = %v, want invalid source flavor", err)
 	}
 }

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -37,6 +37,29 @@ If you scope `SELECT`, it must cover **every column of every monitored table**, 
 
 ---
 
+## MariaDB as a source (alpha)
+
+bintrail can stream from a **MariaDB** source while the index database stays MySQL. Pass `--source-flavor mariadb` (or set `BINTRAIL_SOURCE_FLAVOR=mariadb`):
+
+```bash
+bintrail stream \
+  --source-dsn 'dbtrail:pw@tcp(mariadb-host:3306)/' \
+  --source-flavor mariadb \
+  --index-dsn 'user:pw@tcp(index-host:3306)/binlog_index' \
+  --server-id 200 --schemas shop
+```
+
+The flag defaults to `mysql`, so every existing MySQL command is unchanged. The same `binlog_format = ROW` / `binlog_row_image = FULL` requirement and the same source-user grants apply. File-based `bintrail index` over MariaDB binlog files works too — bintrail decodes MariaDB row events (and skips MariaDB-only `Annotate_rows` / `Gtid_list` / `Binlog_checkpoint` events) transparently.
+
+**Status — alpha.** Tested against **MariaDB 11.4** (the primary target); 10.6 LTS and newer are expected to work but are not yet covered by CI. Known limitations for this release:
+
+- **Prefer position mode for resume.** Both position and GTID capture work, but MariaDB GTID **gap detection** (the purged-binlog data-loss alarm) is not yet implemented — a GTID-mode resume past purged binlogs proceeds with a loud warning instead of the alarm. Position mode retains full gap detection. `--no-gap-fill` is refused in MariaDB GTID mode rather than silently ignored.
+- **The source flavor is fixed per checkpoint.** Resuming a saved MariaDB checkpoint requires the same `--source-flavor mariadb` (a mismatch is rejected with an actionable error; `--reset` starts fresh).
+- **Not yet wired into the console "+ Add server" / control plane** — use the `bintrail stream` CLI for MariaDB sources in this release.
+- **Index-on-MariaDB is out of scope** — the index database stays MySQL.
+
+---
+
 ## The Problem
 
 `bintrail index` reads binlog files from disk. That works well for self-managed MySQL where you have filesystem access, but it doesn't work for managed MySQL services (Amazon RDS, Aurora, Cloud SQL). Those services don't give you file access to the binlog directory.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,16 +33,59 @@ import (
 // ACCESS_DENIED_ERROR), not ErrNoRows, so false-positive risk is essentially
 // nil.
 func CurrentBinlogPosition(db *sql.DB) (file string, pos uint32, err error) {
-	scanArgs := []any{&file, &pos, new(string), new(string), new(string)}
-	if err = db.QueryRow("SHOW BINARY LOG STATUS").Scan(scanArgs...); err == nil {
+	file, pos, err = scanBinlogStatus(db, "SHOW BINARY LOG STATUS")
+	if err == nil {
 		return file, pos, nil
 	}
 	firstErr := err
-	if err = db.QueryRow("SHOW MASTER STATUS").Scan(scanArgs...); err != nil {
+	file, pos, err = scanBinlogStatus(db, "SHOW MASTER STATUS")
+	if err != nil {
 		if errors.Is(firstErr, sql.ErrNoRows) || errors.Is(err, sql.ErrNoRows) {
 			return "", 0, fmt.Errorf("current binlog position empty — log_bin appears to be OFF on the source server (run \"SHOW VARIABLES LIKE 'log_bin'\" to confirm)")
 		}
 		return "", 0, fmt.Errorf("SHOW BINARY LOG STATUS / SHOW MASTER STATUS: %w (fallback: %w)", firstErr, err)
+	}
+	return file, pos, nil
+}
+
+// scanBinlogStatus runs a SHOW … STATUS statement and extracts the binlog file
+// and position from its first two columns. The remaining columns are discarded,
+// which makes the read tolerant to the column-count difference across flavors:
+// MySQL 5.7/8.0 and 8.4 return five columns (… Executed_Gtid_Set), MariaDB
+// returns four (no Executed_Gtid_Set). Only File and Position are needed.
+//
+// An empty resultset (log_bin=OFF) surfaces as sql.ErrNoRows so the caller's
+// OFF-detection keeps working unchanged; statement-not-found surfaces as the
+// driver's syntax error (1064).
+func scanBinlogStatus(db *sql.DB, stmt string) (file string, pos uint32, err error) {
+	rows, err := db.Query(stmt)
+	if err != nil {
+		return "", 0, err
+	}
+	defer rows.Close()
+
+	cols, err := rows.Columns()
+	if err != nil {
+		return "", 0, err
+	}
+	if len(cols) < 2 {
+		return "", 0, fmt.Errorf("%s returned %d column(s), expected at least File and Position", stmt, len(cols))
+	}
+	if !rows.Next() {
+		if rerr := rows.Err(); rerr != nil {
+			return "", 0, rerr
+		}
+		return "", 0, sql.ErrNoRows
+	}
+
+	dest := make([]any, len(cols))
+	dest[0] = &file
+	dest[1] = &pos
+	for i := 2; i < len(cols); i++ {
+		dest[i] = new(sql.RawBytes)
+	}
+	if err := rows.Scan(dest...); err != nil {
+		return "", 0, err
 	}
 	return file, pos, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -99,6 +99,43 @@ func TestCurrentBinlogPosition_FallbackHappyPath(t *testing.T) {
 	}
 }
 
+// TestCurrentBinlogPosition_MariaDBFourColumns covers a MariaDB source:
+// SHOW BINARY LOG STATUS does not exist there (syntax error 1064), and
+// SHOW MASTER STATUS returns only FOUR columns — File, Position, Binlog_Do_DB,
+// Binlog_Ignore_DB — because MariaDB has no Executed_Gtid_Set column. The scan
+// must tolerate the differing column count and still extract File+Position.
+// Reproduces the alpha smoke-test failure "expected 4 destination arguments in
+// Scan, not 5" against real MariaDB 11.4.
+func TestCurrentBinlogPosition_MariaDBFourColumns(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SHOW BINARY LOG STATUS").WillReturnError(&mysql.MySQLError{
+		Number:  1064,
+		Message: "You have an error in your SQL syntax near 'LOG STATUS'",
+	})
+	mock.ExpectQuery("SHOW MASTER STATUS").WillReturnRows(
+		sqlmock.NewRows([]string{"File", "Position", "Binlog_Do_DB", "Binlog_Ignore_DB"}).
+			AddRow("mariadb-bin.000002", uint32(1483), "", ""))
+
+	file, pos, err := CurrentBinlogPosition(db)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if file != "mariadb-bin.000002" {
+		t.Errorf("file = %q, want %q", file, "mariadb-bin.000002")
+	}
+	if pos != 1483 {
+		t.Errorf("pos = %d, want 1483", pos)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
 // TestCurrentBinlogPosition_LogBinOff covers the real-world shape of
 // log_bin=OFF on every supported MySQL/Percona line. The crash-loop
 // in #325 surfaced as an asymmetric error pair — exactly one branch

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -239,8 +239,17 @@ func EnsureSchema(db *sql.DB) error {
 	); err != nil {
 		return err
 	}
-	return ensureColumn(db, "stream_state", "gap_lost_detail",
+	if err := ensureColumn(db, "stream_state", "gap_lost_detail",
 		`ALTER TABLE stream_state ADD COLUMN gap_lost_detail TEXT DEFAULT NULL COMMENT 'human-readable description of the lost gap' AFTER gap_lost_at`,
+	); err != nil {
+		return err
+	}
+	// flavor records the source database flavor (mysql/mariadb) so a resume
+	// parses the saved gtid_set with the correct GTID parser. NOT NULL DEFAULT
+	// 'mysql' means existing rows read back as mysql with no data migration,
+	// keeping every pre-MariaDB install unchanged.
+	return ensureColumn(db, "stream_state", "flavor",
+		`ALTER TABLE stream_state ADD COLUMN flavor VARCHAR(16) NOT NULL DEFAULT 'mysql' COMMENT 'source flavor: mysql or mariadb; selects the GTID parser on resume' AFTER gtid_set`,
 	)
 }
 

--- a/internal/indexer/schema.go
+++ b/internal/indexer/schema.go
@@ -169,6 +169,7 @@ const ddlStreamState = `CREATE TABLE IF NOT EXISTS stream_state (
     binlog_file      VARCHAR(255)    NOT NULL DEFAULT '',
     binlog_position  BIGINT UNSIGNED NOT NULL DEFAULT 0,
     gtid_set         TEXT            DEFAULT NULL,
+    flavor           VARCHAR(16)     NOT NULL DEFAULT 'mysql' COMMENT 'source flavor: mysql or mariadb; selects the GTID parser on resume',
     events_indexed   BIGINT UNSIGNED NOT NULL DEFAULT 0,
     last_event_time  DATETIME        DEFAULT NULL,
     last_checkpoint  DATETIME        NOT NULL,

--- a/internal/indexer/schema_integration_test.go
+++ b/internal/indexer/schema_integration_test.go
@@ -28,6 +28,40 @@ func TestCreateBinlogEventsTable(t *testing.T) {
 	}
 }
 
+// TestEnsureSchemaAddsFlavorColumn pins the MariaDB-source migration: a
+// pre-flavor install must gain stream_state.flavor as NOT NULL DEFAULT 'mysql'
+// (so existing rows read back as mysql with no data migration), and the
+// migration must be idempotent.
+func TestEnsureSchemaAddsFlavorColumn(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	// Simulate a pre-flavor install by dropping the column EnsureSchema re-adds.
+	testutil.MustExec(t, db, `ALTER TABLE stream_state DROP COLUMN flavor`)
+
+	if err := EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	var colDefault, isNullable string
+	if err := db.QueryRow(`SELECT COLUMN_DEFAULT, IS_NULLABLE FROM information_schema.COLUMNS
+		WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'stream_state'
+		  AND COLUMN_NAME = 'flavor'`).Scan(&colDefault, &isNullable); err != nil {
+		t.Fatalf("read flavor column: %v", err)
+	}
+	if colDefault != "mysql" {
+		t.Errorf("flavor COLUMN_DEFAULT = %q, want \"mysql\"", colDefault)
+	}
+	if isNullable != "NO" {
+		t.Errorf("flavor IS_NULLABLE = %q, want \"NO\"", isNullable)
+	}
+
+	// Idempotent: a second run must not error or re-add.
+	if err := EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema (second run): %v", err)
+	}
+}
+
 // TestEnsureSchemaWidensColumnType pins the #472 migration: #212 created
 // schema_snapshots.column_type as VARCHAR(128), which a realistic ENUM
 // declaration exceeds — under strict mode the 1406 aborts the whole

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -694,6 +694,24 @@ func ValidateBinlogRowImage(db *sql.DB) error {
 	return nil
 }
 
+// DetectFlavor reports the source server flavor by inspecting VERSION():
+// "mariadb" when the version string contains "MariaDB" (case-insensitive),
+// otherwise "mysql" (which also covers Percona). On a query error it returns ""
+// (unknown) rather than fabricating a flavor — detection is advisory (surfacing a
+// --source-flavor mismatch), and callers must treat "" as "could not determine"
+// instead of asserting a false mismatch. Returns bare strings to keep
+// internal/metadata free of a go-mysql dependency.
+func DetectFlavor(db *sql.DB) string {
+	var version string
+	if err := db.QueryRow("SELECT VERSION()").Scan(&version); err != nil {
+		return ""
+	}
+	if strings.Contains(strings.ToLower(version), "mariadb") {
+		return "mariadb"
+	}
+	return "mysql"
+}
+
 // buildFKCascadeQuery returns the REFERENTIAL_CONSTRAINTS query (and its args)
 // used to find CASCADE foreign keys. When schemas is non-empty the scan is
 // scoped to exactly those schemas — the operator explicitly asked us to index

--- a/internal/metadata/metadata_test.go
+++ b/internal/metadata/metadata_test.go
@@ -1,9 +1,51 @@
 package metadata
 
 import (
+	"errors"
 	"strings"
 	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
 )
+
+// TestDetectFlavor verifies VERSION()-string flavor detection: any string
+// containing "MariaDB" (case-insensitive) is mariadb, everything else (incl.
+// Percona) is mysql, and a query error returns "" (unknown) rather than a
+// fabricated flavor.
+func TestDetectFlavor(t *testing.T) {
+	cases := []struct {
+		name     string
+		version  string
+		queryErr bool
+		want     string
+	}{
+		{"mysql 8.0", "8.0.36", false, "mysql"},
+		{"percona", "8.0.36-28", false, "mysql"},
+		{"mariadb 11.4", "11.4.10-MariaDB-1:11.4.10+maria~ubu2404", false, "mariadb"},
+		{"mariadb 10.6", "10.6.18-MariaDB", false, "mariadb"},
+		{"query error returns unknown (empty)", "", true, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("sqlmock: %v", err)
+			}
+			defer db.Close()
+
+			exp := mock.ExpectQuery("SELECT VERSION()")
+			if tc.queryErr {
+				exp.WillReturnError(errors.New("connection refused"))
+			} else {
+				exp.WillReturnRows(sqlmock.NewRows([]string{"VERSION()"}).AddRow(tc.version))
+			}
+
+			if got := DetectFlavor(db); got != tc.want {
+				t.Errorf("DetectFlavor(%q) = %q, want %q", tc.version, got, tc.want)
+			}
+		})
+	}
+}
 
 // buildTestResolver constructs a Resolver directly without a database,
 // allowing MapRow and Resolve to be tested without a MySQL connection.

--- a/internal/parser/mariadb_integration_test.go
+++ b/internal/parser/mariadb_integration_test.go
@@ -1,0 +1,104 @@
+//go:build integration
+
+package parser_test
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/config"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/parser"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestParseFile_realBinlog_mariadb is the file-based MariaDB guard for the
+// `bintrail index` path that docs/streaming.md advertises ("File-based bintrail
+// index over MariaDB binlog files works too"). It produces a real MariaDB binlog
+// on the source container, copies it out, parses it, and asserts the exact DML
+// mix AND that the file-parser MariadbGTIDEvent case populated domain-server-seq
+// GTIDs on the indexed rows. Mirrors TestParseFile_realBinlog (MySQL) against
+// bintrail-test-mariadb (13307).
+func TestParseFile_realBinlog_mariadb(t *testing.T) {
+	sourceDB, sourceName := testutil.CreateTestMariaDB(t)
+	indexDB, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, indexDB)
+
+	testutil.MustExec(t, sourceDB, `CREATE TABLE orders (
+		id       INT PRIMARY KEY AUTO_INCREMENT,
+		customer VARCHAR(100)  NOT NULL,
+		amount   DECIMAL(10,2) NOT NULL
+	)`)
+
+	stats, err := metadata.TakeSnapshot(sourceDB, indexDB, []string{sourceName})
+	if err != nil {
+		t.Fatalf("TakeSnapshot: %v", err)
+	}
+	res, err := metadata.NewResolver(indexDB, stats.SnapshotID)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+
+	// Flush to a clean boundary, note the file, do DML, seal it.
+	testutil.MustExec(t, sourceDB, "FLUSH BINARY LOGS")
+	currentBinlog, _, err := config.CurrentBinlogPosition(sourceDB)
+	if err != nil {
+		t.Fatalf("CurrentBinlogPosition (MariaDB): %v", err)
+	}
+	testutil.MustExec(t, sourceDB, "INSERT INTO orders (customer, amount) VALUES ('Alice', 99.99)")
+	testutil.MustExec(t, sourceDB, "INSERT INTO orders (customer, amount) VALUES ('Bob', 50.00)")
+	testutil.MustExec(t, sourceDB, "UPDATE orders SET amount = 109.99 WHERE customer = 'Alice'")
+	testutil.MustExec(t, sourceDB, "DELETE FROM orders WHERE customer = 'Bob'")
+	testutil.MustExec(t, sourceDB, "FLUSH BINARY LOGS")
+
+	tmpDir := t.TempDir()
+	cpCmd := exec.Command("docker", "cp",
+		fmt.Sprintf("bintrail-test-mariadb:/var/lib/mysql/%s", currentBinlog),
+		filepath.Join(tmpDir, currentBinlog),
+	)
+	if out, err := cpCmd.CombinedOutput(); err != nil {
+		testutil.SkipOrFailMariaDB(t, "docker cp %s from bintrail-test-mariadb failed: %v\n%s", currentBinlog, err, out)
+	}
+
+	p := parser.New(tmpDir, res, parser.Filters{Schemas: map[string]bool{sourceName: true}}, nil)
+	events := make(chan parser.Event, 100)
+	errCh := make(chan error, 1)
+	go func() {
+		defer close(events)
+		errCh <- p.ParseFile(context.Background(), currentBinlog, events)
+	}()
+	all := drainEvents(events)
+	if err := <-errCh; err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+
+	dml := dmlEvents(all)
+	var ins, upd, del int
+	for _, ev := range dml {
+		switch ev.EventType {
+		case parser.EventInsert:
+			ins++
+		case parser.EventUpdate:
+			upd++
+		case parser.EventDelete:
+			del++
+		}
+	}
+	if ins != 2 || upd != 1 || del != 1 {
+		t.Fatalf("expected 2 INSERT/1 UPDATE/1 DELETE from MariaDB binlog, got ins=%d upd=%d del=%d (total dml %d)", ins, upd, del, len(dml))
+	}
+
+	// The file-parser MariadbGTIDEvent case must populate domain-server-seq GTIDs.
+	for _, ev := range dml {
+		if ev.GTID == "" {
+			t.Fatalf("DML event carries no GTID — the file-parser MariadbGTIDEvent case is not firing")
+		}
+		if strings.Count(ev.GTID, "-") != 2 || strings.Contains(ev.GTID, ":") {
+			t.Fatalf("indexed GTID %q is not MariaDB domain-server-seq form", ev.GTID)
+		}
+	}
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -173,6 +173,12 @@ func (p *Parser) ParseFile(ctx context.Context, filename string, events chan<- E
 		case *replication.GTIDEvent:
 			currentGTID = formatGTID(ev.SID, ev.GNO)
 
+		case *replication.MariadbGTIDEvent:
+			// MariaDB source: the GTID arrives as domain-server-seq (e.g.
+			// "0-1-100"). ev.GTID.String() returns "" for the zero GTID,
+			// mirroring formatGTID's not-enabled behavior.
+			currentGTID = ev.GTID.String()
+
 		case *replication.QueryEvent:
 			currentConnectionID = ev.SlaveProxyID
 			ts := time.Unix(int64(binlogEv.Header.Timestamp), 0).UTC()
@@ -288,6 +294,22 @@ func handleRows(
 		replication.UPDATE_ROWS_EVENTv1,
 		replication.UPDATE_ROWS_EVENTv2:
 		return emitUpdates(ctx, logger, resolver, rowsEv.Rows, schema, table, filename, currentGTID, connectionID, startPos, endPos, ts, pkCols, schemaVersion, out)
+
+	default:
+		// A RowsEvent whose type matches none of the above — e.g. MariaDB's
+		// MARIADB_WRITE/UPDATE/DELETE_ROWS_COMPRESSED_EVENT_V1 (log_bin_compress=ON),
+		// or PARTIAL_UPDATE_ROWS_EVENT which a MySQL source emits under
+		// binlog_row_value_options=PARTIAL_JSON (out of support; binlog_row_image=FULL
+		// is required). Decoding these is deferred; warn loudly — including how many
+		// rows were skipped — rather than dropping them silently (a data-loss class).
+		// Standard MySQL ROW DML always matches a specific case above.
+		logger.Warn("unhandled row event type — rows skipped (e.g. MariaDB compressed-row events are not yet decoded)",
+			"file", filename,
+			"pos", binlogEv.Header.LogPos,
+			"schema", schema,
+			"table", table,
+			"event_type", binlogEv.Header.EventType,
+			"rows_skipped", len(rowsEv.Rows))
 	}
 
 	return nil

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -2,10 +2,13 @@ package parser
 
 import (
 	"bytes"
+	"context"
 	"log/slog"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/go-mysql-org/go-mysql/replication"
 
 	"github.com/dbtrail/dbtrail/internal/metadata"
 )
@@ -148,6 +151,53 @@ func TestFormatGTID_shortSID(t *testing.T) {
 	got := formatGTID([]byte{0x01, 0x02}, 1)
 	if got != "" {
 		t.Errorf("expected empty string for short SID, got %q", got)
+	}
+}
+
+// ─── handleRows: unhandled (e.g. MariaDB compressed) row event type ───────────
+
+// TestHandleRows_unhandledEventTypeLogsNotSilent verifies that a row event type
+// handleRows does not recognize — e.g. MariaDB's MARIADB_WRITE_ROWS_COMPRESSED_
+// EVENT_V1 — is logged at warn instead of being silently dropped. Before the
+// default arm the switch fell through to `return nil`, dropping every row with
+// no trace (a silent data-loss class). Decoding compressed rows is deferred to
+// beta; the alpha guarantee is only that they are never dropped silently.
+func TestHandleRows_unhandledEventTypeLogsNotSilent(t *testing.T) {
+	tm := &metadata.TableMeta{
+		Schema:    "shop",
+		Table:     "orders",
+		Columns:   []metadata.ColumnMeta{{Name: "id", OrdinalPosition: 1, IsPK: true, DataType: "int"}},
+		PKColumns: []string{"id"},
+	}
+	resolver := metadata.NewResolverFromTables(1, map[string]*metadata.TableMeta{"shop.orders": tm})
+
+	var buf bytes.Buffer
+	logger := newTestLogger(&buf)
+
+	binlogEv := &replication.BinlogEvent{
+		Header: &replication.EventHeader{
+			EventType: replication.MARIADB_WRITE_ROWS_COMPRESSED_EVENT_V1,
+			LogPos:    200,
+			EventSize: 100,
+		},
+		Event: &replication.RowsEvent{
+			Table: &replication.TableMapEvent{
+				Schema:      []byte("shop"),
+				Table:       []byte("orders"),
+				ColumnCount: 1,
+			},
+			Rows: [][]any{{int64(1)}},
+		},
+	}
+	rowsEv := binlogEv.Event.(*replication.RowsEvent)
+
+	out := make(chan Event, 4)
+	if err := handleRows(context.Background(), logger, resolver, &Filters{}, binlogEv, rowsEv, "mariadb-bin.000001", "0-1-1", 0, 1, out); err != nil {
+		t.Fatalf("handleRows: %v", err)
+	}
+
+	if !strings.Contains(strings.ToLower(buf.String()), "unhandled") {
+		t.Errorf("expected a warn mentioning the unhandled row event type, got logs: %q", buf.String())
 	}
 }
 

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -196,8 +196,17 @@ func TestHandleRows_unhandledEventTypeLogsNotSilent(t *testing.T) {
 		t.Fatalf("handleRows: %v", err)
 	}
 
-	if !strings.Contains(strings.ToLower(buf.String()), "unhandled") {
-		t.Errorf("expected a warn mentioning the unhandled row event type, got logs: %q", buf.String())
+	logged := buf.String()
+	if !strings.Contains(strings.ToLower(logged), "unhandled") {
+		t.Errorf("expected a warn mentioning the unhandled row event type, got logs: %q", logged)
+	}
+	// The anti-silent-data-loss contract is two-part: the warn must quantify the
+	// drop (rows_skipped) and nothing may leak onto the output channel.
+	if !strings.Contains(logged, "rows_skipped") {
+		t.Errorf("expected rows_skipped count in the warn, got logs: %q", logged)
+	}
+	if len(out) != 0 {
+		t.Errorf("unhandled event must emit no rows downstream, got %d", len(out))
 	}
 }
 

--- a/internal/parser/stream.go
+++ b/internal/parser/stream.go
@@ -113,6 +113,29 @@ func (sp *StreamParser) Run(ctx context.Context, streamer *replication.BinlogStr
 		}
 	}
 
+	// emitGTIDTracking emits an EventGTID for the in-flight currentGTID so the
+	// stream consumer accumulates it even when no rows follow (#124). No-op when
+	// currentGTID is empty (non-GTID source). Shared by the MySQL GTIDEvent and
+	// MariaDB MariadbGTIDEvent cases so both flavors track identically.
+	emitGTIDTracking := func(hdr *replication.EventHeader) error {
+		if currentGTID == "" {
+			return nil
+		}
+		gtidEv := Event{
+			BinlogFile: currentFile,
+			EndPos:     uint64(hdr.LogPos),
+			Timestamp:  time.Unix(int64(hdr.Timestamp), 0).UTC(),
+			GTID:       currentGTID,
+			EventType:  EventGTID,
+		}
+		select {
+		case out <- gtidEv:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
 	// handleEvent processes one binlog event. It is recursive: with
 	// binlog_transaction_compression=ON the source wraps each transaction's
 	// events (BEGIN + TABLE_MAP + rows + XID) in a single zstd-compressed
@@ -148,20 +171,23 @@ func (sp *StreamParser) Run(ctx context.Context, streamer *replication.BinlogStr
 				return err
 			}
 			currentGTID = formatGTID(ev.SID, ev.GNO)
-			if currentGTID != "" {
-				ts := time.Unix(int64(binlogEv.Header.Timestamp), 0).UTC()
-				gtidEv := Event{
-					BinlogFile: currentFile,
-					EndPos:     uint64(binlogEv.Header.LogPos),
-					Timestamp:  ts,
-					GTID:       currentGTID,
-					EventType:  EventGTID,
-				}
-				select {
-				case out <- gtidEv:
-				case <-ctx.Done():
-					return ctx.Err()
-				}
+			if err := emitGTIDTracking(binlogEv.Header); err != nil {
+				return err
+			}
+
+		case *replication.MariadbGTIDEvent:
+			// MariaDB analogue of GTIDEvent: a MariaDB source emits a
+			// MariadbGTIDEvent (domain-server-seq) instead of a GTIDEvent. The
+			// commit-boundary and tracking-emit logic is identical — see the
+			// GTIDEvent case above for the #491 next-GTID-fallback rationale.
+			// ev.GTID.String() yields "0-1-100" and "" for the zero GTID, so the
+			// emit guard inside emitGTIDTracking is built in.
+			if err := emitCommit(binlogEv.Header); err != nil {
+				return err
+			}
+			currentGTID = ev.GTID.String()
+			if err := emitGTIDTracking(binlogEv.Header); err != nil {
+				return err
 			}
 
 		case *replication.QueryEvent:

--- a/internal/parser/stream_test.go
+++ b/internal/parser/stream_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/go-mysql-org/go-mysql/replication"
 
 	"github.com/dbtrail/dbtrail/internal/metadata"
@@ -60,6 +61,19 @@ func makeXIDEvent(logPos uint32) *replication.BinlogEvent {
 	return &replication.BinlogEvent{
 		Header: &replication.EventHeader{EventType: replication.XID_EVENT, LogPos: logPos},
 		Event:  &replication.XIDEvent{XID: 1},
+	}
+}
+
+// makeMariadbGTIDEvent builds a BinlogEvent wrapping a MariaDB GTID event
+// (domain-server-seq), the MariaDB analogue of makeGTIDEvent. The stream parser
+// switches on the concrete event struct, so the MARIADB_GTID_EVENT header type
+// is set for realism only.
+func makeMariadbGTIDEvent(domain, server uint32, seq uint64) *replication.BinlogEvent {
+	return &replication.BinlogEvent{
+		Header: &replication.EventHeader{EventType: replication.MARIADB_GTID_EVENT},
+		Event: &replication.MariadbGTIDEvent{
+			GTID: mysql.MariadbGTID{DomainID: domain, ServerID: server, SequenceNumber: seq},
+		},
 	}
 }
 
@@ -211,6 +225,65 @@ func TestStreamParser_gtidThenFilteredRows(t *testing.T) {
 	ev := <-out
 	if ev.EventType != EventGTID {
 		t.Errorf("expected EventGTID (%d), got %d", EventGTID, ev.EventType)
+	}
+}
+
+// ─── MariaDB GTIDEvent (alpha) ───────────────────────────────────────────────
+
+// TestStreamParser_mariadbGTIDEventEmitsTrackingEvent verifies that a MariaDB
+// GTID event (MariadbGTIDEvent, domain-server-seq) emits an EventGTID tracking
+// event just like a MySQL GTIDEvent. Without this, currentGTID stays empty for a
+// MariaDB source, no tracking/commit events fire, and the durable GTID
+// checkpoint never advances (endless re-stream + false gap alarm).
+func TestStreamParser_mariadbGTIDEventEmitsTrackingEvent(t *testing.T) {
+	sp := NewStreamParser(nil, Filters{}, nil)
+	streamer := replication.NewBinlogStreamer()
+	out := make(chan Event, 10)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	feedThenCancel(t, streamer, cancel, makeMariadbGTIDEvent(0, 1, 100))
+
+	if err := sp.Run(ctx, streamer, out); err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("expected 1 EventGTID tracking event, got %d", len(out))
+	}
+	ev := <-out
+	if ev.EventType != EventGTID {
+		t.Errorf("expected EventGTID (%d), got %d", EventGTID, ev.EventType)
+	}
+	// MariaDB GTID is domain-server-seq and must NOT be zero-padded like a MySQL UUID.
+	if ev.GTID != "0-1-100" {
+		t.Errorf("expected MariaDB GTID '0-1-100', got %q", ev.GTID)
+	}
+}
+
+// TestStreamParser_mariadbGTIDThenXIDEmitsCommit verifies the #491 commit
+// machinery fires for a MariaDB source: a MariadbGTIDEvent + BEGIN + XID emits
+// [EventGTID, EventCommit] both carrying the MariaDB GTID — that EventCommit is
+// what the consumer feeds to advanceGTID to move the checkpoint forward.
+func TestStreamParser_mariadbGTIDThenXIDEmitsCommit(t *testing.T) {
+	sp := NewStreamParser(nil, Filters{}, nil)
+	streamer := replication.NewBinlogStreamer()
+	out := make(chan Event, 10)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	feedThenCancel(t, streamer, cancel,
+		makeMariadbGTIDEvent(0, 1, 100),
+		makeQueryEvent("BEGIN"),
+		makeXIDEvent(300),
+	)
+	if err := sp.Run(ctx, streamer, out); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	evs := drainAll(out)
+	if len(evs) != 2 || evs[0].EventType != EventGTID || evs[1].EventType != EventCommit {
+		t.Fatalf("expected [EventGTID, EventCommit], got %v", typesOf(evs))
+	}
+	if evs[1].GTID != "0-1-100" || evs[1].GTID != evs[0].GTID {
+		t.Errorf("EventCommit must carry the MariaDB GTID: commit=%q gtid=%q", evs[1].GTID, evs[0].GTID)
 	}
 }
 

--- a/internal/streamrun/mariadb_integration_test.go
+++ b/internal/streamrun/mariadb_integration_test.go
@@ -98,7 +98,7 @@ func TestStreamLoop_liveReplication_mariadb(t *testing.T) {
 
 	streamer, syncErr := syncer.StartSync(gomysql.Position{Name: binlogFile, Pos: binlogPos})
 	if syncErr != nil {
-		t.Skipf("skipping: StartSync failed (replication may not be granted): %v", syncErr)
+		testutil.SkipOrFailMariaDB(t, "StartSync against MariaDB failed (replication may not be granted): %v", syncErr)
 	}
 
 	resolver, err := metadata.NewResolver(indexDB, 0)
@@ -214,7 +214,7 @@ func TestStreamLoop_gtidAdvancesOnCommit_mariadb(t *testing.T) {
 
 	streamer, syncErr := syncer.StartSync(gomysql.Position{Name: binlogFile, Pos: binlogPos})
 	if syncErr != nil {
-		t.Skipf("skipping: StartSync failed: %v", syncErr)
+		testutil.SkipOrFailMariaDB(t, "StartSync against MariaDB failed: %v", syncErr)
 	}
 
 	resolver, err := metadata.NewResolver(indexDB, 0)

--- a/internal/streamrun/mariadb_integration_test.go
+++ b/internal/streamrun/mariadb_integration_test.go
@@ -1,0 +1,260 @@
+//go:build integration
+
+package streamrun
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	gomysql "github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/go-mysql-org/go-mysql/replication"
+	drivermysql "github.com/go-sql-driver/mysql"
+
+	"github.com/dbtrail/dbtrail/internal/config"
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/observe"
+	"github.com/dbtrail/dbtrail/internal/parser"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestStreamLoop_liveReplication_mariadb is the MariaDB-source end-to-end guard
+// (alpha). It pairs a MySQL INDEX (CreateTestDB, 13306) with a MariaDB SOURCE
+// (CreateTestMariaDB, 13307) and streams real row events through the full
+// engine. Beyond proving rows are captured, it is the discriminator for two
+// MariaDB-specific fixes that no unit test exercises:
+//
+//   - config.CurrentBinlogPosition must succeed against MariaDB (SHOW MASTER
+//     STATUS returns 4 columns there, not 5 — the column-tolerant scan).
+//   - the BinlogSyncer Flavor="mariadb" handshake + the MariadbGTIDEvent parser
+//     case must populate domain-server-seq GTIDs on indexed rows.
+//
+// It runs in POSITION mode (the recommended MariaDB resume mode for the alpha)
+// and asserts via the indexed-event counter, not raw event counts — MariaDB
+// interleaves ANNOTATE_ROWS / GTID_LIST / BINLOG_CHECKPOINT events the indexer
+// never counts.
+func TestStreamLoop_liveReplication_mariadb(t *testing.T) {
+	indexDB, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, indexDB)
+
+	sourceDB, sourceName := testutil.CreateTestMariaDB(t)
+
+	testutil.MustExec(t, sourceDB, `CREATE TABLE orders (
+		id     INT PRIMARY KEY AUTO_INCREMENT,
+		amount DECIMAL(10,2) NOT NULL
+	)`)
+
+	var logBin string
+	if err := sourceDB.QueryRow("SELECT @@log_bin").Scan(&logBin); err != nil || logBin != "1" {
+		t.Skip("skipping: binary logging not enabled on test MariaDB")
+	}
+
+	// THE position-discovery discriminator: this call, not memory, proves the
+	// SHOW BINARY LOG STATUS / SHOW MASTER STATUS fallback chain works on the
+	// pinned MariaDB. A 4-vs-5 column scan mismatch would fail here.
+	binlogFile, binlogPos, err := config.CurrentBinlogPosition(sourceDB)
+	if err != nil {
+		t.Fatalf("CurrentBinlogPosition against MariaDB failed (position discovery regression): %v", err)
+	}
+
+	if _, err := metadata.TakeSnapshot(sourceDB, indexDB, []string{sourceName}); err != nil {
+		t.Fatalf("TakeSnapshot: %v", err)
+	}
+
+	mc, err := drivermysql.ParseDSN(testutil.MariaDBBaseDSN() + "/" + sourceName + "?parseTime=true")
+	if err != nil {
+		t.Fatalf("ParseDSN: %v", err)
+	}
+	hostStr, portStr, err := net.SplitHostPort(mc.Addr)
+	if err != nil {
+		t.Fatalf("SplitHostPort: %v", err)
+	}
+	portN, err := strconv.ParseUint(portStr, 10, 16)
+	if err != nil {
+		t.Fatalf("ParseUint(port): %v", err)
+	}
+
+	for i := range 5 {
+		testutil.MustExec(t, sourceDB,
+			"INSERT INTO orders (amount) VALUES (?)", float64(i+1)*10.0)
+	}
+
+	// The MariaDB flavor drives the replication handshake (mariadb_slave_capability
+	// + the MariaDB GTID dump command).
+	syncer := replication.NewBinlogSyncer(replication.BinlogSyncerConfig{
+		ServerID: 99997,
+		Flavor:   gomysql.MariaDBFlavor,
+		Host:     hostStr,
+		Port:     uint16(portN),
+		User:     mc.User,
+		Password: mc.Passwd,
+	})
+	defer syncer.Close()
+
+	streamer, syncErr := syncer.StartSync(gomysql.Position{Name: binlogFile, Pos: binlogPos})
+	if syncErr != nil {
+		t.Skipf("skipping: StartSync failed (replication may not be granted): %v", syncErr)
+	}
+
+	resolver, err := metadata.NewResolver(indexDB, 0)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+	filters := parser.Filters{Schemas: map[string]bool{sourceName: true}}
+
+	sp := parser.NewStreamParser(resolver, filters, nil)
+	idx := indexer.New(indexDB, 100)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	events := make(chan parser.Event, 100)
+	parseErrCh := make(chan error, 1)
+	go func() {
+		defer close(events)
+		parseErrCh <- sp.Run(ctx, streamer, events)
+	}()
+
+	state := &streamState{mode: "position", flavor: gomysql.MariaDBFlavor, serverID: 99997}
+	if err := streamLoop(ctx, events, idx, indexDB, time.Minute, state, observe.ForSource("test-mariadb"), nil); err != nil {
+		t.Fatalf("streamLoop: %v", err)
+	}
+
+	parseErr := <-parseErrCh
+	if parseErr != nil &&
+		!errors.Is(parseErr, context.DeadlineExceeded) &&
+		!errors.Is(parseErr, context.Canceled) {
+		t.Fatalf("StreamParser error: %v", parseErr)
+	}
+
+	if state.eventsIndexed < 5 {
+		t.Errorf("expected at least 5 events indexed from MariaDB, got %d", state.eventsIndexed)
+	}
+
+	// The checkpoint must record the MariaDB flavor so a later resume re-parses
+	// any saved gtid_set with the MariaDB parser.
+	loaded, err := loadStreamState(indexDB)
+	if err != nil {
+		t.Fatalf("loadStreamState: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("expected checkpoint to be saved after streaming")
+	}
+	if loaded.flavor != gomysql.MariaDBFlavor {
+		t.Errorf("checkpoint flavor = %q, want mariadb", loaded.flavor)
+	}
+
+	// At least one indexed row must carry a MariaDB domain-server-seq GTID,
+	// proving the MariadbGTIDEvent parser case fired end-to-end.
+	var gtid string
+	if err := indexDB.QueryRow(
+		`SELECT gtid FROM binlog_events WHERE gtid IS NOT NULL AND gtid <> '' ORDER BY event_id LIMIT 1`,
+	).Scan(&gtid); err != nil {
+		t.Fatalf("query indexed gtid: %v", err)
+	}
+	// MariaDB GTID is "domain-server-seq" (digits and dashes), never a MySQL UUID.
+	if strings.Count(gtid, "-") != 2 || strings.Contains(gtid, ":") {
+		t.Errorf("indexed gtid %q is not MariaDB domain-server-seq form", gtid)
+	}
+}
+
+// TestStreamLoop_gtidAdvancesOnCommit_mariadb is the MariaDB sibling of
+// TestStreamLoop_gtidAdvancesOnCommit_live. It runs streamLoop in GTID mode with
+// a *MariadbGTIDSet accumulator so MariadbGTIDSet.Update() — the durable-checkpoint
+// path that position mode never exercises — is covered in CI. It proves the GTID
+// checkpoint advances (and is re-parseable) for a MariaDB source.
+func TestStreamLoop_gtidAdvancesOnCommit_mariadb(t *testing.T) {
+	indexDB, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, indexDB)
+
+	sourceDB, sourceName := testutil.CreateTestMariaDB(t)
+
+	testutil.MustExec(t, sourceDB, `CREATE TABLE orders (
+		id INT PRIMARY KEY AUTO_INCREMENT, amount DECIMAL(10,2) NOT NULL)`)
+	if _, err := metadata.TakeSnapshot(sourceDB, indexDB, []string{sourceName}); err != nil {
+		t.Fatalf("TakeSnapshot: %v", err)
+	}
+
+	binlogFile, binlogPos, err := config.CurrentBinlogPosition(sourceDB)
+	if err != nil {
+		t.Fatalf("CurrentBinlogPosition: %v", err)
+	}
+
+	// Seed the accumulator from the source's current GTID position so Update()
+	// appends onto a realistic non-empty *MariadbGTIDSet.
+	var seedGTID string
+	if err := sourceDB.QueryRow("SELECT @@gtid_binlog_pos").Scan(&seedGTID); err != nil {
+		t.Fatalf("read @@gtid_binlog_pos: %v", err)
+	}
+	accGTID, err := parseGTIDSetForFlavor(gomysql.MariaDBFlavor, seedGTID)
+	if err != nil {
+		t.Fatalf("parse seed GTID %q: %v", seedGTID, err)
+	}
+
+	mc, err := drivermysql.ParseDSN(testutil.MariaDBBaseDSN() + "/" + sourceName + "?parseTime=true")
+	if err != nil {
+		t.Fatalf("ParseDSN: %v", err)
+	}
+	hostStr, portStr, _ := net.SplitHostPort(mc.Addr)
+	portN, _ := strconv.ParseUint(portStr, 10, 16)
+
+	testutil.MustExec(t, sourceDB, "INSERT INTO orders (amount) VALUES (10.0)")
+	testutil.MustExec(t, sourceDB, "INSERT INTO orders (amount) VALUES (20.0)")
+
+	syncer := replication.NewBinlogSyncer(replication.BinlogSyncerConfig{
+		ServerID: 99996, Flavor: gomysql.MariaDBFlavor,
+		Host: hostStr, Port: uint16(portN), User: mc.User, Password: mc.Passwd,
+	})
+	defer syncer.Close()
+
+	streamer, syncErr := syncer.StartSync(gomysql.Position{Name: binlogFile, Pos: binlogPos})
+	if syncErr != nil {
+		t.Skipf("skipping: StartSync failed: %v", syncErr)
+	}
+
+	resolver, err := metadata.NewResolver(indexDB, 0)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+	sp := parser.NewStreamParser(resolver, parser.Filters{Schemas: map[string]bool{sourceName: true}}, nil)
+	idx := indexer.New(indexDB, 100)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	events := make(chan parser.Event, 100)
+	parseErrCh := make(chan error, 1)
+	go func() {
+		defer close(events)
+		parseErrCh <- sp.Run(ctx, streamer, events)
+	}()
+
+	state := &streamState{mode: "gtid", flavor: gomysql.MariaDBFlavor, serverID: 99996, accGTID: accGTID}
+	if err := streamLoop(ctx, events, idx, indexDB, time.Minute, state, observe.ForSource("test-mariadb-gtid"), nil); err != nil {
+		t.Fatalf("streamLoop: %v", err)
+	}
+
+	parseErr := <-parseErrCh
+	if parseErr != nil &&
+		!errors.Is(parseErr, context.DeadlineExceeded) &&
+		!errors.Is(parseErr, context.Canceled) {
+		t.Fatalf("StreamParser error: %v", parseErr)
+	}
+
+	// advanceGTID must have grown the durable set via MariadbGTIDSet.Update().
+	if state.gtidSet == "" {
+		t.Fatal("expected accumulated GTID set after committing transactions, got empty")
+	}
+	if strings.Contains(state.gtidSet, ":") {
+		t.Errorf("accumulated set %q is not MariaDB domain-server-seq form", state.gtidSet)
+	}
+	// The persisted set must re-parse with the MariaDB parser (resume contract).
+	if _, err := parseGTIDSetForFlavor(gomysql.MariaDBFlavor, state.gtidSet); err != nil {
+		t.Errorf("accumulated MariaDB set %q does not re-parse: %v", state.gtidSet, err)
+	}
+}

--- a/internal/streamrun/streamrun.go
+++ b/internal/streamrun/streamrun.go
@@ -36,14 +36,18 @@ type streamState struct {
 	binlogFile    string
 	binlogPos     uint64
 	gtidSet       string // serialized GTID set (GTID mode only)
+	flavor        string // source flavor: "mysql" (default) or "mariadb"; selects the GTID parser on resume
 	eventsIndexed int64
 	lastEventTime sql.NullTime
 	serverID      uint32
 	bintrailID    string // resolved server identity (empty = unknown, stored as NULL)
 
 	// accGTID is the in-memory accumulated GTID set (GTID mode only).
-	// It is serialized to gtidSet on checkpoint.
-	accGTID *gomysql.MysqlGTIDSet
+	// It is serialized to gtidSet on checkpoint. Typed as the gomysql.GTIDSet
+	// interface so it can hold either a *MysqlGTIDSet or, for a MariaDB source,
+	// a *MariadbGTIDSet. Position mode leaves it a true nil interface, which the
+	// advanceGTID guard relies on.
+	accGTID gomysql.GTIDSet
 }
 
 // loadStreamState loads the saved stream_state row, returning nil if no row exists.
@@ -51,10 +55,10 @@ func loadStreamState(db *sql.DB) (*streamState, error) {
 	var s streamState
 	var gtidSet, bintrailID sql.NullString
 	err := db.QueryRow(`
-		SELECT mode, binlog_file, binlog_position, gtid_set,
+		SELECT mode, binlog_file, binlog_position, gtid_set, flavor,
 		       events_indexed, last_event_time, server_id, bintrail_id
 		FROM stream_state WHERE id = 1`).Scan(
-		&s.mode, &s.binlogFile, &s.binlogPos, &gtidSet,
+		&s.mode, &s.binlogFile, &s.binlogPos, &gtidSet, &s.flavor,
 		&s.eventsIndexed, &s.lastEventTime, &s.serverID, &bintrailID)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
@@ -85,21 +89,28 @@ func saveCheckpoint(db *sql.DB, state *streamState) error {
 	if state.bintrailID != "" {
 		bintrailIDArg = state.bintrailID
 	}
+	// Default an unset flavor to mysql so the NOT NULL column never receives an
+	// empty string from a caller that predates the flavor field.
+	flavor := state.flavor
+	if flavor == "" {
+		flavor = gomysql.MySQLFlavor
+	}
 	_, err := db.Exec(`
 		INSERT INTO stream_state
-		    (id, mode, binlog_file, binlog_position, gtid_set,
+		    (id, mode, binlog_file, binlog_position, gtid_set, flavor,
 		     events_indexed, last_event_time, last_checkpoint, server_id, bintrail_id)
-		VALUES (1, ?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(), ?, ?)
+		VALUES (1, ?, ?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(), ?, ?)
 		ON DUPLICATE KEY UPDATE
 		    binlog_file     = VALUES(binlog_file),
 		    binlog_position = VALUES(binlog_position),
 		    gtid_set        = VALUES(gtid_set),
+		    flavor          = VALUES(flavor),
 		    events_indexed  = VALUES(events_indexed),
 		    last_event_time = VALUES(last_event_time),
 		    last_checkpoint = UTC_TIMESTAMP(),
 		    server_id       = VALUES(server_id),
 		    bintrail_id     = VALUES(bintrail_id)`,
-		state.mode, state.binlogFile, state.binlogPos, gtidSet,
+		state.mode, state.binlogFile, state.binlogPos, gtidSet, flavor,
 		state.eventsIndexed, lastEventTime, state.serverID, bintrailIDArg)
 	return err
 }
@@ -223,13 +234,47 @@ func NormalizeGTIDSet(s string) string {
 	return strings.Join(entries, ",")
 }
 
-// resolveStart determines the start position for replication. It returns the
-// mode ("position" or "gtid"), file, GTID string, pos, and an optional
-// pre-parsed MysqlGTIDSet (non-nil only in GTID mode).
+// parseGTIDSetForFlavor parses a GTID set string with the parser for the given
+// flavor: ParseMariadbGTIDSet for "mariadb", ParseMysqlGTIDSet otherwise. Both
+// library functions return the gomysql.GTIDSet interface (and a true-nil
+// interface on error), so this never produces a typed-nil. The caller is
+// responsible for any flavor-appropriate normalization first (see
+// normalizeGTIDForFlavor).
+func parseGTIDSetForFlavor(flavor, s string) (gomysql.GTIDSet, error) {
+	if flavor == gomysql.MariaDBFlavor {
+		return gomysql.ParseMariadbGTIDSet(s)
+	}
+	return gomysql.ParseMysqlGTIDSet(s)
+}
+
+// normalizeGTIDForFlavor zero-pads UUIDs for MySQL (see NormalizeGTIDSet) and
+// leaves MariaDB domain-server-seq GTIDs untouched (they have no UUID to pad).
+func normalizeGTIDForFlavor(flavor, s string) string {
+	if flavor == gomysql.MariaDBFlavor {
+		return s
+	}
+	return NormalizeGTIDSet(s)
+}
+
+// resolveStart determines the start position for replication for a MySQL source.
+// It is a thin wrapper over resolveStartForFlavor; see that function for the
+// full contract. Kept so existing MySQL callers and tests are unchanged.
 func resolveStart(
 	startFile, startGTID string, startPos uint32,
 	saved *streamState,
-) (mode, file, gtidStr string, pos uint32, accGTID *gomysql.MysqlGTIDSet, err error) {
+) (mode, file, gtidStr string, pos uint32, accGTID gomysql.GTIDSet, err error) {
+	return resolveStartForFlavor(startFile, startGTID, startPos, saved, gomysql.MySQLFlavor)
+}
+
+// resolveStartForFlavor determines the start position for replication. It returns
+// the mode ("position" or "gtid"), file, GTID string, pos, and an optional
+// pre-parsed GTID set (non-nil only in GTID mode). flavor selects the GTID
+// parser; for "mariadb" the set is parsed as domain-server-seq and not UUID
+// zero-padded. Position mode returns a true-nil accGTID interface.
+func resolveStartForFlavor(
+	startFile, startGTID string, startPos uint32,
+	saved *streamState, flavor string,
+) (mode, file, gtidStr string, pos uint32, accGTID gomysql.GTIDSet, err error) {
 	// Saved checkpoint takes priority — makes re-running the same command
 	// idempotent (the user doesn't need to remove --start-file to resume).
 	// Exception: if the user explicitly requests a *different* mode than the
@@ -241,18 +286,30 @@ func resolveStart(
 			return "", "", "", 0, nil, fmt.Errorf("--start-file and --start-gtid are mutually exclusive")
 		}
 
+		// Reject resuming a checkpoint under a different source flavor. The saved
+		// set's format is fixed by the flavor that wrote it; continuing under
+		// another flavor would parse the saved set one way while the BinlogSyncer
+		// handshakes — and the next checkpoint persists — as another, a latent
+		// corruption. Legacy rows (empty flavor, pre-column) adopt the requested
+		// flavor. --reset clears the checkpoint (saved == nil) and bypasses this.
+		if saved.flavor != "" && saved.flavor != flavor {
+			return "", "", "", 0, nil, fmt.Errorf(
+				"saved checkpoint is source flavor %q but %q was requested; pass --source-flavor %s (or --reset to start fresh)",
+				saved.flavor, flavor, saved.flavor)
+		}
+
 		// Detect mode switch: user explicitly requests a different mode.
 		switchToGTID := saved.mode == "position" && startGTID != "" && startFile == ""
 		switchToPosition := saved.mode == "gtid" && startFile != "" && startGTID == ""
 
 		if switchToGTID {
 			slog.Warn("switching from position mode to GTID mode", "old_file", saved.binlogFile, "old_pos", saved.binlogPos)
-			startGTID = NormalizeGTIDSet(startGTID)
-			gs, parseErr := gomysql.ParseMysqlGTIDSet(startGTID)
+			startGTID = normalizeGTIDForFlavor(flavor, startGTID)
+			gs, parseErr := parseGTIDSetForFlavor(flavor, startGTID)
 			if parseErr != nil {
 				return "", "", "", 0, nil, fmt.Errorf("invalid --start-gtid: %w", parseErr)
 			}
-			return "gtid", "", startGTID, 0, gs.(*gomysql.MysqlGTIDSet), nil
+			return "gtid", "", startGTID, 0, gs, nil
 		}
 		if switchToPosition {
 			slog.Warn("switching from GTID mode to position mode", "old_gtid_set", saved.gtidSet)
@@ -264,13 +321,15 @@ func resolveStart(
 			slog.Warn("checkpoint exists; ignoring --start-file/--start-gtid and resuming from saved state")
 		}
 		if saved.mode == "gtid" {
-			normalized := NormalizeGTIDSet(saved.gtidSet)
-			slog.Info("resuming from GTID set", "gtid_set", normalized)
-			gs, parseErr := gomysql.ParseMysqlGTIDSet(normalized)
+			// flavor is authoritative here: the mismatch guard above guarantees
+			// saved.flavor is either empty (legacy) or equal to flavor.
+			normalized := normalizeGTIDForFlavor(flavor, saved.gtidSet)
+			slog.Info("resuming from GTID set", "gtid_set", normalized, "flavor", flavor)
+			gs, parseErr := parseGTIDSetForFlavor(flavor, normalized)
 			if parseErr != nil {
 				return "", "", "", 0, nil, fmt.Errorf("invalid saved gtid_set %q: %w", saved.gtidSet, parseErr)
 			}
-			return "gtid", "", normalized, 0, gs.(*gomysql.MysqlGTIDSet), nil
+			return "gtid", "", normalized, 0, gs, nil
 		}
 		slog.Info("resuming from position", "file", saved.binlogFile, "pos", saved.binlogPos)
 		return "position", saved.binlogFile, "", uint32(saved.binlogPos), nil, nil
@@ -281,12 +340,12 @@ func resolveStart(
 		return "", "", "", 0, nil, fmt.Errorf("--start-file and --start-gtid are mutually exclusive")
 	}
 	if startGTID != "" {
-		startGTID = NormalizeGTIDSet(startGTID)
-		gs, parseErr := gomysql.ParseMysqlGTIDSet(startGTID)
+		startGTID = normalizeGTIDForFlavor(flavor, startGTID)
+		gs, parseErr := parseGTIDSetForFlavor(flavor, startGTID)
 		if parseErr != nil {
 			return "", "", "", 0, nil, fmt.Errorf("invalid --start-gtid: %w", parseErr)
 		}
-		return "gtid", "", startGTID, 0, gs.(*gomysql.MysqlGTIDSet), nil
+		return "gtid", "", startGTID, 0, gs, nil
 	}
 	if startFile != "" {
 		return "position", startFile, "", startPos, nil, nil
@@ -312,8 +371,20 @@ func resolveStartWithAutoDiscover(
 	startFile, startGTID string, startPos uint32,
 	saved *streamState,
 	autoDiscover func() (string, uint32, error),
-) (mode, file, gtidStr string, pos uint32, accGTID *gomysql.MysqlGTIDSet, err error) {
-	mode, file, gtidStr, pos, accGTID, err = resolveStart(startFile, startGTID, startPos, saved)
+) (mode, file, gtidStr string, pos uint32, accGTID gomysql.GTIDSet, err error) {
+	return resolveStartWithAutoDiscoverForFlavor(startFile, startGTID, startPos, saved, gomysql.MySQLFlavor, autoDiscover)
+}
+
+// resolveStartWithAutoDiscoverForFlavor is the flavor-aware variant of
+// resolveStartWithAutoDiscover; see that function for the contract. flavor is
+// threaded into resolveStartForFlavor so saved/flag GTID sets parse with the
+// right flavor.
+func resolveStartWithAutoDiscoverForFlavor(
+	startFile, startGTID string, startPos uint32,
+	saved *streamState, flavor string,
+	autoDiscover func() (string, uint32, error),
+) (mode, file, gtidStr string, pos uint32, accGTID gomysql.GTIDSet, err error) {
+	mode, file, gtidStr, pos, accGTID, err = resolveStartForFlavor(startFile, startGTID, startPos, saved, flavor)
 	if err == nil {
 		return
 	}
@@ -751,8 +822,12 @@ func streamLoop(
 // zero value is invalid; build it from the cobra layer's streamConfigFromFlags
 // or populate it explicitly.
 type Config struct {
-	IndexDSN    string
-	SourceDSN   string
+	IndexDSN  string
+	SourceDSN string
+	// Flavor is the source database flavor: "mysql" (default) or "mariadb".
+	// Empty is normalized to "mysql" in One(). It selects the GTID parser and
+	// the BinlogSyncer flavor, and is persisted to stream_state for resume.
+	Flavor      string
 	ServerID    uint32
 	StartFile   string
 	StartPos    uint32
@@ -870,6 +945,17 @@ func One(ctx context.Context, cfg Config) error {
 		return err
 	}
 
+	// Normalize the source flavor once so every downstream use (GTID parsing,
+	// BinlogSyncerConfig, persistence) sees a concrete value. Empty defaults to
+	// MySQL, keeping every existing caller (which never sets Flavor) unchanged.
+	switch cfg.Flavor {
+	case "":
+		cfg.Flavor = gomysql.MySQLFlavor
+	case gomysql.MySQLFlavor, gomysql.MariaDBFlavor:
+	default:
+		return fmt.Errorf("invalid source flavor %q: must be %q or %q", cfg.Flavor, gomysql.MySQLFlavor, gomysql.MariaDBFlavor)
+	}
+
 	// Derived cancel: internal failures (e.g. the stream loop erroring) must
 	// stop the parser goroutine even when the caller's ctx stays live.
 	ctx, cancel := context.WithCancel(ctx)
@@ -907,6 +993,16 @@ func One(ctx context.Context, cfg Config) error {
 		return err
 	}
 	fmt.Println("Source: no FK cascades \u2713")
+
+	// Advisory only: warn (never block) when the declared flavor disagrees with
+	// the server's actual VERSION(). A mismatch \u2014 e.g. the default --source-flavor
+	// mysql pointed at a MariaDB server \u2014 makes the GTID handshake misbehave.
+	// Detection never flips the configured flavor, so it can't silently
+	// mis-handshake a MySQL source.
+	if detected := metadata.DetectFlavor(sourceDB); detected != "" && detected != cfg.Flavor {
+		slog.Warn("source flavor mismatch: configured flavor differs from the detected server flavor \u2014 GTID handling may misbehave; set --source-flavor to match",
+			"configured", cfg.Flavor, "detected", detected)
+	}
 
 	// ── 3. Resolve server identity ────────────────────────────────────────────
 	bintrailID, err := cfg.Deps.ResolveServerIdentity(ctx, sourceDB, indexDB, cfg.SourceDSN)
@@ -948,8 +1044,8 @@ func One(ctx context.Context, cfg Config) error {
 		}
 	}
 
-	mode, startFile, startGTIDStr, startPos, accGTID, err := resolveStartWithAutoDiscover(
-		cfg.StartFile, cfg.StartGTID, cfg.StartPos, saved,
+	mode, startFile, startGTIDStr, startPos, accGTID, err := resolveStartWithAutoDiscoverForFlavor(
+		cfg.StartFile, cfg.StartGTID, cfg.StartPos, saved, cfg.Flavor,
 		func() (string, uint32, error) { return config.CurrentBinlogPosition(sourceDB) })
 	if err != nil {
 		return err
@@ -973,7 +1069,25 @@ func One(ctx context.Context, cfg Config) error {
 		case "position":
 			gap, gapErr = detectPositionGap(sourceDB, startFile, startPos, gapTimeout)
 		case "gtid":
-			gap, gapErr = detectGTIDGap(sourceDB, startGTIDStr, gapTimeout)
+			if cfg.Flavor == gomysql.MariaDBFlavor {
+				// MariaDB GTID gap detection is not implemented for the alpha:
+				// detectGTIDGap relies on MySQL-only @@gtid_purged/@@gtid_executed
+				// and the MySQL GTID-set map shape, neither of which is portable, so
+				// we cannot verify whether binlogs were purged. If the operator
+				// demanded a hard stop on unverifiable gaps (--no-gap-fill), honor it
+				// — refuse rather than proceed blind. Otherwise warn loudly and
+				// proceed; position mode retains full gap detection and is the
+				// recommended MariaDB resume mode. gap/gapErr stay nil → stream runs.
+				if cfg.NoGapFill {
+					return fmt.Errorf("--no-gap-fill is set but GTID gap detection is unavailable for a MariaDB source; " +
+						"resume in position mode or drop --no-gap-fill (alpha limitation)")
+				}
+				slog.Warn("GTID gap detection is unavailable for a MariaDB source (alpha): a purged-binlog gap on resume " +
+					"will NOT abort or raise the data-loss alarm, and --no-gap-fill cannot be enforced in this mode — " +
+					"prefer position mode for MariaDB resumes")
+			} else {
+				gap, gapErr = detectGTIDGap(sourceDB, startGTIDStr, gapTimeout)
+			}
 		default:
 			slog.Warn("gap detection not implemented for mode", "mode", mode)
 		}
@@ -1014,16 +1128,14 @@ func One(ctx context.Context, cfg Config) error {
 					// Use the purged set as the checkpoint GTID set — this tells
 					// MySQL we have already seen all purged GTIDs, so it will
 					// only send the non-purged GTIDs that remain in @@gtid_executed.
+					// MySQL-only branch: a MariaDB source skips GTID gap detection
+					// above, so gap is nil here and this is never reached for MariaDB.
 					startGTIDStr = NormalizeGTIDSet(gap.PurgedGTIDSet)
 					gs, parseErr := gomysql.ParseMysqlGTIDSet(startGTIDStr)
 					if parseErr != nil {
 						return fmt.Errorf("failed to parse purged GTID set for auto-advance: %w", parseErr)
 					}
-					parsed, ok := gs.(*gomysql.MysqlGTIDSet)
-					if !ok {
-						return fmt.Errorf("unexpected GTID set type %T after parsing purged set", gs)
-					}
-					accGTID = parsed
+					accGTID = gs
 				}
 
 				// Persist the advanced position immediately so that if the stream
@@ -1034,6 +1146,7 @@ func One(ctx context.Context, cfg Config) error {
 					binlogFile:    startFile,
 					binlogPos:     uint64(startPos),
 					gtidSet:       startGTIDStr,
+					flavor:        cfg.Flavor,
 					serverID:      cfg.ServerID,
 					bintrailID:    bintrailID,
 					eventsIndexed: saved.eventsIndexed,
@@ -1072,6 +1185,7 @@ func One(ctx context.Context, cfg Config) error {
 		// valid resume point instead of an empty file / position 0.
 		binlogFile: startFile,
 		binlogPos:  uint64(startPos),
+		flavor:     cfg.Flavor,
 		serverID:   cfg.ServerID,
 		accGTID:    accGTID,
 		bintrailID: bintrailID,
@@ -1098,7 +1212,7 @@ func One(ctx context.Context, cfg Config) error {
 	// ── 7. Create BinlogSyncer ────────────────────────────────────────────────────
 	syncerCfg := replication.BinlogSyncerConfig{
 		ServerID:             cfg.ServerID,
-		Flavor:               "mysql",
+		Flavor:               cfg.Flavor,
 		Host:                 host,
 		Port:                 port,
 		User:                 user,
@@ -1130,7 +1244,7 @@ func One(ctx context.Context, cfg Config) error {
 			}
 			return s, nil
 		case "gtid":
-			gset, parseErr := gomysql.ParseGTIDSet("mysql", startGTIDStr)
+			gset, parseErr := gomysql.ParseGTIDSet(cfg.Flavor, startGTIDStr)
 			if parseErr != nil {
 				return nil, fmt.Errorf("parse start GTID set: %w", parseErr)
 			}

--- a/internal/streamrun/streamrun.go
+++ b/internal/streamrun/streamrun.go
@@ -89,13 +89,13 @@ func saveCheckpoint(db *sql.DB, state *streamState) error {
 	if state.bintrailID != "" {
 		bintrailIDArg = state.bintrailID
 	}
-	// Default an unset flavor to mysql so the NOT NULL column never receives an
-	// empty string from a caller that predates the flavor field.
-	flavor := state.flavor
-	if flavor == "" {
-		flavor = gomysql.MySQLFlavor
+	// Canonicalize the flavor (empty→mysql) so the NOT NULL column never receives
+	// an empty string; an invalid flavor fails loud rather than persisting garbage.
+	flavor, err := normalizeFlavor(state.flavor)
+	if err != nil {
+		return err
 	}
-	_, err := db.Exec(`
+	_, err = db.Exec(`
 		INSERT INTO stream_state
 		    (id, mode, binlog_file, binlog_position, gtid_set, flavor,
 		     events_indexed, last_event_time, last_checkpoint, server_id, bintrail_id)
@@ -256,6 +256,21 @@ func normalizeGTIDForFlavor(flavor, s string) string {
 	return NormalizeGTIDSet(s)
 }
 
+// normalizeFlavor canonicalizes a source flavor: empty defaults to MySQL,
+// "mysql"/"mariadb" pass through, and anything else is rejected. It is the
+// single home for both the empty→mysql default and the supported-flavor check,
+// used at stream startup (One) and on checkpoint persistence (saveCheckpoint).
+func normalizeFlavor(flavor string) (string, error) {
+	switch flavor {
+	case "":
+		return gomysql.MySQLFlavor, nil
+	case gomysql.MySQLFlavor, gomysql.MariaDBFlavor:
+		return flavor, nil
+	default:
+		return "", fmt.Errorf("invalid source flavor %q: must be %q or %q", flavor, gomysql.MySQLFlavor, gomysql.MariaDBFlavor)
+	}
+}
+
 // resolveStart determines the start position for replication for a MySQL source.
 // It is a thin wrapper over resolveStartForFlavor; see that function for the
 // full contract. Kept so existing MySQL callers and tests are unchanged.
@@ -290,8 +305,9 @@ func resolveStartForFlavor(
 		// set's format is fixed by the flavor that wrote it; continuing under
 		// another flavor would parse the saved set one way while the BinlogSyncer
 		// handshakes — and the next checkpoint persists — as another, a latent
-		// corruption. Legacy rows (empty flavor, pre-column) adopt the requested
-		// flavor. --reset clears the checkpoint (saved == nil) and bypasses this.
+		// corruption. Rows predating the column read back as the migration default
+		// 'mysql'; only a genuinely empty flavor (defensive) adopts the requested
+		// one. --reset clears the checkpoint (saved == nil) and bypasses this.
 		if saved.flavor != "" && saved.flavor != flavor {
 			return "", "", "", 0, nil, fmt.Errorf(
 				"saved checkpoint is source flavor %q but %q was requested; pass --source-flavor %s (or --reset to start fresh)",
@@ -947,14 +963,13 @@ func One(ctx context.Context, cfg Config) error {
 
 	// Normalize the source flavor once so every downstream use (GTID parsing,
 	// BinlogSyncerConfig, persistence) sees a concrete value. Empty defaults to
-	// MySQL, keeping every existing caller (which never sets Flavor) unchanged.
-	switch cfg.Flavor {
-	case "":
-		cfg.Flavor = gomysql.MySQLFlavor
-	case gomysql.MySQLFlavor, gomysql.MariaDBFlavor:
-	default:
-		return fmt.Errorf("invalid source flavor %q: must be %q or %q", cfg.Flavor, gomysql.MySQLFlavor, gomysql.MariaDBFlavor)
+	// MySQL, keeping every existing caller (which never sets Flavor) unchanged;
+	// an unsupported flavor is rejected here, before any connection is opened.
+	normalizedFlavor, err := normalizeFlavor(cfg.Flavor)
+	if err != nil {
+		return err
 	}
+	cfg.Flavor = normalizedFlavor
 
 	// Derived cancel: internal failures (e.g. the stream loop erroring) must
 	// stop the parser goroutine even when the caller's ctx stays live.
@@ -1083,8 +1098,7 @@ func One(ctx context.Context, cfg Config) error {
 						"resume in position mode or drop --no-gap-fill (alpha limitation)")
 				}
 				slog.Warn("GTID gap detection is unavailable for a MariaDB source (alpha): a purged-binlog gap on resume " +
-					"will NOT abort or raise the data-loss alarm, and --no-gap-fill cannot be enforced in this mode — " +
-					"prefer position mode for MariaDB resumes")
+					"will NOT raise the data-loss alarm — prefer position mode for MariaDB resumes (or pass --no-gap-fill to refuse starting)")
 			} else {
 				gap, gapErr = detectGTIDGap(sourceDB, startGTIDStr, gapTimeout)
 			}

--- a/internal/streamrun/streamrun_integration_test.go
+++ b/internal/streamrun/streamrun_integration_test.go
@@ -85,6 +85,69 @@ func TestStreamState_upsertAndLoad(t *testing.T) {
 	}
 }
 
+// TestStreamState_mariadbRoundTrip verifies the source flavor persists through a
+// checkpoint save/load cycle and then drives resume parsing: a MariaDB gtid_set
+// ("0-1-100") survives and re-parses with the MariaDB parser. Without the
+// persisted flavor, resume would call ParseMysqlGTIDSet and reject the set.
+func TestStreamState_mariadbRoundTrip(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	if err := saveCheckpoint(db, &streamState{
+		mode:     "gtid",
+		gtidSet:  "0-1-100",
+		flavor:   gomysql.MariaDBFlavor,
+		serverID: 42,
+	}); err != nil {
+		t.Fatalf("saveCheckpoint: %v", err)
+	}
+
+	loaded, err := loadStreamState(db)
+	if err != nil {
+		t.Fatalf("loadStreamState: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("expected non-nil state after save")
+	}
+	if loaded.flavor != gomysql.MariaDBFlavor {
+		t.Errorf("flavor: expected mariadb, got %q", loaded.flavor)
+	}
+	if loaded.gtidSet != "0-1-100" {
+		t.Errorf("gtidSet: expected 0-1-100, got %q", loaded.gtidSet)
+	}
+
+	// The persisted flavor must drive resume parsing.
+	mode, _, gtidStr, _, accGTID, err := resolveStartForFlavor("", "", 0, loaded, loaded.flavor)
+	if err != nil {
+		t.Fatalf("resume resolveStartForFlavor: %v", err)
+	}
+	if mode != "gtid" || gtidStr != "0-1-100" {
+		t.Errorf("resume: mode=%q gtid=%q, want gtid/0-1-100", mode, gtidStr)
+	}
+	if _, ok := accGTID.(*gomysql.MariadbGTIDSet); !ok {
+		t.Errorf("resume accGTID type = %T, want *MariadbGTIDSet", accGTID)
+	}
+}
+
+// TestStreamState_mysqlFlavorDefault verifies a checkpoint written without an
+// explicit flavor loads back as mysql (the NOT NULL DEFAULT) — pre-MariaDB
+// callers and rows are unaffected.
+func TestStreamState_mysqlFlavorDefault(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	if err := saveCheckpoint(db, &streamState{mode: "position", binlogFile: "binlog.000001", binlogPos: 4, serverID: 1}); err != nil {
+		t.Fatalf("saveCheckpoint: %v", err)
+	}
+	loaded, err := loadStreamState(db)
+	if err != nil {
+		t.Fatalf("loadStreamState: %v", err)
+	}
+	if loaded.flavor != gomysql.MySQLFlavor {
+		t.Errorf("flavor default: expected mysql, got %q", loaded.flavor)
+	}
+}
+
 func TestStreamState_upsertUpdate(t *testing.T) {
 	db, _ := testutil.CreateTestDB(t)
 	testutil.InitIndexTables(t, db)

--- a/internal/streamrun/streamrun_test.go
+++ b/internal/streamrun/streamrun_test.go
@@ -183,6 +183,135 @@ func TestResolveStart_invalidStartGTIDFlag(t *testing.T) {
 	}
 }
 
+// ─── MariaDB flavor: GTID parsing + resolveStart (alpha) ──────────────────────
+
+// TestParseGTIDSetForFlavor verifies the flavor dispatch: MariaDB strings parse
+// to *MariadbGTIDSet (domain-server-seq, not zero-padded), MySQL strings to
+// *MysqlGTIDSet, and an unparseable string errors for both flavors.
+func TestParseGTIDSetForFlavor(t *testing.T) {
+	gs, err := parseGTIDSetForFlavor(gomysql.MySQLFlavor, "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-5")
+	if err != nil {
+		t.Fatalf("mysql parse: %v", err)
+	}
+	if _, ok := gs.(*gomysql.MysqlGTIDSet); !ok {
+		t.Errorf("mysql flavor: expected *MysqlGTIDSet, got %T", gs)
+	}
+
+	mgs, err := parseGTIDSetForFlavor(gomysql.MariaDBFlavor, "0-1-100")
+	if err != nil {
+		t.Fatalf("mariadb parse: %v", err)
+	}
+	if _, ok := mgs.(*gomysql.MariadbGTIDSet); !ok {
+		t.Errorf("mariadb flavor: expected *MariadbGTIDSet, got %T", mgs)
+	}
+	if mgs.String() != "0-1-100" {
+		t.Errorf("mariadb GTID string = %q, want %q (must not be zero-padded)", mgs.String(), "0-1-100")
+	}
+
+	if _, err := parseGTIDSetForFlavor(gomysql.MySQLFlavor, "garbage"); err == nil {
+		t.Error("expected error for invalid mysql GTID")
+	}
+	if _, err := parseGTIDSetForFlavor(gomysql.MariaDBFlavor, "garbage"); err == nil {
+		t.Error("expected error for invalid mariadb GTID")
+	}
+}
+
+// TestNormalizeGTIDSet_mariadbPassthrough pins that the MySQL UUID zero-padder
+// leaves MariaDB domain-server-seq GTIDs untouched (3 segments is not a 5-part
+// UUID, so it passes through). Defense in depth in case a MariaDB string reaches
+// NormalizeGTIDSet.
+func TestNormalizeGTIDSet_mariadbPassthrough(t *testing.T) {
+	for _, s := range []string{"0-1-100", "0-1-100,1-2-50"} {
+		if got := NormalizeGTIDSet(s); got != s {
+			t.Errorf("NormalizeGTIDSet(%q) = %q, want unchanged", s, got)
+		}
+	}
+}
+
+// TestResolveStartForFlavor_mariadbGTID verifies a fresh MariaDB GTID start: the
+// GTID is parsed with the MariaDB flavor and returned without zero-padding, and
+// accGTID's dynamic type is *MariadbGTIDSet.
+func TestResolveStartForFlavor_mariadbGTID(t *testing.T) {
+	mode, _, gtidStr, _, accGTID, err := resolveStartForFlavor("", "0-1-100", 4, nil, gomysql.MariaDBFlavor)
+	if err != nil {
+		t.Fatalf("resolveStartForFlavor: %v", err)
+	}
+	if mode != "gtid" {
+		t.Errorf("mode = %q, want gtid", mode)
+	}
+	if gtidStr != "0-1-100" {
+		t.Errorf("gtidStr = %q, want 0-1-100", gtidStr)
+	}
+	if accGTID == nil {
+		t.Fatal("expected non-nil accGTID for mariadb GTID mode")
+	}
+	if _, ok := accGTID.(*gomysql.MariadbGTIDSet); !ok {
+		t.Errorf("accGTID dynamic type = %T, want *MariadbGTIDSet", accGTID)
+	}
+}
+
+// TestResolveStartForFlavor_resumeMariaDBGTID verifies the resume path: a saved
+// MariaDB checkpoint (flavor=mariadb) re-parses its gtid_set with the MariaDB
+// parser. The negative control proves a MariaDB set parsed as MySQL fails — the
+// exact break that the persisted flavor column prevents.
+func TestResolveStartForFlavor_resumeMariaDBGTID(t *testing.T) {
+	saved := &streamState{mode: "gtid", gtidSet: "0-1-100", flavor: gomysql.MariaDBFlavor}
+	mode, _, gtidStr, _, accGTID, err := resolveStartForFlavor("", "", 0, saved, gomysql.MariaDBFlavor)
+	if err != nil {
+		t.Fatalf("resume mariadb: %v", err)
+	}
+	if mode != "gtid" || gtidStr != "0-1-100" {
+		t.Errorf("resume: mode=%q gtidStr=%q, want gtid/0-1-100", mode, gtidStr)
+	}
+	if _, ok := accGTID.(*gomysql.MariadbGTIDSet); !ok {
+		t.Errorf("resume accGTID type = %T, want *MariadbGTIDSet", accGTID)
+	}
+
+	// Negative control: a MariaDB set parsed under the MySQL flavor must fail.
+	if _, err := parseGTIDSetForFlavor(gomysql.MySQLFlavor, "0-1-100"); err == nil {
+		t.Error("expected MariaDB GTID parsed as MySQL to error (this is why flavor must be persisted)")
+	}
+}
+
+// TestResolveStartForFlavor_flavorMismatchErrors verifies that resuming a saved
+// checkpoint under a different source flavor is rejected (latent-corruption
+// guard): the saved set would be parsed as one flavor while the syncer handshake
+// and the next checkpoint use another. A legacy checkpoint (empty flavor) adopts
+// the requested flavor instead of erroring.
+func TestResolveStartForFlavor_flavorMismatchErrors(t *testing.T) {
+	// Saved as mariadb, requested mysql → error (covers GTID mode).
+	mdb := &streamState{mode: "gtid", gtidSet: "0-1-100", flavor: gomysql.MariaDBFlavor}
+	if _, _, _, _, _, err := resolveStartForFlavor("", "", 0, mdb, gomysql.MySQLFlavor); err == nil {
+		t.Error("expected error resuming a mariadb checkpoint under mysql flavor")
+	}
+
+	// Saved as mysql, requested mariadb → error (covers position mode).
+	my := &streamState{mode: "position", binlogFile: "binlog.000001", binlogPos: 4, flavor: gomysql.MySQLFlavor}
+	if _, _, _, _, _, err := resolveStartForFlavor("", "", 0, my, gomysql.MariaDBFlavor); err == nil {
+		t.Error("expected error resuming a mysql checkpoint under mariadb flavor")
+	}
+
+	// Legacy checkpoint (empty flavor) adopts the requested flavor — no error.
+	legacy := &streamState{mode: "position", binlogFile: "binlog.000001", binlogPos: 4}
+	if _, _, _, _, _, err := resolveStartForFlavor("", "", 0, legacy, gomysql.MariaDBFlavor); err != nil {
+		t.Errorf("legacy checkpoint (empty flavor) should adopt requested flavor, got error: %v", err)
+	}
+}
+
+// TestResolveStart_positionModeReturnsTrueNil pins that position mode returns a
+// genuine nil interface — not a typed-nil *MysqlGTIDSet wrapped in the interface
+// — so advanceGTID's `state.accGTID == nil` guard keeps working after the
+// interface widening (the typed-nil-interface trap).
+func TestResolveStart_positionModeReturnsTrueNil(t *testing.T) {
+	_, _, _, _, accGTID, err := resolveStart("binlog.000001", "", 4, nil)
+	if err != nil {
+		t.Fatalf("resolveStart: %v", err)
+	}
+	if accGTID != nil {
+		t.Errorf("position mode must return a true-nil accGTID interface, got %T", accGTID)
+	}
+}
+
 // ─── GTID accumulation ────────────────────────────────────────────────────────
 
 // TestStreamState_gtidAccumulation verifies that accGTID.Update correctly

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -115,18 +115,39 @@ func MariaDBBaseDSN() string {
 	return MariaDBDefaultDSN
 }
 
-// SkipIfNoMariaDB pings the MariaDB source server and calls t.Skip if
-// unreachable, so MariaDB tests degrade gracefully when only the MySQL
-// container is running.
+// MariaDBRequired reports whether MariaDB integration tests must RUN (and fail
+// rather than skip when MariaDB is unavailable or a setup step no-ops). The
+// dedicated CI job sets BINTRAIL_REQUIRE_MARIADB=1, where a MariaDB source is
+// guaranteed present — so a silent skip there would be a false green that hides
+// a real regression in the headline capture path. Unset on developer machines
+// and the MySQL-only matrix job, where graceful skipping is the right behavior.
+func MariaDBRequired() bool {
+	return os.Getenv("BINTRAIL_REQUIRE_MARIADB") == "1"
+}
+
+// SkipOrFailMariaDB skips the test, or fails it when MariaDBRequired() — so a
+// MariaDB step that can't run never silently passes as green in CI.
+func SkipOrFailMariaDB(t *testing.T, format string, args ...any) {
+	t.Helper()
+	if MariaDBRequired() {
+		t.Fatalf(format, args...)
+	}
+	t.Skipf(format, args...)
+}
+
+// SkipIfNoMariaDB pings the MariaDB source server and skips (or fails, when
+// MariaDBRequired()) if unreachable, so MariaDB tests degrade gracefully when
+// only the MySQL container is running but cannot false-green in the CI job that
+// guarantees a MariaDB source.
 func SkipIfNoMariaDB(t *testing.T) {
 	t.Helper()
 	db, err := sql.Open("mysql", MariaDBBaseDSN()+"/?parseTime=true")
-	if err != nil {
-		t.Skipf("skipping: cannot open MariaDB connection: %v", err)
+	if err == nil {
+		defer db.Close()
+		err = db.Ping()
 	}
-	defer db.Close()
-	if err := db.Ping(); err != nil {
-		t.Skipf("skipping: MariaDB not reachable: %v", err)
+	if err != nil {
+		SkipOrFailMariaDB(t, "MariaDB not reachable: %v", err)
 	}
 }
 

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -95,6 +95,82 @@ func CreateTestDB(t *testing.T) (*sql.DB, string) {
 	return db, name
 }
 
+// ─── MariaDB source helpers (MariaDB-as-source alpha) ─────────────────────────
+//
+// These mirror the MySQL helpers above for a MariaDB SOURCE container, used only
+// by MariaDB-tagged integration/e2e tests. The MySQL helpers (index DB) are left
+// completely unchanged. Default container: port 13307, root:testroot.
+
+// MariaDBDefaultDSN is the base DSN used when BINTRAIL_TEST_MARIADB_DSN is not
+// set. It assumes a local Docker MariaDB container on port 13307 with
+// root:testroot (distinct from the MySQL index container on 13306).
+const MariaDBDefaultDSN = "root:testroot@tcp(127.0.0.1:13307)"
+
+// MariaDBBaseDSN returns the base MariaDB source DSN (without database name)
+// from the environment or the default. It always includes parseTime=true.
+func MariaDBBaseDSN() string {
+	if env := os.Getenv("BINTRAIL_TEST_MARIADB_DSN"); env != "" {
+		return env
+	}
+	return MariaDBDefaultDSN
+}
+
+// SkipIfNoMariaDB pings the MariaDB source server and calls t.Skip if
+// unreachable, so MariaDB tests degrade gracefully when only the MySQL
+// container is running.
+func SkipIfNoMariaDB(t *testing.T) {
+	t.Helper()
+	db, err := sql.Open("mysql", MariaDBBaseDSN()+"/?parseTime=true")
+	if err != nil {
+		t.Skipf("skipping: cannot open MariaDB connection: %v", err)
+	}
+	defer db.Close()
+	if err := db.Ping(); err != nil {
+		t.Skipf("skipping: MariaDB not reachable: %v", err)
+	}
+}
+
+// CreateTestMariaDB creates a unique database on the MariaDB SOURCE server,
+// returning a connected *sql.DB, the database name, and registering cleanup.
+// It mirrors CreateTestDB but targets the MariaDB container (13307).
+func CreateTestMariaDB(t *testing.T) (*sql.DB, string) {
+	t.Helper()
+	SkipIfNoMariaDB(t)
+
+	name := fmt.Sprintf("%s_%d", sanitiseDBName(t.Name()), dbCounter.Add(1))
+
+	rootDB, err := sql.Open("mysql", MariaDBBaseDSN()+"/?parseTime=true")
+	if err != nil {
+		t.Fatalf("failed to connect to MariaDB for DB creation: %v", err)
+	}
+	defer rootDB.Close()
+
+	rootDB.Exec("DROP DATABASE IF EXISTS `" + name + "`")
+	if _, err := rootDB.Exec("CREATE DATABASE `" + name + "`"); err != nil {
+		t.Fatalf("failed to create MariaDB test database %q: %v", name, err)
+	}
+
+	dsn := MariaDBBaseDSN() + "/" + name + "?parseTime=true"
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatalf("failed to connect to MariaDB test database %q: %v", name, err)
+	}
+	if err := db.Ping(); err != nil {
+		t.Fatalf("failed to ping MariaDB test database %q: %v", name, err)
+	}
+
+	t.Cleanup(func() {
+		db.Close()
+		cleanup, _ := sql.Open("mysql", MariaDBBaseDSN()+"/?parseTime=true")
+		if cleanup != nil {
+			cleanup.Exec("DROP DATABASE IF EXISTS `" + name + "`")
+			cleanup.Close()
+		}
+	})
+
+	return db, name
+}
+
 // MustExec executes a query or calls t.Fatal on error.
 func MustExec(t *testing.T, db *sql.DB, query string, args ...any) {
 	t.Helper()
@@ -191,6 +267,7 @@ func InitIndexTables(t *testing.T, db *sql.DB) {
 		binlog_file      VARCHAR(255)    NOT NULL DEFAULT '',
 		binlog_position  BIGINT UNSIGNED NOT NULL DEFAULT 0,
 		gtid_set         TEXT            DEFAULT NULL,
+		flavor           VARCHAR(16)     NOT NULL DEFAULT 'mysql',
 		events_indexed   BIGINT UNSIGNED NOT NULL DEFAULT 0,
 		last_event_time  DATETIME        DEFAULT NULL,
 		last_checkpoint  DATETIME        NOT NULL,


### PR DESCRIPTION
## MariaDB as a replication source (alpha)

Adds **MariaDB-as-source** support: `bintrail stream` and file-based `bintrail index` can now run against a MariaDB source while the index database stays MySQL. Opt in with `--source-flavor mariadb` (or `BINTRAIL_SOURCE_FLAVOR=mariadb`); the flag defaults to `mysql`, so **every existing MySQL command is unchanged**.

Built TDD (tests-first at each step), repro-first against a real MariaDB 11.4.12 + MySQL 8.0.46, and reviewed by the pr-review-toolkit code-reviewer + silent-failure-hunter (all findings applied).

### What changed
- **Position discovery** (`internal/config`): column-count-tolerant scan — MariaDB's `SHOW MASTER STATUS` returns 4 columns (no `Executed_Gtid_Set`) vs MySQL's 5. Flavor-agnostic; preserves the `log_bin=OFF` / combined-error contracts.
- **Parser** (`internal/parser`): a `*replication.MariadbGTIDEvent` case in both the stream and file parsers (`ev.GTID.String()` → `domain-server-seq`), and a `default`-warn arm in `handleRows` that closes a silent-drop class for MariaDB compressed-row events.
- **Stream engine** (`internal/streamrun`): `Config.Flavor` (normalized to `mysql` in `One()`), `parseGTIDSetForFlavor`/`normalizeGTIDForFlavor` helpers, `accGTID` widened from `*MysqlGTIDSet` to the `gomysql.GTIDSet` interface (typed-nil trap guarded), flavor-aware start/resume (`resolveStartForFlavor` — wrappers keep the MySQL signatures so no existing call-site changed), a flavor-mismatch-on-resume guard, flavor in the `BinlogSyncerConfig` + `ParseGTIDSet`, and MariaDB GTID gap-detection **degraded to a warn** (`detectGTIDGap` left byte-identical for MySQL; `--no-gap-fill` is refused in MariaDB GTID mode rather than silently ignored).
- **Schema** (`internal/indexer`): `stream_state.flavor VARCHAR(16) NOT NULL DEFAULT 'mysql'` + idempotent `EnsureSchema` migration (legacy rows read back as `mysql`, no data migration) + persistence threading.
- **Detection**: `metadata.DetectFlavor` (advisory startup warn only; returns "" on error rather than fabricating a flavor).
- **CLI**: `--source-flavor` flag + `BINTRAIL_SOURCE_FLAVOR` env (with `envBindings`/`envSections` parity).
- **Tests/CI**: `testutil.SkipIfNoMariaDB`/`CreateTestMariaDB` (port 13307), a live-replication + GTID-advance MariaDB integration test, and a dedicated `integration-mariadb-source` CI job (MySQL 8.4 index + MariaDB 11.4 source). The existing 8.0/8.4 matrix is left **byte-identical** (protects the #415 shared-binlog window); MariaDB tests **skip** (not fail) when no MariaDB container is present.
- **Docs**: a MariaDB-source alpha section in `docs/streaming.md`.

### Verified end-to-end (real MariaDB 11.4.12)
Position mode ✓, GTID mode ✓, GTID **resume** (re-parses the saved MariaDB set — no "invalid Mysql GTID") ✓, degraded-gap warn ✓, flavor persistence ✓. Zero-regression gate: full unit `-race` (28 packages) + full integration all green.

### Alpha limitations (documented, deferred to beta)
- Prefer **position mode** for MariaDB resume — GTID gap detection (the purged-binlog alarm) is not yet implemented (`@@gtid_binlog_state` set-math must be built against a live MariaDB).
- Compressed row events (`log_bin_compress=ON`) are warned-and-skipped, not yet decoded.
- Not yet wired into the console "+ Add server" / control plane (use the `bintrail stream` CLI).
- Index-on-MariaDB is out of scope; the index DB stays MySQL.
- BYOS agent (`cmd/bintrail/agent.go`) MariaDB support not included (same 2-line fix applies).

### Note
The only failing test, `internal/parser/audit_integration_test.go::TestAudit_UnsignedBigint`, is **pre-existing and untracked** (not in this PR, not in CI). It fails identically on clean `main` — it's a fidelity-audit characterization test that asserts a bug already fixed by #494 ("FINDING #4 NOT REPRODUCED" = the fix works). Left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
