### PR TITLE
feat(console): cascade recovery frontend tab (#580)

### DIFF
--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -39,7 +39,7 @@ const EVENT_CSV_COLUMNS = [
 const BADGE_CLASS = { UPDATE: "b-update", INSERT: "b-insert", DELETE: "b-delete" };
 function badgeClass(t) { return BADGE_CLASS[t] || "b-baseline"; }
 
-const ROUTES = ["overview", "events", "timetravel", "recover", "status", "storage"];
+const ROUTES = ["overview", "events", "timetravel", "recover", "cascade", "status", "storage"];
 
 const MON_STATE_TITLES = {
   failed: "stream failing — retrying with backoff; press Start for details",
@@ -558,6 +558,8 @@ function navigate(route, params, push = true) {
   if (!ROUTES.includes(route)) route = "overview";
   // Reconstruct surface is gated; never navigate to a disabled Time-travel.
   if (route === "timetravel" && !capsCache.reconstruct) route = "overview";
+  // Cascade recovery is the free tier but refused under an RBAC profile.
+  if (route === "cascade" && !capsCache.recover_cascade) route = "overview";
   // Storage is a watch-daemon surface (rotation + archiving live there).
   if (route === "storage" && !capsCache.monitor) route = "overview";
   const qs = params && Object.keys(params).length
@@ -576,6 +578,7 @@ function renderRoute() {
     case "events": return renderEvents(params);
     case "timetravel": return renderTimetravel(params);
     case "recover": return renderRecover(params);
+    case "cascade": return renderCascade(params);
     case "status": return renderStatus();
     case "storage": return renderStorage();
     default: return renderOverview();
@@ -1145,6 +1148,94 @@ function undoEvent(e) {
     type: e.event_type, time: e.event_timestamp,
   };
   navigate("recover");
+}
+
+// ── Cascade recovery ──────────────────────────────────────────────────────────
+
+function renderCascade(params) {
+  // Gated off (direct URL or Back): rewrite to /overview and re-dispatch.
+  // replaceState (not navigate) avoids re-entering this guard — see renderTimetravel.
+  if (!capsCache.recover_cascade) { history.replaceState({}, "", "/overview"); renderRoute(); return; }
+  const v = VIEW(); clear(v);
+  const sub = el("p", { class: "page-sub" },
+    "Reverse a foreign-key ON DELETE CASCADE / SET NULL that InnoDB ran below the binlog. Give the ",
+    el("b", { text: "parent" }),
+    " table whose delete cascaded; its synthesized child victims become reversal SQL. ",
+    el("b", { text: "Nothing is ever executed" }),
+    " — review, then apply the script yourself.");
+  v.append(pageHead("Cascade recovery", sub));
+
+  const form = el("form", { class: "filters", id: "cascade-form" });
+  form.append(fieldSelect("Parent schema", "schema", "md", true, false, null, "— select —"));
+  form.append(fieldSelect("Parent table", "table", "md", false, true));
+  form.append(fieldInput("PK", "pk", "sm", "42 or 42|7"));
+  form.append(fieldInput("Since", "since", "md", "YYYY-MM-DD HH:MM"));
+  form.append(fieldInput("Until", "until", "md", "YYYY-MM-DD HH:MM"));
+  form.append(fieldInput("Lookback", "lookback", "sm", "30d"));
+  form.append(fieldInput("Max depth", "max_depth", "sm", "5"));
+  const incField = el("div", { class: "field", style: "justify-content:flex-end" },
+    el("label", { class: "check" }, el("input", { type: "checkbox", name: "allow_incomplete" }), el("span", { text: "Allow incomplete" })));
+  form.append(incField);
+  const actions = el("div", { class: "filter-actions" });
+  actions.append(el("button", { class: "btn btn-primary", type: "submit", text: "Generate cascade recovery SQL" }));
+  form.append(actions);
+  v.append(form);
+
+  v.append(el("div", { id: "cascade-warnings", class: "warnings" }));
+  const out = el("div", { id: "cascade-out" });
+  out.append(el("div", { class: "tt-meta", text: "Pick a deleted parent row, then generate its cascade recovery SQL." }));
+  v.append(out);
+
+  form.addEventListener("submit", (e) => { e.preventDefault(); runCascade(form); });
+  wireSchemaCascade(form);
+  populateSchemas(form);
+
+  // Optional deep-link prefill (schema/table/pk) — survives the async schema load.
+  if (params && params.schema) {
+    setSelectWhenReady(form, "schema", params.schema, () => {
+      if (params.table) form.elements.table.value = params.table;
+      if (params.pk) form.elements.pk.value = params.pk;
+    });
+  }
+  viewEnter();
+}
+
+async function runCascade(form) {
+  const gen = serverGen;
+  const warns = $("#cascade-warnings", VIEW());
+  const out = $("#cascade-out", VIEW());
+  const f = Object.fromEntries(new FormData(form).entries());
+  if (!f.schema || !f.table) { clear(warns); renderError(out, "parent schema and table are required"); return; }
+  const body = {};
+  ["schema", "table", "pk", "since", "until", "lookback"].forEach((k) => { if (f[k] && f[k].trim()) body[k] = f[k].trim(); });
+  // max_depth must be a JSON int — a string fails Go's unmarshal; omit when blank.
+  if (f.max_depth && f.max_depth.trim()) {
+    const d = parseInt(f.max_depth.trim(), 10);
+    if (!Number.isNaN(d)) body.max_depth = d;
+  }
+  // allow_incomplete must be a real boolean (a server-side no-op, sent for symmetry).
+  body.allow_incomplete = !!(form.elements.allow_incomplete && form.elements.allow_incomplete.checked);
+  try {
+    const data = await api("/api/recover-cascade", { method: "POST", body });
+    if (gen !== serverGen) return;
+    // Coverage UX: a partial recovery must NEVER read as whole. Drive the banner
+    // off the response `complete` flag (NOT the allow_incomplete checkbox, which is
+    // a server-side no-op), and surface `incomplete` — the cascade response has no
+    // `warnings` key, so reading data.warnings would silently drop every caveat.
+    const caveats = data.incomplete || [];
+    if (!data.complete) {
+      renderWarnings(warns, ["INCOMPLETE — this recovery is provably partial; do not treat it as a full restore.", ...caveats]);
+    } else {
+      renderWarnings(warns, caveats);
+    }
+    lastSQL = data.sql || "";
+    clear(out);
+    out.append(codePanel(lastSQL,
+      data.statement_count + " statement(s) · " + data.victim_count + " victim(s) · " + data.set_null_count + " SET NULL restore(s)"));
+  } catch (err) {
+    if (gen !== serverGen) return;
+    clear(warns); renderError(out, err);
+  }
 }
 
 // ── Time-travel (reconstruct) ─────────────────────────────────────────────────
@@ -2149,6 +2240,7 @@ function cmdkCommands() {
     { group: "Navigate", label: "Status", run: () => navigate("status") },
   ];
   if (capsCache.reconstruct) cmds.push({ group: "Navigate", label: "Time-travel", run: () => navigate("timetravel") });
+  if (capsCache.recover_cascade) cmds.push({ group: "Navigate", label: "Cascade recovery", run: () => navigate("cascade") });
   if (capsCache.monitor) cmds.push({ group: "Navigate", label: "Storage", run: () => navigate("storage") });
   cmds.push({ group: "Actions", label: "Manage servers", run: () => { closeCmdk(); openServersModal(); } });
   if (capsCache.monitor) cmds.push({ group: "Actions", label: "Configure rotation…", run: () => { closeCmdk(); showRotationDialog(); } });

--- a/internal/console/assets/index.html
+++ b/internal/console/assets/index.html
@@ -71,6 +71,10 @@
             <span class="ni-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7v6h6"/><path d="M3 13a9 9 0 1 0 3-7.7L3 8"/></svg></span>
             <span>Recover</span>
           </a>
+          <a class="nav-item" data-route="cascade" href="/cascade" data-capability="recover_cascade">
+            <span class="ni-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="6" r="2.2"/><circle cx="18" cy="12" r="2.2"/><circle cx="18" cy="19" r="2.2"/><path d="M6 8.2v3.3a3 3 0 0 0 3 3h6.8"/><path d="M8.2 6H16"/></svg></span>
+            <span>Cascade recovery</span>
+          </a>
         </div>
         <div class="nav-group">
           <div class="nav-label">Monitor</div>

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -151,6 +151,77 @@ try {
     ? ok("form: advanced section expanded for a BYO-index entry")
     : bad("form: advanced section expanded for a BYO-index entry", "collapsed — the byoIndex open-arm regressed");
 
+  // Scenario 6 — Cascade recovery tab (#580). The class/[data-capability] gating
+  // bug class is invisible to Go tests, so pin it here: the nav item + ⌘K entry
+  // appear when recover_cascade is on (free tier, true here — no RBAC profile),
+  // the tab renders its parent form, and — critically — both the nav item HIDES
+  // and the route REDIRECTS to overview when the capability is off.
+  await page.evaluate(() => closeServersModal());
+  const casc = await page.evaluate(() => {
+    const navItem = document.querySelector('.nav-item[data-route="cascade"]');
+    const cmds = (typeof cmdkCommands === "function") ? cmdkCommands().map((c) => c.label) : [];
+    return {
+      capOn: typeof capsCache !== "undefined" && !!capsCache.recover_cascade,
+      navPresent: !!navItem,
+      navVisible: navItem ? getComputedStyle(navItem).display !== "none" : false,
+      inPalette: cmds.includes("Cascade recovery"),
+    };
+  });
+  casc.capOn ? ok("cascade: recover_cascade capability reported") : bad("cascade: recover_cascade capability reported", "false — expected true (no RBAC profile)");
+  casc.navPresent ? ok("cascade: nav item present") : bad("cascade: nav item present", "missing from DOM");
+  casc.navVisible ? ok("cascade: nav item visible when capability on") : bad("cascade: nav item visible when capability on", "hidden despite cap-on");
+  casc.inPalette ? ok("cascade: command-palette entry present") : bad("cascade: command-palette entry present", "missing");
+
+  await page.evaluate(() => navigate("cascade"));
+  await page.waitForSelector("#cascade-form", { timeout: 5000 });
+  const cform = await page.evaluate(() => {
+    const f = document.getElementById("cascade-form");
+    if (!f) return { form: false };
+    const btn = Array.from(f.querySelectorAll("button")).find((b) => /Generate cascade recovery SQL/.test(b.textContent));
+    return {
+      form: true,
+      onRoute: location.pathname === "/cascade",
+      schema: !!f.querySelector('[name="schema"]'),
+      table: !!f.querySelector('[name="table"]'),
+      pk: !!f.querySelector('[name="pk"]'),
+      allowInc: !!f.querySelector('[name="allow_incomplete"]'),
+      genBtn: !!btn,
+      warnings: !!document.getElementById("cascade-warnings"),
+    };
+  });
+  cform.form ? ok("cascade: form renders on the tab") : bad("cascade: form renders on the tab", "#cascade-form missing");
+  cform.onRoute ? ok("cascade: navigates to /cascade") : bad("cascade: navigates to /cascade", "wrong route");
+  (cform.schema && cform.table && cform.pk) ? ok("cascade: parent schema/table/pk fields present") : bad("cascade: parent schema/table/pk fields present", JSON.stringify(cform));
+  cform.allowInc ? ok("cascade: allow-incomplete checkbox present") : bad("cascade: allow-incomplete checkbox present", "missing");
+  cform.genBtn ? ok("cascade: generate action present") : bad("cascade: generate action present", "button missing");
+  cform.warnings ? ok("cascade: warnings container present") : bad("cascade: warnings container present", "missing");
+
+  const off = await page.evaluate(() => {
+    capsCache.recover_cascade = false;
+    // Re-apply the same cap-on toggle gateCapabilities() runs (without refetching,
+    // which would reset the flag) — this is the exact class gating under test.
+    document.querySelectorAll("[data-capability]").forEach((n) => n.classList.toggle("cap-on", !!capsCache[n.dataset.capability]));
+    const navItem = document.querySelector('.nav-item[data-route="cascade"]');
+    const navHidden = navItem ? getComputedStyle(navItem).display === "none" : false;
+    // (a) navigate() guard: navigating to a gated route bounces to overview.
+    navigate("cascade");
+    const navGuard = location.pathname === "/overview";
+    // (b) renderCascade's OWN replaceState self-guard. A direct dispatch — a
+    // bookmarked/typed /cascade URL, Back/popstate, or boot — reaches renderRoute
+    // WITHOUT navigate()'s guard, so the in-render guard is the sole defense there.
+    // Force /cascade and call renderCascade directly: it must redirect AND render
+    // no form (deleting that guard would leave this the only failing assertion).
+    history.replaceState({}, "", "/cascade");
+    renderCascade({});
+    const renderGuard = location.pathname === "/overview" && !document.getElementById("cascade-form");
+    capsCache.recover_cascade = true; // restore for any later scenarios
+    document.querySelectorAll("[data-capability]").forEach((n) => n.classList.toggle("cap-on", !!capsCache[n.dataset.capability]));
+    return { navHidden, navGuard, renderGuard };
+  });
+  off.navHidden ? ok("cascade: nav item hides when capability off") : bad("cascade: nav item hides when capability off", "still visible — gating regression");
+  off.navGuard ? ok("cascade: navigate() guard redirects to overview when off") : bad("cascade: navigate() guard redirects to overview when off", "did not redirect");
+  off.renderGuard ? ok("cascade: renderCascade self-guard redirects direct/popstate entry when off") : bad("cascade: renderCascade self-guard redirects direct/popstate entry when off", "form rendered or no redirect — the in-render guard gap");
+
   // No uncaught JS errors over the whole run.
   jsErrors.length === 0 ? ok("no uncaught JS errors") : bad("no uncaught JS errors", JSON.stringify(jsErrors));
 } catch (err) {


### PR DESCRIPTION
closes #580

## Summary

Slice C of console cascade (#577) — **completes the epic**. A new **Cascade recovery** tab in the read-only web console (modeled on Time-travel), driving the slice-B `POST /api/recover-cascade`. Never executes SQL.

- **`internal/console/assets/app.js`**: `renderCascade`/`runCascade` + the route wired in `ROUTES`, the `navigate()` capability guard, the `renderRoute` switch, and a ⌘K command — all gated on `recover_cascade`. Form takes the **parent** schema/table/PK + since/until/lookback/max-depth + an allow-incomplete checkbox; result is a code panel (Copy/Download) + a prominent coverage banner.
- **`internal/console/assets/index.html`**: nav item in the Resolve group with `data-route="cascade" data-capability="recover_cascade"` — the CSS `.cap-on` gating and the generic nav click binding are automatic (no JS wiring).

## Coverage UX (the issue's hard requirement)

A partial recovery must **never** read as whole. The banner is driven off the response `complete` flag (NOT the allow-incomplete checkbox, which is a server-side no-op) and surfaces `incomplete[]` — the cascade response has **no `warnings` key**, so a verbatim copy of the reconstruct tab would silently drop every caveat. When `complete=false`, a bold "INCOMPLETE — provably partial" lead caveat is prepended, echoing the CLI framing.

## Clone-bug guards

`max_depth` is sent as a **JSON int** (a string fails Go's unmarshal); `allow_incomplete` as a **real boolean**; `lastSQL` is set **before** `codePanel` so Copy/Download serve the cascade SQL, not stale.

## Scope (Occam)

**One "Generate" action** — the endpoint is dry-run and returns SQL+counts together, so `victim_count`/`set_null_count` ARE the victim preview (no victim-rows endpoint exists, and showing rows would breach the connection_id-free boundary). The optional event-row **"Undo cascade" deep-link is deferred**.

## Verification — real headless Chrome

`test/console-e2e/console_e2e.mjs` extended with **+12 cascade assertions (26/26 pass)**, driven against a live console with system Chrome: nav item + ⌘K entry appear with the capability on, the form renders, and — **the gating-bug class Go tests can't see** — the nav item **hides** and the route **redirects to overview** when `recover_cascade` is off.

## Test plan
- [x] `go build ./...`; `go test ./internal/console/` green (assets embedded)
- [x] `node --check` on app.js
- [x] Headless-Chrome E2E: 26/26 (12 new cascade assertions) via `PW_CHANNEL=chrome test/console-e2e/run.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)