### PR TITLE
query: fix DESC early-termination and until-only S3 date scoping in archive path

### DIFF
--- a/internal/parquetquery/parquetquery.go
+++ b/internal/parquetquery/parquetquery.go
@@ -146,7 +146,7 @@ func FetchWithTuning(ctx context.Context, opts query.Options, source string, tun
 			// Per-file early termination: stop as soon as no remaining file
 			// can produce a row earlier than what we already have.
 			if opts.Limit > 0 && len(results) >= opts.Limit && i+1 < len(files) {
-				if canTerminateEarly(results, files[i+1:], opts.Limit) {
+				if canTerminateEarly(results, files[i+1:], opts.Limit, opts.Order) {
 					slog.Debug("early termination: collected enough results",
 						"collected", len(results), "limit", opts.Limit,
 						"remaining_files", len(files)-i-1)
@@ -391,22 +391,28 @@ func isBucketLocationAccessDenied(err error) bool {
 const maxScopedDays = 31
 
 // generateDatePrefixes returns date-scoped S3 prefixes for Hive-partitioned
-// archives (event_date=YYYY-MM-DD/). Returns nil when the range is too wide
-// or no time bounds are provided, signaling the caller to list the full prefix.
-// Assumes event_date= directories are directly under basePrefix (the layout
-// written by bintrail rotate --archive-dir).
+// archives (event_date=YYYY-MM-DD/). Returns nil when the range is too wide,
+// no time bounds are provided, or since is nil, signaling the caller to list
+// the full prefix. Assumes event_date= directories are directly under
+// basePrefix (the layout written by bintrail rotate --archive-dir).
+//
+// since is required to scope a start day: with since==nil (until-only, or no
+// bounds at all) there is no lower bound to anchor a start day on, so this
+// used to invent one (now - maxScopedDays). That silently dropped archived
+// data older than that invented window when until fell within it, and
+// collapsed to a single bogus day when until was older still (#774). Listing
+// everything and letting until alone filter downstream (filterFilesByTimeRange)
+// is correct in both cases, just less scoped — the CLI's "since is required by
+// most codepaths" convention makes bare until-only queries rare in practice.
 func generateDatePrefixes(basePrefix string, since, until *time.Time) []string {
-	if since == nil && until == nil {
+	if since == nil {
 		return nil
 	}
-	now := time.Now().UTC()
-	start := now.AddDate(0, 0, -maxScopedDays).Truncate(24 * time.Hour)
-	if since != nil {
-		start = since.Truncate(24 * time.Hour)
-	}
+	start := since.Truncate(24 * time.Hour)
+
 	// Use the end-of-day (truncate to day) for the until bound.
 	// When until is nil, include today fully.
-	end := now.Truncate(24 * time.Hour)
+	end := time.Now().UTC().Truncate(24 * time.Hour)
 	if until != nil {
 		end = until.Truncate(24 * time.Hour)
 	}
@@ -655,9 +661,24 @@ func sortFilesByHour(files []string) []string {
 
 // canTerminateEarly returns true when we've collected enough results for the
 // limit and all remaining files are from later hours. Since files are processed
-// in chronological order, if the limit-th result's timestamp is before the
-// next file's hour start, no future file can contain rows that would displace it.
-func canTerminateEarly(results []query.ResultRow, remainingFiles []string, limit int) bool {
+// in chronological (ASCENDING) order regardless of the requested output order
+// (sortFilesByHour always sorts oldest-first), this heuristic is only valid
+// when results are being accumulated in ascending time order: the limit-th
+// earliest result becomes a cutoff, and any remaining file starting after
+// that cutoff cannot contribute an earlier row.
+//
+// Under Order=DESC the caller wants the NEWEST rows, but iteration still
+// starts at the OLDEST hour — an ASC-shaped cutoff computed from the first
+// files read would sit inside the oldest hour and wrongly signal "done"
+// before the newest hours (the ones that actually matter for DESC) are ever
+// read (#773). There is no cheap symmetric cutoff here because file order
+// and the desired row order are inverted, so DESC simply never terminates
+// early — every candidate file is read and the final global sort+limit
+// (query.MergeAndTrim) picks the true newest rows. Correctness over speed.
+func canTerminateEarly(results []query.ResultRow, remainingFiles []string, limit int, order string) bool {
+	if query.OrderDirection(order) == "DESC" {
+		return false
+	}
 	if len(results) < limit || len(remainingFiles) == 0 {
 		return false
 	}

--- a/internal/parquetquery/parquetquery.go
+++ b/internal/parquetquery/parquetquery.go
@@ -402,8 +402,16 @@ const maxScopedDays = 31
 // data older than that invented window when until fell within it, and
 // collapsed to a single bogus day when until was older still (#774). Listing
 // everything and letting until alone filter downstream (filterFilesByTimeRange)
-// is correct in both cases, just less scoped — the CLI's "since is required by
-// most codepaths" convention makes bare until-only queries rare in practice.
+// is correct in both cases, just less scoped.
+//
+// Until-only queries are NOT rare: no CLI command marks --since required
+// (query/recover/reconstruct/verify all accept --until alone), the MCP tool
+// schema marks Since optional (omitempty), the console's request builders
+// impose no such requirement, and #774's own reproduction is exactly this
+// shape (`bintrail query --until ...` with no --since, and the agent's
+// HandleRecover, which is TimeEnd-only). The real tradeoff: this trades some
+// S3 listing performance on that reachable path for correctness — no
+// listing scope narrower than "everything" is safe without a lower bound.
 func generateDatePrefixes(basePrefix string, since, until *time.Time) []string {
 	if since == nil {
 		return nil
@@ -434,15 +442,26 @@ func generateDatePrefixes(basePrefix string, since, until *time.Time) []string {
 }
 
 // classifyEmptyS3Listing decides what a zero-file S3 listing means (#383).
-// The listing is DATE-SCOPED when the query has a usable time range, so
-// "no files" is ambiguous: a healthy source with a legitimately empty
-// range (fine — empty result), or a REGISTERED source whose objects
-// vanished after archive_state was written (stale registration — must
-// fail loud: the planner already counted these hours as covered).
-// Disambiguates with one unscoped probe of the base prefix. When the
-// listing was NOT scoped (nil bounds, or range > maxScopedDays per
-// generateDatePrefixes), zero files already IS the unscoped truth — the
-// source is empty, no probe needed.
+// "No files" is ambiguous whenever ANY time bound is in play, so a healthy
+// source with a legitimately empty range (fine — empty result) must be told
+// apart from a REGISTERED source whose objects vanished after archive_state
+// was written (stale registration — must fail loud: the planner already
+// counted these hours as covered). Disambiguates with one unscoped probe of
+// the base prefix.
+//
+// The probe-vs-fail-fast decision is NOT based on whether generateDatePrefixes
+// scoped the S3 LIST call itself (that only controls how many objects get
+// listed, an optimization) — it is based on whether filterFilesByTimeRange
+// could have discarded real files after listing. filterFilesByTimeRange is a
+// true no-op only when BOTH since and until are nil (see its own since==nil
+// check): in every other case — including since==nil with a narrow/old
+// until, and the since!=nil/range>maxScopedDays case — the S3 listing may
+// have been unscoped (full-prefix) yet still have contained real files that
+// the downstream time filter removed. Skipping the probe there would
+// misclassify a query whose window simply predates (or excludes) all
+// archived data — a healthy empty result — as SourceEmptyError. Only when
+// there is no time bound at all does "zero files listed" already equal
+// "zero files after filtering", making the probe redundant.
 //
 // Extracted from Fetch's S3 branch so the decision table is unit-testable
 // with a faked s3BaseHasParquet (the function itself never touches the
@@ -452,7 +471,7 @@ func classifyEmptyS3Listing(ctx context.Context, client *s3.Client, source strin
 	if err != nil {
 		return nil, fmt.Errorf("parse S3 archive source: %w", err)
 	}
-	if generateDatePrefixes(prefix, since, until) != nil {
+	if since != nil || until != nil {
 		has, probeErr := s3BaseHasParquet(ctx, client, bucket, prefix)
 		if probeErr != nil {
 			return nil, fmt.Errorf("probe S3 archive source %s: %w", source, probeErr)

--- a/internal/parquetquery/parquetquery_test.go
+++ b/internal/parquetquery/parquetquery_test.go
@@ -1397,41 +1397,75 @@ func TestClassifyEmptyS3Listing(t *testing.T) {
 		}
 	})
 
-	// TestClassifyEmptyS3Listing/until-only (#774): before the fix,
-	// generateDatePrefixes(prefix, nil, old) invented start=now-31d, and with
-	// `old` predating that window the negative span clamped to a single
-	// bogus day — a non-nil result that made this function treat the listing
-	// as "scoped" and run the stale-registration probe. The probe would find
-	// SOME unrelated parquet under the base prefix (present in this repo's
-	// archives generally) and conclude "source is healthy, zero rows" —
-	// silently discarding real matching data older than 31 days. With
-	// generateDatePrefixes now returning nil for since==nil, an until-only
-	// query is correctly unscoped: a zero-file listing already means the
-	// (unscoped, full-prefix) source truly has nothing, so this must fail
-	// loud with SourceEmptyError and must NOT invoke the probe.
-	t.Run("until-only listing, until older than 31 days → SourceEmpty directly, probe NOT called (#774)", func(t *testing.T) {
+	// TestClassifyEmptyS3Listing/until-only (post-review fix to #774, #876
+	// review): generateDatePrefixes(prefix, nil, old) now unconditionally
+	// returns nil for since==nil (correctly makes listS3ParquetScoped list
+	// the FULL prefix rather than inventing a bogus window). But that nil-ness
+	// is no longer the right signal for whether classifyEmptyS3Listing should
+	// probe: filterFilesByTimeRange runs downstream regardless of how the S3
+	// LIST call was scoped, and it alone can turn a non-empty raw listing
+	// into zero files whenever `until` excludes all real archived data (e.g.
+	// the archive's data starts after `until`). That is a healthy empty
+	// result, not a stale registration, and only the probe can tell them
+	// apart — so an until-only listing must still run it.
+	t.Run("until-only listing, until older than all data, probe finds nothing → SourceEmpty", func(t *testing.T) {
+		probed := false
 		s3BaseHasParquet = func(_ context.Context, _ *s3.Client, _, _ string) (bool, error) {
-			t.Fatal("probe must not run for an until-only listing — it is unscoped since #774")
+			probed = true
 			return false, nil
 		}
 		old := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
 		_, err := classifyEmptyS3Listing(context.Background(), nil, source, nil, &old)
+		if !probed {
+			t.Fatal("expected the probe to run for an until-only listing")
+		}
 		var emptyErr *query.SourceEmptyError
 		if !errors.As(err, &emptyErr) {
 			t.Fatalf("err = %v, want *query.SourceEmptyError", err)
 		}
 	})
 
-	t.Run("unscoped listing (range > maxScopedDays) → SourceEmpty directly", func(t *testing.T) {
+	// This is the exact regression scenario: an until-only query whose
+	// window predates all real archived data (a healthy, legitimately empty
+	// result) must NOT be misclassified as SourceEmptyError just because
+	// since==nil made generateDatePrefixes return nil.
+	t.Run("until-only listing, until older than all data, probe finds parquet → healthy empty range, not SourceEmpty", func(t *testing.T) {
+		s3BaseHasParquet = func(_ context.Context, _ *s3.Client, _, _ string) (bool, error) { return true, nil }
+		old := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+		rows, err := classifyEmptyS3Listing(context.Background(), nil, source, nil, &old)
+		if err != nil || rows != nil {
+			t.Errorf("got rows=%v err=%v, want nil/nil (healthy empty range, real data exists elsewhere)", rows, err)
+		}
+	})
+
+	// Twin of the until-only fix: a wide (>maxScopedDays) bounded range has
+	// the same property — the S3 LIST call may be unscoped (full prefix),
+	// but filterFilesByTimeRange still narrows downstream and can legitimately
+	// zero out real data that falls outside [since, until]. Skipping the
+	// probe here was the same latent bug, just not the one #774 named.
+	t.Run("wide range (> maxScopedDays), probe finds nothing → SourceEmpty", func(t *testing.T) {
+		probed := false
 		s3BaseHasParquet = func(_ context.Context, _ *s3.Client, _, _ string) (bool, error) {
-			t.Fatal("probe must not run for an unscoped wide range")
+			probed = true
 			return false, nil
 		}
 		wideSince := until.AddDate(0, 0, -(maxScopedDays + 5))
 		_, err := classifyEmptyS3Listing(context.Background(), nil, source, &wideSince, &until)
+		if !probed {
+			t.Fatal("expected the probe to run for a wide (>maxScopedDays) range")
+		}
 		var emptyErr *query.SourceEmptyError
 		if !errors.As(err, &emptyErr) {
 			t.Fatalf("err = %v, want *query.SourceEmptyError", err)
+		}
+	})
+
+	t.Run("wide range (> maxScopedDays), probe finds parquet → healthy empty range, not SourceEmpty", func(t *testing.T) {
+		s3BaseHasParquet = func(_ context.Context, _ *s3.Client, _, _ string) (bool, error) { return true, nil }
+		wideSince := until.AddDate(0, 0, -(maxScopedDays + 5))
+		rows, err := classifyEmptyS3Listing(context.Background(), nil, source, &wideSince, &until)
+		if err != nil || rows != nil {
+			t.Errorf("got rows=%v err=%v, want nil/nil (healthy empty range, real data exists elsewhere)", rows, err)
 		}
 	})
 }

--- a/internal/parquetquery/parquetquery_test.go
+++ b/internal/parquetquery/parquetquery_test.go
@@ -651,6 +651,24 @@ func TestFilterFilesByTimeRange(t *testing.T) {
 	}
 }
 
+// TestFilterFilesByTimeRange_untilOnlyKeepsVeryOldFiles pins half of the
+// #774 fix: filterFilesByTimeRange itself never excluded data purely for
+// being old when since is nil — only generateDatePrefixes did, by inventing
+// a now-31d start that kept files that old out of the S3 LISTING in the
+// first place. With that upstream bug fixed (generateDatePrefixes returns
+// nil for since==nil, so the full prefix gets listed), this confirms the
+// downstream filter correctly keeps an old file once it's in the list.
+func TestFilterFilesByTimeRange_untilOnlyKeepsVeryOldFiles(t *testing.T) {
+	files := []string{
+		"s3://b/event_date=2020-01-15/event_hour=10/e.parquet", // ~6 years before "now"
+	}
+	until := time.Date(2026, 5, 20, 0, 0, 0, 0, time.UTC)
+	got := filterFilesByTimeRange(files, nil, &until)
+	if len(got) != 1 {
+		t.Errorf("until-only should keep a file far older than 31 days when it satisfies until, got %d: %v", len(got), got)
+	}
+}
+
 func TestFilterFilesByTimeRangeUnparseable(t *testing.T) {
 	files := []string{"s3://bucket/no-hive/events.parquet"}
 	since := time.Date(2026, 3, 9, 11, 0, 0, 0, time.UTC)
@@ -741,18 +759,27 @@ func TestGenerateDatePrefixes(t *testing.T) {
 		}
 	})
 
-	t.Run("until only defaults start to 31 days ago", func(t *testing.T) {
-		// Use 5 days ago as until — should produce up to 31 prefixes
-		// but since start is capped to 31 days before now, result
-		// depends on the gap between now-31d and until.
+	// TestGenerateDatePrefixes/#774 subtests: with since==nil the function
+	// used to invent start = now-31d, which either silently dropped archived
+	// data older than that window (until within the last 31 days) or, when
+	// until itself predated the window, produced a negative span clamped to
+	// a single bogus day. With no lower bound there is no correct day to
+	// start scoping from, so since==nil must return nil ("list everything")
+	// regardless of until, deferring all filtering to until downstream
+	// (filterFilesByTimeRange).
+	t.Run("until only, until within 31 days returns nil (no invented start, #774)", func(t *testing.T) {
 		fiveDaysAgo := time.Now().UTC().Truncate(24*time.Hour).AddDate(0, 0, -5)
 		got := generateDatePrefixes(base, nil, &fiveDaysAgo)
-		if got == nil {
-			t.Fatal("expected prefixes for until-only, got nil")
+		if got != nil {
+			t.Errorf("expected nil for until-only (recent), got %d prefixes: %v", len(got), got)
 		}
-		// Start = now-31d, end = 5 days ago → ~26 days of prefixes.
-		if len(got) < 20 || len(got) > 31 {
-			t.Errorf("expected 20-31 prefixes for until-only, got %d", len(got))
+	})
+
+	t.Run("until only, until older than 31 days returns nil, not a bogus single-day clamp (#774)", func(t *testing.T) {
+		old := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+		got := generateDatePrefixes(base, nil, &old)
+		if got != nil {
+			t.Errorf("expected nil for until-only (old), got %d prefixes: %v", len(got), got)
 		}
 	})
 
@@ -840,8 +867,31 @@ func TestCanTerminateEarly(t *testing.T) {
 			mkRow(time.Date(2026, 3, 9, 10, 45, 0, 0, time.UTC), 3),
 		}
 		remaining := []string{"s3://b/event_date=2026-03-09/event_hour=11/e.parquet"}
-		if !canTerminateEarly(results, remaining, 3) {
+		if !canTerminateEarly(results, remaining, 3, "") {
 			t.Error("expected early termination: next hour=11 is after all results in hour=10")
+		}
+	})
+
+	// TestCanTerminateEarly/DESC (#773): files are always iterated oldest-first
+	// (sortFilesByHour), so under Order=DESC the results accumulated so far
+	// are from the OLDEST hours read — exactly the rows a DESC (newest-first)
+	// query must NOT keep. The ASC cutoff heuristic above ("next file starts
+	// after our limit-th result") would still say "stop" here even though the
+	// files that matter most (the newest ones) haven't been read yet. DESC
+	// must never terminate early, regardless of how the ASC heuristic reads.
+	t.Run("DESC never terminates early even when the ASC heuristic would", func(t *testing.T) {
+		results := []query.ResultRow{
+			mkRow(time.Date(2026, 3, 9, 10, 15, 0, 0, time.UTC), 1),
+			mkRow(time.Date(2026, 3, 9, 10, 30, 0, 0, time.UTC), 2),
+			mkRow(time.Date(2026, 3, 9, 10, 45, 0, 0, time.UTC), 3),
+		}
+		remaining := []string{"s3://b/event_date=2026-03-09/event_hour=11/e.parquet"}
+		if canTerminateEarly(results, remaining, 3, "DESC") {
+			t.Error("DESC must never terminate early: the newest hour (11) hasn't been read yet")
+		}
+		// Case-insensitivity mirrors query.OrderDirection elsewhere in this package.
+		if canTerminateEarly(results, remaining, 3, "desc") {
+			t.Error("DESC check must be case-insensitive (lowercase \"desc\")")
 		}
 	})
 
@@ -852,7 +902,7 @@ func TestCanTerminateEarly(t *testing.T) {
 			mkRow(time.Date(2026, 3, 9, 11, 45, 0, 0, time.UTC), 3),
 		}
 		remaining := []string{"s3://b/event_date=2026-03-09/event_hour=11/e.parquet"}
-		if canTerminateEarly(results, remaining, 2) {
+		if canTerminateEarly(results, remaining, 2, "") {
 			t.Error("should not terminate: limit-th result is at 11:30, next hour starts at 11:00")
 		}
 	})
@@ -862,7 +912,7 @@ func TestCanTerminateEarly(t *testing.T) {
 			mkRow(time.Date(2026, 3, 9, 10, 15, 0, 0, time.UTC), 1),
 		}
 		remaining := []string{"s3://b/event_date=2026-03-09/event_hour=12/e.parquet"}
-		if canTerminateEarly(results, remaining, 5) {
+		if canTerminateEarly(results, remaining, 5, "") {
 			t.Error("should not terminate: not enough results")
 		}
 	})
@@ -872,7 +922,7 @@ func TestCanTerminateEarly(t *testing.T) {
 			mkRow(time.Date(2026, 3, 9, 10, 15, 0, 0, time.UTC), 1),
 		}
 		remaining := []string{"s3://b/no-hive/events.parquet"}
-		if canTerminateEarly(results, remaining, 1) {
+		if canTerminateEarly(results, remaining, 1, "") {
 			t.Error("should not terminate: can't parse remaining file's hour")
 		}
 	})
@@ -886,7 +936,7 @@ func TestCanTerminateEarly(t *testing.T) {
 			mkRow(time.Date(2026, 3, 9, 10, 30, 0, 0, time.UTC), 3),
 		}
 		remaining := []string{"s3://b/event_date=2026-03-09/event_hour=11/e.parquet"}
-		if !canTerminateEarly(results, remaining, 2) {
+		if !canTerminateEarly(results, remaining, 2, "") {
 			t.Error("expected early termination: sorted 2nd result (10:30) is before hour=11")
 		}
 	})
@@ -898,7 +948,7 @@ func TestCanTerminateEarly(t *testing.T) {
 			mkRow(time.Date(2026, 3, 9, 11, 0, 0, 0, time.UTC), 1),
 		}
 		remaining := []string{"s3://b/event_date=2026-03-09/event_hour=11/e.parquet"}
-		if canTerminateEarly(results, remaining, 1) {
+		if canTerminateEarly(results, remaining, 1, "") {
 			t.Error("should not terminate: cutoff is exactly at next hour start")
 		}
 	})
@@ -907,7 +957,7 @@ func TestCanTerminateEarly(t *testing.T) {
 		results := []query.ResultRow{
 			mkRow(time.Date(2026, 3, 9, 10, 15, 0, 0, time.UTC), 1),
 		}
-		if canTerminateEarly(results, nil, 1) {
+		if canTerminateEarly(results, nil, 1, "") {
 			t.Error("should not terminate: no remaining files")
 		}
 	})
@@ -925,7 +975,7 @@ func TestCanTerminateEarly(t *testing.T) {
 		remaining := []string{"s3://b/event_date=2026-03-09/event_hour=11/e.parquet"}
 		// limit=3 means we'd need 3 real-timestamp rows to ground a cutoff,
 		// but we only have 1. Must not terminate.
-		if canTerminateEarly(results, remaining, 3) {
+		if canTerminateEarly(results, remaining, 3, "") {
 			t.Error("should not terminate: only 1 non-drift row, cannot ground cutoff")
 		}
 	})
@@ -942,7 +992,7 @@ func TestCanTerminateEarly(t *testing.T) {
 			mkRow(time.Date(2026, 3, 9, 10, 45, 0, 0, time.UTC), 3),
 		}
 		remaining := []string{"s3://b/event_date=2026-03-09/event_hour=11/e.parquet"}
-		if !canTerminateEarly(results, remaining, 2) {
+		if !canTerminateEarly(results, remaining, 2, "") {
 			t.Error("expected early termination: 2nd real row (10:30) is before hour=11, drift rows filtered out")
 		}
 	})
@@ -1341,6 +1391,31 @@ func TestClassifyEmptyS3Listing(t *testing.T) {
 			return false, nil
 		}
 		_, err := classifyEmptyS3Listing(context.Background(), nil, source, nil, nil)
+		var emptyErr *query.SourceEmptyError
+		if !errors.As(err, &emptyErr) {
+			t.Fatalf("err = %v, want *query.SourceEmptyError", err)
+		}
+	})
+
+	// TestClassifyEmptyS3Listing/until-only (#774): before the fix,
+	// generateDatePrefixes(prefix, nil, old) invented start=now-31d, and with
+	// `old` predating that window the negative span clamped to a single
+	// bogus day — a non-nil result that made this function treat the listing
+	// as "scoped" and run the stale-registration probe. The probe would find
+	// SOME unrelated parquet under the base prefix (present in this repo's
+	// archives generally) and conclude "source is healthy, zero rows" —
+	// silently discarding real matching data older than 31 days. With
+	// generateDatePrefixes now returning nil for since==nil, an until-only
+	// query is correctly unscoped: a zero-file listing already means the
+	// (unscoped, full-prefix) source truly has nothing, so this must fail
+	// loud with SourceEmptyError and must NOT invoke the probe.
+	t.Run("until-only listing, until older than 31 days → SourceEmpty directly, probe NOT called (#774)", func(t *testing.T) {
+		s3BaseHasParquet = func(_ context.Context, _ *s3.Client, _, _ string) (bool, error) {
+			t.Fatal("probe must not run for an until-only listing — it is unscoped since #774")
+			return false, nil
+		}
+		old := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+		_, err := classifyEmptyS3Listing(context.Background(), nil, source, nil, &old)
 		var emptyErr *query.SourceEmptyError
 		if !errors.As(err, &emptyErr) {
 			t.Fatalf("err = %v, want *query.SourceEmptyError", err)


### PR DESCRIPTION
## Summary

Two related P1 bugs in internal/parquetquery/parquetquery.go's S3 archive pipeline:

- **#773**: canTerminateEarly assumed results accumulate in ascending chronological order, because files are always iterated oldest-first (sortFilesByHour). Under Order=DESC (the console's default events view, and "bintrail query --order desc"), this let the loop terminate right after reading the oldest hour -- before any newer hour was ever read -- so a newest-first query silently returned the oldest events with no error. Fix: canTerminateEarly is now direction-aware and never terminates early when Order=DESC (the safer of the two options the issue proposed -- correctness over speed). Every candidate file still gets read, and the final global sort+limit in query.MergeAndTrim picks the true newest rows.
- **#774**: generateDatePrefixes invented start = now - 31d whenever since was nil, even when only until was set. This silently excluded archived data older than 31 days when until fell inside that invented window, and produced a negative day-span clamped to a single bogus date prefix when until predated the window -- which then fooled classifyEmptyS3Listing's stale-registration probe into finding unrelated parquet elsewhere and reporting "source is healthy, zero rows" even though matching data existed. Fix: since == nil now returns nil from generateDatePrefixes ("list everything"), which composes correctly with both callers -- listS3ParquetScoped lists the full prefix, and classifyEmptyS3Listing correctly treats the listing as unscoped (so a genuine zero-file result fails loud with SourceEmptyError instead of masking it as healthy).

Both fixes are minimal and localized to the same file/functions named in the issues; no unrelated refactors.

Known tradeoff (documented in code comments): until-only S3 queries now always list the full archive prefix rather than a date-scoped subset. This is strictly safer (no more silent data loss) at the cost of listing more objects for a source with a very deep archive history. This is NOT a rare shape: no CLI command (`query`/`recover`/`reconstruct`/`verify`) marks `--since` required, the MCP tool schema marks `Since` optional (`omitempty`), the console's request builders impose no such requirement, and #774's own reproduction is exactly this shape (`bintrail query --until ...` with no `--since`, and the agent's `HandleRecover`, which is `TimeEnd`-only). The honest tradeoff is: this trades some S3 listing performance on a real, reachable path for correctness -- no listing scope narrower than "everything" is safe without a lower bound.

**Follow-up commit (post-review):** a subsequent commit on this branch fixes a related regression the #774 fix introduced in `classifyEmptyS3Listing` -- it used to key its stale-registration probe on `generateDatePrefixes(...) != nil`, which after the #774 fix is always nil for `since == nil`. That made every until-only query whose window legitimately predates all archived data (a healthy empty result) skip the probe and get misclassified as `SourceEmptyError`, exactly the case that error type's own doc comment says must not happen. Fixed by keying the probe on `since != nil || until != nil` instead (the same latent flaw also existed for the pre-existing since-set/range-over-`maxScopedDays` case; fixed both). See the follow-up commit message and PR comment for details.

## Test plan

- [x] go build ./... -- clean
- [x] go vet ./... -- clean
- [x] go build -tags integration ./internal/parquetquery/... -- confirms the canTerminateEarly signature change compiles against integration-tagged test files too
- [x] go test ./... -count=1 -- all packages pass
- [x] go test -tags integration ./internal/parquetquery/... -v -count=1 -- Docker MySQL on :13306 was available in this environment; all integration tests pass, including the existing archive/S3-direct pipeline tests (TestFetch_archivedLargeUnsignedExact, TestFetch_archivedNullBinlogFile, TestQueryFileList_globalTopNAcrossFiles)
- [x] New/extended regression tests:
  - TestCanTerminateEarly/DESC_never_terminates_early_even_when_the_ASC_heuristic_would (+ case-insensitive "desc" check) -- pins #773 directly at the exact decision function named in the issue, with a scenario the pre-fix ASC heuristic would have wrongly terminated on
  - TestGenerateDatePrefixes extended: "until only, until within 31 days" and "until only, until older than 31 days" subtests replace the old test that pinned the buggy invented-start behavior -- both now assert nil (#774)
  - TestFilterFilesByTimeRange_untilOnlyKeepsVeryOldFiles -- confirms the downstream filter keeps a file far older than 31 days once it's actually listed
  - TestClassifyEmptyS3Listing extended with an until-only/old-until case proving the stale-registration probe is no longer invoked (and the query fails loud instead of returning a false "healthy, zero rows")

Not run: no true end-to-end S3 test exists for the full download-pipeline loop inside Fetch's S3 branch (no S3/localstack mock harness in this repo -- confirmed by inspection and by advisor review). The canTerminateEarly unit tests exercise the exact decision logic the real loop calls; the local/glob code path structurally can't hit this bug at all (DuckDB does the sort+limit in SQL there, no canTerminateEarly involved).

closes #773
closes #774

Generated with Claude Code

