### PR TITLE
recover (agent/BYOS): fail loud instead of silently truncating to 1000 events

### DIFF
--- a/internal/agent/handler.go
+++ b/internal/agent/handler.go
@@ -178,6 +178,15 @@ func (h *DefaultHandler) resolvePKFromArchive(ctx context.Context, item PKItem, 
 	return "", nil
 }
 
+// recoverEventLimit caps the number of events a single recover call may
+// reverse into one script. #763: silently trimming to this cap and
+// generating reversal SQL from the truncated set produces a script the
+// caller believes reverses the whole requested scope when it doesn't — the
+// remaining events are left half-reverted with no signal. We instead fetch
+// one row past the cap so an over-scoped request can be rejected outright
+// (see the fetch+check below) rather than silently emitting a partial script.
+const recoverEventLimit = 1000
+
 // HandleRecover generates reversal SQL for the specified events.
 //
 // Scope precedence: when GTID is set the agent honours it as the precise
@@ -202,7 +211,10 @@ func (h *DefaultHandler) HandleRecover(ctx context.Context, req RecoverRequest) 
 		Schema: req.Schema,
 		Table:  req.Table,
 		GTID:   req.GTID,
-		Limit:  1000,
+		// Fetch one past the cap so we can detect (and reject) an
+		// over-scoped request instead of silently truncating — see
+		// recoverEventLimit and the check below.
+		Limit: recoverEventLimit + 1,
 	}
 	// Pass time bounds verbatim when the caller supplied them.  Skip
 	// zero-value bounds entirely — passing year-1 to query.Fetch would
@@ -248,7 +260,12 @@ func (h *DefaultHandler) HandleRecover(ctx context.Context, req RecoverRequest) 
 		rows = append(rows, r...)
 	}
 
-	rows = query.MergeResults(rows, opts.Limit, opts.Order)
+	// Dedup+sort without capping yet — capping here would hide the very
+	// overflow we need to detect (#763).
+	rows = query.MergeResults(rows, 0, opts.Order)
+	if len(rows) > recoverEventLimit {
+		return "", fmt.Errorf("recover scope matches more than %d events; narrow the time range/GTID or split the recovery into smaller windows (refusing to emit a partial reversal script)", recoverEventLimit)
+	}
 
 	// Filter to requested pk_hashes if specified.
 	if len(req.PKHashes) > 0 {

--- a/internal/agent/handler_test.go
+++ b/internal/agent/handler_test.go
@@ -171,6 +171,101 @@ func TestHandleRecover_gtidNoMatch_largeFallback(t *testing.T) {
 	}
 }
 
+// TestHandleRecover_rejectsOverCap is the regression test for #763: a
+// recover scope matching more than recoverEventLimit events must be
+// rejected outright instead of silently emitting reversal SQL for only the
+// first recoverEventLimit of them. The prior behavior produced a script
+// that looked complete (its header even reported the truncated count) while
+// leaving the remaining matched rows half-reverted.
+func TestHandleRecover_rejectsOverCap(t *testing.T) {
+	now := time.Now().UTC()
+	buf := buffer.New(buffer.Config{MaxAge: time.Hour})
+	events := make([]parser.Event, 0, recoverEventLimit+1)
+	for i := 0; i < recoverEventLimit+1; i++ {
+		events = append(events, makeRecoverEvent(now, fmt.Sprintf("%d", i), fmt.Sprintf("abc:%d", i)))
+	}
+	buf.Insert(events)
+
+	h := &DefaultHandler{Buffer: buf}
+
+	_, err := h.HandleRecover(context.Background(), RecoverRequest{
+		Schema:    "shop",
+		Table:     "orders",
+		TimeStart: now.Add(-time.Hour),
+		TimeEnd:   now.Add(time.Hour),
+	})
+	if err == nil {
+		t.Fatalf("expected error for over-cap recover scope, got nil")
+	}
+	if !strings.Contains(err.Error(), fmt.Sprintf("more than %d events", recoverEventLimit)) {
+		t.Errorf("expected cap-exceeded error, got: %v", err)
+	}
+}
+
+// TestHandleRecover_pkHashesOverCap pins a deliberate trade-off: the cap
+// check runs on the raw scope fetch, BEFORE the client-side PKHashes
+// filter (handler.go applies PKHashes after MergeResults). So a
+// PK-targeted recover ("reverse these 3 rows") over a busy time window
+// with >recoverEventLimit total table events is rejected too, even though
+// only a handful of rows are actually wanted — checking after the PK
+// filter would let a wanted PK whose events fall past the cap boundary
+// silently get a truncated reversal, which is the exact failure mode #763
+// exists to prevent. Callers hitting this on a busy table should narrow
+// the time range instead of relying on PKHashes to narrow it for them.
+func TestHandleRecover_pkHashesOverCap(t *testing.T) {
+	now := time.Now().UTC()
+	buf := buffer.New(buffer.Config{MaxAge: time.Hour})
+	events := make([]parser.Event, 0, recoverEventLimit+1)
+	for i := 0; i < recoverEventLimit+1; i++ {
+		events = append(events, makeRecoverEvent(now, fmt.Sprintf("%d", i), fmt.Sprintf("abc:%d", i)))
+	}
+	buf.Insert(events)
+
+	h := &DefaultHandler{Buffer: buf}
+
+	_, err := h.HandleRecover(context.Background(), RecoverRequest{
+		Schema:    "shop",
+		Table:     "orders",
+		TimeStart: now.Add(-time.Hour),
+		TimeEnd:   now.Add(time.Hour),
+		PKHashes:  []string{byosPKHash("1")},
+	})
+	if err == nil {
+		t.Fatalf("expected error for over-cap scope even with a narrow PKHashes filter, got nil")
+	}
+	if !strings.Contains(err.Error(), fmt.Sprintf("more than %d events", recoverEventLimit)) {
+		t.Errorf("expected cap-exceeded error, got: %v", err)
+	}
+}
+
+// TestHandleRecover_atCapSucceeds confirms the cap check does not
+// misfire on a scope of exactly recoverEventLimit events — only scopes
+// that exceed the cap should be rejected.
+func TestHandleRecover_atCapSucceeds(t *testing.T) {
+	now := time.Now().UTC()
+	buf := buffer.New(buffer.Config{MaxAge: time.Hour})
+	events := make([]parser.Event, 0, recoverEventLimit)
+	for i := 0; i < recoverEventLimit; i++ {
+		events = append(events, makeRecoverEvent(now, fmt.Sprintf("%d", i), fmt.Sprintf("abc:%d", i)))
+	}
+	buf.Insert(events)
+
+	h := &DefaultHandler{Buffer: buf}
+
+	sql, err := h.HandleRecover(context.Background(), RecoverRequest{
+		Schema:    "shop",
+		Table:     "orders",
+		TimeStart: now.Add(-time.Hour),
+		TimeEnd:   now.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("HandleRecover returned error for exactly-at-cap scope: %v", err)
+	}
+	if !strings.Contains(sql, "DELETE FROM `shop`") {
+		t.Errorf("expected reversal statements for the at-cap scope, got:\n%s", sql)
+	}
+}
+
 // TestRecoverRequestJSON_gtid pins the wire format: the SaaS side sends
 // “"gtid"“ (lowercase) and the agent must decode it into the GTID
 // field.  A typo in the JSON tag would silently drop the field again.


### PR DESCRIPTION
closes #763

## Summary
- `HandleRecover` (internal/agent/handler.go) hardcoded `Limit=1000` and fed the trimmed set straight into `GenerateSQLFromRows` with no signal that more events matched the requested scope — an operator applying the resulting script would believe the whole window was reversed while thousands of matching events were silently dropped, leaving touched rows half-reverted.
- Fix: fetch one row past the cap (`recoverEventLimit+1 = 1001`), dedup/sort via `query.MergeResults` with no cap, then reject the request outright (`return "", fmt.Errorf(...)`) if the merged set still exceeds `recoverEventLimit` (1000). Mirrors the fail-loud empty-scope guard already added for #1512 in this same handler/file.
- The cap check runs on the raw scope fetch, **before** the client-side `PKHashes` filter. This is a deliberate judgment call: checking after the PK filter would let a wanted PK whose events fall past the cap boundary silently get a truncated reversal — the exact failure mode this issue exists to prevent. Practical effect: a PK-targeted recover ("reverse these 3 rows") over a time window with >1000 total table events now errors too, even though only 3 rows are wanted. Narrowing the time range works around it; scoping the underlying fetch by PK so PK-targeted recovers on busy tables don't need to narrow the window is a reasonable follow-up but out of scope here.

## Test plan
- [x] `go test ./... -count=1` (full unit suite, all packages green)
- [x] New focused tests in `internal/agent/handler_test.go`:
  - `TestHandleRecover_rejectsOverCap` — scope of 1001 matching events (no GTID/PK filter) is rejected with the cap-exceeded error
  - `TestHandleRecover_pkHashesOverCap` — same over-cap scope with a narrow `PKHashes` filter still rejected (pins the trade-off above)
  - `TestHandleRecover_atCapSucceeds` — exactly 1000 matching events still succeeds (no off-by-one false positive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
