### PR TITLE
forensics: remove the GTID attribution tier from who-changed

### DIFF
--- a/internal/cli/whochanged.go
+++ b/internal/cli/whochanged.go
@@ -38,12 +38,10 @@ and a confidence grade (exact / corroborated / heuristic):
   1. audit log        — durable identity, works after disconnect; each
                         connection id is bounded by its CONNECT..DISCONNECT
                         lifetime so id reuse (pool churn) cannot misattribute
-  2. GTID join        — exact transaction match via performance_schema
-                        (only when gtid_mode is ON; never assumed)
-  3. performance_schema — live sessions on the source
-  4. connection_cache — identities cached by 'bintrail up' for sessions that
+  2. performance_schema — live sessions on the source
+  3. connection_cache — identities cached by 'bintrail up' for sessions that
                         already disconnected (--attribution-retention)
-  5. binlog only      — no identity available; the event is still returned
+  4. binlog only      — no identity available; the event is still returned
                         with an explanatory note, never an error
 
 When the source captures the original statement per row event
@@ -81,7 +79,7 @@ var (
 func init() {
 	f := whoChangedCmd.Flags()
 	f.StringVar(&wcIndexDSN, "index-dsn", "", "DSN for the index MySQL database (required)")
-	f.StringVar(&wcSourceDSN, "source-dsn", "", "DSN for the source MySQL server (optional; enables the audit-log, GTID, and performance_schema tiers)")
+	f.StringVar(&wcSourceDSN, "source-dsn", "", "DSN for the source MySQL server (optional; enables the audit-log and performance_schema tiers)")
 	f.StringVar(&wcSchema, "schema", "", "Schema of the changed table (required)")
 	f.StringVar(&wcTable, "table", "", "Changed table (required)")
 	f.StringVar(&wcPK, "pk", "", "Restrict to a single row's primary key (pipe-delimited for composite PKs)")

--- a/internal/console/forensics_api.go
+++ b/internal/console/forensics_api.go
@@ -244,7 +244,7 @@ func (s *Server) handleForensicsWhoChanged(w http.ResponseWriter, r *http.Reques
 		// would have, so this doesn't read as a silent downgrade to a
 		// worse attribution tier.
 		sourceUnreachable = "This server's source connection is configured but could not be reached, " +
-			"so the audit-log, GTID, and performance_schema attribution tiers were not consulted; " +
+			"so the audit-log and performance_schema attribution tiers were not consulted; " +
 			"only index-side sources ran."
 	default:
 		defer sourceDB.Close()

--- a/internal/forensics/whochanged.go
+++ b/internal/forensics/whochanged.go
@@ -17,8 +17,8 @@ import (
 type Confidence string
 
 // Confidence tiers (epic #701): exact means the identity join is positively
-// bounded (an audit-log CONNECT..DISCONNECT lifetime containing the event, or a
-// GTID transaction join); corroborated means the identity matched but its
+// bounded (an audit-log CONNECT..DISCONNECT lifetime containing the
+// event); corroborated means the identity matched but its
 // session lifetime could not be verified (nearest audit record without
 // brackets, the connection_cache, or a live performance_schema session — which
 // reflects the current holder of the connection id, and that id may have been
@@ -34,7 +34,6 @@ const (
 // Attribution sources, from most to least durable.
 const (
 	AttributionSourceAuditLog   = "audit_log"
-	AttributionSourceGTID       = "gtid"
 	AttributionSourcePerfSchema = "performance_schema"
 	AttributionSourceConnCache  = "connection_cache"
 )
@@ -103,8 +102,8 @@ type WhoChangedParams struct {
 type WhoChangedDeps struct {
 	// Fetch returns binlog events matching opts. Required.
 	Fetch func(ctx context.Context, opts query.Options) ([]query.ResultRow, error)
-	// SourceDB is the watched MySQL server, used for the audit-log, GTID, and
-	// live performance_schema tiers. nil skips those tiers (index-only mode).
+	// SourceDB is the watched MySQL server, used for the audit-log and live
+	// performance_schema tiers. nil skips those tiers (index-only mode).
 	SourceDB *sql.DB
 	// SourceHost is the resolved host[:port] of the source server (from the
 	// source DSN). It lets the audit-log tier reach the RDS/Aurora audit source
@@ -149,7 +148,7 @@ const (
 
 // WhoChanged fetches the binlog events matching params and attributes each to
 // a database session through the tier cascade: audit log (lifetime-bounded),
-// GTID transaction join, live performance_schema, connection_cache, and
+// live performance_schema, connection_cache, and
 // finally binlog-only with an explanatory note — degradation is an answer,
 // never an error. Only parameter validation and the binlog fetch itself can
 // fail; every attribution source degrades to the next tier.
@@ -308,9 +307,9 @@ func attributeEvents(ctx context.Context, deps WhoChangedDeps, rows []query.Resu
 	if deps.SourceDB != nil {
 		caps, err := DetectCapabilities(ctx, deps.SourceDB)
 		if err != nil {
-			slog.Warn("who-changed: source unreachable; skipping audit/gtid/performance_schema tiers",
+			slog.Warn("who-changed: source unreachable; skipping audit/performance_schema tiers",
 				"error", err)
-			notes = append(notes, "The source server was unreachable, so the audit-log, GTID, "+
+			notes = append(notes, "The source server was unreachable, so the audit-log "+
 				"and performance_schema attribution sources were NOT consulted; only "+
 				"index-side sources ran.")
 			deps.SourceDB = nil // local copy: disable the source tiers below
@@ -350,39 +349,6 @@ func attributeEvents(ctx context.Context, deps WhoChangedDeps, rows []query.Resu
 				}
 				for i, a := range attributeFromAudit(rows, auditRes.Events, truncated) {
 					attr[i] = a
-				}
-			}
-		}
-	}
-
-	// ── Tier 1.5: GTID — exact transaction join, detect-and-use ─────────────
-	// Runs only for events the audit tier left unresolved and only when
-	// gtid_mode is usable (never assumed: RDS/Aurora default OFF_PERMISSIVE,
-	// MariaDB has a different GTID model and no gtid_mode variable at all).
-	if deps.SourceDB != nil {
-		var gtids []string
-		seen := map[string]struct{}{}
-		for i := range rows {
-			if _, done := attr[i]; done {
-				continue
-			}
-			if g := rows[i].GTID; g != nil && *g != "" {
-				if _, dup := seen[*g]; !dup {
-					seen[*g] = struct{}{}
-					gtids = append(gtids, *g)
-				}
-			}
-		}
-		if len(gtids) > 0 && gtidAttributionUsable(ctx, deps.SourceDB) {
-			byGTID := attributeFromGTID(ctx, deps.SourceDB, gtids)
-			for i := range rows {
-				if _, done := attr[i]; done {
-					continue
-				}
-				if g := rows[i].GTID; g != nil {
-					if a, ok := byGTID[*g]; ok {
-						attr[i] = a
-					}
 				}
 			}
 		}
@@ -535,8 +501,8 @@ func lookupLiveThreads(ctx context.Context, sourceDB *sql.DB, ids []int64) (map[
 				// connection id, whose lifetime is not bounded against the
 				// event. A reused id (or COM_CHANGE_USER) can make the live
 				// session a different actor than the one that ran the event —
-				// the exact tiers (audit CONNECT..DISCONNECT, GTID) are the ones
-				// that positively bound identity to the event.
+				// the exact tier (audit CONNECT..DISCONNECT) is the one
+				// that positively bounds identity to the event.
 				Confidence: ConfidenceCorroborated,
 			}
 		}
@@ -788,87 +754,6 @@ func absDuration(d time.Duration) time.Duration {
 		return -d
 	}
 	return d
-}
-
-// ---------------------------------------------------------------------------
-// GTID tier: exact transaction join against performance_schema
-// ---------------------------------------------------------------------------
-
-// gtidAttributionUsable reports whether the source's GTID mode makes the
-// binlog gtid ↔ events_transactions_history join meaningful: ON or
-// ON_PERMISSIVE (new transactions carry GTIDs). Detect-and-use, never assume —
-// RDS/Aurora default OFF_PERMISSIVE, and MariaDB (different GTID model) has no
-// gtid_mode variable at all, so any probe failure means "not usable".
-func gtidAttributionUsable(ctx context.Context, sourceDB *sql.DB) bool {
-	var name, value string
-	err := sourceDB.QueryRowContext(ctx, "SHOW GLOBAL VARIABLES LIKE 'gtid_mode'").Scan(&name, &value)
-	if err != nil {
-		slog.Debug("who-changed: gtid_mode probe failed; skipping GTID tier", "error", err)
-		return false
-	}
-	return strings.HasPrefix(strings.ToUpper(value), "ON")
-}
-
-// attributeFromGTID joins binlog GTIDs against
-// performance_schema.events_transactions_history_long (then the per-thread
-// events_transactions_history) to the owning thread's user/host — an exact
-// transaction-level join, immune to connection-id reuse. Only live threads
-// resolve (performance_schema forgets a thread at disconnect); failures and
-// misses degrade silently to the next tier.
-func attributeFromGTID(ctx context.Context, sourceDB *sql.DB, gtids []string) map[string]Attribution {
-	out := map[string]Attribution{}
-	for _, table := range []string{"events_transactions_history_long", "events_transactions_history"} {
-		var missing []string
-		for _, g := range gtids {
-			if _, ok := out[g]; !ok {
-				missing = append(missing, g)
-			}
-		}
-		if len(missing) == 0 {
-			break
-		}
-
-		placeholders := make([]string, len(missing))
-		args := make([]any, len(missing))
-		for i, g := range missing {
-			placeholders[i] = "?"
-			args[i] = g
-		}
-		//nolint:gosec // table is one of two hardcoded constants above
-		rows, err := sourceDB.QueryContext(ctx, fmt.Sprintf(
-			"SELECT eth.GTID, t.PROCESSLIST_USER, t.PROCESSLIST_HOST "+
-				"FROM performance_schema.%s eth "+
-				"JOIN performance_schema.threads t ON t.THREAD_ID = eth.THREAD_ID "+
-				"WHERE eth.GTID IN (%s)", table, strings.Join(placeholders, ",")), args...)
-		if err != nil {
-			// Unlike the routine gtid_mode-absent probe miss (Debug), a failed
-			// join with gtid_mode ON is notable: consumers off or missing
-			// grants. Warn like the live tier's equivalent failure.
-			slog.Warn("who-changed: GTID tier query failed; continuing cascade",
-				"table", table, "error", err)
-			continue
-		}
-		for rows.Next() {
-			var gtid string
-			var user, host sql.NullString
-			if err := rows.Scan(&gtid, &user, &host); err != nil {
-				slog.Warn("who-changed: scan GTID join row", "error", err)
-				continue
-			}
-			if user.String == "" {
-				continue
-			}
-			out[gtid] = Attribution{
-				User: user.String, Host: host.String,
-				Source: AttributionSourceGTID, Confidence: ConfidenceExact,
-			}
-		}
-		if err := rows.Err(); err != nil {
-			slog.Warn("who-changed: iterate GTID join rows", "error", err)
-		}
-		rows.Close()
-	}
-	return out
 }
 
 // eventTypeName renders an event type for who-changed output using the same

--- a/internal/forensics/whochanged_integration_test.go
+++ b/internal/forensics/whochanged_integration_test.go
@@ -48,7 +48,7 @@ func fetchVia(eng *query.Engine) func(context.Context, query.Options) ([]query.R
 //	    an explanatory note and fallback SQL, never an error.
 //
 // The audit tier is unit-fixture territory (the test container runs no audit
-// plugin), and the GTID tier disables itself unless gtid_mode=ON.
+// plugin).
 func TestIntegrationWhoChanged_LiveThenCacheCascade(t *testing.T) {
 	indexDB, dbName := testutil.CreateTestDB(t)
 	testutil.InitIndexTables(t, indexDB)
@@ -118,7 +118,7 @@ func TestIntegrationWhoChanged_LiveThenCacheCascade(t *testing.T) {
 	// Corroborated, not exact: the live performance_schema tier reports the
 	// current holder of the connection id, whose session lifetime is not bounded
 	// against the event (a reused id could be a different actor). Only the audit
-	// CONNECT..DISCONNECT and GTID tiers earn "exact".
+	// CONNECT..DISCONNECT tier earns "exact".
 	if live.Attribution.Confidence != ConfidenceCorroborated {
 		t.Errorf("live confidence = %q, want %q", live.Attribution.Confidence, ConfidenceCorroborated)
 	}


### PR DESCRIPTION
## Why

Decided in the 2026-07-04 forensics review (see #752, last section). The GTID tier's preconditions almost never co-occur in production:

- `gtid_mode=ON` — RDS/Aurora default `OFF_PERMISSIVE`; MariaDB has no `gtid_mode` variable at all
- `performance_schema` `events_transactions_*` consumers enabled — MySQL default OFF
- the session still connected — `performance_schema` forgets a thread at disconnect
- the transaction still in the `events_transactions_history[_long]` ring buffer

When those DO co-occur, the live performance_schema tier resolves the same connection id — the GTID join only upgraded the confidence label to "exact". The tier also had zero direct test coverage. Removing it deletes an untested near-dead code path; it can be reintroduced with real justification if #709 (microsecond commit timestamps + XID capture) ever lands.

## What was removed

- `internal/forensics/whochanged.go`: the "Tier 1.5: GTID" block in `attributeEvents`, the `gtidAttributionUsable` and `attributeFromGTID` functions (with their section header), and the `AttributionSourceGTID` constant; all prose naming the tier (the `Confidence` tiers doc, the `WhoChanged` and `WhoChangedDeps.SourceDB` comments, the source-unreachable note + its slog message, the `lookupLiveThreads` comment)
- `internal/cli/whochanged.go`: the "GTID join" entry in the command's tier list (remaining tiers renumbered 1..4) and the `--source-dsn` flag description
- `internal/console/forensics_api.go`: the unreachable-source note no longer names a GTID tier
- `internal/forensics/whochanged_integration_test.go`: comments referencing the tier

Kept: the `GTID` field on `WhoChangedEvent` — that is binlog data display, unrelated to the attribution tier. Stream/replication GTID code is untouched. The console frontend displays `attribution.source` verbatim (no label map), so no JS change was needed. docs/*.md are handled in a separate docs PR.

`exact` confidence now comes exclusively from audit-log CONNECT..DISCONNECT lifetime bounding.

Resolves the GTID-tier question in #752 (option b: remove).

## Verification

- `go build ./...`, `go vet ./internal/forensics/ ./internal/cli/` clean
- `go vet -tags integration ./internal/forensics/ ./internal/cli/ ./internal/console/` clean (integration files still compile)
- `go test ./internal/forensics/ ./internal/cli/ ./internal/console/ -count=1` — all pass
- repo-wide grep confirms no remaining reference to `AttributionSourceGTID` / `attributeFromGTID` / `gtidAttributionUsable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)