### PR TITLE
feat(pg): bintrail-pg reset teardown + #532 docs (closes #532)

### DIFF
--- a/cmd/bintrail-pg/reset.go
+++ b/cmd/bintrail-pg/reset.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/jackc/pgx/v5"
+	"github.com/spf13/cobra"
+
+	"github.com/dbtrail/dbtrail/internal/cli"
+	"github.com/dbtrail/dbtrail/internal/config"
+	"github.com/dbtrail/dbtrail/internal/pgcapture"
+)
+
+var resetCmd = &cobra.Command{
+	Use:   "reset",
+	Short: "Tear down a PostgreSQL capture: drop the replication slot and clear the index checkpoint",
+	Long: `Cleanly tears down a PostgreSQL capture so you can re-baseline and start fresh.
+
+It performs the two-system teardown that otherwise has to be done by hand:
+
+  1. drops the replication slot on the SOURCE (--query-dsn) — a slot left behind
+     keeps pinning WAL and can fill the source disk;
+  2. clears the durable checkpoint in the INDEX (--index-dsn): DELETE the
+     stream_state row, so the next 'bintrail-pg stream' starts from a fresh slot.
+
+The slot is dropped first: if the run is interrupted between the two steps, the
+safe state is "slot gone, checkpoint stale" (the next stream fails loud) rather
+than "checkpoint cleared, slot live" (which would silently skip data).
+
+After a lost-slot invalidation the slot may already be gone or unusable; pass
+--index-only to clear just the checkpoint without touching the source.
+
+This is destructive and irreversible — pass --force to confirm. The index's
+recovery data is NOT affected (recovery is index-only); only capture-resume state
+is removed.
+
+Examples:
+
+  bintrail-pg reset --query-dsn "$PG" --index-dsn "$IDX" --slot bintrail_slot --force
+  bintrail-pg reset --index-dsn "$IDX" --index-only --force   # slot already gone`,
+	RunE: runPGReset,
+}
+
+var (
+	pgResetQueryDSN  string
+	pgResetIndexDSN  string
+	pgResetSlot      string
+	pgResetForce     bool
+	pgResetIndexOnly bool
+)
+
+func init() {
+	resetCmd.Flags().StringVar(&pgResetQueryDSN, "query-dsn", "", "PostgreSQL ordinary connection string, to drop the slot (required unless --index-only; env BINTRAIL_PG_QUERY_DSN)")
+	resetCmd.Flags().StringVar(&pgResetIndexDSN, "index-dsn", "", "DSN for the index MySQL database, to clear the checkpoint (required; env BINTRAIL_INDEX_DSN)")
+	resetCmd.Flags().StringVar(&pgResetSlot, "slot", "", "Replication slot to drop (required unless --index-only; env BINTRAIL_PG_SLOT)")
+	resetCmd.Flags().BoolVar(&pgResetForce, "force", false, "Confirm this destructive, irreversible teardown")
+	resetCmd.Flags().BoolVar(&pgResetIndexOnly, "index-only", false, "Only clear the index checkpoint; do not touch the source slot (use when the slot is already gone or lost)")
+	// index-dsn is in cli.EnvBindings, so BindCommandEnv sets it from BINTRAIL_INDEX_DSN;
+	// the PG-specific flags use the BINTRAIL_PG_* fallback applied in runPGReset.
+	cli.BindCommandEnv(resetCmd)
+	rootCmd.AddCommand(resetCmd)
+}
+
+func runPGReset(cmd *cobra.Command, args []string) error {
+	applyEnvFallback(&pgResetQueryDSN, "BINTRAIL_PG_QUERY_DSN")
+	applyEnvFallback(&pgResetSlot, "BINTRAIL_PG_SLOT")
+
+	if pgResetIndexDSN == "" {
+		return fmt.Errorf("missing required --index-dsn (or BINTRAIL_INDEX_DSN)")
+	}
+	if !pgResetIndexOnly {
+		var missing []string
+		if pgResetQueryDSN == "" {
+			missing = append(missing, "--query-dsn (or BINTRAIL_PG_QUERY_DSN)")
+		}
+		if pgResetSlot == "" {
+			missing = append(missing, "--slot (or BINTRAIL_PG_SLOT)")
+		}
+		if len(missing) > 0 {
+			return fmt.Errorf("missing required settings: %s (or pass --index-only to clear just the checkpoint)", strings.Join(missing, ", "))
+		}
+	}
+	if !pgResetForce {
+		return errors.New("refusing to run a destructive teardown without --force — it drops the replication slot and clears the index checkpoint (recovery data is unaffected)")
+	}
+
+	ctx := cmd.Context()
+
+	// 1. Drop the slot on the source FIRST (unless --index-only). Ordering matters: a
+	//    half-failure then leaves "slot gone, checkpoint stale → next stream fails loud",
+	//    not "checkpoint cleared, slot live → silent skip".
+	if pgResetIndexOnly {
+		fmt.Fprintln(os.Stdout, "--index-only: leaving the source replication slot untouched.")
+	} else {
+		conn, err := pgx.Connect(ctx, pgResetQueryDSN)
+		if err != nil {
+			return fmt.Errorf("connect to source: %w", err)
+		}
+		dropped, dropErr := pgcapture.DropSlot(ctx, conn, pgResetSlot)
+		conn.Close(ctx)
+		if dropErr != nil {
+			return fmt.Errorf("%w\n(if the slot is active, stop the running `bintrail-pg stream` first, or use --index-only if the slot is already gone)", dropErr)
+		}
+		if dropped {
+			fmt.Fprintf(os.Stdout, "Dropped replication slot %q on the source.\n", pgResetSlot)
+		} else {
+			fmt.Fprintf(os.Stdout, "Replication slot %q was already absent.\n", pgResetSlot)
+		}
+	}
+
+	// 2. Clear the index checkpoint.
+	idx, err := config.Connect(pgResetIndexDSN)
+	if err != nil {
+		return fmt.Errorf("connect to index: %w", err)
+	}
+	defer idx.Close()
+	res, err := idx.ExecContext(ctx, "DELETE FROM stream_state WHERE id = 1")
+	if err != nil {
+		if isTableMissingErr(err) {
+			// A never-streamed index: nothing to clear.
+			fmt.Fprintln(os.Stdout, "No index checkpoint to clear (stream_state table absent).")
+			fmt.Fprintln(os.Stdout, "Done.")
+			return nil
+		}
+		return fmt.Errorf("clearing the index checkpoint: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	fmt.Fprintf(os.Stdout, "Cleared %d index checkpoint row(s).\n", n)
+	fmt.Fprintln(os.Stdout, "Done. Re-seed the baseline, then run `bintrail-pg stream` to start fresh.")
+	return nil
+}
+
+// isTableMissingErr reports whether err is MySQL error 1146 (ER_NO_SUCH_TABLE), i.e.
+// the index has no stream_state table yet (never streamed) — nothing to reset.
+func isTableMissingErr(err error) bool {
+	var me *mysql.MySQLError
+	return errors.As(err, &me) && me.Number == 1146
+}

--- a/cmd/bintrail-pg/reset.go
+++ b/cmd/bintrail-pg/reset.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"context"
+	"database/sql"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -88,54 +91,100 @@ func runPGReset(cmd *cobra.Command, args []string) error {
 		return errors.New("refusing to run a destructive teardown without --force — it drops the replication slot and clears the index checkpoint (recovery data is unaffected)")
 	}
 
-	ctx := cmd.Context()
-
-	// 1. Drop the slot on the source FIRST (unless --index-only). Ordering matters: a
-	//    half-failure then leaves "slot gone, checkpoint stale → next stream fails loud",
-	//    not "checkpoint cleared, slot live → silent skip".
-	if pgResetIndexOnly {
-		fmt.Fprintln(os.Stdout, "--index-only: leaving the source replication slot untouched.")
-	} else {
+	// Bind the two destructive steps as closures over the live connections, then run
+	// the (seam-injected, unit-tested) orchestration. The connections are opened lazily
+	// inside the closures so resetPlan owns the ordering: the SOURCE slot is dropped
+	// before the INDEX is touched at all.
+	dropFn := func(ctx context.Context) (bool, error) {
 		conn, err := pgx.Connect(ctx, pgResetQueryDSN)
 		if err != nil {
-			return fmt.Errorf("connect to source: %w", err)
+			return false, fmt.Errorf("connect to source: %w", err)
 		}
-		dropped, dropErr := pgcapture.DropSlot(ctx, conn, pgResetSlot)
-		conn.Close(ctx)
-		if dropErr != nil {
-			return fmt.Errorf("%w\n(if the slot is active, stop the running `bintrail-pg stream` first, or use --index-only if the slot is already gone)", dropErr)
+		defer conn.Close(ctx)
+		return pgcapture.DropSlot(ctx, conn, pgResetSlot)
+	}
+	clearFn := func(ctx context.Context) (int64, bool, error) {
+		idx, err := config.Connect(pgResetIndexDSN)
+		if err != nil {
+			return 0, false, fmt.Errorf("connect to index: %w", err)
 		}
+		defer idx.Close()
+		return clearCheckpoint(ctx, idx)
+	}
+	return resetPlan(cmd.Context(), pgResetIndexOnly, pgResetSlot, os.Stdout, dropFn, clearFn)
+}
+
+// resetPlan is the orchestration core of `bintrail-pg reset`, injected with the two
+// teardown steps so the ordering and partial-failure handling are unit-testable without
+// live databases.
+//
+// Ordering is the safety invariant: the SOURCE slot is dropped FIRST, then the INDEX
+// checkpoint is cleared. A failure between them leaves "slot gone, checkpoint stale →
+// next stream fails loud", never "checkpoint cleared, slot live → silent skip". If the
+// clear fails after the slot was already dropped, the error says so and points at
+// --index-only to finish.
+func resetPlan(
+	ctx context.Context,
+	indexOnly bool,
+	slot string,
+	out io.Writer,
+	dropFn func(context.Context) (bool, error),
+	clearFn func(context.Context) (rows int64, tableMissing bool, err error),
+) error {
+	slotHandled := false
+	if indexOnly {
+		fmt.Fprintln(out, "--index-only: leaving the source replication slot untouched.")
+	} else {
+		dropped, err := dropFn(ctx)
+		if err != nil {
+			return fmt.Errorf("%w\n(if the slot is active, stop the running `bintrail-pg stream` first, or use --index-only if the slot is already gone)", err)
+		}
+		slotHandled = true
 		if dropped {
-			fmt.Fprintf(os.Stdout, "Dropped replication slot %q on the source.\n", pgResetSlot)
+			fmt.Fprintf(out, "Dropped replication slot %q on the source.\n", slot)
 		} else {
-			fmt.Fprintf(os.Stdout, "Replication slot %q was already absent.\n", pgResetSlot)
+			fmt.Fprintf(out, "Replication slot %q was already absent.\n", slot)
 		}
 	}
 
-	// 2. Clear the index checkpoint.
-	idx, err := config.Connect(pgResetIndexDSN)
+	rows, tableMissing, err := clearFn(ctx)
 	if err != nil {
-		return fmt.Errorf("connect to index: %w", err)
-	}
-	defer idx.Close()
-	res, err := idx.ExecContext(ctx, "DELETE FROM stream_state WHERE id = 1")
-	if err != nil {
-		if isTableMissingErr(err) {
-			// A never-streamed index: nothing to clear.
-			fmt.Fprintln(os.Stdout, "No index checkpoint to clear (stream_state table absent).")
-			fmt.Fprintln(os.Stdout, "Done.")
-			return nil
+		if slotHandled {
+			// The source slot is already gone; tell the operator how to finish so they
+			// don't have to reason about the half-completed state.
+			return fmt.Errorf("clearing the index checkpoint: %w\n(the source slot was already dropped; once the index is reachable, re-run with --index-only to finish)", err)
 		}
 		return fmt.Errorf("clearing the index checkpoint: %w", err)
 	}
-	n, _ := res.RowsAffected()
-	fmt.Fprintf(os.Stdout, "Cleared %d index checkpoint row(s).\n", n)
-	fmt.Fprintln(os.Stdout, "Done. Re-seed the baseline, then run `bintrail-pg stream` to start fresh.")
+	if tableMissing {
+		// 1146 also fires when --index-dsn points at the wrong database, so don't claim
+		// success unconditionally — name the ambiguity.
+		fmt.Fprintln(out, "No stream_state table in this index — either it was never streamed, or --index-dsn points at the wrong database. Nothing cleared.")
+		fmt.Fprintln(out, "Done.")
+		return nil
+	}
+	fmt.Fprintf(out, "Cleared %d index checkpoint row(s).\n", rows)
+	fmt.Fprintln(out, "Done. Re-seed the baseline, then run `bintrail-pg stream` to start fresh.")
 	return nil
 }
 
+// clearCheckpoint deletes the stream_state checkpoint row. It returns tableMissing=true
+// with a nil error when the stream_state table does not exist (MySQL 1146) — a
+// never-streamed index, or an --index-dsn pointing at the wrong database.
+func clearCheckpoint(ctx context.Context, db *sql.DB) (rows int64, tableMissing bool, err error) {
+	res, err := db.ExecContext(ctx, "DELETE FROM stream_state WHERE id = 1")
+	if err != nil {
+		if isTableMissingErr(err) {
+			return 0, true, nil
+		}
+		return 0, false, err
+	}
+	n, _ := res.RowsAffected()
+	return n, false, nil
+}
+
 // isTableMissingErr reports whether err is MySQL error 1146 (ER_NO_SUCH_TABLE), i.e.
-// the index has no stream_state table yet (never streamed) — nothing to reset.
+// the target has no stream_state table (never streamed, or wrong database).
 func isTableMissingErr(err error) bool {
 	var me *mysql.MySQLError
 	return errors.As(err, &me) && me.Number == 1146

--- a/cmd/bintrail-pg/reset_integration_test.go
+++ b/cmd/bintrail-pg/reset_integration_test.go
@@ -1,0 +1,46 @@
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestClearCheckpoint_Integration covers the index half of `bintrail-pg reset` against
+// a real MySQL index: a present checkpoint clears (1 row), a second clear is a no-op
+// (0 rows), and a missing stream_state table reports tableMissing rather than erroring.
+func TestClearCheckpoint_Integration(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	ctx := context.Background()
+	db, _ := testutil.CreateTestDB(t)
+	if err := indexer.CreateIndexTables(ctx, db, 4, false, nil); err != nil {
+		t.Fatalf("CreateIndexTables: %v", err)
+	}
+
+	if _, err := db.ExecContext(ctx,
+		"INSERT INTO stream_state (id, mode, server_id, last_checkpoint) VALUES (1, 'gtid', 9, UTC_TIMESTAMP())"); err != nil {
+		t.Fatalf("seed checkpoint: %v", err)
+	}
+
+	rows, missing, err := clearCheckpoint(ctx, db)
+	if err != nil || missing || rows != 1 {
+		t.Fatalf("clear present checkpoint = (rows=%d, missing=%t, err=%v), want (1, false, nil)", rows, missing, err)
+	}
+
+	rows, missing, err = clearCheckpoint(ctx, db)
+	if err != nil || missing || rows != 0 {
+		t.Fatalf("second clear = (rows=%d, missing=%t, err=%v), want (0, false, nil)", rows, missing, err)
+	}
+
+	if _, err := db.ExecContext(ctx, "DROP TABLE stream_state"); err != nil {
+		t.Fatalf("drop stream_state: %v", err)
+	}
+	rows, missing, err = clearCheckpoint(ctx, db)
+	if err != nil || !missing {
+		t.Fatalf("clear with no table = (rows=%d, missing=%t, err=%v), want (_, true, nil)", rows, missing, err)
+	}
+}

--- a/cmd/bintrail-pg/reset_test.go
+++ b/cmd/bintrail-pg/reset_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/spf13/cobra"
+)
+
+func resetPGResetFlags() {
+	pgResetQueryDSN = ""
+	pgResetIndexDSN = ""
+	pgResetSlot = ""
+	pgResetForce = false
+	pgResetIndexOnly = false
+}
+
+func clearPGResetEnv(t *testing.T) {
+	t.Helper()
+	for _, v := range []string{"BINTRAIL_PG_QUERY_DSN", "BINTRAIL_PG_SLOT"} {
+		t.Setenv(v, "")
+	}
+}
+
+// runReset invokes the entry point with a throwaway command; the validation paths
+// under test return before cmd.Context()/any connection is used.
+func runReset() error { return runPGReset(&cobra.Command{}, nil) }
+
+func TestPGResetConfig_MissingIndexDSN(t *testing.T) {
+	clearPGResetEnv(t)
+	resetPGResetFlags()
+	pgResetForce = true
+	if err := runReset(); err == nil || !strings.Contains(err.Error(), "index-dsn") {
+		t.Fatalf("expected a missing index-dsn error, got %v", err)
+	}
+}
+
+func TestPGResetConfig_MissingQuerySlotUnlessIndexOnly(t *testing.T) {
+	clearPGResetEnv(t)
+	resetPGResetFlags()
+	pgResetIndexDSN = "user:pass@tcp(localhost:3306)/idx"
+	pgResetForce = true
+	// Not index-only and no query-dsn/slot → must name both as missing.
+	err := runReset()
+	if err == nil {
+		t.Fatal("expected an error for missing query-dsn/slot, got nil")
+	}
+	for _, want := range []string{"--query-dsn", "--slot", "--index-only"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q should mention %q", err, want)
+		}
+	}
+}
+
+func TestPGResetConfig_RequiresForce(t *testing.T) {
+	clearPGResetEnv(t)
+	resetPGResetFlags()
+	pgResetIndexDSN = "idx"
+	pgResetQueryDSN = "pg"
+	pgResetSlot = "s"
+	// All settings present but --force absent → refuse the destructive op.
+	if err := runReset(); err == nil || !strings.Contains(err.Error(), "--force") {
+		t.Fatalf("expected a --force refusal, got %v", err)
+	}
+}
+
+func TestPGResetConfig_EnvFallbackForQuerySlot(t *testing.T) {
+	clearPGResetEnv(t)
+	resetPGResetFlags()
+	pgResetIndexDSN = "idx"
+	pgResetForce = false
+	t.Setenv("BINTRAIL_PG_QUERY_DSN", "pg-from-env")
+	t.Setenv("BINTRAIL_PG_SLOT", "slot-from-env")
+	// query/slot satisfied via env → validation passes → the only error is --force.
+	// (If the env fallback didn't run, this would fail with a missing-settings error.)
+	err := runReset()
+	if err == nil || !strings.Contains(err.Error(), "--force") {
+		t.Fatalf("env fallback for query/slot not applied (got %v)", err)
+	}
+}
+
+func TestPGResetConfig_IndexOnlySkipsQuerySlot(t *testing.T) {
+	clearPGResetEnv(t)
+	resetPGResetFlags()
+	pgResetIndexDSN = "idx"
+	pgResetIndexOnly = true
+	pgResetForce = false
+	// --index-only must NOT require query-dsn/slot; the only validation error is --force.
+	if err := runReset(); err == nil || !strings.Contains(err.Error(), "--force") {
+		t.Fatalf("--index-only should not require query/slot; got %v", err)
+	}
+}
+
+func TestIsTableMissingErr(t *testing.T) {
+	if !isTableMissingErr(&mysql.MySQLError{Number: 1146}) {
+		t.Error("1146 should be recognized as table-missing")
+	}
+	if isTableMissingErr(&mysql.MySQLError{Number: 1054}) {
+		t.Error("1054 (unknown column) is not table-missing")
+	}
+	if isTableMissingErr(errors.New("plain")) {
+		t.Error("a plain error is not table-missing")
+	}
+}

--- a/cmd/bintrail-pg/reset_test.go
+++ b/cmd/bintrail-pg/reset_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -90,6 +92,96 @@ func TestPGResetConfig_IndexOnlySkipsQuerySlot(t *testing.T) {
 	// --index-only must NOT require query-dsn/slot; the only validation error is --force.
 	if err := runReset(); err == nil || !strings.Contains(err.Error(), "--force") {
 		t.Fatalf("--index-only should not require query/slot; got %v", err)
+	}
+}
+
+// ─── resetPlan orchestration (seam-injected; no live DBs) ───────────────────────
+
+// okClear is a clearFn that records invocation and reports n rows cleared.
+func recordingClear(n int64, called *bool) func(context.Context) (int64, bool, error) {
+	return func(context.Context) (int64, bool, error) { *called = true; return n, false, nil }
+}
+
+// TestResetPlan_DropFailureLeavesCheckpoint is the load-bearing ordering guarantee
+// (the reason the command exists): if the slot drop fails, the checkpoint clear must
+// NOT run — the safe half-state is "slot live, checkpoint intact", and the next stream
+// keeps working. A bug that cleared anyway would orphan a live slot from its checkpoint.
+func TestResetPlan_DropFailureLeavesCheckpoint(t *testing.T) {
+	cleared := false
+	dropFn := func(context.Context) (bool, error) { return false, errors.New("slot is active for PID 123") }
+	clearFn := recordingClear(1, &cleared)
+
+	err := resetPlan(context.Background(), false, "s", &bytes.Buffer{}, dropFn, clearFn)
+	if err == nil || !strings.Contains(err.Error(), "active") {
+		t.Fatalf("expected the drop error to surface, got %v", err)
+	}
+	if cleared {
+		t.Error("checkpoint was cleared after the slot drop FAILED — violates the fail-safe ordering")
+	}
+}
+
+func TestResetPlan_IndexOnlySkipsDrop(t *testing.T) {
+	dropped := false
+	dropFn := func(context.Context) (bool, error) { dropped = true; return true, nil }
+	cleared := false
+	var out bytes.Buffer
+	if err := resetPlan(context.Background(), true, "s", &out, dropFn, recordingClear(1, &cleared)); err != nil {
+		t.Fatalf("resetPlan(index-only): %v", err)
+	}
+	if dropped {
+		t.Error("--index-only must NOT drop the slot")
+	}
+	if !cleared {
+		t.Error("--index-only must still clear the checkpoint")
+	}
+	if !strings.Contains(out.String(), "--index-only") || !strings.Contains(out.String(), "Cleared 1") {
+		t.Errorf("unexpected output: %s", out.String())
+	}
+}
+
+func TestResetPlan_HappyPath(t *testing.T) {
+	var out bytes.Buffer
+	dropFn := func(context.Context) (bool, error) { return true, nil }
+	cleared := false
+	if err := resetPlan(context.Background(), false, "myslot", &out, dropFn, recordingClear(1, &cleared)); err != nil {
+		t.Fatalf("resetPlan: %v", err)
+	}
+	if !strings.Contains(out.String(), `Dropped replication slot "myslot"`) || !strings.Contains(out.String(), "Cleared 1 index checkpoint row") {
+		t.Errorf("unexpected output: %s", out.String())
+	}
+}
+
+func TestResetPlan_AbsentSlot(t *testing.T) {
+	var out bytes.Buffer
+	dropFn := func(context.Context) (bool, error) { return false, nil } // already absent
+	cleared := false
+	if err := resetPlan(context.Background(), false, "s", &out, dropFn, recordingClear(0, &cleared)); err != nil {
+		t.Fatalf("resetPlan: %v", err)
+	}
+	if !strings.Contains(out.String(), "already absent") || !strings.Contains(out.String(), "Cleared 0") {
+		t.Errorf("unexpected output: %s", out.String())
+	}
+}
+
+func TestResetPlan_TableMissingNamesAmbiguity(t *testing.T) {
+	var out bytes.Buffer
+	dropFn := func(context.Context) (bool, error) { return true, nil }
+	clearFn := func(context.Context) (int64, bool, error) { return 0, true, nil } // 1146
+	if err := resetPlan(context.Background(), false, "s", &out, dropFn, clearFn); err != nil {
+		t.Fatalf("resetPlan: %v", err)
+	}
+	// Must NOT claim a clean success — it names the wrong-database possibility.
+	if !strings.Contains(out.String(), "wrong database") {
+		t.Errorf("table-missing output should name the wrong-DSN ambiguity: %s", out.String())
+	}
+}
+
+func TestResetPlan_ClearFailsAfterDropMentionsIndexOnly(t *testing.T) {
+	dropFn := func(context.Context) (bool, error) { return true, nil }
+	clearFn := func(context.Context) (int64, bool, error) { return 0, false, errors.New("index unreachable") }
+	err := resetPlan(context.Background(), false, "s", &bytes.Buffer{}, dropFn, clearFn)
+	if err == nil || !strings.Contains(err.Error(), "--index-only") {
+		t.Fatalf("a clear failure after a successful drop must hint --index-only, got %v", err)
 	}
 }
 

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -184,9 +184,9 @@ bintrail-pg doctor --query-dsn "$PG" --slot bintrail_shop --publication bintrail
 
 - **`max_slot_wal_keep_size`** → WARN while unlimited (`-1`); set a bound to clear it.
 - **Replication slot health** → shows `wal_status` and how much WAL the slot is
-  retaining. The status progresses `reserved` → `extended` → `unreserved` →
-  `lost`; a `lost` (invalidated) slot is a loud **FAIL** with the re-baseline
-  recovery path.
+  retaining. The status progresses `reserved` (PASS) → `extended` / `unreserved`
+  (**WARN** — retaining WAL and approaching the limit; doctor still exits 0) →
+  `lost` (a loud **FAIL** with the re-baseline recovery path).
 
 A permanently-lost stream is also recorded durably: once a slot is invalidated or
 dropped out from under a running capture, `bintrail status` shows a loud

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -31,6 +31,7 @@ and set REPLICA IDENTITY; bintrail reads — it never writes to your source.
 | **A `PUBLICATION`** covering those tables | **Yes — you create it** | bintrail-pg validates it exists and covers your tables; it does **not** create it. |
 | **A replication slot** | No — created for you | bintrail-pg creates the logical slot on first run and reuses it on restart. |
 | `max_replication_slots` ≥ 1, `max_wal_senders` ≥ 1 | Yes | Defaults (10) are usually fine. A slot consumes one of each. |
+| **`max_slot_wal_keep_size`** set (not `-1`) | **Strongly recommended** | The production safety valve (PG 13+). Left unlimited (`-1`, the default), a stalled slot pins WAL until the source disk fills — an outage. Set a bound (e.g. `'10GB'`); `bintrail-pg doctor` WARNs while it's unlimited. See [the slot section](#5-the-replication-slot--created-for-you). |
 
 The index MySQL has the same requirements as for any source — see
 [Streaming → index requirements](streaming.md).
@@ -168,8 +169,30 @@ slot (named by `--slot`) on first run and resumes from it on every restart.
 > time, the slot pins WAL and the source disk can fill. On PostgreSQL 13+ set
 > `max_slot_wal_keep_size` as a safety valve so an abandoned slot is capped
 > (it becomes `lost` instead of filling the disk; bintrail-pg then fails loud on
-> resume rather than silently skipping data). If you decommission a capture,
-> drop its slot: `SELECT pg_drop_replication_slot('<slot>');`.
+> resume rather than silently skipping data). To decommission a capture, use
+> `bintrail-pg reset` (below) rather than dropping the slot by hand.
+
+#### Checking slot health
+
+`bintrail-pg doctor` reports the slot's live WAL-retention state on demand,
+alongside the capture prerequisites (`wal_level`, publication coverage, REPLICA
+IDENTITY FULL):
+
+```bash
+bintrail-pg doctor --query-dsn "$PG" --slot bintrail_shop --publication bintrail_shop_pub
+```
+
+- **`max_slot_wal_keep_size`** → WARN while unlimited (`-1`); set a bound to clear it.
+- **Replication slot health** → shows `wal_status` and how much WAL the slot is
+  retaining. The status progresses `reserved` → `extended` → `unreserved` →
+  `lost`; a `lost` (invalidated) slot is a loud **FAIL** with the re-baseline
+  recovery path.
+
+A permanently-lost stream is also recorded durably: once a slot is invalidated or
+dropped out from under a running capture, `bintrail status` shows a loud
+**`EVENTS PERMANENTLY LOST`** banner even after the process has exited. In every
+case the index up to the gap is still fully usable for recovery — recovery never
+needs the slot; only *resuming capture* requires a re-baseline.
 
 ---
 
@@ -233,12 +256,27 @@ exists.
 
 To start over from scratch you must drop the slot **and** clear the checkpoint —
 because in PostgreSQL the *slot* governs the resume position, so clearing the
-checkpoint alone does not rewind:
+checkpoint alone does not rewind. `bintrail-pg reset` does both (it drops the slot
+first, so an interrupted reset fails safe — "slot gone, checkpoint stale" rather
+than "checkpoint cleared, slot live"):
 
-```sql
-SELECT pg_drop_replication_slot('bintrail_shop');   -- on the source
-DELETE FROM stream_state WHERE id = 1;               -- on the index
+```bash
+bintrail-pg reset --query-dsn "$PG" --index-dsn "$IDX" --slot bintrail_shop --force
 ```
+
+`--force` confirms the destructive teardown. If the slot is already gone or `lost`
+(e.g. after a `max_slot_wal_keep_size` invalidation), pass `--index-only` to clear
+just the checkpoint:
+
+```bash
+bintrail-pg reset --index-dsn "$IDX" --index-only --force
+```
+
+This removes only capture-resume state; the index's recovery data is untouched.
+Under the hood it is the two-system teardown that otherwise has to be done by hand
+(`SELECT pg_drop_replication_slot('bintrail_shop')` on the source +
+`DELETE FROM stream_state WHERE id = 1` on the index). After a reset, re-seed the
+baseline and re-run `bintrail-pg stream`.
 
 ---
 
@@ -402,14 +440,18 @@ which are plain SQL.
 
 ## Troubleshooting
 
+> Tip: run `bintrail-pg doctor` to catch most of the rows below *before* they cost
+> you a debugging cycle — it checks `wal_level`, publication coverage, REPLICA
+> IDENTITY FULL, `max_slot_wal_keep_size`, and live slot health in one shot.
+
 | Symptom | Cause / fix |
 |---|---|
 | `wal_level is "replica", must be 'logical'` | Set `wal_level = logical` and **restart** the server (a reload is not enough). |
 | `publication "…" does not exist — create it` | Create the publication first (step 4) — bintrail-pg never creates it. |
 | `publication "…" does not cover requested table(s) […]` | Your `--schemas`/`--tables` include tables not in the publication; `ALTER PUBLICATION … ADD TABLE …` (or widen the publication). |
 | `table(s) not at REPLICA IDENTITY FULL […]` | Run `ALTER TABLE <t> REPLICA IDENTITY FULL` for the listed tables (step 3). |
-| `replication slot "…" is invalidated (wal_status=lost; max_slot_wal_keep_size exceeded)` | The source dropped WAL the slot still needed (slot was stopped too long). The data since the checkpoint is gone — start fresh (drop the slot, clear the checkpoint) and re-seed. Raise `max_slot_wal_keep_size`/keep the consumer running. |
-| `resuming from a saved checkpoint but replication slot "…" no longer exists` | The slot was dropped while a checkpoint still pointed at it. Creating a fresh slot would skip data, so bintrail-pg refuses — clear the checkpoint to start fresh if the gap is acceptable. |
+| `replication slot "…" is invalidated (wal_status=lost; max_slot_wal_keep_size exceeded)` | The source dropped WAL the slot still needed (slot was stopped too long). The data since the checkpoint is gone — `bintrail-pg reset` (drops the slot + clears the checkpoint), re-seed, and raise `max_slot_wal_keep_size` / keep the consumer running. `bintrail status` shows this as a loud `EVENTS PERMANENTLY LOST` banner. |
+| `resuming from a saved checkpoint but replication slot "…" no longer exists` | The slot was dropped while a checkpoint still pointed at it. Creating a fresh slot would skip data, so bintrail-pg refuses — `bintrail-pg reset --index-only` to clear the checkpoint and start fresh if the gap is acceptable. |
 | `must include replication=database` (connection error on `--repl-dsn`) | Add `replication=database` to the `--repl-dsn` connection string. |
 | Permission denied opening replication / creating slot | The role needs the `REPLICATION` attribute (`ALTER ROLE <r> REPLICATION;`), or on managed PG the provider's replication grant. |
 

--- a/internal/pgcapture/health.go
+++ b/internal/pgcapture/health.go
@@ -143,6 +143,23 @@ func QuerySlotHealth(ctx context.Context, conn *pgx.Conn, slotName string) (Slot
 	return r.toHealth()
 }
 
+// DropSlot idempotently drops the replication slot on a plain query connection, for
+// teardown/re-baseline (bintrail-pg reset). It returns dropped=false with a nil error
+// when the slot is already absent. It errors if the slot is ACTIVE — a live consumer
+// (a running `bintrail-pg stream`) holds it — surfacing PostgreSQL's "replication slot
+// is active for PID N" message; the caller must stop the stream first.
+func DropSlot(ctx context.Context, conn *pgx.Conn, slotName string) (bool, error) {
+	// The WHERE EXISTS guard makes this a no-op (0 rows) when the slot is absent, so it
+	// is idempotent; an active slot still raises an error from pg_drop_replication_slot.
+	tag, err := conn.Exec(ctx,
+		`SELECT pg_drop_replication_slot($1) WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name = $1)`,
+		slotName)
+	if err != nil {
+		return false, fmt.Errorf("pgcapture: dropping replication slot %q: %w", slotName, err)
+	}
+	return tag.RowsAffected() > 0, nil
+}
+
 // querySlotState reads only a slot's existence and wal_status — a primary-agnostic
 // catalog read. It is deliberately lighter than QuerySlotHealth, which adds the
 // primary-only pg_current_wal_lsn()/pg_wal_lsn_diff retention metrics (those error on

--- a/internal/pgcapture/health_integration_test.go
+++ b/internal/pgcapture/health_integration_test.go
@@ -88,3 +88,51 @@ func TestQuerySlotHealth_Integration(t *testing.T) {
 		t.Errorf("dropped slot reported Exists=true: %+v", h)
 	}
 }
+
+// TestDropSlot_Integration covers the #532 teardown primitive: dropping an existing
+// slot reports dropped=true and removes it; dropping an absent slot is an idempotent
+// no-op (dropped=false, nil error).
+func TestDropSlot_Integration(t *testing.T) {
+	dsn := testutil.SkipIfNoPostgres(t)
+	ctx := context.Background()
+
+	const slot = "bintrail_dropslot_it"
+
+	conn, err := pgx.Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { conn.Close(context.Background()) })
+	cleanup := func() {
+		_, _ = conn.Exec(context.Background(),
+			"SELECT pg_drop_replication_slot($1) WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name=$1)", slot)
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	// Absent → no-op.
+	if dropped, err := pgcapture.DropSlot(ctx, conn, slot); err != nil || dropped {
+		t.Fatalf("DropSlot(absent) = (%t, %v), want (false, nil)", dropped, err)
+	}
+
+	// Create, then drop → dropped=true and gone.
+	if _, err := conn.Exec(ctx, "SELECT pg_create_logical_replication_slot($1, 'pgoutput')", slot); err != nil {
+		t.Fatalf("create slot: %v", err)
+	}
+	dropped, err := pgcapture.DropSlot(ctx, conn, slot)
+	if err != nil || !dropped {
+		t.Fatalf("DropSlot(present) = (%t, %v), want (true, nil)", dropped, err)
+	}
+	h, err := pgcapture.QuerySlotHealth(ctx, conn, slot)
+	if err != nil {
+		t.Fatalf("QuerySlotHealth after drop: %v", err)
+	}
+	if h.Exists {
+		t.Error("slot still exists after DropSlot")
+	}
+
+	// Idempotent: dropping again is a no-op, not an error.
+	if dropped, err := pgcapture.DropSlot(ctx, conn, slot); err != nil || dropped {
+		t.Errorf("DropSlot(already dropped) = (%t, %v), want (false, nil)", dropped, err)
+	}
+}

--- a/internal/pgstreamrun/pgdoctor.go
+++ b/internal/pgstreamrun/pgdoctor.go
@@ -229,15 +229,16 @@ func slotHealthResult(h pgcapture.SlotHealth, slotName string) doctor.CheckResul
 }
 
 // lostSlotRemediation frames the lost-slot recovery path: capture is broken, but the
-// index (and therefore recovery) is not. The manual re-baseline SQL mirrors the
-// docs; the `bintrail-pg reset` convenience command is a later slice (#532).
+// index (and therefore recovery) is not. It points at `bintrail-pg reset`, which does
+// the dual-plane teardown (drop slot + clear checkpoint), with the manual SQL kept as
+// the under-the-hood explanation.
 func lostSlotRemediation(slotName string) string {
 	return "The replication slot is invalidated — the WAL it needs is gone, so capture cannot resume.\n" +
 		"The index is still fully usable for recovery (recovery never needs the slot).\n" +
 		"To resume capture you must re-baseline:\n" +
-		fmt.Sprintf("  1. on the source:  SELECT pg_drop_replication_slot('%s');\n", slotName) +
-		"  2. on the index:   DELETE FROM stream_state WHERE id = 1;\n" +
-		"  3. re-seed the baseline, then re-run `bintrail-pg stream`\n" +
+		fmt.Sprintf("  1. bintrail-pg reset --query-dsn <pg> --index-dsn <idx> --slot %s --force\n", slotName) +
+		"     (drops the slot on the source + clears the index checkpoint; --index-only if the slot is already gone)\n" +
+		"  2. re-seed the baseline, then re-run `bintrail-pg stream`\n" +
 		"Prevent recurrence: raise max_slot_wal_keep_size and keep the consumer running."
 }
 

--- a/internal/pgstreamrun/pgdoctor_test.go
+++ b/internal/pgstreamrun/pgdoctor_test.go
@@ -48,7 +48,7 @@ func TestSlotHealthResult_lostHasRecoveryPath(t *testing.T) {
 	if got.Status != doctor.StatusFail {
 		t.Fatalf("lost slot must FAIL, got %q", got.Status)
 	}
-	for _, want := range []string{"pg_drop_replication_slot('s1')", "DELETE FROM stream_state", "recovery never needs the slot"} {
+	for _, want := range []string{"bintrail-pg reset", "--slot s1", "recovery never needs the slot"} {
 		if !strings.Contains(got.Remediation, want) {
 			t.Errorf("lost remediation missing %q:\n%s", want, got.Remediation)
 		}

--- a/internal/pgstreamrun/pgstreamrun_integration_test.go
+++ b/internal/pgstreamrun/pgstreamrun_integration_test.go
@@ -354,6 +354,77 @@ func TestOne_LostSlot_FirstRun_SeedsLossBadge(t *testing.T) {
 	}
 }
 
+// TestDropSlot_ActiveSlotErrors covers DropSlot's safety branch: while a capture is
+// running and holds the slot, DropSlot must fail loud ("replication slot is active for
+// PID N") rather than silently no-op — so `bintrail-pg reset` tells the operator to
+// stop the stream first. A running One provides the live consumer.
+func TestDropSlot_ActiveSlotErrors(t *testing.T) {
+	pgDSN := testutil.SkipIfNoPostgres(t)
+	testutil.SkipIfNoMySQL(t)
+	ctx := context.Background()
+
+	_, dbName := testutil.CreateTestDB(t) // One bootstraps the index tables itself
+	indexDSN := testutil.BaseDSN() + "/" + dbName
+
+	const slot = "bintrail_activedrop_it"
+	const pub = "bintrail_activedrop_it_pub"
+	const tbl = "activedrop_it_t"
+
+	pg, err := pgx.Connect(ctx, pgDSN)
+	if err != nil {
+		t.Fatalf("connect PG: %v", err)
+	}
+	t.Cleanup(func() { pg.Close(context.Background()) })
+	dropAll := func() {
+		bg := context.Background()
+		_, _ = pg.Exec(bg, "DROP PUBLICATION IF EXISTS "+pub)
+		_, _ = pg.Exec(bg, "DROP TABLE IF EXISTS "+tbl)
+		_, _ = pg.Exec(bg, "SELECT pg_drop_replication_slot($1) WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name=$1)", slot)
+	}
+	dropAll()
+	t.Cleanup(dropAll)
+	for _, ddl := range []string{
+		fmt.Sprintf("CREATE TABLE %s (id int PRIMARY KEY, v text)", tbl),
+		fmt.Sprintf("ALTER TABLE %s REPLICA IDENTITY FULL", tbl),
+		fmt.Sprintf("CREATE PUBLICATION %s FOR TABLE %s", pub, tbl),
+	} {
+		if _, err := pg.Exec(ctx, ddl); err != nil {
+			t.Fatalf("exec %q: %v", ddl, err)
+		}
+	}
+
+	runCtx, cancel := context.WithCancel(ctx)
+	runErr := make(chan error, 1)
+	go func() {
+		runErr <- pgstreamrun.One(runCtx, pgstreamrun.Config{
+			IndexDSN: indexDSN, ReplDSN: replDSN(pgDSN), QueryDSN: pgDSN,
+			SlotName: slot, Publication: pub, ServerID: 53,
+			Tables: "public." + tbl, BatchSize: 100, Checkpoint: 200 * time.Millisecond,
+		})
+	}()
+	waitFor(t, 15*time.Second, func() bool {
+		var active bool
+		if err := pg.QueryRow(ctx, "SELECT active FROM pg_replication_slots WHERE slot_name=$1", slot).Scan(&active); err != nil {
+			return false
+		}
+		return active
+	}, "replication slot active")
+
+	// A separate connection tries to drop the in-use slot — PostgreSQL refuses.
+	conn, err := pgx.Connect(ctx, pgDSN)
+	if err != nil {
+		t.Fatalf("connect drop conn: %v", err)
+	}
+	_, dropErr := pgcapture.DropSlot(ctx, conn, slot)
+	conn.Close(ctx)
+	if dropErr == nil || !strings.Contains(dropErr.Error(), "active") {
+		t.Errorf("DropSlot on an active slot = %v, want an 'active' error", dropErr)
+	}
+
+	cancel()
+	<-runErr
+}
+
 // TestOne_CapturerFailureSurfaces proves the cancellation bridge in One: when the
 // capturer fails on its own (here: a non-existent publication makes cap.Run return
 // before streaming), One must surface that error PROMPTLY rather than hang forever


### PR DESCRIPTION
## What & why

Completes the PostgreSQL slot/WAL-retention **GA gate** (#532, part 3). Part 1 (`bintrail-pg doctor`, #583) and part 2 (durable lost-slot badge in `status`, #586) covered visibility; this slice adds **clean teardown** + the operator docs.

## Changes

- **`pgcapture.DropSlot`** — idempotent slot drop on a query connection (`dropped=false` when absent; errors loud if the slot is **active**, i.e. a running stream holds it).
- **`bintrail-pg reset`** — the two-system teardown that otherwise had to be done by hand: drops the slot on the **source**, then clears the checkpoint in the **index** (`DELETE stream_state`). **Slot first**, so an interrupted reset fails safe ("slot gone, checkpoint stale → next stream fails loud" rather than "checkpoint cleared, slot live → silent skip"). `--force` gates the destructive op; `--index-only` clears just the checkpoint for the already-lost/gone-slot case; a never-streamed index (missing `stream_state`) is handled gracefully. **Recovery data is untouched.**
- **`docs/postgres.md`** — `max_slot_wal_keep_size` added to the requirements table (the production safety valve); a "Checking slot health" subsection (doctor, the `wal_status` progression, the `EVENTS PERMANENTLY LOST` badge); the re-seed section now uses `bintrail-pg reset` (manual SQL kept as the under-the-hood explanation); troubleshooting cross-references doctor/reset.

## The user decisions, applied
- **`bintrail-pg reset` subcommand** (not a `--drop-slot` flag on `stream`) — teardown stays a deliberate, explicit op.
- **`--index-only`** for the already-lost case.

## Tests
- **Integration (live PG):** `DropSlot` — present → dropped; absent → idempotent no-op.
- **Unit:** reset config validation — required flags, the `--force` gate, `--index-only` skipping query/slot, env fallback, `isTableMissingErr`.
- Build/vet/gofmt + the `pgfree` guard (reset.go links pgx — stays in `cmd/bintrail-pg`) green.

## #532 acceptance — complete
- ✅ Resume after restart from the saved LSN; gap detection over LSN (lost/missing slot → fail loud) — #534/#586.
- ✅ Slot lag visible in `doctor`; a `lost` slot surfaces loudly with the recovery path in **both** `doctor` (#583) and `status` (#586).
- ✅ Slot is dropped cleanly on teardown — this PR.
- ✅ `max_slot_wal_keep_size` documented as the prerequisite — this PR.

Closes #532

🤖 Generated with [Claude Code](https://claude.com/claude-code)