### PR TITLE
feat: real MariaDB GTID gap detection (beta gate #1)

### DIFF
--- a/cmd/bintrail/stream.go
+++ b/cmd/bintrail/stream.go
@@ -75,7 +75,7 @@ var (
 func init() {
 	streamCmd.Flags().StringVar(&strmIndexDSN, "index-dsn", "", "DSN for the index MySQL database (required)")
 	streamCmd.Flags().StringVar(&strmSourceDSN, "source-dsn", "", "DSN for the source MySQL server (required)")
-	streamCmd.Flags().StringVar(&strmFlavor, "source-flavor", "mysql", "Source database flavor: mysql or mariadb (MariaDB source support is alpha; prefer position mode for resume)")
+	streamCmd.Flags().StringVar(&strmFlavor, "source-flavor", "mysql", "Source database flavor: mysql or mariadb (MariaDB source support is alpha)")
 	streamCmd.Flags().Uint32Var(&strmServerID, "server-id", 0, "Unique replica server ID (required, must differ from all other servers)")
 	streamCmd.Flags().StringVar(&strmStartFile, "start-file", "", "Initial binlog file (mutually exclusive with --start-gtid)")
 	streamCmd.Flags().Uint32Var(&strmStartPos, "start-pos", 4, "Initial position within start file")
@@ -92,7 +92,7 @@ func init() {
 	streamCmd.Flags().StringVar(&strmFormat, "format", "text", "Output format: text or json")
 	streamCmd.Flags().BoolVar(&strmReset, "reset", false, "Clear saved checkpoint before starting (forces use of --start-file/--start-gtid)")
 	streamCmd.Flags().BoolVar(&strmNoGapFill, "no-gap-fill", false, "Refuse to start if an unfillable binlog gap is detected (instead of auto-advancing past purged data)")
-	streamCmd.Flags().IntVar(&strmGapTimeout, "gap-timeout", 30, "Timeout in seconds for the one-shot gap-detection queries run at startup (SHOW BINARY LOGS, @@gtid_purged, @@gtid_executed); raise on managed MySQL with many binlog files")
+	streamCmd.Flags().IntVar(&strmGapTimeout, "gap-timeout", 30, "Timeout in seconds for the one-shot gap-detection queries run at startup (SHOW BINARY LOGS plus @@gtid_purged/@@gtid_executed on MySQL or BINLOG_GTID_POS/@@gtid_binlog_pos on MariaDB); raise on managed servers with many binlog files")
 	_ = streamCmd.MarkFlagRequired("index-dsn")
 	_ = streamCmd.MarkFlagRequired("source-dsn")
 	_ = streamCmd.MarkFlagRequired("server-id")

--- a/docs/mariadb.md
+++ b/docs/mariadb.md
@@ -72,8 +72,13 @@ Identical to a MySQL source (see [Streaming → The Source MySQL User](streaming
 
 - **Live capture** in both **position mode** and **GTID mode** (MariaDB
   `domain-server-seq` GTIDs, e.g. `0-1-100`).
-- **GTID resume** — restart and bintrail re-reads the saved MariaDB GTID set and
-  continues where it left off.
+- **GTID resume with gap detection** — restart and bintrail re-reads the saved
+  MariaDB GTID set and continues where it left off. On resume it verifies the
+  source still retains the binlogs needed: MariaDB has no `@@gtid_purged`, so the
+  purge floor is derived from `BINLOG_GTID_POS` over the oldest surviving binlog.
+  A purged-binlog gap raises the data-loss alarm (or, with `--no-gap-fill`,
+  refuses to start) in **both position and GTID mode**, and multi-domain GTID
+  sets are compared per domain.
 - **File-based `bintrail index`** over MariaDB binlog files.
 - All row events (INSERT/UPDATE/DELETE) with before/after images, including
   `UNSIGNED`, `DECIMAL`, and DDL detection / auto-snapshot.
@@ -84,14 +89,6 @@ Identical to a MySQL source (see [Streaming → The Source MySQL User](streaming
 
 ## Alpha limitations
 
-- **Prefer position mode for resume.** Both position and GTID capture work, but
-  MariaDB **GTID gap detection** — the alarm that fires when a resume would skip
-  past binlogs the source has already purged — is **not yet implemented**. A
-  GTID-mode resume past purged binlogs proceeds with a loud warning instead of
-  the data-loss alarm. **Position mode keeps full gap detection** and is the
-  recommended resume mode for MariaDB. If you want a hard stop on unverifiable
-  gaps, pass `--no-gap-fill`: in MariaDB GTID mode it **refuses to start** rather
-  than proceeding blind.
 - **The source flavor is fixed per checkpoint.** Resuming a saved MariaDB
   checkpoint requires the same `--source-flavor mariadb`. A mismatch is rejected
   with an actionable error; use `--reset` to start fresh.
@@ -99,8 +96,10 @@ Identical to a MySQL source (see [Streaming → The Source MySQL User](streaming
   compressed row events are not yet decoded — bintrail logs a loud warning
   (`rows_skipped`) rather than indexing them. Leave `log_bin_compress = OFF` on
   the source for now.
-- **Multi-domain GTID is untested.** Capture works, but resume/gap behavior
-  under multiple GTID domains has not been validated — prefer position mode.
+- **Mid-capture primary failover is untested.** Gap detection compares GTID
+  sequences per domain (correct for single-server and multi-domain topologies),
+  but a primary failover that changes the `server_id` *within* a domain mid-stream
+  has not been validated against a live multi-server MariaDB cluster.
 - **Not wired into the console / control plane.** The console "+ Add server"
   form and `bintrail-console watch` do not yet pass the MariaDB flavor — use the
   `bintrail stream` CLI for MariaDB sources in this release.
@@ -117,7 +116,7 @@ Identical to a MySQL source (see [Streaming → The Source MySQL User](streaming
 | `invalid Mysql GTID` when starting against MariaDB | You omitted `--source-flavor mariadb` — the MariaDB GTID set was parsed as a MySQL set. Add the flag. |
 | `WARN source flavor mismatch: configured … detected …` | `--source-flavor` doesn't match the server's actual flavor. Set it to match. |
 | `saved checkpoint is source flavor "mariadb" but "mysql" was requested` | You resumed a MariaDB checkpoint without `--source-flavor mariadb`. Add the flag, or `--reset` to start fresh. |
-| `--no-gap-fill is set but GTID gap detection is unavailable for a MariaDB source` | Expected guard. Resume in **position mode**, or drop `--no-gap-fill`. |
+| `MariaDB GTID gap detected but CANNOT be filled` | The source purged binlogs your checkpoint still needed. bintrail auto-advances past the lost range and records the data loss durably; pass `--no-gap-fill` to refuse to start instead. Raise `binlog_expire_logs_seconds` to give bintrail more time to resume. |
 | `auto-discover binlog position` errors on an old MariaDB | Ensure `log_bin = ON` and the source user has `REPLICATION CLIENT`. |
 
 ---

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -40,9 +40,10 @@ If you scope `SELECT`, it must cover **every column of every monitored table**, 
 ## MariaDB as a source (alpha)
 
 bintrail can stream from a **MariaDB** source (the index stays MySQL) — pass
-`--source-flavor mariadb`. Everything on this page applies; the MariaDB-specific
-setup, version support, alpha limitations (notably: prefer position mode for
-resume), and troubleshooting live on the dedicated page: **[MariaDB](mariadb.md)**.
+`--source-flavor mariadb`. Everything on this page applies — including gap
+detection on resume, which now works for MariaDB in both position and GTID mode.
+The MariaDB-specific setup, version support, alpha limitations, and
+troubleshooting live on the dedicated page: **[MariaDB](mariadb.md)**.
 
 ---
 

--- a/internal/streamrun/mariadb_gtid_gap_test.go
+++ b/internal/streamrun/mariadb_gtid_gap_test.go
@@ -1,0 +1,451 @@
+package streamrun
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	gomysql "github.com/go-mysql-org/go-mysql/mysql"
+)
+
+// The detectMariaDBGTIDGap unit tests sqlmock the three MariaDB gap-detection
+// queries — SHOW BINARY LOGS, BINLOG_GTID_POS(<earliest>, 4) (the purge floor;
+// MariaDB has no @@gtid_purged), and @@gtid_binlog_pos (the executed set) — and
+// assert the decision for every branch: caught-up, fillable, unfillable, an empty
+// floor (nothing purged), multi-domain, and the post-failover cross-server case
+// that proves the domain-aware coverage check (not go-mysql's server-keyed
+// MariadbGTIDSet.Contain) is in use.
+
+// expectMariaDBGapQueries primes the ordered three-query sequence used by
+// detectMariaDBGTIDGap.
+func expectMariaDBGapQueries(mock sqlmock.Sqlmock, earliestFile, floor, executed string) {
+	mock.ExpectQuery("SHOW BINARY LOGS").WillReturnRows(
+		sqlmock.NewRows([]string{"Log_name", "File_size"}).
+			AddRow(earliestFile, 1024).
+			AddRow("mariadb-bin.999999", 2048))
+	mock.ExpectQuery("SELECT BINLOG_GTID_POS").WithArgs(earliestFile).WillReturnRows(
+		sqlmock.NewRows([]string{"BINLOG_GTID_POS"}).AddRow(floor))
+	mock.ExpectQuery("SELECT @@gtid_binlog_pos").WillReturnRows(
+		sqlmock.NewRows([]string{"@@gtid_binlog_pos"}).AddRow(executed))
+}
+
+func TestDetectMariaDBGTIDGap_noGapNothingPurged(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	// Empty floor = the first binlog still exists, nothing purged; checkpoint
+	// equals the executed set, so the stream is caught up.
+	expectMariaDBGapQueries(mock, "mariadb-bin.000001", "", "0-2-75")
+
+	gap, err := detectMariaDBGTIDGap(db, "0-2-75", 10*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gap.HasGap {
+		t.Errorf("expected no gap when checkpoint equals executed and nothing is purged, got %+v", gap)
+	}
+}
+
+// TestDetectMariaDBGTIDGap_nullFloorNothingPurged pins the SQL-NULL purge floor.
+// On a source whose first-ever binlog still exists, BINLOG_GTID_POS returns NULL
+// (not an empty string); the detector must read that through a NullString and
+// treat it as "nothing purged", not error. A regression to a plain-string Scan
+// fails here — and that path is the common no-purge happy case.
+func TestDetectMariaDBGTIDGap_nullFloorNothingPurged(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SHOW BINARY LOGS").WillReturnRows(
+		sqlmock.NewRows([]string{"Log_name", "File_size"}).AddRow("mariadb-bin.000001", 1024))
+	mock.ExpectQuery("SELECT BINLOG_GTID_POS").WithArgs("mariadb-bin.000001").WillReturnRows(
+		sqlmock.NewRows([]string{"BINLOG_GTID_POS"}).AddRow(nil)) // SQL NULL
+	mock.ExpectQuery("SELECT @@gtid_binlog_pos").WillReturnRows(
+		sqlmock.NewRows([]string{"@@gtid_binlog_pos"}).AddRow("0-2-75"))
+
+	gap, err := detectMariaDBGTIDGap(db, "0-2-75", 10*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error on NULL purge floor (nothing purged): %v", err)
+	}
+	if gap.HasGap {
+		t.Errorf("expected no gap when the purge floor is NULL and checkpoint equals executed, got %+v", gap)
+	}
+}
+
+func TestDetectMariaDBGTIDGap_fillableNothingPurged(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	// Nothing purged but the checkpoint is behind — fillable, just replay.
+	expectMariaDBGapQueries(mock, "mariadb-bin.000001", "", "0-2-200")
+
+	gap, err := detectMariaDBGTIDGap(db, "0-2-75", 10*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !gap.HasGap {
+		t.Fatal("expected a gap when checkpoint is behind executed")
+	}
+	if !gap.Fillable {
+		t.Errorf("expected fillable gap when nothing is purged, got %+v", gap)
+	}
+}
+
+func TestDetectMariaDBGTIDGap_unfillable(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	// Purge floor 0-2-71 is beyond the checkpoint 0-2-50 — GTIDs 51..71 are gone.
+	expectMariaDBGapQueries(mock, "mariadb-bin.000005", "0-2-71", "0-2-200")
+
+	gap, err := detectMariaDBGTIDGap(db, "0-2-50", 10*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !gap.HasGap {
+		t.Fatal("expected a gap when the purge floor is beyond the checkpoint")
+	}
+	if gap.Fillable {
+		t.Error("expected an UNFILLABLE gap when purged GTIDs precede the checkpoint")
+	}
+	if gap.PurgedGTIDSet != "0-2-71" {
+		t.Errorf("expected PurgedGTIDSet=floor %q, got %q", "0-2-71", gap.PurgedGTIDSet)
+	}
+}
+
+// TestDetectMariaDBGTIDGap_boundaryAtFloor pins the strict `cpMax < floorMax`
+// coverage boundary one unit on each side. Every other unfillable case sits far
+// from the boundary, so an off-by-one regression (e.g. `cpMax+1 < floorMax`)
+// would pass them all yet flip cp=floorMax-1 from unfillable to fillable — a real
+// unfillable gap reported as fillable, the silent-data-loss direction.
+func TestDetectMariaDBGTIDGap_boundaryAtFloor(t *testing.T) {
+	// cp = floorMax - 1 (70 vs 71): the checkpoint still needs the purged GTID 71
+	// → UNFILLABLE.
+	t.Run("justBelowFloor_unfillable", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("sqlmock: %v", err)
+		}
+		defer db.Close()
+		expectMariaDBGapQueries(mock, "mariadb-bin.000005", "0-2-71", "0-2-200")
+		gap, err := detectMariaDBGTIDGap(db, "0-2-70", 10*time.Second)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !gap.HasGap || gap.Fillable {
+			t.Errorf("cp=70 / floor=71: still needs purged GTID 71 → want UNFILLABLE, got %+v", gap)
+		}
+	})
+
+	// cp = floorMax exactly (71 vs 71): the checkpoint has seen everything up to the
+	// floor; the next GTID it needs is 72, which survives → FILLABLE (behind the
+	// executed set 200). The safe complement of the boundary.
+	t.Run("atFloor_fillable", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("sqlmock: %v", err)
+		}
+		defer db.Close()
+		expectMariaDBGapQueries(mock, "mariadb-bin.000005", "0-2-71", "0-2-200")
+		gap, err := detectMariaDBGTIDGap(db, "0-2-71", 10*time.Second)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !gap.HasGap {
+			t.Fatal("cp=71 / floor=71: behind executed 200 → expected a gap")
+		}
+		if !gap.Fillable {
+			t.Errorf("cp=71 / floor=71: checkpoint covers the floor exactly → want FILLABLE, got %+v", gap)
+		}
+	})
+}
+
+func TestDetectMariaDBGTIDGap_fillableCheckpointPastFloor(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	// Floor 0-2-50 is purged but the checkpoint 0-2-100 is already past it, and
+	// still behind executed 0-2-200 — fillable.
+	expectMariaDBGapQueries(mock, "mariadb-bin.000003", "0-2-50", "0-2-200")
+
+	gap, err := detectMariaDBGTIDGap(db, "0-2-100", 10*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !gap.HasGap {
+		t.Fatal("expected a gap when checkpoint is behind executed")
+	}
+	if !gap.Fillable {
+		t.Errorf("expected fillable gap when checkpoint is past the purge floor, got %+v", gap)
+	}
+}
+
+func TestDetectMariaDBGTIDGap_caughtUpWithPurged(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	// Floor purged, but the checkpoint is past it AND equal to executed — no gap.
+	expectMariaDBGapQueries(mock, "mariadb-bin.000003", "0-2-50", "0-2-200")
+
+	gap, err := detectMariaDBGTIDGap(db, "0-2-200", 10*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gap.HasGap {
+		t.Errorf("expected no gap when checkpoint is past the floor and equals executed, got %+v", gap)
+	}
+}
+
+func TestDetectMariaDBGTIDGap_multiDomainUnfillable(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	// Two domains. Domain 0 is covered (200 >= 50) but domain 1's checkpoint (20)
+	// is behind its purge floor (30) — multi-domain gap detection must catch it.
+	expectMariaDBGapQueries(mock, "mariadb-bin.000004", "0-1-50,1-2-30", "0-1-200,1-2-100")
+
+	gap, err := detectMariaDBGTIDGap(db, "0-1-200,1-2-20", 10*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !gap.HasGap || gap.Fillable {
+		t.Errorf("expected an unfillable gap when one domain is behind its floor, got %+v", gap)
+	}
+}
+
+func TestDetectMariaDBGTIDGap_multiDomainFillable(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	// Both domains past their floors but behind executed — fillable.
+	expectMariaDBGapQueries(mock, "mariadb-bin.000004", "0-1-50,1-2-30", "0-1-200,1-2-100")
+
+	gap, err := detectMariaDBGTIDGap(db, "0-1-150,1-2-80", 10*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !gap.HasGap {
+		t.Fatal("expected a gap when checkpoint is behind executed")
+	}
+	if !gap.Fillable {
+		t.Errorf("expected fillable gap when both domains cover their floors, got %+v", gap)
+	}
+}
+
+// TestDetectMariaDBGTIDGap_crossServerFailover is the discriminator for the
+// domain-aware coverage check. The purge floor was written by server 1
+// (0-1-71) but after a failover the checkpoint is server 2 at a higher sequence
+// (0-2-100). Because MariaDB sequence numbers are domain-global, 100 >= 71 means
+// the checkpoint HAS seen past the floor — so this must be a fillable gap, not an
+// unfillable one. go-mysql's server-keyed MariadbGTIDSet.Contain would wrongly
+// flag it unfillable (server 1 absent from the checkpoint); this test fails if we
+// regress to that.
+func TestDetectMariaDBGTIDGap_crossServerFailover(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	expectMariaDBGapQueries(mock, "mariadb-bin.000005", "0-1-71", "0-2-200")
+
+	gap, err := detectMariaDBGTIDGap(db, "0-2-100", 10*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !gap.HasGap {
+		t.Fatal("expected a gap when checkpoint is behind executed")
+	}
+	if !gap.Fillable {
+		t.Errorf("expected a FILLABLE gap: checkpoint seq 100 >= floor seq 71 in domain 0 "+
+			"despite a different server_id (domain-aware coverage), got %+v", gap)
+	}
+}
+
+// TestMariaDBCheckpointCoversFloor_multiServerPerDomain pins the one path the
+// detect-level tests cannot reach: mariadbDomainMaxSeq's max() aggregating MORE
+// THAN ONE server within a SINGLE domain. The cross-server detect test keeps its
+// two servers in separate sets (one per domain each), so the multi-server max()
+// never runs there — and the floor-side aggregation is the silent-data-loss
+// direction: under-computing the floor frontier reports a real unfillable gap as
+// fillable, and would stay green on every detect-level test. So assert it
+// directly and order-independently.
+func TestMariaDBCheckpointCoversFloor_multiServerPerDomain(t *testing.T) {
+	mustParse := func(s string) *gomysql.MariadbGTIDSet {
+		set, err := parseMariadbSet(s)
+		if err != nil {
+			t.Fatalf("parseMariadbSet(%q): %v", s, err)
+		}
+		return set
+	}
+
+	// Checkpoint-side max(): a realistic post-failover accumulated checkpoint with
+	// two servers in domain 0. The domain frontier is max(50,100)=100, which
+	// covers floor 71 → fillable. A first-wins/min regression makes this fail
+	// regardless of map iteration order (100 must win).
+	if !mariadbCheckpointCoversFloor(mustParse("0-1-50,0-2-100"), mustParse("0-1-71")) {
+		t.Error("multi-server checkpoint: domain-0 max(50,100)=100 >= floor 71 → want covered (fillable)")
+	}
+
+	// Floor-side max() — the silent-data-loss direction. The domain-0 purge floor
+	// is max(71,30)=71; a checkpoint at seq 50 has NOT seen purged 51..71 →
+	// unfillable.
+	if mariadbCheckpointCoversFloor(mustParse("0-2-50"), mustParse("0-1-71,0-2-30")) {
+		t.Error("multi-server floor: cp seq 50 does not cover domain-0 frontier max(71,30)=71 → want NOT covered (unfillable)")
+	}
+
+	// Pin the floor-side aggregation directly. On a multi-server domain ANY
+	// "pick one server" regression (first-wins, drop-higher) equals the true max
+	// whenever map iteration happens to start on the max element, so a single
+	// assertion is ~50/50 against it — Go re-randomizes map order per range. Turn
+	// that randomization AGAINST the bug: assert the frontier over many iterations
+	// so a first-wins regression (P(miss) = (1/2)^N) is caught with overwhelming
+	// probability, while min/drop-higher are caught on the first iteration.
+	floor := mustParse("0-1-71,0-2-30")
+	for i := range 64 {
+		if got := mariadbDomainMaxSeq(floor.Sets[0]); got != 71 {
+			t.Fatalf("mariadbDomainMaxSeq(domain 0 of {0-1-71,0-2-30}) = %d, want 71 (the per-domain "+
+				"frontier) on iteration %d — the aggregation must be order-independent", got, i)
+		}
+	}
+
+	// Also assert the defining invariant order-independently: the frontier is >=
+	// every server's sequence in the domain (catches any under-computing
+	// aggregation, the silent-data-loss direction).
+	for srv, g := range floor.Sets[0] {
+		if mariadbDomainMaxSeq(floor.Sets[0]) < g.SequenceNumber {
+			t.Errorf("mariadbDomainMaxSeq < server %d seq %d — frontier must cover every server", srv, g.SequenceNumber)
+		}
+	}
+}
+
+// TestDetectMariaDBGTIDGap_domainNeverSeen covers a purge floor in a domain the
+// checkpoint never indexed at all — unreachable, so unfillable.
+func TestDetectMariaDBGTIDGap_domainNeverSeen(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	expectMariaDBGapQueries(mock, "mariadb-bin.000005", "1-2-10", "0-2-200,1-2-50")
+
+	gap, err := detectMariaDBGTIDGap(db, "0-2-200", 10*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !gap.HasGap || gap.Fillable {
+		t.Errorf("expected an unfillable gap for a purged domain the checkpoint never saw, got %+v", gap)
+	}
+}
+
+// TestDetectMariaDBGTIDGap_emptyCheckpointGuard mirrors detectGTIDGap's guard:
+// with a non-empty purge floor we cannot reason about an empty checkpoint.
+func TestDetectMariaDBGTIDGap_emptyCheckpointGuard(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	expectMariaDBGapQueries(mock, "mariadb-bin.000005", "0-2-71", "0-2-200")
+
+	_, err = detectMariaDBGTIDGap(db, "", 10*time.Second)
+	if err == nil {
+		t.Fatal("expected an error for an empty checkpoint against a non-empty purge floor")
+	}
+}
+
+// TestNormalizeGTIDForFlavor pins the byte-identical-for-MySQL guarantee of the
+// flavor-aware auto-advance refactor. The unfillable-gap auto-advance was rewired
+// from a hardcoded NormalizeGTIDSet call to normalizeGTIDForFlavor; for a MySQL
+// source the two must be indistinguishable, and a MariaDB domain-server-seq set
+// (no UUID to pad) must pass through untouched.
+func TestNormalizeGTIDForFlavor(t *testing.T) {
+	const mysqlSet = "3E11FA47-71CA-11E1-9E33-C80AA9429562:1-5"
+	if got, want := normalizeGTIDForFlavor(gomysql.MySQLFlavor, mysqlSet), NormalizeGTIDSet(mysqlSet); got != want {
+		t.Errorf("normalizeGTIDForFlavor(mysql, %q) = %q, want NormalizeGTIDSet = %q (byte-identical for MySQL)", mysqlSet, got, want)
+	}
+	if got := normalizeGTIDForFlavor(gomysql.MariaDBFlavor, "0-2-71"); got != "0-2-71" {
+		t.Errorf("normalizeGTIDForFlavor(mariadb, %q) = %q, want unchanged (no UUID to pad)", "0-2-71", got)
+	}
+}
+
+// advancedTestState is a minimal streamState for persistGapAutoAdvance tests.
+func advancedTestState() *streamState {
+	return &streamState{mode: "gtid", binlogFile: "mariadb-bin.000005", gtidSet: "0-2-71", flavor: gomysql.MariaDBFlavor, serverID: 99}
+}
+
+// TestPersistGapAutoAdvance_stampsBeforeAdvance pins the data-loss-safety ordering
+// invariant: the gap_lost_at stamp (UPDATE) must be written BEFORE the advanced
+// checkpoint (the INSERT...ON DUPLICATE KEY upsert). sqlmock matches expectations
+// in order by default, so declaring UPDATE-then-INSERT fails if the code advances
+// the checkpoint first.
+func TestPersistGapAutoAdvance_stampsBeforeAdvance(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec("UPDATE stream_state").
+		WithArgs("events lost").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT INTO stream_state").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := persistGapAutoAdvance(db, advancedTestState(), "events lost"); err != nil {
+		t.Fatalf("persistGapAutoAdvance: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("stamp must precede checkpoint advance: %v", err)
+	}
+}
+
+// TestPersistGapAutoAdvance_abortsOnStampFailure is the core of the #402 fix: if
+// the gap_lost_at stamp fails, the function must return an error and must NOT
+// advance the checkpoint — otherwise the next restart would see no gap with no
+// durable trace of the loss. The INSERT is deliberately NOT expected; sqlmock
+// errors if the code issues it after the failed UPDATE.
+func TestPersistGapAutoAdvance_abortsOnStampFailure(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec("UPDATE stream_state").
+		WillReturnError(errors.New("index DB transient error"))
+	// No ExpectExec for the INSERT — the checkpoint must not be advanced.
+
+	if err := persistGapAutoAdvance(db, advancedTestState(), "events lost"); err == nil {
+		t.Fatal("expected an error when the gap-loss stamp fails (checkpoint must not advance)")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("checkpoint advance must be skipped when the stamp fails: %v", err)
+	}
+}

--- a/internal/streamrun/mariadb_integration_test.go
+++ b/internal/streamrun/mariadb_integration_test.go
@@ -34,7 +34,7 @@ import (
 //   - the BinlogSyncer Flavor="mariadb" handshake + the MariadbGTIDEvent parser
 //     case must populate domain-server-seq GTIDs on indexed rows.
 //
-// It runs in POSITION mode (the recommended MariaDB resume mode for the alpha)
+// It runs in POSITION mode (the mode this end-to-end guard exercises)
 // and asserts via the indexed-event counter, not raw event counts — MariaDB
 // interleaves ANNOTATE_ROWS / GTID_LIST / BINLOG_CHECKPOINT events the indexer
 // never counts.
@@ -256,5 +256,94 @@ func TestStreamLoop_gtidAdvancesOnCommit_mariadb(t *testing.T) {
 	// The persisted set must re-parse with the MariaDB parser (resume contract).
 	if _, err := parseGTIDSetForFlavor(gomysql.MariaDBFlavor, state.gtidSet); err != nil {
 		t.Errorf("accumulated MariaDB set %q does not re-parse: %v", state.gtidSet, err)
+	}
+}
+
+// TestDetectMariaDBGTIDGap_livePurge is the discriminator for real MariaDB GTID
+// gap detection. The sqlmock unit tests pin the decision tree; this proves the
+// three live queries (SHOW BINARY LOGS, BINLOG_GTID_POS, @@gtid_binlog_pos)
+// behave as the gate-#1 design verified against MariaDB 11.4 — including the part
+// no unit test can: that BINLOG_GTID_POS over the oldest surviving binlog yields
+// a real purge floor after PURGE BINARY LOGS.
+//
+// It manufactures a genuine unfillable gap, then closes the auto-advance loop:
+// advancing the checkpoint to the floor must (a) re-parse with the MariaDB parser
+// and (b) clear the unfillable gap on the next detection — i.e. the advanced
+// position re-syncs cleanly, which is the one thing the design flagged as needing
+// a live check.
+func TestDetectMariaDBGTIDGap_livePurge(t *testing.T) {
+	sourceDB, _ := testutil.CreateTestMariaDB(t)
+
+	// PURGE BINARY LOGS mutates server-wide binlog state, so this test must be
+	// the only writer — the dedicated CI job serializes MariaDB tests with -p 1.
+	testutil.MustExec(t, sourceDB, `CREATE TABLE gap_probe (
+		id INT PRIMARY KEY AUTO_INCREMENT, v INT NOT NULL)`)
+
+	for i := range 3 {
+		testutil.MustExec(t, sourceDB, "INSERT INTO gap_probe (v) VALUES (?)", i)
+	}
+
+	// Checkpoint T1: the GTID position after the first few transactions.
+	var checkpoint string
+	if err := sourceDB.QueryRow("SELECT @@gtid_binlog_pos").Scan(&checkpoint); err != nil {
+		t.Fatalf("read checkpoint @@gtid_binlog_pos: %v", err)
+	}
+	if checkpoint == "" {
+		testutil.SkipOrFailMariaDB(t, "MariaDB reported an empty GTID position; GTID binlogging not active")
+	}
+
+	// Roll several binlog files (with a transaction in each) so PURGE has earlier
+	// files to drop and the floor lands strictly past T1.
+	for i := range 5 {
+		testutil.MustExec(t, sourceDB, "FLUSH BINARY LOGS")
+		testutil.MustExec(t, sourceDB, "INSERT INTO gap_probe (v) VALUES (?)", 100+i)
+	}
+
+	// Before purging: the checkpoint is behind but every binlog is still present,
+	// so detection must NOT report an unfillable gap.
+	pre, err := detectMariaDBGTIDGap(sourceDB, checkpoint, 30*time.Second)
+	if err != nil {
+		t.Fatalf("pre-purge detect: %v", err)
+	}
+	if pre.HasGap && !pre.Fillable {
+		t.Fatalf("pre-purge: expected fillable/no-gap before any purge, got %+v", pre)
+	}
+
+	// Purge up to the current active binlog so T1's binlogs are gone.
+	latestFile, _, err := config.CurrentBinlogPosition(sourceDB)
+	if err != nil {
+		t.Fatalf("CurrentBinlogPosition: %v", err)
+	}
+	testutil.MustExec(t, sourceDB, "PURGE BINARY LOGS TO '"+latestFile+"'")
+
+	// Now the gap MUST be unfillable, and PurgedGTIDSet must carry the floor.
+	gap, err := detectMariaDBGTIDGap(sourceDB, checkpoint, 30*time.Second)
+	if err != nil {
+		t.Fatalf("post-purge detect: %v", err)
+	}
+	if !gap.HasGap || gap.Fillable {
+		t.Fatalf("post-purge: expected an UNFILLABLE gap for a checkpoint below the purge floor, got %+v", gap)
+	}
+	if gap.PurgedGTIDSet == "" {
+		t.Fatal("post-purge: expected the purge floor in PurgedGTIDSet")
+	}
+	if strings.Contains(gap.PurgedGTIDSet, ":") {
+		t.Errorf("purge floor %q is not MariaDB domain-server-seq form", gap.PurgedGTIDSet)
+	}
+
+	// Auto-advance contract (a): the floor re-parses with the MariaDB parser —
+	// exactly what runStream feeds parseGTIDSetForFlavor + StartSyncGTID.
+	if _, err := parseGTIDSetForFlavor(gomysql.MariaDBFlavor, gap.PurgedGTIDSet); err != nil {
+		t.Fatalf("advanced checkpoint (floor) %q does not re-parse with the MariaDB parser: %v", gap.PurgedGTIDSet, err)
+	}
+
+	// Auto-advance contract (b): resuming from the floor clears the unfillable
+	// gap — the advanced position re-syncs cleanly instead of re-tripping.
+	after, err := detectMariaDBGTIDGap(sourceDB, gap.PurgedGTIDSet, 30*time.Second)
+	if err != nil {
+		t.Fatalf("post-advance detect: %v", err)
+	}
+	if after.HasGap && !after.Fillable {
+		t.Fatalf("post-advance: advancing to the floor must clear the unfillable gap, got %+v", after)
 	}
 }

--- a/internal/streamrun/streamrun.go
+++ b/internal/streamrun/streamrun.go
@@ -115,6 +115,29 @@ func saveCheckpoint(db *sql.DB, state *streamState) error {
 	return err
 }
 
+// persistGapAutoAdvance durably records an unfillable-gap auto-advance. It stamps
+// gap_lost_at FIRST, then writes the advanced checkpoint — never the reverse.
+// Ordering is a data-loss-safety invariant: once the checkpoint is advanced past
+// the purge floor the next restart sees no gap, so a loss record written
+// afterwards (and failing) would let the advanced checkpoint silently outlive the
+// only durable trace of the permanently lost events — the console would show a
+// healthy RUNNING badge over a stream that skipped data (#402). Both writes fail
+// loud; a failed stamp aborts startup with the OLD checkpoint intact, so the gap
+// is re-detected and re-recorded on the next start. saveCheckpoint's upsert does
+// not touch the gap_lost_* columns, so the stamp survives it. Cleared by an
+// explicit monitor Stop or --reset.
+func persistGapAutoAdvance(db *sql.DB, advanced *streamState, gapMessage string) error {
+	if _, err := db.Exec(`UPDATE stream_state
+		SET gap_lost_at = UTC_TIMESTAMP(), gap_lost_detail = ?
+		WHERE id = 1`, gapMessage); err != nil {
+		return fmt.Errorf("failed to persist gap-loss record before auto-advance: %w", err)
+	}
+	if err := saveCheckpoint(db, advanced); err != nil {
+		return fmt.Errorf("failed to save advanced checkpoint: %w", err)
+	}
+	return nil
+}
+
 // ─── TLS configuration ───────────────────────────────────────────────────────────────
 
 // buildTLSConfig returns a *tls.Config for the given ssl-mode, or nil for
@@ -671,6 +694,230 @@ func detectGTIDGap(sourceDB *sql.DB, checkpointGTID string, timeout time.Duratio
 	}, nil
 }
 
+// detectMariaDBGTIDGap is the MariaDB analog of detectGTIDGap. MariaDB has no
+// @@gtid_purged, so the purge floor is derived from BINLOG_GTID_POS(<earliest
+// surviving binlog>, 4) — the GTID state recorded at the start of the oldest
+// binlog the source still has. Every GTID strictly before that floor is gone.
+// The floor is empty when nothing has been purged (the very first binlog, whose
+// starting state is "nothing executed", still exists).
+//
+// The three one-shot queries — SHOW BINARY LOGS, BINLOG_GTID_POS, and
+// @@gtid_binlog_pos (the executed set, MariaDB's @@gtid_executed analog) — are
+// bounded by timeout.
+func detectMariaDBGTIDGap(sourceDB *sql.DB, checkpointGTID string, timeout time.Duration) (*gapResult, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	checkpointGTID = strings.TrimSpace(checkpointGTID)
+
+	// 1. The oldest surviving binlog (first row of SHOW BINARY LOGS).
+	earliestFile, err := earliestBinlogFile(ctx, sourceDB)
+	if err != nil {
+		return nil, err
+	}
+
+	// 2. The purge floor: the GTID state at the start of that file. BINLOG_GTID_POS
+	//    returns SQL NULL (not an empty string) when the oldest binlog is the
+	//    first-ever one — i.e. nothing has been purged — so scan through a
+	//    NullString and treat NULL as "no floor". A plain string Scan would error
+	//    on NULL, which is the common no-purge case.
+	var floorNS sql.NullString
+	if err := sourceDB.QueryRowContext(ctx, "SELECT BINLOG_GTID_POS(?, 4)", earliestFile).Scan(&floorNS); err != nil {
+		return nil, fmt.Errorf("query BINLOG_GTID_POS(%q, 4): %w", earliestFile, err)
+	}
+	floorStr := strings.TrimSpace(floorNS.String)
+
+	// 3. The executed set.
+	var executedStr string
+	if err := sourceDB.QueryRowContext(ctx, "SELECT @@gtid_binlog_pos").Scan(&executedStr); err != nil {
+		return nil, fmt.Errorf("query @@gtid_binlog_pos: %w", err)
+	}
+	executedStr = strings.TrimSpace(executedStr)
+
+	// Nothing purged: every GTID is still available, so the only question is
+	// whether the checkpoint is caught up or merely behind.
+	if floorStr == "" {
+		if mariadbGTIDSetsEqual(checkpointGTID, executedStr) {
+			return &gapResult{HasGap: false}, nil
+		}
+		return &gapResult{
+			HasGap:   true,
+			Fillable: true,
+			Message:  "gap detected: checkpoint MariaDB GTID set is behind source @@gtid_binlog_pos; replaying missed events",
+		}, nil
+	}
+
+	if checkpointGTID == "" {
+		return nil, fmt.Errorf("checkpoint GTID set is empty; cannot perform gap detection")
+	}
+
+	checkpoint, err := parseMariadbSet(checkpointGTID)
+	if err != nil {
+		return nil, fmt.Errorf("parse checkpoint GTID set: %w", err)
+	}
+	floor, err := parseMariadbSet(floorStr)
+	if err != nil {
+		return nil, fmt.Errorf("parse purge floor (BINLOG_GTID_POS): %w", err)
+	}
+
+	// The gap is unfillable iff the checkpoint has NOT seen everything up to the
+	// purge floor: some purged GTID the checkpoint never indexed is permanently
+	// gone. PurgedGTIDSet carries the floor so the caller can auto-advance to it.
+	if !mariadbCheckpointCoversFloor(checkpoint, floor) {
+		return &gapResult{
+			HasGap:        true,
+			Fillable:      false,
+			PurgedGTIDSet: floorStr,
+			Message: fmt.Sprintf(
+				"MariaDB GTID gap detected but CANNOT be filled: required GTIDs have been purged from the source "+
+					"(purge floor %s is beyond checkpoint %s); events in the purged range are permanently lost",
+				floorStr, checkpointGTID),
+		}, nil
+	}
+
+	// Checkpoint covers the floor — any gap is fillable.
+	if mariadbGTIDSetsEqual(checkpointGTID, executedStr) {
+		return &gapResult{HasGap: false}, nil
+	}
+	return &gapResult{
+		HasGap:   true,
+		Fillable: true,
+		Message:  "gap detected: checkpoint MariaDB GTID set is behind source @@gtid_binlog_pos; replaying missed events",
+	}, nil
+}
+
+// earliestBinlogFile returns the name of the oldest binlog the source still
+// retains — the first row of SHOW BINARY LOGS (both MySQL and MariaDB order it
+// oldest-first). The column-tolerant scan mirrors detectPositionGap: only the
+// first column (Log_name) is needed, and extra columns vary across versions.
+func earliestBinlogFile(ctx context.Context, sourceDB *sql.DB) (string, error) {
+	rows, err := sourceDB.QueryContext(ctx, "SHOW BINARY LOGS")
+	if err != nil {
+		return "", fmt.Errorf("SHOW BINARY LOGS: %w", err)
+	}
+	defer rows.Close()
+
+	cols, colErr := rows.Columns()
+	if colErr != nil {
+		return "", fmt.Errorf("SHOW BINARY LOGS columns: %w", colErr)
+	}
+	if len(cols) < 1 {
+		return "", fmt.Errorf("SHOW BINARY LOGS returned no columns")
+	}
+
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return "", fmt.Errorf("iterate SHOW BINARY LOGS: %w", err)
+		}
+		return "", fmt.Errorf("SHOW BINARY LOGS returned no results")
+	}
+
+	var name string
+	vals := make([]any, len(cols))
+	vals[0] = &name
+	for i := 1; i < len(cols); i++ {
+		vals[i] = new(sql.RawBytes)
+	}
+	if err := rows.Scan(vals...); err != nil {
+		return "", fmt.Errorf("scan SHOW BINARY LOGS: %w", err)
+	}
+	return name, nil
+}
+
+// parseMariadbSet parses a MariaDB GTID set string into the concrete
+// *MariadbGTIDSet — the gap logic needs the per-domain map, not the interface.
+func parseMariadbSet(s string) (*gomysql.MariadbGTIDSet, error) {
+	set, err := gomysql.ParseMariadbGTIDSet(s)
+	if err != nil {
+		return nil, err
+	}
+	ms, ok := set.(*gomysql.MariadbGTIDSet)
+	if !ok {
+		return nil, fmt.Errorf("unexpected GTID set type %T from MariaDB parse", set)
+	}
+	return ms, nil
+}
+
+// mariadbGTIDSetsEqual parses two MariaDB GTID set strings and compares them
+// structurally, so ordering differences never cause a false mismatch. It returns
+// false (not an error) on a parse failure — the caller treats that as "not equal"
+// and proceeds with gap detection. The MariaDB sibling of gtidSetsEqual.
+//
+// Like the MySQL gtidSetsEqual, this uses go-mysql's set Equal, which keys by
+// (domain, server). Its only failure mode here is reporting "behind, replaying"
+// when the stream is actually caught up — harmless: the syncer resumes from the
+// checkpoint, finds nothing past it, and tails live. The unfillable decision (the
+// path that records permanent data loss) uses mariadbCheckpointCoversFloor, which
+// is server-agnostic.
+func mariadbGTIDSetsEqual(a, b string) bool {
+	if a == "" && b == "" {
+		return true
+	}
+	ga, err := gomysql.ParseMariadbGTIDSet(a)
+	if err != nil {
+		slog.Debug("mariadbGTIDSetsEqual: failed to parse first GTID set", "gtid_set", a, "error", err)
+		return false
+	}
+	gb, err := gomysql.ParseMariadbGTIDSet(b)
+	if err != nil {
+		slog.Debug("mariadbGTIDSetsEqual: failed to parse second GTID set", "gtid_set", b, "error", err)
+		return false
+	}
+	return ga.Equal(gb)
+}
+
+// mariadbCheckpointCoversFloor reports whether the checkpoint has already seen
+// every GTID at or below the purge floor — i.e. resuming from the checkpoint will
+// not require any GTID the source has purged.
+//
+// It compares the MAX sequence number PER DOMAIN and deliberately ignores the
+// server_id, because a MariaDB GTID sequence is domain-GLOBAL: within one
+// replication domain the sequence increments monotonically regardless of which
+// server writes the event. So the next GTID a checkpoint at domainMax needs is
+// domainMax+1, which is still available iff checkpointMax >= floorMax. This is the
+// "per-domain seq >= other.seq" semantics gate #1 was designed around.
+//
+// We deliberately do NOT use go-mysql's MariadbGTIDSet.Contain: its set-level map
+// lookup is keyed by (domain, server), so after a primary failover — where the
+// floor and the checkpoint carry different server_ids inside the same domain — it
+// reports a spurious unfillable gap even though the checkpoint is demonstrably
+// ahead. That error is in the safe direction (a false data-loss alarm, never a
+// silent loss), but the per-domain max comparison avoids it. (go-mysql's per-GTID
+// MariadbGTID.Contain already ignores server_id; only its set wrapper re-keys by
+// server.)
+//
+// Confidence boundary: the max-per-domain logic is exact for the single-server
+// and multi-DOMAIN topologies that are gate #1's scope. Multi-SERVER-within-a-
+// domain only arises after a primary failover mid-capture; the per-domain max
+// handles it and it is unit-tested (TestMariaDBCheckpointCoversFloor_multiServerPerDomain),
+// but it is not validated against a live multi-server failover cluster — the
+// "topology untested" alpha caveat in docs/mariadb.md.
+func mariadbCheckpointCoversFloor(checkpoint, floor *gomysql.MariadbGTIDSet) bool {
+	for domain, floorServers := range floor.Sets {
+		cpServers, ok := checkpoint.Sets[domain]
+		if !ok {
+			// The source purged GTIDs in a domain the checkpoint never indexed —
+			// those events are unreachable.
+			return false
+		}
+		if mariadbDomainMaxSeq(cpServers) < mariadbDomainMaxSeq(floorServers) {
+			return false
+		}
+	}
+	return true
+}
+
+// mariadbDomainMaxSeq returns the highest sequence number across every server
+// recorded for one domain. A MariaDB sequence is domain-global, so this max is the
+// domain's frontier regardless of which server produced the latest event.
+func mariadbDomainMaxSeq(serverSet map[uint32]*gomysql.MariadbGTID) uint64 {
+	var hi uint64
+	for _, gtid := range serverSet {
+		hi = max(hi, gtid.SequenceNumber)
+	}
+	return hi
+}
+
 // ─── Stream loop ────────────────────────────────────────────────────────────────
 
 // streamLoop consumes parser events, flushes batches to MySQL, and writes
@@ -1084,21 +1331,12 @@ func One(ctx context.Context, cfg Config) error {
 		case "position":
 			gap, gapErr = detectPositionGap(sourceDB, startFile, startPos, gapTimeout)
 		case "gtid":
+			// MySQL and MariaDB expose the purge boundary differently
+			// (@@gtid_purged vs BINLOG_GTID_POS over the oldest surviving binlog),
+			// so each flavor has its own detector; both return the same gapResult
+			// and feed the shared auto-advance / gap_lost_at machinery below.
 			if cfg.Flavor == gomysql.MariaDBFlavor {
-				// MariaDB GTID gap detection is not implemented for the alpha:
-				// detectGTIDGap relies on MySQL-only @@gtid_purged/@@gtid_executed
-				// and the MySQL GTID-set map shape, neither of which is portable, so
-				// we cannot verify whether binlogs were purged. If the operator
-				// demanded a hard stop on unverifiable gaps (--no-gap-fill), honor it
-				// — refuse rather than proceed blind. Otherwise warn loudly and
-				// proceed; position mode retains full gap detection and is the
-				// recommended MariaDB resume mode. gap/gapErr stay nil → stream runs.
-				if cfg.NoGapFill {
-					return fmt.Errorf("--no-gap-fill is set but GTID gap detection is unavailable for a MariaDB source; " +
-						"resume in position mode or drop --no-gap-fill (alpha limitation)")
-				}
-				slog.Warn("GTID gap detection is unavailable for a MariaDB source (alpha): a purged-binlog gap on resume " +
-					"will NOT raise the data-loss alarm — prefer position mode for MariaDB resumes (or pass --no-gap-fill to refuse starting)")
+				gap, gapErr = detectMariaDBGTIDGap(sourceDB, startGTIDStr, gapTimeout)
 			} else {
 				gap, gapErr = detectGTIDGap(sourceDB, startGTIDStr, gapTimeout)
 			}
@@ -1139,22 +1377,25 @@ func One(ctx context.Context, cfg Config) error {
 						"old_gtid_set", startGTIDStr,
 						"purged_gtid_set", gap.PurgedGTIDSet)
 					fmt.Printf("Gap: UNFILLABLE — checkpoint GTID set includes purged GTIDs; advancing past purged set (events are permanently lost)\n")
-					// Use the purged set as the checkpoint GTID set — this tells
-					// MySQL we have already seen all purged GTIDs, so it will
-					// only send the non-purged GTIDs that remain in @@gtid_executed.
-					// MySQL-only branch: a MariaDB source skips GTID gap detection
-					// above, so gap is nil here and this is never reached for MariaDB.
-					startGTIDStr = NormalizeGTIDSet(gap.PurgedGTIDSet)
-					gs, parseErr := gomysql.ParseMysqlGTIDSet(startGTIDStr)
+					// Adopt the purged set (MySQL: @@gtid_purged; MariaDB: the
+					// BINLOG_GTID_POS purge floor) as the checkpoint — this tells the
+					// source we have already seen everything up to the purge boundary,
+					// so it sends only the surviving GTIDs that remain in the executed
+					// set. Flavor-aware: for a MySQL source normalizeGTIDForFlavor /
+					// parseGTIDSetForFlavor reduce to NormalizeGTIDSet /
+					// ParseMysqlGTIDSet (byte-identical to the original), and a MariaDB
+					// source parses domain-server-seq instead.
+					startGTIDStr = normalizeGTIDForFlavor(cfg.Flavor, gap.PurgedGTIDSet)
+					gs, parseErr := parseGTIDSetForFlavor(cfg.Flavor, startGTIDStr)
 					if parseErr != nil {
 						return fmt.Errorf("failed to parse purged GTID set for auto-advance: %w", parseErr)
 					}
 					accGTID = gs
 				}
 
-				// Persist the advanced position immediately so that if the stream
-				// crashes during startup, the next restart won't hit the same
-				// purged-binlog error again.
+				// Durably record the loss and advance the checkpoint, in that order
+				// (see persistGapAutoAdvance — the stamp must precede the advance so
+				// the loss record can never desync from an advanced checkpoint, #402).
 				advancedState := &streamState{
 					mode:          mode,
 					binlogFile:    startFile,
@@ -1166,21 +1407,11 @@ func One(ctx context.Context, cfg Config) error {
 					eventsIndexed: saved.eventsIndexed,
 					lastEventTime: saved.lastEventTime,
 				}
-				if err := saveCheckpoint(indexDB, advancedState); err != nil {
-					return fmt.Errorf("failed to save advanced checkpoint: %w", err)
+				if err := persistGapAutoAdvance(indexDB, advancedState, gap.Message); err != nil {
+					return err
 				}
 				slog.Info("saved advanced checkpoint after gap auto-advance",
 					"file", startFile, "pos", startPos, "gtid_set", startGTIDStr)
-				// Record the data loss DURABLY: the advanced checkpoint means
-				// the next start sees no gap, so without this row the only
-				// trace of the permanently lost events would be an in-memory
-				// flag (or a log line) that a restart silently discards.
-				// Cleared by an explicit monitor Stop or --reset.
-				if _, err := indexDB.Exec(`UPDATE stream_state
-					SET gap_lost_at = UTC_TIMESTAMP(), gap_lost_detail = ?
-					WHERE id = 1`, gap.Message); err != nil {
-					slog.Warn("failed to persist gap-loss record; the lost_position state will not survive a restart", "error", err)
-				}
 				// Tell the supervisor events were lost — without this the
 				// auto-advance is only a log line and the console shows a
 				// healthy RUNNING badge over a stream that silently skipped


### PR DESCRIPTION
## Gate #1 of the MariaDB-as-source beta (#517)

Replaces the alpha **degrade-to-warn** for MariaDB GTID-mode resume with real purged-binlog gap detection, following the design verified against live MariaDB 11.4 in the #517 kickoff comment. Implemented TDD, against a live MariaDB, with zero change to the MySQL path.

### How MariaDB gap detection works
MariaDB has no `@@gtid_purged`, so the **purge floor** is derived from `BINLOG_GTID_POS(<oldest surviving binlog>, 4)` — the GTID state at the start of the oldest binlog the source still has; everything strictly before it is gone. The executed set comes from `@@gtid_binlog_pos`. New `detectMariaDBGTIDGap` runs three queries (`SHOW BINARY LOGS` → `BINLOG_GTID_POS` → `@@gtid_binlog_pos`) and returns the same `gapResult` the existing flavor-agnostic auto-advance + durable `gap_lost_at` machinery already consumes.

Decision tree: empty/NULL floor → caught-up or fillable; floor **not covered** by the checkpoint → **unfillable** (`PurgedGTIDSet = floor`, feeds auto-advance); else equal → no-gap / behind → fillable.

### Domain-global coverage (not go-mysql's `Contain`)
`mariadbCheckpointCoversFloor` compares the **max sequence per domain and ignores `server_id`**, because a MariaDB sequence is domain-global. This is faithful to the design's "per-domain `seq >= other.seq`" intent and avoids a spurious unfillable-gap alarm after a primary failover — go-mysql's set-level `MariadbGTIDSet.Contain` is keyed by `(domain, server)` and would false-alarm when the floor and checkpoint carry different `server_id`s in the same domain. (That error is in the safe direction — a false alarm, never silent loss — but the per-domain max avoids it.)

### MySQL stays byte-identical
The GTID auto-advance is now flavor-aware (`normalizeGTIDForFlavor` / `parseGTIDSetForFlavor` instead of the hardcoded `NormalizeGTIDSet` / `ParseMysqlGTIDSet`). For a MySQL source those reduce to the exact original calls — a structural no-op, confirmed by the unchanged MySQL gap test suite.

### Bug caught by empirical verification
`BINLOG_GTID_POS` returns SQL **NULL** (not `""`) on a source whose first binlog still exists — the common no-purge case. A plain-string `Scan` would error and make the stream **refuse to start**. Fixed with `sql.NullString` (NULL ≡ nothing purged), pinned by a deterministic unit test.

### Tests
- **Unit (sqlmock):** every branch — caught-up, fillable, unfillable, empty floor, **NULL floor**, multi-domain (fillable + unfillable), cross-server failover, domain-never-seen, empty-checkpoint guard, plus a **multi-server-per-domain** test that mutation-catches a broken `max()` aggregation (the silent-data-loss direction — added after an adversarial review found the original suite left it untested).
- **Integration (live MariaDB 11.4):** `TestDetectMariaDBGTIDGap_livePurge` manufactures a real `PURGE BINARY LOGS` gap, asserts unfillable detection, and **closes the auto-advance loop** — the floor re-parses with the MariaDB parser and a second detection clears the gap (clean re-sync). Runs in the `integration-mariadb-source` CI job.

### Docs
Dropped the alpha gap-detection limitation from `docs/mariadb.md` (incl. the now-unreachable troubleshooting row) and `docs/streaming.md`; reframed the remaining caveat to the genuinely-untested mid-capture primary-failover topology; fixed the MySQL-specific `--gap-timeout` flag help.

Refs #517 (beta epic), #515 (alpha).

🤖 Generated with [Claude Code](https://claude.com/claude-code)