### PR TITLE
stream/index: fail loud on a flush failure instead of silently skipping

### DIFF
--- a/cmd/bintrail/index.go
+++ b/cmd/bintrail/index.go
@@ -219,28 +219,49 @@ func runIndex(cmd *cobra.Command, args []string) error {
 	})
 
 	var totalEvents int64
+	var failedFiles int
 	for _, filename := range files {
 		n, err := indexFile(ctx, p, idx, indexDB, idxBinlogDir, filename, bintrailID)
 		totalEvents += n
 		if err != nil {
-			// Log and continue so --all processes remaining files.
+			// Log and continue so --all still processes the remaining files;
+			// the failure is surfaced as a non-zero exit after the loop (#652).
 			slog.Error("indexing failed", "file", filename, "error", err)
+			failedFiles++
 		}
 	}
 
-	slog.Info("indexing complete", "files_processed", len(files), "events_indexed", totalEvents)
+	slog.Info("indexing complete",
+		"files_processed", len(files),
+		"events_indexed", totalEvents,
+		"failed_files", failedFiles)
 
 	if idxFormat == "json" {
-		return cliutil.OutputJSON(struct {
+		if err := cliutil.OutputJSON(struct {
 			FilesProcessed int   `json:"files_processed"`
 			EventsIndexed  int64 `json:"events_indexed"`
+			FailedFiles    int   `json:"failed_files"`
 		}{
 			FilesProcessed: len(files),
 			EventsIndexed:  totalEvents,
-		})
+			FailedFiles:    failedFiles,
+		}); err != nil {
+			return err
+		}
+	} else {
+		fmt.Printf("\nTotal events indexed: %d\n", totalEvents)
+		if failedFiles > 0 {
+			fmt.Printf("WARNING: %d of %d file(s) failed to index — see logs above\n", failedFiles, len(files))
+		}
 	}
 
-	fmt.Printf("\nTotal events indexed: %d\n", totalEvents)
+	// Fail loud: a file that could not be fully indexed (e.g. an event the
+	// server rejects as over max_allowed_packet) must not exit 0 and read as
+	// success to a cron/CI wrapper (#652). The per-file failure is already
+	// recorded as status='failed' in index_state.
+	if failedFiles > 0 {
+		return fmt.Errorf("indexing finished with %d of %d file(s) failed", failedFiles, len(files))
+	}
 	return nil
 }
 

--- a/cmd/bintrail/index_integration_test.go
+++ b/cmd/bintrail/index_integration_test.go
@@ -1,0 +1,68 @@
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestRunIndex_failedFileReturnsNonZero verifies that when a binlog file cannot
+// be indexed, `bintrail index` exits non-zero instead of logging the failure and
+// returning success (exit 0) — the silent failure a cron/CI wrapper read as a
+// clean run (#652). The per-file failure is still recorded as status='failed' in
+// index_state and --all still processes the remaining files; only the final exit
+// code changes.
+//
+// The failure is forced with a garbage binlog file (invalid magic), which the
+// parser rejects — a deterministic stand-in for the oversized-event rejection
+// that motivated the issue, reaching the same per-file error aggregation.
+func TestRunIndex_failedFileReturnsNonZero(t *testing.T) {
+	indexDB, name := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, indexDB)
+	// A snapshot must exist so EnsureResolver (sourceDB=nil) loads from the index
+	// and execution reaches the file loop.
+	testutil.InsertSnapshot(t, indexDB, 1, "2026-01-01 00:00:00",
+		"testdb", "orders", "id", 1, "PRI", "int", "NO")
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "binlog.000001"), []byte("not a valid binlog file"), 0o644); err != nil {
+		t.Fatalf("write garbage binlog: %v", err)
+	}
+
+	saved := struct {
+		index, source, binlogDir, files, format, schemas, tables string
+		all, skip                                                bool
+	}{idxIndexDSN, idxSourceDSN, idxBinlogDir, idxFiles, idxFormat, idxSchemas, idxTables, idxAll, idxSkipSourceCheck}
+	t.Cleanup(func() {
+		idxIndexDSN, idxSourceDSN, idxBinlogDir = saved.index, saved.source, saved.binlogDir
+		idxFiles, idxFormat, idxSchemas, idxTables = saved.files, saved.format, saved.schemas, saved.tables
+		idxAll, idxSkipSourceCheck = saved.all, saved.skip
+	})
+
+	idxIndexDSN = testutil.IntegrationDSN(name)
+	idxSourceDSN = ""
+	idxSkipSourceCheck = true // offline: no source pre-flight
+	idxBinlogDir = dir
+	idxFiles = "binlog.000001"
+	idxAll = false
+	idxFormat = "text"
+	idxSchemas = ""
+	idxTables = ""
+
+	// runIndex reads cmd.Context(); set it so indexFile's context.WithCancel
+	// has a non-nil parent (cobra would set it via ExecuteContext at runtime).
+	indexCmd.SetContext(context.Background())
+	err := runIndex(indexCmd, nil)
+	if err == nil {
+		t.Fatal("expected runIndex to return non-zero when a file fails to index, got nil (exit-0 silent failure — #652)")
+	}
+	if !strings.Contains(err.Error(), "failed") {
+		t.Errorf("expected a 'files failed' error, got: %v", err)
+	}
+}

--- a/cmd/bintrail/index_integration_test.go
+++ b/cmd/bintrail/index_integration_test.go
@@ -62,7 +62,67 @@ func TestRunIndex_failedFileReturnsNonZero(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected runIndex to return non-zero when a file fails to index, got nil (exit-0 silent failure — #652)")
 	}
-	if !strings.Contains(err.Error(), "failed") {
-		t.Errorf("expected a 'files failed' error, got: %v", err)
+	// Tight phrase from the aggregation error (index.go) so a setup regression
+	// that errors EARLY (e.g. "failed to connect to index database") can't make
+	// this pass for the wrong reason.
+	if !strings.Contains(err.Error(), "file(s) failed") {
+		t.Errorf("expected the per-file aggregation error, got: %v", err)
+	}
+}
+
+// TestRunIndex_allContinuesPastFailure verifies the --all resilience contract
+// the fix preserves: a failed file does NOT stop the loop (every file is still
+// attempted), and the run exits non-zero. With one garbage file the single-file
+// test cannot distinguish continue-then-fail from fail-fast; two files can —
+// both must get an index_state row (a fail-fast regression would skip file2).
+func TestRunIndex_allContinuesPastFailure(t *testing.T) {
+	indexDB, name := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, indexDB)
+	testutil.InsertSnapshot(t, indexDB, 1, "2026-01-01 00:00:00",
+		"testdb", "orders", "id", 1, "PRI", "int", "NO")
+
+	dir := t.TempDir()
+	for _, f := range []string{"binlog.000001", "binlog.000002"} {
+		if err := os.WriteFile(filepath.Join(dir, f), []byte("not a valid binlog file"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", f, err)
+		}
+	}
+
+	saved := struct {
+		index, source, binlogDir, files, format, schemas, tables string
+		all, skip                                                bool
+	}{idxIndexDSN, idxSourceDSN, idxBinlogDir, idxFiles, idxFormat, idxSchemas, idxTables, idxAll, idxSkipSourceCheck}
+	t.Cleanup(func() {
+		idxIndexDSN, idxSourceDSN, idxBinlogDir = saved.index, saved.source, saved.binlogDir
+		idxFiles, idxFormat, idxSchemas, idxTables = saved.files, saved.format, saved.schemas, saved.tables
+		idxAll, idxSkipSourceCheck = saved.all, saved.skip
+	})
+
+	idxIndexDSN = testutil.IntegrationDSN(name)
+	idxSourceDSN = ""
+	idxSkipSourceCheck = true
+	idxBinlogDir = dir
+	idxFiles = ""
+	idxAll = true // process every file in the dir
+	idxFormat = "text"
+	idxSchemas = ""
+	idxTables = ""
+
+	indexCmd.SetContext(context.Background())
+	err := runIndex(indexCmd, nil)
+	if err == nil {
+		t.Fatal("expected non-zero when files fail, got nil")
+	}
+
+	// Both files must have been attempted — proves the loop did not fail-fast on
+	// the first failure (the --all continue-on-failure contract).
+	var attempted int
+	if qerr := indexDB.QueryRow(
+		"SELECT COUNT(*) FROM index_state WHERE binlog_file IN ('binlog.000001','binlog.000002')",
+	).Scan(&attempted); qerr != nil {
+		t.Fatalf("count index_state: %v", qerr)
+	}
+	if attempted != 2 {
+		t.Errorf("expected both files attempted (--all continues past a failure), got %d index_state rows", attempted)
 	}
 }

--- a/internal/streamrun/streamrun.go
+++ b/internal/streamrun/streamrun.go
@@ -1208,28 +1208,32 @@ func (d Deps) validate() error {
 	return nil
 }
 
+// drainParser stops the stream's parser goroutine and returns its final error.
+//
+// While parked, the parser (sp.Run) returns only on context cancellation — it
+// is blocked in GetEvent waiting for the next binlog event, or on a send to a
+// full events buffer (every such send is a select with a <-ctx.Done() arm).
+// One derives a cancellable context whose deferred cancel runs only once One
+// returns, so when streamLoop returns an error mid-stream (the ticker /
+// batch-full / DDL flush paths, with the caller's ctx still live) a bare
+// `<-parseErrCh` would block forever and One would hang instead of surfacing the
+// failure to its supervisor — turning a fail-loud abort into a silent wedge
+// (#652). Cancelling BEFORE the receive guarantees the parser unblocks.
+// Idempotent on the clean-exit paths (the context is already cancelled, or the
+// parser already returned via close(events)). sp.Run converts cancellation to a
+// nil return, so the resulting parseErr is nil and dropped by the caller's
+// `parseErr != nil` guard; a genuine upstream parser failure (ctx still live)
+// is non-nil and surfaced.
+func drainParser(cancel context.CancelFunc, parseErrCh <-chan error) error {
+	cancel()
+	return <-parseErrCh
+}
+
 // One runs one complete replication stream — connect, validate,
 // resolve identity, snapshot, gap-check, sync, index, checkpoint — until ctx
 // is cancelled or a fatal error occurs. It is self-contained by design: no
 // package globals, no signal handling, safe to run N instances concurrently
 // (each against its own index database).
-// drainParser stops the stream's parser goroutine and returns its final error.
-//
-// The parser (sp.Run) returns only when its context is cancelled — it is
-// otherwise blocked in GetEvent waiting for the next binlog event, or on a send
-// to a full events buffer. One derives a cancellable context whose deferred
-// cancel runs only once One returns, so when streamLoop returns an error
-// mid-stream (the ticker / batch-full / DDL flush paths, with the caller's ctx
-// still live) a bare `<-parseErrCh` would block forever and One would hang
-// instead of surfacing the failure to its supervisor — turning a fail-loud
-// abort into a silent wedge (#652). Cancelling BEFORE the receive guarantees the
-// parser unblocks. Idempotent on the clean-exit paths (the context is already
-// cancelled, or the parser already returned via close(events)); the resulting
-// context.Canceled error is filtered by the caller.
-func drainParser(cancel context.CancelFunc, parseErrCh <-chan error) error {
-	cancel()
-	return <-parseErrCh
-}
 
 func One(ctx context.Context, cfg Config) error {
 	if !cliutil.IsValidOutputFormat(cfg.Format) {

--- a/internal/streamrun/streamrun.go
+++ b/internal/streamrun/streamrun.go
@@ -964,10 +964,17 @@ func streamLoop(
 		return nil
 	}
 
-	checkpoint := func() {
+	// checkpoint flushes the pending batch, then persists the stream position.
+	// A flush failure is RETURNED to the caller so the stream aborts loudly and
+	// replays from the last durable checkpoint on restart — the same fail-loud
+	// contract the batch-full (len>=BatchSize) and DDL flushes already follow.
+	// Swallowing it here let an un-indexable event (e.g. one over the server's
+	// max_allowed_packet) be silently skipped (#652). A saveCheckpoint failure
+	// is NOT data loss — it only re-streams from an older checkpoint on restart —
+	// so it stays a warning.
+	checkpoint := func() error {
 		if err := flush(); err != nil {
-			slog.Warn("batch flush failed", "error", err)
-			return
+			return err
 		}
 		if err := saveCheckpoint(db, state); err != nil {
 			slog.Warn("saveCheckpoint failed", "error", err)
@@ -982,6 +989,7 @@ func streamLoop(
 				"pos", state.binlogPos,
 				"events_indexed", state.eventsIndexed)
 		}
+		return nil
 	}
 
 	// advanceGTID adds a committed transaction's GTID to the durable set. It is
@@ -1011,15 +1019,21 @@ func streamLoop(
 	for {
 		select {
 		case <-ctx.Done():
-			checkpoint()
+			if err := checkpoint(); err != nil {
+				return err
+			}
 			return nil
 
 		case <-ticker.C:
-			checkpoint()
+			if err := checkpoint(); err != nil {
+				return err
+			}
 
 		case ev, ok := <-events:
 			if !ok {
-				checkpoint()
+				if err := checkpoint(); err != nil {
+					return err
+				}
 				return nil
 			}
 			// Update position tracking from each event.

--- a/internal/streamrun/streamrun.go
+++ b/internal/streamrun/streamrun.go
@@ -1213,6 +1213,24 @@ func (d Deps) validate() error {
 // is cancelled or a fatal error occurs. It is self-contained by design: no
 // package globals, no signal handling, safe to run N instances concurrently
 // (each against its own index database).
+// drainParser stops the stream's parser goroutine and returns its final error.
+//
+// The parser (sp.Run) returns only when its context is cancelled — it is
+// otherwise blocked in GetEvent waiting for the next binlog event, or on a send
+// to a full events buffer. One derives a cancellable context whose deferred
+// cancel runs only once One returns, so when streamLoop returns an error
+// mid-stream (the ticker / batch-full / DDL flush paths, with the caller's ctx
+// still live) a bare `<-parseErrCh` would block forever and One would hang
+// instead of surfacing the failure to its supervisor — turning a fail-loud
+// abort into a silent wedge (#652). Cancelling BEFORE the receive guarantees the
+// parser unblocks. Idempotent on the clean-exit paths (the context is already
+// cancelled, or the parser already returned via close(events)); the resulting
+// context.Canceled error is filtered by the caller.
+func drainParser(cancel context.CancelFunc, parseErrCh <-chan error) error {
+	cancel()
+	return <-parseErrCh
+}
+
 func One(ctx context.Context, cfg Config) error {
 	if !cliutil.IsValidOutputFormat(cfg.Format) {
 		return fmt.Errorf("invalid --format %q; must be text or json", cfg.Format)
@@ -1655,7 +1673,7 @@ func One(ctx context.Context, cfg Config) error {
 	loopErr := streamLoop(ctx, events, idx, indexDB,
 		time.Duration(cfg.Checkpoint)*time.Second, state, metrics, cfg.Hooks)
 
-	parseErr := <-parseErrCh
+	parseErr := drainParser(cancel, parseErrCh)
 
 	// ── 12. Summary ───────────────────────────────────────────────────────────────
 	if loopErr != nil {

--- a/internal/streamrun/streamrun_integration_test.go
+++ b/internal/streamrun/streamrun_integration_test.go
@@ -373,6 +373,48 @@ func TestStreamLoop_flushFailurePropagates(t *testing.T) {
 	}
 }
 
+// TestStreamLoop_saveCheckpointFailureDoesNotAbort verifies the deliberate split
+// in the fail-loud fix: a FLUSH failure aborts the stream, but a saveCheckpoint
+// failure stays a warning (it only re-streams from an older checkpoint on
+// restart — re-processing, not data loss). A regression that made checkpoint
+// errors abort would crash streams on transient stream_state write blips.
+//
+// binlog_events is kept (the flush succeeds) and stream_state is dropped (so
+// saveCheckpoint fails); streamLoop must still return nil.
+func TestStreamLoop_saveCheckpointFailureDoesNotAbort(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	testutil.InsertSnapshot(t, db, 1, "2026-01-01 00:00:00",
+		"testdb", "orders", "id", 1, "PRI", "int", "NO")
+
+	idx := indexer.New(db, 10)
+
+	events := make(chan parser.Event, 1)
+	events <- parser.Event{
+		BinlogFile: "binlog.000001",
+		StartPos:   0,
+		EndPos:     100,
+		Timestamp:  time.Now().UTC(),
+		Schema:     "testdb",
+		Table:      "orders",
+		EventType:  parser.EventInsert,
+		PKValues:   "1",
+		RowAfter:   map[string]any{"id": int64(1)},
+	}
+	close(events)
+
+	// The flush (into binlog_events) succeeds; only saveCheckpoint fails.
+	testutil.MustExec(t, db, "DROP TABLE stream_state")
+
+	state := &streamState{mode: "position", serverID: 1}
+	if err := streamLoop(context.Background(), events, idx, db, time.Hour, state, observe.ForSource("test"), nil); err != nil {
+		t.Fatalf("a saveCheckpoint failure must NOT abort the stream, got: %v", err)
+	}
+	if state.eventsIndexed != 1 {
+		t.Errorf("expected the event to be indexed despite the checkpoint failure, got %d", state.eventsIndexed)
+	}
+}
+
 // ─── streamLoop live replication ───────────────────────────────────────────────────────
 
 // TestStreamLoop_liveReplication is a full end-to-end test that connects as a

--- a/internal/streamrun/streamrun_integration_test.go
+++ b/internal/streamrun/streamrun_integration_test.go
@@ -325,6 +325,54 @@ func TestStreamLoop_flushAndCheckpoint(t *testing.T) {
 	}
 }
 
+// TestStreamLoop_flushFailurePropagates verifies that a flush failure at a
+// checkpoint is RETURNED to the caller (the stream aborts loudly) instead of
+// being swallowed with a warning — the silent-skip that let an un-indexable
+// event vanish (#652). The batch-full and DDL flush paths already propagated;
+// this covers the ticker / channel-closed checkpoint path that did not.
+//
+// The failure is forced by dropping binlog_events before the flush, so the
+// INSERT errors. Any InsertBatch error flows through the same checkpoint() path
+// the fix changed, so this is a deterministic stand-in for the oversized-event
+// (max_allowed_packet) rejection that motivated the issue.
+func TestStreamLoop_flushFailurePropagates(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	testutil.InsertSnapshot(t, db, 1, "2026-01-01 00:00:00",
+		"testdb", "orders", "id", 1, "PRI", "int", "NO")
+
+	// Batch size 10 so the single event is not flushed inline (len < BatchSize);
+	// it flushes at channel close, exercising the checkpoint() path.
+	idx := indexer.New(db, 10)
+
+	events := make(chan parser.Event, 1)
+	events <- parser.Event{
+		BinlogFile: "binlog.000001",
+		StartPos:   0,
+		EndPos:     100,
+		Timestamp:  time.Now().UTC(),
+		Schema:     "testdb",
+		Table:      "orders",
+		EventType:  parser.EventInsert,
+		PKValues:   "1",
+		RowAfter:   map[string]any{"id": int64(1)},
+	}
+	close(events)
+
+	// Force the flush to fail (the pool stays open so CreateTestDB's cleanup can
+	// still drop the database).
+	testutil.MustExec(t, db, "DROP TABLE binlog_events")
+
+	state := &streamState{mode: "position", serverID: 1}
+	err := streamLoop(context.Background(), events, idx, db, time.Hour, state, observe.ForSource("test"), nil)
+	if err == nil {
+		t.Fatal("expected streamLoop to propagate the flush failure, got nil (a silent skip — #652)")
+	}
+	if !strings.Contains(err.Error(), "INSERT") {
+		t.Errorf("expected a batch-INSERT flush error, got: %v", err)
+	}
+}
+
 // ─── streamLoop live replication ───────────────────────────────────────────────────────
 
 // TestStreamLoop_liveReplication is a full end-to-end test that connects as a

--- a/internal/streamrun/streamrun_test.go
+++ b/internal/streamrun/streamrun_test.go
@@ -1,6 +1,7 @@
 package streamrun
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -20,6 +21,36 @@ import (
 
 	"github.com/dbtrail/dbtrail/internal/parser"
 )
+
+// TestDrainParser_cancelsBeforeReceive verifies that drainParser cancels the
+// stream context before draining parseErrCh, so a parser goroutine that returns
+// only on cancellation (the real sp.Run behavior when blocked in GetEvent or on
+// a full events buffer) cannot wedge One. Without the cancel, One would hang
+// when streamLoop returns an error mid-stream — the #652 silent-wedge this
+// guards against. The 5s watchdog makes the regression observable: a drain that
+// forgot to cancel would block here and fail.
+func TestDrainParser_cancelsBeforeReceive(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	parseErrCh := make(chan error, 1)
+	// Stand-in for sp.Run: it only returns once the context is cancelled.
+	go func() {
+		<-ctx.Done()
+		parseErrCh <- ctx.Err()
+	}()
+
+	done := make(chan error, 1)
+	go func() { done <- drainParser(cancel, parseErrCh) }()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("parser error = %v, want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("drainParser hung: it must cancel the context before receiving so a ctx-blocked parser unblocks (#652)")
+	}
+}
 
 // selfSignedCAPEM generates a minimal self-signed CA certificate as PEM bytes.
 func selfSignedCAPEM(t *testing.T) []byte {

--- a/internal/streamrun/streamrun_test.go
+++ b/internal/streamrun/streamrun_test.go
@@ -22,13 +22,13 @@ import (
 	"github.com/dbtrail/dbtrail/internal/parser"
 )
 
-// TestDrainParser_cancelsBeforeReceive verifies that drainParser cancels the
-// stream context before draining parseErrCh, so a parser goroutine that returns
-// only on cancellation (the real sp.Run behavior when blocked in GetEvent or on
-// a full events buffer) cannot wedge One. Without the cancel, One would hang
-// when streamLoop returns an error mid-stream — the #652 silent-wedge this
-// guards against. The 5s watchdog makes the regression observable: a drain that
-// forgot to cancel would block here and fail.
+// TestDrainParser_cancelsBeforeReceive verifies drainParser's contract in
+// isolation: it cancels the stream context BEFORE draining parseErrCh, so a
+// parser goroutine that returns only on cancellation (the real sp.Run blocking
+// behavior in GetEvent or on a full events buffer) is unblocked rather than left
+// to wedge One's drain (#652). It exercises the helper, not One()'s call site.
+// The 5s watchdog makes the regression observable: a drain that forgot to cancel
+// blocks here and fails (proven by reverting the cancel()).
 func TestDrainParser_cancelsBeforeReceive(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 


### PR DESCRIPTION
closes #652

## Summary

An event the index cannot accept — e.g. a row image whose serialized size exceeds the server's `max_allowed_packet` — was **silently dropped**:
- `stream`: the ticker/shutdown `checkpoint()` swallowed the flush error (`slog.Warn` + return) and kept going.
- offline `index`: logged "indexing failed" but returned **exit 0** — a cron/CI wrapper read it as success.

(Reproduced on EC2: source had 2 rows, index had 1.)

The **batch-full** and **DDL** flush paths in `streamLoop` *already* propagate flush errors (`if err := flush(); err != nil { return err }`). The bug was a single inconsistent path. Occam: align it, no new machinery.

## Changes
- **`internal/streamrun/streamrun.go`** — `checkpoint()` returns the flush error instead of swallowing it; the 3 call sites (ticker, ctx-done, channel-closed) propagate it. The stream aborts loudly and replays from the last durable checkpoint on restart → **transient errors lose nothing** (re-streamed from the binlog); a genuinely un-indexable event aborts loudly rather than vanishing. A `saveCheckpoint` failure stays a warning (it only causes a re-stream on restart, not data loss).
- **`cmd/bintrail/index.go`** — `runIndex` returns non-zero when any file failed, plus a `failed_files` count in `--format json`. `--all` still processes every file; the per-file `status='failed'` record in `index_state` is unchanged.

## Trade-off (approved)
A truly un-indexable event (now > 1G after #656/#657, very rare) makes the stream **abort and retry** (potentially crashloop) rather than be skipped — this is the same behavior the batch-full path already had, made consistent. It is **fail-loud, not silent-skip**; the operator raises `max_allowed_packet` or excludes the table. The fancier record-and-advance alternative was deliberately not built (Occam).

## Scope guard
Not in scope: storage encoding (#653), unbounded read-path memory (#654). `#656`/`#657` raised the ceiling (stopgap); this is the fail-loud fix.

## Test plan
- [x] Unit suite (`go test ./... -count=1`) — pass
- [x] `internal/streamrun` + `cmd/bintrail` integration (`-tags integration`) — pass, **no regression** in existing streamLoop / live-replication / gtid tests
- [x] New `TestStreamLoop_flushFailurePropagates` — a checkpoint flush failure now propagates (was a silent nil)
- [x] New `TestRunIndex_failedFileReturnsNonZero` — a failed file now exits non-zero (was exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)