### PR TITLE
feat(console): opt-in "Create baseline" button — in-process dump→convert→upload (#613)

### DIFF
--- a/Dockerfile.bintrail-console
+++ b/Dockerfile.bintrail-console
@@ -29,15 +29,22 @@ RUN CGO_ENABLED=1 go build \
 # ── Stage 2: runtime ───────────────────────────────────────
 # Debian slim for glibc compatibility with DuckDB.
 FROM debian:bookworm-slim
+ARG TARGETARCH
 
+# mydumper powers the OPT-IN in-process baseline trigger (#613): with
+# BINTRAIL_CONSOLE_BASELINE_TRIGGER=1 the watch daemon runs mydumper here as a
+# LOCAL subprocess (no docker socket), then converts+uploads in-process. We pin
+# the SAME version the compose baseline-dump pipeline uses (mydumper v1.0.3-1) so
+# console-created baselines are identical to CLI/compose ones — bookworm's apt
+# mydumper is 0.10, too old for the CONSISTENT lock-free --trx-tables snapshot a
+# least-privilege replication user (no RELOAD/FLUSH_TABLES) needs (verified against
+# a real Percona 8.0 source). Idle bytes when the trigger is not enabled.
 RUN apt-get update && \
-    # mydumper powers the OPT-IN in-process baseline trigger (#613): with
-    # BINTRAIL_CONSOLE_BASELINE_TRIGGER=1 the watch daemon runs mydumper here as
-    # a LOCAL subprocess (no docker socket), then converts+uploads in-process.
-    # bookworm ships mydumper < 0.18, so the console's runner omits the
-    # lighter-locking flags (a baseline holds a brief read lock — acceptable for
-    # an occasional snapshot). Idle bytes when the trigger is not enabled.
-    apt-get install -y --no-install-recommends ca-certificates mydumper && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates wget libatomic1 libglib2.0-0 libpcre2-8-0 zstd && \
+    wget -q "https://github.com/mydumper/mydumper/releases/download/v1.0.3-1/mydumper_1.0.3-1.bookworm_${TARGETARCH}.deb" -O /tmp/mydumper.deb && \
+    dpkg -i /tmp/mydumper.deb && \
+    rm -f /tmp/mydumper.deb && \
     rm -rf /var/lib/apt/lists/* && \
     # Pin uid 999: the bundled compose chowns the index password secret to
     # uid 999 (mode 0600) for this process to read — see docker-compose.yml.

--- a/Dockerfile.bintrail-console
+++ b/Dockerfile.bintrail-console
@@ -31,7 +31,13 @@ RUN CGO_ENABLED=1 go build \
 FROM debian:bookworm-slim
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates && \
+    # mydumper powers the OPT-IN in-process baseline trigger (#613): with
+    # BINTRAIL_CONSOLE_BASELINE_TRIGGER=1 the watch daemon runs mydumper here as
+    # a LOCAL subprocess (no docker socket), then converts+uploads in-process.
+    # bookworm ships mydumper < 0.18, so the console's runner omits the
+    # lighter-locking flags (a baseline holds a brief read lock — acceptable for
+    # an occasional snapshot). Idle bytes when the trigger is not enabled.
+    apt-get install -y --no-install-recommends ca-certificates mydumper && \
     rm -rf /var/lib/apt/lists/* && \
     # Pin uid 999: the bundled compose chowns the index password secret to
     # uid 999 (mode 0600) for this process to read — see docker-compose.yml.

--- a/Dockerfile.bintrail-console.goreleaser
+++ b/Dockerfile.bintrail-console.goreleaser
@@ -11,7 +11,13 @@
 FROM debian:bookworm-slim
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates && \
+    # mydumper powers the OPT-IN in-process baseline trigger (#613): with
+    # BINTRAIL_CONSOLE_BASELINE_TRIGGER=1 the watch daemon runs mydumper here as
+    # a LOCAL subprocess (no docker socket), then converts+uploads in-process.
+    # bookworm ships mydumper < 0.18, so the console's runner omits the
+    # lighter-locking flags (a baseline holds a brief read lock — acceptable for
+    # an occasional snapshot). Idle bytes when the trigger is not enabled.
+    apt-get install -y --no-install-recommends ca-certificates mydumper && \
     rm -rf /var/lib/apt/lists/* && \
     # Pin uid 999: the bundled compose chowns the index password secret to
     # uid 999 (mode 0600) for this process to read — see docker-compose.yml.

--- a/Dockerfile.bintrail-console.goreleaser
+++ b/Dockerfile.bintrail-console.goreleaser
@@ -9,15 +9,22 @@
 # glibc for DuckDB's static libs and a shell for debugging. One binary per
 # image (PMM-style) — the core CLI ships as ghcr.io/dbtrail/bintrail.
 FROM debian:bookworm-slim
+ARG TARGETARCH
 
+# mydumper powers the OPT-IN in-process baseline trigger (#613): with
+# BINTRAIL_CONSOLE_BASELINE_TRIGGER=1 the watch daemon runs mydumper here as a
+# LOCAL subprocess (no docker socket), then converts+uploads in-process. We pin
+# the SAME version the compose baseline-dump pipeline uses (mydumper v1.0.3-1) so
+# console-created baselines are identical to CLI/compose ones — bookworm's apt
+# mydumper is 0.10, too old for the CONSISTENT lock-free --trx-tables snapshot a
+# least-privilege replication user (no RELOAD/FLUSH_TABLES) needs (verified against
+# a real Percona 8.0 source). Idle bytes when the trigger is not enabled.
 RUN apt-get update && \
-    # mydumper powers the OPT-IN in-process baseline trigger (#613): with
-    # BINTRAIL_CONSOLE_BASELINE_TRIGGER=1 the watch daemon runs mydumper here as
-    # a LOCAL subprocess (no docker socket), then converts+uploads in-process.
-    # bookworm ships mydumper < 0.18, so the console's runner omits the
-    # lighter-locking flags (a baseline holds a brief read lock — acceptable for
-    # an occasional snapshot). Idle bytes when the trigger is not enabled.
-    apt-get install -y --no-install-recommends ca-certificates mydumper && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates wget libatomic1 libglib2.0-0 libpcre2-8-0 zstd && \
+    wget -q "https://github.com/mydumper/mydumper/releases/download/v1.0.3-1/mydumper_1.0.3-1.bookworm_${TARGETARCH}.deb" -O /tmp/mydumper.deb && \
+    dpkg -i /tmp/mydumper.deb && \
+    rm -f /tmp/mydumper.deb && \
     rm -rf /var/lib/apt/lists/* && \
     # Pin uid 999: the bundled compose chowns the index password secret to
     # uid 999 (mode 0600) for this process to read — see docker-compose.yml.

--- a/cmd/bintrail-console/baseline.go
+++ b/cmd/bintrail-console/baseline.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/baseline"
+	"github.com/dbtrail/dbtrail/internal/config"
+	"github.com/dbtrail/dbtrail/internal/console"
+)
+
+// baselineSupervisor implements console.BaselineController by running the
+// dump→convert→upload pipeline IN-PROCESS (#613): the console image bundles
+// mydumper, so a baseline never starts a sibling container and the daemon never
+// mounts the docker socket. One job at a time per server, tracked in-memory —
+// the durable record is the snapshot itself (listed by /api/baselines).
+type baselineSupervisor struct {
+	ctx        context.Context // daemon lifecycle; cancels an in-flight dump on shutdown
+	stagingDir string          // base dir for temp dump + staged Parquet (S3-destined runs)
+
+	mu   sync.Mutex
+	jobs map[string]*console.BaselineStatus
+}
+
+// newBaselineSupervisor builds a supervisor bound to the daemon context. The
+// staging dir is created lazily per run.
+func newBaselineSupervisor(ctx context.Context, stagingDir string) *baselineSupervisor {
+	return &baselineSupervisor{
+		ctx:        ctx,
+		stagingDir: stagingDir,
+		jobs:       make(map[string]*console.BaselineStatus),
+	}
+}
+
+// Trigger starts a baseline in the background; returns console.ErrBaselineRunning
+// if one is already in flight for this server.
+func (s *baselineSupervisor) Trigger(req console.BaselineRequest) error {
+	s.mu.Lock()
+	if st, ok := s.jobs[req.ServerID]; ok && st.State == "running" {
+		s.mu.Unlock()
+		return console.ErrBaselineRunning
+	}
+	s.jobs[req.ServerID] = &console.BaselineStatus{State: "running", Since: nowStamp()}
+	s.mu.Unlock()
+
+	slog.Info("baseline: starting in-process snapshot", "server", req.ServerName, "id", req.ServerID)
+	go s.run(req)
+	return nil
+}
+
+// Status returns a copy of the latest known job state (idle if never run here).
+func (s *baselineSupervisor) Status(serverID string) console.BaselineStatus {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if st, ok := s.jobs[serverID]; ok {
+		return *st
+	}
+	return console.BaselineStatus{State: "idle"}
+}
+
+func (s *baselineSupervisor) run(req console.BaselineRequest) {
+	stats, uploaded, err := s.execute(req)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	st := s.jobs[req.ServerID]
+	if st == nil { // defensive: never overwritten away under lock, but don't panic
+		st = &console.BaselineStatus{}
+		s.jobs[req.ServerID] = st
+	}
+	st.FinishedAt = nowStamp()
+	if err != nil {
+		st.State = "failed"
+		st.LastError = err.Error()
+		slog.Error("baseline: snapshot failed", "server", req.ServerName, "id", req.ServerID, "error", err)
+		return
+	}
+	st.State = "succeeded"
+	st.LastError = ""
+	st.Tables = stats.TablesProcessed
+	st.Rows = stats.RowsWritten
+	st.Uploaded = uploaded
+	slog.Info("baseline: snapshot complete", "server", req.ServerName, "id", req.ServerID,
+		"tables", stats.TablesProcessed, "rows", stats.RowsWritten, "uploaded", uploaded)
+}
+
+// execute runs the full pipeline: mydumper → baseline.Run → (S3) baseline.Upload.
+// For a local-dir destination the Parquet is written there persistently and not
+// uploaded; for an S3 destination it is staged under a fresh temp dir, uploaded,
+// and the staging removed (so a re-run never re-uploads an old snapshot).
+func (s *baselineSupervisor) execute(req console.BaselineRequest) (baseline.Stats, int, error) {
+	if err := os.MkdirAll(s.stagingDir, 0o755); err != nil {
+		return baseline.Stats{}, 0, fmt.Errorf("create staging dir: %w", err)
+	}
+
+	dumpDir, err := os.MkdirTemp(s.stagingDir, "dump-")
+	if err != nil {
+		return baseline.Stats{}, 0, fmt.Errorf("create dump dir: %w", err)
+	}
+	defer os.RemoveAll(dumpDir)
+
+	if err := runMydumper(s.ctx, req.SourceDSN, req.Schemas, dumpDir); err != nil {
+		return baseline.Stats{}, 0, fmt.Errorf("dump: %w", err)
+	}
+
+	outputDir := req.LocalDir
+	if outputDir == "" { // S3-only: stage then upload, discard staging
+		outputDir, err = os.MkdirTemp(s.stagingDir, "baseline-")
+		if err != nil {
+			return baseline.Stats{}, 0, fmt.Errorf("create baseline staging dir: %w", err)
+		}
+		defer os.RemoveAll(outputDir)
+	}
+
+	stats, err := baseline.Run(s.ctx, baseline.Config{
+		InputDir:    dumpDir,
+		OutputDir:   outputDir,
+		Compression: "zstd",
+	})
+	if err != nil {
+		return baseline.Stats{}, 0, fmt.Errorf("convert: %w", err)
+	}
+
+	var uploaded int
+	if req.S3 != "" {
+		// Region/credentials come from the ambient AWS chain (env / ~/.aws / IAM
+		// role), like every other S3 read the console does.
+		uploaded, err = baseline.Upload(s.ctx, outputDir, req.S3, "", false)
+		if err != nil {
+			return baseline.Stats{}, 0, fmt.Errorf("upload: %w", err)
+		}
+	}
+	return stats, uploaded, nil
+}
+
+// runMydumper invokes the bundled mydumper binary against the source DSN, writing
+// a consistent dump (with binlog coordinates in its metadata, which baseline.Run
+// reads) into dumpDir. The lighter-locking flags (--sync-thread-lock-mode /
+// --trx-tables, mydumper >= 0.18) are deliberately omitted: a baseline is an
+// occasional operation, and omitting them keeps this working on ANY mydumper
+// version the image happens to ship without a version probe.
+func runMydumper(ctx context.Context, sourceDSN string, schemas []string, dumpDir string) error {
+	host, port, user, password, err := config.ParseSourceDSN(sourceDSN)
+	if err != nil {
+		return err
+	}
+
+	args := buildConsoleMydumperArgs(host, port, user, password, schemas, dumpDir)
+	cmd := exec.CommandContext(ctx, "mydumper", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		if msg := strings.TrimSpace(string(out)); msg != "" {
+			return fmt.Errorf("mydumper failed: %w; output: %s", err, msg)
+		}
+		return fmt.Errorf("mydumper failed: %w", err)
+	}
+	return nil
+}
+
+// buildConsoleMydumperArgs builds the mydumper argument slice for the console's
+// in-process dump. Single schema → --database; multiple → an anchored --regex;
+// none → all schemas. Extracted for unit testing without a live mydumper.
+func buildConsoleMydumperArgs(host string, port uint16, user, password string, schemas []string, dumpDir string) []string {
+	args := []string{
+		"--host", host,
+		"--port", strconv.Itoa(int(port)),
+		"--user", user,
+		"--threads", "4",
+		"--compress-protocol",
+		"--complete-insert",
+	}
+	if password != "" {
+		args = append(args, "--password", password)
+	}
+	switch {
+	case len(schemas) == 1:
+		args = append(args, "--database", schemas[0])
+	case len(schemas) > 1:
+		args = append(args, "--regex", "^("+strings.Join(schemas, "|")+")\\.")
+	}
+	// --outputdir last: docker wrapper scripts read the last arg for the mount.
+	args = append(args, "--outputdir", dumpDir)
+	return args
+}
+
+// nowStamp is the RFC3339 timestamp used in job status fields.
+func nowStamp() string { return time.Now().UTC().Format(time.RFC3339) }

--- a/cmd/bintrail-console/baseline.go
+++ b/cmd/bintrail-console/baseline.go
@@ -142,10 +142,9 @@ func (s *baselineSupervisor) execute(req console.BaselineRequest) (baseline.Stat
 
 // runMydumper invokes the bundled mydumper binary against the source DSN, writing
 // a consistent dump (with binlog coordinates in its metadata, which baseline.Run
-// reads) into dumpDir. The lighter-locking flags (--sync-thread-lock-mode /
-// --trx-tables, mydumper >= 0.18) are deliberately omitted: a baseline is an
-// occasional operation, and omitting them keeps this working on ANY mydumper
-// version the image happens to ship without a version probe.
+// reads) into dumpDir. The image pins the SAME mydumper version the compose
+// baseline-dump pipeline uses, so a console-created baseline matches a CLI/compose
+// one exactly.
 func runMydumper(ctx context.Context, sourceDSN string, schemas []string, dumpDir string) error {
 	host, port, user, password, err := config.ParseSourceDSN(sourceDSN)
 	if err != nil {
@@ -164,9 +163,22 @@ func runMydumper(ctx context.Context, sourceDSN string, schemas []string, dumpDi
 	return nil
 }
 
+// systemSchemaExcludeRegex dumps every USER schema but excludes the MySQL system
+// schemas, matching the compose baseline-dump pipeline (#612). A least-privilege
+// capture user (REPLICATION + SELECT, no SHOW VIEW) cannot read the sys views, so
+// an unfiltered mydumper dies with "SHOW VIEW command denied … sys.host_summary";
+// the system schemas are useless as a baseline anyway. mydumper uses PCRE, so the
+// negative lookahead drops a system db both bare and as <db>.<table>.
+const systemSchemaExcludeRegex = `^(?!(mysql|sys|performance_schema|information_schema)($|\.))`
+
 // buildConsoleMydumperArgs builds the mydumper argument slice for the console's
-// in-process dump. Single schema → --database; multiple → an anchored --regex;
-// none → all schemas. Extracted for unit testing without a live mydumper.
+// in-process dump. It mirrors `bintrail dump` / the compose baseline-dump
+// invocation: a CONSISTENT lock-free snapshot (--sync-thread-lock-mode NO_LOCK
+// --trx-tables — no global FTWRL, so a least-privilege replication user WITHOUT
+// RELOAD/FLUSH_TABLES can dump; verified against a real Percona 8.0 source).
+// Schema selection: single → --database; multiple → an anchored --regex; none →
+// every user schema with the system schemas excluded. Extracted for unit testing
+// without a live mydumper.
 func buildConsoleMydumperArgs(host string, port uint16, user, password string, schemas []string, dumpDir string) []string {
 	args := []string{
 		"--host", host,
@@ -175,6 +187,7 @@ func buildConsoleMydumperArgs(host string, port uint16, user, password string, s
 		"--threads", "4",
 		"--compress-protocol",
 		"--complete-insert",
+		"--sync-thread-lock-mode", "NO_LOCK", "--trx-tables",
 	}
 	if password != "" {
 		args = append(args, "--password", password)
@@ -184,6 +197,8 @@ func buildConsoleMydumperArgs(host string, port uint16, user, password string, s
 		args = append(args, "--database", schemas[0])
 	case len(schemas) > 1:
 		args = append(args, "--regex", "^("+strings.Join(schemas, "|")+")\\.")
+	default:
+		args = append(args, "--regex", systemSchemaExcludeRegex)
 	}
 	// --outputdir last: docker wrapper scripts read the last arg for the mount.
 	args = append(args, "--outputdir", dumpDir)

--- a/cmd/bintrail-console/baseline_test.go
+++ b/cmd/bintrail-console/baseline_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+// TestBuildConsoleMydumperArgs covers the schema-filter branches and the
+// invariants the dump relies on: a password only when present, and --outputdir
+// last (docker wrappers read the final arg as the mount path).
+func TestBuildConsoleMydumperArgs(t *testing.T) {
+	t.Run("no schema filter dumps everything", func(t *testing.T) {
+		args := buildConsoleMydumperArgs("h", 3306, "u", "pw", nil, "/out")
+		if has(args, "--database") || has(args, "--regex") {
+			t.Errorf("no schema filter should add neither --database nor --regex: %v", args)
+		}
+		assertOutputdirLast(t, args, "/out")
+	})
+
+	t.Run("single schema uses --database", func(t *testing.T) {
+		args := buildConsoleMydumperArgs("h", 3306, "u", "pw", []string{"wordpress"}, "/out")
+		if v := valueAfter(args, "--database"); v != "wordpress" {
+			t.Errorf("--database = %q, want wordpress: %v", v, args)
+		}
+		if has(args, "--regex") {
+			t.Errorf("single schema must not use --regex: %v", args)
+		}
+	})
+
+	t.Run("multiple schemas use anchored --regex", func(t *testing.T) {
+		args := buildConsoleMydumperArgs("h", 3306, "u", "pw", []string{"a", "b"}, "/out")
+		if v := valueAfter(args, "--regex"); v != "^(a|b)\\." {
+			t.Errorf("--regex = %q, want ^(a|b)\\. : %v", v, args)
+		}
+		if has(args, "--database") {
+			t.Errorf("multiple schemas must not use --database: %v", args)
+		}
+	})
+
+	t.Run("empty password omits --password", func(t *testing.T) {
+		args := buildConsoleMydumperArgs("h", 3306, "u", "", nil, "/out")
+		if has(args, "--password") {
+			t.Errorf("empty password must not add --password: %v", args)
+		}
+	})
+
+	t.Run("password present adds --password", func(t *testing.T) {
+		args := buildConsoleMydumperArgs("h", 3306, "u", "secret", nil, "/out")
+		if v := valueAfter(args, "--password"); v != "secret" {
+			t.Errorf("--password = %q, want secret", v)
+		}
+	})
+}
+
+func has(args []string, flag string) bool { return slices.Contains(args, flag) }
+
+func valueAfter(args []string, flag string) string {
+	i := slices.Index(args, flag)
+	if i < 0 || i+1 >= len(args) {
+		return ""
+	}
+	return args[i+1]
+}
+
+func assertOutputdirLast(t *testing.T, args []string, want string) {
+	t.Helper()
+	n := len(args)
+	if n < 2 || args[n-2] != "--outputdir" || args[n-1] != want {
+		t.Errorf("--outputdir %q must be the last arg pair: ...%v", want, strings.Join(args[max(0, n-3):], " "))
+	}
+}

--- a/cmd/bintrail-console/baseline_test.go
+++ b/cmd/bintrail-console/baseline_test.go
@@ -10,10 +10,28 @@ import (
 // invariants the dump relies on: a password only when present, and --outputdir
 // last (docker wrappers read the final arg as the mount path).
 func TestBuildConsoleMydumperArgs(t *testing.T) {
-	t.Run("no schema filter dumps everything", func(t *testing.T) {
+	t.Run("consistent lock-free flags always present", func(t *testing.T) {
+		// These let a least-privilege replication user (no RELOAD/FLUSH_TABLES)
+		// dump consistently — verified against a real Percona 8.0 source. Their
+		// absence is the bug that produced a schema-only dump.
+		args := buildConsoleMydumperArgs("h", 3306, "u", "pw", []string{"x"}, "/out")
+		if valueAfter(args, "--sync-thread-lock-mode") != "NO_LOCK" {
+			t.Errorf("missing --sync-thread-lock-mode NO_LOCK: %v", args)
+		}
+		if !has(args, "--trx-tables") {
+			t.Errorf("missing --trx-tables: %v", args)
+		}
+	})
+
+	t.Run("no schema filter excludes system schemas", func(t *testing.T) {
 		args := buildConsoleMydumperArgs("h", 3306, "u", "pw", nil, "/out")
-		if has(args, "--database") || has(args, "--regex") {
-			t.Errorf("no schema filter should add neither --database nor --regex: %v", args)
+		if has(args, "--database") {
+			t.Errorf("no schema filter must not use --database: %v", args)
+		}
+		// A least-privilege user can't read the sys views, so an unfiltered dump
+		// dies; the no-filter case must exclude the system schemas instead.
+		if v := valueAfter(args, "--regex"); v != systemSchemaExcludeRegex {
+			t.Errorf("--regex = %q, want the system-schema exclusion: %v", v, args)
 		}
 		assertOutputdirLast(t, args, "/out")
 	})

--- a/cmd/bintrail-console/watch.go
+++ b/cmd/bintrail-console/watch.go
@@ -77,6 +77,13 @@ var (
 	upConsoleAllowedHost []string
 	upConsoleAllowSetup  bool
 	upArchiveStageDir    string
+	// upConsoleBaselineTrigger opts into in-process baseline creation from the
+	// console (#613). Env-only (BINTRAIL_CONSOLE_BASELINE_TRIGGER=1) — off by
+	// default because it needs mydumper in the image and reaches the source DB.
+	upConsoleBaselineTrigger bool
+	// upBaselineStageDir is the local staging base for S3-destined baselines
+	// (BINTRAIL_CONSOLE_BASELINE_STAGING); default a temp subdir.
+	upBaselineStageDir string
 
 	upRotateRetain    string
 	upRotateInterval  string
@@ -354,6 +361,9 @@ func runUpConsoleOnly(cmd *cobra.Command) error {
 
 	supervisor := newMonitorSupervisor(ctx, upIndexDSN, registry, upRotationCfg.Retain)
 	cfg.MonitorCtrl = supervisor
+	if upConsoleBaselineTrigger {
+		cfg.BaselineCtrl = newBaselineSupervisor(ctx, baselineStagingDir())
+	}
 
 	// Built-in rotation covers the boot index plus every per-source database
 	// the control plane provisions — the unattended quickstart's real data
@@ -452,6 +462,9 @@ func runUpStreamWithConsole(cmd *cobra.Command, args []string) error {
 	// the HTTP requests that start them.
 	supervisor := newMonitorSupervisor(ctx, upIndexDSN, registry, upRotationCfg.Retain)
 	cfg.MonitorCtrl = supervisor
+	if upConsoleBaselineTrigger {
+		cfg.BaselineCtrl = newBaselineSupervisor(ctx, baselineStagingDir())
+	}
 
 	// Built-in rotation: boot index + every per-source database the control
 	// plane provisions, on the daemon lifecycle. Live settings provider so the
@@ -602,6 +615,24 @@ func resolveUpConsoleEnv(cmd *cobra.Command) {
 			upArchiveStageDir = v
 		}
 	}
+	// Baseline trigger is env-only (no flag): opt-in plus an optional staging dir.
+	if v := os.Getenv("BINTRAIL_CONSOLE_BASELINE_TRIGGER"); v == "1" || v == "true" {
+		upConsoleBaselineTrigger = true
+	}
+	if v := os.Getenv("BINTRAIL_CONSOLE_BASELINE_STAGING"); v != "" {
+		upBaselineStageDir = v
+	}
+}
+
+// baselineStagingDir resolves the local staging base for baselines destined for
+// S3 (BINTRAIL_CONSOLE_BASELINE_STAGING). The dump and the staged Parquet are
+// written under a fresh temp subdir here per run and removed after upload, so a
+// leftover never causes a re-upload of an old snapshot. Default: an OS temp subdir.
+func baselineStagingDir() string {
+	if upBaselineStageDir != "" {
+		return upBaselineStageDir
+	}
+	return filepath.Join(os.TempDir(), "bintrail-baseline-staging")
 }
 
 // consoleOpts carries watch's console-surface settings into upConsoleConfig —

--- a/cmd/bintrail/baseline.go
+++ b/cmd/bintrail/baseline.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"context"
 	"fmt"
-	"io/fs"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -15,7 +13,6 @@ import (
 
 	"github.com/dbtrail/dbtrail/internal/baseline"
 	"github.com/dbtrail/dbtrail/internal/cliutil"
-	"github.com/dbtrail/dbtrail/internal/storage"
 )
 
 var baselineCmd = &cobra.Command{
@@ -128,7 +125,7 @@ func runBaseline(cmd *cobra.Command, args []string) error {
 	var uploaded int
 	if bslUpload != "" {
 		var err error
-		uploaded, err = uploadBaselineToS3(cmd.Context(), bslOutput, bslUpload, bslUploadRegion, bslRetry)
+		uploaded, err = baseline.Upload(cmd.Context(), bslOutput, bslUpload, bslUploadRegion, bslRetry)
 		if err != nil {
 			return fmt.Errorf("S3 upload: %w", err)
 		}
@@ -162,172 +159,6 @@ func runBaseline(cmd *cobra.Command, args []string) error {
 	fmt.Printf("  rows      : %d\n", stats.RowsWritten)
 	fmt.Printf("  files     : %d\n", stats.FilesWritten)
 	return nil
-}
-
-// uploadBaselineToS3 walks outputDir and uploads every file to the S3 URL,
-// preserving the relative directory structure under the prefix. region is
-// optional — if empty, the AWS SDK resolves it from AWS_REGION env var or
-// ~/.aws/config. When retry is true, files that already exist in S3 are
-// skipped (checked via HeadObject). Returns the number of files uploaded.
-//
-// The upload mirrors the local Run marker contract (#467) so a mid-upload death
-// leaves a snapshot that S3 discovery treats as INCOMPLETE, not complete:
-//
-//  1. _INCOMPLETE FIRST, per snapshot dir (a zero-byte object — the local
-//     _INCOMPLETE marker was already removed once Run succeeded, so there is no
-//     local file to walk).
-//  2. every data file.
-//  3. _SUCCESS LAST. "_SUCCESS" can sort before sibling schema dirs depending
-//     on the database name's first byte ('_' is 0x5F — before lowercase letters
-//     but after digits and uppercase), so a single-pass lexical WalkDir could
-//     publish it before all data is up. We defer it UNCONDITIONALLY, which keeps
-//     the S3 snapshot un-marked-complete until its data is fully present.
-//  4. best-effort _INCOMPLETE delete. s3IncompleteSnapshots only flags a
-//     snapshot incomplete when _INCOMPLETE is present AND _SUCCESS is absent, so
-//     a leftover _INCOMPLETE next to a published _SUCCESS is harmless — a failed
-//     delete never demotes a completed snapshot. (No S3 DeleteObject of partial
-//     data is attempted; resume via --retry overwrites in place.)
-func uploadBaselineToS3(ctx context.Context, outputDir, s3URL, region string, retry bool) (int, error) {
-	bucket, prefix, err := storage.ParseS3URL(s3URL)
-	if err != nil {
-		return 0, fmt.Errorf("invalid --upload URL: %w", err)
-	}
-
-	client, err := storage.NewS3Client(ctx, region)
-	if err != nil {
-		return 0, err
-	}
-
-	// Route the four S3 operations through an injectable seam so the ordering
-	// invariant can be unit-tested with a recording mock (#524 review).
-	ops := s3ops{
-		putEmpty:     func(ctx context.Context, key string) error { return storage.PutEmptyObject(ctx, client, bucket, key) },
-		uploadFile:   func(ctx context.Context, path, key string) error { return storage.UploadFile(ctx, client, path, bucket, key) },
-		objectExists: func(ctx context.Context, key string) (bool, error) { return storage.S3ObjectExists(ctx, client, bucket, key) },
-		deleteObject: func(ctx context.Context, key string) error { return storage.DeleteObject(ctx, client, bucket, key) },
-	}
-	return runBaselineUpload(ctx, outputDir, prefix, retry, ops)
-}
-
-// s3ops abstracts the four S3 operations the baseline upload performs, so the
-// crash-safe ordering invariant (_INCOMPLETE first → data files → _SUCCESS last
-// → best-effort _INCOMPLETE delete) can be pinned by a recording mock without a
-// live client (#524 review).
-type s3ops struct {
-	putEmpty     func(ctx context.Context, key string) error
-	uploadFile   func(ctx context.Context, path, key string) error
-	objectExists func(ctx context.Context, key string) (bool, error)
-	deleteObject func(ctx context.Context, key string) error
-}
-
-// runBaselineUpload performs the crash-safe upload ordering against ops. See the
-// uploadBaselineToS3 doc for the four-step contract it guarantees.
-func runBaselineUpload(ctx context.Context, outputDir, prefix string, retry bool, ops s3ops) (int, error) {
-	upload := func(path string) error {
-		key, err := storage.BuildS3Key(outputDir, path, prefix)
-		if err != nil {
-			return err
-		}
-		if retry {
-			exists, err := ops.objectExists(ctx, key)
-			if err != nil {
-				return err
-			}
-			if exists {
-				slog.Info("skipping existing S3 object (--retry)", "key", key)
-				return nil
-			}
-		}
-		if err := ops.uploadFile(ctx, path, key); err != nil {
-			return err
-		}
-		slog.Debug("uploaded", "file", path, "key", key)
-		return nil
-	}
-
-	// Snapshot dirs to upload, identified by a local _SUCCESS marker — only
-	// completed snapshots reach here post-Run. Each one's _INCOMPLETE marker is
-	// keyed off the snapshot dir, NOT off a walked file (Run already removed it).
-	snapDirs, err := snapshotDirsWithSuccess(outputDir)
-	if err != nil {
-		return 0, err
-	}
-	incompleteKey := func(snapDir string) (string, error) {
-		return storage.BuildS3Key(outputDir, filepath.Join(snapDir, baseline.IncompleteMarker), prefix)
-	}
-
-	// 1. Publish _INCOMPLETE FIRST so an interrupted upload reads as incomplete.
-	for _, snapDir := range snapDirs {
-		key, err := incompleteKey(snapDir)
-		if err != nil {
-			return 0, err
-		}
-		if err := ops.putEmpty(ctx, key); err != nil {
-			return 0, err
-		}
-	}
-
-	// 2 & 3. Upload data files; defer the _SUCCESS marker(s) to the very end.
-	var count int
-	var successMarkers []string
-	err = filepath.WalkDir(outputDir, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil || d.IsDir() {
-			return walkErr
-		}
-		if d.Name() == baseline.SuccessMarker {
-			successMarkers = append(successMarkers, path) // defer to the end
-			return nil
-		}
-		if err := upload(path); err != nil {
-			return err
-		}
-		count++
-		return nil
-	})
-	if err != nil {
-		return count, err
-	}
-	for _, path := range successMarkers {
-		if err := upload(path); err != nil {
-			return count, err
-		}
-		count++
-	}
-
-	// 4. Best-effort _INCOMPLETE cleanup — harmless to leave (see the func doc).
-	for _, snapDir := range snapDirs {
-		key, err := incompleteKey(snapDir)
-		if err != nil {
-			slog.Warn("could not build _INCOMPLETE marker key for cleanup", "snapshot", snapDir, "error", err)
-			continue
-		}
-		if err := ops.deleteObject(ctx, key); err != nil {
-			slog.Warn("could not remove S3 _INCOMPLETE marker after upload (harmless; _SUCCESS decides completeness)",
-				"key", key, "error", err)
-		}
-	}
-	return count, nil
-}
-
-// snapshotDirsWithSuccess returns the immediate child snapshot directories of
-// outputDir that carry a local _SUCCESS marker (i.e. completed snapshots). The
-// baseline layout is <output>/<timestamp>/..., so only one level is scanned.
-func snapshotDirsWithSuccess(outputDir string) ([]string, error) {
-	entries, err := os.ReadDir(outputDir)
-	if err != nil {
-		return nil, fmt.Errorf("read output directory %q: %w", outputDir, err)
-	}
-	var dirs []string
-	for _, e := range entries {
-		if !e.IsDir() {
-			continue
-		}
-		snapDir := filepath.Join(outputDir, e.Name())
-		if _, err := os.Stat(filepath.Join(snapDir, baseline.SuccessMarker)); err == nil {
-			dirs = append(dirs, snapDir)
-		}
-	}
-	return dirs, nil
 }
 
 // decryptDumpFiles walks inputDir and decrypts every .enc file using openssl,

--- a/cmd/bintrail/baseline_test.go
+++ b/cmd/bintrail/baseline_test.go
@@ -7,8 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/dbtrail/dbtrail/internal/baseline"
 )
 
 // ─── cobra command wiring ─────────────────────────────────────────────────────
@@ -344,65 +342,6 @@ func TestDecryptDumpFiles_roundTrip(t *testing.T) {
 	cleanup()
 	if _, err := os.Stat(plainFile); !os.IsNotExist(err) {
 		t.Error("cleanup should have removed the decrypted file")
-	}
-}
-
-// ─── S3 upload marker symmetry (#467 / #524) ──────────────────────────────────
-
-// TestSnapshotDirsWithSuccess verifies the helper that drives the S3 upload's
-// _INCOMPLETE-first ordering: it returns exactly the immediate child snapshot
-// directories carrying a local _SUCCESS marker (completed snapshots), ignoring
-// loose files, marker-less dirs, and nested dirs.
-func TestSnapshotDirsWithSuccess(t *testing.T) {
-	out := t.TempDir()
-
-	mkSnap := func(name string, success bool) {
-		t.Helper()
-		dir := filepath.Join(out, name, "shop")
-		if err := os.MkdirAll(dir, 0o755); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(filepath.Join(dir, "orders.parquet"), nil, 0o644); err != nil {
-			t.Fatal(err)
-		}
-		if success {
-			if err := os.WriteFile(filepath.Join(out, name, baseline.SuccessMarker), nil, 0o644); err != nil {
-				t.Fatal(err)
-			}
-		}
-	}
-	mkSnap("2026-01-01T00-00-00Z", true)  // complete → included
-	mkSnap("2026-02-01T00-00-00Z", true)  // complete → included
-	mkSnap("2026-03-01T00-00-00Z", false) // no _SUCCESS → excluded
-	// A loose file at the top level must not be mistaken for a snapshot dir.
-	if err := os.WriteFile(filepath.Join(out, "stray.txt"), nil, 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	got, err := snapshotDirsWithSuccess(out)
-	if err != nil {
-		t.Fatalf("snapshotDirsWithSuccess: %v", err)
-	}
-	want := map[string]bool{
-		filepath.Join(out, "2026-01-01T00-00-00Z"): true,
-		filepath.Join(out, "2026-02-01T00-00-00Z"): true,
-	}
-	if len(got) != len(want) {
-		t.Fatalf("got %v, want the two _SUCCESS-marked snapshots %v", got, want)
-	}
-	for _, d := range got {
-		if !want[d] {
-			t.Errorf("unexpected snapshot dir %q (only _SUCCESS-marked dirs should be returned)", d)
-		}
-	}
-}
-
-// TestSnapshotDirsWithSuccess_missingDir verifies the helper surfaces a read
-// error rather than silently returning an empty list (which would skip the
-// _INCOMPLETE-first publish entirely).
-func TestSnapshotDirsWithSuccess_missingDir(t *testing.T) {
-	if _, err := snapshotDirsWithSuccess("/nonexistent/path-does-not-exist"); err == nil {
-		t.Fatal("expected error for nonexistent output directory, got nil")
 	}
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -200,6 +200,14 @@ services:
       # Left empty by default: the gate is config-based, so setting it with no
       # snapshots would show a Time-travel tab with nothing behind it.
       BINTRAIL_CONSOLE_BASELINE_DIR: ${BASELINE_DIR:-}
+      # Opt-in "Create baseline" button (#613): set BASELINE_TRIGGER=1 in .env to
+      # let the console create baseline snapshots in-process (dump→convert→upload)
+      # for a monitored server. The console image bundles mydumper and runs it as
+      # a LOCAL subprocess — NO docker socket is mounted (the console never gets
+      # host-root). A server needs a source DSN AND a baseline dir/S3 configured.
+      # Off by default. Staging for S3-destined baselines lives on the state volume.
+      BINTRAIL_CONSOLE_BASELINE_TRIGGER: ${BASELINE_TRIGGER:-}
+      BINTRAIL_CONSOLE_BASELINE_STAGING: /var/lib/bintrail/baseline-staging
       # Password login (persists next to the registry). On first run the
       # console serves a "create your password" screen; later visits sign in.
       # There is deliberately NO password env var: docker inspect must never

--- a/docs/console.md
+++ b/docs/console.md
@@ -279,7 +279,35 @@ across the rotation dialog and the per-server edit form):
   baseline source (`baseline_dir` / `baseline_s3`): each snapshot's timestamp,
   age, table count, and (local sources) the binlog coordinates its deltas
   start from. The empty states explain how to produce a first baseline
-  (`bintrail dump` → `bintrail baseline`).
+  (`bintrail dump` → `bintrail baseline`). When the **Create baseline** button
+  is enabled (see below) it sits in this panel's header.
+
+#### Creating a baseline from the console (opt-in)
+
+By default the console only *lists* baselines — you produce them with the
+`bintrail dump` → `bintrail baseline` CLI (or the compose `baseline` profile).
+A **Create baseline** button can run that pipeline for a monitored server
+straight from the Storage page, but it is **opt-in** and only on the `watch`
+daemon:
+
+- Start `watch` with `BINTRAIL_CONSOLE_BASELINE_TRIGGER=1` (compose: set
+  `BASELINE_TRIGGER=1` in `.env`).
+- The server must have **both** a source DSN and a baseline destination
+  (`baseline_dir` or `baseline_s3`) configured; the button 400s otherwise.
+- Clicking it runs **dump → convert → upload entirely in-process**: the console
+  image bundles `mydumper` and runs it as a **local subprocess** — it never
+  mounts the docker socket, so a console compromise can never escalate to
+  host-root. The source DSN stays inside the process (never written to disk or
+  any HTTP response). One baseline at a time per server (409 while one runs).
+- For an `s3://` destination the dump is staged under
+  `BINTRAIL_CONSOLE_BASELINE_STAGING` (default a temp dir), uploaded, then
+  discarded; for a local `baseline_dir` it is written there. Region and
+  credentials come from the daemon's ambient AWS chain, like every other S3
+  access. When it finishes the new snapshot appears in the listing.
+
+The button is hidden on the read-only `serve` console and whenever the opt-in
+is off — the CLI/compose recipe in the empty state remains the always-available
+path.
 - **AWS credentials** — which ambient credential signals the daemon process
   can see: env keys (presence only, never values), `AWS_PROFILE`,
   `AWS_REGION`, a shared `~/.aws` config, ECS task-role / EKS IRSA markers.
@@ -325,6 +353,11 @@ across the rotation dialog and the per-server edit form):
 - `BINTRAIL_CONSOLE_ARCHIVE_STAGING` (`watch` only) — local staging dir for the
   Archive-to-S3 feature, same as `--archive-staging-dir`. AWS credentials for
   the upload come from the ambient chain (`AWS_*` / `~/.aws` / role).
+- `BINTRAIL_CONSOLE_BASELINE_TRIGGER` (`watch` only) — `1`/`true` enables the
+  opt-in **Create baseline** button (runs `mydumper` → convert → upload
+  in-process; see [The Storage page](#the-storage-page)). Off by default.
+- `BINTRAIL_CONSOLE_BASELINE_STAGING` (`watch` only) — local staging dir for
+  S3-destined baselines created by that button (default a temp subdir).
 
 There is deliberately **no** environment variable for the password itself —
 env vars leak through `docker inspect`, `ps e`, and `/proc`; the password is

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.2
 	github.com/aws/aws-sdk-go-v2/config v1.32.10
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.20.33
+	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.18
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.56.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.96.2
 	github.com/aws/smithy-go v1.24.1
@@ -33,7 +34,6 @@ require (
 	github.com/apache/arrow-go/v18 v18.5.1 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.5 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.10 // indirect
-	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.18 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.18 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.18 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 // indirect

--- a/internal/baseline/upload.go
+++ b/internal/baseline/upload.go
@@ -1,0 +1,184 @@
+package baseline
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/dbtrail/dbtrail/internal/storage"
+)
+
+// Upload walks outputDir and uploads every file to the S3 URL, preserving the
+// relative directory structure under the prefix. region is optional — if empty,
+// the AWS SDK resolves it from AWS_REGION or ~/.aws/config. When retry is true,
+// files that already exist in S3 are skipped (checked via HeadObject). Returns
+// the number of files uploaded.
+//
+// The upload mirrors the local Run marker contract (#467) so a mid-upload death
+// leaves a snapshot that S3 discovery treats as INCOMPLETE, not complete:
+//
+//  1. _INCOMPLETE FIRST, per snapshot dir (a zero-byte object — the local
+//     _INCOMPLETE marker was already removed once Run succeeded, so there is no
+//     local file to walk).
+//  2. every data file.
+//  3. _SUCCESS LAST. "_SUCCESS" can sort before sibling schema dirs depending
+//     on the database name's first byte ('_' is 0x5F — before lowercase letters
+//     but after digits and uppercase), so a single-pass lexical WalkDir could
+//     publish it before all data is up. We defer it UNCONDITIONALLY, which keeps
+//     the S3 snapshot un-marked-complete until its data is fully present.
+//  4. best-effort _INCOMPLETE delete. s3IncompleteSnapshots only flags a
+//     snapshot incomplete when _INCOMPLETE is present AND _SUCCESS is absent, so
+//     a leftover _INCOMPLETE next to a published _SUCCESS is harmless — a failed
+//     delete never demotes a completed snapshot.
+//
+// Extracted from cmd/bintrail (#613) so the bintrail-console daemon can run the
+// dump→convert→upload pipeline in-process, without a docker socket.
+func Upload(ctx context.Context, outputDir, s3URL, region string, retry bool) (int, error) {
+	bucket, prefix, err := storage.ParseS3URL(s3URL)
+	if err != nil {
+		return 0, fmt.Errorf("invalid upload URL: %w", err)
+	}
+
+	client, err := storage.NewS3Client(ctx, region)
+	if err != nil {
+		return 0, err
+	}
+
+	// Route the four S3 operations through an injectable seam so the ordering
+	// invariant can be unit-tested with a recording mock (#524 review).
+	ops := s3UploadOps{
+		putEmpty: func(ctx context.Context, key string) error { return storage.PutEmptyObject(ctx, client, bucket, key) },
+		uploadFile: func(ctx context.Context, path, key string) error {
+			return storage.UploadFile(ctx, client, path, bucket, key)
+		},
+		objectExists: func(ctx context.Context, key string) (bool, error) {
+			return storage.S3ObjectExists(ctx, client, bucket, key)
+		},
+		deleteObject: func(ctx context.Context, key string) error { return storage.DeleteObject(ctx, client, bucket, key) },
+	}
+	return uploadWithOps(ctx, outputDir, prefix, retry, ops)
+}
+
+// s3UploadOps abstracts the four S3 operations the baseline upload performs, so
+// the crash-safe ordering invariant (_INCOMPLETE first → data files → _SUCCESS
+// last → best-effort _INCOMPLETE delete) can be pinned by a recording mock
+// without a live client (#524 review).
+type s3UploadOps struct {
+	putEmpty     func(ctx context.Context, key string) error
+	uploadFile   func(ctx context.Context, path, key string) error
+	objectExists func(ctx context.Context, key string) (bool, error)
+	deleteObject func(ctx context.Context, key string) error
+}
+
+// uploadWithOps performs the crash-safe upload ordering against ops. See the
+// Upload doc for the four-step contract it guarantees.
+func uploadWithOps(ctx context.Context, outputDir, prefix string, retry bool, ops s3UploadOps) (int, error) {
+	upload := func(path string) error {
+		key, err := storage.BuildS3Key(outputDir, path, prefix)
+		if err != nil {
+			return err
+		}
+		if retry {
+			exists, err := ops.objectExists(ctx, key)
+			if err != nil {
+				return err
+			}
+			if exists {
+				slog.Info("skipping existing S3 object (--retry)", "key", key)
+				return nil
+			}
+		}
+		if err := ops.uploadFile(ctx, path, key); err != nil {
+			return err
+		}
+		slog.Debug("uploaded", "file", path, "key", key)
+		return nil
+	}
+
+	// Snapshot dirs to upload, identified by a local _SUCCESS marker — only
+	// completed snapshots reach here post-Run. Each one's _INCOMPLETE marker is
+	// keyed off the snapshot dir, NOT off a walked file (Run already removed it).
+	snapDirs, err := snapshotDirsWithSuccess(outputDir)
+	if err != nil {
+		return 0, err
+	}
+	incompleteKey := func(snapDir string) (string, error) {
+		return storage.BuildS3Key(outputDir, filepath.Join(snapDir, IncompleteMarker), prefix)
+	}
+
+	// 1. Publish _INCOMPLETE FIRST so an interrupted upload reads as incomplete.
+	for _, snapDir := range snapDirs {
+		key, err := incompleteKey(snapDir)
+		if err != nil {
+			return 0, err
+		}
+		if err := ops.putEmpty(ctx, key); err != nil {
+			return 0, err
+		}
+	}
+
+	// 2 & 3. Upload data files; defer the _SUCCESS marker(s) to the very end.
+	var count int
+	var successMarkers []string
+	err = filepath.WalkDir(outputDir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil || d.IsDir() {
+			return walkErr
+		}
+		if d.Name() == SuccessMarker {
+			successMarkers = append(successMarkers, path) // defer to the end
+			return nil
+		}
+		if err := upload(path); err != nil {
+			return err
+		}
+		count++
+		return nil
+	})
+	if err != nil {
+		return count, err
+	}
+	for _, path := range successMarkers {
+		if err := upload(path); err != nil {
+			return count, err
+		}
+		count++
+	}
+
+	// 4. Best-effort _INCOMPLETE cleanup — harmless to leave (see the func doc).
+	for _, snapDir := range snapDirs {
+		key, err := incompleteKey(snapDir)
+		if err != nil {
+			slog.Warn("could not build _INCOMPLETE marker key for cleanup", "snapshot", snapDir, "error", err)
+			continue
+		}
+		if err := ops.deleteObject(ctx, key); err != nil {
+			slog.Warn("could not remove S3 _INCOMPLETE marker after upload (harmless; _SUCCESS decides completeness)",
+				"key", key, "error", err)
+		}
+	}
+	return count, nil
+}
+
+// snapshotDirsWithSuccess returns the immediate child snapshot directories of
+// outputDir that carry a local _SUCCESS marker (i.e. completed snapshots). The
+// baseline layout is <output>/<timestamp>/..., so only one level is scanned.
+func snapshotDirsWithSuccess(outputDir string) ([]string, error) {
+	entries, err := os.ReadDir(outputDir)
+	if err != nil {
+		return nil, fmt.Errorf("read output directory %q: %w", outputDir, err)
+	}
+	var dirs []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		snapDir := filepath.Join(outputDir, e.Name())
+		if _, err := os.Stat(filepath.Join(snapDir, SuccessMarker)); err == nil {
+			dirs = append(dirs, snapDir)
+		}
+	}
+	return dirs, nil
+}

--- a/internal/baseline/upload_test.go
+++ b/internal/baseline/upload_test.go
@@ -1,4 +1,4 @@
-package main
+package baseline
 
 import (
 	"context"
@@ -6,16 +6,14 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/dbtrail/dbtrail/internal/baseline"
 )
 
-// TestRunBaselineUpload_ordering pins the crash-safe S3 upload ordering (#524
+// TestUploadWithOps_ordering pins the crash-safe S3 upload ordering (#524
 // review): _INCOMPLETE is published before any data, _SUCCESS only after all
-// data, and _INCOMPLETE is deleted last. The s3ops seam records the call order
-// without a live client, so a future refactor that reorders the steps (the
+// data, and _INCOMPLETE is deleted last. The s3UploadOps seam records the call
+// order without a live client, so a future refactor that reorders the steps (the
 // original #467-on-upload bug) fails this test instead of silently shipping.
-func TestRunBaselineUpload_ordering(t *testing.T) {
+func TestUploadWithOps_ordering(t *testing.T) {
 	outputDir := t.TempDir()
 	snap := filepath.Join(outputDir, "2025-01-01T00-00-00Z")
 	if err := os.MkdirAll(filepath.Join(snap, "shop"), 0o755); err != nil {
@@ -26,7 +24,7 @@ func TestRunBaselineUpload_ordering(t *testing.T) {
 	for _, f := range []string{
 		filepath.Join(snap, "shop", "orders.parquet"),
 		filepath.Join(snap, "shop", "customers.parquet"),
-		filepath.Join(snap, baseline.SuccessMarker),
+		filepath.Join(snap, SuccessMarker),
 	} {
 		if err := os.WriteFile(f, []byte("x"), 0o644); err != nil {
 			t.Fatal(err)
@@ -34,16 +32,16 @@ func TestRunBaselineUpload_ordering(t *testing.T) {
 	}
 
 	var calls []string
-	ops := s3ops{
+	ops := s3UploadOps{
 		putEmpty:     func(_ context.Context, k string) error { calls = append(calls, "put "+k); return nil },
 		uploadFile:   func(_ context.Context, _, k string) error { calls = append(calls, "upload "+k); return nil },
 		objectExists: func(_ context.Context, _ string) (bool, error) { return false, nil },
 		deleteObject: func(_ context.Context, k string) error { calls = append(calls, "delete "+k); return nil },
 	}
 
-	n, err := runBaselineUpload(context.Background(), outputDir, "p", false, ops)
+	n, err := uploadWithOps(context.Background(), outputDir, "p", false, ops)
 	if err != nil {
-		t.Fatalf("runBaselineUpload: %v", err)
+		t.Fatalf("uploadWithOps: %v", err)
 	}
 	if n != 3 { // 2 data files + 1 _SUCCESS
 		t.Fatalf("uploaded %d objects, want 3", n)
@@ -67,16 +65,16 @@ func TestRunBaselineUpload_ordering(t *testing.T) {
 		return idx
 	}
 	isPutIncomplete := func(c string) bool {
-		return strings.HasPrefix(c, "put ") && strings.Contains(c, baseline.IncompleteMarker)
+		return strings.HasPrefix(c, "put ") && strings.Contains(c, IncompleteMarker)
 	}
 	isUploadSuccess := func(c string) bool {
-		return strings.HasPrefix(c, "upload ") && strings.Contains(c, baseline.SuccessMarker)
+		return strings.HasPrefix(c, "upload ") && strings.Contains(c, SuccessMarker)
 	}
 	isData := func(c string) bool {
-		return strings.HasPrefix(c, "upload ") && !strings.Contains(c, baseline.SuccessMarker)
+		return strings.HasPrefix(c, "upload ") && !strings.Contains(c, SuccessMarker)
 	}
 	isDelIncomplete := func(c string) bool {
-		return strings.HasPrefix(c, "delete ") && strings.Contains(c, baseline.IncompleteMarker)
+		return strings.HasPrefix(c, "delete ") && strings.Contains(c, IncompleteMarker)
 	}
 
 	putInc := first(isPutIncomplete)
@@ -99,9 +97,9 @@ func TestRunBaselineUpload_ordering(t *testing.T) {
 	}
 }
 
-// TestRunBaselineUpload_retrySkipsExisting: under --retry, a data object already
+// TestUploadWithOps_retrySkipsExisting: under --retry, a data object already
 // present in S3 is not re-uploaded.
-func TestRunBaselineUpload_retrySkipsExisting(t *testing.T) {
+func TestUploadWithOps_retrySkipsExisting(t *testing.T) {
 	outputDir := t.TempDir()
 	snap := filepath.Join(outputDir, "2025-01-01T00-00-00Z")
 	if err := os.MkdirAll(filepath.Join(snap, "shop"), 0o755); err != nil {
@@ -109,7 +107,7 @@ func TestRunBaselineUpload_retrySkipsExisting(t *testing.T) {
 	}
 	for _, f := range []string{
 		filepath.Join(snap, "shop", "orders.parquet"),
-		filepath.Join(snap, baseline.SuccessMarker),
+		filepath.Join(snap, SuccessMarker),
 	} {
 		if err := os.WriteFile(f, []byte("x"), 0o644); err != nil {
 			t.Fatal(err)
@@ -117,7 +115,7 @@ func TestRunBaselineUpload_retrySkipsExisting(t *testing.T) {
 	}
 
 	var uploaded []string
-	ops := s3ops{
+	ops := s3UploadOps{
 		putEmpty:     func(_ context.Context, _ string) error { return nil },
 		uploadFile:   func(_ context.Context, _, k string) error { uploaded = append(uploaded, k); return nil },
 		objectExists: func(_ context.Context, _ string) (bool, error) { return true, nil }, // everything already present
@@ -126,10 +124,67 @@ func TestRunBaselineUpload_retrySkipsExisting(t *testing.T) {
 
 	// count is "objects processed" (incremented even when skipped); the
 	// load-bearing assertion is that uploadFile was never actually invoked.
-	if _, err := runBaselineUpload(context.Background(), outputDir, "p", true, ops); err != nil {
-		t.Fatalf("runBaselineUpload: %v", err)
+	if _, err := uploadWithOps(context.Background(), outputDir, "p", true, ops); err != nil {
+		t.Fatalf("uploadWithOps: %v", err)
 	}
 	if len(uploaded) != 0 {
 		t.Fatalf("--retry re-uploaded existing objects %v; want none", uploaded)
+	}
+}
+
+// TestSnapshotDirsWithSuccess verifies the helper that drives the S3 upload's
+// _INCOMPLETE-first ordering: it returns exactly the immediate child snapshot
+// directories carrying a local _SUCCESS marker (completed snapshots), ignoring
+// loose files, marker-less dirs, and nested dirs.
+func TestSnapshotDirsWithSuccess(t *testing.T) {
+	out := t.TempDir()
+
+	mkSnap := func(name string, success bool) {
+		t.Helper()
+		dir := filepath.Join(out, name, "shop")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "orders.parquet"), nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if success {
+			if err := os.WriteFile(filepath.Join(out, name, SuccessMarker), nil, 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	mkSnap("2026-01-01T00-00-00Z", true)  // complete → included
+	mkSnap("2026-02-01T00-00-00Z", true)  // complete → included
+	mkSnap("2026-03-01T00-00-00Z", false) // no _SUCCESS → excluded
+	// A loose file at the top level must not be mistaken for a snapshot dir.
+	if err := os.WriteFile(filepath.Join(out, "stray.txt"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := snapshotDirsWithSuccess(out)
+	if err != nil {
+		t.Fatalf("snapshotDirsWithSuccess: %v", err)
+	}
+	want := map[string]bool{
+		filepath.Join(out, "2026-01-01T00-00-00Z"): true,
+		filepath.Join(out, "2026-02-01T00-00-00Z"): true,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want the two _SUCCESS-marked snapshots %v", got, want)
+	}
+	for _, d := range got {
+		if !want[d] {
+			t.Errorf("unexpected snapshot dir %q (only _SUCCESS-marked dirs should be returned)", d)
+		}
+	}
+}
+
+// TestSnapshotDirsWithSuccess_missingDir verifies the helper surfaces a read
+// error rather than silently returning an empty list (which would skip the
+// _INCOMPLETE-first publish entirely).
+func TestSnapshotDirsWithSuccess_missingDir(t *testing.T) {
+	if _, err := snapshotDirsWithSuccess("/nonexistent/path-does-not-exist"); err == nil {
+		t.Fatal("expected error for nonexistent output directory, got nil")
 	}
 }

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -1737,8 +1737,17 @@ function baselinesPanel(b, servers) {
   const cur = (servers || []).find((s) => s.id === (currentServer || defaultServerId));
   let owner = cur ? serverLabel(cur) : "";
   if (!owner && b && !b.error && b.configured) owner = "daemon (--baseline-dir / --baseline-s3)";
-  panel.append(el("div", { class: "ov-panel-head" },
-    el("h2", { class: "ov-panel-title", text: "Baseline snapshots" + (owner ? " — " + owner : "") })));
+  const head = el("div", { class: "ov-panel-head" },
+    el("h2", { class: "ov-panel-title", text: "Baseline snapshots" + (owner ? " — " + owner : "") }));
+  // Create-baseline action: only when the daemon opted in (capsCache.baseline_trigger),
+  // a real server is selected, and it has a baseline destination configured (else the
+  // endpoint 400s). The endpoint still re-validates the source DSN server-side.
+  if (capsCache.baseline_trigger && cur && cur.id && b && !b.error && b.configured) {
+    const btn = el("button", { class: "btn btn-sm", type: "button", text: "Create baseline" });
+    btn.onclick = () => createBaseline(cur.id, btn);
+    head.append(btn);
+  }
+  panel.append(head);
   const list = el("div", { class: "stg-list" });
   if (!b || b.error) {
     list.append(el("div", { class: "ev-empty", text: "Could not list baselines: " + ((b && b.error) || "unavailable") }));
@@ -1767,6 +1776,51 @@ function baselinesPanel(b, servers) {
   }
   panel.append(list);
   return panel;
+}
+
+// createBaseline triggers an in-process baseline (dump→convert→upload) on the
+// daemon for the selected server, then polls until it finishes and refreshes the
+// Storage view so the new snapshot appears. The button is disabled while in flight.
+async function createBaseline(id, btn) {
+  if (btn) { btn.disabled = true; btn.textContent = "Creating…"; }
+  const restore = () => { if (btn) { btn.disabled = false; btn.textContent = "Create baseline"; } };
+  try {
+    await api("/api/servers/" + encodeURIComponent(id) + "/baseline", { method: "POST", body: {} });
+  } catch (err) {
+    toast("Baseline failed: " + ((err && err.message) || err));
+    restore();
+    return;
+  }
+  toast("Baseline started — dumping the source and uploading…");
+  const done = await pollBaseline(id);
+  restore();
+  if (done && done.state === "succeeded") {
+    toast("Baseline complete: " + (done.tables || 0) + " table(s)" +
+      (done.uploaded ? ", " + done.uploaded + " file(s) uploaded" : ""));
+  } else if (done) {
+    toast("Baseline failed: " + (done.last_error || "unknown error"));
+  } else {
+    toast("Baseline still running — check back shortly.");
+  }
+  if (location.pathname === "/storage") renderStorage();
+}
+
+// pollBaseline polls the per-server baseline status until it leaves "running"
+// (or a ~20-minute cap). Returns the terminal status, or null if it never
+// settled within the cap. Transient poll errors are ignored and retried.
+async function pollBaseline(id) {
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+  for (let i = 0; i < 600; i++) {
+    await sleep(2000);
+    let st;
+    try {
+      st = (await api("/api/servers/" + encodeURIComponent(id) + "/baseline")).baseline;
+    } catch (_) {
+      continue; // a blip mid-dump shouldn't abort the wait
+    }
+    if (st && st.state !== "running") return st;
+  }
+  return null;
 }
 
 // ── schemas / tables cascade ──────────────────────────────────────────────────

--- a/internal/console/baseline_trigger.go
+++ b/internal/console/baseline_trigger.go
@@ -1,0 +1,130 @@
+package console
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+)
+
+// ErrBaselineRunning is returned by BaselineController.Trigger when a baseline
+// for that server is already in flight (one at a time per server). The handler
+// maps it to 409 Conflict.
+var ErrBaselineRunning = errors.New("a baseline is already running for this server")
+
+// BaselineController runs a baseline snapshot for a monitored server entirely
+// in-process — dump → convert → upload — so the console never shells a sibling
+// container and never mounts the docker socket (#613). It is wired in ONLY by
+// `bintrail-console watch` when the operator opts in
+// (BINTRAIL_CONSOLE_BASELINE_TRIGGER=1); nil on the standalone read-only
+// console, where the endpoint refuses with 403 — mirroring how MonitorController
+// gates the monitor verbs.
+type BaselineController interface {
+	// Trigger starts a baseline in the background and returns immediately.
+	// Returns ErrBaselineRunning if one is already running for req.ServerID.
+	Trigger(req BaselineRequest) error
+	// Status reports the latest known state for a server (idle if never run in
+	// this process — the durable record is the snapshot itself, listed by
+	// /api/baselines).
+	Status(serverID string) BaselineStatus
+}
+
+// BaselineRequest is the in-process job description the endpoint hands the
+// controller. The source DSN (a secret) stays inside the process — it is never
+// written to disk or serialized to any HTTP response.
+type BaselineRequest struct {
+	ServerID   string
+	ServerName string
+	SourceDSN  string
+	Schemas    []string
+	// LocalDir is the per-server baseline directory (entry.BaselineDir). When
+	// set, the snapshot is written there persistently and NOT uploaded. Empty
+	// means S3-only: stage in a temp dir, upload to S3, discard the staging.
+	LocalDir string
+	// S3 is the per-server baseline S3 prefix (entry.BaselineS3, s3://…). When
+	// set, the staged snapshot is uploaded there. Region/credentials come from
+	// the ambient AWS chain (env / ~/.aws / IAM role), like the rest of the
+	// console's S3 access.
+	S3 string
+}
+
+// BaselineStatus is the pollable state of a server's most recent baseline job.
+type BaselineStatus struct {
+	State      string `json:"state"` // idle | running | succeeded | failed
+	Since      string `json:"since,omitempty"`
+	FinishedAt string `json:"finished_at,omitempty"`
+	LastError  string `json:"last_error,omitempty"`
+	Tables     int    `json:"tables,omitempty"`
+	Rows       int64  `json:"rows,omitempty"`
+	Uploaded   int    `json:"uploaded,omitempty"`
+}
+
+// handleBaselineTrigger enqueues an in-process baseline for the selected server.
+// Gating, in order: the feature must be enabled (control-plane + opt-in), the
+// entry must be a real registry server with a source configured AND a baseline
+// destination (dir or S3) — without a destination there is nowhere for the
+// snapshot to live, so Time-travel would never see it.
+func (s *Server) handleBaselineTrigger(w http.ResponseWriter, r *http.Request) {
+	if s.baselineCtrl == nil {
+		writeJSONError(w, http.StatusForbidden,
+			"baseline creation from the console is not enabled; start the watch daemon with BINTRAIL_CONSOLE_BASELINE_TRIGGER=1")
+		return
+	}
+	e, ok := s.requireMonitorEntry(w, r.PathValue("id"))
+	if !ok {
+		return
+	}
+	if e.SourceDSN == "" {
+		writeJSONError(w, http.StatusBadRequest, "this server has no source configured; set the source connection first")
+		return
+	}
+	if e.BaselineDir == "" && e.BaselineS3 == "" {
+		writeJSONError(w, http.StatusBadRequest,
+			"this server has no baseline destination configured; set a baseline directory or S3 prefix first (Edit → Advanced)")
+		return
+	}
+
+	req := BaselineRequest{
+		ServerID:   e.ID,
+		ServerName: e.Name,
+		SourceDSN:  e.SourceDSN,
+		Schemas:    splitSchemas(e.Schemas),
+		LocalDir:   e.BaselineDir,
+		S3:         e.BaselineS3,
+	}
+	if err := s.baselineCtrl.Trigger(req); err != nil {
+		if errors.Is(err, ErrBaselineRunning) {
+			writeJSONError(w, http.StatusConflict, err.Error())
+			return
+		}
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusAccepted, map[string]any{"baseline": s.baselineCtrl.Status(e.ID)})
+}
+
+// handleBaselineStatus reports the latest baseline job state for the selected
+// server (for the frontend to poll while a run is in flight).
+func (s *Server) handleBaselineStatus(w http.ResponseWriter, r *http.Request) {
+	if s.baselineCtrl == nil {
+		writeJSONError(w, http.StatusForbidden,
+			"baseline creation from the console is not enabled; start the watch daemon with BINTRAIL_CONSOLE_BASELINE_TRIGGER=1")
+		return
+	}
+	e, ok := s.requireMonitorEntry(w, r.PathValue("id"))
+	if !ok {
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"baseline": s.baselineCtrl.Status(e.ID)})
+}
+
+// splitSchemas parses a comma-separated schema filter into a trimmed,
+// empty-free slice (nil for an empty string = all schemas).
+func splitSchemas(s string) []string {
+	var out []string
+	for part := range strings.SplitSeq(s, ",") {
+		if t := strings.TrimSpace(part); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}

--- a/internal/console/baseline_trigger_test.go
+++ b/internal/console/baseline_trigger_test.go
@@ -1,0 +1,226 @@
+package console
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// stubBaselineCtrl is a recording BaselineController for unit tests.
+type stubBaselineCtrl struct {
+	triggered []BaselineRequest
+	err       error
+	status    BaselineStatus
+}
+
+func (c *stubBaselineCtrl) Trigger(req BaselineRequest) error {
+	c.triggered = append(c.triggered, req)
+	return c.err
+}
+
+func (c *stubBaselineCtrl) Status(string) BaselineStatus { return c.status }
+
+// newBaselineTriggerServer builds a control-plane console with a recording baseline
+// controller wired in (mirrors newSupervisorServer for the monitor surface).
+func newBaselineTriggerServer(t *testing.T) (*Server, *stubBaselineCtrl) {
+	t.Helper()
+	reg, err := LoadRegistry(t.TempDir() + "/console-servers.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctrl := &stubBaselineCtrl{status: BaselineStatus{State: "idle"}}
+	srv, err := New(Config{
+		Listen: "127.0.0.1:8090", Token: "t", Registry: reg,
+		MonitorCtrl: &stubMonitorCtrl{}, BaselineCtrl: ctrl,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return srv, ctrl
+}
+
+const baselineSecretPW = "s3cr3t-baseline-pw"
+
+// addBaselineEntry adds a registry entry with the given source/destination
+// configured, returning its generated id.
+func addBaselineEntry(t *testing.T, srv *Server, source, baselineS3, baselineDir, schemas string) string {
+	t.Helper()
+	e, err := srv.cm.reg.Add(ServerEntry{
+		Name:        "wp",
+		DSN:         "idx:idxpw@tcp(127.0.0.1:3306)/binlog_index",
+		SourceDSN:   source,
+		BaselineS3:  baselineS3,
+		BaselineDir: baselineDir,
+		Schemas:     schemas,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return e.ID
+}
+
+// TestCapabilityBaselineTriggerGate: only a daemon that opted in (Config.BaselineCtrl)
+// advertises baseline_trigger; the standalone read-only console never does.
+func TestCapabilityBaselineTriggerGate(t *testing.T) {
+	for _, enabled := range []bool{true, false} {
+		reg, _ := LoadRegistry("")
+		cfg := Config{Listen: "127.0.0.1:8090", Token: "t", Registry: reg}
+		if enabled {
+			cfg.BaselineCtrl = &stubBaselineCtrl{}
+		}
+		srv, err := New(cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		srv.cm.boot = &bundle{}
+		rec, body := doServersReq(t, srv, "GET", "/api/capabilities", "")
+		if rec.Code != 200 {
+			t.Fatalf("capabilities: code=%d body=%s", rec.Code, body)
+		}
+		var caps capabilitiesResponse
+		if err := json.Unmarshal(body, &caps); err != nil {
+			t.Fatal(err)
+		}
+		if caps.BaselineTrigger != enabled {
+			t.Errorf("baseline_trigger capability = %v, want %v", caps.BaselineTrigger, enabled)
+		}
+	}
+}
+
+// TestBaselineTrigger_disabledConsole: with no BaselineCtrl wired in, the trigger
+// endpoint refuses with 403 even on a control-plane console.
+func TestBaselineTrigger_disabledConsole(t *testing.T) {
+	reg, _ := LoadRegistry(t.TempDir() + "/console-servers.yaml")
+	srv, err := New(Config{Listen: "127.0.0.1:8090", Token: "t", Registry: reg, MonitorCtrl: &stubMonitorCtrl{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := addBaselineEntry(t, srv, "u:p@tcp(127.0.0.1:3306)/", "s3://b/baselines/", "", "")
+	rec, _ := doServersReq(t, srv, "POST", "/api/servers/"+id+"/baseline", "")
+	if rec.Code != 403 {
+		t.Fatalf("disabled console: code=%d, want 403", rec.Code)
+	}
+}
+
+// TestBaselineTrigger_requiresSource: an entry with a destination but no source
+// configured cannot be dumped — 400.
+func TestBaselineTrigger_requiresSource(t *testing.T) {
+	srv, ctrl := newBaselineTriggerServer(t)
+	id := addBaselineEntry(t, srv, "", "s3://b/baselines/", "", "")
+	rec, _ := doServersReq(t, srv, "POST", "/api/servers/"+id+"/baseline", "")
+	if rec.Code != 400 {
+		t.Fatalf("no source: code=%d, want 400", rec.Code)
+	}
+	if len(ctrl.triggered) != 0 {
+		t.Fatalf("controller must not be triggered without a source")
+	}
+}
+
+// TestBaselineTrigger_requiresDestination: an entry with a source but no baseline
+// dir/S3 has nowhere for the snapshot to live — 400.
+func TestBaselineTrigger_requiresDestination(t *testing.T) {
+	srv, ctrl := newBaselineTriggerServer(t)
+	id := addBaselineEntry(t, srv, "u:p@tcp(127.0.0.1:3306)/", "", "", "")
+	rec, _ := doServersReq(t, srv, "POST", "/api/servers/"+id+"/baseline", "")
+	if rec.Code != 400 {
+		t.Fatalf("no destination: code=%d, want 400", rec.Code)
+	}
+	if len(ctrl.triggered) != 0 {
+		t.Fatalf("controller must not be triggered without a destination")
+	}
+}
+
+// TestBaselineTrigger_unknownServer: a bad server id is 404, never a trigger.
+func TestBaselineTrigger_unknownServer(t *testing.T) {
+	srv, _ := newBaselineTriggerServer(t)
+	rec, _ := doServersReq(t, srv, "POST", "/api/servers/deadbeef/baseline", "")
+	if rec.Code != 404 {
+		t.Fatalf("unknown server: code=%d, want 404", rec.Code)
+	}
+}
+
+// TestBaselineTrigger_happy: a fully-configured entry triggers a job (202), the
+// controller receives the source DSN + S3 destination + parsed schemas, and the
+// HTTP response never leaks the source password.
+func TestBaselineTrigger_happy(t *testing.T) {
+	srv, ctrl := newBaselineTriggerServer(t)
+	source := "repl:" + baselineSecretPW + "@tcp(10.0.0.5:3306)/"
+	id := addBaselineEntry(t, srv, source, "s3://my-bucket/baselines/", "", "wordpress, shop")
+
+	rec, body := doServersReq(t, srv, "POST", "/api/servers/"+id+"/baseline", "")
+	if rec.Code != 202 {
+		t.Fatalf("trigger: code=%d body=%s, want 202", rec.Code, body)
+	}
+	if len(ctrl.triggered) != 1 {
+		t.Fatalf("controller triggered %d times, want 1", len(ctrl.triggered))
+	}
+	got := ctrl.triggered[0]
+	if got.SourceDSN != source {
+		t.Errorf("SourceDSN = %q, want the entry's source", got.SourceDSN)
+	}
+	if got.S3 != "s3://my-bucket/baselines/" {
+		t.Errorf("S3 = %q, want the entry's baseline S3", got.S3)
+	}
+	if len(got.Schemas) != 2 || got.Schemas[0] != "wordpress" || got.Schemas[1] != "shop" {
+		t.Errorf("Schemas = %v, want [wordpress shop]", got.Schemas)
+	}
+	// The source password must never reach the HTTP response.
+	if strings.Contains(string(body), baselineSecretPW) {
+		t.Fatalf("response leaked the source password: %s", body)
+	}
+}
+
+// TestBaselineTrigger_alreadyRunning: ErrBaselineRunning from the controller maps
+// to 409 Conflict (one baseline at a time per server).
+func TestBaselineTrigger_alreadyRunning(t *testing.T) {
+	srv, ctrl := newBaselineTriggerServer(t)
+	ctrl.err = ErrBaselineRunning
+	id := addBaselineEntry(t, srv, "u:p@tcp(127.0.0.1:3306)/", "s3://b/baselines/", "", "")
+	rec, _ := doServersReq(t, srv, "POST", "/api/servers/"+id+"/baseline", "")
+	if rec.Code != 409 {
+		t.Fatalf("already running: code=%d, want 409", rec.Code)
+	}
+}
+
+// TestBaselineStatus_returnsControllerState: GET reflects the controller's status.
+func TestBaselineStatus_returnsControllerState(t *testing.T) {
+	srv, ctrl := newBaselineTriggerServer(t)
+	ctrl.status = BaselineStatus{State: "succeeded", Tables: 47, Rows: 33391, Uploaded: 48}
+	id := addBaselineEntry(t, srv, "u:p@tcp(127.0.0.1:3306)/", "s3://b/baselines/", "", "")
+
+	rec, body := doServersReq(t, srv, "GET", "/api/servers/"+id+"/baseline", "")
+	if rec.Code != 200 {
+		t.Fatalf("status: code=%d body=%s, want 200", rec.Code, body)
+	}
+	var resp struct {
+		Baseline BaselineStatus `json:"baseline"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Baseline.State != "succeeded" || resp.Baseline.Tables != 47 || resp.Baseline.Uploaded != 48 {
+		t.Errorf("status = %+v, want the controller's succeeded state", resp.Baseline)
+	}
+}
+
+// TestSplitSchemas covers the comma-separated parse used to build the request.
+func TestSplitSchemas(t *testing.T) {
+	cases := map[string][]string{
+		"":              nil,
+		"a":             {"a"},
+		" a , b ,, c ":  {"a", "b", "c"},
+		"wordpress,wp2": {"wordpress", "wp2"},
+	}
+	for in, want := range cases {
+		got := splitSchemas(in)
+		if len(got) != len(want) {
+			t.Errorf("splitSchemas(%q) = %v, want %v", in, got, want)
+			continue
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("splitSchemas(%q)[%d] = %q, want %q", in, i, got[i], want[i])
+			}
+		}
+	}
+}

--- a/internal/console/reconstruct.go
+++ b/internal/console/reconstruct.go
@@ -58,8 +58,13 @@ type capabilitiesResponse struct {
 	// snapshot (resolver). baselineConfigured can be true with resolver==nil (a
 	// baseline dir set but `bintrail snapshot` never run), where the handler
 	// degrades to Phase-1; advertising true there would over-promise.
-	RecoverCascadeBaseline bool         `json:"recover_cascade_baseline"`
-	Auth                   authCapsInfo `json:"auth"`
+	RecoverCascadeBaseline bool `json:"recover_cascade_baseline"`
+	// BaselineTrigger: this process can create baseline snapshots in-process from
+	// the console (the watch daemon opted in with BINTRAIL_CONSOLE_BASELINE_TRIGGER=1).
+	// Process-global, like Monitor — the endpoint does the per-server validation
+	// (source + baseline destination configured).
+	BaselineTrigger bool         `json:"baseline_trigger"`
+	Auth            authCapsInfo `json:"auth"`
 	// Source names the selected server's source database family — "postgresql"
 	// or "mysql" — derived per-server from stream_state.flavor (the same field
 	// DialectForIndex reads). It drives source-aware PRESENTATION only: the
@@ -97,7 +102,8 @@ func (s *Server) handleCapabilities(w http.ResponseWriter, r *http.Request) {
 		kind = "session"
 	}
 	resp := capabilitiesResponse{
-		Monitor: s.monitorCtrl != nil,
+		Monitor:         s.monitorCtrl != nil,
+		BaselineTrigger: s.baselineCtrl != nil,
 		// recover-cascade is the free tier (like recover) and process-global, gated
 		// only by the RBAC profile (which would make synthesis leak redacted data).
 		RecoverCascade: !s.rbacActive(),

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -75,6 +75,12 @@ type Config struct {
 	// there and every monitor verb refuses at the endpoint with 403,
 	// mirroring how reconstruct gates on baselineConfigured.
 	MonitorCtrl MonitorController
+	// BaselineCtrl runs in-process baseline snapshots (dump→convert→upload) for
+	// a monitored server (#613). Wired in ONLY by `bintrail-console watch` when
+	// the operator opts in (BINTRAIL_CONSOLE_BASELINE_TRIGGER=1); nil otherwise,
+	// where the trigger endpoint refuses with 403 and /api/capabilities reports
+	// baseline_trigger:false. Set together with MonitorCtrl (both control-plane).
+	BaselineCtrl BaselineController
 	// BaselineDir / BaselineS3 enable point-in-time reconstruct (Phase 2) on
 	// the boot entry. When either is set (and no RBAC profile is active), the
 	// "Reconstruct" surface is exposed. BaselineDir takes precedence;
@@ -131,6 +137,9 @@ type Server struct {
 	// monitorCtrl: non-nil only when this process is a control-plane
 	// supervisor (see Config.MonitorCtrl).
 	monitorCtrl MonitorController
+	// baselineCtrl: non-nil only when the watch daemon opted into in-process
+	// baseline creation (see Config.BaselineCtrl).
+	baselineCtrl BaselineController
 	// rotationDefaults are the daemon's --rotate-* values, the fallback GET
 	// /api/rotation reports when no console override is saved.
 	rotationDefaults RotationDefaults
@@ -243,6 +252,7 @@ func New(cfg Config) (*Server, error) {
 		redactCols:       cfg.RedactColumns,
 		allowedHosts:     cfg.AllowedHosts,
 		monitorCtrl:      cfg.MonitorCtrl,
+		baselineCtrl:     cfg.BaselineCtrl,
 		rotationDefaults: cfg.RotationDefaults,
 		cm:               newConnManager(cfg.Registry, profileActive),
 		authPath:         authPath,
@@ -332,6 +342,11 @@ func (s *Server) buildHandler() http.Handler {
 	api.HandleFunc("POST /api/servers/{id}/monitor/start", s.handleMonitorStart)
 	api.HandleFunc("POST /api/servers/{id}/monitor/stop", s.handleMonitorStop)
 	api.HandleFunc("GET /api/servers/{id}/monitor", s.handleMonitorStatus)
+	// Baseline trigger: enqueue an in-process baseline (dump→convert→upload) for
+	// a monitored server. 403 unless the watch daemon opted in
+	// (BINTRAIL_CONSOLE_BASELINE_TRIGGER=1). GET polls the running/last state.
+	api.HandleFunc("POST /api/servers/{id}/baseline", s.handleBaselineTrigger)
+	api.HandleFunc("GET /api/servers/{id}/baseline", s.handleBaselineStatus)
 	// Global built-in-rotation policy: read the effective settings; PUT an
 	// override (refused on the read-only console — only the watch daemon runs
 	// the loop that consumes it).

--- a/internal/storage/s3url.go
+++ b/internal/storage/s3url.go
@@ -7,9 +7,11 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
@@ -41,7 +43,31 @@ func NewS3Client(ctx context.Context, region string) (*s3.Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("load AWS config: %w", err)
 	}
+	// LoadDefaultConfig resolves region from AWS_REGION/AWS_DEFAULT_REGION and the
+	// shared config — but NOT from EC2/ECS IMDS. In an IAM-role-only deployment
+	// with no AWS_REGION set (e.g. the bundled console on EC2, where the in-process
+	// baseline upload passes region=""), the region ends up empty and every request
+	// fails with "region was not a valid DNS name". Fall back to the instance's
+	// IMDS region in that case.
+	if region == "" && awsCfg.Region == "" {
+		if r := imdsRegion(ctx, awsCfg); r != "" {
+			awsCfg.Region = r
+		}
+	}
 	return s3.NewFromConfig(awsCfg), nil
+}
+
+// imdsRegion best-effort fetches the EC2/ECS instance region from IMDS. Returns
+// "" off-instance or on any error; a short timeout keeps it from hanging where
+// IMDS is unreachable (a non-AWS host, or a hop-limited container).
+func imdsRegion(ctx context.Context, cfg aws.Config) string {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	out, err := imds.NewFromConfig(cfg).GetRegion(ctx, &imds.GetRegionInput{})
+	if err != nil || out == nil {
+		return ""
+	}
+	return out.Region
 }
 
 // BuildS3Key constructs the S3 object key for a file by computing its path


### PR DESCRIPTION
closes #613

## Summary
Adds an **opt-in "Create baseline" button** to the console's Storage → Baselines panel, so an operator can produce a baseline snapshot for a monitored server from the UI instead of only via `docker compose --profile baseline` or the CLI.

The key design choice (see issue thread): the console **never mounts the docker socket**. It runs the whole pipeline **in-process** — the `bintrail-console` image bundles `mydumper`, the watch daemon runs it as a **local subprocess**, then converts to Parquet and uploads to S3 by calling `internal/baseline` directly. A console compromise can therefore never escalate to host-root, and the source DSN never leaves the process (never written to disk or any HTTP response).

## What changed
- **`internal/baseline.Upload`** — extracted the crash-safe S3 upload (the `_INCOMPLETE`-first → data → `_SUCCESS`-last ordering, #467/#524) from `cmd/bintrail` so the CLI and the console share one implementation. Its unit tests moved with it.
- **`internal/console`** — `BaselineController` interface (wired by `watch`, mirroring `MonitorController`); `POST`/`GET /api/servers/{id}/baseline`; `baseline_trigger` capability. Gating, in order: control-plane only (403 on read-only `serve`), opt-in (403 unless enabled), source DSN configured (400), baseline destination configured (400), one at a time per server (409).
- **`cmd/bintrail-console`** — `baselineSupervisor` runs `mydumper → baseline.Run → baseline.Upload` in a goroutine with in-memory status. For an `s3://` destination the dump is staged in a fresh temp dir, uploaded, then discarded (so a re-run never re-uploads the local backlog). Opt in with `BINTRAIL_CONSOLE_BASELINE_TRIGGER=1`.
- **Frontend** — "Create baseline" button on the Baselines panel (gated by the capability + a configured destination), polls status, toasts the result. The manual CLI/compose recipe stays as the always-available path.
- **Packaging/docs** — both console Dockerfiles bundle `mydumper`; `docker-compose.yml` passes `BASELINE_TRIGGER` through (+ a staging dir on the state volume); `docs/console.md` documents the opt-in and the security rationale.

## Security notes
- `mydumper` runs as a **local subprocess** — no docker socket, no host-root surface on the network-facing console.
- Source DSN (with password) stays in-process; the trigger response carries only non-secret status. A unit test asserts the password never appears in the HTTP response.
- Off by default; the button is hidden on `serve` and whenever the opt-in is off.

## Test plan
- [x] `go test ./... -count=1` (unit) — new tests: endpoint gating (403/400/404/409/202), capability gate, no-secret-leak, status read-back, `mydumper` arg-building, and the relocated upload-ordering tests.
- [ ] **Build-verify the image** (`docker build -f Dockerfile.bintrail-console .`) — confirms `apt-get install mydumper` resolves on `bookworm-slim` (CI builds the image; flagged because it couldn't be built in the dev sandbox).
- [ ] Manual: on the EC2 demo, `BASELINE_TRIGGER=1`, click Create baseline for `wp`, confirm a new snapshot lands in S3 and appears in the panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)