### PR TITLE
feat(pgcapture): live capturer — connection + slot lifecycle + Run loop (#530 slice 2)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/go-sql-driver/mysql v1.9.3
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pglogrepl v0.0.0-20260401131349-e37c41485510
+	github.com/jackc/pgx/v5 v5.10.0
 	github.com/modelcontextprotocol/go-sdk v1.3.1
 	github.com/parquet-go/parquet-go v0.24.0
 	github.com/prometheus/client_golang v1.23.2
@@ -63,7 +64,6 @@ require (
 	github.com/jackc/pgio v1.0.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
-	github.com/jackc/pgx/v5 v5.10.0 // indirect
 	github.com/klauspost/compress v1.18.3 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect

--- a/internal/pgcapture/capturer.go
+++ b/internal/pgcapture/capturer.go
@@ -27,6 +27,12 @@ const defaultStandbyInterval = 10 * time.Second
 // and ctx-cancel — forever. See sendStandby.
 const standbyWriteTimeout = 10 * time.Second
 
+// startupTimeout bounds the one-shot catalog/slot work in Run (publication + slot
+// checks, consistent-point creation, wal_sender_timeout read) so a hung catalog
+// can't wedge Run before streaming begins. StartReplication and the receive loop
+// deliberately use the full run ctx — they are long-lived.
+const startupTimeout = 30 * time.Second
+
 // Config binds everything Run needs. ReplDSN MUST carry replication=database (it is
 // a CopyBoth replication connection and cannot run queries); QueryDSN is a normal
 // connection used for the catalog PK lookup and the slot/publication checks.
@@ -98,11 +104,17 @@ func (c *Capturer) Run(ctx context.Context, out chan<- event.Event) error {
 	}
 	defer closeQueryConn(queryConn)
 
-	if err := validatePublication(ctx, queryConn, c.cfg.Publication, c.cfg.Filters); err != nil {
+	// Bound the one-shot startup catalog/slot work so a hung catalog can't wedge Run
+	// before streaming begins (StartReplication and the receive loop below use the
+	// full run ctx — they are long-lived, these are not).
+	startupCtx, cancelStartup := context.WithTimeout(ctx, startupTimeout)
+	defer cancelStartup()
+
+	if err := validatePublication(startupCtx, queryConn, c.cfg.Publication, c.cfg.Filters); err != nil {
 		return err
 	}
 
-	startLSN, err := ensureSlot(ctx, replConn, queryConn, c.cfg.SlotName, c.cfg.StartLSN)
+	startLSN, err := ensureSlot(startupCtx, replConn, queryConn, c.cfg.SlotName, c.cfg.StartLSN)
 	if err != nil {
 		return err
 	}
@@ -129,7 +141,7 @@ func (c *Capturer) Run(ctx context.Context, out chan<- event.Event) error {
 
 	interval := c.cfg.StandbyInterval
 	if interval <= 0 {
-		interval = c.deriveStandbyInterval(ctx, queryConn)
+		interval = c.deriveStandbyInterval(startupCtx, queryConn)
 	}
 	standbyTicker := time.NewTicker(interval)
 	defer standbyTicker.Stop()

--- a/internal/pgcapture/capturer.go
+++ b/internal/pgcapture/capturer.go
@@ -1,0 +1,277 @@
+package pgcapture
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync/atomic"
+	"time"
+
+	"github.com/jackc/pglogrepl"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgproto3"
+
+	"github.com/dbtrail/dbtrail/internal/event"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+)
+
+// defaultStandbyInterval is used when StandbyInterval is unset and wal_sender_timeout
+// cannot be read (or is disabled). It is conservatively below the PostgreSQL default
+// wal_sender_timeout (60s) so a quiet stream still refreshes the server's liveness
+// timer well within the deadline.
+const defaultStandbyInterval = 10 * time.Second
+
+// standbyWriteTimeout bounds each standby status write so a stalled socket (TCP
+// backpressure while we are parked emitting, not draining) cannot block the loop —
+// and ctx-cancel — forever. See sendStandby.
+const standbyWriteTimeout = 10 * time.Second
+
+// Config binds everything Run needs. ReplDSN MUST carry replication=database (it is
+// a CopyBoth replication connection and cannot run queries); QueryDSN is a normal
+// connection used for the catalog PK lookup and the slot/publication checks.
+type Config struct {
+	ReplDSN     string
+	QueryDSN    string
+	SlotName    string
+	Publication string
+	Filters     event.Filters
+	StartLSN    pglogrepl.LSN // the resume checkpoint; 0 on first run (see ensureSlot — the gate is slot existence, not this)
+	// StandbyInterval is how often a standby status update is sent (server liveness +
+	// confirmed_flush_lsn feedback). 0 derives it from the server's wal_sender_timeout
+	// (timeout/3, floor 1s), falling back to defaultStandbyInterval. Tests set it low.
+	StandbyInterval time.Duration
+	Logger          *slog.Logger
+}
+
+// Capturer decodes a PostgreSQL logical-replication stream into event.Event. It
+// mirrors parser.StreamParser: a producer whose Run emits on an out channel,
+// returning nil on graceful ctx-cancel and a non-nil error on a decode/network
+// failure (so a supervisor reconnects). The one divergence from StreamParser is the
+// consumer→server feedback PostgreSQL requires: see AckCommitted.
+type Capturer struct {
+	cfg    Config
+	logger *slog.Logger
+	// lastAcked is the confirmed_flush_lsn the consumer has DURABLY persisted; every
+	// standby status update reports it and never anything ahead, so PostgreSQL can
+	// never release WAL for rows the index has not durably recorded.
+	lastAcked atomic.Uint64
+}
+
+// New constructs a Capturer. It does not open connections (Run does), mirroring
+// NewStreamParser's no-I/O constructor. logger may be nil (slog.Default()).
+func New(cfg Config) *Capturer {
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Capturer{cfg: cfg, logger: logger}
+}
+
+// AckCommitted records the LSN the consumer has DURABLY persisted (its checkpoint
+// saved after the batch was flushed to the index). The Run loop reports this in
+// every standby status update and never a position ahead of it — the #491 invariant
+// in PostgreSQL clothing, here additionally guarding the source's WAL (acking before
+// persisting would let PostgreSQL drop WAL the index never recorded, unrecoverable).
+// The consumer (#534) must call this with the EventCommit commit LSN, only after its
+// saveCheckpoint succeeds. Safe to call concurrently with Run.
+func (c *Capturer) AckCommitted(lsn uint64) { c.lastAcked.Store(lsn) }
+
+// Run opens the replication + query connections, validates the publication, ensures
+// the slot, starts replication, and emits event.Event on out until ctx is cancelled.
+// It returns nil on graceful ctx-cancel and does NOT close out (the caller owns the
+// channel, mirroring streamrun).
+func (c *Capturer) Run(ctx context.Context, out chan<- event.Event) error {
+	if c.cfg.ReplDSN == "" || c.cfg.QueryDSN == "" || c.cfg.SlotName == "" || c.cfg.Publication == "" {
+		return fmt.Errorf("pgcapture: Run requires ReplDSN, QueryDSN, SlotName, and Publication")
+	}
+
+	replConn, err := pgconn.Connect(ctx, c.cfg.ReplDSN)
+	if err != nil {
+		return fmt.Errorf("pgcapture: connect replication: %w", err)
+	}
+	defer closeReplConn(replConn)
+
+	queryConn, err := pgx.Connect(ctx, c.cfg.QueryDSN)
+	if err != nil {
+		return fmt.Errorf("pgcapture: connect query: %w", err)
+	}
+	defer closeQueryConn(queryConn)
+
+	if err := validatePublication(ctx, queryConn, c.cfg.Publication, c.cfg.Filters); err != nil {
+		return err
+	}
+
+	startLSN, err := ensureSlot(ctx, replConn, queryConn, c.cfg.SlotName, c.cfg.StartLSN)
+	if err != nil {
+		return err
+	}
+
+	if err := pglogrepl.StartReplication(ctx, replConn, c.cfg.SlotName, startLSN, pglogrepl.StartReplicationOptions{
+		Mode:       pglogrepl.LogicalReplication,
+		PluginArgs: []string{"proto_version '1'", fmt.Sprintf("publication_names '%s'", c.cfg.Publication)},
+	}); err != nil {
+		return fmt.Errorf("pgcapture: start replication slot %q from %s: %w", c.cfg.SlotName, startLSN, err)
+	}
+	// Seed the durable cursor to the resume point: everything up to startLSN is
+	// already durably indexed (first run = ConsistentPoint, nothing precedes it).
+	c.lastAcked.Store(uint64(startLSN))
+	c.logger.Info("pgcapture: started", "slot", c.cfg.SlotName, "publication", c.cfg.Publication, "start_lsn", startLSN)
+
+	// Catalog-backed PKResolver over the query conn, bounded by the Run ctx (+ a
+	// timeout) so a hung catalog lookup cannot wedge or outlive the stream.
+	resolvePK := func(relationID uint32, schema, table string) ([]metadata.ColumnMeta, error) {
+		qctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+		return queryPK(qctx, queryConn, relationID)
+	}
+	decoder := NewDecoder(resolvePK, c.cfg.Filters, c.logger)
+
+	interval := c.cfg.StandbyInterval
+	if interval <= 0 {
+		interval = c.deriveStandbyInterval(ctx, queryConn)
+	}
+	standbyTicker := time.NewTicker(interval)
+	defer standbyTicker.Stop()
+
+	err = c.receiveLoop(ctx, replConn, decoder, out, interval, standbyTicker)
+	if ctx.Err() != nil {
+		return nil // graceful shutdown (ctx-cancel surfaced as a receive/emit error)
+	}
+	return err
+}
+
+// receiveLoop is the single-goroutine replication loop. pgconn is NOT concurrency-
+// safe, so everything — receiving, decoding, emitting, and sending standby updates —
+// happens here in sequence; a second goroutine touching the connection is barred.
+func (c *Capturer) receiveLoop(ctx context.Context, replConn *pgconn.PgConn, decoder *Decoder, out chan<- event.Event, interval time.Duration, standbyTicker *time.Ticker) error {
+	for {
+		// Deadline so a quiet server still triggers a periodic standby update.
+		recvCtx, cancel := context.WithDeadline(ctx, time.Now().Add(interval))
+		msg, err := replConn.ReceiveMessage(recvCtx)
+		cancel()
+		if err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err() // shutdown — Run translates to nil
+			}
+			if pgconn.Timeout(err) {
+				if err := c.sendStandby(replConn); err != nil {
+					return err
+				}
+				continue
+			}
+			return fmt.Errorf("pgcapture: receive message: %w", err)
+		}
+
+		cd, ok := msg.(*pgproto3.CopyData)
+		if !ok {
+			continue
+		}
+		switch cd.Data[0] {
+		case pglogrepl.PrimaryKeepaliveMessageByteID:
+			pkm, err := pglogrepl.ParsePrimaryKeepaliveMessage(cd.Data[1:])
+			if err != nil {
+				return fmt.Errorf("pgcapture: parse keepalive: %w", err)
+			}
+			if pkm.ReplyRequested {
+				if err := c.sendStandby(replConn); err != nil {
+					return err
+				}
+			}
+		case pglogrepl.XLogDataByteID:
+			xld, err := pglogrepl.ParseXLogData(cd.Data[1:])
+			if err != nil {
+				return fmt.Errorf("pgcapture: parse XLogData: %w", err)
+			}
+			logmsg, err := pglogrepl.Parse(xld.WALData)
+			if err != nil {
+				// A malformed logical message is stream desync, not noise — fail loud.
+				return fmt.Errorf("pgcapture: parse logical message at %s: %w", xld.WALStart, err)
+			}
+			ev, emit, err := decoder.Decode(logmsg)
+			if err != nil {
+				return err
+			}
+			if emit {
+				if err := c.emit(ctx, replConn, out, ev, standbyTicker); err != nil {
+					return err
+				}
+			}
+		}
+	}
+}
+
+// emit delivers one event on out. It must not let a slow consumer starve the
+// keepalive: while blocked it keeps sending standby updates on the ticker (which
+// satisfies wal_sender_timeout — the server resets its liveness timer on ANY client
+// message, no WAL consumption required) and stays responsive to ctx-cancel. It is
+// the keepalive-in-the-same-select pattern; a second goroutine is barred (pgconn is
+// not concurrency-safe). While parked here we are intentionally NOT draining the
+// server→client stream; sendStandby's bounded write keeps that backpressure from
+// wedging the loop.
+func (c *Capturer) emit(ctx context.Context, replConn *pgconn.PgConn, out chan<- event.Event, ev event.Event, standbyTicker *time.Ticker) error {
+	for {
+		select {
+		case out <- ev:
+			return nil
+		case <-standbyTicker.C:
+			if err := c.sendStandby(replConn); err != nil {
+				return err
+			}
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+// sendStandby reports the consumer's DURABLE position (lastAcked) as the WAL
+// write/flush position — never the received position — so confirmed_flush_lsn can
+// never advance past durably-indexed WAL. The write is bounded by a deadline:
+// SendStandbyStatusUpdate ignores its context and does a deadline-less net write,
+// which under TCP backpressure (we stop draining while parked in emit) could
+// otherwise block forever and deadlock the loop and ctx-cancel.
+func (c *Capturer) sendStandby(replConn *pgconn.PgConn) error {
+	lsn := pglogrepl.LSN(c.lastAcked.Load())
+	if nc := replConn.Conn(); nc != nil {
+		_ = nc.SetWriteDeadline(time.Now().Add(standbyWriteTimeout))
+		defer func() { _ = nc.SetWriteDeadline(time.Time{}) }()
+	}
+	if err := pglogrepl.SendStandbyStatusUpdate(context.Background(), replConn, pglogrepl.StandbyStatusUpdate{WALWritePosition: lsn}); err != nil {
+		return fmt.Errorf("pgcapture: send standby status (flushed=%s): %w", lsn, err)
+	}
+	return nil
+}
+
+// deriveStandbyInterval reads the server's wal_sender_timeout (milliseconds; 0 =
+// disabled) and returns a third of it (the cadence the walsender itself uses),
+// floored at 1s. It falls back to defaultStandbyInterval on any error or when the
+// timeout is disabled. This avoids baking in the 60s default — an operator who set a
+// shorter wal_sender_timeout would otherwise see the connection dropped.
+func (c *Capturer) deriveStandbyInterval(ctx context.Context, queryConn *pgx.Conn) time.Duration {
+	var ms int
+	err := queryConn.QueryRow(ctx, `SELECT setting::int FROM pg_settings WHERE name = 'wal_sender_timeout'`).Scan(&ms)
+	if err != nil || ms <= 0 {
+		return defaultStandbyInterval
+	}
+	interval := time.Duration(ms) * time.Millisecond / 3
+	if interval < time.Second {
+		interval = time.Second
+	}
+	return interval
+}
+
+// closeReplConn / closeQueryConn close on a fresh background context: Run's ctx is
+// already cancelled exactly when a graceful shutdown runs these defers, and
+// pgconn/pgx Close take a context for the clean terminate message — passing the
+// cancelled ctx would skip it (an abrupt drop).
+func closeReplConn(conn *pgconn.PgConn) {
+	cctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = conn.Close(cctx)
+}
+
+func closeQueryConn(conn *pgx.Conn) {
+	cctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = conn.Close(cctx)
+}

--- a/internal/pgcapture/capturer_integration_test.go
+++ b/internal/pgcapture/capturer_integration_test.go
@@ -224,6 +224,77 @@ func TestCapturer_PublicationCoverageFailsLoud(t *testing.T) {
 	}
 }
 
+// TestCapturer_CompositePKOrder proves PKValues uses primary-key declaration order,
+// not column/attnum order. The table's columns are (a, b, c) but its PRIMARY KEY is
+// (b, a) — so a naive attnum ordering would yield "10|20" where the correct key
+// order is "20|10". This is the one correctness-critical path the single-column
+// integration test leaves uncovered (wrong PK order silently corrupts pk_hash).
+func TestCapturer_CompositePKOrder(t *testing.T) {
+	baseDSN := testutil.SkipIfNoPostgres(t)
+	ctx := context.Background()
+
+	const slot = "bintrail_pgcap_ck"
+	const pub = "bintrail_pgcap_ck_pub"
+	const tbl = "pgcap_ck_t"
+
+	setup, err := pgx.Connect(ctx, baseDSN)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { setup.Close(context.Background()) })
+	cleanup := func() {
+		bg := context.Background()
+		_, _ = setup.Exec(bg, "DROP PUBLICATION IF EXISTS "+pub)
+		_, _ = setup.Exec(bg, "DROP TABLE IF EXISTS "+tbl)
+		_, _ = setup.Exec(bg, "SELECT pg_drop_replication_slot($1) WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name=$1)", slot)
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	mustExec := func(sql string, args ...any) {
+		t.Helper()
+		if _, err := setup.Exec(ctx, sql, args...); err != nil {
+			t.Fatalf("exec %q: %v", sql, err)
+		}
+	}
+	// Columns declared a, b, c (attnums 1, 2, 3); key is (b, a) = attnums (2, 1).
+	mustExec(fmt.Sprintf("CREATE TABLE %s (a int, b int, c text, PRIMARY KEY (b, a))", tbl))
+	mustExec(fmt.Sprintf("ALTER TABLE %s REPLICA IDENTITY FULL", tbl))
+	mustExec(fmt.Sprintf("CREATE PUBLICATION %s FOR TABLE %s", pub, tbl))
+
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	cap := pgcapture.New(pgcapture.Config{
+		ReplDSN:         replDSN(baseDSN),
+		QueryDSN:        baseDSN,
+		SlotName:        slot,
+		Publication:     pub,
+		Filters:         event.Filters{Tables: map[string]bool{"public." + tbl: true}},
+		StandbyInterval: 200 * time.Millisecond,
+	})
+	events := make(chan event.Event, 16)
+	runErr := make(chan error, 1)
+	go func() { runErr <- cap.Run(runCtx, events) }()
+	waitFor(t, 10*time.Second, func() bool {
+		var active bool
+		if err := setup.QueryRow(ctx, "SELECT active FROM pg_replication_slots WHERE slot_name=$1", slot).Scan(&active); err != nil {
+			return false
+		}
+		return active
+	}, "replication slot to become active")
+
+	mustExec(fmt.Sprintf("INSERT INTO %s VALUES (10, 20, 'x')", tbl)) // a=10, b=20
+
+	rows, _ := collect(t, events, 1, 10*time.Second)
+	ins := pick(t, rows, event.EventInsert)
+	if ins.PKValues != "20|10" {
+		t.Errorf("composite PKValues = %q, want %q (key order (b, a), not column/attnum order)", ins.PKValues, "20|10")
+	}
+
+	cancel()
+	<-runErr
+}
+
 // ── helpers ──
 
 func replDSN(base string) string {

--- a/internal/pgcapture/capturer_integration_test.go
+++ b/internal/pgcapture/capturer_integration_test.go
@@ -1,0 +1,327 @@
+//go:build integration
+
+package pgcapture_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pglogrepl"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/dbtrail/dbtrail/internal/event"
+	"github.com/dbtrail/dbtrail/internal/pgcapture"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestCapturer_Integration drives the real Capturer against a live PostgreSQL,
+// reproducing the spike end-to-end: an UPDATE that does not touch an out-of-line
+// TOASTed column under REPLICA IDENTITY FULL must carry the real value in BOTH
+// images (Option B), and confirmed_flush_lsn must advance ONLY after AckCommitted.
+//
+// Requires BINTRAIL_TEST_PG_DSN pointing at a PostgreSQL with wal_level=logical and
+// a REPLICATION role (e.g. postgres://postgres:testpg@localhost:15533/pgtest). The
+// MySQL CI jobs do not set it, so this skips cleanly there (Postgres CI is #534).
+func TestCapturer_Integration(t *testing.T) {
+	baseDSN := testutil.SkipIfNoPostgres(t)
+	ctx := context.Background()
+
+	const slot = "bintrail_pgcap_it"
+	const pub = "bintrail_pgcap_it_pub"
+	const tbl = "pgcap_it_t"
+	const bigSize = 6000
+
+	setup, err := pgx.Connect(ctx, baseDSN)
+	if err != nil {
+		t.Fatalf("connect setup conn: %v", err)
+	}
+	t.Cleanup(func() { setup.Close(context.Background()) })
+
+	dropAll := func(c *pgx.Conn) {
+		bg := context.Background()
+		_, _ = c.Exec(bg, fmt.Sprintf("DROP PUBLICATION IF EXISTS %s", pub))
+		_, _ = c.Exec(bg, fmt.Sprintf("DROP TABLE IF EXISTS %s", tbl))
+		// Drop the slot last (it must be inactive — the Run goroutine is cancelled by
+		// the time Cleanup runs). A leaked permanent slot retains WAL and burns a
+		// max_replication_slots entry on every rerun.
+		_, _ = c.Exec(bg, "SELECT pg_drop_replication_slot($1) WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name=$1)", slot)
+	}
+	dropAll(setup)
+	t.Cleanup(func() { dropAll(setup) })
+
+	mustExec := func(sql string, args ...any) {
+		t.Helper()
+		if _, err := setup.Exec(ctx, sql, args...); err != nil {
+			t.Fatalf("exec %q: %v", sql, err)
+		}
+	}
+	mustExec(fmt.Sprintf("CREATE TABLE %s (id int PRIMARY KEY, small_col text, big_col text)", tbl))
+	mustExec(fmt.Sprintf("ALTER TABLE %s ALTER COLUMN big_col SET STORAGE EXTERNAL", tbl)) // no compression → forced out-of-line
+	mustExec(fmt.Sprintf("ALTER TABLE %s REPLICA IDENTITY FULL", tbl))
+	mustExec(fmt.Sprintf("CREATE PUBLICATION %s FOR TABLE %s", pub, tbl))
+
+	bigVal := strings.Repeat("X", bigSize)
+	mustExec(fmt.Sprintf("INSERT INTO %s VALUES (1, 'orig', $1)", tbl), bigVal) // baseline (pre-slot, not streamed)
+
+	// Prove big_col is genuinely out-of-line, else the 'u' path is never exercised
+	// and the whole test could pass green without testing anything (verify finding).
+	var colSize int
+	if err := setup.QueryRow(ctx, fmt.Sprintf("SELECT pg_column_size(big_col) FROM %s WHERE id=1", tbl)).Scan(&colSize); err != nil {
+		t.Fatalf("pg_column_size: %v", err)
+	}
+	if colSize < 2000 {
+		t.Fatalf("big_col size %d is below the TOAST threshold — not out-of-line, TOAST path not exercised", colSize)
+	}
+	var toastSize int64
+	if err := setup.QueryRow(ctx, "SELECT pg_relation_size(reltoastrelid) FROM pg_class WHERE oid = $1::regclass", "public."+tbl).Scan(&toastSize); err != nil {
+		t.Fatalf("toast relation size: %v", err)
+	}
+	if toastSize == 0 {
+		t.Fatal("TOAST relation is empty — big_col stored inline, TOAST path not exercised")
+	}
+
+	// Start the capturer (it creates the slot from its ConsistentPoint).
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	cap := pgcapture.New(pgcapture.Config{
+		ReplDSN:         replDSN(baseDSN),
+		QueryDSN:        baseDSN,
+		SlotName:        slot,
+		Publication:     pub,
+		Filters:         event.Filters{Tables: map[string]bool{"public." + tbl: true}},
+		StandbyInterval: 200 * time.Millisecond, // low so the never-ahead poll is fast, not flaky
+	})
+	events := make(chan event.Event, 64)
+	runErr := make(chan error, 1)
+	go func() { runErr <- cap.Run(runCtx, events) }()
+
+	// Wait until the slot is active (Run has started replication) before any DML, so
+	// every change below is within the captured range.
+	waitFor(t, 10*time.Second, func() bool {
+		var active bool
+		if err := setup.QueryRow(ctx, "SELECT active FROM pg_replication_slots WHERE slot_name=$1", slot).Scan(&active); err != nil {
+			return false
+		}
+		return active
+	}, "replication slot to become active")
+
+	baseline := confirmedFlush(t, setup, slot) // ≈ the slot's consistent point
+
+	// The discriminating DML: UPDATE leaves big_col untouched.
+	mustExec(fmt.Sprintf("UPDATE %s SET small_col='changed' WHERE id=1", tbl))
+	mustExec(fmt.Sprintf("INSERT INTO %s VALUES (2, 'second', $1)", tbl), strings.Repeat("Y", bigSize))
+	mustExec(fmt.Sprintf("DELETE FROM %s WHERE id=2", tbl))
+
+	// Collect until we have all three row events (commits interleaved).
+	rows, commits := collect(t, events, 3, 15*time.Second)
+
+	// ── UPDATE: the spike's headline TOAST round-trip ──
+	upd := pick(t, rows, event.EventUpdate)
+	if got := upd.RowBefore["big_col"]; got != bigVal {
+		t.Errorf("UPDATE RowBefore[big_col]: got %d-byte %T, want the real %d-byte value", lenOf(got), got, bigSize)
+	}
+	if got := upd.RowAfter["big_col"]; got != bigVal {
+		t.Errorf("UPDATE RowAfter[big_col]: got %v (%T), want the real value resolved from the before-image (Option B)", trunc(got), got)
+	}
+	if changed := event.ChangedColumns(upd.RowBefore, upd.RowAfter); contains(changed, "big_col") {
+		t.Errorf("changed_columns wrongly includes the untouched TOAST column: %v", changed)
+	}
+	if upd.PKValues != "1" {
+		t.Errorf("UPDATE PKValues=%q, want 1", upd.PKValues)
+	}
+	if strings.Contains(upd.PKValues, pgcapture.UnchangedToastKey) {
+		t.Errorf("UPDATE PKValues leaked the unchanged-TOAST marker: %q", upd.PKValues)
+	}
+
+	// ── INSERT / DELETE ──
+	ins := pick(t, rows, event.EventInsert)
+	if ins.PKValues != "2" || ins.RowAfter["small_col"] != "second" {
+		t.Errorf("INSERT event wrong: pk=%q after=%v", ins.PKValues, ins.RowAfter)
+	}
+	del := pick(t, rows, event.EventDelete)
+	if del.PKValues != "2" || del.RowBefore["small_col"] != "second" {
+		t.Errorf("DELETE event wrong: pk=%q before=%v", del.PKValues, del.RowBefore)
+	}
+
+	// ── never-ahead: confirmed_flush must NOT advance without an ack ──
+	// Give the capturer time to send several standby updates (interval 200ms).
+	time.Sleep(700 * time.Millisecond)
+	if cur := confirmedFlush(t, setup, slot); cur > baseline {
+		t.Errorf("confirmed_flush_lsn advanced (%s → %s) WITHOUT AckCommitted — never-ahead violated", baseline, cur)
+	}
+
+	// ── ack the last commit → confirmed_flush advances to it ──
+	if len(commits) == 0 {
+		t.Fatal("no EventCommit collected")
+	}
+	lastCommit, err := pgcapture.DecodeLSN(commits[len(commits)-1].GTID)
+	if err != nil {
+		t.Fatalf("decode commit LSN %q: %v", commits[len(commits)-1].GTID, err)
+	}
+	cap.AckCommitted(uint64(lastCommit))
+	waitFor(t, 5*time.Second, func() bool {
+		return confirmedFlush(t, setup, slot) >= lastCommit
+	}, "confirmed_flush_lsn to advance to the acked commit LSN")
+
+	// Clean shutdown returns nil.
+	cancel()
+	select {
+	case err := <-runErr:
+		if err != nil {
+			t.Errorf("Run returned non-nil on graceful cancel: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Error("Run did not return promptly after ctx cancel")
+	}
+}
+
+// TestCapturer_PublicationCoverageFailsLoud proves the validate-don't-create gate:
+// a publication that omits a requested table fails loud rather than silently
+// streaming zero events for it.
+func TestCapturer_PublicationCoverageFailsLoud(t *testing.T) {
+	baseDSN := testutil.SkipIfNoPostgres(t)
+	ctx := context.Background()
+	const pub = "bintrail_pgcap_cov_pub"
+	const tblA = "pgcap_cov_a"
+
+	setup, err := pgx.Connect(ctx, baseDSN)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { setup.Close(context.Background()) })
+	cleanup := func() {
+		bg := context.Background()
+		_, _ = setup.Exec(bg, "DROP PUBLICATION IF EXISTS "+pub)
+		_, _ = setup.Exec(bg, "DROP TABLE IF EXISTS "+tblA)
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	if _, err := setup.Exec(ctx, fmt.Sprintf("CREATE TABLE %s (id int PRIMARY KEY)", tblA)); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	if _, err := setup.Exec(ctx, fmt.Sprintf("CREATE PUBLICATION %s FOR TABLE %s", pub, tblA)); err != nil {
+		t.Fatalf("create publication: %v", err)
+	}
+
+	cap := pgcapture.New(pgcapture.Config{
+		ReplDSN:     replDSN(baseDSN),
+		QueryDSN:    baseDSN,
+		SlotName:    "bintrail_pgcap_cov_slot",
+		Publication: pub,
+		// Request a table the publication does NOT cover.
+		Filters: event.Filters{Tables: map[string]bool{"public.not_published": true}},
+	})
+	err = cap.Run(ctx, make(chan event.Event, 1))
+	if err == nil {
+		t.Fatal("expected Run to fail loud on a publication that omits a requested table")
+	}
+	if !strings.Contains(err.Error(), "does not cover") {
+		t.Errorf("unexpected error (want coverage failure): %v", err)
+	}
+}
+
+// ── helpers ──
+
+func replDSN(base string) string {
+	if strings.Contains(base, "?") {
+		return base + "&replication=database"
+	}
+	return base + "?replication=database"
+}
+
+func confirmedFlush(t *testing.T, conn *pgx.Conn, slot string) pglogrepl.LSN {
+	t.Helper()
+	var s string
+	if err := conn.QueryRow(context.Background(), "SELECT confirmed_flush_lsn::text FROM pg_replication_slots WHERE slot_name=$1", slot).Scan(&s); err != nil {
+		t.Fatalf("read confirmed_flush_lsn: %v", err)
+	}
+	lsn, err := pglogrepl.ParseLSN(s)
+	if err != nil {
+		t.Fatalf("parse confirmed_flush_lsn %q: %v", s, err)
+	}
+	return lsn
+}
+
+// collect reads from ch until it has wantRows non-commit row events or times out,
+// returning the row events and the EventCommit events separately.
+func collect(t *testing.T, ch <-chan event.Event, wantRows int, timeout time.Duration) (rows, commits []event.Event) {
+	t.Helper()
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	for len(rows) < wantRows {
+		select {
+		case ev := <-ch:
+			if ev.EventType == event.EventCommit {
+				commits = append(commits, ev)
+			} else {
+				rows = append(rows, ev)
+			}
+		case <-deadline.C:
+			t.Fatalf("timed out: collected %d/%d row events (%d commits)", len(rows), wantRows, len(commits))
+		}
+	}
+	// Drain any trailing commit already queued (best-effort, non-blocking).
+	for {
+		select {
+		case ev := <-ch:
+			if ev.EventType == event.EventCommit {
+				commits = append(commits, ev)
+			} else {
+				rows = append(rows, ev)
+			}
+		default:
+			return rows, commits
+		}
+	}
+}
+
+func pick(t *testing.T, rows []event.Event, typ event.EventType) event.Event {
+	t.Helper()
+	for _, ev := range rows {
+		if ev.EventType == typ {
+			return ev
+		}
+	}
+	t.Fatalf("no event of type %d among %d collected row events", typ, len(rows))
+	return event.Event{}
+}
+
+func waitFor(t *testing.T, timeout time.Duration, cond func() bool, what string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+func contains(ss []string, s string) bool {
+	for _, x := range ss {
+		if x == s {
+			return true
+		}
+	}
+	return false
+}
+
+func lenOf(v any) int {
+	if s, ok := v.(string); ok {
+		return len(s)
+	}
+	return -1
+}
+
+func trunc(v any) string {
+	s := fmt.Sprintf("%v", v)
+	if len(s) > 40 {
+		return s[:40] + "…"
+	}
+	return s
+}

--- a/internal/pgcapture/relation.go
+++ b/internal/pgcapture/relation.go
@@ -1,6 +1,13 @@
 package pgcapture
 
-import "github.com/dbtrail/dbtrail/internal/metadata"
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/dbtrail/dbtrail/internal/metadata"
+)
 
 // relColumn is one column of a cached relation, in ordinal (tuple) order. It
 // retains the pgoutput per-column type identity (typeOID/typeMod) even though #530
@@ -43,3 +50,37 @@ type relationInfo struct {
 // connection (the replication connection is in CopyBoth streaming mode and cannot
 // run queries); unit tests stub it.
 type PKResolver func(relationID uint32, schema, table string) ([]metadata.ColumnMeta, error)
+
+// pkColumnsQuery returns a relation's primary-key column names in key order, given
+// the relation's OID (which equals the pgoutput RelationMessage RelationID).
+const pkColumnsQuery = `SELECT a.attname
+FROM pg_index i
+JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
+WHERE i.indrelid = $1 AND i.indisprimary
+ORDER BY array_position(i.indkey, a.attnum)`
+
+// queryPK is the catalog-backed PKResolver body: it looks up a relation's primary-
+// key columns by OID on a regular (non-replication) connection. The capturer wires
+// it into a PKResolver closure over its query conn and the Run context. An empty
+// result (no primary key) returns an empty slice; any query/scan error is returned
+// so the decoder fails loud rather than index under a wrong or missing PK.
+func queryPK(ctx context.Context, conn *pgx.Conn, relationID uint32) ([]metadata.ColumnMeta, error) {
+	rows, err := conn.Query(ctx, pkColumnsQuery, relationID)
+	if err != nil {
+		return nil, fmt.Errorf("pgcapture: query PK columns for relation OID %d: %w", relationID, err)
+	}
+	defer rows.Close()
+
+	var cols []metadata.ColumnMeta
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("pgcapture: scan PK column for relation OID %d: %w", relationID, err)
+		}
+		cols = append(cols, metadata.ColumnMeta{Name: name, OrdinalPosition: len(cols) + 1, IsPK: true})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("pgcapture: iterate PK columns for relation OID %d: %w", relationID, err)
+	}
+	return cols, nil
+}

--- a/internal/pgcapture/slot.go
+++ b/internal/pgcapture/slot.go
@@ -1,0 +1,109 @@
+package pgcapture
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/jackc/pglogrepl"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/dbtrail/dbtrail/internal/event"
+)
+
+// validatePublication checks that the pgoutput publication exists AND covers every
+// table the capturer is asked to stream — validate-don't-create, mirroring how the
+// MySQL path validates binlog_row_image=FULL rather than setting it. The publication
+// defines the captured table set, which is an operator privilege/policy decision; a
+// publication that exists but omits a requested table would emit ZERO events for it,
+// silently and forever, so a coverage gap fails loud.
+func validatePublication(ctx context.Context, conn *pgx.Conn, pubname string, filters event.Filters) error {
+	var allTables bool
+	err := conn.QueryRow(ctx, `SELECT puballtables FROM pg_publication WHERE pubname = $1`, pubname).Scan(&allTables)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return fmt.Errorf("pgcapture: publication %q does not exist — create it (CREATE PUBLICATION) covering the tables to capture", pubname)
+	}
+	if err != nil {
+		return fmt.Errorf("pgcapture: checking publication %q: %w", pubname, err)
+	}
+	// FOR ALL TABLES covers everything; a nil table filter means "accept whatever the
+	// publication streams", so there is no requested set to verify coverage against.
+	if allTables || len(filters.Tables) == 0 {
+		return nil
+	}
+
+	rows, err := conn.Query(ctx, `SELECT schemaname || '.' || tablename FROM pg_publication_tables WHERE pubname = $1`, pubname)
+	if err != nil {
+		return fmt.Errorf("pgcapture: listing tables of publication %q: %w", pubname, err)
+	}
+	defer rows.Close()
+	published := make(map[string]bool)
+	for rows.Next() {
+		var t string
+		if err := rows.Scan(&t); err != nil {
+			return fmt.Errorf("pgcapture: scanning tables of publication %q: %w", pubname, err)
+		}
+		published[t] = true
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("pgcapture: listing tables of publication %q: %w", pubname, err)
+	}
+
+	var missing []string
+	for t := range filters.Tables {
+		if !published[t] {
+			missing = append(missing, t)
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		return fmt.Errorf("pgcapture: publication %q does not cover requested table(s) [%s] — their changes would be silently lost; add them to the publication",
+			pubname, strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+// ensureSlot returns the LSN to start replication from, creating the slot on first
+// run. The first-run-vs-resume decision is gated on slot EXISTENCE in
+// pg_replication_slots (NOT on savedLSN==0 — an empty saved checkpoint decodes to
+// LSN 0, which would collide with a genuine first run).
+//
+//   - Absent: create a permanent pgoutput slot and start from its ConsistentPoint
+//     (NOT IdentifySystem().XLogPos — that is past any pre-StartReplication DML and
+//     yields an empty stream; a footgun hit in the spike).
+//   - Present (resume): return savedLSN. PostgreSQL actually resumes from the slot's
+//     own confirmed_flush_lsn (it clamps a lower client LSN forward and re-delivers —
+//     at-least-once, never skipping), so savedLSN's load-bearing role is seeding
+//     lastAcked, not the StartReplication argument.
+//
+// The slot is permanent (Temporary defaults false) so it survives restarts — required
+// for resume. The flip side is source-side WAL retention if the consumer stalls
+// (the PG analog of binlog retention); WAL-retention monitoring is #532.
+func ensureSlot(ctx context.Context, replConn *pgconn.PgConn, queryConn *pgx.Conn, slotName string, savedLSN pglogrepl.LSN) (pglogrepl.LSN, error) {
+	var exists bool
+	if err := queryConn.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM pg_replication_slots WHERE slot_name = $1)`, slotName).Scan(&exists); err != nil {
+		return 0, fmt.Errorf("pgcapture: checking replication slot %q: %w", slotName, err)
+	}
+	if exists {
+		return savedLSN, nil
+	}
+
+	res, err := pglogrepl.CreateReplicationSlot(ctx, replConn, slotName, "pgoutput", pglogrepl.CreateReplicationSlotOptions{Mode: pglogrepl.LogicalReplication})
+	if err != nil {
+		// TOCTOU: another capturer or a restart created the slot between the EXISTS
+		// check and now (SQLSTATE 42710 = duplicate_object). Treat as a resume.
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.SQLState() == "42710" {
+			return savedLSN, nil
+		}
+		return 0, fmt.Errorf("pgcapture: creating replication slot %q: %w", slotName, err)
+	}
+	lsn, err := pglogrepl.ParseLSN(res.ConsistentPoint)
+	if err != nil {
+		return 0, fmt.Errorf("pgcapture: parsing consistent point %q for slot %q: %w", res.ConsistentPoint, slotName, err)
+	}
+	return lsn, nil
+}

--- a/internal/testutil/postgres.go
+++ b/internal/testutil/postgres.go
@@ -1,0 +1,26 @@
+package testutil
+
+import (
+	"os"
+	"testing"
+)
+
+// PostgresDSN returns the test PostgreSQL DSN from BINTRAIL_TEST_PG_DSN, or "".
+// A suitable target is a local PostgreSQL with wal_level=logical and a role that
+// has REPLICATION (e.g. the spike's container:
+// postgres://postgres:testpg@localhost:15533/pgtest).
+func PostgresDSN() string { return os.Getenv("BINTRAIL_TEST_PG_DSN") }
+
+// SkipIfNoPostgres skips the test unless BINTRAIL_TEST_PG_DSN is set, and returns
+// the DSN. It is presence-only (no driver dependency) on purpose: the MySQL-based
+// CI integration jobs run `go test -tags integration ./...` WITHOUT setting it, so
+// PostgreSQL integration tests must skip cleanly there rather than fail or hang —
+// a live Postgres CI cell arrives with #534's matrix. Mirrors SkipIfNoMySQL.
+func SkipIfNoPostgres(t *testing.T) string {
+	t.Helper()
+	dsn := PostgresDSN()
+	if dsn == "" {
+		t.Skip("skipping: BINTRAIL_TEST_PG_DSN not set (no live PostgreSQL with logical replication)")
+	}
+	return dsn
+}


### PR DESCRIPTION
## What

Second slice of **#530** — the I/O half that wires the pure decoder (slice 1, merged) to a live PostgreSQL logical-replication stream. **Validated end-to-end against a real `postgres:16`** (the capture spike, now a permanent integration test).

## Files

- **`capturer.go`** — `Capturer`/`Config`/`New`/`Run`/`AckCommitted`. `Run` opens a replication conn (`pgconn`, `replication=database`) + a query conn (`pgx`, catalog), validates the publication, ensures the slot, `StartReplication`, then a **single-goroutine** receive loop (`ReceiveMessage` → XLogData/keepalive → `pglogrepl.Parse` → `Decoder.Decode` → emit). Mirrors `parser.StreamParser`; the one divergence is `AckCommitted` (the consumer→server feedback PG requires).
- **`slot.go`** — `validatePublication` (validate-don't-create, **including coverage**) + `ensureSlot` (create-if-absent from `ConsistentPoint`; resume gated on slot existence).
- **`relation.go`** — `queryPK`, the catalog-backed `PKResolver` body (`pg_index.indisprimary` on the query conn), wired by `Run` into a ctx-bounded closure.
- **`testutil.SkipIfNoPostgres`** — presence-only gate on `BINTRAIL_TEST_PG_DSN` so the MySQL CI integration jobs (which run `-tags integration` *without* Postgres) **skip cleanly** — verified before pushing.

## Design — hardened by an adversarial-verify workflow + advisor, proven by the live test

A pre-code verify workflow (5 agents) + advisor caught 4 real I/O-invariant issues before implementation; each load-bearing invariant is now proven by the live integration test:

- **never-ahead** — every standby status update reports `lastAcked` (the consumer's **durable** position), never the received position, so `confirmed_flush_lsn` (and thus source WAL release) can never run ahead of durably-indexed rows. The test asserts `confirmed_flush_lsn` does **not** advance without `AckCommitted`, then **does** after.
- **keepalive-in-select** — a slow consumer blocking `out<-ev` keeps the connection alive via standby ticks in the same `select` (a second goroutine is barred — `pgconn` is not concurrency-safe); the standby write is bounded by a write deadline so TCP backpressure can't deadlock the loop or ctx-cancel.
- **publication coverage (MAJOR fix)** — an existing publication that omits a requested table **fails loud**, not silent zero-events. Proven by `TestCapturer_PublicationCoverageFailsLoud`.
- **slot resume** — gated on slot existence (not `StartLSN==0`); `42710` (duplicate) treated as resume; PG resumes from the slot's `confirmed_flush_lsn` (at-least-once, never skips).
- **graceful shutdown** — both conns close on `context.Background()` (the run ctx is already cancelled at shutdown); `Run` returns `nil` on ctx-cancel, non-nil on a real error so a supervisor reconnects. **`-race` clean.**

The integration test reproduces the spike's headline: an UPDATE that does not touch an out-of-line (`STORAGE EXTERNAL`, 6 KB) TOASTed column under RI FULL carries the real value in **both** images (Option B), `changed_columns` excludes it, no sentinel in `PKValues`. It asserts `pg_column_size` + a non-empty TOAST relation so it **fails if the value ever stayed inline** (the verify caught that `STORAGE EXTERNAL` alone doesn't force out-of-line).

## Verification

- `go build ./...` + `-tags integration` — clean; `go vet` — clean; `gofmt -l` — clean
- full unit suite — green; `check-notices` — green (dep graph unchanged; pgx was already in `go list -m all`)
- **integration test against live postgres:16 — both pass** (`TestCapturer_Integration`, `TestCapturer_PublicationCoverageFailsLoud`), incl. `-race`
- env-unset skip verified (MySQL CI jobs stay green)

> Note: the integration test needs a live PostgreSQL (`BINTRAIL_TEST_PG_DSN`); CI has no Postgres cell until **#534**, so it ran **locally** against `postgres:16` (wal_level=logical) — stated explicitly rather than letting "CI green" stand in for it.

## #534 watch-items (NOT this slice)

The consumer must (a) call `AckCommitted` with the `EventCommit` commit LSN only after `saveCheckpoint` succeeds, (b) resume from that same LSN semantic, and (c) be **idempotent** — resume is at-least-once (PG re-delivers `(confirmed_flush, X]`), so PG-origin events need a dedup key analogous to the MySQL `event_id` path, or the indexer must tolerate re-insert.

Part of #530. Next: #534 (consumer/pgstreamrun + `normalizeFlavor`), #531 (RI-FULL validator + PK-aware recovery), #533 (type-faithful rendering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)