### PR TITLE
feat(pg): PostgreSQL-dialect recovery SQL (#533 — renderer slice)

### DIFF
--- a/internal/cli/recover.go
+++ b/internal/cli/recover.go
@@ -252,17 +252,10 @@ func runRecover(cmd *cobra.Command, args []string) error {
 
 	// ── Generate recovery SQL ─────────────────────────────────────────────────
 	// Select the SQL dialect from the source flavor recorded in the index
-	// (single-source per stream_state). PostgreSQL needs double-quoted identifiers
-	// and standard-conforming-string escaping; MySQL/MariaDB — and an absent or
-	// unknown flavor — keep the default backtick/backslash dialect. Best-effort: a
-	// read failure (no stream_state row on a file-indexed DB, very old schema)
-	// defaults to MySQL and never blocks recovery.
-	dialect := recovery.MySQLDialect
-	var srcFlavor string
-	if ferr := db.QueryRow("SELECT flavor FROM stream_state WHERE id = 1").Scan(&srcFlavor); ferr == nil && srcFlavor == "postgres" {
-		dialect = recovery.PostgresDialect
-	}
-	gen := recovery.NewForDialect(db, resolver, dialect)
+	// (single-source per stream_state) — PostgreSQL needs double-quoted identifiers
+	// and standard-conforming-string escaping; MySQL/MariaDB keep the default. The
+	// read is best-effort and defaults to MySQL (see recovery.DialectForIndex).
+	gen := recovery.NewForDialect(db, resolver, recovery.DialectForIndex(db))
 
 	if rDryRun {
 		if rFormat == "json" {

--- a/internal/cli/recover.go
+++ b/internal/cli/recover.go
@@ -251,7 +251,18 @@ func runRecover(cmd *cobra.Command, args []string) error {
 	}
 
 	// ── Generate recovery SQL ─────────────────────────────────────────────────
-	gen := recovery.New(db, resolver)
+	// Select the SQL dialect from the source flavor recorded in the index
+	// (single-source per stream_state). PostgreSQL needs double-quoted identifiers
+	// and standard-conforming-string escaping; MySQL/MariaDB — and an absent or
+	// unknown flavor — keep the default backtick/backslash dialect. Best-effort: a
+	// read failure (no stream_state row on a file-indexed DB, very old schema)
+	// defaults to MySQL and never blocks recovery.
+	dialect := recovery.MySQLDialect
+	var srcFlavor string
+	if ferr := db.QueryRow("SELECT flavor FROM stream_state WHERE id = 1").Scan(&srcFlavor); ferr == nil && srcFlavor == "postgres" {
+		dialect = recovery.PostgresDialect
+	}
+	gen := recovery.NewForDialect(db, resolver, dialect)
 
 	if rDryRun {
 		if rFormat == "json" {

--- a/internal/pgstreamrun/pgstreamrun_integration_test.go
+++ b/internal/pgstreamrun/pgstreamrun_integration_test.go
@@ -383,6 +383,185 @@ func TestOne_MultiTable_PKScopedRecovery(t *testing.T) {
 	}
 }
 
+// TestOne_PGDialect_ReversalExecutesAgainstPostgres is the #533 PG-dialect proof:
+// the reversal SQL bintrail-pg generates for PG-origin rows is valid PostgreSQL — it
+// EXECUTES against the live source and round-trips the values, including the escaping
+// cases the MySQL dialect would break: a single quote (MySQL `\'` → PG syntax error)
+// and a backslash (MySQL `\\` → silently stored doubled). Mirrors the `bintrail-pg
+// recover` construction: recovery.NewForDialect(indexDB, NewResolver(indexDB,0),
+// PostgresDialect). Covers a reverse INSERT (VALUES, all scary types) and a reverse
+// DELETE (PK-scoped WHERE), each executed against PostgreSQL.
+func TestOne_PGDialect_ReversalExecutesAgainstPostgres(t *testing.T) {
+	pgDSN := testutil.SkipIfNoPostgres(t)
+	testutil.SkipIfNoMySQL(t)
+	ctx := context.Background()
+
+	indexDB, dbName := testutil.CreateTestDB(t)
+	indexDSN := testutil.BaseDSN() + "/" + dbName
+
+	const slot = "bintrail_pgdialect"
+	const pub = "bintrail_pgdialect_pub"
+	const tbl = "pgdialect_t"
+
+	pg, err := pgx.Connect(ctx, pgDSN)
+	if err != nil {
+		t.Fatalf("connect PG: %v", err)
+	}
+	t.Cleanup(func() { pg.Close(context.Background()) })
+
+	dropAll := func() {
+		bg := context.Background()
+		_, _ = pg.Exec(bg, "DROP PUBLICATION IF EXISTS "+pub)
+		_, _ = pg.Exec(bg, "DROP TABLE IF EXISTS "+tbl)
+		_, _ = pg.Exec(bg, "SELECT pg_drop_replication_slot($1) WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name=$1)", slot)
+	}
+	dropAll()
+	t.Cleanup(dropAll)
+
+	mustExec := func(sqlStr string, args ...any) {
+		t.Helper()
+		if _, err := pg.Exec(ctx, sqlStr, args...); err != nil {
+			t.Fatalf("exec %q: %v", sqlStr, err)
+		}
+	}
+	mustExec(fmt.Sprintf(`CREATE TABLE %s (
+		id int PRIMARY KEY, name text, num numeric, frac numeric, bin bytea,
+		uid uuid, doc jsonb, flag boolean, ts timestamptz)`, tbl))
+	mustExec(fmt.Sprintf("ALTER TABLE %s REPLICA IDENTITY FULL", tbl))
+	mustExec(fmt.Sprintf("CREATE PUBLICATION %s FOR TABLE %s", pub, tbl))
+
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	cfg := pgstreamrun.Config{
+		IndexDSN: indexDSN, ReplDSN: replDSN(pgDSN), QueryDSN: pgDSN,
+		SlotName: slot, Publication: pub, ServerID: 44,
+		BatchSize: 100, Checkpoint: 200 * time.Millisecond,
+	}
+	runErr := make(chan error, 1)
+	go func() { runErr <- pgstreamrun.One(runCtx, cfg) }()
+	waitFor(t, 15*time.Second, func() bool {
+		var active bool
+		if err := pg.QueryRow(ctx, "SELECT active FROM pg_replication_slots WHERE slot_name=$1", slot).Scan(&active); err != nil {
+			return false
+		}
+		return active
+	}, "replication slot active")
+
+	// The escaping-critical value: a single quote AND a backslash. With MySQL escaping
+	// the quote would make the INSERT a syntax error and the backslash would be
+	// silently doubled. numeric > 2^53 guards precision; jsonb carries an embedded
+	// quote too.
+	const trickyName = `O'Brien \ C:\back`
+	const bigNum = "18446744073709551615"
+	selCanonical := fmt.Sprintf("SELECT name, num::text, frac::text, encode(bin,'hex'), uid::text, doc::text, flag::text, ts::text FROM %s WHERE id=1", tbl)
+	type rowText struct{ name, num, frac, bin, uid, doc, flag, ts string }
+	// frac=1.50 proves numeric SCALE fidelity (trailing zero), not just integer precision.
+	mustExec(fmt.Sprintf("INSERT INTO %s VALUES (1, $1, $2, 1.50, '\\xdeadbeef', '11111111-1111-1111-1111-111111111111', $3, true, '2026-06-22 12:00:00+00')", tbl),
+		trickyName, bigNum, `{"k": "v's"}`)
+	// Capture PostgreSQL's canonical text rendering BEFORE the row is deleted.
+	var orig rowText
+	if err := pg.QueryRow(ctx, selCanonical).Scan(&orig.name, &orig.num, &orig.frac, &orig.bin, &orig.uid, &orig.doc, &orig.flag, &orig.ts); err != nil {
+		t.Fatalf("capture original canonical text: %v", err)
+	}
+	mustExec(fmt.Sprintf("DELETE FROM %s WHERE id=1", tbl))
+
+	waitFor(t, 15*time.Second, func() bool {
+		var n int
+		if err := indexDB.QueryRow("SELECT COUNT(*) FROM binlog_events WHERE table_name = ?", tbl).Scan(&n); err != nil {
+			return false
+		}
+		return n >= 2 // INSERT + DELETE
+	}, "INSERT+DELETE indexed")
+
+	cancel()
+	if err := <-runErr; err != nil {
+		t.Fatalf("One returned error: %v", err)
+	}
+
+	rows, err := query.New(indexDB).Fetch(ctx, query.Options{Schema: "public", Table: tbl, Order: "ASC"})
+	if err != nil {
+		t.Fatalf("query Fetch: %v", err)
+	}
+	var insRow, delRow *query.ResultRow
+	for i := range rows {
+		switch rows[i].EventType {
+		case event.EventInsert:
+			insRow = &rows[i]
+		case event.EventDelete:
+			delRow = &rows[i]
+		}
+	}
+	if insRow == nil || delRow == nil {
+		t.Fatalf("expected an INSERT and a DELETE event, got %d rows", len(rows))
+	}
+
+	// The bintrail-pg recover construction: index db + latest resolver + PG dialect.
+	resolver, err := metadata.NewResolver(indexDB, 0)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+	genPG := func(r query.ResultRow) string {
+		var buf bytes.Buffer
+		if _, err := recovery.NewForDialect(indexDB, resolver, recovery.PostgresDialect).
+			GenerateSQLFromRows([]query.ResultRow{r}, &buf); err != nil {
+			t.Fatalf("GenerateSQLFromRows: %v", err)
+		}
+		return buf.String()
+	}
+
+	// ── Reverse the DELETE → a reverse INSERT (VALUES, all scary types). The row is
+	// currently gone; executing the reversal against live PostgreSQL must reconstruct
+	// it byte-for-byte. A MySQL-dialect reversal would NOT execute here. ──
+	reverseInsert := genPG(*delRow)
+	if strings.Contains(reverseInsert, "`") {
+		t.Errorf("PG reversal contains MySQL backticks:\n%s", reverseInsert)
+	}
+	if _, err := pg.Exec(ctx, reverseInsert); err != nil {
+		t.Fatalf("PG-dialect reverse INSERT failed to execute against PostgreSQL: %v\nSQL:\n%s", err, reverseInsert)
+	}
+	var got rowText
+	if err := pg.QueryRow(ctx, selCanonical).Scan(&got.name, &got.num, &got.frac, &got.bin, &got.uid, &got.doc, &got.flag, &got.ts); err != nil {
+		t.Fatalf("re-select after reverse INSERT: %v", err)
+	}
+	if got != orig {
+		t.Errorf("round-trip mismatch:\n got  %+v\n want %+v", got, orig)
+	}
+	// The escaping killer, asserted independently of the canonical capture: the exact
+	// bytes must survive — quote round-tripped, backslash NOT doubled.
+	if got.name != trickyName {
+		t.Errorf("name = %q, want exactly %q (quote/backslash escaping bug)", got.name, trickyName)
+	}
+	if got.num != bigNum {
+		t.Errorf("numeric = %q, want %q (precision lost)", got.num, bigNum)
+	}
+	if got.frac != "1.50" {
+		t.Errorf("fractional numeric = %q, want \"1.50\" (scale/trailing-zero not preserved)", got.frac)
+	}
+	// Typed boolean read: the canonical SELECT renders bool as 't' on both sides, so a
+	// typed read is what actually proves the value (not the text) round-tripped.
+	var flagBool bool
+	if err := pg.QueryRow(ctx, fmt.Sprintf("SELECT flag FROM %s WHERE id=1", tbl)).Scan(&flagBool); err != nil {
+		t.Fatalf("typed bool read: %v", err)
+	}
+	if !flagBool {
+		t.Error("flag round-tripped as false, want true")
+	}
+
+	// ── Reverse the INSERT → a reverse DELETE (PK-scoped WHERE). Executing it must
+	// remove the row again — proving the PG WHERE dialect (double-quoted id) runs. ──
+	reverseDelete := genPG(*insRow)
+	if _, err := pg.Exec(ctx, reverseDelete); err != nil {
+		t.Fatalf("PG-dialect reverse DELETE failed to execute against PostgreSQL: %v\nSQL:\n%s", err, reverseDelete)
+	}
+	var cnt int
+	if err := pg.QueryRow(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE id=1", tbl)).Scan(&cnt); err != nil {
+		t.Fatalf("count after reverse DELETE: %v", err)
+	}
+	if cnt != 0 {
+		t.Errorf("reverse DELETE left %d rows, want 0 (PK-scoped WHERE did not match)", cnt)
+	}
+}
+
 // ── helpers ──
 
 func replDSN(base string) string {

--- a/internal/pgstreamrun/pgstreamrun_integration_test.go
+++ b/internal/pgstreamrun/pgstreamrun_integration_test.go
@@ -387,10 +387,15 @@ func TestOne_MultiTable_PKScopedRecovery(t *testing.T) {
 // the reversal SQL bintrail-pg generates for PG-origin rows is valid PostgreSQL — it
 // EXECUTES against the live source and round-trips the values, including the escaping
 // cases the MySQL dialect would break: a single quote (MySQL `\'` → PG syntax error)
-// and a backslash (MySQL `\\` → silently stored doubled). Mirrors the `bintrail-pg
-// recover` construction: recovery.NewForDialect(indexDB, NewResolver(indexDB,0),
-// PostgresDialect). Covers a reverse INSERT (VALUES, all scary types) and a reverse
-// DELETE (PK-scoped WHERE), each executed against PostgreSQL.
+// and a backslash (MySQL `\\` → silently stored doubled). It covers all three reversal
+// shapes — reverse INSERT (VALUES), reverse UPDATE (SET, escaping in the SET clause),
+// reverse DELETE (PK-scoped WHERE) — each executed against PostgreSQL, plus the
+// dialect-selection path (recovery.DialectForIndex on a PG-flavored index).
+//
+// Scope asterisk: this proves validity for tables WITHOUT identity / STORED generated
+// columns. A reverse INSERT into a `GENERATED ALWAYS AS IDENTITY` PK needs OVERRIDING
+// SYSTEM VALUE, and STORED generated columns must be omitted — both capture-side,
+// tracked in #557.
 func TestOne_PGDialect_ReversalExecutesAgainstPostgres(t *testing.T) {
 	pgDSN := testutil.SkipIfNoPostgres(t)
 	testutil.SkipIfNoMySQL(t)
@@ -448,21 +453,21 @@ func TestOne_PGDialect_ReversalExecutesAgainstPostgres(t *testing.T) {
 	}, "replication slot active")
 
 	// The escaping-critical value: a single quote AND a backslash. With MySQL escaping
-	// the quote would make the INSERT a syntax error and the backslash would be
-	// silently doubled. numeric > 2^53 guards precision; jsonb carries an embedded
-	// quote too.
+	// the quote would make a statement a syntax error and the backslash would be
+	// silently doubled. numeric > 2^53 guards precision, frac=1.50 guards scale, jsonb
+	// carries an embedded quote too.
 	const trickyName = `O'Brien \ C:\back`
 	const bigNum = "18446744073709551615"
 	selCanonical := fmt.Sprintf("SELECT name, num::text, frac::text, encode(bin,'hex'), uid::text, doc::text, flag::text, ts::text FROM %s WHERE id=1", tbl)
 	type rowText struct{ name, num, frac, bin, uid, doc, flag, ts string }
-	// frac=1.50 proves numeric SCALE fidelity (trailing zero), not just integer precision.
 	mustExec(fmt.Sprintf("INSERT INTO %s VALUES (1, $1, $2, 1.50, '\\xdeadbeef', '11111111-1111-1111-1111-111111111111', $3, true, '2026-06-22 12:00:00+00')", tbl),
 		trickyName, bigNum, `{"k": "v's"}`)
-	// Capture PostgreSQL's canonical text rendering BEFORE the row is deleted.
+	// Capture PostgreSQL's canonical text rendering of the original row (V1, flag=true).
 	var orig rowText
 	if err := pg.QueryRow(ctx, selCanonical).Scan(&orig.name, &orig.num, &orig.frac, &orig.bin, &orig.uid, &orig.doc, &orig.flag, &orig.ts); err != nil {
 		t.Fatalf("capture original canonical text: %v", err)
 	}
+	mustExec(fmt.Sprintf("UPDATE %s SET flag=false WHERE id=1", tbl)) // → V2; reverse-UPDATE must restore the full V1 before-image
 	mustExec(fmt.Sprintf("DELETE FROM %s WHERE id=1", tbl))
 
 	waitFor(t, 15*time.Second, func() bool {
@@ -470,32 +475,40 @@ func TestOne_PGDialect_ReversalExecutesAgainstPostgres(t *testing.T) {
 		if err := indexDB.QueryRow("SELECT COUNT(*) FROM binlog_events WHERE table_name = ?", tbl).Scan(&n); err != nil {
 			return false
 		}
-		return n >= 2 // INSERT + DELETE
-	}, "INSERT+DELETE indexed")
+		return n >= 3 // INSERT + UPDATE + DELETE
+	}, "INSERT+UPDATE+DELETE indexed")
 
 	cancel()
 	if err := <-runErr; err != nil {
 		t.Fatalf("One returned error: %v", err)
 	}
 
+	// The dialect SELECTION path `bintrail-pg recover` actually runs: a PG-flavored
+	// index (pgstreamrun stamped stream_state.flavor='postgres') must resolve to
+	// PostgresDialect — not the tautological pure-mapper test.
+	if d := recovery.DialectForIndex(indexDB); d != recovery.PostgresDialect {
+		t.Fatalf("DialectForIndex on a PG-flavored index = %v, want PostgresDialect", d)
+	}
+
 	rows, err := query.New(indexDB).Fetch(ctx, query.Options{Schema: "public", Table: tbl, Order: "ASC"})
 	if err != nil {
 		t.Fatalf("query Fetch: %v", err)
 	}
-	var insRow, delRow *query.ResultRow
+	var insRow, updRow, delRow *query.ResultRow
 	for i := range rows {
 		switch rows[i].EventType {
 		case event.EventInsert:
 			insRow = &rows[i]
+		case event.EventUpdate:
+			updRow = &rows[i]
 		case event.EventDelete:
 			delRow = &rows[i]
 		}
 	}
-	if insRow == nil || delRow == nil {
-		t.Fatalf("expected an INSERT and a DELETE event, got %d rows", len(rows))
+	if insRow == nil || updRow == nil || delRow == nil {
+		t.Fatalf("expected INSERT+UPDATE+DELETE events, got %d rows", len(rows))
 	}
 
-	// The bintrail-pg recover construction: index db + latest resolver + PG dialect.
 	resolver, err := metadata.NewResolver(indexDB, 0)
 	if err != nil {
 		t.Fatalf("NewResolver: %v", err)
@@ -510,45 +523,62 @@ func TestOne_PGDialect_ReversalExecutesAgainstPostgres(t *testing.T) {
 	}
 
 	// ── Reverse the DELETE → a reverse INSERT (VALUES, all scary types). The row is
-	// currently gone; executing the reversal against live PostgreSQL must reconstruct
-	// it byte-for-byte. A MySQL-dialect reversal would NOT execute here. ──
+	// gone; executing the reversal against live PostgreSQL must reconstruct the
+	// pre-DELETE row (V2: flag=false). The escaping-critical name comes through VALUES.
+	// A MySQL-dialect reversal would NOT execute here. ──
 	reverseInsert := genPG(*delRow)
 	if strings.Contains(reverseInsert, "`") {
 		t.Errorf("PG reversal contains MySQL backticks:\n%s", reverseInsert)
 	}
+	if !strings.Contains(reverseInsert, "SET LOCAL standard_conforming_strings = on;") {
+		t.Errorf("PG script missing the standard_conforming_strings guard:\n%s", reverseInsert)
+	}
 	if _, err := pg.Exec(ctx, reverseInsert); err != nil {
 		t.Fatalf("PG-dialect reverse INSERT failed to execute against PostgreSQL: %v\nSQL:\n%s", err, reverseInsert)
 	}
-	var got rowText
-	if err := pg.QueryRow(ctx, selCanonical).Scan(&got.name, &got.num, &got.frac, &got.bin, &got.uid, &got.doc, &got.flag, &got.ts); err != nil {
+	var afterIns rowText
+	if err := pg.QueryRow(ctx, selCanonical).Scan(&afterIns.name, &afterIns.num, &afterIns.frac, &afterIns.bin, &afterIns.uid, &afterIns.doc, &afterIns.flag, &afterIns.ts); err != nil {
 		t.Fatalf("re-select after reverse INSERT: %v", err)
 	}
-	if got != orig {
-		t.Errorf("round-trip mismatch:\n got  %+v\n want %+v", got, orig)
+	if afterIns.name != trickyName {
+		t.Errorf("reverse INSERT name = %q, want exactly %q (quote/backslash escaping bug in VALUES)", afterIns.name, trickyName)
 	}
-	// The escaping killer, asserted independently of the canonical capture: the exact
-	// bytes must survive — quote round-tripped, backslash NOT doubled.
-	if got.name != trickyName {
-		t.Errorf("name = %q, want exactly %q (quote/backslash escaping bug)", got.name, trickyName)
+	if afterIns.flag != "false" {
+		t.Errorf("reverse INSERT reconstructed flag = %q, want \"false\" (the pre-DELETE before-image V2)", afterIns.flag)
 	}
-	if got.num != bigNum {
-		t.Errorf("numeric = %q, want %q (precision lost)", got.num, bigNum)
+
+	// ── Reverse the UPDATE → a reverse UPDATE (SET = full V1 before-image, PK-scoped
+	// WHERE). The SET clause carries the escaping-critical name, the >2^53 numeric and
+	// the 1.50 scale; executing it must restore the original row exactly. ──
+	reverseUpdate := genPG(*updRow)
+	if _, err := pg.Exec(ctx, reverseUpdate); err != nil {
+		t.Fatalf("PG-dialect reverse UPDATE failed to execute against PostgreSQL: %v\nSQL:\n%s", err, reverseUpdate)
 	}
-	if got.frac != "1.50" {
-		t.Errorf("fractional numeric = %q, want \"1.50\" (scale/trailing-zero not preserved)", got.frac)
+	var afterUpd rowText
+	if err := pg.QueryRow(ctx, selCanonical).Scan(&afterUpd.name, &afterUpd.num, &afterUpd.frac, &afterUpd.bin, &afterUpd.uid, &afterUpd.doc, &afterUpd.flag, &afterUpd.ts); err != nil {
+		t.Fatalf("re-select after reverse UPDATE: %v", err)
 	}
-	// Typed boolean read: the canonical SELECT renders bool as 't' on both sides, so a
-	// typed read is what actually proves the value (not the text) round-tripped.
+	if afterUpd != orig {
+		t.Errorf("reverse UPDATE round-trip mismatch:\n got  %+v\n want %+v", afterUpd, orig)
+	}
+	if afterUpd.name != trickyName {
+		t.Errorf("reverse UPDATE SET name = %q, want exactly %q (escaping in the SET clause)", afterUpd.name, trickyName)
+	}
+	if afterUpd.num != bigNum || afterUpd.frac != "1.50" {
+		t.Errorf("reverse UPDATE numeric/scale = (%q,%q), want (%q,\"1.50\")", afterUpd.num, afterUpd.frac, bigNum)
+	}
+	// Typed boolean read: the canonical SELECT renders bool as 't' text on both sides,
+	// so a typed read is what actually proves the restored value (not the text).
 	var flagBool bool
 	if err := pg.QueryRow(ctx, fmt.Sprintf("SELECT flag FROM %s WHERE id=1", tbl)).Scan(&flagBool); err != nil {
 		t.Fatalf("typed bool read: %v", err)
 	}
 	if !flagBool {
-		t.Error("flag round-tripped as false, want true")
+		t.Error("reverse UPDATE restored flag=false, want true (typed read)")
 	}
 
-	// ── Reverse the INSERT → a reverse DELETE (PK-scoped WHERE). Executing it must
-	// remove the row again — proving the PG WHERE dialect (double-quoted id) runs. ──
+	// ── Reverse the INSERT → a reverse DELETE (PK-scoped double-quoted WHERE).
+	// Executing it removes the row again — proving the PG WHERE dialect runs. ──
 	reverseDelete := genPG(*insRow)
 	if _, err := pg.Exec(ctx, reverseDelete); err != nil {
 		t.Fatalf("PG-dialect reverse DELETE failed to execute against PostgreSQL: %v\nSQL:\n%s", err, reverseDelete)

--- a/internal/recovery/recovery.go
+++ b/internal/recovery/recovery.go
@@ -61,10 +61,35 @@ func New(db *sql.DB, resolver *metadata.Resolver) *Generator {
 }
 
 // NewForDialect is New with an explicit SQL dialect. Callers that know the source
-// flavor (e.g. `bintrail-pg recover` reading stream_state.flavor) pass
-// PostgresDialect; everything else uses New (MySQL).
+// flavor (e.g. `bintrail-pg recover` via DialectForIndex) pass PostgresDialect;
+// everything else uses New (MySQL).
 func NewForDialect(db *sql.DB, resolver *metadata.Resolver, dialect Dialect) *Generator {
 	return &Generator{db: db, resolver: resolver, dialect: dialect}
+}
+
+// DialectForFlavor maps a stream_state.flavor value to the recovery SQL dialect.
+// PostgreSQL gets its own dialect; MySQL, MariaDB, and an empty/unknown flavor all
+// use MySQL (the established default — MariaDB recovery SQL is MySQL-dialect). It
+// owns the canonical "postgres" flavor literal so callers don't re-derive it.
+func DialectForFlavor(flavor string) Dialect {
+	if flavor == "postgres" {
+		return PostgresDialect
+	}
+	return MySQLDialect
+}
+
+// DialectForIndex returns the recovery dialect for an index database, read from the
+// source flavor recorded in stream_state (the index is single-source). Best-effort:
+// any read failure (no stream_state row on a file-indexed DB, very old schema)
+// returns MySQLDialect and never blocks recovery. This is the authoritative
+// selection every recover surface should use — `cli/recover.go` today; the console,
+// MCP, and agent recover paths adopt it in a follow-up.
+func DialectForIndex(db *sql.DB) Dialect {
+	var flavor string
+	if err := db.QueryRow("SELECT flavor FROM stream_state WHERE id = 1").Scan(&flavor); err != nil {
+		return MySQLDialect
+	}
+	return DialectForFlavor(flavor)
 }
 
 // resolverForRow returns the resolver matching the row's schema version.
@@ -130,6 +155,14 @@ func (g *Generator) GenerateSQLFromRows(rows []query.ResultRow, w io.Writer) (in
 	fmt.Fprintln(w, "-- IMPORTANT: Review carefully before applying to production.")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "BEGIN;")
+	if g.dialect == PostgresDialect {
+		// escapePGString relies on standard_conforming_strings=on (PostgreSQL's
+		// default), under which a backslash is literal. If the operator applies this
+		// script in a session with it OFF, an unescaped backslash would be reinterpreted
+		// (silent corruption). SET LOCAL pins it for this transaction only, so the
+		// script defends its own escaping regardless of the target session's setting.
+		fmt.Fprintln(w, "SET LOCAL standard_conforming_strings = on;")
+	}
 
 	written := 0
 	for _, row := range rows {
@@ -490,6 +523,14 @@ func formatValuePG(v any) string {
 			return "true"
 		}
 		return "false"
+	case map[string]any, []any, json.RawMessage:
+		// Defensive, mirroring FormatSQLValue: a structured value → JSON, quoted. On
+		// the PG path the only structured value a row image can carry is the
+		// unchanged-TOAST sentinel map, reachable only via the all-columns WHERE
+		// fallback under a weaker-than-FULL replica identity (out of support; RI FULL
+		// resolves it at decode). JSON-marshalling keeps it valid, collision-distinct SQL.
+		b, _ := json.Marshal(val)
+		return "'" + escapePGString(string(b)) + "'"
 	default:
 		// Defensive: any other Go type → its text form, quoted + escaped.
 		return "'" + escapePGString(fmt.Sprintf("%v", val)) + "'"

--- a/internal/recovery/recovery.go
+++ b/internal/recovery/recovery.go
@@ -23,17 +23,48 @@ import (
 	"github.com/dbtrail/dbtrail/internal/query"
 )
 
+// Dialect selects the SQL dialect for generated reversal SQL. The index is
+// single-source (stream_state.flavor), so the dialect is decided ONCE at
+// construction from that authoritative signal — never inferred per-row from
+// resolver/type presence, which would silently emit the wrong dialect for a row
+// whose snapshot failed to load (the all-columns fallback path).
+type Dialect int
+
+const (
+	// MySQLDialect emits MySQL/MariaDB SQL: backtick identifiers, X'..' hex blobs,
+	// backslash string escaping. The default, and the only dialect the MySQL-source
+	// path — and the reconstruct mydumper writer, via the exported FormatSQLValue/
+	// QuoteName — has ever produced.
+	MySQLDialect Dialect = iota
+	// PostgresDialect emits PostgreSQL SQL: double-quoted identifiers and
+	// standard-conforming-string escaping ('' doubling, no backslash). Values
+	// captured from pgoutput are already in PostgreSQL's canonical text form, so a
+	// quoted literal coerces into the target column's type on INSERT/UPDATE/WHERE —
+	// the dialect difference is identifier quoting + string escaping, not per-type
+	// literal forms (#533).
+	PostgresDialect
+)
+
 // Generator produces reversal SQL from indexed binlog events.
 type Generator struct {
 	db       *sql.DB
 	resolver *metadata.Resolver            // default resolver (latest snapshot); may be nil
 	cache    map[uint32]*metadata.Resolver // per-snapshot resolvers, loaded lazily
+	dialect  Dialect
 }
 
-// New creates a Generator. resolver may be nil — in that case, WHERE clauses
-// for UPDATE and DELETE reversals will use ALL row columns instead of just PKs.
+// New creates a Generator emitting MySQL-dialect SQL. resolver may be nil — in that
+// case, WHERE clauses for UPDATE and DELETE reversals will use ALL row columns
+// instead of just PKs.
 func New(db *sql.DB, resolver *metadata.Resolver) *Generator {
-	return &Generator{db: db, resolver: resolver}
+	return &Generator{db: db, resolver: resolver, dialect: MySQLDialect}
+}
+
+// NewForDialect is New with an explicit SQL dialect. Callers that know the source
+// flavor (e.g. `bintrail-pg recover` reading stream_state.flavor) pass
+// PostgresDialect; everything else uses New (MySQL).
+func NewForDialect(db *sql.DB, resolver *metadata.Resolver, dialect Dialect) *Generator {
+	return &Generator{db: db, resolver: resolver, dialect: dialect}
 }
 
 // resolverForRow returns the resolver matching the row's schema version.
@@ -168,11 +199,11 @@ func (g *Generator) generateInsert(row query.ResultRow) (string, error) {
 		if genCols[col] {
 			continue
 		}
-		colParts = append(colParts, QuoteName(col))
-		valParts = append(valParts, FormatSQLValue(row.RowBefore[col]))
+		colParts = append(colParts, g.quoteName(col))
+		valParts = append(valParts, g.formatValue(row.RowBefore[col]))
 	}
 	return fmt.Sprintf("INSERT INTO %s.%s (%s) VALUES (%s)",
-		QuoteName(row.SchemaName), QuoteName(row.TableName),
+		g.quoteName(row.SchemaName), g.quoteName(row.TableName),
 		strings.Join(colParts, ", "),
 		strings.Join(valParts, ", "),
 	), nil
@@ -196,15 +227,15 @@ func (g *Generator) generateUpdate(row query.ResultRow) (string, error) {
 		if genCols[col] {
 			continue
 		}
-		setParts = append(setParts, QuoteName(col)+" = "+FormatSQLValue(row.RowBefore[col]))
+		setParts = append(setParts, g.quoteName(col)+" = "+g.formatValue(row.RowBefore[col]))
 	}
 
 	// WHERE uses row_after (current state), so the UPDATE finds the right row
 	// even if the PK itself was changed in the original UPDATE.
-	whereParts := pkWhereClauseFromResolver(r, row.SchemaName, row.TableName, row.RowAfter)
+	whereParts := g.pkWhereClause(r, row.SchemaName, row.TableName, row.RowAfter)
 
 	return fmt.Sprintf("UPDATE %s.%s SET %s WHERE %s",
-		QuoteName(row.SchemaName), QuoteName(row.TableName),
+		g.quoteName(row.SchemaName), g.quoteName(row.TableName),
 		strings.Join(setParts, ", "),
 		strings.Join(whereParts, " AND "),
 	), nil
@@ -217,9 +248,9 @@ func (g *Generator) generateDelete(row query.ResultRow) (string, error) {
 		return "", fmt.Errorf("row_after is nil for INSERT event (event_id=%d)", row.EventID)
 	}
 	r := g.resolverForRow(row)
-	whereParts := pkWhereClauseFromResolver(r, row.SchemaName, row.TableName, row.RowAfter)
+	whereParts := g.pkWhereClause(r, row.SchemaName, row.TableName, row.RowAfter)
 	return fmt.Sprintf("DELETE FROM %s.%s WHERE %s",
-		QuoteName(row.SchemaName), QuoteName(row.TableName),
+		g.quoteName(row.SchemaName), g.quoteName(row.TableName),
 		strings.Join(whereParts, " AND "),
 	), nil
 }
@@ -249,10 +280,13 @@ func generatedColsFromResolver(resolver *metadata.Resolver, schema, table string
 	return gen
 }
 
-// pkWhereClauseFromResolver builds "pk_col = val AND ..." from the given resolver.
-// Falls back to ALL columns if the table cannot be resolved (e.g. table was
-// dropped, or no snapshot was loaded).
-func pkWhereClauseFromResolver(resolver *metadata.Resolver, schema, table string, row map[string]any) []string {
+// pkWhereClause builds "pk_col = val AND ..." from the given resolver, in the
+// Generator's dialect. Falls back to ALL columns if the table cannot be resolved
+// (e.g. table was dropped, or no snapshot was loaded). Note: on the PostgreSQL
+// path the all-columns fallback can emit `"col" = '...'` for a json column, which
+// has no `=` operator in PostgreSQL (jsonb does) — PK-scoped (the #533 norm) avoids
+// it since PKs are scalars.
+func (g *Generator) pkWhereClause(resolver *metadata.Resolver, schema, table string, row map[string]any) []string {
 	if resolver != nil {
 		tm, err := resolver.Resolve(schema, table)
 		if err != nil {
@@ -269,7 +303,7 @@ func pkWhereClauseFromResolver(resolver *metadata.Resolver, schema, table string
 						allFound = false
 						break
 					}
-					parts = append(parts, QuoteName(pk.Name)+" = "+FormatSQLValue(v))
+					parts = append(parts, g.quoteName(pk.Name)+" = "+g.formatValue(v))
 				}
 				if allFound {
 					return parts
@@ -279,14 +313,14 @@ func pkWhereClauseFromResolver(resolver *metadata.Resolver, schema, table string
 	}
 	// Fallback: all columns — verbose but always uniquely identifies the row
 	// (assuming the table has no duplicates, which is true for well-formed data).
-	return allColsWhere(row)
+	return g.allColsWhere(row)
 }
 
-func allColsWhere(row map[string]any) []string {
+func (g *Generator) allColsWhere(row map[string]any) []string {
 	cols := sortedKeys(row)
 	parts := make([]string, len(cols))
 	for i, col := range cols {
-		parts[i] = QuoteName(col) + " = " + FormatSQLValue(row[col])
+		parts[i] = g.quoteName(col) + " = " + g.formatValue(row[col])
 	}
 	return parts
 }
@@ -396,6 +430,70 @@ func EscapeString(s string) string {
 // escaping any backticks in the name itself.
 func QuoteName(name string) string {
 	return "`" + strings.ReplaceAll(name, "`", "``") + "`"
+}
+
+// ─── Dialect dispatch (#533) ───────────────────────────────────────────────────
+
+// quoteName quotes an identifier in the Generator's dialect.
+func (g *Generator) quoteName(name string) string {
+	if g.dialect == PostgresDialect {
+		return quoteNamePG(name)
+	}
+	return QuoteName(name)
+}
+
+// formatValue renders a value as a literal in the Generator's dialect.
+func (g *Generator) formatValue(v any) string {
+	if g.dialect == PostgresDialect {
+		return formatValuePG(v)
+	}
+	return FormatSQLValue(v)
+}
+
+// quoteNamePG wraps a PostgreSQL identifier in double quotes, doubling any embedded
+// double quote.
+func quoteNamePG(name string) string {
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+}
+
+// escapePGString escapes a string for a PostgreSQL single-quoted literal under
+// standard_conforming_strings=on (PostgreSQL's default for 15+ years; the emitted
+// SQL is portable under it): only the single quote is doubled. A backslash is a
+// LITERAL backslash and must NOT be doubled — doubling it (as MySQL escaping does)
+// would silently store two backslashes. PostgreSQL text cannot contain a NUL byte
+// and pgoutput never delivers one, so none is handled.
+func escapePGString(s string) string {
+	return strings.ReplaceAll(s, "'", "''")
+}
+
+// formatValuePG renders a Go value as a PostgreSQL literal. Values captured from
+// pgoutput arrive here as Go strings (pgoutput text mode) or nil — and a quoted,
+// standard-conforming-escaped string coerces into the target column's type on
+// INSERT/UPDATE/WHERE, so no per-type literal forms are needed (a numeric, uuid,
+// bytea '\x..', jsonb, bool 't', timestamptz, etc. all coerce from their canonical
+// text). The non-string cases are DEFENSIVE: they should not occur on the
+// PostgreSQL path (which stores every value as text), but are handled so a stray
+// value never emits invalid SQL.
+func formatValuePG(v any) string {
+	if v == nil {
+		return "NULL"
+	}
+	switch val := v.(type) {
+	case string:
+		return "'" + escapePGString(val) + "'"
+	case json.Number:
+		// Defensive: PG values are stored as strings, not json.Number; if one
+		// appears, emit it verbatim (a valid numeric literal, no float64 rounding).
+		return string(val)
+	case bool:
+		if val {
+			return "true"
+		}
+		return "false"
+	default:
+		// Defensive: any other Go type → its text form, quoted + escaped.
+		return "'" + escapePGString(fmt.Sprintf("%v", val)) + "'"
+	}
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────

--- a/internal/recovery/recovery_test.go
+++ b/internal/recovery/recovery_test.go
@@ -918,6 +918,13 @@ func TestFormatValuePG(t *testing.T) {
 	if got := formatValuePG(true); got != "true" {
 		t.Errorf("bool true → %q, want true", got)
 	}
+	// Defensive structured-value path (mirrors FormatSQLValue): the only structured
+	// value a PG row image can carry is the unchanged-TOAST sentinel map, reachable
+	// only under a weaker-than-FULL replica identity (out of support). It must marshal
+	// to valid, quoted JSON, never panic or emit a bare Go %v rendering.
+	if got := formatValuePG(map[string]any{"__bintrail_unchanged_toast__": true}); got != `'{"__bintrail_unchanged_toast__":true}'` {
+		t.Errorf("map → %q, want quoted JSON", got)
+	}
 }
 
 func TestGeneratePG_ReverseInsertDialect(t *testing.T) {
@@ -979,8 +986,10 @@ func TestGeneratePG_ReverseDeleteWhereDialect(t *testing.T) {
 	}
 }
 
-// TestGenerate_MySQLDialectUnchanged guards the additive change: the default
-// (MySQL) generator output is byte-identical to before — backticks, not double quotes.
+// TestGenerate_MySQLDialectUnchanged guards the additive change: the default (MySQL)
+// generator still emits MySQL-dialect SQL — backtick identifiers and backslash quote
+// escaping, NOT the PG double-quote / doubled-single-quote forms — so the additive PG
+// path did not alter the shipping MySQL output.
 func TestGenerate_MySQLDialectUnchanged(t *testing.T) {
 	g := newGen() // New(nil,nil) → MySQLDialect
 	row := query.ResultRow{
@@ -997,5 +1006,48 @@ func TestGenerate_MySQLDialectUnchanged(t *testing.T) {
 	}
 	if !strings.Contains(stmt, `'O\'Brien'`) {
 		t.Errorf("MySQL dialect must backslash-escape the quote, got: %s", stmt)
+	}
+}
+
+func TestDialectForFlavor(t *testing.T) {
+	cases := map[string]Dialect{
+		"postgres": PostgresDialect,
+		"mysql":    MySQLDialect,
+		"mariadb":  MySQLDialect, // MariaDB recovery SQL is MySQL-dialect
+		"":         MySQLDialect, // absent/unknown → MySQL
+		"pg":       MySQLDialect, // only the exact canonical literal maps to Postgres
+	}
+	for flavor, want := range cases {
+		if got := DialectForFlavor(flavor); got != want {
+			t.Errorf("DialectForFlavor(%q) = %v, want %v", flavor, got, want)
+		}
+	}
+}
+
+// TestGeneratePG_ScriptWrapper pins the standard_conforming_strings guard: a PG-dialect
+// script SET LOCALs it (so the escaping is self-defending regardless of the target
+// session), and the MySQL script does NOT emit it.
+func TestGeneratePG_ScriptWrapper(t *testing.T) {
+	row := query.ResultRow{
+		EventID: 1, SchemaName: "public", TableName: "t",
+		EventType: parser.EventDelete, EventTimestamp: time.Unix(0, 0).UTC(),
+		RowBefore: map[string]any{"id": "1"},
+	}
+	const scs = "SET LOCAL standard_conforming_strings = on;"
+
+	var pgBuf bytes.Buffer
+	if _, err := NewForDialect(nil, nil, PostgresDialect).GenerateSQLFromRows([]query.ResultRow{row}, &pgBuf); err != nil {
+		t.Fatalf("PG GenerateSQLFromRows: %v", err)
+	}
+	if !strings.Contains(pgBuf.String(), scs) {
+		t.Errorf("PG script must contain %q, got:\n%s", scs, pgBuf.String())
+	}
+
+	var myBuf bytes.Buffer
+	if _, err := New(nil, nil).GenerateSQLFromRows([]query.ResultRow{row}, &myBuf); err != nil {
+		t.Fatalf("MySQL GenerateSQLFromRows: %v", err)
+	}
+	if strings.Contains(myBuf.String(), "standard_conforming_strings") {
+		t.Errorf("MySQL script must NOT emit the PG SCS guard, got:\n%s", myBuf.String())
 	}
 }

--- a/internal/recovery/recovery_test.go
+++ b/internal/recovery/recovery_test.go
@@ -868,3 +868,134 @@ func TestFormatValue_byteSliceWithNullByte(t *testing.T) {
 		t.Errorf("arbitrary []byte: got %q", got)
 	}
 }
+
+// ─── PostgreSQL dialect (#533) ──────────────────────────────────────────────────
+
+func TestQuoteNamePG(t *testing.T) {
+	cases := map[string]string{
+		"id":     `"id"`,
+		"My Col": `"My Col"`,
+		`we"ird`: `"we""ird"`, // embedded double-quote doubled
+	}
+	for in, want := range cases {
+		if got := quoteNamePG(in); got != want {
+			t.Errorf("quoteNamePG(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestEscapePGString(t *testing.T) {
+	// standard_conforming_strings=on: double the single quote, leave backslash literal.
+	cases := map[string]string{
+		"O'Brien":                "O''Brien", // MySQL would emit O\'Brien → PG syntax error
+		`C:\path`:                `C:\path`,  // backslash NOT doubled — MySQL would → silent corruption
+		"plain":                  "plain",
+		"":                       "",
+		"a'b'c":                  "a''b''c",
+		`back\slash and 'quote'`: `back\slash and ''quote''`, // both together
+	}
+	for in, want := range cases {
+		if got := escapePGString(in); got != want {
+			t.Errorf("escapePGString(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestFormatValuePG(t *testing.T) {
+	if got := formatValuePG(nil); got != "NULL" {
+		t.Errorf("nil → %q, want NULL", got)
+	}
+	if got := formatValuePG("O'Brien"); got != "'O''Brien'" {
+		t.Errorf("quote string → %q, want 'O''Brien'", got)
+	}
+	if got := formatValuePG(`C:\win`); got != `'C:\win'` {
+		t.Errorf("backslash string → %q, want '%s' (literal backslash, not doubled)", got, `C:\win`)
+	}
+	// Defensive json.Number path: >2^53 verbatim, no float64 rounding.
+	if got := formatValuePG(json.Number("18446744073709551615")); got != "18446744073709551615" {
+		t.Errorf("json.Number → %q, want verbatim", got)
+	}
+	if got := formatValuePG(true); got != "true" {
+		t.Errorf("bool true → %q, want true", got)
+	}
+}
+
+func TestGeneratePG_ReverseInsertDialect(t *testing.T) {
+	// A PostgreSQL-dialect reverse INSERT (from a DELETE event): double-quoted
+	// identifiers + standard-conforming string escaping; NO MySQL backticks / \' / X''.
+	g := NewForDialect(nil, nil, PostgresDialect)
+	row := query.ResultRow{
+		EventID: 1, SchemaName: "public", TableName: "t",
+		EventType: parser.EventDelete,
+		RowBefore: map[string]any{
+			"id":   "1",
+			"name": "O'Brien",
+			"path": `C:\win`,
+			"num":  "18446744073709551615",
+		},
+	}
+	stmt, err := g.generateInsert(row)
+	if err != nil {
+		t.Fatalf("generateInsert: %v", err)
+	}
+	if !strings.Contains(stmt, `INSERT INTO "public"."t"`) {
+		t.Errorf("want double-quoted schema.table, got: %s", stmt)
+	}
+	if strings.Contains(stmt, "`") {
+		t.Errorf("PG SQL must not contain backticks: %s", stmt)
+	}
+	if !strings.Contains(stmt, `'O''Brien'`) {
+		t.Errorf("want ''-doubled quote, got: %s", stmt)
+	}
+	if !strings.Contains(stmt, `'C:\win'`) || strings.Contains(stmt, `C:\\win`) {
+		t.Errorf("backslash must stay literal (not doubled), got: %s", stmt)
+	}
+}
+
+func TestGeneratePG_ReverseDeleteWhereDialect(t *testing.T) {
+	// PG reverse DELETE (from an INSERT event): PK-scoped WHERE with a double-quoted id.
+	resolver := metadata.NewResolverFromTables(1, map[string]*metadata.TableMeta{
+		"public.t": {
+			Schema: "public", Table: "t",
+			Columns:   []metadata.ColumnMeta{{Name: "id", IsPK: true}, {Name: "v"}},
+			PKColumns: []string{"id"},
+		},
+	})
+	g := NewForDialect(nil, resolver, PostgresDialect)
+	row := query.ResultRow{
+		EventID: 2, SchemaName: "public", TableName: "t",
+		EventType: parser.EventInsert, SchemaVersion: 0,
+		RowAfter: map[string]any{"id": "5", "v": "x"},
+	}
+	stmt, err := g.generateDelete(row)
+	if err != nil {
+		t.Fatalf("generateDelete: %v", err)
+	}
+	if !strings.Contains(stmt, `DELETE FROM "public"."t" WHERE "id" = '5'`) {
+		t.Errorf("want PG PK-scoped WHERE, got: %s", stmt)
+	}
+	if strings.Contains(stmt, "`") {
+		t.Errorf("PG SQL must not contain backticks: %s", stmt)
+	}
+}
+
+// TestGenerate_MySQLDialectUnchanged guards the additive change: the default
+// (MySQL) generator output is byte-identical to before — backticks, not double quotes.
+func TestGenerate_MySQLDialectUnchanged(t *testing.T) {
+	g := newGen() // New(nil,nil) → MySQLDialect
+	row := query.ResultRow{
+		EventID: 1, SchemaName: "db", TableName: "t",
+		EventType: parser.EventDelete,
+		RowBefore: map[string]any{"id": "1", "name": "O'Brien"},
+	}
+	stmt, err := g.generateInsert(row)
+	if err != nil {
+		t.Fatalf("generateInsert: %v", err)
+	}
+	if !strings.Contains(stmt, "INSERT INTO `db`.`t`") {
+		t.Errorf("MySQL dialect must use backticks, got: %s", stmt)
+	}
+	if !strings.Contains(stmt, `'O\'Brien'`) {
+		t.Errorf("MySQL dialect must backslash-escape the quote, got: %s", stmt)
+	}
+}


### PR DESCRIPTION
Part of #527 / **#533** (the renderer slice, building on the schema/type oracle from #570). `bintrail-pg recover` now emits **valid PostgreSQL** reversal SQL instead of MySQL-dialect.

> Part of #533 — **does not close it**. Remaining: the documented type-support matrix; identity/generated-column handling (#557); broader type breadth.

## The insight (verified, not assumed)
The dialect difference is **mechanics — identifier quoting + string escaping — not a per-type literal zoo.** Values captured from pgoutput are already in PostgreSQL's canonical text form, so a quoted literal coerces into the target column's type on INSERT/UPDATE/WHERE. `numeric`, `uuid`, `bytea`, `jsonb`, `bool`, `timestamptz` all round-trip. The `#496` float64 hazard structurally cannot occur on the PG path (values are stored as text, never `json.Number`-from-an-int).

## Changes
- **recovery**: additive `Dialect` (`MySQLDialect` default / `PostgresDialect`) + `NewForDialect`. New PG primitives: `quoteNamePG` (double-quote, `""`-escape), `escapePGString` (standard_conforming_strings — double the quote, leave backslash **literal**), `formatValuePG`. `generate*`/`pkWhereClause`/`allColsWhere` dispatch via `g.quoteName`/`g.formatValue`. The exported `FormatSQLValue`/`QuoteName` (reused by `reconstruct`'s mydumper writer) are **untouched** → MySQL output byte-identical (guarded by `TestGenerate_MySQLDialectUnchanged`).
- **cli/recover.go**: select the dialect **once** from `stream_state.flavor` (authoritative — the index is single-source), *not* inferred per-row from resolver/OID presence (which would silently emit MySQL dialect for a row whose snapshot failed to load). Defaults to MySQL when flavor is absent/unknown.

## Escaping — the scariest case, pinned both ways
Under `standard_conforming_strings=on`: `O'Brien` → `'O''Brien'` (MySQL `\'` is a **PG syntax error**) and `C:\path` → `'C:\path'` (MySQL doubles the backslash → **silent corruption**).

## Proof (the deliverable)
`TestOne_PGDialect_ReversalExecutesAgainstPostgres` **executes the generated reversal against live postgres:16**:
- a reverse INSERT (all scary types incl. quote+backslash name, `numeric` >2^53 **and** fractional `1.50` for scale fidelity, bytea, uuid, jsonb-with-quote, typed-bool read) round-trips byte-for-byte;
- a reverse DELETE (PK-scoped, double-quoted WHERE) removes the row.

Plus white-box unit tests for the dialect primitives and the MySQL-unchanged guard. Verified: PG integration + MySQL recovery/cli regression + full unit suite green.

## Scope / asterisks (not in this slice)
- This is **type-agnostic dialect mechanics** — it does NOT surface `pg_type_oid` (coercion proven, not needed yet).
- "Executes against PostgreSQL" holds for tables **without generated/identity columns**: a reverse INSERT would now emit a (valid) INSERT that includes a generated column, which PG rejects (`cannot insert into generated column`), and `GENERATED ALWAYS AS IDENTITY` needs `OVERRIDING SYSTEM VALUE`. Both are capture-side and tracked in **#557** (not a regression — the MySQL-dialect SQL never ran against PG anyway).
- The `json`-not-`jsonb` all-columns-WHERE `=`-operator fallback edge: PK-scoped (the norm) avoids it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)