### PR TITLE
capture: fix DEFAULT_GENERATED columns misflagged as generated (recover data loss)

### DIFF
--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -612,7 +612,7 @@ type columnRow struct {
 	ordinalPosition                   int
 	columnKey, dataType, isNullable   string
 	columnType                        string // full COLUMN_TYPE (e.g. "datetime(6)"); needed by full-table reconstruct for PK precision
-	extra                             string
+	generationExpression              sql.NullString
 	columnDefault                     sql.NullString
 }
 
@@ -649,7 +649,7 @@ func TakeSnapshot(sourceDB, indexDB *sql.DB, schemas []string) (SnapshotStats, e
 		query = `
 			SELECT TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME,
 			       ORDINAL_POSITION, COLUMN_KEY, DATA_TYPE, COLUMN_TYPE,
-			       IS_NULLABLE, COLUMN_DEFAULT, EXTRA
+			       IS_NULLABLE, COLUMN_DEFAULT, GENERATION_EXPRESSION
 			FROM information_schema.COLUMNS
 			WHERE TABLE_SCHEMA NOT IN ('information_schema','performance_schema','mysql','sys')
 			ORDER BY TABLE_SCHEMA, TABLE_NAME, ORDINAL_POSITION`
@@ -658,7 +658,7 @@ func TakeSnapshot(sourceDB, indexDB *sql.DB, schemas []string) (SnapshotStats, e
 		query = fmt.Sprintf(`
 			SELECT TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME,
 			       ORDINAL_POSITION, COLUMN_KEY, DATA_TYPE, COLUMN_TYPE,
-			       IS_NULLABLE, COLUMN_DEFAULT, EXTRA
+			       IS_NULLABLE, COLUMN_DEFAULT, GENERATION_EXPRESSION
 			FROM information_schema.COLUMNS
 			WHERE TABLE_SCHEMA IN (%s)
 			ORDER BY TABLE_SCHEMA, TABLE_NAME, ORDINAL_POSITION`, placeholders)
@@ -681,7 +681,7 @@ func TakeSnapshot(sourceDB, indexDB *sql.DB, schemas []string) (SnapshotStats, e
 		if err := srcRows.Scan(
 			&c.schemaName, &c.tableName, &c.columnName,
 			&c.ordinalPosition, &c.columnKey, &c.dataType, &c.columnType,
-			&c.isNullable, &c.columnDefault, &c.extra,
+			&c.isNullable, &c.columnDefault, &c.generationExpression,
 		); err != nil {
 			return SnapshotStats{}, fmt.Errorf("failed to scan column row: %w", err)
 		}
@@ -751,7 +751,16 @@ func TakeSnapshot(sourceDB, indexDB *sql.DB, schemas []string) (SnapshotStats, e
 			if c.columnDefault.Valid {
 				def = c.columnDefault.String
 			}
-			isGenerated := strings.Contains(strings.ToUpper(c.extra), "GENERATED")
+			// Generated-ness is read from GENERATION_EXPRESSION, not EXTRA: EXTRA
+			// also reports "DEFAULT_GENERATED" for an ordinary column with an
+			// expression default (e.g. created_at TIMESTAMP DEFAULT
+			// CURRENT_TIMESTAMP), so a substring match on "GENERATED" wrongly
+			// flags those real, captured data columns as generated and drops
+			// them from reverse INSERT/UPDATE SQL (#758). GENERATION_EXPRESSION
+			// is non-empty only for true VIRTUAL/STORED generated columns
+			// (empty in MySQL, NULL in MariaDB for everything else) — same
+			// signal consistency.tableColumns uses.
+			isGenerated := c.generationExpression.Valid && strings.TrimSpace(c.generationExpression.String) != ""
 			insertArgs = append(insertArgs,
 				nextID, snapshotTime, c.schemaName, c.tableName, c.columnName,
 				c.ordinalPosition, c.columnKey, c.dataType, c.columnType, c.isNullable, def, isGenerated,

--- a/internal/metadata/metadata_integration_test.go
+++ b/internal/metadata/metadata_integration_test.go
@@ -181,6 +181,51 @@ func TestTakeSnapshot_basic(t *testing.T) {
 	}
 }
 
+// TestTakeSnapshot_defaultGeneratedNotFlaggedGenerated is the #758 regression
+// test: information_schema.COLUMNS.EXTRA reports "DEFAULT_GENERATED" for an
+// ordinary column with an expression default (e.g. created_at TIMESTAMP
+// DEFAULT CURRENT_TIMESTAMP), not just for true VIRTUAL/STORED generated
+// columns. TakeSnapshot must tell these apart via GENERATION_EXPRESSION —
+// a substring match on EXTRA wrongly flags created_at as generated, which
+// makes recover silently omit it from reversal SQL (data corruption on
+// restore).
+func TestTakeSnapshot_defaultGeneratedNotFlaggedGenerated(t *testing.T) {
+	sourceDB, sourceName := testutil.CreateTestDB(t)
+	indexDB, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, indexDB)
+
+	testutil.MustExec(t, sourceDB, `CREATE TABLE orders (
+		id         INT PRIMARY KEY,
+		total      DECIMAL(10,2) NOT NULL,
+		created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		full_total DECIMAL(10,2) GENERATED ALWAYS AS (total * 1) STORED
+	) ENGINE=InnoDB`)
+
+	stats, err := TakeSnapshot(sourceDB, indexDB, []string{sourceName})
+	if err != nil {
+		t.Fatalf("TakeSnapshot: %v", err)
+	}
+
+	isGenerated := func(column string) bool {
+		var got bool
+		if err := indexDB.QueryRow(
+			`SELECT is_generated FROM schema_snapshots
+			 WHERE snapshot_id = ? AND schema_name = ? AND table_name = 'orders' AND column_name = ?`,
+			stats.SnapshotID, sourceName, column,
+		).Scan(&got); err != nil {
+			t.Fatalf("read is_generated for %s: %v", column, err)
+		}
+		return got
+	}
+
+	if isGenerated("created_at") {
+		t.Error("created_at (DEFAULT_GENERATED expression default) must NOT be flagged is_generated — it is a real, captured data column (#758)")
+	}
+	if !isGenerated("full_total") {
+		t.Error("full_total (STORED generated) must be flagged is_generated")
+	}
+}
+
 func TestTakeSnapshot_filteredSchemas(t *testing.T) {
 	// Two source DBs but only snapshot one.
 	sourceDB1, name1 := testutil.CreateTestDB(t)

--- a/internal/recovery/recovery_test.go
+++ b/internal/recovery/recovery_test.go
@@ -534,7 +534,11 @@ func TestEscapeString_combined(t *testing.T) {
 // ─── Generated column filtering ──────────────────────────────────────────────
 
 // newGenWithResolver returns a Generator backed by a resolver containing a
-// table with one STORED generated column ("line_total").
+// table with one STORED generated column ("line_total") and one ordinary
+// column with an expression default ("created_at TIMESTAMP DEFAULT
+// CURRENT_TIMESTAMP", IsGenerated: false) — the #758 DEFAULT_GENERATED trap:
+// MySQL's EXTRA column reports "DEFAULT_GENERATED" for created_at too, but it
+// is a real, captured data column and must NEVER be treated like line_total.
 func newGenWithResolver() *Generator {
 	tm := &metadata.TableMeta{
 		Schema: "shop",
@@ -544,6 +548,7 @@ func newGenWithResolver() *Generator {
 			{Name: "quantity", OrdinalPosition: 2, DataType: "int"},
 			{Name: "unit_price", OrdinalPosition: 3, DataType: "decimal"},
 			{Name: "line_total", OrdinalPosition: 4, DataType: "decimal", IsGenerated: true},
+			{Name: "created_at", OrdinalPosition: 5, DataType: "timestamp", IsGenerated: false},
 		},
 		PKColumns: []string{"order_id"},
 	}
@@ -564,7 +569,8 @@ func TestGenerateInsert_skipsGeneratedColumns(t *testing.T) {
 			"order_id":   float64(5),
 			"quantity":   float64(3),
 			"unit_price": float64(68.81),
-			"line_total": float64(206.43), // STORED generated — must be excluded
+			"line_total": float64(206.43),       // STORED generated — must be excluded
+			"created_at": "2024-01-01 00:00:00", // DEFAULT_GENERATED (expression default) — must be included (#758)
 		},
 	}
 	stmt, err := g.generateInsert(row)
@@ -575,6 +581,7 @@ func TestGenerateInsert_skipsGeneratedColumns(t *testing.T) {
 	assertSQL(t, stmt, "`order_id`")
 	assertSQL(t, stmt, "`quantity`")
 	assertSQL(t, stmt, "`unit_price`")
+	assertSQL(t, stmt, "`created_at`")
 	if strings.Contains(stmt, "line_total") {
 		t.Errorf("generated column 'line_total' must not appear in INSERT: %s", stmt)
 	}
@@ -591,13 +598,15 @@ func TestGenerateUpdate_skipsGeneratedColumns(t *testing.T) {
 			"order_id":   float64(5),
 			"quantity":   float64(2),
 			"unit_price": float64(68.81),
-			"line_total": float64(137.62), // STORED generated — must be excluded from SET
+			"line_total": float64(137.62),       // STORED generated — must be excluded from SET
+			"created_at": "2024-01-01 00:00:00", // DEFAULT_GENERATED — must be included (#758)
 		},
 		RowAfter: map[string]any{
 			"order_id":   float64(5),
 			"quantity":   float64(3),
 			"unit_price": float64(68.81),
 			"line_total": float64(206.43),
+			"created_at": "2024-01-02 00:00:00",
 		},
 	}
 	stmt, err := g.generateUpdate(row)
@@ -615,6 +624,9 @@ func TestGenerateUpdate_skipsGeneratedColumns(t *testing.T) {
 	setPart := stmt[setIdx:whereIdx]
 	if strings.Contains(setPart, "line_total") {
 		t.Errorf("generated column 'line_total' must not appear in SET clause: %s", setPart)
+	}
+	if !strings.Contains(setPart, "`created_at`") {
+		t.Errorf("DEFAULT_GENERATED column 'created_at' must appear in SET clause (#758): %s", setPart)
 	}
 }
 


### PR DESCRIPTION
closes #758

## Summary
- `TakeSnapshot` (`internal/metadata/metadata.go`) derived `is_generated` via a substring match on `information_schema.COLUMNS.EXTRA`, which also reports `DEFAULT_GENERATED` for any ordinary column with an expression default (e.g. `created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP`) — not just true VIRTUAL/STORED generated columns.
- `recovery.generatedColsFromResolver` consumed that flag and `buildInsert`/`updateSetSkipCols` silently omitted such columns from reverse INSERT/UPDATE SQL — on restore, the column falls back to its default (e.g. `NOW()`) instead of its real historical value.
- Fixed by deriving `is_generated` from `GENERATION_EXPRESSION` (non-empty only for true generated columns), matching the already-correct pattern in `internal/consistency/checksum.go`.

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] New integration test `TestTakeSnapshot_defaultGeneratedNotFlaggedGenerated` in `internal/metadata` — verified it **fails** against the pre-fix code and **passes** against the fix (real MySQL 8.0 via Docker)
- [x] Extended `TestGenerateInsert_skipsGeneratedColumns` / `TestGenerateUpdate_skipsGeneratedColumns` in `internal/recovery` to assert a DEFAULT_GENERATED column IS included in reverse SQL, alongside the existing STORED-generated exclusion assertion
- [x] `go test -tags integration ./internal/metadata/... ./internal/recovery/... ./internal/consistency/... ./internal/verify/... ./internal/reconstruct/...` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)