### PR TITLE
verify: decode BLOB/TEXT before comparing, defer TEXT in isDeferredType (#672)

### DIFF
--- a/internal/reconstruct/fulltable.go
+++ b/internal/reconstruct/fulltable.go
@@ -623,9 +623,10 @@ type mergeStats struct {
 // its own Changes map before it ever reaches this function: the writer caller
 // upstream in ReconstructTable, on the full events slice before the Changes
 // map is even built (DecodeEventBinaries, #668); the shim caller upstream in
-// runSnapshotFullTable, via mapEventImages (#661). `verify`'s two
-// SnapshotFullTableImages callers (reconstructDigest, the --explain drill-down)
-// are the remaining undecoded consumers (#672).
+// runSnapshotFullTable, via mapEventImages (#661); `verify`'s callers
+// (reconstructDigest and ExplainBaselinePairMismatch) the same way, upstream
+// of their own Changes map builds (#672). Every SnapshotFullTableImages caller
+// now decodes before this function ever sees a value.
 func mergeBaselineImages(ctx context.Context, in mergeCore, emit func(map[string]any) error) (mergeStats, error) {
 	var stats mergeStats
 

--- a/internal/verify/deferred_test.go
+++ b/internal/verify/deferred_test.go
@@ -8,23 +8,26 @@ import (
 	"github.com/dbtrail/dbtrail/internal/query"
 )
 
-// TestIsDeferredType pins the #672 addition: TEXT family types must be
-// deferred alongside BLOB/binary, since both are decoded by the same
-// epoch-aware DecodeEventBinaries call and degrade the same way (an
-// unresolvable epoch leaves the value as stored base64).
+// TestIsDeferredType pins the case list, including the #672 decision: TEXT
+// family types are decoded by DecodeEventBinaries (same as BLOB) but are NOT
+// deferred — once decoded, TEXT is directly comparable to the baseline/source
+// text, unlike ENUM/JSON/binary, so deferring it would mask genuine
+// divergences instead of guarding against an unresolved representation gap.
 func TestIsDeferredType(t *testing.T) {
 	deferred := []string{
 		"enum", "set", "json",
 		"binary", "varbinary", "blob", "tinyblob", "mediumblob", "longblob", "bit",
-		"text", "tinytext", "mediumtext", "longtext",
-		"TEXT", "Blob", // case-insensitive
+		"BLOB", "Enum", // case-insensitive
 	}
 	for _, dt := range deferred {
 		if !isDeferredType(dt) {
 			t.Errorf("isDeferredType(%q) = false, want true", dt)
 		}
 	}
-	notDeferred := []string{"int", "varchar", "char", "datetime", "double", "decimal"}
+	notDeferred := []string{
+		"int", "varchar", "char", "datetime", "double", "decimal",
+		"text", "tinytext", "mediumtext", "longtext", "TEXT",
+	}
 	for _, dt := range notDeferred {
 		if isDeferredType(dt) {
 			t.Errorf("isDeferredType(%q) = true, want false", dt)

--- a/internal/verify/deferred_test.go
+++ b/internal/verify/deferred_test.go
@@ -8,6 +8,30 @@ import (
 	"github.com/dbtrail/dbtrail/internal/query"
 )
 
+// TestIsDeferredType pins the #672 addition: TEXT family types must be
+// deferred alongside BLOB/binary, since both are decoded by the same
+// epoch-aware DecodeEventBinaries call and degrade the same way (an
+// unresolvable epoch leaves the value as stored base64).
+func TestIsDeferredType(t *testing.T) {
+	deferred := []string{
+		"enum", "set", "json",
+		"binary", "varbinary", "blob", "tinyblob", "mediumblob", "longblob", "bit",
+		"text", "tinytext", "mediumtext", "longtext",
+		"TEXT", "Blob", // case-insensitive
+	}
+	for _, dt := range deferred {
+		if !isDeferredType(dt) {
+			t.Errorf("isDeferredType(%q) = false, want true", dt)
+		}
+	}
+	notDeferred := []string{"int", "varchar", "char", "datetime", "double", "decimal"}
+	for _, dt := range notDeferred {
+		if isDeferredType(dt) {
+			t.Errorf("isDeferredType(%q) = true, want false", dt)
+		}
+	}
+}
+
 func TestDeferredReprChanged(t *testing.T) {
 	intCol := metadata.ColumnMeta{Name: "n", DataType: "int"}
 	strCol := metadata.ColumnMeta{Name: "s", DataType: "varchar"}

--- a/internal/verify/explain_baseline.go
+++ b/internal/verify/explain_baseline.go
@@ -141,6 +141,9 @@ func ExplainBaselinePairMismatch(ctx context.Context, cfg BaselineConfig, p Base
 	if err != nil {
 		return nil, fmt.Errorf("fetch changes %s.%s: %w", p.Schema, p.Table, err)
 	}
+	// BLOB/TEXT base64 → real value, epoch-aware (#672). See verify.go's
+	// VerifyTable for the same wiring and its rationale.
+	reconstruct.DecodeEventBinaries(cfg.IndexDB, p.Schema, p.Table, rows)
 	changes := make(map[string]*query.ResultRow, len(rows))
 	for i := range rows {
 		changes[rows[i].PKValues] = &rows[i]

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -147,6 +147,11 @@ func VerifyTable(ctx context.Context, cfg Config, schema, table string) (TableRe
 		}
 		return res, fmt.Errorf("fetch changes %s.%s: %w", schema, table, err)
 	}
+	// BLOB/TEXT base64 → real value, epoch-aware (#672; same helper #668 wired
+	// into the offline reconstruct writer path). SnapshotFullTableImages itself
+	// never decodes — every caller is responsible for decoding its own changes
+	// map first, same as the shim's runSnapshotFullTable does via mapEventImages.
+	reconstruct.DecodeEventBinaries(cfg.IndexDB, schema, table, rows)
 	changes := make(map[string]*query.ResultRow, len(rows))
 	for i := range rows {
 		changes[rows[i].PKValues] = &rows[i]
@@ -267,11 +272,17 @@ func hasDeferredRepr(cols []metadata.ColumnMeta) bool {
 // isDeferredType reports whether a column's event-image representation can differ
 // from how the baseline/source renders it in a way this version doesn't yet
 // normalize: ENUM/SET (ordinal vs label), JSON (MySQL-canonical text), binary
-// families (base64 in the event image vs raw bytes), BIT.
+// and text families (base64 in the event image vs raw bytes/string), BIT.
+// TEXT is listed alongside BLOB/binary (not just the binary families) because
+// both are decoded by the same epoch-aware DecodeEventBinaries call (#672) and
+// degrade the same way: an unresolvable epoch leaves the value as stored
+// base64 rather than guessing, so a TEXT column needs the same Inconclusive
+// safety net BLOB already has, not a narrower one.
 func isDeferredType(dataType string) bool {
 	switch strings.ToLower(dataType) {
 	case "enum", "set", "json",
-		"binary", "varbinary", "blob", "tinyblob", "mediumblob", "longblob", "bit":
+		"binary", "varbinary", "blob", "tinyblob", "mediumblob", "longblob", "bit",
+		"text", "tinytext", "mediumtext", "longtext":
 		return true
 	}
 	return false

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -272,17 +272,22 @@ func hasDeferredRepr(cols []metadata.ColumnMeta) bool {
 // isDeferredType reports whether a column's event-image representation can differ
 // from how the baseline/source renders it in a way this version doesn't yet
 // normalize: ENUM/SET (ordinal vs label), JSON (MySQL-canonical text), binary
-// and text families (base64 in the event image vs raw bytes/string), BIT.
-// TEXT is listed alongside BLOB/binary (not just the binary families) because
-// both are decoded by the same epoch-aware DecodeEventBinaries call (#672) and
-// degrade the same way: an unresolvable epoch leaves the value as stored
-// base64 rather than guessing, so a TEXT column needs the same Inconclusive
-// safety net BLOB already has, not a narrower one.
+// families (base64 in the event image vs raw bytes), BIT.
+//
+// TEXT is deliberately NOT here, despite being decoded by the same
+// DecodeEventBinaries call as BLOB (#672): once decoded, a TEXT value is just
+// a string, directly comparable to the baseline/source text — unlike
+// ENUM/JSON/binary, decoding doesn't leave a representation gap to defer.
+// Deferring it anyway would mask genuine TEXT divergences as Inconclusive on
+// every table with a TEXT column (the common case, e.g. wp_options), which
+// defeats the point of decoding it in the first place. The narrow remaining
+// risk — an unresolvable epoch leaving a value as stored base64 — is the same
+// accepted risk DecodeEventBinaries already carries for its other callers
+// (recover, shim, reconstruct); it is not given a broader safety net here.
 func isDeferredType(dataType string) bool {
 	switch strings.ToLower(dataType) {
 	case "enum", "set", "json",
-		"binary", "varbinary", "blob", "tinyblob", "mediumblob", "longblob", "bit",
-		"text", "tinytext", "mediumtext", "longtext":
+		"binary", "varbinary", "blob", "tinyblob", "mediumblob", "longblob", "bit":
 		return true
 	}
 	return false

--- a/internal/verify/verify_baseline.go
+++ b/internal/verify/verify_baseline.go
@@ -134,6 +134,9 @@ func VerifyBaselinePair(ctx context.Context, cfg BaselineConfig, p BaselinePair)
 		}
 		return res, fmt.Errorf("fetch changes %s.%s: %w", p.Schema, p.Table, err)
 	}
+	// BLOB/TEXT base64 → real value, epoch-aware (#672). See verify.go's
+	// VerifyTable for the same wiring and its rationale.
+	reconstruct.DecodeEventBinaries(cfg.IndexDB, p.Schema, p.Table, rows)
 	changes := make(map[string]*query.ResultRow, len(rows))
 	for i := range rows {
 		changes[rows[i].PKValues] = &rows[i]

--- a/internal/verify/verify_baseline_integration_test.go
+++ b/internal/verify/verify_baseline_integration_test.go
@@ -5,6 +5,8 @@ package verify
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -587,5 +589,136 @@ func TestVerifyBaselinePair_UnchangedTable(t *testing.T) {
 	}
 	if got.Status != StatusMatch {
 		t.Errorf("unchanged table: status = %q (%s); want match", got.Status, got.Detail)
+	}
+}
+
+// TestVerifyBaselinePair_TextEventDecoded is the #672 regression: a TEXT
+// column's in-window event value (stored base64, since go-mysql delivers
+// TEXT as []byte and marshalRow base64-encodes it) must be decoded before
+// SnapshotFullTableImages compares it to the baseline/source's plain text —
+// neither VerifyBaselinePair's digest nor ExplainBaselinePairMismatch's
+// drill-down decoded it before this fix, so a TEXT-only change (id=1 below)
+// would surface as a false mismatch even though nothing actually diverged.
+//
+// id=2's status is deliberately, genuinely wrong (unrelated to #672) so the
+// table-level result is a real mismatch and ExplainBaselinePairMismatch has
+// something to drill into — proving the TEXT decode neither masks a real
+// divergence nor gets masked by one.
+func TestVerifyBaselinePair_TextEventDecoded(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	for _, c := range []struct {
+		name, key, dt, colType string
+		ord                    int
+	}{
+		{"id", "PRI", "int", "int", 1},
+		{"status", "", "varchar", "varchar(64)", 2},
+		{"body", "", "text", "text", 3},
+	} {
+		testutil.MustExec(t, db, `INSERT INTO schema_snapshots
+			(snapshot_id, snapshot_time, schema_name, table_name, column_name,
+			 ordinal_position, column_key, data_type, column_type, is_nullable, is_generated)
+			VALUES (1, UTC_TIMESTAMP(), ?, 'orders', ?, ?, ?, ?, ?, 'YES', 0)`,
+			dbName, c.name, c.ord, c.key, c.dt, c.colType)
+	}
+
+	baseDir := t.TempDir()
+	now := time.Now().UTC()
+	prevTS := now.Truncate(time.Hour).Add(-2 * time.Hour)
+	newTS := prevTS.Add(time.Hour)
+	createSQL := "CREATE TABLE `orders` (\n  `id` INT NOT NULL,\n  `status` VARCHAR(64),\n  `body` TEXT,\n  PRIMARY KEY (`id`)\n);\n"
+	cols := []baseline.Column{
+		{Name: "id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
+		{Name: "status", MySQLType: "varchar", ParquetType: baseline.MysqlToParquetNode("varchar")},
+		{Name: "body", MySQLType: "text", ParquetType: baseline.MysqlToParquetNode("text")},
+	}
+	// prev {1:a/hello, 2:b/static}; new (truth) {1:a/"updated text", 2:shipped/static}.
+	writeTestBaseline(t, baseDir, prevTS, dbName, "orders", createSQL, cols, [][]string{
+		{"1", "a", "hello"}, {"2", "b", "static"},
+	}, "binlog.000001", 200)
+	writeTestBaseline(t, baseDir, newTS, dbName, "orders", createSQL, cols, [][]string{
+		{"1", "a", "updated text"}, {"2", "shipped", "static"},
+	}, "binlog.000001", 300)
+
+	b64 := func(s string) string { return base64.StdEncoding.EncodeToString([]byte(s)) }
+
+	// Events in (prev, anchor]: id=1's body is updated to "updated text" (matches
+	// truth once decoded); id=2's status is updated to a WRONG value ("wrong",
+	// diverges from truth's "shipped") while body is carried unchanged — every
+	// column appears in row_after under binlog_row_image=FULL, so body is
+	// base64-encoded here too even though its value didn't change.
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{prevTS, newTS, now.Truncate(time.Hour)})
+	ets := prevTS.Add(30 * time.Minute).Format("2006-01-02 15:04:05")
+	testutil.InsertEvent(t, db, "binlog.000001", 200, 250, ets, nil, dbName, "orders", 2 /*UPDATE*/, "1", nil,
+		[]byte(fmt.Sprintf(`{"id":1,"status":"a","body":"%s"}`, b64("hello"))),
+		[]byte(fmt.Sprintf(`{"id":1,"status":"a","body":"%s"}`, b64("updated text"))))
+	testutil.InsertEvent(t, db, "binlog.000001", 250, 300, ets, nil, dbName, "orders", 2 /*UPDATE*/, "2", nil,
+		[]byte(fmt.Sprintf(`{"id":2,"status":"b","body":"%s"}`, b64("static"))),
+		[]byte(fmt.Sprintf(`{"id":2,"status":"wrong","body":"%s"}`, b64("static"))))
+
+	resolver, err := metadata.NewResolver(db, 1)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+	cfg := BaselineConfig{IndexDB: db, Resolver: resolver, IndexDBName: dbName, NoArchive: true}
+	ctx := context.Background()
+	pairs, _, _, err := FindBaselinePair(ctx, baseDir)
+	if err != nil || len(pairs) != 1 {
+		t.Fatalf("FindBaselinePair: %v (pairs=%d)", err, len(pairs))
+	}
+
+	got, err := VerifyBaselinePair(ctx, cfg, pairs[0])
+	if err != nil {
+		t.Fatalf("VerifyBaselinePair: %v", err)
+	}
+	// Mismatch is expected: id=2's status genuinely diverges (unrelated to #672,
+	// predates it). If id=1's body decode were broken, this would ALSO be a
+	// mismatch, for the wrong reason — the explain assertions below are what
+	// distinguish "id=1 correctly excluded" from "id=1 spuriously included".
+	if got.Status != StatusMismatch {
+		t.Fatalf("status = %q (%s); want mismatch (id=2's status genuinely diverges)", got.Status, got.Detail)
+	}
+
+	ex, err := ExplainBaselinePairMismatch(ctx, cfg, pairs[0])
+	if err != nil {
+		t.Fatalf("ExplainBaselinePairMismatch: %v", err)
+	}
+
+	var id1Diff, id2Diff *RowDiff
+	for i := range ex.Diffs {
+		switch ex.Diffs[i].PK {
+		case "id=1":
+			id1Diff = &ex.Diffs[i]
+		case "id=2":
+			id2Diff = &ex.Diffs[i]
+		}
+	}
+
+	// id=1 (TEXT-only change) must NOT appear in the diff at all: its body was
+	// decoded from the event's stored base64 to "updated text", matching truth
+	// exactly. Pre-#672, the undecoded raw base64 would mismatch truth's plain
+	// "updated text" and id=1 would show up here as a spurious diffChanged.
+	if id1Diff != nil {
+		t.Errorf("id=1 (TEXT-only change) should not appear in diffs — body should have decoded to match truth, got: %+v", *id1Diff)
+	}
+
+	// id=2 (real status divergence) must still be reported, with EXACTLY the
+	// status cell — not also a spurious body cell. Pre-#672, body's undecoded
+	// base64 ("c3RhdGlj") would mismatch truth's plain "static" too, adding a
+	// second, spurious cell diff alongside the real one.
+	if id2Diff == nil {
+		t.Fatalf("id=2 (real status divergence) must appear in diffs")
+	}
+	if id2Diff.Kind != diffChanged {
+		t.Fatalf("id=2 diff kind = %q, want %q", id2Diff.Kind, diffChanged)
+	}
+	if len(id2Diff.Cells) != 1 || id2Diff.Cells[0].Column != "status" {
+		t.Fatalf("id=2 cells = %+v, want exactly one status cell (body must not appear — it decoded and matched)", id2Diff.Cells)
+	}
+	if id2Diff.Cells[0].Recovery != "wrong" || id2Diff.Cells[0].Baseline != "shipped" {
+		t.Errorf("id=2 status cell = %+v, want recovery=%q baseline=%q", id2Diff.Cells[0], "wrong", "shipped")
 	}
 }

--- a/internal/verify/verify_baseline_integration_test.go
+++ b/internal/verify/verify_baseline_integration_test.go
@@ -722,3 +722,81 @@ func TestVerifyBaselinePair_TextEventDecoded(t *testing.T) {
 		t.Errorf("id=2 status cell = %+v, want recovery=%q baseline=%q", id2Diff.Cells[0], "wrong", "shipped")
 	}
 }
+
+// TestVerifyBaselinePair_TextOnlyChange_Match isolates VerifyBaselinePair's
+// OWN decode call (#672): a TEXT column changed by an in-window event, with
+// NO other divergence in the table, must report StatusMatch directly. Unlike
+// TestVerifyBaselinePair_TextEventDecoded above (which needs a genuine,
+// unrelated mismatch for ExplainBaselinePairMismatch to drill into, and so
+// can't tell VerifyBaselinePair's own decode apart from ExplainBaselinePair-
+// Mismatch's independent one), this test has nothing else that could produce
+// a mismatch — if VerifyBaselinePair's decode call were missing, the digest
+// would hash the raw base64 instead of "updated text" and this would report
+// StatusMismatch instead.
+func TestVerifyBaselinePair_TextOnlyChange_Match(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	for _, c := range []struct {
+		name, key, dt, colType string
+		ord                    int
+	}{
+		{"id", "PRI", "int", "int", 1},
+		{"body", "", "text", "text", 2},
+	} {
+		testutil.MustExec(t, db, `INSERT INTO schema_snapshots
+			(snapshot_id, snapshot_time, schema_name, table_name, column_name,
+			 ordinal_position, column_key, data_type, column_type, is_nullable, is_generated)
+			VALUES (1, UTC_TIMESTAMP(), ?, 'orders', ?, ?, ?, ?, ?, 'YES', 0)`,
+			dbName, c.name, c.ord, c.key, c.dt, c.colType)
+	}
+
+	baseDir := t.TempDir()
+	now := time.Now().UTC()
+	prevTS := now.Truncate(time.Hour).Add(-2 * time.Hour)
+	newTS := prevTS.Add(time.Hour)
+	createSQL := "CREATE TABLE `orders` (\n  `id` INT NOT NULL,\n  `body` TEXT,\n  PRIMARY KEY (`id`)\n);\n"
+	cols := []baseline.Column{
+		{Name: "id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
+		{Name: "body", MySQLType: "text", ParquetType: baseline.MysqlToParquetNode("text")},
+	}
+	writeTestBaseline(t, baseDir, prevTS, dbName, "orders", createSQL, cols, [][]string{
+		{"1", "hello"},
+	}, "binlog.000001", 200)
+	writeTestBaseline(t, baseDir, newTS, dbName, "orders", createSQL, cols, [][]string{
+		{"1", "updated text"},
+	}, "binlog.000001", 300)
+
+	b64 := func(s string) string { return base64.StdEncoding.EncodeToString([]byte(s)) }
+
+	// changed_columns is populated realistically here (unlike the nil used
+	// elsewhere in this file): there is no unrelated deferred-type column for
+	// deferredReprChanged to gate on, so this exercises the real indexer's
+	// ChangedColumns path without it affecting the outcome.
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{prevTS, newTS, now.Truncate(time.Hour)})
+	ets := prevTS.Add(30 * time.Minute).Format("2006-01-02 15:04:05")
+	testutil.InsertEvent(t, db, "binlog.000001", 200, 300, ets, nil, dbName, "orders", 2 /*UPDATE*/, "1", []byte(`["body"]`),
+		[]byte(fmt.Sprintf(`{"id":1,"body":"%s"}`, b64("hello"))),
+		[]byte(fmt.Sprintf(`{"id":1,"body":"%s"}`, b64("updated text"))))
+
+	resolver, err := metadata.NewResolver(db, 1)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+	cfg := BaselineConfig{IndexDB: db, Resolver: resolver, IndexDBName: dbName, NoArchive: true}
+	ctx := context.Background()
+	pairs, _, _, err := FindBaselinePair(ctx, baseDir)
+	if err != nil || len(pairs) != 1 {
+		t.Fatalf("FindBaselinePair: %v (pairs=%d)", err, len(pairs))
+	}
+
+	got, err := VerifyBaselinePair(ctx, cfg, pairs[0])
+	if err != nil {
+		t.Fatalf("VerifyBaselinePair: %v", err)
+	}
+	if got.Status != StatusMatch {
+		t.Fatalf("status = %q (%s); want match (TEXT body should decode to \"updated text\", matching the new baseline)", got.Status, got.Detail)
+	}
+}

--- a/internal/verify/verify_integration_test.go
+++ b/internal/verify/verify_integration_test.go
@@ -4,6 +4,7 @@ package verify
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -158,5 +159,99 @@ func TestVerifyTable_MatchesAndDetectsDivergence(t *testing.T) {
 	}
 	if got2.Status != StatusMismatch {
 		t.Errorf("after tampering status = %q (%s); want mismatch", got2.Status, got2.Detail)
+	}
+}
+
+// TestVerifyTable_TextEventDecoded is the #672 regression for the live-source
+// path: a TEXT column changed by an in-window event must decode before
+// comparison, the same fix TestVerifyBaselinePair_TextOnlyChange_Match proves
+// for the baseline-anchored path. Neither
+// TestVerifyTable_MatchesAndDetectsDivergence above nor any other existing
+// test in this package exercises a TEXT/BLOB column through VerifyTable, so
+// this closes the only one of the three #672 call sites that had zero
+// coverage. If VerifyTable's DecodeEventBinaries call were missing, the
+// reconstructed digest would hash the event's raw base64 instead of "updated
+// text" and this would report StatusMismatch.
+func TestVerifyTable_TextEventDecoded(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	testutil.MustExec(t, db, `INSERT INTO schema_snapshots
+		(snapshot_id, snapshot_time, schema_name, table_name, column_name, ordinal_position, column_key, data_type, column_type, is_nullable, is_generated)
+		VALUES (1, UTC_TIMESTAMP(), ?, 'orders', 'id', 1, 'PRI', 'int', 'int', 'NO', 0)`, dbName)
+	testutil.MustExec(t, db, `INSERT INTO schema_snapshots
+		(snapshot_id, snapshot_time, schema_name, table_name, column_name, ordinal_position, column_key, data_type, column_type, is_nullable, is_generated)
+		VALUES (1, UTC_TIMESTAMP(), ?, 'orders', 'body', 2, '', 'text', 'text', 'YES', 0)`, dbName)
+
+	// ── live SOURCE table at the FINAL (post-event) state ──
+	testutil.MustExec(t, db, fmt.Sprintf(
+		"CREATE TABLE `%s`.`orders` (`id` INT PRIMARY KEY, `body` TEXT)", dbName))
+	testutil.MustExec(t, db, fmt.Sprintf(
+		"INSERT INTO `%s`.`orders` (id,body) VALUES (1,'updated text')", dbName))
+
+	// ── baseline Parquet at the INITIAL state {1:hello} ──
+	createSQL := "CREATE TABLE `orders` (\n  `id` INT NOT NULL,\n  `body` TEXT,\n  PRIMARY KEY (`id`)\n);\n"
+	baselineDir := t.TempDir()
+	now := time.Now().UTC()
+	curHour := now.Truncate(time.Hour)
+	h1 := curHour.Add(-time.Hour)
+	h2 := curHour
+	tsDir := strings.ReplaceAll(h1.Format(time.RFC3339), ":", "-")
+	parquetDir := filepath.Join(baselineDir, tsDir, dbName)
+	if err := os.MkdirAll(parquetDir, 0o755); err != nil {
+		t.Fatalf("mkdir baseline: %v", err)
+	}
+	cols := []baseline.Column{
+		{Name: "id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
+		{Name: "body", MySQLType: "text", ParquetType: baseline.MysqlToParquetNode("text")},
+	}
+	bw, err := baseline.NewWriter(filepath.Join(parquetDir, "orders.parquet"), cols,
+		baseline.WriterConfig{Compression: "zstd", RowGroupSize: 100,
+			Metadata: map[string]string{baseline.MetaKeyCreateTableSQL: createSQL}})
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	if err := bw.WriteRow([]string{"1", "hello"}, []bool{false, false}); err != nil {
+		t.Fatalf("WriteRow: %v", err)
+	}
+	if err := bw.Close(); err != nil {
+		t.Fatalf("baseline close: %v", err)
+	}
+
+	// ── binlog event: body updated, base64-encoded as TEXT is delivered ──
+	b64 := func(s string) string { return base64.StdEncoding.EncodeToString([]byte(s)) }
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{h1, h2})
+	ts := now.Add(-1 * time.Minute).Format("2006-01-02 15:04:05")
+	testutil.InsertEvent(t, db, "binlog.000001", 100, 200, ts, nil, dbName, "orders", 2 /*UPDATE*/, "1", []byte(`["body"]`),
+		[]byte(fmt.Sprintf(`{"id":1,"body":"%s"}`, b64("hello"))),
+		[]byte(fmt.Sprintf(`{"id":1,"body":"%s"}`, b64("updated text"))))
+
+	// ── stream_state with a GTID superset so the coverage check passes ──
+	var uuid string
+	if err := db.QueryRow("SELECT @@server_uuid").Scan(&uuid); err != nil {
+		t.Fatalf("server_uuid: %v", err)
+	}
+	testutil.MustExec(t, db, `INSERT INTO stream_state
+		(id, mode, gtid_set, last_checkpoint, server_id)
+		VALUES (1, 'gtid', ?, UTC_TIMESTAMP(), 1)`, uuid+":1-1000000")
+
+	resolver, err := metadata.NewResolver(db, 1)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+	cfg := Config{
+		SourceDB: db, IndexDB: db, Resolver: resolver,
+		BaselineSource: baselineDir, IndexDBName: dbName, NoArchive: true,
+	}
+
+	got, err := VerifyTable(context.Background(), cfg, dbName, "orders")
+	if err != nil {
+		t.Fatalf("VerifyTable: %v", err)
+	}
+	if got.Status != StatusMatch {
+		t.Fatalf("status = %q (%s); want match (TEXT body should decode to \"updated text\", matching the live source)", got.Status, got.Detail)
 	}
 }


### PR DESCRIPTION
closes #672

## Summary
- `SnapshotFullTableImages` never decodes BLOB/TEXT base64 itself — every caller must decode its own `Changes` map first. The shim already does this (#661); the offline reconstruct writer does it via #668. `verify`'s three call sites (`VerifyTable` in verify.go, `VerifyBaselinePair` in verify_baseline.go, `ExplainBaselinePairMismatch` in explain_baseline.go) didn't — so an event-sourced TEXT value reached comparison as raw base64, a guaranteed mismatch surfaced as a false `MISMATCH` verdict, verify's core correctness signal.
- Fix: call the existing `reconstruct.DecodeEventBinaries` at all three sites, right after `query.FetchMerged` and before the events fold into a `Changes` map — zero new decode logic, mirrors the established #668/#661 pattern exactly.
- `isDeferredType` (the safety net that downgrades known-divergent types like ENUM/JSON/binary to Inconclusive instead of a false MISMATCH) deliberately does **not** get TEXT added, despite the original issue's fix sketch suggesting it. Review surfaced that `VerifyTable`'s gate is coarse (table merely *contains* a deferred column + anything changed in the window), and TEXT columns are ubiquitous — adding TEXT there would make live-source verify report Inconclusive instead of a genuine MISMATCH on most real tables, defeating the point of decoding TEXT in the first place (once decoded, it's directly comparable text, unlike ENUM/JSON/binary's genuine representation gap).

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] Integration tests pass (`go test -tags integration ./... -count=1`) — except the pre-existing `internal/cascade` flake (binlog FK-cascade blind-spot test, unrelated package, confirmed green in isolation)
- [x] `TestVerifyTable_TextEventDecoded` (live-source path) and `TestVerifyBaselinePair_TextOnlyChange_Match` (baseline-anchored path, isolated from the explain path's own independent decode) each directly assert `StatusMatch` on a TEXT-only event change. Both confirmed to **fail against the pre-fix code** (via `git checkout main -- <file>`, one file at a time) and pass after.
- [x] `TestVerifyBaselinePair_TextEventDecoded` and `TestExplainBaselinePairMismatch_DeferredDrift` cover the explain drill-down path and the existing ENUM/JSON deferral behavior, respectively.
- [x] `TestIsDeferredType` pins the case list, including that TEXT is intentionally excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)