### PR TITLE
baseline: persist content digest + row count in Parquet metadata (#633)

### DIFF
--- a/internal/baseline/baseline.go
+++ b/internal/baseline/baseline.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/dbtrail/dbtrail/internal/consistency"
 )
 
 // Version is embedded in Parquet file metadata.
@@ -265,6 +267,13 @@ func processTable(ctx context.Context, tf TableFiles, outPath string, cfg Writer
 		}
 	}()
 
+	// Fingerprint the rows as they stream past, in MySQL column order. The
+	// digest is byte-identical to a live consistency.ConsistentTableChecksum of
+	// the same rows (#633), so the verify capstone (#634) can compare a baseline
+	// against its source. Tapping the parser values (MySQL's text rendering, the
+	// form ConsistentTableChecksum reads via the text protocol) costs one extra
+	// hash per row and needs no second pass over the dump.
+	hasher := consistency.NewHasher()
 	var rowCount int64
 	rowFn := func(values []string, nulls []bool) error {
 		if ctx.Err() != nil {
@@ -273,6 +282,7 @@ func processTable(ctx context.Context, tf TableFiles, outPath string, cfg Writer
 		if err := w.WriteRow(values, nulls); err != nil {
 			return err
 		}
+		hasher.AddStrings(values, nulls)
 		rowCount++
 		return nil
 	}
@@ -294,6 +304,12 @@ func processTable(ctx context.Context, tf TableFiles, outPath string, cfg Writer
 			return rowCount, fmt.Errorf("unknown format %q", tf.Format)
 		}
 	}
+
+	// Persist the content fingerprint and row count into the Parquet footer
+	// before closing. SetMetadata upserts, so these win even if the same keys
+	// were seeded at writer construction.
+	w.SetMetadata(MetaKeyContentDigest, hasher.Digest())
+	w.SetMetadata(MetaKeyRowCount, strconv.FormatInt(rowCount, 10))
 
 	closed = true
 	if err := w.Close(); err != nil {

--- a/internal/baseline/baseline.go
+++ b/internal/baseline/baseline.go
@@ -145,6 +145,15 @@ func Run(ctx context.Context, cfg Config) (Stats, error) {
 
 			if cfg.Retry {
 				if fi, err := os.Stat(outPath); err == nil && fi.Size() > 0 {
+					// A retry-skipped file keeps whatever digest it already has.
+					// A file written before #633 (or by an older binary across a
+					// mid-baseline upgrade) has none, and re-running --retry will
+					// not heal it — surface that so the operator knows the
+					// snapshot won't be fully verifiable without a fresh run.
+					if existing, mErr := ReadParquetMetadata(outPath); mErr == nil && existing.ContentDigest == "" {
+						slog.Warn("skipped existing file has no content digest; this table won't be verifiable without a fresh baseline",
+							"db", tf.Database, "table", tf.Table, "file", outPath)
+					}
 					slog.Info("skipping existing file (--retry)",
 						"db", tf.Database, "table", tf.Table, "file", outPath)
 					mu.Lock()
@@ -273,6 +282,15 @@ func processTable(ctx context.Context, tf TableFiles, outPath string, cfg Writer
 	// against its source. Tapping the parser values (MySQL's text rendering, the
 	// form ConsistentTableChecksum reads via the text protocol) costs one extra
 	// hash per row and needs no second pass over the dump.
+	//
+	// Scope: this certifies that the dump captured the SAME ROWS as the source,
+	// not that WriteRow encoded them faithfully into Parquet. WriteRow applies
+	// value transforms the tap deliberately does NOT mirror — notably a MySQL
+	// zero-date is stored as Parquet NULL while the tap (and the live checksum's
+	// CAST(... AS CHAR)) both hash the "0000-00-00 00:00:00" string. Mirroring
+	// WriteRow here would instead produce a false MISMATCH on every zero-date
+	// table; the source-fidelity framing is the correct one. Parquet-encoding
+	// fidelity (and the zero-date NULLing) is the verify capstone's concern.
 	hasher := consistency.NewHasher()
 	var rowCount int64
 	rowFn := func(values []string, nulls []bool) error {

--- a/internal/baseline/digest_integration_test.go
+++ b/internal/baseline/digest_integration_test.go
@@ -1,0 +1,81 @@
+//go:build integration
+
+package baseline
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/consistency"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestBaselineDigest_MatchesLiveSource is the keystone of issue #633: the digest
+// a baseline persists must be byte-identical to a live ConsistentTableChecksum
+// (#632) of the same rows — that identity is what makes the verify capstone
+// (#634) able to compare a baseline against its source.
+//
+// It inserts a type-matrix of rows into a live MySQL table, fingerprints the
+// live table (#632), then builds an equivalent mydumper dump of those rows, runs
+// the baseline conversion, and asserts the persisted digest equals the live one.
+// A divergence on any type is a real parser-vs-text-protocol bug, not a flaky
+// test.
+func TestBaselineDigest_MatchesLiveSource(t *testing.T) {
+	db, schema := testutil.CreateTestDB(t)
+
+	testutil.MustExec(t, db, "CREATE TABLE `t` ("+
+		"`id` INT PRIMARY KEY,"+
+		"`name` VARCHAR(64),"+
+		"`big` BIGINT UNSIGNED,"+
+		"`amount` DECIMAL(10,2),"+
+		"`ts` DATETIME(6),"+
+		"`d` DATE,"+
+		"`note` VARCHAR(64)"+
+		") CHARACTER SET utf8mb4")
+	// Row 2's note is NULL; values span unsigned>2^63, decimals, fractional
+	// datetime, date, multibyte utf8mb4 — including the temporal types the
+	// keystone caught rendering as RFC3339 before the CAST fix.
+	testutil.MustExec(t, db, "INSERT INTO `t` VALUES"+
+		"(1,'café',18446744073709551615,'1.50','2021-01-01 00:00:00.123456','2021-03-04','note'),"+
+		"(2,'日本語',9223372036854775808,'2.00','2022-06-15 12:30:45.000000','1999-12-31',NULL)")
+
+	ctx := context.Background()
+	live, err := consistency.ConsistentTableChecksum(ctx, db, schema, "t")
+	if err != nil {
+		t.Fatalf("live checksum: %v", err)
+	}
+
+	// Pull the exact CREATE TABLE so the baseline schema matches the source.
+	var tblName, ddl string
+	if err := db.QueryRow("SHOW CREATE TABLE `t`").Scan(&tblName, &ddl); err != nil {
+		t.Fatalf("show create table: %v", err)
+	}
+
+	inputDir := t.TempDir()
+	outputDir := t.TempDir()
+	// mydumper dump equivalent to the inserted rows (text-protocol form).
+	data := "INSERT INTO `t` VALUES" +
+		"(1,'café',18446744073709551615,'1.50','2021-01-01 00:00:00.123456','2021-03-04','note')," +
+		"(2,'日本語',9223372036854775808,'2.00','2022-06-15 12:30:45.000000','1999-12-31',NULL);\n"
+	mustWrite(t, filepath.Join(inputDir, "metadata"), sampleMetadata)
+	mustWrite(t, filepath.Join(inputDir, schema+".t-schema.sql"), ddl+";\n")
+	mustWrite(t, filepath.Join(inputDir, schema+".t.00000.sql"), data)
+
+	if _, err := Run(ctx, Config{InputDir: inputDir, OutputDir: outputDir, Compression: "none", RowGroupSize: 100}); err != nil {
+		t.Fatalf("baseline Run: %v", err)
+	}
+
+	meta, err := ReadParquetMetadata(findParquet(t, outputDir))
+	if err != nil {
+		t.Fatalf("ReadParquetMetadata: %v", err)
+	}
+
+	if meta.RowCount != live.RowCount {
+		t.Errorf("row count: baseline=%d live=%d", meta.RowCount, live.RowCount)
+	}
+	if meta.ContentDigest != live.Digest {
+		t.Errorf("digest mismatch:\n  baseline=%s\n  live    =%s\n(a real parser-vs-text-protocol divergence if non-empty)",
+			meta.ContentDigest, live.Digest)
+	}
+}

--- a/internal/baseline/digest_test.go
+++ b/internal/baseline/digest_test.go
@@ -60,6 +60,45 @@ func TestRun_PersistsContentDigestAndRowCount(t *testing.T) {
 	}
 }
 
+// TestReadParquetMetadata_CorruptRowCountClearsDigest verifies the contract
+// guard: a present digest paired with an unparseable row count must not be
+// returned as a trustworthy digest with RowCount=0 (which would read as a
+// verified-empty table). The reader clears the digest instead.
+func TestReadParquetMetadata_CorruptRowCountClearsDigest(t *testing.T) {
+	dir := t.TempDir()
+	schemaPath := filepath.Join(dir, "shop.t-schema.sql")
+	mustWrite(t, schemaPath, "CREATE TABLE `t` (\n  `id` int NOT NULL,\n  PRIMARY KEY (`id`)\n);\n")
+	cols, err := ParseSchema(schemaPath)
+	if err != nil {
+		t.Fatalf("ParseSchema: %v", err)
+	}
+
+	outPath := filepath.Join(dir, "t.parquet")
+	w, err := NewWriter(outPath, cols, WriterConfig{Compression: "none", RowGroupSize: 100})
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	if err := w.WriteRow([]string{"1"}, []bool{false}); err != nil {
+		t.Fatalf("WriteRow: %v", err)
+	}
+	w.SetMetadata(MetaKeyContentDigest, "v1:deadbeefdeadbeef")
+	w.SetMetadata(MetaKeyRowCount, "not-a-number") // corrupt
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	meta, err := ReadParquetMetadata(outPath)
+	if err != nil {
+		t.Fatalf("ReadParquetMetadata: %v", err)
+	}
+	if meta.ContentDigest != "" {
+		t.Errorf("ContentDigest = %q, want cleared (corrupt row count)", meta.ContentDigest)
+	}
+	if meta.RowCount != 0 {
+		t.Errorf("RowCount = %d, want 0", meta.RowCount)
+	}
+}
+
 func mustWrite(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {

--- a/internal/baseline/digest_test.go
+++ b/internal/baseline/digest_test.go
@@ -1,0 +1,83 @@
+package baseline
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/consistency"
+)
+
+// TestRun_PersistsContentDigestAndRowCount verifies that a baseline run writes
+// the per-table row count and a content digest into the Parquet metadata, that
+// they round-trip through ReadParquetMetadata, and that the digest equals an
+// independent consistency.Hasher over the same ingested values. No live DB or
+// mydumper needed — this exercises the persist+read path on a synthetic dump.
+func TestRun_PersistsContentDigestAndRowCount(t *testing.T) {
+	inputDir := t.TempDir()
+	outputDir := t.TempDir()
+
+	const schema = "CREATE TABLE `t` (\n" +
+		"  `id` int NOT NULL,\n" +
+		"  `name` varchar(64) DEFAULT NULL,\n" +
+		"  `amount` decimal(10,2) DEFAULT NULL,\n" +
+		"  PRIMARY KEY (`id`)\n" +
+		");\n"
+	const data = "INSERT INTO `t` VALUES(1,'alice','1.50'),(2,NULL,'2.00');\n"
+
+	mustWrite(t, filepath.Join(inputDir, "metadata"), sampleMetadata)
+	mustWrite(t, filepath.Join(inputDir, "shop.t-schema.sql"), schema)
+	mustWrite(t, filepath.Join(inputDir, "shop.t.00000.sql"), data)
+
+	stats, err := Run(context.Background(), Config{
+		InputDir: inputDir, OutputDir: outputDir, Compression: "none", RowGroupSize: 100,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if stats.RowsWritten != 2 {
+		t.Fatalf("RowsWritten = %d, want 2", stats.RowsWritten)
+	}
+
+	meta, err := ReadParquetMetadata(findParquet(t, outputDir))
+	if err != nil {
+		t.Fatalf("ReadParquetMetadata: %v", err)
+	}
+	if meta.RowCount != 2 {
+		t.Errorf("RowCount = %d, want 2", meta.RowCount)
+	}
+
+	// Independent recomputation of the digest over the same ingested rows.
+	h := consistency.NewHasher()
+	h.AddStrings([]string{"1", "alice", "1.50"}, []bool{false, false, false})
+	h.AddStrings([]string{"2", "", "2.00"}, []bool{false, true, false})
+	if meta.ContentDigest != h.Digest() {
+		t.Errorf("persisted digest %q != recomputed %q", meta.ContentDigest, h.Digest())
+	}
+	if meta.ContentDigest == "" {
+		t.Error("ContentDigest is empty")
+	}
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func findParquet(t *testing.T, dir string) string {
+	t.Helper()
+	var p string
+	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err == nil && filepath.Ext(path) == ".parquet" {
+			p = path
+		}
+		return nil
+	})
+	if p == "" {
+		t.Fatal("no .parquet file found in output directory")
+	}
+	return p
+}

--- a/internal/baseline/metadata.go
+++ b/internal/baseline/metadata.go
@@ -29,6 +29,17 @@ const (
 	// (consistency.Hasher, version-tagged). The digest is byte-identical to a
 	// live ConsistentTableChecksum of the same rows, so the verify capstone
 	// (#634) can compare a baseline against the source. Part of epic #631 (#633).
+	//
+	// The digest certifies SOURCE fidelity (the dump captured the same rows as
+	// the source), not Parquet-encoding fidelity: writer transforms such as
+	// zero-date→NULL are invisible to it (that is #634's concern). TIMESTAMP
+	// agreement assumes the dump used UTC (mydumper's default --tz-utc, which
+	// matches ConsistentTableChecksum's UTC session); an externally produced
+	// dump made with --skip-tz-utc on a non-UTC server would not match.
+	//
+	// Readers must treat RowCount as valid only when ContentDigest != ""; the
+	// readers clear ContentDigest if RowCount cannot be parsed, so the two are
+	// never returned in a trustworthy-digest / untrustworthy-count combination.
 	MetaKeyRowCount      = "bintrail.baseline_row_count"
 	MetaKeyContentDigest = "bintrail.baseline_content_digest"
 )
@@ -154,6 +165,11 @@ func ReadParquetMetadata(path string) (DumpMetadata, error) {
 		if parseErr != nil {
 			slog.Warn("corrupt baseline_row_count in Parquet metadata",
 				"path", path, "raw_value", v, "error", parseErr)
+			// A digest we can't pair with a trustworthy count is not usable:
+			// clearing it keeps the "ContentDigest != \"\" ⇒ RowCount valid"
+			// contract from ever being observed false (a 0 would otherwise read
+			// as a verified-empty table).
+			m.ContentDigest = ""
 		} else {
 			m.RowCount = n
 		}
@@ -192,6 +208,7 @@ func ReadParquetMetadataAny(ctx context.Context, path string) (DumpMetadata, err
 	defer rows.Close()
 
 	var m DumpMetadata
+	var rowCountCorrupt bool
 	for rows.Next() {
 		// DuckDB returns key/value as BLOB (BYTE_ARRAY) when the Parquet
 		// metadata column stores raw bytes. Scan as []byte to be safe.
@@ -223,11 +240,18 @@ func ReadParquetMetadataAny(ctx context.Context, path string) (DumpMetadata, err
 			} else {
 				slog.Warn("corrupt baseline_row_count in S3 Parquet metadata",
 					"path", path, "raw_value", val, "error", parseErr)
+				rowCountCorrupt = true
 			}
 		}
 	}
 	if err := rows.Err(); err != nil {
 		return DumpMetadata{}, fmt.Errorf("iterate metadata rows: %w", err)
+	}
+	// Applied after the loop: keys arrive as rows in arbitrary order, so the
+	// digest may be set after the count row. A digest we can't pair with a
+	// trustworthy count is not usable (see ReadParquetMetadata).
+	if rowCountCorrupt {
+		m.ContentDigest = ""
 	}
 	return m, nil
 }

--- a/internal/baseline/metadata.go
+++ b/internal/baseline/metadata.go
@@ -24,6 +24,13 @@ const (
 	MetaKeyBinlogPos      = "bintrail.baseline_binlog_position"
 	MetaKeyGTIDSet        = "bintrail.baseline_gtid_set"
 	MetaKeyCreateTableSQL = "bintrail.create_table_sql"
+	// MetaKeyRowCount and MetaKeyContentDigest record, per table, how many rows
+	// the baseline ingested and an order-independent content fingerprint of them
+	// (consistency.Hasher, version-tagged). The digest is byte-identical to a
+	// live ConsistentTableChecksum of the same rows, so the verify capstone
+	// (#634) can compare a baseline against the source. Part of epic #631 (#633).
+	MetaKeyRowCount      = "bintrail.baseline_row_count"
+	MetaKeyContentDigest = "bintrail.baseline_content_digest"
 )
 
 // DumpMetadata contains information parsed from a mydumper metadata file or
@@ -34,6 +41,8 @@ type DumpMetadata struct {
 	BinlogPos      int64
 	GTIDSet        string
 	CreateTableSQL string // raw mydumper -schema.sql bytes; set for baselines written after #187
+	ContentDigest  string // version-tagged content fingerprint; set after #633, empty when absent (old baselines)
+	RowCount       int64  // rows ingested into this table's baseline; valid only when ContentDigest != ""
 }
 
 // ParseMetadata reads the mydumper "metadata" file in inputDir and returns the
@@ -137,6 +146,18 @@ func ReadParquetMetadata(path string) (DumpMetadata, error) {
 	if v, ok := pf.Lookup(MetaKeyCreateTableSQL); ok {
 		m.CreateTableSQL = v
 	}
+	if v, ok := pf.Lookup(MetaKeyContentDigest); ok {
+		m.ContentDigest = v
+	}
+	if v, ok := pf.Lookup(MetaKeyRowCount); ok {
+		n, parseErr := strconv.ParseInt(v, 10, 64)
+		if parseErr != nil {
+			slog.Warn("corrupt baseline_row_count in Parquet metadata",
+				"path", path, "raw_value", v, "error", parseErr)
+		} else {
+			m.RowCount = n
+		}
+	}
 	return m, nil
 }
 
@@ -194,6 +215,15 @@ func ReadParquetMetadataAny(ctx context.Context, path string) (DumpMetadata, err
 			m.GTIDSet = val
 		case MetaKeyCreateTableSQL:
 			m.CreateTableSQL = val
+		case MetaKeyContentDigest:
+			m.ContentDigest = val
+		case MetaKeyRowCount:
+			if n, parseErr := strconv.ParseInt(val, 10, 64); parseErr == nil {
+				m.RowCount = n
+			} else {
+				slog.Warn("corrupt baseline_row_count in S3 Parquet metadata",
+					"path", path, "raw_value", val, "error", parseErr)
+			}
 		}
 	}
 	if err := rows.Err(); err != nil {

--- a/internal/baseline/writer.go
+++ b/internal/baseline/writer.go
@@ -152,6 +152,14 @@ func (w *Writer) WriteRow(values []string, nulls []bool) error {
 	return err
 }
 
+// SetMetadata sets a key/value pair in the Parquet file metadata. It may be
+// called after rows are written and before Close — the metadata is serialized
+// into the file footer at Close — so it can carry values only known once all
+// rows have been seen (e.g. the row count and content digest, #633).
+func (w *Writer) SetMetadata(key, value string) {
+	w.pw.SetKeyValueMetadata(key, value)
+}
+
 // Close flushes and closes the Parquet writer and the underlying file.
 func (w *Writer) Close() error {
 	if err := w.pw.Close(); err != nil {

--- a/internal/consistency/checksum.go
+++ b/internal/consistency/checksum.go
@@ -129,7 +129,7 @@ func ConsistentTableChecksum(ctx context.Context, db *sql.DB, schema, table stri
 	// Scan every row, hashing as we stream — no full-table buffering.
 	selectList := make([]string, len(cols))
 	for i, c := range cols {
-		selectList[i] = quoteIdent(c)
+		selectList[i] = selectExpr(c)
 	}
 	query := fmt.Sprintf("SELECT %s FROM %s.%s",
 		strings.Join(selectList, ","), quoteIdent(schema), quoteIdent(table))
@@ -203,7 +203,14 @@ func capturedGTID(ctx context.Context, conn *sql.Conn) (string, error) {
 	return strings.TrimSpace(gtid.String), nil
 }
 
-// tableColumns returns the non-generated column names of schema.table in ordinal
+// column is a non-generated source column: its name and information_schema
+// DATA_TYPE (lower-case, e.g. "datetime", "bigint", "varchar").
+type column struct {
+	name     string
+	dataType string
+}
+
+// tableColumns returns the non-generated columns of schema.table in ordinal
 // order. Generated columns are excluded because mydumper omits them from the
 // dump, so they never reach the baseline Parquet.
 //
@@ -214,9 +221,9 @@ func capturedGTID(ctx context.Context, conn *sql.Conn) (string, error) {
 // make their corruption invisible to the fingerprint. GENERATION_EXPRESSION is
 // non-empty only for true VIRTUAL/STORED generated columns (empty in MySQL, NULL
 // in MariaDB for everything else).
-func tableColumns(ctx context.Context, conn *sql.Conn, schema, table string) ([]string, error) {
+func tableColumns(ctx context.Context, conn *sql.Conn, schema, table string) ([]column, error) {
 	const q = `
-		SELECT COLUMN_NAME, GENERATION_EXPRESSION
+		SELECT COLUMN_NAME, DATA_TYPE, GENERATION_EXPRESSION
 		FROM information_schema.COLUMNS
 		WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?
 		ORDER BY ORDINAL_POSITION`
@@ -226,22 +233,40 @@ func tableColumns(ctx context.Context, conn *sql.Conn, schema, table string) ([]
 	}
 	defer rows.Close()
 
-	var cols []string
+	var cols []column
 	for rows.Next() {
-		var name string
+		var name, dataType string
 		var genExpr sql.NullString
-		if err := rows.Scan(&name, &genExpr); err != nil {
+		if err := rows.Scan(&name, &dataType, &genExpr); err != nil {
 			return nil, fmt.Errorf("scan column metadata of %s.%s: %w", schema, table, err)
 		}
 		if genExpr.Valid && strings.TrimSpace(genExpr.String) != "" {
 			continue // VIRTUAL/STORED generated column — not in the dump
 		}
-		cols = append(cols, name)
+		cols = append(cols, column{name: name, dataType: strings.ToLower(dataType)})
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterate column metadata of %s.%s: %w", schema, table, err)
 	}
 	return cols, nil
+}
+
+// selectExpr returns the SELECT expression for a column. DATE/DATETIME/TIMESTAMP
+// columns are wrapped in CAST(... AS CHAR) to force MySQL's native text
+// rendering (e.g. "2021-01-01 00:00:00"). Without it, a connection opened with
+// parseTime=true (config.Connect and the test DSNs both do) makes the driver
+// decode these into time.Time and re-render them as RFC3339 ("2021-01-01T..Z"),
+// which is NOT what mydumper dumps or the binlog carries — so the digest would
+// not match a baseline. The CAST makes the canonical form parseTime-independent.
+// Other types (including TIME and YEAR, which the driver never parses) are read
+// as-is.
+func selectExpr(c column) string {
+	switch c.dataType {
+	case "date", "datetime", "timestamp":
+		return "CAST(" + quoteIdent(c.name) + " AS CHAR)"
+	default:
+		return quoteIdent(c.name)
+	}
 }
 
 // quoteIdent backtick-quotes a MySQL identifier, doubling any embedded backtick.

--- a/internal/consistency/checksum_integration_test.go
+++ b/internal/consistency/checksum_integration_test.go
@@ -4,10 +4,42 @@ package consistency
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 
 	"github.com/dbtrail/dbtrail/internal/testutil"
 )
+
+func TestConsistentTableChecksum_TemporalDigestParseTimeIndependent(t *testing.T) {
+	db, schema := testutil.CreateTestDB(t)
+	testutil.MustExec(t, db, "CREATE TABLE t (id INT PRIMARY KEY, ts DATETIME(6), d DATE, tstamp TIMESTAMP NULL)")
+	testutil.MustExec(t, db, "INSERT INTO t VALUES (1,'2021-01-01 00:00:00.123456','2021-03-04','2021-01-01 00:00:00')")
+
+	ctx := context.Background()
+	// Default test DSN sets parseTime=true (driver decodes DATE/DATETIME/
+	// TIMESTAMP into time.Time and re-renders RFC3339 on RawBytes scan).
+	withParse, err := ConsistentTableChecksum(ctx, db, schema, "t")
+	if err != nil {
+		t.Fatalf("checksum (parseTime=true): %v", err)
+	}
+
+	// Same data over a connection WITHOUT parseTime — the CAST(... AS CHAR) on
+	// temporal columns must make the digest identical, proving the canonical
+	// form is MySQL's native text, not a driver artifact.
+	rawDB, err := sql.Open("mysql", testutil.BaseDSN()+"/"+schema)
+	if err != nil {
+		t.Fatalf("open no-parseTime db: %v", err)
+	}
+	defer rawDB.Close()
+	noParse, err := ConsistentTableChecksum(ctx, rawDB, schema, "t")
+	if err != nil {
+		t.Fatalf("checksum (parseTime=false): %v", err)
+	}
+
+	if withParse.Digest != noParse.Digest {
+		t.Errorf("temporal digest depends on parseTime: %s != %s", withParse.Digest, noParse.Digest)
+	}
+}
 
 func TestConsistentTableChecksum_BasicAndDeterministic(t *testing.T) {
 	db, schema := testutil.CreateTestDB(t)

--- a/internal/consistency/hasher.go
+++ b/internal/consistency/hasher.go
@@ -20,12 +20,19 @@ type Hasher struct {
 func NewHasher() *Hasher { return &Hasher{rh: newRowHasher()} }
 
 // AddStrings folds one row given the parallel value/null slices the baseline
-// dump parser yields, in MySQL column order (matching ConsistentTableChecksum's
-// ordinal SELECT order). A column is NULL when nulls[i] is true or absent — the
-// same rule WriteRow applies — so the persisted digest reflects exactly the
-// columns that reach the baseline. The string bytes are MySQL's text rendering
-// (mydumper dumps what MySQL's text protocol returns), identical to the
-// sql.RawBytes ConsistentTableChecksum hashes.
+// dump parser yields. A column is NULL when nulls[i] is true or absent.
+//
+// The string bytes are MySQL's text rendering (mydumper dumps what MySQL's text
+// protocol returns), so the digest matches a live ConsistentTableChecksum, which
+// hashes the same source text via CAST(... AS CHAR). It therefore fingerprints
+// the SOURCE rows, not the Parquet encoding: value transforms the baseline
+// writer applies downstream (e.g. a MySQL zero-date stored as Parquet NULL) are
+// deliberately not reflected here — see the call site for why mirroring them
+// would be wrong.
+//
+// Byte-identity with the live checksum holds only while the dump's column order
+// equals ordinal order (ConsistentTableChecksum SELECTs by ORDINAL_POSITION) —
+// normally true, since mydumper dumps columns in table order.
 func (h *Hasher) AddStrings(values []string, nulls []bool) {
 	row := make([][]byte, len(values))
 	for i := range values {

--- a/internal/consistency/hasher.go
+++ b/internal/consistency/hasher.go
@@ -1,0 +1,46 @@
+package consistency
+
+// Hasher is the exported, order-independent content-digest accumulator shared
+// across the consistency epic (#631). ConsistentTableChecksum uses it to
+// fingerprint a live source table; the baseline writer (#633) uses it to
+// fingerprint the rows it ingests from a mydumper dump. Both route through the
+// same internal rowHasher and the same version tag, so a live-source digest and
+// a persisted baseline digest are byte-identical for the same data — which is
+// what lets the verify capstone (#634) compare them meaningfully.
+//
+// A row is a list of field byte-slices in column order; a nil field is SQL NULL,
+// distinct from a non-nil empty value. The digest is order-independent (rows may
+// be added in any order) — see rowHasher for the construction and its 64-bit,
+// non-cryptographic, accidental-corruption threat model.
+type Hasher struct {
+	rh *rowHasher
+}
+
+// NewHasher returns an empty Hasher.
+func NewHasher() *Hasher { return &Hasher{rh: newRowHasher()} }
+
+// AddStrings folds one row given the parallel value/null slices the baseline
+// dump parser yields, in MySQL column order (matching ConsistentTableChecksum's
+// ordinal SELECT order). A column is NULL when nulls[i] is true or absent — the
+// same rule WriteRow applies — so the persisted digest reflects exactly the
+// columns that reach the baseline. The string bytes are MySQL's text rendering
+// (mydumper dumps what MySQL's text protocol returns), identical to the
+// sql.RawBytes ConsistentTableChecksum hashes.
+func (h *Hasher) AddStrings(values []string, nulls []bool) {
+	row := make([][]byte, len(values))
+	for i := range values {
+		if i >= len(nulls) || nulls[i] {
+			row[i] = nil
+			continue
+		}
+		row[i] = []byte(values[i])
+	}
+	h.rh.add(row)
+}
+
+// Digest returns the version-tagged hex digest accumulated so far. An empty
+// Hasher returns the version-tagged all-zero digest.
+func (h *Hasher) Digest() string { return digestVersion + h.rh.digest() }
+
+// Count returns the number of rows folded in.
+func (h *Hasher) Count() int64 { return h.rh.count() }

--- a/internal/consistency/hasher_test.go
+++ b/internal/consistency/hasher_test.go
@@ -74,6 +74,26 @@ func TestHasher_OrderIndependentAndCounted(t *testing.T) {
 	}
 }
 
+func TestHasher_ZeroDateHashedAsStringNotNull(t *testing.T) {
+	// The tap must hash a MySQL zero-date as its non-null string — matching the
+	// live checksum's CAST(... AS CHAR) — even though the baseline writer stores
+	// it as Parquet NULL. Mirroring the writer here would false-mismatch every
+	// zero-date table against the source.
+	zeroDate := NewHasher()
+	zeroDate.AddStrings([]string{"1", "0000-00-00 00:00:00"}, []bool{false, false})
+
+	asNull := NewHasher()
+	asNull.AddStrings([]string{"1", "x"}, []bool{false, true})
+
+	if zeroDate.Digest() == asNull.Digest() {
+		t.Errorf("zero-date hashed as NULL instead of its string: %s", zeroDate.Digest())
+	}
+	want := expectedDigest([][][]byte{{[]byte("1"), []byte("0000-00-00 00:00:00")}})
+	if zeroDate.Digest() != want {
+		t.Errorf("zero-date digest %s != raw-string digest %s", zeroDate.Digest(), want)
+	}
+}
+
 func TestHasher_VersionTaggedAndEmpty(t *testing.T) {
 	h := NewHasher()
 	if got := h.Digest(); got != digestVersion+"0000000000000000" {

--- a/internal/consistency/hasher_test.go
+++ b/internal/consistency/hasher_test.go
@@ -1,0 +1,85 @@
+package consistency
+
+import "testing"
+
+// expectedDigest computes the digest the same way ConsistentTableChecksum does
+// (private rowHasher fed []byte rows, version-tagged), so the exported Hasher can
+// be proven byte-identical to it.
+func expectedDigest(rows [][][]byte) string {
+	rh := newRowHasher()
+	for _, r := range rows {
+		rh.add(r)
+	}
+	return digestVersion + rh.digest()
+}
+
+func TestHasher_AddStringsMatchesRawBytesPath(t *testing.T) {
+	// The same logical row fed as strings (baseline path) and as raw bytes
+	// (ConsistentTableChecksum path) must yield the same digest.
+	values := []string{"1", "café", "18446744073709551615", ""}
+	nulls := []bool{false, false, false, false}
+
+	h := NewHasher()
+	h.AddStrings(values, nulls)
+	got := h.Digest()
+
+	want := expectedDigest([][][]byte{{[]byte("1"), []byte("café"), []byte("18446744073709551615"), []byte("")}})
+	if got != want {
+		t.Errorf("AddStrings digest %s != raw-bytes digest %s", got, want)
+	}
+}
+
+func TestHasher_NullDistinctFromEmpty(t *testing.T) {
+	withNull := NewHasher()
+	withNull.AddStrings([]string{"1", "x"}, []bool{false, true})
+
+	withEmpty := NewHasher()
+	withEmpty.AddStrings([]string{"1", ""}, []bool{false, false})
+
+	if withNull.Digest() == withEmpty.Digest() {
+		t.Errorf("NULL and empty hashed the same: %s", withNull.Digest())
+	}
+	// And the NULL path must match a raw nil element exactly.
+	want := expectedDigest([][][]byte{{[]byte("1"), nil}})
+	if withNull.Digest() != want {
+		t.Errorf("AddStrings NULL digest %s != raw nil digest %s", withNull.Digest(), want)
+	}
+}
+
+func TestHasher_NullsShorterThanValuesIsNull(t *testing.T) {
+	// A column index past the end of nulls is treated as NULL (mirrors WriteRow).
+	short := NewHasher()
+	short.AddStrings([]string{"1", "ignored"}, []bool{false}) // index 1 absent → NULL
+
+	want := expectedDigest([][][]byte{{[]byte("1"), nil}})
+	if short.Digest() != want {
+		t.Errorf("out-of-range null not treated as NULL: %s != %s", short.Digest(), want)
+	}
+}
+
+func TestHasher_OrderIndependentAndCounted(t *testing.T) {
+	a := NewHasher()
+	a.AddStrings([]string{"1", "alice"}, []bool{false, false})
+	a.AddStrings([]string{"2", "bob"}, []bool{false, false})
+
+	b := NewHasher()
+	b.AddStrings([]string{"2", "bob"}, []bool{false, false})
+	b.AddStrings([]string{"1", "alice"}, []bool{false, false})
+
+	if a.Digest() != b.Digest() {
+		t.Errorf("digest depends on row order: %s != %s", a.Digest(), b.Digest())
+	}
+	if a.Count() != 2 || b.Count() != 2 {
+		t.Errorf("count = (%d,%d), want (2,2)", a.Count(), b.Count())
+	}
+}
+
+func TestHasher_VersionTaggedAndEmpty(t *testing.T) {
+	h := NewHasher()
+	if got := h.Digest(); got != digestVersion+"0000000000000000" {
+		t.Errorf("empty digest = %q, want version-tagged all-zero", got)
+	}
+	if h.Count() != 0 {
+		t.Errorf("empty count = %d, want 0", h.Count())
+	}
+}


### PR DESCRIPTION
closes #633 — second child of the data-consistency guarantee epic #631.

## Summary
- At baseline conversion, fingerprint the ingested rows with the shared `consistency.Hasher` and persist per-table **`bintrail.baseline_row_count`** + **`bintrail.baseline_content_digest`** into the Parquet key-value metadata (alongside the existing GTID), via `SetKeyValueMetadata` before `Close`.
- **Keystone:** the persisted digest is **byte-identical** to a live `ConsistentTableChecksum` (#632) of the same rows — so the verify capstone (#634) can compare a baseline against its source. Locked by an integration test across unsigned>2^63, decimal, DATETIME(6), DATE, utf8mb4, NULL.
- New `consistency.Hasher` **wraps** the existing `rowHasher` (checksum.go's hashing untouched) and exposes `AddStrings`; live and persisted digests are identical by construction.

## Reshaped scope (post-design-review)
The `baseline` command is **file-based** (no source DSN). A baseline-time live re-read would be a different snapshot than mydumper's (the forbidden now-vs-now), cry wolf on active DBs, and duplicate #634 — so the **source comparison stays in #634**. The digest is computed by tapping the parser values (no second pass, no DuckDB #496 rounding, no Parquet→text renderer — that's #634's tool). No build-time fail-loud: there is no independent file-only reference (mydumper carries no per-table count).

## Fix surfaced by the keystone (a real #632 bug)
With `parseTime=true`, the driver decoded DATE/DATETIME/TIMESTAMP into `time.Time` and re-rendered them as **RFC3339** on a `RawBytes` scan — not MySQL's native text that mydumper/the binlog use. `ConsistentTableChecksum` now `CAST`s those columns `AS CHAR`, making the canonical form MySQL-native and **parseTime-independent**. #632's own tests are unaffected; a new test locks the independence.

## Scope / Occam
`checksum.go`'s `rowHasher` is wrapped, not rewritten. Only `ConsistentTableChecksum`'s SELECT gains the temporal CAST (a correctness fix). All other changes are additive.

## Test plan
- [x] Unit tests pass (`go test ./...`) — Hasher unit tests + fixture pipeline test (no DB) asserting the persisted digest equals an independent Hasher and round-trips through `ReadParquetMetadata`
- [x] Integration tests pass (`go test -tags=integration ./internal/consistency/ ./internal/baseline/`) — keystone (live==persisted) + parseTime-independence
- [x] Full repo builds and unit suite green (no existing test broken)

🤖 Generated with [Claude Code](https://claude.com/claude-code)