### PR TITLE
feat: synthesize stable bintrail_id for MariaDB sources (no @@server_uuid)

### DIFF
--- a/cmd/bintrail/rotate.go
+++ b/cmd/bintrail/rotate.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"os/signal"
 	"syscall"
 	"time"
@@ -73,9 +76,9 @@ func init() {
 	rotateCmd.Flags().StringVar(&rotRetain, "retain", "", "Drop partitions older than this duration (e.g. 7d, 24h)")
 	rotateCmd.Flags().IntVar(&rotAddFuture, "add-future", 0, "Maintain at least N future hourly partitions beyond the current hour (declarative target; top-up only)")
 	rotateCmd.Flags().BoolVar(&rotNoReplace, "no-replace", false, "Do not auto-add future partitions to replace dropped ones (only top up toward --add-future)")
-	rotateCmd.Flags().StringVar(&rotArchiveDir, "archive-dir", "", "Directory to write Parquet archives before dropping partitions (required with --bintrail-id)")
+	rotateCmd.Flags().StringVar(&rotArchiveDir, "archive-dir", "", "Directory to write Parquet archives before dropping partitions")
 	rotateCmd.Flags().StringVar(&rotArchiveCompression, "archive-compression", "zstd", "Compression for archive Parquet files (zstd, snappy, gzip, none)")
-	rotateCmd.Flags().StringVar(&rotBintrailID, "bintrail-id", "", "Server identity UUID (required when --archive-dir is set); archives are written under bintrail_id=<uuid>/event_date=<date>/")
+	rotateCmd.Flags().StringVar(&rotBintrailID, "bintrail-id", "", "Server identity UUID for archive paths (bintrail_id=<uuid>/event_date=<date>/). When --archive-dir is set and this is omitted, the bintrail_id recorded in stream_state is used; an explicit value always wins")
 	rotateCmd.Flags().StringVar(&rotArchiveS3, "archive-s3", "", "S3 destination URL to upload Parquet archives after writing (requires --archive-dir; e.g. s3://my-bucket/archives/)")
 	rotateCmd.Flags().StringVar(&rotArchiveS3Region, "archive-s3-region", "", "AWS region for --archive-s3 (default: from AWS_REGION env var or ~/.aws/config)")
 	rotateCmd.Flags().BoolVar(&rotDaemon, "daemon", false, "Run continuously, repeating rotation on the --interval schedule until SIGINT/SIGTERM")
@@ -88,6 +91,52 @@ func init() {
 	rootCmd.AddCommand(rotateCmd)
 }
 
+// resolveArchiveBintrailID determines the bintrail_id used as the archive
+// S3/Hive partition key. Precedence:
+//
+//  1. An explicitly CLI-typed --bintrail-id — the operator's per-invocation
+//     intent. This preserves every existing invocation (the flag used to be
+//     required) byte-for-byte.
+//  2. The per-server bintrail_id recorded in stream_state (resolved at
+//     stream/index time — the synthesized one for MariaDB, the
+//     @@server_uuid-derived one for MySQL).
+//  3. A BINTRAIL_ID environment value, as a last resort (with a loud warning).
+//
+// flagValue carries whatever bindCommandEnv left on --bintrail-id, which may be
+// CLI-typed OR injected from BINTRAIL_ID — cobra cannot tell them apart, since
+// env binding uses Flags().Set (marking the flag Changed just like a CLI value).
+// We infer: a flagValue that differs from envValue (os.Getenv("BINTRAIL_ID"))
+// was typed on the CLI. This distinction is the whole point — a single GLOBAL
+// BINTRAIL_ID must NOT silently become the write key for every server, which
+// would collapse multiple servers' archives into one bintrail_id=<id>/ prefix
+// (the exact collision this guards against). It errors when nothing is
+// available, so an archive run can never write to an empty bintrail_id= prefix.
+func resolveArchiveBintrailID(ctx context.Context, db *sql.DB, flagValue, envValue string) (string, error) {
+	// Tier 1: an explicitly CLI-typed flag (value differs from the env var).
+	if flagValue != "" && flagValue != envValue {
+		return flagValue, nil
+	}
+
+	// Tier 2: the per-server id resolved into stream_state.
+	var id sql.NullString
+	err := db.QueryRowContext(ctx, "SELECT bintrail_id FROM stream_state WHERE id = 1").Scan(&id)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return "", fmt.Errorf("read bintrail_id from stream_state: %w", err)
+	}
+	if id.Valid && id.String != "" {
+		return id.String, nil
+	}
+
+	// Tier 3: a BINTRAIL_ID env value, only when no per-server id exists. Warn —
+	// reusing one global id across servers collides their archives in S3.
+	if flagValue != "" {
+		slog.Warn("archiving under the global BINTRAIL_ID environment value: no per-server bintrail_id is recorded in stream_state. If you capture more than one server, set a per-source BINTRAIL_ID or pass an explicit --bintrail-id, or their archives will collide under one prefix",
+			"bintrail_id", flagValue)
+		return flagValue, nil
+	}
+	return "", fmt.Errorf("--bintrail-id is required when --archive-dir is set: no bintrail_id is recorded in stream_state to fall back to")
+}
+
 func runRotate(cmd *cobra.Command, args []string) error {
 	if !cliutil.IsValidOutputFormat(rotFormat) {
 		return fmt.Errorf("invalid --format %q; must be text or json", rotFormat)
@@ -95,9 +144,12 @@ func runRotate(cmd *cobra.Command, args []string) error {
 	if rotRetain == "" && rotAddFuture == 0 {
 		return fmt.Errorf("at least one of --retain or --add-future is required")
 	}
-	if rotArchiveDir != "" && rotBintrailID == "" {
-		return fmt.Errorf("--bintrail-id is required when --archive-dir is set")
-	}
+	// NOTE: --bintrail-id is no longer required at parse time when archiving. When
+	// it is omitted we fall back to the bintrail_id already resolved into
+	// stream_state (resolveArchiveBintrailID, inside doRotation, after the DB is
+	// open). An explicit --bintrail-id always wins. This needs the DB, so the
+	// "neither flag nor resolved id" failure surfaces on the first rotation rather
+	// than here.
 	if rotArchiveS3 != "" && rotArchiveDir == "" {
 		return fmt.Errorf("--archive-s3 requires --archive-dir")
 	}
@@ -140,6 +192,20 @@ func runRotate(cmd *cobra.Command, args []string) error {
 		if err := indexer.EnsureSchema(db); err != nil {
 			return fmt.Errorf("schema migration: %w", err)
 		}
+
+		// Resolve the bintrail_id used as the archive S3/Hive partition key. An
+		// explicit --bintrail-id wins; otherwise fall back to the id already
+		// resolved into stream_state (so MariaDB sources — which have no
+		// @@server_uuid and thus get a synthesized id — and MySQL alike namespace
+		// their archives correctly without the operator re-typing the id).
+		archiveBintrailID := rotBintrailID
+		if rotArchiveDir != "" {
+			archiveBintrailID, err = resolveArchiveBintrailID(ctx, db, rotBintrailID, os.Getenv("BINTRAIL_ID"))
+			if err != nil {
+				return err
+			}
+		}
+
 		res, err := rotation.Perform(ctx, db, dbName, rotation.Options{
 			RetainDur:          retainDur,
 			RetainRaw:          rotRetain,
@@ -147,7 +213,7 @@ func runRotate(cmd *cobra.Command, args []string) error {
 			NoReplace:          rotNoReplace,
 			ArchiveDir:         rotArchiveDir,
 			ArchiveCompression: rotArchiveCompression,
-			BintrailID:         rotBintrailID,
+			BintrailID:         archiveBintrailID,
 			ArchiveS3:          rotArchiveS3,
 			ArchiveS3Region:    rotArchiveS3Region,
 			Retry:              rotRetry,

--- a/cmd/bintrail/rotate.go
+++ b/cmd/bintrail/rotate.go
@@ -91,12 +91,18 @@ func init() {
 	rootCmd.AddCommand(rotateCmd)
 }
 
+// errNoArchiveBintrailID is the precondition error from resolveArchiveBintrailID
+// when no archive bintrail_id can be determined (no CLI flag, no stream_state id,
+// no BINTRAIL_ID env). It is a PERMANENT misconfiguration that can never self-heal
+// on retry, so daemon mode fails loud on it at startup (via errors.Is) rather than
+// spinning silently while the index disk fills.
+var errNoArchiveBintrailID = errors.New("--bintrail-id is required when --archive-dir is set: no bintrail_id is recorded in stream_state to fall back to")
+
 // resolveArchiveBintrailID determines the bintrail_id used as the archive
 // S3/Hive partition key. Precedence:
 //
 //  1. An explicitly CLI-typed --bintrail-id — the operator's per-invocation
-//     intent. This preserves every existing invocation (the flag used to be
-//     required) byte-for-byte.
+//     intent. This preserves every existing CLI-typed invocation byte-for-byte.
 //  2. The per-server bintrail_id recorded in stream_state (resolved at
 //     stream/index time — the synthesized one for MariaDB, the
 //     @@server_uuid-derived one for MySQL).
@@ -109,8 +115,9 @@ func init() {
 // was typed on the CLI. This distinction is the whole point — a single GLOBAL
 // BINTRAIL_ID must NOT silently become the write key for every server, which
 // would collapse multiple servers' archives into one bintrail_id=<id>/ prefix
-// (the exact collision this guards against). It errors when nothing is
-// available, so an archive run can never write to an empty bintrail_id= prefix.
+// (the exact collision this guards against). It returns errNoArchiveBintrailID
+// when nothing is available, so an archive run can never write to an empty
+// bintrail_id= prefix.
 func resolveArchiveBintrailID(ctx context.Context, db *sql.DB, flagValue, envValue string) (string, error) {
 	// Tier 1: an explicitly CLI-typed flag (value differs from the env var).
 	if flagValue != "" && flagValue != envValue {
@@ -124,6 +131,14 @@ func resolveArchiveBintrailID(ctx context.Context, db *sql.DB, flagValue, envVal
 		return "", fmt.Errorf("read bintrail_id from stream_state: %w", err)
 	}
 	if id.Valid && id.String != "" {
+		// A non-empty flagValue at this point can only be env-derived (a CLI-typed
+		// value would have won Tier 1). If it disagrees with the per-server id, the
+		// env value is being overridden — surface it rather than silently honoring
+		// stream_state, since the flag help promises an explicit value wins.
+		if flagValue != "" && flagValue != id.String {
+			slog.Warn("--bintrail-id matches BINTRAIL_ID and was treated as environment-derived; using the per-server stream_state bintrail_id instead. To force a value, make --bintrail-id differ from BINTRAIL_ID (or unset BINTRAIL_ID)",
+				"requested", flagValue, "using", id.String)
+		}
 		return id.String, nil
 	}
 
@@ -134,7 +149,7 @@ func resolveArchiveBintrailID(ctx context.Context, db *sql.DB, flagValue, envVal
 			"bintrail_id", flagValue)
 		return flagValue, nil
 	}
-	return "", fmt.Errorf("--bintrail-id is required when --archive-dir is set: no bintrail_id is recorded in stream_state to fall back to")
+	return "", errNoArchiveBintrailID
 }
 
 func runRotate(cmd *cobra.Command, args []string) error {
@@ -244,6 +259,14 @@ func runRotate(cmd *cobra.Command, args []string) error {
 
 	slog.Info("rotate daemon started", "interval", interval)
 	if err := doRotation(ctx); err != nil && ctx.Err() == nil {
+		// A permanent precondition error (no resolvable archive bintrail_id) will
+		// never self-heal on the next tick, so spinning silently would hide a
+		// misconfig while the index disk fills. Fail loud at startup. Transient
+		// errors (DB blip, a not-yet-ready index DB) stay log-and-continue so the
+		// daemon self-heals on the next tick.
+		if errors.Is(err, errNoArchiveBintrailID) {
+			return fmt.Errorf("rotate --daemon cannot start: %w", err)
+		}
 		slog.Error("rotation failed", "error", err)
 	}
 

--- a/cmd/bintrail/rotate_test.go
+++ b/cmd/bintrail/rotate_test.go
@@ -308,8 +308,8 @@ func TestResolveArchiveBintrailID_nullStreamStateErrors(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when stream_state bintrail_id is NULL")
 	}
-	if !strings.Contains(err.Error(), "--bintrail-id is required") {
-		t.Errorf("error %q should explain --bintrail-id is required", err)
+	if !errors.Is(err, errNoArchiveBintrailID) {
+		t.Errorf("error %v should be errNoArchiveBintrailID (daemon fail-loud-at-startup depends on this sentinel)", err)
 	}
 }
 
@@ -328,8 +328,8 @@ func TestResolveArchiveBintrailID_noCheckpointErrors(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when no stream_state row exists")
 	}
-	if !strings.Contains(err.Error(), "--bintrail-id is required") {
-		t.Errorf("error %q should explain --bintrail-id is required", err)
+	if !errors.Is(err, errNoArchiveBintrailID) {
+		t.Errorf("error %v should be errNoArchiveBintrailID (daemon fail-loud-at-startup depends on this sentinel)", err)
 	}
 }
 

--- a/cmd/bintrail/rotate_test.go
+++ b/cmd/bintrail/rotate_test.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"strings"
 	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
 )
 
 // ─── cobra command wiring ────────────────────────────────────────────────────
@@ -242,5 +246,156 @@ func TestRunRotate_daemonInvalidInterval(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "--interval") {
 		t.Errorf("expected '--interval' in error, got: %v", err)
+	}
+}
+
+// ─── archive bintrail-id resolution (flag > stream_state fallback) ────────────
+
+func TestResolveArchiveBintrailID_flagWins(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	// An explicit --bintrail-id must short-circuit before any DB read, so every
+	// existing invocation (which always passed the flag) is byte-for-byte
+	// unchanged and never depends on stream_state.
+	got, err := resolveArchiveBintrailID(context.Background(), db, "explicit-id", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "explicit-id" {
+		t.Errorf("got %q, want explicit-id", got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("expected no DB query when flag is set: %v", err)
+	}
+}
+
+func TestResolveArchiveBintrailID_fallsBackToStreamState(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT bintrail_id FROM stream_state").WillReturnRows(
+		sqlmock.NewRows([]string{"bintrail_id"}).AddRow("resolved-from-checkpoint"))
+
+	got, err := resolveArchiveBintrailID(context.Background(), db, "", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "resolved-from-checkpoint" {
+		t.Errorf("got %q, want resolved-from-checkpoint", got)
+	}
+}
+
+func TestResolveArchiveBintrailID_nullStreamStateErrors(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	// A NULL bintrail_id (e.g. a pre-identity checkpoint) must NOT pass as a valid
+	// empty prefix — archiving to bintrail_id= would collide across servers.
+	mock.ExpectQuery("SELECT bintrail_id FROM stream_state").WillReturnRows(
+		sqlmock.NewRows([]string{"bintrail_id"}).AddRow(nil))
+
+	_, err = resolveArchiveBintrailID(context.Background(), db, "", "")
+	if err == nil {
+		t.Fatal("expected error when stream_state bintrail_id is NULL")
+	}
+	if !strings.Contains(err.Error(), "--bintrail-id is required") {
+		t.Errorf("error %q should explain --bintrail-id is required", err)
+	}
+}
+
+func TestResolveArchiveBintrailID_noCheckpointErrors(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	// No stream_state row at all (rotate run before any stream/index).
+	mock.ExpectQuery("SELECT bintrail_id FROM stream_state").WillReturnRows(
+		sqlmock.NewRows([]string{"bintrail_id"}))
+
+	_, err = resolveArchiveBintrailID(context.Background(), db, "", "")
+	if err == nil {
+		t.Fatal("expected error when no stream_state row exists")
+	}
+	if !strings.Contains(err.Error(), "--bintrail-id is required") {
+		t.Errorf("error %q should explain --bintrail-id is required", err)
+	}
+}
+
+func TestResolveArchiveBintrailID_queryErrorPropagates(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT bintrail_id FROM stream_state").WillReturnError(
+		errors.New("connection reset"))
+
+	_, err = resolveArchiveBintrailID(context.Background(), db, "", "")
+	if err == nil {
+		t.Fatal("expected error when the stream_state query fails")
+	}
+	if !strings.Contains(err.Error(), "read bintrail_id from stream_state") {
+		t.Errorf("error %q should wrap the stream_state read failure", err)
+	}
+}
+
+// TestResolveArchiveBintrailID_envDoesNotOutrankStreamState is the regression
+// guard for the collision blocker: a value sourced from the global BINTRAIL_ID
+// env var (flagValue == envValue) must NOT win over the per-server bintrail_id in
+// stream_state. Otherwise one global BINTRAIL_ID set in config.env would make
+// every server archive under the same bintrail_id=<id>/ prefix in S3.
+func TestResolveArchiveBintrailID_envDoesNotOutrankStreamState(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT bintrail_id FROM stream_state").WillReturnRows(
+		sqlmock.NewRows([]string{"bintrail_id"}).AddRow("per-server-id"))
+
+	// flagValue == envValue → the flag was injected from BINTRAIL_ID, not typed.
+	got, err := resolveArchiveBintrailID(context.Background(), db, "global-env-id", "global-env-id")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "per-server-id" {
+		t.Errorf("got %q, want per-server-id (env must not outrank stream_state)", got)
+	}
+}
+
+// TestResolveArchiveBintrailID_envFallbackWhenNoStreamState confirms a global
+// BINTRAIL_ID is still honored as a last resort when no per-server id exists
+// (e.g. a file-index backfill with no stream_state row), so env-only workflows
+// keep working.
+func TestResolveArchiveBintrailID_envFallbackWhenNoStreamState(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT bintrail_id FROM stream_state").WillReturnRows(
+		sqlmock.NewRows([]string{"bintrail_id"})) // no row
+
+	got, err := resolveArchiveBintrailID(context.Background(), db, "env-id", "env-id")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "env-id" {
+		t.Errorf("got %q, want env-id (env fallback when no stream_state id)", got)
 	}
 }

--- a/docs/mariadb.md
+++ b/docs/mariadb.md
@@ -53,8 +53,58 @@ Identical to a MySQL source (see [Streaming → The Source MySQL User](streaming
 | Source user grants | `REPLICATION SLAVE, REPLICATION CLIENT, SELECT` — the same set as MySQL. |
 
 > MariaDB does not have a `server_uuid` system variable. You will see a benign
-> `WARN … Unknown system variable 'server_uuid'` at startup — bintrail proceeds
-> without a `bintrail_id`. This is expected on MariaDB and not an error.
+> `WARN … Unknown system variable 'server_uuid'` at startup — this is expected
+> and not an error. Because MySQL's stable identity anchor is absent, bintrail
+> **synthesizes a stable `bintrail_id` from the source address** (`host:port`)
+> instead. See [Server identity on MariaDB](#server-identity-on-mariadb) below —
+> it matters when you capture **more than one** MariaDB server.
+
+---
+
+## Server identity on MariaDB
+
+On MySQL, bintrail derives each server's stable `bintrail_id` from `@@server_uuid`.
+MariaDB has no such variable, so bintrail **synthesizes the identity anchor from
+the source address** (`host:port`) and runs it through the same registration
+logic. The result is a normal `bintrail_id` recorded in `bintrail_servers` and
+`stream_state` — identical downstream behavior to MySQL.
+
+Two consequences worth understanding:
+
+- **Stable across restarts.** The same MariaDB server (same address) always
+  resolves to the same `bintrail_id`, so resume and archive paths are stable.
+- **Distinct per server — this is what keeps two servers apart in S3.** Parquet
+  archives are written under `bintrail_id=<id>/event_date=…/`. Two MariaDB
+  servers reached at distinct addresses synthesize **distinct** `bintrail_id`s
+  and land in **distinct** S3 prefixes automatically — no manual bookkeeping, no
+  collision.
+
+> **The address must actually differ per server.** Because the anchor is
+> `host:port`, two *different* MariaDB servers reached through the **same**
+> address (a shared proxy/VIP, or both via a `127.0.0.1` tunnel) synthesize the
+> **same** anchor and would collide under one prefix. Give each server a distinct
+> address, or pass an explicit `--bintrail-id` per server.
+
+When you archive with `bintrail rotate --archive-dir … [--archive-s3 …]`, you no
+longer need to pass `--bintrail-id` by hand: it defaults to the `bintrail_id`
+recorded in `stream_state` (the synthesized one for MariaDB). Precedence is
+**explicit `--bintrail-id` (typed on the CLI) > the `stream_state` id > a global
+`BINTRAIL_ID` env var** — so one `BINTRAIL_ID` in a shared `config.env` can never
+silently become the write key for every server. Two caveats:
+
+- A **file-based `bintrail index`** backfill records identity in `index_state`,
+  not `stream_state`, so `rotate` has nothing to fall back to — pass an explicit
+  `--bintrail-id` when archiving an index-only (never-streamed) source. It fails
+  loud ("no bintrail_id recorded in stream_state") rather than guessing.
+- A `BINTRAIL_ID` env var is used only as a last resort (no `stream_state` id),
+  and `rotate` warns when it does, since reusing one across servers collides them.
+
+> **Address changes split history.** Because the anchor is `host:port`, moving a
+> MariaDB server to a new address (or capturing the same server through two
+> different hostnames) yields a *new* `bintrail_id`, so its archives continue
+> under a new S3 prefix. This is the documented trade-off for MariaDB having no
+> migration-stable identity; pin a stable address, or pass an explicit
+> `--bintrail-id` to keep one identity across an address change.
 
 ---
 
@@ -112,7 +162,7 @@ Identical to a MySQL source (see [Streaming → The Source MySQL User](streaming
 
 | Symptom | Cause / fix |
 |---|---|
-| `WARN … Unknown system variable 'server_uuid'` | Expected — MariaDB has no `server_uuid`. Benign; bintrail proceeds without a `bintrail_id`. |
+| `WARN … Unknown system variable 'server_uuid'` | Expected — MariaDB has no `server_uuid`. Benign; bintrail synthesizes a stable `bintrail_id` from the source address instead. See [Server identity on MariaDB](#server-identity-on-mariadb). |
 | `invalid Mysql GTID` when starting against MariaDB | You omitted `--source-flavor mariadb` — the MariaDB GTID set was parsed as a MySQL set. Add the flag. |
 | `WARN source flavor mismatch: configured … detected …` | `--source-flavor` doesn't match the server's actual flavor. Set it to match. |
 | `saved checkpoint is source flavor "mariadb" but "mysql" was requested` | You resumed a MariaDB checkpoint without `--source-flavor mariadb`. Add the flag, or `--reset` to start fresh. |

--- a/docs/mariadb.md
+++ b/docs/mariadb.md
@@ -52,12 +52,14 @@ Identical to a MySQL source (see [Streaming → The Source MySQL User](streaming
 | `log_bin = ON` | Binary logging must be enabled. |
 | Source user grants | `REPLICATION SLAVE, REPLICATION CLIENT, SELECT` — the same set as MySQL. |
 
-> MariaDB does not have a `server_uuid` system variable. You will see a benign
-> `WARN … Unknown system variable 'server_uuid'` at startup — this is expected
-> and not an error. Because MySQL's stable identity anchor is absent, bintrail
-> **synthesizes a stable `bintrail_id` from the source address** (`host:port`)
-> instead. See [Server identity on MariaDB](#server-identity-on-mariadb) below —
-> it matters when you capture **more than one** MariaDB server.
+> MariaDB does not have a `server_uuid` system variable. bintrail detects this
+> and emits a benign `WARN … MariaDB source has no @@server_uuid; synthesized a
+> stable bintrail_id anchor …` at startup — expected, not an error. (You will
+> *not* see a raw `Unknown system variable 'server_uuid'` driver error: bintrail
+> swallows it and synthesizes instead.) Because MySQL's stable identity anchor is
+> absent, bintrail **synthesizes a stable `bintrail_id` from the source address**
+> (`host:port`) instead. See [Server identity on MariaDB](#server-identity-on-mariadb)
+> below — it matters when you capture **more than one** MariaDB server.
 
 ---
 
@@ -162,7 +164,7 @@ silently become the write key for every server. Two caveats:
 
 | Symptom | Cause / fix |
 |---|---|
-| `WARN … Unknown system variable 'server_uuid'` | Expected — MariaDB has no `server_uuid`. Benign; bintrail synthesizes a stable `bintrail_id` from the source address instead. See [Server identity on MariaDB](#server-identity-on-mariadb). |
+| `WARN … MariaDB source has no @@server_uuid; synthesized …` | Expected — MariaDB has no `server_uuid`. Benign; bintrail synthesizes a stable `bintrail_id` from the source address instead. See [Server identity on MariaDB](#server-identity-on-mariadb). |
 | `invalid Mysql GTID` when starting against MariaDB | You omitted `--source-flavor mariadb` — the MariaDB GTID set was parsed as a MySQL set. Add the flag. |
 | `WARN source flavor mismatch: configured … detected …` | `--source-flavor` doesn't match the server's actual flavor. Set it to match. |
 | `saved checkpoint is source flavor "mariadb" but "mysql" was requested` | You resumed a MariaDB checkpoint without `--source-flavor mariadb`. Add the flag, or `--reset` to start fresh. |

--- a/internal/byos/identity.go
+++ b/internal/byos/identity.go
@@ -4,14 +4,18 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log/slog"
 
 	"github.com/dbtrail/dbtrail/internal/config"
+	"github.com/dbtrail/dbtrail/internal/metadata"
 	"github.com/dbtrail/dbtrail/internal/serverid"
 )
 
-// ResolveServerIdentity queries @@server_uuid from sourceDB, parses the host,
-// port, and username from sourceDSN, then resolves or registers the server in
-// the index database. Returns the stable bintrail_id.
+// ResolveServerIdentity captures the source server's identity anchor
+// (@@server_uuid on MySQL, or a synthesized address-derived anchor on MariaDB —
+// see LoadSourceIdentity), parses the host, port, and username from sourceDSN,
+// then resolves or registers the server in the index database. Returns the
+// stable bintrail_id.
 func ResolveServerIdentity(ctx context.Context, sourceDB, indexDB *sql.DB, sourceDSN string) (string, error) {
 	ident, err := LoadSourceIdentity(ctx, sourceDB, sourceDSN)
 	if err != nil {
@@ -20,21 +24,37 @@ func ResolveServerIdentity(ctx context.Context, sourceDB, indexDB *sql.DB, sourc
 	return serverid.ResolveServer(ctx, indexDB, ident.ServerUUID, ident.Host, uint16(ident.Port), ident.User)
 }
 
-// LoadSourceIdentity captures the source MySQL server's @@server_uuid plus
-// host/port/user parsed from sourceDSN. The result is stamped onto every
-// BYOS MetadataRecord so the dbtrail SaaS side can resolve a stable
+// LoadSourceIdentity captures the source server's identity anchor plus
+// host/port/user parsed from sourceDSN. For MySQL the anchor is @@server_uuid;
+// for MariaDB (which has no @@server_uuid) it is a stable UUID synthesized from
+// the source address (see serverid.SyntheticServerUUID). The result is stamped
+// onto every BYOS MetadataRecord so the dbtrail SaaS side can resolve a stable
 // bintrail_id against its own bintrail_servers table — see
 // bintrail-saas-architecture.md §22.11. Safe to call even when no index DB
 // is available locally (the agent is running in fully stateless BYOS mode).
 func LoadSourceIdentity(ctx context.Context, sourceDB *sql.DB, sourceDSN string) (SourceIdentity, error) {
-	var serverUUID string
-	if err := sourceDB.QueryRowContext(ctx, "SELECT @@server_uuid").Scan(&serverUUID); err != nil {
-		return SourceIdentity{}, fmt.Errorf("query server_uuid: %w", err)
-	}
 	host, port, user, _, err := config.ParseSourceDSN(sourceDSN)
 	if err != nil {
 		return SourceIdentity{}, err
 	}
+
+	var serverUUID string
+	if uuidErr := sourceDB.QueryRowContext(ctx, "SELECT @@server_uuid").Scan(&serverUUID); uuidErr != nil {
+		// @@server_uuid is unavailable. The expected cause is a MariaDB source —
+		// MariaDB has no such system variable. Confirm the flavor via VERSION()
+		// before synthesizing an anchor, so a genuine MySQL failure (permissions,
+		// timeout, dropped connection) still propagates instead of silently
+		// fabricating an identity. A MySQL source therefore never reaches the
+		// synthesis path: its @@server_uuid query succeeds, and even on failure
+		// DetectFlavor reports "mysql"/"" and the error is returned as before.
+		if metadata.DetectFlavor(sourceDB) != "mariadb" {
+			return SourceIdentity{}, fmt.Errorf("query server_uuid: %w", uuidErr)
+		}
+		serverUUID = serverid.SyntheticServerUUID(host, port)
+		slog.Warn("MariaDB source has no @@server_uuid; synthesized a stable bintrail_id anchor from the source address — set a distinct address per server to keep their archives separate in S3",
+			"host", host, "port", port, "synthetic_server_uuid", serverUUID)
+	}
+
 	return SourceIdentity{
 		ServerUUID: serverUUID,
 		Host:       host,

--- a/internal/byos/identity_mariadb_integration_test.go
+++ b/internal/byos/identity_mariadb_integration_test.go
@@ -1,0 +1,61 @@
+//go:build integration
+
+package byos
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/config"
+	"github.com/dbtrail/dbtrail/internal/serverid"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestResolveServerIdentity_MariaDB_Integration exercises the full identity path
+// against a REAL MariaDB source. MariaDB has no @@server_uuid, so the anchor is
+// synthesized from the address; ResolveServer must then register a stable,
+// non-empty bintrail_id, and a repeat call must return the same id. This is the
+// end-to-end proof that two MariaDB servers (distinct addresses → distinct
+// anchors) auto-separate into distinct archive prefixes.
+func TestResolveServerIdentity_MariaDB_Integration(t *testing.T) {
+	sourceDB, srcName := testutil.CreateTestMariaDB(t) // skips/fails if no MariaDB
+	indexDB, _ := testutil.CreateTestDB(t)             // MySQL index (13306)
+	testutil.InitIndexTables(t, indexDB)
+
+	dsn := testutil.MariaDBBaseDSN() + "/" + srcName
+	ctx := context.Background()
+
+	id1, err := ResolveServerIdentity(ctx, sourceDB, indexDB, dsn)
+	if err != nil {
+		t.Fatalf("ResolveServerIdentity (MariaDB): %v", err)
+	}
+	if id1 == "" {
+		t.Fatal("expected a synthesized bintrail_id for MariaDB, got empty")
+	}
+
+	// Idempotent: the same source resolves to the same bintrail_id (rule 1
+	// no-op against the row just registered).
+	id2, err := ResolveServerIdentity(ctx, sourceDB, indexDB, dsn)
+	if err != nil {
+		t.Fatalf("second ResolveServerIdentity: %v", err)
+	}
+	if id1 != id2 {
+		t.Errorf("bintrail_id not stable across calls: first %q, second %q", id1, id2)
+	}
+
+	// The registered anchor is the address-derived synthetic UUID — confirming
+	// the synthesis path (not @@server_uuid) was taken.
+	host, port, _, _, err := config.ParseSourceDSN(dsn)
+	if err != nil {
+		t.Fatalf("ParseSourceDSN: %v", err)
+	}
+	want := serverid.SyntheticServerUUID(host, port)
+	var got string
+	if err := indexDB.QueryRow(
+		"SELECT server_uuid FROM bintrail_servers WHERE bintrail_id = ?", id1).Scan(&got); err != nil {
+		t.Fatalf("read bintrail_servers: %v", err)
+	}
+	if got != want {
+		t.Errorf("registered server_uuid = %q, want synthesized %q", got, want)
+	}
+}

--- a/internal/byos/identity_test.go
+++ b/internal/byos/identity_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/dbtrail/dbtrail/internal/serverid"
 )
 
 func TestLoadSourceIdentityHappyPath(t *testing.T) {
@@ -36,6 +38,10 @@ func TestLoadSourceIdentityHappyPath(t *testing.T) {
 	}
 }
 
+// TestLoadSourceIdentityServerUUIDQueryFails confirms that on a MySQL source
+// (VERSION() does not contain "MariaDB") a failed @@server_uuid query is still
+// surfaced as an error — never silently replaced by a synthesized anchor. The
+// synthesis path is reserved for genuine MariaDB sources (next test).
 func TestLoadSourceIdentityServerUUIDQueryFails(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -44,27 +50,65 @@ func TestLoadSourceIdentityServerUUIDQueryFails(t *testing.T) {
 	defer db.Close()
 
 	mock.ExpectQuery("SELECT @@server_uuid").WillReturnError(errors.New("connection refused"))
+	// On failure, LoadSourceIdentity probes VERSION() to disambiguate MariaDB
+	// (no @@server_uuid, expected) from a real MySQL failure. A MySQL version
+	// string must keep the error propagating.
+	mock.ExpectQuery("SELECT VERSION").WillReturnRows(
+		sqlmock.NewRows([]string{"VERSION()"}).AddRow("8.0.36"))
 
 	_, err = LoadSourceIdentity(context.Background(), db, "u:p@tcp(h:3306)/")
 	if err == nil {
-		t.Fatal("expected error when @@server_uuid query fails")
+		t.Fatal("expected error when @@server_uuid query fails on a MySQL source")
 	}
 	if !strings.Contains(err.Error(), "server_uuid") {
 		t.Errorf("error %q should mention server_uuid", err)
 	}
 }
 
-func TestLoadSourceIdentityBadDSN(t *testing.T) {
+// TestLoadSourceIdentityMariaDBSynthesizes verifies that a MariaDB source (no
+// @@server_uuid; VERSION() contains "MariaDB") gets a stable synthesized anchor
+// derived from its address rather than an error or an empty identity.
+func TestLoadSourceIdentityMariaDBSynthesizes(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock: %v", err)
 	}
 	defer db.Close()
 
-	mock.ExpectQuery("SELECT @@server_uuid").WillReturnRows(
-		sqlmock.NewRows([]string{"@@server_uuid"}).AddRow("uuid-x"))
+	mock.ExpectQuery("SELECT @@server_uuid").WillReturnError(
+		errors.New("Error 1193: Unknown system variable 'server_uuid'"))
+	mock.ExpectQuery("SELECT VERSION").WillReturnRows(
+		sqlmock.NewRows([]string{"VERSION()"}).AddRow("11.4.2-MariaDB-1:11.4.2+maria~ubu2404"))
 
-	// config.ParseSourceDSN rejects unix sockets — use that as the easy bad-DSN trigger.
+	ident, err := LoadSourceIdentity(context.Background(), db, "repl:secret@tcp(10.0.0.7:3306)/")
+	if err != nil {
+		t.Fatalf("unexpected error for MariaDB source: %v", err)
+	}
+	want := serverid.SyntheticServerUUID("10.0.0.7", 3306)
+	if ident.ServerUUID != want {
+		t.Errorf("ServerUUID = %q, want synthesized %q", ident.ServerUUID, want)
+	}
+	if ident.ServerUUID == "" {
+		t.Error("synthesized ServerUUID must not be empty")
+	}
+	if ident.Host != "10.0.0.7" || ident.Port != 3306 || ident.User != "repl" {
+		t.Errorf("identity = %+v, want host=10.0.0.7 port=3306 user=repl", ident)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestLoadSourceIdentityBadDSN(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	// The DSN is parsed before any query, so an invalid DSN fails fast with no
+	// DB round-trip (no mock expectations needed). config.ParseSourceDSN rejects
+	// unix sockets — use that as the easy bad-DSN trigger.
 	_, err = LoadSourceIdentity(context.Background(), db, "u:p@unix(/tmp/sock)/")
 	if err == nil {
 		t.Fatal("expected error for unix-socket DSN")

--- a/internal/byos/identity_test.go
+++ b/internal/byos/identity_test.go
@@ -63,6 +63,38 @@ func TestLoadSourceIdentityServerUUIDQueryFails(t *testing.T) {
 	if !strings.Contains(err.Error(), "server_uuid") {
 		t.Errorf("error %q should mention server_uuid", err)
 	}
+	// Pin that the VERSION() probe is actually issued on the failure path — if the
+	// DetectFlavor guard were removed, this would catch it (unconsumed expectation).
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// TestLoadSourceIdentityUnknownFlavorPropagates covers the case where both
+// @@server_uuid AND VERSION() fail, so DetectFlavor returns "" (flavor
+// undeterminable). The original error MUST propagate — bintrail must never
+// fabricate a synthesized identity for a server whose flavor it cannot confirm
+// is MariaDB (a refactor of the guard to `== "mysql"` would regress exactly here).
+func TestLoadSourceIdentityUnknownFlavorPropagates(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT @@server_uuid").WillReturnError(errors.New("connection reset"))
+	mock.ExpectQuery("SELECT VERSION").WillReturnError(errors.New("connection reset")) // → DetectFlavor returns ""
+
+	_, err = LoadSourceIdentity(context.Background(), db, "u:p@tcp(h:3306)/")
+	if err == nil {
+		t.Fatal("expected error when flavor is undeterminable (VERSION() also fails)")
+	}
+	if !strings.Contains(err.Error(), "server_uuid") {
+		t.Errorf("error %q must propagate the original server_uuid failure, not synthesize", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
 }
 
 // TestLoadSourceIdentityMariaDBSynthesizes verifies that a MariaDB source (no

--- a/internal/serverid/serverid.go
+++ b/internal/serverid/serverid.go
@@ -1,7 +1,10 @@
 // Package serverid manages persistent server identities for bintrail.
-// Each MySQL server is assigned a unique bintrail_id (UUID) on first contact.
-// Identity resolution uses five rules to handle UUID regeneration, host
-// migration, and cloned-server conflicts while preserving the bintrail_id.
+// Each source server is assigned a unique bintrail_id (UUID) on first contact —
+// keyed on the server's @@server_uuid for MySQL, or on a synthesized
+// address-derived anchor for MariaDB (which has no @@server_uuid; see
+// SyntheticServerUUID). Identity resolution uses five rules to handle UUID
+// regeneration, host migration, and cloned-server conflicts while preserving the
+// bintrail_id.
 package serverid
 
 import (

--- a/internal/serverid/serverid.go
+++ b/internal/serverid/serverid.go
@@ -273,6 +273,35 @@ func DecommissionServer(ctx context.Context, db *sql.DB, bintrailID string) erro
 	return nil
 }
 
+// mariadbIdentityNamespace is the fixed UUIDv5 namespace under which MariaDB
+// server-identity anchors are synthesized. MariaDB has no @@server_uuid, so
+// SyntheticServerUUID derives a stable, collision-resistant anchor from the
+// source address instead (see that function). The namespace is an arbitrary
+// constant — its only job is to keep these synthesized UUIDs in their own space,
+// disjoint from any real MySQL @@server_uuid.
+var mariadbIdentityNamespace = uuid.MustParse("d87207bb-1448-4136-b360-d029bbce63d4")
+
+// SyntheticServerUUID returns a deterministic UUIDv5 identity anchor for a
+// source that exposes no @@server_uuid (i.e. MariaDB). It is derived from the
+// source's host:port so that:
+//
+//   - the same server resolves to the same anchor across restarts (stable
+//     bintrail_id, stable archive prefix), and
+//   - two different MariaDB servers — necessarily reachable at distinct
+//     addresses — resolve to distinct anchors, so they auto-separate into
+//     distinct bintrail_id=<uuid>/ Parquet prefixes instead of colliding.
+//
+// The anchor feeds ResolveServer exactly like a real @@server_uuid: it is the
+// strong re-identification key, while the bintrail_id itself stays a fresh
+// random UUID assigned on first contact. Deriving from the address means a
+// server moved to a new host gets a new identity — an accepted MariaDB
+// limitation (MySQL's @@server_uuid survives migration; MariaDB has no
+// equivalent), not a correctness bug.
+func SyntheticServerUUID(host string, port uint16) string {
+	seed := fmt.Sprintf("mariadb|%s:%d", host, port)
+	return uuid.NewSHA1(mariadbIdentityNamespace, []byte(seed)).String()
+}
+
 // DeriveServerID returns a deterministic uint32 server-id by hashing the
 // source DSN's host:user:dbname triple. The same DSN always produces the same
 // ID, so `bintrail up` resumes cleanly across restarts without the user

--- a/internal/serverid/serverid_test.go
+++ b/internal/serverid/serverid_test.go
@@ -3,6 +3,8 @@ package serverid
 import (
 	"fmt"
 	"testing"
+
+	"github.com/google/uuid"
 )
 
 func makeServer(bintrailID, serverUUID, host string, port uint16, username string) Server {
@@ -171,5 +173,45 @@ func TestDeriveServerID(t *testing.T) {
 	// non-deterministic value (the silent-failure fix).
 	if _, err := DeriveServerID("not-a-dsn"); err == nil {
 		t.Error("expected error for unparseable DSN; got nil")
+	}
+}
+
+func TestSyntheticServerUUID(t *testing.T) {
+	// Deterministic: same host:port → same anchor across calls (stable
+	// bintrail_id and stable S3 archive prefix across restarts).
+	a := SyntheticServerUUID("10.0.0.5", 3306)
+	b := SyntheticServerUUID("10.0.0.5", 3306)
+	if a != b {
+		t.Errorf("not deterministic: %q != %q", a, b)
+	}
+
+	// Valid 36-char UUID — it lands in bintrail_servers.server_uuid CHAR(36).
+	if len(a) != 36 {
+		t.Errorf("SyntheticServerUUID = %q, want a 36-char UUID", a)
+	}
+	if _, err := uuid.Parse(a); err != nil {
+		t.Errorf("SyntheticServerUUID = %q is not a valid UUID: %v", a, err)
+	}
+
+	// Distinct addresses → distinct anchors. This is the property that keeps two
+	// MariaDB servers from colliding into the same bintrail_id=<uuid>/ prefix.
+	// A different host OR a different port must change the anchor.
+	cases := []struct {
+		host string
+		port uint16
+	}{
+		{"10.0.0.5", 3307}, // same host, different port
+		{"10.0.0.6", 3306}, // different host, same port
+		{"db.example.com", 3306},
+		{"127.0.0.1", 3306},
+	}
+	seen := map[string]string{a: "10.0.0.5:3306"}
+	for _, c := range cases {
+		got := SyntheticServerUUID(c.host, c.port)
+		key := fmt.Sprintf("%s:%d", c.host, c.port)
+		if prev, dup := seen[got]; dup {
+			t.Errorf("collision: %s and %s both produced %s", prev, key, got)
+		}
+		seen[got] = key
 	}
 }

--- a/internal/serverid/serverid_test.go
+++ b/internal/serverid/serverid_test.go
@@ -215,3 +215,18 @@ func TestSyntheticServerUUID(t *testing.T) {
 		seen[got] = key
 	}
 }
+
+// TestSyntheticServerUUID_GoldenValue pins the exact synthesis output for a fixed
+// input. The seed format ("mariadb|host:port") and the namespace constant are the
+// cross-version stability contract for the anchor: changing either silently
+// re-identifies EVERY MariaDB server, orphaning its existing S3 archives under a
+// new bintrail_id=<uuid>/ prefix. This golden assertion turns such a change into a
+// loud, intentional test failure that forces a migration decision. The literal was
+// captured from a real run against MariaDB on 127.0.0.1:13307.
+func TestSyntheticServerUUID_GoldenValue(t *testing.T) {
+	const want = "dcc224c0-020d-558f-93d4-2095282c8b90"
+	if got := SyntheticServerUUID("127.0.0.1", 13307); got != want {
+		t.Errorf("synthesis wire format changed: SyntheticServerUUID(127.0.0.1, 13307) = %q, want %q.\n"+
+			"A seed/namespace change re-identifies every MariaDB server — if this change is intentional, update the golden value AND plan an archive migration.", got, want)
+	}
+}


### PR DESCRIPTION
## Problem

MariaDB has no `@@server_uuid`. Identity resolution (`byos.LoadSourceIdentity` → `SELECT @@server_uuid`) failed on every MariaDB source, so the stream proceeded with a **NULL `bintrail_id`**. Since Parquet archives are namespaced by the Hive key `bintrail_id=<id>/`, two MariaDB servers archived to the same S3 bucket/prefix would land under `bintrail_id=/` (empty key) and **collide / clobber each other** — silently.

Surfaced by the question: *"monitoring two MariaDB servers for one client — how do I tell them apart in S3?"*

## Fix (three parts)

1. **`internal/serverid.SyntheticServerUUID(host, port)`** — a deterministic UUIDv5 anchor derived from the source address (mirrors the existing `DeriveServerID`). Stable across restarts; distinct per address → two servers auto-separate into distinct archive prefixes. No migration tolerance by design (the user has no MariaDB users and explicitly doesn't want it).

2. **`internal/byos.LoadSourceIdentity` is now flavor-aware.** The **MySQL path is untouched**: `@@server_uuid` runs first; only on failure does `metadata.DetectFlavor` (a `VERSION()` probe — *not* error-code sniffing) decide MariaDB→synthesize vs MySQL→propagate-error. A healthy MySQL source never reaches the synthesis branch (no extra query, existing tests unchanged). The synthesized anchor flows through the same `ResolveServer` registration → a real `bintrail_id` in `bintrail_servers` and `stream_state`.

3. **`bintrail rotate` no longer requires `--bintrail-id` when archiving.** New precedence: **explicit CLI `--bintrail-id` > the `stream_state` id > a global `BINTRAIL_ID` env var** (last resort, warned). cobra's env binding uses `Flags().Set` (so `Changed()` is true for env *and* CLI alike), so CLI-vs-env is inferred by comparing against `os.Getenv("BINTRAIL_ID")` — this stops one global `BINTRAIL_ID` in a shared `config.env` from collapsing every server's archives into one prefix (the same bug, revived through env). The control-plane rotation loop (`internal/rotation`) is unaffected — it already resolves the id from `stream_state`.

## Blast radius

- MySQL identity resolution: **byte-identical** (happy path never enters new code).
- `rotate` for MySQL: every existing invocation passes `--bintrail-id` (it was required) → CLI-typed → wins → unchanged. The only relaxed case (omitting the flag) was previously a hard error.
- `Deps.ResolveServerIdentity` signature unchanged → `index`/`snapshot`/`agent`/`streamdeps` untouched.

## Tests

- `serverid`: synthesis is deterministic, distinct per host/port, valid 36-char UUID.
- `byos` (unit, sqlmock): MySQL `server_uuid` failure still propagates; MariaDB (`VERSION()` = MariaDB) synthesizes.
- `byos` (integration, real MariaDB on 13307): end-to-end — no `@@server_uuid` → synthesize → register → stable/idempotent `bintrail_id`.
- `rotate`: precedence incl. the **env-must-not-outrank-stream_state** regression, env last-resort fallback, NULL/no-row/query-error paths.

All green: `go build`, `go vet`, 30-package unit suite, `-race` on touched packages, and the MariaDB integration test against a live source.

## Docs

`docs/mariadb.md`: new **Server identity on MariaDB** section; corrected the stale "proceeds without a bintrail_id" notes; documents the same-address collision caveat and the index-only (no `stream_state`) caveat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)