### PR TITLE
verify: fix dangling issue reference in zero-date comment

### DIFF
--- a/internal/verify/render.go
+++ b/internal/verify/render.go
@@ -329,7 +329,8 @@ func walkForDuplicateKeys(dec *json.Decoder) (bool, error) {
 //     manipulation, a replication gap) — which already breaks verify's
 //     guarantee for every column type, not something this normalization
 //     introduces. See TestVerifyBaselinePair_StaleZeroDateVsGenuineNull_AcceptedRisk
-//     for the concrete case this accepts, and #693 for the tracking issue.
+//     for the concrete case this accepts — a deliberate, reviewed trade-off,
+//     not open follow-up work.
 //
 // Used ONLY by the baseline-anchored comparison (VerifyBaselinePair,
 // ExplainBaselinePairMismatch): both operands there are produced by this


### PR DESCRIPTION
## Summary
- Tiny follow-up to #694: the accepted-risk comment on `renderCellBaselineAnchored` cited "#693" as its tracking issue, but #693 tracks a different, unrelated gap (live-source mode's own false-MISMATCH class). This trade-off isn't open follow-up work — it's a deliberate, reviewed decision pinned by `TestVerifyBaselinePair_StaleZeroDateVsGenuineNull_AcceptedRisk`, which is the actual tracking artifact.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/verify/...`
- Comment-only change, no behavior affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)