### PR TITLE
baseline: anchor snapshot on process-captured UTC time, not mydumper's ambiguous local-time line

### DIFF
--- a/cliapp/dump.go
+++ b/cliapp/dump.go
@@ -12,9 +12,11 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/spf13/cobra"
 
+	"github.com/dbtrail/dbtrail/internal/baseline"
 	"github.com/dbtrail/dbtrail/internal/cliutil"
 	"github.com/dbtrail/dbtrail/internal/config"
 )
@@ -255,6 +257,13 @@ func runDump(cmd *cobra.Command, args []string) error {
 	} else {
 		c.Stderr = &stderrBuf
 	}
+	// Captured immediately before invoking mydumper so it approximates
+	// mydumper's own dump-start instant, but as this process's UTC wall
+	// clock rather than mydumper's (possibly non-UTC, possibly
+	// containerized) local time. Recorded as a sidecar below so
+	// `bintrail baseline` can anchor on it instead of re-parsing mydumper's
+	// ambiguous "Started dump at" line (#768).
+	dumpStartedAt := time.Now().UTC()
 	if runErr := c.Run(); runErr != nil {
 		if stderr := strings.TrimSpace(stderrBuf.String()); stderr != "" {
 			return fmt.Errorf("mydumper failed: %w; stderr: %s", runErr, stderr)
@@ -263,6 +272,14 @@ func runDump(cmd *cobra.Command, args []string) error {
 	}
 
 	slog.Info("dump complete", "output_dir", dmpOutputDir)
+
+	// Best-effort: a write failure here just means baseline conversion falls
+	// back to mydumper's own (TZ-sensitive) "Started dump at" line rather
+	// than failing the dump itself.
+	if err := baseline.WriteStartedAtMarker(dmpOutputDir, dumpStartedAt); err != nil {
+		slog.Warn("could not write dump-start marker; baseline conversion will fall back to mydumper's local-time 'Started dump at' line",
+			"output_dir", dmpOutputDir, "error", err)
+	}
 
 	if dmpFormat == "json" {
 		return cliutil.OutputJSON(struct {

--- a/cmd/bintrail-console/baseline.go
+++ b/cmd/bintrail-console/baseline.go
@@ -106,6 +106,14 @@ func (s *baselineSupervisor) execute(req console.BaselineRequest) (baseline.Stat
 	}
 	defer os.RemoveAll(dumpDir)
 
+	// Captured immediately before invoking mydumper: since this pipeline runs
+	// mydumper and baseline.Run in the same process, we can pass our own UTC
+	// wall-clock time straight through as the snapshot anchor instead of
+	// letting baseline.Run re-parse mydumper's "Started dump at" metadata
+	// line — which is written in the dump host's LOCAL time and would
+	// otherwise be misread as UTC verbatim, skewing the replay window by the
+	// host's UTC offset (#768).
+	dumpStartedAt := time.Now().UTC()
 	if err := runMydumper(s.ctx, req.SourceDSN, req.Schemas, dumpDir); err != nil {
 		return baseline.Stats{}, 0, fmt.Errorf("dump: %w", err)
 	}
@@ -123,6 +131,7 @@ func (s *baselineSupervisor) execute(req console.BaselineRequest) (baseline.Stat
 		InputDir:    dumpDir,
 		OutputDir:   outputDir,
 		Compression: "zstd",
+		Timestamp:   dumpStartedAt,
 	})
 	if err != nil {
 		return baseline.Stats{}, 0, fmt.Errorf("convert: %w", err)

--- a/docs/dump-and-baseline.md
+++ b/docs/dump-and-baseline.md
@@ -216,7 +216,14 @@ For example:
 /data/baselines/2026-03-02T14-30-00Z/mydb/customers.parquet
 ```
 
-The timestamp defaults to the `Started dump at:` time from mydumper's metadata file. Override it with `--timestamp` if needed.
+The timestamp defaults to the dump's start time, resolved in this order:
+
+1. **The `bintrail dump` marker, if present.** `bintrail dump` records its own UTC wall-clock time immediately before invoking mydumper into a `bintrail_dump_started_at_utc` sidecar in the output directory. This is unambiguous — `bintrail baseline` prefers it whenever present.
+2. **mydumper's `Started dump at:` metadata line, otherwise.** This line is written in the **dump host's local time**, but `bintrail baseline` parses it as if it were already UTC. If you produced the mydumper dump yourself (outside `bintrail dump` — e.g. running mydumper directly, or from another tool), the dump host's clock **must** be set to UTC (`TZ=UTC`), or every reconstruct/verify/shim consumer that anchors replay on this snapshot will be off by the host's UTC offset — on a UTC+2 host, for example, deltas in the resulting 2-hour window are silently excluded from replay.
+
+The console's own **Create baseline** trigger runs mydumper and the Parquet conversion in the same process, so it passes its own captured UTC time straight through and is unaffected by the dump host's timezone either way.
+
+Override the resolved timestamp with `--timestamp` if needed.
 
 Each snapshot also records its **binlog anchor** (the file/position/GTID where the deltas on top of it begin) and, per table, a **content digest + row count** in the Parquet metadata (used by [`bintrail verify`](verify.md)). A `_SUCCESS` marker is written when the conversion completes; a partially-converted snapshot carries an `_INCOMPLETE` marker instead and is excluded from discovery (see [Pruning old local snapshots](#pruning-old-local-snapshots---baseline-retain)).
 

--- a/internal/baseline/baseline_test.go
+++ b/internal/baseline/baseline_test.go
@@ -103,6 +103,76 @@ func TestParseMetadataNewFormat(t *testing.T) {
 	}
 }
 
+// TestParseMetadataPrefersStartedAtMarker verifies the #768 fix: when
+// `bintrail dump` has written its own process-captured UTC start-time
+// marker, ParseMetadata uses it instead of re-parsing mydumper's
+// "Started dump at" line as if it were UTC. Here the mydumper line encodes a
+// dump-host-local timestamp (e.g. a UTC+2 host writing "02:00:00" for an
+// event that actually happened at 00:00:00 UTC) — parsing it verbatim as UTC
+// would anchor the baseline 2 hours in the future and silently exclude the
+// intervening deltas from replay. The marker sidesteps that ambiguity.
+func TestParseMetadataPrefersStartedAtMarker(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "metadata"), []byte(sampleMetadata), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	trueUTC := time.Date(2025, 2, 27, 22, 0, 0, 0, time.UTC) // 2h earlier than the (host-local) mydumper line
+	if err := WriteStartedAtMarker(dir, trueUTC); err != nil {
+		t.Fatalf("WriteStartedAtMarker: %v", err)
+	}
+
+	m, err := ParseMetadata(dir)
+	if err != nil {
+		t.Fatalf("ParseMetadata: %v", err)
+	}
+	if !m.StartedAt.Equal(trueUTC) {
+		t.Errorf("StartedAt = %v, want marker time %v (mydumper's ambiguous local-time line should have been overridden)", m.StartedAt, trueUTC)
+	}
+	// Other fields still come from mydumper's own metadata file.
+	if m.BinlogFile != "binlog.000042" {
+		t.Errorf("BinlogFile = %q, want %q", m.BinlogFile, "binlog.000042")
+	}
+}
+
+// TestParseMetadataFallsBackWithoutMarker pins the pre-#768 behavior for
+// mydumper dumps produced outside `bintrail dump` (no marker file): the
+// ambiguous "Started dump at" line is still parsed as UTC verbatim.
+func TestParseMetadataFallsBackWithoutMarker(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "metadata"), []byte(sampleMetadata), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m, err := ParseMetadata(dir)
+	if err != nil {
+		t.Fatalf("ParseMetadata: %v", err)
+	}
+	want := time.Date(2025, 2, 28, 0, 0, 0, 0, time.UTC)
+	if !m.StartedAt.Equal(want) {
+		t.Errorf("StartedAt = %v, want %v", m.StartedAt, want)
+	}
+}
+
+// TestParseMetadataCorruptMarkerFallsBack verifies that an unparseable
+// dump-start marker (e.g. truncated by a crash mid-write) is a no-op fallback,
+// not a hard failure: ParseMetadata still succeeds using mydumper's own line.
+func TestParseMetadataCorruptMarkerFallsBack(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "metadata"), []byte(sampleMetadata), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, StartedAtMarkerFile), []byte("not-a-timestamp"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m, err := ParseMetadata(dir)
+	if err != nil {
+		t.Fatalf("ParseMetadata: %v", err)
+	}
+	want := time.Date(2025, 2, 28, 0, 0, 0, 0, time.UTC)
+	if !m.StartedAt.Equal(want) {
+		t.Errorf("StartedAt = %v, want %v (fallback to mydumper's line)", m.StartedAt, want)
+	}
+}
+
 func TestParseMetadataMissingTimestamp(t *testing.T) {
 	const content = "SHOW MASTER STATUS:\n\tLog: binlog.000001\n\tPos: 100\n"
 	dir := t.TempDir()

--- a/internal/baseline/metadata.go
+++ b/internal/baseline/metadata.go
@@ -63,6 +63,51 @@ type DumpMetadata struct {
 	LSN            uint64 // PostgreSQL WAL LSN anchor (MetaKeyLSN); 0 = absent (MySQL baseline, or pre-#593 PG baseline)
 }
 
+// StartedAtMarkerFile is a bintrail-authored sidecar written into the mydumper
+// output directory by `bintrail dump`, recording that process's own UTC
+// wall-clock time captured immediately before invoking mydumper.
+//
+// mydumper's own "Started dump at" metadata line is written in the dump
+// host's LOCAL time, but ParseMetadata parses it with ParseInLocation(...,
+// time.UTC) — i.e. verbatim, as if it already were UTC. On a dump host whose
+// clock isn't set to UTC, every reconstruct/verify/shim consumer that anchors
+// replay at this timestamp skews by the host's UTC offset (#768). When this
+// marker is present, ParseMetadata prefers it over the ambiguous mydumper
+// line, sidestepping the timezone question entirely. It is absent for
+// mydumper dumps produced outside `bintrail dump` (manual mydumper run, a
+// different tool) — see docs/dump-and-baseline.md for that case.
+const StartedAtMarkerFile = "bintrail_dump_started_at_utc"
+
+// WriteStartedAtMarker records t (converted to UTC) into inputDir as the
+// authoritative dump-start time. Called by `bintrail dump` right before
+// invoking mydumper; best-effort on the caller's side — a write failure just
+// means ParseMetadata falls back to mydumper's own local-time line.
+func WriteStartedAtMarker(inputDir string, t time.Time) error {
+	path := filepath.Join(inputDir, StartedAtMarkerFile)
+	if err := os.WriteFile(path, []byte(t.UTC().Format(time.RFC3339Nano)+"\n"), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", StartedAtMarkerFile, err)
+	}
+	return nil
+}
+
+// readStartedAtMarker reads StartedAtMarkerFile from inputDir, if present and
+// parseable. Returns ok=false (never an error) when the marker is absent or
+// corrupt — callers fall back to mydumper's own metadata timestamp.
+func readStartedAtMarker(inputDir string) (t time.Time, ok bool) {
+	path := filepath.Join(inputDir, StartedAtMarkerFile)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return time.Time{}, false
+	}
+	t, err = time.Parse(time.RFC3339Nano, strings.TrimSpace(string(data)))
+	if err != nil {
+		slog.Warn("dump-start marker present but unparseable; falling back to mydumper's 'Started dump at' line",
+			"path", path, "error", err)
+		return time.Time{}, false
+	}
+	return t.UTC(), true
+}
+
 // ParseMetadata reads the mydumper "metadata" file in inputDir and returns the
 // extracted dump timestamp and binlog position information.
 //
@@ -74,6 +119,10 @@ type DumpMetadata struct {
 //	    Pos: 12345
 //	    GTID: 3e11fa47-...:1-100
 //	Finished dump at: 2025-02-28 00:01:23
+//
+// If inputDir also carries StartedAtMarkerFile (written by `bintrail dump`),
+// its process-captured UTC time is preferred over the "Started dump at" line
+// above, which is ambiguous with respect to the dump host's timezone (#768).
 func ParseMetadata(inputDir string) (DumpMetadata, error) {
 	path := filepath.Join(inputDir, "metadata")
 	f, err := os.Open(path)
@@ -83,6 +132,11 @@ func ParseMetadata(inputDir string) (DumpMetadata, error) {
 	defer f.Close()
 
 	var m DumpMetadata
+	markerStartedAt, haveMarker := readStartedAtMarker(inputDir)
+	if haveMarker {
+		m.StartedAt = markerStartedAt
+	}
+
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -91,11 +145,13 @@ func ParseMetadata(inputDir string) (DumpMetadata, error) {
 		trimmed := strings.TrimPrefix(line, "# ")
 
 		if after, ok := strings.CutPrefix(trimmed, "Started dump at: "); ok {
-			t, err := time.ParseInLocation("2006-01-02 15:04:05", strings.TrimSpace(after), time.UTC)
-			if err != nil {
-				return DumpMetadata{}, fmt.Errorf("parse dump timestamp %q: %w", after, err)
+			if !haveMarker {
+				t, err := time.ParseInLocation("2006-01-02 15:04:05", strings.TrimSpace(after), time.UTC)
+				if err != nil {
+					return DumpMetadata{}, fmt.Errorf("parse dump timestamp %q: %w", after, err)
+				}
+				m.StartedAt = t
 			}
-			m.StartedAt = t
 		} else if after, ok := strings.CutPrefix(line, "\tLog: "); ok {
 			m.BinlogFile = strings.TrimSpace(after)
 		} else if after, ok := strings.CutPrefix(line, "\tPos: "); ok {


### PR DESCRIPTION
closes #768

## Summary
- `ParseMetadata` parsed mydumper's `Started dump at` line (dump-host LOCAL time) as if it were already UTC — on a non-UTC dump host this anchored the baseline's replay window off by the host's UTC offset, silently excluding the intervening deltas from reconstruct/verify/shim replay.
- Investigated the recommended smaller fix first: both mydumper call sites (`bintrail dump` in `cliapp/dump.go`, and the console's "Create baseline" trigger in `cmd/bintrail-console/baseline.go`) can capture `time.Now().UTC()` themselves right around the mydumper invocation, sidestepping the ambiguous string entirely.
  - The console trigger runs mydumper and `baseline.Run` in the same process, so it now just passes the captured time through the existing `Config.Timestamp` override — no new file, no new flag.
  - `bintrail dump` and `bintrail baseline` are separate process invocations, so the captured time has to cross a file boundary: `dump` now writes a `bintrail_dump_started_at_utc` sidecar into the mydumper output dir, and `ParseMetadata` prefers it over the ambiguous mydumper line when present.
- A mydumper dump produced entirely outside bintrail (manual run, another tool) has no sidecar to prefer, so it still falls back to the old ambiguous line — documented the `TZ=UTC` requirement for that case in `docs/dump-and-baseline.md`. Did not implement the larger `SincePos`-based anchoring redesign flagged in the issue as out of scope.

## Test plan
- [x] `go test ./... -count=1` (full unit suite, no Docker)
- [x] New unit tests in `internal/baseline/baseline_test.go`: marker preferred over the ambiguous mydumper line, fallback when marker absent, fallback when marker is corrupt/unparseable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
