### PR TITLE
fix(compose): exclude system schemas from the default baseline dump

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -267,8 +267,9 @@ services:
     image: mydumper/mydumper:v1.0.3-1
     environment:
       BASELINE_SOURCE_DSN: ${BASELINE_SOURCE_DSN:-${SOURCE_DSN:-}}
-      # Comma-separated schemas to snapshot (defaults to SCHEMAS; empty =
-      # everything mydumper dumps by default).
+      # Comma-separated schemas to snapshot (defaults to SCHEMAS; empty = all
+      # USER schemas — the system schemas mysql/sys/performance_schema/
+      # information_schema are always excluded, see the dump command below).
       BASELINE_SCHEMAS: ${BASELINE_SCHEMAS:-${SCHEMAS:-}}
     entrypoint: ["/bin/sh", "-c"]
     command:
@@ -318,6 +319,15 @@ services:
             *,*) set -- "$$@" --regex "^($$(printf '%s' "$$schemas" | tr ',' '|'))\\." ;;
             *)   set -- "$$@" --database "$$schemas" ;;
           esac
+        else
+          # No explicit schemas: dump every USER schema but exclude the system
+          # ones. A least-privilege capture user (REPLICATION + SELECT, no
+          # SHOW VIEW) cannot read the sys views, so an unfiltered mydumper dies
+          # with "SHOW VIEW command denied ... sys.host_summary" — and the system
+          # schemas are useless as a baseline anyway. Negative-lookahead PCRE
+          # (mydumper uses PCRE) drops any system db, both bare and <db>.<table>;
+          # $$ is a literal $ after compose interpolation, \\. a literal \.
+          set -- "$$@" --regex "^(?!(mysql|sys|performance_schema|information_schema)($$|\\.))"
         fi
         set -- "$$@" --outputdir /dump/snapshot
         mydumper "$$@"


### PR DESCRIPTION
## Problem
`docker compose --profile baseline run --rm baseline` with no `BASELINE_SCHEMAS` added no mydumper filter, so mydumper tried to dump **every** schema including `sys`. A least-privilege capture user (the typical replication user — `REPLICATION SLAVE` + `REPLICATION CLIENT` + `SELECT`, no `SHOW VIEW`) cannot read the `sys` views, so the dump died:

```
CRITICAL: Error dumping view (sys.host_summary) - ERROR 1142: SHOW VIEW
command denied to user 'dbtrail'@'...' for table 'host_summary'
```

and the whole `baseline` profile exited 1 — a cryptic failure for the common case of a fresh install whose source was added via the **console UI** (so `SOURCE_DSN` is unset and `BASELINE_SCHEMAS` defaults to empty).

## Fix
When no schemas are given, the dump now adds a negative-lookahead `--regex` excluding `mysql`/`sys`/`performance_schema`/`information_schema` (both bare-db and `db.table` forms). The system schemas are unreadable by a least-privilege user and useless as a baseline anyway.

## Verification
Run against a live source as the least-privilege `dbtrail` user (the exact failing setup):
- old behavior → `SHOW VIEW command denied ... sys.host_summary`, exit 1
- new regex → **exit 0**, only the user schema dumped, no `sys.*`/`mysql.*` objects

Compose `$$`→`$` and `\\.`→`\.` interpolation confirmed against the existing positive-filter line.

Follow-up (not in this PR): trigger a baseline from the console UI — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)