### PR TITLE
docs: sync secondary touchpoints with query-text forensics (#699) and drift detection (#700)

### DIFF
--- a/docs/capacity.md
+++ b/docs/capacity.md
@@ -33,6 +33,14 @@ Measured against the real `binlog_events` schema on MySQL 8.0 (InnoDB defaults, 
 
 Two practical notes:
 
+- **Statement capture** (`binlog_rows_query_log_events=ON` / MariaDB
+  `binlog_annotate_row_events`, see
+  [query-and-recovery.md](query-and-recovery.md)) stores the originating SQL
+  statement on **every row event it produced** — a 500-row bulk `DELETE`
+  stores the same text 500 times (capped at 16 KB per copy, plus a 64-byte
+  digest). For hand-written/ORM statements this adds roughly the statement's
+  length per event; for bulk-statement-heavy workloads it can dominate, which
+  is one reason capture is opt-in at the source.
 - **Rows with very large TEXT/JSON values** (image > ~8 KB) move off-page in InnoDB: each image is stored in whole 16 KB chunks, and an UPDATE stores two of them. A table with a 20 KB JSON blob costs ~40 KB *per UPDATE event*. If you have such a table and it's hot, it will dominate your index — consider excluding it with `--schemas`/`--tables` filters.
 - **Sparse partitions have a fixed floor.** Each hourly partition is its own `.ibd` file with its own B-trees (a few hundred KB even when nearly empty). For low-traffic deployments the per-partition floor, not the per-event cost, can dominate — don't multiply a per-row number across near-empty hours.
 

--- a/docs/console.md
+++ b/docs/console.md
@@ -76,7 +76,7 @@ and searching events:
    in place to a before→after diff; `j`/`k` move the cursor, `↵` expands, `u`
    jumps to Recover. Results carry **JSON / CSV** export — client-side over the
    rows already on screen, so it stays within the result caps and — like the
-   on-screen rows — never includes `connection_id`.
+   on-screen rows — never includes `connection_id`, `query_text`, or `query_hash`.
 3. **Time-travel** — single-row point-in-time reconstruct, drawn as a timeline
    (baseline snapshot → each change, with a **Restore to this state** jump to
    Recover). Appears **only when a baseline is configured**
@@ -516,10 +516,12 @@ itself:
 
 The console exposes only the free **query_explorer** surface (event query +
 recovery-SQL generation), available on every tier. It deliberately stays out of
-the paid **forensics** surface (who-changed / attribution): the events API drops
-`connection_id` — the MySQL `pseudo_thread_id` of the writing transaction — from
-every response. There is no gating, RBAC, or license code in the binary; the
-boundary is simply what the API chooses to serve.
+the paid **forensics** surface (who-changed / what-statement / attribution): the
+events API drops `connection_id` — the MySQL `pseudo_thread_id` of the writing
+transaction — and `query_text`/`query_hash` — the originating SQL statement and
+its normalized digest — from every response. There is no gating, RBAC, or
+license code in the binary; the boundary is simply what the API chooses to
+serve.
 
 ## PostgreSQL sources
 

--- a/docs/mariadb.md
+++ b/docs/mariadb.md
@@ -137,8 +137,18 @@ silently become the write key for every server. Two caveats:
 - **File-based `bintrail index`** over MariaDB binlog files.
 - All row events (INSERT/UPDATE/DELETE) with before/after images, including
   `UNSIGNED`, `DECIMAL`, and DDL detection / auto-snapshot.
-- MariaDB-only binlog events (`Annotate_rows`, `Gtid_list`, `Binlog_checkpoint`)
-  are skipped transparently.
+- **Statement capture** (`query_text`/`query_hash`): MariaDB's `Annotate_rows`
+  event carries the originating SQL statement and is captured like MySQL's
+  `ROWS_QUERY_EVENT`. `binlog_annotate_row_events` is ON by default since
+  10.2.4; streaming already works because `--source-flavor mariadb` makes the
+  syncer request the events. See
+  [query-and-recovery.md](query-and-recovery.md#statement-capture-query_text-and-query_hash).
+- **Capture-time schema-drift detection**: `binlog_row_metadata=FULL` works on
+  MariaDB 10.5+ (`SET GLOBAL` — MariaDB has no `SET PERSIST`; persist it in
+  `my.cnf`). The default is `NO_LOG`, so it's opt-in. See
+  [indexing.md](indexing.md).
+- Other MariaDB-only binlog events (`Gtid_list`, `Binlog_checkpoint`) are
+  skipped transparently.
 
 ---
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -122,7 +122,8 @@ non-tagged commit.
 **Automatic:** the index schema. Every command that opens the index via a
 CLI-typed `--index-dsn` (`init`, `index`, `stream`, `agent`, `query`,
 `recover`, `rotate`, `bintrail-console serve`/`watch` against their own
-`--index-dsn`) calls `EnsureSchema` on startup — it adds any columns/tables
+`--index-dsn`) calls `EnsureSchema` on startup — including the read-only
+commands (`query`, `recover`, `verify`, `reconstruct`, `shim`, the MCP tools) — it adds any columns/tables
 introduced since your index was created, idempotently (checks
 `information_schema` first, never re-runs a migration). No `bintrail init`
 re-run needed; just start the new binary against the same index.


### PR DESCRIPTION
Docs-only follow-up to #712/#713. The feature pages shipped inside those PRs; this syncs the pages that referenced the old surface:

- **console.md** — the open-core boundary sentence now names `query_text`/`query_hash` alongside `connection_id`
- **capacity.md** — statement capture's per-event cost (text stored on every row event of a statement, 16 KB cap) added to the sizing math
- **mariadb.md** — fixes a claim #712 made false ("`Annotate_rows` … skipped transparently" — it's now captured); documents statement capture and drift detection per flavor
- **upgrade.md** — read-only commands now listed among the EnsureSchema-on-startup callers

🤖 Generated with [Claude Code](https://claude.com/claude-code)