### PR TITLE
verify: fix false MISMATCH on JSON-valued TEXT columns from key-order drift

### DIFF
--- a/internal/verify/explain_baseline.go
+++ b/internal/verify/explain_baseline.go
@@ -209,7 +209,10 @@ func ExplainBaselinePairMismatch(ctx context.Context, cfg BaselineConfig, p Base
 
 // streamRowsByPK reconstructs baselinePath+changes and invokes emit once per row
 // with its PK key (for joining) and canonical per-column bytes. It is the digest
-// row stream (reconstructDigest) re-pointed at a diff instead of a hash.
+// row stream (reconstructDigest) re-pointed at a diff instead of a hash — using
+// the SAME renderCellCanonicalJSON reconstructDigest's baseline-anchored callers
+// use, so a row this drill-down shows as differing is exactly a row the digest
+// that flagged the mismatch also saw as differing (cellEqual's invariant).
 func streamRowsByPK(ctx context.Context, baselinePath, schema, table string, pkCols, orderedCols []metadata.ColumnMeta, changes map[string]*query.ResultRow, emit func(key string, r rowCells) error) error {
 	return reconstruct.SnapshotFullTableImages(ctx, reconstruct.SnapshotFullTableInput{
 		BaselinePath: baselinePath,
@@ -221,7 +224,7 @@ func streamRowsByPK(ctx context.Context, baselinePath, schema, table string, pkC
 		key, pk := pkKeyAndDisplay(rowMap, pkCols)
 		cells := make(map[string][]byte, len(orderedCols))
 		for _, c := range orderedCols {
-			cells[c.Name] = renderCell(rowMap[c.Name], c)
+			cells[c.Name] = renderCellCanonicalJSON(rowMap[c.Name], c)
 		}
 		return emit(key, rowCells{pk: pk, cells: cells})
 	})

--- a/internal/verify/render.go
+++ b/internal/verify/render.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/dbtrail/dbtrail/internal/metadata"
 )
@@ -134,18 +135,20 @@ func temporalPrecision(columnType string) int {
 // happen inside an object; touching scalars would only add risk (whitespace/
 // escaping differences) for no benefit.
 //
-// This exists for one specific gap: a MySQL TEXT/LONGTEXT column (not the
-// native JSON type) whose stored value happens to be JSON text — a common
-// pattern for plugins that json_encode() into a text field. Once an event
-// touches such a row, its event-image round-trips through Go's
-// map[string]any (query.UnmarshalRowImage), which loses the original key
-// order; renderCell's default case then re-marshals it with Go's own
-// (alphabetically sorted) key order, while a baseline dump's text preserves
-// the source's original order verbatim. Two renderings of identical data
-// disagree on bytes alone. A column typed as MySQL's native JSON already has
-// a narrower version of this same gap, covered by isDeferredType's
-// inconclusive downgrade — this closes it more precisely, for the case
-// canonicalization can actually resolve to a genuine match rather than
+// This operates on the RENDERED bytes, not the column's declared SQL type, so
+// it applies to any value that renders JSON-shaped — a native MySQL JSON
+// column, and equally a MySQL TEXT/LONGTEXT column (not the native JSON type)
+// whose stored value happens to be JSON text, a common pattern for plugins
+// that json_encode() into a text field. That TEXT case is the gap this
+// primarily exists to close: once an event touches such a row, its
+// event-image round-trips through Go's map[string]any
+// (query.UnmarshalRowImage), which loses the original key order; renderCell's
+// default case then re-marshals it with Go's own (alphabetically sorted) key
+// order, while a baseline dump's text preserves the source's original order
+// verbatim. Two renderings of identical data disagree on bytes alone. A
+// column typed as MySQL's native JSON already had a narrower version of this
+// same gap, covered by isDeferredType's inconclusive downgrade — this closes
+// it more precisely there too, resolving to a genuine match rather than
 // merely downgrading to "can't tell": see renderCellCanonicalJSON.
 //
 // UseNumber preserves large-integer/decimal literals exactly, the same
@@ -163,6 +166,27 @@ func canonicalizeJSONContainer(b []byte) ([]byte, bool) {
 	if !json.Valid(t) {
 		return b, false
 	}
+	// Not eligible to canonicalize: raw content this transform would corrupt
+	// or hide a divergence in, rather than merely reorder.
+	//   - invalid UTF-8: both json.Decode/Encode replace it with U+FFFD, so two
+	//     DIFFERENT invalid byte sequences could canonicalize to the SAME
+	//     output — silently erasing a real difference.
+	//   - a repeated key within one object: decoding into map[string]any keeps
+	//     only the last occurrence (Go's stdlib behavior), which would make
+	//     `{"a":1,"a":2}` and `{"a":2}` compare equal — but those are NOT the
+	//     same source bytes, and if that duplicate-keyed value came from
+	//     event-image reconstruction, this is exactly the kind of divergence
+	//     verify exists to catch, not paper over.
+	// Both leave b returned unchanged, so a genuinely malformed/duplicated
+	// value still falls back to the pre-fix byte comparison (conservative:
+	// worst case reports a mismatch verify's caller downgrades to
+	// inconclusive or a human reviews, never a silently masked one).
+	if !utf8.Valid(t) {
+		return b, false
+	}
+	if hasDuplicateObjectKeys(t) {
+		return b, false
+	}
 	dec := json.NewDecoder(bytes.NewReader(t))
 	dec.UseNumber()
 	var v any
@@ -176,6 +200,65 @@ func canonicalizeJSONContainer(b []byte) ([]byte, bool) {
 		return b, false
 	}
 	return bytes.TrimRight(buf.Bytes(), "\n"), true
+}
+
+// hasDuplicateObjectKeys reports whether any JSON object within data (already
+// confirmed json.Valid) repeats a key at the same nesting level — a case
+// Go's map[string]any decode would silently collapse to last-key-wins,
+// exactly the kind of information loss canonicalizeJSONContainer must not
+// introduce. Walks the raw token stream (not a map) so duplicates are visible
+// before any collapsing decode runs.
+func hasDuplicateObjectKeys(data []byte) bool {
+	dup, _ := walkForDuplicateKeys(json.NewDecoder(bytes.NewReader(data)))
+	return dup
+}
+
+// walkForDuplicateKeys consumes exactly one JSON value (scalar, object, or
+// array) from dec and reports whether a duplicate object key was found
+// anywhere within it, recursing into nested objects/arrays. err is non-nil
+// only on a stream read failure, which cannot happen against
+// already-json.Valid input; callers treat that case as "no duplicate found"
+// (the same conservative, fall-back-to-raw-bytes behavior every other
+// canonicalizeJSONContainer failure path takes).
+func walkForDuplicateKeys(dec *json.Decoder) (bool, error) {
+	tok, err := dec.Token()
+	if err != nil {
+		return false, err
+	}
+	delim, ok := tok.(json.Delim)
+	if !ok {
+		return false, nil // scalar value: string/number/bool/null, no keys to check
+	}
+	switch delim {
+	case '{':
+		seen := make(map[string]bool)
+		for dec.More() {
+			keyTok, err := dec.Token()
+			if err != nil {
+				return false, err
+			}
+			key, _ := keyTok.(string) // object keys are always strings per the JSON grammar
+			if seen[key] {
+				return true, nil
+			}
+			seen[key] = true
+			if dup, err := walkForDuplicateKeys(dec); dup || err != nil {
+				return dup, err
+			}
+		}
+		_, err := dec.Token() // consume the closing '}'
+		return false, err
+	case '[':
+		for dec.More() {
+			if dup, err := walkForDuplicateKeys(dec); dup || err != nil {
+				return dup, err
+			}
+		}
+		_, err := dec.Token() // consume the closing ']'
+		return false, err
+	default:
+		return false, nil // stray '}'/']' — unreachable against valid JSON
+	}
 }
 
 // renderCellCanonicalJSON renders a cell like renderCell, additionally

--- a/internal/verify/render.go
+++ b/internal/verify/render.go
@@ -157,7 +157,9 @@ func temporalPrecision(columnType string) int {
 // a human reading a mismatch cell would otherwise have to puzzle over.
 //
 // Returns the input unchanged with ok=false when b is not a JSON
-// object/array, or fails to parse.
+// object/array, fails to parse, is not valid UTF-8, decodes to a value
+// containing U+FFFD (see the surrogate-escape note below), or contains a
+// duplicate object key at any depth.
 func canonicalizeJSONContainer(b []byte) ([]byte, bool) {
 	t := bytes.TrimSpace(b)
 	if len(t) == 0 || (t[0] != '{' && t[0] != '[') {
@@ -168,16 +170,16 @@ func canonicalizeJSONContainer(b []byte) ([]byte, bool) {
 	}
 	// Not eligible to canonicalize: raw content this transform would corrupt
 	// or hide a divergence in, rather than merely reorder.
-	//   - invalid UTF-8: both json.Decode/Encode replace it with U+FFFD, so two
-	//     DIFFERENT invalid byte sequences could canonicalize to the SAME
-	//     output — silently erasing a real difference.
+	//   - invalid UTF-8 bytes: both json.Decode/Encode replace them with
+	//     U+FFFD, so two DIFFERENT invalid byte sequences could canonicalize
+	//     to the SAME output — silently erasing a real difference.
 	//   - a repeated key within one object: decoding into map[string]any keeps
 	//     only the last occurrence (Go's stdlib behavior), which would make
 	//     `{"a":1,"a":2}` and `{"a":2}` compare equal — but those are NOT the
 	//     same source bytes, and if that duplicate-keyed value came from
 	//     event-image reconstruction, this is exactly the kind of divergence
 	//     verify exists to catch, not paper over.
-	// Both leave b returned unchanged, so a genuinely malformed/duplicated
+	// All leave b returned unchanged, so a genuinely malformed/duplicated
 	// value still falls back to the pre-fix byte comparison (conservative:
 	// worst case reports a mismatch verify's caller downgrades to
 	// inconclusive or a human reviews, never a silently masked one).
@@ -199,14 +201,30 @@ func canonicalizeJSONContainer(b []byte) ([]byte, bool) {
 	if err := enc.Encode(v); err != nil {
 		return b, false
 	}
-	return bytes.TrimRight(buf.Bytes(), "\n"), true
+	out := bytes.TrimRight(buf.Bytes(), "\n")
+	// An unpaired \uD800-\uDFFF surrogate escape is valid JSON syntax AND
+	// valid raw UTF-8 (it's just six ASCII characters before unescaping), so
+	// utf8.Valid(t) above does not catch it — the invalidity only appears
+	// once json.Decode unescapes the string content, where Go silently
+	// substitutes U+FFFD, same as it does for invalid raw bytes. Two
+	// DIFFERENT unpaired surrogates would decode to the identical U+FFFD and
+	// canonicalize to the identical output. Refuse whenever the canonical
+	// form contains U+FFFD: a real, intentional U+FFFD in source data is
+	// vanishingly rare, and the cost of a false refusal here is only a
+	// fallback to raw-byte comparison, not a wrong answer.
+	if bytes.ContainsRune(out, utf8.RuneError) {
+		return b, false
+	}
+	return out, true
 }
 
 // hasDuplicateObjectKeys reports whether any JSON object within data (already
-// confirmed json.Valid) repeats a key at the same nesting level — a case
-// Go's map[string]any decode would silently collapse to last-key-wins,
-// exactly the kind of information loss canonicalizeJSONContainer must not
-// introduce. Walks the raw token stream (not a map) so duplicates are visible
+// confirmed json.Valid) repeats a key WITHIN THAT SAME OBJECT — a case Go's
+// map[string]any decode would silently collapse to last-key-wins, exactly the
+// kind of information loss canonicalizeJSONContainer must not introduce. Two
+// sibling objects (or an object and its parent) reusing the same key name is
+// NOT a duplicate — key uniqueness is scoped per object, not per nesting
+// depth. Walks the raw token stream (not a map) so duplicates are visible
 // before any collapsing decode runs.
 func hasDuplicateObjectKeys(data []byte) bool {
 	dup, _ := walkForDuplicateKeys(json.NewDecoder(bytes.NewReader(data)))

--- a/internal/verify/render.go
+++ b/internal/verify/render.go
@@ -5,6 +5,7 @@
 package verify
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -123,4 +124,80 @@ func temporalPrecision(columnType string) int {
 		return 0
 	}
 	return n
+}
+
+// canonicalizeJSONContainer re-renders a JSON object/array value from its
+// decoded form, so two byte-different-but-semantically-equal serializations
+// of the same JSON content compare equal. Scoped to CONTAINERS ({...}/[...])
+// only — a scalar that happens to also be valid JSON (a bare number, "true",
+// or a quoted string) is left untouched, since key-order drift can only
+// happen inside an object; touching scalars would only add risk (whitespace/
+// escaping differences) for no benefit.
+//
+// This exists for one specific gap: a MySQL TEXT/LONGTEXT column (not the
+// native JSON type) whose stored value happens to be JSON text — a common
+// pattern for plugins that json_encode() into a text field. Once an event
+// touches such a row, its event-image round-trips through Go's
+// map[string]any (query.UnmarshalRowImage), which loses the original key
+// order; renderCell's default case then re-marshals it with Go's own
+// (alphabetically sorted) key order, while a baseline dump's text preserves
+// the source's original order verbatim. Two renderings of identical data
+// disagree on bytes alone. A column typed as MySQL's native JSON already has
+// a narrower version of this same gap, covered by isDeferredType's
+// inconclusive downgrade — this closes it more precisely, for the case
+// canonicalization can actually resolve to a genuine match rather than
+// merely downgrading to "can't tell": see renderCellCanonicalJSON.
+//
+// UseNumber preserves large-integer/decimal literals exactly, the same
+// precision requirement renderCell's json.Number case already protects
+// (#496). SetEscapeHTML(false) avoids gratuitously mangling '<'/'>'/'&' that
+// a human reading a mismatch cell would otherwise have to puzzle over.
+//
+// Returns the input unchanged with ok=false when b is not a JSON
+// object/array, or fails to parse.
+func canonicalizeJSONContainer(b []byte) ([]byte, bool) {
+	t := bytes.TrimSpace(b)
+	if len(t) == 0 || (t[0] != '{' && t[0] != '[') {
+		return b, false
+	}
+	if !json.Valid(t) {
+		return b, false
+	}
+	dec := json.NewDecoder(bytes.NewReader(t))
+	dec.UseNumber()
+	var v any
+	if err := dec.Decode(&v); err != nil {
+		return b, false
+	}
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		return b, false
+	}
+	return bytes.TrimRight(buf.Bytes(), "\n"), true
+}
+
+// renderCellCanonicalJSON renders a cell like renderCell, additionally
+// canonicalizing a JSON object/array value (see canonicalizeJSONContainer)
+// so a pure representation difference doesn't register as a content
+// difference.
+//
+// Used ONLY by the baseline-anchored comparison (VerifyBaselinePair,
+// ExplainBaselinePairMismatch): both operands there are produced by this
+// same package, so canonicalizing them symmetrically cannot introduce a new
+// disagreement. The live-source comparison (VerifyTable) keeps using
+// renderCell unwrapped — its OTHER operand is MySQL's own raw text via
+// internal/consistency.ConsistentTableChecksum, which this package does not
+// control and does not canonicalize; wrapping only one side there would
+// create a new mismatch instead of fixing one.
+func renderCellCanonicalJSON(v any, col metadata.ColumnMeta) []byte {
+	b := renderCell(v, col)
+	if b == nil {
+		return nil
+	}
+	if canon, ok := canonicalizeJSONContainer(b); ok {
+		return canon
+	}
+	return b
 }

--- a/internal/verify/render_test.go
+++ b/internal/verify/render_test.go
@@ -67,6 +67,116 @@ func TestRenderCell_JSONContainerCompletes(t *testing.T) {
 	}
 }
 
+// TestCanonicalizeJSONContainer_KeyOrderOnly is the core fix: two JSON objects
+// carrying the same key/value pairs in a different order canonicalize to the
+// SAME bytes, and a genuinely different value does NOT.
+func TestCanonicalizeJSONContainer_KeyOrderOnly(t *testing.T) {
+	a, aOK := canonicalizeJSONContainer([]byte(`{"a":1,"b":2}`))
+	b, bOK := canonicalizeJSONContainer([]byte(`{"b":2,"a":1}`))
+	if !aOK || !bOK {
+		t.Fatalf("expected both to canonicalize: aOK=%v bOK=%v", aOK, bOK)
+	}
+	if string(a) != string(b) {
+		t.Errorf("key-order-only difference should canonicalize identically, got %q vs %q", a, b)
+	}
+	c, cOK := canonicalizeJSONContainer([]byte(`{"a":1,"b":3}`))
+	if !cOK {
+		t.Fatal("expected c to canonicalize")
+	}
+	if string(a) == string(c) {
+		t.Error("genuinely different values must NOT canonicalize to the same bytes")
+	}
+}
+
+// TestCanonicalizeJSONContainer_ScalarsAndNonJSONUntouched: scalars (a bare
+// number/bool/null/quoted string, even though each is independently valid
+// JSON) and non-JSON text are left exactly as-is — canonicalization is scoped
+// to object/array containers only.
+func TestCanonicalizeJSONContainer_ScalarsAndNonJSONUntouched(t *testing.T) {
+	for _, in := range []string{"42", "true", "false", "null", `"hello"`, "not json at all", ""} {
+		got, ok := canonicalizeJSONContainer([]byte(in))
+		if ok {
+			t.Errorf("canonicalizeJSONContainer(%q): ok=true, want false (not a container)", in)
+		}
+		if string(got) != in {
+			t.Errorf("canonicalizeJSONContainer(%q) = %q, want input returned unchanged", in, got)
+		}
+	}
+}
+
+// TestCanonicalizeJSONContainer_LargeNumberPrecisionPreserved guards the
+// #496-class risk: decoding through UseNumber and re-marshaling must not
+// round an integer that overflows float64's exact range, or reformat a
+// decimal literal.
+func TestCanonicalizeJSONContainer_LargeNumberPrecisionPreserved(t *testing.T) {
+	for _, in := range []string{
+		`{"n":9223372036854775807}`,  // max int64, loses precision through float64
+		`{"n":18446744073709551615}`, // max uint64
+		`{"n":1.50}`,                 // trailing zero a naive float64 round-trip drops
+	} {
+		got, ok := canonicalizeJSONContainer([]byte(in))
+		if !ok {
+			t.Fatalf("canonicalizeJSONContainer(%q): want ok=true", in)
+		}
+		if string(got) != in {
+			t.Errorf("canonicalizeJSONContainer(%q) = %q, want the number literal preserved exactly", in, got)
+		}
+	}
+}
+
+// TestCanonicalizeJSONContainer_DuplicateKeysRefused is the fix for a review
+// finding: decoding into map[string]any silently keeps only the LAST of a
+// repeated object key. If canonicalizeJSONContainer collapsed
+// {"a":1,"a":2} to {"a":2}, it would make that value indistinguishable from
+// a baseline that never had the duplicate — masking a real divergence
+// instead of merely reordering one. Must refuse (ok=false, raw bytes
+// returned) whenever ANY object in the value repeats a key, at any nesting
+// depth, inside an array or not — never silently collapse it.
+func TestCanonicalizeJSONContainer_DuplicateKeysRefused(t *testing.T) {
+	cases := []string{
+		`{"a":1,"a":2}`,                   // top-level duplicate
+		`{"outer":{"a":1,"a":2}}`,         // duplicate in a nested object
+		`[{"a":1},{"b":1,"b":2}]`,         // duplicate inside an array element
+		`{"a":{"x":1},"b":{"x":1,"x":2}}`, // duplicate in one branch, not the sibling
+	}
+	for _, in := range cases {
+		got, ok := canonicalizeJSONContainer([]byte(in))
+		if ok {
+			t.Errorf("canonicalizeJSONContainer(%q): ok=true, want false (must refuse a duplicate key)", in)
+		}
+		if string(got) != in {
+			t.Errorf("canonicalizeJSONContainer(%q) = %q, want input returned unchanged on refusal", in, got)
+		}
+	}
+	// A key repeated only as a VALUE (not a key) must NOT trip the guard.
+	clean := `{"a":"a","b":"a"}`
+	if _, ok := canonicalizeJSONContainer([]byte(clean)); !ok {
+		t.Errorf("canonicalizeJSONContainer(%q): want ok=true (no key is actually duplicated)", clean)
+	}
+}
+
+// TestCanonicalizeJSONContainer_InvalidUTF8Refused is the fix for a review
+// finding: encoding/json replaces invalid UTF-8 bytes with U+FFFD on
+// decode/re-encode, so two DIFFERENT invalid byte sequences could
+// canonicalize to the SAME output — silently erasing a real difference.
+// Must refuse whenever the input is not valid UTF-8.
+func TestCanonicalizeJSONContainer_InvalidUTF8Refused(t *testing.T) {
+	bad := []byte{'{', '"', 's', '"', ':', '"', 0xff, 0xfe, '"', '}'}
+	got, ok := canonicalizeJSONContainer(bad)
+	if ok {
+		t.Errorf("canonicalizeJSONContainer(invalid UTF-8): ok=true, want false")
+	}
+	if !bytes.Equal(got, bad) {
+		t.Errorf("canonicalizeJSONContainer(invalid UTF-8) = %q, want input returned unchanged on refusal", got)
+	}
+}
+
+func TestRenderCellCanonicalJSON_NullPassesThrough(t *testing.T) {
+	if got := renderCellCanonicalJSON(nil, col("json", "json")); got != nil {
+		t.Errorf("renderCellCanonicalJSON(nil, ...) = %q, want nil (SQL NULL)", got)
+	}
+}
+
 func TestTemporalPrecision(t *testing.T) {
 	cases := map[string]int{
 		"datetime":      0,

--- a/internal/verify/render_test.go
+++ b/internal/verify/render_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/dbtrail/dbtrail/internal/metadata"
 )
@@ -135,9 +136,13 @@ func TestCanonicalizeJSONContainer_LargeNumberPrecisionPreserved(t *testing.T) {
 func TestCanonicalizeJSONContainer_DuplicateKeysRefused(t *testing.T) {
 	cases := []string{
 		`{"a":1,"a":2}`,                   // top-level duplicate
+		`{"a":1,"a":1}`,                   // duplicate with the SAME value — a "compare the final decoded map" approach would miss this; the structural walker must not
 		`{"outer":{"a":1,"a":2}}`,         // duplicate in a nested object
 		`[{"a":1},{"b":1,"b":2}]`,         // duplicate inside an array element
 		`{"a":{"x":1},"b":{"x":1,"x":2}}`, // duplicate in one branch, not the sibling
+		`{"a":1,"b":2,"a":3}`,             // duplicate not adjacent to its first occurrence
+		`[[{"a":1,"a":2}]]`,               // duplicate nested inside array-in-array
+		"{\"\\u0061\":1,\"a\":2}",         // duplicate via a differently-escaped but identical decoded key
 	}
 	for _, in := range cases {
 		got, ok := canonicalizeJSONContainer([]byte(in))
@@ -168,6 +173,30 @@ func TestCanonicalizeJSONContainer_InvalidUTF8Refused(t *testing.T) {
 	}
 	if !bytes.Equal(got, bad) {
 		t.Errorf("canonicalizeJSONContainer(invalid UTF-8) = %q, want input returned unchanged on refusal", got)
+	}
+}
+
+// TestCanonicalizeJSONContainer_UnpairedSurrogateRefused is the fix for a
+// second review finding, distinct from the raw-invalid-UTF-8 case above: a
+// \uD800-\uDFFF escape is valid JSON syntax and valid RAW UTF-8 (it's just
+// ASCII characters before unescaping), so it passes json.Valid AND
+// utf8.Valid(t) — the invalidity only appears once json.Decode unescapes the
+// string, where Go substitutes U+FFFD, same as for raw invalid bytes. Two
+// DIFFERENT unpaired surrogates would otherwise canonicalize to the
+// identical U+FFFD and compare equal.
+func TestCanonicalizeJSONContainer_UnpairedSurrogateRefused(t *testing.T) {
+	one := []byte(`{"s":"\uD800"}`)
+	other := []byte(`{"s":"\uDEAD"}`)
+	if !utf8.Valid(one) || !utf8.Valid(other) {
+		t.Fatal("precondition: the raw bytes (escape sequences, not yet decoded) must be valid UTF-8")
+	}
+	gotOne, okOne := canonicalizeJSONContainer(one)
+	gotOther, okOther := canonicalizeJSONContainer(other)
+	if okOne || okOther {
+		t.Errorf("canonicalizeJSONContainer(unpaired surrogate): okOne=%v okOther=%v, want both false", okOne, okOther)
+	}
+	if !bytes.Equal(gotOne, one) || !bytes.Equal(gotOther, other) {
+		t.Errorf("got %q / %q, want both inputs returned unchanged on refusal", gotOne, gotOther)
 	}
 }
 

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -183,7 +183,7 @@ func VerifyTable(ctx context.Context, cfg Config, schema, table string) (TableRe
 	// masked by this.
 	deferredRepr := hasDeferredRepr(orderedCols) && len(changes) > 0
 
-	reconDigest, reconCount, emitErr := reconstructDigest(ctx, baselinePath, schema, table, pkCols, changes, orderedCols)
+	reconDigest, reconCount, emitErr := reconstructDigest(ctx, baselinePath, schema, table, pkCols, changes, orderedCols, renderCell)
 	if emitErr != nil {
 		return res, fmt.Errorf("reconstruct %s.%s: %w", schema, table, emitErr)
 	}
@@ -223,12 +223,14 @@ func classify(srcDigest string, srcRows int64, reconDigest string, reconRows int
 }
 
 // reconstructDigest reconstructs a table from baselinePath merged with changes,
-// renders each row's columns (in orderedCols order) to the canonical text form,
-// and returns the order-independent content digest + row count. Shared by the
-// live-source verify (VerifyTable) and the baseline-pair verify (#642): both
-// sides of any comparison must be produced by this one function so the digests
-// are byte-comparable by construction.
-func reconstructDigest(ctx context.Context, baselinePath, schema, table string, pkCols []metadata.ColumnMeta, changes map[string]*query.ResultRow, orderedCols []metadata.ColumnMeta) (string, int64, error) {
+// renders each row's columns (in orderedCols order) via render, and returns the
+// order-independent content digest + row count. Shared by the live-source
+// verify (VerifyTable, which passes plain renderCell) and the baseline-pair
+// verify (#642, which passes renderCellCanonicalJSON — see its doc comment for
+// why that canonicalization is safe only there): both sides of any one
+// comparison must be produced with the SAME render func so the digests are
+// byte-comparable by construction.
+func reconstructDigest(ctx context.Context, baselinePath, schema, table string, pkCols []metadata.ColumnMeta, changes map[string]*query.ResultRow, orderedCols []metadata.ColumnMeta, render func(any, metadata.ColumnMeta) []byte) (string, int64, error) {
 	hasher := consistency.NewHasher()
 	err := reconstruct.SnapshotFullTableImages(ctx, reconstruct.SnapshotFullTableInput{
 		BaselinePath: baselinePath,
@@ -239,7 +241,7 @@ func reconstructDigest(ctx context.Context, baselinePath, schema, table string, 
 	}, func(rowMap map[string]any) error {
 		cells := make([][]byte, len(orderedCols))
 		for i, c := range orderedCols {
-			cells[i] = renderCell(rowMap[c.Name], c)
+			cells[i] = render(rowMap[c.Name], c)
 		}
 		hasher.AddBytes(cells)
 		return nil

--- a/internal/verify/verify_baseline.go
+++ b/internal/verify/verify_baseline.go
@@ -143,12 +143,17 @@ func VerifyBaselinePair(ctx context.Context, cfg BaselineConfig, p BaselinePair)
 	}
 
 	// Recovery side: reconstruct the previous baseline forward to the anchor.
-	reconDigest, reconCount, err := reconstructDigest(ctx, p.PrevPath, p.Schema, p.Table, pkCols, changes, orderedCols)
+	// renderCellCanonicalJSON (not plain renderCell): both operands here come
+	// from this package, so canonicalizing a JSON object/array value the SAME
+	// way on both sides closes the false-mismatch gap a TEXT/JSON column's
+	// event-image round-trip can otherwise open (see its doc comment) without
+	// risking the live-source comparison, which this function is not used for.
+	reconDigest, reconCount, err := reconstructDigest(ctx, p.PrevPath, p.Schema, p.Table, pkCols, changes, orderedCols, renderCellCanonicalJSON)
 	if err != nil {
 		return res, fmt.Errorf("reconstruct prev %s.%s: %w", p.Schema, p.Table, err)
 	}
 	// Truth side: the new baseline as-is (no events), via the same path.
-	newDigest, newCount, err := reconstructDigest(ctx, p.NewPath, p.Schema, p.Table, pkCols, map[string]*query.ResultRow{}, orderedCols)
+	newDigest, newCount, err := reconstructDigest(ctx, p.NewPath, p.Schema, p.Table, pkCols, map[string]*query.ResultRow{}, orderedCols, renderCellCanonicalJSON)
 	if err != nil {
 		return res, fmt.Errorf("read new baseline %s.%s: %w", p.Schema, p.Table, err)
 	}

--- a/internal/verify/verify_baseline_integration_test.go
+++ b/internal/verify/verify_baseline_integration_test.go
@@ -933,3 +933,172 @@ func TestVerifyBaselinePair_JSONValuedTextColumn_KeyOrderIsAMatch(t *testing.T) 
 		t.Errorf("id=2 details cell = %+v, want recovery to carry known:true and baseline known:false", id2Diff.Cells[0])
 	}
 }
+
+// TestVerifyBaselinePair_JSONValuedTextColumn_Isolated_Match isolates
+// VerifyBaselinePair's OWN digest wiring (the two renderCellCanonicalJSON
+// calls in verify_baseline.go) for the JSON-key-order fix — the same way
+// TestVerifyBaselinePair_TextOnlyChange_Match isolates the sibling #672
+// TEXT-decode fix.
+//
+// TestVerifyBaselinePair_JSONValuedTextColumn_KeyOrderIsAMatch (above) is NOT
+// sufficient for this: its id=2 row carries a genuine, independent
+// divergence, so its top-level Status assertion reads "mismatch" regardless
+// of whether id=1's key-order canonicalization actually ran — reverting JUST
+// verify_baseline.go's two reconstructDigest calls (leaving
+// explain_baseline.go's streamRowsByPK correct) would NOT be caught by that
+// test's Status check, only by its separate id1Diff check via Explain. This
+// table has nothing else that could cause a mismatch: if canonicalization
+// weren't wired into VerifyBaselinePair's own digest, THIS test — not just
+// the Explain drill-down — would report StatusMismatch.
+func TestVerifyBaselinePair_JSONValuedTextColumn_Isolated_Match(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	for _, c := range []struct {
+		name, key, dt, colType string
+		ord                    int
+	}{
+		{"id", "PRI", "int", "int", 1},
+		{"details", "", "text", "longtext", 2},
+	} {
+		testutil.MustExec(t, db, `INSERT INTO schema_snapshots
+			(snapshot_id, snapshot_time, schema_name, table_name, column_name,
+			 ordinal_position, column_key, data_type, column_type, is_nullable, is_generated)
+			VALUES (1, UTC_TIMESTAMP(), ?, 'audit_log', ?, ?, ?, ?, ?, 'YES', 0)`,
+			dbName, c.name, c.ord, c.key, c.dt, c.colType)
+	}
+
+	baseDir := t.TempDir()
+	now := time.Now().UTC()
+	prevTS := now.Truncate(time.Hour).Add(-2 * time.Hour)
+	newTS := prevTS.Add(time.Hour)
+	createSQL := "CREATE TABLE `audit_log` (\n  `id` INT NOT NULL,\n  `details` LONGTEXT,\n  PRIMARY KEY (`id`)\n);\n"
+	cols := []baseline.Column{
+		{Name: "id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
+		{Name: "details", MySQLType: "longtext", ParquetType: baseline.MysqlToParquetNode("longtext")},
+	}
+	// Both baselines hold the SAME logical value in the SAME (non-alphabetical)
+	// key order — the ONLY row in the table, so nothing else can cause a
+	// mismatch.
+	writeTestBaseline(t, baseDir, prevTS, dbName, "audit_log", createSQL, cols, [][]string{
+		{"1", `{"c":3,"a":1,"b":2}`},
+	}, "binlog.000001", 200)
+	writeTestBaseline(t, baseDir, newTS, dbName, "audit_log", createSQL, cols, [][]string{
+		{"1", `{"c":3,"a":1,"b":2}`},
+	}, "binlog.000001", 300)
+
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{prevTS, newTS, now.Truncate(time.Hour)})
+	ets := prevTS.Add(30 * time.Minute).Format("2006-01-02 15:04:05")
+	// An UPDATE event touches this row's details with the SAME logical value.
+	// row_after embeds it as a nested JSON object (matching marshalRow's
+	// promotion), which decodes to map[string]any and, through plain
+	// renderCell, re-marshals ALPHABETICALLY SORTED — different bytes from the
+	// baseline's verbatim (non-alphabetical) string unless canonicalized.
+	testutil.InsertEvent(t, db, "binlog.000001", 200, 300, ets, nil, dbName, "audit_log", 2 /*UPDATE*/, "1", []byte(`["details"]`),
+		[]byte(`{"id":1,"details":{"c":3,"a":1,"b":2}}`),
+		[]byte(`{"id":1,"details":{"c":3,"a":1,"b":2}}`))
+
+	resolver, err := metadata.NewResolver(db, 1)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+	cfg := BaselineConfig{IndexDB: db, Resolver: resolver, IndexDBName: dbName, NoArchive: true}
+	ctx := context.Background()
+	pairs, _, _, err := FindBaselinePair(ctx, baseDir)
+	if err != nil || len(pairs) != 1 {
+		t.Fatalf("FindBaselinePair: %v (pairs=%d)", err, len(pairs))
+	}
+
+	got, err := VerifyBaselinePair(ctx, cfg, pairs[0])
+	if err != nil {
+		t.Fatalf("VerifyBaselinePair: %v", err)
+	}
+	if got.Status != StatusMatch {
+		t.Fatalf("status = %q (%s); want match — this table's only row has a key-order-shaped JSON-valued TEXT column touched by an event, nothing else that could cause a mismatch", got.Status, got.Detail)
+	}
+}
+
+// TestVerifyBaselinePair_DuplicateJSONKey_StaysMismatch is an integration-level
+// regression test for a review finding: canonicalizeJSONContainer refuses to
+// canonicalize a JSON value with a duplicate object key (see its doc comment)
+// rather than silently collapsing it to last-key-wins, which would make a
+// baseline holding a genuinely duplicate-keyed value match an
+// already-collapsed recovered value — a false MATCH on a real
+// recovery-fidelity divergence. TestCanonicalizeJSONContainer_DuplicateKeysRefused
+// proves the guard in isolation; this proves the guard's CONSEQUENCE survives
+// through the real VerifyBaselinePair pipeline.
+//
+// A duplicate key can only survive verbatim on the BASELINE side: it's a
+// plain string in the Parquet dump (mydumper doesn't validate/normalize TEXT
+// content as JSON). It can NEVER survive in an event's row_after — confirmed
+// empirically against a real MySQL instance — because row_after is itself a
+// MySQL JSON-typed column in bintrail's OWN index schema, and MySQL collapses
+// a duplicate key to last-value-wins AT INSERT TIME, before any Go code runs.
+// So the event below is written pre-collapsed (single key), exactly matching
+// what MySQL would store regardless of what bytes were sent — this is the
+// realistic shape of "a row recovery would actually produce," which is
+// genuinely, unavoidably different from the true source's duplicate-keyed
+// TEXT value once it round-trips through row_after.
+func TestVerifyBaselinePair_DuplicateJSONKey_StaysMismatch(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	for _, c := range []struct {
+		name, key, dt, colType string
+		ord                    int
+	}{
+		{"id", "PRI", "int", "int", 1},
+		{"details", "", "text", "longtext", 2},
+	} {
+		testutil.MustExec(t, db, `INSERT INTO schema_snapshots
+			(snapshot_id, snapshot_time, schema_name, table_name, column_name,
+			 ordinal_position, column_key, data_type, column_type, is_nullable, is_generated)
+			VALUES (1, UTC_TIMESTAMP(), ?, 'audit_log', ?, ?, ?, ?, ?, 'YES', 0)`,
+			dbName, c.name, c.ord, c.key, c.dt, c.colType)
+	}
+
+	baseDir := t.TempDir()
+	now := time.Now().UTC()
+	prevTS := now.Truncate(time.Hour).Add(-2 * time.Hour)
+	newTS := prevTS.Add(time.Hour)
+	createSQL := "CREATE TABLE `audit_log` (\n  `id` INT NOT NULL,\n  `details` LONGTEXT,\n  PRIMARY KEY (`id`)\n);\n"
+	cols := []baseline.Column{
+		{Name: "id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
+		{Name: "details", MySQLType: "longtext", ParquetType: baseline.MysqlToParquetNode("longtext")},
+	}
+	// The baseline's stored text has a GENUINE duplicate key — realistic for
+	// loosely-validated plugin-generated JSON, the exact population this fix
+	// targets. This is the ONLY row in the table.
+	writeTestBaseline(t, baseDir, prevTS, dbName, "audit_log", createSQL, cols, nil, "binlog.000001", 200)
+	writeTestBaseline(t, baseDir, newTS, dbName, "audit_log", createSQL, cols, [][]string{
+		{"1", `{"a":1,"a":2}`},
+	}, "binlog.000001", 300)
+
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{prevTS, newTS, now.Truncate(time.Hour)})
+	ets := prevTS.Add(30 * time.Minute).Format("2006-01-02 15:04:05")
+	testutil.InsertEvent(t, db, "binlog.000001", 200, 300, ets, nil, dbName, "audit_log", 1 /*INSERT*/, "1", nil,
+		nil, []byte(`{"id":1,"details":{"a":2}}`))
+
+	resolver, err := metadata.NewResolver(db, 1)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+	cfg := BaselineConfig{IndexDB: db, Resolver: resolver, IndexDBName: dbName, NoArchive: true}
+	ctx := context.Background()
+	pairs, _, _, err := FindBaselinePair(ctx, baseDir)
+	if err != nil || len(pairs) != 1 {
+		t.Fatalf("FindBaselinePair: %v (pairs=%d)", err, len(pairs))
+	}
+
+	got, err := VerifyBaselinePair(ctx, cfg, pairs[0])
+	if err != nil {
+		t.Fatalf("VerifyBaselinePair: %v", err)
+	}
+	if got.Status != StatusMismatch {
+		t.Fatalf("status = %q (%s); want mismatch — a baseline with a genuine duplicate JSON key must never silently match an already-collapsed recovered value", got.Status, got.Detail)
+	}
+}

--- a/internal/verify/verify_baseline_integration_test.go
+++ b/internal/verify/verify_baseline_integration_test.go
@@ -800,3 +800,136 @@ func TestVerifyBaselinePair_TextOnlyChange_Match(t *testing.T) {
 		t.Fatalf("status = %q (%s); want match (TEXT body should decode to \"updated text\", matching the new baseline)", got.Status, got.Detail)
 	}
 }
+
+// TestVerifyBaselinePair_JSONValuedTextColumn_KeyOrderIsAMatch is a repro +
+// regression test for a user-reported false MISMATCH: a TEXT/LONGTEXT column
+// (not MySQL's native JSON type — e.g. a plugin storing json_encode()'d PHP
+// data, like the wp_aiowps_audit_log.details case reported live) whose stored
+// value happens to be valid JSON text.
+//
+// Root cause: indexer.marshalRow promotes ANY []byte value that is valid JSON
+// to json.RawMessage before writing binlog_events.row_after — regardless of
+// the column's declared SQL type — so this TEXT column's event image is
+// stored as a NESTED JSON object, not a quoted string (mirrored here by
+// writing `"details":{...}` directly rather than through the b64 TEXT path).
+// When verify reads it back, it decodes to map[string]any (Go maps have no
+// stable order); renderCell's default case re-marshals it via json.Marshal,
+// which ALWAYS sorts object keys alphabetically. The baseline (Parquet) side
+// renders the SAME logical value verbatim from its stored string, preserving
+// whatever key order the source originally serialized. isDeferredType("text")
+// is false by design (#672), so this never got the ENUM/JSON/binary
+// inconclusive downgrade either — two byte-different renderings of identical
+// data reported a hard MISMATCH.
+//
+// Fixed by renderCellCanonicalJSON: the baseline-anchored comparison
+// canonicalizes JSON object/array values on BOTH sides, so this now reports a
+// genuine StatusMatch — not merely "inconclusive". id=2 in the same table
+// proves the fix isn't a blanket "ignore JSON columns" — a GENUINE content
+// divergence in the same JSON-valued TEXT column must still surface as a real
+// mismatch.
+func TestVerifyBaselinePair_JSONValuedTextColumn_KeyOrderIsAMatch(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	for _, c := range []struct {
+		name, key, dt, colType string
+		ord                    int
+	}{
+		{"id", "PRI", "int", "int", 1},
+		{"details", "", "text", "longtext", 2},
+	} {
+		testutil.MustExec(t, db, `INSERT INTO schema_snapshots
+			(snapshot_id, snapshot_time, schema_name, table_name, column_name,
+			 ordinal_position, column_key, data_type, column_type, is_nullable, is_generated)
+			VALUES (1, UTC_TIMESTAMP(), ?, 'audit_log', ?, ?, ?, ?, ?, 'YES', 0)`,
+			dbName, c.name, c.ord, c.key, c.dt, c.colType)
+	}
+
+	baseDir := t.TempDir()
+	now := time.Now().UTC()
+	prevTS := now.Truncate(time.Hour).Add(-2 * time.Hour)
+	newTS := prevTS.Add(time.Hour)
+	createSQL := "CREATE TABLE `audit_log` (\n  `id` INT NOT NULL,\n  `details` LONGTEXT,\n  PRIMARY KEY (`id`)\n);\n"
+	cols := []baseline.Column{
+		{Name: "id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
+		{Name: "details", MySQLType: "longtext", ParquetType: baseline.MysqlToParquetNode("longtext")},
+	}
+	// Both rows are NEW in this window — present only in the new baseline,
+	// exactly like a WordPress audit log's append-only inserts.
+	// id=1: same JSON content as its event, keys in a different order —
+	//       must resolve to a MATCH (the bug this test guards).
+	// id=2: GENUINELY different JSON content (known:true vs known:false) —
+	//       must still resolve to a MISMATCH (canonicalization must not mask
+	//       a real divergence).
+	writeTestBaseline(t, baseDir, prevTS, dbName, "audit_log", createSQL, cols, nil, "binlog.000001", 200)
+	writeTestBaseline(t, baseDir, newTS, dbName, "audit_log", createSQL, cols, [][]string{
+		{"1", `{"failed_login":{"imported":false,"username":"dbtrail-admin","known":true}}`},
+		{"2", `{"failed_login":{"imported":false,"username":"demo-bot","known":false}}`},
+	}, "binlog.000001", 300)
+
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{prevTS, newTS, now.Truncate(time.Hour)})
+	ets := prevTS.Add(30 * time.Minute).Format("2006-01-02 15:04:05")
+	// row_after embeds `details` as a NESTED JSON OBJECT (matching marshalRow's
+	// json.RawMessage promotion for any valid-JSON []byte, TEXT column or not).
+	// id=1: same logical value as the baseline, keys in a different order.
+	// id=2: a genuinely different "known" value — the baseline's "truth" wins,
+	//       so recovering this event's value must be reported as a mismatch.
+	testutil.InsertEvent(t, db, "binlog.000001", 200, 250, ets, nil, dbName, "audit_log", 1 /*INSERT*/, "1", nil,
+		nil, []byte(`{"id":1,"details":{"failed_login":{"imported":false,"username":"dbtrail-admin","known":true}}}`))
+	testutil.InsertEvent(t, db, "binlog.000001", 250, 300, ets, nil, dbName, "audit_log", 1 /*INSERT*/, "2", nil,
+		nil, []byte(`{"id":2,"details":{"failed_login":{"imported":false,"username":"demo-bot","known":true}}}`))
+
+	resolver, err := metadata.NewResolver(db, 1)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+	cfg := BaselineConfig{IndexDB: db, Resolver: resolver, IndexDBName: dbName, NoArchive: true}
+	ctx := context.Background()
+	pairs, _, _, err := FindBaselinePair(ctx, baseDir)
+	if err != nil || len(pairs) != 1 {
+		t.Fatalf("FindBaselinePair: %v (pairs=%d)", err, len(pairs))
+	}
+
+	got, err := VerifyBaselinePair(ctx, cfg, pairs[0])
+	if err != nil {
+		t.Fatalf("VerifyBaselinePair: %v", err)
+	}
+	if got.Status != StatusMismatch {
+		t.Fatalf("precondition: id=2's genuine divergence must make this a mismatch, got %q (%s)", got.Status, got.Detail)
+	}
+
+	ex, err := ExplainBaselinePairMismatch(ctx, cfg, pairs[0])
+	if err != nil {
+		t.Fatalf("ExplainBaselinePairMismatch: %v", err)
+	}
+
+	var id1Diff, id2Diff *RowDiff
+	for i := range ex.Diffs {
+		switch ex.Diffs[i].PK {
+		case "id=1":
+			id1Diff = &ex.Diffs[i]
+		case "id=2":
+			id2Diff = &ex.Diffs[i]
+		}
+	}
+
+	// id=1 (key-order-only difference) must NOT appear in the diff: the fix.
+	if id1Diff != nil {
+		t.Errorf("id=1 (same JSON, different key order) should not appear in diffs — canonicalization should have matched it, got: %+v", *id1Diff)
+	}
+
+	// id=2 (genuine content divergence) must still be reported, with the
+	// baseline's real "known":false winning over the event's "known":true —
+	// proving canonicalization compares CONTENT, not just "is it JSON".
+	if id2Diff == nil {
+		t.Fatalf("id=2 (genuine known:true vs known:false divergence) must appear in diffs")
+	}
+	if id2Diff.Kind != diffChanged || len(id2Diff.Cells) != 1 || id2Diff.Cells[0].Column != "details" {
+		t.Fatalf("id=2 diff = %+v, want exactly one changed 'details' cell", *id2Diff)
+	}
+	if !strings.Contains(id2Diff.Cells[0].Recovery, `"known":true`) || !strings.Contains(id2Diff.Cells[0].Baseline, `"known":false`) {
+		t.Errorf("id=2 details cell = %+v, want recovery to carry known:true and baseline known:false", id2Diff.Cells[0])
+	}
+}


### PR DESCRIPTION
## Summary

User-reported (live, `wp_aiowps_audit_log.details`): the console's Verify Explain modal showed 198 rows as mismatched where the "Recovered" and "Baseline (real)" JSON values were literally the same data, just with object keys in a different order.

**Root cause**: `dbt_aiowps_audit_log.details` is a `LONGTEXT` column (not MySQL's native `JSON` type — a very common WordPress-plugin pattern: `json_encode()`'d PHP data stored as text). The indexer's `marshalRow` promotes **any** valid-JSON `[]byte` to a nested JSON value in `binlog_events.row_after`, regardless of the column's declared SQL type. When verify decodes that event image, it lands in `map[string]any` (Go maps have no stable order); `renderCell`'s fallback case re-marshals it via `json.Marshal`, which **always sorts object keys alphabetically**. The baseline dump's text preserves the source's original key order verbatim. Two renderings of identical data compare byte-unequal.

Because the column is typed `text` (not `json`), it never got the existing ENUM/JSON/binary → inconclusive downgrade either (`isDeferredType` deliberately excludes TEXT per #672).

## Fix

`renderCellCanonicalJSON` (new, `render.go`) canonicalizes JSON object/array values before hashing/comparing. Applied **only** to the baseline-anchored comparison — both operands there are produced by this package, so canonicalizing them symmetrically can't introduce a new disagreement. Live-source verify (`VerifyTable`) keeps using plain `renderCell` unwrapped — its other operand is MySQL's own raw text via `ConsistentTableChecksum`, which this package doesn't control. **Known limitation, not fixed here**: live-source mode still has the same false-mismatch symptom for this exact column class — filed as #693.

A genuinely divergent JSON value still reports a real mismatch.

## Review found two real false-MATCH gaps — both fixed

This went through **two full rounds** of parallel specialized review (code-reviewer, silent-failure-hunter, pr-test-analyzer, comment-analyzer) given this touches the flagship correctness feature, where a false MATCH is far worse than the false MISMATCH being fixed.

**Round 1** caught a HIGH-severity gap: decoding a JSON object with a duplicate key (`{"a":1,"a":2}`) into `map[string]any` silently keeps only the last occurrence — naive canonicalization would make a baseline with a genuine duplicate key match an already-collapsed recon side, a false MATCH. Fixed: `canonicalizeJSONContainer` now refuses to canonicalize (falls back to raw-byte comparison) whenever a duplicate key or invalid UTF-8 is present, detected by walking the raw JSON token stream before any collapsing decode runs.

**Round 2** (re-reviewing that fix) caught a second, distinct false-MATCH vector: an unpaired `\uD800`–`\uDFFF` surrogate escape is valid JSON syntax **and** valid raw UTF-8 (it's just ASCII characters before unescaping), so it passed the existing `utf8.Valid` pre-check — the invalidity only appears after JSON unescaping, where Go substitutes U+FFFD, same collapse risk as raw invalid bytes. Fixed by refusing whenever the *canonical output* contains U+FFFD, not just checking the raw input. Round 2 also found two real integration-test gaps (empirically proven by reverting the fix and watching tests stay green): the flagship regression test's top-level status assertion was confounded by an unrelated genuine divergence in the same table, and there was no end-to-end test proving the duplicate-key guard's consequence survives through the real `VerifyBaselinePair` pipeline. Both closed with new isolated tests, each verified by temporarily reverting the fix and confirming the new test fails, then confirming it passes again at HEAD.

## Test plan
- [x] Original repro test run against the CURRENT code first to confirm it reproduced the bug — then updated to assert the fixed behavior
- [x] Unit tests for `canonicalizeJSONContainer`: key-order-only match, genuine-difference still differs, scalars/non-JSON untouched, large-number precision preserved, duplicate keys refused (top-level/same-value/nested/in-array/non-adjacent/escaped-key/array-of-arrays), invalid UTF-8 refused, unpaired surrogate refused
- [x] Integration tests through the real `VerifyBaselinePair`/`ExplainBaselinePairMismatch` pipeline: key-order match (isolated, no confound), genuine divergence still caught, duplicate-key baseline stays a correct mismatch
- [x] Empirically confirmed (not just reasoned about): reverted `verify_baseline.go`'s wiring alone → the new isolated test fails with the exact original bug's error message; restored → passes
- [x] Empirically confirmed MySQL's actual JSON-column duplicate-key behavior against a real MySQL instance before writing the duplicate-key integration test
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./internal/verify/...` (unit) and `go test -tags integration ./internal/verify/...` (integration, both baseline-anchored AND live-source paths) — all green
- [x] Full repo `go test ./...` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)