### PR TITLE
perf: tune bundled index MySQL for high write volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,10 +129,43 @@ services:
     # (maxAllowedPacket=0 → fetched from the server). This is a ceiling raise,
     # not a fix: events above 1G are still rejected and must — but do not yet
     # (#652) — fail loud rather than drop silently.
+    #
+    # Write-throughput tuning for the index workload (append-mostly batched
+    # INSERTs of large JSON row images). mysql:8.4 already ships most of the
+    # high-write defaults (io_capacity=10000, log_buffer=64M, flush_neighbors=0,
+    # change buffer + adaptive hash off), so only three overrides remain:
+    #
+    # --skip-log-bin: the index is a write-only sink — nothing replicates FROM
+    # it, and bintrail reconstructs by re-streaming from the SOURCE, never from
+    # the index's own binlog. 8.4 defaults log_bin=ON + sync_binlog=1, which
+    # writes a second full ROW copy of every JSON image AND fsyncs per commit —
+    # re-introducing the very fsync that --innodb-flush-log-at-trx-commit=2 was
+    # set to remove. Disabling it is the largest single write win and is what
+    # makes trx_commit=2 actually pay off. (Safe: gtid_mode=OFF by default; a
+    # GTID-enabled server would reject --skip-log-bin.)
+    #
+    # --innodb-redo-log-capacity=2G: 8.4 defaults to 100M (this knob replaced
+    # innodb_log_file_size in 8.0.30+). 100M is small for bursts of large JSON
+    # images and triggers sharp-checkpoint / async-flush stalls — the dominant
+    # throughput risk once trx_commit=2 removes the per-commit fsync. Costs disk
+    # under #innodb_redo (operator's to budget, see capacity.md), zero
+    # durability cost at trx_commit=2.
+    #
+    # --innodb-flush-method=O_DIRECT: 8.4 still defaults to fsync. O_DIRECT skips
+    # the OS page-cache double-buffering of dirty InnoDB pages, which matters for
+    # this LOB-heavy write path. Works on the local-driver named volume below; an
+    # operator who repoints the volume at an exotic filesystem may need to drop
+    # this one flag.
+    #
+    # Buffer pool stays at the 128M default — it is host-RAM dependent and the
+    # operator's to size (docs/deployment.md §3); we never hardcode a RAM number.
     command:
       - "--innodb-flush-log-at-trx-commit=2"
       - "--sort-buffer-size=4M"
       - "--max-allowed-packet=1G"
+      - "--skip-log-bin"
+      - "--innodb-redo-log-capacity=2147483648"
+      - "--innodb-flush-method=O_DIRECT"
     environment:
       # 8.4 defaults to caching_sha2_password (native_password disabled);
       # bintrail's driver negotiates it over the plaintext Docker network.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -108,15 +108,22 @@ Budget roughly **1.2–1.6 KB per indexed event** (INSERT/DELETE ≈ 1.2 KB, UPD
 
 ### InnoDB tuning
 
+The **bundled** index (the `index-mysql` service in `docker-compose.yml`) already applies the write-throughput overrides below except `innodb_buffer_pool_size`, which is host-RAM dependent and left to you. The settings here are for a **BYO** index (`INDEX_DSN` pointing at your own MySQL):
+
 ```ini
 [mysqld]
-innodb_buffer_pool_size = 70%           # 50-70% of available RAM
+innodb_buffer_pool_size = 70%           # 50-70% of available RAM (the one you must size)
 innodb_flush_log_at_trx_commit = 2      # acceptable for index (not source)
-innodb_log_file_size = 1G
-innodb_flush_method = O_DIRECT
+innodb_redo_log_capacity = 2G           # 8.4 default is 100M — small for bursty large-row writes
+innodb_flush_method = O_DIRECT          # 8.4 still defaults to fsync
+skip_log_bin                            # the index is a write-only sink (see below)
 ```
 
 `innodb_flush_log_at_trx_commit = 2` trades a tiny recovery window (up to 1s of events) for significantly better write throughput. Since dbtrail can replay from the binlog position in `stream_state`, this tradeoff is acceptable.
+
+`skip_log_bin` disables the index server's **own** binary log. The index is a write-only sink — nothing replicates from it, and dbtrail reconstructs by re-streaming from the source, never from the index's binlog. Leaving it on writes a second full copy of every row image and (with the default `sync_binlog = 1`) fsyncs per commit, which cancels much of the `innodb_flush_log_at_trx_commit = 2` benefit. Only disable it on a dedicated index instance with `gtid_mode = OFF` (a GTID-enabled server rejects `skip_log_bin`).
+
+> **Note on MySQL 8.4 defaults:** `innodb_log_file_size` was replaced by `innodb_redo_log_capacity` in 8.0.30+. MySQL 8.4 LTS already ships several former hand-tunings as defaults (`innodb_io_capacity = 10000`, `innodb_log_buffer_size = 64M`, `innodb_flush_neighbors = 0`, change buffer and adaptive hash index off), so they no longer need setting.
 
 ## 4. Network Topology
 


### PR DESCRIPTION
## What

The bundled index (`index-mysql`, `mysql:8.4.9`) ran at stock defaults beyond the three existing flags. Audited the tuning posture against the index's actual write workload (append-mostly, LOB-heavy JSON row images, batched INSERTs, low per-DB concurrency, durability already relaxed via `trx_commit=2` + replay-from-checkpoint).

**Key finding:** 8.4 LTS already ships most former hand-tunings as defaults — so this is a *small* change, not a big knob sweep. Verified against the image binary (`mysqld --verbose --help`): `io_capacity=10000`, `log_buffer=64M`, `flush_neighbors=0`, change buffer + adaptive hash already off. Three real gaps remain:

| Flag added | 8.4 default | Why |
|---|---|---|
| `--skip-log-bin` | `log_bin=ON`, `sync_binlog=1` | The index is a **write-only sink** — nothing replicates from it; bintrail reconstructs by re-streaming from the **source**, never the index binlog. Leaving it on writes a 2nd full ROW copy of every JSON image **and** fsyncs per commit — cancelling much of `--innodb-flush-log-at-trx-commit=2`. Biggest single win. |
| `--innodb-redo-log-capacity=2G` | `100M` | This knob **replaced `innodb_log_file_size`** in 8.0.30+. 100M is small for bursty large-row writes → checkpoint/async-flush stalls. Zero durability cost at `trx_commit=2`. |
| `--innodb-flush-method=O_DIRECT` | `fsync` | Skips OS page-cache double-buffering of dirty pages on this LOB-heavy path. |

**Buffer pool stays at the default** (128M) — host-RAM dependent, the operator's to size. We never hardcode a RAM number (ship-vs-operate red line).

## Verification (booted the real image)

Ran `mysql:8.4.9` with the **exact** new command on a local-driver volume:

```
log_bin                          OFF
innodb_redo_log_capacity         2147483648
innodb_flush_method              O_DIRECT
innodb_flush_log_at_trx_commit   2
gtid_mode                        OFF        (so --skip-log-bin is accepted)
max_allowed_packet               1073741824
sort_buffer_size                 4194304
```

Clean boot in ~6s, no O_DIRECT / gtid / log-bin warnings in the error log.

## Docs

`docs/deployment.md §3` updated: fixed the stale `innodb_log_file_size` → `innodb_redo_log_capacity` rename, added `skip_log_bin` guidance for BYO indexes (with the `gtid_mode=OFF` caveat), and noted which knobs 8.4 already defaults so operators don't set them needlessly.

## Scope

Sibling to #656 (also a bundled-index hardening within the SHIP carve-out). Orthogonal to #652 (that's the fail-loud follow-up). Only ships RAM-independent, verified-safe flags; buffer-pool sizing and opt-in overrides (`doublewrite=DETECT_ONLY`, `innodb_dedicated_server`) are left to the operator / docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)