### PR TITLE
feat: cascade synthesis engine reads FK rules from the index (#550 cascade-recovery slice B)

### DIFF
--- a/internal/cascade/cascade.go
+++ b/internal/cascade/cascade.go
@@ -1,0 +1,304 @@
+// Package cascade reconstructs child rows that an InnoDB foreign-key
+// ON DELETE CASCADE removed but never wrote to the binary log.
+//
+// On MySQL ≤ 8.x (and all MariaDB) InnoDB enforces FK cascades inside the
+// storage engine, below the SQL layer that writes the binlog — only the parent
+// DELETE is logged, the cascaded child deletes are invisible (MySQL Bug
+// #32506, manual §17.19; fixed only in MySQL 9.6 via WL#11249, reversible with
+// innodb_native_foreign_keys). So bintrail's binlog index has no before-image
+// for the cascaded children and the normal delta-only `recover` has nothing to
+// reverse.
+//
+// The reconstruction insight (from the dbtrail SaaS, issue nethalo/dbtrail#1291):
+// the cascade is deterministic, so "what did the cascade delete?" has the same
+// answer as "what child rows pointed at the parent in their latest known
+// row_after immediately before the parent DELETE?" — and that last row_after IS
+// indexed (the child INSERTs/UPDATEs were logged; only the cascade delete was
+// not). We synthesize a DELETE event whose RowBefore is that last row_after, so
+// the existing recovery generator turns it into a restoring INSERT with no new
+// SQL path.
+//
+// This is a spike (drafts/cascade-recovery-port-2026-06-21.md): Phase-1,
+// binlog-history only, no baseline fallback yet.
+package cascade
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/event"
+	"github.com/dbtrail/dbtrail/internal/query"
+)
+
+// CascadeFK is one foreign-key edge plus its referential delete action.
+//
+// It is loaded from the index's fk_constraints table (LoadCascadeFKs), which
+// since the cascade-recovery Slice A migration carries delete_rule/update_rule.
+// `recover` never connects to the source, so the rule must come from the index.
+type CascadeFK struct {
+	Schema           string // child (dependent) schema
+	Table            string // child table
+	ConstraintName   string // FK constraint name (one CascadeFK per column; composite FKs share it)
+	Column           string // child FK column
+	ReferencedSchema string // parent schema
+	ReferencedTable  string // parent table
+	ReferencedColumn string // parent referenced column (usually its PK)
+	DeleteRule       string // CASCADE, RESTRICT, SET NULL, NO ACTION
+	UpdateRule       string // ON UPDATE rule
+}
+
+// Options tunes the synthesis. Zero values fall back to the dbtrail SaaS
+// constants via withDefaults.
+type Options struct {
+	Lookback       time.Duration // how far before the parent delete to look for child state
+	MaxDepth       int           // multi-level cascade recursion cap
+	CandidateLimit int           // max child candidate rows per (parent event, FK)
+}
+
+func (o Options) withDefaults() Options {
+	if o.Lookback == 0 {
+		o.Lookback = 30 * 24 * time.Hour // CASCADE_LOOKBACK_DAYS=30
+	}
+	if o.MaxDepth == 0 {
+		o.MaxDepth = 5 // FK_MAX_DEPTH=5
+	}
+	if o.CandidateLimit == 0 {
+		o.CandidateLimit = 1000 // CASCADE_VICTIM_CANDIDATE_LIMIT=1000
+	}
+	return o
+}
+
+// SynthesizeVictims reconstructs the cascade-deleted children for a set of
+// parent DELETE events. It returns synthetic DELETE rows (RowBefore = each
+// child's last known state) ready to feed recovery.GenerateSQLFromRows, plus
+// best-effort warnings.
+//
+// It recurses: synthetic victims become the next layer's parents, so a
+// parent→child→grandchild cascade is fully reconstructed, bounded by MaxDepth
+// and a per-(table,pk) visited guard that also breaks self-referencing-FK cycles.
+func SynthesizeVictims(
+	ctx context.Context,
+	eng *query.Engine,
+	fks []CascadeFK,
+	parentDeletes []query.ResultRow,
+	opts Options,
+) (victims []query.ResultRow, warnings []string, err error) {
+	opts = opts.withDefaults()
+
+	// Count columns per constraint so composite (multi-column) FKs can be
+	// detected: the single-column victim match below would mis-reconstruct them
+	// (matching on one column of a multi-column key), so we skip+warn rather
+	// than silently corrupt — the cardinal sin for a recovery tool.
+	colsPerConstraint := map[string]int{}
+	for _, fk := range fks {
+		colsPerConstraint[fk.Schema+"."+fk.Table+"."+fk.ConstraintName]++
+	}
+
+	// Index CASCADE edges by the parent (referenced) table they protect.
+	// Gate on DeleteRule == "CASCADE" ONLY: dbtrail conflates delete_rule/
+	// update_rule (data_plane_router.py:2793), which runs DELETE synthesis on
+	// ON UPDATE CASCADE edges — a bug we deliberately do not port.
+	byParent := map[string][]CascadeFK{}
+	warnedComposite := map[string]bool{}
+	for _, fk := range fks {
+		if fk.DeleteRule != "CASCADE" {
+			continue
+		}
+		ckey := fk.Schema + "." + fk.Table + "." + fk.ConstraintName
+		if colsPerConstraint[ckey] > 1 {
+			if !warnedComposite[ckey] {
+				warnedComposite[ckey] = true
+				warnings = append(warnings, fmt.Sprintf(
+					"composite FK %q on %s.%s not supported; its cascade-deleted rows were NOT reconstructed",
+					fk.ConstraintName, fk.Schema, fk.Table))
+			}
+			continue
+		}
+		byParent[fk.ReferencedSchema+"."+fk.ReferencedTable] = append(
+			byParent[fk.ReferencedSchema+"."+fk.ReferencedTable], fk)
+	}
+
+	visited := map[string]bool{} // "schema.table|pkvalues" → processed
+
+	// The cascade fires atomically at the ROOT delete's timestamp T, so every
+	// descendant existed at T and the lookback window must end at T for EVERY
+	// level — not at each victim's own last-modified time, which is ≤ T and
+	// would shrink the window deeper in the chain (missing a grandchild updated
+	// after its parent's last event, and skewing the re-parented check). Each
+	// layer item therefore carries the originating root T down the recursion.
+	type layerItem struct {
+		ev     query.ResultRow
+		rootTS time.Time
+	}
+	layer := make([]layerItem, 0, len(parentDeletes))
+	for _, pd := range parentDeletes {
+		layer = append(layer, layerItem{ev: pd, rootTS: pd.EventTimestamp})
+	}
+
+	for depth := 0; depth < opts.MaxDepth && len(layer) > 0; depth++ {
+		var next []layerItem
+		for _, item := range layer {
+			pev := item.ev
+			pkey := pev.SchemaName + "." + pev.TableName + "|" + pev.PKValues
+			if visited[pkey] {
+				continue
+			}
+			visited[pkey] = true
+
+			// The deleted parent's image. Synthetic victims carry their last
+			// row_after here too, which is what makes the recursion work.
+			parentRow := pev.RowBefore
+			if parentRow == nil {
+				continue
+			}
+
+			since := item.rootTS.Add(-opts.Lookback)
+			until := item.rootTS
+
+			for _, fk := range byParent[pev.SchemaName+"."+pev.TableName] {
+				refVal, ok := parentRow[fk.ReferencedColumn]
+				if !ok {
+					continue
+				}
+				parentPK := valToString(refVal)
+
+				// Latest event per child PK that referenced this parent in the
+				// lookback window. LimitPerPK=1 picks the newest per pk_values
+				// (event_timestamp DESC, event_id DESC).
+				cands, qerr := eng.Fetch(ctx, query.Options{
+					Schema:     fk.Schema,
+					Table:      fk.Table,
+					ColumnEq:   []query.ColumnEq{{Column: fk.Column, Value: parentPK}},
+					Since:      &since,
+					Until:      &until,
+					Order:      "DESC",
+					LimitPerPK: 1,
+					Limit:      opts.CandidateLimit,
+				})
+				if qerr != nil {
+					warnings = append(warnings, fmt.Sprintf(
+						"victim query failed for %s.%s via %s=%s: %v",
+						fk.Schema, fk.Table, fk.Column, parentPK, qerr))
+					continue
+				}
+				if len(cands) >= opts.CandidateLimit {
+					warnings = append(warnings, fmt.Sprintf(
+						"victim candidates hit the %d-row cap for %s.%s; some victims may be missed",
+						opts.CandidateLimit, fk.Schema, fk.Table))
+				}
+
+				for _, cev := range cands {
+					switch {
+					case cev.EventType == event.EventDelete:
+						// Already gone before the cascade fired.
+						continue
+					case cev.RowAfter == nil:
+						// No post-image to restore (index/parser anomaly).
+						continue
+					case valToString(cev.RowAfter[fk.Column]) != parentPK:
+						// Re-parented before the delete → it survived.
+						continue
+					}
+					victim := query.ResultRow{
+						EventTimestamp: cev.EventTimestamp,
+						SchemaName:     fk.Schema,
+						TableName:      fk.Table,
+						EventType:      event.EventDelete,
+						PKValues:       cev.PKValues,
+						RowBefore:      cev.RowAfter, // last known state → INSERT target
+					}
+					victims = append(victims, victim)
+					// May itself be a parent (grandchildren); keep the SAME root T.
+					next = append(next, layerItem{ev: victim, rootTS: item.rootTS})
+				}
+			}
+		}
+		if depth == opts.MaxDepth-1 && len(next) > 0 {
+			warnings = append(warnings, fmt.Sprintf(
+				"recursion hit MaxDepth=%d; deeper victims (if any) not reconstructed", opts.MaxDepth))
+		}
+		layer = next
+	}
+	return victims, warnings, nil
+}
+
+// LoadCascadeFKs reads the FK graph WITH referential rules from the INDEX's
+// fk_constraints table (the latest snapshot that recorded FKs), optionally
+// scoped to schemas. It returns every FK edge — SynthesizeVictims gates on
+// DeleteRule itself — so it is also the loader a future SET NULL path uses.
+//
+// Source-less by design: `recover` never connects to the source, so the rules
+// come from the index (populated at snapshot time since cascade-recovery Slice
+// A). Pre-Slice-A snapshots whose delete_rule/update_rule are empty load as
+// non-cascade and are simply skipped by the synthesis.
+//
+// LIMITATION: the FK graph is taken from the LATEST snapshot that recorded FKs,
+// not the one in effect at the delete being recovered. If DDL changed the FK
+// topology between the delete and the latest snapshot, synthesis uses the newer
+// graph. Matching the FK graph to event time is deferred (see #548); acceptable
+// because cascade DDL churn mid-recovery-window is rare and the FK-checks-off
+// apply tolerates over-/under-inclusion that the operator reviews.
+func LoadCascadeFKs(ctx context.Context, indexDB *sql.DB, schemas []string) ([]CascadeFK, error) {
+	query := `SELECT schema_name, table_name, constraint_name, column_name,
+	       referenced_schema_name, referenced_table_name, referenced_column_name,
+	       delete_rule, update_rule
+	FROM fk_constraints
+	WHERE snapshot_id = (SELECT MAX(snapshot_id) FROM fk_constraints)`
+	var args []any
+	if len(schemas) > 0 {
+		placeholders := strings.TrimRight(strings.Repeat("?,", len(schemas)), ",")
+		query += " AND schema_name IN (" + placeholders + ")"
+		for _, s := range schemas {
+			args = append(args, s)
+		}
+	}
+	query += " ORDER BY schema_name, table_name, constraint_name, ordinal_position"
+
+	rows, err := indexDB.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("load cascade FKs from index: %w", err)
+	}
+	defer rows.Close()
+	var out []CascadeFK
+	for rows.Next() {
+		var fk CascadeFK
+		if err := rows.Scan(&fk.Schema, &fk.Table, &fk.ConstraintName, &fk.Column,
+			&fk.ReferencedSchema, &fk.ReferencedTable, &fk.ReferencedColumn,
+			&fk.DeleteRule, &fk.UpdateRule); err != nil {
+			return nil, fmt.Errorf("scan cascade FK row: %w", err)
+		}
+		out = append(out, fk)
+	}
+	return out, rows.Err()
+}
+
+// valToString renders a JSON-decoded value the way MySQL's
+// JSON_UNQUOTE(JSON_EXTRACT(...)) does, so comparisons line up with the
+// ColumnEq SQL. JSON numbers arrive as float64; integral ones must print
+// without a decimal point (1, not 1.0) to match an INT FK column.
+func valToString(v any) string {
+	switch x := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return x
+	case float64:
+		if x == float64(int64(x)) {
+			return strconv.FormatInt(int64(x), 10)
+		}
+		return strconv.FormatFloat(x, 'f', -1, 64)
+	case bool:
+		if x {
+			return "1"
+		}
+		return "0"
+	case []byte:
+		return string(x)
+	default:
+		return fmt.Sprintf("%v", x)
+	}
+}

--- a/internal/cascade/cascade.go
+++ b/internal/cascade/cascade.go
@@ -18,13 +18,16 @@
 // the existing recovery generator turns it into a restoring INSERT with no new
 // SQL path.
 //
-// This is a spike (drafts/cascade-recovery-port-2026-06-21.md): Phase-1,
-// binlog-history only, no baseline fallback yet.
+// Scope: Phase-1, binlog-history only — no baseline fallback yet, so a child
+// untouched within the lookback window is not reconstructed (Phase-2 baseline
+// fallback is deferred, #548). Design: drafts/cascade-recovery-port-2026-06-21.md.
 package cascade
 
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -72,26 +75,64 @@ func (o Options) withDefaults() Options {
 	return o
 }
 
+// Result is the outcome of cascade synthesis. Victims are the synthetic DELETE
+// rows to feed recovery.GenerateSQLFromRows. Incomplete lists every reason the
+// reconstruction may be partial (composite FKs skipped, depth/candidate caps
+// hit, index anomalies, DDL-skew). For a recovery tool the caller MUST treat a
+// non-empty Incomplete as "this recovery is provably partial" and surface it —
+// never apply it as if complete. A non-nil error from SynthesizeVictims is an
+// operational failure (e.g. an index query failed) that ALSO leaves Victims
+// partial; it is reported in Incomplete too, so checking either suffices.
+type Result struct {
+	Victims    []query.ResultRow
+	Incomplete []string
+}
+
+// Complete reports whether the reconstruction covered everything it could find.
+func (r Result) Complete() bool { return len(r.Incomplete) == 0 }
+
 // SynthesizeVictims reconstructs the cascade-deleted children for a set of
 // parent DELETE events. It returns synthetic DELETE rows (RowBefore = each
-// child's last known state) ready to feed recovery.GenerateSQLFromRows, plus
-// best-effort warnings.
+// child's last known state) ready to feed recovery.GenerateSQLFromRows.
 //
 // It recurses: synthetic victims become the next layer's parents, so a
 // parent→child→grandchild cascade is fully reconstructed, bounded by MaxDepth
-// and a per-(table,pk) visited guard that also breaks self-referencing-FK cycles.
+// and a per-(table,pk) visited guard that also breaks self-referencing-FK
+// cycles. Multi-path cascades (diamonds, multiple FKs to the same parent) emit
+// each victim once via an emitted set, so recovery never double-INSERTs a PK.
+//
+// Coverage is best-effort: every gap is recorded in Result.Incomplete, and an
+// operational query failure additionally returns a non-nil error. The caller
+// must not present a partial Result as a complete recovery.
 func SynthesizeVictims(
 	ctx context.Context,
 	eng *query.Engine,
 	fks []CascadeFK,
 	parentDeletes []query.ResultRow,
 	opts Options,
-) (victims []query.ResultRow, warnings []string, err error) {
+) (Result, error) {
 	opts = opts.withDefaults()
+
+	var (
+		victims    []query.ResultRow
+		incomplete []string
+		errs       []error
+	)
+	// addIncomplete records a coverage caveat once per distinct key, so a wide
+	// cascade (many parent×FK iterations) cannot flood the list with near-
+	// identical strings and bury the important ones.
+	reported := map[string]bool{}
+	addIncomplete := func(key, msg string) {
+		if reported[key] {
+			return
+		}
+		reported[key] = true
+		incomplete = append(incomplete, msg)
+	}
 
 	// Count columns per constraint so composite (multi-column) FKs can be
 	// detected: the single-column victim match below would mis-reconstruct them
-	// (matching on one column of a multi-column key), so we skip+warn rather
+	// (matching on one column of a multi-column key), so we skip+flag rather
 	// than silently corrupt — the cardinal sin for a recovery tool.
 	colsPerConstraint := map[string]int{}
 	for _, fk := range fks {
@@ -103,33 +144,31 @@ func SynthesizeVictims(
 	// update_rule (data_plane_router.py:2793), which runs DELETE synthesis on
 	// ON UPDATE CASCADE edges — a bug we deliberately do not port.
 	byParent := map[string][]CascadeFK{}
-	warnedComposite := map[string]bool{}
 	for _, fk := range fks {
 		if fk.DeleteRule != "CASCADE" {
 			continue
 		}
 		ckey := fk.Schema + "." + fk.Table + "." + fk.ConstraintName
 		if colsPerConstraint[ckey] > 1 {
-			if !warnedComposite[ckey] {
-				warnedComposite[ckey] = true
-				warnings = append(warnings, fmt.Sprintf(
-					"composite FK %q on %s.%s not supported; its cascade-deleted rows were NOT reconstructed",
-					fk.ConstraintName, fk.Schema, fk.Table))
-			}
+			addIncomplete("composite:"+ckey, fmt.Sprintf(
+				"composite FK %q on %s.%s not supported; its cascade-deleted rows were NOT reconstructed",
+				fk.ConstraintName, fk.Schema, fk.Table))
 			continue
 		}
 		byParent[fk.ReferencedSchema+"."+fk.ReferencedTable] = append(
 			byParent[fk.ReferencedSchema+"."+fk.ReferencedTable], fk)
 	}
 
-	visited := map[string]bool{} // "schema.table|pkvalues" → processed
+	visited := map[string]bool{} // "schema.table|pkvalues" → processed as a parent
+	emitted := map[string]bool{} // "schema.table|pkvalues" → already emitted as a victim
 
 	// The cascade fires atomically at the ROOT delete's timestamp T, so every
 	// descendant existed at T and the lookback window must end at T for EVERY
 	// level — not at each victim's own last-modified time, which is ≤ T and
 	// would shrink the window deeper in the chain (missing a grandchild updated
 	// after its parent's last event, and skewing the re-parented check). Each
-	// layer item therefore carries the originating root T down the recursion.
+	// layer item therefore carries the originating root T down the recursion;
+	// distinct root deletes keep their own T.
 	type layerItem struct {
 		ev     query.ResultRow
 		rootTS time.Time
@@ -153,6 +192,12 @@ func SynthesizeVictims(
 			// row_after here too, which is what makes the recursion work.
 			parentRow := pev.RowBefore
 			if parentRow == nil {
+				// A DELETE always has a before-image under binlog_row_image=FULL,
+				// so a nil here is an index/parser anomaly — the whole subtree
+				// under this parent goes unreconstructed. Never silent.
+				addIncomplete("noparent:"+pev.SchemaName+"."+pev.TableName, fmt.Sprintf(
+					"parent %s.%s pk=%s has no before-image; its cascade subtree was NOT reconstructed",
+					pev.SchemaName, pev.TableName, pev.PKValues))
 				continue
 			}
 
@@ -162,13 +207,21 @@ func SynthesizeVictims(
 			for _, fk := range byParent[pev.SchemaName+"."+pev.TableName] {
 				refVal, ok := parentRow[fk.ReferencedColumn]
 				if !ok {
+					// The FK graph (latest snapshot) names a referenced column
+					// absent from this parent row — the DDL-skew limitation made
+					// real (a renamed/dropped parent key). Drop, but never silent.
+					addIncomplete("noref:"+fk.Schema+"."+fk.Table+"."+fk.ConstraintName, fmt.Sprintf(
+						"FK %q references column %q absent from %s.%s rows (schema changed since snapshot); its cascade-deleted rows were NOT reconstructed",
+						fk.ConstraintName, fk.ReferencedColumn, fk.ReferencedSchema, fk.ReferencedTable))
 					continue
 				}
 				parentPK := valToString(refVal)
 
-				// Latest event per child PK that referenced this parent in the
-				// lookback window. LimitPerPK=1 picks the newest per pk_values
-				// (event_timestamp DESC, event_id DESC).
+				// Latest event per child PK that referenced this parent within the
+				// lookback window. LimitPerPK=1 keeps the timestamp-latest event
+				// per pk_values. Fetch one MORE than CandidateLimit so an overflow
+				// is observable — with LimitPerPK=1 a plain LIMIT=CandidateLimit
+				// caps at exactly the limit and hides truncation.
 				cands, qerr := eng.Fetch(ctx, query.Options{
 					Schema:     fk.Schema,
 					Table:      fk.Table,
@@ -177,18 +230,24 @@ func SynthesizeVictims(
 					Until:      &until,
 					Order:      "DESC",
 					LimitPerPK: 1,
-					Limit:      opts.CandidateLimit,
+					Limit:      opts.CandidateLimit + 1,
 				})
 				if qerr != nil {
-					warnings = append(warnings, fmt.Sprintf(
-						"victim query failed for %s.%s via %s=%s: %v",
+					// Operational failure: we never learned whether victims
+					// existed, so the result is provably partial. Record it AND
+					// return a non-nil error so the caller cannot apply a partial
+					// recovery as if complete. Accumulate, don't abort the batch.
+					errs = append(errs, fmt.Errorf("victim query failed for %s.%s via %s=%s: %w",
 						fk.Schema, fk.Table, fk.Column, parentPK, qerr))
+					addIncomplete("queryfail:"+fk.Schema+"."+fk.Table+"."+fk.Column, fmt.Sprintf(
+						"victim query for %s.%s failed (recovery is partial): %v", fk.Schema, fk.Table, qerr))
 					continue
 				}
-				if len(cands) >= opts.CandidateLimit {
-					warnings = append(warnings, fmt.Sprintf(
-						"victim candidates hit the %d-row cap for %s.%s; some victims may be missed",
-						opts.CandidateLimit, fk.Schema, fk.Table))
+				if len(cands) > opts.CandidateLimit {
+					addIncomplete("truncate:"+fk.Schema+"."+fk.Table, fmt.Sprintf(
+						"%s.%s has more than %d cascade victims for one parent; the excess (and their descendants) were NOT reconstructed",
+						fk.Schema, fk.Table, opts.CandidateLimit))
+					cands = cands[:opts.CandidateLimit]
 				}
 
 				for _, cev := range cands {
@@ -197,12 +256,24 @@ func SynthesizeVictims(
 						// Already gone before the cascade fired.
 						continue
 					case cev.RowAfter == nil:
-						// No post-image to restore (index/parser anomaly).
+						// Non-DELETE with no post-image: an anomaly under FULL —
+						// flag rather than drop a recoverable row silently.
+						addIncomplete("noafter:"+fk.Schema+"."+fk.Table, fmt.Sprintf(
+							"%s.%s has events with no post-image (index anomaly); some victims may not be reconstructed",
+							fk.Schema, fk.Table))
 						continue
 					case valToString(cev.RowAfter[fk.Column]) != parentPK:
 						// Re-parented before the delete → it survived.
 						continue
 					}
+					vkey := fk.Schema + "." + fk.Table + "|" + cev.PKValues
+					if emitted[vkey] {
+						// Reached via another cascade path (diamond / multiple FKs
+						// to the same parent); emit once so recovery never
+						// double-INSERTs the PK.
+						continue
+					}
+					emitted[vkey] = true
 					victim := query.ResultRow{
 						EventTimestamp: cev.EventTimestamp,
 						SchemaName:     fk.Schema,
@@ -218,12 +289,12 @@ func SynthesizeVictims(
 			}
 		}
 		if depth == opts.MaxDepth-1 && len(next) > 0 {
-			warnings = append(warnings, fmt.Sprintf(
-				"recursion hit MaxDepth=%d; deeper victims (if any) not reconstructed", opts.MaxDepth))
+			addIncomplete("depth", fmt.Sprintf(
+				"recursion hit MaxDepth=%d; deeper cascade victims were NOT reconstructed", opts.MaxDepth))
 		}
 		layer = next
 	}
-	return victims, warnings, nil
+	return Result{Victims: victims, Incomplete: incomplete}, errors.Join(errs...)
 }
 
 // LoadCascadeFKs reads the FK graph WITH referential rules from the INDEX's
@@ -243,7 +314,7 @@ func SynthesizeVictims(
 // because cascade DDL churn mid-recovery-window is rare and the FK-checks-off
 // apply tolerates over-/under-inclusion that the operator reviews.
 func LoadCascadeFKs(ctx context.Context, indexDB *sql.DB, schemas []string) ([]CascadeFK, error) {
-	query := `SELECT schema_name, table_name, constraint_name, column_name,
+	q := `SELECT schema_name, table_name, constraint_name, column_name,
 	       referenced_schema_name, referenced_table_name, referenced_column_name,
 	       delete_rule, update_rule
 	FROM fk_constraints
@@ -251,14 +322,14 @@ func LoadCascadeFKs(ctx context.Context, indexDB *sql.DB, schemas []string) ([]C
 	var args []any
 	if len(schemas) > 0 {
 		placeholders := strings.TrimRight(strings.Repeat("?,", len(schemas)), ",")
-		query += " AND schema_name IN (" + placeholders + ")"
+		q += " AND schema_name IN (" + placeholders + ")"
 		for _, s := range schemas {
 			args = append(args, s)
 		}
 	}
-	query += " ORDER BY schema_name, table_name, constraint_name, ordinal_position"
+	q += " ORDER BY schema_name, table_name, constraint_name, ordinal_position"
 
-	rows, err := indexDB.QueryContext(ctx, query, args...)
+	rows, err := indexDB.QueryContext(ctx, q, args...)
 	if err != nil {
 		return nil, fmt.Errorf("load cascade FKs from index: %w", err)
 	}
@@ -278,24 +349,31 @@ func LoadCascadeFKs(ctx context.Context, indexDB *sql.DB, schemas []string) ([]C
 
 // valToString renders a JSON-decoded value the way MySQL's
 // JSON_UNQUOTE(JSON_EXTRACT(...)) does, so comparisons line up with the
-// ColumnEq SQL. JSON numbers arrive as float64; integral ones must print
-// without a decimal point (1, not 1.0) to match an INT FK column.
+// ColumnEq SQL. The index read path decodes JSON numbers as json.Number
+// (UseNumber, #496, to preserve BIGINTs > 2^53), so that is the production type
+// for values from RowBefore/RowAfter; float64 is handled too for callers that
+// build maps with plain numeric literals.
 func valToString(v any) string {
 	switch x := v.(type) {
 	case nil:
 		return ""
 	case string:
 		return x
+	case json.Number:
+		return x.String()
 	case float64:
+		// Integral values must print without a decimal point (1, not 1.0) to
+		// match an INT FK column rendered by JSON_UNQUOTE.
 		if x == float64(int64(x)) {
 			return strconv.FormatInt(int64(x), 10)
 		}
 		return strconv.FormatFloat(x, 'f', -1, 64)
 	case bool:
+		// JSON_UNQUOTE(JSON_EXTRACT(...)) of a JSON boolean yields "true"/"false".
 		if x {
-			return "1"
+			return "true"
 		}
-		return "0"
+		return "false"
 	case []byte:
 		return string(x)
 	default:

--- a/internal/cascade/cascade_cases_integration_test.go
+++ b/internal/cascade/cascade_cases_integration_test.go
@@ -119,13 +119,13 @@ func TestSynthesizeVictims_ruleGate(t *testing.T) {
 			ReferencedSchema: "app", ReferencedTable: "parent", ReferencedColumn: "id",
 			DeleteRule: "RESTRICT", UpdateRule: "CASCADE"}, // ON UPDATE CASCADE only
 	}
-	victims, _, err := cascade.SynthesizeVictims(context.Background(), eng, fks,
+	res, err := cascade.SynthesizeVictims(context.Background(), eng, fks,
 		[]query.ResultRow{parentDel}, cascade.Options{})
 	if err != nil {
 		t.Fatalf("SynthesizeVictims: %v", err)
 	}
-	if len(victims) != 0 {
-		t.Errorf("non-ON-DELETE-CASCADE edges must yield no victims, got %d: %+v", len(victims), victims)
+	if len(res.Victims) != 0 {
+		t.Errorf("non-ON-DELETE-CASCADE edges must yield no victims, got %d: %+v", len(res.Victims), res.Victims)
 	}
 }
 
@@ -150,16 +150,16 @@ func TestSynthesizeVictims_compositeFKSkipped(t *testing.T) {
 		{Schema: "app", Table: "child", ConstraintName: "fk_comp", Column: "pk2",
 			ReferencedSchema: "app", ReferencedTable: "parent", ReferencedColumn: "k2", DeleteRule: "CASCADE"},
 	}
-	victims, warnings, err := cascade.SynthesizeVictims(context.Background(), eng, fks,
+	res, err := cascade.SynthesizeVictims(context.Background(), eng, fks,
 		[]query.ResultRow{parentDel}, cascade.Options{})
 	if err != nil {
 		t.Fatalf("SynthesizeVictims: %v", err)
 	}
-	if len(victims) != 0 {
-		t.Errorf("composite FK must be skipped, not mis-synthesized; got %d victims", len(victims))
+	if len(res.Victims) != 0 {
+		t.Errorf("composite FK must be skipped, not mis-synthesized; got %d victims", len(res.Victims))
 	}
-	if !strings.Contains(strings.Join(warnings, " "), "composite FK") {
-		t.Errorf("composite FK skip must warn; warnings: %v", warnings)
+	if res.Complete() || !strings.Contains(strings.Join(res.Incomplete, " "), "composite FK") {
+		t.Errorf("composite FK skip must flag incompleteness; Incomplete: %v", res.Incomplete)
 	}
 }
 
@@ -262,13 +262,14 @@ func TestSynthesizeVictims_selfRefAndCompositePK(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadCascadeFKs: %v", err)
 	}
-	victims, warnings, err := cascade.SynthesizeVictims(ctx, eng, fks, nodeDeletes, cascade.Options{})
+	res, err := cascade.SynthesizeVictims(ctx, eng, fks, nodeDeletes, cascade.Options{})
 	if err != nil {
 		t.Fatalf("SynthesizeVictims: %v", err)
 	}
-	for _, w := range warnings {
-		t.Logf("warning: %s", w)
+	if !res.Complete() {
+		t.Errorf("expected a complete reconstruction, got Incomplete=%v", res.Incomplete)
 	}
+	victims := res.Victims
 	// Expect nodes 2,3,4 (self-ref recursion) + leaves 2|1, 2|2, 4|1 (composite PK).
 	got := map[string]bool{}
 	for _, v := range victims {
@@ -281,6 +282,39 @@ func TestSynthesizeVictims_selfRefAndCompositePK(t *testing.T) {
 	}
 	if len(victims) != 6 {
 		t.Errorf("want 6 victims, got %d: %v", len(victims), victimList(victims))
+	}
+
+	// node 4 was UPDATEd after its parent's last event; with the root-T window it
+	// must be recovered at its LATEST label ('c2'), not the stale insert ('c').
+	// The byte-exact checksum below also enforces this; assert it explicitly too.
+	for _, v := range victims {
+		if v.TableName == "node" && v.PKValues == "4" && v.RowBefore["label"] != "c2" {
+			t.Errorf("node 4 recovered at stale label %v, want c2", v.RowBefore["label"])
+		}
+	}
+
+	// Depth cap (read-only re-run on the same index): MaxDepth=1 must reconstruct
+	// only the root's direct children and flag the deeper subtree as incomplete.
+	resD, err := cascade.SynthesizeVictims(ctx, eng, fks, nodeDeletes, cascade.Options{MaxDepth: 1})
+	if err != nil {
+		t.Fatalf("SynthesizeVictims(MaxDepth=1): %v", err)
+	}
+	if resD.Complete() || !strings.Contains(strings.Join(resD.Incomplete, " "), "MaxDepth") {
+		t.Errorf("MaxDepth=1 must flag depth incompleteness; Incomplete=%v", resD.Incomplete)
+	}
+	for _, v := range resD.Victims {
+		if v.TableName == "node" && v.PKValues == "4" {
+			t.Errorf("MaxDepth=1 must not reach grandchild node:4; got %v", victimList(resD.Victims))
+		}
+	}
+
+	// Candidate cap: CandidateLimit=1 truncates node 1's two children and flags it.
+	resC, err := cascade.SynthesizeVictims(ctx, eng, fks, nodeDeletes, cascade.Options{CandidateLimit: 1})
+	if err != nil {
+		t.Fatalf("SynthesizeVictims(CandidateLimit=1): %v", err)
+	}
+	if resC.Complete() || !strings.Contains(strings.Join(resC.Incomplete, " "), "more than 1") {
+		t.Errorf("CandidateLimit=1 must flag truncation; Incomplete=%v", resC.Incomplete)
 	}
 
 	// Recover (root from binlog + synthesized subtree) and apply FK-checks-off.
@@ -322,5 +356,168 @@ func applyFKOff(t *testing.T, dbName, sqlText string) {
 	defer conn.Close()
 	if _, err := conn.Exec("SET FOREIGN_KEY_CHECKS=0;\n" + sqlText + "\nSET FOREIGN_KEY_CHECKS=1;"); err != nil {
 		t.Fatalf("apply recovery SQL: %v", err)
+	}
+}
+
+// captureAndIndex flushes to a clean binlog, runs dml (which performs the
+// inserts/updates/deletes to capture), seals + copies the file, and parses it
+// into the index. One captured window per call.
+func captureAndIndex(t *testing.T, sourceDB, indexDB *sql.DB, resolver *metadata.Resolver, sourceName string, dml func()) {
+	t.Helper()
+	testutil.MustExec(t, sourceDB, "FLUSH BINARY LOGS")
+	currentBinlog, _, err := config.CurrentBinlogPosition(sourceDB)
+	if err != nil {
+		t.Fatalf("CurrentBinlogPosition: %v", err)
+	}
+	dml()
+	testutil.MustExec(t, sourceDB, "FLUSH BINARY LOGS")
+
+	tmpDir := t.TempDir()
+	cp := exec.Command("docker", "cp",
+		fmt.Sprintf("bintrail-test-mysql:/var/lib/mysql/%s", currentBinlog),
+		filepath.Join(tmpDir, currentBinlog))
+	if out, e := cp.CombinedOutput(); e != nil {
+		t.Fatalf("docker cp %s: %v\n%s", currentBinlog, e, out)
+	}
+	p := parser.New(tmpDir, resolver, parser.Filters{Schemas: map[string]bool{sourceName: true}}, nil)
+	idx := indexer.New(indexDB, 100)
+	events := make(chan parser.Event, 256)
+	perr := make(chan error, 1)
+	go func() { defer close(events); perr <- p.ParseFile(context.Background(), currentBinlog, events) }()
+	if _, e := idx.Run(context.Background(), events); e != nil {
+		t.Fatalf("indexer.Run: %v", e)
+	}
+	if e := <-perr; e != nil {
+		t.Fatalf("ParseFile: %v", e)
+	}
+}
+
+// TestSynthesizeVictims_multiPathDedup pins the multi-path dedup: a child
+// reachable from the deleted parent via TWO CASCADE FKs must be emitted ONCE,
+// or recovery would double-INSERT its PK and fail on apply.
+func TestSynthesizeVictims_multiPathDedup(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	ctx := context.Background()
+	sourceDB, sourceName := testutil.CreateTestDB(t)
+	indexDB, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, indexDB)
+
+	testutil.MustExec(t, sourceDB, `CREATE TABLE p (id INT PRIMARY KEY) ENGINE=InnoDB`)
+	testutil.MustExec(t, sourceDB, `CREATE TABLE c (
+		id INT PRIMARY KEY, ref1 INT, ref2 INT,
+		CONSTRAINT fk1 FOREIGN KEY (ref1) REFERENCES p(id) ON DELETE CASCADE,
+		CONSTRAINT fk2 FOREIGN KEY (ref2) REFERENCES p(id) ON DELETE CASCADE
+	) ENGINE=InnoDB`)
+
+	stats, err := metadata.TakeSnapshot(sourceDB, indexDB, []string{sourceName})
+	if err != nil {
+		t.Fatalf("TakeSnapshot: %v", err)
+	}
+	resolver, err := metadata.NewResolver(indexDB, stats.SnapshotID)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+
+	captureAndIndex(t, sourceDB, indexDB, resolver, sourceName, func() {
+		testutil.MustExec(t, sourceDB, "INSERT INTO p VALUES (1)")
+		testutil.MustExec(t, sourceDB, "INSERT INTO c VALUES (100,1,1)") // references p=1 via BOTH FKs
+		time.Sleep(1100 * time.Millisecond)
+		testutil.MustExec(t, sourceDB, "DELETE FROM p WHERE id=1") // cascades c once
+	})
+
+	eng := query.New(indexDB)
+	del := event.EventDelete
+	parentDeletes := mustFetch(t, eng, query.Options{Schema: sourceName, Table: "p", EventType: &del})
+	fks, err := cascade.LoadCascadeFKs(ctx, indexDB, []string{sourceName})
+	if err != nil {
+		t.Fatalf("LoadCascadeFKs: %v", err)
+	}
+
+	res, err := cascade.SynthesizeVictims(ctx, eng, fks, parentDeletes, cascade.Options{})
+	if err != nil {
+		t.Fatalf("SynthesizeVictims: %v", err)
+	}
+	if len(res.Victims) != 1 {
+		t.Fatalf("multi-path child must be emitted exactly once, got %d: %v", len(res.Victims), victimList(res.Victims))
+	}
+	if res.Victims[0].TableName != "c" || res.Victims[0].PKValues != "100" {
+		t.Errorf("want victim c:100, got %+v", res.Victims[0])
+	}
+}
+
+// TestSynthesizeVictims_multiRootIndependentT pins the breadth dimension of the
+// root-T fix: two independent cascades deleted at T_A ≪ T_B, each must use its
+// OWN root T. cb is updated BETWEEN T_A and T_B; only per-root T_B recovers its
+// latest 'b1' — a collapse to a single global T (first/min/now) recovers stale 'b0'.
+func TestSynthesizeVictims_multiRootIndependentT(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	ctx := context.Background()
+	sourceDB, sourceName := testutil.CreateTestDB(t)
+	indexDB, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, indexDB)
+
+	testutil.MustExec(t, sourceDB, `CREATE TABLE pa (id INT PRIMARY KEY) ENGINE=InnoDB`)
+	testutil.MustExec(t, sourceDB, `CREATE TABLE pb (id INT PRIMARY KEY) ENGINE=InnoDB`)
+	testutil.MustExec(t, sourceDB, `CREATE TABLE ca (
+		id INT PRIMARY KEY, pid INT, val VARCHAR(16),
+		CONSTRAINT fka FOREIGN KEY (pid) REFERENCES pa(id) ON DELETE CASCADE
+	) ENGINE=InnoDB`)
+	testutil.MustExec(t, sourceDB, `CREATE TABLE cb (
+		id INT PRIMARY KEY, pid INT, val VARCHAR(16),
+		CONSTRAINT fkb FOREIGN KEY (pid) REFERENCES pb(id) ON DELETE CASCADE
+	) ENGINE=InnoDB`)
+
+	stats, err := metadata.TakeSnapshot(sourceDB, indexDB, []string{sourceName})
+	if err != nil {
+		t.Fatalf("TakeSnapshot: %v", err)
+	}
+	resolver, err := metadata.NewResolver(indexDB, stats.SnapshotID)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+
+	captureAndIndex(t, sourceDB, indexDB, resolver, sourceName, func() {
+		testutil.MustExec(t, sourceDB, "INSERT INTO pa VALUES (1)")
+		testutil.MustExec(t, sourceDB, "INSERT INTO pb VALUES (2)")
+		testutil.MustExec(t, sourceDB, "INSERT INTO ca VALUES (10,1,'a0')")
+		testutil.MustExec(t, sourceDB, "INSERT INTO cb VALUES (20,2,'b0')")
+		testutil.MustExec(t, sourceDB, "DELETE FROM pa WHERE id=1") // T_A: cascades ca
+		time.Sleep(1100 * time.Millisecond)
+		testutil.MustExec(t, sourceDB, "UPDATE cb SET val='b1' WHERE id=20") // between T_A and T_B
+		time.Sleep(1100 * time.Millisecond)
+		testutil.MustExec(t, sourceDB, "DELETE FROM pb WHERE id=2") // T_B: cascades cb
+	})
+
+	eng := query.New(indexDB)
+	del := event.EventDelete
+	paDel := mustFetch(t, eng, query.Options{Schema: sourceName, Table: "pa", EventType: &del})
+	pbDel := mustFetch(t, eng, query.Options{Schema: sourceName, Table: "pb", EventType: &del})
+	parentDeletes := append(append([]query.ResultRow{}, paDel...), pbDel...)
+	fks, err := cascade.LoadCascadeFKs(ctx, indexDB, []string{sourceName})
+	if err != nil {
+		t.Fatalf("LoadCascadeFKs: %v", err)
+	}
+
+	res, err := cascade.SynthesizeVictims(ctx, eng, fks, parentDeletes, cascade.Options{})
+	if err != nil {
+		t.Fatalf("SynthesizeVictims: %v", err)
+	}
+	byPK := map[string]query.ResultRow{}
+	for _, v := range res.Victims {
+		byPK[v.TableName+":"+v.PKValues] = v
+	}
+	ca, ok := byPK["ca:10"]
+	if !ok {
+		t.Fatalf("ca:10 missing; got %v", victimList(res.Victims))
+	}
+	if ca.RowBefore["val"] != "a0" {
+		t.Errorf("ca:10 val = %v, want a0", ca.RowBefore["val"])
+	}
+	cb, ok := byPK["cb:20"]
+	if !ok {
+		t.Fatalf("cb:20 missing; got %v", victimList(res.Victims))
+	}
+	if cb.RowBefore["val"] != "b1" {
+		t.Errorf("cb:20 recovered at %v, want b1 (per-root T regression — using a collapsed global T?)", cb.RowBefore["val"])
 	}
 }

--- a/internal/cascade/cascade_cases_integration_test.go
+++ b/internal/cascade/cascade_cases_integration_test.go
@@ -1,0 +1,326 @@
+//go:build integration
+
+package cascade_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/cascade"
+	"github.com/dbtrail/dbtrail/internal/config"
+	"github.com/dbtrail/dbtrail/internal/event"
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/parser"
+	"github.com/dbtrail/dbtrail/internal/query"
+	"github.com/dbtrail/dbtrail/internal/recovery"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestLoadCascadeFKsFromIndex pins the productionized, source-less loader: after
+// a snapshot, the FK graph WITH rules is readable from the index's
+// fk_constraints, scoped by schema, with both CASCADE and non-CASCADE edges.
+func TestLoadCascadeFKsFromIndex(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	ctx := context.Background()
+	sourceDB, sourceName := testutil.CreateTestDB(t)
+	indexDB, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, indexDB)
+
+	testutil.MustExec(t, sourceDB, `CREATE TABLE parent (id INT PRIMARY KEY) ENGINE=InnoDB`)
+	testutil.MustExec(t, sourceDB, `CREATE TABLE child_c (
+		id INT PRIMARY KEY, pid INT,
+		CONSTRAINT fk_c FOREIGN KEY (pid) REFERENCES parent(id) ON DELETE CASCADE
+	) ENGINE=InnoDB`)
+	testutil.MustExec(t, sourceDB, `CREATE TABLE child_r (
+		id INT PRIMARY KEY, pid INT,
+		CONSTRAINT fk_r FOREIGN KEY (pid) REFERENCES parent(id) ON DELETE RESTRICT
+	) ENGINE=InnoDB`)
+	// A composite (multi-column) FK must round-trip as multiple rows sharing one
+	// constraint_name, so the synthesis composite-FK guard can detect it.
+	testutil.MustExec(t, sourceDB, `CREATE TABLE pcomp (a INT, b INT, PRIMARY KEY (a, b)) ENGINE=InnoDB`)
+	testutil.MustExec(t, sourceDB, `CREATE TABLE child_comp (
+		id INT PRIMARY KEY, fa INT, fb INT,
+		CONSTRAINT fk_comp FOREIGN KEY (fa, fb) REFERENCES pcomp(a, b) ON DELETE CASCADE
+	) ENGINE=InnoDB`)
+
+	if _, err := metadata.TakeSnapshot(sourceDB, indexDB, []string{sourceName}); err != nil {
+		t.Fatalf("TakeSnapshot: %v", err)
+	}
+
+	fks, err := cascade.LoadCascadeFKs(ctx, indexDB, []string{sourceName})
+	if err != nil {
+		t.Fatalf("LoadCascadeFKs: %v", err)
+	}
+	byTable := map[string]cascade.CascadeFK{}
+	for _, fk := range fks {
+		byTable[fk.Table] = fk
+	}
+	if c, ok := byTable["child_c"]; !ok || c.DeleteRule != "CASCADE" ||
+		c.ReferencedTable != "parent" || c.ReferencedColumn != "id" || c.Column != "pid" {
+		t.Errorf("child_c edge missing/wrong: %+v (ok=%v)", c, ok)
+	}
+	if r, ok := byTable["child_r"]; !ok || r.DeleteRule != "RESTRICT" {
+		t.Errorf("child_r edge missing/wrong: %+v (ok=%v)", r, ok)
+	}
+
+	// The composite FK must come back as 2 rows sharing constraint_name (and
+	// referenced columns a,b) — what the synthesis composite-FK guard keys on.
+	var comp []cascade.CascadeFK
+	for _, fk := range fks {
+		if fk.Table == "child_comp" {
+			comp = append(comp, fk)
+		}
+	}
+	if len(comp) != 2 {
+		t.Fatalf("composite FK must load as 2 column rows, got %d: %+v", len(comp), comp)
+	}
+	if comp[0].ConstraintName != "fk_comp" || comp[1].ConstraintName != "fk_comp" {
+		t.Errorf("composite FK rows must share constraint_name fk_comp, got %q/%q",
+			comp[0].ConstraintName, comp[1].ConstraintName)
+	}
+
+	// Scope: an unrelated schema yields nothing.
+	none, err := cascade.LoadCascadeFKs(ctx, indexDB, []string{"no_such_schema"})
+	if err != nil {
+		t.Fatalf("LoadCascadeFKs(none): %v", err)
+	}
+	if len(none) != 0 {
+		t.Errorf("want 0 edges for an unrelated schema, got %d", len(none))
+	}
+}
+
+// TestSynthesizeVictims_ruleGate pins the deliberate non-bug: only ON DELETE
+// CASCADE edges are delete-synthesized. A pure RESTRICT edge and an
+// ON-UPDATE-CASCADE-only edge (the dbtrail conflation) must yield no victims —
+// and, being non-CASCADE, never even hit the index, so no events are needed.
+func TestSynthesizeVictims_ruleGate(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	indexDB, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, indexDB)
+	eng := query.New(indexDB)
+
+	parentDel := query.ResultRow{
+		SchemaName: "app", TableName: "parent", EventType: event.EventDelete,
+		PKValues: "1", RowBefore: map[string]any{"id": float64(1)},
+		EventTimestamp: time.Now(),
+	}
+	fks := []cascade.CascadeFK{
+		{Schema: "app", Table: "child_r", ConstraintName: "fk_r", Column: "pid",
+			ReferencedSchema: "app", ReferencedTable: "parent", ReferencedColumn: "id",
+			DeleteRule: "RESTRICT", UpdateRule: "RESTRICT"},
+		{Schema: "app", Table: "child_u", ConstraintName: "fk_u", Column: "pid",
+			ReferencedSchema: "app", ReferencedTable: "parent", ReferencedColumn: "id",
+			DeleteRule: "RESTRICT", UpdateRule: "CASCADE"}, // ON UPDATE CASCADE only
+	}
+	victims, _, err := cascade.SynthesizeVictims(context.Background(), eng, fks,
+		[]query.ResultRow{parentDel}, cascade.Options{})
+	if err != nil {
+		t.Fatalf("SynthesizeVictims: %v", err)
+	}
+	if len(victims) != 0 {
+		t.Errorf("non-ON-DELETE-CASCADE edges must yield no victims, got %d: %+v", len(victims), victims)
+	}
+}
+
+// TestSynthesizeVictims_compositeFKSkipped pins the composite-FK guard: a
+// multi-column CASCADE FK cannot be reconstructed by the single-column victim
+// match, so it must be SKIPPED with a warning, never silently mis-synthesized.
+func TestSynthesizeVictims_compositeFKSkipped(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	indexDB, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, indexDB)
+	eng := query.New(indexDB)
+
+	parentDel := query.ResultRow{
+		SchemaName: "app", TableName: "parent", EventType: event.EventDelete,
+		PKValues: "1|9", RowBefore: map[string]any{"k1": float64(1), "k2": float64(9)},
+		EventTimestamp: time.Now(),
+	}
+	// One composite CASCADE FK = two rows sharing the constraint name.
+	fks := []cascade.CascadeFK{
+		{Schema: "app", Table: "child", ConstraintName: "fk_comp", Column: "pk1",
+			ReferencedSchema: "app", ReferencedTable: "parent", ReferencedColumn: "k1", DeleteRule: "CASCADE"},
+		{Schema: "app", Table: "child", ConstraintName: "fk_comp", Column: "pk2",
+			ReferencedSchema: "app", ReferencedTable: "parent", ReferencedColumn: "k2", DeleteRule: "CASCADE"},
+	}
+	victims, warnings, err := cascade.SynthesizeVictims(context.Background(), eng, fks,
+		[]query.ResultRow{parentDel}, cascade.Options{})
+	if err != nil {
+		t.Fatalf("SynthesizeVictims: %v", err)
+	}
+	if len(victims) != 0 {
+		t.Errorf("composite FK must be skipped, not mis-synthesized; got %d victims", len(victims))
+	}
+	if !strings.Contains(strings.Join(warnings, " "), "composite FK") {
+		t.Errorf("composite FK skip must warn; warnings: %v", warnings)
+	}
+}
+
+// TestSynthesizeVictims_selfRefAndCompositePK exercises two robustness cases in
+// one real cascade: a SELF-REFERENCING tree (node.parent_id → node.id ON DELETE
+// CASCADE) and a COMPOSITE-PK child (leaf PK (node_id, seq)). Deleting the tree
+// root cascades through the whole subtree (none of it binlogged); synthesis must
+// recurse over the self-ref without a false cycle and restore both tables
+// byte-exact, including the pipe-delimited composite PKs.
+func TestSynthesizeVictims_selfRefAndCompositePK(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	ctx := context.Background()
+	sourceDB, sourceName := testutil.CreateTestDB(t)
+	indexDB, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, indexDB)
+
+	testutil.MustExec(t, sourceDB, `CREATE TABLE node (
+		id        INT PRIMARY KEY,
+		parent_id INT NULL,
+		label     VARCHAR(32),
+		CONSTRAINT fk_self FOREIGN KEY (parent_id) REFERENCES node(id) ON DELETE CASCADE
+	) ENGINE=InnoDB`)
+	testutil.MustExec(t, sourceDB, `CREATE TABLE leaf (
+		node_id INT,
+		seq     INT,
+		payload VARCHAR(32),
+		PRIMARY KEY (node_id, seq),
+		CONSTRAINT fk_leaf FOREIGN KEY (node_id) REFERENCES node(id) ON DELETE CASCADE
+	) ENGINE=InnoDB`)
+
+	stats, err := metadata.TakeSnapshot(sourceDB, indexDB, []string{sourceName})
+	if err != nil {
+		t.Fatalf("TakeSnapshot: %v", err)
+	}
+	resolver, err := metadata.NewResolver(indexDB, stats.SnapshotID)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+
+	testutil.MustExec(t, sourceDB, "FLUSH BINARY LOGS")
+	currentBinlog, _, err := config.CurrentBinlogPosition(sourceDB)
+	if err != nil {
+		t.Fatalf("CurrentBinlogPosition: %v", err)
+	}
+
+	// Tree: 1(root) → {2,3}; 2 → {4}. Leaves hang off nodes 2 and 4.
+	testutil.MustExec(t, sourceDB, "INSERT INTO node VALUES (1,NULL,'root'),(2,1,'a'),(3,1,'b'),(4,2,'c')")
+	testutil.MustExec(t, sourceDB, "INSERT INTO leaf VALUES (2,1,'l21'),(2,2,'l22'),(4,1,'l41')")
+
+	// Update the GRANDCHILD (node 4) and its composite-PK leaf in a strictly
+	// LATER statement than their parent's last event. This is the discriminating
+	// timing: the per-level window must end at the ROOT delete time T, not at
+	// each victim's own timestamp — otherwise node 4's (and leaf 4|1's) post-T1
+	// update falls outside the deeper window and a stale state is recovered.
+	time.Sleep(1100 * time.Millisecond) // binlog ts is second-granular
+	testutil.MustExec(t, sourceDB, "UPDATE node SET label='c2' WHERE id=4")
+	testutil.MustExec(t, sourceDB, "UPDATE leaf SET payload='l41b' WHERE node_id=4 AND seq=1")
+
+	time.Sleep(1100 * time.Millisecond) // parent delete strictly after every child event
+
+	wantNode := checksum(t, sourceDB, "node")
+	wantLeaf := checksum(t, sourceDB, "leaf")
+
+	// Delete the root; InnoDB cascades to nodes 2,3,4 and all leaves INTERNALLY
+	// (only the node id=1 delete is binlogged).
+	testutil.MustExec(t, sourceDB, "DELETE FROM node WHERE id=1")
+	testutil.MustExec(t, sourceDB, "FLUSH BINARY LOGS")
+
+	tmpDir := t.TempDir()
+	cp := exec.Command("docker", "cp",
+		fmt.Sprintf("bintrail-test-mysql:/var/lib/mysql/%s", currentBinlog),
+		filepath.Join(tmpDir, currentBinlog))
+	if out, cperr := cp.CombinedOutput(); cperr != nil {
+		t.Fatalf("docker cp %s: %v\n%s", currentBinlog, cperr, out)
+	}
+
+	p := parser.New(tmpDir, resolver, parser.Filters{Schemas: map[string]bool{sourceName: true}}, nil)
+	idx := indexer.New(indexDB, 100)
+	events := make(chan parser.Event, 256)
+	parseErr := make(chan error, 1)
+	go func() {
+		defer close(events)
+		parseErr <- p.ParseFile(ctx, currentBinlog, events)
+	}()
+	if _, rerr := idx.Run(ctx, events); rerr != nil {
+		t.Fatalf("indexer.Run: %v", rerr)
+	}
+	if perr := <-parseErr; perr != nil {
+		t.Fatalf("ParseFile: %v", perr)
+	}
+
+	eng := query.New(indexDB)
+	del := event.EventDelete
+	nodeDeletes := mustFetch(t, eng, query.Options{Schema: sourceName, Table: "node", EventType: &del})
+	if len(nodeDeletes) != 1 || nodeDeletes[0].PKValues != "1" {
+		t.Fatalf("want only the root node delete indexed, got %d: %v", len(nodeDeletes), pkList(nodeDeletes))
+	}
+
+	fks, err := cascade.LoadCascadeFKs(ctx, indexDB, []string{sourceName})
+	if err != nil {
+		t.Fatalf("LoadCascadeFKs: %v", err)
+	}
+	victims, warnings, err := cascade.SynthesizeVictims(ctx, eng, fks, nodeDeletes, cascade.Options{})
+	if err != nil {
+		t.Fatalf("SynthesizeVictims: %v", err)
+	}
+	for _, w := range warnings {
+		t.Logf("warning: %s", w)
+	}
+	// Expect nodes 2,3,4 (self-ref recursion) + leaves 2|1, 2|2, 4|1 (composite PK).
+	got := map[string]bool{}
+	for _, v := range victims {
+		got[v.TableName+":"+v.PKValues] = true
+	}
+	for _, want := range []string{"node:2", "node:3", "node:4", "leaf:2|1", "leaf:2|2", "leaf:4|1"} {
+		if !got[want] {
+			t.Errorf("missing synthesized victim %s; got %v", want, victimList(victims))
+		}
+	}
+	if len(victims) != 6 {
+		t.Errorf("want 6 victims, got %d: %v", len(victims), victimList(victims))
+	}
+
+	// Recover (root from binlog + synthesized subtree) and apply FK-checks-off.
+	gen := recoveryNew(t, indexDB, resolver)
+	rows := append(append([]query.ResultRow{}, nodeDeletes...), victims...)
+	sqlText := generateSQL(t, gen, rows)
+	applyFKOff(t, sourceName, sqlText)
+
+	if got := checksum(t, sourceDB, "node"); got != wantNode {
+		t.Errorf("node checksum mismatch: want %d, got %d", wantNode, got)
+	}
+	if got := checksum(t, sourceDB, "leaf"); got != wantLeaf {
+		t.Errorf("leaf checksum mismatch: want %d, got %d", wantLeaf, got)
+	}
+}
+
+// --- small shared helpers for the recovery+apply tail ---
+
+func recoveryNew(t *testing.T, indexDB *sql.DB, resolver *metadata.Resolver) *recovery.Generator {
+	t.Helper()
+	return recovery.New(indexDB, resolver)
+}
+
+func generateSQL(t *testing.T, gen *recovery.Generator, rows []query.ResultRow) string {
+	t.Helper()
+	var buf strings.Builder
+	if _, err := gen.GenerateSQLFromRows(rows, &buf); err != nil {
+		t.Fatalf("GenerateSQLFromRows: %v", err)
+	}
+	return buf.String()
+}
+
+func applyFKOff(t *testing.T, dbName, sqlText string) {
+	t.Helper()
+	conn, err := sql.Open("mysql", testutil.BaseDSN()+"/"+dbName+"?multiStatements=true")
+	if err != nil {
+		t.Fatalf("open apply conn: %v", err)
+	}
+	defer conn.Close()
+	if _, err := conn.Exec("SET FOREIGN_KEY_CHECKS=0;\n" + sqlText + "\nSET FOREIGN_KEY_CHECKS=1;"); err != nil {
+		t.Fatalf("apply recovery SQL: %v", err)
+	}
+}

--- a/internal/cascade/cascade_integration_test.go
+++ b/internal/cascade/cascade_integration_test.go
@@ -1,0 +1,289 @@
+//go:build integration
+
+package cascade_test
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/cascade"
+	"github.com/dbtrail/dbtrail/internal/config"
+	"github.com/dbtrail/dbtrail/internal/event"
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/parser"
+	"github.com/dbtrail/dbtrail/internal/query"
+	"github.com/dbtrail/dbtrail/internal/recovery"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestCascadeRecoverySpike proves the end-to-end thesis of
+// drafts/cascade-recovery-port-2026-06-21.md: from the bintrail binlog index
+// (which has the child INSERTs/UPDATEs but NOT the cascade-deleted children,
+// because InnoDB ≤8.x never binlogs them) plus the FK graph, we can synthesize
+// the deleted children and emit reversal INSERTs that restore the table to its
+// exact pre-delete state.
+//
+// Topology (two-level cascade):
+//
+//	parent ──ON DELETE CASCADE──▶ child ──ON DELETE CASCADE──▶ grandchild
+//
+// Edge cases baked in:
+//   - child 13 is re-parented (pid 1→2) before the delete  → must SURVIVE
+//   - child 14 is explicitly deleted before the cascade     → must NOT be restored
+//   - grandchildren 100/101/102 are two levels down         → must be restored (recursion)
+//
+// Correctness gate (non-negotiable): CHECKSUM TABLE of parent/child/grandchild
+// captured at T (just before the cascade delete) must equal the checksum after
+// applying the synthesized recovery SQL.
+func TestCascadeRecoverySpike(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	ctx := context.Background()
+
+	sourceDB, sourceName := testutil.CreateTestDB(t)
+	indexDB, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, indexDB)
+
+	// ── Schema: parent → child → grandchild, both edges ON DELETE CASCADE ──
+	testutil.MustExec(t, sourceDB, `CREATE TABLE parent (
+		id   INT PRIMARY KEY,
+		name VARCHAR(64)
+	) ENGINE=InnoDB`)
+	testutil.MustExec(t, sourceDB, `CREATE TABLE child (
+		id      INT PRIMARY KEY,
+		pid     INT,
+		payload VARCHAR(64),
+		CONSTRAINT fk_child FOREIGN KEY (pid) REFERENCES parent(id) ON DELETE CASCADE
+	) ENGINE=InnoDB`)
+	testutil.MustExec(t, sourceDB, `CREATE TABLE grandchild (
+		id   INT PRIMARY KEY,
+		cid  INT,
+		note VARCHAR(64),
+		CONSTRAINT fk_gc FOREIGN KEY (cid) REFERENCES child(id) ON DELETE CASCADE
+	) ENGINE=InnoDB`)
+
+	// Snapshot (columns + FK graph) → resolver for parsing/recovery.
+	stats, err := metadata.TakeSnapshot(sourceDB, indexDB, []string{sourceName})
+	if err != nil {
+		t.Fatalf("TakeSnapshot: %v", err)
+	}
+	resolver, err := metadata.NewResolver(indexDB, stats.SnapshotID)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+
+	// Rotate to a clean file; everything below lands in `currentBinlog`.
+	testutil.MustExec(t, sourceDB, "FLUSH BINARY LOGS")
+	currentBinlog, _, err := config.CurrentBinlogPosition(sourceDB)
+	if err != nil {
+		t.Fatalf("CurrentBinlogPosition: %v", err)
+	}
+
+	// ── DML (all logged; the cascade child deletes will NOT be) ──
+	testutil.MustExec(t, sourceDB, "INSERT INTO parent VALUES (1,'p1'),(2,'p2')")
+	testutil.MustExec(t, sourceDB, "INSERT INTO child VALUES "+
+		"(10,1,'c10'),(11,1,'c11'),(12,2,'c12'),(13,1,'c13'),(14,1,'c14')")
+	testutil.MustExec(t, sourceDB, "INSERT INTO grandchild VALUES "+
+		"(100,10,'g100'),(101,10,'g101'),(102,11,'g102')")
+	testutil.MustExec(t, sourceDB, "UPDATE child SET pid=2 WHERE id=13") // re-parent → survives
+	testutil.MustExec(t, sourceDB, "DELETE FROM child WHERE id=14")      // explicit pre-delete
+
+	// Binlog timestamps are second-granular; ensure the parent delete is
+	// strictly later so the Until=parentTs window cleanly includes the setup.
+	time.Sleep(1100 * time.Millisecond)
+
+	// Ground truth at T (state the recovery must reproduce exactly).
+	wantParent := checksum(t, sourceDB, "parent")
+	wantChild := checksum(t, sourceDB, "child")
+	wantGrandchild := checksum(t, sourceDB, "grandchild")
+
+	// The cascade: removes child 10,11 + grandchild 100,101,102 INTERNALLY
+	// (no binlog), keeps child 12 (parent 2) and child 13 (re-parented to 2).
+	testutil.MustExec(t, sourceDB, "DELETE FROM parent WHERE id=1")
+
+	testutil.MustExec(t, sourceDB, "FLUSH BINARY LOGS") // seal the file
+
+	// ── Parse + index the binlog into binlog_events ──
+	tmpDir := t.TempDir()
+	cp := exec.Command("docker", "cp",
+		fmt.Sprintf("bintrail-test-mysql:/var/lib/mysql/%s", currentBinlog),
+		filepath.Join(tmpDir, currentBinlog))
+	if out, cperr := cp.CombinedOutput(); cperr != nil {
+		t.Fatalf("docker cp %s: %v\n%s", currentBinlog, cperr, out)
+	}
+
+	p := parser.New(tmpDir, resolver, parser.Filters{
+		Schemas: map[string]bool{sourceName: true},
+	}, nil)
+	idx := indexer.New(indexDB, 100)
+	events := make(chan parser.Event, 256)
+	parseErr := make(chan error, 1)
+	go func() {
+		defer close(events)
+		parseErr <- p.ParseFile(ctx, currentBinlog, events)
+	}()
+	if _, rerr := idx.Run(ctx, events); rerr != nil {
+		t.Fatalf("indexer.Run: %v", rerr)
+	}
+	if perr := <-parseErr; perr != nil {
+		t.Fatalf("ParseFile: %v", perr)
+	}
+
+	eng := query.New(indexDB)
+	del := event.EventDelete
+
+	// ── Prove the blind spot: the cascade child deletes are NOT in the index ──
+	childDeletes := mustFetch(t, eng, query.Options{Schema: sourceName, Table: "child", EventType: &del})
+	for _, r := range childDeletes {
+		if r.PKValues == "10" || r.PKValues == "11" {
+			t.Fatalf("blind-spot assumption broken: child %s delete WAS binlogged", r.PKValues)
+		}
+	}
+	if len(childDeletes) != 1 || childDeletes[0].PKValues != "14" {
+		t.Fatalf("want only the explicit child 14 delete indexed, got %d: %v", len(childDeletes), pkList(childDeletes))
+	}
+	gcDeletes := mustFetch(t, eng, query.Options{Schema: sourceName, Table: "grandchild", EventType: &del})
+	if len(gcDeletes) != 0 {
+		t.Fatalf("want 0 grandchild deletes indexed (all were cascade), got %d: %v", len(gcDeletes), pkList(gcDeletes))
+	}
+	t.Logf("blind spot confirmed: child cascade-deletes (10,11) and all grandchild deletes absent from the index")
+
+	// ── Synthesize the victims ──
+	// Load the FK graph (with rules) from the INDEX — the productionized,
+	// source-less path. TakeSnapshot above populated fk_constraints.
+	fks, err := cascade.LoadCascadeFKs(ctx, indexDB, []string{sourceName})
+	if err != nil {
+		t.Fatalf("LoadCascadeFKs: %v", err)
+	}
+	parentDeletes := mustFetch(t, eng, query.Options{Schema: sourceName, Table: "parent", EventType: &del})
+
+	victims, warnings, err := cascade.SynthesizeVictims(ctx, eng, fks, parentDeletes, cascade.Options{})
+	if err != nil {
+		t.Fatalf("SynthesizeVictims: %v", err)
+	}
+	for _, w := range warnings {
+		t.Logf("warning: %s", w)
+	}
+	got := map[string]bool{}
+	for _, v := range victims {
+		got[v.TableName+":"+v.PKValues] = true
+	}
+	want := []string{"child:10", "child:11", "grandchild:100", "grandchild:101", "grandchild:102"}
+	if len(victims) != len(want) {
+		t.Fatalf("want %d victims %v, got %d %v", len(want), want, len(victims), victimList(victims))
+	}
+	for _, w := range want {
+		if !got[w] {
+			t.Fatalf("missing synthesized victim %s; got %v", w, victimList(victims))
+		}
+	}
+	// Edge cases must NOT appear as victims.
+	for _, bad := range []string{"child:12", "child:13", "child:14"} {
+		if got[bad] {
+			t.Fatalf("victim %s should have been excluded (survived/pre-deleted)", bad)
+		}
+	}
+	t.Logf("synthesized %d victims: %v", len(victims), victimList(victims))
+
+	// ── Generate reversal SQL (parent delete + synthetic child/grandchild deletes) ──
+	gen := recovery.New(indexDB, resolver)
+	rows := append(append([]query.ResultRow{}, parentDeletes...), victims...)
+	var buf bytes.Buffer
+	nStmts, err := gen.GenerateSQLFromRows(rows, &buf)
+	if err != nil {
+		t.Fatalf("GenerateSQLFromRows: %v", err)
+	}
+	if nStmts != len(rows) {
+		t.Fatalf("want %d reversal statements, got %d", len(rows), nStmts)
+	}
+	t.Logf("recovery SQL (%d statements):\n%s", nStmts, buf.String())
+
+	// ── Apply the recovery SQL, FK checks off (validates the topo-sort-free path) ──
+	applyDB, err := sql.Open("mysql", testutil.BaseDSN()+"/"+sourceName+"?multiStatements=true")
+	if err != nil {
+		t.Fatalf("open apply conn: %v", err)
+	}
+	defer applyDB.Close()
+	script := "SET FOREIGN_KEY_CHECKS=0;\n" + buf.String() + "\nSET FOREIGN_KEY_CHECKS=1;"
+	if _, err := applyDB.ExecContext(ctx, script); err != nil {
+		t.Fatalf("apply recovery SQL: %v", err)
+	}
+
+	// ── Correctness gate ──
+	if got := checksum(t, sourceDB, "parent"); got != wantParent {
+		t.Errorf("parent checksum mismatch: want %d, got %d", wantParent, got)
+	}
+	if got := checksum(t, sourceDB, "child"); got != wantChild {
+		t.Errorf("child checksum mismatch: want %d, got %d", wantChild, got)
+	}
+	if got := checksum(t, sourceDB, "grandchild"); got != wantGrandchild {
+		t.Errorf("grandchild checksum mismatch: want %d, got %d", wantGrandchild, got)
+	}
+
+	// Spot-check the actual recovered rows for human-readable confidence.
+	assertRows(t, sourceDB, "SELECT id,pid FROM child ORDER BY id",
+		[][2]int{{10, 1}, {11, 1}, {12, 2}, {13, 2}}) // 14 stays gone, 13 stays re-parented
+	assertRows(t, sourceDB, "SELECT id,cid FROM grandchild ORDER BY id",
+		[][2]int{{100, 10}, {101, 10}, {102, 11}})
+	if !t.Failed() {
+		t.Logf("correctness gate PASSED: parent/child/grandchild restored byte-exact to pre-cascade state")
+	}
+}
+
+func checksum(t *testing.T, db *sql.DB, table string) int64 {
+	t.Helper()
+	var name string
+	var sum sql.NullInt64
+	if err := db.QueryRow("CHECKSUM TABLE "+table).Scan(&name, &sum); err != nil {
+		t.Fatalf("CHECKSUM TABLE %s: %v", table, err)
+	}
+	if !sum.Valid {
+		t.Fatalf("CHECKSUM TABLE %s returned NULL", table)
+	}
+	return sum.Int64
+}
+
+func mustFetch(t *testing.T, eng *query.Engine, opts query.Options) []query.ResultRow {
+	t.Helper()
+	rows, err := eng.Fetch(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("Fetch %s.%s: %v", opts.Schema, opts.Table, err)
+	}
+	return rows
+}
+
+func assertRows(t *testing.T, db *sql.DB, q string, want [][2]int) {
+	t.Helper()
+	rows, err := db.Query(q)
+	if err != nil {
+		t.Fatalf("query %q: %v", q, err)
+	}
+	defer rows.Close()
+	var got [][2]int
+	for rows.Next() {
+		var a, b int
+		if err := rows.Scan(&a, &b); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		got = append(got, [2]int{a, b})
+	}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Errorf("rows for %q: want %v, got %v", q, want, got)
+	}
+}
+
+func pkList(rows []query.ResultRow) []string {
+	out := make([]string, len(rows))
+	for i, r := range rows {
+		out[i] = r.TableName + ":" + r.PKValues
+	}
+	return out
+}
+
+func victimList(rows []query.ResultRow) []string { return pkList(rows) }

--- a/internal/cascade/cascade_integration_test.go
+++ b/internal/cascade/cascade_integration_test.go
@@ -163,13 +163,15 @@ func TestCascadeRecoverySpike(t *testing.T) {
 	}
 	parentDeletes := mustFetch(t, eng, query.Options{Schema: sourceName, Table: "parent", EventType: &del})
 
-	victims, warnings, err := cascade.SynthesizeVictims(ctx, eng, fks, parentDeletes, cascade.Options{})
+	res, err := cascade.SynthesizeVictims(ctx, eng, fks, parentDeletes, cascade.Options{})
 	if err != nil {
 		t.Fatalf("SynthesizeVictims: %v", err)
 	}
-	for _, w := range warnings {
-		t.Logf("warning: %s", w)
+	// A clean cascade within the window must reconstruct completely.
+	if !res.Complete() {
+		t.Errorf("expected a complete reconstruction, got Incomplete=%v", res.Incomplete)
 	}
+	victims := res.Victims
 	got := map[string]bool{}
 	for _, v := range victims {
 		got[v.TableName+":"+v.PKValues] = true

--- a/internal/cascade/cascade_internal_test.go
+++ b/internal/cascade/cascade_internal_test.go
@@ -1,0 +1,34 @@
+package cascade
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestValToString covers every branch of the value renderer that backs the
+// re-parented comparison. The index read path decodes numbers as json.Number
+// (UseNumber, #496) — that is the production type, and a plain float64 would
+// lose precision on a BIGINT > 2^53, so the json.Number branch is load-bearing.
+func TestValToString(t *testing.T) {
+	cases := []struct {
+		name string
+		in   any
+		want string
+	}{
+		{"nil", nil, ""},
+		{"string", "abc", "abc"},
+		{"json.Number int", json.Number("42"), "42"},
+		{"json.Number bigint > 2^53", json.Number("9007199254740993"), "9007199254740993"},
+		{"json.Number negative", json.Number("-7"), "-7"},
+		{"float64 integral", float64(1), "1"},
+		{"float64 fractional", 1.5, "1.5"},
+		{"bool true", true, "true"},
+		{"bool false", false, "false"},
+		{"bytes", []byte("xy"), "xy"},
+	}
+	for _, c := range cases {
+		if got := valToString(c.in); got != c.want {
+			t.Errorf("%s: valToString(%#v) = %q, want %q", c.name, c.in, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## What

Cascade-recovery **Slice B** — the synthesis engine. Closes #550. Part of #548. Depends on #549 (merged).

Productionizes the 2026-06-21 spike (`internal/cascade/`) into a maintained, **source-less** package: it reconstructs the child rows an InnoDB `ON DELETE CASCADE` removed but never binlogged (MySQL Bug #32506), from each child's last indexed `row_after`.

### Core
- **`LoadCascadeFKs`** now reads the FK graph + `delete_rule`/`update_rule` from the index's `fk_constraints` (added in Slice A) — **not** the source. `recover` never connects to the source.
- **`SynthesizeVictims`**: for each parent DELETE × `CASCADE` FK, finds the latest `row_after` per child PK that pointed at the parent, applies the pre-deleted / no-after / re-parented filters, fabricates a synthetic DELETE (`RowBefore = last row_after`) so the existing `recovery` generator emits a restoring INSERT, and recurses for multi-level cascades (depth cap + per-`(table,pk)` cycle guard).
- Gated on **`delete_rule == "CASCADE"` only** — does not port the dbtrail SaaS `delete_rule OR update_rule` conflation bug.

### Correctness hardening (from review)
- **Root-T window**: the lookback window is anchored to the **root delete time T at every recursion level** (threaded per-layer), not each victim's own timestamp. The cascade is atomic at T, so a grandchild updated *after* its parent's last event must still be recovered at its T-state. Pinned by a **discriminating** self-ref test that fails if the window shrinks per-level (verified: reverting the fix makes it fail with checksum mismatches).
- **Composite-FK guard**: a multi-column FK can't be reconstructed by the single-column victim match, so it's **skipped with a warning** rather than silently mis-synthesized — the cardinal sin for a recovery tool.

## Tests (integration, MySQL 8.0)
- `TestLoadCascadeFKsFromIndex` — rules + schema scope + composite FK round-tripping as 2 rows sharing `constraint_name`.
- `TestSynthesizeVictims_ruleGate` — `RESTRICT` and `ON UPDATE CASCADE`-only edges yield no victims.
- `TestSynthesizeVictims_compositeFKSkipped` — composite CASCADE FK skipped + warns, never mis-synthesized.
- `TestSynthesizeVictims_selfRefAndCompositePK` — byte-exact (`CHECKSUM TABLE`) recovery over a self-referencing tree + composite-PK child, with a late grandchild update (the discriminating timing).
- `TestCascadeRecoverySpike` — the original `parent→child→grandchild` end-to-end, now via the index loader.

Full unit suite + `internal/cascade` integration green.

## Known limitation (documented, deferred)
The FK graph is taken from the latest snapshot that recorded FKs (`MAX(snapshot_id)`), not the one in effect at the recovered delete. FK-graph-to-event-time matching is deferred (#548); noted on `LoadCascadeFKs`.

## Next
Slice C (#551) adds the `recover-cascade` CLI command that wires this engine to `recovery.GenerateSQLFromRows` and emits dry-run SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
