### PR TITLE
console: AWS credentials card leads with a summary, not raw signals

### DIFF
--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -1610,7 +1610,7 @@ function credentialsCard(storage) {
   else if (aws.web_identity) summary = "Using an IAM role (EKS IRSA detected).";
   card.append(el("p", { class: "stg-hint", text: summary }));
   const adv = el("details", { class: "form-advanced" },
-    el("summary", { text: "Raw signals" }));
+    el("summary", { class: "form-adv-summary", text: "Raw signals" }));
   kvRow(adv, "access keys (env)", aws.access_key_env ? "set" : "not set");
   kvRow(adv, "profile (env)", aws.profile || "—");
   kvRow(adv, "region (env)", aws.region_env || "—");

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -1608,6 +1608,7 @@ function credentialsCard(storage) {
   if (aws.access_key_env) summary = "Static access keys configured via environment.";
   else if (aws.container_creds) summary = "Using an IAM role (ECS task role detected).";
   else if (aws.web_identity) summary = "Using an IAM role (EKS IRSA detected).";
+  else if (aws.shared_config || aws.profile) summary = "Using credentials from a shared ~/.aws config/profile.";
   card.append(el("p", { class: "stg-hint", text: summary }));
   const adv = el("details", { class: "form-advanced" },
     el("summary", { class: "form-adv-summary", text: "Raw signals" }));

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -1604,14 +1604,21 @@ function credentialsCard(storage) {
     card.append(el("p", { class: "form-hint", text: "Could not read the daemon's credential signals" + (storage && storage.error ? ": " + storage.error : ".") }));
     return card;
   }
-  kvRow(card, "access keys (env)", aws.access_key_env ? "set" : "not set");
-  kvRow(card, "profile (env)", aws.profile || "—");
-  kvRow(card, "region (env)", aws.region_env || "—");
-  kvRow(card, "~/.aws config", aws.shared_config ? "present" : "absent");
-  if (aws.container_creds) kvRow(card, "ECS task role", "detected");
-  if (aws.web_identity) kvRow(card, "EKS IRSA", "detected");
-  card.append(el("p", { class: "form-hint stg-hint", text:
-    "Resolved from the daemon's AWS credential chain. IAM roles work even when nothing shows as set here." }));
+  let summary = "No static credentials configured — relying on the ambient AWS credential chain (this includes EC2 instance roles, invisible here).";
+  if (aws.access_key_env) summary = "Static access keys configured via environment.";
+  else if (aws.container_creds) summary = "Using an IAM role (ECS task role detected).";
+  else if (aws.web_identity) summary = "Using an IAM role (EKS IRSA detected).";
+  card.append(el("p", { class: "stg-hint", text: summary }));
+  const adv = el("details", { class: "form-advanced" },
+    el("summary", { text: "Raw signals" }));
+  kvRow(adv, "access keys (env)", aws.access_key_env ? "set" : "not set");
+  kvRow(adv, "profile (env)", aws.profile || "—");
+  kvRow(adv, "region (env)", aws.region_env || "—");
+  kvRow(adv, "~/.aws config", aws.shared_config ? "present" : "absent");
+  if (aws.container_creds) kvRow(adv, "ECS task role", "detected");
+  if (aws.web_identity) kvRow(adv, "EKS IRSA", "detected");
+  card.append(adv);
+  card.append(el("p", { class: "form-hint", text: "IAM roles work even when nothing shows as set here." }));
   return card;
 }
 

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -267,6 +267,42 @@ try {
   cont.missingNeither ? ok("continuity: missing continuity (legacy backend) shows no green") : bad("continuity: missing continuity (legacy backend) shows no green", "rendered green without continuity");
   cont.nilNeither ? ok("continuity: nil stream shows neither box") : bad("continuity: nil stream shows neither box", "rendered a box for nil stream");
 
+  // Scenario 9 — Storage page AWS-credentials card (#681). credentialsCard is
+  // pure (like pgHealthCard/continuityBox): it must lead with a plain-language
+  // summary of which credential source is active, never leave the raw signals
+  // as the only content, and each of the mutually-favored signals (static
+  // env keys > IAM role > shared config > none) must produce distinct copy —
+  // an IAM-role or shared-config setup must never read as "no credentials".
+  const cred = await page.evaluate(() => {
+    const mk = (aws) => credentialsCard({ aws });
+    const none = mk({ access_key_env: false, profile: "", region_env: "", shared_config: false, container_creds: false, web_identity: false });
+    const keys = mk({ access_key_env: true, profile: "", region_env: "", shared_config: false, container_creds: false, web_identity: false });
+    const ecs = mk({ access_key_env: false, profile: "", region_env: "", shared_config: false, container_creds: true, web_identity: false });
+    const irsa = mk({ access_key_env: false, profile: "", region_env: "", shared_config: false, container_creds: false, web_identity: true });
+    const shared = mk({ access_key_env: false, profile: "default", region_env: "", shared_config: true, container_creds: false, web_identity: false });
+    const adv = none.querySelector("details.form-advanced");
+    return {
+      noneSummary: /No static credentials configured/.test(none.textContent),
+      keysSummary: /Static access keys configured via environment/.test(keys.textContent),
+      ecsSummary: /ECS task role detected/.test(ecs.textContent),
+      irsaSummary: /EKS IRSA detected/.test(irsa.textContent),
+      sharedSummary: /shared ~\/\.aws config\/profile/.test(shared.textContent),
+      hasDisclosure: !!adv,
+      disclosureCollapsed: !!adv && !adv.open,
+      hasToggle: !!none.querySelector("summary.form-adv-summary"),
+      rawRowCount: none.querySelectorAll(".kv").length,
+    };
+  });
+  cred.noneSummary ? ok("aws-creds: no signals renders the ambient-chain summary") : bad("aws-creds: no signals renders the ambient-chain summary", "wording missing");
+  cred.keysSummary ? ok("aws-creds: static env keys take priority in the summary") : bad("aws-creds: static env keys take priority in the summary", "wording missing");
+  cred.ecsSummary ? ok("aws-creds: ECS task role reads as an IAM role, not an error") : bad("aws-creds: ECS task role reads as an IAM role, not an error", "wording missing");
+  cred.irsaSummary ? ok("aws-creds: EKS IRSA reads as an IAM role, not an error") : bad("aws-creds: EKS IRSA reads as an IAM role, not an error", "wording missing");
+  cred.sharedSummary ? ok("aws-creds: shared ~/.aws config/profile never reads as 'no credentials'") : bad("aws-creds: shared ~/.aws config/profile never reads as 'no credentials'", "wording missing/contradicts raw signal");
+  cred.hasDisclosure ? ok("aws-creds: raw signals are folded behind a details disclosure") : bad("aws-creds: raw signals are folded behind a details disclosure", "no details.form-advanced");
+  cred.disclosureCollapsed ? ok("aws-creds: raw-signals disclosure is collapsed by default") : bad("aws-creds: raw-signals disclosure is collapsed by default", "rendered open");
+  cred.hasToggle ? ok("aws-creds: disclosure uses the app's toggle style") : bad("aws-creds: disclosure uses the app's toggle style", "missing summary.form-adv-summary");
+  cred.rawRowCount === 4 ? ok("aws-creds: all four raw signal rows still render") : bad("aws-creds: all four raw signal rows still render", `rawRowCount=${cred.rawRowCount}`);
+
   // No uncaught JS errors over the whole run.
   jsErrors.length === 0 ? ok("no uncaught JS errors") : bad("no uncaught JS errors", JSON.stringify(jsErrors));
 } catch (err) {


### PR DESCRIPTION
closes #681

## Summary
- `credentialsCard()` on the Storage page listed four env/config signals (access keys, profile, region, ~/.aws config) as neutral rows, with the reassuring credential-chain note appearing as small gray text *after* them — on an IAM-role setup (EC2 instance profile, ECS task role, EKS IRSA) all four read "not set"/"absent", reading as a wall of errors before the reassurance.
- The card now leads with a single top-line summary computed from signals `/api/storage` already exposes (`container_creds`/`web_identity`) — e.g. "Using an IAM role (ECS task role detected)" or "No static credentials configured — relying on the ambient AWS chain" — and folds the four raw signals behind a "Raw signals" `<details>` disclosure, reusing the existing `form-advanced` pattern.
- No backend change — the data was already available.

## Test plan
- [x] `go build ./...`
- [x] Manually verified in a real browser (source-less `bintrail-console watch`, Storage page) under both an IAM-role-simulated environment and a plain no-credentials environment — summary line reads correctly in both, disclosure expands to show the four raw signals

🤖 Generated with [Claude Code](https://claude.com/claude-code)