### PR TITLE
verify: native row-level drill-down on baseline-anchored mismatch (--explain)

### DIFF
--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -53,8 +53,8 @@ proven (all inconclusive). A source with only one baseline — no predecessor ye
 Add --explain (baseline-anchored mode) to print, below the report, a row-level
 drill-down of each mismatch: which primary keys diverged and, for changed rows,
 the differing columns with the reconstructed value vs the new baseline's. It
-reuses the same reconstruction the verdict came from — no live source, scratch
-database, or external tool.
+re-runs the same reconstruction the verdict came from (byte-identical by
+construction) — no live source, scratch database, or external tool.
 
 Examples:
   # Baseline-anchored (drift-free), all tables

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -23,6 +23,7 @@ var (
 	vfyBaselineS3  string
 	vfyTables      string
 	vfyNoArchive   bool
+	vfyExplain     bool
 )
 
 var verifyCmd = &cobra.Command{
@@ -49,9 +50,18 @@ on any mismatch or error, or when comparable tables existed but none could be
 proven (all inconclusive). A source with only one baseline — no predecessor yet
 — is reported and exits zero.
 
+Add --explain (baseline-anchored mode) to print, below the report, a row-level
+drill-down of each mismatch: which primary keys diverged and, for changed rows,
+the differing columns with the reconstructed value vs the new baseline's. It
+reuses the same reconstruction the verdict came from — no live source, scratch
+database, or external tool.
+
 Examples:
   # Baseline-anchored (drift-free), all tables
   bintrail verify --index-dsn "..." --baseline-dir /data/baselines
+
+  # Baseline-anchored with a row-level drill-down on any mismatch
+  bintrail verify --index-dsn "..." --baseline-dir /data/baselines --explain
 
   # Live-source, specific tables, S3 baselines
   bintrail verify --source-dsn "..." --index-dsn "..." \
@@ -66,6 +76,7 @@ func init() {
 	verifyCmd.Flags().StringVar(&vfyBaselineS3, "baseline-s3", "", "S3 URL prefix of baseline Parquet snapshots (e.g. s3://bucket/baselines/)")
 	verifyCmd.Flags().StringVar(&vfyTables, "tables", "", "Comma-separated schema.table list (default: all tables in the latest schema snapshot)")
 	verifyCmd.Flags().BoolVar(&vfyNoArchive, "no-archive", false, "Query live MySQL partitions only; skip Parquet archive discovery")
+	verifyCmd.Flags().BoolVar(&vfyExplain, "explain", false, "On a baseline-anchored mismatch, print a row-level drill-down (which primary keys diverged and how) below the report")
 	AddDuckDBTuningFlags(verifyCmd)
 }
 
@@ -144,6 +155,7 @@ func runVerifyBaselinePair(cmd *cobra.Command, indexDB *sql.DB, resolver *metada
 	}
 
 	results := make([]verify.TableResult, 0, len(pairs)+len(unpaired))
+	var toExplain []verify.BaselinePair // mismatched pairs to drill into when --explain
 	for _, p := range pairs {
 		if want != nil && !want[p.Schema+"."+p.Table] {
 			continue
@@ -153,6 +165,9 @@ func runVerifyBaselinePair(cmd *cobra.Command, indexDB *sql.DB, resolver *metada
 			res = verify.TableResult{Schema: p.Schema, Table: p.Table, Status: verify.StatusError, Detail: err.Error()}
 		}
 		results = append(results, res)
+		if vfyExplain && res.Status == verify.StatusMismatch {
+			toExplain = append(toExplain, p)
+		}
 	}
 	for _, u := range unpaired {
 		if want != nil && !want[u.Schema+"."+u.Table] {
@@ -202,7 +217,19 @@ func runVerifyBaselinePair(cmd *cobra.Command, indexDB *sql.DB, resolver *metada
 	if len(results) == 0 {
 		return fmt.Errorf("no tables matched --tables in the baseline pair")
 	}
-	return printVerifyReport(cmd, results)
+	reportErr := printVerifyReport(cmd, results)
+	// Drill-downs print AFTER the summary table so the verdict reads first, then
+	// the per-row detail for each mismatch. A drill-down failure is non-fatal — it
+	// must not mask the report's own (mismatch) exit status.
+	for _, p := range toExplain {
+		ex, err := verify.ExplainBaselinePairMismatch(cmd.Context(), cfg, p)
+		if err != nil {
+			fmt.Fprintf(cmd.OutOrStdout(), "\n--- mismatch drill-down: %s.%s — unavailable: %v ---\n", p.Schema, p.Table, err)
+			continue
+		}
+		ex.Write(cmd.OutOrStdout())
+	}
+	return reportErr
 }
 
 // runVerifyLive is the secondary mode: reconstruct each table to a consistent

--- a/internal/cli/verify_baseline_integration_test.go
+++ b/internal/cli/verify_baseline_integration_test.go
@@ -170,3 +170,73 @@ func TestRunVerifyBaselinePair_EndToEnd_Mismatch(t *testing.T) {
 		t.Errorf("want '1 mismatch' in report (divergence detected), got:\n%s", out.String())
 	}
 }
+
+// TestRunVerifyBaselinePair_Explain pins the --explain CLI wiring: on a mismatch
+// the drill-down prints BELOW the report, names the exact diff, AND the run still
+// exits non-zero on the mismatch — a drill-down must never mask the verdict's exit
+// status (this command is an automation gate).
+func TestRunVerifyBaselinePair_Explain(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	for _, c := range []struct {
+		name, key, dt string
+		ord           int
+	}{{"id", "PRI", "int", 1}, {"status", "", "varchar", 2}} {
+		testutil.MustExec(t, db, `INSERT INTO schema_snapshots
+			(snapshot_id, snapshot_time, schema_name, table_name, column_name,
+			 ordinal_position, column_key, data_type, column_type, is_nullable, is_generated)
+			VALUES (1, UTC_TIMESTAMP(), ?, 'orders', ?, ?, ?, ?, ?, 'YES', 0)`,
+			dbName, c.name, c.ord, c.key, c.dt, c.dt)
+	}
+
+	baseDir := t.TempDir()
+	now := time.Now().UTC()
+	prevTS := now.Truncate(time.Hour).Add(-2 * time.Hour)
+	newTS := prevTS.Add(time.Hour)
+	createSQL := "CREATE TABLE `orders` (\n  `id` INT NOT NULL,\n  `status` VARCHAR(64),\n  PRIMARY KEY (`id`)\n);\n"
+	cols := []baseline.Column{
+		{Name: "id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
+		{Name: "status", MySQLType: "varchar", ParquetType: baseline.MysqlToParquetNode("varchar")},
+	}
+	writeCLIBaseline(t, baseDir, prevTS, dbName, "orders", createSQL, cols, [][]string{{"1", "a"}, {"2", "b"}}, 200)
+	writeCLIBaseline(t, baseDir, newTS, dbName, "orders", createSQL, cols, [][]string{{"1", "a"}, {"2", "shipped"}}, 300)
+
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{prevTS, newTS, now.Truncate(time.Hour)})
+	testutil.InsertEvent(t, db, "binlog.000001", 200, 300, prevTS.Add(30*time.Minute).Format("2006-01-02 15:04:05"),
+		nil, dbName, "orders", 2 /*UPDATE*/, "2", nil,
+		[]byte(`{"id":2,"status":"b"}`), []byte(`{"id":2,"status":"cancelled"}`))
+
+	resolver, err := metadata.NewResolver(db, 1)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+	vfyNoArchive = true
+	vfyExplain = true
+	t.Cleanup(func() { vfyNoArchive = false; vfyExplain = false })
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	err = runVerifyBaselinePair(cmd, db, resolver, dbName, baseDir, duckdbutil.Tuning{})
+	if err == nil {
+		t.Fatalf("--explain must not swallow the mismatch exit status, got nil error\noutput:\n%s", out.String())
+	}
+	o := out.String()
+	report := strings.Index(o, "1 mismatch")
+	drill := strings.Index(o, "mismatch drill-down")
+	if report < 0 || drill < 0 {
+		t.Fatalf("want both the report ('1 mismatch') and the drill-down section, got:\n%s", o)
+	}
+	if drill < report {
+		t.Errorf("drill-down must print BELOW the report (drill at %d, report at %d):\n%s", drill, report, o)
+	}
+	for _, want := range []string{"id=2", "recovery=cancelled", "baseline=shipped"} {
+		if !strings.Contains(o, want) {
+			t.Errorf("drill-down missing %q:\n%s", want, o)
+		}
+	}
+}

--- a/internal/verify/explain_baseline.go
+++ b/internal/verify/explain_baseline.go
@@ -1,0 +1,261 @@
+package verify
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/query"
+	"github.com/dbtrail/dbtrail/internal/reconstruct"
+)
+
+// maxExplainRows caps how many differing rows the drill-down prints in detail.
+// It runs only on an already-flagged mismatch (rare, opt-in via --explain); a
+// pathological all-rows-differ table would otherwise dump the whole table. The
+// total count is still reported, so nothing is silently hidden.
+const maxExplainRows = 100
+
+const (
+	diffChanged = "changed" // both sides have the PK; some columns differ
+	diffMissing = "missing" // in the new baseline, not reproduced by the recovery
+	diffExtra   = "extra"   // reconstructed by the recovery, absent from the new baseline
+)
+
+// CellDiff is one column whose reconstructed value diverged from the new
+// baseline's, rendered in the SAME canonical text form the content digest
+// compares — so a reported diff is exactly what made the digests differ.
+type CellDiff struct {
+	Column   string
+	Recovery string // reconstruct(prev baseline + binlog → anchor)
+	Baseline string // the new baseline (the "truth" side)
+}
+
+// RowDiff is one primary key whose reconstructed row differs from the new
+// baseline. Kind is changed/missing/extra (see the diff* constants).
+type RowDiff struct {
+	PK    string
+	Kind  string
+	Cells []CellDiff // populated only for Kind == diffChanged
+}
+
+// MismatchExplanation is the row-level drill-down for one mismatched table: which
+// primary keys diverged and how. It is the "which rows" the one-way content
+// digest cannot give — recomputed from the SAME reconstructed row streams the
+// digest used, so the diff and the verdict can never disagree. No live source,
+// no scratch DB, no external tool: an in-memory full-outer-join on the PK.
+type MismatchExplanation struct {
+	Schema, Table, Anchor string
+	Diffs                 []RowDiff
+	Total                 int // total differing rows (Diffs is capped at maxExplainRows)
+}
+
+func (ex *MismatchExplanation) add(d RowDiff) {
+	ex.Total++
+	if len(ex.Diffs) < maxExplainRows {
+		ex.Diffs = append(ex.Diffs, d)
+	}
+}
+
+// rowCells is one reconstructed row reduced to its canonical per-column bytes
+// (the digest's comparison form) plus a human-readable primary-key label.
+type rowCells struct {
+	pk    string
+	cells map[string][]byte
+}
+
+// ExplainBaselinePairMismatch drills into a table VerifyBaselinePair already
+// reported as StatusMismatch, producing a row-level diff between the recovery
+// side (prev baseline reconstructed forward to the new baseline's anchor) and the
+// new baseline (truth). It reuses the SAME SnapshotFullTableImages row stream the
+// digest is built from, so the diff is guaranteed consistent with the verdict.
+//
+// It re-derives the setup VerifyBaselinePair computed (resolver/columns/changes).
+// Because it runs only after a confirmed mismatch, the guards VerifyBaselinePair
+// applied (PK present and supported, usable anchor, prev→new order) have already
+// passed, so any failure here is a hard error, not an inconclusive verdict.
+func ExplainBaselinePairMismatch(ctx context.Context, cfg BaselineConfig, p BaselinePair) (*MismatchExplanation, error) {
+	tm, err := cfg.Resolver.Resolve(p.Schema, p.Table)
+	if err != nil {
+		return nil, fmt.Errorf("resolve %s.%s: %w", p.Schema, p.Table, err)
+	}
+	pkCols := tm.PKColumnMetas()
+	if len(pkCols) == 0 {
+		return nil, fmt.Errorf("%s.%s has no primary key", p.Schema, p.Table)
+	}
+
+	// Same column set as the digest: exactly what the baseline Parquet holds, via
+	// ReadBaselineColumns (not the is_generated flag — see VerifyBaselinePair).
+	colNames, err := reconstruct.ReadBaselineColumns(ctx, p.NewPath)
+	if err != nil {
+		return nil, fmt.Errorf("read new baseline columns %s.%s: %w", p.Schema, p.Table, err)
+	}
+	colByName := make(map[string]metadata.ColumnMeta, len(tm.Columns))
+	for _, c := range tm.Columns {
+		colByName[c.Name] = c
+	}
+	orderedCols := make([]metadata.ColumnMeta, 0, len(colNames))
+	for _, name := range colNames {
+		cm, ok := colByName[name]
+		if !ok {
+			return nil, fmt.Errorf("baseline column %q absent from the index schema snapshot", name)
+		}
+		orderedCols = append(orderedCols, cm)
+	}
+
+	// Latest event per PK in (prev snapshot, new anchor] — the same window
+	// VerifyBaselinePair reconstructs the recovery side over.
+	engine := query.New(cfg.IndexDB)
+	rows, _, err := query.FetchMerged(ctx, cfg.IndexDB, engine, query.FetchMergedOptions{
+		Opts: query.Options{
+			Schema:     p.Schema,
+			Table:      p.Table,
+			Since:      &p.PrevSnapshot,
+			Until:      &p.NewSnapshot,
+			UntilPos:   &p.NewAnchor,
+			LimitPerPK: 1,
+		},
+		DBName:         cfg.IndexDBName,
+		NoArchive:      cfg.NoArchive,
+		ArchiveFetcher: cfg.ArchiveFetcher,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("fetch changes %s.%s: %w", p.Schema, p.Table, err)
+	}
+	changes := make(map[string]*query.ResultRow, len(rows))
+	for i := range rows {
+		changes[rows[i].PKValues] = &rows[i]
+	}
+
+	// Truth side held fully (the new baseline as-is); recovery streamed against it
+	// so only one side is materialized in memory at a time.
+	truth, err := collectRowsByPK(ctx, p.NewPath, p.Schema, p.Table, pkCols, orderedCols, map[string]*query.ResultRow{})
+	if err != nil {
+		return nil, fmt.Errorf("read new baseline %s.%s: %w", p.Schema, p.Table, err)
+	}
+
+	ex := &MismatchExplanation{Schema: p.Schema, Table: p.Table, Anchor: fmt.Sprintf("%s:%d", p.NewAnchor.File, p.NewAnchor.Pos)}
+	seen := make(map[string]bool, len(truth))
+	err = streamRowsByPK(ctx, p.PrevPath, p.Schema, p.Table, pkCols, orderedCols, changes, func(key string, rec rowCells) error {
+		seen[key] = true
+		t, ok := truth[key]
+		if !ok {
+			ex.add(RowDiff{PK: rec.pk, Kind: diffExtra})
+			return nil
+		}
+		var cells []CellDiff
+		for _, c := range orderedCols {
+			if !bytes.Equal(rec.cells[c.Name], t.cells[c.Name]) {
+				cells = append(cells, CellDiff{Column: c.Name, Recovery: displayCell(rec.cells[c.Name]), Baseline: displayCell(t.cells[c.Name])})
+			}
+		}
+		if len(cells) > 0 {
+			ex.add(RowDiff{PK: rec.pk, Kind: diffChanged, Cells: cells})
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("reconstruct prev %s.%s: %w", p.Schema, p.Table, err)
+	}
+
+	// Truth rows the recovery never produced (deterministic order for stable output).
+	missing := make([]rowCells, 0)
+	for key, t := range truth {
+		if !seen[key] {
+			missing = append(missing, t)
+		}
+	}
+	sort.Slice(missing, func(i, j int) bool { return missing[i].pk < missing[j].pk })
+	for _, m := range missing {
+		ex.add(RowDiff{PK: m.pk, Kind: diffMissing})
+	}
+
+	return ex, nil
+}
+
+// streamRowsByPK reconstructs baselinePath+changes and invokes emit once per row
+// with its PK key (for joining) and canonical per-column bytes. It is the digest
+// row stream (reconstructDigest) re-pointed at a diff instead of a hash.
+func streamRowsByPK(ctx context.Context, baselinePath, schema, table string, pkCols, orderedCols []metadata.ColumnMeta, changes map[string]*query.ResultRow, emit func(key string, r rowCells) error) error {
+	return reconstruct.SnapshotFullTableImages(ctx, reconstruct.SnapshotFullTableInput{
+		BaselinePath: baselinePath,
+		Schema:       schema,
+		Table:        table,
+		PKCols:       pkCols,
+		Changes:      changes,
+	}, func(rowMap map[string]any) error {
+		key, pk := pkKeyAndDisplay(rowMap, pkCols)
+		cells := make(map[string][]byte, len(orderedCols))
+		for _, c := range orderedCols {
+			cells[c.Name] = renderCell(rowMap[c.Name], c)
+		}
+		return emit(key, rowCells{pk: pk, cells: cells})
+	})
+}
+
+func collectRowsByPK(ctx context.Context, baselinePath, schema, table string, pkCols, orderedCols []metadata.ColumnMeta, changes map[string]*query.ResultRow) (map[string]rowCells, error) {
+	out := make(map[string]rowCells)
+	err := streamRowsByPK(ctx, baselinePath, schema, table, pkCols, orderedCols, changes, func(key string, r rowCells) error {
+		out[key] = r
+		return nil
+	})
+	return out, err
+}
+
+// pkKeyAndDisplay builds a join key (canonical PK bytes, NUL-joined so multi-
+// column keys can't collide) and a human label ("col=val, …"). Both sides render
+// the PK through the same renderCell, so equal logical keys produce equal keys.
+func pkKeyAndDisplay(rowMap map[string]any, pkCols []metadata.ColumnMeta) (key, display string) {
+	keyParts := make([]string, len(pkCols))
+	dispParts := make([]string, len(pkCols))
+	for i, c := range pkCols {
+		v := renderCell(rowMap[c.Name], c)
+		keyParts[i] = string(v)
+		dispParts[i] = c.Name + "=" + displayCell(v)
+	}
+	return strings.Join(keyParts, "\x00"), strings.Join(dispParts, ", ")
+}
+
+// displayCell renders a canonical cell for human output: NULL for an absent
+// value, the text form otherwise. Differing columns in a mismatch are
+// non-deferred types (ENUM/SET/JSON/binary changes are classified inconclusive,
+// never mismatch), so the text form is clean here.
+func displayCell(b []byte) string {
+	if b == nil {
+		return "NULL"
+	}
+	return string(b)
+}
+
+// Write prints the drill-down: one line per differing primary key.
+func (ex *MismatchExplanation) Write(w io.Writer) {
+	fmt.Fprintf(w, "\n--- mismatch drill-down: %s.%s @ %s ---\n", ex.Schema, ex.Table, ex.Anchor)
+	fmt.Fprintln(w, "  recovery = previous baseline reconstructed to the anchor; baseline = the new baseline (truth)")
+	if ex.Total == 0 {
+		// A mismatch can be flagged on row COUNT while every matched PK lines up
+		// cell-for-cell (e.g. a duplicate-PK pathology collapsing in the join).
+		// Say so rather than print nothing.
+		fmt.Fprintln(w, "  no per-row content differences found — the mismatch is in row count, not row content")
+		return
+	}
+	for _, d := range ex.Diffs {
+		switch d.Kind {
+		case diffChanged:
+			parts := make([]string, len(d.Cells))
+			for i, c := range d.Cells {
+				parts[i] = fmt.Sprintf("%s: recovery=%s baseline=%s", c.Column, c.Recovery, c.Baseline)
+			}
+			fmt.Fprintf(w, "  ~ %s\t%s\n", d.PK, strings.Join(parts, "; "))
+		case diffMissing:
+			fmt.Fprintf(w, "  + %s\t(in the new baseline, NOT reproduced by the recovery)\n", d.PK)
+		case diffExtra:
+			fmt.Fprintf(w, "  - %s\t(reconstructed by the recovery, absent from the new baseline)\n", d.PK)
+		}
+	}
+	if ex.Total > len(ex.Diffs) {
+		fmt.Fprintf(w, "  … and %d more differing row(s)\n", ex.Total-len(ex.Diffs))
+	}
+}

--- a/internal/verify/explain_baseline.go
+++ b/internal/verify/explain_baseline.go
@@ -25,10 +25,12 @@ const (
 	diffExtra   = "extra"   // reconstructed by the recovery, absent from the new baseline
 )
 
-// deferredMarker stands in for a differing deferred-type (ENUM/SET/JSON/binary)
-// column whose value comparison is not normalized — shown instead of a raw,
-// misleading literal (an event-image ordinal/base64 read as corruption).
-const deferredMarker = "<representation-deferred: comparison not normalized>"
+// deferredCaveat is printed once per drill-down when a deferred-type column
+// (ENUM/SET/JSON/binary) is among the diffs: its reconstructed value may be a
+// binlog event image (ordinal/base64/Go-JSON) rather than MySQL's source text, so
+// a shown value pair is not necessarily corruption. Surfaced rather than blanked
+// so a genuine baseline-vs-baseline drift in such a column is never hidden.
+const deferredCaveat = "  note: a deferred-type column (ENUM/SET/JSON/binary) is among the diffs — its reconstructed value may be an event image (ordinal/base64/JSON), not the source text; not necessarily corruption."
 
 // CellDiff is one column whose reconstructed value diverged from the new
 // baseline's, rendered in the SAME canonical text form the content digest
@@ -59,6 +61,7 @@ type MismatchExplanation struct {
 	Diffs                 []RowDiff
 	Total                 int            // total differing rows (Diffs is capped at maxExplainRows)
 	byKind                map[string]int // per-kind totals, for the overflow breakdown
+	deferredSeen          bool           // a deferred-type column appeared in a diff (drives the caveat)
 }
 
 func (ex *MismatchExplanation) add(d RowDiff) {
@@ -165,16 +168,17 @@ func ExplainBaselinePairMismatch(ctx context.Context, cfg BaselineConfig, p Base
 			if cellEqual(rv, bv) {
 				continue
 			}
-			// A deferred-type column (ENUM/SET/JSON/binary) can still reach here —
-			// on a row-count mismatch (classify returns mismatch before the deferred
-			// check), or when it diverges with no in-window event. Its event-image
-			// form (ordinal, base64, Go-marshaled JSON) is NOT MySQL's source form,
-			// so a raw value pair would read as corruption. Flag it instead.
-			if isDeferredType(c.DataType) {
-				cells = append(cells, CellDiff{Column: c.Name, Recovery: deferredMarker, Baseline: deferredMarker})
-				continue
-			}
+			// Both values are shown raw. For a deferred-type column (ENUM/SET/JSON/
+			// binary) the recovery value MAY be an event image (ordinal/base64/
+			// Go-JSON) rather than MySQL's source text — see deferredCaveat, surfaced
+			// once per drill-down. We deliberately do NOT blank such cells: when the
+			// divergence is a baseline-vs-baseline drift (no in-window event), the
+			// values are directly comparable and hiding them would mask exactly the
+			// silent drift this command exists to catch.
 			cells = append(cells, CellDiff{Column: c.Name, Recovery: displayCell(rv), Baseline: displayCell(bv)})
+			if isDeferredType(c.DataType) {
+				ex.deferredSeen = true
+			}
 		}
 		if len(cells) > 0 {
 			ex.add(RowDiff{PK: rec.pk, Kind: diffChanged, Cells: cells})
@@ -247,10 +251,10 @@ func pkKeyAndDisplay(rowMap map[string]any, pkCols []metadata.ColumnMeta) (key, 
 }
 
 // displayCell renders a canonical cell for human output: NULL for a SQL NULL
-// (renderCell returns nil), the text form otherwise. Most differing columns are
-// non-deferred types and render cleanly; a deferred-TYPE column that reaches the
-// drill-down is flagged with deferredMarker upstream rather than shown literally,
-// because its event-image bytes (ordinal/base64/Go-JSON) are not the source form.
+// (renderCell returns nil), the text form otherwise. The text form is MySQL's
+// source bytes for non-deferred types; a deferred-type column (ENUM/SET/JSON/
+// binary) may instead carry an event-image form (see deferredCaveat), shown raw
+// so a real baseline-vs-baseline drift is never hidden.
 func displayCell(b []byte) string {
 	if b == nil {
 		return "NULL"
@@ -274,6 +278,9 @@ func cellEqual(a, b []byte) bool {
 func (ex *MismatchExplanation) Write(w io.Writer) {
 	fmt.Fprintf(w, "\n--- mismatch drill-down: %s.%s @ %s ---\n", ex.Schema, ex.Table, ex.Anchor)
 	fmt.Fprintln(w, "  recovery = previous baseline reconstructed to the anchor; baseline = the new baseline (truth)")
+	if ex.deferredSeen {
+		fmt.Fprintln(w, deferredCaveat)
+	}
 	if ex.Total == 0 {
 		// A mismatch can be flagged on row COUNT while every matched PK lines up
 		// cell-for-cell (e.g. a duplicate-PK pathology collapsing in the join).

--- a/internal/verify/explain_baseline.go
+++ b/internal/verify/explain_baseline.go
@@ -25,6 +25,11 @@ const (
 	diffExtra   = "extra"   // reconstructed by the recovery, absent from the new baseline
 )
 
+// deferredMarker stands in for a differing deferred-type (ENUM/SET/JSON/binary)
+// column whose value comparison is not normalized — shown instead of a raw,
+// misleading literal (an event-image ordinal/base64 read as corruption).
+const deferredMarker = "<representation-deferred: comparison not normalized>"
+
 // CellDiff is one column whose reconstructed value diverged from the new
 // baseline's, rendered in the SAME canonical text form the content digest
 // compares — so a reported diff is exactly what made the digests differ.
@@ -44,17 +49,24 @@ type RowDiff struct {
 
 // MismatchExplanation is the row-level drill-down for one mismatched table: which
 // primary keys diverged and how. It is the "which rows" the one-way content
-// digest cannot give — recomputed from the SAME reconstructed row streams the
-// digest used, so the diff and the verdict can never disagree. No live source,
-// no scratch DB, no external tool: an in-memory full-outer-join on the PK.
+// digest cannot give — produced by re-running the SAME reconstruction function
+// (SnapshotFullTableImages) over the SAME fixed window (the BaselinePair's
+// snapshots/anchor are immutable), so the row stream is byte-identical to the
+// digest's by construction and the diff and the verdict cannot disagree. No live
+// source, no scratch DB, no external tool: an in-memory full-outer-join on the PK.
 type MismatchExplanation struct {
 	Schema, Table, Anchor string
 	Diffs                 []RowDiff
-	Total                 int // total differing rows (Diffs is capped at maxExplainRows)
+	Total                 int            // total differing rows (Diffs is capped at maxExplainRows)
+	byKind                map[string]int // per-kind totals, for the overflow breakdown
 }
 
 func (ex *MismatchExplanation) add(d RowDiff) {
 	ex.Total++
+	if ex.byKind == nil {
+		ex.byKind = map[string]int{}
+	}
+	ex.byKind[d.Kind]++
 	if len(ex.Diffs) < maxExplainRows {
 		ex.Diffs = append(ex.Diffs, d)
 	}
@@ -70,8 +82,9 @@ type rowCells struct {
 // ExplainBaselinePairMismatch drills into a table VerifyBaselinePair already
 // reported as StatusMismatch, producing a row-level diff between the recovery
 // side (prev baseline reconstructed forward to the new baseline's anchor) and the
-// new baseline (truth). It reuses the SAME SnapshotFullTableImages row stream the
-// digest is built from, so the diff is guaranteed consistent with the verdict.
+// new baseline (truth). It re-runs the SAME SnapshotFullTableImages reconstruction
+// over the SAME fixed window the digest used, so the row stream is byte-identical
+// by construction and the diff is guaranteed consistent with the verdict.
 //
 // It re-derives the setup VerifyBaselinePair computed (resolver/columns/changes).
 // Because it runs only after a confirmed mismatch, the guards VerifyBaselinePair
@@ -148,9 +161,20 @@ func ExplainBaselinePairMismatch(ctx context.Context, cfg BaselineConfig, p Base
 		}
 		var cells []CellDiff
 		for _, c := range orderedCols {
-			if !bytes.Equal(rec.cells[c.Name], t.cells[c.Name]) {
-				cells = append(cells, CellDiff{Column: c.Name, Recovery: displayCell(rec.cells[c.Name]), Baseline: displayCell(t.cells[c.Name])})
+			rv, bv := rec.cells[c.Name], t.cells[c.Name]
+			if cellEqual(rv, bv) {
+				continue
 			}
+			// A deferred-type column (ENUM/SET/JSON/binary) can still reach here —
+			// on a row-count mismatch (classify returns mismatch before the deferred
+			// check), or when it diverges with no in-window event. Its event-image
+			// form (ordinal, base64, Go-marshaled JSON) is NOT MySQL's source form,
+			// so a raw value pair would read as corruption. Flag it instead.
+			if isDeferredType(c.DataType) {
+				cells = append(cells, CellDiff{Column: c.Name, Recovery: deferredMarker, Baseline: deferredMarker})
+				continue
+			}
+			cells = append(cells, CellDiff{Column: c.Name, Recovery: displayCell(rv), Baseline: displayCell(bv)})
 		}
 		if len(cells) > 0 {
 			ex.add(RowDiff{PK: rec.pk, Kind: diffChanged, Cells: cells})
@@ -205,29 +229,45 @@ func collectRowsByPK(ctx context.Context, baselinePath, schema, table string, pk
 	return out, err
 }
 
-// pkKeyAndDisplay builds a join key (canonical PK bytes, NUL-joined so multi-
-// column keys can't collide) and a human label ("col=val, …"). Both sides render
-// the PK through the same renderCell, so equal logical keys produce equal keys.
+// pkKeyAndDisplay builds a join key and a human label ("col=val, …"). Each PK
+// part is length-prefixed before concatenation so a composite key is unambiguous
+// even if a value contains a NUL byte (a VARCHAR/CHAR PK legally can) — two
+// different multi-column keys can never collide. Both sides render the PK through
+// the same renderCell, so equal logical keys produce equal join keys.
 func pkKeyAndDisplay(rowMap map[string]any, pkCols []metadata.ColumnMeta) (key, display string) {
-	keyParts := make([]string, len(pkCols))
+	var b strings.Builder
 	dispParts := make([]string, len(pkCols))
 	for i, c := range pkCols {
 		v := renderCell(rowMap[c.Name], c)
-		keyParts[i] = string(v)
+		fmt.Fprintf(&b, "%d:", len(v))
+		b.Write(v)
 		dispParts[i] = c.Name + "=" + displayCell(v)
 	}
-	return strings.Join(keyParts, "\x00"), strings.Join(dispParts, ", ")
+	return b.String(), strings.Join(dispParts, ", ")
 }
 
-// displayCell renders a canonical cell for human output: NULL for an absent
-// value, the text form otherwise. Differing columns in a mismatch are
-// non-deferred types (ENUM/SET/JSON/binary changes are classified inconclusive,
-// never mismatch), so the text form is clean here.
+// displayCell renders a canonical cell for human output: NULL for a SQL NULL
+// (renderCell returns nil), the text form otherwise. Most differing columns are
+// non-deferred types and render cleanly; a deferred-TYPE column that reaches the
+// drill-down is flagged with deferredMarker upstream rather than shown literally,
+// because its event-image bytes (ordinal/base64/Go-JSON) are not the source form.
 func displayCell(b []byte) string {
 	if b == nil {
 		return "NULL"
 	}
 	return string(b)
+}
+
+// cellEqual compares two canonical cell renderings with the SAME NULL-vs-empty
+// distinction the content digest uses (rowHasher tags a nil/NULL differently from
+// a zero-length value). bytes.Equal alone treats nil and []byte("") as equal,
+// which would make the drill-down miss a NULL↔'' divergence the digest flagged —
+// breaking the "the diff agrees with the verdict" invariant.
+func cellEqual(a, b []byte) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	return bytes.Equal(a, b)
 }
 
 // Write prints the drill-down: one line per differing primary key.
@@ -256,6 +296,39 @@ func (ex *MismatchExplanation) Write(w io.Writer) {
 		}
 	}
 	if ex.Total > len(ex.Diffs) {
-		fmt.Fprintf(w, "  … and %d more differing row(s)\n", ex.Total-len(ex.Diffs))
+		over := ex.Total - len(ex.Diffs)
+		// Break the overflow down by kind (missing first) so the data-loss class —
+		// rows the recovery never reproduced — is never invisible behind the
+		// changed/extra rows that filled the cap first.
+		if bd := ex.overflowBreakdown(); bd != "" {
+			fmt.Fprintf(w, "  … and %d more differing row(s): %s\n", over, bd)
+		} else {
+			fmt.Fprintf(w, "  … and %d more differing row(s)\n", over)
+		}
 	}
+}
+
+// overflowBreakdown summarizes the differing rows that exceeded the cap, by kind
+// (missing/changed/extra). Returns "" when per-kind totals are unavailable (a
+// hand-built explanation that never went through add), so Write falls back to a
+// plain count.
+func (ex *MismatchExplanation) overflowBreakdown() string {
+	if len(ex.byKind) == 0 {
+		return ""
+	}
+	shown := map[string]int{}
+	for _, d := range ex.Diffs {
+		shown[d.Kind]++
+	}
+	var parts []string
+	for _, k := range []struct{ kind, label string }{
+		{diffMissing, "missing (not reproduced)"},
+		{diffChanged, "changed"},
+		{diffExtra, "extra"},
+	} {
+		if n := ex.byKind[k.kind] - shown[k.kind]; n > 0 {
+			parts = append(parts, fmt.Sprintf("%d %s", n, k.label))
+		}
+	}
+	return strings.Join(parts, ", ")
 }

--- a/internal/verify/explain_baseline_test.go
+++ b/internal/verify/explain_baseline_test.go
@@ -70,6 +70,34 @@ func TestMismatchExplanation_add_caps(t *testing.T) {
 	}
 }
 
+// TestMismatchExplanation_Write_deferredCaveat: a drill-down that touched a
+// deferred-type column surfaces the caveat (its reconstructed value may be an
+// event image, not corruption); one that didn't must not show it.
+func TestMismatchExplanation_Write_deferredCaveat(t *testing.T) {
+	with := &MismatchExplanation{
+		Schema: "mydb", Table: "orders", Anchor: "binlog.000001:300",
+		Diffs:        []RowDiff{{PK: "id=2", Kind: diffChanged, Cells: []CellDiff{{Column: "kind", Recovery: "2", Baseline: "shipped"}}}},
+		Total:        1,
+		deferredSeen: true,
+	}
+	var b1 bytes.Buffer
+	with.Write(&b1)
+	if !strings.Contains(b1.String(), "deferred-type column") {
+		t.Errorf("want the deferred caveat, got:\n%s", b1.String())
+	}
+
+	without := &MismatchExplanation{
+		Schema: "mydb", Table: "orders", Anchor: "binlog.000001:300",
+		Diffs: []RowDiff{{PK: "id=2", Kind: diffChanged, Cells: []CellDiff{{Column: "status", Recovery: "wrong", Baseline: "shipped"}}}},
+		Total: 1,
+	}
+	var b2 bytes.Buffer
+	without.Write(&b2)
+	if strings.Contains(b2.String(), "deferred-type column") {
+		t.Errorf("no deferred column touched — caveat must not appear:\n%s", b2.String())
+	}
+}
+
 // TestCellEqual locks the NULL-vs-empty distinction the drill-down must honor to
 // agree with the content digest: a SQL NULL (nil) and an empty value ([]byte(""))
 // are DIFFERENT, where plain bytes.Equal would call them equal and silently miss

--- a/internal/verify/explain_baseline_test.go
+++ b/internal/verify/explain_baseline_test.go
@@ -50,7 +50,8 @@ func TestMismatchExplanation_Write_rowCountOnly(t *testing.T) {
 
 // TestMismatchExplanation_add_caps locks the cap: detail is bounded at
 // maxExplainRows while Total keeps counting, so a pathological all-differ table
-// never dumps the whole table yet nothing is silently hidden.
+// never dumps the whole table yet nothing is silently hidden — and the overflow
+// line breaks the un-shown rows down by kind.
 func TestMismatchExplanation_add_caps(t *testing.T) {
 	ex := &MismatchExplanation{}
 	for i := 0; i < maxExplainRows+25; i++ {
@@ -61,5 +62,35 @@ func TestMismatchExplanation_add_caps(t *testing.T) {
 	}
 	if ex.Total != maxExplainRows+25 {
 		t.Errorf("Total = %d, want %d (counting continues past the cap)", ex.Total, maxExplainRows+25)
+	}
+	var buf bytes.Buffer
+	ex.Write(&buf)
+	if !strings.Contains(buf.String(), "25 extra") {
+		t.Errorf("want the overflow broken down by kind ('25 extra'), got:\n%s", buf.String())
+	}
+}
+
+// TestCellEqual locks the NULL-vs-empty distinction the drill-down must honor to
+// agree with the content digest: a SQL NULL (nil) and an empty value ([]byte(""))
+// are DIFFERENT, where plain bytes.Equal would call them equal and silently miss
+// a NULL↔'' divergence the verdict flagged.
+func TestCellEqual(t *testing.T) {
+	empty := []byte("")
+	for _, tc := range []struct {
+		name string
+		a, b []byte
+		want bool
+	}{
+		{"both NULL", nil, nil, true},
+		{"NULL vs empty", nil, empty, false},
+		{"empty vs NULL", empty, nil, false},
+		{"both empty", empty, empty, true},
+		{"equal values", []byte("x"), []byte("x"), true},
+		{"different values", []byte("x"), []byte("y"), false},
+		{"NULL vs value", nil, []byte("x"), false},
+	} {
+		if got := cellEqual(tc.a, tc.b); got != tc.want {
+			t.Errorf("%s: cellEqual(%q,%q)=%v, want %v", tc.name, tc.a, tc.b, got, tc.want)
+		}
 	}
 }

--- a/internal/verify/explain_baseline_test.go
+++ b/internal/verify/explain_baseline_test.go
@@ -1,0 +1,65 @@
+package verify
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestMismatchExplanation_Write pins the drill-down formatting: a changed row
+// shows the column with recovery-vs-baseline values, missing/extra rows are
+// labeled by side, and a capped run reports the remaining count.
+func TestMismatchExplanation_Write(t *testing.T) {
+	ex := &MismatchExplanation{
+		Schema: "mydb", Table: "orders", Anchor: "binlog.000001:300",
+		Diffs: []RowDiff{
+			{PK: "id=2", Kind: diffChanged, Cells: []CellDiff{{Column: "status", Recovery: "wrong", Baseline: "shipped"}}},
+			{PK: "id=5", Kind: diffExtra},
+			{PK: "id=7", Kind: diffMissing},
+		},
+		Total: 5, // two more than shown
+	}
+	var buf bytes.Buffer
+	ex.Write(&buf)
+	out := buf.String()
+
+	for _, want := range []string{
+		"mydb.orders @ binlog.000001:300",
+		"id=2", "status", "recovery=wrong", "baseline=shipped",
+		"id=5", "absent from the new baseline",
+		"id=7", "NOT reproduced by the recovery",
+		"and 2 more differing row(s)",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("drill-down output missing %q\n--- output ---\n%s", want, out)
+		}
+	}
+}
+
+// TestMismatchExplanation_Write_rowCountOnly covers the edge where a mismatch was
+// flagged on row count but every matched PK lines up cell-for-cell (Total == 0):
+// the drill-down must say so, not print an empty section.
+func TestMismatchExplanation_Write_rowCountOnly(t *testing.T) {
+	ex := &MismatchExplanation{Schema: "mydb", Table: "orders", Anchor: "binlog.000001:300"}
+	var buf bytes.Buffer
+	ex.Write(&buf)
+	if !strings.Contains(buf.String(), "row count, not row content") {
+		t.Errorf("want the row-count-only note, got:\n%s", buf.String())
+	}
+}
+
+// TestMismatchExplanation_add_caps locks the cap: detail is bounded at
+// maxExplainRows while Total keeps counting, so a pathological all-differ table
+// never dumps the whole table yet nothing is silently hidden.
+func TestMismatchExplanation_add_caps(t *testing.T) {
+	ex := &MismatchExplanation{}
+	for i := 0; i < maxExplainRows+25; i++ {
+		ex.add(RowDiff{PK: "x", Kind: diffExtra})
+	}
+	if len(ex.Diffs) != maxExplainRows {
+		t.Errorf("Diffs len = %d, want capped at %d", len(ex.Diffs), maxExplainRows)
+	}
+	if ex.Total != maxExplainRows+25 {
+		t.Errorf("Total = %d, want %d (counting continues past the cap)", ex.Total, maxExplainRows+25)
+	}
+}

--- a/internal/verify/verify_baseline_integration_test.go
+++ b/internal/verify/verify_baseline_integration_test.go
@@ -3,6 +3,7 @@
 package verify
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"path/filepath"
@@ -383,6 +384,86 @@ func TestExplainBaselinePairMismatch_CompositePK(t *testing.T) {
 	}
 	if len(d.Cells) != 1 || d.Cells[0].Column != "status" || d.Cells[0].Recovery != "wrong" || d.Cells[0].Baseline != "shipped" {
 		t.Errorf("cell diff = %+v; want status recovery=wrong baseline=shipped", d.Cells)
+	}
+}
+
+// TestExplainBaselinePairMismatch_DeferredDrift exercises the deferred-type path
+// end to end: an ENUM column that drifts between the two baselines with NO
+// in-window event (the at-rest silent-drift case). Both sides are mydumper labels,
+// directly comparable, so the drill-down must show them RAW ("active" vs
+// "inactive") — never blanked, which would hide exactly the drift this command
+// exists to catch — and surface the representation caveat because a deferred-type
+// column is among the diffs.
+func TestExplainBaselinePairMismatch_DeferredDrift(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	for _, c := range []struct {
+		name, key, dt, colType string
+		ord                    int
+	}{
+		{"id", "PRI", "int", "int", 1},
+		{"state", "", "enum", "enum('active','inactive')", 2},
+	} {
+		testutil.MustExec(t, db, `INSERT INTO schema_snapshots
+			(snapshot_id, snapshot_time, schema_name, table_name, column_name,
+			 ordinal_position, column_key, data_type, column_type, is_nullable, is_generated)
+			VALUES (1, UTC_TIMESTAMP(), ?, 'orders', ?, ?, ?, ?, ?, 'YES', 0)`,
+			dbName, c.name, c.ord, c.key, c.dt, c.colType)
+	}
+
+	baseDir := t.TempDir()
+	now := time.Now().UTC()
+	prevTS := now.Truncate(time.Hour).Add(-2 * time.Hour)
+	newTS := prevTS.Add(time.Hour)
+	createSQL := "CREATE TABLE `orders` (\n  `id` INT NOT NULL,\n  `state` ENUM('active','inactive'),\n  PRIMARY KEY (`id`)\n);\n"
+	cols := []baseline.Column{
+		{Name: "id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
+		{Name: "state", MySQLType: "enum", ParquetType: baseline.MysqlToParquetNode("varchar")},
+	}
+	writeTestBaseline(t, baseDir, prevTS, dbName, "orders", createSQL, cols, [][]string{{"1", "active"}}, "binlog.000001", 200)
+	writeTestBaseline(t, baseDir, newTS, dbName, "orders", createSQL, cols, [][]string{{"1", "inactive"}}, "binlog.000001", 300)
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{prevTS, newTS, now.Truncate(time.Hour)})
+
+	resolver, err := metadata.NewResolver(db, 1)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+	cfg := BaselineConfig{IndexDB: db, Resolver: resolver, IndexDBName: dbName, NoArchive: true}
+	ctx := context.Background()
+	pairs, _, _, err := FindBaselinePair(ctx, baseDir)
+	if err != nil || len(pairs) != 1 {
+		t.Fatalf("FindBaselinePair: %v (pairs=%d)", err, len(pairs))
+	}
+	got, err := VerifyBaselinePair(ctx, cfg, pairs[0])
+	if err != nil {
+		t.Fatalf("VerifyBaselinePair: %v", err)
+	}
+	if got.Status != StatusMismatch {
+		t.Fatalf("precondition: an ENUM drift with no in-window event must be a mismatch (not inconclusive), got %q (%s)", got.Status, got.Detail)
+	}
+
+	ex, err := ExplainBaselinePairMismatch(ctx, cfg, pairs[0])
+	if err != nil {
+		t.Fatalf("ExplainBaselinePairMismatch: %v", err)
+	}
+	if ex.Total != 1 || len(ex.Diffs) != 1 {
+		t.Fatalf("want exactly 1 changed row, got Total=%d Diffs=%+v", ex.Total, ex.Diffs)
+	}
+	// Shown RAW (the revert): the marker would have blanked this real drift.
+	d := ex.Diffs[0]
+	if len(d.Cells) != 1 || d.Cells[0].Column != "state" || d.Cells[0].Recovery != "active" || d.Cells[0].Baseline != "inactive" {
+		t.Errorf("want state shown raw (recovery=active baseline=inactive), got %+v", d.Cells)
+	}
+	if !ex.deferredSeen {
+		t.Error("a deferred-type column was among the diffs; the caveat flag must be set")
+	}
+	var buf bytes.Buffer
+	ex.Write(&buf)
+	if !strings.Contains(buf.String(), "deferred-type column") {
+		t.Errorf("want the deferred caveat in the output, got:\n%s", buf.String())
 	}
 }
 

--- a/internal/verify/verify_baseline_integration_test.go
+++ b/internal/verify/verify_baseline_integration_test.go
@@ -217,21 +217,27 @@ func TestExplainBaselinePairMismatch(t *testing.T) {
 		{Name: "id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
 		{Name: "status", MySQLType: "varchar", ParquetType: baseline.MysqlToParquetNode("varchar")},
 	}
-	// prev {1:a, 2:b, 5:e}; new (truth) {1:a, 2:shipped, 7:g}.
+	// prev {1:a, 2:b, 5:e, 8:x}; new (truth) {1:a, 2:shipped, 7:g, 8:""}. id=8 has
+	// an EMPTY-string status in the new baseline (not NULL) — the NULL-vs-empty
+	// case that bytes.Equal would silently miss.
 	writeTestBaseline(t, baseDir, prevTS, dbName, "orders", createSQL, cols, [][]string{
-		{"1", "a"}, {"2", "b"}, {"5", "e"},
+		{"1", "a"}, {"2", "b"}, {"5", "e"}, {"8", "x"},
 	}, "binlog.000001", 200)
 	writeTestBaseline(t, baseDir, newTS, dbName, "orders", createSQL, cols, [][]string{
-		{"1", "a"}, {"2", "shipped"}, {"7", "g"},
+		{"1", "a"}, {"2", "shipped"}, {"7", "g"}, {"8", ""},
 	}, "binlog.000001", 300)
 
-	// One event in (prev, anchor]: id=2 updated b→"wrong" (diverges from the new
-	// baseline's "shipped"). Nothing touches 5 (recovery keeps it; truth dropped it)
-	// or 7 (truth has it; recovery never gets it) → changed + extra + missing.
+	// Events in (prev, anchor]: id=2 updated b→"wrong" (diverges from the new
+	// baseline's "shipped"); id=8 updated x→NULL (diverges from the baseline's
+	// empty string). Nothing touches 5 (recovery keeps it; truth dropped it) or 7
+	// (truth has it; recovery never gets it) → changed + extra + missing + the
+	// NULL↔'' changed case.
 	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{prevTS, newTS, now.Truncate(time.Hour)})
 	ets := prevTS.Add(30 * time.Minute).Format("2006-01-02 15:04:05")
-	testutil.InsertEvent(t, db, "binlog.000001", 200, 300, ets, nil, dbName, "orders", 2 /*UPDATE*/, "2", nil,
+	testutil.InsertEvent(t, db, "binlog.000001", 200, 250, ets, nil, dbName, "orders", 2 /*UPDATE*/, "2", nil,
 		[]byte(`{"id":2,"status":"b"}`), []byte(`{"id":2,"status":"wrong"}`))
+	testutil.InsertEvent(t, db, "binlog.000001", 250, 300, ets, nil, dbName, "orders", 2 /*UPDATE*/, "8", nil,
+		[]byte(`{"id":8,"status":"x"}`), []byte(`{"id":8,"status":null}`))
 
 	resolver, err := metadata.NewResolver(db, 1)
 	if err != nil {
@@ -271,19 +277,112 @@ func TestExplainBaselinePairMismatch(t *testing.T) {
 			extra[d.PK] = true
 		}
 	}
-	if ex.Total != 3 {
-		t.Errorf("want 3 differing rows (1 changed, 1 extra, 1 missing), got Total=%d: %+v", ex.Total, ex.Diffs)
+	if ex.Total != 4 {
+		t.Errorf("want 4 differing rows (2 changed, 1 extra, 1 missing), got Total=%d: %+v", ex.Total, ex.Diffs)
 	}
 	if d, ok := changed["id=2"]; !ok {
 		t.Errorf("want a changed row for id=2, got changed=%v", changed)
 	} else if len(d.Cells) != 1 || d.Cells[0].Column != "status" || d.Cells[0].Recovery != "wrong" || d.Cells[0].Baseline != "shipped" {
 		t.Errorf("id=2 cell diff = %+v; want status recovery=wrong baseline=shipped", d.Cells)
 	}
+	// id=8 is the NULL-vs-empty case: recovery rendered NULL, baseline an empty
+	// string — cellEqual must NOT collapse them (bytes.Equal would, missing it).
+	if d, ok := changed["id=8"]; !ok {
+		t.Errorf("want a changed row for id=8 (NULL vs empty), got changed=%v", changed)
+	} else if len(d.Cells) != 1 || d.Cells[0].Column != "status" || d.Cells[0].Recovery != "NULL" || d.Cells[0].Baseline != "" {
+		t.Errorf("id=8 cell diff = %+v; want status recovery=NULL baseline=(empty)", d.Cells)
+	}
 	if !extra["id=5"] {
 		t.Errorf("want id=5 as extra (in recovery, not the new baseline), got extra=%v", extra)
 	}
 	if !missing["id=7"] {
 		t.Errorf("want id=7 as missing (in the new baseline, not reproduced), got missing=%v", missing)
+	}
+}
+
+// TestExplainBaselinePairMismatch_CompositePK exercises the most fragile path —
+// the multi-column PK join. With a shared-prefix pair (tenant_id=1, id=1) and
+// (tenant_id=1, id=2), a single UPDATE touching ONLY (1,2) must land on (1,2) and
+// NOT (1,1): the drill-down must report exactly one changed row whose full PK
+// label is "tenant_id=1, id=2". A dropped or reordered PK column in any of the
+// three coordinated encodings (FetchMerged pk_values, SnapshotFullTableImages
+// canonicalization, pkKeyAndDisplay) would misfire and this would catch it.
+func TestExplainBaselinePairMismatch_CompositePK(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	for _, c := range []struct {
+		name, key, dt, colType string
+		ord                    int
+	}{
+		{"tenant_id", "PRI", "int", "int", 1},
+		{"id", "PRI", "int", "int", 2},
+		{"status", "", "varchar", "varchar(64)", 3},
+	} {
+		testutil.MustExec(t, db, `INSERT INTO schema_snapshots
+			(snapshot_id, snapshot_time, schema_name, table_name, column_name,
+			 ordinal_position, column_key, data_type, column_type, is_nullable, is_generated)
+			VALUES (1, UTC_TIMESTAMP(), ?, 'orders', ?, ?, ?, ?, ?, 'YES', 0)`,
+			dbName, c.name, c.ord, c.key, c.dt, c.colType)
+	}
+
+	baseDir := t.TempDir()
+	now := time.Now().UTC()
+	prevTS := now.Truncate(time.Hour).Add(-2 * time.Hour)
+	newTS := prevTS.Add(time.Hour)
+	createSQL := "CREATE TABLE `orders` (\n  `tenant_id` INT NOT NULL,\n  `id` INT NOT NULL,\n  `status` VARCHAR(64),\n  PRIMARY KEY (`tenant_id`, `id`)\n);\n"
+	cols := []baseline.Column{
+		{Name: "tenant_id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
+		{Name: "id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
+		{Name: "status", MySQLType: "varchar", ParquetType: baseline.MysqlToParquetNode("varchar")},
+	}
+	writeTestBaseline(t, baseDir, prevTS, dbName, "orders", createSQL, cols, [][]string{
+		{"1", "1", "a"}, {"1", "2", "b"},
+	}, "binlog.000001", 200)
+	writeTestBaseline(t, baseDir, newTS, dbName, "orders", createSQL, cols, [][]string{
+		{"1", "1", "a"}, {"1", "2", "shipped"},
+	}, "binlog.000001", 300)
+
+	// UPDATE only (1,2): b→"wrong". (1,1) is untouched and identical on both sides.
+	// pk_values for a composite key is "|"-joined in PK ordinal order (BuildPKValues).
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{prevTS, newTS, now.Truncate(time.Hour)})
+	ets := prevTS.Add(30 * time.Minute).Format("2006-01-02 15:04:05")
+	testutil.InsertEvent(t, db, "binlog.000001", 200, 300, ets, nil, dbName, "orders", 2 /*UPDATE*/, "1|2", nil,
+		[]byte(`{"tenant_id":1,"id":2,"status":"b"}`), []byte(`{"tenant_id":1,"id":2,"status":"wrong"}`))
+
+	resolver, err := metadata.NewResolver(db, 1)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+	cfg := BaselineConfig{IndexDB: db, Resolver: resolver, IndexDBName: dbName, NoArchive: true}
+	ctx := context.Background()
+	pairs, _, _, err := FindBaselinePair(ctx, baseDir)
+	if err != nil || len(pairs) != 1 {
+		t.Fatalf("FindBaselinePair: %v (pairs=%d)", err, len(pairs))
+	}
+	got, err := VerifyBaselinePair(ctx, cfg, pairs[0])
+	if err != nil {
+		t.Fatalf("VerifyBaselinePair: %v", err)
+	}
+	if got.Status != StatusMismatch {
+		t.Fatalf("precondition: want mismatch, got %q (%s)", got.Status, got.Detail)
+	}
+
+	ex, err := ExplainBaselinePairMismatch(ctx, cfg, pairs[0])
+	if err != nil {
+		t.Fatalf("ExplainBaselinePairMismatch: %v", err)
+	}
+	if ex.Total != 1 || len(ex.Diffs) != 1 {
+		t.Fatalf("want exactly 1 differing row (the change landed only on (1,2)), got Total=%d Diffs=%+v", ex.Total, ex.Diffs)
+	}
+	d := ex.Diffs[0]
+	if d.Kind != diffChanged || d.PK != "tenant_id=1, id=2" {
+		t.Errorf("diff = {Kind:%s PK:%q}; want a changed row PK 'tenant_id=1, id=2' (dropped/reordered PK column misfires)", d.Kind, d.PK)
+	}
+	if len(d.Cells) != 1 || d.Cells[0].Column != "status" || d.Cells[0].Recovery != "wrong" || d.Cells[0].Baseline != "shipped" {
+		t.Errorf("cell diff = %+v; want status recovery=wrong baseline=shipped", d.Cells)
 	}
 }
 

--- a/internal/verify/verify_baseline_integration_test.go
+++ b/internal/verify/verify_baseline_integration_test.go
@@ -183,6 +183,110 @@ func TestVerifyBaselinePair_MatchAndMismatch(t *testing.T) {
 	}
 }
 
+// TestExplainBaselinePairMismatch is the #644 acceptance: on a known divergence
+// between two at-rest baselines, the drill-down names the exact differing primary
+// keys and, for a changed row, the column with recovery-vs-baseline values — all
+// from the same reconstructed streams the digest used (no live source, scratch
+// DB, or external tool). It exercises all three diff kinds at once.
+func TestExplainBaselinePairMismatch(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	for _, c := range []struct {
+		name, key, dt, colType string
+		ord                    int
+	}{
+		{"id", "PRI", "int", "int", 1},
+		{"status", "", "varchar", "varchar(64)", 2},
+	} {
+		testutil.MustExec(t, db, `INSERT INTO schema_snapshots
+			(snapshot_id, snapshot_time, schema_name, table_name, column_name,
+			 ordinal_position, column_key, data_type, column_type, is_nullable, is_generated)
+			VALUES (1, UTC_TIMESTAMP(), ?, 'orders', ?, ?, ?, ?, ?, 'YES', 0)`,
+			dbName, c.name, c.ord, c.key, c.dt, c.colType)
+	}
+
+	baseDir := t.TempDir()
+	now := time.Now().UTC()
+	prevTS := now.Truncate(time.Hour).Add(-2 * time.Hour)
+	newTS := prevTS.Add(time.Hour)
+	createSQL := "CREATE TABLE `orders` (\n  `id` INT NOT NULL,\n  `status` VARCHAR(64),\n  PRIMARY KEY (`id`)\n);\n"
+	cols := []baseline.Column{
+		{Name: "id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
+		{Name: "status", MySQLType: "varchar", ParquetType: baseline.MysqlToParquetNode("varchar")},
+	}
+	// prev {1:a, 2:b, 5:e}; new (truth) {1:a, 2:shipped, 7:g}.
+	writeTestBaseline(t, baseDir, prevTS, dbName, "orders", createSQL, cols, [][]string{
+		{"1", "a"}, {"2", "b"}, {"5", "e"},
+	}, "binlog.000001", 200)
+	writeTestBaseline(t, baseDir, newTS, dbName, "orders", createSQL, cols, [][]string{
+		{"1", "a"}, {"2", "shipped"}, {"7", "g"},
+	}, "binlog.000001", 300)
+
+	// One event in (prev, anchor]: id=2 updated b→"wrong" (diverges from the new
+	// baseline's "shipped"). Nothing touches 5 (recovery keeps it; truth dropped it)
+	// or 7 (truth has it; recovery never gets it) → changed + extra + missing.
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{prevTS, newTS, now.Truncate(time.Hour)})
+	ets := prevTS.Add(30 * time.Minute).Format("2006-01-02 15:04:05")
+	testutil.InsertEvent(t, db, "binlog.000001", 200, 300, ets, nil, dbName, "orders", 2 /*UPDATE*/, "2", nil,
+		[]byte(`{"id":2,"status":"b"}`), []byte(`{"id":2,"status":"wrong"}`))
+
+	resolver, err := metadata.NewResolver(db, 1)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+	cfg := BaselineConfig{IndexDB: db, Resolver: resolver, IndexDBName: dbName, NoArchive: true}
+	ctx := context.Background()
+	pairs, _, _, err := FindBaselinePair(ctx, baseDir)
+	if err != nil || len(pairs) != 1 {
+		t.Fatalf("FindBaselinePair: %v (pairs=%d)", err, len(pairs))
+	}
+
+	// Precondition: it is a real mismatch.
+	got, err := VerifyBaselinePair(ctx, cfg, pairs[0])
+	if err != nil {
+		t.Fatalf("VerifyBaselinePair: %v", err)
+	}
+	if got.Status != StatusMismatch {
+		t.Fatalf("precondition: want mismatch, got %q (%s)", got.Status, got.Detail)
+	}
+
+	ex, err := ExplainBaselinePairMismatch(ctx, cfg, pairs[0])
+	if err != nil {
+		t.Fatalf("ExplainBaselinePairMismatch: %v", err)
+	}
+
+	changed := map[string]RowDiff{}
+	missing := map[string]bool{}
+	extra := map[string]bool{}
+	for _, d := range ex.Diffs {
+		switch d.Kind {
+		case diffChanged:
+			changed[d.PK] = d
+		case diffMissing:
+			missing[d.PK] = true
+		case diffExtra:
+			extra[d.PK] = true
+		}
+	}
+	if ex.Total != 3 {
+		t.Errorf("want 3 differing rows (1 changed, 1 extra, 1 missing), got Total=%d: %+v", ex.Total, ex.Diffs)
+	}
+	if d, ok := changed["id=2"]; !ok {
+		t.Errorf("want a changed row for id=2, got changed=%v", changed)
+	} else if len(d.Cells) != 1 || d.Cells[0].Column != "status" || d.Cells[0].Recovery != "wrong" || d.Cells[0].Baseline != "shipped" {
+		t.Errorf("id=2 cell diff = %+v; want status recovery=wrong baseline=shipped", d.Cells)
+	}
+	if !extra["id=5"] {
+		t.Errorf("want id=5 as extra (in recovery, not the new baseline), got extra=%v", extra)
+	}
+	if !missing["id=7"] {
+		t.Errorf("want id=7 as missing (in the new baseline, not reproduced), got missing=%v", missing)
+	}
+}
+
 // TestFindBaselinePair_UnpairedAndSelection locks two things: a table present
 // only in the new snapshot lands in `unpaired` (not silently dropped), and the
 // pair is built from the two most recent snapshots, ignoring an older third.


### PR DESCRIPTION
closes #644

## Summary
When baseline-anchored `verify` (#642) flags a table as **mismatch**, the content digest proves *that* it diverged but not *which rows*. `verify --explain` now prints, below the report, a row-level drill-down per mismatched table:
- **changed** — a PK on both sides whose columns differ (shows column: `recovery=<value> baseline=<value>`)
- **missing** — a PK in the new baseline the recovery never reproduced
- **extra** — a PK reconstructed by the recovery, absent from the new baseline

## Native, not pt-table-sync — by design decision
The issue's original plan was to delegate to Percona's `pt-table-sync`. After the design review (and an explicit user decision), this is implemented **natively**:

- bintrail already holds **both sides as the same `map[string]any` row streams the digest is built from** (`reconstruct.SnapshotFullTableImages`). The drill-down is an in-memory **full-outer-join on the primary key** — reusing the *exact* reconstruction the verdict came from, so the diff and the verdict can never disagree.
- pt-table-sync is built for diffing **large, live, replicating** tables (chunked checksums, replication-safe sync). Two **frozen, already-reconstructed** states with a known PK don't need that — and it would require a Percona Toolkit dependency, a scratch MySQL, and a Parquet→MySQL materializer that **doesn't exist today** (`recover` only prints SQL, never executes). Effort/importance asymmetry for a p2 feature firing only on a rare mismatch.

## Scope (user decision)
- ✅ Diff display ("print the exact differing row") — done.
- ⏸️ Reconciliation **fix SQL** ("a fix statement" in the acceptance) — deliberately deferred; a possible follow-up. (`recovery.FormatSQLValue`/`QuoteName` already handle the hard cases, so native fix SQL remains low-risk if wanted later.)

## Test plan
- [x] Unit: `MismatchExplanation.Write` formatting (changed/missing/extra + truncation + row-count-only edge); the detail cap counts past the limit.
- [x] Integration: `TestExplainBaselinePairMismatch` — a known divergence exercising all three diff kinds at once; asserts the exact PK, column, and recovery-vs-baseline values.
- [x] `go build ./...`, `go vet`, full `internal/verify` + `internal/cli` unit suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)