### PR TITLE
forensics: confidence honesty (live tier) + oversized-record resilience (post-merge-review lows)

### DIFF
--- a/internal/forensics/auditlog_enterprise.go
+++ b/internal/forensics/auditlog_enterprise.go
@@ -55,7 +55,7 @@ func parseAuditJSON(r io.Reader, filter auditLogFilter) ([]AuditEvent, int, int,
 			break
 		}
 	}
-	skipped += scanner.Skipped()
+	skipped = foldOversized(scanner, skipped)
 	return events, totalScanned, skipped, scanner.Err()
 }
 

--- a/internal/forensics/auditlog_enterprise.go
+++ b/internal/forensics/auditlog_enterprise.go
@@ -1,7 +1,6 @@
 package forensics
 
 import (
-	"bufio"
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
@@ -23,8 +22,7 @@ import (
 func parseAuditJSON(r io.Reader, filter auditLogFilter) ([]AuditEvent, int, int, error) {
 	var events []AuditEvent
 	totalScanned, skipped := 0, 0
-	scanner := bufio.NewScanner(r)
-	scanner.Buffer(make([]byte, 256*1024), 1024*1024) // up to 1 MB per line
+	scanner := newAuditLineScanner(r)
 
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
@@ -57,6 +55,7 @@ func parseAuditJSON(r io.Reader, filter auditLogFilter) ([]AuditEvent, int, int,
 			break
 		}
 	}
+	skipped += scanner.Skipped()
 	return events, totalScanned, skipped, scanner.Err()
 }
 

--- a/internal/forensics/auditlog_mariadb.go
+++ b/internal/forensics/auditlog_mariadb.go
@@ -82,7 +82,7 @@ func parseMariaDBFile(r io.Reader, filter auditLogFilter) (events []AuditEvent, 
 	if localTimeSeen {
 		notes = append(notes, mariadbLocalTimeNote)
 	}
-	skipped += scanner.Skipped()
+	skipped = foldOversized(scanner, skipped)
 	return events, totalScanned, skipped, notes, scanner.Err()
 }
 

--- a/internal/forensics/auditlog_mariadb.go
+++ b/internal/forensics/auditlog_mariadb.go
@@ -1,7 +1,6 @@
 package forensics
 
 import (
-	"bufio"
 	"io"
 	"strings"
 	"time"
@@ -48,11 +47,11 @@ const minEpochMicrosDigits = 13
 
 // parseMariaDBFile parses the file-based audit log from the MariaDB
 // server_audit plugin family (upstream MariaDB, AWS RDS MySQL fork, Aurora
-// Advanced Auditing). Malformed lines are skipped and counted; notes carries
-// at most one local-time caveat when local-time dialect lines were parsed.
+// Advanced Auditing). Malformed or oversized lines are skipped and counted;
+// notes carries at most one local-time caveat when local-time dialect lines
+// were parsed.
 func parseMariaDBFile(r io.Reader, filter auditLogFilter) (events []AuditEvent, totalScanned, skipped int, notes []string, err error) {
-	scanner := bufio.NewScanner(r)
-	scanner.Buffer(make([]byte, 256*1024), 1024*1024)
+	scanner := newAuditLineScanner(r)
 	localTimeSeen := false
 
 	for scanner.Scan() {
@@ -83,6 +82,7 @@ func parseMariaDBFile(r io.Reader, filter auditLogFilter) (events []AuditEvent, 
 	if localTimeSeen {
 		notes = append(notes, mariadbLocalTimeNote)
 	}
+	skipped += scanner.Skipped()
 	return events, totalScanned, skipped, notes, scanner.Err()
 }
 

--- a/internal/forensics/auditlog_mariadb_test.go
+++ b/internal/forensics/auditlog_mariadb_test.go
@@ -305,6 +305,34 @@ func TestParseMariaDBFile_LocalTimeNote(t *testing.T) {
 	})
 }
 
+// TestParseMariaDBFile_OversizedRecordSkippedNotFatal proves the oversized-skip
+// path through a CSV parser (the end-to-end JSON case lives in auditlog_test.go):
+// a >1 MB record is skipped and counted, and the record AFTER it still parses —
+// the whole point of replacing bufio.Scanner, which aborted the file here.
+func TestParseMariaDBFile_OversizedRecordSkippedNotFatal(t *testing.T) {
+	l1 := `20240615 10:30:01,server1,alice,localhost,42,1,QUERY,test,'SELECT 1',0`
+	// The oversized record's internal shape is irrelevant — the scanner drops it
+	// by length before the CSV parser ever sees it.
+	huge := `20240615 10:30:02,server1,bob,localhost,43,2,QUERY,test,'` + strings.Repeat("x", maxAuditLineBytes+1) + `',0`
+	l3 := `20240615 10:30:03,server1,dave,localhost,44,3,QUERY,test,'SELECT 2',0`
+	input := l1 + "\n" + huge + "\n" + l3 + "\n"
+
+	events, _, skipped, _, err := parseMariaDBFile(strings.NewReader(input), auditLogFilter{})
+	if err != nil {
+		t.Fatalf("parseMariaDBFile: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("events = %d, want 2 (records bracketing the oversized one)", len(events))
+	}
+	if events[0].User != "alice" || events[1].User != "dave" {
+		t.Errorf("users = [%s, %s], want [alice, dave] — the record after the oversized one was lost",
+			events[0].User, events[1].User)
+	}
+	if skipped < 1 {
+		t.Errorf("skipped = %d, want >= 1 (the oversized record counted)", skipped)
+	}
+}
+
 // TestParseMariaDBFile_EpochMicrosFiltering proves that time filters work on
 // Aurora lines end-to-end: the epoch is normalised to RFC 3339 before the
 // filter runs.

--- a/internal/forensics/auditlog_percona.go
+++ b/internal/forensics/auditlog_percona.go
@@ -65,7 +65,7 @@ func parsePerconaCSV(r io.Reader, filter auditLogFilter) ([]AuditEvent, int, int
 			break
 		}
 	}
-	skipped += scanner.Skipped()
+	skipped = foldOversized(scanner, skipped)
 	return events, totalScanned, skipped, scanner.Err()
 }
 

--- a/internal/forensics/auditlog_percona.go
+++ b/internal/forensics/auditlog_percona.go
@@ -1,7 +1,6 @@
 package forensics
 
 import (
-	"bufio"
 	"io"
 	"strings"
 )
@@ -17,8 +16,7 @@ import (
 func parsePerconaCSV(r io.Reader, filter auditLogFilter) ([]AuditEvent, int, int, error) {
 	var events []AuditEvent
 	totalScanned, skipped := 0, 0
-	scanner := bufio.NewScanner(r)
-	scanner.Buffer(make([]byte, 256*1024), 1024*1024)
+	scanner := newAuditLineScanner(r)
 
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
@@ -67,6 +65,7 @@ func parsePerconaCSV(r io.Reader, filter auditLogFilter) ([]AuditEvent, int, int
 			break
 		}
 	}
+	skipped += scanner.Skipped()
 	return events, totalScanned, skipped, scanner.Err()
 }
 

--- a/internal/forensics/auditlog_scanner.go
+++ b/internal/forensics/auditlog_scanner.go
@@ -1,0 +1,143 @@
+package forensics
+
+import (
+	"bufio"
+	"io"
+)
+
+// maxAuditLineBytes bounds a single audit record. A line longer than this is
+// skipped (and counted) rather than aborting the scan: SERVER_AUDIT_QUERY_LOG_LIMIT
+// can be raised so a single query record runs well past a megabyte, and one
+// oversized record must not truncate the rest of the file — which is exactly
+// what bufio.Scanner does when it returns ErrTooLong. The value matches the old
+// bufio.Scanner max-token size, so normal input (every line under 1 MB) is
+// parsed byte-for-byte as before.
+const maxAuditLineBytes = 1024 * 1024
+
+// auditLineScanner is a drop-in replacement for bufio.Scanner used by the
+// audit-log parsers. Unlike bufio.Scanner — which aborts the whole file when a
+// single line exceeds its buffer — an over-long line here is drained, skipped,
+// and counted (see Skipped), and scanning continues with the next record. An
+// oversized line is discarded in fixed-size fragments, never fully buffered, so
+// memory stays bounded regardless of how large a single record is.
+//
+// The method set mirrors the bufio.Scanner methods the parsers use (Scan / Text
+// / Err), plus Skipped, so each parser only swaps its constructor.
+type auditLineScanner struct {
+	r       *bufio.Reader
+	line    string
+	skipped int
+	err     error
+	done    bool
+}
+
+func newAuditLineScanner(r io.Reader) *auditLineScanner {
+	return &auditLineScanner{r: bufio.NewReaderSize(r, 256*1024)}
+}
+
+// Scan advances to the next line within maxAuditLineBytes, returning false at
+// end of input or on a read error (retrievable via Err). Over-long lines are
+// drained, counted, and skipped — never returned to the caller. Like
+// bufio.Scanner, the returned line has its trailing newline stripped, and a
+// blank line is a valid (empty) result rather than an end condition.
+func (s *auditLineScanner) Scan() bool {
+	if s.done {
+		return false
+	}
+	for {
+		line, tooLong, err := s.readLine()
+		if tooLong {
+			s.skipped++
+			if err != nil { // the oversized line ran to EOF (or a read error)
+				s.finish(err)
+				return false
+			}
+			continue // skip it; the next read starts at the following record
+		}
+		if len(line) > 0 {
+			s.line = line
+			if err != nil { // a final line with no trailing newline arrives with io.EOF
+				s.finish(err)
+			}
+			return true
+		}
+		// No bytes and not over-long: either a blank line (err == nil) or the
+		// end of input / a read error.
+		if err != nil {
+			s.finish(err)
+			return false
+		}
+		s.line = ""
+		return true
+	}
+}
+
+// readLine reads one newline-terminated line, stripping the trailing newline.
+// A line exceeding maxAuditLineBytes is drained (its bytes discarded in
+// fragments) and reported as tooLong with an empty line. err is io.EOF at end
+// of input, which may accompany a final line that has no trailing newline.
+func (s *auditLineScanner) readLine() (line string, tooLong bool, err error) {
+	var buf []byte
+	for {
+		frag, e := s.r.ReadSlice('\n')
+		// contentLen is the line length excluding the single '\n' delimiter,
+		// which ReadSlice includes only on the terminating fragment (e == nil).
+		// Comparing content (not content+delimiter) keeps the threshold aligned
+		// with bufio.Scanner's max-token size: a line of exactly
+		// maxAuditLineBytes is kept, not skipped.
+		contentLen := len(buf) + len(frag)
+		if e == nil && contentLen > 0 {
+			contentLen--
+		}
+		if contentLen > maxAuditLineBytes {
+			// Over the bound: stop accumulating and drain the remainder of this
+			// line so the next Scan starts cleanly at the following record.
+			return "", true, s.drainToNewline(e)
+		}
+		// frag aliases the reader's buffer and is only valid until the next
+		// read, so copy it out.
+		buf = append(buf, frag...)
+		if e == bufio.ErrBufferFull {
+			continue // partial line — more fragments follow
+		}
+		// e is nil (line complete) or io.EOF/other (last line, no newline).
+		return trimTrailingNewline(buf), false, e
+	}
+}
+
+// drainToNewline discards the rest of an over-long line without buffering it.
+// e is the error from the ReadSlice that pushed the line over the bound; when
+// it is ErrBufferFull the line continues and is drained fragment by fragment.
+// Returns nil once the terminating newline is consumed, or io.EOF/other at end.
+func (s *auditLineScanner) drainToNewline(e error) error {
+	for e == bufio.ErrBufferFull {
+		_, e = s.r.ReadSlice('\n')
+	}
+	return e
+}
+
+// finish latches the scanner closed and records a terminal read error. io.EOF
+// is normal end-of-input, not an error.
+func (s *auditLineScanner) finish(err error) {
+	s.done = true
+	if err != nil && err != io.EOF {
+		s.err = err
+	}
+}
+
+func (s *auditLineScanner) Text() string { return s.line }
+func (s *auditLineScanner) Err() error   { return s.err }
+func (s *auditLineScanner) Skipped() int { return s.skipped }
+
+// trimTrailingNewline strips a trailing "\n" then a trailing "\r", replicating
+// bufio.ScanLines' dropCR so the line sequence is identical to bufio.Scanner's
+// on normal input (including "\r\n" endings and a final CR-terminated line).
+func trimTrailingNewline(b []byte) string {
+	if n := len(b); n > 0 && b[n-1] == '\n' {
+		b = b[:n-1]
+	}
+	if n := len(b); n > 0 && b[n-1] == '\r' {
+		b = b[:n-1]
+	}
+	return string(b)
+}

--- a/internal/forensics/auditlog_scanner.go
+++ b/internal/forensics/auditlog_scanner.go
@@ -3,6 +3,7 @@ package forensics
 import (
 	"bufio"
 	"io"
+	"log/slog"
 )
 
 // maxAuditLineBytes bounds a single audit record. A line longer than this is
@@ -82,9 +83,11 @@ func (s *auditLineScanner) readLine() (line string, tooLong bool, err error) {
 		frag, e := s.r.ReadSlice('\n')
 		// contentLen is the line length excluding the single '\n' delimiter,
 		// which ReadSlice includes only on the terminating fragment (e == nil).
-		// Comparing content (not content+delimiter) keeps the threshold aligned
-		// with bufio.Scanner's max-token size: a line of exactly
-		// maxAuditLineBytes is kept, not skipped.
+		// Comparing content (not content+delimiter) means a line of exactly
+		// maxAuditLineBytes is kept. That is one byte more permissive than the
+		// old bufio.Scanner, which had to fit content+'\n' in its 1 MB buffer
+		// and so aborted at maxAuditLineBytes content — a safe divergence: every
+		// line the old scanner kept, this one keeps too; none is dropped.
 		contentLen := len(buf) + len(frag)
 		if e == nil && contentLen > 0 {
 			contentLen--
@@ -128,6 +131,23 @@ func (s *auditLineScanner) finish(err error) {
 func (s *auditLineScanner) Text() string { return s.line }
 func (s *auditLineScanner) Err() error   { return s.err }
 func (s *auditLineScanner) Skipped() int { return s.skipped }
+
+// foldOversized adds the scanner's oversized-line drops to a parser's running
+// skip count and, when any occurred, logs them distinctly. They still count in
+// skipped_lines (the total the caller reports), but an oversized drop is a whole
+// audit record discarded for size — not a malformed line — and in a forensics
+// context the dropped record may be the one that names the actor, so operators
+// need it surfaced rather than folded away silently. Every scanner-backed parser
+// calls this once, after its scan loop.
+func foldOversized(scanner *auditLineScanner, skipped int) int {
+	if n := scanner.Skipped(); n > 0 {
+		slog.Warn("forensics: skipped audit record(s) exceeding the 1 MiB parser line limit; "+
+			"attribution from those records is unavailable (raise the limit at the source or shorten the query text)",
+			"oversized_records", n)
+		return skipped + n
+	}
+	return skipped
+}
 
 // trimTrailingNewline strips a trailing "\n" then a trailing "\r", replicating
 // bufio.ScanLines' dropCR so the line sequence is identical to bufio.Scanner's

--- a/internal/forensics/auditlog_scanner_test.go
+++ b/internal/forensics/auditlog_scanner_test.go
@@ -71,6 +71,29 @@ func TestAuditLineScanner_OversizedSkippedMidStream(t *testing.T) {
 	}
 }
 
+// TestAuditLineScanner_MultipleConsecutiveOversized: several over-long lines in
+// a row are each drained, skipped, and counted, and the valid lines bracketing
+// them still come through — the scan never gets "stuck" on a run of big records.
+func TestAuditLineScanner_MultipleConsecutiveOversized(t *testing.T) {
+	huge := strings.Repeat("x", maxAuditLineBytes+1)
+	in := "a\n" + huge + "\n" + huge + "\n" + huge + "\nb\n"
+
+	sc := newAuditLineScanner(strings.NewReader(in))
+	var got []string
+	for sc.Scan() {
+		got = append(got, sc.Text())
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("Err() = %v, want nil", err)
+	}
+	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Fatalf("lines = %q, want [a b] (all three oversized records skipped)", got)
+	}
+	if sc.Skipped() != 3 {
+		t.Errorf("Skipped() = %d, want 3", sc.Skipped())
+	}
+}
+
 // TestAuditLineScanner_OversizedFinalLineNoNewline: an oversized last line with
 // no trailing newline is skipped (counted) and ends the scan cleanly, not as an
 // error.
@@ -94,10 +117,11 @@ func TestAuditLineScanner_OversizedFinalLineNoNewline(t *testing.T) {
 }
 
 // TestAuditLineScanner_BoundaryKeptAndSpanningFills pins two size edges: a line
-// of exactly maxAuditLineBytes content is KEPT (not skipped — matching the old
-// scanner's max-token semantics), and a valid line larger than the 256 KB
-// internal read buffer (so it arrives in multiple ReadSlice fragments) is
-// reassembled intact.
+// of exactly maxAuditLineBytes content is KEPT (the old bufio.Scanner actually
+// aborted here — it needed buffer room for the trailing newline too; this
+// scanner is deliberately one byte more permissive and never drops a line the
+// old one kept), and a valid line larger than the 256 KB internal read buffer
+// (so it arrives in multiple ReadSlice fragments) is reassembled intact.
 func TestAuditLineScanner_BoundaryKeptAndSpanningFills(t *testing.T) {
 	t.Run("exactly at the byte bound is kept", func(t *testing.T) {
 		line := strings.Repeat("a", maxAuditLineBytes)

--- a/internal/forensics/auditlog_scanner_test.go
+++ b/internal/forensics/auditlog_scanner_test.go
@@ -1,0 +1,188 @@
+package forensics
+
+import (
+	"bufio"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+// TestAuditLineScanner_MatchesBufioScanner is a differential test: on any input
+// whose lines all fit within maxAuditLineBytes, auditLineScanner must yield the
+// exact same line sequence as bufio.Scanner (the reader it replaces). This one
+// test guards the newline / blank-line / CRLF / final-line-without-newline
+// edges that a hand-rolled line reader gets wrong.
+func TestAuditLineScanner_MatchesBufioScanner(t *testing.T) {
+	inputs := map[string]string{
+		"empty":                    "",
+		"single line no newline":   "one line",
+		"single line with newline": "one line\n",
+		"two lines":                "a\nb\n",
+		"two lines no trailing nl": "a\nb",
+		"blank lines preserved":    "a\n\n\nb\n",
+		"leading blank line":       "\nafter\n",
+		"only newlines":            "\n\n\n",
+		"crlf endings":             "a\r\nb\r\n",
+		"crlf final no lf":         "a\r\nb\r",
+		"trailing whitespace":      "a   \n   b\n",
+		"csv-ish":                  `"2024-06-15","root","10.0.0.1","QUERY"` + "\n",
+	}
+	for name, in := range inputs {
+		t.Run(name, func(t *testing.T) {
+			want := bufioLines(in)
+			got := auditScanLines(t, strings.NewReader(in))
+			if len(got) != len(want) {
+				t.Fatalf("line count = %d, want %d\n got=%q\nwant=%q", len(got), len(want), got, want)
+			}
+			for i := range want {
+				if got[i] != want[i] {
+					t.Errorf("line %d = %q, want %q", i, got[i], want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestAuditLineScanner_OversizedSkippedMidStream is the core #7 property: an
+// over-long line is skipped and counted, and lines AFTER it are still returned —
+// the exact case bufio.Scanner cannot handle (it aborts on ErrTooLong).
+func TestAuditLineScanner_OversizedSkippedMidStream(t *testing.T) {
+	huge := strings.Repeat("x", maxAuditLineBytes+1)
+	in := "before\n" + huge + "\nafter\n"
+
+	got := auditScanLines(t, strings.NewReader(in))
+	want := []string{"before", "after"}
+	if len(got) != len(want) || got[0] != "before" || got[1] != "after" {
+		t.Fatalf("lines = %q, want %q (the record after the oversized one must survive)", got, want)
+	}
+
+	// And Skipped() reports the drop.
+	sc := newAuditLineScanner(strings.NewReader(in))
+	n := 0
+	for sc.Scan() {
+		n++
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("Err() = %v, want nil", err)
+	}
+	if sc.Skipped() != 1 {
+		t.Errorf("Skipped() = %d, want 1", sc.Skipped())
+	}
+}
+
+// TestAuditLineScanner_OversizedFinalLineNoNewline: an oversized last line with
+// no trailing newline is skipped (counted) and ends the scan cleanly, not as an
+// error.
+func TestAuditLineScanner_OversizedFinalLineNoNewline(t *testing.T) {
+	in := "kept\n" + strings.Repeat("y", maxAuditLineBytes+50) // no trailing \n
+
+	sc := newAuditLineScanner(strings.NewReader(in))
+	var got []string
+	for sc.Scan() {
+		got = append(got, sc.Text())
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("Err() = %v, want nil", err)
+	}
+	if len(got) != 1 || got[0] != "kept" {
+		t.Fatalf("lines = %q, want [kept]", got)
+	}
+	if sc.Skipped() != 1 {
+		t.Errorf("Skipped() = %d, want 1", sc.Skipped())
+	}
+}
+
+// TestAuditLineScanner_BoundaryKeptAndSpanningFills pins two size edges: a line
+// of exactly maxAuditLineBytes content is KEPT (not skipped — matching the old
+// scanner's max-token semantics), and a valid line larger than the 256 KB
+// internal read buffer (so it arrives in multiple ReadSlice fragments) is
+// reassembled intact.
+func TestAuditLineScanner_BoundaryKeptAndSpanningFills(t *testing.T) {
+	t.Run("exactly at the byte bound is kept", func(t *testing.T) {
+		line := strings.Repeat("a", maxAuditLineBytes)
+		sc := newAuditLineScanner(strings.NewReader(line + "\n"))
+		if !sc.Scan() {
+			t.Fatalf("Scan() = false, want the exactly-bounded line kept (Err: %v)", sc.Err())
+		}
+		if len(sc.Text()) != maxAuditLineBytes {
+			t.Errorf("line length = %d, want %d", len(sc.Text()), maxAuditLineBytes)
+		}
+		if sc.Skipped() != 0 {
+			t.Errorf("Skipped() = %d, want 0 — a line at the bound must not be dropped", sc.Skipped())
+		}
+	})
+	t.Run("line spanning several read-buffer fills is intact", func(t *testing.T) {
+		line := strings.Repeat("z", 700*1024) // > 256 KB buffer, < 1 MB bound
+		sc := newAuditLineScanner(strings.NewReader(line + "\n"))
+		if !sc.Scan() {
+			t.Fatalf("Scan() = false, want the multi-fragment line (Err: %v)", sc.Err())
+		}
+		if sc.Text() != line {
+			t.Errorf("reassembled line length = %d, want %d (fragments not stitched correctly)", len(sc.Text()), len(line))
+		}
+	})
+}
+
+// TestAuditLineScanner_ReadErrorSurfaces: a genuine read error (not EOF) is
+// reported via Err, never swallowed as a clean end of input.
+func TestAuditLineScanner_ReadErrorSurfaces(t *testing.T) {
+	boom := errors.New("disk exploded")
+	sc := newAuditLineScanner(&errReader{data: "line one\n", err: boom})
+
+	var got []string
+	for sc.Scan() {
+		got = append(got, sc.Text())
+	}
+	if len(got) != 1 || got[0] != "line one" {
+		t.Fatalf("lines = %q, want [line one] before the error", got)
+	}
+	if !errors.Is(sc.Err(), boom) {
+		t.Errorf("Err() = %v, want the underlying read error", sc.Err())
+	}
+}
+
+// --- helpers ---------------------------------------------------------------
+
+// auditScanLines drains an auditLineScanner into a slice, failing on error.
+func auditScanLines(t *testing.T, r io.Reader) []string {
+	t.Helper()
+	sc := newAuditLineScanner(r)
+	var out []string
+	for sc.Scan() {
+		out = append(out, sc.Text())
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("auditLineScanner Err() = %v, want nil", err)
+	}
+	return out
+}
+
+// bufioLines drains a bufio.Scanner (the reference implementation) into a slice.
+func bufioLines(in string) []string {
+	sc := bufio.NewScanner(strings.NewReader(in))
+	sc.Buffer(make([]byte, 256*1024), 1024*1024)
+	var out []string
+	for sc.Scan() {
+		out = append(out, sc.Text())
+	}
+	return out
+}
+
+// errReader yields data once, then the given error (simulating an I/O failure
+// partway through a stream). The trailing newline in data ensures the first
+// line completes before the error surfaces.
+type errReader struct {
+	data string
+	err  error
+	done bool
+}
+
+func (e *errReader) Read(p []byte) (int, error) {
+	if e.done {
+		return 0, e.err
+	}
+	n := copy(p, e.data)
+	e.done = true
+	return n, nil
+}

--- a/internal/forensics/auditlog_test.go
+++ b/internal/forensics/auditlog_test.go
@@ -464,25 +464,36 @@ func TestParseAuditLogFiles_UnreadableFileWarnsAndContinues(t *testing.T) {
 	}
 }
 
-// TestParseAuditLogFiles_ParseErrorNonFatal: a scanner failure mid-file
-// (line exceeding the 1 MB buffer) must surface as a warning with partial
-// results, never as a fatal error — the SaaS contract this port preserves.
-func TestParseAuditLogFiles_ParseErrorNonFatal(t *testing.T) {
+// TestParseAuditLogFiles_OversizedRecordSkippedNotFatal: a single record larger
+// than maxAuditLineBytes must be skipped and counted, NOT abort the scan —
+// records after it still parse. The old bufio.Scanner returned ErrTooLong here
+// and dropped the rest of the file; the whole point of the fix is that a valid
+// record following an oversized one is still returned (#7).
+func TestParseAuditLogFiles_OversizedRecordSkippedNotFatal(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "audit.json")
 	mustWrite(t, path,
 		`{"timestamp":"2024-06-15T10:30:00Z","name":"Query","user":"root"}`+"\n"+
-			`{"timestamp":"2024-06-15T10:31:00Z","name":"Query","pad":"`+strings.Repeat("x", 2<<20)+`"}`+"\n")
+			`{"timestamp":"2024-06-15T10:31:00Z","name":"Query","pad":"`+strings.Repeat("x", 2<<20)+`"}`+"\n"+
+			`{"timestamp":"2024-06-15T10:32:00Z","name":"Query","user":"dave"}`+"\n")
 
 	res, err := parseAuditLogFiles([]string{path}, AuditFormatJSON, auditLogFilter{}, 0, 10, 0)
 	if err != nil {
 		t.Fatalf("parseAuditLogFiles returned fatal error: %v", err)
 	}
-	if len(res.events) != 1 {
-		t.Errorf("events = %d, want 1 partial result", len(res.events))
+	// Both bracketing records parse — proving the scan continued past the
+	// oversized middle record instead of aborting on it.
+	if len(res.events) != 2 {
+		t.Fatalf("events = %d, want 2 (records before AND after the oversized one)", len(res.events))
 	}
-	if !warningsContain(res.warnings, "parse error in") {
-		t.Errorf("warnings = %v, want a 'parse error in' entry", res.warnings)
+	if got := res.events[0].User; got != "root" {
+		t.Errorf("first event user = %q, want root", got)
+	}
+	if got := res.events[1].User; got != "dave" {
+		t.Errorf("second event user = %q, want dave — the record after the oversized one was lost", got)
+	}
+	if res.skippedLines < 1 {
+		t.Errorf("skippedLines = %d, want >= 1 (the oversized record counted as skipped)", res.skippedLines)
 	}
 }
 

--- a/internal/forensics/whochanged.go
+++ b/internal/forensics/whochanged.go
@@ -17,12 +17,14 @@ import (
 type Confidence string
 
 // Confidence tiers (epic #701): exact means the identity join is positively
-// bounded (an audit-log CONNECT..DISCONNECT lifetime containing the event, a
-// GTID transaction join, or a live performance_schema session); corroborated
-// means the identity matched but its session lifetime could not be verified
-// (nearest audit record without brackets, or the connection_cache); heuristic
-// means we had to choose between multiple plausible identities (e.g. two audit
-// lifetimes abutting within the log's one-second granularity).
+// bounded (an audit-log CONNECT..DISCONNECT lifetime containing the event, or a
+// GTID transaction join); corroborated means the identity matched but its
+// session lifetime could not be verified (nearest audit record without
+// brackets, the connection_cache, or a live performance_schema session — which
+// reflects the current holder of the connection id, and that id may have been
+// reused since the event); heuristic means we had to choose between multiple
+// plausible identities (e.g. two audit lifetimes abutting within the log's
+// one-second granularity).
 const (
 	ConfidenceExact        Confidence = "exact"
 	ConfidenceCorroborated Confidence = "corroborated"
@@ -529,7 +531,13 @@ func lookupLiveThreads(ctx context.Context, sourceDB *sql.DB, ids []int64) (map[
 				Host:          ti.Host,
 				ClientProgram: ti.ConnAttrs["program_name"],
 				Source:        AttributionSourcePerfSchema,
-				Confidence:    ConfidenceExact,
+				// Corroborated, not exact: this is the CURRENT holder of the
+				// connection id, whose lifetime is not bounded against the
+				// event. A reused id (or COM_CHANGE_USER) can make the live
+				// session a different actor than the one that ran the event —
+				// the exact tiers (audit CONNECT..DISCONNECT, GTID) are the ones
+				// that positively bound identity to the event.
+				Confidence: ConfidenceCorroborated,
 			}
 		}
 	}

--- a/internal/forensics/whochanged_integration_test.go
+++ b/internal/forensics/whochanged_integration_test.go
@@ -115,8 +115,12 @@ func TestIntegrationWhoChanged_LiveThenCacheCascade(t *testing.T) {
 	if live.Attribution.Source != AttributionSourcePerfSchema {
 		t.Errorf("live source = %q, want %q", live.Attribution.Source, AttributionSourcePerfSchema)
 	}
-	if live.Attribution.Confidence != ConfidenceExact {
-		t.Errorf("live confidence = %q, want %q", live.Attribution.Confidence, ConfidenceExact)
+	// Corroborated, not exact: the live performance_schema tier reports the
+	// current holder of the connection id, whose session lifetime is not bounded
+	// against the event (a reused id could be a different actor). Only the audit
+	// CONNECT..DISCONNECT and GTID tiers earn "exact".
+	if live.Attribution.Confidence != ConfidenceCorroborated {
+		t.Errorf("live confidence = %q, want %q", live.Attribution.Confidence, ConfidenceCorroborated)
 	}
 	if live.Attribution.User != "root" {
 		t.Errorf("live user = %q, want root", live.Attribution.User)


### PR DESCRIPTION
Closes out the two remaining findings from the forensics post-merge review (the "PR C" tail after #721 / #731). Both are attribution-correctness/robustness fixes; distinct in nature, kept small.

## #4 — live performance_schema tier graded `corroborated`, not `exact`
`internal/forensics/whochanged.go`

Tier 2a resolves a historical event's actor from the **current** holder of its connection id (`lookupLiveThreads` by present `PROCESSLIST_ID`), whose session lifetime is not bounded against the event. On connection-id reuse / `COM_CHANGE_USER` the live session can be a *different* actor than the one that ran the event — so `exact` overstated it, reintroducing the very misattribution the audit tier's `CONNECT..DISCONNECT` bounding exists to prevent, but as a high-confidence answer.

- Downgraded to `corroborated`, aligning it with the `connection_cache` tier (2b) — the same unbounded connection-id lookup. Only the audit `CONNECT..DISCONNECT` and GTID joins positively bound identity, so they keep `exact`.
- **Pure label change**: nothing ranks/dedupes on `Confidence` — the tier cascade arbitrates purely by resolution order (`unresolvedConnIDs`/`applyConnAttributions` gate on "already attributed?", not confidence). Verified across the package (no `== ConfidenceExact` consumer beyond the definition, stamps, and tests).

## #7 — an oversized audit record no longer aborts the scan
`internal/forensics/auditlog_scanner.go` (new) + the three parsers

`bufio.Scanner` returns `ErrTooLong` on any line over its 1 MB buffer and then **stops** — so a single oversized record (`SERVER_AUDIT_QUERY_LOG_LIMIT` can be raised past a megabyte) silently truncated the rest of the file. Replaced with `auditLineScanner`, a drop-in reader that drains + skips an over-long line (counted in `skipped_lines`) and continues.

- Over-long lines are drained in fixed-size fragments, **never fully buffered** — memory stays bounded (a `ReadString` rewrite would have regressed that).
- `maxAuditLineBytes` matches the old scanner's max-token size, so normal input parses **byte-for-byte as before** — pinned by a differential test against `bufio.Scanner` (12 edge cases: CRLF, blank lines, final-line-without-newline, …).
- Shared by the MariaDB / Percona / Enterprise CSV+JSON parsers; the Enterprise **XML** parser uses `xml.Decoder` and is untouched.
- Rewrote the old `TestParseAuditLogFiles_ParseErrorNonFatal` (which pinned the *aborting* behavior) into `..._OversizedRecordSkippedNotFatal`, proving a record **after** the oversized one still parses.

## Testing
- `go build ./... && go vet ./... && go vet -tags=integration ./internal/forensics/` — clean
- Full `internal/forensics` unit suite green, incl. new scanner tests, `-race` clean (50× on the concurrent ones from #731 unaffected here)
- The live-tier confidence assertion in `whochanged_integration_test.go` updated to `corroborated` (runs against MySQL in CI's integration job)
- No new dependencies → THIRD-PARTY-NOTICES guard unaffected

Deployment shapes: this is the OSS engine; both fixes are in the shared forensics library reached identically by the CLI and the BYOS agent WS path — no data-plane-shape divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)