### PR TITLE
forensics: audit-tier + connection_cache robustness (post-merge-review mediums)

### DIFF
--- a/internal/forensics/auditlog.go
+++ b/internal/forensics/auditlog.go
@@ -428,7 +428,7 @@ func collectAuditLogFiles(primary string, includeRotated bool) ([]string, []stri
 	if err != nil {
 		return files, []string{fmt.Sprintf("could not list directory %s for rotated files: %v", dir, err)}
 	}
-	rotated := 0
+	var rotatedFiles []string
 	for _, e := range entries {
 		if e.IsDir() {
 			continue
@@ -439,28 +439,32 @@ func collectAuditLogFiles(primary string, includeRotated bool) ([]string, []stri
 		}
 		// Match patterns like "audit.log.1" or "audit.log-20240101".
 		if strings.HasPrefix(name, base+".") || strings.HasPrefix(name, base+"-") {
-			files = append(files, filepath.Join(dir, name))
-			rotated++
-			if rotated >= maxRotatedFiles {
-				break
-			}
+			rotatedFiles = append(rotatedFiles, filepath.Join(dir, name))
 		}
 	}
 
-	// Sort: primary first, then rotated newest-first (higher suffix = older
-	// in most rotation schemes, but we sort by mtime descending for
-	// accuracy).
-	if len(files) > 1 {
-		sort.Slice(files[1:], func(i, j int) bool {
-			fi, _ := os.Stat(files[1+i])
-			fj, _ := os.Stat(files[1+j])
-			if fi == nil || fj == nil {
-				return files[1+i] > files[1+j]
-			}
-			return fi.ModTime().After(fj.ModTime())
-		})
+	// Sort rotated files newest-first by mtime BEFORE applying the cap — capping
+	// during the directory walk (which is in filename order) would keep the
+	// oldest maxRotatedFiles and silently drop the most-recent history, the
+	// opposite of what a forensic query wants.
+	sort.Slice(rotatedFiles, func(i, j int) bool {
+		fi, _ := os.Stat(rotatedFiles[i])
+		fj, _ := os.Stat(rotatedFiles[j])
+		if fi == nil || fj == nil {
+			return rotatedFiles[i] > rotatedFiles[j]
+		}
+		return fi.ModTime().After(fj.ModTime())
+	})
+
+	var warnings []string
+	if len(rotatedFiles) > maxRotatedFiles {
+		warnings = append(warnings, fmt.Sprintf(
+			"found %d rotated audit files under %s; scanning the %d most recent — older history was not read",
+			len(rotatedFiles), dir, maxRotatedFiles))
+		rotatedFiles = rotatedFiles[:maxRotatedFiles]
 	}
-	return files, nil
+	files = append(files, rotatedFiles...)
+	return files, warnings
 }
 
 // ---------------------------------------------------------------------------
@@ -479,7 +483,10 @@ func detectAuditLogFormat(path string, variant AuditVariant) AuditFormat {
 
 	buf := make([]byte, 512)
 	n, err := f.Read(buf)
-	if err != nil && n == 0 {
+	if err != nil && err != io.EOF && n == 0 {
+		// A genuine read error (not an empty file, which Read reports as EOF
+		// with n==0). An empty file falls through to the extension/variant
+		// fallback so a valid-but-empty log is not rejected as unknown-format.
 		return AuditFormatUnknown
 	}
 	sample := strings.TrimSpace(string(buf[:n]))
@@ -499,7 +506,11 @@ func detectAuditLogFormat(path string, variant AuditVariant) AuditFormat {
 
 	// Content-based detection.
 	if len(sample) == 0 {
-		return AuditFormatUnknown
+		// A valid-but-empty audit file (freshly rotated, freshly enabled, or a
+		// quiet server) has no bytes to sniff. Fall back to the discovered
+		// plugin variant so it is treated as its real format and parses to zero
+		// events, rather than being rejected as "unknown format".
+		return formatFromVariant(variant)
 	}
 	switch sample[0] {
 	case '{', '[':

--- a/internal/forensics/auditlog.go
+++ b/internal/forensics/auditlog.go
@@ -412,7 +412,9 @@ func discoverDataDir(ctx context.Context, db *sql.DB) (string, []string) {
 
 // collectAuditLogFiles returns the primary audit log file and, when
 // includeRotated is true, any rotated variants (*.1, *.2, audit.log-20240101,
-// ...) sorted newest-first by mtime, capped at maxRotatedFiles.
+// ...) sorted newest-first by mtime, capped at maxRotatedFiles. The second
+// return is a warnings slice, non-empty when the cap dropped the oldest
+// rotated files so the truncation is reported rather than silent.
 func collectAuditLogFiles(primary string, includeRotated bool) ([]string, []string) {
 	var files []string
 	if _, err := os.Stat(primary); err == nil {

--- a/internal/forensics/auditlog_test.go
+++ b/internal/forensics/auditlog_test.go
@@ -230,6 +230,11 @@ func TestDetectAuditLogFormat_ContentBased(t *testing.T) {
 		{"aurora_epoch_with_mariadb_hint", `1520091734997155,server,root`, AuditVariantMariaDB, AuditFormatMariaDB},
 		{"percona_csv", `"2024-06-15","root","localhost"`, "", AuditFormatCSV},
 		{"undetectable", `garbage content`, "", AuditFormatUnknown},
+		// A valid-but-empty file falls back to the discovered variant so it is
+		// parsed (to zero events), not rejected as "unknown format" (#5).
+		{"empty_mariadb_variant", "", AuditVariantMariaDB, AuditFormatMariaDB},
+		{"empty_whitespace_mariadb", "   \n\t\n", AuditVariantMariaDB, AuditFormatMariaDB},
+		{"empty_no_variant", "", "", AuditFormatUnknown},
 	}
 
 	for _, tt := range tests {
@@ -338,17 +343,50 @@ func TestCollectAuditLogFiles(t *testing.T) {
 		}
 	})
 
-	t.Run("rotated collection capped at maxRotatedFiles", func(t *testing.T) {
+	t.Run("cap keeps the NEWEST rotated files and warns on the drop", func(t *testing.T) {
 		dir := t.TempDir()
 		primary := filepath.Join(dir, "audit.log")
 		mustWrite(t, primary, "p")
-		for i := range maxRotatedFiles + 5 {
-			mustWrite(t, filepath.Join(dir, fmt.Sprintf("audit.log.%d", i)), "r")
+		// Create more rotated files than the cap, with mtimes ascending in
+		// index order (file .0 oldest, .(N+4) newest). Filenames are in a fixed
+		// zero-padded order so os.ReadDir returns them oldest-first — the order
+		// the pre-fix code capped in, which would keep the oldest.
+		total := maxRotatedFiles + 5
+		now := time.Now()
+		for i := range total {
+			p := filepath.Join(dir, fmt.Sprintf("audit.log.%03d", i))
+			mustWrite(t, p, "r")
+			mt := now.Add(time.Duration(i-total) * time.Minute)
+			if err := os.Chtimes(p, mt, mt); err != nil {
+				t.Fatal(err)
+			}
 		}
 
-		files, _ := collectAuditLogFiles(primary, true)
+		files, warns := collectAuditLogFiles(primary, true)
 		if len(files) != 1+maxRotatedFiles {
-			t.Errorf("len(files) = %d, want %d (primary + cap)", len(files), 1+maxRotatedFiles)
+			t.Fatalf("len(files) = %d, want %d (primary + cap)", len(files), 1+maxRotatedFiles)
+		}
+		if !warningsContain(warns, "older history was not read") {
+			t.Errorf("expected a truncation warning, got %v", warns)
+		}
+		// The newest rotated file (.(total-1)) must be kept; the oldest (.000)
+		// must be dropped — the pre-fix behaviour was the reverse.
+		newest := filepath.Join(dir, fmt.Sprintf("audit.log.%03d", total-1))
+		oldest := filepath.Join(dir, "audit.log.000")
+		var haveNewest, haveOldest bool
+		for _, f := range files {
+			if f == newest {
+				haveNewest = true
+			}
+			if f == oldest {
+				haveOldest = true
+			}
+		}
+		if !haveNewest {
+			t.Error("cap dropped the NEWEST rotated file; must keep the most recent history")
+		}
+		if haveOldest {
+			t.Error("cap kept the OLDEST rotated file; the newest should win")
 		}
 	})
 }
@@ -868,6 +906,34 @@ func TestReadAuditLog_UnknownFormat(t *testing.T) {
 	_, err = ReadAuditLog(context.Background(), db, AuditReadOptions{})
 	if !errors.Is(err, ErrAuditUnknownFormat) {
 		t.Fatalf("err = %v, want ErrAuditUnknownFormat", err)
+	}
+}
+
+// TestReadAuditLog_EmptyFileNoError: a validly-configured but empty audit log
+// (post-rotation / freshly enabled / quiet server) resolves to its discovered
+// plugin variant's format and parses to zero events, rather than hard-failing
+// with ErrAuditUnknownFormat as it did before detectAuditLogFormat fell back to
+// the variant on empty content (#5).
+func TestReadAuditLog_EmptyFileNoError(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "audit.log")
+	mustWrite(t, logPath, "") // zero bytes
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+	// No variant hint (no plugins row) so detection can't fall back to a format.
+	mock.ExpectQuery(showAuditLogFileSQL).WillReturnRows(variableRows("audit_log_file", logPath))
+	mock.ExpectQuery(pluginsSQL).WillReturnRows(pluginRows())
+
+	res, err := ReadAuditLog(context.Background(), db, AuditReadOptions{})
+	if err != nil {
+		t.Fatalf("err = %v, want nil — an empty (validly-configured) audit log must not be a hard error", err)
+	}
+	if len(res.Events) != 0 {
+		t.Errorf("events = %d, want 0", len(res.Events))
 	}
 }
 

--- a/internal/forensics/auditlog_test.go
+++ b/internal/forensics/auditlog_test.go
@@ -924,7 +924,9 @@ func TestReadAuditLog_EmptyFileNoError(t *testing.T) {
 		t.Fatalf("sqlmock: %v", err)
 	}
 	defer db.Close()
-	// No variant hint (no plugins row) so detection can't fall back to a format.
+	// An empty plugins row makes detectVariantFromPlugin return its
+	// MySQLEnterprise default (→ JSON), so detection resolves a concrete format
+	// and the empty file parses to zero events via the #5 variant fallback.
 	mock.ExpectQuery(showAuditLogFileSQL).WillReturnRows(variableRows("audit_log_file", logPath))
 	mock.ExpectQuery(pluginsSQL).WillReturnRows(pluginRows())
 

--- a/internal/forensics/conncache.go
+++ b/internal/forensics/conncache.go
@@ -63,8 +63,10 @@ type cachedConn struct {
 // fatal to the caller — connection failures and per-cycle panics are logged
 // and retried, because attribution capture is a secondary job that must never
 // take down the stream (the primary forensic capture). When the source has an
-// active audit plugin the poller logs and does not poll: audit logs carry
-// better session history at lower cost. The loop stops when ctx is cancelled;
+// active audit plugin the poller does not poll — audit logs carry better
+// session history at lower cost — but it keeps running retention sweeps until
+// ctx is cancelled, so connection_cache rows captured before the plugin was
+// installed still age out. The loop stops when ctx is cancelled;
 // the returned channel closes when it has fully exited (used by tests for
 // deterministic shutdown; production callers may ignore it).
 func StartConnCachePoller(ctx context.Context, cfg ConnCacheConfig) <-chan struct{} {
@@ -103,7 +105,7 @@ func StartConnCachePoller(ctx context.Context, cfg ConnCacheConfig) <-chan struc
 			slog.Info("connection-cache: active audit plugin detected on the source — not polling (the audit log carries better session history at lower cost); running retention sweeps so any pre-audit cached rows still age out")
 			// Polling is skipped, but connection_cache rows captured before the
 			// audit plugin was installed must still be pruned per the retention
-			// window — otherwise they persist forever and tier-2b would
+			// window — otherwise they persist forever and tier 2b would
 			// attribute old events to a frozen, possibly reused identity.
 			sweepLoop(ctx, indexDB, cfg.Retention)
 			return

--- a/internal/forensics/conncache.go
+++ b/internal/forensics/conncache.go
@@ -100,7 +100,12 @@ func StartConnCachePoller(ctx context.Context, cfg ConnCacheConfig) <-chan struc
 		indexDB.SetMaxIdleConns(1)
 
 		if auditProbe(ctx, sourceDB) {
-			slog.Info("connection-cache: active audit plugin detected on the source — not polling (the audit log carries better session history at lower cost)")
+			slog.Info("connection-cache: active audit plugin detected on the source — not polling (the audit log carries better session history at lower cost); running retention sweeps so any pre-audit cached rows still age out")
+			// Polling is skipped, but connection_cache rows captured before the
+			// audit plugin was installed must still be pruned per the retention
+			// window — otherwise they persist forever and tier-2b would
+			// attribute old events to a frozen, possibly reused identity.
+			sweepLoop(ctx, indexDB, cfg.Retention)
 			return
 		}
 
@@ -135,16 +140,7 @@ func pollLoop(ctx context.Context, sourceDB, indexDB *sql.DB, retention time.Dur
 			consecutiveFailures = 0
 		}
 	}
-	sweep := func() {
-		defer func() {
-			if r := recover(); r != nil {
-				slog.Error("connection-cache: retention sweep panicked; sweep continues next tick", "panic", r)
-			}
-		}()
-		if err := cleanupConnectionCache(ctx, indexDB, retention); err != nil && ctx.Err() == nil {
-			slog.Warn("connection-cache: retention sweep error", "error", err)
-		}
-	}
+	sweep := func() { sweepConnectionCache(ctx, indexDB, retention) }
 
 	pollTicker := time.NewTicker(pollInterval)
 	defer pollTicker.Stop()
@@ -305,13 +301,54 @@ func upsertBatch(ctx context.Context, indexDB *sql.DB, conns []cachedConn, attrM
 // cleanupConnectionCache deletes cached entries whose last_seen timestamp is
 // older than the retention window. Active connections keep their last_seen
 // fresh via the poller, so only genuinely stale entries are removed.
+// sweepConnectionCache runs one retention sweep, panic-recovered so a failure
+// never takes down its caller's loop. Shared by pollLoop and sweepLoop.
+func sweepConnectionCache(ctx context.Context, indexDB *sql.DB, retention time.Duration) {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("connection-cache: retention sweep panicked; sweep continues next tick", "panic", r)
+		}
+	}()
+	if err := cleanupConnectionCache(ctx, indexDB, retention); err != nil && ctx.Err() == nil {
+		slog.Warn("connection-cache: retention sweep error", "error", err)
+	}
+}
+
+// sweepLoop runs only the retention sweep (no polling) until ctx is cancelled.
+// Used when an audit plugin is active on the source: polling is skipped in
+// favour of the audit log, but connection_cache rows captured before the plugin
+// was installed must still age out per the retention window. It sweeps once
+// immediately to prune the pre-audit backlog, then on each cleanup tick.
+func sweepLoop(ctx context.Context, indexDB *sql.DB, retention time.Duration) {
+	sweepConnectionCache(ctx, indexDB, retention)
+	ticker := time.NewTicker(cleanupInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			sweepConnectionCache(ctx, indexDB, retention)
+		}
+	}
+}
+
 func cleanupConnectionCache(ctx context.Context, indexDB *sql.DB, retention time.Duration) error {
 	cleanupCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
+	secs := int64(retention.Seconds())
+	if secs < 1 {
+		// Retention is positive here (StartConnCachePoller gates <= 0 before
+		// polling), but under one second int64(Seconds()) truncates to 0 —
+		// which would DELETE every row, including live sessions. last_seen is
+		// second-precision, so round a sub-second window up to the minimum
+		// meaningful value instead of wiping the cache.
+		secs = 1
+	}
 	result, err := indexDB.ExecContext(cleanupCtx,
 		"DELETE FROM connection_cache WHERE last_seen < NOW() - INTERVAL ? SECOND",
-		int64(retention.Seconds()))
+		secs)
 	if err != nil {
 		return fmt.Errorf("cleanup query: %w", err)
 	}

--- a/internal/forensics/conncache.go
+++ b/internal/forensics/conncache.go
@@ -298,9 +298,6 @@ func upsertBatch(ctx context.Context, indexDB *sql.DB, conns []cachedConn, attrM
 	return err
 }
 
-// cleanupConnectionCache deletes cached entries whose last_seen timestamp is
-// older than the retention window. Active connections keep their last_seen
-// fresh via the poller, so only genuinely stale entries are removed.
 // sweepConnectionCache runs one retention sweep, panic-recovered so a failure
 // never takes down its caller's loop. Shared by pollLoop and sweepLoop.
 func sweepConnectionCache(ctx context.Context, indexDB *sql.DB, retention time.Duration) {
@@ -333,6 +330,9 @@ func sweepLoop(ctx context.Context, indexDB *sql.DB, retention time.Duration) {
 	}
 }
 
+// cleanupConnectionCache deletes cached entries whose last_seen timestamp is
+// older than the retention window. Active connections keep their last_seen
+// fresh via the poller, so only genuinely stale entries are removed.
 func cleanupConnectionCache(ctx context.Context, indexDB *sql.DB, retention time.Duration) error {
 	cleanupCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()

--- a/internal/forensics/conncache_integration_test.go
+++ b/internal/forensics/conncache_integration_test.go
@@ -147,34 +147,65 @@ func TestIntegrationHasAuditPlugin_NoneInstalled(t *testing.T) {
 	}
 }
 
-// TestIntegrationAuditPluginSkipsPoller pins the skip branch: with an audit
-// plugin "present" (probe stubbed — the container has none to install), the
-// poller must exit on its own without ever writing to connection_cache.
-func TestIntegrationAuditPluginSkipsPoller(t *testing.T) {
+// TestIntegrationAuditPluginSkipsPollingButStillSweeps pins the audit-present
+// branch (#3): polling is suppressed (the audit log carries better history),
+// but the retention sweep must keep running so connection_cache rows captured
+// before the plugin was installed still age out — otherwise they persist
+// forever and tier-2b attributes old events to a frozen, possibly reused
+// identity. The loop runs until the context is cancelled.
+func TestIntegrationAuditPluginSkipsPollingButStillSweeps(t *testing.T) {
 	db, dbName := testutil.CreateTestDB(t)
 	testutil.InitIndexTables(t, db)
+
+	// A pre-audit row past the retention window (must be swept) and a fresh row
+	// (must survive).
+	testutil.MustExec(t, db, `INSERT INTO connection_cache
+		(connection_id, user, host, db, command, cached_at, last_seen) VALUES
+		(201, 'preaudit', 'oldhost:1', NULL, 'Sleep', NOW() - INTERVAL 2 DAY, NOW() - INTERVAL 2 DAY),
+		(202, 'fresh', 'newhost:2', 'app', 'Query', NOW(), NOW())`)
 
 	old := auditProbe
 	auditProbe = func(context.Context, *sql.DB) bool { return true }
 	defer func() { auditProbe = old }()
 
-	done := StartConnCachePoller(context.Background(), ConnCacheConfig{
+	ctx, cancel := context.WithCancel(context.Background())
+	done := StartConnCachePoller(ctx, ConnCacheConfig{
 		SourceDSN: sourceDSN(),
 		IndexDSN:  testutil.IntegrationDSN(dbName),
-		Retention: DefaultRetention,
+		Retention: 24 * time.Hour,
 	})
-	select {
-	case <-done: // exits on its own — no context cancel involved
-	case <-time.After(30 * time.Second):
-		t.Fatal("poller did not exit after audit-plugin detection")
+
+	// The immediate sweep on the audit branch prunes the 2-day-old row.
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		cached, err := LookupCachedThreads(context.Background(), db, []int64{201})
+		if err != nil {
+			t.Fatalf("LookupCachedThreads: %v", err)
+		}
+		if _, ok := cached[201]; !ok {
+			break // swept
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("pre-audit row was not swept on the audit-present branch — the retention sweep is not running")
+		}
+		time.Sleep(50 * time.Millisecond)
 	}
 
+	// Polling is suppressed: no live-session rows were added, so only the fresh
+	// pre-inserted row (202) remains.
 	var n int
 	if err := db.QueryRow("SELECT COUNT(*) FROM connection_cache").Scan(&n); err != nil {
 		t.Fatalf("count connection_cache: %v", err)
 	}
-	if n != 0 {
-		t.Fatalf("connection_cache has %d rows, want 0 — an audit plugin must suppress polling", n)
+	if n != 1 {
+		t.Errorf("connection_cache has %d rows, want 1 (only the fresh row — polling must be suppressed)", n)
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("sweep loop did not stop on context cancel")
 	}
 }
 

--- a/internal/forensics/conncache_integration_test.go
+++ b/internal/forensics/conncache_integration_test.go
@@ -151,7 +151,7 @@ func TestIntegrationHasAuditPlugin_NoneInstalled(t *testing.T) {
 // branch (#3): polling is suppressed (the audit log carries better history),
 // but the retention sweep must keep running so connection_cache rows captured
 // before the plugin was installed still age out — otherwise they persist
-// forever and tier-2b attributes old events to a frozen, possibly reused
+// forever and tier 2b attributes old events to a frozen, possibly reused
 // identity. The loop runs until the context is cancelled.
 func TestIntegrationAuditPluginSkipsPollingButStillSweeps(t *testing.T) {
 	db, dbName := testutil.CreateTestDB(t)

--- a/internal/forensics/conncache_test.go
+++ b/internal/forensics/conncache_test.go
@@ -3,6 +3,8 @@ package forensics
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
+	"sync"
 	"testing"
 	"time"
 
@@ -165,5 +167,66 @@ func TestCleanupConnectionCache_SubSecondRetention(t *testing.T) {
 				t.Errorf("retention interval mismatch — sub-second must not become INTERVAL 0: %v", err)
 			}
 		})
+	}
+}
+
+// signalingArg is a sqlmock argument matcher that closes fired (once) when the
+// expected bound value is matched, giving a test a happens-before hook to know
+// a query has reached the driver — without racing on sqlmock's internals.
+type signalingArg struct {
+	want  int64
+	fired chan struct{}
+	once  sync.Once
+}
+
+func (s *signalingArg) Match(v driver.Value) bool {
+	if n, ok := v.(int64); ok && n == s.want {
+		s.once.Do(func() { close(s.fired) })
+		return true
+	}
+	return false
+}
+
+// TestSweepLoop_ImmediateSweepThenExitsOnCancel guards the fast-lane coverage
+// of #3's audit-present branch (the end-to-end behavior is pinned by the
+// integration test, which needs a MySQL container). sweepLoop must run one
+// retention sweep immediately — pruning the pre-audit backlog without waiting a
+// full cleanupInterval — and then exit promptly when the context is cancelled.
+func TestSweepLoop_ImmediateSweepThenExitsOnCancel(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	// Exactly one DELETE is expected: the immediate sweep. cleanupInterval is an
+	// hour, so the ticker cannot fire within the test window.
+	sig := &signalingArg{want: 86400, fired: make(chan struct{})} // 24h in seconds
+	mock.ExpectExec("DELETE FROM connection_cache").
+		WithArgs(sig).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		sweepLoop(ctx, db, 24*time.Hour)
+		close(done)
+	}()
+
+	select {
+	case <-sig.fired: // the immediate sweep issued its DELETE
+	case <-time.After(2 * time.Second):
+		cancel()
+		t.Fatal("sweepLoop did not run an immediate sweep before blocking on its ticker")
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("sweepLoop did not exit promptly on context cancel")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unexpected sweep queries — only the immediate sweep should run: %v", err)
 	}
 }

--- a/internal/forensics/conncache_test.go
+++ b/internal/forensics/conncache_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	_ "github.com/go-sql-driver/mysql"
 )
 
@@ -129,4 +130,40 @@ func openLazyDB(t *testing.T, dsn string) *sql.DB {
 	}
 	t.Cleanup(func() { db.Close() })
 	return db
+}
+
+// TestCleanupConnectionCache_SubSecondRetention guards #8: a positive
+// sub-second --attribution-retention must not truncate to INTERVAL 0 SECOND
+// (which would DELETE every row, including live sessions). It is rounded up to
+// the minimum meaningful window of 1 second (last_seen is second-precision).
+func TestCleanupConnectionCache_SubSecondRetention(t *testing.T) {
+	tests := []struct {
+		name      string
+		retention time.Duration
+		wantSecs  int64
+	}{
+		{"half a second rounds up to 1", 500 * time.Millisecond, 1},
+		{"one nanosecond rounds up to 1", time.Nanosecond, 1},
+		{"exactly one second", time.Second, 1},
+		{"24h is exact", 24 * time.Hour, 86400},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("sqlmock: %v", err)
+			}
+			defer db.Close()
+			mock.ExpectExec("DELETE FROM connection_cache").
+				WithArgs(tt.wantSecs).
+				WillReturnResult(sqlmock.NewResult(0, 0))
+
+			if err := cleanupConnectionCache(context.Background(), db, tt.retention); err != nil {
+				t.Fatalf("cleanupConnectionCache: %v", err)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("retention interval mismatch — sub-second must not become INTERVAL 0: %v", err)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Addresses the four robustness findings from the post-merge review of the forensics feature (`drafts/forensics-merge-review-2026-07-03.md`) — the "don't silently lose audit/cache data" cluster. The confidence-labeling finding (#4) and the oversized-record parser refactor (#7) are a separate follow-up (they're distinct in nature and files).

## Fixes

**conncache — retention sweep never ran once an audit plugin was active** (`internal/forensics/conncache.go`). The sweep lived only inside `pollLoop`, which the audit-present branch of `StartConnCachePoller` returns before ever calling. So on the documented operator path (run poller → install `server_audit` → restart), pre-audit `connection_cache` rows were never pruned and persisted forever, and tier-2b kept attributing old events to a frozen, possibly reused identity. Extracted a `sweepLoop` (immediate sweep + ticker until ctx cancel) and run it on the audit branch.

**conncache — sub-second retention wiped the cache** (`conncache.go`). `cleanupConnectionCache` used `int64(retention.Seconds())`, truncating a positive sub-second `--attribution-retention` to `INTERVAL 0 SECOND` — a `DELETE` that removes every row including live sessions. Rounded a sub-second window up to 1s (`last_seen` is second-precision).

**audit log — empty file was a hard error that dropped rotated history** (`internal/forensics/auditlog.go`). An empty (validly-configured) audit log was detected as `AuditFormatUnknown` → hard `ErrAuditUnknownFormat`, and because format was read only from the primary file, a rotated-empty primary discarded all rotated files that held data. `detectAuditLogFormat` now falls back to the discovered plugin variant on empty/ambiguous content (empty file → its real format → zero events), and a 0-byte file no longer short-circuits to Unknown. Non-empty garbage still hard-errors (a genuinely corrupt log isn't masked).

**audit log — rotated-file cap kept the oldest, dropped the newest** (`auditlog.go`). `collectAuditLogFiles` capped during the `os.ReadDir` walk (filename order) BEFORE the mtime sort, so with >`maxRotatedFiles` rotated logs it kept the oldest and silently dropped the most-recent history — the opposite of what a forensic query wants. Collect all → sort newest-first → cap, with a truncation warning.

## Tests
- `TestCleanupConnectionCache_SubSecondRetention` — sqlmock, asserts sub-second → `INTERVAL 1 SECOND` (not 0).
- `TestIntegrationAuditPluginSkipsPollingButStillSweeps` — the audit-present branch sweeps a 2-day-old row while suppressing polling, exits on ctx cancel.
- `TestDetectAuditLogFormat_ContentBased` — new empty-file cases (variant fallback + unknown-variant → Unknown).
- `TestCollectAuditLogFiles` — new subtest: cap keeps the NEWEST rotated files and warns on the drop (fails on pre-fix).
- `TestReadAuditLog_EmptyFileNoError` — empty audit log → zero events, no hard error.

`go build`/`vet`/full unit suite/forensics integration all green; gofmt-clean. An adversarial diff review found all four fixes correct; its one Low nit (an unreachable `isEmptyFile` guard) was removed as dead code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
