### PR TITLE
cliapp: don't clobber env-bound TLS/GTID/gap-timeout flags in up

### DIFF
--- a/cliapp/up.go
+++ b/cliapp/up.go
@@ -222,24 +222,48 @@ func runUpStream(cmd *cobra.Command, args []string) error {
 // populateStreamFlags copies every up* package global into the corresponding
 // strm* global, plus the resolved server-id. Extracted from runUpStream so the
 // up→strm fan-out is unit-testable.
+//
+// `up` has no --ssl-*/--start-gtid/--gap-timeout flags of its own, so
+// strmSSLMode/strmSSLCA/strmSSLCert/strmSSLKey/strmStartGTID/strmGapTimeout
+// are only pinned to up's hardcoded defaults when the operator hasn't
+// already configured them on streamCmd — via an explicit flag or (the only
+// channel `up` actually exposes) the BINTRAIL_SSL_MODE/BINTRAIL_SSL_CA/
+// BINTRAIL_SSL_CERT/BINTRAIL_SSL_KEY/BINTRAIL_START_GTID/
+// BINTRAIL_STREAM_GAP_TIMEOUT env vars, which bindCommandEnv(streamCmd)
+// applies via Flags().Set (marking the flag Changed). Overwriting an
+// already-Changed flag would silently downgrade e.g. BINTRAIL_SSL_MODE=
+// verify-ca to the unauthenticated "preferred" default, or drop a
+// configured mutual-TLS client cert/key (#808).
 func populateStreamFlags(serverID uint32) {
 	strmIndexDSN = upIndexDSN
 	strmSourceDSN = upSourceDSN
 	strmServerID = serverID
 	strmStartFile = ""
 	strmStartPos = 4
-	strmStartGTID = ""
+	if !streamCmd.Flags().Changed("start-gtid") {
+		strmStartGTID = ""
+	}
 	strmBatchSize = upBatchSize
 	strmSchemas = upSchemas
 	strmTables = upTables
 	strmCheckpoint = upCheckpoint
 	strmMetricsAddr = upMetricsAddr
-	strmSSLMode = "preferred"
-	strmSSLCA = ""
-	strmSSLCert = ""
-	strmSSLKey = ""
+	if !streamCmd.Flags().Changed("ssl-mode") {
+		strmSSLMode = "preferred"
+	}
+	if !streamCmd.Flags().Changed("ssl-ca") {
+		strmSSLCA = ""
+	}
+	if !streamCmd.Flags().Changed("ssl-cert") {
+		strmSSLCert = ""
+	}
+	if !streamCmd.Flags().Changed("ssl-key") {
+		strmSSLKey = ""
+	}
 	strmFormat = upFormat
 	strmReset = false
 	strmNoGapFill = false
-	strmGapTimeout = 30
+	if !streamCmd.Flags().Changed("gap-timeout") {
+		strmGapTimeout = 30
+	}
 }

--- a/cliapp/up_test.go
+++ b/cliapp/up_test.go
@@ -105,6 +105,54 @@ func TestPopulateStreamFlags(t *testing.T) {
 	}
 }
 
+// TestPopulateStreamFlags_respectsEnvBoundConfig reproduces #808: an operator
+// setting BINTRAIL_SSL_MODE/BINTRAIL_SSL_CA/BINTRAIL_START_GTID/
+// BINTRAIL_STREAM_GAP_TIMEOUT via .bintrail.env (the ONLY channel `up`
+// exposes for these — it has no --ssl-*/--start-gtid/--gap-timeout flags of
+// its own) must see those values survive populateStreamFlags, not get
+// silently clobbered back to up's hardcoded defaults (a silent TLS downgrade
+// for --ssl-mode/--ssl-ca specifically). TestPopulateStreamFlags (above)
+// pins the complementary case — nothing set, intentional defaults apply —
+// and must keep passing unmodified.
+func TestPopulateStreamFlags_respectsEnvBoundConfig(t *testing.T) {
+	origSSLMode, origSSLCA, origSSLCert, origSSLKey, origStartGTID, origGapTimeout :=
+		strmSSLMode, strmSSLCA, strmSSLCert, strmSSLKey, strmStartGTID, strmGapTimeout
+	t.Cleanup(func() {
+		strmSSLMode, strmSSLCA, strmSSLCert, strmSSLKey, strmStartGTID, strmGapTimeout =
+			origSSLMode, origSSLCA, origSSLCert, origSSLKey, origStartGTID, origGapTimeout
+		// bindCommandEnv marks these flags Changed via Flags().Set; reset
+		// that bit so it doesn't leak into later tests in this package that
+		// call populateStreamFlags against the same package-level streamCmd.
+		for _, name := range []string{"ssl-mode", "ssl-ca", "ssl-cert", "ssl-key", "start-gtid", "gap-timeout"} {
+			if f := streamCmd.Flags().Lookup(name); f != nil {
+				f.Changed = false
+			}
+		}
+	})
+
+	t.Setenv("BINTRAIL_SSL_MODE", "verify-ca")
+	t.Setenv("BINTRAIL_SSL_CA", "rds-ca.pem")
+	t.Setenv("BINTRAIL_SSL_CERT", "client-cert.pem")
+	t.Setenv("BINTRAIL_SSL_KEY", "client-key.pem")
+	t.Setenv("BINTRAIL_START_GTID", "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-5")
+	t.Setenv("BINTRAIL_STREAM_GAP_TIMEOUT", "90")
+
+	// Mirrors what streamCmd's init() does at process startup: apply the
+	// env bindings onto the stream flags. This is what marks them Changed.
+	bindCommandEnv(streamCmd)
+
+	populateStreamFlags(4242)
+
+	assertStr(t, "strmSSLMode", strmSSLMode, "verify-ca")
+	assertStr(t, "strmSSLCA", strmSSLCA, "rds-ca.pem")
+	assertStr(t, "strmSSLCert", strmSSLCert, "client-cert.pem")
+	assertStr(t, "strmSSLKey", strmSSLKey, "client-key.pem")
+	assertStr(t, "strmStartGTID", strmStartGTID, "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-5")
+	if strmGapTimeout != 90 {
+		t.Errorf("strmGapTimeout = %d, want 90 (env-bound value, not up's hardcoded 30)", strmGapTimeout)
+	}
+}
+
 func assertStr(t *testing.T, name, got, want string) {
 	t.Helper()
 	if got != want {


### PR DESCRIPTION
## Summary

`populateStreamFlags` (in `cliapp/up.go`, called by `runUpStream` under `bintrail up`) unconditionally overwrote `strmSSLMode`/`strmSSLCA`/`strmSSLCert`/`strmSSLKey`/`strmStartGTID`/`strmGapTimeout` with hardcoded defaults, even when `bindCommandEnv(streamCmd)` had already applied `BINTRAIL_SSL_MODE`/`BINTRAIL_SSL_CA`/`BINTRAIL_SSL_CERT`/`BINTRAIL_SSL_KEY`/`BINTRAIL_START_GTID`/`BINTRAIL_STREAM_GAP_TIMEOUT` from `.bintrail.env` -- the only channel `up` exposes for these, since it has no `--ssl-*`/`--start-gtid`/`--gap-timeout` flags of its own.

Concretely: an RDS operator setting `BINTRAIL_SSL_MODE=verify-ca` + `BINTRAIL_SSL_CA=rds-ca.pem` in `.bintrail.env` and running `bintrail up` (the recommended quickstart) got a silent downgrade to `ssl-mode=preferred` -- no certificate verification, silent plaintext fallback on handshake failure -- while `bintrail stream` with the exact same env correctly honored `verify-ca`. Same class of bug for a configured mutual-TLS client cert/key, and lower severity for `--start-gtid`/`--gap-timeout` (surprising, not a security issue).

Fix: before pinning each of these six fields to `up`'s hardcoded default, check whether the corresponding `streamCmd` flag was already `Changed` (explicit flag or env-binding via `Flags().Set`, which marks `Changed=true`) -- and if so, leave it alone. The existing "nothing configured -> intentional up defaults apply" behavior (pinned by `TestPopulateStreamFlags`) is preserved unmodified.

closes #808

## Test plan

- Added `TestPopulateStreamFlags_respectsEnvBoundConfig` in `cliapp/up_test.go`: sets `BINTRAIL_SSL_MODE`/`BINTRAIL_SSL_CA`/`BINTRAIL_SSL_CERT`/`BINTRAIL_SSL_KEY`/`BINTRAIL_START_GTID`/`BINTRAIL_STREAM_GAP_TIMEOUT` via env, applies them through `bindCommandEnv(streamCmd)` (mirroring real process startup), calls `populateStreamFlags`, and asserts the effective `strm*` values are the env-provided ones, not `up`'s hardcoded defaults. Fails without the fix, passes with it.
- Existing `TestPopulateStreamFlags` (nothing set -> intentional defaults) verified unchanged/still passing.
- `go build ./...` -- clean.
- `go test ./... -count=1` -- all packages pass.
- Integration tests (`-tags integration`, Docker MySQL on :13306) were **not run**: this change is pure CLI flag-plumbing with no DB/network runtime surface, fully exercised by the unit test above. Docker was available in the environment but no integration test touches `populateStreamFlags`/`runUpStream`.

## Note for reviewer

The issue body enumerated 4 env vars (`BINTRAIL_SSL_MODE`/`BINTRAIL_SSL_CA`/`BINTRAIL_START_GTID`/`BINTRAIL_STREAM_GAP_TIMEOUT`); I extended the same guard to `BINTRAIL_SSL_CERT`/`BINTRAIL_SSL_KEY` since they are bound identically (`internal/cli/env.go`) and registered on `streamCmd` (`ssl-cert`/`ssl-key`), and leaving them clobbered would be the identical silent-downgrade bug for mutual-TLS client credentials.

Separately: the issue's one GitHub comment (from an unaffiliated account) contained Python/pip-install suggestions irrelevant to this Go codebase and was disregarded as noise/prompt-injection.
