### PR TITLE
feat(console): auto-detect cascade recovery inside Recover (drop separate tab)

### DIFF
--- a/docs/console.md
+++ b/docs/console.md
@@ -85,16 +85,13 @@ and searching events:
 4. **Recover** — filter schema / table / PK / time, preview the affected rows
    with before→after diffs, then **Generate undo SQL** and copy/download the
    script. Arriving via an **Undo** action scopes it to that row and shows a
-   context banner. **Nothing is ever executed.**
-5. **Cascade recovery** — reverse a foreign-key `ON DELETE CASCADE` / `SET NULL`
-   that InnoDB ran *below* the binlog: give it the **parent** table whose delete
-   cascaded and **Generate cascade recovery SQL** (copy/download). A provably
-   partial recovery shows a prominent **INCOMPLETE** banner listing every caveat,
-   so it never reads as a full restore. Free tier, but **hidden — its route
-   redirects to Overview — under an RBAC redaction profile**. See
-   [Cascade recovery](#cascade-recovery).
-6. **Status** — index health: partitions, coverage, stream lag, archives.
-7. **Settings** (under `watch` only) — **Storage** (rotation policy,
+   context banner. When you undo a `DELETE` on a foreign-key **parent** whose
+   children InnoDB cascade-deleted *below* the binlog (MySQL ≤ 8.x / MariaDB),
+   Recover **auto-detects** it and folds the invisible children into the same
+   script — no separate tab, no extra step. **Nothing is ever executed.** See
+   [Recover and cascade](#cascade-recovery).
+5. **Status** — index health: partitions, coverage, stream lag, archives.
+6. **Settings** (under `watch` only) — **Storage** (rotation policy,
    per-source S3 archiving, baseline snapshots, AWS credential signals — see
    [The Storage page](#the-storage-page)) and **Rotation** (opens the
    rotation dialog).
@@ -522,9 +519,9 @@ All endpoints return JSON. `/api/*` (except `healthz`) require
 | `GET /api/status` | Index status (same payload as `bintrail status --format json`). |
 | `GET /api/schemas` | Distinct schemas. `?schema=<name>` → that schema's tables. |
 | `GET /api/events` | Event browser. Query params: `schema, table, pk, event_type, gtid, since, until, changed_column, order, limit`. |
-| `POST /api/recover` | Undo-SQL generation. JSON body with the same filter fields (requires at least `schema`; an `order` field is accepted but ignored — recover always processes oldest-first). Returns `{sql, statement_count, row_count, warnings}`. |
+| `POST /api/recover` | Undo-SQL generation. JSON body with the same filter fields (requires at least `schema`; an `order` field is accepted but ignored — recover always processes oldest-first). Returns `{sql, statement_count, row_count, warnings}`. When the target is a foreign-key **parent** whose `DELETE` cascaded below the binlog (MySQL/MariaDB index only), cascade victims are **auto-detected** and folded into the same script; the response then also carries `{cascade_detected, victim_count, set_null_count}` (see [Recover and cascade](#cascade-recovery)). |
 | `POST /api/recover-cascade` | Cascade-recovery SQL generation (reverse FK `ON DELETE CASCADE` / `SET NULL` side effects). JSON body: `schema, table` (the **parent**), `pk, pks, since, until, lookback, max_depth, allow_incomplete`. Returns `{sql, statement_count, victim_count, set_null_count, complete, incomplete}` — text only, never executed. Returns `403` under an active RBAC redaction profile (see [Cascade recovery](#cascade-recovery)). |
-| `GET /api/capabilities` | Reports enabled optional surfaces for the **selected server**, e.g. `{"reconstruct": true, "recover_cascade": true, "recover_cascade_baseline": false, "source": "mysql", "auth": {"password_set": true, "auth_kind": "session"}}`. The frontend uses it to show/hide gated tabs on every switch (`reconstruct` → Time-travel, `recover_cascade` → Cascade recovery) and to gate the logout affordance (`auth_kind` says how this request authenticated). `source` (`"mysql"` or `"postgresql"`, read from the index's `stream_state.flavor`) drives **source-aware presentation** only — never a gate; see [PostgreSQL sources](#postgresql-sources). |
+| `GET /api/capabilities` | Reports enabled optional surfaces for the **selected server**, e.g. `{"reconstruct": true, "recover_cascade": true, "recover_cascade_baseline": false, "source": "mysql", "auth": {"password_set": true, "auth_kind": "session"}}`. The frontend uses it to show/hide gated tabs on every switch (`reconstruct` → Time-travel) and to gate the logout affordance (`auth_kind` says how this request authenticated). `recover_cascade` reports whether cascade synthesis is available (false under an RBAC redaction profile) — it gates the standalone `POST /api/recover-cascade` endpoint; the **Recover** tab's auto-detection follows the same server-side rule. `source` (`"mysql"` or `"postgresql"`, read from the index's `stream_state.flavor`) drives **source-aware presentation** only — never a gate; see [PostgreSQL sources](#postgresql-sources). |
 | `GET /api/reconstruct` | Single-row point-in-time reconstruct (baseline-gated **per server**; 404 when not configured). Query params: `schema, table, pk, at, history, allow_gaps`. Returns `{found, deleted, state, history, baseline_time, event_count, warnings}`. |
 | `GET /api/servers` | List servers (masked: parsed host/port/user/dbname + `has_password`, never a DSN or password) plus `default_id`. |
 | `POST /api/servers` | Add a server to the registry (validates, does not connect; never runs DDL). |
@@ -550,33 +547,44 @@ Selection is stateless — concurrent clients can each target a different server
 
 On MySQL 8.x and earlier (and all MariaDB), InnoDB enforces a foreign-key `ON
 DELETE CASCADE` / `ON DELETE SET NULL` *below* the binary log — only the parent
-`DELETE` is logged, so the cascaded child deletes and SET-NULL updates are
-invisible to the normal **Recover** tab. The **Cascade recovery** tab
-reconstructs them: give it the **parent** table whose delete cascaded (schema /
-table / PK, plus optional `since`/`until`, `lookback`, `max-depth`) and
-**Generate cascade recovery SQL** — `INSERT`s for the cascade-deleted children
-and idempotent guarded `UPDATE`s (`… AND fk IS NULL`) for SET-NULL'd foreign
-keys, wrapped in `SET FOREIGN_KEY_CHECKS=0/1`. Copy or download it; **nothing is
-ever executed.** It is the in-console face of `bintrail recover-cascade` — see
+`DELETE` is logged, so the cascaded child deletes and SET-NULL updates are never
+recorded as events. A plain undo of the parent `DELETE` would re-create the
+parent but leave those children gone.
+
+**Recover handles this automatically — there is no separate tab.** When you
+generate undo SQL for a `DELETE` on a table that is a foreign-key **parent**, the
+console detects it (one index lookup of the recorded FK graph) and folds the
+invisible children into the **same** script: `INSERT`s for the cascade-deleted
+children and idempotent guarded `UPDATE`s (`… AND fk IS NULL`) for SET-NULL'd
+foreign keys, all wrapped in `SET FOREIGN_KEY_CHECKS=0/1`. A **CASCADE detected**
+banner above the result reports how many children and SET-NULL restores were
+included. Copy or download it; **nothing is ever executed.** Detection only fires
+for a MySQL/MariaDB index (PostgreSQL logical replication captures cascade
+deletes as real events — no blind spot to reconstruct) and only when the matched
+rows actually contain a `DELETE` on the target table. The same engine is exposed
+for scripting as `bintrail recover-cascade` and `POST /api/recover-cascade` (with
+explicit `lookback` / `max-depth` knobs) — see
 [query-and-recovery.md](query-and-recovery.md) for the full mechanism, the
 baseline Phase-2 fallback, and the coverage limits.
 
 **Coverage is surfaced, never hidden.** Phase-1 (live binlog window) recovery is
-partial by construction — a child not touched within `lookback` and not in a
-baseline cannot be reconstructed. When the result is provably partial (a coverage
-gap, a per-parent overflow, or archived-out partitions the live scan can't see)
-the tab shows a prominent **INCOMPLETE** banner listing every caveat — and the
-same caveats are embedded in the generated SQL's preamble, so a partial recovery
-can never read as a full restore even after you copy or download it.
+partial by construction — a child not touched within `lookback` (default `30d`)
+and not in a baseline cannot be reconstructed. When the result is provably
+partial (a coverage gap, a per-parent overflow, or archived-out partitions the
+live scan can't see) the warnings carry a prominent **provably partial** notice
+listing every caveat — and the same caveats are embedded in the generated SQL's
+preamble, so a partial recovery can never read as a full restore even after you
+copy or download it.
 
-**Gating.** Cascade recovery is the free `query_explorer` tier, shown whenever
-the `recover_cascade` capability is true — which is whenever `recover` is,
-**except under an active RBAC redaction profile**. Cascade victim synthesis does
-not (yet) pass through the query engine's column redaction, so a `--profile`
-disables it: the tab is hidden, its route redirects to Overview, and `POST
-/api/recover-cascade` returns `403`. When a baseline is configured, the
-`recover_cascade_baseline` capability signals that Phase-2 (recovering children
-untouched within the window) is active for the selected server.
+**Under an RBAC redaction profile**, cascade synthesis is **disabled** (it does
+not yet pass through the query engine's column redaction, so synthesizing child
+rows could leak redacted/denied data): the parent-only undo is still generated,
+but with an explicit warning that cascade children are **not** included — it is
+never silently presented as a full restore. The standalone `POST
+/api/recover-cascade` endpoint returns `403` in that mode. When a baseline is
+configured, the `recover_cascade_baseline` capability signals that Phase-2
+(recovering children untouched within the window) is active for the selected
+server.
 
 ### Time-travel (reconstruct)
 

--- a/internal/cascaderecover/emit.go
+++ b/internal/cascaderecover/emit.go
@@ -38,6 +38,13 @@ type Header struct {
 	Parents, Children int
 	Caveats           []string
 	BaselineActive    bool
+	// Combined switches the preamble to the cascade-AWARE recover wording used
+	// when the console auto-detects a cascade parent inside a normal recover: the
+	// base reversal of the selected change(s) is composed with the synthesized
+	// children in ONE script, so the parent count and the "recover-cascade"
+	// framing no longer fit. The zero value (false) keeps the byte-identical
+	// `recover-cascade` preamble used by the CLI and the explicit endpoint.
+	Combined bool
 }
 
 // EmitSQL writes the documented preamble, the FK-checks-off wrapper, the CASCADE
@@ -70,9 +77,16 @@ func EmitSQL(w io.Writer, gen *recovery.Generator, rows []query.ResultRow, setNu
 	}
 
 	var b strings.Builder
-	fmt.Fprintf(&b, "-- bintrail recover-cascade: reverse ON DELETE CASCADE / SET NULL side effects on %s.%s\n", hdr.Schema, hdr.Table)
-	fmt.Fprintf(&b, "-- Re-inserts %d deleted parent row(s) and %d cascade-deleted child row(s); restores %d SET NULL'd FK(s)\n", hdr.Parents, hdr.Children, len(setNullRows))
-	b.WriteString("-- that InnoDB removed/nulled below the binlog (MySQL Bug #32506). NEVER auto-applied.\n")
+	if hdr.Combined {
+		fmt.Fprintf(&b, "-- bintrail recover (cascade-aware): undo %s.%s, including the foreign-key ON DELETE\n", hdr.Schema, hdr.Table)
+		b.WriteString("-- CASCADE / SET NULL side effects InnoDB ran below the binlog (MySQL Bug #32506).\n")
+		fmt.Fprintf(&b, "-- Re-creates %d cascade-deleted child row(s) and restores %d SET NULL'd FK(s) alongside\n", hdr.Children, len(setNullRows))
+		b.WriteString("-- the reversal of the selected change(s). NEVER auto-applied.\n")
+	} else {
+		fmt.Fprintf(&b, "-- bintrail recover-cascade: reverse ON DELETE CASCADE / SET NULL side effects on %s.%s\n", hdr.Schema, hdr.Table)
+		fmt.Fprintf(&b, "-- Re-inserts %d deleted parent row(s) and %d cascade-deleted child row(s); restores %d SET NULL'd FK(s)\n", hdr.Parents, hdr.Children, len(setNullRows))
+		b.WriteString("-- that InnoDB removed/nulled below the binlog (MySQL Bug #32506). NEVER auto-applied.\n")
+	}
 	b.WriteString("--\n")
 	if hdr.BaselineActive {
 		b.WriteString("-- Phase-2 baseline fallback ACTIVE: children present in a covered baseline are\n")

--- a/internal/console/api.go
+++ b/internal/console/api.go
@@ -76,6 +76,13 @@ type recoverResponse struct {
 	StatementCount int      `json:"statement_count"`
 	RowCount       int      `json:"row_count"`
 	Warnings       []string `json:"warnings,omitempty"`
+	// Cascade fields are set only when the recover target was auto-detected as a
+	// foreign-key parent whose DELETE cascaded below the binlog (the script then
+	// also re-creates the invisible children). Zero/false/empty for a plain
+	// recover, so existing clients are unaffected.
+	CascadeDetected bool `json:"cascade_detected,omitempty"`
+	VictimCount     int  `json:"victim_count,omitempty"`
+	SetNullCount    int  `json:"set_null_count,omitempty"`
 }
 
 type schemasResponse struct {
@@ -249,12 +256,66 @@ func (s *Server) handleRecover(w http.ResponseWriter, r *http.Request) {
 		writeFetchError(w, err)
 		return
 	}
+	warnings := gapWarnings(plan)
+
+	// Per-bundle dialect (the console is multi-server): MySQLDialect covers MySQL +
+	// MariaDB, PostgresDialect a PG-flavored index. Read once and reused below.
+	dialect := recovery.DialectForIndex(b.db)
+
+	// Cascade auto-detection. Undoing a DELETE on a foreign-key parent, the plain
+	// reversal is a strict SUBSET: it re-inserts the parent but not the child rows
+	// InnoDB cascade-deleted below the binlog (MySQL Bug #32506). When the target
+	// is such a parent, synthesize those invisible victims and fold them into ONE
+	// script — the operator never has to know their FK topology or visit a separate
+	// tab. Gated to MySQL/MariaDB: it is a binlog blind-spot fix, and PostgreSQL
+	// logical replication captures cascade deletes as real events (no blind spot to
+	// synthesize — firing here would only surface a misleading "0 victims" banner).
+	// Otherwise only meaningful when a single table is in scope and the matched rows
+	// actually contain a DELETE on it (an INSERT/UPDATE undo never cascades).
+	if dialect == recovery.MySQLDialect && body.Table != "" && rowsContainDeleteOn(rows, body.Table) {
+		isParent, derr := s.cascadeParentDetect(b, body.Schema, body.Table)
+		switch {
+		case derr != nil:
+			// Detection is best-effort: a probe failure must never block a plain
+			// recover. Log and fall through to the plain path.
+			slog.Warn("console: cascade parent detection failed; recover proceeds without cascade synthesis", "error", derr)
+		case isParent && s.rbacActive():
+			// Synthesis can't honor redaction (it would leak denied/redacted child
+			// rows), so it stays disabled under a profile — but SAY so, so a
+			// parent-only script is never silently presented as a full restore.
+			warnings = append([]string{
+				"This table has ON DELETE CASCADE / SET NULL children, but cascade synthesis is disabled while an RBAC redaction profile is active — the script below re-creates the parent only; cascade-deleted child rows are NOT included.",
+			}, warnings...)
+		case isParent:
+			cres, cerr := s.cascadeRecover(r.Context(), b, body, opts, rows)
+			if cerr != nil {
+				writeJSONError(w, http.StatusInternalServerError, cerr.Error())
+				return
+			}
+			cw := warnings
+			if len(cres.Caveats) > 0 {
+				cw = append([]string{
+					"Cascade recovery is provably partial — review the caveats below; some cascade-deleted rows may be missing.",
+				}, cres.Caveats...)
+				cw = append(cw, warnings...)
+			}
+			writeJSON(w, http.StatusOK, recoverResponse{
+				SQL:             cres.SQL,
+				StatementCount:  cres.StatementCount,
+				RowCount:        len(rows),
+				Warnings:        cw,
+				CascadeDetected: true,
+				VictimCount:     cres.VictimCount,
+				SetNullCount:    cres.SetNullCount,
+			})
+			return
+		}
+	}
 
 	var buf bytes.Buffer
-	// Per-bundle dialect: the console is multi-server, so select from THIS server's
-	// index flavor (a PG-flavored index → PostgreSQL reversal SQL). DialectForIndex
-	// defaults to MySQL on any read failure (#533/#573).
-	n, err := recovery.NewForDialect(b.db, b.resolver, recovery.DialectForIndex(b.db)).GenerateSQLFromRows(rows, &buf)
+	// Per-bundle dialect (read above): a PG-flavored index → PostgreSQL reversal SQL.
+	// DialectForIndex defaults to MySQL on any read failure (#533/#573).
+	n, err := recovery.NewForDialect(b.db, b.resolver, dialect).GenerateSQLFromRows(rows, &buf)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -263,7 +324,7 @@ func (s *Server) handleRecover(w http.ResponseWriter, r *http.Request) {
 		SQL:            buf.String(),
 		StatementCount: n,
 		RowCount:       len(rows),
-		Warnings:       gapWarnings(plan),
+		Warnings:       warnings,
 	})
 }
 

--- a/internal/console/api.go
+++ b/internal/console/api.go
@@ -277,8 +277,14 @@ func (s *Server) handleRecover(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case derr != nil:
 			// Detection is best-effort: a probe failure must never block a plain
-			// recover. Log and fall through to the plain path.
+			// recover — but it must NOT silently downgrade one either. If this table
+			// IS a cascade parent we couldn't tell, so warn that any cascade-deleted
+			// children may be missing (mirrors the RBAC arm below), then fall through
+			// to the plain path.
 			slog.Warn("console: cascade parent detection failed; recover proceeds without cascade synthesis", "error", derr)
+			warnings = append([]string{
+				"Could not check whether this table is a foreign-key parent (detection failed: " + derr.Error() + "). If it is, any cascade-deleted child rows are NOT included in the script below — retry, or use recover-cascade to reconstruct them.",
+			}, warnings...)
 		case isParent && s.rbacActive():
 			// Synthesis can't honor redaction (it would leak denied/redacted child
 			// rows), so it stays disabled under a profile — but SAY so, so a
@@ -289,8 +295,16 @@ func (s *Server) handleRecover(w http.ResponseWriter, r *http.Request) {
 		case isParent:
 			cres, cerr := s.cascadeRecover(r.Context(), b, body, opts, rows)
 			if cerr != nil {
-				writeJSONError(w, http.StatusInternalServerError, cerr.Error())
-				return
+				// Cascade synthesis is an ENHANCEMENT of the plain recover, not a
+				// precondition — the base rows were already fetched. A synthesis
+				// failure must not deny the recover the operator can still get;
+				// degrade to the plain path with a loud warning rather than 500ing
+				// the whole request (which would block even the parent-only undo).
+				slog.Warn("console: cascade synthesis failed; falling back to plain recover", "error", cerr)
+				warnings = append([]string{
+					"Cascade synthesis failed (" + cerr.Error() + "); the script below re-creates the parent only — cascade-deleted child rows are NOT included.",
+				}, warnings...)
+				break // out of the switch → plain recover below
 			}
 			cw := warnings
 			if len(cres.Caveats) > 0 {

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -39,7 +39,7 @@ const EVENT_CSV_COLUMNS = [
 const BADGE_CLASS = { UPDATE: "b-update", INSERT: "b-insert", DELETE: "b-delete" };
 function badgeClass(t) { return BADGE_CLASS[t] || "b-baseline"; }
 
-const ROUTES = ["overview", "events", "timetravel", "recover", "cascade", "status", "storage"];
+const ROUTES = ["overview", "events", "timetravel", "recover", "status", "storage"];
 
 const MON_STATE_TITLES = {
   failed: "stream failing — retrying with backoff; press Start for details",
@@ -558,8 +558,6 @@ function navigate(route, params, push = true) {
   if (!ROUTES.includes(route)) route = "overview";
   // Reconstruct surface is gated; never navigate to a disabled Time-travel.
   if (route === "timetravel" && !capsCache.reconstruct) route = "overview";
-  // Cascade recovery is the free tier but refused under an RBAC profile.
-  if (route === "cascade" && !capsCache.recover_cascade) route = "overview";
   // Storage is a watch-daemon surface (rotation + archiving live there).
   if (route === "storage" && !capsCache.monitor) route = "overview";
   const qs = params && Object.keys(params).length
@@ -578,7 +576,6 @@ function renderRoute() {
     case "events": return renderEvents(params);
     case "timetravel": return renderTimetravel(params);
     case "recover": return renderRecover(params);
-    case "cascade": return renderCascade(params);
     case "status": return renderStatus();
     case "storage": return renderStorage();
     default: return renderOverview();
@@ -1127,7 +1124,24 @@ async function generateUndo(form) {
     renderWarnings(warns, data.warnings);
     lastSQL = data.sql || "";
     clear(out);
-    out.append(codePanel(lastSQL, data.statement_count + " statement(s) from " + data.row_count + " event(s)"));
+    // When the target is auto-detected as a foreign-key parent, the script also
+    // re-creates the child rows InnoDB cascade-deleted below the binlog — surface
+    // it so the larger script isn't a surprise (coverage caveats, if any, are in
+    // the warnings above).
+    if (data.cascade_detected) {
+      out.append(el("div", { class: "ctx-banner" },
+        el("span", { class: "badge b-baseline", text: "CASCADE" }),
+        el("div", { class: "ctx-main" },
+          el("span", { class: "ctx-eyebrow", text: "Foreign-key cascade detected — invisible children included" }),
+          el("span", { class: "ctx-detail", text:
+            "this script also re-creates " + (data.victim_count || 0) + " cascade-deleted child row(s)" +
+            (data.set_null_count ? " and restores " + data.set_null_count + " SET NULL'd FK(s)" : "") +
+            " that InnoDB removed below the binlog" }))));
+    }
+    const meta = data.cascade_detected
+      ? data.statement_count + " statement(s) · " + (data.victim_count || 0) + " cascade child row(s) · " + (data.set_null_count || 0) + " SET NULL restore(s)"
+      : data.statement_count + " statement(s) from " + data.row_count + " event(s)";
+    out.append(codePanel(lastSQL, meta));
   } catch (err) {
     if (gen !== serverGen) return;
     clear(warns); renderError(out, err);
@@ -1159,94 +1173,6 @@ function undoEvent(e) {
     type: e.event_type, time: e.event_timestamp,
   };
   navigate("recover");
-}
-
-// ── Cascade recovery ──────────────────────────────────────────────────────────
-
-function renderCascade(params) {
-  // Gated off (direct URL or Back): rewrite to /overview and re-dispatch.
-  // replaceState (not navigate) avoids re-entering this guard — see renderTimetravel.
-  if (!capsCache.recover_cascade) { history.replaceState({}, "", "/overview"); renderRoute(); return; }
-  const v = VIEW(); clear(v);
-  const sub = el("p", { class: "page-sub" },
-    "Reverse a foreign-key ON DELETE CASCADE / SET NULL that InnoDB ran below the binlog. Give the ",
-    el("b", { text: "parent" }),
-    " table whose delete cascaded; its synthesized child victims become reversal SQL. ",
-    el("b", { text: "Nothing is ever executed" }),
-    " — review, then apply the script yourself.");
-  v.append(pageHead("Cascade recovery", sub));
-
-  const form = el("form", { class: "filters", id: "cascade-form" });
-  form.append(fieldSelect("Parent schema", "schema", "md", true, false, null, "— select —"));
-  form.append(fieldSelect("Parent table", "table", "md", false, true));
-  form.append(fieldInput("PK", "pk", "sm", "42 or 42|7"));
-  form.append(fieldInput("Since", "since", "md", "YYYY-MM-DD HH:MM"));
-  form.append(fieldInput("Until", "until", "md", "YYYY-MM-DD HH:MM"));
-  form.append(fieldInput("Lookback", "lookback", "sm", "30d"));
-  form.append(fieldInput("Max depth", "max_depth", "sm", "5"));
-  const incField = el("div", { class: "field", style: "justify-content:flex-end" },
-    el("label", { class: "check" }, el("input", { type: "checkbox", name: "allow_incomplete" }), el("span", { text: "Allow incomplete" })));
-  form.append(incField);
-  const actions = el("div", { class: "filter-actions" });
-  actions.append(el("button", { class: "btn btn-primary", type: "submit", text: "Generate cascade recovery SQL" }));
-  form.append(actions);
-  v.append(form);
-
-  v.append(el("div", { id: "cascade-warnings", class: "warnings" }));
-  const out = el("div", { id: "cascade-out" });
-  out.append(el("div", { class: "tt-meta", text: "Pick a deleted parent row, then generate its cascade recovery SQL." }));
-  v.append(out);
-
-  form.addEventListener("submit", (e) => { e.preventDefault(); runCascade(form); });
-  wireSchemaCascade(form);
-  populateSchemas(form);
-
-  // Optional deep-link prefill (schema/table/pk) — survives the async schema load.
-  if (params && params.schema) {
-    setSelectWhenReady(form, "schema", params.schema, () => {
-      if (params.table) form.elements.table.value = params.table;
-      if (params.pk) form.elements.pk.value = params.pk;
-    });
-  }
-  viewEnter();
-}
-
-async function runCascade(form) {
-  const gen = serverGen;
-  const warns = $("#cascade-warnings", VIEW());
-  const out = $("#cascade-out", VIEW());
-  const f = Object.fromEntries(new FormData(form).entries());
-  if (!f.schema || !f.table) { clear(warns); renderError(out, "parent schema and table are required"); return; }
-  const body = {};
-  ["schema", "table", "pk", "since", "until", "lookback"].forEach((k) => { if (f[k] && f[k].trim()) body[k] = f[k].trim(); });
-  // max_depth must be a JSON int — a string fails Go's unmarshal; omit when blank.
-  if (f.max_depth && f.max_depth.trim()) {
-    const d = parseInt(f.max_depth.trim(), 10);
-    if (!Number.isNaN(d)) body.max_depth = d;
-  }
-  // allow_incomplete must be a real boolean (a server-side no-op, sent for symmetry).
-  body.allow_incomplete = !!(form.elements.allow_incomplete && form.elements.allow_incomplete.checked);
-  try {
-    const data = await api("/api/recover-cascade", { method: "POST", body });
-    if (gen !== serverGen) return;
-    // Coverage UX: a partial recovery must NEVER read as whole. Drive the banner
-    // off the response `complete` flag (NOT the allow_incomplete checkbox, which is
-    // a server-side no-op), and surface `incomplete` — the cascade response has no
-    // `warnings` key, so reading data.warnings would silently drop every caveat.
-    const caveats = data.incomplete || [];
-    if (!data.complete) {
-      renderWarnings(warns, ["INCOMPLETE — this recovery is provably partial; do not treat it as a full restore.", ...caveats]);
-    } else {
-      renderWarnings(warns, caveats);
-    }
-    lastSQL = data.sql || "";
-    clear(out);
-    out.append(codePanel(lastSQL,
-      data.statement_count + " statement(s) · " + data.victim_count + " victim(s) · " + data.set_null_count + " SET NULL restore(s)"));
-  } catch (err) {
-    if (gen !== serverGen) return;
-    clear(warns); renderError(out, err);
-  }
 }
 
 // ── Time-travel (reconstruct) ─────────────────────────────────────────────────
@@ -2422,7 +2348,6 @@ function cmdkCommands() {
     { group: "Navigate", label: "Status", run: () => navigate("status") },
   ];
   if (capsCache.reconstruct) cmds.push({ group: "Navigate", label: "Time-travel", run: () => navigate("timetravel") });
-  if (capsCache.recover_cascade) cmds.push({ group: "Navigate", label: "Cascade recovery", run: () => navigate("cascade") });
   if (capsCache.monitor) cmds.push({ group: "Navigate", label: "Storage", run: () => navigate("storage") });
   cmds.push({ group: "Actions", label: "Manage servers", run: () => { closeCmdk(); openServersModal(); } });
   if (capsCache.monitor) cmds.push({ group: "Actions", label: "Configure rotation…", run: () => { closeCmdk(); showRotationDialog(); } });

--- a/internal/console/assets/index.html
+++ b/internal/console/assets/index.html
@@ -71,10 +71,6 @@
             <span class="ni-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7v6h6"/><path d="M3 13a9 9 0 1 0 3-7.7L3 8"/></svg></span>
             <span>Recover</span>
           </a>
-          <a class="nav-item" data-route="cascade" href="/cascade" data-capability="recover_cascade">
-            <span class="ni-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="6" r="2.2"/><circle cx="18" cy="12" r="2.2"/><circle cx="18" cy="19" r="2.2"/><path d="M6 8.2v3.3a3 3 0 0 0 3 3h6.8"/><path d="M8.2 6H16"/></svg></span>
-            <span>Cascade recovery</span>
-          </a>
         </div>
         <div class="nav-group">
           <div class="nav-label">Monitor</div>

--- a/internal/console/recover_cascade.go
+++ b/internal/console/recover_cascade.go
@@ -134,30 +134,110 @@ func (s *Server) handleRecoverCascade(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx := r.Context()
+	synth, err := s.synthesizeCascade(r.Context(), b, cascadeSynthParams{
+		Schema:   body.Schema,
+		Table:    body.Table,
+		PK:       body.PK,
+		PKs:      body.PKs,
+		Since:    since,
+		Until:    until,
+		Lookback: lookback,
+		MaxDepth: maxDepth,
+	})
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	// The explicit endpoint emits over its OWN live-only parent fetch (cascade
+	// recovery never reads archives), so the parents appear here; the synthesized
+	// victims are children-only, so the parent is re-inserted exactly once.
+	rows := append(append([]query.ResultRow{}, synth.ParentDeletes...), synth.Victims...)
+
+	var buf bytes.Buffer
+	// Per-bundle dialect (matches handleRecover). For a MySQL/MariaDB index — the
+	// only flavor cascade recovery supports — this is byte-identical to the CLI's
+	// recovery.New(MySQL).
+	gen := recovery.NewForDialect(b.db, b.resolver, recovery.DialectForIndex(b.db))
+	n, err := cascaderecover.EmitSQL(&buf, gen, rows, synth.SetNullRows, b.resolver, cascaderecover.Header{
+		Schema:         body.Schema,
+		Table:          body.Table,
+		Parents:        len(synth.ParentDeletes),
+		Children:       len(synth.Victims),
+		Caveats:        synth.Caveats,
+		BaselineActive: synth.BaselineActive,
+	})
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, recoverCascadeResponse{
+		SQL:            buf.String(),
+		StatementCount: n,
+		VictimCount:    len(synth.Victims),
+		SetNullCount:   len(synth.SetNullRows),
+		Complete:       len(synth.Caveats) == 0 && synth.SynthErr == nil,
+		Incomplete:     synth.Caveats,
+	})
+}
+
+// cascadeSynthParams are the already-parsed, validated inputs to a cascade victim
+// synthesis. Both the explicit POST /api/recover-cascade endpoint and the
+// auto-detected cascade branch of POST /api/recover build one and call
+// synthesizeCascade. A zero Lookback/MaxDepth falls back to the cascade engine's
+// defaults (30d / depth 5) — what the auto-detect path passes (the friction this
+// feature removes is making the operator know their FK graph, not tune knobs).
+type cascadeSynthParams struct {
+	Schema, Table string
+	PK            string
+	PKs           []string
+	Since, Until  *time.Time
+	Lookback      time.Duration
+	MaxDepth      int
+}
+
+// cascadeSynthResult carries the synthesized invisible extras plus coverage
+// caveats, WITHOUT any emitted SQL: each caller composes the final script over
+// its own base rows (the explicit endpoint over its live-only parent fetch; the
+// recover branch over the merged base rows) so neither double-inserts the parent.
+type cascadeSynthResult struct {
+	ParentDeletes  []query.ResultRow
+	Victims        []query.ResultRow
+	SetNullRows    []cascade.SetNullRestore
+	Caveats        []string
+	SynthErr       error // operational synthesis failure; its text is also folded into Caveats
+	BaselineActive bool
+}
+
+// synthesizeCascade fetches the parent DELETE events (LIVE index only — cascade
+// recovery never searches archives), probes archive coverage, sets up the
+// optional Phase-2 baseline fallback, and reconstructs the invisible cascade
+// victims / SET NULL restorations. It is the shared engine behind both cascade
+// surfaces; it emits NO SQL so each caller composes the script over its own base
+// rows. A returned error is an operational fetch/FK-load failure (caller 500s);
+// a PARTIAL synthesis is reported via SynthErr + Caveats, never an error.
+func (s *Server) synthesizeCascade(ctx context.Context, b *bundle, p cascadeSynthParams) (cascadeSynthResult, error) {
 	limit := clampLimit(0, recoverDefaultLimit, recoverMaxLimit)
 	del := event.EventDelete
 
-	// Fetch the parent DELETE events — LIVE index only (cascade recovery never
-	// searches archives; their presence is surfaced as a caveat below). DenyTables/
-	// RedactColumns are attached for consistency but are empty here (a profile would
-	// have been refused above).
+	// DenyTables/RedactColumns are attached for consistency but are empty here (an
+	// RBAC profile is refused upstream of every caller of synthesizeCascade).
 	parentDeletes, err := b.engine.Fetch(ctx, query.Options{
-		Schema:        body.Schema,
-		Table:         body.Table,
-		PKValues:      body.PK,
-		PKValuesIn:    body.PKs,
+		Schema:        p.Schema,
+		Table:         p.Table,
+		PKValues:      p.PK,
+		PKValuesIn:    p.PKs,
 		EventType:     &del,
-		Since:         since,
-		Until:         until,
+		Since:         p.Since,
+		Until:         p.Until,
 		Order:         "ASC",
 		Limit:         limit,
 		DenyTables:    s.denyTables,
 		RedactColumns: s.redactCols,
 	})
 	if err != nil {
-		writeJSONError(w, http.StatusInternalServerError, "fetch parent deletes: "+err.Error())
-		return
+		return cascadeSynthResult{}, fmt.Errorf("fetch parent deletes: %w", err)
 	}
 
 	var caveats []string
@@ -203,14 +283,13 @@ func (s *Server) handleRecoverCascade(w http.ResponseWriter, r *http.Request) {
 	var res cascade.Result
 	var synthErr error
 	if len(parentDeletes) > 0 {
-		fks, lerr := cascade.LoadCascadeFKs(ctx, b.db, []string{body.Schema})
+		fks, lerr := cascade.LoadCascadeFKs(ctx, b.db, []string{p.Schema})
 		if lerr != nil {
-			writeJSONError(w, http.StatusInternalServerError, "load FK graph: "+lerr.Error())
-			return
+			return cascadeSynthResult{}, fmt.Errorf("load FK graph: %w", lerr)
 		}
 		res, synthErr = cascade.SynthesizeVictims(ctx, b.engine, fks, parentDeletes, cascade.Options{
-			Lookback:        lookback,
-			MaxDepth:        maxDepth,
+			Lookback:        p.Lookback,
+			MaxDepth:        p.MaxDepth,
 			Baseline:        baselineProvider,
 			ArchivesPresent: archivesExist,
 		})
@@ -220,34 +299,110 @@ func (s *Server) handleRecoverCascade(w http.ResponseWriter, r *http.Request) {
 		caveats = append(caveats, "an index query failed mid-synthesis; the result is partial: "+synthErr.Error())
 	}
 
-	rows := append(append([]query.ResultRow{}, parentDeletes...), res.Victims...)
-
-	var buf bytes.Buffer
-	// Per-bundle dialect (matches handleRecover). For a MySQL/MariaDB index — the
-	// only flavor cascade recovery supports — this is byte-identical to the CLI's
-	// recovery.New(MySQL).
-	gen := recovery.NewForDialect(b.db, b.resolver, recovery.DialectForIndex(b.db))
-	n, err := cascaderecover.EmitSQL(&buf, gen, rows, res.SetNullRows, b.resolver, cascaderecover.Header{
-		Schema:         body.Schema,
-		Table:          body.Table,
-		Parents:        len(parentDeletes),
-		Children:       len(res.Victims),
+	return cascadeSynthResult{
+		ParentDeletes:  parentDeletes,
+		Victims:        res.Victims,
+		SetNullRows:    res.SetNullRows,
 		Caveats:        caveats,
+		SynthErr:       synthErr,
 		BaselineActive: baselineProvider != nil,
+	}, nil
+}
+
+// cascadeParentDetect reports whether schema.table is the referenced (parent)
+// side of an ON DELETE CASCADE / SET NULL edge in the latest FK snapshot — the
+// cheap, one-index-query signal that a DELETE on it may have cascaded below the
+// binlog. Scoped to the parent's own schema, matching the synthesis (cascade only
+// reconstructs same-schema children). A detection error is returned so the caller
+// can log it and fall back to a plain recover; it must never abort one.
+func (s *Server) cascadeParentDetect(b *bundle, schema, table string) (bool, error) {
+	edges, err := metadata.CascadeConstraintsInIndex(b.db, []string{schema})
+	if err != nil {
+		return false, err
+	}
+	for _, e := range edges {
+		if e.ReferencedTable == table && (e.DeleteRule == "CASCADE" || e.DeleteRule == "SET NULL") {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// rowsContainDeleteOn reports whether any row is a DELETE on the given table — the
+// precondition (besides cascade-parent-ness) for auto-routing a recover through
+// cascade synthesis. Undoing an INSERT/UPDATE never triggers an InnoDB cascade.
+func rowsContainDeleteOn(rows []query.ResultRow, table string) bool {
+	for _, r := range rows {
+		if r.EventType == event.EventDelete && r.TableName == table {
+			return true
+		}
+	}
+	return false
+}
+
+// cascadeRecoverResult is the combined cascade-aware reversal cascadeRecover
+// produces for an auto-detected parent DELETE.
+type cascadeRecoverResult struct {
+	SQL            string
+	StatementCount int
+	VictimCount    int
+	SetNullCount   int
+	Caveats        []string
+}
+
+// cascadeRecover composes ONE cascade-aware reversal script for a recover whose
+// target handleRecover auto-detected as a foreign-key parent: the base undo of
+// baseRows (already fetched — merged live+archive, RBAC-redacted, every event
+// type) PLUS the synthesized invisible children and SET NULL restorations, all
+// wrapped in SET FOREIGN_KEY_CHECKS=0/1. baseRows already contains the parent
+// DELETE(s); the synthesized victims are children-only (cascade never returns a
+// parent row), so the parent is re-inserted exactly once.
+func (s *Server) cascadeRecover(ctx context.Context, b *bundle, body recoverRequest, opts query.Options, baseRows []query.ResultRow) (cascadeRecoverResult, error) {
+	synth, err := s.synthesizeCascade(ctx, b, cascadeSynthParams{
+		Schema: body.Schema,
+		Table:  body.Table,
+		PK:     body.PK,
+		Since:  opts.Since,
+		Until:  opts.Until,
+		// Lookback/MaxDepth left zero → cascade engine defaults (30d / depth 5).
 	})
 	if err != nil {
-		writeJSONError(w, http.StatusInternalServerError, err.Error())
-		return
+		return cascadeRecoverResult{}, err
 	}
 
-	writeJSON(w, http.StatusOK, recoverCascadeResponse{
+	caveats := synth.Caveats
+	setNull := synth.SetNullRows
+	// SET NULL restorations need the schema snapshot for their PK WHERE clause
+	// (EmitSQL errors without a resolver). Rather than fail a recover that can
+	// still re-create the CASCADE-deleted rows, drop the restorations and flag
+	// them — never silently.
+	if b.resolver == nil && len(setNull) > 0 {
+		caveats = append(caveats, fmt.Sprintf(
+			"%d ON DELETE SET NULL restoration(s) were skipped: a schema snapshot is required for the restore (run `bintrail snapshot`)", len(setNull)))
+		setNull = nil
+	}
+
+	rows := append(append([]query.ResultRow{}, baseRows...), synth.Victims...)
+	var buf bytes.Buffer
+	gen := recovery.NewForDialect(b.db, b.resolver, recovery.DialectForIndex(b.db))
+	n, err := cascaderecover.EmitSQL(&buf, gen, rows, setNull, b.resolver, cascaderecover.Header{
+		Schema:         body.Schema,
+		Table:          body.Table,
+		Children:       len(synth.Victims),
+		Caveats:        caveats,
+		BaselineActive: synth.BaselineActive,
+		Combined:       true,
+	})
+	if err != nil {
+		return cascadeRecoverResult{}, err
+	}
+	return cascadeRecoverResult{
 		SQL:            buf.String(),
 		StatementCount: n,
-		VictimCount:    len(res.Victims),
-		SetNullCount:   len(res.SetNullRows),
-		Complete:       len(caveats) == 0 && synthErr == nil,
-		Incomplete:     caveats,
-	})
+		VictimCount:    len(synth.Victims),
+		SetNullCount:   len(setNull),
+		Caveats:        caveats,
+	}, nil
 }
 
 // cascadeBaselineProvider implements cascade.BaselineProvider over

--- a/internal/console/recover_cascade_integration_test.go
+++ b/internal/console/recover_cascade_integration_test.go
@@ -148,7 +148,7 @@ func TestIntegrationRecoverCascade_incompleteWithArchives(t *testing.T) {
 // → Phase-1). The capability advertises the sub-flag in lockstep.
 func TestIntegrationRecoverCascade_phase2HeaderWhenBaselineConfigured(t *testing.T) {
 	srv, dbName := seedCascadeConsole(t, func(c *Config) {
-		c.NoArchive = false        // required for baselineConfigured
+		c.NoArchive = false         // required for baselineConfigured
 		c.BaselineDir = t.TempDir() // empty dir → no baseline rows, provider still wired
 	})
 
@@ -203,7 +203,7 @@ func TestIntegrationRecover_autoCascade_endToEnd(t *testing.T) {
 	for _, want := range []string{
 		"SET FOREIGN_KEY_CHECKS=0;",
 		"SET FOREIGN_KEY_CHECKS=1;",
-		"recover (cascade-aware)",                  // the Combined preamble, not "recover-cascade"
+		"recover (cascade-aware)",                   // the Combined preamble, not "recover-cascade"
 		"Re-creates 2 cascade-deleted child row(s)", // Combined header counts the children
 		"`" + dbName + "`.`parent`",
 		"`" + dbName + "`.`child`",
@@ -279,6 +279,48 @@ func TestIntegrationRecover_autoCascade_rbacWarns(t *testing.T) {
 	}
 	if !warned {
 		t.Errorf("a parent-DELETE recover under RBAC must warn that cascade children are NOT included; warnings=%v", resp.Warnings)
+	}
+}
+
+// TestIntegrationRecover_autoCascade_mixedEvents pins the combined path's
+// data-integrity contract: a parent with BOTH a non-DELETE event (UPDATE) and a
+// DELETE in the window. The combined script must reverse the UPDATE AND re-create
+// the parent from the DELETE AND include the synthesized children — because
+// cascadeRecover emits over the MERGED base rows (every event type), while the
+// synthesis uses a DELETE-only parent fetch purely to discover children. A
+// refactor that emitted over the synthesis's DELETE-only parents would silently
+// drop the UPDATE reversal — a data-loss-shaped regression this test catches.
+func TestIntegrationRecover_autoCascade_mixedEvents(t *testing.T) {
+	srv, dbName := seedCascadeConsole(t, nil)
+	// A parent UPDATE between the children (h+10m) and the seeded parent DELETE
+	// (h+20m), on the same pk=1.
+	h := time.Now().UTC().Add(-1 * time.Hour).Truncate(time.Hour)
+	updTs := h.Add(15 * time.Minute).Format("2006-01-02 15:04:05")
+	testutil.InsertEvent(t, srv.cm.boot.db, "binlog.000001", 250, 260, updTs, nil,
+		dbName, "parent", 2 /*UPDATE*/, "1", []byte(`["status"]`),
+		[]byte(`{"id":1,"status":"old"}`), []byte(`{"id":1,"status":"new"}`))
+
+	rec, body := doReq(t, srv, "POST", "/api/recover", `{"schema":"`+dbName+`","table":"parent"}`)
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, body = %s", rec.Code, body)
+	}
+	var resp recoverResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("decode: %v (body=%s)", err, body)
+	}
+	if !resp.CascadeDetected || resp.VictimCount != 2 {
+		t.Errorf("want cascade_detected + 2 victims, got detected=%v victims=%d", resp.CascadeDetected, resp.VictimCount)
+	}
+	// The non-DELETE base reversal must survive alongside the parent re-INSERT and
+	// the 2 child INSERTs.
+	if !strings.Contains(resp.SQL, "UPDATE `"+dbName+"`.`parent`") {
+		t.Errorf("the parent UPDATE reversal was dropped from the combined script (regression: emitted over DELETE-only parents?)\n---\n%s", resp.SQL)
+	}
+	if !strings.Contains(resp.SQL, "INSERT INTO `"+dbName+"`.`parent`") {
+		t.Errorf("the parent re-INSERT (from the DELETE) is missing\n---\n%s", resp.SQL)
+	}
+	if c := strings.Count(resp.SQL, "`"+dbName+"`.`child`"); c != 2 {
+		t.Errorf("want 2 child INSERTs, got %d\n---\n%s", c, resp.SQL)
 	}
 }
 

--- a/internal/console/recover_cascade_integration_test.go
+++ b/internal/console/recover_cascade_integration_test.go
@@ -176,6 +176,208 @@ func TestIntegrationRecoverCascade_phase2HeaderWhenBaselineConfigured(t *testing
 	}
 }
 
+// TestIntegrationRecover_autoCascade_endToEnd is the merge's core guarantee: a
+// plain POST /api/recover on a foreign-key PARENT whose DELETE cascaded auto-
+// detects the cascade and emits ONE combined script — the parent re-INSERT AND
+// its two invisible children, inside the FK-checks wrapper — with cascade_detected
+// + victim_count set. No separate tab, no extra request. The parent must appear
+// exactly once (base rows carry it; synthesized victims are children-only).
+func TestIntegrationRecover_autoCascade_endToEnd(t *testing.T) {
+	srv, dbName := seedCascadeConsole(t, nil)
+
+	rec, body := doReq(t, srv, "POST", "/api/recover", `{"schema":"`+dbName+`","table":"parent"}`)
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, body = %s", rec.Code, body)
+	}
+	var resp recoverResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("decode: %v (body=%s)", err, body)
+	}
+
+	if !resp.CascadeDetected {
+		t.Errorf("cascade_detected should be true for a parent DELETE recover\n---\n%s", resp.SQL)
+	}
+	if resp.VictimCount != 2 {
+		t.Errorf("victim_count = %d, want 2", resp.VictimCount)
+	}
+	for _, want := range []string{
+		"SET FOREIGN_KEY_CHECKS=0;",
+		"SET FOREIGN_KEY_CHECKS=1;",
+		"recover (cascade-aware)",                  // the Combined preamble, not "recover-cascade"
+		"Re-creates 2 cascade-deleted child row(s)", // Combined header counts the children
+		"`" + dbName + "`.`parent`",
+		"`" + dbName + "`.`child`",
+	} {
+		if !strings.Contains(resp.SQL, want) {
+			t.Errorf("SQL missing %q\n---\n%s", want, resp.SQL)
+		}
+	}
+	// Parent re-inserted exactly once (base rows), children exactly twice (victims).
+	if c := strings.Count(resp.SQL, "`"+dbName+"`.`parent`"); c != 1 {
+		t.Errorf("want the parent re-inserted once, got %d\n---\n%s", c, resp.SQL)
+	}
+	if c := strings.Count(resp.SQL, "`"+dbName+"`.`child`"); c != 2 {
+		t.Errorf("want 2 child INSERTs, got %d\n---\n%s", c, resp.SQL)
+	}
+	// connection_id is the paid-forensics boundary: the merged response carries SQL
+	// + counts only (no event rows), exactly like the legacy cascade endpoint.
+	if strings.Contains(string(body), "connection_id") {
+		t.Errorf("connection_id leaked into the recover response: %s", body)
+	}
+}
+
+// TestIntegrationRecover_autoCascade_skippedWhenNotParent locks the gate: a
+// recover on the CHILD table (INSERTs only, not a cascade parent) takes the plain
+// path — no cascade synthesis, no FK-checks wrapper — even though the table
+// participates in the same FK. cascade_detected stays false.
+func TestIntegrationRecover_autoCascade_skippedWhenNotParent(t *testing.T) {
+	srv, dbName := seedCascadeConsole(t, nil)
+
+	rec, body := doReq(t, srv, "POST", "/api/recover", `{"schema":"`+dbName+`","table":"child"}`)
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, body = %s", rec.Code, body)
+	}
+	var resp recoverResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("decode: %v (body=%s)", err, body)
+	}
+	if resp.CascadeDetected {
+		t.Errorf("cascade_detected must be false for a non-parent (child) recover")
+	}
+	if strings.Contains(resp.SQL, "SET FOREIGN_KEY_CHECKS=0;") {
+		t.Errorf("plain recover should not emit the cascade FK-checks wrapper\n---\n%s", resp.SQL)
+	}
+}
+
+// TestIntegrationRecover_autoCascade_rbacWarns: under an RBAC profile cascade
+// synthesis is disabled (it cannot honor redaction), but a parent-DELETE recover
+// must NOT silently emit a parent-only script as if whole — it warns. The recover
+// itself still succeeds (unlike the cascade endpoint, which 403s).
+func TestIntegrationRecover_autoCascade_rbacWarns(t *testing.T) {
+	srv, dbName := seedCascadeConsole(t, func(c *Config) {
+		// A redact rule on an unrelated table is enough to activate the profile (the
+		// guard checks presence, not scope), and leaves the parent recover working.
+		c.RedactColumns = []query.SchemaTableColumn{{Schema: "app", Table: "child", Column: "pid"}}
+	})
+
+	rec, body := doReq(t, srv, "POST", "/api/recover", `{"schema":"`+dbName+`","table":"parent"}`)
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, body = %s", rec.Code, body)
+	}
+	var resp recoverResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("decode: %v (body=%s)", err, body)
+	}
+	if resp.CascadeDetected {
+		t.Errorf("cascade synthesis must stay disabled under an RBAC profile")
+	}
+	var warned bool
+	for _, w := range resp.Warnings {
+		if strings.Contains(w, "RBAC redaction profile is active") {
+			warned = true
+		}
+	}
+	if !warned {
+		t.Errorf("a parent-DELETE recover under RBAC must warn that cascade children are NOT included; warnings=%v", resp.Warnings)
+	}
+}
+
+// TestIntegrationRecover_autoCascade_setNull covers the SET NULL arm of the
+// combined path: a parent whose child FK is ON DELETE SET NULL. Recover on the
+// parent must fold an idempotent guarded UPDATE (… AND fk IS NULL) into the same
+// FK-checks-wrapped script and report set_null_count, with zero victims (a
+// SET NULL child survives — it is restored, not re-inserted). Self-seeded (not
+// seedCascadeConsole, whose CASCADE counts other tests assert).
+func TestIntegrationRecover_autoCascade_setNull(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	h := time.Now().UTC().Add(-1 * time.Hour).Truncate(time.Hour)
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{h})
+	childTs := h.Add(10 * time.Minute).Format("2006-01-02 15:04:05")
+	parentTs := h.Add(20 * time.Minute).Format("2006-01-02 15:04:05")
+
+	// One child row pointing at parent.id=1 via a SET NULL FK column `pid`, plus
+	// the parent DELETE (the cascade SET-NULL update InnoDB ran is NOT indexed).
+	testutil.InsertEvent(t, db, "binlog.000001", 100, 200, childTs, nil,
+		dbName, "snchild", 1 /*INSERT*/, "20", nil, nil, []byte(`{"id":20,"pid":1}`))
+	testutil.InsertEvent(t, db, "binlog.000001", 300, 400, parentTs, nil,
+		dbName, "parent", 3 /*DELETE*/, "1", nil, []byte(`{"id":1}`), nil)
+
+	testutil.MustExec(t, db, `INSERT INTO fk_constraints
+		(snapshot_id, constraint_name, schema_name, table_name, column_name, ordinal_position,
+		 referenced_schema_name, referenced_table_name, referenced_column_name, delete_rule, update_rule)
+		VALUES (1, 'fk_snchild', ?, 'snchild', 'pid', 1, ?, 'parent', 'id', 'SET NULL', 'RESTRICT')`,
+		dbName, dbName)
+
+	snapTs := h.Format("2006-01-02 15:04:05")
+	testutil.InsertSnapshot(t, db, 1, snapTs, dbName, "parent", "id", 1, "PRI", "int", "NO")
+	testutil.InsertSnapshot(t, db, 1, snapTs, dbName, "snchild", "id", 1, "PRI", "int", "NO")
+	testutil.InsertSnapshot(t, db, 1, snapTs, dbName, "snchild", "pid", 2, "", "int", "YES")
+
+	srv, err := New(Config{DB: db, DBName: dbName, Listen: "127.0.0.1:8090", Token: intToken, NoArchive: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rec, body := doReq(t, srv, "POST", "/api/recover", `{"schema":"`+dbName+`","table":"parent"}`)
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, body = %s", rec.Code, body)
+	}
+	var resp recoverResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("decode: %v (body=%s)", err, body)
+	}
+	if !resp.CascadeDetected {
+		t.Errorf("cascade_detected should be true for a SET NULL parent recover")
+	}
+	if resp.SetNullCount != 1 {
+		t.Errorf("set_null_count = %d, want 1", resp.SetNullCount)
+	}
+	if resp.VictimCount != 0 {
+		t.Errorf("victim_count = %d, want 0 (a SET NULL child survives — restored, not re-inserted)", resp.VictimCount)
+	}
+	for _, want := range []string{
+		"SET FOREIGN_KEY_CHECKS=0;",
+		"SET FOREIGN_KEY_CHECKS=1;",
+		"`" + dbName + "`.`parent`",  // the parent re-INSERT
+		"`" + dbName + "`.`snchild`", // the SET NULL restore UPDATE
+		"IS NULL",                    // the idempotent guard
+	} {
+		if !strings.Contains(resp.SQL, want) {
+			t.Errorf("SQL missing %q\n---\n%s", want, resp.SQL)
+		}
+	}
+}
+
+// TestIntegrationRecover_autoCascade_skippedForPostgres locks the dialect gate:
+// cascade auto-detection is a MySQL/MariaDB binlog blind-spot fix. A PostgreSQL-
+// flavored index captures cascade deletes as real events (no blind spot), so a
+// parent recover takes the plain path — no synthesis, no misleading "0 victims".
+func TestIntegrationRecover_autoCascade_skippedForPostgres(t *testing.T) {
+	srv, dbName := seedCascadeConsole(t, nil)
+	// Stamp the index as PostgreSQL-sourced (DialectForIndex reads stream_state.flavor).
+	testutil.MustExec(t, srv.cm.boot.db,
+		`INSERT INTO stream_state (id, mode, flavor, last_checkpoint, server_id)
+		 VALUES (1, 'gtid', 'postgres', UTC_TIMESTAMP(), 1)
+		 ON DUPLICATE KEY UPDATE flavor='postgres'`)
+
+	rec, body := doReq(t, srv, "POST", "/api/recover", `{"schema":"`+dbName+`","table":"parent"}`)
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, body = %s", rec.Code, body)
+	}
+	var resp recoverResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("decode: %v (body=%s)", err, body)
+	}
+	if resp.CascadeDetected {
+		t.Errorf("cascade auto-detection must be skipped for a PG-flavored index")
+	}
+	if strings.Contains(resp.SQL, "SET FOREIGN_KEY_CHECKS=0;") {
+		t.Errorf("PG recover should not emit the MySQL cascade FK-checks wrapper\n---\n%s", resp.SQL)
+	}
+}
+
 // TestIntegrationRecoverCascade_refusedUnderProfile: an active redact/deny
 // profile both flips the capability to false and makes the endpoint 403 (cascade
 // victim synthesis cannot honor redaction — the leak guard).

--- a/internal/console/recover_cascade_test.go
+++ b/internal/console/recover_cascade_test.go
@@ -7,9 +7,30 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/dbtrail/dbtrail/internal/event"
 	"github.com/dbtrail/dbtrail/internal/metadata"
 	"github.com/dbtrail/dbtrail/internal/query"
 )
+
+// TestRowsContainDeleteOn locks the auto-cascade gate's delete precondition: a
+// recover only routes to cascade synthesis when the matched rows actually contain
+// a DELETE on the target table (an INSERT/UPDATE undo never cascades).
+func TestRowsContainDeleteOn(t *testing.T) {
+	rows := []query.ResultRow{
+		{TableName: "orders", EventType: event.EventInsert},
+		{TableName: "orders", EventType: event.EventUpdate},
+	}
+	if rowsContainDeleteOn(rows, "orders") {
+		t.Error("no DELETE present → want false")
+	}
+	rows = append(rows, query.ResultRow{TableName: "orders", EventType: event.EventDelete})
+	if !rowsContainDeleteOn(rows, "orders") {
+		t.Error("a DELETE on orders → want true")
+	}
+	if rowsContainDeleteOn(rows, "customers") {
+		t.Error("the DELETE is on orders, not customers → want false")
+	}
+}
 
 // TestRecoverCascade_validation covers the request-validation branches that
 // reject before any DB work — so a nil-DB boot server is enough.

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -151,76 +151,47 @@ try {
     ? ok("form: advanced section expanded for a BYO-index entry")
     : bad("form: advanced section expanded for a BYO-index entry", "collapsed — the byoIndex open-arm regressed");
 
-  // Scenario 6 — Cascade recovery tab (#580). The class/[data-capability] gating
-  // bug class is invisible to Go tests, so pin it here: the nav item + ⌘K entry
-  // appear when recover_cascade is on (free tier, true here — no RBAC profile),
-  // the tab renders its parent form, and — critically — both the nav item HIDES
-  // and the route REDIRECTS to overview when the capability is off.
+  // Scenario 6 — Recover/Cascade merge. Cascade recovery is no longer a separate
+  // tab: it is auto-detected inside the single Recover flow (the backend routes by
+  // detection and folds the invisible children into one script when the target is
+  // an FK parent). Pin the REMOVAL here — a stray cascade nav item, route, palette
+  // entry, or render function would be a merge regression — and confirm Recover is
+  // the sole Resolve tab and still renders its form.
   await page.evaluate(() => closeServersModal());
-  const casc = await page.evaluate(() => {
-    const navItem = document.querySelector('.nav-item[data-route="cascade"]');
+  const merged = await page.evaluate(() => {
     const cmds = (typeof cmdkCommands === "function") ? cmdkCommands().map((c) => c.label) : [];
     return {
-      capOn: typeof capsCache !== "undefined" && !!capsCache.recover_cascade,
-      navPresent: !!navItem,
-      navVisible: navItem ? getComputedStyle(navItem).display !== "none" : false,
-      inPalette: cmds.includes("Cascade recovery"),
+      cascadeNavGone: !document.querySelector('.nav-item[data-route="cascade"]'),
+      cascadeNotInPalette: !cmds.includes("Cascade recovery"),
+      cascadeRouteGone: typeof ROUTES !== "undefined" ? !ROUTES.includes("cascade") : true,
+      recoverNavPresent: !!document.querySelector('.nav-item[data-route="recover"]'),
+      renderCascadeGone: typeof renderCascade === "undefined",
     };
   });
-  casc.capOn ? ok("cascade: recover_cascade capability reported") : bad("cascade: recover_cascade capability reported", "false — expected true (no RBAC profile)");
-  casc.navPresent ? ok("cascade: nav item present") : bad("cascade: nav item present", "missing from DOM");
-  casc.navVisible ? ok("cascade: nav item visible when capability on") : bad("cascade: nav item visible when capability on", "hidden despite cap-on");
-  casc.inPalette ? ok("cascade: command-palette entry present") : bad("cascade: command-palette entry present", "missing");
+  merged.cascadeNavGone ? ok("merge: cascade nav item removed") : bad("merge: cascade nav item removed", "still present — merge regression");
+  merged.cascadeNotInPalette ? ok("merge: cascade command-palette entry removed") : bad("merge: cascade command-palette entry removed", "still present");
+  merged.cascadeRouteGone ? ok("merge: /cascade route removed from ROUTES") : bad("merge: /cascade route removed from ROUTES", "still routable");
+  merged.recoverNavPresent ? ok("merge: Recover is the sole Resolve tab") : bad("merge: Recover is the sole Resolve tab", "recover nav missing");
+  merged.renderCascadeGone ? ok("merge: renderCascade function removed") : bad("merge: renderCascade function removed", "still defined");
 
-  await page.evaluate(() => navigate("cascade"));
-  await page.waitForSelector("#cascade-form", { timeout: 5000 });
-  const cform = await page.evaluate(() => {
-    const f = document.getElementById("cascade-form");
+  await page.evaluate(() => navigate("recover"));
+  await page.waitForSelector("#recover-form", { timeout: 5000 });
+  const rform = await page.evaluate(() => {
+    const f = document.getElementById("recover-form");
     if (!f) return { form: false };
-    const btn = Array.from(f.querySelectorAll("button")).find((b) => /Generate cascade recovery SQL/.test(b.textContent));
     return {
       form: true,
-      onRoute: location.pathname === "/cascade",
+      onRoute: location.pathname === "/recover",
       schema: !!f.querySelector('[name="schema"]'),
       table: !!f.querySelector('[name="table"]'),
       pk: !!f.querySelector('[name="pk"]'),
-      allowInc: !!f.querySelector('[name="allow_incomplete"]'),
-      genBtn: !!btn,
-      warnings: !!document.getElementById("cascade-warnings"),
+      noCascadeForm: !document.getElementById("cascade-form"),
     };
   });
-  cform.form ? ok("cascade: form renders on the tab") : bad("cascade: form renders on the tab", "#cascade-form missing");
-  cform.onRoute ? ok("cascade: navigates to /cascade") : bad("cascade: navigates to /cascade", "wrong route");
-  (cform.schema && cform.table && cform.pk) ? ok("cascade: parent schema/table/pk fields present") : bad("cascade: parent schema/table/pk fields present", JSON.stringify(cform));
-  cform.allowInc ? ok("cascade: allow-incomplete checkbox present") : bad("cascade: allow-incomplete checkbox present", "missing");
-  cform.genBtn ? ok("cascade: generate action present") : bad("cascade: generate action present", "button missing");
-  cform.warnings ? ok("cascade: warnings container present") : bad("cascade: warnings container present", "missing");
-
-  const off = await page.evaluate(() => {
-    capsCache.recover_cascade = false;
-    // Re-apply the same cap-on toggle gateCapabilities() runs (without refetching,
-    // which would reset the flag) — this is the exact class gating under test.
-    document.querySelectorAll("[data-capability]").forEach((n) => n.classList.toggle("cap-on", !!capsCache[n.dataset.capability]));
-    const navItem = document.querySelector('.nav-item[data-route="cascade"]');
-    const navHidden = navItem ? getComputedStyle(navItem).display === "none" : false;
-    // (a) navigate() guard: navigating to a gated route bounces to overview.
-    navigate("cascade");
-    const navGuard = location.pathname === "/overview";
-    // (b) renderCascade's OWN replaceState self-guard. A direct dispatch — a
-    // bookmarked/typed /cascade URL, Back/popstate, or boot — reaches renderRoute
-    // WITHOUT navigate()'s guard, so the in-render guard is the sole defense there.
-    // Force /cascade and call renderCascade directly: it must redirect AND render
-    // no form (deleting that guard would leave this the only failing assertion).
-    history.replaceState({}, "", "/cascade");
-    renderCascade({});
-    const renderGuard = location.pathname === "/overview" && !document.getElementById("cascade-form");
-    capsCache.recover_cascade = true; // restore for any later scenarios
-    document.querySelectorAll("[data-capability]").forEach((n) => n.classList.toggle("cap-on", !!capsCache[n.dataset.capability]));
-    return { navHidden, navGuard, renderGuard };
-  });
-  off.navHidden ? ok("cascade: nav item hides when capability off") : bad("cascade: nav item hides when capability off", "still visible — gating regression");
-  off.navGuard ? ok("cascade: navigate() guard redirects to overview when off") : bad("cascade: navigate() guard redirects to overview when off", "did not redirect");
-  off.renderGuard ? ok("cascade: renderCascade self-guard redirects direct/popstate entry when off") : bad("cascade: renderCascade self-guard redirects direct/popstate entry when off", "form rendered or no redirect — the in-render guard gap");
+  rform.form ? ok("merge: recover form renders") : bad("merge: recover form renders", "#recover-form missing");
+  rform.onRoute ? ok("merge: navigates to /recover") : bad("merge: navigates to /recover", "wrong route");
+  (rform.schema && rform.table && rform.pk) ? ok("merge: recover schema/table/pk fields present") : bad("merge: recover schema/table/pk fields present", JSON.stringify(rform));
+  rform.noCascadeForm ? ok("merge: no standalone cascade form remains") : bad("merge: no standalone cascade form remains", "#cascade-form still present");
 
   // Scenario 7 — PostgreSQL replication-health panel (#599). pgHealthCard is the
   // load-bearing anti-silent-failure surface: a frozen snapshot over a stopped daemon


### PR DESCRIPTION
## What

Cascade recovery is no longer a separate console tab the operator has to know to visit — it is **auto-detected inside the single Recover flow**. Undoing a `DELETE` on a foreign-key parent whose children InnoDB cascade-deleted *below* the binlog (MySQL Bug #32506) is a **property of the data**, not a mode the user should pick.

## How it works

`handleRecover` fetches the matched rows as before, then — for a **MySQL/MariaDB** index, when a single table is in scope and the matched rows contain a `DELETE` on it — does one cheap `fk_constraints` lookup to check whether that table is a cascade parent. If so it synthesizes the invisible children and folds them into **one script**: the base reversal **plus** the children `INSERT`s and `SET NULL` restores, wrapped in `SET FOREIGN_KEY_CHECKS=0/1`. The response carries `cascade_detected` / `victim_count` / `set_null_count`, and a **CASCADE detected** banner surfaces them.

The combined emit composes base rows (merged live+archive, RBAC-redacted) with **children-only** synthesized victims, so the parent is re-inserted **exactly once** (asserted in tests: `Count(parent)==1 && Count(child)==2`). The synthesis keeps its existing live-only fetch + archive-coverage caveats + Phase-2 baseline fallback — extracted into a shared `synthesizeCascade` helper that the explicit `POST /api/recover-cascade` endpoint now also calls (legacy SQL stays **byte-identical**, confirmed by the unchanged `cascaderecover` unit tests + the 4 pre-existing integration tests).

## Guards (beyond the ask)

- **PostgreSQL indexes are skipped**: logical replication captures cascade deletes as real events (no blind spot — firing would only show a misleading "0 victims" banner).
- **Under an RBAC redaction profile**, synthesis stays disabled (it cannot honor column redaction → would leak), but the parent-only recover now **WARNS** that children are not included — never a silent partial restore.

## Scope decisions (please confirm if you meant otherwise)

1. **CLI `recover-cascade` and the standalone `POST /api/recover-cascade` are unchanged** — they remain the scriptable interface with explicit `--lookback`/`--max-depth` knobs and exit codes. The friction raised was the *console UI*.
2. **The console path uses the engine defaults** (lookback 30d / depth 5) — the cascade knobs were removed from the UI on purpose: the friction this removes is making the operator know their FK topology, not making them tune parameters.

## Frontend

Removed the Cascade nav item, `/cascade` route, capability gate, command-palette entry, and `renderCascade`/`runCascade`; Recover renders the cascade banner instead.

## Validation

- `go build ./...` + `go vet` (incl. `-tags integration`): clean
- Unit (`console` + `cascaderecover`): PASS
- **8 integration tests** — 5 new (`autoCascade` end-to-end, skip-non-parent, RBAC-warn, skip-Postgres, SET NULL) + 4 legacy: PASS
- `node --check` on `app.js`: OK
- **Full browser e2e: 29/29** (incl. 9 `merge:` assertions + "no uncaught JS errors")

> Note: the browser e2e caught a real bug during development — a missing `)` in the new banner that, in a classic-script SPA, killed the entire frontend. Fixed; the render-check now passes clean.

## Docs

`docs/console.md` updated (tab list, Cascade-recovery section, API table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)