### PR TITLE
fix(shim): surface columns dropped after AS OF in full-table time-travel (#600)

### DIFF
--- a/internal/shim/handler.go
+++ b/internal/shim/handler.go
@@ -477,8 +477,8 @@ func (h *Handler) runPointInTime(q TimeTravelQuery) (*mysql.Result, error) {
 	// SELECT * and DROPS missing-from-image columns + APPENDS image
 	// columns absent from ddlOrder (alphabetically). Both behaviours
 	// silently expand and reshuffle the user's explicit projection. The
-	// multi-row sibling imagesToResult already uses cols verbatim, so
-	// runFullTable was unaffected.
+	// multi-row path makes the same split via fullTableResult
+	// (imagesToResultVerbatim vs imagesToResult).
 	if q.Columns != nil {
 		return imageToResultVerbatim(image, q.Columns)
 	}
@@ -508,23 +508,26 @@ func imageToResultVerbatim(image map[string]any, cols []string) (*mysql.Result, 
 	return &mysql.Result{Resultset: rs}, nil
 }
 
-// effectiveColumnOrder returns the column ordering for the multi-row
-// path (runFullTable → imagesToResult). A non-nil q.Columns means the
-// user listed columns explicitly (#313); imagesToResult uses its
-// ddlOrder argument verbatim and emits NULL for missing image keys —
-// the contract this function relies on.
+// fullTableResult builds the multi-row resultset for a full-table
+// time-travel query, dispatching on the projection the user asked for —
+// the exact split the single-row path makes between imageToResult and
+// imageToResultVerbatim (see runPointInTime):
 //
-// DO NOT pass the result of this function into the single-row
-// imageToResult: that path goes through orderColumns, which is
-// designed for SELECT * and silently drops missing-from-image entries
-// while appending image-only keys alphabetically. For single-row
-// user-projection results, use imageToResultVerbatim directly (see
-// runPointInTime).
-func (h *Handler) effectiveColumnOrder(q TimeTravelQuery) []string {
+//   - explicit columns (#313, q.Columns != nil) → imagesToResultVerbatim:
+//     project verbatim onto the user's list (NULL for any column an image
+//     lacks); a column they did NOT list must not reappear. Appending
+//     image-only keys here would silently widen the user's projection.
+//   - SELECT * (q.Columns == nil) → imagesToResult: latest-snapshot order
+//     as the base, plus any image-only keys — e.g. a column dropped between
+//     AS OF and now whose value is still captured in the index (#600).
+//
+// columnOrderFor stays latest-snapshot for SELECT *: it also backs SHOW
+// TABLES and PK validation, which must reflect today's schema.
+func (h *Handler) fullTableResult(q TimeTravelQuery, images []map[string]any) (*mysql.Result, error) {
 	if q.Columns != nil {
-		return q.Columns
+		return imagesToResultVerbatim(images, q.Columns)
 	}
-	return h.columnOrderFor(q.Schema, q.Table)
+	return imagesToResult(images, h.columnOrderFor(q.Schema, q.Table))
 }
 
 // runShowTablesFromVirtual answers `SHOW [FULL] TABLES FROM
@@ -642,7 +645,7 @@ func (h *Handler) runFullTable(q TimeTravelQuery) (*mysql.Result, error) {
 	// ENUM/SET ordinals → labels per event's snapshot epoch (#472/#475),
 	// before the images are extracted.
 	h.mapEventImages(q.Schema, q.Table, rows)
-	return imagesToResult(extractFullTableImages(rows), h.effectiveColumnOrder(q))
+	return h.fullTableResult(q, extractFullTableImages(rows))
 }
 
 // extractFullTableImages picks the post-image of every non-DELETE
@@ -666,43 +669,40 @@ func extractFullTableImages(rows []query.ResultRow) []map[string]any {
 	return images
 }
 
-// imagesToResult is the multi-row sibling of imageToResult. The
-// column list is computed once for the whole resultset so every row
-// in the wire resultset has the same shape, with NULL where a row's
-// image is missing a column.
-//
-// Column selection is snapshot-driven when possible: ddlOrder (taken
-// from the latest schema_snapshots row) is used verbatim when
-// present, even if no image carries every column — missing values
-// become NULL on the wire, matching how MySQL itself returns rows
-// from a table that was ALTER'd to add a column. When ddlOrder is
-// empty (no resolved snapshot for this table — first install, or
-// a snapshot that doesn't cover this schema/table), we fall back
-// to the *union* of every image's keys (sorted) — using the first
-// image alone would silently elide columns that appeared only in
-// later events of the same query.
+// imagesToResult is the SELECT * multi-row sibling of imageToResult. The
+// column list is computed once (by fullTableColumns: latest-snapshot order
+// plus any image-only keys, #600) for the whole resultset so every row in
+// the wire resultset has the same shape, with NULL where a row's image is
+// missing a column. For an explicit user projection use the verbatim sibling.
 //
 // Empty input → empty resultset.
 func imagesToResult(images []map[string]any, ddlOrder []string) (*mysql.Result, error) {
 	if len(images) == 0 {
 		return emptyResult(), nil
 	}
+	return buildImagesResult(images, fullTableColumns(images, ddlOrder))
+}
 
-	cols := ddlOrder
-	if len(cols) == 0 {
-		seen := make(map[string]struct{})
-		for _, img := range images {
-			for k := range img {
-				seen[k] = struct{}{}
-			}
-		}
-		cols = make([]string, 0, len(seen))
-		for k := range seen {
-			cols = append(cols, k)
-		}
-		sort.Strings(cols)
+// imagesToResultVerbatim is the multi-row sibling of imageToResultVerbatim:
+// it projects the images onto cols EXACTLY as given — the user's listed
+// columns (#313), in their order, with NULL for any column an image doesn't
+// carry. Unlike imagesToResult it never appends image-only keys: the user
+// asked for precisely these columns, so a column they did not list (e.g. one
+// dropped after the AS OF instant) must not reappear.
+//
+// Empty input → empty resultset.
+func imagesToResultVerbatim(images []map[string]any, cols []string) (*mysql.Result, error) {
+	if len(images) == 0 {
+		return emptyResult(), nil
 	}
+	return buildImagesResult(images, cols)
+}
 
+// buildImagesResult assembles the wire resultset: one row per image, each
+// projected onto cols (missing key → NULL). Shared by imagesToResult and
+// imagesToResultVerbatim so projection and serialization are identical; only
+// the column-derivation policy differs between the two callers.
+func buildImagesResult(images []map[string]any, cols []string) (*mysql.Result, error) {
 	values := make([][]any, len(images))
 	for i, img := range images {
 		row := make([]any, len(cols))
@@ -717,6 +717,81 @@ func imagesToResult(images []map[string]any, ddlOrder []string) (*mysql.Result, 
 		return nil, fmt.Errorf("build resultset: %w", err)
 	}
 	return &mysql.Result{Resultset: rs}, nil
+}
+
+// fullTableColumns computes the column emission order for a SELECT *
+// full-table resultset. It is the multi-image relative of orderColumns:
+// both APPEND image-only keys instead of strict-projecting them away, which
+// is what fixes the #600 WHERE-clause asymmetry — adding `WHERE pk=` no
+// longer hides a since-dropped column. (Full-table is a SUPERSET of the
+// single-row column set, not strictly equal: it additionally NULL-fills
+// ddlOrder columns no image carries, e.g. a column ADDED after AS OF. The
+// two sets coincide exactly when every ddlOrder column is present in the
+// images — the reported drop case.)
+//
+// Selection is snapshot-driven when possible:
+//
+//   - ddlOrder (the latest schema_snapshots row) is the base, used
+//     verbatim — every column in it appears even if no image carries it
+//     (NULL on the wire), matching how MySQL itself returns rows from a
+//     table that was ALTER'd to ADD a column after some rows existed.
+//   - Then any image-only keys (the union across every image, sorted)
+//     are APPENDED. These are columns present in the captured row images
+//     but absent from the latest snapshot — most importantly a column
+//     DROPPED between the AS OF instant and now. Its value is still in
+//     the index; strict-projecting onto ddlOrder alone (the pre-#600
+//     behavior) silently hid it. Appending surfaces it instead, exactly
+//     as the single-row path (orderColumns) already does.
+//   - When ddlOrder is empty (no resolved snapshot for this table —
+//     first install, or a snapshot that doesn't cover this schema/table),
+//     we fall back to the union of every image's keys (sorted) — using
+//     the first image alone would silently elide columns that appeared
+//     only in later events of the same query.
+//
+// No-drift equivalence: when no schema change spans the query window,
+// every image key is already in ddlOrder, so nothing is appended and the
+// column list is byte-identical to the pre-#600 ddlOrder-verbatim output.
+//
+// Pure function — extracted so the ordering rules can be unit-tested
+// without spinning up MySQL (mirrors orderColumns).
+func fullTableColumns(images []map[string]any, ddlOrder []string) []string {
+	if len(ddlOrder) == 0 {
+		seen := make(map[string]struct{})
+		for _, img := range images {
+			for k := range img {
+				seen[k] = struct{}{}
+			}
+		}
+		cols := make([]string, 0, len(seen))
+		for k := range seen {
+			cols = append(cols, k)
+		}
+		sort.Strings(cols)
+		return cols
+	}
+
+	inDDL := make(map[string]struct{}, len(ddlOrder))
+	for _, c := range ddlOrder {
+		inDDL[c] = struct{}{}
+	}
+	extraSet := make(map[string]struct{})
+	for _, img := range images {
+		for k := range img {
+			if _, ok := inDDL[k]; !ok {
+				extraSet[k] = struct{}{}
+			}
+		}
+	}
+	if len(extraSet) == 0 {
+		return ddlOrder
+	}
+	extras := make([]string, 0, len(extraSet))
+	for k := range extraSet {
+		extras = append(extras, k)
+	}
+	sort.Strings(extras)
+	// Fresh slice — never append into the caller's ddlOrder backing array.
+	return append(append([]string{}, ddlOrder...), extras...)
 }
 
 // validatePKColumn rejects time-travel queries whose WHERE column

--- a/internal/shim/handler.go
+++ b/internal/shim/handler.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -790,8 +791,9 @@ func fullTableColumns(images []map[string]any, ddlOrder []string) []string {
 		extras = append(extras, k)
 	}
 	sort.Strings(extras)
-	// Fresh slice — never append into the caller's ddlOrder backing array.
-	return append(append([]string{}, ddlOrder...), extras...)
+	// slices.Concat allocates a fresh slice — never append into the caller's
+	// ddlOrder backing array (it comes from a cached resolver and is shared).
+	return slices.Concat(ddlOrder, extras)
 }
 
 // validatePKColumn rejects time-travel queries whose WHERE column

--- a/internal/shim/handler_test.go
+++ b/internal/shim/handler_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"net"
 	"slices"
 	"strings"
@@ -940,6 +941,143 @@ func TestImagesToResultBuildsResultset(t *testing.T) {
 				t.Errorf("cols = %v, want %v", gotCols, tc.wantCols)
 			}
 		})
+	}
+}
+
+// TestFullTableColumns pins the #600 fix: the full-table column list
+// keeps ddlOrder verbatim (NULL-filling columns no image carries) AND
+// appends image-only keys (sorted) — most importantly a column dropped
+// between the AS OF instant and now, whose value is still in the index.
+func TestFullTableColumns(t *testing.T) {
+	cases := []struct {
+		name     string
+		images   []map[string]any
+		ddlOrder []string
+		want     []string
+	}{
+		{
+			// The reported bug: coupon_code was DROPPED after AS OF, so the
+			// latest snapshot (ddlOrder) is [id,total] but the captured image
+			// still carries coupon_code. Pre-#600 it was strict-projected away.
+			name:     "dropped_column_appended",
+			images:   []map[string]any{{"id": 1, "total": 100, "coupon_code": "SAVE10"}},
+			ddlOrder: []string{"id", "total"},
+			want:     []string{"id", "total", "coupon_code"},
+		},
+		{
+			// No schema drift across the window → byte-identical to ddlOrder.
+			name:     "no_drift_is_identity",
+			images:   []map[string]any{{"id": 1, "sku": "A", "qty": 3}},
+			ddlOrder: []string{"id", "sku", "qty"},
+			want:     []string{"id", "sku", "qty"},
+		},
+		{
+			// ddlOrder column absent from every image is still emitted (NULL on
+			// the wire) — the ADD-column-after semantics locked by
+			// TestImagesToResultDDLOrderStrictWhenSnapshotPresent. The fix must
+			// not regress this: it only APPENDS, never intersects.
+			name:     "missing_ddl_column_retained_plus_extra_appended",
+			images:   []map[string]any{{"id": 1, "coupon_code": "SAVE10"}},
+			ddlOrder: []string{"id", "total"},
+			want:     []string{"id", "total", "coupon_code"},
+		},
+		{
+			// Extras are the UNION across images, deduped and sorted — a column
+			// appearing only in a later event must not be dropped.
+			name: "extras_union_across_images_sorted",
+			images: []map[string]any{
+				{"id": 1, "zeta": 1},
+				{"id": 2, "alpha": 2},
+				{"id": 3, "zeta": 3},
+			},
+			ddlOrder: []string{"id"},
+			want:     []string{"id", "alpha", "zeta"},
+		},
+		{
+			// No resolved snapshot → union of all image keys, sorted.
+			name: "no_ddlorder_unions_image_keys",
+			images: []map[string]any{
+				{"id": 1, "sku": "A"},
+				{"id": 2, "sku": "B", "added": "X"},
+			},
+			ddlOrder: nil,
+			want:     []string{"added", "id", "sku"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := fullTableColumns(tc.images, tc.ddlOrder)
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("fullTableColumns = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFullTableColumnsDoesNotMutateDDLOrder guards the append-into-caller
+// hazard: ddlOrder is shared (it comes from a cached resolver), so appending
+// extras must allocate a fresh slice, never scribble into ddlOrder's backing
+// array.
+func TestFullTableColumnsDoesNotMutateDDLOrder(t *testing.T) {
+	ddlOrder := make([]string, 2, 8) // spare capacity → append would reuse it
+	ddlOrder[0], ddlOrder[1] = "id", "total"
+	_ = fullTableColumns([]map[string]any{{"id": 1, "coupon_code": "X"}}, ddlOrder)
+	if !slices.Equal(ddlOrder, []string{"id", "total"}) {
+		t.Errorf("ddlOrder was mutated to %v; must stay [id total]", ddlOrder)
+	}
+}
+
+// TestFullTableColumnsMatchesSingleRowColumnSet pins acceptance criterion #3
+// of #600 (asymmetry gone) at the pure-function level for the REPORTED drop
+// case: when the image carries every latest-snapshot column plus a
+// since-dropped one, the full-table column SET equals the single-row
+// (orderColumns) set — so adding/removing a `WHERE pk=` never hides the
+// dropped column. (The two are not equal in general: full-table is a superset
+// that also NULL-fills snapshot columns no image carries — see
+// fullTableColumns' doc. Here every ddlOrder column is in the image, so the
+// superset collapses to equality.)
+func TestFullTableColumnsMatchesSingleRowColumnSet(t *testing.T) {
+	image := map[string]any{"id": 1, "total": 100, "coupon_code": "SAVE10"}
+	ddlOrder := []string{"id", "total"} // coupon_code dropped from latest snapshot
+
+	full := fullTableColumns([]map[string]any{image}, ddlOrder)
+	single := orderColumns(image, ddlOrder)
+
+	fullSet, singleSet := map[string]bool{}, map[string]bool{}
+	for _, c := range full {
+		fullSet[c] = true
+	}
+	for _, c := range single {
+		singleSet[c] = true
+	}
+	if !maps.Equal(fullSet, singleSet) {
+		t.Errorf("column set mismatch: full-table=%v single-row=%v", full, single)
+	}
+}
+
+// TestImagesToResultVerbatimNeverAppendsExtras pins the explicit-projection
+// contract: imagesToResultVerbatim projects onto cols EXACTLY, NULL-filling
+// missing keys and never surfacing an image-only key the user didn't list.
+// This is the multi-row counterpart of imageToResultVerbatim and the builder
+// fullTableResult routes #313 projections to.
+func TestImagesToResultVerbatimNeverAppendsExtras(t *testing.T) {
+	images := []map[string]any{
+		{"id": 1, "total": 100, "coupon_code": "SAVE10"}, // carries an off-projection key
+		{"id": 2, "total": 200},                          // missing nothing the user asked for
+	}
+	res, err := imagesToResultVerbatim(images, []string{"id", "total"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotCols := make([]string, len(res.Resultset.Fields))
+	for i, f := range res.Resultset.Fields {
+		gotCols[i] = string(f.Name)
+	}
+	if want := []string{"id", "total"}; !slices.Equal(gotCols, want) {
+		t.Errorf("cols = %v, want %v (coupon_code must NOT be appended)", gotCols, want)
+	}
+	if got := len(res.Resultset.RowDatas); got != 2 {
+		t.Errorf("rows = %d, want 2", got)
 	}
 }
 
@@ -2273,11 +2411,15 @@ func TestHandleShowTablesFromVirtual(t *testing.T) {
 
 // ─── #313 column projection ───────────────────────────────────────────────────
 
-// TestEffectiveColumnOrder verifies the branch point that #313 added:
-// a non-nil q.Columns short-circuits the snapshot-driven DDL ordering
-// and returns the user's listed columns verbatim; a nil q.Columns
-// preserves the previous behaviour (delegate to columnOrderFor).
-func TestEffectiveColumnOrder(t *testing.T) {
+// TestFullTableResultProjection verifies the branch point #313 added and #600
+// re-confirmed: a non-nil q.Columns projects the user's columns VERBATIM (no
+// image-only keys appended), while a nil q.Columns (SELECT *) takes the
+// snapshot order and UNIONs image-only keys. The explicit-projection subtest
+// is the regression guard for #600: when imagesToResult began unioning extras,
+// the shared full-table path would have silently widened a user's `SELECT
+// id, name` to also include image keys they never asked for — fullTableResult
+// routes explicit projections to imagesToResultVerbatim to prevent that.
+func TestFullTableResultProjection(t *testing.T) {
 	resolverFn := func() (*metadata.Resolver, error) {
 		return metadata.NewResolverFromTables(1, map[string]*metadata.TableMeta{
 			"appdb.users": {
@@ -2295,40 +2437,52 @@ func TestEffectiveColumnOrder(t *testing.T) {
 		logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
 		resolverFn: resolverFn,
 	}
+	// Image carries every snapshot column PLUS an off-snapshot key (legacy_col)
+	// — the since-dropped-column shape from #600.
+	images := []map[string]any{
+		{"id": 1, "email": "a@x", "name": "ann", "created_at": "t0", "legacy_col": "L"},
+	}
+	cols := func(res *gomysql.Result) []string {
+		got := make([]string, len(res.Resultset.Fields))
+		for i, f := range res.Resultset.Fields {
+			got[i] = string(f.Name)
+		}
+		return got
+	}
 
-	t.Run("nil_columns_uses_ddl_order", func(t *testing.T) {
-		q := TimeTravelQuery{Schema: "appdb", Table: "users", Columns: nil}
-		got := h.effectiveColumnOrder(q)
-		want := []string{"id", "email", "name", "created_at"}
-		if !slices.Equal(got, want) {
-			t.Errorf("got %v, want %v", got, want)
+	t.Run("select_star_unions_image_only_keys", func(t *testing.T) {
+		res, err := h.fullTableResult(TimeTravelQuery{Schema: "appdb", Table: "users"}, images)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := []string{"id", "email", "name", "created_at", "legacy_col"}
+		if got := cols(res); !slices.Equal(got, want) {
+			t.Errorf("SELECT * cols = %v, want %v (snapshot order + appended off-snapshot key)", got, want)
 		}
 	})
 
-	t.Run("explicit_columns_used_verbatim", func(t *testing.T) {
-		q := TimeTravelQuery{
-			Schema: "appdb", Table: "users",
-			Columns: []string{"id", "name"}, // user-requested order
+	t.Run("explicit_projection_is_verbatim_no_extras", func(t *testing.T) {
+		q := TimeTravelQuery{Schema: "appdb", Table: "users", Columns: []string{"id", "name"}}
+		res, err := h.fullTableResult(q, images)
+		if err != nil {
+			t.Fatal(err)
 		}
-		got := h.effectiveColumnOrder(q)
 		want := []string{"id", "name"}
-		if !slices.Equal(got, want) {
-			t.Errorf("got %v, want %v", got, want)
+		if got := cols(res); !slices.Equal(got, want) {
+			t.Errorf("explicit projection cols = %v, want %v "+
+				"(must NOT append email/created_at/legacy_col — user asked for exactly these)", got, want)
 		}
 	})
 
-	t.Run("explicit_columns_can_include_unknown", func(t *testing.T) {
-		// Unknown columns surface as NULL on the wire — that's a property
-		// of imageToResultVerbatim (for single-row) and imagesToResult
-		// (for multi-row). effectiveColumnOrder just returns the slice
-		// verbatim, which the verbatim sibling then projects through.
-		q := TimeTravelQuery{
-			Schema: "appdb", Table: "users",
-			Columns: []string{"id", "deleted_column"},
+	t.Run("explicit_columns_can_include_unknown_as_null", func(t *testing.T) {
+		// A listed column absent from the image stays in the projection as NULL.
+		q := TimeTravelQuery{Schema: "appdb", Table: "users", Columns: []string{"id", "deleted_column"}}
+		res, err := h.fullTableResult(q, images)
+		if err != nil {
+			t.Fatal(err)
 		}
-		got := h.effectiveColumnOrder(q)
 		want := []string{"id", "deleted_column"}
-		if !slices.Equal(got, want) {
+		if got := cols(res); !slices.Equal(got, want) {
 			t.Errorf("got %v, want %v", got, want)
 		}
 	})

--- a/internal/shim/schema_drift_repro_integration_test.go
+++ b/internal/shim/schema_drift_repro_integration_test.go
@@ -135,6 +135,26 @@ func TestFullTableFlashback_DroppedColumn_Regression(t *testing.T) {
 	if !sameStringSet(ftFields, stFields) {
 		t.Errorf("_flashback vs _snapshot column set mismatch: %v vs %v", ftFields, stFields)
 	}
+
+	// An EXPLICIT full-table projection (#313) must stay verbatim through the
+	// real runPointInTime → runFullTable → fullTableResult dispatch: a column
+	// the user did NOT list (coupon_code) must not be appended back. This is
+	// the end-to-end regression guard for the #600 union fix — making the
+	// shared builder union unconditionally would have silently widened the
+	// user's projection.
+	projRes, err := h.runPointInTime(TimeTravelQuery{
+		Type:    TypeFlashback,
+		Schema:  "myapp",
+		Table:   "orders",
+		Columns: []string{"id", "total"},
+		AsOf:    asOf,
+	})
+	if err != nil {
+		t.Fatalf("explicit-projection runPointInTime: %v", err)
+	}
+	if projFields := fieldNames(projRes.Resultset.Fields); !slices.Equal(projFields, []string{"id", "total"}) {
+		t.Errorf("explicit full-table projection fields = %v, want exactly [id total] (coupon_code must NOT be appended)", projFields)
+	}
 }
 
 // TestFullTableFlashback_DroppedColumn_RealOracle runs the full lifecycle on

--- a/internal/shim/schema_drift_repro_integration_test.go
+++ b/internal/shim/schema_drift_repro_integration_test.go
@@ -1,0 +1,330 @@
+//go:build integration
+
+package shim
+
+import (
+	"database/sql"
+	"log/slog"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestFullTableFlashback_DroppedColumn_Regression is the inverted #600 repro:
+// a column DROPPED between the AS OF instant and now must still appear in the
+// full-table resultset (its value is captured in the index), and the column
+// set must NOT depend on whether a `WHERE pk=` is present.
+//
+// Scenario (mirrors the real lifecycle — install snapshot, DROP COLUMN,
+// auto re-snapshot on DDL), all on hand-seeded snapshots for speed:
+//
+//	now+1m : snapshot 1 → schema (id, coupon_code, total)
+//	now+5m : INSERT order id=1 → row_after {id, coupon_code:SAVE10, total}
+//	now+8m : <-- AS OF target  (coupon_code STILL existed at this instant)
+//	now+10m: DROP COLUMN coupon_code + re-snapshot → snapshot 2 (id, total)
+//
+// Pre-#600: full-table shaped columns from the LATEST snapshot (post-drop)
+// and silently omitted coupon_code, while single-row showed it — the
+// WHERE-clause asymmetry. After the fix both surface it.
+func TestFullTableFlashback_DroppedColumn_Regression(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Hour)
+	addHourlyPartition(t, db, now)
+
+	snap1TS := now.Add(1 * time.Minute).Format("2006-01-02 15:04:05")
+	snap2TS := now.Add(10 * time.Minute).Format("2006-01-02 15:04:05")
+
+	insertCol := func(snapID int, snapTS, column string, ordinal int, key, dataType, columnType string) {
+		testutil.MustExec(t, db, `INSERT INTO schema_snapshots
+			(snapshot_id, snapshot_time, schema_name, table_name, column_name,
+			 ordinal_position, column_key, data_type, column_type, is_nullable)
+			VALUES (?, ?, 'myapp', 'orders', ?, ?, ?, ?, ?, 'NO')`,
+			snapID, snapTS, column, ordinal, key, dataType, columnType)
+	}
+	// Snapshot 1: the pre-drop schema — coupon_code is real and present.
+	insertCol(1, snap1TS, "id", 1, "PRI", "int", "int")
+	insertCol(1, snap1TS, "coupon_code", 2, "", "varchar", "varchar(32)")
+	insertCol(1, snap1TS, "total", 3, "", "int", "int")
+	// Snapshot 2: the post-drop schema — coupon_code is gone. This is the
+	// LATEST snapshot, so NewResolver(db, 0) loads (id, total).
+	insertCol(2, snap2TS, "id", 1, "PRI", "int", "int")
+	insertCol(2, snap2TS, "total", 2, "", "int", "int")
+
+	// One INSERT captured under the pre-drop schema: row_after carries
+	// coupon_code, exactly as the binlog ROW image recorded it.
+	eventTS := now.Add(5 * time.Minute).Format("2006-01-02 15:04:05")
+	testutil.InsertEvent(t, db, "mysql-bin.000001", 100, 200, eventTS, nil,
+		"myapp", "orders", 1, "1", nil, nil,
+		[]byte(`{"id":1,"coupon_code":"SAVE10","total":100}`))
+
+	h := NewHandlerWithConfig(db, Config{
+		NoArchive:   true,
+		IndexDBName: dbName,
+	}, slog.Default())
+
+	asOf := now.Add(8 * time.Minute) // coupon_code still existed at this instant
+
+	assertHasColumnWithValue := func(t *testing.T, label string, q TimeTravelQuery) []string {
+		t.Helper()
+		res, err := h.runPointInTime(q)
+		if err != nil {
+			t.Fatalf("%s runPointInTime: %v", label, err)
+		}
+		fields := fieldNames(res.Resultset.Fields)
+		cells := rowCells(t, res.Resultset)
+		t.Logf("%s fields=%v rows=%v", label, fields, cells)
+		if !slices.Contains(fields, "coupon_code") {
+			t.Errorf("%s: fields must contain the since-dropped coupon_code, got %v", label, fields)
+		}
+		found := false
+		for _, row := range cells {
+			for _, cell := range row {
+				if strings.Contains(cell, "SAVE10") {
+					found = true
+				}
+			}
+		}
+		if !found {
+			t.Errorf("%s: captured value SAVE10 must be surfaced, rows=%v", label, cells)
+		}
+		return fields
+	}
+
+	// Full-table _flashback: SELECT * FROM _flashback.orders AS OF now+8m
+	ftFields := assertHasColumnWithValue(t, "FULL-TABLE _flashback", TimeTravelQuery{
+		Type:   TypeFlashback,
+		Schema: "myapp",
+		Table:  "orders",
+		AsOf:   asOf,
+	})
+
+	// Single-row: ... WHERE id=1 AS OF now+8m
+	srFields := assertHasColumnWithValue(t, "SINGLE-ROW _flashback", TimeTravelQuery{
+		Type:     TypeFlashback,
+		Schema:   "myapp",
+		Table:    "orders",
+		PKColumn: "id",
+		PKValue:  "1",
+		AsOf:     asOf,
+	})
+
+	// _snapshot full-table goes through the same imagesToResult (degrades to
+	// the binlog-only path with no baseline configured) — it must match too.
+	stFields := assertHasColumnWithValue(t, "FULL-TABLE _snapshot", TimeTravelQuery{
+		Type:   TypeSnapshot,
+		Schema: "myapp",
+		Table:  "orders",
+		AsOf:   asOf,
+	})
+
+	// Asymmetry gone: full-table and single-row return the SAME column set.
+	if !sameStringSet(ftFields, srFields) {
+		t.Errorf("WHERE-clause asymmetry: full-table=%v single-row=%v must be the same column set", ftFields, srFields)
+	}
+	if !sameStringSet(ftFields, stFields) {
+		t.Errorf("_flashback vs _snapshot column set mismatch: %v vs %v", ftFields, stFields)
+	}
+}
+
+// TestFullTableFlashback_DroppedColumn_RealOracle runs the full lifecycle on
+// a REAL source MySQL (real CREATE TABLE → metadata.TakeSnapshot → real
+// SELECT * oracle → real DROP COLUMN → re-snapshot), satisfying #600's
+// acceptance criteria that (a) the no-drift base goes through real
+// TakeSnapshot, not hand-seeded schema_snapshots, and (b) the drop case is
+// asserted against what SELECT * actually returned at T — not against the
+// shim's own (formerly buggy) output.
+func TestFullTableFlashback_DroppedColumn_RealOracle(t *testing.T) {
+	indexDB, indexName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, indexDB)
+	if err := indexer.EnsureSchema(indexDB); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	sourceDB, sourceName := testutil.CreateTestDB(t)
+
+	testutil.MustExec(t, sourceDB, `CREATE TABLE orders (
+		id INT PRIMARY KEY,
+		coupon_code VARCHAR(32) NOT NULL,
+		total INT NOT NULL
+	) ENGINE=InnoDB`)
+
+	// Snapshot 1: the pre-drop schema is the latest at this point.
+	if _, err := metadata.TakeSnapshot(sourceDB, indexDB, []string{sourceName}); err != nil {
+		t.Fatalf("TakeSnapshot (pre-drop): %v", err)
+	}
+
+	// Real oracle: what SELECT * returns while coupon_code still exists.
+	testutil.MustExec(t, sourceDB, `INSERT INTO orders (id, coupon_code, total) VALUES (1, 'SAVE10', 100)`)
+	oracleCols := selectStarColumns(t, sourceDB, "orders")
+	if !slices.Contains(oracleCols, "coupon_code") {
+		t.Fatalf("oracle fixture broken: SELECT * should include coupon_code, got %v", oracleCols)
+	}
+
+	// The captured binlog event for that INSERT, seeded into the index with the
+	// row image the parser would have produced.
+	now := time.Now().UTC().Truncate(time.Hour)
+	addHourlyPartition(t, indexDB, now)
+	eventTS := now.Add(5 * time.Minute).Format("2006-01-02 15:04:05")
+	testutil.InsertEvent(t, indexDB, "mysql-bin.000001", 100, 200, eventTS, nil,
+		sourceName, "orders", 1, "1", nil, nil,
+		[]byte(`{"id":1,"coupon_code":"SAVE10","total":100}`))
+
+	// Now drop the column and re-snapshot: the LATEST schema loses coupon_code.
+	testutil.MustExec(t, sourceDB, `ALTER TABLE orders DROP COLUMN coupon_code`)
+	if _, err := metadata.TakeSnapshot(sourceDB, indexDB, []string{sourceName}); err != nil {
+		t.Fatalf("TakeSnapshot (post-drop): %v", err)
+	}
+
+	h := NewHandlerWithConfig(indexDB, Config{
+		NoArchive:   true,
+		IndexDBName: indexName,
+	}, slog.Default())
+	asOf := now.Add(8 * time.Minute)
+
+	ftRes, err := h.runPointInTime(TimeTravelQuery{
+		Type:   TypeFlashback,
+		Schema: sourceName,
+		Table:  "orders",
+		AsOf:   asOf,
+	})
+	if err != nil {
+		t.Fatalf("full-table runPointInTime: %v", err)
+	}
+	ftFields := fieldNames(ftRes.Resultset.Fields)
+	ftCells := rowCells(t, ftRes.Resultset)
+	t.Logf("oracle SELECT * cols=%v ; FULL-TABLE fields=%v rows=%v", oracleCols, ftFields, ftCells)
+
+	// Acceptance #2: the full-table column SET equals what SELECT * returned at
+	// T (the dropped column is present), asserted against the real oracle.
+	if !sameStringSet(ftFields, oracleCols) {
+		t.Errorf("full-table columns %v must equal the real SELECT * oracle %v at T", ftFields, oracleCols)
+	}
+	if !rowsContain(ftCells, "SAVE10") {
+		t.Errorf("full-table must surface the captured coupon_code value SAVE10, rows=%v", ftCells)
+	}
+
+	// Acceptance #3: single-row returns the same column set (asymmetry gone).
+	srRes, err := h.runPointInTime(TimeTravelQuery{
+		Type:     TypeFlashback,
+		Schema:   sourceName,
+		Table:    "orders",
+		PKColumn: "id",
+		PKValue:  "1",
+		AsOf:     asOf,
+	})
+	if err != nil {
+		t.Fatalf("single-row runPointInTime: %v", err)
+	}
+	srFields := fieldNames(srRes.Resultset.Fields)
+	if !sameStringSet(ftFields, srFields) {
+		t.Errorf("asymmetry: full-table=%v single-row=%v must be the same column set", ftFields, srFields)
+	}
+}
+
+// TestFullTableFlashback_NoDrift_RealSnapshot_Equivalence pins acceptance #1:
+// for a table with NO schema change between T and now, the full-table column
+// list is byte-identical to the latest snapshot's order (== what SELECT *
+// returns) — the fix appends nothing when no image carries an off-snapshot
+// key. Goes through real metadata.TakeSnapshot, not hand-seeded snapshots.
+func TestFullTableFlashback_NoDrift_RealSnapshot_Equivalence(t *testing.T) {
+	indexDB, indexName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, indexDB)
+	if err := indexer.EnsureSchema(indexDB); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	sourceDB, sourceName := testutil.CreateTestDB(t)
+
+	testutil.MustExec(t, sourceDB, `CREATE TABLE widgets (
+		id INT PRIMARY KEY,
+		name VARCHAR(64) NOT NULL,
+		qty INT NOT NULL
+	) ENGINE=InnoDB`)
+	if _, err := metadata.TakeSnapshot(sourceDB, indexDB, []string{sourceName}); err != nil {
+		t.Fatalf("TakeSnapshot: %v", err)
+	}
+	testutil.MustExec(t, sourceDB, `INSERT INTO widgets (id, name, qty) VALUES (1, 'a', 10), (2, 'b', 20)`)
+	oracleCols := selectStarColumns(t, sourceDB, "widgets") // [id name qty], CREATE order
+
+	now := time.Now().UTC().Truncate(time.Hour)
+	addHourlyPartition(t, indexDB, now)
+	tsA := now.Add(3 * time.Minute).Format("2006-01-02 15:04:05")
+	tsB := now.Add(4 * time.Minute).Format("2006-01-02 15:04:05")
+	testutil.InsertEvent(t, indexDB, "mysql-bin.000001", 100, 200, tsA, nil,
+		sourceName, "widgets", 1, "1", nil, nil, []byte(`{"id":1,"name":"a","qty":10}`))
+	testutil.InsertEvent(t, indexDB, "mysql-bin.000001", 200, 300, tsB, nil,
+		sourceName, "widgets", 1, "2", nil, nil, []byte(`{"id":2,"name":"b","qty":20}`))
+
+	h := NewHandlerWithConfig(indexDB, Config{
+		NoArchive:   true,
+		IndexDBName: indexName,
+	}, slog.Default())
+
+	res, err := h.runPointInTime(TimeTravelQuery{
+		Type:   TypeFlashback,
+		Schema: sourceName,
+		Table:  "widgets",
+		AsOf:   now.Add(10 * time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("runPointInTime: %v", err)
+	}
+	gotCols := fieldNames(res.Resultset.Fields)
+	// Byte-identical to the snapshot's ordinal order, == SELECT * order.
+	if !slices.Equal(gotCols, oracleCols) {
+		t.Errorf("no-drift full-table columns = %v, want byte-identical to SELECT * order %v", gotCols, oracleCols)
+	}
+	if n := len(rowCells(t, res.Resultset)); n != 2 {
+		t.Errorf("expected 2 rows, got %d", n)
+	}
+}
+
+// selectStarColumns returns the column names a real `SELECT *` yields for a
+// table — the forensic oracle for what columns existed at that instant.
+func selectStarColumns(t *testing.T, db *sql.DB, table string) []string {
+	t.Helper()
+	rows, err := db.Query("SELECT * FROM " + table)
+	if err != nil {
+		t.Fatalf("oracle SELECT * FROM %s: %v", table, err)
+	}
+	defer rows.Close()
+	cols, err := rows.Columns()
+	if err != nil {
+		t.Fatalf("oracle columns for %s: %v", table, err)
+	}
+	return cols
+}
+
+// sameStringSet reports whether a and b contain the same elements (order- and
+// duplicate-insensitive) — used to assert the full-table/single-row column
+// SETS converged (#600 asymmetry).
+func sameStringSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	sa := append([]string{}, a...)
+	sb := append([]string{}, b...)
+	sort.Strings(sa)
+	sort.Strings(sb)
+	return slices.Equal(sa, sb)
+}
+
+func rowsContain(rows [][]string, want string) bool {
+	for _, row := range rows {
+		for _, cell := range row {
+			if strings.Contains(cell, want) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/shim/snapshot.go
+++ b/internal/shim/snapshot.go
@@ -208,7 +208,7 @@ func (h *Handler) runSnapshotFullTable(q TimeTravelQuery) (*mysql.Result, error)
 		return nil, err
 	}
 
-	return imagesToResult(images, h.effectiveColumnOrder(q))
+	return h.fullTableResult(q, images)
 }
 
 // pkColumnMetas returns the primary-key column metas of schema.table from the

--- a/internal/shim/snapshot_integration_test.go
+++ b/internal/shim/snapshot_integration_test.go
@@ -630,6 +630,88 @@ func TestSnapshotBaseline_FullTableMerge(t *testing.T) {
 	}
 }
 
+// TestSnapshotBaseline_FullTableMerge_DroppedColumn pins #600 acceptance
+// criterion 4 on the path the other tests miss: the _snapshot BASELINE-MERGE
+// path (snapshot.go:211 → fullTableResult), not the degraded no-baseline path
+// that is byte-identical to _flashback. A column dropped between the baseline
+// instant and now lives only in the pre-drop baseline Parquet; the merge must
+// surface it on the never-touched baseline row even though the latest snapshot
+// (which drives columnOrderFor) no longer lists it.
+func TestSnapshotBaseline_FullTableMerge_DroppedColumn(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	hourTop := time.Now().UTC().Truncate(time.Hour)
+	addHourlyPartition(t, db, hourTop)
+	snapTime := hourTop.Add(1 * time.Minute) // pre-drop baseline + snapshot 1
+	dropTime := hourTop.Add(8 * time.Minute) // re-snapshot after DROP COLUMN
+	asOf := hourTop.Add(10 * time.Minute)
+	eventTS := hourTop.Add(5 * time.Minute).Format("2006-01-02 15:04:05")
+
+	// Snapshot 1 (pre-drop): orders(id, coupon_code, total). Snapshot 2 (post-
+	// drop, LATEST) drops coupon_code → columnOrderFor returns [id total].
+	snap1 := snapTime.UTC().Format("2006-01-02 15:04:05")
+	snap2 := dropTime.UTC().Format("2006-01-02 15:04:05")
+	testutil.InsertSnapshot(t, db, 1, snap1, "myapp", "orders", "id", 1, "PRI", "int", "NO")
+	testutil.InsertSnapshot(t, db, 1, snap1, "myapp", "orders", "coupon_code", 2, "", "varchar", "YES")
+	testutil.InsertSnapshot(t, db, 1, snap1, "myapp", "orders", "total", 3, "", "int", "NO")
+	testutil.InsertSnapshot(t, db, 2, snap2, "myapp", "orders", "id", 1, "PRI", "int", "NO")
+	testutil.InsertSnapshot(t, db, 2, snap2, "myapp", "orders", "total", 2, "", "int", "NO")
+
+	// Pre-drop baseline carrying the since-dropped column. id=1 never touched
+	// (its coupon_code can come only from the baseline); id=2 updated after.
+	ordersCols := []baseline.Column{
+		{Name: "id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
+		{Name: "coupon_code", MySQLType: "varchar", ParquetType: baseline.MysqlToParquetNode("varchar")},
+		{Name: "total", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
+	}
+	baselineDir := writeBaselineSnapshot(t, snapTime, "myapp", "orders", ordersCols, [][]string{
+		{"1", "SAVE10", "100"},
+		{"2", "OLD50", "200"},
+	})
+	// id=2 updated after the column was dropped: the event image no longer
+	// carries coupon_code, so id=2's coupon_code resolves to NULL on the wire.
+	testutil.InsertEvent(t, db, "mysql-bin.000001", 100, 200, eventTS, nil,
+		"myapp", "orders", 2 /*update*/, "2", nil,
+		[]byte(`{"id":2,"total":200}`), []byte(`{"id":2,"total":250}`))
+
+	h := NewHandlerWithConfig(db, Config{
+		AllowGaps:   true,
+		NoArchive:   true,
+		IndexDBName: dbName,
+		BaselineDir: baselineDir,
+	}, slog.Default())
+
+	res, err := h.runSnapshot(TimeTravelQuery{Type: TypeSnapshot, Schema: "myapp", Table: "orders", AsOf: asOf})
+	if err != nil {
+		t.Fatalf("full-table _snapshot: %v", err)
+	}
+	fields := fieldNames(res.Resultset.Fields)
+	cells := rowCells(t, res.Resultset)
+	t.Logf("baseline-merge _snapshot fields=%v rows=%v", fields, cells)
+
+	if !slices.Contains(fields, "coupon_code") {
+		t.Fatalf("baseline-merge _snapshot must surface the since-dropped coupon_code, got fields %v", fields)
+	}
+	ccIdx := slices.Index(fields, "coupon_code")
+	idIdx := slices.Index(fields, "id")
+	var sawRow1 bool
+	for _, row := range cells {
+		if row[idIdx] == "1" {
+			sawRow1 = true
+			if row[ccIdx] != "SAVE10" {
+				t.Errorf("never-touched baseline row id=1 coupon_code = %q, want SAVE10 (rows=%v)", row[ccIdx], cells)
+			}
+		}
+	}
+	if !sawRow1 {
+		t.Errorf("baseline-merge _snapshot dropped the never-touched baseline row id=1: %v", cells)
+	}
+}
+
 // TestSnapshotBaseline_FullTableRowCap proves the cost guardrail still bites on
 // the merged path: with the cap below the reconstructed row count, full-table
 // _snapshot returns ER_TOO_BIG_SELECT rather than buffering an unbounded


### PR DESCRIPTION
Closes #600.

## The bug

Full-table `_flashback`/`_snapshot` shaped its result columns from the **latest** schema snapshot and **strict-projected** onto it. A column that existed at the `AS OF` instant but was **dropped** before now was silently omitted from the result — even though its value is still captured in `binlog_events.row_after`. The single-row path already **unions** image-only keys, so the *same logical question* returned different columns depending on whether a `WHERE pk=` was present (the WHERE-clause asymmetry).

This is a forensic-fidelity bug in the core time-travel capability (P1).

```
raw index row_after = {"id":1,"total":100,"coupon_code":"SAVE10"}   <- data is in the index
FULL-TABLE   fields=[id total]              rows=[[1 100]]           <- coupon_code HIDDEN (pre-fix)
SINGLE-ROW   fields=[id total coupon_code]  rows=[[1 100 SAVE10]]    <- coupon_code shown
```

## The fix (Occam — union, not as-of-T epoch)

Converge full-table onto the model the single-row path already uses. `imagesToResult` now derives columns via a new pure helper **`fullTableColumns`**, which keeps the latest-snapshot order **verbatim** as the base (still NULL-filling columns no image carries — the deliberate ADD-column-after semantics) and **appends** any image-only keys (sorted union across images). So:

- **No-drift** queries stay **byte-identical** to today (nothing appended).
- A **dropped** column reappears with its captured value.
- The **WHERE-clause asymmetry is gone** for the reported case.

Covers **both** `_flashback` and `_snapshot` (both route through `imagesToResult`).

### Preserving the #313 explicit-projection contract

`imagesToResult` was previously also the builder for explicit user projections (`SELECT id, name FROM _flashback.orders AS OF ...`, which is a valid no-WHERE full-table query), relying on its old verbatim behavior. Making it union would have **silently widened** the user's projection to include image keys they never asked for.

So the full-table path now mirrors the single-row split (`imageToResult` vs `imageToResultVerbatim`): a new **`fullTableResult`** dispatcher routes `SELECT *` to `imagesToResult` (union) and an explicit column list to the new **`imagesToResultVerbatim`** (verbatim, no extras), replacing `effectiveColumnOrder`. *(This regression was independently confirmed by adversarial review before merge and is pinned by a new end-to-end test.)*

`columnOrderFor` / `effectiveColumnOrder`'s old latest-snapshot semantics for `SHOW TABLES` and PK validation are untouched.

## Acceptance criteria

- [x] **No-drift equivalence** through real `metadata.TakeSnapshot` (real `CREATE TABLE` → snapshot → resolver), byte-identical columns.
- [x] **Drop case** asserted against a **real-MySQL `SELECT *` oracle** (what the columns actually were at T), not against current shim output.
- [x] **Asymmetry gone** — full-table and single-row return the same column set for the reported drop case.
- [x] Applies to **both** `_flashback` and `_snapshot` full-table.
- [x] No-snapshot fallback still unions image keys.
- [x] Explicit `#313` projection stays verbatim (regression guard).

## Tests

- Pure-function unit tests: `TestFullTableColumns` (drop/no-drift/union/no-snapshot), `…DoesNotMutateDDLOrder` (no scribbling into the cached resolver slice), `…MatchesSingleRowColumnSet`, `TestImagesToResultVerbatimNeverAppendsExtras`, `TestFullTableResultProjection` (SELECT \* unions vs explicit projection verbatim — the regression guard).
- The previously-untracked schema-drift repro is **inverted into a regression test** and joined by `TestFullTableFlashback_DroppedColumn_RealOracle` and `TestFullTableFlashback_NoDrift_RealSnapshot_Equivalence`.
- Full `internal/shim` unit + integration suites green against real MySQL.

## Out of scope (deferred per the issue)

- Strict "schema exactly as of T" (epoch-based) column set — YAGNI until forensic-precision evidence demands it; the union fix resolves the reported data-loss and asymmetry.
- `recover` apply-time mismatch and `reconstruct --output-format mydumper` baseline-projection drop — the two sibling issues in this schema-drift family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)