### PR TITLE
feat(pgstreamrun): PostgreSQL streaming consumer — closes #530 (#534 slice 1)

### DIFF
--- a/internal/pgcapture/capturer.go
+++ b/internal/pgcapture/capturer.go
@@ -43,6 +43,11 @@ type Config struct {
 	Publication string
 	Filters     event.Filters
 	StartLSN    pglogrepl.LSN // the resume checkpoint; 0 on first run (see ensureSlot — the gate is slot existence, not this)
+	// ExpectExistingSlot, set by the consumer when resuming from a saved checkpoint,
+	// makes ensureSlot fail loud if the slot is missing or invalidated (wal_status=
+	// 'lost') instead of silently creating a fresh slot that would skip the WAL since
+	// the checkpoint. Leave false on first run. See ensureSlot / #532.
+	ExpectExistingSlot bool
 	// StandbyInterval is how often a standby status update is sent (server liveness +
 	// confirmed_flush_lsn feedback). 0 derives it from the server's wal_sender_timeout
 	// (timeout/3, floor 1s), falling back to defaultStandbyInterval. Tests set it low.
@@ -129,7 +134,7 @@ func (c *Capturer) Run(ctx context.Context, out chan<- event.Event) error {
 		return err
 	}
 
-	startLSN, err := ensureSlot(startupCtx, replConn, queryConn, c.cfg.SlotName, c.cfg.StartLSN)
+	startLSN, err := ensureSlot(startupCtx, replConn, queryConn, c.cfg.SlotName, c.cfg.StartLSN, c.cfg.ExpectExistingSlot)
 	if err != nil {
 		return err
 	}

--- a/internal/pgcapture/capturer_integration_test.go
+++ b/internal/pgcapture/capturer_integration_test.go
@@ -224,6 +224,53 @@ func TestCapturer_PublicationCoverageFailsLoud(t *testing.T) {
 	}
 }
 
+// TestCapturer_ResumeMissingSlotFailsLoud proves the resume guard (#534): when the
+// consumer resumes from a saved checkpoint (ExpectExistingSlot) but the slot is gone
+// (here: never created), Run fails loud rather than silently creating a fresh slot
+// from a new ConsistentPoint — which would skip the WAL since the checkpoint.
+func TestCapturer_ResumeMissingSlotFailsLoud(t *testing.T) {
+	baseDSN := testutil.SkipIfNoPostgres(t)
+	ctx := context.Background()
+	const pub = "bintrail_pgcap_resume_pub"
+	const tbl = "pgcap_resume_t"
+
+	setup, err := pgx.Connect(ctx, baseDSN)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { setup.Close(context.Background()) })
+	cleanup := func() {
+		bg := context.Background()
+		_, _ = setup.Exec(bg, "DROP PUBLICATION IF EXISTS "+pub)
+		_, _ = setup.Exec(bg, "DROP TABLE IF EXISTS "+tbl)
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	if _, err := setup.Exec(ctx, fmt.Sprintf("CREATE TABLE %s (id int PRIMARY KEY)", tbl)); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	if _, err := setup.Exec(ctx, fmt.Sprintf("CREATE PUBLICATION %s FOR TABLE %s", pub, tbl)); err != nil {
+		t.Fatalf("create publication: %v", err)
+	}
+
+	cap := pgcapture.New(pgcapture.Config{
+		ReplDSN:            replDSN(baseDSN),
+		QueryDSN:           baseDSN,
+		SlotName:           "bintrail_pgcap_resume_absent_slot", // never created
+		Publication:        pub,
+		StartLSN:           0x1000, // a non-zero saved checkpoint
+		ExpectExistingSlot: true,   // resuming
+	})
+	err = cap.Run(ctx, make(chan event.Event, 1))
+	if err == nil {
+		t.Fatal("expected Run to fail loud when resuming but the slot is gone")
+	}
+	if !strings.Contains(err.Error(), "no longer exists") {
+		t.Errorf("unexpected error (want missing-slot resume failure): %v", err)
+	}
+}
+
 // TestCapturer_CompositePKOrder proves PKValues uses primary-key declaration order,
 // not column/attnum order. The table's columns are (a, b, c) but its PRIMARY KEY is
 // (b, a) — so a naive attnum ordering would yield "10|20" where the correct key

--- a/internal/pgcapture/slot.go
+++ b/internal/pgcapture/slot.go
@@ -2,6 +2,7 @@ package pgcapture
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"sort"
@@ -82,19 +83,46 @@ func validatePublication(ctx context.Context, conn *pgx.Conn, pubname string, fi
 // The slot is permanent (Temporary defaults false) so it survives restarts — required
 // for resume. The flip side is source-side WAL retention if the consumer stalls
 // (the PG analog of binlog retention); WAL-retention monitoring is #532.
-func ensureSlot(ctx context.Context, replConn *pgconn.PgConn, queryConn *pgx.Conn, slotName string, savedLSN pglogrepl.LSN) (pglogrepl.LSN, error) {
-	var exists bool
-	if err := queryConn.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM pg_replication_slots WHERE slot_name = $1)`, slotName).Scan(&exists); err != nil {
+//
+// expectExisting is set by the consumer when it is resuming from a saved checkpoint
+// (#534). In that case the slot MUST still exist and be valid: if it was dropped, or
+// invalidated by max_slot_wal_keep_size (wal_status='lost' — the PG13+ feature the
+// version floor is chosen to bound), the WAL since the checkpoint is gone, and
+// silently creating a fresh slot from a new ConsistentPoint would SKIP that data.
+// ensureSlot fails loud in that case rather than skip; the recovery policy
+// (re-baseline) is #532.
+func ensureSlot(ctx context.Context, replConn *pgconn.PgConn, queryConn *pgx.Conn, slotName string, savedLSN pglogrepl.LSN, expectExisting bool) (pglogrepl.LSN, error) {
+	var walStatus sql.NullString
+	found := true
+	err := queryConn.QueryRow(ctx, `SELECT wal_status FROM pg_replication_slots WHERE slot_name = $1`, slotName).Scan(&walStatus)
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		found = false
+	case err != nil:
 		return 0, fmt.Errorf("pgcapture: checking replication slot %q: %w", slotName, err)
 	}
-	if exists {
+
+	// A 'lost' slot is unusable regardless of mode — its WAL has been removed.
+	if found && walStatus.String == "lost" {
+		return 0, fmt.Errorf("pgcapture: replication slot %q is invalidated (wal_status=lost; max_slot_wal_keep_size exceeded) — the WAL it needs is gone; re-baseline rather than resume", slotName)
+	}
+
+	if expectExisting {
+		if !found {
+			return 0, fmt.Errorf("pgcapture: resuming from a saved checkpoint but replication slot %q no longer exists — the WAL since the checkpoint is lost; re-baseline (creating a fresh slot would silently skip data)", slotName)
+		}
+		return savedLSN, nil
+	}
+	if found {
+		// First run but the slot already exists (a prior run created it, or a TOCTOU).
+		// Resume from it; PostgreSQL clamps savedLSN forward to the slot's own point.
 		return savedLSN, nil
 	}
 
 	res, err := pglogrepl.CreateReplicationSlot(ctx, replConn, slotName, "pgoutput", pglogrepl.CreateReplicationSlotOptions{Mode: pglogrepl.LogicalReplication})
 	if err != nil {
-		// TOCTOU: another capturer or a restart created the slot between the EXISTS
-		// check and now (SQLSTATE 42710 = duplicate_object). Treat as a resume.
+		// TOCTOU: another capturer or a restart created the slot between the check
+		// and now (SQLSTATE 42710 = duplicate_object). Treat as a resume.
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.SQLState() == "42710" {
 			return savedLSN, nil

--- a/internal/pgstreamrun/pgstreamrun.go
+++ b/internal/pgstreamrun/pgstreamrun.go
@@ -122,11 +122,27 @@ func One(ctx context.Context, cfg Config) error {
 	})
 	idx := indexer.New(indexDB, cfg.BatchSize)
 
+	// Bridge loop-exit and capturer-exit (mirrors streamrun.One). The capturer's
+	// Run does NOT close the events channel (its contract), so the wrapper goroutine
+	// closes it when Run returns: a capturer that dies on its own (slot lost
+	// mid-stream, decode desync, network drop) then makes streamLoopPG drain the
+	// remaining events and exit on the close, where One reads the real error and
+	// returns it for the supervisor to reconnect — instead of hanging forever on a
+	// never-closed channel under a never-cancelled parent ctx. The explicit cancel()
+	// after the loop covers the other direction: if streamLoopPG returns first, it
+	// unblocks the capturer's emit/receive so it can return.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	events := make(chan event.Event, defaultEventBuffer)
 	captureErr := make(chan error, 1)
-	go func() { captureErr <- cap.Run(ctx, events) }()
+	go func() {
+		defer close(events)
+		captureErr <- cap.Run(ctx, events)
+	}()
 
 	loopErr := streamLoopPG(ctx, events, idx, indexDB, cap, checkpointInterval, state, logger)
+	cancel() // loop exited first → unblock the capturer's emit/receive so it returns
 
 	// Run returns nil on ctx-cancel; only a real capture error matters.
 	capErr := <-captureErr
@@ -172,6 +188,11 @@ func streamLoopPG(
 		}
 		n, err := idx.InsertBatch(batch)
 		state.eventsIndexed += n
+		// Discard the batch unconditionally: InsertBatch is a single atomic INSERT
+		// (0 rows on error), and every flush-error path here is fatal — the loop
+		// aborts and PostgreSQL re-streams the whole tail from the unadvanced
+		// checkpoint. If a future change ever retries or continues past a flush
+		// error, this clear must move into the success branch or those rows are lost.
 		batch = batch[:0]
 		return err
 	}

--- a/internal/pgstreamrun/pgstreamrun.go
+++ b/internal/pgstreamrun/pgstreamrun.go
@@ -1,0 +1,312 @@
+// Package pgstreamrun is the PostgreSQL streaming CONSUMER: it drives the
+// internal/pgcapture capturer (the producer) into the shared indexer, persisting a
+// durable LSN checkpoint to stream_state. It is the PostgreSQL analog of
+// internal/streamrun, deliberately a SEPARATE package — the go-mysql GTID/position
+// types and binlog gap detection in streamrun do not parameterize. It reuses the
+// source-agnostic core: event.Event, indexer.Indexer, and the batch→flush→checkpoint
+// loop shape.
+//
+// #534 (the consumer); closes #530's end-to-end acceptance (a live PG change stream
+// indexed into binlog_events via the existing indexer).
+package pgstreamrun
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pglogrepl"
+
+	"github.com/dbtrail/dbtrail/internal/cliutil"
+	"github.com/dbtrail/dbtrail/internal/config"
+	"github.com/dbtrail/dbtrail/internal/event"
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/pgcapture"
+)
+
+// pgFlavor is the stream_state.flavor value for a PostgreSQL source. The checkpoint
+// rides the existing gtid-mode columns (the cursor is a single monotonic LSN, like a
+// GTID set, advanced only at commit boundaries) — mode='gtid' needs no shared-schema
+// change; flavor='postgres' is what actually distinguishes a PG checkpoint.
+const pgFlavor = "postgres"
+
+// defaultEventBuffer is the size of the channel between the capturer and the loop.
+const defaultEventBuffer = 1000
+
+// Config binds everything One needs.
+type Config struct {
+	IndexDSN    string // the index MySQL database (same store as a MySQL source)
+	ReplDSN     string // PostgreSQL replication connection (must carry replication=database)
+	QueryDSN    string // PostgreSQL normal connection (catalog PK lookup + slot/publication checks)
+	SlotName    string
+	Publication string
+	ServerID    uint32 // identifier recorded in stream_state (server_id is NOT NULL)
+	StartLSN    uint64 // explicit start LSN; ignored once a checkpoint exists; 0 = let the slot's ConsistentPoint decide on first run
+	Schemas     string // comma-separated schema filter (empty = all)
+	Tables      string // comma-separated table filter (empty = all)
+	BatchSize   int
+	Partitions  int           // binlog_events partitions for the one-time bootstrap (0 → 48)
+	Checkpoint  time.Duration // checkpoint interval (0 → 5s)
+	Logger      *slog.Logger
+}
+
+// pgStreamState mirrors the streamrun checkpoint row, scoped to what a PG source
+// needs. The live cursor (last committed LSN) is tracked in the loop, NOT here — this
+// holds the loaded resume point and the running counters.
+type pgStreamState struct {
+	lsn           uint64 // resume LSN (loaded from the checkpoint; 0 on first run)
+	eventsIndexed int64
+	lastEventTime sql.NullTime
+	serverID      uint32
+}
+
+// One runs a complete PostgreSQL replication stream until ctx is cancelled. It
+// returns nil on graceful shutdown and a non-nil error on a fatal failure (so a
+// supervisor reconnects).
+func One(ctx context.Context, cfg Config) error {
+	if cfg.IndexDSN == "" || cfg.ReplDSN == "" || cfg.QueryDSN == "" || cfg.SlotName == "" || cfg.Publication == "" {
+		return fmt.Errorf("pgstreamrun: One requires IndexDSN, ReplDSN, QueryDSN, SlotName, and Publication")
+	}
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	partitions := cfg.Partitions
+	if partitions <= 0 {
+		partitions = 48
+	}
+	checkpointInterval := cfg.Checkpoint
+	if checkpointInterval <= 0 {
+		checkpointInterval = 5 * time.Second
+	}
+
+	indexDB, err := config.Connect(cfg.IndexDSN)
+	if err != nil {
+		return fmt.Errorf("pgstreamrun: connect index database: %w", err)
+	}
+	defer indexDB.Close()
+
+	// Bootstrap (idempotent) then migrate: CreateIndexTables handles a fresh index DB
+	// (EnsureSchema alone fails on one), EnsureSchema adds any columns on an existing
+	// one.
+	if err := indexer.CreateIndexTables(ctx, indexDB, partitions, false, nil); err != nil {
+		return fmt.Errorf("pgstreamrun: bootstrap index schema: %w", err)
+	}
+	if err := indexer.EnsureSchema(indexDB); err != nil {
+		return fmt.Errorf("pgstreamrun: migrate index schema: %w", err)
+	}
+
+	saved, err := loadStreamStatePG(indexDB)
+	if err != nil {
+		return err
+	}
+	startLSN := resolveStartLSN(saved, cfg.StartLSN, logger)
+
+	state := &pgStreamState{lsn: startLSN, serverID: cfg.ServerID}
+	if saved != nil {
+		state.eventsIndexed = saved.eventsIndexed
+	}
+
+	cap := pgcapture.New(pgcapture.Config{
+		ReplDSN:            cfg.ReplDSN,
+		QueryDSN:           cfg.QueryDSN,
+		SlotName:           cfg.SlotName,
+		Publication:        cfg.Publication,
+		Filters:            cliutil.BuildIndexFilters(cfg.Schemas, cfg.Tables),
+		StartLSN:           pglogrepl.LSN(startLSN),
+		ExpectExistingSlot: saved != nil, // resuming → the slot must still exist + be valid
+		Logger:             logger,
+	})
+	idx := indexer.New(indexDB, cfg.BatchSize)
+
+	events := make(chan event.Event, defaultEventBuffer)
+	captureErr := make(chan error, 1)
+	go func() { captureErr <- cap.Run(ctx, events) }()
+
+	loopErr := streamLoopPG(ctx, events, idx, indexDB, cap, checkpointInterval, state, logger)
+
+	// Run returns nil on ctx-cancel; only a real capture error matters.
+	capErr := <-captureErr
+	if loopErr != nil {
+		return loopErr
+	}
+	if capErr != nil && !errors.Is(capErr, context.Canceled) {
+		return capErr
+	}
+	logger.Info("pgstreamrun: stopped", "events_indexed", state.eventsIndexed,
+		"last_lsn", pglogrepl.LSN(state.lsn))
+	return nil
+}
+
+// streamLoopPG batches row events into the indexer and checkpoints the durable LSN.
+//
+// The checkpoint cursor is the last COMPLETE transaction's commit LSN (lastCommitLSN)
+// and nothing else — never a per-row LSN. A batch-full or ticker flush can land rows
+// of an in-flight transaction, but the checkpoint stays at the last commit, so a
+// crash resumes at a transaction boundary and PostgreSQL re-delivers the in-flight
+// tail (at-least-once). This is the #491 invariant. The order at every checkpoint is
+// flush → saveCheckpointPG → AckCommitted: PostgreSQL WAL is released only after the
+// rows are durably indexed AND the checkpoint is durably persisted.
+func streamLoopPG(
+	ctx context.Context,
+	events <-chan event.Event,
+	idx *indexer.Indexer,
+	indexDB *sql.DB,
+	cap *pgcapture.Capturer,
+	checkpointInterval time.Duration,
+	state *pgStreamState,
+	logger *slog.Logger,
+) error {
+	batch := make([]event.Event, 0, idx.BatchSize())
+	ticker := time.NewTicker(checkpointInterval)
+	defer ticker.Stop()
+
+	var lastCommitLSN uint64
+
+	flush := func() error {
+		if len(batch) == 0 {
+			return nil
+		}
+		n, err := idx.InsertBatch(batch)
+		state.eventsIndexed += n
+		batch = batch[:0]
+		return err
+	}
+
+	checkpoint := func() error {
+		if err := flush(); err != nil {
+			return err
+		}
+		if lastCommitLSN == 0 {
+			return nil // nothing committed yet — nothing durable to checkpoint
+		}
+		if err := saveCheckpointPG(indexDB, state, lastCommitLSN); err != nil {
+			return err
+		}
+		// Only now is it safe to let PostgreSQL release WAL up to lastCommitLSN.
+		cap.AckCommitted(lastCommitLSN)
+		state.lsn = lastCommitLSN
+		return nil
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			if err := checkpoint(); err != nil {
+				logger.Warn("pgstreamrun: final checkpoint failed on shutdown", "error", err)
+			}
+			return nil
+
+		case <-ticker.C:
+			if err := checkpoint(); err != nil {
+				return err
+			}
+
+		case ev, ok := <-events:
+			if !ok {
+				if err := checkpoint(); err != nil {
+					logger.Warn("pgstreamrun: final checkpoint failed", "error", err)
+				}
+				return nil
+			}
+			if !ev.Timestamp.IsZero() {
+				state.lastEventTime = sql.NullTime{Time: ev.Timestamp, Valid: true}
+			}
+			switch ev.EventType {
+			case event.EventCommit:
+				// The boundary: record the commit LSN; its rows are already in the
+				// batch (pgoutput delivers them before the commit).
+				lastCommitLSN = ev.EndPos
+			case event.EventDDL:
+				if err := flush(); err != nil {
+					return err
+				}
+				lastCommitLSN = ev.EndPos
+			case event.EventGTID:
+				// PostgreSQL does not emit a leading GTID marker; ignore defensively.
+			default:
+				batch = append(batch, ev)
+				if len(batch) >= idx.BatchSize() {
+					if err := flush(); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+}
+
+// loadStreamStatePG loads the single-row checkpoint (id=1) for a PostgreSQL source.
+// It returns nil on first run (no row). If a row exists but is NOT a PostgreSQL
+// checkpoint, it fails loud rather than misread/clobber a MySQL/MariaDB checkpoint
+// (stream_state is single-row; an index DB serves one source).
+func loadStreamStatePG(db *sql.DB) (*pgStreamState, error) {
+	var (
+		flavor        string
+		lsn           uint64
+		eventsIndexed int64
+		serverID      uint32
+		lastEventTime sql.NullTime
+	)
+	err := db.QueryRow(`SELECT flavor, binlog_position, events_indexed, server_id, last_event_time
+		FROM stream_state WHERE id = 1`).Scan(&flavor, &lsn, &eventsIndexed, &serverID, &lastEventTime)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("pgstreamrun: load checkpoint: %w", err)
+	}
+	if flavor != pgFlavor {
+		return nil, fmt.Errorf("pgstreamrun: index database holds a %q checkpoint, not %q — refusing to stream a PostgreSQL source into a non-PostgreSQL index", flavor, pgFlavor)
+	}
+	return &pgStreamState{lsn: lsn, eventsIndexed: eventsIndexed, serverID: serverID, lastEventTime: lastEventTime}, nil
+}
+
+// saveCheckpointPG persists the durable cursor (commitLSN — the last complete
+// transaction) and the running counters. mode='gtid'/flavor='postgres': the LSN
+// rides binlog_position (uint64) and binlog_file/gtid_set (the "X/Y" string).
+func saveCheckpointPG(db *sql.DB, state *pgStreamState, commitLSN uint64) error {
+	lsnStr := pglogrepl.LSN(commitLSN).String()
+	var lastEventTime any
+	if state.lastEventTime.Valid {
+		lastEventTime = state.lastEventTime.Time
+	}
+	_, err := db.Exec(`
+		INSERT INTO stream_state
+			(id, mode, binlog_file, binlog_position, gtid_set, flavor,
+			 events_indexed, last_event_time, last_checkpoint, server_id)
+		VALUES (1, 'gtid', ?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(), ?)
+		ON DUPLICATE KEY UPDATE
+			binlog_file     = VALUES(binlog_file),
+			binlog_position = VALUES(binlog_position),
+			gtid_set        = VALUES(gtid_set),
+			flavor          = VALUES(flavor),
+			events_indexed  = VALUES(events_indexed),
+			last_event_time = VALUES(last_event_time),
+			last_checkpoint = UTC_TIMESTAMP(),
+			server_id       = VALUES(server_id)`,
+		lsnStr, commitLSN, lsnStr, pgFlavor, state.eventsIndexed, lastEventTime, state.serverID)
+	if err != nil {
+		return fmt.Errorf("pgstreamrun: save checkpoint at %s: %w", lsnStr, err)
+	}
+	return nil
+}
+
+// resolveStartLSN picks the start LSN: a saved checkpoint wins (idempotent resume);
+// otherwise the explicit Config.StartLSN; otherwise 0 — on first run 0 is correct,
+// the capturer creates the slot and starts from its ConsistentPoint.
+func resolveStartLSN(saved *pgStreamState, flagLSN uint64, logger *slog.Logger) uint64 {
+	if saved != nil {
+		logger.Info("pgstreamrun: resuming from checkpoint", "lsn", pglogrepl.LSN(saved.lsn))
+		return saved.lsn
+	}
+	if flagLSN != 0 {
+		logger.Info("pgstreamrun: starting from configured LSN", "lsn", pglogrepl.LSN(flagLSN))
+		return flagLSN
+	}
+	logger.Info("pgstreamrun: first run — starting from the slot's consistent point")
+	return 0
+}

--- a/internal/pgstreamrun/pgstreamrun_integration_test.go
+++ b/internal/pgstreamrun/pgstreamrun_integration_test.go
@@ -1,0 +1,180 @@
+//go:build integration
+
+package pgstreamrun_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/dbtrail/dbtrail/internal/event"
+	"github.com/dbtrail/dbtrail/internal/pgstreamrun"
+	"github.com/dbtrail/dbtrail/internal/query"
+	"github.com/dbtrail/dbtrail/internal/recovery"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestOne_EndToEnd_PostgresToIndexToRecovery is the permanent form of the capture
+// spike's Part C: a live PostgreSQL change stream flows through pgstreamrun.One into
+// the real MySQL index (binlog_events), is read back by the query engine, and
+// produces reversal SQL — with an out-of-line TOAST value round-tripping all the way.
+// This is what closes #530's end-to-end acceptance.
+//
+// Needs BOTH a live MySQL index (BINTRAIL_TEST_DSN, the CI default) and a live
+// PostgreSQL source (BINTRAIL_TEST_PG_DSN; not set on the MySQL CI jobs → skips).
+func TestOne_EndToEnd_PostgresToIndexToRecovery(t *testing.T) {
+	pgDSN := testutil.SkipIfNoPostgres(t)
+	testutil.SkipIfNoMySQL(t)
+	ctx := context.Background()
+
+	indexDB, dbName := testutil.CreateTestDB(t)
+	indexDSN := testutil.BaseDSN() + "/" + dbName
+
+	const slot = "bintrail_pgsr_it"
+	const pub = "bintrail_pgsr_it_pub"
+	const tbl = "pgsr_it_t"
+	const bigSize = 6000
+
+	pg, err := pgx.Connect(ctx, pgDSN)
+	if err != nil {
+		t.Fatalf("connect PG: %v", err)
+	}
+	t.Cleanup(func() { pg.Close(context.Background()) })
+
+	dropAll := func() {
+		bg := context.Background()
+		_, _ = pg.Exec(bg, "DROP PUBLICATION IF EXISTS "+pub)
+		_, _ = pg.Exec(bg, "DROP TABLE IF EXISTS "+tbl)
+		_, _ = pg.Exec(bg, "SELECT pg_drop_replication_slot($1) WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name=$1)", slot)
+	}
+	dropAll()
+	t.Cleanup(dropAll)
+
+	mustExec := func(sql string, args ...any) {
+		t.Helper()
+		if _, err := pg.Exec(ctx, sql, args...); err != nil {
+			t.Fatalf("exec %q: %v", sql, err)
+		}
+	}
+	mustExec(fmt.Sprintf("CREATE TABLE %s (id int PRIMARY KEY, small_col text, big_col text)", tbl))
+	mustExec(fmt.Sprintf("ALTER TABLE %s ALTER COLUMN big_col SET STORAGE EXTERNAL", tbl))
+	mustExec(fmt.Sprintf("ALTER TABLE %s REPLICA IDENTITY FULL", tbl))
+	mustExec(fmt.Sprintf("CREATE PUBLICATION %s FOR TABLE %s", pub, tbl))
+
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	cfg := pgstreamrun.Config{
+		IndexDSN:    indexDSN,
+		ReplDSN:     replDSN(pgDSN),
+		QueryDSN:    pgDSN,
+		SlotName:    slot,
+		Publication: pub,
+		ServerID:    42,
+		Tables:      "public." + tbl,
+		BatchSize:   100,
+		Checkpoint:  200 * time.Millisecond,
+	}
+	runErr := make(chan error, 1)
+	go func() { runErr <- pgstreamrun.One(runCtx, cfg) }()
+
+	// Wait until the consumer's capturer has the slot active, then do DML so every
+	// change is captured.
+	waitFor(t, 15*time.Second, func() bool {
+		var active bool
+		if err := pg.QueryRow(ctx, "SELECT active FROM pg_replication_slots WHERE slot_name=$1", slot).Scan(&active); err != nil {
+			return false
+		}
+		return active
+	}, "replication slot active")
+
+	bigVal := strings.Repeat("X", bigSize)
+	mustExec(fmt.Sprintf("INSERT INTO %s VALUES (1, 'orig', $1)", tbl), bigVal)
+	mustExec(fmt.Sprintf("UPDATE %s SET small_col='changed' WHERE id=1", tbl)) // big_col untouched
+
+	// Wait until both row events are indexed (flushed on the 200ms ticker).
+	waitFor(t, 15*time.Second, func() bool {
+		var n int
+		if err := indexDB.QueryRow("SELECT COUNT(*) FROM binlog_events WHERE table_name = ?", tbl).Scan(&n); err != nil {
+			return false
+		}
+		return n >= 2
+	}, "INSERT+UPDATE indexed into binlog_events")
+
+	cancel()
+	if err := <-runErr; err != nil {
+		t.Fatalf("One returned error: %v", err)
+	}
+
+	// Read back through the real query engine.
+	rows, err := query.New(indexDB).Fetch(ctx, query.Options{Schema: "public", Table: tbl, Order: "ASC"})
+	if err != nil {
+		t.Fatalf("query Fetch: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("indexed %d events, want 2 (INSERT + UPDATE)", len(rows))
+	}
+
+	var upd *query.ResultRow
+	for i := range rows {
+		if rows[i].EventType == event.EventUpdate {
+			upd = &rows[i]
+		}
+	}
+	if upd == nil {
+		t.Fatal("no UPDATE event read back from the index")
+	}
+	// The #530 headline: the out-of-line TOAST value round-trips into the index.
+	if got := upd.RowBefore["big_col"]; got != bigVal {
+		t.Errorf("UPDATE RowBefore[big_col] is %d bytes (%T), want the real %d-byte value", lenOf(got), got, bigSize)
+	}
+	// Option B: the after-image carries the real (unchanged) value, not a sentinel.
+	if got := upd.RowAfter["big_col"]; got != bigVal {
+		t.Errorf("UPDATE RowAfter[big_col] not resolved to the real value (Option B): %d bytes (%T)", lenOf(got), got)
+	}
+
+	// Recovery SQL: the TOAST value round-trips all the way into reversal SQL.
+	var buf bytes.Buffer
+	n, err := recovery.New(indexDB, nil).GenerateSQLFromRows(rows, &buf)
+	if err != nil {
+		t.Fatalf("GenerateSQLFromRows: %v", err)
+	}
+	if n == 0 {
+		t.Fatal("no reversal statements generated")
+	}
+	if !strings.Contains(buf.String(), bigVal) {
+		t.Error("reversal SQL does not contain the TOAST value — it did not round-trip into recovery")
+	}
+}
+
+// ── helpers ──
+
+func replDSN(base string) string {
+	if strings.Contains(base, "?") {
+		return base + "&replication=database"
+	}
+	return base + "?replication=database"
+}
+
+func waitFor(t *testing.T, timeout time.Duration, cond func() bool, what string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+func lenOf(v any) int {
+	if s, ok := v.(string); ok {
+		return len(s)
+	}
+	return -1
+}

--- a/internal/pgstreamrun/pgstreamrun_integration_test.go
+++ b/internal/pgstreamrun/pgstreamrun_integration_test.go
@@ -151,6 +151,46 @@ func TestOne_EndToEnd_PostgresToIndexToRecovery(t *testing.T) {
 	}
 }
 
+// TestOne_CapturerFailureSurfaces proves the cancellation bridge in One: when the
+// capturer fails on its own (here: a non-existent publication makes cap.Run return
+// before streaming), One must surface that error PROMPTLY rather than hang forever
+// on a never-closed events channel under a never-cancelled parent ctx (the silent
+// hung-stream class). The 15s timeout is the hang detector.
+func TestOne_CapturerFailureSurfaces(t *testing.T) {
+	pgDSN := testutil.SkipIfNoPostgres(t)
+	testutil.SkipIfNoMySQL(t)
+	ctx := context.Background()
+
+	_, dbName := testutil.CreateTestDB(t)
+	indexDSN := testutil.BaseDSN() + "/" + dbName
+
+	cfg := pgstreamrun.Config{
+		IndexDSN:    indexDSN,
+		ReplDSN:     replDSN(pgDSN),
+		QueryDSN:    pgDSN,
+		SlotName:    "bintrail_pgsr_fail_slot",
+		Publication: "bintrail_pgsr_nonexistent_pub", // does not exist → cap.Run fails
+		ServerID:    7,
+		Checkpoint:  200 * time.Millisecond,
+	}
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- pgstreamrun.One(runCtx, cfg) }()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("One returned nil; expected the capturer's publication failure to surface")
+		}
+		if !strings.Contains(err.Error(), "does not exist") {
+			t.Errorf("unexpected error (want publication failure): %v", err)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("One hung — a capturer failure was not surfaced (cancellation bridge missing)")
+	}
+}
+
 // ── helpers ──
 
 func replDSN(base string) string {

--- a/internal/pgstreamrun/pgstreamrun_internal_test.go
+++ b/internal/pgstreamrun/pgstreamrun_internal_test.go
@@ -1,0 +1,24 @@
+package pgstreamrun
+
+import (
+	"log/slog"
+	"testing"
+)
+
+func TestResolveStartLSN(t *testing.T) {
+	log := slog.New(slog.DiscardHandler)
+
+	// A saved checkpoint wins over the flag (idempotent resume).
+	if got := resolveStartLSN(&pgStreamState{lsn: 500}, 999, log); got != 500 {
+		t.Errorf("saved checkpoint: got %d, want 500", got)
+	}
+	// No checkpoint → the explicit flag.
+	if got := resolveStartLSN(nil, 999, log); got != 999 {
+		t.Errorf("flag start: got %d, want 999", got)
+	}
+	// No checkpoint, no flag → 0: first run, the capturer starts from the slot's
+	// ConsistentPoint (this must NOT be an error).
+	if got := resolveStartLSN(nil, 0, log); got != 0 {
+		t.Errorf("first run: got %d, want 0", got)
+	}
+}


### PR DESCRIPTION
## What

The **consumer** that wires the `internal/pgcapture` producer (#530 slices 1+2) into the shared indexer — **closing #530's end-to-end acceptance**: a live PostgreSQL change stream decoded into neutral `event.Event`s and indexed into `binlog_events` via the existing indexer. Validated end-to-end against a live `postgres:16` + MySQL index (the capture spike's Part C, now a permanent test).

This is the first slice of **#534-A** (the `bintrail-pg` binary's streaming core). The binary + goreleaser + Postgres CI matrix are later slices.

## `internal/pgstreamrun` (new)

The PostgreSQL analog of `internal/streamrun`, deliberately a **separate package** (go-mysql's GTID/position types and binlog gap detection don't parameterize). Reuses the source-agnostic core: `event.Event`, `indexer.Indexer`, `cliutil` filters, and the batch→flush→checkpoint loop shape.

- **`One(ctx, Config)`** — connect index DB, bootstrap (`CreateIndexTables` + `EnsureSchema` — EnsureSchema alone fails on a fresh DB), load checkpoint, resolve start LSN, drive `pgcapture.Capturer.Run` → `streamLoopPG`.
- **`streamLoopPG`** — the checkpoint cursor is the last **complete** commit's LSN and **only** that (never a per-row LSN). A batch-full/ticker flush can land an in-flight txn's rows, but the checkpoint stays at the last commit, so a crash resumes at a transaction boundary and PostgreSQL re-delivers the tail (at-least-once). Order at every checkpoint: **flush → saveCheckpointPG → AckCommitted** — WAL is released only after rows are durably indexed AND the checkpoint is persisted (the #491 invariant). *(This corrected a real data-loss bug in the mapping blueprint, which advanced a per-row cursor.)*
- **Checkpoint mapping** — rides the existing `stream_state` columns: `mode='gtid'` (no shared-schema change; the only readers that branch on `mode` are MySQL-gated by `flavor`), `flavor='postgres'`, the LSN in `binlog_position`/`binlog_file`/`gtid_set`.
- **`loadStreamStatePG`** fails loud if the single-row checkpoint is not a `'postgres'` one (won't misread/clobber a MySQL checkpoint). First run (no checkpoint, no flag) → `StartLSN=0`, the capturer creates the slot from its `ConsistentPoint`.

## `internal/pgcapture` — slot-resume guard (advisor + #534)

`Config.ExpectExistingSlot` makes `ensureSlot` **fail loud when resuming** if the slot is missing **OR** invalidated (`wal_status='lost'` — the `max_slot_wal_keep_size` case the PG13+ version floor is chosen to bound), instead of silently creating a fresh slot that would **skip the WAL since the checkpoint** (silent data loss — the exact failure class the product exists to prevent). Recovery policy (re-baseline) is #532; this slice just refuses to skip silently. `+TestCapturer_ResumeMissingSlotFailsLoud`.

## Idempotency

At-least-once, **inherited from the MySQL path** (a crash between flush and checkpoint re-streams and re-inserts with new `event_id`s); exactly-once is the shared **#500**, not new to PG. So the e2e asserts recovered **content**, not a row count across resume.

## Verification

- `go build` / `vet` / `gofmt -l` — clean; full unit suite + `TestResolveStartLSN` — green; `check-notices` — green (no dep-graph change)
- **end-to-end against live postgres:16 + MySQL** (`TestOne_EndToEnd_PostgresToIndexToRecovery`): PG INSERT+UPDATE (out-of-line 6 KB TOAST, untouched by the UPDATE) → `One` → `binlog_events` → `query.Fetch` (UPDATE before+after `big_col` = the real 6 KB value, Option B) → `recovery.GenerateSQLFromRows` (the TOAST value round-trips into reversal SQL). `-race` clean.
- the slot-resume guard test, and `TestCapturer_*` (still green)

> The pgstreamrun/pgcapture integration tests need a live PG, which CI lacks until #534's matrix → they ran **locally** against `postgres:16`; the MySQL CI jobs skip them cleanly (`SkipIfNoPostgres`).

## Deferred (later #534 slices)

`cmd/bintrail-pg` binary + goreleaser + the Postgres CI matrix (PG 14/15/16/17). Then #531 (RI-FULL validator + PK-aware recovery), #533 (type-faithful rendering).

Closes #530. Part of #534.

🤖 Generated with [Claude Code](https://claude.com/claude-code)