### PR TITLE
reconstruct: refuse/warn on a stamped capture gap inside the reconstruction window

### DIFF
--- a/internal/cli/reconstruct.go
+++ b/internal/cli/reconstruct.go
@@ -273,6 +273,14 @@ func runReconstruct(cmd *cobra.Command, args []string) error {
 
 	engine := query.New(db)
 
+	// Refuse/warn on a stamped capture gap inside the window (#765): a
+	// query.GapError below only catches archive-coverage gaps (rotated hours
+	// with no archive); stream_state.gap_lost_at records events permanently
+	// lost at the source, which no archive can fill.
+	if err := reconstruct.CheckCaptureGap(cmd.Context(), db, recSchema, recTable, snapshotTime, at, recAllowGaps); err != nil {
+		return err
+	}
+
 	// The planner needs a database name derived from the DSN.
 	var dbName string
 	if cfg, parseErr := mysqldriver.ParseDSN(recIndexDSN); parseErr != nil {

--- a/internal/reconstruct/capturegap.go
+++ b/internal/reconstruct/capturegap.go
@@ -1,0 +1,58 @@
+package reconstruct
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/status"
+)
+
+// gapInWindow reports whether a recorded capture-gap timestamp falls inside
+// (since, until] — the reconstruction window a baseline+delta replay covers.
+// Extracted so the boundary logic is unit-testable without a *sql.DB.
+func gapInWindow(gapAt, since, until time.Time) bool {
+	return gapAt.After(since) && !gapAt.After(until)
+}
+
+// CheckCaptureGap consults stream_state.gap_lost_at/gap_lost_detail (#765) —
+// the durable record indexer/streamrun stamps when an unfillable binlog gap
+// forces an auto-advance, permanently losing events (docs/rotation-and-status.md:
+// "the index is valid only up to the gap"). This is a DIFFERENT check from
+// GapDetected in gap.go (baseline-anchor-vs-first-event position gap) and from
+// the query planner's coverage-gap check (query.GapError: an hour rotated out
+// of MySQL with no archive, which is potentially fillable by re-archiving).
+// gap_lost_at marks events that no longer exist ANYWHERE — not live MySQL, not
+// an archive — so a reconstruction spanning it is silently incomplete
+// regardless of archive coverage.
+//
+// If gap_lost_at falls inside (since, until], the loss is in scope for this
+// reconstruction. Under strict mode (allowGaps=false, the reconstruct default)
+// this returns an error; under --allow-gaps it logs a slog.Warn and returns
+// nil so the caller proceeds with a known-incomplete result.
+func CheckCaptureGap(ctx context.Context, db *sql.DB, schema, table string, since, until time.Time, allowGaps bool) error {
+	ss, err := status.LoadStreamState(ctx, db)
+	if err != nil {
+		return fmt.Errorf("check stream_state capture gap: %w", err)
+	}
+	if ss == nil || !ss.GapLostAt.Valid {
+		return nil
+	}
+	gapAt := ss.GapLostAt.Time
+	if !gapInWindow(gapAt, since, until) {
+		return nil
+	}
+
+	detail := ss.GapLostDetail.String
+	if allowGaps {
+		slog.Warn("reconstruct: stamped capture gap falls inside the reconstruction window — events after the gap are permanently lost, output will be incomplete; proceeding due to --allow-gaps",
+			"schema", schema, "table", table,
+			"gap_lost_at", gapAt.UTC().Format(time.RFC3339), "detail", detail,
+			"window_since", since.UTC().Format(time.RFC3339), "window_until", until.UTC().Format(time.RFC3339))
+		return nil
+	}
+	return fmt.Errorf("reconstruct: stamped capture gap at %s falls inside the reconstruction window (%s, %s] for %s.%s — the index permanently lost events after that point (%s); pass --allow-gaps to proceed with a known-incomplete reconstruction",
+		gapAt.UTC().Format(time.RFC3339), since.UTC().Format(time.RFC3339), until.UTC().Format(time.RFC3339), schema, table, detail)
+}

--- a/internal/reconstruct/capturegap_test.go
+++ b/internal/reconstruct/capturegap_test.go
@@ -1,0 +1,153 @@
+package reconstruct
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestGapInWindow(t *testing.T) {
+	since := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	until := time.Date(2026, 6, 10, 0, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name  string
+		gapAt time.Time
+		want  bool
+	}{
+		{"before window = out of scope", since.Add(-time.Hour), false},
+		{"exactly at since (exclusive) = out of scope", since, false},
+		{"inside window = in scope", since.Add(24 * time.Hour), true},
+		{"exactly at until (inclusive) = in scope", until, true},
+		{"after window = out of scope", until.Add(time.Hour), false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := gapInWindow(c.gapAt, since, until); got != c.want {
+				t.Errorf("gapInWindow(%v, %v, %v) = %v, want %v", c.gapAt, since, until, got, c.want)
+			}
+		})
+	}
+}
+
+// streamStateRows builds the sqlmock row set loadStreamStateCore expects,
+// with gap_lost_at/gap_lost_detail set to the given values (nil = SQL NULL).
+func streamStateRows(gapLostAt any, gapLostDetail any) *sqlmock.Rows {
+	return sqlmock.NewRows([]string{
+		"mode", "binlog_file", "binlog_position", "gtid_set",
+		"events_indexed", "last_event_time", "last_checkpoint",
+		"server_id", "bintrail_id", "gap_lost_at", "gap_lost_detail",
+	}).AddRow(
+		"position", "binlog.000001", int64(100), "",
+		int64(0), nil, time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+		uint32(1), "bintrail-1", gapLostAt, gapLostDetail,
+	)
+}
+
+func TestCheckCaptureGap_gapInsideWindow_strictRefuses(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	since := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	until := time.Date(2026, 6, 10, 0, 0, 0, 0, time.UTC)
+	gapAt := since.Add(24 * time.Hour)
+
+	mock.ExpectQuery("SELECT mode, binlog_file").
+		WillReturnRows(streamStateRows(gapAt, "binlogs purged before stream caught up"))
+	mock.ExpectQuery("SELECT source_health").
+		WillReturnError(sql.ErrNoRows)
+
+	err = CheckCaptureGap(context.Background(), db, "mydb", "orders", since, until, false)
+	if err == nil {
+		t.Fatal("expected an error under strict mode when gap_lost_at is inside the window, got nil")
+	}
+	if !strings.Contains(err.Error(), "capture gap") {
+		t.Errorf("expected error to mention the capture gap, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "allow-gaps") {
+		t.Errorf("expected error to mention --allow-gaps as the way to proceed, got: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestCheckCaptureGap_gapInsideWindow_allowGapsWarnsOnly(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	since := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	until := time.Date(2026, 6, 10, 0, 0, 0, 0, time.UTC)
+	gapAt := since.Add(24 * time.Hour)
+
+	mock.ExpectQuery("SELECT mode, binlog_file").
+		WillReturnRows(streamStateRows(gapAt, "binlogs purged before stream caught up"))
+	mock.ExpectQuery("SELECT source_health").
+		WillReturnError(sql.ErrNoRows)
+
+	if err := CheckCaptureGap(context.Background(), db, "mydb", "orders", since, until, true); err != nil {
+		t.Fatalf("expected nil error under --allow-gaps, got: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestCheckCaptureGap_gapOutsideWindow_noError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	since := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	until := time.Date(2026, 6, 10, 0, 0, 0, 0, time.UTC)
+	// Recorded before the reconstruction window (already covered by the
+	// baseline) — must not be flagged.
+	gapAt := since.Add(-time.Hour)
+
+	mock.ExpectQuery("SELECT mode, binlog_file").
+		WillReturnRows(streamStateRows(gapAt, "old gap"))
+	mock.ExpectQuery("SELECT source_health").
+		WillReturnError(sql.ErrNoRows)
+
+	if err := CheckCaptureGap(context.Background(), db, "mydb", "orders", since, until, false); err != nil {
+		t.Fatalf("expected nil error when gap_lost_at is outside the window, got: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestCheckCaptureGap_noGapRecorded_noError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	since := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	until := time.Date(2026, 6, 10, 0, 0, 0, 0, time.UTC)
+
+	mock.ExpectQuery("SELECT mode, binlog_file").
+		WillReturnRows(streamStateRows(nil, nil))
+	mock.ExpectQuery("SELECT source_health").
+		WillReturnError(sql.ErrNoRows)
+
+	if err := CheckCaptureGap(context.Background(), db, "mydb", "orders", since, until, false); err != nil {
+		t.Fatalf("expected nil error when gap_lost_at is NULL, got: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
+	}
+}

--- a/internal/reconstruct/fulltable.go
+++ b/internal/reconstruct/fulltable.go
@@ -390,6 +390,15 @@ func ReconstructTable(
 		return nil, err
 	}
 
+	// ── 3c. Refuse/warn on a stamped capture gap inside the window (#765) ──
+	// stream_state.gap_lost_at records an irreparable capture gap (source
+	// binlogs purged before the stream caught up); unlike the archive-coverage
+	// gap the fetch below already guards against, no amount of archive
+	// resolution can fill this — it must be checked directly.
+	if err := CheckCaptureGap(ctx, db, schema, table, snapshotTime, cfg.At, cfg.AllowGaps); err != nil {
+		return nil, err
+	}
+
 	// ── 4. Fetch events via the shared helper (gap-aware) ──────────────────
 	fetchOpts := query.Options{
 		Schema: schema,


### PR DESCRIPTION
closes #765

## Summary
- `AllowGaps=false` previously only aborted on planner-detected retention gaps (rotated hours with no archive). It never consulted `stream_state.gap_lost_at`/`gap_lost_detail`, the durable record already stamped when an unfillable capture gap forces an auto-advance, so reconstructing across a stamped gap silently produced an incomplete dump with exit 0.
- Adds `reconstruct.CheckCaptureGap` (`internal/reconstruct/capturegap.go`), which reuses the existing `status.LoadStreamState` read path. If `gap_lost_at` falls inside `(snapshotTime, at]` it refuses under strict mode (default) or logs a `slog.Warn` under `--allow-gaps`.
- Wired into `ReconstructTable` (`internal/reconstruct/fulltable.go`, per-table since each table has its own baseline snapshot time bounding a different window) and the single-row path in `internal/cli/reconstruct.go`.
- Known limitation: `gap_lost_at` is a single scalar. If two distinct gaps occur and the reconstruct target window falls between them, the earlier gap can be missed. Fixing that needs the gap-tracking infrastructure this issue explicitly says not to build; the reported single-gap scenario is fully covered.

## Test plan
- [x] `go test ./... -count=1` (unit only, no Docker; shared MySQL port 13306 in use by other agents)
- [x] New unit tests in `internal/reconstruct/capturegap_test.go`: boundary logic (`gapInWindow`) plus sqlmock-backed cases for strict-refuse, allow-gaps-warn, gap-outside-window, and no-gap-recorded
- [ ] No integration/E2E coverage exercising the real MySQL call path (out of scope per task constraints)

Generated with Claude Code
