### PR TITLE
baseline: exclude GENERATED columns from ParseSchema, fail loud on arity mismatch

### DIFF
--- a/internal/baseline/baseline.go
+++ b/internal/baseline/baseline.go
@@ -308,6 +308,17 @@ func processTable(ctx context.Context, tf TableFiles, outPath string, cfg Writer
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
+		// A row's value count must match the schema's column count exactly.
+		// WriteRow tolerates a short row by NULL-padding the missing tail
+		// (mysqlIdx >= len(nulls)) — a defensive bounds check, not a supported
+		// layout — so a genuine mismatch (e.g. ParseSchema's generated-column
+		// detection missing an unusual DDL shape) would otherwise shift or
+		// silently NULL a real column instead of failing loud (issue #767).
+		if len(values) != len(cols) {
+			return fmt.Errorf("row has %d values but schema %s has %d columns "+
+				"(generated columns are excluded from both) — dump/schema mismatch for %s.%s",
+				len(values), tf.SchemaFile, len(cols), tf.Database, tf.Table)
+		}
 		if err := w.WriteRow(values, nulls); err != nil {
 			return err
 		}

--- a/internal/baseline/generated_column_test.go
+++ b/internal/baseline/generated_column_test.go
@@ -1,0 +1,299 @@
+package baseline
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	_ "github.com/duckdb/duckdb-go/v2" // DuckDB driver — exercises the real read path
+)
+
+// TestParseSchemaExcludesGeneratedColumn pins the issue #767 fix at the source:
+// ParseSchema must drop STORED and VIRTUAL generated columns from the returned
+// column list entirely, because mydumper/mysqldump never emit their values in
+// the INSERT column-list or VALUES tuples. Before the fix, ParseSchema kept
+// them, so every column declared after a generated one was mapped to the
+// wrong positional slot in WriteRow.
+func TestParseSchemaExcludesGeneratedColumn(t *testing.T) {
+	const schema = "CREATE TABLE `orders` (\n" +
+		"  `id` int NOT NULL,\n" +
+		"  `price` decimal(10,2) NOT NULL,\n" +
+		"  `total` decimal(10,2) GENERATED ALWAYS AS (`price` * 2) STORED,\n" +
+		"  `full_name` varchar(101) GENERATED ALWAYS AS (concat(`price`,`note`)) VIRTUAL,\n" +
+		"  `note` varchar(64) DEFAULT NULL,\n" +
+		"  PRIMARY KEY (`id`)\n" +
+		") ENGINE=InnoDB;\n"
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "shop.orders-schema.sql")
+	if err := os.WriteFile(path, []byte(schema), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cols, err := ParseSchema(path)
+	if err != nil {
+		t.Fatalf("ParseSchema: %v", err)
+	}
+
+	wantNames := []string{"id", "price", "note"}
+	if len(cols) != len(wantNames) {
+		t.Fatalf("got %d columns %v, want %d (%v) — generated columns must be excluded",
+			len(cols), colNames(cols), len(wantNames), wantNames)
+	}
+	for i, name := range wantNames {
+		if cols[i].Name != name {
+			t.Errorf("col[%d].Name = %q, want %q", i, cols[i].Name, name)
+		}
+	}
+}
+
+// TestParseSchemaExcludesGeneratedColumnMariaDBForm pins detection of
+// MariaDB's shorter accepted generated-column syntax — "AS (expr) PERSISTENT"
+// without the "GENERATED ALWAYS" prefix MySQL always emits — so a MariaDB
+// source's schema dump doesn't slip past generatedRe and reintroduce the
+// #767 shift for MariaDB users.
+func TestParseSchemaExcludesGeneratedColumnMariaDBForm(t *testing.T) {
+	const schema = "CREATE TABLE `orders` (\n" +
+		"  `id` int NOT NULL,\n" +
+		"  `price` decimal(10,2) NOT NULL,\n" +
+		"  `total` decimal(10,2) AS (`price` * 2) PERSISTENT,\n" +
+		"  `note` varchar(64) DEFAULT NULL,\n" +
+		"  PRIMARY KEY (`id`)\n" +
+		") ENGINE=InnoDB;\n"
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "shop.orders-schema.sql")
+	if err := os.WriteFile(path, []byte(schema), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cols, err := ParseSchema(path)
+	if err != nil {
+		t.Fatalf("ParseSchema: %v", err)
+	}
+
+	wantNames := []string{"id", "price", "note"}
+	if len(cols) != len(wantNames) {
+		t.Fatalf("got %d columns %v, want %d (%v) — MariaDB-form generated column must be excluded",
+			len(cols), colNames(cols), len(wantNames), wantNames)
+	}
+	for i, name := range wantNames {
+		if cols[i].Name != name {
+			t.Errorf("col[%d].Name = %q, want %q", i, cols[i].Name, name)
+		}
+	}
+}
+
+func colNames(cols []Column) []string {
+	names := make([]string, len(cols))
+	for i, c := range cols {
+		names[i] = c.Name
+	}
+	return names
+}
+
+// TestProcessTableGeneratedColumnMiddle is the end-to-end arbiter for issue
+// #767: a table with a GENERATED STORED column sandwiched between two ordinary
+// columns must not shift the trailing column's value into the generated
+// column's old slot (or NULL it out). It drives the real production path
+// (processTable → ParseSchema + ReadSQLFile + WriteRow) with a mydumper-style
+// schema + data file pair, matching real dump output: the INSERT carries an
+// explicit column-list that already omits `total`.
+func TestProcessTableGeneratedColumnMiddle(t *testing.T) {
+	const schema = "CREATE TABLE `orders` (\n" +
+		"  `id` int NOT NULL,\n" +
+		"  `price` decimal(10,2) NOT NULL,\n" +
+		"  `total` decimal(10,2) GENERATED ALWAYS AS (`price` * 2) STORED,\n" +
+		"  `note` varchar(64) DEFAULT NULL,\n" +
+		"  PRIMARY KEY (`id`)\n" +
+		") ENGINE=InnoDB;\n"
+	const data = "INSERT INTO `orders` (`id`,`price`,`note`) VALUES(1,10.50,'hello');\n"
+
+	dir := t.TempDir()
+	schemaPath := filepath.Join(dir, "shop.orders-schema.sql")
+	dataPath := filepath.Join(dir, "shop.orders.00000.sql")
+	if err := os.WriteFile(schemaPath, []byte(schema), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dataPath, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tf := TableFiles{
+		Database:   "shop",
+		Table:      "orders",
+		SchemaFile: schemaPath,
+		DataFiles:  []string{dataPath},
+		Format:     "sql",
+	}
+	outPath := filepath.Join(dir, "orders.parquet")
+	rowCount, err := processTable(context.Background(), tf, outPath, WriterConfig{Compression: "none", RowGroupSize: 100})
+	if err != nil {
+		t.Fatalf("processTable: %v", err)
+	}
+	if rowCount != 1 {
+		t.Fatalf("rowCount = %d, want 1", rowCount)
+	}
+
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open duckdb: %v", err)
+	}
+	defer db.Close()
+
+	safePath := strings.ReplaceAll(outPath, "'", "''")
+	var id int64
+	var price float64
+	var note any
+	row := db.QueryRowContext(context.Background(),
+		"SELECT id, price, note FROM parquet_scan('"+safePath+"')")
+	if err := row.Scan(&id, &price, &note); err != nil {
+		t.Fatalf("scan parquet_scan row: %v", err)
+	}
+
+	if id != 1 {
+		t.Errorf("id = %d, want 1", id)
+	}
+	if price != 10.50 {
+		t.Errorf("price = %v, want 10.50", price)
+	}
+	// The load-bearing assertion: before the fix, `note`'s value ("hello")
+	// landed in `total`'s Parquet slot (or an incompatible type caused a
+	// conversion error) and `note` itself read back NULL.
+	noteStr, ok := note.(string)
+	if !ok {
+		t.Fatalf("note scanned as %T (%v), want string %q — value likely shifted or lost", note, note, "hello")
+	}
+	if noteStr != "hello" {
+		t.Errorf("note = %q, want %q", noteStr, "hello")
+	}
+
+	// The Parquet schema itself must not carry a `total` column — it was never
+	// dumped, so there is no data to store for it.
+	rows, err := db.QueryContext(context.Background(), "DESCRIBE SELECT * FROM parquet_scan('"+safePath+"')")
+	if err != nil {
+		t.Fatalf("describe parquet_scan: %v", err)
+	}
+	defer rows.Close()
+	var gotCols []string
+	for rows.Next() {
+		var colName, colType string
+		var rest any
+		// DuckDB's DESCRIBE returns 6 columns; only the first (name) matters here.
+		dest := []any{&colName, &colType, &rest, &rest, &rest, &rest}
+		if err := rows.Scan(dest...); err != nil {
+			t.Fatalf("scan describe row: %v", err)
+		}
+		gotCols = append(gotCols, colName)
+	}
+	for _, c := range gotCols {
+		if c == "total" {
+			t.Errorf("Parquet schema contains %q, want it excluded (generated column)", gotCols)
+		}
+	}
+}
+
+// TestProcessTableGeneratedColumnMiddleTabFormat mirrors
+// TestProcessTableGeneratedColumnMiddle for mydumper's tab (--load-data)
+// output format, locking in that the same ParseSchema fix — the only place
+// the fix lives, shared by both readers — keeps the tab-format pipeline
+// aligned too.
+func TestProcessTableGeneratedColumnMiddleTabFormat(t *testing.T) {
+	const schema = "CREATE TABLE `orders` (\n" +
+		"  `id` int NOT NULL,\n" +
+		"  `price` decimal(10,2) NOT NULL,\n" +
+		"  `total` decimal(10,2) GENERATED ALWAYS AS (`price` * 2) STORED,\n" +
+		"  `note` varchar(64) DEFAULT NULL,\n" +
+		"  PRIMARY KEY (`id`)\n" +
+		") ENGINE=InnoDB;\n"
+	const data = "1\t10.50\thello\n"
+
+	dir := t.TempDir()
+	schemaPath := filepath.Join(dir, "shop.orders-schema.sql")
+	dataPath := filepath.Join(dir, "shop.orders.00000.dat")
+	if err := os.WriteFile(schemaPath, []byte(schema), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dataPath, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tf := TableFiles{
+		Database:   "shop",
+		Table:      "orders",
+		SchemaFile: schemaPath,
+		DataFiles:  []string{dataPath},
+		Format:     "tab",
+	}
+	outPath := filepath.Join(dir, "orders_tab.parquet")
+	rowCount, err := processTable(context.Background(), tf, outPath, WriterConfig{Compression: "none", RowGroupSize: 100})
+	if err != nil {
+		t.Fatalf("processTable: %v", err)
+	}
+	if rowCount != 1 {
+		t.Fatalf("rowCount = %d, want 1", rowCount)
+	}
+
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open duckdb: %v", err)
+	}
+	defer db.Close()
+
+	safePath := strings.ReplaceAll(outPath, "'", "''")
+	var note any
+	row := db.QueryRowContext(context.Background(),
+		"SELECT note FROM parquet_scan('"+safePath+"')")
+	if err := row.Scan(&note); err != nil {
+		t.Fatalf("scan parquet_scan row: %v", err)
+	}
+	noteStr, ok := note.(string)
+	if !ok || noteStr != "hello" {
+		t.Errorf("note = %v (%T), want %q", note, note, "hello")
+	}
+}
+
+// TestProcessTableRowColumnCountMismatchFailsLoud pins the arity defense-in-
+// depth added alongside the #767 fix: if a row's value count ever disagrees
+// with the schema's column count — e.g. because a future DDL shape slips past
+// generatedRe — processTable must fail loud rather than let WriteRow silently
+// NULL-pad or shift the mismatch.
+func TestProcessTableRowColumnCountMismatchFailsLoud(t *testing.T) {
+	const schema = "CREATE TABLE `orders` (\n" +
+		"  `id` int NOT NULL,\n" +
+		"  `price` decimal(10,2) NOT NULL,\n" +
+		"  `note` varchar(64) DEFAULT NULL,\n" +
+		"  PRIMARY KEY (`id`)\n" +
+		") ENGINE=InnoDB;\n"
+	// Only two values for a three-column schema.
+	const data = "INSERT INTO `orders` (`id`,`price`) VALUES(1,10.50);\n"
+
+	dir := t.TempDir()
+	schemaPath := filepath.Join(dir, "shop.orders-schema.sql")
+	dataPath := filepath.Join(dir, "shop.orders.00000.sql")
+	if err := os.WriteFile(schemaPath, []byte(schema), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dataPath, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tf := TableFiles{
+		Database:   "shop",
+		Table:      "orders",
+		SchemaFile: schemaPath,
+		DataFiles:  []string{dataPath},
+		Format:     "sql",
+	}
+	outPath := filepath.Join(dir, "orders.parquet")
+	_, err := processTable(context.Background(), tf, outPath, WriterConfig{Compression: "none", RowGroupSize: 100})
+	if err == nil {
+		t.Fatal("processTable with a row/schema column-count mismatch: got nil error, want loud failure")
+	}
+	for _, want := range []string{"2", "3", "orders"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not mention %q", err.Error(), want)
+		}
+	}
+}

--- a/internal/baseline/generated_column_test.go
+++ b/internal/baseline/generated_column_test.go
@@ -297,3 +297,59 @@ func TestProcessTableRowColumnCountMismatchFailsLoud(t *testing.T) {
 		}
 	}
 }
+
+// TestProcessTableCommentFalsePositiveFailsLoud pins the accepted trade-off
+// documented on generatedRe (schema.go): a COMMENT string that happens to
+// contain "as (...) stored" wrongly drops a real, dumped column from the
+// schema's column list. This must never re-corrupt data the way the original
+// #767 bug did — it must instead trip the arity check and fail loud, because
+// the dump's actual value count no longer matches the (wrongly shortened)
+// column list.
+func TestProcessTableCommentFalsePositiveFailsLoud(t *testing.T) {
+	const schema = "CREATE TABLE `orders` (\n" +
+		"  `id` int NOT NULL,\n" +
+		"  `price` decimal(10,2) NOT NULL,\n" +
+		"  `note` varchar(64) DEFAULT NULL COMMENT 'compute as (x) stored value later',\n" +
+		"  PRIMARY KEY (`id`)\n" +
+		") ENGINE=InnoDB;\n"
+	// The dump carries all three real values — `note` is not actually generated.
+	const data = "INSERT INTO `orders` (`id`,`price`,`note`) VALUES(1,10.50,'hello');\n"
+
+	dir := t.TempDir()
+	schemaPath := filepath.Join(dir, "shop.orders-schema.sql")
+	dataPath := filepath.Join(dir, "shop.orders.00000.sql")
+	if err := os.WriteFile(schemaPath, []byte(schema), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dataPath, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Confirm the false-positive actually happens at the ParseSchema level —
+	// otherwise this test would pass for the wrong reason.
+	cols, err := ParseSchema(schemaPath)
+	if err != nil {
+		t.Fatalf("ParseSchema: %v", err)
+	}
+	if len(cols) != 2 {
+		t.Fatalf("got %d columns %v, want 2 (id, price) — expected the COMMENT false-positive to drop `note`", len(cols), colNames(cols))
+	}
+
+	tf := TableFiles{
+		Database:   "shop",
+		Table:      "orders",
+		SchemaFile: schemaPath,
+		DataFiles:  []string{dataPath},
+		Format:     "sql",
+	}
+	outPath := filepath.Join(dir, "orders.parquet")
+	_, err = processTable(context.Background(), tf, outPath, WriterConfig{Compression: "none", RowGroupSize: 100})
+	if err == nil {
+		t.Fatal("processTable with a COMMENT-triggered false-positive column drop: got nil error, want loud failure (silent-corruption regression)")
+	}
+	for _, want := range []string{"2", "3", "orders"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not mention %q", err.Error(), want)
+		}
+	}
+}

--- a/internal/baseline/schema.go
+++ b/internal/baseline/schema.go
@@ -37,6 +37,25 @@ type Column struct {
 // UNSIGNED from a hand-rolled schema must not silently fall through to signed.
 var colRe = regexp.MustCompile("^\\s+`([^`]+)`\\s+(\\w+)(?:\\s*\\([^)]*\\))?\\s*((?i:unsigned))?")
 
+// generatedRe matches a STORED/VIRTUAL/PERSISTENT generated column's defining
+// clause: MySQL's canonical "GENERATED ALWAYS AS (`price` * `qty`) STORED",
+// and the shorter form MariaDB's SHOW CREATE TABLE may emit without the
+// "GENERATED ALWAYS" prefix, e.g. "AS (`price` * `qty`) PERSISTENT"
+// (PERSISTENT is MariaDB's legacy alias for STORED). mysqldump and mydumper
+// both EXCLUDE generated columns from the INSERT column-list and VALUES
+// tuples they emit (see internal/consistency/checksum.go's tableColumns,
+// which drops them from the live-source fingerprint for the same reason) —
+// so a schema that still lists them shifts every subsequent column's
+// positional mapping in WriteRow (issue #767).
+//
+// Requiring the trailing VIRTUAL/STORED/PERSISTENT keyword (not just "AS (")
+// is a deliberate, accepted trade-off: it is possible in principle for a
+// COMMENT string to contain " as (...) stored" and false-trip this, but
+// unlike the #506 UNSIGNED false-positive (which silently mis-typed a real
+// column), the consequence here is the arity check in baseline.go failing
+// loud on a column-count mismatch — never silent corruption.
+var generatedRe = regexp.MustCompile(`(?i)\bAS\s*\(.*\)\s*(?:VIRTUAL|STORED|PERSISTENT)\b`)
+
 // ParseSchema reads a mydumper <db>.<table>-schema.sql file and returns the
 // ordered list of columns with their Parquet type mappings.
 func ParseSchema(path string) ([]Column, error) {
@@ -61,6 +80,11 @@ func ParseSchema(path string) ([]Column, error) {
 		}
 		m := colRe.FindStringSubmatch(line)
 		if m == nil {
+			continue
+		}
+		if generatedRe.MatchString(line) {
+			// STORED/VIRTUAL generated column — mydumper never dumps its value,
+			// so it must not occupy a slot in the positional column list either.
 			continue
 		}
 		name := m[1]


### PR DESCRIPTION
closes #767

## Summary
- `ParseSchema` (`internal/baseline/schema.go`) previously included STORED/VIRTUAL generated columns in the positional column list it returns, but mydumper/mysqldump both **exclude** generated columns from the INSERT column-list and VALUES tuples they emit. Every column declared after a generated one landed in the wrong Parquet slot in `WriteRow` (or NULLed the trailing column) with no error — silent baseline corruption feeding `reconstruct`/`_snapshot`/`verify` downstream.
- `ParseSchema` now skips generated columns, detecting both MySQL's canonical `GENERATED ALWAYS AS (...) STORED`/`VIRTUAL` and MariaDB's shorter `AS (...) PERSISTENT` form — the same exclusion `internal/consistency/checksum.go`'s `tableColumns` already applies to the live-source fingerprint, so both sides of the baseline-vs-source comparison now agree.
- `processTable` (`internal/baseline/baseline.go`) additionally validates that each row's parsed value count matches the schema's column count, failing loud with a descriptive error instead of letting `WriteRow`'s defensive NULL-padding silently mask a mismatch (defense-in-depth for any future DDL shape the generated-column regex might miss).

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] `go vet ./...`
- New tests in `internal/baseline/generated_column_test.go`:
  - `TestParseSchemaExcludesGeneratedColumn` / `...MariaDBForm` — schema-level exclusion for both DDL forms
  - `TestProcessTableGeneratedColumnMiddle` / `...TabFormat` — full pipeline (schema + data file → Parquet → DuckDB read-back) for a table with a GENERATED STORED column in the middle, asserting the trailing column's value lands correctly instead of NULL/shifted
  - `TestProcessTableRowColumnCountMismatchFailsLoud` — the new arity check
- Verified the new end-to-end test fails without the fix (`note` reads back `NULL`) and passes with it

🤖 Generated with [Claude Code](https://claude.com/claude-code)