### PR TITLE
storage/parquetquery: fall back to EC2/ECS IMDS region when unset

### DIFF
--- a/internal/parquetquery/parquetquery.go
+++ b/internal/parquetquery/parquetquery.go
@@ -18,7 +18,6 @@ import (
 	"sync"
 	"time"
 
-	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	_ "github.com/duckdb/duckdb-go/v2"
 	"golang.org/x/sync/errgroup"
@@ -26,6 +25,7 @@ import (
 	"github.com/dbtrail/dbtrail/internal/duckdbutil"
 	"github.com/dbtrail/dbtrail/internal/event"
 	"github.com/dbtrail/dbtrail/internal/query"
+	"github.com/dbtrail/dbtrail/internal/storage"
 )
 
 // Fetch queries Parquet archive files (local or S3) using DuckDB and returns matching events.
@@ -281,9 +281,9 @@ func listS3ParquetScoped(ctx context.Context, source string, since, until *time.
 		return nil, 0, "", nil, err
 	}
 
-	cfg, err := awsconfig.LoadDefaultConfig(ctx)
+	cfg, err := storage.LoadAWSConfig(ctx, "")
 	if err != nil {
-		return nil, 0, "", nil, fmt.Errorf("load AWS config: %w", err)
+		return nil, 0, "", nil, err
 	}
 
 	// Detect the bucket's actual region via GetBucketLocation (must be called

--- a/internal/storage/s3.go
+++ b/internal/storage/s3.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
@@ -66,13 +65,9 @@ func NewS3Backend(ctx context.Context, cfg S3Config) (*S3Backend, error) {
 
 // newS3Client creates an S3 client from config.
 func newS3Client(ctx context.Context, cfg S3Config) (*s3.Client, error) {
-	var opts []func(*awsconfig.LoadOptions) error
-	if cfg.Region != "" {
-		opts = append(opts, awsconfig.WithRegion(cfg.Region))
-	}
-	awsCfg, err := awsconfig.LoadDefaultConfig(ctx, opts...)
+	awsCfg, err := LoadAWSConfig(ctx, cfg.Region)
 	if err != nil {
-		return nil, fmt.Errorf("storage: load AWS config: %w", err)
+		return nil, fmt.Errorf("storage: %w", err)
 	}
 
 	var s3Opts []func(*s3.Options)

--- a/internal/storage/s3url.go
+++ b/internal/storage/s3url.go
@@ -35,26 +35,43 @@ func ParseS3URL(u string) (bucket, prefix string, err error) {
 // region is optional — if empty, the SDK resolves it from AWS_REGION env var
 // or ~/.aws/config.
 func NewS3Client(ctx context.Context, region string) (*s3.Client, error) {
+	awsCfg, err := LoadAWSConfig(ctx, region)
+	if err != nil {
+		return nil, err
+	}
+	return s3.NewFromConfig(awsCfg), nil
+}
+
+// LoadAWSConfig loads the default AWS config (credential chain, region) for
+// S3 access. region is optional — if empty, the SDK resolves it from
+// AWS_REGION/AWS_DEFAULT_REGION env var or ~/.aws/config.
+//
+// LoadDefaultConfig resolves region from AWS_REGION/AWS_DEFAULT_REGION and the
+// shared config — but NOT from EC2/ECS IMDS. In an IAM-role-only deployment
+// with no AWS_REGION set (e.g. the bundled console on EC2), the region ends
+// up empty and every S3 request fails with "region was not a valid DNS name".
+// This surfaces even when the caller goes on to probe a bucket's own region
+// (e.g. via GetBucketLocation) as a fallback, since that probe typically
+// itself requires an IAM permission (s3:GetBucketLocation) a minimal,
+// least-privilege policy may not grant — leaving the caller with only this
+// empty region to fall back to. So every caller that loads AWS config for S3
+// access should go through this shared helper, not awsconfig.LoadDefaultConfig
+// directly, to get the same IMDS fallback.
+func LoadAWSConfig(ctx context.Context, region string) (aws.Config, error) {
 	opts := []func(*awsconfig.LoadOptions) error{}
 	if region != "" {
 		opts = append(opts, awsconfig.WithRegion(region))
 	}
 	awsCfg, err := awsconfig.LoadDefaultConfig(ctx, opts...)
 	if err != nil {
-		return nil, fmt.Errorf("load AWS config: %w", err)
+		return awsCfg, fmt.Errorf("load AWS config: %w", err)
 	}
-	// LoadDefaultConfig resolves region from AWS_REGION/AWS_DEFAULT_REGION and the
-	// shared config — but NOT from EC2/ECS IMDS. In an IAM-role-only deployment
-	// with no AWS_REGION set (e.g. the bundled console on EC2, where the in-process
-	// baseline upload passes region=""), the region ends up empty and every request
-	// fails with "region was not a valid DNS name". Fall back to the instance's
-	// IMDS region in that case.
 	if region == "" && awsCfg.Region == "" {
 		if r := imdsRegion(ctx, awsCfg); r != "" {
 			awsCfg.Region = r
 		}
 	}
-	return s3.NewFromConfig(awsCfg), nil
+	return awsCfg, nil
 }
 
 // imdsRegion best-effort fetches the EC2/ECS instance region from IMDS. Returns


### PR DESCRIPTION
## Summary
- Fixes a live bug reported via the console's Verify panel on an EC2 demo instance: `bintrail verify` (baseline-anchored, "Compare two saved snapshots") failed on 41/41 tables with `operation error S3: ListObjectsV2, resolve auth scheme: resolve endpoint: endpoint rule error, Invalid region: region was not a valid DNS name.`
- Root cause: `internal/parquetquery`'s `listS3ParquetScoped` loads AWS config directly with `awsconfig.LoadDefaultConfig`, which does **not** consult EC2/ECS IMDS for a region. On an IAM-role-only deployment with no `AWS_REGION` set, this returns an empty region. The function tries to work around this by probing the bucket's actual region via `GetBucketLocation`, but that call itself requires `s3:GetBucketLocation` — a permission a minimal, least-privilege S3 policy (confirmed on the reporting instance) commonly doesn't grant — so it falls back to the same empty region, and every subsequent S3 call fails.
- `internal/storage/s3url.go`'s `NewS3Client` already carries this exact IMDS fallback (#610/#611, a different S3 code path — DuckDB's `httpfs` home-dir issue at the time). Extracted it into a shared `storage.LoadAWSConfig` and wired it into:
  - `internal/parquetquery`'s `listS3ParquetScoped` (the path that surfaced this bug)
  - `internal/storage/s3.go`'s `newS3Client` (the BYOS `bintrail agent --s3-bucket` backend) — same reachable gap, and its own `S3Config.Region` doc comment already (falsely, until now) claimed instance-metadata resolution.
- `cmd/bintrail/init.go`'s two AWS config sites are unaffected — `--s3-region` is a required flag there, so region is never empty.

## Test plan
- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./...` (full repo unit suite)
- This bug class (IMDS resolution) isn't practically unit-testable without a real or mocked EC2 instance metadata endpoint — `storage.NewS3Client`'s existing IMDS fallback has never had one either. Requesting a live validation pass on the reporting EC2 instance before merge (see PR comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)