### PR TITLE
feat: full ON DELETE SET NULL recovery (#553 cascade-recovery slice E)

### DIFF
--- a/docs/query-and-recovery.md
+++ b/docs/query-and-recovery.md
@@ -199,15 +199,22 @@ Reversed: undo the 14:03 UPDATE first, then the 14:02 UPDATE, then the 14:01 INS
 > warn about them and proceed (cascade schemas index normally). To reconstruct
 > cascade-deleted rows, use **`bintrail recover-cascade`** (see below).
 
-### `recover-cascade`: reverse FK ON DELETE CASCADE
+### `recover-cascade`: reverse FK ON DELETE CASCADE / SET NULL
 
-`bintrail recover-cascade` reconstructs rows that an InnoDB `ON DELETE CASCADE`
-removed but never binlogged. It finds the deleted parent rows in the index,
-infers which child rows referenced them in their last indexed state, and emits
-reversal SQL that re-inserts **both** the parents and their cascade-deleted
-descendants (recursing through multi-level cascades), wrapped in
-`SET FOREIGN_KEY_CHECKS=0/1`. Like `recover`, it only generates SQL — review
-before applying.
+`bintrail recover-cascade` reconstructs the side effects of an InnoDB
+`ON DELETE CASCADE` or `ON DELETE SET NULL` that were never binlogged. It finds
+the deleted parent rows in the index, infers which child rows referenced them in
+their last indexed state, and emits reversal SQL:
+
+- **ON DELETE CASCADE** → re-inserts **both** the parents and their
+  cascade-deleted descendants (recursing through multi-level cascades).
+- **ON DELETE SET NULL** → an **idempotent** `UPDATE` restoring each nulled FK,
+  guarded by `... AND fk IS NULL` so a re-run, a manual fix, or a later re-point
+  of the child is never clobbered (the child row survives — only its FK was
+  nulled — so it is not re-inserted).
+
+All wrapped in `SET FOREIGN_KEY_CHECKS=0/1`. Like `recover`, it only generates
+SQL — review before applying.
 
 ```bash
 bintrail recover-cascade --index-dsn "..." \

--- a/internal/cascade/baseline_integration_test.go
+++ b/internal/cascade/baseline_integration_test.go
@@ -260,3 +260,47 @@ func TestPhase2_baselineTruncationFlagged(t *testing.T) {
 		t.Errorf("baseline truncation must be flagged; Incomplete=%v", res.Incomplete)
 	}
 }
+
+// setNullFK is cascadeFK's ON DELETE SET NULL sibling for the Phase-2 tests.
+func setNullFK(schema string) []cascade.CascadeFK {
+	return []cascade.CascadeFK{{
+		Schema: schema, Table: "child", ConstraintName: "fk", Column: "pid",
+		ReferencedSchema: schema, ReferencedTable: "parent", ReferencedColumn: "id",
+		DeleteRule: "SET NULL",
+	}}
+}
+
+// TestPhase2_setNullUntouchedBaselineChild: a child of a SET NULL FK present in
+// the baseline but untouched in the window becomes a SetNullRestore (its FK is
+// nulled, the row survives), NOT a delete victim — the SET NULL analogue of
+// TestPhase2_untouchedBaselineChildRecovered, exercising the Phase-2 br.Row path.
+func TestPhase2_setNullUntouchedBaselineChild(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	eng := query.New(db)
+	T := time.Now().UTC()
+
+	fb := &fakeBaseline{
+		ok:   true,
+		snap: T.Add(-2 * time.Hour),
+		rows: []cascade.BaselineRow{{PKValues: "10", Row: map[string]any{"id": int64(10), "pid": int64(1), "payload": "keep"}}},
+	}
+	res, err := cascade.SynthesizeVictims(context.Background(), eng, setNullFK(dbName), parentDelete(dbName, T),
+		cascade.Options{Baseline: fb})
+	if err != nil {
+		t.Fatalf("SynthesizeVictims: %v", err)
+	}
+	if len(res.Victims) != 0 {
+		t.Errorf("SET NULL must produce no delete victims, got %v", res.Victims)
+	}
+	if len(res.SetNullRows) != 1 || res.SetNullRows[0].PKValues != "10" || res.SetNullRows[0].Column != "pid" {
+		t.Fatalf("want one baseline SET NULL restore for child:10/pid, got %+v", res.SetNullRows)
+	}
+	if res.SetNullRows[0].Row["payload"] != "keep" {
+		t.Errorf("baseline SET NULL restore should carry the baseline row, got %v", res.SetNullRows[0].Row)
+	}
+	if !res.Complete() {
+		t.Errorf("fully-covered baseline SET NULL should be complete, got %v", res.Incomplete)
+	}
+}

--- a/internal/cascade/cascade.go
+++ b/internal/cascade/cascade.go
@@ -1,5 +1,6 @@
-// Package cascade reconstructs child rows that an InnoDB foreign-key
-// ON DELETE CASCADE removed but never wrote to the binary log.
+// Package cascade reconstructs the side effects of an InnoDB foreign-key
+// ON DELETE CASCADE (deleted child rows) or ON DELETE SET NULL (nulled child
+// FKs) that InnoDB applied but never wrote to the binary log.
 //
 // On MySQL ≤ 8.x (and all MariaDB) InnoDB enforces FK cascades inside the
 // storage engine, below the SQL layer that writes the binlog — only the parent
@@ -177,7 +178,7 @@ func SynthesizeVictims(
 		incomplete  []string
 		errs        []error
 	)
-	setNullSeen := map[string]bool{} // "schema.table|pkvalues" → SET NULL restore emitted
+	setNullSeen := map[string]bool{} // "schema.table.column|pkvalues" → SET NULL restore emitted (per-COLUMN: one row may have several single-column SET NULL FKs)
 	// addIncomplete records a coverage caveat once per distinct key, so a wide
 	// cascade (many parent×FK iterations) cannot flood the list with near-
 	// identical strings and bury the important ones.
@@ -369,7 +370,13 @@ func SynthesizeVictims(
 						// with an idempotent UPDATE (rendered with an `IS NULL`
 						// guard by the command) and do NOT recurse — no row was
 						// deleted, so nothing cascades from it.
-						skey := fk.Schema + "." + fk.Table + "|" + cev.PKValues
+						//
+						// Key by COLUMN, not just the row: a child may carry two
+						// distinct single-column SET NULL FKs to the same deleted
+						// parent (e.g. manager_id + mentor_id → user.id). A row-only
+						// key would let the first FK's restore swallow the second's,
+						// leaving a column permanently NULL with no caveat.
+						skey := fk.Schema + "." + fk.Table + "." + fk.Column + "|" + cev.PKValues
 						if setNullSeen[skey] {
 							continue
 						}
@@ -435,7 +442,8 @@ func SynthesizeVictims(
 								continue // touched since baseline → handled by the binlog path
 							}
 							if fk.DeleteRule == "SET NULL" {
-								skey := fk.Schema + "." + fk.Table + "|" + br.PKValues
+								// Per-COLUMN key (see the Phase-1 branch above).
+								skey := fk.Schema + "." + fk.Table + "." + fk.Column + "|" + br.PKValues
 								if setNullSeen[skey] {
 									continue
 								}

--- a/internal/cascade/cascade.go
+++ b/internal/cascade/cascade.go
@@ -18,9 +18,12 @@
 // the existing recovery generator turns it into a restoring INSERT with no new
 // SQL path.
 //
-// Scope: Phase-1, binlog-history only — no baseline fallback yet, so a child
-// untouched within the lookback window is not reconstructed (Phase-2 baseline
-// fallback is deferred, #548). Design: drafts/cascade-recovery-port-2026-06-21.md.
+// ON DELETE SET NULL is handled too: the child row survives with its FK nulled,
+// so it becomes an idempotent restoring UPDATE (SetNullRestore) rather than an
+// INSERT. Phase-1 reconstructs children with a binlog event in the lookback
+// window; Phase-2 (a BaselineProvider) additionally recovers children present in
+// a baseline snapshot but untouched since. Design:
+// drafts/cascade-recovery-port-2026-06-21.md.
 package cascade
 
 import (
@@ -126,8 +129,21 @@ func (o Options) withDefaults() Options {
 // operational failure (e.g. an index query failed) that ALSO leaves Victims
 // partial; it is reported in Incomplete too, so checking either suffices.
 type Result struct {
-	Victims    []query.ResultRow
-	Incomplete []string
+	Victims     []query.ResultRow
+	SetNullRows []SetNullRestore
+	Incomplete  []string
+}
+
+// SetNullRestore describes a child whose foreign key an ON DELETE SET NULL
+// cascade nulled (MySQL ≤8.x never logs it). Unlike a CASCADE victim the row
+// still EXISTS — only its FK column was nulled — so recovery is an idempotent
+// UPDATE (restore Column = Value WHERE pk… AND Column IS NULL), not an INSERT.
+// The command renders it via recovery.FormatSetNullRestore.
+type SetNullRestore struct {
+	Schema, Table, Column string
+	Value                 any            // the parent key to restore into the FK column
+	PKValues              string         // dedup key (matches binlog pk_values)
+	Row                   map[string]any // last-known child row (for the PK WHERE)
 }
 
 // Complete reports whether the reconstruction covered everything it could find.
@@ -156,10 +172,12 @@ func SynthesizeVictims(
 	opts = opts.withDefaults()
 
 	var (
-		victims    []query.ResultRow
-		incomplete []string
-		errs       []error
+		victims     []query.ResultRow
+		setNullRows []SetNullRestore
+		incomplete  []string
+		errs        []error
 	)
+	setNullSeen := map[string]bool{} // "schema.table|pkvalues" → SET NULL restore emitted
 	// addIncomplete records a coverage caveat once per distinct key, so a wide
 	// cascade (many parent×FK iterations) cannot flood the list with near-
 	// identical strings and bury the important ones.
@@ -181,13 +199,15 @@ func SynthesizeVictims(
 		colsPerConstraint[fk.Schema+"."+fk.Table+"."+fk.ConstraintName]++
 	}
 
-	// Index CASCADE edges by the parent (referenced) table they protect.
-	// Gate on DeleteRule == "CASCADE" ONLY: dbtrail conflates delete_rule/
-	// update_rule (data_plane_router.py:2793), which runs DELETE synthesis on
-	// ON UPDATE CASCADE edges — a bug we deliberately do not port.
+	// Index CASCADE and SET NULL edges by the parent (referenced) table they
+	// protect. Gate on the DELETE rule ONLY: dbtrail conflates delete_rule/
+	// update_rule (data_plane_router.py:2793), which runs synthesis on ON UPDATE
+	// CASCADE edges — a bug we deliberately do not port. The emit branch (per
+	// edge) turns CASCADE into a DELETE→INSERT victim and SET NULL into an
+	// idempotent FK-restoring UPDATE.
 	byParent := map[string][]CascadeFK{}
 	for _, fk := range fks {
-		if fk.DeleteRule != "CASCADE" {
+		if fk.DeleteRule != "CASCADE" && fk.DeleteRule != "SET NULL" {
 			continue
 		}
 		ckey := fk.Schema + "." + fk.Table + "." + fk.ConstraintName
@@ -344,6 +364,22 @@ func SynthesizeVictims(
 						// Re-parented before the delete → it survived.
 						continue
 					}
+					if fk.DeleteRule == "SET NULL" {
+						// The child survives; only its FK was nulled. Restore it
+						// with an idempotent UPDATE (rendered with an `IS NULL`
+						// guard by the command) and do NOT recurse — no row was
+						// deleted, so nothing cascades from it.
+						skey := fk.Schema + "." + fk.Table + "|" + cev.PKValues
+						if setNullSeen[skey] {
+							continue
+						}
+						setNullSeen[skey] = true
+						setNullRows = append(setNullRows, SetNullRestore{
+							Schema: fk.Schema, Table: fk.Table, Column: fk.Column,
+							Value: refVal, PKValues: cev.PKValues, Row: cev.RowAfter,
+						})
+						continue
+					}
 					vkey := fk.Schema + "." + fk.Table + "|" + cev.PKValues
 					if emitted[vkey] {
 						// Reached via another cascade path (diamond / multiple FKs
@@ -398,6 +434,18 @@ func SynthesizeVictims(
 							if touched[br.PKValues] {
 								continue // touched since baseline → handled by the binlog path
 							}
+							if fk.DeleteRule == "SET NULL" {
+								skey := fk.Schema + "." + fk.Table + "|" + br.PKValues
+								if setNullSeen[skey] {
+									continue
+								}
+								setNullSeen[skey] = true
+								setNullRows = append(setNullRows, SetNullRestore{
+									Schema: fk.Schema, Table: fk.Table, Column: fk.Column,
+									Value: refVal, PKValues: br.PKValues, Row: br.Row,
+								})
+								continue
+							}
 							vkey := fk.Schema + "." + fk.Table + "|" + br.PKValues
 							if emitted[vkey] {
 								continue
@@ -424,7 +472,7 @@ func SynthesizeVictims(
 		}
 		layer = next
 	}
-	return Result{Victims: victims, Incomplete: incomplete}, errors.Join(errs...)
+	return Result{Victims: victims, SetNullRows: setNullRows, Incomplete: incomplete}, errors.Join(errs...)
 }
 
 // LoadCascadeFKs reads the FK graph WITH referential rules from the INDEX's

--- a/internal/cascade/cascade_cases_integration_test.go
+++ b/internal/cascade/cascade_cases_integration_test.go
@@ -569,3 +569,163 @@ func TestSynthesizeVictims_multiRootIndependentT(t *testing.T) {
 		t.Errorf("cb:20 recovered at %v, want b1 (per-root T regression — using a collapsed global T?)", cb.RowBefore["val"])
 	}
 }
+
+// TestSynthesizeVictims_setNullTwoColumnsSameRow is the regression for the #571
+// review CRITICAL: a SetNullRestore is per-COLUMN, but the dedup key was per-ROW,
+// so a child carrying TWO single-column SET NULL FKs to the same deleted parent
+// (e.g. mgr + mentor → parent.id) had its second column silently dropped. Both
+// columns must be restored, and the result must stay Complete.
+func TestSynthesizeVictims_setNullTwoColumnsSameRow(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	eng := query.New(db)
+
+	T := time.Now().UTC()
+	h := T.Add(-30 * time.Minute).Truncate(time.Hour)
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{h})
+	ts := h.Add(10 * time.Minute).Format("2006-01-02 15:04:05")
+	// child 10 points at parent 1 via BOTH mgr and mentor; the cascade nulls both.
+	testutil.InsertEvent(t, db, "b.000001", 10, 20, ts, nil, dbName, "child", 1, "10", nil, nil, []byte(`{"id":10,"mgr":1,"mentor":1}`))
+
+	fks := []cascade.CascadeFK{
+		{Schema: dbName, Table: "child", ConstraintName: "fk_mgr", Column: "mgr",
+			ReferencedSchema: dbName, ReferencedTable: "parent", ReferencedColumn: "id", DeleteRule: "SET NULL"},
+		{Schema: dbName, Table: "child", ConstraintName: "fk_mentor", Column: "mentor",
+			ReferencedSchema: dbName, ReferencedTable: "parent", ReferencedColumn: "id", DeleteRule: "SET NULL"},
+	}
+	res, err := cascade.SynthesizeVictims(context.Background(), eng, fks, parentDelete(dbName, T), cascade.Options{})
+	if err != nil {
+		t.Fatalf("SynthesizeVictims: %v", err)
+	}
+	if len(res.Victims) != 0 {
+		t.Errorf("SET NULL produces no DELETE victims, got %v", res.Victims)
+	}
+	cols := map[string]bool{}
+	for _, sr := range res.SetNullRows {
+		if sr.PKValues != "10" {
+			t.Errorf("unexpected restore for pk=%s", sr.PKValues)
+		}
+		cols[sr.Column] = true
+	}
+	if len(res.SetNullRows) != 2 || !cols["mgr"] || !cols["mentor"] {
+		t.Fatalf("both mgr and mentor of child:10 must be restored (per-column key), got %+v", res.SetNullRows)
+	}
+	if !res.Complete() {
+		t.Errorf("two-column SET NULL restore should be complete, got %v", res.Incomplete)
+	}
+}
+
+// TestSynthesizeVictims_setNullGuardProtectsRepointedRow proves the `IS NULL`
+// guard is load-bearing, not decorative. A child re-pointed to a NEW parent after
+// the (unlogged) SET NULL still surfaces a STALE restore candidate — its pre-null
+// INSERT image is the only event matching the fk=parent scan, so a SetNullRestore
+// to the OLD parent IS emitted. Only the runtime `AND fk IS NULL` predicate stops
+// it from clobbering the live re-pointed value. This applies the generated UPDATE
+// against the real row and asserts the row is unchanged.
+func TestSynthesizeVictims_setNullGuardProtectsRepointedRow(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	ctx := context.Background()
+	sourceDB, sourceName := testutil.CreateTestDB(t)
+	indexDB, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, indexDB)
+
+	testutil.MustExec(t, sourceDB, `CREATE TABLE parent (id INT PRIMARY KEY) ENGINE=InnoDB`)
+	testutil.MustExec(t, sourceDB, `CREATE TABLE child (
+		id  INT PRIMARY KEY,
+		mgr INT NULL,
+		CONSTRAINT fk_mgr FOREIGN KEY (mgr) REFERENCES parent(id) ON DELETE SET NULL
+	) ENGINE=InnoDB`)
+
+	stats, err := metadata.TakeSnapshot(sourceDB, indexDB, []string{sourceName})
+	if err != nil {
+		t.Fatalf("TakeSnapshot: %v", err)
+	}
+	resolver, err := metadata.NewResolver(indexDB, stats.SnapshotID)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+
+	testutil.MustExec(t, sourceDB, "INSERT INTO parent VALUES (1),(2)")
+
+	// Capture the whole child history: its INSERT (mgr=1, the stale candidate),
+	// the parent delete (InnoDB nulls child.mgr, UNLOGGED), then the operator's
+	// re-point to parent 2 (logged UPDATE before=NULL/after=2).
+	testutil.MustExec(t, sourceDB, "FLUSH BINARY LOGS")
+	currentBinlog, _, err := config.CurrentBinlogPosition(sourceDB)
+	if err != nil {
+		t.Fatalf("CurrentBinlogPosition: %v", err)
+	}
+	testutil.MustExec(t, sourceDB, "INSERT INTO child VALUES (10,1)")
+	testutil.MustExec(t, sourceDB, "DELETE FROM parent WHERE id=1")
+	testutil.MustExec(t, sourceDB, "UPDATE child SET mgr=2 WHERE id=10")
+	testutil.MustExec(t, sourceDB, "FLUSH BINARY LOGS")
+
+	tmpDir := t.TempDir()
+	cp := exec.Command("docker", "cp",
+		fmt.Sprintf("bintrail-test-mysql:/var/lib/mysql/%s", currentBinlog),
+		filepath.Join(tmpDir, currentBinlog))
+	if out, cperr := cp.CombinedOutput(); cperr != nil {
+		t.Fatalf("docker cp %s: %v\n%s", currentBinlog, cperr, out)
+	}
+	p := parser.New(tmpDir, resolver, parser.Filters{Schemas: map[string]bool{sourceName: true}}, nil)
+	idx := indexer.New(indexDB, 100)
+	events := make(chan parser.Event, 256)
+	parseErr := make(chan error, 1)
+	go func() { defer close(events); parseErr <- p.ParseFile(ctx, currentBinlog, events) }()
+	if _, rerr := idx.Run(ctx, events); rerr != nil {
+		t.Fatalf("indexer.Run: %v", rerr)
+	}
+	if perr := <-parseErr; perr != nil {
+		t.Fatalf("ParseFile: %v", perr)
+	}
+
+	// Live truth after the re-point: child 10 now points at parent 2.
+	wantChild := checksum(t, sourceDB, "child")
+
+	eng := query.New(indexDB)
+	del := event.EventDelete
+	parentDeletes := mustFetch(t, eng, query.Options{Schema: sourceName, Table: "parent", EventType: &del})
+	if len(parentDeletes) != 1 || parentDeletes[0].PKValues != "1" {
+		t.Fatalf("want only the parent 1 delete indexed, got %v", pkList(parentDeletes))
+	}
+	fks, err := cascade.LoadCascadeFKs(ctx, indexDB, []string{sourceName})
+	if err != nil {
+		t.Fatalf("LoadCascadeFKs: %v", err)
+	}
+	res, err := cascade.SynthesizeVictims(ctx, eng, fks, parentDeletes, cascade.Options{})
+	if err != nil {
+		t.Fatalf("SynthesizeVictims: %v", err)
+	}
+	// The synthesis can't distinguish the re-pointed child from a still-nulled
+	// one, so it DOES emit a stale restore to mgr=1 — the guard is the defense.
+	if len(res.SetNullRows) != 1 || res.SetNullRows[0].PKValues != "10" {
+		t.Fatalf("expected one (stale) SET NULL restore for child:10, got %+v", res.SetNullRows)
+	}
+
+	tm, err := resolver.Resolve(sourceName, "child")
+	if err != nil {
+		t.Fatalf("resolve child: %v", err)
+	}
+	sr := res.SetNullRows[0]
+	stmt, err := recovery.FormatSetNullRestore(sr.Schema, sr.Table, sr.Column, sr.Value, tm.PKColumnMetas(), sr.Row)
+	if err != nil {
+		t.Fatalf("FormatSetNullRestore: %v", err)
+	}
+	if !strings.Contains(stmt, "IS NULL") {
+		t.Fatalf("restore must carry the IS NULL guard: %q", stmt)
+	}
+	applyFKOff(t, sourceName, stmt+";")
+
+	// The guard must have made the UPDATE a no-op: child 10 still points at 2.
+	if got := checksum(t, sourceDB, "child"); got != wantChild {
+		t.Errorf("guard failed: re-pointed child was clobbered (checksum want %d, got %d)", wantChild, got)
+	}
+	var mgr sql.NullInt64
+	if err := sourceDB.QueryRow("SELECT mgr FROM child WHERE id=10").Scan(&mgr); err != nil {
+		t.Fatalf("read child: %v", err)
+	}
+	if !mgr.Valid || mgr.Int64 != 2 {
+		t.Errorf("child 10 mgr should remain 2 (re-pointed), got %v", mgr)
+	}
+}

--- a/internal/cascade/cascade_cases_integration_test.go
+++ b/internal/cascade/cascade_cases_integration_test.go
@@ -97,9 +97,9 @@ func TestLoadCascadeFKsFromIndex(t *testing.T) {
 }
 
 // TestSynthesizeVictims_ruleGate pins the deliberate non-bug: only ON DELETE
-// CASCADE edges are delete-synthesized. A pure RESTRICT edge and an
-// ON-UPDATE-CASCADE-only edge (the dbtrail conflation) must yield no victims —
-// and, being non-CASCADE, never even hit the index, so no events are needed.
+// CASCADE / SET NULL edges are synthesized. A pure RESTRICT edge and an
+// ON-UPDATE-CASCADE-only edge (the dbtrail conflation) must yield nothing — and,
+// being neither rule, never even hit the index, so no events are needed.
 func TestSynthesizeVictims_ruleGate(t *testing.T) {
 	testutil.SkipIfNoMySQL(t)
 	indexDB, _ := testutil.CreateTestDB(t)
@@ -125,9 +125,57 @@ func TestSynthesizeVictims_ruleGate(t *testing.T) {
 		t.Fatalf("SynthesizeVictims: %v", err)
 	}
 	if len(res.Victims) != 0 {
-		t.Errorf("non-ON-DELETE-CASCADE edges must yield no victims, got %d: %+v", len(res.Victims), res.Victims)
+		t.Errorf("non-CASCADE/SET-NULL edges must yield no victims, got %d: %+v", len(res.Victims), res.Victims)
+	}
+	if len(res.SetNullRows) != 0 {
+		t.Errorf("non-CASCADE/SET-NULL edges must yield no SET NULL restores, got %d: %+v", len(res.SetNullRows), res.SetNullRows)
 	}
 }
+
+// TestSynthesizeVictims_setNull pins ON DELETE SET NULL: a child that referenced
+// the deleted parent (and survives) becomes a SetNullRestore (not a victim), and
+// it is NOT recursed (no row was deleted). A child re-pointed away is excluded.
+func TestSynthesizeVictims_setNull(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	eng := query.New(db)
+
+	T := time.Now().UTC()
+	h := T.Add(-30 * time.Minute).Truncate(time.Hour)
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{h})
+	ts := h.Add(10 * time.Minute).Format("2006-01-02 15:04:05")
+	// child 10 references parent 1 (SET NULL victim); child 13 re-pointed to 2.
+	testutil.InsertEvent(t, db, "b.000001", 10, 20, ts, nil, dbName, "child", 1, "10", nil, nil, []byte(`{"id":10,"pid":1}`))
+	testutil.InsertEvent(t, db, "b.000001", 20, 30, ts, nil, dbName, "child", 1, "13", nil, nil, []byte(`{"id":13,"pid":1}`))
+	testutil.InsertEvent(t, db, "b.000001", 30, 40, ts, nil, dbName, "child", 2 /*UPDATE*/, "13", nil, []byte(`{"id":13,"pid":1}`), []byte(`{"id":13,"pid":2}`))
+
+	fks := []cascade.CascadeFK{{
+		Schema: dbName, Table: "child", ConstraintName: "fk", Column: "pid",
+		ReferencedSchema: dbName, ReferencedTable: "parent", ReferencedColumn: "id",
+		DeleteRule: "SET NULL",
+	}}
+	res, err := cascade.SynthesizeVictims(context.Background(), eng, fks, parentDelete(dbName, T), cascade.Options{})
+	if err != nil {
+		t.Fatalf("SynthesizeVictims: %v", err)
+	}
+	if len(res.Victims) != 0 {
+		t.Errorf("SET NULL must produce no DELETE victims (rows survive), got %v", res.Victims)
+	}
+	if len(res.SetNullRows) != 1 || res.SetNullRows[0].PKValues != "10" || res.SetNullRows[0].Column != "pid" {
+		t.Fatalf("want one SET NULL restore for child:10 column pid, got %+v", res.SetNullRows)
+	}
+	if got := cascadeValToStr(res.SetNullRows[0].Value); got != "1" {
+		t.Errorf("restore value should be the parent key 1, got %q", got)
+	}
+	for _, sr := range res.SetNullRows {
+		if sr.PKValues == "13" {
+			t.Errorf("re-pointed child 13 must NOT be a SET NULL restore")
+		}
+	}
+}
+
+func cascadeValToStr(v any) string { return fmt.Sprintf("%v", v) }
 
 // TestSynthesizeVictims_compositeFKSkipped pins the composite-FK guard: a
 // multi-column CASCADE FK cannot be reconstructed by the single-column victim

--- a/internal/cli/recover.go
+++ b/internal/cli/recover.go
@@ -193,9 +193,10 @@ func runRecover(cmd *cobra.Command, args []string) error {
 				tables = append(tables, k)
 			}
 		}
-		slog.Warn("target schema has FK ON DELETE/UPDATE CASCADE constraints; plain `recover` "+
-			"cannot reconstruct cascade-deleted child rows (they are never binlogged, MySQL Bug "+
-			"#32506); use `bintrail recover-cascade` to reconstruct them",
+		slog.Warn("target schema has FK ON DELETE CASCADE/SET NULL (or ON UPDATE CASCADE) "+
+			"constraints; plain `recover` cannot reconstruct cascade-deleted child rows or "+
+			"SET NULL'd FKs (they are never binlogged, MySQL Bug #32506); use "+
+			"`bintrail recover-cascade` to reconstruct them",
 			"cascade_child_tables", strings.Join(tables, ", "))
 	}
 

--- a/internal/cli/recover_cascade.go
+++ b/internal/cli/recover_cascade.go
@@ -115,17 +115,21 @@ func fkFilterSafe(dataType string) bool {
 
 var recoverCascadeCmd = &cobra.Command{
 	Use:   "recover-cascade",
-	Short: "Generate reversal SQL for rows deleted by a foreign-key ON DELETE CASCADE",
-	Long: `Reconstruct rows that an InnoDB foreign-key ON DELETE CASCADE removed but
-never wrote to the binary log.
+	Short: "Generate reversal SQL for rows hit by a foreign-key ON DELETE CASCADE / SET NULL",
+	Long: `Reconstruct the side effects of an InnoDB foreign-key ON DELETE CASCADE or
+ON DELETE SET NULL that were never written to the binary log.
 
 On MySQL <= 8.x and MariaDB, InnoDB runs FK cascades below the binlog (fixed in
-MySQL 9.6), so only the parent DELETE is logged — the cascaded child deletes are
-invisible to plain
+MySQL 9.6), so only the parent DELETE is logged — the cascaded child deletes (and
+SET NULL FK-nullings) are invisible to plain
 ` + "`recover`" + ` (MySQL Bug #32506). This command finds the deleted parent rows in
 the index, infers which child rows referenced them in their last indexed state,
-and emits reversal SQL that re-inserts BOTH the parent rows and their
-cascade-deleted descendants, wrapped in SET FOREIGN_KEY_CHECKS=0/1.
+and emits reversal SQL:
+  - ON DELETE CASCADE: re-INSERT the parent rows and their cascade-deleted
+    descendants (recursing through multi-level cascades).
+  - ON DELETE SET NULL: an idempotent UPDATE restoring each nulled FK, guarded by
+    "... AND fk IS NULL" so a re-run or a later re-point is never clobbered.
+All wrapped in SET FOREIGN_KEY_CHECKS=0/1.
 
 It NEVER executes SQL — review the dry-run/output before applying.
 
@@ -343,13 +347,14 @@ func runRecoverCascade(cmd *cobra.Command, args []string) error {
 		table:          rcTable,
 		parents:        len(parentDeletes),
 		children:       len(res.Victims),
+		setnulls:       len(res.SetNullRows),
 		caveats:        caveats,
 		baselineActive: baselineProvider != nil,
 	}
 
 	if rcFormat == "json" {
 		var buf bytes.Buffer
-		n, gerr := emitCascadeSQL(&buf, recovery.New(db, resolver), rows, hdr)
+		n, gerr := emitCascadeSQL(&buf, recovery.New(db, resolver), rows, res.SetNullRows, resolver, hdr)
 		if gerr != nil {
 			return gerr
 		}
@@ -361,6 +366,7 @@ func runRecoverCascade(cmd *cobra.Command, args []string) error {
 		out := struct {
 			Parents          int      `json:"parents"`
 			Children         int      `json:"children"`
+			SetNullRestores  int      `json:"set_null_restores"`
 			Statements       int      `json:"statements"`
 			Complete         bool     `json:"complete"`
 			OperationalError bool     `json:"operational_error,omitempty"`
@@ -368,7 +374,7 @@ func runRecoverCascade(cmd *cobra.Command, args []string) error {
 			Output           string   `json:"output,omitempty"`
 			SQL              string   `json:"sql,omitempty"`
 		}{
-			Parents: len(parentDeletes), Children: len(res.Victims), Statements: n,
+			Parents: len(parentDeletes), Children: len(res.Victims), SetNullRestores: len(res.SetNullRows), Statements: n,
 			Complete: len(caveats) == 0 && synthErr == nil, OperationalError: synthErr != nil,
 			Incomplete: caveats, Output: rcOutput,
 		}
@@ -405,7 +411,7 @@ func runRecoverCascade(cmd *cobra.Command, args []string) error {
 			return f.Close()
 		}
 	}
-	n, gerr := emitCascadeSQL(w, recovery.New(db, resolver), rows, hdr)
+	n, gerr := emitCascadeSQL(w, recovery.New(db, resolver), rows, res.SetNullRows, resolver, hdr)
 	if gerr != nil {
 		return gerr
 	}
@@ -449,17 +455,20 @@ func cascadeExit(dest string, synthErr error, caveats []string, allowIncomplete 
 type cascadeHeader struct {
 	schema, table     string
 	parents, children int
+	setnulls          int
 	caveats           []string
 	baselineActive    bool
 }
 
-// emitCascadeSQL writes the documented preamble, the FK-checks-off wrapper, and
-// the reversal statements, returning the statement count from the generator.
-func emitCascadeSQL(w io.Writer, gen *recovery.Generator, rows []query.ResultRow, hdr cascadeHeader) (int, error) {
+// emitCascadeSQL writes the documented preamble, the FK-checks-off wrapper, the
+// CASCADE reversal statements (DELETE→INSERT via the generator), and the SET
+// NULL FK restorations (idempotent guarded UPDATEs). Returns the total statement
+// count. resolver supplies child PK columns for the SET NULL WHERE clauses.
+func emitCascadeSQL(w io.Writer, gen *recovery.Generator, rows []query.ResultRow, setNullRows []cascade.SetNullRestore, resolver *metadata.Resolver, hdr cascadeHeader) (int, error) {
 	var b strings.Builder
-	fmt.Fprintf(&b, "-- bintrail recover-cascade: reverse ON DELETE CASCADE side effects on %s.%s\n", hdr.schema, hdr.table)
-	fmt.Fprintf(&b, "-- Re-inserts %d deleted parent row(s) and %d cascade-deleted child row(s)\n", hdr.parents, hdr.children)
-	b.WriteString("-- that InnoDB removed below the binlog (MySQL Bug #32506). NEVER auto-applied.\n")
+	fmt.Fprintf(&b, "-- bintrail recover-cascade: reverse ON DELETE CASCADE / SET NULL side effects on %s.%s\n", hdr.schema, hdr.table)
+	fmt.Fprintf(&b, "-- Re-inserts %d deleted parent row(s) and %d cascade-deleted child row(s); restores %d SET NULL'd FK(s)\n", hdr.parents, hdr.children, hdr.setnulls)
+	b.WriteString("-- that InnoDB removed/nulled below the binlog (MySQL Bug #32506). NEVER auto-applied.\n")
 	b.WriteString("--\n")
 	if hdr.baselineActive {
 		b.WriteString("-- Phase-2 baseline fallback ACTIVE: children present in a covered baseline are\n")
@@ -487,6 +496,32 @@ func emitCascadeSQL(w io.Writer, gen *recovery.Generator, rows []query.ResultRow
 	n, err := gen.GenerateSQLFromRows(rows, w)
 	if err != nil {
 		return 0, err
+	}
+
+	// SET NULL restorations: idempotent UPDATEs (… AND fk IS NULL) that only
+	// touch rows still in the post-cascade nulled state, so a re-run or a later
+	// re-point of the child is never clobbered.
+	if len(setNullRows) > 0 {
+		if resolver == nil {
+			return n, fmt.Errorf("a schema snapshot is required to restore SET NULL foreign keys (run `bintrail snapshot`)")
+		}
+		if _, err := io.WriteString(w, "\n-- SET NULL FK restorations (idempotent: only rows whose FK is still NULL):\n"); err != nil {
+			return n, err
+		}
+		for _, sr := range setNullRows {
+			tm, terr := resolver.Resolve(sr.Schema, sr.Table)
+			if terr != nil {
+				return n, fmt.Errorf("resolve %s.%s for SET NULL restore: %w", sr.Schema, sr.Table, terr)
+			}
+			stmt, ferr := recovery.FormatSetNullRestore(sr.Schema, sr.Table, sr.Column, sr.Value, tm.PKColumnMetas(), sr.Row)
+			if ferr != nil {
+				return n, ferr
+			}
+			if _, werr := io.WriteString(w, stmt+";\n"); werr != nil {
+				return n, werr
+			}
+			n++
+		}
 	}
 
 	if _, err := io.WriteString(w, "\nSET FOREIGN_KEY_CHECKS=1;\n"); err != nil {

--- a/internal/cli/recover_cascade.go
+++ b/internal/cli/recover_cascade.go
@@ -241,8 +241,10 @@ func runRecoverCascade(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("schema migration: %w", err)
 	}
 
-	// Resolver enables PK-only WHERE clauses; best-effort (recovery here only
-	// emits INSERTs, so a nil resolver is harmless).
+	// Resolver enables PK-only WHERE clauses. Best-effort for the CASCADE path
+	// (INSERTs fall back to full row images), but REQUIRED for SET NULL restores
+	// (their WHERE needs the child PK columns) — emitCascadeSQL errors loudly,
+	// before writing anything, if SET NULL rows exist with a nil resolver.
 	resolver, err := metadata.NewResolver(db, 0)
 	if err != nil {
 		slog.Warn("could not load schema snapshot; recovery INSERTs still use full row images", "error", err)
@@ -413,6 +415,9 @@ func runRecoverCascade(cmd *cobra.Command, args []string) error {
 	}
 	n, gerr := emitCascadeSQL(w, recovery.New(db, resolver), rows, res.SetNullRows, resolver, hdr)
 	if gerr != nil {
+		if closeFn != nil {
+			_ = closeFn() // best-effort: gerr is the real failure, don't mask it (and don't leak the fd)
+		}
 		return gerr
 	}
 	if closeFn != nil {
@@ -465,6 +470,29 @@ type cascadeHeader struct {
 // NULL FK restorations (idempotent guarded UPDATEs). Returns the total statement
 // count. resolver supplies child PK columns for the SET NULL WHERE clauses.
 func emitCascadeSQL(w io.Writer, gen *recovery.Generator, rows []query.ResultRow, setNullRows []cascade.SetNullRestore, resolver *metadata.Resolver, hdr cascadeHeader) (int, error) {
+	// Build every SET NULL restoration BEFORE writing a byte (all-or-nothing): a
+	// missing resolver, an unresolvable table, or an absent PK column must abort
+	// the whole emit cleanly — returning mid-script would leave the parent/child
+	// INSERTs written but drop the closing `SET FOREIGN_KEY_CHECKS=1`, handing the
+	// operator a script that re-enables nothing.
+	var setNullStmts []string
+	if len(setNullRows) > 0 {
+		if resolver == nil {
+			return 0, fmt.Errorf("a schema snapshot is required to restore SET NULL foreign keys (run `bintrail snapshot`)")
+		}
+		for _, sr := range setNullRows {
+			tm, terr := resolver.Resolve(sr.Schema, sr.Table)
+			if terr != nil {
+				return 0, fmt.Errorf("resolve %s.%s for SET NULL restore: %w", sr.Schema, sr.Table, terr)
+			}
+			stmt, ferr := recovery.FormatSetNullRestore(sr.Schema, sr.Table, sr.Column, sr.Value, tm.PKColumnMetas(), sr.Row)
+			if ferr != nil {
+				return 0, ferr
+			}
+			setNullStmts = append(setNullStmts, stmt)
+		}
+	}
+
 	var b strings.Builder
 	fmt.Fprintf(&b, "-- bintrail recover-cascade: reverse ON DELETE CASCADE / SET NULL side effects on %s.%s\n", hdr.schema, hdr.table)
 	fmt.Fprintf(&b, "-- Re-inserts %d deleted parent row(s) and %d cascade-deleted child row(s); restores %d SET NULL'd FK(s)\n", hdr.parents, hdr.children, hdr.setnulls)
@@ -500,23 +528,13 @@ func emitCascadeSQL(w io.Writer, gen *recovery.Generator, rows []query.ResultRow
 
 	// SET NULL restorations: idempotent UPDATEs (… AND fk IS NULL) that only
 	// touch rows still in the post-cascade nulled state, so a re-run or a later
-	// re-point of the child is never clobbered.
-	if len(setNullRows) > 0 {
-		if resolver == nil {
-			return n, fmt.Errorf("a schema snapshot is required to restore SET NULL foreign keys (run `bintrail snapshot`)")
-		}
+	// re-point of the child is never clobbered. Pre-built above, so nothing here
+	// can fail after the INSERTs are already on disk.
+	if len(setNullStmts) > 0 {
 		if _, err := io.WriteString(w, "\n-- SET NULL FK restorations (idempotent: only rows whose FK is still NULL):\n"); err != nil {
 			return n, err
 		}
-		for _, sr := range setNullRows {
-			tm, terr := resolver.Resolve(sr.Schema, sr.Table)
-			if terr != nil {
-				return n, fmt.Errorf("resolve %s.%s for SET NULL restore: %w", sr.Schema, sr.Table, terr)
-			}
-			stmt, ferr := recovery.FormatSetNullRestore(sr.Schema, sr.Table, sr.Column, sr.Value, tm.PKColumnMetas(), sr.Row)
-			if ferr != nil {
-				return n, ferr
-			}
+		for _, stmt := range setNullStmts {
 			if _, werr := io.WriteString(w, stmt+";\n"); werr != nil {
 				return n, werr
 			}

--- a/internal/cli/recover_cascade_integration_test.go
+++ b/internal/cli/recover_cascade_integration_test.go
@@ -389,3 +389,54 @@ func TestRecoverCascade_phase2DedupCompositePK(t *testing.T) {
 		t.Errorf("composite child present in binlog AND baseline must dedup to ONE INSERT, got %d\n---\n%s", c, sql)
 	}
 }
+
+// TestRecoverCascade_setNullEmitsGuardedUpdate proves ON DELETE SET NULL recovery
+// end-to-end: a child that referenced the deleted parent (and survives with its
+// FK nulled) is restored by an idempotent UPDATE carrying the `... AND fk IS NULL`
+// guard — so a re-run or a later re-point of the child is never clobbered.
+func TestRecoverCascade_setNullEmitsGuardedUpdate(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	snapTs := "2026-06-01 00:00:00"
+	testutil.InsertSnapshot(t, db, 1, snapTs, dbName, "parent", "id", 1, "PRI", "int", "NO")
+	testutil.InsertSnapshot(t, db, 1, snapTs, dbName, "child", "id", 1, "PRI", "int", "NO")
+	testutil.InsertSnapshot(t, db, 1, snapTs, dbName, "child", "pid", 2, "", "int", "YES")
+
+	testutil.MustExec(t, db, `INSERT INTO fk_constraints
+		(snapshot_id, constraint_name, schema_name, table_name, column_name, ordinal_position,
+		 referenced_schema_name, referenced_table_name, referenced_column_name, delete_rule, update_rule)
+		VALUES (1, 'fk', ?, 'child', 'pid', 1, ?, 'parent', 'id', 'SET NULL', 'RESTRICT')`, dbName, dbName)
+
+	h := time.Now().UTC().Add(-1 * time.Hour).Truncate(time.Hour)
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{h})
+	childTs := h.Add(10 * time.Minute).Format("2006-01-02 15:04:05")
+	parentTs := h.Add(20 * time.Minute).Format("2006-01-02 15:04:05")
+	testutil.InsertEvent(t, db, "b.000001", 10, 20, childTs, nil, dbName, "child", 1 /*INSERT*/, "10", nil, nil, []byte(`{"id":10,"pid":1}`))
+	testutil.InsertEvent(t, db, "b.000001", 20, 30, parentTs, nil, dbName, "parent", 3 /*DELETE*/, "1", nil, []byte(`{"id":1}`), nil)
+
+	out := filepath.Join(t.TempDir(), "cascade.sql")
+	cleanCascadeFlags(testutil.IntegrationDSN(dbName), dbName, out)
+	rcPK = "1"
+
+	if err := runCascadeCmd(t); err != nil {
+		t.Fatalf("runRecoverCascade: %v", err)
+	}
+	b, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	sql := string(b)
+	// The restore is a guarded UPDATE, not an INSERT (the child row survives).
+	wantUpdate := "UPDATE `" + dbName + "`.`child` SET `pid` = 1 WHERE `id` = 10 AND `pid` IS NULL"
+	if !strings.Contains(sql, wantUpdate) {
+		t.Errorf("missing guarded SET NULL restore %q\n---\n%s", wantUpdate, sql)
+	}
+	if strings.Contains(sql, "INSERT INTO `"+dbName+"`.`child`") {
+		t.Errorf("SET NULL child must be UPDATEd, not re-INSERTed\n---\n%s", sql)
+	}
+}

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -854,7 +854,7 @@ func CascadeConstraintsInIndex(indexDB *sql.DB, schemas []string) ([]FKCascadeEd
 	query := `SELECT schema_name, table_name, column_name, referenced_table_name, delete_rule, update_rule
 		FROM fk_constraints
 		WHERE snapshot_id = (SELECT MAX(snapshot_id) FROM fk_constraints)
-		  AND (delete_rule = 'CASCADE' OR update_rule = 'CASCADE')`
+		  AND (delete_rule IN ('CASCADE', 'SET NULL') OR update_rule = 'CASCADE')`
 	var args []any
 	if len(schemas) > 0 {
 		placeholders := strings.TrimRight(strings.Repeat("?,", len(schemas)), ",")

--- a/internal/recovery/recovery.go
+++ b/internal/recovery/recovery.go
@@ -398,6 +398,33 @@ func QuoteName(name string) string {
 	return "`" + strings.ReplaceAll(name, "`", "``") + "`"
 }
 
+// FormatSetNullRestore emits an idempotent UPDATE that restores a foreign-key
+// column an ON DELETE SET NULL cascade nulled (MySQL ≤8.x never logs it). It
+// sets fkCol back to value, but ONLY for the row still in the nulled state
+// (WHERE pk… AND fkCol IS NULL) — so a re-run, a manual fix, or a later re-point
+// of the child is never clobbered (the cascade synthesis can't tell a
+// re-pointed child from a still-nulled one, because the re-point event doesn't
+// match the fk=parent scan that found the candidate). pkCols + row supply the
+// PK predicate; value is the parent key (typed, so it renders as a numeric
+// literal for an integer FK rather than a quoted string).
+func FormatSetNullRestore(schema, table, fkCol string, value any, pkCols []metadata.ColumnMeta, row map[string]any) (string, error) {
+	if len(pkCols) == 0 {
+		return "", fmt.Errorf("no PK columns for %s.%s SET NULL restore", schema, table)
+	}
+	where := make([]string, 0, len(pkCols)+1)
+	for _, c := range pkCols {
+		v, ok := row[c.Name]
+		if !ok {
+			return "", fmt.Errorf("PK column %q absent from %s.%s row for SET NULL restore", c.Name, schema, table)
+		}
+		where = append(where, QuoteName(c.Name)+" = "+FormatSQLValue(v))
+	}
+	where = append(where, QuoteName(fkCol)+" IS NULL")
+	return fmt.Sprintf("UPDATE %s.%s SET %s = %s WHERE %s",
+		QuoteName(schema), QuoteName(table), QuoteName(fkCol), FormatSQLValue(value),
+		strings.Join(where, " AND ")), nil
+}
+
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 func sortedKeys(m map[string]any) []string {

--- a/internal/recovery/recovery_test.go
+++ b/internal/recovery/recovery_test.go
@@ -868,3 +868,73 @@ func TestFormatValue_byteSliceWithNullByte(t *testing.T) {
 		t.Errorf("arbitrary []byte: got %q", got)
 	}
 }
+
+// ─── FormatSetNullRestore ────────────────────────────────────────────────────
+
+func TestFormatSetNullRestore_singlePKIntValue(t *testing.T) {
+	// An integer FK value (json.Number, as it arrives from the read path) must
+	// render as a bare numeric literal, and the guard `... AND fk IS NULL` must
+	// always be present so the UPDATE is idempotent.
+	pk := []metadata.ColumnMeta{{Name: "id", IsPK: true, DataType: "int"}}
+	row := map[string]any{"id": json.Number("10"), "pid": nil}
+	got, err := FormatSetNullRestore("app", "child", "pid", json.Number("1"), pk, row)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "UPDATE `app`.`child` SET `pid` = 1 WHERE `id` = 10 AND `pid` IS NULL"
+	if got != want {
+		t.Errorf("got  %q\nwant %q", got, want)
+	}
+}
+
+func TestFormatSetNullRestore_stringFKValueQuoted(t *testing.T) {
+	// A string FK value must be quoted+escaped; the IS NULL guard is unchanged.
+	pk := []metadata.ColumnMeta{{Name: "id", IsPK: true, DataType: "int"}}
+	row := map[string]any{"id": json.Number("7")}
+	got, err := FormatSetNullRestore("app", "child", "owner", "o'brien", pk, row)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := `UPDATE ` + "`app`.`child`" + ` SET ` + "`owner`" + ` = 'o\'brien' WHERE ` + "`id`" + ` = 7 AND ` + "`owner`" + ` IS NULL`
+	if got != want {
+		t.Errorf("got  %q\nwant %q", got, want)
+	}
+}
+
+func TestFormatSetNullRestore_compositePK(t *testing.T) {
+	// Every PK column joins the WHERE with AND, before the IS NULL guard.
+	pk := []metadata.ColumnMeta{
+		{Name: "tenant_id", IsPK: true, DataType: "int"},
+		{Name: "id", IsPK: true, DataType: "int"},
+	}
+	row := map[string]any{"tenant_id": json.Number("3"), "id": json.Number("42")}
+	got, err := FormatSetNullRestore("app", "child", "pid", json.Number("9"), pk, row)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "UPDATE `app`.`child` SET `pid` = 9 WHERE `tenant_id` = 3 AND `id` = 42 AND `pid` IS NULL"
+	if got != want {
+		t.Errorf("got  %q\nwant %q", got, want)
+	}
+}
+
+func TestFormatSetNullRestore_errNoPKColumns(t *testing.T) {
+	_, err := FormatSetNullRestore("app", "child", "pid", json.Number("1"), nil, map[string]any{"id": json.Number("10")})
+	if err == nil {
+		t.Fatal("expected error for empty pkCols, got nil")
+	}
+	if !strings.Contains(err.Error(), "no PK columns") {
+		t.Errorf("error should name the missing PK columns: %v", err)
+	}
+}
+
+func TestFormatSetNullRestore_errPKColumnAbsentFromRow(t *testing.T) {
+	pk := []metadata.ColumnMeta{{Name: "id", IsPK: true, DataType: "int"}}
+	_, err := FormatSetNullRestore("app", "child", "pid", json.Number("1"), pk, map[string]any{"pid": nil})
+	if err == nil {
+		t.Fatal("expected error for PK column absent from row, got nil")
+	}
+	if !strings.Contains(err.Error(), "absent") {
+		t.Errorf("error should report the absent PK column: %v", err)
+	}
+}


### PR DESCRIPTION
## What

Cascade-recovery **Slice E** — full `ON DELETE SET NULL` recovery, the last slice. Closes #553. Part of #548. Depends on #549–#552 (merged).

`ON DELETE SET NULL` has the same binlog blind spot as CASCADE (the child UPDATE that nulls the FK is unlogged on MySQL ≤8.x), but the child **row survives** — only its FK was nulled — so recovery is a restoring **UPDATE**, not an INSERT.

### How
- The synthesis engine now gates on `delete_rule` **CASCADE or SET NULL** (still not `update_rule`). Per edge: CASCADE → synthetic DELETE victim (recurses); SET NULL → a `cascade.SetNullRestore` that does **NOT** recurse (no row was deleted, so nothing cascades from it). Reuses all the Phase-1 / Phase-2 / dedup / window machinery — only the emission differs.
- `recovery.FormatSetNullRestore` emits an **idempotent, guarded** UPDATE:
  `UPDATE t SET fk = <parent key> WHERE pk = … AND fk IS NULL`.

### The `IS NULL` guard (advisor catch — the one real structural difference from CASCADE)
CASCADE is safe to apply blindly because the victim row is **absent** (a conflicting INSERT fails loudly). SET NULL mutates a **live** row, and the `fk = parent` scan can't tell a still-nulled child from one **re-pointed after** the cascade — the re-point's `before = NULL` doesn't match the scan, so the candidate selection picks the stale pre-null state. Without a guard the restore would clobber the legitimate re-point. `... AND fk IS NULL` restores only rows still in the nulled state → safe against re-points, manual fixes, and re-runs. `generateUpdate` can't express `IS NULL` (its WHERE is PK-only), hence the dedicated emission path.

### Details
- `Value` uses the **typed** parent key (renders as a numeric literal, not `'1'`); restores **only** the FK column (`RowBefore` single key) so a later non-FK change isn't clobbered.
- `recover-cascade` emits the SET NULL UPDATEs after the CASCADE INSERTs; `--format json` adds `set_null_restores`; the header counts them.
- Plain `recover` + `CascadeConstraintsInIndex` now also flag SET NULL schemas (recovery there is incomplete too).

## Tests
- Rule-gate: RESTRICT and ON-UPDATE-CASCADE-only edges yield neither victims nor restores.
- SET NULL synthesis: a referencing child becomes a restore (not a victim), is not recursed, and a re-pointed child is excluded.
- e2e: the emitted SQL carries the `... AND \`pid\` IS NULL` guard and is an UPDATE, not an INSERT.

Full unit + `cascade`/`cli`/`recovery`/`metadata` integration green.

## Epic
This completes the cascade-recovery epic (#548): A persist FK rules + soften guard, B synthesis engine, C `recover-cascade` command, D Phase-2 baseline fallback, E SET NULL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
