### PR TITLE
refactor(cascade): extract cascade-recovery SQL emission to internal/cascaderecover (#578)

### DIFF
--- a/internal/cascaderecover/emit.go
+++ b/internal/cascaderecover/emit.go
@@ -1,0 +1,125 @@
+// Package cascaderecover assembles the cascade-recovery SQL script (the
+// documented preamble, the SET FOREIGN_KEY_CHECKS=0/1 wrapper, the CASCADE
+// re-INSERTs, and the idempotent SET NULL restorations) from a synthesized
+// cascade result.
+//
+// It is the binary-neutral home for the emission logic that used to live in the
+// `recover-cascade` CLI command: factoring it out lets the CLI and the console
+// (#577) produce BYTE-IDENTICAL scripts that cannot drift. The package depends
+// on cascade (for the SetNullRestore rows), recovery (the reversal-SQL
+// generator), metadata (the child PK columns), and query (the row type); nothing
+// it depends on imports it back, so it stays a leaf composition layer (no import
+// cycle) and keeps the cascade synthesis engine free of any emission/recovery
+// coupling.
+//
+// It owns no cobra flags and no command globals. Callers keep their own flag
+// parsing and exit-code mapping; the structured coverage (cascade.Result's
+// Incomplete/Complete()) stays with the caller so each surface can present it.
+package cascaderecover
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/dbtrail/dbtrail/internal/cascade"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/query"
+	"github.com/dbtrail/dbtrail/internal/recovery"
+)
+
+// Header carries the values rendered into the SQL preamble. Parents and Children
+// cannot be derived from EmitSQL's flattened rows (it cannot split the
+// parents++victims concat back apart), so the caller supplies them; the SET NULL
+// count is NOT carried here — EmitSQL derives it from len(setNullRows) so a
+// caller can never desync the header count from the statements emitted.
+type Header struct {
+	Schema, Table     string
+	Parents, Children int
+	Caveats           []string
+	BaselineActive    bool
+}
+
+// EmitSQL writes the documented preamble, the FK-checks-off wrapper, the CASCADE
+// reversal statements (DELETE→INSERT via the generator), and the SET NULL FK
+// restorations (idempotent guarded UPDATEs). Returns the total statement count.
+// resolver supplies child PK columns for the SET NULL WHERE clauses; gen must be
+// built from the same (or an equivalent) resolver (recovery.New(db, resolver)).
+func EmitSQL(w io.Writer, gen *recovery.Generator, rows []query.ResultRow, setNullRows []cascade.SetNullRestore, resolver *metadata.Resolver, hdr Header) (int, error) {
+	// Build every SET NULL restoration BEFORE writing a byte (all-or-nothing): a
+	// missing resolver, an unresolvable table, or an absent PK column must abort
+	// the whole emit cleanly — returning mid-script would leave the parent/child
+	// INSERTs written but drop the closing `SET FOREIGN_KEY_CHECKS=1`, handing the
+	// operator a script that re-enables nothing.
+	var setNullStmts []string
+	if len(setNullRows) > 0 {
+		if resolver == nil {
+			return 0, fmt.Errorf("a schema snapshot is required to restore SET NULL foreign keys (run `bintrail snapshot`)")
+		}
+		for _, sr := range setNullRows {
+			tm, terr := resolver.Resolve(sr.Schema, sr.Table)
+			if terr != nil {
+				return 0, fmt.Errorf("resolve %s.%s for SET NULL restore: %w", sr.Schema, sr.Table, terr)
+			}
+			stmt, ferr := recovery.FormatSetNullRestore(sr.Schema, sr.Table, sr.Column, sr.Value, tm.PKColumnMetas(), sr.Row)
+			if ferr != nil {
+				return 0, ferr
+			}
+			setNullStmts = append(setNullStmts, stmt)
+		}
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "-- bintrail recover-cascade: reverse ON DELETE CASCADE / SET NULL side effects on %s.%s\n", hdr.Schema, hdr.Table)
+	fmt.Fprintf(&b, "-- Re-inserts %d deleted parent row(s) and %d cascade-deleted child row(s); restores %d SET NULL'd FK(s)\n", hdr.Parents, hdr.Children, len(setNullRows))
+	b.WriteString("-- that InnoDB removed/nulled below the binlog (MySQL Bug #32506). NEVER auto-applied.\n")
+	b.WriteString("--\n")
+	if hdr.BaselineActive {
+		b.WriteString("-- Phase-2 baseline fallback ACTIVE: children present in a covered baseline are\n")
+		b.WriteString("-- reconstructed even if untouched within the window. Tables NOT covered by a\n")
+		b.WriteString("-- baseline are flagged above. \"Complete\" means everything DETECTABLE was recovered.\n")
+	} else {
+		b.WriteString("-- Phase-1 (binlog-window) recovery: a child untouched within --lookback and not\n")
+		b.WriteString("-- in a baseline is NOT reconstructed — pass --baseline-dir/--baseline-s3 to enable\n")
+		b.WriteString("-- Phase-2 fallback. \"Complete\" means everything DETECTABLE was recovered.\n")
+	}
+	b.WriteString("--\n")
+	b.WriteString("-- If you have already re-created a deleted parent, delete its INSERT below:\n")
+	b.WriteString("-- SET FOREIGN_KEY_CHECKS=0 does NOT suppress PRIMARY KEY violations.\n")
+	if len(hdr.Caveats) > 0 {
+		b.WriteString("--\n-- !!! INCOMPLETE RECOVERY — the result is provably partial:\n")
+		for _, c := range hdr.Caveats {
+			fmt.Fprintf(&b, "--   - %s\n", c)
+		}
+	}
+	b.WriteString("\nSET FOREIGN_KEY_CHECKS=0;\n\n")
+	if _, err := io.WriteString(w, b.String()); err != nil {
+		return 0, err
+	}
+
+	n, err := gen.GenerateSQLFromRows(rows, w)
+	if err != nil {
+		return 0, err
+	}
+
+	// SET NULL restorations: idempotent UPDATEs (… AND fk IS NULL) that only
+	// touch rows still in the post-cascade nulled state, so a re-run or a later
+	// re-point of the child is never clobbered. Pre-built above, so nothing here
+	// can fail after the INSERTs are already on disk.
+	if len(setNullStmts) > 0 {
+		if _, err := io.WriteString(w, "\n-- SET NULL FK restorations (idempotent: only rows whose FK is still NULL):\n"); err != nil {
+			return n, err
+		}
+		for _, stmt := range setNullStmts {
+			if _, werr := io.WriteString(w, stmt+";\n"); werr != nil {
+				return n, werr
+			}
+			n++
+		}
+	}
+
+	if _, err := io.WriteString(w, "\nSET FOREIGN_KEY_CHECKS=1;\n"); err != nil {
+		return n, err
+	}
+	return n, nil
+}

--- a/internal/cascaderecover/emit_test.go
+++ b/internal/cascaderecover/emit_test.go
@@ -1,0 +1,331 @@
+package cascaderecover_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/cascade"
+	"github.com/dbtrail/dbtrail/internal/cascaderecover"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/query"
+	"github.com/dbtrail/dbtrail/internal/recovery"
+)
+
+// emit runs EmitSQL into a buffer with a DB-free generator (recovery.New(nil, …)
+// never touches the DB for an empty row set). Returns the full byte output, the
+// statement count, and any error. With rows==nil, GenerateSQLFromRows emits a
+// single deterministic "-- No events matched…" line (no time.Now() timestamp),
+// so the surrounding preamble + wrapper bytes can be pinned exactly.
+func emit(t *testing.T, hdr cascaderecover.Header, rows []query.ResultRow, setNull []cascade.SetNullRestore, resolver *metadata.Resolver) (string, int, error) {
+	t.Helper()
+	var buf bytes.Buffer
+	n, err := cascaderecover.EmitSQL(&buf, recovery.New(nil, resolver), rows, setNull, resolver, hdr)
+	return buf.String(), n, err
+}
+
+// TestEmitSQL_goldenPhase1 pins the byte-exact Phase-1 (no baseline) script: the
+// full preamble (including the literal em-dash in the Phase-1 line), the
+// FK-checks wrapper, and the empty-result body.
+func TestEmitSQL_goldenPhase1(t *testing.T) {
+	hdr := cascaderecover.Header{
+		Schema: "shop", Table: "orders",
+		Parents: 1, Children: 2,
+		BaselineActive: false,
+	}
+	const want = `-- bintrail recover-cascade: reverse ON DELETE CASCADE / SET NULL side effects on shop.orders
+-- Re-inserts 1 deleted parent row(s) and 2 cascade-deleted child row(s); restores 0 SET NULL'd FK(s)
+-- that InnoDB removed/nulled below the binlog (MySQL Bug #32506). NEVER auto-applied.
+--
+-- Phase-1 (binlog-window) recovery: a child untouched within --lookback and not
+-- in a baseline is NOT reconstructed — pass --baseline-dir/--baseline-s3 to enable
+-- Phase-2 fallback. "Complete" means everything DETECTABLE was recovered.
+--
+-- If you have already re-created a deleted parent, delete its INSERT below:
+-- SET FOREIGN_KEY_CHECKS=0 does NOT suppress PRIMARY KEY violations.
+
+SET FOREIGN_KEY_CHECKS=0;
+
+-- No events matched the specified criteria.
+
+SET FOREIGN_KEY_CHECKS=1;
+`
+	got, n, err := emit(t, hdr, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("EmitSQL: %v", err)
+	}
+	if got != want {
+		t.Errorf("byte-identity drift.\n--- got ---\n%q\n--- want ---\n%q", got, want)
+	}
+	if n != 0 {
+		t.Errorf("statement count = %d, want 0 (no rows, no SET NULL)", n)
+	}
+}
+
+// TestEmitSQL_goldenPhase2Active pins the Phase-2 ("baseline fallback ACTIVE")
+// preamble branch.
+func TestEmitSQL_goldenPhase2Active(t *testing.T) {
+	hdr := cascaderecover.Header{
+		Schema: "shop", Table: "orders",
+		Parents: 3, Children: 5,
+		BaselineActive: true,
+	}
+	const want = `-- bintrail recover-cascade: reverse ON DELETE CASCADE / SET NULL side effects on shop.orders
+-- Re-inserts 3 deleted parent row(s) and 5 cascade-deleted child row(s); restores 0 SET NULL'd FK(s)
+-- that InnoDB removed/nulled below the binlog (MySQL Bug #32506). NEVER auto-applied.
+--
+-- Phase-2 baseline fallback ACTIVE: children present in a covered baseline are
+-- reconstructed even if untouched within the window. Tables NOT covered by a
+-- baseline are flagged above. "Complete" means everything DETECTABLE was recovered.
+--
+-- If you have already re-created a deleted parent, delete its INSERT below:
+-- SET FOREIGN_KEY_CHECKS=0 does NOT suppress PRIMARY KEY violations.
+
+SET FOREIGN_KEY_CHECKS=0;
+
+-- No events matched the specified criteria.
+
+SET FOREIGN_KEY_CHECKS=1;
+`
+	got, _, err := emit(t, hdr, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("EmitSQL: %v", err)
+	}
+	if got != want {
+		t.Errorf("byte-identity drift.\n--- got ---\n%q\n--- want ---\n%q", got, want)
+	}
+}
+
+// TestEmitSQL_goldenCaveats pins the INCOMPLETE-RECOVERY caveats block (one line
+// per caveat, three-space indent, em-dash header).
+func TestEmitSQL_goldenCaveats(t *testing.T) {
+	hdr := cascaderecover.Header{
+		Schema: "shop", Table: "orders",
+		Parents: 1, Children: 0,
+		BaselineActive: false,
+		Caveats: []string{
+			"archived partitions exist; coverage unknown",
+			"per-parent overflow at --limit",
+		},
+	}
+	const want = `-- bintrail recover-cascade: reverse ON DELETE CASCADE / SET NULL side effects on shop.orders
+-- Re-inserts 1 deleted parent row(s) and 0 cascade-deleted child row(s); restores 0 SET NULL'd FK(s)
+-- that InnoDB removed/nulled below the binlog (MySQL Bug #32506). NEVER auto-applied.
+--
+-- Phase-1 (binlog-window) recovery: a child untouched within --lookback and not
+-- in a baseline is NOT reconstructed — pass --baseline-dir/--baseline-s3 to enable
+-- Phase-2 fallback. "Complete" means everything DETECTABLE was recovered.
+--
+-- If you have already re-created a deleted parent, delete its INSERT below:
+-- SET FOREIGN_KEY_CHECKS=0 does NOT suppress PRIMARY KEY violations.
+--
+-- !!! INCOMPLETE RECOVERY — the result is provably partial:
+--   - archived partitions exist; coverage unknown
+--   - per-parent overflow at --limit
+
+SET FOREIGN_KEY_CHECKS=0;
+
+-- No events matched the specified criteria.
+
+SET FOREIGN_KEY_CHECKS=1;
+`
+	got, _, err := emit(t, hdr, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("EmitSQL: %v", err)
+	}
+	if got != want {
+		t.Errorf("byte-identity drift.\n--- got ---\n%q\n--- want ---\n%q", got, want)
+	}
+}
+
+// orderResolver builds a DB-free resolver for shop.orders with PK `id` and a
+// nullable FK `customer_id`, used to exercise the SET NULL restoration path.
+func orderResolver() *metadata.Resolver {
+	tm := &metadata.TableMeta{
+		Schema: "shop", Table: "orders",
+		Columns: []metadata.ColumnMeta{
+			{Name: "id", OrdinalPosition: 1, IsPK: true, DataType: "int"},
+			{Name: "customer_id", OrdinalPosition: 2, DataType: "int"},
+		},
+		PKColumns: []string{"id"},
+	}
+	return metadata.NewResolverFromTables(1, map[string]*metadata.TableMeta{"shop.orders": tm})
+}
+
+// TestEmitSQL_goldenSetNull pins the SET NULL section: its idempotent-restore
+// header, the guarded UPDATE (… AND fk IS NULL, produced by FormatSetNullRestore
+// — the extraction must keep delegating to it), the per-statement semicolon, and
+// the incremented statement count.
+func TestEmitSQL_goldenSetNull(t *testing.T) {
+	hdr := cascaderecover.Header{
+		Schema: "shop", Table: "orders",
+		Parents: 1, Children: 0,
+		BaselineActive: false,
+	}
+	setNull := []cascade.SetNullRestore{{
+		Schema: "shop", Table: "orders", Column: "customer_id",
+		Value:    42,
+		PKValues: "7",
+		Row:      map[string]any{"id": 7, "customer_id": nil},
+	}}
+	// The UPDATE is built by recovery.FormatSetNullRestore; we pin its exact text
+	// here (a double-quoted literal — a backtick raw string cannot contain the
+	// backtick identifier quoting).
+	const update = "UPDATE `shop`.`orders` SET `customer_id` = 42 WHERE `id` = 7 AND `customer_id` IS NULL"
+	want := `-- bintrail recover-cascade: reverse ON DELETE CASCADE / SET NULL side effects on shop.orders
+-- Re-inserts 1 deleted parent row(s) and 0 cascade-deleted child row(s); restores 1 SET NULL'd FK(s)
+-- that InnoDB removed/nulled below the binlog (MySQL Bug #32506). NEVER auto-applied.
+--
+-- Phase-1 (binlog-window) recovery: a child untouched within --lookback and not
+-- in a baseline is NOT reconstructed — pass --baseline-dir/--baseline-s3 to enable
+-- Phase-2 fallback. "Complete" means everything DETECTABLE was recovered.
+--
+-- If you have already re-created a deleted parent, delete its INSERT below:
+-- SET FOREIGN_KEY_CHECKS=0 does NOT suppress PRIMARY KEY violations.
+
+SET FOREIGN_KEY_CHECKS=0;
+
+-- No events matched the specified criteria.
+
+-- SET NULL FK restorations (idempotent: only rows whose FK is still NULL):
+` + update + `;
+
+SET FOREIGN_KEY_CHECKS=1;
+`
+	got, n, err := emit(t, hdr, nil, setNull, orderResolver())
+	if err != nil {
+		t.Fatalf("EmitSQL: %v", err)
+	}
+	if got != want {
+		t.Errorf("byte-identity drift.\n--- got ---\n%q\n--- want ---\n%q", got, want)
+	}
+	if !strings.Contains(got, "AND `customer_id` IS NULL") {
+		t.Errorf("idempotency guard `... AND fk IS NULL` missing from SET NULL restore")
+	}
+	if n != 1 {
+		t.Errorf("statement count = %d, want 1 (0 rows + 1 SET NULL)", n)
+	}
+}
+
+// TestEmitSQL_setNullNilResolverIsAllOrNothing locks the #571-review invariant:
+// when SET NULL rows exist but the pre-validation cannot build their statements
+// (here, a nil resolver), EmitSQL must abort BEFORE writing a single byte — never
+// a half-written script missing its closing SET FOREIGN_KEY_CHECKS=1.
+func TestEmitSQL_setNullNilResolverIsAllOrNothing(t *testing.T) {
+	hdr := cascaderecover.Header{Schema: "shop", Table: "orders"}
+	setNull := []cascade.SetNullRestore{{
+		Schema: "shop", Table: "orders", Column: "customer_id",
+		Value: 42, PKValues: "7", Row: map[string]any{"id": 7},
+	}}
+	var buf bytes.Buffer
+	n, err := cascaderecover.EmitSQL(&buf, recovery.New(nil, nil), nil, setNull, nil, hdr)
+	if err == nil {
+		t.Fatal("expected an error when SET NULL rows exist with a nil resolver")
+	}
+	if buf.Len() != 0 {
+		t.Errorf("all-or-nothing violated: %d bytes written before abort:\n%q", buf.Len(), buf.String())
+	}
+	if n != 0 {
+		t.Errorf("statement count = %d, want 0 on abort", n)
+	}
+}
+
+// TestEmitSQL_setNullUnresolvableTableIsAllOrNothing covers the second abort
+// point: the resolver exists but lacks the table, so Resolve fails. Still
+// all-or-nothing — zero bytes written.
+func TestEmitSQL_setNullUnresolvableTableIsAllOrNothing(t *testing.T) {
+	hdr := cascaderecover.Header{Schema: "shop", Table: "orders"}
+	setNull := []cascade.SetNullRestore{{
+		Schema: "shop", Table: "unknown", Column: "customer_id",
+		Value: 42, PKValues: "7", Row: map[string]any{"id": 7},
+	}}
+	var buf bytes.Buffer
+	n, err := cascaderecover.EmitSQL(&buf, recovery.New(nil, orderResolver()), nil, setNull, orderResolver(), hdr)
+	if err == nil {
+		t.Fatal("expected an error when the SET NULL table is absent from the resolver")
+	}
+	if buf.Len() != 0 {
+		t.Errorf("all-or-nothing violated: %d bytes written before abort:\n%q", buf.Len(), buf.String())
+	}
+	if n != 0 {
+		t.Errorf("statement count = %d, want 0 on abort", n)
+	}
+}
+
+// TestEmitSQL_setNullAbsentPKColumnIsAllOrNothing covers the THIRD abort point
+// the package doc advertises: FormatSetNullRestore fails because the child row is
+// missing a PK column. Still all-or-nothing — the resolver knows the table, but
+// the row can't satisfy the WHERE, so EmitSQL aborts with zero bytes written.
+func TestEmitSQL_setNullAbsentPKColumnIsAllOrNothing(t *testing.T) {
+	hdr := cascaderecover.Header{Schema: "shop", Table: "orders"}
+	setNull := []cascade.SetNullRestore{{
+		Schema: "shop", Table: "orders", Column: "customer_id",
+		Value: 42, PKValues: "7",
+		Row: map[string]any{"customer_id": nil}, // PK column "id" absent
+	}}
+	var buf bytes.Buffer
+	n, err := cascaderecover.EmitSQL(&buf, recovery.New(nil, orderResolver()), nil, setNull, orderResolver(), hdr)
+	if err == nil {
+		t.Fatal("expected an error when the SET NULL row is missing a PK column")
+	}
+	if buf.Len() != 0 {
+		t.Errorf("all-or-nothing violated: %d bytes written before abort:\n%q", buf.Len(), buf.String())
+	}
+	if n != 0 {
+		t.Errorf("statement count = %d, want 0 on abort", n)
+	}
+}
+
+// TestEmitSQL_goldenSetNullMultiRow locks the derived-count refactor for N>1: with
+// two SET NULL rows the preamble must read "restores 2", the section header must
+// be emitted EXACTLY ONCE (not per row), one guarded UPDATE per row appears in
+// order, and the statement count accumulates to 2. This is the case that proves
+// the len(setNullRows)-derived count cannot desync from the statements emitted.
+func TestEmitSQL_goldenSetNullMultiRow(t *testing.T) {
+	hdr := cascaderecover.Header{
+		Schema: "shop", Table: "orders",
+		Parents: 1, Children: 0,
+		BaselineActive: false,
+	}
+	setNull := []cascade.SetNullRestore{
+		{Schema: "shop", Table: "orders", Column: "customer_id", Value: 42, PKValues: "7", Row: map[string]any{"id": 7, "customer_id": nil}},
+		{Schema: "shop", Table: "orders", Column: "customer_id", Value: 99, PKValues: "8", Row: map[string]any{"id": 8, "customer_id": nil}},
+	}
+	const update1 = "UPDATE `shop`.`orders` SET `customer_id` = 42 WHERE `id` = 7 AND `customer_id` IS NULL"
+	const update2 = "UPDATE `shop`.`orders` SET `customer_id` = 99 WHERE `id` = 8 AND `customer_id` IS NULL"
+	want := `-- bintrail recover-cascade: reverse ON DELETE CASCADE / SET NULL side effects on shop.orders
+-- Re-inserts 1 deleted parent row(s) and 0 cascade-deleted child row(s); restores 2 SET NULL'd FK(s)
+-- that InnoDB removed/nulled below the binlog (MySQL Bug #32506). NEVER auto-applied.
+--
+-- Phase-1 (binlog-window) recovery: a child untouched within --lookback and not
+-- in a baseline is NOT reconstructed — pass --baseline-dir/--baseline-s3 to enable
+-- Phase-2 fallback. "Complete" means everything DETECTABLE was recovered.
+--
+-- If you have already re-created a deleted parent, delete its INSERT below:
+-- SET FOREIGN_KEY_CHECKS=0 does NOT suppress PRIMARY KEY violations.
+
+SET FOREIGN_KEY_CHECKS=0;
+
+-- No events matched the specified criteria.
+
+-- SET NULL FK restorations (idempotent: only rows whose FK is still NULL):
+` + update1 + `;
+` + update2 + `;
+
+SET FOREIGN_KEY_CHECKS=1;
+`
+	got, n, err := emit(t, hdr, nil, setNull, orderResolver())
+	if err != nil {
+		t.Fatalf("EmitSQL: %v", err)
+	}
+	if got != want {
+		t.Errorf("byte-identity drift.\n--- got ---\n%q\n--- want ---\n%q", got, want)
+	}
+	// The section header is emitted once regardless of row count.
+	if c := strings.Count(got, "-- SET NULL FK restorations"); c != 1 {
+		t.Errorf("SET NULL section header count = %d, want 1", c)
+	}
+	if n != 2 {
+		t.Errorf("statement count = %d, want 2 (0 rows + 2 SET NULL)", n)
+	}
+}

--- a/internal/cli/recover_cascade.go
+++ b/internal/cli/recover_cascade.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/dbtrail/dbtrail/internal/cascade"
+	"github.com/dbtrail/dbtrail/internal/cascaderecover"
 	"github.com/dbtrail/dbtrail/internal/cliutil"
 	"github.com/dbtrail/dbtrail/internal/config"
 	"github.com/dbtrail/dbtrail/internal/event"
@@ -246,8 +247,8 @@ func runRecoverCascade(cmd *cobra.Command, args []string) error {
 
 	// Resolver enables PK-only WHERE clauses. Best-effort for the CASCADE path
 	// (INSERTs fall back to full row images), but REQUIRED for SET NULL restores
-	// (their WHERE needs the child PK columns) — emitCascadeSQL errors loudly,
-	// before writing anything, if SET NULL rows exist with a nil resolver.
+	// (their WHERE needs the child PK columns) — cascaderecover.EmitSQL errors
+	// loudly, before writing anything, if SET NULL rows exist with a nil resolver.
 	resolver, err := metadata.NewResolver(db, 0)
 	if err != nil {
 		slog.Warn("could not load schema snapshot; recovery INSERTs still use full row images", "error", err)
@@ -347,19 +348,18 @@ func runRecoverCascade(cmd *cobra.Command, args []string) error {
 	rows := append(append([]query.ResultRow{}, parentDeletes...), res.Victims...)
 
 	// ── Emit ──────────────────────────────────────────────────────────────────
-	hdr := cascadeHeader{
-		schema:         rcSchema,
-		table:          rcTable,
-		parents:        len(parentDeletes),
-		children:       len(res.Victims),
-		setnulls:       len(res.SetNullRows),
-		caveats:        caveats,
-		baselineActive: baselineProvider != nil,
+	hdr := cascaderecover.Header{
+		Schema:         rcSchema,
+		Table:          rcTable,
+		Parents:        len(parentDeletes),
+		Children:       len(res.Victims),
+		Caveats:        caveats,
+		BaselineActive: baselineProvider != nil,
 	}
 
 	if rcFormat == "json" {
 		var buf bytes.Buffer
-		n, gerr := emitCascadeSQL(&buf, recovery.New(db, resolver), rows, res.SetNullRows, resolver, hdr)
+		n, gerr := cascaderecover.EmitSQL(&buf, recovery.New(db, resolver), rows, res.SetNullRows, resolver, hdr)
 		if gerr != nil {
 			return gerr
 		}
@@ -416,7 +416,7 @@ func runRecoverCascade(cmd *cobra.Command, args []string) error {
 			return f.Close()
 		}
 	}
-	n, gerr := emitCascadeSQL(w, recovery.New(db, resolver), rows, res.SetNullRows, resolver, hdr)
+	n, gerr := cascaderecover.EmitSQL(w, recovery.New(db, resolver), rows, res.SetNullRows, resolver, hdr)
 	if gerr != nil {
 		if closeFn != nil {
 			_ = closeFn() // best-effort: gerr is the real failure, don't mask it (and don't leak the fd)
@@ -457,96 +457,4 @@ func cascadeExit(dest string, synthErr error, caveats []string, allowIncomplete 
 		return fmt.Errorf("SQL written to %s but the recovery is INCOMPLETE (%d caveat(s) above); review, then re-run with --allow-incomplete to exit 0", dest, len(caveats))
 	}
 	return nil
-}
-
-// cascadeHeader carries the values rendered into the SQL preamble.
-type cascadeHeader struct {
-	schema, table     string
-	parents, children int
-	setnulls          int
-	caveats           []string
-	baselineActive    bool
-}
-
-// emitCascadeSQL writes the documented preamble, the FK-checks-off wrapper, the
-// CASCADE reversal statements (DELETE→INSERT via the generator), and the SET
-// NULL FK restorations (idempotent guarded UPDATEs). Returns the total statement
-// count. resolver supplies child PK columns for the SET NULL WHERE clauses.
-func emitCascadeSQL(w io.Writer, gen *recovery.Generator, rows []query.ResultRow, setNullRows []cascade.SetNullRestore, resolver *metadata.Resolver, hdr cascadeHeader) (int, error) {
-	// Build every SET NULL restoration BEFORE writing a byte (all-or-nothing): a
-	// missing resolver, an unresolvable table, or an absent PK column must abort
-	// the whole emit cleanly — returning mid-script would leave the parent/child
-	// INSERTs written but drop the closing `SET FOREIGN_KEY_CHECKS=1`, handing the
-	// operator a script that re-enables nothing.
-	var setNullStmts []string
-	if len(setNullRows) > 0 {
-		if resolver == nil {
-			return 0, fmt.Errorf("a schema snapshot is required to restore SET NULL foreign keys (run `bintrail snapshot`)")
-		}
-		for _, sr := range setNullRows {
-			tm, terr := resolver.Resolve(sr.Schema, sr.Table)
-			if terr != nil {
-				return 0, fmt.Errorf("resolve %s.%s for SET NULL restore: %w", sr.Schema, sr.Table, terr)
-			}
-			stmt, ferr := recovery.FormatSetNullRestore(sr.Schema, sr.Table, sr.Column, sr.Value, tm.PKColumnMetas(), sr.Row)
-			if ferr != nil {
-				return 0, ferr
-			}
-			setNullStmts = append(setNullStmts, stmt)
-		}
-	}
-
-	var b strings.Builder
-	fmt.Fprintf(&b, "-- bintrail recover-cascade: reverse ON DELETE CASCADE / SET NULL side effects on %s.%s\n", hdr.schema, hdr.table)
-	fmt.Fprintf(&b, "-- Re-inserts %d deleted parent row(s) and %d cascade-deleted child row(s); restores %d SET NULL'd FK(s)\n", hdr.parents, hdr.children, hdr.setnulls)
-	b.WriteString("-- that InnoDB removed/nulled below the binlog (MySQL Bug #32506). NEVER auto-applied.\n")
-	b.WriteString("--\n")
-	if hdr.baselineActive {
-		b.WriteString("-- Phase-2 baseline fallback ACTIVE: children present in a covered baseline are\n")
-		b.WriteString("-- reconstructed even if untouched within the window. Tables NOT covered by a\n")
-		b.WriteString("-- baseline are flagged above. \"Complete\" means everything DETECTABLE was recovered.\n")
-	} else {
-		b.WriteString("-- Phase-1 (binlog-window) recovery: a child untouched within --lookback and not\n")
-		b.WriteString("-- in a baseline is NOT reconstructed — pass --baseline-dir/--baseline-s3 to enable\n")
-		b.WriteString("-- Phase-2 fallback. \"Complete\" means everything DETECTABLE was recovered.\n")
-	}
-	b.WriteString("--\n")
-	b.WriteString("-- If you have already re-created a deleted parent, delete its INSERT below:\n")
-	b.WriteString("-- SET FOREIGN_KEY_CHECKS=0 does NOT suppress PRIMARY KEY violations.\n")
-	if len(hdr.caveats) > 0 {
-		b.WriteString("--\n-- !!! INCOMPLETE RECOVERY — the result is provably partial:\n")
-		for _, c := range hdr.caveats {
-			fmt.Fprintf(&b, "--   - %s\n", c)
-		}
-	}
-	b.WriteString("\nSET FOREIGN_KEY_CHECKS=0;\n\n")
-	if _, err := io.WriteString(w, b.String()); err != nil {
-		return 0, err
-	}
-
-	n, err := gen.GenerateSQLFromRows(rows, w)
-	if err != nil {
-		return 0, err
-	}
-
-	// SET NULL restorations: idempotent UPDATEs (… AND fk IS NULL) that only
-	// touch rows still in the post-cascade nulled state, so a re-run or a later
-	// re-point of the child is never clobbered. Pre-built above, so nothing here
-	// can fail after the INSERTs are already on disk.
-	if len(setNullStmts) > 0 {
-		if _, err := io.WriteString(w, "\n-- SET NULL FK restorations (idempotent: only rows whose FK is still NULL):\n"); err != nil {
-			return n, err
-		}
-		for _, stmt := range setNullStmts {
-			if _, werr := io.WriteString(w, stmt+";\n"); werr != nil {
-				return n, werr
-			}
-			n++
-		}
-	}
-
-	if _, err := io.WriteString(w, "\nSET FOREIGN_KEY_CHECKS=1;\n"); err != nil {
-		return n, err
-	}
-	return n, nil
 }


### PR DESCRIPTION
closes #578

## Summary

Slice A of console cascade (#577) — a precondition: factor the cascade-recovery SQL **emission** out of the CLI command layer so the CLI and the future console caller produce **byte-identical** scripts and can't drift.

- **New `internal/cascaderecover`** (`EmitSQL` + `Header`): binary-neutral, no cobra, no command globals. A leaf composition layer over `cascade`+`recovery`+`metadata`+`query`; **none of its deps import it back**, so the `cascade` synthesis engine stays free of emission/recovery coupling. (Placement is decoupling-driven, not cycle-avoidance — neither candidate package creates a cycle; `go list` confirms `recovery`/`query`/`metadata` never import `cascade`.)
- **`internal/cli/recover_cascade.go`**: `emitCascadeSQL`/`cascadeHeader` deleted; the two call sites (JSON + text) now use `cascaderecover.EmitSQL`/`Header`. Flag parsing and the exit-code mapping (`cascadeExit`) **stay in the CLI** per the issue's split.

## Faithful extraction + one deliberate API tightening

This is **not** a pure byte-for-byte move. It is a faithful relocation **plus** one small, behavior-preserving API change driven by review:

- The relocated emit body is otherwise identical to the original (verified by a normalized source diff before the tightening).
- **Tightening for the second caller (#577):** the SET NULL count in the preamble is now derived from `len(setNullRows)` inside `EmitSQL` rather than carried as a `Header.SetNulls` field. At the CLI call site the two were always equal, so **the generated SQL is unchanged** — but a future caller can no longer desync the header count from the statements actually emitted. (The field is unreleased, so folding this in is safe.)

The **output** byte-identity is what matters and is proven below.

## Invariants preserved (constraint: no behavior change)

- **Byte-identical SQL** — locked by a new DB-free golden test (full-string compare, not `Contains`) across both preamble branches (Phase-1 / Phase-2-active), the caveats block, and the SET NULL section; the existing CLI integration suite pins the same output through the full command.
- **All-or-nothing SET NULL pre-validation** (#571 fix) — every SET NULL statement is built before a single byte is written; a nil resolver / unresolvable table / absent PK column aborts with **zero bytes** written (so a script can never open `FK_CHECKS=0` and never close it). Locked by two negative-path tests asserting `buf.Len()==0`.
- **`… AND fk IS NULL` idempotency guard** — untouched; `EmitSQL` keeps delegating to `recovery.FormatSetNullRestore`.
- **Statement-count contract** (`n`) — unchanged (CASCADE INSERTs + 1 per SET NULL UPDATE), still feeds the JSON `statements` field.

## Forward-compat note for #577 (not in scope here)

The **"complete" determination** (`len(caveats)==0 && synthErr==nil`) and the **caveats assembly** (`res.Incomplete` + the archive/limit/synth-error caveats) still live in the CLI command (`recover_cascade.go`), **not** in the shared package. That's correct for slice A (the issue scopes this to *emission* and keeps `cascade.Result.Incomplete/Complete()` accessible to callers). But if the #577 console re-implements that logic slightly differently, the two surfaces could drift on coverage — the exact failure mode this extraction exists to prevent. A later slice should share that determination consciously. (Filed as a note on #577.)

## Review

Three specialized agents reviewed the diff (code-reviewer, silent-failure-hunter, type-design-analyzer): faithful extraction, all error semantics preserved, all-or-nothing invariant intact. Their comment-accuracy nits (a self-contradictory package-doc line, a stale `emitCascadeSQL` reference) and the `SetNulls` tightening above are applied.

## Test plan

- [x] `go test ./... -count=1` (full unit suite; new golden runs DB-free)
- [x] `go vet ./internal/cli/ ./internal/cascaderecover/`
- [x] `go test -tags integration ./internal/cli/ -run TestRecoverCascade` (full-command SQL pinning, all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)