### PR TITLE
release(bintrail-pg): publish image + deb/rpm via goreleaser (#534)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -80,6 +80,35 @@ builds:
       - -X main.CommitSHA={{.Commit}}
       - -X main.BuildDate={{.Date}}
 
+  # bintrail-pg: the PostgreSQL-source binary (#534). Build-identical to
+  # bintrail-console — it links DuckDB via the shared read plane (CGO) plus the
+  # pure-Go pgx/pglogrepl capture stack — so the CGO/cross-compile block and the
+  # main.* ldflags var names mirror bintrail/bintrail-console verbatim. Ships in
+  # the release archives, as its own deb/rpm (nfpms below), and as its own image
+  # (ghcr.io/dbtrail/bintrail-pg — dockers/docker_manifests below).
+  - id: bintrail-pg
+    binary: bintrail-pg
+    main: ./cmd/bintrail-pg
+    env:
+      - CGO_ENABLED=1
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    overrides:
+      - goos: linux
+        goarch: arm64
+        env:
+          - CGO_ENABLED=1
+          - CC=aarch64-linux-gnu-gcc
+          - CXX=aarch64-linux-gnu-g++
+    ldflags:
+      - -s -w
+      - -X main.Version={{.Version}}
+      - -X main.CommitSHA={{.Commit}}
+      - -X main.BuildDate={{.Date}}
+
 archives:
   - formats:
       - tar.gz
@@ -88,6 +117,7 @@ archives:
       - bintrail
       - bintrail-mcp
       - bintrail-console
+      - bintrail-pg
     # `files:` OVERRIDES GoReleaser's default set (LICENSE*/README*/CHANGELOG*),
     # so the defaults are re-listed here alongside the license-compliance
     # artifacts (#428): NOTICE + THIRD-PARTY-NOTICES carry the retained
@@ -167,6 +197,35 @@ nfpms:
         dst: /usr/share/doc/bintrail-console/NOTICE
       - src: THIRD-PARTY-NOTICES
         dst: /usr/share/doc/bintrail-console/THIRD-PARTY-NOTICES
+
+  # Separate package for the PostgreSQL-source binary (#534), mirroring the
+  # console split: a PostgreSQL operator installs only bintrail-pg.
+  - id: bintrail-pg
+    package_name: bintrail-pg
+    ids:
+      - bintrail-pg
+    vendor: dbtrail
+    homepage: https://github.com/dbtrail/dbtrail
+    maintainer: Daniel <daniel@dbtrail.com>
+    description: >-
+      Capture a live PostgreSQL logical-replication stream into the bintrail
+      MySQL index with full before/after images, and generate reversal SQL for
+      recovery (PostgreSQL-source support is alpha).
+    license: Apache-2.0
+    formats:
+      - deb
+      - rpm
+    bindir: /usr/bin
+    dependencies:
+      - ca-certificates
+    # Same notices as the core package, under this package's own doc dir (#428).
+    contents:
+      - src: LICENSE
+        dst: /usr/share/doc/bintrail-pg/LICENSE
+      - src: NOTICE
+        dst: /usr/share/doc/bintrail-pg/NOTICE
+      - src: THIRD-PARTY-NOTICES
+        dst: /usr/share/doc/bintrail-pg/THIRD-PARTY-NOTICES
 
 # ── Docker images (multi-arch, published to GHCR) ──────────
 # One image per arch, then a manifest stitching them into a single
@@ -272,6 +331,52 @@ dockers:
       - "--label=org.opencontainers.image.source=https://github.com/dbtrail/dbtrail"
       - "--label=org.opencontainers.image.licenses=Apache-2.0"
 
+  # bintrail-pg: its own single-binary image (PMM-style split), same shape as
+  # the bintrail-console image pair above.
+  - id: bintrail-pg-amd64
+    goos: linux
+    goarch: amd64
+    ids:
+      - bintrail-pg
+    dockerfile: Dockerfile.bintrail-pg.goreleaser
+    use: buildx
+    extra_files:
+      - LICENSE
+      - NOTICE
+      - THIRD-PARTY-NOTICES
+    image_templates:
+      - "ghcr.io/dbtrail/bintrail-pg:{{ .Version }}-amd64"
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.title=bintrail-pg"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.source=https://github.com/dbtrail/dbtrail"
+      - "--label=org.opencontainers.image.licenses=Apache-2.0"
+
+  - id: bintrail-pg-arm64
+    goos: linux
+    goarch: arm64
+    ids:
+      - bintrail-pg
+    dockerfile: Dockerfile.bintrail-pg.goreleaser
+    use: buildx
+    extra_files:
+      - LICENSE
+      - NOTICE
+      - THIRD-PARTY-NOTICES
+    image_templates:
+      - "ghcr.io/dbtrail/bintrail-pg:{{ .Version }}-arm64"
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.title=bintrail-pg"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.source=https://github.com/dbtrail/dbtrail"
+      - "--label=org.opencontainers.image.licenses=Apache-2.0"
+
 docker_manifests:
   - name_template: "ghcr.io/dbtrail/bintrail:{{ .Version }}"
     image_templates:
@@ -297,6 +402,17 @@ docker_manifests:
     image_templates:
       - "ghcr.io/dbtrail/bintrail-console:{{ .Version }}-amd64"
       - "ghcr.io/dbtrail/bintrail-console:{{ .Version }}-arm64"
+
+  - name_template: "ghcr.io/dbtrail/bintrail-pg:{{ .Version }}"
+    image_templates:
+      - "ghcr.io/dbtrail/bintrail-pg:{{ .Version }}-amd64"
+      - "ghcr.io/dbtrail/bintrail-pg:{{ .Version }}-arm64"
+  # skip_push: auto — same prerelease gating as the core image's :latest.
+  - name_template: "ghcr.io/dbtrail/bintrail-pg:latest"
+    skip_push: "auto"
+    image_templates:
+      - "ghcr.io/dbtrail/bintrail-pg:{{ .Version }}-amd64"
+      - "ghcr.io/dbtrail/bintrail-pg:{{ .Version }}-arm64"
 
 # ── Homebrew tap (DEFERRED — do not uncomment until prerequisites exist) ──
 # Requires BOTH:

--- a/Dockerfile.bintrail-pg.goreleaser
+++ b/Dockerfile.bintrail-pg.goreleaser
@@ -1,0 +1,29 @@
+# GoReleaser-only Dockerfile for the bintrail-pg image.
+#
+# Like Dockerfile.goreleaser (the core binary), this image just copies the
+# binary GoReleaser already cross-compiled. The build context root contains
+# `bintrail-pg` for the target arch — GoReleaser stages it there before
+# invoking `docker build`.
+#
+# Runtime base matches the core image (debian:bookworm-slim): glibc for
+# DuckDB's static libs (linked via the shared read plane) and a shell for
+# debugging. One binary per image (PMM-style) — the MySQL CLI ships as
+# ghcr.io/dbtrail/bintrail, the web console as ghcr.io/dbtrail/bintrail-console.
+FROM debian:bookworm-slim
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates && \
+    rm -rf /var/lib/apt/lists/* && \
+    # Pin uid 999 to match the rest of the image family (the bundled compose
+    # chowns the index password secret to uid 999, mode 0600, for these
+    # processes to read — see docker-compose.yml).
+    useradd --system --no-create-home --uid 999 bintrail
+
+COPY bintrail-pg /usr/local/bin/bintrail-pg
+
+# License-compliance notices (#428). GoReleaser stages these into the build
+# context via the `dockers.*.extra_files` entries in .goreleaser.yaml.
+COPY LICENSE NOTICE THIRD-PARTY-NOTICES /usr/share/doc/bintrail-pg/
+
+USER bintrail
+ENTRYPOINT ["bintrail-pg"]

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,10 @@ build-all:
 	GOOS=linux   GOARCH=arm64 CGO_ENABLED=1 CC=aarch64-linux-gnu-gcc go build $(BINTRAIL_LDFLAGS) -o dist/$(CONSOLE_BINARY)-linux-arm64 ./cmd/bintrail-console
 	GOOS=darwin  GOARCH=amd64 CGO_ENABLED=1 go build $(BINTRAIL_LDFLAGS) -o dist/$(CONSOLE_BINARY)-darwin-amd64 ./cmd/bintrail-console
 	GOOS=darwin  GOARCH=arm64 CGO_ENABLED=1 go build $(BINTRAIL_LDFLAGS) -o dist/$(CONSOLE_BINARY)-darwin-arm64 ./cmd/bintrail-console
+	GOOS=linux   GOARCH=amd64 CGO_ENABLED=1 go build $(BINTRAIL_LDFLAGS) -o dist/$(PG_BINARY)-linux-amd64 ./cmd/bintrail-pg
+	GOOS=linux   GOARCH=arm64 CGO_ENABLED=1 CC=aarch64-linux-gnu-gcc go build $(BINTRAIL_LDFLAGS) -o dist/$(PG_BINARY)-linux-arm64 ./cmd/bintrail-pg
+	GOOS=darwin  GOARCH=amd64 CGO_ENABLED=1 go build $(BINTRAIL_LDFLAGS) -o dist/$(PG_BINARY)-darwin-amd64 ./cmd/bintrail-pg
+	GOOS=darwin  GOARCH=arm64 CGO_ENABLED=1 go build $(BINTRAIL_LDFLAGS) -o dist/$(PG_BINARY)-darwin-arm64 ./cmd/bintrail-pg
 	GOOS=linux   GOARCH=amd64 CGO_ENABLED=0 go build $(GATEWAY_LDFLAGS) -o dist/$(GATEWAY_BINARY)-linux-amd64 ./cmd/mcp-gateway
 	GOOS=linux   GOARCH=arm64 CGO_ENABLED=0 go build $(GATEWAY_LDFLAGS) -o dist/$(GATEWAY_BINARY)-linux-arm64 ./cmd/mcp-gateway
 	GOOS=darwin  GOARCH=amd64 CGO_ENABLED=0 go build $(GATEWAY_LDFLAGS) -o dist/$(GATEWAY_BINARY)-darwin-amd64 ./cmd/mcp-gateway

--- a/docs/install.md
+++ b/docs/install.md
@@ -114,7 +114,8 @@ Multi-arch (`linux/amd64` + `linux/arm64`), signed with cosign, SBOM attached
 to every release. The image bundles both `bintrail` and `bintrail-mcp`; the
 web console ships as its own image, `ghcr.io/dbtrail/bintrail-console`
 (`serve` = read-only console, `watch` = stream + console daemon — what the
-Compose stack runs). See [docker.md](./docker.md) for signature verification,
+Compose stack runs). The PostgreSQL-source binary ships as its own image,
+`ghcr.io/dbtrail/bintrail-pg` (alpha). See [docker.md](./docker.md) for signature verification,
 `docker run` recipes, and the long-running stream container.
 
 ## Linux packages
@@ -135,7 +136,8 @@ sudo rpm -i bintrail_VERSION_linux_amd64.rpm
 
 The `bintrail` package carries the core CLI + `bintrail-mcp`; the web console
 is a separate `bintrail-console` package — install it only where an operator
-wants the UI.
+wants the UI. PostgreSQL-source capture is a separate `bintrail-pg` package
+(alpha) — install it only on hosts that capture from PostgreSQL.
 
 ## Go install
 
@@ -154,7 +156,8 @@ go build ./cmd/bintrail
 ```
 
 `make build` builds both `bintrail` and `bintrail-mcp` with version metadata;
-`make build-console` builds the `bintrail-console` web-console binary.
+`make build-console` builds the `bintrail-console` web-console binary;
+`make build-pg` builds the `bintrail-pg` PostgreSQL-source binary.
 
 > macOS binaries and a Homebrew tap are tracked in
 > [#349](https://github.com/dbtrail/dbtrail/issues/349) — today the


### PR DESCRIPTION
## What

The **last slice of #534**: `bintrail-pg` now ships as a release artifact, mirroring the `bintrail-console` publishing split (PR-E). Per the product decision, PostgreSQL-source is alpha but published now so the binary reaches alpha testers as a real artifact (image + deb/rpm).

**Key fact:** `bintrail-pg` is **build-identical to `bintrail-console`** — CGO + DuckDB via the shared read plane (`query`/`reconstruct`→`parquetquery`), with pgx/pglogrepl pure Go — so every goreleaser stanza maps 1:1.

## Changes (`.goreleaser.yaml`)

- **builds:** a `bintrail-pg` id (CGO + arm64 cross-compile + `main.*` ldflags, verbatim from `bintrail-console`).
- **archives:** `bintrail-pg` joins the release tarballs.
- **nfpms:** a separate `bintrail-pg` deb/rpm (a PG operator installs only it), notices under its own doc dir.
- **dockers + docker_manifests:** `ghcr.io/dbtrail/bintrail-pg` amd64/arm64 images + `:{version}` and `:latest` (`skip_push: auto`) manifests — same prerelease gating as the core/console images.
- **`Dockerfile.bintrail-pg.goreleaser`:** staged single-binary image mirroring the core `Dockerfile.goreleaser` (debian:bookworm-slim, uid 999, notices). **No source Dockerfile** — bintrail-pg has no `docker build`/compose consumer yet (YAGNI); goreleaser stages the prebuilt binary.
- **Makefile `build-all`:** bintrail-pg linux+darwin amd64/arm64 cross-compile (host `build-pg`/`install`/`clean`/`all` were wired in #561).
- **docs/install.md:** bintrail-pg image/package/make-target, marked **alpha**.

## Verification

- `goreleaser check` validates the config (the `dockers`/`docker_manifests` deprecation notes are pre-existing, file-wide).
- `make build-pg` builds + reports version; `make -n build-all` renders the 4 new cross-compile lines.
- The full cross-compile + image push + sign happens in the release pipeline on the next `vX.Y.Z` tag (can't be fully exercised locally — CGO linux cross-build from darwin). The stanzas are byte-mirrors of the proven `bintrail-console`/core stanzas.

## Scope note

This **closes #534** (binary #561 + CI matrix #562 + publishing here). bintrail-pg is **not** added to `docker-compose.yml` — the demo compose runs the console + core; a PG service needs a PostgreSQL source + config the demo doesn't have. Adding a compose example is separate from publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)