### PR TITLE
ci(postgres): integration-postgres-source matrix (PG 14-17) (#534)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,90 @@ jobs:
       - name: MariaDB-source integration tests
         run: go test -tags=integration -race -p 1 -count=1 -run 'MariaDB|Mariadb|mariadb|Flavor|FourColumns' ./...
 
+  integration-postgres-source:
+    # PostgreSQL-as-source (#534). Like integration-mariadb-source, this pairs a
+    # NEW PostgreSQL SOURCE container with the existing MySQL INDEX container
+    # (13306): two containers a single `integration` matrix cell can't host, and
+    # the PG logical-replication tests need wal_level=logical + replication slots
+    # the MySQL index container can't provide. The end-to-end test
+    # (TestOne_EndToEnd_PostgresToIndexToRecovery) streams PG changes INTO the
+    # MySQL index and generates recovery SQL, so both servers must be present.
+    runs-on: ubuntu-22.04
+
+    # Spans the supported PostgreSQL range: 14 (declared minimum — PG13 is EOL)
+    # through 17 (newest GA). fail-fast: false so a regression on one version
+    # still reports the others, matching the MySQL matrix.
+    strategy:
+      fail-fast: false
+      matrix:
+        postgres: ["14", "15", "16", "17"]
+
+    env:
+      BINTRAIL_TEST_DSN: "root:testroot@tcp(127.0.0.1:13306)"
+      # Host port 15432 (not 5432) avoids colliding with any PostgreSQL the
+      # runner image ships; the container-internal port stays 5432. sslmode is
+      # disabled — the stock postgres image serves plaintext. replDSN appends
+      # replication=database onto this for the WAL connection.
+      BINTRAIL_TEST_PG_DSN: "postgres://postgres:testpg@127.0.0.1:15432/pgtest?sslmode=disable"
+      # A PostgreSQL source is guaranteed present here, so the PG tests must FAIL
+      # (not silently skip) if the DSN is missing — guards against green-via-skip.
+      # The 8.0/8.4 matrix and console-e2e leave it unset, so PG tests skip there.
+      BINTRAIL_REQUIRE_POSTGRES: "1"
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Start MySQL index (bintrail-test-mysql, 8.4)
+        run: |
+          docker run -d --name bintrail-test-mysql \
+            -e MYSQL_ROOT_PASSWORD=testroot \
+            -p 13306:3306 \
+            mysql:8.4 \
+            --binlog-format=ROW --binlog-row-image=FULL --log-bin=binlog --server-id=1
+          for i in $(seq 1 60); do
+            if docker exec bintrail-test-mysql mysqladmin ping -u root -ptestroot --silent 2>/dev/null; then
+              echo "MySQL index is ready."; exit 0
+            fi
+            sleep 2
+          done
+          echo "MySQL did not become ready in time" >&2
+          docker logs bintrail-test-mysql >&2 || true
+          exit 1
+
+      - name: Start PostgreSQL source (bintrail-test-postgres, ${{ matrix.postgres }})
+        run: |
+          docker run -d --name bintrail-test-postgres \
+            -e POSTGRES_PASSWORD=testpg \
+            -e POSTGRES_DB=pgtest \
+            -p 15432:5432 \
+            postgres:${{ matrix.postgres }} \
+            -c wal_level=logical -c max_replication_slots=10 -c max_wal_senders=10
+          # Probe TCP from inside the container: during first-init the entrypoint
+          # runs a temporary unix-socket-only server, so a TCP (-h 127.0.0.1)
+          # pg_isready only succeeds once the REAL server is up — avoiding the
+          # false-ready race a socket probe would hit.
+          for i in $(seq 1 60); do
+            if docker exec bintrail-test-postgres pg_isready -h 127.0.0.1 -U postgres -d pgtest --quiet 2>/dev/null; then
+              echo "PostgreSQL source is ready."; exit 0
+            fi
+            sleep 2
+          done
+          echo "PostgreSQL did not become ready in time" >&2
+          docker logs bintrail-test-postgres >&2 || true
+          exit 1
+
+      # Scoped to the two PostgreSQL packages by path (not -run): streamrun has
+      # its own TestOne_* MySQL tests, so a name filter would be ambiguous. The
+      # integration build tag plus the BINTRAIL_TEST_PG_DSN gate select the live
+      # tests; -p 1 serializes (they share one server, creating/dropping their
+      # own slots/publications).
+      - name: PostgreSQL-source integration tests
+        run: go test -tags=integration -race -p 1 -count=1 ./internal/pgcapture/ ./internal/pgstreamrun/
+
   console-e2e:
     # Headless-Chrome regression guard for the console SPA: go test never
     # renders assets/*, so CSS/DOM/presentation bugs (invisible buttons, a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,8 +182,9 @@ jobs:
     runs-on: ubuntu-22.04
 
     # Spans the supported PostgreSQL range: 14 (declared minimum — PG13 is EOL)
-    # through 17 (newest GA). fail-fast: false so a regression on one version
-    # still reports the others, matching the MySQL matrix.
+    # through 17. fail-fast: false so a regression on one version still reports
+    # the others, matching the MySQL matrix. (PG18-specific stream changes — e.g.
+    # STORED generated columns now in the WAL — are tracked with the beta work.)
     strategy:
       fail-fast: false
       matrix:
@@ -247,13 +248,24 @@ jobs:
           docker logs bintrail-test-postgres >&2 || true
           exit 1
 
-      # Scoped to the two PostgreSQL packages by path (not -run): streamrun has
-      # its own TestOne_* MySQL tests, so a name filter would be ambiguous. The
-      # integration build tag plus the BINTRAIL_TEST_PG_DSN gate select the live
-      # tests; -p 1 serializes (they share one server, creating/dropping their
-      # own slots/publications).
+      # Scoped to the two PostgreSQL packages by path (not -run) so the selection
+      # is naming-independent — it won't accidentally catch a future TestOne_*-
+      # style test added elsewhere. -p 1 serializes (the tests share one server,
+      # creating/dropping their own slots/publications).
+      #
+      # Both packages ALSO hold non-tagged unit tests, so a build-tag or path
+      # drift that silently dropped the integration tests would still exit 0
+      # green with ZERO PG coverage (the BINTRAIL_REQUIRE_POSTGRES guard only
+      # fires when an integration test actually runs). Close that false-green by
+      # asserting the headline end-to-end test genuinely ran — not merely that
+      # `go test` exited 0. pipefail keeps the go-test exit code through the tee.
       - name: PostgreSQL-source integration tests
-        run: go test -tags=integration -race -p 1 -count=1 ./internal/pgcapture/ ./internal/pgstreamrun/
+        run: |
+          set -o pipefail
+          go test -tags=integration -race -p 1 -count=1 -v \
+            ./internal/pgcapture/ ./internal/pgstreamrun/ 2>&1 | tee /tmp/pg-it.out
+          grep -q -- '--- PASS: TestOne_EndToEnd_PostgresToIndexToRecovery' /tmp/pg-it.out \
+            || { echo "FATAL: PG end-to-end integration test did not run — false-green tripwire" >&2; exit 1; }
 
   console-e2e:
     # Headless-Chrome regression guard for the console SPA: go test never

--- a/internal/testutil/postgres.go
+++ b/internal/testutil/postgres.go
@@ -11,15 +11,30 @@ import (
 // postgres://postgres:testpg@localhost:15533/pgtest).
 func PostgresDSN() string { return os.Getenv("BINTRAIL_TEST_PG_DSN") }
 
+// PostgresRequired reports whether PostgreSQL integration tests must RUN (and
+// fail rather than skip) when no DSN is configured. The dedicated CI job
+// (integration-postgres-source) sets BINTRAIL_REQUIRE_POSTGRES=1, where a live
+// PostgreSQL source is guaranteed — so a missing DSN there is a misconfiguration
+// to surface loudly, not a green-via-skip. The MySQL integration matrix leaves it
+// unset, so PG tests skip cleanly there. Mirrors MariaDBRequired.
+func PostgresRequired() bool {
+	return os.Getenv("BINTRAIL_REQUIRE_POSTGRES") == "1"
+}
+
 // SkipIfNoPostgres skips the test unless BINTRAIL_TEST_PG_DSN is set, and returns
 // the DSN. It is presence-only (no driver dependency) on purpose: the MySQL-based
 // CI integration jobs run `go test -tags integration ./...` WITHOUT setting it, so
 // PostgreSQL integration tests must skip cleanly there rather than fail or hang —
-// a live Postgres CI cell arrives with #534's matrix. Mirrors SkipIfNoMySQL.
+// the live Postgres CI cell is integration-postgres-source (#534's matrix), which
+// sets BINTRAIL_REQUIRE_POSTGRES=1 so a missing DSN there fails loud instead of
+// passing as green-via-skip. Mirrors SkipIfNoMySQL / SkipOrFailMariaDB.
 func SkipIfNoPostgres(t *testing.T) string {
 	t.Helper()
 	dsn := PostgresDSN()
 	if dsn == "" {
+		if PostgresRequired() {
+			t.Fatal("BINTRAIL_TEST_PG_DSN not set but BINTRAIL_REQUIRE_POSTGRES=1 — the integration-postgres-source CI job must provide a live PostgreSQL server")
+		}
 		t.Skip("skipping: BINTRAIL_TEST_PG_DSN not set (no live PostgreSQL with logical replication)")
 	}
 	return dsn


### PR DESCRIPTION
## What

Adds the **`integration-postgres-source`** CI job — slice 2 of #534 — giving the PostgreSQL capture path a **live CI runner**. Until now `TestCapturer_*` (`internal/pgcapture`) and `TestOne_*` (`internal/pgstreamrun`) skip in every job (no `BINTRAIL_TEST_PG_DSN` is set anywhere), so the entire PG→capture→index→recovery pipeline merged in #530/#531 had **zero CI coverage**. This closes that gap.

## The job

Mirrors `integration-mariadb-source`: a new PostgreSQL **source** container paired with the existing MySQL **index** container. Both must be present because the e2e test (`TestOne_EndToEnd_PostgresToIndexToRecovery`) streams PG changes *into* the MySQL index and generates recovery SQL — a single `integration` matrix cell can't host two servers, and the PG tests need `wal_level=logical` + replication slots the MySQL container can't provide.

- **matrix:** `postgres: ["14","15","16","17"]` (14 = declared minimum, PG13 is EOL; 17 = newest GA), `fail-fast: false` to match the MySQL matrix.
- **PG container:** `wal_level=logical`, `max_replication_slots/wal_senders=10`, host port **15432** (avoids any PostgreSQL the runner image ships), **TCP** `pg_isready` readiness (dodges the first-init unix-socket-only false-ready race).
- **scoped by path** (`./internal/pgcapture/ ./internal/pgstreamrun/`), not `-run`: streamrun has its own `TestOne_*` *MySQL* tests, so a name filter would be ambiguous. `-p 1` serializes (the PG tests share one server, creating/dropping their own slots/publications).

## testutil

`SkipIfNoPostgres` now honors `BINTRAIL_REQUIRE_POSTGRES=1` (set by this job): a missing DSN **fails loud** instead of green-via-skip, mirroring the existing `MariaDBRequired` guard. The MySQL matrix and console-e2e leave it unset, so PG tests keep skipping cleanly there.

## Verification

- The **exact job command** passes against **live `postgres:14` AND `postgres:16`** + MySQL — all 7 PG integration tests (5 `pgcapture` + 2 `pgstreamrun`, incl. the full e2e + recovery). PG14 is the cell that exercises the `indkey::int2[]` cast added in #547.
- Both require-flag modes confirmed: `REQUIRE=1` + no DSN → **FAIL**; neither set → **SKIP**.
- `ci.yml` parses (PyYAML); `go vet -tags=integration` clean on both PG packages.

## Scope

This is the **de-risk slice** — it makes the previously-skipped PG e2e actually run. The remaining #534 slice is **goreleaser** publishing (Docker/deb/rpm) for `bintrail-pg`. Deferred capture-completeness items (`--reset`, Prometheus metrics on the PG daemon) now have a live-PG runner to be tested against when implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)