### PR TITLE
console: mark Time-travel's PK and Table fields as required

### DIFF
--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -807,17 +807,22 @@ function renderEvents(params) {
   viewEnter();
 }
 
-function fieldInput(label, name, size, placeholder) {
+function fieldLabel(label, required) {
+  const lbl = el("label", { class: "field-label" }, label);
+  if (required) lbl.append(el("span", { class: "field-required", title: "Required", text: " *" }));
+  return lbl;
+}
+function fieldInput(label, name, size, placeholder, required) {
   return el("div", { class: "field field--" + size },
-    el("label", { class: "field-label", text: label }),
+    fieldLabel(label, required),
     el("input", { class: "input", name, placeholder: placeholder || "" }));
 }
-function fieldSelect(label, name, size, isSchema, isTable, options, anyLabel) {
+function fieldSelect(label, name, size, isSchema, isTable, options, anyLabel, required) {
   const sel = el("select", { class: "select" + (isSchema ? " schema-select" : "") + (isTable ? " table-select" : ""), name });
   if (options) options.forEach((o) => sel.append(opt(o, o === "" ? (anyLabel || "any") : o)));
   else sel.append(opt("", "any"));
   return el("div", { class: "field field--" + size },
-    el("label", { class: "field-label", text: label }), sel);
+    fieldLabel(label, required), sel);
 }
 
 // parseSmartQuery turns "type:delete pk:1006 orders" into structured filters +
@@ -1190,8 +1195,8 @@ function renderTimetravel(params) {
 
   const form = el("form", { class: "filters", id: "tt-form" });
   form.append(fieldSelect("Schema", "schema", "md", true, false, null, "— select —"));
-  form.append(fieldSelect("Table", "table", "md", false, true));
-  form.append(fieldInput("PK", "pk", "sm", "42 or 42|7"));
+  form.append(fieldSelect("Table", "table", "md", false, true, null, null, true));
+  form.append(fieldInput("PK", "pk", "sm", "42 or 42|7", true));
   form.append(fieldInput("As of", "at", "md", "YYYY-MM-DD HH:MM (default: now)"));
   const gapsField = el("div", { class: "field", style: "justify-content:flex-end" },
     el("label", { class: "check" }, el("input", { type: "checkbox", name: "allow_gaps" }), el("span", { text: "Allow coverage gaps" })));

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -364,6 +364,7 @@ button { font-family: inherit; }
   font-size: 11px; font-weight: 600; letter-spacing: 0.03em;
   color: var(--ink-3); text-transform: none;
 }
+.field-required { color: var(--orange-2); }
 .input, .select {
   appearance: none;
   font-family: var(--f-mono); font-size: 13px;


### PR DESCRIPTION
closes #680

## Summary
- Time-travel's PK field shared Recover's exact label + placeholder (`42 or 42|7`), where PK is genuinely optional. Neither field carried any visual "required" marker, so a user coming from Recover reasonably assumed PK was optional on Time-travel too and hit the client-side guard (`app.js` `runReconstruct`: `"schema, table, and pk are required"`) with no prior indication PK was mandatory here. (The server has its own, differently-worded 400 for the same condition — `"reconstruct requires schema, table, and pk"` in `reconstruct.go` — reached only if that client guard is bypassed.)
- Added an optional `required` param to `fieldInput`/`fieldSelect` (`internal/console/assets/app.js`) that appends a small orange asterisk to the field label (`.field-required` in `style.css`).
- Applied it to Time-travel's **Table** and **PK** fields only. Schema is required on both Time-travel and Recover with the identical widget, so marking it on Time-travel but not Recover would recreate the exact cross-screen inconsistency this issue reports — left untouched.
- Recover's fields are unchanged (no markers, since PK/Table are genuinely optional there).

## Verification
No Go tests touch console JS/CSS. Verified visually by serving `internal/console/assets/` as static files and, via headless Chrome, injecting `capsCache.reconstruct = true` and calling the real `renderTimetravel()`/`renderRecover()` render functions directly (bypassing the auth/backend boot sequence, which the JS assets alone can't satisfy):
- Time-travel: `Table *` and `PK *` render with the orange marker; `Schema` stays unmarked.
- Recover: no fields marked (`Schema`, `Table`, `PK` unchanged).

This confirms the DOM/CSS the fix produces, not a full authenticated end-to-end console session.

## Review
Reviewed in parallel by `code-reviewer` (approve — no broken call sites, scope decision justified by the two screens' actual validators), `silent-failure-hunter` (clean — no silent failures, no positional-arg breakage), and `comment-analyzer` (caught the client-vs-server error-string conflation fixed in this description).

## Test plan
- [x] `go test ./... -count=1` passes
- [x] `go build ./...` passes
- [x] Visual render check in headless Chrome (see Verification above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)