### PR TITLE
forensics: recognize Percona's Audit Log Filter plugin

### DIFF
--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -832,9 +832,12 @@ func checkAuditPlugin(ctx context.Context, db *sql.DB) CheckResult {
 			"  -- MariaDB (built in):\n" +
 			"  INSTALL SONAME 'server_audit';\n" +
 			"  SET GLOBAL server_audit_logging = ON;\n\n" +
-			"  -- Percona Server (free):\n" +
-			"  INSTALL PLUGIN audit_log SONAME 'audit_log.so';\n" +
-			"  SET GLOBAL audit_log_policy = 'ALL';\n\n" +
+			"  -- Percona Server (free, Audit Log Filter plugin — supersedes the legacy audit_log plugin):\n" +
+			"  CREATE TABLE IF NOT EXISTS mysql.audit_log_filter (filter_id INT UNSIGNED NOT NULL AUTO_INCREMENT, name VARCHAR(255) NOT NULL, filter JSON NOT NULL, PRIMARY KEY (filter_id), UNIQUE KEY filter_name (name)) ENGINE=InnoDB;\n" +
+			"  CREATE TABLE IF NOT EXISTS mysql.audit_log_user (username VARCHAR(32) NOT NULL, userhost VARCHAR(255) NOT NULL, filtername VARCHAR(255) NOT NULL, PRIMARY KEY (username, userhost), FOREIGN KEY (filtername) REFERENCES mysql.audit_log_filter(name)) ENGINE=InnoDB;\n" +
+			"  INSTALL PLUGIN audit_log_filter SONAME 'audit_log_filter.so';\n" +
+			"  SELECT audit_log_filter_set_filter('log_all', '{\"filter\": {\"log\": true}}');\n" +
+			"  SELECT audit_log_filter_set_user('%', 'log_all');\n\n" +
 			"  -- MySQL Community: no free audit plugin; MySQL Enterprise Audit requires an Enterprise license.\n\n" +
 			"On RDS for MySQL, add the MARIADB_AUDIT_PLUGIN option to the instance's option group;\n" +
 			"on Aurora MySQL, set server_audit_logging=1 in the cluster parameter group.\n" +

--- a/internal/doctor/forensics_test.go
+++ b/internal/doctor/forensics_test.go
@@ -199,7 +199,7 @@ func TestCheckAuditPlugin(t *testing.T) {
 			wantDetailFrag: "no audit log plugin active",
 			wantRemedFrags: []string{
 				"INSTALL SONAME 'server_audit';",
-				"INSTALL PLUGIN audit_log SONAME 'audit_log.so';",
+				"INSTALL PLUGIN audit_log_filter SONAME 'audit_log_filter.so';",
 				"MARIADB_AUDIT_PLUGIN",
 				"server_audit_logging=1",
 			},

--- a/internal/forensics/auditlog.go
+++ b/internal/forensics/auditlog.go
@@ -147,9 +147,10 @@ type AuditReadResult struct {
 // to map them to their surface's error taxonomy (CLI exit codes, MCP errors,
 // agent responses).
 var (
-	// ErrAuditNotConfigured means neither audit_log_file (MySQL
-	// Enterprise / Percona) nor server_audit_file_path (MariaDB family) is
-	// set on the server: no audit plugin is configured.
+	// ErrAuditNotConfigured means none of audit_log_file (MySQL Enterprise /
+	// legacy Percona), audit_log_filter_file (Percona's newer Audit Log
+	// Filter plugin), or server_audit_file_path (MariaDB family) is set on
+	// the server: no audit plugin is configured.
 	ErrAuditNotConfigured = errors.New("no audit log file configured on this server")
 	// ErrAuditFileNotFound means the server reports an audit log path but
 	// no such file exists on the local filesystem (e.g. bintrail runs on a
@@ -191,8 +192,11 @@ const (
 // matching opts. The local flow is:
 //
 //  1. SHOW GLOBAL VARIABLES LIKE 'audit_log_file' (MySQL Enterprise /
-//     Percona), then 'server_audit_file_path' (MariaDB family);
-//  2. variant disambiguation via information_schema.PLUGINS;
+//     legacy Percona), then 'audit_log_filter_file' (Percona's newer Audit
+//     Log Filter plugin), then 'server_audit_file_path' (MariaDB family);
+//  2. variant disambiguation via information_schema.PLUGINS (only needed
+//     for audit_log_file, which both MySQL Enterprise and legacy Percona
+//     expose — audit_log_filter_file is Percona-exclusive);
 //  3. relative paths resolved against the server datadir, with path
 //     traversal hardening;
 //  4. rotated-file collection (opt-in, capped), tail-mode seeking, and
@@ -352,6 +356,19 @@ func discoverAuditLogFile(ctx context.Context, db *sql.DB) (path string, variant
 	}
 	if scanErr != nil && !errors.Is(scanErr, sql.ErrNoRows) {
 		warns = append(warns, fmt.Sprintf("failed to query audit_log_file variable: %v", scanErr))
+		err = scanErr
+	}
+
+	// Try Percona's newer Audit Log Filter plugin, which supersedes the
+	// legacy audit_log plugin as of Percona Server 8.0.34-26. The variable
+	// is Percona-exclusive, so no plugin-table lookup is needed to pick the
+	// variant.
+	scanErr = db.QueryRowContext(ctx, "SHOW GLOBAL VARIABLES LIKE 'audit_log_filter_file'").Scan(&varName, &varValue)
+	if scanErr == nil && varValue != "" {
+		return varValue, AuditVariantPercona, warns, nil
+	}
+	if scanErr != nil && !errors.Is(scanErr, sql.ErrNoRows) {
+		warns = append(warns, fmt.Sprintf("failed to query audit_log_filter_file variable: %v", scanErr))
 		err = scanErr
 	}
 

--- a/internal/forensics/auditlog.go
+++ b/internal/forensics/auditlog.go
@@ -48,8 +48,16 @@ type AuditVariant string
 // Known audit plugin variants.
 const (
 	AuditVariantMySQLEnterprise AuditVariant = "mysql_enterprise"
-	AuditVariantPercona         AuditVariant = "percona"
-	AuditVariantMariaDB         AuditVariant = "mariadb"
+	// AuditVariantPercona is the legacy audit_log plugin (audit_log_file),
+	// shared with MySQL Enterprise. It supports CSV, JSON, or XML depending
+	// on audit_log_format.
+	AuditVariantPercona AuditVariant = "percona"
+	// AuditVariantPerconaFilter is Percona's newer Audit Log Filter plugin
+	// (audit_log_filter_file) — a distinct constant from AuditVariantPercona
+	// because the two plugins support different format sets: this one never
+	// writes CSV, only NEW (XML-compatible) or JSON.
+	AuditVariantPerconaFilter AuditVariant = "percona_filter"
+	AuditVariantMariaDB       AuditVariant = "mariadb"
 )
 
 // AuditFormat identifies the on-disk audit log file format.
@@ -365,7 +373,7 @@ func discoverAuditLogFile(ctx context.Context, db *sql.DB) (path string, variant
 	// variant.
 	scanErr = db.QueryRowContext(ctx, "SHOW GLOBAL VARIABLES LIKE 'audit_log_filter_file'").Scan(&varName, &varValue)
 	if scanErr == nil && varValue != "" {
-		return varValue, AuditVariantPercona, warns, nil
+		return varValue, AuditVariantPerconaFilter, warns, nil
 	}
 	if scanErr != nil && !errors.Is(scanErr, sql.ErrNoRows) {
 		warns = append(warns, fmt.Sprintf("failed to query audit_log_filter_file variable: %v", scanErr))

--- a/internal/forensics/auditlog_rds.go
+++ b/internal/forensics/auditlog_rds.go
@@ -492,6 +492,11 @@ func formatFromVariant(variant AuditVariant) AuditFormat {
 		return AuditFormatMariaDB
 	case AuditVariantPercona:
 		return AuditFormatCSV
+	case AuditVariantPerconaFilter:
+		// audit_log_filter never writes CSV — only NEW (XML-compatible,
+		// its default) or JSON. NEW is the safer guess for an empty/unread
+		// file since it's the format bintrail's reader is verified against.
+		return AuditFormatXML
 	case AuditVariantMySQLEnterprise:
 		return AuditFormatJSON
 	default:

--- a/internal/forensics/auditlog_rds_test.go
+++ b/internal/forensics/auditlog_rds_test.go
@@ -1150,6 +1150,7 @@ func TestReadAuditLog_AuroraNotConfiguredFallback(t *testing.T) {
 	}
 	defer db.Close()
 	dbmock.ExpectQuery(showAuditLogFileSQL).WillReturnRows(noVariableRows())
+	dbmock.ExpectQuery(showAuditLogFilterFileSQL).WillReturnRows(noVariableRows())
 	dbmock.ExpectQuery(showServerAuditPathSQL).WillReturnRows(noVariableRows())
 	dbmock.ExpectQuery(showServerAuditLoggingSQL).WillReturnRows(variableRows("server_audit_logging", "ON"))
 
@@ -1188,6 +1189,7 @@ func TestReadAuditLog_NotConfiguredWithoutAuditLogging(t *testing.T) {
 	}
 	defer db.Close()
 	dbmock.ExpectQuery(showAuditLogFileSQL).WillReturnRows(noVariableRows())
+	dbmock.ExpectQuery(showAuditLogFilterFileSQL).WillReturnRows(noVariableRows())
 	dbmock.ExpectQuery(showServerAuditPathSQL).WillReturnRows(noVariableRows())
 	dbmock.ExpectQuery(showServerAuditLoggingSQL).WillReturnRows(noVariableRows())
 

--- a/internal/forensics/auditlog_rds_test.go
+++ b/internal/forensics/auditlog_rds_test.go
@@ -116,6 +116,7 @@ func TestFormatFromVariant(t *testing.T) {
 	}{
 		{AuditVariantMariaDB, AuditFormatMariaDB},
 		{AuditVariantPercona, AuditFormatCSV},
+		{AuditVariantPerconaFilter, AuditFormatXML},
 		{AuditVariantMySQLEnterprise, AuditFormatJSON},
 		{AuditVariant("bogus"), AuditFormatUnknown},
 		{AuditVariant(""), AuditFormatUnknown},
@@ -1038,6 +1039,7 @@ func TestReadAuditLog_ExplicitRDSSource_WithDiscovery(t *testing.T) {
 	}
 	defer db.Close()
 	dbmock.ExpectQuery(showAuditLogFileSQL).WillReturnRows(noVariableRows())
+	dbmock.ExpectQuery(showAuditLogFilterFileSQL).WillReturnRows(noVariableRows())
 	dbmock.ExpectQuery(showServerAuditPathSQL).WillReturnRows(variableRows("server_audit_file_path", "/rdsdbdata/log/audit/server_audit.log"))
 
 	mock := &mockRDSClient{
@@ -1073,6 +1075,7 @@ func TestReadAuditLog_AutoFallsBackToRDS(t *testing.T) {
 	}
 	defer db.Close()
 	dbmock.ExpectQuery(showAuditLogFileSQL).WillReturnRows(noVariableRows())
+	dbmock.ExpectQuery(showAuditLogFilterFileSQL).WillReturnRows(noVariableRows())
 	dbmock.ExpectQuery(showServerAuditPathSQL).WillReturnRows(variableRows("server_audit_file_path", "/rdsdbdata/log/audit/server_audit.log"))
 
 	mock := &mockRDSClient{
@@ -1106,6 +1109,7 @@ func TestReadAuditLog_AutoNoFallbackForNonRDSHost(t *testing.T) {
 	}
 	defer db.Close()
 	dbmock.ExpectQuery(showAuditLogFileSQL).WillReturnRows(noVariableRows())
+	dbmock.ExpectQuery(showAuditLogFilterFileSQL).WillReturnRows(noVariableRows())
 	dbmock.ExpectQuery(showServerAuditPathSQL).WillReturnRows(variableRows("server_audit_file_path", "/rdsdbdata/log/audit/server_audit.log"))
 
 	swapRDSFactory(t, nil, nil) // must not be reached
@@ -1127,6 +1131,7 @@ func TestReadAuditLog_LocalSourceNeverFallsBack(t *testing.T) {
 	}
 	defer db.Close()
 	dbmock.ExpectQuery(showAuditLogFileSQL).WillReturnRows(noVariableRows())
+	dbmock.ExpectQuery(showAuditLogFilterFileSQL).WillReturnRows(noVariableRows())
 	dbmock.ExpectQuery(showServerAuditPathSQL).WillReturnRows(variableRows("server_audit_file_path", "/rdsdbdata/log/audit/server_audit.log"))
 
 	swapRDSFactory(t, nil, nil) // must not be reached

--- a/internal/forensics/auditlog_test.go
+++ b/internal/forensics/auditlog_test.go
@@ -663,10 +663,11 @@ func TestParseAuditLogFiles_Fixtures(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 const (
-	showAuditLogFileSQL    = "SHOW GLOBAL VARIABLES LIKE 'audit_log_file'"
-	showServerAuditPathSQL = "SHOW GLOBAL VARIABLES LIKE 'server_audit_file_path'"
-	showDataDirSQL         = "SHOW GLOBAL VARIABLES LIKE 'datadir'"
-	pluginsSQL             = "SELECT PLUGIN_NAME, PLUGIN_DESCRIPTION FROM information_schema.PLUGINS"
+	showAuditLogFileSQL       = "SHOW GLOBAL VARIABLES LIKE 'audit_log_file'"
+	showAuditLogFilterFileSQL = "SHOW GLOBAL VARIABLES LIKE 'audit_log_filter_file'"
+	showServerAuditPathSQL    = "SHOW GLOBAL VARIABLES LIKE 'server_audit_file_path'"
+	showDataDirSQL            = "SHOW GLOBAL VARIABLES LIKE 'datadir'"
+	pluginsSQL                = "SELECT PLUGIN_NAME, PLUGIN_DESCRIPTION FROM information_schema.PLUGINS"
 )
 
 func variableRows(name, value string) *sqlmock.Rows {
@@ -692,6 +693,7 @@ func TestReadAuditLog_NotConfigured(t *testing.T) {
 	}
 	defer db.Close()
 	mock.ExpectQuery(showAuditLogFileSQL).WillReturnRows(noVariableRows())
+	mock.ExpectQuery(showAuditLogFilterFileSQL).WillReturnRows(noVariableRows())
 	mock.ExpectQuery(showServerAuditPathSQL).WillReturnRows(noVariableRows())
 
 	_, err = ReadAuditLog(context.Background(), db, AuditReadOptions{})
@@ -713,6 +715,7 @@ func TestReadAuditLog_DiscoveryQueryFailureIsNotNotConfigured(t *testing.T) {
 	defer db.Close()
 	connErr := errors.New("connection refused")
 	mock.ExpectQuery(showAuditLogFileSQL).WillReturnError(connErr)
+	mock.ExpectQuery(showAuditLogFilterFileSQL).WillReturnError(connErr)
 	mock.ExpectQuery(showServerAuditPathSQL).WillReturnError(connErr)
 
 	_, err = ReadAuditLog(context.Background(), db, AuditReadOptions{})
@@ -774,6 +777,7 @@ func TestReadAuditLog_MariaDBFallbackDiscovery(t *testing.T) {
 	}
 	defer db.Close()
 	mock.ExpectQuery(showAuditLogFileSQL).WillReturnRows(noVariableRows())
+	mock.ExpectQuery(showAuditLogFilterFileSQL).WillReturnRows(noVariableRows())
 	mock.ExpectQuery(showServerAuditPathSQL).WillReturnRows(variableRows("server_audit_file_path", logPath))
 
 	res, err := ReadAuditLog(context.Background(), db, AuditReadOptions{})
@@ -791,6 +795,65 @@ func TestReadAuditLog_MariaDBFallbackDiscovery(t *testing.T) {
 	}
 	if !warningsContain(res.Warnings, "server-local time") {
 		t.Errorf("Warnings = %v, want the local-time caveat", res.Warnings)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// TestReadAuditLog_PerconaAuditLogFilterDiscovery: audit_log_file misses (no
+// legacy plugin), audit_log_filter_file hits — Percona's newer Audit Log
+// Filter plugin. Its NEW-format XML output is field-compatible with the
+// existing MySQL Enterprise/legacy-Percona XML parser, so no new parser is
+// exercised here, only discovery + variant tagging.
+func TestReadAuditLog_PerconaAuditLogFilterDiscovery(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "audit_filter.log")
+	mustWrite(t, logPath,
+		`<?xml version="1.0" encoding="utf-8"?>`+"\n"+
+			`<AUDIT>`+"\n"+
+			`  <AUDIT_RECORD>`+"\n"+
+			`    <NAME>TableInsert</NAME>`+"\n"+
+			`    <TIMESTAMP>2024-06-15T10:30:00</TIMESTAMP>`+"\n"+
+			`    <CONNECTION_ID>99</CONNECTION_ID>`+"\n"+
+			`    <DB>mydb</DB>`+"\n"+
+			`    <SQLTEXT>INSERT INTO t1 VALUES(1)</SQLTEXT>`+"\n"+
+			`  </AUDIT_RECORD>`+"\n"+
+			`  <AUDIT_RECORD>`+"\n"+
+			`    <NAME>Connect</NAME>`+"\n"+
+			`    <TIMESTAMP>2024-06-15T10:31:00</TIMESTAMP>`+"\n"+
+			`    <CONNECTION_ID>100</CONNECTION_ID>`+"\n"+
+			`    <USER>root</USER>`+"\n"+
+			`    <HOST>localhost</HOST>`+"\n"+
+			`  </AUDIT_RECORD>`+"\n"+
+			`</AUDIT>`+"\n")
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+	mock.ExpectQuery(showAuditLogFileSQL).WillReturnRows(noVariableRows())
+	mock.ExpectQuery(showAuditLogFilterFileSQL).WillReturnRows(variableRows("audit_log_filter_file", logPath))
+
+	res, err := ReadAuditLog(context.Background(), db, AuditReadOptions{})
+	if err != nil {
+		t.Fatalf("ReadAuditLog: %v", err)
+	}
+	if res.Variant != AuditVariantPercona {
+		t.Errorf("Variant = %q, want percona", res.Variant)
+	}
+	if res.FormatDetected != AuditFormatXML {
+		t.Errorf("FormatDetected = %q, want xml", res.FormatDetected)
+	}
+	if res.FilePath != logPath {
+		t.Errorf("FilePath = %q, want %q", res.FilePath, logPath)
+	}
+	if len(res.Events) != 2 || res.Events[0].SQLText != "INSERT INTO t1 VALUES(1)" {
+		t.Errorf("Events = %+v, want 2 events with the insert first", res.Events)
+	}
+	if res.Events[1].User != "root" || res.Events[1].Host != "localhost" {
+		t.Errorf("Events[1] = %+v, want User=root Host=localhost", res.Events[1])
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("unmet expectations: %v", err)

--- a/internal/forensics/auditlog_test.go
+++ b/internal/forensics/auditlog_test.go
@@ -840,8 +840,8 @@ func TestReadAuditLog_PerconaAuditLogFilterDiscovery(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadAuditLog: %v", err)
 	}
-	if res.Variant != AuditVariantPercona {
-		t.Errorf("Variant = %q, want percona", res.Variant)
+	if res.Variant != AuditVariantPerconaFilter {
+		t.Errorf("Variant = %q, want percona_filter", res.Variant)
 	}
 	if res.FormatDetected != AuditFormatXML {
 		t.Errorf("FormatDetected = %q, want xml", res.FormatDetected)

--- a/internal/forensics/capabilities.go
+++ b/internal/forensics/capabilities.go
@@ -182,9 +182,8 @@ func detectAuditLog(ctx context.Context, db *sql.DB) AuditLogCapabilities {
 		// Percona-exclusive (its PLUGIN_DESCRIPTION is just "Audit log",
 		// so the name/description substring check below would miss it).
 		switch {
-		case strings.EqualFold(name, "audit_log_filter"):
-			caps.Variant = "percona"
-		case strings.Contains(upperName, "PERCONA") || strings.Contains(strings.ToUpper(description), "PERCONA"):
+		case strings.EqualFold(name, "audit_log_filter") ||
+			strings.Contains(upperName, "PERCONA") || strings.Contains(strings.ToUpper(description), "PERCONA"):
 			caps.Variant = "percona"
 		case strings.Contains(upperName, "SERVER_AUDIT") || strings.Contains(upperName, "MARIADB"):
 			caps.Variant = "mariadb"

--- a/internal/forensics/capabilities.go
+++ b/internal/forensics/capabilities.go
@@ -178,8 +178,12 @@ func detectAuditLog(ctx context.Context, db *sql.DB) AuditLogCapabilities {
 		caps.PluginName = name
 		caps.PluginStatus = status
 
-		// Determine variant based on plugin name.
+		// Determine variant based on plugin name. audit_log_filter is
+		// Percona-exclusive (its PLUGIN_DESCRIPTION is just "Audit log",
+		// so the name/description substring check below would miss it).
 		switch {
+		case strings.EqualFold(name, "audit_log_filter"):
+			caps.Variant = "percona"
 		case strings.Contains(upperName, "PERCONA") || strings.Contains(strings.ToUpper(description), "PERCONA"):
 			caps.Variant = "percona"
 		case strings.Contains(upperName, "SERVER_AUDIT") || strings.Contains(upperName, "MARIADB"):
@@ -213,6 +217,8 @@ func detectAuditLogConfig(ctx context.Context, db *sql.DB) map[string]string {
 		"audit_log_format",
 		"audit_log_file",
 		"audit_log_policy",
+		"audit_log_filter_format",  // Percona Audit Log Filter plugin
+		"audit_log_filter_file",    // Percona Audit Log Filter plugin
 		"server_audit_logging",     // MariaDB
 		"server_audit_file_path",   // MariaDB
 		"server_audit_output_type", // MariaDB

--- a/internal/forensics/capabilities_test.go
+++ b/internal/forensics/capabilities_test.go
@@ -32,12 +32,14 @@ var auditConfigVarNames = []string{
 	"audit_log_format",
 	"audit_log_file",
 	"audit_log_policy",
+	"audit_log_filter_format",
+	"audit_log_filter_file",
 	"server_audit_logging",
 	"server_audit_file_path",
 	"server_audit_output_type",
 }
 
-// expectAuditConfigVars registers the six well-known SHOW GLOBAL VARIABLES
+// expectAuditConfigVars registers the eight well-known SHOW GLOBAL VARIABLES
 // probes; vars named in values return a row, the rest return empty.
 func expectAuditConfigVars(m sqlmock.Sqlmock, values map[string]string) {
 	for _, v := range auditConfigVarNames {
@@ -223,6 +225,27 @@ func TestDetectAuditLog(t *testing.T) {
 			checkConfig: map[string]string{
 				"audit_log_format": "JSON",
 				"audit_log_file":   "/var/lib/mysql/audit.log",
+			},
+		},
+		{
+			name: "percona variant by audit_log_filter plugin name",
+			setup: func(m sqlmock.Sqlmock) {
+				m.ExpectQuery("FROM information_schema.PLUGINS").
+					WillReturnRows(pluginRows([3]string{"audit_log_filter", "ACTIVE", "Audit log"}))
+				expectAuditConfigVars(m, map[string]string{
+					"audit_log_filter_format": "JSON",
+					"audit_log_filter_file":   "/var/lib/mysql/audit_filter.json",
+				})
+			},
+			want: AuditLogCapabilities{
+				Installed:    true,
+				PluginName:   "audit_log_filter",
+				PluginStatus: "ACTIVE",
+				Variant:      "percona",
+			},
+			checkConfig: map[string]string{
+				"audit_log_filter_format": "JSON",
+				"audit_log_filter_file":   "/var/lib/mysql/audit_filter.json",
 			},
 		},
 		{

--- a/internal/forensics/guide.go
+++ b/internal/forensics/guide.go
@@ -235,12 +235,13 @@ func auditRecommendation(variant string) SetupRecommendation {
 			},
 			MycnfSnippet: "[mysqld]\n" +
 				"plugin-load-add = audit_log_filter.so\n" +
-				"audit_log_filter_format = JSON\n" +
-				"audit_log_filter_file = /var/log/mysql/audit_filter.json\n" +
+				"audit_log_filter_file = /var/log/mysql/audit_filter.log\n" +
 				"\n" +
-				"# audit_log_filter_format/_file/_strategy require a server restart to\n" +
-				"# take effect (not dynamic). Which events get logged is controlled\n" +
-				"# separately, at runtime, via audit_log_filter_set_filter().",
+				"# audit_log_filter_file/_format/_strategy require a server restart to\n" +
+				"# take effect (not dynamic) — the default NEW format is left as-is here\n" +
+				"# since it's the one bintrail's audit-log reader is verified against.\n" +
+				"# Which events get logged is controlled separately, at runtime, via\n" +
+				"# audit_log_filter_set_filter().",
 			Priority: "medium",
 		}
 	}

--- a/internal/forensics/guide.go
+++ b/internal/forensics/guide.go
@@ -202,26 +202,45 @@ func auditRecommendation(variant string) SetupRecommendation {
 	if variant == "percona" {
 		return SetupRecommendation{
 			Category: "audit_plugin",
-			Title:    "Install Percona Audit Log Plugin",
+			Title:    "Install Percona Audit Log Filter Plugin",
 			Description: "No audit log plugin detected. Percona Server includes the free, " +
-				"open-source Audit Log Plugin that captures comprehensive query " +
-				"history for long-term forensic investigation.",
+				"open-source Audit Log Filter plugin — Percona's recommended audit " +
+				"plugin, which supersedes the legacy Audit Log plugin — capturing " +
+				"comprehensive query history for long-term forensic investigation.",
 			Impact: "Captures all SQL statements with user, host, timestamp, and " +
 				"connection metadata. Provides forensic data beyond " +
 				"performance_schema's ring buffer — persisted to disk.",
-			PerformanceNote: "JSON format logging adds moderate I/O overhead. Use " +
-				"audit_log_policy = LOGINS for minimal impact (connection " +
-				"events only) or ALL for full query logging.",
+			PerformanceNote: "Logging every statement adds moderate I/O overhead. Narrow " +
+				"the filter definition to the connection and table_access classes " +
+				"(e.g. insert/update/delete only, skipping read) for lower overhead " +
+				"than logging everything including SELECTs.",
 			RuntimeSQL: []string{
-				"INSTALL PLUGIN audit_log SONAME 'audit_log.so';",
-				"SET GLOBAL audit_log_policy = 'ALL';",
-				"SET GLOBAL audit_log_format = 'JSON';",
+				"CREATE TABLE IF NOT EXISTS mysql.audit_log_filter (\n" +
+					"  filter_id INT UNSIGNED NOT NULL AUTO_INCREMENT,\n" +
+					"  name VARCHAR(255) NOT NULL,\n" +
+					"  filter JSON NOT NULL,\n" +
+					"  PRIMARY KEY (filter_id),\n" +
+					"  UNIQUE KEY filter_name (name)\n" +
+					") ENGINE=InnoDB;",
+				"CREATE TABLE IF NOT EXISTS mysql.audit_log_user (\n" +
+					"  username VARCHAR(32) NOT NULL,\n" +
+					"  userhost VARCHAR(255) NOT NULL,\n" +
+					"  filtername VARCHAR(255) NOT NULL,\n" +
+					"  PRIMARY KEY (username, userhost),\n" +
+					"  FOREIGN KEY (filtername) REFERENCES mysql.audit_log_filter(name)\n" +
+					") ENGINE=InnoDB;",
+				"INSTALL PLUGIN audit_log_filter SONAME 'audit_log_filter.so';",
+				`SELECT audit_log_filter_set_filter('log_all', '{"filter": {"log": true}}');`,
+				"SELECT audit_log_filter_set_user('%', 'log_all');",
 			},
 			MycnfSnippet: "[mysqld]\n" +
-				"plugin-load-add = audit_log.so\n" +
-				"audit_log_policy = ALL\n" +
-				"audit_log_format = JSON\n" +
-				"audit_log_file = /var/log/mysql/audit.log",
+				"plugin-load-add = audit_log_filter.so\n" +
+				"audit_log_filter_format = JSON\n" +
+				"audit_log_filter_file = /var/log/mysql/audit_filter.json\n" +
+				"\n" +
+				"# audit_log_filter_format/_file/_strategy require a server restart to\n" +
+				"# take effect (not dynamic). Which events get logged is controlled\n" +
+				"# separately, at runtime, via audit_log_filter_set_filter().",
 			Priority: "medium",
 		}
 	}
@@ -260,7 +279,7 @@ func auditRecommendation(variant string) SetupRecommendation {
 		Description: "No audit log plugin detected. MySQL Enterprise Edition includes " +
 			"the Enterprise Audit plugin (commercial license required). " +
 			"Alternatively, consider migrating to Percona Server (free, " +
-			"drop-in replacement) for the open-source Percona Audit Log Plugin.",
+			"drop-in replacement) for the open-source Percona Audit Log Filter Plugin.",
 		Impact: "Captures all SQL statements with user, host, timestamp, and " +
 			"connection metadata. Provides forensic data beyond " +
 			"performance_schema's ring buffer — persisted to disk.",
@@ -277,7 +296,7 @@ func auditRecommendation(variant string) SetupRecommendation {
 			"audit_log_policy = ALL\n" +
 			"\n" +
 			"# Option 2: Migrate to Percona Server (free, drop-in replacement)\n" +
-			"# and use the Percona Audit Log Plugin (see Percona docs)",
+			"# and use the Percona Audit Log Filter Plugin (see Percona docs)",
 		Priority: "medium",
 	}
 }

--- a/internal/forensics/guide_test.go
+++ b/internal/forensics/guide_test.go
@@ -147,7 +147,7 @@ func TestBuildSetupGuideAuditVariants(t *testing.T) {
 		wantTitle     string
 		wantSQLSubstr string
 	}{
-		{"percona", "Install Percona Audit Log Plugin", "INSTALL PLUGIN audit_log SONAME 'audit_log.so';"},
+		{"percona", "Install Percona Audit Log Filter Plugin", "INSTALL PLUGIN audit_log_filter SONAME 'audit_log_filter.so';"},
 		{"mariadb", "Enable MariaDB Audit Plugin", "INSTALL SONAME 'server_audit';"},
 		{"mysql", "Install an audit log plugin", "INSTALL PLUGIN audit_log SONAME 'audit_log.so';"},
 	}


### PR DESCRIPTION
closes #742

## Summary
- `discoverAuditLogFile` (internal/forensics/auditlog.go) now probes `audit_log_filter_file` in addition to the legacy `audit_log_file` and MariaDB's `server_audit_file_path`, so `who-changed` recognizes Percona's newer Audit Log Filter plugin instead of reporting "no audit log file configured" while it's actively logging. No new format parser needed — its NEW-format XML output is field-compatible with the existing `parseAuditXML`.
- `capabilities.go`'s `detectAuditLog` now recognizes the `audit_log_filter` plugin name directly (its `PLUGIN_DESCRIPTION` doesn't contain "Percona"), and `detectAuditLogConfig`'s known-variable list includes `audit_log_filter_format`/`audit_log_filter_file`.
- `guide.go`'s and `doctor.go`'s Percona remediation now recommend installing `audit_log_filter` (Percona's current recommendation) instead of the legacy `audit_log` plugin, including the `CREATE TABLE` statements the plugin requires (verified against a live Percona Server 8.0.45 install — `INSTALL PLUGIN` alone does not create them).
- The generic/unknown-variant remediation (real MySQL Enterprise, no Percona-exclusive plugin available) is unchanged — it still correctly points at the legacy Enterprise Audit plugin, its only option.

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] `gofmt -l` / `go vet ./...` clean
- [x] New tests: `TestReadAuditLog_PerconaAuditLogFilterDiscovery` (auditlog_test.go), a new `TestDetectAuditLog` case for `audit_log_filter` (capabilities_test.go); updated existing discovery-mock tests (auditlog_test.go, auditlog_rds_test.go) and remediation-text assertions (guide_test.go, doctor/forensics_test.go)

🤖 Generated with [Claude Code](https://claude.com/claude-code)