### PR TITLE
feat(pg): pre-beta no-silent-loss guards + DDL-drift test coverage (#555 #556 #559 #591)

### DIFF
--- a/internal/pgcapture/capturer.go
+++ b/internal/pgcapture/capturer.go
@@ -195,15 +195,20 @@ func (c *Capturer) Run(ctx context.Context, out chan<- event.Event) error {
 // logged at debug and never blocks the stream — these are advisory, and the same
 // catalog state is also reported by `bintrail-pg doctor`.
 func (c *Capturer) warnCaptureCoverage(ctx context.Context, conn *pgx.Conn) {
-	if unlogged, err := listUnloggedPublishedTables(ctx, conn, c.cfg.Publication); err != nil {
-		c.logger.Debug("pgcapture: could not check for UNLOGGED tables", "error", err)
+	// A probe FAILURE is itself surfaced as a WARN, not swallowed at Debug: at the
+	// default --log-level=info a Debug line is invisible, so downgrading the failure
+	// would silently disable the very guard this function exists to provide — the exact
+	// silent-failure class #555/#556 close. Visibility matches the doctor side, which
+	// also maps a probe failure to a WARN.
+	if unlogged, err := listUnloggedCaptureTables(ctx, conn, c.cfg.Publication, c.cfg.Filters); err != nil {
+		c.logger.Warn("pgcapture: UNLOGGED-table coverage check failed to run — could NOT determine whether a captured table writes no WAL (a silent recovery hole); run `bintrail-pg doctor` to re-check", "error", err)
 	} else if len(unlogged) > 0 {
-		c.logger.Warn("pgcapture: UNLOGGED table(s) in the publication produce no WAL — their changes are NOT captured and cannot be recovered (ALTER TABLE <t> SET LOGGED if you need them)",
+		c.logger.Warn("pgcapture: UNLOGGED table(s) in capture scope produce no WAL — their changes are NOT captured and cannot be recovered (ALTER TABLE <t> SET LOGGED if you need them)",
 			"tables", strings.Join(unlogged, ", "))
 	}
 
 	if children, err := listUncoveredCascadeChildren(ctx, conn, c.cfg.Publication); err != nil {
-		c.logger.Debug("pgcapture: could not check FK cascade-child coverage", "error", err)
+		c.logger.Warn("pgcapture: FK cascade-child coverage check failed to run — could NOT determine whether a cascade child is unpublished (cascade deletes would be silently lost); run `bintrail-pg doctor` to re-check", "error", err)
 	} else {
 		for _, ch := range children {
 			c.logger.Warn("pgcapture: FK cascade child is NOT in the publication — cascade deletes from its parent are not captured and cannot be recovered (add it to the publication)",

--- a/internal/pgcapture/capturer.go
+++ b/internal/pgcapture/capturer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -137,6 +138,13 @@ func (c *Capturer) Run(ctx context.Context, out chan<- event.Event) error {
 		return err
 	}
 
+	// Non-fatal capture-coverage warnings (#555 UNLOGGED, #556 FK cascade child): tables
+	// whose changes will be silently ABSENT from the index. Unlike the validate* gates
+	// above, these do NOT abort capture (an operator may keep UNLOGGED data on purpose,
+	// and a missing cascade child may be intentionally out of recovery scope) — but they
+	// must be visible now, not discovered during a failed recovery.
+	c.warnCaptureCoverage(startupCtx, queryConn)
+
 	startLSN, err := ensureSlot(startupCtx, replConn, queryConn, c.cfg.SlotName, c.cfg.StartLSN, c.cfg.ExpectExistingSlot)
 	if err != nil {
 		return err
@@ -180,6 +188,28 @@ func (c *Capturer) Run(ctx context.Context, out chan<- event.Event) error {
 		return nil // graceful shutdown (ctx-cancel surfaced as a receive/emit error)
 	}
 	return err
+}
+
+// warnCaptureCoverage logs the non-fatal coverage gaps (#555 UNLOGGED tables, #556 FK
+// cascade children whose parent is published but the child is not). A probe FAILURE is
+// logged at debug and never blocks the stream — these are advisory, and the same
+// catalog state is also reported by `bintrail-pg doctor`.
+func (c *Capturer) warnCaptureCoverage(ctx context.Context, conn *pgx.Conn) {
+	if unlogged, err := listUnloggedPublishedTables(ctx, conn, c.cfg.Publication); err != nil {
+		c.logger.Debug("pgcapture: could not check for UNLOGGED tables", "error", err)
+	} else if len(unlogged) > 0 {
+		c.logger.Warn("pgcapture: UNLOGGED table(s) in the publication produce no WAL — their changes are NOT captured and cannot be recovered (ALTER TABLE <t> SET LOGGED if you need them)",
+			"tables", strings.Join(unlogged, ", "))
+	}
+
+	if children, err := listUncoveredCascadeChildren(ctx, conn, c.cfg.Publication); err != nil {
+		c.logger.Debug("pgcapture: could not check FK cascade-child coverage", "error", err)
+	} else {
+		for _, ch := range children {
+			c.logger.Warn("pgcapture: FK cascade child is NOT in the publication — cascade deletes from its parent are not captured and cannot be recovered (add it to the publication)",
+				"child", ch.Child, "parent", ch.Parent, "action", ch.Action)
+		}
+	}
 }
 
 // receiveLoop is the single-goroutine replication loop. pgconn is NOT concurrency-

--- a/internal/pgcapture/decoder.go
+++ b/internal/pgcapture/decoder.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/jackc/pglogrepl"
@@ -51,6 +52,11 @@ type Decoder struct {
 
 	relations map[uint32]*relationInfo
 	txn       txnContext
+
+	// timescaleWarned makes the TimescaleDB out-of-scope guard (#559) warn ONCE per
+	// stream: a busy hypertable has many chunk relations, and one warning per chunk
+	// would flood the log.
+	timescaleWarned bool
 }
 
 // DecoderOption configures optional Decoder dependencies without churning the
@@ -185,6 +191,21 @@ func (d *Decoder) Decode(msg pglogrepl.Message) (event.Event, bool, error) {
 // again after a relation's shape changes, so this doubles as cache invalidation —
 // the analog of the MySQL parser's SwapResolver-on-DDL.
 func (d *Decoder) cacheRelation(m *pglogrepl.RelationMessage) error {
+	// TimescaleDB out-of-scope guard (#559): a hypertable's data lives in physical
+	// CHUNK tables (_hyper_<id>_<n>_chunk) under the _timescaledb_internal schema, and
+	// pgoutput streams those chunk relations by their physical names — so bintrail would
+	// index changes under _timescaledb_internal._hyper_* rather than the logical
+	// hypertable (a decode-granularity mismatch). We do NOT silently skip them, but the
+	// operator MUST know the captured target is the chunk, not the parent table — warn
+	// once, before the RI check below so the signal survives even if the chunk is not at
+	// FULL. This is BEFORE the cache write: the warning is about target identity, not a
+	// reason to stop.
+	if !d.timescaleWarned && isTimescaleChunk(m.Namespace, m.RelationName) {
+		d.logger.Warn("pgcapture: TimescaleDB hypertable chunk detected — bintrail indexes raw chunk relations under _timescaledb_internal, NOT the logical hypertable; TimescaleDB is out of scope (decode-granularity mismatch)",
+			"schema", m.Namespace, "table", m.RelationName)
+		d.timescaleWarned = true
+	}
+
 	// REPLICA IDENTITY FULL enforcement at the LIVE boundary, not just startup: a
 	// table added to a FOR ALL TABLES publication after Run started (or any mid-stream
 	// new relation) arrives here as a fresh RelationMessage at PostgreSQL's default
@@ -268,6 +289,17 @@ func (d *Decoder) cacheRelation(m *pglogrepl.RelationMessage) error {
 		pkCols:  pkCols,
 	}
 	return nil
+}
+
+// isTimescaleChunk reports whether a relation is a TimescaleDB hypertable chunk — the
+// internal physical tables (_hyper_<id>_<n>_chunk, or _dist_hyper_* for distributed
+// hypertables) under the _timescaledb_internal schema that pgoutput streams in place
+// of the logical hypertable. Used by the #559 out-of-scope guard. (TimescaleDB's
+// catalog/config schemas — _timescaledb_catalog, _timescaledb_config — are not chunk
+// data and are not flagged here.)
+func isTimescaleChunk(schema, table string) bool {
+	return schema == "_timescaledb_internal" &&
+		(strings.HasPrefix(table, "_hyper_") || strings.HasPrefix(table, "_dist_hyper_"))
 }
 
 // relationEvent builds an EventRelation carrying the relation's shape for the

--- a/internal/pgcapture/decoder_test.go
+++ b/internal/pgcapture/decoder_test.go
@@ -1,7 +1,9 @@
 package pgcapture_test
 
 import (
+	"bytes"
 	"encoding/json"
+	"log/slog"
 	"strings"
 	"testing"
 	"time"
@@ -626,5 +628,82 @@ func TestDecode_NoAttrResolverDefaultsFalse(t *testing.T) {
 		if c.IsIdentityAlways || c.IsGenerated {
 			t.Errorf("col %s: flags should default false without an AttrResolver, got %+v", c.Name, c)
 		}
+	}
+}
+
+// ─── DDL drift: mid-stream shape change (#591) ─────────────────────────────────
+
+// TestDecode_RelationShapeChange_MidStream pins the DDL-drift gate (#591): pgoutput
+// re-emits a RelationMessage after a relation's shape changes (e.g. ALTER TABLE ... ADD
+// COLUMN), and cacheRelation must swap to the new shape so subsequent rows decode
+// against it — the analog of the MySQL parser's SwapResolver-on-DDL. This is the unit
+// half (no live PG); TestOne_DDLDrift_MidStreamAlter drives a real ALTER end-to-end.
+func TestDecode_RelationShapeChange_MidStream(t *testing.T) {
+	d := pgcapture.NewDecoder(pkResolver("id"), event.Filters{}, nil)
+
+	// Initial shape: (id, a).
+	mustDecode(t, d, relMsg(1, "public", "t", "id", "a"))
+	mustDecode(t, d, beginMsg())
+	ev1, emit1 := mustDecode(t, d, &pglogrepl.InsertMessage{
+		RelationID: 1, Tuple: tuple(textCol("1"), textCol("x")),
+	})
+	if !emit1 {
+		t.Fatal("pre-ALTER INSERT should emit")
+	}
+	if len(ev1.RowAfter) != 2 || ev1.RowAfter["id"] != "1" || ev1.RowAfter["a"] != "x" {
+		t.Fatalf("pre-ALTER RowAfter = %v, want {id:1, a:x}", ev1.RowAfter)
+	}
+	if _, ok := ev1.RowAfter["b"]; ok {
+		t.Fatalf("pre-ALTER RowAfter must not carry column b: %v", ev1.RowAfter)
+	}
+	mustDecode(t, d, &pglogrepl.CommitMessage{CommitLSN: txnLSN, CommitTime: txnTime})
+
+	// Mid-stream shape change: (id, a, b) — the RelationMessage PostgreSQL re-emits after
+	// ALTER TABLE t ADD COLUMN b. Same OID, a new column set.
+	mustDecode(t, d, relMsg(1, "public", "t", "id", "a", "b"))
+	mustDecode(t, d, beginMsg())
+
+	// The DISCRIMINATOR: decoding a 3-column tuple only succeeds if cacheRelation swapped
+	// to the new 3-column shape. Against the stale 2-column relation, decodeTuple errors
+	// with a column-count mismatch (mustDecode would t.Fatal). A passing decode that
+	// dropped column b would be caught by the assertions below.
+	ev2, emit2 := mustDecode(t, d, &pglogrepl.InsertMessage{
+		RelationID: 1, Tuple: tuple(textCol("2"), textCol("y"), textCol("z")),
+	})
+	if !emit2 {
+		t.Fatal("post-ALTER INSERT should emit")
+	}
+	if len(ev2.RowAfter) != 3 {
+		t.Fatalf("post-ALTER RowAfter should have 3 columns (shape swapped), got %v", ev2.RowAfter)
+	}
+	if ev2.RowAfter["id"] != "2" || ev2.RowAfter["a"] != "y" || ev2.RowAfter["b"] != "z" {
+		t.Fatalf("post-ALTER RowAfter = %v, want {id:2, a:y, b:z} (new column b present)", ev2.RowAfter)
+	}
+}
+
+// ─── TimescaleDB out-of-scope guard (#559) ─────────────────────────────────────
+
+// TestDecode_TimescaleChunk_WarnsOnce pins the #559 guard: a TimescaleDB hypertable
+// chunk relation (under _timescaledb_internal) is flagged so the operator knows capture
+// targets the raw chunk, not the logical hypertable — and the warning fires ONCE even
+// across many chunks, and never for an ordinary relation.
+func TestDecode_TimescaleChunk_WarnsOnce(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	d := pgcapture.NewDecoder(pkResolver("ts"), event.Filters{}, logger)
+
+	// Two distinct chunks of the same hypertable → two RelationMessages.
+	mustDecode(t, d, relMsg(10, "_timescaledb_internal", "_hyper_1_1_chunk", "ts", "v"))
+	mustDecode(t, d, relMsg(11, "_timescaledb_internal", "_hyper_1_2_chunk", "ts", "v"))
+
+	if n := strings.Count(buf.String(), "TimescaleDB hypertable chunk detected"); n != 1 {
+		t.Fatalf("want exactly ONE TimescaleDB warning across two chunks, got %d:\n%s", n, buf.String())
+	}
+
+	// An ordinary (non-chunk) relation must not warn.
+	buf.Reset()
+	mustDecode(t, d, relMsg(12, "public", "metrics", "ts", "v"))
+	if strings.Contains(buf.String(), "TimescaleDB") {
+		t.Fatalf("ordinary relation must not warn: %s", buf.String())
 	}
 }

--- a/internal/pgcapture/decoder_test.go
+++ b/internal/pgcapture/decoder_test.go
@@ -707,3 +707,25 @@ func TestDecode_TimescaleChunk_WarnsOnce(t *testing.T) {
 		t.Fatalf("ordinary relation must not warn: %s", buf.String())
 	}
 }
+
+// TestDecode_TimescaleChunk_WarnsBeforeReplicaIdentityAbort locks the warn-BEFORE-RI
+// ordering (#559): a chunk relation that is NOT at REPLICA IDENTITY FULL must still emit
+// the out-of-scope warning before cacheRelation's RI-FULL check aborts decoding. The
+// warn is placed first deliberately so the operator gets the TimescaleDB signal even
+// when the chunk is rejected; a future refactor moving the warn below the RI check would
+// silently regress this, so pin it.
+func TestDecode_TimescaleChunk_WarnsBeforeReplicaIdentityAbort(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	d := pgcapture.NewDecoder(pkResolver("ts"), event.Filters{}, logger)
+
+	rel := relMsg(10, "_timescaledb_internal", "_hyper_1_1_chunk", "ts", "v")
+	rel.ReplicaIdentity = 'd' // NOT full → cacheRelation will abort
+	_, _, err := d.Decode(rel)
+	if err == nil {
+		t.Fatal("expected a REPLICA IDENTITY FULL error for a non-FULL chunk relation")
+	}
+	if !strings.Contains(buf.String(), "TimescaleDB hypertable chunk detected") {
+		t.Fatalf("the TimescaleDB warning must fire BEFORE the RI-FULL abort, got:\n%s", buf.String())
+	}
+}

--- a/internal/pgcapture/slot.go
+++ b/internal/pgcapture/slot.go
@@ -183,6 +183,131 @@ func CheckReplicaIdentity(ctx context.Context, conn *pgx.Conn, publication strin
 	return checkReplicaIdentityTables(ctx, conn, publication)
 }
 
+// listUnloggedPublishedTables returns the "schema.table" of every UNLOGGED table the
+// publication streams. UNLOGGED tables generate NO WAL, so logical decoding never sees
+// their changes — they are captured as exactly nothing, silently. PostgreSQL lets an
+// UNLOGGED table sit in a publication without complaint, and an operator may keep
+// ephemeral data UNLOGGED on purpose, so this is surfaced as a WARNING (not the fatal
+// fail of validateReplicaIdentity): a coverage hole the operator should see now rather
+// than discover during a failed recovery. (#555)
+func listUnloggedPublishedTables(ctx context.Context, conn *pgx.Conn, publication string) ([]string, error) {
+	rows, err := conn.Query(ctx, `
+		SELECT pt.schemaname, pt.tablename
+		FROM pg_publication_tables pt
+		JOIN pg_namespace n ON n.nspname = pt.schemaname
+		JOIN pg_class c ON c.relname = pt.tablename AND c.relnamespace = n.oid
+		WHERE pt.pubname = $1 AND c.relpersistence = 'u'`, publication)
+	if err != nil {
+		return nil, fmt.Errorf("pgcapture: checking for UNLOGGED tables in publication %q: %w", publication, err)
+	}
+	defer rows.Close()
+
+	var unlogged []string
+	for rows.Next() {
+		var schema, table string
+		if err := rows.Scan(&schema, &table); err != nil {
+			return nil, fmt.Errorf("pgcapture: scanning UNLOGGED tables for publication %q: %w", publication, err)
+		}
+		unlogged = append(unlogged, schema+"."+table)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("pgcapture: checking for UNLOGGED tables in publication %q: %w", publication, err)
+	}
+	sort.Strings(unlogged)
+	return unlogged, nil
+}
+
+// ListUnloggedPublishedTables is the report-only form of the #555 UNLOGGED guard for
+// bintrail-pg doctor (a pure probe; no mutation). nil/empty means no UNLOGGED tables.
+func ListUnloggedPublishedTables(ctx context.Context, conn *pgx.Conn, publication string) ([]string, error) {
+	return listUnloggedPublishedTables(ctx, conn, publication)
+}
+
+// CascadeChild is one foreign-key cascade child whose PARENT the publication captures
+// but the child itself it does NOT — so a delete on the parent fires an ON DELETE
+// CASCADE / SET NULL / SET DEFAULT that rewrites the child, and that change is never
+// captured. (#556)
+type CascadeChild struct {
+	Child  string // "schema.table" of the FK-bearing (child) table
+	Parent string // "schema.table" of the referenced (parent) table
+	Action string // human action, e.g. "ON DELETE CASCADE"
+}
+
+// listUncoveredCascadeChildren returns cascade children whose parent IS in the
+// publication but the child is NOT. On PostgreSQL, FK ON DELETE CASCADE/SET NULL/SET
+// DEFAULT is performed by real per-row WAL ops on the child (unlike MySQL ≤8.x, which
+// does not log them) — so `recover` works directly IF the child is captured. When the
+// parent is published but the child is not, a cascade delete on the parent silently
+// rewrites rows we never indexed → unrecoverable, and invisible. This surfaces that as
+// a WARNING. (#556)
+//
+// A FOR ALL TABLES publication covers every child by construction, so this finds
+// nothing there; the gap is an explicit FOR TABLE publication that lists a parent but
+// forgets its cascade child. A PUBLISHED child is already forced to RI FULL by
+// checkReplicaIdentityTables, so only the not-published case needs surfacing here.
+//
+// Residual (documented, not covered here): a row that was deleted-by-cascade but never
+// existed in our captured history (it predates capture) is recoverable only from a
+// baseline — the PG baseline producer is a separate GA item (#593).
+func listUncoveredCascadeChildren(ctx context.Context, conn *pgx.Conn, publication string) ([]CascadeChild, error) {
+	rows, err := conn.Query(ctx, `
+		SELECT child_ns.nspname, child.relname, parent_ns.nspname, parent.relname, con.confdeltype
+		FROM pg_constraint con
+		JOIN pg_class child ON child.oid = con.conrelid
+		JOIN pg_namespace child_ns ON child_ns.oid = child.relnamespace
+		JOIN pg_class parent ON parent.oid = con.confrelid
+		JOIN pg_namespace parent_ns ON parent_ns.oid = parent.relnamespace
+		WHERE con.contype = 'f' AND con.confdeltype IN ('c', 'n', 'd')
+		  AND EXISTS (SELECT 1 FROM pg_publication_tables pt
+		              WHERE pt.pubname = $1 AND pt.schemaname = parent_ns.nspname AND pt.tablename = parent.relname)
+		  AND NOT EXISTS (SELECT 1 FROM pg_publication_tables pt
+		              WHERE pt.pubname = $1 AND pt.schemaname = child_ns.nspname AND pt.tablename = child.relname)`,
+		publication)
+	if err != nil {
+		return nil, fmt.Errorf("pgcapture: checking FK cascade-child coverage for publication %q: %w", publication, err)
+	}
+	defer rows.Close()
+
+	var out []CascadeChild
+	for rows.Next() {
+		var childSchema, childTable, parentSchema, parentTable, delType string
+		if err := rows.Scan(&childSchema, &childTable, &parentSchema, &parentTable, &delType); err != nil {
+			return nil, fmt.Errorf("pgcapture: scanning FK cascade-child coverage for publication %q: %w", publication, err)
+		}
+		out = append(out, CascadeChild{
+			Child:  childSchema + "." + childTable,
+			Parent: parentSchema + "." + parentTable,
+			Action: cascadeAction(delType),
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("pgcapture: checking FK cascade-child coverage for publication %q: %w", publication, err)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Child < out[j].Child })
+	return out, nil
+}
+
+// cascadeAction renders a pg_constraint.confdeltype code as its human FK action.
+func cascadeAction(confdeltype string) string {
+	switch confdeltype {
+	case "c":
+		return "ON DELETE CASCADE"
+	case "n":
+		return "ON DELETE SET NULL"
+	case "d":
+		return "ON DELETE SET DEFAULT"
+	default:
+		return "ON DELETE (" + confdeltype + ")"
+	}
+}
+
+// ListUncoveredCascadeChildren is the report-only form of the #556 cascade-coverage
+// guard for bintrail-pg doctor (a pure probe; no mutation). nil/empty means every
+// cascade child of a published parent is itself published.
+func ListUncoveredCascadeChildren(ctx context.Context, conn *pgx.Conn, publication string) ([]CascadeChild, error) {
+	return listUncoveredCascadeChildren(ctx, conn, publication)
+}
+
 // ensureSlot returns the LSN to start replication from, creating the slot on first
 // run. The first-run-vs-resume decision is gated on slot EXISTENCE in
 // pg_replication_slots (NOT on savedLSN==0 — an empty saved checkpoint decodes to

--- a/internal/pgcapture/slot.go
+++ b/internal/pgcapture/slot.go
@@ -183,22 +183,51 @@ func CheckReplicaIdentity(ctx context.Context, conn *pgx.Conn, publication strin
 	return checkReplicaIdentityTables(ctx, conn, publication)
 }
 
-// listUnloggedPublishedTables returns the "schema.table" of every UNLOGGED table the
-// publication streams. UNLOGGED tables generate NO WAL, so logical decoding never sees
-// their changes — they are captured as exactly nothing, silently. PostgreSQL lets an
-// UNLOGGED table sit in a publication without complaint, and an operator may keep
+// listUnloggedCaptureTables returns the "schema.table" of every UNLOGGED base table in
+// the capture scope. UNLOGGED tables generate NO WAL, so logical decoding never sees
+// their changes — they are captured as exactly nothing, silently; an operator may keep
 // ephemeral data UNLOGGED on purpose, so this is surfaced as a WARNING (not the fatal
 // fail of validateReplicaIdentity): a coverage hole the operator should see now rather
 // than discover during a failed recovery. (#555)
-func listUnloggedPublishedTables(ctx context.Context, conn *pgx.Conn, publication string) ([]string, error) {
-	rows, err := conn.Query(ctx, `
-		SELECT pt.schemaname, pt.tablename
-		FROM pg_publication_tables pt
-		JOIN pg_namespace n ON n.nspname = pt.schemaname
-		JOIN pg_class c ON c.relname = pt.tablename AND c.relnamespace = n.oid
-		WHERE pt.pubname = $1 AND c.relpersistence = 'u'`, publication)
+//
+// CRUCIAL: an UNLOGGED table is NEVER in pg_publication_tables, so it must be found
+// against pg_class directly. PostgreSQL refuses to add an UNLOGGED table to a FOR TABLE
+// publication ("cannot add relation ... to publication ... unlogged"), and it EXCLUDES
+// UNLOGGED tables from a FOR ALL TABLES publication's pg_publication_tables view
+// (pg_relation_is_publishable gates on relpersistence). A query over pg_publication_
+// tables therefore can never match an UNLOGGED row — it would be dead code.
+//
+// The dangerous case is FOR ALL TABLES: the operator believes "everything" is captured,
+// but the UNLOGGED tables silently are not. We scan user base tables for relpersistence
+// = 'u' and report the ones in the client filter scope. For a FOR TABLE publication an
+// UNLOGGED table cannot be in the publication at all, and a client --tables naming an
+// unpublished table is already a fatal coverage gap in validatePublication — so there
+// is nothing this guard could uniquely surface and it returns nil. (FOR TABLES IN
+// SCHEMA, PG 15+, is not covered here — a documented limitation, not silent: the doctor
+// still lists the check.)
+func listUnloggedCaptureTables(ctx context.Context, conn *pgx.Conn, publication string, filters event.Filters) ([]string, error) {
+	var allTables bool
+	err := conn.QueryRow(ctx, `SELECT puballtables FROM pg_publication WHERE pubname = $1`, publication).Scan(&allTables)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil // publication absent — validatePublication reports that distinctly
+	}
 	if err != nil {
-		return nil, fmt.Errorf("pgcapture: checking for UNLOGGED tables in publication %q: %w", publication, err)
+		return nil, fmt.Errorf("pgcapture: reading publication %q for the UNLOGGED check: %w", publication, err)
+	}
+	if !allTables {
+		return nil, nil // FOR TABLE: UNLOGGED tables cannot be published (see doc above)
+	}
+
+	rows, err := conn.Query(ctx, `
+		SELECT n.nspname, c.relname
+		FROM pg_class c
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		WHERE c.relkind = 'r' AND c.relpersistence = 'u'
+		  AND n.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
+		  AND n.nspname NOT LIKE 'pg_temp%'
+		  AND n.nspname NOT LIKE 'pg_toast_temp%'`)
+	if err != nil {
+		return nil, fmt.Errorf("pgcapture: scanning for UNLOGGED tables: %w", err)
 	}
 	defer rows.Close()
 
@@ -206,21 +235,26 @@ func listUnloggedPublishedTables(ctx context.Context, conn *pgx.Conn, publicatio
 	for rows.Next() {
 		var schema, table string
 		if err := rows.Scan(&schema, &table); err != nil {
-			return nil, fmt.Errorf("pgcapture: scanning UNLOGGED tables for publication %q: %w", publication, err)
+			return nil, fmt.Errorf("pgcapture: scanning UNLOGGED tables: %w", err)
 		}
-		unlogged = append(unlogged, schema+"."+table)
+		// Under FOR ALL TABLES the captured set is every user table narrowed by the
+		// client schema/table filter (the zero Filters accepts all), so honor it here.
+		if filters.Matches(schema, table) {
+			unlogged = append(unlogged, schema+"."+table)
+		}
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("pgcapture: checking for UNLOGGED tables in publication %q: %w", publication, err)
+		return nil, fmt.Errorf("pgcapture: scanning for UNLOGGED tables: %w", err)
 	}
 	sort.Strings(unlogged)
 	return unlogged, nil
 }
 
-// ListUnloggedPublishedTables is the report-only form of the #555 UNLOGGED guard for
-// bintrail-pg doctor (a pure probe; no mutation). nil/empty means no UNLOGGED tables.
-func ListUnloggedPublishedTables(ctx context.Context, conn *pgx.Conn, publication string) ([]string, error) {
-	return listUnloggedPublishedTables(ctx, conn, publication)
+// ListUnloggedCaptureTables is the report-only form of the #555 UNLOGGED guard for
+// bintrail-pg doctor (a pure probe; no mutation). nil/empty means no UNLOGGED tables
+// in the capture scope.
+func ListUnloggedCaptureTables(ctx context.Context, conn *pgx.Conn, publication string, filters event.Filters) ([]string, error) {
+	return listUnloggedCaptureTables(ctx, conn, publication, filters)
 }
 
 // CascadeChild is one foreign-key cascade child whose PARENT the publication captures

--- a/internal/pgstreamrun/pgdoctor.go
+++ b/internal/pgstreamrun/pgdoctor.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/dbtrail/dbtrail/internal/cliutil"
 	"github.com/dbtrail/dbtrail/internal/doctor"
+	"github.com/dbtrail/dbtrail/internal/event"
 	"github.com/dbtrail/dbtrail/internal/pgcapture"
 )
 
@@ -105,7 +106,7 @@ func BuildPGReport(ctx context.Context, cfg PGDoctorConfig) *doctor.Report {
 		r.Add(doctor.CheckResult{Name: "REPLICA IDENTITY FULL", Status: doctor.StatusPass})
 	}
 
-	addUnloggedCheck(ctx, r, conn, cfg.Publication)
+	addUnloggedCheck(ctx, r, conn, cfg.Publication, filters)
 	addCascadeCoverageCheck(ctx, r, conn, cfg.Publication)
 	addKeepSizeCheck(ctx, r, conn)
 	addSlotHealthCheck(ctx, r, conn, cfg.SlotName)
@@ -172,8 +173,8 @@ func keepSizeResult(setting string) doctor.CheckResult {
 
 // addUnloggedCheck reports UNLOGGED tables in the publication (#555). The mapping is
 // the pure unloggedResult; a query failure is a WARN (the guard is advisory).
-func addUnloggedCheck(ctx context.Context, r *doctor.Report, conn *pgx.Conn, publication string) {
-	unlogged, err := pgcapture.ListUnloggedPublishedTables(ctx, conn, publication)
+func addUnloggedCheck(ctx context.Context, r *doctor.Report, conn *pgx.Conn, publication string, filters event.Filters) {
+	unlogged, err := pgcapture.ListUnloggedCaptureTables(ctx, conn, publication, filters)
 	if err != nil {
 		r.Add(doctor.CheckResult{Name: "No UNLOGGED tables", Status: doctor.StatusWarn, Detail: "could not check: " + err.Error()})
 		return

--- a/internal/pgstreamrun/pgdoctor.go
+++ b/internal/pgstreamrun/pgdoctor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -20,7 +21,7 @@ const doctorTimeout = 30 * time.Second
 
 // dependentCheckNames are the checks BuildPGReport skips when wal_level is genuinely
 // not 'logical' — logical decoding is impossible, so they cannot meaningfully run.
-var dependentCheckNames = []string{"Publication coverage", "REPLICA IDENTITY FULL", "max_slot_wal_keep_size", "Replication slot health"}
+var dependentCheckNames = []string{"Publication coverage", "REPLICA IDENTITY FULL", "No UNLOGGED tables", "FK cascade-child coverage", "max_slot_wal_keep_size", "Replication slot health"}
 
 // PGDoctorConfig is the subset of stream settings a health check needs: a normal
 // (non-replication) connection to the source, the slot to inspect, and the
@@ -104,6 +105,8 @@ func BuildPGReport(ctx context.Context, cfg PGDoctorConfig) *doctor.Report {
 		r.Add(doctor.CheckResult{Name: "REPLICA IDENTITY FULL", Status: doctor.StatusPass})
 	}
 
+	addUnloggedCheck(ctx, r, conn, cfg.Publication)
+	addCascadeCoverageCheck(ctx, r, conn, cfg.Publication)
 	addKeepSizeCheck(ctx, r, conn)
 	addSlotHealthCheck(ctx, r, conn, cfg.SlotName)
 	return r
@@ -165,6 +168,70 @@ func keepSizeResult(setting string) doctor.CheckResult {
 		}
 	}
 	return doctor.CheckResult{Name: name, Status: doctor.StatusPass, Detail: setting}
+}
+
+// addUnloggedCheck reports UNLOGGED tables in the publication (#555). The mapping is
+// the pure unloggedResult; a query failure is a WARN (the guard is advisory).
+func addUnloggedCheck(ctx context.Context, r *doctor.Report, conn *pgx.Conn, publication string) {
+	unlogged, err := pgcapture.ListUnloggedPublishedTables(ctx, conn, publication)
+	if err != nil {
+		r.Add(doctor.CheckResult{Name: "No UNLOGGED tables", Status: doctor.StatusWarn, Detail: "could not check: " + err.Error()})
+		return
+	}
+	r.Add(unloggedResult(unlogged))
+}
+
+// unloggedResult maps the UNLOGGED-table list (#555). UNLOGGED tables write no WAL, so
+// logical decoding captures NONE of their changes — a silent recovery hole. It is a
+// WARN, not a FAIL: an operator may keep ephemeral data UNLOGGED on purpose, so this
+// surfaces the gap loudly without failing the command. Pure (no I/O) for unit testing.
+func unloggedResult(unlogged []string) doctor.CheckResult {
+	const name = "No UNLOGGED tables"
+	if len(unlogged) == 0 {
+		return doctor.CheckResult{Name: name, Status: doctor.StatusPass}
+	}
+	return doctor.CheckResult{
+		Name:   name,
+		Status: doctor.StatusWarn,
+		Detail: strings.Join(unlogged, ", "),
+		Remediation: "These tables are UNLOGGED: PostgreSQL writes no WAL for them, so logical decoding captures NONE of their changes and they cannot be recovered. " +
+			"If they hold recoverable data, convert them with ALTER TABLE <t> SET LOGGED. If they are intentionally ephemeral, this is expected.",
+	}
+}
+
+// addCascadeCoverageCheck reports FK cascade children whose parent is published but the
+// child is not (#556). The mapping is the pure cascadeCoverageResult; a query failure
+// is a WARN (the guard is advisory).
+func addCascadeCoverageCheck(ctx context.Context, r *doctor.Report, conn *pgx.Conn, publication string) {
+	children, err := pgcapture.ListUncoveredCascadeChildren(ctx, conn, publication)
+	if err != nil {
+		r.Add(doctor.CheckResult{Name: "FK cascade-child coverage", Status: doctor.StatusWarn, Detail: "could not check: " + err.Error()})
+		return
+	}
+	r.Add(cascadeCoverageResult(children))
+}
+
+// cascadeCoverageResult maps the uncovered-cascade-child list (#556). On PostgreSQL an
+// ON DELETE CASCADE/SET NULL rewrites the child via real WAL ops, so `recover` works IF
+// the child is captured; a published parent with an unpublished cascade child means
+// those cascade rewrites are silently lost. WARN (not FAIL): the child may be
+// intentionally out of recovery scope. Pure (no I/O) for unit testing.
+func cascadeCoverageResult(children []pgcapture.CascadeChild) doctor.CheckResult {
+	const name = "FK cascade-child coverage"
+	if len(children) == 0 {
+		return doctor.CheckResult{Name: name, Status: doctor.StatusPass}
+	}
+	parts := make([]string, len(children))
+	for i, ch := range children {
+		parts[i] = fmt.Sprintf("%s (%s from %s)", ch.Child, ch.Action, ch.Parent)
+	}
+	return doctor.CheckResult{
+		Name:   name,
+		Status: doctor.StatusWarn,
+		Detail: strings.Join(parts, "; "),
+		Remediation: "These cascade child tables are not in the publication while their parent is: a delete on the parent fires ON DELETE CASCADE/SET NULL/SET DEFAULT, rewriting the child — and that change is not captured, so it cannot be recovered. " +
+			"Add each child to the publication (ALTER PUBLICATION ... ADD TABLE ...) and set it to REPLICA IDENTITY FULL.",
+	}
 }
 
 // addSlotHealthCheck queries the slot's live state and adds its CheckResult. A query

--- a/internal/pgstreamrun/pgdoctor_integration_test.go
+++ b/internal/pgstreamrun/pgdoctor_integration_test.go
@@ -180,3 +180,96 @@ func TestBuildPGReport_LostSlot_Integration(t *testing.T) {
 		}
 	}
 }
+
+// TestBuildPGReport_CoverageWarnings_Integration drives the two new advisory coverage
+// guards against live PostgreSQL — the catalog QUERIES themselves (listUnloggedCapture
+// Tables #555, listUncoveredCascadeChildren #556 incl. cascadeAction), which the pure
+// result-mapper unit tests cannot reach. The #555 query in particular MUST go through
+// pg_class (an UNLOGGED table is never in pg_publication_tables), so a live assertion is
+// the only thing that proves it actually fires.
+//
+// Requires BINTRAIL_TEST_PG_DSN; the MySQL CI jobs leave it unset and skip cleanly.
+func TestBuildPGReport_CoverageWarnings_Integration(t *testing.T) {
+	dsn := testutil.SkipIfNoPostgres(t)
+	ctx := context.Background()
+
+	conn, err := pgx.Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { conn.Close(context.Background()) })
+
+	mustExec := func(sql string) {
+		t.Helper()
+		if _, err := conn.Exec(ctx, sql); err != nil {
+			t.Fatalf("exec %q: %v", sql, err)
+		}
+	}
+
+	t.Run("unlogged-under-for-all-tables", func(t *testing.T) {
+		// #555: an UNLOGGED table is invisible to pg_publication_tables but real on
+		// pg_class; under FOR ALL TABLES the operator believes it is captured. The guard
+		// must scan pg_class and WARN. A Tables filter scopes the assertion to our table
+		// (so any unrelated UNLOGGED table on the dev server can't perturb it).
+		const pub = "bintrail_cov_all_pub"
+		const ult = "doctor_cov_unlogged"
+		dropAll := func() {
+			bg := context.Background()
+			_, _ = conn.Exec(bg, "DROP PUBLICATION IF EXISTS "+pub)
+			_, _ = conn.Exec(bg, "DROP TABLE IF EXISTS "+ult)
+		}
+		dropAll()
+		t.Cleanup(dropAll)
+
+		mustExec("CREATE UNLOGGED TABLE " + ult + " (id int PRIMARY KEY, v text)")
+		mustExec("CREATE PUBLICATION " + pub + " FOR ALL TABLES")
+
+		r := pgstreamrun.BuildPGReport(ctx, pgstreamrun.PGDoctorConfig{
+			QueryDSN: dsn, SlotName: "bintrail_cov_all_slot", Publication: pub,
+			Tables: "public." + ult,
+		})
+		c := findCheck(t, r, "No UNLOGGED tables")
+		if c.Status != doctor.StatusWarn {
+			t.Errorf("No UNLOGGED tables = %s (%s), want warn", c.Status, c.Detail)
+		}
+		if !strings.Contains(c.Detail, ult) {
+			t.Errorf("detail should name the UNLOGGED table %q, got %q", ult, c.Detail)
+		}
+	})
+
+	t.Run("uncovered-cascade-child", func(t *testing.T) {
+		// #556: a published parent whose ON DELETE CASCADE child is NOT published — the
+		// cascade rewrites on the child would be silently lost. The guard must WARN and
+		// name the child, the action, and the parent (exercises cascadeAction too).
+		const pub = "bintrail_cov_tbl_pub"
+		const parent = "doctor_cov_parent"
+		const child = "doctor_cov_child"
+		dropAll := func() {
+			bg := context.Background()
+			_, _ = conn.Exec(bg, "DROP PUBLICATION IF EXISTS "+pub)
+			_, _ = conn.Exec(bg, "DROP TABLE IF EXISTS "+child) // child first (FK)
+			_, _ = conn.Exec(bg, "DROP TABLE IF EXISTS "+parent)
+		}
+		dropAll()
+		t.Cleanup(dropAll)
+
+		mustExec("CREATE TABLE " + parent + " (id int PRIMARY KEY)")
+		mustExec("ALTER TABLE " + parent + " REPLICA IDENTITY FULL")
+		mustExec("CREATE TABLE " + child + " (id int PRIMARY KEY, pid int REFERENCES " + parent + "(id) ON DELETE CASCADE)")
+		mustExec("ALTER TABLE " + child + " REPLICA IDENTITY FULL")
+		mustExec("CREATE PUBLICATION " + pub + " FOR TABLE " + parent) // child intentionally omitted
+
+		r := pgstreamrun.BuildPGReport(ctx, pgstreamrun.PGDoctorConfig{
+			QueryDSN: dsn, SlotName: "bintrail_cov_tbl_slot", Publication: pub,
+		})
+		c := findCheck(t, r, "FK cascade-child coverage")
+		if c.Status != doctor.StatusWarn {
+			t.Errorf("FK cascade-child coverage = %s (%s), want warn", c.Status, c.Detail)
+		}
+		for _, want := range []string{child, "ON DELETE CASCADE", parent} {
+			if !strings.Contains(c.Detail, want) {
+				t.Errorf("detail should mention %q, got %q", want, c.Detail)
+			}
+		}
+	})
+}

--- a/internal/pgstreamrun/pgdoctor_test.go
+++ b/internal/pgstreamrun/pgdoctor_test.go
@@ -137,3 +137,40 @@ func TestFormatBytes(t *testing.T) {
 		}
 	}
 }
+
+func TestUnloggedResult(t *testing.T) {
+	// #555: no UNLOGGED tables → PASS.
+	if got := unloggedResult(nil); got.Status != doctor.StatusPass {
+		t.Errorf("no unlogged → %s, want pass", got.Status)
+	}
+	// UNLOGGED tables present → WARN naming them (a silent capture hole made visible).
+	got := unloggedResult([]string{"public.cache", "public.tmp"})
+	if got.Status != doctor.StatusWarn {
+		t.Errorf("unlogged present → %s, want warn", got.Status)
+	}
+	if !strings.Contains(got.Detail, "public.cache") || !strings.Contains(got.Detail, "public.tmp") {
+		t.Errorf("detail should name the UNLOGGED tables, got %q", got.Detail)
+	}
+	if !strings.Contains(got.Remediation, "SET LOGGED") {
+		t.Errorf("remediation should mention SET LOGGED, got %q", got.Remediation)
+	}
+}
+
+func TestCascadeCoverageResult(t *testing.T) {
+	// #556: every cascade child covered → PASS.
+	if got := cascadeCoverageResult(nil); got.Status != doctor.StatusPass {
+		t.Errorf("no uncovered children → %s, want pass", got.Status)
+	}
+	// An uncovered cascade child → WARN naming the child, action, and parent.
+	got := cascadeCoverageResult([]pgcapture.CascadeChild{
+		{Child: "public.line_items", Parent: "public.orders", Action: "ON DELETE CASCADE"},
+	})
+	if got.Status != doctor.StatusWarn {
+		t.Errorf("uncovered child → %s, want warn", got.Status)
+	}
+	if !strings.Contains(got.Detail, "public.line_items") ||
+		!strings.Contains(got.Detail, "ON DELETE CASCADE") ||
+		!strings.Contains(got.Detail, "public.orders") {
+		t.Errorf("detail should name child + action + parent, got %q", got.Detail)
+	}
+}

--- a/internal/pgstreamrun/pgstreamrun_integration_test.go
+++ b/internal/pgstreamrun/pgstreamrun_integration_test.go
@@ -156,6 +156,144 @@ func TestOne_EndToEnd_PostgresToIndexToRecovery(t *testing.T) {
 	}
 }
 
+// TestOne_DDLDrift_MidStreamAlter is the integration half of the #591 DDL-drift gate:
+// an ALTER TABLE ... ADD COLUMN mid-stream must (1) decode the post-ALTER row against
+// the NEW shape (the added column is captured), (2) stamp it with a NEW schema_version
+// than the pre-ALTER row (the Relation-message-driven re-snapshot — the PG analog of
+// the MySQL #396 auto-snapshot-on-DDL), and (3) still produce valid reversal SQL.
+// Logical decoding streams no DDL, so this proves the RelationMessage shape-swap
+// (decoder.cacheRelation) end-to-end on live PostgreSQL — the behavior the decoder unit
+// test TestDecode_RelationShapeChange_MidStream pins in isolation.
+//
+// CI-only: needs a live PostgreSQL source (BINTRAIL_TEST_PG_DSN) + MySQL index; the
+// MySQL-only CI jobs skip it (a green local `go test` without PG does NOT exercise it).
+func TestOne_DDLDrift_MidStreamAlter(t *testing.T) {
+	pgDSN := testutil.SkipIfNoPostgres(t)
+	testutil.SkipIfNoMySQL(t)
+	ctx := context.Background()
+
+	indexDB, dbName := testutil.CreateTestDB(t)
+	indexDSN := testutil.BaseDSN() + "/" + dbName
+
+	const slot = "bintrail_pgsr_ddl"
+	const pub = "bintrail_pgsr_ddl_pub"
+	const tbl = "pgsr_ddl_t"
+
+	pg, err := pgx.Connect(ctx, pgDSN)
+	if err != nil {
+		t.Fatalf("connect PG: %v", err)
+	}
+	t.Cleanup(func() { pg.Close(context.Background()) })
+
+	dropAll := func() {
+		bg := context.Background()
+		_, _ = pg.Exec(bg, "DROP PUBLICATION IF EXISTS "+pub)
+		_, _ = pg.Exec(bg, "DROP TABLE IF EXISTS "+tbl)
+		_, _ = pg.Exec(bg, "SELECT pg_drop_replication_slot($1) WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name=$1)", slot)
+	}
+	dropAll()
+	t.Cleanup(dropAll)
+
+	mustExec := func(sql string, args ...any) {
+		t.Helper()
+		if _, err := pg.Exec(ctx, sql, args...); err != nil {
+			t.Fatalf("exec %q: %v", sql, err)
+		}
+	}
+	mustExec(fmt.Sprintf("CREATE TABLE %s (id int PRIMARY KEY, a text)", tbl))
+	mustExec(fmt.Sprintf("ALTER TABLE %s REPLICA IDENTITY FULL", tbl))
+	mustExec(fmt.Sprintf("CREATE PUBLICATION %s FOR TABLE %s", pub, tbl))
+
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	cfg := pgstreamrun.Config{
+		IndexDSN:    indexDSN,
+		ReplDSN:     replDSN(pgDSN),
+		QueryDSN:    pgDSN,
+		SlotName:    slot,
+		Publication: pub,
+		ServerID:    43,
+		Tables:      "public." + tbl,
+		BatchSize:   100,
+		Checkpoint:  200 * time.Millisecond,
+	}
+	runErr := make(chan error, 1)
+	go func() { runErr <- pgstreamrun.One(runCtx, cfg) }()
+
+	waitFor(t, 15*time.Second, func() bool {
+		var active bool
+		if err := pg.QueryRow(ctx, "SELECT active FROM pg_replication_slots WHERE slot_name=$1", slot).Scan(&active); err != nil {
+			return false
+		}
+		return active
+	}, "replication slot active")
+
+	// Pre-ALTER row against the (id, a) shape; wait until it is indexed so its
+	// RelationMessage (the first snapshot) is durably recorded before the ALTER.
+	mustExec(fmt.Sprintf("INSERT INTO %s VALUES (1, 'x')", tbl))
+	waitFor(t, 15*time.Second, func() bool {
+		var n int
+		_ = indexDB.QueryRow("SELECT COUNT(*) FROM binlog_events WHERE table_name = ? AND pk_values = '1'", tbl).Scan(&n)
+		return n >= 1
+	}, "pre-ALTER INSERT indexed")
+
+	// Mid-stream DDL: add a column. pgoutput emits no DDL, but it DOES re-emit a fresh
+	// RelationMessage carrying the new shape before the next row event.
+	mustExec(fmt.Sprintf("ALTER TABLE %s ADD COLUMN b text", tbl))
+	mustExec(fmt.Sprintf("INSERT INTO %s VALUES (2, 'y', 'z')", tbl))
+	waitFor(t, 15*time.Second, func() bool {
+		var n int
+		_ = indexDB.QueryRow("SELECT COUNT(*) FROM binlog_events WHERE table_name = ? AND pk_values = '2'", tbl).Scan(&n)
+		return n >= 1
+	}, "post-ALTER INSERT indexed")
+
+	cancel()
+	if err := <-runErr; err != nil {
+		t.Fatalf("One returned error: %v", err)
+	}
+
+	// (1) The post-ALTER row decoded against the NEW shape: the added column is captured.
+	rows, err := query.New(indexDB).Fetch(ctx, query.Options{Schema: "public", Table: tbl, Order: "ASC"})
+	if err != nil {
+		t.Fatalf("query Fetch: %v", err)
+	}
+	var post *query.ResultRow
+	for i := range rows {
+		if rows[i].PKValues == "2" {
+			post = &rows[i]
+		}
+	}
+	if post == nil {
+		t.Fatal("post-ALTER row (pk=2) not indexed")
+	}
+	if got := post.RowAfter["b"]; got != "z" {
+		t.Errorf("post-ALTER RowAfter[b] = %v, want %q (added column captured against the swapped shape)", got, "z")
+	}
+
+	// (2) The re-snapshot: the post-ALTER row carries a DIFFERENT schema_version than the
+	// pre-ALTER row. Equal versions would mean the mid-stream ALTER was not re-snapshotted.
+	var svPre, svPost int
+	if err := indexDB.QueryRow("SELECT schema_version FROM binlog_events WHERE table_name=? AND pk_values='1'", tbl).Scan(&svPre); err != nil {
+		t.Fatalf("read pre-ALTER schema_version: %v", err)
+	}
+	if err := indexDB.QueryRow("SELECT schema_version FROM binlog_events WHERE table_name=? AND pk_values='2'", tbl).Scan(&svPost); err != nil {
+		t.Fatalf("read post-ALTER schema_version: %v", err)
+	}
+	if svPost == svPre {
+		t.Errorf("post-ALTER schema_version (%d) equals pre-ALTER (%d) — the mid-stream ALTER did not trigger a re-snapshot", svPost, svPre)
+	}
+
+	// (3) Recovery still produces valid reversal SQL across the mixed-shape rows.
+	var buf bytes.Buffer
+	n, err := recovery.New(indexDB, nil).GenerateSQLFromRows(rows, &buf)
+	if err != nil {
+		t.Fatalf("GenerateSQLFromRows: %v", err)
+	}
+	if n == 0 {
+		t.Fatal("no reversal statements generated for the mixed-shape rows")
+	}
+}
+
 // TestOne_LostSlotResume_PersistsLossBadge is the #532 slice-4 proof: when a resume
 // finds the replication slot gone (WAL behind the checkpoint is irrecoverable), One
 // returns the ErrSlotMissingOnResume sentinel AND durably records the permanent loss


### PR DESCRIPTION
## Why

The epic #527 close-out audit found the **6 beta-BLOCKING gates all met**, with three small **silent-loss / silent-target** residuals and **one untested** beta gate left before declaring PostgreSQL-as-source beta. This is the pre-close lot. None of these change existing public signatures.

| # | Gap | Class | Guard added |
|---|-----|-------|-------------|
| #555 | UNLOGGED tables write no WAL → captured as nothing | silent **capture** loss | preflight WARN (startup + doctor) |
| #556 | published parent + unpublished cascade child → cascade deletes uncaptured | silent **cascade** loss | preflight WARN (startup + doctor) |
| #559 | TimescaleDB chunks streamed by physical name | silent **wrong target** | decoder warn-once |
| #591 | Relation-message shape-swap correct-by-construction but untested | **verification** gap | unit + integration test |

## What

**#555 — UNLOGGED preflight.** `listUnloggedPublishedTables` (slot.go) finds `relpersistence='u'` tables in the publication. A non-fatal `WARN` at capture startup (`warnCaptureCoverage`) + a doctor check. WARN, not FAIL — an operator may keep ephemeral data UNLOGGED on purpose; the point is it's *visible*, not discovered during a failed recovery.

**#556 — FK cascade-child coverage.** `listUncoveredCascadeChildren` joins `pg_constraint` (`confdeltype IN ('c','n','d')`) to find children whose parent is published but the child isn't. On PG, `ON DELETE CASCADE/SET NULL` is real per-row WAL on the child, so `recover` works *if* the child is captured — this surfaces the gap. `FOR ALL TABLES` covers children by construction; a published child is already forced to RI FULL by the existing validator, so only the not-published case is flagged. Residual (the "row predates capture" baseline class) is documented and tracked at #593 (GA).

**#559 — TimescaleDB out-of-scope guard.** `decoder.cacheRelation` warns **once per stream** on a `_timescaledb_internal._hyper_*` chunk relation, so an operator knows capture targets the raw chunk, not the logical hypertable. Warn-once (a busy hypertable has many chunks); never silently skipped.

**#591 — DDL-drift test coverage.** The mechanism (pgoutput re-emits a `RelationMessage` after a shape change → `cacheRelation` swaps; the consumer re-snapshots with a fresh `schema_version`) was correct but untested.
- **Unit (local):** `TestDecode_RelationShapeChange_MidStream` — discriminating: a 3-column tuple decodes only if the shape swapped; against the stale 2-column relation `decodeTuple` would error (column-count mismatch), or drop the column (caught by the assertions).
- **Integration (CI-only):** `TestOne_DDLDrift_MidStreamAlter` — drives a real `ALTER TABLE ... ADD COLUMN` mid-stream, asserts the added column is captured, the post-ALTER row gets a **different** `schema_version`, and recovery still produces valid SQL.

The doctor gains two WARN checks (`No UNLOGGED tables`, `FK cascade-child coverage`) with pure, unit-tested mappers (`unloggedResult`/`cascadeCoverageResult`), added to `dependentCheckNames` so they SKIP cleanly when `wal_level != logical`.

## Deferred (not in this PR)

**#592** (TOAST read-side fail-loud) is intentionally left as a follow-up: the marker path is dead code under the required RI FULL, and the current behavior is *visible-not-silent* (renders a distinct literal, not a silent corruption). Making it *error* would require threading `formatValue → (string, error)` across `recovery.go` for unreachable code — wrong trade. See the issue.

## Testing

- `go build ./...`, `go vet`, and the full unit suites for `internal/pgcapture`, `internal/pgstreamrun`, `internal/recovery` pass locally.
- New unit tests (`TestDecode_RelationShapeChange_MidStream`, `TestDecode_TimescaleChunk_WarnsOnce`, `TestUnloggedResult`, `TestCascadeCoverageResult`) pass locally.
- **`TestOne_DDLDrift_MidStreamAlter` is CI-only** (needs a live PostgreSQL via `BINTRAIL_TEST_PG_DSN`); a green local `go test` does **not** exercise it — the PG CI matrix (PG 14–17) does.

closes #555
closes #556
closes #559
closes #591

🤖 Generated with [Claude Code](https://claude.com/claude-code)
