### PR TITLE
reconstruct: fix ErrNoBaseline empty-table data loss; console prefers local dir with no S3 fallback

### DIFF
--- a/internal/console/manager.go
+++ b/internal/console/manager.go
@@ -7,12 +7,14 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"time"
 
 	"github.com/go-sql-driver/mysql"
 
 	"github.com/dbtrail/dbtrail/internal/config"
 	"github.com/dbtrail/dbtrail/internal/metadata"
 	"github.com/dbtrail/dbtrail/internal/query"
+	"github.com/dbtrail/dbtrail/internal/reconstruct"
 )
 
 // errNoServers is returned when a request arrives with no selectable server:
@@ -34,6 +36,13 @@ type bundle struct {
 	// baselineSrc is the resolved reconstruct baseline source (local dir wins
 	// over s3:// prefix); empty when reconstruct is not configured.
 	baselineSrc string
+	// baselineFallbackSrc is the S3 prefix to retry on ErrNoBaseline when a
+	// local dir was preferred as baselineSrc AND an S3 prefix is also
+	// configured; empty otherwise. Local baselines can be pruned by retention
+	// (#616) while a durable S3 copy remains — without this, a request for a
+	// table/time only covered by the S3 copy silently degraded to "no
+	// baseline" instead of finding it (#766).
+	baselineFallbackSrc string
 	// baselineConfigured gates the reconstruct surface per server: a baseline
 	// is present AND archives are enabled AND no RBAC profile is active. See
 	// the rationale on newBundleDerived.
@@ -224,17 +233,33 @@ func (cm *connManager) buildBundle(entry ServerEntry) (*bundle, error) {
 func newBundleDerived(db *sql.DB, dbName string, entry ServerEntry, profileActive bool) *bundle {
 	noArchive := entry.NoArchive || profileActive
 	src := entry.BaselineDir
+	fallback := ""
 	if src == "" {
 		src = entry.BaselineS3
+	} else if entry.BaselineS3 != "" {
+		fallback = entry.BaselineS3
 	}
 	return &bundle{
-		db:                 db,
-		dbName:             dbName,
-		engine:             query.New(db),
-		noArchive:          noArchive,
-		baselineSrc:        src,
-		baselineConfigured: src != "" && !noArchive,
+		db:                  db,
+		dbName:              dbName,
+		engine:              query.New(db),
+		noArchive:           noArchive,
+		baselineSrc:         src,
+		baselineFallbackSrc: fallback,
+		baselineConfigured:  src != "" && !noArchive,
 	}
+}
+
+// findBaseline locates a baseline for schema.table at-or-before at via
+// b.baselineSrc, falling back to b.baselineFallbackSrc (the durable S3 copy,
+// when both a local dir and an S3 prefix are configured) on ErrNoBaseline —
+// see the baselineFallbackSrc field doc (#766).
+func (b *bundle) findBaseline(ctx context.Context, schema, table string, at time.Time) (string, time.Time, reconstruct.StaleWarning, error) {
+	path, snapshotTime, stale, err := reconstruct.FindBaseline(ctx, b.baselineSrc, schema, table, at)
+	if b.baselineFallbackSrc == "" || !errors.Is(err, reconstruct.ErrNoBaseline) {
+		return path, snapshotTime, stale, err
+	}
+	return reconstruct.FindBaseline(ctx, b.baselineFallbackSrc, schema, table, at)
 }
 
 // loadResolver loads the latest schema snapshot, best-effort: a missing

--- a/internal/console/reconstruct.go
+++ b/internal/console/reconstruct.go
@@ -256,7 +256,7 @@ func (s *Server) handleReconstruct(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	// 1. Locate the baseline at-or-before `at` and read the row's initial state.
-	path, snapshotTime, stale, err := reconstruct.FindBaseline(ctx, b.baselineSrc, schema, table, atTime)
+	path, snapshotTime, stale, err := b.findBaseline(ctx, schema, table, atTime)
 	if err != nil {
 		if errors.Is(err, reconstruct.ErrNoBaseline) {
 			writeJSONError(w, http.StatusNotFound,

--- a/internal/reconstruct/fulltable.go
+++ b/internal/reconstruct/fulltable.go
@@ -97,6 +97,13 @@ type TableReport struct {
 	DeletesSkipped int64 // baseline rows whose PK matched a DELETE event
 	Files          []string
 	Duration       time.Duration
+	// BinlogOnly is true when the table had no baseline at all and was
+	// recovered entirely from the binlog (#766's ErrNoBaseline fallback,
+	// reconstructBinlogOnly). Files is non-empty in this case too, so
+	// ReconstructTables' shared-metadata-file selector must check this flag
+	// as well — a binlog-only report has no baseline GTID/binlog coordinates
+	// to embed in the metadata file.
+	BinlogOnly bool
 }
 
 // shouldWarnEvents reports whether a fetched event count should trigger the
@@ -242,11 +249,13 @@ func ReconstructTables(ctx context.Context, cfg FullTableConfig) ([]*TableReport
 	// the metadata file will reflect the first one and the rest will log
 	// a warning in ReconstructTable itself.
 	if len(reports) > 0 {
-		// Pick the first report that actually produced output files (skip
-		// tables that had no baseline and returned an empty report).
+		// Pick the first report that actually produced output files from a
+		// real baseline (skip tables that had no baseline: an empty report,
+		// or a #766 binlog-only report — neither has baseline GTID/binlog
+		// coordinates to embed in the metadata file).
 		var metaReport *TableReport
 		for _, r := range reports {
-			if len(r.Files) > 0 {
+			if len(r.Files) > 0 && !r.BinlogOnly {
 				metaReport = r
 				break
 			}
@@ -270,7 +279,7 @@ func ReconstructTables(ctx context.Context, cfg FullTableConfig) ([]*TableReport
 					"table", tableName, "error", perr)
 			}
 		} else {
-			slog.Warn("all reconstructed tables were empty; metadata file not written")
+			slog.Warn("no reconstructed table has a real baseline (all empty or binlog-only); metadata file not written")
 		}
 	}
 
@@ -310,12 +319,11 @@ func ReconstructTable(
 		// No baseline exists for this table. This can happen when: (1) the
 		// table was empty at dump time and the baseline predates 0-row
 		// Parquet support, or (2) the table was created after the last
-		// baseline snapshot. Treat as empty rather than failing the entire
-		// reconstruct run.
-		slog.Warn("no baseline found; treating table as empty at dump time",
-			"schema", schema, "table", table)
-		rep.Duration = time.Since(start)
-		return rep, nil
+		// baseline snapshot. Case (2) can hold real binlog-only rows (#766),
+		// so fall back to a binlog-only reconstruction instead of silently
+		// emitting an empty report — parity with the shim's _snapshot→
+		// _flashback degrade (internal/shim/snapshot.go runSnapshotFullTable).
+		return reconstructBinlogOnly(ctx, cfg, schema, table, db, engine, resolver, dbName, rep, start)
 	}
 	slog.Debug("baseline selected",
 		"schema", schema, "table", table,
@@ -818,6 +826,220 @@ func checkChangesToast(changes map[string]*query.ResultRow) error {
 			return err
 		}
 	}
+	return nil
+}
+
+// reconstructBinlogOnly is the ErrNoBaseline fallback for full-table
+// reconstruct (#766). A table created after the last baseline snapshot has no
+// Parquet to merge against; previously ReconstructTable stopped there and
+// returned an empty report, silently discarding every row that only ever
+// existed in the binlog — even a table with thousands of rows. This mirrors
+// the shim's binlog-only degrade (internal/shim/snapshot.go
+// runSnapshotFullTable falling back to runFullTable): fetch every event for
+// the table up to cfg.At and emit the latest surviving row per PK, skipping
+// DELETEs. There is no baseline Parquet to read a CREATE TABLE statement
+// from, and fabricating one from schema_snapshots column metadata risks
+// silently shipping a wrong PK/engine/charset/index definition as fact — so
+// the schema file records why it's missing instead, and the caller must
+// supply the table structure before loading the accompanying data file(s).
+func reconstructBinlogOnly(
+	ctx context.Context,
+	cfg FullTableConfig,
+	schema, table string,
+	db *sql.DB,
+	engine *query.Engine,
+	resolver *metadata.Resolver,
+	dbName string,
+	rep *TableReport,
+	start time.Time,
+) (*TableReport, error) {
+	tm, err := resolver.Resolve(schema, table)
+	if err != nil {
+		return nil, fmt.Errorf("resolve schema for %s.%s: %w; run `bintrail snapshot` to refresh", schema, table, err)
+	}
+	if len(tm.PKColumnMetas()) == 0 {
+		return nil, fmt.Errorf("%s.%s has no primary key in the loaded snapshot; full-table reconstruct requires a PK", schema, table)
+	}
+
+	// Generated columns can't be set explicitly in an INSERT, so exclude them
+	// from the emitted schema — same exclusion `bintrail baseline` applies.
+	colNames := make([]string, 0, len(tm.Columns))
+	for _, c := range tm.Columns {
+		if c.IsGenerated {
+			continue
+		}
+		colNames = append(colNames, c.Name)
+	}
+	if len(colNames) == 0 {
+		return nil, fmt.Errorf("%s.%s has no non-generated columns in the loaded snapshot", schema, table)
+	}
+
+	fetcher := cfg.ArchiveFetcher
+	if fetcher == nil {
+		fetcher = parquetquery.Fetch
+	}
+	events, _, err := query.FetchMerged(ctx, db, engine, query.FetchMergedOptions{
+		Opts: query.Options{
+			Schema: schema,
+			Table:  table,
+			Until:  &cfg.At,
+			// No Since — there is no baseline instant to anchor from; fetch
+			// the whole retained binlog-only window up to cfg.At.
+		},
+		DBName:         dbName,
+		NoArchive:      false,
+		AllowGaps:      cfg.AllowGaps,
+		ArchiveFetcher: fetcher,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("fetch events: %w", err)
+	}
+	rep.EventsApplied = int64(len(events))
+	maybeWarnEventVolume(schema, table, len(events), cfg.WarnEventThreshold)
+
+	MapEventEnumLabels(db, resolver, schema, table, events)
+	DecodeEventBinaries(db, schema, table, events)
+
+	// Latest event per PK; events is already sorted by (event_timestamp,
+	// event_id) via query.MergeResults, so the last write wins naturally.
+	changes := make(map[string]*query.ResultRow, len(events))
+	for i := range events {
+		changes[events[i].PKValues] = &events[i]
+	}
+
+	// A table that only ever existed after the last baseline was very likely
+	// CREATEd during the retained binlog window, and the schema-drift guard
+	// (#700) records every CREATE TABLE's exact DDL text in schema_changes.
+	// Prefer that real, captured statement over a fabricated one; only fall
+	// back to the explanatory placeholder when no such record exists (e.g.
+	// the table predates schema_changes, or genuinely was never baselined
+	// for another reason).
+	createSQL, ddlFound, err := findCapturedCreateTableDDL(ctx, db, schema, table, cfg.At)
+	if err != nil {
+		slog.Warn("could not query schema_changes for a captured CREATE TABLE; using placeholder schema file",
+			"schema", schema, "table", table, "error", err)
+	}
+	if ddlFound {
+		// The captured DDL is from CREATE time; it does not reflect any ALTER
+		// applied later, up to cfg.At (that class of point-in-time schema
+		// drift is the separately-tracked #600/#601/#602 family). Label it so
+		// a reader doesn't mistake it for a verified-current definition.
+		createSQL = "-- bintrail: CREATE TABLE captured from schema_changes at table-creation time\n" +
+			"-- (binlog-only fallback, #766). If the table was ALTERed afterwards, this may\n" +
+			"-- not match the columns in the accompanying data file(s) — verify before loading.\n" +
+			createSQL
+	} else {
+		createSQL = binlogOnlySchemaPlaceholder(schema, table)
+	}
+
+	rep.BinlogOnly = true
+	if err := writeBinlogOnlyChanges(cfg.OutputDir, schema, table, colNames, cfg.ChunkSize, createSQL, changes, rep); err != nil {
+		return nil, err
+	}
+	rep.Duration = time.Since(start)
+
+	slog.Warn("full-table reconstruct: no baseline found for table; recovered via binlog-only fallback "+
+		"(rows outside the retained binlog window, if any, are not included)",
+		"schema", schema, "table", table,
+		"events_applied", rep.EventsApplied,
+		"inserts_emitted", rep.InsertsEmitted,
+		"deletes_skipped", rep.DeletesSkipped)
+
+	return rep, nil
+}
+
+// binlogOnlySchemaPlaceholder is the schema-file text used when no captured
+// CREATE TABLE DDL is available: fabricating one from column metadata risks
+// silently shipping a wrong PK/engine/charset/index definition as fact.
+func binlogOnlySchemaPlaceholder(schema, table string) string {
+	return fmt.Sprintf(
+		"-- bintrail: no baseline snapshot exists for %s.%s (table created after the last\n"+
+			"-- `bintrail baseline` run, or never baselined), and no CREATE TABLE statement for\n"+
+			"-- it was found in schema_changes either. The rows in the accompanying data\n"+
+			"-- file(s) were recovered entirely from the binlog (binlog-only fallback, #766);\n"+
+			"-- the table structure is deliberately NOT fabricated here. Create the table\n"+
+			"-- structure yourself before loading the data file(s).\n",
+		schema, table)
+}
+
+// findCapturedCreateTableDDL looks up the most recent CREATE TABLE statement
+// the schema-drift guard (#700) recorded for schema.table at-or-before at, in
+// schema_changes.ddl_query. found is false (with a nil error) when no such
+// row exists — the caller falls back to binlogOnlySchemaPlaceholder.
+func findCapturedCreateTableDDL(ctx context.Context, db *sql.DB, schema, table string, at time.Time) (ddl string, found bool, err error) {
+	row := db.QueryRowContext(ctx, `
+		SELECT ddl_query FROM schema_changes
+		WHERE schema_name = ? AND table_name = ? AND ddl_type = ? AND detected_at <= ?
+		ORDER BY detected_at DESC, id DESC
+		LIMIT 1`,
+		schema, table, event.DDLCreateTable, at)
+	if err := row.Scan(&ddl); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	return ddl, true, nil
+}
+
+// writeBinlogOnlyChanges writes the reconstructBinlogOnly output: a schema
+// file (createSQL — either a real captured CREATE TABLE or the explanatory
+// placeholder, decided by the caller) and one data row per surviving entry in
+// changes, in deterministic PK order. Updates rep.InsertsEmitted/
+// DeletesSkipped/Files in place. Split out from reconstructBinlogOnly so it's
+// unit-testable without a MySQL index connection (it does no IO beyond
+// outputDir).
+func writeBinlogOnlyChanges(
+	outputDir, schema, table string,
+	colNames []string,
+	chunkSize int64,
+	createSQL string,
+	changes map[string]*query.ResultRow,
+	rep *TableReport,
+) error {
+	if err := checkChangesToast(changes); err != nil {
+		return err
+	}
+
+	mw, err := NewMydumperWriter(outputDir, schema, table, colNames, chunkSize)
+	if err != nil {
+		return fmt.Errorf("open mydumper writer: %w", err)
+	}
+	defer func() { _ = mw.Close() }() // no-op after the explicit Close below on the happy path
+
+	if err := mw.WriteSchema(createSQL); err != nil {
+		return err
+	}
+
+	// Deterministic order: sort by PK string so tests can assert on output
+	// without flakiness (mirrors the "new PKs" tail loop in mergeBaselineImages).
+	pks := make([]string, 0, len(changes))
+	for pk := range changes {
+		pks = append(pks, pk)
+	}
+	sort.Strings(pks)
+	for _, pk := range pks {
+		ev := changes[pk]
+		if ev.EventType == event.EventDelete {
+			rep.DeletesSkipped++
+			continue
+		}
+		if ev.RowAfter == nil {
+			slog.Error("event has nil RowAfter; skipping to avoid emitting all-NULL tuple",
+				"schema", schema, "table", table, "pk", pk,
+				"event_type", ev.EventType, "event_id", ev.EventID)
+			continue
+		}
+		if err := mw.WriteRow(rowAfterOrdered(ev.RowAfter, colNames, schema, table)); err != nil {
+			return err
+		}
+		rep.InsertsEmitted++
+	}
+
+	if err := mw.Close(); err != nil {
+		return fmt.Errorf("close mydumper writer: %w", err)
+	}
+	rep.Files = mw.Files()
 	return nil
 }
 

--- a/internal/reconstruct/fulltable_test.go
+++ b/internal/reconstruct/fulltable_test.go
@@ -2,10 +2,14 @@ package reconstruct
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
 
 	"github.com/dbtrail/dbtrail/internal/baseline"
 	"github.com/dbtrail/dbtrail/internal/event"
@@ -530,10 +534,10 @@ func TestMergeBaseline_mixedAllEventTypes(t *testing.T) {
 // TestSplitSchemaTable covers the pure helper for parsing --tables entries.
 func TestSplitSchemaTable(t *testing.T) {
 	cases := []struct {
-		in      string
-		ok      bool
-		schema  string
-		table   string
+		in     string
+		ok     bool
+		schema string
+		table  string
 	}{
 		{"mydb.orders", true, "mydb", "orders"},
 		{"schema_with_underscore.table_name", true, "schema_with_underscore", "table_name"},
@@ -553,6 +557,167 @@ func TestSplitSchemaTable(t *testing.T) {
 			t.Errorf("splitSchemaTable(%q) = (%q, %q), want (%q, %q)",
 				c.in, s, tbl, c.schema, c.table)
 		}
+	}
+}
+
+// TestWriteBinlogOnlyChanges_insertsSkipsDeletes covers the #766 ErrNoBaseline
+// fallback core: with no baseline at all, every surviving (non-DELETE)
+// change is emitted as a row, in deterministic PK order, and the schema file
+// carries an explanatory placeholder instead of a fabricated CREATE TABLE.
+func TestWriteBinlogOnlyChanges_insertsSkipsDeletes(t *testing.T) {
+	outDir := t.TempDir()
+	colNames := []string{"id", "status"}
+
+	changes := map[string]*query.ResultRow{
+		pkStrForInt(1): {
+			EventType: parser.EventInsert,
+			PKValues:  pkStrForInt(1),
+			RowAfter:  map[string]any{"id": float64(1), "status": "binlog-only-1"},
+		},
+		pkStrForInt(2): {
+			EventType: parser.EventDelete,
+			PKValues:  pkStrForInt(2),
+			RowBefore: map[string]any{"id": float64(2), "status": "deleted"},
+		},
+		pkStrForInt(3): {
+			EventType: parser.EventUpdate,
+			PKValues:  pkStrForInt(3),
+			RowAfter:  map[string]any{"id": float64(3), "status": "binlog-only-3"},
+		},
+	}
+
+	rep := &TableReport{Schema: "mydb", Table: "orders"}
+	if err := writeBinlogOnlyChanges(outDir, "mydb", "orders", colNames, 0,
+		binlogOnlySchemaPlaceholder("mydb", "orders"), changes, rep); err != nil {
+		t.Fatalf("writeBinlogOnlyChanges: %v", err)
+	}
+
+	if rep.InsertsEmitted != 2 {
+		t.Errorf("InsertsEmitted = %d, want 2", rep.InsertsEmitted)
+	}
+	if rep.DeletesSkipped != 1 {
+		t.Errorf("DeletesSkipped = %d, want 1", rep.DeletesSkipped)
+	}
+	if rep.BaselineRows != 0 || rep.UpdatesApplied != 0 {
+		t.Errorf("unexpected non-zero baseline/update counters: %+v", rep)
+	}
+	if len(rep.Files) == 0 {
+		t.Fatal("rep.Files is empty; expected at least the schema + one data chunk")
+	}
+
+	chunk := mustReadOnlyChunk(t, outDir)
+	if !strings.Contains(chunk, "(1, 'binlog-only-1')") || !strings.Contains(chunk, "(3, 'binlog-only-3')") {
+		t.Errorf("chunk missing surviving rows:\n%s", chunk)
+	}
+	if strings.Contains(chunk, "(2,") {
+		t.Errorf("chunk contains deleted row (id=2):\n%s", chunk)
+	}
+
+	schemaPath := filepath.Join(outDir, "mydb.orders-schema.sql")
+	b, err := os.ReadFile(schemaPath)
+	if err != nil {
+		t.Fatalf("read schema file: %v", err)
+	}
+	if !strings.Contains(string(b), "no baseline snapshot exists") || !strings.Contains(string(b), "#766") {
+		t.Errorf("schema file placeholder missing expected explanation:\n%s", b)
+	}
+}
+
+// TestWriteBinlogOnlyChanges_nilRowAfterSkipped verifies a corrupted event
+// (nil RowAfter on a non-DELETE) is dropped rather than emitting an all-NULL
+// row, mirroring mergeBaselineImages' own defensive skip.
+func TestWriteBinlogOnlyChanges_nilRowAfterSkipped(t *testing.T) {
+	outDir := t.TempDir()
+	colNames := []string{"id", "status"}
+
+	changes := map[string]*query.ResultRow{
+		pkStrForInt(1): {
+			EventType: parser.EventInsert,
+			PKValues:  pkStrForInt(1),
+			RowAfter:  nil,
+		},
+	}
+
+	rep := &TableReport{Schema: "mydb", Table: "orders"}
+	if err := writeBinlogOnlyChanges(outDir, "mydb", "orders", colNames, 0,
+		binlogOnlySchemaPlaceholder("mydb", "orders"), changes, rep); err != nil {
+		t.Fatalf("writeBinlogOnlyChanges: %v", err)
+	}
+	if rep.InsertsEmitted != 0 {
+		t.Errorf("InsertsEmitted = %d, want 0 (nil RowAfter must be skipped)", rep.InsertsEmitted)
+	}
+}
+
+// TestFindCapturedCreateTableDDL_found verifies the happy path: a captured
+// CREATE TABLE row in schema_changes is returned verbatim.
+func TestFindCapturedCreateTableDDL_found(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	at := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	mock.ExpectQuery("SELECT ddl_query FROM schema_changes").
+		WithArgs("mydb", "orders", string(event.DDLCreateTable), at).
+		WillReturnRows(sqlmock.NewRows([]string{"ddl_query"}).
+			AddRow("CREATE TABLE `orders` (`id` int NOT NULL, PRIMARY KEY (`id`))"))
+
+	ddl, found, err := findCapturedCreateTableDDL(context.Background(), db, "mydb", "orders", at)
+	if err != nil {
+		t.Fatalf("findCapturedCreateTableDDL: %v", err)
+	}
+	if !found {
+		t.Fatal("found = false, want true")
+	}
+	if !strings.Contains(ddl, "CREATE TABLE `orders`") {
+		t.Errorf("ddl = %q, want the captured CREATE TABLE text", ddl)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// TestFindCapturedCreateTableDDL_notFound verifies that no matching row
+// (sql.ErrNoRows) reports found=false with a nil error, so the caller falls
+// back to the placeholder rather than treating "never captured" as a fault.
+func TestFindCapturedCreateTableDDL_notFound(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT ddl_query FROM schema_changes").
+		WillReturnRows(sqlmock.NewRows([]string{"ddl_query"}))
+
+	ddl, found, err := findCapturedCreateTableDDL(context.Background(), db, "mydb", "orders", time.Now())
+	if err != nil {
+		t.Fatalf("findCapturedCreateTableDDL: %v", err)
+	}
+	if found {
+		t.Errorf("found = true, want false; ddl = %q", ddl)
+	}
+}
+
+// TestFindCapturedCreateTableDDL_realErrorSurfaces verifies a genuine query
+// failure (not just "no rows") is returned to the caller, not swallowed.
+func TestFindCapturedCreateTableDDL_realErrorSurfaces(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	forcedErr := errors.New("connection reset")
+	mock.ExpectQuery("SELECT ddl_query FROM schema_changes").WillReturnError(forcedErr)
+
+	_, found, err := findCapturedCreateTableDDL(context.Background(), db, "mydb", "orders", time.Now())
+	if err == nil {
+		t.Fatal("expected the underlying query error to surface")
+	}
+	if found {
+		t.Error("found = true on a real error, want false")
 	}
 }
 


### PR DESCRIPTION
closes #766

## Summary

- `internal/reconstruct/fulltable.go`: full-table reconstruct no longer emits
  an empty report on `ErrNoBaseline`. It now mirrors the shim's
  `_snapshot`-degrades-to-`_flashback` fallback: fetch every event for the
  table up to `--at` and emit the latest surviving row per PK (skipping
  DELETEs). The schema file prefers a real `CREATE TABLE` captured by the
  #700 drift guard in `schema_changes.ddl_query` when one exists (the common
  case: table created within the retained binlog window); otherwise it
  writes an explanatory placeholder rather than fabricating DDL from column
  metadata.
- Added `TableReport.BinlogOnly` and used it to fix a related regression:
  `ReconstructTables`' shared-metadata-file selector previously picked the
  first report with output files to source GTID/binlog coordinates from — a
  binlog-only report now has files too but no real baseline to read
  coordinates from, so the selector explicitly skips `BinlogOnly` reports.
- `internal/console/manager.go` + `reconstruct.go`: the console's per-server
  `bundle` unconditionally preferred a local baseline dir over a configured
  S3 prefix. Local baselines can be pruned by retention (#616) while a
  durable S3 copy remains, so a reconstruct/time-travel request for an older
  instant silently hit `ErrNoBaseline` even though S3 still had it.
  `bundle.findBaseline` now retries the S3 prefix on `ErrNoBaseline` when
  both a local dir and an S3 prefix are configured.

## Operator-visible caveat

Binlog-only reconstruct output may need the operator to verify or create the
table schema before `cat *.sql | mysql`: if no CREATE TABLE was captured in
`schema_changes` (e.g. a very old table, or `schema_changes` disabled), the
schema file is a placeholder, not real DDL. When a captured CREATE TABLE
*is* found, it reflects the table's state at creation time — a later ALTER
before `--at` is not replayed onto it (labeled in the emitted schema file
comment; full point-in-time schema reconstruction is the separate
#600/#601/#602 family).

## Known follow-ups (deliberately out of scope, kept small per the sibling
PRs touching this same file)

- `internal/console/baselines_api.go`'s `ListBaselines` and
  `recover_cascade.go`'s `cascadeBaselineProvider` still read only the
  local-preferred `baselineSrc` with no S3 fallback (display-incompleteness /
  Phase-1 cascade degrade respectively — not data loss).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -count=1` (unit only — no Docker; shared MySQL port
      13306 was in use by sibling agents working #764/#765/#768 in parallel)
- [x] New unit tests: `writeBinlogOnlyChanges` (inserts/deletes/nil-RowAfter
      skip, deterministic PK order, schema placeholder content) and
      `findCapturedCreateTableDDL` (found / not-found / real-error, via
      sqlmock)
- [ ] Not exercised by the unit suite (integration-only): the
      `ReconstructTables` metadata-selector fix and the console
      local→S3 fallback both need a live MySQL index + real baseline/archive
      fixtures to drive end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
