### PR TITLE
console: Overview 'latest window' now names its real 200-event scope

### DIFF
--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -627,15 +627,15 @@ function buildOverview(status, eventsData) {
     else if (e.event_type === "DELETE") s.delete++;
   }
   const tables = Array.from(byTable.values()).sort((a, b) => b.total - a.total);
-  const latest = cov.latest_event || (events[0] && events[0].event_timestamp) || "—";
-  const earliest = cov.earliest_event || (events.length ? events[events.length - 1].event_timestamp : "—");
+  const latest = (events[0] && events[0].event_timestamp) || "—";
+  const earliest = events.length ? events[events.length - 1].event_timestamp : "—";
 
   const v = VIEW(); clear(v);
 
   const sub = el("p", { class: "page-sub" },
     "What changed recently, and where — your starting point. ",
     el("b", { text: deletes + " delete(s)" }),
-    " in the latest window: the ones worth a look first.");
+    " in the last " + events.length + " event(s): the ones worth a look first.");
   v.append(pageHead("Overview", sub));
 
   // stats
@@ -676,7 +676,7 @@ function buildOverview(status, eventsData) {
   tables.slice(0, 12).forEach((s) => tbox.append(ovTableRow(s)));
   tablesPanel.append(tbox);
   tablesPanel.append(el("div", { class: "ov-coverage" },
-    el("span", { text: "coverage" }), " ",
+    el("span", { text: "window" }), " ",
     el("b", { text: earliest }), " → ", el("b", { text: latest })));
   grid.append(tablesPanel);
 


### PR DESCRIPTION
closes #679

## Summary
- The Overview subhead read "N delete(s) in the latest window", implying a time-based window, but `renderOverview()` always fetches a fixed 200 most-recent events — the subhead now reads "N delete(s) in the last `<count>` event(s)".
- The `WINDOW` line (previously labeled `COVERAGE`) at the foot of the Activity-by-table panel preferred `status.coverage` — the **global** index's earliest/latest event — whenever `/api/status` succeeded, which misrepresented the fetched window's real span whenever the index has more history than 200 events. It now derives unconditionally from the fetched window's own first/last event.
- Relabeled `coverage` → `window` to make the scope explicit and avoid re-introducing the same ambiguity in copy.

## Test plan
- [x] `go build ./...`
- [x] Manually verified in a real browser: seeded a test index with 350 events spanning ~14.5 days, confirmed the subhead reads "... in the last 200 event(s)" and the window line shows only the ~8.3-day span of the 200 fetched events (not the full 14.5-day index span)

🤖 Generated with [Claude Code](https://claude.com/claude-code)