### PR TITLE
feat: DBA-centric bintrail_index_* metrics + index/baseline size in status

### DIFF
--- a/cmd/bintrail-console/watch.go
+++ b/cmd/bintrail-console/watch.go
@@ -53,17 +53,18 @@ Examples:
 }
 
 var (
-	upSourceDSN   string
-	upIndexDSN    string
-	upServerID    uint32
-	upSchemas     string
-	upTables      string
-	upBatchSize   int
-	upCheckpoint  int
-	upMetricsAddr string
-	upPartitions  int
-	upSkipDoctor  bool
-	upFormat      string
+	upSourceDSN             string
+	upIndexDSN              string
+	upServerID              uint32
+	upSchemas               string
+	upTables                string
+	upBatchSize             int
+	upCheckpoint            int
+	upMetricsAddr           string
+	upMetricsScrapeInterval int
+	upPartitions            int
+	upSkipDoctor            bool
+	upFormat                string
 
 	upConsoleListen      string
 	upConsoleToken       string
@@ -104,6 +105,7 @@ var watchEnvBindings = []struct {
 	{"server-id", "BINTRAIL_SERVER_ID"},
 	{"batch-size", "BINTRAIL_BATCH_SIZE"},
 	{"metrics-addr", "BINTRAIL_METRICS_ADDR"},
+	{"metrics-scrape-interval", "BINTRAIL_METRICS_SCRAPE_INTERVAL"},
 	{"rotate-retain", "BINTRAIL_ROTATE_RETAIN"},
 	{"rotate-interval", "BINTRAIL_ROTATE_INTERVAL"},
 	{"rotate-add-future", "BINTRAIL_ROTATE_ADD_FUTURE"},
@@ -140,6 +142,7 @@ func init() {
 	watchCmd.Flags().IntVar(&upBatchSize, "batch-size", 1000, "Events per batch INSERT")
 	watchCmd.Flags().IntVar(&upCheckpoint, "checkpoint", 10, "Checkpoint interval in seconds")
 	watchCmd.Flags().StringVar(&upMetricsAddr, "metrics-addr", "", "Address to expose Prometheus metrics (e.g. :9090); empty = disabled")
+	watchCmd.Flags().IntVar(&upMetricsScrapeInterval, "metrics-scrape-interval", 60, "How often (seconds) to refresh the bintrail_index_* gauges from a status snapshot")
 	watchCmd.Flags().IntVar(&upPartitions, "partitions", 48, "Hourly partitions to create on first init")
 	watchCmd.Flags().BoolVar(&upSkipDoctor, "skip-doctor", false, "Skip the preflight checks (useful when you've already verified with `bintrail doctor`)")
 	watchCmd.Flags().StringVar(&upFormat, "format", "text", "Output format: text or json")
@@ -528,7 +531,12 @@ func watchStreamConfig(serverID uint32) streamrun.Config {
 		SSLMode:    "preferred",
 		Format:     upFormat,
 		GapTimeout: 30,
-		Deps:       streamdeps.Default(),
+		// The daemon serves /metrics centrally, so the primary stream sets
+		// neither MetricsAddr nor MetricsSource — IndexMetrics turns the
+		// bintrail_index_* scraper on for it when the daemon exposes metrics.
+		IndexMetrics:          upMetricsAddr != "",
+		MetricsScrapeInterval: upMetricsScrapeInterval,
+		Deps:                  streamdeps.Default(),
 	}
 }
 

--- a/cmd/bintrail-console/watch_test.go
+++ b/cmd/bintrail-console/watch_test.go
@@ -162,12 +162,13 @@ func TestResolveUpConsoleEnv(t *testing.T) {
 // future "let me delete this unused field" refactor can't change behavior.
 func TestWatchStreamConfig(t *testing.T) {
 	orig := struct {
-		src, idx, sch, tbl, fmtv string
-		batch, chk               int
-	}{upSourceDSN, upIndexDSN, upSchemas, upTables, upFormat, upBatchSize, upCheckpoint}
+		src, idx, sch, tbl, fmtv, met string
+		batch, chk, msi               int
+	}{upSourceDSN, upIndexDSN, upSchemas, upTables, upFormat, upMetricsAddr, upBatchSize, upCheckpoint, upMetricsScrapeInterval}
 	t.Cleanup(func() {
 		upSourceDSN, upIndexDSN, upSchemas, upTables, upFormat = orig.src, orig.idx, orig.sch, orig.tbl, orig.fmtv
 		upBatchSize, upCheckpoint = orig.batch, orig.chk
+		upMetricsAddr, upMetricsScrapeInterval = orig.met, orig.msi
 	})
 
 	upSourceDSN = "user:pass@tcp(source.example.com:3306)/src"
@@ -177,6 +178,8 @@ func TestWatchStreamConfig(t *testing.T) {
 	upBatchSize = 2500
 	upCheckpoint = 15
 	upFormat = "json"
+	upMetricsAddr = "" // primary stream gates index metrics on this being set
+	upMetricsScrapeInterval = 33
 
 	const passedServerID uint32 = 4242424242
 	cfg := watchStreamConfig(passedServerID)
@@ -203,6 +206,20 @@ func TestWatchStreamConfig(t *testing.T) {
 	// The daemon serves ONE /metrics endpoint for all streams; a per-stream
 	// bind here would conflict with it.
 	assertStr(t, "MetricsAddr", cfg.MetricsAddr, "")
+	if cfg.MetricsScrapeInterval != 33 {
+		t.Errorf("MetricsScrapeInterval = %d, want 33", cfg.MetricsScrapeInterval)
+	}
+	// IndexMetrics is the load-bearing wiring for the daemon's OWN primary
+	// stream (it sets neither MetricsAddr nor MetricsSource): it must be ON iff
+	// the daemon exposes /metrics (upMetricsAddr set), else the index gauges are
+	// silently never scraped.
+	if cfg.IndexMetrics {
+		t.Error("IndexMetrics = true with --metrics-addr unset, want false")
+	}
+	upMetricsAddr = ":9090"
+	if got := watchStreamConfig(passedServerID); !got.IndexMetrics {
+		t.Error("IndexMetrics = false with --metrics-addr set, want true")
+	}
 	if cfg.StartPos != 4 {
 		t.Errorf("StartPos = %d, want 4 (binlog magic-number header end)", cfg.StartPos)
 	}

--- a/cmd/bintrail/config.go
+++ b/cmd/bintrail/config.go
@@ -137,6 +137,7 @@ var envSections = []envSection{
 			{"BINTRAIL_SERVER_ID", ""},
 			{"BINTRAIL_BATCH_SIZE", "1000"},
 			{"BINTRAIL_METRICS_ADDR", ""},
+			{"BINTRAIL_METRICS_SCRAPE_INTERVAL", "60"},
 			{"BINTRAIL_STREAM_GAP_TIMEOUT", "30"},
 		},
 	},

--- a/cmd/bintrail/envload.go
+++ b/cmd/bintrail/envload.go
@@ -39,6 +39,7 @@ var envBindings = []envBinding{
 	{"s3-region", "BINTRAIL_S3_REGION"},
 	{"s3-arn", "BINTRAIL_S3_ARN"},
 	{"metrics-addr", "BINTRAIL_METRICS_ADDR"},
+	{"metrics-scrape-interval", "BINTRAIL_METRICS_SCRAPE_INTERVAL"},
 	{"ssl-mode", "BINTRAIL_SSL_MODE"},
 	{"ssl-ca", "BINTRAIL_SSL_CA"},
 	{"ssl-cert", "BINTRAIL_SSL_CERT"},

--- a/cmd/bintrail/status.go
+++ b/cmd/bintrail/status.go
@@ -87,6 +87,8 @@ func runStatus(cmd *cobra.Command, args []string) error {
 				var size int64
 				if fi, sErr := os.Stat(b.Path); sErr == nil {
 					size = fi.Size()
+				} else {
+					slog.Warn("could not stat baseline file for size", "path", b.Path, "error", sErr)
 				}
 				data.Baselines = append(data.Baselines, status.BaselineInfo{
 					SnapshotTime: b.SnapshotTime,

--- a/cmd/bintrail/status.go
+++ b/cmd/bintrail/status.go
@@ -84,6 +84,10 @@ func runStatus(cmd *cobra.Command, args []string) error {
 			slog.Warn("could not discover baselines", "dir", stBaselineDir, "error", bErr)
 		} else {
 			for _, b := range baselines {
+				var size int64
+				if fi, sErr := os.Stat(b.Path); sErr == nil {
+					size = fi.Size()
+				}
 				data.Baselines = append(data.Baselines, status.BaselineInfo{
 					SnapshotTime: b.SnapshotTime,
 					Database:     b.Database,
@@ -92,6 +96,7 @@ func runStatus(cmd *cobra.Command, args []string) error {
 					BinlogPos:    b.BinlogPos,
 					GTIDSet:      b.GTIDSet,
 					Path:         b.Path,
+					Size:         size,
 				})
 			}
 		}

--- a/cmd/bintrail/stream.go
+++ b/cmd/bintrail/stream.go
@@ -50,26 +50,27 @@ a checkpoint before exiting.`,
 }
 
 var (
-	strmIndexDSN    string
-	strmSourceDSN   string
-	strmFlavor      string
-	strmServerID    uint32
-	strmStartFile   string
-	strmStartPos    uint32
-	strmStartGTID   string
-	strmBatchSize   int
-	strmSchemas     string
-	strmTables      string
-	strmCheckpoint  int
-	strmMetricsAddr string
-	strmSSLMode     string
-	strmSSLCA       string
-	strmSSLCert     string
-	strmSSLKey      string
-	strmFormat      string
-	strmReset       bool
-	strmNoGapFill   bool
-	strmGapTimeout  int
+	strmIndexDSN              string
+	strmSourceDSN             string
+	strmFlavor                string
+	strmServerID              uint32
+	strmStartFile             string
+	strmStartPos              uint32
+	strmStartGTID             string
+	strmBatchSize             int
+	strmSchemas               string
+	strmTables                string
+	strmCheckpoint            int
+	strmMetricsAddr           string
+	strmMetricsScrapeInterval int
+	strmSSLMode               string
+	strmSSLCA                 string
+	strmSSLCert               string
+	strmSSLKey                string
+	strmFormat                string
+	strmReset                 bool
+	strmNoGapFill             bool
+	strmGapTimeout            int
 )
 
 func init() {
@@ -85,6 +86,7 @@ func init() {
 	streamCmd.Flags().StringVar(&strmTables, "tables", "", "Only index these tables (comma-separated, e.g. mydb.orders)")
 	streamCmd.Flags().IntVar(&strmCheckpoint, "checkpoint", 10, "Checkpoint interval in seconds")
 	streamCmd.Flags().StringVar(&strmMetricsAddr, "metrics-addr", "", "Address to expose Prometheus metrics (e.g. :9090); empty = disabled")
+	streamCmd.Flags().IntVar(&strmMetricsScrapeInterval, "metrics-scrape-interval", 60, "How often (seconds) to refresh the bintrail_index_* gauges from a status snapshot")
 	streamCmd.Flags().StringVar(&strmSSLMode, "ssl-mode", "preferred", "TLS mode: disabled, preferred, required, verify-ca, verify-identity")
 	streamCmd.Flags().StringVar(&strmSSLCA, "ssl-ca", "", "Path to CA certificate file for TLS verification (omit to use system CAs)")
 	streamCmd.Flags().StringVar(&strmSSLCert, "ssl-cert", "", "Path to client certificate file for mutual TLS")
@@ -107,27 +109,28 @@ func init() {
 // become values, with the host-supplied Deps attached.
 func streamConfigFromFlags() streamrun.Config {
 	return streamrun.Config{
-		IndexDSN:    strmIndexDSN,
-		SourceDSN:   strmSourceDSN,
-		Flavor:      strmFlavor,
-		ServerID:    strmServerID,
-		StartFile:   strmStartFile,
-		StartPos:    strmStartPos,
-		StartGTID:   strmStartGTID,
-		BatchSize:   strmBatchSize,
-		Schemas:     strmSchemas,
-		Tables:      strmTables,
-		Checkpoint:  strmCheckpoint,
-		MetricsAddr: strmMetricsAddr,
-		SSLMode:     strmSSLMode,
-		SSLCA:       strmSSLCA,
-		SSLCert:     strmSSLCert,
-		SSLKey:      strmSSLKey,
-		Format:      strmFormat,
-		Reset:       strmReset,
-		NoGapFill:   strmNoGapFill,
-		GapTimeout:  strmGapTimeout,
-		Deps:        streamdeps.Default(),
+		IndexDSN:              strmIndexDSN,
+		SourceDSN:             strmSourceDSN,
+		Flavor:                strmFlavor,
+		ServerID:              strmServerID,
+		StartFile:             strmStartFile,
+		StartPos:              strmStartPos,
+		StartGTID:             strmStartGTID,
+		BatchSize:             strmBatchSize,
+		Schemas:               strmSchemas,
+		Tables:                strmTables,
+		Checkpoint:            strmCheckpoint,
+		MetricsAddr:           strmMetricsAddr,
+		MetricsScrapeInterval: strmMetricsScrapeInterval,
+		SSLMode:               strmSSLMode,
+		SSLCA:                 strmSSLCA,
+		SSLCert:               strmSSLCert,
+		SSLKey:                strmSSLKey,
+		Format:                strmFormat,
+		Reset:                 strmReset,
+		NoGapFill:             strmNoGapFill,
+		GapTimeout:            strmGapTimeout,
+		Deps:                  streamdeps.Default(),
 	}
 }
 

--- a/cmd/bintrail/stream_test.go
+++ b/cmd/bintrail/stream_test.go
@@ -163,7 +163,7 @@ func TestStreamConfigFromFlags(t *testing.T) {
 	orig := struct {
 		src, idx, file, gtid, sch, tbl, met, fmtv, ssl, ca, cert, key, flavor string
 		sid, pos                                                              uint32
-		batch, chk, gap                                                       int
+		batch, chk, gap, msi                                                  int
 		reset, noGap                                                          bool
 	}{
 		src: strmSourceDSN, idx: strmIndexDSN, file: strmStartFile,
@@ -172,6 +172,7 @@ func TestStreamConfigFromFlags(t *testing.T) {
 		ca: strmSSLCA, cert: strmSSLCert, key: strmSSLKey, flavor: strmFlavor,
 		sid: strmServerID, pos: strmStartPos,
 		batch: strmBatchSize, chk: strmCheckpoint, gap: strmGapTimeout,
+		msi:   strmMetricsScrapeInterval,
 		reset: strmReset, noGap: strmNoGapFill,
 	}
 	t.Cleanup(func() {
@@ -181,6 +182,7 @@ func TestStreamConfigFromFlags(t *testing.T) {
 		strmSSLCA, strmSSLCert, strmSSLKey = orig.ca, orig.cert, orig.key
 		strmServerID, strmStartPos = orig.sid, orig.pos
 		strmBatchSize, strmCheckpoint, strmGapTimeout = orig.batch, orig.chk, orig.gap
+		strmMetricsScrapeInterval = orig.msi
 		strmReset, strmNoGapFill = orig.reset, orig.noGap
 		strmFlavor = orig.flavor
 	})
@@ -197,6 +199,7 @@ func TestStreamConfigFromFlags(t *testing.T) {
 	strmTables = "mydb.orders"
 	strmCheckpoint = 17
 	strmMetricsAddr = ":9191"
+	strmMetricsScrapeInterval = 45
 	strmSSLMode = "verify-ca"
 	strmSSLCA = "/tmp/ca.pem"
 	strmSSLCert = "/tmp/cert.pem"
@@ -217,26 +220,27 @@ func TestStreamConfigFromFlags(t *testing.T) {
 	// strm* → field snapshot, so zero it before the struct comparison.
 	got.Deps = streamrun.Deps{}
 	want := streamrun.Config{
-		IndexDSN:    "ix:pw@tcp(127.0.0.1:3306)/binlog_index",
-		SourceDSN:   "user:pass@tcp(source.example.com:3306)/src",
-		Flavor:      "mariadb",
-		ServerID:    424242,
-		StartFile:   "mysql-bin.000777",
-		StartPos:    1234,
-		StartGTID:   "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-5",
-		BatchSize:   333,
-		Schemas:     "mydb,otherdb",
-		Tables:      "mydb.orders",
-		Checkpoint:  17,
-		MetricsAddr: ":9191",
-		SSLMode:     "verify-ca",
-		SSLCA:       "/tmp/ca.pem",
-		SSLCert:     "/tmp/cert.pem",
-		SSLKey:      "/tmp/key.pem",
-		Format:      "json",
-		Reset:       true,
-		NoGapFill:   true,
-		GapTimeout:  99,
+		IndexDSN:              "ix:pw@tcp(127.0.0.1:3306)/binlog_index",
+		SourceDSN:             "user:pass@tcp(source.example.com:3306)/src",
+		Flavor:                "mariadb",
+		ServerID:              424242,
+		StartFile:             "mysql-bin.000777",
+		StartPos:              1234,
+		StartGTID:             "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-5",
+		BatchSize:             333,
+		Schemas:               "mydb,otherdb",
+		Tables:                "mydb.orders",
+		Checkpoint:            17,
+		MetricsAddr:           ":9191",
+		MetricsScrapeInterval: 45,
+		SSLMode:               "verify-ca",
+		SSLCA:                 "/tmp/ca.pem",
+		SSLCert:               "/tmp/cert.pem",
+		SSLKey:                "/tmp/key.pem",
+		Format:                "json",
+		Reset:                 true,
+		NoGapFill:             true,
+		GapTimeout:            99,
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("streamConfigFromFlags mismatch:\n got: %+v\nwant: %+v", got, want)

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,98 @@
+# Observability
+
+`bintrail stream` (and the `bintrail-console watch` control plane) expose
+Prometheus metrics describing both the **live replication pipeline** and the
+**state of the index** a DBA cares about for recovery readiness.
+
+Enable the endpoint on a standalone stream with `--metrics-addr`:
+
+```bash
+bintrail stream --metrics-addr :9090 --index-dsn ... --source-dsn ... --server-id 100
+# scrape http://localhost:9090/metrics
+```
+
+Under `bintrail-console watch` the daemon serves one `/metrics` endpoint for
+every monitored source; the per-source `source` label keeps them distinct.
+
+Every metric carries a `source` label (the supervisor's entry ID when
+monitored, else the resolved `bintrail_id`, or `default`).
+
+## Stream metrics (`bintrail_stream_*`)
+
+The live pipeline — emitted on the hot path as events flow.
+
+| Metric | Type | Meaning |
+|---|---|---|
+| `bintrail_stream_events_received_total` | counter | Row events received from the replication stream |
+| `bintrail_stream_events_indexed_total` | counter | Row events written to `binlog_events` |
+| `bintrail_stream_batch_flushes_total` | counter | Batch INSERT operations executed |
+| `bintrail_stream_checkpoint_saves_total` | counter | Successful checkpoint saves |
+| `bintrail_stream_last_event_timestamp_seconds` | gauge | Timestamp of the last event processed |
+| `bintrail_stream_replication_lag_seconds` | gauge | Now minus the last processed event timestamp |
+| `bintrail_stream_errors_total` | counter | Errors, by `type` |
+| `bintrail_stream_batch_size` | histogram | Events per INSERT batch |
+
+## Index metrics (`bintrail_index_*`)
+
+The **state of the index** — refreshed periodically (default 60s,
+`--metrics-scrape-interval`) from a status snapshot, not per event.
+
+| Metric | Type | Meaning |
+|---|---|---|
+| `bintrail_index_oldest_event_timestamp_seconds` | gauge | Oldest event still in the index — the recovery floor |
+| `bintrail_index_newest_event_timestamp_seconds` | gauge | Newest event in the index |
+| `bintrail_index_retention_horizon_seconds` | gauge | How far back recovery reaches (now − oldest) |
+| `bintrail_index_events_total` | gauge | Approximate event count (information_schema estimate) |
+| `bintrail_index_partitions_total{kind}` | gauge | Partition count, `kind` = `active` or `future` |
+| `bintrail_index_gap_hours` | gauge | Hours rotated out of MySQL but **not** archived to Parquet — holes in recovery coverage |
+| `bintrail_index_storage_bytes{location}` | gauge | Index size, `location` = `mysql` (the `binlog_events` table) or `parquet` (archived partitions) |
+
+> The oldest/newest timestamp gauges are **not published** for an empty index,
+> so they never report a misleading 1970 epoch.
+>
+> `events_total` is deliberately a single aggregate per source — it is **not**
+> labelled per schema/table, which would grow unbounded as tables come and go.
+> Per-table baseline size is surfaced via `bintrail status --format json`
+> instead (the `size_bytes` field on each baseline).
+
+## PromQL recipes
+
+**Recovery floor is slipping** — alert if the index no longer reaches back the
+required retention (e.g. 7 days):
+
+```promql
+bintrail_index_retention_horizon_seconds < 7 * 24 * 3600
+```
+
+**Coverage gaps** — any hour rotated out without an archive is unrecoverable:
+
+```promql
+bintrail_index_gap_hours > 0
+```
+
+**Index disk growth** — MySQL index size trend, to project a disk-full date:
+
+```promql
+bintrail_index_storage_bytes{location="mysql"}
+predict_linear(bintrail_index_storage_bytes{location="mysql"}[6h], 7 * 24 * 3600)
+```
+
+**Stream stalled** — replication lag climbing or no events indexed:
+
+```promql
+bintrail_stream_replication_lag_seconds > 300
+rate(bintrail_stream_events_indexed_total[5m]) == 0
+```
+
+**Newest event is stale** — the index has stopped advancing even though the
+stream is up:
+
+```promql
+time() - bintrail_index_newest_event_timestamp_seconds > 600
+```
+
+## See also
+
+- [rotation-and-status.md](rotation-and-status.md) — `bintrail status` reports
+  the same coverage, index size, and per-table baseline size in text/JSON.
+- [capacity.md](capacity.md) — sizing math and the `doctor` disk-capacity check.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -54,6 +54,13 @@ The **state of the index** — refreshed periodically (default 60s,
 > labelled per schema/table, which would grow unbounded as tables come and go.
 > Per-table baseline size is surfaced via `bintrail status --format json`
 > instead (the `size_bytes` field on each baseline).
+>
+> `gap_hours` counts holes **within the retained span** — from the oldest data
+> still known (live or archived) up to the newest explicit hourly partition. It
+> cannot detect holes entirely *before* the oldest surviving data (nothing
+> records that those hours ever existed), and the not-yet-rotated current hours
+> (`p_future`) are excluded, so a stream with no rotation loop never false-counts
+> them.
 
 ## PromQL recipes
 
@@ -70,17 +77,25 @@ bintrail_index_retention_horizon_seconds < 7 * 24 * 3600
 bintrail_index_gap_hours > 0
 ```
 
-**Index disk growth** — MySQL index size trend, to project a disk-full date:
+**Index disk growth** — MySQL index size trend, to project a disk-full date
+(two separate queries — current size, then the 7-day projection):
 
 ```promql
 bintrail_index_storage_bytes{location="mysql"}
+```
+
+```promql
 predict_linear(bintrail_index_storage_bytes{location="mysql"}[6h], 7 * 24 * 3600)
 ```
 
-**Stream stalled** — replication lag climbing or no events indexed:
+**Stream stalled** — replication lag climbing, **or** no events indexed (either
+condition is a separate alert):
 
 ```promql
 bintrail_stream_replication_lag_seconds > 300
+```
+
+```promql
 rate(bintrail_stream_events_indexed_total[5m]) == 0
 ```
 

--- a/internal/observe/index_metrics_test.go
+++ b/internal/observe/index_metrics_test.go
@@ -14,6 +14,7 @@ func TestIndexMetricsSet(t *testing.T) {
 	now := time.Date(2026, 1, 3, 0, 0, 0, 0, time.UTC)
 
 	m.Set(IndexSnapshot{
+		HaveCoverage:     true,
 		OldestEvent:      oldest,
 		NewestEvent:      newest,
 		Events:           1234,
@@ -63,5 +64,26 @@ func TestIndexMetricsSet_zeroTimestampsNotPublished(t *testing.T) {
 	// Aggregates without a time dimension are still published.
 	if got := testutil.ToFloat64(indexPartitions.WithLabelValues("empty-src", "active")); got != 1 {
 		t.Errorf("active partitions = %v, want 1", got)
+	}
+}
+
+// A degraded scrape (coverage load failed → HaveCoverage=false) must NOT
+// overwrite events_total / storage_bytes{mysql} with a misleading 0; the
+// partition counts (independent of coverage) still update.
+func TestIndexMetricsSet_degradedCoverageRetainsPriorGauges(t *testing.T) {
+	m := IndexForSource("degraded-src")
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	m.Set(IndexSnapshot{HaveCoverage: true, Events: 777, MySQLBytes: 555, ActivePartitions: 3}, now)
+	m.Set(IndexSnapshot{HaveCoverage: false, Events: 0, MySQLBytes: 0, ActivePartitions: 4}, now)
+
+	if got := testutil.ToFloat64(indexEventsTotal.WithLabelValues("degraded-src")); got != 777 {
+		t.Errorf("events_total = %v after degraded scrape, want retained 777", got)
+	}
+	if got := testutil.ToFloat64(indexStorageBytes.WithLabelValues("degraded-src", "mysql")); got != 555 {
+		t.Errorf("storage_bytes{mysql} = %v after degraded scrape, want retained 555", got)
+	}
+	if got := testutil.ToFloat64(indexPartitions.WithLabelValues("degraded-src", "active")); got != 4 {
+		t.Errorf("active partitions = %v, want updated 4 (independent of coverage)", got)
 	}
 }

--- a/internal/observe/index_metrics_test.go
+++ b/internal/observe/index_metrics_test.go
@@ -1,0 +1,67 @@
+package observe
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestIndexMetricsSet(t *testing.T) {
+	m := IndexForSource("test-src")
+	oldest := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	newest := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
+	now := time.Date(2026, 1, 3, 0, 0, 0, 0, time.UTC)
+
+	m.Set(IndexSnapshot{
+		OldestEvent:      oldest,
+		NewestEvent:      newest,
+		Events:           1234,
+		ActivePartitions: 5,
+		FuturePartitions: 1,
+		GapHours:         2,
+		MySQLBytes:       1000,
+		ParquetBytes:     2000,
+	}, now)
+
+	checks := []struct {
+		name string
+		got  float64
+		want float64
+	}{
+		{"oldest", testutil.ToFloat64(indexOldestEvent.WithLabelValues("test-src")), float64(oldest.Unix())},
+		{"newest", testutil.ToFloat64(indexNewestEvent.WithLabelValues("test-src")), float64(newest.Unix())},
+		{"retention", testutil.ToFloat64(indexRetentionHorizon.WithLabelValues("test-src")), now.Sub(oldest).Seconds()},
+		{"events", testutil.ToFloat64(indexEventsTotal.WithLabelValues("test-src")), 1234},
+		{"active_partitions", testutil.ToFloat64(indexPartitions.WithLabelValues("test-src", "active")), 5},
+		{"future_partitions", testutil.ToFloat64(indexPartitions.WithLabelValues("test-src", "future")), 1},
+		{"gap_hours", testutil.ToFloat64(indexGapHours.WithLabelValues("test-src")), 2},
+		{"mysql_bytes", testutil.ToFloat64(indexStorageBytes.WithLabelValues("test-src", "mysql")), 1000},
+		{"parquet_bytes", testutil.ToFloat64(indexStorageBytes.WithLabelValues("test-src", "parquet")), 2000},
+	}
+	for _, c := range checks {
+		if c.got != c.want {
+			t.Errorf("%s = %v, want %v", c.name, c.got, c.want)
+		}
+	}
+}
+
+// A zero OldestEvent/NewestEvent (empty index) must NOT publish a misleading
+// 1970-epoch timestamp — the timestamp + retention gauges stay at their default.
+func TestIndexMetricsSet_zeroTimestampsNotPublished(t *testing.T) {
+	m := IndexForSource("empty-src")
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	m.Set(IndexSnapshot{Events: 0, ActivePartitions: 1}, now)
+
+	if got := testutil.ToFloat64(indexOldestEvent.WithLabelValues("empty-src")); got != 0 {
+		t.Errorf("oldest timestamp should be unpublished (0) for an empty index, got %v", got)
+	}
+	if got := testutil.ToFloat64(indexRetentionHorizon.WithLabelValues("empty-src")); got != 0 {
+		t.Errorf("retention horizon should be unpublished (0) for an empty index, got %v", got)
+	}
+	// Aggregates without a time dimension are still published.
+	if got := testutil.ToFloat64(indexPartitions.WithLabelValues("empty-src", "active")); got != 1 {
+		t.Errorf("active partitions = %v, want 1", got)
+	}
+}

--- a/internal/observe/metrics.go
+++ b/internal/observe/metrics.go
@@ -173,6 +173,11 @@ type IndexSnapshot struct {
 	GapHours         int
 	MySQLBytes       int64
 	ParquetBytes     int64
+	// HaveCoverage reports whether the coverage load succeeded. Events and
+	// MySQLBytes come from it; when it degraded (false) they are NOT published,
+	// so a swallowed partial-load failure can't mask the real values with a 0 —
+	// the same misleading-zero defense as the OldestEvent/NewestEvent guards.
+	HaveCoverage bool
 }
 
 // IndexMetrics is the index gauge set curried to one source.
@@ -198,10 +203,14 @@ func (m *IndexMetrics) Set(snap IndexSnapshot, now time.Time) {
 	if !snap.NewestEvent.IsZero() {
 		indexNewestEvent.WithLabelValues(s).Set(float64(snap.NewestEvent.Unix()))
 	}
-	indexEventsTotal.WithLabelValues(s).Set(float64(snap.Events))
+	// events_total and storage_bytes{mysql} are coverage-derived — skip them on a
+	// degraded load so a swallowed failure can't publish a misleading 0.
+	if snap.HaveCoverage {
+		indexEventsTotal.WithLabelValues(s).Set(float64(snap.Events))
+		indexStorageBytes.WithLabelValues(s, "mysql").Set(float64(snap.MySQLBytes))
+	}
 	indexPartitions.WithLabelValues(s, "active").Set(float64(snap.ActivePartitions))
 	indexPartitions.WithLabelValues(s, "future").Set(float64(snap.FuturePartitions))
 	indexGapHours.WithLabelValues(s).Set(float64(snap.GapHours))
-	indexStorageBytes.WithLabelValues(s, "mysql").Set(float64(snap.MySQLBytes))
 	indexStorageBytes.WithLabelValues(s, "parquet").Set(float64(snap.ParquetBytes))
 }

--- a/internal/observe/metrics.go
+++ b/internal/observe/metrics.go
@@ -1,6 +1,8 @@
 package observe
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
@@ -106,4 +108,100 @@ func ForSource(source string) *StreamMetrics {
 		Errors:             streamErrors.MustCurryWith(prometheus.Labels{"source": source}),
 		BatchSize:          streamBatchSize.WithLabelValues(source),
 	}
+}
+
+// Index metrics — the bintrail_index namespace (#351).
+//
+// Where the stream metrics describe the live replication pipeline, these
+// describe the STATE of the index a DBA cares about for forensic readiness:
+// how far back recovery reaches, whether there are coverage gaps, and how much
+// disk the index + archives occupy. They are GAUGES set periodically by a
+// scraper (see streamrun) from a status snapshot — there is no per-event hot
+// path here. Every series carries "source" for the same multi-stream reason as
+// the stream metrics.
+//
+// CARDINALITY: index_events_total is a single aggregate per source — NOT
+// labelled per schema/table, which would grow unbounded as tables come and go.
+var (
+	indexOldestEvent = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "bintrail", Subsystem: "index", Name: "oldest_event_timestamp_seconds",
+		Help: "Unix timestamp of the oldest event still in the index (recovery floor).",
+	}, []string{"source"})
+
+	indexNewestEvent = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "bintrail", Subsystem: "index", Name: "newest_event_timestamp_seconds",
+		Help: "Unix timestamp of the newest event in the index.",
+	}, []string{"source"})
+
+	indexRetentionHorizon = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "bintrail", Subsystem: "index", Name: "retention_horizon_seconds",
+		Help: "How far back the index reaches: now minus the oldest event timestamp.",
+	}, []string{"source"})
+
+	indexEventsTotal = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "bintrail", Subsystem: "index", Name: "events_total",
+		Help: "Approximate number of row events in the index (information_schema estimate).",
+	}, []string{"source"})
+
+	indexPartitions = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "bintrail", Subsystem: "index", Name: "partitions_total",
+		Help: "Number of binlog_events partitions, by kind (active hourly vs the p_future catch-all).",
+	}, []string{"source", "kind"})
+
+	indexGapHours = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "bintrail", Subsystem: "index", Name: "gap_hours",
+		Help: "Hours that were rotated out of MySQL but not archived to Parquet — a hole in recovery coverage.",
+	}, []string{"source"})
+
+	indexStorageBytes = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "bintrail", Subsystem: "index", Name: "storage_bytes",
+		Help: "Bytes occupied by the index, by location (mysql = binlog_events table, parquet = archived partitions).",
+	}, []string{"source", "location"})
+)
+
+// IndexSnapshot is a flat, status-package-free view of the index state that the
+// scraper passes to IndexMetrics.Set. Keeping it plain avoids an observe→status
+// import (status already depends on lower layers; a cycle would be one edit
+// away). Zero OldestEvent/NewestEvent mean "unknown" (empty index) and are not
+// published, so the timestamp gauges never report a misleading 1970 epoch.
+type IndexSnapshot struct {
+	OldestEvent      time.Time
+	NewestEvent      time.Time
+	Events           int64
+	ActivePartitions int
+	FuturePartitions int
+	GapHours         int
+	MySQLBytes       int64
+	ParquetBytes     int64
+}
+
+// IndexMetrics is the index gauge set curried to one source.
+type IndexMetrics struct{ source string }
+
+// IndexForSource returns an index-metrics handle for the given source label
+// (empty → "default", matching ForSource).
+func IndexForSource(source string) *IndexMetrics {
+	if source == "" {
+		source = "default"
+	}
+	return &IndexMetrics{source: source}
+}
+
+// Set publishes one snapshot to the gauges. now is taken explicitly so the
+// retention-horizon computation is deterministic under test.
+func (m *IndexMetrics) Set(snap IndexSnapshot, now time.Time) {
+	s := m.source
+	if !snap.OldestEvent.IsZero() {
+		indexOldestEvent.WithLabelValues(s).Set(float64(snap.OldestEvent.Unix()))
+		indexRetentionHorizon.WithLabelValues(s).Set(now.Sub(snap.OldestEvent).Seconds())
+	}
+	if !snap.NewestEvent.IsZero() {
+		indexNewestEvent.WithLabelValues(s).Set(float64(snap.NewestEvent.Unix()))
+	}
+	indexEventsTotal.WithLabelValues(s).Set(float64(snap.Events))
+	indexPartitions.WithLabelValues(s, "active").Set(float64(snap.ActivePartitions))
+	indexPartitions.WithLabelValues(s, "future").Set(float64(snap.FuturePartitions))
+	indexGapHours.WithLabelValues(s).Set(float64(snap.GapHours))
+	indexStorageBytes.WithLabelValues(s, "mysql").Set(float64(snap.MySQLBytes))
+	indexStorageBytes.WithLabelValues(s, "parquet").Set(float64(snap.ParquetBytes))
 }

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -39,12 +39,12 @@ type PartitionStat struct {
 
 // ServerInfo holds one active row from the bintrail_servers table.
 type ServerInfo struct {
-	BintrailID      string
-	ServerUUID      string
-	Host            string
-	Port            uint16
-	Username        string
-	CreatedAt       time.Time
+	BintrailID       string
+	ServerUUID       string
+	Host             string
+	Port             uint16
+	Username         string
+	CreatedAt        time.Time
 	DecommissionedAt sql.NullTime
 }
 
@@ -86,15 +86,20 @@ type StreamStateInfo struct {
 
 // CoverageInfo summarizes the restore coverage of the index.
 type CoverageInfo struct {
-	EarliestEvent     sql.NullTime
-	LatestEvent       sql.NullTime
-	TotalEvents       int64
-	SchemaChanges     int
-	UncoveredDDLs     int // DDLs without a snapshot (file mode, or failed auto-snapshot in stream mode)
+	EarliestEvent sql.NullTime
+	LatestEvent   sql.NullTime
+	TotalEvents   int64
+	SchemaChanges int
+	UncoveredDDLs int // DDLs without a snapshot (file mode, or failed auto-snapshot in stream mode)
 
 	// Archive-derived fields (from archive_state partition names and row counts).
 	ArchiveEarliestHour sql.NullTime // earliest hour derived from MIN(partition_name)
 	ArchiveTotalRows    int64
+
+	// IndexSizeBytes is the on-disk size of the binlog_events table
+	// (DATA_LENGTH + INDEX_LENGTH, an InnoDB estimate). Surfaced so an operator
+	// sees how much disk the live index occupies alongside its time coverage.
+	IndexSizeBytes int64
 }
 
 // TSFmt is the timestamp format used in status output.
@@ -339,6 +344,10 @@ type BaselineInfo struct {
 	BinlogPos    int64
 	GTIDSet      string
 	Path         string // filesystem path; ignored by display/JSON output
+	// Size is the Parquet file size in bytes (0 = unknown). Surfaced so an
+	// operator can see per-table baseline size — the signal that tells whether
+	// a single-table baseline has grown into the large regime.
+	Size int64
 }
 
 // CollectStatus loads all status data from the index database.
@@ -382,7 +391,31 @@ func CollectStatus(ctx context.Context, db *sql.DB, dbName string) (*StatusData,
 		d.Coverage = coverage
 	}
 
+	// Best-effort: the binlog_events on-disk size, attached to coverage so it
+	// surfaces alongside the time-coverage figures (and is reused by the
+	// bintrail_index_storage_bytes gauge).
+	if size, err := LoadIndexSizeBytes(ctx, db, dbName); err != nil {
+		slog.Warn("could not load index size", "error", err)
+	} else if d.Coverage != nil {
+		d.Coverage.IndexSizeBytes = size
+	}
+
 	return d, nil
+}
+
+// LoadIndexSizeBytes returns the on-disk size of the binlog_events table
+// (DATA_LENGTH + INDEX_LENGTH summed across partitions) — an InnoDB estimate
+// from information_schema, the same figure the doctor capacity check uses.
+func LoadIndexSizeBytes(ctx context.Context, db *sql.DB, dbName string) (int64, error) {
+	var b sql.NullInt64
+	err := db.QueryRowContext(ctx, `
+		SELECT COALESCE(SUM(DATA_LENGTH + INDEX_LENGTH), 0)
+		FROM information_schema.PARTITIONS
+		WHERE TABLE_SCHEMA = ? AND TABLE_NAME = 'binlog_events'`, dbName).Scan(&b)
+	if err != nil {
+		return 0, err
+	}
+	return b.Int64, nil
 }
 
 // Write writes the status data as a human-readable report to w.
@@ -538,6 +571,9 @@ func WriteStatus(w io.Writer, files []IndexStateRow, parts []PartitionStat, arch
 		} else {
 			fmt.Fprintf(w, "  Total events:   %d\n", totalEvents)
 		}
+		if coverage.IndexSizeBytes > 0 {
+			fmt.Fprintf(w, "  Index size:     %s (MySQL binlog_events)\n", formatBytes(coverage.IndexSizeBytes))
+		}
 		fmt.Fprintf(w, "  Schema changes: %d\n", coverage.SchemaChanges)
 		if coverage.UncoveredDDLs > 0 {
 			fmt.Fprintf(w, "  Warning: %d DDL(s) detected without auto-snapshot (file mode) — recovery across these DDLs may require manual snapshot\n",
@@ -661,6 +697,8 @@ func writeStatusJSONFull(w io.Writer, files []IndexStateRow, parts []PartitionSt
 		LiveEvents           int64   `json:"live_events"`
 		ArchivedEvents       int64   `json:"archived_events"`
 		ArchiveEarliestEvent *string `json:"archive_earliest_event,omitempty"`
+		IndexSizeBytes       int64   `json:"index_size_bytes,omitempty"`
+		IndexSizeHuman       string  `json:"index_size_human,omitempty"`
 		SchemaChanges        int     `json:"schema_changes"`
 		UncoveredDDLs        int     `json:"uncovered_ddls"`
 	}
@@ -691,6 +729,8 @@ func writeStatusJSONFull(w io.Writer, files []IndexStateRow, parts []PartitionSt
 		BinlogFile   *string `json:"binlog_file,omitempty"`
 		BinlogPos    *int64  `json:"binlog_position,omitempty"`
 		GTIDSet      *string `json:"gtid_set,omitempty"`
+		Size         int64   `json:"size_bytes,omitempty"`
+		SizeHuman    string  `json:"size_human,omitempty"`
 	}
 	type jsonSummary struct {
 		Servers   []jsonServer    `json:"servers,omitempty"`
@@ -791,8 +831,12 @@ func writeStatusJSONFull(w io.Writer, files []IndexStateRow, parts []PartitionSt
 			TotalEvents:    coverage.TotalEvents + coverage.ArchiveTotalRows,
 			LiveEvents:     coverage.TotalEvents,
 			ArchivedEvents: coverage.ArchiveTotalRows,
+			IndexSizeBytes: coverage.IndexSizeBytes,
 			SchemaChanges:  coverage.SchemaChanges,
 			UncoveredDDLs:  coverage.UncoveredDDLs,
+		}
+		if coverage.IndexSizeBytes > 0 {
+			jc.IndexSizeHuman = formatBytes(coverage.IndexSizeBytes)
 		}
 
 		// Effective earliest: archive may extend further back than live data.
@@ -821,6 +865,10 @@ func writeStatusJSONFull(w io.Writer, files []IndexStateRow, parts []PartitionSt
 			SnapshotTime: b.SnapshotTime.Format(TSFmt),
 			Database:     b.Database,
 			Table:        b.Table,
+			Size:         b.Size,
+		}
+		if b.Size > 0 {
+			jb.SizeHuman = formatBytes(b.Size)
 		}
 		if b.BinlogFile != "" {
 			jb.BinlogFile = &b.BinlogFile
@@ -847,8 +895,8 @@ func writeBaselines(w io.Writer, baselines []BaselineInfo) {
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "=== Baselines ===")
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(tw, "SNAPSHOT\tDATABASE\tTABLE\tBINLOG_FILE\tBINLOG_POS\tGTID")
-	fmt.Fprintln(tw, "────────\t────────\t─────\t───────────\t──────────\t────")
+	fmt.Fprintln(tw, "SNAPSHOT\tDATABASE\tTABLE\tSIZE\tBINLOG_FILE\tBINLOG_POS\tGTID")
+	fmt.Fprintln(tw, "────────\t────────\t─────\t────\t───────────\t──────────\t────")
 	for _, b := range baselines {
 		binlogFile := "-"
 		if b.BinlogFile != "" {
@@ -862,9 +910,13 @@ func writeBaselines(w io.Writer, baselines []BaselineInfo) {
 		if b.GTIDSet != "" {
 			gtid = Truncate(b.GTIDSet, 40)
 		}
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
+		size := "-"
+		if b.Size > 0 {
+			size = formatBytes(b.Size)
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 			b.SnapshotTime.Format(TSFmt),
-			b.Database, b.Table,
+			b.Database, b.Table, size,
 			binlogFile, binlogPos, gtid)
 	}
 	tw.Flush()

--- a/internal/status/status_size_test.go
+++ b/internal/status/status_size_test.go
@@ -1,0 +1,61 @@
+package status
+
+import (
+	"bytes"
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestStatusSurfacesIndexAndBaselineSize pins the #351/#406-residual display:
+// the MySQL index storage size shows in the Restore Coverage section, and the
+// per-table baseline Parquet size shows in the Baselines section — both in text
+// and JSON.
+func TestStatusSurfacesIndexAndBaselineSize(t *testing.T) {
+	const (
+		indexBytes    = int64(5 * 1024 * 1024)  // 5 MiB
+		baselineBytes = int64(12 * 1024 * 1024) // 12 MiB
+	)
+	d := &StatusData{
+		Coverage: &CoverageInfo{
+			EarliestEvent:  sql.NullTime{Time: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), Valid: true},
+			LatestEvent:    sql.NullTime{Time: time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC), Valid: true},
+			TotalEvents:    100,
+			IndexSizeBytes: indexBytes,
+		},
+		Baselines: []BaselineInfo{
+			{
+				SnapshotTime: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+				Database:     "shop",
+				Table:        "orders",
+				Size:         baselineBytes,
+			},
+		},
+	}
+
+	var text bytes.Buffer
+	d.Write(&text)
+	ts := text.String()
+	if !strings.Contains(ts, "Index size:") {
+		t.Errorf("text status missing 'Index size:' line:\n%s", ts)
+	}
+	if !strings.Contains(ts, formatBytes(indexBytes)) {
+		t.Errorf("text status missing index size value %q:\n%s", formatBytes(indexBytes), ts)
+	}
+	if !strings.Contains(ts, formatBytes(baselineBytes)) {
+		t.Errorf("text status missing baseline size value %q:\n%s", formatBytes(baselineBytes), ts)
+	}
+
+	var jsonBuf bytes.Buffer
+	if err := d.WriteJSON(&jsonBuf); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+	js := jsonBuf.String()
+	if !strings.Contains(js, `"index_size_bytes":`) {
+		t.Errorf("JSON missing index_size_bytes:\n%s", js)
+	}
+	if !strings.Contains(js, `"size_bytes":`) {
+		t.Errorf("JSON missing baseline size_bytes:\n%s", js)
+	}
+}

--- a/internal/streamrun/index_metrics.go
+++ b/internal/streamrun/index_metrics.go
@@ -61,7 +61,7 @@ func scrapeIndexMetrics(ctx context.Context, db *sql.DB, dbName string, m *obser
 		return
 	}
 
-	snap := observe.IndexSnapshot{}
+	snap := observe.IndexSnapshot{HaveCoverage: data.Coverage != nil}
 	if data.Coverage != nil {
 		if data.Coverage.EarliestEvent.Valid {
 			snap.OldestEvent = data.Coverage.EarliestEvent.Time
@@ -72,27 +72,35 @@ func scrapeIndexMetrics(ctx context.Context, db *sql.DB, dbName string, m *obser
 		snap.Events = data.Coverage.TotalEvents
 		snap.MySQLBytes = data.Coverage.IndexSizeBytes
 	}
+	var newestExplicit time.Time // newest EXPLICIT hourly partition (excludes p_future)
 	for _, p := range data.Parts {
 		if p.Name == "p_future" {
 			snap.FuturePartitions++
-		} else {
-			snap.ActivePartitions++
+			continue
+		}
+		snap.ActivePartitions++
+		if h, ok := query.ParsePartitionName(p.Name); ok && h.After(newestExplicit) {
+			newestExplicit = h
 		}
 	}
 	if data.Archives != nil {
 		snap.ParquetBytes = data.Archives.TotalSizeBytes
 	}
 
-	// Gap hours: hours rotated out of MySQL with no Parquet archive — holes in
-	// recovery coverage. query.Plan SHORT-CIRCUITS to a nil plan when given a
-	// nil range (planner.go), so we must pass a concrete window — and it has to
-	// reach back to the earliest data that SHOULD exist (live or archived) for
-	// the count to mean anything. An empty index has no span and no gaps.
+	// Gap hours: hours ROTATED OUT of MySQL and never archived — holes in
+	// recovery coverage. Two bounds matter: since reaches back to the earliest
+	// data that should exist (oldest live event or earliest archived hour) so a
+	// hole anywhere in the retained span is seen; until is the end of the EXPLICIT
+	// hourly partitions, because hours beyond that live in p_future (current data,
+	// never rotated) and counting them as gaps would make a no-rotation standalone
+	// stream report a steadily climbing false gap_hours (loadLivePartitionHours
+	// excludes p_future). A concrete range also keeps the scraper off query.Plan's
+	// nil-range short-circuit (the earlier nil-deref panic).
 	var archiveEarliest sql.NullTime
 	if data.Coverage != nil {
 		archiveEarliest = data.Coverage.ArchiveEarliestHour
 	}
-	if since, until, ok := gapScrapeRange(snap.OldestEvent, archiveEarliest, time.Now()); ok {
+	if since, until, ok := gapScrapeRange(snap.OldestEvent, archiveEarliest, newestExplicit); ok {
 		if plan, err := query.Plan(ctx, db, dbName, &since, &until); err != nil {
 			slog.Warn("index metrics scrape: could not plan gap hours", "error", err)
 		} else if plan != nil { // belt-and-suspenders: Plan can still return nil
@@ -104,19 +112,26 @@ func scrapeIndexMetrics(ctx context.Context, db *sql.DB, dbName string, m *obser
 }
 
 // gapScrapeRange returns the [since, until] window over which to count coverage
-// gap hours, or ok=false when the index has no data to span. since reaches back
-// to the earliest data that should exist — the earlier of the oldest live event
-// and the earliest archived hour — so a hole anywhere in the covered span is
-// seen. Returning a concrete (non-nil) range is also what keeps the scraper
-// from calling query.Plan with nil bounds, which it short-circuits to a nil
-// plan (the cause of an earlier nil-deref panic).
-func gapScrapeRange(oldest time.Time, archiveEarliest sql.NullTime, now time.Time) (since, until time.Time, ok bool) {
+// gap hours, or ok=false when there is no rotated span to measure. since is the
+// earlier of the oldest live event and the earliest archived hour (so a hole
+// anywhere in the retained span is seen); until is one hour past the newest
+// EXPLICIT hourly partition, so the not-yet-rotated p_future tail is excluded —
+// otherwise a no-rotation standalone stream over-counts current hours as gaps.
+// A concrete (non-nil) range also keeps the scraper off query.Plan's nil-range
+// short-circuit (the cause of an earlier nil-deref panic).
+func gapScrapeRange(oldest time.Time, archiveEarliest sql.NullTime, newestExplicit time.Time) (since, until time.Time, ok bool) {
 	since = oldest
 	if archiveEarliest.Valid && (since.IsZero() || archiveEarliest.Time.Before(since)) {
 		since = archiveEarliest.Time
 	}
-	if since.IsZero() {
+	// No data to anchor since, or no explicit partition to bound until → there is
+	// no rotated span to measure.
+	if since.IsZero() || newestExplicit.IsZero() {
 		return time.Time{}, time.Time{}, false
 	}
-	return since, now, true
+	until = newestExplicit.Add(time.Hour)
+	if !until.After(since) {
+		return time.Time{}, time.Time{}, false
+	}
+	return since, until, true
 }

--- a/internal/streamrun/index_metrics.go
+++ b/internal/streamrun/index_metrics.go
@@ -82,13 +82,41 @@ func scrapeIndexMetrics(ctx context.Context, db *sql.DB, dbName string, m *obser
 	if data.Archives != nil {
 		snap.ParquetBytes = data.Archives.TotalSizeBytes
 	}
+
 	// Gap hours: hours rotated out of MySQL with no Parquet archive — holes in
-	// recovery coverage. Plan over the full range (nil since/until).
-	if plan, err := query.Plan(ctx, db, dbName, nil, nil); err != nil {
-		slog.Warn("index metrics scrape: could not plan gap hours", "error", err)
-	} else {
-		snap.GapHours = len(plan.GapHours)
+	// recovery coverage. query.Plan SHORT-CIRCUITS to a nil plan when given a
+	// nil range (planner.go), so we must pass a concrete window — and it has to
+	// reach back to the earliest data that SHOULD exist (live or archived) for
+	// the count to mean anything. An empty index has no span and no gaps.
+	var archiveEarliest sql.NullTime
+	if data.Coverage != nil {
+		archiveEarliest = data.Coverage.ArchiveEarliestHour
+	}
+	if since, until, ok := gapScrapeRange(snap.OldestEvent, archiveEarliest, time.Now()); ok {
+		if plan, err := query.Plan(ctx, db, dbName, &since, &until); err != nil {
+			slog.Warn("index metrics scrape: could not plan gap hours", "error", err)
+		} else if plan != nil { // belt-and-suspenders: Plan can still return nil
+			snap.GapHours = len(plan.GapHours)
+		}
 	}
 
 	m.Set(snap, time.Now())
+}
+
+// gapScrapeRange returns the [since, until] window over which to count coverage
+// gap hours, or ok=false when the index has no data to span. since reaches back
+// to the earliest data that should exist — the earlier of the oldest live event
+// and the earliest archived hour — so a hole anywhere in the covered span is
+// seen. Returning a concrete (non-nil) range is also what keeps the scraper
+// from calling query.Plan with nil bounds, which it short-circuits to a nil
+// plan (the cause of an earlier nil-deref panic).
+func gapScrapeRange(oldest time.Time, archiveEarliest sql.NullTime, now time.Time) (since, until time.Time, ok bool) {
+	since = oldest
+	if archiveEarliest.Valid && (since.IsZero() || archiveEarliest.Time.Before(since)) {
+		since = archiveEarliest.Time
+	}
+	if since.IsZero() {
+		return time.Time{}, time.Time{}, false
+	}
+	return since, now, true
 }

--- a/internal/streamrun/index_metrics.go
+++ b/internal/streamrun/index_metrics.go
@@ -1,0 +1,94 @@
+package streamrun
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+	"time"
+
+	drivermysql "github.com/go-sql-driver/mysql"
+
+	"github.com/dbtrail/dbtrail/internal/observe"
+	"github.com/dbtrail/dbtrail/internal/query"
+	"github.com/dbtrail/dbtrail/internal/status"
+)
+
+// defaultIndexMetricsInterval is how often the bintrail_index_* gauges are
+// refreshed from a status snapshot when no interval is configured (#351).
+const defaultIndexMetricsInterval = 60 * time.Second
+
+// startIndexMetricsScraper launches a goroutine that periodically publishes the
+// bintrail_index_* gauges (recovery floor, gap hours, storage bytes, partition
+// counts) for source, derived from a status snapshot of the index DB. It
+// returns immediately and stops when ctx is cancelled. A scrape failure is
+// logged and the previous gauge values are left in place — a slightly stale
+// reading beats a gap or a misleading zero. The work is a handful of
+// information_schema/aggregate queries on a timer, not a per-event path.
+func startIndexMetricsScraper(ctx context.Context, db *sql.DB, indexDSN, source string, intervalSeconds int) {
+	interval := time.Duration(intervalSeconds) * time.Second
+	if interval <= 0 {
+		interval = defaultIndexMetricsInterval
+	}
+	dbName := ""
+	if c, err := drivermysql.ParseDSN(indexDSN); err == nil {
+		dbName = c.DBName
+	} else {
+		slog.Warn("index metrics scraper: could not parse index DSN for schema name; metrics disabled", "error", err)
+		return
+	}
+	m := observe.IndexForSource(source)
+	go func() {
+		// Scrape once promptly so the gauges populate without waiting a full
+		// interval, then on the ticker.
+		scrapeIndexMetrics(ctx, db, dbName, m)
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				scrapeIndexMetrics(ctx, db, dbName, m)
+			}
+		}
+	}()
+}
+
+func scrapeIndexMetrics(ctx context.Context, db *sql.DB, dbName string, m *observe.IndexMetrics) {
+	data, err := status.CollectStatus(ctx, db, dbName)
+	if err != nil {
+		slog.Warn("index metrics scrape: could not collect status", "error", err)
+		return
+	}
+
+	snap := observe.IndexSnapshot{}
+	if data.Coverage != nil {
+		if data.Coverage.EarliestEvent.Valid {
+			snap.OldestEvent = data.Coverage.EarliestEvent.Time
+		}
+		if data.Coverage.LatestEvent.Valid {
+			snap.NewestEvent = data.Coverage.LatestEvent.Time
+		}
+		snap.Events = data.Coverage.TotalEvents
+		snap.MySQLBytes = data.Coverage.IndexSizeBytes
+	}
+	for _, p := range data.Parts {
+		if p.Name == "p_future" {
+			snap.FuturePartitions++
+		} else {
+			snap.ActivePartitions++
+		}
+	}
+	if data.Archives != nil {
+		snap.ParquetBytes = data.Archives.TotalSizeBytes
+	}
+	// Gap hours: hours rotated out of MySQL with no Parquet archive — holes in
+	// recovery coverage. Plan over the full range (nil since/until).
+	if plan, err := query.Plan(ctx, db, dbName, nil, nil); err != nil {
+		slog.Warn("index metrics scrape: could not plan gap hours", "error", err)
+	} else {
+		snap.GapHours = len(plan.GapHours)
+	}
+
+	m.Set(snap, time.Now())
+}

--- a/internal/streamrun/index_metrics_integration_test.go
+++ b/internal/streamrun/index_metrics_integration_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/dbtrail/dbtrail/internal/observe"
 	"github.com/dbtrail/dbtrail/internal/testutil"
 )
@@ -15,8 +17,10 @@ import (
 // query.Plan + Set) against a live index — the path the unit tests don't reach.
 // It guards the regression where scrapeIndexMetrics called query.Plan(nil,nil)
 // (which returns a nil plan) and dereferenced it: with a real event present,
-// OldestEvent is non-zero so Plan IS invoked with a concrete range, and the
-// scrape must complete without panicking.
+// OldestEvent is non-zero so Plan IS invoked with a concrete range. Beyond not
+// panicking, it asserts a coverage-derived gauge was actually published, so a
+// future early-return before Set can't keep the test green while silently
+// un-exercising the path.
 func TestScrapeIndexMetrics_endToEnd(t *testing.T) {
 	testutil.SkipIfNoMySQL(t)
 	db, dbName := testutil.CreateTestDB(t)
@@ -27,8 +31,35 @@ func TestScrapeIndexMetrics_endToEnd(t *testing.T) {
 		"shop", "orders", 1, "1", nil, nil, []byte(`{"id":1}`))
 
 	m := observe.IndexForSource("e2e-src")
-	// A panic here (the nil-plan deref) would crash the test; reaching the next
-	// line is the regression assertion. CollectStatus + query.Plan both run
-	// against the real schema with a non-zero OldestEvent.
 	scrapeIndexMetrics(context.Background(), db, dbName, m)
+
+	// The one inserted event must surface in events_total{source="e2e-src"} —
+	// proving CollectStatus + Set ran end-to-end (read via the public gatherer so
+	// the test doesn't reach into observe's unexported vectors).
+	if got, ok := indexGaugeValue(t, "bintrail_index_events_total", "e2e-src"); !ok || got != 1 {
+		t.Fatalf("events_total{source=e2e-src} = %v (present=%v), want 1", got, ok)
+	}
+}
+
+// indexGaugeValue reads a single gauge value by metric name and source label
+// from the default Prometheus registry.
+func indexGaugeValue(t *testing.T, name, source string) (float64, bool) {
+	t.Helper()
+	mfs, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("gather metrics: %v", err)
+	}
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			for _, l := range m.GetLabel() {
+				if l.GetName() == "source" && l.GetValue() == source {
+					return m.GetGauge().GetValue(), true
+				}
+			}
+		}
+	}
+	return 0, false
 }

--- a/internal/streamrun/index_metrics_integration_test.go
+++ b/internal/streamrun/index_metrics_integration_test.go
@@ -1,0 +1,34 @@
+//go:build integration
+
+package streamrun
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/observe"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestScrapeIndexMetrics_endToEnd drives the real scrape path (CollectStatus +
+// query.Plan + Set) against a live index — the path the unit tests don't reach.
+// It guards the regression where scrapeIndexMetrics called query.Plan(nil,nil)
+// (which returns a nil plan) and dereferenced it: with a real event present,
+// OldestEvent is non-zero so Plan IS invoked with a concrete range, and the
+// scrape must complete without panicking.
+func TestScrapeIndexMetrics_endToEnd(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	ts := time.Now().UTC().Add(-1 * time.Hour).Format("2006-01-02 15:04:05")
+	testutil.InsertEvent(t, db, "binlog.000001", 100, 200, ts, nil,
+		"shop", "orders", 1, "1", nil, nil, []byte(`{"id":1}`))
+
+	m := observe.IndexForSource("e2e-src")
+	// A panic here (the nil-plan deref) would crash the test; reaching the next
+	// line is the regression assertion. CollectStatus + query.Plan both run
+	// against the real schema with a non-zero OldestEvent.
+	scrapeIndexMetrics(context.Background(), db, dbName, m)
+}

--- a/internal/streamrun/index_metrics_internal_test.go
+++ b/internal/streamrun/index_metrics_internal_test.go
@@ -6,41 +6,46 @@ import (
 	"time"
 )
 
-// TestGapScrapeRange pins that the scraper computes a CONCRETE archive-aware
-// window for query.Plan (it short-circuits to a nil plan on a nil range, which
-// caused a nil-deref panic), and skips entirely on an empty index.
+// TestGapScrapeRange pins the gap window: a CONCRETE archive-aware range for
+// query.Plan (it short-circuits to a nil plan on a nil range — the cause of an
+// earlier nil-deref panic), since = earliest data, until = one hour past the
+// newest EXPLICIT partition (so the not-yet-rotated p_future tail is excluded),
+// and ok=false when there is no rotated span to measure.
 func TestGapScrapeRange(t *testing.T) {
-	now := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
 	oldest := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
 	archive := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	newest := time.Date(2026, 1, 20, 0, 0, 0, 0, time.UTC) // newest explicit partition hour
 
 	tests := []struct {
-		name      string
-		oldest    time.Time
-		archive   sql.NullTime
-		wantOK    bool
-		wantSince time.Time
+		name           string
+		oldest         time.Time
+		archive        sql.NullTime
+		newestExplicit time.Time
+		wantOK         bool
+		wantSince      time.Time
 	}{
-		{"empty index → no range", time.Time{}, sql.NullTime{}, false, time.Time{}},
-		{"live only → since=oldest", oldest, sql.NullTime{}, true, oldest},
-		{"archive earlier than live → since=archive", oldest, sql.NullTime{Time: archive, Valid: true}, true, archive},
-		{"archive only, no live → since=archive", time.Time{}, sql.NullTime{Time: archive, Valid: true}, true, archive},
-		{"archive later than live → since=oldest", oldest, sql.NullTime{Time: now, Valid: true}, true, oldest},
+		{"empty index → no range", time.Time{}, sql.NullTime{}, time.Time{}, false, time.Time{}},
+		{"data but only p_future (no explicit partition) → no rotated span", oldest, sql.NullTime{}, time.Time{}, false, time.Time{}},
+		{"live only → since=oldest", oldest, sql.NullTime{}, newest, true, oldest},
+		{"archive earlier than live → since=archive", oldest, sql.NullTime{Time: archive, Valid: true}, newest, true, archive},
+		{"archive only, no live → since=archive", time.Time{}, sql.NullTime{Time: archive, Valid: true}, newest, true, archive},
+		{"newest explicit before since → empty span", oldest, sql.NullTime{}, oldest.Add(-time.Hour), false, time.Time{}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			since, until, ok := gapScrapeRange(tt.oldest, tt.archive, now)
+			since, until, ok := gapScrapeRange(tt.oldest, tt.archive, tt.newestExplicit)
 			if ok != tt.wantOK {
 				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
 			}
 			if !ok {
-				return // no range — scraper skips Plan entirely
+				return // no rotated span — scraper skips Plan entirely
 			}
 			if !since.Equal(tt.wantSince) {
 				t.Errorf("since = %v, want %v", since, tt.wantSince)
 			}
-			if !until.Equal(now) {
-				t.Errorf("until = %v, want now %v", until, now)
+			// until excludes the p_future tail: one hour past the newest explicit partition.
+			if want := tt.newestExplicit.Add(time.Hour); !until.Equal(want) {
+				t.Errorf("until = %v, want %v (newest explicit + 1h)", until, want)
 			}
 		})
 	}

--- a/internal/streamrun/index_metrics_internal_test.go
+++ b/internal/streamrun/index_metrics_internal_test.go
@@ -1,0 +1,47 @@
+package streamrun
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+)
+
+// TestGapScrapeRange pins that the scraper computes a CONCRETE archive-aware
+// window for query.Plan (it short-circuits to a nil plan on a nil range, which
+// caused a nil-deref panic), and skips entirely on an empty index.
+func TestGapScrapeRange(t *testing.T) {
+	now := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	oldest := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+	archive := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name      string
+		oldest    time.Time
+		archive   sql.NullTime
+		wantOK    bool
+		wantSince time.Time
+	}{
+		{"empty index → no range", time.Time{}, sql.NullTime{}, false, time.Time{}},
+		{"live only → since=oldest", oldest, sql.NullTime{}, true, oldest},
+		{"archive earlier than live → since=archive", oldest, sql.NullTime{Time: archive, Valid: true}, true, archive},
+		{"archive only, no live → since=archive", time.Time{}, sql.NullTime{Time: archive, Valid: true}, true, archive},
+		{"archive later than live → since=oldest", oldest, sql.NullTime{Time: now, Valid: true}, true, oldest},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			since, until, ok := gapScrapeRange(tt.oldest, tt.archive, now)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !ok {
+				return // no range — scraper skips Plan entirely
+			}
+			if !since.Equal(tt.wantSince) {
+				t.Errorf("since = %v, want %v", since, tt.wantSince)
+			}
+			if !until.Equal(now) {
+				t.Errorf("until = %v, want now %v", until, now)
+			}
+		})
+	}
+}

--- a/internal/streamrun/streamrun.go
+++ b/internal/streamrun/streamrun.go
@@ -1108,14 +1108,19 @@ type Config struct {
 	// MetricsScrapeInterval is how often (seconds) the bintrail_index_* gauges
 	// are refreshed from a status snapshot. 0 = the 60s default.
 	MetricsScrapeInterval int
-	SSLMode               string
-	SSLCA                 string
-	SSLCert               string
-	SSLKey                string
-	Format                string
-	Reset                 bool
-	NoGapFill             bool
-	GapTimeout            int // seconds
+	// IndexMetrics forces the bintrail_index_* scraper on even when this stream
+	// sets neither MetricsAddr nor MetricsSource — the `bintrail-console watch`
+	// daemon's OWN primary stream needs this, since it serves /metrics centrally
+	// (MetricsAddr empty) and isn't supervisor-launched (MetricsSource empty).
+	IndexMetrics bool
+	SSLMode      string
+	SSLCA        string
+	SSLCert      string
+	SSLKey       string
+	Format       string
+	Reset        bool
+	NoGapFill    bool
+	GapTimeout   int // seconds
 	// Hooks, when non-nil, lets a supervisor observe this stream's liveness
 	// without polling. Plain `bintrail stream` leaves it nil.
 	Hooks *Hooks
@@ -1554,11 +1559,11 @@ func One(ctx context.Context, cfg Config) error {
 	metrics := observe.ForSource(metricsSource)
 
 	// Index-state gauges (bintrail_index_*, #351): refresh periodically from a
-	// status snapshot whenever metrics are exposed — standalone --metrics-addr
-	// or under the `bintrail-console watch` supervisor (which sets MetricsSource
-	// and serves the process-global registry on its own endpoint). The scraper
-	// stops with ctx.
-	if cfg.MetricsAddr != "" || cfg.MetricsSource != "" {
+	// status snapshot whenever metrics are exposed — standalone --metrics-addr,
+	// a supervisor-launched stream (MetricsSource set), or the watch daemon's
+	// own primary stream (IndexMetrics set, since it serves /metrics centrally
+	// with MetricsAddr/MetricsSource both empty). The scraper stops with ctx.
+	if cfg.MetricsAddr != "" || cfg.MetricsSource != "" || cfg.IndexMetrics {
 		startIndexMetricsScraper(ctx, indexDB, cfg.IndexDSN, metricsSource, cfg.MetricsScrapeInterval)
 	}
 

--- a/internal/streamrun/streamrun.go
+++ b/internal/streamrun/streamrun.go
@@ -1105,14 +1105,17 @@ type Config struct {
 	// concurrent streams stay distinguishable on one /metrics endpoint.
 	// Empty = fall back to the resolved bintrail_id (or "default").
 	MetricsSource string
-	SSLMode       string
-	SSLCA         string
-	SSLCert       string
-	SSLKey        string
-	Format        string
-	Reset         bool
-	NoGapFill     bool
-	GapTimeout    int // seconds
+	// MetricsScrapeInterval is how often (seconds) the bintrail_index_* gauges
+	// are refreshed from a status snapshot. 0 = the 60s default.
+	MetricsScrapeInterval int
+	SSLMode               string
+	SSLCA                 string
+	SSLCert               string
+	SSLKey                string
+	Format                string
+	Reset                 bool
+	NoGapFill             bool
+	GapTimeout            int // seconds
 	// Hooks, when non-nil, lets a supervisor observe this stream's liveness
 	// without polling. Plain `bintrail stream` leaves it nil.
 	Hooks *Hooks
@@ -1549,6 +1552,15 @@ func One(ctx context.Context, cfg Config) error {
 		metricsSource = bintrailID
 	}
 	metrics := observe.ForSource(metricsSource)
+
+	// Index-state gauges (bintrail_index_*, #351): refresh periodically from a
+	// status snapshot whenever metrics are exposed — standalone --metrics-addr
+	// or under the `bintrail-console watch` supervisor (which sets MetricsSource
+	// and serves the process-global registry on its own endpoint). The scraper
+	// stops with ctx.
+	if cfg.MetricsAddr != "" || cfg.MetricsSource != "" {
+		startIndexMetricsScraper(ctx, indexDB, cfg.IndexDSN, metricsSource, cfg.MetricsScrapeInterval)
+	}
 
 	// ── 10. StreamParser + its synchronous DDL hook ──────────────────────────
 	sp := parser.NewStreamParser(resolver, filters, nil)


### PR DESCRIPTION
Implements #351 — a `bintrail_index_*` Prometheus gauge family describing the **state of the index** a DBA cares about for recovery readiness, complementing the existing live-pipeline `bintrail_stream_*` metrics.

## Metrics (`internal/observe/metrics.go`)
New `index` subsystem gauges, all with a `source` label:
- `oldest_event_timestamp_seconds` / `newest_event_timestamp_seconds` / `retention_horizon_seconds` — the recovery floor and how far back it reaches
- `events_total` — single aggregate (NOT per-table; cardinality guard, per the issue)
- `partitions_total{kind=active|future}`
- `gap_hours` — hours rotated out of MySQL but not archived to Parquet = recovery-coverage holes
- `storage_bytes{location=mysql|parquet}`

Empty-index timestamp gauges are **left unpublished** so they never report a 1970 epoch.

## Scraper (`internal/streamrun/index_metrics.go`)
A goroutine (default 60s, new `--metrics-scrape-interval` flag) refreshes the gauges from a status snapshot, **reusing `status.CollectStatus` + `query.Plan`** rather than re-querying. Wired into the stream lifecycle whenever metrics are exposed — standalone `--metrics-addr` or the `bintrail-console watch` supervisor (which sets `MetricsSource` and serves the process-global registry). Stops with `ctx`. A scrape failure logs and leaves the prior values in place.

## `bintrail status` surfacing (folded #406 residual)
- **MySQL index storage size** in the Restore Coverage section (text + JSON) — via the shared `status.LoadIndexSizeBytes`, also feeding the `storage_bytes{mysql}` gauge.
- **Per-table baseline Parquet size** in the Baselines section (`BaselineInfo.Size`, text column + JSON `size_bytes`) — the signal that makes a large single-table baseline visible (the #208 reopen trigger, which stays NOT_PLANNED).

## Docs
New `docs/observability.md` — every metric + PromQL recipes (retention alert, gap-hours, disk-growth `predict_linear`, stream-stall).

## Tests
- `internal/observe`: `TestIndexMetricsSet` (all gauges from a synthetic snapshot, via `testutil.ToFloat64`) + `TestIndexMetricsSet_zeroTimestampsNotPublished`.
- `internal/status`: `TestStatusSurfacesIndexAndBaselineSize` (index + baseline size in text and JSON).
- Build + vet + unit green for `internal/observe`, `internal/status`, `internal/streamrun`, `cmd/bintrail`.

Closes #351. Refs #406 (status size/age residual), #208 (per-table baseline size makes its trigger measurable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)