### PR TITLE
test: verify path-filtered CI skip (no-op, closing unmerged)

### DIFF
--- a/.github/CI_VERIFY_SKIP_TMP.md
+++ b/.github/CI_VERIFY_SKIP_TMP.md
@@ -1,0 +1,2 @@
+Temporary file to verify CI path-filter skip semantics (PR #739 follow-up).
+Safe to ignore -- this PR will be closed without merging.


### PR DESCRIPTION
Throwaway PR to confirm the changes-detection gate added in #739 correctly resolves required checks as skipped rather than leaving the PR stuck on "Expected -- waiting for status". This file touches neither the `go` nor `console` path filters. Will be closed without merging once verified.