### PR TITLE
forensics: connection_cache poller — persist session identity in the index

### DIFF
--- a/cmd/bintrail-console/monitor.go
+++ b/cmd/bintrail-console/monitor.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dbtrail/dbtrail/internal/config"
 	"github.com/dbtrail/dbtrail/internal/console"
 	"github.com/dbtrail/dbtrail/internal/doctor"
+	"github.com/dbtrail/dbtrail/internal/forensics"
 	"github.com/dbtrail/dbtrail/internal/indexer"
 	"github.com/dbtrail/dbtrail/internal/serverid"
 	"github.com/dbtrail/dbtrail/internal/streamdeps"
@@ -426,6 +427,24 @@ func (m *monitorSupervisor) run(ctx context.Context, job *monitorJob, e console.
 			job.lockDB.Close() // releases the advisory lock
 		}
 	}()
+
+	// Forensics: cache this source's live session identity into its
+	// per-source index database so attribution survives disconnects. Scoped
+	// to the supervision session (stopped when run returns — stop verb,
+	// circuit breaker, daemon shutdown), and deliberately spanning crash-loop
+	// backoff gaps: identities captured while the stream is down attribute
+	// the events gap-fill indexes afterwards. Gate-checked at the surface
+	// (#701 D1); --attribution-retention 0 disables it inside the poller.
+	// The SourceDSN guard keeps direct run() callers (tests) poller-free.
+	if forensics.Enabled() && e.SourceDSN != "" {
+		pollerCtx, stopPoller := context.WithCancel(ctx)
+		defer stopPoller()
+		forensics.StartConnCachePoller(pollerCtx, forensics.ConnCacheConfig{
+			SourceDSN: e.SourceDSN,
+			IndexDSN:  e.DSN,
+			Retention: upAttributionRetention,
+		})
+	}
 
 	attempt := 0
 	var crashLoopSince time.Time // first failure of the current loop; zero = healthy

--- a/cmd/bintrail-console/watch.go
+++ b/cmd/bintrail-console/watch.go
@@ -21,6 +21,7 @@ import (
 	"github.com/dbtrail/dbtrail/internal/config"
 	"github.com/dbtrail/dbtrail/internal/console"
 	"github.com/dbtrail/dbtrail/internal/doctor"
+	"github.com/dbtrail/dbtrail/internal/forensics"
 	"github.com/dbtrail/dbtrail/internal/indexer"
 	"github.com/dbtrail/dbtrail/internal/rotation"
 	"github.com/dbtrail/dbtrail/internal/serverid"
@@ -97,6 +98,8 @@ var (
 	upRotateInterval  string
 	upRotateAddFuture int
 
+	upAttributionRetention time.Duration
+
 	// upRotationCfg holds the parsed built-in-rotation settings from runWatch's
 	// validation, read at the phase-3 start sites (the cobra-accumulator
 	// pattern; the parsing and the loop itself live in internal/rotation).
@@ -124,6 +127,7 @@ var watchEnvBindings = []struct {
 	{"rotate-retain", "BINTRAIL_ROTATE_RETAIN"},
 	{"rotate-interval", "BINTRAIL_ROTATE_INTERVAL"},
 	{"rotate-add-future", "BINTRAIL_ROTATE_ADD_FUTURE"},
+	{"attribution-retention", "BINTRAIL_ATTRIBUTION_RETENTION"},
 }
 
 // bindWatchEnv loads the env file (once) and applies BINTRAIL_* environment
@@ -176,6 +180,7 @@ func init() {
 	watchCmd.Flags().StringVar(&upRotateRetain, "rotate-retain", "30d", "Built-in rotation: drop index partitions older than this (Nd/Nh; \"off\" disables)")
 	watchCmd.Flags().StringVar(&upRotateInterval, "rotate-interval", "1h", "Built-in rotation: how often to run a rotation cycle")
 	watchCmd.Flags().IntVar(&upRotateAddFuture, "rotate-add-future", 3, "Built-in rotation: keep at least N future hourly partitions ready")
+	watchCmd.Flags().DurationVar(&upAttributionRetention, "attribution-retention", forensics.DefaultRetention, "Forensics: keep disconnected-session identity (connection_cache) for this long; 0 disables the poller")
 	// --source-dsn is deliberately NOT required: the daemon may start
 	// source-less (zero-config install) and sources are added from the UI.
 	_ = watchCmd.MarkFlagRequired("index-dsn")
@@ -541,6 +546,19 @@ func runUpStreamWithConsole(cmd *cobra.Command, args []string) error {
 	// desired state lives in the registry, positions in each per-source
 	// stream_state checkpoint.
 	go supervisor.Reconcile(registry)
+
+	// Forensics: session-identity poller for the main stream's source (each
+	// supervised per-source stream gets its own inside the supervisor). Same
+	// lifecycle and contract as rotation: a secondary job on the daemon
+	// context, never fatal to the stream. Gate-checked at the surface
+	// (#701 D1); --attribution-retention 0 disables it inside the poller.
+	if forensics.Enabled() {
+		forensics.StartConnCachePoller(ctx, forensics.ConnCacheConfig{
+			SourceDSN: upSourceDSN,
+			IndexDSN:  upIndexDSN,
+			Retention: upAttributionRetention,
+		})
+	}
 
 	streamErr := streamrun.One(ctx, watchStreamConfig(serverID))
 	stop()                // drain the console even if the stream returned without a signal

--- a/cmd/bintrail/config.go
+++ b/cmd/bintrail/config.go
@@ -189,6 +189,12 @@ var envSections = []envSection{
 		},
 	},
 	{
+		Header: "Forensics attribution (used by bintrail up / bintrail-console watch; 0 disables the session-identity poller)",
+		Bindings: []envTemplateEntry{
+			{"BINTRAIL_ATTRIBUTION_RETENTION", "24h"},
+		},
+	},
+	{
 		Header: "Baseline retention (used by bintrail baseline; prunes local snapshots once a durable S3 copy exists)",
 		Bindings: []envTemplateEntry{
 			{"BINTRAIL_BASELINE_RETAIN", ""},

--- a/cmd/bintrail/up.go
+++ b/cmd/bintrail/up.go
@@ -5,11 +5,13 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/dbtrail/dbtrail/internal/cliutil"
 	"github.com/dbtrail/dbtrail/internal/doctor"
+	"github.com/dbtrail/dbtrail/internal/forensics"
 	"github.com/dbtrail/dbtrail/internal/rotation"
 	"github.com/dbtrail/dbtrail/internal/serverid"
 )
@@ -57,6 +59,8 @@ var (
 	upRotateInterval  string
 	upRotateAddFuture int
 
+	upAttributionRetention time.Duration
+
 	// upRotationCfg holds the parsed built-in-rotation settings from runUp's
 	// validation, read at the phase-3 start site (the cobra-accumulator
 	// pattern; the parsing and the loop itself live in internal/rotation).
@@ -78,6 +82,7 @@ func init() {
 	upCmd.Flags().StringVar(&upRotateRetain, "rotate-retain", "30d", "Built-in rotation: drop index partitions older than this (Nd/Nh; \"off\" disables)")
 	upCmd.Flags().StringVar(&upRotateInterval, "rotate-interval", "1h", "Built-in rotation: how often to run a rotation cycle")
 	upCmd.Flags().IntVar(&upRotateAddFuture, "rotate-add-future", 3, "Built-in rotation: keep at least N future hourly partitions ready")
+	upCmd.Flags().DurationVar(&upAttributionRetention, "attribution-retention", forensics.DefaultRetention, "Forensics: keep disconnected-session identity (connection_cache) for this long; 0 disables the poller")
 	// --source-dsn is validated in runUp instead of MarkFlagRequired so the
 	// rotation settings parse first (fail-fast on a typo before any phase
 	// runs) — see TestRunUp_explicitRetentionWiring, which relies on that
@@ -199,6 +204,18 @@ func runUpStream(cmd *cobra.Command, args []string) error {
 	rotation.StartLoop(rotCtx, func() rotation.Settings { return upRotationCfg }, func() []rotation.RotateTarget {
 		return []rotation.RotateTarget{{DSN: upIndexDSN}}
 	})
+	// Forensics: cache live session identity (user/host/program per
+	// connection_id) into the index so attribution survives disconnects.
+	// Same lifecycle and contract as rotation: a secondary job that is never
+	// fatal to the stream. Gate-checked at the surface (#701 D1);
+	// --attribution-retention 0 disables it inside StartConnCachePoller.
+	if forensics.Enabled() {
+		forensics.StartConnCachePoller(rotCtx, forensics.ConnCacheConfig{
+			SourceDSN: upSourceDSN,
+			IndexDSN:  upIndexDSN,
+			Retention: upAttributionRetention,
+		})
+	}
 	return runStream(cmd, args)
 }
 

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -60,6 +60,7 @@ var EnvBindings = []EnvBinding{
 	{"rotate-retain", "BINTRAIL_ROTATE_RETAIN"},
 	{"rotate-interval", "BINTRAIL_ROTATE_INTERVAL"},
 	{"rotate-add-future", "BINTRAIL_ROTATE_ADD_FUTURE"},
+	{"attribution-retention", "BINTRAIL_ATTRIBUTION_RETENTION"},
 	{"baseline-retain", "BINTRAIL_BASELINE_RETAIN"},
 	{"ultrafast", "BINTRAIL_ULTRAFAST"},
 	{"duckdb-threads", "BINTRAIL_DUCKDB_THREADS"},

--- a/internal/forensics/conncache.go
+++ b/internal/forensics/conncache.go
@@ -1,0 +1,452 @@
+package forensics
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/config"
+)
+
+// The capture cadences are constants, not knobs (#703): a 500ms poll makes
+// even short-lived sessions likely to be seen at least once, and reading
+// performance_schema.threads is an in-memory scan with no disk I/O on the
+// source. Retention — how much identity history to keep — is the operator's
+// choice (--attribution-retention); how we capture is ours.
+const (
+	pollInterval    = 500 * time.Millisecond
+	cleanupInterval = time.Hour
+)
+
+// DefaultRetention is how long connection_cache rows outlive their last
+// sighting when the operator does not choose otherwise (epic #701, decision
+// D2 — the SaaS agent hardcoded 24h; here it is the --attribution-retention
+// default and the sweep window is a parameter).
+const DefaultRetention = 24 * time.Hour
+
+// ConnCacheConfig configures one source's connection-identity poller.
+type ConnCacheConfig struct {
+	// SourceDSN is the watched MySQL server whose performance_schema is
+	// polled. Strictly read-only — the poller never writes to the source.
+	SourceDSN string
+	// IndexDSN is the bintrail index database holding the connection_cache
+	// table (created by `bintrail init` / indexer.EnsureSchema).
+	IndexDSN string
+	// Retention is how long a cached connection outlives its last sighting
+	// before the hourly sweep deletes it. Zero or negative disables the
+	// poller entirely.
+	Retention time.Duration
+}
+
+// cachedConn holds a row from performance_schema.threads during polling.
+type cachedConn struct {
+	id      int64
+	user    sql.NullString
+	host    sql.NullString
+	db      sql.NullString
+	command sql.NullString
+}
+
+// StartConnCachePoller launches the connection-identity poller: every 500ms
+// it reads the source's live foreground sessions (performance_schema.threads
+// plus session_connect_attrs, scoped to the ids just seen) and upserts them
+// into the connection_cache table in the index DB, so forensic attribution of
+// a binlog event's connection_id still resolves after the session disconnects
+// — performance_schema rows vanish the moment a session ends. An hourly sweep
+// deletes rows unseen for cfg.Retention.
+//
+// Mirrors rotation.StartLoop's contract: returns immediately and is never
+// fatal to the caller — connection failures and per-cycle panics are logged
+// and retried, because attribution capture is a secondary job that must never
+// take down the stream (the primary forensic capture). When the source has an
+// active audit plugin the poller logs and does not poll: audit logs carry
+// better session history at lower cost. The loop stops when ctx is cancelled;
+// the returned channel closes when it has fully exited (used by tests for
+// deterministic shutdown; production callers may ignore it).
+func StartConnCachePoller(ctx context.Context, cfg ConnCacheConfig) <-chan struct{} {
+	done := make(chan struct{})
+	if cfg.Retention <= 0 {
+		slog.Info("connection-cache: attribution retention disabled; not caching session identity")
+		close(done)
+		return done
+	}
+	go func() {
+		defer close(done)
+
+		sourceDB, err := config.Connect(cfg.SourceDSN)
+		if err != nil {
+			slog.Warn("connection-cache: cannot connect to source; session identity will not be cached this run",
+				"error", config.ScrubDSNText(err.Error(), cfg.SourceDSN, cfg.IndexDSN))
+			return
+		}
+		defer sourceDB.Close()
+		// Courtesy caps: the poller must never contend with the customer's
+		// workload on the source.
+		sourceDB.SetMaxOpenConns(2)
+		sourceDB.SetMaxIdleConns(1)
+
+		indexDB, err := config.Connect(cfg.IndexDSN)
+		if err != nil {
+			slog.Warn("connection-cache: cannot connect to index; session identity will not be cached this run",
+				"error", config.ScrubDSNText(err.Error(), cfg.SourceDSN, cfg.IndexDSN))
+			return
+		}
+		defer indexDB.Close()
+		indexDB.SetMaxOpenConns(2)
+		indexDB.SetMaxIdleConns(1)
+
+		if auditProbe(ctx, sourceDB) {
+			slog.Info("connection-cache: active audit plugin detected on the source — not polling (the audit log carries better session history at lower cost)")
+			return
+		}
+
+		slog.Info("connection-cache: caching session identity for forensic attribution",
+			"poll_interval", pollInterval.String(), "retention", cfg.Retention.String())
+		pollLoop(ctx, sourceDB, indexDB, cfg.Retention)
+	}()
+	return done
+}
+
+// pollLoop drives the two tickers — the 500ms thread poll and the hourly
+// retention sweep — until ctx is cancelled. Each cycle is recover-guarded so
+// a panic can never take down the caller's stream (mirrors rotation.StartLoop).
+func pollLoop(ctx context.Context, sourceDB, indexDB *sql.DB, retention time.Duration) {
+	var consecutiveFailures int
+	poll := func() {
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Error("connection-cache: poll cycle panicked; polling continues next tick", "panic", r)
+			}
+		}()
+		if err := pollOnce(ctx, sourceDB, indexDB); err != nil && ctx.Err() == nil {
+			consecutiveFailures++
+			// Log the first failure and then every 60th (≈ every 30s at the
+			// 500ms cadence) so an outage doesn't flood the log.
+			if consecutiveFailures == 1 || consecutiveFailures%60 == 0 {
+				slog.Warn("connection-cache: poll error",
+					"consecutive_failures", consecutiveFailures, "error", err)
+			}
+		} else if err == nil && consecutiveFailures > 0 {
+			slog.Info("connection-cache: poll recovered", "after_failures", consecutiveFailures)
+			consecutiveFailures = 0
+		}
+	}
+	sweep := func() {
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Error("connection-cache: retention sweep panicked; sweep continues next tick", "panic", r)
+			}
+		}()
+		if err := cleanupConnectionCache(ctx, indexDB, retention); err != nil && ctx.Err() == nil {
+			slog.Warn("connection-cache: retention sweep error", "error", err)
+		}
+	}
+
+	pollTicker := time.NewTicker(pollInterval)
+	defer pollTicker.Stop()
+	cleanupTicker := time.NewTicker(cleanupInterval)
+	defer cleanupTicker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-pollTicker.C:
+			poll()
+		case <-cleanupTicker.C:
+			sweep()
+		}
+	}
+}
+
+// pollOnce reads the current foreground connections from performance_schema
+// and upserts them into connection_cache in the index DB.
+func pollOnce(ctx context.Context, sourceDB, indexDB *sql.DB) error {
+	pollCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	// 1. Read foreground threads from performance_schema (in-memory, no disk I/O).
+	rows, err := sourceDB.QueryContext(pollCtx,
+		"SELECT PROCESSLIST_ID, PROCESSLIST_USER, PROCESSLIST_HOST, "+
+			"PROCESSLIST_DB, PROCESSLIST_COMMAND "+
+			"FROM performance_schema.threads WHERE TYPE = 'FOREGROUND'")
+	if err != nil {
+		return fmt.Errorf("query threads: %w", err)
+	}
+
+	var conns []cachedConn
+	for rows.Next() {
+		var c cachedConn
+		if err := rows.Scan(&c.id, &c.user, &c.host, &c.db, &c.command); err != nil {
+			slog.Warn("connection-cache: scan thread row", "error", err)
+			continue
+		}
+		conns = append(conns, c)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate threads: %w", err)
+	}
+
+	if len(conns) == 0 {
+		return nil
+	}
+
+	// 2. Read session_connect_attrs only for the foreground connections we
+	// found — never a blanket scan.
+	connIDs := make([]int64, len(conns))
+	for i, c := range conns {
+		connIDs[i] = c.id
+	}
+	attrMap := pollConnAttrs(pollCtx, sourceDB, connIDs)
+
+	// 3. Batch upsert into connection_cache.
+	return upsertConnections(pollCtx, indexDB, conns, attrMap)
+}
+
+// pollConnAttrs reads session_connect_attrs for the given connection IDs and
+// returns a map of connection_id → {attr_name: attr_value}. Failures are
+// logged, not fatal — identity without client attributes still attributes.
+func pollConnAttrs(ctx context.Context, sourceDB *sql.DB, connIDs []int64) map[int64]map[string]string {
+	result := map[int64]map[string]string{}
+	if len(connIDs) == 0 {
+		return result
+	}
+
+	placeholders := make([]string, len(connIDs))
+	args := make([]any, len(connIDs))
+	for i, id := range connIDs {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+
+	rows, err := sourceDB.QueryContext(ctx, fmt.Sprintf(
+		"SELECT PROCESSLIST_ID, ATTR_NAME, ATTR_VALUE "+
+			"FROM performance_schema.session_connect_attrs "+
+			"WHERE PROCESSLIST_ID IN (%s)",
+		strings.Join(placeholders, ",")), args...)
+	if err != nil {
+		slog.Warn("connection-cache: query session_connect_attrs", "error", err)
+		return result
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var connID int64
+		var name, value string
+		if err := rows.Scan(&connID, &name, &value); err != nil {
+			slog.Warn("connection-cache: scan session_connect_attrs row", "error", err)
+			continue
+		}
+		if result[connID] == nil {
+			result[connID] = map[string]string{}
+		}
+		result[connID][name] = value
+	}
+	if err := rows.Err(); err != nil {
+		slog.Warn("connection-cache: iterate session_connect_attrs", "error", err)
+	}
+	return result
+}
+
+// upsertConnections batch-inserts connections into connection_cache using
+// INSERT … ON DUPLICATE KEY UPDATE to minimize round trips.
+func upsertConnections(ctx context.Context, indexDB *sql.DB, conns []cachedConn, attrMap map[int64]map[string]string) error {
+	const batchSize = 50
+	for i := 0; i < len(conns); i += batchSize {
+		if err := upsertBatch(ctx, indexDB, conns[i:min(i+batchSize, len(conns))], attrMap); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func upsertBatch(ctx context.Context, indexDB *sql.DB, conns []cachedConn, attrMap map[int64]map[string]string) error {
+	if len(conns) == 0 {
+		return nil
+	}
+
+	var sb strings.Builder
+	sb.WriteString("INSERT INTO connection_cache " +
+		"(connection_id, user, host, db, command, connection_attributes, cached_at, last_seen) VALUES ")
+
+	args := make([]any, 0, len(conns)*6)
+	for i, c := range conns {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		sb.WriteString("(?,?,?,?,?,?,NOW(),NOW())")
+
+		var attrsJSON []byte
+		if attrs, ok := attrMap[c.id]; ok && len(attrs) > 0 {
+			var merr error
+			attrsJSON, merr = json.Marshal(attrs)
+			if merr != nil {
+				slog.Warn("connection-cache: marshal connection attributes", "connection_id", c.id, "error", merr)
+				attrsJSON = nil
+			}
+		}
+
+		args = append(args, c.id, c.user, c.host, c.db, c.command, attrsJSON)
+	}
+
+	sb.WriteString(" ON DUPLICATE KEY UPDATE " +
+		"user=VALUES(user), host=VALUES(host), db=VALUES(db), " +
+		"command=VALUES(command), connection_attributes=VALUES(connection_attributes), " +
+		"last_seen=NOW()")
+
+	_, err := indexDB.ExecContext(ctx, sb.String(), args...)
+	return err
+}
+
+// cleanupConnectionCache deletes cached entries whose last_seen timestamp is
+// older than the retention window. Active connections keep their last_seen
+// fresh via the poller, so only genuinely stale entries are removed.
+func cleanupConnectionCache(ctx context.Context, indexDB *sql.DB, retention time.Duration) error {
+	cleanupCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	result, err := indexDB.ExecContext(cleanupCtx,
+		"DELETE FROM connection_cache WHERE last_seen < NOW() - INTERVAL ? SECOND",
+		int64(retention.Seconds()))
+	if err != nil {
+		return fmt.Errorf("cleanup query: %w", err)
+	}
+	if n, _ := result.RowsAffected(); n > 0 {
+		slog.Info("connection-cache: retention sweep removed stale entries",
+			"rows", n, "retention", retention.String())
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Audit plugin check — skip polling when an audit log is available
+// ---------------------------------------------------------------------------
+
+// auditProbe is the audit-plugin check the poller runs once at start — a var,
+// not a direct call, so tests can exercise the skip branch without installing
+// an audit plugin (the rotation.escalateAfter seam pattern).
+var auditProbe = hasAuditPlugin
+
+// hasAuditPlugin reports whether an active audit plugin is installed on the
+// source MySQL. When one is, the poller should not run: the audit log carries
+// better historical connection data at lower cost (doctor and the setup guide,
+// #702, carry the remediation). A probe failure returns false — "could not
+// check" must degrade to capturing, never to a silent attribution gap.
+func hasAuditPlugin(ctx context.Context, sourceDB *sql.DB) bool {
+	probeCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	rows, err := sourceDB.QueryContext(probeCtx,
+		"SELECT PLUGIN_NAME FROM information_schema.PLUGINS "+
+			"WHERE UPPER(PLUGIN_NAME) LIKE '%AUDIT%' AND PLUGIN_STATUS = 'ACTIVE'")
+	if err != nil {
+		slog.Warn("connection-cache: could not check for an audit plugin; poller will start", "error", err)
+		return false
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			slog.Warn("connection-cache: scan audit plugin row", "error", err)
+			continue
+		}
+		// The RDS internal audit plugin is not queryable via SQL and gives
+		// the operator no session history — it must not suppress the poller.
+		if strings.Contains(strings.ToUpper(name), "RDS_SECURITY") {
+			continue
+		}
+		slog.Info("connection-cache: audit plugin detected", "plugin", name)
+		return true
+	}
+	if err := rows.Err(); err != nil {
+		slog.Warn("connection-cache: audit plugin check failed mid-read; poller will start", "error", err)
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// Cache lookup — the disconnected-session fallback for forensic enrichment
+// ---------------------------------------------------------------------------
+
+// CachedThread is one connection identity resolved from the connection_cache
+// table — the disconnected-session sibling of a live performance_schema row.
+type CachedThread struct {
+	ConnectionID int64
+	User         string
+	Host         string
+	DB           string
+	Command      string
+	ConnAttrs    map[string]string
+}
+
+// LookupCachedThreads resolves connection identities from the connection_cache
+// table in the index DB — typically for connection IDs no longer present in
+// live performance_schema because the session disconnected. Returns a map
+// keyed by connection ID; IDs with no cached row are simply absent. An empty
+// ids slice returns (nil, nil) without touching the database.
+func LookupCachedThreads(ctx context.Context, indexDB *sql.DB, ids []int64) (map[int64]CachedThread, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	placeholders := make([]string, len(ids))
+	args := make([]any, len(ids))
+	for i, id := range ids {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+
+	rows, err := indexDB.QueryContext(ctx, fmt.Sprintf(
+		"SELECT connection_id, user, host, db, command, connection_attributes "+
+			"FROM connection_cache WHERE connection_id IN (%s)",
+		strings.Join(placeholders, ",")), args...)
+	if err != nil {
+		return nil, fmt.Errorf("query connection_cache: %w", err)
+	}
+	defer rows.Close()
+
+	result := map[int64]CachedThread{}
+	for rows.Next() {
+		var ct CachedThread
+		var user, host, dbName, command, attrsJSON sql.NullString
+		if err := rows.Scan(&ct.ConnectionID, &user, &host, &dbName, &command, &attrsJSON); err != nil {
+			slog.Warn("connection-cache: scan cached row", "error", err)
+			continue
+		}
+		ct.User = user.String
+		ct.Host = host.String
+		ct.DB = dbName.String
+		ct.Command = command.String
+		if attrsJSON.Valid && attrsJSON.String != "" {
+			var attrs map[string]string
+			if err := json.Unmarshal([]byte(attrsJSON.String), &attrs); err != nil {
+				slog.Warn("connection-cache: unmarshal connection attributes",
+					"connection_id", ct.ConnectionID, "error", err)
+			} else {
+				ct.ConnAttrs = attrs
+			}
+		}
+		result[ct.ConnectionID] = ct
+	}
+	return result, rows.Err()
+}
+
+// enrichSourceString labels where enrichment data came from: live
+// performance_schema, the connection_cache fallback, or both. The enrichment
+// engine (#706) surfaces it so an analyst can tell live identities apart from
+// ones recovered after a disconnect.
+func enrichSourceString(liveCount, cacheCount int) string {
+	switch {
+	case cacheCount > 0 && liveCount > 0:
+		return "performance_schema+connection_cache"
+	case cacheCount > 0:
+		return "connection_cache"
+	default:
+		return "performance_schema"
+	}
+}

--- a/internal/forensics/conncache_integration_test.go
+++ b/internal/forensics/conncache_integration_test.go
@@ -1,0 +1,255 @@
+//go:build integration
+
+package forensics
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// sourceDSN returns the test container's server-level DSN. The container is
+// both the SOURCE (its performance_schema sees every test connection) and the
+// index server, mirroring the smallest real deployment.
+func sourceDSN() string {
+	return testutil.BaseDSN() + "/"
+}
+
+// TestIntegrationConnCachePoller_IdentityOutlivesDisconnect is the headline
+// acceptance path (#703): the poller caches a live session's identity, the
+// session is killed, and the identity still resolves from connection_cache —
+// exactly the window where performance_schema has already forgotten it.
+func TestIntegrationConnCachePoller_IdentityOutlivesDisconnect(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	// A dedicated "victim" session pinned to a single connection.
+	victim, err := sql.Open("mysql", sourceDSN()+"?parseTime=true")
+	if err != nil {
+		t.Fatalf("open victim connection: %v", err)
+	}
+	victim.SetMaxOpenConns(1)
+	victim.SetMaxIdleConns(1)
+	var victimID int64
+	if err := victim.QueryRow("SELECT CONNECTION_ID()").Scan(&victimID); err != nil {
+		victim.Close()
+		t.Fatalf("read victim connection id: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := StartConnCachePoller(ctx, ConnCacheConfig{
+		SourceDSN: sourceDSN(),
+		IndexDSN:  testutil.IntegrationDSN(dbName),
+		Retention: DefaultRetention,
+	})
+
+	// The 500ms cadence should see the victim within a couple of ticks.
+	waitForCachedThread(t, db, victimID, 20*time.Second)
+
+	// Kill the session. performance_schema forgets it immediately; the cache
+	// must not.
+	victim.Close()
+
+	cached, err := LookupCachedThreads(context.Background(), db, []int64{victimID})
+	if err != nil {
+		t.Fatalf("LookupCachedThreads after disconnect: %v", err)
+	}
+	ct, ok := cached[victimID]
+	if !ok {
+		t.Fatalf("connection %d no longer resolvable after disconnect — the cache did not outlive the session", victimID)
+	}
+	if ct.User != "root" {
+		t.Errorf("cached user = %q, want %q", ct.User, "root")
+	}
+	if ct.Host == "" {
+		t.Error("cached host is empty, want the client endpoint")
+	}
+	if ct.ConnectionID != victimID {
+		t.Errorf("cached connection id = %d, want %d", ct.ConnectionID, victimID)
+	}
+
+	// An id that never existed stays absent (no phantom identities).
+	absent, err := LookupCachedThreads(context.Background(), db, []int64{victimID + 1_000_000})
+	if err != nil {
+		t.Fatalf("LookupCachedThreads for absent id: %v", err)
+	}
+	if len(absent) != 0 {
+		t.Errorf("lookup of a never-seen id returned %v, want empty", absent)
+	}
+
+	// Deterministic shutdown: cancelling the context closes done.
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("poller did not stop on context cancel")
+	}
+}
+
+// TestIntegrationConnCacheRetentionSweep pins the D2 parameterized sweep: rows
+// unseen for longer than the retention are deleted; fresh rows survive.
+func TestIntegrationConnCacheRetentionSweep(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	testutil.MustExec(t, db, `INSERT INTO connection_cache
+		(connection_id, user, host, db, command, cached_at, last_seen) VALUES
+		(101, 'olduser', 'oldhost:1', NULL, 'Sleep', NOW() - INTERVAL 2 DAY, NOW() - INTERVAL 2 DAY),
+		(102, 'newuser', 'newhost:2', 'app', 'Query', NOW(), NOW())`)
+
+	if err := cleanupConnectionCache(context.Background(), db, 24*time.Hour); err != nil {
+		t.Fatalf("cleanupConnectionCache: %v", err)
+	}
+
+	cached, err := LookupCachedThreads(context.Background(), db, []int64{101, 102})
+	if err != nil {
+		t.Fatalf("LookupCachedThreads: %v", err)
+	}
+	if _, ok := cached[101]; ok {
+		t.Error("row unseen for 2 days survived a 24h retention sweep")
+	}
+	if _, ok := cached[102]; !ok {
+		t.Error("fresh row was deleted by the retention sweep")
+	}
+
+	// A longer retention keeps everything: the window is a parameter, not the
+	// SaaS's hardcoded 24h.
+	testutil.MustExec(t, db, `INSERT INTO connection_cache
+		(connection_id, user, host, db, command, cached_at, last_seen) VALUES
+		(103, 'olduser2', 'oldhost:3', NULL, 'Sleep', NOW() - INTERVAL 2 DAY, NOW() - INTERVAL 2 DAY)`)
+	if err := cleanupConnectionCache(context.Background(), db, 72*time.Hour); err != nil {
+		t.Fatalf("cleanupConnectionCache (72h): %v", err)
+	}
+	cached, err = LookupCachedThreads(context.Background(), db, []int64{103})
+	if err != nil {
+		t.Fatalf("LookupCachedThreads: %v", err)
+	}
+	if _, ok := cached[103]; !ok {
+		t.Error("2-day-old row was deleted under a 72h retention")
+	}
+}
+
+// TestIntegrationHasAuditPlugin_NoneInstalled pins the probe against a real
+// server with no audit plugin: it must report false so the poller runs.
+func TestIntegrationHasAuditPlugin_NoneInstalled(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	db, err := sql.Open("mysql", sourceDSN()+"?parseTime=true")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+	if hasAuditPlugin(context.Background(), db) {
+		t.Fatal("test container reports an active audit plugin; expected none (did the container image change?)")
+	}
+}
+
+// TestIntegrationAuditPluginSkipsPoller pins the skip branch: with an audit
+// plugin "present" (probe stubbed — the container has none to install), the
+// poller must exit on its own without ever writing to connection_cache.
+func TestIntegrationAuditPluginSkipsPoller(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	old := auditProbe
+	auditProbe = func(context.Context, *sql.DB) bool { return true }
+	defer func() { auditProbe = old }()
+
+	done := StartConnCachePoller(context.Background(), ConnCacheConfig{
+		SourceDSN: sourceDSN(),
+		IndexDSN:  testutil.IntegrationDSN(dbName),
+		Retention: DefaultRetention,
+	})
+	select {
+	case <-done: // exits on its own — no context cancel involved
+	case <-time.After(30 * time.Second):
+		t.Fatal("poller did not exit after audit-plugin detection")
+	}
+
+	var n int
+	if err := db.QueryRow("SELECT COUNT(*) FROM connection_cache").Scan(&n); err != nil {
+		t.Fatalf("count connection_cache: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("connection_cache has %d rows, want 0 — an audit plugin must suppress polling", n)
+	}
+}
+
+// TestIntegrationConnCachePoller_RefreshesLastSeen pins the upsert half of
+// the ON DUPLICATE KEY UPDATE: a connection seen across consecutive polls
+// keeps ONE row whose last_seen advances (the property the retention sweep
+// relies on to spare active sessions).
+func TestIntegrationConnCachePoller_RefreshesLastSeen(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	// The test's own index connection is a foreground session on the source
+	// (same container), so the poller always has at least one row to upsert.
+	var selfID int64
+	if err := db.QueryRow("SELECT CONNECTION_ID()").Scan(&selfID); err != nil {
+		t.Fatalf("read own connection id: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := StartConnCachePoller(ctx, ConnCacheConfig{
+		SourceDSN: sourceDSN(),
+		IndexDSN:  testutil.IntegrationDSN(dbName),
+		Retention: DefaultRetention,
+	})
+	waitForCachedThread(t, db, selfID, 20*time.Second)
+
+	var firstSeen time.Time
+	if err := db.QueryRow(
+		"SELECT last_seen FROM connection_cache WHERE connection_id = ?", selfID).
+		Scan(&firstSeen); err != nil {
+		t.Fatalf("read last_seen: %v", err)
+	}
+
+	// TIMESTAMP has 1s granularity; wait past it plus a few poll ticks.
+	time.Sleep(2500 * time.Millisecond)
+
+	var laterSeen time.Time
+	var rowCount int
+	if err := db.QueryRow(
+		"SELECT last_seen, (SELECT COUNT(*) FROM connection_cache WHERE connection_id = ?) "+
+			"FROM connection_cache WHERE connection_id = ?", selfID, selfID).
+		Scan(&laterSeen, &rowCount); err != nil {
+		t.Fatalf("re-read last_seen: %v", err)
+	}
+	if rowCount != 1 {
+		t.Errorf("connection %d has %d rows, want exactly 1 (upsert, not append)", selfID, rowCount)
+	}
+	if !laterSeen.After(firstSeen) {
+		t.Errorf("last_seen did not advance across polls: first %v, later %v", firstSeen, laterSeen)
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("poller did not stop on context cancel")
+	}
+}
+
+// waitForCachedThread polls connection_cache until the given connection id
+// appears or the deadline passes.
+func waitForCachedThread(t *testing.T, indexDB *sql.DB, connID int64, wait time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(wait)
+	for {
+		cached, err := LookupCachedThreads(context.Background(), indexDB, []int64{connID})
+		if err == nil {
+			if _, ok := cached[connID]; ok {
+				return
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("connection %d never appeared in connection_cache within %v (last err: %v)", connID, wait, err)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}

--- a/internal/forensics/conncache_test.go
+++ b/internal/forensics/conncache_test.go
@@ -1,0 +1,132 @@
+package forensics
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+func TestEnrichSourceString(t *testing.T) {
+	// The source string depends on how many identities came from live
+	// performance_schema vs the connection_cache fallback.
+	tests := []struct {
+		name       string
+		liveCount  int
+		cacheCount int
+		want       string
+	}{
+		{"all live", 5, 0, "performance_schema"},
+		{"all cached", 0, 3, "connection_cache"},
+		{"mixed", 2, 1, "performance_schema+connection_cache"},
+		{"none found", 0, 0, "performance_schema"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := enrichSourceString(tc.liveCount, tc.cacheCount)
+			if got != tc.want {
+				t.Errorf("enrichSourceString(%d, %d) = %q, want %q",
+					tc.liveCount, tc.cacheCount, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLookupCachedThreads_EmptyIDs(t *testing.T) {
+	// Empty ids must return (nil, nil) before any DB use — a nil *sql.DB
+	// proves the fast path never touches the handle.
+	result, err := LookupCachedThreads(context.Background(), nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != nil {
+		t.Fatalf("expected nil result for empty ids, got %v", result)
+	}
+}
+
+func TestLookupCachedThreads_UnreachableDB(t *testing.T) {
+	// A valid-looking but unreachable DB must surface an error, not nil.
+	db := openLazyDB(t, "user:pass@tcp(127.0.0.1:39999)/db")
+	result, err := LookupCachedThreads(context.Background(), db, []int64{42, 99})
+	if err == nil {
+		t.Fatal("expected error for unreachable DB")
+	}
+	if result != nil {
+		t.Fatalf("expected nil result on error, got %v", result)
+	}
+}
+
+func TestPollOnce_SourceUnreachable(t *testing.T) {
+	// pollOnce must return an error (not panic) when the source is
+	// unreachable. sql.Open doesn't connect; the error surfaces at query time.
+	sourceDB := openLazyDB(t, "user:pass@tcp(127.0.0.1:39998)/db")
+	indexDB := openLazyDB(t, "user:pass@tcp(127.0.0.1:39999)/db")
+
+	if err := pollOnce(context.Background(), sourceDB, indexDB); err == nil {
+		t.Fatal("expected error when source is unreachable")
+	}
+}
+
+func TestUpsertBatch_Empty(t *testing.T) {
+	// upsertBatch with an empty slice is a no-op — nil DB proves it never
+	// reaches the handle.
+	if err := upsertBatch(context.Background(), nil, nil, nil); err != nil {
+		t.Fatalf("unexpected error for empty batch: %v", err)
+	}
+}
+
+func TestHasAuditPlugin_Unreachable(t *testing.T) {
+	// An unreachable source must return false (poller starts), never panic:
+	// "could not check" degrades to capturing, not to an attribution gap.
+	db := openLazyDB(t, "user:pass@tcp(127.0.0.1:39997)/db")
+	if hasAuditPlugin(context.Background(), db) {
+		t.Fatal("expected false for unreachable source")
+	}
+}
+
+func TestStartConnCachePoller_DisabledRetention(t *testing.T) {
+	// Retention <= 0 disables the poller entirely: the done channel is closed
+	// before StartConnCachePoller returns and no connection is ever attempted
+	// (the DSNs here would not even parse).
+	for _, retention := range []time.Duration{0, -time.Hour} {
+		done := StartConnCachePoller(context.Background(), ConnCacheConfig{
+			SourceDSN: "not-a-dsn",
+			IndexDSN:  "also-not-a-dsn",
+			Retention: retention,
+		})
+		select {
+		case <-done:
+		default:
+			t.Fatalf("retention %v: done channel not closed synchronously for a disabled poller", retention)
+		}
+	}
+}
+
+func TestStartConnCachePoller_BadSourceDSN(t *testing.T) {
+	// An unparseable source DSN must be non-fatal: the goroutine logs and
+	// exits, closing done — the caller (the stream) is never taken down.
+	done := StartConnCachePoller(context.Background(), ConnCacheConfig{
+		SourceDSN: "not-a-dsn",
+		IndexDSN:  "also-not-a-dsn",
+		Retention: DefaultRetention,
+	})
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("poller did not exit on an unparseable source DSN")
+	}
+}
+
+// openLazyDB opens a sql.DB without connecting (lazy connect) and registers
+// cleanup. Errors surface at first use, which is what these tests exercise.
+func openLazyDB(t *testing.T, dsn string) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatalf("sql.Open(%q): %v", dsn, err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}

--- a/internal/forensics/gate.go
+++ b/internal/forensics/gate.go
@@ -1,0 +1,9 @@
+package forensics
+
+// Enabled reports whether the forensics surface is available in this build.
+//
+// dbtrail OSS ships with forensics enabled. This indirection is the single
+// entitlement seam a future enterprise-license build closes; policy lives at
+// surface entry points (CLI, console, MCP, agent, poller wiring) — never
+// inside this library, so closing the gate never touches mechanism code.
+var Enabled = func() bool { return true }

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -317,6 +317,20 @@ func EnsureSchema(db *sql.DB) error {
 			return err
 		}
 	}
+	// connection_cache post-dates the original schema (#703): the forensics
+	// poller persists session identity here so attribution survives
+	// disconnects. A whole-table migration, so it is presence-checked first —
+	// an up-to-date index keeps EnsureSchema write-free (ensureColumn's
+	// contract), which matters for index users without CREATE privilege.
+	hasConnCache, err := tableExists(db, "connection_cache")
+	if err != nil {
+		return err
+	}
+	if !hasConnCache {
+		if _, err := db.Exec(ddlConnectionCache); err != nil {
+			return fmt.Errorf("failed to create connection_cache: %w", err)
+		}
+	}
 	return nil
 }
 

--- a/internal/indexer/schema.go
+++ b/internal/indexer/schema.go
@@ -57,6 +57,7 @@ func CreateIndexTables(ctx context.Context, db *sql.DB, partitions int, encrypt 
 		{"archive_state", ddlArchiveState},
 		{"schema_changes", ddlSchemaChanges},
 		{"fk_constraints", ddlFKConstraints},
+		{"connection_cache", ddlConnectionCache},
 	}
 	for _, t := range ddls {
 		if _, err := db.Exec(t.ddl); err != nil {
@@ -273,6 +274,26 @@ const ddlFKConstraints = `CREATE TABLE IF NOT EXISTS fk_constraints (
     delete_rule              VARCHAR(16)  NOT NULL DEFAULT '' COMMENT 'ON DELETE rule (CASCADE/RESTRICT/SET NULL/NO ACTION); empty for pre-cascade-recovery snapshots',
     update_rule              VARCHAR(16)  NOT NULL DEFAULT '' COMMENT 'ON UPDATE rule; empty for pre-cascade-recovery snapshots',
     PRIMARY KEY (snapshot_id, schema_name, constraint_name, ordinal_position)
+) ENGINE=InnoDB`
+
+// ─── Forensics: connection identity cache ─────────────────────────────────────
+
+// ddlConnectionCache persists session identity (user/host/db/program) captured
+// from the source's performance_schema so forensic attribution of a binlog
+// event's connection_id survives disconnects (#703) — performance_schema rows
+// vanish the moment a session ends. Populated by the poller in
+// internal/forensics; rows unseen for --attribution-retention (default 24h)
+// are swept hourly. A separate table, not binlog_events columns, so the
+// Parquet archive/baseline schemas are untouched.
+const ddlConnectionCache = `CREATE TABLE IF NOT EXISTS connection_cache (
+    connection_id         BIGINT UNSIGNED NOT NULL PRIMARY KEY,
+    user                  VARCHAR(128),
+    host                  VARCHAR(255),
+    db                    VARCHAR(128),
+    command               VARCHAR(64),
+    connection_attributes JSON,
+    cached_at             TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    last_seen             TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB`
 
 // ─── DDL tracking ─────────────────────────────────────────────────────────────

--- a/internal/indexer/schema_integration_test.go
+++ b/internal/indexer/schema_integration_test.go
@@ -3,6 +3,7 @@
 package indexer
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -250,6 +251,61 @@ func TestEnsureSchemaAddsIdentityColumn(t *testing.T) {
 	// Idempotent: a second run must not error or re-add.
 	if err := EnsureSchema(db); err != nil {
 		t.Fatalf("EnsureSchema (second run): %v", err)
+	}
+}
+
+// TestEnsureSchemaCreatesConnectionCache pins the existing-install half of the
+// #703 migration: an index predating the forensics connection cache must gain
+// the connection_cache table (BIGINT UNSIGNED connection_id PK), idempotently.
+func TestEnsureSchemaCreatesConnectionCache(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	// Simulate a pre-#703 install by dropping the table EnsureSchema re-adds.
+	testutil.MustExec(t, db, `DROP TABLE connection_cache`)
+
+	if err := EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	var columnType, columnKey string
+	if err := db.QueryRow(`SELECT COLUMN_TYPE, COLUMN_KEY FROM information_schema.COLUMNS
+		WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'connection_cache'
+		  AND COLUMN_NAME = 'connection_id'`).Scan(&columnType, &columnKey); err != nil {
+		t.Fatalf("read connection_id column: %v", err)
+	}
+	// MySQL connection IDs are unsigned 64-bit; a signed or narrower column
+	// would silently truncate high IDs on long-lived servers.
+	if !strings.Contains(strings.ToLower(columnType), "bigint") ||
+		!strings.Contains(strings.ToLower(columnType), "unsigned") {
+		t.Errorf("connection_id COLUMN_TYPE = %q, want BIGINT UNSIGNED", columnType)
+	}
+	if columnKey != "PRI" {
+		t.Errorf("connection_id COLUMN_KEY = %q, want PRI (the upsert relies on the PK)", columnKey)
+	}
+
+	// Idempotent: a second run must not error or re-create.
+	if err := EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema (second run): %v", err)
+	}
+}
+
+// TestCreateIndexTablesIncludesConnectionCache pins the fresh-install half of
+// #703: `bintrail init` (CreateIndexTables) creates connection_cache too.
+func TestCreateIndexTablesIncludesConnectionCache(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
+
+	if err := CreateIndexTables(context.Background(), db, 2, false, nil); err != nil {
+		t.Fatalf("CreateIndexTables: %v", err)
+	}
+
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM information_schema.TABLES
+		WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'connection_cache'`).Scan(&n); err != nil {
+		t.Fatalf("check connection_cache: %v", err)
+	}
+	if n != 1 {
+		t.Fatal("fresh install (CreateIndexTables) did not create connection_cache")
 	}
 }
 

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -377,6 +377,17 @@ func InitIndexTables(t *testing.T, db *sql.DB) {
 		snapshot_id     INT UNSIGNED DEFAULT NULL,
 		INDEX idx_detected_at (detected_at)
 	) ENGINE=InnoDB`)
+
+	MustExec(t, db, `CREATE TABLE IF NOT EXISTS connection_cache (
+		connection_id         BIGINT UNSIGNED NOT NULL PRIMARY KEY,
+		user                  VARCHAR(128),
+		host                  VARCHAR(255),
+		db                    VARCHAR(128),
+		command               VARCHAR(64),
+		connection_attributes JSON,
+		cached_at             TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+		last_seen             TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+	) ENGINE=InnoDB`)
 }
 
 // InsertEvent inserts a single event into binlog_events using raw SQL.

--- a/migrations/001_create_tables.sql
+++ b/migrations/001_create_tables.sql
@@ -146,3 +146,22 @@ CREATE TABLE IF NOT EXISTS index_state (
     completed_at   DATETIME DEFAULT NULL,
     error_message  TEXT     DEFAULT NULL
 ) ENGINE=InnoDB;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Forensics: connection identity cache (#703)
+-- Persists session identity (user/host/db/program) captured from the source's
+-- performance_schema so forensic attribution of a binlog event's connection_id
+-- survives disconnects — performance_schema rows vanish the moment a session
+-- ends. Populated by the poller in internal/forensics; rows unseen for
+-- --attribution-retention (default 24h) are swept hourly.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS connection_cache (
+    connection_id         BIGINT UNSIGNED NOT NULL PRIMARY KEY,
+    user                  VARCHAR(128),
+    host                  VARCHAR(255),
+    db                    VARCHAR(128),
+    command               VARCHAR(64),
+    connection_attributes JSON,
+    cached_at             TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    last_seen             TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB;


### PR DESCRIPTION
Part of #701 (decisions D1/D2). Sibling of #702/#704 — see merge notes below.

Ports the SaaS agent's connection-cache poller (`agent/handler/conncache.go`, ~480 LOC) into the OSS tree as `internal/forensics`: a lightweight poller that persists session identity in the index so forensic attribution of a binlog event's `connection_id` survives disconnects — `performance_schema.threads` rows vanish the moment a session ends.

## Ported vs adapted

**Ported faithfully** (SaaS behavior and helper names kept):
- 500ms ticker over `performance_schema.threads WHERE TYPE='FOREGROUND'`, then `session_connect_attrs` scoped to the ids just seen (never a blanket scan). The SaaS doc comment said 1s; the code says 500ms — the code is the spec.
- Batched `INSERT … ON DUPLICATE KEY UPDATE` (50/batch) into `connection_cache`; identical table shape (`connection_id BIGINT UNSIGNED PK`, user/host/db/command, `connection_attributes JSON`, `cached_at`/`last_seen`).
- Source-pool courtesy caps kept: `SetMaxOpenConns(2)` / `SetMaxIdleConns(1)` — never contend with the customer's workload.
- Failure-streak logging (first failure, then every 60th ≈ every 30s) + recovery line.
- `hasAuditPlugin` probe (`information_schema.PLUGINS`, active `%AUDIT%`, RDS_SECURITY excluded): an active audit plugin logs at info and skips polling — audit logs carry better history at lower cost. Probe failure degrades to *capturing* (poller starts), never to a silent attribution gap. The resume-after-restart path is the daemons' own boot wiring (`up`/`watch` re-run it every start; the supervisor's `Reconcile` covers registry sources).
- Private helper names kept for sibling coordination: `pollOnce`, `pollConnAttrs`, `upsertConnections`/`upsertBatch`, `cleanupConnectionCache`, `hasAuditPlugin`, `enrichSourceString`.

**Adapted for this repo:**
- Structured like `rotation.StartLoop` (the repo's secondary-loop idiom): `StartConnCachePoller(ctx, ConnCacheConfig) <-chan struct{}` — returns immediately, never fatal to the caller, per-cycle panic recovery, done-channel closes on exit (tests use it for deterministic shutdown). One goroutine drives both tickers (poll + hourly sweep) instead of the SaaS's three-goroutine Stop() plumbing; lifecycle is ctx-driven.
- **D2**: retention is a parameter — `DELETE … WHERE last_seen < NOW() - INTERVAL ? SECOND` — surfaced as `--attribution-retention` (default 24h; `0` disables the poller entirely). The SaaS hardcoded 24h. The 500ms cadence stays a constant, not a flag.
- `config.Connect` (repo invariant: parseTime + UTC + 10s timeout) instead of raw `sql.Open`; `slog` instead of `log`; DSNs scrubbed from log lines via `config.ScrubDSNText`.
- `LookupCachedThreads(ctx, *sql.DB, ids) (map[int64]CachedThread, error)` is **exported** — #706's engine composes it with #702's live enrichment. Takes a DB handle (not a DSN like the SaaS) and returns int64-keyed values (the SaaS's string-keyed JSON shape belongs to its HTTP layer).
- Table creation is the indexer's job, not the poller's (single source of DDL truth): the SaaS `ensureConnectionCacheTable` is replaced by the schema halves below.

## Index schema — both halves

- `ddlConnectionCache` const in `internal/indexer/schema.go`, added to the `CreateIndexTables` set (fresh installs).
- Presence-checked `CREATE` in `EnsureSchema` (existing installs) — checked via `tableExists` first so an up-to-date index keeps `EnsureSchema` write-free (`ensureColumn`'s contract; matters for index users without CREATE privilege).
- Same DDL appended to `migrations/001_create_tables.sql` and mirrored in `testutil.InitIndexTables`.
- Separate table ⇒ zero impact on `binlog_events`, Parquet archives, or baselines.

## Gate check in the wiring (D1)

Every start site is wrapped in `if forensics.Enabled()`:
- `cmd/bintrail/up.go`: poller starts next to `rotation.StartLoop` on the same signal-bound context.
- `cmd/bintrail-console/watch.go`: the main stream's poller starts beside the rotation loop; per-source pollers start inside `monitorSupervisor.run`, scoped to the supervision session (stop verb / circuit breaker / daemon shutdown all stop them) and deliberately spanning crash-loop backoff gaps — identities captured while a stream is down attribute the events gap fill indexes afterwards.

`internal/forensics/gate.go` is **byte-identical** to the file #702 creates (sha1 `16317a2805f99681741dc2af314f55b7a7f13e79`) — identical blobs merge cleanly.

## Flag / env

One new knob: `--attribution-retention` (duration, default `24h`, `0` disables) on `bintrail up` and `bintrail-console watch`; `BINTRAIL_ATTRIBUTION_RETENTION` via `cli.EnvBindings` + `envSections` (sync test satisfied) + watch's own binding table.

## Deliberate deferrals

- **Zero `internal/streamrun` changes**: the issue's optional nil-checked `streamrun.Deps` hook for bare `bintrail stream` is deferred — `bintrail-pg` stays untouched (`performance_schema` is MySQL-family-only). Bare `stream` runs no poller; `up`/`watch` are the supported daemon paths.
- Consumers do not auto-assert anything on the source (validate-never-set); doctor + setup-guide remediation is #702's.

## Test evidence

MySQL 8.4.9 test container (13306) — which also proves the `VALUES()` upsert form on 8.4 (repo floor is BYO MySQL 8.0+, where the 8.0.19+ row-alias form would not parse):

```
$ go build ./... && go vet ./...                                        # clean
$ go test ./... -count=1                                                # whole tree: PASS
$ go test -tags integration ./internal/forensics/... ./internal/indexer/... -count=1
ok  github.com/dbtrail/dbtrail/internal/forensics   4.7s
ok  github.com/dbtrail/dbtrail/internal/indexer     3.0s
$ go test -tags integration ./... -count=1                              # whole tree: PASS
$ git diff go.mod                                                       # empty — zero new deps
```

Key integration tests:
- `TestIntegrationConnCachePoller_IdentityOutlivesDisconnect` — the headline path: poller caches a live session, the session is killed, `LookupCachedThreads` still resolves user/host from the cache.
- `TestIntegrationConnCacheRetentionSweep` — 2-day-old row swept under 24h retention, kept under 72h (D2 is a real parameter).
- `TestIntegrationConnCachePoller_RefreshesLastSeen` — one row per connection, `last_seen` advances (what spares active sessions from the sweep).
- `TestIntegrationAuditPluginSkipsPoller` — probe stubbed via the `auditProbe` seam (container has no audit plugin to install): poller exits on its own, table stays empty; `TestIntegrationHasAuditPlugin_NoneInstalled` pins the real probe against the container.
- `TestEnsureSchemaCreatesConnectionCache` / `TestCreateIndexTablesIncludesConnectionCache` — both schema halves, idempotency included.

Closes #703

🤖 Generated with [Claude Code](https://claude.com/claude-code)
