### PR TITLE
compose+docs: opt-in `flashback` profile — time-travel SQL terminal (no ProxySQL)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -303,18 +303,31 @@ services:
   # Runs `bintrail shim` — an in-process MySQL-protocol server that answers the
   # virtual _flashback / _snapshot / _diff schemas against the bundled index.
   # Point a plain `mysql` client at :3308 and read historical row state — NO
-  # ProxySQL required:
+  # ProxySQL required.
   #
+  # SCOPE: this shim serves the boot `SOURCE_DSN` source — the one the `bintrail`
+  # service streams into `bintrail_index`. So it needs SOURCE_DSN set in .env AND
+  # the main stack running: the `bintrail` service creates the index tables and
+  # streams; the shim only reads, it never provisions. Bring it up WITH the full
+  # stack — `up -d`, NOT `up -d shim` (which would skip `bintrail` and leave the
+  # index empty):
+  #
+  #   # in .env: SOURCE_DSN=user:pass@tcp(your-db:3306)/yourdb
   #   SHIM_USER=analyst SHIM_PASSWORD='pick-a-strong-one' \
-  #     docker compose --profile flashback up -d shim
+  #     docker compose --profile flashback up -d
   #   mysql -h 127.0.0.1 -P 3308 -u analyst -p
-  #   mysql> USE myapp;
+  #   mysql> USE yourdb;
   #   mysql> SELECT * FROM _flashback.orders AS OF '2026-05-02 10:00:00' WHERE id = 1;
   #
-  # This is a DEDICATED terminal for time-travel SQL: a normal SELECT on this
-  # connection returns ER_NOT_SUPPORTED_YET (1235). Transparently mixing normal
-  # and AS OF queries on one connection is what ProxySQL adds and is out of
-  # scope here — see docs/time-travel-sql.md.
+  # Sources added from the console UI stream into their OWN per-source index DB
+  # (bintrail_idx_<id>), NOT bintrail_index — to time-travel one of those, point
+  # INDEX_DSN at that database. Won't start / returns nothing? Almost always a
+  # missing SHIM_USER/SHIM_PASSWORD or an unset SOURCE_DSN — `docker compose logs
+  # shim` shows the FATAL line (the restart policy can bury it under `ps`).
+  #
+  # This is a DEDICATED terminal: a normal `SELECT * FROM orders` here returns
+  # ER_NOT_SUPPORTED_YET (1235). Transparently mixing normal and AS OF queries on
+  # one connection is what ProxySQL adds and is out of scope — docs/time-travel-sql.md.
   #
   # Opt-in because it needs YOU to choose the login it authenticates against —
   # there is deliberately no default credential on a MySQL port. Uses the CORE
@@ -334,9 +347,9 @@ services:
       # shipping a known credential on a MySQL port would be a footgun.
       SHIM_USER: ${SHIM_USER:-}
       SHIM_PASSWORD: ${SHIM_PASSWORD:-}
-      # Optional: derives the default schema so `_flashback.orders` resolves
-      # without a prior `USE` (parse-only — the shim never connects to it). If
-      # unset (the UI-driven multi-source path), just run `USE <db>` first.
+      # The source streamed into bintrail_index — also derives the default schema
+      # so `_flashback.orders` resolves without a prior `USE` (parse-only — the
+      # shim never connects to it). If unset, run `USE <db>` first in the client.
       SOURCE_DSN: ${SOURCE_DSN:-}
       # Bring your own index (default: the bundled MySQL, DSN built from the
       # generated password in the secret volume).
@@ -358,7 +371,14 @@ services:
         set -e
         if [ -z "$$SHIM_USER" ] || [ -z "$$SHIM_PASSWORD" ]; then
           echo "FATAL: set SHIM_USER and SHIM_PASSWORD to the login your mysql client will use, e.g." >&2
-          echo "  SHIM_USER=analyst SHIM_PASSWORD='...' docker compose --profile flashback up -d shim" >&2
+          echo "  SHIM_USER=analyst SHIM_PASSWORD='...' docker compose --profile flashback up -d" >&2
+          exit 1
+        fi
+        # A newline in a credential would fold in the single-quoted YAML into a
+        # silently-wrong value (auth then fails with no hint) — reject it loud,
+        # the same rejection `bintrail init-shim` makes.
+        if [ "$$(printf '%s' "$$SHIM_USER$$SHIM_PASSWORD" | wc -l)" -ne 0 ]; then
+          echo "FATAL: SHIM_USER / SHIM_PASSWORD must not contain a newline" >&2
           exit 1
         fi
         # Build the bundled-index DSN from the generated password unless the
@@ -385,6 +405,11 @@ services:
     depends_on:
       index-mysql:
         condition: service_healthy
+      # The shim only reads the index; the `bintrail` service is what creates
+      # the tables and streams the boot SOURCE_DSN source into bintrail_index.
+      # Depend on it so `up -d shim` can't start against an unprovisioned index.
+      bintrail:
+        condition: service_started
     restart: unless-stopped
 
   # ── Baselines (one-shot, opt-in `baseline` profile) ──────

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,10 @@
 # boundary: SUPPORT.md. Bring your own instead: set INDEX_DSN in .env (see
 # docs/docker.md).
 #
+# Opt-in profiles (neither runs by default): `baseline` (snapshot for the
+# console's Time-travel reconstruct) and `flashback` (a `mysql` time-travel
+# terminal on :3308 — set SHIM_USER/SHIM_PASSWORD; see docs/docker.md).
+#
 # For the full interactive demo (traffic generator, Grafana, Prometheus),
 # see demo/compose.yml instead.
 
@@ -290,6 +294,94 @@ services:
           exec bintrail-console watch --source-dsn "$$SOURCE_DSN" --index-dsn "$$INDEX_DSN"
         fi
         exec bintrail-console watch --index-dsn "$$INDEX_DSN"
+    depends_on:
+      index-mysql:
+        condition: service_healthy
+    restart: unless-stopped
+
+  # ── Time-travel SQL terminal (opt-in `flashback` profile) ─
+  # Runs `bintrail shim` — an in-process MySQL-protocol server that answers the
+  # virtual _flashback / _snapshot / _diff schemas against the bundled index.
+  # Point a plain `mysql` client at :3308 and read historical row state — NO
+  # ProxySQL required:
+  #
+  #   SHIM_USER=analyst SHIM_PASSWORD='pick-a-strong-one' \
+  #     docker compose --profile flashback up -d shim
+  #   mysql -h 127.0.0.1 -P 3308 -u analyst -p
+  #   mysql> USE myapp;
+  #   mysql> SELECT * FROM _flashback.orders AS OF '2026-05-02 10:00:00' WHERE id = 1;
+  #
+  # This is a DEDICATED terminal for time-travel SQL: a normal SELECT on this
+  # connection returns ER_NOT_SUPPORTED_YET (1235). Transparently mixing normal
+  # and AS OF queries on one connection is what ProxySQL adds and is out of
+  # scope here — see docs/time-travel-sql.md.
+  #
+  # Opt-in because it needs YOU to choose the login it authenticates against —
+  # there is deliberately no default credential on a MySQL port. Uses the CORE
+  # image (the console image omits the `shim` command). Full-table _snapshot.*
+  # needs a baseline: run the `baseline` profile, then set BASELINE_DIR.
+  shim:
+    profiles: ["flashback"]
+    image: ghcr.io/dbtrail/bintrail:${BINTRAIL_TAG:-latest}
+    ports:
+      # Loopback only. The shim binds 0.0.0.0 INSIDE the container so this host
+      # mapping can reach it (it logs a non-loopback Warn for that bind, which
+      # is expected — the mapping below is the real exposure control). To reach
+      # it from another host, change to "3308:3308", ideally behind TLS/stunnel.
+      - "127.0.0.1:3308:3308"
+    environment:
+      # REQUIRED: the login your `mysql` client authenticates with. No default —
+      # shipping a known credential on a MySQL port would be a footgun.
+      SHIM_USER: ${SHIM_USER:-}
+      SHIM_PASSWORD: ${SHIM_PASSWORD:-}
+      # Optional: derives the default schema so `_flashback.orders` resolves
+      # without a prior `USE` (parse-only — the shim never connects to it). If
+      # unset (the UI-driven multi-source path), just run `USE <db>` first.
+      SOURCE_DSN: ${SOURCE_DSN:-}
+      # Bring your own index (default: the bundled MySQL, DSN built from the
+      # generated password in the secret volume).
+      INDEX_DSN: ${INDEX_DSN:-}
+      # Enables full-table _snapshot.* (baseline + deltas → complete rows). Set
+      # to /var/lib/bintrail/baselines after a `baseline` profile run — same
+      # path as the console's BASELINE_DIR. Empty = binlog-only _flashback.
+      BASELINE_DIR: ${BASELINE_DIR:-}
+      # Optional client auth plugin. The default (mysql_native_password) works
+      # for the `mysql` CLI; set caching_sha2_password for drivers that require
+      # it (those clients then need TLS or a primed SHA2 cache to the shim).
+      SHIM_AUTH_METHOD: ${SHIM_AUTH_METHOD:-}
+    volumes:
+      - bintrail-state:/var/lib/bintrail:ro   # read-only: baselines for _snapshot
+      - bintrail-index-secret:/run/secret:ro
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        set -e
+        if [ -z "$$SHIM_USER" ] || [ -z "$$SHIM_PASSWORD" ]; then
+          echo "FATAL: set SHIM_USER and SHIM_PASSWORD to the login your mysql client will use, e.g." >&2
+          echo "  SHIM_USER=analyst SHIM_PASSWORD='...' docker compose --profile flashback up -d shim" >&2
+          exit 1
+        fi
+        # Build the bundled-index DSN from the generated password unless the
+        # operator brought their own. Plain assignment under `set -e` so an
+        # unreadable secret aborts loud (see the bintrail service for why).
+        if [ -z "$$INDEX_DSN" ]; then
+          INDEX_DSN="root:$$(cat /run/secret/index_password)@tcp(index-mysql:3306)/bintrail_index"
+        fi
+        # One-tenant shim.yaml in /tmp (regenerated from env every boot — not
+        # persisted, so the state volume stays read-only). server_id is a label
+        # (the shim does not filter events by it); source_dsn is parse-only.
+        # Single-quoted YAML (matching `bintrail init-shim`): the only escape is
+        # ' -> '', so a password with \ or " survives literally.
+        esc() { printf '%s' "$$1" | sed "s/'/''/g"; }
+        umask 077
+        printf "listen: '0.0.0.0:3308'\ntenants:\n  - server_id: 'compose-shim'\n    source_dsn: '%s'\n    mysql_user: '%s'\n    mysql_password: '%s'\n" \
+          "$$(esc "$$SOURCE_DSN")" "$$(esc "$$SHIM_USER")" "$$(esc "$$SHIM_PASSWORD")" > /tmp/shim.yaml
+        # The flag --listen (not shim.yaml's listen:) drives the actual bind, so
+        # 0.0.0.0 must be passed here for the host port mapping to reach it.
+        set -- shim --listen 0.0.0.0:3308 --shim-config /tmp/shim.yaml --index-dsn "$$INDEX_DSN"
+        [ -n "$$BASELINE_DIR" ] && set -- "$$@" --baseline-dir "$$BASELINE_DIR"
+        [ -n "$$SHIM_AUTH_METHOD" ] && set -- "$$@" --auth-method "$$SHIM_AUTH_METHOD"
+        exec bintrail "$$@"
     depends_on:
       index-mysql:
         condition: service_healthy

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -291,16 +291,49 @@ Notes:
 
 ### Time-travel SQL (`AS OF`) and the compose stack
 
-The console's Time-travel tab and time-travel **SQL** are different surfaces.
-`SELECT … AS OF` queries are answered by `bintrail shim` behind ProxySQL — a
-subcommand of the **core** `bintrail` binary that the console image
-deliberately does not ship — and the compose file includes no shim or ProxySQL
-service. To put `AS OF` SQL in front of this stack, run the core image
-(`ghcr.io/dbtrail/bintrail`) joined to the compose network with
-`shim --index-dsn` pointed at the bundled index (`index-mysql:3306`, password
-from the `bintrail-index-secret` volume — the boot `SOURCE_DSN` entry streams
-into `bintrail_index`), plus a ProxySQL loaded with `bintrail proxysql-config`
-output. The full shim + ProxySQL walkthrough is
+The console's Time-travel tab and time-travel **SQL** (`SELECT … AS OF`) are
+different surfaces. `AS OF` SQL is answered by `bintrail shim`, an in-process
+MySQL-protocol server (a subcommand of the **core** `bintrail` binary; the
+console image deliberately omits it).
+
+**The `flashback` profile — a dedicated time-travel terminal (no ProxySQL).**
+The compose file ships an opt-in `shim` service: point a plain `mysql` client at
+it and read historical row state. It uses the core image against the bundled
+index, so the only thing you supply is the login the terminal authenticates
+with:
+
+```sh
+SHIM_USER=analyst SHIM_PASSWORD='pick-a-strong-one' \
+  docker compose --profile flashback up -d shim
+
+mysql -h 127.0.0.1 -P 3308 -u analyst -p
+mysql> USE myapp;
+mysql> SELECT * FROM _flashback.orders AS OF '2026-05-02 10:00:00' WHERE id = 12345;
+mysql> SELECT * FROM _snapshot.orders  AS OF '2026-05-02 10:00:00';   -- full table (needs a baseline)
+mysql> SELECT * FROM _diff.orders BETWEEN '2026-05-01' AND '2026-05-02' WHERE id = 12345;
+```
+
+This is a **dedicated** terminal for time-travel: a normal `SELECT * FROM orders`
+on this connection returns `ER_NOT_SUPPORTED_YET` (1235). The shim reads the
+index only (it never touches your source) and binds to host loopback. Notes:
+
+- **`_snapshot.*` (the full table as it was) needs a baseline.** Run the
+  `baseline` profile (above), add `BASELINE_DIR=/var/lib/bintrail/baselines` to
+  `.env`, and recreate the shim (`docker compose --profile flashback up -d
+  shim`). Without it, `_flashback.*` returns only rows with binlog activity in
+  the retained window (a *partial* table), and full-table `_snapshot` degrades
+  to that behaviour.
+- **`SOURCE_DSN`** (if set) just supplies the default schema so `_flashback.orders`
+  resolves without a prior `USE`. On the UI-driven multi-source path it is unset
+  — run `USE <db>` first.
+- **MySQL 8.4 / driver clients**: the default auth plugin
+  (`mysql_native_password`) works for the `mysql` CLI; set
+  `SHIM_AUTH_METHOD=caching_sha2_password` for a driver that requires it.
+
+**Transparent routing (ProxySQL).** To let an application's *normal* connection
+mix live queries and `AS OF` queries on the same endpoint, put ProxySQL in front
+— it routes virtual-schema queries to the shim and everything else to your real
+MySQL. That is the full walkthrough in
 [time-travel-sql.md](./time-travel-sql.md); for a zero-setup taste of the SQL
 surface, use the demo image ([demo.md](./demo.md)).
 
@@ -316,7 +349,10 @@ surface, use the demo image ([demo.md](./demo.md)).
 | `BINTRAIL_TAG` | compose (optional) | Image tag to run (default `latest`) |
 | `BASELINE_SOURCE_DSN` | compose `baseline` profile | Source MySQL to snapshot (default: `SOURCE_DSN`) |
 | `BASELINE_SCHEMAS` | compose `baseline` profile | Comma-separated schemas to snapshot (default: `SCHEMAS`; empty = all user schemas, system schemas excluded) |
-| `BASELINE_DIR` | compose (optional) | Baseline dir for the boot `SOURCE_DSN` entry — set `/var/lib/bintrail/baselines` after the first `baseline` profile run to enable Time-travel on it |
+| `BASELINE_DIR` | compose (optional) | Baseline dir for the boot `SOURCE_DSN` entry — set `/var/lib/bintrail/baselines` after the first `baseline` profile run to enable Time-travel on it. Also enables full-table `_snapshot.*` on the `flashback` profile shim |
+| `SHIM_USER` | compose `flashback` profile | Login the time-travel `mysql` terminal authenticates with (required to start the `shim` service) |
+| `SHIM_PASSWORD` | compose `flashback` profile | Cleartext password for `SHIM_USER` (required) |
+| `SHIM_AUTH_METHOD` | compose `flashback` profile (optional) | Client auth plugin for the shim (default `mysql_native_password`; set `caching_sha2_password` for drivers that require it) |
 | `BINTRAIL_INDEX_DSN` | bintrail-mcp | Index DSN for the MCP server |
 
 (`SERVER_ID` is no longer needed — `bintrail-console watch` derives a stable

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -299,15 +299,19 @@ console image deliberately omits it).
 **The `flashback` profile — a dedicated time-travel terminal (no ProxySQL).**
 The compose file ships an opt-in `shim` service: point a plain `mysql` client at
 it and read historical row state. It uses the core image against the bundled
-index, so the only thing you supply is the login the terminal authenticates
-with:
+index. It serves the **boot `SOURCE_DSN` source** — the one the `bintrail`
+service streams into `bintrail_index` — so it needs `SOURCE_DSN` set in `.env`
+**and** the main stack running (the `bintrail` service creates the index tables
+and streams; the shim only reads — it never provisions). Bring it up *with* the
+full stack — note `up -d`, not `up -d shim`, so `bintrail` comes along:
 
 ```sh
+# in .env: SOURCE_DSN=user:pass@tcp(your-db:3306)/yourdb
 SHIM_USER=analyst SHIM_PASSWORD='pick-a-strong-one' \
-  docker compose --profile flashback up -d shim
+  docker compose --profile flashback up -d
 
 mysql -h 127.0.0.1 -P 3308 -u analyst -p
-mysql> USE myapp;
+mysql> USE yourdb;
 mysql> SELECT * FROM _flashback.orders AS OF '2026-05-02 10:00:00' WHERE id = 12345;
 mysql> SELECT * FROM _snapshot.orders  AS OF '2026-05-02 10:00:00';   -- full table (needs a baseline)
 mysql> SELECT * FROM _diff.orders BETWEEN '2026-05-01' AND '2026-05-02' WHERE id = 12345;
@@ -315,20 +319,30 @@ mysql> SELECT * FROM _diff.orders BETWEEN '2026-05-01' AND '2026-05-02' WHERE id
 
 This is a **dedicated** terminal for time-travel: a normal `SELECT * FROM orders`
 on this connection returns `ER_NOT_SUPPORTED_YET` (1235). The shim reads the
-index only (it never touches your source) and binds to host loopback. Notes:
+index only (it never touches your source). The shim process binds `0.0.0.0`
+inside the container — and logs a non-loopback warning, which is expected — while
+the `127.0.0.1:3308:3308` port mapping restricts host exposure to loopback. Notes:
 
 - **`_snapshot.*` (the full table as it was) needs a baseline.** Run the
   `baseline` profile (above), add `BASELINE_DIR=/var/lib/bintrail/baselines` to
-  `.env`, and recreate the shim (`docker compose --profile flashback up -d
-  shim`). Without it, `_flashback.*` returns only rows with binlog activity in
-  the retained window (a *partial* table), and full-table `_snapshot` degrades
-  to that behaviour.
-- **`SOURCE_DSN`** (if set) just supplies the default schema so `_flashback.orders`
-  resolves without a prior `USE`. On the UI-driven multi-source path it is unset
-  — run `USE <db>` first.
+  `.env`, and re-run `docker compose --profile flashback up -d`. Without it,
+  `_flashback.*` returns only rows with binlog activity in the retained window
+  (a *partial* table), and full-table `_snapshot` degrades to that behaviour.
+- **Sources added from the console UI are not served by this shim.** They stream
+  into their own per-source index database (`bintrail_idx_<id>`), not
+  `bintrail_index`. To time-travel one of those, point `INDEX_DSN` at that
+  database (one shim per source — see [time-travel-sql.md](./time-travel-sql.md)
+  "Single source MySQL per shim").
+- **Use a throwaway credential.** `SHIM_PASSWORD` is passed via the environment
+  (visible to `docker inspect`, like `AWS_SECRET_ACCESS_KEY` here) and written to
+  `/tmp/shim.yaml` in the container — make it a dedicated analyst login, not a
+  reused production password.
 - **MySQL 8.4 / driver clients**: the default auth plugin
   (`mysql_native_password`) works for the `mysql` CLI; set
   `SHIM_AUTH_METHOD=caching_sha2_password` for a driver that requires it.
+- **Bring-your-own index**: like the `bintrail` service, the `shim` service
+  mounts `bintrail-index-secret` and depends on `index-mysql` — adjust both if
+  you set `INDEX_DSN` and remove the bundled index.
 
 **Transparent routing (ProxySQL).** To let an application's *normal* connection
 mix live queries and `AS OF` queries on the same endpoint, put ProxySQL in front

--- a/docs/time-travel-sql.md
+++ b/docs/time-travel-sql.md
@@ -28,8 +28,8 @@ There are two ways to put `AS OF` SQL in front of your data; they differ only in
    Simplest. The shim already speaks the MySQL protocol, so an analyst connects
    a `mysql` client directly to it and runs `_flashback` / `_snapshot` / `_diff`
    queries. Trade-off: that connection answers *only* time-travel queries (a
-   normal `SELECT` returns `ER_NOT_SUPPORTED_YET`, 1235). Use it when a person
-   or tool just needs to read historical state.
+   normal `SELECT` against a real table returns `ER_NOT_SUPPORTED_YET`, 1235).
+   Use it when a person or tool just needs to read historical state.
 2. **Transparent routing — ProxySQL in front (the rest of this guide).** Needed
    only when an application's *normal* connection must mix live queries and
    `AS OF` queries on the same endpoint. ProxySQL routes virtual-schema queries
@@ -38,18 +38,22 @@ There are two ways to put `AS OF` SQL in front of your data; they differ only in
 ### The dedicated terminal
 
 **With the Docker Compose stack**, the shim ships as the opt-in `flashback`
-profile — supply a login and bring it up:
+profile. It serves the boot `SOURCE_DSN` source, so set `SOURCE_DSN` in `.env`
+and bring it up *with* the full stack (`up -d`, not `up -d shim`, so the
+streaming `bintrail` service comes along — see [docker.md](./docker.md)):
 
 ```sh
 SHIM_USER=analyst SHIM_PASSWORD='pick-a-strong-one' \
-  docker compose --profile flashback up -d shim
+  docker compose --profile flashback up -d
 ```
 
 **Standalone** (the shim is a subcommand of the core `bintrail` binary), run it
 against your index — no ProxySQL, and the source MySQL need not even be
-reachable (the shim reads the index):
+reachable (the shim reads the index). `init-shim` reads `BINTRAIL_SOURCE_DSN`
+and `BINTRAIL_SERVER_ID` from the environment (or `.bintrail.env`):
 
 ```sh
+export BINTRAIL_SOURCE_DSN='user:pass@tcp(your-db:3306)/yourdb' BINTRAIL_SERVER_ID=prod-1
 bintrail init-shim --out shim.yaml          # then fill in mysql_user + mysql_password
 bintrail shim --shim-config shim.yaml \
   --index-dsn 'user:pass@tcp(127.0.0.1:3306)/bintrail_index'

--- a/docs/time-travel-sql.md
+++ b/docs/time-travel-sql.md
@@ -19,7 +19,61 @@ The query is answered by `bintrail shim`, an in-process MySQL-protocol server (a
                                 └──────────┘                   └────────────┘
 ```
 
-The whole walkthrough takes about 10 minutes on a fresh Ubuntu 22.04 or Amazon Linux 2023 host that already has a populated dbtrail index.
+## Two ways to run time-travel SQL
+
+There are two ways to put `AS OF` SQL in front of your data; they differ only in
+*how the client connects*:
+
+1. **A dedicated terminal — point `mysql` straight at the shim (no ProxySQL).**
+   Simplest. The shim already speaks the MySQL protocol, so an analyst connects
+   a `mysql` client directly to it and runs `_flashback` / `_snapshot` / `_diff`
+   queries. Trade-off: that connection answers *only* time-travel queries (a
+   normal `SELECT` returns `ER_NOT_SUPPORTED_YET`, 1235). Use it when a person
+   or tool just needs to read historical state.
+2. **Transparent routing — ProxySQL in front (the rest of this guide).** Needed
+   only when an application's *normal* connection must mix live queries and
+   `AS OF` queries on the same endpoint. ProxySQL routes virtual-schema queries
+   to the shim and everything else to your real MySQL.
+
+### The dedicated terminal
+
+**With the Docker Compose stack**, the shim ships as the opt-in `flashback`
+profile — supply a login and bring it up:
+
+```sh
+SHIM_USER=analyst SHIM_PASSWORD='pick-a-strong-one' \
+  docker compose --profile flashback up -d shim
+```
+
+**Standalone** (the shim is a subcommand of the core `bintrail` binary), run it
+against your index — no ProxySQL, and the source MySQL need not even be
+reachable (the shim reads the index):
+
+```sh
+bintrail init-shim --out shim.yaml          # then fill in mysql_user + mysql_password
+bintrail shim --shim-config shim.yaml \
+  --index-dsn 'user:pass@tcp(127.0.0.1:3306)/bintrail_index'
+```
+
+Either way, connect a plain `mysql` client to the shim's port (default `3308`)
+and query the virtual schemas:
+
+```sh
+mysql -h 127.0.0.1 -P 3308 -u analyst -p
+mysql> USE myapp;
+mysql> SELECT * FROM _flashback.orders AS OF '2026-05-02 10:00:00' WHERE id = 12345;
+mysql> SELECT * FROM _snapshot.orders  AS OF '2026-05-02 10:00:00';   -- full table (needs a baseline)
+```
+
+`_snapshot.*` (the complete table as it was) requires a baseline configured with
+`--baseline-dir` / `--baseline-s3` (or `BASELINE_DIR` on the compose profile);
+without one, `_flashback.*` returns only rows with binlog activity in the
+retained window. The statement shapes and their semantics are identical on both
+paths — see **Step 6 — Run a time-travel query** below.
+
+---
+
+The ProxySQL walkthrough below takes about 10 minutes on a fresh Ubuntu 22.04 or Amazon Linux 2023 host that already has a populated dbtrail index.
 
 ---
 


### PR DESCRIPTION
## What

Adds an opt-in `flashback` profile to `docker-compose.yml` that runs a `shim`
service — `bintrail shim`, the in-process MySQL-protocol server for the virtual
`_flashback` / `_snapshot` / `_diff` schemas — so an analyst can point a plain
`mysql` client at `:3308` and read historical row state. **No ProxySQL
required.**

## Why

ProxySQL was the only documented way to put `AS OF` SQL in front of the stack,
but it is only needed for *transparent routing* (mixing normal + `AS OF` queries
on one connection). For a **dedicated time-travel terminal**, the shim already
speaks the MySQL protocol — a client can connect to it directly. The compose
stack shipped no shim service, so that simplest path required hand-rolling one.

## Usage

```sh
SHIM_USER=analyst SHIM_PASSWORD='pick-a-strong-one' \
  docker compose --profile flashback up -d shim

mysql -h 127.0.0.1 -P 3308 -u analyst -p
mysql> USE myapp;
mysql> SELECT * FROM _flashback.orders AS OF '2026-05-02 10:00:00' WHERE id = 1;
```

A normal `SELECT` on this connection returns `ER_NOT_SUPPORTED_YET` (1235) — it
is a dedicated terminal for time-travel SQL. Full-table `_snapshot.*` needs a
baseline (`BASELINE_DIR`).

## Design notes

- **Core image** (the console image omits `shim`); binds host loopback `127.0.0.1:3308`.
- **Opt-in + fail-loud**: requires `SHIM_USER`/`SHIM_PASSWORD` — no default
  credential on a MySQL port. Same opt-in pattern as the `baseline` profile.
- Generates `shim.yaml` in `/tmp` at boot with single-quoted YAML matching
  `bintrail init-shim` (password round-trips through `'` / `\`); state volume
  stays read-only.
- Index DSN built from the bundled secret (uid 999 reads it, 0600); the bind is
  driven by `--listen 0.0.0.0:3308` (the yaml `listen:` is parse-only).
- `server_id` is a label (the shim does not filter events by it); `source_dsn`
  is parse-only (default schema). Optional `BASELINE_DIR` enables full-table
  `_snapshot.*`; `SHIM_AUTH_METHOD` covers drivers needing `caching_sha2_password`.

## Docs

- `docs/docker.md` — Time-travel section rewritten to lead with the dedicated
  terminal; `SHIM_*` rows added to the env-var table.
- `docs/time-travel-sql.md` — new "Two ways to run time-travel SQL" section
  (dedicated terminal vs ProxySQL).

## Testing

- `docker compose --profile flashback config` parses.
- Entrypoint shell logic verified standalone: missing creds → FATAL; correct
  args; password with `'` / `\` / `@` round-trips through the generated YAML
  exactly (parsed back with a YAML loader).
- Generated `shim.yaml` matches the schema `internal/shim` expects (same keys as
  `bintrail init-shim`).
- Not run as a full live stack (needs a populated index + image pull).

## Note

`SHIM_PASSWORD` is visible via `docker inspect` (as `AWS_SECRET_ACCESS_KEY`
already is in this compose). It is the analyst's loopback terminal login, not
the index/source credential.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
