### PR TITLE
forensics: core library — capabilities, thread enrichment, activity queries, setup guide, doctor checks

### DIFF
--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -139,6 +139,8 @@ func Build(parent context.Context, sourceDSN, indexDSN, schemasCSV string, index
 	report.add(checkReplicationGrants(ctx, sourceDB))
 	report.add(checkFKCascades(sourceDB, schemas))
 	report.add(checkSchemaVisibility(ctx, sourceDB, schemas))
+	report.add(checkPerformanceSchema(ctx, sourceDB))
+	report.add(checkAuditPlugin(ctx, sourceDB))
 
 	// ── Index MySQL checks (optional) ─────────────────────────────────────────
 	if indexDSN != "" {
@@ -543,6 +545,175 @@ func countVisibleSchemas(ctx context.Context, db *sql.DB, schemas []string) (int
 	var n int
 	err := db.QueryRowContext(ctx, query, args...).Scan(&n)
 	return n, err
+}
+
+// forensicsConsumers are the performance_schema setup_consumers rows the
+// forensic activity queries (user_activity / ddl_history) read from. Listed in
+// the order they should appear in the check detail.
+var forensicsConsumers = []string{"events_statements_history", "events_statements_history_long"}
+
+// checkPerformanceSchema reports whether performance_schema — and the two
+// statement-history consumers forensics reads — are available on the source.
+// Forensics is optional, so a missing or degraded source is WARN, never FAIL:
+// streaming must not be blocked because attribution data is unavailable.
+// Validate, never set: the check reports state with copy-pasteable
+// remediation; it never writes to the source server.
+func checkPerformanceSchema(ctx context.Context, db *sql.DB) CheckResult {
+	const name = "performance_schema (forensics)"
+
+	var varName, varValue string
+	err := db.QueryRowContext(ctx,
+		"SHOW GLOBAL VARIABLES LIKE 'performance_schema'").Scan(&varName, &varValue)
+	if err != nil {
+		return CheckResult{
+			Name:   name,
+			Status: StatusWarn,
+			Detail: "could not read the performance_schema variable: " + err.Error(),
+		}
+	}
+	if !strings.EqualFold(varValue, "ON") {
+		return CheckResult{
+			Name:   name,
+			Status: StatusWarn,
+			Detail: fmt.Sprintf("performance_schema=%s — forensic attribution (who-changed, user activity) unavailable", varValue),
+			Remediation: "Enable performance_schema in my.cnf and restart MySQL (it cannot be enabled at runtime):\n\n" +
+				"  [mysqld]\n" +
+				"  performance_schema = ON\n" +
+				"  performance-schema-consumer-events-statements-history = ON\n" +
+				"  performance-schema-consumer-events-statements-history-long = ON\n\n" +
+				"It is enabled by default on MySQL 8.0+. On RDS/Aurora, set the (static) performance_schema\n" +
+				"parameter in the parameter group and reboot; enabling Performance Insights also turns it on.",
+		}
+	}
+
+	// performance_schema is ON — check the statement-history consumers.
+	rows, err := db.QueryContext(ctx,
+		"SELECT NAME, ENABLED FROM performance_schema.setup_consumers "+
+			"WHERE NAME IN ('events_statements_history', 'events_statements_history_long')")
+	if err != nil {
+		return CheckResult{
+			Name:   name,
+			Status: StatusWarn,
+			Detail: "ON, but could not read setup_consumers: " + err.Error(),
+		}
+	}
+	defer rows.Close()
+
+	enabled := map[string]bool{}
+	for rows.Next() {
+		var consumer, state string
+		if err := rows.Scan(&consumer, &state); err != nil {
+			return CheckResult{
+				Name:   name,
+				Status: StatusWarn,
+				Detail: "ON, but could not scan setup_consumers: " + err.Error(),
+			}
+		}
+		enabled[consumer] = strings.EqualFold(state, "YES")
+	}
+	if err := rows.Err(); err != nil {
+		return CheckResult{
+			Name:   name,
+			Status: StatusWarn,
+			Detail: "ON, but could not read setup_consumers: " + err.Error(),
+		}
+	}
+
+	var off []string
+	for _, c := range forensicsConsumers {
+		if !enabled[c] {
+			off = append(off, c)
+		}
+	}
+	if len(off) == 0 {
+		return CheckResult{
+			Name:   name,
+			Status: StatusPass,
+			Detail: "ON (statement history consumers enabled)",
+		}
+	}
+	var updates strings.Builder
+	for _, c := range off {
+		fmt.Fprintf(&updates, "  UPDATE performance_schema.setup_consumers SET ENABLED = 'YES' WHERE NAME = '%s';\n", c)
+	}
+	return CheckResult{
+		Name:   name,
+		Status: StatusWarn,
+		Detail: fmt.Sprintf("ON, but consumer(s) disabled: %s — forensic statement history will be missing", strings.Join(off, ", ")),
+		Remediation: "Enable the statement-history consumer(s) at runtime:\n\n" +
+			updates.String() +
+			"\nAnd persist across restarts in my.cnf:\n\n" +
+			"  [mysqld]\n" +
+			"  performance-schema-consumer-events-statements-history = ON\n" +
+			"  performance-schema-consumer-events-statements-history-long = ON\n\n" +
+			"On RDS/Aurora there is NO parameter-group option for setup_consumers, so the runtime\n" +
+			"UPDATE does not survive a reboot — re-assert it after every reboot.",
+	}
+}
+
+// checkAuditPlugin reports whether an audit-log plugin (MariaDB server_audit /
+// its AWS RDS fork, Percona Audit Log, or MySQL Enterprise Audit) is active on
+// the source. An audit log is the strongest forensic attribution source
+// (persisted to disk, survives disconnects), but entirely optional — so absent
+// or unreadable is WARN, never FAIL. Validate, never set.
+func checkAuditPlugin(ctx context.Context, db *sql.DB) CheckResult {
+	const name = "Audit log plugin (forensics)"
+
+	rows, err := db.QueryContext(ctx,
+		"SELECT PLUGIN_NAME FROM information_schema.PLUGINS "+
+			"WHERE UPPER(PLUGIN_NAME) LIKE '%AUDIT%' AND PLUGIN_STATUS = 'ACTIVE'")
+	if err != nil {
+		return CheckResult{
+			Name:   name,
+			Status: StatusWarn,
+			Detail: "could not query information_schema.PLUGINS: " + err.Error(),
+		}
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var plugin string
+		if err := rows.Scan(&plugin); err != nil {
+			return CheckResult{
+				Name:   name,
+				Status: StatusWarn,
+				Detail: "could not scan plugin row: " + err.Error(),
+			}
+		}
+		// Skip the RDS internal audit plugin — it's not queryable via SQL.
+		if strings.Contains(strings.ToUpper(plugin), "RDS_SECURITY") {
+			continue
+		}
+		return CheckResult{
+			Name:   name,
+			Status: StatusPass,
+			Detail: plugin + " active",
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return CheckResult{
+			Name:   name,
+			Status: StatusWarn,
+			Detail: "could not read plugin rows: " + err.Error(),
+		}
+	}
+
+	return CheckResult{
+		Name:   name,
+		Status: StatusWarn,
+		Detail: "no audit log plugin active — forensic attribution falls back to performance_schema's in-memory ring buffers",
+		Remediation: "An audit plugin gives durable who-ran-what history. Pick the one for your server variant:\n\n" +
+			"  -- MariaDB (built in):\n" +
+			"  INSTALL SONAME 'server_audit';\n" +
+			"  SET GLOBAL server_audit_logging = ON;\n\n" +
+			"  -- Percona Server (free):\n" +
+			"  INSTALL PLUGIN audit_log SONAME 'audit_log.so';\n" +
+			"  SET GLOBAL audit_log_policy = 'ALL';\n\n" +
+			"  -- MySQL Community: no free audit plugin; MySQL Enterprise Audit requires an Enterprise license.\n\n" +
+			"On RDS for MySQL, add the MARIADB_AUDIT_PLUGIN option to the instance's option group;\n" +
+			"on Aurora MySQL, set server_audit_logging=1 in the cluster parameter group.\n" +
+			"Run `bintrail doctor` again afterwards; the forensics setup guide has the full walkthrough.",
+	}
 }
 
 func checkIndexConnection(ctx context.Context, dsn, dbName string) CheckResult {

--- a/internal/doctor/forensics_integration_test.go
+++ b/internal/doctor/forensics_integration_test.go
@@ -1,0 +1,72 @@
+//go:build integration
+
+package doctor
+
+import (
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/config"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestIntegrationForensicsChecksNeverFail runs the two forensics doctor checks
+// against the live test server. The container's performance_schema / audit
+// plugin state is whatever it is, so the assertion is the status contract:
+// forensics is optional — the checks may PASS or WARN but must never FAIL,
+// and a WARN must carry actionable detail.
+func TestIntegrationForensicsChecksNeverFail(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	db, err := config.Connect(testutil.BaseDSN() + "/")
+	if err != nil {
+		t.Fatalf("connect to test MySQL: %v", err)
+	}
+	defer db.Close()
+	ctx := t.Context()
+
+	checks := []struct {
+		name string
+		run  func() CheckResult
+	}{
+		{"checkPerformanceSchema", func() CheckResult { return checkPerformanceSchema(ctx, db) }},
+		{"checkAuditPlugin", func() CheckResult { return checkAuditPlugin(ctx, db) }},
+	}
+	for _, c := range checks {
+		t.Run(c.name, func(t *testing.T) {
+			got := c.run()
+			if got.Status != StatusPass && got.Status != StatusWarn {
+				t.Errorf("Status = %q (detail=%q), want pass or warn — forensics checks never fail", got.Status, got.Detail)
+			}
+			if got.Status == StatusWarn && got.Detail == "" {
+				t.Error("WARN with no detail gives the operator nothing to act on")
+			}
+		})
+	}
+}
+
+// TestIntegrationBuildIncludesForensicsChecks asserts the Build wiring: the
+// source-checks section must surface both forensics checks in the report.
+func TestIntegrationBuildIncludesForensicsChecks(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+
+	report := Build(t.Context(), testutil.BaseDSN()+"/", "", "", 0)
+
+	for _, name := range []string{"performance_schema (forensics)", "Audit log plugin (forensics)"} {
+		found := false
+		for _, c := range report.Checks {
+			if c.Name != name {
+				continue
+			}
+			found = true
+			if c.Status == StatusFail {
+				t.Errorf("%s reported FAIL (detail=%q) — forensics checks never fail", name, c.Detail)
+			}
+		}
+		if !found {
+			var names []string
+			for _, c := range report.Checks {
+				names = append(names, c.Name)
+			}
+			t.Errorf("Build report is missing %q; got %v", name, names)
+		}
+	}
+}

--- a/internal/doctor/forensics_test.go
+++ b/internal/doctor/forensics_test.go
@@ -1,0 +1,246 @@
+package doctor
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+// The forensics checks are advisory: forensics is an optional capability, so
+// every branch — including total probe failure — must resolve to PASS or WARN,
+// never FAIL (a missing audit plugin must not block `up` from streaming).
+// Each table below asserts the branch outcome AND that structural invariant.
+
+func TestCheckPerformanceSchema(t *testing.T) {
+	forcedErr := errors.New("forced query failure")
+
+	psVarRows := func(val string) *sqlmock.Rows {
+		return sqlmock.NewRows([]string{"Variable_name", "Value"}).AddRow("performance_schema", val)
+	}
+	consumerRows := func(pairs ...[2]string) *sqlmock.Rows {
+		rows := sqlmock.NewRows([]string{"NAME", "ENABLED"})
+		for _, p := range pairs {
+			rows.AddRow(p[0], p[1])
+		}
+		return rows
+	}
+
+	tests := []struct {
+		name             string
+		setup            func(m sqlmock.Sqlmock)
+		wantStatus       CheckStatus
+		wantDetailFrag   string
+		wantRemedFrags   []string // all must be present in Remediation
+		wantNoRemedation bool
+	}{
+		{
+			name: "ON with both consumers enabled",
+			setup: func(m sqlmock.Sqlmock) {
+				m.ExpectQuery("SHOW GLOBAL VARIABLES LIKE 'performance_schema'").
+					WillReturnRows(psVarRows("ON"))
+				m.ExpectQuery("FROM performance_schema.setup_consumers").
+					WillReturnRows(consumerRows(
+						[2]string{"events_statements_history", "YES"},
+						[2]string{"events_statements_history_long", "YES"}))
+			},
+			wantStatus:       StatusPass,
+			wantDetailFrag:   "statement history consumers enabled",
+			wantNoRemedation: true,
+		},
+		{
+			name: "ON with history_long consumer off warns with runtime SQL and the RDS reboot caveat",
+			setup: func(m sqlmock.Sqlmock) {
+				m.ExpectQuery("SHOW GLOBAL VARIABLES LIKE 'performance_schema'").
+					WillReturnRows(psVarRows("ON"))
+				m.ExpectQuery("FROM performance_schema.setup_consumers").
+					WillReturnRows(consumerRows(
+						[2]string{"events_statements_history", "YES"},
+						[2]string{"events_statements_history_long", "NO"}))
+			},
+			wantStatus:     StatusWarn,
+			wantDetailFrag: "events_statements_history_long",
+			wantRemedFrags: []string{
+				"UPDATE performance_schema.setup_consumers SET ENABLED = 'YES' WHERE NAME = 'events_statements_history_long';",
+				"re-assert it after every reboot",
+			},
+		},
+		{
+			name: "ON with consumers absent from the resultset treats both as off",
+			setup: func(m sqlmock.Sqlmock) {
+				m.ExpectQuery("SHOW GLOBAL VARIABLES LIKE 'performance_schema'").
+					WillReturnRows(psVarRows("ON"))
+				m.ExpectQuery("FROM performance_schema.setup_consumers").
+					WillReturnRows(consumerRows())
+			},
+			wantStatus:     StatusWarn,
+			wantDetailFrag: "events_statements_history, events_statements_history_long",
+			wantRemedFrags: []string{"WHERE NAME = 'events_statements_history';", "WHERE NAME = 'events_statements_history_long';"},
+		},
+		{
+			name: "OFF warns with the my.cnf remediation",
+			setup: func(m sqlmock.Sqlmock) {
+				m.ExpectQuery("SHOW GLOBAL VARIABLES LIKE 'performance_schema'").
+					WillReturnRows(psVarRows("OFF"))
+			},
+			wantStatus:     StatusWarn,
+			wantDetailFrag: "performance_schema=OFF",
+			wantRemedFrags: []string{"performance_schema = ON", "parameter group"},
+		},
+		{
+			name: "variable query failure degrades to WARN",
+			setup: func(m sqlmock.Sqlmock) {
+				m.ExpectQuery("SHOW GLOBAL VARIABLES LIKE 'performance_schema'").
+					WillReturnError(forcedErr)
+			},
+			wantStatus:       StatusWarn,
+			wantDetailFrag:   "could not read the performance_schema variable",
+			wantNoRemedation: true,
+		},
+		{
+			name: "consumers query failure degrades to WARN",
+			setup: func(m sqlmock.Sqlmock) {
+				m.ExpectQuery("SHOW GLOBAL VARIABLES LIKE 'performance_schema'").
+					WillReturnRows(psVarRows("ON"))
+				m.ExpectQuery("FROM performance_schema.setup_consumers").
+					WillReturnError(forcedErr)
+			},
+			wantStatus:       StatusWarn,
+			wantDetailFrag:   "could not read setup_consumers",
+			wantNoRemedation: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("sqlmock: %v", err)
+			}
+			defer db.Close()
+			tt.setup(mock)
+
+			got := checkPerformanceSchema(t.Context(), db)
+			if got.Status == StatusFail {
+				t.Errorf("forensics checks must NEVER fail — got FAIL (detail=%q)", got.Detail)
+			}
+			if got.Status != tt.wantStatus {
+				t.Errorf("Status = %q, want %q (detail=%q)", got.Status, tt.wantStatus, got.Detail)
+			}
+			if !strings.Contains(got.Detail, tt.wantDetailFrag) {
+				t.Errorf("Detail = %q, want substring %q", got.Detail, tt.wantDetailFrag)
+			}
+			for _, frag := range tt.wantRemedFrags {
+				if !strings.Contains(got.Remediation, frag) {
+					t.Errorf("Remediation missing %q:\n%s", frag, got.Remediation)
+				}
+			}
+			if tt.wantNoRemedation && got.Remediation != "" && tt.wantStatus == StatusPass {
+				t.Errorf("PASS should not carry remediation, got %q", got.Remediation)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("unmet expectations: %v", err)
+			}
+		})
+	}
+}
+
+func TestCheckAuditPlugin(t *testing.T) {
+	pluginRows := func(names ...string) *sqlmock.Rows {
+		rows := sqlmock.NewRows([]string{"PLUGIN_NAME"})
+		for _, n := range names {
+			rows.AddRow(n)
+		}
+		return rows
+	}
+
+	tests := []struct {
+		name           string
+		setup          func(m sqlmock.Sqlmock)
+		wantStatus     CheckStatus
+		wantDetailFrag string
+		wantRemedFrags []string
+	}{
+		{
+			name: "active audit plugin passes",
+			setup: func(m sqlmock.Sqlmock) {
+				m.ExpectQuery("FROM information_schema.PLUGINS").
+					WillReturnRows(pluginRows("SERVER_AUDIT"))
+			},
+			wantStatus:     StatusPass,
+			wantDetailFrag: "SERVER_AUDIT active",
+		},
+		{
+			name: "RDS internal security plugin does not count",
+			setup: func(m sqlmock.Sqlmock) {
+				m.ExpectQuery("FROM information_schema.PLUGINS").
+					WillReturnRows(pluginRows("RDS_SECURITY_AUDIT"))
+			},
+			wantStatus:     StatusWarn,
+			wantDetailFrag: "no audit log plugin active",
+			wantRemedFrags: []string{"INSTALL SONAME 'server_audit';", "MARIADB_AUDIT_PLUGIN"},
+		},
+		{
+			name: "RDS internal plugin skipped, real plugin after it passes",
+			setup: func(m sqlmock.Sqlmock) {
+				m.ExpectQuery("FROM information_schema.PLUGINS").
+					WillReturnRows(pluginRows("RDS_SECURITY_AUDIT", "audit_log"))
+			},
+			wantStatus:     StatusPass,
+			wantDetailFrag: "audit_log active",
+		},
+		{
+			name: "no audit plugin warns with variant-specific install guidance",
+			setup: func(m sqlmock.Sqlmock) {
+				m.ExpectQuery("FROM information_schema.PLUGINS").
+					WillReturnRows(pluginRows())
+			},
+			wantStatus:     StatusWarn,
+			wantDetailFrag: "no audit log plugin active",
+			wantRemedFrags: []string{
+				"INSTALL SONAME 'server_audit';",
+				"INSTALL PLUGIN audit_log SONAME 'audit_log.so';",
+				"MARIADB_AUDIT_PLUGIN",
+				"server_audit_logging=1",
+			},
+		},
+		{
+			name: "plugins query failure degrades to WARN",
+			setup: func(m sqlmock.Sqlmock) {
+				m.ExpectQuery("FROM information_schema.PLUGINS").
+					WillReturnError(errors.New("forced query failure"))
+			},
+			wantStatus:     StatusWarn,
+			wantDetailFrag: "could not query information_schema.PLUGINS",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("sqlmock: %v", err)
+			}
+			defer db.Close()
+			tt.setup(mock)
+
+			got := checkAuditPlugin(t.Context(), db)
+			if got.Status == StatusFail {
+				t.Errorf("forensics checks must NEVER fail — got FAIL (detail=%q)", got.Detail)
+			}
+			if got.Status != tt.wantStatus {
+				t.Errorf("Status = %q, want %q (detail=%q)", got.Status, tt.wantStatus, got.Detail)
+			}
+			if !strings.Contains(got.Detail, tt.wantDetailFrag) {
+				t.Errorf("Detail = %q, want substring %q", got.Detail, tt.wantDetailFrag)
+			}
+			for _, frag := range tt.wantRemedFrags {
+				if !strings.Contains(got.Remediation, frag) {
+					t.Errorf("Remediation missing %q:\n%s", frag, got.Remediation)
+				}
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("unmet expectations: %v", err)
+			}
+		})
+	}
+}

--- a/internal/forensics/activity.go
+++ b/internal/forensics/activity.go
@@ -1,0 +1,649 @@
+package forensics
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"strings"
+)
+
+// Activity query types.
+const (
+	QueryUserActivity      = "user_activity"
+	QueryConnectionHistory = "connection_history"
+	QueryDDLHistory        = "ddl_history"
+)
+
+// ActivityQuery selects one of the three forensic activity query modes and
+// carries its filters. Fields not used by the selected Type are ignored.
+type ActivityQuery struct {
+	// Type is one of QueryUserActivity, QueryConnectionHistory, QueryDDLHistory.
+	Type   string
+	User   string // required for user_activity; optional filter for connection_history
+	Host   string // optional filter for connection_history (one of User/Host required there)
+	Schema string // optional filter for ddl_history
+	// Since/Until accept MySQL DATETIME or ISO 8601 strings. performance_schema
+	// ring buffers have no wall-clock column, so these only shape the generated
+	// fallback SQL (general_log filters) — they never filter the live query.
+	Since string
+	Until string
+	Limit int    // defaults to 50; capped at 1000
+	Order string // "ASC" for ascending; anything else means descending
+}
+
+// ActivityResult is the outcome of an activity query. Events is populated for
+// user_activity and ddl_history; Connections for connection_history. When the
+// needed performance_schema data is unavailable, Source is "fallback" and
+// FallbackQueries carries executable SQL for manual investigation —
+// fallback-over-error is the point: a degraded source is an answer, not an
+// error.
+type ActivityResult struct {
+	Events          []map[string]any `json:"events,omitempty"`
+	Connections     []map[string]any `json:"connections,omitempty"`
+	Source          string           `json:"source"`
+	Count           int              `json:"count"`
+	Note            string           `json:"note,omitempty"`
+	Diagnostics     map[string]any   `json:"diagnostics,omitempty"`
+	FallbackQueries []FallbackQuery  `json:"fallback_queries,omitempty"`
+}
+
+// Activity runs a general forensic query (user activity, connection history,
+// or DDL history) against performance_schema on the source server. It returns
+// an error only for invalid parameters or an unknown query type; data-source
+// failures degrade to fallback SQL inside the result.
+func Activity(ctx context.Context, sourceDB *sql.DB, q ActivityQuery) (ActivityResult, error) {
+	limit := q.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 1000 {
+		limit = 1000
+	}
+	ascending := strings.EqualFold(q.Order, "ASC")
+
+	switch q.Type {
+	case QueryUserActivity:
+		if q.User == "" {
+			return ActivityResult{}, fmt.Errorf("user is required for %s query", QueryUserActivity)
+		}
+		return handleUserActivity(ctx, sourceDB, q.User, q.Since, q.Until, limit, ascending), nil
+	case QueryConnectionHistory:
+		if q.User == "" && q.Host == "" {
+			return ActivityResult{}, fmt.Errorf("user or host is required for %s query", QueryConnectionHistory)
+		}
+		return handleConnectionHistory(ctx, sourceDB, q.User, q.Host, limit, ascending), nil
+	case QueryDDLHistory:
+		return handleDDLHistory(ctx, sourceDB, q.Schema, q.Since, q.Until, limit, ascending), nil
+	default:
+		return ActivityResult{}, fmt.Errorf("unknown query_type %q: must be %s, %s, or %s",
+			q.Type, QueryUserActivity, QueryConnectionHistory, QueryDDLHistory)
+	}
+}
+
+// perfSchemaGrantNote returns a user-friendly message when performance_schema
+// queries fail, including the actual MySQL error.
+func perfSchemaGrantNote(queryErr error) string {
+	return fmt.Sprintf("performance_schema query failed: %v", queryErr)
+}
+
+// normalizeTimestamp converts ISO 8601 "T" separators to spaces so that
+// lexicographic comparison works against MySQL DATETIME format
+// ("2006-01-02 15:04:05") in the generated fallback SQL.
+func normalizeTimestamp(ts string) string {
+	return strings.Replace(ts, "T", " ", 1)
+}
+
+// handleUserActivity returns recent statement history for a MySQL user.
+// Falls back to providing SQL queries when performance_schema data is unavailable.
+func handleUserActivity(ctx context.Context, db *sql.DB, user, since, until string, limit int, ascending bool) ActivityResult {
+	since = normalizeTimestamp(since)
+	until = normalizeTimestamp(until)
+
+	// Try events_statements_history_long first (larger history).
+	events, err := queryUserStatements(ctx, db, user, limit, ascending)
+	if err != nil {
+		slog.Warn("forensics: user_activity query failed", "error", err)
+		return ActivityResult{
+			Events:          []map[string]any{},
+			Source:          "fallback",
+			FallbackQueries: generateUserActivityFallback(user, since, until, limit),
+			Note:            perfSchemaGrantNote(err),
+		}
+	}
+
+	// events_statements_history_long returned 0 rows — try the per-thread
+	// history buffer as a fallback (smaller but still useful).
+	if len(events) == 0 {
+		var shortErr error
+		events, shortErr = queryUserStatementsShort(ctx, db, user, limit, ascending)
+		if shortErr != nil {
+			slog.Warn("forensics: events_statements_history fallback failed", "error", shortErr)
+		}
+	}
+
+	if len(events) > 0 {
+		return ActivityResult{
+			Events: events,
+			Source: "performance_schema",
+			Count:  len(events),
+		}
+	}
+
+	// Still empty — diagnose why and include actionable info.
+	diag := diagnoseEmptyUserActivity(ctx, db, user)
+	slog.Info("forensics: user_activity returned 0 rows", "user", user, "diagnostics", diag)
+	res := ActivityResult{
+		Events:          []map[string]any{},
+		Source:          "fallback",
+		Diagnostics:     diag,
+		FallbackQueries: generateUserActivityFallback(user, since, until, limit),
+	}
+	if note, ok := diag["note"].(string); ok {
+		res.Note = note
+	}
+	return res
+}
+
+// queryUserStatements queries performance_schema for recent statements by a user.
+// Note: events_statements_history_long doesn't have a timestamp column,
+// but TIMER_START is in picoseconds since server start. We can't easily
+// filter by wall-clock time, so time filters are best-effort (fallback SQL only).
+func queryUserStatements(ctx context.Context, db *sql.DB, user string, limit int, ascending bool) ([]map[string]any, error) {
+	orderDir := "DESC"
+	if ascending {
+		orderDir = "ASC"
+	}
+	query := `SELECT
+		t.PROCESSLIST_ID AS connection_id,
+		t.PROCESSLIST_USER AS user,
+		t.PROCESSLIST_HOST AS host,
+		esh.SQL_TEXT AS sql_text,
+		esh.DIGEST_TEXT AS digest,
+		esh.ROWS_AFFECTED AS rows_affected,
+		esh.ROWS_EXAMINED AS rows_examined,
+		esh.CREATED_TMP_TABLES AS tmp_tables,
+		esh.NO_INDEX_USED AS no_index_used,
+		esh.TIMER_WAIT / 1000000000 AS duration_ms
+	FROM performance_schema.events_statements_history_long esh
+	JOIN performance_schema.threads t ON t.THREAD_ID = esh.THREAD_ID
+	WHERE t.PROCESSLIST_USER = ?
+	ORDER BY esh.TIMER_START ` + orderDir + fmt.Sprintf(" LIMIT %d", limit)
+
+	rows, err := db.QueryContext(ctx, query, user)
+	if err != nil {
+		return nil, fmt.Errorf("query events_statements_history_long: %w", err)
+	}
+	defer rows.Close()
+	return scanStatementRows(rows)
+}
+
+// queryUserStatementsShort queries the per-thread events_statements_history
+// buffer. It's smaller (typically last 10 statements per thread) but can
+// succeed when _history_long is empty because its consumer is off.
+func queryUserStatementsShort(ctx context.Context, db *sql.DB, user string, limit int, ascending bool) ([]map[string]any, error) {
+	orderDir := "DESC"
+	if ascending {
+		orderDir = "ASC"
+	}
+	query := `SELECT
+		t.PROCESSLIST_ID AS connection_id,
+		t.PROCESSLIST_USER AS user,
+		t.PROCESSLIST_HOST AS host,
+		esh.SQL_TEXT AS sql_text,
+		esh.DIGEST_TEXT AS digest,
+		esh.ROWS_AFFECTED AS rows_affected,
+		esh.ROWS_EXAMINED AS rows_examined,
+		esh.CREATED_TMP_TABLES AS tmp_tables,
+		esh.NO_INDEX_USED AS no_index_used,
+		esh.TIMER_WAIT / 1000000000 AS duration_ms
+	FROM performance_schema.events_statements_history esh
+	JOIN performance_schema.threads t ON t.THREAD_ID = esh.THREAD_ID
+	WHERE t.PROCESSLIST_USER = ?
+	ORDER BY esh.TIMER_START ` + orderDir + fmt.Sprintf(" LIMIT %d", limit)
+
+	rows, err := db.QueryContext(ctx, query, user)
+	if err != nil {
+		return nil, fmt.Errorf("query events_statements_history: %w", err)
+	}
+	defer rows.Close()
+	return scanStatementRows(rows)
+}
+
+// scanStatementRows scans rows from either events_statements_history or
+// events_statements_history_long into a slice of event maps.
+// Both tables share the same column layout in our SELECT.
+func scanStatementRows(rows *sql.Rows) ([]map[string]any, error) {
+	var events []map[string]any
+	for rows.Next() {
+		var connID int64
+		var sqlUser, host string
+		var sqlText, digest sql.NullString
+		var rowsAffected, rowsExamined, tmpTables, noIndexUsed int64
+		var durationMS float64
+
+		if err := rows.Scan(&connID, &sqlUser, &host, &sqlText, &digest,
+			&rowsAffected, &rowsExamined, &tmpTables, &noIndexUsed, &durationMS); err != nil {
+			slog.Warn("forensics: scan statement row", "error", err)
+			continue
+		}
+
+		event := map[string]any{
+			"connection_id": connID,
+			"user":          sqlUser,
+			"host":          host,
+			"rows_affected": rowsAffected,
+			"rows_examined": rowsExamined,
+			"duration_ms":   durationMS,
+		}
+		if sqlText.Valid && sqlText.String != "" {
+			event["sql_text"] = sqlText.String
+		}
+		if digest.Valid && digest.String != "" {
+			event["digest"] = digest.String
+		}
+		events = append(events, event)
+	}
+	if events == nil {
+		events = []map[string]any{}
+	}
+	return events, rows.Err()
+}
+
+// diagnoseEmptyUserActivity checks why both the _history_long and _history
+// queries returned 0 rows for a given user, and returns actionable diagnostics.
+func diagnoseEmptyUserActivity(ctx context.Context, db *sql.DB, user string) map[string]any {
+	diag := map[string]any{}
+
+	// Track which queries succeeded so the switch doesn't operate on zero-values.
+	var consumerOK, historyOK, threadsOK, fgOK bool
+
+	// 1. Is the history_long consumer enabled?
+	var consumerEnabled string
+	err := db.QueryRowContext(ctx,
+		"SELECT ENABLED FROM performance_schema.setup_consumers WHERE NAME = 'events_statements_history_long'",
+	).Scan(&consumerEnabled)
+	if err != nil {
+		slog.Warn("forensics: diagnose setup_consumers query failed", "error", err)
+	} else {
+		consumerOK = true
+		diag["history_long_consumer"] = consumerEnabled
+	}
+
+	// 2. How many rows are in the global history buffer?
+	var historyCount int
+	err = db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM performance_schema.events_statements_history_long",
+	).Scan(&historyCount)
+	if err != nil {
+		slog.Warn("forensics: diagnose history_long count query failed", "error", err)
+	} else {
+		historyOK = true
+		diag["history_long_rows"] = historyCount
+	}
+
+	// 3. Can we see the target user's threads? (requires PROCESS privilege)
+	var userThreads int
+	err = db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM performance_schema.threads WHERE PROCESSLIST_USER = ?", user,
+	).Scan(&userThreads)
+	if err != nil {
+		slog.Warn("forensics: diagnose user threads query failed", "error", err)
+	} else {
+		threadsOK = true
+		diag["user_threads_visible"] = userThreads
+	}
+
+	// 4. Total foreground threads visible (to detect privilege restrictions).
+	var totalFG int
+	err = db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM performance_schema.threads WHERE TYPE = 'FOREGROUND'",
+	).Scan(&totalFG)
+	if err != nil {
+		slog.Warn("forensics: diagnose foreground threads query failed", "error", err)
+	} else {
+		fgOK = true
+		diag["total_foreground_threads"] = totalFG
+	}
+
+	// 5. Does the accounts table confirm the user exists?
+	var totalConns sql.NullInt64
+	err = db.QueryRowContext(ctx,
+		"SELECT TOTAL_CONNECTIONS FROM performance_schema.accounts WHERE USER = ?", user,
+	).Scan(&totalConns)
+	if err != nil {
+		slog.Warn("forensics: diagnose accounts query failed", "error", err)
+	} else if totalConns.Valid {
+		diag["user_total_connections"] = totalConns.Int64
+	}
+
+	// Build an actionable note — only reference values from queries that succeeded.
+	switch {
+	case consumerOK && !strings.EqualFold(consumerEnabled, "YES"):
+		diag["note"] = "The events_statements_history_long consumer is disabled. " +
+			"Enable it with: UPDATE performance_schema.setup_consumers SET ENABLED = 'YES' " +
+			"WHERE NAME = 'events_statements_history_long'"
+	case historyOK && historyCount == 0 && consumerOK && strings.EqualFold(consumerEnabled, "YES"):
+		diag["note"] = "Consumer is enabled but history buffer is empty. " +
+			"The server may have been recently restarted, or the monitoring user may lack SELECT on performance_schema."
+	case threadsOK && userThreads == 0 && fgOK && totalFG <= 1:
+		diag["note"] = fmt.Sprintf("Only %d foreground thread(s) visible — the monitoring user likely lacks PROCESS privilege. "+
+			"GRANT PROCESS ON *.* TO '<monitoring_user>'@'%%' to see all users' activity.", totalFG)
+	case threadsOK && userThreads == 0 && fgOK && totalFG > 1:
+		diag["note"] = fmt.Sprintf("No active threads found for user %q (but %d other foreground threads are visible). "+
+			"The user may not be currently connected, or statements were evicted from the ring buffer.", user, totalFG)
+	case !consumerOK && !historyOK && !threadsOK:
+		diag["note"] = "All diagnostic queries failed — the monitoring user may lack SELECT privilege on performance_schema."
+	default:
+		diag["note"] = fmt.Sprintf("No statements found for user %q. "+
+			"The user may have had no recent activity, or statements were evicted from the ring buffer.", user)
+	}
+
+	return diag
+}
+
+// handleConnectionHistory returns connection/account information from performance_schema.
+func handleConnectionHistory(ctx context.Context, db *sql.DB, user, host string, limit int, ascending bool) ActivityResult {
+	connections, err := queryConnections(ctx, db, user, host, limit, ascending)
+	if err != nil {
+		slog.Warn("forensics: connection_history query failed", "error", err)
+		return ActivityResult{
+			Connections:     []map[string]any{},
+			Source:          "fallback",
+			FallbackQueries: generateConnectionFallback(user, host, limit),
+			Note:            perfSchemaGrantNote(err),
+		}
+	}
+
+	return ActivityResult{
+		Connections: connections,
+		Source:      "performance_schema",
+		Count:       len(connections),
+	}
+}
+
+// queryConnections queries performance_schema for connection metadata.
+func queryConnections(ctx context.Context, db *sql.DB, user, host string, limit int, ascending bool) ([]map[string]any, error) {
+	// Get current connections matching the filter.
+	query := `SELECT
+		t.PROCESSLIST_ID AS connection_id,
+		t.PROCESSLIST_USER AS user,
+		t.PROCESSLIST_HOST AS host,
+		t.PROCESSLIST_DB AS current_db,
+		t.PROCESSLIST_COMMAND AS command,
+		t.PROCESSLIST_STATE AS state,
+		t.PROCESSLIST_TIME AS time_seconds,
+		t.PROCESSLIST_INFO AS current_query
+	FROM performance_schema.threads t
+	WHERE t.TYPE = 'FOREGROUND'`
+
+	var args []any
+	if user != "" {
+		query += " AND t.PROCESSLIST_USER = ?"
+		args = append(args, user)
+	}
+	if host != "" {
+		query += " AND t.PROCESSLIST_HOST LIKE ?"
+		args = append(args, "%"+host+"%")
+	}
+	orderDir := "DESC"
+	if ascending {
+		orderDir = "ASC"
+	}
+	query += fmt.Sprintf(" ORDER BY t.PROCESSLIST_TIME %s LIMIT %d", orderDir, limit)
+
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query threads for connections: %w", err)
+	}
+	defer rows.Close()
+
+	var connections []map[string]any
+	for rows.Next() {
+		var connID int64
+		var connUser, connHost string
+		var connDB, command, state, currentQuery sql.NullString
+		var timeSeconds sql.NullInt64
+
+		if err := rows.Scan(&connID, &connUser, &connHost, &connDB,
+			&command, &state, &timeSeconds, &currentQuery); err != nil {
+			slog.Warn("forensics: scan connection row", "error", err)
+			continue
+		}
+
+		conn := map[string]any{
+			"connection_id": connID,
+			"user":          connUser,
+			"host":          connHost,
+		}
+		if connDB.Valid {
+			conn["current_db"] = connDB.String
+		}
+		if command.Valid {
+			conn["command"] = command.String
+		}
+		if state.Valid {
+			conn["state"] = state.String
+		}
+		if timeSeconds.Valid {
+			conn["time_seconds"] = timeSeconds.Int64
+		}
+		if currentQuery.Valid && currentQuery.String != "" {
+			conn["current_query"] = currentQuery.String
+		}
+		connections = append(connections, conn)
+	}
+	if connections == nil {
+		connections = []map[string]any{}
+	}
+	return connections, rows.Err()
+}
+
+// handleDDLHistory queries for DDL events from performance_schema.
+func handleDDLHistory(ctx context.Context, db *sql.DB, schema, since, until string, limit int, ascending bool) ActivityResult {
+	since = normalizeTimestamp(since)
+	until = normalizeTimestamp(until)
+
+	// Try events_statements_history_long for DDL statements.
+	events, err := queryDDLStatements(ctx, db, schema, limit, ascending)
+	if err != nil {
+		slog.Warn("forensics: ddl_history query failed", "error", err)
+		return ActivityResult{
+			Events:          []map[string]any{},
+			Source:          "fallback",
+			FallbackQueries: generateDDLFallback(schema, since, until, limit),
+			Note:            perfSchemaGrantNote(err),
+		}
+	}
+
+	return ActivityResult{
+		Events: events,
+		Source: "performance_schema",
+		Count:  len(events),
+	}
+}
+
+// queryDDLStatements finds DDL statements in events_statements_history_long.
+func queryDDLStatements(ctx context.Context, db *sql.DB, schema string, limit int, ascending bool) ([]map[string]any, error) {
+	query := `SELECT
+		t.PROCESSLIST_ID AS connection_id,
+		t.PROCESSLIST_USER AS user,
+		t.PROCESSLIST_HOST AS host,
+		esh.SQL_TEXT AS sql_text,
+		esh.TIMER_WAIT / 1000000000 AS duration_ms
+	FROM performance_schema.events_statements_history_long esh
+	JOIN performance_schema.threads t ON t.THREAD_ID = esh.THREAD_ID
+	WHERE (esh.SQL_TEXT LIKE 'CREATE %'
+		OR esh.SQL_TEXT LIKE 'ALTER %'
+		OR esh.SQL_TEXT LIKE 'DROP %'
+		OR esh.SQL_TEXT LIKE 'RENAME %'
+		OR esh.SQL_TEXT LIKE 'TRUNCATE %')`
+
+	var args []any
+	if schema != "" {
+		query += " AND esh.CURRENT_SCHEMA = ?"
+		args = append(args, schema)
+	}
+	orderDir := "DESC"
+	if ascending {
+		orderDir = "ASC"
+	}
+	query += " ORDER BY esh.TIMER_START " + orderDir
+	query += fmt.Sprintf(" LIMIT %d", limit)
+
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query DDL statements: %w", err)
+	}
+	defer rows.Close()
+
+	var events []map[string]any
+	for rows.Next() {
+		var connID int64
+		var sqlUser, host string
+		var sqlText sql.NullString
+		var durationMS float64
+
+		if err := rows.Scan(&connID, &sqlUser, &host, &sqlText, &durationMS); err != nil {
+			slog.Warn("forensics: scan DDL row", "error", err)
+			continue
+		}
+
+		event := map[string]any{
+			"connection_id": connID,
+			"user":          sqlUser,
+			"host":          host,
+			"duration_ms":   durationMS,
+		}
+		if sqlText.Valid {
+			event["sql_text"] = sqlText.String
+		}
+		events = append(events, event)
+	}
+	if events == nil {
+		events = []map[string]any{}
+	}
+	return events, rows.Err()
+}
+
+// ---------------------------------------------------------------------------
+// Fallback query generators — used when performance_schema data is unavailable
+// ---------------------------------------------------------------------------
+
+// sqlEscape escapes user-supplied values for safe interpolation into fallback
+// SQL queries. These queries are returned as text (not executed by bintrail),
+// but may be executed by MCP clients — so we prevent injection.
+//
+// Uses ANSI SQL standard quote-doubling (every embedded single quote is
+// doubled) rather than backslash escaping (\'), which is immune to
+// backslash-based bypass attacks in MySQL.
+func sqlEscape(s string) string {
+	s = strings.ReplaceAll(s, "\\", "\\\\")
+	s = strings.ReplaceAll(s, "'", "''")
+	return s
+}
+
+func generateUserActivityFallback(user, since, until string, limit int) []FallbackQuery {
+	safeUser := sqlEscape(user)
+	queries := []FallbackQuery{
+		{
+			Description: "Check current connections for this user",
+			SQL: fmt.Sprintf(
+				"SELECT * FROM information_schema.PROCESSLIST WHERE USER = '%s'", safeUser),
+		},
+		{
+			Description: "Recent statement history for this user (requires events_statements_history consumer)",
+			SQL: fmt.Sprintf(
+				"SELECT t.PROCESSLIST_ID, t.PROCESSLIST_HOST, "+
+					"esh.SQL_TEXT, esh.DIGEST_TEXT, esh.ROWS_AFFECTED, "+
+					"esh.TIMER_WAIT/1000000000 AS duration_ms "+
+					"FROM performance_schema.events_statements_history esh "+
+					"JOIN performance_schema.threads t ON t.THREAD_ID = esh.THREAD_ID "+
+					"WHERE t.PROCESSLIST_USER = '%s' "+
+					"ORDER BY esh.TIMER_START DESC LIMIT %d", safeUser, limit),
+		},
+	}
+	if since != "" || until != "" {
+		timeFilter := ""
+		if since != "" {
+			timeFilter += fmt.Sprintf(" AND event_time >= '%s'", sqlEscape(since))
+		}
+		if until != "" {
+			timeFilter += fmt.Sprintf(" AND event_time <= '%s'", sqlEscape(until))
+		}
+		queries = append(queries, FallbackQuery{
+			Description: "Check general log for historical queries (if general_log is ON)",
+			SQL: fmt.Sprintf(
+				"SELECT event_time, user_host, thread_id, command_type, argument "+
+					"FROM mysql.general_log "+
+					"WHERE user_host LIKE '%s@%%'%s "+
+					"ORDER BY event_time DESC LIMIT %d", safeUser, timeFilter, limit),
+		})
+	}
+	return queries
+}
+
+func generateConnectionFallback(user, host string, limit int) []FallbackQuery {
+	safeUser := sqlEscape(user)
+	safeHost := sqlEscape(host)
+	var filter string
+	if user != "" && host != "" {
+		filter = fmt.Sprintf("WHERE USER = '%s' AND HOST LIKE '%%%s%%'", safeUser, safeHost)
+	} else if user != "" {
+		filter = fmt.Sprintf("WHERE USER = '%s'", safeUser)
+	} else {
+		filter = fmt.Sprintf("WHERE HOST LIKE '%%%s%%'", safeHost)
+	}
+
+	return []FallbackQuery{
+		{
+			Description: "Current connections matching filter",
+			SQL:         fmt.Sprintf("SELECT * FROM information_schema.PROCESSLIST %s LIMIT %d", filter, limit),
+		},
+		{
+			Description: "Account summary from performance_schema (cumulative, survives disconnection)",
+			SQL: fmt.Sprintf(
+				"SELECT USER, HOST, CURRENT_CONNECTIONS, TOTAL_CONNECTIONS "+
+					"FROM performance_schema.accounts %s", filter),
+		},
+		{
+			Description: "Host connection summary",
+			SQL: "SELECT HOST, CURRENT_CONNECTIONS, TOTAL_CONNECTIONS " +
+				"FROM performance_schema.hosts WHERE HOST IS NOT NULL ORDER BY TOTAL_CONNECTIONS DESC",
+		},
+	}
+}
+
+func generateDDLFallback(schema, since, until string, limit int) []FallbackQuery {
+	queries := []FallbackQuery{
+		{
+			Description: "Use bintrail's indexed DDL events instead",
+			SQL:         "-- Use `bintrail query --event-type ddl` or the list_schema_changes MCP tool instead",
+		},
+	}
+
+	timeFilter := ""
+	if since != "" {
+		timeFilter += fmt.Sprintf(" AND event_time >= '%s'", sqlEscape(since))
+	}
+	if until != "" {
+		timeFilter += fmt.Sprintf(" AND event_time <= '%s'", sqlEscape(until))
+	}
+	schemaFilter := ""
+	if schema != "" {
+		schemaFilter = fmt.Sprintf(" AND argument LIKE '%%%s%%'", sqlEscape(schema))
+	}
+
+	queries = append(queries, FallbackQuery{
+		Description: "Check general log for DDL statements (if general_log is ON)",
+		SQL: fmt.Sprintf(
+			"SELECT event_time, user_host, thread_id, argument "+
+				"FROM mysql.general_log "+
+				"WHERE command_type = 'Query' "+
+				"AND (argument LIKE 'CREATE %%' OR argument LIKE 'ALTER %%' "+
+				"OR argument LIKE 'DROP %%' OR argument LIKE 'RENAME %%')%s%s "+
+				"ORDER BY event_time DESC LIMIT %d", schemaFilter, timeFilter, limit),
+	})
+
+	return queries
+}

--- a/internal/forensics/activity_test.go
+++ b/internal/forensics/activity_test.go
@@ -1,0 +1,430 @@
+package forensics
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+// statementCols is the column list scanStatementRows expects, shared by the
+// events_statements_history and events_statements_history_long SELECTs.
+var statementCols = []string{
+	"connection_id", "user", "host", "sql_text", "digest",
+	"rows_affected", "rows_examined", "tmp_tables", "no_index_used", "duration_ms",
+}
+
+func TestActivityValidation(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	tests := []struct {
+		name    string
+		query   ActivityQuery
+		wantErr string
+	}{
+		{
+			name:    "unknown query type",
+			query:   ActivityQuery{Type: "bogus"},
+			wantErr: "bogus",
+		},
+		{
+			name:    "empty query type",
+			query:   ActivityQuery{},
+			wantErr: "unknown query_type",
+		},
+		{
+			name:    "user_activity requires user",
+			query:   ActivityQuery{Type: QueryUserActivity},
+			wantErr: "user is required",
+		},
+		{
+			name:    "connection_history requires user or host",
+			query:   ActivityQuery{Type: QueryConnectionHistory},
+			wantErr: "user or host is required",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Activity(t.Context(), db, tt.query)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("Activity error = %v, want it to contain %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestActivityUserActivityFallbackOnQueryError pins fallback-over-error: a
+// failing performance_schema query is an answer (source=fallback + executable
+// SQL + note), never an error. Limit 0 must surface as the default 50 in the
+// generated fallback SQL.
+func TestActivityUserActivityFallbackOnQueryError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("events_statements_history_long esh").
+		WillReturnError(errors.New("SELECT command denied to user"))
+
+	res, err := Activity(t.Context(), db, ActivityQuery{Type: QueryUserActivity, User: "app_user"})
+	if err != nil {
+		t.Fatalf("Activity must not error on a data-source failure: %v", err)
+	}
+	if res.Source != "fallback" {
+		t.Errorf("Source = %q, want fallback", res.Source)
+	}
+	if len(res.Events) != 0 {
+		t.Errorf("Events = %v, want empty", res.Events)
+	}
+	if !strings.Contains(res.Note, "performance_schema query failed") {
+		t.Errorf("Note = %q, want the perf-schema failure note", res.Note)
+	}
+	if len(res.FallbackQueries) == 0 {
+		t.Fatal("expected fallback queries")
+	}
+	foundLimit := false
+	for _, q := range res.FallbackQueries {
+		if !strings.Contains(q.SQL, "app_user") && !strings.Contains(q.Description, "user") {
+			t.Errorf("fallback query does not reference the user: %+v", q)
+		}
+		if strings.Contains(q.SQL, "LIMIT 50") {
+			foundLimit = true
+		}
+	}
+	if !foundLimit {
+		t.Error("expected the default limit 50 in the fallback SQL")
+	}
+}
+
+func TestActivityUserActivityHappyPath(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("events_statements_history_long esh").
+		WithArgs("app_user").
+		WillReturnRows(sqlmock.NewRows(statementCols).
+			AddRow(42, "app_user", "10.0.0.5:33060", "UPDATE orders SET status = 1", "UPDATE `orders` ...", 3, 3, 0, 0, 12.5))
+
+	res, err := Activity(t.Context(), db, ActivityQuery{Type: QueryUserActivity, User: "app_user"})
+	if err != nil {
+		t.Fatalf("Activity: %v", err)
+	}
+	if res.Source != "performance_schema" || res.Count != 1 || len(res.Events) != 1 {
+		t.Fatalf("result = source=%q count=%d events=%d, want performance_schema/1/1", res.Source, res.Count, len(res.Events))
+	}
+	ev := res.Events[0]
+	if ev["connection_id"] != int64(42) || ev["user"] != "app_user" {
+		t.Errorf("event identity fields wrong: %v", ev)
+	}
+	if ev["sql_text"] != "UPDATE orders SET status = 1" {
+		t.Errorf("sql_text = %v", ev["sql_text"])
+	}
+	if ev["rows_affected"] != int64(3) {
+		t.Errorf("rows_affected = %v, want 3", ev["rows_affected"])
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// TestActivityUserActivityShortHistoryFallback pins the two-tier read: when
+// the global history_long buffer has nothing (consumer off), the per-thread
+// events_statements_history buffer is tried before giving up.
+func TestActivityUserActivityShortHistoryFallback(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("events_statements_history_long esh").
+		WithArgs("app_user").
+		WillReturnRows(sqlmock.NewRows(statementCols))
+	mock.ExpectQuery("events_statements_history esh").
+		WithArgs("app_user").
+		WillReturnRows(sqlmock.NewRows(statementCols).
+			AddRow(7, "app_user", "localhost", "DELETE FROM t WHERE id = 9", nil, 1, 1, 0, 0, 3.25))
+
+	res, err := Activity(t.Context(), db, ActivityQuery{Type: QueryUserActivity, User: "app_user"})
+	if err != nil {
+		t.Fatalf("Activity: %v", err)
+	}
+	if res.Source != "performance_schema" || res.Count != 1 {
+		t.Fatalf("result = source=%q count=%d, want performance_schema/1", res.Source, res.Count)
+	}
+	if _, hasDigest := res.Events[0]["digest"]; hasDigest {
+		t.Error("NULL digest must be omitted from the event map")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// TestActivityUserActivityDiagnostics pins the diagnose path: both history
+// buffers empty → the result carries diagnostics and an actionable note (here:
+// the history_long consumer is disabled → the exact UPDATE to run).
+func TestActivityUserActivityDiagnostics(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("events_statements_history_long esh").
+		WillReturnRows(sqlmock.NewRows(statementCols))
+	mock.ExpectQuery("events_statements_history esh").
+		WillReturnRows(sqlmock.NewRows(statementCols))
+	// diagnoseEmptyUserActivity probes, in order:
+	mock.ExpectQuery("SELECT ENABLED FROM performance_schema.setup_consumers").
+		WillReturnRows(sqlmock.NewRows([]string{"ENABLED"}).AddRow("NO"))
+	mock.ExpectQuery("SELECT COUNT\\(\\*\\) FROM performance_schema.events_statements_history_long").
+		WillReturnRows(sqlmock.NewRows([]string{"COUNT"}).AddRow(0))
+	mock.ExpectQuery("FROM performance_schema.threads WHERE PROCESSLIST_USER").
+		WillReturnRows(sqlmock.NewRows([]string{"COUNT"}).AddRow(0))
+	mock.ExpectQuery("FROM performance_schema.threads WHERE TYPE = 'FOREGROUND'").
+		WillReturnRows(sqlmock.NewRows([]string{"COUNT"}).AddRow(4))
+	mock.ExpectQuery("SELECT TOTAL_CONNECTIONS FROM performance_schema.accounts").
+		WillReturnRows(sqlmock.NewRows([]string{"TOTAL_CONNECTIONS"}))
+
+	res, err := Activity(t.Context(), db, ActivityQuery{Type: QueryUserActivity, User: "app_user"})
+	if err != nil {
+		t.Fatalf("Activity: %v", err)
+	}
+	if res.Source != "fallback" {
+		t.Errorf("Source = %q, want fallback", res.Source)
+	}
+	if res.Diagnostics["history_long_consumer"] != "NO" {
+		t.Errorf("diagnostics = %v, want history_long_consumer=NO", res.Diagnostics)
+	}
+	if !strings.Contains(res.Note, "UPDATE performance_schema.setup_consumers") {
+		t.Errorf("Note = %q, want the consumer-enable UPDATE", res.Note)
+	}
+	if len(res.FallbackQueries) == 0 {
+		t.Error("expected fallback queries")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestActivityConnectionHistoryHappyPath(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	connectionCols := []string{
+		"connection_id", "user", "host", "current_db",
+		"command", "state", "time_seconds", "current_query",
+	}
+	mock.ExpectQuery("FROM performance_schema.threads t").
+		WithArgs("root").
+		WillReturnRows(sqlmock.NewRows(connectionCols).
+			AddRow(11, "root", "localhost", "shop", "Query", "executing", 120, "SELECT 1"))
+
+	res, err := Activity(t.Context(), db, ActivityQuery{Type: QueryConnectionHistory, User: "root"})
+	if err != nil {
+		t.Fatalf("Activity: %v", err)
+	}
+	if res.Source != "performance_schema" || res.Count != 1 || len(res.Connections) != 1 {
+		t.Fatalf("result = source=%q count=%d connections=%d, want performance_schema/1/1",
+			res.Source, res.Count, len(res.Connections))
+	}
+	conn := res.Connections[0]
+	if conn["connection_id"] != int64(11) || conn["current_db"] != "shop" || conn["current_query"] != "SELECT 1" {
+		t.Errorf("connection = %v", conn)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestActivityConnectionHistoryFallbackOnQueryError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("FROM performance_schema.threads t").
+		WillReturnError(errors.New("denied"))
+
+	res, err := Activity(t.Context(), db, ActivityQuery{Type: QueryConnectionHistory, Host: "10.0.1.50"})
+	if err != nil {
+		t.Fatalf("Activity must not error on a data-source failure: %v", err)
+	}
+	if res.Source != "fallback" || len(res.FallbackQueries) == 0 || res.Note == "" {
+		t.Errorf("want fallback+queries+note, got %+v", res)
+	}
+}
+
+func TestActivityDDLHistoryHappyPath(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	ddlCols := []string{"connection_id", "user", "host", "sql_text", "duration_ms"}
+	mock.ExpectQuery("events_statements_history_long esh").
+		WithArgs("shop").
+		WillReturnRows(sqlmock.NewRows(ddlCols).
+			AddRow(3, "admin", "10.0.0.9", "ALTER TABLE orders ADD COLUMN note TEXT", 88.0))
+
+	res, err := Activity(t.Context(), db, ActivityQuery{Type: QueryDDLHistory, Schema: "shop"})
+	if err != nil {
+		t.Fatalf("Activity: %v", err)
+	}
+	if res.Source != "performance_schema" || res.Count != 1 {
+		t.Fatalf("result = source=%q count=%d, want performance_schema/1", res.Source, res.Count)
+	}
+	if res.Events[0]["sql_text"] != "ALTER TABLE orders ADD COLUMN note TEXT" {
+		t.Errorf("sql_text = %v", res.Events[0]["sql_text"])
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// TestActivityDDLHistoryFallbackCapsLimit exercises the DDL fallback path and
+// pins the limit cap: 5000 must clamp to 1000 in the generated SQL.
+func TestActivityDDLHistoryFallbackCapsLimit(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("events_statements_history_long esh").
+		WillReturnError(errors.New("denied"))
+
+	res, err := Activity(t.Context(), db, ActivityQuery{Type: QueryDDLHistory, Limit: 5000})
+	if err != nil {
+		t.Fatalf("Activity: %v", err)
+	}
+	if res.Source != "fallback" || len(res.FallbackQueries) == 0 {
+		t.Fatalf("want fallback with queries, got %+v", res)
+	}
+	capped := false
+	for _, q := range res.FallbackQueries {
+		if strings.Contains(q.SQL, "LIMIT 1000") {
+			capped = true
+		}
+		if strings.Contains(q.SQL, "LIMIT 5000") {
+			t.Errorf("limit was not capped: %s", q.SQL)
+		}
+	}
+	if !capped {
+		t.Error("expected the capped LIMIT 1000 in fallback SQL")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Fallback query generator tests (ported from the SaaS agent's forensics_test.go)
+// ---------------------------------------------------------------------------
+
+func TestSqlEscape(t *testing.T) {
+	tests := []struct {
+		input, want string
+	}{
+		{"root", "root"},
+		{"it's", "it''s"},
+		{`\' OR 1=1 --`, `\\'' OR 1=1 --`},
+		{`admin\`, `admin\\`},
+		{"a'b'c", "a''b''c"},
+		{"", ""},
+	}
+	for _, tc := range tests {
+		got := sqlEscape(tc.input)
+		if got != tc.want {
+			t.Errorf("sqlEscape(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestGenerateUserActivityFallback(t *testing.T) {
+	queries := generateUserActivityFallback("app_user", "2026-03-10 14:00:00", "", 50)
+
+	if len(queries) < 2 {
+		t.Fatalf("expected at least 2 fallback queries, got %d", len(queries))
+	}
+
+	found := false
+	for _, q := range queries {
+		if strings.Contains(q.SQL, "app_user") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("fallback queries should reference the user")
+	}
+
+	// A since/until filter adds the general_log query with the time filter.
+	last := queries[len(queries)-1]
+	if !strings.Contains(last.SQL, "2026-03-10 14:00:00") {
+		t.Errorf("expected the since filter in the general_log query: %s", last.SQL)
+	}
+
+	// User-supplied values must be escaped in the generated SQL.
+	escaped := generateUserActivityFallback("it's", "", "", 50)
+	for _, q := range escaped {
+		if strings.Contains(q.SQL, "it's") {
+			t.Errorf("unescaped quote in fallback SQL: %s", q.SQL)
+		}
+	}
+}
+
+func TestGenerateConnectionFallback(t *testing.T) {
+	queries := generateConnectionFallback("root", "10.0.1.50", 50)
+
+	if len(queries) < 2 {
+		t.Fatalf("expected at least 2 fallback queries, got %d", len(queries))
+	}
+	if !strings.Contains(queries[0].SQL, "USER = 'root'") || !strings.Contains(queries[0].SQL, "10.0.1.50") {
+		t.Errorf("combined user+host filter missing: %s", queries[0].SQL)
+	}
+
+	hostOnly := generateConnectionFallback("", "10.0.1.50", 50)
+	if strings.Contains(hostOnly[0].SQL, "USER =") {
+		t.Errorf("host-only filter must not reference USER: %s", hostOnly[0].SQL)
+	}
+}
+
+func TestGenerateDDLFallback(t *testing.T) {
+	queries := generateDDLFallback("mydb", "2026-03-01", "2026-03-10", 50)
+
+	if len(queries) < 1 {
+		t.Fatalf("expected at least 1 fallback query, got %d", len(queries))
+	}
+	genLog := queries[len(queries)-1]
+	for _, want := range []string{"mydb", "2026-03-01", "2026-03-10", "general_log"} {
+		if !strings.Contains(genLog.SQL, want) {
+			t.Errorf("general_log DDL fallback missing %q: %s", want, genLog.SQL)
+		}
+	}
+}
+
+func TestNormalizeTimestamp(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"2026-03-10T14:00:00", "2026-03-10 14:00:00"},
+		{"2026-03-10 14:00:00", "2026-03-10 14:00:00"},
+		{"", ""},
+		// Only the first T (the date/time separator) is replaced.
+		{"2026-03-10T14:00:00TZ", "2026-03-10 14:00:00TZ"},
+	}
+	for _, tc := range tests {
+		if got := normalizeTimestamp(tc.in); got != tc.want {
+			t.Errorf("normalizeTimestamp(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/forensics/capabilities.go
+++ b/internal/forensics/capabilities.go
@@ -1,0 +1,304 @@
+// Package forensics inspects a MySQL-family source server's forensic data
+// sources — performance_schema and the audit-log plugin family — so binlog
+// changes can be attributed to users, hosts, and client programs ("who
+// changed this"). Ported from the dbtrail SaaS agent (agent/handler/
+// forensics.go) and setup-guide service (services/forensics_guide.py); JSON
+// field names match the SaaS wire contract (models/forensics.py) so later
+// surfaces (CLI, console, MCP, agent WS) stay wire-compatible.
+//
+// This package is mechanism only. The entitlement seam is Enabled (gate.go),
+// checked at surface entry points — never inside this library. All SQL here
+// is read-only against the source server: capabilities are detected and
+// remediation is suggested, but bintrail never writes to a monitored server
+// (the "validate, never set" convention).
+package forensics
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+)
+
+// Capabilities describes the forensic data sources available on a MySQL
+// server.
+type Capabilities struct {
+	PerformanceSchema PerfSchemaCapabilities `json:"performance_schema"`
+	AuditLog          AuditLogCapabilities   `json:"audit_log"`
+	ServerInfo        ServerInfo             `json:"server_info"`
+}
+
+// PerfSchemaConsumers reports the state of the two setup_consumers rows the
+// forensic activity queries depend on.
+type PerfSchemaConsumers struct {
+	EventsStatementsHistory     bool `json:"events_statements_history"`
+	EventsStatementsHistoryLong bool `json:"events_statements_history_long"`
+}
+
+// PerfSchemaCapabilities reports whether performance_schema is enabled and
+// which relevant pieces of it are usable.
+type PerfSchemaCapabilities struct {
+	Enabled           bool                `json:"enabled"`
+	Consumers         PerfSchemaConsumers `json:"consumers"`
+	ThreadsAccessible bool                `json:"threads_accessible"`
+}
+
+// AuditLogCapabilities reports whether an audit-log plugin is active and, if
+// so, which variant and how it is configured.
+type AuditLogCapabilities struct {
+	Installed    bool   `json:"installed"`
+	PluginName   string `json:"plugin_name,omitempty"`
+	PluginStatus string `json:"plugin_status,omitempty"`
+	// Variant is "percona", "mariadb" (also the AWS RDS/Aurora fork of
+	// MariaDB server_audit), or "mysql_enterprise".
+	Variant string `json:"variant,omitempty"`
+	// Config holds the audit-related SHOW GLOBAL VARIABLES that matched
+	// (format, file path, policy, ...).
+	Config map[string]string `json:"config,omitempty"`
+}
+
+// ServerInfo identifies the server version and variant.
+type ServerInfo struct {
+	Version        string `json:"version,omitempty"`
+	VersionComment string `json:"version_comment,omitempty"`
+	// Variant is "percona", "mariadb", or "mysql".
+	Variant string `json:"variant,omitempty"`
+}
+
+// DetectCapabilities checks what forensic data sources are available on the
+// MySQL server reachable via sourceDB.
+//
+// It inspects:
+//   - performance_schema: enabled status, relevant consumers, threads access
+//   - audit_log plugin: installed status, variant (Percona/MySQL/MariaDB), config
+//   - server info: MySQL version and server variant (Percona/MariaDB/MySQL)
+//
+// Detection is best-effort: individual probe failures degrade to "not
+// available" (logged at WARN) rather than failing the whole call. An error is
+// returned only when the server itself is unreachable.
+func DetectCapabilities(ctx context.Context, sourceDB *sql.DB) (Capabilities, error) {
+	if err := sourceDB.PingContext(ctx); err != nil {
+		return Capabilities{}, fmt.Errorf("connect to MySQL: %w", err)
+	}
+	return Capabilities{
+		PerformanceSchema: detectPerfSchema(ctx, sourceDB),
+		AuditLog:          detectAuditLog(ctx, sourceDB),
+		ServerInfo:        detectServerInfo(ctx, sourceDB),
+	}, nil
+}
+
+// detectPerfSchema checks whether performance_schema is enabled and which
+// relevant consumers are active.
+func detectPerfSchema(ctx context.Context, db *sql.DB) PerfSchemaCapabilities {
+	var caps PerfSchemaCapabilities
+
+	var varName, varValue string
+	err := db.QueryRowContext(ctx,
+		"SHOW GLOBAL VARIABLES LIKE 'performance_schema'",
+	).Scan(&varName, &varValue)
+	if err != nil {
+		slog.Warn("forensics: could not check performance_schema variable", "error", err)
+		return caps
+	}
+	caps.Enabled = strings.EqualFold(varValue, "ON")
+	if !caps.Enabled {
+		return caps
+	}
+
+	// Check relevant consumers.
+	rows, err := db.QueryContext(ctx,
+		"SELECT NAME, ENABLED FROM performance_schema.setup_consumers "+
+			"WHERE NAME IN ('events_statements_history', 'events_statements_history_long')",
+	)
+	if err != nil {
+		slog.Warn("forensics: could not query setup_consumers", "error", err)
+	} else {
+		defer rows.Close()
+		for rows.Next() {
+			var name, enabled string
+			if err := rows.Scan(&name, &enabled); err != nil {
+				slog.Warn("forensics: scan consumer row", "error", err)
+				continue
+			}
+			on := strings.EqualFold(enabled, "YES")
+			switch name {
+			case "events_statements_history":
+				caps.Consumers.EventsStatementsHistory = on
+			case "events_statements_history_long":
+				caps.Consumers.EventsStatementsHistoryLong = on
+			}
+		}
+		if err := rows.Err(); err != nil {
+			slog.Warn("forensics: iterate consumer rows", "error", err)
+		}
+	}
+
+	// Check if the threads table is accessible.
+	var threadCount int
+	err = db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM performance_schema.threads WHERE TYPE = 'FOREGROUND' LIMIT 1",
+	).Scan(&threadCount)
+	caps.ThreadsAccessible = err == nil
+
+	return caps
+}
+
+// detectAuditLog checks whether an audit log plugin is installed and determines
+// its variant (Percona, MySQL Enterprise, or MariaDB).
+func detectAuditLog(ctx context.Context, db *sql.DB) AuditLogCapabilities {
+	var caps AuditLogCapabilities
+
+	rows, err := db.QueryContext(ctx,
+		"SELECT PLUGIN_NAME, PLUGIN_STATUS, PLUGIN_DESCRIPTION "+
+			"FROM information_schema.PLUGINS "+
+			"WHERE UPPER(PLUGIN_NAME) LIKE '%AUDIT%' AND PLUGIN_STATUS = 'ACTIVE'",
+	)
+	if err != nil {
+		slog.Warn("forensics: could not query audit plugins", "error", err)
+		return caps
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var name, status, description string
+		if err := rows.Scan(&name, &status, &description); err != nil {
+			slog.Warn("forensics: scan audit plugin row", "error", err)
+			continue
+		}
+
+		// Skip the RDS internal audit plugin — it's not queryable via SQL.
+		upperName := strings.ToUpper(name)
+		if strings.Contains(upperName, "RDS_SECURITY") {
+			continue
+		}
+
+		caps.Installed = true
+		caps.PluginName = name
+		caps.PluginStatus = status
+
+		// Determine variant based on plugin name.
+		switch {
+		case strings.Contains(upperName, "PERCONA") || strings.Contains(strings.ToUpper(description), "PERCONA"):
+			caps.Variant = "percona"
+		case strings.Contains(upperName, "SERVER_AUDIT") || strings.Contains(upperName, "MARIADB"):
+			caps.Variant = "mariadb"
+		default:
+			caps.Variant = "mysql_enterprise"
+		}
+
+		// Try to get the audit log configuration.
+		caps.Config = detectAuditLogConfig(ctx, db)
+		break // Only need the first active audit plugin.
+	}
+	if err := rows.Err(); err != nil {
+		slog.Warn("forensics: iterate audit plugin rows", "error", err)
+	}
+
+	return caps
+}
+
+// detectAuditLogConfig reads audit log configuration variables.
+//
+// Uses string formatting instead of prepared-statement placeholders for
+// SHOW GLOBAL VARIABLES — some MySQL/RDS configurations reject prepared
+// statements for SHOW commands. Variable names are hardcoded constants.
+//
+// If none of the well-known variable names match (common on RDS where
+// SERVER_AUDIT exists but MariaDB-style config vars do not), falls back
+// to a wildcard query to discover any audit-related variables.
+func detectAuditLogConfig(ctx context.Context, db *sql.DB) map[string]string {
+	configVars := []string{
+		"audit_log_format",
+		"audit_log_file",
+		"audit_log_policy",
+		"server_audit_logging",     // MariaDB
+		"server_audit_file_path",   // MariaDB
+		"server_audit_output_type", // MariaDB
+	}
+
+	config := map[string]string{}
+	for _, v := range configVars {
+		var name, value string
+		//nolint:gosec // v is a hardcoded constant, not user input
+		err := db.QueryRowContext(ctx,
+			fmt.Sprintf("SHOW GLOBAL VARIABLES LIKE '%s'", v),
+		).Scan(&name, &value)
+		if err == nil {
+			config[name] = value
+		} else if !errors.Is(err, sql.ErrNoRows) {
+			slog.Warn("forensics: detectAuditLogConfig SHOW variable", "variable", v, "error", err)
+		}
+	}
+	if len(config) > 0 {
+		return config
+	}
+
+	// Fallback: if none of the well-known vars matched, try a wildcard
+	// to discover any audit-related variables (covers RDS managed plugins
+	// which use different parameter names).
+	rows, err := db.QueryContext(ctx, "SHOW GLOBAL VARIABLES LIKE '%audit%'")
+	if err != nil {
+		slog.Warn("forensics: detectAuditLogConfig wildcard query", "error", err)
+		return nil
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var name, value string
+		if scanErr := rows.Scan(&name, &value); scanErr != nil {
+			slog.Warn("forensics: detectAuditLogConfig wildcard scan", "error", scanErr)
+			continue
+		}
+		config[name] = value
+	}
+	if rowErr := rows.Err(); rowErr != nil {
+		slog.Warn("forensics: detectAuditLogConfig wildcard rows", "error", rowErr)
+	}
+	if len(config) == 0 {
+		return nil
+	}
+	return config
+}
+
+// detectServerInfo reads MySQL version metadata to determine the server variant
+// (Percona Server, MariaDB, or MySQL Community/Enterprise).
+// Same fmt.Sprintf rationale as detectAuditLogConfig (RDS prepared-statement quirk).
+func detectServerInfo(ctx context.Context, db *sql.DB) ServerInfo {
+	var info ServerInfo
+
+	for _, v := range []string{"version", "version_comment"} {
+		var name, value string
+		//nolint:gosec // v is a hardcoded constant, not user input
+		err := db.QueryRowContext(ctx,
+			fmt.Sprintf("SHOW GLOBAL VARIABLES LIKE '%s'", v),
+		).Scan(&name, &value)
+		if err != nil {
+			if !errors.Is(err, sql.ErrNoRows) {
+				slog.Warn("forensics: detectServerInfo SHOW variable", "variable", v, "error", err)
+			}
+			continue
+		}
+		switch v {
+		case "version":
+			info.Version = value
+		case "version_comment":
+			info.VersionComment = value
+		}
+	}
+
+	// Derive variant from version_comment.
+	if info.VersionComment != "" {
+		upper := strings.ToUpper(info.VersionComment)
+		switch {
+		case strings.Contains(upper, "PERCONA"):
+			info.Variant = "percona"
+		case strings.Contains(upper, "MARIADB"):
+			info.Variant = "mariadb"
+		default:
+			info.Variant = "mysql"
+		}
+	}
+
+	return info
+}

--- a/internal/forensics/capabilities_test.go
+++ b/internal/forensics/capabilities_test.go
@@ -1,0 +1,458 @@
+package forensics
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+// varRows builds a SHOW GLOBAL VARIABLES-shaped resultset with one row.
+func varRows(name, value string) *sqlmock.Rows {
+	return sqlmock.NewRows([]string{"Variable_name", "Value"}).AddRow(name, value)
+}
+
+// emptyVarRows builds a SHOW GLOBAL VARIABLES-shaped resultset with no rows
+// (variable does not exist → sql.ErrNoRows on Scan).
+func emptyVarRows() *sqlmock.Rows {
+	return sqlmock.NewRows([]string{"Variable_name", "Value"})
+}
+
+func consumerRows(pairs ...[2]string) *sqlmock.Rows {
+	rows := sqlmock.NewRows([]string{"NAME", "ENABLED"})
+	for _, p := range pairs {
+		rows.AddRow(p[0], p[1])
+	}
+	return rows
+}
+
+// auditConfigVarNames mirrors the well-known variable list probed by
+// detectAuditLogConfig, in probe order.
+var auditConfigVarNames = []string{
+	"audit_log_format",
+	"audit_log_file",
+	"audit_log_policy",
+	"server_audit_logging",
+	"server_audit_file_path",
+	"server_audit_output_type",
+}
+
+// expectAuditConfigVars registers the six well-known SHOW GLOBAL VARIABLES
+// probes; vars named in values return a row, the rest return empty.
+func expectAuditConfigVars(m sqlmock.Sqlmock, values map[string]string) {
+	for _, v := range auditConfigVarNames {
+		e := m.ExpectQuery("SHOW GLOBAL VARIABLES LIKE '" + v + "'")
+		if val, ok := values[v]; ok {
+			e.WillReturnRows(varRows(v, val))
+		} else {
+			e.WillReturnRows(emptyVarRows())
+		}
+	}
+}
+
+func TestDetectPerfSchema(t *testing.T) {
+	forcedErr := errors.New("forced failure")
+
+	tests := []struct {
+		name  string
+		setup func(m sqlmock.Sqlmock)
+		want  PerfSchemaCapabilities
+	}{
+		{
+			name: "enabled with both consumers on",
+			setup: func(m sqlmock.Sqlmock) {
+				m.ExpectQuery("SHOW GLOBAL VARIABLES LIKE 'performance_schema'").
+					WillReturnRows(varRows("performance_schema", "ON"))
+				m.ExpectQuery("FROM performance_schema.setup_consumers WHERE NAME IN").
+					WillReturnRows(consumerRows(
+						[2]string{"events_statements_history", "YES"},
+						[2]string{"events_statements_history_long", "YES"}))
+				m.ExpectQuery("FROM performance_schema.threads WHERE TYPE = 'FOREGROUND' LIMIT 1").
+					WillReturnRows(sqlmock.NewRows([]string{"COUNT"}).AddRow(5))
+			},
+			want: PerfSchemaCapabilities{
+				Enabled: true,
+				Consumers: PerfSchemaConsumers{
+					EventsStatementsHistory:     true,
+					EventsStatementsHistoryLong: true,
+				},
+				ThreadsAccessible: true,
+			},
+		},
+		{
+			name: "enabled with history_long off",
+			setup: func(m sqlmock.Sqlmock) {
+				m.ExpectQuery("SHOW GLOBAL VARIABLES LIKE 'performance_schema'").
+					WillReturnRows(varRows("performance_schema", "ON"))
+				m.ExpectQuery("FROM performance_schema.setup_consumers WHERE NAME IN").
+					WillReturnRows(consumerRows(
+						[2]string{"events_statements_history", "YES"},
+						[2]string{"events_statements_history_long", "NO"}))
+				m.ExpectQuery("FROM performance_schema.threads WHERE TYPE = 'FOREGROUND' LIMIT 1").
+					WillReturnRows(sqlmock.NewRows([]string{"COUNT"}).AddRow(5))
+			},
+			want: PerfSchemaCapabilities{
+				Enabled:           true,
+				Consumers:         PerfSchemaConsumers{EventsStatementsHistory: true},
+				ThreadsAccessible: true,
+			},
+		},
+		{
+			name: "consumer missing from the resultset is treated as off",
+			setup: func(m sqlmock.Sqlmock) {
+				m.ExpectQuery("SHOW GLOBAL VARIABLES LIKE 'performance_schema'").
+					WillReturnRows(varRows("performance_schema", "ON"))
+				m.ExpectQuery("FROM performance_schema.setup_consumers WHERE NAME IN").
+					WillReturnRows(consumerRows([2]string{"events_statements_history", "YES"}))
+				m.ExpectQuery("FROM performance_schema.threads WHERE TYPE = 'FOREGROUND' LIMIT 1").
+					WillReturnRows(sqlmock.NewRows([]string{"COUNT"}).AddRow(5))
+			},
+			want: PerfSchemaCapabilities{
+				Enabled:           true,
+				Consumers:         PerfSchemaConsumers{EventsStatementsHistory: true},
+				ThreadsAccessible: true,
+			},
+		},
+		{
+			name: "disabled runs no further probes",
+			setup: func(m sqlmock.Sqlmock) {
+				m.ExpectQuery("SHOW GLOBAL VARIABLES LIKE 'performance_schema'").
+					WillReturnRows(varRows("performance_schema", "OFF"))
+			},
+			want: PerfSchemaCapabilities{},
+		},
+		{
+			name: "variable query failure degrades to disabled",
+			setup: func(m sqlmock.Sqlmock) {
+				m.ExpectQuery("SHOW GLOBAL VARIABLES LIKE 'performance_schema'").
+					WillReturnError(forcedErr)
+			},
+			want: PerfSchemaCapabilities{},
+		},
+		{
+			name: "consumers query failure keeps enabled and threads probes",
+			setup: func(m sqlmock.Sqlmock) {
+				m.ExpectQuery("SHOW GLOBAL VARIABLES LIKE 'performance_schema'").
+					WillReturnRows(varRows("performance_schema", "ON"))
+				m.ExpectQuery("FROM performance_schema.setup_consumers WHERE NAME IN").
+					WillReturnError(forcedErr)
+				m.ExpectQuery("FROM performance_schema.threads WHERE TYPE = 'FOREGROUND' LIMIT 1").
+					WillReturnRows(sqlmock.NewRows([]string{"COUNT"}).AddRow(5))
+			},
+			want: PerfSchemaCapabilities{Enabled: true, ThreadsAccessible: true},
+		},
+		{
+			name: "threads query failure means threads not accessible",
+			setup: func(m sqlmock.Sqlmock) {
+				m.ExpectQuery("SHOW GLOBAL VARIABLES LIKE 'performance_schema'").
+					WillReturnRows(varRows("performance_schema", "ON"))
+				m.ExpectQuery("FROM performance_schema.setup_consumers WHERE NAME IN").
+					WillReturnRows(consumerRows(
+						[2]string{"events_statements_history", "YES"},
+						[2]string{"events_statements_history_long", "YES"}))
+				m.ExpectQuery("FROM performance_schema.threads WHERE TYPE = 'FOREGROUND' LIMIT 1").
+					WillReturnError(forcedErr)
+			},
+			want: PerfSchemaCapabilities{
+				Enabled: true,
+				Consumers: PerfSchemaConsumers{
+					EventsStatementsHistory:     true,
+					EventsStatementsHistoryLong: true,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("sqlmock: %v", err)
+			}
+			defer db.Close()
+			tt.setup(mock)
+
+			got := detectPerfSchema(t.Context(), db)
+			if got != tt.want {
+				t.Errorf("detectPerfSchema = %+v, want %+v", got, tt.want)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("unmet expectations: %v", err)
+			}
+		})
+	}
+}
+
+func TestDetectAuditLog(t *testing.T) {
+	pluginRows := func(rows ...[3]string) *sqlmock.Rows {
+		r := sqlmock.NewRows([]string{"PLUGIN_NAME", "PLUGIN_STATUS", "PLUGIN_DESCRIPTION"})
+		for _, row := range rows {
+			r.AddRow(row[0], row[1], row[2])
+		}
+		return r
+	}
+
+	tests := []struct {
+		name        string
+		setup       func(m sqlmock.Sqlmock)
+		want        AuditLogCapabilities
+		checkConfig map[string]string // non-nil: assert Config equals this
+	}{
+		{
+			name: "no audit plugins",
+			setup: func(m sqlmock.Sqlmock) {
+				m.ExpectQuery("FROM information_schema.PLUGINS").WillReturnRows(pluginRows())
+			},
+			want: AuditLogCapabilities{},
+		},
+		{
+			name: "percona variant by description",
+			setup: func(m sqlmock.Sqlmock) {
+				m.ExpectQuery("FROM information_schema.PLUGINS").
+					WillReturnRows(pluginRows([3]string{"audit_log", "ACTIVE", "Percona Audit Log"}))
+				expectAuditConfigVars(m, map[string]string{
+					"audit_log_format": "JSON",
+					"audit_log_file":   "/var/lib/mysql/audit.log",
+				})
+			},
+			want: AuditLogCapabilities{
+				Installed:    true,
+				PluginName:   "audit_log",
+				PluginStatus: "ACTIVE",
+				Variant:      "percona",
+			},
+			checkConfig: map[string]string{
+				"audit_log_format": "JSON",
+				"audit_log_file":   "/var/lib/mysql/audit.log",
+			},
+		},
+		{
+			name: "mariadb variant by SERVER_AUDIT name",
+			setup: func(m sqlmock.Sqlmock) {
+				m.ExpectQuery("FROM information_schema.PLUGINS").
+					WillReturnRows(pluginRows([3]string{"SERVER_AUDIT", "ACTIVE", "Audit the server activity"}))
+				expectAuditConfigVars(m, map[string]string{
+					"server_audit_logging":   "ON",
+					"server_audit_file_path": "/rdsdbdata/log/audit/server_audit.log",
+				})
+			},
+			want: AuditLogCapabilities{
+				Installed:    true,
+				PluginName:   "SERVER_AUDIT",
+				PluginStatus: "ACTIVE",
+				Variant:      "mariadb",
+			},
+			checkConfig: map[string]string{
+				"server_audit_logging":   "ON",
+				"server_audit_file_path": "/rdsdbdata/log/audit/server_audit.log",
+			},
+		},
+		{
+			name: "mysql_enterprise as the default variant",
+			setup: func(m sqlmock.Sqlmock) {
+				m.ExpectQuery("FROM information_schema.PLUGINS").
+					WillReturnRows(pluginRows([3]string{"audit_log", "ACTIVE", "Oracle Audit Log"}))
+				expectAuditConfigVars(m, nil)
+				// No well-known vars matched → wildcard fallback.
+				m.ExpectQuery("SHOW GLOBAL VARIABLES LIKE '%audit%'").
+					WillReturnRows(varRows("audit_log_connection_policy", "ALL"))
+			},
+			want: AuditLogCapabilities{
+				Installed:    true,
+				PluginName:   "audit_log",
+				PluginStatus: "ACTIVE",
+				Variant:      "mysql_enterprise",
+			},
+			checkConfig: map[string]string{"audit_log_connection_policy": "ALL"},
+		},
+		{
+			name: "RDS internal security plugin is skipped",
+			setup: func(m sqlmock.Sqlmock) {
+				m.ExpectQuery("FROM information_schema.PLUGINS").
+					WillReturnRows(pluginRows([3]string{"RDS_SECURITY_AUDIT", "ACTIVE", "internal"}))
+			},
+			want: AuditLogCapabilities{},
+		},
+		{
+			name: "RDS internal plugin skipped but real plugin after it wins",
+			setup: func(m sqlmock.Sqlmock) {
+				m.ExpectQuery("FROM information_schema.PLUGINS").
+					WillReturnRows(pluginRows(
+						[3]string{"RDS_SECURITY_AUDIT", "ACTIVE", "internal"},
+						[3]string{"SERVER_AUDIT", "ACTIVE", "Audit the server activity"}))
+				expectAuditConfigVars(m, nil)
+				m.ExpectQuery("SHOW GLOBAL VARIABLES LIKE '%audit%'").WillReturnRows(emptyVarRows())
+			},
+			want: AuditLogCapabilities{
+				Installed:    true,
+				PluginName:   "SERVER_AUDIT",
+				PluginStatus: "ACTIVE",
+				Variant:      "mariadb",
+			},
+		},
+		{
+			name: "plugins query failure degrades to not installed",
+			setup: func(m sqlmock.Sqlmock) {
+				m.ExpectQuery("FROM information_schema.PLUGINS").WillReturnError(errors.New("denied"))
+			},
+			want: AuditLogCapabilities{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("sqlmock: %v", err)
+			}
+			defer db.Close()
+			tt.setup(mock)
+
+			got := detectAuditLog(t.Context(), db)
+			if got.Installed != tt.want.Installed || got.PluginName != tt.want.PluginName ||
+				got.PluginStatus != tt.want.PluginStatus || got.Variant != tt.want.Variant {
+				t.Errorf("detectAuditLog = %+v, want %+v", got, tt.want)
+			}
+			if tt.checkConfig != nil {
+				if len(got.Config) != len(tt.checkConfig) {
+					t.Errorf("Config = %v, want %v", got.Config, tt.checkConfig)
+				}
+				for k, v := range tt.checkConfig {
+					if got.Config[k] != v {
+						t.Errorf("Config[%q] = %q, want %q", k, got.Config[k], v)
+					}
+				}
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("unmet expectations: %v", err)
+			}
+		})
+	}
+}
+
+func TestDetectServerInfo(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		comment string // empty = variable absent
+		want    ServerInfo
+	}{
+		{
+			name:    "mysql community",
+			version: "8.0.36",
+			comment: "MySQL Community Server - GPL",
+			want:    ServerInfo{Version: "8.0.36", VersionComment: "MySQL Community Server - GPL", Variant: "mysql"},
+		},
+		{
+			name:    "percona server",
+			version: "8.0.36-28",
+			comment: "Percona Server (GPL), Release 28",
+			want:    ServerInfo{Version: "8.0.36-28", VersionComment: "Percona Server (GPL), Release 28", Variant: "percona"},
+		},
+		{
+			name:    "mariadb",
+			version: "10.11.6-MariaDB",
+			comment: "mariadb.org binary distribution",
+			want:    ServerInfo{Version: "10.11.6-MariaDB", VersionComment: "mariadb.org binary distribution", Variant: "mariadb"},
+		},
+		{
+			name:    "missing version_comment leaves variant empty",
+			version: "8.0.36",
+			comment: "",
+			want:    ServerInfo{Version: "8.0.36"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("sqlmock: %v", err)
+			}
+			defer db.Close()
+
+			mock.ExpectQuery("SHOW GLOBAL VARIABLES LIKE 'version'").
+				WillReturnRows(varRows("version", tt.version))
+			e := mock.ExpectQuery("SHOW GLOBAL VARIABLES LIKE 'version_comment'")
+			if tt.comment == "" {
+				e.WillReturnRows(emptyVarRows())
+			} else {
+				e.WillReturnRows(varRows("version_comment", tt.comment))
+			}
+
+			got := detectServerInfo(t.Context(), db)
+			if got != tt.want {
+				t.Errorf("detectServerInfo = %+v, want %+v", got, tt.want)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("unmet expectations: %v", err)
+			}
+		})
+	}
+}
+
+// TestDetectCapabilities exercises the composed entry point end-to-end against
+// a mocked server: p_s enabled with one consumer off, no audit plugin, MySQL
+// community — the most common self-managed 8.0 shape.
+func TestDetectCapabilities(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SHOW GLOBAL VARIABLES LIKE 'performance_schema'").
+		WillReturnRows(varRows("performance_schema", "ON"))
+	mock.ExpectQuery("FROM performance_schema.setup_consumers WHERE NAME IN").
+		WillReturnRows(consumerRows(
+			[2]string{"events_statements_history", "YES"},
+			[2]string{"events_statements_history_long", "NO"}))
+	mock.ExpectQuery("FROM performance_schema.threads WHERE TYPE = 'FOREGROUND' LIMIT 1").
+		WillReturnRows(sqlmock.NewRows([]string{"COUNT"}).AddRow(3))
+	mock.ExpectQuery("FROM information_schema.PLUGINS").
+		WillReturnRows(sqlmock.NewRows([]string{"PLUGIN_NAME", "PLUGIN_STATUS", "PLUGIN_DESCRIPTION"}))
+	mock.ExpectQuery("SHOW GLOBAL VARIABLES LIKE 'version'").
+		WillReturnRows(varRows("version", "8.0.36"))
+	mock.ExpectQuery("SHOW GLOBAL VARIABLES LIKE 'version_comment'").
+		WillReturnRows(varRows("version_comment", "MySQL Community Server - GPL"))
+
+	caps, err := DetectCapabilities(t.Context(), db)
+	if err != nil {
+		t.Fatalf("DetectCapabilities: %v", err)
+	}
+	if !caps.PerformanceSchema.Enabled {
+		t.Error("PerformanceSchema.Enabled = false, want true")
+	}
+	if !caps.PerformanceSchema.Consumers.EventsStatementsHistory {
+		t.Error("EventsStatementsHistory = false, want true")
+	}
+	if caps.PerformanceSchema.Consumers.EventsStatementsHistoryLong {
+		t.Error("EventsStatementsHistoryLong = true, want false")
+	}
+	if !caps.PerformanceSchema.ThreadsAccessible {
+		t.Error("ThreadsAccessible = false, want true")
+	}
+	if caps.AuditLog.Installed {
+		t.Error("AuditLog.Installed = true, want false")
+	}
+	if caps.ServerInfo.Variant != "mysql" {
+		t.Errorf("ServerInfo.Variant = %q, want mysql", caps.ServerInfo.Variant)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// TestDetectCapabilitiesUnreachableServer pins the one hard-error path: an
+// unreachable server must return an error, not all-false capabilities that
+// would read as "nothing is configured".
+func TestDetectCapabilitiesUnreachableServer(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectPing().WillReturnError(errors.New("connection refused"))
+
+	if _, err := DetectCapabilities(t.Context(), db); err == nil {
+		t.Fatal("expected error for unreachable server, got nil")
+	}
+}

--- a/internal/forensics/enrich.go
+++ b/internal/forensics/enrich.go
@@ -1,0 +1,210 @@
+package forensics
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+)
+
+// maxEnrichThreadIDs caps a single enrichment batch. Larger requests must be
+// chunked by the caller — an unbounded IN clause against performance_schema
+// is both slow and a memory hazard.
+const maxEnrichThreadIDs = 500
+
+// ThreadInfo holds forensic metadata about a MySQL connection.
+type ThreadInfo struct {
+	User          string            `json:"user"`
+	Host          string            `json:"host"`
+	ConnectionID  int64             `json:"connection_id"`
+	ProcesslistDB *string           `json:"db,omitempty"`
+	Command       string            `json:"command"`
+	State         string            `json:"state"`
+	ConnAttrs     map[string]string `json:"connection_attributes,omitempty"`
+}
+
+// FallbackQuery is an executable SQL query returned to the caller when the
+// requested forensic data is not directly available — the caller (a human, or
+// an MCP client) can run it manually against the source server.
+type FallbackQuery struct {
+	Description string `json:"description"`
+	SQL         string `json:"sql"`
+}
+
+// EnrichResult maps "connection_id" (stringified) to live thread metadata.
+// IDs with no live session appear in NotFound together with fallback queries
+// for manual investigation.
+type EnrichResult struct {
+	Threads         map[string]*ThreadInfo `json:"threads"`
+	Source          string                 `json:"source"`
+	NotFound        []int64                `json:"not_found,omitempty"`
+	FallbackQueries []FallbackQuery        `json:"fallback_queries,omitempty"`
+}
+
+// EnrichThreads looks up forensic metadata for the given thread/connection IDs
+// from performance_schema (threads + session_connect_attrs). At most
+// maxEnrichThreadIDs may be requested per call.
+//
+// LIVE-ONLY: this looks at currently-connected sessions. The SaaS falls back
+// to a connection_cache table for disconnected sessions; that cache is ported
+// in the sibling connection-cache poller (#703), and the live→cache
+// composition happens in the who-changed engine (#706) — not here.
+func EnrichThreads(ctx context.Context, sourceDB *sql.DB, threadIDs []int64) (EnrichResult, error) {
+	if len(threadIDs) == 0 {
+		return EnrichResult{}, errors.New("thread_ids is required and must not be empty")
+	}
+	if len(threadIDs) > maxEnrichThreadIDs {
+		return EnrichResult{}, fmt.Errorf("thread_ids must not exceed %d entries", maxEnrichThreadIDs)
+	}
+
+	threads, err := lookupThreads(ctx, sourceDB, threadIDs)
+	if err != nil {
+		return EnrichResult{}, err
+	}
+
+	// Generate fallback queries for thread IDs not found.
+	var notFound []int64
+	for _, tid := range threadIDs {
+		key := fmt.Sprintf("%d", tid)
+		if _, ok := threads[key]; !ok {
+			notFound = append(notFound, tid)
+		}
+	}
+
+	res := EnrichResult{
+		Threads:  threads,
+		Source:   "performance_schema",
+		NotFound: notFound,
+	}
+	if len(notFound) > 0 {
+		res.FallbackQueries = generateThreadFallbackQueries(notFound)
+	}
+	return res, nil
+}
+
+// lookupThreads queries performance_schema.threads and session_connect_attrs
+// for the given connection IDs. Returns a map of "connection_id" → ThreadInfo.
+func lookupThreads(ctx context.Context, db *sql.DB, threadIDs []int64) (map[string]*ThreadInfo, error) {
+	result := map[string]*ThreadInfo{}
+
+	// Build IN clause with positional args.
+	placeholders := make([]string, len(threadIDs))
+	args := make([]any, len(threadIDs))
+	for i, id := range threadIDs {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+	inClause := strings.Join(placeholders, ",")
+
+	// Query the threads table — PROCESSLIST_ID is the connection_id used in
+	// binlog events.
+	rows, err := db.QueryContext(ctx, fmt.Sprintf(
+		"SELECT PROCESSLIST_ID, PROCESSLIST_USER, PROCESSLIST_HOST, "+
+			"PROCESSLIST_DB, PROCESSLIST_COMMAND, PROCESSLIST_STATE "+
+			"FROM performance_schema.threads "+
+			"WHERE TYPE = 'FOREGROUND' AND PROCESSLIST_ID IN (%s)", inClause), args...)
+	if err != nil {
+		return nil, fmt.Errorf("query performance_schema.threads: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var ti ThreadInfo
+		var processlistDB sql.NullString
+		var state sql.NullString
+		if err := rows.Scan(&ti.ConnectionID, &ti.User, &ti.Host,
+			&processlistDB, &ti.Command, &state); err != nil {
+			slog.Warn("forensics: scan thread row", "error", err)
+			continue
+		}
+		if processlistDB.Valid {
+			ti.ProcesslistDB = &processlistDB.String
+		}
+		if state.Valid {
+			ti.State = state.String
+		}
+		key := fmt.Sprintf("%d", ti.ConnectionID)
+		result[key] = &ti
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate thread rows: %w", err)
+	}
+
+	// Enrich with session_connect_attrs (client program, OS, pid, etc.).
+	enrichWithConnAttrs(ctx, db, result, inClause, args)
+
+	return result, nil
+}
+
+// enrichWithConnAttrs adds session_connect_attrs data to thread info entries.
+func enrichWithConnAttrs(ctx context.Context, db *sql.DB, threads map[string]*ThreadInfo, inClause string, args []any) {
+	rows, err := db.QueryContext(ctx, fmt.Sprintf(
+		"SELECT PROCESSLIST_ID, ATTR_NAME, ATTR_VALUE "+
+			"FROM performance_schema.session_connect_attrs "+
+			"WHERE PROCESSLIST_ID IN (%s)", inClause), args...)
+	if err != nil {
+		slog.Warn("forensics: could not query session_connect_attrs", "error", err)
+		return
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var connID int64
+		var attrName, attrValue string
+		if err := rows.Scan(&connID, &attrName, &attrValue); err != nil {
+			slog.Warn("forensics: scan connect_attr row", "error", err)
+			continue
+		}
+		key := fmt.Sprintf("%d", connID)
+		ti, ok := threads[key]
+		if !ok {
+			// Connection found in attrs but not in threads (might have disconnected).
+			ti = &ThreadInfo{ConnectionID: connID}
+			threads[key] = ti
+		}
+		if ti.ConnAttrs == nil {
+			ti.ConnAttrs = map[string]string{}
+		}
+		ti.ConnAttrs[attrName] = attrValue
+	}
+	if err := rows.Err(); err != nil {
+		slog.Warn("forensics: iterate connect_attr rows", "error", err)
+	}
+}
+
+// generateThreadFallbackQueries returns SQL queries the user can run manually
+// to investigate thread IDs that are no longer in performance_schema (historical).
+func generateThreadFallbackQueries(threadIDs []int64) []FallbackQuery {
+	ids := make([]string, len(threadIDs))
+	for i, id := range threadIDs {
+		ids[i] = fmt.Sprintf("%d", id)
+	}
+	idList := strings.Join(ids, ", ")
+
+	return []FallbackQuery{
+		{
+			Description: "Check processlist for active connections (MySQL)",
+			SQL:         fmt.Sprintf("SELECT * FROM information_schema.PROCESSLIST WHERE ID IN (%s)", idList),
+		},
+		{
+			Description: "Check recent statement history (requires events_statements_history consumer)",
+			SQL: fmt.Sprintf(
+				"SELECT t.PROCESSLIST_ID, t.PROCESSLIST_USER, t.PROCESSLIST_HOST, "+
+					"esh.SQL_TEXT, esh.TIMER_START, esh.TIMER_END, esh.ROWS_AFFECTED "+
+					"FROM performance_schema.events_statements_history esh "+
+					"JOIN performance_schema.threads t ON t.THREAD_ID = esh.THREAD_ID "+
+					"WHERE t.PROCESSLIST_ID IN (%s) "+
+					"ORDER BY esh.TIMER_START DESC LIMIT 50", idList),
+		},
+		{
+			Description: "Check general log for historical queries (if enabled)",
+			SQL: fmt.Sprintf(
+				"SELECT event_time, user_host, thread_id, command_type, argument "+
+					"FROM mysql.general_log "+
+					"WHERE thread_id IN (%s) "+
+					"ORDER BY event_time DESC LIMIT 50", idList),
+		},
+	}
+}

--- a/internal/forensics/enrich_test.go
+++ b/internal/forensics/enrich_test.go
@@ -1,0 +1,177 @@
+package forensics
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestEnrichThreadsEmptyIDs(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	_, err = EnrichThreads(t.Context(), db, nil)
+	if err == nil || !strings.Contains(err.Error(), "must not be empty") {
+		t.Errorf("expected 'must not be empty' error, got %v", err)
+	}
+}
+
+func TestEnrichThreadsTooManyIDs(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	ids := make([]int64, maxEnrichThreadIDs+1)
+	_, err = EnrichThreads(t.Context(), db, ids)
+	if err == nil || !strings.Contains(err.Error(), "500") {
+		t.Errorf("expected limit error mentioning 500, got %v", err)
+	}
+}
+
+func TestEnrichThreadsLiveLookup(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	// Thread 42 is live (with NULL db/state to exercise the NullString paths);
+	// thread 77 is gone.
+	mock.ExpectQuery("FROM performance_schema.threads").
+		WithArgs(int64(42), int64(77)).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"PROCESSLIST_ID", "PROCESSLIST_USER", "PROCESSLIST_HOST",
+			"PROCESSLIST_DB", "PROCESSLIST_COMMAND", "PROCESSLIST_STATE",
+		}).AddRow(42, "root", "localhost", nil, "Query", nil))
+	mock.ExpectQuery("FROM performance_schema.session_connect_attrs").
+		WithArgs(int64(42), int64(77)).
+		WillReturnRows(sqlmock.NewRows([]string{"PROCESSLIST_ID", "ATTR_NAME", "ATTR_VALUE"}).
+			AddRow(42, "_client_name", "libmysql").
+			AddRow(42, "program_name", "mysqldump"))
+
+	res, err := EnrichThreads(t.Context(), db, []int64{42, 77})
+	if err != nil {
+		t.Fatalf("EnrichThreads: %v", err)
+	}
+
+	ti, ok := res.Threads["42"]
+	if !ok {
+		t.Fatalf("thread 42 missing from result: %+v", res.Threads)
+	}
+	if ti.User != "root" || ti.Host != "localhost" || ti.ConnectionID != 42 {
+		t.Errorf("thread 42 = %+v, want root@localhost id=42", ti)
+	}
+	if ti.ProcesslistDB != nil {
+		t.Errorf("ProcesslistDB = %v, want nil for NULL column", *ti.ProcesslistDB)
+	}
+	if ti.State != "" {
+		t.Errorf("State = %q, want empty for NULL column", ti.State)
+	}
+	if ti.ConnAttrs["_client_name"] != "libmysql" || ti.ConnAttrs["program_name"] != "mysqldump" {
+		t.Errorf("ConnAttrs = %v, want client attrs merged in", ti.ConnAttrs)
+	}
+
+	if res.Source != "performance_schema" {
+		t.Errorf("Source = %q, want performance_schema", res.Source)
+	}
+	if len(res.NotFound) != 1 || res.NotFound[0] != 77 {
+		t.Errorf("NotFound = %v, want [77]", res.NotFound)
+	}
+	if len(res.FallbackQueries) == 0 {
+		t.Fatal("expected fallback queries for the missing thread ID")
+	}
+	for _, q := range res.FallbackQueries {
+		if q.SQL == "" || q.Description == "" {
+			t.Errorf("fallback query with empty field: %+v", q)
+		}
+		if !strings.Contains(q.SQL, "77") {
+			t.Errorf("fallback query should reference the missing ID 77: %s", q.SQL)
+		}
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// TestEnrichThreadsAttrsOnlyStub pins the SaaS behavior for a session visible
+// in session_connect_attrs but not in threads (raced a disconnect): a stub
+// entry with just the connection id and attrs is returned, and the ID is not
+// reported as missing.
+func TestEnrichThreadsAttrsOnlyStub(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("FROM performance_schema.threads").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"PROCESSLIST_ID", "PROCESSLIST_USER", "PROCESSLIST_HOST",
+			"PROCESSLIST_DB", "PROCESSLIST_COMMAND", "PROCESSLIST_STATE",
+		}))
+	mock.ExpectQuery("FROM performance_schema.session_connect_attrs").
+		WillReturnRows(sqlmock.NewRows([]string{"PROCESSLIST_ID", "ATTR_NAME", "ATTR_VALUE"}).
+			AddRow(99, "_client_name", "libmysql"))
+
+	res, err := EnrichThreads(t.Context(), db, []int64{99})
+	if err != nil {
+		t.Fatalf("EnrichThreads: %v", err)
+	}
+	ti, ok := res.Threads["99"]
+	if !ok {
+		t.Fatalf("expected stub entry for 99, got %+v", res.Threads)
+	}
+	if ti.ConnectionID != 99 || ti.ConnAttrs["_client_name"] != "libmysql" {
+		t.Errorf("stub = %+v, want id 99 with attrs", ti)
+	}
+	if len(res.NotFound) != 0 {
+		t.Errorf("NotFound = %v, want empty (attrs-only session still counts as found)", res.NotFound)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestEnrichThreadsQueryError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("FROM performance_schema.threads").
+		WillReturnError(errors.New("SELECT command denied"))
+
+	_, err = EnrichThreads(t.Context(), db, []int64{1})
+	if err == nil || !strings.Contains(err.Error(), "performance_schema.threads") {
+		t.Errorf("expected threads query error, got %v", err)
+	}
+}
+
+func TestGenerateThreadFallbackQueries(t *testing.T) {
+	queries := generateThreadFallbackQueries([]int64{123, 456})
+
+	if len(queries) < 2 {
+		t.Fatalf("expected at least 2 fallback queries, got %d", len(queries))
+	}
+
+	// Verify the queries contain the thread IDs.
+	for _, q := range queries {
+		if q.SQL == "" {
+			t.Error("fallback query has empty SQL")
+		}
+		if q.Description == "" {
+			t.Error("fallback query has empty description")
+		}
+		if !strings.Contains(q.SQL, "123") || !strings.Contains(q.SQL, "456") {
+			t.Errorf("fallback query should contain thread IDs: %s", q.SQL)
+		}
+	}
+}

--- a/internal/forensics/forensics_integration_test.go
+++ b/internal/forensics/forensics_integration_test.go
@@ -1,0 +1,292 @@
+//go:build integration
+
+package forensics
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/config"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// integrationSourceDB opens a connection to the shared test MySQL server —
+// forensics inspects server-global state (performance_schema, plugins), so
+// these tests connect to the server itself rather than a per-test database.
+func integrationSourceDB(t *testing.T) *sql.DB {
+	t.Helper()
+	testutil.SkipIfNoMySQL(t)
+	db, err := config.Connect(testutil.BaseDSN() + "/")
+	if err != nil {
+		t.Fatalf("connect to test MySQL: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+// TestIntegrationDetectCapabilities asserts shape and internal consistency of
+// the detection result against the live server. The container's
+// performance_schema/audit state is whatever it is, so the assertions are
+// invariants, not exact server config.
+func TestIntegrationDetectCapabilities(t *testing.T) {
+	db := integrationSourceDB(t)
+	ctx := t.Context()
+
+	caps, err := DetectCapabilities(ctx, db)
+	if err != nil {
+		t.Fatalf("DetectCapabilities: %v", err)
+	}
+
+	if caps.ServerInfo.Version == "" {
+		t.Error("ServerInfo.Version is empty on a live server")
+	}
+	validVariants := []string{"mysql", "percona", "mariadb"}
+	if !slices.Contains(validVariants, caps.ServerInfo.Variant) {
+		t.Errorf("ServerInfo.Variant = %q, want one of %v", caps.ServerInfo.Variant, validVariants)
+	}
+
+	// Consistency: consumer/threads flags are only meaningful under an
+	// enabled performance_schema.
+	if !caps.PerformanceSchema.Enabled {
+		if caps.PerformanceSchema.Consumers.EventsStatementsHistory ||
+			caps.PerformanceSchema.Consumers.EventsStatementsHistoryLong ||
+			caps.PerformanceSchema.ThreadsAccessible {
+			t.Errorf("p_s disabled but sub-capabilities set: %+v", caps.PerformanceSchema)
+		}
+	}
+	// Consistency: no plugin → no plugin metadata.
+	if !caps.AuditLog.Installed {
+		if caps.AuditLog.PluginName != "" || caps.AuditLog.Variant != "" {
+			t.Errorf("audit not installed but metadata set: %+v", caps.AuditLog)
+		}
+	}
+
+	// The setup guide composes from any capability state.
+	guide := BuildSetupGuide(caps)
+	if guide.Summary == "" {
+		t.Error("BuildSetupGuide returned an empty summary")
+	}
+	if len(guide.Recommendations) == 0 && !strings.Contains(guide.Summary, "fully configured") {
+		t.Errorf("no recommendations but summary is not the fully-configured one: %q", guide.Summary)
+	}
+}
+
+// TestIntegrationConsumerToggle exercises detection and guide generation with
+// the events_statements_history_long consumer both OFF and ON, restoring the
+// server's original state afterwards.
+func TestIntegrationConsumerToggle(t *testing.T) {
+	db := integrationSourceDB(t)
+	ctx := t.Context()
+
+	caps, err := DetectCapabilities(ctx, db)
+	if err != nil {
+		t.Fatalf("DetectCapabilities: %v", err)
+	}
+	if !caps.PerformanceSchema.Enabled {
+		t.Skip("performance_schema disabled on the test server")
+	}
+
+	const consumer = "events_statements_history_long"
+	var orig string
+	if err := db.QueryRowContext(ctx,
+		"SELECT ENABLED FROM performance_schema.setup_consumers WHERE NAME = ?", consumer,
+	).Scan(&orig); err != nil {
+		t.Skipf("cannot read setup_consumers: %v", err)
+	}
+	setConsumer := func(val string) {
+		t.Helper()
+		// context.Background(), not t.Context(): the restore runs from
+		// t.Cleanup, after the test context is already canceled.
+		if _, err := db.ExecContext(context.Background(),
+			"UPDATE performance_schema.setup_consumers SET ENABLED = ? WHERE NAME = ?", val, consumer); err != nil {
+			t.Fatalf("toggle consumer to %s: %v", val, err)
+		}
+	}
+	t.Cleanup(func() { setConsumer(orig) })
+
+	// OFF: detection reports it off and the guide recommends enabling it.
+	setConsumer("NO")
+	capsOff, err := DetectCapabilities(ctx, db)
+	if err != nil {
+		t.Fatalf("DetectCapabilities (consumer off): %v", err)
+	}
+	if capsOff.PerformanceSchema.Consumers.EventsStatementsHistoryLong {
+		t.Error("consumer toggled NO but detection reports it enabled")
+	}
+	guideOff := BuildSetupGuide(capsOff)
+	foundRec := false
+	for _, rec := range guideOff.Recommendations {
+		if rec.Title == "Enable global statement history consumer" {
+			foundRec = true
+			if len(rec.RuntimeSQL) == 0 || !strings.Contains(rec.RuntimeSQL[0], consumer) {
+				t.Errorf("recommendation lacks the runtime UPDATE for %s: %v", consumer, rec.RuntimeSQL)
+			}
+		}
+	}
+	if !foundRec {
+		t.Errorf("guide with consumer off is missing the history_long recommendation: %v", recTitles(guideOff))
+	}
+
+	// ON: detection reports it on and the recommendation disappears.
+	setConsumer("YES")
+	capsOn, err := DetectCapabilities(ctx, db)
+	if err != nil {
+		t.Fatalf("DetectCapabilities (consumer on): %v", err)
+	}
+	if !capsOn.PerformanceSchema.Consumers.EventsStatementsHistoryLong {
+		t.Error("consumer toggled YES but detection reports it disabled")
+	}
+	for _, rec := range BuildSetupGuide(capsOn).Recommendations {
+		if rec.Title == "Enable global statement history consumer" {
+			t.Error("guide still recommends enabling history_long after it was enabled")
+		}
+	}
+}
+
+// TestIntegrationEnrichThreads enriches this test's own pinned connection —
+// the one session guaranteed to be live — plus an ID guaranteed not to exist.
+func TestIntegrationEnrichThreads(t *testing.T) {
+	db := integrationSourceDB(t)
+	ctx := t.Context()
+
+	caps, err := DetectCapabilities(ctx, db)
+	if err != nil {
+		t.Fatalf("DetectCapabilities: %v", err)
+	}
+	if !caps.PerformanceSchema.Enabled || !caps.PerformanceSchema.ThreadsAccessible {
+		t.Skip("performance_schema threads not accessible on the test server")
+	}
+
+	// Pin a dedicated connection so its session stays visible in
+	// performance_schema.threads while the enrichment (on other pool
+	// connections) runs.
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("pin connection: %v", err)
+	}
+	defer conn.Close()
+	var myID int64
+	if err := conn.QueryRowContext(ctx, "SELECT CONNECTION_ID()").Scan(&myID); err != nil {
+		t.Fatalf("CONNECTION_ID(): %v", err)
+	}
+
+	const ghostID int64 = 999999999
+	res, err := EnrichThreads(ctx, db, []int64{myID, ghostID})
+	if err != nil {
+		t.Fatalf("EnrichThreads: %v", err)
+	}
+
+	if res.Source != "performance_schema" {
+		t.Errorf("Source = %q, want performance_schema", res.Source)
+	}
+	ti, ok := res.Threads[fmt.Sprintf("%d", myID)]
+	if !ok {
+		t.Fatalf("own connection %d not found in %v", myID, res.Threads)
+	}
+	if ti.ConnectionID != myID {
+		t.Errorf("ConnectionID = %d, want %d", ti.ConnectionID, myID)
+	}
+	if ti.User == "" {
+		t.Error("User is empty for a live session")
+	}
+	if slices.Contains(res.NotFound, myID) {
+		t.Errorf("own live connection reported as not found: %v", res.NotFound)
+	}
+	if !slices.Contains(res.NotFound, ghostID) {
+		t.Errorf("ghost ID missing from NotFound: %v", res.NotFound)
+	}
+	if len(res.FallbackQueries) == 0 {
+		t.Fatal("expected fallback queries for the ghost ID")
+	}
+	for _, q := range res.FallbackQueries {
+		if !strings.Contains(q.SQL, fmt.Sprintf("%d", ghostID)) {
+			t.Errorf("fallback SQL does not reference the ghost ID: %s", q.SQL)
+		}
+	}
+}
+
+// TestIntegrationActivity runs the three query modes live. Ring-buffer
+// contents depend on server history, so assertions target the contract:
+// no errors, and fallback (with executable SQL) whenever data is absent.
+func TestIntegrationActivity(t *testing.T) {
+	db := integrationSourceDB(t)
+	ctx := t.Context()
+
+	caps, err := DetectCapabilities(ctx, db)
+	if err != nil {
+		t.Fatalf("DetectCapabilities: %v", err)
+	}
+
+	t.Run("user_activity nonexistent user falls back", func(t *testing.T) {
+		res, err := Activity(ctx, db, ActivityQuery{Type: QueryUserActivity, User: "bt_no_such_user_702"})
+		if err != nil {
+			t.Fatalf("Activity: %v", err)
+		}
+		if res.Source != "fallback" {
+			t.Errorf("Source = %q, want fallback for a user with no activity", res.Source)
+		}
+		if len(res.FallbackQueries) == 0 {
+			t.Error("expected fallback queries")
+		}
+		if res.Note == "" {
+			t.Error("expected a diagnostic note")
+		}
+	})
+
+	t.Run("connection_history sees own session", func(t *testing.T) {
+		// Pin a connection so at least one root session is guaranteed live.
+		conn, err := db.Conn(ctx)
+		if err != nil {
+			t.Fatalf("pin connection: %v", err)
+		}
+		defer conn.Close()
+		var user string
+		if err := conn.QueryRowContext(ctx, "SELECT SUBSTRING_INDEX(CURRENT_USER(), '@', 1)").Scan(&user); err != nil {
+			t.Fatalf("CURRENT_USER(): %v", err)
+		}
+
+		res, err := Activity(ctx, db, ActivityQuery{Type: QueryConnectionHistory, User: user})
+		if err != nil {
+			t.Fatalf("Activity: %v", err)
+		}
+		if caps.PerformanceSchema.Enabled && caps.PerformanceSchema.ThreadsAccessible {
+			if res.Source != "performance_schema" || res.Count < 1 {
+				t.Errorf("source=%q count=%d, want performance_schema with >=1 connection", res.Source, res.Count)
+			}
+			for _, c := range res.Connections {
+				if _, ok := c["connection_id"]; !ok {
+					t.Errorf("connection entry missing connection_id: %v", c)
+				}
+			}
+		}
+	})
+
+	t.Run("ddl_history returns cleanly", func(t *testing.T) {
+		res, err := Activity(ctx, db, ActivityQuery{Type: QueryDDLHistory})
+		if err != nil {
+			t.Fatalf("Activity: %v", err)
+		}
+		if res.Source != "performance_schema" && res.Source != "fallback" {
+			t.Errorf("Source = %q, want performance_schema or fallback", res.Source)
+		}
+		if res.Source == "fallback" && len(res.FallbackQueries) == 0 {
+			t.Error("fallback source but no fallback queries")
+		}
+	})
+}
+
+func TestIntegrationListUsers(t *testing.T) {
+	db := integrationSourceDB(t)
+
+	users, err := ListUsers(t.Context(), db)
+	if err != nil {
+		t.Fatalf("ListUsers: %v", err)
+	}
+	if !slices.Contains(users, "root") {
+		t.Errorf("users = %v, want it to contain root", users)
+	}
+}

--- a/internal/forensics/gate.go
+++ b/internal/forensics/gate.go
@@ -1,0 +1,9 @@
+package forensics
+
+// Enabled reports whether the forensics surface is available in this build.
+//
+// dbtrail OSS ships with forensics enabled. This indirection is the single
+// entitlement seam a future enterprise-license build closes; policy lives at
+// surface entry points (CLI, console, MCP, agent, poller wiring) — never
+// inside this library, so closing the gate never touches mechanism code.
+var Enabled = func() bool { return true }

--- a/internal/forensics/guide.go
+++ b/internal/forensics/guide.go
@@ -1,0 +1,283 @@
+package forensics
+
+import "strings"
+
+// SetupRecommendation is a single actionable recommendation for improving
+// forensic data. All recommendations are advisory — bintrail never writes to
+// a monitored server; the operator applies RuntimeSQL / MycnfSnippet manually.
+type SetupRecommendation struct {
+	Category        string   `json:"category"` // "performance_schema" or "audit_plugin"
+	Title           string   `json:"title"`
+	Description     string   `json:"description"`
+	Impact          string   `json:"impact"`
+	PerformanceNote string   `json:"performance_note"`
+	RuntimeSQL      []string `json:"runtime_sql"`
+	MycnfSnippet    string   `json:"mycnf_snippet"`
+	Priority        string   `json:"priority"` // "high", "medium", or "low"
+}
+
+// SetupGuide is a tailored set of setup recommendations based on detected
+// capabilities.
+type SetupGuide struct {
+	Summary         string                `json:"summary"`
+	Recommendations []SetupRecommendation `json:"recommendations"`
+}
+
+// mycnfPerfSchemaFull is the full my.cnf snippet for enabling
+// performance_schema from scratch.
+const mycnfPerfSchemaFull = "[mysqld]\n" +
+	"performance_schema = ON\n" +
+	"performance-schema-consumer-events-statements-history = ON\n" +
+	"performance-schema-consumer-events-statements-history-long = ON\n" +
+	"performance_schema_events_statements_history_long_size = 10000"
+
+// BuildSetupGuide produces tailored guidance from detected capabilities: what
+// forensic data source is missing or degraded, why it matters, and the exact
+// runtime SQL / my.cnf snippet to fix it. Pure function — port of the SaaS
+// forensics_guide.py decision tree.
+func BuildSetupGuide(caps Capabilities) SetupGuide {
+	var recommendations []SetupRecommendation
+	ps := caps.PerformanceSchema
+	audit := caps.AuditLog
+	variant := caps.ServerInfo.Variant
+	if variant == "" {
+		variant = "mysql"
+	}
+
+	// ── Performance Schema ──
+
+	if !ps.Enabled {
+		recommendations = append(recommendations, SetupRecommendation{
+			Category: "performance_schema",
+			Title:    "Enable Performance Schema",
+			Description: "performance_schema is disabled on this server. It provides real-time " +
+				"connection metadata and statement history essential for forensic " +
+				"investigation. Enabling it requires a MySQL restart.",
+			Impact: "Enables who-changed tracing, user activity queries, connection " +
+				"history, and client attribution (program name, source host).",
+			PerformanceNote: "Typically adds 5-10% memory overhead. CPU impact is negligible " +
+				"for most workloads. Enabled by default in MySQL 8.0+.",
+			RuntimeSQL:   []string{},
+			MycnfSnippet: mycnfPerfSchemaFull,
+			Priority:     "high",
+		})
+	} else {
+		if !ps.Consumers.EventsStatementsHistory {
+			recommendations = append(recommendations, SetupRecommendation{
+				Category: "performance_schema",
+				Title:    "Enable statement history consumer",
+				Description: "The events_statements_history consumer is disabled. This " +
+					"per-connection ring buffer stores recent SQL statements for " +
+					"each active thread.",
+				Impact: "Enables per-connection recent SQL history. Useful for seeing " +
+					"what a specific connection executed recently.",
+				PerformanceNote: "Minimal overhead — stores the last 10 statements per thread " +
+					"by default. Memory usage scales with max_connections.",
+				RuntimeSQL: []string{
+					"UPDATE performance_schema.setup_consumers\n" +
+						"SET ENABLED = 'YES'\n" +
+						"WHERE NAME = 'events_statements_history';",
+				},
+				MycnfSnippet: "[mysqld]\n" +
+					"performance-schema-consumer-events-statements-history = ON",
+				Priority: "medium",
+			})
+		}
+
+		if !ps.Consumers.EventsStatementsHistoryLong {
+			recommendations = append(recommendations, SetupRecommendation{
+				Category: "performance_schema",
+				Title:    "Enable global statement history consumer",
+				Description: "The events_statements_history_long consumer is disabled. This " +
+					"global ring buffer stores recent SQL statements across all " +
+					"connections — critical for forensic investigation of past activity.",
+				Impact: "Enables user_activity queries and DDL history across all " +
+					"connections. This is the primary data source for forensic " +
+					"statement analysis.",
+				PerformanceNote: "Stores the last 10,000 statements globally by default. " +
+					"Memory usage is fixed (not per-connection). Adjust " +
+					"performance_schema_events_statements_history_long_size " +
+					"to control buffer size.",
+				RuntimeSQL: []string{
+					"UPDATE performance_schema.setup_consumers\n" +
+						"SET ENABLED = 'YES'\n" +
+						"WHERE NAME = 'events_statements_history_long';",
+				},
+				MycnfSnippet: "[mysqld]\n" +
+					"performance-schema-consumer-events-statements-history-long = ON\n" +
+					"performance_schema_events_statements_history_long_size = 10000",
+				Priority: "high",
+			})
+		}
+	}
+
+	// ── Audit Plugin ──
+
+	if !audit.Installed {
+		recommendations = append(recommendations, auditRecommendation(variant))
+	} else if isRDSAuditPath(audit.Config) {
+		recommendations = append(recommendations, SetupRecommendation{
+			Category: "audit_plugin",
+			Title:    "Grant IAM permissions for RDS audit log access",
+			Description: "The audit log plugin is active and writing to the RDS-managed " +
+				"filesystem. To read these logs, the IAM role of the host running " +
+				"bintrail needs RDS log download permissions. Without these " +
+				"permissions, audit-log reads will fail with an access denied error.",
+			Impact: "Enables bintrail to download and parse audit logs directly " +
+				"from RDS via the AWS API, providing full SQL statement history " +
+				"with user attribution.",
+			PerformanceNote: "Read-only API calls with no impact on the RDS instance. " +
+				"Large audit log files (50 MB+) may take a few seconds to " +
+				"download and parse.",
+			RuntimeSQL: []string{},
+			MycnfSnippet: "# IAM policy to attach to the role of the host running bintrail:\n" +
+				"{\n" +
+				"  \"Effect\": \"Allow\",\n" +
+				"  \"Action\": [\n" +
+				"    \"rds:DescribeDBLogFiles\",\n" +
+				"    \"rds:DownloadDBLogFilePortion\"\n" +
+				"  ],\n" +
+				"  \"Resource\": \"arn:aws:rds:*:*:db:*\"\n" +
+				"}",
+			Priority: "medium",
+		})
+	}
+
+	// ── Build summary ──
+
+	var summary string
+	if len(recommendations) == 0 {
+		summary = "All forensic data sources are fully configured. " +
+			"performance_schema consumers are enabled and " +
+			"an audit log plugin is installed."
+	} else {
+		var parts []string
+		if !ps.Enabled {
+			parts = append(parts, "performance_schema is disabled")
+		} else if !(ps.Consumers.EventsStatementsHistory && ps.Consumers.EventsStatementsHistoryLong) {
+			parts = append(parts, "statement history consumers are not fully enabled")
+		}
+		if !audit.Installed {
+			parts = append(parts, "no audit log plugin is installed")
+		} else if isRDSAuditPath(audit.Config) {
+			parts = append(parts, "RDS audit log requires IAM permissions for access")
+		}
+		if len(parts) > 0 {
+			summary = "Forensic data can be improved. " +
+				capitalizeFirst(strings.Join(parts, "; ")) +
+				". See recommendations below."
+		} else {
+			summary = "See recommendations below."
+		}
+	}
+
+	return SetupGuide{Summary: summary, Recommendations: recommendations}
+}
+
+// capitalizeFirst uppercases the first byte of an ASCII sentence. Unlike
+// Python's str.capitalize() (which the SaaS used), it does NOT lowercase the
+// rest — "RDS audit log ..." must not become "Rds audit log ...".
+func capitalizeFirst(s string) string {
+	if s == "" {
+		return s
+	}
+	if c := s[0]; c >= 'a' && c <= 'z' {
+		return string(c-'a'+'A') + s[1:]
+	}
+	return s
+}
+
+// isRDSAuditPath detects RDS-managed audit logs by the /rdsdbdata/ path prefix.
+func isRDSAuditPath(auditConfig map[string]string) bool {
+	for _, key := range []string{"server_audit_file_path", "audit_log_file"} {
+		if val := auditConfig[key]; val != "" && strings.Contains(val, "/rdsdbdata/") {
+			return true
+		}
+	}
+	return false
+}
+
+// auditRecommendation builds variant-specific audit plugin installation guidance.
+func auditRecommendation(variant string) SetupRecommendation {
+	if variant == "percona" {
+		return SetupRecommendation{
+			Category: "audit_plugin",
+			Title:    "Install Percona Audit Log Plugin",
+			Description: "No audit log plugin detected. Percona Server includes the free, " +
+				"open-source Audit Log Plugin that captures comprehensive query " +
+				"history for long-term forensic investigation.",
+			Impact: "Captures all SQL statements with user, host, timestamp, and " +
+				"connection metadata. Provides forensic data beyond " +
+				"performance_schema's ring buffer — persisted to disk.",
+			PerformanceNote: "JSON format logging adds moderate I/O overhead. Use " +
+				"audit_log_policy = LOGINS for minimal impact (connection " +
+				"events only) or ALL for full query logging.",
+			RuntimeSQL: []string{
+				"INSTALL PLUGIN audit_log SONAME 'audit_log.so';",
+				"SET GLOBAL audit_log_policy = 'ALL';",
+				"SET GLOBAL audit_log_format = 'JSON';",
+			},
+			MycnfSnippet: "[mysqld]\n" +
+				"plugin-load-add = audit_log.so\n" +
+				"audit_log_policy = ALL\n" +
+				"audit_log_format = JSON\n" +
+				"audit_log_file = /var/log/mysql/audit.log",
+			Priority: "medium",
+		}
+	}
+
+	if variant == "mariadb" {
+		return SetupRecommendation{
+			Category: "audit_plugin",
+			Title:    "Enable MariaDB Audit Plugin",
+			Description: "No audit log plugin detected. MariaDB includes the Server Audit " +
+				"Plugin that captures connection and query events for forensic " +
+				"investigation.",
+			Impact: "Captures SQL statements, connection events, and DDL with user " +
+				"attribution. Persisted to disk for long-term forensic analysis.",
+			PerformanceNote: "FILE output type adds moderate I/O overhead. Use " +
+				"server_audit_events = CONNECT for minimal impact (connection " +
+				"events only) or CONNECT,QUERY for full logging.",
+			RuntimeSQL: []string{
+				"INSTALL SONAME 'server_audit';",
+				"SET GLOBAL server_audit_logging = ON;",
+				"SET GLOBAL server_audit_output_type = 'FILE';",
+				"SET GLOBAL server_audit_file_path = '/var/log/mysql/server_audit.log';",
+			},
+			MycnfSnippet: "[mysqld]\n" +
+				"plugin-load-add = server_audit\n" +
+				"server_audit_logging = ON\n" +
+				"server_audit_output_type = FILE\n" +
+				"server_audit_file_path = /var/log/mysql/server_audit.log",
+			Priority: "medium",
+		}
+	}
+
+	// MySQL Community / Enterprise / unknown.
+	return SetupRecommendation{
+		Category: "audit_plugin",
+		Title:    "Install an audit log plugin",
+		Description: "No audit log plugin detected. MySQL Enterprise Edition includes " +
+			"the Enterprise Audit plugin (commercial license required). " +
+			"Alternatively, consider migrating to Percona Server (free, " +
+			"drop-in replacement) for the open-source Percona Audit Log Plugin.",
+		Impact: "Captures all SQL statements with user, host, timestamp, and " +
+			"connection metadata. Provides forensic data beyond " +
+			"performance_schema's ring buffer — persisted to disk.",
+		PerformanceNote: "Audit logging adds moderate I/O overhead depending on query " +
+			"volume and log format.",
+		RuntimeSQL: []string{
+			"-- MySQL Enterprise Audit (requires Enterprise Edition):\n" +
+				"INSTALL PLUGIN audit_log SONAME 'audit_log.so';",
+		},
+		MycnfSnippet: "# Option 1: MySQL Enterprise Audit (requires Enterprise license)\n" +
+			"[mysqld]\n" +
+			"plugin-load-add = audit_log.so\n" +
+			"audit_log_format = JSON\n" +
+			"audit_log_policy = ALL\n" +
+			"\n" +
+			"# Option 2: Migrate to Percona Server (free, drop-in replacement)\n" +
+			"# and use the Percona Audit Log Plugin (see Percona docs)",
+		Priority: "medium",
+	}
+}

--- a/internal/forensics/guide_test.go
+++ b/internal/forensics/guide_test.go
@@ -1,0 +1,236 @@
+package forensics
+
+import (
+	"strings"
+	"testing"
+)
+
+// fullCaps returns a fully-configured capability set the tests degrade from.
+func fullCaps() Capabilities {
+	return Capabilities{
+		PerformanceSchema: PerfSchemaCapabilities{
+			Enabled: true,
+			Consumers: PerfSchemaConsumers{
+				EventsStatementsHistory:     true,
+				EventsStatementsHistoryLong: true,
+			},
+			ThreadsAccessible: true,
+		},
+		AuditLog: AuditLogCapabilities{
+			Installed:  true,
+			PluginName: "audit_log",
+			Variant:    "percona",
+			Config:     map[string]string{"audit_log_file": "/var/log/mysql/audit.log"},
+		},
+		ServerInfo: ServerInfo{Version: "8.0.36", VersionComment: "Percona Server (GPL)", Variant: "percona"},
+	}
+}
+
+func recTitles(g SetupGuide) []string {
+	titles := make([]string, len(g.Recommendations))
+	for i, r := range g.Recommendations {
+		titles[i] = r.Title
+	}
+	return titles
+}
+
+func findRec(t *testing.T, g SetupGuide, title string) SetupRecommendation {
+	t.Helper()
+	for _, r := range g.Recommendations {
+		if r.Title == title {
+			return r
+		}
+	}
+	t.Fatalf("recommendation %q not found in %v", title, recTitles(g))
+	return SetupRecommendation{}
+}
+
+func TestBuildSetupGuideFullyConfigured(t *testing.T) {
+	g := BuildSetupGuide(fullCaps())
+	if len(g.Recommendations) != 0 {
+		t.Errorf("expected no recommendations, got %v", recTitles(g))
+	}
+	if !strings.Contains(g.Summary, "fully configured") {
+		t.Errorf("Summary = %q, want the fully-configured summary", g.Summary)
+	}
+}
+
+func TestBuildSetupGuidePerfSchemaDisabled(t *testing.T) {
+	caps := fullCaps()
+	caps.PerformanceSchema = PerfSchemaCapabilities{} // disabled
+	caps.AuditLog = AuditLogCapabilities{}            // no plugin
+	caps.ServerInfo.Variant = ""                      // unknown → treated as mysql
+
+	g := BuildSetupGuide(caps)
+
+	ps := findRec(t, g, "Enable Performance Schema")
+	if ps.Category != "performance_schema" || ps.Priority != "high" {
+		t.Errorf("perf-schema rec category/priority = %s/%s, want performance_schema/high", ps.Category, ps.Priority)
+	}
+	if len(ps.RuntimeSQL) != 0 {
+		t.Errorf("enabling p_s needs a restart — no runtime SQL expected, got %v", ps.RuntimeSQL)
+	}
+	if !strings.Contains(ps.MycnfSnippet, "performance_schema = ON") {
+		t.Errorf("my.cnf snippet = %q", ps.MycnfSnippet)
+	}
+
+	// Disabled p_s must NOT also emit the per-consumer recommendations
+	// (they are meaningless until p_s itself is on).
+	for _, title := range []string{"Enable statement history consumer", "Enable global statement history consumer"} {
+		for _, r := range g.Recommendations {
+			if r.Title == title {
+				t.Errorf("unexpected consumer recommendation %q while p_s is disabled", title)
+			}
+		}
+	}
+
+	// Unknown variant falls back to the generic MySQL audit guidance.
+	audit := findRec(t, g, "Install an audit log plugin")
+	if audit.Category != "audit_plugin" {
+		t.Errorf("audit rec category = %s", audit.Category)
+	}
+
+	for _, want := range []string{"is disabled", "no audit log plugin is installed", "See recommendations below."} {
+		if !strings.Contains(g.Summary, want) {
+			t.Errorf("Summary = %q, want it to contain %q", g.Summary, want)
+		}
+	}
+}
+
+func TestBuildSetupGuideConsumersOff(t *testing.T) {
+	caps := fullCaps()
+	caps.PerformanceSchema.Consumers = PerfSchemaConsumers{}
+
+	g := BuildSetupGuide(caps)
+
+	short := findRec(t, g, "Enable statement history consumer")
+	if short.Priority != "medium" {
+		t.Errorf("history consumer priority = %s, want medium", short.Priority)
+	}
+	if len(short.RuntimeSQL) != 1 || !strings.Contains(short.RuntimeSQL[0], "'events_statements_history'") {
+		t.Errorf("history consumer RuntimeSQL = %v", short.RuntimeSQL)
+	}
+
+	long := findRec(t, g, "Enable global statement history consumer")
+	if long.Priority != "high" {
+		t.Errorf("history_long consumer priority = %s, want high", long.Priority)
+	}
+	if len(long.RuntimeSQL) != 1 || !strings.Contains(long.RuntimeSQL[0], "'events_statements_history_long'") {
+		t.Errorf("history_long consumer RuntimeSQL = %v", long.RuntimeSQL)
+	}
+	if !strings.Contains(long.MycnfSnippet, "performance-schema-consumer-events-statements-history-long = ON") {
+		t.Errorf("history_long my.cnf snippet = %q", long.MycnfSnippet)
+	}
+
+	// First letter is uppercased by the summary composition, so match past it.
+	if !strings.Contains(g.Summary, "tatement history consumers are not fully enabled") {
+		t.Errorf("Summary = %q", g.Summary)
+	}
+}
+
+func TestBuildSetupGuideOnlyHistoryLongOff(t *testing.T) {
+	caps := fullCaps()
+	caps.PerformanceSchema.Consumers.EventsStatementsHistoryLong = false
+
+	g := BuildSetupGuide(caps)
+	if len(g.Recommendations) != 1 {
+		t.Fatalf("expected exactly 1 recommendation, got %v", recTitles(g))
+	}
+	if g.Recommendations[0].Title != "Enable global statement history consumer" {
+		t.Errorf("recommendation = %q", g.Recommendations[0].Title)
+	}
+}
+
+func TestBuildSetupGuideAuditVariants(t *testing.T) {
+	tests := []struct {
+		variant       string
+		wantTitle     string
+		wantSQLSubstr string
+	}{
+		{"percona", "Install Percona Audit Log Plugin", "INSTALL PLUGIN audit_log SONAME 'audit_log.so';"},
+		{"mariadb", "Enable MariaDB Audit Plugin", "INSTALL SONAME 'server_audit';"},
+		{"mysql", "Install an audit log plugin", "INSTALL PLUGIN audit_log SONAME 'audit_log.so';"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.variant, func(t *testing.T) {
+			caps := fullCaps()
+			caps.AuditLog = AuditLogCapabilities{}
+			caps.ServerInfo.Variant = tt.variant
+
+			g := BuildSetupGuide(caps)
+			rec := findRec(t, g, tt.wantTitle)
+			joined := strings.Join(rec.RuntimeSQL, "\n")
+			if !strings.Contains(joined, tt.wantSQLSubstr) {
+				t.Errorf("RuntimeSQL = %q, want it to contain %q", joined, tt.wantSQLSubstr)
+			}
+			if rec.Category != "audit_plugin" || rec.Priority != "medium" {
+				t.Errorf("category/priority = %s/%s, want audit_plugin/medium", rec.Category, rec.Priority)
+			}
+		})
+	}
+}
+
+// TestBuildSetupGuideRDSIAM pins the RDS branch: an installed audit plugin
+// writing under /rdsdbdata/ yields the IAM-policy recommendation, and the
+// summary keeps "RDS" capitalized (unlike Python's str.capitalize(), which
+// would lowercase it to "Rds").
+func TestBuildSetupGuideRDSIAM(t *testing.T) {
+	caps := fullCaps()
+	caps.AuditLog.Variant = "mariadb"
+	caps.AuditLog.Config = map[string]string{
+		"server_audit_file_path": "/rdsdbdata/log/audit/server_audit.log",
+	}
+
+	g := BuildSetupGuide(caps)
+	rec := findRec(t, g, "Grant IAM permissions for RDS audit log access")
+	for _, want := range []string{"rds:DescribeDBLogFiles", "rds:DownloadDBLogFilePortion"} {
+		if !strings.Contains(rec.MycnfSnippet, want) {
+			t.Errorf("IAM policy snippet missing %q: %s", want, rec.MycnfSnippet)
+		}
+	}
+	if len(rec.RuntimeSQL) != 0 {
+		t.Errorf("IAM rec must have no runtime SQL, got %v", rec.RuntimeSQL)
+	}
+
+	wantSummary := "Forensic data can be improved. RDS audit log requires IAM permissions for access. See recommendations below."
+	if g.Summary != wantSummary {
+		t.Errorf("Summary = %q, want %q", g.Summary, wantSummary)
+	}
+}
+
+func TestIsRDSAuditPath(t *testing.T) {
+	tests := []struct {
+		name   string
+		config map[string]string
+		want   bool
+	}{
+		{"mariadb rds path", map[string]string{"server_audit_file_path": "/rdsdbdata/log/audit/server_audit.log"}, true},
+		{"percona rds path", map[string]string{"audit_log_file": "/rdsdbdata/log/audit.log"}, true},
+		{"self-managed path", map[string]string{"server_audit_file_path": "/var/log/mysql/server_audit.log"}, false},
+		{"no relevant keys", map[string]string{"audit_log_policy": "ALL"}, false},
+		{"empty config", map[string]string{}, false},
+		{"nil config", nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isRDSAuditPath(tt.config); got != tt.want {
+				t.Errorf("isRDSAuditPath(%v) = %v, want %v", tt.config, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCapitalizeFirst(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"", ""},
+		{"abc def", "Abc def"},
+		{"RDS stays RDS", "RDS stays RDS"},
+		{"9 things", "9 things"},
+		{"performance_schema is disabled", "Performance_schema is disabled"},
+	}
+	for _, tc := range tests {
+		if got := capitalizeFirst(tc.in); got != tc.want {
+			t.Errorf("capitalizeFirst(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/forensics/users.go
+++ b/internal/forensics/users.go
@@ -1,0 +1,70 @@
+package forensics
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+)
+
+// ListUsers returns the list of known MySQL user accounts by querying
+// mysql.user (authoritative, survives restarts) and performance_schema.accounts
+// (includes historically connected users). The two sources are merged and
+// deduplicated, preserving first-seen order. It errors only when BOTH sources
+// fail — a single inaccessible source degrades gracefully.
+//
+// Intended for filter dropdowns in the CLI/console/MCP surfaces.
+func ListUsers(ctx context.Context, sourceDB *sql.DB) ([]string, error) {
+	seen := make(map[string]struct{})
+	users := make([]string, 0)
+
+	collectUsers := func(query, source string) error {
+		rows, err := sourceDB.QueryContext(ctx, query)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var u string
+			if err := rows.Scan(&u); err != nil {
+				slog.Warn("forensics: users scan error", "source", source, "error", err)
+				continue
+			}
+			if u == "" {
+				continue
+			}
+			if _, ok := seen[u]; !ok {
+				seen[u] = struct{}{}
+				users = append(users, u)
+			}
+		}
+		if err := rows.Err(); err != nil {
+			slog.Warn("forensics: users iteration error", "source", source, "error", err)
+		}
+		return nil
+	}
+
+	// Primary source: mysql.user (all defined accounts).
+	mysqlUserErr := collectUsers(
+		"SELECT DISTINCT User FROM mysql.user WHERE User != '' ORDER BY User",
+		"mysql.user")
+	if mysqlUserErr != nil {
+		slog.Warn("forensics: mysql.user query failed (may lack privileges)", "error", mysqlUserErr)
+	}
+
+	// Secondary source: performance_schema.accounts (connected since last restart).
+	perfSchemaErr := collectUsers(
+		"SELECT DISTINCT USER FROM performance_schema.accounts WHERE USER IS NOT NULL AND USER != '' ORDER BY USER",
+		"performance_schema.accounts")
+	if perfSchemaErr != nil {
+		slog.Warn("forensics: performance_schema.accounts query failed", "error", perfSchemaErr)
+	}
+
+	if mysqlUserErr != nil && perfSchemaErr != nil {
+		return nil, fmt.Errorf("could not query MySQL user accounts (insufficient privileges or connectivity issue): %w",
+			errors.Join(mysqlUserErr, perfSchemaErr))
+	}
+
+	return users, nil
+}

--- a/internal/forensics/users_test.go
+++ b/internal/forensics/users_test.go
@@ -1,0 +1,87 @@
+package forensics
+
+import (
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func userRows(users ...string) *sqlmock.Rows {
+	r := sqlmock.NewRows([]string{"User"})
+	for _, u := range users {
+		r.AddRow(u)
+	}
+	return r
+}
+
+func TestListUsersMergesAndDeduplicates(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT DISTINCT User FROM mysql.user").
+		WillReturnRows(userRows("app", "root"))
+	mock.ExpectQuery("FROM performance_schema.accounts").
+		WillReturnRows(userRows("ghost", "root"))
+
+	users, err := ListUsers(t.Context(), db)
+	if err != nil {
+		t.Fatalf("ListUsers: %v", err)
+	}
+	want := []string{"app", "root", "ghost"} // first-seen order, deduped
+	if !slices.Equal(users, want) {
+		t.Errorf("users = %v, want %v", users, want)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestListUsersSurvivesMysqlUserDenied(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT DISTINCT User FROM mysql.user").
+		WillReturnError(errors.New("SELECT command denied"))
+	mock.ExpectQuery("FROM performance_schema.accounts").
+		WillReturnRows(userRows("app"))
+
+	users, err := ListUsers(t.Context(), db)
+	if err != nil {
+		t.Fatalf("ListUsers must degrade gracefully when one source fails: %v", err)
+	}
+	if !slices.Equal(users, []string{"app"}) {
+		t.Errorf("users = %v, want [app]", users)
+	}
+}
+
+func TestListUsersErrorsWhenBothSourcesFail(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT DISTINCT User FROM mysql.user").
+		WillReturnError(errors.New("denied one"))
+	mock.ExpectQuery("FROM performance_schema.accounts").
+		WillReturnError(errors.New("denied two"))
+
+	_, err = ListUsers(t.Context(), db)
+	if err == nil {
+		t.Fatal("expected error when both sources fail")
+	}
+	for _, want := range []string{"could not query MySQL user accounts", "denied one", "denied two"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err.Error(), want)
+		}
+	}
+}


### PR DESCRIPTION
Part of #701. The mechanism layer everything later builds on: `internal/forensics` (source inspection) plus two forensic-readiness doctor checks.

Port sources (SaaS repo `nethalo/dbtrail`): `agent/handler/forensics.go` (~1300 LOC, pure `database/sql`) and `backend/app/services/forensics_guide.py` (pure decision tree), with `backend/app/models/forensics.py` as the JSON reference contract.

## What was ported vs adapted

**Ported nearly verbatim** (SaaS private helper names kept — `detectPerfSchema`, `detectAuditLog`, `detectAuditLogConfig`, `detectServerInfo`, `lookupThreads`, `enrichWithConnAttrs`, `sqlEscape`, the `handle*`/`query*`/`generate*Fallback` family — so the sibling PRs merging into this package stay collision-free):

- **capabilities.go** — `DetectCapabilities`: performance_schema enabled + the `events_statements_history`/`_long` consumers + threads access; audit plugin variant (Percona / MariaDB incl. the AWS RDS fork / MySQL Enterprise; RDS's internal `RDS_SECURITY` plugin skipped) + config discovery incl. the wildcard fallback; server version/variant. Best-effort probes; hard error only when the server is unreachable.
- **enrich.go** — `EnrichThreads`: batch thread_ids (cap 500) → `threads` + `session_connect_attrs`; missing ids return as `not_found` + executable fallback SQL instead of erroring.
- **activity.go** — `Activity` with the three modes (`user_activity`, `connection_history`, `ddl_history`) and the SaaS's key UX property intact: **fallback-over-error** (failing/empty performance_schema source ⇒ runnable fallback SQL + diagnostics + note, never an error). `sqlEscape` ported with its rationale: ANSI quote-doubling, because fallback SQL is often *executed* by MCP clients and backslash escaping is bypassable in some SQL modes.
- **users.go** — `ListUsers`: `mysql.user` + `performance_schema.accounts` merged/deduped; errors only when both fail.
- **guide.go** — `BuildSetupGuide`: the `forensics_guide.py` decision tree as a pure function (p_s off → my.cnf + restart, no runtime SQL; consumers off → runtime `UPDATE setup_consumers` (history_long = high priority); no plugin → variant-specific INSTALL guidance; audit path under `/rdsdbdata/` → the exact RDS IAM policy JSON). Advisory only — bintrail never writes to monitored servers.

**Adapted** (all deliberate, called out for review):

- Transport/SaaS shells stripped: HTTP handlers, `Config`, `index_dsn`/`source_dsn` vault resolution (functions take a `*sql.DB`), `respondJSON`, request-validation shells. Validation that survives (empty/oversized thread_ids, unknown query_type, required filters) moved into the library entry points.
- `map[string]any` response envelopes → exported structs with JSON tags matching `models/forensics.py` (`Capabilities`, `EnrichResult`, `ActivityResult`, `SetupGuide`, …) so later surfaces (CLI #706, MCP #707, console #708, agent WS #710) stay wire-compatible. Event/connection rows stay `[]map[string]any` exactly as the SaaS built them (conditional keys ≙ Pydantic optional fields).
- `log.Printf("WARN: …")` → `slog` (repo convention).
- Dropped the dead `since`/`until` params from `queryUserStatements` (the SaaS accepted but never used them — p_s ring buffers have no wall-clock column; they only ever shaped fallback SQL, which still receives them).
- The DDL fallback's first suggestion now points at OSS surfaces (`bintrail query --event-type ddl` / `list_schema_changes`) instead of the SaaS `/api/v1/schema_changes` endpoint; the RDS IAM guide copy de-SaaS-ified ("data-plane EC2 instance role" → the bintrail host's role).
- Fixed a Python artifact in the summary composition: `str.capitalize()` lowercases the rest of the string ("RDS…" → "Rds…"); the Go `capitalizeFirst` only uppercases the first letter (pinned by test).

**Gate seam (#701 D1)** — `gate.go` created exactly as specified: `Enabled = func() bool { return true }`, the single entitlement seam a future enterprise build closes. It is **never called inside the library** — policy lives at surface entry points only. Byte-identical with the copies in the parallel #703/#704 PRs so the blobs merge cleanly (sha256 `29ec0b4f77d9406dc8692fba2d4b32fb4f63f25bdcc6c3022e2c81bfd5790f73`).

**Enrich is live-only by design** — the SaaS's `connection_cache` fallback for disconnected sessions is the sibling poller PR (#703); the live → cache composition happens in the #706 who-changed engine, not here.

## Doctor checks

`checkPerformanceSchema` (p_s on? which consumers?) and `checkAuditPlugin` (active plugin? RDS internal one doesn't count), one `report.add` line each in `Build`'s source section. Status semantics: **Pass when available, Warn when missing/degraded, never Fail** — forensics is optional and must not block `up` from streaming. Validate, never set: copy-pasteable remediation, including the caveat that **RDS parameter groups cannot persist `setup_consumers`** (no parameter-group option exists), so the runtime `UPDATE` must be re-asserted after every reboot.

## How it was tested

```
go build ./... && go vet ./...                     # pass
gofmt -l internal/forensics internal/doctor        # clean
go test ./... -count=1                             # full unit suite: ok (every package, incl. the 2 new/changed ones)
go test -tags integration ./internal/forensics/... ./internal/doctor/... -count=1
                                                   # ok (live MySQL 8 container on 127.0.0.1:13306)
git diff go.mod                                    # empty — zero new dependencies
```

- Unit tests ported/adapted from `agent/handler/forensics_test.go` (`TestSqlEscape` verbatim; fallback-generator tests adapted to the typed `FallbackQuery`), plus new sqlmock coverage for every detection branch, the two-tier history read, the empty-result diagnostics path, and fallback-over-error for all three activity modes. New table-driven coverage for the whole guide decision tree (incl. RDS `/rdsdbdata/` detection and both audit-path keys).
- Integration (assertions resilient to the container's p_s state, per the container-is-whatever-it-is constraint): `DetectCapabilities` shape/consistency invariants; a **consumer on/off toggle** test (flips `events_statements_history_long`, asserts detection + the guide recommendation both ways, restores the server's original state); `EnrichThreads` against the test's own pinned connection + a ghost id (fallback SQL generation live); all three activity modes live (nonexistent user deterministically exercises the fallback path); `ListUsers`; both doctor checks never-fail + `Build` wiring.
- Doctor unit tests: every branch of both checks incl. the never-FAIL structural invariant and the RDS reboot caveat presence.

## Merge coordination for the sibling PRs (#703 / #704)

- `gate.go` must remain byte-identical (sha above) — do not reformat.
- Shared types `ThreadInfo` and `FallbackQuery` are defined here in `enrich.go`. #703's `lookupCachedThreads` should return `map[string]*ThreadInfo` using this type, not redefine it (in the SaaS the type lived in `forensics.go` and conncache.go borrowed it).
- The package doc comment lives at the top of `capabilities.go` — don't add a second one.
- `sqlEscape` and `normalizeTimestamp` are defined in `activity.go` — reuse from there if the audit-log parsers need them.

Closes #702

🤖 Generated with [Claude Code](https://claude.com/claude-code)
