### PR TITLE
review follow-up: PG14-safe PK ordering + monotonic ack + comment fix (#530)

### DIFF
--- a/internal/pgcapture/capturer.go
+++ b/internal/pgcapture/capturer.go
@@ -81,7 +81,22 @@ func New(cfg Config) *Capturer {
 // persisting would let PostgreSQL drop WAL the index never recorded, unrecoverable).
 // The consumer (#534) must call this with the EventCommit commit LSN, only after its
 // saveCheckpoint succeeds. Safe to call concurrently with Run.
-func (c *Capturer) AckCommitted(lsn uint64) { c.lastAcked.Store(lsn) }
+func (c *Capturer) AckCommitted(lsn uint64) {
+	// Advance-only: lastAcked is durable progress, which is monotonic, so a stale or
+	// out-of-order ack (a consumer retry/ordering race) must not regress it — that
+	// would make the next standby update report a lower confirmed_flush_lsn. (Not a
+	// data-loss guard — PostgreSQL clamps a lower client LSN forward and re-delivers;
+	// this keeps the reported cursor monotonic by construction.)
+	for {
+		old := c.lastAcked.Load()
+		if lsn <= old {
+			return
+		}
+		if c.lastAcked.CompareAndSwap(old, lsn) {
+			return
+		}
+	}
+}
 
 // Run opens the replication + query connections, validates the publication, ensures
 // the slot, starts replication, and emits event.Event on out until ctx is cancelled.
@@ -255,10 +270,13 @@ func (c *Capturer) sendStandby(replConn *pgconn.PgConn) error {
 }
 
 // deriveStandbyInterval reads the server's wal_sender_timeout (milliseconds; 0 =
-// disabled) and returns a third of it (the cadence the walsender itself uses),
-// floored at 1s. It falls back to defaultStandbyInterval on any error or when the
-// timeout is disabled. This avoids baking in the 60s default — an operator who set a
-// shorter wal_sender_timeout would otherwise see the connection dropped.
+// disabled) and returns a third of it — so a quiet stream refreshes the server's
+// liveness timer ~3x per timeout window, comfortably under the drop threshold —
+// floored at 1s. (The walsender's own keepalive cadence is timeout/2; a third is
+// the deliberately more conservative client side.) It falls back to
+// defaultStandbyInterval on any error or when the timeout is disabled. This avoids
+// baking in the 60s default — an operator who set a shorter wal_sender_timeout would
+// otherwise see the connection dropped.
 func (c *Capturer) deriveStandbyInterval(ctx context.Context, queryConn *pgx.Conn) time.Duration {
 	var ms int
 	err := queryConn.QueryRow(ctx, `SELECT setting::int FROM pg_settings WHERE name = 'wal_sender_timeout'`).Scan(&ms)

--- a/internal/pgcapture/capturer_internal_test.go
+++ b/internal/pgcapture/capturer_internal_test.go
@@ -1,0 +1,34 @@
+package pgcapture
+
+import "testing"
+
+// TestAckCommitted_AdvanceOnly pins the monotonicity of lastAcked: a stale or
+// out-of-order ack must never regress the durable cursor (which would make the next
+// standby update report a lower confirmed_flush_lsn). Internal test — it reads the
+// unexported lastAcked directly; no live PostgreSQL needed.
+func TestAckCommitted_AdvanceOnly(t *testing.T) {
+	c := New(Config{}) // New opens no connections; lastAcked starts at 0
+	if got := c.lastAcked.Load(); got != 0 {
+		t.Fatalf("fresh Capturer: lastAcked=%d, want 0", got)
+	}
+
+	c.AckCommitted(100)
+	if got := c.lastAcked.Load(); got != 100 {
+		t.Fatalf("after Ack(100): lastAcked=%d, want 100", got)
+	}
+
+	c.AckCommitted(50) // stale / regressing — must be ignored
+	if got := c.lastAcked.Load(); got != 100 {
+		t.Errorf("after stale Ack(50): lastAcked=%d, want 100 (advance-only)", got)
+	}
+
+	c.AckCommitted(100) // equal — no-op
+	if got := c.lastAcked.Load(); got != 100 {
+		t.Errorf("after equal Ack(100): lastAcked=%d, want 100", got)
+	}
+
+	c.AckCommitted(150) // advances
+	if got := c.lastAcked.Load(); got != 150 {
+		t.Errorf("after Ack(150): lastAcked=%d, want 150", got)
+	}
+}

--- a/internal/pgcapture/relation.go
+++ b/internal/pgcapture/relation.go
@@ -53,11 +53,17 @@ type PKResolver func(relationID uint32, schema, table string) ([]metadata.Column
 
 // pkColumnsQuery returns a relation's primary-key column names in key order, given
 // the relation's OID (which equals the pgoutput RelationMessage RelationID).
+//
+// i.indkey is an int2vector; it is cast to int2[] before array_position because
+// array_position is declared over anyarray/anyelement and int2vector is a distinct
+// internal type whose implicit coercion to int2[] is not guaranteed across the
+// supported version range (PG14+). The explicit cast removes that version-dependence
+// — without it the ordering query could error on a floor-version server.
 const pkColumnsQuery = `SELECT a.attname
 FROM pg_index i
 JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
 WHERE i.indrelid = $1 AND i.indisprimary
-ORDER BY array_position(i.indkey, a.attnum)`
+ORDER BY array_position(i.indkey::int2[], a.attnum)`
 
 // queryPK is the catalog-backed PKResolver body: it looks up a relation's primary-
 // key columns by OID on a regular (non-replication) connection. The capturer wires


### PR DESCRIPTION
## What

Follow-up to the **post-merge comprehensive review of #530 slice 2** (#546). The slice-2 review ran all five toolkit dimensions; code + silent-failure (pre-merge) found no blockers, and the test/type/comment audits (post-merge) surfaced three small actionable items — fixed here. The rest were CI-gated test gaps (deferred to #534) or note-only.

## Fixes

1. **`relation.go` — PG14-safe PK ordering cast.** `pkColumnsQuery`'s `ORDER BY array_position(i.indkey, a.attnum)` now casts `i.indkey::int2[]`. `array_position` is declared over `anyarray`/`anyelement`, and `int2vector` is a distinct internal type whose implicit coercion to `int2[]` is not guaranteed across the supported range. It works on PG16 (which `TestCapturer_CompositePKOrder` exercises) but **PG14 is the declared floor**; the explicit cast removes the version-dependence so the composite-PK ordering query can't error on a floor-version server. *(comment-analyzer)*
2. **`capturer.go` `AckCommitted` — advance-only CAS.** A stale/out-of-order ack can no longer regress `lastAcked` (which would make the next standby update report a lower `confirmed_flush_lsn`). Defense-in-depth, not a data-loss fix — PostgreSQL clamps a lower client LSN forward and re-delivers — but it makes the documented monotonicity invariant type-enforced. Adds `TestAckCommitted_AdvanceOnly` (internal, no live PG → runs in CI). *(type-design-analyzer)*
3. **`capturer.go` `deriveStandbyInterval` doc — correct the cadence attribution.** The walsender's own keepalive cadence is `wal_sender_timeout/2`, not `/3`; the `/3` value is the deliberately-more-conservative client interval (~3 refreshes per window). The value was always correct; only the rationale was wrong. *(comment-analyzer)*

## Verification

- `go build` / `vet` / `gofmt -l` — clean
- full unit suite + the new `TestAckCommitted_AdvanceOnly` — green (the CAS test needs no Postgres → runs in CI)
- all three integration tests (incl. `TestCapturer_CompositePKOrder`, which now exercises the `::int2[]` cast) — green against a live `postgres:16`

## Deferred (not this PR)

- **#534** (need a live-PG CI cell + the consumer): resume-from-saved-LSN test, no-PK `queryPK` test, `emit` slow-consumer/ctx-cancel test, `validatePublication` not-exist-branch test.
- **Note-only:** `ReplDSN`'s `replication=database` contract stays documented — parsing the DSN would couple `Config` to libpq format, and the runtime connect failure is already loud.

Part of #530.

🤖 Generated with [Claude Code](https://claude.com/claude-code)