### PR TITLE
stream: fail loud on post-DDL snapshot failure instead of silently skipping rows

### DIFF
--- a/docs/ddl-tracking.md
+++ b/docs/ddl-tracking.md
@@ -26,13 +26,13 @@ When a DDL is detected, dbtrail automatically takes a new snapshot from the live
 
 ### Error handling
 
-DDL handling is best-effort — a snapshot failure never aborts the stream. If the snapshot fails (e.g., the source DB is temporarily unreachable), the DDL is still recorded in `schema_changes` but without a `snapshot_id`. The parser continues with the old resolver, which may produce column count mismatches until the next successful snapshot.
+A snapshot (or resolver-reload) failure **aborts the stream**. The DDL is still recorded in `schema_changes` before the abort, but without a `snapshot_id`.
 
-Failures are logged at `slog.Error` level so they're visible in production monitoring:
+This used to be best-effort: the failure was only logged, and the parser kept decoding with the old resolver. In practice that meant every row event that followed the DDL in the binlog — an unbounded burst of INSERT/UPDATE/DELETE on the altered/created table — was silently skipped as a "column count mismatch" / "table not in snapshot", while the stream checkpoint kept advancing past them. Once healthy schema tracking resumed, those events were already behind the checkpoint and could never be re-streamed: a permanent, unmarked loss.
 
-```
-ERROR DDL snapshot failed schema=mydb table=users error="connection refused"
-```
+Aborting instead means the process exits non-zero *before the DDL event itself is even emitted* to the indexer, so the durable checkpoint (which only advances off events it actually receives) stays exactly where it was *before* this DDL. A supervisor restart (`bintrail-console watch`'s monitor, or an external process manager for standalone `bintrail stream`) resumes from that checkpoint, re-reads the same DDL off the binlog, retries the snapshot, and only then decodes the rows that follow — against a fresh resolver. No gap, no silent skip.
+
+The abort surfaces as the process's error output — `bintrail stream` prints it to stderr and exits 1; under `bintrail-console watch` the monitor logs it and applies its crash-loop backoff before retrying — so it's visible in production monitoring either way.
 
 ---
 

--- a/internal/parser/stream.go
+++ b/internal/parser/stream.go
@@ -5,6 +5,7 @@ package parser
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"sync/atomic"
 	"time"
@@ -23,10 +24,11 @@ type StreamParser struct {
 	filters       Filters
 	logger        *slog.Logger
 	schemaVersion atomic.Uint32 // actual snapshot_id from schema_snapshots; updated by SwapResolver
-	// onDDL, when set, runs SYNCHRONOUSLY inside Run after a DDL event is
-	// emitted and before ANY subsequent binlog event is decoded. See
-	// SetSyncDDLHook for why this must not move off the parse path.
-	onDDL atomic.Pointer[func(Event)]
+	// onDDL, when set, runs SYNCHRONOUSLY inside Run for a DDL event, BEFORE
+	// that event is emitted and before ANY subsequent binlog event is
+	// decoded. See SetSyncDDLHook for why this must not move off the parse
+	// path, and why the ordering (hook, then emit) is load-bearing for #760.
+	onDDL atomic.Pointer[func(Event) error]
 }
 
 // NewStreamParser creates a StreamParser that resolves column names via
@@ -52,8 +54,9 @@ func (sp *StreamParser) SwapResolver(r *metadata.Resolver) {
 	sp.resolver.Store(r)
 }
 
-// SetSyncDDLHook registers fn to run synchronously inside Run, after each DDL
-// event is emitted and BEFORE any subsequent binlog event is decoded.
+// SetSyncDDLHook registers fn to run synchronously inside Run, for each DDL
+// event, BEFORE that event is emitted on out and BEFORE any subsequent
+// binlog event is decoded.
 //
 // This is the ONLY correct place for the auto-snapshot-on-DDL work (#396):
 // the binlog is sequential — `CREATE TABLE t; INSERT INTO t;` puts the row
@@ -65,10 +68,25 @@ func (sp *StreamParser) SwapResolver(r *metadata.Resolver) {
 // snapshot and calls SwapResolver, so the very next row event decodes with
 // the post-DDL schema.
 //
+// fn returning a non-nil error aborts Run immediately, WITHOUT ever emitting
+// the DDL event (#760): if the post-DDL snapshot/resolver refresh failed, the
+// resolver is stale and every row event that follows this DDL in the binlog
+// would otherwise be silently skipped as "column count mismatch" / "table
+// not in snapshot" while the stream checkpoint keeps advancing past them — a
+// permanent, unmarked loss. The checkpoint (in this package's consumers)
+// advances off events it actually receives, including the DDL event itself;
+// withholding that event on hook failure means the checkpoint stays exactly
+// where it was BEFORE this DDL. A supervisor restart then resumes from
+// there, re-reads the same DDL off the binlog, re-runs this hook (retrying
+// the snapshot), and only then decodes the rows that follow — with a fresh
+// resolver. Emitting the DDL event first and running fn after would let the
+// checkpoint advance past the DDL before a failure is even known, defeating
+// the retry.
+//
 // While fn runs, no new events are produced (the replication connection
 // buffers server-side); consumers keep draining already-emitted events.
 // Safe to call concurrently with Run.
-func (sp *StreamParser) SetSyncDDLHook(fn func(Event)) {
+func (sp *StreamParser) SetSyncDDLHook(fn func(Event) error) {
 	if fn == nil {
 		sp.onDDL.Store(nil)
 		return
@@ -206,16 +224,29 @@ func (sp *StreamParser) Run(ctx context.Context, streamer *replication.BinlogStr
 			currentQueryText = ""
 			ts := time.Unix(int64(binlogEv.Header.Timestamp), 0).UTC()
 			if ddlEv, ok := parseDDL(sp.logger, currentFile, binlogEv.Header.LogPos, ts, currentGTID, string(ev.Query), sp.schemaVersion.Load()); ok {
+				// Synchronous DDL hook runs BEFORE ddlEv is emitted (#760,
+				// reordered from emit-then-hook). The consumer (streamLoop)
+				// advances the durable checkpoint's binlogPos/GTID off events
+				// it receives, including EventDDL itself — so if ddlEv were
+				// emitted first and the hook then failed, the checkpoint
+				// would already have moved past this DDL by the time Run
+				// aborts. A restart would resume AFTER the DDL, never
+				// re-read the QUERY_EVENT that carries it, and never re-fire
+				// this hook — leaving the resolver stale forever while rows
+				// keep getting silently skipped as "column count mismatch".
+				// Running the hook first and returning its error WITHOUT
+				// ever sending ddlEv means a failure leaves the checkpoint
+				// exactly where it was before this DDL; a restart re-reads
+				// the DDL from the binlog and retries the snapshot.
+				if hook := sp.onDDL.Load(); hook != nil {
+					if err := (*hook)(ddlEv); err != nil {
+						return fmt.Errorf("sync DDL hook: %w", err)
+					}
+				}
 				select {
 				case out <- ddlEv:
 				case <-ctx.Done():
 					return ctx.Err()
-				}
-				// Synchronous DDL hook: the resolver refresh must complete
-				// before the next event is processed, or the rows that follow a
-				// CREATE/ALTER in the binlog are skipped as unknown (#396).
-				if hook := sp.onDDL.Load(); hook != nil {
-					(*hook)(ddlEv)
 				}
 				// Table DDL auto-commits its own GTID; EventDDL is the commit
 				// boundary the consumer acts on, so clear the in-flight GTID to keep

--- a/internal/parser/stream_test.go
+++ b/internal/parser/stream_test.go
@@ -765,12 +765,14 @@ func TestStreamParser_mixedSequenceGTIDOnly(t *testing.T) {
 
 // ─── Synchronous DDL hook (#396) ──────────────────────────────────────────────
 
-// TestStreamParser_syncDDLHookOrdering locks the #396 fix: the hook runs
-// synchronously inside Run — after the DDL is emitted, before ANY subsequent
-// event is decoded. Observable two ways: (1) when the hook runs, the output
-// channel holds exactly the DDL (the following event cannot have been
-// processed yet); (2) a resolver swapped inside the hook is what stamps the
-// NEXT event's SchemaVersion.
+// TestStreamParser_syncDDLHookOrdering locks the #396/#760 fix: the hook runs
+// synchronously inside Run — BEFORE the DDL itself is emitted, and before ANY
+// subsequent event is decoded (#760 reordered this from emit-then-hook to
+// hook-then-emit, so a hook failure can withhold the DDL event entirely — see
+// TestStreamParser_syncDDLHookErrorAbortsRun). Observable two ways: (1) when
+// the hook runs, the output channel is still empty (neither the DDL nor the
+// following event has been emitted yet); (2) a resolver swapped inside the
+// hook is what stamps the NEXT event's SchemaVersion.
 func TestStreamParser_syncDDLHookOrdering(t *testing.T) {
 	r1 := metadata.NewResolverFromTables(1, nil)
 	sp := NewStreamParser(r1, Filters{}, nil)
@@ -778,7 +780,7 @@ func TestStreamParser_syncDDLHookOrdering(t *testing.T) {
 	out := make(chan Event, 10)
 
 	hookRuns := 0
-	sp.SetSyncDDLHook(func(ev Event) {
+	sp.SetSyncDDLHook(func(ev Event) error {
 		hookRuns++
 		if ev.EventType != EventDDL {
 			t.Errorf("hook received %v, want EventDDL", ev.EventType)
@@ -786,13 +788,14 @@ func TestStreamParser_syncDDLHookOrdering(t *testing.T) {
 		if ev.SchemaVersion != 1 {
 			t.Errorf("first DDL SchemaVersion = %d, want pre-swap 1", ev.SchemaVersion)
 		}
-		// The DDL itself is emitted; the event AFTER it must not be yet.
-		if got := len(out); got != 1 {
-			t.Errorf("hook must run before the next event is processed; out holds %d events", got)
+		// The hook runs BEFORE the DDL itself is emitted (#760).
+		if got := len(out); got != 0 {
+			t.Errorf("hook must run before the DDL is emitted; out holds %d events", got)
 		}
 		// The snapshot-refresh stand-in: the very next decode must see this.
 		sp.SwapResolver(metadata.NewResolverFromTables(99, nil))
 		sp.SetSyncDDLHook(nil) // only assert the first DDL
+		return nil
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -816,6 +819,56 @@ func TestStreamParser_syncDDLHookOrdering(t *testing.T) {
 	}
 	if evs[1].SchemaVersion != 99 {
 		t.Errorf("post-hook event SchemaVersion = %d, want 99 (the in-hook swap must land before the next decode)", evs[1].SchemaVersion)
+	}
+}
+
+// TestStreamParser_syncDDLHookErrorAbortsRun locks the #760 fail-loud fix: a
+// hook error must abort Run WITHOUT ever emitting the DDL event itself, and
+// before it decodes any event that follows the DDL in the binlog.
+//
+// Why withholding the DDL event matters (not just the rows after it): the
+// stream consumer (streamLoop) advances the durable checkpoint's
+// binlogPos/GTID off events it actually receives, including EventDDL, whose
+// own commit boundary the consumer treats as safe to persist. If the DDL
+// event were emitted before the hook's failure is known, the checkpoint
+// could advance past the DDL before Run aborts; a restart would then resume
+// AFTER the DDL, never re-read the QUERY_EVENT that carries it, never re-run
+// this hook, and silently skip the following rows forever against the same
+// stale resolver — turning "permanent silent loss" into "one crash, then
+// permanent silent loss again". Withholding ddlEv on hook failure keeps the
+// checkpoint at (or before) the DDL, so a restart re-reads it, retries the
+// snapshot, and only then decodes the rows that follow.
+func TestStreamParser_syncDDLHookErrorAbortsRun(t *testing.T) {
+	sp := NewStreamParser(nil, Filters{}, nil)
+	streamer := replication.NewBinlogStreamer()
+	out := make(chan Event, 10)
+
+	sentinel := errors.New("snapshot: connection refused")
+	sp.SetSyncDDLHook(func(ev Event) error {
+		return sentinel
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	feedThenCancel(t, streamer, cancel,
+		makeQueryEvent("CREATE TABLE mydb.orders (id INT)"),
+		makeRowsEvent("mydb", "orders"), // must never be decoded
+	)
+
+	err := sp.Run(ctx, streamer, out)
+	if err == nil {
+		t.Fatal("Run returned nil, want the wrapped hook error")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("Run error = %v, want it to wrap %v", err, sentinel)
+	}
+
+	close(out)
+	var evs []Event
+	for ev := range out {
+		evs = append(evs, ev)
+	}
+	if len(evs) != 0 {
+		t.Fatalf("out = %v, want NO events (the DDL itself, and the row event that followed, must never be emitted/decoded)", typesOf(evs))
 	}
 }
 

--- a/internal/streamrun/streamrun.go
+++ b/internal/streamrun/streamrun.go
@@ -1632,11 +1632,23 @@ func One(ctx context.Context, cfg Config) error {
 	// (`CREATE TABLE t; INSERT INTO t;`), so the resolver must be refreshed
 	// before the parser decodes the events that FOLLOW the DDL — a
 	// consumer-side handler ran too late and the trailing rows were skipped
-	// as "table not in snapshot" (#396). Best-effort: failures are logged and
-	// streaming continues with the previous schema.
+	// as "table not in snapshot" (#396).
 	// TRUNCATE does not change schema structure, so it only records the change.
+	//
+	// Fail-loud on snapshot/resolver failure (#760, same philosophy as the
+	// #652 flush fix): a stale resolver here means every row event that
+	// follows this DDL in the binlog gets silently skipped as "column count
+	// mismatch" / "table not in snapshot" while streamLoop's checkpoint keeps
+	// advancing past them — a permanent, unmarked loss, since the checkpoint
+	// never revisits those events. Returning an error aborts sp.Run BEFORE it
+	// even emits this DDL event (see SetSyncDDLHook — the hook now runs
+	// before the DDL is sent, not after), so streamLoop never observes it and
+	// the checkpoint stays exactly where it was before this DDL. The process
+	// exits non-zero; a supervisor restart resumes from there, re-reads this
+	// same DDL off the binlog, retries the snapshot, and only then decodes
+	// the rows that follow — with a fresh resolver.
 	schemas := cfg.Deps.ParseSchemaList(cfg.Schemas)
-	sp.SetSyncDDLHook(func(ev parser.Event) {
+	sp.SetSyncDDLHook(func(ev parser.Event) error {
 		if ev.DDLType == parser.DDLTruncateTable {
 			slog.Info("DDL detected (no snapshot needed)",
 				"file", ev.BinlogFile, "pos", ev.EndPos,
@@ -1644,7 +1656,7 @@ func One(ctx context.Context, cfg Config) error {
 			if err := cfg.Deps.InsertSchemaChange(indexDB, ev, nil); err != nil {
 				slog.Warn("failed to record schema change", "error", err)
 			}
-			return
+			return nil
 		}
 
 		slog.Info("DDL detected — taking auto-snapshot",
@@ -1652,27 +1664,34 @@ func One(ctx context.Context, cfg Config) error {
 			"ddl_type", ev.DDLType, "schema", ev.Schema, "table", ev.Table)
 
 		stats, snapErr := metadata.TakeSnapshot(sourceDB, indexDB, schemas)
-		var snapID *int
 		if snapErr != nil {
-			slog.Error("auto-snapshot after DDL failed; subsequent events may use stale schema",
-				"error", snapErr, "ddl_type", ev.DDLType, "table", ev.Table)
-		} else {
-			snapID = &stats.SnapshotID
-			newResolver, resolverErr := metadata.NewResolver(indexDB, stats.SnapshotID)
-			if resolverErr != nil {
-				slog.Warn("failed to load new resolver after DDL snapshot", "error", resolverErr)
-			} else {
-				sp.SwapResolver(newResolver)
-				slog.Info("auto-snapshot taken; resolver updated",
-					"snapshot_id", stats.SnapshotID,
-					"tables", stats.TableCount,
-					"columns", stats.ColumnCount)
+			// Best-effort history record of the attempt, then abort — see the
+			// fail-loud rationale above.
+			if err := cfg.Deps.InsertSchemaChange(indexDB, ev, nil); err != nil {
+				slog.Warn("failed to record schema change", "error", err)
 			}
+			return fmt.Errorf("auto-snapshot after DDL on %s.%s: %w", ev.Schema, ev.Table, snapErr)
 		}
+
+		snapID := &stats.SnapshotID
+		newResolver, resolverErr := metadata.NewResolver(indexDB, stats.SnapshotID)
+		if resolverErr != nil {
+			if err := cfg.Deps.InsertSchemaChange(indexDB, ev, snapID); err != nil {
+				slog.Warn("failed to record schema change", "error", err)
+			}
+			return fmt.Errorf("load resolver after DDL snapshot on %s.%s: %w", ev.Schema, ev.Table, resolverErr)
+		}
+
+		sp.SwapResolver(newResolver)
+		slog.Info("auto-snapshot taken; resolver updated",
+			"snapshot_id", stats.SnapshotID,
+			"tables", stats.TableCount,
+			"columns", stats.ColumnCount)
 
 		if err := cfg.Deps.InsertSchemaChange(indexDB, ev, snapID); err != nil {
 			slog.Warn("failed to record schema change", "error", err)
 		}
+		return nil
 	})
 
 	events := make(chan parser.Event, 1000)


### PR DESCRIPTION
closes #760

## Summary
- The synchronous DDL hook (`StreamParser.SetSyncDDLHook`) took `TakeSnapshot` best-effort: on failure it only logged and let the parser keep decoding with the stale resolver, silently skipping every row event that followed the DDL in the binlog ("column count mismatch" / "table not in snapshot") while the stream checkpoint kept advancing past them — a permanent, unmarked loss.
- Fix (same fail-loud philosophy as the #652/#659 flush fix): the hook now returns an `error`, and `Run` invokes it **before** emitting the DDL event itself (reordered from emit-then-hook). A failure aborts `Run` without ever emitting the DDL, so `streamLoop`'s checkpoint — which only advances off events it actually receives, including `EventDDL`'s own commit boundary — stays exactly where it was *before* this DDL.
- The process exits non-zero; a supervisor restart (`bintrail-console watch`'s monitor, or an external process manager for standalone `bintrail stream`) resumes from that checkpoint, re-reads the same DDL off the binlog, retries the snapshot, and only then decodes the rows that follow, against a fresh resolver.
- Judgment call verified before landing this: emit-then-hook (the naive ordering) would **not** have fixed the bug — `EnsureResolver` only re-snapshots when no snapshot exists at all, so a restart after a mid-run failure would just reload the last (stale) snapshot and resume skipping, turning "permanent silent loss" into "one crash, then permanent silent loss again." The reorder (hook-then-emit) is what actually makes the retry work.
- Both the `TakeSnapshot` failure and the post-snapshot `NewResolver` failure paths abort (both leave the resolver stale for the following rows); the `NewResolver` failure still records the DDL in `schema_changes` with its `snapshot_id` before aborting. `TRUNCATE` (no schema change) and the record-only `InsertSchemaChange` failure path are unchanged (best-effort, no row-skip risk).
- Updated `docs/ddl-tracking.md`'s "Error handling" section, which documented the old best-effort behavior as the correct contract.

## Test plan
- [x] `go test ./... -count=1`
- [x] `go build -tags integration ./...` (compile-only check of the `//go:build integration` files against the new hook signature — no Docker started, per instructions)
- [x] New unit test `TestStreamParser_syncDDLHookErrorAbortsRun` locks the fix: a hook error aborts `Run` with the wrapped error and **zero** events (not even the DDL) reach the output channel.
- [x] Updated `TestStreamParser_syncDDLHookOrdering` for the new hook-then-emit ordering.

## Notes / known minor edge case
- A DDL landing exactly at process shutdown (SIGTERM) now runs the snapshot attempt before the `ctx.Done()` check on emit; if it fails in that narrow window, standalone `bintrail stream` would exit non-zero for what was otherwise a graceful stop (the `bintrail-console watch` supervisor already treats a cancelled-context stream as "stopped" regardless of this). Not restructured — the snapshot call is not context-aware, and the window is small.
- Sibling issue #759 (resume-time duplication) is being fixed separately; this fix's correctness depends on stream resume being safe on restart but is independent of the merge order, as noted in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
