### PR TITLE
refactor: move the recover command to internal/cli (#529 slice 5)

### DIFF
--- a/cmd/bintrail/read_commands_test.go
+++ b/cmd/bintrail/read_commands_test.go
@@ -12,7 +12,7 @@ import "testing"
 //
 // Grow `want` as more read commands migrate into internal/cli (#529).
 func TestReadCommandsWiredOnRoot(t *testing.T) {
-	want := []string{"status", "query"}
+	want := []string{"status", "query", "recover"}
 
 	have := make(map[string]bool)
 	for _, c := range rootCmd.Commands() {

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -8,9 +8,10 @@ import "github.com/spf13/cobra"
 // shim surface without duplicating the command definitions.
 //
 // Commands are migrated into internal/cli one slice at a time (#529); today this
-// registers status and query. As the others (recover, reconstruct, shim) move,
+// registers status, query, and recover. As the others (reconstruct, shim) move,
 // they join this function.
 func AddReadCommands(root *cobra.Command) {
 	root.AddCommand(statusCmd)
 	root.AddCommand(queryCmd)
+	root.AddCommand(recoverCmd)
 }

--- a/internal/cli/query.go
+++ b/internal/cli/query.go
@@ -116,7 +116,7 @@ func runQuery(cmd *cobra.Command, args []string) error {
 	if qPK != "" && len(qPKs) > 0 {
 		return fmt.Errorf("--pk and --pks are mutually exclusive; use one or the other")
 	}
-	cleanedPKs, err := CleanPKList(qPKs)
+	cleanedPKs, err := cleanPKList(qPKs)
 	if err != nil {
 		return err
 	}
@@ -595,18 +595,19 @@ func eventTypeJSONName(t parser.EventType) string {
 	}
 }
 
-// CleanPKList normalizes the values collected from a --pks StringSliceVar flag:
-// trims surrounding whitespace, rejects empty entries, and deduplicates while
-// preserving input order. Duplicates are common when callers programmatically
-// compose the list (e.g. dbtrail SaaS batching N pending PKs with repeats from
-// retries); an unfiltered list would produce duplicate groups in grouped JSON
-// output and waste bind-parameter slots in the SQL IN clause.
+// cleanPKList normalizes the values collected from a --pks StringSliceVar flag
+// (shared by the query and recover commands): trims surrounding whitespace,
+// rejects empty entries, and deduplicates while preserving input order.
+// Duplicates are common when callers programmatically compose the list (e.g.
+// dbtrail SaaS batching N pending PKs with repeats from retries); an unfiltered
+// list would produce duplicate result rows/groups and waste bind-parameter slots
+// in the SQL IN clause.
 //
 // Returns an error on empty entries rather than silently dropping them — a
-// --pks=,, invocation almost certainly indicates a shell interpolation bug,
-// and silently treating it as --pks with zero values would return "0 rows"
-// success output for a broken command.
-func CleanPKList(pks []string) ([]string, error) {
+// --pks=,, invocation almost certainly indicates a shell interpolation bug, and
+// silently treating it as --pks with zero values would return a misleadingly
+// empty/no-op success for a broken command.
+func cleanPKList(pks []string) ([]string, error) {
 	if len(pks) == 0 {
 		return nil, nil
 	}

--- a/internal/cli/query.go
+++ b/internal/cli/query.go
@@ -600,13 +600,15 @@ func eventTypeJSONName(t parser.EventType) string {
 // rejects empty entries, and deduplicates while preserving input order.
 // Duplicates are common when callers programmatically compose the list (e.g.
 // dbtrail SaaS batching N pending PKs with repeats from retries); an unfiltered
-// list would produce duplicate result rows/groups and waste bind-parameter slots
-// in the SQL IN clause.
+// list would emit duplicate groups in query's grouped-JSON output and waste
+// bind-parameter slots in the shared `pk_values IN (...)` clause. (The flat
+// query and recover paths use IN set-membership, so duplicate input PKs there
+// match each row once — the duplication harm is groups-only.)
 //
 // Returns an error on empty entries rather than silently dropping them — a
 // --pks=,, invocation almost certainly indicates a shell interpolation bug, and
-// silently treating it as --pks with zero values would return a misleadingly
-// empty/no-op success for a broken command.
+// silently treating it as --pks with zero values would mask a broken command (a
+// misleadingly empty query result, or an unintended over-broad recover).
 func cleanPKList(pks []string) ([]string, error) {
 	if len(pks) == 0 {
 		return nil, nil

--- a/internal/cli/query_test.go
+++ b/internal/cli/query_test.go
@@ -1299,10 +1299,10 @@ func TestSanitizeArchiveErrorMessage(t *testing.T) {
 	}
 }
 
-// ─── CleanPKList ─────────────────────────────────────────────────────────────
+// ─── cleanPKList ─────────────────────────────────────────────────────────────
 
 func TestCleanPKList_dedupAndTrim(t *testing.T) {
-	got, err := CleanPKList([]string{"1", " 2 ", "1", "3", "2"})
+	got, err := cleanPKList([]string{"1", " 2 ", "1", "3", "2"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1328,7 +1328,7 @@ func TestCleanPKList_rejectsEmpty(t *testing.T) {
 		{"trailing comma artifact", []string{"1", "2", ""}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := CleanPKList(tc.in)
+			_, err := cleanPKList(tc.in)
 			if err == nil {
 				t.Fatalf("expected error for input %v", tc.in)
 			}
@@ -1340,11 +1340,11 @@ func TestCleanPKList_rejectsEmpty(t *testing.T) {
 }
 
 func TestCleanPKList_nilAndEmpty(t *testing.T) {
-	got, err := CleanPKList(nil)
+	got, err := cleanPKList(nil)
 	if err != nil || got != nil {
 		t.Errorf("expected (nil, nil) for nil input, got (%v, %v)", got, err)
 	}
-	got, err = CleanPKList([]string{})
+	got, err = cleanPKList([]string{})
 	if err != nil || len(got) != 0 {
 		t.Errorf("expected empty result for empty input, got (%v, %v)", got, err)
 	}

--- a/internal/cli/recover.go
+++ b/internal/cli/recover.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"bufio"
@@ -11,7 +11,6 @@ import (
 	mysqldriver "github.com/go-sql-driver/mysql"
 	"github.com/spf13/cobra"
 
-	"github.com/dbtrail/dbtrail/internal/cli"
 	"github.com/dbtrail/dbtrail/internal/cliutil"
 	"github.com/dbtrail/dbtrail/internal/config"
 	"github.com/dbtrail/dbtrail/internal/indexer"
@@ -90,11 +89,10 @@ func init() {
 	recoverCmd.Flags().StringVar(&rProfile, "profile", "", "Apply RBAC access rules for this profile (table-level deny and column-level redaction)")
 	recoverCmd.Flags().StringVar(&rFormat, "format", "text", "Output format: text or json")
 	recoverCmd.Flags().BoolVar(&rNoArchive, "no-archive", false, "Disable auto-routing to Parquet archives (MySQL-only results)")
-	cli.AddDuckDBTuningFlags(recoverCmd)
+	AddDuckDBTuningFlags(recoverCmd)
 	_ = recoverCmd.MarkFlagRequired("index-dsn")
-	bindCommandEnv(recoverCmd)
+	BindCommandEnv(recoverCmd)
 
-	rootCmd.AddCommand(recoverCmd)
 }
 
 func runRecover(cmd *cobra.Command, args []string) error {
@@ -115,7 +113,7 @@ func runRecover(cmd *cobra.Command, args []string) error {
 	if rPK != "" && len(rPKs) > 0 {
 		return fmt.Errorf("--pk and --pks are mutually exclusive; use one or the other")
 	}
-	cleanedPKs, err := cli.CleanPKList(rPKs)
+	cleanedPKs, err := cleanPKList(rPKs)
 	if err != nil {
 		return err
 	}
@@ -210,7 +208,7 @@ func runRecover(cmd *cobra.Command, args []string) error {
 		dbName = cfg.DBName
 	}
 
-	duckTuning, err := cli.DuckDBTuningFromFlags(cmd)
+	duckTuning, err := DuckDBTuningFromFlags(cmd)
 	if err != nil {
 		return err
 	}
@@ -219,7 +217,7 @@ func runRecover(cmd *cobra.Command, args []string) error {
 		DBName:         dbName,
 		NoArchive:      rNoArchive || rProfile != "",
 		AllowGaps:      true, // preserve recover's warn-and-continue behavior
-		ArchiveFetcher: cli.TunedArchiveFetcher(duckTuning),
+		ArchiveFetcher: TunedArchiveFetcher(duckTuning),
 	})
 	if err != nil {
 		return err

--- a/internal/cli/recover_test.go
+++ b/internal/cli/recover_test.go
@@ -1,22 +1,26 @@
-package main
+package cli
 
 import (
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 // ─── cobra command wiring ─────────────────────────────────────────────────────
 
 func TestRecoverCmd_registered(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	AddReadCommands(root)
 	found := false
-	for _, cmd := range rootCmd.Commands() {
+	for _, cmd := range root.Commands() {
 		if cmd.Use == "recover" {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Error("expected 'recover' command to be registered under rootCmd")
+		t.Error("expected 'recover' command to be registered by AddReadCommands")
 	}
 }
 


### PR DESCRIPTION
## What

**Fifth slice of #529** — the `recover` command moves into `internal/cli`, following the proven status/query pattern.

## Changes

- `internal/cli/recover.go`: `recoverCmd` + `runRecover` + flags moved from `cmd/bintrail` (package main → cli). The `cli.*` calls de-prefixed (now same package); `bindCommandEnv` → `BindCommandEnv`; `rootCmd.AddCommand` dropped; registered via `AddReadCommands`.
- **`CleanPKList` un-exported back to `cleanPKList`**: with both callers (query + recover) now in `cli`, it no longer needs to be exported. Its doc rationale is de-query-specified since it serves both commands now (the polish deferred from the #541 review).
- `cmd/bintrail/read_commands_test.go`: `recover` added to the `TestReadCommandsWiredOnRoot` guard.
- `recover_test.go` moved; `TestRecoverCmd_registered` adapted to `AddReadCommands`.

## Verification

- `go build ./...` ✓, `go vet` ✓, gofmt-clean ✓
- Full unit suite (30 packages) ✓
- **`go test -tags integration -run TestEndToEnd`** — runs the real `bintrail recover` — **passes**.

Done in an isolated worktree off main (the user's branch untouched). Part of #529. Next: reconstruct, then shim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)