### PR TITLE
refactor: move shim command to internal/cli (#529 slice 7, final)

### DIFF
--- a/cmd/bintrail/read_commands_test.go
+++ b/cmd/bintrail/read_commands_test.go
@@ -10,7 +10,7 @@ import "testing"
 // shipped binary wires them in: a dropped AddReadCommands call would otherwise
 // let a command silently vanish from the CLI with the unit suite still green.
 //
-// Grow `want` as more read commands migrate into internal/cli (#529).
+// Add to `want` whenever a new read command is registered by cli.AddReadCommands.
 func TestReadCommandsWiredOnRoot(t *testing.T) {
 	want := []string{"status", "query", "recover", "reconstruct", "shim"}
 

--- a/cmd/bintrail/read_commands_test.go
+++ b/cmd/bintrail/read_commands_test.go
@@ -12,7 +12,7 @@ import "testing"
 //
 // Grow `want` as more read commands migrate into internal/cli (#529).
 func TestReadCommandsWiredOnRoot(t *testing.T) {
-	want := []string{"status", "query", "recover", "reconstruct"}
+	want := []string{"status", "query", "recover", "reconstruct", "shim"}
 
 	have := make(map[string]bool)
 	for _, c := range rootCmd.Commands() {

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -4,7 +4,7 @@ import "github.com/spf13/cobra"
 
 // AddReadCommands registers the source-agnostic read/recover commands on root.
 // Each binary (the core bintrail, and the planned PostgreSQL-native bintrail-pg
-// — #527) calls this so both expose the same query/recover/reconstruct/status/
+// — #527) calls this so both expose the same status/query/recover/reconstruct/
 // shim surface without duplicating the command definitions.
 //
 // Commands are migrated into internal/cli one slice at a time (#529); this now

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -7,12 +7,17 @@ import "github.com/spf13/cobra"
 // — #527) calls this so both expose the same query/recover/reconstruct/status/
 // shim surface without duplicating the command definitions.
 //
-// Commands are migrated into internal/cli one slice at a time (#529); today this
-// registers status, query, recover, and reconstruct. As shim moves, it joins
-// this function.
+// Commands are migrated into internal/cli one slice at a time (#529); this now
+// registers the full read-plane surface: status, query, recover, reconstruct,
+// and shim. "Read" is the serve/read plane (these read from or serve the shared
+// index) as opposed to the capture plane (stream/index/snapshot/agent), which
+// stays source-specific in each binary's cmd/ package. shim is a long-running
+// MySQL-protocol server rather than a one-shot query, but it serves the same
+// index, so it belongs here too.
 func AddReadCommands(root *cobra.Command) {
 	root.AddCommand(statusCmd)
 	root.AddCommand(queryCmd)
 	root.AddCommand(recoverCmd)
 	root.AddCommand(reconstructCmd)
+	root.AddCommand(shimCmd)
 }

--- a/internal/cli/shim.go
+++ b/internal/cli/shim.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"context"
@@ -168,8 +168,7 @@ func init() {
 	shimCmd.Flags().StringVar(&shBaselineDir, "baseline-dir", "", "Local directory of baseline Parquet snapshots (from 'bintrail baseline'). Enables _snapshot baseline lookup so rows untouched within the retained binlog window still resolve at AS OF. _flashback stays binlog-only. Unset (default) makes _snapshot behave like _flashback.")
 	shimCmd.Flags().StringVar(&shBaselineS3, "baseline-s3", "", "S3 URL prefix of baseline Parquet snapshots (e.g. s3://bucket/baselines/). Takes precedence over --baseline-dir. Uses the standard AWS credential chain. See --baseline-dir for what it enables.")
 	_ = shimCmd.MarkFlagRequired("index-dsn")
-	bindCommandEnv(shimCmd)
-	rootCmd.AddCommand(shimCmd)
+	BindCommandEnv(shimCmd)
 }
 
 func runShim(cmd *cobra.Command, args []string) error {

--- a/internal/cli/shim_registered_test.go
+++ b/internal/cli/shim_registered_test.go
@@ -1,0 +1,26 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// TestShimCmd_registered mirrors the sibling *_registered tests: it pins that
+// AddReadCommands wires shim onto a root command. The binary-level wiring (that
+// main.go actually calls cli.AddReadCommands) is covered separately by
+// cmd/bintrail/read_commands_test.go.
+func TestShimCmd_registered(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	AddReadCommands(root)
+	found := false
+	for _, cmd := range root.Commands() {
+		if cmd.Use == "shim" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'shim' command to be registered by AddReadCommands")
+	}
+}

--- a/internal/cli/shim_test.go
+++ b/internal/cli/shim_test.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"bytes"

--- a/internal/cli/shim_wire_test.go
+++ b/internal/cli/shim_wire_test.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"context"


### PR DESCRIPTION
## What

Final slice of #529: lift-and-shift the `shim` command — the in-process MySQL-protocol time-travel server for the `_flashback` / `_snapshot` / `_diff` virtual schemas — and its two test files out of `cmd/bintrail` (package main) into `internal/cli` (package cli). Registered via `cli.AddReadCommands(root)` so the `bintrail` binary and the upcoming `bintrail-pg` binary share one definition.

**This completes #529** — all read-plane commands (status, query, recover, reconstruct, shim) now live in `internal/cli`.

## Why shim is a "read-plane" command

`shim` is a long-running server rather than a one-shot query, but it *serves the same shared index* (answering time-travel SQL against `binlog_events` + Parquet archives). So it belongs on the read/serve plane alongside query/recover/reconstruct/status, as opposed to the capture plane (stream/index/snapshot/agent) which stays source-specific in each binary's `cmd/` package. The `AddReadCommands` doc comment is generalized to spell this out.

## Scope decisions

- **`init-shim` is intentionally NOT moved.** It's the ProxySQL/MySQL `shim.yaml` generator — source-specific config tooling, not a read-plane command. It stays in `cmd/bintrail`.
- **shim links `go-mysql/server`** (its wire protocol). That's fine in `internal/cli`: the read-layer `parser.Event` dep guard (#528) and the console `uifree` guard both exclude shim by design, so no guard is violated. Verified `go vet` clean.

## Tests

- Added `TestShimCmd_registered` (sibling of the other `*_registered` tests) — pins that `AddReadCommands` wires shim onto a root.
- Grew `read_commands_test.go` `TestReadCommandsWiredOnRoot` `want` to include `shim` (the binary-wiring guard on the real `rootCmd`).
- The two moved test files (`shim_test.go`, `shim_wire_test.go`, incl. the in-process wire-protocol tests) are byte-identical except `package main` → `package cli`.

## Verification

- `go build ./...` + `-tags integration` — clean
- `go vet ./...` + `-tags integration` — clean
- `gofmt -l` — clean (only the pre-existing `baseline.go` drift on main, untouched)
- full unit suite + `internal/cli` (incl. moved shim + new registration test) — green
- `TestEndToEnd` — green
- `bintrail shim --help` confirms the command is exposed via `AddReadCommands`

Closes #529.

🤖 Generated with [Claude Code](https://claude.com/claude-code)