### PR TITLE
feat(pg+console): live PostgreSQL replication-health panel (#599)

### DIFF
--- a/docs/console.md
+++ b/docs/console.md
@@ -459,11 +459,19 @@ per server as `source` in [`/api/capabilities`](#api), derived from
   backend connection id, so actor attribution (who-changed) is unavailable
   *upstream* — not merely dropped by the open-core boundary above. The Events
   page says so for PostgreSQL sources rather than leaving it an unexplained gap.
-
-Live source-side signals — replication-slot lag, `wal_status`,
-`max_slot_wal_keep_size`, `REPLICA IDENTITY FULL` validation — are **not** shown
-here: they require querying the source PostgreSQL, which the index-only console
-never does. Use `bintrail-pg doctor` for those.
+- **Replication-health panel.** The Status page shows the replication slot's
+  WAL-retention state (`wal_status`, retained WAL, the safe margin before
+  invalidation) and whether every published table is at `REPLICA IDENTITY FULL`.
+  The console is still index-only: it never queries the source. Instead the
+  streaming daemon (`bintrail-pg stream` / `watch`) polls the source every ~30s
+  and persists a snapshot to the index (`stream_state.source_health`), which the
+  console renders. Because a snapshot can outlive a stopped daemon, the panel
+  shows **how recently it was checked** and **degrades a stale snapshot** (older
+  than ~90s) to muted with a warning — a frozen "reserved" must never read as
+  live-healthy. If the daemon cannot read the source at all (for example a
+  standby, where the slot-retention metrics are unavailable), the panel shows
+  **probe failing** with the reason rather than disappearing. For an on-demand,
+  always-live check, use `bintrail-pg doctor`.
 
 ## API
 

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -1432,6 +1432,10 @@ async function renderStatus() {
     ["rows", arch.total_rows],
     ["size", arch.total_size_human],
   ]));
+  // Replication-health panel (#599): the streaming daemon polls the PostgreSQL source
+  // (slot wal_status/lag + REPLICA IDENTITY coverage) and persists a snapshot to the
+  // index; this renders it. Gated on source==postgresql AND a snapshot existing.
+  if (pg && stream && stream.source_health) cards.append(pgHealthCard(stream.source_health));
   // Durable permanent-loss record (status JSON stream.gap_lost): an unfillable
   // binlog gap (MySQL) or an invalidated/lost replication slot (PostgreSQL, #532).
   // The index is valid only up to this point; capture must be re-baselined to
@@ -1457,6 +1461,91 @@ function statusCard(title, rows) {
       el("span", { class: "kv-v" + (big ? " big" : ""), text: val === null || val === undefined ? "—" : String(val) })));
   });
   return card;
+}
+
+// PG_HEALTH_STALE_SEC: a source_health snapshot older than this reads as STALE. The
+// daemon polls every 30s, so 90s ≈ 3 missed polls → likely stopped. Load-bearing, not
+// decoration: an index-only console cannot tell a frozen "reserved" from a live one, so
+// a stale snapshot must never render as healthy green (#599).
+const PG_HEALTH_STALE_SEC = 90;
+
+// pgHealthCard renders the persisted PostgreSQL replication-health snapshot. h is the
+// parsed stream.source_health object {exists,active,wal_status,retained_bytes,
+// safe_wal_size,restart_lsn,confirmed_flush_lsn,replica_identity_not_full,checked_at}.
+function pgHealthCard(h) {
+  const card = el("div", { class: "card" });
+  card.append(el("div", { class: "card-title", text: "Replication health" }));
+
+  // Staleness drives everything: an unparseable/old checked_at mutes the whole card and
+  // labels it, so a dead poller never reads healthy.
+  const checked = h.checked_at ? Date.parse(h.checked_at) : NaN;
+  const ageSec = isNaN(checked) ? Infinity : Math.max(0, (Date.now() - checked) / 1000);
+  const stale = ageSec >= PG_HEALTH_STALE_SEC;
+  if (stale) card.classList.add("card-stale");
+
+  // probe_error: the daemon could not read source health (e.g. a standby source, or a
+  // query-DSN failure). Show it explicitly — a recorded failure, never a blank panel or
+  // a misleading "all FULL". The slot/RI sections are skipped (their fields are absent).
+  if (h.probe_error) {
+    card.append(healthKV("status", el("span", { class: "hstat hstat-err", text: "probe failing" })));
+    card.append(el("div", { class: "hlist", text: h.probe_error }));
+  } else {
+    if (!h.exists) {
+      card.append(healthKV("slot", el("span", { class: "hstat hstat-muted", text: "not found yet" })));
+    } else {
+      card.append(healthKV("WAL status", el("span", { class: "hstat " + walStatusClass(h.wal_status), text: h.wal_status || "—" })));
+      card.append(healthKV("retained WAL", el("span", { class: "kv-v", text: humanBytes(h.retained_bytes) })));
+      card.append(healthKV("safe margin", el("span", { class: "kv-v", text: h.safe_wal_size == null ? "unlimited" : humanBytes(h.safe_wal_size) })));
+      card.append(healthKV("consumer", el("span", { class: "kv-v", text: h.active ? "connected" : "—" })));
+    }
+
+    const nf = h.replica_identity_not_full || [];
+    if (nf.length === 0) {
+      card.append(healthKV("replica identity", el("span", { class: "hstat hstat-ok", text: "all FULL ✓" })));
+    } else {
+      card.append(healthKV("replica identity", el("span", { class: "hstat hstat-warn", text: "⚠ " + nf.length + " not FULL" })));
+      const list = el("div", { class: "hlist" });
+      nf.forEach((t) => list.append(el("div", { text: t })));
+      card.append(list);
+    }
+  }
+
+  const foot = el("div", { class: "hstale" + (stale ? " hstale-warn" : "") });
+  foot.append(stale
+    ? "stale — last checked " + agoText(ageSec) + " (daemon may be stopped)"
+    : "checked " + agoText(ageSec));
+  card.append(foot);
+  return card;
+}
+
+function healthKV(k, valNode) {
+  return el("div", { class: "kv" }, el("span", { class: "kv-k", text: k }), valNode);
+}
+
+function walStatusClass(s) {
+  switch (s) {
+    case "reserved": return "hstat-ok";
+    case "extended": return "hstat-warn";
+    case "unreserved": return "hstat-warn hstat-strong";
+    case "lost": return "hstat-err";
+    default: return "hstat-muted";
+  }
+}
+
+function humanBytes(n) {
+  n = Number(n) || 0;
+  if (n < 1024) return n + " B";
+  const u = ["KB", "MB", "GB", "TB"];
+  let i = -1;
+  do { n /= 1024; i++; } while (n >= 1024 && i < u.length - 1);
+  return n.toFixed(1) + " " + u[i];
+}
+
+function agoText(sec) {
+  if (!isFinite(sec)) return "unknown";
+  if (sec < 60) return Math.round(sec) + "s ago";
+  if (sec < 3600) return Math.round(sec / 60) + "m ago";
+  return Math.round(sec / 3600) + "h ago";
 }
 
 function updateSideMeta(status) {

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -1471,7 +1471,9 @@ const PG_HEALTH_STALE_SEC = 90;
 
 // pgHealthCard renders the persisted PostgreSQL replication-health snapshot. h is the
 // parsed stream.source_health object {exists,active,wal_status,retained_bytes,
-// safe_wal_size,restart_lsn,confirmed_flush_lsn,replica_identity_not_full,checked_at}.
+// safe_wal_size,restart_lsn,confirmed_flush_lsn,replica_identity_not_full,checked_at,
+// probe_error}. probe_error is the failed-probe discriminator: when set, this snapshot
+// records a probe failure (the slot fields are absent) and the card shows "probe failing".
 function pgHealthCard(h) {
   const card = el("div", { class: "card" });
   card.append(el("div", { class: "card-title", text: "Replication health" }));

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -1165,6 +1165,24 @@ button { font-family: inherit; }
   border-radius: var(--radius-sm); padding: 9px 12px; margin: 6px 0;
 }
 
+/* PostgreSQL replication-health card (#599) */
+.hstat { font-family: var(--f-mono); font-size: 12.5px; font-weight: 600; }
+.hstat-ok     { color: var(--insert); }
+.hstat-warn   { color: var(--orange-2); }
+.hstat-strong { text-decoration: underline; }
+.hstat-err    { color: var(--delete); }
+.hstat-muted  { color: var(--ink-3); }
+.hlist {
+  font-family: var(--f-mono); font-size: 11.5px; color: var(--orange-2);
+  margin: 4px 0 2px; padding-left: 2px; display: flex; flex-direction: column; gap: 2px;
+}
+.hstale {
+  font-family: var(--f-mono); font-size: 11px; color: var(--ink-3);
+  margin-top: 9px; padding-top: 7px; border-top: 1px solid var(--line-soft);
+}
+.hstale-warn { color: var(--orange-2); }
+.card-stale { opacity: 0.6; }
+
 /* point-in-time state table (Time-travel "Value as of T") */
 .statetable { width: 100%; border-collapse: collapse; font-family: var(--f-mono); font-size: 12.5px; }
 .statetable th, .statetable td {

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -269,6 +269,16 @@ func EnsureSchema(db *sql.DB) error {
 	); err != nil {
 		return err
 	}
+	// source_health holds the latest source-side health snapshot a streaming
+	// daemon polls (#599): for PostgreSQL, replication-slot wal_status/lag and
+	// REPLICA IDENTITY coverage, with an embedded checked_at so the index-only
+	// console can show staleness. Source-agnostic JSON payload (one index schema
+	// for all source families); NULL on every index no daemon has polled.
+	if err := ensureColumn(db, "stream_state", "source_health",
+		`ALTER TABLE stream_state ADD COLUMN source_health JSON DEFAULT NULL COMMENT 'latest source-side health snapshot (PostgreSQL: replication-slot wal_status/lag + REPLICA IDENTITY coverage) with an embedded checked_at; serialized payload, source-agnostic column' AFTER gap_lost_detail`,
+	); err != nil {
+		return err
+	}
 	// flavor records the source database flavor (mysql/mariadb) so a resume
 	// parses the saved gtid_set with the correct GTID parser. NOT NULL DEFAULT
 	// 'mysql' means existing rows read back as mysql with no data migration,

--- a/internal/indexer/schema.go
+++ b/internal/indexer/schema.go
@@ -180,6 +180,7 @@ const ddlStreamState = `CREATE TABLE IF NOT EXISTS stream_state (
     bintrail_id      CHAR(36)        NULL DEFAULT NULL,
     gap_lost_at      DATETIME        DEFAULT NULL COMMENT 'when an unfillable binlog gap forced an auto-advance (events permanently lost); cleared by an explicit monitor Stop or --reset',
     gap_lost_detail  TEXT            DEFAULT NULL COMMENT 'human-readable description of the lost gap',
+    source_health    JSON            DEFAULT NULL COMMENT 'latest source-side health snapshot (PostgreSQL: replication-slot wal_status/lag + REPLICA IDENTITY coverage) with an embedded checked_at; serialized payload, source-agnostic column',
     CONSTRAINT single_row CHECK (id = 1)
 ) ENGINE=InnoDB`
 

--- a/internal/indexer/schema_integration_test.go
+++ b/internal/indexer/schema_integration_test.go
@@ -63,6 +63,38 @@ func TestEnsureSchemaAddsFlavorColumn(t *testing.T) {
 	}
 }
 
+// TestEnsureSchemaAddsSourceHealthColumn pins the #599 migration: a pre-source-health
+// install must gain stream_state.source_health as a nullable JSON column, idempotently.
+func TestEnsureSchemaAddsSourceHealthColumn(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	// Simulate a pre-#599 install by dropping the column EnsureSchema re-adds.
+	testutil.MustExec(t, db, `ALTER TABLE stream_state DROP COLUMN source_health`)
+
+	if err := EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	var dataType, isNullable string
+	if err := db.QueryRow(`SELECT DATA_TYPE, IS_NULLABLE FROM information_schema.COLUMNS
+		WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'stream_state'
+		  AND COLUMN_NAME = 'source_health'`).Scan(&dataType, &isNullable); err != nil {
+		t.Fatalf("read source_health column: %v", err)
+	}
+	if dataType != "json" {
+		t.Errorf("source_health DATA_TYPE = %q, want \"json\"", dataType)
+	}
+	if isNullable != "YES" {
+		t.Errorf("source_health IS_NULLABLE = %q, want \"YES\"", isNullable)
+	}
+
+	// Idempotent: a second run must not error or re-add.
+	if err := EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema (second run): %v", err)
+	}
+}
+
 // TestEnsureSchemaAddsFKRuleColumns pins the cascade-recovery migration: a
 // pre-cascade install must gain fk_constraints.delete_rule/update_rule as
 // NOT NULL DEFAULT ” (existing rows backfill to "" = unknown), idempotently.

--- a/internal/pgcapture/health.go
+++ b/internal/pgcapture/health.go
@@ -143,6 +143,39 @@ func QuerySlotHealth(ctx context.Context, conn *pgx.Conn, slotName string) (Slot
 	return r.toHealth()
 }
 
+// HealthSnapshot is a point-in-time source-side health reading the streaming daemon
+// persists to the index for the console (#599): the replication slot's WAL-retention
+// state plus any published table not at REPLICA IDENTITY FULL. pgstreamrun owns the
+// serialized wire shape written to stream_state.source_health; this is the in-memory
+// form the probe returns.
+type HealthSnapshot struct {
+	Slot                   SlotHealth
+	ReplicaIdentityNotFull []string
+}
+
+// ProbeHealth opens a short-lived plain connection to queryDSN and reads current source
+// health: the slot's WAL-retention state (QuerySlotHealth) and the published tables not
+// at REPLICA IDENTITY FULL (QueryReplicaIdentityNotFull). Connect-per-call — the daemon
+// polls infrequently, so a dropped connection self-heals on the next poll; the caller
+// bounds the whole probe with a timeout. It never mutates the source.
+func ProbeHealth(ctx context.Context, queryDSN, slotName, publication string) (HealthSnapshot, error) {
+	conn, err := pgx.Connect(ctx, queryDSN)
+	if err != nil {
+		return HealthSnapshot{}, fmt.Errorf("pgcapture: health probe connect: %w", err)
+	}
+	defer conn.Close(context.Background())
+
+	slot, err := QuerySlotHealth(ctx, conn, slotName)
+	if err != nil {
+		return HealthSnapshot{}, err
+	}
+	notFull, err := QueryReplicaIdentityNotFull(ctx, conn, publication)
+	if err != nil {
+		return HealthSnapshot{}, err
+	}
+	return HealthSnapshot{Slot: slot, ReplicaIdentityNotFull: notFull}, nil
+}
+
 // DropSlot idempotently drops the replication slot on a plain query connection, for
 // teardown/re-baseline (bintrail-pg reset). It returns dropped=false with a nil error
 // when the slot is already absent. It errors if the slot is ACTIVE — a live consumer

--- a/internal/pgcapture/probe_integration_test.go
+++ b/internal/pgcapture/probe_integration_test.go
@@ -1,0 +1,75 @@
+//go:build integration
+
+package pgcapture_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/dbtrail/dbtrail/internal/pgcapture"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestProbeHealth_Integration drives ProbeHealth (slot health + REPLICA IDENTITY
+// coverage, connect-per-call) against a live PostgreSQL — the source-side read the
+// streaming daemon persists for the console health panel (#599). It also exercises the
+// report-only QueryReplicaIdentityNotFull entry point and the shared replicaIdentityNotFull
+// helper end to end: a publication with one FULL and one default-identity table must
+// report exactly the non-FULL one.
+//
+// Requires BINTRAIL_TEST_PG_DSN (e.g. postgres://postgres:testpg@localhost:15533/pgtest).
+func TestProbeHealth_Integration(t *testing.T) {
+	dsn := testutil.SkipIfNoPostgres(t)
+	ctx := context.Background()
+	const slot = "bintrail_probe_it"
+	const pub = "bintrail_probe_pub"
+
+	conn, err := pgx.Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { conn.Close(context.Background()) })
+
+	cleanup := func() {
+		bg := context.Background()
+		_, _ = conn.Exec(bg, "SELECT pg_drop_replication_slot($1) WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name=$1)", slot)
+		_, _ = conn.Exec(bg, "DROP PUBLICATION IF EXISTS "+pub)
+		_, _ = conn.Exec(bg, "DROP TABLE IF EXISTS probe_full, probe_nofull")
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	mustExec := func(sql string) {
+		t.Helper()
+		if _, err := conn.Exec(ctx, sql); err != nil {
+			t.Fatalf("exec %q: %v", sql, err)
+		}
+	}
+	mustExec("CREATE TABLE probe_full (id int PRIMARY KEY)")
+	mustExec("CREATE TABLE probe_nofull (id int PRIMARY KEY)")
+	mustExec("ALTER TABLE probe_full REPLICA IDENTITY FULL")
+	// probe_nofull keeps the default identity (relreplident='d') → reported not-FULL.
+	mustExec("CREATE PUBLICATION " + pub + " FOR TABLE probe_full, probe_nofull")
+	if _, err := conn.Exec(ctx, "SELECT pg_create_logical_replication_slot($1, 'pgoutput')", slot); err != nil {
+		t.Fatalf("create slot: %v", err)
+	}
+
+	snap, err := pgcapture.ProbeHealth(ctx, dsn, slot, pub)
+	if err != nil {
+		t.Fatalf("ProbeHealth: %v", err)
+	}
+	if !snap.Slot.Exists {
+		t.Errorf("ProbeHealth slot Exists=false for a created slot: %+v", snap.Slot)
+	}
+	if len(snap.ReplicaIdentityNotFull) != 1 || !strings.Contains(snap.ReplicaIdentityNotFull[0], "probe_nofull") {
+		t.Errorf("ReplicaIdentityNotFull = %v, want exactly the one default-identity table", snap.ReplicaIdentityNotFull)
+	}
+	for _, s := range snap.ReplicaIdentityNotFull {
+		if strings.Contains(s, "probe_full") {
+			t.Errorf("a REPLICA IDENTITY FULL table must not be reported not-FULL: %v", snap.ReplicaIdentityNotFull)
+		}
+	}
+}

--- a/internal/pgcapture/slot.go
+++ b/internal/pgcapture/slot.go
@@ -125,9 +125,12 @@ func checkWALLevel(ctx context.Context, conn *pgx.Conn) error {
 	return nil
 }
 
-// checkReplicaIdentityTables verifies every table the publication streams is at
-// REPLICA IDENTITY FULL (the per-table loop; wal_level is checked separately).
-func checkReplicaIdentityTables(ctx context.Context, conn *pgx.Conn, publication string) error {
+// replicaIdentityNotFull returns the sorted "schema.table (relreplident=x)" of every
+// published table NOT at REPLICA IDENTITY FULL. It is the single catalog-query source
+// of truth shared by the capture-time validator (which turns a non-empty list into a
+// fatal error) and the report-only QueryReplicaIdentityNotFull (which surfaces the list
+// for the console health panel). An empty result means every published table is FULL.
+func replicaIdentityNotFull(ctx context.Context, conn *pgx.Conn, publication string) ([]string, error) {
 	rows, err := conn.Query(ctx, `
 		SELECT pt.schemaname, pt.tablename, c.relreplident::text
 		FROM pg_publication_tables pt
@@ -135,7 +138,7 @@ func checkReplicaIdentityTables(ctx context.Context, conn *pgx.Conn, publication
 		JOIN pg_class c ON c.relname = pt.tablename AND c.relnamespace = n.oid
 		WHERE pt.pubname = $1`, publication)
 	if err != nil {
-		return fmt.Errorf("pgcapture: checking replica identity for publication %q: %w", publication, err)
+		return nil, fmt.Errorf("pgcapture: checking replica identity for publication %q: %w", publication, err)
 	}
 	defer rows.Close()
 
@@ -143,17 +146,27 @@ func checkReplicaIdentityTables(ctx context.Context, conn *pgx.Conn, publication
 	for rows.Next() {
 		var schema, table, relreplident string
 		if err := rows.Scan(&schema, &table, &relreplident); err != nil {
-			return fmt.Errorf("pgcapture: scanning replica identity for publication %q: %w", publication, err)
+			return nil, fmt.Errorf("pgcapture: scanning replica identity for publication %q: %w", publication, err)
 		}
 		if relreplident != "f" {
 			notFull = append(notFull, fmt.Sprintf("%s.%s (relreplident=%s)", schema, table, relreplident))
 		}
 	}
 	if err := rows.Err(); err != nil {
-		return fmt.Errorf("pgcapture: checking replica identity for publication %q: %w", publication, err)
+		return nil, fmt.Errorf("pgcapture: checking replica identity for publication %q: %w", publication, err)
+	}
+	sort.Strings(notFull)
+	return notFull, nil
+}
+
+// checkReplicaIdentityTables verifies every table the publication streams is at
+// REPLICA IDENTITY FULL (the per-table loop; wal_level is checked separately).
+func checkReplicaIdentityTables(ctx context.Context, conn *pgx.Conn, publication string) error {
+	notFull, err := replicaIdentityNotFull(ctx, conn, publication)
+	if err != nil {
+		return err
 	}
 	if len(notFull) > 0 {
-		sort.Strings(notFull)
 		return fmt.Errorf("pgcapture: table(s) not at REPLICA IDENTITY FULL [%s] — before-images would be partial (an unchanged out-of-line TOAST value is lost under a weaker identity, so recovery would be wrong); run ALTER TABLE <t> REPLICA IDENTITY FULL",
 			strings.Join(notFull, ", "))
 	}
@@ -181,6 +194,14 @@ func CheckPublication(ctx context.Context, conn *pgx.Conn, publication string, f
 // doctor can report the two distinctly.
 func CheckReplicaIdentity(ctx context.Context, conn *pgx.Conn, publication string) error {
 	return checkReplicaIdentityTables(ctx, conn, publication)
+}
+
+// QueryReplicaIdentityNotFull is the report-only sibling of CheckReplicaIdentity: it
+// returns the published tables NOT at REPLICA IDENTITY FULL (empty = all FULL) instead
+// of folding them into a fatal error. The streaming daemon polls it for the console
+// health panel (#599) — a coverage signal the operator reads, not a startup gate.
+func QueryReplicaIdentityNotFull(ctx context.Context, conn *pgx.Conn, publication string) ([]string, error) {
+	return replicaIdentityNotFull(ctx, conn, publication)
 }
 
 // listUnloggedCaptureTables returns the "schema.table" of every UNLOGGED base table in

--- a/internal/pgstreamrun/health_wiring_integration_test.go
+++ b/internal/pgstreamrun/health_wiring_integration_test.go
@@ -1,0 +1,95 @@
+//go:build integration
+
+package pgstreamrun
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/event"
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/pgcapture"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// driveHealthOnce runs streamLoopPG with the given health probe and a tiny interval,
+// waits (bounded) for the first source_health snapshot to land, then stops the loop and
+// returns the index DB for assertions. No live PostgreSQL is needed: the probe is
+// injected, and a health-only tick never touches `cap` (the only cap deref is
+// cap.AckCommitted inside checkpoint(), gated behind lastCommitLSN != 0 — and no commit
+// event is ever sent here), so a nil cap is safe. checkpointInterval is an hour so only
+// the health ticker fires.
+func driveHealthOnce(t *testing.T, probe func(context.Context) (pgcapture.HealthSnapshot, error)) *sql.DB {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	indexDB, _ := testutil.CreateTestDB(t)
+	if err := indexer.CreateIndexTables(ctx, indexDB, 4, false, nil); err != nil {
+		cancel()
+		t.Fatalf("CreateIndexTables: %v", err)
+	}
+	idx := indexer.New(indexDB, 100)
+	events := make(chan event.Event) // never sent → no commit → nil cap untouched
+	state := &pgStreamState{serverID: 88}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- streamLoopPG(ctx, events, idx, indexDB, nil, time.Hour, probe, 15*time.Millisecond, state, slog.New(slog.DiscardHandler))
+	}()
+
+	present := false
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		var sh sql.NullString
+		if err := indexDB.QueryRow(`SELECT source_health FROM stream_state WHERE id=1`).Scan(&sh); err == nil && sh.Valid {
+			present = true
+			break
+		}
+		time.Sleep(15 * time.Millisecond)
+	}
+	cancel()
+	<-done
+	if !present {
+		t.Fatal("no source_health snapshot landed — the healthTicker → pollHealth → saveSourceHealth wiring is dead")
+	}
+	return indexDB
+}
+
+// TestStreamLoopPG_HealthTickWiring exercises the full loop wiring (#599 review, sev-6):
+// the three pieces (probe / buildSourceHealthJSON / saveSourceHealth) are unit-tested
+// separately, but broken wiring would silently write nothing while every separate test
+// stays green. A successful probe must land its snapshot in stream_state.source_health.
+func TestStreamLoopPG_HealthTickWiring(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	db := driveHealthOnce(t, func(context.Context) (pgcapture.HealthSnapshot, error) {
+		return pgcapture.HealthSnapshot{Slot: pgcapture.SlotHealth{Exists: true, WalStatus: "reserved"}}, nil
+	})
+	var ws sql.NullString
+	if err := db.QueryRow(`SELECT source_health->>'$.wal_status' FROM stream_state WHERE id=1`).Scan(&ws); err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if ws.String != "reserved" {
+		t.Errorf("the loop did not persist the probe's snapshot: %q", ws.String)
+	}
+}
+
+// TestStreamLoopPG_HealthProbeErrorPersists proves the never-written-snapshot fix (#599
+// review HIGH): a probe that always errors must STILL persist a snapshot — carrying
+// probe_error — so the console shows "probe failing" rather than a blank panel.
+func TestStreamLoopPG_HealthProbeErrorPersists(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	db := driveHealthOnce(t, func(context.Context) (pgcapture.HealthSnapshot, error) {
+		return pgcapture.HealthSnapshot{}, errors.New("recovery is in progress")
+	})
+	var pe sql.NullString
+	if err := db.QueryRow(`SELECT source_health->>'$.probe_error' FROM stream_state WHERE id=1`).Scan(&pe); err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if !pe.Valid || !strings.Contains(pe.String, "recovery is in progress") {
+		t.Errorf("a persistently failing probe must record probe_error (the never-written-snapshot gap), got: %v", pe)
+	}
+}

--- a/internal/pgstreamrun/persist_integration_test.go
+++ b/internal/pgstreamrun/persist_integration_test.go
@@ -68,3 +68,60 @@ func TestPersistSlotLostPG(t *testing.T) {
 		t.Errorf("gap_lost_detail not updated on the existing row: %q", gapDetail.String)
 	}
 }
+
+// TestSaveSourceHealth pins the #599 upsert contract (white-box, MySQL index only),
+// mirroring TestPersistSlotLostPG: a health write BEFORE the first checkpoint must SEED a
+// complete row (the slot exists from startup, so the daemon polls health before any
+// commit — a bare UPDATE would match zero rows and the console would show no health on an
+// idle stream), and a write against an existing checkpoint must set source_health WITHOUT
+// clobbering the position/checkpoint columns saveCheckpointPG owns. JSON is read back via
+// a path extraction because MySQL re-serializes JSON column values.
+func TestSaveSourceHealth(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	ctx := context.Background()
+	indexDB, _ := testutil.CreateTestDB(t)
+	if err := indexer.CreateIndexTables(ctx, indexDB, 4, false, nil); err != nil {
+		t.Fatalf("CreateIndexTables: %v", err)
+	}
+	logger := slog.New(slog.DiscardHandler)
+
+	// (1) No row yet → the write must seed one.
+	saveSourceHealth(indexDB, 77, []byte(`{"wal_status":"reserved"}`), logger)
+
+	var mode string
+	var serverID uint32
+	var ws sql.NullString
+	if err := indexDB.QueryRowContext(ctx,
+		`SELECT mode, server_id, source_health->>'$.wal_status' FROM stream_state WHERE id=1`).
+		Scan(&mode, &serverID, &ws); err != nil {
+		t.Fatalf("no row was seeded by saveSourceHealth (the no-op false-negative): %v", err)
+	}
+	if !ws.Valid || ws.String != "reserved" {
+		t.Errorf("seeded row missing source_health.wal_status: %v", ws)
+	}
+	if serverID != 77 || mode != "gtid" {
+		t.Errorf("seeded row has wrong NOT NULL fields: server_id=%d mode=%q", serverID, mode)
+	}
+
+	// (2) Existing checkpoint row → the write must preserve the position/file and update
+	// ONLY source_health.
+	if _, err := indexDB.ExecContext(ctx,
+		`UPDATE stream_state SET binlog_position=999, binlog_file='5/ABC' WHERE id=1`); err != nil {
+		t.Fatalf("seed checkpoint: %v", err)
+	}
+	saveSourceHealth(indexDB, 77, []byte(`{"wal_status":"lost"}`), logger)
+
+	var pos uint64
+	var file string
+	if err := indexDB.QueryRowContext(ctx,
+		`SELECT binlog_position, binlog_file, source_health->>'$.wal_status' FROM stream_state WHERE id=1`).
+		Scan(&pos, &file, &ws); err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if pos != 999 || file != "5/ABC" {
+		t.Errorf("source-health write clobbered the checkpoint position: pos=%d file=%q (want 999 / 5/ABC)", pos, file)
+	}
+	if ws.String != "lost" {
+		t.Errorf("source_health not updated on the existing row: %q", ws.String)
+	}
+}

--- a/internal/pgstreamrun/pgstreamrun.go
+++ b/internal/pgstreamrun/pgstreamrun.go
@@ -13,6 +13,7 @@ package pgstreamrun
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -36,6 +37,17 @@ const pgFlavor = "postgres"
 
 // defaultEventBuffer is the size of the channel between the capturer and the loop.
 const defaultEventBuffer = 1000
+
+// healthPollInterval is how often the loop polls the source for a health snapshot
+// (slot WAL-retention + REPLICA IDENTITY coverage) to persist for the console (#599).
+// Slot health changes slowly, so 30s keeps the catalog read cheap; the console's
+// staleness indicator degrades a snapshot older than a few intervals (a dead daemon
+// must not read as healthy). healthPollTimeout bounds one probe so a hung source can
+// only briefly pause event draining (the poll runs inline in the loop's select).
+const (
+	healthPollInterval = 30 * time.Second
+	healthPollTimeout  = 5 * time.Second
+)
 
 // Config binds everything One needs.
 type Config struct {
@@ -142,7 +154,12 @@ func One(ctx context.Context, cfg Config) error {
 		captureErr <- cap.Run(ctx, events)
 	}()
 
-	loopErr := streamLoopPG(ctx, events, idx, indexDB, cap, checkpointInterval, state, logger)
+	// The health probe reads slot/RI state on its own short-lived catalog connection
+	// (connect-per-poll), independent of the capturer's replication and query conns.
+	probe := func(c context.Context) (pgcapture.HealthSnapshot, error) {
+		return pgcapture.ProbeHealth(c, cfg.QueryDSN, cfg.SlotName, cfg.Publication)
+	}
+	loopErr := streamLoopPG(ctx, events, idx, indexDB, cap, checkpointInterval, probe, healthPollInterval, state, logger)
 	cancel() // loop exited first → unblock the capturer's emit/receive so it returns
 
 	// Run returns nil on ctx-cancel; only a real capture error matters.
@@ -201,6 +218,90 @@ func persistSlotLostPG(db *sql.DB, serverID uint32, detail string, logger *slog.
 	}
 }
 
+// sourceHealthJSON is the wire/persisted shape written to stream_state.source_health
+// (#599) — a clean, frontend-friendly projection of pgcapture.HealthSnapshot.
+// SlotHealth's sql.NullInt64 and pglogrepl.LSN do not marshal to a usable JSON shape,
+// so this flattens them: SafeWalSize is a *int64 (null = unlimited retention or an
+// already-lost slot), LSNs are their "X/Y" strings. CheckedAt is RFC3339 UTC so the
+// index-only console can compute staleness unambiguously — a frozen snapshot over a
+// dead daemon must read as stale, not healthy.
+type sourceHealthJSON struct {
+	Exists                 bool     `json:"exists"`
+	Active                 bool     `json:"active"`
+	WalStatus              string   `json:"wal_status"`
+	RetainedBytes          int64    `json:"retained_bytes"`
+	SafeWalSize            *int64   `json:"safe_wal_size"`
+	RestartLSN             string   `json:"restart_lsn"`
+	ConfirmedFlushLSN      string   `json:"confirmed_flush_lsn"`
+	ReplicaIdentityNotFull []string `json:"replica_identity_not_full"`
+	CheckedAt              string   `json:"checked_at"`
+	// ProbeError, when set, means this snapshot records a FAILED probe rather than a
+	// reading — the slot fields are absent/zero. Persisted so the console shows an
+	// explicit "probe failing" state instead of a blank panel (see buildProbeErrorJSON).
+	ProbeError string `json:"probe_error,omitempty"`
+}
+
+// buildSourceHealthJSON marshals a probe result + the wall-clock it was taken into the
+// wire shape. checkedAt is stamped by the caller (not inside, so a test is deterministic).
+func buildSourceHealthJSON(snap pgcapture.HealthSnapshot, checkedAt time.Time) ([]byte, error) {
+	h := sourceHealthJSON{
+		Exists:                 snap.Slot.Exists,
+		Active:                 snap.Slot.Active,
+		WalStatus:              snap.Slot.WalStatus,
+		RetainedBytes:          snap.Slot.RetainedBytes,
+		RestartLSN:             snap.Slot.RestartLSN.String(),
+		ConfirmedFlushLSN:      snap.Slot.ConfirmedFlushLSN.String(),
+		ReplicaIdentityNotFull: snap.ReplicaIdentityNotFull,
+		CheckedAt:              checkedAt.UTC().Format(time.RFC3339),
+	}
+	if snap.Slot.SafeWalSize.Valid {
+		v := snap.Slot.SafeWalSize.Int64
+		h.SafeWalSize = &v
+	}
+	if h.ReplicaIdentityNotFull == nil {
+		h.ReplicaIdentityNotFull = []string{} // marshal as [] not null — a cleaner contract for the frontend
+	}
+	return json.Marshal(h)
+}
+
+// buildProbeErrorJSON records a FAILED probe as a source_health snapshot so the console
+// renders an explicit "probe failing" state instead of nothing. Without this, a probe
+// that never once succeeds — a standby source (the slot-health query runs the
+// primary-only pg_current_wal_lsn()), or a query-DSN auth/network failure that begins
+// after startup — would leave the panel ABSENT, indistinguishable from "no daemon
+// configured", and the staleness indicator cannot age a snapshot that was never written.
+// That is a silent failure in the exact visibility path #599 exists to provide. The slot
+// fields stay zero; the frontend keys off probe_error.
+func buildProbeErrorJSON(probeErr string, checkedAt time.Time) ([]byte, error) {
+	return json.Marshal(sourceHealthJSON{
+		ReplicaIdentityNotFull: []string{},
+		CheckedAt:              checkedAt.UTC().Format(time.RFC3339),
+		ProbeError:             probeErr,
+	})
+}
+
+// saveSourceHealth persists the latest source-health snapshot to
+// stream_state.source_health (#599). Like persistSlotLostPG it is an UPSERT, not a bare
+// UPDATE: the daemon polls health before the first commit writes the row (the slot
+// exists from startup), so an `UPDATE ... WHERE id=1` would match zero rows and silently
+// drop every snapshot until the first checkpoint — the console would show no health on
+// an idle stream. The INSERT seeds the NOT NULL columns; ON DUPLICATE KEY touches ONLY
+// source_health, never the checkpoint/position columns (saveCheckpointPG owns those, so
+// a real checkpoint survives this write). Best-effort: a failed write is logged, never
+// fatal to the stream.
+func saveSourceHealth(db *sql.DB, serverID uint32, healthJSON []byte, logger *slog.Logger) {
+	_, err := db.Exec(`
+		INSERT INTO stream_state (id, mode, flavor, server_id, last_checkpoint, source_health)
+		VALUES (1, 'gtid', ?, ?, UTC_TIMESTAMP(), ?)
+		ON DUPLICATE KEY UPDATE
+			source_health = VALUES(source_health)`,
+		pgFlavor, serverID, healthJSON)
+	if err != nil {
+		logger.Warn("pgstreamrun: could not persist source-health snapshot; the console health panel will stay stale",
+			"error", err)
+	}
+}
+
 // streamLoopPG batches row events into the indexer and checkpoints the durable LSN.
 //
 // The checkpoint cursor is the last COMPLETE transaction's commit LSN (lastCommitLSN)
@@ -217,12 +318,45 @@ func streamLoopPG(
 	indexDB *sql.DB,
 	cap *pgcapture.Capturer,
 	checkpointInterval time.Duration,
+	probe func(context.Context) (pgcapture.HealthSnapshot, error),
+	healthInterval time.Duration,
 	state *pgStreamState,
 	logger *slog.Logger,
 ) error {
 	batch := make([]event.Event, 0, idx.BatchSize())
 	ticker := time.NewTicker(checkpointInterval)
 	defer ticker.Stop()
+
+	// Source-health polling (#599) shares the loop's single goroutine — no concurrent
+	// writer of the stream_state row, so saveSourceHealth can never race saveCheckpointPG.
+	// healthC stays nil when no probe is configured (the case then never fires).
+	var healthC <-chan time.Time
+	if probe != nil {
+		healthTicker := time.NewTicker(healthInterval)
+		defer healthTicker.Stop()
+		healthC = healthTicker.C
+	}
+	pollHealth := func() {
+		pctx, cancel := context.WithTimeout(ctx, healthPollTimeout)
+		defer cancel()
+		snap, err := probe(pctx)
+		if err != nil {
+			logger.Warn("pgstreamrun: source-health probe failed; recording it so the console shows the failure, not a blank panel", "error", err)
+			// Persist the failure (not just log it): a never-written snapshot leaves the
+			// panel absent and the staleness net has nothing to age — the silent-failure
+			// the visibility feature must not have. buildProbeErrorJSON cannot fail.
+			if errJSON, mErr := buildProbeErrorJSON(err.Error(), time.Now()); mErr == nil {
+				saveSourceHealth(indexDB, state.serverID, errJSON, logger)
+			}
+			return
+		}
+		healthJSON, err := buildSourceHealthJSON(snap, time.Now())
+		if err != nil {
+			logger.Warn("pgstreamrun: marshal source-health snapshot", "error", err)
+			return
+		}
+		saveSourceHealth(indexDB, state.serverID, healthJSON, logger)
+	}
 
 	var lastCommitLSN uint64
 
@@ -279,6 +413,13 @@ func streamLoopPG(
 			if err := checkpoint(); err != nil {
 				return err
 			}
+
+		case <-healthC:
+			// Inline in the loop (no second goroutine): a ~tens-of-ms catalog read every
+			// healthInterval, bounded by healthPollTimeout, so a hung source pauses event
+			// draining only briefly. Errors are logged, never fatal — a failed health
+			// poll must not abort the stream.
+			pollHealth()
 
 		case ev, ok := <-events:
 			if !ok {

--- a/internal/pgstreamrun/pgstreamrun.go
+++ b/internal/pgstreamrun/pgstreamrun.go
@@ -341,6 +341,13 @@ func streamLoopPG(
 		defer cancel()
 		snap, err := probe(pctx)
 		if err != nil {
+			// A cancellation is a graceful shutdown (the loop's ctx is done), not a
+			// source-side failure — don't persist a spurious "probe failing" snapshot that
+			// would make a clean stop look broken. A poll TIMEOUT (pctx deadline, ctx still
+			// live) is a real hung-source failure and DOES fall through to be recorded.
+			if ctx.Err() != nil {
+				return
+			}
 			logger.Warn("pgstreamrun: source-health probe failed; recording it so the console shows the failure, not a blank panel", "error", err)
 			// Persist the failure (not just log it): a never-written snapshot leaves the
 			// panel absent and the staleness net has nothing to age — the silent-failure

--- a/internal/pgstreamrun/pgstreamrun_internal_test.go
+++ b/internal/pgstreamrun/pgstreamrun_internal_test.go
@@ -1,9 +1,119 @@
 package pgstreamrun
 
 import (
+	"database/sql"
+	"encoding/json"
 	"log/slog"
 	"testing"
+	"time"
+
+	"github.com/jackc/pglogrepl"
+
+	"github.com/dbtrail/dbtrail/internal/pgcapture"
 )
+
+// TestBuildSourceHealthJSON pins the wire shape written to stream_state.source_health
+// (#599): SlotHealth's sql.NullInt64 and pglogrepl.LSN must flatten cleanly (NULL safe
+// margin → JSON null, LSN → "X/Y" string), an empty not-full list must marshal as []
+// (not null) for a stable frontend contract, and checked_at must be RFC3339 UTC.
+func TestBuildSourceHealthJSON(t *testing.T) {
+	checkedAt := time.Date(2026, 6, 23, 18, 30, 0, 0, time.UTC)
+
+	// Unlimited retention (invalid SafeWalSize → null) + a non-FULL table.
+	snap := pgcapture.HealthSnapshot{
+		Slot: pgcapture.SlotHealth{
+			Exists: true, Active: true, WalStatus: "reserved",
+			RetainedBytes: 16384, RestartLSN: pglogrepl.LSN(0x1A2B3C4),
+			SafeWalSize: sql.NullInt64{}, // invalid → null
+		},
+		ReplicaIdentityNotFull: []string{"app.t1 (relreplident=d)"},
+	}
+	var got map[string]any
+	if b, err := buildSourceHealthJSON(snap, checkedAt); err != nil {
+		t.Fatalf("buildSourceHealthJSON: %v", err)
+	} else if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["wal_status"] != "reserved" {
+		t.Errorf("wal_status = %v", got["wal_status"])
+	}
+	// Pin the key NAMES the frontend (pgHealthCard) reads directly — a json-tag rename on
+	// any of these would pass a looser test green and silently blank the panel.
+	if got["exists"] != true {
+		t.Errorf("exists = %v, want true", got["exists"])
+	}
+	if got["active"] != true {
+		t.Errorf("active = %v, want true", got["active"])
+	}
+	if got["retained_bytes"] != float64(16384) {
+		t.Errorf("retained_bytes = %v, want 16384", got["retained_bytes"])
+	}
+	if got["safe_wal_size"] != nil {
+		t.Errorf("safe_wal_size must be null when SafeWalSize is invalid, got %v", got["safe_wal_size"])
+	}
+	if got["checked_at"] != "2026-06-23T18:30:00Z" {
+		t.Errorf("checked_at = %v, want RFC3339 UTC", got["checked_at"])
+	}
+	if got["restart_lsn"] != pglogrepl.LSN(0x1A2B3C4).String() {
+		t.Errorf("restart_lsn = %v, want %q", got["restart_lsn"], pglogrepl.LSN(0x1A2B3C4).String())
+	}
+	if nf, _ := got["replica_identity_not_full"].([]any); len(nf) != 1 || nf[0] != "app.t1 (relreplident=d)" {
+		t.Errorf("replica_identity_not_full = %v", got["replica_identity_not_full"])
+	}
+
+	// Valid SafeWalSize → a number; empty not-full → [] (a non-nil slice), never null.
+	snap2 := pgcapture.HealthSnapshot{
+		Slot:                   pgcapture.SlotHealth{Exists: true, SafeWalSize: sql.NullInt64{Int64: 1 << 30, Valid: true}},
+		ReplicaIdentityNotFull: nil,
+	}
+	var got2 map[string]any
+	if b, err := buildSourceHealthJSON(snap2, checkedAt); err != nil {
+		t.Fatalf("buildSourceHealthJSON(2): %v", err)
+	} else if err := json.Unmarshal(b, &got2); err != nil {
+		t.Fatalf("unmarshal(2): %v", err)
+	}
+	if got2["safe_wal_size"] == nil {
+		t.Errorf("safe_wal_size must be a number when SafeWalSize is valid")
+	}
+	if nf, ok := got2["replica_identity_not_full"].([]any); !ok || nf == nil {
+		t.Errorf("empty replica_identity_not_full must marshal as [], got %v", got2["replica_identity_not_full"])
+	}
+}
+
+// TestBuildProbeErrorJSON pins the failed-probe wire shape (#599 review): a probe error
+// is persisted as a snapshot carrying probe_error + checked_at (so the console shows
+// "probe failing", not a blank panel), with replica_identity_not_full normalized to [];
+// and a healthy snapshot must OMIT probe_error.
+func TestBuildProbeErrorJSON(t *testing.T) {
+	checkedAt := time.Date(2026, 6, 23, 18, 30, 0, 0, time.UTC)
+	b, err := buildProbeErrorJSON("recovery is in progress", checkedAt)
+	if err != nil {
+		t.Fatalf("buildProbeErrorJSON: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["probe_error"] != "recovery is in progress" {
+		t.Errorf("probe_error = %v", got["probe_error"])
+	}
+	if got["checked_at"] != "2026-06-23T18:30:00Z" {
+		t.Errorf("checked_at = %v", got["checked_at"])
+	}
+	if nf, ok := got["replica_identity_not_full"].([]any); !ok || nf == nil {
+		t.Errorf("replica_identity_not_full must be [], got %v", got["replica_identity_not_full"])
+	}
+
+	// A successful snapshot must NOT carry probe_error (omitempty).
+	healthy, _ := buildSourceHealthJSON(pgcapture.HealthSnapshot{}, checkedAt)
+	var gm map[string]any
+	if err := json.Unmarshal(healthy, &gm); err != nil {
+		t.Fatalf("unmarshal healthy: %v", err)
+	}
+	if _, present := gm["probe_error"]; present {
+		t.Errorf("a healthy snapshot must omit probe_error, got %v", gm["probe_error"])
+	}
+}
 
 func TestResolveStartLSN(t *testing.T) {
 	log := slog.New(slog.DiscardHandler)

--- a/internal/status/legacy_stream_state_integration_test.go
+++ b/internal/status/legacy_stream_state_integration_test.go
@@ -4,6 +4,7 @@ package status_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	_ "github.com/go-sql-driver/mysql"
@@ -45,5 +46,47 @@ func TestLoadStreamState_LegacyIndexMissingGapColumns(t *testing.T) {
 	}
 	if st.GapLostAt.Valid {
 		t.Errorf("a legacy index has no gap-loss record; GapLostAt should be invalid, got %v", st.GapLostAt)
+	}
+}
+
+// TestLoadStreamState_SourceHealth pins the #599 read path: a row with a source_health
+// JSON snapshot is returned verbatim, and an index missing the column (legacy / not yet
+// migrated — the console never migrates registry DSNs) must NOT error. The separate
+// best-effort query degrades to "no health" only on the unknown-column error.
+func TestLoadStreamState_SourceHealth(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	ctx := context.Background()
+	db, _ := testutil.CreateTestDB(t)
+	if err := indexer.CreateIndexTables(ctx, db, 4, false, nil); err != nil {
+		t.Fatalf("CreateIndexTables: %v", err)
+	}
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO stream_state (id, mode, flavor, server_id, last_checkpoint, source_health)
+		 VALUES (1, 'gtid', 'postgres', 9, UTC_TIMESTAMP(), '{"wal_status":"reserved"}')`); err != nil {
+		t.Fatalf("seed row: %v", err)
+	}
+
+	st, err := status.LoadStreamState(ctx, db)
+	if err != nil {
+		t.Fatalf("LoadStreamState: %v", err)
+	}
+	if st == nil || !st.SourceHealth.Valid {
+		t.Fatalf("expected a source_health snapshot, got %+v", st)
+	}
+	if !strings.Contains(st.SourceHealth.String, `"wal_status"`) {
+		t.Errorf("source_health not loaded verbatim: %q", st.SourceHealth.String)
+	}
+
+	// Legacy index without the column → the best-effort second query tolerates the
+	// unknown-column error, leaving SourceHealth invalid (no health, no error).
+	if _, err := db.ExecContext(ctx, "ALTER TABLE stream_state DROP COLUMN source_health"); err != nil {
+		t.Fatalf("drop source_health: %v", err)
+	}
+	st, err = status.LoadStreamState(ctx, db)
+	if err != nil {
+		t.Fatalf("LoadStreamState must not error on an index missing source_health, got: %v", err)
+	}
+	if st == nil || st.SourceHealth.Valid {
+		t.Errorf("a legacy index has no source_health; want invalid, got %+v", st)
 	}
 }

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -326,9 +326,9 @@ func LoadStreamState(ctx context.Context, db *sql.DB) (*StreamStateInfo, error) 
 	// source_health (#599) is loaded by a SEPARATE best-effort query, not folded into the
 	// SELECTs above: it is newer than gap_lost_*, so adding it there would drag any index
 	// that has gap_lost but not yet source_health down to the base fallback (losing the
-	// loss record). The separate query degrades to "no health" only on the unknown-column
-	// error (a legacy/un-migrated index); any other error surfaces, since the core load
-	// already proved the DB reachable.
+	// loss record). The separate query degrades to "no health" on the unknown-column error
+	// (a legacy/un-migrated index) or an empty row; any OTHER error surfaces, since the core
+	// load already proved the DB reachable.
 	if err := loadSourceHealth(ctx, db, s); err != nil {
 		return nil, err
 	}

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -92,6 +92,12 @@ type StreamStateInfo struct {
 	// human-readable context and may be absent. Both writers set them atomically.
 	GapLostAt     sql.NullTime
 	GapLostDetail sql.NullString
+	// SourceHealth is the latest source-side health snapshot a streaming daemon polled
+	// (#599) — for PostgreSQL, a JSON document with the replication slot's wal_status/lag
+	// and REPLICA IDENTITY coverage plus an embedded checked_at. Opaque here (raw JSON);
+	// the console renders it and computes staleness from checked_at. Invalid on a legacy
+	// index without the column or an index no daemon has polled.
+	SourceHealth sql.NullString
 }
 
 // CoverageInfo summarizes the restore coverage of the index.
@@ -313,6 +319,23 @@ func LoadServers(ctx context.Context, db *sql.DB) ([]ServerInfo, error) {
 // LoadStreamState loads the single row from stream_state (if any).
 // Returns nil with no error when the table is empty (no active stream).
 func LoadStreamState(ctx context.Context, db *sql.DB) (*StreamStateInfo, error) {
+	s, err := loadStreamStateCore(ctx, db)
+	if err != nil || s == nil {
+		return s, err
+	}
+	// source_health (#599) is loaded by a SEPARATE best-effort query, not folded into the
+	// SELECTs above: it is newer than gap_lost_*, so adding it there would drag any index
+	// that has gap_lost but not yet source_health down to the base fallback (losing the
+	// loss record). The separate query degrades to "no health" only on the unknown-column
+	// error (a legacy/un-migrated index); any other error surfaces, since the core load
+	// already proved the DB reachable.
+	if err := loadSourceHealth(ctx, db, s); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func loadStreamStateCore(ctx context.Context, db *sql.DB) (*StreamStateInfo, error) {
 	var s StreamStateInfo
 	err := db.QueryRowContext(ctx, `
 		SELECT mode, binlog_file, binlog_position, gtid_set,
@@ -338,6 +361,18 @@ func LoadStreamState(ctx context.Context, db *sql.DB) (*StreamStateInfo, error) 
 		return nil, err
 	}
 	return &s, nil
+}
+
+// loadSourceHealth augments an already-loaded StreamStateInfo with the source_health
+// column. It tolerates ONLY the unknown-column error (a legacy index missing the column)
+// and an empty row — there it leaves SourceHealth invalid (no health to show). Any other
+// error is returned, so a genuine fault is not silently hidden behind a blank panel.
+func loadSourceHealth(ctx context.Context, db *sql.DB, s *StreamStateInfo) error {
+	err := db.QueryRowContext(ctx, `SELECT source_health FROM stream_state WHERE id = 1`).Scan(&s.SourceHealth)
+	if isUnknownColumnErr(err) || errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	return err
 }
 
 // loadStreamStateBase loads the stream_state columns guaranteed by the original CREATE
@@ -789,6 +824,10 @@ func writeStatusJSONFull(w io.Writer, files []IndexStateRow, parts []PartitionSt
 		LastCheckpoint string       `json:"last_checkpoint"`
 		ServerID       uint32       `json:"server_id"`
 		GapLost        *jsonGapLost `json:"gap_lost,omitempty"`
+		// SourceHealth is the raw source_health JSON passed through verbatim (#599):
+		// the console knows its shape (slot wal_status/lag, replica_identity_not_full,
+		// checked_at), this layer does not. Omitted when no daemon has polled.
+		SourceHealth json.RawMessage `json:"source_health,omitempty"`
 	}
 	type jsonBaseline struct {
 		SnapshotTime string  `json:"snapshot_time"`
@@ -883,6 +922,9 @@ func writeStatusJSONFull(w io.Writer, files []IndexStateRow, parts []PartitionSt
 		}
 		if stream.GapLostAt.Valid {
 			jstr.GapLost = &jsonGapLost{At: stream.GapLostAt.Time.Format(TSFmt), Detail: stream.GapLostDetail.String}
+		}
+		if stream.SourceHealth.Valid && stream.SourceHealth.String != "" {
+			jstr.SourceHealth = json.RawMessage(stream.SourceHealth.String)
 		}
 		out.Stream = jstr
 	}

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -1193,3 +1193,41 @@ func TestWriteStatusJSON_gapLost(t *testing.T) {
 		t.Errorf("healthy stream JSON must omit gap_lost:\n%s", buf2.String())
 	}
 }
+
+// TestWriteStatusJSON_sourceHealth pins the daemon→console emission seam (#599): the
+// raw source_health JSON must reach the API response verbatim as a nested object, and be
+// omitted when no daemon has polled. Pure unit (no MySQL) — this branch is the only thing
+// between the persisted snapshot and the panel; a break here silently blanks the panel.
+func TestWriteStatusJSON_sourceHealth(t *testing.T) {
+	var buf bytes.Buffer
+	stream := &StreamStateInfo{
+		Mode: "gtid", LastCheckpoint: time.Now(), ServerID: 7,
+		SourceHealth: sql.NullString{Valid: true, String: `{"wal_status":"reserved","checked_at":"2026-06-23T18:30:00Z"}`},
+	}
+	if err := WriteStatusJSON(&buf, nil, nil, nil, nil, nil, stream); err != nil {
+		t.Fatal(err)
+	}
+	var result struct {
+		Stream struct {
+			SourceHealth struct {
+				WalStatus string `json:"wal_status"`
+			} `json:"source_health"`
+		} `json:"stream"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, buf.String())
+	}
+	if result.Stream.SourceHealth.WalStatus != "reserved" {
+		t.Errorf("stream.source_health did not pass through to JSON (the emission seam is broken): got wal_status=%q\n%s",
+			result.Stream.SourceHealth.WalStatus, buf.String())
+	}
+
+	// Omitted entirely when no daemon has polled (additive, omitempty).
+	var buf2 bytes.Buffer
+	if err := WriteStatusJSON(&buf2, nil, nil, nil, nil, nil, &StreamStateInfo{Mode: "gtid", LastCheckpoint: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(buf2.String(), "source_health") {
+		t.Errorf("a stream with no health snapshot must omit source_health:\n%s", buf2.String())
+	}
+}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -299,6 +299,7 @@ func InitIndexTables(t *testing.T, db *sql.DB) {
 		bintrail_id      CHAR(36)        NULL DEFAULT NULL,
 		gap_lost_at      DATETIME        DEFAULT NULL,
 		gap_lost_detail  TEXT            DEFAULT NULL,
+		source_health    JSON            DEFAULT NULL,
 		CONSTRAINT single_row CHECK (id = 1)
 	) ENGINE=InnoDB`)
 

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -236,12 +236,14 @@ try {
     const fresh = pgHealthCard({ ...base, checked_at: iso(3000) });
     const stale = pgHealthCard({ ...base, safe_wal_size: null, checked_at: iso(300000) });
     const noTs = pgHealthCard({ ...base }); // missing checked_at
+    const lost = pgHealthCard({ ...base, wal_status: "lost", safe_wal_size: null, checked_at: iso(3000) });
     const perr = pgHealthCard({ exists: false, replica_identity_not_full: [], checked_at: iso(2000), probe_error: "recovery is in progress" });
     const nofound = pgHealthCard({ exists: false, replica_identity_not_full: [], checked_at: iso(2000) });
     return {
       freshGreen: !fresh.classList.contains("card-stale") && /checked \d+s ago/.test(fresh.textContent) && !!fresh.querySelector(".hstat-ok"),
       staleMuted: stale.classList.contains("card-stale") && /daemon may be stopped/.test(stale.textContent),
       missingTsStale: noTs.classList.contains("card-stale"),
+      lostRed: !!lost.querySelector(".hstat-err") && /lost/.test(lost.textContent),
       probeErrVisible: /probe failing/i.test(perr.textContent) && /recovery is in progress/.test(perr.textContent) && !!perr.querySelector(".hstat-err"),
       notFoundShown: /not found yet/.test(nofound.textContent),
     };
@@ -249,6 +251,7 @@ try {
   ph.freshGreen ? ok("pg-health: fresh snapshot renders healthy + 'checked Ns ago'") : bad("pg-health: fresh snapshot renders healthy + 'checked Ns ago'", "missing fresh/ok state");
   ph.staleMuted ? ok("pg-health: stale snapshot degrades to muted/warn (never silent-green)") : bad("pg-health: stale snapshot degrades to muted/warn (never silent-green)", "no card-stale / warn footer");
   ph.missingTsStale ? ok("pg-health: missing checked_at reads as stale (fail-safe)") : bad("pg-health: missing checked_at reads as stale (fail-safe)", "rendered fresh");
+  ph.lostRed ? ok("pg-health: a lost slot renders with the red error chip (critical state never benign)") : bad("pg-health: a lost slot renders with the red error chip (critical state never benign)", "wal_status=lost not .hstat-err");
   ph.probeErrVisible ? ok("pg-health: probe failure shows 'probe failing' (not a blank panel)") : bad("pg-health: probe failure shows 'probe failing' (not a blank panel)", "probe_error not surfaced");
   ph.notFoundShown ? ok("pg-health: absent slot shows 'not found yet'") : bad("pg-health: absent slot shows 'not found yet'", "missing not-found state");
 

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -222,6 +222,36 @@ try {
   off.navGuard ? ok("cascade: navigate() guard redirects to overview when off") : bad("cascade: navigate() guard redirects to overview when off", "did not redirect");
   off.renderGuard ? ok("cascade: renderCascade self-guard redirects direct/popstate entry when off") : bad("cascade: renderCascade self-guard redirects direct/popstate entry when off", "form rendered or no redirect — the in-render guard gap");
 
+  // Scenario 7 — PostgreSQL replication-health panel (#599). pgHealthCard is the
+  // load-bearing anti-silent-failure surface: a frozen snapshot over a stopped daemon
+  // must degrade to muted/warn (never render healthy-green), a missing/unparseable
+  // checked_at must read as stale (fail-safe), a recorded probe failure must show as
+  // "probe failing" (not a blank panel), and an absent slot reads "not found yet".
+  // Driven directly with fixtures — the seeded console is MySQL-sourced, so this
+  // unit-drives the render function rather than needing a live PG source.
+  const ph = await page.evaluate(() => {
+    const iso = (msAgo) => new Date(Date.now() - msAgo).toISOString();
+    const base = { exists: true, active: true, wal_status: "reserved", retained_bytes: 16384,
+      safe_wal_size: 1073741824, replica_identity_not_full: [] };
+    const fresh = pgHealthCard({ ...base, checked_at: iso(3000) });
+    const stale = pgHealthCard({ ...base, safe_wal_size: null, checked_at: iso(300000) });
+    const noTs = pgHealthCard({ ...base }); // missing checked_at
+    const perr = pgHealthCard({ exists: false, replica_identity_not_full: [], checked_at: iso(2000), probe_error: "recovery is in progress" });
+    const nofound = pgHealthCard({ exists: false, replica_identity_not_full: [], checked_at: iso(2000) });
+    return {
+      freshGreen: !fresh.classList.contains("card-stale") && /checked \d+s ago/.test(fresh.textContent) && !!fresh.querySelector(".hstat-ok"),
+      staleMuted: stale.classList.contains("card-stale") && /daemon may be stopped/.test(stale.textContent),
+      missingTsStale: noTs.classList.contains("card-stale"),
+      probeErrVisible: /probe failing/i.test(perr.textContent) && /recovery is in progress/.test(perr.textContent) && !!perr.querySelector(".hstat-err"),
+      notFoundShown: /not found yet/.test(nofound.textContent),
+    };
+  });
+  ph.freshGreen ? ok("pg-health: fresh snapshot renders healthy + 'checked Ns ago'") : bad("pg-health: fresh snapshot renders healthy + 'checked Ns ago'", "missing fresh/ok state");
+  ph.staleMuted ? ok("pg-health: stale snapshot degrades to muted/warn (never silent-green)") : bad("pg-health: stale snapshot degrades to muted/warn (never silent-green)", "no card-stale / warn footer");
+  ph.missingTsStale ? ok("pg-health: missing checked_at reads as stale (fail-safe)") : bad("pg-health: missing checked_at reads as stale (fail-safe)", "rendered fresh");
+  ph.probeErrVisible ? ok("pg-health: probe failure shows 'probe failing' (not a blank panel)") : bad("pg-health: probe failure shows 'probe failing' (not a blank panel)", "probe_error not surfaced");
+  ph.notFoundShown ? ok("pg-health: absent slot shows 'not found yet'") : bad("pg-health: absent slot shows 'not found yet'", "missing not-found state");
+
   // No uncaught JS errors over the whole run.
   jsErrors.length === 0 ? ok("no uncaught JS errors") : bad("no uncaught JS errors", JSON.stringify(jsErrors));
 } catch (err) {


### PR DESCRIPTION
closes #599

## Summary

Live PostgreSQL replication-slot health (`wal_status`, retained WAL, safe margin) and `REPLICA IDENTITY` coverage live on the **source** — but the shared `bintrail-console` reads only the **index** (no pgx). So the streaming daemon now polls the source every ~30s and persists a snapshot to `stream_state.source_health`, which the index-only console renders as a **Replication health** panel. This closes the deferred half of #595 (the live slot-health / RI-FULL signals).

- **pgcapture**: `ProbeHealth` (slot health + RI-not-FULL) on a short-lived catalog connection; `QueryReplicaIdentityNotFull` exposes the list form of the existing RI validator (one shared catalog query).
- **pgstreamrun**: a `healthTicker` folded into `streamLoopPG` (single goroutine — no concurrent `stream_state` writer), serializing a clean wire JSON; the UPSERT touches **only** `source_health`, never the checkpoint columns (the #586 no-clobber lesson). A failed probe is **persisted** (`probe_error`) so the panel shows "probe failing", never a silently-absent panel.
- **indexer**: `stream_state.source_health` JSON column (source-agnostic — one index schema for all source families) + an `EnsureSchema` migration.
- **status**: a best-effort second query gated on the unknown-column error only (legacy index → no health, never an error).
- **console**: the panel — color-coded `wal_status`, RI coverage, and a **load-bearing staleness indicator**: a snapshot older than ~90s (or with a missing/unparseable `checked_at`) degrades to muted/warn so a frozen reading never reads as live-healthy.

Presentation stays index-only; `bintrail-pg doctor` remains the on-demand live check.

## Adversarial review (4 agents — all actionable findings fixed)
- **silent-failure HIGH** — never-written-snapshot gap (a persistently failing probe, e.g. a standby source, left the panel absent): **fixed** by persisting probe failures.
- **pr-test sev-8** — staleness logic unguarded in CI: added **scenario 7** to the committed `test/console-e2e` harness (5 pg-health assertions).
- **pr-test sev-6** — loop wiring untested: added `TestStreamLoopPG_HealthTickWiring` + `_HealthProbeErrorPersists`.
- **type-design nit** — widened `TestBuildSourceHealthJSON` to pin the `exists`/`active`/`retained_bytes` keys the frontend reads.
- **code-reviewer**: ship (traced the phantom-row resume path → not a bug).

## Test plan
- [x] `go test ./... -count=1` (unit) + `gofmt`/`build`/`vet`
- [x] Integration vs MySQL: UPSERT no-clobber, `EnsureSchema` migration, read+legacy, **loop wiring** (success + probe-error persist)
- [x] **Committed console-e2e harness: 32/32** (incl. 5 new pg-health scenarios) against a real running console daemon
- [x] Headless-Chrome render of the panel: fresh / stale / lost-slot / probe-error / MySQL-absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)