### PR TITLE
shim: decode BLOB/TEXT columns instead of returning their base64 text

### DIFF
--- a/internal/shim/handler.go
+++ b/internal/shim/handler.go
@@ -3,6 +3,7 @@ package shim
 import (
 	"context"
 	"database/sql"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -979,15 +980,171 @@ func (h *Handler) mapEventImages(schema, table string, rows []query.ResultRow) {
 	if r, err := h.resolverCache.get(time.Now, resolverCacheTTL, h.resolverFn, h.logger); err == nil {
 		fallback = r
 	}
+	epochs := h.loadEpochs()
 	src := metadata.EnumMapperSource{
-		Epochs:      h.loadEpochs(),
+		Epochs:      epochs,
 		ResolverFor: h.epochResolver,
 		Fallback:    fallback,
+	}
+	// BLOB/TEXT columns are stored base64-encoded (marshalRow base64-encodes the
+	// []byte go-mysql delivers); decode them back to raw bytes / strings before
+	// emission so the wire resultset carries the real value, not its base64 text
+	// (#661, sibling of recover #662 / reconstruct #663).
+	//
+	// Resolve the decodable columns at EACH event's epoch, not from the latest
+	// snapshot, mirroring the ENUM/SET mapper beside it (#475). Whether a column
+	// is base64-stored depends on whether go-mysql delivered it as []byte
+	// (BLOB/TEXT) or string (VARCHAR/CHAR) when the event was captured — so a
+	// latest-snapshot lookup would wrongly decode an old plain-string value that
+	// happens to be valid base64 (e.g. "test") across a VARCHAR→TEXT widening,
+	// silently corrupting it.
+	//
+	// Unlike the ENUM mapper, base64 decode has NO latest-snapshot fallback:
+	// relabeling an ENUM by the latest definition is harmless (strings pass
+	// through), but base64-decoding by the wrong schema is destructive, and the
+	// degraded path is reachable in production — resolverCache is sticky on
+	// failure (serves a stale latest resolver) while loadEpochs returns nil
+	// uncached on a DB blip, so an empty epoch list can coincide with a non-nil
+	// latest fallback. When the event's epoch typing is unavailable we therefore
+	// leave the value as the base64 it was stored as (mirrors reconstruct #666).
+	// The lone exception is a no-DB test handler (indexDB nil), where the
+	// injected fallback is the sole schema source and decoding by it is intended.
+	// The per-epoch column map is memoized.
+	b64Memo := make(map[int]map[string]bool)
+	base64ColsAt := func(t time.Time) map[string]bool {
+		id, ok := metadata.EpochAt(epochs, t)
+		if !ok {
+			// Empty epoch list: in production decline (leave base64); only the
+			// no-DB test handler decodes via the injected fallback (bucket -1).
+			if h.indexDB != nil {
+				return nil
+			}
+			id = -1
+		}
+		// Memoize per epoch id BEFORE attempting the load, so a snapshot whose
+		// resolver consistently fails to load is probed at most once rather than
+		// once per row at that epoch (mirrors EnumMapperSource.MapperAt, which
+		// checks its memo before calling ResolverFor).
+		if m, seen := b64Memo[id]; seen {
+			return m
+		}
+		r := fallback // only reached for id == -1 (the no-DB test path)
+		if id != -1 {
+			// The event's epoch is known; type the column from THAT epoch's
+			// resolver. If it fails to load, leave the value as base64 rather
+			// than fall back to the latest snapshot — cross-epoch typing is the
+			// corruption risk this closure exists to avoid.
+			er, err := h.epochResolver(id)
+			if err != nil || er == nil {
+				b64Memo[id] = nil
+				return nil
+			}
+			r = er
+		}
+		m := base64Cols(r, schema, table)
+		b64Memo[id] = m
+		return m
 	}
 	for i := range rows {
 		m := src.MapperAt(schema, table, rows[i].EventTimestamp)
 		m.MapImage(rows[i].RowBefore)
 		m.MapImage(rows[i].RowAfter)
+		// Decode AFTER the ENUM/SET map: the two passes touch disjoint columns
+		// (ENUM/SET are never BLOB/TEXT), so order is immaterial, but keeping the
+		// base64 decode last mirrors reconstruct.decodeChangeBinaries running
+		// after MapEventEnumLabels. Event images only — never a baseline row, so
+		// _snapshot decodes its deltas pre-merge and never double-decodes the
+		// baseline value DuckDB scans straight to a Go string.
+		b64 := base64ColsAt(rows[i].EventTimestamp)
+		decodeImageBase64(rows[i].RowBefore, b64)
+		decodeImageBase64(rows[i].RowAfter, b64)
+	}
+}
+
+// base64StoredKind reports whether a column's DataType is in the BLOB or TEXT
+// family — the ones go-mysql delivers as []byte so marshalRow base64-encodes
+// them in storage — and if so whether it is binary (true → raw []byte) or text
+// (false → string). Local copy of the predicate added for recover (#662) and
+// reconstruct (#663); duplicated because those copies are unexported (#661 is
+// the third consumer — a future refactor may hoist one shared copy).
+//
+// GEOMETRY/VECTOR are also delivered as []byte but deliberately out of scope
+// here, matching the recover/reconstruct fixes.
+func base64StoredKind(dataType string) (binary, ok bool) {
+	switch strings.ToLower(dataType) {
+	case "blob", "tinyblob", "mediumblob", "longblob":
+		return true, true
+	case "text", "tinytext", "mediumtext", "longtext":
+		return false, true
+	default:
+		return false, false
+	}
+}
+
+// decodeStoredBase64 reverses the storage-side base64 encoding of a BLOB/TEXT
+// value. binary selects the decoded Go type (true → []byte, false → string).
+// On the text resultset both render to the same wire bytes via
+// BuildSimpleTextResultset, but the distinction is load-bearing for _diff, which
+// JSON-marshals the image (marshalImageOrdered): a BLOB must stay []byte so it
+// re-base64-encodes cleanly rather than emit raw, possibly invalid-UTF-8 bytes
+// into the audit JSON. A value that is not a decodable base64 string is returned
+// unchanged (defensive — NULL, a raw-JSON object/array blob promoted by
+// marshalRow, or pre-existing non-base64 data).
+func decodeStoredBase64(v any, binary bool) any {
+	s, ok := v.(string)
+	if !ok {
+		return v
+	}
+	b, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return v
+	}
+	if binary {
+		return b
+	}
+	return string(b)
+}
+
+// base64Cols maps each BLOB/TEXT column of schema.table to whether it is binary,
+// using the SUPPLIED resolver — base64ColsAt passes the resolver in effect at
+// the event's epoch (NOT necessarily the latest snapshot), which is what keeps
+// an old VARCHAR value from being decoded across a VARCHAR→TEXT widening. Returns
+// nil when the resolver is nil, the table is unknown, or no column needs
+// decoding — in which case BLOB/TEXT values are left as the base64 they were
+// stored as (no usable schema means no safe typing; this preserves the pre-fix
+// behavior rather than guessing).
+func base64Cols(r *metadata.Resolver, schema, table string) map[string]bool {
+	if r == nil {
+		return nil
+	}
+	tm, err := r.Resolve(schema, table)
+	if err != nil {
+		return nil
+	}
+	var m map[string]bool
+	for _, c := range tm.Columns {
+		if binary, ok := base64StoredKind(c.DataType); ok {
+			if m == nil {
+				m = make(map[string]bool)
+			}
+			m[c.Name] = binary
+		}
+	}
+	return m
+}
+
+// decodeImageBase64 decodes the storage-side base64 of every BLOB/TEXT column in
+// one event image, in place. No-op when binCols is empty or image is nil. Iterates
+// binCols (typically a handful of columns) and only rewrites keys the image
+// carries, so a partial image is left otherwise untouched.
+func decodeImageBase64(image map[string]any, binCols map[string]bool) {
+	if len(binCols) == 0 || image == nil {
+		return
+	}
+	for col, binary := range binCols {
+		if v, ok := image[col]; ok {
+			image[col] = decodeStoredBase64(v, binary)
+		}
 	}
 }
 

--- a/internal/shim/handler_integration_test.go
+++ b/internal/shim/handler_integration_test.go
@@ -4,6 +4,7 @@ package shim
 
 import (
 	"database/sql"
+	"encoding/base64"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -358,6 +359,101 @@ func TestRunPointInTime_EnumSetOrdinalsMapToLabels(t *testing.T) {
 	}
 }
 
+// TestRunPointInTime_BlobTextDecoded pins #661 end-to-end against a real index
+// DB: BLOB/TEXT columns are stored base64-encoded (marshalRow base64-encodes the
+// []byte go-mysql delivers), so _flashback must decode them before emission or
+// the client gets the base64 text instead of the real value. Covers the single-
+// row path, the full-table path (with a NULL row to exercise []byte + nil column
+// type-consistency), and _diff (TEXT renders as the real string in the audit JSON).
+func TestRunPointInTime_BlobTextDecoded(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Hour)
+	addHourlyPartition(t, db, now)
+	snapTS := now.Format("2006-01-02 15:04:05")
+	testutil.InsertSnapshot(t, db, 1, snapTS, "myapp", "docs", "id", 1, "PRI", "int", "NO")
+	testutil.InsertSnapshot(t, db, 1, snapTS, "myapp", "docs", "body", 2, "", "text", "YES")
+	testutil.InsertSnapshot(t, db, 1, snapTS, "myapp", "docs", "payload", 3, "", "blob", "YES")
+
+	b64 := func(s string) string { return base64.StdEncoding.EncodeToString([]byte(s)) }
+	rawBlob := "\x00\xff\x7f\x80" // arbitrary non-UTF-8 bytes must survive the wire
+	eventTS := now.Add(5 * time.Minute).Format("2006-01-02 15:04:05")
+	// id=1: real text + binary blob, both stored base64.
+	testutil.InsertEvent(t, db, "mysql-bin.000001", 100, 200, eventTS, nil,
+		"myapp", "docs", 1 /*insert*/, "1", nil, nil,
+		[]byte(fmt.Sprintf(`{"id":1,"body":%q,"payload":%q}`, b64("hello world"), b64(rawBlob))))
+	// id=2: NULL body, so the full-table BLOB/TEXT columns mix decoded values
+	// with NULL — the one case that could trip BuildSimpleTextResultset.
+	testutil.InsertEvent(t, db, "mysql-bin.000001", 200, 300, eventTS, nil,
+		"myapp", "docs", 1 /*insert*/, "2", nil, nil,
+		[]byte(fmt.Sprintf(`{"id":2,"body":null,"payload":%q}`, b64("second"))))
+
+	h := NewHandlerWithConfig(db, Config{NoArchive: true, IndexDBName: dbName}, slog.Default())
+
+	// Single-row _flashback id=1.
+	res, err := h.runPointInTime(TimeTravelQuery{
+		Type: TypeFlashback, Schema: "myapp", Table: "docs",
+		PKColumn: "id", PKValue: "1", AsOf: now.Add(10 * time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("runPointInTime: %v", err)
+	}
+	cells := rowCells(t, res.Resultset)
+	if len(cells) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(cells))
+	}
+	if got, want := cells[0][1], "hello world"; got != want {
+		t.Errorf("body = %q, want %q (TEXT not decoded from base64)", got, want)
+	}
+	if got, want := cells[0][2], rawBlob; got != want {
+		t.Errorf("payload = %q, want %q (BLOB not decoded from base64)", got, want)
+	}
+
+	// Full-table _flashback: id=1 decoded, id=2 body NULL + payload decoded.
+	ftRes, err := h.runFullTable(TimeTravelQuery{
+		Type: TypeFlashback, Schema: "myapp", Table: "docs", AsOf: now.Add(10 * time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("full-table _flashback: %v", err)
+	}
+	byID := make(map[string][]string)
+	for _, c := range rowCells(t, ftRes.Resultset) {
+		byID[c[0]] = c
+	}
+	if len(byID) != 2 {
+		t.Fatalf("full-table: expected 2 rows, got %d (%v)", len(byID), byID)
+	}
+	if got, want := byID["1"][1], "hello world"; got != want {
+		t.Errorf("full-table id=1 body = %q, want %q", got, want)
+	}
+	if got, want := byID["2"][1], "NULL"; got != want {
+		t.Errorf("full-table id=2 body = %q, want %q (NULL must survive alongside decoded rows)", got, want)
+	}
+	if got, want := byID["2"][2], "second"; got != want {
+		t.Errorf("full-table id=2 payload = %q, want %q", got, want)
+	}
+
+	// _diff id=1: the audit JSON must carry the decoded TEXT, not the base64.
+	diffRes, err := h.runDiff(TimeTravelQuery{
+		Type: TypeDiff, Schema: "myapp", Table: "docs", PKValue: "1",
+		Since: now.Add(time.Minute), Until: now.Add(15 * time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("runDiff: %v", err)
+	}
+	diffCells := rowCells(t, diffRes.Resultset)
+	if len(diffCells) != 1 {
+		t.Fatalf("_diff: expected 1 row, got %d", len(diffCells))
+	}
+	if rowAfter := diffCells[0][5]; !strings.Contains(rowAfter, `"body":"hello world"`) {
+		t.Errorf("_diff row_after = %s, want body decoded to \"hello world\"", rowAfter)
+	}
+}
+
 // TestEnumLabels_FullChainFromRealSnapshot covers the wiring no other
 // test exercises end-to-end: real CREATE TABLE → metadata.TakeSnapshot
 // (capturing an ENUM declaration well past #212's old VARCHAR(128)
@@ -495,6 +591,71 @@ func TestEnumLabels_EpochAwareDecoding(t *testing.T) {
 		}
 		if got := cells[0][1]; got != tc.want {
 			t.Errorf("pk=%s: status = %q, want %q — %s", tc.pk, got, tc.want, tc.why)
+		}
+	}
+}
+
+// TestRunPointInTime_BlobTextEpochAware is the load-bearing proof that the #661
+// base64 decode is resolved at each event's epoch, not from the latest snapshot.
+// A column widened VARCHAR→TEXT across the flashback window is the trap: an old
+// VARCHAR value reached go-mysql as a Go string, so marshalRow stored it as a
+// PLAIN JSON string (never base64). If the decode used the latest (TEXT) snapshot
+// for the old event, a plain value that happens to be valid base64 ("test")
+// would be silently mangled to garbage bytes. The epoch-aware lookup types the
+// old event's column as VARCHAR → leaves it untouched, while the new TEXT event
+// is still decoded.
+func TestRunPointInTime_BlobTextEpochAware(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Hour)
+	addHourlyPartition(t, db, now)
+
+	insertTyped := func(snapID int, snapTS, column string, ordinal int, key, dataType string) {
+		testutil.InsertSnapshot(t, db, snapID, snapTS, "myapp", "docs", column, ordinal, key, dataType, "YES")
+	}
+	snap1TS := now.Add(1 * time.Minute).Format("2006-01-02 15:04:05")
+	snap2TS := now.Add(10 * time.Minute).Format("2006-01-02 15:04:05")
+	// Epoch 1: notes is VARCHAR (stored plain). Epoch 2: notes widened to TEXT.
+	insertTyped(1, snap1TS, "id", 1, "PRI", "int")
+	insertTyped(1, snap1TS, "notes", 2, "", "varchar")
+	insertTyped(2, snap2TS, "id", 1, "PRI", "int")
+	insertTyped(2, snap2TS, "notes", 2, "", "text")
+
+	b64 := func(s string) string { return base64.StdEncoding.EncodeToString([]byte(s)) }
+	// Event A in epoch 1: VARCHAR value stored as a PLAIN string. "test" is valid
+	// base64, so an epoch-blind decode would corrupt it.
+	testutil.InsertEvent(t, db, "mysql-bin.000001", 100, 200,
+		now.Add(5*time.Minute).Format("2006-01-02 15:04:05"), nil,
+		"myapp", "docs", 1 /*insert*/, "1", nil, nil, []byte(`{"id":1,"notes":"test"}`))
+	// Event B in epoch 2: TEXT value stored base64-encoded.
+	testutil.InsertEvent(t, db, "mysql-bin.000001", 300, 400,
+		now.Add(15*time.Minute).Format("2006-01-02 15:04:05"), nil,
+		"myapp", "docs", 1 /*insert*/, "2", nil, nil,
+		[]byte(fmt.Sprintf(`{"id":2,"notes":%q}`, b64("hi there"))))
+
+	h := NewHandlerWithConfig(db, Config{NoArchive: true, IndexDBName: dbName}, slog.Default())
+	asOf := now.Add(20 * time.Minute)
+	for _, tc := range []struct{ pk, want, why string }{
+		{"1", "test", "epoch-1 VARCHAR value was stored plain, NOT base64 — decoding it (latest=TEXT) corrupts it"},
+		{"2", "hi there", "epoch-2 TEXT value is base64-stored and must be decoded"},
+	} {
+		res, err := h.runPointInTime(TimeTravelQuery{
+			Type: TypeFlashback, Schema: "myapp", Table: "docs",
+			PKColumn: "id", PKValue: tc.pk, AsOf: asOf,
+		})
+		if err != nil {
+			t.Fatalf("pk=%s: %v", tc.pk, err)
+		}
+		cells := rowCells(t, res.Resultset)
+		if len(cells) != 1 {
+			t.Fatalf("pk=%s: expected 1 row, got %d", tc.pk, len(cells))
+		}
+		if got := cells[0][1]; got != tc.want {
+			t.Errorf("pk=%s: notes = %q, want %q — %s", tc.pk, got, tc.want, tc.why)
 		}
 	}
 }

--- a/internal/shim/handler_test.go
+++ b/internal/shim/handler_test.go
@@ -3,6 +3,7 @@ package shim
 import (
 	"context"
 	"database/sql"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -73,8 +74,8 @@ func TestResultsetValue_jsonNumber(t *testing.T) {
 		{"9223372036854775807", "9223372036854775807"},   // 2^63-1 → int64 branch
 		{"9223372036854775808", "9223372036854775808"},   // exactly 2^63 → uint64 branch
 		{"18446744073709551615", "18446744073709551615"}, // BIGINT UNSIGNED max → uint64
-		{"3.14", "3.14"},                                 // fractional → float64
-		{"1e1000", "1e1000"},                             // beyond float64 range → literal passthrough
+		{"3.14", "3.14"},     // fractional → float64
+		{"1e1000", "1e1000"}, // beyond float64 range → literal passthrough
 	}
 	for _, c := range cases {
 		b, ok := resultsetValue(json.Number(c.in)).([]byte)
@@ -142,11 +143,11 @@ func TestFullTableTextCell_jsonNumberMatchesNative(t *testing.T) {
 		num    json.Number
 		native any
 	}{
-		{"18446744073709551615", uint64(18446744073709551615)},   // BIGINT UNSIGNED max
+		{"18446744073709551615", uint64(18446744073709551615)}, // BIGINT UNSIGNED max
 		{"100", int64(100)},
-		{"-9223372036854775808", int64(-9223372036854775808)},    // BIGINT signed min
-		{"1e+21", float64(1e21)},                                 // extreme double: "1e+21" vs decimal
-		{"-1e+21", float64(-1e21)},                               // negative extreme double
+		{"-9223372036854775808", int64(-9223372036854775808)}, // BIGINT signed min
+		{"1e+21", float64(1e21)},                              // extreme double: "1e+21" vs decimal
+		{"-1e+21", float64(-1e21)},                            // negative extreme double
 		{"0.0000001", float64(1e-7)},
 		{"100.5", float64(100.5)},
 	}
@@ -708,7 +709,7 @@ func TestExtractFullTableImages(t *testing.T) {
 }
 
 // TestRunPointInTimeDispatchesByPKColumn pins the fix for the empty-
-// string PK collision: `WHERE id = ''` is a legitimate single-row
+// string PK collision: `WHERE id = ”` is a legitimate single-row
 // query against a NOT-NULL VARCHAR with empty default, and a dispatch
 // on q.PKValue would silently flip it into a 100k-row table scan.
 //
@@ -2506,7 +2507,7 @@ func TestImageToResultVerbatim(t *testing.T) {
 		image := map[string]any{
 			"id":         1,
 			"name":       "alice",
-			"email":      "a@b.com",   // image has email, user did NOT ask
+			"email":      "a@b.com",    // image has email, user did NOT ask
 			"created_at": "2026-05-02", // image has created_at, user did NOT ask
 		}
 		res, err := imageToResultVerbatim(image, []string{"id", "name"})
@@ -2593,5 +2594,182 @@ func TestMapEventImagesFallback(t *testing.T) {
 	bare.mapEventImages("myapp", "orders", rows2)
 	if rows2[0].RowAfter["status"] != float64(3) {
 		t.Errorf("bare handler must pass through, got %v", rows2[0].RowAfter["status"])
+	}
+}
+
+// TestMapEventImagesDecodesBlobText is the core unit proof for #661: the
+// storage-side base64 of BLOB/TEXT event values is decoded back to raw bytes /
+// strings in BOTH row images, in place, before emission — while non-BLOB/TEXT
+// columns, NULLs, and columns absent from an image are left untouched. Because
+// mapEventImages is the single chokepoint every event-sourced path traverses
+// before emit/merge (and never sees a baseline row), decoding here gives every
+// event-sourced emit path the fix with provenance-correctness for free.
+func TestMapEventImagesDecodesBlobText(t *testing.T) {
+	silent := slog.New(slog.NewTextHandler(io.Discard, nil))
+	b64 := func(s string) string { return base64.StdEncoding.EncodeToString([]byte(s)) }
+	h := &Handler{
+		logger: silent,
+		resolverFn: func() (*metadata.Resolver, error) {
+			return metadata.NewResolverFromTables(1, map[string]*metadata.TableMeta{
+				"appdb.docs": {Schema: "appdb", Table: "docs", Columns: []metadata.ColumnMeta{
+					{Name: "id", OrdinalPosition: 1, DataType: "int", IsPK: true},
+					{Name: "body", OrdinalPosition: 2, DataType: "text"},
+					{Name: "payload", OrdinalPosition: 3, DataType: "blob"},
+				}},
+			}), nil
+		},
+	}
+	rawBlob := "\x00\xff\x7f\x80" // arbitrary non-UTF-8 bytes must survive
+	rows := []query.ResultRow{{
+		SchemaName:     "appdb",
+		TableName:      "docs",
+		EventTimestamp: time.Unix(1_700_000_000, 0).UTC(),
+		RowBefore: map[string]any{
+			"id": json.Number("1"), "body": b64("old bio"), "payload": b64("\x01\x02"),
+		},
+		RowAfter: map[string]any{
+			"id": json.Number("1"), "body": b64("hello world"), "payload": b64(rawBlob),
+		},
+	}}
+	h.mapEventImages("appdb", "docs", rows)
+
+	// TEXT family → decoded Go string.
+	if got := rows[0].RowAfter["body"]; got != "hello world" {
+		t.Errorf("RowAfter body = %#v, want decoded string %q", got, "hello world")
+	}
+	if got := rows[0].RowBefore["body"]; got != "old bio" {
+		t.Errorf("RowBefore body = %#v, want decoded string %q (both images decode, for _diff)", got, "old bio")
+	}
+	// BLOB family → decoded raw []byte, arbitrary bytes intact.
+	if got, ok := rows[0].RowAfter["payload"].([]byte); !ok || string(got) != rawBlob {
+		t.Errorf("RowAfter payload = %#v, want decoded []byte %q", rows[0].RowAfter["payload"], rawBlob)
+	}
+	// Non-BLOB/TEXT column untouched.
+	if got := rows[0].RowAfter["id"]; got != json.Number("1") {
+		t.Errorf("RowAfter id = %#v, want untouched json.Number(\"1\")", got)
+	}
+}
+
+// TestMapEventImagesDecodeEdgeCases pins the defensive branches of the #661
+// decode so a future refactor can't silently regress them: NULL values, a
+// value that is not a decodable base64 string, and a column absent from the
+// image must all be left as-is (no panic, no corruption).
+func TestMapEventImagesDecodeEdgeCases(t *testing.T) {
+	silent := slog.New(slog.NewTextHandler(io.Discard, nil))
+	h := &Handler{
+		logger: silent,
+		resolverFn: func() (*metadata.Resolver, error) {
+			return metadata.NewResolverFromTables(1, map[string]*metadata.TableMeta{
+				"appdb.docs": {Schema: "appdb", Table: "docs", Columns: []metadata.ColumnMeta{
+					{Name: "id", OrdinalPosition: 1, DataType: "int", IsPK: true},
+					{Name: "body", OrdinalPosition: 2, DataType: "text"},
+					{Name: "payload", OrdinalPosition: 3, DataType: "blob"},
+				}},
+			}), nil
+		},
+	}
+	rows := []query.ResultRow{{
+		SchemaName:     "appdb",
+		TableName:      "docs",
+		EventTimestamp: time.Unix(1_700_000_000, 0).UTC(),
+		// body is NULL; payload key absent entirely (partial image).
+		RowAfter: map[string]any{"id": json.Number("1"), "body": nil},
+	}}
+	h.mapEventImages("appdb", "docs", rows)
+	if got, ok := rows[0].RowAfter["body"]; !ok || got != nil {
+		t.Errorf("NULL body = %#v, want nil untouched", got)
+	}
+	if _, present := rows[0].RowAfter["payload"]; present {
+		t.Errorf("absent payload column must not be materialized, got %#v", rows[0].RowAfter["payload"])
+	}
+
+	// A TEXT value that is not valid base64 is returned unchanged (the decode
+	// is best-effort — DecodeString errors fall through).
+	if got := decodeStoredBase64("not base64!!", false); got != "not base64!!" {
+		t.Errorf("non-base64 string = %#v, want unchanged", got)
+	}
+	if got := decodeStoredBase64(nil, true); got != nil {
+		t.Errorf("nil value = %#v, want nil", got)
+	}
+}
+
+// TestBase64StoredKind and TestBase64Cols pin the pure type predicates the
+// #661 decode is gated on.
+func TestBase64StoredKind(t *testing.T) {
+	binaryFamily := []string{"blob", "tinyblob", "mediumblob", "longblob"}
+	textFamily := []string{"text", "tinytext", "mediumtext", "longtext"}
+	for _, dt := range binaryFamily {
+		if binary, ok := base64StoredKind(dt); !ok || !binary {
+			t.Errorf("base64StoredKind(%q) = (%v,%v), want (true,true)", dt, binary, ok)
+		}
+	}
+	for _, dt := range textFamily {
+		if binary, ok := base64StoredKind(dt); !ok || binary {
+			t.Errorf("base64StoredKind(%q) = (%v,%v), want (false,true)", dt, binary, ok)
+		}
+	}
+	// Case-insensitive, and unrelated types are not decoded (incl. the
+	// deliberately-excluded geometry/vector families).
+	if binary, ok := base64StoredKind("LONGTEXT"); !ok || binary {
+		t.Errorf("base64StoredKind is not case-insensitive: got (%v,%v)", binary, ok)
+	}
+	for _, dt := range []string{"int", "varchar", "json", "geometry", "datetime", ""} {
+		if _, ok := base64StoredKind(dt); ok {
+			t.Errorf("base64StoredKind(%q) reported a decodable column, want none", dt)
+		}
+	}
+}
+
+func TestBase64Cols(t *testing.T) {
+	// Nil resolver → nil map (no schema = no safe typing, preserves pre-fix base64).
+	if got := base64Cols(nil, "appdb", "docs"); got != nil {
+		t.Errorf("base64Cols(nil) = %v, want nil", got)
+	}
+	r := metadata.NewResolverFromTables(1, map[string]*metadata.TableMeta{
+		"appdb.docs": {Schema: "appdb", Table: "docs", Columns: []metadata.ColumnMeta{
+			{Name: "id", DataType: "int"},
+			{Name: "body", DataType: "text"},
+			{Name: "payload", DataType: "blob"},
+		}},
+	})
+	got := base64Cols(r, "appdb", "docs")
+	want := map[string]bool{"body": false, "payload": true}
+	if len(got) != len(want) || got["body"] != false || got["payload"] != true {
+		t.Errorf("base64Cols = %v, want %v", got, want)
+	}
+	// Unknown table → nil (not a panic).
+	if got := base64Cols(r, "appdb", "nope"); got != nil {
+		t.Errorf("base64Cols(unknown table) = %v, want nil", got)
+	}
+}
+
+// TestMapEventImagesDecodesExactlyOnce guards against a double-decode: every
+// stored BLOB/TEXT value is base64, but its decoded bytes can THEMSELVES be
+// valid base64. A real TEXT value of "SGVsbG8=" is stored as base64("SGVsbG8=");
+// one decode yields "SGVsbG8=", a second would yield "Hello". The single decode
+// in mapEventImages must return "SGVsbG8=" verbatim.
+func TestMapEventImagesDecodesExactlyOnce(t *testing.T) {
+	silent := slog.New(slog.NewTextHandler(io.Discard, nil))
+	h := &Handler{
+		logger: silent,
+		resolverFn: func() (*metadata.Resolver, error) {
+			return metadata.NewResolverFromTables(1, map[string]*metadata.TableMeta{
+				"appdb.docs": {Schema: "appdb", Table: "docs", Columns: []metadata.ColumnMeta{
+					{Name: "id", OrdinalPosition: 1, DataType: "int", IsPK: true},
+					{Name: "body", OrdinalPosition: 2, DataType: "text"},
+				}},
+			}), nil
+		},
+	}
+	stored := base64.StdEncoding.EncodeToString([]byte("SGVsbG8=")) // a real value that is itself base64
+	rows := []query.ResultRow{{
+		SchemaName:     "appdb",
+		TableName:      "docs",
+		EventTimestamp: time.Unix(1_700_000_000, 0).UTC(),
+		RowAfter:       map[string]any{"id": json.Number("1"), "body": stored},
+	}}
+	h.mapEventImages("appdb", "docs", rows)
+	if got := rows[0].RowAfter["body"]; got != "SGVsbG8=" {
+		t.Errorf("body = %#v, want \"SGVsbG8=\" (decoded exactly once, not twice → \"Hello\")", got)
 	}
 }

--- a/internal/shim/snapshot_integration_test.go
+++ b/internal/shim/snapshot_integration_test.go
@@ -4,6 +4,7 @@ package shim
 
 import (
 	"database/sql"
+	"encoding/base64"
 	"fmt"
 	"log/slog"
 	"os"
@@ -404,7 +405,7 @@ func TestSnapshotBaseline_DatetimePKResolvesFromBaseline(t *testing.T) {
 }
 
 // TestSnapshotBaseline_EmptyStringPK is a regression test for the empty-PK
-// filter bypass: `WHERE name = ''` against a NOT-NULL string PK is a
+// filter bypass: `WHERE name = ”` against a NOT-NULL string PK is a
 // documented legitimate shape, but Options.PKValues=="" disables the
 // pk_values filter in buildQuery. If runSnapshotPointInTime routed the
 // empty value through PKValues (not PKValuesIn), the fetch would return
@@ -627,6 +628,142 @@ func TestSnapshotBaseline_FullTableMerge(t *testing.T) {
 	}
 	if flash["2"] != "bob2" || flash["4"] != "dave" {
 		t.Errorf("full-table _flashback = %v, want id=2 bob2 and id=4 dave (rows with binlog activity)", flash)
+	}
+}
+
+// TestSnapshotBaseline_BlobTextProvenance is the load-bearing proof that the
+// #661 BLOB/TEXT decode respects provenance in the _snapshot merge: it decodes
+// ONLY event-sourced values, never baseline-origin ones. mapEventImages runs on
+// the delta events before the merge, so a never-touched baseline row whose TEXT
+// value happens to be valid base64 ("YWxpY2U=" → "alice") must pass through
+// verbatim, while a row updated post-baseline has its base64-stored event value
+// decoded. Decoding by Go-type at emit time would corrupt the baseline value;
+// decoding pre-merge on the events only is what keeps the two apart.
+func TestSnapshotBaseline_BlobTextProvenance(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	hourTop := time.Now().UTC().Truncate(time.Hour)
+	addHourlyPartition(t, db, hourTop)
+	snapTime := hourTop.Add(1 * time.Minute)
+	asOf := hourTop.Add(10 * time.Minute)
+	eventTS := hourTop.Add(5 * time.Minute).Format("2006-01-02 15:04:05")
+
+	// Snapshot types docs.body as TEXT so base64Cols flags it for decoding.
+	snapTS := snapTime.UTC().Format("2006-01-02 15:04:05")
+	testutil.InsertSnapshot(t, db, 1, snapTS, "myapp", "docs", "id", 1, "PRI", "int", "NO")
+	testutil.InsertSnapshot(t, db, 1, snapTS, "myapp", "docs", "body", 2, "", "text", "YES")
+
+	cols := []baseline.Column{
+		{Name: "id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
+		{Name: "body", MySQLType: "text", ParquetType: baseline.MysqlToParquetNode("text")},
+	}
+	// id=1 never touched in the binlog window; its baseline body LOOKS like
+	// base64. id=2 is updated post-baseline; its event body IS base64-stored.
+	baselineDir := writeBaselineSnapshot(t, snapTime, "myapp", "docs", cols, [][]string{
+		{"1", "YWxpY2U="},
+		{"2", "bob-orig"},
+	})
+	b64 := func(s string) string { return base64.StdEncoding.EncodeToString([]byte(s)) }
+	testutil.InsertEvent(t, db, "mysql-bin.000001", 100, 200, eventTS, nil,
+		"myapp", "docs", 2 /*update*/, "2", nil,
+		[]byte(fmt.Sprintf(`{"id":2,"body":%q}`, b64("bob-orig"))),
+		[]byte(fmt.Sprintf(`{"id":2,"body":%q}`, b64("bob-new"))))
+
+	h := NewHandlerWithConfig(db, Config{
+		AllowGaps:   true,
+		NoArchive:   true,
+		IndexDBName: dbName,
+		BaselineDir: baselineDir,
+	}, slog.Default())
+
+	res, err := h.runSnapshot(TimeTravelQuery{Type: TypeSnapshot, Schema: "myapp", Table: "docs", AsOf: asOf})
+	if err != nil {
+		t.Fatalf("full-table _snapshot: %v", err)
+	}
+	got := rowsByKey(t, res.Resultset)
+	// Provenance guard: the baseline-origin value passes through verbatim — a
+	// regression that decoded it by column type would surface "alice" here.
+	if got["1"] != "YWxpY2U=" {
+		t.Errorf("id=1 body = %q, want \"YWxpY2U=\" verbatim — a baseline-origin value must NOT be base64-decoded", got["1"])
+	}
+	// The fix: the event-origin value IS decoded.
+	if got["2"] != "bob-new" {
+		t.Errorf("id=2 body = %q, want \"bob-new\" (event-sourced TEXT decoded from base64)", got["2"])
+	}
+}
+
+// TestSnapshotBaseline_BlobTextProvenanceSingleRow is the single-row sibling of
+// the provenance test above: it drives runSnapshotPointInTime (PKColumn set),
+// the one emission surface whose mapEventImages call (snapshot.go:440) the
+// full-table provenance test does not exercise. It guards both that decode call
+// (deleting it would leave id=2 base64) AND single-row baseline-vs-event
+// provenance (id=1 must pass through verbatim).
+func TestSnapshotBaseline_BlobTextProvenanceSingleRow(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	hourTop := time.Now().UTC().Truncate(time.Hour)
+	addHourlyPartition(t, db, hourTop)
+	snapTime := hourTop.Add(1 * time.Minute)
+	asOf := hourTop.Add(10 * time.Minute)
+	eventTS := hourTop.Add(5 * time.Minute).Format("2006-01-02 15:04:05")
+
+	snapTS := snapTime.UTC().Format("2006-01-02 15:04:05")
+	testutil.InsertSnapshot(t, db, 1, snapTS, "myapp", "docs", "id", 1, "PRI", "int", "NO")
+	testutil.InsertSnapshot(t, db, 1, snapTS, "myapp", "docs", "body", 2, "", "text", "YES")
+
+	cols := []baseline.Column{
+		{Name: "id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
+		{Name: "body", MySQLType: "text", ParquetType: baseline.MysqlToParquetNode("text")},
+	}
+	// id=1 never touched; its baseline body LOOKS like base64. id=2 updated.
+	baselineDir := writeBaselineSnapshot(t, snapTime, "myapp", "docs", cols, [][]string{
+		{"1", "YWxpY2U="},
+		{"2", "bob-orig"},
+	})
+	b64 := func(s string) string { return base64.StdEncoding.EncodeToString([]byte(s)) }
+	testutil.InsertEvent(t, db, "mysql-bin.000001", 100, 200, eventTS, nil,
+		"myapp", "docs", 2 /*update*/, "2", nil,
+		[]byte(fmt.Sprintf(`{"id":2,"body":%q}`, b64("bob-orig"))),
+		[]byte(fmt.Sprintf(`{"id":2,"body":%q}`, b64("bob-new"))))
+
+	h := NewHandlerWithConfig(db, Config{
+		AllowGaps:   true,
+		NoArchive:   true,
+		IndexDBName: dbName,
+		BaselineDir: baselineDir,
+	}, slog.Default())
+
+	bodyOf := func(pk string) string {
+		t.Helper()
+		res, err := h.runSnapshot(TimeTravelQuery{
+			Type: TypeSnapshot, Schema: "myapp", Table: "docs",
+			PKColumn: "id", PKValue: pk, AsOf: asOf,
+		})
+		if err != nil {
+			t.Fatalf("single-row _snapshot pk=%s: %v", pk, err)
+		}
+		cells := rowCells(t, res.Resultset)
+		if len(cells) != 1 {
+			t.Fatalf("pk=%s: expected 1 row, got %d (%v)", pk, len(cells), cells)
+		}
+		return cells[0][1] // columns are [id, body] in DDL order
+	}
+
+	// id=1 never touched → baseline value passes through verbatim (NOT decoded).
+	if got := bodyOf("1"); got != "YWxpY2U=" {
+		t.Errorf("single-row id=1 body = %q, want \"YWxpY2U=\" verbatim (baseline must NOT be base64-decoded)", got)
+	}
+	// id=2 updated → event value decoded.
+	if got := bodyOf("2"); got != "bob-new" {
+		t.Errorf("single-row id=2 body = %q, want \"bob-new\" (event-sourced TEXT decoded)", got)
 	}
 }
 


### PR DESCRIPTION
closes #661

## Summary
- The shim's `_flashback`/`_snapshot`/`_diff` virtual schemas returned BLOB/TEXT column values as the **base64 text** they are stored as, instead of the real bytes/string, over the MySQL wire protocol. Sibling of recover #662 and reconstruct #663 (same root: go-mysql delivers BLOB/TEXT as `[]byte`, which `marshalRow` base64-encodes into the stored event JSON).
- Fix adds a base64-decode pass inside `mapEventImages` — the single chokepoint every event-sourced path crosses before emit/merge, and which only ever touches event images, never a baseline row. So `_flashback` decodes all images, `_snapshot` decodes its deltas **pre-merge** (the baseline DuckDB scans is never double-decoded), and `_diff` renders TEXT as the real string. One change covers all six call sites.
- **Epoch-aware** (the key subtlety, caught in review): the decodable columns are resolved at **each event's epoch**, mirroring the ENUM/SET mapper beside it (#475), not from the latest snapshot. Whether a value is base64-stored depends on whether go-mysql delivered the column as `[]byte` (BLOB/TEXT) or `string` (VARCHAR/CHAR) when the event was captured — so a `VARCHAR→TEXT` widening across the flashback window would otherwise make a latest-snapshot lookup wrongly decode an old plain-string value that happens to be valid base64 (e.g. `"test"`), silently corrupting it.
- 100% additive, scoped entirely to `internal/shim` — `recover`/`reconstruct` untouched. `base64StoredKind`/`decodeStoredBase64` duplicated locally (third consumer) rather than hoisted, to keep the change minimal.

## Why no crash risk
`BuildSimpleTextResultset` maps both `[]byte` and `string` to `MYSQL_TYPE_VAR_STRING`, and upgrades a `NULL`-first column to the first non-null type — so a BLOB/TEXT column mixing decoded values with NULL stays type-consistent (`"row types aren't consistent"` only fires between two distinct non-null types).

## Test plan
- [x] Unit (`go test ./...`): `mapEventImages` decode (BLOB→`[]byte`, TEXT→`string`, NULL/non-base64/absent untouched), `base64StoredKind`/`base64Cols`, **decode-exactly-once** (a real value that is itself valid base64).
- [x] Integration (Docker MySQL): single-row + full-table (with a NULL row) + `_diff` decode; **`_snapshot` baseline-vs-event provenance** (a baseline value that looks like base64 passes through verbatim, the event is decoded); **VARCHAR→TEXT epoch-drift** (an old plain-string `"test"` survives verbatim, a new TEXT value decodes).
- [x] Full repo unit suite + full shim integration suite green.

## Follow-up (not fixed here)
`reconstruct.ApplyAt` (single-row) does not decode, so `bintrail reconstruct --sql` single-row may carry the same base64 bug — a separate follow-up. The shim avoids it by decoding before `ApplyAt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)