### PR TITLE
recover/query/reconstruct: bound peak memory at scale (#654)

### DIFF
--- a/cmd/bintrail-mcp/ceiling_test.go
+++ b/cmd/bintrail-mcp/ceiling_test.go
@@ -1,6 +1,42 @@
 package main
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
+
+func TestQueryResultNotice(t *testing.T) {
+	t.Run("ceiling supersedes the generic truncation notice", func(t *testing.T) {
+		// After a cap, n == limit (== ceiling), so the generic arm would also
+		// match; the ceiling message must win and must NOT say "increase the limit".
+		got := queryResultNotice(true, 5_000_000, 1_000_000, 1_000_000, 1_000_000)
+		if !strings.Contains(got, "exceeds the MCP query ceiling") {
+			t.Errorf("want ceiling message, got %q", got)
+		}
+		if !strings.Contains(got, "bintrail query") {
+			t.Errorf("want CLI escape-hatch hint, got %q", got)
+		}
+		if strings.Contains(got, "increase the limit") {
+			t.Errorf("ceiling notice must not tell the agent to increase the limit: %q", got)
+		}
+	})
+
+	t.Run("generic truncation notice when not capped and full", func(t *testing.T) {
+		got := queryResultNotice(false, 100, 1_000_000, 100, 100)
+		if !strings.Contains(got, "increase the limit") {
+			t.Errorf("want generic truncation notice, got %q", got)
+		}
+		if strings.Contains(got, "ceiling") {
+			t.Errorf("must not mention ceiling when no cap fired: %q", got)
+		}
+	})
+
+	t.Run("no notice below the limit", func(t *testing.T) {
+		if got := queryResultNotice(false, 100, 1_000_000, 42, 100); got != "" {
+			t.Errorf("want empty notice for a partial result, got %q", got)
+		}
+	})
+}
 
 func TestApplyQueryCeiling(t *testing.T) {
 	cases := []struct {

--- a/cmd/bintrail-mcp/ceiling_test.go
+++ b/cmd/bintrail-mcp/ceiling_test.go
@@ -1,0 +1,55 @@
+package main
+
+import "testing"
+
+func TestApplyQueryCeiling(t *testing.T) {
+	cases := []struct {
+		name      string
+		limit     int
+		max       int
+		wantLimit int
+		wantCap   bool
+	}{
+		{"below ceiling unchanged", 500, 1000, 500, false},
+		{"at ceiling unchanged", 1000, 1000, 1000, false},
+		{"above ceiling capped", 5000, 1000, 1000, true},
+		{"zero passes through (coercion runs earlier)", 0, 1000, 0, false},
+		{"max<=0 disables capping", 9_999_999, 0, 9_999_999, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotLimit, gotCap := applyQueryCeiling(tc.limit, tc.max)
+			if gotLimit != tc.wantLimit || gotCap != tc.wantCap {
+				t.Fatalf("applyQueryCeiling(%d,%d) = (%d,%v), want (%d,%v)",
+					tc.limit, tc.max, gotLimit, gotCap, tc.wantLimit, tc.wantCap)
+			}
+		})
+	}
+}
+
+func TestMCPQueryMaxLimit(t *testing.T) {
+	cases := []struct {
+		name string
+		env  string // "" = unset
+		set  bool
+		want int
+	}{
+		{"unset → default", "", false, defaultMCPQueryMaxLimit},
+		{"valid override", "500000", true, 500_000},
+		{"invalid → default", "abc", true, defaultMCPQueryMaxLimit},
+		{"zero → default (not disengageable)", "0", true, defaultMCPQueryMaxLimit},
+		{"negative → default", "-5", true, defaultMCPQueryMaxLimit},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.set {
+				t.Setenv("BINTRAIL_MCP_QUERY_MAX_LIMIT", tc.env)
+			} else {
+				t.Setenv("BINTRAIL_MCP_QUERY_MAX_LIMIT", "")
+			}
+			if got := mcpQueryMaxLimit(); got != tc.want {
+				t.Fatalf("mcpQueryMaxLimit() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/bintrail-mcp/main.go
+++ b/cmd/bintrail-mcp/main.go
@@ -412,16 +412,7 @@ func makeQueryTool(connect connectFunc) func(context.Context, *mcp.CallToolReque
 		if n > 0 && format != "json" {
 			text += fmt.Sprintf("\n%d row(s)\n", n)
 		}
-		switch {
-		case ceilingApplied:
-			// Supersede the generic truncation notice: telling the agent to
-			// "increase the limit" here would be wrong — its requested limit was
-			// the one we capped.
-			text += fmt.Sprintf("\nWarning: requested limit %d exceeds the MCP query ceiling of %d rows; capped to %d. "+
-				"Narrow your filters/time range, or run the `bintrail query` CLI for an unbounded export.\n", requestedLimit, ceiling, ceiling)
-		case n >= opts.Limit:
-			text += fmt.Sprintf("\nWarning: results truncated at %d rows. Use a narrower since/until range or increase the limit to see more.\n", opts.Limit)
-		}
+		text += queryResultNotice(ceilingApplied, requestedLimit, ceiling, n, opts.Limit)
 
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
@@ -765,6 +756,22 @@ func applyQueryCeiling(limit, max int) (int, bool) {
 		return max, true
 	}
 	return limit, false
+}
+
+// queryResultNotice composes the trailing warning appended to a query-tool
+// result. When the ceiling fired it SUPERSEDES the generic truncation notice —
+// telling an agent to "increase the limit" would be wrong, since the limit it
+// asked for is exactly the one that was capped (and after a cap n == limit makes
+// the generic arm true too, so order matters). Returns "" when no notice applies.
+func queryResultNotice(ceilingApplied bool, requestedLimit, ceiling, n, limit int) string {
+	switch {
+	case ceilingApplied:
+		return fmt.Sprintf("\nWarning: requested limit %d exceeds the MCP query ceiling of %d rows; capped to %d. "+
+			"Narrow your filters/time range, or run the `bintrail query` CLI for an unbounded export.\n", requestedLimit, ceiling, ceiling)
+	case n >= limit:
+		return fmt.Sprintf("\nWarning: results truncated at %d rows. Use a narrower since/until range or increase the limit to see more.\n", limit)
+	}
+	return ""
 }
 
 func buildQueryOptions(schema, table, pk, eventType, gtid, since, until, changedCol string, columnEq []string, flagVal string, limit, defaultLimit int) (query.Options, error) {

--- a/cmd/bintrail-mcp/main.go
+++ b/cmd/bintrail-mcp/main.go
@@ -34,6 +34,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -337,6 +338,19 @@ func makeQueryTool(connect connectFunc) func(context.Context, *mcp.CallToolReque
 			return errorResult(err), nil, nil
 		}
 
+		// Hard ceiling on an explicit, oversized limit (#654). buildQueryOptions
+		// already coerces limit<=0 to the default, so this only bounds a large
+		// EXPLICIT value an agent might pass. It is applied here, per-tool, on the
+		// local opts — NOT in the shared buildQueryOptions, because the recover
+		// tool must refuse on size, not silently cap a read.
+		ceiling := mcpQueryMaxLimit()
+		requestedLimit := opts.Limit
+		ceilingApplied := false
+		if c, did := applyQueryCeiling(opts.Limit, ceiling); did {
+			opts.Limit = c
+			ceilingApplied = true
+		}
+
 		if args.Profile != "" {
 			denyTables, redactCols, err := query.LoadProfileRules(ctx, db, args.Profile)
 			if err != nil {
@@ -398,7 +412,14 @@ func makeQueryTool(connect connectFunc) func(context.Context, *mcp.CallToolReque
 		if n > 0 && format != "json" {
 			text += fmt.Sprintf("\n%d row(s)\n", n)
 		}
-		if n >= opts.Limit {
+		switch {
+		case ceilingApplied:
+			// Supersede the generic truncation notice: telling the agent to
+			// "increase the limit" here would be wrong — its requested limit was
+			// the one we capped.
+			text += fmt.Sprintf("\nWarning: requested limit %d exceeds the MCP query ceiling of %d rows; capped to %d. "+
+				"Narrow your filters/time range, or run the `bintrail query` CLI for an unbounded export.\n", requestedLimit, ceiling, ceiling)
+		case n >= opts.Limit:
 			text += fmt.Sprintf("\nWarning: results truncated at %d rows. Use a narrower since/until range or increase the limit to see more.\n", opts.Limit)
 		}
 
@@ -715,6 +736,35 @@ func resolveArchiveSources(ctx context.Context, db *sql.DB) []string {
 		return nil
 	}
 	return sources
+}
+
+// defaultMCPQueryMaxLimit is the hard row ceiling for the MCP query tool (#654):
+// a backstop against a pathological explicit limit OOMing the long-lived server.
+// ~1M rows is multiple GB worst-case at the project's per-row sizing — far above
+// any legitimate agent query, yet bounded. The unbounded escape hatch is the
+// `bintrail query` CLI, so this is deliberately not disengageable via env.
+const defaultMCPQueryMaxLimit = 1_000_000
+
+// mcpQueryMaxLimit returns the MCP query-tool row ceiling. BINTRAIL_MCP_QUERY_MAX_LIMIT
+// raises or lowers it; an empty/invalid/<=0 value falls back to the default
+// rather than disabling the ceiling (the CLI is the unbounded path, not the
+// agent-facing tool).
+func mcpQueryMaxLimit() int {
+	if v := os.Getenv("BINTRAIL_MCP_QUERY_MAX_LIMIT"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return defaultMCPQueryMaxLimit
+}
+
+// applyQueryCeiling caps limit to max, returning the (possibly capped) limit and
+// whether a cap was applied. max <= 0 disables capping.
+func applyQueryCeiling(limit, max int) (int, bool) {
+	if max > 0 && limit > max {
+		return max, true
+	}
+	return limit, false
 }
 
 func buildQueryOptions(schema, table, pk, eventType, gtid, since, until, changedCol string, columnEq []string, flagVal string, limit, defaultLimit int) (query.Options, error) {

--- a/cmd/bintrail/config.go
+++ b/cmd/bintrail/config.go
@@ -202,6 +202,15 @@ var envSections = []envSection{
 			{"BINTRAIL_DUCKDB_MEMORY_LIMIT", ""},
 		},
 	},
+	{
+		Header: "Memory budgets (bound peak RAM at scale, #654)",
+		Bindings: []envTemplateEntry{
+			// recover: refuse a reversal script whose row payload exceeds this (0 = unlimited).
+			{"BINTRAIL_RECOVER_MAX_BYTES", "2GB"},
+			// reconstruct: warn when a full-table window exceeds this many events (0 disables).
+			{"BINTRAIL_RECONSTRUCT_WARN_EVENTS", "5000000"},
+		},
+	},
 	// The BINTRAIL_CONSOLE_* vars moved with the web console to the standalone
 	// bintrail-console binary (serve/watch), which reads the same env file —
 	// they are no longer advertised in the core CLI's template.

--- a/cmd/bintrail/config.go
+++ b/cmd/bintrail/config.go
@@ -203,7 +203,7 @@ var envSections = []envSection{
 		},
 	},
 	{
-		Header: "Memory budgets (bound peak RAM at scale, #654)",
+		Header: "Memory guards at scale (recover refuses oversized scripts; reconstruct warns on large windows, #654)",
 		Bindings: []envTemplateEntry{
 			// recover: refuse a reversal script whose row payload exceeds this (0 = unlimited).
 			{"BINTRAIL_RECOVER_MAX_BYTES", "2GB"},

--- a/internal/cascaderecover/emit.go
+++ b/internal/cascaderecover/emit.go
@@ -53,6 +53,15 @@ type Header struct {
 // resolver supplies child PK columns for the SET NULL WHERE clauses; gen must be
 // built from the same (or an equivalent) resolver (recovery.New(db, resolver)).
 func EmitSQL(w io.Writer, gen *recovery.Generator, rows []query.ResultRow, setNullRows []cascade.SetNullRestore, resolver *metadata.Resolver, hdr Header) (int, error) {
+	// Enforce the recover script-size budget BEFORE writing a byte (#654): EmitSQL
+	// emits its preamble (including `SET FOREIGN_KEY_CHECKS=0`) ahead of the
+	// generator, so without an up-front check a budget refusal would leave that
+	// dangling FK-disable on the writer. Refusing here keeps "emit nothing on
+	// refusal" consistent with the plain recover path.
+	if err := gen.CheckScriptBudget(rows); err != nil {
+		return 0, err
+	}
+
 	// Build every SET NULL restoration BEFORE writing a byte (all-or-nothing): a
 	// missing resolver, an unresolvable table, or an absent PK column must abort
 	// the whole emit cleanly — returning mid-script would leave the parent/child

--- a/internal/cascaderecover/emit_test.go
+++ b/internal/cascaderecover/emit_test.go
@@ -2,11 +2,13 @@ package cascaderecover_test
 
 import (
 	"bytes"
+	"errors"
 	"strings"
 	"testing"
 
 	"github.com/dbtrail/dbtrail/internal/cascade"
 	"github.com/dbtrail/dbtrail/internal/cascaderecover"
+	"github.com/dbtrail/dbtrail/internal/event"
 	"github.com/dbtrail/dbtrail/internal/metadata"
 	"github.com/dbtrail/dbtrail/internal/query"
 	"github.com/dbtrail/dbtrail/internal/recovery"
@@ -22,6 +24,37 @@ func emit(t *testing.T, hdr cascaderecover.Header, rows []query.ResultRow, setNu
 	var buf bytes.Buffer
 	n, err := cascaderecover.EmitSQL(&buf, recovery.New(nil, resolver), rows, setNull, resolver, hdr)
 	return buf.String(), n, err
+}
+
+// TestEmitSQL_scriptBudgetRefusesCleanly verifies the #654 budget guard in the
+// cascade path: when the rows exceed the script-size budget, EmitSQL refuses
+// BEFORE writing its preamble, so it leaves NO dangling `SET FOREIGN_KEY_CHECKS=0`
+// on the writer (the footgun a refusal after the preamble would create).
+func TestEmitSQL_scriptBudgetRefusesCleanly(t *testing.T) {
+	hdr := cascaderecover.Header{Schema: "shop", Table: "orders", Parents: 1, Children: 0}
+	rows := []query.ResultRow{{
+		EventType:  event.EventDelete,
+		SchemaName: "shop", TableName: "orders",
+		PKValues:  "1",
+		RowBefore: map[string]any{"id": float64(1), "blob": strings.Repeat("x", 1<<20)}, // 1 MiB
+	}}
+
+	gen := recovery.New(nil, nil)
+	gen.SetMaxScriptBytes(1024) // tiny budget → the 1 MiB row trips it
+
+	var buf bytes.Buffer
+	n, err := cascaderecover.EmitSQL(&buf, gen, rows, nil, nil, hdr)
+
+	var be *recovery.ScriptBudgetError
+	if !errors.As(err, &be) {
+		t.Fatalf("want *ScriptBudgetError, got %v", err)
+	}
+	if n != 0 {
+		t.Errorf("want 0 statements on refusal, got %d", n)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("refusal must write nothing (no dangling FK-disable), wrote %d bytes: %q", buf.Len(), buf.String())
+	}
 }
 
 // TestEmitSQL_goldenPhase1 pins the byte-exact Phase-1 (no baseline) script: the

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -64,6 +64,8 @@ var EnvBindings = []EnvBinding{
 	{"ultrafast", "BINTRAIL_ULTRAFAST"},
 	{"duckdb-threads", "BINTRAIL_DUCKDB_THREADS"},
 	{"duckdb-memory-limit", "BINTRAIL_DUCKDB_MEMORY_LIMIT"},
+	{"max-script-bytes", "BINTRAIL_RECOVER_MAX_BYTES"},
+	{"warn-event-threshold", "BINTRAIL_RECONSTRUCT_WARN_EVENTS"},
 }
 
 var envOnce sync.Once

--- a/internal/cli/memguard_test.go
+++ b/internal/cli/memguard_test.go
@@ -1,0 +1,75 @@
+package cli
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/recovery"
+)
+
+func TestLimitWarning(t *testing.T) {
+	cases := []struct {
+		limit    int
+		wantWarn bool
+	}{
+		{100, false},
+		{1, false},
+		{0, true},
+		{-1, true},
+	}
+	for _, tc := range cases {
+		got := limitWarning(tc.limit)
+		if (got != "") != tc.wantWarn {
+			t.Fatalf("limitWarning(%d) = %q, wantWarn=%v", tc.limit, got, tc.wantWarn)
+		}
+		if tc.wantWarn && !strings.Contains(got, "--limit 0") {
+			t.Errorf("limitWarning(%d) should mention --limit 0: %q", tc.limit, got)
+		}
+	}
+}
+
+func TestWrapScriptBudget(t *testing.T) {
+	t.Run("budget error gets CLI hint", func(t *testing.T) {
+		base := &recovery.ScriptBudgetError{EstimatedBytes: 3 << 30, Budget: 2 << 30}
+		got := wrapScriptBudget(base)
+		// The typed error must remain unwrappable for callers/tests.
+		var be *recovery.ScriptBudgetError
+		if !errors.As(got, &be) {
+			t.Fatalf("wrapped error no longer unwraps to *ScriptBudgetError: %v", got)
+		}
+		for _, want := range []string{"--since", "--pk", "--limit", "--max-script-bytes", "BINTRAIL_RECOVER_MAX_BYTES"} {
+			if !strings.Contains(got.Error(), want) {
+				t.Errorf("CLI hint missing %q: %s", want, got.Error())
+			}
+		}
+	})
+
+	t.Run("other errors pass through unchanged", func(t *testing.T) {
+		base := errors.New("some other failure")
+		if got := wrapScriptBudget(base); got != base {
+			t.Fatalf("non-budget error should pass through unchanged, got %v", got)
+		}
+	})
+
+	t.Run("nil passes through", func(t *testing.T) {
+		if got := wrapScriptBudget(nil); got != nil {
+			t.Fatalf("nil should stay nil, got %v", got)
+		}
+	})
+}
+
+// TestMemGuardFlagDefaults pins the break-nothing defaults so a future edit that
+// silently zeroes them (which would disable the guards) fails the build (#654).
+func TestMemGuardFlagDefaults(t *testing.T) {
+	if f := recoverCmd.Flags().Lookup("max-script-bytes"); f == nil {
+		t.Fatal("recover: --max-script-bytes flag is missing")
+	} else if f.DefValue != "2GB" {
+		t.Errorf("recover --max-script-bytes default = %q, want 2GB", f.DefValue)
+	}
+	if f := reconstructCmd.Flags().Lookup("warn-event-threshold"); f == nil {
+		t.Fatal("reconstruct: --warn-event-threshold flag is missing")
+	} else if f.DefValue != "5000000" {
+		t.Errorf("reconstruct --warn-event-threshold default = %q, want 5000000", f.DefValue)
+	}
+}

--- a/internal/cli/query.go
+++ b/internal/cli/query.go
@@ -104,6 +104,19 @@ func init() {
 
 }
 
+// limitWarning returns a stderr warning when the query --limit is unbounded
+// (0 or negative → no LIMIT clause, a full scan buffered into memory, #654), or
+// "" when the limit is bounded. The query path deliberately keeps limit=0
+// working (it is a live internal contract used by reconstruct/verify/shim); this
+// only alerts the operator, it never changes the limit.
+func limitWarning(limit int) string {
+	if limit > 0 {
+		return ""
+	}
+	return "Warning: --limit 0 returns ALL matching rows with no bound; a very large result set may " +
+		"exhaust memory. Pass --limit N to bound the result, or narrow --since/--until."
+}
+
 func runQuery(cmd *cobra.Command, args []string) error {
 	start := time.Now()
 	// ── Validate flag combinations ────────────────────────────────────────────
@@ -126,6 +139,9 @@ func runQuery(cmd *cobra.Command, args []string) error {
 	}
 	if qLimitPerPK > 0 && qPK == "" && len(qPKs) == 0 {
 		return fmt.Errorf("--limit-per-pk requires --pk or --pks")
+	}
+	if w := limitWarning(qLimit); w != "" {
+		fmt.Fprintln(os.Stderr, w)
 	}
 	if qChangedCol != "" && (qSchema == "" || qTable == "") {
 		return fmt.Errorf("--changed-column requires both --schema and --table")

--- a/internal/cli/reconstruct.go
+++ b/internal/cli/reconstruct.go
@@ -95,6 +95,7 @@ var (
 	recTables       string
 	recChunkSize    string
 	recParallelism  int
+	recWarnEvents   int64
 )
 
 func init() {
@@ -118,6 +119,7 @@ func init() {
 	reconstructCmd.Flags().StringVar(&recTables, "tables", "", "Comma-separated schema.table list for --output-format=mydumper (e.g. mydb.orders,mydb.users)")
 	reconstructCmd.Flags().StringVar(&recChunkSize, "chunk-size", "256MB", "Max size per SQL chunk file in full-table mode (e.g. 64MB, 1GB)")
 	reconstructCmd.Flags().IntVar(&recParallelism, "parallelism", 0, "Max tables to reconstruct concurrently in full-table mode (default: runtime.NumCPU())")
+	reconstructCmd.Flags().Int64Var(&recWarnEvents, "warn-event-threshold", 5_000_000, "Full-table mode: log a memory warning when a table's reconstruct window exceeds this many events (full-table reconstruct holds them all in RAM, #654; 0 disables)")
 	AddDuckDBTuningFlags(reconstructCmd)
 	BindCommandEnv(reconstructCmd)
 
@@ -452,6 +454,9 @@ func runReconstructFullTable(cmd *cobra.Command, start time.Time) error {
 	if err != nil {
 		return fmt.Errorf("--chunk-size: %w", err)
 	}
+	if recWarnEvents < 0 {
+		return fmt.Errorf("--warn-event-threshold must be >= 0 (0 disables)")
+	}
 
 	// ── Parse --tables (comma-separated schema.table list) ────────────────
 	tables := splitAndTrim(recTables, ",")
@@ -477,15 +482,16 @@ func runReconstructFullTable(cmd *cobra.Command, start time.Time) error {
 
 	// ── Run ────────────────────────────────────────────────────────────────
 	cfg := reconstruct.FullTableConfig{
-		IndexDSN:       recIndexDSN,
-		BaselineSrc:    baselineSrc,
-		Tables:         tables,
-		At:             at,
-		OutputDir:      recOutputDir,
-		ChunkSize:      chunkSize,
-		Parallelism:    recParallelism,
-		AllowGaps:      recAllowGaps,
-		ArchiveFetcher: TunedArchiveFetcher(duckTuning),
+		IndexDSN:           recIndexDSN,
+		BaselineSrc:        baselineSrc,
+		Tables:             tables,
+		At:                 at,
+		OutputDir:          recOutputDir,
+		ChunkSize:          chunkSize,
+		Parallelism:        recParallelism,
+		AllowGaps:          recAllowGaps,
+		WarnEventThreshold: recWarnEvents,
+		ArchiveFetcher:     TunedArchiveFetcher(duckTuning),
 	}
 	reports, err := reconstruct.ReconstructTables(cmd.Context(), cfg)
 	if err != nil {

--- a/internal/cli/recover.go
+++ b/internal/cli/recover.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -51,24 +52,25 @@ Examples:
 }
 
 var (
-	rIndexDSN   string
-	rSchema     string
-	rTable      string
-	rPK         string
-	rPKs        []string
-	rLimitPerPK int
-	rEventType  string
-	rGTID       string
-	rSince      string
-	rUntil      string
-	rFlag       string
-	rOutput     string
-	rDryRun     bool
-	rLimit      int
-	rProfile    string
-	rFormat     string
-	rNoArchive  bool
-	rColumnEq   []string
+	rIndexDSN       string
+	rSchema         string
+	rTable          string
+	rPK             string
+	rPKs            []string
+	rLimitPerPK     int
+	rEventType      string
+	rGTID           string
+	rSince          string
+	rUntil          string
+	rFlag           string
+	rOutput         string
+	rDryRun         bool
+	rLimit          int
+	rProfile        string
+	rFormat         string
+	rNoArchive      bool
+	rColumnEq       []string
+	rMaxScriptBytes string
 )
 
 func init() {
@@ -90,6 +92,7 @@ func init() {
 	recoverCmd.Flags().StringVar(&rProfile, "profile", "", "Apply RBAC access rules for this profile (table-level deny and column-level redaction)")
 	recoverCmd.Flags().StringVar(&rFormat, "format", "text", "Output format: text or json")
 	recoverCmd.Flags().BoolVar(&rNoArchive, "no-archive", false, "Disable auto-routing to Parquet archives (MySQL-only results)")
+	recoverCmd.Flags().StringVar(&rMaxScriptBytes, "max-script-bytes", "2GB", "Refuse to generate a reversal script whose estimated row payload exceeds this size (e.g. 512MB, 4GB; 0 = unlimited). Guards against OOM on BLOB/TEXT-heavy recoveries (#654).")
 	AddDuckDBTuningFlags(recoverCmd)
 	_ = recoverCmd.MarkFlagRequired("index-dsn")
 	BindCommandEnv(recoverCmd)
@@ -145,6 +148,10 @@ func runRecover(cmd *cobra.Command, args []string) error {
 	until, err := cliutil.ParseTime(rUntil)
 	if err != nil {
 		return fmt.Errorf("--until: %w", err)
+	}
+	maxScriptBytes, err := cliutil.ParseByteSize(rMaxScriptBytes)
+	if err != nil {
+		return fmt.Errorf("invalid --max-script-bytes: %w", err)
 	}
 
 	opts := query.Options{
@@ -257,6 +264,10 @@ func runRecover(cmd *cobra.Command, args []string) error {
 	// and standard-conforming-string escaping; MySQL/MariaDB keep the default. The
 	// read is best-effort and defaults to MySQL (see recovery.DialectForIndex).
 	gen := recovery.NewForDialect(db, resolver, recovery.DialectForIndex(db))
+	// Bound the in-memory reversal script (#654): refuse before rendering when
+	// the matched events would render past the budget, rather than buffering a
+	// multi-GB script. 0 (from --max-script-bytes 0) disables the guard.
+	gen.SetMaxScriptBytes(maxScriptBytes)
 
 	if rDryRun {
 		if rFormat == "json" {
@@ -264,7 +275,7 @@ func runRecover(cmd *cobra.Command, args []string) error {
 			var buf bytes.Buffer
 			n, err := gen.GenerateSQLFromRows(rows, &buf)
 			if err != nil {
-				return err
+				return wrapScriptBudget(err)
 			}
 			slog.Info("recovery SQL generated",
 				"statements", n, "dry_run", true,
@@ -278,7 +289,7 @@ func runRecover(cmd *cobra.Command, args []string) error {
 
 		n, err := gen.GenerateSQLFromRows(rows, os.Stdout)
 		if err != nil {
-			return err
+			return wrapScriptBudget(err)
 		}
 		slog.Info("recovery SQL generated",
 			"statements", n, "dry_run", true,
@@ -302,7 +313,7 @@ func runRecover(cmd *cobra.Command, args []string) error {
 	bw := bufio.NewWriter(f)
 	n, err := gen.GenerateSQLFromRows(rows, bw)
 	if err != nil {
-		return err
+		return wrapScriptBudget(err)
 	}
 	if err := bw.Flush(); err != nil {
 		return fmt.Errorf("failed to flush output file: %w", err)
@@ -329,4 +340,18 @@ func runRecover(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(os.Stderr, "Warning: results truncated at %d rows. Use a narrower time range or --limit to adjust.\n", rLimit)
 	}
 	return nil
+}
+
+// wrapScriptBudget adds recover-CLI-specific guidance to a recovery
+// ScriptBudgetError (#654); any other error passes through unchanged. The typed
+// error already states the sizes; this names the knobs the operator can turn.
+func wrapScriptBudget(err error) error {
+	var be *recovery.ScriptBudgetError
+	if errors.As(err, &be) {
+		return fmt.Errorf("%w. Narrow the recovery with --since/--until, a specific --pk/--pks, or a smaller "+
+			"--limit (default 1000 events); or raise the budget with --max-script-bytes (e.g. 4GB) or "+
+			"BINTRAIL_RECOVER_MAX_BYTES (0 = unlimited). Note: --limit bounds the event count; this budget "+
+			"guards the rendered script size, not the initial fetch", err)
+	}
+	return err
 }

--- a/internal/cli/recover.go
+++ b/internal/cli/recover.go
@@ -92,7 +92,7 @@ func init() {
 	recoverCmd.Flags().StringVar(&rProfile, "profile", "", "Apply RBAC access rules for this profile (table-level deny and column-level redaction)")
 	recoverCmd.Flags().StringVar(&rFormat, "format", "text", "Output format: text or json")
 	recoverCmd.Flags().BoolVar(&rNoArchive, "no-archive", false, "Disable auto-routing to Parquet archives (MySQL-only results)")
-	recoverCmd.Flags().StringVar(&rMaxScriptBytes, "max-script-bytes", "2GB", "Refuse to generate a reversal script whose estimated row payload exceeds this size (e.g. 512MB, 4GB; 0 = unlimited). Guards against OOM on BLOB/TEXT-heavy recoveries (#654).")
+	recoverCmd.Flags().StringVar(&rMaxScriptBytes, "max-script-bytes", "2GB", "Refuse to generate a reversal script whose estimated row payload exceeds this size (e.g. 512MB, 4GB; 0 = unlimited). Bounds the rendered-script memory spike on BLOB/TEXT-heavy recoveries (#654).")
 	AddDuckDBTuningFlags(recoverCmd)
 	_ = recoverCmd.MarkFlagRequired("index-dsn")
 	BindCommandEnv(recoverCmd)

--- a/internal/reconstruct/fulltable.go
+++ b/internal/reconstruct/fulltable.go
@@ -104,6 +104,21 @@ func shouldWarnEvents(n, threshold int64) bool {
 	return threshold > 0 && n > threshold
 }
 
+// maybeWarnEventVolume emits the #654 large-window memory warning when the
+// fetched event count exceeds threshold (0 disables). Extracted from
+// ReconstructTable so the emission — not just the predicate — is unit-testable.
+func maybeWarnEventVolume(schema, table string, n int, threshold int64) {
+	if !shouldWarnEvents(int64(n), threshold) {
+		return
+	}
+	slog.Warn("reconstruct: very large event window — full-table reconstruct holds every event "+
+		"plus one change-map entry per touched row in memory and may exhaust RAM",
+		"schema", schema, "table", table,
+		"events", n, "threshold", threshold,
+		"hint", "narrow the window with a later --at or a fresher baseline snapshot, or raise/silence "+
+			"via --warn-event-threshold / BINTRAIL_RECONSTRUCT_WARN_EVENTS (0 disables)")
+}
+
 // ReconstructTables runs ReconstructTable concurrently for every entry in
 // cfg.Tables, sharing a single *sql.DB + *query.Engine + *metadata.Resolver.
 // Returns the list of reports in arbitrary order plus a joined error
@@ -389,21 +404,12 @@ func ReconstructTable(
 	}
 	rep.EventsApplied = int64(len(events))
 
-	// Large-window memory warning (#654). Full-table reconstruct holds the whole
-	// event slice plus one change-map entry per touched PK in RAM. len(events) is
-	// the real, archive-inclusive count (FetchMerged already merged live + Parquet),
-	// so no separate COUNT is needed — a live-only COUNT would undercount archived
-	// partitions. Advisory only: it fires before the change-map build below and
-	// tells the operator to narrow the next run; it cannot shrink the already-resident
+	// Large-window memory warning (#654). len(events) is the real, archive-inclusive
+	// count (FetchMerged already merged live + Parquet), so no separate COUNT is
+	// needed. Advisory only: it fires before the change-map build below and tells
+	// the operator to narrow the next run; it cannot shrink the already-resident
 	// slice (reconstruct warns, never refuses — the OOM at scale is unreproduced).
-	if shouldWarnEvents(int64(len(events)), cfg.WarnEventThreshold) {
-		slog.Warn("reconstruct: very large event window — full-table reconstruct holds every event "+
-			"plus one change-map entry per touched row in memory and may exhaust RAM",
-			"schema", schema, "table", table,
-			"events", len(events), "threshold", cfg.WarnEventThreshold,
-			"hint", "narrow the window with a later --at or a fresher baseline snapshot, or raise/silence "+
-				"via --warn-event-threshold / BINTRAIL_RECONSTRUCT_WARN_EVENTS (0 disables)")
-	}
+	maybeWarnEventVolume(schema, table, len(events), cfg.WarnEventThreshold)
 
 	// ENUM/SET ordinals → labels (#476), each delta decoded with the
 	// snapshot in effect at its event time (#475). Must run before the

--- a/internal/reconstruct/fulltable.go
+++ b/internal/reconstruct/fulltable.go
@@ -71,6 +71,13 @@ type FullTableConfig struct {
 	Parallelism int       // max concurrent tables (0 → runtime.NumCPU())
 	AllowGaps   bool      // false = strict abort on gaps (default for reconstruct)
 
+	// WarnEventThreshold logs a loud warning when a table's fetched event count
+	// exceeds it: full-table reconstruct holds every event plus one change-map
+	// entry per touched PK in memory and can exhaust RAM at scale (#654). 0 =
+	// disabled — the zero value, so direct library callers stay silent; the CLI
+	// defaults it to 5,000,000 via --warn-event-threshold.
+	WarnEventThreshold int64
+
 	// ArchiveFetcher fetches archived binlog events for a table. nil →
 	// parquetquery.Fetch (the container-safe DuckDB budget). The CLI sets it
 	// to a tuned fetcher under --ultrafast so the flag is honored on the
@@ -88,6 +95,13 @@ type TableReport struct {
 	DeletesSkipped int64 // baseline rows whose PK matched a DELETE event
 	Files          []string
 	Duration       time.Duration
+}
+
+// shouldWarnEvents reports whether a fetched event count should trigger the
+// large-window memory warning (#654). threshold <= 0 disables the warning, so
+// the zero-value FullTableConfig stays silent for direct library callers.
+func shouldWarnEvents(n, threshold int64) bool {
+	return threshold > 0 && n > threshold
 }
 
 // ReconstructTables runs ReconstructTable concurrently for every entry in
@@ -374,6 +388,22 @@ func ReconstructTable(
 		return nil, fmt.Errorf("fetch events: %w", err)
 	}
 	rep.EventsApplied = int64(len(events))
+
+	// Large-window memory warning (#654). Full-table reconstruct holds the whole
+	// event slice plus one change-map entry per touched PK in RAM. len(events) is
+	// the real, archive-inclusive count (FetchMerged already merged live + Parquet),
+	// so no separate COUNT is needed — a live-only COUNT would undercount archived
+	// partitions. Advisory only: it fires before the change-map build below and
+	// tells the operator to narrow the next run; it cannot shrink the already-resident
+	// slice (reconstruct warns, never refuses — the OOM at scale is unreproduced).
+	if shouldWarnEvents(int64(len(events)), cfg.WarnEventThreshold) {
+		slog.Warn("reconstruct: very large event window — full-table reconstruct holds every event "+
+			"plus one change-map entry per touched row in memory and may exhaust RAM",
+			"schema", schema, "table", table,
+			"events", len(events), "threshold", cfg.WarnEventThreshold,
+			"hint", "narrow the window with a later --at or a fresher baseline snapshot, or raise/silence "+
+				"via --warn-event-threshold / BINTRAIL_RECONSTRUCT_WARN_EVENTS (0 disables)")
+	}
 
 	// ENUM/SET ordinals → labels (#476), each delta decoded with the
 	// snapshot in effect at its event time (#475). Must run before the

--- a/internal/reconstruct/warn_test.go
+++ b/internal/reconstruct/warn_test.go
@@ -1,6 +1,61 @@
 package reconstruct
 
-import "testing"
+import (
+	"bytes"
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// TestMaybeWarnEventVolume exercises the warning EMISSION (not just the
+// predicate): a captured slog handler must see exactly one Warn record with the
+// right attributes above threshold, and nothing at/below threshold or disabled.
+func TestMaybeWarnEventVolume(t *testing.T) {
+	cases := []struct {
+		name      string
+		n         int
+		threshold int64
+		wantWarn  bool
+	}{
+		{"above threshold warns", 101, 100, true},
+		{"at threshold silent", 100, 100, false},
+		{"below threshold silent", 99, 100, false},
+		{"disabled (0) silent", 1 << 30, 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			prev := slog.Default()
+			slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+			t.Cleanup(func() { slog.SetDefault(prev) })
+
+			maybeWarnEventVolume("db", "orders", tc.n, tc.threshold)
+			out := buf.String()
+
+			if !tc.wantWarn {
+				if strings.Contains(out, "very large event window") {
+					t.Fatalf("expected no warn (n=%d threshold=%d), got %q", tc.n, tc.threshold, out)
+				}
+				return
+			}
+			if c := strings.Count(out, "very large event window"); c != 1 {
+				t.Fatalf("want exactly one warn record, got %d: %q", c, out)
+			}
+			for _, want := range []string{
+				`"schema":"db"`,
+				`"table":"orders"`,
+				fmt.Sprintf(`"events":%d`, tc.n),
+				fmt.Sprintf(`"threshold":%d`, tc.threshold),
+				"--warn-event-threshold",
+			} {
+				if !strings.Contains(out, want) {
+					t.Errorf("warn record missing %s:\n%s", want, out)
+				}
+			}
+		})
+	}
+}
 
 func TestShouldWarnEvents(t *testing.T) {
 	const thr = 5_000_000

--- a/internal/reconstruct/warn_test.go
+++ b/internal/reconstruct/warn_test.go
@@ -1,0 +1,27 @@
+package reconstruct
+
+import "testing"
+
+func TestShouldWarnEvents(t *testing.T) {
+	const thr = 5_000_000
+	cases := []struct {
+		name      string
+		n         int64
+		threshold int64
+		want      bool
+	}{
+		{"below threshold", thr - 1, thr, false},
+		{"at threshold", thr, thr, false},
+		{"above threshold", thr + 1, thr, true},
+		{"threshold 0 disables", 1 << 40, 0, false},
+		{"threshold negative disables", 1 << 40, -1, false},
+		{"zero events never warns", 0, thr, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldWarnEvents(tc.n, tc.threshold); got != tc.want {
+				t.Fatalf("shouldWarnEvents(%d,%d) = %v, want %v", tc.n, tc.threshold, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/recovery/budget_test.go
+++ b/internal/recovery/budget_test.go
@@ -39,12 +39,13 @@ func TestEstimateScriptBytes(t *testing.T) {
 			wantMax: (1 << 20) + 1<<10,
 		},
 		{
-			// The bug fix (#654 review): a reverse UPDATE renders the BEFORE
-			// image only, so the fat after image must NOT inflate the estimate.
-			name:    "update ignores the after image",
+			// A reverse UPDATE renders SET(before) + WHERE(after) (buildUpdate
+			// keys the WHERE on row_after), so the fat after image MUST count —
+			// under-counting it would let an oversized UPDATE script slip the guard.
+			name:    "update counts both images (SET before + WHERE after)",
 			rows:    []query.ResultRow{{EventType: event.EventUpdate, PKValues: "1", RowBefore: map[string]any{"k": "v"}, RowAfter: map[string]any{"blob": big}}},
-			wantMin: 1,
-			wantMax: 1024, // only the tiny before image + PK, NOT the 1 MiB after image
+			wantMin: 1 << 20, // the 1 MiB after image is counted (WHERE clause)
+			wantMax: (1 << 20) + 1<<10,
 		},
 		{
 			name: "N deletes roughly N times one",

--- a/internal/recovery/budget_test.go
+++ b/internal/recovery/budget_test.go
@@ -1,0 +1,153 @@
+package recovery
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/event"
+	"github.com/dbtrail/dbtrail/internal/query"
+)
+
+func TestEstimateScriptBytes(t *testing.T) {
+	big := strings.Repeat("x", 1<<20) // 1 MiB string value (e.g. a base64 BLOB)
+
+	cases := []struct {
+		name    string
+		rows    []query.ResultRow
+		wantMin int64 // estimate must be at least this (floor properties)
+		wantMax int64 // and at most this (no wild over-count)
+	}{
+		{name: "empty", rows: nil, wantMin: 0, wantMax: 0},
+		{
+			name:    "small narrow row",
+			rows:    []query.ResultRow{{PKValues: "1", RowAfter: map[string]any{"id": float64(1), "name": "ann"}}},
+			wantMin: 1,    // at least the PK + "name"+"ann" bytes
+			wantMax: 1024, // nowhere near a KB
+		},
+		{
+			name:    "one BLOB-heavy row dominates",
+			rows:    []query.ResultRow{{PKValues: "7", RowAfter: map[string]any{"id": float64(7), "blob": big}}},
+			wantMin: 1 << 20,             // at least the big value
+			wantMax: (1 << 20) + 1<<10,   // big value + small constant overhead
+		},
+		{
+			name: "N rows roughly N times one",
+			rows: []query.ResultRow{
+				{PKValues: "1", RowAfter: map[string]any{"blob": big}},
+				{PKValues: "2", RowAfter: map[string]any{"blob": big}},
+				{PKValues: "3", RowAfter: map[string]any{"blob": big}},
+			},
+			wantMin: 3 << 20,
+			wantMax: (3 << 20) + 1<<10,
+		},
+		{
+			name:    "before-image counted too",
+			rows:    []query.ResultRow{{PKValues: "1", RowBefore: map[string]any{"blob": big}, RowAfter: map[string]any{"blob": big}}},
+			wantMin: 2 << 20, // both images summed
+			wantMax: (2 << 20) + 1<<10,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := EstimateScriptBytes(tc.rows)
+			if got < tc.wantMin || got > tc.wantMax {
+				t.Fatalf("EstimateScriptBytes = %d, want in [%d, %d]", got, tc.wantMin, tc.wantMax)
+			}
+		})
+	}
+}
+
+// TestEstimateScriptBytes_monotonic confirms adding rows never lowers the estimate.
+func TestEstimateScriptBytes_monotonic(t *testing.T) {
+	row := query.ResultRow{PKValues: "1", RowAfter: map[string]any{"blob": strings.Repeat("y", 4096)}}
+	var prev int64 = -1
+	for n := 0; n <= 5; n++ {
+		rows := make([]query.ResultRow, n)
+		for i := range rows {
+			rows[i] = row
+		}
+		got := EstimateScriptBytes(rows)
+		if got < prev {
+			t.Fatalf("estimate decreased: n=%d got=%d prev=%d", n, got, prev)
+		}
+		prev = got
+	}
+}
+
+// TestGenerateSQLFromRows_budget verifies the fail-loud refusal (#654): over
+// budget GenerateSQLFromRows returns a *ScriptBudgetError and writes NOTHING
+// (refusal before rendering, so no truncated script can reach the writer).
+func TestGenerateSQLFromRows_budget(t *testing.T) {
+	big := strings.Repeat("z", 1<<20) // 1 MiB payload
+	rows := []query.ResultRow{{
+		EventType:  event.EventInsert, // INSERT → DELETE reversal
+		SchemaName: "db",
+		TableName:  "t",
+		PKValues:   "1",
+		RowAfter:   map[string]any{"id": float64(1), "blob": big},
+	}}
+
+	t.Run("over budget refuses before writing", func(t *testing.T) {
+		gen := New(nil, nil) // nil resolver → all-columns fallback (DB-free)
+		gen.SetMaxScriptBytes(1024)
+		var buf bytes.Buffer
+		n, err := gen.GenerateSQLFromRows(rows, &buf)
+		var be *ScriptBudgetError
+		if !errors.As(err, &be) {
+			t.Fatalf("want *ScriptBudgetError, got %v", err)
+		}
+		if n != 0 {
+			t.Fatalf("want 0 statements on refusal, got %d", n)
+		}
+		if buf.Len() != 0 {
+			t.Fatalf("refusal must write nothing, wrote %d bytes", buf.Len())
+		}
+		if be.EstimatedBytes <= be.Budget {
+			t.Fatalf("ScriptBudgetError fields look wrong: est=%d budget=%d", be.EstimatedBytes, be.Budget)
+		}
+	})
+
+	t.Run("budget 0 disables the guard", func(t *testing.T) {
+		gen := New(nil, nil)
+		gen.SetMaxScriptBytes(0) // unlimited
+		var buf bytes.Buffer
+		_, err := gen.GenerateSQLFromRows(rows, &buf)
+		var be *ScriptBudgetError
+		if errors.As(err, &be) {
+			t.Fatalf("budget 0 must not trip the guard, got %v", err)
+		}
+	})
+
+	t.Run("under budget renders", func(t *testing.T) {
+		small := []query.ResultRow{{
+			EventType:  event.EventInsert,
+			SchemaName: "db",
+			TableName:  "t",
+			PKValues:   "1",
+			RowAfter:   map[string]any{"id": float64(1), "name": "ann"},
+		}}
+		gen := New(nil, nil)
+		gen.SetMaxScriptBytes(DefaultMaxScriptBytes)
+		var buf bytes.Buffer
+		n, err := gen.GenerateSQLFromRows(small, &buf)
+		if err != nil {
+			t.Fatalf("under budget should render, got %v", err)
+		}
+		if n != 1 || buf.Len() == 0 {
+			t.Fatalf("want 1 statement and non-empty output, got n=%d len=%d", n, buf.Len())
+		}
+	})
+}
+
+func TestScriptBudgetError_message(t *testing.T) {
+	e := &ScriptBudgetError{EstimatedBytes: 3 << 30, Budget: 2 << 30}
+	msg := e.Error()
+	for _, want := range []string{"refusing", "3.00GB", "2.00GB", "budget"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message missing %q: %s", want, msg)
+		}
+	}
+}

--- a/internal/recovery/budget_test.go
+++ b/internal/recovery/budget_test.go
@@ -16,37 +16,45 @@ func TestEstimateScriptBytes(t *testing.T) {
 	cases := []struct {
 		name    string
 		rows    []query.ResultRow
-		wantMin int64 // estimate must be at least this (floor properties)
+		wantMin int64 // estimate must be at least this
 		wantMax int64 // and at most this (no wild over-count)
 	}{
 		{name: "empty", rows: nil, wantMin: 0, wantMax: 0},
 		{
-			name:    "small narrow row",
-			rows:    []query.ResultRow{{PKValues: "1", RowAfter: map[string]any{"id": float64(1), "name": "ann"}}},
+			name:    "small narrow insert",
+			rows:    []query.ResultRow{{EventType: event.EventInsert, PKValues: "1", RowAfter: map[string]any{"id": float64(1), "name": "ann"}}},
 			wantMin: 1,    // at least the PK + "name"+"ann" bytes
 			wantMax: 1024, // nowhere near a KB
 		},
 		{
-			name:    "one BLOB-heavy row dominates",
-			rows:    []query.ResultRow{{PKValues: "7", RowAfter: map[string]any{"id": float64(7), "blob": big}}},
-			wantMin: 1 << 20,             // at least the big value
-			wantMax: (1 << 20) + 1<<10,   // big value + small constant overhead
+			name:    "delete counts the before image (the rendered INSERT)",
+			rows:    []query.ResultRow{{EventType: event.EventDelete, PKValues: "7", RowBefore: map[string]any{"id": float64(7), "blob": big}}},
+			wantMin: 1 << 20,
+			wantMax: (1 << 20) + 1<<10,
 		},
 		{
-			name: "N rows roughly N times one",
+			name:    "insert counts the after image (conservative WHERE bound)",
+			rows:    []query.ResultRow{{EventType: event.EventInsert, PKValues: "7", RowAfter: map[string]any{"id": float64(7), "blob": big}}},
+			wantMin: 1 << 20,
+			wantMax: (1 << 20) + 1<<10,
+		},
+		{
+			// The bug fix (#654 review): a reverse UPDATE renders the BEFORE
+			// image only, so the fat after image must NOT inflate the estimate.
+			name:    "update ignores the after image",
+			rows:    []query.ResultRow{{EventType: event.EventUpdate, PKValues: "1", RowBefore: map[string]any{"k": "v"}, RowAfter: map[string]any{"blob": big}}},
+			wantMin: 1,
+			wantMax: 1024, // only the tiny before image + PK, NOT the 1 MiB after image
+		},
+		{
+			name: "N deletes roughly N times one",
 			rows: []query.ResultRow{
-				{PKValues: "1", RowAfter: map[string]any{"blob": big}},
-				{PKValues: "2", RowAfter: map[string]any{"blob": big}},
-				{PKValues: "3", RowAfter: map[string]any{"blob": big}},
+				{EventType: event.EventDelete, PKValues: "1", RowBefore: map[string]any{"blob": big}},
+				{EventType: event.EventDelete, PKValues: "2", RowBefore: map[string]any{"blob": big}},
+				{EventType: event.EventDelete, PKValues: "3", RowBefore: map[string]any{"blob": big}},
 			},
 			wantMin: 3 << 20,
 			wantMax: (3 << 20) + 1<<10,
-		},
-		{
-			name:    "before-image counted too",
-			rows:    []query.ResultRow{{PKValues: "1", RowBefore: map[string]any{"blob": big}, RowAfter: map[string]any{"blob": big}}},
-			wantMin: 2 << 20, // both images summed
-			wantMax: (2 << 20) + 1<<10,
 		},
 	}
 
@@ -62,7 +70,7 @@ func TestEstimateScriptBytes(t *testing.T) {
 
 // TestEstimateScriptBytes_monotonic confirms adding rows never lowers the estimate.
 func TestEstimateScriptBytes_monotonic(t *testing.T) {
-	row := query.ResultRow{PKValues: "1", RowAfter: map[string]any{"blob": strings.Repeat("y", 4096)}}
+	row := query.ResultRow{EventType: event.EventInsert, PKValues: "1", RowAfter: map[string]any{"blob": strings.Repeat("y", 4096)}}
 	var prev int64 = -1
 	for n := 0; n <= 5; n++ {
 		rows := make([]query.ResultRow, n)

--- a/internal/recovery/budget_test.go
+++ b/internal/recovery/budget_test.go
@@ -57,6 +57,17 @@ func TestEstimateScriptBytes(t *testing.T) {
 			wantMin: 3 << 20,
 			wantMax: (3 << 20) + 1<<10,
 		},
+		{
+			// A fat JSON column decodes to nested maps/arrays (the #652 class);
+			// the estimator must recurse into them, not fall to the 16-byte
+			// scalar default, or it under-counts the exact payload #654 targets.
+			name: "nested JSON column recurses (map + array)",
+			rows: []query.ResultRow{{EventType: event.EventDelete, PKValues: "1", RowBefore: map[string]any{
+				"doc": map[string]any{"a": big, "b": []any{big, "x"}},
+			}}},
+			wantMin: 2 << 20, // both nested 1 MiB values counted via recursion
+			wantMax: (2 << 20) + 1<<10,
+		},
 	}
 
 	for _, tc := range cases {
@@ -66,6 +77,20 @@ func TestEstimateScriptBytes(t *testing.T) {
 				t.Fatalf("EstimateScriptBytes = %d, want in [%d, %d]", got, tc.wantMin, tc.wantMax)
 			}
 		})
+	}
+}
+
+// TestNewDefaultsBudget pins the zero-config guard (#654): New / NewForDialect
+// must seed maxScriptBytes with DefaultMaxScriptBytes. The MCP recover tool, the
+// console, and recover-cascade never call SetMaxScriptBytes, so if a constructor
+// stopped defaulting the field (zero value = unlimited) the guard would silently
+// vanish for them while every SetMaxScriptBytes-using test still passed.
+func TestNewDefaultsBudget(t *testing.T) {
+	if got := New(nil, nil).maxScriptBytes; got != DefaultMaxScriptBytes {
+		t.Errorf("New() maxScriptBytes = %d, want DefaultMaxScriptBytes (%d)", got, DefaultMaxScriptBytes)
+	}
+	if got := NewForDialect(nil, nil, PostgresDialect).maxScriptBytes; got != DefaultMaxScriptBytes {
+		t.Errorf("NewForDialect() maxScriptBytes = %d, want DefaultMaxScriptBytes (%d)", got, DefaultMaxScriptBytes)
 	}
 }
 

--- a/internal/recovery/recovery.go
+++ b/internal/recovery/recovery.go
@@ -93,6 +93,22 @@ const DefaultMaxScriptBytes int64 = 2 << 30
 // sets it from --max-script-bytes; other callers keep DefaultMaxScriptBytes.
 func (g *Generator) SetMaxScriptBytes(n int64) { g.maxScriptBytes = n }
 
+// CheckScriptBudget returns a *ScriptBudgetError when rendering rows would exceed
+// the configured script-size budget (#654), or nil when within budget (or the
+// budget is disabled). GenerateSQLFromRows calls it before rendering; callers
+// that write their own preamble BEFORE GenerateSQLFromRows — e.g.
+// cascaderecover.EmitSQL — call it first so a refusal writes nothing instead of
+// leaving a dangling header (and, for cascade, a `SET FOREIGN_KEY_CHECKS=0`).
+func (g *Generator) CheckScriptBudget(rows []query.ResultRow) error {
+	if g.maxScriptBytes <= 0 {
+		return nil
+	}
+	if est := EstimateScriptBytes(rows); est > g.maxScriptBytes {
+		return &ScriptBudgetError{EstimatedBytes: est, Budget: g.maxScriptBytes}
+	}
+	return nil
+}
+
 // DialectForFlavor maps a stream_state.flavor value to the recovery SQL dialect.
 // PostgreSQL gets its own dialect; MySQL, MariaDB, and an empty/unknown flavor all
 // use MySQL (the established default — MariaDB recovery SQL is MySQL-dialect). It
@@ -185,10 +201,8 @@ func (g *Generator) GenerateSQLFromRows(rows []query.ResultRow, w io.Writer) (in
 	// silently-wrong recovery — the same fail-loud stance as the schema-drift
 	// refusal below. The bound is on the rendered payload, not the initial fetch
 	// (the events are already loaded, row-count-bounded by --limit).
-	if g.maxScriptBytes > 0 {
-		if est := EstimateScriptBytes(rows); est > g.maxScriptBytes {
-			return 0, &ScriptBudgetError{EstimatedBytes: est, Budget: g.maxScriptBytes}
-		}
+	if err := g.CheckScriptBudget(rows); err != nil {
+		return 0, err
 	}
 
 	// Reverse so the most-recent event is undone first.

--- a/internal/recovery/recovery.go
+++ b/internal/recovery/recovery.go
@@ -307,39 +307,28 @@ func (e *ScriptBudgetError) Error() string {
 		humanizeBytes(e.EstimatedBytes), humanizeBytes(e.Budget))
 }
 
-// EstimateScriptBytes approximates the row payload GenerateSQLFromRows will
-// render into the in-memory script buffer, per event type — matching what the
-// reversal actually emits, NOT the full resident row:
-//
-//   - DELETE → INSERT renders the before image (the row to restore) → RowBefore.
-//   - UPDATE → reverse UPDATE renders the before image in SET + the key → RowBefore
-//     (the after image is never rendered, so it is NOT counted).
-//   - INSERT → DELETE renders only a WHERE clause; with a known PK that is just
-//     the key, but without a resolver it falls back to the whole after image, so
-//     RowAfter is counted as the conservative upper bound.
-//
-// For DELETE/UPDATE this is a floor (the rendered SQL adds hex/base64 escaping,
-// identifiers and comments); for a PK-only INSERT→DELETE it is a conservative
-// over-estimate. It walks the already-decoded maps (allocation-free) and targets
-// the GB-scale pathological windows the #654 guard exists for, not byte-exact
-// accounting.
+// EstimateScriptBytes returns a cheap estimate of the row payload
+// GenerateSQLFromRows will render into the in-memory script buffer (#654). It
+// sums the resident before- and after-image bytes plus the PK across every row,
+// walking the already-decoded maps (allocation-free). BOTH images are counted
+// because the reversal can reference either, and a reverse UPDATE references
+// both: DELETE→INSERT renders the before image; INSERT→DELETE renders the after
+// image in its WHERE clause; UPDATE renders the before image in SET AND the after
+// image in WHERE (see buildUpdate/buildDelete — the WHERE keys on row_after, the
+// nil-resolver fallback using every after column). Summing both never
+// under-counts the referenced payload, so the guard fails loud rather than
+// letting an oversized script through. The rendered SQL adds escaping (binary →
+// hex can roughly double a value) plus identifiers and comments, so this is a
+// payload proxy, not byte-exact — adequate for the GB-scale pathological windows
+// the guard targets. (A reverse DELETE of an INSERT whose PK is known renders
+// only the key, so this is then a conservative over-estimate — the safe, fail-
+// loud, recoverable direction.)
 func EstimateScriptBytes(rows []query.ResultRow) int64 {
 	var total int64
 	for i := range rows {
 		total += int64(len(rows[i].PKValues))
-		switch rows[i].EventType {
-		case event.EventDelete, event.EventUpdate:
-			// Reversal renders the before image (INSERT values / reverse-UPDATE SET).
-			total += estimateRowBytes(rows[i].RowBefore)
-		case event.EventInsert:
-			// Reversal renders a DELETE WHERE; RowBefore is nil here, so the
-			// after image is the only/largest possible rendered payload.
-			total += estimateRowBytes(rows[i].RowAfter)
-		default:
-			// EventSnapshot and any future type: GenerateSQLFromRows rejects them
-			// at render time, but be conservative and count both images.
-			total += estimateRowBytes(rows[i].RowBefore) + estimateRowBytes(rows[i].RowAfter)
-		}
+		total += estimateRowBytes(rows[i].RowBefore)
+		total += estimateRowBytes(rows[i].RowAfter)
 	}
 	return total
 }

--- a/internal/recovery/recovery.go
+++ b/internal/recovery/recovery.go
@@ -307,19 +307,39 @@ func (e *ScriptBudgetError) Error() string {
 		humanizeBytes(e.EstimatedBytes), humanizeBytes(e.Budget))
 }
 
-// EstimateScriptBytes returns a cheap lower-bound estimate of the row payload
-// GenerateSQLFromRows will render into the in-memory script buffer. It sums the
-// resident PK and before/after image bytes across all rows by walking the
-// already-decoded maps (allocation-free). The rendered SQL (hex/base64 escaping,
-// identifiers, comments) is larger, so this is a floor — adequate for catching
-// the GB-scale pathological windows the #654 guard targets, not byte-exact
+// EstimateScriptBytes approximates the row payload GenerateSQLFromRows will
+// render into the in-memory script buffer, per event type — matching what the
+// reversal actually emits, NOT the full resident row:
+//
+//   - DELETE → INSERT renders the before image (the row to restore) → RowBefore.
+//   - UPDATE → reverse UPDATE renders the before image in SET + the key → RowBefore
+//     (the after image is never rendered, so it is NOT counted).
+//   - INSERT → DELETE renders only a WHERE clause; with a known PK that is just
+//     the key, but without a resolver it falls back to the whole after image, so
+//     RowAfter is counted as the conservative upper bound.
+//
+// For DELETE/UPDATE this is a floor (the rendered SQL adds hex/base64 escaping,
+// identifiers and comments); for a PK-only INSERT→DELETE it is a conservative
+// over-estimate. It walks the already-decoded maps (allocation-free) and targets
+// the GB-scale pathological windows the #654 guard exists for, not byte-exact
 // accounting.
 func EstimateScriptBytes(rows []query.ResultRow) int64 {
 	var total int64
 	for i := range rows {
 		total += int64(len(rows[i].PKValues))
-		total += estimateRowBytes(rows[i].RowBefore)
-		total += estimateRowBytes(rows[i].RowAfter)
+		switch rows[i].EventType {
+		case event.EventDelete, event.EventUpdate:
+			// Reversal renders the before image (INSERT values / reverse-UPDATE SET).
+			total += estimateRowBytes(rows[i].RowBefore)
+		case event.EventInsert:
+			// Reversal renders a DELETE WHERE; RowBefore is nil here, so the
+			// after image is the only/largest possible rendered payload.
+			total += estimateRowBytes(rows[i].RowAfter)
+		default:
+			// EventSnapshot and any future type: GenerateSQLFromRows rejects them
+			// at render time, but be conservative and count both images.
+			total += estimateRowBytes(rows[i].RowBefore) + estimateRowBytes(rows[i].RowAfter)
+		}
 	}
 	return total
 }

--- a/internal/recovery/recovery.go
+++ b/internal/recovery/recovery.go
@@ -53,21 +53,45 @@ type Generator struct {
 	resolver *metadata.Resolver            // default resolver (latest snapshot); may be nil
 	cache    map[uint32]*metadata.Resolver // per-snapshot resolvers, loaded lazily
 	dialect  Dialect
+	// maxScriptBytes bounds the estimated row payload GenerateSQLFromRows will
+	// render before it refuses (#654). 0 = unlimited. Defaults to
+	// DefaultMaxScriptBytes in the constructors so every caller — CLI, the MCP
+	// recover tool, the console, recover-cascade — is guarded with zero config;
+	// the recover CLI overrides it via SetMaxScriptBytes (--max-script-bytes).
+	maxScriptBytes int64
 }
 
 // New creates a Generator emitting MySQL-dialect SQL. resolver may be nil — in that
 // case, WHERE clauses for UPDATE and DELETE reversals will use ALL row columns
 // instead of just PKs.
 func New(db *sql.DB, resolver *metadata.Resolver) *Generator {
-	return &Generator{db: db, resolver: resolver, dialect: MySQLDialect}
+	return &Generator{db: db, resolver: resolver, dialect: MySQLDialect, maxScriptBytes: DefaultMaxScriptBytes}
 }
 
 // NewForDialect is New with an explicit SQL dialect. Callers that know the source
 // flavor (e.g. `bintrail-pg recover` via DialectForIndex) pass PostgresDialect;
 // everything else uses New (MySQL).
 func NewForDialect(db *sql.DB, resolver *metadata.Resolver, dialect Dialect) *Generator {
-	return &Generator{db: db, resolver: resolver, dialect: dialect}
+	return &Generator{db: db, resolver: resolver, dialect: dialect, maxScriptBytes: DefaultMaxScriptBytes}
 }
+
+// DefaultMaxScriptBytes is the default ceiling on the estimated row payload of a
+// reversal script. Above it, GenerateSQLFromRows refuses rather than buffering
+// the whole script into RAM (#654): rendering builds a second full copy on top
+// of the already-resident events, so a multi-gigabyte script roughly doubles
+// peak memory. 2 GiB is deliberately generous — an ordinary recover renders
+// kilobytes to megabytes, and a 2 GiB SQL script is already past being
+// reviewable or appliable; only BLOB/TEXT-heavy windows approach it. The recover
+// CLI exposes --max-script-bytes / BINTRAIL_RECOVER_MAX_BYTES to raise it or set
+// 0 to disable. The bound is on the *rendered script*, not end-to-end memory:
+// the events are fetched (row-count-bounded by --limit) before this runs, so it
+// caps the render doubling, not the initial fetch.
+const DefaultMaxScriptBytes int64 = 2 << 30
+
+// SetMaxScriptBytes overrides the reversal-script payload budget enforced by
+// GenerateSQLFromRows. n <= 0 disables the guard (unlimited). The recover CLI
+// sets it from --max-script-bytes; other callers keep DefaultMaxScriptBytes.
+func (g *Generator) SetMaxScriptBytes(n int64) { g.maxScriptBytes = n }
 
 // DialectForFlavor maps a stream_state.flavor value to the recovery SQL dialect.
 // PostgreSQL gets its own dialect; MySQL, MariaDB, and an empty/unknown flavor all
@@ -152,6 +176,19 @@ func (g *Generator) GenerateSQLFromRows(rows []query.ResultRow, w io.Writer) (in
 	if len(rows) == 0 {
 		fmt.Fprintln(w, "-- No events matched the specified criteria.")
 		return 0, nil
+	}
+
+	// Bound peak memory before rendering (#654). The whole script is buffered
+	// into RAM (body, below) on top of the already-resident events, so a
+	// pathological BLOB/TEXT window roughly doubles peak. Refuse up front rather
+	// than emit a truncated script: a partial reversal applied to production is a
+	// silently-wrong recovery — the same fail-loud stance as the schema-drift
+	// refusal below. The bound is on the rendered payload, not the initial fetch
+	// (the events are already loaded, row-count-bounded by --limit).
+	if g.maxScriptBytes > 0 {
+		if est := EstimateScriptBytes(rows); est > g.maxScriptBytes {
+			return 0, &ScriptBudgetError{EstimatedBytes: est, Budget: g.maxScriptBytes}
+		}
 	}
 
 	// Reverse so the most-recent event is undone first.
@@ -248,6 +285,99 @@ func schemaDriftError(drift map[string]map[string]bool, order []string) error {
 		"snapshot no longer has (dropped or renamed after the event was captured), so the SQL would not apply to "+
 		"the current table: %s. Re-snapshot if the table actually still has these columns; otherwise reconcile the "+
 		"column(s) by hand", strings.Join(parts, "; "))
+}
+
+// ─── Script-size budget (#654) ─────────────────────────────────────────────────
+
+// ScriptBudgetError is returned by GenerateSQLFromRows when the estimated row
+// payload of the matched events exceeds the configured script-size budget
+// (#654). It is a fail-loud refusal, not a truncation: a partial reversal script
+// applied to a production database is a silently-wrong recovery, so recover
+// refuses to emit anything. The recover CLI wraps it with command-specific
+// guidance; the typed fields let other callers report it however they like.
+type ScriptBudgetError struct {
+	EstimatedBytes int64 // estimated row payload to render
+	Budget         int64 // the configured ceiling that was exceeded
+}
+
+func (e *ScriptBudgetError) Error() string {
+	return fmt.Sprintf("recover: refusing to generate the reversal script — the matched events hold ~%s "+
+		"of row data, over the script-size budget of %s. Rendering the SQL would roughly double peak memory "+
+		"(the events are already loaded). Narrow the recovery window, or raise/disable the budget (0 = unlimited)",
+		humanizeBytes(e.EstimatedBytes), humanizeBytes(e.Budget))
+}
+
+// EstimateScriptBytes returns a cheap lower-bound estimate of the row payload
+// GenerateSQLFromRows will render into the in-memory script buffer. It sums the
+// resident PK and before/after image bytes across all rows by walking the
+// already-decoded maps (allocation-free). The rendered SQL (hex/base64 escaping,
+// identifiers, comments) is larger, so this is a floor — adequate for catching
+// the GB-scale pathological windows the #654 guard targets, not byte-exact
+// accounting.
+func EstimateScriptBytes(rows []query.ResultRow) int64 {
+	var total int64
+	for i := range rows {
+		total += int64(len(rows[i].PKValues))
+		total += estimateRowBytes(rows[i].RowBefore)
+		total += estimateRowBytes(rows[i].RowAfter)
+	}
+	return total
+}
+
+func estimateRowBytes(m map[string]any) int64 {
+	var t int64
+	for k, v := range m {
+		t += int64(len(k)) + estimateValueBytes(v)
+	}
+	return t
+}
+
+// estimateValueBytes approximates the in-memory footprint of a JSON-decoded
+// value. Strings ([]byte base64 / TEXT / hex) and json.Number dominate the
+// payload of fat rows, so their exact length is counted; scalars get a small
+// constant. After json.Unmarshal into map[string]any, numbers are float64 (see
+// the codebase's JSON round-trip note), with json.Number covered for UseNumber
+// callers.
+func estimateValueBytes(v any) int64 {
+	switch x := v.(type) {
+	case nil:
+		return 0
+	case string:
+		return int64(len(x))
+	case []byte:
+		return int64(len(x))
+	case json.Number:
+		return int64(len(x))
+	case bool:
+		return 1
+	case float64:
+		return 8
+	case map[string]any:
+		return estimateRowBytes(x)
+	case []any:
+		var t int64
+		for _, e := range x {
+			t += estimateValueBytes(e)
+		}
+		return t
+	default:
+		return 16
+	}
+}
+
+// humanizeBytes formats a byte count with a binary KB/MB/GB suffix, matching the
+// units cliutil.ParseByteSize accepts on the --max-script-bytes flag.
+func humanizeBytes(n int64) string {
+	switch {
+	case n >= 1<<30:
+		return fmt.Sprintf("%.2fGB", float64(n)/(1<<30))
+	case n >= 1<<20:
+		return fmt.Sprintf("%.2fMB", float64(n)/(1<<20))
+	case n >= 1<<10:
+		return fmt.Sprintf("%.2fKB", float64(n)/(1<<10))
+	default:
+		return fmt.Sprintf("%dB", n)
+	}
 }
 
 // ─── Statement generators ─────────────────────────────────────────────────────


### PR DESCRIPTION
## What & why

Closes #654. Three of bintrail's offline read/recover/reconstruct paths loaded their full matching set into the Go heap, bounded only by **row count** (`--limit`), never by **payload size** — so a BLOB/TEXT-heavy or wide-window run could OOM the process. This adds three small, local, break-nothing **guards**. It is the tranche-1 resolution the audit (`drafts/large-data-robustness-audit-2026-06-28.md`) planned: bound/warn/document — **not** a streaming/chunk rearchitecture (deferred, see below).

## The three guards

| Path | Behavior | Knob (default) |
|---|---|---|
| `recover` | **Fail-loud refuse** when the matched events' estimated row payload would exceed the budget, *before* buffering the whole reversal script into RAM (which ~doubles peak on top of the resident events). A truncated reversal script applied to prod is a silently-wrong recovery — so it refuses, never caps/truncates. | `--max-script-bytes` / `BINTRAIL_RECOVER_MAX_BYTES` (**2GB**, `0` = unlimited) |
| `query --limit 0` | **Warn** on stderr that the result is unbounded. `--limit 0` keeps working — it is a live internal contract used by reconstruct/verify/shim. **MCP query tool**: hard **ceiling** on an oversized *explicit* limit (cap + warn), per-tool. | `BINTRAIL_MCP_QUERY_MAX_LIMIT` (**1,000,000 rows**) |
| `reconstruct` full-table | **Warn** (never refuse — the OOM is unreproduced) on the exact, archive-inclusive `len(events)` above the threshold, before the change-map build. | `--warn-event-threshold` / `BINTRAIL_RECONSTRUCT_WARN_EVENTS` (**5,000,000**, `0` disables) |

The recover budget lives on a `recovery.Generator` field defaulted to `DefaultMaxScriptBytes`, so **every** renderer caller — the recover CLI, the MCP recover tool, the console, recover-cascade — is guarded at 2GB with zero config; only the CLI exposes an override flag.

## Design invariants held (verified)

- **`limit=0` stays a live internal contract.** The `--limit 0` warn + MCP ceiling live **only** at the CLI-flag and MCP-arg layers; `query.Engine.Fetch` / `MergeResults` / `FetchMerged` are untouched, so the reconstruct/verify/shim/console/cascade/agent `limit=0` paths are unchanged (`TestMergeResults_zeroLimit` still green).
- **MCP ceiling is per-tool.** Applied in `makeQueryTool` on the local `opts`, **not** in the shared `buildQueryOptions` (which the recover tool also calls — recover must refuse, not cap).

## Honest about what it does *not* do

- **recover is not byte-bounded end-to-end.** The events are fetched (row-count-bounded by `--limit`) and resident *before* the guard runs, so the budget caps the **render doubling**, not the initial fetch. The error message says so.
- **reconstruct's warn is operator *awareness*, not OOM prevention** — the slice is already resident when it fires; it tells you to narrow the *next* run.
- **Deferred (YAGNI until reproduced):** the heavier streaming / chunk-by-PK rearchitecture that would make reconstruct truly memory-bounded. The reconstruct OOM was never reproduced (the demo host has only 3.7GB RAM); the issue's own proposed direction (bound/warn/document) is satisfied. The unbounded escape hatch for large exports stays the `bintrail query` CLI.

## Behavior change

`recover` (CLI, MCP, console, recover-cascade) can now **refuse** with a clear error naming the knob to raise/disable. The default (2GB) trips only on pathological BLOB/TEXT-heavy input. No new console surface is added — those paths inherit the shared-renderer default, intentionally.

## Tests

New table-driven unit tests (no MySQL): `EstimateScriptBytes` per event type + the fail-loud refusal-writes-nothing property (`internal/recovery/budget_test.go`); the MCP `applyQueryCeiling`/`mcpQueryMaxLimit`/cap-supersedes-truncation-notice helpers (`cmd/bintrail-mcp/ceiling_test.go`); the reconstruct warn predicate **and** slog emission (`internal/reconstruct/warn_test.go`); `limitWarning` + `wrapScriptBudget` + the new flag defaults (`internal/cli/memguard_test.go`). New `BINTRAIL_*` vars wired into both `EnvBindings` and `envSections` (the bijection consistency test stays green). `go build ./...`, `go vet`, and the full unit suite pass.

## Process

Scoped + designed by a multi-agent design/verify workflow (one investigator per path + a scope cop), then adversarially reviewed (5 lenses → per-finding refute-or-confirm). The review caught a real over-count; a follow-up advisor pass caught that the first "fix" had inverted it into a *dangerous under-count* for UPDATE (a reverse UPDATE keys its WHERE on `row_after`), now reverted to the correct flat sum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
