### PR TITLE
docs: surface recover-cascade (FK CASCADE/SET NULL recovery)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ before/after images in a searchable index:
 
 - **See every change** — what changed and when, for every row, with before → after diffs
 - **Undo precisely** — generate exact reversal SQL for just the damaged rows
+- **Undo cascade deletes** — reconstruct child rows an `ON DELETE CASCADE` wiped out (and restore FKs an `ON DELETE SET NULL` cleared) that InnoDB removes *below* the binlog and most tools can't see — see [Query & Recovery](docs/query-and-recovery.md)
 - **Time-travel** — query any row (or table) as it was at any moment (requires ProxySQL — see [Time-Travel SQL](docs/time-travel-sql.md))
 - **Web console** — browse, recover, and add servers to monitor, all in the UI
 - **[MCP server](docs/mcp-server.md)** — Claude or any MCP client can search history and draft recoveries

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -119,6 +119,8 @@ mysql -u root -p mydb < recovery.sql
 
 **Verify** — query the index again or run a `SELECT` against the source to confirm the rows are back.
 
+> **Was the deleted row a parent in a foreign-key relationship?** An `ON DELETE CASCADE` may have taken child rows with it that InnoDB removed *below* the binlog — the query above won't show them, and plain `recover` can't bring them back. See **Scenario M** to reconstruct the whole subtree.
+
 ---
 
 ### Scenario B: A bad UPDATE went out — need to roll back column values
@@ -414,6 +416,58 @@ Redirect stderr only (stdout still shows query output):
 ```sh
 bintrail --log-level debug query --index-dsn "..." --schema mydb --table orders 2>debug.log
 ```
+
+---
+
+### Scenario M: An ON DELETE CASCADE also wiped out child rows
+
+**Situation:** Someone deleted a parent row — say `customers.id = 42` — and a foreign key with `ON DELETE CASCADE` took its orders, line items, and everything below them down with it. On MySQL 8.x and earlier (and MariaDB), InnoDB runs the cascade *inside the storage engine, below the binary log*, so only the parent `DELETE` was ever written. Plain `recover` has nothing to reverse for the children, and a normal query won't even show them as deleted — they vanished without a trace in the log.
+
+`bintrail recover-cascade` solves exactly this: it finds the deleted parent, infers which child rows pointed at it in their last indexed state, and reconstructs the whole subtree.
+
+**Preview the fix** — point it at the **parent** table and the deleted parent's PK:
+
+```sh
+bintrail recover-cascade \
+  --index-dsn "user:pass@tcp(127.0.0.1:3306)/binlog_index" \
+  --schema    shop \
+  --table     customers \
+  --pk        '42' \
+  --dry-run
+```
+
+The output re-INSERTs the parent and every cascade-deleted descendant — recursing through multi-level cascades (orders → line_items → …) — wrapped in `SET FOREIGN_KEY_CHECKS=0/1`. For an `ON DELETE SET NULL` foreign key the child row survived and only its FK was cleared, so you get an idempotent `UPDATE ... SET fk = <parent> WHERE pk = ... AND fk IS NULL` instead — safe to re-run, and it never clobbers a child you have since re-pointed.
+
+Process several deleted parents at once with `--pks '42,43,44'`, or a whole window with `--since`/`--until`.
+
+**Mind the coverage line.** recover-cascade rebuilds a child from its **last indexed state**, so it can only see children that have a binlog event within `--lookback` (default `30d`). An insert-once child that has not changed in months falls outside that window — it cannot be reconstructed from the binlog alone, and the command says so instead of silently dropping it:
+
+```
+-- !!! INCOMPLETE RECOVERY — the result is provably partial:
+--   - no baseline covers shop.line_items; children untouched within the lookback window are not reconstructed
+```
+
+When the output is flagged `INCOMPLETE RECOVERY` the command **exits non-zero**, so a script can't apply a half-recovery as if it were whole. To reach those untouched children, point it at a [baseline snapshot](dump-and-baseline.md) — they are recovered from the snapshot and the binlog window is widened back to the snapshot time:
+
+```sh
+bintrail recover-cascade \
+  --index-dsn    "user:pass@tcp(127.0.0.1:3306)/binlog_index" \
+  --schema shop --table customers --pk '42' \
+  --baseline-dir ./baseline \
+  --output       cascade-recovery.sql
+```
+
+**Review and apply** — read the SQL first, always. If you have already re-created the parent by hand, delete its `INSERT` from the file (`FOREIGN_KEY_CHECKS=0` does **not** suppress primary-key violations):
+
+```sh
+cat cascade-recovery.sql
+
+mysql -u root -p shop < cascade-recovery.sql
+```
+
+**Verify** — `SELECT` the parent and a child table to confirm the subtree is back.
+
+See [Query & Recovery](query-and-recovery.md) for the full flag reference and the exact best-effort boundaries.
 
 ---
 

--- a/docs/indexing.md
+++ b/docs/indexing.md
@@ -39,7 +39,9 @@ bintrail index \
 `--source-dsn` lets `index` preflight the source (`binlog_format=ROW` and
 `binlog_row_image=FULL`, both required; `ON DELETE/UPDATE CASCADE` foreign keys
 are allowed but warned — InnoDB executes cascades below the binlog, so the
-cascaded child deletes are not captured and plain `recover` cannot restore them)
+cascaded child deletes are not captured and plain `recover` cannot reverse them;
+use `bintrail recover-cascade` to reconstruct them, see
+[Query & Recovery](query-and-recovery.md))
 and auto-snapshot if no snapshot exists yet. It is **required**
 unless you pass `--skip-source-validation` to index offline binlogs against an
 already-captured snapshot — the silent skip is gone so a non-`FULL` source can't

--- a/internal/cli/recover_cascade.go
+++ b/internal/cli/recover_cascade.go
@@ -508,7 +508,7 @@ func emitCascadeSQL(w io.Writer, gen *recovery.Generator, rows []query.ResultRow
 	} else {
 		b.WriteString("-- Phase-1 (binlog-window) recovery: a child untouched within --lookback and not\n")
 		b.WriteString("-- in a baseline is NOT reconstructed — pass --baseline-dir/--baseline-s3 to enable\n")
-		b.WriteString("-- Phase-2 fallback (#552). \"Complete\" means everything DETECTABLE was recovered.\n")
+		b.WriteString("-- Phase-2 fallback. \"Complete\" means everything DETECTABLE was recovered.\n")
 	}
 	b.WriteString("--\n")
 	b.WriteString("-- If you have already re-created a deleted parent, delete its INSERT below:\n")

--- a/internal/cli/recover_cascade.go
+++ b/internal/cli/recover_cascade.go
@@ -133,10 +133,13 @@ All wrapped in SET FOREIGN_KEY_CHECKS=0/1.
 
 It NEVER executes SQL — review the dry-run/output before applying.
 
-Phase-1 (binlog-window) recovery: a child untouched within --lookback and not in
-a baseline cannot be reconstructed (baseline fallback is tracked in #552).
-The command searches the live index only — archived partitions are not scanned;
-when they exist, the output is flagged incomplete.
+Phase-1 (binlog-window) recovers children with a binlog event within --lookback.
+A child untouched in that window (e.g. an insert-once row from months ago) needs
+Phase-2: point --baseline-dir/--baseline-s3 at a ` + "`bintrail baseline`" + ` snapshot and
+those untouched children are recovered from it too. When the result is provably
+partial — no baseline, a per-parent overflow, or archived partitions the live
+scan cannot see — it is flagged INCOMPLETE and the command exits non-zero unless
+--allow-incomplete.
 
 Examples:
   # Preview recovery for one accidentally-deleted parent and its cascade


### PR DESCRIPTION
Raises the discoverability of the cascade-recovery feature (epic #548, shipped in **v0.18.0**), which until now lived only in the `recover-cascade` reference section of `query-and-recovery.md`. Also fixes one stale in-binary help claim.

## Changes
- **README "What you get"** — a bullet for reconstructing `ON DELETE CASCADE` child rows / restoring `ON DELETE SET NULL` FKs (InnoDB removes them *below* the binlog; most tools can't see them).
- **docs/guide.md** — new **Scenario M**, a worked end-to-end walkthrough in the guide's scenario style, deliberately showing the *unhappy path*: the `INCOMPLETE RECOVERY` flag, the `--lookback` blind spot, and the `--baseline-dir`/`--baseline-s3` Phase-2 fallback for untouched children. Plus a cross-reference from **Scenario A** (the most-read delete scenario).
- **docs/indexing.md** — the FK-cascade index-time warning now points at `recover-cascade` instead of dead-ending at "plain recover cannot restore them".
- **internal/cli/recover_cascade.go** — the `--help` Long text said baseline fallback was "tracked in #552", but #552 (Slice D) shipped and `--baseline-dir`/`--baseline-s3` are listed in the same help. Rewrote it to describe Phase-2 as available.

## Verification
- Flag names/defaults checked against `bintrail recover-cascade --help`.
- Honesty parity kept with the 4-agent-reviewed reference section (dry-run-only, best-effort, exits non-zero on `INCOMPLETE`).
- `go build`, `go test ./internal/cli/` green; help renders correctly (backtick concatenation in the raw string).

🤖 Generated with [Claude Code](https://claude.com/claude-code)