### PR TITLE
forensics: console Forensics view — retire the connection_id open-core boundary

### DIFF
--- a/internal/console/api_test.go
+++ b/internal/console/api_test.go
@@ -101,10 +101,12 @@ func TestBuildOptionsAttachesRBAC(t *testing.T) {
 	}
 }
 
-// TestEventsHandlerOmitsConnectionID exercises handleEvents at the HTTP layer
-// with sqlmock and asserts the open-core boundary holds over real data flow:
-// the source row carries connection_id, the response must not.
-func TestEventsHandlerOmitsConnectionID(t *testing.T) {
+// TestEventsHandlerIncludesConnectionID exercises handleEvents at the HTTP
+// layer with sqlmock and asserts the #701 D1 boundary move holds over real
+// data flow: the source row carries connection_id, and the response now does
+// too — while query_text/query_hash (#699, untouched by this epic) still
+// never reach the wire.
+func TestEventsHandlerIncludesConnectionID(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatal(err)
@@ -142,8 +144,8 @@ func TestEventsHandlerOmitsConnectionID(t *testing.T) {
 			t.Errorf("events response must not contain %q: %s", banned, body)
 		}
 	}
-	if strings.Contains(body, "connection_id") || strings.Contains(body, "4242") {
-		t.Errorf("events HTTP response leaked connection_id: %s", body)
+	if !strings.Contains(body, "connection_id") || !strings.Contains(body, "4242") {
+		t.Errorf("events HTTP response must carry connection_id (#701 D1): %s", body)
 	}
 	var resp eventsResponse
 	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -13,9 +13,9 @@
 //  3. Every async render captures `serverGen` before its await and bails if a
 //     server switch happened mid-flight (no cross-server repaint).
 //  4. Capability gating toggles the `.cap-on` class on [data-capability] nodes.
-//  5. Exports stay connection_id-free: CSV via the EVENT_CSV_COLUMNS allowlist;
-//     JSON only because the server's eventDTO omits connection_id (it serializes
-//     rows as-is). The open-core line is enforced server-side — don't add it.
+//  5. CSV export (EVENT_CSV_COLUMNS) and the JSON view stay in lockstep: both
+//     mirror whatever eventDTO serializes server-side (including connection_id,
+//     per epic #701 D1) — CSV is not a separate, narrower boundary to maintain.
 //  6. The DOM is built with el()/textContent only — no innerHTML anywhere. The
 //     one string→DOM path is svgEl(), which DOMParses STATIC icon constants
 //     (never data) into SVG nodes. No value from the API touches markup.
@@ -27,19 +27,19 @@ const TOKEN_KEY = "bintrail_console_token";
 const SERVER_KEY = "bintrail_console_server";
 const ONBOARD_KEY = "bintrail_console_onboarded";
 
-// Export columns. connection_id is DELIBERATELY ABSENT — it is paid-forensics
-// data and the console (query_explorer surface) never exposes it.
+// Export columns. connection_id is INCLUDED (epic #701 D1 — no longer a
+// gated field on the events API; CSV mirrors the JSON view exactly).
 const EVENT_CSV_COLUMNS = [
   "event_id", "event_timestamp", "schema_name", "table_name", "event_type",
-  "pk_values", "changed_columns", "gtid", "binlog_file", "start_pos", "end_pos",
-  "row_before", "row_after",
+  "pk_values", "changed_columns", "gtid", "connection_id", "binlog_file",
+  "start_pos", "end_pos", "row_before", "row_after",
 ];
 
 // event_type → badge modifier class.
 const BADGE_CLASS = { UPDATE: "b-update", INSERT: "b-insert", DELETE: "b-delete" };
 function badgeClass(t) { return BADGE_CLASS[t] || "b-baseline"; }
 
-const ROUTES = ["overview", "events", "timetravel", "recover", "status", "storage"];
+const ROUTES = ["overview", "events", "forensics", "timetravel", "recover", "status", "storage"];
 
 const MON_STATE_TITLES = {
   failed: "connection is failing and retrying automatically; press Start for details",
@@ -574,6 +574,7 @@ function renderRoute() {
   switch (route) {
     case "overview": return renderOverview();
     case "events": return renderEvents(params);
+    case "forensics": return renderForensics(params);
     case "timetravel": return renderTimetravel(params);
     case "recover": return renderRecover(params);
     case "status": return renderStatus();
@@ -1005,6 +1006,329 @@ function downloadEventsCSV(events) {
   const lines = [EVENT_CSV_COLUMNS.join(",")];
   (events || []).forEach((ev) => lines.push(EVENT_CSV_COLUMNS.map((c) => csvCell(ev[c])).join(",")));
   downloadBlob("dbtrail-events.csv", lines.join("\r\n"), "text/csv");
+}
+
+// ── Forensics ────────────────────────────────────────────────────────────────
+// Who changed a row, and three general investigation queries (user activity,
+// connection history, DDL history) against the SOURCE server's
+// performance_schema / audit log (epic #701). Unlike Events (index-only),
+// these hit /api/forensics/*. Capabilities and who-changed degrade to a setup
+// prompt / index-only attribution when the selected server has no source
+// connection configured — but user-activity, connection-history, and
+// ddl-history have no index-side fallback and error instead (handled the
+// same way any other query error is: renderError in the results panel).
+
+const FX_MODES = [
+  { id: "who_changed", label: "Who changed", desc: "Trace who modified rows in a table (schema and table required, PK optional)." },
+  { id: "user_activity", label: "User activity", desc: "Recent statements by a MySQL user." },
+  { id: "connection_history", label: "Connections", desc: "Current/recent connections from a user or host." },
+  { id: "ddl_history", label: "DDL history", desc: "Recent CREATE / ALTER / DROP statements." },
+];
+
+const FX_ACTIVITY_COLS = {
+  user_activity: [["user", "User"], ["host", "Host"], ["sql_text", "SQL"], ["duration_ms", "Duration (ms)"], ["rows_affected", "Rows affected"], ["connection_id", "Conn ID"]],
+  connection_history: [["user", "User"], ["host", "Host"], ["current_db", "Database"], ["command", "Command"], ["time_seconds", "Time (s)"], ["connection_id", "Conn ID"]],
+  ddl_history: [["user", "User"], ["host", "Host"], ["sql_text", "SQL"], ["duration_ms", "Duration (ms)"], ["connection_id", "Conn ID"]],
+};
+
+function renderForensics(params) {
+  // Landed on /forensics but the feature is gated off (direct URL, Back, or a
+  // stale bookmark) — same redirect-then-redispatch shape as Time-travel.
+  if (!capsCache.forensics) { history.replaceState({}, "", "/overview"); renderRoute(); return; }
+  const v = VIEW(); clear(v);
+  v.append(pageHead("Forensics", el("p", { class: "page-sub", text:
+    "Investigate who changed a row, or what a user, connection, or schema did — reads your source database's performance_schema and audit log directly." })));
+
+  v.append(el("div", { class: "fx-caps", id: "fx-caps" }, el("div", { class: "view-loading", text: "Detecting forensic sources…" })));
+
+  const mode = (params && FX_MODES.some((m) => m.id === params.mode)) ? params.mode : "who_changed";
+  const tabs = el("div", { class: "fx-modes" });
+  FX_MODES.forEach((m) => tabs.append(el("button", {
+    type: "button", class: "fx-mode-tab" + (m.id === mode ? " on" : ""),
+    onclick: () => navigate("forensics", { mode: m.id }, true), text: m.label,
+  })));
+  v.append(tabs);
+  v.append(el("p", { class: "fx-mode-desc", text: (FX_MODES.find((m) => m.id === mode) || FX_MODES[0]).desc }));
+
+  const form = el("form", { class: "filters", id: "fx-form" });
+  if (mode === "who_changed" || mode === "ddl_history") {
+    form.append(fieldSelect("Schema", "schema", "md", true, false, null, "— select —", mode === "who_changed"));
+  }
+  if (mode === "who_changed") {
+    form.append(fieldSelect("Table", "table", "md", false, true, null, null, true));
+    form.append(fieldInput("PK", "pk", "sm", "42 or 42|7"));
+  }
+  if (mode === "user_activity" || mode === "connection_history") {
+    form.append(fieldInput("User", "user", "md", "app_rw", mode === "user_activity"));
+  }
+  if (mode === "connection_history") {
+    form.append(fieldInput("Host", "host", "md", "10.0.1.%"));
+  }
+  form.append(fieldInput("Since", "since", "md", "YYYY-MM-DD HH:MM"));
+  form.append(fieldInput("Until", "until", "md", "YYYY-MM-DD HH:MM"));
+  form.append(fieldSelect("Limit", "limit", "sm", false, false, ["50", "100", "500"], null));
+  form.append(fieldSelect("Order", "order", "sm", false, false, ["DESC", "ASC"], null));
+  const actions = el("div", { class: "filter-actions" });
+  actions.append(el("button", { class: "btn btn-primary", type: "submit", text: "Investigate" }));
+  form.append(actions);
+  v.append(form);
+
+  v.append(el("div", { id: "fx-warnings", class: "warnings" }));
+  const out = el("div", { id: "fx-out" });
+  out.append(el("div", { class: "ev-empty", text: "Set the filters above and run an investigation." }));
+  v.append(out);
+
+  form.addEventListener("submit", (e) => { e.preventDefault(); runForensicsQuery(mode, form); });
+  if (mode === "who_changed" || mode === "ddl_history") { wireSchemaCascade(form); populateSchemas(form); }
+
+  fxLoadCapabilities();
+  viewEnter();
+}
+
+async function fxLoadCapabilities() {
+  const gen = serverGen;
+  const box = $("#fx-caps", VIEW());
+  if (!box) return;
+  try {
+    // api() returns null for an empty-body 200 (a real shape on some other
+    // endpoints, e.g. DELETE) — this endpoint always serializes a full
+    // struct, but build the banner from {} rather than trust that forever.
+    const caps = (await api("/api/forensics/capabilities")) || {};
+    if (gen !== serverGen) return;
+    clear(box);
+    box.append(buildFxCapsBanner(caps));
+  } catch (err) {
+    if (gen !== serverGen) return;
+    clear(box); renderError(box, err);
+  }
+}
+
+function buildFxCapsBanner(caps) {
+  const wrap = el("div", { class: "fx-caps-banner" });
+  if (!caps.source_configured) {
+    wrap.append(el("div", { class: "stg-empty" },
+      el("p", { class: "stg-empty-lead", text: "No source connection configured for this server." }),
+      el("p", { class: "stg-empty-sub", text:
+        "Who-changed still works from the index alone (connection_cache and binlog-only attribution), but user activity, " +
+        "connection history, and DDL history all read the source directly. Add a source connection from Manage servers → Edit to unlock them." })));
+    return wrap;
+  }
+  const ps = caps.performance_schema || {};
+  const al = caps.audit_log || {};
+  const row = el("div", { class: "fx-caps-row" });
+  row.append(el("div", { class: "fx-caps-item" },
+    el("span", { class: "fx-caps-dot" + (ps.enabled ? " on" : "") }),
+    el("span", { class: "fx-caps-label", text: "performance_schema" }),
+    ps.enabled ? el("span", { class: "fx-caps-detail", text: fxPerfSchemaDetail(ps) }) : null));
+  row.append(el("div", { class: "fx-caps-item" },
+    el("span", { class: "fx-caps-dot" + (al.installed ? " on" : "") }),
+    el("span", { class: "fx-caps-label", text: "audit log" }),
+    (al.installed && al.variant) ? el("span", { class: "fx-caps-detail", text: al.variant }) : null));
+  wrap.append(row);
+  if (!ps.enabled && !al.installed) {
+    wrap.append(el("div", { class: "warn-item" }, icon("warn"),
+      el("span", { text: "No forensic sources detected on this server — results fall back to index-only attribution and fallback SQL." })));
+  }
+  if (caps.setup_guide && caps.setup_guide.recommendations && caps.setup_guide.recommendations.length) {
+    wrap.append(buildFxGuide(caps.setup_guide));
+  }
+  return wrap;
+}
+
+function fxPerfSchemaDetail(ps) {
+  const c = ps.consumers || {};
+  return [
+    c.events_statements_history_long ? "history_long" : null,
+    c.events_statements_history ? "history" : null,
+    ps.threads_accessible ? "threads" : null,
+  ].filter(Boolean).join(" + ");
+}
+
+function buildFxGuide(guide) {
+  const panel = el("div", { class: "fx-guide" });
+  const toggle = el("button", { class: "fx-guide-toggle", type: "button" },
+    el("span", { text: "Improve forensics data" }),
+    el("span", { class: "fx-guide-count", text: guide.recommendations.length + " recommendation" + (guide.recommendations.length === 1 ? "" : "s") }),
+    icon("caret", "ev-caret fx-guide-caret"));
+  const content = el("div", { class: "fx-guide-content", hidden: true });
+  content.append(el("p", { class: "stg-empty-sub", text: guide.summary }));
+  guide.recommendations.forEach((rec) => {
+    const card = el("div", { class: "fx-guide-rec" });
+    card.append(el("div", { class: "fx-guide-rec-head" },
+      el("span", { class: "fx-priority fx-priority-" + rec.priority, text: rec.priority }),
+      el("b", { text: rec.title }),
+      el("span", { class: "fx-caps-detail", text: rec.category.replace("_", " ") })));
+    card.append(el("p", { class: "stg-empty-sub", text: rec.description }));
+    if (rec.runtime_sql && rec.runtime_sql.length) {
+      card.append(buildFxCopyBlock("Runtime SQL (temporary, until restart)", rec.runtime_sql.join("\n\n")));
+    }
+    if (rec.mycnf_snippet) {
+      card.append(buildFxCopyBlock("my.cnf (persistent, survives restart)", rec.mycnf_snippet));
+    }
+    content.append(card);
+  });
+  toggle.addEventListener("click", () => {
+    const open = toggle.classList.toggle("on");
+    content.hidden = !open;
+  });
+  panel.append(toggle, content);
+  return panel;
+}
+
+function buildFxCopyBlock(label, text) {
+  const block = el("div", { class: "fx-sql-block" });
+  const copyBtn = el("button", { class: "btn btn-sm btn-ghost", type: "button", text: "Copy" });
+  copyBtn.addEventListener("click", () => navigator.clipboard.writeText(text).then(
+    () => { copyBtn.textContent = "Copied"; setTimeout(() => { copyBtn.textContent = "Copy"; }, 1500); },
+    () => toast("Copy failed.")));
+  block.append(el("div", { class: "fx-sql-block-head" }, el("span", { class: "form-hint", text: label }), copyBtn));
+  block.append(el("pre", { class: "fx-sql", text }));
+  return block;
+}
+
+async function runForensicsQuery(mode, form) {
+  const gen = serverGen;
+  const warns = $("#fx-warnings", VIEW());
+  const out = $("#fx-out", VIEW());
+  if (!out) return;
+  const f = Object.fromEntries(new FormData(form).entries());
+
+  if (mode === "who_changed" && (!f.schema || !f.table)) {
+    clear(warns); renderError(out, "Schema and table are required for who-changed."); return;
+  }
+  if (mode === "user_activity" && !f.user) {
+    clear(warns); renderError(out, "A user is required for user activity."); return;
+  }
+  if (mode === "connection_history" && !f.user && !f.host) {
+    clear(warns); renderError(out, "A user or host is required for connection history."); return;
+  }
+
+  clear(warns);
+  clear(out);
+  out.append(el("div", { class: "view-loading", text: "Investigating…" }));
+
+  try {
+    let data;
+    if (mode === "who_changed") {
+      data = await api("/api/forensics/who-changed", { method: "POST", body: {
+        schema: f.schema, table: f.table, pk: f.pk || undefined,
+        since: f.since || undefined, until: f.until || undefined,
+        limit: f.limit ? Number(f.limit) : undefined, order: f.order || undefined,
+      } });
+    } else {
+      data = await api("/api/forensics/activity", { method: "POST", body: {
+        query_type: mode, user: f.user || undefined, host: f.host || undefined,
+        schema: f.schema || undefined, since: f.since || undefined, until: f.until || undefined,
+        limit: f.limit ? Number(f.limit) : undefined, order: f.order || undefined,
+      } });
+    }
+    if (gen !== serverGen) return;
+    clear(out);
+    if (data.notes && data.notes.length) renderWarnings(warns, data.notes);
+    if (mode === "who_changed") buildWhoChangedTimeline(out, data);
+    else buildActivityTable(out, mode, data);
+    buildFallbackPanel(out, data.fallback_queries);
+  } catch (err) {
+    if (gen !== serverGen) return;
+    clear(out); renderError(out, err);
+  }
+}
+
+function buildWhoChangedTimeline(container, data) {
+  const events = data.events || [];
+  const bar = el("div", { class: "result-bar" });
+  bar.append(el("span", { class: "result-count" },
+    el("b", { text: String(data.total_count != null ? data.total_count : events.length) }), " change(s) found"));
+  if (data.applied_default_window) {
+    bar.append(el("span", { class: "fx-note-inline", text: "showing the last 24 hours (no time range given)" }));
+  }
+  container.append(bar);
+
+  if (!events.length) {
+    container.append(el("div", { class: "ev-empty", text: "No changes found. Try widening the time range or filters." }));
+    return;
+  }
+
+  const list = el("div", { class: "fx-timeline", id: "fx-timeline" });
+  events.forEach((e, i) => {
+    const a = e.attribution;
+    const summary = el("div", { class: "fx-timeline-summary", "data-fx-ev": i, tabindex: "0" },
+      badge(e.event_type),
+      el("span", { class: "ev-time", text: e.timestamp }),
+      el("span", { class: "ev-table", text: e.schema + "." + e.table }),
+      el("span", { class: "ev-pk", text: "PK: " + e.pk_values }),
+      a ? el("span", { class: "fx-who", text: a.user + (a.host ? "@" + a.host : "") })
+        : el("span", { class: "fx-who fx-who-unknown", text: "unattributed" }),
+      icon("caret", "ev-caret"));
+    const detail = el("div", { class: "fx-timeline-detail", hidden: true });
+    let built = false;
+    summary.addEventListener("click", () => {
+      const open = summary.classList.toggle("open");
+      detail.hidden = !open;
+      if (open && !built) { detail.append(buildFxWhoChangedDetail(e)); built = true; }
+    });
+    list.append(el("div", { class: "fx-timeline-item" },
+      el("div", { class: "fx-timeline-marker" }, el("span", { class: "fx-timeline-dot" })),
+      el("div", { class: "fx-timeline-content" }, summary, detail)));
+  });
+  container.append(list);
+}
+
+function buildFxWhoChangedDetail(e) {
+  const wrap = el("div", { class: "fx-detail" });
+  const a = e.attribution;
+  if (a) {
+    wrap.append(healthKV("User", el("span", { class: "kv-v", text: a.user || "—" })));
+    if (a.host) wrap.append(healthKV("Host", el("span", { class: "kv-v", text: a.host })));
+    if (e.connection_id != null) wrap.append(healthKV("Connection ID", el("span", { class: "kv-v", text: String(e.connection_id) })));
+    if (a.client_program) wrap.append(healthKV("Client", el("span", { class: "kv-v", text: a.client_program })));
+    wrap.append(healthKV("Source", el("span", { class: "kv-v", text: a.source })));
+    wrap.append(healthKV("Confidence", el("span", { class: "kv-v", text: a.confidence })));
+    if (a.audit_sql) wrap.append(buildFxCopyBlock("Matching audit-log record", a.audit_sql));
+  } else {
+    wrap.append(el("p", { class: "stg-empty-sub", text: "No forensic attribution available for this event." }));
+  }
+  if (e.query_text) wrap.append(buildFxCopyBlock("Captured statement (ROWS_QUERY / ANNOTATE_ROWS)", e.query_text));
+  return wrap;
+}
+
+function buildActivityTable(container, mode, data) {
+  const rows = (mode === "connection_history" ? data.connections : data.events) || [];
+  const bar = el("div", { class: "result-bar" });
+  bar.append(el("span", { class: "result-count" }, el("b", { text: String(data.count != null ? data.count : rows.length) }), " result(s)"));
+  if (data.source) bar.append(el("span", { class: "chip chip-mon", text: data.source }));
+  container.append(bar);
+  if (data.note) container.append(el("div", { class: "warn-item" }, icon("warn"), el("span", { text: data.note })));
+
+  if (!rows.length) {
+    container.append(el("div", { class: "ev-empty", text: "No results. Try widening the time range or filters." }));
+    return;
+  }
+  const cols = FX_ACTIVITY_COLS[mode] || FX_ACTIVITY_COLS.user_activity;
+  const table = el("table", { class: "fx-table" });
+  const headRow = el("tr");
+  cols.forEach(([, label]) => headRow.append(el("th", { text: label })));
+  const tbody = el("tbody");
+  rows.forEach((r) => {
+    const tr = el("tr");
+    cols.forEach(([key]) => {
+      let v = r[key];
+      if (key === "sql_text" && typeof v === "string" && v.length > 100) v = v.slice(0, 100) + "…";
+      tr.append(el("td", { text: v == null || v === "" ? "—" : String(v) }));
+    });
+    tbody.append(tr);
+  });
+  table.append(el("thead", {}, headRow), tbody);
+  container.append(el("div", { class: "fx-table-wrap" }, table));
+}
+
+function buildFallbackPanel(container, queries) {
+  if (!queries || !queries.length) return;
+  const panel = el("div", { class: "fx-fallback" });
+  panel.append(el("div", { class: "ov-panel-title", text: "Fallback SQL queries" }),
+    el("p", { class: "stg-empty-sub", text: "Run these manually against your source database to investigate further." }));
+  queries.forEach((fq) => panel.append(buildFxCopyBlock(fq.description, fq.sql)));
+  container.append(panel);
 }
 
 // ── Recover ────────────────────────────────────────────────────────────────

--- a/internal/console/assets/index.html
+++ b/internal/console/assets/index.html
@@ -64,6 +64,10 @@
             <span class="ni-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 5v5h5"/><path d="M3.5 10a9 9 0 1 1-.7 4"/><path d="M12 8v4l3 2"/></svg></span>
             <span>Time-travel</span>
           </a>
+          <a class="nav-item" data-route="forensics" href="/forensics" data-capability="forensics">
+            <span class="ni-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="10" cy="10" r="7"/><path d="M15 15l6 6"/></svg></span>
+            <span>Forensics</span>
+          </a>
         </div>
         <div class="nav-group">
           <div class="nav-label">Resolve</div>

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -1315,6 +1315,116 @@ button { font-family: inherit; }
   align-self: flex-start; overflow-x: auto; max-width: 100%;
 }
 
+/* ============================================================
+   Forensics (epic #701) — investigation mode tabs, capability banner,
+   setup guide, who-changed timeline, activity tables, fallback SQL.
+   ============================================================ */
+.fx-caps { margin-bottom: 16px; }
+.fx-caps-banner {
+  border: 1px solid var(--line); border-radius: var(--radius);
+  background: var(--surface-2); padding: 14px 18px;
+}
+.fx-caps-row { display: flex; flex-wrap: wrap; gap: 20px; align-items: center; }
+.fx-caps-item { display: flex; align-items: center; gap: 7px; font-size: 13px; color: var(--ink-2); }
+.fx-caps-label { font-weight: 600; color: var(--ink); }
+.fx-caps-detail { font-family: var(--f-mono); font-size: 11.5px; color: var(--ink-3); }
+.fx-caps-dot {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--ink-4); flex: none;
+}
+.fx-caps-dot.on { background: var(--insert); }
+
+.fx-guide { margin-top: 12px; border-top: 1px dotted var(--line); padding-top: 12px; }
+.fx-guide-toggle {
+  display: flex; align-items: center; gap: 8px; width: 100%;
+  background: none; border: none; padding: 0; cursor: pointer;
+  font-size: 13px; font-weight: 600; color: var(--ink-2); text-align: left;
+}
+.fx-guide-toggle:hover { color: var(--ink); }
+.fx-guide-count {
+  font-family: var(--f-mono); font-size: 11px; font-weight: 500;
+  color: var(--ink-3); background: var(--surface-3);
+  border-radius: 20px; padding: 1px 8px;
+}
+.fx-guide-caret { margin-left: auto; transition: transform .15s var(--ease); }
+.fx-guide-toggle.on .fx-guide-caret { transform: rotate(90deg); }
+.fx-guide-content { margin-top: 12px; display: flex; flex-direction: column; gap: 14px; }
+.fx-guide-rec {
+  border: 1px solid var(--line); border-radius: var(--radius-sm);
+  padding: 12px 14px; background: var(--surface);
+}
+.fx-guide-rec-head { display: flex; align-items: center; gap: 8px; margin-bottom: 4px; }
+.fx-priority {
+  font-family: var(--f-mono); font-size: 10px; font-weight: 600;
+  letter-spacing: 0.05em; text-transform: uppercase;
+  padding: 2px 7px; border-radius: 5px; border: 1px solid currentColor;
+}
+.fx-priority-high { color: var(--delete); background: var(--delete-bg); }
+.fx-priority-medium { color: var(--orange-2); background: var(--orange-bg); }
+.fx-priority-low { color: var(--ink-3); background: var(--surface-2); }
+
+.fx-sql-block { margin-top: 8px; }
+.fx-sql-block-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 4px; }
+.fx-sql-block-head .form-hint { margin: 0; }
+.fx-sql {
+  font-family: var(--f-mono); font-size: 11.5px; color: var(--ink-2);
+  background: var(--surface-3); border-radius: 4px; padding: 9px 11px;
+  overflow-x: auto; white-space: pre-wrap; word-break: break-word; margin: 0;
+}
+
+.fx-modes { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 6px; }
+.fx-mode-tab {
+  display: inline-flex; align-items: center; gap: 6px;
+  height: 34px; padding: 0 14px; font-size: 13px; font-weight: 600;
+  color: var(--ink-2); background: var(--surface); cursor: pointer;
+  border: 1px solid var(--line); border-radius: 999px;
+}
+.fx-mode-tab:hover { border-color: var(--ink-4); color: var(--ink); }
+.fx-mode-tab.on { color: var(--accent); border-color: var(--accent); background: var(--accent-bg); }
+.fx-mode-desc { color: var(--ink-3); font-size: 12.5px; margin: 0 0 16px; }
+
+.fx-note-inline { font-size: 12.5px; color: var(--ink-3); }
+
+.fx-timeline { display: flex; flex-direction: column; }
+.fx-timeline-item { display: flex; gap: 12px; }
+.fx-timeline-marker { display: flex; flex-direction: column; align-items: center; width: 10px; flex: none; }
+.fx-timeline-dot {
+  width: 9px; height: 9px; border-radius: 50%; background: var(--accent);
+  margin-top: 14px; flex: none;
+}
+.fx-timeline-item:not(:last-child) .fx-timeline-marker::after {
+  content: ""; flex: 1; width: 1px; background: var(--line); margin-top: 4px;
+}
+.fx-timeline-content { flex: 1; min-width: 0; padding-bottom: 14px; }
+.fx-timeline-summary {
+  display: flex; align-items: center; gap: 12px; cursor: pointer;
+  padding: 10px 12px; border: 1px solid var(--line); border-radius: var(--radius-sm);
+  background: var(--surface);
+}
+.fx-timeline-summary:hover { border-color: var(--ink-4); }
+.fx-timeline-summary .ev-caret { margin-left: auto; transition: transform .15s var(--ease); }
+.fx-timeline-summary.open .ev-caret { transform: rotate(90deg); }
+.fx-who { font-size: 13px; color: var(--ink); }
+.fx-who-unknown { color: var(--ink-4); font-style: italic; }
+.fx-timeline-detail { padding: 12px 14px 4px; }
+.fx-detail { display: flex; flex-direction: column; }
+
+.fx-table-wrap { width: 100%; overflow-x: auto; }
+.fx-table { width: 100%; border-collapse: collapse; font-size: 13px; }
+.fx-table th {
+  text-align: left; font-size: 11px; font-weight: 600; letter-spacing: 0.04em;
+  text-transform: uppercase; color: var(--ink-3); padding: 8px 10px;
+  border-bottom: 1px solid var(--line); white-space: nowrap;
+}
+.fx-table td {
+  padding: 9px 10px; border-bottom: 1px solid var(--line-soft);
+  font-family: var(--f-mono); font-size: 12.5px; color: var(--ink);
+  max-width: 340px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.fx-table tr:last-child td { border-bottom: none; }
+
+.fx-fallback { margin-top: 20px; border-top: 1px dotted var(--line); padding-top: 16px; }
+
 .srv-note {
   margin-top: 6px; padding: 0 2px;
   font-size: 11px; line-height: 1.45; color: var(--ink-3);

--- a/internal/console/console_integration_test.go
+++ b/internal/console/console_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -65,8 +66,11 @@ func TestIntegrationEventsAPI(t *testing.T) {
 	if rec.Code != 200 {
 		t.Fatalf("events code = %d, body = %s", rec.Code, body)
 	}
-	if strings.Contains(string(body), "connection_id") {
-		t.Errorf("events response must not contain connection_id: %s", body)
+	// #701 D1: connection_id is no longer a redacted field on the events API —
+	// the entitlement seam moved to forensics.Enabled, checked at surface entry
+	// points, not per-field here.
+	if !strings.Contains(string(body), "connection_id") {
+		t.Errorf("events response must contain connection_id (#701 D1): %s", body)
 	}
 	var resp eventsResponse
 	if err := json.Unmarshal(body, &resp); err != nil {
@@ -74,6 +78,60 @@ func TestIntegrationEventsAPI(t *testing.T) {
 	}
 	if resp.Count != 2 {
 		t.Errorf("event count = %d, want 2", resp.Count)
+	}
+}
+
+// TestIntegrationForensicsCapabilitiesAndUsers_realSource drives GET
+// /api/forensics/capabilities and /api/forensics/users against a server whose
+// SourceDSN points at the real test MySQL — the "source configured and
+// reachable" success path forensics_api_test.go's sqlmock-based tests can't
+// reach (config.Connect opens a real DSN, not an injectable seam). Without
+// this, breaking openForensicsSource so it always reports "not configured"
+// would pass every existing test.
+func TestIntegrationForensicsCapabilitiesAndUsers_realSource(t *testing.T) {
+	srv, _ := seedConsoleData(t)
+	_, idxDBName := testutil.CreateTestDB(t)
+
+	rec, body := doReq(t, srv, "POST", "/api/servers", `{
+		"name":"fx-src",
+		"host":"127.0.0.1","port":"13306","user":"root","password":"testroot","dbname":"`+idxDBName+`",
+		"source_host":"127.0.0.1","source_port":"13306","source_user":"root","source_password":"testroot"
+	}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create server: status = %d, body = %s", rec.Code, body)
+	}
+	var created struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(body, &created); err != nil {
+		t.Fatal(err)
+	}
+
+	rec, body = doReqOn(t, srv, created.ID, "GET", "/api/forensics/capabilities", "")
+	if rec.Code != 200 {
+		t.Fatalf("capabilities: status = %d, body = %s", rec.Code, body)
+	}
+	var caps forensicsCapabilitiesResponse
+	if err := json.Unmarshal(body, &caps); err != nil {
+		t.Fatal(err)
+	}
+	if !caps.SourceConfigured {
+		t.Errorf("source_configured should be true for a server with a real, reachable source: %s", body)
+	}
+	if caps.ServerInfo.Version == "" {
+		t.Errorf("expected a real server_info.version detected from a live MySQL connection: %s", body)
+	}
+
+	rec, body = doReqOn(t, srv, created.ID, "GET", "/api/forensics/users", "")
+	if rec.Code != 200 {
+		t.Fatalf("users: status = %d, body = %s", rec.Code, body)
+	}
+	var usersResp forensicsUsersResponse
+	if err := json.Unmarshal(body, &usersResp); err != nil {
+		t.Fatal(err)
+	}
+	if len(usersResp.Users) == 0 {
+		t.Errorf("expected at least one real MySQL user account (root) from mysql.user: %s", body)
 	}
 }
 

--- a/internal/console/console_integration_test.go
+++ b/internal/console/console_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/dbtrail/dbtrail/internal/forensics"
 	"github.com/dbtrail/dbtrail/internal/query"
 	"github.com/dbtrail/dbtrail/internal/recovery"
 	"github.com/dbtrail/dbtrail/internal/testutil"
@@ -132,6 +133,61 @@ func TestIntegrationForensicsCapabilitiesAndUsers_realSource(t *testing.T) {
 	}
 	if len(usersResp.Users) == 0 {
 		t.Errorf("expected at least one real MySQL user account (root) from mysql.user: %s", body)
+	}
+}
+
+// TestIntegrationForensicsWhoChanged_UnreachableSource covers who-changed's
+// "configured but unreachable" behavior specifically — resolveOr and
+// openForensicsSource both key off the SAME selected server, so unlike the
+// other three forensics handlers (whose sqlmock unit tests can freely mix a
+// fake index with a fake source entry — see
+// TestForensicsHandlers_SourceConfiguredButUnreachable in
+// forensics_api_test.go) this needs a REAL, working index paired with a
+// genuinely unreachable source on the one registry entry. Without this, a
+// regression that silently swallowed the unreachable-source note (or dropped
+// back to erroring instead of degrading) would pass every sqlmock test.
+func TestIntegrationForensicsWhoChanged_UnreachableSource(t *testing.T) {
+	srv, _ := seedConsoleData(t)
+	idxDB, idxDBName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, idxDB)
+	testutil.InsertEvent(t, idxDB, "bin.000001", 4, 40, "2026-06-01 12:00:00", nil,
+		"app", "users", 2 /*UPDATE*/, "1", nil, nil, []byte(`{"id":1,"name":"alicia"}`))
+
+	rec, body := doReq(t, srv, "POST", "/api/servers", `{
+		"name":"fx-dead-src",
+		"host":"127.0.0.1","port":"13306","user":"root","password":"testroot","dbname":"`+idxDBName+`",
+		"source_host":"127.0.0.1","source_port":"1","source_user":"root","source_password":"testroot"
+	}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create server: status = %d, body = %s", rec.Code, body)
+	}
+	var created struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(body, &created); err != nil {
+		t.Fatal(err)
+	}
+
+	rec, body = doReqOn(t, srv, created.ID, "POST", "/api/forensics/who-changed",
+		`{"schema":"app","table":"users","since":"2000-01-01 00:00:00"}`)
+	if rec.Code != 200 {
+		t.Fatalf("who-changed: status = %d, want 200 (unreachable source degrades, it doesn't error): %s", rec.Code, body)
+	}
+	var res forensics.WhoChangedResult
+	if err := json.Unmarshal(body, &res); err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Events) != 1 {
+		t.Fatalf("expected the one seeded event from the real index, got %d: %s", len(res.Events), body)
+	}
+	found := false
+	for _, n := range res.Notes {
+		if strings.Contains(n, "could not be reached") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("Notes should record the unreachable source, got: %v", res.Notes)
 	}
 }
 

--- a/internal/console/dto.go
+++ b/internal/console/dto.go
@@ -13,15 +13,18 @@ const consoleTSFormat = "2006-01-02 15:04:05"
 // eventDTO is the JSON-serialisable view of a query.ResultRow exposed by the
 // console's read-only API.
 //
-// It deliberately OMITS connection_id, query_text, and query_hash. Those
-// fields — the MySQL pseudo_thread_id of the transaction that produced the
-// change, and the originating SQL statement + its STATEMENT_DIGEST (#699) —
-// are actor/statement-attribution data and belong to the paid "forensics"
-// surface (who-changed / what-statement / audit), not the free
-// "query_explorer" surface this console exposes. The omission is the entire
-// open-core boundary for the events API: query.ResultRow carries those fields,
-// the package's own jsonRow serialises them, but this DTO drops them on the
-// way out. Do not add them here without crossing the licensing line.
+// connection_id is INCLUDED (epic #701 decision D1): the scattered
+// per-field redaction that used to hide it here is retired in favor of a
+// single entitlement seam, internal/forensics.Enabled, checked at surface
+// entry points (this console's forensics_api.go among them). dbtrail OSS
+// ships forensics enabled today, so the general events surface carries the
+// same session-identity field the forensics surface does — there is no
+// separate "free" events view to protect it from anymore.
+//
+// query_text and query_hash remain OMITTED. That is a distinct, still-live
+// boundary (#699, "what statement produced this row") that this epic does
+// NOT touch — this DTO has simply never grown a consumer for statement text.
+// Do not add them here without a surface that actually reads them.
 type eventDTO struct {
 	EventID        uint64         `json:"event_id"`
 	BinlogFile     string         `json:"binlog_file"`
@@ -29,6 +32,7 @@ type eventDTO struct {
 	EndPos         uint64         `json:"end_pos"`
 	EventTimestamp string         `json:"event_timestamp"`
 	GTID           *string        `json:"gtid"`
+	ConnectionID   *uint32        `json:"connection_id"`
 	SchemaName     string         `json:"schema_name"`
 	TableName      string         `json:"table_name"`
 	EventType      string         `json:"event_type"`
@@ -38,9 +42,9 @@ type eventDTO struct {
 	RowAfter       map[string]any `json:"row_after"`
 }
 
-// toEventDTO maps a query.ResultRow to the redacted wire view, dropping
-// connection_id/query_text/query_hash and stringifying the event type and
-// timestamp.
+// toEventDTO maps a query.ResultRow to the wire view: connection_id now
+// passes through (#701 D1); query_text/query_hash are still dropped (#699);
+// the event type and timestamp are stringified.
 func toEventDTO(r query.ResultRow) eventDTO {
 	return eventDTO{
 		EventID:        r.EventID,
@@ -49,6 +53,7 @@ func toEventDTO(r query.ResultRow) eventDTO {
 		EndPos:         r.EndPos,
 		EventTimestamp: r.EventTimestamp.Format(consoleTSFormat),
 		GTID:           r.GTID,
+		ConnectionID:   r.ConnectionID,
 		SchemaName:     r.SchemaName,
 		TableName:      r.TableName,
 		EventType:      eventTypeName(r.EventType),

--- a/internal/console/dto_test.go
+++ b/internal/console/dto_test.go
@@ -12,10 +12,12 @@ import (
 	"github.com/dbtrail/dbtrail/internal/query"
 )
 
-// TestEventDTOOmitsConnectionID is the load-bearing open-core test: the events
-// API must never expose connection_id (actor attribution = paid forensics),
-// nor query_text/query_hash (statement attribution = paid forensics, #699).
-func TestEventDTOOmitsConnectionID(t *testing.T) {
+// TestEventDTOIncludesConnectionID is the load-bearing open-core test,
+// updated for epic #701 decision D1: the events API now exposes connection_id
+// (the entitlement seam moved to internal/forensics.Enabled, checked at
+// surface entry points) but still omits query_text/query_hash — a distinct,
+// still-live boundary (#699) this epic does not touch.
+func TestEventDTOIncludesConnectionID(t *testing.T) {
 	cid := uint32(98765)
 	gtid := "uuid:1-10"
 	qText := "UPDATE users SET email='b@x' WHERE id=42"
@@ -42,13 +44,14 @@ func TestEventDTOOmitsConnectionID(t *testing.T) {
 	}
 	js := string(b)
 
-	// …but must NOT cross into the redacted wire view.
-	if strings.Contains(js, "connection_id") {
-		t.Errorf("eventDTO JSON must not contain connection_id key: %s", js)
+	// …and now crosses into the wire view.
+	if !strings.Contains(js, "connection_id") {
+		t.Errorf("eventDTO JSON must contain the connection_id key: %s", js)
 	}
-	if strings.Contains(js, "98765") {
-		t.Errorf("eventDTO JSON must not leak the connection id value: %s", js)
+	if !strings.Contains(js, "98765") {
+		t.Errorf("eventDTO JSON must carry the connection id value: %s", js)
 	}
+	// …but query_text/query_hash (#699) still must not.
 	if strings.Contains(js, "query_text") || strings.Contains(js, "query_hash") {
 		t.Errorf("eventDTO JSON must not contain query_text/query_hash keys: %s", js)
 	}
@@ -58,7 +61,7 @@ func TestEventDTOOmitsConnectionID(t *testing.T) {
 
 	for _, want := range []string{
 		"event_id", "schema_name", "table_name", "event_type",
-		"pk_values", "changed_columns", "row_before", "row_after", "gtid",
+		"pk_values", "changed_columns", "row_before", "row_after", "gtid", "connection_id",
 	} {
 		if !strings.Contains(js, want) {
 			t.Errorf("eventDTO JSON missing expected field %q: %s", want, js)
@@ -71,6 +74,9 @@ func TestEventDTOOmitsConnectionID(t *testing.T) {
 	}
 	if dto.EventTimestamp != "2026-01-02 03:04:05" {
 		t.Errorf("EventTimestamp = %q, want 2026-01-02 03:04:05", dto.EventTimestamp)
+	}
+	if dto.ConnectionID == nil || *dto.ConnectionID != cid {
+		t.Errorf("ConnectionID = %v, want %d", dto.ConnectionID, cid)
 	}
 }
 
@@ -100,6 +106,8 @@ func TestToEventDTOsNonNil(t *testing.T) {
 // may expose. A new field added to eventDTO (or a future sensitive field on
 // query.ResultRow copied through toEventDTO) fails this test until the allowlist
 // is consciously updated — catching a leak that name-specific checks would miss.
+// connection_id is on the allowlist (#701 D1); query_text/query_hash are not
+// (#699, untouched by this epic).
 func TestEventDTOFieldAllowlist(t *testing.T) {
 	cid := uint32(1)
 	gtid := "g:1"
@@ -125,7 +133,7 @@ func TestEventDTOFieldAllowlist(t *testing.T) {
 	sort.Strings(got)
 
 	want := []string{
-		"binlog_file", "changed_columns", "end_pos", "event_id",
+		"binlog_file", "changed_columns", "connection_id", "end_pos", "event_id",
 		"event_timestamp", "event_type", "gtid", "pk_values",
 		"row_after", "row_before", "schema_name", "start_pos", "table_name",
 	}

--- a/internal/console/forensics_api.go
+++ b/internal/console/forensics_api.go
@@ -87,26 +87,32 @@ func (s *Server) forensicsRefused(w http.ResponseWriter) bool {
 	return false
 }
 
+// errSourceNotConfigured is openForensicsSource's sentinel for "this server
+// has no source connection set up at all" — distinct from any other error
+// (which means a source IS configured but couldn't be reached: a genuine
+// misconfiguration or outage the caller must surface, not silently relabel
+// as "not configured"). Conflating the two used to leave an operator staring
+// at "add a source connection" for a server that already has one. Encoding
+// this as the error itself (rather than a separate bool alongside err) makes
+// the fourth, illegal combination — "not configured" AND "some other error"
+// — unrepresentable, instead of relying on every call site to check them in
+// the right order.
+var errSourceNotConfigured = errors.New("no source connection configured")
+
 // openForensicsSource opens the selected server's source connection for the
 // forensic data-source queries (performance_schema, audit log, mysql.user).
-//
-// It distinguishes "no source configured" (configured=false, err=nil — the
-// caller renders a setup prompt, same as before this DSN was ever typed) from
-// "a source IS configured but can't be reached" (configured=true, err set —
-// a genuine misconfiguration or outage the caller must surface, not silently
-// relabel as "not configured"). Conflating the two used to leave an operator
-// staring at "add a source connection" for a server that already has one.
-// The returned db must be closed by the caller when err is nil and
-// configured is true.
-func (s *Server) openForensicsSource(r *http.Request) (db *sql.DB, host string, configured bool, err error) {
+// Callers distinguish the three outcomes with errors.Is(err, errSourceNotConfigured)
+// then a plain err != nil check. The returned db must be closed by the
+// caller whenever err is nil.
+func (s *Server) openForensicsSource(r *http.Request) (db *sql.DB, host string, err error) {
 	e, found := s.selectedEntry(r)
 	if !found || e.SourceDSN == "" {
-		return nil, "", false, nil
+		return nil, "", errSourceNotConfigured
 	}
 	db, cerr := config.Connect(e.SourceDSN)
 	if cerr != nil {
 		slog.Warn("forensics: source connect failed", "server", e.Name, "error", cerr)
-		return nil, "", true, errors.New(scrubDSNError(cerr, e.SourceDSN))
+		return nil, "", errors.New(scrubDSNError(cerr, e.SourceDSN))
 	}
 	// A DSN shape Connect accepts but ParseSourceDSN rejects (e.g. a
 	// unix-socket source) just loses SourceHost — degrading the RDS/Aurora
@@ -117,7 +123,7 @@ func (s *Server) openForensicsSource(r *http.Request) (db *sql.DB, host string, 
 	if perr != nil {
 		slog.Warn("forensics: could not derive source host for RDS/Aurora audit-log discovery", "server", e.Name, "error", perr)
 	}
-	return db, host, true, nil
+	return db, host, nil
 }
 
 // handleForensicsCapabilities serves GET /api/forensics/capabilities:
@@ -133,8 +139,8 @@ func (s *Server) handleForensicsCapabilities(w http.ResponseWriter, r *http.Requ
 	if s.forensicsRefused(w) {
 		return
 	}
-	sourceDB, _, configured, err := s.openForensicsSource(r)
-	if !configured {
+	sourceDB, _, err := s.openForensicsSource(r)
+	if errors.Is(err, errSourceNotConfigured) {
 		writeJSON(w, http.StatusOK, forensicsCapabilitiesResponse{})
 		return
 	}
@@ -165,8 +171,8 @@ func (s *Server) handleForensicsUsers(w http.ResponseWriter, r *http.Request) {
 	if s.forensicsRefused(w) {
 		return
 	}
-	sourceDB, _, configured, err := s.openForensicsSource(r)
-	if !configured {
+	sourceDB, _, err := s.openForensicsSource(r)
+	if errors.Is(err, errSourceNotConfigured) {
 		writeJSON(w, http.StatusOK, forensicsUsersResponse{Users: []string{}})
 		return
 	}
@@ -227,21 +233,23 @@ func (s *Server) handleForensicsWhoChanged(w http.ResponseWriter, r *http.Reques
 		return rows, ferr
 	}
 	var sourceUnreachable string
-	if sourceDB, host, configured, serr := s.openForensicsSource(r); configured {
-		if serr != nil {
-			// Degrade, per the library's own "degradation is an answer"
-			// design (deps.SourceDB stays nil, same as index-only mode) —
-			// but say so, exactly like DetectCapabilities' own unreachable-
-			// source note would have, so this doesn't read as a silent
-			// downgrade to a worse attribution tier.
-			sourceUnreachable = "This server's source connection is configured but could not be reached, " +
-				"so the audit-log, GTID, and performance_schema attribution tiers were not consulted; " +
-				"only index-side sources ran."
-		} else {
-			defer sourceDB.Close()
-			deps.SourceDB = sourceDB
-			deps.SourceHost = host
-		}
+	switch sourceDB, host, serr := s.openForensicsSource(r); {
+	case errors.Is(serr, errSourceNotConfigured):
+		// No source at all — same as always, deps.SourceDB stays nil and
+		// WhoChanged runs index-only tiers with no note (nothing changed).
+	case serr != nil:
+		// Degrade, per the library's own "degradation is an answer" design
+		// (deps.SourceDB stays nil, same as index-only mode) — but say so,
+		// exactly like DetectCapabilities' own unreachable-source note
+		// would have, so this doesn't read as a silent downgrade to a
+		// worse attribution tier.
+		sourceUnreachable = "This server's source connection is configured but could not be reached, " +
+			"so the audit-log, GTID, and performance_schema attribution tiers were not consulted; " +
+			"only index-side sources ran."
+	default:
+		defer sourceDB.Close()
+		deps.SourceDB = sourceDB
+		deps.SourceHost = host
 	}
 
 	res, err := forensics.WhoChanged(r.Context(), deps, forensics.WhoChangedParams{
@@ -301,8 +309,8 @@ func (s *Server) handleForensicsActivity(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	sourceDB, _, configured, err := s.openForensicsSource(r)
-	if !configured {
+	sourceDB, _, err := s.openForensicsSource(r)
+	if errors.Is(err, errSourceNotConfigured) {
 		writeJSONError(w, http.StatusBadRequest,
 			"this server has no source connection configured; set the source connection first")
 		return
@@ -324,7 +332,14 @@ func (s *Server) handleForensicsActivity(w http.ResponseWriter, r *http.Request)
 		Order:  body.Order,
 	})
 	if err != nil {
-		writeJSONError(w, http.StatusBadRequest, err.Error())
+		// By this point query_type/user/host preconditions are already
+		// validated above and forensics.Activity re-checks nothing new — any
+		// error here is a genuine query failure against a source that DID
+		// connect (e.g. missing performance_schema/mysql.user grants), never
+		// a client mistake. A bare 400 would tell an operator their filters
+		// are wrong when the real problem is server-side; match the other
+		// three forensics handlers' precedent (502/writeFetchError) instead.
+		writeJSONError(w, http.StatusBadGateway, "could not run the forensic query: "+err.Error())
 		return
 	}
 	writeJSON(w, http.StatusOK, res)

--- a/internal/console/forensics_api.go
+++ b/internal/console/forensics_api.go
@@ -1,0 +1,331 @@
+package console
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/cliutil"
+	"github.com/dbtrail/dbtrail/internal/config"
+	"github.com/dbtrail/dbtrail/internal/forensics"
+	"github.com/dbtrail/dbtrail/internal/query"
+)
+
+// whoChangedDefaultLimit/whoChangedMaxLimit bound POST /api/forensics/who-changed's
+// limit. Every other console surface bounds its top end (events'
+// eventsMaxLimit, activity queries at 1000 inside the forensics library
+// itself); forensics.WhoChangedParams only floors an unset limit (mirrored
+// here as the default, since that unexported constant isn't reachable from
+// this package), so the handler must clamp the ceiling itself.
+const (
+	whoChangedDefaultLimit = 100
+	whoChangedMaxLimit     = 1000
+)
+
+// forensicsCapabilitiesResponse flattens forensics.Capabilities (embedding
+// promotes performance_schema/audit_log/server_info to top-level JSON keys,
+// matching the SaaS wire contract) and adds the tailored setup guide plus
+// whether the selected server even has a source connection to detect against.
+type forensicsCapabilitiesResponse struct {
+	forensics.Capabilities
+	SetupGuide       *forensics.SetupGuide `json:"setup_guide,omitempty"`
+	SourceConfigured bool                  `json:"source_configured"`
+}
+
+// forensicsUsersResponse is the wire view for GET /api/forensics/users — a
+// MySQL user list for filter dropdowns.
+type forensicsUsersResponse struct {
+	Users []string `json:"users"`
+}
+
+// whoChangedRequest is the JSON body accepted by POST /api/forensics/who-changed.
+type whoChangedRequest struct {
+	Schema string `json:"schema"`
+	Table  string `json:"table"`
+	PK     string `json:"pk"`
+	Since  string `json:"since"`
+	Until  string `json:"until"`
+	Limit  int    `json:"limit"`
+	Order  string `json:"order"`
+}
+
+// forensicsActivityRequest is the JSON body accepted by POST
+// /api/forensics/activity. QueryType selects one of forensics'
+// QueryUserActivity/QueryConnectionHistory/QueryDDLHistory.
+type forensicsActivityRequest struct {
+	QueryType string `json:"query_type"`
+	User      string `json:"user"`
+	Host      string `json:"host"`
+	Schema    string `json:"schema"`
+	Since     string `json:"since"`
+	Until     string `json:"until"`
+	Limit     int    `json:"limit"`
+	Order     string `json:"order"`
+}
+
+// forensicsRefused checks the two gates every forensics endpoint shares —
+// the entitlement seam (epic #701 D1) and the RBAC-profile refusal #708
+// specifies for v1 (forensic output includes unredacted SQL text and session
+// identity, which the redaction pipeline does not yet cover, matching the
+// Verify/recover-cascade precedent) — writing the error response and
+// reporting true when the caller must stop.
+func (s *Server) forensicsRefused(w http.ResponseWriter) bool {
+	if !forensics.Enabled() {
+		writeJSONError(w, http.StatusForbidden, "forensics is not enabled in this build")
+		return true
+	}
+	if s.rbacActive() {
+		writeJSONError(w, http.StatusForbidden,
+			"forensics isn't available while an access-control profile is active — forensic output includes unredacted SQL text and session identity")
+		return true
+	}
+	return false
+}
+
+// openForensicsSource opens the selected server's source connection for the
+// forensic data-source queries (performance_schema, audit log, mysql.user).
+//
+// It distinguishes "no source configured" (configured=false, err=nil — the
+// caller renders a setup prompt, same as before this DSN was ever typed) from
+// "a source IS configured but can't be reached" (configured=true, err set —
+// a genuine misconfiguration or outage the caller must surface, not silently
+// relabel as "not configured"). Conflating the two used to leave an operator
+// staring at "add a source connection" for a server that already has one.
+// The returned db must be closed by the caller when err is nil and
+// configured is true.
+func (s *Server) openForensicsSource(r *http.Request) (db *sql.DB, host string, configured bool, err error) {
+	e, found := s.selectedEntry(r)
+	if !found || e.SourceDSN == "" {
+		return nil, "", false, nil
+	}
+	db, cerr := config.Connect(e.SourceDSN)
+	if cerr != nil {
+		slog.Warn("forensics: source connect failed", "server", e.Name, "error", cerr)
+		return nil, "", true, errors.New(scrubDSNError(cerr, e.SourceDSN))
+	}
+	// A DSN shape Connect accepts but ParseSourceDSN rejects (e.g. a
+	// unix-socket source) just loses SourceHost — degrading the RDS/Aurora
+	// audit-log-over-file-API tier per WhoChangedDeps' own doc comment — not
+	// the connection itself; log it so that degradation is diagnosable rather
+	// than silently invisible.
+	host, _, _, _, perr := config.ParseSourceDSN(e.SourceDSN)
+	if perr != nil {
+		slog.Warn("forensics: could not derive source host for RDS/Aurora audit-log discovery", "server", e.Name, "error", perr)
+	}
+	return db, host, true, nil
+}
+
+// handleForensicsCapabilities serves GET /api/forensics/capabilities:
+// detected forensic data sources (performance_schema, audit log) for the
+// selected server, plus tailored setup guidance. SourceConfigured=false
+// (rather than an error) when the server has no source connection set up —
+// the frontend renders that as a setup prompt, not a failure. A source that
+// IS configured but unreachable is a different, genuine failure (bad
+// credentials, network outage) and gets a 502, matching resolveOr's
+// precedent for "a server whose connection cannot be established" — it must
+// not read as "you never set this up."
+func (s *Server) handleForensicsCapabilities(w http.ResponseWriter, r *http.Request) {
+	if s.forensicsRefused(w) {
+		return
+	}
+	sourceDB, _, configured, err := s.openForensicsSource(r)
+	if !configured {
+		writeJSON(w, http.StatusOK, forensicsCapabilitiesResponse{})
+		return
+	}
+	if err != nil {
+		writeJSONError(w, http.StatusBadGateway, "could not reach this server's source connection: "+err.Error())
+		return
+	}
+	defer sourceDB.Close()
+
+	caps, err := forensics.DetectCapabilities(r.Context(), sourceDB)
+	if err != nil {
+		writeJSONError(w, http.StatusBadGateway, "could not detect forensic capabilities: "+err.Error())
+		return
+	}
+	guide := forensics.BuildSetupGuide(caps)
+	writeJSON(w, http.StatusOK, forensicsCapabilitiesResponse{
+		Capabilities:     caps,
+		SetupGuide:       &guide,
+		SourceConfigured: true,
+	})
+}
+
+// handleForensicsUsers serves GET /api/forensics/users: known MySQL user
+// accounts for the selected server, for filter dropdowns. An empty list
+// (never an error) when no source is configured; a configured-but-unreachable
+// source is a 502, same distinction as handleForensicsCapabilities.
+func (s *Server) handleForensicsUsers(w http.ResponseWriter, r *http.Request) {
+	if s.forensicsRefused(w) {
+		return
+	}
+	sourceDB, _, configured, err := s.openForensicsSource(r)
+	if !configured {
+		writeJSON(w, http.StatusOK, forensicsUsersResponse{Users: []string{}})
+		return
+	}
+	if err != nil {
+		writeJSONError(w, http.StatusBadGateway, "could not reach this server's source connection: "+err.Error())
+		return
+	}
+	defer sourceDB.Close()
+
+	users, err := forensics.ListUsers(r.Context(), sourceDB)
+	if err != nil {
+		writeJSONError(w, http.StatusBadGateway, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, forensicsUsersResponse{Users: users})
+}
+
+// handleForensicsWhoChanged serves POST /api/forensics/who-changed: attributes
+// indexed binlog events for a table (optionally one row) to the database
+// sessions that produced them. Always resolves — a missing/unreachable source
+// degrades the attribution tiers rather than failing the request; only bad
+// parameters or the underlying index fetch can error.
+func (s *Server) handleForensicsWhoChanged(w http.ResponseWriter, r *http.Request) {
+	if s.forensicsRefused(w) {
+		return
+	}
+	b := s.resolveOr(w, r)
+	if b == nil {
+		return
+	}
+	var body whoChangedRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil && !errors.Is(err, io.EOF) {
+		writeJSONError(w, http.StatusBadRequest, "malformed request body: "+err.Error())
+		return
+	}
+	if body.Schema == "" || body.Table == "" {
+		writeJSONError(w, http.StatusBadRequest, "schema and table are required")
+		return
+	}
+	since, err := cliutil.ParseTime(body.Since)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid since: "+err.Error())
+		return
+	}
+	until, err := cliutil.ParseTime(body.Until)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid until: "+err.Error())
+		return
+	}
+
+	deps := forensics.WhoChangedDeps{IndexDB: b.db}
+	var gapHours []time.Time
+	deps.Fetch = func(ctx context.Context, opts query.Options) ([]query.ResultRow, error) {
+		rows, plan, ferr := s.fetch(ctx, b, opts)
+		if plan != nil {
+			gapHours = plan.GapHours
+		}
+		return rows, ferr
+	}
+	var sourceUnreachable string
+	if sourceDB, host, configured, serr := s.openForensicsSource(r); configured {
+		if serr != nil {
+			// Degrade, per the library's own "degradation is an answer"
+			// design (deps.SourceDB stays nil, same as index-only mode) —
+			// but say so, exactly like DetectCapabilities' own unreachable-
+			// source note would have, so this doesn't read as a silent
+			// downgrade to a worse attribution tier.
+			sourceUnreachable = "This server's source connection is configured but could not be reached, " +
+				"so the audit-log, GTID, and performance_schema attribution tiers were not consulted; " +
+				"only index-side sources ran."
+		} else {
+			defer sourceDB.Close()
+			deps.SourceDB = sourceDB
+			deps.SourceHost = host
+		}
+	}
+
+	res, err := forensics.WhoChanged(r.Context(), deps, forensics.WhoChangedParams{
+		Schema: body.Schema,
+		Table:  body.Table,
+		PK:     body.PK,
+		Since:  since,
+		Until:  until,
+		Limit:  clampLimit(body.Limit, whoChangedDefaultLimit, whoChangedMaxLimit),
+		Order:  body.Order,
+	})
+	if err != nil {
+		// By this point schema/table/deps.Fetch are all set, so the only
+		// realistic error WhoChanged returns is its wrapped index-fetch
+		// failure — route it through the same classifier handleEvents uses
+		// (writeFetchError) so a pre-connection_id-column index gets the
+		// same actionable 422 migration guidance instead of a bare 400.
+		writeFetchError(w, err)
+		return
+	}
+	if sourceUnreachable != "" {
+		res.Notes = append(res.Notes, sourceUnreachable)
+	}
+	if len(gapHours) > 0 {
+		res.Notes = append(res.Notes, "Index coverage warning: "+query.FormatGapWarning(gapHours))
+	}
+	writeJSON(w, http.StatusOK, res)
+}
+
+// handleForensicsActivity serves POST /api/forensics/activity: the three
+// general investigation modes (user_activity / connection_history /
+// ddl_history) against the selected server's performance_schema. Unlike
+// who-changed, these modes have no index-side fallback — they require a
+// configured source connection.
+func (s *Server) handleForensicsActivity(w http.ResponseWriter, r *http.Request) {
+	if s.forensicsRefused(w) {
+		return
+	}
+	var body forensicsActivityRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil && !errors.Is(err, io.EOF) {
+		writeJSONError(w, http.StatusBadRequest, "malformed request body: "+err.Error())
+		return
+	}
+	switch body.QueryType {
+	case forensics.QueryUserActivity, forensics.QueryConnectionHistory, forensics.QueryDDLHistory:
+	default:
+		writeJSONError(w, http.StatusBadRequest,
+			"query_type must be one of user_activity, connection_history, ddl_history")
+		return
+	}
+	if body.QueryType == forensics.QueryUserActivity && body.User == "" {
+		writeJSONError(w, http.StatusBadRequest, "user_activity requires a user")
+		return
+	}
+	if body.QueryType == forensics.QueryConnectionHistory && body.User == "" && body.Host == "" {
+		writeJSONError(w, http.StatusBadRequest, "connection_history requires a user or host")
+		return
+	}
+
+	sourceDB, _, configured, err := s.openForensicsSource(r)
+	if !configured {
+		writeJSONError(w, http.StatusBadRequest,
+			"this server has no source connection configured; set the source connection first")
+		return
+	}
+	if err != nil {
+		writeJSONError(w, http.StatusBadGateway, "could not reach this server's source connection: "+err.Error())
+		return
+	}
+	defer sourceDB.Close()
+
+	res, err := forensics.Activity(r.Context(), sourceDB, forensics.ActivityQuery{
+		Type:   body.QueryType,
+		User:   body.User,
+		Host:   body.Host,
+		Schema: body.Schema,
+		Since:  body.Since,
+		Until:  body.Until,
+		Limit:  body.Limit,
+		Order:  body.Order,
+	})
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, res)
+}

--- a/internal/console/forensics_api_test.go
+++ b/internal/console/forensics_api_test.go
@@ -1,0 +1,262 @@
+package console
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/dbtrail/dbtrail/internal/forensics"
+	"github.com/dbtrail/dbtrail/internal/parser"
+	"github.com/dbtrail/dbtrail/internal/query"
+)
+
+// TestForensicsGate_Disabled proves the entitlement seam is enforced at every
+// forensics HTTP entry point: with forensics.Enabled() false, each handler
+// refuses with 403 before touching a bundle or a source connection (#701 D1).
+func TestForensicsGate_Disabled(t *testing.T) {
+	orig := forensics.Enabled
+	forensics.Enabled = func() bool { return false }
+	t.Cleanup(func() { forensics.Enabled = orig })
+
+	s := newBootServer(nil)
+	cases := []struct {
+		name   string
+		method string
+		path   string
+		body   string
+		run    func(*Server, http.ResponseWriter, *http.Request)
+	}{
+		{"capabilities", "GET", "/api/forensics/capabilities", "", (*Server).handleForensicsCapabilities},
+		{"users", "GET", "/api/forensics/users", "", (*Server).handleForensicsUsers},
+		{"who-changed", "POST", "/api/forensics/who-changed", `{"schema":"app","table":"users"}`, (*Server).handleForensicsWhoChanged},
+		{"activity", "POST", "/api/forensics/activity", `{"query_type":"user_activity","user":"app_rw"}`, (*Server).handleForensicsActivity},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var body io.Reader
+			if tc.body != "" {
+				body = strings.NewReader(tc.body)
+			}
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(tc.method, tc.path, body)
+			tc.run(s, rec, req)
+			if rec.Code != http.StatusForbidden {
+				t.Errorf("%s: status = %d, want 403; body = %s", tc.name, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+// TestForensicsGate_RBACActive proves the v1 posture from the issue: forensics
+// refuses outright while an RBAC redaction profile is active, matching the
+// Verify/recover-cascade precedent (forensic output carries unredacted SQL
+// text and session identity that the redaction pipeline does not cover yet).
+func TestForensicsGate_RBACActive(t *testing.T) {
+	s := newBootServer(nil)
+	s.redactCols = append(s.redactCols, query.SchemaTableColumn{Schema: "app", Table: "users", Column: "ssn"})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/forensics/capabilities", nil)
+	s.handleForensicsCapabilities(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403; body = %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "access-control profile") {
+		t.Errorf("expected an access-control-profile refusal message, got: %s", rec.Body.String())
+	}
+}
+
+// TestHandleForensicsCapabilities_NoSourceConfigured: a server with no source
+// DSN degrades to source_configured=false rather than erroring — capabilities
+// detection has nothing to probe, and that is a setup prompt, not a failure.
+func TestHandleForensicsCapabilities_NoSourceConfigured(t *testing.T) {
+	s := newBootServer(nil)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/forensics/capabilities", nil)
+	s.handleForensicsCapabilities(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	var resp forensicsCapabilitiesResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.SourceConfigured {
+		t.Error("SourceConfigured should be false: the boot bundle has no registry SourceDSN")
+	}
+	if resp.SetupGuide != nil {
+		t.Error("SetupGuide should be nil when no source is configured")
+	}
+}
+
+// TestHandleForensicsUsers_NoSourceConfigured mirrors the capabilities
+// degradation: an empty list, never an error, so a filter dropdown can still
+// render (just empty) for a server with no source connection.
+func TestHandleForensicsUsers_NoSourceConfigured(t *testing.T) {
+	s := newBootServer(nil)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/forensics/users", nil)
+	s.handleForensicsUsers(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	var resp forensicsUsersResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Users == nil || len(resp.Users) != 0 {
+		t.Errorf("Users = %v, want an empty (non-nil) slice", resp.Users)
+	}
+}
+
+// TestHandleForensicsWhoChanged_RequiresSchemaTable guards the same
+// precondition as the CLI and the forensics library itself.
+func TestHandleForensicsWhoChanged_RequiresSchemaTable(t *testing.T) {
+	s := newBootServer(nil)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/forensics/who-changed", strings.NewReader(`{"schema":"app"}`))
+	s.handleForensicsWhoChanged(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400; body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestHandleForensicsWhoChanged_DegradesWithoutSource drives the handler
+// against a real (mocked) index with no source connection configured: the
+// binlog-only tier still answers — degradation is a result, not an error.
+func TestHandleForensicsWhoChanged_DegradesWithoutSource(t *testing.T) {
+	db, mock, closeFn := newSQLMock(t)
+	defer closeFn()
+
+	cols := []string{
+		"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp",
+		"gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values",
+		"changed_columns", "row_before", "row_after", "schema_version", "query_text", "query_hash",
+	}
+	rows := sqlmock.NewRows(cols).AddRow(
+		int64(1), "bin.000001", int64(4), int64(40), time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC),
+		nil, nil, "app", "users", int64(parser.EventUpdate), "7",
+		[]byte(`["email"]`), []byte(`{"email":"a@x"}`), []byte(`{"email":"b@x"}`), int64(0),
+		nil, nil,
+	)
+	mock.ExpectQuery("FROM binlog_events").WillReturnRows(rows)
+
+	s := newBootServer(db)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/forensics/who-changed",
+		strings.NewReader(`{"schema":"app","table":"users"}`))
+	s.handleForensicsWhoChanged(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	var res forensics.WhoChangedResult
+	if err := json.Unmarshal(rec.Body.Bytes(), &res); err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Events) != 1 {
+		t.Fatalf("events = %d, want 1: %s", len(res.Events), rec.Body.String())
+	}
+	if res.Events[0].Attribution != nil {
+		t.Errorf("with no source and no connection_id, attribution should be nil, got %+v", res.Events[0].Attribution)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+// TestHandleForensicsActivity_BadQueryType and TestHandleForensicsActivity_NoSourceConfigured
+// cover the request-shape and precondition guards ahead of the source-dependent path.
+func TestHandleForensicsActivity_BadQueryType(t *testing.T) {
+	s := newBootServer(nil)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/forensics/activity", strings.NewReader(`{"query_type":"bogus"}`))
+	s.handleForensicsActivity(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400; body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleForensicsActivity_UserActivityRequiresUser(t *testing.T) {
+	s := newBootServer(nil)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/forensics/activity", strings.NewReader(`{"query_type":"user_activity"}`))
+	s.handleForensicsActivity(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400; body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleForensicsActivity_ConnectionHistoryRequiresUserOrHost(t *testing.T) {
+	s := newBootServer(nil)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/forensics/activity", strings.NewReader(`{"query_type":"connection_history"}`))
+	s.handleForensicsActivity(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400; body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleForensicsActivity_NoSourceConfigured(t *testing.T) {
+	s := newBootServer(nil)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/forensics/activity",
+		strings.NewReader(`{"query_type":"ddl_history"}`))
+	s.handleForensicsActivity(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "no source connection configured") {
+		t.Errorf("expected a no-source-configured message, got: %s", rec.Body.String())
+	}
+}
+
+// TestCapabilitiesResponse_AdvertisesForensics checks the nav-visibility gate
+// this issue adds to the shared /api/capabilities endpoint: on, unless the
+// build has forensics disabled or an RBAC profile is active.
+func TestCapabilitiesResponse_AdvertisesForensics(t *testing.T) {
+	s := newBootServer(nil)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/capabilities", nil)
+	s.handleCapabilities(rec, req)
+	var resp capabilitiesResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if !resp.Forensics {
+		t.Errorf("capabilities.forensics should be true by default (OSS ships forensics enabled): %s", rec.Body.String())
+	}
+
+	s.redactCols = append(s.redactCols, query.SchemaTableColumn{Schema: "app", Table: "users", Column: "ssn"})
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/capabilities", nil)
+	s.handleCapabilities(rec, req)
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Forensics {
+		t.Errorf("capabilities.forensics should be false under an active RBAC profile: %s", rec.Body.String())
+	}
+
+	// The other conjunct: with no RBAC profile active, a closed entitlement
+	// gate must still zero out the nav-visibility flag — otherwise the nav
+	// item would show while every underlying forensics endpoint 403s.
+	s2 := newBootServer(nil)
+	orig := forensics.Enabled
+	forensics.Enabled = func() bool { return false }
+	t.Cleanup(func() { forensics.Enabled = orig })
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/capabilities", nil)
+	s2.handleCapabilities(rec, req)
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Forensics {
+		t.Errorf("capabilities.forensics should be false with the entitlement gate closed: %s", rec.Body.String())
+	}
+}

--- a/internal/console/forensics_api_test.go
+++ b/internal/console/forensics_api_test.go
@@ -57,18 +57,40 @@ func TestForensicsGate_Disabled(t *testing.T) {
 // refuses outright while an RBAC redaction profile is active, matching the
 // Verify/recover-cascade precedent (forensic output carries unredacted SQL
 // text and session identity that the redaction pipeline does not cover yet).
+// Table-driven across all 4 handlers, mirroring TestForensicsGate_Disabled —
+// an earlier version of this test only covered handleForensicsCapabilities.
 func TestForensicsGate_RBACActive(t *testing.T) {
 	s := newBootServer(nil)
 	s.redactCols = append(s.redactCols, query.SchemaTableColumn{Schema: "app", Table: "users", Column: "ssn"})
 
-	rec := httptest.NewRecorder()
-	req := httptest.NewRequest("GET", "/api/forensics/capabilities", nil)
-	s.handleForensicsCapabilities(rec, req)
-	if rec.Code != http.StatusForbidden {
-		t.Fatalf("status = %d, want 403; body = %s", rec.Code, rec.Body.String())
+	cases := []struct {
+		name   string
+		method string
+		path   string
+		body   string
+		run    func(*Server, http.ResponseWriter, *http.Request)
+	}{
+		{"capabilities", "GET", "/api/forensics/capabilities", "", (*Server).handleForensicsCapabilities},
+		{"users", "GET", "/api/forensics/users", "", (*Server).handleForensicsUsers},
+		{"who-changed", "POST", "/api/forensics/who-changed", `{"schema":"app","table":"users"}`, (*Server).handleForensicsWhoChanged},
+		{"activity", "POST", "/api/forensics/activity", `{"query_type":"user_activity","user":"app_rw"}`, (*Server).handleForensicsActivity},
 	}
-	if !strings.Contains(rec.Body.String(), "access-control profile") {
-		t.Errorf("expected an access-control-profile refusal message, got: %s", rec.Body.String())
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var body io.Reader
+			if tc.body != "" {
+				body = strings.NewReader(tc.body)
+			}
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(tc.method, tc.path, body)
+			tc.run(s, rec, req)
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("%s: status = %d, want 403; body = %s", tc.name, rec.Code, rec.Body.String())
+			}
+			if !strings.Contains(rec.Body.String(), "access-control profile") {
+				t.Errorf("%s: expected an access-control-profile refusal message, got: %s", tc.name, rec.Body.String())
+			}
+		})
 	}
 }
 
@@ -258,5 +280,98 @@ func TestCapabilitiesResponse_AdvertisesForensics(t *testing.T) {
 	}
 	if resp.Forensics {
 		t.Errorf("capabilities.forensics should be false with the entitlement gate closed: %s", rec.Body.String())
+	}
+}
+
+// registerDeadSource adds a registry entry whose SourceDSN points at a
+// closed local port — config.Connect fails fast (no network hang) without
+// needing live infra, exercising "configured but unreachable" the same way
+// servers_api_test.go's dead-index-DSN tests do for the index side. DSN
+// (the index connection) is deliberately left empty: none of
+// capabilities/users/activity ever resolve the index bundle.
+func registerDeadSource(t *testing.T, s *Server) ServerEntry {
+	t.Helper()
+	e, err := s.cm.reg.Add(ServerEntry{Name: "dead-source", SourceDSN: "u:p@tcp(127.0.0.1:1)/db?timeout=200ms"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return e
+}
+
+// TestForensicsHandlers_SourceConfiguredButUnreachable closes the coverage
+// gap the "no source configured" vs "configured but unreachable" distinction
+// shipped with: a regression that re-conflates the two (relabeling a real
+// outage as "never set up", the exact bug this endpoint design fixed once)
+// must fail these tests, not just look right in the source.
+func TestForensicsHandlers_SourceConfiguredButUnreachable(t *testing.T) {
+	s := newBootServer(nil)
+	e := registerDeadSource(t, s)
+
+	t.Run("capabilities", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/api/forensics/capabilities", nil)
+		req.Header.Set(serverHeader, e.ID)
+		s.handleForensicsCapabilities(rec, req)
+		if rec.Code != http.StatusBadGateway {
+			t.Fatalf("status = %d, want 502 (not 200/'not configured'); body = %s", rec.Code, rec.Body.String())
+		}
+	})
+	t.Run("users", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/api/forensics/users", nil)
+		req.Header.Set(serverHeader, e.ID)
+		s.handleForensicsUsers(rec, req)
+		if rec.Code != http.StatusBadGateway {
+			t.Fatalf("status = %d, want 502 (not 200 with an empty user list); body = %s", rec.Code, rec.Body.String())
+		}
+	})
+	t.Run("activity", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/api/forensics/activity", strings.NewReader(`{"query_type":"user_activity","user":"app_rw"}`))
+		req.Header.Set(serverHeader, e.ID)
+		s.handleForensicsActivity(rec, req)
+		if rec.Code != http.StatusBadGateway {
+			t.Fatalf("status = %d, want 502 (not 400 'set the source connection first'); body = %s", rec.Code, rec.Body.String())
+		}
+	})
+}
+
+// Who-changed's own "configured but unreachable" behavior (index-only
+// degrade + a Notes entry, never an error) needs a REAL, working index
+// alongside a dead source — resolveOr and openForensicsSource both key off
+// the same selected server, so a sqlmock index can't be paired with a
+// registry source entry the way the other three handlers' tests are above
+// (those never touch the index at all). See
+// TestIntegrationForensicsWhoChanged_UnreachableSource in
+// console_integration_test.go for that case, against real MySQL.
+
+// TestHandleForensicsWhoChanged_LimitClamped proves the clamp end-to-end: an
+// over-limit request must reach the index fetch already capped, not just
+// satisfy clampLimit in isolation (TestClampLimit in api_test.go tests the
+// generic helper, never this handler's actual wiring of it).
+func TestHandleForensicsWhoChanged_LimitClamped(t *testing.T) {
+	db, mock, closeFn := newSQLMock(t)
+	defer closeFn()
+
+	cols := []string{
+		"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp",
+		"gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values",
+		"changed_columns", "row_before", "row_after", "schema_version", "query_text", "query_hash",
+	}
+	// The mock only needs to prove which LIMIT value the query carried — an
+	// empty result set is fine, WithArgs is what does the real assertion.
+	mock.ExpectQuery("FROM binlog_events").
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), whoChangedMaxLimit).
+		WillReturnRows(sqlmock.NewRows(cols))
+
+	s := newBootServer(db)
+	rec := httptest.NewRecorder()
+	body := `{"schema":"app","table":"users","limit":99999}`
+	s.handleForensicsWhoChanged(rec, httptest.NewRequest("POST", "/api/forensics/who-changed", strings.NewReader(body)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("query did not carry the clamped limit (%d): %v", whoChangedMaxLimit, err)
 	}
 }

--- a/internal/console/reconstruct.go
+++ b/internal/console/reconstruct.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/dbtrail/dbtrail/internal/cliutil"
+	"github.com/dbtrail/dbtrail/internal/forensics"
 	"github.com/dbtrail/dbtrail/internal/parquetquery"
 	"github.com/dbtrail/dbtrail/internal/query"
 	"github.com/dbtrail/dbtrail/internal/reconstruct"
@@ -52,6 +53,16 @@ type capabilitiesResponse struct {
 	// profile cascade victim synthesis cannot honor redaction, so the endpoint
 	// refuses (see handleRecoverCascade). Process-global, like Monitor.
 	RecoverCascade bool `json:"recover_cascade"`
+	// Forensics: the who-changed/user-activity/connection-history/ddl-history
+	// investigation surface is available (epic #701). Gated by the single
+	// entitlement seam (forensics.Enabled) and, like RecoverCascade, refused
+	// while an RBAC redaction profile is active — forensic output includes
+	// unredacted SQL text and session identity. Process-global: it never needs
+	// the selected server's bundle — per-server "no source configured" is a
+	// property of the SELECTED server, handled inside the forensics endpoints
+	// themselves (who-changed degrades to index-only attribution; the other
+	// three modes have no fallback and error), not this process-wide flag.
+	Forensics bool `json:"forensics"`
 	// RecoverCascadeBaseline: cascade recovery's Phase-2 (recover children
 	// untouched within the window) is active for this server. Per-server, and gated
 	// EXACTLY like the handler builds its provider — a baseline source AND a schema
@@ -121,6 +132,7 @@ func (s *Server) handleCapabilities(w http.ResponseWriter, r *http.Request) {
 		// recover-cascade is the free tier (like recover) and process-global, gated
 		// only by the RBAC profile (which would make synthesis leak redacted data).
 		RecoverCascade: !s.rbacActive(),
+		Forensics:      forensics.Enabled() && !s.rbacActive(),
 		Auth:           authCapsInfo{PasswordSet: s.passwordLoginEnabled(), AuthKind: kind},
 		// Default until the bundle resolves: a degraded console renders MySQL
 		// vocabulary (the common case), never a blank source.

--- a/internal/console/recover_cascade.go
+++ b/internal/console/recover_cascade.go
@@ -42,9 +42,11 @@ type recoverCascadeRequest struct {
 	AllowIncomplete bool `json:"allow_incomplete"`
 }
 
-// recoverCascadeResponse is text + structured coverage only — never event rows,
-// so it stays inside the free query_explorer boundary (connection_id can never
-// leak, exactly like recoverResponse).
+// recoverCascadeResponse is text + structured coverage only — never event
+// rows, so it stays outside the events-API boundary entirely (there is no
+// connection_id/query_text/query_hash field to gate here, exactly like
+// recoverResponse). This holds independent of the #701 D1 boundary move —
+// connection_id is no longer gated on the events API either, see dto.go.
 type recoverCascadeResponse struct {
 	SQL            string `json:"sql"`
 	StatementCount int    `json:"statement_count"`

--- a/internal/console/recover_cascade_integration_test.go
+++ b/internal/console/recover_cascade_integration_test.go
@@ -94,8 +94,10 @@ func TestIntegrationRecoverCascade_endToEnd(t *testing.T) {
 	if !resp.Complete {
 		t.Errorf("a clean cascade with no archives should be complete; incomplete=%v", resp.Incomplete)
 	}
-	// connection_id is the paid-forensics boundary: it must never appear in the
-	// cascade response (the response carries SQL + counts only, no event rows).
+	// connection_id is no longer a redacted field on the events API (#701 D1),
+	// but this assertion was never really about that boundary: the cascade
+	// response carries SQL + counts only, never event rows, so the key has no
+	// path onto the wire here regardless. Kept as a shape guard.
 	if strings.Contains(string(body), "connection_id") {
 		t.Errorf("connection_id leaked into the cascade response: %s", body)
 	}
@@ -219,8 +221,9 @@ func TestIntegrationRecover_autoCascade_endToEnd(t *testing.T) {
 	if c := strings.Count(resp.SQL, "`"+dbName+"`.`child`"); c != 2 {
 		t.Errorf("want 2 child INSERTs, got %d\n---\n%s", c, resp.SQL)
 	}
-	// connection_id is the paid-forensics boundary: the merged response carries SQL
-	// + counts only (no event rows), exactly like the legacy cascade endpoint.
+	// Same shape guard as the cascade endpoint above (#701 D1 note): the merged
+	// response carries SQL + counts only, no event rows, so connection_id has
+	// no path onto the wire here independent of the events-API boundary.
 	if strings.Contains(string(body), "connection_id") {
 		t.Errorf("connection_id leaked into the recover response: %s", body)
 	}

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -348,6 +348,16 @@ func (s *Server) buildHandler() http.Handler {
 	api.HandleFunc("POST /api/recover-cascade", s.handleRecoverCascade)
 	api.HandleFunc("GET /api/capabilities", s.handleCapabilities)
 	api.HandleFunc("GET /api/reconstruct", s.handleReconstruct)
+	// Forensics investigation surface (epic #701): who changed a row, and the
+	// three general activity queries. Selected-server-scoped via the same
+	// X-Bintrail-Server header as /api/events, not the /api/servers/{id}/...
+	// path convention — forensics is a passive investigative tab bound to
+	// whichever server the UI has selected, like Events/Explorer, not an
+	// explicitly-targeted background action like verify/baseline.
+	api.HandleFunc("GET /api/forensics/capabilities", s.handleForensicsCapabilities)
+	api.HandleFunc("GET /api/forensics/users", s.handleForensicsUsers)
+	api.HandleFunc("POST /api/forensics/who-changed", s.handleForensicsWhoChanged)
+	api.HandleFunc("POST /api/forensics/activity", s.handleForensicsActivity)
 	// Storage surfaces (read-only): the selected server's baseline snapshot
 	// listing, and the process's ambient AWS credential signals (presence
 	// booleans and non-secret names — never values).

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -151,6 +151,107 @@ try {
     ? ok("form: advanced section expanded for a BYO-index entry")
     : bad("form: advanced section expanded for a BYO-index entry", "collapsed — the byoIndex open-arm regressed");
 
+  // Scenario 5b — Forensics (#708): the "byo-idx" server just created has NO
+  // source configured but points at a real, schema-migrated index carrying
+  // one row run.sh seeded directly — covering both required states in one
+  // fixture: the no-source setup prompt, and the who-changed happy path.
+  //
+  // Bumps serverGen and clears schemaCache/tablesCache by hand rather than
+  // calling switchServer(): switchServer's own renderRoute() re-renders
+  // whatever route is CURRENT (still whatever scenario 4 left it on) before
+  // this scenario's navigate("forensics") fires — two renders racing under
+  // the SAME just-bumped serverGen (navigate() doesn't bump it further), so
+  // if the first (stale-route) render's fetch resolves after forensics has
+  // already painted, its own serverGen check still passes and it clobbers
+  // #view out from under this scenario. Bumping/clearing without triggering
+  // a render, then navigating exactly once, avoids the race while still
+  // fixing the cache-poisoning switchServer would have fixed.
+  await page.evaluate(() => closeServersModal());
+  await page.evaluate((id) => { setCurrentServer(id); serverGen++; schemaCache = null; tablesCache.clear(); }, byoId);
+  await page.evaluate(() => navigate("forensics"));
+  await page.waitForSelector("#fx-caps", { timeout: 5000 });
+  await page.waitForFunction(
+    () => !document.getElementById("fx-caps").querySelector(".view-loading"),
+    { timeout: 8000 },
+  );
+  const capsGate = await page.evaluate(() => ({
+    navVisible: (() => {
+      const n = document.querySelector('.nav-item[data-route="forensics"]');
+      return !!n && getComputedStyle(n).display !== "none";
+    })(),
+    noSourcePrompt: /No source connection configured/.test(document.getElementById("fx-caps").textContent),
+  }));
+  capsGate.navVisible
+    ? ok("forensics: nav item visible (capsCache.forensics gate)")
+    : bad("forensics: nav item visible (capsCache.forensics gate)", "hidden — forensics capability not advertised");
+  capsGate.noSourcePrompt
+    ? ok("forensics: no-source-configured setup prompt renders")
+    : bad("forensics: no-source-configured setup prompt renders", "expected copy missing from #fx-caps");
+
+  await page.waitForFunction(
+    () => { const s = document.querySelector('#fx-form [name="schema"]'); return s && [...s.options].some((o) => o.value === "fx_e2e"); },
+    { timeout: 8000 },
+  );
+  await page.evaluate(() => {
+    const form = document.getElementById("fx-form");
+    form.elements.schema.value = "fx_e2e";
+    form.elements.schema.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+  // loadTables() (fired by the change event above) is async and its latency
+  // depends on whether byo-idx's bundle is already open (single-flighted lazy
+  // connect) — poll for the real "probe" option instead of a fixed sleep, so
+  // this doesn't flake under load.
+  await page.waitForFunction(
+    () => { const s = document.querySelector('#fx-form [name="table"]'); return s && [...s.options].some((o) => o.value === "probe"); },
+    { timeout: 8000 },
+  );
+  await page.evaluate(() => {
+    const form = document.getElementById("fx-form");
+    form.elements.table.value = "probe";
+    form.elements.since.value = "2000-01-01 00:00:00";
+    form.requestSubmit();
+  });
+  // The query itself is async (index fetch, possibly a lazy bundle open) —
+  // poll for either outcome (timeline rendered, or an error box) rather than
+  // a fixed sleep.
+  await page.waitForFunction(
+    () => !!document.getElementById("fx-timeline") || !!document.querySelector("#fx-out .error, #fx-out .empty"),
+    { timeout: 8000 },
+  );
+  const who = await page.evaluate(() => {
+    const timeline = document.getElementById("fx-timeline");
+    return {
+      rendered: !!timeline,
+      hasBadge: !!timeline && !!timeline.querySelector(".badge.b-update"),
+      hasPK: !!timeline && /PK: 1/.test(timeline.textContent),
+      fallbackPanel: !!document.querySelector(".fx-fallback"),
+    };
+  });
+  who.rendered
+    ? ok("forensics: who-changed happy path renders the timeline")
+    : bad("forensics: who-changed happy path renders the timeline", "no #fx-timeline");
+  who.hasBadge
+    ? ok("forensics: who-changed event shows its UPDATE badge")
+    : bad("forensics: who-changed event shows its UPDATE badge", "no .b-update badge");
+  who.hasPK
+    ? ok("forensics: who-changed event shows its PK")
+    : bad("forensics: who-changed event shows its PK", "PK: 1 not found in timeline");
+  who.fallbackPanel
+    ? ok("forensics: fallback SQL panel renders for an unattributed event")
+    : bad("forensics: fallback SQL panel renders for an unattributed event", "no .fx-fallback");
+
+  // Restore the default server selection and invalidate the caches byo-idx's
+  // populateSchemas call wrote into (same reasoning as the switch above: a
+  // bare setCurrentServer("") would restore the selection but leave
+  // schemaCache/tablesCache holding byo-idx's data). Bump/clear by hand
+  // rather than calling switchServer(), which would also fire its own
+  // renderRoute() — an extra, redundant re-render of the current (forensics)
+  // route racing scenario 6's very next navigate() under the same
+  // just-bumped serverGen, for the exact reason explained at the switch-in
+  // above. No render is needed here at all: scenario 6's navigate() builds
+  // whatever view it needs from a clean, cache-invalidated state.
+  await page.evaluate(() => { setCurrentServer(""); serverGen++; schemaCache = null; tablesCache.clear(); });
+
   // Scenario 6 — Recover/Cascade merge. Cascade recovery is no longer a separate
   // tab: it is auto-detected inside the single Recover flow (the backend routes by
   // detection and folds the invisible children into one script when the target is

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -411,6 +411,70 @@ try {
   cred.hasToggle ? ok("aws-creds: disclosure uses the app's toggle style") : bad("aws-creds: disclosure uses the app's toggle style", "missing summary.form-adv-summary");
   cred.rawRowCount === 4 ? ok("aws-creds: all four raw signal rows still render") : bad("aws-creds: all four raw signal rows still render", `rawRowCount=${cred.rawRowCount}`);
 
+  // Scenario 10 — Forensics setup-guide panel (#708). buildFxCapsBanner is pure
+  // (like pgHealthCard/continuityBox/credentialsCard): the real test MySQL fixture
+  // always reports performance_schema enabled with no recommendations, so Scenario
+  // 5b's who-changed run never exercises the degraded-capabilities/setup-guide path
+  // — the panel + its copy-to-clipboard blocks have never rendered in a browser
+  // until this fixture-driven check. Feeds buildFxCapsBanner synthetic capability
+  // payloads directly, mirroring the no-source, fully-capable, and degraded-with-
+  // recommendations states.
+  const fxGuide = await page.evaluate(() => {
+    const noSource = buildFxCapsBanner({ source_configured: false });
+    const fullyCapable = buildFxCapsBanner({
+      source_configured: true,
+      performance_schema: { enabled: true, consumers: { events_statements_history_long: true }, threads_accessible: true },
+      audit_log: { installed: true, variant: "MariaDB" },
+    });
+    const degraded = buildFxCapsBanner({
+      source_configured: true,
+      performance_schema: { enabled: false, consumers: {}, threads_accessible: false },
+      audit_log: { installed: false },
+      setup_guide: {
+        summary: "Enable performance_schema consumers to unlock full attribution.",
+        recommendations: [
+          {
+            priority: "high",
+            category: "performance_schema",
+            title: "Enable events_statements_history_long",
+            description: "Without this consumer, statement text cannot be correlated to row changes.",
+            runtime_sql: ["UPDATE performance_schema.setup_consumers SET enabled='YES' WHERE name='events_statements_history_long';"],
+            mycnf_snippet: "[mysqld]\nperformance-schema-consumer-events-statements-history-long=ON",
+          },
+        ],
+      },
+    });
+    document.body.appendChild(degraded);
+    const toggle = degraded.querySelector(".fx-guide-toggle");
+    const contentBeforeClick = degraded.querySelector(".fx-guide-content");
+    const hiddenBeforeClick = contentBeforeClick ? contentBeforeClick.hidden : null;
+    toggle && toggle.click();
+    const hiddenAfterClick = contentBeforeClick ? contentBeforeClick.hidden : null;
+    const copyBtn = degraded.querySelector(".fx-sql-block .btn");
+    const result = {
+      noSourcePrompt: !!noSource && /No source connection configured/.test(noSource.textContent),
+      fullyCapableNoGuide: !!fullyCapable && !fullyCapable.querySelector(".fx-guide"),
+      degradedHasGuide: !!degraded.querySelector(".fx-guide"),
+      guideCollapsedByDefault: hiddenBeforeClick === true,
+      guideExpandsOnClick: hiddenAfterClick === false,
+      hasPriorityBadge: !!degraded.querySelector(".fx-priority-high"),
+      hasRuntimeSqlBlock: Array.from(degraded.querySelectorAll(".fx-sql")).some((n) => /events_statements_history_long/.test(n.textContent)),
+      hasMycnfBlock: Array.from(degraded.querySelectorAll(".fx-sql")).some((n) => /performance-schema-consumer/.test(n.textContent)),
+      hasCopyButton: !!copyBtn && copyBtn.textContent.trim() === "Copy",
+    };
+    degraded.remove();
+    return result;
+  });
+  fxGuide.noSourcePrompt ? ok("forensics: no-source state shows the setup prompt") : bad("forensics: no-source state shows the setup prompt", "prompt text missing");
+  fxGuide.fullyCapableNoGuide ? ok("forensics: fully-capable source renders no guide panel") : bad("forensics: fully-capable source renders no guide panel", "guide rendered with no recommendations");
+  fxGuide.degradedHasGuide ? ok("forensics: degraded capabilities render the setup-guide panel") : bad("forensics: degraded capabilities render the setup-guide panel", "no .fx-guide");
+  fxGuide.guideCollapsedByDefault ? ok("forensics: setup guide is collapsed by default") : bad("forensics: setup guide is collapsed by default", "rendered expanded");
+  fxGuide.guideExpandsOnClick ? ok("forensics: setup guide expands on toggle click") : bad("forensics: setup guide expands on toggle click", "stayed collapsed");
+  fxGuide.hasPriorityBadge ? ok("forensics: recommendation shows its priority badge") : bad("forensics: recommendation shows its priority badge", "no .fx-priority-high");
+  fxGuide.hasRuntimeSqlBlock ? ok("forensics: runtime SQL snippet renders") : bad("forensics: runtime SQL snippet renders", "missing runtime SQL text");
+  fxGuide.hasMycnfBlock ? ok("forensics: my.cnf snippet renders") : bad("forensics: my.cnf snippet renders", "missing my.cnf text");
+  fxGuide.hasCopyButton ? ok("forensics: copy-to-clipboard button renders") : bad("forensics: copy-to-clipboard button renders", "no Copy button");
+
   // No uncaught JS errors over the whole run.
   jsErrors.length === 0 ? ok("no uncaught JS errors") : bad("no uncaught JS errors", JSON.stringify(jsErrors));
 } catch (err) {

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -167,6 +167,11 @@ try {
   // a render, then navigating exactly once, avoids the race while still
   // fixing the cache-poisoning switchServer would have fixed.
   await page.evaluate(() => closeServersModal());
+  // Let scenario 5's editServer() open/populate-form fetches (if any) fully
+  // settle before switching server + route — an in-flight one resolving
+  // after navigate("forensics") could otherwise touch shared state
+  // (capsCache, tablesCache) at the wrong moment.
+  await page.waitForLoadState("networkidle");
   await page.evaluate((id) => { setCurrentServer(id); serverGen++; schemaCache = null; tablesCache.clear(); }, byoId);
   await page.evaluate(() => navigate("forensics"));
   await page.waitForSelector("#fx-caps", { timeout: 5000 });
@@ -212,10 +217,12 @@ try {
     form.requestSubmit();
   });
   // The query itself is async (index fetch, possibly a lazy bundle open) —
-  // poll for either outcome (timeline rendered, or an error box) rather than
-  // a fixed sleep.
+  // poll for any outcome (timeline rendered, the "no changes found" empty
+  // state, or a rendered error) rather than a fixed sleep. Matches the
+  // actual classes renderError()/buildWhoChangedTimeline() use — NOT
+  // generic ".error"/".empty" names, which don't exist in this file.
   await page.waitForFunction(
-    () => !!document.getElementById("fx-timeline") || !!document.querySelector("#fx-out .error, #fx-out .empty"),
+    () => !!document.getElementById("fx-timeline") || !!document.querySelector("#fx-out .error-box, #fx-out .ev-empty, #fx-out .empty"),
     { timeout: 8000 },
   );
   const who = await page.evaluate(() => {

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -219,10 +219,10 @@ try {
   // The query itself is async (index fetch, possibly a lazy bundle open) —
   // poll for any outcome (timeline rendered, the "no changes found" empty
   // state, or a rendered error) rather than a fixed sleep. Matches the
-  // actual classes renderError()/buildWhoChangedTimeline() use — NOT
-  // generic ".error"/".empty" names, which don't exist in this file.
+  // actual classes renderError()/buildWhoChangedTimeline() use — NOT a
+  // generic ".error"/".empty" name, which doesn't exist in this file.
   await page.waitForFunction(
-    () => !!document.getElementById("fx-timeline") || !!document.querySelector("#fx-out .error-box, #fx-out .ev-empty, #fx-out .empty"),
+    () => !!document.getElementById("fx-timeline") || !!document.querySelector("#fx-out .error-box, #fx-out .ev-empty"),
     { timeout: 8000 },
   );
   const who = await page.evaluate(() => {
@@ -412,13 +412,17 @@ try {
   cred.rawRowCount === 4 ? ok("aws-creds: all four raw signal rows still render") : bad("aws-creds: all four raw signal rows still render", `rawRowCount=${cred.rawRowCount}`);
 
   // Scenario 10 — Forensics setup-guide panel (#708). buildFxCapsBanner is pure
-  // (like pgHealthCard/continuityBox/credentialsCard): the real test MySQL fixture
-  // always reports performance_schema enabled with no recommendations, so Scenario
-  // 5b's who-changed run never exercises the degraded-capabilities/setup-guide path
-  // — the panel + its copy-to-clipboard blocks have never rendered in a browser
-  // until this fixture-driven check. Feeds buildFxCapsBanner synthetic capability
-  // payloads directly, mirroring the no-source, fully-capable, and degraded-with-
-  // recommendations states.
+  // (like pgHealthCard/continuityBox/credentialsCard): the only live-browser
+  // forensics scenario (5b) uses byo-idx, which has no source connection
+  // configured at all — handleForensicsCapabilities short-circuits before ever
+  // calling DetectCapabilities/BuildSetupGuide, so neither the fully-capable
+  // nor the degraded-with-recommendations state ever renders in a real browser.
+  // (Even a source-configured probe against the stock test MySQL would show
+  // recommendations, not the fully-capable state — events_statements_history_long
+  // and the audit plugin are both off by default — so there's no live fixture
+  // that reaches this UI path either way.) Feeds buildFxCapsBanner synthetic
+  // capability payloads directly, mirroring the no-source, fully-capable, and
+  // degraded-with-recommendations states.
   const fxGuide = await page.evaluate(() => {
     const noSource = buildFxCapsBanner({ source_configured: false });
     const fullyCapable = buildFxCapsBanner({

--- a/test/console-e2e/run.sh
+++ b/test/console-e2e/run.sh
@@ -68,6 +68,19 @@ curl -fsS -X POST \
   -d '{"name":"wp","source_host":"127.0.0.1","source_port":"13306","source_user":"dbtrail","source_password":"x"}' \
   "http://127.0.0.1:$PORT/api/servers" >/dev/null
 
+# Forensics who-changed happy-path fixture (#708): one real row in the boot
+# index ($IDX_DB, already schema-migrated by the daemon's own EnsureSchema on
+# startup). The "byo-idx" server created below by scenario 5 points at this
+# exact database with no source configured — reusing it here gives the
+# who-changed scenarios both a working index AND the "no source" capability
+# state without a second fixture.
+echo "==> seed one binlog_events row for the forensics who-changed scenarios"
+mysql_exec -e "
+USE $IDX_DB;
+INSERT INTO binlog_events (binlog_file, start_pos, end_pos, event_timestamp, connection_id, schema_name, table_name, event_type, pk_values, changed_columns, row_before, row_after, schema_version)
+VALUES ('bin.000001', 4, 40, NOW(), 4242, 'fx_e2e', 'probe', 2, '1', JSON_ARRAY('val'), JSON_OBJECT('val','a'), JSON_OBJECT('val','b'), 0);
+"
+
 echo "==> install node deps"
 (cd "$HERE" && npm install --no-audit --no-fund --silent)
 if [ "${PW_CHANNEL:-}" = "" ]; then


### PR DESCRIPTION
closes #708

Part of epic #701 (D1). Depends on #706 (merged).

## Summary

- New `internal/console/forensics_api.go`: 4 handlers (`capabilities`, `users`, `who-changed`, `activity`) wrapping the existing `internal/forensics` library. Gated by `forensics.Enabled()` and refused outright under an active RBAC redaction profile (v1 posture per the issue — forensic output carries unredacted SQL text and session identity the redaction pipeline doesn't cover yet, matching the Verify/recover-cascade precedent).
- New console tab (`app.js`/`style.css`/`index.html`): capabilities banner with live source dots, collapsible setup-guide panel with copy-to-clipboard runtime SQL/my.cnf snippets, four investigation modes (who-changed/user-activity/connection-history/ddl-history), a who-changed vertical timeline with expandable forensic context, and an aggregated fallback-SQL panel. Ported the interaction model from the SaaS `Forensics.tsx` into this file's existing vanilla-JS conventions (not copied verbatim).
- **D1 boundary retirement**: `dto.go`'s `eventDTO` now includes `connection_id` on the general `/api/events` surface — the scattered per-field redaction is replaced by the single `forensics.Enabled()` entitlement seam. `query_text`/`query_hash` remain omitted (a separate, still-live #699 boundary this epic doesn't touch). Rewrote the four sibling guard tests accordingly.
- `capabilitiesResponse` gained a process-global `forensics` field (nav-visibility gate), mirroring `RecoverCascade`'s pattern exactly.

## Design notes

- `openForensicsSource` returns `(db, host, err)`, distinguishing the sentinel `errSourceNotConfigured` ("never set up" → 200/setup-prompt) from any other error ("configured but unreachable" → 502, a genuine misconfiguration/outage) — conflating the two would leave an operator staring at "add a source connection" for a server that already has one. The two states used to be carried by a separate `configured bool` alongside `err`; collapsed to one sentinel-error return so the illegal fourth combination is unrepresentable, not just conventionally avoided (per review).
- who-changed degrades to index-only attribution when the source is unreachable (matches the library's "degradation is an answer" design) and says so in `Notes`; the other three activity modes have no index-side fallback and return a 502 on a genuine backend failure (400 only for actual bad input, caught before ever touching the source).
- Reused `writeFetchError` for who-changed's index-fetch errors, so a pre-migration index missing `connection_id`/`query_text`/`query_hash` gets the same actionable 422 the Events tab already gives, instead of a bare 400.
- Added `whoChangedDefaultLimit`/`whoChangedMaxLimit` (clamped via the existing `clampLimit` helper), proven end-to-end against the actual query sent to the index, not just as an isolated pure-function fact.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean
- [x] `go test ./...` (unit) — all green, no regressions
- [x] `go test -tags integration ./internal/console/...` — green, including two real-MySQL tests: the source-configured-and-reachable success path, and who-changed's configured-but-unreachable degrade+note behavior (paired index+source on one registry entry — can't be reached with a sqlmock index alone)
- [x] `test/console-e2e` (Playwright): **61/61**, including scenarios covering the nav-visibility gate, the no-source setup prompt, a real who-changed happy path against a seeded index row, and the collapsible setup-guide panel (priority badges, runtime-SQL/my.cnf copy blocks)
- [x] Manually drove a real console instance against stock MySQL 8.4: confirmed `/api/forensics/capabilities` correctly reports the partial-capability (perf_schema on, audit_log off) + setup-guide state
- [x] Reviewed in two full passes — first an initial 3-agent pass (code-reviewer, silent-failure-hunter, comment-analyzer), then a comprehensive 5-agent pass (adding pr-test-analyzer and type-design-analyzer) via `/pr-review-toolkit:review-pr` against the final diff. All actionable findings applied: the configured-vs-unreachable distinction (now a sentinel-error 3-tuple, closing an implicit-invariant gap type-design-analyzer flagged), `handleForensicsActivity` mislabeling real backend failures as 400 instead of 502 (silent-failure-hunter), a factually wrong e2e-test comment and a dead CSS selector (comment-analyzer, code-reviewer), and four missing-coverage gaps — configured-but-unreachable 502 across all 4 handlers, RBAC-403 table-driven across all 4 handlers, and an end-to-end limit-clamp assertion (pr-test-analyzer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)