### PR TITLE
parser: don't format ANONYMOUS_GTID_LOG_EVENT into a fake real GTID

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -125,7 +125,7 @@ func (p *Parser) ParseFile(ctx context.Context, filename string, events chan<- E
 
 		switch ev := binlogEv.Event.(type) {
 		case *replication.GTIDEvent:
-			currentGTID = formatGTID(ev.SID, ev.GNO)
+			currentGTID = formatGTID(binlogEv.Header.EventType, ev.SID, ev.GNO)
 
 		case *replication.MariadbGTIDEvent:
 			// MariaDB source: the GTID arrives as domain-server-seq (e.g.
@@ -447,9 +447,17 @@ func ChangedColumns(before, after map[string]any) []string {
 }
 
 // formatGTID formats a MySQL GTID from the raw 16-byte server UUID (SID) and
-// the group number (GNO). Returns an empty string if SID is not 16 bytes
-// (GTID not enabled on the source server).
-func formatGTID(sid []byte, gno int64) string {
+// the group number (GNO). Returns an empty string when there is no real GTID
+// to report: eventType is ANONYMOUS_GTID_EVENT (gtid_mode=OFF still wraps
+// every transaction in this event; go-mysql decodes it into the same
+// GTIDEvent struct as a real GTID_EVENT, with a 16-zero-byte SID that would
+// otherwise pass the length check below and format into a fake-but-valid-
+// looking GTID, e.g. "00000000-0000-0000-0000-000000000000:0" — #678), or SID
+// is not 16 bytes.
+func formatGTID(eventType replication.EventType, sid []byte, gno int64) string {
+	if eventType == replication.ANONYMOUS_GTID_EVENT {
+		return ""
+	}
 	if len(sid) != 16 {
 		return ""
 	}

--- a/internal/parser/parser_integration_test.go
+++ b/internal/parser/parser_integration_test.go
@@ -173,6 +173,14 @@ func TestParseFile_realBinlog(t *testing.T) {
 		if ev.PKValues == "" {
 			t.Errorf("event[%d]: expected non-empty PKValues", i)
 		}
+		// The test MySQL runs with gtid_mode=OFF (no --gtid-mode flag in CI's
+		// docker run, and OFF is the stock default) — every transaction is
+		// still wrapped in an ANONYMOUS_GTID_LOG_EVENT, which must format to
+		// an empty GTID, not the fake "00000000-...-000000000000:0" #678
+		// produced before the fix.
+		if ev.GTID != "" {
+			t.Errorf("event[%d]: expected empty GTID (gtid_mode=OFF source), got %q", i, ev.GTID)
+		}
 
 		switch ev.EventType {
 		case parser.EventInsert:

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -140,7 +140,7 @@ func TestBuildPKValues_emptyPKColumns(t *testing.T) {
 func TestFormatGTID_valid(t *testing.T) {
 	// UUID "3e11fa47-71ca-11e1-9e33-c80aa9429562", GNO=42
 	sid := []byte{0x3e, 0x11, 0xfa, 0x47, 0x71, 0xca, 0x11, 0xe1, 0x9e, 0x33, 0xc8, 0x0a, 0xa9, 0x42, 0x95, 0x62}
-	got := formatGTID(sid, 42)
+	got := formatGTID(replication.GTID_EVENT, sid, 42)
 	want := "3e11fa47-71ca-11e1-9e33-c80aa9429562:42"
 	if got != want {
 		t.Errorf("expected %q, got %q", want, got)
@@ -149,9 +149,22 @@ func TestFormatGTID_valid(t *testing.T) {
 
 func TestFormatGTID_shortSID(t *testing.T) {
 	// Fewer than 16 bytes → GTID not enabled → empty string.
-	got := formatGTID([]byte{0x01, 0x02}, 1)
+	got := formatGTID(replication.GTID_EVENT, []byte{0x01, 0x02}, 1)
 	if got != "" {
 		t.Errorf("expected empty string for short SID, got %q", got)
+	}
+}
+
+func TestFormatGTID_anonymousEvent(t *testing.T) {
+	// ANONYMOUS_GTID_LOG_EVENT (gtid_mode=OFF still wraps every transaction in
+	// this event; go-mysql decodes it into the same GTIDEvent struct as a real
+	// GTID_EVENT) must never format into a GTID, even with a well-formed
+	// 16-byte SID — #678: a 16-zero-byte SID was passing the length check and
+	// producing a fake-but-valid-looking GTID.
+	sid := []byte{0x3e, 0x11, 0xfa, 0x47, 0x71, 0xca, 0x11, 0xe1, 0x9e, 0x33, 0xc8, 0x0a, 0xa9, 0x42, 0x95, 0x62}
+	got := formatGTID(replication.ANONYMOUS_GTID_EVENT, sid, 0)
+	if got != "" {
+		t.Errorf("expected empty string for ANONYMOUS_GTID_EVENT, got %q", got)
 	}
 }
 

--- a/internal/parser/stream.go
+++ b/internal/parser/stream.go
@@ -170,7 +170,7 @@ func (sp *StreamParser) Run(ctx context.Context, streamer *replication.BinlogStr
 			if err := emitCommit(binlogEv.Header); err != nil {
 				return err
 			}
-			currentGTID = formatGTID(ev.SID, ev.GNO)
+			currentGTID = formatGTID(binlogEv.Header.EventType, ev.SID, ev.GNO)
 			if err := emitGTIDTracking(binlogEv.Header); err != nil {
 				return err
 			}

--- a/internal/parser/stream_test.go
+++ b/internal/parser/stream_test.go
@@ -48,6 +48,19 @@ func makeGTIDEvent(gno int64) *replication.BinlogEvent {
 	}
 }
 
+// makeAnonymousGTIDEvent builds a BinlogEvent wrapping a GTIDEvent tagged as
+// ANONYMOUS_GTID_EVENT (gtid_mode=OFF) — the header EventType is what
+// distinguishes it from makeGTIDEvent's "real" GTID_EVENT; go-mysql decodes
+// both into the same GTIDEvent struct, with an all-zero SID for the anonymous
+// case, matching what the source actually sends on the wire (#678).
+func makeAnonymousGTIDEvent(gno int64) *replication.BinlogEvent {
+	sid := make([]byte, 16)
+	return &replication.BinlogEvent{
+		Header: &replication.EventHeader{EventType: replication.ANONYMOUS_GTID_EVENT},
+		Event:  &replication.GTIDEvent{SID: sid, GNO: gno},
+	}
+}
+
 // makeQueryEvent builds a BinlogEvent wrapping a QueryEvent.
 func makeQueryEvent(query string) *replication.BinlogEvent {
 	return &replication.BinlogEvent{
@@ -225,6 +238,29 @@ func TestStreamParser_gtidThenFilteredRows(t *testing.T) {
 	ev := <-out
 	if ev.EventType != EventGTID {
 		t.Errorf("expected EventGTID (%d), got %d", EventGTID, ev.EventType)
+	}
+}
+
+// TestStreamParser_anonymousGTIDEventEmitsNoTrackingEvent verifies that an
+// ANONYMOUS_GTID_LOG_EVENT (gtid_mode=OFF, still wraps every transaction) does
+// NOT emit an EventGTID tracking event — currentGTID must stay empty rather
+// than formatting the wire's zero SID into a fake GTID (#678). Contrast with
+// TestStreamParser_gtidEventEmitsTrackingEvent, which asserts exactly one
+// EventGTID for the real GTID_EVENT case.
+func TestStreamParser_anonymousGTIDEventEmitsNoTrackingEvent(t *testing.T) {
+	sp := NewStreamParser(nil, Filters{}, nil)
+	streamer := replication.NewBinlogStreamer()
+	out := make(chan Event, 10)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	feedThenCancel(t, streamer, cancel, makeAnonymousGTIDEvent(0))
+
+	if err := sp.Run(ctx, streamer, out); err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+	if len(out) != 0 {
+		evs := drainAll(out)
+		t.Fatalf("expected no tracking event for an anonymous GTID, got %d: %+v", len(evs), evs)
 	}
 }
 

--- a/internal/parser/stream_test.go
+++ b/internal/parser/stream_test.go
@@ -51,8 +51,11 @@ func makeGTIDEvent(gno int64) *replication.BinlogEvent {
 // makeAnonymousGTIDEvent builds a BinlogEvent wrapping a GTIDEvent tagged as
 // ANONYMOUS_GTID_EVENT (gtid_mode=OFF) — the header EventType is what
 // distinguishes it from makeGTIDEvent's "real" GTID_EVENT; go-mysql decodes
-// both into the same GTIDEvent struct, with an all-zero SID for the anonymous
-// case, matching what the source actually sends on the wire (#678).
+// both into the same GTIDEvent struct. The all-zero SID mirrors what #678
+// observed go-mysql decode for an anonymous event, but isn't load-bearing
+// here: formatGTID's eventType check fires before it ever looks at SID, so
+// this fixture would behave identically with a non-zero SID (see
+// TestFormatGTID_anonymousEvent, which asserts exactly that).
 func makeAnonymousGTIDEvent(gno int64) *replication.BinlogEvent {
 	sid := make([]byte, 16)
 	return &replication.BinlogEvent{
@@ -238,6 +241,40 @@ func TestStreamParser_gtidThenFilteredRows(t *testing.T) {
 	ev := <-out
 	if ev.EventType != EventGTID {
 		t.Errorf("expected EventGTID (%d), got %d", EventGTID, ev.EventType)
+	}
+}
+
+// TestStreamParser_anonymousGTIDThenRowsEmitsEmptyGTID verifies the actual
+// production impact of #678: a row event following an ANONYMOUS_GTID_LOG_EVENT
+// must carry an empty GTID, not the fake zero-UUID formatGTID used to produce.
+// This is the field indexer.InsertBatch stores into binlog_events.gtid (via
+// nullOrString) — TestStreamParser_anonymousGTIDEventEmitsNoTrackingEvent only
+// covers the lower-stakes tracking-event side of the fix.
+func TestStreamParser_anonymousGTIDThenRowsEmitsEmptyGTID(t *testing.T) {
+	sp := NewStreamParser(makeOrdersResolver(), Filters{}, nil)
+	streamer := replication.NewBinlogStreamer()
+	out := make(chan Event, 10)
+
+	rowsEv := &replication.BinlogEvent{
+		Header: &replication.EventHeader{EventType: replication.WRITE_ROWS_EVENTv2, LogPos: 200, EventSize: 100},
+		Event: &replication.RowsEvent{
+			Table: &replication.TableMapEvent{Schema: []byte("shop"), Table: []byte("orders"), ColumnCount: 2},
+			Rows:  [][]any{{int64(1), int64(10)}},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	feedThenCancel(t, streamer, cancel, makeAnonymousGTIDEvent(0), rowsEv)
+
+	if err := sp.Run(ctx, streamer, out); err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+	evs := drainAll(out)
+	if len(evs) != 1 || evs[0].EventType != EventInsert {
+		t.Fatalf("expected 1 EventInsert (no GTID tracking event), got %v", typesOf(evs))
+	}
+	if evs[0].GTID != "" {
+		t.Errorf("expected empty GTID on the row event following an anonymous GTID, got %q", evs[0].GTID)
 	}
 }
 


### PR DESCRIPTION
closes #678

## Summary
- `formatGTID` (`internal/parser/parser.go`) only checked `len(sid) != 16` to detect "GTID not enabled." A source with `gtid_mode=OFF` still wraps every transaction in an `ANONYMOUS_GTID_LOG_EVENT`, which go-mysql decodes into the *same* `*replication.GTIDEvent` struct as a real `GTID_LOG_EVENT` — with a 16-zero-byte SID that passed the length check and formatted into a plausible-looking but meaningless GTID (`00000000-0000-0000-0000-000000000000:0`).
- `formatGTID` now takes the event's wire `EventType` and returns `""` for `ANONYMOUS_GTID_EVENT` before the SID check, mirroring the existing "GTID not enabled" behavior for a wrong-length SID. Fixed at both call sites: file-based parsing (`ParseFile`) and live streaming (`StreamParser.Run`).
- MariaDB's GTID path is untouched — `MariadbGTIDEvent.GTID.String()` already returns `""` for the zero GTID via a different mechanism, unaffected by this bug.
- Verified the compressed-transaction path (`binlog_transaction_compression=ON`, zstd `Transaction_payload`) still works correctly: go-mysql fully re-parses each inner event from its raw bytes, so each sub-event's `Header.EventType` is independently and correctly set.

## Test plan
- [x] `go test ./... -count=1` — all packages pass
- [x] `go vet ./internal/parser/...` clean, `gofmt -l` clean
- [x] New unit test `TestFormatGTID_anonymousEvent`: a well-formed 16-byte SID with `eventType=ANONYMOUS_GTID_EVENT` still returns `""`
- [x] New unit test `TestStreamParser_anonymousGTIDEventEmitsNoTrackingEvent`: an anonymous GTID event emits zero `EventGTID` tracking events (contrast with the existing `TestStreamParser_gtidEventEmitsTrackingEvent`, which asserts exactly one for a real `GTID_EVENT`)
- [x] Existing `TestFormatGTID_valid`/`TestFormatGTID_shortSID` updated for the new signature, still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)