### PR TITLE
feat: Phase-2 baseline fallback for cascade recovery (#552 cascade-recovery slice D)

### DIFF
--- a/docs/query-and-recovery.md
+++ b/docs/query-and-recovery.md
@@ -224,12 +224,15 @@ bintrail recover-cascade --index-dsn "..." \
   window are visible. Point at a `bintrail baseline` snapshot and those untouched
   children are recovered from it too, and the binlog window is widened to the
   snapshot time. Tables not covered by the baseline are flagged incomplete.
-- **Still best-effort:** archived binlog partitions are not searched, and a table
-  with no baseline keeps the Phase-1 window limit. When the result is provably
-  partial the output is flagged `INCOMPLETE RECOVERY` and the command exits
-  non-zero unless `--allow-incomplete` is given. If you have already re-created a
-  deleted parent, remove its `INSERT` from the output — `FOREIGN_KEY_CHECKS=0`
-  does not suppress primary-key violations.
+- **Still best-effort:** baseline augmentation is skipped (and flagged) for a
+  table when the index has archived partitions (which the live scan can't see, so
+  a child re-parented or deleted in the gap can't be told apart from an untouched
+  one) or when one parent has more cascade victims than the per-parent cap. A
+  table with no baseline keeps the Phase-1 window limit. When the result is
+  provably partial the output is flagged `INCOMPLETE RECOVERY` and the command
+  exits non-zero unless `--allow-incomplete` is given. If you have already
+  re-created a deleted parent, remove its `INSERT` from the output —
+  `FOREIGN_KEY_CHECKS=0` does not suppress primary-key violations.
 
 ### WHERE Clause Strategy
 

--- a/docs/query-and-recovery.md
+++ b/docs/query-and-recovery.md
@@ -218,13 +218,18 @@ bintrail recover-cascade --index-dsn "..." \
   `--since`/`--until` narrow which deleted parents to process.
 - `--lookback` (default `30d`) bounds how far back the last child state is
   searched; `--max-depth` (default 5) bounds cascade recursion.
-- **Phase-1 limitation:** a child untouched within `--lookback` and absent from a
-  baseline is not reconstructed (baseline fallback is #552), and archived
-  partitions are not searched. When the result is provably partial the output is
-  flagged `INCOMPLETE RECOVERY` and the command exits non-zero unless
-  `--allow-incomplete` is given. If you have already re-created a deleted parent,
-  remove its `INSERT` from the output — `FOREIGN_KEY_CHECKS=0` does not suppress
-  primary-key violations.
+- **Phase-2 baseline fallback** (`--baseline-dir` or `--baseline-s3`): without a
+  baseline, a child untouched within `--lookback` (e.g. an insert-once row from
+  months ago) cannot be reconstructed — only children with a binlog event in the
+  window are visible. Point at a `bintrail baseline` snapshot and those untouched
+  children are recovered from it too, and the binlog window is widened to the
+  snapshot time. Tables not covered by the baseline are flagged incomplete.
+- **Still best-effort:** archived binlog partitions are not searched, and a table
+  with no baseline keeps the Phase-1 window limit. When the result is provably
+  partial the output is flagged `INCOMPLETE RECOVERY` and the command exits
+  non-zero unless `--allow-incomplete` is given. If you have already re-created a
+  deleted parent, remove its `INSERT` from the output — `FOREIGN_KEY_CHECKS=0`
+  does not suppress primary-key violations.
 
 ### WHERE Clause Strategy
 

--- a/internal/cascade/baseline_integration_test.go
+++ b/internal/cascade/baseline_integration_test.go
@@ -1,0 +1,211 @@
+//go:build integration
+
+package cascade_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/cascade"
+	"github.com/dbtrail/dbtrail/internal/query"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// fakeBaseline is a canned BaselineProvider — it lets the Phase-1/Phase-2 merge
+// logic be tested without a real Parquet snapshot (the binlog side still uses a
+// real but possibly-empty index DB).
+type fakeBaseline struct {
+	snap  time.Time
+	rows  []cascade.BaselineRow
+	ok    bool
+	trunc bool
+	err   error
+	calls int
+}
+
+func (f *fakeBaseline) BaselineChildren(_ context.Context, _, _, _, _ string, _ time.Time, _ int) (cascade.BaselineLookup, bool, error) {
+	f.calls++
+	if f.err != nil {
+		return cascade.BaselineLookup{}, false, f.err
+	}
+	return cascade.BaselineLookup{SnapshotTime: f.snap, Rows: f.rows, Truncated: f.trunc}, f.ok, nil
+}
+
+func cascadeFK(schema string) []cascade.CascadeFK {
+	return []cascade.CascadeFK{{
+		Schema: schema, Table: "child", ConstraintName: "fk", Column: "pid",
+		ReferencedSchema: schema, ReferencedTable: "parent", ReferencedColumn: "id",
+		DeleteRule: "CASCADE",
+	}}
+}
+
+func parentDelete(schema string, at time.Time) []query.ResultRow {
+	return []query.ResultRow{{
+		SchemaName: schema, TableName: "parent", EventType: 3 /* DELETE */, PKValues: "1",
+		RowBefore: map[string]any{"id": json.Number("1")}, EventTimestamp: at,
+	}}
+}
+
+func victimKeys(rows []query.ResultRow) map[string]bool {
+	m := map[string]bool{}
+	for _, r := range rows {
+		m[r.TableName+":"+r.PKValues] = true
+	}
+	return m
+}
+
+// TestPhase2_untouchedBaselineChildRecovered is the headline correctness case:
+// a child present in the baseline with NO binlog event in the window (the gap
+// Phase-1 misses) is recovered from its baseline row.
+func TestPhase2_untouchedBaselineChildRecovered(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	eng := query.New(db)
+	T := time.Now().UTC()
+
+	fb := &fakeBaseline{
+		ok:   true,
+		snap: T.Add(-2 * time.Hour),
+		rows: []cascade.BaselineRow{{PKValues: "10", Row: map[string]any{"id": int64(10), "pid": int64(1), "payload": "keep"}}},
+	}
+	res, err := cascade.SynthesizeVictims(context.Background(), eng, cascadeFK(dbName), parentDelete(dbName, T),
+		cascade.Options{Baseline: fb})
+	if err != nil {
+		t.Fatalf("SynthesizeVictims: %v", err)
+	}
+	if !res.Complete() {
+		t.Errorf("a fully-covered baseline cascade should be complete, got Incomplete=%v", res.Incomplete)
+	}
+	if k := victimKeys(res.Victims); len(res.Victims) != 1 || !k["child:10"] {
+		t.Fatalf("want exactly child:10 from baseline, got %v", res.Victims)
+	}
+	if res.Victims[0].RowBefore["payload"] != "keep" {
+		t.Errorf("baseline victim should carry the baseline row, got %v", res.Victims[0].RowBefore)
+	}
+}
+
+// TestPhase2_reparentedNotResurrected pins the touched-exclusion: a child that
+// was re-parented away (X→Y) after the baseline appears in the binlog scan and
+// is correctly filtered; the baseline augmentation must NOT resurrect it from
+// its stale baseline (fk=X) state.
+func TestPhase2_reparentedNotResurrected(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	eng := query.New(db)
+
+	T := time.Now().UTC()
+	h := T.Add(-30 * time.Minute).Truncate(time.Hour)
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{h})
+	ts := h.Add(10 * time.Minute).Format("2006-01-02 15:04:05")
+	// child 10: inserted pointing at parent 1, then re-parented to parent 2.
+	testutil.InsertEvent(t, db, "b.000001", 10, 20, ts, nil, dbName, "child", 1 /*INSERT*/, "10", nil, nil, []byte(`{"id":10,"pid":1,"payload":"x"}`))
+	testutil.InsertEvent(t, db, "b.000001", 20, 30, ts, nil, dbName, "child", 2 /*UPDATE*/, "10", nil, []byte(`{"id":10,"pid":1,"payload":"x"}`), []byte(`{"id":10,"pid":2,"payload":"x"}`))
+
+	fb := &fakeBaseline{
+		ok:   true,
+		snap: h.Add(-time.Hour),
+		rows: []cascade.BaselineRow{{PKValues: "10", Row: map[string]any{"id": int64(10), "pid": int64(1)}}},
+	}
+	res, err := cascade.SynthesizeVictims(context.Background(), eng, cascadeFK(dbName), parentDelete(dbName, T),
+		cascade.Options{Baseline: fb})
+	if err != nil {
+		t.Fatalf("SynthesizeVictims: %v", err)
+	}
+	if len(res.Victims) != 0 {
+		t.Errorf("re-parented child must NOT be a victim (neither binlog nor resurrected from baseline), got %v", res.Victims)
+	}
+}
+
+// TestPhase2_windowWidenedToSnapshot pins the window widening: a child inserted
+// after the baseline but BEFORE the (short) lookback window is still caught,
+// because a configured baseline widens the binlog scan to the snapshot time.
+func TestPhase2_windowWidenedToSnapshot(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	eng := query.New(db)
+
+	T := time.Now().UTC()
+	h := T.Add(-2 * time.Hour).Truncate(time.Hour)
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{h})
+	ts := h.Add(10 * time.Minute).Format("2006-01-02 15:04:05")
+	// child 11 inserted ~2h before T — outside a 1-minute lookback, after the snapshot.
+	testutil.InsertEvent(t, db, "b.000001", 10, 20, ts, nil, dbName, "child", 1 /*INSERT*/, "11", nil, nil, []byte(`{"id":11,"pid":1,"payload":"y"}`))
+
+	fb := &fakeBaseline{ok: true, snap: h.Add(-time.Hour)} // child 11 NOT in baseline (inserted after)
+	res, err := cascade.SynthesizeVictims(context.Background(), eng, cascadeFK(dbName), parentDelete(dbName, T),
+		cascade.Options{Baseline: fb, Lookback: time.Minute})
+	if err != nil {
+		t.Fatalf("SynthesizeVictims: %v", err)
+	}
+	if k := victimKeys(res.Victims); len(res.Victims) != 1 || !k["child:11"] {
+		t.Fatalf("widened window should catch child:11 (insert after snapshot, before lookback), got %v", res.Victims)
+	}
+}
+
+// TestPhase2_truncationSkipsBaseline pins the stale-resurrection guard: when the
+// binlog scan truncates, `touched` is incomplete, so baseline augmentation is
+// skipped (a truncated-out re-parented child must not be resurrected) and flagged.
+func TestPhase2_truncationSkipsBaseline(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	eng := query.New(db)
+
+	T := time.Now().UTC()
+	h := T.Add(-30 * time.Minute).Truncate(time.Hour)
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{h})
+	ts := h.Add(10 * time.Minute).Format("2006-01-02 15:04:05")
+	testutil.InsertEvent(t, db, "b.000001", 10, 20, ts, nil, dbName, "child", 1, "10", nil, nil, []byte(`{"id":10,"pid":1}`))
+	testutil.InsertEvent(t, db, "b.000001", 20, 30, ts, nil, dbName, "child", 1, "11", nil, nil, []byte(`{"id":11,"pid":1}`))
+
+	fb := &fakeBaseline{ok: true, snap: h.Add(-time.Hour),
+		rows: []cascade.BaselineRow{{PKValues: "12", Row: map[string]any{"id": int64(12), "pid": int64(1)}}}}
+	res, err := cascade.SynthesizeVictims(context.Background(), eng, cascadeFK(dbName), parentDelete(dbName, T),
+		cascade.Options{Baseline: fb, CandidateLimit: 1})
+	if err != nil {
+		t.Fatalf("SynthesizeVictims: %v", err)
+	}
+	if res.Complete() || !strings.Contains(strings.Join(res.Incomplete, " "), "baseline augmentation") {
+		t.Errorf("binlog truncation must skip+flag baseline augmentation; Incomplete=%v", res.Incomplete)
+	}
+	// The baseline child 12 must NOT have been added under truncation.
+	if victimKeys(res.Victims)["child:12"] {
+		t.Errorf("baseline child must not be added when the binlog scan truncated")
+	}
+}
+
+// TestPhase2_noBaselineCoverageFlagged: a provider configured but with no
+// baseline for the table flags incompleteness; a provider error flags it too.
+func TestPhase2_noBaselineCoverageFlagged(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	eng := query.New(db)
+	T := time.Now().UTC()
+
+	notCovered := &fakeBaseline{ok: false}
+	res, err := cascade.SynthesizeVictims(context.Background(), eng, cascadeFK(dbName), parentDelete(dbName, T),
+		cascade.Options{Baseline: notCovered})
+	if err != nil {
+		t.Fatalf("SynthesizeVictims: %v", err)
+	}
+	if res.Complete() || !strings.Contains(strings.Join(res.Incomplete, " "), "no baseline covers") {
+		t.Errorf("uncovered table must flag incompleteness; Incomplete=%v", res.Incomplete)
+	}
+
+	failing := &fakeBaseline{err: context.DeadlineExceeded}
+	res2, err := cascade.SynthesizeVictims(context.Background(), eng, cascadeFK(dbName), parentDelete(dbName, T),
+		cascade.Options{Baseline: failing})
+	if err != nil {
+		t.Fatalf("SynthesizeVictims: %v", err)
+	}
+	if res2.Complete() || !strings.Contains(strings.Join(res2.Incomplete, " "), "baseline lookup failed") {
+		t.Errorf("baseline lookup error must flag incompleteness; Incomplete=%v", res2.Incomplete)
+	}
+}

--- a/internal/cascade/baseline_integration_test.go
+++ b/internal/cascade/baseline_integration_test.go
@@ -209,3 +209,54 @@ func TestPhase2_noBaselineCoverageFlagged(t *testing.T) {
 		t.Errorf("baseline lookup error must flag incompleteness; Incomplete=%v", res2.Incomplete)
 	}
 }
+
+// TestPhase2_archivesSkipBaseline pins the archive-gap guard (the #569 critical):
+// when the index has archived partitions, the live [snapshot,T] scan may be
+// gapped, so baseline augmentation is SKIPPED (a child re-parented/deleted in an
+// archived partition must not be resurrected from its stale baseline row).
+func TestPhase2_archivesSkipBaseline(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	eng := query.New(db)
+	T := time.Now().UTC()
+
+	fb := &fakeBaseline{ok: true, snap: T.Add(-2 * time.Hour),
+		rows: []cascade.BaselineRow{{PKValues: "10", Row: map[string]any{"id": int64(10), "pid": int64(1)}}}}
+	res, err := cascade.SynthesizeVictims(context.Background(), eng, cascadeFK(dbName), parentDelete(dbName, T),
+		cascade.Options{Baseline: fb, ArchivesPresent: true})
+	if err != nil {
+		t.Fatalf("SynthesizeVictims: %v", err)
+	}
+	if len(res.Victims) != 0 {
+		t.Errorf("baseline augmentation must be skipped when archives present; got %v", res.Victims)
+	}
+	if res.Complete() || !strings.Contains(strings.Join(res.Incomplete, " "), "archived") {
+		t.Errorf("archive-gap skip must flag incompleteness; Incomplete=%v", res.Incomplete)
+	}
+}
+
+// TestPhase2_baselineTruncationFlagged pins the baseTrunc branch: the baseline
+// scan hit its cap (binlog NOT truncated) → the capped rows are still emitted but
+// the run is flagged incomplete.
+func TestPhase2_baselineTruncationFlagged(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	eng := query.New(db)
+	T := time.Now().UTC()
+
+	fb := &fakeBaseline{ok: true, trunc: true, snap: T.Add(-2 * time.Hour),
+		rows: []cascade.BaselineRow{{PKValues: "10", Row: map[string]any{"id": int64(10), "pid": int64(1)}}}}
+	res, err := cascade.SynthesizeVictims(context.Background(), eng, cascadeFK(dbName), parentDelete(dbName, T),
+		cascade.Options{Baseline: fb})
+	if err != nil {
+		t.Fatalf("SynthesizeVictims: %v", err)
+	}
+	if k := victimKeys(res.Victims); len(res.Victims) != 1 || !k["child:10"] {
+		t.Errorf("capped baseline rows must still be emitted, got %v", res.Victims)
+	}
+	if res.Complete() || !strings.Contains(strings.Join(res.Incomplete, " "), "baseline children") {
+		t.Errorf("baseline truncation must be flagged; Incomplete=%v", res.Incomplete)
+	}
+}

--- a/internal/cascade/cascade.go
+++ b/internal/cascade/cascade.go
@@ -54,12 +54,46 @@ type CascadeFK struct {
 	UpdateRule       string // ON UPDATE rule
 }
 
+// BaselineRow is one child row from a baseline snapshot, with its primary key
+// pre-encoded as a pipe-delimited string matching binlog_events.pk_values. The
+// caller (which owns the schema resolver) computes PKValues, so the cascade
+// engine needs no metadata/parser dependency.
+type BaselineRow struct {
+	PKValues string         // pipe-delimited, matches binlog_events.pk_values
+	Row      map[string]any // full column image → becomes the recovery INSERT
+}
+
+// BaselineLookup is the Phase-2 result for one (child table, parent-key) scan.
+type BaselineLookup struct {
+	SnapshotTime time.Time     // start of the delta window (widens the binlog scan)
+	Rows         []BaselineRow // child rows that referenced the parent at the snapshot
+	Truncated    bool          // more rows matched than the requested limit
+}
+
+// BaselineProvider supplies Phase-2 baseline fallback: the child rows that
+// referenced a deleted parent at the most recent baseline snapshot. It is
+// implemented by the command over internal/reconstruct; the cascade engine
+// depends only on this interface, so the Phase-1/Phase-2 merge logic is
+// unit-testable against a fake with canned rows (no Parquet fixture).
+type BaselineProvider interface {
+	// BaselineChildren returns the snapshot time and the child rows where
+	// fkCol == parentPK in the newest complete baseline for (schema, table) at
+	// or before `at`, capped at limit. ok is false when no baseline covers the
+	// table (the caller then runs Phase-1 only for it).
+	BaselineChildren(ctx context.Context, schema, table, fkCol, parentPK string, at time.Time, limit int) (lookup BaselineLookup, ok bool, err error)
+}
+
 // Options tunes the synthesis. Zero values fall back to the dbtrail SaaS
 // constants via withDefaults.
 type Options struct {
 	Lookback       time.Duration // how far before the parent delete to look for child state
 	MaxDepth       int           // multi-level cascade recursion cap
 	CandidateLimit int           // max child candidate rows per (parent event, FK)
+	// Baseline, when non-nil, enables Phase-2: untouched children present in a
+	// baseline snapshot (no binlog event within the window) are also recovered,
+	// and the binlog scan window is widened to the snapshot time. nil = Phase-1
+	// only (binlog-history within Lookback).
+	Baseline BaselineProvider
 }
 
 func (o Options) withDefaults() Options {
@@ -201,7 +235,6 @@ func SynthesizeVictims(
 				continue
 			}
 
-			since := item.rootTS.Add(-opts.Lookback)
 			until := item.rootTS
 
 			for _, fk := range byParent[pev.SchemaName+"."+pev.TableName] {
@@ -217,11 +250,39 @@ func SynthesizeVictims(
 				}
 				parentPK := valToString(refVal)
 
+				// Phase-1 window; widened to the baseline snapshot below.
+				since := item.rootTS.Add(-opts.Lookback)
+
+				// Phase-2: look up the child rows that referenced this parent at
+				// the baseline snapshot. Widen the binlog window to the snapshot
+				// time so the scan catches every child touched SINCE the baseline;
+				// the untouched ones are added after the scan.
+				var (
+					baseRows    []BaselineRow
+					baseSnap    time.Time
+					baseTrunc   bool
+					baseCovered bool
+				)
+				if opts.Baseline != nil {
+					bl, covered, berr := opts.Baseline.BaselineChildren(ctx, fk.Schema, fk.Table, fk.Column, parentPK, item.rootTS, opts.CandidateLimit)
+					switch {
+					case berr != nil:
+						addIncomplete("baselinefail:"+fk.Schema+"."+fk.Table, fmt.Sprintf(
+							"baseline lookup failed for %s.%s (recovery may be partial): %v", fk.Schema, fk.Table, berr))
+					case covered:
+						baseCovered, baseSnap, baseRows, baseTrunc = true, bl.SnapshotTime, bl.Rows, bl.Truncated
+						since = bl.SnapshotTime
+					default:
+						addIncomplete("nobaseline:"+fk.Schema+"."+fk.Table, fmt.Sprintf(
+							"no baseline covers %s.%s; children untouched within the lookback window are not reconstructed", fk.Schema, fk.Table))
+					}
+				}
+
 				// Latest event per child PK that referenced this parent within the
-				// lookback window. LimitPerPK=1 keeps the timestamp-latest event
-				// per pk_values. Fetch one MORE than CandidateLimit so an overflow
-				// is observable — with LimitPerPK=1 a plain LIMIT=CandidateLimit
-				// caps at exactly the limit and hides truncation.
+				// window. LimitPerPK=1 keeps the timestamp-latest event per
+				// pk_values. Fetch one MORE than CandidateLimit so an overflow is
+				// observable — with LimitPerPK=1 a plain LIMIT=CandidateLimit caps
+				// at exactly the limit and hides truncation.
 				cands, qerr := eng.Fetch(ctx, query.Options{
 					Schema:     fk.Schema,
 					Table:      fk.Table,
@@ -243,14 +304,23 @@ func SynthesizeVictims(
 						"victim query for %s.%s failed (recovery is partial): %v", fk.Schema, fk.Table, qerr))
 					continue
 				}
+				binlogTrunc := false
 				if len(cands) > opts.CandidateLimit {
+					binlogTrunc = true
 					addIncomplete("truncate:"+fk.Schema+"."+fk.Table, fmt.Sprintf(
 						"%s.%s has more than %d cascade victims for one parent; the excess (and their descendants) were NOT reconstructed",
 						fk.Schema, fk.Table, opts.CandidateLimit))
 					cands = cands[:opts.CandidateLimit]
 				}
 
+				// touched = every child PK with an event matching fk=parentPK in
+				// the window (before filtering). Baseline augmentation skips these:
+				// a touched child is fully handled by the binlog path (emitted, or
+				// correctly filtered as re-parented/deleted) — so a re-parented
+				// child is not resurrected from its stale baseline state.
+				touched := make(map[string]bool, len(cands))
 				for _, cev := range cands {
+					touched[cev.PKValues] = true
 					switch {
 					case cev.EventType == event.EventDelete:
 						// Already gone before the cascade fired.
@@ -285,6 +355,49 @@ func SynthesizeVictims(
 					victims = append(victims, victim)
 					// May itself be a parent (grandchildren); keep the SAME root T.
 					next = append(next, layerItem{ev: victim, rootTS: item.rootTS})
+				}
+
+				// Phase-2 augmentation: add the baseline children that referenced
+				// this parent but had NO event in the window (untouched since the
+				// snapshot). Their state at T is the baseline row verbatim — a child
+				// with any post-baseline event would appear in `touched` (its first
+				// event carries before=parentPK and matches the fk scan), so
+				// ∉touched means zero deltas. Skip entirely when the binlog scan
+				// truncated: `touched` is then incomplete and a truncated-out
+				// re-parented/deleted child would be wrongly resurrected.
+				if baseCovered && len(baseRows) > 0 {
+					switch {
+					case binlogTrunc:
+						addIncomplete("baseline-skip:"+fk.Schema+"."+fk.Table, fmt.Sprintf(
+							"binlog scan truncated for %s.%s; skipped baseline augmentation to avoid resurrecting stale rows",
+							fk.Schema, fk.Table))
+					default:
+						if baseTrunc {
+							addIncomplete("baseline-truncate:"+fk.Schema+"."+fk.Table, fmt.Sprintf(
+								"more than %d baseline children for %s.%s; some untouched children were NOT reconstructed",
+								opts.CandidateLimit, fk.Schema, fk.Table))
+						}
+						for _, br := range baseRows {
+							if touched[br.PKValues] {
+								continue // touched since baseline → handled by the binlog path
+							}
+							vkey := fk.Schema + "." + fk.Table + "|" + br.PKValues
+							if emitted[vkey] {
+								continue
+							}
+							emitted[vkey] = true
+							victim := query.ResultRow{
+								EventTimestamp: baseSnap, // baseline rows have no event of their own
+								SchemaName:     fk.Schema,
+								TableName:      fk.Table,
+								EventType:      event.EventDelete,
+								PKValues:       br.PKValues,
+								RowBefore:      br.Row,
+							}
+							victims = append(victims, victim)
+							next = append(next, layerItem{ev: victim, rootTS: item.rootTS})
+						}
+					}
 				}
 			}
 		}

--- a/internal/cascade/cascade.go
+++ b/internal/cascade/cascade.go
@@ -94,6 +94,14 @@ type Options struct {
 	// and the binlog scan window is widened to the snapshot time. nil = Phase-1
 	// only (binlog-history within Lookback).
 	Baseline BaselineProvider
+	// ArchivesPresent reports that the index has archived (rotated-out) binlog
+	// partitions. Phase-2's "untouched ⟹ baseline verbatim" rule assumes the
+	// live binlog is contiguous over [snapshot, T]; an archived partition in that
+	// window breaks it (a child re-parented/deleted in the gap would be absent
+	// from the live scan and wrongly resurrected from its stale baseline row).
+	// When true, baseline augmentation is skipped + flagged, exactly like a
+	// truncated binlog scan.
+	ArchivesPresent bool
 }
 
 func (o Options) withDefaults() Options {
@@ -370,6 +378,15 @@ func SynthesizeVictims(
 					case binlogTrunc:
 						addIncomplete("baseline-skip:"+fk.Schema+"."+fk.Table, fmt.Sprintf(
 							"binlog scan truncated for %s.%s; skipped baseline augmentation to avoid resurrecting stale rows",
+							fk.Schema, fk.Table))
+					case opts.ArchivesPresent:
+						// The widened [snapshot, T] window may include archived partitions the
+						// live scan cannot see, so `touched` may be incomplete — a child
+						// re-parented/deleted in an archived gap would be wrongly resurrected
+						// from its stale baseline row. Skip, like the truncated-binlog case.
+						addIncomplete("baseline-skip-archived:"+fk.Schema+"."+fk.Table, fmt.Sprintf(
+							"index has archived partitions that may gap the [snapshot, T] window for %s.%s; "+
+								"skipped baseline augmentation to avoid resurrecting rows whose deletion/re-parent was archived",
 							fk.Schema, fk.Table))
 					default:
 						if baseTrunc {

--- a/internal/cli/recover_cascade.go
+++ b/internal/cli/recover_cascade.go
@@ -42,6 +42,22 @@ func (p *cascadeBaselineProvider) BaselineChildren(ctx context.Context, schema, 
 		}
 		return cascade.BaselineLookup{}, false, err
 	}
+
+	tm, err := p.resolver.Resolve(schema, table)
+	if err != nil {
+		return cascade.BaselineLookup{}, false, fmt.Errorf("resolve %s.%s for baseline: %w", schema, table, err)
+	}
+	// The FK filter binds parentPK as a STRING against the baseline column.
+	// DuckDB coerces it exactly for integer/string FK columns, but for
+	// DATETIME/DECIMAL/DATE the string form may not match the stored value and
+	// would silently zero-match. Refuse those (flagged as a coverage gap) rather
+	// than under-recover silently.
+	if !fkFilterSafe(columnDataType(tm, fkCol)) {
+		return cascade.BaselineLookup{}, false, fmt.Errorf(
+			"baseline scan of %s.%s by FK column %q (type %q) is unsupported (string match may not coerce); baseline augmentation skipped",
+			schema, table, fkCol, columnDataType(tm, fkCol))
+	}
+
 	// Fetch one more than the cap so truncation is observable.
 	fetch := 0
 	if limit > 0 {
@@ -57,12 +73,7 @@ func (p *cascadeBaselineProvider) BaselineChildren(ctx context.Context, schema, 
 		rows = rows[:limit]
 	}
 
-	tm, err := p.resolver.Resolve(schema, table)
-	if err != nil {
-		return cascade.BaselineLookup{}, false, fmt.Errorf("resolve %s.%s PK for baseline: %w", schema, table, err)
-	}
 	pkCols := tm.PKColumnMetas()
-
 	out := make([]cascade.BaselineRow, 0, len(rows))
 	for _, r := range rows {
 		// Canonicalize PK values the same way the indexer encoded pk_values, so
@@ -77,6 +88,29 @@ func (p *cascadeBaselineProvider) BaselineChildren(ctx context.Context, schema, 
 		})
 	}
 	return cascade.BaselineLookup{SnapshotTime: snap, Rows: out, Truncated: trunc}, true, nil
+}
+
+func columnDataType(tm *metadata.TableMeta, name string) string {
+	for _, c := range tm.Columns {
+		if c.Name == name {
+			return c.DataType
+		}
+	}
+	return ""
+}
+
+// fkFilterSafe reports whether a string-bound equality filter on a column of
+// this DATA_TYPE coerces exactly in DuckDB (integer + string families). Types
+// where the string form may diverge from the stored value (datetime, decimal,
+// date, …) are excluded so the baseline FK scan never silently zero-matches.
+func fkFilterSafe(dataType string) bool {
+	switch strings.ToLower(strings.TrimSpace(dataType)) {
+	case "int", "integer", "smallint", "tinyint", "mediumint", "bigint",
+		"char", "varchar", "text", "tinytext", "mediumtext", "longtext", "enum", "set":
+		return true
+	default:
+		return false
+	}
 }
 
 var recoverCascadeCmd = &cobra.Command{
@@ -148,7 +182,7 @@ func init() {
 	f.IntVar(&rcMaxDepth, "max-depth", 5, "Maximum cascade recursion depth (parent -> child -> grandchild ...)")
 	f.IntVar(&rcLimit, "limit", 1000, "Maximum number of parent DELETE events to process")
 	f.BoolVar(&rcAllowIncomplete, "allow-incomplete", false, "Exit 0 even when the reconstruction is provably partial (coverage gaps only; an operational failure still exits non-zero)")
-	f.StringVar(&rcBaselineDir, "baseline-dir", "", "Local baseline-snapshot directory for Phase-2 fallback (recovers children untouched within the lookback window)")
+	f.StringVar(&rcBaselineDir, "baseline-dir", "", "Local baseline-snapshot directory for Phase-2 fallback (also recovers children present in the snapshot but untouched since it)")
 	f.StringVar(&rcBaselineS3, "baseline-s3", "", "S3 baseline-snapshot prefix (s3://bucket/prefix) for Phase-2 fallback; alternative to --baseline-dir")
 	_ = recoverCascadeCmd.MarkFlagRequired("index-dsn")
 	_ = recoverCascadeCmd.MarkFlagRequired("schema")
@@ -249,9 +283,11 @@ func runRecoverCascade(cmd *cobra.Command, args []string) error {
 	//     archived could still be missed → a visible warning, NOT a hard caveat:
 	//     otherwise every archived deployment trips INCOMPLETE on every run and
 	//     --allow-incomplete becomes routine, masking the real coverage gaps.
+	archivesExist := false
 	if archives, aerr := query.ResolveArchiveSources(cmd.Context(), db); aerr != nil {
 		caveats = append(caveats, "could not determine whether archived partitions exist (probe failed: "+aerr.Error()+"); coverage is unknown")
 	} else if len(archives) > 0 {
+		archivesExist = true
 		if len(parentDeletes) == 0 {
 			caveats = append(caveats, "no parent DELETE matched in the live index, but the index has archived partitions (cascade recovery does NOT search them); the deleted parent may be archived")
 		} else {
@@ -288,9 +324,10 @@ func runRecoverCascade(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("load FK graph: %w", lerr)
 		}
 		res, synthErr = cascade.SynthesizeVictims(cmd.Context(), eng, fks, parentDeletes, cascade.Options{
-			Lookback: lookback,
-			MaxDepth: rcMaxDepth,
-			Baseline: baselineProvider,
+			Lookback:        lookback,
+			MaxDepth:        rcMaxDepth,
+			Baseline:        baselineProvider,
+			ArchivesPresent: archivesExist,
 		})
 	}
 	caveats = append(caveats, res.Incomplete...)

--- a/internal/cli/recover_cascade.go
+++ b/internal/cli/recover_cascade.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"bufio"
 	"bytes"
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -19,8 +21,63 @@ import (
 	"github.com/dbtrail/dbtrail/internal/indexer"
 	"github.com/dbtrail/dbtrail/internal/metadata"
 	"github.com/dbtrail/dbtrail/internal/query"
+	"github.com/dbtrail/dbtrail/internal/reconstruct"
 	"github.com/dbtrail/dbtrail/internal/recovery"
 )
+
+// cascadeBaselineProvider implements cascade.BaselineProvider over
+// internal/reconstruct: it finds the child table's baseline snapshot, scans it
+// for rows referencing the deleted parent, and encodes each row's PK to match
+// binlog_events.pk_values so the cascade engine can dedup against Phase-1.
+type cascadeBaselineProvider struct {
+	source   string             // local dir or s3:// prefix
+	resolver *metadata.Resolver // for child PK columns
+}
+
+func (p *cascadeBaselineProvider) BaselineChildren(ctx context.Context, schema, table, fkCol, parentPK string, at time.Time, limit int) (cascade.BaselineLookup, bool, error) {
+	path, snap, _, err := reconstruct.FindBaseline(ctx, p.source, schema, table, at)
+	if err != nil {
+		if errors.Is(err, reconstruct.ErrNoBaseline) {
+			return cascade.BaselineLookup{}, false, nil // table not covered → Phase-1 only
+		}
+		return cascade.BaselineLookup{}, false, err
+	}
+	// Fetch one more than the cap so truncation is observable.
+	fetch := 0
+	if limit > 0 {
+		fetch = limit + 1
+	}
+	rows, err := reconstruct.ReadBaselineRows(ctx, path, map[string]string{fkCol: parentPK}, fetch)
+	if err != nil {
+		return cascade.BaselineLookup{}, false, err
+	}
+	trunc := false
+	if limit > 0 && len(rows) > limit {
+		trunc = true
+		rows = rows[:limit]
+	}
+
+	tm, err := p.resolver.Resolve(schema, table)
+	if err != nil {
+		return cascade.BaselineLookup{}, false, fmt.Errorf("resolve %s.%s PK for baseline: %w", schema, table, err)
+	}
+	pkCols := tm.PKColumnMetas()
+
+	out := make([]cascade.BaselineRow, 0, len(rows))
+	for _, r := range rows {
+		// Canonicalize PK values the same way the indexer encoded pk_values, so
+		// the dedup key matches a Phase-1 victim's PKValues exactly.
+		canon, cerr := reconstruct.CanonicalizePKMap(r, pkCols)
+		if cerr != nil {
+			return cascade.BaselineLookup{}, false, fmt.Errorf("canonicalize baseline PK for %s.%s: %w", schema, table, cerr)
+		}
+		out = append(out, cascade.BaselineRow{
+			PKValues: event.BuildPKValues(pkCols, canon),
+			Row:      r,
+		})
+	}
+	return cascade.BaselineLookup{SnapshotTime: snap, Rows: out, Truncated: trunc}, true, nil
+}
 
 var recoverCascadeCmd = &cobra.Command{
 	Use:   "recover-cascade",
@@ -71,6 +128,8 @@ var (
 	rcMaxDepth        int
 	rcLimit           int
 	rcAllowIncomplete bool
+	rcBaselineDir     string
+	rcBaselineS3      string
 )
 
 func init() {
@@ -89,6 +148,8 @@ func init() {
 	f.IntVar(&rcMaxDepth, "max-depth", 5, "Maximum cascade recursion depth (parent -> child -> grandchild ...)")
 	f.IntVar(&rcLimit, "limit", 1000, "Maximum number of parent DELETE events to process")
 	f.BoolVar(&rcAllowIncomplete, "allow-incomplete", false, "Exit 0 even when the reconstruction is provably partial (coverage gaps only; an operational failure still exits non-zero)")
+	f.StringVar(&rcBaselineDir, "baseline-dir", "", "Local baseline-snapshot directory for Phase-2 fallback (recovers children untouched within the lookback window)")
+	f.StringVar(&rcBaselineS3, "baseline-s3", "", "S3 baseline-snapshot prefix (s3://bucket/prefix) for Phase-2 fallback; alternative to --baseline-dir")
 	_ = recoverCascadeCmd.MarkFlagRequired("index-dsn")
 	_ = recoverCascadeCmd.MarkFlagRequired("schema")
 	_ = recoverCascadeCmd.MarkFlagRequired("table")
@@ -202,6 +263,22 @@ func runRecoverCascade(cmd *cobra.Command, args []string) error {
 		caveats = append(caveats, fmt.Sprintf("parent DELETE events were capped at --limit=%d; narrow --pk/--since/--until or raise --limit", rcLimit))
 	}
 
+	// Phase-2 baseline fallback provider — enabled when --baseline-dir or
+	// --baseline-s3 is set AND a schema snapshot is available (needed to encode
+	// each baseline row's PK to match binlog pk_values).
+	var baselineProvider cascade.BaselineProvider
+	baselineSrc := rcBaselineDir
+	if baselineSrc == "" {
+		baselineSrc = rcBaselineS3
+	}
+	if baselineSrc != "" {
+		if resolver == nil {
+			slog.Warn("baseline source set but no schema snapshot is available; Phase-2 fallback disabled (run `bintrail snapshot`)")
+		} else {
+			baselineProvider = &cascadeBaselineProvider{source: baselineSrc, resolver: resolver}
+		}
+	}
+
 	// ── Synthesize the cascade victims ────────────────────────────────────────
 	var res cascade.Result
 	var synthErr error
@@ -213,6 +290,7 @@ func runRecoverCascade(cmd *cobra.Command, args []string) error {
 		res, synthErr = cascade.SynthesizeVictims(cmd.Context(), eng, fks, parentDeletes, cascade.Options{
 			Lookback: lookback,
 			MaxDepth: rcMaxDepth,
+			Baseline: baselineProvider,
 		})
 	}
 	caveats = append(caveats, res.Incomplete...)
@@ -224,11 +302,12 @@ func runRecoverCascade(cmd *cobra.Command, args []string) error {
 
 	// ── Emit ──────────────────────────────────────────────────────────────────
 	hdr := cascadeHeader{
-		schema:   rcSchema,
-		table:    rcTable,
-		parents:  len(parentDeletes),
-		children: len(res.Victims),
-		caveats:  caveats,
+		schema:         rcSchema,
+		table:          rcTable,
+		parents:        len(parentDeletes),
+		children:       len(res.Victims),
+		caveats:        caveats,
+		baselineActive: baselineProvider != nil,
 	}
 
 	if rcFormat == "json" {
@@ -334,6 +413,7 @@ type cascadeHeader struct {
 	schema, table     string
 	parents, children int
 	caveats           []string
+	baselineActive    bool
 }
 
 // emitCascadeSQL writes the documented preamble, the FK-checks-off wrapper, and
@@ -344,9 +424,15 @@ func emitCascadeSQL(w io.Writer, gen *recovery.Generator, rows []query.ResultRow
 	fmt.Fprintf(&b, "-- Re-inserts %d deleted parent row(s) and %d cascade-deleted child row(s)\n", hdr.parents, hdr.children)
 	b.WriteString("-- that InnoDB removed below the binlog (MySQL Bug #32506). NEVER auto-applied.\n")
 	b.WriteString("--\n")
-	b.WriteString("-- Phase-1 (binlog-window) recovery: a child untouched within --lookback and not\n")
-	b.WriteString("-- in a baseline is NOT reconstructed (baseline fallback: #552). \"Complete\" means\n")
-	b.WriteString("-- everything DETECTABLE was recovered, not that no row was missed.\n")
+	if hdr.baselineActive {
+		b.WriteString("-- Phase-2 baseline fallback ACTIVE: children present in a covered baseline are\n")
+		b.WriteString("-- reconstructed even if untouched within the window. Tables NOT covered by a\n")
+		b.WriteString("-- baseline are flagged above. \"Complete\" means everything DETECTABLE was recovered.\n")
+	} else {
+		b.WriteString("-- Phase-1 (binlog-window) recovery: a child untouched within --lookback and not\n")
+		b.WriteString("-- in a baseline is NOT reconstructed — pass --baseline-dir/--baseline-s3 to enable\n")
+		b.WriteString("-- Phase-2 fallback (#552). \"Complete\" means everything DETECTABLE was recovered.\n")
+	}
 	b.WriteString("--\n")
 	b.WriteString("-- If you have already re-created a deleted parent, delete its INSERT below:\n")
 	b.WriteString("-- SET FOREIGN_KEY_CHECKS=0 does NOT suppress PRIMARY KEY violations.\n")

--- a/internal/cli/recover_cascade_integration_test.go
+++ b/internal/cli/recover_cascade_integration_test.go
@@ -5,13 +5,16 @@ package cli
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/spf13/cobra"
 
+	"github.com/dbtrail/dbtrail/internal/baseline"
 	"github.com/dbtrail/dbtrail/internal/indexer"
 	"github.com/dbtrail/dbtrail/internal/testutil"
 )
@@ -125,6 +128,7 @@ func cleanCascadeFlags(dsn, dbName, out string) {
 	rcPK, rcPKs, rcSince, rcUntil = "", nil, "", ""
 	rcOutput, rcDryRun, rcFormat = out, false, "text"
 	rcLookback, rcMaxDepth, rcLimit, rcAllowIncomplete = "30d", 5, 1000, false
+	rcBaselineDir, rcBaselineS3 = "", ""
 }
 
 // TestRecoverCascade_incompleteExit proves the dangerous "nothing found" case:
@@ -204,5 +208,96 @@ func TestRecoverCascade_jsonExitParity(t *testing.T) {
 	rcAllowIncomplete = true
 	if err := runCascadeCmd(t); err != nil {
 		t.Fatalf("JSON + --allow-incomplete should exit 0, got: %v", err)
+	}
+}
+
+// writeChildBaseline writes a real Parquet snapshot of the `child` table at
+// parquetPath using DuckDB (the same engine ReadBaselineRows queries with).
+func writeChildBaseline(t *testing.T, parquetPath string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(parquetPath), 0o755); err != nil {
+		t.Fatalf("mkdir baseline: %v", err)
+	}
+	d, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open duckdb: %v", err)
+	}
+	defer d.Close()
+	// child 10,11 reference parent 1 (cascade victims); 12 references parent 2.
+	q := fmt.Sprintf(
+		`COPY (SELECT * FROM (VALUES (10,1,'keep10'),(11,1,'keep11'),(12,2,'other')) AS t(id,pid,payload)) TO '%s' (FORMAT PARQUET)`,
+		strings.ReplaceAll(parquetPath, "'", "''"))
+	if _, err := d.Exec(q); err != nil {
+		t.Fatalf("write baseline parquet: %v", err)
+	}
+}
+
+// TestRecoverCascade_phase2BaselineRecoversUntouchedChild proves Phase-2
+// end-to-end through the real provider: children that exist ONLY in a baseline
+// snapshot (no binlog event — the gap Phase-1 misses) are recovered, scoped to
+// the deleted parent, with the run reported complete.
+func TestRecoverCascade_phase2BaselineRecoversUntouchedChild(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	// Schema snapshot so the resolver knows child PK (id) + columns.
+	snapTs := "2026-06-01 00:00:00"
+	testutil.InsertSnapshot(t, db, 1, snapTs, dbName, "parent", "id", 1, "PRI", "int", "NO")
+	testutil.InsertSnapshot(t, db, 1, snapTs, dbName, "child", "id", 1, "PRI", "int", "NO")
+	testutil.InsertSnapshot(t, db, 1, snapTs, dbName, "child", "pid", 2, "", "int", "YES")
+	testutil.InsertSnapshot(t, db, 1, snapTs, dbName, "child", "payload", 3, "", "varchar", "YES")
+
+	testutil.MustExec(t, db, `INSERT INTO fk_constraints
+		(snapshot_id, constraint_name, schema_name, table_name, column_name, ordinal_position,
+		 referenced_schema_name, referenced_table_name, referenced_column_name, delete_rule, update_rule)
+		VALUES (1, 'fk', ?, 'child', 'pid', 1, ?, 'parent', 'id', 'CASCADE', 'RESTRICT')`, dbName, dbName)
+
+	// Parent DELETE in the binlog; the children have NO binlog events — they
+	// live only in the baseline (the Phase-1 blind spot).
+	h := time.Now().UTC().Add(-1 * time.Hour).Truncate(time.Hour)
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{h})
+	parentTs := h.Add(30 * time.Minute).Format("2006-01-02 15:04:05")
+	testutil.InsertEvent(t, db, "b.000001", 10, 20, parentTs, nil, dbName, "parent", 3 /*DELETE*/, "1", nil, []byte(`{"id":1}`), nil)
+
+	// Baseline snapshot dated before the parent delete.
+	baselineDir := t.TempDir()
+	snapDir := filepath.Join(baselineDir, "2026-06-01T00-00-00Z")
+	writeChildBaseline(t, filepath.Join(snapDir, dbName, "child.parquet"))
+	if err := baseline.WriteSuccessMarker(snapDir); err != nil {
+		t.Fatalf("write success marker: %v", err)
+	}
+
+	out := filepath.Join(t.TempDir(), "cascade.sql")
+	cleanCascadeFlags(testutil.IntegrationDSN(dbName), dbName, out)
+	rcPK = "1"
+	rcBaselineDir = baselineDir
+	defer func() { rcBaselineDir = "" }()
+
+	if err := runCascadeCmd(t); err != nil {
+		t.Fatalf("runRecoverCascade: %v", err)
+	}
+	b, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	sql := string(b)
+	for _, want := range []string{
+		"keep10", "keep11", // children recovered from the baseline
+		"Phase-2 baseline fallback ACTIVE",
+		"`" + dbName + "`.`parent`", // parent restored
+	} {
+		if !strings.Contains(sql, want) {
+			t.Errorf("output missing %q\n---\n%s", want, sql)
+		}
+	}
+	if strings.Contains(sql, "other") {
+		t.Errorf("child 12 (pid=2, different parent) must NOT be recovered\n---\n%s", sql)
+	}
+	if strings.Contains(sql, "INCOMPLETE RECOVERY") {
+		t.Errorf("a baseline-covered cascade must be complete\n---\n%s", sql)
 	}
 }

--- a/internal/cli/recover_cascade_integration_test.go
+++ b/internal/cli/recover_cascade_integration_test.go
@@ -224,8 +224,14 @@ func writeChildBaseline(t *testing.T, parquetPath string) {
 	}
 	defer d.Close()
 	// child 10,11 reference parent 1 (cascade victims); 12 references parent 2.
+	// created_at is a TIMESTAMP so the test also verifies a DuckDB time.Time
+	// non-PK value renders as a MySQL DATETIME literal in the recovery SQL.
 	q := fmt.Sprintf(
-		`COPY (SELECT * FROM (VALUES (10,1,'keep10'),(11,1,'keep11'),(12,2,'other')) AS t(id,pid,payload)) TO '%s' (FORMAT PARQUET)`,
+		`COPY (SELECT * FROM (VALUES `+
+			`(10,1,'keep10',TIMESTAMP '2026-05-01 12:00:00'),`+
+			`(11,1,'keep11',TIMESTAMP '2026-05-02 13:00:00'),`+
+			`(12,2,'other',TIMESTAMP '2026-05-03 14:00:00')`+
+			`) AS t(id,pid,payload,created_at)) TO '%s' (FORMAT PARQUET)`,
 		strings.ReplaceAll(parquetPath, "'", "''"))
 	if _, err := d.Exec(q); err != nil {
 		t.Fatalf("write baseline parquet: %v", err)
@@ -250,6 +256,7 @@ func TestRecoverCascade_phase2BaselineRecoversUntouchedChild(t *testing.T) {
 	testutil.InsertSnapshot(t, db, 1, snapTs, dbName, "child", "id", 1, "PRI", "int", "NO")
 	testutil.InsertSnapshot(t, db, 1, snapTs, dbName, "child", "pid", 2, "", "int", "YES")
 	testutil.InsertSnapshot(t, db, 1, snapTs, dbName, "child", "payload", 3, "", "varchar", "YES")
+	testutil.InsertSnapshot(t, db, 1, snapTs, dbName, "child", "created_at", 4, "", "datetime", "YES")
 
 	testutil.MustExec(t, db, `INSERT INTO fk_constraints
 		(snapshot_id, constraint_name, schema_name, table_name, column_name, ordinal_position,
@@ -287,6 +294,7 @@ func TestRecoverCascade_phase2BaselineRecoversUntouchedChild(t *testing.T) {
 	sql := string(b)
 	for _, want := range []string{
 		"keep10", "keep11", // children recovered from the baseline
+		"'2026-05-01 12:00:00", // DuckDB time.Time non-PK value → MySQL DATETIME literal
 		"Phase-2 baseline fallback ACTIVE",
 		"`" + dbName + "`.`parent`", // parent restored
 	} {
@@ -299,5 +307,85 @@ func TestRecoverCascade_phase2BaselineRecoversUntouchedChild(t *testing.T) {
 	}
 	if strings.Contains(sql, "INCOMPLETE RECOVERY") {
 		t.Errorf("a baseline-covered cascade must be complete\n---\n%s", sql)
+	}
+}
+
+// writeCompositeChildBaseline writes a `child` snapshot with a composite PK (a,b).
+func writeCompositeChildBaseline(t *testing.T, parquetPath string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(parquetPath), 0o755); err != nil {
+		t.Fatalf("mkdir baseline: %v", err)
+	}
+	d, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open duckdb: %v", err)
+	}
+	defer d.Close()
+	q := fmt.Sprintf(
+		`COPY (SELECT * FROM (VALUES (1,2,1,'c12')) AS t(a,b,pid,payload)) TO '%s' (FORMAT PARQUET)`,
+		strings.ReplaceAll(parquetPath, "'", "''"))
+	if _, err := d.Exec(q); err != nil {
+		t.Fatalf("write composite baseline parquet: %v", err)
+	}
+}
+
+// TestRecoverCascade_phase2DedupCompositePK pins the load-bearing dedup contract:
+// a child present in BOTH the binlog (touched, still referencing the parent) AND
+// the baseline must be emitted EXACTLY ONCE. If the provider's composite-PK
+// encoding (CanonicalizePKMap + BuildPKValues) diverged by one byte from the
+// indexer's pk_values, the dedup would miss and the recovery SQL would
+// double-INSERT the PK (which FOREIGN_KEY_CHECKS=0 does not suppress).
+func TestRecoverCascade_phase2DedupCompositePK(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	snapTs := "2026-06-01 00:00:00"
+	testutil.InsertSnapshot(t, db, 1, snapTs, dbName, "parent", "id", 1, "PRI", "int", "NO")
+	testutil.InsertSnapshot(t, db, 1, snapTs, dbName, "child", "a", 1, "PRI", "int", "NO")
+	testutil.InsertSnapshot(t, db, 1, snapTs, dbName, "child", "b", 2, "PRI", "int", "NO")
+	testutil.InsertSnapshot(t, db, 1, snapTs, dbName, "child", "pid", 3, "", "int", "YES")
+	testutil.InsertSnapshot(t, db, 1, snapTs, dbName, "child", "payload", 4, "", "varchar", "YES")
+
+	testutil.MustExec(t, db, `INSERT INTO fk_constraints
+		(snapshot_id, constraint_name, schema_name, table_name, column_name, ordinal_position,
+		 referenced_schema_name, referenced_table_name, referenced_column_name, delete_rule, update_rule)
+		VALUES (1, 'fk', ?, 'child', 'pid', 1, ?, 'parent', 'id', 'CASCADE', 'RESTRICT')`, dbName, dbName)
+
+	h := time.Now().UTC().Add(-1 * time.Hour).Truncate(time.Hour)
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{h})
+	childTs := h.Add(10 * time.Minute).Format("2006-01-02 15:04:05")
+	parentTs := h.Add(20 * time.Minute).Format("2006-01-02 15:04:05")
+	// child (a=1,b=2) is TOUCHED in the binlog (still referencing parent 1)...
+	testutil.InsertEvent(t, db, "b.000001", 10, 20, childTs, nil, dbName, "child", 1 /*INSERT*/, "1|2", nil, nil, []byte(`{"a":1,"b":2,"pid":1,"payload":"c12"}`))
+	testutil.InsertEvent(t, db, "b.000001", 20, 30, parentTs, nil, dbName, "parent", 3 /*DELETE*/, "1", nil, []byte(`{"id":1}`), nil)
+
+	// ...and ALSO present in the baseline (same composite PK).
+	baselineDir := t.TempDir()
+	snapDir := filepath.Join(baselineDir, "2026-06-01T00-00-00Z")
+	writeCompositeChildBaseline(t, filepath.Join(snapDir, dbName, "child.parquet"))
+	if err := baseline.WriteSuccessMarker(snapDir); err != nil {
+		t.Fatalf("success marker: %v", err)
+	}
+
+	out := filepath.Join(t.TempDir(), "cascade.sql")
+	cleanCascadeFlags(testutil.IntegrationDSN(dbName), dbName, out)
+	rcPK = "1"
+	rcBaselineDir = baselineDir
+	defer func() { rcBaselineDir = "" }()
+
+	if err := runCascadeCmd(t); err != nil {
+		t.Fatalf("runRecoverCascade: %v", err)
+	}
+	b, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	sql := string(b)
+	if c := strings.Count(sql, "`"+dbName+"`.`child`"); c != 1 {
+		t.Errorf("composite child present in binlog AND baseline must dedup to ONE INSERT, got %d\n---\n%s", c, sql)
 	}
 }

--- a/internal/reconstruct/baseline.go
+++ b/internal/reconstruct/baseline.go
@@ -57,6 +57,20 @@ func FindBaseline(ctx context.Context, source, schema, table string, at time.Tim
 // first row matching pkFilter (column name → value string). Returns nil when
 // no row matches. Loads the httpfs extension automatically for s3:// paths.
 func ReadBaselineRow(ctx context.Context, path string, pkFilter map[string]string) (map[string]any, error) {
+	rows, err := ReadBaselineRows(ctx, path, pkFilter, 1)
+	if err != nil || len(rows) == 0 {
+		return nil, err
+	}
+	return rows[0], nil
+}
+
+// ReadBaselineRows returns every baseline row matching filter (an arbitrary
+// column→value map, AND-ed), up to limit rows (limit <= 0 = no cap). Unlike
+// ReadBaselineRow it is not restricted to the primary key, so cascade Phase-2
+// can scan a child snapshot by a foreign-key column and recover ALL matching
+// children. Values are bound as query parameters; column names are quoted
+// identifiers; the path is single-quote-escaped.
+func ReadBaselineRows(ctx context.Context, path string, filter map[string]string, limit int) ([]map[string]any, error) {
 	db, err := sql.Open("duckdb", "")
 	if err != nil {
 		return nil, fmt.Errorf("open duckdb: %w", err)
@@ -74,7 +88,7 @@ func ReadBaselineRow(ctx context.Context, path string, pkFilter map[string]strin
 	}
 
 	// Build sorted conditions for deterministic SQL + arg ordering.
-	conds := buildCondsList(pkFilter)
+	conds := buildCondsList(filter)
 	safePath := strings.ReplaceAll(path, "'", "''")
 	q := "SELECT * FROM parquet_scan('" + safePath + "')"
 	if len(conds) > 0 {
@@ -84,7 +98,9 @@ func ReadBaselineRow(ctx context.Context, path string, pkFilter map[string]strin
 		}
 		q += " WHERE " + strings.Join(parts, " AND ")
 	}
-	q += " LIMIT 1"
+	if limit > 0 {
+		q += fmt.Sprintf(" LIMIT %d", limit)
+	}
 
 	args := make([]any, len(conds))
 	for i, c := range conds {
@@ -101,23 +117,23 @@ func ReadBaselineRow(ctx context.Context, path string, pkFilter map[string]strin
 	if err != nil {
 		return nil, fmt.Errorf("baseline columns: %w", err)
 	}
-	if !rows.Next() {
-		return nil, rows.Err() // nil when simply no rows; non-nil on iteration error
+	var out []map[string]any
+	for rows.Next() {
+		vals := make([]any, len(cols))
+		ptrs := make([]any, len(cols))
+		for i := range vals {
+			ptrs[i] = &vals[i]
+		}
+		if err := rows.Scan(ptrs...); err != nil {
+			return nil, fmt.Errorf("scan baseline row: %w", err)
+		}
+		row := make(map[string]any, len(cols))
+		for i, col := range cols {
+			row[col] = vals[i]
+		}
+		out = append(out, row)
 	}
-
-	vals := make([]any, len(cols))
-	ptrs := make([]any, len(cols))
-	for i := range vals {
-		ptrs[i] = &vals[i]
-	}
-	if err := rows.Scan(ptrs...); err != nil {
-		return nil, fmt.Errorf("scan baseline row: %w", err)
-	}
-	row := make(map[string]any, len(cols))
-	for i, col := range cols {
-		row[col] = vals[i]
-	}
-	return row, rows.Err()
+	return out, rows.Err()
 }
 
 // ExecSQL runs arbitrary SQL against an in-memory DuckDB instance and returns

--- a/internal/reconstruct/pk_canonicalize.go
+++ b/internal/reconstruct/pk_canonicalize.go
@@ -267,6 +267,13 @@ func canonicalizePKMap(row map[string]any, pkCols []metadata.ColumnMeta) (map[st
 // their binlog-only path when it isn't supported.
 func SupportedPKType(dataType string) bool { return supportedPKType(dataType) }
 
+// CanonicalizePKMap is the exported form of canonicalizePKMap, for callers
+// outside this package (cascade Phase-2) that must encode a baseline Parquet
+// row's primary key to match binlog_events.pk_values for deduplication.
+func CanonicalizePKMap(row map[string]any, pkCols []metadata.ColumnMeta) (map[string]any, error) {
+	return canonicalizePKMap(row, pkCols)
+}
+
 // supportedPKType returns true if dataType is in the set of PK column types
 // that canonicalizePKValue handles correctly. Callers use this at the start
 // of a reconstruct run to warn operators about edge cases.


### PR DESCRIPTION
## What

Cascade-recovery **Slice D** — Phase-2 baseline fallback, **the correctness slice**. Closes #552. Part of #548. Depends on #549/#550/#551 (merged).

Phase-1 only sees children with a binlog event in the lookback window, so an insert-once child untouched for months is silently missed — the gap the epic flagged as the dangerous one for a recovery tool. Phase-2 reconstructs those from a `bintrail baseline` snapshot.

### How it works
When a baseline covers a child table, the engine:
1. **Widens the binlog window** from `[T−lookback]` to `[snapshot_time]`, so every child *touched* since the baseline (insert/update/delete/re-parent) is handled by the existing Phase-1 path — including post-baseline inserts that predate the lookback window.
2. **Adds the untouched baseline children**: rows where `fk_col = parent_pk` in the baseline that have **no** binlog event in the window. A child with any post-baseline event necessarily appears in the scan (its first event carries `before = parent_pk`), so *not-in-the-scan ⟹ zero deltas ⟹ state at T = the baseline row verbatim* — no delta application needed.

Recurses for grandchildren; deduped against Phase-1 by PK.

### Pieces
- `reconstruct.ReadBaselineRows` — multi-row baseline scan by an arbitrary (non-PK) column (`ReadBaselineRow` now delegates with `LIMIT 1`). `reconstruct.CanonicalizePKMap` exported so a baseline row's PK encodes to match `binlog_events.pk_values` for dedup (handles the DATETIME/DATE canonicalization, #212).
- `cascade.BaselineProvider` interface (+ `BaselineRow`/`BaselineLookup`) in `Options`. **The engine depends only on the interface** — no `reconstruct`/DuckDB import — so the Phase-1/Phase-2 merge logic is unit-tested against a fake with canned rows (no Parquet fixture).
- `recover-cascade` gains `--baseline-dir`/`--baseline-s3` (omitted in #551, now working) + a `cascadeBaselineProvider` over `reconstruct`; the SQL header reflects Phase-2 active.

### Review hardening (from the design advisor)
- Bound the baseline scan (same cap + truncation caveat).
- **Skip baseline augmentation when the binlog scan truncated** — a partial touched-set would resurrect a truncated-out re-parented/deleted child from its stale baseline state (worse than missing it).
- Baseline-victim `EventTimestamp` = snapshot time, not zero.
- A table the configured baseline doesn't cover, or a lookup failure, is flagged `Incomplete`. A *missing* provider (no `--baseline-*`) is **not** flagged — that is the documented Phase-1 mode (unchanged from #551).

## Tests
- 5 fake-provider tests (no Parquet): untouched child recovered; re-parented child **not** resurrected; window widening catches a post-baseline pre-lookback insert; binlog-truncation skips+flags baseline augmentation; uncovered-table / provider-error flagged.
- End-to-end command test with a **real baseline Parquet** (written via DuckDB): children present only in the baseline are recovered, scoped to the parent (a different-parent child is excluded), reported complete.

Full unit + `reconstruct`/`cascade`/`cli` integration green.

## Next
Slice E (#553) — full `ON DELETE SET NULL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
