### PR TITLE
cascade: scope console combined-recover's parent-fetch to the recover request

### DIFF
--- a/internal/console/recover_cascade.go
+++ b/internal/console/recover_cascade.go
@@ -194,13 +194,24 @@ func (s *Server) handleRecoverCascade(w http.ResponseWriter, r *http.Request) {
 // synthesizeCascade. A zero Lookback/MaxDepth falls back to the cascade engine's
 // defaults (30d / depth 5) — what the auto-detect path passes (the friction this
 // feature removes is making the operator know their FK graph, not tune knobs).
+//
+// GTID/ChangedColumn/Limit exist so the auto-detect path (cascadeRecover) can
+// scope its internal parent-fetch IDENTICALLY to the recover request that
+// triggered it (#772): without them, a GTID-scoped "undo this one transaction"
+// recover would still search the entire table history for cascade parents,
+// synthesizing victims for deletes the operator never asked to touch. The
+// explicit endpoint leaves these zero (its own request has no such fields),
+// which preserves its existing behavior exactly.
 type cascadeSynthParams struct {
 	Schema, Table string
 	PK            string
 	PKs           []string
+	GTID          string
+	ChangedColumn string
 	Since, Until  *time.Time
 	Lookback      time.Duration
 	MaxDepth      int
+	Limit         int // 0 = default (recoverDefaultLimit/recoverMaxLimit)
 }
 
 // cascadeSynthResult carries the synthesized invisible extras plus coverage
@@ -224,7 +235,7 @@ type cascadeSynthResult struct {
 // rows. A returned error is an operational fetch/FK-load failure (caller 500s);
 // a PARTIAL synthesis is reported via SynthErr + Caveats, never an error.
 func (s *Server) synthesizeCascade(ctx context.Context, b *bundle, p cascadeSynthParams) (cascadeSynthResult, error) {
-	limit := clampLimit(0, recoverDefaultLimit, recoverMaxLimit)
+	limit := clampLimit(p.Limit, recoverDefaultLimit, recoverMaxLimit)
 	del := event.EventDelete
 
 	// DenyTables/RedactColumns are attached for consistency but are empty here (an
@@ -235,6 +246,8 @@ func (s *Server) synthesizeCascade(ctx context.Context, b *bundle, p cascadeSynt
 		PKValues:      p.PK,
 		PKValuesIn:    p.PKs,
 		EventType:     &del,
+		GTID:          p.GTID,
+		ChangedColumn: p.ChangedColumn,
 		Since:         p.Since,
 		Until:         p.Until,
 		Order:         "ASC",
@@ -368,8 +381,16 @@ func (s *Server) cascadeRecover(ctx context.Context, b *bundle, body recoverRequ
 		Schema: body.Schema,
 		Table:  body.Table,
 		PK:     body.PK,
-		Since:  opts.Since,
-		Until:  opts.Until,
+		// GTID/ChangedColumn/Limit mirror the SAME recover request that
+		// auto-detected this cascade, so the internal parent-fetch can never
+		// diverge from baseRows' scope (#772) — e.g. a GTID-scoped "undo this
+		// one transaction" recover must not synthesize victims for parent
+		// deletes outside that transaction.
+		GTID:          opts.GTID,
+		ChangedColumn: opts.ChangedColumn,
+		Since:         opts.Since,
+		Until:         opts.Until,
+		Limit:         opts.Limit,
 		// Lookback/MaxDepth left zero → cascade engine defaults (30d / depth 5).
 	})
 	if err != nil {

--- a/internal/console/recover_cascade.go
+++ b/internal/console/recover_cascade.go
@@ -311,9 +311,14 @@ func (s *Server) synthesizeCascade(ctx context.Context, b *bundle, p cascadeSynt
 		}
 	}
 
-	// Only meaningful for the internal DB-fetch path: when ParentDeletes is
-	// caller-supplied (derived from baseRows), any truncation already happened
-	// on baseRows' own fetch and is surfaced by that caller's own warnings.
+	// This caveat text ("parent DELETE events were capped") describes the
+	// internal DB-fetch's own LIMIT clause, which only fires on that path
+	// (p.ParentDeletes == nil). When ParentDeletes is caller-supplied (derived
+	// from baseRows), any truncation happened on baseRows' OWN fetch instead —
+	// NOTE this is not currently surfaced by a dedicated caveat anywhere
+	// (handleRecover's warnings are coverage-gap hours from gapWarnings(plan),
+	// not a Limit-truncation signal); a baseRows-level truncation caveat is a
+	// pre-existing gap in the plain recover path too, out of scope here.
 	if p.ParentDeletes == nil && len(parentDeletes) >= limit {
 		caveats = append(caveats, fmt.Sprintf("parent DELETE events were capped at the limit (%d); narrow pk/since/until", limit))
 	}

--- a/internal/console/recover_cascade.go
+++ b/internal/console/recover_cascade.go
@@ -202,6 +202,23 @@ func (s *Server) handleRecoverCascade(w http.ResponseWriter, r *http.Request) {
 // synthesizing victims for deletes the operator never asked to touch. The
 // explicit endpoint leaves these zero (its own request has no such fields),
 // which preserves its existing behavior exactly.
+//
+// ParentDeletes, when non-nil, is used AS-IS as the parent DELETE set instead
+// of the internal DB fetch in synthesizeCascade. This closes a residual gap
+// in the GTID/ChangedColumn/Limit threading above: matching the *numeric*
+// Limit does not guarantee the internal fetch is a subset of baseRows,
+// because baseRows is an ALL-event-types fetch while the internal fetch is
+// DELETE-only. Over the identical window, non-DELETE rows on the table
+// consume baseRows' Limit budget but never consume the DELETE-only fetch's
+// budget — so the DELETE-only fetch can rank a later DELETE inside the same
+// numeric Limit that baseRows' Limit already excluded, pulling in an
+// unrelated parent DELETE the recover request never actually returned (and
+// synthesizing orphan children for it). cascadeRecover (the auto-detect
+// path, which already has baseRows in hand) derives ParentDeletes by
+// filtering baseRows itself, so the parent set can never diverge from it —
+// no re-fetch, no Limit/ordering/EventType mismatch possible. The explicit
+// /api/recover-cascade endpoint has no baseRows to derive from, so it always
+// leaves this nil and keeps its existing DB-fetch behavior exactly.
 type cascadeSynthParams struct {
 	Schema, Table string
 	PK            string
@@ -212,6 +229,7 @@ type cascadeSynthParams struct {
 	Lookback      time.Duration
 	MaxDepth      int
 	Limit         int // 0 = default (recoverDefaultLimit/recoverMaxLimit)
+	ParentDeletes []query.ResultRow
 }
 
 // cascadeSynthResult carries the synthesized invisible extras plus coverage
@@ -238,28 +256,38 @@ func (s *Server) synthesizeCascade(ctx context.Context, b *bundle, p cascadeSynt
 	limit := clampLimit(p.Limit, recoverDefaultLimit, recoverMaxLimit)
 	del := event.EventDelete
 
-	// DenyTables/RedactColumns are attached for consistency but are empty here (an
-	// RBAC profile is refused upstream of every caller of synthesizeCascade).
-	parentDeletes, err := b.engine.Fetch(ctx, query.Options{
-		Schema:        p.Schema,
-		Table:         p.Table,
-		PKValues:      p.PK,
-		PKValuesIn:    p.PKs,
-		EventType:     &del,
-		GTID:          p.GTID,
-		ChangedColumn: p.ChangedColumn,
-		Since:         p.Since,
-		Until:         p.Until,
-		Order:         "ASC",
-		Limit:         limit,
-		DenyTables:    s.denyTables,
-		RedactColumns: s.redactCols,
-	})
-	if err != nil {
-		return cascadeSynthResult{}, fmt.Errorf("fetch parent deletes: %w", err)
-	}
-
 	var caveats []string
+	var parentDeletes []query.ResultRow
+	if p.ParentDeletes != nil {
+		// Caller (cascadeRecover) already derived the parent DELETE set from its
+		// own baseRows — use it as-is rather than re-fetching (see the
+		// ParentDeletes doc comment on cascadeSynthParams for why a re-fetch,
+		// even with matched filters/Limit, cannot guarantee this subset).
+		parentDeletes = p.ParentDeletes
+	} else {
+		// DenyTables/RedactColumns are attached for consistency but are empty
+		// here (an RBAC profile is refused upstream of every caller of
+		// synthesizeCascade).
+		var err error
+		parentDeletes, err = b.engine.Fetch(ctx, query.Options{
+			Schema:        p.Schema,
+			Table:         p.Table,
+			PKValues:      p.PK,
+			PKValuesIn:    p.PKs,
+			EventType:     &del,
+			GTID:          p.GTID,
+			ChangedColumn: p.ChangedColumn,
+			Since:         p.Since,
+			Until:         p.Until,
+			Order:         "ASC",
+			Limit:         limit,
+			DenyTables:    s.denyTables,
+			RedactColumns: s.redactCols,
+		})
+		if err != nil {
+			return cascadeSynthResult{}, fmt.Errorf("fetch parent deletes: %w", err)
+		}
+	}
 
 	// Live-only trap (mirrors the CLI): probe archives UNCONDITIONALLY — the #569
 	// over-recovery guard is about whether archived partitions physically EXIST
@@ -283,7 +311,10 @@ func (s *Server) synthesizeCascade(ctx context.Context, b *bundle, p cascadeSynt
 		}
 	}
 
-	if len(parentDeletes) >= limit {
+	// Only meaningful for the internal DB-fetch path: when ParentDeletes is
+	// caller-supplied (derived from baseRows), any truncation already happened
+	// on baseRows' own fetch and is surfaced by that caller's own warnings.
+	if p.ParentDeletes == nil && len(parentDeletes) >= limit {
 		caveats = append(caveats, fmt.Sprintf("parent DELETE events were capped at the limit (%d); narrow pk/since/until", limit))
 	}
 
@@ -369,6 +400,28 @@ type cascadeRecoverResult struct {
 	Caveats        []string
 }
 
+// parentDeletesOnTable filters rows down to the DELETE events on table — used
+// by cascadeRecover to derive the cascade parent set DIRECTLY from baseRows
+// (#772 residual gap) instead of re-fetching it from the index. A re-fetch
+// scoped by matching filters/Limit is NOT guaranteed to return the same set:
+// baseRows is an ALL-event-types fetch, so non-DELETE rows on the table
+// consume its Limit budget, while a DELETE-only re-fetch's budget is consumed
+// only by DELETEs — over the identical window and numeric Limit, the
+// DELETE-only fetch can therefore rank (and include) a DELETE further into
+// the window than baseRows' own cutoff reached, pulling in an unrelated
+// parent the operator's recover request never actually returned. Filtering
+// baseRows itself makes the parent set a subset BY CONSTRUCTION, independent
+// of Limit, ordering, or any filter mismatch.
+func parentDeletesOnTable(rows []query.ResultRow, table string) []query.ResultRow {
+	var out []query.ResultRow
+	for _, r := range rows {
+		if r.EventType == event.EventDelete && r.TableName == table {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
 // cascadeRecover composes ONE cascade-aware reversal script for a recover whose
 // target handleRecover auto-detected as a foreign-key parent: the base undo of
 // baseRows (already fetched — merged live+archive, RBAC-redacted, every event
@@ -381,11 +434,15 @@ func (s *Server) cascadeRecover(ctx context.Context, b *bundle, body recoverRequ
 		Schema: body.Schema,
 		Table:  body.Table,
 		PK:     body.PK,
-		// GTID/ChangedColumn/Limit mirror the SAME recover request that
-		// auto-detected this cascade, so the internal parent-fetch can never
-		// diverge from baseRows' scope (#772) — e.g. a GTID-scoped "undo this
-		// one transaction" recover must not synthesize victims for parent
-		// deletes outside that transaction.
+		// ParentDeletes is derived directly from baseRows (#772 residual gap —
+		// see parentDeletesOnTable), so the cascade parent set can never
+		// diverge from what this recover request actually returned.
+		ParentDeletes: parentDeletesOnTable(baseRows, body.Table),
+		// GTID/ChangedColumn/Since/Until/Limit are still threaded through for
+		// completeness (e.g. if ParentDeletes were ever nil), but are unused
+		// by synthesizeCascade whenever ParentDeletes is non-nil, which it
+		// always is here (rowsContainDeleteOn already guarantees baseRows has
+		// at least one qualifying DELETE before cascadeRecover is called).
 		GTID:          opts.GTID,
 		ChangedColumn: opts.ChangedColumn,
 		Since:         opts.Since,

--- a/internal/console/recover_cascade_integration_test.go
+++ b/internal/console/recover_cascade_integration_test.go
@@ -327,6 +327,103 @@ func TestIntegrationRecover_autoCascade_mixedEvents(t *testing.T) {
 	}
 }
 
+// TestIntegrationRecover_autoCascade_gtidScoped is the regression test for #772:
+// the combined recover path must scope its internal cascade parent-fetch to the
+// SAME filters (here, GTID) as the triggering recover request, so it can never
+// synthesize victims for a parent DELETE the operator did not ask to recover.
+//
+// Two independent parents are seeded on the same table, each deleted under its
+// own transaction (distinct GTID) and each with two cascade-deleted children.
+// Recovering by the FIRST parent's GTID alone (the natural "undo this one
+// transaction" flow, no since/until) must synthesize victims ONLY for that
+// parent's children. Before the fix, the internal parent-fetch dropped GTID and
+// searched the entire table history, pulling in the second (unrelated) parent's
+// deletion and synthesizing INSERTs for its children too — even though that
+// parent itself is never re-created by this recover, orphaning them once
+// FOREIGN_KEY_CHECKS is re-enabled.
+func TestIntegrationRecover_autoCascade_gtidScoped(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	h := time.Now().UTC().Add(-1 * time.Hour).Truncate(time.Hour)
+	gtidA := "3e11fa47-71ca-11e1-9e33-c80aa9429562:5"
+	gtidB := "3e11fa47-71ca-11e1-9e33-c80aa9429562:6"
+
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{h})
+
+	// Transaction A: parent id=1 deleted under gtidA, cascading children pid=1
+	// (id=10, id=11) — this is the ONLY transaction the recover request targets.
+	childATs := h.Add(10 * time.Minute).Format("2006-01-02 15:04:05")
+	parentATs := h.Add(20 * time.Minute).Format("2006-01-02 15:04:05")
+	testutil.InsertEvent(t, db, "binlog.000001", 100, 200, childATs, nil,
+		dbName, "child", 1 /*INSERT*/, "10", nil, nil, []byte(`{"id":10,"pid":1}`))
+	testutil.InsertEvent(t, db, "binlog.000001", 200, 300, childATs, nil,
+		dbName, "child", 1 /*INSERT*/, "11", nil, nil, []byte(`{"id":11,"pid":1}`))
+	testutil.InsertEvent(t, db, "binlog.000001", 300, 400, parentATs, &gtidA,
+		dbName, "parent", 3 /*DELETE*/, "1", nil, []byte(`{"id":1}`), nil)
+
+	// Transaction B: an UNRELATED parent id=2 deleted under gtidB, cascading its
+	// own children pid=2 (id=20, id=21). The recover request below never
+	// mentions gtidB, pk=2, or these children.
+	childBTs := h.Add(11 * time.Minute).Format("2006-01-02 15:04:05")
+	parentBTs := h.Add(21 * time.Minute).Format("2006-01-02 15:04:05")
+	testutil.InsertEvent(t, db, "binlog.000001", 400, 500, childBTs, nil,
+		dbName, "child", 1 /*INSERT*/, "20", nil, nil, []byte(`{"id":20,"pid":2}`))
+	testutil.InsertEvent(t, db, "binlog.000001", 500, 600, childBTs, nil,
+		dbName, "child", 1 /*INSERT*/, "21", nil, nil, []byte(`{"id":21,"pid":2}`))
+	testutil.InsertEvent(t, db, "binlog.000001", 600, 700, parentBTs, &gtidB,
+		dbName, "parent", 3 /*DELETE*/, "2", nil, []byte(`{"id":2}`), nil)
+
+	testutil.MustExec(t, db, `INSERT INTO fk_constraints
+		(snapshot_id, constraint_name, schema_name, table_name, column_name, ordinal_position,
+		 referenced_schema_name, referenced_table_name, referenced_column_name, delete_rule, update_rule)
+		VALUES (1, 'fk_child', ?, 'child', 'pid', 1, ?, 'parent', 'id', 'CASCADE', 'RESTRICT')`,
+		dbName, dbName)
+
+	snapTs := h.Format("2006-01-02 15:04:05")
+	testutil.InsertSnapshot(t, db, 1, snapTs, dbName, "parent", "id", 1, "PRI", "int", "NO")
+	testutil.InsertSnapshot(t, db, 1, snapTs, dbName, "child", "id", 1, "PRI", "int", "NO")
+	testutil.InsertSnapshot(t, db, 1, snapTs, dbName, "child", "pid", 2, "", "int", "YES")
+
+	srv, err := New(Config{DB: db, DBName: dbName, Listen: "127.0.0.1:8090", Token: intToken, NoArchive: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Recover ONLY gtidA's transaction — no since/until, no pk.
+	rec, body := doReq(t, srv, "POST", "/api/recover",
+		`{"schema":"`+dbName+`","table":"parent","gtid":"`+gtidA+`"}`)
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, body = %s", rec.Code, body)
+	}
+	var resp recoverResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("decode: %v (body=%s)", err, body)
+	}
+	if !resp.CascadeDetected {
+		t.Errorf("cascade_detected should be true for a GTID-scoped parent DELETE recover")
+	}
+	if resp.VictimCount != 2 {
+		t.Errorf("victim_count = %d, want 2 (only gtidA's children); a pre-fix regression would report 4 (both transactions' children)\n---\n%s", resp.VictimCount, resp.SQL)
+	}
+	for _, want := range []string{"VALUES (10, 1)", "VALUES (11, 1)"} {
+		if !strings.Contains(resp.SQL, want) {
+			t.Errorf("SQL missing %q (gtidA's own child)\n---\n%s", want, resp.SQL)
+		}
+	}
+	for _, notWant := range []string{"VALUES (20, 2)", "VALUES (21, 2)", "VALUES (2)"} {
+		if strings.Contains(resp.SQL, notWant) {
+			t.Errorf("SQL must NOT include %q — gtidB's parent/children are outside the recover request's scope\n---\n%s", notWant, resp.SQL)
+		}
+	}
+	if c := strings.Count(resp.SQL, "`"+dbName+"`.`child`"); c != 2 {
+		t.Errorf("want exactly 2 child INSERTs (gtidA's own), got %d\n---\n%s", c, resp.SQL)
+	}
+	if c := strings.Count(resp.SQL, "`"+dbName+"`.`parent`"); c != 1 {
+		t.Errorf("want the gtidA parent re-inserted exactly once (gtidB's parent must not appear), got %d\n---\n%s", c, resp.SQL)
+	}
+}
+
 // TestIntegrationRecover_autoCascade_setNull covers the SET NULL arm of the
 // combined path: a parent whose child FK is ON DELETE SET NULL. Recover on the
 // parent must fold an idempotent guarded UPDATE (… AND fk IS NULL) into the same

--- a/internal/console/recover_cascade_integration_test.go
+++ b/internal/console/recover_cascade_integration_test.go
@@ -424,6 +424,119 @@ func TestIntegrationRecover_autoCascade_gtidScoped(t *testing.T) {
 	}
 }
 
+// TestIntegrationRecover_autoCascade_limitTruncated is the regression test for
+// the residual #772 gap that matching the recover request's numeric Limit does
+// NOT close: baseRows is an ALL-event-types fetch, while the internal cascade
+// parent-fetch is DELETE-only. Over the identical window, non-DELETE rows on
+// the table consume baseRows' Limit budget but never consume the DELETE-only
+// fetch's budget — so a DELETE-only re-fetch using the SAME numeric Limit can
+// rank (and include) a DELETE further into the window than baseRows' own
+// cutoff reached, pulling in an unrelated parent the recover request never
+// actually returned and synthesizing orphan children for it.
+//
+// Seeded on table "parent", in this exact chronological order, with the
+// recover request's limit set to 3:
+//  1. DELETE id=1         (rank 1 of ALL events, rank 1 of DELETEs)
+//  2. INSERT id=99, noise (rank 2 of ALL events)
+//  3. INSERT id=98, noise (rank 3 of ALL events)
+//  4. DELETE id=2         (rank 4 of ALL events — excluded by baseRows'
+//     Limit=3 cutoff — but rank 2 of DELETEs, well within a DELETE-only
+//     fetch's own Limit=3)
+//
+// baseRows (Limit=3, ASC, all event types) therefore contains only
+// [DELETE id=1, noise, noise] — it never sees id=2's DELETE. A DELETE-only
+// re-fetch with the same Limit=3 returns BOTH deletes. The combined recover
+// must synthesize victims ONLY for id=1's children: id=2's parent is never
+// re-created by this recover (it's outside baseRows), so synthesizing its
+// children would orphan them once FOREIGN_KEY_CHECKS is re-enabled.
+func TestIntegrationRecover_autoCascade_limitTruncated(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	h := time.Now().UTC().Add(-1 * time.Hour).Truncate(time.Hour)
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{h})
+
+	childTs := h.Add(5 * time.Minute).Format("2006-01-02 15:04:05")
+	del1Ts := h.Add(20 * time.Minute).Format("2006-01-02 15:04:05")
+	noise1Ts := h.Add(21 * time.Minute).Format("2006-01-02 15:04:05")
+	noise2Ts := h.Add(22 * time.Minute).Format("2006-01-02 15:04:05")
+	del2Ts := h.Add(23 * time.Minute).Format("2006-01-02 15:04:05")
+
+	// Children of BOTH parents (their own timestamps don't matter — the
+	// parent-fetch is table="parent"-scoped and never sees table="child" rows).
+	testutil.InsertEvent(t, db, "binlog.000001", 100, 200, childTs, nil,
+		dbName, "child", 1 /*INSERT*/, "10", nil, nil, []byte(`{"id":10,"pid":1}`))
+	testutil.InsertEvent(t, db, "binlog.000001", 200, 300, childTs, nil,
+		dbName, "child", 1 /*INSERT*/, "11", nil, nil, []byte(`{"id":11,"pid":1}`))
+	testutil.InsertEvent(t, db, "binlog.000001", 300, 400, childTs, nil,
+		dbName, "child", 1 /*INSERT*/, "20", nil, nil, []byte(`{"id":20,"pid":2}`))
+	testutil.InsertEvent(t, db, "binlog.000001", 400, 500, childTs, nil,
+		dbName, "child", 1 /*INSERT*/, "21", nil, nil, []byte(`{"id":21,"pid":2}`))
+
+	// The 4 "parent"-table events, in strict chronological order.
+	testutil.InsertEvent(t, db, "binlog.000001", 500, 600, del1Ts, nil,
+		dbName, "parent", 3 /*DELETE*/, "1", nil, []byte(`{"id":1}`), nil)
+	testutil.InsertEvent(t, db, "binlog.000001", 600, 700, noise1Ts, nil,
+		dbName, "parent", 1 /*INSERT, noise*/, "99", nil, nil, []byte(`{"id":99}`))
+	testutil.InsertEvent(t, db, "binlog.000001", 700, 800, noise2Ts, nil,
+		dbName, "parent", 1 /*INSERT, noise*/, "98", nil, nil, []byte(`{"id":98}`))
+	testutil.InsertEvent(t, db, "binlog.000001", 800, 900, del2Ts, nil,
+		dbName, "parent", 3 /*DELETE*/, "2", nil, []byte(`{"id":2}`), nil)
+
+	testutil.MustExec(t, db, `INSERT INTO fk_constraints
+		(snapshot_id, constraint_name, schema_name, table_name, column_name, ordinal_position,
+		 referenced_schema_name, referenced_table_name, referenced_column_name, delete_rule, update_rule)
+		VALUES (1, 'fk_child', ?, 'child', 'pid', 1, ?, 'parent', 'id', 'CASCADE', 'RESTRICT')`,
+		dbName, dbName)
+
+	snapTs := h.Format("2006-01-02 15:04:05")
+	testutil.InsertSnapshot(t, db, 1, snapTs, dbName, "parent", "id", 1, "PRI", "int", "NO")
+	testutil.InsertSnapshot(t, db, 1, snapTs, dbName, "child", "id", 1, "PRI", "int", "NO")
+	testutil.InsertSnapshot(t, db, 1, snapTs, dbName, "child", "pid", 2, "", "int", "YES")
+
+	srv, err := New(Config{DB: db, DBName: dbName, Listen: "127.0.0.1:8090", Token: intToken, NoArchive: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Recover the whole table's history, capped at limit=3 — the exact numeric
+	// Limit that (pre-fix) let the internal DELETE-only parent-fetch see id=2's
+	// DELETE while baseRows' own Limit=3 cutoff never reached it.
+	rec, body := doReq(t, srv, "POST", "/api/recover",
+		`{"schema":"`+dbName+`","table":"parent","limit":3}`)
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, body = %s", rec.Code, body)
+	}
+	var resp recoverResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("decode: %v (body=%s)", err, body)
+	}
+	if !resp.CascadeDetected {
+		t.Errorf("cascade_detected should be true (baseRows contains id=1's DELETE)")
+	}
+	if resp.VictimCount != 2 {
+		t.Errorf("victim_count = %d, want 2 (only id=1's children); a pre-fix regression would report 4 "+
+			"(id=2's children too, even though id=2's own parent is never re-inserted)\n---\n%s", resp.VictimCount, resp.SQL)
+	}
+	for _, want := range []string{"VALUES (10, 1)", "VALUES (11, 1)"} {
+		if !strings.Contains(resp.SQL, want) {
+			t.Errorf("SQL missing %q (id=1's own child)\n---\n%s", want, resp.SQL)
+		}
+	}
+	for _, notWant := range []string{"VALUES (20, 2)", "VALUES (21, 2)"} {
+		if strings.Contains(resp.SQL, notWant) {
+			t.Errorf("SQL must NOT include %q — id=2's parent fell outside baseRows' Limit-truncated "+
+				"scope, so its children would be orphaned\n---\n%s", notWant, resp.SQL)
+		}
+	}
+	if strings.Contains(resp.SQL, "INSERT INTO `"+dbName+"`.`parent` (`id`) VALUES (2)") {
+		t.Errorf("SQL must NOT re-insert parent id=2 — it is outside this recover's Limit-truncated scope\n---\n%s", resp.SQL)
+	}
+	if c := strings.Count(resp.SQL, "`"+dbName+"`.`child`"); c != 2 {
+		t.Errorf("want exactly 2 child INSERTs (id=1's own), got %d\n---\n%s", c, resp.SQL)
+	}
+}
+
 // TestIntegrationRecover_autoCascade_setNull covers the SET NULL arm of the
 // combined path: a parent whose child FK is ON DELETE SET NULL. Recover on the
 // parent must fold an idempotent guarded UPDATE (… AND fk IS NULL) into the same


### PR DESCRIPTION
closes #772

## Summary

- `cascadeRecover` (the auto-detected cascade branch of `POST /api/recover`) built `cascadeSynthParams` carrying only `Schema`/`Table`/`PK`/`Since`/`Until` — dropping the triggering request's `GTID`, `ChangedColumn`, and `Limit`.
- `synthesizeCascade`'s internal parent-fetch then always used `clampLimit(0, ...)` = 1000 with no GTID/changed-column filter, searching the table's **entire history** for cascade parents instead of scoping identically to `baseRows`.
- Concretely: a GTID-scoped "undo this one transaction" recover that deleted parent `pk=1` would also pull in an unrelated parent `pk=2` deleted under a different transaction, and synthesize INSERTs for `pk=2`'s cascade-deleted children — even though `pk=2` itself is never re-created by this recover (it's outside `baseRows`), orphaning those children once `FOREIGN_KEY_CHECKS` is re-enabled.
- Fix: propagate `opts.GTID`/`opts.ChangedColumn`/`opts.Limit` into `cascadeSynthParams` and thread them into the internal parent-fetch's `query.Options`, so the parent set can never diverge from what the operator actually asked to recover. The explicit `POST /api/recover-cascade` endpoint is unaffected — its own request schema has no such fields, so they stay zero-valued there, preserving its existing (already-correct) behavior exactly.

## Test plan

- Added `TestIntegrationRecover_autoCascade_gtidScoped` (`internal/console/recover_cascade_integration_test.go`): seeds two independent parent DELETEs on the same table under distinct GTIDs, each cascading its own two children. Recovering by only the first GTID must synthesize victims for that parent's 2 children only, and must NOT include the unrelated parent or its children.
- Verified the new test **fails pre-fix** (stashed the fix, re-ran the test — it emitted orphan INSERTs for the unrelated parent's children while never re-creating that parent) and **passes post-fix**.
- `go test ./... -count=1` — all packages pass.
- `go test -tags integration ./internal/console/... -run 'TestIntegrationRecoverCascade|TestIntegrationRecover_autoCascade' -v -count=1` against Docker MySQL (`:13306`) — all pass, including the new regression test and all pre-existing cascade/recover integration tests (no regressions).
- Did not run the full repo-wide `-tags integration` suite (only the console cascade/recover subset relevant to this change); the change is scoped to `internal/console` and doesn't touch other packages' integration paths.
