### PR TITLE
Detect schema drift at capture time: cross-check the snapshot against TABLE_MAP column names

### DIFF
--- a/cmd/bintrail/agent.go
+++ b/cmd/bintrail/agent.go
@@ -995,7 +995,13 @@ func buildResolverFromSource(sourceDB *sql.DB, schemas []string) (*metadata.Reso
 		})
 	}
 
-	return metadata.NewResolverFromTables(0, tables), nil
+	// The resolver reflects the LIVE schema read moments ago, so its
+	// creation time is exactly now. Without it the #700 drift guard runs in
+	// zero-time strict mode: an agent catching up through backlog written
+	// before a column rename would hard-error on every restart, with a
+	// remediation (`bintrail snapshot`) that does nothing for this
+	// resolver — it never reads schema_snapshots.
+	return metadata.NewResolverFromTablesAt(0, time.Now().UTC(), tables), nil
 }
 
 // validateServerUUID enforces that --server-uuid (when supplied) is a

--- a/docs/indexing.md
+++ b/docs/indexing.md
@@ -23,6 +23,17 @@ relationships) into the index so events can be decoded into named columns.
   **skips that table's events** rather than corrupting data. The fix is to
   re-run `bintrail snapshot`. To automate this, see
   [DDL tracking](ddl-tracking.md).
+- **Same-count changes are the dangerous ones.** A column rename (or a
+  `DROP COLUMN` + `ADD COLUMN` in one `ALTER`) keeps the count equal, so the
+  count check can't see it — values would silently index under the wrong
+  column names. If the source sets `binlog_row_metadata=FULL` (MySQL 8.0+,
+  MariaDB 10.5+ — `bintrail doctor` reports it), every binlog event also
+  carries its real column names and dbtrail verifies the snapshot against
+  them, **stopping with a loud error** instead of indexing corrupt data:
+
+  ```sql
+  SET PERSIST binlog_row_metadata = 'FULL';  -- optional, a few bytes per TABLE_MAP event
+  ```
 
 ---
 

--- a/docs/indexing.md
+++ b/docs/indexing.md
@@ -32,8 +32,17 @@ relationships) into the index so events can be decoded into named columns.
   them, **stopping with a loud error** instead of indexing corrupt data:
 
   ```sql
-  SET PERSIST binlog_row_metadata = 'FULL';  -- optional, a few bytes per TABLE_MAP event
+  -- MySQL 8.0+ (optional, a few bytes per TABLE_MAP event):
+  SET PERSIST binlog_row_metadata = 'FULL';
+  -- MariaDB 10.5+ (no SET PERSIST; persist it in my.cnf under [mysqld]):
+  SET GLOBAL binlog_row_metadata = 'FULL';
   ```
+
+  Only events **newer than the snapshot** stop indexing — that is the stale
+  case a fresh `bintrail snapshot` genuinely fixes. Events *older* than the
+  snapshot (re-indexing history after a rename, a stream catching up through
+  a backlog) index under the snapshot's current names with a loud warning,
+  exactly as they did before drift detection existed.
 
 ---
 

--- a/docs/indexing.md
+++ b/docs/indexing.md
@@ -27,22 +27,23 @@ relationships) into the index so events can be decoded into named columns.
   `DROP COLUMN` + `ADD COLUMN` in one `ALTER`) keeps the count equal, so the
   count check can't see it — values would silently index under the wrong
   column names. If the source sets `binlog_row_metadata=FULL` (MySQL 8.0+,
-  MariaDB 10.5+ — `bintrail doctor` reports it), every binlog event also
-  carries its real column names and dbtrail verifies the snapshot against
-  them, **stopping with a loud error** instead of indexing corrupt data:
+  MariaDB 10.5+ — `bintrail doctor` reports it), every row event's TABLE_MAP
+  carries the table's real column names (a handful of extra bytes per column
+  per TABLE_MAP event) and dbtrail verifies the snapshot against them,
+  **stopping with a loud error** instead of indexing corrupt data:
 
   ```sql
-  -- MySQL 8.0+ (optional, a few bytes per TABLE_MAP event):
+  -- MySQL 8.0+ (optional):
   SET PERSIST binlog_row_metadata = 'FULL';
   -- MariaDB 10.5+ (no SET PERSIST; persist it in my.cnf under [mysqld]):
   SET GLOBAL binlog_row_metadata = 'FULL';
   ```
 
-  Only events **newer than the snapshot** stop indexing — that is the stale
-  case a fresh `bintrail snapshot` genuinely fixes. Events *older* than the
-  snapshot (re-indexing history after a rename, a stream catching up through
-  a backlog) index under the snapshot's current names with a loud warning,
-  exactly as they did before drift detection existed.
+  Only events **at or after the snapshot's creation time** stop indexing —
+  that is the stale case a fresh `bintrail snapshot` genuinely fixes. Events
+  *older* than the snapshot (re-indexing history after a rename, a stream
+  catching up through a backlog) index under the snapshot's current names
+  with a loud warning, exactly as they did before drift detection existed.
 
 ---
 

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -136,6 +136,7 @@ func Build(parent context.Context, sourceDSN, indexDSN, schemasCSV string, index
 	report.add(checkBinlogFormat(sourceDB))
 	report.add(checkBinlogRowImage(sourceDB))
 	report.add(checkBinlogRetention(sourceDB))
+	report.add(checkRowMetadata(sourceDB))
 	report.add(checkReplicationGrants(ctx, sourceDB))
 	report.add(checkFKCascades(sourceDB, schemas))
 	report.add(checkSchemaVisibility(ctx, sourceDB, schemas))
@@ -320,6 +321,39 @@ func checkBinlogRetention(db *sql.DB) CheckResult {
 		Name:   "Binlog retention >= 2 days",
 		Status: StatusPass,
 		Detail: fmt.Sprintf("%dh", seconds/3600),
+	}
+}
+
+// checkRowMetadata reports whether the source embeds column names in every
+// binlog TABLE_MAP event (#700): binlog_row_metadata=FULL (MySQL 8.0+,
+// MariaDB 10.5+) lets bintrail cross-check the schema snapshot against
+// per-event ground truth and fail loud on a stale snapshot — including the
+// same-column-count drift (a rename, or a DROP+ADD in one ALTER) that the
+// count guard cannot see and that would otherwise index values under the
+// wrong column names. The setting is OPTIONAL, so this check never FAILs:
+// FULL → PASS, MINIMAL → WARN with an enable suggestion (validate, never
+// set), variable absent → SKIP.
+func checkRowMetadata(db *sql.DB) CheckResult {
+	const name = "Schema-drift detection (binlog_row_metadata)"
+	var val string
+	if err := db.QueryRow("SELECT @@binlog_row_metadata").Scan(&val); err != nil {
+		// MySQL error 1193 (unknown system variable) on servers without it
+		// (MySQL 5.7, MariaDB <10.5); any read failure degrades the same way.
+		return CheckResult{
+			Name:   name,
+			Status: StatusSkip,
+			Detail: "binlog_row_metadata is not available on this server (needs MySQL 8.0+ or MariaDB 10.5+)",
+		}
+	}
+	if strings.EqualFold(val, "FULL") {
+		return CheckResult{Name: name, Status: StatusPass, Detail: "binlog_row_metadata=FULL"}
+	}
+	return CheckResult{
+		Name:   name,
+		Status: StatusWarn,
+		Detail: "binlog_row_metadata=" + val + " — a stale schema snapshot cannot be detected at capture time (a same-column-count change like a rename would index values under the wrong column names)",
+		Remediation: "Optional: embed column names in row-event metadata so bintrail can verify the snapshot against every event (dynamic, no restart; adds a few bytes per TABLE_MAP event):\n\n" +
+			"  SET PERSIST binlog_row_metadata = 'FULL';",
 	}
 }
 

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -337,12 +337,22 @@ func checkRowMetadata(db *sql.DB) CheckResult {
 	const name = "Schema-drift detection (binlog_row_metadata)"
 	var val string
 	if err := db.QueryRow("SELECT @@binlog_row_metadata").Scan(&val); err != nil {
-		// MySQL error 1193 (unknown system variable) on servers without it
-		// (MySQL 5.7, MariaDB <10.5); any read failure degrades the same way.
+		// Only MySQL error 1193 (unknown system variable) means the server
+		// genuinely lacks the variable (MySQL 5.7, MariaDB <10.5). Any other
+		// failure is a read problem — surface the real error instead of a
+		// fabricated version diagnosis (checkBinlogRetention's pattern).
+		var myErr *mysql.MySQLError
+		if errors.As(err, &myErr) && myErr.Number == 1193 {
+			return CheckResult{
+				Name:   name,
+				Status: StatusSkip,
+				Detail: "binlog_row_metadata is not available on this server (needs MySQL 8.0+ or MariaDB 10.5+)",
+			}
+		}
 		return CheckResult{
 			Name:   name,
-			Status: StatusSkip,
-			Detail: "binlog_row_metadata is not available on this server (needs MySQL 8.0+ or MariaDB 10.5+)",
+			Status: StatusWarn,
+			Detail: "could not read binlog_row_metadata: " + err.Error(),
 		}
 	}
 	if strings.EqualFold(val, "FULL") {
@@ -353,7 +363,10 @@ func checkRowMetadata(db *sql.DB) CheckResult {
 		Status: StatusWarn,
 		Detail: "binlog_row_metadata=" + val + " — a stale schema snapshot cannot be detected at capture time (a same-column-count change like a rename would index values under the wrong column names)",
 		Remediation: "Optional: embed column names in row-event metadata so bintrail can verify the snapshot against every event (dynamic, no restart; adds a few bytes per TABLE_MAP event):\n\n" +
-			"  SET PERSIST binlog_row_metadata = 'FULL';",
+			"  -- MySQL 8.0+:\n" +
+			"  SET PERSIST binlog_row_metadata = 'FULL';\n\n" +
+			"  -- MariaDB 10.5+ (no SET PERSIST; persist it in my.cnf under [mysqld]):\n" +
+			"  SET GLOBAL binlog_row_metadata = 'FULL';",
 	}
 }
 

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -340,7 +340,8 @@ func checkRowMetadata(db *sql.DB) CheckResult {
 		// Only MySQL error 1193 (unknown system variable) means the server
 		// genuinely lacks the variable (MySQL 5.7, MariaDB <10.5). Any other
 		// failure is a read problem — surface the real error instead of a
-		// fabricated version diagnosis (checkBinlogRetention's pattern).
+		// fabricated version diagnosis (unlike checkBinlogRetention, which
+		// treats any error on the modern variable as absent and falls back).
 		var myErr *mysql.MySQLError
 		if errors.As(err, &myErr) && myErr.Number == 1193 {
 			return CheckResult{
@@ -362,7 +363,7 @@ func checkRowMetadata(db *sql.DB) CheckResult {
 		Name:   name,
 		Status: StatusWarn,
 		Detail: "binlog_row_metadata=" + val + " — a stale schema snapshot cannot be detected at capture time (a same-column-count change like a rename would index values under the wrong column names)",
-		Remediation: "Optional: embed column names in row-event metadata so bintrail can verify the snapshot against every event (dynamic, no restart; adds a few bytes per TABLE_MAP event):\n\n" +
+		Remediation: "Optional: embed column names in row-event metadata so bintrail can verify the snapshot against every event (dynamic, no restart; adds a handful of bytes per column to each TABLE_MAP event):\n\n" +
 			"  -- MySQL 8.0+:\n" +
 			"  SET PERSIST binlog_row_metadata = 'FULL';\n\n" +
 			"  -- MariaDB 10.5+ (no SET PERSIST; persist it in my.cnf under [mysqld]):\n" +

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -353,7 +353,9 @@ func TestCheckRowMetadata(t *testing.T) {
 	}{
 		{"FULL", row("FULL"), StatusPass, "binlog_row_metadata=FULL", false},
 		{"MINIMAL", row("MINIMAL"), StatusWarn, "binlog_row_metadata=MINIMAL", true},
-		{"variable absent", errResp("Error 1193: Unknown system variable"), StatusSkip, "not available", false},
+		{"MariaDB NO_LOG default", row("NO_LOG"), StatusWarn, "binlog_row_metadata=NO_LOG", true},
+		{"variable absent", mysqlErrResp(1193, "Unknown system variable 'binlog_row_metadata'"), StatusSkip, "not available", false},
+		{"transient read failure", errResp("driver: bad connection"), StatusWarn, "could not read binlog_row_metadata: driver: bad connection", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -394,6 +396,12 @@ type mockSQLScalar struct {
 
 func row(v string) mockSQLScalar       { return mockSQLScalar{value: v} }
 func errResp(msg string) mockSQLScalar { return mockSQLScalar{err: errors.New(msg)} }
+
+// mysqlErrResp mocks a typed MySQL server error (e.g. 1193 unknown system
+// variable) so checks that discriminate by error number can be exercised.
+func mysqlErrResp(number uint16, msg string) mockSQLScalar {
+	return mockSQLScalar{err: &mysql.MySQLError{Number: number, Message: msg}}
+}
 
 func (r mockSQLScalar) apply(exp *sqlmock.ExpectedQuery, col string) {
 	if r.err != nil {

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -341,6 +341,51 @@ func TestCheckBinlogRetention(t *testing.T) {
 	}
 }
 
+// TestCheckRowMetadata pins the #700 advisory check: PASS on FULL, WARN
+// (never FAIL) on MINIMAL, SKIP when the variable does not exist.
+func TestCheckRowMetadata(t *testing.T) {
+	tests := []struct {
+		name            string
+		probe           mockSQLScalar
+		wantStatus      CheckStatus
+		wantDetailFrag  string
+		wantRemediation bool
+	}{
+		{"FULL", row("FULL"), StatusPass, "binlog_row_metadata=FULL", false},
+		{"MINIMAL", row("MINIMAL"), StatusWarn, "binlog_row_metadata=MINIMAL", true},
+		{"variable absent", errResp("Error 1193: Unknown system variable"), StatusSkip, "not available", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("sqlmock: %v", err)
+			}
+			defer db.Close()
+
+			exp := mock.ExpectQuery("SELECT @@binlog_row_metadata")
+			tt.probe.apply(exp, "@@binlog_row_metadata")
+
+			got := checkRowMetadata(db)
+			if got.Status != tt.wantStatus {
+				t.Errorf("Status = %q, want %q (detail=%q)", got.Status, tt.wantStatus, got.Detail)
+			}
+			if !strings.Contains(got.Detail, tt.wantDetailFrag) {
+				t.Errorf("Detail = %q, want substring %q", got.Detail, tt.wantDetailFrag)
+			}
+			if tt.wantRemediation && got.Remediation == "" {
+				t.Error("expected remediation but got none")
+			}
+			if got.Status == StatusFail {
+				t.Error("binlog_row_metadata is optional — the check must never FAIL")
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("unmet expectations: %v", err)
+			}
+		})
+	}
+}
+
 // mockSQLScalar is a single-value SELECT mock — value xor err.
 type mockSQLScalar struct {
 	value string

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -72,7 +72,13 @@ type SnapshotStats struct {
 // It holds the full snapshot in memory for fast per-event lookups during indexing.
 type Resolver struct {
 	snapshotID int
-	tables     map[string]*TableMeta // key: "schema.table"
+	// snapshotTime is the snapshot's creation time (schema_snapshots.
+	// snapshot_time, stamped from the bintrail host clock by TakeSnapshot).
+	// Zero = unknown (test resolvers built via NewResolverFromTables).
+	// The #700 drift guard uses it to tell a STALE snapshot (event newer
+	// than the snapshot) from a routine HISTORICAL event (older).
+	snapshotTime time.Time
+	tables       map[string]*TableMeta // key: "schema.table"
 }
 
 // NewResolver loads all table metadata for the given snapshot from the index
@@ -106,6 +112,17 @@ func NewResolver(db *sql.DB, snapshotID int) (*Resolver, error) {
 	defer rows.Close()
 
 	r := &Resolver{snapshotID: snapshotID, tables: make(map[string]*TableMeta)}
+
+	// Snapshot creation time (all rows of one snapshot share it; MIN is
+	// defensive). Best-effort: a scan failure leaves it zero (unknown), which
+	// the #700 drift guard treats as strict.
+	var snapTime sql.NullTime
+	if err := db.QueryRow(
+		"SELECT MIN(snapshot_time) FROM schema_snapshots WHERE snapshot_id = ?",
+		snapshotID).Scan(&snapTime); err == nil && snapTime.Valid {
+		r.snapshotTime = snapTime.Time
+	}
+
 	sawColumnType := false
 	sawDataType := false
 
@@ -174,13 +191,24 @@ func NewResolver(db *sql.DB, snapshotID int) (*Resolver, error) {
 }
 
 // NewResolverFromTables creates a Resolver directly from a pre-built table map.
-// The map key must be "schema.table". Primarily useful for testing.
+// The map key must be "schema.table". Primarily useful for testing. The
+// snapshot time is left zero (unknown) — use NewResolverFromTablesAt to set it.
 func NewResolverFromTables(snapshotID int, tables map[string]*TableMeta) *Resolver {
 	return &Resolver{snapshotID: snapshotID, tables: tables}
 }
 
+// NewResolverFromTablesAt is NewResolverFromTables with an explicit snapshot
+// creation time, for tests exercising the #700 historical-event distinction.
+func NewResolverFromTablesAt(snapshotID int, snapshotTime time.Time, tables map[string]*TableMeta) *Resolver {
+	return &Resolver{snapshotID: snapshotID, snapshotTime: snapshotTime, tables: tables}
+}
+
 // SnapshotID returns the snapshot ID this resolver was loaded from.
 func (r *Resolver) SnapshotID() int { return r.snapshotID }
+
+// SnapshotTime returns the snapshot's creation time; zero when unknown
+// (resolvers built by NewResolverFromTables without an explicit time).
+func (r *Resolver) SnapshotTime() time.Time { return r.snapshotTime }
 
 // TableCount returns the number of tables in this resolver.
 func (r *Resolver) TableCount() int { return len(r.tables) }

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -73,10 +73,12 @@ type SnapshotStats struct {
 type Resolver struct {
 	snapshotID int
 	// snapshotTime is the snapshot's creation time (schema_snapshots.
-	// snapshot_time, stamped from the bintrail host clock by TakeSnapshot).
-	// Zero = unknown (test resolvers built via NewResolverFromTables).
-	// The #700 drift guard uses it to tell a STALE snapshot (event newer
-	// than the snapshot) from a routine HISTORICAL event (older).
+	// snapshot_time, stamped from the bintrail host clock by TakeSnapshot
+	// and WritePGSnapshot). Zero = unknown: any constructor that does not
+	// set it — NewResolverFromTables without the At variant — which the
+	// #700 drift guard treats as strict. The guard uses it to tell a STALE
+	// snapshot (event at-or-after the snapshot) from a routine HISTORICAL
+	// event (before it).
 	snapshotTime time.Time
 	tables       map[string]*TableMeta // key: "schema.table"
 }
@@ -114,12 +116,17 @@ func NewResolver(db *sql.DB, snapshotID int) (*Resolver, error) {
 	r := &Resolver{snapshotID: snapshotID, tables: make(map[string]*TableMeta)}
 
 	// Snapshot creation time (all rows of one snapshot share it; MIN is
-	// defensive). Best-effort: a scan failure leaves it zero (unknown), which
-	// the #700 drift guard treats as strict.
+	// defensive). Best-effort: a failure leaves it zero (unknown), which the
+	// #700 drift guard treats as STRICT — silently flipping historical
+	// events from warn-and-proceed to hard-error — so the cause must be in
+	// the logs, never swallowed.
 	var snapTime sql.NullTime
 	if err := db.QueryRow(
 		"SELECT MIN(snapshot_time) FROM schema_snapshots WHERE snapshot_id = ?",
-		snapshotID).Scan(&snapTime); err == nil && snapTime.Valid {
+		snapshotID).Scan(&snapTime); err != nil {
+		slog.Warn("could not read the snapshot's creation time — the schema-drift guard will treat ALL diverging events as stale (hard error), including historical ones",
+			"snapshot_id", snapshotID, "error", err)
+	} else if snapTime.Valid {
 		r.snapshotTime = snapTime.Time
 	}
 

--- a/internal/parser/drift_integration_test.go
+++ b/internal/parser/drift_integration_test.go
@@ -1,0 +1,121 @@
+//go:build integration
+
+package parser_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	drivermysql "github.com/go-sql-driver/mysql"
+
+	"github.com/dbtrail/dbtrail/internal/config"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/parser"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestParseFile_schemaDriftFailsLoud is the #700 end-to-end guard against a
+// REAL binlog: take a snapshot, RENAME a column (same column count — invisible
+// to the count guard), write rows, and parse with the now-stale resolver.
+// With binlog_row_metadata=FULL the TABLE_MAP carries the new name and
+// ParseFile must fail loud instead of silently indexing values under the old
+// column name.
+func TestParseFile_schemaDriftFailsLoud(t *testing.T) {
+	sourceDB, sourceName := testutil.CreateTestDB(t)
+	indexDB, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, indexDB)
+
+	// GLOBAL-only variable: read original, set FULL, restore in Cleanup.
+	var original string
+	if err := sourceDB.QueryRow("SELECT @@binlog_row_metadata").Scan(&original); err != nil {
+		var myErr *drivermysql.MySQLError
+		if errors.As(err, &myErr) && myErr.Number == 1193 {
+			t.Skipf("binlog_row_metadata not supported on this server: %v", err)
+		}
+		t.Fatalf("read binlog_row_metadata failed: %v", err)
+	}
+	testutil.MustExec(t, sourceDB, "SET GLOBAL binlog_row_metadata = 'FULL'")
+	t.Cleanup(func() {
+		if _, err := sourceDB.Exec("SET GLOBAL binlog_row_metadata = ?", original); err != nil {
+			t.Errorf("restore binlog_row_metadata=%s failed (later packages' binlogs are affected): %v", original, err)
+		}
+	})
+
+	testutil.MustExec(t, sourceDB, `CREATE TABLE orders (
+		id       INT PRIMARY KEY AUTO_INCREMENT,
+		customer VARCHAR(100) NOT NULL,
+		amount   DECIMAL(10,2) NOT NULL
+	)`)
+
+	stats, err := metadata.TakeSnapshot(sourceDB, indexDB, []string{sourceName})
+	if err != nil {
+		t.Fatalf("TakeSnapshot failed: %v", err)
+	}
+	staleResolver, err := metadata.NewResolver(indexDB, stats.SnapshotID)
+	if err != nil {
+		t.Fatalf("NewResolver failed: %v", err)
+	}
+
+	testutil.MustExec(t, sourceDB, "FLUSH BINARY LOGS")
+	currentBinlog, _, err := config.CurrentBinlogPosition(sourceDB)
+	if err != nil {
+		t.Fatalf("CurrentBinlogPosition failed: %v", err)
+	}
+
+	// Positive-path traffic FIRST: with names matching the snapshot, rows
+	// must parse cleanly under FULL metadata.
+	testutil.MustExec(t, sourceDB, "INSERT INTO orders (customer, amount) VALUES ('Alice', 99.99)")
+
+	// The same-count drift: rename a column AFTER the snapshot. The count
+	// guard cannot see this; only the FULL-metadata name check can.
+	testutil.MustExec(t, sourceDB, "ALTER TABLE orders RENAME COLUMN customer TO client")
+	testutil.MustExec(t, sourceDB, "INSERT INTO orders (client, amount) VALUES ('Bob', 50.00)")
+
+	testutil.MustExec(t, sourceDB, "FLUSH BINARY LOGS")
+
+	tmpDir := t.TempDir()
+	cpCmd := exec.Command("docker", "cp",
+		fmt.Sprintf("bintrail-test-mysql:/var/lib/mysql/%s", currentBinlog),
+		filepath.Join(tmpDir, currentBinlog),
+	)
+	if out, err := cpCmd.CombinedOutput(); err != nil {
+		t.Fatalf("docker cp %s failed: %v\n%s", currentBinlog, err, out)
+	}
+
+	p := parser.New(tmpDir, staleResolver, parser.Filters{
+		Schemas: map[string]bool{sourceName: true},
+	}, nil)
+
+	events := make(chan parser.Event, 100)
+	done := make(chan error, 1)
+	go func() {
+		defer close(events)
+		done <- p.ParseFile(context.Background(), currentBinlog, events)
+	}()
+	all := drainEvents(events)
+	parseErr := <-done
+
+	// The pre-drift INSERT must have emitted normally.
+	dml := dmlEvents(all)
+	if len(dml) != 1 {
+		t.Errorf("expected exactly 1 pre-drift DML event, got %d", len(dml))
+	} else if dml[0].RowAfter["customer"] == nil {
+		t.Errorf("pre-drift event must map the snapshot's column name, got %v", dml[0].RowAfter)
+	}
+
+	// The post-rename rows must abort the parse with the drift error —
+	// naming both sides and the remediation.
+	if parseErr == nil {
+		t.Fatal("expected ParseFile to fail loud on the renamed column, got nil (silent corruption)")
+	}
+	for _, want := range []string{"schema drift", "client", "customer", "bintrail snapshot"} {
+		if !strings.Contains(parseErr.Error(), want) {
+			t.Errorf("drift error missing %q: %v", want, parseErr)
+		}
+	}
+}

--- a/internal/parser/drift_integration_test.go
+++ b/internal/parser/drift_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	drivermysql "github.com/go-sql-driver/mysql"
 
@@ -67,6 +68,13 @@ func TestParseFile_schemaDriftFailsLoud(t *testing.T) {
 		t.Fatalf("CurrentBinlogPosition failed: %v", err)
 	}
 
+	// The stale-vs-historical distinction compares the binlog event
+	// timestamp (source clock, 1s granularity) against the snapshot's
+	// creation time (bintrail host clock): sleep past both the granularity
+	// and modest container/host clock skew so the post-rename events are
+	// unambiguously NEWER than the snapshot (the hard-error side).
+	time.Sleep(2 * time.Second)
+
 	// Positive-path traffic FIRST: with names matching the snapshot, rows
 	// must parse cleanly under FULL metadata.
 	testutil.MustExec(t, sourceDB, "INSERT INTO orders (customer, amount) VALUES ('Alice', 99.99)")
@@ -117,5 +125,100 @@ func TestParseFile_schemaDriftFailsLoud(t *testing.T) {
 		if !strings.Contains(parseErr.Error(), want) {
 			t.Errorf("drift error missing %q: %v", want, parseErr)
 		}
+	}
+}
+
+// TestParseFile_historicalDriftWarnsAndIndexes pins the review-forced
+// distinction end-to-end: events written BEFORE the snapshot whose TABLE_MAP
+// names differ (the snapshot post-dates a rename) are a routine historical
+// state — re-indexing old files must WARN and index them under the
+// snapshot's current names, never dead-end on a hard error whose remediation
+// (re-snapshot) would be a no-op.
+func TestParseFile_historicalDriftWarnsAndIndexes(t *testing.T) {
+	sourceDB, sourceName := testutil.CreateTestDB(t)
+	indexDB, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, indexDB)
+
+	var original string
+	if err := sourceDB.QueryRow("SELECT @@binlog_row_metadata").Scan(&original); err != nil {
+		var myErr *drivermysql.MySQLError
+		if errors.As(err, &myErr) && myErr.Number == 1193 {
+			t.Skipf("binlog_row_metadata not supported on this server: %v", err)
+		}
+		t.Fatalf("read binlog_row_metadata failed: %v", err)
+	}
+	testutil.MustExec(t, sourceDB, "SET GLOBAL binlog_row_metadata = 'FULL'")
+	t.Cleanup(func() {
+		if _, err := sourceDB.Exec("SET GLOBAL binlog_row_metadata = ?", original); err != nil {
+			t.Errorf("restore binlog_row_metadata=%s failed: %v", original, err)
+		}
+	})
+
+	testutil.MustExec(t, sourceDB, `CREATE TABLE orders (
+		id       INT PRIMARY KEY,
+		customer VARCHAR(100) NOT NULL
+	)`)
+
+	testutil.MustExec(t, sourceDB, "FLUSH BINARY LOGS")
+	currentBinlog, _, err := config.CurrentBinlogPosition(sourceDB)
+	if err != nil {
+		t.Fatalf("CurrentBinlogPosition failed: %v", err)
+	}
+
+	// History: a row written under the OLD column name...
+	testutil.MustExec(t, sourceDB, "INSERT INTO orders (id, customer) VALUES (1, 'Alice')")
+	// ...then the rename, then the snapshot — taken AFTER both, so the
+	// insert above is a pre-snapshot event whose TABLE_MAP carries a name
+	// the snapshot no longer has. Sleep past the 1s binlog-timestamp
+	// granularity + modest clock skew so the event is unambiguously OLDER.
+	testutil.MustExec(t, sourceDB, "ALTER TABLE orders RENAME COLUMN customer TO client")
+	time.Sleep(2 * time.Second)
+
+	stats, err := metadata.TakeSnapshot(sourceDB, indexDB, []string{sourceName})
+	if err != nil {
+		t.Fatalf("TakeSnapshot failed: %v", err)
+	}
+	resolver, err := metadata.NewResolver(indexDB, stats.SnapshotID)
+	if err != nil {
+		t.Fatalf("NewResolver failed: %v", err)
+	}
+	if resolver.SnapshotTime().IsZero() {
+		t.Fatal("NewResolver must load the snapshot creation time (the drift guard depends on it)")
+	}
+
+	testutil.MustExec(t, sourceDB, "FLUSH BINARY LOGS")
+
+	tmpDir := t.TempDir()
+	cpCmd := exec.Command("docker", "cp",
+		fmt.Sprintf("bintrail-test-mysql:/var/lib/mysql/%s", currentBinlog),
+		filepath.Join(tmpDir, currentBinlog),
+	)
+	if out, err := cpCmd.CombinedOutput(); err != nil {
+		t.Fatalf("docker cp %s failed: %v\n%s", currentBinlog, err, out)
+	}
+
+	p := parser.New(tmpDir, resolver, parser.Filters{
+		Schemas: map[string]bool{sourceName: true},
+	}, nil)
+
+	events := make(chan parser.Event, 100)
+	done := make(chan error, 1)
+	go func() {
+		defer close(events)
+		done <- p.ParseFile(context.Background(), currentBinlog, events)
+	}()
+	all := drainEvents(events)
+	if err := <-done; err != nil {
+		t.Fatalf("re-indexing history through a rename must not hard-error (permanent dead end), got: %v", err)
+	}
+
+	dml := dmlEvents(all)
+	if len(dml) != 1 {
+		t.Fatalf("expected the historical INSERT to index, got %d DML events", len(dml))
+	}
+	// Values land under the snapshot's CURRENT name — pre-#700 behavior,
+	// positionally correct for a pure rename.
+	if dml[0].RowAfter["client"] != "Alice" {
+		t.Errorf("historical event must index under the snapshot's current column name, got %v", dml[0].RowAfter)
 	}
 }

--- a/internal/parser/drift_mariadb_integration_test.go
+++ b/internal/parser/drift_mariadb_integration_test.go
@@ -1,0 +1,123 @@
+//go:build integration
+
+package parser_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	drivermysql "github.com/go-sql-driver/mysql"
+
+	"github.com/dbtrail/dbtrail/internal/config"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/parser"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestParseFile_schemaDrift_mariadb mirrors TestParseFile_schemaDriftFailsLoud
+// against MariaDB (container bintrail-test-mariadb, 13307). It verifies the
+// load-bearing cross-flavor assumption the doctor check and docs advertise:
+// MariaDB's binlog_row_metadata=FULL TABLE_MAP decodes through the same
+// go-mysql ColumnName path, so the drift guard genuinely fires there — if the
+// decode differed, the guard would degrade to a silent no-op on MariaDB
+// (fail-open, exactly the corruption class #700 exists to stop) and only a
+// real-binlog test can notice.
+func TestParseFile_schemaDrift_mariadb(t *testing.T) {
+	sourceDB, sourceName := testutil.CreateTestMariaDB(t)
+	indexDB, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, indexDB)
+
+	// GLOBAL-only variable on MariaDB too: read original (default NO_LOG),
+	// set FULL, restore in Cleanup.
+	var original string
+	if err := sourceDB.QueryRow("SELECT @@binlog_row_metadata").Scan(&original); err != nil {
+		var myErr *drivermysql.MySQLError
+		if errors.As(err, &myErr) && myErr.Number == 1193 {
+			t.Skipf("binlog_row_metadata not supported on this MariaDB: %v", err)
+		}
+		testutil.SkipOrFailMariaDB(t, "read binlog_row_metadata failed: %v", err)
+	}
+	testutil.MustExec(t, sourceDB, "SET GLOBAL binlog_row_metadata = 'FULL'")
+	t.Cleanup(func() {
+		if _, err := sourceDB.Exec("SET GLOBAL binlog_row_metadata = ?", original); err != nil {
+			t.Errorf("restore binlog_row_metadata=%s failed: %v", original, err)
+		}
+	})
+
+	testutil.MustExec(t, sourceDB, `CREATE TABLE orders (
+		id       INT PRIMARY KEY AUTO_INCREMENT,
+		customer VARCHAR(100) NOT NULL,
+		amount   DECIMAL(10,2) NOT NULL
+	)`)
+
+	stats, err := metadata.TakeSnapshot(sourceDB, indexDB, []string{sourceName})
+	if err != nil {
+		t.Fatalf("TakeSnapshot: %v", err)
+	}
+	staleResolver, err := metadata.NewResolver(indexDB, stats.SnapshotID)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+
+	testutil.MustExec(t, sourceDB, "FLUSH BINARY LOGS")
+	currentBinlog, _, err := config.CurrentBinlogPosition(sourceDB)
+	if err != nil {
+		t.Fatalf("CurrentBinlogPosition (MariaDB): %v", err)
+	}
+
+	// Same stale-vs-historical timing discipline as the MySQL test: the
+	// post-rename events must be unambiguously NEWER than the snapshot.
+	time.Sleep(2 * time.Second)
+
+	// Matching traffic parses cleanly under FULL metadata...
+	testutil.MustExec(t, sourceDB, "INSERT INTO orders (customer, amount) VALUES ('Alice', 99.99)")
+	// ...then the same-count rename the count guard can't see.
+	testutil.MustExec(t, sourceDB, "ALTER TABLE orders RENAME COLUMN customer TO client")
+	testutil.MustExec(t, sourceDB, "INSERT INTO orders (client, amount) VALUES ('Bob', 50.00)")
+
+	testutil.MustExec(t, sourceDB, "FLUSH BINARY LOGS")
+
+	tmpDir := t.TempDir()
+	cpCmd := exec.Command("docker", "cp",
+		fmt.Sprintf("bintrail-test-mariadb:/var/lib/mysql/%s", currentBinlog),
+		filepath.Join(tmpDir, currentBinlog),
+	)
+	if out, err := cpCmd.CombinedOutput(); err != nil {
+		testutil.SkipOrFailMariaDB(t, "docker cp %s from bintrail-test-mariadb failed: %v\n%s", currentBinlog, err, out)
+	}
+
+	p := parser.New(tmpDir, staleResolver, parser.Filters{
+		Schemas: map[string]bool{sourceName: true},
+	}, nil)
+
+	events := make(chan parser.Event, 100)
+	done := make(chan error, 1)
+	go func() {
+		defer close(events)
+		done <- p.ParseFile(context.Background(), currentBinlog, events)
+	}()
+	all := drainEvents(events)
+	parseErr := <-done
+
+	dml := dmlEvents(all)
+	if len(dml) != 1 {
+		t.Errorf("expected exactly 1 pre-drift DML event, got %d", len(dml))
+	} else if dml[0].RowAfter["customer"] == nil {
+		t.Errorf("pre-drift event must map the snapshot's column name, got %v", dml[0].RowAfter)
+	}
+
+	if parseErr == nil {
+		t.Fatal("MariaDB FULL metadata must trip the drift guard on the renamed column — a nil error means the guard silently no-ops on this flavor (fail-open)")
+	}
+	for _, want := range []string{"schema drift", "client", "customer", "bintrail snapshot"} {
+		if !strings.Contains(parseErr.Error(), want) {
+			t.Errorf("drift error missing %q: %v", want, parseErr)
+		}
+	}
+}

--- a/internal/parser/drift_test.go
+++ b/internal/parser/drift_test.go
@@ -240,3 +240,72 @@ func TestMysqlIdentEqualFold_turkishDottedI(t *testing.T) {
 		t.Error("distinct identifiers must not fold equal")
 	}
 }
+
+// The boundary case: an event in the SAME second as the snapshot (1s binlog
+// timestamp granularity makes this the common real tie) must take the
+// hard-error side — "at-or-after" — so a refactor to eventTime.After() can't
+// silently flip ties onto the warn-and-proceed (corruption) side.
+func TestHandleRows_snapshotTimeTieFailsLoud(t *testing.T) {
+	snapTime := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	evs, err := runHandleRowsWith(t, driftResolverAt(snapTime),
+		driftRowsEventAt([]string{"id", "total"}, snapTime), &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("event at exactly the snapshot time must hard-error (at-or-after = stale)")
+	}
+	if len(evs) != 0 {
+		t.Errorf("tie must emit no events, got %d", len(evs))
+	}
+}
+
+// A zero EVENT timestamp (tool-generated/rewritten binlogs) is an unknown
+// age — it must stay strict, not classify as pre-snapshot lenient.
+func TestHandleRows_zeroEventTimestampStaysStrict(t *testing.T) {
+	snapTime := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	ev := driftRowsEvent([]string{"id", "total"})
+	ev.Header.Timestamp = 0
+	evs, err := runHandleRowsWith(t, driftResolverAt(snapTime), ev, &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("zero event timestamp must stay strict (unknown age), got warn-and-proceed")
+	}
+	if len(evs) != 0 {
+		t.Errorf("expected no events, got %d", len(evs))
+	}
+}
+
+// Pins the deliberate asymmetry: names present but COUNT differing takes the
+// pre-existing count-guard warn-and-skip (parser.go count validation), never
+// the drift hard error — and the len(names)==len(tm.Columns) gate is what
+// keeps the name loop in bounds.
+func TestHandleRows_namesPresentCountDiffersTakesCountGuard(t *testing.T) {
+	tme := &replication.TableMapEvent{
+		Schema:      []byte("shop"),
+		Table:       []byte("orders"),
+		ColumnCount: 1, // table now has ONE column; snapshot has two
+		ColumnName:  [][]byte{[]byte("id")},
+	}
+	binlogEv := &replication.BinlogEvent{
+		Header: &replication.EventHeader{
+			EventType: replication.WRITE_ROWS_EVENTv2,
+			LogPos:    200,
+			EventSize: 100,
+		},
+		Event: &replication.RowsEvent{
+			Table: tme,
+			Rows:  [][]any{{int64(1)}},
+		},
+	}
+
+	var logBuf bytes.Buffer
+	evs, err := runHandleRowsWith(t, driftResolver(), binlogEv, &logBuf)
+	if err != nil {
+		t.Fatalf("count divergence must take the count-guard skip, not the drift error: %v", err)
+	}
+	if len(evs) != 0 {
+		t.Errorf("count guard must skip the event, got %d emitted", len(evs))
+	}
+	if !strings.Contains(logBuf.String(), "column count mismatch") {
+		t.Errorf("expected the count-guard warn, got logs: %s", logBuf.String())
+	}
+}

--- a/internal/parser/drift_test.go
+++ b/internal/parser/drift_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-mysql-org/go-mysql/replication"
 
@@ -59,9 +60,14 @@ func driftRowsEvent(columnNames []string) *replication.BinlogEvent {
 
 func runHandleRows(t *testing.T, binlogEv *replication.BinlogEvent) ([]Event, error) {
 	t.Helper()
+	return runHandleRowsWith(t, driftResolver(), binlogEv, &bytes.Buffer{})
+}
+
+func runHandleRowsWith(t *testing.T, resolver *metadata.Resolver, binlogEv *replication.BinlogEvent, logBuf *bytes.Buffer) ([]Event, error) {
+	t.Helper()
 	rowsEv := binlogEv.Event.(*replication.RowsEvent)
 	out := make(chan Event, 4)
-	err := handleRows(context.Background(), newTestLogger(&bytes.Buffer{}), driftResolver(), &Filters{}, binlogEv, rowsEv, "binlog.000001", "", 0, 9, out)
+	err := handleRows(context.Background(), newTestLogger(logBuf), resolver, &Filters{}, binlogEv, rowsEv, "binlog.000001", "", 0, 9, out)
 	close(out)
 	var evs []Event
 	for ev := range out {
@@ -144,5 +150,93 @@ func TestStreamParser_driftErrorPropagates(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "schema drift") {
 		t.Errorf("error = %v, want schema-drift", err)
+	}
+}
+
+// driftResolverAt is driftResolver with an explicit snapshot creation time,
+// for the historical-vs-stale distinction tests.
+func driftResolverAt(snapTime time.Time) *metadata.Resolver {
+	tm := &metadata.TableMeta{
+		Schema: "shop",
+		Table:  "orders",
+		Columns: []metadata.ColumnMeta{
+			{Name: "id", OrdinalPosition: 1, IsPK: true, DataType: "int"},
+			{Name: "amount", OrdinalPosition: 2, DataType: "int"},
+		},
+		PKColumns: []string{"id"},
+	}
+	return metadata.NewResolverFromTablesAt(9, snapTime, map[string]*metadata.TableMeta{"shop.orders": tm})
+}
+
+// driftRowsEventAt is driftRowsEvent with an explicit event timestamp.
+func driftRowsEventAt(columnNames []string, ts time.Time) *replication.BinlogEvent {
+	ev := driftRowsEvent(columnNames)
+	ev.Header.Timestamp = uint32(ts.Unix())
+	return ev
+}
+
+// A divergence on an event OLDER than the snapshot is a routine historical
+// state (re-indexing history after a rename; stream backlog catch-up) — a
+// hard error would be a permanent dead end whose remediation (re-snapshot)
+// is a no-op. It must warn and proceed under the snapshot's names.
+func TestHandleRows_preSnapshotDriftWarnsAndProceeds(t *testing.T) {
+	snapTime := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	eventTime := snapTime.Add(-1 * time.Hour) // event predates the snapshot
+
+	var logBuf bytes.Buffer
+	evs, err := runHandleRowsWith(t, driftResolverAt(snapTime),
+		driftRowsEventAt([]string{"id", "total"}, eventTime), &logBuf)
+	if err != nil {
+		t.Fatalf("pre-snapshot divergence must not hard-error: %v", err)
+	}
+	if len(evs) != 1 {
+		t.Fatalf("pre-snapshot event must still index, got %d events", len(evs))
+	}
+	if evs[0].RowAfter["amount"] != int64(10) {
+		t.Errorf("values must index under the SNAPSHOT's names, got %v", evs[0].RowAfter)
+	}
+	logged := logBuf.String()
+	for _, want := range []string{"pre-snapshot", "total", "amount"} {
+		if !strings.Contains(logged, want) {
+			t.Errorf("historical divergence must warn naming both sides; logs missing %q: %s", want, logged)
+		}
+	}
+}
+
+// A divergence on an event AT-OR-AFTER the snapshot is the genuine stale
+// case — hard error, and re-snapshotting actually converges.
+func TestHandleRows_postSnapshotDriftFailsLoud(t *testing.T) {
+	snapTime := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	eventTime := snapTime.Add(1 * time.Hour) // event AFTER the snapshot
+
+	evs, err := runHandleRowsWith(t, driftResolverAt(snapTime),
+		driftRowsEventAt([]string{"id", "total"}, eventTime), &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("post-snapshot divergence must hard-error (stale snapshot)")
+	}
+	if !strings.Contains(err.Error(), "schema drift") {
+		t.Errorf("error = %v, want schema-drift", err)
+	}
+	if len(evs) != 0 {
+		t.Errorf("stale-snapshot drift must emit no events, got %d", len(evs))
+	}
+}
+
+// MySQL treats the Turkish dotted/dotless I pair (İ U+0130, ı U+0131) as
+// equal to I/i in identifiers, but Unicode simple folding does not — a legal
+// case-style rename İstanbul→istanbul must NOT be drift.
+func TestMysqlIdentEqualFold_turkishDottedI(t *testing.T) {
+	cases := [][2]string{
+		{"İstanbul", "istanbul"},
+		{"ıspanak", "ISPANAK"},
+		{"amount", "AMOUNT"},
+	}
+	for _, c := range cases {
+		if !mysqlIdentEqualFold(c[0], c[1]) {
+			t.Errorf("mysqlIdentEqualFold(%q, %q) = false, want true (MySQL treats them as the same identifier)", c[0], c[1])
+		}
+	}
+	if mysqlIdentEqualFold("amount", "total") {
+		t.Error("distinct identifiers must not fold equal")
 	}
 }

--- a/internal/parser/drift_test.go
+++ b/internal/parser/drift_test.go
@@ -1,0 +1,148 @@
+package parser
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/go-mysql-org/go-mysql/replication"
+
+	"github.com/dbtrail/dbtrail/internal/metadata"
+)
+
+// ─── Capture-time schema-drift cross-check (#700) ─────────────────────────────
+//
+// With binlog_row_metadata=FULL the TABLE_MAP event carries the table's real
+// column names. handleRows must hold the schema snapshot against them and fail
+// LOUD on a same-count divergence (rename, DROP+ADD) — the drift class the
+// column-count guard cannot see, which would otherwise index row values under
+// the wrong column names.
+
+// driftResolver builds a two-column shop.orders resolver (id PK, amount).
+func driftResolver() *metadata.Resolver {
+	tm := &metadata.TableMeta{
+		Schema: "shop",
+		Table:  "orders",
+		Columns: []metadata.ColumnMeta{
+			{Name: "id", OrdinalPosition: 1, IsPK: true, DataType: "int"},
+			{Name: "amount", OrdinalPosition: 2, DataType: "int"},
+		},
+		PKColumns: []string{"id"},
+	}
+	return metadata.NewResolverFromTables(9, map[string]*metadata.TableMeta{"shop.orders": tm})
+}
+
+// driftRowsEvent builds a WRITE_ROWS event for shop.orders with the given
+// TABLE_MAP column names (nil = binlog_row_metadata=MINIMAL, no names).
+func driftRowsEvent(columnNames []string) *replication.BinlogEvent {
+	tme := &replication.TableMapEvent{
+		Schema:      []byte("shop"),
+		Table:       []byte("orders"),
+		ColumnCount: 2,
+	}
+	for _, n := range columnNames {
+		tme.ColumnName = append(tme.ColumnName, []byte(n))
+	}
+	return &replication.BinlogEvent{
+		Header: &replication.EventHeader{
+			EventType: replication.WRITE_ROWS_EVENTv2,
+			LogPos:    200,
+			EventSize: 100,
+		},
+		Event: &replication.RowsEvent{
+			Table: tme,
+			Rows:  [][]any{{int64(1), int64(10)}},
+		},
+	}
+}
+
+func runHandleRows(t *testing.T, binlogEv *replication.BinlogEvent) ([]Event, error) {
+	t.Helper()
+	rowsEv := binlogEv.Event.(*replication.RowsEvent)
+	out := make(chan Event, 4)
+	err := handleRows(context.Background(), newTestLogger(&bytes.Buffer{}), driftResolver(), &Filters{}, binlogEv, rowsEv, "binlog.000001", "", 0, 9, out)
+	close(out)
+	var evs []Event
+	for ev := range out {
+		evs = append(evs, ev)
+	}
+	return evs, err
+}
+
+func TestHandleRows_matchingColumnNamesEmit(t *testing.T) {
+	evs, err := runHandleRows(t, driftRowsEvent([]string{"id", "amount"}))
+	if err != nil {
+		t.Fatalf("matching names must not error: %v", err)
+	}
+	if len(evs) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(evs))
+	}
+	if evs[0].RowAfter["amount"] != int64(10) {
+		t.Errorf("RowAfter[amount] = %v, want 10", evs[0].RowAfter["amount"])
+	}
+}
+
+// The corruption case: same column COUNT, different NAME (a rename since the
+// snapshot). Must return a hard error naming both sides — never emit.
+func TestHandleRows_renamedColumnFailsLoud(t *testing.T) {
+	evs, err := runHandleRows(t, driftRowsEvent([]string{"id", "total"}))
+	if err == nil {
+		t.Fatal("expected a schema-drift error for a renamed column, got nil")
+	}
+	for _, want := range []string{"schema drift", "total", "amount", "bintrail snapshot", "shop.orders", "binlog.000001"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("drift error missing %q: %v", want, err)
+		}
+	}
+	if len(evs) != 0 {
+		t.Errorf("drift must emit no events, got %d", len(evs))
+	}
+}
+
+// A case-only difference is not drift: MySQL column names are
+// case-insensitive, so the name→value mapping is unchanged.
+func TestHandleRows_caseOnlyNameDifferenceIsNotDrift(t *testing.T) {
+	evs, err := runHandleRows(t, driftRowsEvent([]string{"ID", "Amount"}))
+	if err != nil {
+		t.Fatalf("case-only difference must not error: %v", err)
+	}
+	if len(evs) != 1 {
+		t.Errorf("expected 1 event, got %d", len(evs))
+	}
+}
+
+// Under the default binlog_row_metadata=MINIMAL the TABLE_MAP carries no
+// names — the check must degrade to a no-op (today's behavior, unchanged).
+func TestHandleRows_noColumnNamesNoCheck(t *testing.T) {
+	evs, err := runHandleRows(t, driftRowsEvent(nil))
+	if err != nil {
+		t.Fatalf("MINIMAL metadata (no names) must not error: %v", err)
+	}
+	if len(evs) != 1 {
+		t.Errorf("expected 1 event, got %d", len(evs))
+	}
+}
+
+// TestStreamParser_driftErrorPropagates pins that the drift error aborts the
+// stream (fail closed) rather than being swallowed by the Run loop.
+func TestStreamParser_driftErrorPropagates(t *testing.T) {
+	sp := NewStreamParser(driftResolver(), Filters{}, nil)
+	streamer := replication.NewBinlogStreamer()
+	out := make(chan Event, 4)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	feedThenCancel(t, streamer, cancel,
+		makeRotate("binlog.000001"),
+		driftRowsEvent([]string{"id", "total"}),
+	)
+
+	err := sp.Run(ctx, streamer, out)
+	if err == nil {
+		t.Fatal("expected Run to surface the schema-drift error")
+	}
+	if !strings.Contains(err.Error(), "schema drift") {
+		t.Errorf("error = %v, want schema-drift", err)
+	}
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -261,7 +261,8 @@ func handleRows(
 	// count-mismatch skip. The compare is case-insensitive per MySQL's
 	// identifier rules (a case-only rename does not change the mapping) and
 	// includes generated columns (present in both the snapshot and the FULL
-	// row image). Under the default binlog_row_metadata=MINIMAL the event
+	// TABLE_MAP metadata — a different knob from the #493 guard's
+	// binlog_row_image below). Under the default binlog_row_metadata=MINIMAL the event
 	// carries no names and the check degrades to a no-op.
 	//
 	// A divergence splits on the event's age relative to the snapshot:
@@ -287,14 +288,17 @@ func handleRows(
 	// while event timestamps come from the source server; a large clock skew
 	// can misclassify a rename taken moments around the snapshot — the
 	// failure mode is a loud warning instead of a hard stop, never silence.
-	// A zero snapshot time (unknown) stays strict.
+	// A zero snapshot time (unknown) stays strict,
+	// and so does a zero EVENT timestamp (tool-generated/rewritten binlogs
+	// occasionally carry zeroed headers — an unknown age must not take the
+	// lenient path).
 	if names := rowsEv.Table.ColumnNameString(); len(names) > 0 && len(names) == len(tm.Columns) {
 		for i := range names {
 			if mysqlIdentEqualFold(names[i], tm.Columns[i].Name) {
 				continue
 			}
 			eventTime := time.Unix(int64(binlogEv.Header.Timestamp), 0).UTC()
-			if snapTime := resolver.SnapshotTime(); !snapTime.IsZero() && eventTime.Before(snapTime) {
+			if snapTime := resolver.SnapshotTime(); binlogEv.Header.Timestamp != 0 && !snapTime.IsZero() && eventTime.Before(snapTime) {
 				logger.Warn("column names differ from snapshot for a pre-snapshot event — indexing under the snapshot's names",
 					"file", filename,
 					"pos", binlogEv.Header.LogPos,
@@ -312,7 +316,8 @@ func handleRows(
 					"the snapshot is stale (a column was renamed, or dropped and re-added, since it was taken) and indexing "+
 					"these events would attribute row values to the wrong columns — run `bintrail snapshot` against the "+
 					"current schema, then re-run indexing (a failed file re-indexes from the start; a stream resumes from "+
-					"its checkpoint)",
+					"its checkpoint); if this event actually PREDATES the snapshot, check for clock skew between the "+
+					"bintrail host and the source server",
 				filename, binlogEv.Header.LogPos, schema, table,
 				i+1, names[i], schemaVersion, tm.Columns[i].Name)
 		}
@@ -509,6 +514,9 @@ func emitUpdates(
 // column error, and RENAME COLUMN İstanbul TO istanbul succeeds as a
 // case-style rename), while Unicode simple folding maps neither to 'i' — so
 // a plain EqualFold would flag that legal case-style rename as drift (#700).
+// Accents are NOT folded by MySQL identifiers (verified on 8.4: CREATE TABLE
+// t (e INT, é INT) succeeds with two distinct columns), so no wider
+// normalization is needed.
 func mysqlIdentEqualFold(a, b string) bool {
 	if strings.EqualFold(a, b) {
 		return true

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -258,25 +258,63 @@ func handleRows(
 	// schema change (a column rename, or a DROP+ADD in one ALTER) leaves the
 	// count equal while every value after the changed ordinal would be
 	// attributed to the WRONG column name — silent corruption, worse than the
-	// count-mismatch skip. Fail loud like the partial-image guard below: this
-	// is the authoritative chokepoint covering both the file-index and stream
-	// paths, and proceeding would write wrong data that `recover` later
-	// trusts. The compare is case-insensitive (MySQL column names are
-	// case-insensitive; a case-only rename does not change the mapping) and
+	// count-mismatch skip. The compare is case-insensitive per MySQL's
+	// identifier rules (a case-only rename does not change the mapping) and
 	// includes generated columns (present in both the snapshot and the FULL
 	// row image). Under the default binlog_row_metadata=MINIMAL the event
 	// carries no names and the check degrades to a no-op.
+	//
+	// A divergence splits on the event's age relative to the snapshot:
+	//
+	//   * Event AT-OR-AFTER the snapshot → the snapshot is STALE (the schema
+	//     changed after it was taken). Fail loud like the partial-image guard
+	//     below — proceeding would write wrong data that `recover` later
+	//     trusts, and the remediation (re-run `bintrail snapshot`) genuinely
+	//     converges: the fresh snapshot matches these events.
+	//
+	//   * Event BEFORE the snapshot → a routine historical state, not a
+	//     stale snapshot: re-indexing old files after a rename, or a stream
+	//     catching up through a backlog written before the operator
+	//     re-snapshotted. Re-snapshotting is a NO-OP here (the old names are
+	//     baked into the binlog), so a hard error would be a permanent dead
+	//     end with no converging remediation. Proceed exactly as before
+	//     #700 — values index under the snapshot's CURRENT names, which is
+	//     positionally correct for a pure rename (and is what makes the
+	//     generated recovery SQL executable against the live table) — and
+	//     warn loudly per rows event, the count guard's verbosity class.
+	//
+	// The snapshot time comes from the bintrail host clock (TakeSnapshot)
+	// while event timestamps come from the source server; a large clock skew
+	// can misclassify a rename taken moments around the snapshot — the
+	// failure mode is a loud warning instead of a hard stop, never silence.
+	// A zero snapshot time (unknown) stays strict.
 	if names := rowsEv.Table.ColumnNameString(); len(names) > 0 && len(names) == len(tm.Columns) {
 		for i := range names {
-			if !strings.EqualFold(names[i], tm.Columns[i].Name) {
-				return fmt.Errorf(
-					"schema drift detected at %s:%d for %s.%s: binlog TABLE_MAP column %d is %q but schema snapshot %d has %q; "+
-						"the snapshot is stale (a column was renamed, or dropped and re-added, since it was taken) and indexing "+
-						"these events would attribute row values to the wrong columns — run `bintrail snapshot` against the "+
-						"current schema and re-index from this point",
-					filename, binlogEv.Header.LogPos, schema, table,
-					i+1, names[i], schemaVersion, tm.Columns[i].Name)
+			if mysqlIdentEqualFold(names[i], tm.Columns[i].Name) {
+				continue
 			}
+			eventTime := time.Unix(int64(binlogEv.Header.Timestamp), 0).UTC()
+			if snapTime := resolver.SnapshotTime(); !snapTime.IsZero() && eventTime.Before(snapTime) {
+				logger.Warn("column names differ from snapshot for a pre-snapshot event — indexing under the snapshot's names",
+					"file", filename,
+					"pos", binlogEv.Header.LogPos,
+					"schema", schema,
+					"table", table,
+					"ordinal", i+1,
+					"binlog_column", names[i],
+					"snapshot_column", tm.Columns[i].Name,
+					"event_time", eventTime,
+					"snapshot_time", snapTime)
+				break
+			}
+			return fmt.Errorf(
+				"schema drift detected at %s:%d for %s.%s: binlog TABLE_MAP column %d is %q but schema snapshot %d has %q; "+
+					"the snapshot is stale (a column was renamed, or dropped and re-added, since it was taken) and indexing "+
+					"these events would attribute row values to the wrong columns — run `bintrail snapshot` against the "+
+					"current schema, then re-run indexing (a failed file re-indexes from the start; a stream resumes from "+
+					"its checkpoint)",
+				filename, binlogEv.Header.LogPos, schema, table,
+				i+1, names[i], schemaVersion, tm.Columns[i].Name)
 		}
 	}
 
@@ -462,6 +500,27 @@ func emitUpdates(
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
+
+// mysqlIdentEqualFold reports whether two column identifiers are equal under
+// MySQL's case-insensitive identifier comparison. strings.EqualFold covers
+// every case MySQL folds except the Turkish dotted/dotless I pair: MySQL's
+// identifier collation treats İ (U+0130) and ı (U+0131) as equal to I/i
+// (verified on 8.4: CREATE TABLE t (i INT, İ INT) fails with a duplicate-
+// column error, and RENAME COLUMN İstanbul TO istanbul succeeds as a
+// case-style rename), while Unicode simple folding maps neither to 'i' — so
+// a plain EqualFold would flag that legal case-style rename as drift (#700).
+func mysqlIdentEqualFold(a, b string) bool {
+	if strings.EqualFold(a, b) {
+		return true
+	}
+	dotless := func(r rune) rune {
+		if r == 'İ' || r == 'ı' {
+			return 'i'
+		}
+		return r
+	}
+	return strings.EqualFold(strings.Map(dotless, a), strings.Map(dotless, b))
+}
 
 // BuildPKValues forwards to event.BuildPKValues (kept for back-compat; the
 // canonical doc lives on event.BuildPKValues).

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -251,6 +251,35 @@ func handleRows(
 		return nil
 	}
 
+	// Column NAME cross-check (#700): with binlog_row_metadata=FULL the
+	// TABLE_MAP event embeds the table's real column names at write time,
+	// giving us per-event ground truth to hold the snapshot against. This
+	// catches the drift class the count guard above CANNOT see: a same-count
+	// schema change (a column rename, or a DROP+ADD in one ALTER) leaves the
+	// count equal while every value after the changed ordinal would be
+	// attributed to the WRONG column name — silent corruption, worse than the
+	// count-mismatch skip. Fail loud like the partial-image guard below: this
+	// is the authoritative chokepoint covering both the file-index and stream
+	// paths, and proceeding would write wrong data that `recover` later
+	// trusts. The compare is case-insensitive (MySQL column names are
+	// case-insensitive; a case-only rename does not change the mapping) and
+	// includes generated columns (present in both the snapshot and the FULL
+	// row image). Under the default binlog_row_metadata=MINIMAL the event
+	// carries no names and the check degrades to a no-op.
+	if names := rowsEv.Table.ColumnNameString(); len(names) > 0 && len(names) == len(tm.Columns) {
+		for i := range names {
+			if !strings.EqualFold(names[i], tm.Columns[i].Name) {
+				return fmt.Errorf(
+					"schema drift detected at %s:%d for %s.%s: binlog TABLE_MAP column %d is %q but schema snapshot %d has %q; "+
+						"the snapshot is stale (a column was renamed, or dropped and re-added, since it was taken) and indexing "+
+						"these events would attribute row values to the wrong columns — run `bintrail snapshot` against the "+
+						"current schema and re-index from this point",
+					filename, binlogEv.Header.LogPos, schema, table,
+					i+1, names[i], schemaVersion, tm.Columns[i].Name)
+			}
+		}
+	}
+
 	// Partial row image guard (#493): bintrail requires binlog_row_image=FULL.
 	// Under MINIMAL/NOBLOB, MySQL omits columns from the before/after image and
 	// go-mysql pads the absent positions to nil — which we would otherwise store


### PR DESCRIPTION
closes #700

## Summary
- **The gap**: the column-count guard in `handleRows` can't see a *same-count* schema change — a column rename, or `DROP COLUMN` + `ADD COLUMN` in one `ALTER` — after the snapshot. Today those events index with values attributed to the **wrong column names**: silent corruption, worse than the count-mismatch skip, and `recover` would later trust it.
- **The check**: when the source runs `binlog_row_metadata=FULL` (MySQL 8.0+, MariaDB 10.5+), each TABLE_MAP event embeds the real column names (`go-mysql` already decodes them — `TableMapEvent.ColumnNameString()`). `handleRows` — the single chokepoint shared by file + stream parsers — now compares them ordinal-by-ordinal against the snapshot and returns a **hard error** on divergence (the #493 partial-image fail-loud precedent), naming both sides, the binlog coordinates, and the remediation.
- **Deliberate softenings**: case-insensitive compare (MySQL column names are case-insensitive; a case-only rename doesn't change the mapping); generated columns included (present on both sides); `MINIMAL` (the default) carries no names → the check no-ops and existing installs see zero behavior change.
- **Doctor**: advisory `Schema-drift detection (binlog_row_metadata)` check — PASS on FULL, WARN + `SET PERSIST` suggestion on MINIMAL, SKIP where the variable doesn't exist; never FAIL (validate, never set).
- **Docs**: `indexing.md` now explains why same-count changes are the dangerous ones and how to opt in.

Complements the schema-drift epic (#600/#601/#602), which handles drift at read/apply time — this catches it at **capture time**, before wrong data is written. The MariaDB alpha benefits for free (same TableMapEvent path).

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] New unit tests: matching names emit; renamed column → hard error naming both sides (no event emitted); case-only difference is not drift; no names (MINIMAL) no-ops; the error propagates out of `StreamParser.Run` (fail closed)
- [x] Integration (Docker MySQL 13306): end-to-end corruption repro — snapshot → `ALTER TABLE ... RENAME COLUMN` → insert → parse with the stale resolver: the pre-drift event indexes normally, the post-rename rows abort the parse with the drift error; `SET GLOBAL binlog_row_metadata` restored in `t.Cleanup` (GLOBAL-only variable, `-p 1` shared-binlog discipline)
- [x] Doctor unit tests: FULL→PASS, MINIMAL→WARN+remediation, absent→SKIP, never-FAIL pinned

🤖 Generated with [Claude Code](https://claude.com/claude-code)