### PR TITLE
forensics: remove ddl-history — superseded by the indexed DDL record

### DIFF
--- a/cliapp/forensics_commands_test.go
+++ b/cliapp/forensics_commands_test.go
@@ -12,7 +12,7 @@ import "testing"
 // bintrail-pg — which shares AddReadCommands — must not grow them. Like
 // doctor, they are registered by this binary only.
 func TestForensicsCommandsWiredOnRoot(t *testing.T) {
-	want := []string{"who-changed", "user-activity", "connection-history", "ddl-history"}
+	want := []string{"who-changed", "user-activity", "connection-history"}
 
 	have := make(map[string]bool)
 	for _, c := range rootCmd.Commands() {

--- a/internal/agent/command.go
+++ b/internal/agent/command.go
@@ -13,8 +13,8 @@
 //     server (performance_schema, audit plugin, server variant)
 //   - forensics_enrich        — live thread/connection attribution for a
 //     set of connection IDs
-//   - forensics_activity      — user_activity / connection_history /
-//     ddl_history queries against performance_schema
+//   - forensics_activity      — user_activity / connection_history
+//     queries against performance_schema
 //   - forensics_users         — list known MySQL user accounts
 //   - forensics_audit_log     — parse the server's on-disk audit log
 //
@@ -140,14 +140,13 @@ type ForensicsEnrichRequest struct {
 }
 
 // ForensicsActivityRequest is the payload for "forensics_activity" commands.
-// QueryType selects the mode ("user_activity", "connection_history", or
-// "ddl_history"); the remaining fields are mode-specific filters — see
-// forensics.ActivityQuery for which apply to which mode.
+// QueryType selects the mode ("user_activity" or "connection_history"); the
+// remaining fields are mode-specific filters — see forensics.ActivityQuery
+// for which apply to which mode.
 type ForensicsActivityRequest struct {
 	QueryType string `json:"query_type"`
 	User      string `json:"user,omitempty"`
 	Host      string `json:"host,omitempty"`
-	Schema    string `json:"schema,omitempty"`
 	// Since/Until accept MySQL DATETIME or ISO 8601 strings.
 	Since string `json:"since,omitempty"`
 	Until string `json:"until,omitempty"`

--- a/internal/agent/forensics_commands_test.go
+++ b/internal/agent/forensics_commands_test.go
@@ -117,7 +117,10 @@ func TestDispatch_forensicsActivity(t *testing.T) {
 			}, nil
 		},
 	}
-	// SaaS wire shape (models/forensics.py ForensicsQueryParams).
+	// SaaS wire shape (models/forensics.py ForensicsQueryParams). The "schema"
+	// key belonged to the removed DDL-history mode; older callers may still
+	// send it, so the payload keeps it here to pin that it is ignored, not a
+	// decode error.
 	raw := `{"query_type":"user_activity","user":"app","host":"10.0.0.5",` +
 		`"schema":"shop","since":"2026-07-01T00:00:00","until":"2026-07-02 00:00:00",` +
 		`"limit":25,"order":"ASC"}`
@@ -127,7 +130,7 @@ func TestDispatch_forensicsActivity(t *testing.T) {
 		t.Fatalf("unexpected error: %s", resp.Error)
 	}
 	want := ForensicsActivityRequest{
-		QueryType: "user_activity", User: "app", Host: "10.0.0.5", Schema: "shop",
+		QueryType: "user_activity", User: "app", Host: "10.0.0.5",
 		Since: "2026-07-01T00:00:00", Until: "2026-07-02 00:00:00", Limit: 25, Order: "ASC",
 	}
 	if got != want {
@@ -315,7 +318,7 @@ func TestDefaultHandler_forensicsCommandsRequireSourceDSN(t *testing.T) {
 			return err
 		},
 		"forensics_activity": func() error {
-			_, err := h.HandleForensicsActivity(ctx, ForensicsActivityRequest{QueryType: "ddl_history"})
+			_, err := h.HandleForensicsActivity(ctx, ForensicsActivityRequest{QueryType: "user_activity"})
 			return err
 		},
 		"forensics_users": func() error { _, err := h.HandleForensicsUsers(ctx); return err },

--- a/internal/agent/handler.go
+++ b/internal/agent/handler.go
@@ -377,22 +377,21 @@ func (h *DefaultHandler) HandleForensicsEnrich(ctx context.Context, req Forensic
 	return forensics.EnrichThreads(ctx, h.SourceDB, req.ThreadIDs)
 }
 
-// HandleForensicsActivity runs one of the three fixed activity queries
-// (user_activity, connection_history, ddl_history) against
-// performance_schema on the source server.
+// HandleForensicsActivity runs one of the two fixed activity queries
+// (user_activity, connection_history) against performance_schema on the
+// source server.
 func (h *DefaultHandler) HandleForensicsActivity(ctx context.Context, req ForensicsActivityRequest) (forensics.ActivityResult, error) {
 	if err := h.requireSourceDB(); err != nil {
 		return forensics.ActivityResult{}, err
 	}
 	return forensics.Activity(ctx, h.SourceDB, forensics.ActivityQuery{
-		Type:   req.QueryType,
-		User:   req.User,
-		Host:   req.Host,
-		Schema: req.Schema,
-		Since:  req.Since,
-		Until:  req.Until,
-		Limit:  req.Limit,
-		Order:  req.Order,
+		Type:  req.QueryType,
+		User:  req.User,
+		Host:  req.Host,
+		Since: req.Since,
+		Until: req.Until,
+		Limit: req.Limit,
+		Order: req.Order,
 	})
 }
 

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -25,7 +25,7 @@ func AddReadCommands(root *cobra.Command) {
 }
 
 // AddForensicsCommands registers the forensics read commands: who-changed,
-// user-activity, connection-history, and ddl-history (#706).
+// user-activity, and connection-history (#706).
 //
 // Deliberately NOT part of AddReadCommands: these commands interrogate
 // MySQL-family sources (performance_schema, the audit-plugin family, binlog
@@ -38,5 +38,4 @@ func AddForensicsCommands(root *cobra.Command) {
 	root.AddCommand(whoChangedCmd)
 	root.AddCommand(userActivityCmd)
 	root.AddCommand(connectionHistoryCmd)
-	root.AddCommand(ddlHistoryCmd)
 }

--- a/internal/cli/whochanged.go
+++ b/internal/cli/whochanged.go
@@ -282,7 +282,7 @@ func printFallbackQueries(w io.Writer, fqs []forensics.FallbackQuery) {
 	}
 }
 
-// ─── user-activity / connection-history / ddl-history ────────────────────────
+// ─── user-activity / connection-history ──────────────────────────────────────
 
 var userActivityCmd = &cobra.Command{
 	Use:   "user-activity",
@@ -309,27 +309,12 @@ Example:
 	RunE: runConnectionHistory,
 }
 
-var ddlHistoryCmd = &cobra.Command{
-	Use:   "ddl-history",
-	Short: "Show recent DDL statements from performance_schema",
-	Long: `Find CREATE/ALTER/DROP/RENAME/TRUNCATE statements in the source server's
-performance_schema statement history, optionally filtered by schema. For
-durable DDL history use the index instead: bintrail query --event-type DDL.
-
-Example:
-  bintrail ddl-history --source-dsn "$SRC" --schema shop`,
-	RunE: runDDLHistory,
-}
-
 var (
 	uaSourceDSN, uaUser, uaSince, uaUntil, uaOrder, uaFormat string
 	uaLimit                                                  int
 
 	chSourceDSN, chUser, chHost, chOrder, chFormat string
 	chLimit                                        int
-
-	dhSourceDSN, dhSchema, dhSince, dhUntil, dhOrder, dhFormat string
-	dhLimit                                                    int
 )
 
 func init() {
@@ -354,17 +339,6 @@ func init() {
 	f.StringVar(&chFormat, "format", "table", "Output format: table or json")
 	_ = connectionHistoryCmd.MarkFlagRequired("source-dsn")
 	BindCommandEnv(connectionHistoryCmd)
-
-	f = ddlHistoryCmd.Flags()
-	f.StringVar(&dhSourceDSN, "source-dsn", "", "DSN for the source MySQL server (required)")
-	f.StringVar(&dhSchema, "schema", "", "Filter DDL by schema")
-	f.StringVar(&dhSince, "since", "", "Time lower bound; shapes the generated fallback SQL only")
-	f.StringVar(&dhUntil, "until", "", "Time upper bound; shapes the generated fallback SQL only")
-	f.IntVar(&dhLimit, "limit", 50, "Maximum number of statements to return (capped at 1000)")
-	f.StringVar(&dhOrder, "order", "DESC", "Sort direction: ASC (oldest first) or DESC (newest first)")
-	f.StringVar(&dhFormat, "format", "table", "Output format: table or json")
-	_ = ddlHistoryCmd.MarkFlagRequired("source-dsn")
-	BindCommandEnv(ddlHistoryCmd)
 }
 
 func runUserActivity(cmd *cobra.Command, args []string) error {
@@ -394,18 +368,7 @@ func runConnectionHistory(cmd *cobra.Command, args []string) error {
 	})
 }
 
-func runDDLHistory(cmd *cobra.Command, args []string) error {
-	return runActivity(cmd, dhFormat, dhSourceDSN, forensics.ActivityQuery{
-		Type:   forensics.QueryDDLHistory,
-		Schema: dhSchema,
-		Since:  dhSince,
-		Until:  dhUntil,
-		Limit:  dhLimit,
-		Order:  dhOrder,
-	})
-}
-
-// runActivity is the shared body of the three thin activity wrappers over
+// runActivity is the shared body of the two thin activity wrappers over
 // forensics.Activity (#716): gate, validate, connect, query, render.
 func runActivity(cmd *cobra.Command, format, sourceDSN string, q forensics.ActivityQuery) error {
 	if !forensics.Enabled() {

--- a/internal/cli/whochanged_test.go
+++ b/internal/cli/whochanged_test.go
@@ -18,7 +18,7 @@ func TestAddForensicsCommands_RegistersAll(t *testing.T) {
 	root := &cobra.Command{Use: "test-root"}
 	AddForensicsCommands(root)
 
-	want := []string{"who-changed", "user-activity", "connection-history", "ddl-history"}
+	want := []string{"who-changed", "user-activity", "connection-history"}
 	have := map[string]bool{}
 	for _, c := range root.Commands() {
 		have[c.Use] = true
@@ -47,7 +47,6 @@ func TestForensicsCommands_GateClosed(t *testing.T) {
 		{"who-changed", runWhoChanged, whoChangedCmd},
 		{"user-activity", runUserActivity, userActivityCmd},
 		{"connection-history", runConnectionHistory, connectionHistoryCmd},
-		{"ddl-history", runDDLHistory, ddlHistoryCmd},
 	}
 	for _, tc := range cases {
 		err := tc.run(tc.cmd, nil)

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -1213,26 +1213,24 @@ function downloadEventsCSV(events) {
 }
 
 // ── Forensics ────────────────────────────────────────────────────────────────
-// Who changed a row, and three general investigation queries (user activity,
-// connection history, DDL history) against the SOURCE server's
+// Who changed a row, and two general investigation queries (user activity,
+// connection history) against the SOURCE server's
 // performance_schema / audit log (epic #701). Unlike Events (index-only),
 // these hit /api/forensics/*. Capabilities and who-changed degrade to a setup
 // prompt / index-only attribution when the selected server has no source
-// connection configured — but user-activity, connection-history, and
-// ddl-history have no index-side fallback and error instead (handled the
-// same way any other query error is: renderError in the results panel).
+// connection configured — but user-activity and connection-history have no
+// index-side fallback and error instead (handled the same way any other
+// query error is: renderError in the results panel).
 
 const FX_MODES = [
   { id: "who_changed", label: "Who changed", desc: "Trace who modified rows in a table (schema and table required, PK optional)." },
   { id: "user_activity", label: "User activity", desc: "Recent statements by a MySQL user." },
   { id: "connection_history", label: "Connections", desc: "Current/recent connections from a user or host." },
-  { id: "ddl_history", label: "DDL history", desc: "Recent CREATE / ALTER / DROP statements." },
 ];
 
 const FX_ACTIVITY_COLS = {
   user_activity: [["user", "User"], ["host", "Host"], ["sql_text", "SQL"], ["duration_ms", "Duration (ms)"], ["rows_affected", "Rows affected"], ["connection_id", "Conn ID"]],
   connection_history: [["user", "User"], ["host", "Host"], ["current_db", "Database"], ["command", "Command"], ["time_seconds", "Time (s)"], ["connection_id", "Conn ID"]],
-  ddl_history: [["user", "User"], ["host", "Host"], ["sql_text", "SQL"], ["duration_ms", "Duration (ms)"], ["connection_id", "Conn ID"]],
 };
 
 function renderForensics(params) {
@@ -1255,10 +1253,8 @@ function renderForensics(params) {
   v.append(el("p", { class: "fx-mode-desc", text: (FX_MODES.find((m) => m.id === mode) || FX_MODES[0]).desc }));
 
   const form = el("form", { class: "filters", id: "fx-form" });
-  if (mode === "who_changed" || mode === "ddl_history") {
-    form.append(fieldSelect("Schema", "schema", "md", true, false, null, "— select —", mode === "who_changed"));
-  }
   if (mode === "who_changed") {
+    form.append(fieldSelect("Schema", "schema", "md", true, false, null, "— select —", true));
     form.append(fieldSelect("Table", "table", "md", false, true, null, null, true));
     form.append(fieldInput("PK", "pk", "sm", "42 or 42|7"));
   }
@@ -1283,7 +1279,7 @@ function renderForensics(params) {
   v.append(out);
 
   form.addEventListener("submit", (e) => { e.preventDefault(); runForensicsQuery(mode, form); });
-  if (mode === "who_changed" || mode === "ddl_history") { wireSchemaCascade(form); populateSchemas(form); }
+  if (mode === "who_changed") { wireSchemaCascade(form); populateSchemas(form); }
 
   fxLoadCapabilities();
   viewEnter();
@@ -1313,8 +1309,8 @@ function buildFxCapsBanner(caps) {
     wrap.append(el("div", { class: "stg-empty" },
       el("p", { class: "stg-empty-lead", text: "No source connection configured for this server." }),
       el("p", { class: "stg-empty-sub", text:
-        "Who-changed still works from the index alone (connection_cache and binlog-only attribution), but user activity, " +
-        "connection history, and DDL history all read the source directly. Add a source connection from Manage servers → Edit to unlock them." })));
+        "Who-changed still works from the index alone (connection_cache and binlog-only attribution), but user activity " +
+        "and connection history read the source directly. Add a source connection from Manage servers → Edit to unlock them." })));
     return wrap;
   }
   const ps = caps.performance_schema || {};
@@ -1422,7 +1418,7 @@ async function runForensicsQuery(mode, form) {
     } else {
       data = await api("/api/forensics/activity", { method: "POST", body: {
         query_type: mode, user: f.user || undefined, host: f.host || undefined,
-        schema: f.schema || undefined, since: f.since || undefined, until: f.until || undefined,
+        since: f.since || undefined, until: f.until || undefined,
         limit: f.limit ? Number(f.limit) : undefined, order: f.order || undefined,
       } });
     }

--- a/internal/console/forensics_api.go
+++ b/internal/console/forensics_api.go
@@ -56,12 +56,11 @@ type whoChangedRequest struct {
 
 // forensicsActivityRequest is the JSON body accepted by POST
 // /api/forensics/activity. QueryType selects one of forensics'
-// QueryUserActivity/QueryConnectionHistory/QueryDDLHistory.
+// QueryUserActivity/QueryConnectionHistory.
 type forensicsActivityRequest struct {
 	QueryType string `json:"query_type"`
 	User      string `json:"user"`
 	Host      string `json:"host"`
-	Schema    string `json:"schema"`
 	Since     string `json:"since"`
 	Until     string `json:"until"`
 	Limit     int    `json:"limit"`
@@ -279,9 +278,9 @@ func (s *Server) handleForensicsWhoChanged(w http.ResponseWriter, r *http.Reques
 	writeJSON(w, http.StatusOK, res)
 }
 
-// handleForensicsActivity serves POST /api/forensics/activity: the three
-// general investigation modes (user_activity / connection_history /
-// ddl_history) against the selected server's performance_schema. Unlike
+// handleForensicsActivity serves POST /api/forensics/activity: the two
+// general investigation modes (user_activity / connection_history)
+// against the selected server's performance_schema. Unlike
 // who-changed, these modes have no index-side fallback — they require a
 // configured source connection.
 func (s *Server) handleForensicsActivity(w http.ResponseWriter, r *http.Request) {
@@ -294,10 +293,10 @@ func (s *Server) handleForensicsActivity(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	switch body.QueryType {
-	case forensics.QueryUserActivity, forensics.QueryConnectionHistory, forensics.QueryDDLHistory:
+	case forensics.QueryUserActivity, forensics.QueryConnectionHistory:
 	default:
 		writeJSONError(w, http.StatusBadRequest,
-			"query_type must be one of user_activity, connection_history, ddl_history")
+			"query_type must be one of user_activity, connection_history")
 		return
 	}
 	if body.QueryType == forensics.QueryUserActivity && body.User == "" {
@@ -322,14 +321,13 @@ func (s *Server) handleForensicsActivity(w http.ResponseWriter, r *http.Request)
 	defer sourceDB.Close()
 
 	res, err := forensics.Activity(r.Context(), sourceDB, forensics.ActivityQuery{
-		Type:   body.QueryType,
-		User:   body.User,
-		Host:   body.Host,
-		Schema: body.Schema,
-		Since:  body.Since,
-		Until:  body.Until,
-		Limit:  body.Limit,
-		Order:  body.Order,
+		Type:  body.QueryType,
+		User:  body.User,
+		Host:  body.Host,
+		Since: body.Since,
+		Until: body.Until,
+		Limit: body.Limit,
+		Order: body.Order,
 	})
 	if err != nil {
 		// By this point query_type/user/host preconditions are already

--- a/internal/console/forensics_api_test.go
+++ b/internal/console/forensics_api_test.go
@@ -228,7 +228,7 @@ func TestHandleForensicsActivity_NoSourceConfigured(t *testing.T) {
 	s := newBootServer(nil)
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/forensics/activity",
-		strings.NewReader(`{"query_type":"ddl_history"}`))
+		strings.NewReader(`{"query_type":"connection_history","user":"root"}`))
 	s.handleForensicsActivity(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400; body = %s", rec.Code, rec.Body.String())

--- a/internal/console/reconstruct.go
+++ b/internal/console/reconstruct.go
@@ -53,7 +53,7 @@ type capabilitiesResponse struct {
 	// profile cascade victim synthesis cannot honor redaction, so the endpoint
 	// refuses (see handleRecoverCascade). Process-global, like Monitor.
 	RecoverCascade bool `json:"recover_cascade"`
-	// Forensics: the who-changed/user-activity/connection-history/ddl-history
+	// Forensics: the who-changed/user-activity/connection-history
 	// investigation surface is available (epic #701). Gated by the single
 	// entitlement seam (forensics.Enabled) and, like RecoverCascade, refused
 	// while an RBAC redaction profile is active — forensic output includes
@@ -61,7 +61,7 @@ type capabilitiesResponse struct {
 	// the selected server's bundle — per-server "no source configured" is a
 	// property of the SELECTED server, handled inside the forensics endpoints
 	// themselves (who-changed degrades to index-only attribution; the other
-	// three modes have no fallback and error), not this process-wide flag.
+	// two modes have no fallback and error), not this process-wide flag.
 	Forensics bool `json:"forensics"`
 	// RecoverCascadeBaseline: cascade recovery's Phase-2 (recover children
 	// untouched within the window) is active for this server. Per-server, and gated

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -674,8 +674,8 @@ func countVisibleSchemas(ctx context.Context, db *sql.DB, schemas []string) (int
 }
 
 // forensicsConsumers are the performance_schema setup_consumers rows the
-// forensic activity queries (user_activity / ddl_history) read from. Listed in
-// the order they should appear in the check detail.
+// user_activity forensic query reads from. Listed in the order they should
+// appear in the check detail.
 var forensicsConsumers = []string{"events_statements_history", "events_statements_history_long"}
 
 // checkPerformanceSchema reports whether performance_schema — and the two

--- a/internal/forensics/activity.go
+++ b/internal/forensics/activity.go
@@ -12,17 +12,15 @@ import (
 const (
 	QueryUserActivity      = "user_activity"
 	QueryConnectionHistory = "connection_history"
-	QueryDDLHistory        = "ddl_history"
 )
 
-// ActivityQuery selects one of the three forensic activity query modes and
+// ActivityQuery selects one of the two forensic activity query modes and
 // carries its filters. Fields not used by the selected Type are ignored.
 type ActivityQuery struct {
-	// Type is one of QueryUserActivity, QueryConnectionHistory, QueryDDLHistory.
-	Type   string
-	User   string // required for user_activity; optional filter for connection_history
-	Host   string // optional filter for connection_history (one of User/Host required there)
-	Schema string // optional filter for ddl_history
+	// Type is one of QueryUserActivity, QueryConnectionHistory.
+	Type string
+	User string // required for user_activity; optional filter for connection_history
+	Host string // optional filter for connection_history (one of User/Host required there)
 	// Since/Until accept MySQL DATETIME or ISO 8601 strings. performance_schema
 	// ring buffers have no wall-clock column, so these only shape the generated
 	// fallback SQL (general_log filters) — they never filter the live query.
@@ -33,7 +31,7 @@ type ActivityQuery struct {
 }
 
 // ActivityResult is the outcome of an activity query. Events is populated for
-// user_activity and ddl_history; Connections for connection_history. When the
+// user_activity; Connections for connection_history. When the
 // needed performance_schema data is unavailable, Source is "fallback" and
 // FallbackQueries carries executable SQL for manual investigation —
 // fallback-over-error is the point: a degraded source is an answer, not an
@@ -48,8 +46,8 @@ type ActivityResult struct {
 	FallbackQueries []FallbackQuery  `json:"fallback_queries,omitempty"`
 }
 
-// Activity runs a general forensic query (user activity, connection history,
-// or DDL history) against performance_schema on the source server. It returns
+// Activity runs a general forensic query (user activity or connection
+// history) against performance_schema on the source server. It returns
 // an error only for invalid parameters or an unknown query type; data-source
 // failures degrade to fallback SQL inside the result.
 func Activity(ctx context.Context, sourceDB *sql.DB, q ActivityQuery) (ActivityResult, error) {
@@ -73,11 +71,9 @@ func Activity(ctx context.Context, sourceDB *sql.DB, q ActivityQuery) (ActivityR
 			return ActivityResult{}, fmt.Errorf("user or host is required for %s query", QueryConnectionHistory)
 		}
 		return handleConnectionHistory(ctx, sourceDB, q.User, q.Host, limit, ascending), nil
-	case QueryDDLHistory:
-		return handleDDLHistory(ctx, sourceDB, q.Schema, q.Since, q.Until, limit, ascending), nil
 	default:
-		return ActivityResult{}, fmt.Errorf("unknown query_type %q: must be %s, %s, or %s",
-			q.Type, QueryUserActivity, QueryConnectionHistory, QueryDDLHistory)
+		return ActivityResult{}, fmt.Errorf("unknown query_type %q: must be %s or %s",
+			q.Type, QueryUserActivity, QueryConnectionHistory)
 	}
 }
 
@@ -439,93 +435,6 @@ func queryConnections(ctx context.Context, db *sql.DB, user, host string, limit 
 	return connections, rows.Err()
 }
 
-// handleDDLHistory queries for DDL events from performance_schema.
-func handleDDLHistory(ctx context.Context, db *sql.DB, schema, since, until string, limit int, ascending bool) ActivityResult {
-	since = normalizeTimestamp(since)
-	until = normalizeTimestamp(until)
-
-	// Try events_statements_history_long for DDL statements.
-	events, err := queryDDLStatements(ctx, db, schema, limit, ascending)
-	if err != nil {
-		slog.Warn("forensics: ddl_history query failed", "error", err)
-		return ActivityResult{
-			Events:          []map[string]any{},
-			Source:          "fallback",
-			FallbackQueries: generateDDLFallback(schema, since, until, limit),
-			Note:            perfSchemaGrantNote(err),
-		}
-	}
-
-	return ActivityResult{
-		Events: events,
-		Source: "performance_schema",
-		Count:  len(events),
-	}
-}
-
-// queryDDLStatements finds DDL statements in events_statements_history_long.
-func queryDDLStatements(ctx context.Context, db *sql.DB, schema string, limit int, ascending bool) ([]map[string]any, error) {
-	query := `SELECT
-		t.PROCESSLIST_ID AS connection_id,
-		t.PROCESSLIST_USER AS user,
-		t.PROCESSLIST_HOST AS host,
-		esh.SQL_TEXT AS sql_text,
-		esh.TIMER_WAIT / 1000000000 AS duration_ms
-	FROM performance_schema.events_statements_history_long esh
-	JOIN performance_schema.threads t ON t.THREAD_ID = esh.THREAD_ID
-	WHERE (esh.SQL_TEXT LIKE 'CREATE %'
-		OR esh.SQL_TEXT LIKE 'ALTER %'
-		OR esh.SQL_TEXT LIKE 'DROP %'
-		OR esh.SQL_TEXT LIKE 'RENAME %'
-		OR esh.SQL_TEXT LIKE 'TRUNCATE %')`
-
-	var args []any
-	if schema != "" {
-		query += " AND esh.CURRENT_SCHEMA = ?"
-		args = append(args, schema)
-	}
-	orderDir := "DESC"
-	if ascending {
-		orderDir = "ASC"
-	}
-	query += " ORDER BY esh.TIMER_START " + orderDir
-	query += fmt.Sprintf(" LIMIT %d", limit)
-
-	rows, err := db.QueryContext(ctx, query, args...)
-	if err != nil {
-		return nil, fmt.Errorf("query DDL statements: %w", err)
-	}
-	defer rows.Close()
-
-	var events []map[string]any
-	for rows.Next() {
-		var connID int64
-		var sqlUser, host string
-		var sqlText sql.NullString
-		var durationMS float64
-
-		if err := rows.Scan(&connID, &sqlUser, &host, &sqlText, &durationMS); err != nil {
-			slog.Warn("forensics: scan DDL row", "error", err)
-			continue
-		}
-
-		event := map[string]any{
-			"connection_id": connID,
-			"user":          sqlUser,
-			"host":          host,
-			"duration_ms":   durationMS,
-		}
-		if sqlText.Valid {
-			event["sql_text"] = sqlText.String
-		}
-		events = append(events, event)
-	}
-	if events == nil {
-		events = []map[string]any{}
-	}
-	return events, rows.Err()
-}
-
 // ---------------------------------------------------------------------------
 // Fallback query generators — used when performance_schema data is unavailable
 // ---------------------------------------------------------------------------
@@ -612,38 +521,4 @@ func generateConnectionFallback(user, host string, limit int) []FallbackQuery {
 				"FROM performance_schema.hosts WHERE HOST IS NOT NULL ORDER BY TOTAL_CONNECTIONS DESC",
 		},
 	}
-}
-
-func generateDDLFallback(schema, since, until string, limit int) []FallbackQuery {
-	queries := []FallbackQuery{
-		{
-			Description: "Use bintrail's indexed DDL events instead",
-			SQL:         "-- Use `bintrail query --event-type ddl` or the list_schema_changes MCP tool instead",
-		},
-	}
-
-	timeFilter := ""
-	if since != "" {
-		timeFilter += fmt.Sprintf(" AND event_time >= '%s'", sqlEscape(since))
-	}
-	if until != "" {
-		timeFilter += fmt.Sprintf(" AND event_time <= '%s'", sqlEscape(until))
-	}
-	schemaFilter := ""
-	if schema != "" {
-		schemaFilter = fmt.Sprintf(" AND argument LIKE '%%%s%%'", sqlEscape(schema))
-	}
-
-	queries = append(queries, FallbackQuery{
-		Description: "Check general log for DDL statements (if general_log is ON)",
-		SQL: fmt.Sprintf(
-			"SELECT event_time, user_host, thread_id, argument "+
-				"FROM mysql.general_log "+
-				"WHERE command_type = 'Query' "+
-				"AND (argument LIKE 'CREATE %%' OR argument LIKE 'ALTER %%' "+
-				"OR argument LIKE 'DROP %%' OR argument LIKE 'RENAME %%')%s%s "+
-				"ORDER BY event_time DESC LIMIT %d", schemaFilter, timeFilter, limit),
-	})
-
-	return queries
 }

--- a/internal/forensics/activity_test.go
+++ b/internal/forensics/activity_test.go
@@ -268,37 +268,9 @@ func TestActivityConnectionHistoryFallbackOnQueryError(t *testing.T) {
 	}
 }
 
-func TestActivityDDLHistoryHappyPath(t *testing.T) {
-	db, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("sqlmock: %v", err)
-	}
-	defer db.Close()
-
-	ddlCols := []string{"connection_id", "user", "host", "sql_text", "duration_ms"}
-	mock.ExpectQuery("events_statements_history_long esh").
-		WithArgs("shop").
-		WillReturnRows(sqlmock.NewRows(ddlCols).
-			AddRow(3, "admin", "10.0.0.9", "ALTER TABLE orders ADD COLUMN note TEXT", 88.0))
-
-	res, err := Activity(t.Context(), db, ActivityQuery{Type: QueryDDLHistory, Schema: "shop"})
-	if err != nil {
-		t.Fatalf("Activity: %v", err)
-	}
-	if res.Source != "performance_schema" || res.Count != 1 {
-		t.Fatalf("result = source=%q count=%d, want performance_schema/1", res.Source, res.Count)
-	}
-	if res.Events[0]["sql_text"] != "ALTER TABLE orders ADD COLUMN note TEXT" {
-		t.Errorf("sql_text = %v", res.Events[0]["sql_text"])
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Errorf("unmet expectations: %v", err)
-	}
-}
-
-// TestActivityDDLHistoryFallbackCapsLimit exercises the DDL fallback path and
+// TestActivityUserActivityFallbackCapsLimit exercises the fallback path and
 // pins the limit cap: 5000 must clamp to 1000 in the generated SQL.
-func TestActivityDDLHistoryFallbackCapsLimit(t *testing.T) {
+func TestActivityUserActivityFallbackCapsLimit(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock: %v", err)
@@ -308,7 +280,7 @@ func TestActivityDDLHistoryFallbackCapsLimit(t *testing.T) {
 	mock.ExpectQuery("events_statements_history_long esh").
 		WillReturnError(errors.New("denied"))
 
-	res, err := Activity(t.Context(), db, ActivityQuery{Type: QueryDDLHistory, Limit: 5000})
+	res, err := Activity(t.Context(), db, ActivityQuery{Type: QueryUserActivity, User: "app_user", Limit: 5000})
 	if err != nil {
 		t.Fatalf("Activity: %v", err)
 	}
@@ -397,20 +369,6 @@ func TestGenerateConnectionFallback(t *testing.T) {
 	hostOnly := generateConnectionFallback("", "10.0.1.50", 50)
 	if strings.Contains(hostOnly[0].SQL, "USER =") {
 		t.Errorf("host-only filter must not reference USER: %s", hostOnly[0].SQL)
-	}
-}
-
-func TestGenerateDDLFallback(t *testing.T) {
-	queries := generateDDLFallback("mydb", "2026-03-01", "2026-03-10", 50)
-
-	if len(queries) < 1 {
-		t.Fatalf("expected at least 1 fallback query, got %d", len(queries))
-	}
-	genLog := queries[len(queries)-1]
-	for _, want := range []string{"mydb", "2026-03-01", "2026-03-10", "general_log"} {
-		if !strings.Contains(genLog.SQL, want) {
-			t.Errorf("general_log DDL fallback missing %q: %s", want, genLog.SQL)
-		}
 	}
 }
 

--- a/internal/forensics/forensics_integration_test.go
+++ b/internal/forensics/forensics_integration_test.go
@@ -209,7 +209,7 @@ func TestIntegrationEnrichThreads(t *testing.T) {
 	}
 }
 
-// TestIntegrationActivity runs the three query modes live. Ring-buffer
+// TestIntegrationActivity runs the two query modes live. Ring-buffer
 // contents depend on server history, so assertions target the contract:
 // no errors, and fallback (with executable SQL) whenever data is absent.
 func TestIntegrationActivity(t *testing.T) {

--- a/internal/forensics/forensics_integration_test.go
+++ b/internal/forensics/forensics_integration_test.go
@@ -265,18 +265,6 @@ func TestIntegrationActivity(t *testing.T) {
 		}
 	})
 
-	t.Run("ddl_history returns cleanly", func(t *testing.T) {
-		res, err := Activity(ctx, db, ActivityQuery{Type: QueryDDLHistory})
-		if err != nil {
-			t.Fatalf("Activity: %v", err)
-		}
-		if res.Source != "performance_schema" && res.Source != "fallback" {
-			t.Errorf("Source = %q, want performance_schema or fallback", res.Source)
-		}
-		if res.Source == "fallback" && len(res.FallbackQueries) == 0 {
-			t.Error("fallback source but no fallback queries")
-		}
-	})
 }
 
 func TestIntegrationListUsers(t *testing.T) {

--- a/internal/forensics/guide.go
+++ b/internal/forensics/guide.go
@@ -91,8 +91,8 @@ func BuildSetupGuide(caps Capabilities) SetupGuide {
 				Description: "The events_statements_history_long consumer is disabled. This " +
 					"global ring buffer stores recent SQL statements across all " +
 					"connections — critical for forensic investigation of past activity.",
-				Impact: "Enables user_activity queries and DDL history across all " +
-					"connections. This is the primary data source for forensic " +
+				Impact: "Enables user_activity queries across all connections. " +
+					"This is the primary data source for forensic " +
 					"statement analysis.",
 				PerformanceNote: "Stores the last 10,000 statements globally by default. " +
 					"Memory usage is fixed (not per-connection). Adjust " +


### PR DESCRIPTION
## Rationale

Decided in the 2026-07-04 forensics review. `ddl-history` read DDL from performance_schema's `events_statements_history_long` ring buffer — roughly the last 10k statements server-wide, with no wall-clock timestamps, no time filtering, and prefix-matching on `SQL_TEXT`. Meanwhile bintrail already keeps a durable, complete DDL record parsed from the binlog: the `schema_changes` table, served by `bintrail query --event-type ddl` and the `list_schema_changes` MCP tool (docs/ddl-tracking.md). The feature's own first fallback message literally said: "Use `bintrail query --event-type ddl` or the list_schema_changes MCP tool instead". This removes a strictly-worse duplicate of an existing feature.

## Removal scope

- **CLI** (`internal/cli`): the `ddl-history` command, its flags, and its registration in `AddForensicsCommands`. The shared `runActivity` helper stays — `user-activity` and `connection-history` still use it.
- **Engine** (`internal/forensics`): `QueryDDLHistory`, its `Activity()` dispatch case, `handleDDLHistory`, `queryDDLStatements`, `generateDDLFallback`, and the now-unused `ActivityQuery.Schema` field. The unknown-query_type error now lists the two remaining modes.
- **Console** (`internal/console`): `ddl_history` removed from the `/api/forensics/activity` query_type validation and request struct; the Forensics view's DDL-history mode (tab, columns, schema-filter field wiring) removed from `app.js`.
- **Agent** (`internal/agent`): the `forensics_activity` command vocabulary no longer lists `ddl_history`; the request's `schema` passthrough is gone. A legacy `"schema"` wire key from older callers is still tolerated and ignored on decode — pinned by test.
- **Collateral**: comment/text updates in `internal/doctor` (forensicsConsumers), the forensics setup guide's history_long Impact text, and the console capabilities doc comment. Test coverage moved to the remaining modes (the limit-cap fallback pin now runs against `user_activity`).

`docs/*.md` are deliberately untouched — a separate docs PR handles them.

## Where DDL questions are answered now

`bintrail query --event-type ddl`, the `list_schema_changes` MCP tool, and docs/ddl-tracking.md — the durable, binlog-derived record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)