### PR TITLE
feat: fail loud on partial binlog row images

### DIFF
--- a/cmd/bintrail/index.go
+++ b/cmd/bintrail/index.go
@@ -35,15 +35,16 @@ Files already marked 'completed' in index_state are skipped.`,
 }
 
 var (
-	idxIndexDSN  string
-	idxSourceDSN string
-	idxBinlogDir string
-	idxFiles     string
-	idxAll       bool
-	idxBatchSize int
-	idxSchemas   string
-	idxTables    string
-	idxFormat    string
+	idxIndexDSN        string
+	idxSourceDSN       string
+	idxBinlogDir       string
+	idxFiles           string
+	idxAll             bool
+	idxBatchSize       int
+	idxSchemas         string
+	idxTables          string
+	idxFormat          string
+	idxSkipSourceCheck bool
 )
 
 func init() {
@@ -56,6 +57,8 @@ func init() {
 	indexCmd.Flags().StringVar(&idxSchemas, "schemas", "", "Only index events from these schemas (comma-separated)")
 	indexCmd.Flags().StringVar(&idxTables, "tables", "", "Only index these tables (comma-separated, e.g. mydb.orders,mydb.items)")
 	indexCmd.Flags().StringVar(&idxFormat, "format", "text", "Output format: text or json")
+	indexCmd.Flags().BoolVar(&idxSkipSourceCheck, "skip-source-validation", false,
+		"Index offline binlogs without --source-dsn, skipping the binlog_format/binlog_row_image/FK-cascade pre-flight (the per-row partial-image guard still applies)")
 	_ = indexCmd.MarkFlagRequired("index-dsn")
 	_ = indexCmd.MarkFlagRequired("binlog-dir")
 	bindCommandEnv(indexCmd)
@@ -69,6 +72,15 @@ func runIndex(cmd *cobra.Command, args []string) error {
 	}
 	if !idxAll && idxFiles == "" {
 		return fmt.Errorf("either --files or --all must be specified")
+	}
+	// Without --source-dsn the binlog_format/binlog_row_image/FK-cascade
+	// pre-flight cannot run; silently skipping it (the old behavior) let a
+	// non-FULL source be indexed with NULL-filled partial images. Require an
+	// explicit opt-out so offline binlog indexing stays possible while the skip
+	// is never accidental (#493). The per-row partial-image guard in
+	// internal/parser still fires even under the opt-out.
+	if idxSourceDSN == "" && !idxSkipSourceCheck {
+		return fmt.Errorf("--source-dsn is required for source validation; pass --skip-source-validation to index offline binlogs without it")
 	}
 
 	ctx := cmd.Context()
@@ -98,7 +110,7 @@ func runIndex(cmd *cobra.Command, args []string) error {
 		}
 		fmt.Println("Source: no FK cascades \u2713")
 	} else {
-		slog.Warn("--source-dsn not provided; skipping source server validation")
+		slog.Warn("--skip-source-validation set: skipping binlog_format/binlog_row_image/FK-cascade pre-flight — the per-row partial-image guard still applies")
 	}
 
 	// ── 2. Index database connection ──────────────────────────────────────────

--- a/cmd/bintrail/index_test.go
+++ b/cmd/bintrail/index_test.go
@@ -98,10 +98,14 @@ func TestRunIndex_allSetPassesFirstGuard(t *testing.T) {
 // first guard even without --all.
 func TestRunIndex_filesSetPassesFirstGuard(t *testing.T) {
 	savedFiles, savedAll := idxFiles, idxAll
-	t.Cleanup(func() { idxFiles = savedFiles; idxAll = savedAll })
+	savedSkip := idxSkipSourceCheck
+	t.Cleanup(func() { idxFiles = savedFiles; idxAll = savedAll; idxSkipSourceCheck = savedSkip })
 
 	idxFiles = "binlog.000001"
 	idxAll = false
+	// Clear the source guard (#493) so execution again reaches config.Connect —
+	// the first guard under test, not the later --source-dsn requirement.
+	idxSkipSourceCheck = true
 
 	err := runIndex(indexCmd, nil) // fails later at config.Connect
 	if err != nil && strings.Contains(err.Error(), "--files or --all") {

--- a/cmd/bintrail/index_test.go
+++ b/cmd/bintrail/index_test.go
@@ -37,6 +37,7 @@ func TestIndexCmd_requiredFlags(t *testing.T) {
 func TestIndexCmd_allFlagsRegistered(t *testing.T) {
 	for _, name := range []string{
 		"index-dsn", "source-dsn", "binlog-dir", "files", "all", "batch-size", "schemas", "tables",
+		"skip-source-validation",
 	} {
 		if indexCmd.Flag(name) == nil {
 			t.Errorf("flag --%s not registered on indexCmd", name)
@@ -105,6 +106,45 @@ func TestRunIndex_filesSetPassesFirstGuard(t *testing.T) {
 	err := runIndex(indexCmd, nil) // fails later at config.Connect
 	if err != nil && strings.Contains(err.Error(), "--files or --all") {
 		t.Errorf("first guard should not fire when --files is set, got: %v", err)
+	}
+}
+
+// TestRunIndex_requiresSourceOrSkip verifies #493 part 2: without --source-dsn
+// the source pre-flight cannot run, so indexing must fail with an actionable
+// error instead of silently skipping validation. Passing
+// --skip-source-validation is the sanctioned opt-out (for offline binlogs);
+// it then fails later at the index DB connect, not at this guard.
+func TestRunIndex_requiresSourceOrSkip(t *testing.T) {
+	savedFiles, savedAll := idxFiles, idxAll
+	savedSource, savedSkip := idxSourceDSN, idxSkipSourceCheck
+	savedIndex := idxIndexDSN
+	t.Cleanup(func() {
+		idxFiles, idxAll = savedFiles, savedAll
+		idxSourceDSN, idxSkipSourceCheck = savedSource, savedSkip
+		idxIndexDSN = savedIndex
+	})
+
+	idxFiles = "binlog.000001"
+	idxAll = false
+	idxIndexDSN = "user:pass@tcp(127.0.0.1:1)/idx" // unreachable on purpose
+	idxSourceDSN = ""
+
+	// Neither --source-dsn nor --skip-source-validation → fail at the new guard.
+	idxSkipSourceCheck = false
+	err := runIndex(indexCmd, nil)
+	if err == nil {
+		t.Fatal("expected error when neither --source-dsn nor --skip-source-validation is set")
+	}
+	if !strings.Contains(err.Error(), "--source-dsn is required") ||
+		!strings.Contains(err.Error(), "--skip-source-validation") {
+		t.Errorf("guard error should name both flags, got: %v", err)
+	}
+
+	// --skip-source-validation set → past the guard; fails later at index connect.
+	idxSkipSourceCheck = true
+	err = runIndex(indexCmd, nil)
+	if err != nil && strings.Contains(err.Error(), "--source-dsn is required") {
+		t.Errorf("--skip-source-validation should pass the source guard, got: %v", err)
 	}
 }
 

--- a/docs/ddl-tracking.md
+++ b/docs/ddl-tracking.md
@@ -46,6 +46,11 @@ When `--source-dsn` points to the source MySQL server, file mode behaves identic
 
 ### Without `--source-dsn`: Record Only
 
+> **Note:** since the source pre-flight became mandatory (#493), this flow now
+> requires an explicit opt-out — run `bintrail index --skip-source-validation ...`.
+> Without it, `index` aborts because `--source-dsn` is required; the silent
+> no-source skip was removed so a non-`FULL` source can't be indexed by accident.
+
 When no source connection is available (e.g., indexing binlogs from a decommissioned server), dbtrail records the DDL in `schema_changes` and logs a warning:
 
 ```

--- a/docs/indexing.md
+++ b/docs/indexing.md
@@ -36,12 +36,22 @@ bintrail index \
   --all
 ```
 
-With `--source-dsn`, `index` preflights the source
+`--source-dsn` lets `index` preflight the source
 (`binlog_format=ROW`, `binlog_row_image=FULL`, no `ON DELETE/UPDATE CASCADE`
-foreign keys) and auto-snapshots if no snapshot exists yet. `--all` discovers
-and processes every binlog file in `--binlog-dir` in order; `--files` takes an
-explicit comma-separated list. Tune write throughput with `--batch-size`
-(default 1000) and scope with `--schemas` / `--tables`.
+foreign keys) and auto-snapshot if no snapshot exists yet. It is **required**
+unless you pass `--skip-source-validation` to index offline binlogs against an
+already-captured snapshot — the silent skip is gone so a non-`FULL` source can't
+be indexed by accident.
+
+Either way, `index` also guards **every row event**: if a binlog event carries a
+partial row image (the signature of a session-level
+`binlog_row_image=MINIMAL`/`NOBLOB` that the one-shot server-wide check can't
+catch), `index` aborts loudly rather than store the absent columns as `NULL` and
+corrupt the before/after images `recover` relies on.
+
+`--all` discovers and processes every binlog file in `--binlog-dir` in order;
+`--files` takes an explicit comma-separated list. Tune write throughput with
+`--batch-size` (default 1000) and scope with `--schemas` / `--tables`.
 
 ---
 

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -224,7 +224,9 @@ func rewriteInnerHeader(inner, outer *replication.EventHeader) {
 // firstPartialImage reports whether any row image in a RowsEvent omitted
 // columns — the signature of a non-FULL binlog_row_image (MINIMAL/NOBLOB). It
 // returns the absent column indices of the first partial image found, or nil
-// when every image is complete.
+// when every image is complete. The returned indices are go-mysql's 0-based
+// column ordinals (NOT bintrail's 1-based metadata.ColumnMeta.OrdinalPosition);
+// the guard surfaces them verbatim in its error for diagnosis.
 //
 // go-mysql populates RowsEvent.SkippedColumns in lock-step with RowsEvent.Rows:
 // one entry per decoded image (for UPDATE there are two images per logical row —

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -221,6 +221,28 @@ func rewriteInnerHeader(inner, outer *replication.EventHeader) {
 
 // ─── Row event handler ────────────────────────────────────────────────────────
 
+// firstPartialImage reports whether any row image in a RowsEvent omitted
+// columns — the signature of a non-FULL binlog_row_image (MINIMAL/NOBLOB). It
+// returns the absent column indices of the first partial image found, or nil
+// when every image is complete.
+//
+// go-mysql populates RowsEvent.SkippedColumns in lock-step with RowsEvent.Rows:
+// one entry per decoded image (for UPDATE there are two images per logical row —
+// before and after), each listing the column ordinals whose present-bit was
+// clear in the event's column bitmap. Under binlog_row_image=FULL every bit is
+// set, so each entry is an empty (non-nil) slice; under MINIMAL/NOBLOB the
+// omitted columns appear here while go-mysql pads them to nil in Rows.
+// Confirmed empirically against go-mysql v1.13.0, including that a FULL image of
+// a table with a VIRTUAL generated column yields no skips (no false positive).
+func firstPartialImage(skipped [][]int) []int {
+	for _, image := range skipped {
+		if len(image) > 0 {
+			return image
+		}
+	}
+	return nil
+}
+
 // handleRows processes a RowsEvent, resolving column names and dispatching to
 // the appropriate emit function. It is shared by Parser.ParseFile and StreamParser.Run.
 func handleRows(
@@ -271,6 +293,25 @@ func handleRows(
 			"binlog_columns", rowsEv.Table.ColumnCount,
 			"snapshot_columns", len(tm.Columns))
 		return nil
+	}
+
+	// Partial row image guard (#493): bintrail requires binlog_row_image=FULL.
+	// Under MINIMAL/NOBLOB, MySQL omits columns from the before/after image and
+	// go-mysql pads the absent positions to nil — which we would otherwise store
+	// as a genuine NULL, silently corrupting the before/after images that
+	// `recover` later trusts. The server-global SHOW VARIABLES check in
+	// `metadata.ValidateBinlogRowImage` is one-shot and session-settable, so it
+	// can be bypassed; this per-row check is the authoritative chokepoint that
+	// covers BOTH the file-index and stream paths. Fail loud rather than index
+	// NULL-filled rows.
+	if firstSkipped := firstPartialImage(rowsEv.SkippedColumns); firstSkipped != nil {
+		return fmt.Errorf(
+			"partial binlog row image detected at %s:%d for %s.%s (%d column(s) absent: %v); "+
+				"bintrail requires binlog_row_image=FULL — set it server-wide (a session-level "+
+				"override produced this event) and re-generate the binlog, or these events would "+
+				"be indexed with absent columns stored as NULL",
+			filename, binlogEv.Header.LogPos, schema, table,
+			len(firstSkipped), firstSkipped)
 	}
 
 	// LogPos points to the byte AFTER the event. Subtract EventSize to get start.

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"log/slog"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -422,5 +423,136 @@ func TestTimestampUTC(t *testing.T) {
 	}
 	if ts.Unix() != epoch {
 		t.Errorf("expected epoch %d, got %d", epoch, ts.Unix())
+	}
+}
+
+// ─── Partial row image detection (#493) ──────────────────────────────────────
+
+// TestFirstPartialImage matches the shape go-mysql produces in
+// RowsEvent.SkippedColumns: one entry per decoded image, an empty (non-nil)
+// slice under binlog_row_image=FULL and a non-empty slice of absent column
+// ordinals under MINIMAL/NOBLOB. (Shapes confirmed empirically against
+// go-mysql v1.13.0: FULL UPDATE → [[] []], MINIMAL UPDATE → [[1 2 3] [0 2]].)
+func TestFirstPartialImage(t *testing.T) {
+	cases := []struct {
+		name    string
+		skipped [][]int
+		want    []int
+	}{
+		{"nil", nil, nil},
+		{"full_insert_or_delete", [][]int{{}}, nil},
+		{"full_update_both_images", [][]int{{}, {}}, nil},
+		{"minimal_delete_pk_only", [][]int{{1, 2, 3}}, []int{1, 2, 3}},
+		{"minimal_update_before_partial", [][]int{{1, 2, 3}, {0, 2}}, []int{1, 2, 3}},
+		{"minimal_update_only_after_partial", [][]int{{}, {0, 2}}, []int{0, 2}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := firstPartialImage(tc.skipped)
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("firstPartialImage(%v) = %v, want %v", tc.skipped, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestHandleRows_partialImageFailsLoud verifies that a RowsEvent carrying a
+// non-FULL image (some columns absent, as MINIMAL/NOBLOB produces) makes
+// handleRows return an error rather than emitting an event whose absent columns
+// would be stored as NULL. Both the file-index and stream paths return this
+// error directly, so a non-nil result aborts indexing.
+func TestHandleRows_partialImageFailsLoud(t *testing.T) {
+	tm := &metadata.TableMeta{
+		Schema: "shop",
+		Table:  "orders",
+		Columns: []metadata.ColumnMeta{
+			{Name: "id", OrdinalPosition: 1, IsPK: true, DataType: "int"},
+			{Name: "qty", OrdinalPosition: 2, DataType: "int"},
+		},
+		PKColumns: []string{"id"},
+	}
+	resolver := metadata.NewResolverFromTables(1, map[string]*metadata.TableMeta{"shop.orders": tm})
+
+	binlogEv := &replication.BinlogEvent{
+		Header: &replication.EventHeader{
+			EventType: replication.UPDATE_ROWS_EVENTv2,
+			LogPos:    300,
+			EventSize: 100,
+		},
+		Event: &replication.RowsEvent{
+			Table: &replication.TableMapEvent{
+				Schema:      []byte("shop"),
+				Table:       []byte("orders"),
+				ColumnCount: 2,
+			},
+			// Before-image PK-only (qty absent → padded nil), after-image full.
+			Rows: [][]any{{int64(1), nil}, {int64(1), int64(9)}},
+			// MINIMAL before-image skips ordinal 1 (qty); after-image complete.
+			SkippedColumns: [][]int{{1}, {}},
+		},
+	}
+	rowsEv := binlogEv.Event.(*replication.RowsEvent)
+
+	out := make(chan Event, 4)
+	err := handleRows(context.Background(), newTestLogger(&bytes.Buffer{}), resolver, &Filters{}, binlogEv, rowsEv, "binlog.000001", "0-1-1", 0, 1, out)
+	if err == nil {
+		t.Fatal("expected handleRows to fail loud on a partial row image, got nil")
+	}
+	if !strings.Contains(err.Error(), "partial binlog row image") {
+		t.Errorf("error should name the partial-image cause, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "FULL") {
+		t.Errorf("error should mention binlog_row_image=FULL, got: %v", err)
+	}
+	select {
+	case ev := <-out:
+		t.Errorf("no event must be emitted for a partial image; got %+v", ev)
+	default:
+	}
+}
+
+// TestHandleRows_fullImagePasses confirms the detector does not false-positive
+// on a FULL image, where every SkippedColumns entry is an empty slice (the
+// shape go-mysql produces even for a table containing a VIRTUAL generated
+// column — confirmed empirically against go-mysql v1.13.0).
+func TestHandleRows_fullImagePasses(t *testing.T) {
+	tm := &metadata.TableMeta{
+		Schema: "shop",
+		Table:  "orders",
+		Columns: []metadata.ColumnMeta{
+			{Name: "id", OrdinalPosition: 1, IsPK: true, DataType: "int"},
+			{Name: "qty", OrdinalPosition: 2, DataType: "int"},
+		},
+		PKColumns: []string{"id"},
+	}
+	resolver := metadata.NewResolverFromTables(1, map[string]*metadata.TableMeta{"shop.orders": tm})
+
+	binlogEv := &replication.BinlogEvent{
+		Header: &replication.EventHeader{
+			EventType: replication.UPDATE_ROWS_EVENTv2,
+			LogPos:    300,
+			EventSize: 100,
+		},
+		Event: &replication.RowsEvent{
+			Table: &replication.TableMapEvent{
+				Schema:      []byte("shop"),
+				Table:       []byte("orders"),
+				ColumnCount: 2,
+			},
+			Rows:           [][]any{{int64(1), int64(5)}, {int64(1), int64(9)}},
+			SkippedColumns: [][]int{{}, {}},
+		},
+	}
+	rowsEv := binlogEv.Event.(*replication.RowsEvent)
+
+	out := make(chan Event, 4)
+	if err := handleRows(context.Background(), newTestLogger(&bytes.Buffer{}), resolver, &Filters{}, binlogEv, rowsEv, "binlog.000001", "0-1-1", 0, 1, out); err != nil {
+		t.Fatalf("handleRows must not fail on a FULL image, got: %v", err)
+	}
+	select {
+	case <-out:
+		// expected: the UPDATE event was emitted
+	default:
+		t.Error("expected an UPDATE event to be emitted for a FULL image")
 	}
 }

--- a/internal/parser/partial_image_integration_test.go
+++ b/internal/parser/partial_image_integration_test.go
@@ -121,4 +121,103 @@ func TestParseFile_partialRowImageFailsLoud(t *testing.T) {
 			t.Errorf("partial UPDATE must not be emitted (it would store absent columns as NULL); got %+v", ev)
 		}
 	}
+
+	// NOBLOB is the same code path: it produces the identical SkippedColumns
+	// shape (a non-empty per-image slice naming the omitted BLOB/TEXT ordinals),
+	// so the per-row guard fires there too. We exercise MINIMAL here because it
+	// drops columns from any table; NOBLOB would need a BLOB/TEXT column left
+	// unchanged across the UPDATE to trip the same branch with no extra coverage.
+}
+
+// TestParseFile_fullImageWithVirtualColumnNotPartial pins the PR's central safety
+// claim: a FULL-image UPDATE on a table that carries a VIRTUAL generated column
+// must NOT false-positive the partial-row-image guard. Under
+// binlog_row_image=FULL, MySQL logs the virtual column's computed value, so its
+// present-bit is set and it never lands in RowsEvent.SkippedColumns — the
+// detector sees an all-empty shape and the event flows through unblocked.
+//
+// The unit tier (TestHandleRows_fullImagePasses) can only assert this against a
+// hand-built [][]int slice, which is circular by construction. This drives a real
+// go-mysql decode of a real binlog so a future dependency/server bump that
+// changed virtual-column bitmap handling would surface here in CI — as a loud
+// false-positive abort blocking a healthy FULL table — rather than in production.
+func TestParseFile_fullImageWithVirtualColumnNotPartial(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	ctx := context.Background()
+
+	sourceDB, sourceName := testutil.CreateTestDB(t)
+	indexDB, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, indexDB)
+
+	// `total` is a VIRTUAL generated column — the case the guard must not flag.
+	testutil.MustExec(t, sourceDB, `CREATE TABLE p (
+		id    INT PRIMARY KEY,
+		qty   INT NOT NULL,
+		total INT AS (qty * 2) VIRTUAL,
+		note  VARCHAR(64) NOT NULL
+	)`)
+
+	stats, err := metadata.TakeSnapshot(sourceDB, indexDB, []string{sourceName})
+	if err != nil {
+		t.Fatalf("TakeSnapshot failed: %v", err)
+	}
+	res, err := metadata.NewResolver(indexDB, stats.SnapshotID)
+	if err != nil {
+		t.Fatalf("NewResolver failed: %v", err)
+	}
+
+	// Everything runs under FULL: seed, rotate to an isolated binlog, mutate.
+	conn, err := sourceDB.Conn(ctx)
+	if err != nil {
+		t.Fatalf("acquire pinned conn: %v", err)
+	}
+	defer conn.Close()
+	mustExecConn := func(q string) {
+		t.Helper()
+		if _, err := conn.ExecContext(ctx, q); err != nil {
+			t.Fatalf("exec %q: %v", q, err)
+		}
+	}
+
+	mustExecConn("SET SESSION binlog_row_image = FULL")
+	mustExecConn(`INSERT INTO p (id, qty, note) VALUES (1, 10, 'a')`)
+	mustExecConn("FLUSH BINARY LOGS")
+	currentBinlog, _, err := config.CurrentBinlogPosition(sourceDB)
+	if err != nil {
+		t.Fatalf("CurrentBinlogPosition failed: %v", err)
+	}
+	// A non-PK UPDATE under FULL: the before-image carries every column
+	// (qty + note, and the computed total) — no column is absent.
+	mustExecConn(`UPDATE p SET qty = 99 WHERE id = 1`)
+	mustExecConn("FLUSH BINARY LOGS")
+
+	tmpDir := t.TempDir()
+	cpCmd := exec.Command("docker", "cp",
+		fmt.Sprintf("bintrail-test-mysql:/var/lib/mysql/%s", currentBinlog),
+		filepath.Join(tmpDir, currentBinlog),
+	)
+	if out, err := cpCmd.CombinedOutput(); err != nil {
+		t.Fatalf("docker cp %s failed: %v\n%s", currentBinlog, err, out)
+	}
+
+	p := parser.New(tmpDir, res, parser.Filters{Schemas: map[string]bool{sourceName: true}}, nil)
+	events := make(chan parser.Event, 50)
+	errCh := make(chan error, 1)
+	go func() {
+		defer close(events)
+		errCh <- p.ParseFile(ctx, currentBinlog, events)
+	}()
+
+	var sawUpdate bool
+	for ev := range events {
+		if ev.Table == "p" && ev.EventType == parser.EventUpdate {
+			sawUpdate = true
+		}
+	}
+	if err := <-errCh; err != nil {
+		t.Fatalf("FULL-image UPDATE on a VIRTUAL-column table must not trip the partial-image guard, got: %v", err)
+	}
+	if !sawUpdate {
+		t.Error("expected the FULL UPDATE on the VIRTUAL-column table to be emitted")
+	}
 }

--- a/internal/parser/partial_image_integration_test.go
+++ b/internal/parser/partial_image_integration_test.go
@@ -1,0 +1,124 @@
+//go:build integration
+
+package parser_test
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/config"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/parser"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestParseFile_partialRowImageFailsLoud is the end-to-end repro for #493: when a
+// session sets binlog_row_image=MINIMAL (bypassing the server-global SHOW
+// VARIABLES pre-flight), the resulting UPDATE/DELETE events carry partial row
+// images — go-mysql pads the absent columns to nil. Without the per-row guard
+// those NULLs would be indexed as genuine column values, silently corrupting the
+// before/after images that `recover` trusts. The guard must instead abort
+// parsing with a clear error and emit nothing for the partial event.
+func TestParseFile_partialRowImageFailsLoud(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	ctx := context.Background()
+
+	sourceDB, sourceName := testutil.CreateTestDB(t)
+	indexDB, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, indexDB)
+
+	// A PK is required for MINIMAL to actually drop columns: without one, MySQL
+	// logs the full before-image and no skip occurs.
+	testutil.MustExec(t, sourceDB, `CREATE TABLE p (
+		id   INT PRIMARY KEY,
+		qty  INT NOT NULL,
+		note VARCHAR(64) NOT NULL
+	)`)
+
+	stats, err := metadata.TakeSnapshot(sourceDB, indexDB, []string{sourceName})
+	if err != nil {
+		t.Fatalf("TakeSnapshot failed: %v", err)
+	}
+	res, err := metadata.NewResolver(indexDB, stats.SnapshotID)
+	if err != nil {
+		t.Fatalf("NewResolver failed: %v", err)
+	}
+
+	// SET SESSION is per-connection, so pin ONE connection for the whole
+	// seed→MINIMAL→mutate sequence — running it on the pooled *sql.DB would not
+	// guarantee the SET and the UPDATE land on the same connection.
+	conn, err := sourceDB.Conn(ctx)
+	if err != nil {
+		t.Fatalf("acquire pinned conn: %v", err)
+	}
+	defer conn.Close()
+	mustExecConn := func(q string) {
+		t.Helper()
+		if _, err := conn.ExecContext(ctx, q); err != nil {
+			t.Fatalf("exec %q: %v", q, err)
+		}
+	}
+
+	// Seed under FULL so the row exists, then switch the SESSION to MINIMAL and
+	// mutate — this is exactly the bypass the server-global check cannot catch.
+	mustExecConn("SET SESSION binlog_row_image = FULL")
+	mustExecConn(`INSERT INTO p (id, qty, note) VALUES (1, 10, 'a')`)
+
+	mustExecConn("SET SESSION binlog_row_image = MINIMAL")
+	mustExecConn("FLUSH BINARY LOGS")
+	currentBinlog, _, err := config.CurrentBinlogPosition(sourceDB)
+	if err != nil {
+		t.Fatalf("CurrentBinlogPosition failed: %v", err)
+	}
+	// Update a non-PK column: the UPDATE before-image is PK-only (qty + note
+	// absent) — the partial-image case.
+	mustExecConn(`UPDATE p SET qty = 99 WHERE id = 1`)
+	// Restore so we don't leak the session setting; FLUSH closes the test binlog.
+	mustExecConn("SET SESSION binlog_row_image = FULL")
+	mustExecConn("FLUSH BINARY LOGS")
+
+	tmpDir := t.TempDir()
+	cpCmd := exec.Command("docker", "cp",
+		fmt.Sprintf("bintrail-test-mysql:/var/lib/mysql/%s", currentBinlog),
+		filepath.Join(tmpDir, currentBinlog),
+	)
+	if out, err := cpCmd.CombinedOutput(); err != nil {
+		t.Fatalf("docker cp %s failed: %v\n%s", currentBinlog, err, out)
+	}
+
+	p := parser.New(tmpDir, res, parser.Filters{Schemas: map[string]bool{sourceName: true}}, nil)
+	events := make(chan parser.Event, 50)
+	errCh := make(chan error, 1)
+	go func() {
+		defer close(events)
+		errCh <- p.ParseFile(ctx, currentBinlog, events)
+	}()
+
+	var got []parser.Event
+	for ev := range events {
+		if ev.Table == "p" {
+			got = append(got, ev)
+		}
+	}
+	err = <-errCh
+	if err == nil {
+		t.Fatalf("expected ParseFile to fail loud on the MINIMAL UPDATE, got nil (events: %+v)", got)
+	}
+	if !strings.Contains(err.Error(), "partial binlog row image") {
+		t.Errorf("error should name the partial-image cause, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "FULL") {
+		t.Errorf("error should mention binlog_row_image=FULL, got: %v", err)
+	}
+	// Critically: the partial UPDATE must NOT have been emitted as an event whose
+	// absent columns are stored as NULL.
+	for _, ev := range got {
+		if ev.EventType == parser.EventUpdate {
+			t.Errorf("partial UPDATE must not be emitted (it would store absent columns as NULL); got %+v", ev)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`binlog_row_image=FULL` enforcement was a one-shot, server-global
`SHOW VARIABLES LIKE 'binlog_row_image'` (`metadata.ValidateBinlogRowImage`) —
session-settable, thus **bypassable**. When bypassed (e.g. a client doing
`SET SESSION binlog_row_image=MINIMAL`), the resulting UPDATE/DELETE events carry
**partial row images**. go-mysql pads the absent columns to `nil`, and bintrail
stored those as genuine `NULL`s — silently corrupting the before/after images
that `recover` later trusts. Plus `bintrail index` skipped source validation
**entirely and silently** when `--source-dsn` was omitted.

This is the last open item of the binlog-fidelity audit (#493).

## Fix

**Core — per-row partial-image detector** in the shared `handleRows` chokepoint
in `internal/parser/parser.go`, so it covers **both** the file-index
(`ParseFile`) and `StreamParser` paths in one place. When any row image omitted
columns, `handleRows` returns an error instead of storing NULL-filled rows. Both
call sites `return handleRows(...)` directly, and both outer loops treat a
non-nil result as fatal (file path → `parseErrCh` abort; stream path →
`StreamParser.Run` returns the error), so the abort is real on both.

**Detection API:** `RowsEvent.SkippedColumns` (go-mysql v1.13.0). go-mysql
populates it in lock-step with `Rows` — one entry per decoded image (UPDATE has
two: before + after), each listing the column ordinals whose present-bit was
clear in the event's column bitmap. Under `FULL` every entry is an empty
(non-nil) slice; under MINIMAL/NOBLOB the absent columns appear there while
go-mysql pads them to `nil`. The detector keys on `len(image) > 0`.

**Empirically verified** against go-mysql v1.13.0 / MySQL 8.x with a throwaway
probe before implementing:

| image  | WRITE      | UPDATE              | DELETE       |
|--------|------------|---------------------|--------------|
| FULL   | `[[]]`     | `[[] []]`           | `[[]]`       |
| MINIMAL| `[[]]`     | `[[1 2 3] [0 2]]`   | `[[1 2 3]]`  |

The probe table included a `VIRTUAL` generated column: `columnCount=4` includes
it, yet a FULL image still yields **zero skips** — so the detector does not
false-positive on virtual columns. (Residual boundary, noted for future readers:
the only way it could over-fire on a healthy table is a hypothetical MySQL
version where TABLE_MAP includes a virtual column but the row image clears its
bit; even then the failure mode is a loud, clearly-messaged abort, not silent
corruption.) Note INSERT after-images are full even under MINIMAL, so the
trigger is UPDATE/DELETE.

**CLI — kill the silent skip.** `bintrail index` now requires `--source-dsn`, or
an explicit `--skip-source-validation` opt-out for indexing offline binlogs
against an already-captured snapshot. The per-row guard still applies under the
opt-out, so offline indexing stays protected. `stream` is unchanged (already
requires `--source-dsn`).

## Tests

- **Unit** (`internal/parser/parser_test.go`): table-driven `TestFirstPartialImage`
  over the exact go-mysql `SkippedColumns` shapes; `TestHandleRows_partialImageFailsLoud`
  (fabricated partial UPDATE → error, no event emitted);
  `TestHandleRows_fullImagePasses` (FULL → emits, no false positive).
- **Unit** (`cmd/bintrail/index_test.go`): `TestRunIndex_requiresSourceOrSkip`
  (no `--source-dsn` and no opt-out → actionable error; opt-out → past the guard).
- **Integration** (`internal/parser/partial_image_integration_test.go`,
  `//go:build integration`): sets `binlog_row_image=MINIMAL` at session level on a
  **pinned connection**, generates a partial UPDATE, copies the binlog, and asserts
  `ParseFile` fails loud and emits no NULL-filled event.

### Evidence (ran against Docker MySQL on :13306)

```
go build ./...                                                 ok
go vet ./internal/parser/... ./internal/metadata/... ./cmd/bintrail/...  ok
go test ./internal/parser/... ./internal/metadata/...         ok
go test -tags integration ./internal/parser/                  ok  (full suite — no FULL-image false positives)
go test -tags integration ./internal/parser/ -run TestParseFile_partialRowImageFailsLoud  PASS
```

Closes #493

🤖 Generated with [Claude Code](https://claude.com/claude-code)