### PR TITLE
fix(query): avoid Error 1038 (Out of sort memory) on wide rows (#608)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,7 +111,8 @@ services:
     # window is acceptable). buffer-pool size is left at the default — it
     # depends on host RAM and is the operator's to tune (docs/deployment.md §3).
     #
-    # --sort-buffer-size=4M raises the stock 256K default. binlog_events stores
+    # --sort-buffer-size=4M raises the stock default (256K on MySQL 8.x).
+    # binlog_events stores
     # full before/after row images as JSON, and a single fat row (e.g. a
     # WordPress wp_options autoload blob, observed at ~750K) can exceed 256K. A
     # filesort that carries such a row as an addon field then dies with

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,7 +110,18 @@ services:
     # (bintrail replays from the stream_state checkpoint, so a ≤1s recovery
     # window is acceptable). buffer-pool size is left at the default — it
     # depends on host RAM and is the operator's to tune (docs/deployment.md §3).
-    command: ["--innodb-flush-log-at-trx-commit=2"]
+    #
+    # --sort-buffer-size=4M raises the stock 256K default. binlog_events stores
+    # full before/after row images as JSON, and a single fat row (e.g. a
+    # WordPress wp_options autoload blob, observed at ~750K) can exceed 256K. A
+    # filesort that carries such a row as an addon field then dies with
+    # ER_OUT_OF_SORTMEMORY (1038). The query engine avoids this on the hot path
+    # by sorting narrow keys only (internal/query late materialization); 4M is
+    # defense-in-depth for any other sort, bounded and cheap at this index's low
+    # connection concurrency.
+    command:
+      - "--innodb-flush-log-at-trx-commit=2"
+      - "--sort-buffer-size=4M"
     environment:
       # 8.4 defaults to caching_sha2_password (native_password disabled);
       # bintrail's driver negotiates it over the plaintext Docker network.

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"sort"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -194,10 +195,37 @@ func (e *Engine) Fetch(ctx context.Context, opts Options) ([]ResultRow, error) {
 	if err != nil {
 		return nil, err
 	}
+	// buildQuery deliberately omits the outer ORDER BY (see there for why), so
+	// the JOIN may hand rows back in any order. Re-establish the total
+	// (event_timestamp, event_id) ordering here — the result set is already
+	// capped by the inner LIMIT, so this Go-side sort is cheap and keeps the
+	// "Fetch returns ordered rows" contract that recovery.GenerateSQL and the
+	// formatters rely on.
+	sortResults(results, OrderDirection(opts.Order))
 	if len(opts.RedactColumns) > 0 {
 		applyRedaction(results, opts.RedactColumns)
 	}
 	return results, nil
+}
+
+// sortResults orders rows by (event_timestamp, event_id) in dir ("ASC"/"DESC"),
+// matching what the old in-SQL outer ORDER BY produced. Both keys share the
+// direction so the order is total and deterministic across timestamp ties.
+func sortResults(rows []ResultRow, dir string) {
+	desc := dir == "DESC"
+	sort.SliceStable(rows, func(i, j int) bool {
+		a, b := &rows[i], &rows[j]
+		if !a.EventTimestamp.Equal(b.EventTimestamp) {
+			if desc {
+				return a.EventTimestamp.After(b.EventTimestamp)
+			}
+			return a.EventTimestamp.Before(b.EventTimestamp)
+		}
+		if desc {
+			return a.EventID > b.EventID
+		}
+		return a.EventID < b.EventID
+	})
 }
 
 // Run executes the query and writes formatted results to w.
@@ -337,39 +365,56 @@ func buildQuery(opts Options) (string, []any) {
 		args = append(args, dt.Schema, dt.Table)
 	}
 
-	cols := `event_id, binlog_file, start_pos, end_pos, event_timestamp,
-	         gtid, connection_id, schema_name, table_name, event_type, pk_values,
-	         changed_columns, row_before, row_after, schema_version`
+	// Late materialization. A naive `SELECT <wide cols> ... ORDER BY
+	// event_timestamp ... LIMIT N` makes MySQL carry the wide JSON columns
+	// (row_before/row_after) through the filesort as "addon fields". A single
+	// fat row image (e.g. a WordPress wp_options autoload blob) larger than
+	// sort_buffer_size then overflows the sort buffer and the whole query dies
+	// with ER_OUT_OF_SORTMEMORY (1038) — even though only a handful of rows are
+	// oversized and the host has memory to spare. Raising sort_buffer_size only
+	// moves the cliff; an even fatter row re-breaks it.
+	//
+	// Instead, sort + limit on the NARROW key columns alone (a few bytes each,
+	// so the filesort never trips 1038 regardless of row width), then JOIN back
+	// to binlog_events on the primary key to fetch the wide columns for just
+	// those rows. No outer ORDER BY: it would re-introduce the wide-column
+	// filesort. Fetch re-establishes the final ordering in Go (sortResults).
+	//
+	// The PK is (event_id, event_timestamp) — joining on both keys keeps the
+	// match 1:1 and lets MySQL prune partitions on the eq_ref lookup.
+	cols := `be.event_id, be.binlog_file, be.start_pos, be.end_pos, be.event_timestamp,
+	         be.gtid, be.connection_id, be.schema_name, be.table_name, be.event_type, be.pk_values,
+	         be.changed_columns, be.row_before, be.row_after, be.schema_version`
 
 	dir := OrderDirection(opts.Order)
-	outerOrderBy := " ORDER BY event_timestamp " + dir + ", event_id " + dir
-
-	var q string
-	if opts.LimitPerPK > 0 {
-		// Per-PK cap via ROW_NUMBER. Inner ORDER BY DESC is fixed: it
-		// selects "latest N events per pk_values" regardless of the
-		// requested outer direction. Only the outer ORDER BY follows
-		// opts.Order so callers can pick the most recent or the earliest
-		// page across all PKs.
-		inner := "SELECT " + cols + ", ROW_NUMBER() OVER (PARTITION BY pk_values" +
-			" ORDER BY event_timestamp DESC, event_id DESC) AS bt_rn FROM binlog_events"
-		if len(where) > 0 {
-			inner += " WHERE " + strings.Join(where, " AND ")
-		}
-		q = "SELECT " + cols + " FROM (" + inner + ") AS t WHERE bt_rn <= ?"
-		args = append(args, opts.LimitPerPK)
-		q += outerOrderBy
-	} else {
-		q = "SELECT " + cols + " FROM binlog_events"
-		if len(where) > 0 {
-			q += " WHERE " + strings.Join(where, " AND ")
-		}
-		q += outerOrderBy
+	whereSQL := ""
+	if len(where) > 0 {
+		whereSQL = " WHERE " + strings.Join(where, " AND ")
 	}
+
+	var keys string
+	if opts.LimitPerPK > 0 {
+		// Per-PK cap via ROW_NUMBER over the narrow keys only. Inner ORDER BY
+		// DESC is fixed: it selects "latest N events per pk_values" regardless
+		// of the requested final direction.
+		window := "SELECT event_id, event_timestamp, ROW_NUMBER() OVER (PARTITION BY pk_values" +
+			" ORDER BY event_timestamp DESC, event_id DESC) AS bt_rn FROM binlog_events" + whereSQL
+		keys = "SELECT event_id, event_timestamp FROM (" + window + ") AS w WHERE bt_rn <= ?"
+		args = append(args, opts.LimitPerPK)
+	} else {
+		keys = "SELECT event_id, event_timestamp FROM binlog_events" + whereSQL
+	}
+	// The narrow ORDER BY + LIMIT only matters when paging: it decides WHICH N
+	// rows survive. With no LIMIT the selection is the whole filtered set, so
+	// the order is irrelevant here (Fetch sorts in Go anyway) — skip it.
 	if opts.Limit > 0 {
-		q += " LIMIT ?"
+		keys += " ORDER BY event_timestamp " + dir + ", event_id " + dir + " LIMIT ?"
 		args = append(args, opts.Limit)
 	}
+
+	q := "SELECT " + cols + " FROM binlog_events AS be" +
+		" JOIN (" + keys + ") AS k" +
+		" ON be.event_id = k.event_id AND be.event_timestamp = k.event_timestamp"
 
 	return q, args
 }

--- a/internal/query/query_integration_test.go
+++ b/internal/query/query_integration_test.go
@@ -514,10 +514,10 @@ func TestFetch_orderDirectionDisjointRowSets(t *testing.T) {
 
 // TestFetch_wideRowSurvivesSmallSortBuffer reproduces the ER_OUT_OF_SORTMEMORY
 // (1038) class seen on a WordPress source: a single fat row image (wp_options
-// autoload blob, ~750K in the field) is wider than the stock 256K
-// sort_buffer_size, so a filesort that carries the wide JSON columns as addon
-// fields overflows and the whole query dies — even on the Overview/Events list
-// where only a handful of rows are oversized.
+// autoload blob, ~750K in the field) is wider than the stock default
+// sort_buffer_size (256K on MySQL 8.x), so a filesort that carries the wide JSON
+// columns as addon fields overflows and the whole query dies — even on the
+// Overview/Events list where only a handful of rows are oversized.
 //
 // The test pins the connection to the stock 256K buffer, proves with a control
 // query that a naive wide-column sort genuinely 1038s at that size, then asserts
@@ -525,12 +525,13 @@ func TestFetch_orderDirectionDisjointRowSets(t *testing.T) {
 // row with the ordering intact. A regression that re-introduces a wide-column
 // filesort fails here with 1038.
 //
-// Version note: this 1038 is MySQL-8.4-specific (the bundled index version).
-// MySQL 8.0 — which the project's integration MySQL on :13306 runs — degrades a
-// too-wide addon sort to the sort-by-rowid algorithm instead of erroring, so
-// the control cannot reproduce and the test SKIPs there (not a flake). The
-// version-independent guard is the unit test TestBuildQuery_wideColumnsNeverSorted,
-// which pins the SQL shape regardless of server version.
+// Version note: this 1038 is MySQL-8.4-specific. The CI integration matrix
+// (.github/workflows/ci.yml) runs the suite on BOTH 8.0 and 8.4 (port 13306):
+// on the 8.4 cell this test actively reproduces the 1038 and asserts the fix;
+// on the 8.0 cell it SKIPs (8.0 degrades a too-wide addon sort to sort-by-rowid
+// instead of erroring — not a flake). The version-independent guards that run
+// on every cell are the unit tests TestBuildQuery_wideColumnsNeverSorted (SQL
+// shape) and TestSortResults_orderingAndTieBreak (Go-side order).
 func TestFetch_wideRowSurvivesSmallSortBuffer(t *testing.T) {
 	db, _ := testutil.CreateTestDB(t)
 	testutil.InitIndexTables(t, db)

--- a/internal/query/query_integration_test.go
+++ b/internal/query/query_integration_test.go
@@ -511,3 +511,75 @@ func TestFetch_orderDirectionDisjointRowSets(t *testing.T) {
 			ascRows[0].EventTimestamp, descRows[len(descRows)-1].EventTimestamp)
 	}
 }
+
+// TestFetch_wideRowSurvivesSmallSortBuffer reproduces the ER_OUT_OF_SORTMEMORY
+// (1038) class seen on a WordPress source: a single fat row image (wp_options
+// autoload blob, ~750K in the field) is wider than the stock 256K
+// sort_buffer_size, so a filesort that carries the wide JSON columns as addon
+// fields overflows and the whole query dies — even on the Overview/Events list
+// where only a handful of rows are oversized.
+//
+// The test pins the connection to the stock 256K buffer, proves with a control
+// query that a naive wide-column sort genuinely 1038s at that size, then asserts
+// Fetch (which sorts narrow keys only via late materialization) returns every
+// row with the ordering intact. A regression that re-introduces a wide-column
+// filesort fails here with 1038.
+//
+// Version note: this 1038 is MySQL-8.4-specific (the bundled index version).
+// MySQL 8.0 — which the project's integration MySQL on :13306 runs — degrades a
+// too-wide addon sort to the sort-by-rowid algorithm instead of erroring, so
+// the control cannot reproduce and the test SKIPs there (not a flake). The
+// version-independent guard is the unit test TestBuildQuery_wideColumnsNeverSorted,
+// which pins the SQL shape regardless of server version.
+func TestFetch_wideRowSurvivesSmallSortBuffer(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	// Pin the whole pool to one connection at the stock MySQL default buffer so
+	// the fat row below genuinely cannot fit a wide-column filesort.
+	db.SetMaxOpenConns(1)
+	if _, err := db.Exec("SET SESSION sort_buffer_size = 262144"); err != nil {
+		t.Fatalf("pin sort_buffer_size: %v", err)
+	}
+
+	ts := "2026-02-19 14:00:00"
+	for i := uint64(1); i <= 5; i++ {
+		testutil.InsertEvent(t, db, "binlog.000001", 100, 200, ts, nil,
+			"wordpress", "dbt_options", 1, fmt.Sprint(i),
+			nil, nil, []byte(fmt.Sprintf(`{"id":%d}`, i)))
+	}
+	// One fat image well over 256K — mimics a serialized wp_options autoload value.
+	fat := `{"option_value":"` + strings.Repeat("a", 400*1024) + `"}`
+	testutil.InsertEvent(t, db, "binlog.000001", 300, 400, ts, nil,
+		"wordpress", "dbt_options", 1, "6", nil, nil, []byte(fat))
+
+	// Control: a naive wide-column filesort overflows the 256K buffer, proving
+	// the regression condition is real before we assert Fetch survives it.
+	ctrlRows, ctrlErr := db.Query(
+		"SELECT event_id, row_after FROM binlog_events ORDER BY event_timestamp DESC, event_id DESC LIMIT 200")
+	if ctrlErr == nil {
+		ctrlRows.Close()
+		t.Skip("test MySQL did not honor the 256K sort buffer; cannot reproduce 1038 here")
+	}
+	if !strings.Contains(ctrlErr.Error(), "1038") {
+		t.Fatalf("control query failed for an unexpected reason (wanted 1038): %v", ctrlErr)
+	}
+
+	// The real path must return all 6 rows at the same buffer that just broke
+	// the naive sort.
+	e := New(db)
+	rows, err := e.Fetch(context.Background(), Options{
+		Schema: "wordpress", Table: "dbt_options", Limit: 200, Order: "DESC",
+	})
+	if err != nil {
+		t.Fatalf("Fetch must survive a fat row at 256K sort buffer, got: %v", err)
+	}
+	if len(rows) != 6 {
+		t.Fatalf("expected 6 rows, got %d", len(rows))
+	}
+	// Ordering preserved by the Go-side sort: DESC ⇒ highest event_id first.
+	if rows[0].EventID < rows[len(rows)-1].EventID {
+		t.Errorf("expected DESC order by event_id, got first=%d last=%d",
+			rows[0].EventID, rows[len(rows)-1].EventID)
+	}
+}

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -643,19 +643,31 @@ func TestBuildQuery_orderDESC_limitPerPK(t *testing.T) {
 // fat row image (e.g. a WordPress wp_options blob) overflows sort_buffer_size
 // and the query dies. Covers both the plain and per-PK shapes.
 func TestBuildQuery_wideColumnsNeverSorted(t *testing.T) {
+	// Includes the no-Limit shape, and asserts BOTH halves of the invariant so
+	// this guard is self-sufficient (not reliant on HasSuffix in sibling tests):
+	// the wide columns are absent from the sorted key subquery AND there is no
+	// outer ORDER BY after the JOIN — re-appending one over the wide outer
+	// SELECT would re-introduce the filesort without putting row_after in the
+	// key subquery, the exact regression shape this guards against.
 	for _, opts := range []Options{
 		{Schema: "db", Table: "t", Limit: 200, Order: "DESC"},
+		{Schema: "db", Table: "t", Limit: 0, Order: "DESC"},
 		{Schema: "db", Table: "t", PKValuesIn: []string{"1"}, LimitPerPK: 5, Limit: 200, Order: "DESC"},
+		{Schema: "db", Table: "t", PKValuesIn: []string{"1"}, LimitPerPK: 5, Limit: 0, Order: "DESC"},
 	} {
 		q, _ := buildQuery(opts)
-		// The key subquery is everything up to the JOIN's ON clause. row_after
-		// must not appear there — only in the outer SELECT list before "FROM".
+		// The key subquery is everything from the JOIN onward. row_after must not
+		// appear there — only in the outer SELECT list before "FROM".
 		keyPart := q
 		if i := strings.Index(q, " FROM binlog_events AS be JOIN ("); i >= 0 {
 			keyPart = q[i:]
 		}
 		if strings.Contains(keyPart, "row_after") || strings.Contains(keyPart, "row_before") {
 			t.Errorf("wide JSON columns must not appear inside the sorted key subquery: %s", q)
+		}
+		// No outer sort over the wide projection: the statement ends at the JOIN.
+		if !strings.HasSuffix(q, joinSuffix) {
+			t.Errorf("query must end at the JOIN (no outer ORDER BY over wide cols): %s", q)
 		}
 	}
 }

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -672,6 +672,54 @@ func TestBuildQuery_wideColumnsNeverSorted(t *testing.T) {
 	}
 }
 
+// TestSortResults_orderingAndTieBreak is the version-independent guard for the
+// result ORDERING contract, which moved out of SQL and into Go when buildQuery
+// dropped its outer ORDER BY: the JOIN may hand rows back in any order, so
+// sortResults is now the sole source of truth for output order. Feeds a
+// deliberately shuffled slice with a timestamp tie and asserts the
+// (event_timestamp, event_id) total order for ASC, DESC, and the default
+// (empty Order normalises to ASC via OrderDirection, which Fetch always
+// applies). Runs on every CI invocation — the integration reproducer can't,
+// since the 1038 it needs is MySQL-8.4-specific.
+func TestSortResults_orderingAndTieBreak(t *testing.T) {
+	t0 := time.Date(2026, 2, 19, 14, 0, 0, 0, time.UTC)
+	t1 := t0.Add(time.Second)
+	// id 3 and id 1 share t0 — the timestamp tie must break on event_id.
+	in := []ResultRow{
+		{EventID: 3, EventTimestamp: t0},
+		{EventID: 5, EventTimestamp: t1},
+		{EventID: 1, EventTimestamp: t0},
+	}
+	clone := func() []ResultRow { return append([]ResultRow(nil), in...) }
+	ids := func(rows []ResultRow) []uint64 {
+		out := make([]uint64, len(rows))
+		for i, r := range rows {
+			out[i] = r.EventID
+		}
+		return out
+	}
+
+	asc := clone()
+	sortResults(asc, "ASC")
+	if got := ids(asc); got[0] != 1 || got[1] != 3 || got[2] != 5 {
+		t.Errorf("ASC order/tiebreak wrong: got %v want [1 3 5]", got)
+	}
+
+	desc := clone()
+	sortResults(desc, "DESC")
+	if got := ids(desc); got[0] != 5 || got[1] != 3 || got[2] != 1 {
+		t.Errorf("DESC order/tiebreak wrong: got %v want [5 3 1]", got)
+	}
+
+	// Empty/garbage Order must sort ASC — Fetch passes OrderDirection(opts.Order),
+	// and sortResults trusts that upstream normalisation (it checks dir=="DESC").
+	def := clone()
+	sortResults(def, OrderDirection(""))
+	if got := ids(def); got[0] != 1 || got[1] != 3 || got[2] != 5 {
+		t.Errorf("empty Order must sort ASC: got %v want [1 3 5]", got)
+	}
+}
+
 // TestBuildQuery_orderCaseInsensitive locks the normalisation rule:
 // "desc"/"Desc"/"DESC" all produce DESC; "asc"/"" all produce ASC.
 func TestBuildQuery_orderCaseInsensitive(t *testing.T) {

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -551,6 +551,12 @@ func TestBuildQuery_pkValues_winsOver_pkValuesIn(t *testing.T) {
 	}
 }
 
+// joinSuffix is the late-materialization tail every buildQuery output ends
+// with: the wide-column SELECT joins back to the key subquery on the PK and is
+// NOT followed by an ORDER BY. Asserting HasSuffix on it is the regression
+// guard that no outer filesort over the wide JSON columns can creep back in.
+const joinSuffix = ") AS k ON be.event_id = k.event_id AND be.event_timestamp = k.event_timestamp"
+
 func TestBuildQuery_limitPerPK(t *testing.T) {
 	opts := Options{Schema: "db", Table: "t", PKValuesIn: []string{"1", "2"}, LimitPerPK: 1, Limit: 100}
 	q, args := buildQuery(opts)
@@ -562,12 +568,17 @@ func TestBuildQuery_limitPerPK(t *testing.T) {
 		t.Errorf("expected DESC ordering inside window so latest events are kept: %s", q)
 	}
 	if !strings.Contains(q, "WHERE bt_rn <= ?") {
-		t.Errorf("expected outer WHERE bt_rn <= ?: %s", q)
+		t.Errorf("expected WHERE bt_rn <= ? on the windowed keys: %s", q)
 	}
-	// Outer ORDER BY follows opts.Order (default ASC for backward compat).
-	// Both keys get the same direction so the ordering is total.
-	if !strings.HasSuffix(q, "ORDER BY event_timestamp ASC, event_id ASC LIMIT ?") {
-		t.Errorf("expected outer ORDER BY event_timestamp ASC, event_id ASC LIMIT ?: %s", q)
+	// The narrow key sort + LIMIT lives INSIDE the JOIN subquery (it picks which
+	// N rows survive); it follows opts.Order (default ASC for backward compat),
+	// both keys same direction so the page is total.
+	if !strings.Contains(q, "WHERE bt_rn <= ? ORDER BY event_timestamp ASC, event_id ASC LIMIT ?") {
+		t.Errorf("expected narrow ORDER BY ASC + LIMIT inside the key subquery: %s", q)
+	}
+	// No outer sort over the wide columns: the statement ends at the JOIN.
+	if !strings.HasSuffix(q, joinSuffix) {
+		t.Errorf("query must end at the JOIN (no outer ORDER BY over wide cols): %s", q)
 	}
 	// Args: schema, table, pk1, pk2, limitPerPK, limit
 	wantArgs := []any{"db", "t", "1", "2", 1, 100}
@@ -576,19 +587,20 @@ func TestBuildQuery_limitPerPK(t *testing.T) {
 	}
 }
 
-// TestBuildQuery_orderDESC pins the #1511 fix: when Order="DESC" the outer
-// ORDER BY uses DESC for BOTH sort keys (timestamp + event_id), so that the
-// "DESC LIMIT N" page returns the newest N events — not a wrong page that
-// just happens to be sorted descending in display order. The inner
-// ROW_NUMBER window stays fixed at DESC regardless of caller direction
-// because its semantic is "latest N per PK", not "first N in requested
-// direction".
+// TestBuildQuery_orderDESC pins the #1511 fix: when Order="DESC" the key sort
+// uses DESC for BOTH keys (timestamp + event_id), so the "DESC LIMIT N" page
+// returns the newest N events — not a wrong page that just happens to be sorted
+// descending. The sort now lives on the narrow key subquery (late
+// materialization), never carrying the wide JSON columns through a filesort.
 func TestBuildQuery_orderDESC(t *testing.T) {
 	opts := Options{Schema: "db", Table: "t", Limit: 100, Order: "DESC"}
 	q, _ := buildQuery(opts)
 
-	if !strings.HasSuffix(q, "ORDER BY event_timestamp DESC, event_id DESC LIMIT ?") {
-		t.Errorf("expected ORDER BY event_timestamp DESC, event_id DESC LIMIT ? for Order=DESC, got: %s", q)
+	if !strings.Contains(q, "ORDER BY event_timestamp DESC, event_id DESC LIMIT ?") {
+		t.Errorf("expected key ORDER BY event_timestamp DESC, event_id DESC LIMIT ? for Order=DESC, got: %s", q)
+	}
+	if !strings.HasSuffix(q, joinSuffix) {
+		t.Errorf("query must end at the JOIN (no outer ORDER BY over wide cols): %s", q)
 	}
 }
 
@@ -598,13 +610,16 @@ func TestBuildQuery_orderASC(t *testing.T) {
 	opts := Options{Schema: "db", Table: "t", Limit: 100, Order: "ASC"}
 	q, _ := buildQuery(opts)
 
-	if !strings.HasSuffix(q, "ORDER BY event_timestamp ASC, event_id ASC LIMIT ?") {
-		t.Errorf("expected ORDER BY event_timestamp ASC, event_id ASC LIMIT ? for Order=ASC, got: %s", q)
+	if !strings.Contains(q, "ORDER BY event_timestamp ASC, event_id ASC LIMIT ?") {
+		t.Errorf("expected key ORDER BY event_timestamp ASC, event_id ASC LIMIT ? for Order=ASC, got: %s", q)
+	}
+	if !strings.HasSuffix(q, joinSuffix) {
+		t.Errorf("query must end at the JOIN (no outer ORDER BY over wide cols): %s", q)
 	}
 }
 
 // TestBuildQuery_orderDESC_limitPerPK verifies the per-PK ROW_NUMBER inner
-// ORDER BY stays DESC (semantic: "latest N per PK") while the outer ORDER BY
+// ORDER BY stays DESC (semantic: "latest N per PK") while the narrow key sort
 // follows the requested direction.
 func TestBuildQuery_orderDESC_limitPerPK(t *testing.T) {
 	opts := Options{Schema: "db", Table: "t", PKValuesIn: []string{"1", "2"}, LimitPerPK: 1, Limit: 100, Order: "DESC"}
@@ -613,8 +628,35 @@ func TestBuildQuery_orderDESC_limitPerPK(t *testing.T) {
 	if !strings.Contains(q, "ORDER BY event_timestamp DESC, event_id DESC) AS bt_rn") {
 		t.Errorf("inner ROW_NUMBER ORDER BY must stay DESC (selects latest N per PK), got: %s", q)
 	}
-	if !strings.HasSuffix(q, "ORDER BY event_timestamp DESC, event_id DESC LIMIT ?") {
-		t.Errorf("outer ORDER BY must follow opts.Order=DESC, got: %s", q)
+	if !strings.Contains(q, "WHERE bt_rn <= ? ORDER BY event_timestamp DESC, event_id DESC LIMIT ?") {
+		t.Errorf("narrow key sort must follow opts.Order=DESC, got: %s", q)
+	}
+	if !strings.HasSuffix(q, joinSuffix) {
+		t.Errorf("query must end at the JOIN (no outer ORDER BY over wide cols): %s", q)
+	}
+}
+
+// TestBuildQuery_wideColumnsNeverSorted is the core regression guard for the
+// ER_OUT_OF_SORTMEMORY (1038) class: the row_before/row_after JSON columns must
+// only appear in the outer wide SELECT, never inside the subquery that carries
+// the ORDER BY. If they ever leak into the sorted projection again, a single
+// fat row image (e.g. a WordPress wp_options blob) overflows sort_buffer_size
+// and the query dies. Covers both the plain and per-PK shapes.
+func TestBuildQuery_wideColumnsNeverSorted(t *testing.T) {
+	for _, opts := range []Options{
+		{Schema: "db", Table: "t", Limit: 200, Order: "DESC"},
+		{Schema: "db", Table: "t", PKValuesIn: []string{"1"}, LimitPerPK: 5, Limit: 200, Order: "DESC"},
+	} {
+		q, _ := buildQuery(opts)
+		// The key subquery is everything up to the JOIN's ON clause. row_after
+		// must not appear there — only in the outer SELECT list before "FROM".
+		keyPart := q
+		if i := strings.Index(q, " FROM binlog_events AS be JOIN ("); i >= 0 {
+			keyPart = q[i:]
+		}
+		if strings.Contains(keyPart, "row_after") || strings.Contains(keyPart, "row_before") {
+			t.Errorf("wide JSON columns must not appear inside the sorted key subquery: %s", q)
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #608.

## Problem
The console **Overview**/**Events** page (`GET /api/events?limit=200&order=DESC`) died with `Error 1038 (HY001): Out of sort memory` when watching a source with wide rows — reproduced on a WordPress source where `wordpress.dbt_options` had a `row_after` of **751,547 bytes** (bundled `mysql:8.4.9`, stock `sort_buffer_size=262144`).

MySQL carried the wide `row_before`/`row_after` JSON columns through the filesort as packed addon fields; a single row image larger than `sort_buffer_size` overflowed the buffer.

## Why an index does NOT fix it
On the RANGE-partitioned `binlog_events`, an index on `(event_timestamp, event_id)` makes EXPLAIN show "Backward index scan" — but at runtime the merge across ~49 partitions still carries the wide columns and **still 1038s** (verified on real data). Raising `sort_buffer_size` only moves the cliff.

## Fix
1. **`internal/query` late materialization (definitive):** `buildQuery` sorts + limits the **narrow** key columns `(event_id, event_timestamp)` only, then JOINs back to `binlog_events` on the PK for the wide columns. No outer `ORDER BY` (it would re-introduce the wide-column sort); `Fetch` re-establishes the `(event_timestamp, event_id)` order in Go. Row width can no longer trip the filesort.
2. **Bundled tuned default (defense-in-depth):** `--sort-buffer-size=4M` on the index MySQL in `docker-compose.yml`.

Affects every `query.Fetch` consumer (console, MCP, CLI `query`/`recover`) — order contract preserved (rows still come back sorted).

## Verification
End-to-end on **MySQL 8.4.9 with real WordPress data**, at the stock 256K buffer:
- new late-mat shape → **200 rows** ✅
- old naive shape → **Error 1038** ✅ (control proves the buffer constrains)

Empirical matrix (256K buffer, 236 real rows incl. the 734K blob):

| Variant | Result |
|---|---|
| Current query | ❌ 1038 |
| + INDEX `(event_timestamp, event_id)` | ❌ 1038 |
| Late-mat **with** outer ORDER BY over wide cols | ❌ 1038 |
| **Late-mat, narrow-key sort only (this PR)** | ✅ |

## Tests
- **Unit (version-independent):** `TestBuildQuery_wideColumnsNeverSorted` pins the invariant that `row_before`/`row_after` never appear inside the sorted key subquery; the 4 ORDER-BY-shape tests updated to the late-mat contract.
- **Integration:** `TestFetch_wideRowSurvivesSmallSortBuffer` reproduces the 1038 with a control query, then asserts `Fetch` survives. The 1038 is MySQL-8.4-specific (8.0 degrades to sort-by-rowid), so it **skips** on the project's 8.0 CI MySQL — documented in the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)