### PR TITLE
feat(pg): durable lost-slot record + loud "events permanently lost" badge in status (#532 part 2)

### DIFF
--- a/internal/pgcapture/slot.go
+++ b/internal/pgcapture/slot.go
@@ -102,9 +102,13 @@ var ErrWALLevelNotLogical = errors.New("wal_level is not 'logical'")
 // (wal_status=lost) or dropped. ensureSlot wraps them (preserving its descriptive
 // message); the consumer (pgstreamrun.One) matches them with errors.Is to durably
 // record the permanent loss so index-only `status` can show it after the process exits.
+// Base strings are bare (no "pgcapture:" prefix) because ensureSlot wraps them with a
+// "pgcapture: ...: %w" message; doubling the prefix would stutter, and the wrapped text
+// is stored verbatim in stream_state.gap_lost_detail / shown in the status badge. Mirrors
+// ErrWALLevelNotLogical's bare base string.
 var (
-	ErrSlotLost            = errors.New("pgcapture: replication slot invalidated (wal_status=lost)")
-	ErrSlotMissingOnResume = errors.New("pgcapture: replication slot missing on resume")
+	ErrSlotLost            = errors.New("replication slot invalidated (wal_status=lost)")
+	ErrSlotMissingOnResume = errors.New("replication slot missing on resume")
 )
 
 // checkWALLevel verifies the (global) wal_level is 'logical' — logical replication

--- a/internal/pgcapture/slot.go
+++ b/internal/pgcapture/slot.go
@@ -97,6 +97,16 @@ func validateReplicaIdentity(ctx context.Context, conn *pgx.Conn, publication st
 // (restart-with-config vs retry) without mislabeling a transient blip as a config bug.
 var ErrWALLevelNotLogical = errors.New("wal_level is not 'logical'")
 
+// ErrSlotLost and ErrSlotMissingOnResume mark the two fatal resume conditions where
+// the WAL behind the saved checkpoint is irrecoverably gone — the slot was invalidated
+// (wal_status=lost) or dropped. ensureSlot wraps them (preserving its descriptive
+// message); the consumer (pgstreamrun.One) matches them with errors.Is to durably
+// record the permanent loss so index-only `status` can show it after the process exits.
+var (
+	ErrSlotLost            = errors.New("pgcapture: replication slot invalidated (wal_status=lost)")
+	ErrSlotMissingOnResume = errors.New("pgcapture: replication slot missing on resume")
+)
+
 // checkWALLevel verifies the (global) wal_level is 'logical' — logical replication
 // is impossible otherwise. A value-wrong result wraps ErrWALLevelNotLogical; a query
 // failure does not.
@@ -201,12 +211,12 @@ func ensureSlot(ctx context.Context, replConn *pgconn.PgConn, queryConn *pgx.Con
 
 	// A 'lost' slot is unusable regardless of mode — its WAL has been removed.
 	if found && walStatus == WalStatusLost {
-		return 0, fmt.Errorf("pgcapture: replication slot %q is invalidated (wal_status=lost; max_slot_wal_keep_size exceeded) — the WAL it needs is gone; re-baseline rather than resume", slotName)
+		return 0, fmt.Errorf("pgcapture: replication slot %q is invalidated (wal_status=lost; max_slot_wal_keep_size exceeded) — the WAL it needs is gone; re-baseline rather than resume: %w", slotName, ErrSlotLost)
 	}
 
 	if expectExisting {
 		if !found {
-			return 0, fmt.Errorf("pgcapture: resuming from a saved checkpoint but replication slot %q no longer exists — the WAL since the checkpoint is lost; re-baseline (creating a fresh slot would silently skip data)", slotName)
+			return 0, fmt.Errorf("pgcapture: resuming from a saved checkpoint but replication slot %q no longer exists — the WAL since the checkpoint is lost; re-baseline (creating a fresh slot would silently skip data): %w", slotName, ErrSlotMissingOnResume)
 		}
 		return savedLSN, nil
 	}

--- a/internal/pgstreamrun/persist_integration_test.go
+++ b/internal/pgstreamrun/persist_integration_test.go
@@ -1,0 +1,70 @@
+//go:build integration
+
+package pgstreamrun
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestPersistSlotLostPG pins the #532 upsert contract (white-box, MySQL index only):
+//   - with NO stream_state row (a slot detected lost before the first checkpoint), the
+//     stamp must SEED a complete row — a bare UPDATE would match zero rows and record
+//     nothing (the false-negative the CRITICAL review caught);
+//   - with an existing checkpoint row, the stamp must set gap_lost_* WITHOUT clobbering
+//     the saved position/checkpoint.
+func TestPersistSlotLostPG(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	ctx := context.Background()
+	indexDB, _ := testutil.CreateTestDB(t)
+	if err := indexer.CreateIndexTables(ctx, indexDB, 4, false, nil); err != nil {
+		t.Fatalf("CreateIndexTables: %v", err)
+	}
+	logger := slog.New(slog.DiscardHandler)
+
+	// (1) No row yet → the stamp must seed one.
+	persistSlotLostPG(indexDB, 51, "replication slot invalidated (wal_status=lost)", logger)
+
+	var gapAt sql.NullTime
+	var gapDetail sql.NullString
+	var serverID uint32
+	var mode string
+	if err := indexDB.QueryRowContext(ctx,
+		"SELECT mode, server_id, gap_lost_at, gap_lost_detail FROM stream_state WHERE id=1").
+		Scan(&mode, &serverID, &gapAt, &gapDetail); err != nil {
+		t.Fatalf("no row was seeded by persistSlotLostPG (the CRITICAL no-op): %v", err)
+	}
+	if !gapAt.Valid || gapDetail.String != "replication slot invalidated (wal_status=lost)" {
+		t.Errorf("seeded row missing gap_lost: at=%v detail=%q", gapAt, gapDetail.String)
+	}
+	if serverID != 51 || mode != "gtid" {
+		t.Errorf("seeded row has wrong NOT NULL fields: server_id=%d mode=%q", serverID, mode)
+	}
+
+	// (2) Existing checkpoint row → the stamp must preserve the position/checkpoint and
+	// only update gap_lost_*. Write a real checkpoint first.
+	if _, err := indexDB.ExecContext(ctx,
+		`UPDATE stream_state SET binlog_position=999, binlog_file='5/ABC', gap_lost_at=NULL, gap_lost_detail=NULL WHERE id=1`); err != nil {
+		t.Fatalf("seed checkpoint: %v", err)
+	}
+	persistSlotLostPG(indexDB, 51, "lost again", logger)
+
+	var pos uint64
+	var file string
+	if err := indexDB.QueryRowContext(ctx,
+		"SELECT binlog_position, binlog_file, gap_lost_detail FROM stream_state WHERE id=1").
+		Scan(&pos, &file, &gapDetail); err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if pos != 999 || file != "5/ABC" {
+		t.Errorf("stamp clobbered the checkpoint position: pos=%d file=%q (want 999 / 5/ABC)", pos, file)
+	}
+	if gapDetail.String != "lost again" {
+		t.Errorf("gap_lost_detail not updated on the existing row: %q", gapDetail.String)
+	}
+}

--- a/internal/pgstreamrun/pgstreamrun.go
+++ b/internal/pgstreamrun/pgstreamrun.go
@@ -156,7 +156,7 @@ func One(ctx context.Context, cfg Config) error {
 		// fatal error) so index-only `status` shows the loud badge even after we exit —
 		// otherwise the only trace is this one log line. Reuses the gap_lost_* columns.
 		if errors.Is(capErr, pgcapture.ErrSlotLost) || errors.Is(capErr, pgcapture.ErrSlotMissingOnResume) {
-			persistSlotLostPG(indexDB, capErr.Error(), logger)
+			persistSlotLostPG(indexDB, cfg.ServerID, capErr.Error(), logger)
 		}
 		return capErr
 	}
@@ -168,15 +168,35 @@ func One(ctx context.Context, cfg Config) error {
 // persistSlotLostPG durably records a lost/missing replication slot in the shared
 // stream_state.gap_lost_at/gap_lost_detail columns — the same machinery the MySQL path
 // uses for an unfillable binlog gap (streamrun.persistGapAutoAdvance), so index-only
-// `status` shows the loud "events permanently lost" badge after the process exits.
+// `status` shows the loud permanent-loss banner after the process exits.
 //
-// This is best-effort, layered on an ALREADY-fatal lost-slot error (no checkpoint is
-// advanced here — we are aborting): if the stamp fails we log and let the original
-// fatal error propagate, never masking it. The detail is the lost-slot error text,
-// which names the slot but carries no DSN/secret.
-func persistSlotLostPG(db *sql.DB, detail string, logger *slog.Logger) {
-	if _, err := db.Exec(`UPDATE stream_state SET gap_lost_at = UTC_TIMESTAMP(), gap_lost_detail = ? WHERE id = 1`, detail); err != nil {
-		logger.Error("pgstreamrun: could not persist lost-slot record; `status` will not show the permanent-loss badge",
+// It is an UPSERT, not a bare UPDATE: a slot can be detected lost on the very FIRST
+// ensureSlot — before any commit has written the stream_state row — so an
+// `UPDATE ... WHERE id=1` would match zero rows and silently record nothing (the exact
+// false-negative this slice prevents). The INSERT seeds a minimal but complete row
+// (mode/flavor/server_id/last_checkpoint are NOT NULL); ON DUPLICATE KEY preserves an
+// existing checkpoint and only stamps the loss (it does not touch last_checkpoint or
+// the position columns — saveCheckpointPG owns those, so a real checkpoint survives).
+//
+// Best-effort, layered on an ALREADY-fatal lost-slot error (no checkpoint is advanced —
+// we are aborting): if the stamp fails we log and let the original fatal error
+// propagate, never masking it. The detail is the lost-slot error text, which names the
+// slot but carries no DSN/secret.
+//
+// Mid-stream invalidation is NOT routed here: once streaming, a lost slot surfaces as a
+// raw replication-protocol error without the sentinel, so One returns it unstamped; the
+// supervisor re-invokes One, and ensureSlot re-detects the lost slot at startup, which
+// reaches this stamp on that next run.
+func persistSlotLostPG(db *sql.DB, serverID uint32, detail string, logger *slog.Logger) {
+	_, err := db.Exec(`
+		INSERT INTO stream_state (id, mode, flavor, server_id, last_checkpoint, gap_lost_at, gap_lost_detail)
+		VALUES (1, 'gtid', ?, ?, UTC_TIMESTAMP(), UTC_TIMESTAMP(), ?)
+		ON DUPLICATE KEY UPDATE
+			gap_lost_at     = UTC_TIMESTAMP(),
+			gap_lost_detail = VALUES(gap_lost_detail)`,
+		pgFlavor, serverID, detail)
+	if err != nil {
+		logger.Error("pgstreamrun: could not persist lost-slot record; `status` will not show the permanent-loss banner",
 			"error", err, "detail", detail)
 	}
 }

--- a/internal/pgstreamrun/pgstreamrun.go
+++ b/internal/pgstreamrun/pgstreamrun.go
@@ -151,11 +151,34 @@ func One(ctx context.Context, cfg Config) error {
 		return loopErr
 	}
 	if capErr != nil && !errors.Is(capErr, context.Canceled) {
+		// A lost/missing slot on resume means WAL behind the checkpoint is gone for
+		// good. Durably record the permanent loss (best-effort, layered on an already
+		// fatal error) so index-only `status` shows the loud badge even after we exit —
+		// otherwise the only trace is this one log line. Reuses the gap_lost_* columns.
+		if errors.Is(capErr, pgcapture.ErrSlotLost) || errors.Is(capErr, pgcapture.ErrSlotMissingOnResume) {
+			persistSlotLostPG(indexDB, capErr.Error(), logger)
+		}
 		return capErr
 	}
 	logger.Info("pgstreamrun: stopped", "events_indexed", state.eventsIndexed,
 		"last_lsn", pglogrepl.LSN(state.lsn))
 	return nil
+}
+
+// persistSlotLostPG durably records a lost/missing replication slot in the shared
+// stream_state.gap_lost_at/gap_lost_detail columns — the same machinery the MySQL path
+// uses for an unfillable binlog gap (streamrun.persistGapAutoAdvance), so index-only
+// `status` shows the loud "events permanently lost" badge after the process exits.
+//
+// This is best-effort, layered on an ALREADY-fatal lost-slot error (no checkpoint is
+// advanced here — we are aborting): if the stamp fails we log and let the original
+// fatal error propagate, never masking it. The detail is the lost-slot error text,
+// which names the slot but carries no DSN/secret.
+func persistSlotLostPG(db *sql.DB, detail string, logger *slog.Logger) {
+	if _, err := db.Exec(`UPDATE stream_state SET gap_lost_at = UTC_TIMESTAMP(), gap_lost_detail = ? WHERE id = 1`, detail); err != nil {
+		logger.Error("pgstreamrun: could not persist lost-slot record; `status` will not show the permanent-loss badge",
+			"error", err, "detail", detail)
+	}
 }
 
 // streamLoopPG batches row events into the indexer and checkpoints the durable LSN.

--- a/internal/pgstreamrun/pgstreamrun_integration_test.go
+++ b/internal/pgstreamrun/pgstreamrun_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -15,9 +16,11 @@ import (
 
 	"github.com/dbtrail/dbtrail/internal/event"
 	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/pgcapture"
 	"github.com/dbtrail/dbtrail/internal/pgstreamrun"
 	"github.com/dbtrail/dbtrail/internal/query"
 	"github.com/dbtrail/dbtrail/internal/recovery"
+	"github.com/dbtrail/dbtrail/internal/status"
 	"github.com/dbtrail/dbtrail/internal/testutil"
 )
 
@@ -150,6 +153,109 @@ func TestOne_EndToEnd_PostgresToIndexToRecovery(t *testing.T) {
 	}
 	if !strings.Contains(buf.String(), bigVal) {
 		t.Error("reversal SQL does not contain the TOAST value — it did not round-trip into recovery")
+	}
+}
+
+// TestOne_LostSlotResume_PersistsLossBadge is the #532 slice-4 proof: when a resume
+// finds the replication slot gone (WAL behind the checkpoint is irrecoverable), One
+// returns the ErrSlotMissingOnResume sentinel AND durably records the permanent loss
+// in stream_state.gap_lost_at, so index-only `status` shows the loud badge after the
+// process has exited. (Dropping the slot is the deterministic trigger; a wal_status=lost
+// invalidation takes the same ErrSlotLost → persist path.)
+func TestOne_LostSlotResume_PersistsLossBadge(t *testing.T) {
+	pgDSN := testutil.SkipIfNoPostgres(t)
+	testutil.SkipIfNoMySQL(t)
+	ctx := context.Background()
+
+	indexDB, dbName := testutil.CreateTestDB(t)
+	indexDSN := testutil.BaseDSN() + "/" + dbName
+
+	const slot = "bintrail_lostresume_it"
+	const pub = "bintrail_lostresume_it_pub"
+	const tbl = "lostresume_it_t"
+
+	pg, err := pgx.Connect(ctx, pgDSN)
+	if err != nil {
+		t.Fatalf("connect PG: %v", err)
+	}
+	t.Cleanup(func() { pg.Close(context.Background()) })
+
+	dropAll := func() {
+		bg := context.Background()
+		_, _ = pg.Exec(bg, "DROP PUBLICATION IF EXISTS "+pub)
+		_, _ = pg.Exec(bg, "DROP TABLE IF EXISTS "+tbl)
+		_, _ = pg.Exec(bg, "SELECT pg_drop_replication_slot($1) WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name=$1)", slot)
+	}
+	dropAll()
+	t.Cleanup(dropAll)
+
+	mustExec := func(sql string) {
+		t.Helper()
+		if _, err := pg.Exec(ctx, sql); err != nil {
+			t.Fatalf("exec %q: %v", sql, err)
+		}
+	}
+	mustExec(fmt.Sprintf("CREATE TABLE %s (id int PRIMARY KEY, v text)", tbl))
+	mustExec(fmt.Sprintf("ALTER TABLE %s REPLICA IDENTITY FULL", tbl))
+	mustExec(fmt.Sprintf("CREATE PUBLICATION %s FOR TABLE %s", pub, tbl))
+
+	cfg := pgstreamrun.Config{
+		IndexDSN: indexDSN, ReplDSN: replDSN(pgDSN), QueryDSN: pgDSN,
+		SlotName: slot, Publication: pub, ServerID: 51,
+		Tables: "public." + tbl, BatchSize: 100, Checkpoint: 200 * time.Millisecond,
+	}
+
+	// ── First run: create the slot, index a row, save a checkpoint, then stop. ──
+	runCtx, cancel := context.WithCancel(ctx)
+	runErr := make(chan error, 1)
+	go func() { runErr <- pgstreamrun.One(runCtx, cfg) }()
+	waitFor(t, 15*time.Second, func() bool {
+		var active bool
+		if err := pg.QueryRow(ctx, "SELECT active FROM pg_replication_slots WHERE slot_name=$1", slot).Scan(&active); err != nil {
+			return false
+		}
+		return active
+	}, "replication slot active")
+	mustExec(fmt.Sprintf("INSERT INTO %s VALUES (1, 'a')", tbl))
+	waitFor(t, 15*time.Second, func() bool {
+		var n int
+		if err := indexDB.QueryRow("SELECT COUNT(*) FROM binlog_events WHERE table_name = ?", tbl).Scan(&n); err != nil {
+			return false
+		}
+		return n >= 1 // a flush happened → a checkpoint row exists in stream_state
+	}, "first row indexed (checkpoint saved)")
+	cancel()
+	if err := <-runErr; err != nil {
+		t.Fatalf("first run returned error: %v", err)
+	}
+
+	// ── Drop the slot: the WAL behind the saved checkpoint is now gone. ──
+	mustExec(fmt.Sprintf("SELECT pg_drop_replication_slot('%s')", slot))
+
+	// ── Resume: One must fail loud with ErrSlotMissingOnResume (not silently create a
+	// fresh slot that skips data) AND record the permanent loss. ──
+	resumeCtx, resumeCancel := context.WithTimeout(ctx, 20*time.Second)
+	defer resumeCancel()
+	err = pgstreamrun.One(resumeCtx, cfg)
+	if !errors.Is(err, pgcapture.ErrSlotMissingOnResume) {
+		t.Fatalf("resume error = %v, want ErrSlotMissingOnResume", err)
+	}
+
+	// The permanent-loss record is durable in the index.
+	st, err := status.LoadStreamState(ctx, indexDB)
+	if err != nil {
+		t.Fatalf("LoadStreamState: %v", err)
+	}
+	if st == nil || !st.GapLostAt.Valid {
+		t.Fatalf("gap_lost_at not set after a lost-slot resume: %+v", st)
+	}
+
+	// And index-only status (the same data the process would show after exiting)
+	// renders the loud badge.
+	var buf bytes.Buffer
+	status.WriteStatus(&buf, nil, nil, nil, nil, nil, st)
+	if !strings.Contains(buf.String(), "EVENTS PERMANENTLY LOST") {
+		t.Errorf("status does not show the permanent-loss badge:\n%s", buf.String())
 	}
 }
 

--- a/internal/pgstreamrun/pgstreamrun_integration_test.go
+++ b/internal/pgstreamrun/pgstreamrun_integration_test.go
@@ -259,6 +259,101 @@ func TestOne_LostSlotResume_PersistsLossBadge(t *testing.T) {
 	}
 }
 
+// TestOne_LostSlot_FirstRun_SeedsLossBadge is the CRITICAL-review repro: a slot detected
+// lost (wal_status=lost) on a run with NO prior checkpoint row must still record the
+// permanent loss — persistSlotLostPG UPSERTs, seeding a complete stream_state row, so the
+// badge appears (a bare UPDATE would match zero rows and be silent). It also covers the
+// ErrSlotLost arm end-to-end through One (the ErrSlotMissingOnResume arm is the resume
+// test above). max_slot_wal_keep_size is server-wide; CI runs PG packages -p 1 and this
+// test is non-parallel, and t.Cleanup resets it even on failure.
+func TestOne_LostSlot_FirstRun_SeedsLossBadge(t *testing.T) {
+	pgDSN := testutil.SkipIfNoPostgres(t)
+	testutil.SkipIfNoMySQL(t)
+	ctx := context.Background()
+
+	indexDB, dbName := testutil.CreateTestDB(t)
+	indexDSN := testutil.BaseDSN() + "/" + dbName
+
+	const slot = "bintrail_lostfirst_it"
+	const pub = "bintrail_lostfirst_it_pub"
+	const tbl = "lostfirst_it_t"
+
+	pg, err := pgx.Connect(ctx, pgDSN)
+	if err != nil {
+		t.Fatalf("connect PG: %v", err)
+	}
+	t.Cleanup(func() { pg.Close(context.Background()) })
+
+	mustExec := func(sql string) {
+		t.Helper()
+		if _, err := pg.Exec(ctx, sql); err != nil {
+			t.Fatalf("exec %q: %v", sql, err)
+		}
+	}
+	t.Cleanup(func() {
+		bg := context.Background()
+		_, _ = pg.Exec(bg, "ALTER SYSTEM RESET max_slot_wal_keep_size")
+		_, _ = pg.Exec(bg, "SELECT pg_reload_conf()")
+		_, _ = pg.Exec(bg, "DROP PUBLICATION IF EXISTS "+pub)
+		_, _ = pg.Exec(bg, "DROP TABLE IF EXISTS "+tbl)
+		_, _ = pg.Exec(bg, "SELECT pg_drop_replication_slot($1) WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name=$1)", slot)
+	})
+	// Start clean.
+	_, _ = pg.Exec(ctx, "DROP PUBLICATION IF EXISTS "+pub)
+	_, _ = pg.Exec(ctx, "DROP TABLE IF EXISTS "+tbl)
+	_, _ = pg.Exec(ctx, "SELECT pg_drop_replication_slot($1) WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name=$1)", slot)
+
+	mustExec(fmt.Sprintf("CREATE TABLE %s (id serial PRIMARY KEY, pad text)", tbl))
+	mustExec(fmt.Sprintf("ALTER TABLE %s REPLICA IDENTITY FULL", tbl))
+	mustExec(fmt.Sprintf("CREATE PUBLICATION %s FOR TABLE %s", pub, tbl))
+
+	// Bound retention, create an idle slot, churn WAL past the bound → next checkpoint
+	// invalidates it (wal_status=lost).
+	mustExec("ALTER SYSTEM SET max_slot_wal_keep_size = '1MB'")
+	mustExec("SELECT pg_reload_conf()")
+	mustExec(fmt.Sprintf("SELECT pg_create_logical_replication_slot('%s', 'pgoutput')", slot))
+	lost := false
+	for i := 0; i < 10 && !lost; i++ {
+		mustExec(fmt.Sprintf("INSERT INTO %s (pad) SELECT repeat('x', 900) FROM generate_series(1, 4000)", tbl))
+		mustExec("SELECT pg_switch_wal()")
+		mustExec("CHECKPOINT")
+		var status string
+		if err := pg.QueryRow(ctx, "SELECT wal_status FROM pg_replication_slots WHERE slot_name=$1", slot).Scan(&status); err != nil {
+			t.Fatalf("read wal_status: %v", err)
+		}
+		lost = status == "lost"
+	}
+	if !lost {
+		t.Skip("could not drive the slot to wal_status=lost on this server; skipping")
+	}
+
+	// First run with NO prior checkpoint row: ensureSlot detects the lost slot and One
+	// must fail loud AND seed the loss record (the upsert, not a no-op UPDATE).
+	runCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+	err = pgstreamrun.One(runCtx, pgstreamrun.Config{
+		IndexDSN: indexDSN, ReplDSN: replDSN(pgDSN), QueryDSN: pgDSN,
+		SlotName: slot, Publication: pub, ServerID: 52,
+		Tables: "public." + tbl, BatchSize: 100, Checkpoint: 200 * time.Millisecond,
+	})
+	if !errors.Is(err, pgcapture.ErrSlotLost) {
+		t.Fatalf("first-run lost slot: One returned %v, want ErrSlotLost", err)
+	}
+
+	st, err := status.LoadStreamState(ctx, indexDB)
+	if err != nil {
+		t.Fatalf("LoadStreamState: %v", err)
+	}
+	if st == nil || !st.GapLostAt.Valid {
+		t.Fatalf("gap_lost_at not seeded after a first-run lost slot (the CRITICAL no-op): %+v", st)
+	}
+	var buf bytes.Buffer
+	status.WriteStatus(&buf, nil, nil, nil, nil, nil, st)
+	if !strings.Contains(buf.String(), "EVENTS PERMANENTLY LOST") {
+		t.Errorf("status does not show the permanent-loss badge:\n%s", buf.String())
+	}
+}
+
 // TestOne_CapturerFailureSurfaces proves the cancellation bridge in One: when the
 // capturer fails on its own (here: a non-existent publication makes cap.Run return
 // before streaming), One must surface that error PROMPTLY rather than hang forever

--- a/internal/status/legacy_stream_state_integration_test.go
+++ b/internal/status/legacy_stream_state_integration_test.go
@@ -1,0 +1,49 @@
+//go:build integration
+
+package status_test
+
+import (
+	"context"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/status"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestLoadStreamState_LegacyIndexMissingGapColumns pins the #586 graceful fallback: a
+// pre-cascade index lacking gap_lost_at/gap_lost_detail — read before any migrating
+// command ran EnsureSchema (the console never migrates registry DSNs) — must NOT error
+// `status`. LoadStreamState falls back to the base columns and reports no loss record.
+func TestLoadStreamState_LegacyIndexMissingGapColumns(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	ctx := context.Background()
+	db, _ := testutil.CreateTestDB(t)
+	if err := indexer.CreateIndexTables(ctx, db, 4, false, nil); err != nil {
+		t.Fatalf("CreateIndexTables: %v", err)
+	}
+	// Simulate a legacy index: drop the columns the cascade-recovery work added.
+	if _, err := db.ExecContext(ctx, "ALTER TABLE stream_state DROP COLUMN gap_lost_at, DROP COLUMN gap_lost_detail"); err != nil {
+		t.Fatalf("drop gap columns: %v", err)
+	}
+	if _, err := db.ExecContext(ctx,
+		"INSERT INTO stream_state (id, mode, server_id, last_checkpoint) VALUES (1, 'gtid', 7, UTC_TIMESTAMP())"); err != nil {
+		t.Fatalf("seed base row: %v", err)
+	}
+
+	st, err := status.LoadStreamState(ctx, db)
+	if err != nil {
+		t.Fatalf("LoadStreamState must not error on a legacy index, got: %v", err)
+	}
+	if st == nil {
+		t.Fatal("expected the base row, got nil")
+	}
+	if st.ServerID != 7 || st.Mode != "gtid" {
+		t.Errorf("base columns not loaded after fallback: %+v", st)
+	}
+	if st.GapLostAt.Valid {
+		t.Errorf("a legacy index has no gap-loss record; GapLostAt should be invalid, got %v", st.GapLostAt)
+	}
+}

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"text/tabwriter"
 	"time"
+
+	"github.com/go-sql-driver/mysql"
 )
 
 // IndexStateRow holds one row from the index_state table.
@@ -85,7 +87,9 @@ type StreamStateInfo struct {
 	// GapLostAt / GapLostDetail record that the stream permanently lost data it could
 	// not recover — an unfillable binlog gap (MySQL) or an invalidated/lost replication
 	// slot (PostgreSQL, #532). When set, the index is valid only up to the gap and
-	// capture must be re-baselined to resume; status surfaces them loudly.
+	// capture must be re-baselined to resume; status surfaces them loudly. GapLostAt is
+	// authoritative (the badge is gated on it alone); GapLostDetail is supplementary
+	// human-readable context and may be absent. Both writers set them atomically.
 	GapLostAt     sql.NullTime
 	GapLostDetail sql.NullString
 }
@@ -320,6 +324,13 @@ func LoadStreamState(ctx context.Context, db *sql.DB) (*StreamStateInfo, error) 
 		&s.EventsIndexed, &s.LastEventTime, &s.LastCheckpoint,
 		&s.ServerID, &s.BintrailID, &s.GapLostAt, &s.GapLostDetail,
 	)
+	// A legacy index predating the gap_lost_* columns (added by the cascade-recovery
+	// work), read before any migrating command (EnsureSchema) ran — the console never
+	// migrates registry DSNs — lacks those columns. Degrade gracefully to the base
+	// columns rather than erroring `status`; such an index simply has no loss record.
+	if isUnknownColumnErr(err) {
+		return loadStreamStateBase(ctx, db)
+	}
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
@@ -327,6 +338,37 @@ func LoadStreamState(ctx context.Context, db *sql.DB) (*StreamStateInfo, error) 
 		return nil, err
 	}
 	return &s, nil
+}
+
+// loadStreamStateBase loads the stream_state columns guaranteed by the original CREATE
+// TABLE (no gap_lost_*), for a legacy index that has not been migrated. The gap-loss
+// fields stay zero (no badge).
+func loadStreamStateBase(ctx context.Context, db *sql.DB) (*StreamStateInfo, error) {
+	var s StreamStateInfo
+	err := db.QueryRowContext(ctx, `
+		SELECT mode, binlog_file, binlog_position, gtid_set,
+		       events_indexed, last_event_time, last_checkpoint,
+		       server_id, bintrail_id
+		FROM stream_state
+		WHERE id = 1`).Scan(
+		&s.Mode, &s.BinlogFile, &s.BinlogPosition, &s.GTIDSet,
+		&s.EventsIndexed, &s.LastEventTime, &s.LastCheckpoint,
+		&s.ServerID, &s.BintrailID,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+
+// isUnknownColumnErr reports whether err is MySQL error 1054 (ER_BAD_FIELD_ERROR,
+// "Unknown column"), i.e. the index schema predates a column this build SELECTs.
+func isUnknownColumnErr(err error) bool {
+	var me *mysql.MySQLError
+	return errors.As(err, &me) && me.Number == 1054
 }
 
 // StatusData holds all data sections loaded by CollectStatus.

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -82,6 +82,12 @@ type StreamStateInfo struct {
 	LastCheckpoint time.Time
 	ServerID       uint32
 	BintrailID     sql.NullString
+	// GapLostAt / GapLostDetail record that the stream permanently lost data it could
+	// not recover — an unfillable binlog gap (MySQL) or an invalidated/lost replication
+	// slot (PostgreSQL, #532). When set, the index is valid only up to the gap and
+	// capture must be re-baselined to resume; status surfaces them loudly.
+	GapLostAt     sql.NullTime
+	GapLostDetail sql.NullString
 }
 
 // CoverageInfo summarizes the restore coverage of the index.
@@ -307,12 +313,12 @@ func LoadStreamState(ctx context.Context, db *sql.DB) (*StreamStateInfo, error) 
 	err := db.QueryRowContext(ctx, `
 		SELECT mode, binlog_file, binlog_position, gtid_set,
 		       events_indexed, last_event_time, last_checkpoint,
-		       server_id, bintrail_id
+		       server_id, bintrail_id, gap_lost_at, gap_lost_detail
 		FROM stream_state
 		WHERE id = 1`).Scan(
 		&s.Mode, &s.BinlogFile, &s.BinlogPosition, &s.GTIDSet,
 		&s.EventsIndexed, &s.LastEventTime, &s.LastCheckpoint,
-		&s.ServerID, &s.BintrailID,
+		&s.ServerID, &s.BintrailID, &s.GapLostAt, &s.GapLostDetail,
 	)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -473,6 +479,21 @@ func WriteStatus(w io.Writer, files []IndexStateRow, parts []PartitionStat, arch
 		fmt.Fprintf(w, "  Last checkpoint: %s\n", stream.LastCheckpoint.Format(TSFmt))
 		fmt.Fprintf(w, "  Server ID:       %d\n", stream.ServerID)
 		fmt.Fprintln(w)
+
+		// Loud, unmissable banner when the stream permanently lost data (an unfillable
+		// binlog gap, or an invalidated/lost PostgreSQL replication slot — #532). This
+		// is the only way index-only `status` can show a lost stream after the capture
+		// process has exited; the index up to the gap is still valid for recovery.
+		if stream.GapLostAt.Valid {
+			fmt.Fprintln(w, "=== ⚠ EVENTS PERMANENTLY LOST ===")
+			fmt.Fprintf(w, "  Detected:  %s\n", stream.GapLostAt.Time.Format(TSFmt))
+			if stream.GapLostDetail.Valid && stream.GapLostDetail.String != "" {
+				fmt.Fprintf(w, "  Detail:    %s\n", stream.GapLostDetail.String)
+			}
+			fmt.Fprintln(w, "  The capture stream lost data it could not recover. The index up to the")
+			fmt.Fprintln(w, "  gap is still valid for recovery, but to resume capture you must re-baseline.")
+			fmt.Fprintln(w)
+		}
 	}
 
 	// ── Section 1: Indexed Files ──────────────────────────────────────────────
@@ -711,16 +732,21 @@ func writeStatusJSONFull(w io.Writer, files []IndexStateRow, parts []PartitionSt
 		CreatedAt        string  `json:"created_at"`
 		DecommissionedAt *string `json:"decommissioned_at"`
 	}
+	type jsonGapLost struct {
+		At     string `json:"at"`
+		Detail string `json:"detail,omitempty"`
+	}
 	type jsonStream struct {
-		BintrailID     *string `json:"bintrail_id"`
-		Mode           string  `json:"mode"`
-		BinlogFile     string  `json:"binlog_file,omitempty"`
-		BinlogPosition uint64  `json:"binlog_position,omitempty"`
-		GTIDSet        *string `json:"gtid_set,omitempty"`
-		EventsIndexed  int64   `json:"events_indexed"`
-		LastEventTime  *string `json:"last_event_time"`
-		LastCheckpoint string  `json:"last_checkpoint"`
-		ServerID       uint32  `json:"server_id"`
+		BintrailID     *string      `json:"bintrail_id"`
+		Mode           string       `json:"mode"`
+		BinlogFile     string       `json:"binlog_file,omitempty"`
+		BinlogPosition uint64       `json:"binlog_position,omitempty"`
+		GTIDSet        *string      `json:"gtid_set,omitempty"`
+		EventsIndexed  int64        `json:"events_indexed"`
+		LastEventTime  *string      `json:"last_event_time"`
+		LastCheckpoint string       `json:"last_checkpoint"`
+		ServerID       uint32       `json:"server_id"`
+		GapLost        *jsonGapLost `json:"gap_lost,omitempty"`
 	}
 	type jsonBaseline struct {
 		SnapshotTime string  `json:"snapshot_time"`
@@ -812,6 +838,9 @@ func writeStatusJSONFull(w io.Writer, files []IndexStateRow, parts []PartitionSt
 		if stream.LastEventTime.Valid {
 			s := stream.LastEventTime.Time.Format(TSFmt)
 			jstr.LastEventTime = &s
+		}
+		if stream.GapLostAt.Valid {
+			jstr.GapLost = &jsonGapLost{At: stream.GapLostAt.Time.Format(TSFmt), Detail: stream.GapLostDetail.String}
 		}
 		out.Stream = jstr
 	}

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -1079,7 +1079,7 @@ func TestStatusData_Write_equivalence(t *testing.T) {
 	}}
 	stream := &StreamStateInfo{
 		Mode: "gtid", BinlogFile: "binlog.000005", BinlogPosition: 12345,
-		GTIDSet: sql.NullString{Valid: true, String: "aaa-bbb:1-100"},
+		GTIDSet:       sql.NullString{Valid: true, String: "aaa-bbb:1-100"},
 		EventsIndexed: 267354, LastCheckpoint: ts, ServerID: 42,
 	}
 
@@ -1121,5 +1121,75 @@ func TestStatusData_WriteJSON_equivalence(t *testing.T) {
 
 	if got.String() != want.String() {
 		t.Errorf("StatusData.WriteJSON output differs from WriteStatusJSON:\ngot:\n%s\nwant:\n%s", got.String(), want.String())
+	}
+}
+
+// ─── permanently-lost badge (#532) ──────────────────────────────────────────────
+
+// gapLostStream builds a minimal stream with a permanent-loss record set. The badge
+// is flavor-agnostic (gap_lost_at is shared by MySQL binlog gaps and PostgreSQL
+// lost slots), so this fixture leaves the mode/flavor unset on purpose.
+func gapLostStream() *StreamStateInfo {
+	at := time.Date(2026, 6, 22, 12, 0, 0, 0, time.UTC)
+	return &StreamStateInfo{
+		Mode:           "gtid",
+		EventsIndexed:  42,
+		LastCheckpoint: at,
+		ServerID:       7,
+		GapLostAt:      sql.NullTime{Valid: true, Time: at},
+		GapLostDetail:  sql.NullString{Valid: true, String: "replication slot invalidated (wal_status=lost)"},
+	}
+}
+
+func TestWriteStatus_permanentLossBadge(t *testing.T) {
+	var buf bytes.Buffer
+	WriteStatus(&buf, nil, nil, nil, nil, nil, gapLostStream())
+	out := buf.String()
+	for _, want := range []string{"EVENTS PERMANENTLY LOST", "replication slot invalidated", "re-baseline"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("status text missing %q\n--- output ---\n%s", want, out)
+		}
+	}
+}
+
+func TestWriteStatus_noBadgeWhenNotLost(t *testing.T) {
+	// A healthy stream (gap_lost_at NULL) must NOT show the banner.
+	var buf bytes.Buffer
+	WriteStatus(&buf, nil, nil, nil, nil, nil, &StreamStateInfo{Mode: "gtid", ServerID: 7, LastCheckpoint: time.Now()})
+	if strings.Contains(buf.String(), "PERMANENTLY LOST") {
+		t.Errorf("healthy stream should not show the loss badge:\n%s", buf.String())
+	}
+}
+
+func TestWriteStatusJSON_gapLost(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteStatusJSON(&buf, nil, nil, nil, nil, nil, gapLostStream()); err != nil {
+		t.Fatal(err)
+	}
+	var result struct {
+		Stream struct {
+			GapLost *struct {
+				At     string `json:"at"`
+				Detail string `json:"detail"`
+			} `json:"gap_lost"`
+		} `json:"stream"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, buf.String())
+	}
+	if result.Stream.GapLost == nil {
+		t.Fatalf("stream.gap_lost missing from JSON:\n%s", buf.String())
+	}
+	if result.Stream.GapLost.Detail != "replication slot invalidated (wal_status=lost)" {
+		t.Errorf("gap_lost.detail = %q", result.Stream.GapLost.Detail)
+	}
+
+	// And it is omitted entirely for a healthy stream (additive, omitempty).
+	var buf2 bytes.Buffer
+	if err := WriteStatusJSON(&buf2, nil, nil, nil, nil, nil, &StreamStateInfo{Mode: "gtid", LastCheckpoint: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(buf2.String(), "gap_lost") {
+		t.Errorf("healthy stream JSON must omit gap_lost:\n%s", buf2.String())
 	}
 }


### PR DESCRIPTION
## What & why

When a PostgreSQL resume finds its replication slot **gone** — invalidated (`wal_status=lost`) or dropped — the WAL behind the saved checkpoint is irrecoverable; capture cannot resume without re-baselining. Until now that fatal condition lived only in a log line and the exit code — index-only `status` showed **nothing**. This slice makes it durable and loud, satisfying #532's *"a `lost` slot surfaces loudly with the recovery path"* + *"don't show a healthy badge over a lost slot."*

Part 2 of #532 (part 1 = `bintrail-pg doctor`, #583). Remaining: `bintrail-pg reset` teardown, docs.

## Changes

- **`pgcapture`**: `ensureSlot`'s two fatal resume paths now wrap sentinels **`ErrSlotLost`** / **`ErrSlotMissingOnResume`** (descriptive message preserved) so the consumer can `errors.Is` them.
- **`pgstreamrun`**: `One()` catches those sentinels → `persistSlotLostPG` stamps `stream_state.gap_lost_at`/`gap_lost_detail` — the **same columns** the MySQL path uses for an unfillable binlog gap. Best-effort, layered on an already-fatal error (no checkpoint advanced — we're aborting): a failed stamp is logged, the fatal error still propagates, never masked.
- **`status`**: `LoadStreamState` loads the gap-lost columns; `WriteStatus` renders a loud `=== ⚠ EVENTS PERMANENTLY LOST ===` banner (Detected/Detail + re-baseline guidance, noting the index up to the gap is still valid for recovery); `WriteStatusJSON` adds an **additive, `omitempty`** `gap_lost` sub-object.

## Decisions / invariants
- **Generalized to all sources** (your call): the badge fires for any flavor when `gap_lost_at` is set — which also surfaces the previously-unsurfaced **MySQL** unfillable-gap record.
- **JSON strictly additive** (`gap_lost` is `omitempty`, existing fields unchanged) → console/MCP consumers of `WriteStatusJSON` unaffected.
- **One index schema**: reuses the existing `gap_lost_*` columns; no schema change.
- **Offline-recovery**: `status` stays index-only; the badge explicitly says the index up to the gap is still usable for recovery.

## Tests
- **Unit:** the badge in text + JSON, set *and* unset, flavor-agnostic.
- **Integration (live PG + MySQL):** `TestOne_LostSlotResume_PersistsLossBadge` — first run creates the slot + checkpoints, the slot is dropped, the resume returns `ErrSlotMissingOnResume` **and** stamps `gap_lost_at`, and index-only `status` then renders the badge (i.e. the loss is visible *after the process has exited*). Regressions (`EndToEnd`, `CapturerFailureSurfaces`) green; full unit suite + pgfree guard green.

Part of #532

🤖 Generated with [Claude Code](https://claude.com/claude-code)