### PR TITLE
fix: baseline UNSIGNED integers silently lost to NULL

### DIFF
--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -17,6 +17,14 @@ import (
 // BinlogEventColumns defines the 15 non-generated binlog_events columns in
 // MySQL table order (pk_hash is a stored generated column and is omitted).
 // Exported for reuse by the buffer package when writing Parquet files.
+//
+// event_id / start_pos / end_pos are BIGINT UNSIGNED in MySQL but are scanned as
+// sql.NullInt64 here (ArchivePartition) and never exceed int64 in practice —
+// AUTO_INCREMENT and binlog byte offsets stay well under 2^63 — so the signed
+// Int64 column they map to via MysqlToParquetNode is lossless. connection_id is
+// the one column that genuinely needs the unsigned widening below: it is INT
+// UNSIGNED (a CONNECTION_ID() can exceed int32's 2147483647) and is written via
+// FormatUint by the buffer path, so a signed Int(32) column would reject it.
 var BinlogEventColumns = []baseline.Column{
 	{Name: "event_id", MySQLType: "bigint", ParquetType: baseline.MysqlToParquetNode("bigint")},
 	{Name: "binlog_file", MySQLType: "varchar", ParquetType: baseline.MysqlToParquetNode("varchar")},
@@ -24,7 +32,7 @@ var BinlogEventColumns = []baseline.Column{
 	{Name: "end_pos", MySQLType: "bigint", ParquetType: baseline.MysqlToParquetNode("bigint")},
 	{Name: "event_timestamp", MySQLType: "datetime", ParquetType: baseline.MysqlToParquetNode("datetime")},
 	{Name: "gtid", MySQLType: "varchar", ParquetType: baseline.MysqlToParquetNode("varchar")},
-	{Name: "connection_id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
+	{Name: "connection_id", MySQLType: "int", Unsigned: true, ParquetType: baseline.MysqlToParquetNode2("int", true)},
 	{Name: "schema_name", MySQLType: "varchar", ParquetType: baseline.MysqlToParquetNode("varchar")},
 	{Name: "table_name", MySQLType: "varchar", ParquetType: baseline.MysqlToParquetNode("varchar")},
 	{Name: "event_type", MySQLType: "tinyint", ParquetType: baseline.MysqlToParquetNode("tinyint")},

--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -1,10 +1,14 @@
 package archive
 
 import (
+	"context"
+	"database/sql"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	_ "github.com/duckdb/duckdb-go/v2" // DuckDB driver — exercises the real read path
 	"github.com/parquet-go/parquet-go"
 
 	"github.com/dbtrail/dbtrail/internal/baseline"
@@ -175,6 +179,76 @@ func TestWriteReadRoundTrip(t *testing.T) {
 
 	if _, ok := pf.Lookup("bintrail.archive.version"); !ok {
 		t.Error("expected bintrail.archive.version metadata key")
+	}
+}
+
+// TestWriteRowConnectionIDUnsignedDuckDBScan pins the fail-loud regression fix:
+// connection_id is INT UNSIGNED (a CONNECTION_ID() reaches 4294967295, past
+// int32). Before BinlogEventColumns widened it via MysqlToParquetNode2("int",
+// true), a value over 2147483647 hit the new fail-loud WriteRow against a signed
+// Int(32) column and ABORTED the whole partition archive. This drives the
+// production BinlogEventColumns through WriteRow with the unsigned maximum and a
+// mid-range value, then reads back via DuckDB parquet_scan (the real consumer):
+// both must round-trip, NOT abort and NOT become NULL.
+func TestWriteRowConnectionIDUnsignedDuckDBScan(t *testing.T) {
+	const connIDIdx = 6 // MySQL order: event_id, binlog_file, start_pos, end_pos, event_timestamp, gtid, connection_id
+
+	for _, connID := range []string{"4294967295", "3000000000"} {
+		t.Run(connID, func(t *testing.T) {
+			dir := t.TempDir()
+			outPath := filepath.Join(dir, "conn.parquet")
+			w, err := baseline.NewWriter(outPath, BinlogEventColumns,
+				baseline.WriterConfig{Compression: "none", RowGroupSize: 100})
+			if err != nil {
+				t.Fatalf("NewWriter: %v", err)
+			}
+
+			// Only connection_id and the truly-NOT-NULL columns carry a value;
+			// everything else is NULL so the row stays minimal.
+			values := make([]string, 15)
+			nulls := make([]bool, 15)
+			for i := range nulls {
+				nulls[i] = true
+			}
+			values[0], nulls[0] = "1", false // event_id
+			values[4], nulls[4] = "2026-02-19 10:00:00", false
+			values[connIDIdx], nulls[connIDIdx] = connID, false
+
+			if err := w.WriteRow(values, nulls); err != nil {
+				t.Fatalf("WriteRow(connection_id=%s): got error, want round-trip (fail-loud regression): %v", connID, err)
+			}
+			if err := w.Close(); err != nil {
+				t.Fatalf("Close: %v", err)
+			}
+
+			db, err := sql.Open("duckdb", "")
+			if err != nil {
+				t.Fatalf("open duckdb: %v", err)
+			}
+			defer db.Close()
+
+			safePath := strings.ReplaceAll(outPath, "'", "''")
+			var conn any
+			if err := db.QueryRowContext(context.Background(),
+				"SELECT connection_id FROM parquet_scan('"+safePath+"')").Scan(&conn); err != nil {
+				t.Fatalf("scan connection_id: %v", err)
+			}
+			// INT UNSIGNED widened to signed Int64 → DuckDB BIGINT → Go int64.
+			got, ok := conn.(int64)
+			if !ok {
+				t.Fatalf("connection_id scanned as %T, want int64", conn)
+			}
+			want := int64(0)
+			switch connID {
+			case "4294967295":
+				want = 4294967295
+			case "3000000000":
+				want = 3000000000
+			}
+			if got != want {
+				t.Errorf("connection_id = %d, want %d", got, want)
+			}
+		})
 	}
 }
 

--- a/internal/baseline/schema.go
+++ b/internal/baseline/schema.go
@@ -85,11 +85,23 @@ func BuildParquetSchema(cols []Column) *parquet.Schema {
 
 // MysqlToParquetNode maps a MySQL type token to the appropriate parquet-go node,
 // treating integer types as signed. Callers with an UNSIGNED column should build
-// the column via ParseSchema (which threads the attribute through) — this
-// signed-only entry point is preserved for external callers that pass a bare
-// type token (e.g. internal/archive, internal/byos).
+// the column via ParseSchema (which threads the attribute through) or via
+// MysqlToParquetNode2 — this signed-only entry point is preserved for external
+// callers that pass a bare type token (e.g. internal/archive, internal/byos).
 func MysqlToParquetNode(typeToken string) parquet.Node {
 	return mysqlToParquetNode(typeToken, false)
+}
+
+// MysqlToParquetNode2 is the unsigned-aware entry point for callers that hand-
+// build a Column from a bare type token (internal/archive.BinlogEventColumns,
+// internal/byos) rather than going through ParseSchema. It must be used for any
+// column backing an UNSIGNED MySQL type (e.g. connection_id is INT UNSIGNED):
+// the signed-only MysqlToParquetNode would emit an Int(32) column, and a value
+// past int32 (a CONNECTION_ID() above 2147483647) would then fail conversion
+// against that signed column. Passing unsigned=true widens it the same way
+// ParseSchema does (INT UNSIGNED → Int64, BIGINT UNSIGNED → Uint64).
+func MysqlToParquetNode2(typeToken string, unsigned bool) parquet.Node {
+	return mysqlToParquetNode(typeToken, unsigned)
 }
 
 // mysqlToParquetNode maps a MySQL type token (plus its UNSIGNED attribute) to the

--- a/internal/baseline/schema.go
+++ b/internal/baseline/schema.go
@@ -24,7 +24,10 @@ type Column struct {
 // the type token (plus an optional display width like int(10)), so a column
 // literally named `is_unsigned` or a COMMENT containing "unsigned" never trips
 // it — the name lives in group 1 inside backticks, separate from group 3.
-var colRe = regexp.MustCompile("^\\s+`([^`]+)`\\s+(\\w+)(?:\\s*\\([^)]*\\))?\\s*(unsigned)?")
+// The unsigned group is case-insensitive (`(?i:...)` inside a capture group, so
+// group 3 is preserved): mydumper emits lowercase by contract, but an uppercase
+// UNSIGNED from a hand-rolled schema must not silently fall through to signed.
+var colRe = regexp.MustCompile("^\\s+`([^`]+)`\\s+(\\w+)(?:\\s*\\([^)]*\\))?\\s*((?i:unsigned))?")
 
 // ParseSchema reads a mydumper <db>.<table>-schema.sql file and returns the
 // ordered list of columns with their Parquet type mappings.

--- a/internal/baseline/schema.go
+++ b/internal/baseline/schema.go
@@ -14,13 +14,17 @@ import (
 type Column struct {
 	Name        string
 	MySQLType   string // raw type token e.g. "int", "varchar", "datetime"
+	Unsigned    bool   // true when the column carries the UNSIGNED attribute
 	ParquetType parquet.Node
 }
 
 // colRe matches a column definition line from mydumper's schema SQL output.
-// Groups: 1=name, 2=type token.
-// Handles backtick-quoted names and covers common MySQL type forms.
-var colRe = regexp.MustCompile("^\\s+`([^`]+)`\\s+(\\w+)")
+// Groups: 1=name, 2=type token, 3="unsigned" iff present.
+// The unsigned attribute is matched only in the tail that immediately follows
+// the type token (plus an optional display width like int(10)), so a column
+// literally named `is_unsigned` or a COMMENT containing "unsigned" never trips
+// it — the name lives in group 1 inside backticks, separate from group 3.
+var colRe = regexp.MustCompile("^\\s+`([^`]+)`\\s+(\\w+)(?:\\s*\\([^)]*\\))?\\s*(unsigned)?")
 
 // ParseSchema reads a mydumper <db>.<table>-schema.sql file and returns the
 // ordered list of columns with their Parquet type mappings.
@@ -50,10 +54,12 @@ func ParseSchema(path string) ([]Column, error) {
 		}
 		name := m[1]
 		typeToken := strings.ToLower(m[2])
+		unsigned := strings.EqualFold(m[3], "unsigned")
 		cols = append(cols, Column{
 			Name:        name,
 			MySQLType:   typeToken,
-			ParquetType: MysqlToParquetNode(typeToken),
+			Unsigned:    unsigned,
+			ParquetType: mysqlToParquetNode(typeToken, unsigned),
 		})
 	}
 	if err := scanner.Err(); err != nil {
@@ -74,13 +80,36 @@ func BuildParquetSchema(cols []Column) *parquet.Schema {
 	return parquet.NewSchema("row", group)
 }
 
-// MysqlToParquetNode maps a MySQL type token to the appropriate parquet-go node.
-// All fields are Optional so NULL values can be represented.
+// MysqlToParquetNode maps a MySQL type token to the appropriate parquet-go node,
+// treating integer types as signed. Callers with an UNSIGNED column should build
+// the column via ParseSchema (which threads the attribute through) — this
+// signed-only entry point is preserved for external callers that pass a bare
+// type token (e.g. internal/archive, internal/byos).
 func MysqlToParquetNode(typeToken string) parquet.Node {
+	return mysqlToParquetNode(typeToken, false)
+}
+
+// mysqlToParquetNode maps a MySQL type token (plus its UNSIGNED attribute) to the
+// appropriate parquet-go node. All fields are Optional so NULL values can be
+// represented. UNSIGNED integers are widened so the full unsigned range
+// round-trips without overflow into the signed-NULL fallback (issue #506):
+//   - INT/INTEGER UNSIGNED (max 4294967295) → INT64 (holds it as a positive value)
+//   - BIGINT UNSIGNED (max 18446744073709551615) → UINT64 (logical unsigned)
+//
+// TINYINT/SMALLINT/MEDIUMINT UNSIGNED already fit in int32, so they keep Int(32).
+func mysqlToParquetNode(typeToken string, unsigned bool) parquet.Node {
 	switch typeToken {
-	case "tinyint", "smallint", "mediumint", "int", "integer":
+	case "int", "integer":
+		if unsigned {
+			return parquet.Optional(parquet.Int(64))
+		}
+		return parquet.Optional(parquet.Int(32))
+	case "tinyint", "smallint", "mediumint":
 		return parquet.Optional(parquet.Int(32))
 	case "bigint":
+		if unsigned {
+			return parquet.Optional(parquet.Uint(64))
+		}
 		return parquet.Optional(parquet.Int(64))
 	case "float":
 		return parquet.Optional(parquet.Leaf(parquet.FloatType))

--- a/internal/baseline/unsigned_test.go
+++ b/internal/baseline/unsigned_test.go
@@ -1,11 +1,17 @@
 package baseline
 
 import (
+	"context"
+	"database/sql"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	_ "github.com/duckdb/duckdb-go/v2" // DuckDB driver — exercises the real read path
 	"github.com/parquet-go/parquet-go"
+
+	"github.com/dbtrail/dbtrail/internal/recovery"
 )
 
 // TestParseSchemaUnsigned pins the colRe attribute-tail match: the UNSIGNED flag
@@ -174,6 +180,78 @@ func TestWriteRowUnsignedRoundTrip(t *testing.T) {
 	}
 	if got := row[1].Int64(); got != 4294967295 {
 		t.Errorf("c_int_u: got %d, want 4294967295", got)
+	}
+}
+
+// TestWriteRowUnsignedDuckDBScan is the round-trip the TOOL actually performs:
+// every production consumer (reconstruct.ReadBaselineRow, fulltable.go, shim
+// _snapshot) reads baselines through DuckDB `parquet_scan`, not parquet-go's
+// manual reader. This pins that the unsigned maxima survive the real read path
+// AND format to the right SQL literal via recovery.FormatSQLValue — the chain
+// that turns a scanned value into recovery output (issue #506 review).
+//
+// Type expectations differ by column because schema.go widens INT UNSIGNED into
+// a SIGNED Int(64) but BIGINT UNSIGNED into Uint(64):
+//   - BIGINT UNSIGNED → DuckDB UBIGINT → Go uint64 (the load-bearing assertion:
+//     proves the real consumer never sees a negative for the unsigned maximum)
+//   - INT UNSIGNED    → DuckDB BIGINT  → Go int64 (positive, exact value)
+func TestWriteRowUnsignedDuckDBScan(t *testing.T) {
+	cols := []Column{
+		{Name: "c_big_u", MySQLType: "bigint", Unsigned: true, ParquetType: mysqlToParquetNode("bigint", true)},
+		{Name: "c_int_u", MySQLType: "int", Unsigned: true, ParquetType: mysqlToParquetNode("int", true)},
+	}
+
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "unsigned_duck.parquet")
+	w, err := NewWriter(outPath, cols, WriterConfig{Compression: "none", RowGroupSize: 100})
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	// Values in MySQL (== alphabetical) order: c_big_u, c_int_u.
+	if err := w.WriteRow([]string{"18446744073709551615", "4294967295"}, []bool{false, false}); err != nil {
+		t.Fatalf("WriteRow: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open duckdb: %v", err)
+	}
+	defer db.Close()
+
+	safePath := strings.ReplaceAll(outPath, "'", "''")
+	var big, intv any
+	row := db.QueryRowContext(context.Background(),
+		"SELECT c_big_u, c_int_u FROM parquet_scan('"+safePath+"')")
+	if err := row.Scan(&big, &intv); err != nil {
+		t.Fatalf("scan parquet_scan row: %v", err)
+	}
+
+	// BIGINT UNSIGNED max must come back as a concrete uint64 — a negative int64
+	// here would be the #506 corruption surfacing through the real consumer.
+	bigU, ok := big.(uint64)
+	if !ok {
+		t.Fatalf("c_big_u scanned as %T, want uint64", big)
+	}
+	if bigU != 18446744073709551615 {
+		t.Errorf("c_big_u = %d, want 18446744073709551615", bigU)
+	}
+	if got := recovery.FormatSQLValue(bigU); got != "18446744073709551615" {
+		t.Errorf("FormatSQLValue(c_big_u) = %q, want %q", got, "18446744073709551615")
+	}
+
+	// INT UNSIGNED widened into a signed Int(64) → scans as int64 (positive).
+	intI, ok := intv.(int64)
+	if !ok {
+		t.Fatalf("c_int_u scanned as %T, want int64", intv)
+	}
+	if intI != 4294967295 {
+		t.Errorf("c_int_u = %d, want 4294967295", intI)
+	}
+	if got := recovery.FormatSQLValue(intI); got != "4294967295" {
+		t.Errorf("FormatSQLValue(c_int_u) = %q, want %q", got, "4294967295")
 	}
 }
 

--- a/internal/baseline/unsigned_test.go
+++ b/internal/baseline/unsigned_test.go
@@ -1,0 +1,214 @@
+package baseline
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/parquet-go/parquet-go"
+)
+
+// TestParseSchemaUnsigned pins the colRe attribute-tail match: the UNSIGNED flag
+// must be detected only when it follows the type token (optionally after a
+// display width), and never from a column name or comment that merely contains
+// the word "unsigned" (issue #506).
+func TestParseSchemaUnsigned(t *testing.T) {
+	const schema = "CREATE TABLE `t` (\n" +
+		"  `a` int unsigned NOT NULL,\n" +
+		"  `b` int(10) unsigned NOT NULL,\n" +
+		"  `c` bigint unsigned NOT NULL,\n" +
+		"  `d` bigint unsigned zerofill NOT NULL,\n" +
+		"  `e` int NOT NULL,\n" +
+		"  `f` bigint NOT NULL,\n" +
+		"  `is_unsigned` tinyint NOT NULL,\n" +
+		"  `note` varchar(64) DEFAULT NULL COMMENT 'unsigned counter',\n" +
+		"  PRIMARY KEY (`a`)\n" +
+		") ENGINE=InnoDB;\n"
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "shop.t-schema.sql")
+	if err := os.WriteFile(path, []byte(schema), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cols, err := ParseSchema(path)
+	if err != nil {
+		t.Fatalf("ParseSchema: %v", err)
+	}
+
+	want := []struct {
+		name      string
+		mysqlType string
+		unsigned  bool
+	}{
+		{"a", "int", true},
+		{"b", "int", true},
+		{"c", "bigint", true},
+		{"d", "bigint", true},
+		{"e", "int", false},
+		{"f", "bigint", false},
+		{"is_unsigned", "tinyint", false}, // name contains "unsigned" — must NOT match
+		{"note", "varchar", false},        // COMMENT contains "unsigned" — must NOT match
+	}
+	if len(cols) != len(want) {
+		t.Fatalf("got %d columns, want %d: %+v", len(cols), len(want), cols)
+	}
+	for i, w := range want {
+		if cols[i].Name != w.name {
+			t.Errorf("col[%d].Name = %q, want %q", i, cols[i].Name, w.name)
+		}
+		if cols[i].MySQLType != w.mysqlType {
+			t.Errorf("col[%d].MySQLType = %q, want %q", i, cols[i].MySQLType, w.mysqlType)
+		}
+		if cols[i].Unsigned != w.unsigned {
+			t.Errorf("col[%d] (%s) Unsigned = %v, want %v", i, w.name, cols[i].Unsigned, w.unsigned)
+		}
+	}
+}
+
+// TestConvertValueUnsigned verifies that UNSIGNED integers at the top of their
+// range convert without overflowing into the convertValue error path (which,
+// post-fix, aborts the write instead of silently NULLing — issue #506/#503).
+func TestConvertValueUnsigned(t *testing.T) {
+	cases := []struct {
+		name      string
+		mysqlType string
+		raw       string
+		check     func(*testing.T, parquet.Value)
+	}{
+		{"int_unsigned_max", "int", "4294967295", func(t *testing.T, v parquet.Value) {
+			if v.Int64() != 4294967295 {
+				t.Errorf("got %d, want 4294967295", v.Int64())
+			}
+		}},
+		{"int_unsigned_mid", "int", "3000000000", func(t *testing.T, v parquet.Value) {
+			if v.Int64() != 3000000000 {
+				t.Errorf("got %d, want 3000000000", v.Int64())
+			}
+		}},
+		{"bigint_unsigned_max", "bigint", "18446744073709551615", func(t *testing.T, v parquet.Value) {
+			// Stored as the int64 bit pattern; read back via uint64 reinterpret.
+			if got := uint64(v.Int64()); got != 18446744073709551615 {
+				t.Errorf("got %d, want 18446744073709551615", got)
+			}
+		}},
+		{"bigint_unsigned_mid", "bigint", "10000000000000000000", func(t *testing.T, v parquet.Value) {
+			if got := uint64(v.Int64()); got != 10000000000000000000 {
+				t.Errorf("got %d, want 10000000000000000000", got)
+			}
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			col := Column{Name: "c", MySQLType: tc.mysqlType, Unsigned: true}
+			v, err := convertValue(col, tc.raw)
+			if err != nil {
+				t.Fatalf("convertValue(%q unsigned, %q): %v", tc.mysqlType, tc.raw, err)
+			}
+			tc.check(t, v)
+		})
+	}
+}
+
+// TestWriteRowUnsignedRoundTrip is the end-to-end arbiter for the #506 fix: an
+// INT UNSIGNED at 4294967295 and a BIGINT UNSIGNED at 18446744073709551615
+// must survive a full WriteRow → Parquet → read-back without becoming NULL.
+//
+// Column names are alphabetical so MySQL write order matches Parquet storage
+// order (parquet.Group sorts alphabetically).
+func TestWriteRowUnsignedRoundTrip(t *testing.T) {
+	cols := []Column{
+		{Name: "c_big_u", MySQLType: "bigint", Unsigned: true, ParquetType: mysqlToParquetNode("bigint", true)},
+		{Name: "c_int_u", MySQLType: "int", Unsigned: true, ParquetType: mysqlToParquetNode("int", true)},
+	}
+
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "unsigned.parquet")
+	w, err := NewWriter(outPath, cols, WriterConfig{Compression: "none", RowGroupSize: 100})
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	// Values in MySQL (== alphabetical) order: c_big_u, c_int_u.
+	values := []string{"18446744073709551615", "4294967295"}
+	nulls := []bool{false, false}
+	if err := w.WriteRow(values, nulls); err != nil {
+		t.Fatalf("WriteRow: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	rf, err := os.Open(outPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer rf.Close()
+	info, err := rf.Stat()
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	pf, err := parquet.OpenFile(rf, info.Size())
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+	reader := parquet.NewReader(pf)
+	defer reader.Close()
+	rows := make([]parquet.Row, 1)
+	n, _ := reader.ReadRows(rows)
+	if n != 1 {
+		t.Fatalf("ReadRows = %d, want 1", n)
+	}
+	row := rows[0]
+	if len(row) != 2 {
+		t.Fatalf("row has %d values, want 2", len(row))
+	}
+
+	// Column order is alphabetical: [0]=c_big_u, [1]=c_int_u.
+	if row[0].IsNull() {
+		t.Fatal("c_big_u (BIGINT UNSIGNED): got NULL, want 18446744073709551615")
+	}
+	if got := uint64(row[0].Int64()); got != 18446744073709551615 {
+		t.Errorf("c_big_u: got %d, want 18446744073709551615", got)
+	}
+	if row[1].IsNull() {
+		t.Fatal("c_int_u (INT UNSIGNED): got NULL, want 4294967295")
+	}
+	if got := row[1].Int64(); got != 4294967295 {
+		t.Errorf("c_int_u: got %d, want 4294967295", got)
+	}
+}
+
+// TestWriteRowFailsLoudOnUnconvertible pins the #503 item-3 silencer fix: a
+// genuinely-unconvertible value must abort WriteRow with an error that names the
+// column and value — NOT silently become NULL. This exercises WriteRow (where
+// the old silent swallow lived), not convertValue alone.
+func TestWriteRowFailsLoudOnUnconvertible(t *testing.T) {
+	cols := []Column{
+		{Name: "n", MySQLType: "int", ParquetType: MysqlToParquetNode("int")},
+	}
+	dir := t.TempDir()
+	w, err := NewWriter(filepath.Join(dir, "loud.parquet"), cols, WriterConfig{Compression: "none", RowGroupSize: 100})
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	defer w.Close()
+
+	err = w.WriteRow([]string{"not-a-number"}, []bool{false})
+	if err == nil {
+		t.Fatal("WriteRow with unconvertible int value: got nil error, want loud failure (silent-NULL regression)")
+	}
+	// The error must locate the row for the operator.
+	for _, want := range []string{"n", "not-a-number"} {
+		if !contains(err.Error(), want) {
+			t.Errorf("error %q does not mention %q", err.Error(), want)
+		}
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/baseline/unsigned_test.go
+++ b/internal/baseline/unsigned_test.go
@@ -255,6 +255,78 @@ func TestWriteRowUnsignedDuckDBScan(t *testing.T) {
 	}
 }
 
+// TestParseSchemaWiringUnsignedDuckDBScan exercises the FULL production chain —
+// ParseSchema (NOT a hand-built ParquetType) → NewWriter → WriteRow → DuckDB
+// parquet_scan — for UNSIGNED maxima. This is the one test that fails if the
+// schema.go call site regresses (e.g. ParseSchema calling
+// mysqlToParquetNode(typeToken, false)): every other unsigned test hand-builds
+// the ParquetType with explicit unsigned=true and would stay green under that
+// bug (MUT-D). Here the widening must come from ParseSchema itself.
+func TestParseSchemaWiringUnsignedDuckDBScan(t *testing.T) {
+	const schema = "CREATE TABLE `t` (\n" +
+		"  `c_big_u` bigint unsigned NOT NULL,\n" +
+		"  `c_int_u` int unsigned NOT NULL,\n" +
+		"  PRIMARY KEY (`c_int_u`)\n" +
+		") ENGINE=InnoDB;\n"
+
+	dir := t.TempDir()
+	schemaPath := filepath.Join(dir, "shop.t-schema.sql")
+	if err := os.WriteFile(schemaPath, []byte(schema), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cols, err := ParseSchema(schemaPath)
+	if err != nil {
+		t.Fatalf("ParseSchema: %v", err)
+	}
+
+	outPath := filepath.Join(dir, "wiring.parquet")
+	w, err := NewWriter(outPath, cols, WriterConfig{Compression: "none", RowGroupSize: 100})
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	// Values in MySQL (schema) order: c_big_u, c_int_u.
+	if err := w.WriteRow([]string{"18446744073709551615", "4294967295"}, []bool{false, false}); err != nil {
+		t.Fatalf("WriteRow: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open duckdb: %v", err)
+	}
+	defer db.Close()
+
+	safePath := strings.ReplaceAll(outPath, "'", "''")
+	var big, intv any
+	row := db.QueryRowContext(context.Background(),
+		"SELECT c_big_u, c_int_u FROM parquet_scan('"+safePath+"')")
+	if err := row.Scan(&big, &intv); err != nil {
+		t.Fatalf("scan parquet_scan row: %v", err)
+	}
+
+	// BIGINT UNSIGNED → DuckDB UBIGINT → Go uint64. Under MUT-D this column would
+	// be a signed Int64 (DuckDB BIGINT → int64) and the max would read negative.
+	bigU, ok := big.(uint64)
+	if !ok {
+		t.Fatalf("c_big_u scanned as %T, want uint64 (ParseSchema must widen BIGINT UNSIGNED to Uint64)", big)
+	}
+	if bigU != 18446744073709551615 {
+		t.Errorf("c_big_u = %d, want 18446744073709551615", bigU)
+	}
+
+	// INT UNSIGNED → widened to signed Int64 → DuckDB BIGINT → Go int64. Under
+	// MUT-D this would be an Int32 column and 4294967295 would fail to convert.
+	intI, ok := intv.(int64)
+	if !ok {
+		t.Fatalf("c_int_u scanned as %T, want int64 (ParseSchema must widen INT UNSIGNED to Int64)", intv)
+	}
+	if intI != 4294967295 {
+		t.Errorf("c_int_u = %d, want 4294967295", intI)
+	}
+}
+
 // TestWriteRowFailsLoudOnUnconvertible pins the #503 item-3 silencer fix: a
 // genuinely-unconvertible value must abort WriteRow with an error that names the
 // column and value — NOT silently become NULL. This exercises WriteRow (where

--- a/internal/baseline/writer.go
+++ b/internal/baseline/writer.go
@@ -26,8 +26,9 @@ import (
 // out of range"). They are representable as NULL — MySQL itself treats the zero
 // date as its pseudo-NULL — so WriteRow maps them to a deliberate NULL plus a
 // once-per-column warning, rather than aborting the whole baseline run. This is
-// distinct from a genuinely unrepresentable value (UNSIGNED overflow, garbage),
-// which would be silently corrupted by a NULL and must still fail loud.
+// distinct from a genuinely unrepresentable value (non-numeric garbage in an
+// integer column, an out-of-range literal), which would be silently corrupted
+// by a NULL and must still fail loud.
 var errZeroDate = errors.New("zero date sentinel (mydumper pseudo-NULL)")
 
 // WriterConfig carries Parquet writer options.
@@ -135,8 +136,10 @@ func (w *Writer) WriteRow(values []string, nulls []bool) error {
 				// data-recovery tool — abort the run rather than hand back a
 				// snapshot that quietly dropped a value. Context lets the
 				// operator locate the offending row. (A value that would be
-				// silently CORRUPTED by NULL — UNSIGNED overflow, garbage —
-				// still aborts; only the zero-date pseudo-NULL above does not.)
+				// silently CORRUPTED by NULL — e.g. non-numeric garbage in an
+				// int column, an out-of-range literal — still aborts; only the
+				// zero-date pseudo-NULL above does not. In-range UNSIGNED values
+				// no longer reach here: they are widened by convertValue.)
 				return fmt.Errorf("baseline: column %q (%s) value %q: %w",
 					col.Name, col.MySQLType, raw, err)
 			default:

--- a/internal/baseline/writer.go
+++ b/internal/baseline/writer.go
@@ -1,7 +1,9 @@
 package baseline
 
 import (
+	"errors"
 	"fmt"
+	"log/slog"
 	"math"
 	"os"
 	"path/filepath"
@@ -16,6 +18,17 @@ import (
 	"github.com/parquet-go/parquet-go/compress/snappy"
 	"github.com/parquet-go/parquet-go/compress/zstd"
 )
+
+// errZeroDate marks MySQL's all-zero DATE/DATETIME/TIMESTAMP pseudo-NULL
+// sentinel (`0000-00-00`, `0000-00-00 00:00:00`, fractional `.000000` variant).
+// These are LEGAL legacy MySQL values (a column with DEFAULT '0000-00-00
+// 00:00:00' carries them in every row) that Go's time parser rejects ("month
+// out of range"). They are representable as NULL — MySQL itself treats the zero
+// date as its pseudo-NULL — so WriteRow maps them to a deliberate NULL plus a
+// once-per-column warning, rather than aborting the whole baseline run. This is
+// distinct from a genuinely unrepresentable value (UNSIGNED overflow, garbage),
+// which would be silently corrupted by a NULL and must still fail loud.
+var errZeroDate = errors.New("zero date sentinel (mydumper pseudo-NULL)")
 
 // WriterConfig carries Parquet writer options.
 type WriterConfig struct {
@@ -32,6 +45,10 @@ type Writer struct {
 	parquetCols []Column
 	// mysqlOrder[parquetIdx] = original MySQL column index in the source data.
 	mysqlOrder []int
+	// zeroDateWarned tracks parquet column indexes already warned about a
+	// zero-date sentinel, so a legacy table with DEFAULT '0000-00-00' (the
+	// sentinel in every row) emits one warning per column, not per row.
+	zeroDateWarned map[int]bool
 }
 
 // NewWriter creates a new Parquet writer for the given table.
@@ -74,10 +91,11 @@ func NewWriter(path string, cols []Column, cfg WriterConfig) (*Writer, error) {
 
 	pw := parquet.NewWriter(f, opts...)
 	return &Writer{
-		pw:          pw,
-		file:        f,
-		parquetCols: parquetCols,
-		mysqlOrder:  mysqlOrder,
+		pw:             pw,
+		file:           f,
+		parquetCols:    parquetCols,
+		mysqlOrder:     mysqlOrder,
+		zeroDateWarned: make(map[int]bool),
 	}, nil
 }
 
@@ -97,16 +115,33 @@ func (w *Writer) WriteRow(values []string, nulls []bool) error {
 				raw = values[mysqlIdx]
 			}
 			converted, err := convertValue(col, raw)
-			if err != nil {
+			switch {
+			case errors.Is(err, errZeroDate):
+				// MySQL's all-zero date/datetime is a LEGAL pseudo-NULL that the
+				// Go time parser rejects. It is representable as NULL (that IS
+				// its semantics), so map it to a deliberate NULL and warn once
+				// per column — visible, not a silent drop. Aborting here would
+				// kill the baseline of any legacy table carrying DEFAULT
+				// '0000-00-00 00:00:00' (issue #506 review carve-out).
+				if !w.zeroDateWarned[parquetIdx] {
+					w.zeroDateWarned[parquetIdx] = true
+					slog.Warn("baseline: zero date mapped to NULL",
+						"column", col.Name, "type", col.MySQLType, "value", raw)
+				}
+				v = parquet.NullValue().Level(0, 0, parquetIdx)
+			case err != nil:
 				// Fail loud: silently coercing an unconvertible value to NULL
 				// publishes a lossy baseline (issue #503 item-3). This is a
 				// data-recovery tool — abort the run rather than hand back a
 				// snapshot that quietly dropped a value. Context lets the
-				// operator locate the offending row.
+				// operator locate the offending row. (A value that would be
+				// silently CORRUPTED by NULL — UNSIGNED overflow, garbage —
+				// still aborts; only the zero-date pseudo-NULL above does not.)
 				return fmt.Errorf("baseline: column %q (%s) value %q: %w",
 					col.Name, col.MySQLType, raw, err)
+			default:
+				v = converted.Level(0, 1, parquetIdx)
 			}
-			v = converted.Level(0, 1, parquetIdx)
 		}
 		row[parquetIdx] = v
 	}
@@ -209,6 +244,9 @@ func convertValue(col Column, raw string) (parquet.Value, error) {
 		return parquet.DoubleValue(f), nil
 
 	case "datetime", "timestamp":
+		if isZeroDate(raw) {
+			return parquet.Value{}, errZeroDate
+		}
 		us, err := parseDatetimeToMicros(raw)
 		if err != nil {
 			return parquet.Value{}, err
@@ -216,6 +254,9 @@ func convertValue(col Column, raw string) (parquet.Value, error) {
 		return parquet.Int64Value(us), nil
 
 	case "date":
+		if isZeroDate(raw) {
+			return parquet.Value{}, errZeroDate
+		}
 		days, err := parseDateToDays(raw)
 		if err != nil {
 			return parquet.Value{}, err
@@ -236,6 +277,16 @@ func convertValue(col Column, raw string) (parquet.Value, error) {
 		// String types and fallback.
 		return parquet.ByteArrayValue([]byte(raw)), nil
 	}
+}
+
+// isZeroDate reports whether raw is MySQL's all-zero date pseudo-NULL sentinel:
+// `0000-00-00`, `0000-00-00 00:00:00`, and the `.000000` fractional variant. The
+// `0000-00-00` prefix uniquely identifies the family (a real date never starts
+// with a zero year), so one prefix check covers DATE, DATETIME, and TIMESTAMP.
+// TIME is deliberately excluded — `00:00:00` is legal midnight, stored as a
+// string, and round-trips fine; it is not a pseudo-NULL.
+func isZeroDate(raw string) bool {
+	return strings.HasPrefix(strings.TrimSpace(raw), "0000-00-00")
 }
 
 // parseDatetimeToMicros parses MySQL DATETIME/TIMESTAMP strings to microseconds

--- a/internal/baseline/writer.go
+++ b/internal/baseline/writer.go
@@ -98,11 +98,15 @@ func (w *Writer) WriteRow(values []string, nulls []bool) error {
 			}
 			converted, err := convertValue(col, raw)
 			if err != nil {
-				// On conversion error, store as NULL to avoid data loss.
-				v = parquet.NullValue().Level(0, 0, parquetIdx)
-			} else {
-				v = converted.Level(0, 1, parquetIdx)
+				// Fail loud: silently coercing an unconvertible value to NULL
+				// publishes a lossy baseline (issue #503 item-3). This is a
+				// data-recovery tool — abort the run rather than hand back a
+				// snapshot that quietly dropped a value. Context lets the
+				// operator locate the offending row.
+				return fmt.Errorf("baseline: column %q (%s) value %q: %w",
+					col.Name, col.MySQLType, raw, err)
 			}
+			v = converted.Level(0, 1, parquetIdx)
 		}
 		row[parquetIdx] = v
 	}
@@ -147,7 +151,25 @@ func sortColumnsForParquet(cols []Column) ([]Column, []int) {
 // column's MySQL type. Caller sets Level after.
 func convertValue(col Column, raw string) (parquet.Value, error) {
 	switch col.MySQLType {
-	case "tinyint", "smallint", "mediumint", "int", "integer":
+	case "tinyint", "smallint", "mediumint":
+		// These fit int32 whether signed or unsigned (max 16777215 for
+		// MEDIUMINT UNSIGNED), so a plain signed parse is lossless.
+		n, err := strconv.ParseInt(strings.TrimSpace(raw), 10, 32)
+		if err != nil {
+			return parquet.Value{}, err
+		}
+		return parquet.Int32Value(int32(n)), nil
+
+	case "int", "integer":
+		if col.Unsigned {
+			// INT UNSIGNED reaches 4294967295, which overflows int32.
+			// Parse as uint32 and widen into the INT64 column (issue #506).
+			n, err := strconv.ParseUint(strings.TrimSpace(raw), 10, 32)
+			if err != nil {
+				return parquet.Value{}, err
+			}
+			return parquet.Int64Value(int64(n)), nil
+		}
 		n, err := strconv.ParseInt(strings.TrimSpace(raw), 10, 32)
 		if err != nil {
 			return parquet.Value{}, err
@@ -155,6 +177,17 @@ func convertValue(col Column, raw string) (parquet.Value, error) {
 		return parquet.Int32Value(int32(n)), nil
 
 	case "bigint":
+		if col.Unsigned {
+			// BIGINT UNSIGNED reaches 18446744073709551615, which overflows
+			// int64. Parse as uint64 and store the bit pattern in the UINT64
+			// column: int64(MaxUint64) round-trips back via uint64(v.Int64())
+			// (issue #506).
+			n, err := strconv.ParseUint(strings.TrimSpace(raw), 10, 64)
+			if err != nil {
+				return parquet.Value{}, err
+			}
+			return parquet.Int64Value(int64(n)), nil
+		}
 		n, err := strconv.ParseInt(strings.TrimSpace(raw), 10, 64)
 		if err != nil {
 			return parquet.Value{}, err

--- a/internal/baseline/zerodate_test.go
+++ b/internal/baseline/zerodate_test.go
@@ -1,0 +1,155 @@
+package baseline
+
+import (
+	"bytes"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/parquet-go/parquet-go"
+)
+
+// TestWriteRowZeroDateCarveOut pins the #506 review carve-out: MySQL's all-zero
+// date pseudo-NULL (`0000-00-00 00:00:00`, common in legacy tables with that
+// DEFAULT) must COMPLETE the baseline as a deliberate NULL plus a once-per-column
+// warning — NOT abort the run like a genuinely unrepresentable value would. The
+// pre-carve-out blanket fail-loud killed the snapshot of any such legacy table.
+func TestWriteRowZeroDateCarveOut(t *testing.T) {
+	// Capture slog so we can assert the warn fired and named the column.
+	var logBuf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	defer slog.SetDefault(prev)
+
+	cols := []Column{
+		{Name: "created_dt", MySQLType: "datetime", ParquetType: mysqlToParquetNode("datetime", false)},
+		{Name: "created_on", MySQLType: "date", ParquetType: mysqlToParquetNode("date", false)},
+		{Name: "created_ts", MySQLType: "timestamp", ParquetType: mysqlToParquetNode("timestamp", false)},
+	}
+
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "zerodate.parquet")
+	w, err := NewWriter(outPath, cols, WriterConfig{Compression: "none", RowGroupSize: 100})
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+
+	// Two rows, both all-zero across the three forms (datetime full,
+	// datetime-with-fraction, date, timestamp). The second row exercises the
+	// once-per-column dedup: a per-row warn would flood here.
+	rows := [][]string{
+		{"0000-00-00 00:00:00", "0000-00-00", "0000-00-00 00:00:00"},
+		{"0000-00-00 00:00:00.000000", "0000-00-00", "0000-00-00 00:00:00.000000"},
+	}
+	for i, r := range rows {
+		if err := w.WriteRow(r, []bool{false, false, false}); err != nil {
+			t.Fatalf("WriteRow(row %d) returned error, want nil (zero date must NOT abort): %v", i, err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// (b) Read back: every column of every row must be NULL.
+	rf, err := os.Open(outPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer rf.Close()
+	info, err := rf.Stat()
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	pf, err := parquet.OpenFile(rf, info.Size())
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+	reader := parquet.NewReader(pf)
+	defer reader.Close()
+	got := make([]parquet.Row, 2)
+	n, _ := reader.ReadRows(got)
+	if n != 2 {
+		t.Fatalf("ReadRows = %d, want 2", n)
+	}
+	for ri := range got[:n] {
+		for ci, v := range got[ri] {
+			if !v.IsNull() {
+				t.Errorf("row %d col %d: got %v, want NULL", ri, ci, v)
+			}
+		}
+	}
+
+	// (c) The warn fired and named each column — exactly once each (dedup).
+	logStr := logBuf.String()
+	for _, name := range []string{"created_dt", "created_on", "created_ts"} {
+		if c := countOccurrences(logStr, name); c != 1 {
+			t.Errorf("column %q appears %d times in warn log, want exactly 1 (once-per-column dedup): %s", name, c, logStr)
+		}
+	}
+}
+
+// TestWriteRowZeroDateStillAbortsGarbage confirms the carve-out is surgical: a
+// genuinely-unconvertible date (NOT the zero sentinel) still fails loud, naming
+// the column and value. Only the legal pseudo-NULL is carved out.
+func TestWriteRowZeroDateStillAbortsGarbage(t *testing.T) {
+	cols := []Column{
+		{Name: "d", MySQLType: "date", ParquetType: mysqlToParquetNode("date", false)},
+	}
+	dir := t.TempDir()
+	w, err := NewWriter(filepath.Join(dir, "garbage.parquet"), cols, WriterConfig{Compression: "none", RowGroupSize: 100})
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	defer w.Close()
+
+	err = w.WriteRow([]string{"not-a-date"}, []bool{false})
+	if err == nil {
+		t.Fatal("WriteRow with unconvertible date: got nil, want loud failure (carve-out must not swallow garbage)")
+	}
+	for _, want := range []string{"d", "not-a-date"} {
+		if !contains(err.Error(), want) {
+			t.Errorf("error %q does not mention %q", err.Error(), want)
+		}
+	}
+}
+
+// TestParseSchemaUnsignedUppercase hardens the colRe case-insensitive group: an
+// uppercase UNSIGNED (hand-rolled schema; mydumper emits lowercase) must still
+// populate the attribute, not silently fall through to signed.
+func TestParseSchemaUnsignedUppercase(t *testing.T) {
+	const schema = "CREATE TABLE `t` (\n" +
+		"  `a` INT UNSIGNED NOT NULL,\n" +
+		"  `b` BIGINT UNSIGNED NOT NULL,\n" +
+		"  `c` Int(10) Unsigned NOT NULL,\n" +
+		"  PRIMARY KEY (`a`)\n" +
+		") ENGINE=InnoDB;\n"
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "shop.t-schema.sql")
+	if err := os.WriteFile(path, []byte(schema), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cols, err := ParseSchema(path)
+	if err != nil {
+		t.Fatalf("ParseSchema: %v", err)
+	}
+	if len(cols) != 3 {
+		t.Fatalf("got %d columns, want 3: %+v", len(cols), cols)
+	}
+	for i, c := range cols {
+		if !c.Unsigned {
+			t.Errorf("col[%d] (%s) Unsigned = false, want true (uppercase UNSIGNED must match)", i, c.Name)
+		}
+	}
+}
+
+func countOccurrences(s, sub string) int {
+	n := 0
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			n++
+		}
+	}
+	return n
+}

--- a/internal/baseline/zerodate_test.go
+++ b/internal/baseline/zerodate_test.go
@@ -114,6 +114,48 @@ func TestWriteRowZeroDateStillAbortsGarbage(t *testing.T) {
 	}
 }
 
+// TestWriteRowPartialZeroDateAborts pins that the carve-out is keyed on the
+// ALL-zero `0000-00-00` prefix only: a PARTIAL zero date (`2020-00-00`, a real
+// year with a zero month, or `2020-05-00 00:00:00`, a zero day) is NOT MySQL's
+// pseudo-NULL sentinel — Go's parser rejects it as out-of-range, and that must
+// still fail loud naming the column, not get silently carved to NULL.
+func TestWriteRowPartialZeroDateAborts(t *testing.T) {
+	cases := []struct {
+		name      string
+		mysqlType string
+		raw       string
+	}{
+		{"date_zero_month", "date", "2020-00-00"},
+		{"date_zero_day", "date", "2020-05-00"},
+		{"datetime_zero_month", "datetime", "2020-00-00 00:00:00"},
+		{"datetime_zero_day", "datetime", "2020-05-00 00:00:00"},
+		{"timestamp_zero_day", "timestamp", "2020-05-00 00:00:00"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cols := []Column{
+				{Name: "d", MySQLType: tc.mysqlType, ParquetType: mysqlToParquetNode(tc.mysqlType, false)},
+			}
+			dir := t.TempDir()
+			w, err := NewWriter(filepath.Join(dir, "partial.parquet"), cols, WriterConfig{Compression: "none", RowGroupSize: 100})
+			if err != nil {
+				t.Fatalf("NewWriter: %v", err)
+			}
+			defer w.Close()
+
+			err = w.WriteRow([]string{tc.raw}, []bool{false})
+			if err == nil {
+				t.Fatalf("WriteRow(%q) with partial-zero date: got nil, want loud failure (only all-zero is carved out)", tc.raw)
+			}
+			for _, want := range []string{"d", tc.raw} {
+				if !contains(err.Error(), want) {
+					t.Errorf("error %q does not mention %q", err.Error(), want)
+				}
+			}
+		})
+	}
+}
+
 // TestParseSchemaUnsignedUppercase hardens the colRe case-insensitive group: an
 // uppercase UNSIGNED (hand-rolled schema; mydumper emits lowercase) must still
 // populate the attribute, not silently fall through to signed.

--- a/internal/buffer/parquet_test.go
+++ b/internal/buffer/parquet_test.go
@@ -1,11 +1,16 @@
 package buffer
 
 import (
+	"context"
+	"database/sql"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
+	_ "github.com/duckdb/duckdb-go/v2" // DuckDB driver — exercises the real read path
 	"github.com/parquet-go/parquet-go"
 
 	"github.com/dbtrail/dbtrail/internal/parser"
@@ -60,6 +65,63 @@ func TestWriteParquet_roundTrip(t *testing.T) {
 	// Verify metadata.
 	if _, ok := pf.Lookup("bintrail.buffer.version"); !ok {
 		t.Error("expected bintrail.buffer.version metadata key")
+	}
+}
+
+// TestWriteParquet_connectionIDUnsignedDuckDBScan pins the fail-loud regression
+// fix on the buffer write path: ResultRow.ConnectionID is *uint32 and is written
+// via FormatUint, so a value above int32's 2147483647 (a real CONNECTION_ID())
+// must round-trip through the unsigned-widened connection_id column rather than
+// abort the BYOS flush. Read back via DuckDB parquet_scan — the real consumer.
+func TestWriteParquet_connectionIDUnsignedDuckDBScan(t *testing.T) {
+	for _, connID := range []uint32{4294967295, 3000000000} {
+		t.Run(strconv.FormatUint(uint64(connID), 10), func(t *testing.T) {
+			dir := t.TempDir()
+			outPath := filepath.Join(dir, "conn.parquet")
+
+			cid := connID
+			rows := []query.ResultRow{{
+				EventID:        idOffset + 1,
+				BinlogFile:     "binlog.000001",
+				StartPos:       100,
+				EndPos:         200,
+				EventTimestamp: time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+				SchemaName:     "db",
+				TableName:      "t",
+				EventType:      parser.EventInsert,
+				PKValues:       "1",
+				ConnectionID:   &cid,
+				RowAfter:       map[string]any{"id": 1},
+			}}
+
+			n, err := WriteParquet(rows, outPath, "none")
+			if err != nil {
+				t.Fatalf("WriteParquet(connection_id=%d): got error, want round-trip (fail-loud regression): %v", connID, err)
+			}
+			if n != 1 {
+				t.Fatalf("count = %d, want 1", n)
+			}
+
+			db, err := sql.Open("duckdb", "")
+			if err != nil {
+				t.Fatalf("open duckdb: %v", err)
+			}
+			defer db.Close()
+
+			safePath := strings.ReplaceAll(outPath, "'", "''")
+			var conn any
+			if err := db.QueryRowContext(context.Background(),
+				"SELECT connection_id FROM parquet_scan('"+safePath+"')").Scan(&conn); err != nil {
+				t.Fatalf("scan connection_id: %v", err)
+			}
+			got, ok := conn.(int64) // INT UNSIGNED widened to signed Int64 → DuckDB BIGINT
+			if !ok {
+				t.Fatalf("connection_id scanned as %T, want int64", conn)
+			}
+			if got != int64(connID) {
+				t.Errorf("connection_id = %d, want %d", got, connID)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Problem

The mydumper-schema parser (`internal/baseline/schema.go`) captured only the bare type token (`\w+`), **dropping the `UNSIGNED` attribute for every integer width**. Consequently:

- `BIGINT UNSIGNED` in `[2^63, 2^64-1]` failed `ParseInt(raw, 10, 64)`
- `INT/INTEGER UNSIGNED` > 2147483647 failed `ParseInt(raw, 10, 32)`

Both errors hit the **silent NULL-on-error fallback** in `WriteRow` (the bare `store NULL` whose comment claimed "to avoid data loss" while *causing* it). The value was dropped from the baseline snapshot with no error — silent data loss in a data-recovery tool.

## Fix (two coupled parts)

**#506 — UNSIGNED:**
- `colRe` now captures the trailing `unsigned` attribute, matched **only in the type tail** (after the token + optional display width like `int(10)`), so a column literally named `is_unsigned` or a `COMMENT 'unsigned…'` never trips it (the name is isolated in backticks, group 1).
- `Column` gains an `Unsigned bool`. `INT/INTEGER UNSIGNED` → Parquet `INT64`; `BIGINT UNSIGNED` → Parquet `UINT64`. `convertValue` uses `ParseUint` so the full unsigned range round-trips (`BIGINT UNSIGNED` stored by bit pattern: `uint64(v.Int64())` reads it back).
- The **exported `MysqlToParquetNode(string)` signature is unchanged** (signed) — `internal/archive` and `internal/byos` pass bare tokens and keep working; the unsigned-aware variant is internal and threaded through `ParseSchema`.

**#503 item-3 — the silencer:**
- `WriteRow` no longer turns a `convertValue` error into a silent NULL. It **fails loud**, naming the column and raw value, so the run aborts rather than publishing a lossy snapshot — consistent with the project's fail-loud convention (compose empty-dump FATAL, `--allow-gaps` default-abort).

### Behavioral note
Fail-loud means a baseline that previously *silently* NULLed an unconvertible value (e.g. a `0000-00-00` zero-date or a malformed numeric) will now **abort the run** with a located error. That is the intended fix (fail-loud > lossy snapshot), called out here so it isn't later filed as a regression.

## Tests (table-driven, `internal/baseline` unit)
- `TestParseSchemaUnsigned` — pins `Unsigned` per column incl. `int(10) unsigned`, `bigint unsigned zerofill`, an `is_unsigned tinyint` column, and an `unsigned`-in-COMMENT column (both must be `Unsigned=false`).
- `TestConvertValueUnsigned` — `INT UNSIGNED` = 4294967295 and `BIGINT UNSIGNED` = 18446744073709551615 convert without overflow.
- `TestWriteRowUnsignedRoundTrip` — full `WriteRow → Parquet → read-back` for both maxima; neither becomes NULL.
- `TestWriteRowFailsLoudOnUnconvertible` — a bad value through **`WriteRow`** (where the silencer lived) now returns a non-nil error mentioning the column and value.

Verified green: `go build ./...`, `go vet ./internal/baseline/...`, `go test ./internal/baseline/... ./internal/archive/... ./internal/byos/... ./internal/reconstruct/... ./internal/parquetquery/...` (unit), and `go test -tags integration ./internal/baseline/...` (Docker MySQL on :13306).

Closes #506
Addresses #503 item-3 (silent NULL-on-error); items 1 (hex-blob), 2 (GEOMETRY), 4 (column-count guard) remain as follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)