### PR TITLE
Console: default the Create-baseline button to on (opt-out)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -247,13 +247,17 @@ services:
       # Left empty by default: the gate is config-based, so setting it with no
       # snapshots would show a Time-travel tab with nothing behind it.
       BINTRAIL_CONSOLE_BASELINE_DIR: ${BASELINE_DIR:-}
-      # Opt-in "Create baseline" button (#613): set BASELINE_TRIGGER=1 in .env to
-      # let the console create baseline snapshots in-process (dump→convert→upload)
-      # for a monitored server. The console image bundles mydumper and runs it as
-      # a LOCAL subprocess — NO docker socket is mounted (the console never gets
-      # host-root). A server needs a source DSN AND a baseline dir/S3 configured.
-      # Off by default. Staging for S3-destined baselines lives on the state volume.
-      BINTRAIL_CONSOLE_BASELINE_TRIGGER: ${BASELINE_TRIGGER:-}
+      # "Create baseline" button (#613): lets the console create baseline
+      # snapshots in-process (dump→convert→upload) for a monitored server. The
+      # console image bundles mydumper and runs it as a LOCAL subprocess — NO
+      # docker socket is mounted (the console never gets host-root). A server
+      # still needs a source DSN AND a baseline dir/S3 configured before the
+      # button does anything — unlike BASELINE_DIR above, on-by-default here is
+      # safe because the button *creates* the missing baseline rather than
+      # exposing an empty surface. On by default; set BASELINE_TRIGGER=0 in
+      # .env to disable. Staging for S3-destined baselines lives on the state
+      # volume.
+      BINTRAIL_CONSOLE_BASELINE_TRIGGER: ${BASELINE_TRIGGER:-1}
       BINTRAIL_CONSOLE_BASELINE_STAGING: /var/lib/bintrail/baseline-staging
       # Password login (persists next to the registry). On first run the
       # console serves a "create your password" screen; later visits sign in.

--- a/docs/console.md
+++ b/docs/console.md
@@ -284,16 +284,17 @@ across the rotation dialog and the per-server edit form):
   (`bintrail dump` → `bintrail baseline`). When the **Create baseline** button
   is enabled (see below) it sits in this panel's header.
 
-#### Creating a baseline from the console (opt-in)
+#### Creating a baseline from the console
 
 By default the console only *lists* baselines — you produce them with the
 `bintrail dump` → `bintrail baseline` CLI (or the compose `baseline` profile).
 A **Create baseline** button can run that pipeline for a monitored server
-straight from the Storage page, but it is **opt-in** and only on the `watch`
-daemon:
+straight from the Storage page, and it only runs on the `watch` daemon:
 
-- Start `watch` with `BINTRAIL_CONSOLE_BASELINE_TRIGGER=1` (compose: set
-  `BASELINE_TRIGGER=1` in `.env`).
+- A bare `watch` invocation (no compose) has this **opt-in** and off by
+  default — start it with `BINTRAIL_CONSOLE_BASELINE_TRIGGER=1`. The bundled
+  compose stack flips this to **on by default**; set `BASELINE_TRIGGER=0` in
+  `.env` to opt out there.
 - The server must have **both** a source DSN and a baseline destination
   (`baseline_dir` or `baseline_s3`) configured; the button 400s otherwise.
 - Clicking it runs **dump → convert → upload entirely in-process**: the console
@@ -307,9 +308,9 @@ daemon:
   credentials come from the daemon's ambient AWS chain, like every other S3
   access. When it finishes the new snapshot appears in the listing.
 
-The button is hidden on the read-only `serve` console and whenever the opt-in
-is off — the CLI/compose recipe in the empty state remains the always-available
-path.
+The button is hidden on the read-only `serve` console and whenever the trigger
+is disabled — the CLI/compose recipe in the empty state remains the
+always-available path.
 - **AWS credentials** — which ambient credential signals the daemon process
   can see: env keys (presence only, never values), `AWS_PROFILE`,
   `AWS_REGION`, a shared `~/.aws` config, ECS task-role / EKS IRSA markers.
@@ -356,8 +357,10 @@ path.
   Archive-to-S3 feature, same as `--archive-staging-dir`. AWS credentials for
   the upload come from the ambient chain (`AWS_*` / `~/.aws` / role).
 - `BINTRAIL_CONSOLE_BASELINE_TRIGGER` (`watch` only) — `1`/`true` enables the
-  opt-in **Create baseline** button (runs `mydumper` → convert → upload
-  in-process; see [The Storage page](#the-storage-page)). Off by default.
+  **Create baseline** button (runs `mydumper` → convert → upload in-process;
+  see [The Storage page](#the-storage-page)). Off by default for a bare
+  `watch` invocation; the bundled compose stack sets this on by default (see
+  [docker.md](docker.md) — `BASELINE_TRIGGER=0` in `.env` opts out there).
 - `BINTRAIL_CONSOLE_BASELINE_STAGING` (`watch` only) — local staging dir for
   S3-destined baselines created by that button (default a temp subdir).
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -267,9 +267,9 @@ reconstruct knows where deltas begin. Then point the console at it:
 - **The boot `SOURCE_DSN` entry**: set `BASELINE_DIR=/var/lib/bintrail/baselines`
   in `.env` and `docker compose up -d` again.
 
-The console also has an in-process **Create baseline** button (a server's
-Storage panel under Manage servers) that runs the same dump→convert→upload
-pipeline without the CLI profile — it's on by default in this compose stack;
+The console also has an in-process **Create baseline** button (in the sidebar
+under Settings → Storage, for the selected server) that runs the same
+dump→convert→upload pipeline without the CLI profile — it's on by default in this compose stack;
 set `BASELINE_TRIGGER=0` in `.env` to disable it. The button still needs a
 source DSN and a baseline dir/S3 configured on the server before it does
 anything.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -267,6 +267,13 @@ reconstruct knows where deltas begin. Then point the console at it:
 - **The boot `SOURCE_DSN` entry**: set `BASELINE_DIR=/var/lib/bintrail/baselines`
   in `.env` and `docker compose up -d` again.
 
+The console also has an in-process **Create baseline** button (a server's
+Storage panel under Manage servers) that runs the same dump→convert→upload
+pipeline without the CLI profile — it's on by default in this compose stack;
+set `BASELINE_TRIGGER=0` in `.env` to disable it. The button still needs a
+source DSN and a baseline dir/S3 configured on the server before it does
+anything.
+
 Notes:
 
 - The dump uses mydumper light locking (`--sync-thread-lock-mode NO_LOCK
@@ -364,6 +371,7 @@ surface, use the demo image ([demo.md](./demo.md)).
 | `BASELINE_SOURCE_DSN` | compose `baseline` profile | Source MySQL to snapshot (default: `SOURCE_DSN`) |
 | `BASELINE_SCHEMAS` | compose `baseline` profile | Comma-separated schemas to snapshot (default: `SCHEMAS`; empty = all user schemas, system schemas excluded) |
 | `BASELINE_DIR` | compose (optional) | Baseline dir for the boot `SOURCE_DSN` entry — set `/var/lib/bintrail/baselines` after the first `baseline` profile run to enable Time-travel on it. Also enables full-table `_snapshot.*` on the `flashback` profile shim |
+| `BASELINE_TRIGGER` | compose (optional) | Enables the console's in-process **Create baseline** button (dump→convert→upload) for a monitored server; **on by default** — set `BASELINE_TRIGGER=0` to disable |
 | `SHIM_USER` | compose `flashback` profile | Login the time-travel `mysql` terminal authenticates with (required to start the `shim` service) |
 | `SHIM_PASSWORD` | compose `flashback` profile | Cleartext password for `SHIM_USER` (required) |
 | `SHIM_AUTH_METHOD` | compose `flashback` profile (optional) | Client auth plugin for the shim (default `mysql_native_password`; set `caching_sha2_password` for drivers that require it) |


### PR DESCRIPTION
closes #676

## Summary
- `docker-compose.yml`: `BINTRAIL_CONSOLE_BASELINE_TRIGGER` now defaults to on (`${BASELINE_TRIGGER:-1}`) instead of empty/off, so a fresh `install.sh` install shows the console's "Create baseline" button once a server has a source DSN + baseline destination configured, without needing to discover and hand-edit an undocumented env var.
- Add an explicit opt-out: set `BASELINE_TRIGGER=0` in `.env` to disable the console-run mydumper subprocess entirely.
- `docs/docker.md`: document the button and the `BASELINE_TRIGGER` env var (was undocumented).
- No backend/Go change — `internal/console/baseline_trigger.go` and the capability gate are unchanged; the button is still double-gated per server (source DSN AND baseline dir/S3), so this is a no-op for any server without a destination configured.

## Test plan
- [x] `docker compose config -q` validates the compose file after the edit
- [x] `go build ./...` (unaffected — no Go changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)