### PR TITLE
refactor: establish internal/cli + move DuckDB tuning helpers (#529 slice 1)

### DIFF
--- a/cmd/bintrail/query.go
+++ b/cmd/bintrail/query.go
@@ -15,6 +15,7 @@ import (
 	mysqldriver "github.com/go-sql-driver/mysql"
 	"github.com/spf13/cobra"
 
+	"github.com/dbtrail/dbtrail/internal/cli"
 	"github.com/dbtrail/dbtrail/internal/cliutil"
 	"github.com/dbtrail/dbtrail/internal/config"
 	"github.com/dbtrail/dbtrail/internal/indexer"
@@ -98,7 +99,7 @@ func init() {
 	queryCmd.Flags().BoolVar(&qNoArchive, "no-archive", false, "Disable auto-routing to Parquet archives (MySQL-only results)")
 	queryCmd.Flags().BoolVar(&qIncludeSnapshot, "include-snapshot", false, "Also scan the mydumper baseline Parquet and emit matching rows as SNAPSHOT events (requires --baseline, --schema, --table)")
 	queryCmd.Flags().StringVar(&qBaseline, "baseline", "", "Path to a baseline Parquet file or directory containing <schema>/<table>.parquet (local path or s3:// URL); used with --include-snapshot")
-	addDuckDBTuningFlags(queryCmd)
+	cli.AddDuckDBTuningFlags(queryCmd)
 	_ = queryCmd.MarkFlagRequired("index-dsn")
 	bindCommandEnv(queryCmd)
 
@@ -153,7 +154,7 @@ func runQuery(cmd *cobra.Command, args []string) error {
 	if qNoArchive && (qArchiveDir != "" || qArchiveS3 != "") {
 		return fmt.Errorf("--no-archive cannot be combined with --archive-dir or --archive-s3")
 	}
-	duckTuning, err := duckDBTuningFromFlags(cmd)
+	duckTuning, err := cli.DuckDBTuningFromFlags(cmd)
 	if err != nil {
 		return err
 	}
@@ -322,7 +323,7 @@ func runQuery(cmd *cobra.Command, args []string) error {
 			cmd.Context(),
 			archSources,
 			fetchOpts,
-			tunedArchiveFetcher(duckTuning),
+			cli.TunedArchiveFetcher(duckTuning),
 			os.Stderr,
 		)
 		if err != nil {

--- a/cmd/bintrail/reconstruct.go
+++ b/cmd/bintrail/reconstruct.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/dbtrail/dbtrail/internal/baseline"
+	"github.com/dbtrail/dbtrail/internal/cli"
 	"github.com/dbtrail/dbtrail/internal/cliutil"
 	"github.com/dbtrail/dbtrail/internal/config"
 	"github.com/dbtrail/dbtrail/internal/query"
@@ -118,7 +119,7 @@ func init() {
 	reconstructCmd.Flags().StringVar(&recTables, "tables", "", "Comma-separated schema.table list for --output-format=mydumper (e.g. mydb.orders,mydb.users)")
 	reconstructCmd.Flags().StringVar(&recChunkSize, "chunk-size", "256MB", "Max size per SQL chunk file in full-table mode (e.g. 64MB, 1GB)")
 	reconstructCmd.Flags().IntVar(&recParallelism, "parallelism", 0, "Max tables to reconstruct concurrently in full-table mode (default: runtime.NumCPU())")
-	addDuckDBTuningFlags(reconstructCmd)
+	cli.AddDuckDBTuningFlags(reconstructCmd)
 	bindCommandEnv(reconstructCmd)
 
 	rootCmd.AddCommand(reconstructCmd)
@@ -268,7 +269,7 @@ func runReconstruct(cmd *cobra.Command, args []string) error {
 		Since:    &snapshotTime,
 		Until:    &at,
 	}
-	duckTuning, err := duckDBTuningFromFlags(cmd)
+	duckTuning, err := cli.DuckDBTuningFromFlags(cmd)
 	if err != nil {
 		return err
 	}
@@ -277,7 +278,7 @@ func runReconstruct(cmd *cobra.Command, args []string) error {
 		DBName:         dbName,
 		NoArchive:      recNoArchive,
 		AllowGaps:      recAllowGaps,
-		ArchiveFetcher: tunedArchiveFetcher(duckTuning),
+		ArchiveFetcher: cli.TunedArchiveFetcher(duckTuning),
 	})
 	if err != nil {
 		// Surface CLI hints only at the CLI layer; the library types
@@ -471,7 +472,7 @@ func runReconstructFullTable(cmd *cobra.Command, start time.Time) error {
 		baselineSrc = recBaselineS3
 	}
 
-	duckTuning, err := duckDBTuningFromFlags(cmd)
+	duckTuning, err := cli.DuckDBTuningFromFlags(cmd)
 	if err != nil {
 		return err
 	}
@@ -486,7 +487,7 @@ func runReconstructFullTable(cmd *cobra.Command, start time.Time) error {
 		ChunkSize:      chunkSize,
 		Parallelism:    recParallelism,
 		AllowGaps:      recAllowGaps,
-		ArchiveFetcher: tunedArchiveFetcher(duckTuning),
+		ArchiveFetcher: cli.TunedArchiveFetcher(duckTuning),
 	}
 	reports, err := reconstruct.ReconstructTables(cmd.Context(), cfg)
 	if err != nil {

--- a/cmd/bintrail/recover.go
+++ b/cmd/bintrail/recover.go
@@ -11,6 +11,7 @@ import (
 	mysqldriver "github.com/go-sql-driver/mysql"
 	"github.com/spf13/cobra"
 
+	"github.com/dbtrail/dbtrail/internal/cli"
 	"github.com/dbtrail/dbtrail/internal/cliutil"
 	"github.com/dbtrail/dbtrail/internal/config"
 	"github.com/dbtrail/dbtrail/internal/indexer"
@@ -89,7 +90,7 @@ func init() {
 	recoverCmd.Flags().StringVar(&rProfile, "profile", "", "Apply RBAC access rules for this profile (table-level deny and column-level redaction)")
 	recoverCmd.Flags().StringVar(&rFormat, "format", "text", "Output format: text or json")
 	recoverCmd.Flags().BoolVar(&rNoArchive, "no-archive", false, "Disable auto-routing to Parquet archives (MySQL-only results)")
-	addDuckDBTuningFlags(recoverCmd)
+	cli.AddDuckDBTuningFlags(recoverCmd)
 	_ = recoverCmd.MarkFlagRequired("index-dsn")
 	bindCommandEnv(recoverCmd)
 
@@ -209,7 +210,7 @@ func runRecover(cmd *cobra.Command, args []string) error {
 		dbName = cfg.DBName
 	}
 
-	duckTuning, err := duckDBTuningFromFlags(cmd)
+	duckTuning, err := cli.DuckDBTuningFromFlags(cmd)
 	if err != nil {
 		return err
 	}
@@ -218,7 +219,7 @@ func runRecover(cmd *cobra.Command, args []string) error {
 		DBName:         dbName,
 		NoArchive:      rNoArchive || rProfile != "",
 		AllowGaps:      true, // preserve recover's warn-and-continue behavior
-		ArchiveFetcher: tunedArchiveFetcher(duckTuning),
+		ArchiveFetcher: cli.TunedArchiveFetcher(duckTuning),
 	})
 	if err != nil {
 		return err

--- a/internal/cli/duckdbtuning.go
+++ b/internal/cli/duckdbtuning.go
@@ -1,4 +1,13 @@
-package main
+// Package cli holds command-layer building blocks shared across bintrail
+// binaries. It exists so a second binary (the planned PostgreSQL-native
+// bintrail-pg, #527/#529) can register the same source-agnostic read/recover
+// commands and their shared flag/helper infrastructure without duplicating the
+// command layer that lives in package main today.
+//
+// This first file extracts the DuckDB resource-tuning flags shared by the
+// offline query/recover/reconstruct commands (#510/#511). Subsequent slices of
+// #529 move the env-binding helpers and the source-agnostic commands themselves.
+package cli
 
 import (
 	"context"
@@ -40,7 +49,7 @@ func validateDuckDBMemoryLimit(s string) error {
 	return nil
 }
 
-// addDuckDBTuningFlags registers the shared DuckDB resource flags on the
+// AddDuckDBTuningFlags registers the shared DuckDB resource flags on the
 // offline query/recover/reconstruct commands. They lift the conservative,
 // container-safe DuckDB budget (threads=2, memory_limit=4GB) that
 // parquetquery.Fetch applies by default — useful on a dedicated box with
@@ -50,7 +59,7 @@ func validateDuckDBMemoryLimit(s string) error {
 //
 // --duckdb-threads default -1 (not 0) so 0 stays a meaningful explicit value:
 // "let DuckDB pick one thread per core". --duckdb-memory-limit "" means unset.
-func addDuckDBTuningFlags(cmd *cobra.Command) {
+func AddDuckDBTuningFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("ultrafast", false,
 		"trade DuckDB memory-safety for speed: let DuckDB self-tune to the host (all cores, ~80% RAM) instead of the container-safe 2 threads / 4GB cap — for big boxes, not small containers")
 	cmd.Flags().Int("duckdb-threads", -1,
@@ -59,7 +68,7 @@ func addDuckDBTuningFlags(cmd *cobra.Command) {
 		"override DuckDB memory limit, e.g. 16GB (empty keeps the mode default)")
 }
 
-// duckDBTuningFromFlags resolves the effective DuckDB tuning for a command.
+// DuckDBTuningFromFlags resolves the effective DuckDB tuning for a command.
 // Precedence: an explicit --duckdb-* flag wins over --ultrafast, which wins
 // over the conservative default. The granular flags let an operator tune to
 // their box without the all-or-nothing --ultrafast switch.
@@ -69,7 +78,7 @@ func addDuckDBTuningFlags(cmd *cobra.Command) {
 // best-effort downstream and would either silently fall back to the default
 // (a typo) or silently uncap on a negative value, neither of which an operator
 // who explicitly asked for a budget should get without being told.
-func duckDBTuningFromFlags(cmd *cobra.Command) (duckdbutil.Tuning, error) {
+func DuckDBTuningFromFlags(cmd *cobra.Command) (duckdbutil.Tuning, error) {
 	t := duckdbutil.DefaultTuning()
 	if ultrafast, _ := cmd.Flags().GetBool("ultrafast"); ultrafast {
 		t = duckdbutil.Ultrafast()
@@ -86,10 +95,10 @@ func duckDBTuningFromFlags(cmd *cobra.Command) (duckdbutil.Tuning, error) {
 	return t, nil
 }
 
-// tunedArchiveFetcher adapts a DuckDB Tuning into a query.ArchiveFetcher so the
+// TunedArchiveFetcher adapts a DuckDB Tuning into a query.ArchiveFetcher so the
 // CLI commands can inject their budget without changing parquetquery.Fetch's
 // signature (which other packages pass as a function value).
-func tunedArchiveFetcher(t duckdbutil.Tuning) query.ArchiveFetcher {
+func TunedArchiveFetcher(t duckdbutil.Tuning) query.ArchiveFetcher {
 	return func(ctx context.Context, opts query.Options, source string) ([]query.ResultRow, error) {
 		return parquetquery.FetchWithTuning(ctx, opts, source, t)
 	}

--- a/internal/cli/duckdbtuning.go
+++ b/internal/cli/duckdbtuning.go
@@ -1,12 +1,15 @@
-// Package cli holds command-layer building blocks shared across bintrail
-// binaries. It exists so a second binary (the planned PostgreSQL-native
+// Package cli holds command-layer building blocks intended to be shared across
+// bintrail binaries. It exists so a second binary (the planned PostgreSQL-native
 // bintrail-pg, #527/#529) can register the same source-agnostic read/recover
 // commands and their shared flag/helper infrastructure without duplicating the
 // command layer that lives in package main today.
 //
-// This first file extracts the DuckDB resource-tuning flags shared by the
-// offline query/recover/reconstruct commands (#510/#511). Subsequent slices of
-// #529 move the env-binding helpers and the source-agnostic commands themselves.
+// Today it holds only shared flag/helper infrastructure — this first file
+// extracts the DuckDB resource-tuning flags shared by the offline
+// query/recover/reconstruct commands (#510/#511), and cmd/bintrail is its only
+// importer. Subsequent slices of #529 move the env-binding helpers and the
+// source-agnostic commands themselves, at which point bintrail-pg becomes a
+// second importer.
 package cli
 
 import (

--- a/internal/cli/duckdbtuning_test.go
+++ b/internal/cli/duckdbtuning_test.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"testing"
@@ -101,24 +101,24 @@ func TestDuckDBTuningFromFlags(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cmd := &cobra.Command{Use: "test"}
-			addDuckDBTuningFlags(cmd)
+			AddDuckDBTuningFlags(cmd)
 			for flag, val := range tt.flags {
 				if err := cmd.Flags().Set(flag, val); err != nil {
 					t.Fatalf("set --%s=%s: %v", flag, val, err)
 				}
 			}
-			got, err := duckDBTuningFromFlags(cmd)
+			got, err := DuckDBTuningFromFlags(cmd)
 			if tt.wantErr {
 				if err == nil {
-					t.Fatalf("duckDBTuningFromFlags() = %+v, want error", got)
+					t.Fatalf("DuckDBTuningFromFlags() = %+v, want error", got)
 				}
 				return
 			}
 			if err != nil {
-				t.Fatalf("duckDBTuningFromFlags() unexpected error: %v", err)
+				t.Fatalf("DuckDBTuningFromFlags() unexpected error: %v", err)
 			}
 			if got != tt.want {
-				t.Fatalf("duckDBTuningFromFlags() = %+v, want %+v", got, tt.want)
+				t.Fatalf("DuckDBTuningFromFlags() = %+v, want %+v", got, tt.want)
 			}
 		})
 	}
@@ -127,7 +127,7 @@ func TestDuckDBTuningFromFlags(t *testing.T) {
 // TestTunedArchiveFetcherNonNil: the adapter must always return a usable
 // fetcher (it is passed where a nil ArchiveFetcher is a hard error).
 func TestTunedArchiveFetcherNonNil(t *testing.T) {
-	if tunedArchiveFetcher(duckdbutil.DefaultTuning()) == nil {
-		t.Fatal("tunedArchiveFetcher returned nil")
+	if TunedArchiveFetcher(duckdbutil.DefaultTuning()) == nil {
+		t.Fatal("TunedArchiveFetcher returned nil")
 	}
 }


### PR DESCRIPTION
## What

**First slice of #529** — establishes the shared `internal/cli` package and moves the self-contained DuckDB resource-tuning helpers into it.

#529 extracts the command layer from `cmd/bintrail` (`package main`) into a shared `internal/cli` so the planned PostgreSQL-native `bintrail-pg` (#527) can register the same source-agnostic read commands (`query`/`recover`/`reconstruct`/`status`/`shim`) without duplicating them. This PR lays the foundation.

## Changes

- New `internal/cli` package.
- Moves the DuckDB tuning helpers (`#510`/`#511`) — shared by `query`/`recover`/`reconstruct` — into it: `AddDuckDBTuningFlags`, `DuckDBTuningFromFlags`, `TunedArchiveFetcher` (exported), plus `validateDuckDBMemoryLimit` and the precedence/validation tests.
- Repoints `query`/`recover`/`reconstruct` to `cli.*`.

## Approach (set with advisor for the whole of #529)

- **Lift-and-shift, not constructor rewrites**: move files (and their tests) into `internal/cli` keeping the existing patterns; two binaries are two processes, so package-level vars are fine. Turns "rewrite" into "move + repoint".
- **Scope**: the source-agnostic read commands only (`query`/`recover`/`reconstruct`/`status`/`shim`); `snapshot` stays out (it reads the *source* schema → belongs with the pgcapture work, #530). No source parameter on the read commands — parameterization lives in each binary's `main`.
- **Sequencing**: helpers (this PR) → `status` pilot (validates the command lift-and-shift on the cheapest case) → `query`/`recover`/`reconstruct` → `shim` (its own slice; it links `go-mysql/server` for the wire protocol, orthogonal to the #528 isolation). `e2e_test.go` is the behavioral guarantee across all slices.

## Verification

- `go build ./...` ✓, `go vet ./...` ✓, gofmt-clean ✓
- Full unit suite (30 packages, incl. the moved tests in `internal/cli` and the `cmd/bintrail` uifree guard) ✓
- Pure no-op refactor — behavior unchanged.

Part of #529. Foundation for #527 (PostgreSQL-as-source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
