### PR TITLE
verify: extend JSON-key-order and zero-date normalization to live-source mode

### DIFF
--- a/internal/consistency/checksum.go
+++ b/internal/consistency/checksum.go
@@ -91,6 +91,38 @@ type TableChecksum struct {
 // Generated columns (VIRTUAL/STORED) are excluded: mydumper does not dump them,
 // so they are absent from the baseline Parquet and must be absent here too.
 func ConsistentTableChecksum(ctx context.Context, db *sql.DB, schema, table string) (TableChecksum, error) {
+	return consistentTableChecksum(ctx, db, schema, table, nil)
+}
+
+// ConsistentTableChecksumNormalized is ConsistentTableChecksum with an extra
+// per-column hook: normalize, when non-nil, rewrites a scanned column's raw
+// text-protocol bytes before it is folded into the digest.
+//
+// This exists so a caller comparing this digest against a digest computed by
+// a DIFFERENT renderer (internal/verify's reconstruct, in the live-source
+// verify path) can rewrite away known representation-only gaps between the
+// two — e.g. a MySQL zero-date sentinel the reconstruct side normalizes to
+// NULL, or a JSON-shaped TEXT value the reconstruct side re-serializes in
+// canonical key order — symmetrically on THIS side too, the same way
+// internal/verify's own renderCellNormalized does for its side. Applying the
+// SAME normalization asymmetrically (only one side) would trade one false
+// mismatch for a different one; this package intentionally does not import
+// internal/verify to decide what "normalized" means — the caller supplies
+// that policy as a closure, keeping this package's only knowledge of the
+// concept a raw-bytes-in, raw-bytes-out hook.
+//
+// normalize receives the column's information_schema.COLUMNS DATA_TYPE
+// (lower-case) and is never called for a genuine SQL NULL (nil raw bytes) —
+// there is nothing to rewrite. It is not called by ConsistentTableChecksum
+// (nil hook, unmodified behavior) — callers that persist this digest
+// independently of internal/verify (e.g. the baseline writer, #633) must not
+// normalize, since their digest is compared against ANOTHER raw, unnormalized
+// rendering of the same contract, not against a reconstruct digest.
+func ConsistentTableChecksumNormalized(ctx context.Context, db *sql.DB, schema, table string, normalize func(raw []byte, dataType string) []byte) (TableChecksum, error) {
+	return consistentTableChecksum(ctx, db, schema, table, normalize)
+}
+
+func consistentTableChecksum(ctx context.Context, db *sql.DB, schema, table string, normalize func(raw []byte, dataType string) []byte) (TableChecksum, error) {
 	res := TableChecksum{Schema: schema, Table: table}
 
 	conn, err := db.Conn(ctx)
@@ -162,9 +194,12 @@ func ConsistentTableChecksum(ctx context.Context, db *sql.DB, schema, table stri
 		}
 		for i := range dest {
 			// nil RawBytes is SQL NULL; a non-nil empty slice is an empty value.
-			if dest[i] == nil {
+			switch {
+			case dest[i] == nil:
 				values[i] = nil
-			} else {
+			case normalize != nil:
+				values[i] = normalize(dest[i], cols[i].dataType)
+			default:
 				values[i] = dest[i]
 			}
 		}

--- a/internal/consistency/checksum.go
+++ b/internal/consistency/checksum.go
@@ -194,6 +194,11 @@ func consistentTableChecksum(ctx context.Context, db *sql.DB, schema, table stri
 		}
 		for i := range dest {
 			// nil RawBytes is SQL NULL; a non-nil empty slice is an empty value.
+			// normalize (when it returns its input unchanged) and the
+			// fallthrough default both alias dest[i]'s backing buffer, which
+			// the driver reuses on the NEXT rows.Scan — safe only because
+			// hasher.add below runs synchronously and copies every byte
+			// before this loop iterates again. Do not defer or buffer this.
 			switch {
 			case dest[i] == nil:
 				values[i] = nil

--- a/internal/verify/explain_baseline.go
+++ b/internal/verify/explain_baseline.go
@@ -210,7 +210,7 @@ func ExplainBaselinePairMismatch(ctx context.Context, cfg BaselineConfig, p Base
 // streamRowsByPK reconstructs baselinePath+changes and invokes emit once per row
 // with its PK key (for joining) and canonical per-column bytes. It is the digest
 // row stream (reconstructDigest) re-pointed at a diff instead of a hash — using
-// the SAME renderCellBaselineAnchored reconstructDigest's baseline-anchored callers
+// the SAME renderCellNormalized reconstructDigest's baseline-anchored callers
 // use, so a row this drill-down shows as differing is exactly a row the digest
 // that flagged the mismatch also saw as differing (cellEqual's invariant).
 func streamRowsByPK(ctx context.Context, baselinePath, schema, table string, pkCols, orderedCols []metadata.ColumnMeta, changes map[string]*query.ResultRow, emit func(key string, r rowCells) error) error {
@@ -224,7 +224,7 @@ func streamRowsByPK(ctx context.Context, baselinePath, schema, table string, pkC
 		key, pk := pkKeyAndDisplay(rowMap, pkCols)
 		cells := make(map[string][]byte, len(orderedCols))
 		for _, c := range orderedCols {
-			cells[c.Name] = renderCellBaselineAnchored(rowMap[c.Name], c)
+			cells[c.Name] = renderCellNormalized(rowMap[c.Name], c)
 		}
 		return emit(key, rowCells{pk: pk, cells: cells})
 	})

--- a/internal/verify/render.go
+++ b/internal/verify/render.go
@@ -169,7 +169,7 @@ func isZeroDateSentinel(b []byte, col metadata.ColumnMeta) bool {
 // column typed as MySQL's native JSON already had a narrower version of this
 // same gap, covered by isDeferredType's inconclusive downgrade — this closes
 // it more precisely there too, resolving to a genuine match rather than
-// merely downgrading to "can't tell": see renderCellBaselineAnchored.
+// merely downgrading to "can't tell": see renderCellNormalized.
 //
 // UseNumber preserves large-integer/decimal literals exactly, the same
 // precision requirement renderCell's json.Number case already protects
@@ -299,10 +299,11 @@ func walkForDuplicateKeys(dec *json.Decoder) (bool, error) {
 	}
 }
 
-// renderCellBaselineAnchored renders a cell like renderCell, additionally
+// renderCellNormalized renders a cell like renderCell, additionally
 // normalizing two known representation gaps between an event-image value and
-// a baseline-Parquet value of the SAME underlying data, so a pure
-// representation difference doesn't register as a content difference:
+// the SAME underlying data rendered independently on the comparison's other
+// side, so a pure representation difference doesn't register as a content
+// difference:
 //
 //   - a JSON object/array value (see canonicalizeJSONContainer) — Go's
 //     map[string]any decode loses object key order, which renderCell's
@@ -312,41 +313,57 @@ func walkForDuplicateKeys(dec *json.Decoder) (bool, error) {
 //     '0000-00-00'-family pseudo-NULL to Parquet NULL, unconditionally, for
 //     EVERY zero-date value (Go's time parser rejects it outright). An
 //     event-touched row's image still carries the literal sentinel text, so
-//     recon renders the string while a same-valued baseline cell renders
-//     NULL. This mapping only runs one direction (string → nil): it does NOT
-//     touch a genuine NULL.
+//     recon renders the string while a same-valued baseline or live-source
+//     cell can render NULL. This mapping only runs one direction (string →
+//     nil): it does NOT touch a genuine NULL.
 //
-//     A baseline NULL for a temporal column is NOT provably zero-date-only —
-//     WriteRow also NULLs a temporal column for a genuine SQL NULL (the
-//     ordinary isNull path, checked before errZeroDate even runs), and that
-//     information is already indistinguishable at rest: both paths write the
-//     identical parquet.NullValue(). So this normalization is safe under
-//     verify's baseline assumption that the binlog captured every write to
-//     the row: if it did, recon's zero-date-text cell and the baseline's
-//     NULL cell are the same underlying value, whichever path produced the
-//     NULL. It stops being safe only if the source transitioned zero-date ->
-//     NULL through a write the binlog never saw (sql_log_bin=0, direct file
-//     manipulation, a replication gap) — which already breaks verify's
-//     guarantee for every column type, not something this normalization
-//     introduces. See TestVerifyBaselinePair_StaleZeroDateVsGenuineNull_AcceptedRisk
-//     for the concrete case this accepts — a deliberate, reviewed trade-off,
-//     not open follow-up work.
+//     A NULL for a temporal column is NOT provably zero-date-only — the
+//     writer that produced it (internal/baseline.Writer.WriteRow, or MySQL
+//     itself) also NULLs a temporal column for a genuine SQL NULL, and that
+//     information is already indistinguishable at rest. So this
+//     normalization is safe under verify's assumption that the binlog
+//     captured every write to the row: if it did, recon's zero-date-text
+//     cell and the other side's NULL cell are the same underlying value,
+//     whichever path produced the NULL. It stops being safe only if the
+//     source transitioned zero-date -> NULL through a write the binlog never
+//     saw (sql_log_bin=0, direct file manipulation, a replication gap) —
+//     which already breaks verify's guarantee for every column type, not
+//     something this normalization introduces. See
+//     TestVerifyBaselinePair_StaleZeroDateVsGenuineNull_AcceptedRisk for the
+//     concrete case this accepts — a deliberate, reviewed trade-off, not
+//     open follow-up work.
 //
-// Used ONLY by the baseline-anchored comparison (VerifyBaselinePair,
-// ExplainBaselinePairMismatch): both operands there are produced by this
-// same package, so normalizing them symmetrically cannot introduce a new
-// disagreement. The live-source comparison (VerifyTable) keeps using
-// renderCell unwrapped — its OTHER operand is MySQL's own raw text via
-// internal/consistency.ConsistentTableChecksum, which this package does not
-// control and does not normalize; wrapping only one side there would create
-// a new mismatch instead of fixing one (MySQL's live CAST(...AS CHAR) still
-// renders a zero-date as the literal sentinel text, same as an event image —
-// only the BASELINE side ever substitutes NULL).
-func renderCellBaselineAnchored(v any, col metadata.ColumnMeta) []byte {
-	b := renderCell(v, col)
+// Used by both verify comparisons, each pairing it with a same-package
+// renderer on the OTHER side so the normalization is applied symmetrically
+// (asymmetric application would trade one false mismatch for a different
+// one):
+//
+//   - baseline-anchored (VerifyBaselinePair, ExplainBaselinePairMismatch):
+//     both operands are produced by this package's own reconstructDigest, so
+//     wiring this renderer into both sides is sufficient.
+//   - live-source (VerifyTable): the other operand is MySQL's own raw text
+//     via internal/consistency.ConsistentTableChecksum, which this package
+//     does not render. VerifyTable pairs this renderer with
+//     ConsistentTableChecksumNormalized, passing normalizeRenderedBytes as
+//     that function's hook — the same normalization logic, applied to
+//     already-scanned bytes instead of a Go value, so both sides agree on
+//     what counts as a representation-only difference.
+func renderCellNormalized(v any, col metadata.ColumnMeta) []byte {
+	return normalizeRenderedBytes(renderCell(v, col), col.DataType)
+}
+
+// normalizeRenderedBytes applies renderCellNormalized's representation-gap
+// normalization directly to already-rendered bytes, for a context that
+// doesn't go through renderCell — internal/consistency.ConsistentTableChecksum's
+// raw MySQL scan (see ConsistentTableChecksumNormalized and its use in
+// VerifyTable). Both call sites must apply the identical logic for the two
+// sides of a comparison to be symmetric, so renderCellNormalized itself calls
+// this rather than duplicating the checks.
+func normalizeRenderedBytes(b []byte, dataType string) []byte {
 	if b == nil {
 		return nil
 	}
+	col := metadata.ColumnMeta{DataType: dataType}
 	if isZeroDateSentinel(b, col) {
 		return nil
 	}

--- a/internal/verify/render.go
+++ b/internal/verify/render.go
@@ -328,10 +328,16 @@ func walkForDuplicateKeys(dec *json.Decoder) (bool, error) {
 //     source transitioned zero-date -> NULL through a write the binlog never
 //     saw (sql_log_bin=0, direct file manipulation, a replication gap) —
 //     which already breaks verify's guarantee for every column type, not
-//     something this normalization introduces. See
-//     TestVerifyBaselinePair_StaleZeroDateVsGenuineNull_AcceptedRisk for the
-//     concrete case this accepts — a deliberate, reviewed trade-off, not
-//     open follow-up work.
+//     something this normalization introduces. This holds identically for
+//     both comparisons below — masking requires BOTH sides to already land
+//     in the {NULL, zero-date} equivalence class, regardless of which side
+//     is a baseline reconstruction and which is MySQL ground truth; live-
+//     source does not widen the risk, it just makes "the other side" MySQL
+//     itself instead of another baseline. See
+//     TestVerifyBaselinePair_StaleZeroDateVsGenuineNull_AcceptedRisk and its
+//     live-source sibling TestVerifyTable_StaleZeroDateVsGenuineNull_AcceptedRisk
+//     for the concrete case this accepts — a deliberate, reviewed trade-off,
+//     not open follow-up work.
 //
 // Used by both verify comparisons, each pairing it with a same-package
 // renderer on the OTHER side so the normalization is applied symmetrically

--- a/internal/verify/render_test.go
+++ b/internal/verify/render_test.go
@@ -89,14 +89,14 @@ func TestIsZeroDateSentinel_TemporalOnly(t *testing.T) {
 }
 
 func TestRenderCellBaselineAnchored_ZeroDateNormalizesToNull(t *testing.T) {
-	got := renderCellBaselineAnchored("0000-00-00 00:00:00", col("datetime", "datetime"))
+	got := renderCellNormalized("0000-00-00 00:00:00", col("datetime", "datetime"))
 	if got != nil {
-		t.Errorf("renderCellBaselineAnchored(zero-date, datetime col) = %q, want nil (NULL)", got)
+		t.Errorf("renderCellNormalized(zero-date, datetime col) = %q, want nil (NULL)", got)
 	}
 	// A real value for the same column type must render normally, untouched.
-	got2 := renderCellBaselineAnchored("2026-06-15 12:30:45", col("datetime", "datetime"))
+	got2 := renderCellNormalized("2026-06-15 12:30:45", col("datetime", "datetime"))
 	if string(got2) != "2026-06-15 12:30:45" {
-		t.Errorf("renderCellBaselineAnchored(real date) = %q, want the value unchanged", got2)
+		t.Errorf("renderCellNormalized(real date) = %q, want the value unchanged", got2)
 	}
 }
 
@@ -244,8 +244,8 @@ func TestCanonicalizeJSONContainer_UnpairedSurrogateRefused(t *testing.T) {
 }
 
 func TestRenderCellCanonicalJSON_NullPassesThrough(t *testing.T) {
-	if got := renderCellBaselineAnchored(nil, col("json", "json")); got != nil {
-		t.Errorf("renderCellBaselineAnchored(nil, ...) = %q, want nil (SQL NULL)", got)
+	if got := renderCellNormalized(nil, col("json", "json")); got != nil {
+		t.Errorf("renderCellNormalized(nil, ...) = %q, want nil (SQL NULL)", got)
 	}
 }
 

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -93,8 +93,12 @@ func VerifyTable(ctx context.Context, cfg Config, schema, table string) (TableRe
 		}
 	}
 
-	// 1. Live source fingerprint at a consistent snapshot.
-	src, err := consistency.ConsistentTableChecksum(ctx, cfg.SourceDB, schema, table)
+	// 1. Live source fingerprint at a consistent snapshot. Normalized (see
+	// renderCellNormalized) so it stays symmetric with step 5's reconstruct
+	// digest: both sides must agree on what counts as a representation-only
+	// difference, or normalizing only one would trade one false mismatch for
+	// another.
+	src, err := consistency.ConsistentTableChecksumNormalized(ctx, cfg.SourceDB, schema, table, normalizeRenderedBytes)
 	if err != nil {
 		return res, fmt.Errorf("source checksum %s.%s: %w", schema, table, err)
 	}
@@ -183,7 +187,7 @@ func VerifyTable(ctx context.Context, cfg Config, schema, table string) (TableRe
 	// masked by this.
 	deferredRepr := hasDeferredRepr(orderedCols) && len(changes) > 0
 
-	reconDigest, reconCount, emitErr := reconstructDigest(ctx, baselinePath, schema, table, pkCols, changes, orderedCols, renderCell)
+	reconDigest, reconCount, emitErr := reconstructDigest(ctx, baselinePath, schema, table, pkCols, changes, orderedCols, renderCellNormalized)
 	if emitErr != nil {
 		return res, fmt.Errorf("reconstruct %s.%s: %w", schema, table, emitErr)
 	}
@@ -225,11 +229,12 @@ func classify(srcDigest string, srcRows int64, reconDigest string, reconRows int
 // reconstructDigest reconstructs a table from baselinePath merged with changes,
 // renders each row's columns (in orderedCols order) via render, and returns the
 // order-independent content digest + row count. Shared by the live-source
-// verify (VerifyTable, which passes plain renderCell) and the baseline-pair
-// verify (#642, which passes renderCellBaselineAnchored — see its doc comment for
-// why that canonicalization is safe only there): both sides of any one
-// comparison must be produced with the SAME render func so the digests are
-// byte-comparable by construction.
+// verify (VerifyTable) and the baseline-pair verify (#642) — both now pass
+// renderCellNormalized (see its doc comment for why the normalization it
+// applies is safe, and how each caller keeps it symmetric with the OTHER
+// side of its own comparison): both sides of any one comparison must be
+// produced with the SAME render func so the digests are byte-comparable by
+// construction.
 func reconstructDigest(ctx context.Context, baselinePath, schema, table string, pkCols []metadata.ColumnMeta, changes map[string]*query.ResultRow, orderedCols []metadata.ColumnMeta, render func(any, metadata.ColumnMeta) []byte) (string, int64, error) {
 	hasher := consistency.NewHasher()
 	err := reconstruct.SnapshotFullTableImages(ctx, reconstruct.SnapshotFullTableInput{

--- a/internal/verify/verify_baseline.go
+++ b/internal/verify/verify_baseline.go
@@ -143,17 +143,17 @@ func VerifyBaselinePair(ctx context.Context, cfg BaselineConfig, p BaselinePair)
 	}
 
 	// Recovery side: reconstruct the previous baseline forward to the anchor.
-	// renderCellBaselineAnchored (not plain renderCell): both operands here come
+	// renderCellNormalized (not plain renderCell): both operands here come
 	// from this package, so canonicalizing a JSON object/array value the SAME
 	// way on both sides closes the false-mismatch gap a TEXT/JSON column's
 	// event-image round-trip can otherwise open (see its doc comment) without
 	// risking the live-source comparison, which this function is not used for.
-	reconDigest, reconCount, err := reconstructDigest(ctx, p.PrevPath, p.Schema, p.Table, pkCols, changes, orderedCols, renderCellBaselineAnchored)
+	reconDigest, reconCount, err := reconstructDigest(ctx, p.PrevPath, p.Schema, p.Table, pkCols, changes, orderedCols, renderCellNormalized)
 	if err != nil {
 		return res, fmt.Errorf("reconstruct prev %s.%s: %w", p.Schema, p.Table, err)
 	}
 	// Truth side: the new baseline as-is (no events), via the same path.
-	newDigest, newCount, err := reconstructDigest(ctx, p.NewPath, p.Schema, p.Table, pkCols, map[string]*query.ResultRow{}, orderedCols, renderCellBaselineAnchored)
+	newDigest, newCount, err := reconstructDigest(ctx, p.NewPath, p.Schema, p.Table, pkCols, map[string]*query.ResultRow{}, orderedCols, renderCellNormalized)
 	if err != nil {
 		return res, fmt.Errorf("read new baseline %s.%s: %w", p.Schema, p.Table, err)
 	}

--- a/internal/verify/verify_baseline_integration_test.go
+++ b/internal/verify/verify_baseline_integration_test.go
@@ -859,7 +859,7 @@ func TestVerifyBaselinePair_TextOnlyChange_Match(t *testing.T) {
 // inconclusive downgrade either — two byte-different renderings of identical
 // data reported a hard MISMATCH.
 //
-// Fixed by renderCellBaselineAnchored: the baseline-anchored comparison
+// Fixed by renderCellNormalized: the baseline-anchored comparison
 // canonicalizes JSON object/array values on BOTH sides, so this now reports a
 // genuine StatusMatch — not merely "inconclusive". id=2 in the same table
 // proves the fix isn't a blanket "ignore JSON columns" — a GENUINE content
@@ -973,7 +973,7 @@ func TestVerifyBaselinePair_JSONValuedTextColumn_KeyOrderIsAMatch(t *testing.T) 
 }
 
 // TestVerifyBaselinePair_JSONValuedTextColumn_Isolated_Match isolates
-// VerifyBaselinePair's OWN digest wiring (the two renderCellBaselineAnchored
+// VerifyBaselinePair's OWN digest wiring (the two renderCellNormalized
 // calls in verify_baseline.go) for the JSON-key-order fix — the same way
 // TestVerifyBaselinePair_TextOnlyChange_Match isolates the sibling #672
 // TEXT-decode fix.
@@ -1158,7 +1158,7 @@ func TestVerifyBaselinePair_DuplicateJSONKey_StaysMismatch(t *testing.T) {
 // zero-date value — reported a hard mismatch.
 //
 // This table has nothing else that could cause a mismatch: if
-// renderCellBaselineAnchored's isZeroDateSentinel normalization weren't
+// renderCellNormalized's isZeroDateSentinel normalization weren't
 // wired into VerifyBaselinePair's own digest, this test — not just an
 // Explain drill-down — would report StatusMismatch.
 func TestVerifyBaselinePair_ZeroDateSentinel_IsAMatch(t *testing.T) {

--- a/internal/verify/verify_integration_test.go
+++ b/internal/verify/verify_integration_test.go
@@ -566,3 +566,213 @@ func TestVerifyTable_ZeroDateVsRealNull_StaysMismatch(t *testing.T) {
 		t.Fatalf("status = %q (%s); want mismatch — a real live value diverging from a zero-date-derived baseline NULL must not be swallowed by the zero-date equivalence", got.Status, got.Detail)
 	}
 }
+
+// TestVerifyTable_DuplicateJSONKey_StaysMismatch is the live-source
+// counterpart of TestVerifyBaselinePair_DuplicateJSONKey_StaysMismatch: the
+// duplicate-JSON-key guard (canonicalizeJSONContainer's hasDuplicateObjectKeys
+// bail, see internal/verify/render.go) must survive through the NEW raw-bytes
+// code path this PR adds (ConsistentTableChecksumNormalized's hook), not just
+// the Go-value path (renderCellNormalized) the baseline-anchored test already
+// covers.
+//
+// A duplicate key can only survive verbatim on the LIVE side: it's a plain
+// string in a TEXT column, which MySQL does not validate/normalize as JSON.
+// It cannot survive in an event's row_after — row_after is itself a MySQL
+// JSON-typed column in bintrail's own index schema, and MySQL collapses a
+// duplicate key to last-value-wins AT INSERT TIME, before any Go code runs
+// (same reasoning, confirmed empirically, as the baseline-anchored sibling
+// test). So the event below is written pre-collapsed (single key), matching
+// what indexing a real duplicate-keyed write would actually produce — which
+// is genuinely, unavoidably different from the live source's duplicate-keyed
+// TEXT value.
+func TestVerifyTable_DuplicateJSONKey_StaysMismatch(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	for _, c := range []struct {
+		name, key, dt, colType string
+		ord                    int
+	}{
+		{"id", "PRI", "int", "int", 1},
+		{"details", "", "text", "longtext", 2},
+	} {
+		testutil.MustExec(t, db, `INSERT INTO schema_snapshots
+			(snapshot_id, snapshot_time, schema_name, table_name, column_name,
+			 ordinal_position, column_key, data_type, column_type, is_nullable, is_generated)
+			VALUES (1, UTC_TIMESTAMP(), ?, 'audit_log', ?, ?, ?, ?, ?, 'YES', 0)`,
+			dbName, c.name, c.ord, c.key, c.dt, c.colType)
+	}
+
+	// ── live SOURCE table: a GENUINE duplicate key, verbatim TEXT ──
+	testutil.MustExec(t, db, fmt.Sprintf(
+		"CREATE TABLE `%s`.`audit_log` (`id` INT PRIMARY KEY, `details` LONGTEXT)", dbName))
+	testutil.MustExec(t, db, fmt.Sprintf(
+		`INSERT INTO `+"`%s`.`audit_log`"+` (id,details) VALUES (1,'{"a":1,"a":2}')`, dbName))
+
+	// ── baseline Parquet: placeholder, since the row is event-touched ──
+	createSQL := "CREATE TABLE `audit_log` (\n  `id` INT NOT NULL,\n  `details` LONGTEXT,\n  PRIMARY KEY (`id`)\n);\n"
+	baselineDir := t.TempDir()
+	now := time.Now().UTC()
+	curHour := now.Truncate(time.Hour)
+	h1 := curHour.Add(-time.Hour)
+	h2 := curHour
+	tsDir := strings.ReplaceAll(h1.Format(time.RFC3339), ":", "-")
+	parquetDir := filepath.Join(baselineDir, tsDir, dbName)
+	if err := os.MkdirAll(parquetDir, 0o755); err != nil {
+		t.Fatalf("mkdir baseline: %v", err)
+	}
+	cols := []baseline.Column{
+		{Name: "id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
+		{Name: "details", MySQLType: "longtext", ParquetType: baseline.MysqlToParquetNode("longtext")},
+	}
+	bw, err := baseline.NewWriter(filepath.Join(parquetDir, "audit_log.parquet"), cols,
+		baseline.WriterConfig{Compression: "zstd", RowGroupSize: 100,
+			Metadata: map[string]string{baseline.MetaKeyCreateTableSQL: createSQL}})
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	if err := bw.WriteRow([]string{"1", `{"placeholder":true}`}, []bool{false, false}); err != nil {
+		t.Fatalf("WriteRow: %v", err)
+	}
+	if err := bw.Close(); err != nil {
+		t.Fatalf("baseline close: %v", err)
+	}
+
+	// ── binlog event: row_after is pre-collapsed, as MySQL's own JSON column
+	// would store it, regardless of what bytes were sent ──
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{h1, h2})
+	ts := now.Add(-1 * time.Minute).Format("2006-01-02 15:04:05")
+	testutil.InsertEvent(t, db, "binlog.000001", 100, 200, ts, nil, dbName, "audit_log", 2 /*UPDATE*/, "1", []byte(`["details"]`),
+		[]byte(`{"id":1,"details":{"placeholder":true}}`),
+		[]byte(`{"id":1,"details":{"a":2}}`))
+
+	var uuid string
+	if err := db.QueryRow("SELECT @@server_uuid").Scan(&uuid); err != nil {
+		t.Fatalf("server_uuid: %v", err)
+	}
+	testutil.MustExec(t, db, `INSERT INTO stream_state
+		(id, mode, gtid_set, last_checkpoint, server_id)
+		VALUES (1, 'gtid', ?, UTC_TIMESTAMP(), 1)`, uuid+":1-1000000")
+
+	resolver, err := metadata.NewResolver(db, 1)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+	cfg := Config{
+		SourceDB: db, IndexDB: db, Resolver: resolver,
+		BaselineSource: baselineDir, IndexDBName: dbName, NoArchive: true,
+	}
+
+	got, err := VerifyTable(context.Background(), cfg, dbName, "audit_log")
+	if err != nil {
+		t.Fatalf("VerifyTable: %v", err)
+	}
+	if got.Status != StatusMismatch {
+		t.Fatalf("status = %q (%s); want mismatch — a live source with a genuine duplicate JSON key must never silently match an already-collapsed recovered value", got.Status, got.Detail)
+	}
+}
+
+// TestVerifyTable_StaleZeroDateVsGenuineNull_AcceptedRisk is the live-source
+// counterpart of TestVerifyBaselinePair_StaleZeroDateVsGenuineNull_AcceptedRisk,
+// pinning the SAME accepted trade-off (see renderCellNormalized's doc
+// comment) through this path too: the live source is genuinely NULL for a
+// reason unrelated to zero-dates; the only in-window event faithfully
+// captured a real write that set the column to the zero-date sentinel, and
+// nothing later in the binlog moved this PK past it. This can only happen if
+// the source transitioned zero-date -> NULL via a write the binlog never saw
+// — which already breaks verify's guarantee for every column type in every
+// mode, not something this normalization introduces or widens for
+// live-source specifically.
+func TestVerifyTable_StaleZeroDateVsGenuineNull_AcceptedRisk(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	for _, c := range []struct {
+		name, key, dt, colType string
+		ord                    int
+	}{
+		{"action_id", "PRI", "int", "int", 1},
+		{"last_attempt_gmt", "", "datetime", "datetime", 2},
+	} {
+		testutil.MustExec(t, db, `INSERT INTO schema_snapshots
+			(snapshot_id, snapshot_time, schema_name, table_name, column_name,
+			 ordinal_position, column_key, data_type, column_type, is_nullable, is_generated)
+			VALUES (1, UTC_TIMESTAMP(), ?, 'actionscheduler_actions', ?, ?, ?, ?, ?, 'YES', 0)`,
+			dbName, c.name, c.ord, c.key, c.dt, c.colType)
+	}
+
+	// ── live SOURCE table: a GENUINE NULL, unrelated to zero-dates — the
+	// "reset out-of-band, binlog never saw it" state ──
+	testutil.MustExec(t, db, fmt.Sprintf(
+		"CREATE TABLE `%s`.`actionscheduler_actions` (`action_id` INT PRIMARY KEY, `last_attempt_gmt` DATETIME)", dbName))
+	testutil.MustExec(t, db, fmt.Sprintf(
+		"INSERT INTO `%s`.`actionscheduler_actions` (action_id,last_attempt_gmt) VALUES (577,NULL)", dbName))
+
+	// ── baseline Parquet: an ordinary, unrelated value — the in-window event
+	// below is what recon actually reflects for this PK, not this row ──
+	createSQL := "CREATE TABLE `actionscheduler_actions` (\n  `action_id` INT NOT NULL,\n  `last_attempt_gmt` DATETIME,\n  PRIMARY KEY (`action_id`)\n);\n"
+	baselineDir := t.TempDir()
+	now := time.Now().UTC()
+	curHour := now.Truncate(time.Hour)
+	h1 := curHour.Add(-time.Hour)
+	h2 := curHour
+	tsDir := strings.ReplaceAll(h1.Format(time.RFC3339), ":", "-")
+	parquetDir := filepath.Join(baselineDir, tsDir, dbName)
+	if err := os.MkdirAll(parquetDir, 0o755); err != nil {
+		t.Fatalf("mkdir baseline: %v", err)
+	}
+	cols := []baseline.Column{
+		{Name: "action_id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
+		{Name: "last_attempt_gmt", MySQLType: "datetime", ParquetType: baseline.MysqlToParquetNode("datetime")},
+	}
+	bw, err := baseline.NewWriter(filepath.Join(parquetDir, "actionscheduler_actions.parquet"), cols,
+		baseline.WriterConfig{Compression: "zstd", RowGroupSize: 100,
+			Metadata: map[string]string{baseline.MetaKeyCreateTableSQL: createSQL}})
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	if err := bw.WriteRow([]string{"577", "2026-05-01 00:00:00"}, []bool{false, false}); err != nil {
+		t.Fatalf("WriteRow: %v", err)
+	}
+	if err := bw.Close(); err != nil {
+		t.Fatalf("baseline close: %v", err)
+	}
+
+	// ── the only in-window event for this PK: a real, faithfully-captured
+	// write setting the column to the zero-date sentinel. Nothing later in
+	// the binlog moves this PK past it ──
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{h1, h2})
+	ts := now.Add(-1 * time.Minute).Format("2006-01-02 15:04:05")
+	testutil.InsertEvent(t, db, "binlog.000001", 100, 200, ts, nil, dbName, "actionscheduler_actions", 2 /*UPDATE*/, "577", []byte(`["last_attempt_gmt"]`),
+		[]byte(`{"action_id":577,"last_attempt_gmt":"2026-05-01 00:00:00"}`),
+		[]byte(`{"action_id":577,"last_attempt_gmt":"0000-00-00 00:00:00"}`))
+
+	var uuid string
+	if err := db.QueryRow("SELECT @@server_uuid").Scan(&uuid); err != nil {
+		t.Fatalf("server_uuid: %v", err)
+	}
+	testutil.MustExec(t, db, `INSERT INTO stream_state
+		(id, mode, gtid_set, last_checkpoint, server_id)
+		VALUES (1, 'gtid', ?, UTC_TIMESTAMP(), 1)`, uuid+":1-1000000")
+
+	resolver, err := metadata.NewResolver(db, 1)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+	cfg := Config{
+		SourceDB: db, IndexDB: db, Resolver: resolver,
+		BaselineSource: baselineDir, IndexDBName: dbName, NoArchive: true,
+	}
+
+	got, err := VerifyTable(context.Background(), cfg, dbName, "actionscheduler_actions")
+	if err != nil {
+		t.Fatalf("VerifyTable: %v", err)
+	}
+	if got.Status != StatusMatch {
+		t.Fatalf("status = %q (%s); this test pins the accepted-risk behavior — if this now fails, the zero-date normalization's blast radius changed and this comment/test pair needs re-evaluating, not just updating the assertion", got.Status, got.Detail)
+	}
+}

--- a/internal/verify/verify_integration_test.go
+++ b/internal/verify/verify_integration_test.go
@@ -4,6 +4,7 @@ package verify
 
 import (
 	"context"
+	"database/sql"
 	"encoding/base64"
 	"fmt"
 	"os"
@@ -253,5 +254,315 @@ func TestVerifyTable_TextEventDecoded(t *testing.T) {
 	}
 	if got.Status != StatusMatch {
 		t.Fatalf("status = %q (%s); want match (TEXT body should decode to \"updated text\", matching the live source)", got.Status, got.Detail)
+	}
+}
+
+// mustExecOnPinnedConn runs query on a single pinned connection, so a session
+// variable set beforehand (e.g. sql_mode) is guaranteed to apply to it — a
+// plain *sql.DB.Exec call may be routed to a different pooled connection than
+// whatever SET SESSION ran on. The connection is released back to the pool
+// afterward; nothing about the effect being tested (a value already stored in
+// a table) depends on which connection reads it back later.
+func mustExecOnPinnedConn(t *testing.T, db *sql.DB, stmts ...string) {
+	t.Helper()
+	conn, err := db.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("pin connection: %v", err)
+	}
+	defer conn.Close()
+	for _, s := range stmts {
+		if _, err := conn.ExecContext(context.Background(), s); err != nil {
+			t.Fatalf("exec %q: %v", s, err)
+		}
+	}
+}
+
+// TestVerifyTable_JSONValuedTextColumn_KeyOrderIsAMatch is the live-source
+// counterpart of TestVerifyBaselinePair_JSONValuedTextColumn_Isolated_Match —
+// #693's live-source half of the JSON-key-order false MISMATCH. The live
+// source's TEXT column holds JSON text in a non-alphabetical key order (MySQL
+// stores TEXT verbatim, preserving whatever order it was written in); the
+// reconstructed side decodes the event image through Go's map[string]any and
+// re-serializes it alphabetically. Without ConsistentTableChecksumNormalized
+// wired into VerifyTable's source-side digest, these compare byte-unequal
+// despite being the same JSON content — this table's only row has nothing
+// else that could cause a mismatch.
+func TestVerifyTable_JSONValuedTextColumn_KeyOrderIsAMatch(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	for _, c := range []struct {
+		name, key, dt, colType string
+		ord                    int
+	}{
+		{"id", "PRI", "int", "int", 1},
+		{"details", "", "text", "longtext", 2},
+	} {
+		testutil.MustExec(t, db, `INSERT INTO schema_snapshots
+			(snapshot_id, snapshot_time, schema_name, table_name, column_name,
+			 ordinal_position, column_key, data_type, column_type, is_nullable, is_generated)
+			VALUES (1, UTC_TIMESTAMP(), ?, 'audit_log', ?, ?, ?, ?, ?, 'YES', 0)`,
+			dbName, c.name, c.ord, c.key, c.dt, c.colType)
+	}
+
+	// ── live SOURCE table: non-alphabetical key order, verbatim MySQL text ──
+	testutil.MustExec(t, db, fmt.Sprintf(
+		"CREATE TABLE `%s`.`audit_log` (`id` INT PRIMARY KEY, `details` LONGTEXT)", dbName))
+	testutil.MustExec(t, db, fmt.Sprintf(
+		`INSERT INTO `+"`%s`.`audit_log`"+` (id,details) VALUES (1,'{"c":3,"a":1,"b":2}')`, dbName))
+
+	// ── baseline Parquet holding the same logical value ──
+	createSQL := "CREATE TABLE `audit_log` (\n  `id` INT NOT NULL,\n  `details` LONGTEXT,\n  PRIMARY KEY (`id`)\n);\n"
+	baselineDir := t.TempDir()
+	now := time.Now().UTC()
+	curHour := now.Truncate(time.Hour)
+	h1 := curHour.Add(-time.Hour)
+	h2 := curHour
+	tsDir := strings.ReplaceAll(h1.Format(time.RFC3339), ":", "-")
+	parquetDir := filepath.Join(baselineDir, tsDir, dbName)
+	if err := os.MkdirAll(parquetDir, 0o755); err != nil {
+		t.Fatalf("mkdir baseline: %v", err)
+	}
+	cols := []baseline.Column{
+		{Name: "id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
+		{Name: "details", MySQLType: "longtext", ParquetType: baseline.MysqlToParquetNode("longtext")},
+	}
+	bw, err := baseline.NewWriter(filepath.Join(parquetDir, "audit_log.parquet"), cols,
+		baseline.WriterConfig{Compression: "zstd", RowGroupSize: 100,
+			Metadata: map[string]string{baseline.MetaKeyCreateTableSQL: createSQL}})
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	if err := bw.WriteRow([]string{"1", `{"c":3,"a":1,"b":2}`}, []bool{false, false}); err != nil {
+		t.Fatalf("WriteRow: %v", err)
+	}
+	if err := bw.Close(); err != nil {
+		t.Fatalf("baseline close: %v", err)
+	}
+
+	// ── binlog event: an UPDATE touches details with the SAME logical value,
+	// embedded as a nested JSON object (matching marshalRow's promotion) ──
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{h1, h2})
+	ts := now.Add(-1 * time.Minute).Format("2006-01-02 15:04:05")
+	testutil.InsertEvent(t, db, "binlog.000001", 100, 200, ts, nil, dbName, "audit_log", 2 /*UPDATE*/, "1", []byte(`["details"]`),
+		[]byte(`{"id":1,"details":{"c":3,"a":1,"b":2}}`),
+		[]byte(`{"id":1,"details":{"c":3,"a":1,"b":2}}`))
+
+	var uuid string
+	if err := db.QueryRow("SELECT @@server_uuid").Scan(&uuid); err != nil {
+		t.Fatalf("server_uuid: %v", err)
+	}
+	testutil.MustExec(t, db, `INSERT INTO stream_state
+		(id, mode, gtid_set, last_checkpoint, server_id)
+		VALUES (1, 'gtid', ?, UTC_TIMESTAMP(), 1)`, uuid+":1-1000000")
+
+	resolver, err := metadata.NewResolver(db, 1)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+	cfg := Config{
+		SourceDB: db, IndexDB: db, Resolver: resolver,
+		BaselineSource: baselineDir, IndexDBName: dbName, NoArchive: true,
+	}
+
+	got, err := VerifyTable(context.Background(), cfg, dbName, "audit_log")
+	if err != nil {
+		t.Fatalf("VerifyTable: %v", err)
+	}
+	if got.Status != StatusMatch {
+		t.Fatalf("status = %q (%s); want match — same JSON content in a different key order is a representation-only difference, not a real divergence\n  source=%s recon=%s",
+			got.Status, got.Detail, got.SourceDigest, got.ReconstructDigest)
+	}
+}
+
+// TestVerifyTable_ZeroDateSentinel_IsAMatch is the live-source counterpart of
+// TestVerifyBaselinePair_ZeroDateSentinel_IsAMatch — #693's live-source half
+// of the zero-date-vs-NULL false MISMATCH. The live source genuinely holds
+// the zero-date sentinel right now (sql_mode relaxed for the one INSERT below,
+// mirroring how a legacy/non-strict production database ends up with one in
+// the first place); the row is never touched by any binlog event, so the
+// reconstructed side reads the baseline Parquet passthrough, where
+// internal/baseline.Writer.WriteRow already substituted NULL for the same
+// zero-date value at dump time. Without ConsistentTableChecksumNormalized
+// wired into VerifyTable's source-side digest, MySQL's live CAST(...AS CHAR)
+// still renders the literal sentinel text, so this compares byte-unequal
+// against the baseline's NULL despite being the same underlying value.
+func TestVerifyTable_ZeroDateSentinel_IsAMatch(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	for _, c := range []struct {
+		name, key, dt, colType string
+		ord                    int
+	}{
+		{"action_id", "PRI", "int", "int", 1},
+		{"last_attempt_gmt", "", "datetime", "datetime", 2},
+	} {
+		testutil.MustExec(t, db, `INSERT INTO schema_snapshots
+			(snapshot_id, snapshot_time, schema_name, table_name, column_name,
+			 ordinal_position, column_key, data_type, column_type, is_nullable, is_generated)
+			VALUES (1, UTC_TIMESTAMP(), ?, 'actionscheduler_actions', ?, ?, ?, ?, ?, 'YES', 0)`,
+			dbName, c.name, c.ord, c.key, c.dt, c.colType)
+	}
+
+	// ── live SOURCE table: genuinely holds the zero-date sentinel right now ──
+	testutil.MustExec(t, db, fmt.Sprintf(
+		"CREATE TABLE `%s`.`actionscheduler_actions` (`action_id` INT PRIMARY KEY, `last_attempt_gmt` DATETIME)", dbName))
+	mustExecOnPinnedConn(t, db,
+		"SET SESSION sql_mode=''",
+		fmt.Sprintf("INSERT INTO `%s`.`actionscheduler_actions` (action_id,last_attempt_gmt) VALUES (577,'0000-00-00 00:00:00')", dbName))
+
+	// ── baseline Parquet: WriteRow substitutes the same zero-date to NULL ──
+	createSQL := "CREATE TABLE `actionscheduler_actions` (\n  `action_id` INT NOT NULL,\n  `last_attempt_gmt` DATETIME,\n  PRIMARY KEY (`action_id`)\n);\n"
+	baselineDir := t.TempDir()
+	now := time.Now().UTC()
+	curHour := now.Truncate(time.Hour)
+	h1 := curHour.Add(-time.Hour)
+	tsDir := strings.ReplaceAll(h1.Format(time.RFC3339), ":", "-")
+	parquetDir := filepath.Join(baselineDir, tsDir, dbName)
+	if err := os.MkdirAll(parquetDir, 0o755); err != nil {
+		t.Fatalf("mkdir baseline: %v", err)
+	}
+	cols := []baseline.Column{
+		{Name: "action_id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
+		{Name: "last_attempt_gmt", MySQLType: "datetime", ParquetType: baseline.MysqlToParquetNode("datetime")},
+	}
+	bw, err := baseline.NewWriter(filepath.Join(parquetDir, "actionscheduler_actions.parquet"), cols,
+		baseline.WriterConfig{Compression: "zstd", RowGroupSize: 100,
+			Metadata: map[string]string{baseline.MetaKeyCreateTableSQL: createSQL}})
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	if err := bw.WriteRow([]string{"577", "0000-00-00 00:00:00"}, []bool{false, false}); err != nil {
+		t.Fatalf("WriteRow: %v", err)
+	}
+	if err := bw.Close(); err != nil {
+		t.Fatalf("baseline close: %v", err)
+	}
+
+	// ── no binlog event touches this PK: recon is a pure baseline passthrough ──
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{h1, curHour})
+
+	var uuid string
+	if err := db.QueryRow("SELECT @@server_uuid").Scan(&uuid); err != nil {
+		t.Fatalf("server_uuid: %v", err)
+	}
+	testutil.MustExec(t, db, `INSERT INTO stream_state
+		(id, mode, gtid_set, last_checkpoint, server_id)
+		VALUES (1, 'gtid', ?, UTC_TIMESTAMP(), 1)`, uuid+":1-1000000")
+
+	resolver, err := metadata.NewResolver(db, 1)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+	cfg := Config{
+		SourceDB: db, IndexDB: db, Resolver: resolver,
+		BaselineSource: baselineDir, IndexDBName: dbName, NoArchive: true,
+	}
+
+	got, err := VerifyTable(context.Background(), cfg, dbName, "actionscheduler_actions")
+	if err != nil {
+		t.Fatalf("VerifyTable: %v", err)
+	}
+	if got.Status != StatusMatch {
+		t.Fatalf("status = %q (%s); want match — the live zero-date sentinel and the baseline's zero-date-substituted NULL are the same underlying value\n  source=%s recon=%s",
+			got.Status, got.Detail, got.SourceDigest, got.ReconstructDigest)
+	}
+}
+
+// TestVerifyTable_ZeroDateVsRealNull_StaysMismatch is the live-source
+// counterpart of TestVerifyBaselinePair_ZeroDateVsRealNull_StaysMismatch:
+// proves the zero-date normalization stays narrowly scoped through the
+// live-source path too. The live source holds a REAL, non-zero-date value;
+// the reconstructed side is NULL from the SAME zero-date substitution the
+// sibling match test above exercises (nothing in the window corrects it).
+// isZeroDateSentinel must only match the exact sentinel text, not "any real
+// value when the other side happens to be NULL" — a genuine divergence must
+// not be swallowed by the normalization meant to fix a representation
+// artifact.
+func TestVerifyTable_ZeroDateVsRealNull_StaysMismatch(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	for _, c := range []struct {
+		name, key, dt, colType string
+		ord                    int
+	}{
+		{"action_id", "PRI", "int", "int", 1},
+		{"last_attempt_gmt", "", "datetime", "datetime", 2},
+	} {
+		testutil.MustExec(t, db, `INSERT INTO schema_snapshots
+			(snapshot_id, snapshot_time, schema_name, table_name, column_name,
+			 ordinal_position, column_key, data_type, column_type, is_nullable, is_generated)
+			VALUES (1, UTC_TIMESTAMP(), ?, 'actionscheduler_actions', ?, ?, ?, ?, ?, 'YES', 0)`,
+			dbName, c.name, c.ord, c.key, c.dt, c.colType)
+	}
+
+	// ── live SOURCE table: a REAL, non-zero-date value ──
+	testutil.MustExec(t, db, fmt.Sprintf(
+		"CREATE TABLE `%s`.`actionscheduler_actions` (`action_id` INT PRIMARY KEY, `last_attempt_gmt` DATETIME)", dbName))
+	testutil.MustExec(t, db, fmt.Sprintf(
+		"INSERT INTO `%s`.`actionscheduler_actions` (action_id,last_attempt_gmt) VALUES (577,'2026-06-15 12:30:45')", dbName))
+
+	// ── baseline Parquet: zero-date at dump time, substituted to NULL ──
+	createSQL := "CREATE TABLE `actionscheduler_actions` (\n  `action_id` INT NOT NULL,\n  `last_attempt_gmt` DATETIME,\n  PRIMARY KEY (`action_id`)\n);\n"
+	baselineDir := t.TempDir()
+	now := time.Now().UTC()
+	curHour := now.Truncate(time.Hour)
+	h1 := curHour.Add(-time.Hour)
+	tsDir := strings.ReplaceAll(h1.Format(time.RFC3339), ":", "-")
+	parquetDir := filepath.Join(baselineDir, tsDir, dbName)
+	if err := os.MkdirAll(parquetDir, 0o755); err != nil {
+		t.Fatalf("mkdir baseline: %v", err)
+	}
+	cols := []baseline.Column{
+		{Name: "action_id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
+		{Name: "last_attempt_gmt", MySQLType: "datetime", ParquetType: baseline.MysqlToParquetNode("datetime")},
+	}
+	bw, err := baseline.NewWriter(filepath.Join(parquetDir, "actionscheduler_actions.parquet"), cols,
+		baseline.WriterConfig{Compression: "zstd", RowGroupSize: 100,
+			Metadata: map[string]string{baseline.MetaKeyCreateTableSQL: createSQL}})
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	if err := bw.WriteRow([]string{"577", "0000-00-00 00:00:00"}, []bool{false, false}); err != nil {
+		t.Fatalf("WriteRow: %v", err)
+	}
+	if err := bw.Close(); err != nil {
+		t.Fatalf("baseline close: %v", err)
+	}
+
+	// ── no binlog event touches this PK: recon is a pure baseline passthrough ──
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{h1, curHour})
+
+	var uuid string
+	if err := db.QueryRow("SELECT @@server_uuid").Scan(&uuid); err != nil {
+		t.Fatalf("server_uuid: %v", err)
+	}
+	testutil.MustExec(t, db, `INSERT INTO stream_state
+		(id, mode, gtid_set, last_checkpoint, server_id)
+		VALUES (1, 'gtid', ?, UTC_TIMESTAMP(), 1)`, uuid+":1-1000000")
+
+	resolver, err := metadata.NewResolver(db, 1)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+	cfg := Config{
+		SourceDB: db, IndexDB: db, Resolver: resolver,
+		BaselineSource: baselineDir, IndexDBName: dbName, NoArchive: true,
+	}
+
+	got, err := VerifyTable(context.Background(), cfg, dbName, "actionscheduler_actions")
+	if err != nil {
+		t.Fatalf("VerifyTable: %v", err)
+	}
+	if got.Status != StatusMismatch {
+		t.Fatalf("status = %q (%s); want mismatch — a real live value diverging from a zero-date-derived baseline NULL must not be swallowed by the zero-date equivalence", got.Status, got.Detail)
 	}
 }


### PR DESCRIPTION
## Summary
- Closes the live-source half of #693: `VerifyTable` (`--source-dsn` / the console's "Compare against your live database" mode) had the SAME two false-MISMATCH classes already fixed in baseline-anchored mode (#692 JSON key-order, #694 zero-date-vs-NULL), because its source-side digest (`ConsistentTableChecksum`, raw MySQL text) and reconstruct-side digest (`renderCell`) each rendered these values differently, with no normalization on either side.
- Adds `ConsistentTableChecksumNormalized` to `internal/consistency`: an optional per-column hook that rewrites a scanned column's raw bytes before hashing. `internal/consistency` still does not import `internal/verify` — the caller supplies the normalization policy as a closure. `ConsistentTableChecksum` itself is unchanged (nil hook), so its other behavior and all existing callers/tests are untouched.
- Renames `renderCellBaselineAnchored` → `renderCellNormalized` now that it's used by both baseline-anchored AND live-source comparisons, and extracts the shared byte-level normalization (`normalizeRenderedBytes`) so both call sites (Go-value path and raw-SQL-bytes path) apply identical logic — required for the two sides of a comparison to stay symmetric.
- `VerifyTable` now passes `renderCellNormalized` to its reconstruct digest and `normalizeRenderedBytes` as `ConsistentTableChecksumNormalized`'s hook.

## Test plan
- [x] New regression tests reproduce both original bugs through `VerifyTable` against a real live MySQL table (`TestVerifyTable_JSONValuedTextColumn_KeyOrderIsAMatch`, `TestVerifyTable_ZeroDateSentinel_IsAMatch`).
- [x] New guard test proves a genuine divergence still surfaces as `StatusMismatch` (`TestVerifyTable_ZeroDateVsRealNull_StaysMismatch`) — the normalization stays narrowly scoped through the live-source path too.
- [x] Verified empirically: reverted the `VerifyTable` wiring, confirmed both new match tests fail with the original `StatusMismatch`, then restored and confirmed they pass.
- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./...` (full repo unit suite)
- [x] `go test -tags integration ./internal/verify/... ./internal/consistency/...` (full integration suite for both touched packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)