### PR TITLE
recover: fix all-columns fallback WHERE emitting col = NULL (silent no-op)

### DIFF
--- a/docs/query-and-recovery.md
+++ b/docs/query-and-recovery.md
@@ -310,12 +310,12 @@ For `UPDATE` and `DELETE` reversals, the generator needs a `WHERE` clause to ide
 UPDATE `mydb`.`orders` SET `status` = 'draft' WHERE `id` = 42
 ```
 
-**Without a snapshot (fallback)**: Uses every column in the row image. This is verbose but always correct for tables without duplicate rows:
+**Without a snapshot (fallback)**: Uses every column in the row image. This is verbose but uniquely identifies the row for tables without duplicate rows. A `NULL` column renders as `IS NULL` (not `= NULL`, which never matches in SQL):
 
 ```sql
 UPDATE `mydb`.`orders`
 SET `status` = 'draft'
-WHERE `id` = 42 AND `status` = 'published' AND `created_at` = '2026-02-19 14:01:00'
+WHERE `id` = 42 AND `status` = 'published' AND `created_at` = '2026-02-19 14:01:00' AND `notes` IS NULL
 ```
 
 The resolver is loaded best-effort in the `recover` command — a failure logs a warning and falls back to the all-columns strategy.

--- a/internal/recovery/recovery.go
+++ b/internal/recovery/recovery.go
@@ -883,7 +883,16 @@ func (g *Generator) allColsWhere(row map[string]any) (clauses []string, cols []s
 	cols = sortedKeys(row)
 	parts := make([]string, len(cols))
 	for i, col := range cols {
-		parts[i] = g.quoteName(col) + " = " + g.formatValue(row[col])
+		v := row[col]
+		if v == nil {
+			// `col = NULL` is never true in SQL (NULL comparisons are UNKNOWN, not
+			// TRUE) — a `col = NULL` fallback WHERE would match zero rows, silently
+			// no-op'ing the reversal on any PK-less/unresolvable table with a NULL
+			// column (#762). `IS NULL` is the correct predicate for both dialects.
+			parts[i] = g.quoteName(col) + " IS NULL"
+			continue
+		}
+		parts[i] = g.quoteName(col) + " = " + g.formatValue(v)
 	}
 	return parts, cols
 }

--- a/internal/recovery/recovery_test.go
+++ b/internal/recovery/recovery_test.go
@@ -315,6 +315,51 @@ func TestGenerateDelete_nilRowAfter(t *testing.T) {
 	}
 }
 
+// TestGenerateDelete_allColsFallbackNullColumn pins #762: without a resolver
+// (all-columns WHERE fallback), a NULL column must render as `IS NULL`, never
+// `= NULL` — the latter is never true in SQL and silently no-ops the reversal
+// on any PK-less/unresolvable table with a NULL column.
+func TestGenerateDelete_allColsFallbackNullColumn(t *testing.T) {
+	g := newGen()
+	row := query.ResultRow{
+		EventID:    3,
+		SchemaName: "mydb",
+		TableName:  "orders",
+		EventType:  parser.EventInsert,
+		RowAfter:   map[string]any{"id": float64(99), "status": "new", "notes": nil},
+	}
+	stmt, err := g.generateDelete(row)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertSQL(t, stmt, "`notes` IS NULL")
+	if strings.Contains(stmt, "`notes` = NULL") {
+		t.Errorf("WHERE clause emits `col = NULL` (never matches): %s", stmt)
+	}
+}
+
+// TestGenerateUpdate_allColsFallbackNullColumn covers the same #762 fallback
+// for UPDATE reversals, whose WHERE is built from row_after.
+func TestGenerateUpdate_allColsFallbackNullColumn(t *testing.T) {
+	g := newGen()
+	row := query.ResultRow{
+		EventID:    4,
+		SchemaName: "mydb",
+		TableName:  "orders",
+		EventType:  parser.EventUpdate,
+		RowBefore:  map[string]any{"id": float64(1), "status": "pending", "notes": "hi"},
+		RowAfter:   map[string]any{"id": float64(1), "status": "shipped", "notes": nil},
+	}
+	stmt, err := g.generateUpdate(row)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertSQL(t, stmt, "`notes` IS NULL")
+	if strings.Contains(stmt, "`notes` = NULL") {
+		t.Errorf("WHERE clause emits `col = NULL` (never matches): %s", stmt)
+	}
+}
+
 // ─── GenerateSQL integration (no DB, exercising the output wrapper) ────────────
 
 func TestGenerateSQL_noRows(t *testing.T) {


### PR DESCRIPTION
closes #762

## Summary
- `allColsWhere` (`internal/recovery/recovery.go`) rendered NULL row values as `col = NULL` in the all-columns fallback WHERE used for PK-less/unresolvable tables. `= NULL` is never true in SQL, so the reverse DELETE/UPDATE matched zero rows: the script applied clean, exited 0, and did nothing.
- Fix emits `col IS NULL` for nil values instead, applied above the MySQL/PostgreSQL dialect dispatch so both dialects get it in one place. The PK-scoped WHERE (preferred path) is unaffected since primary keys cannot be NULL.
- Corrected the false "always correct for tables without duplicate rows" claim at docs/query-and-recovery.md:313.
- Added two focused unit tests pinning the fallback for DELETE and UPDATE reversals with a NULL column.

## Test plan
- [x] go test ./... -count=1 (all packages pass)
- [x] New tests TestGenerateDelete_allColsFallbackNullColumn / TestGenerateUpdate_allColsFallbackNullColumn pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
