### PR TITLE
demo: build multi-arch image (amd64 + arm64) via Percona Server 8.0

### DIFF
--- a/.github/workflows/demo-image.yml
+++ b/.github/workflows/demo-image.yml
@@ -70,16 +70,17 @@ jobs:
         with:
           context: .
           file: demo/image/Dockerfile
-          # amd64-only: MySQL's apt repo ships no arm64 packages for
-          # Debian. Apple Silicon evaluators run it via Rosetta/QEMU.
-          platforms: linux/amd64
-          # No provenance attestation: it turns the pushed artifact into
-          # an OCI *index* (image + attestation manifest), and on an ARM
-          # host `docker run` resolves the index, finds no arm64 entry,
-          # and errors with "no matching manifest" instead of falling
-          # back to Rosetta. A plain single-platform manifest emulates
-          # with just a warning — which is the README's promised UX.
-          # Supply-chain integrity still comes from the cosign signature.
+          # Multi-arch: Percona Server 8.0 + ProxySQL 2.6 both ship arm64
+          # packages, so the demo builds natively for ARM64 (Graviton) too.
+          # The arm64 leg cross-builds on this amd64 runner via the
+          # setup-qemu-action above.
+          platforms: linux/amd64,linux/arm64
+          # No provenance attestation: it would add per-platform attestation
+          # manifests to the image index. The manifest list itself already
+          # carries both linux/amd64 and linux/arm64, so a Docker host
+          # resolves its native entry directly. Keeping provenance off keeps
+          # the index a plain multi-platform manifest; supply-chain integrity
+          # still comes from the cosign signature.
           provenance: false
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/demo-image.yml
+++ b/.github/workflows/demo-image.yml
@@ -97,6 +97,10 @@ jobs:
         env:
           DIGEST: ${{ steps.build.outputs.digest }}
         run: |
+          set -euo pipefail
+          # Guard against an empty/malformed build output silently producing
+          # a bad artifact filename that would poison the merge.
+          [[ "$DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]] || { echo "unexpected build digest: '$DIGEST'"; exit 1; }
           mkdir -p "${{ runner.temp }}/digests"
           touch "${{ runner.temp }}/digests/${DIGEST#sha256:}"
 
@@ -141,6 +145,10 @@ jobs:
       - name: Create multi-arch manifest list
         working-directory: ${{ runner.temp }}/digests
         run: |
+          set -euo pipefail
+          # failglob: an empty digests dir aborts here instead of passing a
+          # literal `*` to imagetools as a bogus source ref.
+          shopt -s failglob
           # Intentional word-splitting: expand to multiple -t flags and
           # multiple image@digest args (Docker's documented merge idiom).
           # shellcheck disable=SC2046
@@ -148,11 +156,23 @@ jobs:
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf "${IMAGE}@sha256:%s " *)
 
-      - name: Inspect and sign
+      - name: Inspect, verify both arches, and sign
         env:
           VERSION: ${{ steps.meta.outputs.version }}
         run: |
+          set -euo pipefail
           docker buildx imagetools inspect "${IMAGE}:${VERSION}"
+          # Guard the PR's core promise: the published index MUST carry both
+          # arches. A partial build (one matrix leg's digest missing) would
+          # otherwise tag+sign a single-arch manifest green — exactly the
+          # regression this image's multi-arch support exists to prevent.
+          PLATFORMS=$(docker buildx imagetools inspect "${IMAGE}:${VERSION}" \
+            --format '{{range .Manifest.Manifests}}{{.Platform.OS}}/{{.Platform.Architecture}} {{end}}')
+          echo "manifest platforms: ${PLATFORMS}"
+          for want in linux/amd64 linux/arm64; do
+            case " ${PLATFORMS} " in *" ${want} "*) ;; *) echo "published manifest is missing ${want}"; exit 1 ;; esac
+          done
           DIGEST=$(docker buildx imagetools inspect "${IMAGE}:${VERSION}" \
             --format '{{json .Manifest.Digest}}' | tr -d '"')
+          [[ "$DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]] || { echo "unexpected index digest: '$DIGEST'"; exit 1; }
           cosign sign --yes "${IMAGE}@${DIGEST}"

--- a/.github/workflows/demo-image.yml
+++ b/.github/workflows/demo-image.yml
@@ -31,10 +31,31 @@ permissions:
   packages: write
   id-token: write # cosign keyless signing via GitHub OIDC
 
+env:
+  IMAGE: ghcr.io/dbtrail/bintrail-demo
+
 jobs:
-  build-push:
-    runs-on: ubuntu-22.04
+  # Build each arch on its OWN native runner instead of QEMU-emulating arm64
+  # on an amd64 host: the bintrail binary links DuckDB via CGO (a large C++
+  # compile) and emulated it can take 30+ min / OOM. Each leg pushes a
+  # tagless image BY DIGEST; the `merge` job stitches the digests into one
+  # multi-arch manifest list. (Docker's documented multi-runner pattern.)
+  build:
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-22.04
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
     steps:
+      - name: Prepare platform slug
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: echo "PLATFORM_PAIR=${PLATFORM//\//-}" >> "$GITHUB_ENV"
+
       - uses: actions/checkout@v4
         with:
           # On dispatch, build the tag's tree (checkout fails loudly if
@@ -42,7 +63,59 @@ jobs:
           # is the pushed ref anyway.
           ref: ${{ inputs.tag || github.ref }}
 
-      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+
+      - id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: demo/image/Dockerfile
+          # Percona Server 8.0 + ProxySQL 2.6 both ship arm64 packages, so
+          # the demo builds natively on each arch (no cross-compile).
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Push by digest only (no tag here); the merge job applies tags.
+          # No provenance attestation: it would add per-platform attestation
+          # manifests to the index; the manifest list already carries both
+          # arches so a host resolves its native entry directly. Integrity
+          # comes from the cosign signature on the merged index.
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          provenance: false
+
+      - name: Export digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          touch "${{ runner.temp }}/digests/${DIGEST#sha256:}"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-22.04
+    needs: build
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
 
       - uses: docker/setup-buildx-action@v3
 
@@ -57,7 +130,7 @@ jobs:
       - id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/dbtrail/bintrail-demo
+          images: ${{ env.IMAGE }}
           tags: |
             type=semver,pattern={{version}},value=${{ inputs.tag || github.ref_name }}
             # :latest stays off prereleases (tags containing '-', e.g.
@@ -65,28 +138,21 @@ jobs:
             # manifest in .goreleaser.yaml.
             type=raw,value=latest,enable=${{ !contains(inputs.tag || github.ref_name, '-') }}
 
-      - id: build
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: demo/image/Dockerfile
-          # Multi-arch: Percona Server 8.0 + ProxySQL 2.6 both ship arm64
-          # packages, so the demo builds natively for ARM64 (Graviton) too.
-          # The arm64 leg cross-builds on this amd64 runner via the
-          # setup-qemu-action above.
-          platforms: linux/amd64,linux/arm64
-          # No provenance attestation: it would add per-platform attestation
-          # manifests to the image index. The manifest list itself already
-          # carries both linux/amd64 and linux/arm64, so a Docker host
-          # resolves its native entry directly. Keeping provenance off keeps
-          # the index a plain multi-platform manifest; supply-chain integrity
-          # still comes from the cosign signature.
-          provenance: false
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+      - name: Create multi-arch manifest list
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          # Intentional word-splitting: expand to multiple -t flags and
+          # multiple image@digest args (Docker's documented merge idiom).
+          # shellcheck disable=SC2046
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf "${IMAGE}@sha256:%s " *)
 
-      - name: Sign image
+      - name: Inspect and sign
         env:
-          DIGEST: ${{ steps.build.outputs.digest }}
-        run: cosign sign --yes "ghcr.io/dbtrail/bintrail-demo@${DIGEST}"
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          docker buildx imagetools inspect "${IMAGE}:${VERSION}"
+          DIGEST=$(docker buildx imagetools inspect "${IMAGE}:${VERSION}" \
+            --format '{{json .Manifest.Digest}}' | tr -d '"')
+          cosign sign --yes "${IMAGE}@${DIGEST}"

--- a/demo/image/Dockerfile
+++ b/demo/image/Dockerfile
@@ -1,23 +1,24 @@
 # bintrail demo image — single-container evaluation demo (#350).
 #
-# Bundles: bintrail (built from this repo) + MySQL 8.0 (source AND index
-# in one instance) + ProxySQL preloaded for Time Travel SQL + a traffic
-# generator. EVALUATION ONLY — stateless, restart = fresh demo.
+# Bundles: bintrail (built from this repo) + Percona Server 8.0 (source
+# AND index in one instance) + ProxySQL preloaded for Time Travel SQL + a
+# traffic generator. EVALUATION ONLY — stateless, restart = fresh demo.
 #
 #   docker build -f demo/image/Dockerfile -t bintrail-demo .
 #   docker run --rm -p 6033:6033 bintrail-demo
 #
 # Base-image note: the runtime MUST be glibc-compatible with the builder.
-# mysql:8.0 (Oracle Linux 9, glibc 2.34) cannot run a bookworm-built
-# (glibc 2.36) binary — so the runtime is debian:bookworm-slim with
-# MySQL 8.0 from MySQL's apt repo and ProxySQL from repo.proxysql.com
-# (same install path docs/time-travel-sql.md documents). Alpine is out:
-# DuckDB's static libs need glibc (see docs/docker.md "Why not Alpine?").
+# The bintrail binary is built on golang:1.25-bookworm (glibc 2.36), so the
+# runtime is debian:bookworm-slim with Percona Server 8.0 and ProxySQL 2.6
+# from their bookworm apt repos (both built for bookworm, so glibc stays in
+# lockstep). Alpine is out: DuckDB's static libs need glibc (see
+# docs/docker.md "Why not Alpine?").
 #
-# amd64-only: MySQL's apt repo ships no arm64 packages for Debian
-# (Architectures: i386 amd64). Apple Silicon runs the image via
-# Rosetta/QEMU emulation — fine for an evaluation. On an ARM host build
-# with: docker build --platform linux/amd64 -f demo/image/Dockerfile .
+# Multi-arch (amd64 + arm64): MySQL's own Debian apt repo ships no arm64
+# packages (Architectures: i386 amd64), which is why this image used to be
+# amd64-only. Percona Server 8.0 is a drop-in MySQL with arm64 packages
+# (identical mysqld/mysql binaries and ROW binlog format), so the image now
+# builds and runs natively on ARM64 hosts (AWS Graviton, etc.).
 
 FROM golang:1.25-bookworm AS build
 
@@ -34,28 +35,36 @@ RUN go build -trimpath -ldflags "-s -w" -o /out/bintrail ./cmd/bintrail
 
 FROM debian:bookworm-slim
 
-# MySQL 8.0 (community, NOT default-mysql-server which is MariaDB and
-# has a different binlog format) + ProxySQL 2.6 + bintrail runtime deps.
+# Percona Server 8.0 (a drop-in MySQL — NOT default-mysql-server, which is
+# MariaDB with a different binlog format) + ProxySQL 2.6 + bintrail runtime
+# deps. Percona is used over MySQL community because its apt repo ships
+# arm64 packages (MySQL's Debian repo is amd64/i386-only); the mysqld/mysql
+# binaries and ROW binlog format are identical to upstream MySQL 8.0.
 # policy-rc.d blocks the packages' postinst from trying to start daemons
 # during the image build.
 RUN set -eux; \
     printf '#!/bin/sh\nexit 101\n' > /usr/sbin/policy-rc.d && chmod +x /usr/sbin/policy-rc.d; \
     apt-get update; \
     apt-get install -y --no-install-recommends ca-certificates gnupg wget; \
-    wget -qO /tmp/mysql.key 'https://repo.mysql.com/RPM-GPG-KEY-mysql-2025'; \
-    gpg --dearmor -o /usr/share/keyrings/mysql.gpg /tmp/mysql.key; \
-    echo 'deb [signed-by=/usr/share/keyrings/mysql.gpg] http://repo.mysql.com/apt/debian bookworm mysql-8.0' \
-        > /etc/apt/sources.list.d/mysql.list; \
+    # Percona Server 8.0 via percona-release: the official installer wires
+    # the repo + signing key for the detected architecture (amd64 or arm64).
+    # `enable ps-80 release` is the non-interactive form (`setup ps80` prompts
+    # without a TTY); the apt repo it adds is http, same posture as the MySQL
+    # community repo this replaced — integrity comes from the signed-by key.
+    wget -qO /tmp/percona-release.deb 'https://repo.percona.com/apt/percona-release_latest.generic_all.deb'; \
+    apt-get install -y --no-install-recommends /tmp/percona-release.deb; \
+    percona-release enable ps-80 release; \
+    # ProxySQL 2.6 — already multi-arch (amd64 + arm64).
     wget -qO /tmp/proxysql.key 'https://repo.proxysql.com/ProxySQL/proxysql-2.6.x/repo_pub_key'; \
     gpg --dearmor -o /usr/share/keyrings/proxysql.gpg /tmp/proxysql.key; \
     echo 'deb [signed-by=/usr/share/keyrings/proxysql.gpg] https://repo.proxysql.com/ProxySQL/proxysql-2.6.x/bookworm/ ./' \
         > /etc/apt/sources.list.d/proxysql.list; \
     apt-get update; \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        mysql-server mysql-client proxysql libstdc++6 procps; \
+        percona-server-server percona-server-client proxysql libstdc++6 procps; \
     apt-get purge -y gnupg wget; \
     apt-get autoremove -y; \
-    rm -rf /var/lib/apt/lists/* /tmp/*.key; \
+    rm -rf /var/lib/apt/lists/* /tmp/*.key /tmp/percona-release.deb; \
     # The demo is stateless: drop whatever datadir the package
     # postinst initialized (wrong config) — entrypoint.sh re-initializes
     # with demo/image/my.cnf at first boot.

--- a/demo/image/Dockerfile
+++ b/demo/image/Dockerfile
@@ -48,9 +48,11 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends ca-certificates gnupg wget; \
     # Percona Server 8.0 via percona-release: the official installer wires
     # the repo + signing key for the detected architecture (amd64 or arm64).
-    # `enable ps-80 release` is the non-interactive form (`setup ps80` prompts
-    # without a TTY); the apt repo it adds is http, same posture as the MySQL
-    # community repo this replaced — integrity comes from the signed-by key.
+    # `enable ps-80 release` is the documented non-interactive form and adds
+    # only this repo (vs `setup`, which can disable/reset other Percona repos).
+    # percona-release writes its own signed-by keyring entry
+    # (/usr/share/keyrings/percona-keyring.gpg), so the http apt repo is
+    # key-verified — same posture as the MySQL community repo this replaced.
     wget -qO /tmp/percona-release.deb 'https://repo.percona.com/apt/percona-release_latest.generic_all.deb'; \
     apt-get install -y --no-install-recommends /tmp/percona-release.deb; \
     percona-release enable ps-80 release; \
@@ -62,6 +64,12 @@ RUN set -eux; \
     apt-get update; \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         percona-server-server percona-server-client proxysql libstdc++6 procps; \
+    # Gate the swap: confirm the repo actually yielded Percona Server 8.0 (the
+    # ROW-binlog flavor the demo depends on). A wrong repo/component would
+    # otherwise install a different flavor or major and fail only at runtime.
+    v="$(mysqld --version)"; echo "$v"; \
+    case "$v" in *"Percona Server"*) ;; *) echo "FATAL: not Percona Server: $v"; exit 1;; esac; \
+    case "$v" in *"Ver 8.0."*) ;; *) echo "FATAL: not MySQL 8.0: $v"; exit 1;; esac; \
     apt-get purge -y gnupg wget; \
     apt-get autoremove -y; \
     rm -rf /var/lib/apt/lists/* /tmp/*.key /tmp/percona-release.deb; \

--- a/demo/image/smoke-test.sh
+++ b/demo/image/smoke-test.sh
@@ -19,8 +19,11 @@ NAME="bintrail-demo-smoke"
 log() { echo "[smoke] $(date '+%H:%M:%S') $*"; }
 
 if [ -z "${SKIP_BUILD:-}" ]; then
-    log "Building image (amd64 — MySQL's Debian apt repo has no arm64)..."
-    docker build --platform linux/amd64 -f demo/image/Dockerfile -t "$IMAGE" .
+    # Build for the host's native architecture (Percona Server + ProxySQL
+    # both ship arm64, so this works on Graviton/Apple Silicon too). Override
+    # with PLATFORM=linux/amd64 to cross-build a specific arch.
+    log "Building image${PLATFORM:+ (${PLATFORM})}..."
+    docker build ${PLATFORM:+--platform "$PLATFORM"} -f demo/image/Dockerfile -t "$IMAGE" .
 fi
 
 cleanup() {


### PR DESCRIPTION
closes #605

## Summary
- The `bintrail-demo` image was **amd64-only**, so `docker run` on ARM64 hosts (AWS Graviton) failed with `exec format error` — Docker pulled the only (amd64) manifest and a bare ARM Linux host has no QEMU/binfmt emulation to run it (Apple Silicon masked this via Docker Desktop's bundled emulation).
- **Root cause:** the demo apt-installs MySQL community from Oracle's Debian repo, which ships **no arm64 packages** (`Architectures: i386 amd64`). The product binaries/images were already multi-arch — only the single-container demo appliance was stuck.
- **Fix (single path for both arches):** swap MySQL community → **Percona Server 8.0** via `percona-release enable ps-80 release`. Percona is a drop-in MySQL with arm64 packages — identical `mysqld`/`mysql` binaries and ROW binlog format (it's MySQL, not MariaDB). ProxySQL 2.6 already ships arm64.

### Changes
- `demo/image/Dockerfile`: MySQL community apt → Percona Server 8.0 via `percona-release`; `mysql-server`/`mysql-client` → `percona-server-server`/`percona-server-client`. Updated the amd64-only / base-image comments.
- `.github/workflows/demo-image.yml`: rebuilt as a **native-runner matrix** — `linux/amd64` on `ubuntu-22.04` and `linux/arm64` on `ubuntu-24.04-arm`, each pushing by digest; a `merge` job stitches the digests into one multi-arch manifest list and cosign-signs the index. This avoids QEMU-emulating the CGO/DuckDB compile (which would take 30+ min / OOM on an amd64 runner).
- `demo/image/smoke-test.sh`: build for the host's native arch (drop the forced `--platform linux/amd64`), overridable via `PLATFORM=`.

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] **Full demo build + smoke-test on a native arm64 host: PASS** — mysqld → seed → `bintrail up` → shim → proxysql → traffic, and the time-travel acceptance flow returned a distinct historical row (`live: cancelled 73.97` vs `1-min-ago: pending 62.97`), covering virtual, bare `AS OF`, and `DBTRAIL_AT` hint forms.
- [x] amd64 package resolution confirmed (`percona-server-server 8.0.46-37` installs on `linux/amd64`).
- [x] Workflow passes `actionlint`.
- [ ] CI publishes a multi-arch manifest; verify `docker buildx imagetools inspect ghcr.io/dbtrail/bintrail-demo:latest` lists both `linux/amd64` and `linux/arm64` after the next tag. (The workflow's CI-side behavior — arm64 runner, digest hand-off, manifest merge — can only be confirmed on a real run.)

> Note: `ubuntu-24.04-arm` hosted runners are free for public repositories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)