### PR TITLE
recover: strict-by-default coverage-gap handling, add --allow-gaps

### DIFF
--- a/internal/cli/recover.go
+++ b/internal/cli/recover.go
@@ -35,6 +35,13 @@ Reversal logic:
   UPDATE → UPDATE ... SET (row_before) WHERE (row_after, current state)
   INSERT → DELETE FROM ... WHERE (row_after, current state)
 
+Events are fetched from both live MySQL partitions and any Parquet archives
+auto-discovered via archive_state. Pass --no-archive to query MySQL only.
+By default, a coverage gap (an hour rotated out of MySQL with no archive, or
+an archive source that fails to fetch) aborts recovery before any SQL is
+generated; pass --allow-gaps to proceed with a warning and a possibly
+incomplete reversal script.
+
 Examples:
   # Recover deleted rows in a time window
   bintrail recover --index-dsn "..." \
@@ -74,6 +81,7 @@ var (
 	rNoArchive      bool
 	rColumnEq       []string
 	rMaxScriptBytes string
+	rAllowGaps      bool
 )
 
 func init() {
@@ -96,6 +104,7 @@ func init() {
 	recoverCmd.Flags().StringVar(&rFormat, "format", "text", "Output format: text or json")
 	recoverCmd.Flags().BoolVar(&rNoArchive, "no-archive", false, "Disable auto-routing to Parquet archives (MySQL-only results)")
 	recoverCmd.Flags().StringVar(&rMaxScriptBytes, "max-script-bytes", "2GB", "Refuse to generate a reversal script whose estimated row payload exceeds this size (e.g. 512MB, 4GB; 0 = unlimited). Bounds the rendered-script memory spike on BLOB/TEXT-heavy recoveries (#654).")
+	recoverCmd.Flags().BoolVar(&rAllowGaps, "allow-gaps", false, "Proceed even when the event index has coverage gaps (hours rotated out of MySQL with no archive) or an archive source fails (may produce an incomplete reversal script)")
 	AddDuckDBTuningFlags(recoverCmd)
 	_ = recoverCmd.MarkFlagRequired("index-dsn")
 	BindCommandEnv(recoverCmd)
@@ -255,10 +264,20 @@ func runRecover(cmd *cobra.Command, args []string) error {
 		Opts:           opts,
 		DBName:         dbName,
 		NoArchive:      rNoArchive || rProfile != "",
-		AllowGaps:      true, // preserve recover's warn-and-continue behavior
+		AllowGaps:      rAllowGaps,
 		ArchiveFetcher: TunedArchiveFetcher(duckTuning),
 	})
 	if err != nil {
+		// Surface CLI hints only at the CLI layer; the library types
+		// (query.GapError, query.SourceEmptyError) stay command-neutral.
+		var gapErr *query.GapError
+		if errors.As(err, &gapErr) {
+			return fmt.Errorf("%w; pass --allow-gaps to proceed with a possibly incomplete recovery", err)
+		}
+		var emptyErr *query.SourceEmptyError
+		if errors.As(err, &emptyErr) {
+			return fmt.Errorf("%w; run `bintrail archive reconcile` to re-sync archive_state with storage, or pass --allow-gaps to proceed without that source", err)
+		}
 		return err
 	}
 

--- a/internal/cli/recover_test.go
+++ b/internal/cli/recover_test.go
@@ -42,6 +42,7 @@ func TestRecoverCmd_defaults(t *testing.T) {
 		{"limit", "1000"},
 		{"dry-run", "false"},
 		{"format", "text"},
+		{"allow-gaps", "false"},
 	}
 	for _, tc := range cases {
 		f := recoverCmd.Flag(tc.flag)
@@ -74,11 +75,28 @@ func TestRecoverCmd_allFlagsRegistered(t *testing.T) {
 	for _, name := range []string{
 		"index-dsn", "schema", "table", "pk", "event-type",
 		"gtid", "since", "until", "flag", "output", "dry-run", "limit",
-		"no-archive", "column-eq",
+		"no-archive", "column-eq", "allow-gaps",
 	} {
 		if recoverCmd.Flag(name) == nil {
 			t.Errorf("flag --%s not registered on recoverCmd", name)
 		}
+	}
+}
+
+// TestRecoverCmd_allowGapsDefaultIsStrict pins the load-bearing claim of
+// issue #761: `recover` must default to strict coverage-gap handling like
+// `reconstruct`/`shim`/`recover-cascade`, not the old hardcoded
+// AllowGaps=true that let an incomplete reversal script exit 0. A
+// regression that flips this default back to permissive would silently
+// reintroduce the "operator applies a partial restore believing it
+// complete" failure mode.
+func TestRecoverCmd_allowGapsDefaultIsStrict(t *testing.T) {
+	f := recoverCmd.Flag("allow-gaps")
+	if f == nil {
+		t.Fatal("--allow-gaps flag not registered on recoverCmd")
+	}
+	if f.DefValue != "false" {
+		t.Errorf("--allow-gaps default = %q, want %q (strict mode is the safe default; see #761)", f.DefValue, "false")
 	}
 }
 

--- a/internal/cli/shim_test.go
+++ b/internal/cli/shim_test.go
@@ -20,13 +20,14 @@ import (
 
 // TestAllowGapsDefaultIsStrict pins the load-bearing claim of issue #257:
 // the shim CLI's --allow-gaps flag defaults to false. A regression that
-// flips this default (e.g. someone copy-pasting from `bintrail recover`,
-// which is intentionally permissive) would silently re-introduce the
-// silent-partial-result bug — archive failures absorbed as slog.Warn
-// while the connecting MySQL client gets an apparently-successful
-// resultset missing rows. This test exists specifically because the
-// default value is what the issue's fix turns on; framework wiring is
-// not the load-bearing claim.
+// flips this default would silently re-introduce the silent-partial-result
+// bug — archive failures absorbed as slog.Warn while the connecting MySQL
+// client gets an apparently-successful resultset missing rows. This test
+// exists specifically because the default value is what the issue's fix
+// turns on; framework wiring is not the load-bearing claim. `bintrail
+// recover` used to be the one intentionally-permissive exception to this
+// convention; it now defaults to strict too (see #761,
+// TestRecoverCmd_allowGapsDefaultIsStrict in recover_test.go).
 func TestAllowGapsDefaultIsStrict(t *testing.T) {
 	flag := shimCmd.Flags().Lookup("allow-gaps")
 	if flag == nil {


### PR DESCRIPTION
closes #761

## Summary
- `recover` called `query.FetchMerged` with `AllowGaps` hardcoded to `true`, so a coverage gap (an hour rotated out of MySQL with no archive) or a broken archive source only produced a `slog.Warn` — the script was written and the process exited 0 as if recovery were complete. It was the only restore command still permissive by design; `reconstruct`, the shim, and `recover-cascade` all fail closed.
- Added `--allow-gaps` (default `false`) to `recover`, wired into `FetchMerged`'s `AllowGaps`. On a gap or archive-source failure, `FetchMerged` now returns `*query.GapError`/`*query.SourceEmptyError` before any SQL is generated; `recover` wraps these with a CLI hint pointing at `--allow-gaps`, exactly mirroring `reconstruct`'s existing pattern (`internal/cli/reconstruct.go`).
- Judgment call: the issue's recommended direction was "write the partial output, then flag it non-zero" (cascade-recovery's `cascadeExit` style). I diverged to "abort before generating any SQL" instead, because under permissive mode an archive-fetch failure is only a `slog.Warn` — invisible in both the returned rows and the query plan — so a post-hoc check on the plan can't detect the "archive fetch fails on expired credentials" case the issue explicitly names. Aborting up front (like `reconstruct`'s `GapError` abort, which the issue itself cites as the model to follow) catches every degradation mode `FetchMerged` already distinguishes, with no new plumbing.
- Updated the stale comment in `shim_test.go` that called out `recover` as "intentionally permissive" (no longer true).
- The command-reference doc for this repo (`CLAUDE.md`) is untracked/local-only, so it isn't part of this diff; the `--allow-gaps` flag is documented in the command's `--help` and Long description instead.

## Test plan
- [x] `go test ./... -count=1` (unit only; no Docker — shared MySQL port 13306 used by other agents in parallel)
- [x] Added `TestRecoverCmd_allowGapsDefaultIsStrict` pinning the flag default, mirroring the existing `shim` precedent (`TestAllowGapsDefaultIsStrict`)
- [x] `allow-gaps` added to `TestRecoverCmd_defaults` and `TestRecoverCmd_allFlagsRegistered`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
