### PR TITLE
test: unflake the two PG-15 integration tests blocking the merge queue (#607)

### DIFF
--- a/internal/pgcapture/capturer_integration_test.go
+++ b/internal/pgcapture/capturer_integration_test.go
@@ -99,14 +99,24 @@ func TestCapturer_Integration(t *testing.T) {
 	go func() { runErr <- cap.Run(runCtx, events) }()
 
 	// Wait until the slot is active (Run has started replication) before any DML, so
-	// every change below is within the captured range.
+	// every change below is within the captured range. `active` alone is not enough:
+	// a slot can be active=true while confirmed_flush_lsn is still NULL (the slot is
+	// acquired but confirmed_flush_lsn is not yet visible — it is populated from the
+	// consumer's standby feedback, initially the slot's consistent point), and
+	// confirmedFlush below
+	// scans confirmed_flush_lsn::text into a string — NULL then errors "cannot scan
+	// NULL into *string". That NULL window's timing is PG-version-sensitive (it bit
+	// PG 15). Gate on a non-NULL confirmed_flush_lsn so the baseline is the real
+	// consistent point.
 	waitFor(t, 10*time.Second, func() bool {
-		var active bool
-		if err := setup.QueryRow(ctx, "SELECT active FROM pg_replication_slots WHERE slot_name=$1", slot).Scan(&active); err != nil {
+		var active, hasFlush bool
+		if err := setup.QueryRow(ctx,
+			"SELECT active, confirmed_flush_lsn IS NOT NULL FROM pg_replication_slots WHERE slot_name=$1",
+			slot).Scan(&active, &hasFlush); err != nil {
 			return false
 		}
-		return active
-	}, "replication slot to become active")
+		return active && hasFlush
+	}, "replication slot active with a confirmed_flush_lsn")
 
 	baseline := confirmedFlush(t, setup, slot) // ≈ the slot's consistent point
 

--- a/internal/pgstreamrun/pgstreamrun_integration_test.go
+++ b/internal/pgstreamrun/pgstreamrun_integration_test.go
@@ -356,16 +356,37 @@ func TestOne_LostSlotResume_PersistsLossBadge(t *testing.T) {
 	}, "replication slot active")
 	mustExec(fmt.Sprintf("INSERT INTO %s VALUES (1, 'a')", tbl))
 	waitFor(t, 15*time.Second, func() bool {
-		var n int
-		if err := indexDB.QueryRow("SELECT COUNT(*) FROM binlog_events WHERE table_name = ?", tbl).Scan(&n); err != nil {
-			return false
+		// The resume path needs a DURABLE checkpoint, not just a flushed row. Polling
+		// binlog_events was the #607 race: checkpoint() runs flush() (row → binlog_events)
+		// but only calls saveCheckpointPG when lastCommitLSN != 0, so a ticker flush can
+		// land the row while the COMMIT is still undrained (lastCommitLSN == 0) — the row
+		// appears before any checkpoint exists. A resume then finds no prior cursor and
+		// never returns ErrSlotMissingOnResume. binlog_position (the commit LSN) is written
+		// ONLY by saveCheckpointPG, so a non-zero value is the real "resumable cursor
+		// durable" signal, and it is deterministic across PG versions.
+		var pos uint64
+		if err := indexDB.QueryRow("SELECT binlog_position FROM stream_state WHERE id = 1").Scan(&pos); err != nil {
+			return false // no row yet → keep waiting
 		}
-		return n >= 1 // a flush happened → a checkpoint row exists in stream_state
-	}, "first row indexed (checkpoint saved)")
+		return pos > 0
+	}, "first checkpoint persisted (resumable cursor durable)")
 	cancel()
 	if err := <-runErr; err != nil {
 		t.Fatalf("first run returned error: %v", err)
 	}
+
+	// One has returned, but PostgreSQL clearing the slot's active_pid (the walsender
+	// backend exiting) lags the client's clean Terminate — and that lag varies by PG
+	// version. Without this gate, the pg_drop_replication_slot below races the backend
+	// exit and errors 55006 "replication slot is active for PID" on PG 15/16 (it passed
+	// on 14/17): the #607 flake. Wait for the slot to go inactive before dropping it.
+	waitFor(t, 15*time.Second, func() bool {
+		var active bool
+		if err := pg.QueryRow(ctx, "SELECT active FROM pg_replication_slots WHERE slot_name=$1", slot).Scan(&active); err != nil {
+			return false // slot row must still exist here (not dropped yet); transient → keep waiting
+		}
+		return !active
+	}, "replication slot inactive (walsender backend exited)")
 
 	// ── Drop the slot: the WAL behind the saved checkpoint is now gone. ──
 	mustExec(fmt.Sprintf("SELECT pg_drop_replication_slot('%s')", slot))


### PR DESCRIPTION
closes #607

## Context

`integration-postgres-source (15)` was red on `main`, forcing `--admin` merges (PR #606). The CI logs showed **two co-occurring flaky tests on PG 15** — fixing only the one #607 names leaves PG-15 red, and #607's acceptance criterion is literally "PG-15 green, no `--admin`". So this PR fixes both. Both are test-only timing races; production code is untouched.

## Fix 1 — `TestOne_LostSlotResume_PersistsLossBadge` (the named #607 test)

CI signature: `pg_drop_replication_slot ... ERROR: replication slot is active for PID (55006)` at the slot drop. After the first run's `One` returns, the client has cleanly terminated, but PostgreSQL clearing the slot's `active_pid` (the walsender backend exiting) lags that EOF, version-dependently. The immediate drop raced the backend exit.

- **Primary fix:** gate the drop on `pg_replication_slots.active` going false before `pg_drop_replication_slot`.
- **Secondary hardening (kept per review):** the first-run precondition waited on the `binlog_events` row, assuming "flush ⇒ checkpoint saved" — false (`checkpoint()` runs `flush()` but only calls `saveCheckpointPG` when `lastCommitLSN != 0`). Gate instead on `stream_state.binlog_position > 0` (the commit LSN, written only by `saveCheckpointPG`).

✅ Confirmed on CI run `28238012310`: this test now **PASSes on PG 14/15/16/17**.

## Fix 2 — `TestCapturer_Integration` (the co-occurring PG-15 flake)

CI signature: `read confirmed_flush_lsn: cannot scan NULL into *string`. The precondition waited only for the slot to be `active`, then read `confirmed_flush_lsn` as the baseline — but a slot can be `active=true` with `confirmed_flush_lsn` still NULL (walsender attached, no flush position reported yet). NULL-window timing is PG-version-sensitive (bit PG 15). Gate the precondition on `confirmed_flush_lsn IS NOT NULL` so the baseline is the real consistent point.

## Review
4-agent review on Fix 1 (code / test-quality / comment-accuracy / silent-failure). The **test-quality agent read the CI logs and caught that the original single-fix diagnosis was incomplete** (the real failure was the slot-active drop race, not the checkpoint race) — primary-source evidence corrected the fix. Fix 2 was surfaced by watching the PR's own CI: with Fix 1 in, PG-15 went from red to red-for-a-different-reason, exposing the second flake.

## Test plan
- [x] Both packages compile under the integration tag (`go vet -tags integration ./internal/pgcapture/ ./internal/pgstreamrun/`)
- [x] Unit tests pass (`go test ./... -count=1` — 35 packages ok)
- [x] Fix 1 test PASSes on PG 14/15/16/17 (CI run 28238012310)
- [ ] Full `integration-postgres-source (14/15/16/17)` green with BOTH fixes (CI run 28238635641, in progress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)