### PR TITLE
feat: recover-cascade command — reverse FK ON DELETE CASCADE deletes (#551 cascade-recovery slice C)

### DIFF
--- a/cmd/bintrail/index.go
+++ b/cmd/bintrail/index.go
@@ -112,7 +112,7 @@ func runIndex(cmd *cobra.Command, args []string) error {
 			slog.Warn("FK cascade constraints present on source; indexing will proceed, "+
 				"but InnoDB executes cascades below the binlog (MySQL Bug #32506) so cascaded "+
 				"child-row deletes are NOT captured \u2014 plain `recover` cannot restore them. "+
-				"Cascade recovery is in progress (#548).",
+				"Reconstruct them with `bintrail recover-cascade`.",
 				"detail", err.Error())
 		} else {
 			fmt.Println("Source: no FK cascades \u2713")

--- a/docs/query-and-recovery.md
+++ b/docs/query-and-recovery.md
@@ -196,8 +196,35 @@ Reversed: undo the 14:03 UPDATE first, then the 14:02 UPDATE, then the 14:01 INS
 > side-effect row changes (InnoDB runs cascades below the binlog, MySQL Bug
 > #32506, so cascaded child deletes are never captured) that plain `recover`
 > cannot reliably undo. `bintrail doctor`, and `stream`/`watch`/`index --source-dsn`,
-> warn about them and proceed (cascade schemas index normally). Dedicated
-> cascade recovery is in progress (#548).
+> warn about them and proceed (cascade schemas index normally). To reconstruct
+> cascade-deleted rows, use **`bintrail recover-cascade`** (see below).
+
+### `recover-cascade`: reverse FK ON DELETE CASCADE
+
+`bintrail recover-cascade` reconstructs rows that an InnoDB `ON DELETE CASCADE`
+removed but never binlogged. It finds the deleted parent rows in the index,
+infers which child rows referenced them in their last indexed state, and emits
+reversal SQL that re-inserts **both** the parents and their cascade-deleted
+descendants (recursing through multi-level cascades), wrapped in
+`SET FOREIGN_KEY_CHECKS=0/1`. Like `recover`, it only generates SQL — review
+before applying.
+
+```bash
+bintrail recover-cascade --index-dsn "..." \
+  --schema shop --table orders --pk '42' --dry-run
+```
+
+- `--table` is the **parent** table whose delete cascaded; `--pk`/`--pks`,
+  `--since`/`--until` narrow which deleted parents to process.
+- `--lookback` (default `30d`) bounds how far back the last child state is
+  searched; `--max-depth` (default 5) bounds cascade recursion.
+- **Phase-1 limitation:** a child untouched within `--lookback` and absent from a
+  baseline is not reconstructed (baseline fallback is #552), and archived
+  partitions are not searched. When the result is provably partial the output is
+  flagged `INCOMPLETE RECOVERY` and the command exits non-zero unless
+  `--allow-incomplete` is given. If you have already re-created a deleted parent,
+  remove its `INSERT` from the output — `FOREIGN_KEY_CHECKS=0` does not suppress
+  primary-key violations.
 
 ### WHERE Clause Strategy
 

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -18,6 +18,7 @@ func AddReadCommands(root *cobra.Command) {
 	root.AddCommand(statusCmd)
 	root.AddCommand(queryCmd)
 	root.AddCommand(recoverCmd)
+	root.AddCommand(recoverCascadeCmd)
 	root.AddCommand(reconstructCmd)
 	root.AddCommand(shimCmd)
 }

--- a/internal/cli/recover.go
+++ b/internal/cli/recover.go
@@ -176,8 +176,8 @@ func runRecover(cmd *cobra.Command, args []string) error {
 	// Plain recover cannot reconstruct rows deleted by an FK ON DELETE CASCADE:
 	// InnoDB executes the cascade below the binlog (MySQL Bug #32506), so the
 	// cascaded child deletes were never indexed. Warn loudly when the targeted
-	// schema carries cascade FKs — a dedicated cascade-recovery path (#548) will
-	// handle these; plain recover cannot.
+	// schema carries cascade FKs and point at `recover-cascade`, which
+	// reconstructs them; plain recover cannot.
 	var cascadeScope []string
 	if rSchema != "" {
 		cascadeScope = []string{rSchema}
@@ -195,7 +195,7 @@ func runRecover(cmd *cobra.Command, args []string) error {
 		}
 		slog.Warn("target schema has FK ON DELETE/UPDATE CASCADE constraints; plain `recover` "+
 			"cannot reconstruct cascade-deleted child rows (they are never binlogged, MySQL Bug "+
-			"#32506); cascade recovery is in progress (#548)",
+			"#32506); use `bintrail recover-cascade` to reconstruct them",
 			"cascade_child_tables", strings.Join(tables, ", "))
 	}
 

--- a/internal/cli/recover_cascade.go
+++ b/internal/cli/recover_cascade.go
@@ -1,0 +1,338 @@
+package cli
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dbtrail/dbtrail/internal/cascade"
+	"github.com/dbtrail/dbtrail/internal/cliutil"
+	"github.com/dbtrail/dbtrail/internal/config"
+	"github.com/dbtrail/dbtrail/internal/event"
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/query"
+	"github.com/dbtrail/dbtrail/internal/recovery"
+)
+
+var recoverCascadeCmd = &cobra.Command{
+	Use:   "recover-cascade",
+	Short: "Generate reversal SQL for rows deleted by a foreign-key ON DELETE CASCADE",
+	Long: `Reconstruct rows that an InnoDB foreign-key ON DELETE CASCADE removed but
+never wrote to the binary log.
+
+On MySQL <= 8.x (and MariaDB) InnoDB runs FK cascades below the binlog, so only
+the parent DELETE is logged — the cascaded child deletes are invisible to plain
+` + "`recover`" + ` (MySQL Bug #32506). This command finds the deleted parent rows in
+the index, infers which child rows referenced them in their last indexed state,
+and emits reversal SQL that re-inserts BOTH the parent rows and their
+cascade-deleted descendants, wrapped in SET FOREIGN_KEY_CHECKS=0/1.
+
+It NEVER executes SQL — review the dry-run/output before applying.
+
+Phase-1 (binlog-window) recovery: a child untouched within --lookback and not in
+a baseline cannot be reconstructed (baseline fallback is tracked in #548/#552).
+The command searches the live index only — archived partitions are not scanned;
+when they exist, the output is flagged incomplete.
+
+Examples:
+  # Preview recovery for one accidentally-deleted parent and its cascade
+  bintrail recover-cascade --index-dsn "..." \
+    --schema shop --table orders --pk '42' --dry-run
+
+  # All order deletes in a window, written to a file
+  bintrail recover-cascade --index-dsn "..." \
+    --schema shop --table orders \
+    --since "2026-06-21 14:00:00" --until "2026-06-21 14:10:00" \
+    --output cascade-recovery.sql`,
+	RunE: runRecoverCascade,
+}
+
+var (
+	rcIndexDSN        string
+	rcSchema          string
+	rcTable           string
+	rcPK              string
+	rcPKs             []string
+	rcSince           string
+	rcUntil           string
+	rcOutput          string
+	rcDryRun          bool
+	rcFormat          string
+	rcLookback        string
+	rcMaxDepth        int
+	rcLimit           int
+	rcAllowIncomplete bool
+)
+
+func init() {
+	f := recoverCascadeCmd.Flags()
+	f.StringVar(&rcIndexDSN, "index-dsn", "", "DSN for the index MySQL database (required)")
+	f.StringVar(&rcSchema, "schema", "", "Schema of the parent table whose delete cascaded (required)")
+	f.StringVar(&rcTable, "table", "", "Parent table whose ON DELETE CASCADE removed children (required)")
+	f.StringVar(&rcPK, "pk", "", "Restrict to a single deleted parent PK (pipe-delimited for composite PKs)")
+	f.StringSliceVar(&rcPKs, "pks", nil, "Restrict to multiple deleted parent PKs (comma-separated or repeated); mutually exclusive with --pk")
+	f.StringVar(&rcSince, "since", "", "Only parent deletes at or after this time (2006-01-02 15:04:05)")
+	f.StringVar(&rcUntil, "until", "", "Only parent deletes at or before this time (2006-01-02 15:04:05)")
+	f.StringVar(&rcOutput, "output", "", "Write recovery SQL to this file (required unless --dry-run)")
+	f.BoolVar(&rcDryRun, "dry-run", false, "Print recovery SQL to stdout instead of writing a file")
+	f.StringVar(&rcFormat, "format", "text", "Output format: text or json")
+	f.StringVar(&rcLookback, "lookback", "30d", "How far before each parent delete to search for child state (e.g. 30d, 24h)")
+	f.IntVar(&rcMaxDepth, "max-depth", 5, "Maximum cascade recursion depth (parent -> child -> grandchild ...)")
+	f.IntVar(&rcLimit, "limit", 1000, "Maximum number of parent DELETE events to process")
+	f.BoolVar(&rcAllowIncomplete, "allow-incomplete", false, "Exit 0 even when the reconstruction is provably partial (coverage gaps only; an operational failure still exits non-zero)")
+	_ = recoverCascadeCmd.MarkFlagRequired("index-dsn")
+	_ = recoverCascadeCmd.MarkFlagRequired("schema")
+	_ = recoverCascadeCmd.MarkFlagRequired("table")
+	BindCommandEnv(recoverCascadeCmd)
+}
+
+func runRecoverCascade(cmd *cobra.Command, args []string) error {
+	start := time.Now()
+
+	// ── Validate flags ────────────────────────────────────────────────────────
+	if !cliutil.IsValidOutputFormat(rcFormat) {
+		return fmt.Errorf("invalid --format %q; must be text or json", rcFormat)
+	}
+	if !rcDryRun && rcOutput == "" {
+		return fmt.Errorf("one of --output or --dry-run is required")
+	}
+	if rcPK != "" && len(rcPKs) > 0 {
+		return fmt.Errorf("--pk and --pks are mutually exclusive; use one or the other")
+	}
+	if rcMaxDepth < 1 {
+		return fmt.Errorf("--max-depth must be >= 1")
+	}
+	if rcLimit < 1 {
+		return fmt.Errorf("--limit must be >= 1")
+	}
+	cleanedPKs, err := cleanPKList(rcPKs)
+	if err != nil {
+		return err
+	}
+	rcPKs = cleanedPKs
+	lookback, err := cliutil.ParseRetain(rcLookback)
+	if err != nil {
+		return fmt.Errorf("--lookback: %w", err)
+	}
+	since, err := cliutil.ParseTime(rcSince)
+	if err != nil {
+		return fmt.Errorf("--since: %w", err)
+	}
+	until, err := cliutil.ParseTime(rcUntil)
+	if err != nil {
+		return fmt.Errorf("--until: %w", err)
+	}
+
+	// ── Connect + migrate ─────────────────────────────────────────────────────
+	db, err := config.Connect(rcIndexDSN)
+	if err != nil {
+		return fmt.Errorf("failed to connect to index database: %w", err)
+	}
+	defer db.Close()
+	if err := indexer.EnsureSchema(db); err != nil {
+		return fmt.Errorf("schema migration: %w", err)
+	}
+
+	// Resolver enables PK-only WHERE clauses; best-effort (recovery here only
+	// emits INSERTs, so a nil resolver is harmless).
+	resolver, err := metadata.NewResolver(db, 0)
+	if err != nil {
+		slog.Warn("could not load schema snapshot; recovery INSERTs still use full row images", "error", err)
+		resolver = nil
+	}
+
+	eng := query.New(db)
+	del := event.EventDelete
+
+	// ── Fetch the parent DELETE events (live index only) ──────────────────────
+	parentDeletes, err := eng.Fetch(cmd.Context(), query.Options{
+		Schema:     rcSchema,
+		Table:      rcTable,
+		PKValues:   rcPK,
+		PKValuesIn: rcPKs,
+		EventType:  &del,
+		Since:      since,
+		Until:      until,
+		Order:      "ASC",
+		Limit:      rcLimit,
+	})
+	if err != nil {
+		return fmt.Errorf("fetch parent deletes: %w", err)
+	}
+
+	// Coverage caveats accumulate here (detectable gaps only); the always-on
+	// Phase-1 scope note is separate and printed unconditionally.
+	var caveats []string
+
+	// Live-only trap: if the index has archived partitions, a parent or child
+	// whose events were rotated out is invisible here. Signal it rather than
+	// let "nothing found" read as "nothing to recover".
+	if archives, aerr := query.ResolveArchiveSources(cmd.Context(), db); aerr != nil {
+		slog.Warn("could not check for archived partitions", "error", aerr)
+	} else if len(archives) > 0 {
+		caveats = append(caveats, "the index has archived partitions, which cascade recovery does NOT search (live index only); events rotated out may be missed")
+	}
+
+	if len(parentDeletes) >= rcLimit {
+		caveats = append(caveats, fmt.Sprintf("parent DELETE events were capped at --limit=%d; narrow --pk/--since/--until or raise --limit", rcLimit))
+	}
+
+	// ── Synthesize the cascade victims ────────────────────────────────────────
+	var res cascade.Result
+	var synthErr error
+	if len(parentDeletes) > 0 {
+		fks, lerr := cascade.LoadCascadeFKs(cmd.Context(), db, []string{rcSchema})
+		if lerr != nil {
+			return fmt.Errorf("load FK graph: %w", lerr)
+		}
+		res, synthErr = cascade.SynthesizeVictims(cmd.Context(), eng, fks, parentDeletes, cascade.Options{
+			Lookback: lookback,
+			MaxDepth: rcMaxDepth,
+		})
+	}
+	caveats = append(caveats, res.Incomplete...)
+	if synthErr != nil {
+		caveats = append(caveats, "an index query failed mid-synthesis; the result is partial: "+synthErr.Error())
+	}
+
+	rows := append(append([]query.ResultRow{}, parentDeletes...), res.Victims...)
+
+	// ── Emit ──────────────────────────────────────────────────────────────────
+	hdr := cascadeHeader{
+		schema:   rcSchema,
+		table:    rcTable,
+		parents:  len(parentDeletes),
+		children: len(res.Victims),
+		caveats:  caveats,
+	}
+
+	if rcFormat == "json" {
+		var buf bytes.Buffer
+		n, gerr := emitCascadeSQL(&buf, recovery.New(db, resolver), rows, hdr)
+		if gerr != nil {
+			return gerr
+		}
+		if rcOutput != "" {
+			if werr := os.WriteFile(rcOutput, buf.Bytes(), 0o600); werr != nil {
+				return fmt.Errorf("failed to write output file %q: %w", rcOutput, werr)
+			}
+		}
+		out := struct {
+			Parents    int      `json:"parents"`
+			Children   int      `json:"children"`
+			Statements int      `json:"statements"`
+			Complete   bool     `json:"complete"`
+			Incomplete []string `json:"incomplete,omitempty"`
+			Output     string   `json:"output,omitempty"`
+			SQL        string   `json:"sql,omitempty"`
+		}{
+			Parents: len(parentDeletes), Children: len(res.Victims), Statements: n,
+			Complete: len(caveats) == 0 && synthErr == nil, Incomplete: caveats,
+			Output: rcOutput,
+		}
+		if rcOutput == "" {
+			out.SQL = buf.String()
+		}
+		// JSON carries `complete`; the consumer branches on it, so exit 0.
+		return cliutil.OutputJSON(out)
+	}
+
+	var w io.Writer = os.Stdout
+	var closeFn func() error
+	if rcOutput != "" {
+		f, ferr := os.OpenFile(rcOutput, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
+		if ferr != nil {
+			return fmt.Errorf("failed to create output file %q: %w", rcOutput, ferr)
+		}
+		bw := bufio.NewWriter(f)
+		w = bw
+		closeFn = func() error {
+			if e := bw.Flush(); e != nil {
+				return e
+			}
+			return f.Close()
+		}
+	}
+	n, gerr := emitCascadeSQL(w, recovery.New(db, resolver), rows, hdr)
+	if gerr != nil {
+		return gerr
+	}
+	if closeFn != nil {
+		if e := closeFn(); e != nil {
+			return fmt.Errorf("failed to flush output file: %w", e)
+		}
+	}
+
+	dest := "stdout"
+	if rcOutput != "" {
+		dest = rcOutput
+	}
+	for _, c := range caveats {
+		slog.Warn("cascade recovery incomplete", "reason", c)
+	}
+	slog.Info("cascade recovery SQL generated",
+		"parents", len(parentDeletes), "children", len(res.Victims), "statements", n,
+		"complete", len(caveats) == 0 && synthErr == nil,
+		"output", dest, "duration_ms", time.Since(start).Milliseconds())
+
+	// An operational failure always exits non-zero. Coverage gaps exit non-zero
+	// unless the operator opted in with --allow-incomplete.
+	if synthErr != nil {
+		return fmt.Errorf("SQL written to %s but synthesis hit an operational failure (result is partial): %w", dest, synthErr)
+	}
+	if len(caveats) > 0 && !rcAllowIncomplete {
+		return fmt.Errorf("SQL written to %s but the recovery is INCOMPLETE (%d caveat(s) above); review, then re-run with --allow-incomplete to exit 0", dest, len(caveats))
+	}
+	return nil
+}
+
+// cascadeHeader carries the values rendered into the SQL preamble.
+type cascadeHeader struct {
+	schema, table     string
+	parents, children int
+	caveats           []string
+}
+
+// emitCascadeSQL writes the documented preamble, the FK-checks-off wrapper, and
+// the reversal statements, returning the statement count from the generator.
+func emitCascadeSQL(w io.Writer, gen *recovery.Generator, rows []query.ResultRow, hdr cascadeHeader) (int, error) {
+	var b strings.Builder
+	fmt.Fprintf(&b, "-- bintrail recover-cascade: reverse ON DELETE CASCADE side effects on %s.%s\n", hdr.schema, hdr.table)
+	fmt.Fprintf(&b, "-- Re-inserts %d deleted parent row(s) and %d cascade-deleted child row(s)\n", hdr.parents, hdr.children)
+	b.WriteString("-- that InnoDB removed below the binlog (MySQL Bug #32506). NEVER auto-applied.\n")
+	b.WriteString("--\n")
+	b.WriteString("-- Phase-1 (binlog-window) recovery: a child untouched within --lookback and not\n")
+	b.WriteString("-- in a baseline is NOT reconstructed (baseline fallback: #552). \"Complete\" means\n")
+	b.WriteString("-- everything DETECTABLE was recovered, not that no row was missed.\n")
+	b.WriteString("--\n")
+	b.WriteString("-- If you have already re-created a deleted parent, delete its INSERT below:\n")
+	b.WriteString("-- SET FOREIGN_KEY_CHECKS=0 does NOT suppress PRIMARY KEY violations.\n")
+	if len(hdr.caveats) > 0 {
+		b.WriteString("--\n-- !!! INCOMPLETE RECOVERY — the result is provably partial:\n")
+		for _, c := range hdr.caveats {
+			fmt.Fprintf(&b, "--   - %s\n", c)
+		}
+	}
+	b.WriteString("\nSET FOREIGN_KEY_CHECKS=0;\n\n")
+	if _, err := io.WriteString(w, b.String()); err != nil {
+		return 0, err
+	}
+
+	n, err := gen.GenerateSQLFromRows(rows, w)
+	if err != nil {
+		return 0, err
+	}
+
+	if _, err := io.WriteString(w, "\nSET FOREIGN_KEY_CHECKS=1;\n"); err != nil {
+		return n, err
+	}
+	return n, nil
+}

--- a/internal/cli/recover_cascade.go
+++ b/internal/cli/recover_cascade.go
@@ -28,8 +28,9 @@ var recoverCascadeCmd = &cobra.Command{
 	Long: `Reconstruct rows that an InnoDB foreign-key ON DELETE CASCADE removed but
 never wrote to the binary log.
 
-On MySQL <= 8.x (and MariaDB) InnoDB runs FK cascades below the binlog, so only
-the parent DELETE is logged — the cascaded child deletes are invisible to plain
+On MySQL <= 8.x and MariaDB, InnoDB runs FK cascades below the binlog (fixed in
+MySQL 9.6), so only the parent DELETE is logged — the cascaded child deletes are
+invisible to plain
 ` + "`recover`" + ` (MySQL Bug #32506). This command finds the deleted parent rows in
 the index, infers which child rows referenced them in their last indexed state,
 and emits reversal SQL that re-inserts BOTH the parent rows and their
@@ -38,7 +39,7 @@ cascade-deleted descendants, wrapped in SET FOREIGN_KEY_CHECKS=0/1.
 It NEVER executes SQL — review the dry-run/output before applying.
 
 Phase-1 (binlog-window) recovery: a child untouched within --lookback and not in
-a baseline cannot be reconstructed (baseline fallback is tracked in #548/#552).
+a baseline cannot be reconstructed (baseline fallback is tracked in #552).
 The command searches the live index only — archived partitions are not scanned;
 when they exist, the output is flagged incomplete.
 
@@ -168,17 +169,33 @@ func runRecoverCascade(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("fetch parent deletes: %w", err)
 	}
 
-	// Coverage caveats accumulate here (detectable gaps only); the always-on
-	// Phase-1 scope note is separate and printed unconditionally.
+	// Coverage caveats accumulate here (detectable gaps that gate exit); the
+	// always-on Phase-1 scope note is separate and printed unconditionally.
 	var caveats []string
 
-	// Live-only trap: if the index has archived partitions, a parent or child
-	// whose events were rotated out is invisible here. Signal it rather than
-	// let "nothing found" read as "nothing to recover".
+	// A plain empty match is legitimately "complete", but the operator must not
+	// read silence as "nothing was deleted" — it could be a wrong filter.
+	if len(parentDeletes) == 0 {
+		slog.Warn("no parent DELETE events matched in the live index; verify --schema/--table/--pk/--since/--until")
+	}
+
+	// Live-only trap: cascade recovery searches the LIVE index only.
+	//   - probe failure  → we cannot tell whether archives exist → coverage
+	//     unknown (hard caveat).
+	//   - archives exist AND nothing matched live → the deleted parent may itself
+	//     be archived → hard caveat (the dangerous "nothing found" case).
+	//   - archives exist but parents WERE found → a child whose events were
+	//     archived could still be missed → a visible warning, NOT a hard caveat:
+	//     otherwise every archived deployment trips INCOMPLETE on every run and
+	//     --allow-incomplete becomes routine, masking the real coverage gaps.
 	if archives, aerr := query.ResolveArchiveSources(cmd.Context(), db); aerr != nil {
-		slog.Warn("could not check for archived partitions", "error", aerr)
+		caveats = append(caveats, "could not determine whether archived partitions exist (probe failed: "+aerr.Error()+"); coverage is unknown")
 	} else if len(archives) > 0 {
-		caveats = append(caveats, "the index has archived partitions, which cascade recovery does NOT search (live index only); events rotated out may be missed")
+		if len(parentDeletes) == 0 {
+			caveats = append(caveats, "no parent DELETE matched in the live index, but the index has archived partitions (cascade recovery does NOT search them); the deleted parent may be archived")
+		} else {
+			slog.Warn("index has archived partitions, which cascade recovery does NOT search (live index only); a child whose events were archived may be missed")
+		}
 	}
 
 	if len(parentDeletes) >= rcLimit {
@@ -226,23 +243,34 @@ func runRecoverCascade(cmd *cobra.Command, args []string) error {
 			}
 		}
 		out := struct {
-			Parents    int      `json:"parents"`
-			Children   int      `json:"children"`
-			Statements int      `json:"statements"`
-			Complete   bool     `json:"complete"`
-			Incomplete []string `json:"incomplete,omitempty"`
-			Output     string   `json:"output,omitempty"`
-			SQL        string   `json:"sql,omitempty"`
+			Parents          int      `json:"parents"`
+			Children         int      `json:"children"`
+			Statements       int      `json:"statements"`
+			Complete         bool     `json:"complete"`
+			OperationalError bool     `json:"operational_error,omitempty"`
+			Incomplete       []string `json:"incomplete,omitempty"`
+			Output           string   `json:"output,omitempty"`
+			SQL              string   `json:"sql,omitempty"`
 		}{
 			Parents: len(parentDeletes), Children: len(res.Victims), Statements: n,
-			Complete: len(caveats) == 0 && synthErr == nil, Incomplete: caveats,
-			Output: rcOutput,
+			Complete: len(caveats) == 0 && synthErr == nil, OperationalError: synthErr != nil,
+			Incomplete: caveats, Output: rcOutput,
 		}
 		if rcOutput == "" {
 			out.SQL = buf.String()
 		}
-		// JSON carries `complete`; the consumer branches on it, so exit 0.
-		return cliutil.OutputJSON(out)
+		if err := cliutil.OutputJSON(out); err != nil {
+			return err
+		}
+		// Same exit contract as text mode: the `complete` field is on stdout, but
+		// a consumer gating on EXIT CODE must still see a non-zero exit when the
+		// recovery is partial. Returning an error here makes the root emit
+		// {"error":...} to stderr while the result stays on stdout (#568 review).
+		dest := "stdout"
+		if rcOutput != "" {
+			dest = rcOutput
+		}
+		return cascadeExit(dest, synthErr, caveats, rcAllowIncomplete)
 	}
 
 	var w io.Writer = os.Stdout
@@ -283,12 +311,19 @@ func runRecoverCascade(cmd *cobra.Command, args []string) error {
 		"complete", len(caveats) == 0 && synthErr == nil,
 		"output", dest, "duration_ms", time.Since(start).Milliseconds())
 
-	// An operational failure always exits non-zero. Coverage gaps exit non-zero
-	// unless the operator opted in with --allow-incomplete.
+	return cascadeExit(dest, synthErr, caveats, rcAllowIncomplete)
+}
+
+// cascadeExit returns the error the command should end with, shared by text and
+// JSON modes so the exit-code contract is identical: an operational failure
+// always exits non-zero (even with --allow-incomplete); detectable coverage
+// gaps exit non-zero unless --allow-incomplete. The SQL is already durable by
+// the time this is called, so the error reports "written but partial".
+func cascadeExit(dest string, synthErr error, caveats []string, allowIncomplete bool) error {
 	if synthErr != nil {
 		return fmt.Errorf("SQL written to %s but synthesis hit an operational failure (result is partial): %w", dest, synthErr)
 	}
-	if len(caveats) > 0 && !rcAllowIncomplete {
+	if len(caveats) > 0 && !allowIncomplete {
 		return fmt.Errorf("SQL written to %s but the recovery is INCOMPLETE (%d caveat(s) above); review, then re-run with --allow-incomplete to exit 0", dest, len(caveats))
 	}
 	return nil

--- a/internal/cli/recover_cascade_integration_test.go
+++ b/internal/cli/recover_cascade_integration_test.go
@@ -1,0 +1,146 @@
+//go:build integration
+
+package cli
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// seedCascadeIndex builds a minimal indexed cascade in a fresh index DB: a
+// parent DELETE plus two child INSERTs that referenced it, and the fk_constraints
+// row marking child.pid -> parent.id ON DELETE CASCADE. Returns (db, dbName, dsn).
+func seedCascadeIndex(t *testing.T) (*sql.DB, string, string) {
+	t.Helper()
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	h := time.Now().UTC().Add(-1 * time.Hour).Truncate(time.Hour)
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{h})
+	childTs := h.Add(10 * time.Minute).Format("2006-01-02 15:04:05")
+	parentTs := h.Add(20 * time.Minute).Format("2006-01-02 15:04:05")
+
+	// child INSERTs (the cascade victims' last indexed state) and the parent
+	// DELETE that cascaded them. The cascade child deletes are intentionally
+	// NOT inserted — that is the blind spot the command reconstructs.
+	testutil.InsertEvent(t, db, "binlog.000001", 100, 200, childTs, nil,
+		dbName, "child", 1 /* INSERT */, "10", nil, nil, []byte(`{"id":10,"pid":1}`))
+	testutil.InsertEvent(t, db, "binlog.000001", 200, 300, childTs, nil,
+		dbName, "child", 1 /* INSERT */, "11", nil, nil, []byte(`{"id":11,"pid":1}`))
+	testutil.InsertEvent(t, db, "binlog.000001", 300, 400, parentTs, nil,
+		dbName, "parent", 3 /* DELETE */, "1", nil, []byte(`{"id":1}`), nil)
+
+	testutil.MustExec(t, db, `INSERT INTO fk_constraints
+		(snapshot_id, constraint_name, schema_name, table_name, column_name, ordinal_position,
+		 referenced_schema_name, referenced_table_name, referenced_column_name, delete_rule, update_rule)
+		VALUES (1, 'fk_child', ?, 'child', 'pid', 1, ?, 'parent', 'id', 'CASCADE', 'RESTRICT')`,
+		dbName, dbName)
+
+	return db, dbName, testutil.IntegrationDSN(dbName)
+}
+
+func runCascadeCmd(t *testing.T) error {
+	t.Helper()
+	c := &cobra.Command{}
+	c.SetContext(context.Background())
+	return runRecoverCascade(c, nil)
+}
+
+// TestRecoverCascade_endToEnd drives the command over a seeded index and checks
+// the emitted SQL re-inserts the parent and its cascade-deleted children inside
+// the FK-checks-off wrapper, with the Phase-1 scope header, and reports complete.
+func TestRecoverCascade_endToEnd(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	_, dbName, dsn := seedCascadeIndex(t)
+	out := t.TempDir() + "/cascade.sql"
+
+	// Reset command globals to a clean state for this run.
+	rcIndexDSN, rcSchema, rcTable = dsn, dbName, "parent"
+	rcPK, rcPKs, rcSince, rcUntil = "", nil, "", ""
+	rcOutput, rcDryRun, rcFormat = out, false, "text"
+	rcLookback, rcMaxDepth, rcLimit, rcAllowIncomplete = "30d", 5, 1000, false
+
+	if err := runCascadeCmd(t); err != nil {
+		t.Fatalf("runRecoverCascade: %v", err)
+	}
+
+	b, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	sql := string(b)
+	for _, want := range []string{
+		"SET FOREIGN_KEY_CHECKS=0;",
+		"SET FOREIGN_KEY_CHECKS=1;",
+		"Phase-1",
+		"`" + dbName + "`.`parent`", // parent re-insert
+		"`" + dbName + "`.`child`",  // child re-inserts
+	} {
+		if !strings.Contains(sql, want) {
+			t.Errorf("output missing %q\n---\n%s", want, sql)
+		}
+	}
+	// Both children must be re-inserted.
+	if c := strings.Count(sql, "`"+dbName+"`.`child`"); c != 2 {
+		t.Errorf("want 2 child INSERTs, got %d\n---\n%s", c, sql)
+	}
+	// A clean cascade with no archives must NOT be flagged incomplete.
+	if strings.Contains(sql, "INCOMPLETE RECOVERY") {
+		t.Errorf("clean cascade should not be flagged incomplete\n---\n%s", sql)
+	}
+}
+
+// TestRecoverCascade_incompleteExit proves that a detectable coverage gap (here:
+// the index has archived partitions the live-only search can't see) flags the
+// output incomplete and makes the command exit non-zero unless --allow-incomplete.
+func TestRecoverCascade_incompleteExit(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	db, dbName, dsn := seedCascadeIndex(t)
+
+	// An archive_state row with an S3 location makes ResolveArchiveSources
+	// return non-empty (no disk dependency), tripping the live-only caveat.
+	testutil.MustExec(t, db, `INSERT INTO archive_state
+		(bintrail_id, partition_name, s3_bucket, s3_key)
+		VALUES ('bt', 'p_2026010100', 'bucket', 'bintrail_id=bt/p_2026010100/data.parquet')`)
+
+	out := t.TempDir() + "/cascade.sql"
+	rcIndexDSN, rcSchema, rcTable = dsn, dbName, "parent"
+	rcPK, rcPKs, rcSince, rcUntil = "", nil, "", ""
+	rcOutput, rcDryRun, rcFormat = out, false, "text"
+	rcLookback, rcMaxDepth, rcLimit = "30d", 5, 1000
+
+	// Without --allow-incomplete: SQL is still written, but the command errors.
+	rcAllowIncomplete = false
+	err := runCascadeCmd(t)
+	if err == nil {
+		t.Fatal("expected a non-nil error when incomplete and --allow-incomplete is false")
+	}
+	if !strings.Contains(err.Error(), "INCOMPLETE") {
+		t.Errorf("error should explain incompleteness, got: %v", err)
+	}
+	b, rerr := os.ReadFile(out)
+	if rerr != nil {
+		t.Fatalf("output should still be written on incomplete: %v", rerr)
+	}
+	if !strings.Contains(string(b), "INCOMPLETE RECOVERY") {
+		t.Errorf("output should carry the incomplete header")
+	}
+
+	// With --allow-incomplete: same output, but exit 0.
+	rcAllowIncomplete = true
+	if err := runCascadeCmd(t); err != nil {
+		t.Fatalf("--allow-incomplete should exit 0, got: %v", err)
+	}
+}

--- a/internal/cli/recover_cascade_integration_test.go
+++ b/internal/cli/recover_cascade_integration_test.go
@@ -100,28 +100,45 @@ func TestRecoverCascade_endToEnd(t *testing.T) {
 	if strings.Contains(sql, "INCOMPLETE RECOVERY") {
 		t.Errorf("clean cascade should not be flagged incomplete\n---\n%s", sql)
 	}
+
+	// 0 parent deletes (a --pk that matches nothing), no archives: a legitimately
+	// empty result is complete and exits 0 (the operator gets a stderr warning).
+	rcPK = "999"
+	if err := runCascadeCmd(t); err != nil {
+		t.Errorf("0 matched parents with no archives must exit 0, got: %v", err)
+	}
 }
 
-// TestRecoverCascade_incompleteExit proves that a detectable coverage gap (here:
-// the index has archived partitions the live-only search can't see) flags the
-// output incomplete and makes the command exit non-zero unless --allow-incomplete.
-func TestRecoverCascade_incompleteExit(t *testing.T) {
-	testutil.SkipIfNoMySQL(t)
-	db, dbName, dsn := seedCascadeIndex(t)
-
-	// An archive_state row with an S3 location makes ResolveArchiveSources
-	// return non-empty (no disk dependency), tripping the live-only caveat.
+// addArchiveRow makes ResolveArchiveSources return non-empty (no disk
+// dependency) by registering an S3-located archived partition.
+func addArchiveRow(t *testing.T, db *sql.DB) {
+	t.Helper()
 	testutil.MustExec(t, db, `INSERT INTO archive_state
 		(bintrail_id, partition_name, s3_bucket, s3_key)
 		VALUES ('bt', 'p_2026010100', 'bucket', 'bintrail_id=bt/p_2026010100/data.parquet')`)
+}
 
-	out := t.TempDir() + "/cascade.sql"
+// cleanCascadeFlags sets every recover-cascade global to a valid baseline for an
+// integration run, so no stale value leaks in from another test.
+func cleanCascadeFlags(dsn, dbName, out string) {
 	rcIndexDSN, rcSchema, rcTable = dsn, dbName, "parent"
 	rcPK, rcPKs, rcSince, rcUntil = "", nil, "", ""
 	rcOutput, rcDryRun, rcFormat = out, false, "text"
-	rcLookback, rcMaxDepth, rcLimit = "30d", 5, 1000
+	rcLookback, rcMaxDepth, rcLimit, rcAllowIncomplete = "30d", 5, 1000, false
+}
 
-	// Without --allow-incomplete: SQL is still written, but the command errors.
+// TestRecoverCascade_incompleteExit proves the dangerous "nothing found" case:
+// 0 live parents matched BUT the index has archived partitions (not searched) →
+// flagged incomplete, exit non-zero unless --allow-incomplete; SQL still written.
+func TestRecoverCascade_incompleteExit(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	db, dbName, dsn := seedCascadeIndex(t)
+	addArchiveRow(t, db)
+
+	out := t.TempDir() + "/cascade.sql"
+	cleanCascadeFlags(dsn, dbName, out)
+	rcPK = "999" // matches no live parent → the "nothing found, but archives exist" trap
+
 	rcAllowIncomplete = false
 	err := runCascadeCmd(t)
 	if err == nil {
@@ -138,9 +155,54 @@ func TestRecoverCascade_incompleteExit(t *testing.T) {
 		t.Errorf("output should carry the incomplete header")
 	}
 
-	// With --allow-incomplete: same output, but exit 0.
 	rcAllowIncomplete = true
 	if err := runCascadeCmd(t); err != nil {
 		t.Fatalf("--allow-incomplete should exit 0, got: %v", err)
+	}
+}
+
+// TestRecoverCascade_archivesWithParentsNotBlocking pins the cry-wolf fix: when
+// parents ARE found, the presence of archives is a warning, NOT a hard caveat —
+// so a routine archived deployment doesn't force --allow-incomplete (which would
+// mask the real coverage gaps). Also exercises --pk filtering (pk=1 matches).
+func TestRecoverCascade_archivesWithParentsNotBlocking(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	db, dbName, dsn := seedCascadeIndex(t)
+	addArchiveRow(t, db)
+
+	out := t.TempDir() + "/cascade.sql"
+	cleanCascadeFlags(dsn, dbName, out)
+	rcPK = "1" // matches the seeded parent delete → parents found
+
+	if err := runCascadeCmd(t); err != nil {
+		t.Fatalf("archives present but parents found must NOT block (cry-wolf), got: %v", err)
+	}
+	b, _ := os.ReadFile(out)
+	if strings.Contains(string(b), "INCOMPLETE RECOVERY") {
+		t.Errorf("found-parents + archives must not flag INCOMPLETE\n---\n%s", string(b))
+	}
+}
+
+// TestRecoverCascade_jsonExitParity pins the #568 fix: --format json must honor
+// the same exit contract as text — a partial result exits non-zero (the body's
+// `complete:false` is on stdout, but consumers gating on exit code must see it).
+func TestRecoverCascade_jsonExitParity(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	db, dbName, dsn := seedCascadeIndex(t)
+	addArchiveRow(t, db)
+
+	out := t.TempDir() + "/cascade.sql"
+	cleanCascadeFlags(dsn, dbName, out)
+	rcFormat = "json"
+	rcPK = "999" // 0 parents + archives → incomplete
+
+	rcAllowIncomplete = false
+	if err := runCascadeCmd(t); err == nil {
+		t.Fatal("JSON mode must exit non-zero when incomplete, like text mode (#568)")
+	}
+	// --allow-incomplete suppresses the coverage-gap exit in JSON mode too.
+	rcAllowIncomplete = true
+	if err := runCascadeCmd(t); err != nil {
+		t.Fatalf("JSON + --allow-incomplete should exit 0, got: %v", err)
 	}
 }

--- a/internal/cli/recover_cascade_test.go
+++ b/internal/cli/recover_cascade_test.go
@@ -1,0 +1,39 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestRecoverCascadeFlagsRegistered(t *testing.T) {
+	for _, name := range []string{
+		"index-dsn", "schema", "table", "pk", "pks", "since", "until",
+		"output", "dry-run", "format", "lookback", "max-depth", "limit", "allow-incomplete",
+	} {
+		if recoverCascadeCmd.Flags().Lookup(name) == nil {
+			t.Errorf("flag --%s not registered on recoverCascadeCmd", name)
+		}
+	}
+	for _, name := range []string{"index-dsn", "schema", "table"} {
+		f := recoverCascadeCmd.Flags().Lookup(name)
+		if f == nil || f.Annotations[cobra.BashCompOneRequiredFlag] == nil {
+			t.Errorf("flag --%s should be required", name)
+		}
+	}
+}
+
+func TestRecoverCascadeRegistered(t *testing.T) {
+	root := &cobra.Command{Use: "bintrail"}
+	AddReadCommands(root)
+	var found bool
+	for _, c := range root.Commands() {
+		if c.Name() == "recover-cascade" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("recover-cascade not registered by AddReadCommands")
+	}
+}

--- a/internal/cli/recover_cascade_test.go
+++ b/internal/cli/recover_cascade_test.go
@@ -1,10 +1,56 @@
 package cli
 
 import (
+	"context"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
 )
+
+// resetCascadeFlags sets every recover-cascade global to a valid baseline so a
+// validation test can flip exactly one into the bad state it exercises.
+func resetCascadeFlags() {
+	rcIndexDSN = "root:x@tcp(127.0.0.1:1)/idx"
+	rcSchema, rcTable = "app", "parent"
+	rcPK, rcPKs, rcSince, rcUntil = "", nil, "", ""
+	rcOutput, rcDryRun, rcFormat = "", true, "text"
+	rcLookback, rcMaxDepth, rcLimit, rcAllowIncomplete = "30d", 5, 1000, false
+}
+
+// TestRunRecoverCascade_validation pins the pre-DB validation branches — they
+// all return before config.Connect, so no MySQL is needed.
+func TestRunRecoverCascade_validation(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func()
+		want   string
+	}{
+		{"invalid format", func() { rcFormat = "xml" }, "invalid --format"},
+		{"no output and no dry-run", func() { rcDryRun = false; rcOutput = "" }, "--output or --dry-run"},
+		{"pk and pks", func() { rcPK = "1"; rcPKs = []string{"2"} }, "mutually exclusive"},
+		{"max-depth zero", func() { rcMaxDepth = 0 }, "--max-depth"},
+		{"limit zero", func() { rcLimit = 0 }, "--limit"},
+		{"bad lookback", func() { rcLookback = "bogus" }, "--lookback"},
+		{"bad since", func() { rcSince = "not-a-time" }, "--since"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			resetCascadeFlags()
+			c.mutate()
+			cmd := &cobra.Command{}
+			cmd.SetContext(context.Background())
+			err := runRecoverCascade(cmd, nil)
+			if err == nil {
+				t.Fatalf("expected an error for %q, got nil", c.name)
+			}
+			if !strings.Contains(err.Error(), c.want) {
+				t.Errorf("error %q should contain %q", err.Error(), c.want)
+			}
+		})
+	}
+	resetCascadeFlags() // leave globals clean for other tests
+}
 
 func TestRecoverCascadeFlagsRegistered(t *testing.T) {
 	for _, name := range []string{

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -423,11 +423,12 @@ func checkFKCascades(db *sql.DB, schemas []string) CheckResult {
 			"     ALTER TABLE <child> DROP FOREIGN KEY <fk_name>;\n" +
 			"     ALTER TABLE <child> ADD CONSTRAINT <fk_name> FOREIGN KEY (...) REFERENCES <parent>(...)\n" +
 			"         ON DELETE RESTRICT ON UPDATE RESTRICT;\n\n" +
-			"  2. Keep the cascades and recover cascade-deleted child rows manually for\n" +
-			"     now (full cascade recovery is in progress, #548).\n\n" +
+			"  2. Keep the cascades and reconstruct cascade-deleted child rows with\n" +
+			"     `bintrail recover-cascade` (Phase-1: binlog-window; baseline fallback #552).\n\n" +
 			"Ingestion (`stream`/`watch`/`up`/`index --source-dsn`) no longer refuses cascade\n" +
 			"schemas — it WARNS and proceeds — so the FK graph is captured for cascade recovery.\n" +
-			"Plain `recover` still produces incomplete SQL for cascade-affected tables.",
+			"Plain `recover` still produces incomplete SQL for cascade-affected tables; use\n" +
+			"`recover-cascade` instead for those.",
 	}
 }
 

--- a/internal/streamrun/streamrun.go
+++ b/internal/streamrun/streamrun.go
@@ -1266,7 +1266,7 @@ func One(ctx context.Context, cfg Config) error {
 		slog.Warn("FK cascade constraints present on source; streaming will proceed, "+
 			"but InnoDB executes cascades below the binlog (MySQL Bug #32506) so cascaded "+
 			"child-row deletes are NOT captured \u2014 plain `recover` cannot restore them. "+
-			"Cascade recovery is in progress (#548).",
+			"Reconstruct them with `bintrail recover-cascade`.",
 			"detail", err.Error())
 	} else {
 		fmt.Println("Source: no FK cascades \u2713")


### PR DESCRIPTION
## What

Cascade-recovery **Slice C** — the user-facing command. Closes #551. Part of #548. Depends on #549 + #550 (merged).

New **`bintrail recover-cascade`** (in `internal/cli`, registered via `AddReadCommands` so `bintrail-pg` gets it too) wires the synthesis engine (#550) to recovery-SQL generation. It finds the deleted parent rows in the index, synthesizes the cascade-deleted children from their last indexed `row_after`, and emits reversal SQL that re-inserts **both** the parents and their cascade-deleted descendants (recursing through multi-level cascades), wrapped in `SET FOREIGN_KEY_CHECKS=0/1`. **Dry-run only — never executes.**

### Flags
`--index-dsn`/`--schema`/`--table` (parent) required; `--pk`/`--pks`, `--since`/`--until`; `--output`/`--dry-run`; `--format`; `--lookback` (default `30d`, parsed via `cliutil.ParseRetain` so `30d`/`24h` work — Go's `DurationVar` rejects `d`); `--max-depth` (default 5); `--limit` (default 1000, bounds the parent-delete fetch); `--allow-incomplete`.

### Incompleteness contract (consumes `cascade.Result.Complete()`)
For a recovery tool, presenting a partial result as complete is the cardinal sin. So:
- **Detectable gaps** — composite FK skipped, depth/candidate caps hit, **archived partitions present** (cascade recovery is live-index-only), index anomalies — print an `INCOMPLETE RECOVERY` header + `slog.Warn` and **exit non-zero unless `--allow-incomplete`**.
- An **operational query failure** always exits non-zero (even with `--allow-incomplete`).
- `--format json` carries `complete`/`incomplete` and exits 0 (the consumer branches on the field).
- An **always-on Phase-1 scope note** is in the header unconditionally (binlog-window only; baseline fallback #552), kept separate from detectable-gap warnings because the lookback omission is *undetectable* — "Complete" means "everything detectable was recovered," not "nothing was missed."
- Header also warns: if you already re-created a deleted parent, drop its `INSERT` — `FOREIGN_KEY_CHECKS=0` does not suppress PK violations.

### Loop-closing
The cascade warnings in `index`/`stream`/`recover`/`doctor` and `docs/query-and-recovery.md` previously said "cascade recovery is in progress (#548)"; now that the command exists (this PR), they name **`recover-cascade`**.

## Tests
- Unit: flags registered (+ required), command registered by `AddReadCommands`.
- Integration (MySQL 8.0, direct index seeding): end-to-end recovery re-inserts the parent + both children inside the FK-checks wrapper with the Phase-1 header and reports complete; incomplete path (archived partitions) writes the SQL with the `INCOMPLETE` header and exits non-zero, while `--allow-incomplete` exits 0.

Full unit suite + `internal/cli` + `internal/doctor` integration green.

## Deviation from the issue
Issue #551 said to wire `--baseline-dir`/`--baseline-s3` through now. **Omitted** — stub flags that do nothing are the same vapor this epic has been stripping out; Slice D (#552) adds them when baseline fallback actually works.

## Next
Slice D (#552) — Phase-2 baseline fallback (the correctness slice) — and Slice E (#553) — full `ON DELETE SET NULL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
