### PR TITLE
fix(reconstruct): fail loud on a column added after the baseline in full-table mydumper output (#602)

### DIFF
--- a/internal/cli/reconstruct_fulltable_drift_integration_test.go
+++ b/internal/cli/reconstruct_fulltable_drift_integration_test.go
@@ -1,0 +1,143 @@
+//go:build integration
+
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/baseline"
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestRunReconstruct_fullTable_columnAddedAfterBaseline_failsLoud is the
+// end-to-end regression for #602. It drives the REAL read path
+// (query.FetchMerged → UnmarshalRowImage), not a hand-built change map, so it
+// locks the assumption the fix rests on: a column ADDED to the source after
+// the baseline shows up as a verbatim key in the delta event's row_after. If a
+// future refactor ever inserts a schema-projection step before the change map
+// is built, postBaselineColumns would silently become dead code and re-open
+// the data-loss bug — this test would catch that.
+//
+// Setup mirrors TestRunReconstruct_fullTableRoundTrip but minimal (no archive):
+// a baseline with columns (id, status); then a `note` column is ADDed and an
+// existing row UPDATEd so its row_after carries id, status AND note. The run
+// must fail loud naming `note` and leave no chunk file on disk.
+func TestRunReconstruct_fullTable_columnAddedAfterBaseline_failsLoud(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	// schema_snapshots so the resolver finds the table columns (id, status) and
+	// its PK (id). Note the `note` column is intentionally NOT in the snapshot
+	// or the baseline —
+	// it exists only in the captured delta event, exactly like a column added
+	// after the baseline that the resolver/baseline never saw.
+	testutil.MustExec(t, db, `INSERT INTO schema_snapshots
+		(snapshot_id, snapshot_time, schema_name, table_name, column_name, ordinal_position, column_key, data_type, is_nullable, is_generated)
+		VALUES (1, UTC_TIMESTAMP(), 'testdb', 'orders', 'id', 1, 'PRI', 'int', 'NO', 0)`)
+	testutil.MustExec(t, db, `INSERT INTO schema_snapshots
+		(snapshot_id, snapshot_time, schema_name, table_name, column_name, ordinal_position, column_key, data_type, is_nullable, is_generated)
+		VALUES (1, UTC_TIMESTAMP(), 'testdb', 'orders', 'status', 2, '', 'varchar', 'NO', 0)`)
+
+	createSQL := "CREATE TABLE `orders` (\n  `id` INT NOT NULL,\n  `status` VARCHAR(64) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;\n"
+
+	baselineDir := t.TempDir()
+	h1 := time.Now().UTC().Add(-48 * time.Hour).Truncate(time.Hour)
+	h2 := h1.Add(time.Hour)
+	snapshotTS := h1
+	snapshotTSDir := strings.ReplaceAll(snapshotTS.Format(time.RFC3339), ":", "-")
+	parquetDir := filepath.Join(baselineDir, snapshotTSDir, "testdb")
+	if err := os.MkdirAll(parquetDir, 0o755); err != nil {
+		t.Fatalf("mkdir baseline: %v", err)
+	}
+	baselinePath := filepath.Join(parquetDir, "orders.parquet")
+
+	cols := []baseline.Column{
+		{Name: "id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
+		{Name: "status", MySQLType: "varchar", ParquetType: baseline.MysqlToParquetNode("varchar")},
+	}
+	bw, err := baseline.NewWriter(baselinePath, cols, baseline.WriterConfig{
+		Compression:  "zstd",
+		RowGroupSize: 100,
+		Metadata:     map[string]string{baseline.MetaKeyCreateTableSQL: createSQL},
+	})
+	if err != nil {
+		t.Fatalf("baseline.NewWriter: %v", err)
+	}
+	for _, row := range [][]string{{"1", "start-1"}, {"2", "start-2"}} {
+		if err := bw.WriteRow(row, []bool{false, false}); err != nil {
+			t.Fatalf("WriteRow: %v", err)
+		}
+	}
+	if err := bw.Close(); err != nil {
+		t.Fatalf("writer close: %v", err)
+	}
+
+	// id=2 UPDATEd at h2 after `note` was ADDed: row_after carries the new
+	// column. note ∉ baseline columns (id, status).
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{h1, h2})
+	ts2 := h2.Add(30 * time.Minute).Format("2006-01-02 15:04:05")
+	testutil.InsertEvent(t, db, "binlog.000001", 100, 200, ts2, nil,
+		"testdb", "orders", 2 /* UPDATE */, "2", nil,
+		[]byte(`{"id":2,"status":"start-2"}`),
+		[]byte(`{"id":2,"status":"shipped","note":"gift-wrap"}`))
+
+	// ── Drive runReconstructFullTable via flag vars ──────────────────────
+	orig := captureRecFlags()
+	t.Cleanup(func() { applyRecFlags(orig) })
+	savedOutputFormat := recOutputFormat
+	savedOutputDir := recOutputDir
+	savedTables := recTables
+	savedChunkSize := recChunkSize
+	savedParallelism := recParallelism
+	t.Cleanup(func() {
+		recOutputFormat = savedOutputFormat
+		recOutputDir = savedOutputDir
+		recTables = savedTables
+		recChunkSize = savedChunkSize
+		recParallelism = savedParallelism
+	})
+
+	outputDir := t.TempDir()
+	recIndexDSN = testutil.SnapshotDSN(dbName)
+	recBaselineDir = baselineDir
+	recBaselineS3 = ""
+	recAllowGaps = false
+	recNoArchive = false // full-table ignores this flag; gap check stays active
+	recOutputFormat = "mydumper"
+	recOutputDir = outputDir
+	recTables = "testdb.orders"
+	recChunkSize = "256MB"
+	recParallelism = 1
+	recAt = h2.Add(45 * time.Minute).Format(time.RFC3339)
+
+	reconstructCmd.SetContext(context.Background())
+	t.Cleanup(func() { reconstructCmd.SetContext(nil) })
+
+	err = runReconstruct(reconstructCmd, nil)
+	if err == nil {
+		t.Fatalf("expected a fail-loud error for the post-baseline 'note' column, got nil")
+	}
+	if !strings.Contains(err.Error(), "note") {
+		t.Errorf("error should name the dropped column %q, got: %v", "note", err)
+	}
+
+	// No partial output: the guard fires before the writer opens.
+	entries, derr := os.ReadDir(outputDir)
+	if derr != nil {
+		t.Fatalf("read output dir: %v", derr)
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".sql") {
+			t.Errorf("partial output left on disk after failed run: %s", e.Name())
+		}
+	}
+}

--- a/internal/reconstruct/fulltable.go
+++ b/internal/reconstruct/fulltable.go
@@ -455,6 +455,25 @@ func mergeBaselineIntoWriter(ctx context.Context, in mergeInput, rep *TableRepor
 	if err != nil {
 		return fmt.Errorf("read baseline columns: %w", err)
 	}
+
+	// Fail loud on a column ADDED after the baseline (#602). This path projects
+	// every emitted row onto the baseline column set and writes the baseline's
+	// CREATE TABLE as the schema header; it does not reconstruct intermediate
+	// DDL. So a delta event's row_after key absent from the baseline columns
+	// would be dropped silently by rowAfterOrdered (its value never reaches the
+	// dump). Refuse instead, the same fail-loud choice the supportedPKType
+	// guard in ReconstructTable makes: a warning isn't enough because an
+	// operator running --log-level error would not see it and would get a dump
+	// silently missing a column. Detected up front, before the writer opens, so
+	// no partial chunk files are left on disk.
+	if extra := postBaselineColumns(in.Changes, colNames); len(extra) > 0 {
+		return fmt.Errorf(
+			"full-table reconstruct: %s.%s has column(s) %s present in delta events but absent from the baseline schema "+
+				"(added after the baseline snapshot); their values cannot be emitted without dropping data silently — "+
+				"re-run `bintrail baseline` to capture a snapshot that includes the new column(s)",
+			in.Schema, in.Table, strings.Join(extra, ", "))
+	}
+
 	mw, err := NewMydumperWriter(in.OutputDir, in.Schema, in.Table, colNames, in.ChunkSize)
 	if err != nil {
 		return fmt.Errorf("open mydumper writer: %w", err)
@@ -795,12 +814,49 @@ func zipMap(cols []string, vals []any) map[string]any {
 	return out
 }
 
+// postBaselineColumns returns, sorted and de-duplicated, the column names
+// that appear in some non-DELETE event's row_after image but are absent from
+// the baseline column set — i.e. columns ADDED to the source table after the
+// baseline snapshot. The mydumper writer projects every emitted row onto the
+// baseline columns (rowAfterOrdered), so these columns' values would be
+// dropped silently; mergeBaselineIntoWriter calls this up front to refuse the
+// run instead (#602). DELETE events carry no row_after and are skipped.
+func postBaselineColumns(changes map[string]*query.ResultRow, colNames []string) []string {
+	baseline := make(map[string]struct{}, len(colNames))
+	for _, c := range colNames {
+		baseline[c] = struct{}{}
+	}
+	extra := make(map[string]struct{})
+	for _, ev := range changes {
+		if ev == nil || ev.EventType == event.EventDelete || ev.RowAfter == nil {
+			continue
+		}
+		for col := range ev.RowAfter {
+			if _, ok := baseline[col]; !ok {
+				extra[col] = struct{}{}
+			}
+		}
+	}
+	if len(extra) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(extra))
+	for col := range extra {
+		out = append(out, col)
+	}
+	sort.Strings(out)
+	return out
+}
+
 // rowAfterOrdered walks colNames and looks up each name in rowAfter (a
 // map[string]any from a binlog event's row_after image), returning a slice
-// of values aligned to the baseline Parquet column order. Missing columns
-// become nil (SQL NULL) with an slog.Warn — this covers the schema drift
-// case where a column was added to the source table between baseline time
-// and target time.
+// of values aligned to the baseline Parquet column order. A baseline column
+// absent from this event's row_after becomes nil (SQL NULL) with an slog.Warn
+// — e.g. a column DROPPED after the baseline (newer events stop carrying it)
+// or a partial image. The opposite direction — a column ADDED after the
+// baseline, present in row_after but not in colNames — is handled up front by
+// the postBaselineColumns guard in mergeBaselineIntoWriter, which refuses the
+// run rather than letting this function drop the value silently (#602).
 func rowAfterOrdered(rowAfter map[string]any, colNames []string, schema, table string) []any {
 	out := make([]any, len(colNames))
 	for i, col := range colNames {

--- a/internal/reconstruct/schema_drift_602_test.go
+++ b/internal/reconstruct/schema_drift_602_test.go
@@ -1,0 +1,144 @@
+package reconstruct
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/event"
+	"github.com/dbtrail/dbtrail/internal/parser"
+	"github.com/dbtrail/dbtrail/internal/query"
+)
+
+// TestReconstruct602_columnAddedAfterBaselineFailsLoud is the regression for
+// #602. A column ADDed to the source table after the baseline snapshot lives
+// only in the delta events' row_after (the baseline Parquet predates it). The
+// mydumper writer projects every row onto the baseline column set, so that
+// column's value used to be dropped silently from the dump. The fix refuses
+// the run loudly instead — and must do so BEFORE writing any chunk file, so
+// no partial output is left on disk.
+func TestReconstruct602_columnAddedAfterBaselineFailsLoud(t *testing.T) {
+	baselinePath := writeTestBaseline(t, [][]string{
+		{"1", "new"},
+		{"2", "paid"},
+	})
+	outDir := t.TempDir()
+
+	// id=2 is UPDATEd after a `note` column was ADDed. The event row_after
+	// carries id, status AND note. note ∉ baseline columns (id, status).
+	changes := map[string]*query.ResultRow{
+		pkStrForInt(2): {
+			EventType: parser.EventUpdate,
+			PKValues:  pkStrForInt(2),
+			RowBefore: map[string]any{"id": float64(2), "status": "paid"},
+			RowAfter:  map[string]any{"id": float64(2), "status": "shipped", "note": "gift-wrap"},
+		},
+	}
+
+	rep := &TableReport{}
+	err := mergeBaselineIntoWriter(context.Background(), mergeInput{
+		LocalBaselinePath: baselinePath,
+		CreateTableSQL:    "-- test",
+		Schema:            "mydb",
+		Table:             "orders",
+		PKCols:            pkColsIntID(),
+		Changes:           changes,
+		OutputDir:         outDir,
+		ChunkSize:         0,
+	}, rep)
+
+	if err == nil {
+		t.Fatalf("expected a fail-loud error for the post-baseline 'note' column, got nil")
+	}
+	if !strings.Contains(err.Error(), "note") {
+		t.Errorf("error should name the dropped column %q, got: %v", "note", err)
+	}
+
+	// No partial output may be left on disk: the guard fires before the writer
+	// opens, so the output dir must contain no .sql chunk files.
+	entries, derr := os.ReadDir(outDir)
+	if derr != nil {
+		t.Fatalf("read output dir: %v", derr)
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".sql") {
+			t.Errorf("partial output left on disk after failed run: %s", e.Name())
+		}
+	}
+}
+
+// TestPostBaselineColumns covers the pure detection helper directly.
+func TestPostBaselineColumns(t *testing.T) {
+	baseCols := []string{"id", "status"}
+
+	cases := []struct {
+		name    string
+		changes map[string]*query.ResultRow
+		want    []string
+	}{
+		{
+			name:    "no events",
+			changes: map[string]*query.ResultRow{},
+			want:    nil,
+		},
+		{
+			name: "no drift",
+			changes: map[string]*query.ResultRow{
+				"2": {EventType: event.EventUpdate, RowAfter: map[string]any{"id": 2, "status": "x"}},
+			},
+			want: nil,
+		},
+		{
+			name: "one added column",
+			changes: map[string]*query.ResultRow{
+				"2": {EventType: event.EventUpdate, RowAfter: map[string]any{"id": 2, "status": "x", "note": "n"}},
+			},
+			want: []string{"note"},
+		},
+		{
+			name: "multiple added columns sorted and deduped across events",
+			changes: map[string]*query.ResultRow{
+				"2": {EventType: event.EventUpdate, RowAfter: map[string]any{"id": 2, "zeta": "z", "note": "n"}},
+				"3": {EventType: event.EventInsert, RowAfter: map[string]any{"id": 3, "note": "n2", "alpha": "a"}},
+			},
+			want: []string{"alpha", "note", "zeta"},
+		},
+		{
+			name: "DELETE events ignored (no row_after)",
+			changes: map[string]*query.ResultRow{
+				"2": {EventType: event.EventDelete, RowBefore: map[string]any{"id": 2, "ghost": "g"}},
+			},
+			want: nil,
+		},
+		{
+			name: "nil row_after ignored",
+			changes: map[string]*query.ResultRow{
+				"2": {EventType: event.EventInsert, RowAfter: nil},
+			},
+			want: nil,
+		},
+		{
+			name: "nil event entry ignored",
+			changes: map[string]*query.ResultRow{
+				"2": nil,
+				"3": {EventType: event.EventUpdate, RowAfter: map[string]any{"id": 3, "note": "n"}},
+			},
+			want: []string{"note"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := postBaselineColumns(c.changes, baseCols)
+			if len(got) != len(c.want) {
+				t.Fatalf("postBaselineColumns = %v, want %v", got, c.want)
+			}
+			for i := range got {
+				if got[i] != c.want[i] {
+					t.Fatalf("postBaselineColumns = %v, want %v", got, c.want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
closes #602

## Summary
Full-table `bintrail reconstruct --output-format mydumper` derives its output column set **and** `CREATE TABLE` header from the **baseline** Parquet. A column **added** to the source table after the baseline snapshot lives only in the delta events' `row_after`; `rowAfterOrdered` projects every emitted row onto the baseline columns, so that column's captured value was **dropped silently** from the dump — a restore that reloads cleanly but is missing a column.

## Scope decision (the triage fork)
**Minimum = fail-loud ERROR**, not the "fuller" union/reconcile. Surfacing the column would require reconstructing the as-of-T DDL: a pass-through baseline row has no captured value for the new column anywhere (only the as-of-T `DEFAULT`), and the `CREATE TABLE` header needs the new column's type. That is the schema-drift machinery this family deliberately defers (YAGNI). Refusing loudly mirrors the existing `supportedPKType` guard — a warning isn't enough because an operator on `--log-level error` would get a silently-wrong dump.

## Changes
- `internal/reconstruct/fulltable.go`: new pure helper `postBaselineColumns` + an up-front guard in `mergeBaselineIntoWriter`. The guard scans the full change map **before** the `MydumperWriter` opens, so a refusal leaves **no partial chunk files** on disk. Detection is writer-path-only; the shim's shared `mergeBaselineImages` semantics (unioned in #600) are untouched.

## Scope boundary
This handles the column-**ADDED**-after-baseline direction. The inverse (column **DROPPED** after `AS OF`) is the shim sibling **#600**, already fixed by its union; the `recover` apply-time sibling is distinct.

## Test plan
- [x] Unit: regression on the real `mergeBaselineIntoWriter` path (errors naming the column, asserts no `.sql` left on disk) + `postBaselineColumns` pure-helper cases (sort/dedup/DELETE-skip/nil-event/nil-row_after).
- [x] Integration (`-tags integration`): drives the real `query.FetchMerged → UnmarshalRowImage` read path (not a hand-built map) so the verbatim-`row_after` assumption the fix rests on can't silently regress — verified fail-loud against MySQL 8.4.
- [x] Full unit suite green; `go vet` (incl. `-tags integration`) clean.

## Review
Reviewed by 4 agents in parallel (code-reviewer, silent-failure-hunter, pr-test-analyzer, comment-analyzer). No findings ≥80 confidence; silent-failure-hunter confirmed the guard's scan set is a superset of both emit paths (no remaining silent-drop). Applied: comment reframed off roadmap-state to durable behavioral fact, nil-event helper case, and the real-oracle integration test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)