### PR TITLE
config+compose: raise index max_allowed_packet ceiling (stopgap for #652)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,9 +120,18 @@ services:
     # by sorting narrow keys only (internal/query late materialization); 4M is
     # defense-in-depth for any other sort, bounded and cheap at this index's low
     # connection concurrency.
+    #
+    # --max-allowed-packet=1G raises the 64M stock default. A single INSERT into
+    # binlog_events carries the full before/after row images as JSON; a large
+    # BLOB/JSON value is base64-inflated ~1.33× and can exceed 64M, which the
+    # server would reject (#652). 1G is the MySQL maximum. bintrail's client
+    # honors this via config.Connect (maxAllowedPacket=0 → fetched from server).
+    # This is a ceiling raise, not a fix: events above 1G are still rejected and
+    # must fail loud rather than drop silently (see #652).
     command:
       - "--innodb-flush-log-at-trx-commit=2"
       - "--sort-buffer-size=4M"
+      - "--max-allowed-packet=1G"
     environment:
       # 8.4 defaults to caching_sha2_password (native_password disabled);
       # bintrail's driver negotiates it over the plaintext Docker network.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,13 +121,14 @@ services:
     # defense-in-depth for any other sort, bounded and cheap at this index's low
     # connection concurrency.
     #
-    # --max-allowed-packet=1G raises the 64M stock default. A single INSERT into
-    # binlog_events carries the full before/after row images as JSON; a large
+    # --max-allowed-packet=1G raises the 64M stock default. Each INSERT into
+    # binlog_events carries full before/after row images as JSON; a single large
     # BLOB/JSON value is base64-inflated ~1.33× and can exceed 64M, which the
-    # server would reject (#652). 1G is the MySQL maximum. bintrail's client
-    # honors this via config.Connect (maxAllowedPacket=0 → fetched from server).
-    # This is a ceiling raise, not a fix: events above 1G are still rejected and
-    # must fail loud rather than drop silently (see #652).
+    # server rejects (the reproduced Error 1105 in #652). 1G is the MySQL
+    # maximum. bintrail's client tracks this via config.Connect
+    # (maxAllowedPacket=0 → fetched from the server). This is a ceiling raise,
+    # not a fix: events above 1G are still rejected and must — but do not yet
+    # (#652) — fail loud rather than drop silently.
     command:
       - "--innodb-flush-log-at-trx-commit=2"
       - "--sort-buffer-size=4M"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -114,11 +114,17 @@ func Connect(dsn string) (*sql.DB, error) {
 	return db, nil
 }
 
+// driverDefaultMaxAllowedPacket is the client-side max_allowed_packet the
+// go-sql-driver assigns when a DSN omits the parameter. Read from the driver
+// itself (via NewConfig) so it tracks any change to that default instead of
+// hardcoding 64 MiB.
+var driverDefaultMaxAllowedPacket = mysql.NewConfig().MaxAllowedPacket
+
 // buildDSN applies bintrail's connection invariants to a user DSN and returns
 // the normalized DSN string. Split out from Connect so the invariants are unit
 // testable without a live server. Invariants: parseTime=true (DATETIME scans
-// into time.Time), Loc=UTC, a default connect timeout, and honoring the
-// server's max_allowed_packet.
+// into time.Time), Loc=UTC, a default connect timeout, and aligning the
+// client's max_allowed_packet with the server's.
 func buildDSN(dsn string) (string, error) {
 	cfg, err := mysql.ParseDSN(dsn)
 	if err != nil {
@@ -129,28 +135,30 @@ func buildDSN(dsn string) (string, error) {
 	if cfg.Timeout == 0 {
 		cfg.Timeout = defaultTimeout
 	}
-	// Honor the server's max_allowed_packet instead of the go-sql-driver's
-	// 64 MiB client-side default. binlog_events stores full before/after row
-	// images as JSON, and a large BLOB/JSON value (base64-inflated ~1.33×) can
-	// exceed 64 MiB; with the client capped at 64 MiB the driver rejects the
-	// write locally even when the server would accept it. maxAllowedPacket=0
-	// makes the driver fetch @@max_allowed_packet from the server (the bundled
-	// index MySQL raises it to 1 GiB; BYO indexes get whatever they set).
+	// Align the client's max_allowed_packet with the server's instead of the
+	// go-sql-driver's fixed 64 MiB default. binlog_events stores full
+	// before/after row images as JSON, and a large BLOB/JSON value
+	// (base64-inflated ~1.33×) can exceed 64 MiB. The rejection #652 reproduced
+	// is server-side (Error 1105 "… mysql_send_long_data() … longer than
+	// 'max_allowed_packet'"), so raising the *server* limit (docker-compose
+	// --max-allowed-packet=1G) is the load-bearing change; maxAllowedPacket=0
+	// makes the driver fetch @@max_allowed_packet from the server and size to it
+	// (bundled index MySQL: 1 GiB; a BYO index: whatever it set) so the client
+	// tracks the server rather than imposing its own cap.
 	//
-	// This is a ceiling raise, not a fix — events larger than the server's
-	// max_allowed_packet are still rejected; that rejection must be handled
-	// fail-loud rather than silently dropped (see #652). An explicit
-	// maxAllowedPacket in the user's DSN is preserved.
-	if !dsnSpecifiesMaxAllowedPacket(dsn) {
+	// This is a ceiling raise, not a fix: events larger than the server's
+	// max_allowed_packet are still rejected, and that rejection must — but does
+	// not yet (#652) — fail loud rather than drop silently.
+	//
+	// Precedence: an explicit non-default maxAllowedPacket in the DSN is
+	// preserved. We compare against the driver's own default rather than
+	// string-matching the DSN, so a value the case-sensitive driver ignores
+	// (e.g. a mis-cased param) falls through to the safe server-honoring 0
+	// instead of being silently left at the 64 MiB cap.
+	if cfg.MaxAllowedPacket == driverDefaultMaxAllowedPacket {
 		cfg.MaxAllowedPacket = 0
 	}
 	return cfg.FormatDSN(), nil
-}
-
-// dsnSpecifiesMaxAllowedPacket reports whether the user's DSN already carries a
-// maxAllowedPacket parameter, so buildDSN does not override an explicit choice.
-func dsnSpecifiesMaxAllowedPacket(dsn string) bool {
-	return strings.Contains(strings.ToLower(dsn), "maxallowedpacket")
 }
 
 // ParseSourceDSN decomposes a go-sql-driver DSN into host, port, user, and

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -99,17 +99,11 @@ const defaultTimeout = 10 * time.Second
 // A 10-second TCP connect timeout is applied when the DSN does not specify one.
 // The caller is responsible for closing the returned *sql.DB.
 func Connect(dsn string) (*sql.DB, error) {
-	cfg, err := mysql.ParseDSN(dsn)
+	normalized, err := buildDSN(dsn)
 	if err != nil {
-		return nil, fmt.Errorf("invalid DSN: %w", err)
+		return nil, err
 	}
-	cfg.ParseTime = true
-	cfg.Loc = time.UTC
-	if cfg.Timeout == 0 {
-		cfg.Timeout = defaultTimeout
-	}
-
-	db, err := sql.Open("mysql", cfg.FormatDSN())
+	db, err := sql.Open("mysql", normalized)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open MySQL connection: %w", err)
 	}
@@ -118,6 +112,45 @@ func Connect(dsn string) (*sql.DB, error) {
 		return nil, fmt.Errorf("failed to ping MySQL: %w", err)
 	}
 	return db, nil
+}
+
+// buildDSN applies bintrail's connection invariants to a user DSN and returns
+// the normalized DSN string. Split out from Connect so the invariants are unit
+// testable without a live server. Invariants: parseTime=true (DATETIME scans
+// into time.Time), Loc=UTC, a default connect timeout, and honoring the
+// server's max_allowed_packet.
+func buildDSN(dsn string) (string, error) {
+	cfg, err := mysql.ParseDSN(dsn)
+	if err != nil {
+		return "", fmt.Errorf("invalid DSN: %w", err)
+	}
+	cfg.ParseTime = true
+	cfg.Loc = time.UTC
+	if cfg.Timeout == 0 {
+		cfg.Timeout = defaultTimeout
+	}
+	// Honor the server's max_allowed_packet instead of the go-sql-driver's
+	// 64 MiB client-side default. binlog_events stores full before/after row
+	// images as JSON, and a large BLOB/JSON value (base64-inflated ~1.33×) can
+	// exceed 64 MiB; with the client capped at 64 MiB the driver rejects the
+	// write locally even when the server would accept it. maxAllowedPacket=0
+	// makes the driver fetch @@max_allowed_packet from the server (the bundled
+	// index MySQL raises it to 1 GiB; BYO indexes get whatever they set).
+	//
+	// This is a ceiling raise, not a fix — events larger than the server's
+	// max_allowed_packet are still rejected; that rejection must be handled
+	// fail-loud rather than silently dropped (see #652). An explicit
+	// maxAllowedPacket in the user's DSN is preserved.
+	if !dsnSpecifiesMaxAllowedPacket(dsn) {
+		cfg.MaxAllowedPacket = 0
+	}
+	return cfg.FormatDSN(), nil
+}
+
+// dsnSpecifiesMaxAllowedPacket reports whether the user's DSN already carries a
+// maxAllowedPacket parameter, so buildDSN does not override an explicit choice.
+func dsnSpecifiesMaxAllowedPacket(dsn string) bool {
+	return strings.Contains(strings.ToLower(dsn), "maxallowedpacket")
 }
 
 // ParseSourceDSN decomposes a go-sql-driver DSN into host, port, user, and

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -26,6 +26,57 @@ func TestConnect_locUTCApplied(t *testing.T) {
 	}
 }
 
+// TestBuildDSN_honorsServerMaxAllowedPacket verifies that buildDSN sets
+// MaxAllowedPacket=0 (fetch the limit from the server) instead of leaving the
+// driver's 64 MiB client-side default, so large row images up to the index
+// server's configured ceiling can be written. It re-parses the output to assert
+// on the resolved config (FormatDSN omits loc=UTC because UTC is the driver
+// default, so a string check would miss it). It also confirms the existing
+// invariants (ParseTime, Loc=UTC) survive the round-trip.
+func TestBuildDSN_honorsServerMaxAllowedPacket(t *testing.T) {
+	out, err := buildDSN("root:pass@tcp(127.0.0.1:3306)/bintrail_index")
+	if err != nil {
+		t.Fatalf("buildDSN: %v", err)
+	}
+	cfg, err := mysql.ParseDSN(out)
+	if err != nil {
+		t.Fatalf("re-parse buildDSN output %q: %v", out, err)
+	}
+	if cfg.MaxAllowedPacket != 0 {
+		t.Errorf("expected MaxAllowedPacket=0 (honor server limit), got %d", cfg.MaxAllowedPacket)
+	}
+	if !cfg.ParseTime {
+		t.Error("expected ParseTime=true preserved")
+	}
+	if cfg.Loc != time.UTC {
+		t.Errorf("expected Loc=UTC preserved, got %v", cfg.Loc)
+	}
+}
+
+// TestBuildDSN_explicitMaxAllowedPacketWins verifies precedence: an explicit
+// maxAllowedPacket in the user's DSN is not overridden by the server-honoring
+// default. Matches the project's CLI flag > env > default precedence ethos.
+func TestBuildDSN_explicitMaxAllowedPacketWins(t *testing.T) {
+	out, err := buildDSN("root:pass@tcp(127.0.0.1:3306)/db?maxAllowedPacket=33554432")
+	if err != nil {
+		t.Fatalf("buildDSN: %v", err)
+	}
+	cfg, err := mysql.ParseDSN(out)
+	if err != nil {
+		t.Fatalf("re-parse buildDSN output %q: %v", out, err)
+	}
+	if cfg.MaxAllowedPacket != 33554432 {
+		t.Errorf("explicit DSN maxAllowedPacket should be preserved, got %d", cfg.MaxAllowedPacket)
+	}
+}
+
+// TestBuildDSN_invalid surfaces a parse error rather than panicking.
+func TestBuildDSN_invalid(t *testing.T) {
+	if _, err := buildDSN("not-a-valid-dsn::::"); err == nil {
+		t.Error("expected error for invalid DSN, got nil")
+	}
+}
+
 // binlogStatusColumns matches the layout SHOW BINARY LOG STATUS /
 // SHOW MASTER STATUS returns: File, Position, Binlog_Do_DB,
 // Binlog_Ignore_DB, Executed_Gtid_Set. CurrentBinlogPosition scans

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -30,9 +30,10 @@ func TestConnect_locUTCApplied(t *testing.T) {
 // MaxAllowedPacket=0 (fetch the limit from the server) instead of leaving the
 // driver's 64 MiB client-side default, so large row images up to the index
 // server's configured ceiling can be written. It re-parses the output to assert
-// on the resolved config (FormatDSN omits loc=UTC because UTC is the driver
-// default, so a string check would miss it). It also confirms the existing
-// invariants (ParseTime, Loc=UTC) survive the round-trip.
+// on the resolved config. ParseTime and Timeout are meaningful checks here
+// (ParseDSN defaults them to false / 0); the Loc override is verified
+// separately in TestBuildDSN_forcesLocUTC (a plain DSN can't prove it because
+// ParseDSN already defaults Loc to UTC).
 func TestBuildDSN_honorsServerMaxAllowedPacket(t *testing.T) {
 	out, err := buildDSN("root:pass@tcp(127.0.0.1:3306)/bintrail_index")
 	if err != nil {
@@ -48,14 +49,34 @@ func TestBuildDSN_honorsServerMaxAllowedPacket(t *testing.T) {
 	if !cfg.ParseTime {
 		t.Error("expected ParseTime=true preserved")
 	}
-	if cfg.Loc != time.UTC {
-		t.Errorf("expected Loc=UTC preserved, got %v", cfg.Loc)
+	if cfg.Timeout != defaultTimeout {
+		t.Errorf("expected default Timeout=%v applied, got %v", defaultTimeout, cfg.Timeout)
 	}
 }
 
-// TestBuildDSN_explicitMaxAllowedPacketWins verifies precedence: an explicit
-// maxAllowedPacket in the user's DSN is not overridden by the server-honoring
-// default. Matches the project's CLI flag > env > default precedence ethos.
+// TestBuildDSN_forcesLocUTC verifies buildDSN overrides a user-supplied loc
+// with UTC. The input sets loc=Local (which survives a FormatDSN round-trip
+// unless overridden), so the assertion would fail if the cfg.Loc=UTC line were
+// removed — unlike a plain DSN, where ParseDSN already defaults Loc to UTC.
+func TestBuildDSN_forcesLocUTC(t *testing.T) {
+	out, err := buildDSN("root:pass@tcp(127.0.0.1:3306)/db?loc=Local")
+	if err != nil {
+		t.Fatalf("buildDSN: %v", err)
+	}
+	cfg, err := mysql.ParseDSN(out)
+	if err != nil {
+		t.Fatalf("re-parse buildDSN output %q: %v", out, err)
+	}
+	if cfg.Loc != time.UTC {
+		t.Errorf("expected Loc forced to UTC, got %v", cfg.Loc)
+	}
+}
+
+// TestBuildDSN_explicitMaxAllowedPacketWins verifies precedence: an explicit,
+// non-default maxAllowedPacket in the user's DSN is not overridden by the
+// server-honoring default. Matches the project's CLI flag > env > default
+// precedence ethos. 33554432 (32 MiB) differs from both the driver default
+// (67108864) and the server-honoring 0, so it genuinely discriminates.
 func TestBuildDSN_explicitMaxAllowedPacketWins(t *testing.T) {
 	out, err := buildDSN("root:pass@tcp(127.0.0.1:3306)/db?maxAllowedPacket=33554432")
 	if err != nil {
@@ -67,6 +88,43 @@ func TestBuildDSN_explicitMaxAllowedPacketWins(t *testing.T) {
 	}
 	if cfg.MaxAllowedPacket != 33554432 {
 		t.Errorf("explicit DSN maxAllowedPacket should be preserved, got %d", cfg.MaxAllowedPacket)
+	}
+}
+
+// TestBuildDSN_miscasedParamHonorsServer guards the precedence logic against the
+// casing class: a mis-cased maxAllowedPacket param is NOT recognized by the
+// case-sensitive go-sql-driver (it leaves MaxAllowedPacket at the default), so
+// buildDSN must fall through to the safe server-honoring 0 rather than silently
+// leave the client capped at 64 MiB. A substring/case-insensitive guard would
+// regress this.
+func TestBuildDSN_miscasedParamHonorsServer(t *testing.T) {
+	out, err := buildDSN("root:pass@tcp(127.0.0.1:3306)/db?MaxAllowedPacket=33554432")
+	if err != nil {
+		t.Fatalf("buildDSN: %v", err)
+	}
+	cfg, err := mysql.ParseDSN(out)
+	if err != nil {
+		t.Fatalf("re-parse buildDSN output %q: %v", out, err)
+	}
+	if cfg.MaxAllowedPacket != 0 {
+		t.Errorf("mis-cased param (ignored by the driver) should honor the server (0), got %d", cfg.MaxAllowedPacket)
+	}
+}
+
+// TestBuildDSN_credentialSubstringHonorsServer guards against a regression to
+// substring-matching the whole DSN: a password that contains the literal
+// "maxAllowedPacket" must NOT suppress the server-honoring default.
+func TestBuildDSN_credentialSubstringHonorsServer(t *testing.T) {
+	out, err := buildDSN("root:maxAllowedPacketX@tcp(127.0.0.1:3306)/db")
+	if err != nil {
+		t.Fatalf("buildDSN: %v", err)
+	}
+	cfg, err := mysql.ParseDSN(out)
+	if err != nil {
+		t.Fatalf("re-parse buildDSN output %q: %v", out, err)
+	}
+	if cfg.MaxAllowedPacket != 0 {
+		t.Errorf("a credential containing the param name must not suppress server-honoring (0), got %d", cfg.MaxAllowedPacket)
 	}
 }
 


### PR DESCRIPTION
## What

Quick-win **step 0** from the large-data robustness grooming. Raises the index `max_allowed_packet` ceiling so large BLOB/JSON row images can be written, and makes the client honor it.

**Two legs, both required together:**
1. `docker-compose.yml` index-mysql → `--max-allowed-packet=1G` (the MySQL maximum), alongside the existing `--sort-buffer-size=4M` (SHIP carve-out: tuning the bundled index MySQL).
2. `internal/config/config.go` `Connect` → the go-sql-driver caps the **client** at 64 MiB by default even when the server allows more. Setting `maxAllowedPacket=0` makes the driver fetch `@@max_allowed_packet` from the server and honor it. Extracted a unit-testable `buildDSN` seam; an explicit `maxAllowedPacket` in the user's DSN is preserved (precedence).

## Why

`binlog_events` stores full before/after row images as JSON. A binary BLOB is base64-inflated ~1.33×, so a ~48 MB blob already crosses the 64 MiB packet limit and the index INSERT is rejected — today that event is **silently dropped** (reproduced on EC2: source=2 rows / index=1).

## Scope — this is a ceiling raise, NOT the fix

Partial mitigation for #652. It does **not** close #652:
- Events larger than the server's `max_allowed_packet` are still rejected — the silent-drop must be made **fail-loud** (#652 ROOT-2).
- BYO indexes still at 64 M are unaffected until they raise their own limit (validate-warn is #652 ROOT-1).

Deliberately **not** changing the storage encoding (the grooming rejected re-encode: worse ceiling with hex, crosses the one-index-schema red line, O(every-row) irreversible migration).

## Tests

`internal/config` unit tests: `maxAllowedPacket=0` is emitted (honor server), an explicit DSN value wins, parseTime/Loc invariants survive, invalid DSN errors. All green.

Refs #652

🤖 Generated with [Claude Code](https://claude.com/claude-code)