### PR TITLE
verify: baseline-anchored (drift-free) CLI mode (#643)

### DIFF
--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -45,7 +45,9 @@ the data. Two modes:
 Results are per table: match, mismatch, or inconclusive (no predecessor
 baseline, index behind, unsupported PK, coverage gap, or a value class this
 version can't yet compare — never reported as a failure). The run exits non-zero
-on any mismatch or error, or when nothing was verified.
+on any mismatch or error, or when comparable tables existed but none could be
+proven (all inconclusive). A source with only one baseline — no predecessor yet
+— is reported and exits zero.
 
 Examples:
   # Baseline-anchored (drift-free), all tables
@@ -107,7 +109,7 @@ func runVerify(cmd *cobra.Command, _ []string) error {
 // runVerifyBaselinePair is the default, drift-free mode: compare the two most
 // recent baselines (#642). It reads no live source.
 func runVerifyBaselinePair(cmd *cobra.Command, indexDB *sql.DB, resolver *metadata.Resolver, indexDBName, baselineSrc string, duckTuning duckdbutil.Tuning) error {
-	pairs, unpaired, err := verify.FindBaselinePair(cmd.Context(), baselineSrc)
+	pairs, unpaired, prevOnly, err := verify.FindBaselinePair(cmd.Context(), baselineSrc)
 	if err != nil {
 		return fmt.Errorf("discover baseline pair: %w", err)
 	}
@@ -159,6 +161,20 @@ func runVerifyBaselinePair(cmd *cobra.Command, indexDB *sql.DB, resolver *metada
 		results = append(results, verify.TableResult{
 			Schema: u.Schema, Table: u.Table, Status: verify.StatusInconclusive,
 			Detail: "no predecessor baseline (new since the previous snapshot)",
+		})
+	}
+	// Tables in the previous baseline the newest snapshot no longer carries —
+	// dropped, or skipped by a subset ("--tables") re-baseline. Reported as
+	// inconclusive (not verified) so they appear instead of silently vanishing
+	// from a default all-tables run; the exit code is unchanged (inconclusive,
+	// like unpaired, does not by itself fail the run).
+	for _, d := range prevOnly {
+		if want != nil && !want[d.Schema+"."+d.Table] {
+			continue
+		}
+		results = append(results, verify.TableResult{
+			Schema: d.Schema, Table: d.Table, Status: verify.StatusInconclusive,
+			Detail: "present in the previous baseline but absent from the newest snapshot (dropped, or the newest baseline was run with --tables); not verified",
 		})
 	}
 	// A table named in --tables that is absent from BOTH the paired and unpaired

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -112,7 +112,20 @@ func runVerifyBaselinePair(cmd *cobra.Command, indexDB *sql.DB, resolver *metada
 		return fmt.Errorf("discover baseline pair: %w", err)
 	}
 	if len(pairs) == 0 && len(unpaired) == 0 {
-		fmt.Fprintln(cmd.OutOrStdout(), "fewer than two baselines under the source; nothing to verify yet")
+		// Two physically different causes reach here as "fewer than two
+		// baselines". A source with NO baselines at all is almost always a
+		// misconfiguration or a broken baseline job — exiting 0 there would let a
+		// CI/cron gate go permanently green while verifying nothing, the exact
+		// false-assurance this command exists to prevent. A source with exactly
+		// one baseline is a legitimate first run with no predecessor to compare.
+		any, err := verify.AnyBaseline(cmd.Context(), baselineSrc)
+		if err != nil {
+			return fmt.Errorf("list baselines under source: %w", err)
+		}
+		if !any {
+			return fmt.Errorf("no baselines found under %q; nothing to verify (check --baseline-dir/--baseline-s3 and that the baseline job is producing complete snapshots)", baselineSrc)
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), "only one baseline under the source; nothing to verify yet (no predecessor to compare against)")
 		return nil
 	}
 
@@ -147,6 +160,28 @@ func runVerifyBaselinePair(cmd *cobra.Command, indexDB *sql.DB, resolver *metada
 			Schema: u.Schema, Table: u.Table, Status: verify.StatusInconclusive,
 			Detail: "no predecessor baseline (new since the previous snapshot)",
 		})
+	}
+	// A table named in --tables that is absent from BOTH the paired and unpaired
+	// sets was never iterated above, so it would silently vanish from the report
+	// while the run still exited 0 on the other tables' matches — the exact
+	// silent-omission this command exists to prevent (and asymmetric with live
+	// mode, where a bogus --tables entry reaches VerifyTable and gates the exit).
+	// Surface each unseen request as an error so it appears and fails the run.
+	if want != nil {
+		seen := make(map[string]bool, len(results))
+		for _, r := range results {
+			seen[r.Schema+"."+r.Table] = true
+		}
+		for key := range want {
+			if seen[key] {
+				continue
+			}
+			schema, table, _ := strings.Cut(key, ".")
+			results = append(results, verify.TableResult{
+				Schema: schema, Table: table, Status: verify.StatusError,
+				Detail: "requested via --tables but not present in the latest baseline pair",
+			})
+		}
 	}
 	if len(results) == 0 {
 		return fmt.Errorf("no tables matched --tables in the baseline pair")

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/dbtrail/dbtrail/internal/config"
+	"github.com/dbtrail/dbtrail/internal/duckdbutil"
 	"github.com/dbtrail/dbtrail/internal/metadata"
 	"github.com/dbtrail/dbtrail/internal/verify"
 )
@@ -26,30 +27,38 @@ var (
 
 var verifyCmd = &cobra.Command{
 	Use:   "verify",
-	Short: "Verify that a recovery would reproduce the live source",
-	Long: `Reconstruct each table's current state from its baseline + indexed binlog
-events, fingerprint it, and compare to a consistent snapshot of the live source.
-A match proves a recovery would reproduce the source byte-for-byte; a mismatch
-flags a real divergence between the recovery chain and the source.
+	Short: "Verify that a recovery would reproduce the source",
+	Long: `Prove the recovery chain (baseline + indexed binlog) faithfully reproduces
+the data. Two modes:
 
-The source fingerprint reads the whole table at a consistent snapshot, so run
-this off-peak. Results are per table: match, mismatch, or inconclusive (index
-behind the snapshot, no baseline, unsupported PK, coverage gap, or a value class
-this version can't yet compare — never reported as a failure).
+  Baseline-anchored (default, drift-free) — omit --source-dsn. Compares the two
+  most recent baselines: reconstructs the previous baseline forward to the new
+  baseline's exact binlog anchor and fingerprints it against the new baseline.
+  Both sides are at-rest, so it reads no live source — run it any time after a
+  baseline (e.g. right after "bintrail baseline", or on a schedule). No
+  production impact.
+
+  Live-source — pass --source-dsn. Reconstructs each table to a consistent
+  snapshot of the live source and compares. Reads the whole table off the live
+  server, so run it off-peak.
+
+Results are per table: match, mismatch, or inconclusive (no predecessor
+baseline, index behind, unsupported PK, coverage gap, or a value class this
+version can't yet compare — never reported as a failure). The run exits non-zero
+on any mismatch or error, or when nothing was verified.
 
 Examples:
-  # All tables in the latest schema snapshot
-  bintrail verify --source-dsn "..." --index-dsn "..." \
-    --baseline-dir /data/baselines
+  # Baseline-anchored (drift-free), all tables
+  bintrail verify --index-dsn "..." --baseline-dir /data/baselines
 
-  # Specific tables, S3 baselines
+  # Live-source, specific tables, S3 baselines
   bintrail verify --source-dsn "..." --index-dsn "..." \
     --baseline-s3 s3://bucket/baselines --tables mydb.orders,mydb.users`,
 	RunE: runVerify,
 }
 
 func init() {
-	verifyCmd.Flags().StringVar(&vfySourceDSN, "source-dsn", "", "DSN for the live source MySQL database (required)")
+	verifyCmd.Flags().StringVar(&vfySourceDSN, "source-dsn", "", "DSN for the live source MySQL database; pass it for live-source mode, omit for baseline-anchored mode")
 	verifyCmd.Flags().StringVar(&vfyIndexDSN, "index-dsn", "", "DSN for the index MySQL database (required)")
 	verifyCmd.Flags().StringVar(&vfyBaselineDir, "baseline-dir", "", "Local directory of baseline Parquet snapshots")
 	verifyCmd.Flags().StringVar(&vfyBaselineS3, "baseline-s3", "", "S3 URL prefix of baseline Parquet snapshots (e.g. s3://bucket/baselines/)")
@@ -59,9 +68,6 @@ func init() {
 }
 
 func runVerify(cmd *cobra.Command, _ []string) error {
-	if vfySourceDSN == "" {
-		return fmt.Errorf("--source-dsn is required")
-	}
 	if vfyIndexDSN == "" {
 		return fmt.Errorf("--index-dsn is required")
 	}
@@ -73,12 +79,6 @@ func runVerify(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("one of --baseline-dir or --baseline-s3 is required")
 	}
 
-	sourceDB, err := config.Connect(vfySourceDSN)
-	if err != nil {
-		return fmt.Errorf("connect to source database: %w", err)
-	}
-	defer sourceDB.Close()
-
 	indexDB, err := config.Connect(vfyIndexDSN)
 	if err != nil {
 		return fmt.Errorf("connect to index database: %w", err)
@@ -89,16 +89,79 @@ func runVerify(cmd *cobra.Command, _ []string) error {
 	if cfg, parseErr := mysqldriver.ParseDSN(vfyIndexDSN); parseErr == nil {
 		indexDBName = cfg.DBName
 	}
-
 	resolver, err := metadata.NewResolver(indexDB, 0)
 	if err != nil {
 		return fmt.Errorf("load schema snapshot from index: %w", err)
 	}
-
 	duckTuning, err := DuckDBTuningFromFlags(cmd)
 	if err != nil {
 		return err
 	}
+
+	if vfySourceDSN != "" {
+		return runVerifyLive(cmd, indexDB, resolver, indexDBName, baselineSrc, duckTuning)
+	}
+	return runVerifyBaselinePair(cmd, indexDB, resolver, indexDBName, baselineSrc, duckTuning)
+}
+
+// runVerifyBaselinePair is the default, drift-free mode: compare the two most
+// recent baselines (#642). It reads no live source.
+func runVerifyBaselinePair(cmd *cobra.Command, indexDB *sql.DB, resolver *metadata.Resolver, indexDBName, baselineSrc string, duckTuning duckdbutil.Tuning) error {
+	pairs, unpaired, err := verify.FindBaselinePair(cmd.Context(), baselineSrc)
+	if err != nil {
+		return fmt.Errorf("discover baseline pair: %w", err)
+	}
+	if len(pairs) == 0 && len(unpaired) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "fewer than two baselines under the source; nothing to verify yet")
+		return nil
+	}
+
+	want, err := verifyTableFilter()
+	if err != nil {
+		return err
+	}
+	cfg := verify.BaselineConfig{
+		IndexDB:        indexDB,
+		Resolver:       resolver,
+		IndexDBName:    indexDBName,
+		NoArchive:      vfyNoArchive,
+		ArchiveFetcher: TunedArchiveFetcher(duckTuning),
+	}
+
+	results := make([]verify.TableResult, 0, len(pairs)+len(unpaired))
+	for _, p := range pairs {
+		if want != nil && !want[p.Schema+"."+p.Table] {
+			continue
+		}
+		res, err := verify.VerifyBaselinePair(cmd.Context(), cfg, p)
+		if err != nil {
+			res = verify.TableResult{Schema: p.Schema, Table: p.Table, Status: verify.StatusError, Detail: err.Error()}
+		}
+		results = append(results, res)
+	}
+	for _, u := range unpaired {
+		if want != nil && !want[u.Schema+"."+u.Table] {
+			continue
+		}
+		results = append(results, verify.TableResult{
+			Schema: u.Schema, Table: u.Table, Status: verify.StatusInconclusive,
+			Detail: "no predecessor baseline (new since the previous snapshot)",
+		})
+	}
+	if len(results) == 0 {
+		return fmt.Errorf("no tables matched --tables in the baseline pair")
+	}
+	return printVerifyReport(cmd, results)
+}
+
+// runVerifyLive is the secondary mode: reconstruct each table to a consistent
+// snapshot of the live source and compare (#634).
+func runVerifyLive(cmd *cobra.Command, indexDB *sql.DB, resolver *metadata.Resolver, indexDBName, baselineSrc string, duckTuning duckdbutil.Tuning) error {
+	sourceDB, err := config.Connect(vfySourceDSN)
+	if err != nil {
+		return fmt.Errorf("connect to source database: %w", err)
+	}
+	defer sourceDB.Close()
 
 	tables, err := verifyTargetTables(cmd, indexDB)
 	if err != nil {
@@ -128,8 +191,23 @@ func runVerify(cmd *cobra.Command, _ []string) error {
 		}
 		results = append(results, res)
 	}
-
 	return printVerifyReport(cmd, results)
+}
+
+// verifyTableFilter parses --tables into a "schema.table" set, or nil for all.
+func verifyTableFilter() (map[string]bool, error) {
+	if vfyTables == "" {
+		return nil, nil
+	}
+	want := map[string]bool{}
+	for _, entry := range splitAndTrim(vfyTables, ",") {
+		parts := strings.SplitN(entry, ".", 2)
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			return nil, fmt.Errorf("invalid --tables entry %q (want schema.table)", entry)
+		}
+		want[parts[0]+"."+parts[1]] = true
+	}
+	return want, nil
 }
 
 type schemaTable struct{ schema, table string }

--- a/internal/cli/verify_baseline_integration_test.go
+++ b/internal/cli/verify_baseline_integration_test.go
@@ -104,3 +104,69 @@ func TestRunVerifyBaselinePair_EndToEnd(t *testing.T) {
 		t.Errorf("expected '1 match' in report, got:\n%s", out.String())
 	}
 }
+
+// TestRunVerifyBaselinePair_EndToEnd_Mismatch is the inversion that proves the
+// command actually turns red on a real divergence — the whole reason it exists.
+// Same setup as _EndToEnd, but the indexed UPDATE's after-image ("cancelled")
+// disagrees with the new baseline's row ("shipped"), so reconstruct(prev→anchor)
+// differs from the new baseline. The assertion checks the mismatch-specific
+// signal ("1 mismatch"), NOT merely err != nil: printVerifyReport also errors on
+// the all-inconclusive (match==0) path, so an err-only check would pass even if
+// the comparison silently degraded to inconclusive instead of detecting the
+// divergence. The divergence is built from a disagreeing after-image, not an
+// omitted event (which would trip the coverage-gap inconclusive path — green for
+// the wrong reason).
+func TestRunVerifyBaselinePair_EndToEnd_Mismatch(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	for _, c := range []struct {
+		name, key, dt string
+		ord           int
+	}{{"id", "PRI", "int", 1}, {"status", "", "varchar", 2}} {
+		testutil.MustExec(t, db, `INSERT INTO schema_snapshots
+			(snapshot_id, snapshot_time, schema_name, table_name, column_name,
+			 ordinal_position, column_key, data_type, column_type, is_nullable, is_generated)
+			VALUES (1, UTC_TIMESTAMP(), ?, 'orders', ?, ?, ?, ?, ?, 'YES', 0)`,
+			dbName, c.name, c.ord, c.key, c.dt, c.dt)
+	}
+
+	baseDir := t.TempDir()
+	now := time.Now().UTC()
+	prevTS := now.Truncate(time.Hour).Add(-2 * time.Hour)
+	newTS := prevTS.Add(time.Hour)
+	createSQL := "CREATE TABLE `orders` (\n  `id` INT NOT NULL,\n  `status` VARCHAR(64),\n  PRIMARY KEY (`id`)\n);\n"
+	cols := []baseline.Column{
+		{Name: "id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
+		{Name: "status", MySQLType: "varchar", ParquetType: baseline.MysqlToParquetNode("varchar")},
+	}
+	writeCLIBaseline(t, baseDir, prevTS, dbName, "orders", createSQL, cols, [][]string{{"1", "a"}, {"2", "b"}}, 200)
+	writeCLIBaseline(t, baseDir, newTS, dbName, "orders", createSQL, cols, [][]string{{"1", "a"}, {"2", "shipped"}}, 300)
+
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{prevTS, newTS, now.Truncate(time.Hour)})
+	// after-image "cancelled" disagrees with the new baseline's "shipped".
+	testutil.InsertEvent(t, db, "binlog.000001", 200, 300, prevTS.Add(30*time.Minute).Format("2006-01-02 15:04:05"),
+		nil, dbName, "orders", 2 /*UPDATE*/, "2", nil,
+		[]byte(`{"id":2,"status":"b"}`), []byte(`{"id":2,"status":"cancelled"}`))
+
+	resolver, err := metadata.NewResolver(db, 1)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+	vfyNoArchive = true
+	t.Cleanup(func() { vfyNoArchive = false })
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	err = runVerifyBaselinePair(cmd, db, resolver, dbName, baseDir, duckdbutil.Tuning{})
+	if err == nil {
+		t.Fatalf("want a non-nil error (non-zero exit) on divergence, got nil\noutput:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "1 mismatch") {
+		t.Errorf("want '1 mismatch' in report (divergence detected), got:\n%s", out.String())
+	}
+}

--- a/internal/cli/verify_baseline_integration_test.go
+++ b/internal/cli/verify_baseline_integration_test.go
@@ -1,0 +1,106 @@
+//go:build integration
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dbtrail/dbtrail/internal/baseline"
+	"github.com/dbtrail/dbtrail/internal/duckdbutil"
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+func writeCLIBaseline(t *testing.T, baseDir string, ts time.Time, db, table, createSQL string,
+	cols []baseline.Column, rows [][]string, anchorPos int64) {
+	t.Helper()
+	snapDir := filepath.Join(baseDir, strings.ReplaceAll(ts.Format(time.RFC3339), ":", "-"))
+	if err := os.MkdirAll(filepath.Join(snapDir, db), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	bw, err := baseline.NewWriter(filepath.Join(snapDir, db, table+".parquet"), cols,
+		baseline.WriterConfig{Compression: "zstd", RowGroupSize: 100, Metadata: map[string]string{
+			baseline.MetaKeyCreateTableSQL: createSQL,
+			baseline.MetaKeyBinlogFile:     "binlog.000001",
+			baseline.MetaKeyBinlogPos:      strconv.FormatInt(anchorPos, 10),
+		}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range rows {
+		if err := bw.WriteRow(r, make([]bool, len(r))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := bw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := baseline.WriteSuccessMarker(snapDir); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestRunVerifyBaselinePair_EndToEnd drives the CLI baseline-anchored mode: two
+// baselines + events between them → the report shows a match and the run exits 0.
+func TestRunVerifyBaselinePair_EndToEnd(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	for _, c := range []struct {
+		name, key, dt string
+		ord           int
+	}{{"id", "PRI", "int", 1}, {"status", "", "varchar", 2}} {
+		testutil.MustExec(t, db, `INSERT INTO schema_snapshots
+			(snapshot_id, snapshot_time, schema_name, table_name, column_name,
+			 ordinal_position, column_key, data_type, column_type, is_nullable, is_generated)
+			VALUES (1, UTC_TIMESTAMP(), ?, 'orders', ?, ?, ?, ?, ?, 'YES', 0)`,
+			dbName, c.name, c.ord, c.key, c.dt, c.dt)
+	}
+
+	baseDir := t.TempDir()
+	now := time.Now().UTC()
+	prevTS := now.Truncate(time.Hour).Add(-2 * time.Hour)
+	newTS := prevTS.Add(time.Hour)
+	createSQL := "CREATE TABLE `orders` (\n  `id` INT NOT NULL,\n  `status` VARCHAR(64),\n  PRIMARY KEY (`id`)\n);\n"
+	cols := []baseline.Column{
+		{Name: "id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
+		{Name: "status", MySQLType: "varchar", ParquetType: baseline.MysqlToParquetNode("varchar")},
+	}
+	writeCLIBaseline(t, baseDir, prevTS, dbName, "orders", createSQL, cols, [][]string{{"1", "a"}, {"2", "b"}}, 200)
+	writeCLIBaseline(t, baseDir, newTS, dbName, "orders", createSQL, cols, [][]string{{"1", "a"}, {"2", "shipped"}}, 300)
+
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{prevTS, newTS, now.Truncate(time.Hour)})
+	testutil.InsertEvent(t, db, "binlog.000001", 200, 300, prevTS.Add(30*time.Minute).Format("2006-01-02 15:04:05"),
+		nil, dbName, "orders", 2 /*UPDATE*/, "2", nil,
+		[]byte(`{"id":2,"status":"b"}`), []byte(`{"id":2,"status":"shipped"}`))
+
+	resolver, err := metadata.NewResolver(db, 1)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+	vfyNoArchive = true
+	t.Cleanup(func() { vfyNoArchive = false })
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := runVerifyBaselinePair(cmd, db, resolver, dbName, baseDir, duckdbutil.Tuning{}); err != nil {
+		t.Fatalf("runVerifyBaselinePair: %v\noutput:\n%s", err, out.String())
+	}
+	if !strings.Contains(out.String(), "1 match") {
+		t.Errorf("expected '1 match' in report, got:\n%s", out.String())
+	}
+}

--- a/internal/cli/verify_baseline_test.go
+++ b/internal/cli/verify_baseline_test.go
@@ -3,29 +3,92 @@ package cli
 import (
 	"bytes"
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 
+	"github.com/dbtrail/dbtrail/internal/baseline"
 	"github.com/dbtrail/dbtrail/internal/duckdbutil"
 )
 
-// TestRunVerifyBaselinePair_NothingToVerify locks the CLI early-return: with
-// fewer than two baselines under the source, the run prints a clear message and
-// exits 0 (not a failure — the first baseline has no predecessor). It returns
-// before touching the index, so nil DBs are safe here.
-func TestRunVerifyBaselinePair_NothingToVerify(t *testing.T) {
+// writeMinimalBaseline writes one complete baseline snapshot (one table, one
+// row, plus the success marker) under baseDir. It needs no live database — the
+// "nothing to verify" paths return before touching the index — so it lets the
+// single-baseline case be a fast unit test rather than an integration one.
+func writeMinimalBaseline(t *testing.T, baseDir, db, table string, ts time.Time) {
+	t.Helper()
+	snapDir := filepath.Join(baseDir, strings.ReplaceAll(ts.Format(time.RFC3339), ":", "-"))
+	if err := os.MkdirAll(filepath.Join(snapDir, db), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cols := []baseline.Column{
+		{Name: "id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
+	}
+	bw, err := baseline.NewWriter(filepath.Join(snapDir, db, table+".parquet"), cols,
+		baseline.WriterConfig{Compression: "zstd", RowGroupSize: 100, Metadata: map[string]string{
+			baseline.MetaKeyCreateTableSQL: "CREATE TABLE `" + table + "` (`id` INT PRIMARY KEY);",
+			baseline.MetaKeyBinlogFile:     "binlog.000001",
+			baseline.MetaKeyBinlogPos:      "200",
+		}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bw.WriteRow([]string{"1"}, []bool{false}); err != nil {
+		t.Fatal(err)
+	}
+	if err := bw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := baseline.WriteSuccessMarker(snapDir); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestRunVerifyBaselinePair_NoBaselines locks the fail-loud contract: a source
+// with NO baselines at all (an empty dir — almost always a misconfigured
+// --baseline-dir or a broken baseline job) must error and exit non-zero, not
+// silently exit 0. A green CI gate over zero baselines is the false assurance
+// this command exists to prevent. It returns before touching the index, so nil
+// DBs are safe.
+func TestRunVerifyBaselinePair_NoBaselines(t *testing.T) {
 	cmd := &cobra.Command{}
 	cmd.SetContext(context.Background())
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 
 	err := runVerifyBaselinePair(cmd, nil, nil, "", t.TempDir(), duckdbutil.Tuning{})
-	if err != nil {
-		t.Fatalf("want nil error (exit 0) for <2 baselines, got %v", err)
+	if err == nil {
+		t.Fatalf("want a non-nil error (non-zero exit) for zero baselines, got nil; output:\n%s", out.String())
 	}
-	if !strings.Contains(out.String(), "nothing to verify") {
-		t.Errorf("want a 'nothing to verify' message, got %q", out.String())
+	if !strings.Contains(err.Error(), "no baselines found") {
+		t.Errorf("want a 'no baselines found' error, got %v", err)
+	}
+}
+
+// TestRunVerifyBaselinePair_SingleBaseline locks the other half of that
+// distinction: a legitimate first run with exactly one baseline has no
+// predecessor, so it prints a clear message and exits 0 (not an error). This
+// also proves the NoBaselines fail-loud above did not over-reach into the
+// legitimate not-yet case. Returns before touching the index, so nil DBs are
+// safe.
+func TestRunVerifyBaselinePair_SingleBaseline(t *testing.T) {
+	baseDir := t.TempDir()
+	writeMinimalBaseline(t, baseDir, "mydb", "orders", time.Now().UTC().Truncate(time.Hour))
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	err := runVerifyBaselinePair(cmd, nil, nil, "", baseDir, duckdbutil.Tuning{})
+	if err != nil {
+		t.Fatalf("want nil error (exit 0) for a single baseline, got %v\noutput:\n%s", err, out.String())
+	}
+	if !strings.Contains(out.String(), "only one baseline") {
+		t.Errorf("want an 'only one baseline' message, got %q", out.String())
 	}
 }

--- a/internal/cli/verify_baseline_test.go
+++ b/internal/cli/verify_baseline_test.go
@@ -1,0 +1,31 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dbtrail/dbtrail/internal/duckdbutil"
+)
+
+// TestRunVerifyBaselinePair_NothingToVerify locks the CLI early-return: with
+// fewer than two baselines under the source, the run prints a clear message and
+// exits 0 (not a failure — the first baseline has no predecessor). It returns
+// before touching the index, so nil DBs are safe here.
+func TestRunVerifyBaselinePair_NothingToVerify(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	err := runVerifyBaselinePair(cmd, nil, nil, "", t.TempDir(), duckdbutil.Tuning{})
+	if err != nil {
+		t.Fatalf("want nil error (exit 0) for <2 baselines, got %v", err)
+	}
+	if !strings.Contains(out.String(), "nothing to verify") {
+		t.Errorf("want a 'nothing to verify' message, got %q", out.String())
+	}
+}

--- a/internal/cli/verify_baseline_test.go
+++ b/internal/cli/verify_baseline_test.go
@@ -92,3 +92,34 @@ func TestRunVerifyBaselinePair_SingleBaseline(t *testing.T) {
 		t.Errorf("want an 'only one baseline' message, got %q", out.String())
 	}
 }
+
+// TestRunVerifyBaselinePair_TablesAbsent locks the no-silent-omission contract
+// for --tables: a requested table that exists in neither the paired nor the
+// unpaired set must surface as an error and fail the run, not vanish while the
+// other tables' matches keep the exit at 0. Two baselines for `orders` form a
+// real pair; --tables names a table that isn't there, so every real pair is
+// filtered out (the index is never touched — nil DBs are safe) and the unseen
+// request is the only result, as a StatusError.
+func TestRunVerifyBaselinePair_TablesAbsent(t *testing.T) {
+	baseDir := t.TempDir()
+	base := time.Now().UTC().Truncate(time.Hour)
+	writeMinimalBaseline(t, baseDir, "mydb", "orders", base.Add(-2*time.Hour))
+	writeMinimalBaseline(t, baseDir, "mydb", "orders", base.Add(-1*time.Hour))
+
+	vfyTables = "mydb.ghost"
+	t.Cleanup(func() { vfyTables = "" })
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	err := runVerifyBaselinePair(cmd, nil, nil, "", baseDir, duckdbutil.Tuning{})
+	if err == nil {
+		t.Fatalf("want a non-nil error (non-zero exit) for an absent --tables request, got nil; output:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "1 error") ||
+		!strings.Contains(out.String(), "not present in the latest baseline pair") {
+		t.Errorf("want the ghost table surfaced as an error, got output:\n%s", out.String())
+	}
+}

--- a/internal/verify/verify_baseline.go
+++ b/internal/verify/verify_baseline.go
@@ -210,15 +210,25 @@ func AnyBaseline(ctx context.Context, source string) (bool, error) {
 // FindBaselinePair builds the verifiable table pairs from the two most recent
 // baseline snapshots under source: for every table present in both, the prev +
 // new Parquet paths, the prev snapshot time, and the new baseline's binlog
-// anchor (read from its Parquet metadata). It also returns the tables in the new
-// snapshot that have NO predecessor image (new since the prev snapshot) so the
-// caller can report them rather than silently dropping them — an
-// operator must be able to tell "verified" from "not present to verify". Returns
-// nil, nil, nil (nothing to verify) when fewer than two snapshots exist.
-func FindBaselinePair(ctx context.Context, source string) (pairs []BaselinePair, unpaired []query.SchemaTable, err error) {
+// anchor (read from its Parquet metadata).
+//
+// It also surfaces the two asymmetric "can't pair" sets so the caller reports
+// them instead of silently dropping either — an operator must be able to tell
+// "verified" from "not present to verify":
+//   - unpaired: present in the NEW snapshot, absent from the prev (new since the
+//     prev snapshot — no predecessor image to reconstruct from).
+//   - prevOnly: present in the PREV snapshot, absent from the new. Either a table
+//     dropped between the snapshots, or the newest baseline was a subset (e.g.
+//     "bintrail baseline --tables") that didn't re-snapshot it. Without this the
+//     table would produce no report row at all on a default all-tables run — a
+//     silent omission that could let "recovery verified" hide untouched tables.
+//
+// Returns nil, nil, nil, nil (nothing to verify) when fewer than two snapshots
+// exist.
+func FindBaselinePair(ctx context.Context, source string) (pairs []BaselinePair, unpaired, prevOnly []query.SchemaTable, err error) {
 	files, err := reconstruct.ListBaselines(ctx, source)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	// files are newest-snapshot-first; find the two most recent distinct times.
 	var tNew, tPrev time.Time
@@ -233,7 +243,7 @@ func FindBaselinePair(ctx context.Context, source string) (pairs []BaselinePair,
 		}
 	}
 	if tNew.IsZero() || tPrev.IsZero() {
-		return nil, nil, nil // fewer than two snapshots: nothing to verify yet
+		return nil, nil, nil, nil // fewer than two snapshots: nothing to verify yet
 	}
 
 	newByTable := map[string]reconstruct.BaselineFile{}
@@ -257,7 +267,7 @@ func FindBaselinePair(ctx context.Context, source string) (pairs []BaselinePair,
 		}
 		meta, err := baseline.ReadParquetMetadataAny(ctx, nf.Path)
 		if err != nil {
-			return nil, nil, fmt.Errorf("read new baseline metadata %s: %w", nf.Path, err)
+			return nil, nil, nil, fmt.Errorf("read new baseline metadata %s: %w", nf.Path, err)
 		}
 		pairs = append(pairs, BaselinePair{
 			Schema:       nf.Schema,
@@ -269,11 +279,24 @@ func FindBaselinePair(ctx context.Context, source string) (pairs []BaselinePair,
 			NewAnchor:    query.BinlogPos{File: meta.BinlogFile, Pos: uint64(meta.BinlogPos)},
 		})
 	}
-	sort.Slice(unpaired, func(i, j int) bool {
-		if unpaired[i].Schema != unpaired[j].Schema {
-			return unpaired[i].Schema < unpaired[j].Schema
+	// Symmetric to unpaired: tables in the prev snapshot the new one no longer
+	// carries. Reported, never silently dropped.
+	for key, pf := range prevByTable {
+		if _, ok := newByTable[key]; ok {
+			continue
 		}
-		return unpaired[i].Table < unpaired[j].Table
+		prevOnly = append(prevOnly, query.SchemaTable{Schema: pf.Schema, Table: pf.Table})
+	}
+	sortSchemaTables(unpaired)
+	sortSchemaTables(prevOnly)
+	return pairs, unpaired, prevOnly, nil
+}
+
+func sortSchemaTables(s []query.SchemaTable) {
+	sort.Slice(s, func(i, j int) bool {
+		if s[i].Schema != s[j].Schema {
+			return s[i].Schema < s[j].Schema
+		}
+		return s[i].Table < s[j].Table
 	})
-	return pairs, unpaired, nil
 }

--- a/internal/verify/verify_baseline.go
+++ b/internal/verify/verify_baseline.go
@@ -192,6 +192,21 @@ func deferredReprChanged(cols []metadata.ColumnMeta, changes map[string]*query.R
 	return false
 }
 
+// AnyBaseline reports whether at least one complete baseline snapshot exists
+// under source. The CLI uses it on the "nothing to verify" path to tell two
+// physically different causes apart: a misconfigured or empty source (no
+// baselines at all — a broken baseline job → fail loud) from a legitimate first
+// run (exactly one baseline, no predecessor yet → genuinely nothing to compare).
+// FindBaselinePair collapses both into nil, nil, nil, so the distinction has to
+// be recovered here.
+func AnyBaseline(ctx context.Context, source string) (bool, error) {
+	files, err := reconstruct.ListBaselines(ctx, source)
+	if err != nil {
+		return false, err
+	}
+	return len(files) > 0, nil
+}
+
 // FindBaselinePair builds the verifiable table pairs from the two most recent
 // baseline snapshots under source: for every table present in both, the prev +
 // new Parquet paths, the prev snapshot time, and the new baseline's binlog

--- a/internal/verify/verify_baseline_integration_test.go
+++ b/internal/verify/verify_baseline_integration_test.go
@@ -130,7 +130,7 @@ func TestVerifyBaselinePair_MatchAndMismatch(t *testing.T) {
 	cfg := BaselineConfig{IndexDB: db, Resolver: resolver, IndexDBName: dbName, NoArchive: true}
 	ctx := context.Background()
 
-	pairs, unpaired, err := FindBaselinePair(ctx, baseDir)
+	pairs, unpaired, prevOnly, err := FindBaselinePair(ctx, baseDir)
 	if err != nil {
 		t.Fatalf("FindBaselinePair: %v", err)
 	}
@@ -139,6 +139,9 @@ func TestVerifyBaselinePair_MatchAndMismatch(t *testing.T) {
 	}
 	if len(unpaired) != 0 {
 		t.Errorf("expected no unpaired tables, got %v", unpaired)
+	}
+	if len(prevOnly) != 0 {
+		t.Errorf("expected no prev-only tables, got %v", prevOnly)
 	}
 
 	// MATCH: reconstruct(prev → anchor) == the new baseline.
@@ -198,7 +201,7 @@ func TestFindBaselinePair_UnpairedAndSelection(t *testing.T) {
 	writeTestBaseline(t, baseDir, newTS, "db", "orders", createSQL, cols, rows, "binlog.000001", 300)
 	writeTestBaseline(t, baseDir, newTS, "db", "fresh", createSQL, cols, rows, "binlog.000001", 300) // new-only
 
-	pairs, unpaired, err := FindBaselinePair(context.Background(), baseDir)
+	pairs, unpaired, _, err := FindBaselinePair(context.Background(), baseDir)
 	if err != nil {
 		t.Fatalf("FindBaselinePair: %v", err)
 	}
@@ -211,6 +214,40 @@ func TestFindBaselinePair_UnpairedAndSelection(t *testing.T) {
 	}
 	if len(unpaired) != 1 || unpaired[0].Table != "fresh" {
 		t.Errorf("expected 'fresh' in unpaired (new since prev), got %+v", unpaired)
+	}
+}
+
+// TestFindBaselinePair_PrevOnly locks the symmetric reverse of the unpaired
+// case: a table present in the previous snapshot but absent from the newest one
+// (a drop, or a subset "--tables" re-baseline) must surface in prevOnly, never
+// silently vanish. Without it a default verify could report a clean pass while
+// such a table was never checked or even printed.
+func TestFindBaselinePair_PrevOnly(t *testing.T) {
+	baseDir := t.TempDir()
+	now := time.Now().UTC()
+	createSQL := "CREATE TABLE `t` (\n  `id` INT NOT NULL,\n  PRIMARY KEY (`id`)\n);\n"
+	cols := []baseline.Column{{Name: "id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")}}
+	rows := [][]string{{"1"}}
+	prevTS := now.Truncate(time.Hour).Add(-2 * time.Hour)
+	newTS := now.Truncate(time.Hour).Add(-1 * time.Hour)
+
+	// prev snapshot carries two tables; the newest re-snapshots only orders.
+	writeTestBaseline(t, baseDir, prevTS, "db", "orders", createSQL, cols, rows, "binlog.000001", 200)
+	writeTestBaseline(t, baseDir, prevTS, "db", "customers", createSQL, cols, rows, "binlog.000001", 200)
+	writeTestBaseline(t, baseDir, newTS, "db", "orders", createSQL, cols, rows, "binlog.000001", 300)
+
+	pairs, unpaired, prevOnly, err := FindBaselinePair(context.Background(), baseDir)
+	if err != nil {
+		t.Fatalf("FindBaselinePair: %v", err)
+	}
+	if len(pairs) != 1 || pairs[0].Table != "orders" {
+		t.Fatalf("expected one pair for orders, got %+v", pairs)
+	}
+	if len(unpaired) != 0 {
+		t.Errorf("expected no unpaired tables, got %+v", unpaired)
+	}
+	if len(prevOnly) != 1 || prevOnly[0].Table != "customers" {
+		t.Errorf("expected 'customers' in prevOnly (in prev, absent from newest), got %+v", prevOnly)
 	}
 }
 
@@ -256,7 +293,7 @@ func TestVerifyBaselinePair_UnchangedTable(t *testing.T) {
 		t.Fatalf("NewResolver: %v", err)
 	}
 	cfg := BaselineConfig{IndexDB: db, Resolver: resolver, IndexDBName: dbName, NoArchive: true}
-	pairs, _, err := FindBaselinePair(context.Background(), baseDir)
+	pairs, _, _, err := FindBaselinePair(context.Background(), baseDir)
 	if err != nil || len(pairs) != 1 {
 		t.Fatalf("FindBaselinePair: %v (pairs=%d)", err, len(pairs))
 	}


### PR DESCRIPTION
closes #643 — makes the baseline-anchored verify epic #640 usable from the CLI.

## Summary
`bintrail verify` now **defaults to the baseline-anchored mode** and runs the live-source mode only when `--source-dsn` is passed.

- **Default (drift-free):** compares the two most recent baselines (`VerifyBaselinePair`, #642) — reconstructs the previous baseline forward to the new baseline's exact binlog anchor and fingerprints it against the new baseline. Both sides at-rest → no live source, no production impact. Run it post-baseline or on a schedule.
- **`--source-dsn` (optional, was required):** live-source mode (#634), unchanged.
- `<2` baselines → clear "nothing to verify yet", exit 0 (the first baseline has no predecessor — not a failure).
- Tables new since the previous snapshot are reported `inconclusive`, not dropped; `--tables` filters the pair.
- Reuses `printVerifyReport` (per-table report + exit code).

## Out of scope (documented follow-ups)
The `baseline --verify` auto-trigger, the console badge, and index persistence of results. The standalone command — run post-baseline or scheduled, like the live mode — already makes the epic usable.

## Test plan
- [x] Full repo unit suite green (`--source-dsn` optional broke nothing)
- [x] No-DB unit test for the `<2`-baselines early return (message + exit 0)
- [x] **Integration**: full CLI baseline-anchored path — two baselines + an event between them → the report shows a match, exit 0
- [x] Caught + fixed a test-only hang: `cmd.Context()` is nil for a bare cobra command (production sets it via Execute); the test now sets it, else DuckDB QueryContext(nil) panicked

🤖 Generated with [Claude Code](https://claude.com/claude-code)