### PR TITLE
feat(bintrail-pg): standalone PostgreSQL-source binary (#534)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ BINARY_NAME=bintrail
 MCP_BINARY=bintrail-mcp
 GATEWAY_BINARY=mcp-gateway
 CONSOLE_BINARY=bintrail-console
+PG_BINARY=bintrail-pg
 VERSION=$(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 COMMIT=$(shell git rev-parse --short HEAD 2>/dev/null || echo "none")
 BUILD_DATE=$(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
@@ -9,12 +10,12 @@ BUILD_DATE=$(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
 BINTRAIL_LDFLAGS=-ldflags "-X main.Version=$(VERSION) -X main.CommitSHA=$(COMMIT) -X main.BuildDate=$(BUILD_DATE)"
 MCP_LDFLAGS=-ldflags "-X main.mcpVersion=$(VERSION)"
 GATEWAY_LDFLAGS=-ldflags "-X main.gatewayVersion=$(VERSION)"
-# bintrail-console reuses BINTRAIL_LDFLAGS: it injects the same
-# main.Version/CommitSHA/BuildDate vars as the core binary.
+# bintrail-console and bintrail-pg both reuse BINTRAIL_LDFLAGS: they inject the
+# same main.Version/CommitSHA/BuildDate vars as the core binary.
 
-.PHONY: all build build-mcp build-gateway build-console clean test console-e2e lint install build-all tidy deps notices check-notices
+.PHONY: all build build-mcp build-gateway build-console build-pg clean test console-e2e lint install build-all tidy deps notices check-notices
 
-all: build build-mcp build-gateway build-console
+all: build build-mcp build-gateway build-console build-pg
 
 build:
 	go build $(BINTRAIL_LDFLAGS) -o $(BINARY_NAME) ./cmd/bintrail
@@ -30,14 +31,21 @@ build-gateway:
 build-console:
 	go build $(BINTRAIL_LDFLAGS) -o $(CONSOLE_BINARY) ./cmd/bintrail-console
 
+# bintrail-pg links jackc/pgx + pglogrepl (PostgreSQL capture) plus DuckDB via
+# the shared read plane (query/reconstruct → parquetquery), so it requires
+# CGO_ENABLED=1 like the core bintrail and bintrail-console binaries.
+build-pg:
+	go build $(BINTRAIL_LDFLAGS) -o $(PG_BINARY) ./cmd/bintrail-pg
+
 install:
 	go install $(BINTRAIL_LDFLAGS) ./cmd/bintrail
 	go install $(MCP_LDFLAGS) ./cmd/bintrail-mcp
 	go install $(GATEWAY_LDFLAGS) ./cmd/mcp-gateway
 	go install $(BINTRAIL_LDFLAGS) ./cmd/bintrail-console
+	go install $(BINTRAIL_LDFLAGS) ./cmd/bintrail-pg
 
 clean:
-	rm -f $(BINARY_NAME) $(MCP_BINARY) $(GATEWAY_BINARY) $(CONSOLE_BINARY)
+	rm -f $(BINARY_NAME) $(MCP_BINARY) $(GATEWAY_BINARY) $(CONSOLE_BINARY) $(PG_BINARY)
 	go clean
 
 test:

--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -17,8 +17,8 @@ This file has two parts:
 
   2. A GENERATED section, produced by `make notices` (which runs
      `go-licenses save` over ./cmd/bintrail, ./cmd/bintrail-mcp,
-     ./cmd/bintrail-console and ./cmd/bintrail-pg), reproducing the LICENSE —
-     and, where present, the NOTICE — file of every linked Go module.
+     ./cmd/bintrail-console and ./cmd/bintrail-pg), reproducing the LICENSE
+     — and, where present, the NOTICE — file of every linked Go module.
 
 Regenerate with `make notices`. Do not edit the GENERATED section by hand.
 

--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -2,9 +2,10 @@
 THIRD-PARTY NOTICES
 ================================================================================
 
-bintrail (and the bintrail-mcp and bintrail-console binaries published from this
-repository) statically links a number of third-party Go modules and, through
-the precompiled libduckdb static library, a number of vendored C/C++ libraries.
+bintrail (and the bintrail-mcp, bintrail-console and bintrail-pg binaries
+published from this repository) statically links a number of third-party Go
+modules and, through the precompiled libduckdb static library, a number of
+vendored C/C++ libraries.
 The licenses below are reproduced to satisfy their notice-retention terms.
 
 This file has two parts:
@@ -15,9 +16,9 @@ This file has two parts:
      dependency (go-sql-driver/mysql, MPL-2.0).
 
   2. A GENERATED section, produced by `make notices` (which runs
-     `go-licenses save` over ./cmd/bintrail, ./cmd/bintrail-mcp and
-     ./cmd/bintrail-console), reproducing the LICENSE — and, where present, the
-     NOTICE — file of every linked Go module.
+     `go-licenses save` over ./cmd/bintrail, ./cmd/bintrail-mcp,
+     ./cmd/bintrail-console and ./cmd/bintrail-pg), reproducing the LICENSE —
+     and, where present, the NOTICE — file of every linked Go module.
 
 Regenerate with `make notices`. Do not edit the GENERATED section by hand.
 
@@ -4849,6 +4850,141 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+================================================================================
+github.com/jackc/pgio
+================================================================================
+
+Copyright (c) 2019 Jack Christensen
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+================================================================================
+github.com/jackc/pglogrepl
+================================================================================
+
+Copyright (c) 2019 Jack Christensen
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+================================================================================
+github.com/jackc/pgpassfile
+================================================================================
+
+Copyright (c) 2019 Jack Christensen
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+================================================================================
+github.com/jackc/pgservicefile
+================================================================================
+
+Copyright (c) 2020 Jack Christensen
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+================================================================================
+github.com/jackc/pgx/v5
+================================================================================
+
+Copyright (c) 2013-2021 Jack Christensen
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 github.com/klauspost/compress

--- a/cmd/bintrail-pg/main.go
+++ b/cmd/bintrail-pg/main.go
@@ -1,0 +1,97 @@
+// Command bintrail-pg is the PostgreSQL-source sibling of the core bintrail
+// binary. It captures a live PostgreSQL logical-replication stream into the SAME
+// MySQL index store (the "one index schema for all sources" red line, #527) and
+// serves the identical read plane — status, query, recover, reconstruct, shim —
+// over that index via internal/cli.AddReadCommands.
+//
+// Why a separate binary rather than a subcommand of bintrail: the PostgreSQL
+// capture path links jackc/pgx + pglogrepl, which the core MySQL binary must
+// stay free of (cmd/bintrail/pgfree_test.go enforces this). Splitting the
+// capture plane per source keeps each binary's dependency surface honest while
+// the read plane is shared code. The user wants a distinct `bintrail-pg` as the
+// recognizable artifact for the Postgres-recovery niche (#534).
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dbtrail/dbtrail/internal/cli"
+	"github.com/dbtrail/dbtrail/internal/observe"
+)
+
+var (
+	logLevel  string
+	logFormat string
+)
+
+// Build-time variables injected via -ldflags. These are the SAME names the core
+// bintrail binary uses (main.Version/CommitSHA/BuildDate), so the Makefile's
+// BINTRAIL_LDFLAGS applies to this binary verbatim — exactly as bintrail-console
+// already reuses them.
+var (
+	Version   = "dev"
+	CommitSHA = "none"
+	BuildDate = "unknown"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "bintrail-pg",
+	Short: "PostgreSQL binlog (logical replication) indexer and recovery tool",
+	Long: `bintrail-pg captures a live PostgreSQL logical-replication stream and indexes
+every row change into a MySQL index table with full before/after images, then
+provides the same query and recovery capabilities as the core bintrail binary.
+The index is self-contained — recovery does not depend on the PostgreSQL WAL or
+the replication slot still existing.
+
+Capture requires REPLICA IDENTITY FULL on every replicated table so the
+before-image (and de-TOASTed unchanged values) is present in the WAL. See
+'bintrail-pg stream --help'.`,
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		observe.Setup(os.Stderr, logFormat, logLevel)
+		return nil
+	},
+	SilenceErrors: true, // we handle error output ourselves in main()
+	SilenceUsage:  true, // don't print usage/help on errors — users can use --help
+}
+
+func init() {
+	rootCmd.Version = fmt.Sprintf("%s (commit %s, built %s)", Version, CommitSHA, BuildDate)
+	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "Log level: debug, info, warn, error")
+	rootCmd.PersistentFlags().StringVar(&logFormat, "log-format", "text", "Log format: text or json")
+	// The source-agnostic read plane (status/query/recover/reconstruct/shim),
+	// shared verbatim with the core binary. The PostgreSQL capture command
+	// (stream) is registered in stream.go's init().
+	cli.AddReadCommands(rootCmd)
+}
+
+func main() {
+	err := rootCmd.Execute()
+	if err == nil {
+		return
+	}
+	if wantsJSON(rootCmd) {
+		json.NewEncoder(os.Stderr).Encode(map[string]string{"error": err.Error()})
+	} else {
+		fmt.Fprintln(os.Stderr, err)
+	}
+	os.Exit(1)
+}
+
+// wantsJSON reports whether the active command has a --format flag set to "json"
+// (the read commands do). Mirrors cmd/bintrail/main.go so error output is shaped
+// consistently across both binaries.
+func wantsJSON(root *cobra.Command) bool {
+	cmd, _, _ := root.Find(os.Args[1:])
+	if cmd == nil {
+		return false
+	}
+	f := cmd.Flags().Lookup("format")
+	if f == nil {
+		return false
+	}
+	return f.Value.String() == "json"
+}

--- a/cmd/bintrail-pg/main.go
+++ b/cmd/bintrail-pg/main.go
@@ -74,7 +74,9 @@ func main() {
 		return
 	}
 	if wantsJSON(rootCmd) {
-		json.NewEncoder(os.Stderr).Encode(map[string]string{"error": err.Error()})
+		if encErr := json.NewEncoder(os.Stderr).Encode(map[string]string{"error": err.Error()}); encErr != nil {
+			fmt.Fprintln(os.Stderr, err) // fall back to text so the message is never wholly lost
+		}
 	} else {
 		fmt.Fprintln(os.Stderr, err)
 	}

--- a/cmd/bintrail-pg/stream.go
+++ b/cmd/bintrail-pg/stream.go
@@ -1,0 +1,193 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/jackc/pglogrepl"
+	"github.com/spf13/cobra"
+
+	"github.com/dbtrail/dbtrail/internal/cli"
+	"github.com/dbtrail/dbtrail/internal/pgstreamrun"
+)
+
+var streamCmd = &cobra.Command{
+	Use:   "stream",
+	Short: "Index changes from a live PostgreSQL logical-replication stream",
+	Long: `Connects to a PostgreSQL server over the logical-replication protocol (pgoutput)
+and indexes every row change in real-time into the MySQL binlog_events index.
+
+PostgreSQL requires two connections, which cannot be the same:
+
+  --repl-dsn    a REPLICATION connection (the connection string must include
+                replication=database); used for the WAL stream itself. A
+                replication connection runs in walsender mode and cannot execute
+                ordinary SQL.
+  --query-dsn   an ordinary connection; used for primary-key catalog lookups and
+                slot/publication validation.
+
+Prerequisites on the source (validated at startup, fails loud otherwise):
+  - wal_level = logical
+  - every replicated table at REPLICA IDENTITY FULL (so the WAL carries the full
+    before-image and de-TOASTed unchanged values — without it recovery silently
+    loses columns)
+  - a PUBLICATION covering the tables you want indexed (--publication)
+
+The replication slot (--slot) is created on first run if absent and reused on
+restart. The durable checkpoint is the last committed LSN, persisted to
+stream_state; on restart the stream resumes from it automatically, so re-running
+the same command is idempotent. --start-lsn only takes effect on the very first
+run (before any checkpoint exists); thereafter the checkpoint always wins.
+
+Graceful shutdown: send SIGINT or SIGTERM to flush the current batch and write a
+final checkpoint before exiting.`,
+	RunE: runPGStream,
+}
+
+var (
+	pgIndexDSN    string
+	pgReplDSN     string
+	pgQueryDSN    string
+	pgSlot        string
+	pgPublication string
+	pgServerID    uint32
+	pgStartLSN    string
+	pgSchemas     string
+	pgTables      string
+	pgBatchSize   int
+	pgCheckpoint  int
+	pgPartitions  int
+)
+
+func init() {
+	streamCmd.Flags().StringVar(&pgIndexDSN, "index-dsn", "", "DSN for the index MySQL database (required)")
+	streamCmd.Flags().StringVar(&pgReplDSN, "repl-dsn", "", "PostgreSQL REPLICATION connection string, must include replication=database (required; env BINTRAIL_PG_REPL_DSN)")
+	streamCmd.Flags().StringVar(&pgQueryDSN, "query-dsn", "", "PostgreSQL ordinary connection string for catalog/PK lookups (required; env BINTRAIL_PG_QUERY_DSN)")
+	streamCmd.Flags().StringVar(&pgSlot, "slot", "", "Logical replication slot name; created if absent (required; env BINTRAIL_PG_SLOT)")
+	streamCmd.Flags().StringVar(&pgPublication, "publication", "", "PostgreSQL publication name covering the tables to index (required; env BINTRAIL_PG_PUBLICATION)")
+	streamCmd.Flags().Uint32Var(&pgServerID, "server-id", 0, "Identifier recorded in stream_state (required, must differ from all other sources)")
+	streamCmd.Flags().StringVar(&pgStartLSN, "start-lsn", "", "Explicit start LSN (e.g. 0/1A2B3C4); first run only, ignored once a checkpoint exists (env BINTRAIL_PG_START_LSN)")
+	streamCmd.Flags().StringVar(&pgSchemas, "schemas", "", "Only index changes from these schemas (comma-separated)")
+	streamCmd.Flags().StringVar(&pgTables, "tables", "", "Only index these tables (comma-separated, e.g. public.orders)")
+	streamCmd.Flags().IntVar(&pgBatchSize, "batch-size", 1000, "Events per batch INSERT")
+	streamCmd.Flags().IntVar(&pgCheckpoint, "checkpoint", 5, "Checkpoint interval in seconds")
+	streamCmd.Flags().IntVar(&pgPartitions, "partitions", 48, "binlog_events partitions for the one-time index bootstrap")
+	// index-dsn and server-id live in cli.EnvBindings, so BindCommandEnv both
+	// loads the env file (.bintrail.env) AND sets these flags from
+	// BINTRAIL_INDEX_DSN/BINTRAIL_SERVER_ID — which marks them Changed, so
+	// MarkFlagRequired is satisfied by env too. The PostgreSQL-specific flags
+	// are NOT in EnvBindings; their BINTRAIL_PG_* fallback is applied in
+	// runPGStream (the env file is already loaded by the time RunE runs).
+	_ = streamCmd.MarkFlagRequired("index-dsn")
+	_ = streamCmd.MarkFlagRequired("server-id")
+	cli.BindCommandEnv(streamCmd)
+
+	rootCmd.AddCommand(streamCmd)
+}
+
+// pgStreamConfigFromFlags applies the BINTRAIL_PG_* env fallback, validates the
+// PostgreSQL-specific required settings, parses --start-lsn, and snapshots the
+// pg* package globals into a pgstreamrun.Config. It is the single pure seam
+// (returning an error rather than calling os.Exit) so the wiring is unit-tested
+// without a live PostgreSQL — the analog of cmd/bintrail/stream.go's
+// streamConfigFromFlags, which is pure because BindCommandEnv handles its env.
+func pgStreamConfigFromFlags() (pgstreamrun.Config, error) {
+	// BINTRAIL_PG_* fallback for the flags outside cli.EnvBindings. The env file
+	// was already loaded into os env by cli.BindCommandEnv (envOnce) at init, so
+	// these reads see both the shell environment and .bintrail.env values. A CLI
+	// flag (non-empty) always wins over env.
+	applyEnvFallback(&pgReplDSN, "BINTRAIL_PG_REPL_DSN")
+	applyEnvFallback(&pgQueryDSN, "BINTRAIL_PG_QUERY_DSN")
+	applyEnvFallback(&pgSlot, "BINTRAIL_PG_SLOT")
+	applyEnvFallback(&pgPublication, "BINTRAIL_PG_PUBLICATION")
+	applyEnvFallback(&pgStartLSN, "BINTRAIL_PG_START_LSN")
+
+	// Validate the PG-specific required values here (they cannot use
+	// MarkFlagRequired because that ignores the env-only path above).
+	var missing []string
+	if pgReplDSN == "" {
+		missing = append(missing, "--repl-dsn (or BINTRAIL_PG_REPL_DSN)")
+	}
+	if pgQueryDSN == "" {
+		missing = append(missing, "--query-dsn (or BINTRAIL_PG_QUERY_DSN)")
+	}
+	if pgSlot == "" {
+		missing = append(missing, "--slot (or BINTRAIL_PG_SLOT)")
+	}
+	if pgPublication == "" {
+		missing = append(missing, "--publication (or BINTRAIL_PG_PUBLICATION)")
+	}
+	if len(missing) > 0 {
+		return pgstreamrun.Config{}, fmt.Errorf("missing required PostgreSQL connection settings: %s", strings.Join(missing, ", "))
+	}
+
+	var startLSN uint64
+	if pgStartLSN != "" {
+		lsn, err := pglogrepl.ParseLSN(pgStartLSN)
+		if err != nil {
+			return pgstreamrun.Config{}, fmt.Errorf("invalid --start-lsn %q: %w", pgStartLSN, err)
+		}
+		startLSN = uint64(lsn)
+	}
+
+	return pgstreamrun.Config{
+		IndexDSN:    pgIndexDSN,
+		ReplDSN:     pgReplDSN,
+		QueryDSN:    pgQueryDSN,
+		SlotName:    pgSlot,
+		Publication: pgPublication,
+		ServerID:    pgServerID,
+		StartLSN:    startLSN,
+		Schemas:     pgSchemas,
+		Tables:      pgTables,
+		BatchSize:   pgBatchSize,
+		Partitions:  pgPartitions,
+		Checkpoint:  time.Duration(pgCheckpoint) * time.Second,
+	}, nil
+}
+
+// runPGStream is the `bintrail-pg stream` entrypoint: it owns the PROCESS
+// concerns (signal handling) and delegates the config assembly to
+// pgStreamConfigFromFlags and the streaming to pgstreamrun.One, mirroring
+// cmd/bintrail/stream.go's split for the MySQL path.
+func runPGStream(cmd *cobra.Command, args []string) error {
+	cfg, err := pgStreamConfigFromFlags()
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithCancel(cmd.Context())
+	defer cancel()
+
+	// Graceful shutdown on SIGINT/SIGTERM: cancel the context so pgstreamrun.One
+	// flushes its batch and writes a final checkpoint before returning.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+	go func() {
+		select {
+		case sig := <-sigCh:
+			slog.Info("received signal — shutting down gracefully", "signal", sig.String())
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	return pgstreamrun.One(ctx, cfg)
+}
+
+// applyEnvFallback sets *dst from the named env var when *dst is empty (i.e. the
+// flag was not given on the command line). A CLI-provided value always wins.
+func applyEnvFallback(dst *string, envVar string) {
+	if *dst == "" {
+		if v := os.Getenv(envVar); v != "" {
+			*dst = v
+		}
+	}
+}

--- a/cmd/bintrail-pg/stream.go
+++ b/cmd/bintrail-pg/stream.go
@@ -45,6 +45,12 @@ stream_state; on restart the stream resumes from it automatically, so re-running
 the same command is idempotent. --start-lsn only takes effect on the very first
 run (before any checkpoint exists); thereafter the checkpoint always wins.
 
+Re-seeding: once a checkpoint and slot exist, PostgreSQL resumes from the slot's
+position — --start-lsn cannot rewind to an earlier point (the older WAL may have
+been reclaimed). To force a fresh start, drop the replication slot on the source
+and clear the stream_state checkpoint row (DELETE FROM stream_state WHERE id=1),
+then re-run.
+
 Graceful shutdown: send SIGINT or SIGTERM to flush the current batch and write a
 final checkpoint before exiting.`,
 	RunE: runPGStream,

--- a/cmd/bintrail-pg/stream_test.go
+++ b/cmd/bintrail-pg/stream_test.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pglogrepl"
+)
+
+// resetPGFlags restores the stream command's package-global flag vars to their
+// declared defaults so each subtest starts clean — pgStreamConfigFromFlags
+// writes the env fallback back into the globals, so they must be reset between
+// cases. These subtests mutate shared globals and must NOT run in parallel.
+func resetPGFlags() {
+	pgIndexDSN = ""
+	pgReplDSN = ""
+	pgQueryDSN = ""
+	pgSlot = ""
+	pgPublication = ""
+	pgServerID = 0
+	pgStartLSN = ""
+	pgSchemas = ""
+	pgTables = ""
+	pgBatchSize = 1000
+	pgCheckpoint = 5
+	pgPartitions = 48
+}
+
+// clearPGEnv blanks the BINTRAIL_PG_* vars for the test. t.Setenv to "" reads as
+// unset in applyEnvFallback (which treats empty as absent), so a developer's
+// shell environment cannot leak into these table-driven cases.
+func clearPGEnv(t *testing.T) {
+	t.Helper()
+	for _, v := range []string{
+		"BINTRAIL_PG_REPL_DSN", "BINTRAIL_PG_QUERY_DSN", "BINTRAIL_PG_SLOT",
+		"BINTRAIL_PG_PUBLICATION", "BINTRAIL_PG_START_LSN",
+	} {
+		t.Setenv(v, "")
+	}
+}
+
+func TestPGStreamConfigFromFlags_MissingRequired(t *testing.T) {
+	clearPGEnv(t)
+	resetPGFlags()
+	// index-dsn/server-id are enforced by MarkFlagRequired at the cobra layer,
+	// not here; this seam only validates the PG-specific connection settings.
+
+	_, err := pgStreamConfigFromFlags()
+	if err == nil {
+		t.Fatal("expected an error when all PG connection settings are missing, got nil")
+	}
+	for _, want := range []string{"--repl-dsn", "--query-dsn", "--slot", "--publication"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q should name the missing flag %q", err, want)
+		}
+	}
+}
+
+func TestPGStreamConfigFromFlags_HappyPathFromFlags(t *testing.T) {
+	clearPGEnv(t)
+	resetPGFlags()
+	pgIndexDSN = "user:pass@tcp(localhost:3306)/bintrail_index"
+	pgReplDSN = "postgres://u@localhost/db?replication=database"
+	pgQueryDSN = "postgres://u@localhost/db"
+	pgSlot = "bintrail_slot"
+	pgPublication = "bintrail_pub"
+	pgServerID = 42
+	pgSchemas = "public"
+	pgTables = "public.orders"
+	pgBatchSize = 500
+	pgCheckpoint = 12
+	pgPartitions = 24
+
+	cfg, err := pgStreamConfigFromFlags()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.IndexDSN != pgIndexDSN || cfg.ReplDSN != pgReplDSN || cfg.QueryDSN != pgQueryDSN {
+		t.Errorf("DSN passthrough mismatch: %+v", cfg)
+	}
+	if cfg.SlotName != "bintrail_slot" || cfg.Publication != "bintrail_pub" {
+		t.Errorf("slot/publication mismatch: %+v", cfg)
+	}
+	if cfg.ServerID != 42 || cfg.Schemas != "public" || cfg.Tables != "public.orders" {
+		t.Errorf("filter/server-id mismatch: %+v", cfg)
+	}
+	if cfg.BatchSize != 500 || cfg.Partitions != 24 {
+		t.Errorf("batch/partitions mismatch: %+v", cfg)
+	}
+	if cfg.Checkpoint != 12*time.Second {
+		t.Errorf("Checkpoint = %v, want 12s (the --checkpoint int is seconds)", cfg.Checkpoint)
+	}
+	if cfg.StartLSN != 0 {
+		t.Errorf("StartLSN = %d, want 0 when --start-lsn is unset", cfg.StartLSN)
+	}
+}
+
+func TestPGStreamConfigFromFlags_EnvFallback(t *testing.T) {
+	clearPGEnv(t)
+	resetPGFlags()
+	pgIndexDSN = "idx"
+	pgServerID = 7
+	// All PG-specific settings supplied via env only (no CLI flag).
+	t.Setenv("BINTRAIL_PG_REPL_DSN", "repl-from-env")
+	t.Setenv("BINTRAIL_PG_QUERY_DSN", "query-from-env")
+	t.Setenv("BINTRAIL_PG_SLOT", "slot-from-env")
+	t.Setenv("BINTRAIL_PG_PUBLICATION", "pub-from-env")
+
+	cfg, err := pgStreamConfigFromFlags()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.ReplDSN != "repl-from-env" || cfg.QueryDSN != "query-from-env" ||
+		cfg.SlotName != "slot-from-env" || cfg.Publication != "pub-from-env" {
+		t.Errorf("env fallback not applied: %+v", cfg)
+	}
+}
+
+func TestPGStreamConfigFromFlags_FlagWinsOverEnv(t *testing.T) {
+	clearPGEnv(t)
+	resetPGFlags()
+	pgIndexDSN = "idx"
+	pgServerID = 7
+	pgReplDSN = "repl-from-flag" // CLI flag set
+	pgQueryDSN = "query-from-flag"
+	pgSlot = "slot-from-flag"
+	pgPublication = "pub-from-flag"
+	t.Setenv("BINTRAIL_PG_REPL_DSN", "repl-from-env") // env also set — flag must win
+
+	cfg, err := pgStreamConfigFromFlags()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.ReplDSN != "repl-from-flag" {
+		t.Errorf("ReplDSN = %q, want the CLI flag value to win over env", cfg.ReplDSN)
+	}
+}
+
+func TestPGStreamConfigFromFlags_StartLSN(t *testing.T) {
+	clearPGEnv(t)
+
+	t.Run("invalid", func(t *testing.T) {
+		resetPGFlags()
+		setPGRequired()
+		pgStartLSN = "not-an-lsn"
+		_, err := pgStreamConfigFromFlags()
+		if err == nil || !strings.Contains(err.Error(), "start-lsn") {
+			t.Fatalf("expected a start-lsn parse error, got %v", err)
+		}
+	})
+
+	t.Run("valid", func(t *testing.T) {
+		resetPGFlags()
+		setPGRequired()
+		pgStartLSN = "16/B374D848"
+		cfg, err := pgStreamConfigFromFlags()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want, _ := pglogrepl.ParseLSN("16/B374D848")
+		if cfg.StartLSN != uint64(want) {
+			t.Errorf("StartLSN = %d, want %d", cfg.StartLSN, uint64(want))
+		}
+	})
+}
+
+// setPGRequired fills the PG-specific required settings so a test can exercise
+// downstream parsing (e.g. --start-lsn) without tripping the missing-settings
+// guard. Callers must resetPGFlags() first.
+func setPGRequired() {
+	pgReplDSN = "repl"
+	pgQueryDSN = "query"
+	pgSlot = "slot"
+	pgPublication = "pub"
+}

--- a/cmd/bintrail-pg/stream_test.go
+++ b/cmd/bintrail-pg/stream_test.go
@@ -163,6 +163,49 @@ func TestPGStreamConfigFromFlags_StartLSN(t *testing.T) {
 			t.Errorf("StartLSN = %d, want %d", cfg.StartLSN, uint64(want))
 		}
 	})
+
+	// start-lsn is the one connection setting whose env binding is otherwise
+	// only exercised indirectly — drive it through BINTRAIL_PG_START_LSN so a
+	// typo in that fallback's env-var name would fail this test.
+	t.Run("valid-from-env", func(t *testing.T) {
+		resetPGFlags()
+		setPGRequired()
+		t.Setenv("BINTRAIL_PG_START_LSN", "16/B374D848")
+		cfg, err := pgStreamConfigFromFlags()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want, _ := pglogrepl.ParseLSN("16/B374D848")
+		if cfg.StartLSN != uint64(want) {
+			t.Errorf("StartLSN = %d, want %d (env fallback)", cfg.StartLSN, uint64(want))
+		}
+	})
+}
+
+// TestPGStreamCmd_defaults pins the registered cobra flag defaults so a drift in
+// stream.go's IntVar registrations (e.g. --batch-size 1000→100) fails a test —
+// resetPGFlags() hardcodes these same literals, so without this guard a default
+// change would silently diverge from the documented user-facing behavior. Mirrors
+// cmd/bintrail/stream_test.go's TestStreamCmd_defaults.
+func TestPGStreamCmd_defaults(t *testing.T) {
+	cases := []struct {
+		flag string
+		want string
+	}{
+		{"batch-size", "1000"},
+		{"checkpoint", "5"},
+		{"partitions", "48"},
+	}
+	for _, tc := range cases {
+		f := streamCmd.Flag(tc.flag)
+		if f == nil {
+			t.Errorf("flag --%s not registered", tc.flag)
+			continue
+		}
+		if f.DefValue != tc.want {
+			t.Errorf("flag --%s: expected default %q, got %q", tc.flag, tc.want, f.DefValue)
+		}
+	}
 }
 
 // setPGRequired fills the PG-specific required settings so a test can exercise

--- a/cmd/bintrail/main.go
+++ b/cmd/bintrail/main.go
@@ -75,7 +75,9 @@ func main() {
 		os.Exit(code)
 	}
 	if wantsJSON(rootCmd) {
-		json.NewEncoder(os.Stderr).Encode(map[string]string{"error": err.Error()})
+		if encErr := json.NewEncoder(os.Stderr).Encode(map[string]string{"error": err.Error()}); encErr != nil {
+			fmt.Fprintln(os.Stderr, err) // fall back to text so the message is never wholly lost
+		}
 	} else {
 		fmt.Fprintln(os.Stderr, err)
 	}

--- a/cmd/bintrail/pgfree_test.go
+++ b/cmd/bintrail/pgfree_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestCoreBinaryIsPostgresFree is the source-split guard (#534): the core
+// bintrail binary captures MySQL and must NOT link the PostgreSQL capture stack
+// (jackc/pgx + pglogrepl, pulled in via internal/pgcapture and internal/
+// pgstreamrun). That stack lives only in the standalone bintrail-pg binary, so
+// the MySQL binary's dependency surface stays free of pgx. A new import path
+// from any core command back into either package, however indirect, fails this
+// test.
+//
+// The shared read plane (internal/cli: status/query/recover/reconstruct/shim) is
+// deliberately NOT banned — it is source-agnostic and linked by both binaries.
+// Only the PostgreSQL CAPTURE packages are off-limits to the core binary.
+func TestCoreBinaryIsPostgresFree(t *testing.T) {
+	out, err := exec.Command("go", "list", "-deps",
+		"github.com/dbtrail/dbtrail/cmd/bintrail").CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list -deps: %v\n%s", err, out)
+	}
+	banned := []string{
+		"github.com/dbtrail/dbtrail/internal/pgcapture",
+		"github.com/dbtrail/dbtrail/internal/pgstreamrun",
+		"github.com/jackc/pglogrepl",
+		"github.com/jackc/pgx",
+	}
+	for line := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
+		pkg := strings.TrimSpace(line)
+		for _, b := range banned {
+			// Exact match or a subpackage — never a substring (so
+			// github.com/jackc/pgx matches pgx/v5 and pgx/v5/pgconn but not an
+			// unrelated package that merely contains the string).
+			if pkg == b || strings.HasPrefix(pkg, b+"/") {
+				t.Errorf("cmd/bintrail links %s — the PostgreSQL capture stack must only be linked by cmd/bintrail-pg", pkg)
+			}
+		}
+	}
+}

--- a/scripts/gen-notices.sh
+++ b/scripts/gen-notices.sh
@@ -7,9 +7,10 @@
 #                        the C/C++ libraries vendored inside the precompiled
 #                        libduckdb static library (which go-licenses cannot see)
 #                        plus the MPL-2.0 note for go-sql-driver/mysql.
-#   PART 2 (generated) — `go-licenses save` over the THREE published binary
-#                        mains (bintrail, bintrail-mcp, bintrail-console),
-#                        reproducing each linked Go module's LICENSE and, where
+#   PART 2 (generated) — `go-licenses save` over the FOUR published binary
+#                        mains (bintrail, bintrail-mcp, bintrail-console,
+#                        bintrail-pg), reproducing each linked Go module's
+#                        LICENSE and, where
 #                        present, NOTICE file.
 #
 # Output is deterministic (modules walked in sorted order, host-arch-only
@@ -28,7 +29,7 @@ OUT="$REPO_ROOT/THIRD-PARTY-NOTICES"
 HEADER="$REPO_ROOT/scripts/notices-header.txt"
 MARKER="$REPO_ROOT/THIRD-PARTY-NOTICES.deps.sha256"
 
-MAINS=(./cmd/bintrail ./cmd/bintrail-mcp ./cmd/bintrail-console)
+MAINS=(./cmd/bintrail ./cmd/bintrail-mcp ./cmd/bintrail-console ./cmd/bintrail-pg)
 
 if ! command -v go-licenses >/dev/null 2>&1; then
   echo "error: go-licenses not on PATH. Install it with:" >&2

--- a/scripts/notices-header.txt
+++ b/scripts/notices-header.txt
@@ -17,8 +17,8 @@ This file has two parts:
 
   2. A GENERATED section, produced by `make notices` (which runs
      `go-licenses save` over ./cmd/bintrail, ./cmd/bintrail-mcp,
-     ./cmd/bintrail-console and ./cmd/bintrail-pg), reproducing the LICENSE —
-     and, where present, the NOTICE — file of every linked Go module.
+     ./cmd/bintrail-console and ./cmd/bintrail-pg), reproducing the LICENSE
+     — and, where present, the NOTICE — file of every linked Go module.
 
 Regenerate with `make notices`. Do not edit the GENERATED section by hand.
 

--- a/scripts/notices-header.txt
+++ b/scripts/notices-header.txt
@@ -2,9 +2,10 @@
 THIRD-PARTY NOTICES
 ================================================================================
 
-bintrail (and the bintrail-mcp and bintrail-console binaries published from this
-repository) statically links a number of third-party Go modules and, through
-the precompiled libduckdb static library, a number of vendored C/C++ libraries.
+bintrail (and the bintrail-mcp, bintrail-console and bintrail-pg binaries
+published from this repository) statically links a number of third-party Go
+modules and, through the precompiled libduckdb static library, a number of
+vendored C/C++ libraries.
 The licenses below are reproduced to satisfy their notice-retention terms.
 
 This file has two parts:
@@ -15,9 +16,9 @@ This file has two parts:
      dependency (go-sql-driver/mysql, MPL-2.0).
 
   2. A GENERATED section, produced by `make notices` (which runs
-     `go-licenses save` over ./cmd/bintrail, ./cmd/bintrail-mcp and
-     ./cmd/bintrail-console), reproducing the LICENSE — and, where present, the
-     NOTICE — file of every linked Go module.
+     `go-licenses save` over ./cmd/bintrail, ./cmd/bintrail-mcp,
+     ./cmd/bintrail-console and ./cmd/bintrail-pg), reproducing the LICENSE —
+     and, where present, the NOTICE — file of every linked Go module.
 
 Regenerate with `make notices`. Do not edit the GENERATED section by hand.
 


### PR DESCRIPTION
## What

Adds **`cmd/bintrail-pg`** — the PostgreSQL sibling of the core `bintrail` binary, the first slice of #534. It captures a live PostgreSQL logical-replication stream into the **same MySQL index** (the "one index schema for all sources" red line, #527) and serves the **identical read plane** — `status`/`query`/`recover`/`reconstruct`/`shim` — via `internal/cli.AddReadCommands`.

This is thin, well-tested glue over the already-merged producer/consumer (`internal/pgcapture` #530, `internal/pgstreamrun`); the capture engine itself is unchanged.

## Why a separate binary

The PostgreSQL capture path links `jackc/pgx` + `pglogrepl`, which the core MySQL binary must stay free of. Splitting the **capture plane** per source keeps each binary's dependency surface honest, while the **read plane** is shared code in `internal/cli` (the payoff of the #529 extraction). The user wants a recognizable `bintrail-pg` artifact for the Postgres-recovery niche.

## Changes

- **`cmd/bintrail-pg/main.go`** — `rootCmd "bintrail-pg"`, reusing the core's `main.Version/CommitSHA/BuildDate` ldflags vars so the Makefile `BINTRAIL_LDFLAGS` applies verbatim (exactly as `bintrail-console` does) + `cli.AddReadCommands`.
- **`cmd/bintrail-pg/stream.go`** — `bintrail-pg stream` wires flags/env → `pgstreamrun.One`. PostgreSQL needs **two distinct connections**: `--repl-dsn` (walsender mode, cannot run SQL) and `--query-dsn` (catalog/PK lookups). `index-dsn`/`server-id` reuse `cli.EnvBindings`; the `BINTRAIL_PG_*` connection vars get a direct env fallback. Config assembly is a pure, unit-tested seam (`pgStreamConfigFromFlags`), mirroring the MySQL stream's `streamConfigFromFlags`.
- **`cmd/bintrail/pgfree_test.go`** — decouple guard: the core MySQL binary must NOT link `internal/pgcapture`, `internal/pgstreamrun`, `jackc/pgx`, or `jackc/pglogrepl` (mirrors `uifree_test.go`).
- **`THIRD-PARTY-NOTICES` + `scripts/`** — `bintrail-pg` links `jackc/pgx` + `pglogrepl` into a published binary (previously unreachable from any main), so `gen-notices.sh` scans the fourth main and the regenerated notices include their licenses (jackc `pgio`/`pglogrepl`/`pgpassfile`/`pgservicefile`/`pgx`). The dependency-graph hash is unchanged (pgx entered `go.mod` in #530), so `check-notices` stays green.
- **Makefile** — `make build-pg` / `install` / `clean` / `all` wire the new binary.

## Tests

- `go test ./... -count=1` — green (33 pkgs).
- `cmd/bintrail-pg` unit tests cover the config seam: missing-required aggregation, happy path, `BINTRAIL_PG_*` env fallback, flag-wins-over-env, and `--start-lsn` parse (valid + invalid).
- Guard test passes (`cmd/bintrail` does not link the pgx stack).
- Smoked the three end-user error paths (required-flag, missing-PG-settings, bad start-lsn) — all clear, actionable messages.

## Scope / follow-ups (rest of #534)

- **Postgres CI matrix** (next slice) — compose service + `testutil.CreateTestPostgres` + CI axis (PG 14–17). This is what finally gives `TestOne_EndToEnd_PostgresToIndexToRecovery` (currently `SkipIfNoPostgres`) a runner; the capture path has no CI coverage until it lands.
- **goreleaser** (later slice) — Docker/deb/rpm publishing for `bintrail-pg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)