### PR TITLE
feat(console): POST /api/recover-cascade endpoint + capability gate (#579)

### DIFF
--- a/internal/console/reconstruct.go
+++ b/internal/console/reconstruct.go
@@ -27,8 +27,20 @@ type capabilitiesResponse struct {
 	// Monitor: this process can start/stop monitoring (a control-plane
 	// supervisor — `bintrail-console watch`). Process-global, not per-server:
 	// it is about what the PROCESS is, not about the selected connection.
-	Monitor bool         `json:"monitor"`
-	Auth    authCapsInfo `json:"auth"`
+	Monitor bool `json:"monitor"`
+	// RecoverCascade: the recover-cascade surface is available. Free tier (like
+	// recover), so available unless an RBAC redaction profile is active — under a
+	// profile cascade victim synthesis cannot honor redaction, so the endpoint
+	// refuses (see handleRecoverCascade). Process-global, like Monitor.
+	RecoverCascade bool `json:"recover_cascade"`
+	// RecoverCascadeBaseline: cascade recovery's Phase-2 (recover children
+	// untouched within the window) is active for this server. Per-server, and gated
+	// EXACTLY like the handler builds its provider — a baseline source AND a schema
+	// snapshot (resolver). baselineConfigured can be true with resolver==nil (a
+	// baseline dir set but `bintrail snapshot` never run), where the handler
+	// degrades to Phase-1; advertising true there would over-promise.
+	RecoverCascadeBaseline bool         `json:"recover_cascade_baseline"`
+	Auth                   authCapsInfo `json:"auth"`
 }
 
 // authCapsInfo tells the authenticated SPA how it got in and whether a
@@ -58,10 +70,17 @@ func (s *Server) handleCapabilities(w http.ResponseWriter, r *http.Request) {
 	}
 	resp := capabilitiesResponse{
 		Monitor: s.monitorCtrl != nil,
-		Auth:    authCapsInfo{PasswordSet: s.passwordLoginEnabled(), AuthKind: kind},
+		// recover-cascade is the free tier (like recover) and process-global, gated
+		// only by the RBAC profile (which would make synthesis leak redacted data).
+		RecoverCascade: !s.rbacActive(),
+		Auth:           authCapsInfo{PasswordSet: s.passwordLoginEnabled(), AuthKind: kind},
 	}
 	if b, err := s.resolve(r); err == nil {
 		resp.Reconstruct = b.baselineConfigured
+		// Match the recover-cascade handler's Phase-2 gate exactly so the advertised
+		// capability can't over-promise (handler builds the provider only when both
+		// a baseline source and a resolver are present).
+		resp.RecoverCascadeBaseline = b.baselineConfigured && b.resolver != nil
 	} else if !errors.Is(err, ErrUnknownServer) && !errors.Is(err, errNoServers) {
 		// Expected for a bad X-Bintrail-Server header or a fresh install;
 		// anything else (e.g. a genuine connection failure) would silently

--- a/internal/console/recover_cascade.go
+++ b/internal/console/recover_cascade.go
@@ -1,0 +1,344 @@
+package console
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/cascade"
+	"github.com/dbtrail/dbtrail/internal/cascaderecover"
+	"github.com/dbtrail/dbtrail/internal/cliutil"
+	"github.com/dbtrail/dbtrail/internal/event"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/query"
+	"github.com/dbtrail/dbtrail/internal/reconstruct"
+	"github.com/dbtrail/dbtrail/internal/recovery"
+)
+
+// recoverCascadeRequest is the JSON body accepted by POST /api/recover-cascade.
+// Schema/Table identify the PARENT table whose delete cascaded; the handler
+// synthesizes the invisible child victims (ON DELETE CASCADE / SET NULL that
+// InnoDB ran below the binlog) and returns reversal SQL — never executing it.
+type recoverCascadeRequest struct {
+	Schema   string   `json:"schema"`
+	Table    string   `json:"table"`
+	PK       string   `json:"pk"`
+	PKs      []string `json:"pks"`
+	Since    string   `json:"since"`
+	Until    string   `json:"until"`
+	Lookback string   `json:"lookback"`
+	MaxDepth int      `json:"max_depth"`
+	// AllowIncomplete is reserved (for CLI request symmetry / forward-compat) and
+	// currently has NO effect — there is no exit code to gate over a wire, so the
+	// response ALWAYS returns 200 carrying `complete` + `incomplete` for the client
+	// to decide. It does not buy a fail-closed gate.
+	AllowIncomplete bool `json:"allow_incomplete"`
+}
+
+// recoverCascadeResponse is text + structured coverage only — never event rows,
+// so it stays inside the free query_explorer boundary (connection_id can never
+// leak, exactly like recoverResponse).
+type recoverCascadeResponse struct {
+	SQL            string `json:"sql"`
+	StatementCount int    `json:"statement_count"`
+	VictimCount    int    `json:"victim_count"`
+	SetNullCount   int    `json:"set_null_count"`
+	// Complete is a convenience for the client: it is exactly Incomplete being
+	// empty (an operational synthesis error is folded into Incomplete too), so the
+	// two are always set together — never independently.
+	Complete   bool     `json:"complete"`
+	Incomplete []string `json:"incomplete,omitempty"`
+}
+
+// rbacActive reports whether the console is running under an RBAC profile with
+// deny/redact rules. recover-cascade is refused in that mode (see
+// handleRecoverCascade) because cascade victim synthesis cannot yet honor column
+// redaction / table deny on its internal child fetches.
+func (s *Server) rbacActive() bool {
+	return len(s.denyTables) > 0 || len(s.redactCols) > 0
+}
+
+// handleRecoverCascade serves POST /api/recover-cascade — generates reversal SQL
+// for rows hit by a foreign-key ON DELETE CASCADE / SET NULL that InnoDB ran
+// below the binlog (MySQL Bug #32506). Like /api/recover it NEVER executes the
+// SQL: it synthesizes the invisible victims from the index, builds the script in
+// a buffer, and returns it as text for the operator to review.
+func (s *Server) handleRecoverCascade(w http.ResponseWriter, r *http.Request) {
+	// RBAC guard FIRST — it is process-global and needs no bundle, so refuse before
+	// resolveOr even opens the per-server connection or loads a schema snapshot.
+	// cascade.SynthesizeVictims' internal child fetches do NOT carry the bundle's
+	// DenyTables/RedactColumns, so a redacted column / denied table could surface
+	// in a cascade victim's reversal SQL — a leak the normal recover endpoint does
+	// not have (its fetched rows are redacted). Until RBAC is threaded through
+	// synthesis (#585), refuse cascade recovery whenever a profile is active. The
+	// capability gate is intended to hide the tab once the frontend lands (#580);
+	// this guard is the actual enforcement / defense-in-depth backstop.
+	if s.rbacActive() {
+		writeJSONError(w, http.StatusForbidden,
+			"recover-cascade is unavailable while an RBAC redaction profile is active "+
+				"(cascade victim synthesis cannot yet honor column redaction / table deny)")
+		return
+	}
+
+	b := s.resolveOr(w, r)
+	if b == nil {
+		return
+	}
+
+	var body recoverCascadeRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil && !errors.Is(err, io.EOF) {
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		return
+	}
+
+	if body.Schema == "" || body.Table == "" {
+		writeJSONError(w, http.StatusBadRequest, "recover-cascade requires schema and table (the parent table whose delete cascaded)")
+		return
+	}
+	if body.PK != "" && len(body.PKs) > 0 {
+		writeJSONError(w, http.StatusBadRequest, "pk and pks are mutually exclusive; use one or the other")
+		return
+	}
+	maxDepth := body.MaxDepth
+	if maxDepth == 0 {
+		maxDepth = 5
+	}
+	if maxDepth < 1 {
+		writeJSONError(w, http.StatusBadRequest, "max_depth must be >= 1")
+		return
+	}
+	lookbackStr := body.Lookback
+	if lookbackStr == "" {
+		lookbackStr = "30d"
+	}
+	lookback, err := cliutil.ParseRetain(lookbackStr)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid lookback: "+err.Error())
+		return
+	}
+	since, err := cliutil.ParseTime(body.Since)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid since: "+err.Error())
+		return
+	}
+	until, err := cliutil.ParseTime(body.Until)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid until: "+err.Error())
+		return
+	}
+
+	ctx := r.Context()
+	limit := clampLimit(0, recoverDefaultLimit, recoverMaxLimit)
+	del := event.EventDelete
+
+	// Fetch the parent DELETE events — LIVE index only (cascade recovery never
+	// searches archives; their presence is surfaced as a caveat below). DenyTables/
+	// RedactColumns are attached for consistency but are empty here (a profile would
+	// have been refused above).
+	parentDeletes, err := b.engine.Fetch(ctx, query.Options{
+		Schema:        body.Schema,
+		Table:         body.Table,
+		PKValues:      body.PK,
+		PKValuesIn:    body.PKs,
+		EventType:     &del,
+		Since:         since,
+		Until:         until,
+		Order:         "ASC",
+		Limit:         limit,
+		DenyTables:    s.denyTables,
+		RedactColumns: s.redactCols,
+	})
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "fetch parent deletes: "+err.Error())
+		return
+	}
+
+	var caveats []string
+
+	// Live-only trap (mirrors the CLI): probe archives UNCONDITIONALLY — the #569
+	// over-recovery guard is about whether archived partitions physically EXIST
+	// (so the live index has gaps in the Phase-2 window), orthogonal to whether
+	// this console reads them. Never gate the probe on no-archive.
+	//   - probe failure → coverage unknown (hard caveat)
+	//   - archives exist AND nothing matched live → the parent may itself be
+	//     archived (hard caveat: the dangerous "nothing found" case)
+	//   - archives exist AND parents found → a child whose events were archived
+	//     could be missed → a server log only, NOT a caveat (else every archived
+	//     deployment trips INCOMPLETE on every run).
+	archivesExist := false
+	if archives, aerr := query.ResolveArchiveSources(ctx, b.db); aerr != nil {
+		caveats = append(caveats, "could not determine whether archived partitions exist (probe failed: "+aerr.Error()+"); coverage is unknown")
+	} else if len(archives) > 0 {
+		archivesExist = true
+		if len(parentDeletes) == 0 {
+			caveats = append(caveats, "no parent DELETE matched in the live index, but the index has archived partitions (cascade recovery does NOT search them); the deleted parent may be archived")
+		} else {
+			slog.Warn("console: index has archived partitions, which cascade recovery does NOT search (live index only); a child whose events were archived may be missed")
+		}
+	}
+
+	if len(parentDeletes) >= limit {
+		caveats = append(caveats, fmt.Sprintf("parent DELETE events were capped at the limit (%d); narrow pk/since/until", limit))
+	}
+
+	// Phase-2 baseline fallback — enabled only when the bundle has a baseline
+	// configured (baselineConfigured already folds in --no-archive/profile) AND a
+	// resolver is available to encode each baseline row's PK to match pk_values.
+	var baselineProvider cascade.BaselineProvider
+	if b.baselineConfigured && b.resolver != nil {
+		baselineProvider = &cascadeBaselineProvider{source: b.baselineSrc, resolver: b.resolver}
+	} else if b.baselineConfigured {
+		// Baseline source set but no schema snapshot — degrade to Phase-1 rather than
+		// silently, mirroring the CLI. The capability already reports this as false.
+		slog.Warn("console: baseline configured but no schema snapshot is available; cascade Phase-2 fallback disabled (run `bintrail snapshot`)")
+	}
+
+	var res cascade.Result
+	var synthErr error
+	if len(parentDeletes) > 0 {
+		fks, lerr := cascade.LoadCascadeFKs(ctx, b.db, []string{body.Schema})
+		if lerr != nil {
+			writeJSONError(w, http.StatusInternalServerError, "load FK graph: "+lerr.Error())
+			return
+		}
+		res, synthErr = cascade.SynthesizeVictims(ctx, b.engine, fks, parentDeletes, cascade.Options{
+			Lookback:        lookback,
+			MaxDepth:        maxDepth,
+			Baseline:        baselineProvider,
+			ArchivesPresent: archivesExist,
+		})
+	}
+	caveats = append(caveats, res.Incomplete...)
+	if synthErr != nil {
+		caveats = append(caveats, "an index query failed mid-synthesis; the result is partial: "+synthErr.Error())
+	}
+
+	rows := append(append([]query.ResultRow{}, parentDeletes...), res.Victims...)
+
+	var buf bytes.Buffer
+	// Per-bundle dialect (matches handleRecover). For a MySQL/MariaDB index — the
+	// only flavor cascade recovery supports — this is byte-identical to the CLI's
+	// recovery.New(MySQL).
+	gen := recovery.NewForDialect(b.db, b.resolver, recovery.DialectForIndex(b.db))
+	n, err := cascaderecover.EmitSQL(&buf, gen, rows, res.SetNullRows, b.resolver, cascaderecover.Header{
+		Schema:         body.Schema,
+		Table:          body.Table,
+		Parents:        len(parentDeletes),
+		Children:       len(res.Victims),
+		Caveats:        caveats,
+		BaselineActive: baselineProvider != nil,
+	})
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, recoverCascadeResponse{
+		SQL:            buf.String(),
+		StatementCount: n,
+		VictimCount:    len(res.Victims),
+		SetNullCount:   len(res.SetNullRows),
+		Complete:       len(caveats) == 0 && synthErr == nil,
+		Incomplete:     caveats,
+	})
+}
+
+// cascadeBaselineProvider implements cascade.BaselineProvider over
+// internal/reconstruct: it finds the child table's baseline snapshot, scans it
+// for rows referencing the deleted parent, and encodes each row's PK to match
+// binlog_events.pk_values so the cascade engine can dedup against Phase-1.
+//
+// Ported from internal/cli/recover_cascade.go (internal/cli is not importable
+// from the console binary). Unifying the two copies — and threading RBAC through
+// SynthesizeVictims so the profile guard above can be lifted — is tracked as a
+// follow-up.
+type cascadeBaselineProvider struct {
+	source   string             // local dir or s3:// prefix
+	resolver *metadata.Resolver // for child PK columns
+}
+
+func (p *cascadeBaselineProvider) BaselineChildren(ctx context.Context, schema, table, fkCol, parentPK string, at time.Time, limit int) (cascade.BaselineLookup, bool, error) {
+	path, snap, _, err := reconstruct.FindBaseline(ctx, p.source, schema, table, at)
+	if err != nil {
+		if errors.Is(err, reconstruct.ErrNoBaseline) {
+			return cascade.BaselineLookup{}, false, nil // table not covered → Phase-1 only
+		}
+		return cascade.BaselineLookup{}, false, err
+	}
+
+	tm, err := p.resolver.Resolve(schema, table)
+	if err != nil {
+		return cascade.BaselineLookup{}, false, fmt.Errorf("resolve %s.%s for baseline: %w", schema, table, err)
+	}
+	// The FK filter binds parentPK as a STRING against the baseline column.
+	// DuckDB coerces it exactly for integer/string FK columns, but for
+	// DATETIME/DECIMAL/DATE the string form may not match the stored value and
+	// would silently zero-match. Refuse those (flagged as a coverage gap) rather
+	// than under-recover silently.
+	if !fkFilterSafe(columnDataType(tm, fkCol)) {
+		return cascade.BaselineLookup{}, false, fmt.Errorf(
+			"baseline scan of %s.%s by FK column %q (type %q) is unsupported (string match may not coerce); baseline augmentation skipped",
+			schema, table, fkCol, columnDataType(tm, fkCol))
+	}
+
+	// Fetch one more than the cap so truncation is observable.
+	fetch := 0
+	if limit > 0 {
+		fetch = limit + 1
+	}
+	rows, err := reconstruct.ReadBaselineRows(ctx, path, map[string]string{fkCol: parentPK}, fetch)
+	if err != nil {
+		return cascade.BaselineLookup{}, false, err
+	}
+	trunc := false
+	if limit > 0 && len(rows) > limit {
+		trunc = true
+		rows = rows[:limit]
+	}
+
+	pkCols := tm.PKColumnMetas()
+	out := make([]cascade.BaselineRow, 0, len(rows))
+	for _, rrow := range rows {
+		// Canonicalize PK values the same way the indexer encoded pk_values, so
+		// the dedup key matches a Phase-1 victim's PKValues exactly.
+		canon, cerr := reconstruct.CanonicalizePKMap(rrow, pkCols)
+		if cerr != nil {
+			return cascade.BaselineLookup{}, false, fmt.Errorf("canonicalize baseline PK for %s.%s: %w", schema, table, cerr)
+		}
+		out = append(out, cascade.BaselineRow{
+			PKValues: event.BuildPKValues(pkCols, canon),
+			Row:      rrow,
+		})
+	}
+	return cascade.BaselineLookup{SnapshotTime: snap, Rows: out, Truncated: trunc}, true, nil
+}
+
+func columnDataType(tm *metadata.TableMeta, name string) string {
+	for _, c := range tm.Columns {
+		if c.Name == name {
+			return c.DataType
+		}
+	}
+	return ""
+}
+
+// fkFilterSafe reports whether a string-bound equality filter on a column of
+// this DATA_TYPE coerces exactly in DuckDB (integer + string families). Types
+// where the string form may diverge from the stored value (datetime, decimal,
+// date, …) are excluded so the baseline FK scan never silently zero-matches.
+func fkFilterSafe(dataType string) bool {
+	switch strings.ToLower(strings.TrimSpace(dataType)) {
+	case "int", "integer", "smallint", "tinyint", "mediumint", "bigint",
+		"char", "varchar", "text", "tinytext", "mediumtext", "longtext", "enum", "set":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/console/recover_cascade_integration_test.go
+++ b/internal/console/recover_cascade_integration_test.go
@@ -1,0 +1,203 @@
+//go:build integration
+
+package console
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/query"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// seedCascadeConsole builds a Server over a fresh index holding a parent DELETE
+// plus two child INSERTs that referenced it, and the fk_constraints row marking
+// child.pid -> parent.id ON DELETE CASCADE. The cascade child deletes are NOT
+// indexed — that is the blind spot the endpoint reconstructs. Extra Config is
+// applied via the mutator (e.g. RBAC rules).
+func seedCascadeConsole(t *testing.T, mutate func(*Config)) (*Server, string) {
+	t.Helper()
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	h := time.Now().UTC().Add(-1 * time.Hour).Truncate(time.Hour)
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{h})
+	childTs := h.Add(10 * time.Minute).Format("2006-01-02 15:04:05")
+	parentTs := h.Add(20 * time.Minute).Format("2006-01-02 15:04:05")
+
+	testutil.InsertEvent(t, db, "binlog.000001", 100, 200, childTs, nil,
+		dbName, "child", 1 /*INSERT*/, "10", nil, nil, []byte(`{"id":10,"pid":1}`))
+	testutil.InsertEvent(t, db, "binlog.000001", 200, 300, childTs, nil,
+		dbName, "child", 1 /*INSERT*/, "11", nil, nil, []byte(`{"id":11,"pid":1}`))
+	testutil.InsertEvent(t, db, "binlog.000001", 300, 400, parentTs, nil,
+		dbName, "parent", 3 /*DELETE*/, "1", nil, []byte(`{"id":1}`), nil)
+
+	testutil.MustExec(t, db, `INSERT INTO fk_constraints
+		(snapshot_id, constraint_name, schema_name, table_name, column_name, ordinal_position,
+		 referenced_schema_name, referenced_table_name, referenced_column_name, delete_rule, update_rule)
+		VALUES (1, 'fk_child', ?, 'child', 'pid', 1, ?, 'parent', 'id', 'CASCADE', 'RESTRICT')`,
+		dbName, dbName)
+
+	// A schema snapshot so the bundle's resolver is non-nil (PK columns known) —
+	// required for the Phase-2 gate to engage and harmless to Phase-1 INSERT output.
+	snapTs := h.Format("2006-01-02 15:04:05")
+	testutil.InsertSnapshot(t, db, 1, snapTs, dbName, "parent", "id", 1, "PRI", "int", "NO")
+	testutil.InsertSnapshot(t, db, 1, snapTs, dbName, "child", "id", 1, "PRI", "int", "NO")
+	testutil.InsertSnapshot(t, db, 1, snapTs, dbName, "child", "pid", 2, "", "int", "YES")
+
+	cfg := Config{DB: db, DBName: dbName, Listen: "127.0.0.1:8090", Token: intToken, NoArchive: true}
+	if mutate != nil {
+		mutate(&cfg)
+	}
+	srv, err := New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return srv, dbName
+}
+
+// TestIntegrationRecoverCascade_endToEnd drives POST /api/recover-cascade over a
+// seeded cascade and checks the emitted SQL re-inserts the parent and its two
+// cascade-deleted children inside the FK-checks wrapper, reports complete, and
+// never leaks connection_id (text-only response, no event rows).
+func TestIntegrationRecoverCascade_endToEnd(t *testing.T) {
+	srv, dbName := seedCascadeConsole(t, nil)
+
+	rec, body := doReq(t, srv, "POST", "/api/recover-cascade", `{"schema":"`+dbName+`","table":"parent"}`)
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, body = %s", rec.Code, body)
+	}
+	var resp recoverCascadeResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("decode: %v (body=%s)", err, body)
+	}
+
+	for _, want := range []string{
+		"SET FOREIGN_KEY_CHECKS=0;",
+		"SET FOREIGN_KEY_CHECKS=1;",
+		"Phase-1",
+		"`" + dbName + "`.`parent`",
+		"`" + dbName + "`.`child`",
+	} {
+		if !strings.Contains(resp.SQL, want) {
+			t.Errorf("SQL missing %q\n---\n%s", want, resp.SQL)
+		}
+	}
+	if c := strings.Count(resp.SQL, "`"+dbName+"`.`child`"); c != 2 {
+		t.Errorf("want 2 child INSERTs, got %d\n---\n%s", c, resp.SQL)
+	}
+	if resp.VictimCount != 2 {
+		t.Errorf("victim_count = %d, want 2", resp.VictimCount)
+	}
+	if !resp.Complete {
+		t.Errorf("a clean cascade with no archives should be complete; incomplete=%v", resp.Incomplete)
+	}
+	// connection_id is the paid-forensics boundary: it must never appear in the
+	// cascade response (the response carries SQL + counts only, no event rows).
+	if strings.Contains(string(body), "connection_id") {
+		t.Errorf("connection_id leaked into the cascade response: %s", body)
+	}
+
+	// Capability is reported true (free tier, no profile).
+	_, capsBody := doReq(t, srv, "GET", "/api/capabilities", "")
+	var caps capabilitiesResponse
+	if err := json.Unmarshal(capsBody, &caps); err != nil {
+		t.Fatalf("decode caps: %v", err)
+	}
+	if !caps.RecoverCascade {
+		t.Errorf("capability recover_cascade should be true, got: %s", capsBody)
+	}
+}
+
+// TestIntegrationRecoverCascade_incompleteWithArchives: when archived partitions
+// exist and no parent matches the live index, the result is flagged incomplete
+// (the deleted parent may itself be archived — the dangerous "nothing found" case).
+func TestIntegrationRecoverCascade_incompleteWithArchives(t *testing.T) {
+	srv, dbName := seedCascadeConsole(t, nil)
+	// Register an archived partition (S3-resolvable: a key carrying bintrail_id=)
+	// so the unconditional archive probe reports that archives physically exist.
+	testutil.MustExec(t, srv.cm.boot.db, `INSERT INTO archive_state
+		(bintrail_id, partition_name, local_path, s3_bucket, s3_key)
+		VALUES ('bt', 'p_x', '', 'bucket', 'pfx/bintrail_id=bt/p_x.parquet')`)
+
+	// A PK that matches no live parent → with archives present, that is a hard caveat.
+	rec, body := doReq(t, srv, "POST", "/api/recover-cascade",
+		`{"schema":"`+dbName+`","table":"parent","pk":"999"}`)
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, body = %s", rec.Code, body)
+	}
+	var resp recoverCascadeResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Complete {
+		t.Errorf("result should be INCOMPLETE when archives exist and no parent matched")
+	}
+	if len(resp.Incomplete) == 0 {
+		t.Errorf("incomplete[] should carry the archived-partition caveat")
+	}
+}
+
+// TestIntegrationRecoverCascade_phase2HeaderWhenBaselineConfigured covers the
+// console's Phase-2 GATING decision (the synthesis itself is the CLI's verbatim-
+// ported, CLI-tested provider). With a baseline dir AND a resolver, the handler
+// constructs the provider and the emitted SQL flips to the Phase-2 header — even
+// though the empty baseline dir yields no extra rows (FindBaseline → no baseline
+// → Phase-1). The capability advertises the sub-flag in lockstep.
+func TestIntegrationRecoverCascade_phase2HeaderWhenBaselineConfigured(t *testing.T) {
+	srv, dbName := seedCascadeConsole(t, func(c *Config) {
+		c.NoArchive = false        // required for baselineConfigured
+		c.BaselineDir = t.TempDir() // empty dir → no baseline rows, provider still wired
+	})
+
+	rec, body := doReq(t, srv, "POST", "/api/recover-cascade", `{"schema":"`+dbName+`","table":"parent"}`)
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, body = %s", rec.Code, body)
+	}
+	var resp recoverCascadeResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !strings.Contains(resp.SQL, "Phase-2 baseline fallback ACTIVE") {
+		t.Errorf("a baseline-configured bundle should emit the Phase-2 header\n---\n%s", resp.SQL)
+	}
+
+	// Capability sub-flag is true (baseline + resolver both present) — and equals
+	// the handler's gate, closing the over-advertise seam.
+	_, capsBody := doReq(t, srv, "GET", "/api/capabilities", "")
+	var caps capabilitiesResponse
+	if err := json.Unmarshal(capsBody, &caps); err != nil {
+		t.Fatalf("decode caps: %v", err)
+	}
+	if !caps.RecoverCascadeBaseline {
+		t.Errorf("recover_cascade_baseline should be true with baseline + resolver, got: %s", capsBody)
+	}
+}
+
+// TestIntegrationRecoverCascade_refusedUnderProfile: an active redact/deny
+// profile both flips the capability to false and makes the endpoint 403 (cascade
+// victim synthesis cannot honor redaction — the leak guard).
+func TestIntegrationRecoverCascade_refusedUnderProfile(t *testing.T) {
+	// The guard fires on any redact/deny rule (it checks presence, not scope), so
+	// the schema literal here need not match the generated test DB name.
+	srv, dbName := seedCascadeConsole(t, func(c *Config) {
+		c.NoArchive = false
+		c.RedactColumns = []query.SchemaTableColumn{{Schema: "app", Table: "child", Column: "pid"}}
+	})
+
+	rec, body := doReq(t, srv, "POST", "/api/recover-cascade", `{"schema":"`+dbName+`","table":"parent"}`)
+	if rec.Code != 403 {
+		t.Fatalf("status = %d, want 403 (body=%s)", rec.Code, body)
+	}
+
+	_, capsBody := doReq(t, srv, "GET", "/api/capabilities", "")
+	var caps capabilitiesResponse
+	if err := json.Unmarshal(capsBody, &caps); err != nil {
+		t.Fatalf("decode caps: %v", err)
+	}
+	if caps.RecoverCascade {
+		t.Errorf("capability recover_cascade must be false under an RBAC profile, got: %s", capsBody)
+	}
+}

--- a/internal/console/recover_cascade_test.go
+++ b/internal/console/recover_cascade_test.go
@@ -1,0 +1,115 @@
+package console
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/query"
+)
+
+// TestRecoverCascade_validation covers the request-validation branches that
+// reject before any DB work — so a nil-DB boot server is enough.
+func TestRecoverCascade_validation(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want int
+	}{
+		{"missing schema+table", `{}`, http.StatusBadRequest},
+		{"missing table", `{"schema":"app"}`, http.StatusBadRequest},
+		{"pk and pks together", `{"schema":"app","table":"parent","pk":"1","pks":["2"]}`, http.StatusBadRequest},
+		{"max_depth negative", `{"schema":"app","table":"parent","max_depth":-1}`, http.StatusBadRequest},
+		{"bad lookback", `{"schema":"app","table":"parent","lookback":"nope"}`, http.StatusBadRequest},
+		{"bad since", `{"schema":"app","table":"parent","since":"not-a-time"}`, http.StatusBadRequest},
+		{"invalid JSON", `{bad`, http.StatusBadRequest},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s := newBootServer(nil)
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest("POST", "/api/recover-cascade", strings.NewReader(c.body))
+			s.handleRecoverCascade(rec, req)
+			if rec.Code != c.want {
+				t.Errorf("code = %d, want %d (body=%s)", rec.Code, c.want, rec.Body.String())
+			}
+		})
+	}
+}
+
+// TestRecoverCascade_refusedUnderRBAC locks the leak guard: with a redact/deny
+// profile active the endpoint refuses BEFORE touching the DB (the bundle's db is
+// nil here — a 403, not a panic, proves the guard runs first), because cascade
+// victim synthesis cannot honor redaction.
+func TestRecoverCascade_refusedUnderRBAC(t *testing.T) {
+	s := newBootServer(nil)
+	s.redactCols = []query.SchemaTableColumn{{Schema: "app", Table: "child", Column: "ssn"}}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/recover-cascade", strings.NewReader(`{"schema":"app","table":"parent"}`))
+	s.handleRecoverCascade(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("code = %d, want 403 (body=%s)", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "RBAC") {
+		t.Errorf("403 body should explain the RBAC refusal, got: %s", rec.Body.String())
+	}
+}
+
+// TestRecoverCascadeCapability exercises the gate the frontend reads: recover_cascade
+// is true by default (free tier), false under an RBAC profile, and
+// recover_cascade_baseline mirrors the per-server baseline configuration.
+func TestRecoverCascadeCapability(t *testing.T) {
+	get := func(s *Server) capabilitiesResponse {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/api/capabilities", nil)
+		s.handleCapabilities(rec, req)
+		var resp capabilitiesResponse
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode capabilities: %v (body=%s)", err, rec.Body.String())
+		}
+		return resp
+	}
+
+	t.Run("default available, no baseline", func(t *testing.T) {
+		caps := get(newBootServer(nil))
+		if !caps.RecoverCascade {
+			t.Error("recover_cascade should be true by default (free tier)")
+		}
+		if caps.RecoverCascadeBaseline {
+			t.Error("recover_cascade_baseline should be false without a baseline")
+		}
+	})
+
+	t.Run("false under RBAC profile", func(t *testing.T) {
+		s := newBootServer(nil)
+		s.redactCols = []query.SchemaTableColumn{{Schema: "app", Table: "child", Column: "ssn"}}
+		if get(s).RecoverCascade {
+			t.Error("recover_cascade must be false while a redaction profile is active")
+		}
+	})
+
+	t.Run("baseline sub-flag true with baseline + resolver", func(t *testing.T) {
+		s := newBootServer(nil)
+		s.cm.boot.baselineConfigured = true
+		s.cm.boot.resolver = metadata.NewResolverFromTables(1, nil)
+		if !get(s).RecoverCascadeBaseline {
+			t.Error("recover_cascade_baseline should be true when baseline + resolver are present")
+		}
+	})
+
+	t.Run("baseline sub-flag false when resolver nil (no snapshot)", func(t *testing.T) {
+		// baselineConfigured can be true with resolver==nil (baseline dir set but
+		// `bintrail snapshot` never run); the handler degrades to Phase-1 there, so
+		// the capability must NOT over-advertise Phase-2 — it gates on resolver too.
+		s := newBootServer(nil)
+		s.cm.boot.baselineConfigured = true // resolver stays nil
+		if get(s).RecoverCascadeBaseline {
+			t.Error("recover_cascade_baseline must be false without a resolver (would over-advertise Phase-2)")
+		}
+	})
+}

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -309,6 +309,7 @@ func (s *Server) buildHandler() http.Handler {
 	api.HandleFunc("GET /api/schemas", s.handleSchemas)
 	api.HandleFunc("GET /api/events", s.handleEvents)
 	api.HandleFunc("POST /api/recover", s.handleRecover)
+	api.HandleFunc("POST /api/recover-cascade", s.handleRecoverCascade)
 	api.HandleFunc("GET /api/capabilities", s.handleCapabilities)
 	api.HandleFunc("GET /api/reconstruct", s.handleReconstruct)
 	// Storage surfaces (read-only): the selected server's baseline snapshot


### PR DESCRIPTION
closes #579

## Summary

Slice B of console cascade (#577): surface **recover-cascade** in the read-only web console (free `query_explorer` tier), wiring `cascade.LoadCascadeFKs` + `SynthesizeVictims` + the Slice-A shared emitter (`cascaderecover.EmitSQL`) over the per-server bundle. Like `/api/recover`, it **never executes SQL** — text + structured coverage only.

- **`POST /api/recover-cascade`** (`internal/console/recover_cascade.go`): `resolveOr` → decode `recoverCascadeRequest` {schema, table, pk/pks, since/until, lookback, max_depth, allow_incomplete} → validate → fetch parent DELETEs **live-only** via `b.engine` → synthesize victims → `EmitSQL` via `recovery.NewForDialect` → `{sql, statement_count, victim_count, set_null_count, complete, incomplete}`.
- **#569 over-recovery guard**: `cascade.Options.ArchivesPresent` is probed **unconditionally** (`query.ResolveArchiveSources`) — it reports whether archived partitions *physically exist* (live-index gaps in the Phase-2 window), orthogonal to whether the console reads archives. Never gated on no-archive (that would re-open #569).
- **Phase-2 baseline**: a ported `cascadeBaselineProvider` is wired only when the bundle has a baseline configured AND a resolver is available.
- **Capability**: `recover_cascade` (free tier, process-global) + `recover_cascade_baseline` (per-server, mirrors `reconstruct`).

## Open-core / safety

- **No `connection_id` leak**: the response is SQL text + counts only — never event rows — so the paid-forensics boundary holds (reversal SQL is built from row images, which don't embed `connection_id`). Pinned by an integration assert.
- **RBAC leak guard**: cascade victim synthesis bypasses the bundle's `DenyTables`/`RedactColumns` (its internal child fetches build plain `query.Options`), so a redacted column / denied table could surface in a victim's reversal SQL — a leak the normal `recover` endpoint does **not** have (its fetched rows are redacted). Until RBAC is threaded through `SynthesizeVictims`, recover-cascade is **refused** (capability `false` + `403`) whenever a redact/deny profile is active. (Honors the issue's "honor profile" requirement.)

## Generator choice

Uses `recovery.NewForDialect(b.db, b.resolver, DialectForIndex(b.db))` (console convention). For a MySQL/MariaDB index — the only flavor cascade recovery supports — this is **byte-identical** to the CLI's `recovery.New` (both `MySQLDialect`), so CLI/console parity holds where it matters. PG is degenerate either way (the `SET FOREIGN_KEY_CHECKS` wrapper is MySQL syntax) — a documented limitation, not engineered.

## Scope (Occam's razor)

**Console-only.** The CLI is untouched; the cascade baseline provider is **ported** (not extracted to a shared package) and the caveat assembly is **inlined**. The Phase-2 *synthesis* is verbatim-ported from the CLI (which fully tests it in `TestRecoverCascade_phase2BaselineRecoversUntouchedChild`); the console tests cover its **gating**. Unifying the duplicated provider/caveats and threading RBAC through `SynthesizeVictims` (to lift the guard) are deferred to a follow-up.

## Test plan

- [x] Unit: validation branches, RBAC `403`, capability gating (`go test ./internal/console/`)
- [x] Integration: parent+2-children e2e, INCOMPLETE-with-archives, refused-under-profile, `connection_id`-free body (`go test -tags integration ./internal/console/`)
- [x] `go build ./...`; full unit suite green (one unrelated `internal/shim` handshake flake, passes in isolation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)