### PR TITLE
fix(baseline): fail loud on INSERT/REPLACE without VALUES (#468 shape 1)

### DIFF
--- a/internal/baseline/baseline_test.go
+++ b/internal/baseline/baseline_test.go
@@ -671,6 +671,63 @@ func TestReadSQLRowTruncated(t *testing.T) {
 	}
 }
 
+func TestReadSQLRowTruncatedBeforeValues(t *testing.T) {
+	// #468 shape 1: a dump truncated mid-INSERT-header — the last physical line
+	// opens an INSERT/REPLACE but the truncation cut it off BEFORE the VALUES
+	// keyword. Pre-fix the reader `continue`d past it and exited cleanly with a
+	// short row count (silent data loss → wrong Time-travel reconstructions).
+	// It must now fail loudly. The preceding complete INSERT is intact.
+	cases := map[string]string{
+		"insert-header-only":      "INSERT INTO `orders` VALUES(1,'a');\nINSERT INTO `orders` (`id`,`na",
+		"replace-header-only":     "REPLACE INTO `orders` VALUES(1,'a');\nREPLACE INTO `orders` (`id`,`co",
+		"values-on-next-line":     "INSERT INTO `orders` VALUES(1,'a');\nINSERT INTO `orders` (`id`,`name`)\nVALUES(2,'b');\n",
+		"truncated-as-first-stmt": "INSERT INTO `orders` (`id`,`na",
+	}
+	for name, sqlData := range cases {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "shop.orders.00000.sql")
+			if err := os.WriteFile(path, []byte(sqlData), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			var count int
+			err := ReadSQLFile(path, func(values []string, nulls []bool) error {
+				count++
+				return nil
+			})
+			if err == nil {
+				t.Fatalf("expected error for INSERT/REPLACE without VALUES, got nil (parsed %d rows)", count)
+			}
+			if !strings.Contains(err.Error(), "VALUES") {
+				t.Errorf("error = %v, want it to mention the missing VALUES clause", err)
+			}
+		})
+	}
+}
+
+func TestReadSQLRowValuesAtLineEndStillParses(t *testing.T) {
+	// Guard against over-firing the shape-1 truncation check: the supported
+	// mydumper layout where VALUES ends the header line (tuples follow on
+	// continuation lines) keeps VALUES on the INSERT line, so it must NOT be
+	// mistaken for a truncated header.
+	const sqlData = "INSERT INTO `t` VALUES\n(1),\n(2),\n(3);\n"
+	dir := t.TempDir()
+	path := filepath.Join(dir, "shop.t.00000.sql")
+	if err := os.WriteFile(path, []byte(sqlData), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var ids []string
+	if err := ReadSQLFile(path, func(values []string, nulls []bool) error {
+		ids = append(ids, values[0])
+		return nil
+	}); err != nil {
+		t.Fatalf("ReadSQLFile must accept VALUES-at-line-end layout: %v", err)
+	}
+	if got := strings.Join(ids, ","); got != "1,2,3" {
+		t.Errorf("ids = %q, want \"1,2,3\"", got)
+	}
+}
+
 func TestReadSQLRowMydumperBinaryJSON(t *testing.T) {
 	// Fixture is captured mydumper output (--complete-insert) for a table with
 	// VARBINARY, BLOB, BIT, and JSON columns holding adversarial bytes (',' ')'

--- a/internal/baseline/baseline_test.go
+++ b/internal/baseline/baseline_test.go
@@ -672,11 +672,15 @@ func TestReadSQLRowTruncated(t *testing.T) {
 }
 
 func TestReadSQLRowTruncatedBeforeValues(t *testing.T) {
-	// #468 shape 1: a dump truncated mid-INSERT-header — the last physical line
-	// opens an INSERT/REPLACE but the truncation cut it off BEFORE the VALUES
-	// keyword. Pre-fix the reader `continue`d past it and exited cleanly with a
-	// short row count (silent data loss → wrong Time-travel reconstructions).
-	// It must now fail loudly. The preceding complete INSERT is intact.
+	// #468 shape 1 + the adjacent unsupported layout: the reader must fail
+	// loudly when an INSERT/REPLACE opening line carries no VALUES clause —
+	// whether because the dump was truncated mid-header (the header/first-stmt
+	// cases) or because VALUES was wrapped onto a continuation line (the
+	// values-on-next-line case, an unsupported layout, not truncation). Pre-fix
+	// the reader `continue`d past it and exited cleanly with a short row count
+	// (silent data loss → wrong Time-travel reconstructions). Cases with a
+	// preceding complete INSERT leave it intact; truncated-as-first-stmt has no
+	// preceding statement.
 	cases := map[string]string{
 		"insert-header-only":      "INSERT INTO `orders` VALUES(1,'a');\nINSERT INTO `orders` (`id`,`na",
 		"replace-header-only":     "REPLACE INTO `orders` VALUES(1,'a');\nREPLACE INTO `orders` (`id`,`co",

--- a/internal/baseline/reader_sql.go
+++ b/internal/baseline/reader_sql.go
@@ -64,7 +64,18 @@ func ReadSQLFile(path string, fn func(values []string, nulls []bool) error) erro
 			// Find VALUES keyword (after any column list).
 			valIdx := strings.Index(upper, " VALUES")
 			if valIdx < 0 {
-				continue
+				// The line opens an INSERT/REPLACE but carries no VALUES clause.
+				// In a complete mydumper/mysqldump data file every INSERT/REPLACE
+				// statement has VALUES on this same line — so this is a truncated
+				// statement (a partial trailing line, #468 shape 1) or an
+				// unsupported layout (VALUES wrapped to a continuation line).
+				// Silently `continue`ing past it drops every row the statement
+				// carried with a clean exit and a short count — the #461 silent
+				// data-loss class at row granularity. Fail loud, matching the
+				// unterminated-INSERT guard below.
+				return fmt.Errorf("%s line %d: INSERT/REPLACE statement without a VALUES clause "+
+					"— dump file may be truncated or in an unsupported layout: %q",
+					path, lineNum, truncateForError(trimmed))
 			}
 			fragment = strings.TrimSpace(trimmed[valIdx+7:])
 		}
@@ -84,6 +95,16 @@ func ReadSQLFile(path string, fn func(values []string, nulls []bool) error) erro
 		return fmt.Errorf("%s: unterminated INSERT statement (missing ';') — dump file may be truncated", path)
 	}
 	return nil
+}
+
+// truncateForError caps a line excerpt used in an error message so a long
+// (but truncated) INSERT doesn't flood the log with the whole statement.
+func truncateForError(s string) string {
+	const max = 80
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "…"
 }
 
 // parseSQLTuples parses a fragment of an INSERT's values portion:


### PR DESCRIPTION
## What

`internal/baseline/reader_sql.go` `ReadSQLFile` silently `continue`d past an `INSERT`/`REPLACE` line that lacked a ` VALUES` clause. Two truncation shapes hit this and produced a **clean exit with fewer rows than the dump contained** (issue #468):

- a dump truncated to a partial trailing line that opens `INSERT ... (` but is cut off **before** `VALUES`;
- (also caught) a statement whose `VALUES` wrapped onto a continuation line — an unsupported layout that was previously dropping the row silently.

A baseline silently missing rows yields **wrong Time-travel reconstructions** — the #461 silent-data-loss class at row granularity.

## Fix

In a complete `mydumper`/`mysqldump` data file every `INSERT`/`REPLACE` statement carries `VALUES` on the **same physical line** (all six layouts in `TestReadSQLRowMultiLineLayouts`, including `values-then-tuples` where `VALUES` ends the header line, keep it there). So an `INSERT`/`REPLACE` line with no `VALUES` is a truncation or an unsupported layout — not something to skip.

The `valIdx < 0` branch now returns a loud error (with a truncated line excerpt) instead of `continue`-ing, matching the adjacent unterminated-`INSERT` guard a few lines below. The caller `baseline.Convert` (`baseline.go:290`) propagates it, so the partial snapshot never gets its `_SUCCESS` marker.

Header/comment/`SET` lines are filtered earlier by the `INSERT`/`REPLACE` prefix gate, so they are unaffected — no false positives on valid dumps.

## Tests

- `TestReadSQLRowTruncatedBeforeValues` — four truncation shapes (insert/replace header-only, VALUES-on-next-line, truncated-as-first-statement) all now error.
- `TestReadSQLRowValuesAtLineEndStillParses` — over-fire guard: the supported `INSERT ... VALUES\n(1),(2),(3);` layout still parses to 3 rows.
- Full `internal/baseline` unit + integration suites green.

## Scope

**Shape 1 of #468 only.** Shape 2 (truncation landing exactly on a tuple boundary, `...),` then EOF) is undetectable without a `mydumper`-metadata row-count cross-check and **remains tracked in #468** — this PR intentionally does not close the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)