### PR TITLE
reconstruct: decode BLOB/TEXT in the single-row path instead of base64 text

### DIFF
--- a/internal/cli/reconstruct.go
+++ b/internal/cli/reconstruct.go
@@ -298,6 +298,10 @@ func runReconstruct(cmd *cobra.Command, args []string) error {
 	// fallback here: if the epoch lookup fails, ordinals pass through
 	// raw — the pre-#476 CLI output.
 	reconstruct.MapEventEnumLabels(db, nil, recSchema, recTable, events)
+	// BLOB/TEXT columns are stored base64-encoded; decode them on the deltas
+	// before the ApplyAt/BuildHistory fold so the output carries the real value,
+	// not its base64 text (#666). Baseline rows are read raw and untouched.
+	reconstruct.DecodeEventBinaries(db, recSchema, recTable, events)
 
 	// Warn if there is a gap between the baseline binlog position and the
 	// first indexed event — events in that gap are missing from the reconstruction.

--- a/internal/cli/reconstruct_integration_test.go
+++ b/internal/cli/reconstruct_integration_test.go
@@ -4,6 +4,7 @@ package cli
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -687,5 +688,101 @@ func TestRunReconstruct_archiveAwareE2E(t *testing.T) {
 	}
 	if !strings.Contains(history, `"live-state"`) {
 		t.Errorf("expected history to include the live event's state transition, got: %s", history)
+	}
+}
+
+// TestRunReconstruct_blobTextDecoded is the end-to-end proof for #666: a
+// single-row `bintrail reconstruct` whose answer is event-sourced must emit the
+// real BLOB/TEXT value, not the base64 it is stored as. Before the fix the
+// single-row path folded events via ApplyAt without decoding, so the output
+// carried the base64 text. schema_snapshots types `body` as TEXT so
+// DecodeEventBinaries flags it.
+func TestRunReconstruct_blobTextDecoded(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	h1 := time.Now().UTC().Add(-48 * time.Hour).Truncate(time.Hour)
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{h1})
+
+	// Type the table so the resolver flags `body` as TEXT (base64-stored).
+	snapTS := h1.Format("2006-01-02 15:04:05")
+	testutil.InsertSnapshot(t, db, 1, snapTS, "testdb", "docs", "id", 1, "PRI", "int", "NO")
+	testutil.InsertSnapshot(t, db, 1, snapTS, "testdb", "docs", "body", 2, "", "text", "YES")
+
+	// Baseline: id=7, body="baseline-bio".
+	baselineDir := t.TempDir()
+	snapshotTSDir := strings.ReplaceAll(h1.Format(time.RFC3339), ":", "-")
+	parquetDir := filepath.Join(baselineDir, snapshotTSDir, "testdb")
+	if err := os.MkdirAll(parquetDir, 0o755); err != nil {
+		t.Fatalf("mkdir baseline: %v", err)
+	}
+	baselinePath := filepath.Join(parquetDir, "docs.parquet")
+	cols := []baseline.Column{
+		{Name: "id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
+		{Name: "body", MySQLType: "text", ParquetType: baseline.MysqlToParquetNode("text")},
+	}
+	w, err := baseline.NewWriter(baselinePath, cols, baseline.WriterConfig{Compression: "zstd", RowGroupSize: 100})
+	if err != nil {
+		t.Fatalf("baseline.NewWriter: %v", err)
+	}
+	if err := w.WriteRow([]string{"7", "baseline-bio"}, []bool{false, false}); err != nil {
+		t.Fatalf("WriteRow: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("writer close: %v", err)
+	}
+
+	// UPDATE event: body set to a new value, stored base64 (as marshalRow encodes
+	// the []byte go-mysql delivers for a TEXT column).
+	b64 := base64.StdEncoding.EncodeToString([]byte("updated bio ☃"))
+	ts1 := h1.Add(30 * time.Minute).Format("2006-01-02 15:04:05")
+	testutil.InsertEvent(t, db, "binlog.000001", 100, 200, ts1, nil,
+		"testdb", "docs", 2 /* UPDATE */, "7", nil,
+		[]byte(`{"id":7,"body":"`+base64.StdEncoding.EncodeToString([]byte("baseline-bio"))+`"}`),
+		[]byte(`{"id":7,"body":"`+b64+`"}`))
+
+	orig := captureRecFlags()
+	t.Cleanup(func() { applyRecFlags(orig) })
+	recIndexDSN = testutil.SnapshotDSN(dbName)
+	recSchema = "testdb"
+	recTable = "docs"
+	recPK = "7"
+	recPKColumns = "id"
+	recBaselineDir = baselineDir
+	recBaselineS3 = ""
+	recBaselineOnly = false
+	recHistory = false
+	recSQL = ""
+	recFormat = "json"
+	recNoArchive = true
+	recAllowGaps = true
+	recAt = h1.Add(45 * time.Minute).Format(time.RFC3339)
+
+	reconstructCmd.SetContext(context.Background())
+	t.Cleanup(func() { reconstructCmd.SetContext(nil) })
+
+	oldStdout := os.Stdout
+	t.Cleanup(func() { os.Stdout = oldStdout })
+	r, wPipe, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = wPipe
+	runErr := runReconstruct(reconstructCmd, nil)
+	wPipe.Close()
+	os.Stdout = oldStdout
+	outBytes, _ := io.ReadAll(r)
+	out := string(outBytes)
+	if runErr != nil {
+		t.Fatalf("runReconstruct failed: %v\noutput: %s", runErr, out)
+	}
+	if !strings.Contains(out, "updated bio ☃") {
+		t.Errorf("expected decoded TEXT \"updated bio ☃\" in output, got: %s", out)
+	}
+	if strings.Contains(out, b64) {
+		t.Errorf("output still contains the base64 text %q (decode did not run): %s", b64, out)
 	}
 }

--- a/internal/console/reconstruct.go
+++ b/internal/console/reconstruct.go
@@ -278,6 +278,10 @@ func (s *Server) handleReconstruct(w http.ResponseWriter, r *http.Request) {
 	// already labels and pass through. Must run before the fold below so
 	// both State and History carry labels.
 	reconstruct.MapEventEnumLabels(b.db, b.resolver, schema, table, rows)
+	// BLOB/TEXT columns are stored base64-encoded; decode them on the deltas
+	// before the fold so State/History carry the real value, not base64 text
+	// (#666). Baseline values are read raw from Parquet and pass through.
+	reconstruct.DecodeEventBinaries(b.db, schema, table, rows)
 
 	resp := reconstructResponse{
 		Schema: schema, Table: table, PK: pk,

--- a/internal/console/reconstruct_integration_test.go
+++ b/internal/console/reconstruct_integration_test.go
@@ -3,6 +3,7 @@
 package console
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -297,5 +298,74 @@ func TestIntegrationReconstructEnumLabels(t *testing.T) {
 	if fmt.Sprint(r.History[0].State["status"]) != "pending" || fmt.Sprint(r.History[1].State["status"]) != "shipped" {
 		t.Errorf("history statuses = [%v, %v], want [pending, shipped]",
 			r.History[0].State["status"], r.History[1].State["status"])
+	}
+}
+
+// TestIntegrationReconstructBlobText pins #666 on the console Time-travel
+// surface — the literal sibling of the ENUM test above, and the surface the
+// issue names. A TEXT column is stored base64; the console reconstruct must
+// return it decoded in both State and History, not as base64. Guards against a
+// one-line deletion of the DecodeEventBinaries wiring silently reintroducing the
+// bug. TEXT (not BLOB): a decoded BLOB []byte re-base64-encodes in the JSON
+// response and would assert vacuously.
+func TestIntegrationReconstructBlobText(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	testutil.InsertSnapshot(t, db, 1, "2026-06-01 00:00:00", "app", "docs", "id", 1, "PRI", "int", "NO")
+	testutil.InsertSnapshot(t, db, 1, "2026-06-01 00:00:00", "app", "docs", "body", 2, "", "text", "YES")
+
+	// Post-baseline UPDATE: body stored base64, as marshalRow encodes the []byte
+	// go-mysql delivers for a TEXT column.
+	b64 := base64.StdEncoding.EncodeToString([]byte("updated bio ☃"))
+	testutil.InsertEvent(t, db, "bin.000001", 4, 40, "2026-06-01 12:00:00", nil, "app", "docs", 2, "1",
+		[]byte(`["body"]`),
+		[]byte(`{"id":1,"body":"`+base64.StdEncoding.EncodeToString([]byte("baseline-bio"))+`"}`),
+		[]byte(`{"id":1,"body":"`+b64+`"}`))
+
+	baseDir := t.TempDir()
+	tsDir := strings.ReplaceAll(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339), ":", "-")
+	dir := filepath.Join(baseDir, tsDir, "app")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cols := []baseline.Column{
+		{Name: "id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
+		{Name: "body", MySQLType: "text", ParquetType: baseline.MysqlToParquetNode("text")},
+	}
+	w, err := baseline.NewWriter(filepath.Join(dir, "docs.parquet"), cols,
+		baseline.WriterConfig{Compression: "none", RowGroupSize: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := w.WriteRow([]string{"1", "baseline-bio"}, []bool{false, false}); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	srv, err := New(Config{DB: db, DBName: dbName, Listen: "127.0.0.1:8090", Token: intToken, BaselineDir: baseDir})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// After the delta: the TEXT value must come back decoded, not base64.
+	r := reconstructAt(t, srv, "schema=app&table=docs&pk=1&at=2026-06-01%2012:30:00&allow_gaps=true")
+	if !r.Found || fmt.Sprint(r.State["body"]) != "updated bio ☃" {
+		t.Errorf("at 12:30: found=%v body=%v, want decoded 'updated bio ☃'", r.Found, r.State["body"])
+	}
+	if fmt.Sprint(r.State["body"]) == b64 {
+		t.Errorf("body came back as base64 %q (decode did not run)", b64)
+	}
+
+	// History: the delta entry carries the decoded value too (the toStateEntryDTOs
+	// path the CLI E2E does not exercise).
+	r = reconstructAt(t, srv, "schema=app&table=docs&pk=1&at=2026-06-01%2012:30:00&history=true&allow_gaps=true")
+	if len(r.History) != 2 {
+		t.Fatalf("history len=%d, want 2: %+v", len(r.History), r.History)
+	}
+	if fmt.Sprint(r.History[1].State["body"]) != "updated bio ☃" {
+		t.Errorf("history[1] body = %v, want decoded 'updated bio ☃'", r.History[1].State["body"])
 	}
 }

--- a/internal/reconstruct/enumlabels.go
+++ b/internal/reconstruct/enumlabels.go
@@ -3,6 +3,7 @@ package reconstruct
 import (
 	"database/sql"
 	"log/slog"
+	"time"
 
 	"github.com/dbtrail/dbtrail/internal/metadata"
 	"github.com/dbtrail/dbtrail/internal/query"
@@ -47,5 +48,89 @@ func MapEventEnumLabels(db *sql.DB, latest *metadata.Resolver, schema, table str
 		m := src.MapperAt(schema, table, events[i].EventTimestamp)
 		m.MapImage(events[i].RowBefore)
 		m.MapImage(events[i].RowAfter)
+	}
+}
+
+// DecodeEventBinaries reverses the storage-side base64 of BLOB/TEXT columns in
+// the events' row images in place — the sibling of MapEventEnumLabels for the
+// other class of values go-mysql delivers as []byte (#666, same root as recover
+// #662 / shim #661). go-mysql delivers BLOB/TEXT as []byte, which marshalRow
+// base64-encodes into the stored event JSON; the single-row reconstruction
+// surfaces (`bintrail reconstruct`, console Time-travel) fold these events onto
+// the baseline via ApplyAt/BuildHistory, which do NOT decode, so without this
+// pass the client gets the base64 text instead of the real value.
+//
+// Call this on fetched deltas BEFORE folding them onto a baseline: event images
+// only, never a baseline row (baseline rows are scanned raw from Parquet and
+// must not be decoded — a baseline TEXT value that happens to be valid base64
+// would be corrupted). The full-table merge path has its own decode
+// (decodeChangeBinaries) and must NOT call this — doing so would double-decode.
+//
+// Each column is typed at the snapshot in effect at its event's timestamp
+// (#475-style epoch awareness, matching MapEventEnumLabels): whether a value is
+// base64-stored depends on whether the column was delivered as []byte (BLOB/TEXT)
+// or string (VARCHAR/CHAR) when the event was captured, so a VARCHAR→TEXT
+// widening must not make a wrong-epoch lookup wrongly decode an old plain-string
+// value that happens to be valid base64.
+//
+// Unlike MapEventEnumLabels there is deliberately NO latest-snapshot fallback:
+// relabeling an ENUM by the latest definition is harmless (strings pass through),
+// but base64-decoding a value the wrong schema calls BLOB/TEXT is DESTRUCTIVE (a
+// plain VARCHAR value that happens to be valid base64 would be corrupted to
+// garbage bytes). So when the epoch
+// typing is unavailable — no snapshots, or a per-epoch resolver that fails to
+// load — the value is left as the base64 it was stored as, never decoded by a
+// guess.
+func DecodeEventBinaries(db *sql.DB, schema, table string, events []query.ResultRow) {
+	if len(events) == 0 || db == nil {
+		return
+	}
+	epochs, err := metadata.LoadSnapshotEpochs(db)
+	if err != nil {
+		slog.Debug("snapshot epoch lookup failed; leaving BLOB/TEXT as stored base64",
+			"schema", schema, "table", table, "err", err)
+		epochs = nil
+	}
+	// The per-epoch BLOB/TEXT column map is memoized; the check sits before
+	// NewResolver so a snapshot whose resolver fails to load is probed at most
+	// once, not once per row.
+	memo := make(map[int]map[string]bool)
+	binColsAt := func(t time.Time) map[string]bool {
+		id, ok := metadata.EpochAt(epochs, t)
+		if !ok {
+			return nil // no snapshots → no safe typing → leave values as base64
+		}
+		if m, seen := memo[id]; seen {
+			return m
+		}
+		var m map[string]bool
+		if r, nerr := metadata.NewResolver(db, id); nerr == nil && r != nil {
+			if tm, rerr := r.Resolve(schema, table); rerr == nil {
+				m = binaryColsFromTableMeta(tm)
+			}
+		}
+		memo[id] = m
+		return m
+	}
+	for i := range events {
+		binCols := binColsAt(events[i].EventTimestamp)
+		decodeImageBinaries(events[i].RowBefore, binCols)
+		decodeImageBinaries(events[i].RowAfter, binCols)
+	}
+}
+
+// decodeImageBinaries decodes the storage-side base64 of every BLOB/TEXT column
+// in one event image, in place. No-op when binCols is empty or image is nil.
+// The per-image sibling of decodeChangeBinaries (which decodes a change map's
+// RowAfter); kept separate so the single-row decode never touches the full-table
+// merge path.
+func decodeImageBinaries(image map[string]any, binCols map[string]bool) {
+	if len(binCols) == 0 || image == nil {
+		return
+	}
+	for col, binary := range binCols {
+		if v, ok := image[col]; ok {
+			image[col] = decodeStoredBase64(v, binary)
+		}
 	}
 }

--- a/internal/reconstruct/enumlabels_integration_test.go
+++ b/internal/reconstruct/enumlabels_integration_test.go
@@ -1,0 +1,127 @@
+//go:build integration
+
+package reconstruct
+
+import (
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/query"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestDecodeEventBinaries_decodesEpochAware is the load-bearing proof for #666:
+// DecodeEventBinaries decodes the storage-side base64 of BLOB/TEXT event values,
+// typing each column at the snapshot in effect at the event's timestamp. The
+// VARCHAR→TEXT widening is the trap — an old VARCHAR value reached go-mysql as a
+// Go string, so it was stored as a PLAIN string (never base64); decoding it
+// against the latest (TEXT) snapshot would corrupt a plain value that happens to
+// be valid base64 ("test"). The epoch-aware lookup leaves the old VARCHAR value
+// alone and still decodes the new TEXT value.
+func TestDecodeEventBinaries_decodesEpochAware(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Hour)
+	t1 := now.Add(1 * time.Minute).Format("2006-01-02 15:04:05")
+	t2 := now.Add(10 * time.Minute).Format("2006-01-02 15:04:05")
+	// Epoch 1: body is VARCHAR (stored plain). Epoch 2: body widened to TEXT.
+	testutil.InsertSnapshot(t, db, 1, t1, "myapp", "docs", "id", 1, "PRI", "int", "NO")
+	testutil.InsertSnapshot(t, db, 1, t1, "myapp", "docs", "body", 2, "", "varchar", "YES")
+	testutil.InsertSnapshot(t, db, 2, t2, "myapp", "docs", "id", 1, "PRI", "int", "NO")
+	testutil.InsertSnapshot(t, db, 2, t2, "myapp", "docs", "body", 2, "", "text", "YES")
+
+	b64 := func(s string) string { return base64.StdEncoding.EncodeToString([]byte(s)) }
+	rawBlob := "\x00\xff\x7f"
+	events := []query.ResultRow{
+		// Epoch-1 event: VARCHAR value stored PLAIN. "test" is valid base64, so an
+		// epoch-blind decode would corrupt it.
+		{
+			SchemaName: "myapp", TableName: "docs",
+			EventTimestamp: now.Add(5 * time.Minute),
+			RowAfter:       map[string]any{"id": float64(1), "body": "test"},
+		},
+		// Epoch-2 event: TEXT value stored base64.
+		{
+			SchemaName: "myapp", TableName: "docs",
+			EventTimestamp: now.Add(15 * time.Minute),
+			RowAfter:       map[string]any{"id": float64(2), "body": b64("decoded text")},
+		},
+	}
+	DecodeEventBinaries(db, "myapp", "docs", events)
+
+	if got := events[0].RowAfter["body"]; got != "test" {
+		t.Errorf("epoch-1 VARCHAR plain value = %#v, want \"test\" untouched (epoch-blind decode would corrupt it)", got)
+	}
+	if got := events[1].RowAfter["body"]; got != "decoded text" {
+		t.Errorf("epoch-2 TEXT value = %#v, want decoded \"decoded text\"", got)
+	}
+
+	// Single-epoch BLOB decode → raw []byte (arbitrary bytes survive).
+	blobEvents := []query.ResultRow{{
+		SchemaName: "myapp", TableName: "docs",
+		EventTimestamp: now.Add(15 * time.Minute),
+		RowAfter:       map[string]any{"id": float64(3), "payload": b64(rawBlob)},
+	}}
+	testutil.InsertSnapshot(t, db, 2, t2, "myapp", "docs", "payload", 3, "", "blob", "YES")
+	DecodeEventBinaries(db, "myapp", "docs", blobEvents)
+	if got, ok := blobEvents[0].RowAfter["payload"].([]byte); !ok || string(got) != rawBlob {
+		t.Errorf("BLOB payload = %#v, want decoded []byte %q", blobEvents[0].RowAfter["payload"], rawBlob)
+	}
+}
+
+// TestDecodeEventBinaries_noSnapshotsLeavesBase64 confirms the safe degradation:
+// with no usable schema (no snapshots → no column typing), values pass through
+// as the base64 they were stored as rather than being guessed at.
+func TestDecodeEventBinaries_noSnapshotsLeavesBase64(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	b64 := base64.StdEncoding.EncodeToString([]byte("hello"))
+	events := []query.ResultRow{{
+		SchemaName: "myapp", TableName: "docs",
+		EventTimestamp: time.Now().UTC(),
+		RowAfter:       map[string]any{"id": float64(1), "body": b64},
+	}}
+	DecodeEventBinaries(db, "myapp", "docs", events)
+	if got := events[0].RowAfter["body"]; got != b64 {
+		t.Errorf("with no snapshots the value must pass through as base64, got %#v", got)
+	}
+}
+
+// TestDecodeEventBinaries_tableAbsentLeavesBase64 pins the non-trivial safe
+// degradation — the exact branch this PR's removed-`latest`-fallback decision
+// protects. A snapshot EXISTS (so a latest resolver IS available to wrongly
+// decode by), but the event's table is absent from it, so per-epoch typing
+// fails (Resolve errors → nil binCols). The value must be LEFT as base64, never
+// decoded by the latest schema — otherwise a plain value that is valid base64
+// would be corrupted.
+func TestDecodeEventBinaries_tableAbsentLeavesBase64(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Hour)
+	ts := now.Add(1 * time.Minute).Format("2006-01-02 15:04:05")
+	// A snapshot exists, but only for `docs` — not for the event's table.
+	testutil.InsertSnapshot(t, db, 1, ts, "myapp", "docs", "id", 1, "PRI", "int", "NO")
+	testutil.InsertSnapshot(t, db, 1, ts, "myapp", "docs", "body", 2, "", "text", "YES")
+
+	b64 := base64.StdEncoding.EncodeToString([]byte("hello"))
+	events := []query.ResultRow{{
+		SchemaName: "myapp", TableName: "other", // absent from the snapshot
+		EventTimestamp: now.Add(5 * time.Minute),
+		RowAfter:       map[string]any{"id": float64(1), "body": b64},
+	}}
+	DecodeEventBinaries(db, "myapp", "other", events)
+	if got := events[0].RowAfter["body"]; got != b64 {
+		t.Errorf("table absent from snapshot: value must pass through as base64 (never decoded by the latest schema), got %#v", got)
+	}
+}

--- a/internal/reconstruct/enumlabels_test.go
+++ b/internal/reconstruct/enumlabels_test.go
@@ -1,0 +1,71 @@
+package reconstruct
+
+import (
+	"encoding/base64"
+	"testing"
+)
+
+// TestDecodeImageBinaries pins the per-image base64 decode primitive used by
+// DecodeEventBinaries (#666): BLOB → []byte, TEXT → string, NULL stays nil, a
+// non-blob/text column and an absent column are untouched. Sibling of
+// TestDecodeChangeBinaries (the full-table change-map decoder).
+func TestDecodeImageBinaries(t *testing.T) {
+	b64 := func(s string) string { return base64.StdEncoding.EncodeToString([]byte(s)) }
+	image := map[string]any{
+		"id": float64(1),
+		"bl": b64("BIN\x00BLOB"), // base64 binary blob with a NUL byte
+		"tx": b64("hello text"),  // base64 text
+		"bn": nil,                // NULL blob stays nil
+		"vc": "plain varchar",    // not in the decode set → untouched
+	}
+	decodeImageBinaries(image, map[string]bool{"bl": true, "tx": false, "bn": true, "gone": true})
+
+	if got, ok := image["bl"].([]byte); !ok || string(got) != "BIN\x00BLOB" {
+		t.Errorf("bl: want decoded []byte \"BIN\\0BLOB\", got %T %v", image["bl"], image["bl"])
+	}
+	if got, ok := image["tx"].(string); !ok || got != "hello text" {
+		t.Errorf("tx: want decoded string \"hello text\", got %T %v", image["tx"], image["tx"])
+	}
+	if image["bn"] != nil {
+		t.Errorf("bn: NULL must stay nil, got %v", image["bn"])
+	}
+	if image["vc"] != "plain varchar" {
+		t.Errorf("vc: column not in the decode set must be untouched, got %v", image["vc"])
+	}
+	if image["id"] != float64(1) {
+		t.Errorf("id: non-blob/text column must be untouched, got %v", image["id"])
+	}
+	if _, present := image["gone"]; present {
+		t.Errorf("a decode-set column absent from the image must not be materialized, got %v", image["gone"])
+	}
+}
+
+// TestDecodeImageBinaries_noopGuards confirms the cheap no-op paths: an empty
+// decode set or a nil image must not panic and must change nothing.
+func TestDecodeImageBinaries_noopGuards(t *testing.T) {
+	image := map[string]any{"bl": "QUJD"}
+	decodeImageBinaries(image, nil)
+	if image["bl"] != "QUJD" {
+		t.Errorf("empty binCols must leave the image untouched, got %v", image["bl"])
+	}
+	decodeImageBinaries(nil, map[string]bool{"bl": true}) // must not panic
+}
+
+// TestFormatCell pins the table/CSV cell formatter (#666): a decoded BLOB column
+// is a []byte and must render as base64 (matching the JSON path of the same
+// command), not the raw "%v" decimal byte array; everything else uses "%v".
+func TestFormatCell(t *testing.T) {
+	raw := "BIN\x00BLOB"
+	if got, want := formatCell([]byte(raw)), base64.StdEncoding.EncodeToString([]byte(raw)); got != want {
+		t.Errorf("[]byte: got %q, want base64 %q (not a decimal array)", got, want)
+	}
+	if got := formatCell("hello text"); got != "hello text" {
+		t.Errorf("string: got %q, want %q", got, "hello text")
+	}
+	if got := formatCell(int64(42)); got != "42" {
+		t.Errorf("int64: got %q, want %q", got, "42")
+	}
+	if got := formatCell(nil); got != "<nil>" {
+		t.Errorf("nil: got %q, want %q", got, "<nil>")
+	}
+}

--- a/internal/reconstruct/reconstruct.go
+++ b/internal/reconstruct/reconstruct.go
@@ -8,6 +8,7 @@
 package reconstruct
 
 import (
+	"encoding/base64"
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
@@ -112,6 +113,18 @@ func WriteHistoryJSON(entries []StateEntry, w io.Writer) error {
 	return enc.Encode(out)
 }
 
+// formatCell renders a state value as text for the table/CSV formatters. A
+// []byte — a decoded BLOB column (#666), or a baseline BLOB scanned by DuckDB —
+// is rendered as base64 to match the JSON output of the same command; fmt's
+// "%v" would otherwise print a raw decimal byte array (e.g. "[72 101 ...]").
+// Everything else uses the default "%v".
+func formatCell(v any) string {
+	if b, ok := v.([]byte); ok {
+		return base64.StdEncoding.EncodeToString(b)
+	}
+	return fmt.Sprintf("%v", v)
+}
+
 // WriteStateTable writes a single row state as aligned key-value pairs.
 func WriteStateTable(state map[string]any, w io.Writer) error {
 	if state == nil {
@@ -123,7 +136,7 @@ func WriteStateTable(state map[string]any, w io.Writer) error {
 	fmt.Fprintln(tw, "COLUMN\tVALUE")
 	fmt.Fprintln(tw, "──────\t─────")
 	for _, col := range sortedKeys(state) {
-		fmt.Fprintf(tw, "%s\t%v\n", col, state[col])
+		fmt.Fprintf(tw, "%s\t%s\n", col, formatCell(state[col]))
 	}
 	return nil
 }
@@ -148,7 +161,7 @@ func WriteHistoryTable(entries []StateEntry, w io.Writer) error {
 		if e.State != nil {
 			var parts []string
 			for _, col := range sortedKeys(e.State) {
-				parts = append(parts, fmt.Sprintf("%s=%v", col, e.State[col]))
+				parts = append(parts, fmt.Sprintf("%s=%s", col, formatCell(e.State[col])))
 			}
 			stateStr = strings.Join(parts, " ")
 		}
@@ -175,7 +188,7 @@ func WriteStateCSV(state map[string]any, w io.Writer) error {
 	}
 	vals := make([]string, len(keys))
 	for i, k := range keys {
-		vals[i] = fmt.Sprintf("%v", state[k])
+		vals[i] = formatCell(state[k])
 	}
 	if err := cw.Write(vals); err != nil {
 		return err
@@ -212,7 +225,7 @@ func WriteHistoryCSV(entries []StateEntry, w io.Writer) error {
 			if e.State == nil {
 				record = append(record, "")
 			} else {
-				record = append(record, fmt.Sprintf("%v", e.State[col]))
+				record = append(record, formatCell(e.State[col]))
 			}
 		}
 		if err := cw.Write(record); err != nil {


### PR DESCRIPTION
closes #666

## Summary
- The single-row reconstruction surfaces — `bintrail reconstruct` (CLI) and the console Time-travel reconstruct — returned BLOB/TEXT columns as the **base64 text** they are stored as, not the real bytes/string. Sibling of recover #662, reconstruct full-table #663, and shim #661 (same root: go-mysql delivers BLOB/TEXT as `[]byte`, which `marshalRow` base64-encodes into the stored event JSON). The single-row path folds events via `ApplyAt`/`BuildHistory`, which copy `row_after` verbatim with **no decode** — the full-table path's decode (`decodeChangeBinaries`) is not on this path.
- New `DecodeEventBinaries` (sibling of `MapEventEnumLabels`) decodes the fetched deltas' BLOB/TEXT base64 in place, **before** the fold:
  - **event images only**, never a baseline row (DuckDB scans baselines raw — a baseline TEXT value that happens to be valid base64 must not be decoded);
  - **epoch-aware**, typing each column at the snapshot in effect at the event's timestamp (mirrors #475), so a `VARCHAR→TEXT` widening does not wrongly decode an old plain-string value that happens to be valid base64;
  - **no latest-snapshot fallback** (unlike enum mapping): base64-decoding by the wrong schema is destructive, so when epoch typing is unavailable the value is left as the base64 it was stored as.
- Wired into the CLI and console single-row paths after `MapEventEnumLabels`. **The full-table merge path (#663) is left untouched** — it has its own decode and must not call this (would double-decode). 100% additive.

## Review
Two specialized agents reviewed the diff. The silent-failure-hunter caught a MEDIUM: the console initially passed a latest-snapshot fallback into the decoder, which is destructive in the degraded path — fixed by removing the `latest` fallback from `DecodeEventBinaries` entirely so no caller can trigger it.

## Test plan
- [x] Unit: `decodeImageBinaries` primitive (BLOB→`[]byte`, TEXT→`string`, NULL/non-base64/absent untouched).
- [x] Integration (Docker MySQL): `DecodeEventBinaries` decode + **VARCHAR→TEXT epoch-drift** (an old plain `"test"` survives verbatim, the new TEXT decodes) + no-snapshots safe degradation.
- [x] Integration E2E: `bintrail reconstruct --format json` over a baseline + base64 TEXT event emits the decoded value, not base64.
- [x] Full reconstruct/cli/console unit + reconstruct/cli integration suites + full repo unit suite green — full-table path (#663) confirmed unaffected.

## Related (separate follow-up)
The full-table merge's `decodeChangeBinaries` types columns via `binaryColsFromTableMeta(tm)` from a single snapshot — it is **epoch-blind**, carrying the same VARCHAR→TEXT edge. Noted in #666 for a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)