### PR TITLE
reconstruct: full-table BLOB/TEXT decode is epoch-aware (#668)

### DIFF
--- a/internal/cli/reconstruct_fulltable_epoch_blobtext_integration_test.go
+++ b/internal/cli/reconstruct_fulltable_epoch_blobtext_integration_test.go
@@ -1,0 +1,193 @@
+//go:build integration
+
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/baseline"
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestRunReconstruct_fullTable_blobTextEpochDrift is the end-to-end regression
+// for #668: the full-table reconstruct writer path must type each delta
+// event's BLOB/TEXT decode columns from the schema snapshot in effect AT THE
+// EVENT'S TIMESTAMP, not from the latest snapshot. Before the fix,
+// ReconstructTable resolved the decode-column set once from the latest
+// snapshot and applied it to every event regardless of epoch.
+//
+// Repro: `body` starts as VARCHAR (epoch 1, delivered as a plain Go string by
+// go-mysql — never base64-encoded at storage time) and is later widened to
+// TEXT (epoch 2, delivered as []byte — base64-encoded at storage time, #668's
+// own "VARCHAR→TEXT" example). An old event captured under epoch 1 stores its
+// plain string "test" — which happens to be valid base64 — verbatim. A new
+// event captured under epoch 2 stores its TEXT value base64-encoded. Typing
+// both from the latest (epoch 2 / TEXT) snapshot makes the old plain "test"
+// look like a BLOB/TEXT column needing decode, corrupting it to garbage bytes;
+// typing each event by its own epoch (the fix) leaves it untouched and still
+// correctly decodes the new event.
+func TestRunReconstruct_fullTable_blobTextEpochDrift(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	h1 := time.Now().UTC().Add(-48 * time.Hour).Truncate(time.Hour)
+	h2 := h1.Add(time.Hour)
+
+	epoch1TS := h1.Format("2006-01-02 15:04:05")
+	epoch2TS := h2.Format("2006-01-02 15:04:05")
+
+	// Epoch 1 (snapshot_id=1, at h1): body is VARCHAR.
+	testutil.InsertSnapshot(t, db, 1, epoch1TS, "testdb", "orders", "id", 1, "PRI", "int", "NO")
+	testutil.InsertSnapshot(t, db, 1, epoch1TS, "testdb", "orders", "body", 2, "", "varchar", "NO")
+	// Epoch 2 (snapshot_id=2, at h2): body widened to TEXT.
+	testutil.InsertSnapshot(t, db, 2, epoch2TS, "testdb", "orders", "id", 1, "PRI", "int", "NO")
+	testutil.InsertSnapshot(t, db, 2, epoch2TS, "testdb", "orders", "body", 2, "", "text", "NO")
+
+	createSQL := "CREATE TABLE `orders` (\n  `id` INT NOT NULL,\n  `body` TEXT NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;\n"
+
+	baselineDir := t.TempDir()
+	snapshotTSDir := strings.ReplaceAll(h1.Format(time.RFC3339), ":", "-")
+	parquetDir := filepath.Join(baselineDir, snapshotTSDir, "testdb")
+	if err := os.MkdirAll(parquetDir, 0o755); err != nil {
+		t.Fatalf("mkdir baseline: %v", err)
+	}
+	baselinePath := filepath.Join(parquetDir, "orders.parquet")
+
+	cols := []baseline.Column{
+		{Name: "id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
+		{Name: "body", MySQLType: "text", ParquetType: baseline.MysqlToParquetNode("text")},
+	}
+	bw, err := baseline.NewWriter(baselinePath, cols, baseline.WriterConfig{
+		Compression:  "zstd",
+		RowGroupSize: 100,
+		Metadata:     map[string]string{baseline.MetaKeyCreateTableSQL: createSQL},
+	})
+	if err != nil {
+		t.Fatalf("baseline.NewWriter: %v", err)
+	}
+	if err := bw.WriteRow([]string{"1", "base-1"}, []bool{false, false}); err != nil {
+		t.Fatalf("WriteRow: %v", err)
+	}
+	if err := bw.Close(); err != nil {
+		t.Fatalf("writer close: %v", err)
+	}
+
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{h1, h2})
+
+	// id=2 INSERT under epoch 1 (h1+10m): body="test" stored PLAIN — VARCHAR
+	// delivers as a Go string, never base64-encoded — and "test" happens to be
+	// valid base64.
+	ts1 := h1.Add(10 * time.Minute).Format("2006-01-02 15:04:05")
+	testutil.InsertEvent(t, db, "binlog.000001", 100, 200, ts1, nil,
+		"testdb", "orders", 1 /* INSERT */, "2", nil,
+		nil, []byte(`{"id":2,"body":"test"}`))
+
+	// id=3 INSERT under epoch 2 (h2+10m): body stored base64("hello text") —
+	// TEXT delivers as []byte, base64-encoded by marshalRow at storage time.
+	ts2 := h2.Add(10 * time.Minute).Format("2006-01-02 15:04:05")
+	testutil.InsertEvent(t, db, "binlog.000001", 200, 300, ts2, nil,
+		"testdb", "orders", 1 /* INSERT */, "3", nil,
+		nil, []byte(`{"id":3,"body":"aGVsbG8gdGV4dA=="}`))
+
+	orig := captureRecFlags()
+	t.Cleanup(func() { applyRecFlags(orig) })
+	savedOutputFormat := recOutputFormat
+	savedOutputDir := recOutputDir
+	savedTables := recTables
+	savedChunkSize := recChunkSize
+	savedParallelism := recParallelism
+	t.Cleanup(func() {
+		recOutputFormat = savedOutputFormat
+		recOutputDir = savedOutputDir
+		recTables = savedTables
+		recChunkSize = savedChunkSize
+		recParallelism = savedParallelism
+	})
+
+	outputDir := t.TempDir()
+	recIndexDSN = testutil.SnapshotDSN(dbName)
+	recBaselineDir = baselineDir
+	recBaselineS3 = ""
+	recAllowGaps = false
+	recNoArchive = false
+	recOutputFormat = "mydumper"
+	recOutputDir = outputDir
+	recTables = "testdb.orders"
+	recChunkSize = "256MB"
+	recParallelism = 1
+	recAt = h2.Add(30 * time.Minute).Format(time.RFC3339)
+
+	reconstructCmd.SetContext(context.Background())
+	t.Cleanup(func() { reconstructCmd.SetContext(nil) })
+
+	if err := runReconstruct(reconstructCmd, nil); err != nil {
+		t.Fatalf("runReconstruct: %v", err)
+	}
+
+	// ── Apply the dump to a fresh destination and read back the rows ──────
+	testutil.MustExec(t, db, "DROP DATABASE IF EXISTS `testdb`")
+	testutil.MustExec(t, db, "CREATE DATABASE `testdb`")
+	t.Cleanup(func() {
+		testutil.MustExec(t, db, "DROP DATABASE IF EXISTS `testdb`")
+	})
+
+	schemaSQL, err := os.ReadFile(filepath.Join(outputDir, "testdb.orders-schema.sql"))
+	if err != nil {
+		t.Fatalf("read schema file: %v", err)
+	}
+	testutil.MustExec(t, db, "USE `testdb`")
+	testutil.MustExec(t, db, string(schemaSQL))
+
+	chunkSQL, err := os.ReadFile(filepath.Join(outputDir, "testdb.orders.00000.sql"))
+	if err != nil {
+		t.Fatalf("read chunk file: %v", err)
+	}
+	testutil.MustExec(t, db, string(chunkSQL))
+
+	rows, err := db.Query("SELECT id, body FROM `testdb`.`orders` ORDER BY id")
+	if err != nil {
+		t.Fatalf("select restored: %v", err)
+	}
+	defer rows.Close()
+
+	got := map[int]string{}
+	for rows.Next() {
+		var id int
+		var body string
+		if err := rows.Scan(&id, &body); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		got[id] = body
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows.Err: %v", err)
+	}
+
+	want := map[int]string{
+		1: "base-1",     // baseline pass-through, untouched
+		2: "test",       // epoch-1 VARCHAR plain value: must survive untouched, NOT base64-decoded
+		3: "hello text", // epoch-2 TEXT base64 value: must be decoded
+	}
+	for id, w := range want {
+		g, ok := got[id]
+		if !ok {
+			t.Errorf("id=%d: missing from restored rows (got %v)", id, got)
+			continue
+		}
+		if g != w {
+			t.Errorf("id=%d: body = %q, want %q", id, g, w)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("unexpected row count: got %v, want %v", got, want)
+	}
+}

--- a/internal/reconstruct/enumlabels.go
+++ b/internal/reconstruct/enumlabels.go
@@ -63,8 +63,10 @@ func MapEventEnumLabels(db *sql.DB, latest *metadata.Resolver, schema, table str
 // Call this on fetched deltas BEFORE folding them onto a baseline: event images
 // only, never a baseline row (baseline rows are scanned raw from Parquet and
 // must not be decoded — a baseline TEXT value that happens to be valid base64
-// would be corrupted). The full-table merge path has its own decode
-// (decodeChangeBinaries) and must NOT call this — doing so would double-decode.
+// would be corrupted). The full-table merge path (ReconstructTable, #668) calls
+// this too, on the full events slice before its change map is built — callers
+// must call it exactly once per events slice, since decodeStoredBase64 is not
+// idempotent and a second pass would double-decode.
 //
 // Each column is typed at the snapshot in effect at its event's timestamp
 // (#475-style epoch awareness, matching MapEventEnumLabels): whether a value is
@@ -121,9 +123,6 @@ func DecodeEventBinaries(db *sql.DB, schema, table string, events []query.Result
 
 // decodeImageBinaries decodes the storage-side base64 of every BLOB/TEXT column
 // in one event image, in place. No-op when binCols is empty or image is nil.
-// The per-image sibling of decodeChangeBinaries (which decodes a change map's
-// RowAfter); kept separate so the single-row decode never touches the full-table
-// merge path.
 func decodeImageBinaries(image map[string]any, binCols map[string]bool) {
 	if len(binCols) == 0 || image == nil {
 		return

--- a/internal/reconstruct/enumlabels_test.go
+++ b/internal/reconstruct/enumlabels_test.go
@@ -7,8 +7,7 @@ import (
 
 // TestDecodeImageBinaries pins the per-image base64 decode primitive used by
 // DecodeEventBinaries (#666): BLOB → []byte, TEXT → string, NULL stays nil, a
-// non-blob/text column and an absent column are untouched. Sibling of
-// TestDecodeChangeBinaries (the full-table change-map decoder).
+// non-blob/text column and an absent column are untouched.
 func TestDecodeImageBinaries(t *testing.T) {
 	b64 := func(s string) string { return base64.StdEncoding.EncodeToString([]byte(s)) }
 	image := map[string]any{

--- a/internal/reconstruct/fulltable.go
+++ b/internal/reconstruct/fulltable.go
@@ -617,13 +617,15 @@ type mergeStats struct {
 //
 // This is the shared core for both the offline `bintrail reconstruct` writer
 // (mergeBaselineIntoWriter) and the shim full-table _snapshot path
-// (SnapshotFullTableImages), so the two reconstruction surfaces can never drift
-// in the merge ALGORITHM (baseline/event matching, ordering, drain). Per-value
-// decoding is NOT done here — the writer caller's decode happens further
-// upstream, on the full events slice in ReconstructTable, before the Changes
-// map this function drains is even built (DecodeEventBinaries, #668); the
-// shim's SnapshotFullTableImages caller does not decode at all yet (#672), so
-// the two surfaces currently DO diverge on emitted blob/text values.
+// (SnapshotFullTableImages, via runSnapshotFullTable), so the two reconstruction
+// surfaces can never drift in the merge ALGORITHM (baseline/event matching,
+// ordering, drain). Per-value decoding is NOT done here — every caller decodes
+// its own Changes map before it ever reaches this function: the writer caller
+// upstream in ReconstructTable, on the full events slice before the Changes
+// map is even built (DecodeEventBinaries, #668); the shim caller upstream in
+// runSnapshotFullTable, via mapEventImages (#661). `verify`'s two
+// SnapshotFullTableImages callers (reconstructDigest, the --explain drill-down)
+// are the remaining undecoded consumers (#672).
 func mergeBaselineImages(ctx context.Context, in mergeCore, emit func(map[string]any) error) (mergeStats, error) {
 	var stats mergeStats
 

--- a/internal/reconstruct/fulltable.go
+++ b/internal/reconstruct/fulltable.go
@@ -418,6 +418,15 @@ func ReconstructTable(
 	// ordinals.
 	MapEventEnumLabels(db, resolver, schema, table, events)
 
+	// BLOB/TEXT base64 → real value, each delta decoded with the snapshot in
+	// effect at its event time (#668; same epoch-aware approach as the ENUM/SET
+	// pass above and the single-row reconstruct path, #666). Must run before
+	// the merge map is built below so changes' RowAfter images carry decoded
+	// values for free — typing the decode columns from a single latest-snapshot
+	// resolve (the pre-#668 behavior) corrupts a column captured as VARCHAR at
+	// an old epoch and widened to TEXT later.
+	DecodeEventBinaries(db, schema, table, events)
+
 	// ── 5. Build the change map: PK string → last event for that PK ───────
 	// events is already sorted by (event_timestamp, event_id) via
 	// query.MergeResults, so the last write wins naturally.
@@ -444,7 +453,6 @@ func ReconstructTable(
 		Changes:           changes,
 		OutputDir:         cfg.OutputDir,
 		ChunkSize:         cfg.ChunkSize,
-		BinaryCols:        binaryColsFromTableMeta(tm),
 	}, rep); err != nil {
 		return nil, err
 	}
@@ -472,10 +480,6 @@ type mergeInput struct {
 	Changes           map[string]*query.ResultRow
 	OutputDir         string
 	ChunkSize         int64
-	// BinaryCols maps each BLOB/TEXT column to whether it is binary, so
-	// delta-event row_after values (stored base64) are decoded before emission
-	// (#660). nil = nothing to decode.
-	BinaryCols map[string]bool
 }
 
 // mergeBaselineIntoWriter streams the local baseline Parquet via DuckDB,
@@ -534,14 +538,12 @@ func mergeBaselineIntoWriter(ctx context.Context, in mergeInput, rep *TableRepor
 		return err
 	}
 
-	// Decode the BLOB/TEXT base64 of the delta-event after-images up front, on
-	// the Changes map — the one place where every value is unambiguously
-	// event-sourced (loaded from binlog_events JSON, so blob/text are uniformly
-	// base64 strings). This covers BOTH event emit paths in mergeBaselineImages
-	// (the matched-PK emit and the leftover-INSERT drain, both reading
-	// in.Changes) without touching baseline pass-through rows, whose TEXT values
-	// arrive from the DuckDB scan as Go strings and must NOT be decoded (#660).
-	decodeChangeBinaries(in.Changes, in.BinaryCols)
+	// BLOB/TEXT base64 of the delta-event after-images is already decoded by
+	// the caller (DecodeEventBinaries, run epoch-aware over the full events
+	// slice before the Changes map was built, #668) — in.Changes entries alias
+	// those same event structs. Baseline pass-through rows are untouched here:
+	// their TEXT values arrive from the DuckDB scan as Go strings and must NOT
+	// be decoded (#660).
 
 	// emit re-orders each emitted row map into the baseline Parquet column
 	// order the writer was constructed with. For baseline pass-through rows
@@ -988,28 +990,6 @@ func binaryColsFromTableMeta(tm *metadata.TableMeta) map[string]bool {
 	return m
 }
 
-// decodeChangeBinaries decodes the storage-side base64 of BLOB/TEXT columns in
-// every delta event's RowAfter image, in place. Called before the merge, so
-// both event emit paths (matched-PK and leftover-INSERT) write decoded values.
-// In-place mutation matches MapEventEnumLabels, which already rewrites these
-// same RowAfter maps before the merge; nothing reads the pre-decode images
-// afterwards. No-op when binCols is empty.
-func decodeChangeBinaries(changes map[string]*query.ResultRow, binCols map[string]bool) {
-	if len(binCols) == 0 {
-		return
-	}
-	for _, rr := range changes {
-		if rr == nil || rr.RowAfter == nil {
-			continue
-		}
-		for col, binary := range binCols {
-			if v, ok := rr.RowAfter[col]; ok {
-				rr.RowAfter[col] = decodeStoredBase64(v, binary)
-			}
-		}
-	}
-}
-
 // rowAfterOrdered walks colNames and looks up each name in rowAfter (a
 // map[string]any from a binlog event's row_after image), returning a slice
 // of values aligned to the baseline Parquet column order. A baseline column
@@ -1024,8 +1004,8 @@ func decodeChangeBinaries(changes map[string]*query.ResultRow, binCols map[strin
 // here, so it must NOT base64-decode BLOB/TEXT values: a baseline TEXT value is
 // a Go string (DuckDB scans parquet.String() as string) indistinguishable from
 // a base64 event value, and decoding it would corrupt valid-base64 baseline
-// text. Event values are decoded upstream, on the Changes map, before the merge
-// (see decodeChangeBinaries in mergeBaselineIntoWriter, #660).
+// text. Event values are decoded upstream, epoch-aware, before the change map
+// is even built (see DecodeEventBinaries in ReconstructTable, #668).
 func rowAfterOrdered(rowAfter map[string]any, colNames []string, schema, table string) []any {
 	out := make([]any, len(colNames))
 	for i, col := range colNames {

--- a/internal/reconstruct/fulltable.go
+++ b/internal/reconstruct/fulltable.go
@@ -619,9 +619,11 @@ type mergeStats struct {
 // (mergeBaselineIntoWriter) and the shim full-table _snapshot path
 // (SnapshotFullTableImages), so the two reconstruction surfaces can never drift
 // in the merge ALGORITHM (baseline/event matching, ordering, drain). Per-value
-// decoding is NOT done here — the writer caller decodes BLOB/TEXT base64 on the
-// Changes map up front (#660); the shim caller does not yet (#661), so the two
-// surfaces currently DO diverge on emitted blob/text values.
+// decoding is NOT done here — the writer caller's decode happens further
+// upstream, on the full events slice in ReconstructTable, before the Changes
+// map this function drains is even built (DecodeEventBinaries, #668); the
+// shim's SnapshotFullTableImages caller does not decode at all yet (#672), so
+// the two surfaces currently DO diverge on emitted blob/text values.
 func mergeBaselineImages(ctx context.Context, in mergeCore, emit func(map[string]any) error) (mergeStats, error) {
 	var stats mergeStats
 

--- a/internal/reconstruct/fulltable_test.go
+++ b/internal/reconstruct/fulltable_test.go
@@ -134,8 +134,12 @@ func writeBlobTextBaseline(t *testing.T, rows [][]string) string {
 // string), and an already-decoded delta-event TEXT/BLOB (decode now happens
 // upstream, epoch-aware, via DecodeEventBinaries before mergeBaselineIntoWriter
 // ever sees the Changes map — #668) must reach the writer untouched, not
-// decoded a second time. Re-introducing a decode in rowAfterOrdered or
-// mergeBaselineIntoWriter makes this fail.
+// decoded a second time. Re-introducing a decode in rowAfterOrdered makes this
+// fail directly; the delta-event "tx" fixture is itself valid base64 (like the
+// baseline fixture above it) so a reintroduced decode anywhere on the Changes
+// path — e.g. inside mergeBaselineIntoWriter — corrupts it and trips the
+// assertion below too, instead of silently no-op'ing on an already-decoded
+// value that doesn't happen to look like base64.
 func TestMergeBaseline_blobTextProvenance(t *testing.T) {
 	baselinePath := writeBlobTextBaseline(t, [][]string{
 		{"1", "YWJjZA==", "RAW"}, // untouched; tx is valid base64 (of "abcd"); bl bytes "RAW"
@@ -146,8 +150,10 @@ func TestMergeBaseline_blobTextProvenance(t *testing.T) {
 		pkStrForInt(2): {
 			EventType: event.EventInsert,
 			PKValues:  pkStrForInt(2),
-			// Already decoded, as DecodeEventBinaries would leave it.
-			RowAfter: map[string]any{"id": float64(2), "tx": "hello", "bl": []byte("BIN")},
+			// Already decoded, as DecodeEventBinaries would leave it. "test" is
+			// itself valid base64 (decodes to garbage bytes), on purpose: it's
+			// what catches a reintroduced double-decode on this path.
+			RowAfter: map[string]any{"id": float64(2), "tx": "test", "bl": []byte("BIN")},
 		},
 	}
 
@@ -174,8 +180,10 @@ func TestMergeBaseline_blobTextProvenance(t *testing.T) {
 	if strings.Contains(chunk, "'abcd'") {
 		t.Errorf("baseline TEXT was wrongly base64-decoded (corruption, #660):\n%s", chunk)
 	}
-	// Delta event: already-decoded values must reach the writer unchanged.
-	if !strings.Contains(chunk, "(X'42494e', 2, 'hello')") {
+	// Delta event: already-decoded values must reach the writer unchanged. "test"
+	// is valid base64, so a reintroduced decode here would corrupt it — this is
+	// what makes the assertion an actual double-decode regression guard.
+	if !strings.Contains(chunk, "(X'42494e', 2, 'test')") {
 		t.Errorf("delta-event BLOB/TEXT must reach the writer already decoded, got:\n%s", chunk)
 	}
 }

--- a/internal/reconstruct/fulltable_test.go
+++ b/internal/reconstruct/fulltable_test.go
@@ -128,31 +128,26 @@ func writeBlobTextBaseline(t *testing.T, rows [][]string) string {
 	return path
 }
 
-// TestMergeBaseline_blobTextProvenance is the #660 anchor across the derivation
-// seam AND both value branches: BinaryCols is derived through the real
-// binaryColsFromTableMeta(tm) — NOT hand-injected, which is the test-vs-production
-// divergence that let the round-1 bug ship — an UNTOUCHED baseline TEXT whose
-// content is valid base64 must survive VERBATIM (the corruption case, since
-// DuckDB delivers it as a Go string), and a delta-event TEXT/BLOB are decoded
-// (string / X'hex'). Re-introducing a decode in rowAfterOrdered makes this fail.
+// TestMergeBaseline_blobTextProvenance is the #660/#668 anchor across both
+// value branches: an UNTOUCHED baseline TEXT whose content is valid base64
+// must survive VERBATIM (the corruption case, since DuckDB delivers it as a Go
+// string), and an already-decoded delta-event TEXT/BLOB (decode now happens
+// upstream, epoch-aware, via DecodeEventBinaries before mergeBaselineIntoWriter
+// ever sees the Changes map — #668) must reach the writer untouched, not
+// decoded a second time. Re-introducing a decode in rowAfterOrdered or
+// mergeBaselineIntoWriter makes this fail.
 func TestMergeBaseline_blobTextProvenance(t *testing.T) {
 	baselinePath := writeBlobTextBaseline(t, [][]string{
 		{"1", "YWJjZA==", "RAW"}, // untouched; tx is valid base64 (of "abcd"); bl bytes "RAW"
 	})
 	outDir := t.TempDir()
 
-	// Derive the decode set through the production path, not by hand.
-	tm := &metadata.TableMeta{Columns: []metadata.ColumnMeta{
-		{Name: "id", DataType: "int"},
-		{Name: "tx", DataType: "text"},
-		{Name: "bl", DataType: "blob"},
-	}}
-
 	changes := map[string]*query.ResultRow{
 		pkStrForInt(2): {
 			EventType: event.EventInsert,
 			PKValues:  pkStrForInt(2),
-			RowAfter:  map[string]any{"id": float64(2), "tx": "aGVsbG8=", "bl": "QklO"}, // base64("hello"), base64("BIN")
+			// Already decoded, as DecodeEventBinaries would leave it.
+			RowAfter: map[string]any{"id": float64(2), "tx": "hello", "bl": []byte("BIN")},
 		},
 	}
 
@@ -166,7 +161,6 @@ func TestMergeBaseline_blobTextProvenance(t *testing.T) {
 		Changes:           changes,
 		OutputDir:         outDir,
 		ChunkSize:         0,
-		BinaryCols:        binaryColsFromTableMeta(tm),
 	}, rep); err != nil {
 		t.Fatalf("mergeBaselineIntoWriter: %v", err)
 	}
@@ -180,12 +174,9 @@ func TestMergeBaseline_blobTextProvenance(t *testing.T) {
 	if strings.Contains(chunk, "'abcd'") {
 		t.Errorf("baseline TEXT was wrongly base64-decoded (corruption, #660):\n%s", chunk)
 	}
-	// Delta event: BLOB decoded to X'hex', TEXT decoded to a string.
+	// Delta event: already-decoded values must reach the writer unchanged.
 	if !strings.Contains(chunk, "(X'42494e', 2, 'hello')") {
-		t.Errorf("delta-event BLOB/TEXT must be decoded, got:\n%s", chunk)
-	}
-	if strings.Contains(chunk, "'aGVsbG8='") || strings.Contains(chunk, "'QklO'") {
-		t.Errorf("delta-event value was not decoded:\n%s", chunk)
+		t.Errorf("delta-event BLOB/TEXT must reach the writer already decoded, got:\n%s", chunk)
 	}
 }
 

--- a/internal/reconstruct/fulltable_validation_test.go
+++ b/internal/reconstruct/fulltable_validation_test.go
@@ -181,33 +181,6 @@ func TestBinaryColsFromTableMeta(t *testing.T) {
 	}
 }
 
-// TestDecodeChangeBinaries verifies #660: delta-event RowAfter BLOB/TEXT values
-// (base64 strings) are decoded in place (BLOB → []byte, TEXT → string), NULL is
-// left nil, and a non-base64-column value is untouched.
-func TestDecodeChangeBinaries(t *testing.T) {
-	rr := &query.ResultRow{RowAfter: map[string]any{
-		"id": float64(1),
-		"bl": "QklOAEJMT0I=",     // base64("BIN\0BLOB")
-		"tx": "aGVsbG8gdGV4dA==", // base64("hello text")
-		"bn": nil,                // NULL blob stays NULL
-	}}
-	changes := map[string]*query.ResultRow{"1": rr}
-	decodeChangeBinaries(changes, map[string]bool{"bl": true, "tx": false, "bn": true})
-
-	if got, ok := rr.RowAfter["bl"].([]byte); !ok || string(got) != "BIN\x00BLOB" {
-		t.Errorf("bl: expected decoded []byte \"BIN\\0BLOB\", got %T %v", rr.RowAfter["bl"], rr.RowAfter["bl"])
-	}
-	if got, ok := rr.RowAfter["tx"].(string); !ok || got != "hello text" {
-		t.Errorf("tx: expected decoded string \"hello text\", got %T %v", rr.RowAfter["tx"], rr.RowAfter["tx"])
-	}
-	if rr.RowAfter["bn"] != nil {
-		t.Errorf("bn: NULL must stay nil, got %v", rr.RowAfter["bn"])
-	}
-	if rr.RowAfter["id"] != float64(1) {
-		t.Errorf("id: non-blob/text column must be untouched, got %v", rr.RowAfter["id"])
-	}
-}
-
 // readFileInfo wraps os.Stat; kept tiny for test readability.
 func readFileInfo(path string) (fileInfoLike, error) {
 	return os.Stat(path)

--- a/internal/shim/handler.go
+++ b/internal/shim/handler.go
@@ -1051,7 +1051,7 @@ func (h *Handler) mapEventImages(schema, table string, rows []query.ResultRow) {
 		m.MapImage(rows[i].RowAfter)
 		// Decode AFTER the ENUM/SET map: the two passes touch disjoint columns
 		// (ENUM/SET are never BLOB/TEXT), so order is immaterial, but keeping the
-		// base64 decode last mirrors reconstruct.decodeChangeBinaries running
+		// base64 decode last mirrors reconstruct.DecodeEventBinaries running
 		// after MapEventEnumLabels. Event images only — never a baseline row, so
 		// _snapshot decodes its deltas pre-merge and never double-decodes the
 		// baseline value DuckDB scans straight to a Go string.


### PR DESCRIPTION
closes #668

## Summary
- `ReconstructTable`'s full-table writer path typed BLOB/TEXT decode columns once from the *latest* schema snapshot and applied that to every delta event regardless of when it was captured — a column captured as VARCHAR (plain string) at an old epoch and later widened to TEXT (base64-encoded) would have its old plain value wrongly decoded under the new typing, corrupting any value that happens to be valid base64 (the issue's own example: `"test"`).
- Fix: call `DecodeEventBinaries` — the epoch-aware decode already built for the single-row reconstruct path (#666/#667) — on the full `events` slice before the change map is built, mirroring the established sibling pattern (recover #662, shim #661/PR #665) instead of writing new bespoke logic.
- Removed the now-redundant `decodeChangeBinaries`/`mergeInput.BinaryCols` from the writer path (would have double-decoded otherwise — `decodeStoredBase64` isn't idempotent) and updated the stale doc comments that referenced it.

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] Integration tests pass (`go test -tags integration ./... -count=1`) — except a pre-existing flake in `internal/cascade` unrelated to this change (binlog FK-cascade blind-spot test, green in isolation; not touched by this PR)
- [x] New integration test (`internal/cli/reconstruct_fulltable_epoch_blobtext_integration_test.go`) drives the real CLI path: two `schema_snapshots` epochs (`body` VARCHAR → TEXT), one delta event captured under each. Verified the test **fails against the pre-fix code** (corrupts the old VARCHAR value `"test"` to garbage bytes, exactly the issue's repro) and passes after the fix.

## Scope note
While researching this, found a separate, more severe bug in `SnapshotFullTableImages` (used by the shim's `_snapshot`, `verify`, and `verify --explain`) — it doesn't decode BLOB/TEXT at all, and `verify`'s `isDeferredType` doesn't cover TEXT types, so it can produce a false `MISMATCH` verdict. Filed separately as #672 since it's a different function/different consumers/different severity class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)