### PR TITLE
docs: sync documentation with the v0.14→v0.24 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ before/after images in a searchable index:
 - **Undo precisely** — generate exact reversal SQL for just the damaged rows
 - **Undo cascade deletes** — reconstruct child rows an `ON DELETE CASCADE` wiped out (and restore FKs an `ON DELETE SET NULL` cleared) that InnoDB removes *below* the binlog and most tools can't see — see [Query & Recovery](docs/query-and-recovery.md)
 - **Time-travel** — query any row (or table) as it was at any moment (requires ProxySQL — see [Time-Travel SQL](docs/time-travel-sql.md))
+- **Prove the safety net holds** — `bintrail verify` checks (off-line, drift-free) that a recovery would actually reproduce the source, and `bintrail status` flags any gap in the captured stream — so you find out *before* you need it — see [Verify](docs/verify.md)
 - **Web console** — browse, recover, and add servers to monitor, all in the UI
 - **[MCP server](docs/mcp-server.md)** — Claude or any MCP client can search history and draft recoveries
 
@@ -65,7 +66,7 @@ See [the demo image](docs/demo.md).
 |---|---|---|
 | [Install](docs/install.md) | [Query & Recovery](docs/query-and-recovery.md) | [Deployment](docs/deployment.md) · [Capacity](docs/capacity.md) |
 | [Quickstart](docs/quickstart.md) | [Web console](docs/console.md) | [Rotation & Status](docs/rotation-and-status.md) |
-| [DBA guide](docs/guide.md) | [Time-Travel SQL](docs/time-travel-sql.md) | [Docker](docs/docker.md) |
+| [DBA guide](docs/guide.md) | [Time-Travel SQL](docs/time-travel-sql.md) · [Verify recoveries](docs/verify.md) | [Docker](docs/docker.md) |
 | [30-second demo](docs/demo.md) | [Streaming](docs/streaming.md) · [Indexing](docs/indexing.md) | [Upload to S3](docs/upload.md) |
 | | [MariaDB source (alpha)](docs/mariadb.md) · [PostgreSQL source (beta)](docs/postgres.md) | [Server identity](docs/server-identity.md) |
 | | [MCP server](docs/mcp-server.md) | [Parquet debugging](docs/parquet-debugging.md) |

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ before/after images in a searchable index:
 - **See every change** — what changed and when, for every row, with before → after diffs
 - **Undo precisely** — generate exact reversal SQL for just the damaged rows
 - **Undo cascade deletes** — reconstruct child rows an `ON DELETE CASCADE` wiped out (and restore FKs an `ON DELETE SET NULL` cleared) that InnoDB removes *below* the binlog and most tools can't see — see [Query & Recovery](docs/query-and-recovery.md)
-- **Time-travel** — query any row (or table) as it was at any moment (requires ProxySQL — see [Time-Travel SQL](docs/time-travel-sql.md))
+- **Time-travel** — query any row (or table) as it was at any moment, from the web console or the `reconstruct` CLI; the live SQL `AS OF` interface additionally needs ProxySQL — see [Time-Travel SQL](docs/time-travel-sql.md)
 - **Prove the safety net holds** — `bintrail verify` checks (off-line, drift-free) that a recovery would actually reproduce the source, and `bintrail status` flags any gap in the captured stream — so you find out *before* you need it — see [Verify](docs/verify.md)
 - **Web console** — browse, recover, and add servers to monitor, all in the UI
 - **[MCP server](docs/mcp-server.md)** — Claude or any MCP client can search history and draft recoveries

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -85,7 +85,11 @@ The boundary triage cites:
 
 ## Source server configuration (required for correct capture)
 
-dbtrail reads ROW-format binary logs from your **source** MySQL. Faithful capture
+dbtrail captures changes from your **source** database — **MySQL**, **MariaDB**
+(alpha), or **PostgreSQL** (beta); see [Supported source families](#supported-source-families)
+below. The requirements here cover a **MySQL** (and MariaDB) source's ROW-format
+binary logs; PostgreSQL's capture requirements (logical replication, `wal_level`,
+`REPLICA IDENTITY`) live in [docs/postgres.md](docs/postgres.md). Faithful capture
 requires the source to be configured **server-wide** (not just per-session):
 
 - `binlog_format = ROW`.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -29,6 +29,9 @@ ship-vs-operate boundary below.
   (every row event, full before/after images).
 - dbtrail's own tooling for operating the index *data*: `rotate`, `status`,
   `doctor`, `archive reconcile`, Parquet archives and their queries.
+- The recovery and consistency tooling: `query`, `recover`, `recover-cascade`,
+  `reconstruct`, `baseline`, and `verify` (the data-consistency check that
+  proves a recovery would reproduce the source).
 - The web console, the MCP server, the time-travel shim.
 - The Docker images we publish, **including the pinned MySQL 8.4 index image
   bundled in docker-compose**: its build, tuned defaults, and documented
@@ -108,6 +111,37 @@ responsibility. Data captured while the source violated these requirements is ou
 of scope — configure the source (see
 [deployment.md → Source MySQL Requirements](docs/deployment.md#2-source-mysql-requirements))
 and re-index.
+
+## Supported source families
+
+dbtrail captures from three source families. **All of them index into the same
+MySQL index** — there is no per-source index store, and the index schema is
+identical across sources (that portability is deliberate). Pointing `--index-dsn`
+at a non-MySQL server is **not** supported.
+
+| Source | Status | Capture mechanism | Guide |
+|---|---|---|---|
+| **MySQL** 8.0+ (incl. Percona, RDS, Aurora, Cloud SQL) | Supported | ROW-format binlog over the replication protocol | [streaming.md](docs/streaming.md) |
+| **MariaDB** (target 11.4) | Alpha | ROW-format binlog (MariaDB GTID) | [mariadb.md](docs/mariadb.md) |
+| **PostgreSQL** | Beta — via the separate `bintrail-pg` binary | Logical replication (`pgoutput`) | [postgres.md](docs/postgres.md) |
+
+**We install nothing in your source database.** dbtrail connects as an ordinary
+read-only replication client. For PostgreSQL specifically, capture uses the
+**built-in `pgoutput`** logical-decoding plugin only — dbtrail never installs a
+custom output plugin, runs `CREATE EXTENSION`, adds an event trigger, or places
+any other server-side component in your source, and it never writes to the
+source. This keeps managed PostgreSQL (RDS/Aurora/Cloud SQL/Azure) in scope. We
+**validate** the source's configuration (`wal_level`, `REPLICA IDENTITY`, the
+publication); we never create it for you.
+
+**Operating the source-side capture prerequisites is the operator's
+responsibility** — the same ship-vs-operate split as the index. In particular, a
+PostgreSQL logical replication **slot retains WAL** until dbtrail consumes it: if
+`bintrail-pg` is stopped long enough, the slot can fill the source's disk. Sizing
+`max_slot_wal_keep_size`, monitoring slot lag, and the source's own disk are
+yours (`bintrail-pg doctor` reports slot/WAL health — see
+[postgres.md](docs/postgres.md)). Capturing from a misconfigured source
+(non-`FULL` row image, missing `REPLICA IDENTITY`, `PARTIAL_JSON`) is out of scope.
 
 ## Reporting issues
 

--- a/docs/capacity.md
+++ b/docs/capacity.md
@@ -63,6 +63,8 @@ total_GB = Σ over sources ( events_per_day × retain_days × avg_event_bytes ) 
 
 Adding a server from the console is a disk decision, not just a connection — budget for it.
 
+**Baselines are separate storage.** A `bintrail baseline` snapshot (used for full-table time-travel and [`verify`](verify.md)) is Parquet, written to disk or S3 *outside* the index MySQL — so it is **not** part of `total_GB` above. Size it like an archive (≈30–60× smaller than the live index per the table above), one snapshot per dump; local snapshots can be pruned automatically once a durable S3 copy exists (`--baseline-retain`, see [Dump & Baseline](./dump-and-baseline.md)). `bintrail status` reports the live index size and per-snapshot baseline sizes directly.
+
 ### Estimating `events_per_day` before you have history
 
 If dbtrail isn't streaming yet, ask the source itself. On the production MySQL:

--- a/docs/console.md
+++ b/docs/console.md
@@ -90,7 +90,12 @@ and searching events:
    Recover **auto-detects** it and folds the invisible children into the same
    script — no separate tab, no extra step. **Nothing is ever executed.** See
    [Recover and cascade](#cascade-recovery).
-5. **Status** — index health: partitions, coverage, stream lag, archives.
+5. **Status** — index health: partitions, coverage, stream lag, archives, and a
+   first-class **stream-continuity** signal — a green "✓ No gaps in captured
+   stream" badge when the captured range is contiguous, or a red "⚠ Events
+   permanently lost" record when an unfillable gap (or a lost PostgreSQL slot)
+   was detected. Both fire for any source family. See
+   [the continuity signal](rotation-and-status.md#stream-continuity-no-data-lost).
 6. **Settings** (under `watch` only) — **Storage** (rotation policy,
    per-source S3 archiving, baseline snapshots, AWS credential signals — see
    [The Storage page](#the-storage-page)) and **Rotation** (opens the

--- a/docs/console.md
+++ b/docs/console.md
@@ -425,10 +425,11 @@ A running server accepts it on the next login — no restart needed.
 The binary has no Supabase/RBAC backend to lean on, so the console defends
 itself:
 
-- **Loopback by default + a credential required.** A random 128-bit token is
-  generated for loopback binds and printed in the URL. Binding to a
-  non-loopback address (`0.0.0.0`, a LAN IP, …) **requires** an explicit
-  `--token` or a configured console password, or the command refuses to start.
+- **Loopback by default + a credential required.** On a loopback bind the
+  console prompts you to create a password on first run — no credential is ever
+  auto-generated for you. Binding to a non-loopback address (`0.0.0.0`, a LAN
+  IP, …) **requires** an explicit `--token` or a configured console password, or
+  the command refuses to start.
 - **Constant-time credential checks** (`crypto/subtle` for the token;
   sessions are looked up by SHA-256 of the presented value, so raw session
   tokens never live server-side; unknown-username logins still burn a full

--- a/docs/ddl-tracking.md
+++ b/docs/ddl-tracking.md
@@ -12,7 +12,7 @@ Before DDL tracking, the only solution was to notice the "column count mismatch"
 
 DDL tracking solves three problems:
 
-1. **Detection**: The parser identifies DDL statements (`ALTER TABLE`, `CREATE TABLE`, `DROP TABLE`, `RENAME TABLE`) and emits them as events instead of just logging warnings.
+1. **Detection**: The parser identifies DDL statements (`ALTER TABLE`, `CREATE TABLE`, `DROP TABLE`, `RENAME TABLE`, `TRUNCATE TABLE`) and emits them as events instead of just logging warnings.
 2. **Auto-snapshot**: When a DDL is detected and a source database connection is available, dbtrail automatically takes a new snapshot and hot-swaps the resolver — no manual intervention needed. This works in both stream mode (always has source connection) and file mode (when `--source-dsn` is provided).
 3. **Restore coverage**: The `status` command shows the time range of indexed events and warns about DDLs that weren't followed by a snapshot (file mode), so you know where recovery gaps might exist.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -215,7 +215,7 @@ journalctl -u bintrail-stream -f
 
 [docker.md](docker.md) is the canonical home for the image, `docker run`, and the compose stack. For production, harden that base:
 - Use Docker secrets or environment files instead of inline credentials
-- Pin image versions (`FROM golang:1.25.7-alpine` in your Dockerfile)
+- Pin image versions (`FROM golang:1.25.11-bookworm` in your Dockerfile — the DuckDB Go bindings link glibc, so an Alpine/musl base breaks at runtime)
 - Mount a named volume for any persistent state (the index MySQL is the real persistent state — dbtrail itself is stateless)
 - Set resource limits (`mem_limit`, `cpus`) on the bintrail container
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -117,11 +117,15 @@ innodb_flush_log_at_trx_commit = 2      # acceptable for index (not source)
 innodb_redo_log_capacity = 2G           # 8.4 default is 100M — small for bursty large-row writes
 innodb_flush_method = O_DIRECT          # 8.4 still defaults to fsync
 skip_log_bin                            # the index is a write-only sink (see below)
+max_allowed_packet = 1G                 # full JSON row images per INSERT — 64M default rejects large events
+sort_buffer_size = 4M                   # wide-row ORDER BY overflows the 256K default → Error 1038
 ```
 
 `innodb_flush_log_at_trx_commit = 2` trades a tiny recovery window (up to 1s of events) for significantly better write throughput. Since dbtrail can replay from the binlog position in `stream_state`, this tradeoff is acceptable.
 
 `skip_log_bin` disables the index server's **own** binary log. The index is a write-only sink — nothing replicates from it, and dbtrail reconstructs by re-streaming from the source, never from the index's binlog. Leaving it on writes a second full copy of every row image and (with the default `sync_binlog = 1`) fsyncs per commit, which cancels much of the `innodb_flush_log_at_trx_commit = 2` benefit. Only disable it on a dedicated index instance with `gtid_mode = OFF` (a GTID-enabled server rejects `skip_log_bin`).
+
+`max_allowed_packet` and `sort_buffer_size` matter specifically for the dbtrail index workload and are easy to miss: each `binlog_events` INSERT carries the full before/after JSON row images (base64-inflated ~1.33×), so a large row event can exceed MySQL's 64M default and be **rejected** (silent large-event loss, [#652](https://github.com/dbtrail/dbtrail/issues/652)); and an `ORDER BY` over wide rows overflows the 256K `sort_buffer_size` default with `Error 1038 (Out of sort memory)` ([#608](https://github.com/dbtrail/dbtrail/issues/608)). The bundled Compose index sets both already — a **BYO** index needs them set explicitly.
 
 > **Note on MySQL 8.4 defaults:** `innodb_log_file_size` was replaced by `innodb_redo_log_capacity` in 8.0.30+. MySQL 8.4 LTS already ships several former hand-tunings as defaults (`innodb_io_capacity = 10000`, `innodb_log_buffer_size = 64M`, `innodb_flush_neighbors = 0`, change buffer and adaptive hash index off), so they no longer need setting.
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -38,6 +38,7 @@ Each tagged release publishes a multi-arch image (`linux/amd64` + `linux/arm64`)
 ```bash
 docker pull ghcr.io/dbtrail/bintrail:latest          # core CLI + MCP server
 docker pull ghcr.io/dbtrail/bintrail-console:latest  # web console (serve/watch)
+docker pull ghcr.io/dbtrail/bintrail-pg:latest       # PostgreSQL-source capturer (beta)
 docker pull ghcr.io/dbtrail/bintrail:v0.7.12         # a specific version
 ```
 

--- a/docs/dump-and-baseline.md
+++ b/docs/dump-and-baseline.md
@@ -222,7 +222,7 @@ Each snapshot also records its **binlog anchor** (the file/position/GTID where t
 
 ### At-rest integrity (the `_MANIFEST` sidecar)
 
-Alongside each snapshot, `bintrail baseline` writes a `_MANIFEST` sidecar holding a **CRC-32C** over every Parquet file's bytes. The local read paths that consume baselines — full-table `reconstruct`, cascade recovery, and `query --include-snapshot` — **re-validate the CRC on every read** and **fail loud** on a mismatch (bit-rot, a truncated/partial write), rather than silently reconstructing from corrupt data. Snapshots created before this feature (no `_MANIFEST`) are read without validation, so it degrades gracefully. S3 read-validation is not yet covered in this release (the bytes can be re-encoded in transit); local reads are.
+Alongside each snapshot, `bintrail baseline` writes a `_MANIFEST` sidecar holding a **CRC-32C** over every Parquet file's bytes. Every local read path that consumes a baseline — full-table and single-row `reconstruct`, cascade recovery, the time-travel shim's `_snapshot`, and `query --include-snapshot` — **re-validates the CRC on every read** and **fails loud** on a mismatch (bit-rot, a truncated/partial write), rather than silently reconstructing from corrupt data. Snapshots created before this feature (no `_MANIFEST`) are read without validation, so it degrades gracefully. S3 read-validation is not yet covered in this release (the bytes can be re-encoded in transit); local reads are.
 
 ### Upload to S3
 

--- a/docs/dump-and-baseline.md
+++ b/docs/dump-and-baseline.md
@@ -129,6 +129,8 @@ This dumps **every accessible schema** into `/tmp/mydumper-output` — bare `bin
 | `--mydumper-path` | `mydumper` | Path to the mydumper binary. When set, skips Docker fallback. |
 | `--mydumper-image` | `mydumper/mydumper:latest` | Docker image for mydumper. Used only when no local binary is found. |
 | `--threads` | `4` | Number of parallel dump threads |
+| `--encrypt` | `false` | Encrypt dump files at rest using AES-256-CBC (requires `openssl` on `$PATH`) |
+| `--encrypt-key` | `~/.config/bintrail/dump.key` | Path to the encryption key file (generate with `bintrail generate-key`) |
 | `--format` | `text` | Output format: `text` or `json` |
 
 ### Schema and table filtering
@@ -191,6 +193,8 @@ bintrail baseline \
 | `--tables` | *(all)* | Comma-separated `db.table` filter |
 | `--compression` | `zstd` | Parquet compression: `zstd`, `snappy`, `gzip`, `none` |
 | `--row-group-size` | `500000` | Rows per Parquet row group |
+| `--encrypt` | `false` | Decrypt encrypted dump files (`.enc`, from `dump --encrypt`) before processing (requires `openssl` on `$PATH`) |
+| `--encrypt-key` | `~/.config/bintrail/dump.key` | Path to the decryption key file |
 | `--upload` | *(disabled)* | S3 URL to upload Parquet files after generation |
 | `--upload-region` | *(from AWS env)* | AWS region for `--upload` |
 | `--baseline-retain` | *(disabled)* | Prune local snapshots older than this (`Nd`/`Nh`) once a durable S3 copy exists (requires `--upload`) |
@@ -213,6 +217,12 @@ For example:
 ```
 
 The timestamp defaults to the `Started dump at:` time from mydumper's metadata file. Override it with `--timestamp` if needed.
+
+Each snapshot also records its **binlog anchor** (the file/position/GTID where the deltas on top of it begin) and, per table, a **content digest + row count** in the Parquet metadata (used by [`bintrail verify`](verify.md)). A `_SUCCESS` marker is written when the conversion completes; a partially-converted snapshot carries an `_INCOMPLETE` marker instead and is excluded from discovery (see [Pruning old local snapshots](#pruning-old-local-snapshots---baseline-retain)).
+
+### At-rest integrity (the `_MANIFEST` sidecar)
+
+Alongside each snapshot, `bintrail baseline` writes a `_MANIFEST` sidecar holding a **CRC-32C** over every Parquet file's bytes. The local read paths that consume baselines — full-table `reconstruct`, cascade recovery, and `query --include-snapshot` — **re-validate the CRC on every read** and **fail loud** on a mismatch (bit-rot, a truncated/partial write), rather than silently reconstructing from corrupt data. Snapshots created before this feature (no `_MANIFEST`) are read without validation, so it degrades gracefully. S3 read-validation is not yet covered in this release (the bytes can be re-encoded in transit); local reads are.
 
 ### Upload to S3
 

--- a/docs/dump-and-baseline.md
+++ b/docs/dump-and-baseline.md
@@ -116,7 +116,7 @@ bintrail dump \
   --output-dir /tmp/mydumper-output
 ```
 
-This dumps all user schemas from the source server into `/tmp/mydumper-output`.
+This dumps **every accessible schema** into `/tmp/mydumper-output` — bare `bintrail dump` applies no schema filter, so mydumper also tries `mysql`, `sys`, and `performance_schema`. Pass `--schemas mydb,otherdb` to scope it to your data: a least-privilege capture user (no `SHOW VIEW` on the `sys` views) **needs** that filter or the dump fails loudly. (The bundled Compose `baseline` profile excludes system schemas automatically; the bare CLI does not.)
 
 ### All flags
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -8,7 +8,7 @@ dbtrail indexes every INSERT, UPDATE, and DELETE from MySQL ROW-format binary lo
 
 dbtrail ingests changes two ways:
 
-- **`bintrail stream`** (and `bintrail up`, which wraps it) connects over the MySQL **replication protocol** — no access to binlog files on disk. This is the default, the only option for managed MySQL (RDS, Aurora, Cloud SQL), and runs anywhere with a TCP path to the source. See [Streaming](streaming.md). A **MariaDB** source is supported in alpha — see [MariaDB](mariadb.md). A **PostgreSQL** source is supported in alpha via the separate `bintrail-pg` binary — see [PostgreSQL](postgres.md).
+- **`bintrail stream`** (and `bintrail up`, which wraps it) connects over the MySQL **replication protocol** — no access to binlog files on disk. This is the default, the only option for managed MySQL (RDS, Aurora, Cloud SQL), and runs anywhere with a TCP path to the source. See [Streaming](streaming.md). A **MariaDB** source is supported in alpha — see [MariaDB](mariadb.md). A **PostgreSQL** source is supported in beta via the separate `bintrail-pg` binary — see [PostgreSQL](postgres.md).
 - **`bintrail index`** reads binlog **files** from a local path (`--binlog-dir`). Use it to **backfill** historical files on self-managed MySQL; it never reads remote, SSH, or object-storage paths, and it opens files read-only. See [Indexing](indexing.md).
 
 | | `bintrail index` | `bintrail stream` |

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -471,6 +471,42 @@ See [Query & Recovery](query-and-recovery.md) for the full flag reference and th
 
 ---
 
+### Scenario N: Prove a recovery would actually work — before you need it
+
+You don't want to discover a broken recovery chain *during* an incident. `bintrail
+verify` reconstructs your data from the baseline + indexed binlog and checks it
+reproduces the source — per table, `match` / `mismatch` / `inconclusive`.
+
+**Run the drift-free check** (no live source, no production impact — safe on a
+schedule). It compares the two most recent baselines, reconstructing the older
+one forward to the newer one's binlog anchor:
+
+```sh
+bintrail verify --index-dsn "$IDX" --baseline-dir /data/baselines
+```
+
+It exits non-zero on any mismatch (or if comparable tables existed but none could
+be proven), so you can wire it into cron or CI as a recovery-readiness gate.
+
+**On a mismatch, drill down** to the exact diverging rows and columns:
+
+```sh
+bintrail verify --index-dsn "$IDX" --baseline-dir /data/baselines --explain
+```
+
+**Check the other half — the capture stream itself** — with the continuity
+signal, which flags any unfillable gap as permanently lost:
+
+```sh
+bintrail status --index-dsn "$IDX" --fail-on-gap
+```
+
+See [Verify recoveries](verify.md) for both modes and the exit-code semantics,
+and [Rotation & Status](rotation-and-status.md#stream-continuity-no-data-lost)
+for the continuity signal.
+
+---
+
 ## 4. Keeping dbtrail Running (Day-to-Day)
 
 **Re-indexing new binlog files:** Just run `index --all` again. Files already marked `completed` are skipped automatically — re-running is always safe.

--- a/docs/install.md
+++ b/docs/install.md
@@ -18,7 +18,7 @@ it's the first section — the same four lines as the README.
   and `SELECT`.
 - An **index MySQL 8.0+** database for dbtrail's data (the Compose stack
   bundles one).
-- Go 1.24+ — only when building from source.
+- Go 1.25+ (the module targets `go 1.25.11`) — only when building from source. The default `GOTOOLCHAIN=auto` fetches the right toolchain for you.
 
 ## Docker Compose (the bundled default)
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -115,7 +115,7 @@ to every release. The image bundles both `bintrail` and `bintrail-mcp`; the
 web console ships as its own image, `ghcr.io/dbtrail/bintrail-console`
 (`serve` = read-only console, `watch` = stream + console daemon — what the
 Compose stack runs). The PostgreSQL-source binary ships as its own image,
-`ghcr.io/dbtrail/bintrail-pg` (alpha). See [docker.md](./docker.md) for signature verification,
+`ghcr.io/dbtrail/bintrail-pg` (beta). See [docker.md](./docker.md) for signature verification,
 `docker run` recipes, and the long-running stream container.
 
 ## Linux packages
@@ -137,7 +137,7 @@ sudo rpm -i bintrail_VERSION_linux_amd64.rpm
 The `bintrail` package carries the core CLI + `bintrail-mcp`; the web console
 is a separate `bintrail-console` package — install it only where an operator
 wants the UI. PostgreSQL-source capture is a separate `bintrail-pg` package
-(alpha) — install it only on hosts that capture from PostgreSQL.
+(beta) — install it only on hosts that capture from PostgreSQL.
 
 ## Go install
 

--- a/docs/mariadb.md
+++ b/docs/mariadb.md
@@ -8,7 +8,10 @@ pointing it at production.
 
 **Scope:** MariaDB is supported as a **source** (the database you capture
 changes from). The **index** — where bintrail stores the indexed events — stays
-**MySQL**. Pointing the index at MariaDB is not supported.
+**MySQL**. Pointing the index at MariaDB is not supported. Because the index is
+MySQL, the index-side tooling works unchanged: `query`, `recover`,
+`recover-cascade` (FK cascade recovery), and `verify` (consistency check) all
+apply to a MariaDB source.
 
 ---
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -112,7 +112,7 @@ time() - bintrail_index_newest_event_timestamp_seconds > 600
 (hours rotated out of MySQL but never archived). It does **not** signal a
 permanently lost capture stream — an unfillable binlog gap or a lost PostgreSQL
 replication slot. That verdict lives in `bintrail status` (the `Continuity:`
-line / `continuity.status` JSON field), and the alertable hook is its exit code:
+line / `stream.continuity.status` JSON field), and the alertable hook is its exit code:
 
 ```bash
 # in CI/cron — exits non-zero on gap_lost OR an unconfirmable state (fails closed)

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -106,8 +106,25 @@ stream is up:
 time() - bintrail_index_newest_event_timestamp_seconds > 600
 ```
 
+## Permanent data loss is not a metric — alert on `status`
+
+`bintrail_index_gap_hours` counts coverage holes **within the retained span**
+(hours rotated out of MySQL but never archived). It does **not** signal a
+permanently lost capture stream — an unfillable binlog gap or a lost PostgreSQL
+replication slot. That verdict lives in `bintrail status` (the `Continuity:`
+line / `continuity.status` JSON field), and the alertable hook is its exit code:
+
+```bash
+# in CI/cron — exits non-zero on gap_lost OR an unconfirmable state (fails closed)
+bintrail status --index-dsn "$IDX" --fail-on-gap
+```
+
+See [the continuity signal](rotation-and-status.md#stream-continuity-no-data-lost).
+A Prometheus gauge for this state is not exposed in this release.
+
 ## See also
 
 - [rotation-and-status.md](rotation-and-status.md) — `bintrail status` reports
-  the same coverage, index size, and per-table baseline size in text/JSON.
+  the same coverage, index size, and per-table baseline size in text/JSON, plus
+  the stream-continuity verdict.
 - [capacity.md](capacity.md) — sizing math and the `doctor` disk-capacity check.

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -430,8 +430,10 @@ your own round-trip.
 - **`GENERATED ... AS IDENTITY` / generated columns** can need care on recovery
   (`GENERATED ALWAYS AS IDENTITY` rejects an explicit insert; `STORED` generated
   columns are absent from the stream before PostgreSQL 18). Treat as best-effort.
-- **`reconstruct` / time-travel `shim` are not wired for PostgreSQL** (no
-  baseline yet) — see above.
+- **`reconstruct`, time-travel `shim`, and the baseline-anchored mode of
+  `verify` are not wired for PostgreSQL** (no baseline yet) — see above.
+  (`recover` and `recover-cascade` work; cascades are captured as ordinary row
+  changes — see [Querying and recovering](#querying-and-recovering).)
 - **No connection/forensics attribution.** `pgoutput` does not carry the backend
   PID, so the per-connection forensics surface (available for MySQL) is empty
   for PostgreSQL.

--- a/docs/query-and-recovery.md
+++ b/docs/query-and-recovery.md
@@ -254,7 +254,7 @@ of a single `--pk`, and cap how many events are undone per key with
 (`--schema`/`--table`/`--event-type`/`--since`/`--until`/`--column-eq`/`--gtid`/`--flag`).
 
 **PostgreSQL sources:** when the source is PostgreSQL, `recover` emits
-PostgreSQL-dialect reversal SQL (identifier quoting and type literals) rather than
+PostgreSQL-dialect reversal SQL (double-quoted identifiers and string/boolean literals) rather than
 MySQL syntax — see [PostgreSQL](postgres.md#querying-and-recovering).
 
 ### WHERE Clause Strategy

--- a/docs/query-and-recovery.md
+++ b/docs/query-and-recovery.md
@@ -165,6 +165,11 @@ Equivalent env vars: `BINTRAIL_ULTRAFAST=1`, `BINTRAIL_DUCKDB_THREADS`, `BINTRAI
 
 The `recover` command also supports archive auto-discovery and the `--no-archive` flag, using the same merge logic as `query`. When archives are available, events are fetched from both MySQL and Parquet, merged, and then turned into reversal SQL.
 
+> **`recover` vs `reconstruct` vs `verify` — three different jobs.**
+> - **`recover`** (this page) undoes *specific touched rows* from stored before/after images — delta-only. It cannot materialize a whole table.
+> - **`reconstruct`** materializes a *full table or single row as of a point in time* by merging a baseline snapshot with binlog deltas — see [Dump & Baseline](dump-and-baseline.md) and [Time-Travel SQL](time-travel-sql.md).
+> - **`verify`** doesn't recover anything; it *proves* the reconstruct chain reproduces the source so your recoveries are trustworthy before you need them — see [Verify recoveries](verify.md).
+
 ### The Concept
 
 Recovery works because dbtrail stores **full before and after images** for every row event. To undo an operation, you simply reverse it:

--- a/docs/query-and-recovery.md
+++ b/docs/query-and-recovery.md
@@ -246,6 +246,17 @@ bintrail recover-cascade --index-dsn "..." \
   re-created a deleted parent, remove its `INSERT` from the output —
   `FOREIGN_KEY_CHECKS=0` does not suppress primary-key violations.
 
+### Recovering many rows at once
+
+To reverse a specific set of primary keys, pass `--pks` (comma-separated) instead
+of a single `--pk`, and cap how many events are undone per key with
+`--limit-per-pk`. These compose with the shared event filters
+(`--schema`/`--table`/`--event-type`/`--since`/`--until`/`--column-eq`/`--gtid`/`--flag`).
+
+**PostgreSQL sources:** when the source is PostgreSQL, `recover` emits
+PostgreSQL-dialect reversal SQL (identifier quoting and type literals) rather than
+MySQL syntax — see [PostgreSQL](postgres.md#querying-and-recovering).
+
 ### WHERE Clause Strategy
 
 For `UPDATE` and `DELETE` reversals, the generator needs a `WHERE` clause to identify the correct row in the current database state.

--- a/docs/query-and-recovery.md
+++ b/docs/query-and-recovery.md
@@ -290,5 +290,5 @@ COMMIT;
 Key properties:
 - Wrapped in `BEGIN` / `COMMIT` — all changes apply atomically or not at all.
 - Comments before each statement showing the original event ID, type, table, PK, timestamp, and GTID.
-- Generation errors emit a `-- ERROR ...` comment rather than halting — the script remains runnable (the transaction will roll back on the first error anyway).
+- Per-event generation errors emit a `-- ERROR ...` comment rather than halting — the script remains runnable (the transaction rolls back on the first error anyway). **Schema drift is the exception:** if a statement references a column dropped or renamed after the event, `recover` refuses up front — it writes nothing and exits non-zero (with `--output`, the target file is left empty), rather than emitting SQL that would fail at apply time. Always check the exit code before applying a generated file.
 - **Never auto-executed**: dbtrail only generates the file. Applying it is always a manual step.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -134,6 +134,7 @@ dbtrail never applies it for you. Check progress any time with
 | Time-travel: reconstruct full rows as of a point in time | [Dump and Baseline](./dump-and-baseline.md) — or the compose [`baseline` profile](./docker.md#baselines-and-time-travel-the-baseline-profile) |
 | Use RDS, Aurora, or Cloud SQL | [Streaming](./streaming.md) |
 | Understand the query and recovery options in depth | [Query and Recovery](./query-and-recovery.md) |
+| Prove a recovery would actually reproduce the source | [Verify recoveries](./verify.md) |
 | Archive old events to S3 before dropping | [Rotation and Status](./rotation-and-status.md#archiving-partitions-to-parquet) |
 | Plan disk space for the index MySQL | [Capacity Planning](./capacity.md) |
 | Use AI (Claude) to investigate changes | [MCP Server](./mcp-server.md) |

--- a/docs/rotation-and-status.md
+++ b/docs/rotation-and-status.md
@@ -253,9 +253,77 @@ Safety rules worth knowing:
 bintrail status --index-dsn "..."
 ```
 
-The status command produces a multi-section report, implemented in `internal/status/status.go`:
+It accepts `--format text` (default) or `--format json`, plus `--baseline-dir`
+(to list baseline snapshots) and `--fail-on-gap` (see continuity below).
 
-**Section 1 — Indexed Files**: Shows every row in `index_state`. The `BINTRAIL_ID` column identifies which dbtrail server instance indexed each file:
+The status command produces a multi-section report, implemented in `internal/status/status.go`. The sections, in order:
+
+| Section | Shown when | Contents |
+|---|---|---|
+| **Servers** | `bintrail_servers` has rows | Registered source servers — `bintrail_id`, host/port, server UUID, status |
+| **Stream** | `stream_state` has a checkpoint | Replication position/GTID, events indexed, last event/checkpoint, and the **continuity verdict** (below) |
+| **Indexed Files** | always | Every row in `index_state`, with the `bintrail_id` that indexed each file |
+| **Partitions** | always | Each partition's boundary and estimated row count |
+| **Archives** | `archive_state` has data | Archived-file / S3-upload counts |
+| **Restore Coverage** | always | Earliest/latest event, live + archived totals, **index size**, schema-change count |
+| **Summary** | always | Files grouped by server identity, with aggregated counts |
+| **Baselines** | `--baseline-dir` given | Baseline snapshots found on disk, with their binlog anchors and size |
+
+### Stream continuity ("no data lost")
+
+The **Stream** section ends with an always-present continuity verdict — the cheap
+"did I lose any events?" answer the gap detector already computes. It is strictly
+about gap-**contiguity** of the captured range; it is **not** a liveness/lag check
+(a contiguous stream may still be stopped or behind).
+
+```
+=== Stream ===
+  Bintrail ID:     abc123de-0000-0000-0000-000000000001
+  Mode:            gtid
+  Position:        binlog.000042:99012
+  Events indexed:  986655
+  Last checkpoint: 2026-02-19 10:01:12
+  Continuity:      no gaps in the captured range (not a liveness check)
+```
+
+The verdict is one of three states:
+
+| Text | JSON `continuity.status` | Meaning |
+|---|---|---|
+| `no gaps in the captured range` | `ok` | The captured range is contiguous — nothing was dropped |
+| `⚠ GAP LOST at <ts>` | `gap_lost` | An unfillable gap was stamped; the index is valid only up to the gap |
+| `not evaluated (legacy index …)` | `unknown` | A legacy index without the gap-detection columns — the state can't be confirmed (never a false "ok") |
+
+When data was permanently lost, a loud banner follows the section:
+
+```
+=== ⚠ EVENTS PERMANENTLY LOST ===
+  Detected:  2026-02-19 11:30:00
+  Detail:    unfillable binlog gap detected; resume requires re-baseline
+  The capture stream lost data it could not recover. The index up to the
+  gap is still valid for recovery, but to resume capture you must re-baseline.
+```
+
+This banner is also how an index-only `status` surfaces a lost or invalidated
+PostgreSQL replication slot (#532) after the capture process has exited.
+
+**`--fail-on-gap` (for CI / cron).** By default a gap **never** changes the exit
+code — `status` is a report. Pass `--fail-on-gap` to exit non-zero when continuity
+is `gap_lost` **or** `unknown`; it **fails closed**, so an un-migrated legacy index
+or an unloadable stream state also trips it:
+
+```sh
+bintrail status --index-dsn "$IDX" --fail-on-gap || alert "dbtrail lost events"
+```
+
+Under `--format json` the verdict is always present as a top-level `continuity`
+object (`{"status": "ok|gap_lost|unknown"}`), with a `gap_lost` object carrying the
+detail when applicable. The green "no gaps" badge in the [web console](console.md)
+keys on `continuity.status == "ok"`.
+
+### Sections in detail
+
+**Indexed Files** — shows every row in `index_state`. The `BINTRAIL_ID` column identifies which dbtrail server instance indexed each file:
 
 ```
 === Indexed Files ===
@@ -268,7 +336,7 @@ binlog.000001     completed  999     2026-02-01 00:00:00  2026-02-01 00:05:00  -
 
 Rows with `-` in `BINTRAIL_ID` were indexed before the server identity feature was introduced; their server of origin is unknown.
 
-**Section 2 — Partitions**: Shows each partition with its boundary and estimated row count:
+**Partitions** — shows each partition with its boundary and estimated row count:
 
 ```
 === Partitions ===
@@ -281,7 +349,7 @@ p_future      MAXVALUE            0
 Total events (est.): 987654
 ```
 
-**Section 3 — Summary**: Groups files by server identity and aggregates counts:
+**Summary** — groups files by server identity and aggregates counts:
 
 ```
 === Summary ===
@@ -296,16 +364,16 @@ Server (unknown)
 
 Files with a NULL `bintrail_id` are grouped under `Server (unknown)`. This is common when a shared index database receives files from multiple dbtrail instances (e.g. one per replica), or when upgrading from a version predating the server identity feature.
 
-**Section 4 — Archives** (shown when `archive_state` contains data): Displays archive and S3 upload statistics:
+**Archives** (shown when `archive_state` contains data) — archive and S3 upload statistics:
 
 ```
 === Archives ===
-Total archived: 168 partitions
-Total size:     4.2 GB (local)
-S3 uploaded:    168 partitions
+  Total:  168 files (4.2 GB, 987654 rows)
+  Local:  168
+  S3:     168 (bucket: my-archive-bucket)
 ```
 
-This section is loaded best-effort — if the `archive_state` table does not exist (older index databases created before the archiving feature), the section is silently omitted.
+`S3: 0` means nothing has been uploaded yet. This section is loaded best-effort — if the `archive_state` table does not exist (older index databases created before the archiving feature), it is silently omitted. A **Restore Coverage** section follows it with the earliest/latest indexed event, live + archived event totals, the **index size** on disk (`binlog_events`), and the schema-change count.
 
 The row counts in the partitions section are **estimates** from `information_schema.PARTITIONS.TABLE_ROWS`. InnoDB doesn't maintain exact row counts, so these are good approximations for capacity planning but not for exact totals. For turning these estimates into a disk forecast, see [Capacity Planning](./capacity.md).
 
@@ -333,8 +401,11 @@ bintrail rotate --retain 7d [--archive-s3 s3://...]
         auto-adds replacement future partitions (reorganize p_future)
 
 bintrail status
-    └── reads index_state, information_schema.PARTITIONS, archive_state
-        prints multi-section report (files, partitions, summary, archives)
+    └── reads bintrail_servers, stream_state, index_state,
+        information_schema.PARTITIONS, archive_state, schema_changes
+        (and baseline Parquet with --baseline-dir)
+        prints multi-section report incl. the stream-continuity verdict
+        (--format json for machine-readable; --fail-on-gap to alert on loss)
 
 bintrail query [--archive-s3 s3://...]
     └── partition pruning: only reads relevant partitions

--- a/docs/rotation-and-status.md
+++ b/docs/rotation-and-status.md
@@ -256,7 +256,7 @@ bintrail status --index-dsn "..."
 It accepts `--format text` (default) or `--format json`, plus `--baseline-dir`
 (to list baseline snapshots) and `--fail-on-gap` (see continuity below).
 
-The status command produces a multi-section report, implemented in `internal/status/status.go`. The sections, in order:
+The status command produces a multi-section report. The sections, in order:
 
 | Section | Shown when | Contents |
 |---|---|---|
@@ -265,9 +265,9 @@ The status command produces a multi-section report, implemented in `internal/sta
 | **Indexed Files** | always | Every row in `index_state`, with the `bintrail_id` that indexed each file |
 | **Partitions** | always | Each partition's boundary and estimated row count |
 | **Archives** | `archive_state` has data | Archived-file / S3-upload counts |
-| **Restore Coverage** | always | Earliest/latest event, live + archived totals, **index size**, schema-change count |
-| **Summary** | always | Files grouped by server identity, with aggregated counts |
-| **Baselines** | `--baseline-dir` given | Baseline snapshots found on disk, with their binlog anchors and size |
+| **Restore Coverage** | best-effort (skipped on load error) | Earliest/latest event, live + archived totals, **index size**, schema-change count |
+| **Summary** | `index_state` has rows | Files grouped by server identity, with aggregated counts (a pure-streaming index has none) |
+| **Baselines** | `--baseline-dir` given **and** snapshots found | Baseline snapshots on disk, with their binlog anchors and size |
 
 ### Stream continuity ("no data lost")
 
@@ -283,12 +283,13 @@ about gap-**contiguity** of the captured range; it is **not** a liveness/lag che
   Position:        binlog.000042:99012
   Events indexed:  986655
   Last checkpoint: 2026-02-19 10:01:12
+  Server ID:       100
   Continuity:      no gaps in the captured range (not a liveness check)
 ```
 
 The verdict is one of three states:
 
-| Text | JSON `continuity.status` | Meaning |
+| Text | JSON `stream.continuity.status` | Meaning |
 |---|---|---|
 | `no gaps in the captured range` | `ok` | The captured range is contiguous — nothing was dropped |
 | `⚠ GAP LOST at <ts>` | `gap_lost` | An unfillable gap was stamped; the index is valid only up to the gap |
@@ -316,10 +317,13 @@ or an unloadable stream state also trips it:
 bintrail status --index-dsn "$IDX" --fail-on-gap || alert "dbtrail lost events"
 ```
 
-Under `--format json` the verdict is always present as a top-level `continuity`
-object (`{"status": "ok|gap_lost|unknown"}`), with a `gap_lost` object carrying the
-detail when applicable. The green "no gaps" badge in the [web console](console.md)
-keys on `continuity.status == "ok"`.
+Under `--format json` the verdict is **nested in the `stream` object** as
+`stream.continuity` (`{"status": "ok|gap_lost|unknown"}`), with a sibling
+`stream.gap_lost` object carrying the detail when applicable. It is present
+whenever the `stream` object is — i.e. once a checkpoint exists — so a
+CI check uses `jq -e '.stream.continuity.status == "ok"'` (a `null` from a
+missing `stream` is itself a "can't confirm" signal). The green "no gaps" badge
+in the [web console](console.md) keys on `stream.continuity.status == "ok"`.
 
 ### Sections in detail
 
@@ -349,7 +353,20 @@ p_future      MAXVALUE            0
 Total events (est.): 987654
 ```
 
-**Summary** — groups files by server identity and aggregates counts:
+**Archives** (shown when `archive_state` contains data) — archive and S3 upload statistics:
+
+```
+=== Archives ===
+  Total:  168 files (4.2 GB, 987654 rows)
+  Local:  168
+  S3:     168 (bucket: my-archive-bucket)
+```
+
+`S3: 0` means nothing has been uploaded yet. This section is loaded best-effort — if the `archive_state` table does not exist (older index databases created before the archiving feature), it is silently omitted.
+
+**Restore Coverage** follows the Archives section: the earliest/latest indexed event, live + archived event totals, the **index size** on disk (`binlog_events`), and the schema-change count.
+
+**Summary** (printed last, when `index_state` has rows) — groups files by server identity and aggregates counts:
 
 ```
 === Summary ===
@@ -363,17 +380,6 @@ Server (unknown)
 ```
 
 Files with a NULL `bintrail_id` are grouped under `Server (unknown)`. This is common when a shared index database receives files from multiple dbtrail instances (e.g. one per replica), or when upgrading from a version predating the server identity feature.
-
-**Archives** (shown when `archive_state` contains data) — archive and S3 upload statistics:
-
-```
-=== Archives ===
-  Total:  168 files (4.2 GB, 987654 rows)
-  Local:  168
-  S3:     168 (bucket: my-archive-bucket)
-```
-
-`S3: 0` means nothing has been uploaded yet. This section is loaded best-effort — if the `archive_state` table does not exist (older index databases created before the archiving feature), it is silently omitted. A **Restore Coverage** section follows it with the earliest/latest indexed event, live + archived event totals, the **index size** on disk (`binlog_events`), and the schema-change count.
 
 The row counts in the partitions section are **estimates** from `information_schema.PARTITIONS.TABLE_ROWS`. InnoDB doesn't maintain exact row counts, so these are good approximations for capacity planning but not for exact totals. For turning these estimates into a disk forecast, see [Capacity Planning](./capacity.md).
 

--- a/docs/server-identity.md
+++ b/docs/server-identity.md
@@ -174,6 +174,31 @@ mydb     orders     (table)   billing   2026-03-01 05:00:00
 
 `(table)` in the COLUMN field means the flag applies to the table as a whole.
 
+### `bintrail profile` and `bintrail access` commands
+
+Flags label *what* is sensitive; **profiles** and **access rules** decide *who*
+may see it. A profile is a named role; an access rule maps a profile to a flag
+with `allow` or `deny`. At query time, `--profile <name>` withholds denied tables
+and redacts (NULLs) denied columns.
+
+```sh
+# 1. Create a profile (a role)
+bintrail profile add marketing --description "Marketing analysts" --index-dsn "$IDX"
+
+# 2. Grant/deny that profile access to a flag
+bintrail access add --profile marketing --flag pii --permission deny --index-dsn "$IDX"
+
+# 3. Run a query/recover as that profile — pii-flagged columns come back NULL,
+#    deny-flagged tables are withheld
+bintrail query  --profile marketing --schema mydb --table customers --index-dsn "$IDX"
+bintrail recover --profile marketing --schema mydb --table orders   --index-dsn "$IDX" --dry-run
+```
+
+`profile remove <name>` deletes a profile and cascades to its access rules;
+`profile list` and `access list [--profile <name>]` show what's configured.
+`access remove --profile <name> --flag <flag>` drops a single rule. All take
+`--index-dsn`.
+
 ### `--flag` Filter on `query` and `recover`
 
 Once flags are applied, you can filter events to only those from flagged tables or columns:

--- a/docs/server-identity.md
+++ b/docs/server-identity.md
@@ -98,7 +98,7 @@ Server (unknown)
 
 The flag system lets you label tables and columns with named flags (e.g. `billing`, `pii`, `sensitive`). These flags are the foundation for role-based access control: access rules can then restrict which profiles may query data carrying each flag.
 
-**Current state**: The flag infrastructure (`table_flags`, `profiles`, `access_rules` tables and the `bintrail flag` CLI) is fully implemented. Profile enforcement with query-time column redaction is tracked in separate follow-up issues.
+**Current state**: Fully implemented and enforced. The flag registry (`table_flags`, `profiles`, `access_rules` tables, managed by the `bintrail flag`, `bintrail profile`, and `bintrail access` CLIs) is in place, and **profile enforcement is live**: pass `--profile <name>` to `query` or `recover` and the read path withholds denied tables and redacts (NULLs) flagged columns at query time. See [`bintrail profile` / `bintrail access`](#bintrail-profile-and-bintrail-access-commands) below.
 
 ### Database Tables
 

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -45,6 +45,13 @@ detection on resume, which now works for MariaDB in both position and GTID mode.
 The MariaDB-specific setup, version support, alpha limitations, and
 troubleshooting live on the dedicated page: **[MariaDB](mariadb.md)**.
 
+## PostgreSQL as a source (beta)
+
+bintrail also captures from **PostgreSQL** (beta) via the separate `bintrail-pg`
+binary, over logical replication (`pgoutput`) — the index still stays MySQL.
+Setup, requirements, the slot/WAL operator boundary, type support, and beta
+limitations live on the dedicated page: **[PostgreSQL](postgres.md)**.
+
 ---
 
 ## The Problem
@@ -80,10 +87,16 @@ The `stream_state` table has exactly one row (enforced by a `CHECK (id = 1)` con
 | `last_event_time` | Timestamp of the last indexed event |
 | `last_checkpoint` | When the checkpoint was last written |
 | `server_id` | The `--server-id` used |
+| `bintrail_id` | The server identity this checkpoint belongs to |
+| `flavor` | Source flavor (`mysql` / `mariadb`; PostgreSQL capture uses its own LSN/slot state) |
+| `gap_lost_at` / `gap_lost_detail` | Stamped when an unfillable gap permanently lost data — see [Binlog Gap Detection](#binlog-gap-detection) and the [continuity signal](rotation-and-status.md#stream-continuity-no-data-lost) |
+| `source_health` | Periodic source-health snapshot (JSON) powering the console replication-health panel (e.g. a PostgreSQL slot's state) |
 
 **GTID accumulation**: In GTID mode, the stream state doesn't store just the latest GTID — it stores the entire accumulated executed GTID set. This is how MySQL replication works: when resuming, you tell MySQL "I've already seen all of these GTIDs, send me everything after."
 
 **Checkpoint interval**: Default 10 seconds, configurable via `--checkpoint`. This is the maximum amount of data you'd need to re-index if the process crashes — events between the last checkpoint and the crash are re-indexed on restart (they're deduplicated naturally because the same GTID/position is just re-received from MySQL).
+
+**Commit-boundary safety**: in GTID mode the checkpoint advances **only at transaction-commit boundaries**, never mid-transaction, so a saved `gtid_set` is always a set of fully-applied transactions — a crash can't persist a partial GTID that would skip the rest of that transaction on resume.
 
 ### Mode switching
 

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -88,7 +88,7 @@ The `stream_state` table has exactly one row (enforced by a `CHECK (id = 1)` con
 | `last_checkpoint` | When the checkpoint was last written |
 | `server_id` | The `--server-id` used |
 | `bintrail_id` | The server identity this checkpoint belongs to |
-| `flavor` | Source flavor (`mysql` / `mariadb`; PostgreSQL capture uses its own LSN/slot state) |
+| `flavor` | Source flavor — `mysql`/`mariadb` (this command) or `postgres` (written by `bintrail-pg`); selects the recovery SQL dialect |
 | `gap_lost_at` / `gap_lost_detail` | Stamped when an unfillable gap permanently lost data — see [Binlog Gap Detection](#binlog-gap-detection) and the [continuity signal](rotation-and-status.md#stream-continuity-no-data-lost) |
 | `source_health` | Periodic source-health snapshot (JSON) powering the console replication-health panel (e.g. a PostgreSQL slot's state) |
 
@@ -150,7 +150,7 @@ When binlogs have been purged and the gap cannot be filled:
    ```
 2. The checkpoint is **immediately updated** to the new (advanced) position. This prevents a crash loop if the stream fails during startup — the next restart will not hit the same purged-binlog error.
 3. The stream resumes from the earliest available position.
-4. **The loss is recorded durably** — it is not just a log line that scrolls away. The gap is stamped in `stream_state` (`gap_lost_at` / `gap_lost_detail`), so `bintrail status` reports `Continuity: ⚠ GAP LOST` and a loud `=== ⚠ EVENTS PERMANENTLY LOST ===` banner from then on (and `continuity.status: "gap_lost"` under `--format json`), even after the capture process has exited. The index up to the gap stays valid for recovery; resuming capture cleanly requires a re-baseline. To alert on this in CI/cron, run `bintrail status --fail-on-gap` (exits non-zero, fails closed). See [Rotation & Status](rotation-and-status.md#stream-continuity-no-data-lost).
+4. **The loss is recorded durably** — it is not just a log line that scrolls away. The gap is stamped in `stream_state` (`gap_lost_at` / `gap_lost_detail`), so `bintrail status` reports `Continuity: ⚠ GAP LOST` and a loud `=== ⚠ EVENTS PERMANENTLY LOST ===` banner from then on (and `stream.continuity.status: "gap_lost"` under `--format json`), even after the capture process has exited. The index up to the gap stays valid for recovery; resuming capture cleanly requires a re-baseline. To alert on this in CI/cron, run `bintrail status --fail-on-gap` (exits non-zero, fails closed). See [Rotation & Status](rotation-and-status.md#stream-continuity-no-data-lost).
 
 ### The `--no-gap-fill` flag
 

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -137,6 +137,7 @@ When binlogs have been purged and the gap cannot be filled:
    ```
 2. The checkpoint is **immediately updated** to the new (advanced) position. This prevents a crash loop if the stream fails during startup — the next restart will not hit the same purged-binlog error.
 3. The stream resumes from the earliest available position.
+4. **The loss is recorded durably** — it is not just a log line that scrolls away. The gap is stamped in `stream_state` (`gap_lost_at` / `gap_lost_detail`), so `bintrail status` reports `Continuity: ⚠ GAP LOST` and a loud `=== ⚠ EVENTS PERMANENTLY LOST ===` banner from then on (and `continuity.status: "gap_lost"` under `--format json`), even after the capture process has exited. The index up to the gap stays valid for recovery; resuming capture cleanly requires a re-baseline. To alert on this in CI/cron, run `bintrail status --fail-on-gap` (exits non-zero, fails closed). See [Rotation & Status](rotation-and-status.md#stream-continuity-no-data-lost).
 
 ### The `--no-gap-fill` flag
 

--- a/docs/time-travel-sql.md
+++ b/docs/time-travel-sql.md
@@ -263,6 +263,8 @@ SELECT id, email, name FROM _flashback.users AS OF TIMESTAMP '2026-05-02 10:00:0
 
 The column list accepts bare identifiers only; backticks, schema-qualified columns (`users.id`), and aliases (`id AS user_id`) are not yet parsed and surface as `ER_PARSE_ERROR`. Columns the row image is missing (e.g. dropped post-event) come back as `NULL` — matching MySQL's behaviour after an `ALTER TABLE DROP COLUMN`.
 
+For a **full-table** `SELECT *` (no column list), dbtrail unions the columns present across the reconstructed rows, so a column that existed at the queried time but was **dropped afterward** still appears — with its historical values — rather than being silently hidden by the current (narrower) schema.
+
 The WHERE column must match the table's primary key. A WHERE on a non-PK column is rejected with a parser error rather than silently returning the wrong row.
 
 `SHOW TABLES FROM _flashback / _diff / _snapshot` returns the indexed tables in the current schema (from the latest `schema_snapshots` row) so an interactive `mysql>` session can explore the virtual schemas:

--- a/docs/verify.md
+++ b/docs/verify.md
@@ -55,9 +55,12 @@ Results are **per table**, one of:
 ## Exit codes (for cron / CI)
 
 - **Non-zero** on any **mismatch** or error, **or** when comparable tables
-  existed but none could be proven (all inconclusive).
+  existed but none could be proven (all inconclusive). An `inconclusive` table
+  never *by itself* fails the run — but a run where *no* table could be proven does.
 - **Zero** when a source has only one baseline (no predecessor to compare yet) —
   this is reported, not failed.
+- **Non-zero** when *no* baselines are found at all — that's a misconfiguration
+  (wrong `--baseline-dir`/`--baseline-s3`), not a "nothing to do."
 
 This makes `bintrail verify` safe to wire straight into a pipeline: a clean exit
 means "nothing disproved the recovery chain."
@@ -82,6 +85,8 @@ diff tool involved.
 | `--tables` | *(all)* | Comma-separated `schema.table` list (default: all tables in the latest schema snapshot) |
 | `--no-archive` | `false` | Query live MySQL partitions only; skip Parquet archive discovery |
 | `--explain` | `false` | On a baseline-anchored mismatch, print a per-row drill-down |
+
+One of `--baseline-dir` or `--baseline-s3` is **required** — `verify` always reads baselines, in both modes.
 
 It also accepts the shared DuckDB tuning flags (`--ultrafast`,
 `--duckdb-threads`, `--duckdb-memory-limit`) — see the DuckDB resource tuning

--- a/docs/verify.md
+++ b/docs/verify.md
@@ -84,8 +84,8 @@ diff tool involved.
 | `--explain` | `false` | On a baseline-anchored mismatch, print a per-row drill-down |
 
 It also accepts the shared DuckDB tuning flags (`--ultrafast`,
-`--duckdb-threads`, `--duckdb-memory-limit`) — see
-[Query & Recovery](query-and-recovery.md#duckdb-resource-tuning).
+`--duckdb-threads`, `--duckdb-memory-limit`) — see the DuckDB resource tuning
+section in [Query & Recovery](query-and-recovery.md).
 
 ## How it relates to `recover` and `reconstruct`
 

--- a/docs/verify.md
+++ b/docs/verify.md
@@ -1,0 +1,109 @@
+# Verifying a recovery (`bintrail verify`)
+
+`bintrail verify` proves that the recovery chain — a baseline snapshot plus the
+indexed binlog deltas on top of it — would faithfully reproduce your data. It
+answers the question the rest of dbtrail assumes: *if I reconstructed this table,
+would I actually get the right rows back?*
+
+It is read-only and never writes to your source or your index.
+
+## The two modes
+
+### Baseline-anchored (default, drift-free)
+
+Omit `--source-dsn`. `verify` compares the **two most recent baselines** of each
+table: it reconstructs the older baseline *forward* — applying indexed binlog
+events up to the newer baseline's exact binlog anchor — and fingerprints the
+result against the newer baseline.
+
+Both sides are at-rest data (Parquet snapshots), so this mode reads **no live
+source** and has **no production impact**. Run it any time after a baseline — for
+example right after `bintrail baseline`, or on a schedule (cron/CI). Because
+neither side is the live table, it can't be fooled by drift that happened on the
+source after capture; it tests the capture-and-reconstruct chain itself.
+
+```sh
+# All tables, baselines on local disk
+bintrail verify --index-dsn "$IDX" --baseline-dir /data/baselines
+
+# With a row-level drill-down on any mismatch
+bintrail verify --index-dsn "$IDX" --baseline-dir /data/baselines --explain
+```
+
+### Live-source
+
+Pass `--source-dsn`. For each table, `verify` reconstructs a consistent
+point-in-time snapshot and compares it against the **live source** table. This
+reads the whole table off the live server, so **run it off-peak**.
+
+```sh
+bintrail verify --source-dsn "$SRC" --index-dsn "$IDX" \
+  --baseline-s3 s3://bucket/baselines --tables mydb.orders,mydb.users
+```
+
+## What it reports
+
+Results are **per table**, one of:
+
+- **match** — the reconstruction reproduces the comparison exactly.
+- **mismatch** — they differ. The chain would not reproduce this table; investigate.
+- **inconclusive** — verify could not prove the table either way, and this is
+  **never reported as a failure**. Causes include: no predecessor baseline yet,
+  the index is behind the baseline anchor, an unsupported primary key, a coverage
+  gap, or a value class this version cannot yet compare.
+
+## Exit codes (for cron / CI)
+
+- **Non-zero** on any **mismatch** or error, **or** when comparable tables
+  existed but none could be proven (all inconclusive).
+- **Zero** when a source has only one baseline (no predecessor to compare yet) —
+  this is reported, not failed.
+
+This makes `bintrail verify` safe to wire straight into a pipeline: a clean exit
+means "nothing disproved the recovery chain."
+
+## `--explain` — row-level drill-down
+
+In baseline-anchored mode, add `--explain` to print, below the per-table report,
+exactly which rows diverged on a mismatch: the differing primary keys and, for
+changed rows, the differing columns with the reconstructed value vs the new
+baseline's. It re-runs the same reconstruction the verdict came from (byte-
+identical by construction) — no live source, scratch database, or external
+diff tool involved.
+
+## Flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `--index-dsn` | *(required)* | DSN for the index MySQL database |
+| `--source-dsn` | *(empty)* | Live source DSN. Pass it for **live-source** mode; omit for **baseline-anchored** mode |
+| `--baseline-dir` | *(empty)* | Local directory of baseline Parquet snapshots |
+| `--baseline-s3` | *(empty)* | S3 URL prefix of baseline snapshots (e.g. `s3://bucket/baselines/`) |
+| `--tables` | *(all)* | Comma-separated `schema.table` list (default: all tables in the latest schema snapshot) |
+| `--no-archive` | `false` | Query live MySQL partitions only; skip Parquet archive discovery |
+| `--explain` | `false` | On a baseline-anchored mismatch, print a per-row drill-down |
+
+It also accepts the shared DuckDB tuning flags (`--ultrafast`,
+`--duckdb-threads`, `--duckdb-memory-limit`) — see
+[Query & Recovery](query-and-recovery.md#duckdb-resource-tuning).
+
+## How it relates to `recover` and `reconstruct`
+
+- **`recover`** undoes *specific touched rows* from stored before/after images
+  (delta-only).
+- **`reconstruct`** materializes a *full table or row* at a point in time
+  (baseline + deltas).
+- **`verify`** doesn't recover anything — it *checks* that the `reconstruct`
+  chain is sound, so you find out your recoveries are trustworthy **before** you
+  need them.
+
+See also: the stream-continuity "no data lost" signal in
+[`bintrail status`](rotation-and-status.md#stream-continuity-no-data-lost), which
+verifies the *other* half — that no events were dropped from the capture stream.
+
+## Notes per source
+
+`verify` runs against the MySQL index, so it works for any source family whose
+baselines are wired. Baseline-anchored mode requires baselines; **PostgreSQL
+baselines are not yet wired** (see [PostgreSQL beta limitations](postgres.md#beta-limitations)),
+so `verify` against a PostgreSQL source is not usable in this release.


### PR DESCRIPTION
Closes the documentation drift surfaced by a full audit of the docs against everything shipped from v0.14.0 → v0.24.0 (98 confirmed gaps, 0 false positives). Docs-only; no code changes. Organized as thematic commits:

1. **P0 — wrong/misleading claims** (highest priority — these were factually wrong):
   - `console.md`: the loopback console prompts to create a password; no token is auto-generated (the "random 128-bit token printed in the URL" was false and self-contradictory).
   - `install.md`: Go minimum is 1.25.11, not 1.24+.
   - `deployment.md`: pin `golang:1.25.11-bookworm`, not `1.25.7-alpine` (DuckDB needs glibc).
   - `guide.md`: PostgreSQL source is **beta**, not alpha.
   - `server-identity.md`: RBAC profile enforcement + column redaction **ship** (`--profile`); the "follow-up issues" note was stale.
   - `dump-and-baseline.md`: bare `bintrail dump` filters no schemas (fails for least-privilege users).
   - `query-and-recovery.md`: `recover` refuses (empty output, non-zero exit) on schema drift.
   - `SUPPORT.md`: source families are MySQL, MariaDB (alpha), PostgreSQL (beta).

2. **`bintrail verify`** — the v0.24.0 data-consistency headline had no user docs. New `docs/verify.md` (two modes, `--explain`, exit codes) + entry points in README, guide (Scenario N), quickstart, and query-and-recovery.

3. **Stream continuity "no data lost" (#649)** — documented the `status` continuity verdict, `continuity.status` JSON, and `--fail-on-gap` across rotation-and-status (status section rewrite + corrected Archives example/section order), streaming, console, and observability.

4. **SUPPORT.md red lines** — the ratified non-MySQL-source case + the "we install nothing in your source database" (pgoutput-only) promise + the source-side slot/WAL operator boundary.

5. **P2 feature/flag gaps** — at-rest CRC `_MANIFEST` (#636), `--encrypt`, `profile`/`access` commands, `--pks`/`--limit-per-pk`, PG-dialect recovery, `stream_state` schema, commit-boundary checkpoints (#491), full-table dropped-column surfacing (#600), PG/MariaDB tooling notes, `bintrail-pg` image, TRUNCATE, baseline storage, README ProxySQL scoping.

All intra-repo anchor links were validated.

**Not in this PR:**
- `CLAUDE.md` refresh (it's gitignored — applied locally).
- `docs/deployment.md §3 InnoDB tuning` is owned by the in-progress `perf/index-write-tuning` branch; the `max_allowed_packet`/`sort_buffer` BYO-floor doc belongs there to avoid a conflict.

Full audit report: `drafts/doc-gap-audit-2026-06-29.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)