### PR TITLE
Console: full lifecycle for bintrail verify (trigger, poll, explain)

### DIFF
--- a/cmd/bintrail-console/verify.go
+++ b/cmd/bintrail-console/verify.go
@@ -1,0 +1,456 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/go-sql-driver/mysql"
+
+	"github.com/dbtrail/dbtrail/internal/config"
+	"github.com/dbtrail/dbtrail/internal/console"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/parquetquery"
+	"github.com/dbtrail/dbtrail/internal/query"
+	"github.com/dbtrail/dbtrail/internal/verify"
+)
+
+// verifySupervisor implements console.VerifyController by running
+// internal/verify's engine IN-PROCESS, one table at a time in a background
+// goroutine — the same functions internal/cli/verify.go calls, looped here
+// instead of printed (#677). It is fully self-sufficient like
+// baselineSupervisor: it opens its own index/source connections per run
+// rather than reaching into the console's per-server bundle, so it needs
+// nothing from internal/console beyond the DTOs/interface it implements.
+//
+// One job at a time per server, tracked in-memory — like baseline, the
+// durable record (when there is one) is the baseline snapshots themselves;
+// a verify run's result has no artifact of its own, so a console restart
+// loses it (mirrors BaselineStatus's "idle if never run in this process").
+type verifySupervisor struct {
+	ctx context.Context // daemon lifecycle; cancels an in-flight run on shutdown
+
+	mu   sync.Mutex
+	jobs map[string]*verifyJob
+}
+
+// verifyJob is the mutable per-server job state: the pollable status PLUS the
+// bookkeeping Explain needs that must never reach the wire — the exact
+// BaselinePair each mismatched table was verified against, and enough of the
+// request to reopen a connection on demand. Re-deriving the pair via a fresh
+// FindBaselinePair at explain time would risk explaining a DIFFERENT pair
+// than the one the displayed verdict came from, if a new baseline landed
+// in between (see internal/verify.FindBaselinePair's doc comment).
+type verifyJob struct {
+	status console.VerifyStatus
+	mode   console.VerifyMode
+
+	indexDSN  string
+	noArchive bool
+
+	// pairs caches the BaselinePair behind every table this run reported as a
+	// mismatch, keyed "schema.table". Only populated for baseline-anchored
+	// runs (live-source has no explain support in the engine).
+	pairs map[string]verify.BaselinePair
+}
+
+// newVerifySupervisor builds a supervisor bound to the daemon context.
+func newVerifySupervisor(ctx context.Context) *verifySupervisor {
+	return &verifySupervisor{ctx: ctx, jobs: make(map[string]*verifyJob)}
+}
+
+// Trigger starts a verify run in the background; returns
+// console.ErrVerifyRunning if one is already in flight for this server.
+func (s *verifySupervisor) Trigger(req console.VerifyRequest) error {
+	s.mu.Lock()
+	if j, ok := s.jobs[req.ServerID]; ok && j.status.State == "running" {
+		s.mu.Unlock()
+		return console.ErrVerifyRunning
+	}
+	baselineSrc := req.BaselineDir
+	if baselineSrc == "" {
+		baselineSrc = req.BaselineS3
+	}
+	s.jobs[req.ServerID] = &verifyJob{
+		status:    console.VerifyStatus{State: "running", Mode: req.Mode, Since: nowStamp()},
+		mode:      req.Mode,
+		indexDSN:  req.IndexDSN,
+		noArchive: req.NoArchive,
+	}
+	s.mu.Unlock()
+
+	slog.Info("verify: starting in-process run", "server", req.ServerName, "id", req.ServerID, "mode", req.Mode)
+	go s.run(req, baselineSrc)
+	return nil
+}
+
+// Status returns a copy of the latest known run state (idle if never run here).
+func (s *verifySupervisor) Status(serverID string) console.VerifyStatus {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if j, ok := s.jobs[serverID]; ok {
+		return j.status
+	}
+	return console.VerifyStatus{State: "idle"}
+}
+
+// Explain re-runs the row-level drill-down for one table the last completed
+// baseline-anchored run reported as a mismatch, using the EXACT BaselinePair
+// that run verified — never a freshly re-derived one (see verifyJob's doc
+// comment). It opens its own short-lived index connection: the triggering
+// run's connection is already closed by the time an operator clicks Explain.
+func (s *verifySupervisor) Explain(serverID, schema, table string) (*console.VerifyExplanation, error) {
+	s.mu.Lock()
+	j, ok := s.jobs[serverID]
+	s.mu.Unlock()
+	if !ok || j.mode != console.VerifyModeBaselineAnchored {
+		return nil, console.ErrExplainUnavailable
+	}
+	pair, ok := j.pairs[schema+"."+table]
+	if !ok {
+		return nil, console.ErrExplainUnavailable
+	}
+
+	db, err := config.Connect(j.indexDSN)
+	if err != nil {
+		return nil, fmt.Errorf("connect index: %w", err)
+	}
+	defer db.Close()
+	resolver, err := metadata.NewResolver(db, 0)
+	if err != nil {
+		return nil, fmt.Errorf("load schema snapshot: %w", err)
+	}
+	// The pair already carries the resolved Prev/New Parquet paths — no need
+	// to re-resolve a baseline source dir/S3 prefix here.
+	cfg := verify.BaselineConfig{
+		IndexDB: db, Resolver: resolver, IndexDBName: indexDBName(j.indexDSN),
+		NoArchive: j.noArchive, ArchiveFetcher: parquetquery.Fetch,
+	}
+
+	ex, err := verify.ExplainBaselinePairMismatch(s.ctx, cfg, pair)
+	if err != nil {
+		return nil, fmt.Errorf("explain %s.%s: %w", schema, table, err)
+	}
+
+	var buf bytes.Buffer
+	ex.Write(&buf)
+	diffs := make([]console.VerifyRowDiff, len(ex.Diffs))
+	for i, d := range ex.Diffs {
+		cells := make([]console.VerifyCellDiff, len(d.Cells))
+		for j, c := range d.Cells {
+			cells[j] = console.VerifyCellDiff{Column: c.Column, Recovery: c.Recovery, Baseline: c.Baseline}
+		}
+		diffs[i] = console.VerifyRowDiff{PK: d.PK, Kind: d.Kind, Cells: cells}
+	}
+	return &console.VerifyExplanation{
+		Schema: ex.Schema, Table: ex.Table, Anchor: ex.Anchor,
+		Total: ex.Total, Diffs: diffs, Rendered: buf.String(),
+	}, nil
+}
+
+// run drives the verify engine to completion and publishes the final state.
+// Per-table results are appended as each table completes (see appendResult)
+// so Status polls see progress mid-run — internal/verify has no progress
+// callback of its own; this loop IS the streaming.
+func (s *verifySupervisor) run(req console.VerifyRequest, baselineSrc string) {
+	db, err := config.Connect(req.IndexDSN)
+	if err != nil {
+		s.finish(req.ServerID, fmt.Errorf("connect index: %w", err))
+		return
+	}
+	defer db.Close()
+	resolver, err := metadata.NewResolver(db, 0)
+	if err != nil {
+		// Hard requirement, no fallback — mirrors internal/cli/verify.go: a
+		// missing schema snapshot means verify cannot resolve primary keys.
+		s.finish(req.ServerID, fmt.Errorf("load schema snapshot (run `bintrail snapshot`): %w", err))
+		return
+	}
+	dbName := indexDBName(req.IndexDSN)
+
+	var runErr error
+	switch req.Mode {
+	case console.VerifyModeLiveSource:
+		runErr = s.runLiveSource(req, db, resolver, dbName)
+	default:
+		runErr = s.runBaselineAnchored(req, baselineSrc, db, resolver, dbName)
+	}
+	s.finish(req.ServerID, runErr)
+}
+
+func (s *verifySupervisor) runBaselineAnchored(req console.VerifyRequest, baselineSrc string, indexDB *sql.DB, resolver *metadata.Resolver, dbName string) error {
+	ctx := s.ctx
+	pairs, unpaired, prevOnly, err := verify.FindBaselinePair(ctx, baselineSrc)
+	if err != nil {
+		return fmt.Errorf("list baselines: %w", err)
+	}
+	if len(pairs) == 0 && len(unpaired) == 0 {
+		any, err := verify.AnyBaseline(ctx, baselineSrc)
+		if err != nil {
+			return fmt.Errorf("list baselines: %w", err)
+		}
+		if !any {
+			return fmt.Errorf("no baselines found under the configured baseline destination")
+		}
+		s.setNote(req.ServerID, "only one baseline exists for this server yet — nothing to compare")
+		return nil
+	}
+	sort.Slice(pairs, func(i, j int) bool {
+		if pairs[i].Schema != pairs[j].Schema {
+			return pairs[i].Schema < pairs[j].Schema
+		}
+		return pairs[i].Table < pairs[j].Table
+	})
+
+	filter, seen := tableFilter(req.Tables)
+	cfg := verify.BaselineConfig{
+		IndexDB: indexDB, Resolver: resolver, IndexDBName: dbName,
+		NoArchive: req.NoArchive, ArchiveFetcher: parquetquery.Fetch,
+	}
+
+	for _, p := range pairs {
+		key := p.Schema + "." + p.Table
+		if filter != nil && !filter[key] {
+			continue
+		}
+		delete(seen, key)
+		res, err := verify.VerifyBaselinePair(ctx, cfg, p)
+		if err != nil {
+			res = verify.TableResult{Schema: p.Schema, Table: p.Table, Status: verify.StatusError, Detail: err.Error()}
+		}
+		if res.Status == verify.StatusMismatch {
+			s.cachePair(req.ServerID, key, p)
+		}
+		s.appendResult(req.ServerID, toWireResult(res, res.Status == verify.StatusMismatch))
+	}
+	for _, st := range unpaired {
+		key := st.Schema + "." + st.Table
+		if filter != nil && !filter[key] {
+			continue
+		}
+		delete(seen, key)
+		s.appendResult(req.ServerID, console.VerifyTableResult{
+			Schema: st.Schema, Table: st.Table, Status: string(verify.StatusInconclusive),
+			Detail: "new since the previous baseline — no predecessor image to reconstruct from",
+		})
+	}
+	for _, st := range prevOnly {
+		key := st.Schema + "." + st.Table
+		if filter != nil && !filter[key] {
+			continue
+		}
+		delete(seen, key)
+		s.appendResult(req.ServerID, console.VerifyTableResult{
+			Schema: st.Schema, Table: st.Table, Status: string(verify.StatusInconclusive),
+			Detail: "absent from the newest baseline (dropped, or the newest baseline was a --tables subset)",
+		})
+	}
+	for key := range seen {
+		schema, table, _ := strings.Cut(key, ".")
+		s.appendResult(req.ServerID, console.VerifyTableResult{
+			Schema: schema, Table: table, Status: string(verify.StatusError),
+			Detail: "requested via the tables filter but not present in the latest baseline pair",
+		})
+	}
+	return nil
+}
+
+func (s *verifySupervisor) runLiveSource(req console.VerifyRequest, indexDB *sql.DB, resolver *metadata.Resolver, dbName string) error {
+	ctx := s.ctx
+	sourceDB, err := config.Connect(req.SourceDSN)
+	if err != nil {
+		return fmt.Errorf("connect source: %w", err)
+	}
+	defer sourceDB.Close()
+
+	tables, err := liveSourceTargetTables(ctx, indexDB, req.Tables)
+	if err != nil {
+		return fmt.Errorf("resolve target tables: %w", err)
+	}
+
+	baselineSrc := req.BaselineDir
+	if baselineSrc == "" {
+		baselineSrc = req.BaselineS3
+	}
+	cfg := verify.Config{
+		SourceDB: sourceDB, IndexDB: indexDB, Resolver: resolver,
+		BaselineSource: baselineSrc, IndexDBName: dbName,
+		NoArchive: req.NoArchive, ArchiveFetcher: parquetquery.Fetch,
+	}
+	for _, st := range tables {
+		res, err := verify.VerifyTable(ctx, cfg, st.Schema, st.Table)
+		if err != nil {
+			res = verify.TableResult{Schema: st.Schema, Table: st.Table, Status: verify.StatusError, Detail: err.Error()}
+		}
+		// Live-source mismatches have no explain support in the engine.
+		s.appendResult(req.ServerID, toWireResult(res, false))
+	}
+	return nil
+}
+
+// liveSourceTargetTables mirrors internal/cli/verify.go's unexported
+// verifyTargetTables: an explicit --tables-style filter, or every table in
+// the latest schema snapshot. No new internal/verify logic — this is the same
+// small orchestration query the CLI runs, kept local since the CLI's helper
+// isn't exported.
+func liveSourceTargetTables(ctx context.Context, indexDB *sql.DB, tables []string) ([]query.SchemaTable, error) {
+	if len(tables) > 0 {
+		out := make([]query.SchemaTable, 0, len(tables))
+		for _, t := range tables {
+			schema, table, ok := strings.Cut(t, ".")
+			if !ok {
+				return nil, fmt.Errorf("invalid table filter %q (want schema.table)", t)
+			}
+			out = append(out, query.SchemaTable{Schema: schema, Table: table})
+		}
+		sort.Slice(out, func(i, j int) bool {
+			if out[i].Schema != out[j].Schema {
+				return out[i].Schema < out[j].Schema
+			}
+			return out[i].Table < out[j].Table
+		})
+		return out, nil
+	}
+	rows, err := indexDB.QueryContext(ctx,
+		`SELECT DISTINCT schema_name, table_name FROM schema_snapshots
+		 WHERE snapshot_id = (SELECT MAX(snapshot_id) FROM schema_snapshots)
+		 ORDER BY schema_name, table_name`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []query.SchemaTable
+	for rows.Next() {
+		var st query.SchemaTable
+		if err := rows.Scan(&st.Schema, &st.Table); err != nil {
+			return nil, err
+		}
+		out = append(out, st)
+	}
+	return out, rows.Err()
+}
+
+// tableFilter builds a lookup set from a "schema.table" list (nil filter = no
+// restriction) plus a mutable "seen" copy the caller deletes from as each
+// entry is matched — whatever remains at the end was requested but never
+// found, mirroring the CLI's --tables-not-present-in-pair StatusError.
+func tableFilter(tables []string) (filter map[string]bool, seen map[string]bool) {
+	if len(tables) == 0 {
+		return nil, nil
+	}
+	filter = make(map[string]bool, len(tables))
+	seen = make(map[string]bool, len(tables))
+	for _, t := range tables {
+		filter[t] = true
+		seen[t] = true
+	}
+	return filter, seen
+}
+
+func toWireResult(res verify.TableResult, explainable bool) console.VerifyTableResult {
+	return console.VerifyTableResult{
+		Schema: res.Schema, Table: res.Table, Status: string(res.Status), Detail: res.Detail,
+		SourceRows: res.SourceRows, ReconstructRows: res.ReconstructRows, Anchor: res.Anchor,
+		Explainable: explainable,
+	}
+}
+
+// appendResult publishes one table's outcome under the job lock, so a
+// concurrent Status() poll sees it immediately — the "as they land" progress
+// #677 asks for.
+func (s *verifySupervisor) appendResult(serverID string, tr console.VerifyTableResult) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	j, ok := s.jobs[serverID]
+	if !ok {
+		return // job was cleared out from under us; drop (defensive, shouldn't happen)
+	}
+	j.status.Results = append(j.status.Results, tr)
+	switch verify.Status(tr.Status) {
+	case verify.StatusMatch:
+		j.status.Summary.Match++
+	case verify.StatusMismatch:
+		j.status.Summary.Mismatch++
+	case verify.StatusInconclusive:
+		j.status.Summary.Inconclusive++
+	default:
+		j.status.Summary.Error++
+	}
+}
+
+// cachePair records the BaselinePair behind a mismatched table for a later
+// on-demand Explain call. Must be called before appendResult's status update
+// is polled by a racing Explain — both are under s.mu, and cachePair always
+// runs first in the caller, so a client can never observe Explainable:true
+// before the pair is actually cached.
+func (s *verifySupervisor) cachePair(serverID, key string, p verify.BaselinePair) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	j, ok := s.jobs[serverID]
+	if !ok {
+		return
+	}
+	if j.pairs == nil {
+		j.pairs = make(map[string]verify.BaselinePair)
+	}
+	j.pairs[key] = p
+}
+
+// setNote records a benign informational message for the run (e.g. "only one
+// baseline yet") and marks it succeeded — this is not a failure.
+func (s *verifySupervisor) setNote(serverID, note string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	j, ok := s.jobs[serverID]
+	if !ok {
+		return
+	}
+	j.status.State = "succeeded"
+	j.status.Note = note
+	j.status.FinishedAt = nowStamp()
+}
+
+// finish marks a run's terminal state. err (from the run's own setup, e.g. a
+// connect failure) fails the whole run; per-table failures never reach here —
+// they are recorded as StatusError results by appendResult instead, exactly
+// like internal/cli/verify.go's per-table error isolation.
+func (s *verifySupervisor) finish(serverID string, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	j, ok := s.jobs[serverID]
+	if !ok {
+		j = &verifyJob{status: console.VerifyStatus{}}
+		s.jobs[serverID] = j
+	}
+	if j.status.State == "succeeded" {
+		return // setNote already finalized this run (the one-baseline no-op path)
+	}
+	j.status.FinishedAt = nowStamp()
+	if err != nil {
+		j.status.State = "failed"
+		j.status.LastError = err.Error()
+		slog.Error("verify: run failed", "server", serverID, "error", err)
+		return
+	}
+	j.status.State = "succeeded"
+	slog.Info("verify: run complete", "server", serverID,
+		"match", j.status.Summary.Match, "mismatch", j.status.Summary.Mismatch,
+		"inconclusive", j.status.Summary.Inconclusive, "error", j.status.Summary.Error)
+}
+
+// indexDBName extracts the database name from an index DSN, mirroring
+// internal/cli/verify.go's own tolerant handling: a parse failure just leaves
+// it empty rather than failing the run (IndexDBName is used for planner
+// diagnostics, not correctness).
+func indexDBName(dsn string) string {
+	cfg, err := mysql.ParseDSN(dsn)
+	if err != nil {
+		return ""
+	}
+	return cfg.DBName
+}

--- a/cmd/bintrail-console/verify.go
+++ b/cmd/bintrail-console/verify.go
@@ -105,18 +105,29 @@ func (s *verifySupervisor) Status(serverID string) console.VerifyStatus {
 // comment). It opens its own short-lived index connection: the triggering
 // run's connection is already closed by the time an operator clicks Explain.
 func (s *verifySupervisor) Explain(serverID, schema, table string) (*console.VerifyExplanation, error) {
+	// Copy everything needed out of the job under the SAME critical section:
+	// j.pairs is a plain map, mutated by cachePair from the run's goroutine
+	// while a run is still in flight (mismatches on later tables cache in
+	// after earlier ones have already been polled/explained) — reading it
+	// after releasing the lock would race that write.
 	s.mu.Lock()
 	j, ok := s.jobs[serverID]
-	s.mu.Unlock()
-	if !ok || j.mode != console.VerifyModeBaselineAnchored {
-		return nil, console.ErrExplainUnavailable
+	var (
+		indexDSN  string
+		noArchive bool
+		pair      verify.BaselinePair
+		pairOK    bool
+	)
+	if ok && j.mode == console.VerifyModeBaselineAnchored {
+		indexDSN, noArchive = j.indexDSN, j.noArchive
+		pair, pairOK = j.pairs[schema+"."+table]
 	}
-	pair, ok := j.pairs[schema+"."+table]
-	if !ok {
+	s.mu.Unlock()
+	if !pairOK {
 		return nil, console.ErrExplainUnavailable
 	}
 
-	db, err := config.Connect(j.indexDSN)
+	db, err := config.Connect(indexDSN)
 	if err != nil {
 		return nil, fmt.Errorf("connect index: %w", err)
 	}
@@ -128,8 +139,8 @@ func (s *verifySupervisor) Explain(serverID, schema, table string) (*console.Ver
 	// The pair already carries the resolved Prev/New Parquet paths — no need
 	// to re-resolve a baseline source dir/S3 prefix here.
 	cfg := verify.BaselineConfig{
-		IndexDB: db, Resolver: resolver, IndexDBName: indexDBName(j.indexDSN),
-		NoArchive: j.noArchive, ArchiveFetcher: parquetquery.Fetch,
+		IndexDB: db, Resolver: resolver, IndexDBName: indexDBName(indexDSN),
+		NoArchive: noArchive, ArchiveFetcher: parquetquery.Fetch,
 	}
 
 	ex, err := verify.ExplainBaselinePairMismatch(s.ctx, cfg, pair)
@@ -158,6 +169,16 @@ func (s *verifySupervisor) Explain(serverID, schema, table string) (*console.Ver
 // so Status polls see progress mid-run — internal/verify has no progress
 // callback of its own; this loop IS the streaming.
 func (s *verifySupervisor) run(req console.VerifyRequest, baselineSrc string) {
+	// A panic here must NEVER take down the daemon: this background goroutine
+	// shares the process with the stream and console under `watch`. Mirrors
+	// rotation.StartLoop's and the baseline-prune loop's guard.
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("verify: run panicked", "server", req.ServerID, "panic", r)
+			s.finish(req.ServerID, fmt.Errorf("internal error: %v", r))
+		}
+	}()
+
 	db, err := config.Connect(req.IndexDSN)
 	if err != nil {
 		s.finish(req.ServerID, fmt.Errorf("connect index: %w", err))
@@ -401,8 +422,14 @@ func (s *verifySupervisor) cachePair(serverID, key string, p verify.BaselinePair
 	j.pairs[key] = p
 }
 
-// setNote records a benign informational message for the run (e.g. "only one
-// baseline yet") and marks it succeeded — this is not a failure.
+// setNote records a benign informational message for the run in progress
+// (e.g. "only one baseline yet") WITHOUT changing State — finish, called
+// once at the tail of run() regardless of which branch it took, is the sole
+// place that transitions State out of "running". Setting State here too
+// would let it leave "running" before the goroutine's actual terminal call,
+// opening a window where a second concurrent Trigger for the same server is
+// wrongly admitted (State != "running" already) and finish's caller ends up
+// racing two jobs' state under one map entry.
 func (s *verifySupervisor) setNote(serverID, note string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -410,15 +437,14 @@ func (s *verifySupervisor) setNote(serverID, note string) {
 	if !ok {
 		return
 	}
-	j.status.State = "succeeded"
 	j.status.Note = note
-	j.status.FinishedAt = nowStamp()
 }
 
-// finish marks a run's terminal state. err (from the run's own setup, e.g. a
-// connect failure) fails the whole run; per-table failures never reach here —
-// they are recorded as StatusError results by appendResult instead, exactly
-// like internal/cli/verify.go's per-table error isolation.
+// finish marks a run's terminal state — the ONLY place State leaves
+// "running" (see setNote). err (from the run's own setup, e.g. a connect
+// failure) fails the whole run; per-table failures never reach here — they
+// are recorded as StatusError results by appendResult instead, exactly like
+// internal/cli/verify.go's per-table error isolation.
 func (s *verifySupervisor) finish(serverID string, err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -426,9 +452,6 @@ func (s *verifySupervisor) finish(serverID string, err error) {
 	if !ok {
 		j = &verifyJob{status: console.VerifyStatus{}}
 		s.jobs[serverID] = j
-	}
-	if j.status.State == "succeeded" {
-		return // setNote already finalized this run (the one-baseline no-op path)
 	}
 	j.status.FinishedAt = nowStamp()
 	if err != nil {

--- a/cmd/bintrail-console/verify.go
+++ b/cmd/bintrail-console/verify.go
@@ -43,9 +43,15 @@ type verifySupervisor struct {
 // bookkeeping Explain needs that must never reach the wire — the exact
 // BaselinePair each mismatched table was verified against, and enough of the
 // request to reopen a connection on demand. Re-deriving the pair via a fresh
-// FindBaselinePair at explain time would risk explaining a DIFFERENT pair
-// than the one the displayed verdict came from, if a new baseline landed
-// in between (see internal/verify.FindBaselinePair's doc comment).
+// internal/verify.FindBaselinePair call at explain time would risk explaining
+// a DIFFERENT pair than the one the displayed verdict came from, if a new
+// baseline landed in between (FindBaselinePair always picks the two MOST
+// RECENT snapshots).
+//
+// Every field is read/written ONLY while holding verifySupervisor.mu — a
+// plain map (pairs) and a growing slice (status.Results) make an unlocked
+// read from one goroutine race a locked write from another (see Explain's
+// and appendResult's comments for the specific hazard this closes).
 type verifyJob struct {
 	status console.VerifyStatus
 	mode   console.VerifyMode

--- a/cmd/bintrail-console/verify_test.go
+++ b/cmd/bintrail-console/verify_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/dbtrail/dbtrail/internal/console"
@@ -55,5 +57,106 @@ func TestIndexDBName(t *testing.T) {
 	}
 	if got := indexDBName("not a dsn"); got != "" {
 		t.Errorf("indexDBName(invalid) = %q, want empty", got)
+	}
+}
+
+// TestVerifySupervisor_Status_idleDefault: a server never triggered here
+// reports idle, never a zero-value State.
+func TestVerifySupervisor_Status_idleDefault(t *testing.T) {
+	s := newVerifySupervisor(context.Background())
+	if got := s.Status("never-triggered"); got.State != "idle" {
+		t.Errorf("Status = %+v, want State=idle", got)
+	}
+}
+
+// TestVerifySupervisor_Trigger_collision: a job already running for a server
+// refuses a second Trigger with ErrVerifyRunning and leaves the running job
+// untouched — exercises the exact single-flight guard the whole "one run at
+// a time per server" invariant depends on.
+func TestVerifySupervisor_Trigger_collision(t *testing.T) {
+	s := newVerifySupervisor(context.Background())
+	s.jobs["srv1"] = &verifyJob{status: console.VerifyStatus{State: "running", Since: "t0"}}
+
+	err := s.Trigger(console.VerifyRequest{ServerID: "srv1"})
+	if !errors.Is(err, console.ErrVerifyRunning) {
+		t.Fatalf("Trigger while running: err = %v, want ErrVerifyRunning", err)
+	}
+	if got := s.Status("srv1"); got.Since != "t0" {
+		t.Errorf("a rejected Trigger must not touch the in-flight job, got %+v", got)
+	}
+}
+
+// TestVerifySupervisor_appendResult_accumulatesSummary: results grow in
+// call order and each status bucket (including an unrecognized status
+// falling through to Error, mirroring the CLI's anti-false-assurance
+// classification in printVerifyReport) is tallied correctly — this is the
+// exact bookkeeping "as they land" polling depends on.
+func TestVerifySupervisor_appendResult_accumulatesSummary(t *testing.T) {
+	s := newVerifySupervisor(context.Background())
+	s.jobs["srv1"] = &verifyJob{status: console.VerifyStatus{State: "running"}}
+
+	s.appendResult("srv1", console.VerifyTableResult{Schema: "wp", Table: "posts", Status: "match"})
+	s.appendResult("srv1", console.VerifyTableResult{Schema: "wp", Table: "users", Status: "mismatch"})
+	s.appendResult("srv1", console.VerifyTableResult{Schema: "wp", Table: "opts", Status: "inconclusive"})
+	s.appendResult("srv1", console.VerifyTableResult{Schema: "wp", Table: "bad", Status: "something-unrecognized"})
+
+	got := s.Status("srv1")
+	if len(got.Results) != 4 || got.Results[0].Table != "posts" || got.Results[3].Table != "bad" {
+		t.Fatalf("Results = %+v, want 4 entries in append order", got.Results)
+	}
+	want := console.VerifySummary{Match: 1, Mismatch: 1, Inconclusive: 1, Error: 1}
+	if got.Summary != want {
+		t.Errorf("Summary = %+v, want %+v (an unrecognized status must fall through to Error)", got.Summary, want)
+	}
+
+	// appendResult on an unknown server id (job cleared out from under it) is
+	// a defensive no-op, never a panic.
+	s.appendResult("unknown-server", console.VerifyTableResult{Schema: "a", Table: "b", Status: "match"})
+}
+
+// TestVerifySupervisor_setNote_doesNotChangeState: setNote must leave State
+// as "running" — finish() is the sole terminal-state transition. Regression
+// guard for the race where setNote setting State="succeeded" itself let a
+// second concurrent Trigger in before the goroutine's own finish() ran,
+// which could suppress that second run's real failure.
+func TestVerifySupervisor_setNote_doesNotChangeState(t *testing.T) {
+	s := newVerifySupervisor(context.Background())
+	s.jobs["srv1"] = &verifyJob{status: console.VerifyStatus{State: "running"}}
+
+	s.setNote("srv1", "only one baseline exists for this server yet — nothing to compare")
+	if got := s.Status("srv1"); got.State != "running" || got.Note == "" {
+		t.Fatalf("after setNote: %+v, want State still running with Note set", got)
+	}
+	// A concurrent Trigger must still see this job as in-flight.
+	if err := s.Trigger(console.VerifyRequest{ServerID: "srv1"}); !errors.Is(err, console.ErrVerifyRunning) {
+		t.Errorf("Trigger after setNote (before finish): err = %v, want ErrVerifyRunning", err)
+	}
+
+	s.finish("srv1", nil)
+	got := s.Status("srv1")
+	if got.State != "succeeded" || got.Note == "" || got.FinishedAt == "" {
+		t.Errorf("after finish: %+v, want State=succeeded with Note preserved and FinishedAt set", got)
+	}
+}
+
+// TestVerifySupervisor_Explain_preconditions: all three "nothing to explain"
+// cases refuse with ErrExplainUnavailable and never dial a database — no job
+// for the server, a live-source run (no explain support in the engine), and
+// a baseline-anchored run where the requested table was never a mismatch.
+func TestVerifySupervisor_Explain_preconditions(t *testing.T) {
+	s := newVerifySupervisor(context.Background())
+
+	if _, err := s.Explain("no-such-server", "wp", "posts"); !errors.Is(err, console.ErrExplainUnavailable) {
+		t.Errorf("no job: err = %v, want ErrExplainUnavailable", err)
+	}
+
+	s.jobs["live"] = &verifyJob{status: console.VerifyStatus{State: "succeeded"}, mode: console.VerifyModeLiveSource}
+	if _, err := s.Explain("live", "wp", "posts"); !errors.Is(err, console.ErrExplainUnavailable) {
+		t.Errorf("live-source run: err = %v, want ErrExplainUnavailable (no explain support in that mode)", err)
+	}
+
+	s.jobs["baseline"] = &verifyJob{status: console.VerifyStatus{State: "succeeded"}, mode: console.VerifyModeBaselineAnchored}
+	if _, err := s.Explain("baseline", "wp", "never_mismatched"); !errors.Is(err, console.ErrExplainUnavailable) {
+		t.Errorf("table never cached as a mismatch: err = %v, want ErrExplainUnavailable", err)
 	}
 }

--- a/cmd/bintrail-console/verify_test.go
+++ b/cmd/bintrail-console/verify_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/console"
+	"github.com/dbtrail/dbtrail/internal/verify"
+)
+
+// TestTableFilter covers the nil-vs-empty semantics: no filter means "verify
+// everything" (nil map, never restricts), a non-empty filter tracks what it
+// has and hasn't matched via the mutable seen copy.
+func TestTableFilter(t *testing.T) {
+	if filter, seen := tableFilter(nil); filter != nil || seen != nil {
+		t.Fatalf("no filter: got filter=%v seen=%v, want both nil", filter, seen)
+	}
+	filter, seen := tableFilter([]string{"wp.posts", "wp.users"})
+	if len(filter) != 2 || !filter["wp.posts"] || !filter["wp.users"] {
+		t.Fatalf("filter = %v, want both entries set", filter)
+	}
+	delete(seen, "wp.posts")
+	if len(seen) != 1 || !seen["wp.users"] {
+		t.Fatalf("seen after delete = %v, want only wp.users left", seen)
+	}
+}
+
+// TestToWireResult covers the field mapping from the engine's TableResult to
+// the console DTO, including the explainable flag being caller-controlled
+// (not derived from Status alone — a live-source mismatch must never claim
+// explainable, since the engine has no explain support for that mode).
+func TestToWireResult(t *testing.T) {
+	res := verify.TableResult{
+		Schema: "wp", Table: "posts", Status: verify.StatusMismatch, Detail: "row count differs",
+		SourceRows: 10, ReconstructRows: 9, Anchor: "mysql-bin.000123:456",
+	}
+	got := toWireResult(res, true)
+	want := console.VerifyTableResult{
+		Schema: "wp", Table: "posts", Status: "mismatch", Detail: "row count differs",
+		SourceRows: 10, ReconstructRows: 9, Anchor: "mysql-bin.000123:456", Explainable: true,
+	}
+	if got != want {
+		t.Errorf("toWireResult = %+v, want %+v", got, want)
+	}
+	if got := toWireResult(res, false); got.Explainable {
+		t.Error("explainable must be exactly what the caller passed, not re-derived from Status")
+	}
+}
+
+// TestIndexDBName covers the tolerant DSN-parse-failure handling (mirrors
+// internal/cli/verify.go: a bad DSN never crashes DB-name resolution, it's
+// simply left empty).
+func TestIndexDBName(t *testing.T) {
+	if got := indexDBName("idx:pw@tcp(127.0.0.1:3306)/binlog_index"); got != "binlog_index" {
+		t.Errorf("indexDBName = %q, want binlog_index", got)
+	}
+	if got := indexDBName("not a dsn"); got != "" {
+		t.Errorf("indexDBName(invalid) = %q, want empty", got)
+	}
+}

--- a/cmd/bintrail-console/watch.go
+++ b/cmd/bintrail-console/watch.go
@@ -86,6 +86,12 @@ var (
 	// upBaselineStageDir is the local staging base for S3-destined baselines
 	// (BINTRAIL_CONSOLE_BASELINE_STAGING); default a temp subdir.
 	upBaselineStageDir string
+	// upConsoleVerifyTrigger opts into in-process bintrail verify runs from the
+	// console (#677). Env-only (BINTRAIL_CONSOLE_VERIFY_TRIGGER=1) — off by
+	// default for a bare `watch` invocation; unlike baseline-trigger it starts
+	// no subprocess and reads no live source in its default (baseline-anchored)
+	// mode, so the bundled compose stack defaults it ON (see docker-compose.yml).
+	upConsoleVerifyTrigger bool
 
 	upRotateRetain    string
 	upRotateInterval  string
@@ -367,6 +373,9 @@ func runUpConsoleOnly(cmd *cobra.Command) error {
 	if upConsoleBaselineTrigger {
 		cfg.BaselineCtrl = newBaselineSupervisor(ctx, baselineStagingDir())
 	}
+	if upConsoleVerifyTrigger {
+		cfg.VerifyCtrl = newVerifySupervisor(ctx)
+	}
 
 	// Built-in rotation covers the boot index plus every per-source database
 	// the control plane provisions — the unattended quickstart's real data
@@ -473,6 +482,9 @@ func runUpStreamWithConsole(cmd *cobra.Command, args []string) error {
 	cfg.MonitorCtrl = supervisor
 	if upConsoleBaselineTrigger {
 		cfg.BaselineCtrl = newBaselineSupervisor(ctx, baselineStagingDir())
+	}
+	if upConsoleVerifyTrigger {
+		cfg.VerifyCtrl = newVerifySupervisor(ctx)
 	}
 
 	// Built-in rotation: boot index + every per-source database the control
@@ -641,6 +653,10 @@ func resolveUpConsoleEnv(cmd *cobra.Command) {
 	}
 	if v := os.Getenv("BINTRAIL_CONSOLE_BASELINE_STAGING"); v != "" {
 		upBaselineStageDir = v
+	}
+	// Verify trigger is env-only (no flag), same shape as baseline trigger.
+	if v := os.Getenv("BINTRAIL_CONSOLE_VERIFY_TRIGGER"); v == "1" || v == "true" {
+		upConsoleVerifyTrigger = true
 	}
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -259,6 +259,16 @@ services:
       # volume.
       BINTRAIL_CONSOLE_BASELINE_TRIGGER: ${BASELINE_TRIGGER:-1}
       BINTRAIL_CONSOLE_BASELINE_STAGING: /var/lib/bintrail/baseline-staging
+      # "Run verification" button (#677): lets the console run `bintrail verify`
+      # in-process for a monitored server (trigger, poll per-table results,
+      # explain a mismatch) — the same read-only baseline/index reads the
+      # console already does for Reconstruct, no subprocess and no live-source
+      # read in its default (baseline-anchored) mode. Lower risk than the
+      # Create-baseline button above, so it defaults ON without an opt-in
+      # period; set VERIFY_TRIGGER=0 in .env to disable. A server still needs
+      # a baseline dir/S3 configured (baseline-anchored) or a source DSN
+      # (live-source) before the button does anything.
+      BINTRAIL_CONSOLE_VERIFY_TRIGGER: ${VERIFY_TRIGGER:-1}
       # Password login (persists next to the registry). On first run the
       # console serves a "create your password" screen; later visits sign in.
       # There is deliberately NO password env var: docker inspect must never

--- a/docs/console.md
+++ b/docs/console.md
@@ -311,6 +311,44 @@ straight from the Storage page, and it only runs on the `watch` daemon:
 The button is hidden on the read-only `serve` console and whenever the trigger
 is disabled — the CLI/compose recipe in the empty state remains the
 always-available path.
+
+#### Running verification from the console
+
+The Storage page's **Verification** panel runs [`bintrail verify`](verify.md)
+in-process for the selected server — trigger a run, watch per-table results
+land as they complete, and drill into a mismatch — instead of only reading
+results a `verify` cron/CI run produced elsewhere:
+
+- Like the Create-baseline button, this only runs on the `watch` daemon; a
+  bare invocation needs `BINTRAIL_CONSOLE_VERIFY_TRIGGER=1`, while the bundled
+  compose stack enables it **by default** (`VERIFY_TRIGGER=0` in `.env` opts
+  out). Unlike baseline creation it starts no subprocess and, in its default
+  mode, reads no live source — the same in-process baseline/index reads the
+  console already does for Time-travel — so it skips the opt-in-then-flip
+  cycle baseline-trigger went through.
+- **Baseline-anchored** (the default) compares the two most recent baseline
+  snapshots, drift-free — no live source read. It needs a baseline
+  destination configured (same precondition as Time-travel) and at least two
+  snapshots; with only one, the run reports a benign "nothing to compare yet"
+  note rather than an error.
+- **Live-source** reconstructs each table to a consistent snapshot of the
+  actual source and compares — it needs the server's source DSN and reads the
+  *whole table* off production, so the panel warns to run it off-peak (see
+  [verify.md](verify.md)'s own warning). It only appears in the mode selector
+  when the server has a source DSN configured.
+- Per-table results are colored match / mismatch / inconclusive / error, the
+  same four outcomes `bintrail verify` reports. A mismatch found by a
+  baseline-anchored run gets an **Explain** button — an on-demand,
+  never-precomputed row-level drill-down (`--explain`'s console equivalent),
+  re-run only when clicked. Live-source mismatches have no explain support
+  (mirroring the CLI).
+- One run at a time per server (409 while one is in flight). Like baseline
+  jobs, a run's result lives only in the daemon's memory — restarting the
+  console loses it; there is no persisted run history.
+- Verify's baseline/live-source reads carry no RBAC redaction (like Time-travel's),
+  so the panel and its endpoints are unavailable whenever an RBAC profile
+  (`--profile`) is active.
+
 - **AWS credentials** — which ambient credential signals the daemon process
   can see: env keys (presence only, never values), `AWS_PROFILE`,
   `AWS_REGION`, a shared `~/.aws` config, ECS task-role / EKS IRSA markers.
@@ -363,6 +401,12 @@ always-available path.
   [docker.md](docker.md) — `BASELINE_TRIGGER=0` in `.env` opts out there).
 - `BINTRAIL_CONSOLE_BASELINE_STAGING` (`watch` only) — local staging dir for
   S3-destined baselines created by that button (default a temp subdir).
+- `BINTRAIL_CONSOLE_VERIFY_TRIGGER` (`watch` only) — `1`/`true` enables the
+  Storage page's **Verification** panel (runs `bintrail verify` in-process;
+  see [Running verification from the console](#running-verification-from-the-console)).
+  Off by default for a bare `watch` invocation; the bundled compose stack sets
+  this on by default (see [docker.md](docker.md) — `VERIFY_TRIGGER=0` in
+  `.env` opts out there).
 
 There is deliberately **no** environment variable for the password itself —
 env vars leak through `docker inspect`, `ps e`, and `/proc`; the password is

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -274,6 +274,12 @@ set `BASELINE_TRIGGER=0` in `.env` to disable it. The button still needs a
 source DSN and a baseline dir/S3 configured on the server before it does
 anything.
 
+The same Storage page also has a **Verification** panel (also on by default;
+`VERIFY_TRIGGER=0` in `.env` to disable) that runs `bintrail verify` in-process
+for the selected server — trigger a run, watch per-table match/mismatch/
+inconclusive results land, and drill into a mismatch — see
+[console.md](console.md#running-verification-from-the-console).
+
 Notes:
 
 - The dump uses mydumper light locking (`--sync-thread-lock-mode NO_LOCK
@@ -372,6 +378,7 @@ surface, use the demo image ([demo.md](./demo.md)).
 | `BASELINE_SCHEMAS` | compose `baseline` profile | Comma-separated schemas to snapshot (default: `SCHEMAS`; empty = all user schemas, system schemas excluded) |
 | `BASELINE_DIR` | compose (optional) | Baseline dir for the boot `SOURCE_DSN` entry — set `/var/lib/bintrail/baselines` after the first `baseline` profile run to enable Time-travel on it. Also enables full-table `_snapshot.*` on the `flashback` profile shim |
 | `BASELINE_TRIGGER` | compose (optional) | Enables the console's in-process **Create baseline** button (dump→convert→upload) for a monitored server; **on by default** — set `BASELINE_TRIGGER=0` to disable |
+| `VERIFY_TRIGGER` | compose (optional) | Enables the console's Storage **Verification** panel (runs `bintrail verify` in-process) for a monitored server; **on by default** — set `VERIFY_TRIGGER=0` to disable |
 | `SHIM_USER` | compose `flashback` profile | Login the time-travel `mysql` terminal authenticates with (required to start the `shim` service) |
 | `SHIM_PASSWORD` | compose `flashback` profile | Cleartext password for `SHIM_USER` (required) |
 | `SHIM_AUTH_METHOD` | compose `flashback` profile (optional) | Client auth plugin for the shim (default `mysql_native_password`; set `caching_sha2_password` for drivers that require it) |

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -1576,6 +1576,7 @@ function buildStorage(serversRes, rotation, storage, baselines) {
   const grid = el("div", { class: "ov-grid", style: "margin-top:18px" });
   grid.append(archivingPanel(servers, serversErr));
   grid.append(baselinesPanel(baselines, servers));
+  grid.append(verifyPanel(servers));
   v.append(grid);
   viewEnter();
 }
@@ -1785,6 +1786,187 @@ async function pollBaseline(id) {
   }
   return null;
 }
+
+// verifyPanel (#677): trigger/poll/explain the recovery-chain verification
+// engine (`bintrail verify`) for the selected server. Mirrors baselinesPanel's
+// structure — its own capability gate (verify_trigger, process-global, like
+// baseline_trigger) plus a per-server precondition (verify: a baseline is
+// configured; verify_live_source: a source DSN is also configured), both
+// re-enforced server-side so this gating is UX only.
+function verifyPanel(servers) {
+  const panel = el("section", { class: "ov-panel" });
+  const cur = (servers || []).find((s) => s.id === (currentServer || defaultServerId));
+  const head = el("div", { class: "ov-panel-head" }, el("h2", { class: "ov-panel-title", text: "Verification" }));
+  const list = el("div", { class: "stg-list vfy-list" });
+
+  if (!capsCache.verify_trigger) {
+    list.append(el("div", { class: "stg-empty" },
+      el("p", { class: "stg-empty-lead", text: "Verification from the console is not enabled." }),
+      el("p", { class: "stg-empty-sub", text:
+        "Start the watch daemon with BINTRAIL_CONSOLE_VERIFY_TRIGGER=1 (the bundled compose stack enables this by default; set VERIFY_TRIGGER=0 in .env to disable)." })));
+    panel.append(head, list);
+    return panel;
+  }
+  if (!cur || !cur.id) {
+    list.append(el("div", { class: "ev-empty", text: "Select a server to run verification." }));
+    panel.append(head, list);
+    return panel;
+  }
+
+  const modeSel = el("select", { class: "select vfy-mode" },
+    el("option", { value: "baseline-anchored", text: "Baseline-anchored (drift-free)" }));
+  if (capsCache.verify_live_source) {
+    modeSel.append(el("option", { value: "live-source", text: "Live-source (reads the whole table)" }));
+  }
+  const warn = el("p", { class: "form-hint vfy-livewarn", hidden: true, text:
+    "Live-source reads the entire table off your live source at a consistent snapshot — this can take a while and adds load. Run it off-peak." });
+  modeSel.onchange = () => { warn.hidden = modeSel.value !== "live-source"; };
+
+  const results = el("div", { class: "vfy-results" });
+  const btn = el("button", { class: "btn btn-sm", type: "button", text: "Run verification" });
+  const configured = !!capsCache.verify;
+  btn.disabled = !configured;
+  btn.onclick = () => createVerify(cur.id, modeSel.value, btn, results);
+  head.append(el("div", { class: "vfy-actions" }, modeSel, btn));
+  panel.append(head);
+
+  if (!configured) {
+    list.append(el("div", { class: "stg-empty" },
+      el("p", { class: "stg-empty-lead", text: "No baseline configured for this server yet." }),
+      el("p", { class: "stg-empty-sub", text:
+        "Baseline-anchored verification compares the two most recent baseline snapshots. Set a baseline directory or S3 prefix (Manage servers → Edit → Advanced) and create at least two snapshots." })));
+  } else {
+    list.append(warn);
+    renderVerifyResults(results, null, cur.id);
+    list.append(results);
+  }
+  panel.append(list);
+  return panel;
+}
+
+// createVerify triggers an in-process verify run on the daemon for the
+// selected server, then polls until it finishes, updating resultsEl live
+// after every poll tick so results appear "as they land" (#677) — the engine
+// itself has no progress callback; the console's own poll loop is the only
+// source of incremental updates.
+async function createVerify(id, mode, btn, resultsEl) {
+  if (btn) { btn.disabled = true; btn.textContent = "Running…"; }
+  const restore = () => { if (btn) { btn.disabled = false; btn.textContent = "Run verification"; } };
+  let status;
+  try {
+    status = (await api("/api/servers/" + encodeURIComponent(id) + "/verify", { method: "POST", body: { mode } })).verify;
+  } catch (err) {
+    toast("Verify failed: " + ((err && err.message) || err));
+    restore();
+    return;
+  }
+  renderVerifyResults(resultsEl, status, id);
+  toast("Verification started…");
+  const done = await pollVerify(id, (st) => renderVerifyResults(resultsEl, st, id));
+  restore();
+  if (done && done.state === "succeeded") {
+    const s = done.summary || {};
+    toast(done.note || ("Verification complete: " + s.match + " match, " + s.mismatch + " mismatch, " +
+      s.inconclusive + " inconclusive, " + s.error + " error"));
+  } else if (done) {
+    toast("Verification failed: " + (done.last_error || "unknown error"));
+  } else {
+    toast("Verification still running — check back shortly.");
+  }
+}
+
+// pollVerify polls the per-server verify status until it leaves "running" (or
+// a ~20-minute cap), invoking onTick after every poll so the caller can
+// re-render mid-run progress. Returns the terminal status, or null if it
+// never settled within the cap. Transient poll errors are ignored and retried.
+async function pollVerify(id, onTick) {
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+  for (let i = 0; i < 600; i++) {
+    await sleep(2000);
+    let st;
+    try {
+      st = (await api("/api/servers/" + encodeURIComponent(id) + "/verify")).verify;
+    } catch (_) {
+      continue; // a blip mid-run shouldn't abort the wait
+    }
+    if (st && onTick) onTick(st);
+    if (st && st.state !== "running") return st;
+  }
+  return null;
+}
+
+const VFY_STATUS_CLASS = { match: "pass", mismatch: "fail", error: "fail", inconclusive: "warn" };
+const VFY_STATUS_MARK = { pass: "✓", fail: "✗", warn: "!" };
+
+// renderVerifyResults draws the current run's summary + per-table cards into
+// container, reusing the doctor preflight card styling (pass/fail/warn) since
+// both are "a list of named checks, each with a status and free-text detail".
+function renderVerifyResults(container, status, id) {
+  clear(container);
+  if (!status || status.state === "idle") {
+    container.append(el("div", { class: "ev-empty", text: "No verification run yet." }));
+    return;
+  }
+  const stateLabel = { running: "RUNNING", succeeded: "DONE", failed: "FAILED" }[status.state] || status.state.toUpperCase();
+  const summaryRow = el("div", { class: "vfy-summary" },
+    el("span", { class: "chip chip-mon", text: stateLabel }));
+  if (status.mode) summaryRow.append(el("span", { class: "stg-age", text: status.mode }));
+  const s = status.summary || {};
+  if (status.results && status.results.length) {
+    summaryRow.append(el("span", { class: "stg-age", text:
+      s.match + " match · " + s.mismatch + " mismatch · " + s.inconclusive + " inconclusive · " + s.error + " error" }));
+  }
+  container.append(summaryRow);
+  if (status.note) container.append(el("p", { class: "form-hint", text: status.note }));
+  if (status.last_error) container.append(el("p", { class: "form-msg err", text: status.last_error }));
+
+  const cards = el("div", { class: "doctor-cards" });
+  (status.results || []).forEach((r) => {
+    const cls = VFY_STATUS_CLASS[r.status] || "warn";
+    const card = el("div", { class: "doctor-card " + cls });
+    card.append(el("span", { class: "dc-mark", text: VFY_STATUS_MARK[cls] || "?" }));
+    const body = el("div", { class: "dc-body" },
+      el("div", { class: "dc-name", text: r.schema + "." + r.table + " — " + r.status + (r.detail ? " — " + r.detail : "") }));
+    if (r.explainable) {
+      const explainBtn = el("button", { class: "btn btn-sm btn-ghost", type: "button", text: "Explain" });
+      explainBtn.onclick = () => openVerifyExplain(id, r.schema, r.table);
+      body.append(explainBtn);
+    }
+    card.append(body);
+    cards.append(card);
+  });
+  container.append(cards);
+}
+
+// openVerifyExplain fetches and shows the row-level drill-down for one
+// mismatched table, re-using the modal chrome showRotationDialog established.
+async function openVerifyExplain(id, schema, table) {
+  let ex;
+  try {
+    ex = (await api("/api/servers/" + encodeURIComponent(id) + "/verify/explain" +
+      "?schema=" + encodeURIComponent(schema) + "&table=" + encodeURIComponent(table))).explain;
+  } catch (err) {
+    toast("Explain failed: " + ((err && err.message) || err));
+    return;
+  }
+  const mount = document.getElementById("modal");
+  const scrim = el("div", { class: "modal-scrim show" });
+  const modal = el("div", { class: "modal", role: "dialog", "aria-label": "Verify mismatch drill-down" });
+  const head = el("div", { class: "modal-head" });
+  head.append(el("h2", { class: "modal-title", text: "Mismatch: " + ex.schema + "." + ex.table }));
+  head.append(el("p", { class: "modal-desc", text: ex.total + " differing row(s) at " + ex.anchor }));
+  head.append(el("button", { class: "modal-x", type: "button", text: "✕", onclick: closeVerifyExplain }));
+  modal.append(head);
+  modal.append(el("pre", { class: "dc-rem vfy-explain-pre", text: ex.rendered }));
+  const foot = el("div", { class: "modal-foot" });
+  foot.append(el("button", { class: "btn btn-ghost", type: "button", text: "Close", onclick: closeVerifyExplain }));
+  modal.append(foot);
+  scrim.append(modal);
+  scrim.addEventListener("click", (e) => { if (e.target === scrim) closeVerifyExplain(); });
+  mount.replaceChildren(scrim);
+}
+
+function closeVerifyExplain() { document.getElementById("modal").replaceChildren(); }
 
 // ── schemas / tables cascade ──────────────────────────────────────────────────
 

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -1864,6 +1864,7 @@ async function createVerify(id, mode, btn, resultsEl) {
   toast("Verification started…");
   const done = await pollVerify(id, (st) => renderVerifyResults(resultsEl, st, id));
   restore();
+  if (done) renderVerifyResults(resultsEl, done, id);
   if (done && done.state === "succeeded") {
     const s = done.summary || {};
     toast(done.note || ("Verification complete: " + s.match + " match, " + s.mismatch + " mismatch, " +
@@ -1886,8 +1887,17 @@ async function pollVerify(id, onTick) {
     let st;
     try {
       st = (await api("/api/servers/" + encodeURIComponent(id) + "/verify")).verify;
-    } catch (_) {
-      continue; // a blip mid-run shouldn't abort the wait
+    } catch (err) {
+      // 403/404 are durable (the feature got disabled, an RBAC profile came
+      // on, or the server was deleted mid-run) — the run this poll is
+      // watching is gone or unreachable, so retrying for the full ~20-minute
+      // cap would just leave the button stuck on "Running…". Everything else
+      // (network blip, 5xx) is presumed transient and retried. 401 is already
+      // handled centrally by api()'s sign-in gate.
+      if (err && (err.status === 403 || err.status === 404)) {
+        return { state: "failed", last_error: (err && err.message) || String(err) };
+      }
+      continue;
     }
     if (st && onTick) onTick(st);
     if (st && st.state !== "running") return st;

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -1280,6 +1280,14 @@ button { font-family: inherit; }
 .stg-empty { padding: 14px 4px; display: flex; flex-direction: column; gap: 7px; }
 .stg-empty-lead { margin: 0; font-size: 13.5px; font-weight: 600; color: var(--ink-2); }
 .stg-empty-sub { margin: 0; font-size: 12.5px; color: var(--ink-3); max-width: 52ch; }
+
+/* Verification panel (#677) */
+.vfy-actions { display: flex; align-items: center; gap: 8px; }
+.vfy-mode { max-width: 260px; }
+.vfy-livewarn { margin: 0 0 8px; color: var(--orange-2); }
+.vfy-results { display: flex; flex-direction: column; gap: 8px; }
+.vfy-summary { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+.vfy-explain-pre { max-height: 50vh; overflow-y: auto; }
 .stg-code {
   font-family: var(--f-mono); font-size: 11.5px; color: var(--ink-2);
   background: var(--surface-3); border-radius: 4px; padding: 7px 10px;

--- a/internal/console/reconstruct.go
+++ b/internal/console/reconstruct.go
@@ -63,8 +63,21 @@ type capabilitiesResponse struct {
 	// the console (the watch daemon opted in with BINTRAIL_CONSOLE_BASELINE_TRIGGER=1).
 	// Process-global, like Monitor — the endpoint does the per-server validation
 	// (source + baseline destination configured).
-	BaselineTrigger bool         `json:"baseline_trigger"`
-	Auth            authCapsInfo `json:"auth"`
+	BaselineTrigger bool `json:"baseline_trigger"`
+	// VerifyTrigger: this process can run bintrail verify in-process from the
+	// console (the watch daemon opted in with BINTRAIL_CONSOLE_VERIFY_TRIGGER=1).
+	// Process-global, like BaselineTrigger — the endpoint does the per-server/
+	// per-mode validation.
+	VerifyTrigger bool `json:"verify_trigger"`
+	// Verify: baseline-anchored verify is usable for the SELECTED server — a
+	// baseline destination is configured, mirroring Reconstruct's gate (both
+	// read baseline state with no RBAC redaction, so an active profile also
+	// forces this false — see rbacActive() below). Per-server.
+	Verify bool `json:"verify"`
+	// VerifyLiveSource: live-source verify is additionally usable — the
+	// selected server also has a source DSN configured. Per-server.
+	VerifyLiveSource bool         `json:"verify_live_source"`
+	Auth             authCapsInfo `json:"auth"`
 	// Source names the selected server's source database family — "postgresql"
 	// or "mysql" — derived per-server from stream_state.flavor (the same field
 	// DialectForIndex reads). It drives source-aware PRESENTATION only: the
@@ -104,6 +117,7 @@ func (s *Server) handleCapabilities(w http.ResponseWriter, r *http.Request) {
 	resp := capabilitiesResponse{
 		Monitor:         s.monitorCtrl != nil,
 		BaselineTrigger: s.baselineCtrl != nil,
+		VerifyTrigger:   s.verifyCtrl != nil,
 		// recover-cascade is the free tier (like recover) and process-global, gated
 		// only by the RBAC profile (which would make synthesis leak redacted data).
 		RecoverCascade: !s.rbacActive(),
@@ -118,6 +132,15 @@ func (s *Server) handleCapabilities(w http.ResponseWriter, r *http.Request) {
 		// capability can't over-promise (handler builds the provider only when both
 		// a baseline source and a resolver are present).
 		resp.RecoverCascadeBaseline = b.baselineConfigured && b.resolver != nil
+		// Verify's engine (baseline-anchored and live-source alike) carries no RBAC
+		// redaction — see verify_trigger.go — so an active profile forces both
+		// false here exactly as it forces Reconstruct false via baselineConfigured.
+		if s.verifyCtrl != nil && !s.rbacActive() {
+			resp.Verify = b.baselineSrc != ""
+			if e, ok := s.selectedEntry(r); ok {
+				resp.VerifyLiveSource = e.SourceDSN != ""
+			}
+		}
 		// Per-server source family, read from this index's stream_state.flavor.
 		// DialectForIndex is nil-safe and legacy-tolerant (any read error → MySQL),
 		// so a pre-flavor index simply presents as MySQL.

--- a/internal/console/reconstruct.go
+++ b/internal/console/reconstruct.go
@@ -133,10 +133,14 @@ func (s *Server) handleCapabilities(w http.ResponseWriter, r *http.Request) {
 		// a baseline source and a resolver are present).
 		resp.RecoverCascadeBaseline = b.baselineConfigured && b.resolver != nil
 		// Verify's engine (baseline-anchored and live-source alike) carries no RBAC
-		// redaction — see verify_trigger.go — so an active profile forces both
-		// false here exactly as it forces Reconstruct false via baselineConfigured.
+		// redaction — see verify_trigger.go — so this reuses baselineConfigured
+		// verbatim (not just b.baselineSrc != ""): that field already folds in
+		// !noArchive, and verify's own query.FetchMerged calls respect NoArchive
+		// too, so a no-archive server would otherwise advertise verify:true and
+		// then reliably fail with a coverage-gap error on any window touching a
+		// rotated-out hour — worse than just hiding it, like Reconstruct does.
 		if s.verifyCtrl != nil && !s.rbacActive() {
-			resp.Verify = b.baselineSrc != ""
+			resp.Verify = b.baselineConfigured
 			if e, ok := s.selectedEntry(r); ok {
 				resp.VerifyLiveSource = e.SourceDSN != ""
 			}

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -81,6 +81,12 @@ type Config struct {
 	// where the trigger endpoint refuses with 403 and /api/capabilities reports
 	// baseline_trigger:false. Set together with MonitorCtrl (both control-plane).
 	BaselineCtrl BaselineController
+	// VerifyCtrl runs bintrail verify's engine in-process for a monitored
+	// server (#677). Wired in ONLY by `bintrail-console watch` when the
+	// operator opts in (BINTRAIL_CONSOLE_VERIFY_TRIGGER=1); nil otherwise,
+	// where the trigger endpoint refuses with 403 and /api/capabilities reports
+	// verify_trigger:false. Set together with MonitorCtrl (both control-plane).
+	VerifyCtrl VerifyController
 	// BaselineDir / BaselineS3 enable point-in-time reconstruct (Phase 2) on
 	// the boot entry. When either is set (and no RBAC profile is active), the
 	// "Reconstruct" surface is exposed. BaselineDir takes precedence;
@@ -140,6 +146,9 @@ type Server struct {
 	// baselineCtrl: non-nil only when the watch daemon opted into in-process
 	// baseline creation (see Config.BaselineCtrl).
 	baselineCtrl BaselineController
+	// verifyCtrl: non-nil only when the watch daemon opted into in-process
+	// verify runs (see Config.VerifyCtrl).
+	verifyCtrl VerifyController
 	// rotationDefaults are the daemon's --rotate-* values, the fallback GET
 	// /api/rotation reports when no console override is saved.
 	rotationDefaults RotationDefaults
@@ -253,6 +262,7 @@ func New(cfg Config) (*Server, error) {
 		allowedHosts:     cfg.AllowedHosts,
 		monitorCtrl:      cfg.MonitorCtrl,
 		baselineCtrl:     cfg.BaselineCtrl,
+		verifyCtrl:       cfg.VerifyCtrl,
 		rotationDefaults: cfg.RotationDefaults,
 		cm:               newConnManager(cfg.Registry, profileActive),
 		authPath:         authPath,
@@ -306,6 +316,22 @@ func (s *Server) resolveOr(w http.ResponseWriter, r *http.Request) *bundle {
 	return nil
 }
 
+// selectedEntry returns the registry entry behind the request's effective
+// server selection (header, or the default when absent), for capability
+// hints that need registry-only fields (e.g. SourceDSN) a bundle doesn't
+// carry. False for the boot entry (not in the registry) or an unresolvable
+// selection — callers must treat that as "no hint available", not an error.
+func (s *Server) selectedEntry(r *http.Request) (ServerEntry, bool) {
+	id := r.Header.Get(serverHeader)
+	if id == "" {
+		id = s.cm.defaultID()
+	}
+	if id == "" || id == bootServerID {
+		return ServerEntry{}, false
+	}
+	return s.cm.reg.Get(id)
+}
+
 // buildHandler wires the route tree and middleware chain:
 //   - host guard on EVERY request (DNS-rebinding defense)
 //   - three static security headers on every response
@@ -347,6 +373,9 @@ func (s *Server) buildHandler() http.Handler {
 	// (BINTRAIL_CONSOLE_BASELINE_TRIGGER=1). GET polls the running/last state.
 	api.HandleFunc("POST /api/servers/{id}/baseline", s.handleBaselineTrigger)
 	api.HandleFunc("GET /api/servers/{id}/baseline", s.handleBaselineStatus)
+	api.HandleFunc("POST /api/servers/{id}/verify", s.handleVerifyTrigger)
+	api.HandleFunc("GET /api/servers/{id}/verify", s.handleVerifyStatus)
+	api.HandleFunc("GET /api/servers/{id}/verify/explain", s.handleVerifyExplain)
 	// Global built-in-rotation policy: read the effective settings; PUT an
 	// override (refused on the read-only console — only the watch daemon runs
 	// the loop that consumes it).

--- a/internal/console/verify_trigger.go
+++ b/internal/console/verify_trigger.go
@@ -3,6 +3,7 @@ package console
 import (
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 )
 
@@ -168,27 +169,36 @@ func (s *Server) handleVerifyTrigger(w http.ResponseWriter, r *http.Request) {
 		Mode   string   `json:"mode"`
 		Tables []string `json:"tables"`
 	}
-	if r.Body != nil {
-		_ = json.NewDecoder(r.Body).Decode(&body) // no/empty body = defaults
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil && !errors.Is(err, io.EOF) {
+		// EOF = no/empty body = defaults. Any other decode error means the
+		// caller's actual request (e.g. an explicit live-source mode) must
+		// not be silently substituted with the baseline-anchored default.
+		writeJSONError(w, http.StatusBadRequest, "malformed request body: "+err.Error())
+		return
 	}
 	mode := VerifyModeBaselineAnchored
 	if body.Mode != "" {
 		mode = VerifyMode(body.Mode)
 	}
 	switch mode {
-	case VerifyModeBaselineAnchored:
-		if e.BaselineDir == "" && e.BaselineS3 == "" {
-			writeJSONError(w, http.StatusBadRequest,
-				"this server has no baseline destination configured; set a baseline directory or S3 prefix first (Edit → Advanced)")
-			return
-		}
-	case VerifyModeLiveSource:
-		if e.SourceDSN == "" {
-			writeJSONError(w, http.StatusBadRequest, "this server has no source configured; set the source connection first")
-			return
-		}
+	case VerifyModeBaselineAnchored, VerifyModeLiveSource:
 	default:
 		writeJSONError(w, http.StatusBadRequest, "unknown mode (want baseline-anchored or live-source)")
+		return
+	}
+	// Both modes need a baseline destination — mirrors internal/cli/verify.go,
+	// which requires --baseline-dir/--baseline-s3 before the mode split, not
+	// just for baseline-anchored. Live-source still reconstructs each table
+	// from baseline + deltas (internal/verify.VerifyTable); without one every
+	// table degrades to inconclusive AFTER a full off-peak read of the live
+	// table, which the CLI refuses up front instead of wasting that read.
+	if e.BaselineDir == "" && e.BaselineS3 == "" {
+		writeJSONError(w, http.StatusBadRequest,
+			"this server has no baseline destination configured; set a baseline directory or S3 prefix first (Edit → Advanced)")
+		return
+	}
+	if mode == VerifyModeLiveSource && e.SourceDSN == "" {
+		writeJSONError(w, http.StatusBadRequest, "this server has no source configured; set the source connection first")
 		return
 	}
 

--- a/internal/console/verify_trigger.go
+++ b/internal/console/verify_trigger.go
@@ -1,0 +1,260 @@
+package console
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+)
+
+// ErrVerifyRunning is returned by VerifyController.Trigger when a verify run
+// for that server is already in flight (one at a time per server, mirroring
+// BaselineController). The handler maps it to 409 Conflict.
+var ErrVerifyRunning = errors.New("a verify run is already running for this server")
+
+// ErrExplainUnavailable is returned by VerifyController.Explain when there is
+// no cached baseline pair to explain from: no completed baseline-anchored run
+// exists for this server, the table was not reported as a mismatch by it, or
+// a newer run has since replaced it. The handler maps it to 404.
+var ErrExplainUnavailable = errors.New("no explainable mismatch for this table — run a baseline-anchored verify first, or this table was not reported as a mismatch by the last run")
+
+// VerifyController runs bintrail verify's engine in-process for a monitored
+// server (#677) — the same internal/verify functions internal/cli/verify.go
+// calls, looped over a server's tables in a background goroutine so the
+// console can poll per-table results as they land. It is wired in ONLY by
+// `bintrail-console watch` when the operator opts in
+// (BINTRAIL_CONSOLE_VERIFY_TRIGGER=1); nil on the standalone read-only
+// console, where the endpoints refuse with 403 — mirroring how
+// BaselineController gates in-process baseline creation.
+type VerifyController interface {
+	// Trigger starts a verify run in the background and returns immediately.
+	// Returns ErrVerifyRunning if one is already running for req.ServerID.
+	Trigger(req VerifyRequest) error
+	// Status reports the latest known run for a server (idle if never run in
+	// this process): overall state plus per-table results accumulated so far.
+	Status(serverID string) VerifyStatus
+	// Explain drills into one table the last completed baseline-anchored run
+	// reported as a mismatch, re-running the row-level diff on demand — never
+	// precomputed for every mismatch (internal/verify.ExplainBaselinePairMismatch
+	// re-reconstructs the table). Returns ErrExplainUnavailable when no such
+	// run/table exists (including: the last run was live-source, which has no
+	// explain support in the engine).
+	Explain(serverID, schema, table string) (*VerifyExplanation, error)
+}
+
+// VerifyMode selects which internal/verify engine path a run uses.
+type VerifyMode string
+
+const (
+	// VerifyModeBaselineAnchored compares the two most recent baselines,
+	// drift-free — no live source read. The default.
+	VerifyModeBaselineAnchored VerifyMode = "baseline-anchored"
+	// VerifyModeLiveSource reconstructs each table to a consistent snapshot of
+	// the live source and compares. Needs the server's source DSN and reads
+	// the whole table off production — the console warns to run it off-peak,
+	// matching docs/verify.md.
+	VerifyModeLiveSource VerifyMode = "live-source"
+)
+
+// VerifyRequest is the in-process job description the endpoint hands the
+// controller. The index/source DSNs (secrets) stay inside the process — never
+// written to disk or serialized to any HTTP response.
+type VerifyRequest struct {
+	ServerID    string
+	ServerName  string
+	Mode        VerifyMode
+	Tables      []string // optional "schema.table" filter; empty = all
+	IndexDSN    string
+	SourceDSN   string // only required/used for VerifyModeLiveSource
+	BaselineDir string
+	BaselineS3  string
+	NoArchive   bool
+}
+
+// VerifyTableResult is the wire view of one table's verify.TableResult.
+type VerifyTableResult struct {
+	Schema          string `json:"schema"`
+	Table           string `json:"table"`
+	Status          string `json:"status"` // match | mismatch | inconclusive | error
+	Detail          string `json:"detail,omitempty"`
+	SourceRows      int64  `json:"source_rows,omitempty"`
+	ReconstructRows int64  `json:"reconstruct_rows,omitempty"`
+	Anchor          string `json:"anchor,omitempty"`
+	// Explainable is true only for a baseline-anchored mismatch whose pair is
+	// still cached from the run that produced this result — the precondition
+	// for calling Explain on it.
+	Explainable bool `json:"explainable"`
+}
+
+// VerifySummary tallies VerifyStatus.Results by status, for a run's headline.
+type VerifySummary struct {
+	Match        int `json:"match"`
+	Mismatch     int `json:"mismatch"`
+	Inconclusive int `json:"inconclusive"`
+	Error        int `json:"error"`
+}
+
+// VerifyStatus is the pollable state of a server's most recent verify run.
+// Unlike BaselineStatus (one terminal struct overwritten at job end), Results
+// grows as each table completes so the console can show progress mid-run —
+// internal/verify has no progress callback of its own; the controller loops
+// over tables itself and appends after each one returns.
+type VerifyStatus struct {
+	State      string     `json:"state"` // idle | running | succeeded | failed
+	Mode       VerifyMode `json:"mode,omitempty"`
+	Since      string     `json:"since,omitempty"`
+	FinishedAt string     `json:"finished_at,omitempty"`
+	LastError  string     `json:"last_error,omitempty"`
+	// Note carries a benign, non-error informational message — e.g. "only one
+	// baseline exists yet, nothing to compare" (a legitimate first run, not a
+	// failure; mirrors the CLI's zero-exit early return in that case).
+	Note    string              `json:"note,omitempty"`
+	Results []VerifyTableResult `json:"results,omitempty"`
+	Summary VerifySummary       `json:"summary"`
+}
+
+// VerifyCellDiff is the wire view of verify.CellDiff.
+type VerifyCellDiff struct {
+	Column   string `json:"column"`
+	Recovery string `json:"recovery"`
+	Baseline string `json:"baseline"`
+}
+
+// VerifyRowDiff is the wire view of verify.RowDiff.
+type VerifyRowDiff struct {
+	PK    string           `json:"pk"`
+	Kind  string           `json:"kind"` // changed | missing | extra
+	Cells []VerifyCellDiff `json:"cells,omitempty"`
+}
+
+// VerifyExplanation is the wire view of verify.MismatchExplanation: the
+// structured per-row diffs (Diffs/Total, capped and overflow-summarized
+// exactly like the CLI) plus Rendered — the same text internal/verify's
+// MismatchExplanation.Write produces (including the deferred-type caveat and
+// overflow breakdown, which live in unexported fields and so are only
+// available through the rendered text, not the structured Diffs).
+type VerifyExplanation struct {
+	Schema   string          `json:"schema"`
+	Table    string          `json:"table"`
+	Anchor   string          `json:"anchor"`
+	Total    int             `json:"total"`
+	Diffs    []VerifyRowDiff `json:"diffs"`
+	Rendered string          `json:"rendered"`
+}
+
+// handleVerifyTrigger enqueues an in-process verify run for the selected
+// server. Gating, in order: the feature must be enabled (control-plane +
+// opt-in), no RBAC profile may be active (verify's engine reads baseline/live
+// state with no redaction — internal/verify.Config/BaselineConfig carry no
+// DenyTables/RedactColumns, unlike query.Options), the entry must be a real
+// registry server, and the requested mode's precondition must hold (a
+// baseline destination for baseline-anchored, a source DSN for live-source).
+func (s *Server) handleVerifyTrigger(w http.ResponseWriter, r *http.Request) {
+	if s.verifyCtrl == nil {
+		writeJSONError(w, http.StatusForbidden,
+			"verify from the console is not enabled; start the watch daemon with BINTRAIL_CONSOLE_VERIFY_TRIGGER=1")
+		return
+	}
+	if s.rbacActive() {
+		writeJSONError(w, http.StatusForbidden,
+			"verify is not available while an RBAC profile is active — its baseline/live-source reads carry no redaction")
+		return
+	}
+	e, ok := s.requireMonitorEntry(w, r.PathValue("id"))
+	if !ok {
+		return
+	}
+
+	var body struct {
+		Mode   string   `json:"mode"`
+		Tables []string `json:"tables"`
+	}
+	if r.Body != nil {
+		_ = json.NewDecoder(r.Body).Decode(&body) // no/empty body = defaults
+	}
+	mode := VerifyModeBaselineAnchored
+	if body.Mode != "" {
+		mode = VerifyMode(body.Mode)
+	}
+	switch mode {
+	case VerifyModeBaselineAnchored:
+		if e.BaselineDir == "" && e.BaselineS3 == "" {
+			writeJSONError(w, http.StatusBadRequest,
+				"this server has no baseline destination configured; set a baseline directory or S3 prefix first (Edit → Advanced)")
+			return
+		}
+	case VerifyModeLiveSource:
+		if e.SourceDSN == "" {
+			writeJSONError(w, http.StatusBadRequest, "this server has no source configured; set the source connection first")
+			return
+		}
+	default:
+		writeJSONError(w, http.StatusBadRequest, "unknown mode (want baseline-anchored or live-source)")
+		return
+	}
+
+	req := VerifyRequest{
+		ServerID: e.ID, ServerName: e.Name, Mode: mode, Tables: body.Tables,
+		IndexDSN: e.DSN, SourceDSN: e.SourceDSN,
+		BaselineDir: e.BaselineDir, BaselineS3: e.BaselineS3, NoArchive: e.NoArchive,
+	}
+	if err := s.verifyCtrl.Trigger(req); err != nil {
+		if errors.Is(err, ErrVerifyRunning) {
+			writeJSONError(w, http.StatusConflict, err.Error())
+			return
+		}
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusAccepted, map[string]any{"verify": s.verifyCtrl.Status(e.ID)})
+}
+
+// handleVerifyStatus reports the latest verify run state for the selected
+// server (for the frontend to poll while a run is in flight).
+func (s *Server) handleVerifyStatus(w http.ResponseWriter, r *http.Request) {
+	if s.verifyCtrl == nil {
+		writeJSONError(w, http.StatusForbidden,
+			"verify from the console is not enabled; start the watch daemon with BINTRAIL_CONSOLE_VERIFY_TRIGGER=1")
+		return
+	}
+	e, ok := s.requireMonitorEntry(w, r.PathValue("id"))
+	if !ok {
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"verify": s.verifyCtrl.Status(e.ID)})
+}
+
+// handleVerifyExplain serves GET /api/servers/{id}/verify/explain?schema=&table=
+// — an on-demand row-level drill-down for one table the last completed
+// baseline-anchored run reported as a mismatch.
+func (s *Server) handleVerifyExplain(w http.ResponseWriter, r *http.Request) {
+	if s.verifyCtrl == nil {
+		writeJSONError(w, http.StatusForbidden,
+			"verify from the console is not enabled; start the watch daemon with BINTRAIL_CONSOLE_VERIFY_TRIGGER=1")
+		return
+	}
+	if s.rbacActive() {
+		writeJSONError(w, http.StatusForbidden,
+			"verify is not available while an RBAC profile is active — its baseline reads carry no redaction")
+		return
+	}
+	e, ok := s.requireMonitorEntry(w, r.PathValue("id"))
+	if !ok {
+		return
+	}
+	q := r.URL.Query()
+	schema, table := q.Get("schema"), q.Get("table")
+	if schema == "" || table == "" {
+		writeJSONError(w, http.StatusBadRequest, "verify explain requires schema and table")
+		return
+	}
+	ex, err := s.verifyCtrl.Explain(e.ID, schema, table)
+	if err != nil {
+		if errors.Is(err, ErrExplainUnavailable) {
+			writeJSONError(w, http.StatusNotFound, err.Error())
+			return
+		}
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"explain": ex})
+}

--- a/internal/console/verify_trigger_test.go
+++ b/internal/console/verify_trigger_test.go
@@ -1,0 +1,385 @@
+package console
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/query"
+)
+
+// stubVerifyCtrl is a recording VerifyController for unit tests.
+type stubVerifyCtrl struct {
+	triggered  []VerifyRequest
+	err        error
+	status     VerifyStatus
+	explainErr error
+	explain    *VerifyExplanation
+}
+
+func (c *stubVerifyCtrl) Trigger(req VerifyRequest) error {
+	c.triggered = append(c.triggered, req)
+	return c.err
+}
+
+func (c *stubVerifyCtrl) Status(string) VerifyStatus { return c.status }
+
+func (c *stubVerifyCtrl) Explain(serverID, schema, table string) (*VerifyExplanation, error) {
+	if c.explainErr != nil {
+		return nil, c.explainErr
+	}
+	return c.explain, nil
+}
+
+// newVerifyTriggerServer builds a control-plane console with a recording
+// verify controller wired in (mirrors newBaselineTriggerServer).
+func newVerifyTriggerServer(t *testing.T) (*Server, *stubVerifyCtrl) {
+	t.Helper()
+	reg, err := LoadRegistry(t.TempDir() + "/console-servers.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctrl := &stubVerifyCtrl{status: VerifyStatus{State: "idle"}}
+	srv, err := New(Config{
+		Listen: "127.0.0.1:8090", Token: "t", Registry: reg,
+		MonitorCtrl: &stubMonitorCtrl{}, VerifyCtrl: ctrl,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return srv, ctrl
+}
+
+const verifySecretPW = "s3cr3t-verify-pw"
+
+// doServersReqHeader is doServersReq with an explicit X-Bintrail-Server
+// selection header, for capability checks scoped to a non-default server.
+func doServersReqHeader(t *testing.T, srv *Server, method, path, body, serverID string) (*httptest.ResponseRecorder, []byte) {
+	t.Helper()
+	req := httptest.NewRequest(method, "http://127.0.0.1:8090"+path, strings.NewReader(body))
+	req.Host = "127.0.0.1:8090"
+	req.Header.Set("Authorization", "Bearer t")
+	req.Header.Set("X-Bintrail-Server", serverID)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	return rec, rec.Body.Bytes()
+}
+
+// addVerifyEntry adds a registry entry with the given source/destination
+// configured, returning its generated id.
+func addVerifyEntry(t *testing.T, srv *Server, source, baselineS3, baselineDir string) string {
+	t.Helper()
+	e, err := srv.cm.reg.Add(ServerEntry{
+		Name:        "wp",
+		DSN:         "idx:idxpw@tcp(127.0.0.1:3306)/binlog_index",
+		SourceDSN:   source,
+		BaselineS3:  baselineS3,
+		BaselineDir: baselineDir,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return e.ID
+}
+
+// TestCapabilityVerifyTriggerGate: only a daemon that opted in
+// (Config.VerifyCtrl) advertises verify_trigger; the standalone read-only
+// console never does.
+func TestCapabilityVerifyTriggerGate(t *testing.T) {
+	for _, enabled := range []bool{true, false} {
+		reg, _ := LoadRegistry("")
+		cfg := Config{Listen: "127.0.0.1:8090", Token: "t", Registry: reg}
+		if enabled {
+			cfg.VerifyCtrl = &stubVerifyCtrl{}
+		}
+		srv, err := New(cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		srv.cm.boot = &bundle{}
+		rec, body := doServersReq(t, srv, "GET", "/api/capabilities", "")
+		if rec.Code != 200 {
+			t.Fatalf("capabilities: code=%d body=%s", rec.Code, body)
+		}
+		var caps capabilitiesResponse
+		if err := json.Unmarshal(body, &caps); err != nil {
+			t.Fatal(err)
+		}
+		if caps.VerifyTrigger != enabled {
+			t.Errorf("verify_trigger capability = %v, want %v", caps.VerifyTrigger, enabled)
+		}
+	}
+}
+
+// TestCapabilityVerify_perServerAndRBAC: Verify/VerifyLiveSource reflect the
+// SELECTED server's own baseline/source config, and both collapse to false
+// under an active RBAC profile even though verify_trigger stays true
+// (process-global) — the endpoint, not just the capability, must enforce
+// this (see TestVerifyTrigger_rbacBlocked).
+func TestCapabilityVerify_perServerAndRBAC(t *testing.T) {
+	reg, _ := LoadRegistry(t.TempDir() + "/console-servers.yaml")
+	srv, err := New(Config{
+		Listen: "127.0.0.1:8090", Token: "t", Registry: reg,
+		MonitorCtrl: &stubMonitorCtrl{}, VerifyCtrl: &stubVerifyCtrl{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := addVerifyEntry(t, srv, "u:p@tcp(10.0.0.5:3306)/", "", "s3://b/baselines/")
+	// Force the bundle to resolve without a real connection.
+	srv.cm.bundles[id] = &bundle{baselineSrc: "s3://b/baselines/", baselineConfigured: true}
+
+	req := func() (*capabilitiesResponse, int) {
+		rec, body := doServersReqHeader(t, srv, "GET", "/api/capabilities", "", id)
+		var caps capabilitiesResponse
+		if err := json.Unmarshal(body, &caps); err != nil {
+			t.Fatal(err)
+		}
+		return &caps, rec.Code
+	}
+
+	caps, code := req()
+	if code != 200 {
+		t.Fatalf("capabilities: code=%d", code)
+	}
+	if !caps.Verify {
+		t.Error("verify should be true: server has a baseline destination and no active profile")
+	}
+	if !caps.VerifyLiveSource {
+		t.Error("verify_live_source should be true: server has a source DSN")
+	}
+
+	// Now with an active RBAC profile: both must collapse to false.
+	reg2, _ := LoadRegistry(t.TempDir() + "/console-servers2.yaml")
+	srvRBAC, err := New(Config{
+		Listen: "127.0.0.1:8090", Token: "t", Registry: reg2,
+		MonitorCtrl: &stubMonitorCtrl{}, VerifyCtrl: &stubVerifyCtrl{},
+		DenyTables: []query.SchemaTable{{Schema: "a", Table: "b"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	id2 := addVerifyEntry(t, srvRBAC, "u:p@tcp(10.0.0.5:3306)/", "", "s3://b/baselines/")
+	srvRBAC.cm.bundles[id2] = &bundle{baselineSrc: "s3://b/baselines/", baselineConfigured: false}
+	rec, body := doServersReqHeader(t, srvRBAC, "GET", "/api/capabilities", "", id2)
+	if rec.Code != 200 {
+		t.Fatalf("capabilities: code=%d body=%s", rec.Code, body)
+	}
+	var capsRBAC capabilitiesResponse
+	if err := json.Unmarshal(body, &capsRBAC); err != nil {
+		t.Fatal(err)
+	}
+	if capsRBAC.Verify || capsRBAC.VerifyLiveSource {
+		t.Errorf("an active RBAC profile must disable both verify capabilities, got %+v", capsRBAC)
+	}
+}
+
+// TestVerifyTrigger_disabledConsole: with no VerifyCtrl wired in, the trigger
+// endpoint refuses with 403 even on a control-plane console.
+func TestVerifyTrigger_disabledConsole(t *testing.T) {
+	reg, _ := LoadRegistry(t.TempDir() + "/console-servers.yaml")
+	srv, err := New(Config{Listen: "127.0.0.1:8090", Token: "t", Registry: reg, MonitorCtrl: &stubMonitorCtrl{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := addVerifyEntry(t, srv, "u:p@tcp(127.0.0.1:3306)/", "s3://b/baselines/", "")
+	rec, _ := doServersReq(t, srv, "POST", "/api/servers/"+id+"/verify", "")
+	if rec.Code != 403 {
+		t.Fatalf("disabled console: code=%d, want 403", rec.Code)
+	}
+}
+
+// TestVerifyTrigger_rbacBlocked: an active RBAC profile refuses verify even
+// though VerifyCtrl is wired — its engine carries no redaction.
+func TestVerifyTrigger_rbacBlocked(t *testing.T) {
+	reg, _ := LoadRegistry(t.TempDir() + "/console-servers.yaml")
+	ctrl := &stubVerifyCtrl{}
+	srv, err := New(Config{
+		Listen: "127.0.0.1:8090", Token: "t", Registry: reg,
+		MonitorCtrl: &stubMonitorCtrl{}, VerifyCtrl: ctrl,
+		RedactColumns: []query.SchemaTableColumn{{Schema: "a", Table: "b", Column: "c"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := addVerifyEntry(t, srv, "u:p@tcp(127.0.0.1:3306)/", "s3://b/baselines/", "")
+	rec, _ := doServersReq(t, srv, "POST", "/api/servers/"+id+"/verify", "")
+	if rec.Code != 403 {
+		t.Fatalf("rbac active: code=%d, want 403", rec.Code)
+	}
+	if len(ctrl.triggered) != 0 {
+		t.Fatal("controller must not be triggered while an RBAC profile is active")
+	}
+}
+
+// TestVerifyTrigger_requiresBaselineDestination: baseline-anchored mode (the
+// default) needs a baseline dir/S3 — 400 without one.
+func TestVerifyTrigger_requiresBaselineDestination(t *testing.T) {
+	srv, ctrl := newVerifyTriggerServer(t)
+	id := addVerifyEntry(t, srv, "u:p@tcp(127.0.0.1:3306)/", "", "")
+	rec, _ := doServersReq(t, srv, "POST", "/api/servers/"+id+"/verify", "")
+	if rec.Code != 400 {
+		t.Fatalf("no destination: code=%d, want 400", rec.Code)
+	}
+	if len(ctrl.triggered) != 0 {
+		t.Fatal("controller must not be triggered without a baseline destination")
+	}
+}
+
+// TestVerifyTrigger_requiresSourceForLiveSource: live-source mode needs a
+// source DSN — 400 without one, even with a baseline destination configured.
+func TestVerifyTrigger_requiresSourceForLiveSource(t *testing.T) {
+	srv, ctrl := newVerifyTriggerServer(t)
+	id := addVerifyEntry(t, srv, "", "s3://b/baselines/", "")
+	rec, _ := doServersReq(t, srv, "POST", "/api/servers/"+id+"/verify", `{"mode":"live-source"}`)
+	if rec.Code != 400 {
+		t.Fatalf("no source: code=%d, want 400", rec.Code)
+	}
+	if len(ctrl.triggered) != 0 {
+		t.Fatal("controller must not be triggered without a source")
+	}
+}
+
+// TestVerifyTrigger_unknownMode: an unrecognized mode string is 400, not
+// silently defaulted.
+func TestVerifyTrigger_unknownMode(t *testing.T) {
+	srv, ctrl := newVerifyTriggerServer(t)
+	id := addVerifyEntry(t, srv, "u:p@tcp(127.0.0.1:3306)/", "s3://b/baselines/", "")
+	rec, _ := doServersReq(t, srv, "POST", "/api/servers/"+id+"/verify", `{"mode":"bogus"}`)
+	if rec.Code != 400 {
+		t.Fatalf("unknown mode: code=%d, want 400", rec.Code)
+	}
+	if len(ctrl.triggered) != 0 {
+		t.Fatal("controller must not be triggered with an unknown mode")
+	}
+}
+
+// TestVerifyTrigger_unknownServer: a bad server id is 404, never a trigger.
+func TestVerifyTrigger_unknownServer(t *testing.T) {
+	srv, _ := newVerifyTriggerServer(t)
+	rec, _ := doServersReq(t, srv, "POST", "/api/servers/deadbeef/verify", "")
+	if rec.Code != 404 {
+		t.Fatalf("unknown server: code=%d, want 404", rec.Code)
+	}
+}
+
+// TestVerifyTrigger_happy: a fully-configured entry triggers a default
+// (baseline-anchored) run (202), the controller receives the index DSN and
+// baseline destination, and the HTTP response never leaks the index password.
+func TestVerifyTrigger_happy(t *testing.T) {
+	srv, ctrl := newVerifyTriggerServer(t)
+	id := addVerifyEntry(t, srv, "u:p@tcp(127.0.0.1:3306)/", "s3://my-bucket/baselines/", "")
+	// Overwrite the entry's index DSN with one carrying a distinctive secret.
+	e, _ := srv.cm.reg.Get(id)
+	e.DSN = "idx:" + verifySecretPW + "@tcp(127.0.0.1:3306)/binlog_index"
+	if err := srv.cm.reg.Update(e); err != nil {
+		t.Fatal(err)
+	}
+
+	rec, body := doServersReq(t, srv, "POST", "/api/servers/"+id+"/verify", "")
+	if rec.Code != 202 {
+		t.Fatalf("trigger: code=%d body=%s, want 202", rec.Code, body)
+	}
+	if len(ctrl.triggered) != 1 {
+		t.Fatalf("controller triggered %d times, want 1", len(ctrl.triggered))
+	}
+	got := ctrl.triggered[0]
+	if got.Mode != VerifyModeBaselineAnchored {
+		t.Errorf("Mode = %q, want the default baseline-anchored", got.Mode)
+	}
+	if !strings.Contains(got.IndexDSN, verifySecretPW) {
+		t.Errorf("IndexDSN = %q, want the entry's index DSN", got.IndexDSN)
+	}
+	if got.BaselineS3 != "s3://my-bucket/baselines/" {
+		t.Errorf("BaselineS3 = %q, want the entry's baseline S3", got.BaselineS3)
+	}
+	if strings.Contains(string(body), verifySecretPW) {
+		t.Fatalf("response leaked the index password: %s", body)
+	}
+}
+
+// TestVerifyTrigger_alreadyRunning: ErrVerifyRunning from the controller maps
+// to 409 Conflict (one verify run at a time per server).
+func TestVerifyTrigger_alreadyRunning(t *testing.T) {
+	srv, ctrl := newVerifyTriggerServer(t)
+	ctrl.err = ErrVerifyRunning
+	id := addVerifyEntry(t, srv, "u:p@tcp(127.0.0.1:3306)/", "s3://b/baselines/", "")
+	rec, _ := doServersReq(t, srv, "POST", "/api/servers/"+id+"/verify", "")
+	if rec.Code != 409 {
+		t.Fatalf("already running: code=%d, want 409", rec.Code)
+	}
+}
+
+// TestVerifyStatus_returnsControllerState: GET reflects the controller's
+// accumulated per-table results and summary.
+func TestVerifyStatus_returnsControllerState(t *testing.T) {
+	srv, ctrl := newVerifyTriggerServer(t)
+	ctrl.status = VerifyStatus{
+		State: "succeeded", Mode: VerifyModeBaselineAnchored,
+		Results: []VerifyTableResult{{Schema: "wp", Table: "posts", Status: "match"}},
+		Summary: VerifySummary{Match: 1},
+	}
+	id := addVerifyEntry(t, srv, "u:p@tcp(127.0.0.1:3306)/", "s3://b/baselines/", "")
+
+	rec, body := doServersReq(t, srv, "GET", "/api/servers/"+id+"/verify", "")
+	if rec.Code != 200 {
+		t.Fatalf("status: code=%d body=%s, want 200", rec.Code, body)
+	}
+	var resp struct {
+		Verify VerifyStatus `json:"verify"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Verify.State != "succeeded" || resp.Verify.Summary.Match != 1 || len(resp.Verify.Results) != 1 {
+		t.Errorf("status = %+v, want the controller's succeeded state", resp.Verify)
+	}
+}
+
+// TestVerifyExplain_requiresSchemaAndTable: missing schema/table is 400.
+func TestVerifyExplain_requiresSchemaAndTable(t *testing.T) {
+	srv, _ := newVerifyTriggerServer(t)
+	id := addVerifyEntry(t, srv, "u:p@tcp(127.0.0.1:3306)/", "s3://b/baselines/", "")
+	rec, _ := doServersReq(t, srv, "GET", "/api/servers/"+id+"/verify/explain", "")
+	if rec.Code != 400 {
+		t.Fatalf("missing schema/table: code=%d, want 400", rec.Code)
+	}
+}
+
+// TestVerifyExplain_unavailable: ErrExplainUnavailable maps to 404.
+func TestVerifyExplain_unavailable(t *testing.T) {
+	srv, ctrl := newVerifyTriggerServer(t)
+	ctrl.explainErr = ErrExplainUnavailable
+	id := addVerifyEntry(t, srv, "u:p@tcp(127.0.0.1:3306)/", "s3://b/baselines/", "")
+	rec, _ := doServersReq(t, srv, "GET", "/api/servers/"+id+"/verify/explain?schema=wp&table=posts", "")
+	if rec.Code != 404 {
+		t.Fatalf("unavailable: code=%d, want 404", rec.Code)
+	}
+}
+
+// TestVerifyExplain_happy: a successful drill-down round-trips through JSON.
+func TestVerifyExplain_happy(t *testing.T) {
+	srv, ctrl := newVerifyTriggerServer(t)
+	ctrl.explain = &VerifyExplanation{
+		Schema: "wp", Table: "posts", Anchor: "mysql-bin.000123:456", Total: 1,
+		Diffs: []VerifyRowDiff{{PK: "id=1", Kind: "changed", Cells: []VerifyCellDiff{
+			{Column: "title", Recovery: "old", Baseline: "new"},
+		}}},
+		Rendered: "--- mismatch drill-down ---",
+	}
+	id := addVerifyEntry(t, srv, "u:p@tcp(127.0.0.1:3306)/", "s3://b/baselines/", "")
+	rec, body := doServersReq(t, srv, "GET", "/api/servers/"+id+"/verify/explain?schema=wp&table=posts", "")
+	if rec.Code != 200 {
+		t.Fatalf("explain: code=%d body=%s, want 200", rec.Code, body)
+	}
+	var resp struct {
+		Explain VerifyExplanation `json:"explain"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Explain.Total != 1 || len(resp.Explain.Diffs) != 1 || resp.Explain.Diffs[0].PK != "id=1" {
+		t.Errorf("explain = %+v, want the controller's explanation", resp.Explain)
+	}
+}

--- a/internal/console/verify_trigger_test.go
+++ b/internal/console/verify_trigger_test.go
@@ -241,6 +241,23 @@ func TestVerifyTrigger_requiresSourceForLiveSource(t *testing.T) {
 	}
 }
 
+// TestVerifyTrigger_liveSourceRequiresBaselineDestination: live-source mode
+// ALSO needs a baseline destination — internal/verify.VerifyTable still
+// reconstructs from baseline + deltas, so without one every table would
+// degrade to inconclusive only AFTER a full off-peak read of the live
+// table. A source DSN alone must not be enough to trigger it.
+func TestVerifyTrigger_liveSourceRequiresBaselineDestination(t *testing.T) {
+	srv, ctrl := newVerifyTriggerServer(t)
+	id := addVerifyEntry(t, srv, "u:p@tcp(127.0.0.1:3306)/", "", "")
+	rec, _ := doServersReq(t, srv, "POST", "/api/servers/"+id+"/verify", `{"mode":"live-source"}`)
+	if rec.Code != 400 {
+		t.Fatalf("no baseline destination: code=%d, want 400", rec.Code)
+	}
+	if len(ctrl.triggered) != 0 {
+		t.Fatal("controller must not be triggered without a baseline destination, even in live-source mode")
+	}
+}
+
 // TestVerifyTrigger_unknownMode: an unrecognized mode string is 400, not
 // silently defaulted.
 func TestVerifyTrigger_unknownMode(t *testing.T) {


### PR DESCRIPTION
closes #677

## Summary

Mirrors the Baseline-trigger pattern (#613/PR #615) for `bintrail verify`, giving the console a full lifecycle instead of only reading results a CLI/cron/CI run produced elsewhere:

- **`VerifyController`** (`internal/console/verify_trigger.go`): `Trigger`/`Status`/`Explain` interface, wired watch-only (`Config.VerifyCtrl`, nil on the standalone `serve` console) — mirrors `BaselineController`'s gating exactly.
- **`verifySupervisor`** (`cmd/bintrail-console/verify.go`): the concrete implementation. Fully self-sufficient like `baselineSupervisor` — opens its own index/source connections per run rather than reaching into the console's per-server bundle. One job at a time per server; per-table results are appended as each table completes (`internal/verify` has no progress callback of its own, so this loop *is* the "as they land" streaming). Both modes are supported:
  - **baseline-anchored** (default): `verify.FindBaselinePair` → `verify.VerifyBaselinePair` per table, sorted deterministically (the engine's own pair-building ranges a Go map). The "only one baseline" and "zero baselines" cases are told apart exactly like the CLI does.
  - **live-source**: `verify.VerifyTable` per table, needs the server's source DSN.
- **Explain**: on-demand only, never precomputed for every mismatch (`verify.ExplainBaselinePairMismatch` re-reconstructs). The supervisor caches the exact `BaselinePair` behind each mismatched table from the run that produced the verdict — re-deriving it later via a fresh `FindBaselinePair` could silently explain a *different* pair if a new baseline landed in between.
- **Endpoints**: `POST/GET /api/servers/{id}/verify`, `GET /api/servers/{id}/verify/explain?schema=&table=` (registry-servers-only, mirroring baseline's `requireMonitorEntry` gate). `GET /api/capabilities` gains `verify_trigger` (process-global) plus per-server `verify`/`verify_live_source`.
- **RBAC**: verify's engine (`verify.Config`/`verify.BaselineConfig`) carries no `DenyTables`/`RedactColumns` — like Time-travel's baseline reads, it bypasses redaction structurally. Both endpoints and the capability response explicitly refuse while an RBAC profile is active, since (unlike Reconstruct) verify doesn't route through the bundle's `baselineConfigured` gate that already collapses under a profile.
- **Frontend**: a new Verification panel on the Storage page — mode selector (live-source only offered when the server has a source DSN), a live-updating results list reusing the doctor-preflight card styling (match→pass, mismatch/error→fail, inconclusive→warn), and an Explain modal for mismatched rows.
- **Default**: on in the bundled compose stack (`VERIFY_TRIGGER`, opt-out — `docker-compose.yml`), same shape as `BASELINE_TRIGGER` after #683's flip. Unlike baseline creation, verify starts no subprocess and its default mode reads no live source, so it skips the opt-in-then-flip cycle. A bare `watch` invocation stays opt-in (`BINTRAIL_CONSOLE_VERIFY_TRIGGER=1`).

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean
- [x] `go test ./...` — full repo suite green
- [x] New unit tests: capability gating (including the RBAC-collapse case), 403/400/404/409/202 gating on trigger/status/explain, secret non-leak, pure-helper tests (`tableFilter`, `toWireResult`, `indexDBName`)
- [x] Live end-to-end smoke test against a real MySQL index (Docker): built both binaries, seeded a registry entry with a baseline dir, drove the Storage page with a real browser. Confirmed: the panel renders and gates correctly (live-source option hidden with no source DSN configured), clicking "Run verification" round-trips through the real HTTP API into a real background goroutine hitting `internal/verify` against a real index DB (exercised both the "no schema snapshot" and, after `bintrail snapshot`, the "no baselines found" failure paths — status polling and toast both reflected the real error), zero JS console errors throughout.
- [ ] **Not exercised against live data**: the match/mismatch card styling and the Explain modal, since that needs a real two-baseline mismatch fixture (out of scope to hand-roll for this pass — noting explicitly rather than claiming full coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)