### PR TITLE
refactor: move reconstruct command to internal/cli (#529 slice 6)

### DIFF
--- a/cmd/bintrail/agent.go
+++ b/cmd/bintrail/agent.go
@@ -7,9 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"math"
 	"slices"
-	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -295,7 +293,7 @@ func runAgent(cmd *cobra.Command, args []string) error {
 		if agtBufferMaxEvents < 0 {
 			return fmt.Errorf("invalid --buffer-max-events %d: must be >= 0", agtBufferMaxEvents)
 		}
-		maxBytes, err := parseByteSize(agtBufferMaxBytes)
+		maxBytes, err := cliutil.ParseByteSize(agtBufferMaxBytes)
 		if err != nil {
 			return fmt.Errorf("invalid --buffer-max-bytes: %w", err)
 		}
@@ -1049,38 +1047,4 @@ func validateBYOSFlushConfig(byosMode bool, s3Bucket string) error {
 		return fmt.Errorf("BYOS mode (--source-dsn + --server-id) requires --s3-bucket (or BINTRAIL_S3_BUCKET) to flush events to durable storage; agent refuses to start to prevent silent data loss (the in-memory buffer would accumulate events and drop them on restart with no operator signal). See issue #289")
 	}
 	return nil
-}
-
-// parseByteSize parses a human-readable byte size string like "256MB" or "1GB".
-// Plain integers are treated as bytes. Returns 0 for "0" (unlimited).
-func parseByteSize(s string) (int64, error) {
-	s = strings.TrimSpace(s)
-	if s == "" || s == "0" {
-		return 0, nil
-	}
-
-	original := s
-	s = strings.ToUpper(s)
-
-	multiplier := int64(1)
-	switch {
-	case strings.HasSuffix(s, "GB"):
-		multiplier = 1 << 30
-		s = strings.TrimSuffix(s, "GB")
-	case strings.HasSuffix(s, "MB"):
-		multiplier = 1 << 20
-		s = strings.TrimSuffix(s, "MB")
-	case strings.HasSuffix(s, "KB"):
-		multiplier = 1 << 10
-		s = strings.TrimSuffix(s, "KB")
-	}
-
-	n, err := strconv.ParseInt(s, 10, 64)
-	if err != nil || n < 0 {
-		return 0, fmt.Errorf("invalid byte size %q; expected a number with optional KB/MB/GB suffix, e.g. 256MB", original)
-	}
-	if n > math.MaxInt64/multiplier {
-		return 0, fmt.Errorf("byte size %q overflows int64", original)
-	}
-	return n * multiplier, nil
 }

--- a/cmd/bintrail/agent_test.go
+++ b/cmd/bintrail/agent_test.go
@@ -674,38 +674,3 @@ func TestAgentServerUUIDHelpWarnsAboutSilentIgnore(t *testing.T) {
 		}
 	}
 }
-
-func TestParseByteSize(t *testing.T) {
-	tests := []struct {
-		input string
-		want  int64
-	}{
-		{"0", 0},
-		{"", 0},
-		{"1024", 1024},
-		{"256MB", 256 << 20},
-		{"256mb", 256 << 20},
-		{"1GB", 1 << 30},
-		{"1gb", 1 << 30},
-		{"512KB", 512 << 10},
-	}
-	for _, tt := range tests {
-		got, err := parseByteSize(tt.input)
-		if err != nil {
-			t.Errorf("parseByteSize(%q): unexpected error: %v", tt.input, err)
-			continue
-		}
-		if got != tt.want {
-			t.Errorf("parseByteSize(%q) = %d, want %d", tt.input, got, tt.want)
-		}
-	}
-}
-
-func TestParseByteSize_invalid(t *testing.T) {
-	for _, input := range []string{"abc", "-1GB", "not_a_number", "1.5GB", "9999999999GB"} {
-		_, err := parseByteSize(input)
-		if err == nil {
-			t.Errorf("parseByteSize(%q): expected error", input)
-		}
-	}
-}

--- a/cmd/bintrail/read_commands_test.go
+++ b/cmd/bintrail/read_commands_test.go
@@ -12,7 +12,7 @@ import "testing"
 //
 // Grow `want` as more read commands migrate into internal/cli (#529).
 func TestReadCommandsWiredOnRoot(t *testing.T) {
-	want := []string{"status", "query", "recover"}
+	want := []string{"status", "query", "recover", "reconstruct"}
 
 	have := make(map[string]bool)
 	for _, c := range rootCmd.Commands() {

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -8,10 +8,11 @@ import "github.com/spf13/cobra"
 // shim surface without duplicating the command definitions.
 //
 // Commands are migrated into internal/cli one slice at a time (#529); today this
-// registers status, query, and recover. As the others (reconstruct, shim) move,
-// they join this function.
+// registers status, query, recover, and reconstruct. As shim moves, it joins
+// this function.
 func AddReadCommands(root *cobra.Command) {
 	root.AddCommand(statusCmd)
 	root.AddCommand(queryCmd)
 	root.AddCommand(recoverCmd)
+	root.AddCommand(reconstructCmd)
 }

--- a/internal/cli/reconstruct.go
+++ b/internal/cli/reconstruct.go
@@ -538,5 +538,3 @@ func splitAndTrim(s, sep string) []string {
 	}
 	return out
 }
-
-// parseByteSize is defined in agent.go and reused here for --chunk-size.

--- a/internal/cli/reconstruct.go
+++ b/internal/cli/reconstruct.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"errors"
@@ -13,7 +13,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/dbtrail/dbtrail/internal/baseline"
-	"github.com/dbtrail/dbtrail/internal/cli"
 	"github.com/dbtrail/dbtrail/internal/cliutil"
 	"github.com/dbtrail/dbtrail/internal/config"
 	"github.com/dbtrail/dbtrail/internal/query"
@@ -119,10 +118,9 @@ func init() {
 	reconstructCmd.Flags().StringVar(&recTables, "tables", "", "Comma-separated schema.table list for --output-format=mydumper (e.g. mydb.orders,mydb.users)")
 	reconstructCmd.Flags().StringVar(&recChunkSize, "chunk-size", "256MB", "Max size per SQL chunk file in full-table mode (e.g. 64MB, 1GB)")
 	reconstructCmd.Flags().IntVar(&recParallelism, "parallelism", 0, "Max tables to reconstruct concurrently in full-table mode (default: runtime.NumCPU())")
-	cli.AddDuckDBTuningFlags(reconstructCmd)
-	bindCommandEnv(reconstructCmd)
+	AddDuckDBTuningFlags(reconstructCmd)
+	BindCommandEnv(reconstructCmd)
 
-	rootCmd.AddCommand(reconstructCmd)
 }
 
 func runReconstruct(cmd *cobra.Command, args []string) error {
@@ -269,7 +267,7 @@ func runReconstruct(cmd *cobra.Command, args []string) error {
 		Since:    &snapshotTime,
 		Until:    &at,
 	}
-	duckTuning, err := cli.DuckDBTuningFromFlags(cmd)
+	duckTuning, err := DuckDBTuningFromFlags(cmd)
 	if err != nil {
 		return err
 	}
@@ -278,7 +276,7 @@ func runReconstruct(cmd *cobra.Command, args []string) error {
 		DBName:         dbName,
 		NoArchive:      recNoArchive,
 		AllowGaps:      recAllowGaps,
-		ArchiveFetcher: cli.TunedArchiveFetcher(duckTuning),
+		ArchiveFetcher: TunedArchiveFetcher(duckTuning),
 	})
 	if err != nil {
 		// Surface CLI hints only at the CLI layer; the library types
@@ -450,7 +448,7 @@ func runReconstructFullTable(cmd *cobra.Command, start time.Time) error {
 	}
 
 	// ── Parse --chunk-size ─────────────────────────────────────────────────
-	chunkSize, err := parseByteSize(recChunkSize)
+	chunkSize, err := cliutil.ParseByteSize(recChunkSize)
 	if err != nil {
 		return fmt.Errorf("--chunk-size: %w", err)
 	}
@@ -472,7 +470,7 @@ func runReconstructFullTable(cmd *cobra.Command, start time.Time) error {
 		baselineSrc = recBaselineS3
 	}
 
-	duckTuning, err := cli.DuckDBTuningFromFlags(cmd)
+	duckTuning, err := DuckDBTuningFromFlags(cmd)
 	if err != nil {
 		return err
 	}
@@ -487,7 +485,7 @@ func runReconstructFullTable(cmd *cobra.Command, start time.Time) error {
 		ChunkSize:      chunkSize,
 		Parallelism:    recParallelism,
 		AllowGaps:      recAllowGaps,
-		ArchiveFetcher: cli.TunedArchiveFetcher(duckTuning),
+		ArchiveFetcher: TunedArchiveFetcher(duckTuning),
 	}
 	reports, err := reconstruct.ReconstructTables(cmd.Context(), cfg)
 	if err != nil {

--- a/internal/cli/reconstruct_fulltable_integration_test.go
+++ b/internal/cli/reconstruct_fulltable_integration_test.go
@@ -1,6 +1,6 @@
 //go:build integration
 
-package main
+package cli
 
 import (
 	"context"

--- a/internal/cli/reconstruct_fulltable_test.go
+++ b/internal/cli/reconstruct_fulltable_test.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"strings"

--- a/internal/cli/reconstruct_integration_test.go
+++ b/internal/cli/reconstruct_integration_test.go
@@ -1,6 +1,6 @@
 //go:build integration
 
-package main
+package cli
 
 import (
 	"context"

--- a/internal/cli/reconstruct_pk_types_integration_test.go
+++ b/internal/cli/reconstruct_pk_types_integration_test.go
@@ -1,6 +1,6 @@
 //go:build integration
 
-package main
+package cli
 
 import (
 	"context"

--- a/internal/cli/reconstruct_test.go
+++ b/internal/cli/reconstruct_test.go
@@ -1,22 +1,26 @@
-package main
+package cli
 
 import (
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 // ─── cobra command wiring ─────────────────────────────────────────────────────
 
 func TestReconstructCmd_registered(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	AddReadCommands(root)
 	found := false
-	for _, cmd := range rootCmd.Commands() {
+	for _, cmd := range root.Commands() {
 		if cmd.Use == "reconstruct" {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Error("expected 'reconstruct' command to be registered under rootCmd")
+		t.Error("expected 'reconstruct' command to be registered by AddReadCommands")
 	}
 }
 

--- a/internal/cliutil/bytesize.go
+++ b/internal/cliutil/bytesize.go
@@ -1,0 +1,43 @@
+package cliutil
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+)
+
+// ParseByteSize parses a human-readable byte size string like "256MB" or "1GB".
+// Plain integers are treated as bytes. Returns 0 for "0" (unlimited). Shared by
+// the agent (--buffer-max-bytes) and reconstruct (--chunk-size) commands.
+func ParseByteSize(s string) (int64, error) {
+	s = strings.TrimSpace(s)
+	if s == "" || s == "0" {
+		return 0, nil
+	}
+
+	original := s
+	s = strings.ToUpper(s)
+
+	multiplier := int64(1)
+	switch {
+	case strings.HasSuffix(s, "GB"):
+		multiplier = 1 << 30
+		s = strings.TrimSuffix(s, "GB")
+	case strings.HasSuffix(s, "MB"):
+		multiplier = 1 << 20
+		s = strings.TrimSuffix(s, "MB")
+	case strings.HasSuffix(s, "KB"):
+		multiplier = 1 << 10
+		s = strings.TrimSuffix(s, "KB")
+	}
+
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil || n < 0 {
+		return 0, fmt.Errorf("invalid byte size %q; expected a number with optional KB/MB/GB suffix, e.g. 256MB", original)
+	}
+	if n > math.MaxInt64/multiplier {
+		return 0, fmt.Errorf("byte size %q overflows int64", original)
+	}
+	return n * multiplier, nil
+}

--- a/internal/cliutil/bytesize_test.go
+++ b/internal/cliutil/bytesize_test.go
@@ -1,0 +1,38 @@
+package cliutil
+
+import "testing"
+
+func TestParseByteSize(t *testing.T) {
+	tests := []struct {
+		input string
+		want  int64
+	}{
+		{"0", 0},
+		{"", 0},
+		{"1024", 1024},
+		{"256MB", 256 << 20},
+		{"256mb", 256 << 20},
+		{"1GB", 1 << 30},
+		{"1gb", 1 << 30},
+		{"512KB", 512 << 10},
+	}
+	for _, tt := range tests {
+		got, err := ParseByteSize(tt.input)
+		if err != nil {
+			t.Errorf("ParseByteSize(%q): unexpected error: %v", tt.input, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("ParseByteSize(%q) = %d, want %d", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestParseByteSize_invalid(t *testing.T) {
+	for _, input := range []string{"abc", "-1GB", "not_a_number", "1.5GB", "9999999999GB"} {
+		_, err := ParseByteSize(input)
+		if err == nil {
+			t.Errorf("ParseByteSize(%q): expected error", input)
+		}
+	}
+}


### PR DESCRIPTION
## What

Slice 6 of #529: lift-and-shift the `reconstruct` command (var + `init()` + `runReconstruct` + full-table mydumper mode) and its four test files out of `cmd/bintrail` (package main) into `internal/cli` (package cli). Registered via `cli.AddReadCommands(root)` so the `bintrail` binary and the upcoming `bintrail-pg` binary share one command definition.

## Shared helper extracted

The build surfaced exactly one cross-command helper: `parseByteSize` (powers both reconstruct's `--chunk-size` and agent's `--buffer-max-bytes`). Extracted it to **`cliutil.ParseByteSize`** (exported, with its own test), repointed both call sites, and removed the now-unused `math`/`strconv` imports from `agent.go`. The `agent` command itself stays in `cmd/bintrail` for now (it's a write/stream command, not a read command).

## Behavior

Unchanged — same flags, same validation order, same output. Pure relocation.

- `read_commands_test.go` `TestReadCommandsWiredOnRoot` `want` now includes `reconstruct` (pins it onto the real shipped `rootCmd`).
- `reconstruct_test.go` registration test re-targeted to a synthetic root + `AddReadCommands` (the per-command pattern from earlier slices).

## Verification

- `go build ./...` + `go build -tags integration ./...` — clean
- `go vet ./...` + `-tags integration` — clean
- `gofmt -l` — clean (only the pre-existing `baseline.go` drift on main, untouched)
- full unit suite — green
- reconstruct integration tests (now in `internal/cli`) — green
- `TestEndToEnd` full CLI pipeline — green (the binary-wiring guard)

Part of #529.

🤖 Generated with [Claude Code](https://claude.com/claude-code)