### PR TITLE
feat: persist FK referential rules + soften FK-cascade guard (#549 cascade-recovery slice A)

### DIFF
--- a/cmd/bintrail/index.go
+++ b/cmd/bintrail/index.go
@@ -106,9 +106,14 @@ func runIndex(cmd *cobra.Command, args []string) error {
 		fmt.Println("Source: binlog_row_image=FULL \u2713")
 
 		if err := metadata.ValidateNoFKCascades(sourceDB, cliutil.ParseSchemaList(idxSchemas)); err != nil {
-			return err
+			slog.Warn("FK cascade constraints present on source; indexing will proceed, "+
+				"but InnoDB executes cascades below the binlog (MySQL Bug #32506) so cascaded "+
+				"child-row deletes are NOT captured \u2014 plain `recover` cannot restore them. "+
+				"Cascade recovery is in progress (#548).",
+				"detail", err.Error())
+		} else {
+			fmt.Println("Source: no FK cascades \u2713")
 		}
-		fmt.Println("Source: no FK cascades \u2713")
 	} else {
 		slog.Warn("--skip-source-validation set: skipping binlog_format/binlog_row_image/FK-cascade pre-flight — the per-row partial-image guard still applies")
 	}

--- a/cmd/bintrail/index.go
+++ b/cmd/bintrail/index.go
@@ -106,6 +106,9 @@ func runIndex(cmd *cobra.Command, args []string) error {
 		fmt.Println("Source: binlog_row_image=FULL \u2713")
 
 		if err := metadata.ValidateNoFKCascades(sourceDB, cliutil.ParseSchemaList(idxSchemas)); err != nil {
+			if !errors.Is(err, metadata.ErrFKCascadesFound) {
+				return err // genuine query/connection failure: abort as before
+			}
 			slog.Warn("FK cascade constraints present on source; indexing will proceed, "+
 				"but InnoDB executes cascades below the binlog (MySQL Bug #32506) so cascaded "+
 				"child-row deletes are NOT captured \u2014 plain `recover` cannot restore them. "+

--- a/docs/indexing.md
+++ b/docs/indexing.md
@@ -36,9 +36,11 @@ bintrail index \
   --all
 ```
 
-`--source-dsn` lets `index` preflight the source
-(`binlog_format=ROW`, `binlog_row_image=FULL`, no `ON DELETE/UPDATE CASCADE`
-foreign keys) and auto-snapshot if no snapshot exists yet. It is **required**
+`--source-dsn` lets `index` preflight the source (`binlog_format=ROW` and
+`binlog_row_image=FULL`, both required; `ON DELETE/UPDATE CASCADE` foreign keys
+are allowed but warned — InnoDB executes cascades below the binlog, so the
+cascaded child deletes are not captured and plain `recover` cannot restore them)
+and auto-snapshot if no snapshot exists yet. It is **required**
 unless you pass `--skip-source-validation` to index offline binlogs against an
 already-captured snapshot — the silent skip is gone so a non-`FULL` source can't
 be indexed by accident.

--- a/docs/query-and-recovery.md
+++ b/docs/query-and-recovery.md
@@ -193,10 +193,11 @@ Reversed: undo the 14:03 UPDATE first, then the 14:02 UPDATE, then the 14:01 INS
 > ordering `bintrail recover` applies — there is no FK-graph analysis, no
 > topological reordering across tables, and the generated script never emits
 > `SET FOREIGN_KEY_CHECKS`. Tables with `ON DELETE/UPDATE CASCADE` produce
-> side-effect row changes that reversal SQL cannot reliably undo
-> (`bintrail doctor` warns about them, and `stream`/`watch` — plus `index`
-> runs given a `--source-dsn` to validate against — refuse to start when the
-> source has them).
+> side-effect row changes (InnoDB runs cascades below the binlog, MySQL Bug
+> #32506, so cascaded child deletes are never captured) that plain `recover`
+> cannot reliably undo. `bintrail doctor`, and `stream`/`watch`/`index --source-dsn`,
+> warn about them and proceed (cascade schemas index normally). Dedicated
+> cascade recovery is in progress (#548).
 
 ### WHERE Clause Strategy
 

--- a/internal/cli/recover.go
+++ b/internal/cli/recover.go
@@ -176,7 +176,8 @@ func runRecover(cmd *cobra.Command, args []string) error {
 	// Plain recover cannot reconstruct rows deleted by an FK ON DELETE CASCADE:
 	// InnoDB executes the cascade below the binlog (MySQL Bug #32506), so the
 	// cascaded child deletes were never indexed. Warn loudly when the targeted
-	// schema carries cascade FKs — the cascade-recovery path handles these.
+	// schema carries cascade FKs — a dedicated cascade-recovery path (#548) will
+	// handle these; plain recover cannot.
 	var cascadeScope []string
 	if rSchema != "" {
 		cascadeScope = []string{rSchema}

--- a/internal/cli/recover.go
+++ b/internal/cli/recover.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 	"time"
 
 	mysqldriver "github.com/go-sql-driver/mysql"
@@ -170,6 +171,31 @@ func runRecover(cmd *cobra.Command, args []string) error {
 
 	if err := indexer.EnsureSchema(db); err != nil {
 		return fmt.Errorf("schema migration: %w", err)
+	}
+
+	// Plain recover cannot reconstruct rows deleted by an FK ON DELETE CASCADE:
+	// InnoDB executes the cascade below the binlog (MySQL Bug #32506), so the
+	// cascaded child deletes were never indexed. Warn loudly when the targeted
+	// schema carries cascade FKs — the cascade-recovery path handles these.
+	var cascadeScope []string
+	if rSchema != "" {
+		cascadeScope = []string{rSchema}
+	}
+	if edges, cerr := metadata.CascadeConstraintsInIndex(db, cascadeScope); cerr != nil {
+		slog.Warn("could not check the index for FK cascade constraints", "error", cerr)
+	} else if len(edges) > 0 {
+		seen := map[string]bool{}
+		var tables []string
+		for _, e := range edges {
+			if k := e.Schema + "." + e.Table; !seen[k] {
+				seen[k] = true
+				tables = append(tables, k)
+			}
+		}
+		slog.Warn("target schema has FK ON DELETE/UPDATE CASCADE constraints; plain `recover` "+
+			"cannot reconstruct cascade-deleted child rows (they are never binlogged, MySQL Bug "+
+			"#32506); cascade recovery is in progress (#548)",
+			"cascade_child_tables", strings.Join(tables, ", "))
 	}
 
 	if rProfile != "" {

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -416,18 +416,18 @@ func checkFKCascades(db *sql.DB, schemas []string) CheckResult {
 		Name:   "No FK CASCADE constraints",
 		Status: StatusWarn,
 		Detail: err.Error(),
-		Remediation: "Foreign keys with ON DELETE CASCADE or ON UPDATE CASCADE produce side-effect row changes\n" +
-			"that bintrail's reversal SQL cannot reliably undo. Two options:\n\n" +
+		Remediation: "Foreign keys with ON DELETE CASCADE or ON UPDATE CASCADE produce side-effect row\n" +
+			"changes that InnoDB executes below the binary log (MySQL Bug #32506), so plain\n" +
+			"`recover` cannot reconstruct cascade-deleted child rows. Options:\n\n" +
 			"  1. Drop or change the cascade rules:\n" +
 			"     ALTER TABLE <child> DROP FOREIGN KEY <fk_name>;\n" +
 			"     ALTER TABLE <child> ADD CONSTRAINT <fk_name> FOREIGN KEY (...) REFERENCES <parent>(...)\n" +
 			"         ON DELETE RESTRICT ON UPDATE RESTRICT;\n\n" +
-			"  2. Accept that reversal across cascades requires manual review.\n\n" +
-			"This check is a WARN here, but ingestion enforces it hard: `stream`/`watch`/`up`\n" +
-			"(and `index` runs given --source-dsn to validate against) refuse to start while\n" +
-			"cascade constraints exist — apply option 1 before streaming. Where events ARE\n" +
-			"indexed despite cascades (`index` without --source-dsn, `agent`), `recover` may\n" +
-			"produce incomplete SQL for the tables involved.",
+			"  2. Keep the cascades and recover cascade-deleted child rows manually for\n" +
+			"     now (full cascade recovery is in progress, #548).\n\n" +
+			"Ingestion (`stream`/`watch`/`up`/`index --source-dsn`) no longer refuses cascade\n" +
+			"schemas — it WARNS and proceeds — so the FK graph is captured for cascade recovery.\n" +
+			"Plain `recover` still produces incomplete SQL for cascade-affected tables.",
 	}
 }
 

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -262,22 +262,27 @@ func EnsureSchema(db *sql.DB) error {
 	//
 	// fk_constraints post-dates the original schema and may be absent on very
 	// old indexes (TakeSnapshot tolerates its absence). Only migrate it when
-	// present; `bintrail init` / a fresh snapshot creates it with the columns.
+	// present; `bintrail init` (the DDL) creates the table with these columns,
+	// and a snapshot then populates the rule once the table exists. The block is
+	// gated by `if hasFK` (rather than an early return) so any migration added
+	// after it still runs on an index that predates fk_constraints.
 	hasFK, err := tableExists(db, "fk_constraints")
 	if err != nil {
 		return err
 	}
-	if !hasFK {
-		return nil
+	if hasFK {
+		if err := ensureColumn(db, "fk_constraints", "delete_rule",
+			`ALTER TABLE fk_constraints ADD COLUMN delete_rule VARCHAR(16) NOT NULL DEFAULT '' COMMENT 'ON DELETE rule (CASCADE/RESTRICT/SET NULL/NO ACTION); empty for pre-cascade-recovery snapshots' AFTER referenced_column_name`,
+		); err != nil {
+			return err
+		}
+		if err := ensureColumn(db, "fk_constraints", "update_rule",
+			`ALTER TABLE fk_constraints ADD COLUMN update_rule VARCHAR(16) NOT NULL DEFAULT '' COMMENT 'ON UPDATE rule; empty for pre-cascade-recovery snapshots' AFTER delete_rule`,
+		); err != nil {
+			return err
+		}
 	}
-	if err := ensureColumn(db, "fk_constraints", "delete_rule",
-		`ALTER TABLE fk_constraints ADD COLUMN delete_rule VARCHAR(16) NOT NULL DEFAULT '' COMMENT 'ON DELETE rule (CASCADE/RESTRICT/SET NULL/NO ACTION); empty for pre-cascade-recovery snapshots' AFTER referenced_column_name`,
-	); err != nil {
-		return err
-	}
-	return ensureColumn(db, "fk_constraints", "update_rule",
-		`ALTER TABLE fk_constraints ADD COLUMN update_rule VARCHAR(16) NOT NULL DEFAULT '' COMMENT 'ON UPDATE rule; empty for pre-cascade-recovery snapshots' AFTER delete_rule`,
-	)
+	return nil
 }
 
 // tableExists reports whether a base table named `table` exists in the current

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -248,9 +248,47 @@ func EnsureSchema(db *sql.DB) error {
 	// parses the saved gtid_set with the correct GTID parser. NOT NULL DEFAULT
 	// 'mysql' means existing rows read back as mysql with no data migration,
 	// keeping every pre-MariaDB install unchanged.
-	return ensureColumn(db, "stream_state", "flavor",
+	if err := ensureColumn(db, "stream_state", "flavor",
 		`ALTER TABLE stream_state ADD COLUMN flavor VARCHAR(16) NOT NULL DEFAULT 'mysql' COMMENT 'source flavor: mysql or mariadb; selects the GTID parser on resume' AFTER gtid_set`,
+	); err != nil {
+		return err
+	}
+	// delete_rule/update_rule carry each FK's referential action so cascade
+	// recovery can tell which edges are ON DELETE CASCADE at recovery time.
+	// `recover` is source-less, so the rule must live in the index rather than
+	// be re-queried from the source. NOT NULL DEFAULT '' means pre-existing
+	// rows read back as "unknown" (treated as non-cascade) with no data
+	// migration; a fresh snapshot of the schema populates the real rule.
+	//
+	// fk_constraints post-dates the original schema and may be absent on very
+	// old indexes (TakeSnapshot tolerates its absence). Only migrate it when
+	// present; `bintrail init` / a fresh snapshot creates it with the columns.
+	hasFK, err := tableExists(db, "fk_constraints")
+	if err != nil {
+		return err
+	}
+	if !hasFK {
+		return nil
+	}
+	if err := ensureColumn(db, "fk_constraints", "delete_rule",
+		`ALTER TABLE fk_constraints ADD COLUMN delete_rule VARCHAR(16) NOT NULL DEFAULT '' COMMENT 'ON DELETE rule (CASCADE/RESTRICT/SET NULL/NO ACTION); empty for pre-cascade-recovery snapshots' AFTER referenced_column_name`,
+	); err != nil {
+		return err
+	}
+	return ensureColumn(db, "fk_constraints", "update_rule",
+		`ALTER TABLE fk_constraints ADD COLUMN update_rule VARCHAR(16) NOT NULL DEFAULT '' COMMENT 'ON UPDATE rule; empty for pre-cascade-recovery snapshots' AFTER delete_rule`,
 	)
+}
+
+// tableExists reports whether a base table named `table` exists in the current
+// database.
+func tableExists(db *sql.DB, table string) (bool, error) {
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM information_schema.TABLES
+		WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?`, table).Scan(&n); err != nil {
+		return false, fmt.Errorf("check table %s: %w", table, err)
+	}
+	return n > 0, nil
 }
 
 // ensureColumnWidened runs an idempotent ALTER TABLE MODIFY COLUMN: it

--- a/internal/indexer/schema.go
+++ b/internal/indexer/schema.go
@@ -266,6 +266,8 @@ const ddlFKConstraints = `CREATE TABLE IF NOT EXISTS fk_constraints (
     referenced_schema_name   VARCHAR(64)  NOT NULL,
     referenced_table_name    VARCHAR(64)  NOT NULL,
     referenced_column_name   VARCHAR(64)  NOT NULL,
+    delete_rule              VARCHAR(16)  NOT NULL DEFAULT '' COMMENT 'ON DELETE rule (CASCADE/RESTRICT/SET NULL/NO ACTION); empty for pre-cascade-recovery snapshots',
+    update_rule              VARCHAR(16)  NOT NULL DEFAULT '' COMMENT 'ON UPDATE rule; empty for pre-cascade-recovery snapshots',
     PRIMARY KEY (snapshot_id, schema_name, constraint_name, ordinal_position)
 ) ENGINE=InnoDB`
 

--- a/internal/indexer/schema_integration_test.go
+++ b/internal/indexer/schema_integration_test.go
@@ -62,6 +62,67 @@ func TestEnsureSchemaAddsFlavorColumn(t *testing.T) {
 	}
 }
 
+// TestEnsureSchemaAddsFKRuleColumns pins the cascade-recovery migration: a
+// pre-cascade install must gain fk_constraints.delete_rule/update_rule as
+// NOT NULL DEFAULT ” (existing rows backfill to "" = unknown), idempotently.
+func TestEnsureSchemaAddsFKRuleColumns(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	// Simulate a pre-cascade install: drop the columns + seed an old-shape row.
+	testutil.MustExec(t, db, `ALTER TABLE fk_constraints DROP COLUMN delete_rule, DROP COLUMN update_rule`)
+	testutil.MustExec(t, db, `INSERT INTO fk_constraints
+		(snapshot_id, constraint_name, schema_name, table_name, column_name,
+		 ordinal_position, referenced_schema_name, referenced_table_name, referenced_column_name)
+		VALUES (1,'fk','app','child','pid',1,'app','parent','id')`)
+
+	if err := EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	for _, col := range []string{"delete_rule", "update_rule"} {
+		var def, nullable string
+		if err := db.QueryRow(`SELECT COLUMN_DEFAULT, IS_NULLABLE FROM information_schema.COLUMNS
+			WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'fk_constraints' AND COLUMN_NAME = ?`,
+			col).Scan(&def, &nullable); err != nil {
+			t.Fatalf("read %s column: %v", col, err)
+		}
+		if def != "" {
+			t.Errorf("%s COLUMN_DEFAULT = %q, want \"\"", col, def)
+		}
+		if nullable != "NO" {
+			t.Errorf("%s IS_NULLABLE = %q, want \"NO\"", col, nullable)
+		}
+	}
+
+	// The pre-existing row must backfill to '' (unknown), not NULL.
+	var del, upd string
+	if err := db.QueryRow(`SELECT delete_rule, update_rule FROM fk_constraints WHERE constraint_name='fk'`).
+		Scan(&del, &upd); err != nil {
+		t.Fatalf("read backfilled row: %v", err)
+	}
+	if del != "" || upd != "" {
+		t.Errorf("backfilled rules = (%q,%q), want empty", del, upd)
+	}
+
+	// Idempotent: a second run must not error or re-add.
+	if err := EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema (second run): %v", err)
+	}
+}
+
+// TestEnsureSchemaToleratesMissingFKConstraints guards the regression where the
+// cascade-recovery migration would break EnsureSchema on very old indexes that
+// predate the fk_constraints table (TakeSnapshot already tolerates its absence).
+func TestEnsureSchemaToleratesMissingFKConstraints(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	testutil.MustExec(t, db, `DROP TABLE fk_constraints`)
+	if err := EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema must tolerate a missing fk_constraints table, got: %v", err)
+	}
+}
+
 // TestEnsureSchemaWidensColumnType pins the #472 migration: #212 created
 // schema_snapshots.column_type as VARCHAR(128), which a realistic ENUM
 // declaration exceeds — under strict mode the 1406 aborts the whole

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -315,6 +315,8 @@ type fkRow struct {
 	referencedSchemaName string
 	referencedTableName  string
 	referencedColumnName string
+	deleteRule           string // ON DELETE rule (CASCADE/RESTRICT/SET NULL/NO ACTION)
+	updateRule           string // ON UPDATE rule
 }
 
 // TakeSnapshot reads column metadata and foreign key constraints from
@@ -470,17 +472,19 @@ func TakeSnapshot(sourceDB, indexDB *sql.DB, schemas []string) (SnapshotStats, e
 		for i := 0; i < len(fkRows); i += batchSize {
 			batch := fkRows[i:min(i+batchSize, len(fkRows))]
 
-			valClause := strings.TrimRight(strings.Repeat("(?,?,?,?,?,?,?,?,?),", len(batch)), ",")
+			valClause := strings.TrimRight(strings.Repeat("(?,?,?,?,?,?,?,?,?,?,?),", len(batch)), ",")
 			insertSQL := "INSERT INTO fk_constraints " +
 				"(snapshot_id, constraint_name, schema_name, table_name, column_name, " +
-				"ordinal_position, referenced_schema_name, referenced_table_name, referenced_column_name) VALUES " +
+				"ordinal_position, referenced_schema_name, referenced_table_name, referenced_column_name, " +
+				"delete_rule, update_rule) VALUES " +
 				valClause
 
-			insertArgs := make([]any, 0, len(batch)*9)
+			insertArgs := make([]any, 0, len(batch)*11)
 			for _, fk := range batch {
 				insertArgs = append(insertArgs,
 					nextID, fk.constraintName, fk.schemaName, fk.tableName, fk.columnName,
 					fk.ordinalPosition, fk.referencedSchemaName, fk.referencedTableName, fk.referencedColumnName,
+					fk.deleteRule, fk.updateRule,
 				)
 			}
 
@@ -518,7 +522,7 @@ func queryFKConstraints(sourceDB *sql.DB, schemas []string) ([]fkRow, error) {
 			SELECT kcu.CONSTRAINT_NAME, kcu.TABLE_SCHEMA, kcu.TABLE_NAME,
 			       kcu.COLUMN_NAME, kcu.ORDINAL_POSITION,
 			       kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME,
-			       kcu.REFERENCED_COLUMN_NAME
+			       kcu.REFERENCED_COLUMN_NAME, rc.DELETE_RULE, rc.UPDATE_RULE
 			FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE kcu
 			JOIN INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS rc
 			    ON rc.CONSTRAINT_SCHEMA = kcu.TABLE_SCHEMA
@@ -532,7 +536,7 @@ func queryFKConstraints(sourceDB *sql.DB, schemas []string) ([]fkRow, error) {
 			SELECT kcu.CONSTRAINT_NAME, kcu.TABLE_SCHEMA, kcu.TABLE_NAME,
 			       kcu.COLUMN_NAME, kcu.ORDINAL_POSITION,
 			       kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME,
-			       kcu.REFERENCED_COLUMN_NAME
+			       kcu.REFERENCED_COLUMN_NAME, rc.DELETE_RULE, rc.UPDATE_RULE
 			FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE kcu
 			JOIN INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS rc
 			    ON rc.CONSTRAINT_SCHEMA = kcu.TABLE_SCHEMA
@@ -558,6 +562,7 @@ func queryFKConstraints(sourceDB *sql.DB, schemas []string) ([]fkRow, error) {
 			&fk.constraintName, &fk.schemaName, &fk.tableName,
 			&fk.columnName, &fk.ordinalPosition,
 			&fk.referencedSchemaName, &fk.referencedTableName, &fk.referencedColumnName,
+			&fk.deleteRule, &fk.updateRule,
 		); err != nil {
 			return nil, fmt.Errorf("failed to scan FK row: %w", err)
 		}
@@ -801,6 +806,68 @@ func ValidateNoFKCascades(db *sql.DB, schemas []string) error {
 		return fmt.Errorf("%d FK cascade constraint(s) found on source; reversal SQL from `recover` may not correctly handle cascade side-effects", len(found))
 	}
 	return nil
+}
+
+// FKCascadeEdge describes a CASCADE foreign-key edge recorded in the index's
+// fk_constraints table (latest snapshot).
+type FKCascadeEdge struct {
+	Schema          string
+	Table           string
+	Column          string
+	ReferencedTable string
+	DeleteRule      string
+	UpdateRule      string
+}
+
+// CascadeConstraintsInIndex returns the CASCADE foreign-key edges recorded in
+// the latest schema snapshot's fk_constraints, optionally scoped to schemas.
+// Unlike ValidateNoFKCascades (which queries the source's information_schema),
+// this reads from the INDEX, so the source-less `recover` path can warn that
+// cascade-deleted child rows are not reversible by plain recover.
+//
+// Returns nil when fk_constraints is absent (index predates it) or carries no
+// cascade rules — including pre-cascade-recovery snapshots whose delete_rule/
+// update_rule columns are empty.
+func CascadeConstraintsInIndex(indexDB *sql.DB, schemas []string) ([]FKCascadeEdge, error) {
+	var exists bool
+	if err := indexDB.QueryRow(
+		"SELECT COUNT(*) > 0 FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'fk_constraints'",
+	).Scan(&exists); err != nil {
+		return nil, fmt.Errorf("failed to check fk_constraints table: %w", err)
+	}
+	if !exists {
+		return nil, nil
+	}
+
+	query := `SELECT schema_name, table_name, column_name, referenced_table_name, delete_rule, update_rule
+		FROM fk_constraints
+		WHERE snapshot_id = (SELECT MAX(snapshot_id) FROM fk_constraints)
+		  AND (delete_rule = 'CASCADE' OR update_rule = 'CASCADE')`
+	var args []any
+	if len(schemas) > 0 {
+		placeholders := strings.TrimRight(strings.Repeat("?,", len(schemas)), ",")
+		query += " AND schema_name IN (" + placeholders + ")"
+		for _, s := range schemas {
+			args = append(args, s)
+		}
+	}
+	query += " ORDER BY schema_name, table_name, column_name"
+
+	rows, err := indexDB.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query cascade FK constraints: %w", err)
+	}
+	defer rows.Close()
+
+	var out []FKCascadeEdge
+	for rows.Next() {
+		var e FKCascadeEdge
+		if err := rows.Scan(&e.Schema, &e.Table, &e.Column, &e.ReferencedTable, &e.DeleteRule, &e.UpdateRule); err != nil {
+			return nil, fmt.Errorf("failed to scan cascade FK row: %w", err)
+		}
+		out = append(out, e)
+	}
+	return out, rows.Err()
 }
 
 // EnsureResolver returns a Resolver loaded from the latest snapshot, taking a

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -759,11 +759,21 @@ func buildFKCascadeQuery(schemas []string) (string, []any) {
 	return query, args
 }
 
+// ErrFKCascadesFound is wrapped into the error ValidateNoFKCascades returns when
+// the source carries FK CASCADE constraints — as opposed to an operational
+// failure (a dropped connection, a permissions error reading
+// information_schema). Call sites use errors.Is to tell the two apart: a cascade
+// finding is now a warn-and-proceed signal, while a genuine query failure must
+// still abort. Without this distinction a real fault would be silently
+// downgraded to a warning and mislabeled as "cascades present".
+var ErrFKCascadesFound = errors.New("FK cascade constraints present on source")
+
 // ValidateNoFKCascades checks that none of the targeted schemas contain foreign
 // key constraints with CASCADE rules. When schemas is empty, all non-system,
 // non-bintrail-internal schemas are checked (see buildFKCascadeQuery). FK
 // cascades produce invisible side-effect row changes that make reversal SQL
-// unreliable.
+// unreliable. A cascade finding is returned wrapped in ErrFKCascadesFound; any
+// other returned error is an operational failure.
 func ValidateNoFKCascades(db *sql.DB, schemas []string) error {
 	query, args := buildFKCascadeQuery(schemas)
 
@@ -803,7 +813,7 @@ func ValidateNoFKCascades(db *sql.DB, schemas []string) error {
 				"source_schema", c.schema, "constraint", c.name,
 				"delete_rule", c.deleteRule, "update_rule", c.updateRule)
 		}
-		return fmt.Errorf("%d FK cascade constraint(s) found on source; reversal SQL from `recover` may not correctly handle cascade side-effects", len(found))
+		return fmt.Errorf("%d FK cascade constraint(s) found on source; reversal SQL from `recover` may not correctly handle cascade side-effects: %w", len(found), ErrFKCascadesFound)
 	}
 	return nil
 }
@@ -820,10 +830,12 @@ type FKCascadeEdge struct {
 }
 
 // CascadeConstraintsInIndex returns the CASCADE foreign-key edges recorded in
-// the latest schema snapshot's fk_constraints, optionally scoped to schemas.
-// Unlike ValidateNoFKCascades (which queries the source's information_schema),
-// this reads from the INDEX, so the source-less `recover` path can warn that
-// cascade-deleted child rows are not reversible by plain recover.
+// the latest snapshot that captured FK rows (MAX(snapshot_id) in fk_constraints),
+// optionally scoped to schemas. Unlike ValidateNoFKCascades (which queries the
+// source's information_schema), this reads from the INDEX, so the source-less
+// `recover` path can warn that cascade-deleted child rows are not reversible by
+// plain recover. (If a newer snapshot recorded zero FKs, this can surface a
+// cascade warning from an older snapshot — acceptable for a warn-only path.)
 //
 // Returns nil when fk_constraints is absent (index predates it) or carries no
 // cascade rules — including pre-cascade-recovery snapshots whose delete_rule/

--- a/internal/metadata/metadata_integration_test.go
+++ b/internal/metadata/metadata_integration_test.go
@@ -4,6 +4,7 @@ package metadata
 
 import (
 	"database/sql"
+	"errors"
 	"strings"
 	"testing"
 
@@ -24,6 +25,13 @@ func TestTakeSnapshotCapturesFKRules(t *testing.T) {
 		id  INT PRIMARY KEY,
 		pid INT,
 		CONSTRAINT fk_child FOREIGN KEY (pid) REFERENCES parent(id) ON DELETE CASCADE ON UPDATE CASCADE
+	) ENGINE=InnoDB`)
+	// A non-cascade (RESTRICT) child must be EXCLUDED by CascadeConstraintsInIndex —
+	// pins the delete_rule/update_rule = 'CASCADE' filter against being too permissive.
+	testutil.MustExec(t, sourceDB, `CREATE TABLE child_restrict (
+		id  INT PRIMARY KEY,
+		pid INT,
+		CONSTRAINT fk_restrict FOREIGN KEY (pid) REFERENCES parent(id) ON DELETE RESTRICT ON UPDATE RESTRICT
 	) ENGINE=InnoDB`)
 
 	if _, err := TakeSnapshot(sourceDB, indexDB, []string{sourceName}); err != nil {
@@ -48,10 +56,15 @@ func TestTakeSnapshotCapturesFKRules(t *testing.T) {
 		t.Fatalf("CascadeConstraintsInIndex: %v", err)
 	}
 	if len(edges) != 1 {
-		t.Fatalf("want 1 cascade edge, got %d: %+v", len(edges), edges)
+		t.Fatalf("want exactly 1 cascade edge (RESTRICT child excluded), got %d: %+v", len(edges), edges)
 	}
 	if edges[0].Table != "child" || edges[0].DeleteRule != "CASCADE" || edges[0].ReferencedTable != "parent" {
 		t.Errorf("unexpected cascade edge: %+v", edges[0])
+	}
+	for _, e := range edges {
+		if e.Table == "child_restrict" {
+			t.Errorf("RESTRICT-only child must be excluded, but appeared: %+v", e)
+		}
 	}
 
 	// An unrelated schema yields no cascade edges.
@@ -404,8 +417,14 @@ func TestValidateNoFKCascades_cascade(t *testing.T) {
 		CONSTRAINT fk_order FOREIGN KEY (order_id) REFERENCES orders(id) ON DELETE CASCADE
 	)`)
 
-	if err := ValidateNoFKCascades(db, []string{dbName}); err == nil {
+	err := ValidateNoFKCascades(db, []string{dbName})
+	if err == nil {
 		t.Fatal("expected error for schema with FK cascade, got nil")
+	}
+	// The cascade finding must be wrapped in ErrFKCascadesFound so call sites can
+	// errors.Is it apart from an operational query failure (which must still abort).
+	if !errors.Is(err, ErrFKCascadesFound) {
+		t.Errorf("cascade error must wrap ErrFKCascadesFound, got: %v", err)
 	}
 }
 

--- a/internal/metadata/metadata_integration_test.go
+++ b/internal/metadata/metadata_integration_test.go
@@ -10,6 +10,60 @@ import (
 	"github.com/dbtrail/dbtrail/internal/testutil"
 )
 
+// TestTakeSnapshotCapturesFKRules pins cascade-recovery Slice A: a snapshot of
+// a cascade schema records each FK's delete_rule/update_rule in fk_constraints,
+// and CascadeConstraintsInIndex surfaces the CASCADE edge for the source-less
+// recover-time warning.
+func TestTakeSnapshotCapturesFKRules(t *testing.T) {
+	sourceDB, sourceName := testutil.CreateTestDB(t)
+	indexDB, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, indexDB)
+
+	testutil.MustExec(t, sourceDB, `CREATE TABLE parent (id INT PRIMARY KEY) ENGINE=InnoDB`)
+	testutil.MustExec(t, sourceDB, `CREATE TABLE child (
+		id  INT PRIMARY KEY,
+		pid INT,
+		CONSTRAINT fk_child FOREIGN KEY (pid) REFERENCES parent(id) ON DELETE CASCADE ON UPDATE CASCADE
+	) ENGINE=InnoDB`)
+
+	if _, err := TakeSnapshot(sourceDB, indexDB, []string{sourceName}); err != nil {
+		t.Fatalf("TakeSnapshot: %v", err)
+	}
+
+	var del, upd string
+	if err := indexDB.QueryRow(`SELECT delete_rule, update_rule FROM fk_constraints
+		WHERE schema_name = ? AND table_name = 'child' AND column_name = 'pid'`,
+		sourceName).Scan(&del, &upd); err != nil {
+		t.Fatalf("read fk_constraints rule: %v", err)
+	}
+	if del != "CASCADE" {
+		t.Errorf("delete_rule = %q, want CASCADE", del)
+	}
+	if upd != "CASCADE" {
+		t.Errorf("update_rule = %q, want CASCADE", upd)
+	}
+
+	edges, err := CascadeConstraintsInIndex(indexDB, []string{sourceName})
+	if err != nil {
+		t.Fatalf("CascadeConstraintsInIndex: %v", err)
+	}
+	if len(edges) != 1 {
+		t.Fatalf("want 1 cascade edge, got %d: %+v", len(edges), edges)
+	}
+	if edges[0].Table != "child" || edges[0].DeleteRule != "CASCADE" || edges[0].ReferencedTable != "parent" {
+		t.Errorf("unexpected cascade edge: %+v", edges[0])
+	}
+
+	// An unrelated schema yields no cascade edges.
+	none, err := CascadeConstraintsInIndex(indexDB, []string{"nonexistent_schema"})
+	if err != nil {
+		t.Fatalf("CascadeConstraintsInIndex(none): %v", err)
+	}
+	if len(none) != 0 {
+		t.Errorf("want 0 edges for an unrelated schema, got %d", len(none))
+	}
+}
+
 func TestTakeSnapshot_nonInnoDB(t *testing.T) {
 	sourceDB, sourceName := testutil.CreateTestDB(t)
 	indexDB, _ := testutil.CreateTestDB(t)

--- a/internal/streamrun/streamrun.go
+++ b/internal/streamrun/streamrun.go
@@ -1260,6 +1260,9 @@ func One(ctx context.Context, cfg Config) error {
 	fmt.Println("Source: binlog_row_image=FULL \u2713")
 
 	if err := cfg.Deps.ValidateNoFKCascades(sourceDB, cfg.Deps.ParseSchemaList(cfg.Schemas)); err != nil {
+		if !errors.Is(err, metadata.ErrFKCascadesFound) {
+			return err // genuine query/connection failure: abort as before
+		}
 		slog.Warn("FK cascade constraints present on source; streaming will proceed, "+
 			"but InnoDB executes cascades below the binlog (MySQL Bug #32506) so cascaded "+
 			"child-row deletes are NOT captured \u2014 plain `recover` cannot restore them. "+

--- a/internal/streamrun/streamrun.go
+++ b/internal/streamrun/streamrun.go
@@ -1260,9 +1260,14 @@ func One(ctx context.Context, cfg Config) error {
 	fmt.Println("Source: binlog_row_image=FULL \u2713")
 
 	if err := cfg.Deps.ValidateNoFKCascades(sourceDB, cfg.Deps.ParseSchemaList(cfg.Schemas)); err != nil {
-		return err
+		slog.Warn("FK cascade constraints present on source; streaming will proceed, "+
+			"but InnoDB executes cascades below the binlog (MySQL Bug #32506) so cascaded "+
+			"child-row deletes are NOT captured \u2014 plain `recover` cannot restore them. "+
+			"Cascade recovery is in progress (#548).",
+			"detail", err.Error())
+	} else {
+		fmt.Println("Source: no FK cascades \u2713")
 	}
-	fmt.Println("Source: no FK cascades \u2713")
 
 	// Advisory only: warn (never block) when the declared flavor disagrees with
 	// the server's actual VERSION(). A mismatch \u2014 e.g. the default --source-flavor

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -355,6 +355,8 @@ func InitIndexTables(t *testing.T, db *sql.DB) {
 		referenced_schema_name   VARCHAR(64)  NOT NULL,
 		referenced_table_name    VARCHAR(64)  NOT NULL,
 		referenced_column_name   VARCHAR(64)  NOT NULL,
+		delete_rule              VARCHAR(16)  NOT NULL DEFAULT '',
+		update_rule              VARCHAR(16)  NOT NULL DEFAULT '',
 		PRIMARY KEY (snapshot_id, schema_name, constraint_name, ordinal_position)
 	) ENGINE=InnoDB`)
 

--- a/migrations/001_create_tables.sql
+++ b/migrations/001_create_tables.sql
@@ -90,6 +90,8 @@ CREATE TABLE IF NOT EXISTS fk_constraints (
     referenced_schema_name   VARCHAR(64)  NOT NULL,
     referenced_table_name    VARCHAR(64)  NOT NULL,
     referenced_column_name   VARCHAR(64)  NOT NULL,
+    delete_rule              VARCHAR(16)  NOT NULL DEFAULT '' COMMENT 'ON DELETE rule (CASCADE/RESTRICT/SET NULL/NO ACTION); empty for pre-cascade-recovery snapshots',
+    update_rule              VARCHAR(16)  NOT NULL DEFAULT '' COMMENT 'ON UPDATE rule; empty for pre-cascade-recovery snapshots',
     PRIMARY KEY (snapshot_id, schema_name, constraint_name, ordinal_position)
 ) ENGINE=InnoDB;
 -- One row per FK column mapping. Composite FKs produce multiple rows with


### PR DESCRIPTION
## What

Cascade-recovery **Slice A** (precondition). Closes #549. Part of #548.

Two changes that unblock the cascade-recovery synthesis engine (#550):

### 1. Persist FK referential rules in the index
`fk_constraints` stored the FK column graph but not the action rule, so at recovery time bintrail couldn't tell which edges are `ON DELETE CASCADE`. Since `recover` is **source-less**, the rule must live in the index (it can't be re-queried from the source at recovery time).

- `fk_constraints` gains `delete_rule` / `update_rule` (`VARCHAR(16) NOT NULL DEFAULT ''`) in `migrations/001`, `indexer/schema.go`, and the testutil mirror.
- Idempotent `EnsureSchema` migration adds the columns on existing indexes — **guarded by a `tableExists` check** so it doesn't break very old indexes that predate the `fk_constraints` table (`TakeSnapshot` already tolerates its absence).
- Captured in `TakeSnapshot` → `queryFKConstraints` (both SELECTs + scan + batch INSERT now carry the two rules).
- `delete_rule == ''` (pre-cascade-recovery snapshots) is treated as non-cascade — safe.

### 2. Soften the FK-cascade guard (refuse → warn)
`ValidateNoFKCascades` previously **refused** `index --source-dsn` and `stream` (which couldn't bypass it at all), so a cascade schema couldn't even be indexed through the FK-capturing path.

- The **detector** `ValidateNoFKCascades` is unchanged (still returns the error; its tests still pass). Policy moved to the call sites: `index`/`stream` now **warn and proceed**.
- Plain `recover` warns when the target schema carries cascade FKs, read from the index via the new `metadata.CascadeConstraintsInIndex`.
- `doctor` remediation text + `docs/indexing.md` + `docs/query-and-recovery.md` updated (the old "ingestion refuses cascade" claim is now false). Warnings describe the limitation and reference #548 — they do **not** promise a command that doesn't exist yet (Slice C).

## Tests (integration, vs MySQL 8.0)
- `TestTakeSnapshotCapturesFKRules` — snapshot of a cascade schema records `delete_rule=CASCADE`/`update_rule=CASCADE`; `CascadeConstraintsInIndex` surfaces the edge; unrelated schema → no edges.
- `TestEnsureSchemaAddsFKRuleColumns` — pre-cascade install gains both columns `NOT NULL DEFAULT ''`, existing rows backfill to `''`, idempotent.
- `TestEnsureSchemaToleratesMissingFKConstraints` — `EnsureSchema` tolerates a dropped `fk_constraints` table (old-index regression guard).

Full unit suite + integration (metadata, indexer, cli, streamrun, doctor, cascade) green.

## Not in this PR
The synthesis engine spike (`internal/cascade/`) is left untracked — it belongs to Slice B (#550), which productionizes it to read these rules from the index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
