### PR TITLE
feat(pg): persisted schema/type oracle — PK-scoped recovery (#533 slice 1, closes #531)

### DIFF
--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -46,6 +46,14 @@ const (
 	// can never claim a half-streamed transaction (#491). The file parser does not
 	// produce it.
 	EventCommit EventType = 7
+	// EventRelation carries a PostgreSQL relation's shape (column names, ordinals,
+	// PK flags, type OIDs) in Relation, with no row data. The pgcapture decoder
+	// emits one when it sees a pgoutput RelationMessage for an in-scope table; the
+	// consumer persists it as a schema snapshot (metadata.WritePGSnapshot) and
+	// stamps subsequent rows' SchemaVersion (#533). It is NEVER written to
+	// binlog_events — the consumer handles it out-of-band — so it does not break the
+	// "EventType numeric values are a persistence contract" rule for stored rows.
+	EventRelation EventType = 8
 )
 
 // Event is a fully resolved change event with column names attached. It carries
@@ -77,6 +85,10 @@ type Event struct {
 	SchemaVersion uint32         // actual snapshot_id from schema_snapshots; updated by SwapResolver on DDL
 	DDLQuery      string         // original DDL statement (EventDDL only)
 	DDLType       DDLKind        // ALTER TABLE, CREATE TABLE, DROP TABLE, RENAME TABLE, TRUNCATE TABLE (EventDDL only)
+	// Relation carries a PostgreSQL relation's shape (EventRelation only); the
+	// consumer persists it as a schema snapshot and stamps subsequent rows'
+	// SchemaVersion. nil for every other event type; never written to binlog_events.
+	Relation *metadata.PGRelationSchema
 }
 
 // Filters controls which schemas and tables produce events.

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -230,6 +230,22 @@ func EnsureSchema(db *sql.DB) error {
 	); err != nil {
 		return err
 	}
+	// pg_type_oid/pg_type_mod carry the PostgreSQL per-column type identity (pg_type
+	// OID + atttypmod) from a pgoutput RelationMessage (#533). They are captured at
+	// stream time because the offline recover path has no live PostgreSQL catalog to
+	// rebuild them from. Nullable: MySQL snapshots leave them NULL (MySQL uses
+	// data_type/column_type). WritePGSnapshot writes them; the type-faithful renderer
+	// that reads them is a later #533 slice.
+	if err := ensureColumn(db, "schema_snapshots", "pg_type_oid",
+		`ALTER TABLE schema_snapshots ADD COLUMN pg_type_oid INT UNSIGNED DEFAULT NULL COMMENT 'PostgreSQL pg_type OID (pgoutput RelationMessage); NULL for MySQL snapshots (#533)' AFTER is_generated`,
+	); err != nil {
+		return err
+	}
+	if err := ensureColumn(db, "schema_snapshots", "pg_type_mod",
+		`ALTER TABLE schema_snapshots ADD COLUMN pg_type_mod INT DEFAULT NULL COMMENT 'PostgreSQL atttypmod (pgoutput RelationMessage); NULL for MySQL snapshots (#533)' AFTER pg_type_oid`,
+	); err != nil {
+		return err
+	}
 	// gap_lost_at/_detail record an unfillable-gap auto-advance durably
 	// (#402): the advanced checkpoint is persisted, so without these columns
 	// the only trace of the permanently lost events would be an in-memory

--- a/internal/indexer/schema.go
+++ b/internal/indexer/schema.go
@@ -159,6 +159,8 @@ const ddlSchemaSnapshots = `CREATE TABLE IF NOT EXISTS schema_snapshots (
     is_nullable      VARCHAR(3)   NOT NULL,
     column_default   TEXT         DEFAULT NULL,
     is_generated     TINYINT(1)   NOT NULL DEFAULT 0 COMMENT '1 if STORED or VIRTUAL generated column',
+    pg_type_oid      INT UNSIGNED DEFAULT NULL COMMENT 'PostgreSQL pg_type OID (pgoutput RelationMessage); NULL for MySQL snapshots (#533)',
+    pg_type_mod      INT          DEFAULT NULL COMMENT 'PostgreSQL atttypmod (pgoutput RelationMessage); NULL for MySQL snapshots (#533)',
     INDEX idx_snapshot_id    (snapshot_id),
     INDEX idx_snapshot_table (snapshot_id, schema_name, table_name)
 ) ENGINE=InnoDB`

--- a/internal/indexer/schema_integration_test.go
+++ b/internal/indexer/schema_integration_test.go
@@ -111,6 +111,54 @@ func TestEnsureSchemaAddsFKRuleColumns(t *testing.T) {
 	}
 }
 
+// TestEnsureSchemaAddsPGTypeColumns pins the #533 migration: a pre-#533 install must
+// gain schema_snapshots.pg_type_oid/pg_type_mod as NULLABLE (MySQL snapshots leave
+// them NULL; only PostgreSQL's WritePGSnapshot populates them), idempotently and with
+// no data migration of existing rows.
+func TestEnsureSchemaAddsPGTypeColumns(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	// Simulate a pre-#533 install: drop the columns EnsureSchema re-adds, after seeding
+	// an old-shape MySQL snapshot row that must survive untouched.
+	testutil.MustExec(t, db, `ALTER TABLE schema_snapshots DROP COLUMN pg_type_oid, DROP COLUMN pg_type_mod`)
+	testutil.MustExec(t, db, `INSERT INTO schema_snapshots
+		(snapshot_id, snapshot_time, schema_name, table_name, column_name,
+		 ordinal_position, column_key, data_type, column_type, is_nullable, is_generated)
+		VALUES (1, UTC_TIMESTAMP(), 'app', 't', 'id', 1, 'PRI', 'int', 'int', 'NO', 0)`)
+
+	if err := EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	for _, col := range []string{"pg_type_oid", "pg_type_mod"} {
+		var nullable string
+		if err := db.QueryRow(`SELECT IS_NULLABLE FROM information_schema.COLUMNS
+			WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'schema_snapshots' AND COLUMN_NAME = ?`,
+			col).Scan(&nullable); err != nil {
+			t.Fatalf("read %s column: %v", col, err)
+		}
+		if nullable != "YES" {
+			t.Errorf("%s IS_NULLABLE = %q, want \"YES\" (MySQL snapshots leave it NULL)", col, nullable)
+		}
+	}
+
+	// The pre-existing MySQL row reads back with NULL type identity (no migration).
+	var oid, mod *int
+	if err := db.QueryRow(`SELECT pg_type_oid, pg_type_mod FROM schema_snapshots WHERE column_name='id'`).
+		Scan(&oid, &mod); err != nil {
+		t.Fatalf("read backfilled row: %v", err)
+	}
+	if oid != nil || mod != nil {
+		t.Errorf("existing MySQL row pg_type_oid/mod = (%v,%v), want NULL/NULL", oid, mod)
+	}
+
+	// Idempotent: a second run must not error or re-add.
+	if err := EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema (second run): %v", err)
+	}
+}
+
 // TestEnsureSchemaToleratesMissingFKConstraints guards the regression where the
 // cascade-recovery migration would break EnsureSchema on very old indexes that
 // predate the fk_constraints table (TakeSnapshot already tolerates its absence).

--- a/internal/indexer/schema_integration_test.go
+++ b/internal/indexer/schema_integration_test.go
@@ -3,6 +3,7 @@
 package indexer
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/dbtrail/dbtrail/internal/testutil"
@@ -132,14 +133,19 @@ func TestEnsureSchemaAddsPGTypeColumns(t *testing.T) {
 	}
 
 	for _, col := range []string{"pg_type_oid", "pg_type_mod"} {
-		var nullable string
-		if err := db.QueryRow(`SELECT IS_NULLABLE FROM information_schema.COLUMNS
+		var nullable, columnType string
+		if err := db.QueryRow(`SELECT IS_NULLABLE, COLUMN_TYPE FROM information_schema.COLUMNS
 			WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'schema_snapshots' AND COLUMN_NAME = ?`,
-			col).Scan(&nullable); err != nil {
+			col).Scan(&nullable, &columnType); err != nil {
 			t.Fatalf("read %s column: %v", col, err)
 		}
 		if nullable != "YES" {
 			t.Errorf("%s IS_NULLABLE = %q, want \"YES\" (MySQL snapshots leave it NULL)", col, nullable)
+		}
+		// pg_type_oid holds a PostgreSQL pg_type OID (uint32); high user-type OIDs
+		// exceed int32, so the column must be UNSIGNED or they'd silently truncate.
+		if col == "pg_type_oid" && !strings.Contains(strings.ToLower(columnType), "unsigned") {
+			t.Errorf("pg_type_oid COLUMN_TYPE = %q, want an UNSIGNED int (PG OIDs are uint32)", columnType)
 		}
 	}
 

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -352,9 +352,9 @@ type PGRelationSchema struct {
 // loads each row's own snapshot_id), but a whole-schema consumer (console Tables(),
 // shim SHOW TABLES) must not assume MAX(snapshot_id) is the full schema.
 //
-// PG columns leave the MySQL-only fields empty/NULL: data_type='' and is_nullable=''
-// (both NOT NULL columns, hence empty string not NULL), column_type/column_default
-// NULL, is_generated 0. The PostgreSQL type identity rides the nullable
+// PG columns leave the MySQL-only fields empty/NULL: data_type and is_nullable are
+// the empty string (both NOT NULL columns, so empty string not NULL), column_type and
+// column_default NULL, is_generated 0. The PostgreSQL type identity rides the nullable
 // pg_type_oid/pg_type_mod columns for the deferred type-faithful renderer.
 func WritePGSnapshot(db *sql.DB, rel *PGRelationSchema) (int, error) {
 	if rel == nil || len(rel.Columns) == 0 {

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -102,6 +102,7 @@ func NewResolver(db *sql.DB, snapshotID int) (*Resolver, error) {
 
 	r := &Resolver{snapshotID: snapshotID, tables: make(map[string]*TableMeta)}
 	sawColumnType := false
+	sawDataType := false
 
 	for rows.Next() {
 		var schemaName, tableName, columnName, columnKey, dataType, columnType string
@@ -130,6 +131,9 @@ func NewResolver(db *sql.DB, snapshotID int) (*Resolver, error) {
 		if columnType != "" {
 			sawColumnType = true
 		}
+		if dataType != "" {
+			sawDataType = true
+		}
 		tm.Columns = append(tm.Columns, col)
 		if col.IsPK {
 			tm.PKColumns = append(tm.PKColumns, columnName)
@@ -144,7 +148,15 @@ func NewResolver(db *sql.DB, snapshotID int) (*Resolver, error) {
 	// integer columns are UNSIGNED and silently indexes them as-is. Warn once (not
 	// per row) so an operator who upgraded for the unsigned fix (#490) isn't misled
 	// into thinking a stale snapshot is corrected.
-	if len(r.tables) > 0 && !sawColumnType {
+	//
+	// Gate on sawDataType so this MySQL-only warning never fires for a PostgreSQL
+	// snapshot (#533): WritePGSnapshot leaves both data_type AND column_type empty
+	// (PG carries no MySQL DATA_TYPE/COLUMN_TYPE, and UNSIGNED sign-correction is a
+	// MySQL-only concern coerceUnsigned never runs for PG rows). A genuine pre-#212
+	// MySQL snapshot always has a non-empty data_type (from information_schema), so
+	// it still trips the warning; only the all-empty-data_type PG signature is
+	// suppressed.
+	if len(r.tables) > 0 && sawDataType && !sawColumnType {
 		slog.Warn("snapshot predates column_type capture (#212); UNSIGNED integer "+
 			"columns cannot be sign-corrected and are indexed with the wrong value when "+
 			"the high bit is set (unsigned PKs also corrupt pk_hash) — re-run "+
@@ -290,6 +302,111 @@ func coerceUnsigned(v any, col ColumnMeta) any {
 	default:
 		return v
 	}
+}
+
+// ─── PostgreSQL schema oracle (#533) ─────────────────────────────────────────
+
+// PGRelationColumn is one column of a PostgreSQL relation's shape, decoded in-band
+// from a pgoutput RelationMessage (no information_schema). Ordinal is the 1-based
+// table-column position; IsPK marks a primary-key column; TypeOID/TypeMod are the
+// pg_type OID and atttypmod, persisted now for the (deferred #533) type-faithful
+// renderer even though slice-1 stores values as text and does not read them.
+type PGRelationColumn struct {
+	Name    string
+	Ordinal int
+	IsPK    bool
+	TypeOID uint32
+	TypeMod int32
+}
+
+// PGRelationSchema is a PostgreSQL relation's shape as seen on the logical-
+// replication stream — the in-band, source-neutral payload an event.EventRelation
+// carries from the pgcapture decoder to the consumer, which persists it via
+// WritePGSnapshot. Columns are in table-ordinal order (so a primary key declared
+// out of column order still yields ordinal-order pk_values matching the resolver —
+// the pgcapture decoder reorders its catalog-key-order PK to match).
+//
+// It lives here, not in internal/event, because event imports metadata (so the
+// reverse would be an import cycle) and because WritePGSnapshot — its only
+// consumer — belongs next to TakeSnapshot.
+type PGRelationSchema struct {
+	Schema  string
+	Table   string
+	Columns []PGRelationColumn // table-ordinal order
+}
+
+// WritePGSnapshot persists one PostgreSQL relation's shape as a schema_snapshots
+// snapshot and returns the allocated snapshot_id. It is the PostgreSQL,
+// stream-time sibling of TakeSnapshot: where TakeSnapshot reads MySQL
+// information_schema for a whole schema, WritePGSnapshot takes one relation's
+// in-band shape (decoded from a pgoutput RelationMessage) so the offline recover
+// path can build a PK-scoped WHERE without a live PostgreSQL connection — closing
+// the remainder of #531 (PK-aware recovery on the PG path).
+//
+// Each call writes ONE table under a fresh snapshot_id (MAX+1), unlike MySQL where
+// one snapshot covers a whole schema: PostgreSQL relations arrive one
+// RelationMessage at a time, interleaved with rows, so each is its own snapshot and
+// each PG row is stamped (by the consumer) with its table's snapshot_id.
+// Consequence to respect in later slices: NewResolver(db, 0) (latest) yields a
+// SINGLE table for a PG index, not a whole-schema view — recovery is unaffected (it
+// loads each row's own snapshot_id), but a whole-schema consumer (console Tables(),
+// shim SHOW TABLES) must not assume MAX(snapshot_id) is the full schema.
+//
+// PG columns leave the MySQL-only fields empty/NULL: data_type='' and is_nullable=''
+// (both NOT NULL columns, hence empty string not NULL), column_type/column_default
+// NULL, is_generated 0. The PostgreSQL type identity rides the nullable
+// pg_type_oid/pg_type_mod columns for the deferred type-faithful renderer.
+func WritePGSnapshot(db *sql.DB, rel *PGRelationSchema) (int, error) {
+	if rel == nil || len(rel.Columns) == 0 {
+		return 0, fmt.Errorf("metadata: WritePGSnapshot requires a relation with at least one column")
+	}
+
+	tx, err := db.Begin()
+	if err != nil {
+		return 0, fmt.Errorf("metadata: WritePGSnapshot begin: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	// Allocate the next snapshot_id inside the transaction (same scheme as
+	// TakeSnapshot). MySQL and PG snapshots coexist in one table with distinct ids.
+	var nextID int
+	if err = tx.QueryRow("SELECT COALESCE(MAX(snapshot_id), 0) + 1 FROM schema_snapshots").Scan(&nextID); err != nil {
+		return 0, fmt.Errorf("metadata: WritePGSnapshot allocate snapshot_id: %w", err)
+	}
+
+	snapshotTime := time.Now().UTC()
+	valClause := strings.TrimRight(strings.Repeat("(?,?,?,?,?,?,?,?,?,?,?,?,?,?),", len(rel.Columns)), ",")
+	insertSQL := "INSERT INTO schema_snapshots " +
+		"(snapshot_id, snapshot_time, schema_name, table_name, column_name, " +
+		"ordinal_position, column_key, data_type, column_type, is_nullable, column_default, is_generated, " +
+		"pg_type_oid, pg_type_mod) VALUES " + valClause
+
+	args := make([]any, 0, len(rel.Columns)*14)
+	for _, c := range rel.Columns {
+		columnKey := ""
+		if c.IsPK {
+			columnKey = "PRI"
+		}
+		args = append(args,
+			nextID, snapshotTime, rel.Schema, rel.Table, c.Name,
+			c.Ordinal, columnKey, "", nil, "", nil, false,
+			c.TypeOID, c.TypeMod,
+		)
+	}
+	if _, err = tx.Exec(insertSQL, args...); err != nil {
+		return 0, fmt.Errorf("metadata: WritePGSnapshot insert %s.%s: %w", rel.Schema, rel.Table, err)
+	}
+
+	if err = tx.Commit(); err != nil {
+		return 0, fmt.Errorf("metadata: WritePGSnapshot commit: %w", err)
+	}
+	committed = true
+	return nextID, nil
 }
 
 // ─── TakeSnapshot ────────────────────────────────────────────────────────────

--- a/internal/metadata/metadata_integration_test.go
+++ b/internal/metadata/metadata_integration_test.go
@@ -3,8 +3,10 @@
 package metadata
 
 import (
+	"bytes"
 	"database/sql"
 	"errors"
+	"log/slog"
 	"strings"
 	"testing"
 
@@ -693,4 +695,91 @@ func TestTakeSnapshot_longEnumColumnType(t *testing.T) {
 			t.Fatalf("fixture regression: status COLUMN_TYPE is %d chars, must exceed the old VARCHAR(128) to pin the widening", len(want))
 		}
 	}
+}
+
+// TestWritePGSnapshot_OracleRoundTrip pins the #533 schema/type oracle: a PostgreSQL
+// relation persisted via WritePGSnapshot reads back through the SAME metadata.Resolver
+// the MySQL path uses — a composite PK in table-ordinal order, with the type OID/typmod
+// round-tripped — and the pre-#212 UNSIGNED warning is suppressed for a PG snapshot
+// (all data_type empty) while STILL firing for a genuine pre-#212 MySQL snapshot.
+func TestWritePGSnapshot_OracleRoundTrip(t *testing.T) {
+	indexDB, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, indexDB)
+
+	rel := &PGRelationSchema{
+		Schema: "public", Table: "orders",
+		Columns: []PGRelationColumn{
+			{Name: "id", Ordinal: 1, IsPK: true, TypeOID: 23},                      // int4
+			{Name: "region", Ordinal: 2, IsPK: true, TypeOID: 25},                  // text — composite PK part
+			{Name: "amount", Ordinal: 3, IsPK: false, TypeOID: 1700, TypeMod: 100}, // numeric(p,s)
+		},
+	}
+	id, err := WritePGSnapshot(indexDB, rel)
+	if err != nil {
+		t.Fatalf("WritePGSnapshot: %v", err)
+	}
+	if id <= 0 {
+		t.Fatalf("snapshot_id = %d, want > 0", id)
+	}
+
+	// Load through the shared resolver; capture warnings — a PG snapshot must NOT trip
+	// the MySQL-only pre-#212 UNSIGNED warning (all data_type empty is the PG signature).
+	r := newResolverCapturingWarnings(t, indexDB, id, false /* wantWarning */)
+
+	tm, err := r.Resolve("public", "orders")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	// Composite PK preserved in table-ordinal order [id, region].
+	if got := tm.PKColumns; len(got) != 2 || got[0] != "id" || got[1] != "region" {
+		t.Errorf("PKColumns = %v, want [id region] (table-ordinal order)", got)
+	}
+	if pks := tm.PKColumnMetas(); len(pks) != 2 || pks[0].Name != "id" || pks[1].Name != "region" {
+		t.Errorf("PKColumnMetas = %+v, want id,region in order", pks)
+	}
+
+	// Type OID/typmod round-trip (read directly — slice-1 NewResolver does not surface them).
+	var oid, mod sql.NullInt64
+	if err := indexDB.QueryRow(
+		`SELECT pg_type_oid, pg_type_mod FROM schema_snapshots
+		 WHERE snapshot_id=? AND column_name='amount'`, id,
+	).Scan(&oid, &mod); err != nil {
+		t.Fatalf("select pg_type cols: %v", err)
+	}
+	if !oid.Valid || oid.Int64 != 1700 || !mod.Valid || mod.Int64 != 100 {
+		t.Errorf("amount pg_type_oid/mod = (%v,%v), want (1700,100)", oid, mod)
+	}
+
+	// Control: a genuine pre-#212 MySQL snapshot (non-empty data_type, NULL column_type)
+	// STILL trips the warning — the gate suppresses ONLY the all-empty-data_type PG case.
+	mysqlID := id + 1
+	if _, err := indexDB.Exec(
+		`INSERT INTO schema_snapshots
+		   (snapshot_id, snapshot_time, schema_name, table_name, column_name,
+		    ordinal_position, column_key, data_type, column_type, is_nullable, is_generated)
+		 VALUES (?, UTC_TIMESTAMP(), 'app', 'widgets', 'qty', 1, 'PRI', 'int', NULL, 'NO', 0)`,
+		mysqlID,
+	); err != nil {
+		t.Fatalf("insert pre-#212 MySQL snapshot: %v", err)
+	}
+	newResolverCapturingWarnings(t, indexDB, mysqlID, true /* wantWarning */)
+}
+
+// newResolverCapturingWarnings loads a snapshot with slog redirected to a buffer and
+// asserts whether the pre-#212 UNSIGNED warning fired.
+func newResolverCapturingWarnings(t *testing.T, db *sql.DB, snapshotID int, wantWarning bool) *Resolver {
+	t.Helper()
+	var buf bytes.Buffer
+	old := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	r, err := NewResolver(db, snapshotID)
+	slog.SetDefault(old)
+	if err != nil {
+		t.Fatalf("NewResolver(%d): %v", snapshotID, err)
+	}
+	got := strings.Contains(buf.String(), "#212")
+	if got != wantWarning {
+		t.Errorf("pre-#212 UNSIGNED warning fired=%v, want %v (snapshot %d):\n%s", got, wantWarning, snapshotID, buf.String())
+	}
+	return r
 }

--- a/internal/pgcapture/capturer_integration_test.go
+++ b/internal/pgcapture/capturer_integration_test.go
@@ -322,11 +322,16 @@ func TestCapturer_ResumeMissingSlotFailsLoud(t *testing.T) {
 	}
 }
 
-// TestCapturer_CompositePKOrder proves PKValues uses primary-key declaration order,
-// not column/attnum order. The table's columns are (a, b, c) but its PRIMARY KEY is
-// (b, a) — so a naive attnum ordering would yield "10|20" where the correct key
-// order is "20|10". This is the one correctness-critical path the single-column
-// integration test leaves uncovered (wrong PK order silently corrupts pk_hash).
+// TestCapturer_CompositePKOrder proves PKValues uses TABLE-ORDINAL (column
+// declaration) order, matching the offline resolver's metadata.PKColumnMetas — NOT
+// PostgreSQL's primary-key KEY order. The table's columns are (a, b, c) but its
+// PRIMARY KEY is (b, a); the catalog returns the key in (b, a) order, so the decoder
+// REORDERS it to (a, b) ordinal order (#533). This is the cross-source invariant:
+// pk_values == BuildPKValues(resolver PKColumnMetas, row), which MySQL satisfies by
+// construction and reconstruct/fulltable.go relies on POSITIONALLY — a key-order
+// pk_values would silently corrupt the baseline+delta merge (and diverge pk_hash
+// from a MySQL source) for a composite PK declared out of column order. With
+// a=10, b=20 the ordinal order (a, b) yields "10|20".
 func TestCapturer_CompositePKOrder(t *testing.T) {
 	baseDSN := testutil.SkipIfNoPostgres(t)
 	ctx := context.Background()
@@ -356,6 +361,7 @@ func TestCapturer_CompositePKOrder(t *testing.T) {
 		}
 	}
 	// Columns declared a, b, c (attnums 1, 2, 3); key is (b, a) = attnums (2, 1).
+	// The decoder reorders the catalog's key-order PK to table-ordinal order (a, b).
 	mustExec(fmt.Sprintf("CREATE TABLE %s (a int, b int, c text, PRIMARY KEY (b, a))", tbl))
 	mustExec(fmt.Sprintf("ALTER TABLE %s REPLICA IDENTITY FULL", tbl))
 	mustExec(fmt.Sprintf("CREATE PUBLICATION %s FOR TABLE %s", pub, tbl))
@@ -385,8 +391,8 @@ func TestCapturer_CompositePKOrder(t *testing.T) {
 
 	rows, _ := collect(t, events, 1, 10*time.Second)
 	ins := pick(t, rows, event.EventInsert)
-	if ins.PKValues != "20|10" {
-		t.Errorf("composite PKValues = %q, want %q (key order (b, a), not column/attnum order)", ins.PKValues, "20|10")
+	if ins.PKValues != "10|20" {
+		t.Errorf("composite PKValues = %q, want %q (table-ordinal order (a, b), matching the offline resolver — NOT key order (b, a))", ins.PKValues, "10|20")
 	}
 
 	cancel()

--- a/internal/pgcapture/capturer_integration_test.go
+++ b/internal/pgcapture/capturer_integration_test.go
@@ -430,9 +430,12 @@ func collect(t *testing.T, ch <-chan event.Event, wantRows int, timeout time.Dur
 	for len(rows) < wantRows {
 		select {
 		case ev := <-ch:
-			if ev.EventType == event.EventCommit {
+			switch ev.EventType {
+			case event.EventCommit:
 				commits = append(commits, ev)
-			} else {
+			case event.EventRelation:
+				// Schema/shape event (#533) — not a row; ignore for row collection.
+			default:
 				rows = append(rows, ev)
 			}
 		case <-deadline.C:
@@ -443,9 +446,12 @@ func collect(t *testing.T, ch <-chan event.Event, wantRows int, timeout time.Dur
 	for {
 		select {
 		case ev := <-ch:
-			if ev.EventType == event.EventCommit {
+			switch ev.EventType {
+			case event.EventCommit:
 				commits = append(commits, ev)
-			} else {
+			case event.EventRelation:
+				// Schema/shape event (#533) — not a row; ignore for row collection.
+			default:
 				rows = append(rows, ev)
 			}
 		default:

--- a/internal/pgcapture/decoder.go
+++ b/internal/pgcapture/decoder.go
@@ -3,11 +3,13 @@ package pgcapture
 import (
 	"fmt"
 	"log/slog"
+	"sort"
 	"time"
 
 	"github.com/jackc/pglogrepl"
 
 	"github.com/dbtrail/dbtrail/internal/event"
+	"github.com/dbtrail/dbtrail/internal/metadata"
 )
 
 // UnchangedToastKey is the single key of the structurally-distinct marker the
@@ -104,7 +106,15 @@ func (d *Decoder) Decode(msg pglogrepl.Message) (event.Event, bool, error) {
 		if err := d.cacheRelation(m); err != nil {
 			return event.Event{}, false, err
 		}
-		return event.Event{}, false, nil
+		// Emit a schema snapshot for the consumer to persist (#533), but only for an
+		// in-scope relation: cacheRelation caches EVERY relation so row decoding can
+		// resolve any OID, yet a filtered-out table must not write snapshot rows or
+		// stamp a SchemaVersion. Gate the EMIT, not the cache.
+		rel := d.relations[m.RelationID]
+		if !d.filters.Matches(rel.schema, rel.table) {
+			return event.Event{}, false, nil
+		}
+		return relationEvent(rel), true, nil
 
 	case *pglogrepl.InsertMessage:
 		return d.decodeInsert(m)
@@ -197,6 +207,25 @@ func (d *Decoder) cacheRelation(m *pglogrepl.RelationMessage) error {
 		}
 	}
 
+	// Order PK columns by their table-column (ordinal) position. The catalog query
+	// returns them in PK-KEY order, which diverges from table order for a composite
+	// PRIMARY KEY declared out of column order (e.g. PRIMARY KEY (b, a) on a table
+	// (a, b)). event.BuildPKValues here would then build pk_values in key order,
+	// while the offline resolver (metadata.PKColumnMetas) yields the PK columns in
+	// table-ordinal order — and reconstruct pairs the two POSITIONALLY, silently
+	// corrupting the merge. Reordering to table-ordinal keeps the cross-source
+	// invariant pk_values == BuildPKValues(resolver PKColumnMetas, row). Single-column
+	// PKs are unaffected; all pkCols names are present in cols (drift check above).
+	if len(pkCols) > 1 {
+		ordinalOf := make(map[string]int, len(cols))
+		for i, c := range cols {
+			ordinalOf[c.name] = i
+		}
+		sort.SliceStable(pkCols, func(a, b int) bool {
+			return ordinalOf[pkCols[a].Name] < ordinalOf[pkCols[b].Name]
+		})
+	}
+
 	d.relations[m.RelationID] = &relationInfo{
 		schema:  m.Namespace,
 		table:   m.RelationName,
@@ -204,6 +233,38 @@ func (d *Decoder) cacheRelation(m *pglogrepl.RelationMessage) error {
 		pkCols:  pkCols,
 	}
 	return nil
+}
+
+// relationEvent builds an EventRelation carrying the relation's shape for the
+// consumer to persist as a schema snapshot (the source-neutral, in-band analog of
+// MySQL's TakeSnapshot — no information_schema). IsPK is by name; rel.pkCols is
+// already in table-ordinal order (cacheRelation reordered it), so the snapshot's PK
+// columns align with the resolver. Ordinal is the table-column position.
+func relationEvent(rel *relationInfo) event.Event {
+	pkNames := make(map[string]bool, len(rel.pkCols))
+	for _, pk := range rel.pkCols {
+		pkNames[pk.Name] = true
+	}
+	cols := make([]metadata.PGRelationColumn, len(rel.columns))
+	for i, c := range rel.columns {
+		cols[i] = metadata.PGRelationColumn{
+			Name:    c.name,
+			Ordinal: i + 1,
+			IsPK:    pkNames[c.name],
+			TypeOID: c.typeOID,
+			TypeMod: c.typeMod,
+		}
+	}
+	return event.Event{
+		Schema:    rel.schema,
+		Table:     rel.table,
+		EventType: event.EventRelation,
+		Relation: &metadata.PGRelationSchema{
+			Schema:  rel.schema,
+			Table:   rel.table,
+			Columns: cols,
+		},
+	}
 }
 
 func (d *Decoder) decodeInsert(m *pglogrepl.InsertMessage) (event.Event, bool, error) {

--- a/internal/pgcapture/decoder_test.go
+++ b/internal/pgcapture/decoder_test.go
@@ -472,6 +472,80 @@ func TestDecode_TextValuesRoundTripAsStrings(t *testing.T) {
 	}
 }
 
+// ─── EventRelation schema emission (#533 — the schema/type oracle) ─────────────
+
+func TestDecode_RelationEmitsSchema(t *testing.T) {
+	// A RelationMessage now emits an EventRelation carrying the relation's shape for
+	// the consumer to persist as a schema snapshot. PK is flagged by name, ordinals
+	// are table positions, and the per-column type OID/typmod are carried.
+	d := pgcapture.NewDecoder(pkResolver("id"), event.Filters{}, nil)
+	m := relMsg(1, "public", "orders", "id", "amount")
+	m.Columns[0].DataType = 23      // int4
+	m.Columns[1].DataType = 1700    // numeric
+	m.Columns[1].TypeModifier = 100 // numeric(p,s) typmod
+	ev, emit := mustDecode(t, d, m)
+	if !emit || ev.EventType != event.EventRelation {
+		t.Fatalf("RelationMessage: emit=%v type=%d, want emit EventRelation", emit, ev.EventType)
+	}
+	if ev.Relation == nil || ev.Relation.Schema != "public" || ev.Relation.Table != "orders" {
+		t.Fatalf("Relation = %+v, want public.orders", ev.Relation)
+	}
+	if len(ev.Relation.Columns) != 2 {
+		t.Fatalf("got %d columns, want 2", len(ev.Relation.Columns))
+	}
+	id := ev.Relation.Columns[0]
+	if id.Name != "id" || id.Ordinal != 1 || !id.IsPK || id.TypeOID != 23 {
+		t.Errorf("col[0] = %+v, want {Name:id Ordinal:1 IsPK:true TypeOID:23}", id)
+	}
+	amt := ev.Relation.Columns[1]
+	if amt.Name != "amount" || amt.Ordinal != 2 || amt.IsPK || amt.TypeOID != 1700 || amt.TypeMod != 100 {
+		t.Errorf("col[1] = %+v, want {Name:amount Ordinal:2 IsPK:false TypeOID:1700 TypeMod:100}", amt)
+	}
+}
+
+func TestDecode_CompositePKReorderedToOrdinal(t *testing.T) {
+	// PRIMARY KEY (b, a) on columns (a, b, c): the catalog reports the PK in key
+	// order (b, a), but the decoder must reorder it to table-ordinal (a, b) so the
+	// pk_values it builds matches the offline resolver's metadata.PKColumnMetas
+	// (also ordinal) — the cross-source invariant reconstruct pairs positionally.
+	d := pgcapture.NewDecoder(pkResolver("b", "a"), event.Filters{}, nil) // key order (b, a)
+	rel, emit := mustDecode(t, d, relMsg(1, "public", "t", "a", "b", "c"))
+	if !emit {
+		t.Fatal("RelationMessage should emit an EventRelation")
+	}
+	cols := rel.Relation.Columns
+	if cols[0].Name != "a" || !cols[0].IsPK || cols[1].Name != "b" || !cols[1].IsPK || cols[2].IsPK {
+		t.Errorf("PK flags wrong (want a,b PK; c not): %+v", cols)
+	}
+
+	mustDecode(t, d, beginMsg())
+	ins, emit := mustDecode(t, d, &pglogrepl.InsertMessage{
+		RelationID: 1, Tuple: tuple(textCol("10"), textCol("20"), textCol("x")), // a=10, b=20, c=x
+	})
+	if !emit {
+		t.Fatal("INSERT should emit")
+	}
+	if ins.PKValues != "10|20" {
+		t.Errorf("PKValues = %q, want %q (table-ordinal (a, b), NOT catalog key order (b, a))", ins.PKValues, "10|20")
+	}
+}
+
+func TestDecode_RelationFilterGatesEmitNotCache(t *testing.T) {
+	// A filtered-out relation is still CACHED (so its rows can resolve OIDs) but must
+	// NOT emit an EventRelation — otherwise the consumer would persist a snapshot and
+	// stamp a SchemaVersion for a table the operator excluded.
+	d := pgcapture.NewDecoder(pkResolver("id"),
+		event.Filters{Tables: map[string]bool{"public.keep": true}}, nil)
+	_, emit := mustDecode(t, d, relMsg(1, "public", "skip", "id"))
+	if emit {
+		t.Error("RelationMessage for a filtered-out table must not emit an EventRelation")
+	}
+	_, emit = mustDecode(t, d, relMsg(2, "public", "keep", "id"))
+	if !emit {
+		t.Error("RelationMessage for an in-scope table must emit an EventRelation")
+	}
+}
+
 // ─── small helpers ────────────────────────────────────────────────────────────
 
 var errBoom = errBoomType("catalog unreachable")

--- a/internal/pgcapture/relation.go
+++ b/internal/pgcapture/relation.go
@@ -29,11 +29,15 @@ type relationInfo struct {
 	schema  string
 	table   string
 	columns []relColumn           // ordinal order, matching the tuple column order
-	pkCols  []metadata.ColumnMeta // primary-key columns in ordinal order (from a PKResolver)
+	pkCols  []metadata.ColumnMeta // primary-key columns in table-ordinal order (cacheRelation reorders the PKResolver's key-order result so pk_values aligns with the offline resolver)
 }
 
-// PKResolver returns the primary-key columns of a relation, in ordinal order, used
-// to build event.Event.PKValues.
+// PKResolver returns the primary-key columns of a relation, in primary-key (indkey)
+// KEY order — the catalog order, which for a composite PK declared out of column
+// order differs from table-ordinal order. cacheRelation reorders the result to
+// table-ordinal before caching, so the pk_values it builds align with the offline
+// resolver's metadata.PKColumnMetas (also table-ordinal). Used to build
+// event.Event.PKValues.
 //
 // It must source the PK from the catalog (pg_index.indisprimary), NOT from the
 // RelationMessage's per-column "key" flag: under REPLICA IDENTITY FULL — the mode

--- a/internal/pgstreamrun/pgstreamrun.go
+++ b/internal/pgstreamrun/pgstreamrun.go
@@ -24,6 +24,7 @@ import (
 	"github.com/dbtrail/dbtrail/internal/config"
 	"github.com/dbtrail/dbtrail/internal/event"
 	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/metadata"
 	"github.com/dbtrail/dbtrail/internal/pgcapture"
 )
 
@@ -182,6 +183,16 @@ func streamLoopPG(
 
 	var lastCommitLSN uint64
 
+	// snapshotByTable maps "schema.table" → the snapshot_id of that table's most
+	// recent EventRelation (#533). Per-TABLE, not a single scalar: pgoutput sends a
+	// RelationMessage once per relation per session, so a second table's snapshot
+	// would otherwise clobber the first, and every later row of the first table would
+	// be stamped the wrong snapshot_id (recovery would silently fall back to an
+	// all-columns WHERE — #531 left unclosed for all but the last table). A map miss
+	// yields 0 → the safe SchemaVersion-0 all-columns fallback, which an in-scope row
+	// never hits (its RelationMessage always precedes it).
+	snapshotByTable := make(map[string]uint32)
+
 	flush := func() error {
 		if len(batch) == 0 {
 			return nil
@@ -246,9 +257,25 @@ func streamLoopPG(
 					return err
 				}
 				lastCommitLSN = ev.EndPos
+			case event.EventRelation:
+				// A relation's shape (#533): persist it as a schema snapshot and record
+				// its snapshot_id for stamping this table's subsequent rows. The snapshot
+				// commits immediately (its own txn), BEFORE the rows referencing it are
+				// flushed — so "snapshot durable before its rows durable" holds; it sits
+				// outside the flush→checkpoint→ack sequence, so it does not advance the
+				// cursor and does NOT force a flush (already-batched rows carry their own,
+				// already-persisted snapshot_ids — per-row schema_version makes a mixed
+				// batch correct). A crash before the next checkpoint just re-delivers and
+				// re-snapshots (a benign orphan id).
+				id, werr := metadata.WritePGSnapshot(indexDB, ev.Relation)
+				if werr != nil {
+					return fmt.Errorf("pgstreamrun: persist schema snapshot for %s.%s: %w", ev.Schema, ev.Table, werr)
+				}
+				snapshotByTable[ev.Schema+"."+ev.Table] = uint32(id)
 			case event.EventGTID:
 				// PostgreSQL does not emit a leading GTID marker; ignore defensively.
 			default:
+				ev.SchemaVersion = snapshotByTable[ev.Schema+"."+ev.Table]
 				batch = append(batch, ev)
 				if len(batch) >= idx.BatchSize() {
 					if err := flush(); err != nil {

--- a/internal/pgstreamrun/pgstreamrun_integration_test.go
+++ b/internal/pgstreamrun/pgstreamrun_integration_test.go
@@ -5,6 +5,7 @@ package pgstreamrun_test
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"fmt"
 	"strings"
 	"testing"
@@ -188,6 +189,171 @@ func TestOne_CapturerFailureSurfaces(t *testing.T) {
 		}
 	case <-time.After(15 * time.Second):
 		t.Fatal("One hung — a capturer failure was not surfaced (cancellation bridge missing)")
+	}
+}
+
+// TestOne_MultiTable_PKScopedRecovery is the #533/#531-closure discriminator: with
+// TWO published tables, a row of the FIRST table that arrives AFTER the second
+// table's RelationMessage must still recover with a PK-SCOPED WHERE. A single scalar
+// "current snapshot id" would stamp it with the second table's snapshot, silently
+// degrading recovery to an all-columns WHERE — the multi-table blocker a single-table
+// test cannot catch (pgoutput sends a RelationMessage once per relation per session,
+// so the UPDATE of the first table has no fresh Relation preceding it). Also asserts
+// schema_snapshots carries column_key='PRI' and a non-NULL pg_type_oid per table, and
+// that no unchanged-TOAST sentinel is persisted under RI FULL.
+func TestOne_MultiTable_PKScopedRecovery(t *testing.T) {
+	pgDSN := testutil.SkipIfNoPostgres(t)
+	testutil.SkipIfNoMySQL(t)
+	ctx := context.Background()
+
+	indexDB, dbName := testutil.CreateTestDB(t)
+	indexDSN := testutil.BaseDSN() + "/" + dbName
+
+	const slot = "bintrail_pgsr_mt"
+	const pub = "bintrail_pgsr_mt_pub"
+	const t1 = "pgsr_mt_t1"
+	const t2 = "pgsr_mt_t2"
+
+	pg, err := pgx.Connect(ctx, pgDSN)
+	if err != nil {
+		t.Fatalf("connect PG: %v", err)
+	}
+	t.Cleanup(func() { pg.Close(context.Background()) })
+
+	dropAll := func() {
+		bg := context.Background()
+		_, _ = pg.Exec(bg, "DROP PUBLICATION IF EXISTS "+pub)
+		_, _ = pg.Exec(bg, "DROP TABLE IF EXISTS "+t1)
+		_, _ = pg.Exec(bg, "DROP TABLE IF EXISTS "+t2)
+		_, _ = pg.Exec(bg, "SELECT pg_drop_replication_slot($1) WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name=$1)", slot)
+	}
+	dropAll()
+	t.Cleanup(dropAll)
+
+	mustExec := func(sqlStr string, args ...any) {
+		t.Helper()
+		if _, err := pg.Exec(ctx, sqlStr, args...); err != nil {
+			t.Fatalf("exec %q: %v", sqlStr, err)
+		}
+	}
+	mustExec(fmt.Sprintf("CREATE TABLE %s (id int PRIMARY KEY, label text)", t1))
+	mustExec(fmt.Sprintf("CREATE TABLE %s (id int PRIMARY KEY, note text)", t2))
+	mustExec(fmt.Sprintf("ALTER TABLE %s REPLICA IDENTITY FULL", t1))
+	mustExec(fmt.Sprintf("ALTER TABLE %s REPLICA IDENTITY FULL", t2))
+	mustExec(fmt.Sprintf("CREATE PUBLICATION %s FOR TABLE %s, %s", pub, t1, t2))
+
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	cfg := pgstreamrun.Config{
+		IndexDSN:    indexDSN,
+		ReplDSN:     replDSN(pgDSN),
+		QueryDSN:    pgDSN,
+		SlotName:    slot,
+		Publication: pub,
+		ServerID:    43,
+		BatchSize:   100,
+		Checkpoint:  200 * time.Millisecond,
+	}
+	runErr := make(chan error, 1)
+	go func() { runErr <- pgstreamrun.One(runCtx, cfg) }()
+
+	waitFor(t, 15*time.Second, func() bool {
+		var active bool
+		if err := pg.QueryRow(ctx, "SELECT active FROM pg_replication_slots WHERE slot_name=$1", slot).Scan(&active); err != nil {
+			return false
+		}
+		return active
+	}, "replication slot active")
+
+	// The interleave: INSERT t1, INSERT t2, then UPDATE t1 — the UPDATE t1 arrives
+	// AFTER t2's RelationMessage (and with no fresh Relation t1), so a single-scalar
+	// snapshot id would mis-stamp it with t2's snapshot. t2's UPDATE is the control.
+	mustExec(fmt.Sprintf("INSERT INTO %s VALUES (1, 'one-before')", t1))
+	mustExec(fmt.Sprintf("INSERT INTO %s VALUES (1, 'two-before')", t2))
+	mustExec(fmt.Sprintf("UPDATE %s SET label='one-after' WHERE id=1", t1))
+	mustExec(fmt.Sprintf("UPDATE %s SET note='two-after' WHERE id=1", t2))
+
+	waitFor(t, 15*time.Second, func() bool {
+		var n int
+		if err := indexDB.QueryRow("SELECT COUNT(*) FROM binlog_events WHERE table_name IN (?, ?)", t1, t2).Scan(&n); err != nil {
+			return false
+		}
+		return n >= 4
+	}, "2 INSERT + 2 UPDATE indexed")
+
+	cancel()
+	if err := <-runErr; err != nil {
+		t.Fatalf("One returned error: %v", err)
+	}
+
+	// For each table, the UPDATE reversal must use a PK-SCOPED WHERE (names the PK
+	// column, NOT the non-PK column). t1's UPDATE is the discriminator; t2's the control.
+	assertPKScoped := func(table, pkCol, nonPKCol string) {
+		t.Helper()
+		rows, err := query.New(indexDB).Fetch(ctx, query.Options{Schema: "public", Table: table, Order: "ASC"})
+		if err != nil {
+			t.Fatalf("query %s: %v", table, err)
+		}
+		var upd *query.ResultRow
+		for i := range rows {
+			if rows[i].EventType == event.EventUpdate {
+				upd = &rows[i]
+			}
+		}
+		if upd == nil {
+			t.Fatalf("%s: no UPDATE event indexed", table)
+		}
+		if upd.SchemaVersion == 0 {
+			t.Errorf("%s UPDATE has SchemaVersion 0 — not stamped with its table's snapshot id", table)
+		}
+		var buf bytes.Buffer
+		if _, err := recovery.New(indexDB, nil).GenerateSQLFromRows([]query.ResultRow{*upd}, &buf); err != nil {
+			t.Fatalf("%s recovery: %v", table, err)
+		}
+		_, where, ok := strings.Cut(buf.String(), " WHERE ")
+		if !ok {
+			t.Fatalf("%s reversal has no WHERE clause: %s", table, buf.String())
+		}
+		if !strings.Contains(where, pkCol) {
+			t.Errorf("%s reversal WHERE does not name PK %q (PK-scoped expected): %s", table, pkCol, where)
+		}
+		if strings.Contains(where, nonPKCol) {
+			t.Errorf("%s reversal WHERE references non-PK %q — all-columns fallback, NOT PK-scoped (snapshot mis-stamped?): %s", table, nonPKCol, where)
+		}
+	}
+	assertPKScoped(t1, "id", "label")
+	assertPKScoped(t2, "id", "note")
+
+	// The oracle: schema_snapshots carries the PK flag and the captured PG type OID.
+	for _, table := range []string{t1, t2} {
+		var columnKey string
+		var oid sql.NullInt64
+		if err := indexDB.QueryRow(
+			`SELECT column_key, pg_type_oid FROM schema_snapshots
+			 WHERE schema_name='public' AND table_name=? AND column_name='id'`, table,
+		).Scan(&columnKey, &oid); err != nil {
+			t.Fatalf("%s snapshot row: %v", table, err)
+		}
+		if columnKey != "PRI" {
+			t.Errorf("%s.id column_key=%q, want PRI", table, columnKey)
+		}
+		if !oid.Valid || oid.Int64 == 0 {
+			t.Errorf("%s.id pg_type_oid is NULL/0, want the captured int4 OID", table)
+		}
+	}
+
+	// No unchanged-TOAST sentinel persisted under RI FULL.
+	var sentinels int
+	const marker = "%__bintrail_unchanged_toast__%"
+	if err := indexDB.QueryRow(
+		`SELECT COUNT(*) FROM binlog_events
+		 WHERE table_name IN (?, ?) AND (row_before LIKE ? OR row_after LIKE ?)`,
+		t1, t2, marker, marker,
+	).Scan(&sentinels); err != nil {
+		t.Fatalf("sentinel scan: %v", err)
+	}
+	if sentinels != 0 {
+		t.Errorf("found %d rows carrying the unchanged-TOAST sentinel, want 0 under RI FULL", sentinels)
 	}
 }
 

--- a/internal/pgstreamrun/pgstreamrun_integration_test.go
+++ b/internal/pgstreamrun/pgstreamrun_integration_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/dbtrail/dbtrail/internal/event"
+	"github.com/dbtrail/dbtrail/internal/metadata"
 	"github.com/dbtrail/dbtrail/internal/pgstreamrun"
 	"github.com/dbtrail/dbtrail/internal/query"
 	"github.com/dbtrail/dbtrail/internal/recovery"
@@ -286,6 +287,18 @@ func TestOne_MultiTable_PKScopedRecovery(t *testing.T) {
 		t.Fatalf("One returned error: %v", err)
 	}
 
+	// Build the recovery generator EXACTLY as the `bintrail-pg recover` command does
+	// (internal/cli/recover.go): the index db + the latest-snapshot resolver. This is
+	// the load-bearing path — PK-scoped WHERE depends on resolverForRow lazy-loading
+	// each row's own snapshot from the db (a nil-db or pre-empting top-level resolver
+	// would silently emit all-columns WHERE). For a PG index the latest snapshot is a
+	// SINGLE table, so this also proves the top-level resolver does not pre-empt the
+	// other table's per-row resolution.
+	latestResolver, err := metadata.NewResolver(indexDB, 0)
+	if err != nil {
+		t.Fatalf("NewResolver(latest): %v", err)
+	}
+
 	// For each table, the UPDATE reversal must use a PK-SCOPED WHERE (names the PK
 	// column, NOT the non-PK column). t1's UPDATE is the discriminator; t2's the control.
 	assertPKScoped := func(table, pkCol, nonPKCol string) {
@@ -307,7 +320,7 @@ func TestOne_MultiTable_PKScopedRecovery(t *testing.T) {
 			t.Errorf("%s UPDATE has SchemaVersion 0 — not stamped with its table's snapshot id", table)
 		}
 		var buf bytes.Buffer
-		if _, err := recovery.New(indexDB, nil).GenerateSQLFromRows([]query.ResultRow{*upd}, &buf); err != nil {
+		if _, err := recovery.New(indexDB, latestResolver).GenerateSQLFromRows([]query.ResultRow{*upd}, &buf); err != nil {
 			t.Fatalf("%s recovery: %v", table, err)
 		}
 		_, where, ok := strings.Cut(buf.String(), " WHERE ")
@@ -323,6 +336,19 @@ func TestOne_MultiTable_PKScopedRecovery(t *testing.T) {
 	}
 	assertPKScoped(t1, "id", "label")
 	assertPKScoped(t2, "id", "note")
+
+	// EventRelation must never be persisted as a binlog_events row (the consumer
+	// handles it out-of-band). A bare count of indexed rows would pass even if it
+	// leaked in, so assert event_type=8 (EventRelation) has zero rows.
+	var relRows int
+	if err := indexDB.QueryRow(
+		"SELECT COUNT(*) FROM binlog_events WHERE event_type = ?", uint8(event.EventRelation),
+	).Scan(&relRows); err != nil {
+		t.Fatalf("count EventRelation rows: %v", err)
+	}
+	if relRows != 0 {
+		t.Errorf("found %d EventRelation rows persisted to binlog_events, want 0 (it must be consumed out-of-band)", relRows)
+	}
 
 	// The oracle: schema_snapshots carries the PK flag and the captured PG type OID.
 	for _, table := range []string{t1, t2} {

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -265,6 +265,8 @@ func InitIndexTables(t *testing.T, db *sql.DB) {
 		is_nullable      VARCHAR(3)   NOT NULL,
 		column_default   TEXT         DEFAULT NULL,
 		is_generated     TINYINT(1)   NOT NULL DEFAULT 0,
+		pg_type_oid      INT UNSIGNED DEFAULT NULL,
+		pg_type_mod      INT          DEFAULT NULL,
 		INDEX idx_snapshot_id    (snapshot_id),
 		INDEX idx_snapshot_table (snapshot_id, schema_name, table_name)
 	) ENGINE=InnoDB`)


### PR DESCRIPTION
Part of #527 (PostgreSQL-as-source) — the **#533 first slice**: a persisted PostgreSQL schema/type oracle so **offline** `recover`/`reconstruct` can build a PK-scoped `WHERE` for PG-origin rows without a live source connection. This **closes #531** (the deferred PK-aware-recovery half PR #560 moved here).

> `Closes #531`. **#533 stays open** — this is slice 1 of the type matrix; the PG-dialect type renderer (numeric/#496 scariest-first) is the next slice.

## What it does
- **Reuse `schema_snapshots`** (the one-index-schema red line): PG snapshots interleave with distinct `snapshot_id`s. `NewResolver` derives `IsPK` from `column_key='PRI'`, so recovery's existing `pkWhereClauseFromResolver` emits a PK-scoped `WHERE` with **zero recovery-code change**.
- `metadata.WritePGSnapshot` + `PGRelationSchema`/`PGRelationColumn` (the stream-time sibling of `TakeSnapshot`; types live in `metadata`, not `event`, to avoid an import cycle).
- `event.EventRelation` (=8) carries the relation shape; the decoder emits one per in-scope table (filter-gated; the cache still holds every relation so rows resolve OIDs). It is **never persisted** to `binlog_events` — the consumer handles it out-of-band.
- `pgstreamrun` keeps a per-table `snapshotByTable` map and stamps each row's `SchemaVersion`. **Per-table, not a scalar** — `pgoutput` sends one `RelationMessage` per relation per session, so a scalar would mis-stamp the first table's later rows and silently degrade them to an all-columns `WHERE` (the multi-table blocker the adversarial review caught; a single-table test masks it).
- Nullable `pg_type_oid`/`pg_type_mod` columns (DDL + idempotent `EnsureSchema` ALTERs) — captured now because offline recovery has no live PG catalog to rebuild them from; the renderer that **reads** them is the next slice.

## Correctness fix folded in (was latent in #530)
`cacheRelation` reorders the catalog's **key-order** PK to **table-ordinal** order, so the capturer's `pk_values` matches the resolver's `PKColumnMetas` (also ordinal) — the cross-source invariant `reconstruct` pairs positionally. A composite PK declared out of column order otherwise silently corrupts the baseline+delta merge. `TestCapturer_CompositePKOrder` flips `20|10`→`10|20` to match (PG now consistent with MySQL). Also gated the pre-#212 UNSIGNED warning so it never fires on a PG snapshot.

## Verified (live postgres:16.14 + MySQL 8.0)
- decoder units: `EventRelation` shape, composite-PK reorder, emit gated on filters
- `metadata` round-trip + the UNSIGNED-warning gate (fires on pre-#212 MySQL, silent on PG)
- `EnsureSchema` migration: a pre-#533 index gains the nullable columns, existing rows read NULL, idempotent
- **`TestOne_MultiTable_PKScopedRecovery`** — two published tables, the first's UPDATE arriving after the second's `RelationMessage` still recovers PK-scoped, using the **CLI-exact** `recovery.New(db, NewResolver(db,0))` construction; asserts no `EventRelation` row persisted and no unchanged-TOAST sentinel under RI FULL
- MySQL regression green (metadata/indexer/recovery integration); gofmt/vet/dep-guards clean

## Known follow-ups (not in this slice)
- Reconnect `snapshot_id` churn (re-sent `RelationMessage`s re-allocate ids) — correct but growing; content-dedupe is slice-1.5.
- Recovery SQL is **MySQL-dialect** (PK-scoped + value-faithful, not yet PG-executable) — the PG-dialect renderer is the next #533 slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)