### PR TITLE
feat(pg): adopt DialectForIndex on console/MCP/agent recover (closes #573)

### DIFF
--- a/cmd/bintrail-mcp/main.go
+++ b/cmd/bintrail-mcp/main.go
@@ -481,7 +481,7 @@ func makeRecoverTool(connect connectFunc) func(context.Context, *mcp.CallToolReq
 			}
 		}
 
-		gen := recovery.New(db, resolver)
+		gen := recovery.NewForDialect(db, resolver, recovery.DialectForIndex(db))
 		var buf bytes.Buffer
 		n, err := gen.GenerateSQLFromRows(rows, &buf)
 		if err != nil {

--- a/internal/agent/handler.go
+++ b/internal/agent/handler.go
@@ -263,7 +263,9 @@ func (h *DefaultHandler) HandleRecover(ctx context.Context, req RecoverRequest) 
 			resolver = nil
 		}
 	}
-	gen := recovery.New(h.IndexDB, resolver)
+	// DialectForIndex is nil-safe: h.IndexDB may be nil here, in which case it returns
+	// MySQLDialect (#533/#573).
+	gen := recovery.NewForDialect(h.IndexDB, resolver, recovery.DialectForIndex(h.IndexDB))
 
 	var buf bytes.Buffer
 	_, err := gen.GenerateSQLFromRows(rows, &buf)

--- a/internal/console/api.go
+++ b/internal/console/api.go
@@ -251,7 +251,10 @@ func (s *Server) handleRecover(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var buf bytes.Buffer
-	n, err := recovery.New(b.db, b.resolver).GenerateSQLFromRows(rows, &buf)
+	// Per-bundle dialect: the console is multi-server, so select from THIS server's
+	// index flavor (a PG-flavored index → PostgreSQL reversal SQL). DialectForIndex
+	// defaults to MySQL on any read failure (#533/#573).
+	n, err := recovery.NewForDialect(b.db, b.resolver, recovery.DialectForIndex(b.db)).GenerateSQLFromRows(rows, &buf)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, err.Error())
 		return

--- a/internal/console/console_integration_test.go
+++ b/internal/console/console_integration_test.go
@@ -155,6 +155,40 @@ func TestIntegrationRecoverMatchesGenerator(t *testing.T) {
 	}
 }
 
+// TestIntegrationRecoverPGDialect proves the console recover surface emits
+// PostgreSQL-dialect SQL when the selected server's index is PG-flavored (#573):
+// the console is the reachable-today surface for PG customers (capture with
+// bintrail-pg, view/recover with the shared console). DialectForIndex reads the
+// per-bundle stream_state.flavor, so a 'postgres' flavor → double-quoted identifiers
+// + the standard_conforming_strings guard, NOT MySQL backticks.
+func TestIntegrationRecoverPGDialect(t *testing.T) {
+	srv, _ := seedConsoleData(t)
+	// Stamp the boot bundle's index as PostgreSQL-sourced (single-row stream_state).
+	if _, err := srv.cm.boot.db.Exec(
+		`INSERT INTO stream_state (id, mode, flavor, last_checkpoint, server_id)
+		 VALUES (1, 'gtid', 'postgres', UTC_TIMESTAMP(), 1)`); err != nil {
+		t.Fatalf("stamp stream_state flavor=postgres: %v", err)
+	}
+
+	rec, body := doReq(t, srv, "POST", "/api/recover", `{"schema":"app","table":"users"}`)
+	if rec.Code != 200 {
+		t.Fatalf("recover code = %d, body = %s", rec.Code, body)
+	}
+	var resp recoverResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(resp.SQL, `"app"."users"`) {
+		t.Errorf("console PG recover must use double-quoted identifiers, got:\n%s", resp.SQL)
+	}
+	if !strings.Contains(resp.SQL, "SET LOCAL standard_conforming_strings = on;") {
+		t.Errorf("console PG recover must emit the standard_conforming_strings guard, got:\n%s", resp.SQL)
+	}
+	if strings.Contains(resp.SQL, "`") {
+		t.Errorf("console PG recover must NOT contain MySQL backticks, got:\n%s", resp.SQL)
+	}
+}
+
 // TestIntegrationRecoverWithTimeRangeSurfacesGap exercises the planner-active
 // recover path. testutil.InitIndexTables creates only the p_future partition,
 // so loadLivePartitionHours is empty and every hour in a bounded query range is

--- a/internal/recovery/recovery.go
+++ b/internal/recovery/recovery.go
@@ -80,11 +80,14 @@ func DialectForFlavor(flavor string) Dialect {
 
 // DialectForIndex returns the recovery dialect for an index database, read from the
 // source flavor recorded in stream_state (the index is single-source). Best-effort:
-// any read failure (no stream_state row on a file-indexed DB, very old schema)
-// returns MySQLDialect and never blocks recovery. This is the authoritative
-// selection every recover surface should use — `cli/recover.go` today; the console,
-// MCP, and agent recover paths adopt it in a follow-up.
+// a nil db, or any read failure (no stream_state row on a file-indexed DB, very old
+// schema), returns MySQLDialect and never blocks recovery. This is the authoritative
+// selection every recover surface uses (cli/recover.go, console, MCP, agent). The nil
+// guard lets a caller pass an as-yet-unopened handle (e.g. agent.IndexDB) directly.
 func DialectForIndex(db *sql.DB) Dialect {
+	if db == nil {
+		return MySQLDialect
+	}
 	var flavor string
 	if err := db.QueryRow("SELECT flavor FROM stream_state WHERE id = 1").Scan(&flavor); err != nil {
 		return MySQLDialect

--- a/internal/recovery/recovery_test.go
+++ b/internal/recovery/recovery_test.go
@@ -1024,6 +1024,14 @@ func TestDialectForFlavor(t *testing.T) {
 	}
 }
 
+func TestDialectForIndex_nilDB(t *testing.T) {
+	// A nil db (e.g. agent.IndexDB before it's opened) must not panic — DialectForIndex
+	// returns MySQLDialect, the safe default (#573).
+	if got := DialectForIndex(nil); got != MySQLDialect {
+		t.Errorf("DialectForIndex(nil) = %v, want MySQLDialect", got)
+	}
+}
+
 // TestGeneratePG_ScriptWrapper pins the standard_conforming_strings guard: a PG-dialect
 // script SET LOCALs it (so the escaping is self-defending regardless of the target
 // session), and the MySQL script does NOT emit it.


### PR DESCRIPTION
Closes #573. Follow-up from #572 (the PG-dialect renderer): adopt `recovery.DialectForIndex` on the remaining recover surfaces so a **PostgreSQL index** (a normal MySQL index DB with `flavor='postgres'`) gets PostgreSQL-dialect reversal SQL everywhere, not just `bintrail-pg recover`.

> Not a regression (no PG dialect existed before #570/#572). But the **console is reachable today** — PG customers capture with `bintrail-pg` and view/recover with the shared `bintrail-console`.

## Changes (one line each, using the #572 helper)
- `internal/console/api.go` — `recovery.NewForDialect(b.db, b.resolver, recovery.DialectForIndex(b.db))`. The console is multi-server, so the dialect is selected **per-bundle**: a PG-flavored server yields PG SQL, a MySQL server is unchanged.
- `cmd/bintrail-mcp/main.go`, `internal/agent/handler.go` — the same swap.
- `internal/recovery/recovery.go` — **`DialectForIndex` is now nil-safe** (`nil` db → `MySQLDialect`). `agent.IndexDB` can be nil at the call site, and `DialectForIndex(nil)` would otherwise panic on `QueryRow`.

## Tests
- `recovery.TestDialectForIndex_nilDB` — pins the new nil guard.
- `console.TestIntegrationRecoverPGDialect` — drives `POST /api/recover` against a PG-flavored index (`stream_state.flavor='postgres'`) and asserts double-quoted identifiers + the `standard_conforming_strings` guard + no backticks. The reachable-today surface, proven end-to-end.
- MCP/agent share the identical one-line wiring plus the already-proven `DialectForIndex` (path-tested against a real PG-flavored index in #572).
- MySQL surfaces unchanged — all existing recover tests green (regression).

Verified: full unit suite + console/agent/recovery/MCP/pgstreamrun integration green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)