### PR TITLE
Forensics: capture the original SQL statement per row event (query_text/query_hash)

### DIFF
--- a/cmd/bintrail-mcp/main.go
+++ b/cmd/bintrail-mcp/main.go
@@ -332,6 +332,14 @@ func makeQueryTool(connect connectFunc) func(context.Context, *mcp.CallToolReque
 		}
 		defer db.Close()
 
+		// Same idempotent migration as the recover tool below: the query
+		// engine SELECTs post-initial-schema binlog_events columns
+		// (query_text/query_hash, #699) and the MCP server opens a fresh DB
+		// per tool call, so the migration has to run here.
+		if err := indexer.EnsureSchema(db); err != nil {
+			return errorResult(fmt.Errorf("ensure index schema: %w", err)), nil, nil
+		}
+
 		opts, err := buildQueryOptions(args.Schema, args.Table, args.PK, args.EventType,
 			args.GTID, args.Since, args.Until, args.ChangedColumn, args.ColumnEq, args.Flag, args.Limit, 100)
 		if err != nil {
@@ -358,6 +366,7 @@ func makeQueryTool(connect connectFunc) func(context.Context, *mcp.CallToolReque
 			}
 			opts.DenyTables = denyTables
 			opts.RedactColumns = redactCols
+			opts.ProfileActive = true
 		}
 
 		format := args.Format
@@ -453,6 +462,7 @@ func makeRecoverTool(connect connectFunc) func(context.Context, *mcp.CallToolReq
 			}
 			opts.DenyTables = denyTables
 			opts.RedactColumns = redactCols
+			opts.ProfileActive = true
 		}
 
 		// Load schema resolver best-effort for PK-only WHERE clauses.

--- a/docs/parquet-debugging.md
+++ b/docs/parquet-debugging.md
@@ -37,6 +37,8 @@ Archive Parquet files contain 15 columns (the `pk_hash` stored generated column 
 | `row_before` | VARCHAR | JSON object of the row before the event (nullable) |
 | `row_after` | VARCHAR | JSON object of the row after the event (nullable) |
 | `schema_version` | INT | Schema snapshot version at index time |
+| `query_text` | VARCHAR | Original SQL statement, when the source logs it (nullable; archives written before statement capture existed lack the column entirely — readers substitute NULL) |
+| `query_hash` | VARCHAR | `STATEMENT_DIGEST()` of `query_text` (nullable) |
 
 ---
 

--- a/docs/parquet-debugging.md
+++ b/docs/parquet-debugging.md
@@ -18,7 +18,7 @@ Verify with `duckdb --version`.
 
 ## Parquet Column Schema
 
-Archive Parquet files contain 15 columns (the `pk_hash` stored generated column is omitted):
+Archive Parquet files contain 17 columns (the `pk_hash` stored generated column is omitted):
 
 | Column | Type | Description |
 |--------|------|-------------|

--- a/docs/query-and-recovery.md
+++ b/docs/query-and-recovery.md
@@ -66,20 +66,20 @@ Results can be formatted three ways:
 
 When the source logs the original SQL statement alongside row events, `bintrail` stores it with every indexed event and shows it in the `json` and `csv` output (the `table` format omits it to stay scannable):
 
-- **`query_text`** — the literal statement that produced the row event (`UPDATE users SET ...`), exactly as the application sent it. One statement covers all of its rows: a 500-row bulk `DELETE` yields 500 events sharing the same text, and each statement in a multi-statement transaction carries its own.
+- **`query_text`** — the literal statement that produced the row event (`UPDATE users SET ...`), as the application sent it (subject to the sanitization notes below). One statement covers all of its rows: a 500-row bulk `DELETE` yields 500 events sharing the same text, and each statement in a multi-statement transaction carries its own.
 - **`query_hash`** — MySQL's `STATEMENT_DIGEST()` of that text, computed against the **index** server at index time. Statements that differ only in literal values share one hash, so you can group by it to find the query patterns mutating a table ("which statement shape is behind this DELETE volume?").
 
-Capture is **opt-in at the source** and off by default:
+Capture is **opt-in at the source** — off by default on MySQL, on by default on MariaDB 10.2.4+:
 
 ```sql
 -- MySQL (dynamic, no restart; costs binlog bytes per statement):
 SET PERSIST binlog_rows_query_log_events = ON;
 
--- MariaDB (default ON since 10.2):
+-- MariaDB (default ON since 10.2.4):
 SET GLOBAL binlog_annotate_row_events = ON;
 ```
 
-`bintrail doctor` reports the setting. Events indexed while capture is off (and all events indexed before upgrading) simply have `NULL` in both columns — nothing else changes.
+`bintrail doctor` reports the setting. On MariaDB, **streaming** capture additionally needs `--source-flavor mariadb` — the server only forwards ANNOTATE events to a replica that asks for them (file-based `bintrail index` reads them regardless). Events indexed while capture is off (and all events indexed before upgrading) simply have `NULL` in both columns — nothing else changes.
 
 Notes:
 

--- a/docs/query-and-recovery.md
+++ b/docs/query-and-recovery.md
@@ -83,7 +83,7 @@ SET GLOBAL binlog_annotate_row_events = ON;
 
 Notes:
 
-- Statements longer than 16 KiB are stored truncated, ending in `/* bintrail:truncated */`.
+- Statements longer than 16 KiB are stored truncated, ending in `/* bintrail:truncated */`. Truncated statements are not digested (`query_hash` stays `NULL`) — a mid-token fragment would misrepresent the statement's shape.
 - Under an active `--profile`, `query_text` and `query_hash` are withheld on **every** row, not just rows of flagged tables — a single statement can touch several tables, so its text can embed values of a column your profile redacts even when the row itself belongs to another table.
 - The web console never shows these fields (same boundary as `connection_id`).
 

--- a/docs/query-and-recovery.md
+++ b/docs/query-and-recovery.md
@@ -62,6 +62,31 @@ Results can be formatted three ways:
 
 **`csv`**: All columns including `row_before`/`row_after` serialized as JSON strings in the CSV cells. Fixed column order matching `csvHeaders`.
 
+### Statement capture: `query_text` and `query_hash`
+
+When the source logs the original SQL statement alongside row events, `bintrail` stores it with every indexed event and shows it in the `json` and `csv` output (the `table` format omits it to stay scannable):
+
+- **`query_text`** — the literal statement that produced the row event (`UPDATE users SET ...`), exactly as the application sent it. One statement covers all of its rows: a 500-row bulk `DELETE` yields 500 events sharing the same text, and each statement in a multi-statement transaction carries its own.
+- **`query_hash`** — MySQL's `STATEMENT_DIGEST()` of that text, computed against the **index** server at index time. Statements that differ only in literal values share one hash, so you can group by it to find the query patterns mutating a table ("which statement shape is behind this DELETE volume?").
+
+Capture is **opt-in at the source** and off by default:
+
+```sql
+-- MySQL (dynamic, no restart; costs binlog bytes per statement):
+SET PERSIST binlog_rows_query_log_events = ON;
+
+-- MariaDB (default ON since 10.2):
+SET GLOBAL binlog_annotate_row_events = ON;
+```
+
+`bintrail doctor` reports the setting. Events indexed while capture is off (and all events indexed before upgrading) simply have `NULL` in both columns — nothing else changes.
+
+Notes:
+
+- Statements longer than 16 KiB are stored truncated, ending in `/* bintrail:truncated */`.
+- Under an active `--profile`, `query_text` and `query_hash` are withheld on **every** row, not just rows of flagged tables — a single statement can touch several tables, so its text can embed values of a column your profile redacts even when the row itself belongs to another table.
+- The web console never shows these fields (same boundary as `connection_id`).
+
 ---
 
 ## Parquet Archive Queries

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -41,6 +41,8 @@ var BinlogEventColumns = []baseline.Column{
 	{Name: "row_before", MySQLType: "json", ParquetType: baseline.MysqlToParquetNode("json")},
 	{Name: "row_after", MySQLType: "json", ParquetType: baseline.MysqlToParquetNode("json")},
 	{Name: "schema_version", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
+	{Name: "query_text", MySQLType: "text", ParquetType: baseline.MysqlToParquetNode("text")},
+	{Name: "query_hash", MySQLType: "varchar", ParquetType: baseline.MysqlToParquetNode("varchar")},
 }
 
 // ArchivePartition writes all rows from the named partition of binlog_events
@@ -76,7 +78,7 @@ func ArchivePartition(ctx context.Context, db *sql.DB, dbName, partition, output
 	q := fmt.Sprintf(
 		"SELECT event_id, binlog_file, start_pos, end_pos, event_timestamp,"+
 			" gtid, connection_id, schema_name, table_name, event_type, pk_values,"+
-			" changed_columns, row_before, row_after, schema_version"+
+			" changed_columns, row_before, row_after, schema_version, query_text, query_hash"+
 			" FROM `%s`.`binlog_events` PARTITION (`%s`) ORDER BY event_id",
 		dbName, partition,
 	)
@@ -110,11 +112,13 @@ func ArchivePartition(ctx context.Context, db *sql.DB, dbName, partition, output
 			rowBefore      []byte // nil = NULL
 			rowAfter       []byte // nil = NULL
 			schemaVersion  sql.NullInt32
+			queryText      sql.NullString
+			queryHash      sql.NullString
 		)
 		if err := rows.Scan(
 			&eventID, &binlogFile, &startPos, &endPos, &eventTimestamp,
 			&gtid, &connID, &schemaName, &tableName, &eventType, &pkValues,
-			&changedColumns, &rowBefore, &rowAfter, &schemaVersion,
+			&changedColumns, &rowBefore, &rowAfter, &schemaVersion, &queryText, &queryHash,
 		); err != nil {
 			return rowCount, fmt.Errorf("scan row: %w", err)
 		}
@@ -144,6 +148,8 @@ func ArchivePartition(ctx context.Context, db *sql.DB, dbName, partition, output
 			string(rowBefore),
 			string(rowAfter),
 			strconv.FormatInt(int64(schemaVersion.Int32), 10),
+			queryText.String,
+			queryHash.String,
 		}
 		nulls := []bool{
 			false, // event_id (AUTO_INCREMENT, cannot be NULL)
@@ -161,6 +167,8 @@ func ArchivePartition(ctx context.Context, db *sql.DB, dbName, partition, output
 			rowBefore == nil,
 			rowAfter == nil,
 			!schemaVersion.Valid,
+			!queryText.Valid,
+			!queryHash.Valid,
 		}
 
 		if err := w.WriteRow(values, nulls); err != nil {

--- a/internal/archive/archive_integration_test.go
+++ b/internal/archive/archive_integration_test.go
@@ -82,3 +82,73 @@ func TestArchivePartition_nullBinlogFile(t *testing.T) {
 		t.Errorf("row 1 binlog_file: got %q, want NULL", parquetRows[1][binlogFileIdx].String())
 	}
 }
+
+// TestArchivePartition_queryTextRoundTrip pins the #699 wiring through the
+// rotate path: the SELECT list, Scan targets, and the positional values/nulls
+// arrays must stay aligned — a transposition of queryText/queryHash would
+// archive "cleanly" with swapped fields at rest and nothing else would
+// notice. Assert the exact values (and a real NULL) at the Parquet layer.
+func TestArchivePartition_queryTextRoundTrip(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	ts := "2026-02-19 14:00:00"
+	stmt := "UPDATE mydb.orders SET amount = 5 WHERE id = 1"
+	hash := "aa11bb22cc33"
+	if _, err := db.Exec(`INSERT INTO binlog_events
+		(binlog_file, start_pos, end_pos, event_timestamp,
+		 schema_name, table_name, event_type, pk_values, row_after,
+		 query_text, query_hash)
+		VALUES (?, 100, 200, ?, 'mydb', 'orders', 2, '1', '{"id":1}', ?, ?)`,
+		"binlog.000001", ts, stmt, hash,
+	); err != nil {
+		t.Fatalf("insert row with query_text failed: %v", err)
+	}
+	// Second row: statement not captured (both NULL).
+	testutil.InsertEvent(t, db, "binlog.000001", 300, 400, ts, nil, "mydb", "orders", 1, "2",
+		nil, nil, []byte(`{"id":2}`))
+
+	outPath := filepath.Join(t.TempDir(), "p_future.parquet")
+	n, err := ArchivePartition(context.Background(), db, dbName, "p_future", outPath, "none")
+	if err != nil {
+		t.Fatalf("ArchivePartition failed: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("rowCount = %d, want 2", n)
+	}
+
+	rf, err := os.Open(outPath)
+	if err != nil {
+		t.Fatalf("open archived parquet: %v", err)
+	}
+	defer rf.Close()
+	info, _ := rf.Stat()
+	pf, err := parquet.OpenFile(rf, info.Size())
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+	textIdx := parquetColumnIndex(t, pf, "query_text")
+	hashIdx := parquetColumnIndex(t, pf, "query_hash")
+	reader := parquet.NewReader(pf)
+	defer reader.Close()
+
+	// Row 0 (lower event_id, ORDER BY event_id) carries the exact values;
+	// row 1 must be real Parquet NULLs.
+	row := make([]parquet.Row, 1)
+	if _, err := reader.ReadRows(row); err != nil {
+		t.Fatalf("ReadRows row 0: %v", err)
+	}
+	if got := row[0][textIdx].String(); got != stmt {
+		t.Errorf("row 0 query_text = %q, want %q (values/nulls transposition?)", got, stmt)
+	}
+	if got := row[0][hashIdx].String(); got != hash {
+		t.Errorf("row 0 query_hash = %q, want %q", got, hash)
+	}
+	if _, err := reader.ReadRows(row); err != nil {
+		t.Fatalf("ReadRows row 1: %v", err)
+	}
+	if !row[0][textIdx].IsNull() || !row[0][hashIdx].IsNull() {
+		t.Errorf("row 1 query fields must be real Parquet NULLs, got text=%v hash=%v",
+			row[0][textIdx], row[0][hashIdx])
+	}
+}

--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -15,8 +15,8 @@ import (
 )
 
 func TestBinlogEventColumns_count(t *testing.T) {
-	if len(BinlogEventColumns) != 15 {
-		t.Errorf("expected 15 columns, got %d", len(BinlogEventColumns))
+	if len(BinlogEventColumns) != 17 {
+		t.Errorf("expected 17 columns, got %d", len(BinlogEventColumns))
 	}
 }
 
@@ -25,7 +25,7 @@ func TestBinlogEventColumns_names(t *testing.T) {
 		"event_id", "binlog_file", "start_pos", "end_pos",
 		"event_timestamp", "gtid", "connection_id", "schema_name", "table_name",
 		"event_type", "pk_values", "changed_columns", "row_before", "row_after",
-		"schema_version",
+		"schema_version", "query_text", "query_hash",
 	}
 	for i, want := range wantNames {
 		if i >= len(BinlogEventColumns) {
@@ -101,7 +101,7 @@ func TestWriteReadRoundTrip(t *testing.T) {
 		true, // connection_id null
 		false, false, false, false,
 		true, true, true, // changed_columns, row_before, row_after null
-		false,            // schema_version not null
+		false, // schema_version not null
 	}
 	if err := w.WriteRow(row2, nulls2); err != nil {
 		t.Fatalf("WriteRow 2: %v", err)

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -94,6 +94,12 @@ func (b *Buffer) Insert(events []event.Event) {
 			connID = &v
 		}
 
+		var queryText *string
+		if ev.QueryText != "" {
+			s := ev.QueryText
+			queryText = &s
+		}
+
 		row := query.ResultRow{
 			BinlogFile:     ev.BinlogFile,
 			StartPos:       ev.StartPos,
@@ -109,6 +115,10 @@ func (b *Buffer) Insert(events []event.Event) {
 			RowBefore:      ev.RowBefore,
 			RowAfter:       ev.RowAfter,
 			SchemaVersion:  ev.SchemaVersion,
+			QueryText:      queryText,
+			// QueryHash stays nil: the digest is an index-side enrichment
+			// (STATEMENT_DIGEST on the index connection) and the BYOS buffer
+			// has no index database.
 		}
 
 		sz := estimateRowSize(&row)
@@ -325,6 +335,9 @@ func estimateRowSize(r *query.ResultRow) int64 {
 
 	if r.GTID != nil {
 		n += int64(len(*r.GTID))
+	}
+	if r.QueryText != nil {
+		n += int64(len(*r.QueryText))
 	}
 	for _, c := range r.ChangedColumns {
 		n += int64(len(c))

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -157,7 +157,19 @@ func (b *Buffer) Fetch(_ context.Context, opts query.Options) []query.ResultRow 
 		if !matchesOpts(e, opts) {
 			continue
 		}
-		results = append(results, e.row)
+		row := e.row
+		// The #699 statement-text invariant (see query.applyRedaction): the
+		// captured statement is per-STATEMENT, not per-table, so under ANY
+		// active profile it is withheld on every row. The buffer path does
+		// not implement column redaction (the agent handler never plumbs
+		// profiles today), but if profile options ever reach it, statement
+		// text must not be the surface that leaks. The stored entry is
+		// untouched — row is a copy, and QueryText is only niled on it.
+		if opts.ProfileActive || len(opts.RedactColumns) > 0 || len(opts.DenyTables) > 0 {
+			row.QueryText = nil
+			row.QueryHash = nil
+		}
+		results = append(results, row)
 		if len(results) >= limit {
 			break
 		}

--- a/internal/buffer/parquet.go
+++ b/internal/buffer/parquet.go
@@ -67,7 +67,7 @@ func WriteParquet(rows []query.ResultRow, outputPath, compression string) (int64
 
 // rowToParquet converts a ResultRow to the string values and null flags
 // expected by baseline.Writer.WriteRow. Column order matches
-// archive.BinlogEventColumns (15 columns).
+// archive.BinlogEventColumns (17 columns).
 func rowToParquet(r *query.ResultRow) ([]string, []bool, error) {
 	gtidStr := ""
 	gtidNull := true
@@ -81,6 +81,20 @@ func rowToParquet(r *query.ResultRow) ([]string, []bool, error) {
 	if r.ConnectionID != nil {
 		connIDStr = strconv.FormatUint(uint64(*r.ConnectionID), 10)
 		connIDNull = false
+	}
+
+	queryTextStr := ""
+	queryTextNull := true
+	if r.QueryText != nil {
+		queryTextStr = *r.QueryText
+		queryTextNull = false
+	}
+
+	queryHashStr := ""
+	queryHashNull := true
+	if r.QueryHash != nil {
+		queryHashStr = *r.QueryHash
+		queryHashNull = false
 	}
 
 	changedCols, changedNull, err := marshalJSONField(r.ChangedColumns)
@@ -112,6 +126,8 @@ func rowToParquet(r *query.ResultRow) ([]string, []bool, error) {
 		rowBefore,
 		rowAfter,
 		strconv.FormatUint(uint64(r.SchemaVersion), 10),
+		queryTextStr,
+		queryHashStr,
 	}
 
 	nulls := []bool{
@@ -123,6 +139,8 @@ func rowToParquet(r *query.ResultRow) ([]string, []bool, error) {
 		beforeNull,
 		afterNull,
 		false,
+		queryTextNull,
+		queryHashNull,
 	}
 
 	return values, nulls, nil

--- a/internal/buffer/parquet_test.go
+++ b/internal/buffer/parquet_test.go
@@ -125,6 +125,74 @@ func TestWriteParquet_connectionIDUnsignedDuckDBScan(t *testing.T) {
 	}
 }
 
+// TestWriteParquet_queryTextRoundTrip pins #699 on the buffer write path:
+// a captured statement round-trips through the query_text column, and a row
+// without one reads back NULL (not empty string). Read back via DuckDB
+// parquet_scan — the real consumer.
+func TestWriteParquet_queryTextRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "qtext.parquet")
+
+	stmt := "INSERT INTO db.t (id) VALUES (1)"
+	withText := query.ResultRow{
+		EventID:        idOffset + 1,
+		BinlogFile:     "binlog.000001",
+		StartPos:       100,
+		EndPos:         200,
+		EventTimestamp: time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+		SchemaName:     "db",
+		TableName:      "t",
+		EventType:      parser.EventInsert,
+		PKValues:       "1",
+		RowAfter:       map[string]any{"id": 1},
+		QueryText:      &stmt,
+	}
+	withoutText := withText
+	withoutText.EventID = idOffset + 2
+	withoutText.PKValues = "2"
+	withoutText.QueryText = nil
+
+	n, err := WriteParquet([]query.ResultRow{withText, withoutText}, outPath, "none")
+	if err != nil {
+		t.Fatalf("WriteParquet: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("count = %d, want 2", n)
+	}
+
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open duckdb: %v", err)
+	}
+	defer db.Close()
+
+	safePath := strings.ReplaceAll(outPath, "'", "''")
+	rows, err := db.QueryContext(context.Background(),
+		"SELECT query_text FROM parquet_scan('"+safePath+"') ORDER BY event_id")
+	if err != nil {
+		t.Fatalf("scan query_text: %v", err)
+	}
+	defer rows.Close()
+
+	var got []sql.NullString
+	for rows.Next() {
+		var v sql.NullString
+		if err := rows.Scan(&v); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		got = append(got, v)
+	}
+	if len(got) != 2 {
+		t.Fatalf("rows = %d, want 2", len(got))
+	}
+	if !got[0].Valid || got[0].String != stmt {
+		t.Errorf("row 1 query_text = %+v, want %q", got[0], stmt)
+	}
+	if got[1].Valid {
+		t.Errorf("row 2 query_text = %q, want NULL (statement not captured)", got[1].String)
+	}
+}
+
 func TestWriteParquet_nullableFields(t *testing.T) {
 	dir := t.TempDir()
 	outPath := filepath.Join(dir, "nulls.parquet")

--- a/internal/buffer/querytext_test.go
+++ b/internal/buffer/querytext_test.go
@@ -1,0 +1,50 @@
+package buffer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/parser"
+	"github.com/dbtrail/dbtrail/internal/query"
+)
+
+// TestFetch_queryTextPropagationAndProfileBlanking pins two #699 contracts on
+// the live-buffer path: (a) Insert carries the captured statement into Fetch
+// results; (b) under any active profile the statement fields are withheld
+// from the RETURNED rows without mutating the stored entries.
+func TestFetch_queryTextPropagationAndProfileBlanking(t *testing.T) {
+	buf := New(Config{MaxAge: time.Hour})
+	base := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+	buf.Insert([]parser.Event{{
+		BinlogFile: "binlog.000001", StartPos: 100, EndPos: 200,
+		Timestamp: base, Schema: "mydb", Table: "users",
+		EventType: parser.EventInsert, PKValues: "1",
+		RowAfter:  map[string]any{"id": 1},
+		QueryText: "INSERT INTO mydb.users (id) VALUES (1)",
+	}})
+
+	plain := buf.Fetch(context.Background(), query.Options{Schema: "mydb", Table: "users"})
+	if len(plain) != 1 {
+		t.Fatalf("rows = %d, want 1", len(plain))
+	}
+	if plain[0].QueryText == nil || *plain[0].QueryText != "INSERT INTO mydb.users (id) VALUES (1)" {
+		t.Fatalf("Insert must propagate QueryText into Fetch results, got %v", plain[0].QueryText)
+	}
+
+	blanked := buf.Fetch(context.Background(), query.Options{Schema: "mydb", Table: "users", ProfileActive: true})
+	if len(blanked) != 1 {
+		t.Fatalf("rows = %d, want 1", len(blanked))
+	}
+	if blanked[0].QueryText != nil || blanked[0].QueryHash != nil {
+		t.Errorf("statement fields must be withheld under an active profile, got %v / %v",
+			blanked[0].QueryText, blanked[0].QueryHash)
+	}
+
+	// The stored entry must be untouched: a later unrestricted Fetch still
+	// sees the text.
+	again := buf.Fetch(context.Background(), query.Options{Schema: "mydb", Table: "users"})
+	if again[0].QueryText == nil {
+		t.Error("profile blanking must not mutate the stored buffer entry")
+	}
+}

--- a/internal/byos/payload.go
+++ b/internal/byos/payload.go
@@ -26,6 +26,7 @@ var payloadColumns = []baseline.Column{
 	{Name: "row_after", MySQLType: "json", ParquetType: baseline.MysqlToParquetNode("json")},
 	{Name: "changed_columns", MySQLType: "json", ParquetType: baseline.MysqlToParquetNode("json")},
 	{Name: "schema_version", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
+	{Name: "query_text", MySQLType: "text", ParquetType: baseline.MysqlToParquetNode("text")},
 }
 
 // PayloadWriter writes payload records to a storage backend as Parquet files,
@@ -174,6 +175,7 @@ func marshalPayloadRow(r *PayloadRecord) ([]string, []bool, error) {
 		string(rowAfter),
 		string(changed),
 		strconv.FormatUint(uint64(r.SchemaVersion), 10),
+		r.QueryText,
 	}
 	nulls := []bool{
 		false, // pk_hash
@@ -185,7 +187,8 @@ func marshalPayloadRow(r *PayloadRecord) ([]string, []bool, error) {
 		r.RowBefore == nil,
 		r.RowAfter == nil,
 		r.ChangedColumns == nil,
-		false, // schema_version
+		false,             // schema_version
+		r.QueryText == "", // query_text: empty = not captured = NULL
 	}
 	return values, nulls, nil
 }

--- a/internal/byos/split.go
+++ b/internal/byos/split.go
@@ -77,6 +77,14 @@ type PayloadRecord struct {
 	RowAfter       map[string]any `json:"row_after,omitempty"`
 	ChangedColumns []string       `json:"changed_columns,omitempty"`
 	SchemaVersion  uint32         `json:"schema_version"`
+	// QueryText is the original SQL statement (#699). PAYLOAD-ONLY by design:
+	// statement text embeds literal column values — row-level data in another
+	// form — so it must never appear on MetadataRecord ("only indexing
+	// metadata — no row-level data"). Empty when the source does not log
+	// ROWS_QUERY/ANNOTATE events. There is no query_hash here: the digest is
+	// an index-side enrichment (STATEMENT_DIGEST on the index connection) and
+	// the BYOS pipeline has no index database.
+	QueryText string `json:"query_text,omitempty"`
 }
 
 // PKHash computes the SHA-256 hex digest of pkValues, matching MySQL's
@@ -133,6 +141,7 @@ func SplitEvent(ev event.Event, serverID string, ident SourceIdentity) (Metadata
 		RowAfter:       maps.Clone(ev.RowAfter),
 		ChangedColumns: slices.Clone(changed),
 		SchemaVersion:  ev.SchemaVersion,
+		QueryText:      ev.QueryText,
 	}
 
 	return meta, payload, nil

--- a/internal/byos/split_test.go
+++ b/internal/byos/split_test.go
@@ -1,6 +1,8 @@
 package byos
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -118,6 +120,44 @@ func TestSplitEventInsert(t *testing.T) {
 	}
 	if payload.SchemaVersion != 5 {
 		t.Errorf("payload.SchemaVersion = %d, want 5", payload.SchemaVersion)
+	}
+}
+
+// TestSplitEventQueryTextPayloadOnly pins the #699 BYOS boundary: the
+// captured statement text embeds literal column values (row-level data in
+// another form), so it flows to the customer-side PayloadRecord ONLY and must
+// never appear in the MetadataRecord sent to the dbtrail API.
+func TestSplitEventQueryTextPayloadOnly(t *testing.T) {
+	ev := parser.Event{
+		Timestamp: time.Date(2026, 3, 31, 12, 0, 0, 0, time.UTC),
+		Schema:    "mydb",
+		Table:     "users",
+		EventType: parser.EventInsert,
+		PKValues:  "42",
+		RowAfter:  map[string]any{"id": 42, "ssn": "123-45-6789"},
+		QueryText: "INSERT INTO users (id, ssn) VALUES (42, '123-45-6789')",
+	}
+
+	meta, payload, err := SplitEvent(ev, "server-1", SourceIdentity{})
+	if err != nil {
+		t.Fatalf("SplitEvent: %v", err)
+	}
+
+	if payload.QueryText != ev.QueryText {
+		t.Errorf("payload.QueryText = %q, want the captured statement", payload.QueryText)
+	}
+
+	// The metadata wire form must carry neither the key nor the value.
+	b, err := json.Marshal(meta)
+	if err != nil {
+		t.Fatalf("marshal metadata: %v", err)
+	}
+	js := string(b)
+	if strings.Contains(js, "query_text") {
+		t.Errorf("MetadataRecord JSON must not contain a query_text key: %s", js)
+	}
+	if strings.Contains(js, "123-45-6789") {
+		t.Errorf("MetadataRecord JSON must not leak statement literals: %s", js)
 	}
 }
 

--- a/internal/cli/query.go
+++ b/internal/cli/query.go
@@ -246,6 +246,7 @@ func runQuery(cmd *cobra.Command, args []string) error {
 		}
 		opts.DenyTables = denyTables
 		opts.RedactColumns = redactCols
+		opts.ProfileActive = true
 	}
 
 	engine := query.New(db)

--- a/internal/cli/reconstruct.go
+++ b/internal/cli/reconstruct.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dbtrail/dbtrail/internal/baseline"
 	"github.com/dbtrail/dbtrail/internal/cliutil"
 	"github.com/dbtrail/dbtrail/internal/config"
+	"github.com/dbtrail/dbtrail/internal/indexer"
 	"github.com/dbtrail/dbtrail/internal/query"
 	"github.com/dbtrail/dbtrail/internal/reconstruct"
 )
@@ -251,6 +252,15 @@ func runReconstruct(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("connect to index database: %w", err)
 	}
 	defer db.Close()
+
+	// Idempotent schema migration: the query engine SELECTs
+	// post-initial-schema binlog_events columns (query_text/query_hash,
+	// #699); without this, single-row/--history reconstruct against a
+	// pre-upgrade index 1054s while full-table mode (which already calls
+	// EnsureSchema in reconstruct.ReconstructTable) self-heals.
+	if err := indexer.EnsureSchema(db); err != nil {
+		return fmt.Errorf("ensure index schema: %w", err)
+	}
 
 	engine := query.New(db)
 

--- a/internal/cli/recover.go
+++ b/internal/cli/recover.go
@@ -214,6 +214,7 @@ func runRecover(cmd *cobra.Command, args []string) error {
 		}
 		opts.DenyTables = denyTables
 		opts.RedactColumns = redactCols
+		opts.ProfileActive = true
 	}
 
 	// ── Load schema resolver (best-effort; non-fatal) ─────────────────────────

--- a/internal/cli/shim.go
+++ b/internal/cli/shim.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/dbtrail/dbtrail/internal/config"
+	"github.com/dbtrail/dbtrail/internal/indexer"
 	"github.com/dbtrail/dbtrail/internal/shim"
 )
 
@@ -225,6 +226,16 @@ func runShim(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("ping index DB: %w", err)
 	}
 	pingCancel()
+
+	// Idempotent schema migration (CLI-typed DSN — the one-DDL boundary):
+	// the shared query engine SELECTs post-initial-schema binlog_events
+	// columns (query_text/query_hash, #699). Without this a shim restarted
+	// on a new binary against an index last written by an older one would
+	// abort EVERY _flashback/_snapshot client query with MySQL error 1054
+	// until some unrelated writer command migrated the index.
+	if err := indexer.EnsureSchema(db); err != nil {
+		return fmt.Errorf("ensure index schema: %w", err)
+	}
 
 	listener, err := net.Listen("tcp", shListen)
 	if err != nil {

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/dbtrail/dbtrail/internal/config"
 	"github.com/dbtrail/dbtrail/internal/duckdbutil"
+	"github.com/dbtrail/dbtrail/internal/indexer"
 	"github.com/dbtrail/dbtrail/internal/metadata"
 	"github.com/dbtrail/dbtrail/internal/verify"
 )
@@ -97,6 +98,15 @@ func runVerify(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("connect to index database: %w", err)
 	}
 	defer indexDB.Close()
+
+	// Idempotent schema migration (CLI-typed DSN — the one-DDL boundary):
+	// the shared query engine SELECTs post-initial-schema binlog_events
+	// columns (connection_id, query_text/query_hash #699), so verify against
+	// an index last written by an older binary would otherwise fail with
+	// MySQL error 1054 — a false drift alert.
+	if err := indexer.EnsureSchema(indexDB); err != nil {
+		return fmt.Errorf("ensure index schema: %w", err)
+	}
 
 	var indexDBName string
 	if cfg, parseErr := mysqldriver.ParseDSN(vfyIndexDSN); parseErr == nil {

--- a/internal/console/api.go
+++ b/internal/console/api.go
@@ -475,16 +475,26 @@ func atoiDefault(s string, def int) int {
 }
 
 // writeFetchError maps a cross-source fetch failure onto the right HTTP
-// response. The interesting case: a registry index that predates the
-// connection_id column fails the events SELECT with MySQL error 1054. The
+// response. The interesting case: a registry index that predates one of the
+// post-initial-schema binlog_events columns (connection_id, or #699's
+// query_text/query_hash) fails the events SELECT with MySQL error 1054. The
 // console deliberately never migrates registry servers (EnsureSchema — an
 // ALTER — is confined to the command-line DSN), so instead of a cryptic 500 we
 // return an actionable 422 telling the operator how to migrate.
 func writeFetchError(w http.ResponseWriter, err error) {
 	var myErr *mysql.MySQLError
-	if errors.As(err, &myErr) && myErr.Number == 1054 && strings.Contains(myErr.Message, "connection_id") {
+	if errors.As(err, &myErr) && myErr.Number == 1054 &&
+		(strings.Contains(myErr.Message, "connection_id") ||
+			strings.Contains(myErr.Message, "query_text") ||
+			strings.Contains(myErr.Message, "query_hash")) {
+		col := "connection_id"
+		for _, c := range []string{"query_text", "query_hash"} {
+			if strings.Contains(myErr.Message, c) {
+				col = c
+			}
+		}
 		writeJSONError(w, http.StatusUnprocessableEntity,
-			"this index predates the connection_id column, and the console never migrates servers added in the UI; "+
+			"this index predates the "+col+" column, and the console never migrates servers added in the UI; "+
 				"run a writer command against it once (bintrail index / stream / agent), or start a console with --index-dsn pointing at it")
 		return
 	}

--- a/internal/console/api_test.go
+++ b/internal/console/api_test.go
@@ -134,6 +134,14 @@ func TestEventsHandlerOmitsConnectionID(t *testing.T) {
 		t.Fatalf("events status = %d, body = %s", rec.Code, rec.Body.String())
 	}
 	body := rec.Body.String()
+	// #699 forensics fields ride the same open-core boundary as
+	// connection_id: the mock row above feeds a statement + digest through
+	// the handler, and neither key nor value may reach the wire.
+	for _, banned := range []string{"query_text", "query_hash", "UPDATE users SET", "cafe0000"} {
+		if strings.Contains(body, banned) {
+			t.Errorf("events response must not contain %q: %s", banned, body)
+		}
+	}
 	if strings.Contains(body, "connection_id") || strings.Contains(body, "4242") {
 		t.Errorf("events HTTP response leaked connection_id: %s", body)
 	}

--- a/internal/console/api_test.go
+++ b/internal/console/api_test.go
@@ -114,13 +114,14 @@ func TestEventsHandlerOmitsConnectionID(t *testing.T) {
 	cols := []string{
 		"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp",
 		"gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values",
-		"changed_columns", "row_before", "row_after", "schema_version",
+		"changed_columns", "row_before", "row_after", "schema_version", "query_text", "query_hash",
 	}
 	ts := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
 	rows := sqlmock.NewRows(cols).AddRow(
 		int64(1), "bin.000001", int64(4), int64(40), ts,
 		nil, int64(4242), "app", "users", int64(parser.EventUpdate), "7",
 		[]byte(`["email"]`), []byte(`{"email":"a@x"}`), []byte(`{"email":"b@x"}`), int64(0),
+		"UPDATE users SET email='b@x'", "cafe0000",
 	)
 	mock.ExpectQuery("FROM binlog_events").WillReturnRows(rows)
 
@@ -176,7 +177,7 @@ func TestRecoverIsReadOnly(t *testing.T) {
 	cols := []string{
 		"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp",
 		"gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values",
-		"changed_columns", "row_before", "row_after", "schema_version",
+		"changed_columns", "row_before", "row_after", "schema_version", "query_text", "query_hash",
 	}
 	ts := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
 	// An INSERT event (event_type=1); its reversal is a DELETE built from
@@ -186,6 +187,7 @@ func TestRecoverIsReadOnly(t *testing.T) {
 		int64(1), "bin.000001", int64(4), int64(40), ts,
 		nil, nil, "app", "users", int64(parser.EventInsert), "42",
 		nil, nil, []byte(`{"id":42,"email":"a@x"}`), int64(0),
+		nil, nil,
 	)
 	mock.ExpectQuery("FROM binlog_events").WillReturnRows(resultRows)
 

--- a/internal/console/dto.go
+++ b/internal/console/dto.go
@@ -13,13 +13,15 @@ const consoleTSFormat = "2006-01-02 15:04:05"
 // eventDTO is the JSON-serialisable view of a query.ResultRow exposed by the
 // console's read-only API.
 //
-// It deliberately OMITS connection_id. That field — the MySQL pseudo_thread_id
-// of the transaction that produced the change — is actor-attribution data and
-// belongs to the paid "forensics" surface (who-changed / audit), not the free
+// It deliberately OMITS connection_id, query_text, and query_hash. Those
+// fields — the MySQL pseudo_thread_id of the transaction that produced the
+// change, and the originating SQL statement + its STATEMENT_DIGEST (#699) —
+// are actor/statement-attribution data and belong to the paid "forensics"
+// surface (who-changed / what-statement / audit), not the free
 // "query_explorer" surface this console exposes. The omission is the entire
-// open-core boundary for the events API: query.ResultRow carries ConnectionID,
-// the package's own jsonRow serialises it, but this DTO drops it on the way out.
-// Do not add it here without crossing the licensing line.
+// open-core boundary for the events API: query.ResultRow carries those fields,
+// the package's own jsonRow serialises them, but this DTO drops them on the
+// way out. Do not add them here without crossing the licensing line.
 type eventDTO struct {
 	EventID        uint64         `json:"event_id"`
 	BinlogFile     string         `json:"binlog_file"`
@@ -37,7 +39,8 @@ type eventDTO struct {
 }
 
 // toEventDTO maps a query.ResultRow to the redacted wire view, dropping
-// connection_id and stringifying the event type and timestamp.
+// connection_id/query_text/query_hash and stringifying the event type and
+// timestamp.
 func toEventDTO(r query.ResultRow) eventDTO {
 	return eventDTO{
 		EventID:        r.EventID,

--- a/internal/console/dto_test.go
+++ b/internal/console/dto_test.go
@@ -13,10 +13,13 @@ import (
 )
 
 // TestEventDTOOmitsConnectionID is the load-bearing open-core test: the events
-// API must never expose connection_id (actor attribution = paid forensics).
+// API must never expose connection_id (actor attribution = paid forensics),
+// nor query_text/query_hash (statement attribution = paid forensics, #699).
 func TestEventDTOOmitsConnectionID(t *testing.T) {
 	cid := uint32(98765)
 	gtid := "uuid:1-10"
+	qText := "UPDATE users SET email='b@x' WHERE id=42"
+	qHash := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 	row := query.ResultRow{
 		EventID:        1,
 		EventTimestamp: time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC),
@@ -29,6 +32,8 @@ func TestEventDTOOmitsConnectionID(t *testing.T) {
 		ChangedColumns: []string{"email"},
 		RowBefore:      map[string]any{"email": "a@x"},
 		RowAfter:       map[string]any{"email": "b@x"},
+		QueryText:      &qText, // present on the source row…
+		QueryHash:      &qHash, // present on the source row…
 	}
 
 	b, err := json.Marshal(toEventDTO(row))
@@ -43,6 +48,12 @@ func TestEventDTOOmitsConnectionID(t *testing.T) {
 	}
 	if strings.Contains(js, "98765") {
 		t.Errorf("eventDTO JSON must not leak the connection id value: %s", js)
+	}
+	if strings.Contains(js, "query_text") || strings.Contains(js, "query_hash") {
+		t.Errorf("eventDTO JSON must not contain query_text/query_hash keys: %s", js)
+	}
+	if strings.Contains(js, "WHERE id=42") || strings.Contains(js, qHash) {
+		t.Errorf("eventDTO JSON must not leak the statement text or its digest: %s", js)
 	}
 
 	for _, want := range []string{

--- a/internal/console/fetcherror_test.go
+++ b/internal/console/fetcherror_test.go
@@ -1,0 +1,31 @@
+package console
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-sql-driver/mysql"
+)
+
+// TestWriteFetchErrorWrapped1054 pins the legacy-registry-index mapping for
+// WRAPPED errors: the recover-cascade path wraps the fetch failure
+// (fmt.Errorf %w), and writeFetchError must still unwrap the MySQL 1054 on a
+// post-initial-schema column (query_text, #699) into the actionable 422
+// instead of a cryptic 500.
+func TestWriteFetchErrorWrapped1054(t *testing.T) {
+	inner := &mysql.MySQLError{Number: 1054, Message: "Unknown column 'be.query_text' in 'field list'"}
+	err := fmt.Errorf("fetch parent deletes: %w", inner)
+
+	rec := httptest.NewRecorder()
+	writeFetchError(rec, err)
+
+	if rec.Code != 422 {
+		t.Fatalf("status = %d, want 422; body = %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "query_text") || !strings.Contains(body, "never migrates") {
+		t.Errorf("422 body must name the column and the remediation, got: %s", body)
+	}
+}

--- a/internal/console/recover_cascade.go
+++ b/internal/console/recover_cascade.go
@@ -145,7 +145,11 @@ func (s *Server) handleRecoverCascade(w http.ResponseWriter, r *http.Request) {
 		MaxDepth: maxDepth,
 	})
 	if err != nil {
-		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		// writeFetchError, not a bare 500: a registry index that predates a
+		// post-initial-schema binlog_events column (query_text/query_hash,
+		// #699) fails the parent fetch with MySQL 1054, and the operator
+		// should get the same actionable 422 the sibling tabs show.
+		writeFetchError(w, err)
 		return
 	}
 

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -136,6 +136,7 @@ func Build(parent context.Context, sourceDSN, indexDSN, schemasCSV string, index
 	report.add(checkBinlogFormat(sourceDB))
 	report.add(checkBinlogRowImage(sourceDB))
 	report.add(checkBinlogRetention(sourceDB))
+	report.add(checkStatementCapture(sourceDB))
 	report.add(checkReplicationGrants(ctx, sourceDB))
 	report.add(checkFKCascades(sourceDB, schemas))
 	report.add(checkSchemaVisibility(ctx, sourceDB, schemas))
@@ -320,6 +321,55 @@ func checkBinlogRetention(db *sql.DB) CheckResult {
 		Name:   "Binlog retention >= 2 days",
 		Status: StatusPass,
 		Detail: fmt.Sprintf("%dh", seconds/3600),
+	}
+}
+
+// checkStatementCapture reports whether the source logs the original SQL
+// statement alongside each row event (#699): MySQL's
+// binlog_rows_query_log_events or MariaDB's binlog_annotate_row_events. The
+// capture is OPTIONAL — it feeds the query_text/query_hash forensics columns —
+// so this check never FAILs: ON → PASS, OFF → WARN with an enable suggestion
+// (validate, never set), variable absent on both probes → SKIP. Both probes use
+// SELECT @@var, which errors (MySQL 1193) rather than returning rows for a
+// variable the flavor doesn't have — the checkBinlogRetention fallback pattern.
+func checkStatementCapture(db *sql.DB) CheckResult {
+	const name = "Statement capture (query_text)"
+	isOn := func(val string) bool { return val == "1" || strings.EqualFold(val, "ON") }
+
+	var val string
+	if err := db.QueryRow("SELECT @@binlog_rows_query_log_events").Scan(&val); err == nil {
+		if isOn(val) {
+			return CheckResult{Name: name, Status: StatusPass, Detail: "binlog_rows_query_log_events=ON"}
+		}
+		return CheckResult{
+			Name:   name,
+			Status: StatusWarn,
+			Detail: "binlog_rows_query_log_events=OFF — events index without the originating SQL statement (query_text stays NULL)",
+			Remediation: "Optional: log the original statement with each row event so `bintrail query` can show it (dynamic, no restart; costs binlog bytes per statement):\n\n" +
+				"  SET PERSIST binlog_rows_query_log_events = ON;",
+		}
+	}
+
+	// MariaDB names the same capability binlog_annotate_row_events
+	// (default ON since 10.2.4).
+	if err := db.QueryRow("SELECT @@binlog_annotate_row_events").Scan(&val); err == nil {
+		if isOn(val) {
+			return CheckResult{Name: name, Status: StatusPass, Detail: "binlog_annotate_row_events=ON"}
+		}
+		return CheckResult{
+			Name:   name,
+			Status: StatusWarn,
+			Detail: "binlog_annotate_row_events=OFF — events index without the originating SQL statement (query_text stays NULL)",
+			Remediation: "Optional: log the original statement with each row event so `bintrail query` can show it:\n\n" +
+				"  SET GLOBAL binlog_annotate_row_events = ON;\n\n" +
+				"Persist it in my.cnf ([mysqld] binlog_annotate_row_events=ON) to survive restarts.",
+		}
+	}
+
+	return CheckResult{
+		Name:   name,
+		Status: StatusSkip,
+		Detail: "neither binlog_rows_query_log_events nor binlog_annotate_row_events is available on this server",
 	}
 }
 

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -335,9 +335,17 @@ func checkBinlogRetention(db *sql.DB) CheckResult {
 func checkStatementCapture(db *sql.DB) CheckResult {
 	const name = "Statement capture (query_text)"
 	isOn := func(val string) bool { return val == "1" || strings.EqualFold(val, "ON") }
+	// Only MySQL error 1193 (unknown system variable) means the variable is
+	// genuinely absent; any other failure is a read problem and must surface
+	// the real error rather than a fabricated flavor diagnosis.
+	isUnknownVar := func(err error) bool {
+		var myErr *mysql.MySQLError
+		return errors.As(err, &myErr) && myErr.Number == 1193
+	}
 
 	var val string
-	if err := db.QueryRow("SELECT @@binlog_rows_query_log_events").Scan(&val); err == nil {
+	err := db.QueryRow("SELECT @@binlog_rows_query_log_events").Scan(&val)
+	if err == nil {
 		if isOn(val) {
 			return CheckResult{Name: name, Status: StatusPass, Detail: "binlog_rows_query_log_events=ON"}
 		}
@@ -349,20 +357,40 @@ func checkStatementCapture(db *sql.DB) CheckResult {
 				"  SET PERSIST binlog_rows_query_log_events = ON;",
 		}
 	}
+	if !isUnknownVar(err) {
+		return CheckResult{
+			Name:   name,
+			Status: StatusWarn,
+			Detail: "could not read binlog_rows_query_log_events: " + err.Error(),
+		}
+	}
 
 	// MariaDB names the same capability binlog_annotate_row_events
-	// (default ON since 10.2.4).
-	if err := db.QueryRow("SELECT @@binlog_annotate_row_events").Scan(&val); err == nil {
+	// (default ON since 10.2.4). Note stream capture additionally requires
+	// `--source-flavor mariadb` so the syncer requests ANNOTATE events.
+	err = db.QueryRow("SELECT @@binlog_annotate_row_events").Scan(&val)
+	if err == nil {
 		if isOn(val) {
-			return CheckResult{Name: name, Status: StatusPass, Detail: "binlog_annotate_row_events=ON"}
+			return CheckResult{
+				Name:   name,
+				Status: StatusPass,
+				Detail: "binlog_annotate_row_events=ON (MariaDB; stream capture also needs --source-flavor mariadb)",
+			}
 		}
 		return CheckResult{
 			Name:   name,
 			Status: StatusWarn,
 			Detail: "binlog_annotate_row_events=OFF — events index without the originating SQL statement (query_text stays NULL)",
-			Remediation: "Optional: log the original statement with each row event so `bintrail query` can show it:\n\n" +
+			Remediation: "Optional: log the original statement with each row event so `bintrail query` can show it (stream capture also needs `--source-flavor mariadb`):\n\n" +
 				"  SET GLOBAL binlog_annotate_row_events = ON;\n\n" +
 				"Persist it in my.cnf ([mysqld] binlog_annotate_row_events=ON) to survive restarts.",
+		}
+	}
+	if !isUnknownVar(err) {
+		return CheckResult{
+			Name:   name,
+			Status: StatusWarn,
+			Detail: "could not read binlog_annotate_row_events: " + err.Error(),
 		}
 	}
 

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -341,6 +341,61 @@ func TestCheckBinlogRetention(t *testing.T) {
 	}
 }
 
+// TestCheckStatementCapture pins the #699 advisory check: PASS when the
+// source logs statement text, WARN (never FAIL) when it doesn't, MariaDB
+// fallback probe when the MySQL variable is absent, SKIP when neither exists.
+func TestCheckStatementCapture(t *testing.T) {
+	tests := []struct {
+		name            string
+		mysqlVar        mockSQLScalar  // SELECT @@binlog_rows_query_log_events
+		mariaVar        *mockSQLScalar // SELECT @@binlog_annotate_row_events (only probed on mysqlVar error)
+		wantStatus      CheckStatus
+		wantDetailFrag  string
+		wantRemediation bool
+	}{
+		{"mysql ON", row("1"), nil, StatusPass, "binlog_rows_query_log_events=ON", false},
+		{"mysql OFF", row("0"), nil, StatusWarn, "binlog_rows_query_log_events=OFF", true},
+		{"mariadb ON", errResp("Error 1193: Unknown system variable"), ptr(row("1")), StatusPass, "binlog_annotate_row_events=ON", false},
+		{"mariadb OFF", errResp("Error 1193: Unknown system variable"), ptr(row("OFF")), StatusWarn, "binlog_annotate_row_events=OFF", true},
+		{"neither variable", errResp("Error 1193"), ptr(errResp("Error 1193")), StatusSkip, "neither", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("sqlmock: %v", err)
+			}
+			defer db.Close()
+
+			exp := mock.ExpectQuery("SELECT @@binlog_rows_query_log_events")
+			tt.mysqlVar.apply(exp, "@@binlog_rows_query_log_events")
+			if tt.mariaVar != nil {
+				mexp := mock.ExpectQuery("SELECT @@binlog_annotate_row_events")
+				tt.mariaVar.apply(mexp, "@@binlog_annotate_row_events")
+			}
+
+			got := checkStatementCapture(db)
+			if got.Status != tt.wantStatus {
+				t.Errorf("Status = %q, want %q (detail=%q)", got.Status, tt.wantStatus, got.Detail)
+			}
+			if !strings.Contains(got.Detail, tt.wantDetailFrag) {
+				t.Errorf("Detail = %q, want substring %q", got.Detail, tt.wantDetailFrag)
+			}
+			if tt.wantRemediation && got.Remediation == "" {
+				t.Error("expected remediation but got none")
+			}
+			if got.Status == StatusFail {
+				t.Error("statement capture is optional — the check must never FAIL")
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("unmet expectations: %v", err)
+			}
+		})
+	}
+}
+
+func ptr[T any](v T) *T { return &v }
+
 // mockSQLScalar is a single-value SELECT mock — value xor err.
 type mockSQLScalar struct {
 	value string

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -348,16 +348,20 @@ func TestCheckStatementCapture(t *testing.T) {
 	tests := []struct {
 		name            string
 		mysqlVar        mockSQLScalar  // SELECT @@binlog_rows_query_log_events
-		mariaVar        *mockSQLScalar // SELECT @@binlog_annotate_row_events (only probed on mysqlVar error)
+		mariaVar        *mockSQLScalar // SELECT @@binlog_annotate_row_events (only probed on a 1193 from mysqlVar)
 		wantStatus      CheckStatus
 		wantDetailFrag  string
 		wantRemediation bool
 	}{
 		{"mysql ON", row("1"), nil, StatusPass, "binlog_rows_query_log_events=ON", false},
 		{"mysql OFF", row("0"), nil, StatusWarn, "binlog_rows_query_log_events=OFF", true},
-		{"mariadb ON", errResp("Error 1193: Unknown system variable"), ptr(row("1")), StatusPass, "binlog_annotate_row_events=ON", false},
-		{"mariadb OFF", errResp("Error 1193: Unknown system variable"), ptr(row("OFF")), StatusWarn, "binlog_annotate_row_events=OFF", true},
-		{"neither variable", errResp("Error 1193"), ptr(errResp("Error 1193")), StatusSkip, "neither", false},
+		{"mariadb ON", mysqlErrResp(1193, "Unknown system variable 'binlog_rows_query_log_events'"), ptr(row("1")), StatusPass, "binlog_annotate_row_events=ON", false},
+		{"mariadb OFF", mysqlErrResp(1193, "Unknown system variable 'binlog_rows_query_log_events'"), ptr(row("OFF")), StatusWarn, "binlog_annotate_row_events=OFF", true},
+		{"neither variable", mysqlErrResp(1193, "Unknown system variable"), ptr(mysqlErrResp(1193, "Unknown system variable")), StatusSkip, "neither", false},
+		// A non-1193 failure is a READ problem, not a flavor fact — the real
+		// error must surface instead of a fabricated "not available" claim.
+		{"transient read failure", errResp("driver: bad connection"), nil, StatusWarn, "could not read binlog_rows_query_log_events: driver: bad connection", false},
+		{"mariadb probe read failure", mysqlErrResp(1193, "Unknown system variable"), ptr(errResp("driver: bad connection")), StatusWarn, "could not read binlog_annotate_row_events: driver: bad connection", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -404,6 +408,12 @@ type mockSQLScalar struct {
 
 func row(v string) mockSQLScalar       { return mockSQLScalar{value: v} }
 func errResp(msg string) mockSQLScalar { return mockSQLScalar{err: errors.New(msg)} }
+
+// mysqlErrResp mocks a typed MySQL server error (e.g. 1193 unknown system
+// variable) so checks that discriminate by error number can be exercised.
+func mysqlErrResp(number uint16, msg string) mockSQLScalar {
+	return mockSQLScalar{err: &mysql.MySQLError{Number: number, Message: msg}}
+}
 
 func (r mockSQLScalar) apply(exp *sqlmock.ExpectedQuery, col string) {
 	if r.err != nil {

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -16,6 +16,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/dbtrail/dbtrail/internal/metadata"
 )
@@ -145,6 +146,45 @@ func ChangedColumns(before, after map[string]any) []string {
 	}
 	sort.Strings(changed)
 	return changed
+}
+
+// ─── Query-text sanitization (#699) ──────────────────────────────────────────
+
+// MaxQueryTextBytes caps a captured statement's stored size. ROWS_QUERY/
+// ANNOTATE events carry the FULL original statement — a bulk INSERT can run to
+// megabytes — and every row event of that statement carries the text, so an
+// uncapped statement would bloat the batch INSERT on the index path and the
+// buffer/payload Parquet on the BYOS path. 16 KiB keeps any realistic
+// hand-written or ORM statement intact; only bulk-statement tails are cut.
+const MaxQueryTextBytes = 16 * 1024
+
+// QueryTextTruncationMarker is appended to a capped statement so a forensics
+// reader can tell a truncated statement from a complete one. (A truncated
+// statement is deliberately NOT fed to STATEMENT_DIGEST — it usually ends
+// mid-token and would not parse.)
+const QueryTextTruncationMarker = " /* bintrail:truncated */"
+
+// SanitizeQueryText prepares a captured statement for storage: it replaces
+// invalid UTF-8 (a _binary'...' literal embeds raw bytes, which MySQL strict
+// mode would reject with error 1366, aborting the whole batch INSERT) and
+// caps the byte length at a rune boundary, appending
+// QueryTextTruncationMarker when cut. Applied ONCE at the capture boundary
+// (the parsers' ROWS_QUERY/ANNOTATE cases) so every downstream path — index
+// batch INSERT, BYOS buffer accounting, payload Parquet — sees bounded, valid
+// text; the indexer re-applies it as defense in depth.
+func SanitizeQueryText(s string) string {
+	if s == "" {
+		return ""
+	}
+	s = strings.ToValidUTF8(s, "�")
+	if len(s) <= MaxQueryTextBytes {
+		return s
+	}
+	cut := MaxQueryTextBytes
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut] + QueryTextTruncationMarker
 }
 
 // DDLKind identifies the type of DDL statement detected in a binlog QUERY_EVENT.

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -74,8 +74,15 @@ type Event struct {
 	Timestamp    time.Time
 	GTID         string // empty when GTID is not enabled on the source
 	ConnectionID uint32 // MySQL pseudo_thread_id from the transaction's QUERY(BEGIN) event; 0 = unknown
-	Schema       string
-	Table        string
+	// QueryText is the original SQL statement that produced this row event,
+	// captured from the statement's ROWS_QUERY_EVENT (MySQL,
+	// binlog_rows_query_log_events=ON) or ANNOTATE_ROWS event (MariaDB,
+	// binlog_annotate_row_events=ON). Empty when the source does not log it —
+	// capture is opt-in on the source (#699). Statement-scoped: a multi-statement
+	// transaction stamps each statement's own text onto its rows.
+	QueryText string
+	Schema    string
+	Table     string
 	// EventType numeric values are a PERSISTENCE CONTRACT: stored as a number in
 	// binlog_events.event_type and filtered by it. Never renumber existing values.
 	EventType     EventType

--- a/internal/event/querytext_test.go
+++ b/internal/event/querytext_test.go
@@ -1,4 +1,4 @@
-package indexer
+package event
 
 import (
 	"strings"
@@ -6,23 +6,23 @@ import (
 	"unicode/utf8"
 )
 
-// ─── sanitizeQueryText (#699) ─────────────────────────────────────────────────
+// ─── SanitizeQueryText (#699) ─────────────────────────────────────────────────
 
 func TestSanitizeQueryText_passthrough(t *testing.T) {
-	if got := sanitizeQueryText(""); got != "" {
+	if got := SanitizeQueryText(""); got != "" {
 		t.Errorf("empty in, got %q", got)
 	}
 	s := "UPDATE users SET email='a@x' WHERE id=42"
-	if got := sanitizeQueryText(s); got != s {
+	if got := SanitizeQueryText(s); got != s {
 		t.Errorf("short valid statement must pass through unchanged, got %q", got)
 	}
 }
 
 // A _binary'...' literal embeds raw bytes; under strict mode those would 1366
-// the whole batch INSERT. sanitizeQueryText must yield valid UTF-8.
+// the whole batch INSERT. SanitizeQueryText must yield valid UTF-8.
 func TestSanitizeQueryText_invalidUTF8Replaced(t *testing.T) {
 	s := "INSERT INTO t VALUES (_binary'\xff\xfe\x00')"
-	got := sanitizeQueryText(s)
+	got := SanitizeQueryText(s)
 	if !utf8.ValidString(got) {
 		t.Fatalf("output is not valid UTF-8: %q", got)
 	}
@@ -34,17 +34,17 @@ func TestSanitizeQueryText_invalidUTF8Replaced(t *testing.T) {
 func TestSanitizeQueryText_truncatesAtCap(t *testing.T) {
 	// Build a statement well over the cap with a multi-byte rune straddling
 	// the cut point so the rune-boundary backoff is exercised.
-	long := "INSERT INTO t VALUES ('" + strings.Repeat("é", maxQueryTextBytes) + "')"
-	got := sanitizeQueryText(long)
+	long := "INSERT INTO t VALUES ('" + strings.Repeat("é", MaxQueryTextBytes) + "')"
+	got := SanitizeQueryText(long)
 
-	if !strings.HasSuffix(got, queryTextTruncationMarker) {
+	if !strings.HasSuffix(got, QueryTextTruncationMarker) {
 		t.Fatalf("truncated statement must end with the truncation marker, got tail %q", got[len(got)-40:])
 	}
 	if !utf8.ValidString(got) {
 		t.Fatal("truncation must not cut a rune in half")
 	}
-	if len(got) > maxQueryTextBytes+len(queryTextTruncationMarker) {
-		t.Errorf("output length %d exceeds cap %d + marker", len(got), maxQueryTextBytes)
+	if len(got) > MaxQueryTextBytes+len(QueryTextTruncationMarker) {
+		t.Errorf("output length %d exceeds cap %d + marker", len(got), MaxQueryTextBytes)
 	}
 	if !strings.HasPrefix(got, "INSERT INTO t VALUES ('") {
 		t.Error("truncation must preserve the statement head")
@@ -52,8 +52,8 @@ func TestSanitizeQueryText_truncatesAtCap(t *testing.T) {
 }
 
 func TestSanitizeQueryText_exactCapUntouched(t *testing.T) {
-	s := strings.Repeat("a", maxQueryTextBytes)
-	if got := sanitizeQueryText(s); got != s {
+	s := strings.Repeat("a", MaxQueryTextBytes)
+	if got := SanitizeQueryText(s); got != s {
 		t.Errorf("statement exactly at the cap must pass through unchanged (len %d)", len(got))
 	}
 }

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -11,7 +11,6 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
-	"unicode/utf8"
 
 	mysql "github.com/go-sql-driver/mysql"
 
@@ -127,7 +126,7 @@ func (idx *Indexer) insertBatch(batch []event.Event) (int64, error) {
 		if batch[i].QueryText == "" {
 			continue
 		}
-		sanitized[i] = sanitizeQueryText(batch[i].QueryText)
+		sanitized[i] = event.SanitizeQueryText(batch[i].QueryText)
 		if _, ok := seen[sanitized[i]]; !ok {
 			seen[sanitized[i]] = struct{}{}
 			distinct = append(distinct, sanitized[i])
@@ -182,47 +181,61 @@ func (idx *Indexer) insertBatch(batch []event.Event) (int64, error) {
 
 // ─── Query-text enrichment (#699) ─────────────────────────────────────────────
 
-// maxQueryTextBytes caps the stored query_text. ROWS_QUERY/ANNOTATE events
-// carry the FULL original statement — a bulk INSERT can run to megabytes — and
-// every row event of that statement repeats the text in the batch INSERT args,
-// so uncapped text could blow past max_allowed_packet on the index connection
-// and fail the whole batch. 16 KiB keeps any realistic hand-written or ORM
-// statement intact; only bulk-statement tails are cut.
-const maxQueryTextBytes = 16 * 1024
-
-// queryTextTruncationMarker is appended to a capped query_text so a forensics
-// reader can tell a truncated statement from a complete one.
-const queryTextTruncationMarker = " /* bintrail:truncated */"
-
-// sanitizeQueryText prepares a captured statement for storage: it replaces
-// invalid UTF-8 (a _binary'...' literal embeds raw bytes, which strict mode
-// would reject with error 1366, aborting the whole batch INSERT) and caps the
-// byte length at a rune boundary, appending queryTextTruncationMarker when cut.
-func sanitizeQueryText(s string) string {
-	if s == "" {
-		return ""
-	}
-	s = strings.ToValidUTF8(s, "�")
-	if len(s) <= maxQueryTextBytes {
-		return s
-	}
-	cut := maxQueryTextBytes
-	for cut > 0 && !utf8.RuneStart(s[cut]) {
-		cut--
-	}
-	return s[:cut] + queryTextTruncationMarker
-}
-
-// digestStatements resolves each distinct statement text to its
-// STATEMENT_DIGEST() hash in ONE round trip on the index connection
-// (STATEMENT_DIGEST exists on MySQL 8.0+, the index contract floor). The
-// digest is an enrichment: on any failure it degrades to a nil map (all
-// query_hash values NULL) while query_text is still stored, and the failure
-// is logged once per Indexer.
+// digestStatements resolves distinct statement texts to their
+// STATEMENT_DIGEST() hashes on the index connection (STATEMENT_DIGEST exists
+// on MySQL 8.0+, the index contract floor). Texts ending in the truncation
+// marker are skipped up front: a capped statement ends mid-token, so its
+// digest would both fail to parse (MySQL error 3676) and misrepresent the
+// statement's true shape — NULL is the honest value.
+//
+// The happy path is ONE combined SELECT over all texts. That SELECT fails as
+// a unit when ANY single text is unparseable, so on error it falls back to
+// per-text digests — one bad statement can then never null the whole batch's
+// hashes. The digest is an enrichment: every failure degrades to a missing
+// map entry (NULL query_hash) while query_text is still stored; only the
+// all-texts-failed case (e.g. an index without STATEMENT_DIGEST) warns, once
+// per Indexer.
 func (idx *Indexer) digestStatements(texts []string) map[string]string {
-	if len(texts) == 0 {
+	candidates := make([]string, 0, len(texts))
+	for _, t := range texts {
+		if !strings.HasSuffix(t, event.QueryTextTruncationMarker) {
+			candidates = append(candidates, t)
+		}
+	}
+	if len(candidates) == 0 {
 		return nil
 	}
+
+	if out, err := idx.digestCombined(candidates); err == nil {
+		return out
+	}
+
+	out := make(map[string]string, len(candidates))
+	failures := 0
+	var lastErr error
+	for _, t := range candidates {
+		var v sql.NullString
+		if err := idx.db.QueryRow("SELECT STATEMENT_DIGEST(?)", t).Scan(&v); err != nil {
+			failures++
+			lastErr = err
+			continue
+		}
+		if v.Valid {
+			out[t] = v.String
+		}
+	}
+	if failures == len(candidates) {
+		idx.digestWarnOnce.Do(func() {
+			slog.Warn("STATEMENT_DIGEST failed for every statement in a batch — query_hash will be NULL (query_text is unaffected)",
+				"error", lastErr)
+		})
+	}
+	return out
+}
+
+// digestCombined runs the single-round-trip form: one SELECT with one
+// STATEMENT_DIGEST expression per text.
+func (idx *Indexer) digestCombined(texts []string) (map[string]string, error) {
 	var sb strings.Builder
 	sb.WriteString("SELECT STATEMENT_DIGEST(?)")
 	for range len(texts) - 1 {
@@ -238,11 +251,7 @@ func (idx *Indexer) digestStatements(texts []string) map[string]string {
 		ptrs[i] = &vals[i]
 	}
 	if err := idx.db.QueryRow(sb.String(), args...).Scan(ptrs...); err != nil {
-		idx.digestWarnOnce.Do(func() {
-			slog.Warn("STATEMENT_DIGEST unavailable on the index connection — query_hash will be NULL (query_text is unaffected)",
-				"error", err)
-		})
-		return nil
+		return nil, err
 	}
 	out := make(map[string]string, len(texts))
 	for i, t := range texts {
@@ -250,7 +259,7 @@ func (idx *Indexer) digestStatements(texts []string) map[string]string {
 			out[t] = vals[i].String
 		}
 	}
-	return out
+	return out, nil
 }
 
 // ─── Serialisation helpers ────────────────────────────────────────────────────

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
+	"unicode/utf8"
 
 	mysql "github.com/go-sql-driver/mysql"
 
@@ -26,6 +27,18 @@ type Indexer struct {
 	// digestWarnOnce rate-limits the STATEMENT_DIGEST-unavailable warning to
 	// one line per Indexer — without it a non-8.0 index would warn every batch.
 	digestWarnOnce sync.Once
+	// digestPartialWarnOnce rate-limits the some-statements-failed warning:
+	// a systematic-but-partial condition (one application's statements always
+	// tripping the digest) must be discoverable without waiting for the
+	// all-failed case, but must not warn on every batch either.
+	digestPartialWarnOnce sync.Once
+	// digestUnavailable short-circuits digesting for the Indexer's lifetime
+	// once the index has proven it lacks STATEMENT_DIGEST entirely (MySQL
+	// error 1305, unknown function — e.g. a MariaDB index outside the 8.0+
+	// contract). Without it a long-lived stream daemon would pay one failed
+	// combined SELECT plus N failed per-text SELECTs on every batch, forever,
+	// after its single warning line.
+	digestUnavailable bool
 }
 
 // New creates an Indexer writing to db with the given batch size.
@@ -184,18 +197,23 @@ func (idx *Indexer) insertBatch(batch []event.Event) (int64, error) {
 // digestStatements resolves distinct statement texts to their
 // STATEMENT_DIGEST() hashes on the index connection (STATEMENT_DIGEST exists
 // on MySQL 8.0+, the index contract floor). Texts ending in the truncation
-// marker are skipped up front: a capped statement ends mid-token, so its
-// digest would both fail to parse (MySQL error 3676) and misrepresent the
-// statement's true shape — NULL is the honest value.
+// marker are skipped up front: a truncated fragment misrepresents the
+// statement's true shape — NULL is the honest value — and it usually ends
+// mid-token, failing to parse anyway (MySQL error 3676).
 //
 // The happy path is ONE combined SELECT over all texts. That SELECT fails as
 // a unit when ANY single text is unparseable, so on error it falls back to
 // per-text digests — one bad statement can then never null the whole batch's
 // hashes. The digest is an enrichment: every failure degrades to a missing
-// map entry (NULL query_hash) while query_text is still stored; only the
-// all-texts-failed case (e.g. an index without STATEMENT_DIGEST) warns, once
-// per Indexer.
+// map entry (NULL query_hash) while query_text is still stored. Failures are
+// surfaced without flooding: per-statement details at debug, plus one
+// warning per Indexer for the first partial failure and one for the first
+// all-failed batch; a missing STATEMENT_DIGEST function (1305) additionally
+// disables digesting for the Indexer's lifetime.
 func (idx *Indexer) digestStatements(texts []string) map[string]string {
+	if idx.digestUnavailable {
+		return nil
+	}
 	candidates := make([]string, 0, len(texts))
 	for _, t := range texts {
 		if !strings.HasSuffix(t, event.QueryTextTruncationMarker) {
@@ -206,11 +224,24 @@ func (idx *Indexer) digestStatements(texts []string) map[string]string {
 		return nil
 	}
 
-	if out, err := idx.digestCombined(candidates); err == nil {
+	out, combinedErr := idx.digestCombined(candidates)
+	if combinedErr == nil {
 		return out
 	}
+	// ER_SP_DOES_NOT_EXIST: the index simply has no STATEMENT_DIGEST function
+	// — no per-text retry can succeed now or later. Warn once and stop trying.
+	var myErr *mysql.MySQLError
+	if errors.As(combinedErr, &myErr) && myErr.Number == 1305 {
+		idx.digestUnavailable = true
+		idx.digestWarnOnce.Do(func() {
+			slog.Warn("STATEMENT_DIGEST is not available on the index connection — query_hash will be NULL for all events (query_text is unaffected)",
+				"error", combinedErr)
+		})
+		return nil
+	}
+	slog.Debug("combined STATEMENT_DIGEST failed — falling back to per-text digests", "error", combinedErr)
 
-	out := make(map[string]string, len(candidates))
+	out = make(map[string]string, len(candidates))
 	failures := 0
 	var lastErr error
 	for _, t := range candidates {
@@ -218,19 +249,44 @@ func (idx *Indexer) digestStatements(texts []string) map[string]string {
 		if err := idx.db.QueryRow("SELECT STATEMENT_DIGEST(?)", t).Scan(&v); err != nil {
 			failures++
 			lastErr = err
+			slog.Debug("STATEMENT_DIGEST failed for one statement — query_hash stays NULL for it",
+				"error", err, "statement_prefix", truncateForLog(t))
 			continue
 		}
 		if v.Valid {
 			out[t] = v.String
 		}
 	}
-	if failures == len(candidates) {
+	switch {
+	case failures == len(candidates):
 		idx.digestWarnOnce.Do(func() {
 			slog.Warn("STATEMENT_DIGEST failed for every statement in a batch — query_hash will be NULL (query_text is unaffected)",
 				"error", lastErr)
 		})
+	case failures > 0:
+		// Partial failure: a systematic condition affecting one application's
+		// statements would otherwise stay invisible until someone notices
+		// NULL hashes in query results months later.
+		idx.digestPartialWarnOnce.Do(func() {
+			slog.Warn("STATEMENT_DIGEST failed for some statements — their query_hash stays NULL (per-statement details at debug level; this warning prints once)",
+				"failed", failures, "of", len(candidates), "error", lastErr)
+		})
 	}
 	return out
+}
+
+// truncateForLog bounds a statement text for a debug log line, cutting at a
+// rune boundary (the input is sanitized UTF-8; keep it valid).
+func truncateForLog(s string) string {
+	const max = 120
+	if len(s) <= max {
+		return s
+	}
+	cut := max
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut] + "…"
 }
 
 // digestCombined runs the single-round-trip form: one SELECT with one
@@ -369,9 +425,11 @@ func EnsureSchema(db *sql.DB) error {
 	// binlog_annotate_row_events), and its STATEMENT_DIGEST computed on the
 	// index connection at insert time. Nullable: rows indexed before this
 	// column existed, or while capture is off at the source, read back NULL.
-	// MEDIUMTEXT (not TEXT): a bulk statement easily exceeds 64 KB and a 1406
-	// under strict mode would abort the whole batch INSERT; the indexer also
-	// caps the stored text at maxQueryTextBytes as defense in depth.
+	// event.SanitizeQueryText caps every text at event.MaxQueryTextBytes
+	// (16 KiB) before it reaches this column; MEDIUMTEXT (not TEXT) is
+	// headroom on top of that cap, so raising the cap — or any future path
+	// that bypasses sanitization — cannot turn into a strict-mode 1406 that
+	// aborts a whole batch INSERT.
 	if err := ensureColumn(db, "binlog_events", "query_text",
 		`ALTER TABLE binlog_events ADD COLUMN query_text MEDIUMTEXT DEFAULT NULL COMMENT 'original SQL statement from ROWS_QUERY/ANNOTATE_ROWS; NULL unless binlog_rows_query_log_events (MySQL) / binlog_annotate_row_events (MariaDB) is ON at the source (#699)' AFTER schema_version`,
 	); err != nil {

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -8,7 +8,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
+	"sync"
+	"unicode/utf8"
 
 	mysql "github.com/go-sql-driver/mysql"
 
@@ -21,6 +24,9 @@ type Indexer struct {
 	db        *sql.DB
 	batchSize int
 	onDDL     func(ev event.Event) error
+	// digestWarnOnce rate-limits the STATEMENT_DIGEST-unavailable warning to
+	// one line per Indexer — without it a non-8.0 index would warn every batch.
+	digestWarnOnce sync.Once
 }
 
 // New creates an Indexer writing to db with the given batch size.
@@ -104,14 +110,32 @@ func (idx *Indexer) BatchSize() int {
 // event_id and pk_hash are omitted — they are AUTO_INCREMENT and STORED
 // generated respectively, so MySQL computes them on write.
 func (idx *Indexer) insertBatch(batch []event.Event) (int64, error) {
-	// 14 placeholders per row
-	valClause := strings.TrimRight(strings.Repeat("(?,?,?,?,?,?,?,?,?,?,?,?,?,?),", len(batch)), ",")
+	// 16 placeholders per row
+	valClause := strings.TrimRight(strings.Repeat("(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?),", len(batch)), ",")
 	insertSQL := `INSERT INTO binlog_events ` +
 		`(binlog_file, start_pos, end_pos, event_timestamp, gtid, connection_id, ` +
 		`schema_name, table_name, event_type, pk_values, ` +
-		`changed_columns, row_before, row_after, schema_version) VALUES ` + valClause
+		`changed_columns, row_before, row_after, schema_version, query_text, query_hash) VALUES ` + valClause
 
-	args := make([]any, 0, len(batch)*14)
+	// Sanitize each event's captured statement text, then resolve the batch's
+	// DISTINCT texts to STATEMENT_DIGEST hashes in one round trip (#699).
+	// Sanitizing first keeps the stored hash consistent with the stored text.
+	sanitized := make([]string, len(batch))
+	var distinct []string
+	seen := make(map[string]struct{})
+	for i := range batch {
+		if batch[i].QueryText == "" {
+			continue
+		}
+		sanitized[i] = sanitizeQueryText(batch[i].QueryText)
+		if _, ok := seen[sanitized[i]]; !ok {
+			seen[sanitized[i]] = struct{}{}
+			distinct = append(distinct, sanitized[i])
+		}
+	}
+	digests := idx.digestStatements(distinct)
+
+	args := make([]any, 0, len(batch)*16)
 	for i := range batch {
 		ev := &batch[i]
 
@@ -143,6 +167,8 @@ func (idx *Indexer) insertBatch(batch []event.Event) (int64, error) {
 			rowBefore,
 			rowAfter,
 			ev.SchemaVersion,
+			nullOrString(sanitized[i]),
+			nullOrString(digests[sanitized[i]]),
 		)
 	}
 
@@ -152,6 +178,79 @@ func (idx *Indexer) insertBatch(batch []event.Event) (int64, error) {
 	}
 	n, _ := result.RowsAffected()
 	return n, nil
+}
+
+// ─── Query-text enrichment (#699) ─────────────────────────────────────────────
+
+// maxQueryTextBytes caps the stored query_text. ROWS_QUERY/ANNOTATE events
+// carry the FULL original statement — a bulk INSERT can run to megabytes — and
+// every row event of that statement repeats the text in the batch INSERT args,
+// so uncapped text could blow past max_allowed_packet on the index connection
+// and fail the whole batch. 16 KiB keeps any realistic hand-written or ORM
+// statement intact; only bulk-statement tails are cut.
+const maxQueryTextBytes = 16 * 1024
+
+// queryTextTruncationMarker is appended to a capped query_text so a forensics
+// reader can tell a truncated statement from a complete one.
+const queryTextTruncationMarker = " /* bintrail:truncated */"
+
+// sanitizeQueryText prepares a captured statement for storage: it replaces
+// invalid UTF-8 (a _binary'...' literal embeds raw bytes, which strict mode
+// would reject with error 1366, aborting the whole batch INSERT) and caps the
+// byte length at a rune boundary, appending queryTextTruncationMarker when cut.
+func sanitizeQueryText(s string) string {
+	if s == "" {
+		return ""
+	}
+	s = strings.ToValidUTF8(s, "�")
+	if len(s) <= maxQueryTextBytes {
+		return s
+	}
+	cut := maxQueryTextBytes
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut] + queryTextTruncationMarker
+}
+
+// digestStatements resolves each distinct statement text to its
+// STATEMENT_DIGEST() hash in ONE round trip on the index connection
+// (STATEMENT_DIGEST exists on MySQL 8.0+, the index contract floor). The
+// digest is an enrichment: on any failure it degrades to a nil map (all
+// query_hash values NULL) while query_text is still stored, and the failure
+// is logged once per Indexer.
+func (idx *Indexer) digestStatements(texts []string) map[string]string {
+	if len(texts) == 0 {
+		return nil
+	}
+	var sb strings.Builder
+	sb.WriteString("SELECT STATEMENT_DIGEST(?)")
+	for range len(texts) - 1 {
+		sb.WriteString(", STATEMENT_DIGEST(?)")
+	}
+	args := make([]any, len(texts))
+	for i, t := range texts {
+		args[i] = t
+	}
+	vals := make([]sql.NullString, len(texts))
+	ptrs := make([]any, len(texts))
+	for i := range vals {
+		ptrs[i] = &vals[i]
+	}
+	if err := idx.db.QueryRow(sb.String(), args...).Scan(ptrs...); err != nil {
+		idx.digestWarnOnce.Do(func() {
+			slog.Warn("STATEMENT_DIGEST unavailable on the index connection — query_hash will be NULL (query_text is unaffected)",
+				"error", err)
+		})
+		return nil
+	}
+	out := make(map[string]string, len(texts))
+	for i, t := range texts {
+		if vals[i].Valid {
+			out[t] = vals[i].String
+		}
+	}
+	return out
 }
 
 // ─── Serialisation helpers ────────────────────────────────────────────────────
@@ -252,6 +351,25 @@ func EnsureSchema(db *sql.DB) error {
 	// existing rows + MySQL snapshots read back as "not identity" with no migration.
 	if err := ensureColumn(db, "schema_snapshots", "is_identity_always",
 		`ALTER TABLE schema_snapshots ADD COLUMN is_identity_always TINYINT(1) NOT NULL DEFAULT 0 COMMENT '1 if PostgreSQL GENERATED ALWAYS AS IDENTITY; 0 for MySQL (#557)' AFTER pg_type_mod`,
+	); err != nil {
+		return err
+	}
+	// query_text/query_hash carry the original SQL statement that produced each
+	// row event (#699): the text from the binlog's ROWS_QUERY/ANNOTATE_ROWS
+	// event (opt-in on the source via binlog_rows_query_log_events /
+	// binlog_annotate_row_events), and its STATEMENT_DIGEST computed on the
+	// index connection at insert time. Nullable: rows indexed before this
+	// column existed, or while capture is off at the source, read back NULL.
+	// MEDIUMTEXT (not TEXT): a bulk statement easily exceeds 64 KB and a 1406
+	// under strict mode would abort the whole batch INSERT; the indexer also
+	// caps the stored text at maxQueryTextBytes as defense in depth.
+	if err := ensureColumn(db, "binlog_events", "query_text",
+		`ALTER TABLE binlog_events ADD COLUMN query_text MEDIUMTEXT DEFAULT NULL COMMENT 'original SQL statement from ROWS_QUERY/ANNOTATE_ROWS; NULL unless binlog_rows_query_log_events (MySQL) / binlog_annotate_row_events (MariaDB) is ON at the source (#699)' AFTER schema_version`,
+	); err != nil {
+		return err
+	}
+	if err := ensureColumn(db, "binlog_events", "query_hash",
+		`ALTER TABLE binlog_events ADD COLUMN query_hash CHAR(64) DEFAULT NULL COMMENT 'STATEMENT_DIGEST(query_text) computed on the index connection at index time; groups statements by normalized shape (#699)' AFTER query_text`,
 	); err != nil {
 		return err
 	}

--- a/internal/indexer/querytext_integration_test.go
+++ b/internal/indexer/querytext_integration_test.go
@@ -5,9 +5,11 @@ package indexer
 import (
 	"database/sql"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/dbtrail/dbtrail/internal/event"
 	"github.com/dbtrail/dbtrail/internal/parser"
 	"github.com/dbtrail/dbtrail/internal/testutil"
 )
@@ -75,7 +77,7 @@ func TestInsertBatch_queryTextAndDigestRoundTrip(t *testing.T) {
 	batch := []parser.Event{
 		mkEvent("1", "INSERT INTO orders (id) VALUES (1)"),
 		mkEvent("2", "INSERT INTO orders (id) VALUES (2)"), // same shape, different literal
-		mkEvent("3", ""),                                   // statement not captured
+		mkEvent("3", ""), // statement not captured
 	}
 	if _, err := idx.InsertBatch(batch); err != nil {
 		t.Fatalf("InsertBatch: %v", err)
@@ -124,5 +126,75 @@ func TestInsertBatch_queryTextAndDigestRoundTrip(t *testing.T) {
 	if byPK["3"].text.Valid || byPK["3"].hash.Valid {
 		t.Errorf("uncaptured statement must store NULL/NULL, got text=%+v hash=%+v",
 			byPK["3"].text, byPK["3"].hash)
+	}
+}
+
+// TestInsertBatch_digestPoisonAndTruncationFallback pins the degradation
+// contract the #699 review forced: (a) a truncated statement (ends mid-token)
+// is never digested — NULL hash, text still stored; (b) an unparseable text
+// fails the combined digest SELECT as a unit (MySQL error 3676), and the
+// per-text fallback must still hash the batch's parseable statements instead
+// of nulling the whole batch.
+func TestInsertBatch_digestPoisonAndTruncationFallback(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	idx := New(db, 1000)
+	ts := time.Date(2026, 2, 19, 12, 0, 0, 0, time.UTC)
+	mkEvent := func(pk, queryText string) parser.Event {
+		return parser.Event{
+			BinlogFile: "binlog.000001", StartPos: 100, EndPos: 200,
+			Timestamp: ts, Schema: "mydb", Table: "orders",
+			EventType: parser.EventInsert, PKValues: pk,
+			RowAfter:  map[string]any{"id": pk},
+			QueryText: queryText,
+		}
+	}
+
+	// A statement over the cap: SanitizeQueryText truncates it mid-token and
+	// appends the marker — it must be stored truncated and NOT digested.
+	huge := "INSERT INTO orders (blob_col) VALUES ('" + strings.Repeat("x", event.MaxQueryTextBytes) + "')"
+	batch := []parser.Event{
+		mkEvent("1", "INSERT INTO orders (id) VALUES (1)"), // parseable
+		mkEvent("2", "bad ((( not sql"),                    // poisons the combined SELECT (3676)
+		mkEvent("3", huge),                                 // truncated → skipped from digesting
+	}
+	if _, err := idx.InsertBatch(batch); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+
+	rows, err := db.Query(`SELECT pk_values, query_text, query_hash FROM binlog_events ORDER BY event_id`)
+	if err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	defer rows.Close()
+	type got struct{ text, hash sql.NullString }
+	byPK := map[string]got{}
+	for rows.Next() {
+		var pk string
+		var g got
+		if err := rows.Scan(&pk, &g.text, &g.hash); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		byPK[pk] = g
+	}
+
+	// (b) the parseable statement keeps its hash despite the poisoned batch.
+	if !byPK["1"].hash.Valid {
+		t.Error("parseable statement lost its digest to a poisoned batch — per-text fallback broken")
+	}
+	// The unparseable text stores NULL hash but keeps its text.
+	if byPK["2"].hash.Valid {
+		t.Errorf("unparseable statement must have NULL query_hash, got %q", byPK["2"].hash.String)
+	}
+	if !byPK["2"].text.Valid {
+		t.Error("unparseable statement must still store its query_text")
+	}
+	// (a) truncated: text stored with the marker, hash NULL.
+	if !byPK["3"].text.Valid || !strings.HasSuffix(byPK["3"].text.String, event.QueryTextTruncationMarker) {
+		t.Errorf("truncated statement must be stored ending in the truncation marker")
+	}
+	if byPK["3"].hash.Valid {
+		t.Errorf("truncated statement must never be digested (mid-token text), got %q", byPK["3"].hash.String)
 	}
 }

--- a/internal/indexer/querytext_integration_test.go
+++ b/internal/indexer/querytext_integration_test.go
@@ -1,0 +1,128 @@
+//go:build integration
+
+package indexer
+
+import (
+	"database/sql"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/parser"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestEnsureSchemaAddsQueryTextColumns mirrors the flavor/source_health
+// migration tests: simulate a pre-#699 install by dropping the columns, then
+// assert EnsureSchema restores them (nullable, right types) and is idempotent.
+func TestEnsureSchemaAddsQueryTextColumns(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	testutil.MustExec(t, db, `ALTER TABLE binlog_events DROP COLUMN query_hash`)
+	testutil.MustExec(t, db, `ALTER TABLE binlog_events DROP COLUMN query_text`)
+
+	if err := EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	for col, wantType := range map[string]string{
+		"query_text": "mediumtext",
+		"query_hash": "char",
+	} {
+		var dataType, isNullable string
+		err := db.QueryRow(`SELECT DATA_TYPE, IS_NULLABLE FROM information_schema.COLUMNS
+			WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'binlog_events' AND COLUMN_NAME = ?`,
+			col).Scan(&dataType, &isNullable)
+		if err != nil {
+			t.Fatalf("column %s not found after EnsureSchema: %v", col, err)
+		}
+		if dataType != wantType {
+			t.Errorf("%s DATA_TYPE = %q, want %q", col, dataType, wantType)
+		}
+		if isNullable != "YES" {
+			t.Errorf("%s IS_NULLABLE = %q, want YES (pre-#699 rows must read back NULL)", col, isNullable)
+		}
+	}
+
+	// Second run must be a no-op.
+	if err := EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema (second run): %v", err)
+	}
+}
+
+// TestInsertBatch_queryTextAndDigestRoundTrip drives the #699 write path
+// against a real index MySQL: query_text round-trips, query_hash is a real
+// STATEMENT_DIGEST (64-hex, computed on the index connection), same-shape
+// statements with different literals collapse to the SAME hash, and events
+// without a captured statement store NULL in both columns.
+func TestInsertBatch_queryTextAndDigestRoundTrip(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	idx := New(db, 1000)
+	ts := time.Date(2026, 2, 19, 12, 0, 0, 0, time.UTC)
+	mkEvent := func(pk, queryText string) parser.Event {
+		return parser.Event{
+			BinlogFile: "binlog.000001", StartPos: 100, EndPos: 200,
+			Timestamp: ts, Schema: "mydb", Table: "orders",
+			EventType: parser.EventInsert, PKValues: pk,
+			RowAfter:  map[string]any{"id": pk},
+			QueryText: queryText,
+		}
+	}
+
+	batch := []parser.Event{
+		mkEvent("1", "INSERT INTO orders (id) VALUES (1)"),
+		mkEvent("2", "INSERT INTO orders (id) VALUES (2)"), // same shape, different literal
+		mkEvent("3", ""),                                   // statement not captured
+	}
+	if _, err := idx.InsertBatch(batch); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+
+	rows, err := db.Query(`SELECT pk_values, query_text, query_hash
+		FROM binlog_events ORDER BY event_id`)
+	if err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	defer rows.Close()
+
+	type got struct {
+		text, hash sql.NullString
+	}
+	byPK := map[string]got{}
+	for rows.Next() {
+		var pk string
+		var g got
+		if err := rows.Scan(&pk, &g.text, &g.hash); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		byPK[pk] = g
+	}
+	if len(byPK) != 3 {
+		t.Fatalf("rows = %d, want 3", len(byPK))
+	}
+
+	hexRe := regexp.MustCompile(`^[0-9a-f]{64}$`)
+	for _, pk := range []string{"1", "2"} {
+		g := byPK[pk]
+		if !g.text.Valid {
+			t.Fatalf("pk %s: query_text is NULL, want the captured statement", pk)
+		}
+		if !g.hash.Valid || !hexRe.MatchString(g.hash.String) {
+			t.Errorf("pk %s: query_hash = %+v, want a 64-hex STATEMENT_DIGEST", pk, g.hash)
+		}
+	}
+	if byPK["1"].text.String == byPK["2"].text.String {
+		t.Error("distinct statements must store distinct query_text")
+	}
+	if byPK["1"].hash.String != byPK["2"].hash.String {
+		t.Errorf("same-shape statements must share one digest: %q vs %q",
+			byPK["1"].hash.String, byPK["2"].hash.String)
+	}
+	if byPK["3"].text.Valid || byPK["3"].hash.Valid {
+		t.Errorf("uncaptured statement must store NULL/NULL, got text=%+v hash=%+v",
+			byPK["3"].text, byPK["3"].hash)
+	}
+}

--- a/internal/indexer/querytext_test.go
+++ b/internal/indexer/querytext_test.go
@@ -1,0 +1,59 @@
+package indexer
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// ─── sanitizeQueryText (#699) ─────────────────────────────────────────────────
+
+func TestSanitizeQueryText_passthrough(t *testing.T) {
+	if got := sanitizeQueryText(""); got != "" {
+		t.Errorf("empty in, got %q", got)
+	}
+	s := "UPDATE users SET email='a@x' WHERE id=42"
+	if got := sanitizeQueryText(s); got != s {
+		t.Errorf("short valid statement must pass through unchanged, got %q", got)
+	}
+}
+
+// A _binary'...' literal embeds raw bytes; under strict mode those would 1366
+// the whole batch INSERT. sanitizeQueryText must yield valid UTF-8.
+func TestSanitizeQueryText_invalidUTF8Replaced(t *testing.T) {
+	s := "INSERT INTO t VALUES (_binary'\xff\xfe\x00')"
+	got := sanitizeQueryText(s)
+	if !utf8.ValidString(got) {
+		t.Fatalf("output is not valid UTF-8: %q", got)
+	}
+	if !strings.Contains(got, "INSERT INTO t VALUES") {
+		t.Errorf("statement head must survive sanitization, got %q", got)
+	}
+}
+
+func TestSanitizeQueryText_truncatesAtCap(t *testing.T) {
+	// Build a statement well over the cap with a multi-byte rune straddling
+	// the cut point so the rune-boundary backoff is exercised.
+	long := "INSERT INTO t VALUES ('" + strings.Repeat("é", maxQueryTextBytes) + "')"
+	got := sanitizeQueryText(long)
+
+	if !strings.HasSuffix(got, queryTextTruncationMarker) {
+		t.Fatalf("truncated statement must end with the truncation marker, got tail %q", got[len(got)-40:])
+	}
+	if !utf8.ValidString(got) {
+		t.Fatal("truncation must not cut a rune in half")
+	}
+	if len(got) > maxQueryTextBytes+len(queryTextTruncationMarker) {
+		t.Errorf("output length %d exceeds cap %d + marker", len(got), maxQueryTextBytes)
+	}
+	if !strings.HasPrefix(got, "INSERT INTO t VALUES ('") {
+		t.Error("truncation must preserve the statement head")
+	}
+}
+
+func TestSanitizeQueryText_exactCapUntouched(t *testing.T) {
+	s := strings.Repeat("a", maxQueryTextBytes)
+	if got := sanitizeQueryText(s); got != s {
+		t.Errorf("statement exactly at the cap must pass through unchanged (len %d)", len(got))
+	}
+}

--- a/internal/indexer/schema.go
+++ b/internal/indexer/schema.go
@@ -120,6 +120,8 @@ func buildBinlogEventsDDL(parts []string, encrypt bool) string {
     row_before      JSON             DEFAULT NULL COMMENT 'full row before image (UPDATE, DELETE)',
     row_after       JSON             DEFAULT NULL COMMENT 'full row after image (INSERT, UPDATE)',
     schema_version  INT UNSIGNED     NOT NULL DEFAULT 0 COMMENT 'snapshot_id from schema_snapshots at index time; enables per-row resolver lookup for recovery',
+    query_text      MEDIUMTEXT       DEFAULT NULL COMMENT 'original SQL statement from ROWS_QUERY/ANNOTATE_ROWS; NULL unless binlog_rows_query_log_events (MySQL) / binlog_annotate_row_events (MariaDB) is ON at the source (#699)',
+    query_hash      CHAR(64)         DEFAULT NULL COMMENT 'STATEMENT_DIGEST(query_text) computed on the index connection at index time; groups statements by normalized shape (#699)',
     PRIMARY KEY (event_id, event_timestamp),
     INDEX idx_row_lookup (schema_name, table_name, event_timestamp),
     INDEX idx_pk_hash    (schema_name, table_name, pk_hash, event_timestamp),

--- a/internal/indexer/schema_test.go
+++ b/internal/indexer/schema_test.go
@@ -25,6 +25,9 @@ func TestBuildBinlogEventsDDL_noEncrypt(t *testing.T) {
 	if !strings.Contains(ddl, "schema_version") {
 		t.Error("expected schema_version column in DDL")
 	}
+	if !strings.Contains(ddl, "query_text") || !strings.Contains(ddl, "query_hash") {
+		t.Error("expected query_text and query_hash columns in DDL (#699)")
+	}
 }
 
 func TestBuildBinlogEventsDDL_withEncrypt(t *testing.T) {

--- a/internal/parquetquery/parquetquery.go
+++ b/internal/parquetquery/parquetquery.go
@@ -703,14 +703,10 @@ func fileArrayLiteral(files []string) string {
 func buildQueryFromFiles(files []string, opts query.Options, cols map[string]bool) (string, []any) {
 	where, args := buildFilters(opts)
 
-	connCol := "connection_id"
-	if !cols["connection_id"] {
-		connCol = "NULL::INT32 AS connection_id"
-	}
-
 	q := "SELECT event_id, binlog_file, start_pos, end_pos, event_timestamp," +
-		" gtid, " + connCol + ", schema_name, table_name, event_type, pk_values," +
-		" changed_columns, row_before, row_after, schema_version" +
+		" gtid, " + optionalCol(cols, "connection_id", "INT32") + ", schema_name, table_name, event_type, pk_values," +
+		" changed_columns, row_before, row_after, schema_version," +
+		" " + optionalCol(cols, "query_text", "VARCHAR") + ", " + optionalCol(cols, "query_hash", "VARCHAR") +
 		" FROM parquet_scan(" + fileArrayLiteral(files) + ", hive_partitioning=true, union_by_name=true)"
 	if len(where) > 0 {
 		q += " WHERE " + strings.Join(where, " AND ")
@@ -750,7 +746,7 @@ func buildUnsortedQuery(path string, opts query.Options) (string, []any) {
 
 	q := "SELECT event_id, binlog_file, start_pos, end_pos, event_timestamp," +
 		" gtid, connection_id, schema_name, table_name, event_type, pk_values," +
-		" changed_columns, row_before, row_after, schema_version" +
+		" changed_columns, row_before, row_after, schema_version, query_text, query_hash" +
 		" FROM parquet_scan('" + safePath + "', union_by_name=true)"
 	if len(where) > 0 {
 		q += " WHERE " + strings.Join(where, " AND ")
@@ -774,7 +770,7 @@ func buildQuery(glob string, opts query.Options) (string, []any) {
 
 	q := "SELECT event_id, binlog_file, start_pos, end_pos, event_timestamp," +
 		" gtid, connection_id, schema_name, table_name, event_type, pk_values," +
-		" changed_columns, row_before, row_after, schema_version" +
+		" changed_columns, row_before, row_after, schema_version, query_text, query_hash" +
 		" FROM parquet_scan('" + safeGlob + "', hive_partitioning=true, union_by_name=true)"
 	if len(where) > 0 {
 		q += " WHERE " + strings.Join(where, " AND ")
@@ -909,22 +905,29 @@ func parquetColumns(ctx context.Context, db *sql.DB, path string) (map[string]bo
 	return cols, nil
 }
 
+// optionalCol returns the bare column name when the scanned parquet source has
+// it, or a typed-NULL alias when absent. This handles backward compatibility
+// when reading archive files written before a schema-adding release (e.g.
+// pre-v0.4.4 files lack connection_id; pre-#699 files lack query_text and
+// query_hash) — parquet_scan with an explicit column list errors when the
+// column exists in NONE of the scanned files, even under union_by_name.
+func optionalCol(cols map[string]bool, name, sqlType string) string {
+	if cols[name] {
+		return name
+	}
+	return "NULL::" + sqlType + " AS " + name
+}
+
 // buildQueryForFile constructs a DuckDB query for a single parquet file,
 // substituting typed NULLs for optional columns not present in the file.
-// This handles backward compatibility when reading archive files written
-// before a schema-adding release (e.g., pre-v0.4.4 files lack connection_id).
 func buildQueryForFile(path string, opts query.Options, cols map[string]bool) (string, []any) {
 	where, args := buildFilters(opts)
 	safePath := strings.ReplaceAll(path, "'", "''")
 
-	connCol := "connection_id"
-	if !cols["connection_id"] {
-		connCol = "NULL::INT32 AS connection_id"
-	}
-
 	q := "SELECT event_id, binlog_file, start_pos, end_pos, event_timestamp," +
-		" gtid, " + connCol + ", schema_name, table_name, event_type, pk_values," +
-		" changed_columns, row_before, row_after, schema_version" +
+		" gtid, " + optionalCol(cols, "connection_id", "INT32") + ", schema_name, table_name, event_type, pk_values," +
+		" changed_columns, row_before, row_after, schema_version," +
+		" " + optionalCol(cols, "query_text", "VARCHAR") + ", " + optionalCol(cols, "query_hash", "VARCHAR") +
 		" FROM parquet_scan('" + safePath + "', hive_partitioning=true, union_by_name=true)"
 	if len(where) > 0 {
 		q += " WHERE " + strings.Join(where, " AND ")
@@ -1016,11 +1019,13 @@ func scanRows(rows *sql.Rows) ([]query.ResultRow, error) {
 			rowBefore      sql.NullString
 			rowAfter       sql.NullString
 			schemaVersion  sql.NullInt32
+			queryText      sql.NullString
+			queryHash      sql.NullString
 		)
 		if err := rows.Scan(
 			&eventID, &binlogFile, &startPos, &endPos, &eventTimestamp,
 			&gtid, &connID, &schemaName, &tableName, &eventType, &pkValues,
-			&changedCols, &rowBefore, &rowAfter, &schemaVersion,
+			&changedCols, &rowBefore, &rowAfter, &schemaVersion, &queryText, &queryHash,
 		); err != nil {
 			return nil, fmt.Errorf("scan parquet result: %w", err)
 		}
@@ -1043,6 +1048,12 @@ func scanRows(rows *sql.Rows) ([]query.ResultRow, error) {
 		if connID.Valid {
 			v := uint32(connID.Int64)
 			r.ConnectionID = &v
+		}
+		if queryText.Valid {
+			r.QueryText = &queryText.String
+		}
+		if queryHash.Valid {
+			r.QueryHash = &queryHash.String
 		}
 		if changedCols.Valid && changedCols.String != "" {
 			_ = json.Unmarshal([]byte(changedCols.String), &r.ChangedColumns)

--- a/internal/parquetquery/parquetquery_test.go
+++ b/internal/parquetquery/parquetquery_test.go
@@ -531,6 +531,27 @@ func TestBuildQueryForFileMissingConnectionID(t *testing.T) {
 	assertContains(t, q, "table_name = ?")
 }
 
+// Pre-#699 archives lack query_text/query_hash — both builders must
+// substitute typed NULLs so old files keep reading back, and select the real
+// columns when present.
+func TestBuildQueryQueryTextSubstitution(t *testing.T) {
+	old := map[string]bool{"connection_id": true} // pre-#699, post-v0.4.4 archive
+	cur := map[string]bool{"connection_id": true, "query_text": true, "query_hash": true}
+
+	q, _ := buildQueryForFile("/tmp/old.parquet", query.Options{Limit: 10}, old)
+	assertContains(t, q, "NULL::VARCHAR AS query_text")
+	assertContains(t, q, "NULL::VARCHAR AS query_hash")
+
+	q2, _ := buildQueryForFile("/tmp/new.parquet", query.Options{Limit: 10}, cur)
+	if strings.Contains(q2, "NULL::VARCHAR AS query_text") || strings.Contains(q2, "NULL::VARCHAR AS query_hash") {
+		t.Errorf("should select the real query_text/query_hash when present, got: %s", q2)
+	}
+
+	q3, _ := buildQueryFromFiles([]string{"s3://b/old.parquet"}, query.Options{Limit: 10}, old)
+	assertContains(t, q3, "NULL::VARCHAR AS query_text")
+	assertContains(t, q3, "NULL::VARCHAR AS query_hash")
+}
+
 // ─── parseFileHour ──────────────────────────────────────────────────────────
 
 func TestParseFileHour(t *testing.T) {

--- a/internal/parquetquery/querytext_roundtrip_test.go
+++ b/internal/parquetquery/querytext_roundtrip_test.go
@@ -1,0 +1,115 @@
+package parquetquery
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/archive"
+	"github.com/dbtrail/dbtrail/internal/baseline"
+	"github.com/dbtrail/dbtrail/internal/query"
+)
+
+// ─── #699 real-file round-trips through Fetch ─────────────────────────────────
+//
+// TestBuildQueryQueryTextSubstitution pins the generated SQL; these two pin
+// the actual DuckDB behavior: a current 17-column archive file round-trips
+// query_text/query_hash through Fetch, and a pre-#699 15-column file — the
+// backward-compat case the column-probe NULL substitution exists for — reads
+// back nil fields with no error.
+
+// writeArchiveFixture writes one parquet file with the given column schema
+// under dir and returns the directory (Fetch takes the dir as source).
+func writeArchiveFixture(t *testing.T, cols []baseline.Column, rows [][2][]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	w, err := baseline.NewWriter(filepath.Join(dir, "events.parquet"), cols, baseline.WriterConfig{Compression: "none"})
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	for _, r := range rows {
+		values, nullFlags := r[0], r[1]
+		nulls := make([]bool, len(nullFlags))
+		for i, f := range nullFlags {
+			nulls[i] = f == "1"
+		}
+		if err := w.WriteRow(values, nulls); err != nil {
+			t.Fatalf("WriteRow: %v", err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	return dir
+}
+
+func TestFetch_queryTextRoundTripCurrentSchema(t *testing.T) {
+	if os.Getenv("CGO_ENABLED") == "0" {
+		t.Skip("DuckDB requires CGO")
+	}
+	// Row layout follows archive.BinlogEventColumns (17 columns): the first
+	// row carries a statement + hash, the second has both NULL.
+	stmt := "UPDATE mydb.orders SET amount = 5 WHERE id = 1"
+	hash := "aa11bb22"
+	mkRow := func(id, pk, text, textNull, hashVal, hashNull string) [2][]string {
+		return [2][]string{
+			{id, "binlog.000001", "100", "200", "2026-02-19 14:00:00", "", "", "mydb", "orders", "2", pk, "", `{"id":` + pk + `}`, `{"id":` + pk + `,"amount":5}`, "0", text, hashVal},
+			{"0", "0", "0", "0", "0", "1", "1", "0", "0", "0", "0", "1", "0", "0", "0", textNull, hashNull},
+		}
+	}
+	dir := writeArchiveFixture(t, archive.BinlogEventColumns, [][2][]string{
+		mkRow("1", "1", stmt, "0", hash, "0"),
+		mkRow("2", "2", "", "1", "", "1"),
+	})
+
+	rows, err := Fetch(context.Background(), query.Options{Schema: "mydb", Table: "orders", Limit: 10}, dir)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("rows = %d, want 2", len(rows))
+	}
+	if rows[0].QueryText == nil || *rows[0].QueryText != stmt {
+		t.Errorf("row 1 QueryText = %v, want %q", rows[0].QueryText, stmt)
+	}
+	if rows[0].QueryHash == nil || *rows[0].QueryHash != hash {
+		t.Errorf("row 1 QueryHash = %v, want %q", rows[0].QueryHash, hash)
+	}
+	if rows[1].QueryText != nil || rows[1].QueryHash != nil {
+		t.Errorf("row 2 must read back nil query fields, got %v / %v", rows[1].QueryText, rows[1].QueryHash)
+	}
+}
+
+func TestFetch_oldFifteenColumnArchiveReadsNullQueryText(t *testing.T) {
+	if os.Getenv("CGO_ENABLED") == "0" {
+		t.Skip("DuckDB requires CGO")
+	}
+	// A REAL pre-#699 archive file: the first 15 columns of the current
+	// schema, exactly what every v<0.27 rotate wrote. The probe must detect
+	// the missing columns and substitute typed NULLs — an unguarded SELECT
+	// would Binder-error, the pre-v0.4.4 connection_id incident class.
+	oldCols := archive.BinlogEventColumns[:15]
+	if oldCols[len(oldCols)-1].Name != "schema_version" {
+		t.Fatalf("fixture assumption broken: 15th column is %q, want schema_version", oldCols[len(oldCols)-1].Name)
+	}
+	row := [2][]string{
+		{"1", "binlog.000001", "100", "200", "2026-02-19 14:00:00", "", "", "mydb", "orders", "1", "1", "", "", `{"id":1}`, "0"},
+		{"0", "0", "0", "0", "0", "1", "1", "0", "0", "0", "0", "1", "1", "0", "0"},
+	}
+	dir := writeArchiveFixture(t, oldCols, [][2][]string{row})
+
+	rows, err := Fetch(context.Background(), query.Options{Schema: "mydb", Table: "orders", Limit: 10}, dir)
+	if err != nil {
+		t.Fatalf("Fetch over a pre-#699 archive must not error: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want 1", len(rows))
+	}
+	if rows[0].QueryText != nil || rows[0].QueryHash != nil {
+		t.Errorf("pre-#699 file must read back nil query fields, got %v / %v", rows[0].QueryText, rows[0].QueryHash)
+	}
+	if rows[0].PKValues != "1" {
+		t.Errorf("PKValues = %q, want 1 (scan alignment)", rows[0].PKValues)
+	}
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -114,8 +114,11 @@ func (p *Parser) ParseFile(ctx context.Context, filename string, events chan<- E
 	// ANNOTATE_ROWS event (MariaDB, binlog_annotate_row_events=ON). It is
 	// statement-scoped: each statement's event overwrites the previous one,
 	// and one statement's text covers ALL of its (possibly chained) rows
-	// events. Cleared at QUERY and GTID boundaries so a statement that logged
-	// no text (variable toggled off mid-stream) can never inherit a stale one.
+	// events. Cleared in three places, each load-bearing: QUERY and GTID
+	// boundaries (across transactions), and the STMT_END_F rows event (the
+	// statement boundary WITHIN a transaction — the only clear that stops a
+	// later ROWS_QUERY-less statement in the same transaction from inheriting
+	// stale text when the variable is toggled off mid-transaction).
 	var currentQueryText string
 
 	bp := replication.NewBinlogParser()

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -109,6 +109,14 @@ func (p *Parser) ParseFile(ctx context.Context, filename string, events chan<- E
 	// recent QueryEvent. For DML transactions, this is the QUERY(BEGIN)
 	// event that precedes the row events.
 	var currentConnectionID uint32
+	// currentQueryText holds the original SQL statement from the most recent
+	// ROWS_QUERY_EVENT (MySQL, binlog_rows_query_log_events=ON) or
+	// ANNOTATE_ROWS event (MariaDB, binlog_annotate_row_events=ON). It is
+	// statement-scoped: each statement's event overwrites the previous one,
+	// and one statement's text covers ALL of its (possibly chained) rows
+	// events. Cleared at QUERY and GTID boundaries so a statement that logged
+	// no text (variable toggled off mid-stream) can never inherit a stale one.
+	var currentQueryText string
 
 	bp := replication.NewBinlogParser()
 
@@ -126,15 +134,21 @@ func (p *Parser) ParseFile(ctx context.Context, filename string, events chan<- E
 		switch ev := binlogEv.Event.(type) {
 		case *replication.GTIDEvent:
 			currentGTID = formatGTID(binlogEv.Header.EventType, ev.SID, ev.GNO)
+			currentQueryText = "" // transaction boundary — statement text never crosses it
 
 		case *replication.MariadbGTIDEvent:
 			// MariaDB source: the GTID arrives as domain-server-seq (e.g.
 			// "0-1-100"). ev.GTID.String() returns "" for the zero GTID,
 			// mirroring formatGTID's not-enabled behavior.
 			currentGTID = ev.GTID.String()
+			currentQueryText = ""
 
 		case *replication.QueryEvent:
 			currentConnectionID = ev.SlaveProxyID
+			// A new QUERY (BEGIN of the next transaction, or a DDL) opens a new
+			// statement scope; any ROWS_QUERY text from the previous statement
+			// is stale. The statement's own ROWS_QUERY_EVENT arrives AFTER this.
+			currentQueryText = ""
 			ts := time.Unix(int64(binlogEv.Header.Timestamp), 0).UTC()
 			if ddlEv, ok := parseDDL(p.logger, filename, binlogEv.Header.LogPos, ts, currentGTID, string(ev.Query), p.schemaVersion.Load()); ok {
 				select {
@@ -144,8 +158,18 @@ func (p *Parser) ParseFile(ctx context.Context, filename string, events chan<- E
 				}
 			}
 
+		case *replication.RowsQueryEvent:
+			// The original SQL statement (binlog_rows_query_log_events=ON),
+			// emitted right before the statement's TABLE_MAP + rows events.
+			currentQueryText = string(ev.Query)
+
+		case *replication.MariadbAnnotateRowsEvent:
+			// MariaDB's positional sibling of ROWS_QUERY_EVENT
+			// (binlog_annotate_row_events=ON).
+			currentQueryText = string(ev.Query)
+
 		case *replication.RowsEvent:
-			return handleRows(ctx, p.logger, p.resolver.Load(), &p.filters, binlogEv, ev, filename, currentGTID, currentConnectionID, p.schemaVersion.Load(), events)
+			return handleRows(ctx, p.logger, p.resolver.Load(), &p.filters, binlogEv, ev, filename, currentGTID, currentConnectionID, currentQueryText, p.schemaVersion.Load(), events)
 
 		case *replication.TransactionPayloadEvent:
 			for _, inner := range ev.Events {
@@ -210,6 +234,7 @@ func handleRows(
 	rowsEv *replication.RowsEvent,
 	filename, currentGTID string,
 	connectionID uint32,
+	queryText string,
 	schemaVersion uint32,
 	out chan<- Event,
 ) error {
@@ -280,17 +305,17 @@ func handleRows(
 	case replication.WRITE_ROWS_EVENTv0,
 		replication.WRITE_ROWS_EVENTv1,
 		replication.WRITE_ROWS_EVENTv2:
-		return emitInserts(ctx, logger, resolver, rowsEv.Rows, schema, table, filename, currentGTID, connectionID, startPos, endPos, ts, pkCols, schemaVersion, out)
+		return emitInserts(ctx, logger, resolver, rowsEv.Rows, schema, table, filename, currentGTID, connectionID, queryText, startPos, endPos, ts, pkCols, schemaVersion, out)
 
 	case replication.DELETE_ROWS_EVENTv0,
 		replication.DELETE_ROWS_EVENTv1,
 		replication.DELETE_ROWS_EVENTv2:
-		return emitDeletes(ctx, logger, resolver, rowsEv.Rows, schema, table, filename, currentGTID, connectionID, startPos, endPos, ts, pkCols, schemaVersion, out)
+		return emitDeletes(ctx, logger, resolver, rowsEv.Rows, schema, table, filename, currentGTID, connectionID, queryText, startPos, endPos, ts, pkCols, schemaVersion, out)
 
 	case replication.UPDATE_ROWS_EVENTv0,
 		replication.UPDATE_ROWS_EVENTv1,
 		replication.UPDATE_ROWS_EVENTv2:
-		return emitUpdates(ctx, logger, resolver, rowsEv.Rows, schema, table, filename, currentGTID, connectionID, startPos, endPos, ts, pkCols, schemaVersion, out)
+		return emitUpdates(ctx, logger, resolver, rowsEv.Rows, schema, table, filename, currentGTID, connectionID, queryText, startPos, endPos, ts, pkCols, schemaVersion, out)
 
 	default:
 		// A RowsEvent whose type matches none of the above — e.g. MariaDB's
@@ -319,6 +344,7 @@ func emitInserts(
 	rows [][]any,
 	schema, table, filename, gtid string,
 	connectionID uint32,
+	queryText string,
 	startPos, endPos uint64,
 	ts time.Time,
 	pkCols []metadata.ColumnMeta,
@@ -334,7 +360,7 @@ func emitInserts(
 		}
 		ev := Event{
 			BinlogFile: filename, StartPos: startPos, EndPos: endPos,
-			Timestamp: ts, GTID: gtid, ConnectionID: connectionID,
+			Timestamp: ts, GTID: gtid, ConnectionID: connectionID, QueryText: queryText,
 			Schema: schema, Table: table, EventType: EventInsert,
 			PKValues:      BuildPKValues(pkCols, named),
 			RowAfter:      named,
@@ -356,6 +382,7 @@ func emitDeletes(
 	rows [][]any,
 	schema, table, filename, gtid string,
 	connectionID uint32,
+	queryText string,
 	startPos, endPos uint64,
 	ts time.Time,
 	pkCols []metadata.ColumnMeta,
@@ -371,7 +398,7 @@ func emitDeletes(
 		}
 		ev := Event{
 			BinlogFile: filename, StartPos: startPos, EndPos: endPos,
-			Timestamp: ts, GTID: gtid, ConnectionID: connectionID,
+			Timestamp: ts, GTID: gtid, ConnectionID: connectionID, QueryText: queryText,
 			Schema: schema, Table: table, EventType: EventDelete,
 			PKValues:      BuildPKValues(pkCols, named),
 			RowBefore:     named,
@@ -393,6 +420,7 @@ func emitUpdates(
 	rows [][]any,
 	schema, table, filename, gtid string,
 	connectionID uint32,
+	queryText string,
 	startPos, endPos uint64,
 	ts time.Time,
 	pkCols []metadata.ColumnMeta,
@@ -416,7 +444,7 @@ func emitUpdates(
 		}
 		ev := Event{
 			BinlogFile: filename, StartPos: startPos, EndPos: endPos,
-			Timestamp: ts, GTID: gtid, ConnectionID: connectionID,
+			Timestamp: ts, GTID: gtid, ConnectionID: connectionID, QueryText: queryText,
 			Schema: schema, Table: table, EventType: EventUpdate,
 			PKValues:      BuildPKValues(pkCols, before), // PK from before-image
 			RowBefore:     before,

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -161,15 +161,28 @@ func (p *Parser) ParseFile(ctx context.Context, filename string, events chan<- E
 		case *replication.RowsQueryEvent:
 			// The original SQL statement (binlog_rows_query_log_events=ON),
 			// emitted right before the statement's TABLE_MAP + rows events.
-			currentQueryText = string(ev.Query)
+			// Sanitized ONCE here at the capture boundary — every downstream
+			// path (index INSERT, BYOS buffer/payload) sees bounded, valid
+			// UTF-8 text.
+			currentQueryText = event.SanitizeQueryText(string(ev.Query))
 
 		case *replication.MariadbAnnotateRowsEvent:
 			// MariaDB's positional sibling of ROWS_QUERY_EVENT
 			// (binlog_annotate_row_events=ON).
-			currentQueryText = string(ev.Query)
+			currentQueryText = event.SanitizeQueryText(string(ev.Query))
 
 		case *replication.RowsEvent:
-			return handleRows(ctx, p.logger, p.resolver.Load(), &p.filters, binlogEv, ev, filename, currentGTID, currentConnectionID, currentQueryText, p.schemaVersion.Load(), events)
+			err := handleRows(ctx, p.logger, p.resolver.Load(), &p.filters, binlogEv, ev, filename, currentGTID, currentConnectionID, currentQueryText, p.schemaVersion.Load(), events)
+			// The LAST rows event of a statement carries STMT_END_F — the
+			// actual statement boundary. Clearing here keeps one statement's
+			// text alive across its chained/split rows events, while a later
+			// statement in the SAME transaction that logged no ROWS_QUERY
+			// (variable toggled off mid-transaction — MySQL allows it; there
+			// is no GTID/QUERY boundary in between) can never inherit it.
+			if ev.Flags&replication.RowsEventStmtEndFlag != 0 {
+				currentQueryText = ""
+			}
+			return err
 
 		case *replication.TransactionPayloadEvent:
 			for _, inner := range ev.Events {

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -206,7 +206,7 @@ func TestHandleRows_unhandledEventTypeLogsNotSilent(t *testing.T) {
 	rowsEv := binlogEv.Event.(*replication.RowsEvent)
 
 	out := make(chan Event, 4)
-	if err := handleRows(context.Background(), logger, resolver, &Filters{}, binlogEv, rowsEv, "mariadb-bin.000001", "0-1-1", 0, 1, out); err != nil {
+	if err := handleRows(context.Background(), logger, resolver, &Filters{}, binlogEv, rowsEv, "mariadb-bin.000001", "0-1-1", 0, "", 1, out); err != nil {
 		t.Fatalf("handleRows: %v", err)
 	}
 
@@ -507,7 +507,7 @@ func TestHandleRows_partialImageFailsLoud(t *testing.T) {
 	rowsEv := binlogEv.Event.(*replication.RowsEvent)
 
 	out := make(chan Event, 4)
-	err := handleRows(context.Background(), newTestLogger(&bytes.Buffer{}), resolver, &Filters{}, binlogEv, rowsEv, "binlog.000001", "0-1-1", 0, 1, out)
+	err := handleRows(context.Background(), newTestLogger(&bytes.Buffer{}), resolver, &Filters{}, binlogEv, rowsEv, "binlog.000001", "0-1-1", 0, "", 1, out)
 	if err == nil {
 		t.Fatal("expected handleRows to fail loud on a partial row image, got nil")
 	}
@@ -559,7 +559,7 @@ func TestHandleRows_fullImagePasses(t *testing.T) {
 	rowsEv := binlogEv.Event.(*replication.RowsEvent)
 
 	out := make(chan Event, 4)
-	if err := handleRows(context.Background(), newTestLogger(&bytes.Buffer{}), resolver, &Filters{}, binlogEv, rowsEv, "binlog.000001", "0-1-1", 0, 1, out); err != nil {
+	if err := handleRows(context.Background(), newTestLogger(&bytes.Buffer{}), resolver, &Filters{}, binlogEv, rowsEv, "binlog.000001", "0-1-1", 0, "", 1, out); err != nil {
 		t.Fatalf("handleRows must not fail on a FULL image, got: %v", err)
 	}
 	select {

--- a/internal/parser/querytext_integration_test.go
+++ b/internal/parser/querytext_integration_test.go
@@ -161,3 +161,106 @@ func TestParseFile_queryTextAbsentWhenVariableOff(t *testing.T) {
 		}
 	}
 }
+
+// TestParseFile_queryTextMidTransactionToggle is the regression guard for the
+// stale-attribution bug the #699 review reproduced: MySQL allows
+// SET SESSION binlog_rows_query_log_events=OFF INSIDE an open transaction, so
+// a later statement in the SAME transaction emits rows with no ROWS_QUERY of
+// its own. Those rows must carry NO text — never the previous statement's
+// (a confidently wrong forensic attribution). The STMT_END_F clear is what
+// makes this hold; GTID/QUERY boundaries do not exist mid-transaction.
+func TestParseFile_queryTextMidTransactionToggle(t *testing.T) {
+	sourceDB, sourceName := testutil.CreateTestDB(t)
+	indexDB, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, indexDB)
+
+	testutil.MustExec(t, sourceDB, `CREATE TABLE orders (
+		id     INT PRIMARY KEY,
+		amount DECIMAL(10,2) NOT NULL
+	)`)
+
+	stats, err := metadata.TakeSnapshot(sourceDB, indexDB, []string{sourceName})
+	if err != nil {
+		t.Fatalf("TakeSnapshot failed: %v", err)
+	}
+	resolver, err := metadata.NewResolver(indexDB, stats.SnapshotID)
+	if err != nil {
+		t.Fatalf("NewResolver failed: %v", err)
+	}
+
+	ctx := context.Background()
+	conn, err := sourceDB.Conn(ctx)
+	if err != nil {
+		t.Fatalf("Conn failed: %v", err)
+	}
+	defer conn.Close()
+	if _, err := conn.ExecContext(ctx, "SET SESSION binlog_rows_query_log_events = ON"); err != nil {
+		var myErr *drivermysql.MySQLError
+		if errors.As(err, &myErr) && myErr.Number == 1193 {
+			t.Skipf("binlog_rows_query_log_events not supported on this server: %v", err)
+		}
+		t.Fatalf("SET SESSION failed for a non-version reason: %v", err)
+	}
+
+	testutil.MustExec(t, sourceDB, "FLUSH BINARY LOGS")
+	currentBinlog, _, err := config.CurrentBinlogPosition(sourceDB)
+	if err != nil {
+		t.Fatalf("CurrentBinlogPosition failed: %v", err)
+	}
+
+	firstSQL := "INSERT INTO orders (id, amount) VALUES (1, 10.00)"
+	tx, err := conn.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTx failed: %v", err)
+	}
+	if _, err := tx.ExecContext(ctx, firstSQL); err != nil {
+		t.Fatalf("INSERT #1 failed: %v", err)
+	}
+	// Toggle OFF inside the open transaction — allowed by MySQL.
+	if _, err := tx.ExecContext(ctx, "SET SESSION binlog_rows_query_log_events = OFF"); err != nil {
+		t.Fatalf("mid-transaction SET SESSION OFF failed: %v", err)
+	}
+	if _, err := tx.ExecContext(ctx, "INSERT INTO orders (id, amount) VALUES (2, 20.00)"); err != nil {
+		t.Fatalf("INSERT #2 failed: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("COMMIT failed: %v", err)
+	}
+
+	testutil.MustExec(t, sourceDB, "FLUSH BINARY LOGS")
+
+	tmpDir := t.TempDir()
+	cpCmd := exec.Command("docker", "cp",
+		fmt.Sprintf("bintrail-test-mysql:/var/lib/mysql/%s", currentBinlog),
+		filepath.Join(tmpDir, currentBinlog),
+	)
+	if out, err := cpCmd.CombinedOutput(); err != nil {
+		t.Fatalf("docker cp %s failed: %v\n%s", currentBinlog, err, out)
+	}
+
+	p := parser.New(tmpDir, resolver, parser.Filters{
+		Schemas: map[string]bool{sourceName: true},
+	}, nil)
+
+	events := make(chan parser.Event, 100)
+	done := make(chan error, 1)
+	go func() {
+		defer close(events)
+		done <- p.ParseFile(context.Background(), currentBinlog, events)
+	}()
+	all := drainEvents(events)
+	if err := <-done; err != nil {
+		t.Fatalf("ParseFile failed: %v", err)
+	}
+
+	dml := dmlEvents(all)
+	if len(dml) != 2 {
+		t.Fatalf("expected 2 DML events, got %d", len(dml))
+	}
+	if dml[0].QueryText != firstSQL {
+		t.Errorf("row 1: QueryText = %q, want %q", dml[0].QueryText, firstSQL)
+	}
+	if dml[1].QueryText != "" {
+		t.Errorf("row 2: QueryText = %q, want EMPTY — a statement that logged no ROWS_QUERY must never inherit the previous statement's text", dml[1].QueryText)
+	}
+}

--- a/internal/parser/querytext_integration_test.go
+++ b/internal/parser/querytext_integration_test.go
@@ -1,0 +1,163 @@
+//go:build integration
+
+package parser_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	drivermysql "github.com/go-sql-driver/mysql"
+
+	"github.com/dbtrail/dbtrail/internal/config"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/parser"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestParseFile_queryTextCapture drives the #699 capture path against a REAL
+// binlog: with binlog_rows_query_log_events=ON the server writes a
+// ROWS_QUERY_EVENT before each statement's row events, and every emitted DML
+// event must carry that statement in QueryText — per-statement, so the UPDATE's
+// rows must NOT carry the INSERT's text.
+func TestParseFile_queryTextCapture(t *testing.T) {
+	sourceDB, sourceName := testutil.CreateTestDB(t)
+	indexDB, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, indexDB)
+
+	testutil.MustExec(t, sourceDB, `CREATE TABLE orders (
+		id       INT PRIMARY KEY AUTO_INCREMENT,
+		customer VARCHAR(100) NOT NULL,
+		amount   DECIMAL(10,2) NOT NULL
+	)`)
+
+	stats, err := metadata.TakeSnapshot(sourceDB, indexDB, []string{sourceName})
+	if err != nil {
+		t.Fatalf("TakeSnapshot failed: %v", err)
+	}
+	resolver, err := metadata.NewResolver(indexDB, stats.SnapshotID)
+	if err != nil {
+		t.Fatalf("NewResolver failed: %v", err)
+	}
+
+	// Session-scoped statement logging on a dedicated connection: only THIS
+	// conn's statements get ROWS_QUERY events, no global pollution of the
+	// suite's shared binlog (#415 discipline).
+	ctx := context.Background()
+	conn, err := sourceDB.Conn(ctx)
+	if err != nil {
+		t.Fatalf("Conn failed: %v", err)
+	}
+	defer conn.Close()
+	if _, err := conn.ExecContext(ctx, "SET SESSION binlog_rows_query_log_events = ON"); err != nil {
+		// Skip ONLY on ER_UNKNOWN_SYSTEM_VARIABLE (a server without the
+		// variable, e.g. MariaDB which spells it binlog_annotate_row_events).
+		// Any other failure must FAIL, not skip.
+		var myErr *drivermysql.MySQLError
+		if errors.As(err, &myErr) && myErr.Number == 1193 {
+			t.Skipf("binlog_rows_query_log_events not supported on this server: %v", err)
+		}
+		t.Fatalf("SET SESSION binlog_rows_query_log_events failed for a non-version reason: %v", err)
+	}
+
+	testutil.MustExec(t, sourceDB, "FLUSH BINARY LOGS")
+	currentBinlog, _, err := config.CurrentBinlogPosition(sourceDB)
+	if err != nil {
+		t.Fatalf("CurrentBinlogPosition failed: %v", err)
+	}
+
+	// Two distinct statements on the logging connection. The multi-row INSERT
+	// produces two row events sharing ONE statement text; the UPDATE's row
+	// must carry its own.
+	insertSQL := "INSERT INTO orders (customer, amount) VALUES ('Alice', 99.99), ('Bob', 50.00)"
+	updateSQL := "UPDATE orders SET amount = 109.99 WHERE customer = 'Alice'"
+	if _, err := conn.ExecContext(ctx, insertSQL); err != nil {
+		t.Fatalf("INSERT failed: %v", err)
+	}
+	if _, err := conn.ExecContext(ctx, updateSQL); err != nil {
+		t.Fatalf("UPDATE failed: %v", err)
+	}
+
+	testutil.MustExec(t, sourceDB, "FLUSH BINARY LOGS")
+
+	tmpDir := t.TempDir()
+	cpCmd := exec.Command("docker", "cp",
+		fmt.Sprintf("bintrail-test-mysql:/var/lib/mysql/%s", currentBinlog),
+		filepath.Join(tmpDir, currentBinlog),
+	)
+	if out, err := cpCmd.CombinedOutput(); err != nil {
+		t.Fatalf("docker cp %s failed: %v\n%s", currentBinlog, err, out)
+	}
+
+	p := parser.New(tmpDir, resolver, parser.Filters{
+		Schemas: map[string]bool{sourceName: true},
+	}, nil)
+
+	events := make(chan parser.Event, 100)
+	done := make(chan error, 1)
+	go func() {
+		defer close(events)
+		done <- p.ParseFile(context.Background(), currentBinlog, events)
+	}()
+	all := drainEvents(events)
+	if err := <-done; err != nil {
+		t.Fatalf("ParseFile failed: %v", err)
+	}
+
+	dml := dmlEvents(all)
+	if len(dml) != 3 {
+		t.Fatalf("expected 3 DML events (2 INSERT rows + 1 UPDATE), got %d", len(dml))
+	}
+
+	// Both INSERT rows share the multi-row statement's text.
+	for i := 0; i < 2; i++ {
+		if dml[i].EventType != parser.EventInsert {
+			t.Fatalf("event[%d]: type = %d, want INSERT", i, dml[i].EventType)
+		}
+		if dml[i].QueryText != insertSQL {
+			t.Errorf("INSERT row %d: QueryText = %q, want %q", i, dml[i].QueryText, insertSQL)
+		}
+	}
+	// The UPDATE row carries its OWN statement, not the INSERT's.
+	if dml[2].EventType != parser.EventUpdate {
+		t.Fatalf("event[2]: type = %d, want UPDATE", dml[2].EventType)
+	}
+	if dml[2].QueryText != updateSQL {
+		t.Errorf("UPDATE row: QueryText = %q, want %q", dml[2].QueryText, updateSQL)
+	}
+}
+
+// TestParseFile_queryTextAbsentWhenVariableOff pins the degradation contract:
+// with the variable at its default (OFF), events parse exactly as before and
+// QueryText stays empty.
+func TestParseFile_queryTextAbsentWhenVariableOff(t *testing.T) {
+	binlogDir, binlogFile, schemaName, resolver := setupBinlog(t)
+
+	p := parser.New(binlogDir, resolver, parser.Filters{
+		Schemas: map[string]bool{schemaName: true},
+	}, nil)
+
+	events := make(chan parser.Event, 100)
+	done := make(chan error, 1)
+	go func() {
+		defer close(events)
+		done <- p.ParseFile(context.Background(), binlogFile, events)
+	}()
+	all := drainEvents(events)
+	if err := <-done; err != nil {
+		t.Fatalf("ParseFile failed: %v", err)
+	}
+
+	dml := dmlEvents(all)
+	if len(dml) == 0 {
+		t.Fatal("expected DML events from setupBinlog traffic")
+	}
+	for i, ev := range dml {
+		if ev.QueryText != "" {
+			t.Errorf("event[%d]: QueryText = %q, want empty (binlog_rows_query_log_events is OFF)", i, ev.QueryText)
+		}
+	}
+}

--- a/internal/parser/querytext_test.go
+++ b/internal/parser/querytext_test.go
@@ -53,6 +53,14 @@ func makeOrdersInsertEvent(id, amount int64) *replication.BinlogEvent {
 	}
 }
 
+// makeOrdersInsertEventFlags is makeOrdersInsertEvent with explicit RowsEvent
+// flags (STMT_END_F marks the last rows event of a statement).
+func makeOrdersInsertEventFlags(id, amount int64, flags uint16) *replication.BinlogEvent {
+	ev := makeOrdersInsertEvent(id, amount)
+	ev.Event.(*replication.RowsEvent).Flags = flags
+	return ev
+}
+
 // dmlOf filters the emitted stream down to row-DML events (drops the GTID
 // tracking and commit boundary events that ride along).
 func dmlOf(evs []Event) []Event {
@@ -218,5 +226,48 @@ func TestStreamParser_queryTextInsideTransactionPayload(t *testing.T) {
 	}
 	if got, want := dml[0].QueryText, "INSERT INTO shop.orders VALUES (1, 10)"; got != want {
 		t.Errorf("QueryText = %q, want %q (from inner ROWS_QUERY)", got, want)
+	}
+}
+
+// TestStreamParser_queryTextClearedAtStatementEnd pins the STMT_END_F clear:
+// MySQL allows SET SESSION binlog_rows_query_log_events=OFF INSIDE an open
+// transaction, so a later statement in the SAME transaction can emit rows with
+// no ROWS_QUERY of its own — it must NOT inherit the previous statement's
+// text (there is no GTID/QUERY boundary in between to clear it). The last
+// rows event of a statement carries STMT_END_F; that is the boundary.
+func TestStreamParser_queryTextClearedAtStatementEnd(t *testing.T) {
+	sp := NewStreamParser(makeOrdersResolver(), Filters{}, nil)
+	streamer := replication.NewBinlogStreamer()
+	out := make(chan Event, 16)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	feedThenCancel(t, streamer, cancel,
+		makeRotate("binlog.000001"),
+		makeGTIDEvent(1),
+		makeQueryEvent("BEGIN"),
+		// Statement 1: logged, spans TWO chained rows events — only the
+		// second carries STMT_END_F; both must share the text.
+		makeRowsQueryEvent("INSERT INTO shop.orders VALUES (1, 10), (2, 20)"),
+		makeOrdersInsertEventFlags(1, 10, 0),
+		makeOrdersInsertEventFlags(2, 20, replication.RowsEventStmtEndFlag),
+		// Statement 2, SAME transaction: variable toggled off — no
+		// ROWS_QUERY. Its rows must carry NO text.
+		makeOrdersInsertEventFlags(3, 30, replication.RowsEventStmtEndFlag),
+		makeXIDEvent(900),
+	)
+
+	if err := sp.Run(ctx, streamer, out); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	dml := dmlOf(drainAll(out))
+	if len(dml) != 3 {
+		t.Fatalf("expected 3 DML events, got %d", len(dml))
+	}
+	want := "INSERT INTO shop.orders VALUES (1, 10), (2, 20)"
+	if dml[0].QueryText != want || dml[1].QueryText != want {
+		t.Errorf("chained rows events of one statement must share its text, got %q / %q", dml[0].QueryText, dml[1].QueryText)
+	}
+	if dml[2].QueryText != "" {
+		t.Errorf("statement after mid-transaction toggle must carry NO text, got %q (stale attribution)", dml[2].QueryText)
 	}
 }

--- a/internal/parser/querytext_test.go
+++ b/internal/parser/querytext_test.go
@@ -1,0 +1,222 @@
+package parser
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-mysql-org/go-mysql/replication"
+)
+
+// ─── Query-text capture (#699) ────────────────────────────────────────────────
+//
+// These tests pin the statement-scoped query-text state machine in
+// StreamParser.Run: a ROWS_QUERY_EVENT (MySQL, binlog_rows_query_log_events=ON)
+// or ANNOTATE_ROWS event (MariaDB, binlog_annotate_row_events=ON) sets the text
+// for the rows events that follow it, and QUERY/GTID/XID boundaries clear it so
+// text can never leak onto a later statement that logged none.
+
+// makeRowsQueryEvent builds the MySQL ROWS_QUERY_EVENT carrying the original
+// statement text.
+func makeRowsQueryEvent(query string) *replication.BinlogEvent {
+	return &replication.BinlogEvent{
+		Header: &replication.EventHeader{EventType: replication.ROWS_QUERY_EVENT},
+		Event:  &replication.RowsQueryEvent{Query: []byte(query)},
+	}
+}
+
+// makeAnnotateRowsEvent builds the MariaDB ANNOTATE_ROWS event, the positional
+// sibling of MySQL's ROWS_QUERY_EVENT.
+func makeAnnotateRowsEvent(query string) *replication.BinlogEvent {
+	return &replication.BinlogEvent{
+		Header: &replication.EventHeader{EventType: replication.MARIADB_ANNOTATE_ROWS_EVENT},
+		Event:  &replication.MariadbAnnotateRowsEvent{Query: []byte(query)},
+	}
+}
+
+// makeOrdersInsertEvent builds a decodable WRITE_ROWS event for shop.orders
+// (matching makeOrdersResolver) so handleRows clears every guard and emits.
+func makeOrdersInsertEvent(id, amount int64) *replication.BinlogEvent {
+	return &replication.BinlogEvent{
+		Header: &replication.EventHeader{
+			EventType: replication.WRITE_ROWS_EVENTv2,
+			LogPos:    200,
+			EventSize: 100,
+		},
+		Event: &replication.RowsEvent{
+			Table: &replication.TableMapEvent{
+				Schema:      []byte("shop"),
+				Table:       []byte("orders"),
+				ColumnCount: 2,
+			},
+			Rows: [][]any{{id, amount}},
+		},
+	}
+}
+
+// dmlOf filters the emitted stream down to row-DML events (drops the GTID
+// tracking and commit boundary events that ride along).
+func dmlOf(evs []Event) []Event {
+	var dml []Event
+	for _, ev := range evs {
+		switch ev.EventType {
+		case EventInsert, EventUpdate, EventDelete:
+			dml = append(dml, ev)
+		}
+	}
+	return dml
+}
+
+// TestStreamParser_rowsQueryTextAttachedToRows: the text from a ROWS_QUERY
+// event lands on the statement's row events, and a later transaction that
+// logs NO rows-query text emits rows with an empty QueryText (no stale leak
+// across the XID/GTID boundary).
+func TestStreamParser_rowsQueryTextAttachedToRows(t *testing.T) {
+	sp := NewStreamParser(makeOrdersResolver(), Filters{}, nil)
+	streamer := replication.NewBinlogStreamer()
+	out := make(chan Event, 16)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	feedThenCancel(t, streamer, cancel,
+		makeRotate("binlog.000001"),
+		// Transaction 1: statement text logged.
+		makeGTIDEvent(1),
+		makeQueryEvent("BEGIN"),
+		makeRowsQueryEvent("INSERT INTO shop.orders VALUES (1, 10)"),
+		makeOrdersInsertEvent(1, 10),
+		makeXIDEvent(300),
+		// Transaction 2: variable toggled off — no ROWS_QUERY event.
+		makeGTIDEvent(2),
+		makeQueryEvent("BEGIN"),
+		makeOrdersInsertEvent(2, 20),
+		makeXIDEvent(600),
+	)
+
+	if err := sp.Run(ctx, streamer, out); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	dml := dmlOf(drainAll(out))
+	if len(dml) != 2 {
+		t.Fatalf("expected 2 DML events, got %d", len(dml))
+	}
+	if got, want := dml[0].QueryText, "INSERT INTO shop.orders VALUES (1, 10)"; got != want {
+		t.Errorf("trx1 QueryText = %q, want %q", got, want)
+	}
+	if dml[1].QueryText != "" {
+		t.Errorf("trx2 QueryText = %q, want empty (no ROWS_QUERY logged; stale text must not leak)", dml[1].QueryText)
+	}
+}
+
+// TestStreamParser_perStatementQueryTextScoping: a multi-statement transaction
+// emits one ROWS_QUERY event per statement; each statement's rows must carry
+// their OWN text, not the transaction's first.
+func TestStreamParser_perStatementQueryTextScoping(t *testing.T) {
+	sp := NewStreamParser(makeOrdersResolver(), Filters{}, nil)
+	streamer := replication.NewBinlogStreamer()
+	out := make(chan Event, 16)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	feedThenCancel(t, streamer, cancel,
+		makeRotate("binlog.000001"),
+		makeGTIDEvent(1),
+		makeQueryEvent("BEGIN"),
+		makeRowsQueryEvent("INSERT INTO shop.orders VALUES (1, 10)"),
+		makeOrdersInsertEvent(1, 10),
+		makeRowsQueryEvent("INSERT INTO shop.orders VALUES (2, 20)"),
+		makeOrdersInsertEvent(2, 20),
+		makeXIDEvent(900),
+	)
+
+	if err := sp.Run(ctx, streamer, out); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	dml := dmlOf(drainAll(out))
+	if len(dml) != 2 {
+		t.Fatalf("expected 2 DML events, got %d", len(dml))
+	}
+	if got, want := dml[0].QueryText, "INSERT INTO shop.orders VALUES (1, 10)"; got != want {
+		t.Errorf("statement 1 QueryText = %q, want %q", got, want)
+	}
+	if got, want := dml[1].QueryText, "INSERT INTO shop.orders VALUES (2, 20)"; got != want {
+		t.Errorf("statement 2 QueryText = %q, want %q", got, want)
+	}
+}
+
+// TestStreamParser_annotateRowsCarriesQueryText: the MariaDB ANNOTATE_ROWS
+// event feeds the same QueryText field as MySQL's ROWS_QUERY_EVENT.
+func TestStreamParser_annotateRowsCarriesQueryText(t *testing.T) {
+	sp := NewStreamParser(makeOrdersResolver(), Filters{}, nil)
+	streamer := replication.NewBinlogStreamer()
+	out := make(chan Event, 16)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	feedThenCancel(t, streamer, cancel,
+		makeRotate("mariadb-bin.000001"),
+		makeMariadbGTIDEvent(0, 1, 100),
+		makeQueryEvent("BEGIN"),
+		makeAnnotateRowsEvent("DELETE FROM shop.orders WHERE id = 1"),
+		makeOrdersInsertEvent(1, 10), // event type is irrelevant to the text plumbing
+		makeXIDEvent(400),
+	)
+
+	if err := sp.Run(ctx, streamer, out); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	dml := dmlOf(drainAll(out))
+	if len(dml) != 1 {
+		t.Fatalf("expected 1 DML event, got %d", len(dml))
+	}
+	if got, want := dml[0].QueryText, "DELETE FROM shop.orders WHERE id = 1"; got != want {
+		t.Errorf("QueryText = %q, want %q", got, want)
+	}
+}
+
+// TestStreamParser_queryTextInsideTransactionPayload: with
+// binlog_transaction_compression=ON the ROWS_QUERY event arrives INSIDE the
+// Transaction_payload envelope (like the BEGIN that carries connection_id) —
+// the recursive dispatch must capture it before the inner rows decode.
+func TestStreamParser_queryTextInsideTransactionPayload(t *testing.T) {
+	sp := NewStreamParser(makeOrdersResolver(), Filters{}, nil)
+	streamer := replication.NewBinlogStreamer()
+	out := make(chan Event, 16)
+
+	innerBegin := &replication.BinlogEvent{
+		Header: &replication.EventHeader{EventType: replication.QUERY_EVENT, LogPos: 0},
+		Event:  &replication.QueryEvent{Query: []byte("BEGIN"), SlaveProxyID: 42},
+	}
+	innerRowsQuery := &replication.BinlogEvent{
+		Header: &replication.EventHeader{EventType: replication.ROWS_QUERY_EVENT, LogPos: 0},
+		Event:  &replication.RowsQueryEvent{Query: []byte("INSERT INTO shop.orders VALUES (1, 10)")},
+	}
+	innerInsert := &replication.BinlogEvent{
+		Header: &replication.EventHeader{
+			EventType: replication.WRITE_ROWS_EVENTv2,
+			LogPos:    0,
+			EventSize: 500,
+		},
+		Event: &replication.RowsEvent{
+			Table: &replication.TableMapEvent{
+				Schema:      []byte("shop"),
+				Table:       []byte("orders"),
+				ColumnCount: 2,
+			},
+			Rows: [][]any{{int64(1), int64(10)}},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	feedThenCancel(t, streamer, cancel,
+		makeGTIDEvent(7),
+		makePayloadEvent(5000, 900, innerBegin, innerRowsQuery, innerInsert),
+	)
+
+	if err := sp.Run(ctx, streamer, out); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	dml := dmlOf(drainAll(out))
+	if len(dml) != 1 {
+		t.Fatalf("expected 1 DML event from payload inner rows, got %d", len(dml))
+	}
+	if got, want := dml[0].QueryText, "INSERT INTO shop.orders VALUES (1, 10)"; got != want {
+		t.Errorf("QueryText = %q, want %q (from inner ROWS_QUERY)", got, want)
+	}
+}

--- a/internal/parser/stream.go
+++ b/internal/parser/stream.go
@@ -85,6 +85,12 @@ func (sp *StreamParser) Run(ctx context.Context, streamer *replication.BinlogStr
 	var currentFile string
 	var currentGTID string
 	var currentConnectionID uint32 // pseudo_thread_id from most recent QueryEvent
+	// currentQueryText holds the original SQL statement from the most recent
+	// ROWS_QUERY_EVENT (MySQL, binlog_rows_query_log_events=ON) or
+	// ANNOTATE_ROWS event (MariaDB, binlog_annotate_row_events=ON; the syncer
+	// must request it via BINLOG_SEND_ANNOTATE_ROWS_EVENT). Statement-scoped —
+	// see the file parser's currentQueryText for the full contract.
+	var currentQueryText string
 
 	// emitCommit signals a transaction commit boundary so the stream consumer can
 	// advance the durable GTID checkpoint only after the transaction's rows have
@@ -171,6 +177,7 @@ func (sp *StreamParser) Run(ctx context.Context, streamer *replication.BinlogStr
 				return err
 			}
 			currentGTID = formatGTID(binlogEv.Header.EventType, ev.SID, ev.GNO)
+			currentQueryText = "" // transaction boundary — statement text never crosses it
 			if err := emitGTIDTracking(binlogEv.Header); err != nil {
 				return err
 			}
@@ -186,12 +193,16 @@ func (sp *StreamParser) Run(ctx context.Context, streamer *replication.BinlogStr
 				return err
 			}
 			currentGTID = ev.GTID.String()
+			currentQueryText = ""
 			if err := emitGTIDTracking(binlogEv.Header); err != nil {
 				return err
 			}
 
 		case *replication.QueryEvent:
 			currentConnectionID = ev.SlaveProxyID
+			// New statement scope (BEGIN of the next transaction, or a DDL) —
+			// the previous statement's ROWS_QUERY text is stale.
+			currentQueryText = ""
 			ts := time.Unix(int64(binlogEv.Header.Timestamp), 0).UTC()
 			if ddlEv, ok := parseDDL(sp.logger, currentFile, binlogEv.Header.LogPos, ts, currentGTID, string(ev.Query), sp.schemaVersion.Load()); ok {
 				select {
@@ -217,12 +228,24 @@ func (sp *StreamParser) Run(ctx context.Context, streamer *replication.BinlogStr
 		case *replication.XIDEvent:
 			// InnoDB transaction commit — the boundary at which it's safe to
 			// advance the durable GTID checkpoint (#491).
+			currentQueryText = ""
 			if err := emitCommit(binlogEv.Header); err != nil {
 				return err
 			}
 
+		case *replication.RowsQueryEvent:
+			// The original SQL statement (binlog_rows_query_log_events=ON),
+			// emitted right before the statement's TABLE_MAP + rows events.
+			currentQueryText = string(ev.Query)
+
+		case *replication.MariadbAnnotateRowsEvent:
+			// MariaDB's positional sibling of ROWS_QUERY_EVENT
+			// (binlog_annotate_row_events=ON on the source; only sent when the
+			// syncer requested BINLOG_SEND_ANNOTATE_ROWS_EVENT).
+			currentQueryText = string(ev.Query)
+
 		case *replication.RowsEvent:
-			return handleRows(ctx, sp.logger, sp.resolver.Load(), &sp.filters, binlogEv, ev, currentFile, currentGTID, currentConnectionID, sp.schemaVersion.Load(), out)
+			return handleRows(ctx, sp.logger, sp.resolver.Load(), &sp.filters, binlogEv, ev, currentFile, currentGTID, currentConnectionID, currentQueryText, sp.schemaVersion.Load(), out)
 
 		case *replication.TransactionPayloadEvent:
 			for _, inner := range ev.Events {

--- a/internal/parser/stream.go
+++ b/internal/parser/stream.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-mysql-org/go-mysql/replication"
 
+	"github.com/dbtrail/dbtrail/internal/event"
 	"github.com/dbtrail/dbtrail/internal/metadata"
 )
 
@@ -236,16 +237,26 @@ func (sp *StreamParser) Run(ctx context.Context, streamer *replication.BinlogStr
 		case *replication.RowsQueryEvent:
 			// The original SQL statement (binlog_rows_query_log_events=ON),
 			// emitted right before the statement's TABLE_MAP + rows events.
-			currentQueryText = string(ev.Query)
+			// Sanitized ONCE here at the capture boundary — every downstream
+			// path (index INSERT, BYOS buffer/payload) sees bounded, valid
+			// UTF-8 text.
+			currentQueryText = event.SanitizeQueryText(string(ev.Query))
 
 		case *replication.MariadbAnnotateRowsEvent:
 			// MariaDB's positional sibling of ROWS_QUERY_EVENT
 			// (binlog_annotate_row_events=ON on the source; only sent when the
 			// syncer requested BINLOG_SEND_ANNOTATE_ROWS_EVENT).
-			currentQueryText = string(ev.Query)
+			currentQueryText = event.SanitizeQueryText(string(ev.Query))
 
 		case *replication.RowsEvent:
-			return handleRows(ctx, sp.logger, sp.resolver.Load(), &sp.filters, binlogEv, ev, currentFile, currentGTID, currentConnectionID, currentQueryText, sp.schemaVersion.Load(), out)
+			err := handleRows(ctx, sp.logger, sp.resolver.Load(), &sp.filters, binlogEv, ev, currentFile, currentGTID, currentConnectionID, currentQueryText, sp.schemaVersion.Load(), out)
+			// Statement boundary — see the file parser's RowsEvent case: the
+			// STMT_END_F clear prevents a ROWS_QUERY-less later statement in
+			// the same transaction from inheriting this statement's text.
+			if ev.Flags&replication.RowsEventStmtEndFlag != 0 {
+				currentQueryText = ""
+			}
+			return err
 
 		case *replication.TransactionPayloadEvent:
 			for _, inner := range ev.Events {

--- a/internal/query/profileactive_test.go
+++ b/internal/query/profileactive_test.go
@@ -1,0 +1,51 @@
+package query
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+// TestFetch_profileActiveBlanksQueryText pins the #699 gate: a named profile
+// that resolved to ZERO deny/redact rules (nonexistent or empty profile) must
+// still withhold QueryText/QueryHash — ProfileActive alone triggers the
+// redaction pass.
+func TestFetch_profileActiveBlanksQueryText(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	cols := []string{
+		"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp",
+		"gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values",
+		"changed_columns", "row_before", "row_after", "schema_version", "query_text", "query_hash",
+	}
+	ts := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	rows := sqlmock.NewRows(cols).AddRow(
+		int64(1), "bin.000001", int64(4), int64(40), ts,
+		nil, nil, "app", "users", int64(2), "7",
+		nil, []byte(`{"ssn":"123-45-6789"}`), []byte(`{"ssn":"999"}`), int64(0),
+		"UPDATE app.users SET ssn='999' WHERE id=7", "cafe0000",
+	)
+	mock.ExpectQuery("FROM binlog_events").WillReturnRows(rows)
+
+	results, err := New(db).Fetch(context.Background(), Options{ProfileActive: true})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("rows = %d, want 1", len(results))
+	}
+	if results[0].QueryText != nil || results[0].QueryHash != nil {
+		t.Errorf("QueryText/QueryHash must be withheld under ProfileActive with zero rules, got %v / %v",
+			results[0].QueryText, results[0].QueryHash)
+	}
+	// Row images stay intact: no redact rules matched.
+	if results[0].RowBefore["ssn"] == nil {
+		t.Error("row images must not be touched when no redact rule matches")
+	}
+}

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -155,6 +155,11 @@ type Options struct {
 
 	DenyTables    []SchemaTable       // tables excluded by RBAC profile
 	RedactColumns []SchemaTableColumn // column values nulled out by RBAC profile
+	// ProfileActive is set by callers whenever a profile NAME was supplied,
+	// even if it resolved to zero deny/redact rules (a nonexistent or empty
+	// profile). It forces the redaction pass so QueryText/QueryHash are
+	// withheld under EVERY named profile — see applyRedaction (#699).
+	ProfileActive bool
 }
 
 // ─── ResultRow ────────────────────────────────────────────────────────────────
@@ -222,10 +227,11 @@ func (e *Engine) Fetch(ctx context.Context, opts Options) ([]ResultRow, error) {
 	// "Fetch returns ordered rows" contract that recovery.GenerateSQL and the
 	// formatters rely on.
 	sortResults(results, OrderDirection(opts.Order))
-	// Redaction also fires on DenyTables-only profiles: query_text is
-	// per-STATEMENT, so rows of an ALLOWED table can carry a statement whose
-	// literals belong to a denied sibling table — see applyRedaction (#699).
-	if len(opts.RedactColumns) > 0 || len(opts.DenyTables) > 0 {
+	// Redaction also fires on DenyTables-only profiles — and on a named
+	// profile with ZERO rules (ProfileActive): query_text is per-STATEMENT,
+	// so rows of an ALLOWED table can carry a statement whose literals
+	// belong to a denied sibling table — see applyRedaction (#699).
+	if opts.ProfileActive || len(opts.RedactColumns) > 0 || len(opts.DenyTables) > 0 {
 		applyRedaction(results, opts.RedactColumns)
 	}
 	return results, nil

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -176,6 +176,8 @@ type ResultRow struct {
 	RowBefore      map[string]any // nil for INSERT
 	RowAfter       map[string]any // nil for DELETE
 	SchemaVersion  uint32         // snapshot_id at index time; 0 for pre-migration data
+	QueryText      *string        // original SQL statement (#699); nil unless the source logs ROWS_QUERY/ANNOTATE events
+	QueryHash      *string        // STATEMENT_DIGEST of QueryText computed at index time (#699); nil when text absent or digest unavailable
 }
 
 // OrderDirection normalises an Options.Order value to a SQL direction keyword
@@ -220,7 +222,10 @@ func (e *Engine) Fetch(ctx context.Context, opts Options) ([]ResultRow, error) {
 	// "Fetch returns ordered rows" contract that recovery.GenerateSQL and the
 	// formatters rely on.
 	sortResults(results, OrderDirection(opts.Order))
-	if len(opts.RedactColumns) > 0 {
+	// Redaction also fires on DenyTables-only profiles: query_text is
+	// per-STATEMENT, so rows of an ALLOWED table can carry a statement whose
+	// literals belong to a denied sibling table — see applyRedaction (#699).
+	if len(opts.RedactColumns) > 0 || len(opts.DenyTables) > 0 {
 		applyRedaction(results, opts.RedactColumns)
 	}
 	return results, nil
@@ -408,7 +413,7 @@ func buildQuery(opts Options) (string, []any) {
 	// match 1:1 and lets MySQL prune partitions on the eq_ref lookup.
 	cols := `be.event_id, be.binlog_file, be.start_pos, be.end_pos, be.event_timestamp,
 	         be.gtid, be.connection_id, be.schema_name, be.table_name, be.event_type, be.pk_values,
-	         be.changed_columns, be.row_before, be.row_after, be.schema_version`
+	         be.changed_columns, be.row_before, be.row_after, be.schema_version, be.query_text, be.query_hash`
 
 	dir := OrderDirection(opts.Order)
 	whereSQL := ""
@@ -444,6 +449,17 @@ func buildQuery(opts Options) (string, []any) {
 }
 
 // applyRedaction nulls out denied column values in RowBefore and RowAfter maps.
+//
+// It also blanks QueryText/QueryHash on EVERY row, not just rows of flagged
+// tables (#699): the captured statement is per-STATEMENT, not per-table — a
+// multi-table UPDATE (or a trigger cascade) stamps the SAME text, literal
+// values included, onto row events of every table it touched, so per-table
+// blanking would still leak a redacted column's value through an unflagged
+// sibling table's rows. The hash is blanked with the text: a stable digest
+// leaks statement shape and permits dictionary confirmation of embedded
+// values. This mirrors the codebase's "a surface that cannot honor redaction
+// is disabled entirely under a profile" pattern (archives, cascade,
+// reconstruct).
 func applyRedaction(rows []ResultRow, redact []SchemaTableColumn) {
 	type colKey struct{ schema, table, column string }
 	set := make(map[colKey]struct{}, len(redact))
@@ -452,6 +468,8 @@ func applyRedaction(rows []ResultRow, redact []SchemaTableColumn) {
 	}
 	for i := range rows {
 		r := &rows[i]
+		r.QueryText = nil
+		r.QueryHash = nil
 		for col := range r.RowBefore {
 			if _, ok := set[colKey{r.SchemaName, r.TableName, col}]; ok {
 				r.RowBefore[col] = nil
@@ -492,13 +510,15 @@ func scanRows(rows *sql.Rows) ([]ResultRow, error) {
 			eventType      sql.NullInt32
 			pkValues       sql.NullString
 			schemaVersion  sql.NullInt32
+			queryText      sql.NullString
+			queryHash      sql.NullString
 		)
 		var changedCols, rowBefore, rowAfter []byte
 
 		if err := rows.Scan(
 			&r.EventID, &binlogFile, &startPos, &endPos, &eventTimestamp,
 			&gtid, &connID, &schemaName, &tableName, &eventType, &pkValues,
-			&changedCols, &rowBefore, &rowAfter, &schemaVersion,
+			&changedCols, &rowBefore, &rowAfter, &schemaVersion, &queryText, &queryHash,
 		); err != nil {
 			return nil, fmt.Errorf("failed to scan result row: %w", err)
 		}
@@ -535,6 +555,12 @@ func scanRows(rows *sql.Rows) ([]ResultRow, error) {
 		}
 		if schemaVersion.Valid {
 			r.SchemaVersion = uint32(schemaVersion.Int32)
+		}
+		if queryText.Valid {
+			r.QueryText = &queryText.String
+		}
+		if queryHash.Valid {
+			r.QueryHash = &queryHash.String
 		}
 		if changedCols != nil {
 			_ = json.Unmarshal(changedCols, &r.ChangedColumns)
@@ -634,6 +660,8 @@ type jsonRow struct {
 	ChangedColumns []string       `json:"changed_columns"`
 	RowBefore      map[string]any `json:"row_before"`
 	RowAfter       map[string]any `json:"row_after"`
+	QueryText      *string        `json:"query_text"`
+	QueryHash      *string        `json:"query_hash"`
 }
 
 func writeJSON(rows []ResultRow, w io.Writer) (int, error) {
@@ -654,6 +682,8 @@ func writeJSON(rows []ResultRow, w io.Writer) (int, error) {
 			ChangedColumns: r.ChangedColumns,
 			RowBefore:      r.RowBefore,
 			RowAfter:       r.RowAfter,
+			QueryText:      r.QueryText,
+			QueryHash:      r.QueryHash,
 		}
 	}
 	enc := json.NewEncoder(w)
@@ -668,7 +698,7 @@ func writeJSON(rows []ResultRow, w io.Writer) (int, error) {
 var csvHeaders = []string{
 	"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp",
 	"gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values",
-	"changed_columns", "row_before", "row_after",
+	"changed_columns", "row_before", "row_after", "query_text", "query_hash",
 }
 
 func writeCSV(rows []ResultRow, w io.Writer) (int, error) {
@@ -701,6 +731,14 @@ func writeCSV(rows []ResultRow, w io.Writer) (int, error) {
 			b, _ := json.Marshal(r.RowAfter)
 			after = string(b)
 		}
+		queryText := ""
+		if r.QueryText != nil {
+			queryText = *r.QueryText
+		}
+		queryHash := ""
+		if r.QueryHash != nil {
+			queryHash = *r.QueryHash
+		}
 		record := []string{
 			fmt.Sprintf("%d", r.EventID),
 			r.BinlogFile,
@@ -716,6 +754,8 @@ func writeCSV(rows []ResultRow, w io.Writer) (int, error) {
 			changed,
 			before,
 			after,
+			queryText,
+			queryHash,
 		}
 		if err := cw.Write(record); err != nil {
 			return i, err

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -817,6 +817,44 @@ func TestLimitPerPK_zero_passthrough(t *testing.T) {
 	}
 }
 
+// TestApplyRedaction_blanksQueryTextEverywhere pins the #699 policy: the
+// captured statement text (and its digest) is per-STATEMENT, not per-table —
+// a multi-table statement stamps the same text, literal values included, onto
+// rows of EVERY table it touched. So whenever redaction runs, QueryText and
+// QueryHash are blanked on ALL rows, including rows of tables with no
+// redaction rule of their own.
+func TestApplyRedaction_blanksQueryTextEverywhere(t *testing.T) {
+	qText := "UPDATE mydb.orders o JOIN mydb.products p SET o.amount=100, p.price=5"
+	qHash := strings.Repeat("ab", 32)
+	rows := []ResultRow{
+		{
+			SchemaName: "mydb", TableName: "orders",
+			RowBefore: map[string]any{"amount": float64(100)},
+			QueryText: &qText, QueryHash: &qHash,
+		},
+		{
+			// Different table, NO redaction rule — still must not carry the
+			// statement (it embeds the redacted table's literals).
+			SchemaName: "mydb", TableName: "products",
+			RowBefore: map[string]any{"price": float64(5)},
+			QueryText: &qText, QueryHash: &qHash,
+		},
+	}
+	redact := []SchemaTableColumn{
+		{Schema: "mydb", Table: "orders", Column: "amount"},
+	}
+	applyRedaction(rows, redact)
+
+	for i := range rows {
+		if rows[i].QueryText != nil {
+			t.Errorf("row %d: QueryText must be blanked under an active profile, got %q", i, *rows[i].QueryText)
+		}
+		if rows[i].QueryHash != nil {
+			t.Errorf("row %d: QueryHash must be blanked with the text, got %q", i, *rows[i].QueryHash)
+		}
+	}
+}
+
 func TestApplyRedaction_wrongTable(t *testing.T) {
 	rows := []ResultRow{{
 		SchemaName: "mydb",

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -394,36 +394,62 @@ func TestWriteTable_singleRow(t *testing.T) {
 
 func TestWriteJSON_structure(t *testing.T) {
 	ts := time.Date(2026, 2, 19, 14, 0, 1, 0, time.UTC)
-	rows := []ResultRow{{
-		EventID:        7,
-		EventTimestamp: ts,
-		SchemaName:     "s",
-		TableName:      "t",
-		EventType:      parser.EventInsert,
-		PKValues:       "1",
-		RowAfter:       map[string]any{"id": float64(1), "name": "Alice"},
-	}}
+	qText := "INSERT INTO s.t (id, name) VALUES (1, 'Alice')"
+	qHash := "abc123"
+	rows := []ResultRow{
+		{
+			EventID:        7,
+			EventTimestamp: ts,
+			SchemaName:     "s",
+			TableName:      "t",
+			EventType:      parser.EventInsert,
+			PKValues:       "1",
+			RowAfter:       map[string]any{"id": float64(1), "name": "Alice"},
+			QueryText:      &qText,
+			QueryHash:      &qHash,
+		},
+		{
+			EventID:        8,
+			EventTimestamp: ts,
+			SchemaName:     "s",
+			TableName:      "t",
+			EventType:      parser.EventInsert,
+			PKValues:       "2",
+			// QueryText/QueryHash nil: statement not captured.
+		},
+	}
 	var buf bytes.Buffer
 	n, err := writeJSON(rows, &buf)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if n != 1 {
-		t.Errorf("expected 1 row, got %d", n)
+	if n != 2 {
+		t.Errorf("expected 2 rows, got %d", n)
 	}
 
 	var out []map[string]any
 	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
 		t.Fatalf("output is not valid JSON: %v\n%s", err, buf.String())
 	}
-	if len(out) != 1 {
-		t.Fatalf("expected 1 JSON element, got %d", len(out))
+	if len(out) != 2 {
+		t.Fatalf("expected 2 JSON elements, got %d", len(out))
 	}
 	if out[0]["event_type"] != "INSERT" {
 		t.Errorf("expected event_type=INSERT, got %v", out[0]["event_type"])
 	}
 	if out[0]["event_id"] != float64(7) {
 		t.Errorf("expected event_id=7, got %v", out[0]["event_id"])
+	}
+	// #699 forensics fields: populated row carries them, uncaptured row
+	// serializes explicit nulls (jsonRow has no omitempty on them).
+	if out[0]["query_text"] != qText {
+		t.Errorf("query_text = %v, want %q", out[0]["query_text"], qText)
+	}
+	if out[0]["query_hash"] != qHash {
+		t.Errorf("query_hash = %v, want %q", out[0]["query_hash"], qHash)
+	}
+	if v, present := out[1]["query_text"]; !present || v != nil {
+		t.Errorf("uncaptured row must serialize query_text as null, got %v (present=%v)", v, present)
 	}
 }
 
@@ -450,6 +476,8 @@ func TestBuildQuery_gtidFilter(t *testing.T) {
 
 func TestWriteCSV_headersAndRow(t *testing.T) {
 	ts := time.Date(2026, 2, 19, 14, 0, 1, 0, time.UTC)
+	qText := "DELETE FROM db.tbl WHERE id = 99"
+	qHash := "feed99"
 	rows := []ResultRow{{
 		EventID:        3,
 		BinlogFile:     "binlog.000001",
@@ -458,6 +486,8 @@ func TestWriteCSV_headersAndRow(t *testing.T) {
 		TableName:      "tbl",
 		EventType:      parser.EventDelete,
 		PKValues:       "99",
+		QueryText:      &qText,
+		QueryHash:      &qHash,
 	}}
 	var buf bytes.Buffer
 	n, err := writeCSV(rows, &buf)
@@ -476,6 +506,14 @@ func TestWriteCSV_headersAndRow(t *testing.T) {
 	}
 	if !strings.Contains(lines[1], "DELETE") {
 		t.Errorf("expected DELETE in data row, got: %s", lines[1])
+	}
+	// #699: the two appended columns must stay in lockstep between csvHeaders
+	// and the record slice — a one-sided append silently shifts CSV columns.
+	if !strings.HasSuffix(lines[0], ",query_text,query_hash") {
+		t.Errorf("expected header to end with query_text,query_hash, got: %s", lines[0])
+	}
+	if !strings.Contains(lines[1], qText) || !strings.HasSuffix(lines[1], ","+qHash) {
+		t.Errorf("expected statement text and trailing hash in data row, got: %s", lines[1])
 	}
 }
 

--- a/internal/shim/handler_test.go
+++ b/internal/shim/handler_test.go
@@ -783,7 +783,7 @@ func TestRunPointInTimeDispatchesByPKColumn(t *testing.T) {
 			rows.AddRow(int64(i+1), "binlog.000001", int64(100), int64(200), now,
 				nil, nil, "myapp", "orders", parser.EventInsert,
 				fmt.Sprintf("%d", i+1), nil, nil,
-				fmt.Sprintf(`{"id":%d,"sku":"X"}`, i+1), 0)
+				fmt.Sprintf(`{"id":%d,"sku":"X"}`, i+1), 0, nil, nil)
 		}
 		mock.ExpectQuery("FROM binlog_events").WillReturnRows(rows)
 
@@ -818,6 +818,7 @@ func binlogEventsColumns() []string {
 		"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp",
 		"gtid", "connection_id", "schema_name", "table_name", "event_type",
 		"pk_values", "changed_columns", "row_before", "row_after", "schema_version",
+		"query_text", "query_hash",
 	}
 }
 
@@ -1514,7 +1515,7 @@ func TestRunPointInTimeInvokesArchiveFetcher(t *testing.T) {
 	// Live MySQL fetch may or may not run depending on planner output;
 	// stub it permissive (no expected rows) so a call is fine.
 	mock.ExpectQuery("FROM binlog_events").
-		WillReturnRows(sqlmock.NewRows([]string{"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp", "gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values", "changed_columns", "row_before", "row_after", "schema_version"}))
+		WillReturnRows(sqlmock.NewRows([]string{"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp", "gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values", "changed_columns", "row_before", "row_after", "schema_version", "query_text", "query_hash"}))
 
 	called := false
 	fakeFetcher := func(ctx context.Context, opts query.Options, src string) ([]query.ResultRow, error) {
@@ -1592,7 +1593,7 @@ func TestRunFullTableEnforcesCostCap(t *testing.T) {
 			int64(i+1), "binlog.000001", int64(100), int64(200), now,
 			nil, nil, "myapp", "orders", parser.EventInsert,
 			fmt.Sprintf("%d", i+1), nil, nil,
-			fmt.Sprintf(`{"id":%d,"sku":"X"}`, i+1), 0,
+			fmt.Sprintf(`{"id":%d,"sku":"X"}`, i+1), 0, nil, nil,
 		)
 	}
 	mock.ExpectQuery("FROM binlog_events").WillReturnRows(rows)
@@ -1665,7 +1666,7 @@ func TestRunPointInTimeStrictModePropagatesArchiveError(t *testing.T) {
 	mock.ExpectQuery("information_schema.PARTITIONS").
 		WillReturnRows(sqlmock.NewRows([]string{"PARTITION_NAME", "PARTITION_DESCRIPTION"}))
 	mock.ExpectQuery("FROM binlog_events").
-		WillReturnRows(sqlmock.NewRows([]string{"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp", "gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values", "changed_columns", "row_before", "row_after", "schema_version"}))
+		WillReturnRows(sqlmock.NewRows([]string{"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp", "gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values", "changed_columns", "row_before", "row_after", "schema_version", "query_text", "query_hash"}))
 
 	archiveErr := errors.New("synthetic archive failure (e.g. S3 throttling)")
 	failingFetcher := func(ctx context.Context, opts query.Options, src string) ([]query.ResultRow, error) {
@@ -1721,7 +1722,7 @@ func TestPlannerScopesPartitionsToIndexDB(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"PARTITION_NAME"}).
 			AddRow("p_2026050415"))
 	mock.ExpectQuery("FROM binlog_events").
-		WillReturnRows(sqlmock.NewRows([]string{"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp", "gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values", "changed_columns", "row_before", "row_after", "schema_version"}))
+		WillReturnRows(sqlmock.NewRows([]string{"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp", "gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values", "changed_columns", "row_before", "row_after", "schema_version", "query_text", "query_hash"}))
 
 	h := &Handler{
 		indexDB: db,
@@ -1770,7 +1771,7 @@ func TestRunDiffScopesPartitionsToIndexDB(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"PARTITION_NAME"}).
 			AddRow("p_2026050415"))
 	mock.ExpectQuery("FROM binlog_events").
-		WillReturnRows(sqlmock.NewRows([]string{"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp", "gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values", "changed_columns", "row_before", "row_after", "schema_version"}))
+		WillReturnRows(sqlmock.NewRows([]string{"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp", "gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values", "changed_columns", "row_before", "row_after", "schema_version", "query_text", "query_hash"}))
 
 	h := &Handler{
 		indexDB: db,

--- a/internal/streamrun/streamrun.go
+++ b/internal/streamrun/streamrun.go
@@ -1518,6 +1518,16 @@ func One(ctx context.Context, cfg Config) error {
 		MaxReconnectAttempts: 0, // infinite retry
 		TLSConfig:            tlsCfg,
 	}
+	if cfg.Flavor == "mariadb" {
+		// Ask the MariaDB source to send ANNOTATE_ROWS events (the original
+		// SQL statement, MariaDB's sibling of MySQL's ROWS_QUERY_EVENT) over
+		// the replication stream. Unlike MySQL — which sends ROWS_QUERY
+		// unconditionally when binlog_rows_query_log_events=ON — MariaDB only
+		// forwards ANNOTATE events to a replica that set this dump flag, even
+		// when binlog_annotate_row_events=ON wrote them to the binlog (#699).
+		// Harmless when the source has annotation off: no events, no cost.
+		syncerCfg.DumpCommandFlag |= replication.BINLOG_SEND_ANNOTATE_ROWS_EVENT
+	}
 
 	// Use a closure defer so the active syncer is always closed on exit,
 	// even if we replace it during the preferred-mode TLS fallback below.

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -242,6 +242,8 @@ func InitIndexTables(t *testing.T, db *sql.DB) {
 		row_before      JSON             DEFAULT NULL,
 		row_after       JSON             DEFAULT NULL,
 		schema_version  INT UNSIGNED     NOT NULL DEFAULT 0,
+		query_text      MEDIUMTEXT       DEFAULT NULL,
+		query_hash      CHAR(64)         DEFAULT NULL,
 		PRIMARY KEY (event_id, event_timestamp),
 		INDEX idx_row_lookup (schema_name, table_name, event_timestamp),
 		INDEX idx_pk_hash    (schema_name, table_name, pk_hash, event_timestamp),


### PR DESCRIPTION
closes #699

## Summary
- **Parser (file + stream)**: capture MySQL `ROWS_QUERY_EVENT` / MariaDB `ANNOTATE_ROWS` text, statement-scoped (set on the event, cleared at QUERY/GTID/XID boundaries so stale text never leaks onto a statement that logged none); works inside compressed `Transaction_payload` envelopes; the syncer requests `BINLOG_SEND_ANNOTATE_ROWS_EVENT` when `--source-flavor mariadb`.
- **Index schema**: `binlog_events.query_text MEDIUMTEXT NULL` + `query_hash CHAR(64) NULL` via fresh DDL **and** `EnsureSchema` (connection_id pattern). Go-side sanitization before insert: invalid UTF-8 replaced, 16 KiB cap with a `/* bintrail:truncated */` marker — protects the batch INSERT from 1366 / `max_allowed_packet` failures on bulk statements.
- **Digest**: `query_hash` = `STATEMENT_DIGEST(query_text)` computed on the **index** connection (8.0+ contract floor), ONE round trip per batch over distinct texts; degrades to NULL hash with a once-per-indexer warning if the digest is unavailable.
- **Read side**: `query`/`recover` JSON + CSV output (table format deliberately unchanged), Parquet archive schema + BYOS buffer snapshots (pre-#699 files read back NULL via the existing column-probe `NULL::TYPE` substitution — same mechanism as pre-v0.4.4 `connection_id`), MCP via the shared formatters.
- **Open-core boundary**: console `eventDTO` omits both fields (comment + denylist test extended); the console's legacy-registry-index 422 guard now also names the new columns.
- **RBAC**: under ANY active profile, `query_text`/`query_hash` are blanked on **every** row — the statement is per-STATEMENT, not per-table, so a multi-table UPDATE would leak a redacted column's literals through an unflagged sibling table's rows. The redaction gate now also fires for DenyTables-only profiles.
- **BYOS**: `query_text` goes to the customer-side `PayloadRecord` ONLY (statement text embeds literal values = row-level data); `MetadataRecord` keeps its zero-row-level-data contract (test-pinned). No hash in BYOS (no index connection to digest on).
- **Doctor**: advisory `Statement capture (query_text)` check — PASS/WARN/SKIP, never FAIL; MariaDB fallback probe; validate-never-set.
- **Docs**: `query-and-recovery.md` new section, `parquet-debugging.md` schema table.

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] Integration (`-tags integration -p 1`, Docker MySQL 13306): parser (real binlog with `SET SESSION binlog_rows_query_log_events=ON` on a pinned conn — per-statement scoping + off-by-default degradation), indexer (EnsureSchema migration + digest round-trip: same-shape statements share one 64-hex digest, uncaptured → NULL/NULL), archive, query, buffer (DuckDB read-back of query_text incl. NULL), byos, doctor
- [x] New unit tests: stream-parser state machine (per-statement scoping, boundary clearing, MariaDB annotate, payload-inner ROWS_QUERY), sanitizeQueryText (UTF-8, cap, rune boundary), redaction blanking, parquet NULL substitution, console DTO denylist, BYOS payload-only split

🤖 Generated with [Claude Code](https://claude.com/claude-code)