### PR TITLE
console: Verification panel spans the full Storage grid width

### DIFF
--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -43,6 +43,17 @@ upgrades to be a deliberate, one-line edit rather than whatever `latest`
 currently points to — useful once you're past initial eval and want
 predictable upgrades.
 
+**`docker compose pull` only updates images — it never touches
+`docker-compose.yml` itself.** A release that adds a new service, env var, or
+default (e.g. the `VERIFY_TRIGGER` default-on wiring in 0.26.0) only takes
+effect if your copy of `docker-compose.yml` actually has that line — an
+older file on disk keeps running with whatever it already had, silently,
+with no error. If a newer feature seems missing or a documented default
+doesn't match what you see, re-download `docker-compose.yml` (the curl in
+[Quick start](../README.md)) and diff it against your customized copy before
+`up -d`, or add the specific new line by hand if you've heavily customized
+the file.
+
 Data volumes (`bintrail-index-data`, `bintrail-index-secret`,
 `bintrail-state`, including saved console servers) carry over unchanged
 across a `pull && up -d` — only the images and `docker-compose.yml` itself

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -1794,7 +1794,13 @@ async function pollBaseline(id) {
 // configured; verify_live_source: a source DSN is also configured), both
 // re-enforced server-side so this gating is UX only.
 function verifyPanel(servers) {
-  const panel = el("section", { class: "ov-panel" });
+  // Full-width: ov-grid is a 2-column grid (archiving | baselines) with
+  // align-items:start, and Baseline snapshots routinely runs much taller
+  // than S3 archiving (one row per snapshot) — a 3rd item left to the grid's
+  // normal auto-placement lands in row 2 col 1, floating under the SHORT
+  // sibling with a large dead gap to its right where the tall one still
+  // extends. Spanning both columns puts it in its own row instead.
+  const panel = el("section", { class: "ov-panel vfy-panel-full" });
   const cur = (servers || []).find((s) => s.id === (currentServer || defaultServerId));
   const head = el("div", { class: "ov-panel-head" }, el("h2", { class: "ov-panel-title", text: "Verification" }));
   const list = el("div", { class: "stg-list vfy-list" });

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -1967,13 +1967,35 @@ async function openVerifyExplain(id, schema, table) {
   }
   const mount = document.getElementById("modal");
   const scrim = el("div", { class: "modal-scrim show" });
-  const modal = el("div", { class: "modal", role: "dialog", "aria-label": "Verify mismatch drill-down" });
+  const modal = el("div", { class: "modal vfy-explain-modal", role: "dialog", "aria-label": "Verify mismatch drill-down" });
   const head = el("div", { class: "modal-head" });
-  head.append(el("h2", { class: "modal-title", text: "Mismatch: " + ex.schema + "." + ex.table }));
-  head.append(el("p", { class: "modal-desc", text: ex.total + " differing row(s) at " + ex.anchor }));
+  head.append(el("h2", { class: "modal-title", text: ex.schema + "." + ex.table + " doesn't match" }));
+  head.append(el("p", { class: "modal-desc", text:
+    (ex.total === 1 ? "1 row differs" : ex.total + " rows differ") +
+    " — checked against binlog position " + ex.anchor + "." }));
+  head.append(el("p", { class: "modal-desc", text:
+    "Recovered = what replaying the change log on top of the older snapshot produced. Baseline (real) = the actual values from the newer, trusted snapshot." }));
   head.append(el("button", { class: "modal-x", type: "button", text: "✕", onclick: closeVerifyExplain }));
   modal.append(head);
-  modal.append(el("pre", { class: "dc-rem vfy-explain-pre", text: ex.rendered }));
+
+  const body = el("div", { class: "vfy-explain-body" });
+  if (!ex.diffs || !ex.diffs.length) {
+    body.append(el("p", { class: "form-hint", text:
+      "The row count differs, but no per-row content difference was found — see raw output below." }));
+  } else {
+    ex.diffs.forEach((d) => body.append(verifyDiffCard(d)));
+    if (ex.total > ex.diffs.length) {
+      body.append(el("p", { class: "form-hint", text:
+        "…and " + (ex.total - ex.diffs.length) + " more differing row(s), not shown here." }));
+    }
+  }
+  modal.append(body);
+
+  const raw = el("details", { class: "form-advanced vfy-explain-raw" },
+    el("summary", { class: "form-adv-summary", text: "Raw output" }));
+  raw.append(el("pre", { class: "dc-rem vfy-explain-pre", text: ex.rendered }));
+  modal.append(raw);
+
   const foot = el("div", { class: "modal-foot" });
   foot.append(el("button", { class: "btn btn-ghost", type: "button", text: "Close", onclick: closeVerifyExplain }));
   modal.append(foot);
@@ -1983,6 +2005,57 @@ async function openVerifyExplain(id, schema, table) {
 }
 
 function closeVerifyExplain() { document.getElementById("modal").replaceChildren(); }
+
+const VFY_KIND_LABEL = {
+  changed: "Value differs",
+  missing: "Missing from recovery",
+  extra: "Unexpected in recovery",
+};
+const VFY_KIND_CLASS = { changed: "warn", missing: "fail", extra: "fail" };
+const VFY_KIND_NOTE = {
+  missing: "This row exists in the real baseline, but replaying the change log never reproduced it.",
+  extra: "Replaying the change log produced this row, but it isn't in the real baseline.",
+};
+
+// verifyDiffCard renders one RowDiff, reusing the doctor-preflight card
+// styling already established for verify's own match/mismatch/inconclusive
+// results — same "named check + status + detail" shape.
+function verifyDiffCard(d) {
+  const cls = VFY_KIND_CLASS[d.kind] || "warn";
+  const card = el("div", { class: "doctor-card " + cls });
+  card.append(el("span", { class: "dc-mark", text: cls === "fail" ? "✗" : "!" }));
+  const bodyEl = el("div", { class: "dc-body" },
+    el("div", { class: "dc-name", text: (VFY_KIND_LABEL[d.kind] || d.kind) + " — " + d.pk }));
+  if (VFY_KIND_NOTE[d.kind]) {
+    bodyEl.append(el("p", { class: "form-hint", text: VFY_KIND_NOTE[d.kind] }));
+  } else if (d.cells && d.cells.length) {
+    bodyEl.append(verifyDiffCellsTable(d.cells));
+  }
+  card.append(bodyEl);
+  return card;
+}
+
+function verifyDiffCellsTable(cells) {
+  const table = el("table", { class: "vfy-diff-table" });
+  table.append(el("thead", {}, el("tr", {},
+    el("th", { text: "Column" }), el("th", { text: "Recovered" }), el("th", { text: "Baseline (real)" }))));
+  const tbody = el("tbody");
+  cells.forEach((c) => tbody.append(el("tr", {},
+    el("td", { text: c.column }),
+    el("td", {}, verifyDiffValue(c.recovery)),
+    el("td", {}, verifyDiffValue(c.baseline)))));
+  table.append(tbody);
+  return table;
+}
+
+// verifyDiffValue styles a NULL cell distinctly from the literal text "NULL"
+// a real value could (rarely) contain — a display-only best effort, not a
+// data distinction: the underlying comparison that flagged this diff already
+// happened server-side against the real NULL-vs-empty-aware bytes.
+function verifyDiffValue(v) {
+  if (v === "NULL") return el("span", { class: "vfy-null", text: "NULL" });
+  return document.createTextNode(v);
+}
 
 // ── schemas / tables cascade ──────────────────────────────────────────────────
 

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -1282,6 +1282,7 @@ button { font-family: inherit; }
 .stg-empty-sub { margin: 0; font-size: 12.5px; color: var(--ink-3); max-width: 52ch; }
 
 /* Verification panel (#677) */
+.vfy-panel-full { grid-column: 1 / -1; }
 .vfy-actions { display: flex; align-items: center; gap: 8px; }
 .vfy-mode { max-width: 260px; }
 .vfy-livewarn { margin: 0 0 8px; color: var(--orange-2); }

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -1288,7 +1288,27 @@ button { font-family: inherit; }
 .vfy-livewarn { margin: 0 0 8px; color: var(--orange-2); }
 .vfy-results { display: flex; flex-direction: column; gap: 8px; }
 .vfy-summary { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
-.vfy-explain-pre { max-height: 50vh; overflow-y: auto; }
+
+/* Verify explain modal: a wider modal + doctor-cards for each diverging row,
+   a comparison table for changed columns, raw CLI-style text tucked behind a
+   disclosure for troubleshooting (#690 follow-up: the raw dump alone read as
+   "no se entiende una verga"). */
+.vfy-explain-modal { max-width: 900px; }
+.vfy-explain-body { padding: 4px 28px 16px; display: flex; flex-direction: column; gap: 8px; max-height: 45vh; overflow-y: auto; }
+.vfy-diff-table { width: 100%; border-collapse: collapse; margin-top: 8px; font-size: 12.5px; }
+.vfy-diff-table th {
+  text-align: left; font-weight: 600; color: var(--ink-3); font-size: 11px;
+  text-transform: uppercase; letter-spacing: .02em;
+  padding: 4px 10px 4px 0; border-bottom: 1px solid var(--line-soft);
+}
+.vfy-diff-table td {
+  font-family: var(--f-mono); padding: 5px 10px 5px 0; border-bottom: 1px solid var(--line-soft);
+  vertical-align: top; word-break: break-all;
+}
+.vfy-diff-table tr:last-child td { border-bottom: none; }
+.vfy-null { color: var(--ink-4); font-style: italic; }
+.vfy-explain-raw { margin: 0 28px 16px; }
+.vfy-explain-pre { max-height: 26vh; overflow-y: auto; }
 .stg-code {
   font-family: var(--f-mono); font-size: 11.5px; color: var(--ink-2);
   background: var(--surface-3); border-radius: 4px; padding: 7px 10px;


### PR DESCRIPTION
## Summary

User-reported follow-ups to #688/#677, from a real deployment:

1. **CSS**: the Verification panel floated oddly with a large dead gap to its right. `ov-grid` is a 2-column grid with `align-items:start`; Baseline snapshots (one row per snapshot) routinely runs much taller than S3 archiving, so a 3rd grid item with no explicit placement landed under the SHORT sibling while the TALL one still extended alongside it. `grid-column: 1 / -1` puts Verification in its own full-width row instead — also gives its (potentially long) results list more room.
2. **Docs**: "Verification from the console is not enabled" despite thinking VERIFY_TRIGGER was opt-out. Root cause isn't a bug: the default-on wiring lives only in the bundled `docker-compose.yml`'s `${VERIFY_TRIGGER:-1}` — the Go binary's own default stays off unless the env var reaches it (matching #683's precedent for BASELINE_TRIGGER exactly). The user's deployment predates today's merge, so their `docker-compose.yml` doesn't have the new line yet, and `docker compose pull` only updates images, never the compose file. Expanded `docs/upgrade.md` with this as a general lesson.
3. **Explain modal readability** ("no se entiende una verga" — fair): the modal rendered `internal/verify`'s `MismatchExplanation.Write()` output verbatim — plain text built for a terminal. The structured `VerifyExplanation.Diffs` was already fetched from the API but never rendered. Now shows a plain-language card per differing row (reusing the doctor-preflight card idiom the match/mismatch/inconclusive results already use) plus a Column/Recovered/Baseline comparison table for changed values; the raw CLI text stays available behind a collapsed "Raw output" disclosure for troubleshooting.

## Test plan
- [x] `node --check` on the modified JS
- [x] `go build ./...`, `go test ./internal/console/...`
- [x] Visually verified item 3 in a real browser: served `internal/console/assets/` statically, stubbed `window.api()` with canned explain responses (a changed+missing+extra mix, and the empty-diffs row-count-only edge case), drove the real `openVerifyExplain()` through headless Chrome — renders correctly, zero console errors, disclosure and Close button both work
- [ ] Item 1 (grid span) not re-verified against a live browser render — mechanical, well-understood CSS Grid change scoped to a single class addition

🤖 Generated with [Claude Code](https://claude.com/claude-code)