### PR TITLE
ci: add oss-firewall guard against private-module references

### DIFF
--- a/.github/workflows/oss-firewall.yml
+++ b/.github/workflows/oss-firewall.yml
@@ -1,0 +1,30 @@
+name: oss-firewall
+
+# This repo is Apache 2.0: anything merged here is open source forever.
+# This guard rejects the only mechanically-detectable breach — Go
+# imports or module requirements pointing at private nethalo/* repos.
+# (Plain-text references like issue links "nethalo/dbtrail#123" in
+# comments are fine and intentionally not matched.)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Forbid private-module references
+        run: |
+          fail=0
+          if grep -rn --include='*.go' -E '"github\.com/nethalo/' .; then
+            echo '::error::Go import of a private nethalo/* module — the public repo must never depend on private code'
+            fail=1
+          fi
+          if grep -n 'github.com/nethalo/' go.mod go.sum 2>/dev/null; then
+            echo '::error::go.mod/go.sum references a private nethalo/* module'
+            fail=1
+          fi
+          exit $fail


### PR DESCRIPTION
Adds a CI job that fails any PR or push to main containing a Go import of `github.com/nethalo/*` or a go.mod/go.sum reference to one — the mechanically-detectable half of the open-core dependency rule (private imports public, never the reverse).

Issue-link mentions in comments (e.g. `nethalo/dbtrail#123`) are deliberately not matched; only quoted import strings and module files trip the guard.

Companion to #723 (cliapp export).

🤖 Generated with [Claude Code](https://claude.com/claude-code)