### PR TITLE
refactor: move the status command to internal/cli — read-command pilot (#529 slice 3)

### DIFF
--- a/cmd/bintrail/main.go
+++ b/cmd/bintrail/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/dbtrail/dbtrail/internal/agent"
+	"github.com/dbtrail/dbtrail/internal/cli"
 	"github.com/dbtrail/dbtrail/internal/observe"
 )
 
@@ -44,6 +45,9 @@ func init() {
 	rootCmd.Version = fmt.Sprintf("%s (commit %s, built %s)", Version, CommitSHA, BuildDate)
 	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "Log level: debug, info, warn, error")
 	rootCmd.PersistentFlags().StringVar(&logFormat, "log-format", "text", "Log format: text or json")
+	// Register the source-agnostic read commands that have moved to internal/cli
+	// (#529) so a future bintrail-pg can register the same set. Today: status.
+	cli.AddReadCommands(rootCmd)
 }
 
 func main() {

--- a/cmd/bintrail/read_commands_test.go
+++ b/cmd/bintrail/read_commands_test.go
@@ -1,0 +1,26 @@
+package main
+
+import "testing"
+
+// TestReadCommandsWiredOnRoot asserts that the source-agnostic read commands
+// migrated to internal/cli (#529) are actually registered on the real rootCmd —
+// i.e. that main.go calls cli.AddReadCommands(rootCmd). Each command's own
+// registration test moved into internal/cli with it (where it tests
+// AddReadCommands against a throwaway root), so only THIS test pins that the
+// shipped binary wires them in: a dropped AddReadCommands call would otherwise
+// let a command silently vanish from the CLI with the unit suite still green.
+//
+// Grow `want` as more read commands migrate into internal/cli (#529).
+func TestReadCommandsWiredOnRoot(t *testing.T) {
+	want := []string{"status"}
+
+	have := make(map[string]bool)
+	for _, c := range rootCmd.Commands() {
+		have[c.Use] = true
+	}
+	for _, name := range want {
+		if !have[name] {
+			t.Errorf("read command %q not registered on rootCmd — main.go must call cli.AddReadCommands(rootCmd)", name)
+		}
+	}
+}

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -1,0 +1,14 @@
+package cli
+
+import "github.com/spf13/cobra"
+
+// AddReadCommands registers the source-agnostic read/recover commands on root.
+// Each binary (the core bintrail, and the planned PostgreSQL-native bintrail-pg
+// — #527) calls this so both expose the same query/recover/reconstruct/status/
+// shim surface without duplicating the command definitions.
+//
+// Commands are migrated into internal/cli one slice at a time (#529); today this
+// registers only status. As the others move, they join this function.
+func AddReadCommands(root *cobra.Command) {
+	root.AddCommand(statusCmd)
+}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"fmt"
@@ -42,9 +42,9 @@ func init() {
 	statusCmd.Flags().StringVar(&stFormat, "format", "text", "Output format: text or json")
 	statusCmd.Flags().StringVar(&stBaselineDir, "baseline-dir", "", "Local directory of baseline Parquet snapshots (optional, shows baseline binlog positions)")
 	_ = statusCmd.MarkFlagRequired("index-dsn")
-	bindCommandEnv(statusCmd)
-
-	rootCmd.AddCommand(statusCmd)
+	BindCommandEnv(statusCmd)
+	// Registration on a root command happens via AddReadCommands(root), which
+	// each binary's main() calls — see commands.go (#529).
 }
 
 func runStatus(cmd *cobra.Command, args []string) error {

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -1,22 +1,29 @@
-package main
+package cli
 
 import (
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 // ─── cobra command wiring ─────────────────────────────────────────────────────
 
+// TestStatusCmd_registered verifies AddReadCommands registers the status command
+// on a root (the post-#529 wiring: each binary's main calls AddReadCommands
+// instead of status.go reaching a package-global rootCmd).
 func TestStatusCmd_registered(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	AddReadCommands(root)
 	found := false
-	for _, cmd := range rootCmd.Commands() {
+	for _, cmd := range root.Commands() {
 		if cmd.Use == "status" {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Error("expected 'status' command to be registered under rootCmd")
+		t.Error("expected 'status' command to be registered by AddReadCommands")
 	}
 }
 


### PR DESCRIPTION
## What

**Third slice of #529** — the first source-agnostic **read command** moves into `internal/cli`, validating the command lift-and-shift pattern on the cheapest case (`status`, ~114 LOC) before scaling to query/recover/reconstruct/shim.

## Changes

- `internal/cli/status.go`: `statusCmd` + `runStatus` + flags moved verbatim from `cmd/bintrail` (package main → cli). Its `init()` keeps the flags + required-mark + `BindCommandEnv`, but **no longer calls `rootCmd.AddCommand`**.
- `internal/cli/commands.go`: new `AddReadCommands(root)` — the registration entry point each binary's `main` calls (today: status; grows as more commands move). This is what lets a future `bintrail-pg` expose the same read surface.
- `cmd/bintrail/main.go`: calls `cli.AddReadCommands(rootCmd)` in `init()`.
- `internal/cli/status_test.go`: moved; `TestStatusCmd_registered` adapted to assert `AddReadCommands(root)` registers status (was a package-global `rootCmd` check). All other tests moved verbatim.

## Approach

Lift-and-shift (advisor-blessed plan for #529): move the file + its test into `internal/cli` keeping the `var statusCmd` + `init()` pattern; the only structural change is replacing `rootCmd.AddCommand(statusCmd)` with membership in `cli.AddReadCommands(root)`. Two binaries are two processes, so package-level command vars are fine. `status` uses no `wantsJSON`/`outputJSON` (it does its own formatting), so this slice needs nothing else from package main beyond `BindCommandEnv` (already moved in slice 2).

## Verification

- `go build ./...` ✓, `go vet` ✓, gofmt-clean ✓
- Unit: `internal/cli` (status tests) + `cmd/bintrail` (incl. the uifree guard — status still registered, not duplicated) ✓
- **End-to-end: `go test -tags integration -run TestEndToEnd`** — which builds the binary and runs the real `bintrail status` command — **passes**, proving the `AddReadCommands` wiring works through the actual CLI.

Part of #529. Next: query/recover/reconstruct (they also need wantsJSON/outputJSON moved), then shim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)