### PR TITLE
feat(pg): bintrail-pg doctor — replication-slot / WAL-retention health (#532 part 1)

### DIFF
--- a/cmd/bintrail-pg/doctor.go
+++ b/cmd/bintrail-pg/doctor.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dbtrail/dbtrail/internal/cli"
+	"github.com/dbtrail/dbtrail/internal/pgstreamrun"
+)
+
+var doctorCmd = &cobra.Command{
+	Use:   "doctor",
+	Short: "Check a PostgreSQL source's readiness and replication-slot/WAL-retention health",
+	Long: `Runs preflight checks against a live PostgreSQL source and reports each as
+PASS, FAIL, WARN, or SKIP with copy-pasteable remediation.
+
+It checks the capture prerequisites (wal_level=logical, publication coverage,
+REPLICA IDENTITY FULL) AND the operational WAL-retention health that gates
+production safety:
+
+  - max_slot_wal_keep_size: WARNs when unlimited (-1) — a stalled slot could then
+    pin WAL until the source disk fills.
+  - Replication slot health: shows the slot's wal_status and how much WAL it is
+    retaining. A 'lost' (invalidated) slot is a loud FAIL with the re-baseline
+    recovery path — capture cannot resume, though the index is still fully usable
+    for recovery (recovery never needs the slot).
+
+This connects to the live source for health only; recovery itself is index-only
+and never touches the source.
+
+Exit code is 0 only when every required check passes. WARNs (including unlimited
+max_slot_wal_keep_size) do not affect the exit code, so doctor is CI-safe.
+
+Examples:
+
+  bintrail-pg doctor --query-dsn "$PG" --slot bintrail_slot --publication bintrail_pub
+  bintrail-pg doctor --query-dsn "$PG" --slot s --publication p --format json`,
+	RunE: runPGDoctor,
+}
+
+var (
+	pgDoctorQueryDSN    string
+	pgDoctorSlot        string
+	pgDoctorPublication string
+	pgDoctorSchemas     string
+	pgDoctorTables      string
+	pgDoctorFormat      string
+)
+
+func init() {
+	doctorCmd.Flags().StringVar(&pgDoctorQueryDSN, "query-dsn", "", "PostgreSQL ordinary connection string (required; env BINTRAIL_PG_QUERY_DSN)")
+	doctorCmd.Flags().StringVar(&pgDoctorSlot, "slot", "", "Replication slot to inspect (required; env BINTRAIL_PG_SLOT)")
+	doctorCmd.Flags().StringVar(&pgDoctorPublication, "publication", "", "Publication to validate coverage/replica-identity against (required; env BINTRAIL_PG_PUBLICATION)")
+	doctorCmd.Flags().StringVar(&pgDoctorSchemas, "schemas", "", "Restrict the publication-coverage check to these schemas (comma-separated)")
+	doctorCmd.Flags().StringVar(&pgDoctorTables, "tables", "", "Restrict the publication-coverage check to these tables (comma-separated, e.g. public.orders)")
+	doctorCmd.Flags().StringVar(&pgDoctorFormat, "format", "text", "Output format: text or json")
+	// BindCommandEnv loads .bintrail.env so the BINTRAIL_PG_* fallback (applied in
+	// pgDoctorConfigFromFlags) sees its values; the PG-specific flags are not in
+	// cli.EnvBindings, so they cannot use MarkFlagRequired (it ignores env-only).
+	cli.BindCommandEnv(doctorCmd)
+	rootCmd.AddCommand(doctorCmd)
+}
+
+// pgDoctorConfigFromFlags applies the BINTRAIL_PG_* env fallback and validates the
+// required settings — the pure seam (returns an error rather than os.Exit) so the
+// wiring is unit-tested without a live PostgreSQL, mirroring pgStreamConfigFromFlags.
+func pgDoctorConfigFromFlags() (pgstreamrun.PGDoctorConfig, error) {
+	applyEnvFallback(&pgDoctorQueryDSN, "BINTRAIL_PG_QUERY_DSN")
+	applyEnvFallback(&pgDoctorSlot, "BINTRAIL_PG_SLOT")
+	applyEnvFallback(&pgDoctorPublication, "BINTRAIL_PG_PUBLICATION")
+
+	var missing []string
+	if pgDoctorQueryDSN == "" {
+		missing = append(missing, "--query-dsn (or BINTRAIL_PG_QUERY_DSN)")
+	}
+	if pgDoctorSlot == "" {
+		missing = append(missing, "--slot (or BINTRAIL_PG_SLOT)")
+	}
+	if pgDoctorPublication == "" {
+		missing = append(missing, "--publication (or BINTRAIL_PG_PUBLICATION)")
+	}
+	if len(missing) > 0 {
+		return pgstreamrun.PGDoctorConfig{}, fmt.Errorf("missing required PostgreSQL settings: %s", strings.Join(missing, ", "))
+	}
+	if pgDoctorFormat != "text" && pgDoctorFormat != "json" {
+		return pgstreamrun.PGDoctorConfig{}, fmt.Errorf("invalid --format %q; must be text or json", pgDoctorFormat)
+	}
+
+	return pgstreamrun.PGDoctorConfig{
+		QueryDSN:    pgDoctorQueryDSN,
+		SlotName:    pgDoctorSlot,
+		Publication: pgDoctorPublication,
+		Schemas:     pgDoctorSchemas,
+		Tables:      pgDoctorTables,
+	}, nil
+}
+
+// runPGDoctor builds the report against the live source, writes it to stdout, and
+// returns a non-nil error iff a required check failed (so CI exits non-zero). WARNs
+// do not fail the command.
+func runPGDoctor(cmd *cobra.Command, args []string) error {
+	cfg, err := pgDoctorConfigFromFlags()
+	if err != nil {
+		return err
+	}
+	report := pgstreamrun.BuildPGReport(cmd.Context(), cfg)
+	if err := report.Write(os.Stdout, pgDoctorFormat); err != nil {
+		return fmt.Errorf("write report: %w", err)
+	}
+	return report.Err()
+}

--- a/cmd/bintrail-pg/doctor_test.go
+++ b/cmd/bintrail-pg/doctor_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// resetPGDoctorFlags restores the doctor command's package-global flag vars to their
+// declared defaults so each subtest starts clean (pgDoctorConfigFromFlags writes the
+// env fallback back into the globals). These subtests mutate shared globals and must
+// NOT run in parallel.
+func resetPGDoctorFlags() {
+	pgDoctorQueryDSN = ""
+	pgDoctorSlot = ""
+	pgDoctorPublication = ""
+	pgDoctorSchemas = ""
+	pgDoctorTables = ""
+	pgDoctorFormat = "text"
+}
+
+func clearPGDoctorEnv(t *testing.T) {
+	t.Helper()
+	for _, v := range []string{"BINTRAIL_PG_QUERY_DSN", "BINTRAIL_PG_SLOT", "BINTRAIL_PG_PUBLICATION"} {
+		t.Setenv(v, "")
+	}
+}
+
+func TestPGDoctorConfigFromFlags_MissingRequired(t *testing.T) {
+	clearPGDoctorEnv(t)
+	resetPGDoctorFlags()
+
+	_, err := pgDoctorConfigFromFlags()
+	if err == nil {
+		t.Fatal("expected an error when required settings are missing, got nil")
+	}
+	for _, want := range []string{"--query-dsn", "--slot", "--publication"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q should name the missing flag %q", err, want)
+		}
+	}
+}
+
+func TestPGDoctorConfigFromFlags_HappyPath(t *testing.T) {
+	clearPGDoctorEnv(t)
+	resetPGDoctorFlags()
+	pgDoctorQueryDSN = "postgres://u@localhost/db"
+	pgDoctorSlot = "bintrail_slot"
+	pgDoctorPublication = "bintrail_pub"
+	pgDoctorSchemas = "public"
+	pgDoctorTables = "public.orders"
+
+	cfg, err := pgDoctorConfigFromFlags()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.QueryDSN != "postgres://u@localhost/db" || cfg.SlotName != "bintrail_slot" || cfg.Publication != "bintrail_pub" {
+		t.Errorf("passthrough mismatch: %+v", cfg)
+	}
+	if cfg.Schemas != "public" || cfg.Tables != "public.orders" {
+		t.Errorf("filter mismatch: %+v", cfg)
+	}
+}
+
+func TestPGDoctorConfigFromFlags_EnvFallback(t *testing.T) {
+	clearPGDoctorEnv(t)
+	resetPGDoctorFlags()
+	t.Setenv("BINTRAIL_PG_QUERY_DSN", "query-from-env")
+	t.Setenv("BINTRAIL_PG_SLOT", "slot-from-env")
+	t.Setenv("BINTRAIL_PG_PUBLICATION", "pub-from-env")
+
+	cfg, err := pgDoctorConfigFromFlags()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.QueryDSN != "query-from-env" || cfg.SlotName != "slot-from-env" || cfg.Publication != "pub-from-env" {
+		t.Errorf("env fallback not applied: %+v", cfg)
+	}
+}
+
+func TestPGDoctorConfigFromFlags_FlagWinsOverEnv(t *testing.T) {
+	clearPGDoctorEnv(t)
+	resetPGDoctorFlags()
+	pgDoctorQueryDSN = "query-from-flag"
+	pgDoctorSlot = "slot-from-flag"
+	pgDoctorPublication = "pub-from-flag"
+	t.Setenv("BINTRAIL_PG_QUERY_DSN", "query-from-env")
+
+	cfg, err := pgDoctorConfigFromFlags()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.QueryDSN != "query-from-flag" {
+		t.Errorf("QueryDSN = %q, want the CLI flag to win over env", cfg.QueryDSN)
+	}
+}
+
+func TestPGDoctorConfigFromFlags_InvalidFormat(t *testing.T) {
+	clearPGDoctorEnv(t)
+	resetPGDoctorFlags()
+	pgDoctorQueryDSN = "q"
+	pgDoctorSlot = "s"
+	pgDoctorPublication = "p"
+	pgDoctorFormat = "yaml"
+
+	if _, err := pgDoctorConfigFromFlags(); err == nil || !strings.Contains(err.Error(), "format") {
+		t.Fatalf("expected an invalid-format error, got %v", err)
+	}
+}
+
+// TestPGDoctorCmd_defaults pins the registered --format default ("text").
+func TestPGDoctorCmd_defaults(t *testing.T) {
+	f := doctorCmd.Flag("format")
+	if f == nil {
+		t.Fatal("flag --format not registered")
+	}
+	if f.DefValue != "text" {
+		t.Errorf("--format default = %q, want text", f.DefValue)
+	}
+}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -45,7 +45,22 @@ type Report struct {
 	Failed   int           `json:"failed"`
 	Warnings int           `json:"warnings"`
 	Skipped  int           `json:"skipped"`
+
+	// ReadyFooter / FixFooter customize the trailing one-line guidance in the TEXT
+	// output (the all-passed line and the has-failures line respectively). They are
+	// excluded from JSON. Empty values fall back to the default MySQL-oriented
+	// guidance, so existing callers are unaffected; a non-MySQL caller (e.g.
+	// bintrail-pg doctor) sets them to its own command names.
+	ReadyFooter string `json:"-"`
+	FixFooter   string `json:"-"`
 }
+
+// Add appends a check result and updates the counters. It is the exported entry
+// point for callers building a Report outside this package — e.g. the PostgreSQL
+// doctor, which cannot live in this package because internal/doctor must stay free
+// of the pgx/pglogrepl dependency (cmd/bintrail's pgfree ban). MySQL's own Build
+// uses the unexported add.
+func (r *Report) Add(c CheckResult) { r.add(c) }
 
 // binlogRetentionMinSeconds is the minimum binlog retention bintrail asks for
 // (docs/streaming.md:279). Hoisted so the check function and any test referring
@@ -754,10 +769,18 @@ func (r *Report) Write(w io.Writer, format string) error {
 	fmt.Fprintln(w)
 	fmt.Fprintf(w, "Passed: %d  Failed: %d  Warnings: %d  Skipped: %d\n",
 		r.Passed, r.Failed, r.Warnings, r.Skipped)
+	ready := r.ReadyFooter
+	if ready == "" {
+		ready = "Ready to stream. Run `bintrail up --source-dsn ... --index-dsn ...` to start."
+	}
+	fix := r.FixFooter
+	if fix == "" {
+		fix = "Fix the failures above, then re-run `bintrail doctor` to verify."
+	}
 	if r.Failed == 0 {
-		fmt.Fprintln(w, "\nReady to stream. Run `bintrail up --source-dsn ... --index-dsn ...` to start.")
+		fmt.Fprintln(w, "\n"+ready)
 	} else {
-		fmt.Fprintln(w, "\nFix the failures above, then re-run `bintrail doctor` to verify.")
+		fmt.Fprintln(w, "\n"+fix)
 	}
 	return nil
 }

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -60,6 +60,10 @@ type Report struct {
 // doctor, which cannot live in this package because internal/doctor must stay free
 // of the pgx/pglogrepl dependency (cmd/bintrail's pgfree ban). MySQL's own Build
 // uses the unexported add.
+//
+// Add (and the internal add) are the ONLY sanctioned way to grow a Report: appending
+// to the exported Checks slice directly would leave Passed/Failed/Warnings/Skipped
+// stale. Callers must always go through Add.
 func (r *Report) Add(c CheckResult) { r.add(c) }
 
 // binlogRetentionMinSeconds is the minimum binlog retention bintrail asks for

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -560,6 +560,53 @@ func TestDoctorReportWriteText(t *testing.T) {
 	}
 }
 
+// TestDoctorReportFooter pins the parameterized text footer (#532): a non-MySQL
+// caller (e.g. bintrail-pg doctor) can override the trailing guidance, and an empty
+// footer falls back to the default MySQL-oriented text — so existing callers (and the
+// JSON output) are unaffected.
+func TestDoctorReportFooter(t *testing.T) {
+	render := func(r *Report) string {
+		var buf bytes.Buffer
+		if err := r.Write(&buf, "text"); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+		return buf.String()
+	}
+
+	// Custom footers: all-passed → ReadyFooter; has-failure → FixFooter.
+	passed := &Report{ReadyFooter: "CUSTOM READY", FixFooter: "CUSTOM FIX"}
+	passed.Add(CheckResult{Name: "p", Status: StatusPass})
+	if out := render(passed); !strings.Contains(out, "CUSTOM READY") || strings.Contains(out, "Ready to stream") {
+		t.Errorf("all-passed should render the custom ReadyFooter, not the default:\n%s", out)
+	}
+	failed := &Report{ReadyFooter: "CUSTOM READY", FixFooter: "CUSTOM FIX"}
+	failed.Add(CheckResult{Name: "f", Status: StatusFail})
+	if out := render(failed); !strings.Contains(out, "CUSTOM FIX") {
+		t.Errorf("has-failure should render the custom FixFooter:\n%s", out)
+	}
+
+	// Empty footers → the default MySQL guidance (back-compat for existing callers).
+	def := &Report{}
+	def.Add(CheckResult{Name: "p", Status: StatusPass})
+	if out := render(def); !strings.Contains(out, "Ready to stream. Run `bintrail up") {
+		t.Errorf("empty ReadyFooter should fall back to the MySQL default:\n%s", out)
+	}
+	defFail := &Report{}
+	defFail.Add(CheckResult{Name: "f", Status: StatusFail})
+	if out := render(defFail); !strings.Contains(out, "re-run `bintrail doctor`") {
+		t.Errorf("empty FixFooter should fall back to the MySQL default:\n%s", out)
+	}
+
+	// The footer fields must not leak into JSON.
+	var jbuf bytes.Buffer
+	if err := passed.Write(&jbuf, "json"); err != nil {
+		t.Fatalf("Write(json): %v", err)
+	}
+	if strings.Contains(jbuf.String(), "CUSTOM") {
+		t.Errorf("footer fields leaked into JSON:\n%s", jbuf.String())
+	}
+}
+
 // TestCheckSchemaVisibility_emptyVsInvisible pins the #402 discrimination:
 // zero tables because the schema is EMPTY routes the operator to "create a
 // table", zero tables because the schema is INVISIBLE routes to grants — the

--- a/internal/pgcapture/health.go
+++ b/internal/pgcapture/health.go
@@ -10,10 +10,21 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
+// PostgreSQL pg_replication_slots.wal_status values. They are named constants so the
+// safety-critical comparisons — the capture-time fail-loud in ensureSlot and the
+// doctor's FAIL/WARN mapping — do not hinge on bare string literals, where a typo
+// would silently disable the data-loss guard.
+const (
+	WalStatusReserved   = "reserved"   // within max_wal_size
+	WalStatusExtended   = "extended"   // beyond max_wal_size, still retained (by the slot or wal_keep_size)
+	WalStatusUnreserved = "unreserved" // past max_slot_wal_keep_size; the next checkpoint may invalidate the slot
+	WalStatusLost       = "lost"       // invalidated — the WAL it needed has been removed
+)
+
 // SlotHealth is the live WAL-retention state of a replication slot, read from
 // pg_replication_slots on a plain query connection. It is the foundation for #532
-// WAL-retention monitoring: ensureSlot uses it at capture startup, and bintrail-pg
-// doctor reports it on demand.
+// WAL-retention monitoring: bintrail-pg doctor reports it on demand. (Capture startup
+// uses the lighter, primary-agnostic querySlotState instead — see ensureSlot.)
 //
 // Health-only: callers REPORT a SlotHealth, they do not fail-loud on it. Failing
 // loud on an invalidated slot is ensureSlot's job (at capture time, where skipping
@@ -25,10 +36,11 @@ type SlotHealth struct {
 	Exists bool
 	// Active is true when a consumer (a walsender) currently holds the slot.
 	Active bool
-	// WalStatus is the slot's WAL-retention state: reserved (within max_wal_size),
-	// extended (beyond max_wal_size but within max_slot_wal_keep_size), unreserved
-	// (at risk — the next checkpoint may invalidate it), or lost (invalidated, its
-	// WAL removed). Empty when the slot is absent.
+	// WalStatus is the slot's WAL-retention state — one of the WalStatus* constants:
+	// reserved (within max_wal_size), extended (beyond max_wal_size, still retained by
+	// the slot or wal_keep_size), unreserved (past max_slot_wal_keep_size; the next
+	// checkpoint may invalidate it), or lost (invalidated, its WAL removed). Empty when
+	// the slot is absent.
 	WalStatus string
 	// RestartLSN is the oldest WAL the slot still needs; the WAL the slot pins runs
 	// from here to the server head. 0 when NULL (a just-created slot) or absent.
@@ -44,7 +56,8 @@ type SlotHealth struct {
 	// SafeWalSize is how much more WAL can be written before this slot risks
 	// invalidation (pg_replication_slots.safe_wal_size). Invalid (NULL) when
 	// max_slot_wal_keep_size = -1 (unlimited retention — the production red line the
-	// doctor warns about), because there is then no bound to be safely under.
+	// doctor warns about), because there is then no bound to be safely under; PostgreSQL
+	// also returns NULL once a slot is already lost.
 	SafeWalSize sql.NullInt64
 }
 
@@ -128,4 +141,23 @@ func QuerySlotHealth(ctx context.Context, conn *pgx.Conn, slotName string) (Slot
 		return SlotHealth{}, fmt.Errorf("pgcapture: querying slot health for %q: %w", slotName, err)
 	}
 	return r.toHealth()
+}
+
+// querySlotState reads only a slot's existence and wal_status — a primary-agnostic
+// catalog read. It is deliberately lighter than QuerySlotHealth, which adds the
+// primary-only pg_current_wal_lsn()/pg_wal_lsn_diff retention metrics (those error on
+// a standby, "recovery is in progress"). ensureSlot uses this at capture STARTUP so
+// capture is not gratuitously broken on a standby source; the richer QuerySlotHealth
+// is for the doctor health surface (documented primary). Returns exists=false with a
+// nil error when the slot is absent.
+func querySlotState(ctx context.Context, conn *pgx.Conn, slotName string) (exists bool, walStatus string, err error) {
+	var ws sql.NullString
+	err = conn.QueryRow(ctx, `SELECT wal_status FROM pg_replication_slots WHERE slot_name = $1`, slotName).Scan(&ws)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return false, "", nil
+	}
+	if err != nil {
+		return false, "", fmt.Errorf("pgcapture: checking replication slot %q: %w", slotName, err)
+	}
+	return true, ws.String, nil
 }

--- a/internal/pgcapture/health.go
+++ b/internal/pgcapture/health.go
@@ -1,0 +1,131 @@
+package pgcapture
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pglogrepl"
+	"github.com/jackc/pgx/v5"
+)
+
+// SlotHealth is the live WAL-retention state of a replication slot, read from
+// pg_replication_slots on a plain query connection. It is the foundation for #532
+// WAL-retention monitoring: ensureSlot uses it at capture startup, and bintrail-pg
+// doctor reports it on demand.
+//
+// Health-only: callers REPORT a SlotHealth, they do not fail-loud on it. Failing
+// loud on an invalidated slot is ensureSlot's job (at capture time, where skipping
+// WAL would silently lose data); a health/doctor surface must keep working precisely
+// so it can SHOW the bad state.
+type SlotHealth struct {
+	// Exists is false when no slot of that name is present (first run, or torn
+	// down). All other fields are zero in that case.
+	Exists bool
+	// Active is true when a consumer (a walsender) currently holds the slot.
+	Active bool
+	// WalStatus is the slot's WAL-retention state: reserved (within max_wal_size),
+	// extended (beyond max_wal_size but within max_slot_wal_keep_size), unreserved
+	// (at risk — the next checkpoint may invalidate it), or lost (invalidated, its
+	// WAL removed). Empty when the slot is absent.
+	WalStatus string
+	// RestartLSN is the oldest WAL the slot still needs; the WAL the slot pins runs
+	// from here to the server head. 0 when NULL (a just-created slot) or absent.
+	RestartLSN pglogrepl.LSN
+	// ConfirmedFlushLSN is how far the consumer has durably acked. 0 when NULL/absent.
+	ConfirmedFlushLSN pglogrepl.LSN
+	// CurrentWalLSN is the server's current WAL write head (pg_current_wal_lsn()).
+	CurrentWalLSN pglogrepl.LSN
+	// RetainedBytes is the WAL the slot pins on the source disk
+	// (pg_current_wal_lsn() - restart_lsn). This is the continuous early-warning
+	// signal — it rises before wal_status flips to lost. 0 when restart_lsn is NULL.
+	RetainedBytes int64
+	// SafeWalSize is how much more WAL can be written before this slot risks
+	// invalidation (pg_replication_slots.safe_wal_size). Invalid (NULL) when
+	// max_slot_wal_keep_size = -1 (unlimited retention — the production red line the
+	// doctor warns about), because there is then no bound to be safely under.
+	SafeWalSize sql.NullInt64
+}
+
+// slotHealthQuery reads one slot's retention state. LSN columns are cast to ::text so
+// they scan into a plain string regardless of the pg_lsn codec; restart_lsn /
+// confirmed_flush_lsn / safe_wal_size can be NULL (just-created slot, or unlimited
+// retention). retained_bytes is derived in SQL via pg_wal_lsn_diff. pg_current_wal_lsn()
+// assumes a primary (the source we capture from); on a standby it would error, which a
+// health surface reports rather than hides. The columns exist on every supported
+// version (PG14+).
+const slotHealthQuery = `SELECT
+	s.active,
+	s.wal_status,
+	s.restart_lsn::text,
+	s.confirmed_flush_lsn::text,
+	pg_current_wal_lsn()::text,
+	pg_wal_lsn_diff(pg_current_wal_lsn(), s.restart_lsn)::bigint,
+	s.safe_wal_size
+FROM pg_replication_slots s
+WHERE s.slot_name = $1`
+
+// slotHealthRow is the raw catalog row, scanned with NULL-tolerant types before being
+// folded into a SlotHealth by toHealth (a pure step, unit-tested without a live PG).
+type slotHealthRow struct {
+	active            bool
+	walStatus         sql.NullString
+	restartLSN        sql.NullString
+	confirmedFlushLSN sql.NullString
+	currentWalLSN     sql.NullString
+	retainedBytes     sql.NullInt64
+	safeWalSize       sql.NullInt64
+}
+
+// toHealth converts a scanned row into a SlotHealth (Exists is always true here — the
+// absent case is handled by QuerySlotHealth before this is called). It parses the
+// text-form LSNs, treating NULL/empty as 0.
+func (r slotHealthRow) toHealth() (SlotHealth, error) {
+	h := SlotHealth{
+		Exists:        true,
+		Active:        r.active,
+		WalStatus:     r.walStatus.String,
+		RetainedBytes: r.retainedBytes.Int64, // .Int64 is 0 when NULL
+		SafeWalSize:   r.safeWalSize,
+	}
+	var err error
+	if h.RestartLSN, err = parseNullLSN(r.restartLSN); err != nil {
+		return SlotHealth{}, fmt.Errorf("restart_lsn: %w", err)
+	}
+	if h.ConfirmedFlushLSN, err = parseNullLSN(r.confirmedFlushLSN); err != nil {
+		return SlotHealth{}, fmt.Errorf("confirmed_flush_lsn: %w", err)
+	}
+	if h.CurrentWalLSN, err = parseNullLSN(r.currentWalLSN); err != nil {
+		return SlotHealth{}, fmt.Errorf("current_wal_lsn: %w", err)
+	}
+	return h, nil
+}
+
+// parseNullLSN parses a text-form LSN ("X/Y"), returning 0 for NULL/empty.
+func parseNullLSN(s sql.NullString) (pglogrepl.LSN, error) {
+	if !s.Valid || s.String == "" {
+		return 0, nil
+	}
+	return pglogrepl.ParseLSN(s.String)
+}
+
+// QuerySlotHealth reads the live WAL-retention state of slotName on a plain query
+// connection (never the replication conn, which is a walsender and cannot run SQL).
+// It returns SlotHealth{Exists: false} with a nil error when the slot is absent — an
+// expected state (first run, torn down), not an error — so callers can distinguish
+// "no slot" from "query failed".
+func QuerySlotHealth(ctx context.Context, conn *pgx.Conn, slotName string) (SlotHealth, error) {
+	var r slotHealthRow
+	err := conn.QueryRow(ctx, slotHealthQuery, slotName).Scan(
+		&r.active, &r.walStatus, &r.restartLSN, &r.confirmedFlushLSN,
+		&r.currentWalLSN, &r.retainedBytes, &r.safeWalSize,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return SlotHealth{Exists: false}, nil
+	}
+	if err != nil {
+		return SlotHealth{}, fmt.Errorf("pgcapture: querying slot health for %q: %w", slotName, err)
+	}
+	return r.toHealth()
+}

--- a/internal/pgcapture/health_integration_test.go
+++ b/internal/pgcapture/health_integration_test.go
@@ -1,0 +1,90 @@
+//go:build integration
+
+package pgcapture_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/dbtrail/dbtrail/internal/pgcapture"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestQuerySlotHealth_Integration drives QuerySlotHealth against a live PostgreSQL:
+// an absent slot reports Exists=false (no error), a present logical slot reports its
+// real retention state, and a dropped slot reverts to Exists=false. This is the
+// foundation query for #532 WAL-retention monitoring (doctor + ensureSlot).
+//
+// Requires BINTRAIL_TEST_PG_DSN (e.g. postgres://postgres:testpg@localhost:15533/pgtest);
+// the MySQL CI jobs leave it unset and skip cleanly (Postgres CI is #534).
+func TestQuerySlotHealth_Integration(t *testing.T) {
+	dsn := testutil.SkipIfNoPostgres(t)
+	ctx := context.Background()
+
+	const slot = "bintrail_health_it"
+
+	conn, err := pgx.Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { conn.Close(context.Background()) })
+
+	dropSlot := func() {
+		_, _ = conn.Exec(context.Background(),
+			"SELECT pg_drop_replication_slot($1) WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name=$1)", slot)
+	}
+	dropSlot()
+	t.Cleanup(dropSlot)
+
+	// Absent slot: Exists=false, nil error (an expected state, not a failure).
+	h, err := pgcapture.QuerySlotHealth(ctx, conn, slot)
+	if err != nil {
+		t.Fatalf("QuerySlotHealth(absent): %v", err)
+	}
+	if h.Exists {
+		t.Fatalf("absent slot reported Exists=true: %+v", h)
+	}
+
+	// Create a logical slot, write a little WAL, then read its health.
+	if _, err := conn.Exec(ctx, "SELECT pg_create_logical_replication_slot($1, 'pgoutput')", slot); err != nil {
+		t.Fatalf("create slot: %v", err)
+	}
+	if _, err := conn.Exec(ctx, "SELECT pg_switch_wal()"); err != nil {
+		t.Fatalf("switch wal: %v", err)
+	}
+
+	h, err = pgcapture.QuerySlotHealth(ctx, conn, slot)
+	if err != nil {
+		t.Fatalf("QuerySlotHealth(present): %v", err)
+	}
+	if !h.Exists {
+		t.Fatal("present slot reported Exists=false")
+	}
+	if h.WalStatus != "reserved" {
+		// A brand-new slot under the default (unlimited) retention is always reserved.
+		t.Errorf("WalStatus = %q, want reserved", h.WalStatus)
+	}
+	if h.Active {
+		t.Error("slot reported Active=true with no consumer holding it")
+	}
+	if h.CurrentWalLSN == 0 {
+		t.Error("CurrentWalLSN is 0; expected the live server WAL head")
+	}
+	if h.RetainedBytes < 0 {
+		t.Errorf("RetainedBytes = %d, want >= 0", h.RetainedBytes)
+	}
+	// safe_wal_size is NULL on the dev/CI container (max_slot_wal_keep_size=-1); just
+	// assert QuerySlotHealth handled the NULL without erroring (it returned above).
+
+	// Drop the slot: back to Exists=false.
+	dropSlot()
+	h, err = pgcapture.QuerySlotHealth(ctx, conn, slot)
+	if err != nil {
+		t.Fatalf("QuerySlotHealth(after drop): %v", err)
+	}
+	if h.Exists {
+		t.Errorf("dropped slot reported Exists=true: %+v", h)
+	}
+}

--- a/internal/pgcapture/health_test.go
+++ b/internal/pgcapture/health_test.go
@@ -71,25 +71,26 @@ func TestSlotHealthRow_toHealth(t *testing.T) {
 		}
 	})
 
-	// A lost slot: wal_status=lost, safe_wal_size present (0), restart_lsn may still be set.
-	t.Run("lost-with-bounded-retention", func(t *testing.T) {
+	// A lost slot: wal_status=lost; PostgreSQL returns safe_wal_size NULL for a lost
+	// slot (as it does under unlimited retention), not 0.
+	t.Run("lost-safe-wal-null", func(t *testing.T) {
 		r := slotHealthRow{
 			active:        false,
-			walStatus:     nullStr("lost"),
+			walStatus:     nullStr(WalStatusLost),
 			restartLSN:    nullStr("0/1000000"),
 			currentWalLSN: nullStr("0/9000000"),
 			retainedBytes: nullInt(0),
-			safeWalSize:   nullInt(0),
+			safeWalSize:   sql.NullInt64{}, // NULL for a lost slot
 		}
 		h, err := r.toHealth()
 		if err != nil {
 			t.Fatalf("toHealth: %v", err)
 		}
-		if h.WalStatus != "lost" {
-			t.Errorf("WalStatus = %q, want lost", h.WalStatus)
+		if h.WalStatus != WalStatusLost {
+			t.Errorf("WalStatus = %q, want %q", h.WalStatus, WalStatusLost)
 		}
-		if !h.SafeWalSize.Valid || h.SafeWalSize.Int64 != 0 {
-			t.Errorf("SafeWalSize = %v, want valid 0", h.SafeWalSize)
+		if h.SafeWalSize.Valid {
+			t.Errorf("SafeWalSize = %v, want NULL (invalid) for a lost slot", h.SafeWalSize)
 		}
 	})
 

--- a/internal/pgcapture/health_test.go
+++ b/internal/pgcapture/health_test.go
@@ -1,0 +1,120 @@
+package pgcapture
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/jackc/pglogrepl"
+)
+
+func nullStr(s string) sql.NullString { return sql.NullString{String: s, Valid: true} }
+func nullInt(i int64) sql.NullInt64   { return sql.NullInt64{Int64: i, Valid: true} }
+
+func TestParseNullLSN(t *testing.T) {
+	want, err := pglogrepl.ParseLSN("16/B374D848")
+	if err != nil {
+		t.Fatalf("setup ParseLSN: %v", err)
+	}
+	tests := []struct {
+		name    string
+		in      sql.NullString
+		want    pglogrepl.LSN
+		wantErr bool
+	}{
+		{"valid", nullStr("16/B374D848"), want, false},
+		{"null", sql.NullString{}, 0, false},
+		{"empty-but-valid", nullStr(""), 0, false},
+		{"garbage", nullStr("not-an-lsn"), 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseNullLSN(tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseNullLSN(%v) err=%v, wantErr=%v", tt.in, err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("parseNullLSN(%v) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSlotHealthRow_toHealth(t *testing.T) {
+	// A healthy slot under unlimited retention (max_slot_wal_keep_size=-1): all LSNs
+	// present, safe_wal_size NULL.
+	t.Run("healthy-unlimited-retention", func(t *testing.T) {
+		r := slotHealthRow{
+			active:            true,
+			walStatus:         nullStr("reserved"),
+			restartLSN:        nullStr("0/1000000"),
+			confirmedFlushLSN: nullStr("0/1000060"),
+			currentWalLSN:     nullStr("0/2000000"),
+			retainedBytes:     nullInt(16777216),
+			safeWalSize:       sql.NullInt64{}, // NULL when retention is unlimited
+		}
+		h, err := r.toHealth()
+		if err != nil {
+			t.Fatalf("toHealth: %v", err)
+		}
+		if !h.Exists || !h.Active || h.WalStatus != "reserved" {
+			t.Errorf("basic fields wrong: %+v", h)
+		}
+		if h.RetainedBytes != 16777216 {
+			t.Errorf("RetainedBytes = %d, want 16777216", h.RetainedBytes)
+		}
+		if h.SafeWalSize.Valid {
+			t.Errorf("SafeWalSize should be NULL (invalid) under unlimited retention, got %v", h.SafeWalSize)
+		}
+		want, _ := pglogrepl.ParseLSN("0/2000000")
+		if h.CurrentWalLSN != want {
+			t.Errorf("CurrentWalLSN = %v, want %v", h.CurrentWalLSN, want)
+		}
+	})
+
+	// A lost slot: wal_status=lost, safe_wal_size present (0), restart_lsn may still be set.
+	t.Run("lost-with-bounded-retention", func(t *testing.T) {
+		r := slotHealthRow{
+			active:        false,
+			walStatus:     nullStr("lost"),
+			restartLSN:    nullStr("0/1000000"),
+			currentWalLSN: nullStr("0/9000000"),
+			retainedBytes: nullInt(0),
+			safeWalSize:   nullInt(0),
+		}
+		h, err := r.toHealth()
+		if err != nil {
+			t.Fatalf("toHealth: %v", err)
+		}
+		if h.WalStatus != "lost" {
+			t.Errorf("WalStatus = %q, want lost", h.WalStatus)
+		}
+		if !h.SafeWalSize.Valid || h.SafeWalSize.Int64 != 0 {
+			t.Errorf("SafeWalSize = %v, want valid 0", h.SafeWalSize)
+		}
+	})
+
+	// A just-created slot can have NULL restart_lsn → RetainedBytes 0, RestartLSN 0.
+	t.Run("null-lsns", func(t *testing.T) {
+		r := slotHealthRow{
+			active:        false,
+			walStatus:     nullStr("reserved"),
+			restartLSN:    sql.NullString{},
+			currentWalLSN: nullStr("0/3000000"),
+			retainedBytes: sql.NullInt64{}, // NULL when restart_lsn is NULL
+		}
+		h, err := r.toHealth()
+		if err != nil {
+			t.Fatalf("toHealth: %v", err)
+		}
+		if h.RestartLSN != 0 || h.RetainedBytes != 0 {
+			t.Errorf("NULL restart_lsn should give 0/0, got RestartLSN=%v RetainedBytes=%d", h.RestartLSN, h.RetainedBytes)
+		}
+	})
+
+	t.Run("bad-lsn-errors", func(t *testing.T) {
+		r := slotHealthRow{walStatus: nullStr("reserved"), restartLSN: nullStr("bogus")}
+		if _, err := r.toHealth(); err == nil {
+			t.Fatal("expected an error for a malformed LSN")
+		}
+	})
+}

--- a/internal/pgcapture/slot.go
+++ b/internal/pgcapture/slot.go
@@ -2,7 +2,6 @@ package pgcapture
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
 	"sort"
@@ -86,6 +85,15 @@ func validatePublication(ctx context.Context, conn *pgx.Conn, pubname string, fi
 // FOR ALL TABLES publication mid-stream — which this one-shot check never re-runs for
 // — is caught at the live boundary too.
 func validateReplicaIdentity(ctx context.Context, conn *pgx.Conn, publication string) error {
+	if err := checkWALLevel(ctx, conn); err != nil {
+		return err
+	}
+	return checkReplicaIdentityTables(ctx, conn, publication)
+}
+
+// checkWALLevel verifies the (global) wal_level is 'logical' — logical replication
+// is impossible otherwise.
+func checkWALLevel(ctx context.Context, conn *pgx.Conn) error {
 	var walLevel string
 	if err := conn.QueryRow(ctx, "SELECT current_setting('wal_level')").Scan(&walLevel); err != nil {
 		return fmt.Errorf("pgcapture: checking wal_level: %w", err)
@@ -93,7 +101,12 @@ func validateReplicaIdentity(ctx context.Context, conn *pgx.Conn, publication st
 	if walLevel != "logical" {
 		return fmt.Errorf("pgcapture: wal_level is %q, must be 'logical' for logical replication", walLevel)
 	}
+	return nil
+}
 
+// checkReplicaIdentityTables verifies every table the publication streams is at
+// REPLICA IDENTITY FULL (the per-table loop; wal_level is checked separately).
+func checkReplicaIdentityTables(ctx context.Context, conn *pgx.Conn, publication string) error {
 	rows, err := conn.Query(ctx, `
 		SELECT pt.schemaname, pt.tablename, c.relreplident::text
 		FROM pg_publication_tables pt
@@ -126,6 +139,29 @@ func validateReplicaIdentity(ctx context.Context, conn *pgx.Conn, publication st
 	return nil
 }
 
+// The exported Check* functions are the report-only form of the capture-time
+// validate* guards above, for bintrail-pg doctor. They are pure probes (no CREATE,
+// no mutation) returning nil when healthy and a descriptive error otherwise; the
+// doctor converts that error into a CheckResult. They live here so the single
+// catalog-query source of truth (and its error wording) is shared with capture.
+
+// CheckWALLevel verifies wal_level = 'logical' on the source.
+func CheckWALLevel(ctx context.Context, conn *pgx.Conn) error {
+	return checkWALLevel(ctx, conn)
+}
+
+// CheckPublication verifies the publication exists and covers the requested tables.
+func CheckPublication(ctx context.Context, conn *pgx.Conn, publication string, filters event.Filters) error {
+	return validatePublication(ctx, conn, publication, filters)
+}
+
+// CheckReplicaIdentity verifies every table the publication streams is at REPLICA
+// IDENTITY FULL. It does NOT re-check wal_level (use CheckWALLevel for that), so the
+// doctor can report the two distinctly.
+func CheckReplicaIdentity(ctx context.Context, conn *pgx.Conn, publication string) error {
+	return checkReplicaIdentityTables(ctx, conn, publication)
+}
+
 // ensureSlot returns the LSN to start replication from, creating the slot on first
 // run. The first-run-vs-resume decision is gated on slot EXISTENCE in
 // pg_replication_slots (NOT on savedLSN==0 — an empty saved checkpoint decodes to
@@ -151,18 +187,14 @@ func validateReplicaIdentity(ctx context.Context, conn *pgx.Conn, publication st
 // ensureSlot fails loud in that case rather than skip; the recovery policy
 // (re-baseline) is #532.
 func ensureSlot(ctx context.Context, replConn *pgconn.PgConn, queryConn *pgx.Conn, slotName string, savedLSN pglogrepl.LSN, expectExisting bool) (pglogrepl.LSN, error) {
-	var walStatus sql.NullString
-	found := true
-	err := queryConn.QueryRow(ctx, `SELECT wal_status FROM pg_replication_slots WHERE slot_name = $1`, slotName).Scan(&walStatus)
-	switch {
-	case errors.Is(err, pgx.ErrNoRows):
-		found = false
-	case err != nil:
-		return 0, fmt.Errorf("pgcapture: checking replication slot %q: %w", slotName, err)
+	health, err := QuerySlotHealth(ctx, queryConn, slotName)
+	if err != nil {
+		return 0, err
 	}
+	found := health.Exists
 
 	// A 'lost' slot is unusable regardless of mode — its WAL has been removed.
-	if found && walStatus.String == "lost" {
+	if found && health.WalStatus == "lost" {
 		return 0, fmt.Errorf("pgcapture: replication slot %q is invalidated (wal_status=lost; max_slot_wal_keep_size exceeded) — the WAL it needs is gone; re-baseline rather than resume", slotName)
 	}
 

--- a/internal/pgcapture/slot.go
+++ b/internal/pgcapture/slot.go
@@ -91,15 +91,22 @@ func validateReplicaIdentity(ctx context.Context, conn *pgx.Conn, publication st
 	return checkReplicaIdentityTables(ctx, conn, publication)
 }
 
+// ErrWALLevelNotLogical marks the "wal_level is readable but not 'logical'" case (a
+// genuine misconfiguration) so a caller — the doctor — can distinguish it from a
+// query failure (connection/permission/timeout) and give the right remediation
+// (restart-with-config vs retry) without mislabeling a transient blip as a config bug.
+var ErrWALLevelNotLogical = errors.New("wal_level is not 'logical'")
+
 // checkWALLevel verifies the (global) wal_level is 'logical' — logical replication
-// is impossible otherwise.
+// is impossible otherwise. A value-wrong result wraps ErrWALLevelNotLogical; a query
+// failure does not.
 func checkWALLevel(ctx context.Context, conn *pgx.Conn) error {
 	var walLevel string
 	if err := conn.QueryRow(ctx, "SELECT current_setting('wal_level')").Scan(&walLevel); err != nil {
 		return fmt.Errorf("pgcapture: checking wal_level: %w", err)
 	}
 	if walLevel != "logical" {
-		return fmt.Errorf("pgcapture: wal_level is %q, must be 'logical' for logical replication", walLevel)
+		return fmt.Errorf("pgcapture: wal_level is %q, must be 'logical' for logical replication: %w", walLevel, ErrWALLevelNotLogical)
 	}
 	return nil
 }
@@ -187,14 +194,13 @@ func CheckReplicaIdentity(ctx context.Context, conn *pgx.Conn, publication strin
 // ensureSlot fails loud in that case rather than skip; the recovery policy
 // (re-baseline) is #532.
 func ensureSlot(ctx context.Context, replConn *pgconn.PgConn, queryConn *pgx.Conn, slotName string, savedLSN pglogrepl.LSN, expectExisting bool) (pglogrepl.LSN, error) {
-	health, err := QuerySlotHealth(ctx, queryConn, slotName)
+	found, walStatus, err := querySlotState(ctx, queryConn, slotName)
 	if err != nil {
 		return 0, err
 	}
-	found := health.Exists
 
 	// A 'lost' slot is unusable regardless of mode — its WAL has been removed.
-	if found && health.WalStatus == "lost" {
+	if found && walStatus == WalStatusLost {
 		return 0, fmt.Errorf("pgcapture: replication slot %q is invalidated (wal_status=lost; max_slot_wal_keep_size exceeded) — the WAL it needs is gone; re-baseline rather than resume", slotName)
 	}
 

--- a/internal/pgstreamrun/pgdoctor.go
+++ b/internal/pgstreamrun/pgdoctor.go
@@ -1,0 +1,200 @@
+package pgstreamrun
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/dbtrail/dbtrail/internal/cliutil"
+	"github.com/dbtrail/dbtrail/internal/doctor"
+	"github.com/dbtrail/dbtrail/internal/pgcapture"
+)
+
+// PGDoctorConfig is the subset of stream settings a health check needs: a normal
+// (non-replication) connection to the source, the slot to inspect, and the
+// publication + filters to validate coverage/replica-identity against.
+type PGDoctorConfig struct {
+	QueryDSN    string
+	SlotName    string
+	Publication string
+	Schemas     string // comma-separated; restricts the publication-coverage check
+	Tables      string // comma-separated; restricts the publication-coverage check
+}
+
+// BuildPGReport runs the bintrail-pg preflight + WAL-retention health checks against
+// a live PostgreSQL source and returns a doctor.Report.
+//
+// Health-only: this connects to the live source, but that does NOT cross the
+// offline-recovery invariant — recovery is index-only and never touches the source;
+// a health/doctor check legitimately does. It REPORTS every check and never mutates
+// anything (no slot create/drop, no config change). A connection failure short-
+// circuits (nothing else can run); a wal_level failure skips the dependent checks.
+//
+// It lives in pgstreamrun (not internal/doctor) because the report builder links
+// pgx/pgcapture, which internal/doctor must stay free of (cmd/bintrail's pgfree ban).
+func BuildPGReport(ctx context.Context, cfg PGDoctorConfig) *doctor.Report {
+	r := &doctor.Report{
+		ReadyFooter: "All checks passed. Run `bintrail-pg stream` to start (or resume) capture.",
+		FixFooter:   "Fix the failures above, then re-run `bintrail-pg doctor` to verify.",
+	}
+
+	conn, err := pgx.Connect(ctx, cfg.QueryDSN)
+	if err != nil {
+		r.Add(doctor.CheckResult{
+			Name:        "Source PostgreSQL connection",
+			Status:      doctor.StatusFail,
+			Detail:      err.Error(),
+			Remediation: "Check --query-dsn (or BINTRAIL_PG_QUERY_DSN) is reachable and the credentials are valid.",
+		})
+		return r // nothing else can run without a connection
+	}
+	defer conn.Close(context.Background())
+	r.Add(doctor.CheckResult{Name: "Source PostgreSQL connection", Status: doctor.StatusPass})
+
+	// wal_level is the prerequisite for everything else; if it's wrong, the rest
+	// can't meaningfully run, so skip them rather than emit a cascade of failures.
+	if err := pgcapture.CheckWALLevel(ctx, conn); err != nil {
+		r.Add(doctor.CheckResult{
+			Name:        "wal_level = logical",
+			Status:      doctor.StatusFail,
+			Detail:      err.Error(),
+			Remediation: "Set wal_level=logical in postgresql.conf and restart the server (this setting is not reloadable).",
+		})
+		for _, name := range []string{"Publication coverage", "REPLICA IDENTITY FULL", "max_slot_wal_keep_size", "Replication slot health"} {
+			r.Add(doctor.CheckResult{Name: name, Status: doctor.StatusSkip, Detail: "requires wal_level=logical"})
+		}
+		return r
+	}
+	r.Add(doctor.CheckResult{Name: "wal_level = logical", Status: doctor.StatusPass})
+
+	filters := cliutil.BuildIndexFilters(cfg.Schemas, cfg.Tables)
+
+	if err := pgcapture.CheckPublication(ctx, conn, cfg.Publication, filters); err != nil {
+		r.Add(doctor.CheckResult{
+			Name:        "Publication coverage",
+			Status:      doctor.StatusFail,
+			Detail:      err.Error(),
+			Remediation: "Create or extend the publication so it covers every table you index (CREATE PUBLICATION ... FOR TABLE ...; or FOR ALL TABLES).",
+		})
+	} else {
+		r.Add(doctor.CheckResult{Name: "Publication coverage", Status: doctor.StatusPass})
+	}
+
+	if err := pgcapture.CheckReplicaIdentity(ctx, conn, cfg.Publication); err != nil {
+		r.Add(doctor.CheckResult{
+			Name:        "REPLICA IDENTITY FULL",
+			Status:      doctor.StatusFail,
+			Detail:      err.Error(),
+			Remediation: "Run ALTER TABLE <t> REPLICA IDENTITY FULL on every replicated table, so before-images (and de-TOASTed unchanged values) are complete — otherwise recovery silently loses columns.",
+		})
+	} else {
+		r.Add(doctor.CheckResult{Name: "REPLICA IDENTITY FULL", Status: doctor.StatusPass})
+	}
+
+	addKeepSizeCheck(ctx, r, conn)
+	addSlotHealthCheck(ctx, r, conn, cfg.SlotName)
+	return r
+}
+
+// addKeepSizeCheck reports max_slot_wal_keep_size — the production red line (#532).
+// -1 (unlimited) means a stalled slot can pin WAL until the source disk fills, with
+// no in-database bound; that is a WARN, not a FAIL (it is a recommendation, and a
+// running consumer keeps it safe), so it does not fail the command.
+func addKeepSizeCheck(ctx context.Context, r *doctor.Report, conn *pgx.Conn) {
+	var setting string
+	if err := conn.QueryRow(ctx, "SELECT current_setting('max_slot_wal_keep_size')").Scan(&setting); err != nil {
+		r.Add(doctor.CheckResult{Name: "max_slot_wal_keep_size", Status: doctor.StatusWarn, Detail: "could not read: " + err.Error()})
+		return
+	}
+	if setting == "-1" {
+		r.Add(doctor.CheckResult{
+			Name:   "max_slot_wal_keep_size",
+			Status: doctor.StatusWarn,
+			Detail: "-1 (unlimited retention)",
+			Remediation: "Unlimited WAL retention: if this stream stalls, its replication slot can pin WAL until the source disk fills — an outage. " +
+				"Set a bound (e.g. max_slot_wal_keep_size = '10GB') so PostgreSQL invalidates the slot instead; bintrail-pg then fails loud and you re-baseline. " +
+				"This is the single GA-gating operational risk (#532).",
+		})
+		return
+	}
+	r.Add(doctor.CheckResult{Name: "max_slot_wal_keep_size", Status: doctor.StatusPass, Detail: setting})
+}
+
+// addSlotHealthCheck queries the slot's live state and adds its CheckResult. A query
+// failure is itself a FAIL; otherwise the (pure) slotHealthResult maps the state.
+func addSlotHealthCheck(ctx context.Context, r *doctor.Report, conn *pgx.Conn, slotName string) {
+	h, err := pgcapture.QuerySlotHealth(ctx, conn, slotName)
+	if err != nil {
+		r.Add(doctor.CheckResult{Name: "Replication slot health", Status: doctor.StatusFail, Detail: "could not query slot: " + err.Error()})
+		return
+	}
+	r.Add(slotHealthResult(h, slotName))
+}
+
+// slotHealthResult maps a SlotHealth into a CheckResult. It is pure (no I/O) so the
+// surfacing logic — especially the load-bearing lost→FAIL path — is unit-testable
+// with a stubbed SlotHealth, without driving a real slot to invalidation. A lost slot
+// is a loud FAIL with the re-baseline recovery path; extended/unreserved is a WARN
+// (approaching invalidation); reserved is a PASS; an absent slot is a SKIP (normal
+// before the first stream run).
+func slotHealthResult(h pgcapture.SlotHealth, slotName string) doctor.CheckResult {
+	const name = "Replication slot health"
+	if !h.Exists {
+		return doctor.CheckResult{
+			Name:        name,
+			Status:      doctor.StatusSkip,
+			Detail:      fmt.Sprintf("slot %q does not exist yet", slotName),
+			Remediation: "Normal before the first `bintrail-pg stream` run (the slot is created then). If you were resuming an existing slot, it was dropped or invalidated — re-baseline.",
+		}
+	}
+
+	detail := fmt.Sprintf("wal_status=%s, active=%t, retained_wal=%s", h.WalStatus, h.Active, formatBytes(h.RetainedBytes))
+	if h.SafeWalSize.Valid {
+		detail += ", safe_wal=" + formatBytes(h.SafeWalSize.Int64)
+	}
+
+	switch h.WalStatus {
+	case "lost":
+		return doctor.CheckResult{Name: name, Status: doctor.StatusFail, Detail: detail, Remediation: lostSlotRemediation(slotName)}
+	case "extended", "unreserved":
+		return doctor.CheckResult{
+			Name:   name,
+			Status: doctor.StatusWarn,
+			Detail: detail,
+			Remediation: "The slot is retaining WAL beyond max_wal_size and is approaching the max_slot_wal_keep_size limit. " +
+				"If it crosses, PostgreSQL invalidates the slot (wal_status=lost) and capture cannot resume — you must re-baseline. " +
+				"Make sure `bintrail-pg stream` is running and keeping up with the source's write rate.",
+		}
+	default:
+		// "reserved" (healthy) or an unexpected/empty value — show the detail, pass.
+		return doctor.CheckResult{Name: name, Status: doctor.StatusPass, Detail: detail}
+	}
+}
+
+// lostSlotRemediation frames the lost-slot recovery path: capture is broken, but the
+// index (and therefore recovery) is not. The manual re-baseline SQL mirrors the
+// docs; the `bintrail-pg reset` convenience command is a later slice (#532).
+func lostSlotRemediation(slotName string) string {
+	return "The replication slot is invalidated — the WAL it needs is gone, so capture cannot resume.\n" +
+		"The index is still fully usable for recovery (recovery never needs the slot).\n" +
+		"To resume capture you must re-baseline:\n" +
+		fmt.Sprintf("  1. on the source:  SELECT pg_drop_replication_slot('%s');\n", slotName) +
+		"  2. on the index:   DELETE FROM stream_state WHERE id = 1;\n" +
+		"  3. re-seed the baseline, then re-run `bintrail-pg stream`\n" +
+		"Prevent recurrence: raise max_slot_wal_keep_size and keep the consumer running."
+}
+
+// formatBytes renders a byte count as a human-readable size (operator-facing detail).
+func formatBytes(b int64) string {
+	const unit = 1024
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB", float64(b)/float64(div), "KMGTPE"[exp])
+}

--- a/internal/pgstreamrun/pgdoctor.go
+++ b/internal/pgstreamrun/pgdoctor.go
@@ -2,7 +2,9 @@ package pgstreamrun
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 
@@ -10,6 +12,15 @@ import (
 	"github.com/dbtrail/dbtrail/internal/doctor"
 	"github.com/dbtrail/dbtrail/internal/pgcapture"
 )
+
+// doctorTimeout bounds the whole health report so `bintrail-pg doctor` can't hang for
+// the OS TCP timeout against a black-holed host (it is a connectivity-diagnosis tool).
+// Mirrors the MySQL doctor.Build 30s budget.
+const doctorTimeout = 30 * time.Second
+
+// dependentCheckNames are the checks BuildPGReport skips when wal_level is genuinely
+// not 'logical' — logical decoding is impossible, so they cannot meaningfully run.
+var dependentCheckNames = []string{"Publication coverage", "REPLICA IDENTITY FULL", "max_slot_wal_keep_size", "Replication slot health"}
 
 // PGDoctorConfig is the subset of stream settings a health check needs: a normal
 // (non-replication) connection to the source, the slot to inspect, and the
@@ -34,6 +45,9 @@ type PGDoctorConfig struct {
 // It lives in pgstreamrun (not internal/doctor) because the report builder links
 // pgx/pgcapture, which internal/doctor must stay free of (cmd/bintrail's pgfree ban).
 func BuildPGReport(ctx context.Context, cfg PGDoctorConfig) *doctor.Report {
+	ctx, cancel := context.WithTimeout(ctx, doctorTimeout)
+	defer cancel()
+
 	r := &doctor.Report{
 		ReadyFooter: "All checks passed. Run `bintrail-pg stream` to start (or resume) capture.",
 		FixFooter:   "Fix the failures above, then re-run `bintrail-pg doctor` to verify.",
@@ -52,21 +66,19 @@ func BuildPGReport(ctx context.Context, cfg PGDoctorConfig) *doctor.Report {
 	defer conn.Close(context.Background())
 	r.Add(doctor.CheckResult{Name: "Source PostgreSQL connection", Status: doctor.StatusPass})
 
-	// wal_level is the prerequisite for everything else; if it's wrong, the rest
-	// can't meaningfully run, so skip them rather than emit a cascade of failures.
-	if err := pgcapture.CheckWALLevel(ctx, conn); err != nil {
-		r.Add(doctor.CheckResult{
-			Name:        "wal_level = logical",
-			Status:      doctor.StatusFail,
-			Detail:      err.Error(),
-			Remediation: "Set wal_level=logical in postgresql.conf and restart the server (this setting is not reloadable).",
-		})
-		for _, name := range []string{"Publication coverage", "REPLICA IDENTITY FULL", "max_slot_wal_keep_size", "Replication slot health"} {
+	// wal_level is the prerequisite for everything else. A genuine misconfiguration
+	// (readable, but not 'logical') skips the dependent checks — they can't run. A
+	// query FAILURE, by contrast, must NOT skip them: the slot-health check runs its
+	// own query and would report the dangerous state honestly, so a transient blip must
+	// never silently suppress it.
+	walRes, skipDependents := walLevelResult(pgcapture.CheckWALLevel(ctx, conn))
+	r.Add(walRes)
+	if skipDependents {
+		for _, name := range dependentCheckNames {
 			r.Add(doctor.CheckResult{Name: name, Status: doctor.StatusSkip, Detail: "requires wal_level=logical"})
 		}
 		return r
 	}
-	r.Add(doctor.CheckResult{Name: "wal_level = logical", Status: doctor.StatusPass})
 
 	filters := cliutil.BuildIndexFilters(cfg.Schemas, cfg.Tables)
 
@@ -97,28 +109,62 @@ func BuildPGReport(ctx context.Context, cfg PGDoctorConfig) *doctor.Report {
 	return r
 }
 
-// addKeepSizeCheck reports max_slot_wal_keep_size — the production red line (#532).
-// -1 (unlimited) means a stalled slot can pin WAL until the source disk fills, with
-// no in-database bound; that is a WARN, not a FAIL (it is a recommendation, and a
-// running consumer keeps it safe), so it does not fail the command.
+// walLevelResult maps the CheckWALLevel outcome to its CheckResult and whether the
+// dependent checks must be SKIPped. It is pure (takes the error) so both branches —
+// value-wrong (skip) and query-failed (don't skip) — are unit-testable without a live
+// non-logical server. A genuine wal_level!=logical config error fails AND skips
+// (logical decoding is impossible); a query error fails but does NOT skip, so a
+// transient blip never suppresses the load-bearing slot-health check.
+func walLevelResult(err error) (doctor.CheckResult, bool) {
+	const name = "wal_level = logical"
+	switch {
+	case err == nil:
+		return doctor.CheckResult{Name: name, Status: doctor.StatusPass}, false
+	case errors.Is(err, pgcapture.ErrWALLevelNotLogical):
+		return doctor.CheckResult{
+			Name:        name,
+			Status:      doctor.StatusFail,
+			Detail:      err.Error(),
+			Remediation: "Set wal_level=logical in postgresql.conf and restart the server (this setting is not reloadable).",
+		}, true
+	default:
+		return doctor.CheckResult{
+			Name:        name,
+			Status:      doctor.StatusFail,
+			Detail:      err.Error(),
+			Remediation: "Could not read wal_level. Retry once (a transient connection drop or timeout is the common cause); if it persists, check the role's privileges on the source.",
+		}, false
+	}
+}
+
+// addKeepSizeCheck reads max_slot_wal_keep_size and adds its result (a query failure
+// is a WARN — keep-size is advisory). The mapping is the pure keepSizeResult.
 func addKeepSizeCheck(ctx context.Context, r *doctor.Report, conn *pgx.Conn) {
 	var setting string
 	if err := conn.QueryRow(ctx, "SELECT current_setting('max_slot_wal_keep_size')").Scan(&setting); err != nil {
 		r.Add(doctor.CheckResult{Name: "max_slot_wal_keep_size", Status: doctor.StatusWarn, Detail: "could not read: " + err.Error()})
 		return
 	}
+	r.Add(keepSizeResult(setting))
+}
+
+// keepSizeResult maps the max_slot_wal_keep_size setting — the production red line
+// (#532). -1 (unlimited) means a stalled slot can pin WAL until the source disk fills,
+// with no in-database bound; that is a WARN, not a FAIL (it is a recommendation, and a
+// running consumer keeps it safe), so it does not fail the command.
+func keepSizeResult(setting string) doctor.CheckResult {
+	const name = "max_slot_wal_keep_size"
 	if setting == "-1" {
-		r.Add(doctor.CheckResult{
-			Name:   "max_slot_wal_keep_size",
+		return doctor.CheckResult{
+			Name:   name,
 			Status: doctor.StatusWarn,
 			Detail: "-1 (unlimited retention)",
 			Remediation: "Unlimited WAL retention: if this stream stalls, its replication slot can pin WAL until the source disk fills — an outage. " +
 				"Set a bound (e.g. max_slot_wal_keep_size = '10GB') so PostgreSQL invalidates the slot instead; bintrail-pg then fails loud and you re-baseline. " +
 				"This is the single GA-gating operational risk (#532).",
-		})
-		return
+		}
 	}
-	r.Add(doctor.CheckResult{Name: "max_slot_wal_keep_size", Status: doctor.StatusPass, Detail: setting})
+	return doctor.CheckResult{Name: name, Status: doctor.StatusPass, Detail: setting}
 }
 
 // addSlotHealthCheck queries the slot's live state and adds its CheckResult. A query
@@ -155,9 +201,9 @@ func slotHealthResult(h pgcapture.SlotHealth, slotName string) doctor.CheckResul
 	}
 
 	switch h.WalStatus {
-	case "lost":
+	case pgcapture.WalStatusLost:
 		return doctor.CheckResult{Name: name, Status: doctor.StatusFail, Detail: detail, Remediation: lostSlotRemediation(slotName)}
-	case "extended", "unreserved":
+	case pgcapture.WalStatusExtended, pgcapture.WalStatusUnreserved:
 		return doctor.CheckResult{
 			Name:   name,
 			Status: doctor.StatusWarn,
@@ -166,9 +212,19 @@ func slotHealthResult(h pgcapture.SlotHealth, slotName string) doctor.CheckResul
 				"If it crosses, PostgreSQL invalidates the slot (wal_status=lost) and capture cannot resume — you must re-baseline. " +
 				"Make sure `bintrail-pg stream` is running and keeping up with the source's write rate.",
 		}
-	default:
-		// "reserved" (healthy) or an unexpected/empty value — show the detail, pass.
+	case pgcapture.WalStatusReserved, "":
+		// reserved = healthy; "" = a just-created slot that hasn't reserved WAL yet
+		// (restart_lsn NULL) — both benign.
 		return doctor.CheckResult{Name: name, Status: doctor.StatusPass, Detail: detail}
+	default:
+		// An unrecognized, non-empty status (e.g. a future PostgreSQL value) must not
+		// be silently shown as healthy — WARN so a new dangerous state can't slip through.
+		return doctor.CheckResult{
+			Name:        name,
+			Status:      doctor.StatusWarn,
+			Detail:      detail,
+			Remediation: fmt.Sprintf("Unrecognized wal_status %q — treating as non-fatal; verify the slot manually against your PostgreSQL version's pg_replication_slots docs.", h.WalStatus),
+		}
 	}
 }
 

--- a/internal/pgstreamrun/pgdoctor_integration_test.go
+++ b/internal/pgstreamrun/pgdoctor_integration_test.go
@@ -1,0 +1,176 @@
+//go:build integration
+
+package pgstreamrun_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/dbtrail/dbtrail/internal/doctor"
+	"github.com/dbtrail/dbtrail/internal/pgstreamrun"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+func findCheck(t *testing.T, r *doctor.Report, name string) doctor.CheckResult {
+	t.Helper()
+	for _, c := range r.Checks {
+		if c.Name == name {
+			return c
+		}
+	}
+	t.Fatalf("report has no check named %q; checks=%v", name, r.Checks)
+	return doctor.CheckResult{}
+}
+
+// TestBuildPGReport_Integration drives the doctor report against a live PostgreSQL:
+// a healthy source (slot + publication + REPLICA IDENTITY FULL) passes the required
+// checks, and a wrong publication name surfaces as a publication-coverage FAIL.
+//
+// Requires BINTRAIL_TEST_PG_DSN; the MySQL CI jobs leave it unset and skip cleanly.
+func TestBuildPGReport_Integration(t *testing.T) {
+	dsn := testutil.SkipIfNoPostgres(t)
+	ctx := context.Background()
+
+	const slot = "bintrail_doctor_it"
+	const pub = "bintrail_doctor_it_pub"
+	const tbl = "doctor_it_t"
+
+	conn, err := pgx.Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { conn.Close(context.Background()) })
+
+	mustExec := func(sql string) {
+		t.Helper()
+		if _, err := conn.Exec(ctx, sql); err != nil {
+			t.Fatalf("exec %q: %v", sql, err)
+		}
+	}
+	dropAll := func() {
+		bg := context.Background()
+		_, _ = conn.Exec(bg, "DROP PUBLICATION IF EXISTS "+pub)
+		_, _ = conn.Exec(bg, "DROP TABLE IF EXISTS "+tbl)
+		_, _ = conn.Exec(bg, "SELECT pg_drop_replication_slot($1) WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name=$1)", slot)
+	}
+	dropAll()
+	t.Cleanup(dropAll)
+
+	mustExec("CREATE TABLE " + tbl + " (id int PRIMARY KEY, v text)")
+	mustExec("ALTER TABLE " + tbl + " REPLICA IDENTITY FULL")
+	mustExec("CREATE PUBLICATION " + pub + " FOR TABLE " + tbl)
+	mustExec("SELECT pg_create_logical_replication_slot('" + slot + "', 'pgoutput')")
+
+	t.Run("healthy", func(t *testing.T) {
+		r := pgstreamrun.BuildPGReport(ctx, pgstreamrun.PGDoctorConfig{
+			QueryDSN: dsn, SlotName: slot, Publication: pub,
+		})
+		for _, name := range []string{"Source PostgreSQL connection", "wal_level = logical", "Publication coverage", "REPLICA IDENTITY FULL"} {
+			if c := findCheck(t, r, name); c.Status != doctor.StatusPass {
+				t.Errorf("%s = %s (%s), want pass", name, c.Status, c.Detail)
+			}
+		}
+		// The slot is reserved (healthy) under the default unlimited retention.
+		if c := findCheck(t, r, "Replication slot health"); c.Status != doctor.StatusPass {
+			t.Errorf("slot health = %s (%s), want pass", c.Status, c.Detail)
+		}
+		if r.Failed != 0 {
+			t.Errorf("healthy source has %d failed checks, want 0", r.Failed)
+		}
+		if err := r.Err(); err != nil {
+			t.Errorf("Err() = %v, want nil for a healthy source", err)
+		}
+	})
+
+	t.Run("missing-publication", func(t *testing.T) {
+		r := pgstreamrun.BuildPGReport(ctx, pgstreamrun.PGDoctorConfig{
+			QueryDSN: dsn, SlotName: slot, Publication: "no_such_pub",
+		})
+		if c := findCheck(t, r, "Publication coverage"); c.Status != doctor.StatusFail {
+			t.Errorf("Publication coverage = %s, want fail for a non-existent publication", c.Status)
+		}
+		if r.Err() == nil {
+			t.Error("Err() = nil, want non-nil when a required check failed")
+		}
+	})
+}
+
+// TestBuildPGReport_LostSlot_Integration is the #532 linchpin: it drives a real slot
+// to wal_status='lost' and asserts the doctor reports it as a loud FAIL with the
+// recovery path. max_slot_wal_keep_size is a server-wide SIGHUP setting; the CI runs
+// PG packages with -p 1 (serial) and these tests are non-parallel, so the keep-size
+// window is isolated. t.Cleanup RESETs it even on failure.
+func TestBuildPGReport_LostSlot_Integration(t *testing.T) {
+	dsn := testutil.SkipIfNoPostgres(t)
+	ctx := context.Background()
+
+	const slot = "bintrail_lostslot_it"
+	const tbl = "lostslot_it_churn"
+
+	conn, err := pgx.Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { conn.Close(context.Background()) })
+
+	mustExec := func(sql string) {
+		t.Helper()
+		if _, err := conn.Exec(ctx, sql); err != nil {
+			t.Fatalf("exec %q: %v", sql, err)
+		}
+	}
+
+	// Restore the server-wide setting and clean up regardless of outcome.
+	t.Cleanup(func() {
+		bg := context.Background()
+		_, _ = conn.Exec(bg, "ALTER SYSTEM RESET max_slot_wal_keep_size")
+		_, _ = conn.Exec(bg, "SELECT pg_reload_conf()")
+		_, _ = conn.Exec(bg, "DROP TABLE IF EXISTS "+tbl)
+		_, _ = conn.Exec(bg, "SELECT pg_drop_replication_slot($1) WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name=$1)", slot)
+	})
+	// Start clean.
+	_, _ = conn.Exec(ctx, "DROP TABLE IF EXISTS "+tbl)
+	_, _ = conn.Exec(ctx, "SELECT pg_drop_replication_slot($1) WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name=$1)", slot)
+
+	// Bound WAL retention tightly, create an (idle) slot, then churn WAL past the
+	// bound so the next checkpoint invalidates the slot.
+	mustExec("ALTER SYSTEM SET max_slot_wal_keep_size = '1MB'")
+	mustExec("SELECT pg_reload_conf()")
+	mustExec("SELECT pg_create_logical_replication_slot('" + slot + "', 'pgoutput')")
+	mustExec("CREATE TABLE " + tbl + " (id serial, pad text)")
+
+	lost := false
+	for i := 0; i < 10 && !lost; i++ {
+		mustExec("INSERT INTO " + tbl + " (pad) SELECT repeat('x', 900) FROM generate_series(1, 4000)")
+		mustExec("SELECT pg_switch_wal()")
+		mustExec("CHECKPOINT")
+		var status string
+		if err := conn.QueryRow(ctx, "SELECT wal_status FROM pg_replication_slots WHERE slot_name=$1", slot).Scan(&status); err != nil {
+			t.Fatalf("read wal_status: %v", err)
+		}
+		lost = status == "lost"
+	}
+	if !lost {
+		t.Skip("could not drive the slot to wal_status=lost on this server; skipping the lost-slot assertion")
+	}
+
+	r := pgstreamrun.BuildPGReport(ctx, pgstreamrun.PGDoctorConfig{
+		QueryDSN: dsn, SlotName: slot, Publication: "irrelevant_for_slot_check",
+	})
+	c := findCheck(t, r, "Replication slot health")
+	if c.Status != doctor.StatusFail {
+		t.Fatalf("lost slot reported %s, want fail; detail=%q", c.Status, c.Detail)
+	}
+	if r.Err() == nil {
+		t.Error("Err() = nil, want non-nil when the slot is lost")
+	}
+	// The recovery path must be present and reassure that recovery is unaffected.
+	for _, want := range []string{"re-baseline", "recovery never needs the slot"} {
+		if !strings.Contains(c.Remediation, want) {
+			t.Errorf("lost-slot remediation missing %q:\n%s", want, c.Remediation)
+		}
+	}
+}

--- a/internal/pgstreamrun/pgdoctor_integration_test.go
+++ b/internal/pgstreamrun/pgdoctor_integration_test.go
@@ -77,6 +77,12 @@ func TestBuildPGReport_Integration(t *testing.T) {
 		if c := findCheck(t, r, "Replication slot health"); c.Status != doctor.StatusPass {
 			t.Errorf("slot health = %s (%s), want pass", c.Status, c.Detail)
 		}
+		// max_slot_wal_keep_size runs and reads the real setting: the dev/CI container
+		// leaves it at the -1 default, so it WARNs (the production red line). A bounded
+		// server would PASS; either way it must not FAIL or SKIP in a healthy run.
+		if c := findCheck(t, r, "max_slot_wal_keep_size"); c.Status != doctor.StatusWarn && c.Status != doctor.StatusPass {
+			t.Errorf("max_slot_wal_keep_size = %s (%s), want warn (unlimited) or pass (bounded)", c.Status, c.Detail)
+		}
 		if r.Failed != 0 {
 			t.Errorf("healthy source has %d failed checks, want 0", r.Failed)
 		}

--- a/internal/pgstreamrun/pgdoctor_test.go
+++ b/internal/pgstreamrun/pgdoctor_test.go
@@ -1,0 +1,87 @@
+package pgstreamrun
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/doctor"
+	"github.com/dbtrail/dbtrail/internal/pgcapture"
+)
+
+func TestSlotHealthResult(t *testing.T) {
+	tests := []struct {
+		name              string
+		h                 pgcapture.SlotHealth
+		wantStatus        doctor.CheckStatus
+		wantInDetailOrRem string
+	}{
+		{"absent", pgcapture.SlotHealth{Exists: false}, doctor.StatusSkip, "does not exist"},
+		{"reserved", pgcapture.SlotHealth{Exists: true, WalStatus: "reserved", Active: true}, doctor.StatusPass, "wal_status=reserved"},
+		{"extended", pgcapture.SlotHealth{Exists: true, WalStatus: "extended"}, doctor.StatusWarn, "approaching"},
+		{"unreserved", pgcapture.SlotHealth{Exists: true, WalStatus: "unreserved"}, doctor.StatusWarn, "approaching"},
+		{"lost", pgcapture.SlotHealth{Exists: true, WalStatus: "lost"}, doctor.StatusFail, "re-baseline"},
+		{"unknown-status-passes", pgcapture.SlotHealth{Exists: true, WalStatus: "weird"}, doctor.StatusPass, "wal_status=weird"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := slotHealthResult(tt.h, "myslot")
+			if got.Status != tt.wantStatus {
+				t.Errorf("Status = %q, want %q", got.Status, tt.wantStatus)
+			}
+			hay := got.Detail + " " + got.Remediation
+			if !strings.Contains(hay, tt.wantInDetailOrRem) {
+				t.Errorf("detail/remediation %q missing %q", hay, tt.wantInDetailOrRem)
+			}
+		})
+	}
+}
+
+// TestSlotHealthResult_lostHasRecoveryPath pins the load-bearing #532 acceptance: a
+// lost slot is a loud FAIL whose remediation names the manual re-baseline steps and
+// reassures that recovery (which is index-only) is unaffected.
+func TestSlotHealthResult_lostHasRecoveryPath(t *testing.T) {
+	got := slotHealthResult(pgcapture.SlotHealth{Exists: true, WalStatus: "lost"}, "s1")
+	if got.Status != doctor.StatusFail {
+		t.Fatalf("lost slot must FAIL, got %q", got.Status)
+	}
+	for _, want := range []string{"pg_drop_replication_slot('s1')", "DELETE FROM stream_state", "recovery never needs the slot"} {
+		if !strings.Contains(got.Remediation, want) {
+			t.Errorf("lost remediation missing %q:\n%s", want, got.Remediation)
+		}
+	}
+}
+
+func TestSlotHealthResult_safeWalSizeRendering(t *testing.T) {
+	withSafe := slotHealthResult(pgcapture.SlotHealth{
+		Exists: true, WalStatus: "reserved", RetainedBytes: 2048,
+		SafeWalSize: sql.NullInt64{Int64: 1048576, Valid: true},
+	}, "s")
+	if !strings.Contains(withSafe.Detail, "retained_wal=2.0 KiB") {
+		t.Errorf("missing humanized retained_wal: %q", withSafe.Detail)
+	}
+	if !strings.Contains(withSafe.Detail, "safe_wal=1.0 MiB") {
+		t.Errorf("missing safe_wal when valid: %q", withSafe.Detail)
+	}
+	// NULL safe_wal_size (unlimited retention) → safe_wal omitted entirely.
+	noSafe := slotHealthResult(pgcapture.SlotHealth{Exists: true, WalStatus: "reserved"}, "s")
+	if strings.Contains(noSafe.Detail, "safe_wal=") {
+		t.Errorf("safe_wal must be omitted when NULL: %q", noSafe.Detail)
+	}
+}
+
+func TestFormatBytes(t *testing.T) {
+	cases := map[int64]string{
+		0:          "0 B",
+		512:        "512 B",
+		1024:       "1.0 KiB",
+		1536:       "1.5 KiB",
+		1048576:    "1.0 MiB",
+		1073741824: "1.0 GiB",
+	}
+	for in, want := range cases {
+		if got := formatBytes(in); got != want {
+			t.Errorf("formatBytes(%d) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/pgstreamrun/pgdoctor_test.go
+++ b/internal/pgstreamrun/pgdoctor_test.go
@@ -2,6 +2,8 @@ package pgstreamrun
 
 import (
 	"database/sql"
+	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -18,10 +20,11 @@ func TestSlotHealthResult(t *testing.T) {
 	}{
 		{"absent", pgcapture.SlotHealth{Exists: false}, doctor.StatusSkip, "does not exist"},
 		{"reserved", pgcapture.SlotHealth{Exists: true, WalStatus: "reserved", Active: true}, doctor.StatusPass, "wal_status=reserved"},
+		{"empty-status-passes", pgcapture.SlotHealth{Exists: true, WalStatus: ""}, doctor.StatusPass, "wal_status="},
 		{"extended", pgcapture.SlotHealth{Exists: true, WalStatus: "extended"}, doctor.StatusWarn, "approaching"},
 		{"unreserved", pgcapture.SlotHealth{Exists: true, WalStatus: "unreserved"}, doctor.StatusWarn, "approaching"},
 		{"lost", pgcapture.SlotHealth{Exists: true, WalStatus: "lost"}, doctor.StatusFail, "re-baseline"},
-		{"unknown-status-passes", pgcapture.SlotHealth{Exists: true, WalStatus: "weird"}, doctor.StatusPass, "wal_status=weird"},
+		{"unknown-status-warns", pgcapture.SlotHealth{Exists: true, WalStatus: "weird"}, doctor.StatusWarn, "Unrecognized wal_status"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -68,6 +71,55 @@ func TestSlotHealthResult_safeWalSizeRendering(t *testing.T) {
 	if strings.Contains(noSafe.Detail, "safe_wal=") {
 		t.Errorf("safe_wal must be omitted when NULL: %q", noSafe.Detail)
 	}
+}
+
+// TestWalLevelResult pins the distinction the silent-failure review required: a
+// genuine wal_level!=logical config error FAILs and SKIPs dependents, while a query
+// failure FAILs but does NOT skip (so a transient blip never suppresses slot-health).
+func TestWalLevelResult(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		res, skip := walLevelResult(nil)
+		if res.Status != doctor.StatusPass || skip {
+			t.Errorf("nil err → got (%s, skip=%t), want (pass, false)", res.Status, skip)
+		}
+	})
+	t.Run("not-logical-skips", func(t *testing.T) {
+		err := fmt.Errorf("wrap: %w", pgcapture.ErrWALLevelNotLogical)
+		res, skip := walLevelResult(err)
+		if res.Status != doctor.StatusFail || !skip {
+			t.Errorf("not-logical → got (%s, skip=%t), want (fail, true)", res.Status, skip)
+		}
+		if !strings.Contains(res.Remediation, "restart the server") {
+			t.Errorf("not-logical remediation should mention the restart: %q", res.Remediation)
+		}
+	})
+	t.Run("query-error-does-not-skip", func(t *testing.T) {
+		res, skip := walLevelResult(errors.New("connection refused"))
+		if res.Status != doctor.StatusFail || skip {
+			t.Errorf("query error → got (%s, skip=%t), want (fail, false — must not suppress dependents)", res.Status, skip)
+		}
+		if !strings.Contains(res.Remediation, "Retry") {
+			t.Errorf("query-error remediation should suggest retry, not a server restart: %q", res.Remediation)
+		}
+	})
+}
+
+func TestKeepSizeResult(t *testing.T) {
+	t.Run("unlimited-warns", func(t *testing.T) {
+		res := keepSizeResult("-1")
+		if res.Status != doctor.StatusWarn {
+			t.Errorf("'-1' → %s, want warn (the production red line)", res.Status)
+		}
+		if !strings.Contains(res.Remediation, "disk fills") {
+			t.Errorf("unlimited remediation should name the disk-fill risk: %q", res.Remediation)
+		}
+	})
+	t.Run("bounded-passes", func(t *testing.T) {
+		res := keepSizeResult("10GB")
+		if res.Status != doctor.StatusPass || res.Detail != "10GB" {
+			t.Errorf("'10GB' → (%s, %q), want (pass, 10GB)", res.Status, res.Detail)
+		}
+	})
 }
 
 func TestFormatBytes(t *testing.T) {


### PR DESCRIPTION
## What & why

**#532 is the GA gate for PostgreSQL-as-source.** A stalled/abandoned logical-replication slot pins WAL → the source disk fills → outage. This slice delivers operator visibility into that risk, plus the shared slot-health primitive the rest of #532 builds on.

This is **part 1** of #532 (remaining: durable lost-slot badge in index-only `status`, `bintrail-pg reset` teardown, docs).

## Changes

**`pgcapture.QuerySlotHealth`** (`internal/pgcapture/health.go`) — one canonical, NULL-tolerant query of `pg_replication_slots`: `wal_status`, `active`, restart/confirmed-flush LSNs, WAL pinned (`pg_wal_lsn_diff`), `safe_wal_size` (NULL under unlimited retention). `ensureSlot` is refactored onto it (single query path; **capture behavior unchanged**). Health-only — callers report, they never fail-loud on it (that stays `ensureSlot`'s job). LSN/NULL folding is a pure, unit-tested helper.

**`bintrail-pg doctor`** (`cmd/bintrail-pg/doctor.go` + `internal/pgstreamrun/pgdoctor.go`) — operator preflight + slot health, mirroring `bintrail doctor`:

| Check | Logic |
|---|---|
| Source connection | fail if unreachable |
| `wal_level = logical` | fail → skip dependents |
| Publication coverage | reuses the capture-time validator |
| REPLICA IDENTITY FULL | reuses the capture-time validator |
| `max_slot_wal_keep_size` | **WARN if `-1`** (unlimited = disk-fill risk) |
| Replication slot health | `lost` → **loud FAIL** + recovery path; extended/unreserved → WARN; reserved → PASS; absent → SKIP |

Text + JSON via `doctor.Report`.

## Invariants honored
- **Offline-recovery**: doctor connects to the live source for *health only* — recovery stays index-only. The lost-slot remediation makes this explicit ("the index is still fully usable for recovery; recovery never needs the slot").
- **pgfree ban**: the report builder lives in `pgstreamrun`, not `internal/doctor`, so `internal/doctor` (and thus `cmd/bintrail`) stays pgx-free. `TestCoreBinaryIsPostgresFree` passes.
- **`doctor.Report`** gains an exported `Add` + a back-compatible parameterized text footer — **MySQL output unchanged; JSON strictly additive** (footer fields are `json:"-"`).
- **One index schema**: no schema changes.

## Tests
- **Unit (deterministic):** `slotHealthResult` mapping (lost→FAIL, extended/unreserved→WARN, reserved→PASS, absent→SKIP), `formatBytes`, the LSN/NULL helper, doctor config env-fallback/validation.
- **Integration (live PG):** `QuerySlotHealth` (present/absent/dropped); `BuildPGReport` (healthy + missing-publication); and the linchpin — **`TestBuildPGReport_LostSlot_Integration` drives a real slot to `wal_status='lost'`** (bound `max_slot_wal_keep_size` + WAL churn) and asserts the FAIL + recovery path. PG CI runs `-p 1` (serial) and the server-wide setting is reset in `t.Cleanup`, so the mutation is isolated.
- Full unit suite + the existing capturer integration suite (the `ensureSlot` refactor regression) green; gofmt clean.

Part of #532

🤖 Generated with [Claude Code](https://claude.com/claude-code)