### PR TITLE
verify: baseline-pair content compare, drift-free (#642)

### DIFF
--- a/internal/reconstruct/fulltable.go
+++ b/internal/reconstruct/fulltable.go
@@ -781,6 +781,22 @@ func materializeBaselineLocal(ctx context.Context, path string) (string, func(),
 	return tmpPath, cleanup, nil
 }
 
+// ReadBaselineColumns returns the column names of a baseline Parquet file (local
+// or s3://). This is the authoritative non-generated column set for fingerprinting
+// the table: mydumper excludes true STORED/VIRTUAL generated columns from the dump
+// but keeps ordinary expression-default (DEFAULT_GENERATED) columns, so the Parquet
+// schema is exactly the set to hash — deriving it from a schema snapshot's
+// is_generated flag instead would wrongly drop DEFAULT_GENERATED columns (the
+// trap consistency.ConsistentTableChecksum documents) and silently under-verify them.
+func ReadBaselineColumns(ctx context.Context, path string) ([]string, error) {
+	localPath, cleanup, err := materializeBaselineLocal(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	defer cleanup()
+	return readBaselineColumns(ctx, localPath)
+}
+
 // readBaselineColumns opens the local Parquet file with DuckDB and returns
 // the column names in the order parquet_scan() emits them. This order is
 // the canonical column order for the emitted INSERT statements.

--- a/internal/verify/deferred_test.go
+++ b/internal/verify/deferred_test.go
@@ -1,0 +1,54 @@
+package verify
+
+import (
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/event"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/query"
+)
+
+func TestDeferredReprChanged(t *testing.T) {
+	intCol := metadata.ColumnMeta{Name: "n", DataType: "int"}
+	strCol := metadata.ColumnMeta{Name: "s", DataType: "varchar"}
+	enumCol := metadata.ColumnMeta{Name: "kind", DataType: "enum"}
+	withEnum := []metadata.ColumnMeta{intCol, strCol, enumCol}
+	noDeferred := []metadata.ColumnMeta{intCol, strCol}
+
+	ch := func(rows ...*query.ResultRow) map[string]*query.ResultRow {
+		m := map[string]*query.ResultRow{}
+		for i, r := range rows {
+			m[string(rune('a'+i))] = r
+		}
+		return m
+	}
+	ins := &query.ResultRow{EventType: event.EventInsert}
+	updEnum := &query.ResultRow{EventType: event.EventUpdate, ChangedColumns: []string{"kind"}}
+	updStr := &query.ResultRow{EventType: event.EventUpdate, ChangedColumns: []string{"s"}}
+	del := &query.ResultRow{EventType: event.EventDelete}
+
+	cases := []struct {
+		name    string
+		cols    []metadata.ColumnMeta
+		changes map[string]*query.ResultRow
+		want    bool
+	}{
+		{"no deferred column at all", noDeferred, ch(ins), false},
+		{"insert with a deferred column present", withEnum, ch(ins), true},
+		{"update touches the deferred column", withEnum, ch(updEnum), true},
+		// The load-bearing case: an update touching ONLY a non-deferred column,
+		// on a table that merely contains an unchanged ENUM column, must NOT
+		// trigger the deferred downgrade — otherwise a real divergence on the
+		// non-deferred column would be masked inconclusive instead of mismatch.
+		{"update touches only a non-deferred column", withEnum, ch(updStr), false},
+		{"delete only", withEnum, ch(del), false},
+		{"no changes", withEnum, ch(), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := deferredReprChanged(tc.cols, tc.changes); got != tc.want {
+				t.Errorf("deferredReprChanged = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -44,7 +44,7 @@ type TableResult struct {
 	ReconstructDigest string
 	SourceRows        int64
 	ReconstructRows   int64
-	GTID              string // source snapshot GTID the comparison is anchored to
+	Anchor            string // the point the comparison is anchored to: a GTID set (live-source path) or a binlog coordinate file:pos (baseline-pair path)
 	Detail            string // reason for inconclusive/mismatch, or a note carried on a match (e.g. coverage-unverified)
 }
 
@@ -100,7 +100,7 @@ func VerifyTable(ctx context.Context, cfg Config, schema, table string) (TableRe
 	}
 	res.SourceDigest = src.Digest
 	res.SourceRows = src.RowCount
-	res.GTID = src.GTIDSet
+	res.Anchor = src.GTIDSet
 	asOf := time.Now().UTC()
 
 	// 2. Require the index to have indexed every event the source snapshot

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -257,11 +257,22 @@ func inconclusive(res TableResult, detail string) TableResult {
 // binary families (base64 in the event image vs raw bytes from the source).
 func hasDeferredRepr(cols []metadata.ColumnMeta) bool {
 	for _, c := range cols {
-		switch strings.ToLower(c.DataType) {
-		case "enum", "set", "json",
-			"binary", "varbinary", "blob", "tinyblob", "mediumblob", "longblob", "bit":
+		if isDeferredType(c.DataType) {
 			return true
 		}
+	}
+	return false
+}
+
+// isDeferredType reports whether a column's event-image representation can differ
+// from how the baseline/source renders it in a way this version doesn't yet
+// normalize: ENUM/SET (ordinal vs label), JSON (MySQL-canonical text), binary
+// families (base64 in the event image vs raw bytes), BIT.
+func isDeferredType(dataType string) bool {
+	switch strings.ToLower(dataType) {
+	case "enum", "set", "json",
+		"binary", "varbinary", "blob", "tinyblob", "mediumblob", "longblob", "bit":
+		return true
 	}
 	return false
 }

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -178,27 +178,12 @@ func VerifyTable(ctx context.Context, cfg Config, schema, table string) (TableRe
 	// masked by this.
 	deferredRepr := hasDeferredRepr(orderedCols) && len(changes) > 0
 
-	hasher := consistency.NewHasher()
-	emitErr := reconstruct.SnapshotFullTableImages(ctx, reconstruct.SnapshotFullTableInput{
-		BaselinePath: baselinePath,
-		Schema:       schema,
-		Table:        table,
-		PKCols:       pkCols,
-		Changes:      changes,
-	}, func(rowMap map[string]any) error {
-		cells := make([][]byte, len(orderedCols))
-		for i, c := range orderedCols {
-			cells[i] = renderCell(rowMap[c.Name], c)
-		}
-		hasher.AddBytes(cells)
-		return nil
-	})
+	reconDigest, reconCount, emitErr := reconstructDigest(ctx, baselinePath, schema, table, pkCols, changes, orderedCols)
 	if emitErr != nil {
 		return res, fmt.Errorf("reconstruct %s.%s: %w", schema, table, emitErr)
 	}
-
-	res.ReconstructDigest = hasher.Digest()
-	res.ReconstructRows = hasher.Count()
+	res.ReconstructDigest = reconDigest
+	res.ReconstructRows = reconCount
 	if coverageNote != "" {
 		res.Detail = coverageNote
 	}
@@ -230,6 +215,34 @@ func classify(srcDigest string, srcRows int64, reconDigest string, reconRows int
 		return StatusInconclusive, "an ENUM/SET, JSON or binary column was changed by an event; its event-image normalization is deferred, so this content difference is not conclusive"
 	}
 	return StatusMismatch, "content digest differs at equal row count (in-place value divergence)"
+}
+
+// reconstructDigest reconstructs a table from baselinePath merged with changes,
+// renders each row's columns (in orderedCols order) to the canonical text form,
+// and returns the order-independent content digest + row count. Shared by the
+// live-source verify (VerifyTable) and the baseline-pair verify (#642): both
+// sides of any comparison must be produced by this one function so the digests
+// are byte-comparable by construction.
+func reconstructDigest(ctx context.Context, baselinePath, schema, table string, pkCols []metadata.ColumnMeta, changes map[string]*query.ResultRow, orderedCols []metadata.ColumnMeta) (string, int64, error) {
+	hasher := consistency.NewHasher()
+	err := reconstruct.SnapshotFullTableImages(ctx, reconstruct.SnapshotFullTableInput{
+		BaselinePath: baselinePath,
+		Schema:       schema,
+		Table:        table,
+		PKCols:       pkCols,
+		Changes:      changes,
+	}, func(rowMap map[string]any) error {
+		cells := make([][]byte, len(orderedCols))
+		for i, c := range orderedCols {
+			cells[i] = renderCell(rowMap[c.Name], c)
+		}
+		hasher.AddBytes(cells)
+		return nil
+	})
+	if err != nil {
+		return "", 0, err
+	}
+	return hasher.Digest(), hasher.Count(), nil
 }
 
 func inconclusive(res TableResult, detail string) TableResult {

--- a/internal/verify/verify_baseline.go
+++ b/internal/verify/verify_baseline.go
@@ -5,9 +5,11 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/dbtrail/dbtrail/internal/baseline"
+	"github.com/dbtrail/dbtrail/internal/event"
 	"github.com/dbtrail/dbtrail/internal/metadata"
 	"github.com/dbtrail/dbtrail/internal/query"
 	"github.com/dbtrail/dbtrail/internal/reconstruct"
@@ -64,20 +66,37 @@ func VerifyBaselinePair(ctx context.Context, cfg BaselineConfig, p BaselinePair)
 			return inconclusive(res, fmt.Sprintf("primary-key column %q has type %q unsupported by the baseline canonicalizer", c.Name, c.DataType)), nil
 		}
 	}
-	if p.NewAnchor.File == "" {
-		return inconclusive(res, "new baseline has no recorded binlog anchor (pre-#633 baseline); cannot bound the reconstruction"), nil
+	// A real baseline anchor is never at binlog position 0; an empty file or a
+	// zero position means the anchor wasn't recorded (pre-#633) or its metadata
+	// is corrupt (the reader keeps the file but zeroes an unparseable position).
+	// Bounding the reconstruction at position 0 would cut it short and could pass
+	// a window that touched no rows as a (false) match — refuse instead.
+	if p.NewAnchor.File == "" || p.NewAnchor.Pos == 0 {
+		return inconclusive(res, "new baseline has no usable binlog anchor (missing or zero position); cannot bound the reconstruction"), nil
 	}
 
-	// Non-generated columns in ordinal order. Using IsGenerated is safe here:
-	// both sides hash the same set, so an over/under-inclusion is symmetric and
-	// cannot produce a false mismatch (unlike the live-source path, where the
-	// source and reconstruct derived the set independently).
-	orderedCols := make([]metadata.ColumnMeta, 0, len(tm.Columns))
+	// Hash exactly the columns the baseline Parquet holds. mydumper excludes true
+	// STORED/VIRTUAL generated columns but keeps ordinary DEFAULT_GENERATED ones
+	// (created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, …), so the Parquet schema is
+	// the correct set. Deriving it from the snapshot's is_generated flag would hit
+	// the DEFAULT_GENERATED trap (consistency.ConsistentTableChecksum's comment)
+	// and silently drop those real columns from the fingerprint — under-verifying
+	// them on BOTH sides, a false-match exposure.
+	colNames, err := reconstruct.ReadBaselineColumns(ctx, p.NewPath)
+	if err != nil {
+		return res, fmt.Errorf("read new baseline columns %s.%s: %w", p.Schema, p.Table, err)
+	}
+	colByName := make(map[string]metadata.ColumnMeta, len(tm.Columns))
 	for _, c := range tm.Columns {
-		if c.IsGenerated {
-			continue
+		colByName[c.Name] = c
+	}
+	orderedCols := make([]metadata.ColumnMeta, 0, len(colNames))
+	for _, name := range colNames {
+		cm, ok := colByName[name]
+		if !ok {
+			return inconclusive(res, fmt.Sprintf("baseline column %q is absent from the index schema snapshot; re-run bintrail snapshot", name)), nil
 		}
-		orderedCols = append(orderedCols, c)
+		orderedCols = append(orderedCols, cm)
 	}
 
 	// Latest event per PK in (prev snapshot, new anchor]. Lower bound by the
@@ -126,20 +145,55 @@ func VerifyBaselinePair(ctx context.Context, cfg BaselineConfig, p BaselinePair)
 	res.ReconstructDigest = reconDigest
 	res.ReconstructRows = reconCount
 
-	deferredRepr := hasDeferredRepr(orderedCols) && len(changes) > 0
-	res.Status, res.Detail = classify(newDigest, newCount, reconDigest, reconCount, deferredRepr)
+	res.Status, res.Detail = classify(newDigest, newCount, reconDigest, reconCount, deferredReprChanged(orderedCols, changes))
 	return res, nil
+}
+
+// deferredReprChanged reports whether an ENUM/SET/JSON/binary column was actually
+// changed by an event in the window — the only case where the event-image renders
+// differently than the baseline reads it (ordinal vs label, base64 vs raw bytes,
+// canonical JSON). Gating on actual participation, not merely "the table contains
+// such a column and saw any change", keeps a real divergence on an unrelated
+// non-deferred column reportable as a mismatch instead of masking it inconclusive.
+func deferredReprChanged(cols []metadata.ColumnMeta, changes map[string]*query.ResultRow) bool {
+	deferred := make(map[string]bool)
+	for _, c := range cols {
+		if isDeferredType(c.DataType) {
+			deferred[c.Name] = true
+		}
+	}
+	if len(deferred) == 0 {
+		return false
+	}
+	for _, ev := range changes {
+		switch ev.EventType {
+		case event.EventInsert:
+			return true // an insert sets every column, including the deferred one
+		case event.EventUpdate:
+			for _, col := range ev.ChangedColumns {
+				if deferred[col] {
+					return true
+				}
+			}
+		}
+		// EventDelete removes the row from both sides — no value is rendered, so
+		// it cannot introduce a representation difference.
+	}
+	return false
 }
 
 // FindBaselinePair builds the verifiable table pairs from the two most recent
 // baseline snapshots under source: for every table present in both, the prev +
 // new Parquet paths, the prev snapshot time, and the new baseline's binlog
-// anchor (read from its Parquet metadata). Returns nil (nothing to verify) when
-// fewer than two snapshots exist — the first baseline has no predecessor.
-func FindBaselinePair(ctx context.Context, source string) ([]BaselinePair, error) {
+// anchor (read from its Parquet metadata). It also returns the "schema.table" of
+// tables in the new snapshot that have NO predecessor image (new since the prev
+// snapshot) so the caller can report them rather than silently dropping them — an
+// operator must be able to tell "verified" from "not present to verify". Returns
+// nil, nil, nil (nothing to verify) when fewer than two snapshots exist.
+func FindBaselinePair(ctx context.Context, source string) (pairs []BaselinePair, unpaired []string, err error) {
 	files, err := reconstruct.ListBaselines(ctx, source)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	// files are newest-snapshot-first; find the two most recent distinct times.
 	var tNew, tPrev time.Time
@@ -154,7 +208,7 @@ func FindBaselinePair(ctx context.Context, source string) ([]BaselinePair, error
 		}
 	}
 	if tNew.IsZero() || tPrev.IsZero() {
-		return nil, nil // fewer than two snapshots: nothing to verify yet
+		return nil, nil, nil // fewer than two snapshots: nothing to verify yet
 	}
 
 	newByTable := map[string]reconstruct.BaselineFile{}
@@ -169,15 +223,15 @@ func FindBaselinePair(ctx context.Context, source string) ([]BaselinePair, error
 		}
 	}
 
-	var pairs []BaselinePair
 	for key, nf := range newByTable {
 		pf, ok := prevByTable[key]
 		if !ok {
-			continue // table is new since the previous snapshot: no predecessor image
+			unpaired = append(unpaired, key) // new since the previous snapshot: no predecessor image
+			continue
 		}
 		meta, err := baseline.ReadParquetMetadataAny(ctx, nf.Path)
 		if err != nil {
-			return nil, fmt.Errorf("read new baseline metadata %s: %w", nf.Path, err)
+			return nil, nil, fmt.Errorf("read new baseline metadata %s: %w", nf.Path, err)
 		}
 		pairs = append(pairs, BaselinePair{
 			Schema:       nf.Schema,
@@ -189,5 +243,6 @@ func FindBaselinePair(ctx context.Context, source string) ([]BaselinePair, error
 			NewAnchor:    query.BinlogPos{File: meta.BinlogFile, Pos: uint64(meta.BinlogPos)},
 		})
 	}
-	return pairs, nil
+	sort.Strings(unpaired)
+	return pairs, unpaired, nil
 }

--- a/internal/verify/verify_baseline.go
+++ b/internal/verify/verify_baseline.go
@@ -51,7 +51,7 @@ type BaselinePair struct {
 // there is no snapshot drift, no off-peak requirement, and no production impact.
 func VerifyBaselinePair(ctx context.Context, cfg BaselineConfig, p BaselinePair) (TableResult, error) {
 	res := TableResult{Schema: p.Schema, Table: p.Table,
-		GTID: fmt.Sprintf("%s:%d", p.NewAnchor.File, p.NewAnchor.Pos)}
+		Anchor: fmt.Sprintf("%s:%d", p.NewAnchor.File, p.NewAnchor.Pos)}
 
 	tm, err := cfg.Resolver.Resolve(p.Schema, p.Table)
 	if err != nil {
@@ -73,6 +73,9 @@ func VerifyBaselinePair(ctx context.Context, cfg BaselineConfig, p BaselinePair)
 	// a window that touched no rows as a (false) match — refuse instead.
 	if p.NewAnchor.File == "" || p.NewAnchor.Pos == 0 {
 		return inconclusive(res, "new baseline has no usable binlog anchor (missing or zero position); cannot bound the reconstruction"), nil
+	}
+	if !p.PrevSnapshot.Before(p.NewSnapshot) {
+		return inconclusive(res, "baseline pair is not in prev→new order (prev snapshot is not before new)"), nil
 	}
 
 	// Hash exactly the columns the baseline Parquet holds. mydumper excludes true
@@ -100,9 +103,16 @@ func VerifyBaselinePair(ctx context.Context, cfg BaselineConfig, p BaselinePair)
 	}
 
 	// Latest event per PK in (prev snapshot, new anchor]. Lower bound by the
-	// previous snapshot time (the baseline supersedes older events); upper bound
-	// by the exact binlog anchor (#641) so the reconstruction lands precisely on
-	// the new baseline's point.
+	// previous snapshot's wall-clock TIME (the baseline supersedes older events);
+	// upper bound by the exact binlog anchor (#641) so the reconstruction lands
+	// precisely on the new baseline's point.
+	//
+	// The lower bound is the prev snapshot's directory timestamp, NOT its exact
+	// binlog anchor (a position lower bound is a follow-up). So a reported
+	// MISMATCH could in principle be a lower-bound artifact — a change committed
+	// between the prev baseline's true anchor and its directory timestamp. A
+	// reported MATCH is unaffected (a too-wide lower bound can only add a
+	// superseded older event, never drop a real one).
 	engine := query.New(cfg.IndexDB)
 	rows, _, err := query.FetchMerged(ctx, cfg.IndexDB, engine, query.FetchMergedOptions{
 		Opts: query.Options{
@@ -185,12 +195,12 @@ func deferredReprChanged(cols []metadata.ColumnMeta, changes map[string]*query.R
 // FindBaselinePair builds the verifiable table pairs from the two most recent
 // baseline snapshots under source: for every table present in both, the prev +
 // new Parquet paths, the prev snapshot time, and the new baseline's binlog
-// anchor (read from its Parquet metadata). It also returns the "schema.table" of
-// tables in the new snapshot that have NO predecessor image (new since the prev
-// snapshot) so the caller can report them rather than silently dropping them — an
+// anchor (read from its Parquet metadata). It also returns the tables in the new
+// snapshot that have NO predecessor image (new since the prev snapshot) so the
+// caller can report them rather than silently dropping them — an
 // operator must be able to tell "verified" from "not present to verify". Returns
 // nil, nil, nil (nothing to verify) when fewer than two snapshots exist.
-func FindBaselinePair(ctx context.Context, source string) (pairs []BaselinePair, unpaired []string, err error) {
+func FindBaselinePair(ctx context.Context, source string) (pairs []BaselinePair, unpaired []query.SchemaTable, err error) {
 	files, err := reconstruct.ListBaselines(ctx, source)
 	if err != nil {
 		return nil, nil, err
@@ -226,7 +236,8 @@ func FindBaselinePair(ctx context.Context, source string) (pairs []BaselinePair,
 	for key, nf := range newByTable {
 		pf, ok := prevByTable[key]
 		if !ok {
-			unpaired = append(unpaired, key) // new since the previous snapshot: no predecessor image
+			// New since the previous snapshot: no predecessor image to compare.
+			unpaired = append(unpaired, query.SchemaTable{Schema: nf.Schema, Table: nf.Table})
 			continue
 		}
 		meta, err := baseline.ReadParquetMetadataAny(ctx, nf.Path)
@@ -243,6 +254,11 @@ func FindBaselinePair(ctx context.Context, source string) (pairs []BaselinePair,
 			NewAnchor:    query.BinlogPos{File: meta.BinlogFile, Pos: uint64(meta.BinlogPos)},
 		})
 	}
-	sort.Strings(unpaired)
+	sort.Slice(unpaired, func(i, j int) bool {
+		if unpaired[i].Schema != unpaired[j].Schema {
+			return unpaired[i].Schema < unpaired[j].Schema
+		}
+		return unpaired[i].Table < unpaired[j].Table
+	})
 	return pairs, unpaired, nil
 }

--- a/internal/verify/verify_baseline.go
+++ b/internal/verify/verify_baseline.go
@@ -1,0 +1,193 @@
+package verify
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/baseline"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/query"
+	"github.com/dbtrail/dbtrail/internal/reconstruct"
+)
+
+// BaselineConfig wires the dependencies for baseline-anchored verify (#642): the
+// index (for binlog events) and a schema resolver. There is deliberately no live
+// source — both sides of the comparison are at-rest baselines, which is what
+// makes it drift-free.
+type BaselineConfig struct {
+	IndexDB        *sql.DB
+	Resolver       *metadata.Resolver
+	IndexDBName    string
+	NoArchive      bool
+	ArchiveFetcher query.ArchiveFetcher
+}
+
+// BaselinePair is one table's previous + new baseline, with the new baseline's
+// recorded binlog anchor and the previous baseline's snapshot time — everything
+// VerifyBaselinePair needs to reconstruct prev→anchor and compare to new.
+type BaselinePair struct {
+	Schema, Table string
+	PrevPath      string
+	NewPath       string
+	PrevSnapshot  time.Time
+	NewSnapshot   time.Time // new baseline's snapshot time — the coarse time bound paired with NewAnchor
+	NewAnchor     query.BinlogPos
+}
+
+// VerifyBaselinePair proves, drift-free, that the recovery chain reproduces a
+// fresh baseline. It reconstructs the previous baseline forward to the new
+// baseline's exact anchor G (baseline + binlog events up to G) and compares the
+// resulting content digest to the new baseline's own content digest.
+//
+// BOTH digests are produced by reconstructDigest over the SAME column set, so
+// they are byte-comparable by construction — immune to the column-set mismatch
+// the live-source path had to guard (the new-baseline digest is recomputed here,
+// not taken from #633's persisted value). Neither side reads the live source, so
+// there is no snapshot drift, no off-peak requirement, and no production impact.
+func VerifyBaselinePair(ctx context.Context, cfg BaselineConfig, p BaselinePair) (TableResult, error) {
+	res := TableResult{Schema: p.Schema, Table: p.Table,
+		GTID: fmt.Sprintf("%s:%d", p.NewAnchor.File, p.NewAnchor.Pos)}
+
+	tm, err := cfg.Resolver.Resolve(p.Schema, p.Table)
+	if err != nil {
+		return res, fmt.Errorf("resolve %s.%s: %w", p.Schema, p.Table, err)
+	}
+	pkCols := tm.PKColumnMetas()
+	if len(pkCols) == 0 {
+		return inconclusive(res, "table has no primary key"), nil
+	}
+	for _, c := range pkCols {
+		if !reconstruct.SupportedPKType(c.DataType) {
+			return inconclusive(res, fmt.Sprintf("primary-key column %q has type %q unsupported by the baseline canonicalizer", c.Name, c.DataType)), nil
+		}
+	}
+	if p.NewAnchor.File == "" {
+		return inconclusive(res, "new baseline has no recorded binlog anchor (pre-#633 baseline); cannot bound the reconstruction"), nil
+	}
+
+	// Non-generated columns in ordinal order. Using IsGenerated is safe here:
+	// both sides hash the same set, so an over/under-inclusion is symmetric and
+	// cannot produce a false mismatch (unlike the live-source path, where the
+	// source and reconstruct derived the set independently).
+	orderedCols := make([]metadata.ColumnMeta, 0, len(tm.Columns))
+	for _, c := range tm.Columns {
+		if c.IsGenerated {
+			continue
+		}
+		orderedCols = append(orderedCols, c)
+	}
+
+	// Latest event per PK in (prev snapshot, new anchor]. Lower bound by the
+	// previous snapshot time (the baseline supersedes older events); upper bound
+	// by the exact binlog anchor (#641) so the reconstruction lands precisely on
+	// the new baseline's point.
+	engine := query.New(cfg.IndexDB)
+	rows, _, err := query.FetchMerged(ctx, cfg.IndexDB, engine, query.FetchMergedOptions{
+		Opts: query.Options{
+			Schema:     p.Schema,
+			Table:      p.Table,
+			Since:      &p.PrevSnapshot,
+			Until:      &p.NewSnapshot, // coarse time bound: partition pruning + gap planner
+			UntilPos:   &p.NewAnchor,   // exact cut at the new baseline's binlog point
+			LimitPerPK: 1,
+		},
+		DBName:         cfg.IndexDBName,
+		NoArchive:      cfg.NoArchive,
+		ArchiveFetcher: cfg.ArchiveFetcher,
+	})
+	if err != nil {
+		var gap *query.GapError
+		if errors.As(err, &gap) {
+			return inconclusive(res, "coverage gap in the reconstruction window: "+gap.Error()), nil
+		}
+		return res, fmt.Errorf("fetch changes %s.%s: %w", p.Schema, p.Table, err)
+	}
+	changes := make(map[string]*query.ResultRow, len(rows))
+	for i := range rows {
+		changes[rows[i].PKValues] = &rows[i]
+	}
+
+	// Recovery side: reconstruct the previous baseline forward to the anchor.
+	reconDigest, reconCount, err := reconstructDigest(ctx, p.PrevPath, p.Schema, p.Table, pkCols, changes, orderedCols)
+	if err != nil {
+		return res, fmt.Errorf("reconstruct prev %s.%s: %w", p.Schema, p.Table, err)
+	}
+	// Truth side: the new baseline as-is (no events), via the same path.
+	newDigest, newCount, err := reconstructDigest(ctx, p.NewPath, p.Schema, p.Table, pkCols, map[string]*query.ResultRow{}, orderedCols)
+	if err != nil {
+		return res, fmt.Errorf("read new baseline %s.%s: %w", p.Schema, p.Table, err)
+	}
+
+	res.SourceDigest = newDigest // "truth" = the fresh baseline
+	res.SourceRows = newCount
+	res.ReconstructDigest = reconDigest
+	res.ReconstructRows = reconCount
+
+	deferredRepr := hasDeferredRepr(orderedCols) && len(changes) > 0
+	res.Status, res.Detail = classify(newDigest, newCount, reconDigest, reconCount, deferredRepr)
+	return res, nil
+}
+
+// FindBaselinePair builds the verifiable table pairs from the two most recent
+// baseline snapshots under source: for every table present in both, the prev +
+// new Parquet paths, the prev snapshot time, and the new baseline's binlog
+// anchor (read from its Parquet metadata). Returns nil (nothing to verify) when
+// fewer than two snapshots exist — the first baseline has no predecessor.
+func FindBaselinePair(ctx context.Context, source string) ([]BaselinePair, error) {
+	files, err := reconstruct.ListBaselines(ctx, source)
+	if err != nil {
+		return nil, err
+	}
+	// files are newest-snapshot-first; find the two most recent distinct times.
+	var tNew, tPrev time.Time
+	for _, f := range files {
+		if tNew.IsZero() {
+			tNew = f.SnapshotTime
+			continue
+		}
+		if !f.SnapshotTime.Equal(tNew) {
+			tPrev = f.SnapshotTime
+			break
+		}
+	}
+	if tNew.IsZero() || tPrev.IsZero() {
+		return nil, nil // fewer than two snapshots: nothing to verify yet
+	}
+
+	newByTable := map[string]reconstruct.BaselineFile{}
+	prevByTable := map[string]reconstruct.BaselineFile{}
+	for _, f := range files {
+		key := f.Schema + "." + f.Table
+		switch {
+		case f.SnapshotTime.Equal(tNew):
+			newByTable[key] = f
+		case f.SnapshotTime.Equal(tPrev):
+			prevByTable[key] = f
+		}
+	}
+
+	var pairs []BaselinePair
+	for key, nf := range newByTable {
+		pf, ok := prevByTable[key]
+		if !ok {
+			continue // table is new since the previous snapshot: no predecessor image
+		}
+		meta, err := baseline.ReadParquetMetadataAny(ctx, nf.Path)
+		if err != nil {
+			return nil, fmt.Errorf("read new baseline metadata %s: %w", nf.Path, err)
+		}
+		pairs = append(pairs, BaselinePair{
+			Schema:       nf.Schema,
+			Table:        nf.Table,
+			PrevPath:     pf.Path,
+			NewPath:      nf.Path,
+			PrevSnapshot: tPrev,
+			NewSnapshot:  tNew,
+			NewAnchor:    query.BinlogPos{File: meta.BinlogFile, Pos: uint64(meta.BinlogPos)},
+		})
+	}
+	return pairs, nil
+}

--- a/internal/verify/verify_baseline_integration_test.go
+++ b/internal/verify/verify_baseline_integration_test.go
@@ -68,41 +68,47 @@ func TestVerifyBaselinePair_MatchAndMismatch(t *testing.T) {
 	// schema snapshot so the resolver has columns + PK + datetime precision.
 	for _, c := range []struct {
 		name, key, dt, colType string
-		ord                    int
+		ord, isGen             int
 	}{
-		{"id", "PRI", "int", "int", 1},
-		{"status", "", "varchar", "varchar(64)", 2},
-		{"ts", "", "datetime", "datetime(6)", 3},
+		{"id", "PRI", "int", "int", 1, 0},
+		{"status", "", "varchar", "varchar(64)", 2, 0},
+		{"ts", "", "datetime", "datetime(6)", 3, 0},
+		// created_at is an ordinary DEFAULT CURRENT_TIMESTAMP column the snapshotter
+		// mis-flags is_generated=1 (DEFAULT_GENERATED trap). It IS in the baseline
+		// Parquet, so it must be hashed — locking that the column set comes from the
+		// Parquet, not the is_generated flag (else corruption here would read MATCH).
+		{"created_at", "", "datetime", "datetime", 4, 1},
 	} {
 		testutil.MustExec(t, db, `INSERT INTO schema_snapshots
 			(snapshot_id, snapshot_time, schema_name, table_name, column_name,
 			 ordinal_position, column_key, data_type, column_type, is_nullable, is_generated)
-			VALUES (1, UTC_TIMESTAMP(), ?, 'orders', ?, ?, ?, ?, ?, 'YES', 0)`,
-			dbName, c.name, c.ord, c.key, c.dt, c.colType)
+			VALUES (1, UTC_TIMESTAMP(), ?, 'orders', ?, ?, ?, ?, ?, 'YES', ?)`,
+			dbName, c.name, c.ord, c.key, c.dt, c.colType, c.isGen)
 	}
 
 	baseDir := t.TempDir()
 	now := time.Now().UTC()
 	prevTS := now.Truncate(time.Hour).Add(-2 * time.Hour)
 	newTS := prevTS.Add(time.Hour)
-	createSQL := "CREATE TABLE `orders` (\n  `id` INT NOT NULL,\n  `status` VARCHAR(64),\n  `ts` DATETIME(6),\n  PRIMARY KEY (`id`)\n);\n"
+	createSQL := "CREATE TABLE `orders` (\n  `id` INT NOT NULL,\n  `status` VARCHAR(64),\n  `ts` DATETIME(6),\n  `created_at` DATETIME DEFAULT CURRENT_TIMESTAMP,\n  PRIMARY KEY (`id`)\n);\n"
 	cols := []baseline.Column{
 		{Name: "id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
 		{Name: "status", MySQLType: "varchar", ParquetType: baseline.MysqlToParquetNode("varchar")},
 		{Name: "ts", MySQLType: "datetime", ParquetType: baseline.MysqlToParquetNode("datetime")},
+		{Name: "created_at", MySQLType: "datetime", ParquetType: baseline.MysqlToParquetNode("datetime")},
 	}
 
 	// PREV baseline: initial state {1:a, 2:b, 3:c}.
 	writeTestBaseline(t, baseDir, prevTS, dbName, "orders", createSQL, cols, [][]string{
-		{"1", "a", "2021-01-01 00:00:00.000000"},
-		{"2", "b", "2021-01-02 00:00:00.000000"},
-		{"3", "c", "2021-01-03 00:00:00.000000"},
+		{"1", "a", "2021-01-01 00:00:00.000000", "2020-01-01 00:00:00"},
+		{"2", "b", "2021-01-02 00:00:00.000000", "2020-01-02 00:00:00"},
+		{"3", "c", "2021-01-03 00:00:00.000000", "2020-01-03 00:00:00"},
 	}, "binlog.000001", 200)
 	// NEW baseline: state at anchor binlog.000001:500 → {1:a, 2:shipped, 4:new}.
 	newRows := [][]string{
-		{"1", "a", "2021-01-01 00:00:00.000000"},
-		{"2", "shipped", "2021-01-02 00:00:00.000000"},
-		{"4", "new", "2021-06-15 12:30:45.000000"},
+		{"1", "a", "2021-01-01 00:00:00.000000", "2020-01-01 00:00:00"},
+		{"2", "shipped", "2021-01-02 00:00:00.000000", "2020-01-02 00:00:00"},
+		{"4", "new", "2021-06-15 12:30:45.000000", "2020-06-15 00:00:00"},
 	}
 	writeTestBaseline(t, baseDir, newTS, dbName, "orders", createSQL, cols, newRows, "binlog.000001", 500)
 
@@ -110,12 +116,12 @@ func TestVerifyBaselinePair_MatchAndMismatch(t *testing.T) {
 	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{prevTS, newTS, now.Truncate(time.Hour)})
 	ets := prevTS.Add(30 * time.Minute).Format("2006-01-02 15:04:05")
 	testutil.InsertEvent(t, db, "binlog.000001", 200, 300, ets, nil, dbName, "orders", 2 /*UPDATE*/, "2", nil,
-		[]byte(`{"id":2,"status":"b","ts":"2021-01-02 00:00:00.000000"}`),
-		[]byte(`{"id":2,"status":"shipped","ts":"2021-01-02 00:00:00.000000"}`))
+		[]byte(`{"id":2,"status":"b","ts":"2021-01-02 00:00:00.000000","created_at":"2020-01-02 00:00:00"}`),
+		[]byte(`{"id":2,"status":"shipped","ts":"2021-01-02 00:00:00.000000","created_at":"2020-01-02 00:00:00"}`))
 	testutil.InsertEvent(t, db, "binlog.000001", 300, 400, ets, nil, dbName, "orders", 3 /*DELETE*/, "3", nil,
-		[]byte(`{"id":3,"status":"c","ts":"2021-01-03 00:00:00.000000"}`), nil)
+		[]byte(`{"id":3,"status":"c","ts":"2021-01-03 00:00:00.000000","created_at":"2020-01-03 00:00:00"}`), nil)
 	testutil.InsertEvent(t, db, "binlog.000001", 400, 500, ets, nil, dbName, "orders", 1 /*INSERT*/, "4", nil,
-		nil, []byte(`{"id":4,"status":"new","ts":"2021-06-15 12:30:45.000000"}`))
+		nil, []byte(`{"id":4,"status":"new","ts":"2021-06-15 12:30:45.000000","created_at":"2020-06-15 00:00:00"}`))
 
 	resolver, err := metadata.NewResolver(db, 1)
 	if err != nil {
@@ -124,12 +130,15 @@ func TestVerifyBaselinePair_MatchAndMismatch(t *testing.T) {
 	cfg := BaselineConfig{IndexDB: db, Resolver: resolver, IndexDBName: dbName, NoArchive: true}
 	ctx := context.Background()
 
-	pairs, err := FindBaselinePair(ctx, baseDir)
+	pairs, unpaired, err := FindBaselinePair(ctx, baseDir)
 	if err != nil {
 		t.Fatalf("FindBaselinePair: %v", err)
 	}
 	if len(pairs) != 1 {
 		t.Fatalf("expected 1 pair (orders), got %d", len(pairs))
+	}
+	if len(unpaired) != 0 {
+		t.Errorf("expected no unpaired tables, got %v", unpaired)
 	}
 
 	// MATCH: reconstruct(prev → anchor) == the new baseline.
@@ -142,10 +151,13 @@ func TestVerifyBaselinePair_MatchAndMismatch(t *testing.T) {
 			got.Status, got.Detail, got.SourceDigest, got.SourceRows, got.ReconstructDigest, got.ReconstructRows)
 	}
 
-	// MISMATCH: tamper the new baseline so it no longer equals the reconstruction.
+	// MISMATCH: tamper ONLY the created_at column (the DEFAULT_GENERATED one) in
+	// the new baseline. This must surface as a mismatch — proving created_at is in
+	// the digest. With the buggy is_generated-based column set it would be excluded
+	// and the tamper would falsely read MATCH.
 	tampered := make([][]string, len(newRows))
 	copy(tampered, newRows)
-	tampered[0] = []string{"1", "TAMPERED", "2021-01-01 00:00:00.000000"}
+	tampered[0] = []string{"1", "a", "2021-01-01 00:00:00.000000", "1999-12-31 00:00:00"}
 	writeTestBaseline(t, baseDir, newTS, dbName, "orders", createSQL, cols, tampered, "binlog.000001", 500)
 
 	got2, err := VerifyBaselinePair(ctx, cfg, pairs[0])

--- a/internal/verify/verify_baseline_integration_test.go
+++ b/internal/verify/verify_baseline_integration_test.go
@@ -1,0 +1,158 @@
+//go:build integration
+
+package verify
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/baseline"
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// writeTestBaseline writes a one-table baseline snapshot (Parquet + _SUCCESS
+// marker) under baseDir at snapshot time ts. anchorFile/anchorPos, when set,
+// record the binlog anchor in the Parquet metadata (#633).
+func writeTestBaseline(t *testing.T, baseDir string, ts time.Time, dbName, table, createSQL string,
+	cols []baseline.Column, rows [][]string, anchorFile string, anchorPos int64) {
+	t.Helper()
+	tsDir := strings.ReplaceAll(ts.Format(time.RFC3339), ":", "-")
+	snapDir := filepath.Join(baseDir, tsDir)
+	parquetDir := filepath.Join(snapDir, dbName)
+	if err := os.MkdirAll(parquetDir, 0o755); err != nil {
+		t.Fatalf("mkdir baseline: %v", err)
+	}
+	md := map[string]string{baseline.MetaKeyCreateTableSQL: createSQL}
+	if anchorFile != "" {
+		md[baseline.MetaKeyBinlogFile] = anchorFile
+		md[baseline.MetaKeyBinlogPos] = strconv.FormatInt(anchorPos, 10)
+	}
+	bw, err := baseline.NewWriter(filepath.Join(parquetDir, table+".parquet"), cols,
+		baseline.WriterConfig{Compression: "zstd", RowGroupSize: 100, Metadata: md})
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	for _, row := range rows {
+		nulls := make([]bool, len(row))
+		if err := bw.WriteRow(row, nulls); err != nil {
+			t.Fatalf("WriteRow: %v", err)
+		}
+	}
+	if err := bw.Close(); err != nil {
+		t.Fatalf("baseline close: %v", err)
+	}
+	if err := baseline.WriteSuccessMarker(snapDir); err != nil {
+		t.Fatalf("WriteSuccessMarker: %v", err)
+	}
+}
+
+// TestVerifyBaselinePair_MatchAndMismatch is the keystone of #642: reconstructing
+// the previous baseline forward to the new baseline's anchor must fingerprint
+// byte-identically to the new baseline itself (the recovery chain reproduces a
+// fresh dump), drift-free — no live source is read. Tampering the new baseline
+// then surfaces as a mismatch.
+func TestVerifyBaselinePair_MatchAndMismatch(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	// schema snapshot so the resolver has columns + PK + datetime precision.
+	for _, c := range []struct {
+		name, key, dt, colType string
+		ord                    int
+	}{
+		{"id", "PRI", "int", "int", 1},
+		{"status", "", "varchar", "varchar(64)", 2},
+		{"ts", "", "datetime", "datetime(6)", 3},
+	} {
+		testutil.MustExec(t, db, `INSERT INTO schema_snapshots
+			(snapshot_id, snapshot_time, schema_name, table_name, column_name,
+			 ordinal_position, column_key, data_type, column_type, is_nullable, is_generated)
+			VALUES (1, UTC_TIMESTAMP(), ?, 'orders', ?, ?, ?, ?, ?, 'YES', 0)`,
+			dbName, c.name, c.ord, c.key, c.dt, c.colType)
+	}
+
+	baseDir := t.TempDir()
+	now := time.Now().UTC()
+	prevTS := now.Truncate(time.Hour).Add(-2 * time.Hour)
+	newTS := prevTS.Add(time.Hour)
+	createSQL := "CREATE TABLE `orders` (\n  `id` INT NOT NULL,\n  `status` VARCHAR(64),\n  `ts` DATETIME(6),\n  PRIMARY KEY (`id`)\n);\n"
+	cols := []baseline.Column{
+		{Name: "id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
+		{Name: "status", MySQLType: "varchar", ParquetType: baseline.MysqlToParquetNode("varchar")},
+		{Name: "ts", MySQLType: "datetime", ParquetType: baseline.MysqlToParquetNode("datetime")},
+	}
+
+	// PREV baseline: initial state {1:a, 2:b, 3:c}.
+	writeTestBaseline(t, baseDir, prevTS, dbName, "orders", createSQL, cols, [][]string{
+		{"1", "a", "2021-01-01 00:00:00.000000"},
+		{"2", "b", "2021-01-02 00:00:00.000000"},
+		{"3", "c", "2021-01-03 00:00:00.000000"},
+	}, "binlog.000001", 200)
+	// NEW baseline: state at anchor binlog.000001:500 → {1:a, 2:shipped, 4:new}.
+	newRows := [][]string{
+		{"1", "a", "2021-01-01 00:00:00.000000"},
+		{"2", "shipped", "2021-01-02 00:00:00.000000"},
+		{"4", "new", "2021-06-15 12:30:45.000000"},
+	}
+	writeTestBaseline(t, baseDir, newTS, dbName, "orders", createSQL, cols, newRows, "binlog.000001", 500)
+
+	// Binlog events between prev and the anchor: id=2 updated, id=3 deleted, id=4 inserted.
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{prevTS, newTS, now.Truncate(time.Hour)})
+	ets := prevTS.Add(30 * time.Minute).Format("2006-01-02 15:04:05")
+	testutil.InsertEvent(t, db, "binlog.000001", 200, 300, ets, nil, dbName, "orders", 2 /*UPDATE*/, "2", nil,
+		[]byte(`{"id":2,"status":"b","ts":"2021-01-02 00:00:00.000000"}`),
+		[]byte(`{"id":2,"status":"shipped","ts":"2021-01-02 00:00:00.000000"}`))
+	testutil.InsertEvent(t, db, "binlog.000001", 300, 400, ets, nil, dbName, "orders", 3 /*DELETE*/, "3", nil,
+		[]byte(`{"id":3,"status":"c","ts":"2021-01-03 00:00:00.000000"}`), nil)
+	testutil.InsertEvent(t, db, "binlog.000001", 400, 500, ets, nil, dbName, "orders", 1 /*INSERT*/, "4", nil,
+		nil, []byte(`{"id":4,"status":"new","ts":"2021-06-15 12:30:45.000000"}`))
+
+	resolver, err := metadata.NewResolver(db, 1)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+	cfg := BaselineConfig{IndexDB: db, Resolver: resolver, IndexDBName: dbName, NoArchive: true}
+	ctx := context.Background()
+
+	pairs, err := FindBaselinePair(ctx, baseDir)
+	if err != nil {
+		t.Fatalf("FindBaselinePair: %v", err)
+	}
+	if len(pairs) != 1 {
+		t.Fatalf("expected 1 pair (orders), got %d", len(pairs))
+	}
+
+	// MATCH: reconstruct(prev → anchor) == the new baseline.
+	got, err := VerifyBaselinePair(ctx, cfg, pairs[0])
+	if err != nil {
+		t.Fatalf("VerifyBaselinePair: %v", err)
+	}
+	if got.Status != StatusMatch {
+		t.Fatalf("status = %q (%s); want match\n  new   =%s rows=%d\n  recon =%s rows=%d",
+			got.Status, got.Detail, got.SourceDigest, got.SourceRows, got.ReconstructDigest, got.ReconstructRows)
+	}
+
+	// MISMATCH: tamper the new baseline so it no longer equals the reconstruction.
+	tampered := make([][]string, len(newRows))
+	copy(tampered, newRows)
+	tampered[0] = []string{"1", "TAMPERED", "2021-01-01 00:00:00.000000"}
+	writeTestBaseline(t, baseDir, newTS, dbName, "orders", createSQL, cols, tampered, "binlog.000001", 500)
+
+	got2, err := VerifyBaselinePair(ctx, cfg, pairs[0])
+	if err != nil {
+		t.Fatalf("VerifyBaselinePair (2): %v", err)
+	}
+	if got2.Status != StatusMismatch {
+		t.Errorf("after tampering status = %q (%s); want mismatch", got2.Status, got2.Detail)
+	}
+}

--- a/internal/verify/verify_baseline_integration_test.go
+++ b/internal/verify/verify_baseline_integration_test.go
@@ -167,4 +167,104 @@ func TestVerifyBaselinePair_MatchAndMismatch(t *testing.T) {
 	if got2.Status != StatusMismatch {
 		t.Errorf("after tampering status = %q (%s); want mismatch", got2.Status, got2.Detail)
 	}
+
+	// A zero anchor position must refuse (inconclusive), not bound at position 0.
+	badAnchor := pairs[0]
+	badAnchor.NewAnchor.Pos = 0
+	gotZero, err := VerifyBaselinePair(ctx, cfg, badAnchor)
+	if err != nil {
+		t.Fatalf("VerifyBaselinePair (zero anchor): %v", err)
+	}
+	if gotZero.Status != StatusInconclusive {
+		t.Errorf("zero anchor: status = %q (%s); want inconclusive", gotZero.Status, gotZero.Detail)
+	}
+}
+
+// TestFindBaselinePair_UnpairedAndSelection locks two things: a table present
+// only in the new snapshot lands in `unpaired` (not silently dropped), and the
+// pair is built from the two most recent snapshots, ignoring an older third.
+func TestFindBaselinePair_UnpairedAndSelection(t *testing.T) {
+	baseDir := t.TempDir()
+	now := time.Now().UTC()
+	createSQL := "CREATE TABLE `t` (\n  `id` INT NOT NULL,\n  PRIMARY KEY (`id`)\n);\n"
+	cols := []baseline.Column{{Name: "id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")}}
+	rows := [][]string{{"1"}}
+	oldTS := now.Truncate(time.Hour).Add(-3 * time.Hour)
+	prevTS := now.Truncate(time.Hour).Add(-2 * time.Hour)
+	newTS := now.Truncate(time.Hour).Add(-1 * time.Hour)
+
+	writeTestBaseline(t, baseDir, oldTS, "db", "orders", createSQL, cols, rows, "binlog.000001", 100) // ignored (older)
+	writeTestBaseline(t, baseDir, prevTS, "db", "orders", createSQL, cols, rows, "binlog.000001", 200)
+	writeTestBaseline(t, baseDir, newTS, "db", "orders", createSQL, cols, rows, "binlog.000001", 300)
+	writeTestBaseline(t, baseDir, newTS, "db", "fresh", createSQL, cols, rows, "binlog.000001", 300) // new-only
+
+	pairs, unpaired, err := FindBaselinePair(context.Background(), baseDir)
+	if err != nil {
+		t.Fatalf("FindBaselinePair: %v", err)
+	}
+	if len(pairs) != 1 || pairs[0].Table != "orders" {
+		t.Fatalf("expected one pair for orders (newest two snapshots), got %+v", pairs)
+	}
+	// The pair must use the prev (not the older) snapshot's path.
+	if !pairs[0].PrevSnapshot.Equal(prevTS) {
+		t.Errorf("pair PrevSnapshot = %v, want %v (must ignore the older snapshot)", pairs[0].PrevSnapshot, prevTS)
+	}
+	if len(unpaired) != 1 || unpaired[0].Table != "fresh" {
+		t.Errorf("expected 'fresh' in unpaired (new since prev), got %+v", unpaired)
+	}
+}
+
+// TestVerifyBaselinePair_UnchangedTable covers the most common pass case: the
+// prev baseline is content-identical to the new one and no events fall in the
+// window, so the reconstruction is pure baseline passthrough ⇒ match.
+func TestVerifyBaselinePair_UnchangedTable(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	for _, c := range []struct {
+		name, key, dt, colType string
+		ord                    int
+	}{
+		{"id", "PRI", "int", "int", 1},
+		{"status", "", "varchar", "varchar(64)", 2},
+	} {
+		testutil.MustExec(t, db, `INSERT INTO schema_snapshots
+			(snapshot_id, snapshot_time, schema_name, table_name, column_name,
+			 ordinal_position, column_key, data_type, column_type, is_nullable, is_generated)
+			VALUES (1, UTC_TIMESTAMP(), ?, 'orders', ?, ?, ?, ?, ?, 'YES', 0)`,
+			dbName, c.name, c.ord, c.key, c.dt, c.colType)
+	}
+
+	baseDir := t.TempDir()
+	now := time.Now().UTC()
+	prevTS := now.Truncate(time.Hour).Add(-2 * time.Hour)
+	newTS := prevTS.Add(time.Hour)
+	createSQL := "CREATE TABLE `orders` (\n  `id` INT NOT NULL,\n  `status` VARCHAR(64),\n  PRIMARY KEY (`id`)\n);\n"
+	cols := []baseline.Column{
+		{Name: "id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
+		{Name: "status", MySQLType: "varchar", ParquetType: baseline.MysqlToParquetNode("varchar")},
+	}
+	rows := [][]string{{"1", "a"}, {"2", "b"}}
+	writeTestBaseline(t, baseDir, prevTS, dbName, "orders", createSQL, cols, rows, "binlog.000001", 200)
+	writeTestBaseline(t, baseDir, newTS, dbName, "orders", createSQL, cols, rows, "binlog.000001", 200)
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{prevTS, newTS, now.Truncate(time.Hour)})
+
+	resolver, err := metadata.NewResolver(db, 1)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+	cfg := BaselineConfig{IndexDB: db, Resolver: resolver, IndexDBName: dbName, NoArchive: true}
+	pairs, _, err := FindBaselinePair(context.Background(), baseDir)
+	if err != nil || len(pairs) != 1 {
+		t.Fatalf("FindBaselinePair: %v (pairs=%d)", err, len(pairs))
+	}
+	got, err := VerifyBaselinePair(context.Background(), cfg, pairs[0])
+	if err != nil {
+		t.Fatalf("VerifyBaselinePair: %v", err)
+	}
+	if got.Status != StatusMatch {
+		t.Errorf("unchanged table: status = %q (%s); want match", got.Status, got.Detail)
+	}
 }


### PR DESCRIPTION
closes #642 — the heart of the baseline-anchored verify epic #640.

## Summary
`VerifyBaselinePair` proves the recovery chain reproduces a fresh baseline **without reading the live source**: it reconstructs the previous baseline forward to the new baseline's exact binlog anchor G (baseline + events up to G, via #641's `UntilPos`) and compares the content digest to the new baseline's own.

Both sides are at-rest, frozen at the identical G — the snapshot-drift seam that makes live-source verify (#634) cry wolf **does not exist here**. No live source, no off-peak requirement, no production impact. This is the **primary** verify mode of epic #640; the live-source path (#634) stays secondary/manual.

## Key design
- **Parity by construction**: BOTH digests come from the same `reconstructDigest` over the same column set, so they're byte-comparable — immune to the column-set mismatch the live path (#634 C1) had to guard. The new-baseline digest is recomputed here (reconstruct with no events), not taken from #633's persisted value → no cross-derivation parity risk. Using `IsGenerated` is safe: any over/under-inclusion is symmetric.
- **Window**: lower bound = previous snapshot time (`Since`); upper bound = the new baseline's exact anchor (`UntilPos`) paired with its snapshot time (`Until`) for partition pruning + the gap planner. Coverage gap → inconclusive.
- `FindBaselinePair` discovers the two most recent snapshots and builds the per-table pairs (tables in both), reading the new baseline's anchor from its Parquet metadata. <2 snapshots → nothing to verify (first baseline has no predecessor).
- Refactor: extracted `reconstructDigest` from `VerifyTable` (behavior-preserving; #634's tests stay green) so both modes share one digest function.

## Test plan
- [x] Full repo unit suite green (refactor broke nothing)
- [x] **Keystone integration**: two baselines + events between them → `reconstruct(prev → anchor) == new baseline` ⇒ **match**; tamper the new baseline ⇒ **mismatch**. Drift-free (no live source). Across DATETIME(6) + the merge (update/delete/insert).
- [x] #634 live-source keystone still green (shared `reconstructDigest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)