### PR TITLE
ext: public extension seams — AuditSink + forensics gate override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Public `ext` package: extension seams for embedding distributions** — an `AuditSink` interface (`ext.SetAuditSink`/`ext.Record`) recording data-access and script-generation operations, and `ext.SetForensicsEnabled` to override the forensics feature gate. Seams follow the `forensics.Enabled` convention: package-level vars set at startup, called at surface entry points. Wired surfaces: CLI `query`/`recover` and the MCP server's `query`/`recover` tools; the OSS binary installs no sink, so behavior is unchanged (one nil check per operation). Shim/console surfaces are follow-ups.
+
 ## [0.27.0] - 2026-07-03
 
 ### Changed

--- a/cmd/bintrail-mcp/main.go
+++ b/cmd/bintrail-mcp/main.go
@@ -43,6 +43,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/dbtrail/dbtrail/ext"
 	"github.com/dbtrail/dbtrail/internal/cliutil"
 	"github.com/dbtrail/dbtrail/internal/config"
 	"github.com/dbtrail/dbtrail/internal/indexer"
@@ -423,6 +424,15 @@ func makeQueryTool(connect connectFunc) func(context.Context, *mcp.CallToolReque
 		}
 		text += queryResultNotice(ceilingApplied, requestedLimit, ceiling, n, opts.Limit)
 
+		ext.Record(ctx, ext.AuditEvent{
+			Surface: "mcp",
+			Action:  "query.run",
+			Actor:   ext.ProcessActor(args.Profile),
+			Schema:  args.Schema,
+			Table:   args.Table,
+			Detail:  map[string]string{"results": strconv.Itoa(n), "format": format},
+		})
+
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
 				&mcp.TextContent{Text: text},
@@ -520,6 +530,19 @@ func makeRecoverTool(connect connectFunc) func(context.Context, *mcp.CallToolReq
 		if n >= opts.Limit {
 			text += fmt.Sprintf("\n-- Warning: results truncated at %d rows. Use a narrower since/until range or increase the limit to see more.\n", opts.Limit)
 		}
+
+		ext.Record(ctx, ext.AuditEvent{
+			Surface: "mcp",
+			Action:  "recover.generate",
+			Actor:   ext.ProcessActor(args.Profile),
+			Schema:  args.Schema,
+			Table:   args.Table,
+			Detail: map[string]string{
+				"statements": strconv.Itoa(n),
+				"dry_run":    "true", // MCP recover always returns the script, never applies it
+				"gtid":       args.GTID,
+			},
+		})
 
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{

--- a/ext/audit.go
+++ b/ext/audit.go
@@ -1,0 +1,48 @@
+package ext
+
+import (
+	"context"
+	"time"
+)
+
+// AuditEvent describes one auditable operation. dbtrail never executes
+// SQL against a user database, so events fall into two classes:
+// historical data access (query, shim time-travel, reconstruct) and
+// mutation-artifact generation (recover producing a reversal script).
+type AuditEvent struct {
+	Time    time.Time         // stamped by Record when zero
+	Surface string            // "cli", "mcp", "shim", "console"
+	Action  string            // e.g. "query.run", "recover.generate"
+	Actor   string            // see ProcessActor; shim uses its authenticated user
+	Schema  string            // schema filter/target, may be empty
+	Table   string            // table filter/target, may be empty
+	Detail  map[string]string // action-specific fields (statements, dry_run, gtid, ...)
+}
+
+// AuditSink receives audit events. Implementations must be safe for
+// concurrent use and must not block: a slow or failing sink must never
+// stall a recovery operation.
+type AuditSink interface {
+	Record(ctx context.Context, ev AuditEvent)
+}
+
+// sink is nil in the OSS build — auditing is a no-op.
+var sink AuditSink
+
+// SetAuditSink installs the process-wide audit sink. Call once from
+// main() before command dispatch.
+func SetAuditSink(s AuditSink) {
+	sink = s
+}
+
+// Record forwards an event to the installed sink, stamping Time when
+// unset. Safe to call with no sink installed.
+func Record(ctx context.Context, ev AuditEvent) {
+	if sink == nil {
+		return
+	}
+	if ev.Time.IsZero() {
+		ev.Time = time.Now().UTC()
+	}
+	sink.Record(ctx, ev)
+}

--- a/ext/ext.go
+++ b/ext/ext.go
@@ -1,0 +1,43 @@
+// Package ext exposes the extension points that embedding distributions
+// — builds that import cliapp and wrap the OSS core — use to inject
+// behavior: an audit sink recording data-access operations, and
+// overrides for feature-entitlement gates.
+//
+// Seams follow the same convention as the internal forensics.Enabled
+// gate: package-level variables set once at process startup (before any
+// command runs), called by the core at surface entry points (CLI, MCP,
+// shim, console) — never inside the library layer. The OSS binary
+// leaves every seam at its default: auditing is a no-op and every
+// feature gate is open. Setters are not safe for concurrent use with
+// command execution; call them from main() before dispatch.
+package ext
+
+import (
+	"os"
+	"os/user"
+
+	"github.com/dbtrail/dbtrail/internal/forensics"
+)
+
+// SetForensicsEnabled overrides the forensics feature gate. The OSS
+// default is always-on; an embedding distribution may tie it to its own
+// entitlement model.
+func SetForensicsEnabled(f func() bool) {
+	forensics.Enabled = f
+}
+
+// ProcessActor returns the best available identity for locally-invoked
+// surfaces (CLI, stdio MCP): the operating-system user, plus the RBAC
+// profile when one is active. Network surfaces with real authentication
+// (the shim) should record their authenticated user instead.
+func ProcessActor(profile string) string {
+	name := os.Getenv("USER")
+	if u, err := user.Current(); err == nil && u.Username != "" {
+		name = u.Username
+	}
+	actor := "os:" + name
+	if profile != "" {
+		actor += " profile:" + profile
+	}
+	return actor
+}

--- a/ext/ext_test.go
+++ b/ext/ext_test.go
@@ -1,0 +1,72 @@
+package ext
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/forensics"
+)
+
+type captureSink struct {
+	events []AuditEvent
+}
+
+func (c *captureSink) Record(_ context.Context, ev AuditEvent) {
+	c.events = append(c.events, ev)
+}
+
+func TestRecordNoSinkIsNoop(t *testing.T) {
+	SetAuditSink(nil)
+	// Must not panic.
+	Record(context.Background(), AuditEvent{Action: "query.run"})
+}
+
+func TestRecordStampsTimeAndForwards(t *testing.T) {
+	c := &captureSink{}
+	SetAuditSink(c)
+	t.Cleanup(func() { SetAuditSink(nil) })
+
+	Record(context.Background(), AuditEvent{
+		Surface: "cli",
+		Action:  "recover.generate",
+		Schema:  "shop",
+		Table:   "orders",
+		Detail:  map[string]string{"statements": "12", "dry_run": "true"},
+	})
+
+	if len(c.events) != 1 {
+		t.Fatalf("got %d events, want 1", len(c.events))
+	}
+	ev := c.events[0]
+	if ev.Time.IsZero() {
+		t.Error("Record did not stamp zero Time")
+	}
+	if ev.Action != "recover.generate" || ev.Detail["statements"] != "12" {
+		t.Errorf("event mangled: %+v", ev)
+	}
+}
+
+func TestSetForensicsEnabled(t *testing.T) {
+	orig := forensics.Enabled
+	t.Cleanup(func() { forensics.Enabled = orig })
+
+	SetForensicsEnabled(func() bool { return false })
+	if forensics.Enabled() {
+		t.Fatal("gate override did not take effect")
+	}
+	SetForensicsEnabled(func() bool { return true })
+	if !forensics.Enabled() {
+		t.Fatal("gate re-open did not take effect")
+	}
+}
+
+func TestProcessActor(t *testing.T) {
+	a := ProcessActor("")
+	if !strings.HasPrefix(a, "os:") || a == "os:" {
+		t.Errorf("ProcessActor() = %q, want os:<user>", a)
+	}
+	if got := ProcessActor("auditor"); !strings.HasSuffix(got, " profile:auditor") {
+		t.Errorf("ProcessActor(auditor) = %q", got)
+	}
+}

--- a/internal/cli/query.go
+++ b/internal/cli/query.go
@@ -9,12 +9,14 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
 	mysqldriver "github.com/go-sql-driver/mysql"
 	"github.com/spf13/cobra"
 
+	"github.com/dbtrail/dbtrail/ext"
 	"github.com/dbtrail/dbtrail/internal/cliutil"
 	"github.com/dbtrail/dbtrail/internal/config"
 	"github.com/dbtrail/dbtrail/internal/indexer"
@@ -297,6 +299,7 @@ func runQuery(cmd *cobra.Command, args []string) error {
 			"results", n,
 			"format", qFormat,
 			"duration_ms", time.Since(start).Milliseconds())
+		auditQueryRun(cmd.Context(), n)
 		if qFormat == "table" && n > 0 {
 			fmt.Fprintf(os.Stderr, "\n%d row(s)\n", n)
 		}
@@ -372,6 +375,7 @@ func runQuery(cmd *cobra.Command, args []string) error {
 		"results", n,
 		"format", qFormat,
 		"duration_ms", time.Since(start).Milliseconds())
+	auditQueryRun(cmd.Context(), n)
 	if qFormat == "table" && n > 0 {
 		fmt.Fprintf(os.Stderr, "\n%d row(s)\n", n)
 	}
@@ -670,4 +674,21 @@ func archiveSources() []string {
 		sources = append(sources, base+"/bintrail_id="+qBintrailID)
 	}
 	return sources
+}
+
+// auditQueryRun reports a completed index query to the audit seam.
+// ext.Record is a no-op unless an embedding distribution installed a
+// sink — the OSS binary pays one nil check.
+func auditQueryRun(ctx context.Context, results int) {
+	ext.Record(ctx, ext.AuditEvent{
+		Surface: "cli",
+		Action:  "query.run",
+		Actor:   ext.ProcessActor(qProfile),
+		Schema:  qSchema,
+		Table:   qTable,
+		Detail: map[string]string{
+			"results": strconv.Itoa(results),
+			"format":  qFormat,
+		},
+	})
 }

--- a/internal/cli/recover.go
+++ b/internal/cli/recover.go
@@ -3,16 +3,19 @@ package cli
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
 	mysqldriver "github.com/go-sql-driver/mysql"
 	"github.com/spf13/cobra"
 
+	"github.com/dbtrail/dbtrail/ext"
 	"github.com/dbtrail/dbtrail/internal/cliutil"
 	"github.com/dbtrail/dbtrail/internal/config"
 	"github.com/dbtrail/dbtrail/internal/indexer"
@@ -281,6 +284,7 @@ func runRecover(cmd *cobra.Command, args []string) error {
 			slog.Info("recovery SQL generated",
 				"statements", n, "dry_run", true,
 				"duration_ms", time.Since(start).Milliseconds())
+			auditRecoverGenerated(cmd.Context(), n, true, "")
 			return cliutil.OutputJSON(struct {
 				Statements int    `json:"statements"`
 				DryRun     bool   `json:"dry_run"`
@@ -295,6 +299,7 @@ func runRecover(cmd *cobra.Command, args []string) error {
 		slog.Info("recovery SQL generated",
 			"statements", n, "dry_run", true,
 			"duration_ms", time.Since(start).Milliseconds())
+		auditRecoverGenerated(cmd.Context(), n, true, "")
 		if n > 0 {
 			fmt.Fprintf(os.Stderr, "\n%d reversal statement(s) generated.\n", n)
 		}
@@ -323,6 +328,7 @@ func runRecover(cmd *cobra.Command, args []string) error {
 	slog.Info("recovery SQL generated",
 		"statements", n, "dry_run", false, "output", rOutput,
 		"duration_ms", time.Since(start).Milliseconds())
+	auditRecoverGenerated(cmd.Context(), n, false, rOutput)
 
 	if rFormat == "json" {
 		return cliutil.OutputJSON(struct {
@@ -355,4 +361,23 @@ func wrapScriptBudget(err error) error {
 			"guards the rendered script size, not the initial fetch", err)
 	}
 	return err
+}
+
+// auditRecoverGenerated reports a generated reversal script to the
+// audit seam. ext.Record is a no-op unless an embedding distribution
+// installed a sink — the OSS binary pays one nil check.
+func auditRecoverGenerated(ctx context.Context, statements int, dryRun bool, output string) {
+	ext.Record(ctx, ext.AuditEvent{
+		Surface: "cli",
+		Action:  "recover.generate",
+		Actor:   ext.ProcessActor(rProfile),
+		Schema:  rSchema,
+		Table:   rTable,
+		Detail: map[string]string{
+			"statements": strconv.Itoa(statements),
+			"dry_run":    strconv.FormatBool(dryRun),
+			"output":     output,
+			"gtid":       rGTID,
+		},
+	})
 }


### PR DESCRIPTION
## What

New public `ext` package — the extension points embedding distributions use to inject behavior:

- `ext.AuditSink` + `SetAuditSink` + `Record`: audit events for data-access (`query.run`) and mutation-artifact generation (`recover.generate`). Event carries surface/action/actor/schema/table + detail map.
- `ext.SetForensicsEnabled(func() bool)`: overrides the `internal/forensics.Enabled` gate (internal packages aren't reachable from another module, so the override has to be exported from a public package).
- `ext.ProcessActor(profile)`: best-available identity for locally-invoked surfaces (OS user + RBAC profile).

## Wired call sites (surface entry points, per the gate.go convention)

- `internal/cli/recover.go` — all three generation paths (JSON dry-run, text dry-run, file output)
- `internal/cli/query.go` — fast path and archive-merge path
- `cmd/bintrail-mcp` — `query` and `recover` tools (surface `"mcp"`)

**Not wired yet (follow-ups):** the shim (highest-value surface — it has the only *authenticated* actor — but needs its MySQL username threaded from the handshake into the Handler first) and the console.

## Design notes

- Placement follows `internal/forensics/gate.go`: policy at surfaces, never inside `internal/query`/`internal/recovery`. The alternative (hooking the library choke points) would be un-bypassable but violates that documented convention and lacks actor context.
- OSS binary behavior is unchanged: no sink installed → `Record` is a nil check. Sinks must not block (documented on the interface).
- Setters are startup-time only (main before dispatch), same discipline as `forensics.Enabled`.

## Testing

`ext` unit tests (nil-safety, time stamping, forwarding, gate toggle, actor format); `go build ./...`, vet, and the `ext`/`internal/cli`/`cliapp` suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)