### PR TITLE
refactor: move the query command to internal/cli (#529 slice 4)

### DIFF
--- a/cmd/bintrail/read_commands_test.go
+++ b/cmd/bintrail/read_commands_test.go
@@ -12,7 +12,7 @@ import "testing"
 //
 // Grow `want` as more read commands migrate into internal/cli (#529).
 func TestReadCommandsWiredOnRoot(t *testing.T) {
-	want := []string{"status"}
+	want := []string{"status", "query"}
 
 	have := make(map[string]bool)
 	for _, c := range rootCmd.Commands() {

--- a/cmd/bintrail/recover.go
+++ b/cmd/bintrail/recover.go
@@ -115,7 +115,7 @@ func runRecover(cmd *cobra.Command, args []string) error {
 	if rPK != "" && len(rPKs) > 0 {
 		return fmt.Errorf("--pk and --pks are mutually exclusive; use one or the other")
 	}
-	cleanedPKs, err := cleanPKList(rPKs)
+	cleanedPKs, err := cli.CleanPKList(rPKs)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -8,7 +8,9 @@ import "github.com/spf13/cobra"
 // shim surface without duplicating the command definitions.
 //
 // Commands are migrated into internal/cli one slice at a time (#529); today this
-// registers only status. As the others move, they join this function.
+// registers status and query. As the others (recover, reconstruct, shim) move,
+// they join this function.
 func AddReadCommands(root *cobra.Command) {
 	root.AddCommand(statusCmd)
+	root.AddCommand(queryCmd)
 }

--- a/internal/cli/query.go
+++ b/internal/cli/query.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"context"
@@ -15,7 +15,6 @@ import (
 	mysqldriver "github.com/go-sql-driver/mysql"
 	"github.com/spf13/cobra"
 
-	"github.com/dbtrail/dbtrail/internal/cli"
 	"github.com/dbtrail/dbtrail/internal/cliutil"
 	"github.com/dbtrail/dbtrail/internal/config"
 	"github.com/dbtrail/dbtrail/internal/indexer"
@@ -99,11 +98,10 @@ func init() {
 	queryCmd.Flags().BoolVar(&qNoArchive, "no-archive", false, "Disable auto-routing to Parquet archives (MySQL-only results)")
 	queryCmd.Flags().BoolVar(&qIncludeSnapshot, "include-snapshot", false, "Also scan the mydumper baseline Parquet and emit matching rows as SNAPSHOT events (requires --baseline, --schema, --table)")
 	queryCmd.Flags().StringVar(&qBaseline, "baseline", "", "Path to a baseline Parquet file or directory containing <schema>/<table>.parquet (local path or s3:// URL); used with --include-snapshot")
-	cli.AddDuckDBTuningFlags(queryCmd)
+	AddDuckDBTuningFlags(queryCmd)
 	_ = queryCmd.MarkFlagRequired("index-dsn")
-	bindCommandEnv(queryCmd)
+	BindCommandEnv(queryCmd)
 
-	rootCmd.AddCommand(queryCmd)
 }
 
 func runQuery(cmd *cobra.Command, args []string) error {
@@ -118,7 +116,7 @@ func runQuery(cmd *cobra.Command, args []string) error {
 	if qPK != "" && len(qPKs) > 0 {
 		return fmt.Errorf("--pk and --pks are mutually exclusive; use one or the other")
 	}
-	cleanedPKs, err := cleanPKList(qPKs)
+	cleanedPKs, err := CleanPKList(qPKs)
 	if err != nil {
 		return err
 	}
@@ -154,7 +152,7 @@ func runQuery(cmd *cobra.Command, args []string) error {
 	if qNoArchive && (qArchiveDir != "" || qArchiveS3 != "") {
 		return fmt.Errorf("--no-archive cannot be combined with --archive-dir or --archive-s3")
 	}
-	duckTuning, err := cli.DuckDBTuningFromFlags(cmd)
+	duckTuning, err := DuckDBTuningFromFlags(cmd)
 	if err != nil {
 		return err
 	}
@@ -323,7 +321,7 @@ func runQuery(cmd *cobra.Command, args []string) error {
 			cmd.Context(),
 			archSources,
 			fetchOpts,
-			cli.TunedArchiveFetcher(duckTuning),
+			TunedArchiveFetcher(duckTuning),
 			os.Stderr,
 		)
 		if err != nil {
@@ -597,7 +595,7 @@ func eventTypeJSONName(t parser.EventType) string {
 	}
 }
 
-// cleanPKList normalizes the values collected from a --pks StringSliceVar flag:
+// CleanPKList normalizes the values collected from a --pks StringSliceVar flag:
 // trims surrounding whitespace, rejects empty entries, and deduplicates while
 // preserving input order. Duplicates are common when callers programmatically
 // compose the list (e.g. dbtrail SaaS batching N pending PKs with repeats from
@@ -608,7 +606,7 @@ func eventTypeJSONName(t parser.EventType) string {
 // --pks=,, invocation almost certainly indicates a shell interpolation bug,
 // and silently treating it as --pks with zero values would return "0 rows"
 // success output for a broken command.
-func cleanPKList(pks []string) ([]string, error) {
+func CleanPKList(pks []string) ([]string, error) {
 	if len(pks) == 0 {
 		return nil, nil
 	}

--- a/internal/cli/query_test.go
+++ b/internal/cli/query_test.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"bytes"
@@ -16,6 +16,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/cobra"
+
 	binparser "github.com/dbtrail/dbtrail/internal/parser"
 	"github.com/dbtrail/dbtrail/internal/query"
 )
@@ -23,15 +25,17 @@ import (
 // ─── cobra command wiring ─────────────────────────────────────────────────────
 
 func TestQueryCmd_registered(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	AddReadCommands(root)
 	found := false
-	for _, cmd := range rootCmd.Commands() {
+	for _, cmd := range root.Commands() {
 		if cmd.Use == "query" {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Error("expected 'query' command to be registered under rootCmd")
+		t.Error("expected 'query' command to be registered by AddReadCommands")
 	}
 }
 
@@ -1295,10 +1299,10 @@ func TestSanitizeArchiveErrorMessage(t *testing.T) {
 	}
 }
 
-// ─── cleanPKList ─────────────────────────────────────────────────────────────
+// ─── CleanPKList ─────────────────────────────────────────────────────────────
 
 func TestCleanPKList_dedupAndTrim(t *testing.T) {
-	got, err := cleanPKList([]string{"1", " 2 ", "1", "3", "2"})
+	got, err := CleanPKList([]string{"1", " 2 ", "1", "3", "2"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1324,7 +1328,7 @@ func TestCleanPKList_rejectsEmpty(t *testing.T) {
 		{"trailing comma artifact", []string{"1", "2", ""}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := cleanPKList(tc.in)
+			_, err := CleanPKList(tc.in)
 			if err == nil {
 				t.Fatalf("expected error for input %v", tc.in)
 			}
@@ -1336,11 +1340,11 @@ func TestCleanPKList_rejectsEmpty(t *testing.T) {
 }
 
 func TestCleanPKList_nilAndEmpty(t *testing.T) {
-	got, err := cleanPKList(nil)
+	got, err := CleanPKList(nil)
 	if err != nil || got != nil {
 		t.Errorf("expected (nil, nil) for nil input, got (%v, %v)", got, err)
 	}
-	got, err = cleanPKList([]string{})
+	got, err = CleanPKList([]string{})
 	if err != nil || len(got) != 0 {
 		t.Errorf("expected empty result for empty input, got (%v, %v)", got, err)
 	}


### PR DESCRIPTION
## What

**Fourth slice of #529** — the `query` command (the largest read command, ~650 LOC) moves into `internal/cli`, following the status pilot's proven lift-and-shift.

## Changes

- `internal/cli/query.go`: `queryCmd` + `runQuery` + flags moved from `cmd/bintrail` (package main → cli). The slice-1 DuckDB-tuning calls lose their `cli.` prefix (now same package); `bindCommandEnv` → `BindCommandEnv`; `rootCmd.AddCommand` dropped in favor of `AddReadCommands`.
- `internal/cli/commands.go`: `AddReadCommands` now registers `queryCmd` too.
- **`CleanPKList`** (was `cleanPKList` in query.go) exported — `recover.go` (still in cmd/bintrail) shares it; `recover.go` repointed to `cli.CleanPKList` (it'll de-prefix when recover moves in the next slice). *The compiler caught this shared-helper dependency.*
- `cmd/bintrail/read_commands_test.go`: `query` added to the `TestReadCommandsWiredOnRoot` guard (so the real binary's query wiring stays unit-covered, per the slice-3 review).
- `query_test.go` moved; `TestQueryCmd_registered` adapted to assert `AddReadCommands`.

## Verification

- `go build ./...` ✓, `go vet` ✓, gofmt-clean ✓
- Full unit suite (30 packages) ✓
- **`go test -tags integration -run TestEndToEnd`** — builds the binary and runs the real `bintrail query` — **passes**, proving the wiring through the actual CLI.

Done in an isolated git worktree off main (the user's branch had uncommitted work — not touched). Part of #529. Next: recover + reconstruct, then shim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)