### PR TITLE
archive: atomic tmp+rename write + footer verification before --retry skip

### DIFF
--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -11,6 +11,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/parquet-go/parquet-go"
+
 	"github.com/dbtrail/dbtrail/internal/baseline"
 )
 
@@ -50,8 +52,17 @@ var BinlogEventColumns = []baseline.Column{
 // parseTime=true (i.e. via config.Connect) so DATETIME columns scan as
 // time.Time. Returns the number of rows written.
 //
-// On error the partial output file is removed before returning.
+// The file is written to outputPath+".tmp" and atomically renamed into place
+// only after the write completes and the writer is closed (issue #802): a
+// process kill, OOM, or host reboot mid-write can never leave a truncated,
+// no-footer file at outputPath — either the rename happened (a complete,
+// valid file) or it didn't (outputPath is untouched). A stale .tmp file left
+// by an earlier crash is silently overwritten by the next run (os.Create
+// truncates it) and is otherwise ignored — nothing ever reads from it.
+//
+// On error the partial .tmp output file is removed before returning.
 func ArchivePartition(ctx context.Context, db *sql.DB, dbName, partition, outputPath, compression string) (int64, error) {
+	tmpPath := outputPath + ".tmp"
 	cfg := baseline.WriterConfig{
 		Compression:  compression,
 		RowGroupSize: 500_000,
@@ -62,7 +73,7 @@ func ArchivePartition(ctx context.Context, db *sql.DB, dbName, partition, output
 		},
 	}
 
-	w, err := baseline.NewWriter(outputPath, BinlogEventColumns, cfg)
+	w, err := baseline.NewWriter(tmpPath, BinlogEventColumns, cfg)
 	if err != nil {
 		return 0, fmt.Errorf("create parquet writer: %w", err)
 	}
@@ -70,8 +81,8 @@ func ArchivePartition(ctx context.Context, db *sql.DB, dbName, partition, output
 	var closed bool
 	defer func() {
 		if !closed {
-			w.Close()             //nolint
-			os.Remove(outputPath) //nolint
+			w.Close()          //nolint
+			os.Remove(tmpPath) //nolint
 		}
 	}()
 
@@ -182,8 +193,40 @@ func ArchivePartition(ctx context.Context, db *sql.DB, dbName, partition, output
 
 	closed = true
 	if err := w.Close(); err != nil {
-		os.Remove(outputPath) //nolint
+		os.Remove(tmpPath) //nolint
 		return rowCount, fmt.Errorf("close writer: %w", err)
 	}
+	if err := os.Rename(tmpPath, outputPath); err != nil {
+		os.Remove(tmpPath) //nolint
+		return rowCount, fmt.Errorf("rename %s into place: %w", tmpPath, err)
+	}
 	return rowCount, nil
+}
+
+// ValidateArchiveFile opens the Parquet file at path just far enough to read
+// its trailing footer metadata (row-group index, schema, row count) without
+// decoding any row data. A file left partially written by a crash mid-write
+// (issue #802: kill -9, OOM, host reboot — none of which run Go's
+// defer-based cleanup) has no valid footer and parquet.OpenFile fails on it,
+// even though the file's size is greater than zero. Callers deciding whether
+// an on-disk archive can be trusted (e.g. rotation's --retry skip, or
+// deciding it is safe to drop the source partition) must not rely on
+// size > 0 alone — they should use this instead. Returns the row count
+// recorded in the footer on success.
+func ValidateArchiveFile(path string) (int64, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return 0, err
+	}
+	pf, err := parquet.OpenFile(f, info.Size())
+	if err != nil {
+		return 0, fmt.Errorf("invalid or truncated parquet footer: %w", err)
+	}
+	return pf.NumRows(), nil
 }

--- a/internal/archive/archive_integration_test.go
+++ b/internal/archive/archive_integration_test.go
@@ -83,6 +83,57 @@ func TestArchivePartition_nullBinlogFile(t *testing.T) {
 	}
 }
 
+// TestArchivePartition_NoStrayTmpFileOnSuccess pins the issue #802 atomic-write
+// invariant on the success path: ArchivePartition must write to
+// outputPath+".tmp" and rename it into place, leaving no ".tmp" leftover once
+// it returns without error.
+func TestArchivePartition_NoStrayTmpFileOnSuccess(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	ts := "2026-02-19 14:00:00"
+	testutil.InsertEvent(t, db, "binlog.000001", 100, 200, ts, nil, "mydb", "orders", 1, "1",
+		nil, nil, []byte(`{"id":1}`))
+
+	outPath := filepath.Join(t.TempDir(), "events.parquet")
+	if _, err := ArchivePartition(context.Background(), db, dbName, "p_future", outPath, "none"); err != nil {
+		t.Fatalf("ArchivePartition failed: %v", err)
+	}
+	if _, err := os.Stat(outPath); err != nil {
+		t.Fatalf("final output file must exist: %v", err)
+	}
+	if _, err := os.Stat(outPath + ".tmp"); !os.IsNotExist(err) {
+		t.Errorf("stray .tmp file left behind after a successful archive, stat err = %v", err)
+	}
+}
+
+// TestArchivePartition_QueryErrorLeavesNoFinalFile reproduces the failure
+// window issue #802 targets: an error partway through ArchivePartition (here,
+// querying a partition that doesn't exist) must never leave anything at the
+// final outputPath — only the (cleaned-up) .tmp file may have existed. Before
+// the tmp+rename fix, ArchivePartition wrote directly to outputPath, so a
+// crash after the writer was created but before Close() could leave a
+// truncated file exactly there; a process kill (which skips Go's defer-based
+// cleanup entirely) could not be caught by this test, but the underlying
+// write target can: the fixed code physically cannot reach outputPath except
+// via the final os.Rename.
+func TestArchivePartition_QueryErrorLeavesNoFinalFile(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	outPath := filepath.Join(t.TempDir(), "events.parquet")
+	_, err := ArchivePartition(context.Background(), db, dbName, "p_does_not_exist", outPath, "none")
+	if err == nil {
+		t.Fatal("expected an error archiving a nonexistent partition")
+	}
+	if _, statErr := os.Stat(outPath); !os.IsNotExist(statErr) {
+		t.Errorf("final output path must not exist after a failed archive, stat err = %v", statErr)
+	}
+	if _, statErr := os.Stat(outPath + ".tmp"); !os.IsNotExist(statErr) {
+		t.Errorf(".tmp file must be cleaned up after a failed archive, stat err = %v", statErr)
+	}
+}
+
 // TestArchivePartition_queryTextRoundTrip pins the #699 wiring through the
 // rotate path: the SELECT list, Scan targets, and the positional values/nulls
 // arrays must stay aligned — a transposition of queryText/queryHash would

--- a/internal/rotation/rotation.go
+++ b/internal/rotation/rotation.go
@@ -141,7 +141,31 @@ func Perform(ctx context.Context, db *sql.DB, dbName string, opts Options) (Resu
 						return Result{}, fmt.Errorf("create archive directory for %s: %w", name, err)
 					}
 					var n int64
-					skipped := opts.Retry && fileExists(outPath)
+					skipped := false
+					if opts.Retry && fileExists(outPath) {
+						// A file existing at outPath with size>0 is NOT sufficient
+						// evidence it is a complete archive: a crash mid-write
+						// (kill -9, OOM, reboot) can leave a truncated, no-footer
+						// file here even though ArchivePartition now writes via a
+						// temp file + atomic rename (issue #802) — this guards
+						// leftovers from before that fix, or any other corruption.
+						// Only trust the file when archive_state independently
+						// recorded the same row count for this partition; a
+						// missing/mismatched row (exactly what a mid-write crash
+						// leaves, since that INSERT only happens after the write
+						// completes) means re-archive rather than silently
+						// skip-and-later-upload/drop a corrupt file.
+						verified, err := verifiedExistingArchive(ctx, db, outPath, name, opts.BintrailID)
+						if err != nil {
+							return Result{}, fmt.Errorf("verify existing archive for %s: %w", name, err)
+						}
+						if verified {
+							skipped = true
+						} else {
+							slog.Warn("existing archive file failed verification (truncated or unrecorded); re-archiving",
+								"partition", name, "file", outPath)
+						}
+					}
 					if skipped {
 						slog.Info("skipping existing archive (--retry)", "partition", name, "file", outPath)
 						if opts.Format != "json" {
@@ -460,9 +484,44 @@ func partitionArchived(ctx context.Context, db *sql.DB, partition string) (bool,
 }
 
 // fileExists reports whether a file exists and has a size greater than zero.
+// Existence alone does NOT mean the file is a complete archive — see
+// verifiedExistingArchive, which callers deciding whether to trust an
+// on-disk file (--retry skip, or before a DROP PARTITION) must use instead.
 func fileExists(path string) bool {
 	fi, err := os.Stat(path)
 	return err == nil && fi.Size() > 0
+}
+
+// verifiedExistingArchive reports whether the Parquet file at outPath can be
+// trusted as a complete, previously-finished archive of partition — i.e.
+// whether --retry may safely skip re-archiving it. It is trusted only when
+// BOTH: (1) archive_state records a row count for this partition (a
+// completed prior run inserts that row only after the write finishes — a
+// crash mid-write never reaches it), and (2) the file's own Parquet footer
+// opens cleanly and reports that same row count (issue #802: a truncated
+// file has no valid footer, even though its size is greater than zero). A
+// missing archive_state row or a footer/row-count mismatch both mean the
+// file cannot be trusted, so this returns false and the caller re-archives.
+func verifiedExistingArchive(ctx context.Context, db *sql.DB, outPath, partition, bintrailID string) (bool, error) {
+	var recordedRows sql.NullInt64
+	err := db.QueryRowContext(ctx,
+		`SELECT row_count FROM archive_state WHERE partition_name = ? AND bintrail_id = ?`,
+		partition, bintrailID,
+	).Scan(&recordedRows)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return false, nil
+	case err != nil:
+		return false, err
+	}
+	if !recordedRows.Valid {
+		return false, nil
+	}
+	fileRows, err := archive.ValidateArchiveFile(outPath)
+	if err != nil {
+		return false, nil // truncated/invalid footer: not trusted, not a hard error
+	}
+	return fileRows == recordedRows.Int64, nil
 }
 
 // HiveArchivePath returns the Hive-partitioned path for a binlog_events partition

--- a/internal/rotation/rotation_integration_test.go
+++ b/internal/rotation/rotation_integration_test.go
@@ -3,6 +3,7 @@
 package rotation
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"fmt"
@@ -12,7 +13,9 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/parquet-go/parquet-go"
 
+	"github.com/dbtrail/dbtrail/internal/archive"
 	"github.com/dbtrail/dbtrail/internal/indexer"
 	"github.com/dbtrail/dbtrail/internal/testutil"
 )
@@ -650,6 +653,186 @@ func TestPerformRotation_S3UploadSuccessPrunesAndDrops(t *testing.T) {
 		if p.Name == indexer.PartitionName(h1) {
 			t.Error("partition should have been dropped after a successful upload")
 		}
+	}
+}
+
+// TestPerformRotation_TruncatedArchiveRetryReArchives reproduces the OLD
+// buggy precondition from issue #802: a truncated (no valid Parquet footer)
+// file already sits at the Hive archive path with size>0 — as a crash
+// mid-write used to leave behind — but there is NO archive_state row for the
+// partition (that INSERT only ever happened after a completed write).
+// Before the fix, --retry's `fileExists(outPath)` trusted the truncated file,
+// skipped re-archiving AND skipped the archive_state INSERT, then uploaded
+// the corrupt bytes to S3 as-is; since no archive_state row ever existed, the
+// pending-upload guard saw nothing pending and rotation dropped the partition
+// and (with PruneLocalAfterUpload) deleted the local copy too — the hour of
+// data then existed only as an unreadable Parquet file in S3. The fixed code
+// must recognize the file is unverifiable (no archive_state row confirms its
+// row count) and re-archive it before ever uploading or dropping anything.
+func TestPerformRotation_TruncatedArchiveRetryReArchives(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	h1 := time.Now().UTC().Add(-48 * time.Hour).Truncate(time.Hour)
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{h1})
+	ts1 := h1.Add(30 * time.Minute).Format("2006-01-02 15:04:05")
+	testutil.InsertEvent(t, db, "binlog.000001", 100, 200, ts1, nil, "testdb", "users", 1, "1", nil, nil, []byte(`{"id":1}`))
+
+	archiveDir := t.TempDir()
+	bintrailID := "test-uuid-truncated"
+	outPath, _ := HiveArchivePath(archiveDir, bintrailID, indexer.PartitionName(h1))
+	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Simulate the crash-mid-write leftover: a "parquet" file with content
+	// that has no valid footer, size>0, and (deliberately) no archive_state
+	// row inserted for it yet.
+	const garbage = "truncated-not-a-real-parquet-footer"
+	if err := os.WriteFile(outPath, []byte(garbage), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var uploadedBytes []byte
+	prev := uploadFileFunc
+	uploadFileFunc = func(ctx context.Context, client *s3.Client, path, bucket, key string) error {
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		uploadedBytes = b
+		return nil
+	}
+	t.Cleanup(func() { uploadFileFunc = prev })
+
+	res, err := Perform(context.Background(), db, dbName, Options{
+		RetainDur:          24 * time.Hour,
+		ArchiveDir:         archiveDir,
+		ArchiveS3:          "s3://fake-bucket/prefix/",
+		ArchiveS3Region:    "us-east-1",
+		BintrailID:         bintrailID,
+		ArchiveCompression: "none",
+		Format:             "json",
+		NoReplace:          true,
+		Retry:              true,
+	})
+	if err != nil {
+		t.Fatalf("Perform: %v", err)
+	}
+	if res.Dropped != 1 {
+		t.Errorf("Dropped = %d, want 1 (re-archived successfully, then uploaded and dropped)", res.Dropped)
+	}
+
+	if uploadedBytes == nil {
+		t.Fatal("expected an S3 upload to occur")
+	}
+	if string(uploadedBytes) == garbage {
+		t.Fatal("uploaded the truncated garbage file instead of re-archiving it first")
+	}
+	pf, err := parquet.OpenFile(bytes.NewReader(uploadedBytes), int64(len(uploadedBytes)))
+	if err != nil {
+		t.Fatalf("uploaded bytes are not a valid parquet file (footer): %v", err)
+	}
+	if pf.NumRows() != 1 {
+		t.Errorf("uploaded parquet NumRows = %d, want 1", pf.NumRows())
+	}
+
+	// archive_state must now record the real row count — the row a crash
+	// mid-write never got to insert.
+	var rowCount sql.NullInt64
+	if err := db.QueryRow(
+		`SELECT row_count FROM archive_state WHERE partition_name = ? AND bintrail_id = ?`,
+		indexer.PartitionName(h1), bintrailID,
+	).Scan(&rowCount); err != nil {
+		t.Fatalf("read archive_state: %v", err)
+	}
+	if !rowCount.Valid || rowCount.Int64 != 1 {
+		t.Errorf("archive_state.row_count = %v, want 1", rowCount)
+	}
+}
+
+// TestPerformRotation_ValidExistingArchiveRetrySkips pins the side of the
+// issue #802 fix that must NOT regress: a genuinely complete prior archive —
+// a Parquet file whose footer row count matches what archive_state recorded
+// for it — is still trusted and skipped under --retry, not needlessly
+// re-archived. The stricter verification added for #802 must reject only
+// unverifiable/corrupt files, never a legitimately complete one.
+func TestPerformRotation_ValidExistingArchiveRetrySkips(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	h1 := time.Now().UTC().Add(-48 * time.Hour).Truncate(time.Hour)
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{h1})
+	ts1 := h1.Add(30 * time.Minute).Format("2006-01-02 15:04:05")
+	testutil.InsertEvent(t, db, "binlog.000001", 100, 200, ts1, nil, "testdb", "users", 1, "1", nil, nil, []byte(`{"id":1}`))
+
+	archiveDir := t.TempDir()
+	bintrailID := "test-uuid-valid-skip"
+	outPath, _ := HiveArchivePath(archiveDir, bintrailID, indexer.PartitionName(h1))
+	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Seed a genuinely complete, valid 1-row archive up front (as a prior
+	// successful run would have left it) and record it in archive_state —
+	// the state a legitimate --retry skip depends on.
+	if _, err := archive.ArchivePartition(context.Background(), db, dbName, indexer.PartitionName(h1), outPath, "none"); err != nil {
+		t.Fatalf("seed ArchivePartition: %v", err)
+	}
+	origBytes, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testutil.MustExec(t, db, `INSERT INTO archive_state
+		(partition_name, bintrail_id, local_path, row_count)
+		VALUES (?, ?, ?, 1)`, indexer.PartitionName(h1), bintrailID, outPath)
+
+	// A second live row lands in the partition after the archive was taken;
+	// it must NOT force a re-archive under --retry — the recorded row_count
+	// (1) still matches the file's own footer, so the file stays trusted.
+	ts2 := h1.Add(40 * time.Minute).Format("2006-01-02 15:04:05")
+	testutil.InsertEvent(t, db, "binlog.000001", 300, 400, ts2, nil, "testdb", "users", 1, "2", nil, nil, []byte(`{"id":2}`))
+
+	var uploadedBytes []byte
+	prev := uploadFileFunc
+	uploadFileFunc = func(ctx context.Context, client *s3.Client, path, bucket, key string) error {
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		uploadedBytes = b
+		return nil
+	}
+	t.Cleanup(func() { uploadFileFunc = prev })
+
+	res, err := Perform(context.Background(), db, dbName, Options{
+		RetainDur:          24 * time.Hour,
+		ArchiveDir:         archiveDir,
+		ArchiveS3:          "s3://fake-bucket/prefix/",
+		ArchiveS3Region:    "us-east-1",
+		BintrailID:         bintrailID,
+		ArchiveCompression: "none",
+		Format:             "json",
+		NoReplace:          true,
+		Retry:              true,
+	})
+	if err != nil {
+		t.Fatalf("Perform: %v", err)
+	}
+	if res.Dropped != 1 {
+		t.Errorf("Dropped = %d, want 1", res.Dropped)
+	}
+	if !bytes.Equal(uploadedBytes, origBytes) {
+		t.Error("a valid, already-recorded archive was re-archived (bytes changed) instead of being skipped")
+	}
+
+	var rowCount int64
+	if err := db.QueryRow(
+		`SELECT row_count FROM archive_state WHERE partition_name = ? AND bintrail_id = ?`,
+		indexer.PartitionName(h1), bintrailID,
+	).Scan(&rowCount); err != nil {
+		t.Fatalf("read archive_state: %v", err)
+	}
+	if rowCount != 1 {
+		t.Errorf("archive_state.row_count = %d, want unchanged at 1 (a re-archive would have recomputed it to 2)", rowCount)
 	}
 }
 


### PR DESCRIPTION
closes #802

## Summary

- `ArchivePartition` (`internal/archive/archive.go`) now writes to
  `events.parquet.tmp` in the same directory as the final Hive-layout path
  and `os.Rename`s it into place only after `Close()` succeeds. A process
  kill, OOM (#654), or host reboot mid-write can no longer leave a truncated,
  no-footer file at the final path — either the rename happened (a complete
  file) or it didn't (the final path is untouched). Adds
  `archive.ValidateArchiveFile(path)`, which opens just the Parquet footer
  and returns the recorded row count (or an error if the footer is
  invalid/truncated).
- `rotation.Perform`'s `--retry` skip (`internal/rotation/rotation.go`) no
  longer trusts an existing file solely because `size > 0`. It now calls a
  new `verifiedExistingArchive` helper that only honors the skip when
  `archive_state` independently recorded a row count for the partition
  **and** that count matches the file's own Parquet footer. A missing
  `archive_state` row (exactly what a mid-write crash leaves, since that
  `INSERT` only happens after a completed write) or a footer/row-count
  mismatch both force a re-archive instead of trusting/uploading/dropping a
  possibly-corrupt file. This closes the whole sequence described in the
  issue (retry-skip → upload-corrupt-to-S3 → drop-partition →
  prune-local-copy), not just the write path.

## Test plan

- Added regression tests reproducing the issue's exact failure precondition
  and pinning the fix:
  - `internal/archive/archive_integration_test.go`:
    `TestArchivePartition_NoStrayTmpFileOnSuccess` (no `.tmp` leftover after a
    successful archive) and `TestArchivePartition_QueryErrorLeavesNoFinalFile`
    (an error after the `.tmp` writer is created never leaves anything at the
    final path).
  - `internal/rotation/rotation_integration_test.go`:
    `TestPerformRotation_TruncatedArchiveRetryReArchives` recreates the old
    buggy precondition (truncated file, size>0, no `archive_state` row) and
    asserts the fixed code re-archives before uploading/dropping — the
    corrupt bytes are never uploaded and `archive_state.row_count` ends up
    correct. `TestPerformRotation_ValidExistingArchiveRetrySkips` pins the
    side that must NOT regress: a genuinely complete, previously-recorded
    archive is still skipped under `--retry`, not needlessly re-archived.
- Ran `go build ./...`, `go vet ./...`, and `go test ./... -count=1` — all
  packages pass. One `cliapp` unit test
  (`TestRunDump_capturesStderrOnFailure`) failed on an earlier full run with
  a "dump already running (PID …)" error; this is a pre-existing PID-lock
  collision from other agents' parallel test runs on the same host, not
  related to this diff — it passes in isolation and on a subsequent full
  clean run.
- Ran `go test -tags integration ./internal/archive/... ./internal/rotation/...`
  against the repo's Docker MySQL fixture (`127.0.0.1:13306`) — all
  integration tests pass, including the new ones above.
