### PR TITLE
feat(console): source-aware presentation for PostgreSQL sources (#595)

### DIFF
--- a/docs/console.md
+++ b/docs/console.md
@@ -438,6 +438,33 @@ the paid **forensics** surface (who-changed / attribution): the events API drops
 every response. There is no gating, RBAC, or license code in the binary; the
 boundary is simply what the API chooses to serve.
 
+## PostgreSQL sources
+
+The console reads only the **index**, never the source database, so it works
+identically for a PostgreSQL source captured by `bintrail-pg`: the index schema
+is the same. It does adapt its **presentation** to the source family (reported
+per server as `source` in [`/api/capabilities`](#api), derived from
+`stream_state.flavor`):
+
+- **Stream vocabulary.** A PostgreSQL stream shows its cursor as an **LSN** (and
+  labels the source "PostgreSQL · logical replication") instead of MySQL binlog
+  file / position / GTID. Slot and publication *names* are capture-side
+  configuration and are not stored in the index, so the console does not show
+  them.
+- **Permanent-loss badge.** The Status page surfaces the durable loss record
+  (`stream_state.gap_lost_at`) — for PostgreSQL, an invalidated/lost replication
+  slot; for MySQL, an unfillable binlog gap. The index is valid only up to that
+  point and capture must be re-baselined to resume.
+- **Forensics note.** PostgreSQL logical replication (`pgoutput`) carries no
+  backend connection id, so actor attribution (who-changed) is unavailable
+  *upstream* — not merely dropped by the open-core boundary above. The Events
+  page says so for PostgreSQL sources rather than leaving it an unexplained gap.
+
+Live source-side signals — replication-slot lag, `wal_status`,
+`max_slot_wal_keep_size`, `REPLICA IDENTITY FULL` validation — are **not** shown
+here: they require querying the source PostgreSQL, which the index-only console
+never does. Use `bintrail-pg doctor` for those.
+
 ## API
 
 All endpoints return JSON. `/api/*` (except `healthz`) require
@@ -456,7 +483,7 @@ All endpoints return JSON. `/api/*` (except `healthz`) require
 | `GET /api/events` | Event browser. Query params: `schema, table, pk, event_type, gtid, since, until, changed_column, order, limit`. |
 | `POST /api/recover` | Undo-SQL generation. JSON body with the same filter fields (requires at least `schema`; an `order` field is accepted but ignored — recover always processes oldest-first). Returns `{sql, statement_count, row_count, warnings}`. |
 | `POST /api/recover-cascade` | Cascade-recovery SQL generation (reverse FK `ON DELETE CASCADE` / `SET NULL` side effects). JSON body: `schema, table` (the **parent**), `pk, pks, since, until, lookback, max_depth, allow_incomplete`. Returns `{sql, statement_count, victim_count, set_null_count, complete, incomplete}` — text only, never executed. Returns `403` under an active RBAC redaction profile (see [Cascade recovery](#cascade-recovery)). |
-| `GET /api/capabilities` | Reports enabled optional surfaces for the **selected server**, e.g. `{"reconstruct": true, "recover_cascade": true, "recover_cascade_baseline": false, "auth": {"password_set": true, "auth_kind": "session"}}`. The frontend uses it to show/hide gated tabs on every switch (`reconstruct` → Time-travel, `recover_cascade` → Cascade recovery) and to gate the logout affordance (`auth_kind` says how this request authenticated). |
+| `GET /api/capabilities` | Reports enabled optional surfaces for the **selected server**, e.g. `{"reconstruct": true, "recover_cascade": true, "recover_cascade_baseline": false, "source": "mysql", "auth": {"password_set": true, "auth_kind": "session"}}`. The frontend uses it to show/hide gated tabs on every switch (`reconstruct` → Time-travel, `recover_cascade` → Cascade recovery) and to gate the logout affordance (`auth_kind` says how this request authenticated). `source` (`"mysql"` or `"postgresql"`, read from the index's `stream_state.flavor`) drives **source-aware presentation** only — never a gate; see [PostgreSQL sources](#postgresql-sources). |
 | `GET /api/reconstruct` | Single-row point-in-time reconstruct (baseline-gated **per server**; 404 when not configured). Query params: `schema, table, pk, at, history, allow_gaps`. Returns `{found, deleted, state, history, baseline_time, event_count, warnings}`. |
 | `GET /api/servers` | List servers (masked: parsed host/port/user/dbname + `has_password`, never a DSN or password) plus `default_id`. |
 | `POST /api/servers` | Add a server to the registry (validates, does not connect; never runs DDL). |

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -738,6 +738,17 @@ function renderEvents(params) {
   const v = VIEW(); clear(v);
   v.append(pageHead("Events", el("p", { class: "page-sub", text: "Browse indexed row events with full before / after images." })));
 
+  // Forensics-degraded note (#595): PostgreSQL logical replication (pgoutput)
+  // carries no backend connection id, so actor attribution ("who changed this")
+  // is unavailable for PG sources. The free events surface never shows
+  // connection_id anyway (it is paid-forensics, dropped from eventDTO), but for
+  // PG it cannot be recovered upstream at all — say so rather than leave it an
+  // unexplained gap. capsCache.source is resolved before this paints.
+  if (capsCache.source === "postgresql") {
+    v.append(el("div", { class: "warn-item" }, icon("warn"),
+      el("span", { text: "Actor attribution (who-changed) is unavailable for PostgreSQL sources — the logical replication stream carries no backend connection id." })));
+  }
+
   const form = el("form", { id: "ev-form" });
   // search bar
   const searchwrap = el("div", { class: "ev-searchwrap" });
@@ -1387,6 +1398,13 @@ async function renderStatus() {
   const cov = data.coverage || {};
   const stream = data.stream || null;
   const arch = data.archives || null;
+  // Source-aware presentation: a PostgreSQL stream's cursor is an LSN, written
+  // across binlog_file (the "X/Y" string form, the one shown here) and
+  // binlog_position (the same value as a uint64, for resume); mode='gtid' is an
+  // internal detail. MySQL vocabulary would mislabel all of it. capsCache.source
+  // is resolved before this paints (bootSequence/switchServer await
+  // gateCapabilities → renderRoute).
+  const pg = capsCache.source === "postgresql";
 
   cards.append(statusCard("Summary", [
     ["total events (est.)", data.total_events_estimate, true],
@@ -1399,7 +1417,11 @@ async function renderStatus() {
     ["total events", cov.total_events],
     ["schema changes", cov.schema_changes],
   ]));
-  if (stream) cards.append(statusCard("Stream", [
+  if (stream) cards.append(statusCard(pg ? "Stream · PostgreSQL" : "Stream", pg ? [
+    ["source", "PostgreSQL · logical replication"],
+    ["LSN", stream.binlog_file],
+    ["events indexed", stream.events_indexed],
+  ] : [
     ["mode", stream.mode],
     ["binlog file", stream.binlog_file],
     ["position", stream.binlog_position],
@@ -1410,6 +1432,19 @@ async function renderStatus() {
     ["rows", arch.total_rows],
     ["size", arch.total_size_human],
   ]));
+  // Durable permanent-loss record (status JSON stream.gap_lost): an unfillable
+  // binlog gap (MySQL) or an invalidated/lost replication slot (PostgreSQL, #532).
+  // The index is valid only up to this point; capture must be re-baselined to
+  // resume. Surfaced loudly above the cards — flavor-agnostic, PG-worded note.
+  if (stream && stream.gap_lost) {
+    const lost = el("div", { class: "error-box" });
+    lost.append(el("b", { text: "⚠ Events permanently lost" }));
+    lost.append(el("div", { text: stream.gap_lost.detail ||
+      (pg ? "the replication slot was invalidated; capture must be re-baselined to resume"
+          : "an unfillable binlog gap was detected; capture must be re-baselined to resume") }));
+    lost.append(el("div", { text: "Detected: " + stream.gap_lost.at }));
+    v.append(lost);
+  }
   v.append(cards);
   viewEnter();
 }
@@ -1435,8 +1470,10 @@ function updateSideMeta(status) {
     clear(streamEl);
     streamEl.append("stream ");
     if (status.stream) {
-      streamEl.append(el("b", { text: status.stream.mode }));
-      if (status.stream.binlog_file) streamEl.append(" · " + status.stream.binlog_file);
+      // PG stores its LSN cursor in binlog_file; "gtid" mode is an internal detail.
+      const pg = capsCache.source === "postgresql";
+      streamEl.append(el("b", { text: pg ? "PostgreSQL" : status.stream.mode }));
+      if (status.stream.binlog_file) streamEl.append((pg ? " · LSN " : " · ") + status.stream.binlog_file);
     } else {
       streamEl.append(el("b", { text: "—" }));
     }

--- a/internal/console/console_integration_test.go
+++ b/internal/console/console_integration_test.go
@@ -189,6 +189,42 @@ func TestIntegrationRecoverPGDialect(t *testing.T) {
 	}
 }
 
+// TestIntegrationCapabilitiesSourcePostgres proves /api/capabilities reports the
+// source family per-server from stream_state.flavor (#595). The shared console
+// reads only the index, so this is the signal the frontend uses to present PG
+// vocabulary (LSN vs binlog file/pos/GTID) and the forensics-degraded note —
+// without ever probing the source database. A fresh/legacy index (no flavor row)
+// reads as "mysql" (the safe default); a PG-flavored index as "postgresql".
+func TestIntegrationCapabilitiesSourcePostgres(t *testing.T) {
+	srv, _ := seedConsoleData(t)
+
+	// Default: seedConsoleData writes no stream_state row, so DialectForIndex
+	// falls back to MySQL — capabilities must report the common case, never blank.
+	_, body := doReq(t, srv, "GET", "/api/capabilities", "")
+	var caps capabilitiesResponse
+	if err := json.Unmarshal(body, &caps); err != nil {
+		t.Fatal(err)
+	}
+	if caps.Source != "mysql" {
+		t.Errorf("a MySQL/legacy index must report source=mysql, got %q", caps.Source)
+	}
+
+	// Stamp the boot bundle's index as PostgreSQL-sourced (single-row stream_state).
+	if _, err := srv.cm.boot.db.Exec(
+		`INSERT INTO stream_state (id, mode, flavor, last_checkpoint, server_id)
+		 VALUES (1, 'gtid', 'postgres', UTC_TIMESTAMP(), 1)`); err != nil {
+		t.Fatalf("stamp stream_state flavor=postgres: %v", err)
+	}
+
+	_, body = doReq(t, srv, "GET", "/api/capabilities", "")
+	if err := json.Unmarshal(body, &caps); err != nil {
+		t.Fatal(err)
+	}
+	if caps.Source != "postgresql" {
+		t.Errorf("a PG-flavored index must report source=postgresql, got %q", caps.Source)
+	}
+}
+
 // TestIntegrationRecoverWithTimeRangeSurfacesGap exercises the planner-active
 // recover path. testutil.InitIndexTables creates only the p_future partition,
 // so loadLivePartitionHours is empty and every hour in a bounded query range is

--- a/internal/console/reconstruct.go
+++ b/internal/console/reconstruct.go
@@ -12,7 +12,26 @@ import (
 	"github.com/dbtrail/dbtrail/internal/parquetquery"
 	"github.com/dbtrail/dbtrail/internal/query"
 	"github.com/dbtrail/dbtrail/internal/reconstruct"
+	"github.com/dbtrail/dbtrail/internal/recovery"
 )
+
+// Source labels for capabilitiesResponse.Source. The console reads only the
+// index, so the source family is whatever stream_state.flavor records — never a
+// live probe of the source database.
+const (
+	sourceMySQL    = "mysql"
+	sourcePostgres = "postgresql"
+)
+
+// sourceForDialect maps the index's recovery dialect to a source-family label.
+// PostgresDialect is set by DialectForFlavor("postgres"); everything else
+// (mysql, mariadb, or an unreadable/legacy index) collapses to "mysql".
+func sourceForDialect(d recovery.Dialect) string {
+	if d == recovery.PostgresDialect {
+		return sourcePostgres
+	}
+	return sourceMySQL
+}
 
 // reconstructMaxEvents caps the binlog events applied to a single row in the
 // [baseline, at] window. Reconstruct is scoped to one PK, so this is generous;
@@ -41,6 +60,15 @@ type capabilitiesResponse struct {
 	// degrades to Phase-1; advertising true there would over-promise.
 	RecoverCascadeBaseline bool         `json:"recover_cascade_baseline"`
 	Auth                   authCapsInfo `json:"auth"`
+	// Source names the selected server's source database family — "postgresql"
+	// or "mysql" — derived per-server from stream_state.flavor (the same field
+	// DialectForIndex reads). It drives source-aware PRESENTATION only: the
+	// frontend relabels stream vocabulary (LSN vs binlog file/pos/GTID) and shows
+	// a forensics-degraded note for PostgreSQL, whose pgoutput stream carries no
+	// backend connection id. NOT a capability gate — it never hides a surface,
+	// only renames or annotates what one shows. Defaults to "mysql" when the
+	// bundle can't be resolved, so a degraded console reads as the common case.
+	Source string `json:"source"`
 }
 
 // authCapsInfo tells the authenticated SPA how it got in and whether a
@@ -74,6 +102,9 @@ func (s *Server) handleCapabilities(w http.ResponseWriter, r *http.Request) {
 		// only by the RBAC profile (which would make synthesis leak redacted data).
 		RecoverCascade: !s.rbacActive(),
 		Auth:           authCapsInfo{PasswordSet: s.passwordLoginEnabled(), AuthKind: kind},
+		// Default until the bundle resolves: a degraded console renders MySQL
+		// vocabulary (the common case), never a blank source.
+		Source: sourceMySQL,
 	}
 	if b, err := s.resolve(r); err == nil {
 		resp.Reconstruct = b.baselineConfigured
@@ -81,6 +112,10 @@ func (s *Server) handleCapabilities(w http.ResponseWriter, r *http.Request) {
 		// capability can't over-promise (handler builds the provider only when both
 		// a baseline source and a resolver are present).
 		resp.RecoverCascadeBaseline = b.baselineConfigured && b.resolver != nil
+		// Per-server source family, read from this index's stream_state.flavor.
+		// DialectForIndex is nil-safe and legacy-tolerant (any read error → MySQL),
+		// so a pre-flavor index simply presents as MySQL.
+		resp.Source = sourceForDialect(recovery.DialectForIndex(b.db))
 	} else if !errors.Is(err, ErrUnknownServer) && !errors.Is(err, errNoServers) {
 		// Expected for a bad X-Bintrail-Server header or a fresh install;
 		// anything else (e.g. a genuine connection failure) would silently


### PR DESCRIPTION
closes #595

## Summary

Makes the shared `bintrail-console` **source-aware** for PostgreSQL sources — presentation only, no new dependency. The console reads only the index, so it adapts what it *shows* (it never queries the source).

New per-server `source` field in `GET /api/capabilities` (`"mysql"`/`"postgresql"`), derived from `stream_state.flavor` via the nil-safe, legacy-tolerant `recovery.DialectForIndex` (zero new SQL, no pgx). The frontend gates on it:

- **Stream vocabulary** — a PostgreSQL stream shows its **LSN** cursor (and "PostgreSQL · logical replication") instead of binlog file / position / GTID, on the Status card and the sidebar meta.
- **Permanent-loss badge** — the Status page now renders the durable `stream_state.gap_lost` record (a lost PG replication slot or an unfillable MySQL binlog gap). Flavor-agnostic; it was previously only surfaced by the `status` CLI.
- **Forensics-degraded note** — the Events page notes that actor attribution (who-changed) is unavailable for PostgreSQL, because `pgoutput` carries no backend connection id (the UI half of the connection_id gap; the nil-safe + documented code half already shipped).

### Scope (Occam) — what's intentionally NOT here

Live **source-side** signals — replication-slot lag, `wal_status`, `max_slot_wal_keep_size`, `REPLICA IDENTITY FULL` validation — require querying the source PostgreSQL, which the index-only `bintrail-console` must not do (no-pgx boundary). Surfacing them needs a **capture-side change to persist those metrics into the index** — a separate follow-up under epic #597, not this cosmetic PR. `bintrail-pg doctor` covers them today.

### Architecture red lines respected
- No `pgcapture`/pgx/jackc linkage (console stays no-pgx; `DialectForIndex` reads the index only).
- Open-core boundary intact — `connection_id` is **not** added to any DTO/response (the note is UI text).
- `source` never hides a surface; it only relabels/annotates (not a capability gate).

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] `gofmt`/`go build`/`go vet` (incl. `-tags integration`) clean
- [x] Integration vs real MySQL: new `TestIntegrationCapabilitiesSourcePostgres` (PG index → `source=postgresql`; MySQL/legacy → `mysql`) + existing `TestIntegrationRecoverPGDialect` — PASS
- [x] **Real headless-Chrome render** of the actual `app.js` (mocked `/api/*`), both source families: PG shows LSN/PostgreSQL/loss-badge/forensics-note; MySQL unchanged (binlog/position, no note, badge still renders); 0 page errors
- [x] Adversarial review (code-reviewer + silent-failure-hunter + comment-analyzer): 0 critical/important

🤖 Generated with [Claude Code](https://claude.com/claude-code)