### PR TITLE
pg: anchor baseline delta-replay on the slot floor, not the live snapshot LSN (#771)

### DIFF
--- a/cmd/bintrail-pg/baseline.go
+++ b/cmd/bintrail-pg/baseline.go
@@ -129,6 +129,7 @@ func runPGBaseline(cmd *cobra.Command, args []string) error {
 		"rows_written", stats.RowsWritten,
 		"files_written", stats.FilesWritten,
 		"anchor_lsn", stats.AnchorLSN,
+		"delta_start_lsn", stats.DeltaStartLSN,
 		"snapshot_time", stats.SnapshotTime)
 
 	var uploaded int
@@ -147,6 +148,7 @@ func runPGBaseline(cmd *cobra.Command, args []string) error {
 	fmt.Printf("  rows       : %d\n", stats.RowsWritten)
 	fmt.Printf("  files      : %d\n", stats.FilesWritten)
 	fmt.Printf("  anchor LSN : %d\n", stats.AnchorLSN)
+	fmt.Printf("  delta start LSN: %d (embedded metadata; the safe replay floor — see MetaKeyLSN)\n", stats.DeltaStartLSN)
 	fmt.Printf("  snapshot   : %s\n", stats.SnapshotTime.Format("2006-01-02T15:04:05Z07:00"))
 	if pgbUpload != "" {
 		fmt.Printf("  uploaded   : %d files → %s\n", uploaded, pgbUpload)

--- a/cmd/bintrail-pg/baseline.go
+++ b/cmd/bintrail-pg/baseline.go
@@ -21,14 +21,18 @@ one Parquet file per table (the PostgreSQL sibling of 'bintrail baseline' —
 no mydumper/pg_dump step; tables are COPYed inside one REPEATABLE READ
 transaction directly into Parquet).
 
-The snapshot is anchored to the WAL: pg_current_wal_lsn() is captured in the
-same statement that establishes the MVCC snapshot and embedded in each Parquet
-file's metadata, so reconstruct can apply the indexed deltas that start
-strictly after it. The replication slot (--slot) is ensured to exist BEFORE
-the snapshot opens — if it does not exist and --repl-dsn is given, it is
-created (the same slot 'bintrail-pg stream' will consume); without --repl-dsn
-a missing slot is a fatal error, because a baseline without a slot has no
-delta stream to anchor.
+The snapshot is anchored to the WAL: the replication slot's own
+confirmed_flush_lsn/restart_lsn is read just before the snapshot transaction
+opens and embedded in each Parquet file's metadata as the delta-replay floor,
+so reconstruct can apply the indexed deltas at or after it (#771 — not
+pg_current_wal_lsn(), and not a strictly-after cutoff: the slot floor is
+always at or before the snapshot's own live LSN, and any resulting overlap
+with rows already in the baseline is harmless because the merge is
+last-write-wins over full-row images). The replication slot (--slot) is
+ensured to exist BEFORE the snapshot opens — if it does not exist and
+--repl-dsn is given, it is created (the same slot 'bintrail-pg stream' will
+consume); without --repl-dsn a missing slot is a fatal error, because a
+baseline without a slot has no delta stream to anchor.
 
 Values are stored as raw PostgreSQL text, matching the pgoutput rendering the
 delta path indexes — no type conversion.

--- a/internal/baseline/metadata.go
+++ b/internal/baseline/metadata.go
@@ -24,11 +24,28 @@ const (
 	MetaKeyBinlogPos      = "bintrail.baseline_binlog_position"
 	MetaKeyGTIDSet        = "bintrail.baseline_gtid_set"
 	MetaKeyCreateTableSQL = "bintrail.create_table_sql"
-	// MetaKeyLSN anchors a PostgreSQL-source baseline: the WAL LSN at which the
-	// snapshot is consistent (the slot's consistent_point), stored as the decimal
-	// string of the uint64 LSN. Deltas for the table start strictly after this
-	// point. Absent on MySQL/MariaDB baselines (which use the binlog file/pos/GTID
-	// keys above) and on PG baselines taken before #593 slice A. Part of #593.
+	// MetaKeyLSN anchors a PostgreSQL-source baseline: a WAL LSN floor, stored as
+	// the decimal string of the uint64 LSN, such that deltas replayed AT OR AFTER
+	// this point reconstruct the table's state after the snapshot correctly.
+	//
+	// This is the replication slot's confirmed_flush_lsn/restart_lsn as of just
+	// before the snapshot transaction opened (pgcapture.SlotFloorLSN) — NOT the
+	// live pg_current_wal_lsn() read when the snapshot was taken (#771). The two
+	// can differ: a transaction committing concurrently with the snapshot can
+	// flush its commit WAL record at or before that live LSN while still being
+	// invisible to the snapshot's MVCC view (WAL flush happens before the
+	// transaction is removed from the procarray), so anchoring the delta window
+	// on the live LSN with a strict "after" comparison can silently exclude that
+	// transaction from BOTH the baseline and the deltas. The slot floor is always
+	// <= the live LSN (read earlier, before the snapshot began), so replaying
+	// from it never misses that transaction; any resulting overlap with rows
+	// already in the baseline is harmless because the merge is last-write-wins
+	// over full-row images. Consumers should therefore treat this value as an
+	// INCLUSIVE lower bound ("at or after"), not an exclusive one.
+	//
+	// Absent on MySQL/MariaDB baselines (which use the binlog file/pos/GTID keys
+	// above) and on PG baselines taken before #593 slice A. Part of #593; the
+	// floor-vs-live-LSN correction is #771.
 	MetaKeyLSN = "bintrail.baseline_lsn"
 	// MetaKeyRowCount and MetaKeyContentDigest record, per table, how many rows
 	// the baseline ingested and an order-independent content fingerprint of them
@@ -60,7 +77,7 @@ type DumpMetadata struct {
 	CreateTableSQL string // raw mydumper -schema.sql bytes; set for baselines written after #187
 	ContentDigest  string // version-tagged content fingerprint; set after #633, empty when absent (old baselines)
 	RowCount       int64  // rows ingested into this table's baseline; valid only when ContentDigest != ""
-	LSN            uint64 // PostgreSQL WAL LSN anchor (MetaKeyLSN); 0 = absent (MySQL baseline, or pre-#593 PG baseline)
+	LSN            uint64 // PostgreSQL WAL LSN delta-replay floor, inclusive (MetaKeyLSN, see its doc comment / #771); 0 = absent (MySQL baseline, or pre-#593 PG baseline)
 }
 
 // StartedAtMarkerFile is a bintrail-authored sidecar written into the mydumper

--- a/internal/cli/reconstruct.go
+++ b/internal/cli/reconstruct.go
@@ -334,11 +334,18 @@ func runReconstruct(cmd *cobra.Command, args []string) error {
 
 	// Warn if there is a gap between the baseline position and the first indexed
 	// event — events in that gap are missing from the reconstruction. The
-	// comparable anchor is flavor-dependent (#593): PostgreSQL baselines anchor
-	// on the numeric WAL LSN (baseline.MetaKeyLSN); MySQL/MariaDB on binlog
-	// file+pos. PG LSN TEXT ("0/1A2B3C4") is NOT lexically ordered, so the
-	// binlog_file column must never be compared for a PG source — see
-	// reconstruct.GapDetected and resolveGapCheck.
+	// comparable anchor is flavor-dependent (#593): PostgreSQL baselines carry
+	// the numeric WAL LSN delta-replay floor (baseline.MetaKeyLSN — an
+	// INCLUSIVE lower bound, corrected by #771 to be the replication slot's
+	// own confirmed_flush_lsn/restart_lsn rather than the snapshot's live
+	// pg_current_wal_lsn(); see MetaKeyLSN's doc comment); MySQL/MariaDB on
+	// binlog file+pos. PG LSN TEXT ("0/1A2B3C4") is NOT lexically ordered, so
+	// the binlog_file column must never be compared for a PG source — see
+	// reconstruct.GapDetected and resolveGapCheck. NOTE: PG full-table/single-
+	// row reconstruct is not yet un-gated for Postgres sources (#593 slice D) —
+	// this gap check runs generically here but the PG merge path itself is not
+	// wired; whoever builds slice D must honor "replay at/after the floor", not
+	// "strictly after the snapshot's live LSN".
 	if len(events) > 0 {
 		first := events[0]
 		flavor, lineageGuard, anchorPresent, eventPosMissing := resolveGapCheck(

--- a/internal/pgbaseline/pgbaseline.go
+++ b/internal/pgbaseline/pgbaseline.go
@@ -11,13 +11,18 @@
 // The dependency points the other way: pgbaseline imports internal/baseline
 // for the Writer, markers, and metadata keys.
 //
-// Anchoring: the output embeds baseline.MetaKeyLSN — pg_current_wal_lsn()
-// captured in the SAME statement that establishes the MVCC snapshot — so
-// deltas strictly after that LSN, applied by reconstruct, yield the table
-// state at any later time. The replication slot is ensured to exist BEFORE
-// the snapshot opens (ordering invariant: slot consistent_point ≤ anchor LSN);
-// the overlap is redelivered and is harmless because reconstruct's merge is
-// last-write-wins idempotent.
+// Anchoring: the output embeds baseline.MetaKeyLSN — a delta-replay FLOOR
+// (pgcapture.SlotFloorLSN: the replication slot's confirmed_flush_lsn/
+// restart_lsn, read BEFORE the snapshot transaction opens) — so deltas AT OR
+// AFTER that LSN, applied by reconstruct, yield the table state at any later
+// time (#771: the corrected contract is "from the floor forward", NOT
+// "strictly after the live pg_current_wal_lsn() anchor" — see Stats.AnchorLSN
+// and the snapshot-anchor comment below for why the live LSN alone cannot be
+// the cutoff). The replication slot is ensured to exist BEFORE the snapshot
+// opens (ordering invariant: the floor LSN, read at that point, is ≤ every
+// LSN read afterwards on the same connection, in particular the anchor LSN);
+// any resulting overlap is redelivered and is harmless because reconstruct's
+// merge is last-write-wins idempotent over full-row images.
 //
 // Values are stored as raw PostgreSQL text (Column.RawText — COPY text output,
 // unescaped): identical to the pgoutput text rendering the delta path indexes,
@@ -87,9 +92,24 @@ type Stats struct {
 	TablesProcessed int
 	RowsWritten     int64
 	FilesWritten    int
-	AnchorLSN       uint64    // pg_current_wal_lsn() at snapshot establishment
-	SnapshotTime    time.Time // DB now() at snapshot establishment (UTC)
-	SlotCreated     bool      // true when this run created the replication slot
+	// AnchorLSN is pg_current_wal_lsn() at snapshot establishment — informational
+	// only (roughly "where the snapshot's visible data sits in the WAL timeline").
+	// It is NOT the delta-replay cutoff (#771): a transaction committing
+	// concurrently with the snapshot can flush its commit record at or before
+	// this LSN while still being invisible to the snapshot's MVCC view, so using
+	// AnchorLSN as "deltas start strictly after here" can silently drop that
+	// transaction from both the baseline and the delta window. Use DeltaStartLSN
+	// (also embedded in the Parquet metadata as baseline.MetaKeyLSN) instead.
+	AnchorLSN uint64
+	// DeltaStartLSN is the safe floor for delta replay: the replication slot's
+	// confirmed_flush_lsn/restart_lsn (pgcapture.SlotFloorLSN), read BEFORE the
+	// snapshot transaction opened. It is always <= AnchorLSN. A consumer should
+	// replay deltas at or after DeltaStartLSN, not strictly after AnchorLSN;
+	// any overlap with data already in the baseline is harmless because the
+	// baseline+delta merge is last-write-wins over full-row images.
+	DeltaStartLSN uint64
+	SnapshotTime  time.Time // DB now() at snapshot establishment (UTC)
+	SlotCreated   bool      // true when this run created the replication slot
 }
 
 // Run takes a consistent baseline snapshot of every table the publication
@@ -138,9 +158,29 @@ func Run(ctx context.Context, cfg Config) (Stats, error) {
 		logger.Info("pgbaseline: created replication slot", "slot", cfg.SlotName)
 	}
 
+	// Read the delta-replay floor (#771) BEFORE opening the snapshot
+	// transaction: pgcapture.SlotFloorLSN reports the slot's own
+	// confirmed_flush_lsn/restart_lsn, which only ever advances past
+	// transactions already fully resolved in WAL order. Reading it here, on
+	// this same connection before BEGIN, guarantees it is <= every LSN read
+	// afterwards (including the anchor below) — the invariant that makes
+	// "replay deltas from this floor" safe regardless of the snapshot-vs-
+	// concurrent-commit race described on SlotFloorLSN.
+	floorLSN, err := pgcapture.SlotFloorLSN(ctx, conn, cfg.SlotName)
+	if err != nil {
+		return Stats{}, err
+	}
+
 	// Open the snapshot transaction. The FIRST statement both establishes the
 	// REPEATABLE READ MVCC snapshot and reads the WAL anchor + snapshot time,
-	// so (anchorLSN, snapshotTime, visible data) are fixed atomically.
+	// so (anchorLSN, snapshotTime, visible data) are fixed together — but
+	// anchorLSN is NOT the delta-replay cutoff (#771, see Stats.AnchorLSN):
+	// a transaction can flush its commit record at or before this LSN while
+	// still being invisible to this snapshot (WAL-flush happens before the
+	// transaction is removed from the procarray), so treating "strictly after
+	// anchorLSN" as the delta window can silently drop it from both the
+	// baseline AND the deltas. floorLSN (above), not anchorLSN, is what gets
+	// embedded as the delta-replay cutoff.
 	if _, err := conn.Exec(ctx, "BEGIN ISOLATION LEVEL REPEATABLE READ, READ ONLY"); err != nil {
 		return Stats{}, fmt.Errorf("pgbaseline: begin snapshot transaction: %w", err)
 	}
@@ -161,6 +201,18 @@ func Run(ctx context.Context, cfg Config) (Stats, error) {
 	snapshotTime = snapshotTime.UTC()
 	if testHookAfterSnapshot != nil {
 		testHookAfterSnapshot()
+	}
+
+	// deltaStartLSN is what actually gets embedded as the replay cutoff.
+	// floorLSN <= anchorLSN by construction (read earlier on the same
+	// connection); this clamp is defense in depth only — it must never
+	// trigger — so a violated assumption can never make the embedded
+	// metadata claim a LATER delta start than the snapshot boundary itself.
+	deltaStartLSN := floorLSN
+	if deltaStartLSN > anchorLSN {
+		logger.Warn("pgbaseline: slot floor LSN exceeded the snapshot anchor LSN (unexpected — clamping)",
+			"floor_lsn", uint64(floorLSN), "anchor_lsn", uint64(anchorLSN))
+		deltaStartLSN = anchorLSN
 	}
 
 	// Discovery + column resolution run INSIDE the snapshot transaction, so
@@ -226,7 +278,7 @@ func Run(ctx context.Context, cfg Config) (Stats, error) {
 		return Stats{}, fmt.Errorf("pgbaseline: could not write incomplete-snapshot marker in %s (refusing to copy without the crash-safety marker): %w", snapDir, err)
 	}
 
-	stats := Stats{AnchorLSN: uint64(anchorLSN), SnapshotTime: snapshotTime, SlotCreated: created}
+	stats := Stats{AnchorLSN: uint64(anchorLSN), DeltaStartLSN: uint64(deltaStartLSN), SnapshotTime: snapshotTime, SlotCreated: created}
 
 	var (
 		mu   sync.Mutex
@@ -274,7 +326,7 @@ func Run(ctx context.Context, cfg Config) (Stats, error) {
 				if ctx.Err() != nil {
 					return
 				}
-				n, err := processTable(ctx, wconn, t, cfg.OutputDir, tsDir, tsStr, uint64(anchorLSN), compression, rowGroupSize, logger)
+				n, err := processTable(ctx, wconn, t, cfg.OutputDir, tsDir, tsStr, uint64(deltaStartLSN), compression, rowGroupSize, logger)
 				mu.Lock()
 				if err != nil {
 					logger.Error("pgbaseline: failed to process table",
@@ -344,7 +396,7 @@ func openWorkerConn(ctx context.Context, dsn, snapshotID string) (*pgx.Conn, err
 // would CRC-certify a stale or partial Parquet (possibly carrying another
 // anchor's MetaKeyLSN) into a _SUCCESS baseline. The CLI's --retry applies
 // only to baseline.Upload's S3 object skip, which keys on real object state.
-func processTable(ctx context.Context, conn *pgx.Conn, t tableInfo, outputDir, tsDir, tsStr string, anchorLSN uint64, compression string, rowGroupSize int, logger *slog.Logger) (int64, error) {
+func processTable(ctx context.Context, conn *pgx.Conn, t tableInfo, outputDir, tsDir, tsStr string, deltaStartLSN uint64, compression string, rowGroupSize int, logger *slog.Logger) (int64, error) {
 	outPath := filepath.Join(outputDir, tsDir, t.Schema, t.Table+".parquet")
 
 	md := map[string]string{
@@ -352,10 +404,18 @@ func processTable(ctx context.Context, conn *pgx.Conn, t tableInfo, outputDir, t
 		"bintrail.source_database":    t.Schema,
 		"bintrail.source_table":       t.Table,
 		"bintrail.bintrail_version":   baseline.Version,
-		// The LSN anchor (#593 slice A): deltas for this table start strictly
-		// after this point. MetaKeyCreateTableSQL is deliberately absent — it
-		// exists for full-table mydumper reconstruct, out of scope for PG.
-		baseline.MetaKeyLSN: strconv.FormatUint(anchorLSN, 10),
+		// The LSN delta-replay floor (#593 slice A, corrected by #771): deltas
+		// for this table replay from AT OR AFTER this point — the slot's own
+		// confirmed_flush_lsn/restart_lsn (pgcapture.SlotFloorLSN), NOT the
+		// live pg_current_wal_lsn() read when the snapshot was taken (that
+		// live LSN can be at-or-after a concurrently-committing transaction's
+		// commit record while the transaction is still invisible to the
+		// snapshot — see Stats.AnchorLSN). Any overlap this floor introduces
+		// with rows already in the baseline is harmless: the merge is
+		// last-write-wins over full-row images. MetaKeyCreateTableSQL is
+		// deliberately absent — it exists for full-table mydumper
+		// reconstruct, out of scope for PG.
+		baseline.MetaKeyLSN: strconv.FormatUint(deltaStartLSN, 10),
 	}
 
 	cols := make([]baseline.Column, len(t.Columns))

--- a/internal/pgbaseline/pgbaseline_integration_test.go
+++ b/internal/pgbaseline/pgbaseline_integration_test.go
@@ -128,6 +128,15 @@ func TestPGBaseline_Integration(t *testing.T) {
 	if stats.AnchorLSN == 0 {
 		t.Error("stats.AnchorLSN = 0, want a real LSN")
 	}
+	// #771: DeltaStartLSN is the corrected, safe delta-replay floor (the
+	// slot's own confirmed_flush_lsn/restart_lsn, read before the snapshot
+	// began) and must never exceed the live snapshot anchor.
+	if stats.DeltaStartLSN == 0 {
+		t.Error("stats.DeltaStartLSN = 0, want a real LSN")
+	}
+	if stats.DeltaStartLSN > stats.AnchorLSN {
+		t.Errorf("stats.DeltaStartLSN %d > stats.AnchorLSN %d — safety invariant violated", stats.DeltaStartLSN, stats.AnchorLSN)
+	}
 
 	// ── Snapshot directory, markers, manifest ──
 	entries, err := os.ReadDir(outDir)
@@ -150,19 +159,22 @@ func TestPGBaseline_Integration(t *testing.T) {
 		}
 	}
 
-	// ── MetaKeyLSN: present, equals Stats.AnchorLSN, ≤ current WAL ──
+	// ── MetaKeyLSN: present, equals Stats.DeltaStartLSN (#771 — NOT
+	// Stats.AnchorLSN; they only coincide here because nothing else wrote WAL
+	// between slot creation and the snapshot anchor in this first run), ≤
+	// current WAL ──
 	pathA := filepath.Join(snapDir, "public", itTblA+".parquet")
 	md := readParquetMetadata(t, pathA)
 	lsnStr, ok := md[baseline.MetaKeyLSN]
 	if !ok {
 		t.Fatalf("MetaKeyLSN absent from %s metadata (%v)", pathA, md)
 	}
-	anchor, err := strconv.ParseUint(lsnStr, 10, 64)
+	embeddedLSN, err := strconv.ParseUint(lsnStr, 10, 64)
 	if err != nil {
 		t.Fatalf("MetaKeyLSN %q is not a decimal uint64: %v", lsnStr, err)
 	}
-	if anchor != stats.AnchorLSN {
-		t.Errorf("MetaKeyLSN %d != Stats.AnchorLSN %d", anchor, stats.AnchorLSN)
+	if embeddedLSN != stats.DeltaStartLSN {
+		t.Errorf("MetaKeyLSN %d != Stats.DeltaStartLSN %d", embeddedLSN, stats.DeltaStartLSN)
 	}
 	var curLSNText string
 	if err := setup.QueryRow(ctx, "SELECT pg_current_wal_lsn()::text").Scan(&curLSNText); err != nil {
@@ -172,8 +184,8 @@ func TestPGBaseline_Integration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse current LSN: %v", err)
 	}
-	if anchor > uint64(curLSN) {
-		t.Errorf("anchor LSN %d > current WAL LSN %d", anchor, uint64(curLSN))
+	if embeddedLSN > uint64(curLSN) {
+		t.Errorf("embedded delta-floor LSN %d > current WAL LSN %d", embeddedLSN, uint64(curLSN))
 	}
 	if md["bintrail.source_database"] != "public" || md["bintrail.source_table"] != itTblA {
 		t.Errorf("source metadata wrong: %v", md)
@@ -182,10 +194,12 @@ func TestPGBaseline_Integration(t *testing.T) {
 		t.Error("MetaKeyCreateTableSQL present — must be omitted for PG baselines")
 	}
 
-	// ── Ordering invariant: slot exists, confirmed_flush_lsn ≤ anchor ──
-	// The slot was created BEFORE the snapshot transaction, so its consistent
-	// point (= confirmed_flush_lsn on a fresh, never-acked slot) cannot be
-	// past the anchor; the overlap is redelivered and merged idempotently.
+	// ── Ordering invariant: slot exists, confirmed_flush_lsn ≤ embedded floor
+	// ≤ anchor ── The slot was created BEFORE the snapshot transaction, so its
+	// consistent point (= confirmed_flush_lsn on a fresh, never-acked slot)
+	// cannot be past the anchor; the overlap is redelivered and merged
+	// idempotently. Re-reading confirmed_flush_lsn here (nothing has consumed
+	// the slot since Run) should match what got embedded.
 	var flushText string
 	if err := setup.QueryRow(ctx, "SELECT confirmed_flush_lsn::text FROM pg_replication_slots WHERE slot_name=$1", itSlot).Scan(&flushText); err != nil {
 		t.Fatalf("slot %s missing or unreadable after Run: %v", itSlot, err)
@@ -194,8 +208,8 @@ func TestPGBaseline_Integration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse confirmed_flush_lsn %q: %v", flushText, err)
 	}
-	if uint64(flush) > anchor {
-		t.Errorf("ORDERING INVARIANT VIOLATED: slot confirmed_flush_lsn %d > baseline anchor %d — deltas between them would be lost", uint64(flush), anchor)
+	if uint64(flush) != embeddedLSN {
+		t.Errorf("slot confirmed_flush_lsn %d != embedded delta-floor LSN %d (slot untouched since Run)", uint64(flush), embeddedLSN)
 	}
 
 	// ── Table A contents: TOAST value complete, escapes + multibyte intact ──
@@ -282,6 +296,44 @@ func TestPGBaseline_Integration(t *testing.T) {
 	b3v2 := rowByCol(t, rowsB2, "id", "3")
 	if got := b3v2["v"]; got == nil || *got != "updated" {
 		t.Errorf("re-baseline table B row 3 v = %v, want %q", strOrNull(got), "updated")
+	}
+
+	// ── #771 pin: the slot was never consumed (no StartReplication) between
+	// the two runs, so its floor cannot have moved even though the UPDATE
+	// above committed and durably advanced the live WAL anchor in between.
+	// This reproduces, deterministically, the exact shape of gap the bug
+	// left open: a value the LIVE anchor alone cannot distinguish from "no
+	// concurrent activity", but the slot floor correctly reflects. ──
+	if stats2.DeltaStartLSN > stats2.AnchorLSN {
+		t.Errorf("re-baseline DeltaStartLSN %d > AnchorLSN %d — safety invariant violated", stats2.DeltaStartLSN, stats2.AnchorLSN)
+	}
+	if stats2.DeltaStartLSN != stats.DeltaStartLSN {
+		t.Errorf("re-baseline DeltaStartLSN %d != first-run DeltaStartLSN %d — the slot floor must not move when nothing consumed it", stats2.DeltaStartLSN, stats.DeltaStartLSN)
+	}
+	md2 := readParquetMetadata(t, filepath.Join(snapDir2, "public", itTblB+".parquet"))
+	lsnStr2, ok := md2[baseline.MetaKeyLSN]
+	if !ok {
+		t.Fatalf("re-baseline MetaKeyLSN absent (%v)", md2)
+	}
+	embeddedLSN2, err := strconv.ParseUint(lsnStr2, 10, 64)
+	if err != nil {
+		t.Fatalf("re-baseline MetaKeyLSN %q is not a decimal uint64: %v", lsnStr2, err)
+	}
+	if embeddedLSN2 != stats2.DeltaStartLSN {
+		t.Errorf("re-baseline embedded MetaKeyLSN %d != Stats.DeltaStartLSN %d", embeddedLSN2, stats2.DeltaStartLSN)
+	}
+	// THE core #771 regression pin: pre-fix, this metadata held AnchorLSN —
+	// which, in this exact scenario (a commit lands between slot creation and
+	// the second run's live anchor read with the slot never consumed), would
+	// equal stats2.AnchorLSN and sit STRICTLY ABOVE the marker UPDATE's commit
+	// LSN once accounting for the invisible-commit race #771 describes,
+	// silently excluding a concurrently-committing transaction from the delta
+	// window. The corrected embedded value must be the smaller, safe slot
+	// floor — strictly below the live anchor here, since the UPDATE
+	// committed (and advanced the live WAL position) after the slot was
+	// created and with the slot never consumed since.
+	if embeddedLSN2 >= stats2.AnchorLSN {
+		t.Errorf("re-baseline embedded delta floor %d >= live anchor %d — want strictly less (an UPDATE committed between slot creation and this run's anchor read, with the slot never consumed)", embeddedLSN2, stats2.AnchorLSN)
 	}
 }
 

--- a/internal/pgcapture/slot.go
+++ b/internal/pgcapture/slot.go
@@ -495,6 +495,62 @@ func EnsureSlotExists(ctx context.Context, queryConn *pgx.Conn, slotName string,
 	return true, nil
 }
 
+// SlotFloorLSN returns a safe lower bound for replaying this slot's changes as
+// deltas on top of a baseline snapshot — the fix for #771.
+//
+// It is deliberately NOT pg_current_wal_lsn() (a live read of "now"). Reading
+// pg_current_wal_lsn() inside the baseline's snapshot transaction does not
+// close the race between a concurrent transaction's WAL commit-record flush
+// and its later removal from the procarray (the moment it becomes visible to
+// new snapshots): a transaction can flush its commit record, and only
+// afterwards be removed from the procarray, so a snapshot taken in that
+// window correctly treats it as invisible while a same-transaction LSN read
+// moments later can already be >= its commit LSN. Anchoring "deltas start
+// here" on that live LSN can therefore silently exclude a transaction from
+// BOTH the baseline (correctly, per MVCC) AND the delta window (incorrectly).
+//
+// SlotFloorLSN instead reports the slot's own confirmed_flush_lsn (falling
+// back to restart_lsn when confirmed_flush_lsn is unset — a brand new slot
+// that has never streamed) — call it BEFORE the caller's snapshot
+// transaction begins. Logical decoding only advances these positions past
+// transactions it has already resolved in full WAL order, so no transaction
+// concurrent with (or later than) the caller's snapshot can have a commit
+// LSN below what this returns; the value is therefore always <= any LSN read
+// afterwards on the same connection (LSNs are monotonically non-decreasing),
+// including the caller's own live pg_current_wal_lsn() anchor. Replaying
+// deltas from this floor forward — rather than from the live anchor — may
+// redeliver some already-visible-in-the-baseline changes; that overlap is
+// harmless because the baseline+delta merge is last-write-wins over
+// full-row images (same idempotency EnsureSlotExists's ordering invariant
+// already relies on).
+func SlotFloorLSN(ctx context.Context, conn *pgx.Conn, slotName string) (pglogrepl.LSN, error) {
+	var restartText, confirmedText *string
+	err := conn.QueryRow(ctx, `
+		SELECT restart_lsn::text, confirmed_flush_lsn::text
+		FROM pg_replication_slots WHERE slot_name = $1`, slotName).
+		Scan(&restartText, &confirmedText)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return 0, fmt.Errorf("pgcapture: replication slot %q not found while reading its floor LSN", slotName)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("pgcapture: reading floor LSN for replication slot %q: %w", slotName, err)
+	}
+	var text string
+	switch {
+	case confirmedText != nil && *confirmedText != "":
+		text = *confirmedText
+	case restartText != nil && *restartText != "":
+		text = *restartText
+	default:
+		return 0, fmt.Errorf("pgcapture: replication slot %q has neither confirmed_flush_lsn nor restart_lsn set — cannot compute a safe delta floor", slotName)
+	}
+	lsn, err := pglogrepl.ParseLSN(text)
+	if err != nil {
+		return 0, fmt.Errorf("pgcapture: parsing floor LSN %q for replication slot %q: %w", text, slotName, err)
+	}
+	return lsn, nil
+}
+
 // queryScopedSlotState is querySlotState with slot IDENTITY checks: it reports
 // existence and wal_status only for a LOGICAL pgoutput slot belonging to the
 // CURRENT database. A same-named slot of any other kind is a loud, actionable

--- a/internal/pgcapture/slotfloor_integration_test.go
+++ b/internal/pgcapture/slotfloor_integration_test.go
@@ -1,0 +1,113 @@
+//go:build integration
+
+package pgcapture_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pglogrepl"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/dbtrail/dbtrail/internal/pgcapture"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestSlotFloorLSN_Integration pins the #771 fix's core value contract:
+// SlotFloorLSN reports a floor that (a) matches the slot's own
+// confirmed_flush_lsn, (b) does NOT move when the slot is never consumed
+// even though unrelated WAL activity advances pg_current_wal_lsn(), and
+// (c) stays <= any later live LSN read on the same connection — the
+// invariant pgbaseline.Run leans on to make "replay deltas from this floor
+// forward" safe regardless of the snapshot-vs-concurrent-commit race
+// described on SlotFloorLSN's doc comment.
+func TestSlotFloorLSN_Integration(t *testing.T) {
+	baseDSN := testutil.SkipIfNoPostgres(t)
+	ctx := context.Background()
+
+	const slot = "bintrail_pgcap_it_slotfloor_issue_771"
+	const tbl = "pgcap_it_slotfloor_issue_771"
+
+	conn, err := pgx.Connect(ctx, baseDSN)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { conn.Close(context.Background()) })
+	drop := func() {
+		bg := context.Background()
+		_, _ = conn.Exec(bg, "DROP TABLE IF EXISTS "+tbl)
+		_, _ = conn.Exec(bg, "SELECT pg_drop_replication_slot($1) WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name=$1)", slot)
+	}
+	drop()
+	t.Cleanup(drop)
+
+	if _, err := conn.Exec(ctx, "CREATE TABLE "+tbl+" (id int PRIMARY KEY)"); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+
+	// Missing slot: actionable error, not a zero value.
+	if _, err := pgcapture.SlotFloorLSN(ctx, conn, slot); err == nil {
+		t.Fatal("SlotFloorLSN on a missing slot succeeded, want an error")
+	}
+
+	replConnect := func(ctx context.Context) (*pgconn.PgConn, error) {
+		return pgconn.Connect(ctx, replDSN(baseDSN))
+	}
+	if _, err := pgcapture.EnsureSlotExists(ctx, conn, slot, replConnect); err != nil {
+		t.Fatalf("EnsureSlotExists: %v", err)
+	}
+
+	floor1, err := pgcapture.SlotFloorLSN(ctx, conn, slot)
+	if err != nil {
+		t.Fatalf("SlotFloorLSN (fresh slot): %v", err)
+	}
+	if floor1 == 0 {
+		t.Error("SlotFloorLSN on a freshly created slot = 0, want a real LSN")
+	}
+
+	// The fresh slot's floor must equal its own confirmed_flush_lsn (verified
+	// independently of SlotFloorLSN's internal query).
+	var flushText string
+	if err := conn.QueryRow(ctx, "SELECT confirmed_flush_lsn::text FROM pg_replication_slots WHERE slot_name=$1", slot).Scan(&flushText); err != nil {
+		t.Fatalf("read confirmed_flush_lsn: %v", err)
+	}
+	flush, err := pglogrepl.ParseLSN(flushText)
+	if err != nil {
+		t.Fatalf("parse confirmed_flush_lsn %q: %v", flushText, err)
+	}
+	if floor1 != flush {
+		t.Errorf("SlotFloorLSN = %d, want confirmed_flush_lsn %d", uint64(floor1), uint64(flush))
+	}
+
+	// Unrelated WAL activity (no consumer ever reads from the slot) must
+	// advance pg_current_wal_lsn() while leaving the slot's floor untouched —
+	// this is the exact gap the #771 fix relies on: a live "now" LSN and the
+	// slot's own floor are NOT the same thing, and can diverge arbitrarily.
+	if _, err := conn.Exec(ctx, "INSERT INTO "+tbl+" VALUES (1), (2), (3)"); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	var curText string
+	if err := conn.QueryRow(ctx, "SELECT pg_current_wal_lsn()::text").Scan(&curText); err != nil {
+		t.Fatalf("pg_current_wal_lsn: %v", err)
+	}
+	cur, err := pglogrepl.ParseLSN(curText)
+	if err != nil {
+		t.Fatalf("parse current LSN %q: %v", curText, err)
+	}
+	if uint64(cur) <= uint64(floor1) {
+		t.Fatalf("test setup: current WAL LSN %d did not advance past the slot floor %d after committing inserts", uint64(cur), uint64(floor1))
+	}
+
+	floor2, err := pgcapture.SlotFloorLSN(ctx, conn, slot)
+	if err != nil {
+		t.Fatalf("SlotFloorLSN (after unrelated writes): %v", err)
+	}
+	if floor2 != floor1 {
+		t.Errorf("SlotFloorLSN moved from %d to %d after unrelated WAL activity with no slot consumption — the floor must stay fixed until something actually consumes the slot", uint64(floor1), uint64(floor2))
+	}
+	if uint64(floor2) > uint64(cur) {
+		t.Errorf("SlotFloorLSN %d > live pg_current_wal_lsn() %d — safety invariant violated", uint64(floor2), uint64(cur))
+	}
+}

--- a/internal/reconstruct/gap.go
+++ b/internal/reconstruct/gap.go
@@ -13,15 +13,24 @@ package reconstruct
 // TEXT form ("0/1A2B3C4"), which is NOT lexically ordered ("0/10" < "0/9"
 // lexically but not numerically), so the comparison must use the numeric LSN
 // that PG events carry in StartPos (internal/pgcapture rowEvent) against the
-// baseline's numeric anchor (baseline.MetaKeyLSN). baselineLSN == 0 means the
-// baseline predates the LSN anchor (#593 slice A) or is not a PG baseline at
-// all: the anchor is UNKNOWN, so no gap is flagged. That mirrors how this
-// path already treats missing coordinates — the caller's "baseline lacks
-// position metadata" branch skips detection with an informational message
-// rather than failing (and status's continuity verdict fails closed only
-// under an explicit --fail-on-gap) — and it can never silently produce wrong
-// data because this check only gates a WARNING, never the reconstruction
-// itself. Callers should log the skip (cli/reconstruct.go does).
+// baseline's numeric delta-replay floor (baseline.MetaKeyLSN — an INCLUSIVE
+// lower bound: the slot's confirmed_flush_lsn/restart_lsn as of just before
+// the snapshot, not the snapshot's own live pg_current_wal_lsn(); see that
+// key's doc comment and #771). baselineLSN == 0 means the baseline predates
+// the LSN floor (#593 slice A) or is not a PG baseline at all: the floor is
+// UNKNOWN, so no gap is flagged. That mirrors how this path already treats
+// missing coordinates — the caller's "baseline lacks position metadata"
+// branch skips detection with an informational message rather than failing
+// (and status's continuity verdict fails closed only under an explicit
+// --fail-on-gap) — and it can never silently produce wrong data because this
+// check only gates a WARNING, never the reconstruction itself. Callers should
+// log the skip (cli/reconstruct.go does).
+//
+// The strict "eventStartPos > baselineLSN" comparison below is unchanged by
+// #771: a baseline floor is a value below which no coverage gap can exist by
+// construction (deltas are read from at-or-after it), so "no gap" already
+// means eventStartPos <= baselineLSN — the same comparison as when this
+// value was (incorrectly) the live anchor.
 //
 // Any other flavor (MySQL, MariaDB, ""): the established two-key binlog
 // compare — file names ordered lexically (equal to numeric order for MySQL's


### PR DESCRIPTION
closes #771

## Summary

`internal/pgbaseline.Run` anchored its delta-replay cutoff on
`pg_current_wal_lsn()` read inside the baseline's own snapshot
transaction. That live LSN does not close the race described in #771: a
transaction committing concurrently with the snapshot can flush its
commit WAL record — advancing `pg_current_wal_lsn()` — before it is
removed from the procarray (the moment it becomes visible to new MVCC
snapshots). A snapshot taken in that narrow window correctly treats the
transaction as invisible (so it's absent from the baseline) while a
live-LSN read moments later can already be at-or-past that commit's
LSN — so the old "deltas strictly after the anchor" contract could
silently exclude the transaction from **both** the baseline and the
delta window.

This closes the practical race by anchoring on the replication slot's
own decode progress instead of a live "now" reading:

- New `pgcapture.SlotFloorLSN(ctx, conn, slotName)` reads the slot's
  `confirmed_flush_lsn` (falling back to `restart_lsn` for a slot that
  has never streamed), called **before** the baseline's snapshot
  transaction opens. Logical decoding only advances these positions
  past transactions already fully resolved in WAL order, so this floor
  can never be ahead of a transaction that is concurrent with, or
  later than, the snapshot — closing the window described above (down
  to a sub-microsecond WAL-flush → procarray-removal gap that an async
  decoder cannot realistically outrace; see "Known residual" below).
- `pgbaseline.Run` now embeds `Stats.DeltaStartLSN` (this floor, read
  before `BEGIN`) as `baseline.MetaKeyLSN` — the actual replay
  cutoff — instead of `Stats.AnchorLSN` (kept as informational-only:
  "where the snapshot's visible data sits in the WAL timeline").
  `DeltaStartLSN` is clamped to never exceed `AnchorLSN` as
  defense-in-depth (by construction it never should, since it's read
  strictly earlier on the same connection); a clamp trigger logs a
  warning.
- The contract is now an **inclusive** lower bound ("replay deltas at
  or after this LSN"), not the old exclusive "strictly after". Any
  redelivery overlap this introduces with rows already in the baseline
  is harmless: I verified directly against `internal/reconstruct`
  (`mergeBaselineImages`, `ApplyAt`) that the baseline+delta merge is
  last-write-wins over full-row images, including the leftover-DELETE-
  for-a-PK-absent-from-the-baseline skip path (a DELETE redelivered for
  a row the baseline already reflects as deleted is a correct no-op,
  not a spurious insert).
- Doc comments updated everywhere the old "deltas strictly after
  anchor" contract was asserted: `MetaKeyLSN`, `DumpMetadata.LSN`,
  `internal/cli/reconstruct.go`'s gap-check comment,
  `internal/reconstruct/gap.go`'s `GapDetected` doc comment, and the
  `bintrail-pg baseline` CLI output.

### Known residual (not closed by this PR)

The floor read shrinks the race from the full window the issue
described down to the sub-microsecond gap between a transaction's WAL
commit-record flush and its removal from the procarray — a window an
async logical decoder cannot realistically outrace in practice, but
not *provably* zero. The issue's alternative fix,
`CREATE_REPLICATION_SLOT ... USE_SNAPSHOT`, would tie the slot's
consistent point to the exact same snapshot the baseline COPYs from and
close this to zero. The issue author's write-up treats the floor
approach as an acceptable fix; flagging the residual here for the
record.

## WRITER-SIDE-ONLY — cannot be verified end-to-end yet

This fixes the **producer** side only (`bintrail-pg baseline` /
`internal/pgbaseline`). The Postgres delta-consuming side ("slice D" —
wiring `internal/reconstruct`'s baseline+delta merge to actually run
for a Postgres-sourced baseline) does not exist in this codebase yet
(`internal/cli/reconstruct.go` still gates PG sources out before the
merge path). So while the merge algorithm's last-write-wins/idempotent-
overlap property is verified by reading the shared merge code, the
full "baseline minted with `DeltaStartLSN` X, replay deltas from X
forward, get correct post-snapshot state" flow cannot be integration-
tested end-to-end until slice D exists.

## Rebase risk

**Correction (post-review):** #725 and #729 were believed open/unmerged
when this section was originally written, but both had already merged
to `main` on 2026-07-03 (`ed304a8`, `60b0784`) — before this branch was
even created. This branch is based on `main` at a point that already
includes both, so there is no pending rebase against them; the
paragraph below is left for history only and should be disregarded.

~~Both open, unmerged PRs below touch files this PR also touches — a
straight rebase is likely once either merges first:~~

- ~~**#725** — touches `internal/baseline/metadata.go`,
  `internal/cli/reconstruct.go`, `internal/reconstruct/gap.go` (all 3
  also touched here).~~
- ~~**#729** — touches `cmd/bintrail-pg/baseline.go`,
  `internal/pgbaseline/pgbaseline.go`,
  `internal/pgbaseline/pgbaseline_integration_test.go`,
  `internal/pgcapture/slot.go` (all 4 also touched here).~~

~~Every file this PR modifies overlaps with one of the two. Whoever
merges next should expect to resolve conflicts in the other.~~

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./... -count=1` — all packages pass (no build tag)
- [x] `go test -tags integration ./internal/pgbaseline/... ./internal/pgcapture/...` against a live PostgreSQL 16 container
      (`wal_level=logical`), targeted at the new/changed tests first
      (`TestPGBaseline_Integration`, `TestSlotFloorLSN_Integration`),
      then the full packages:
  - `internal/pgbaseline` — full package: **pass**
  - `internal/pgcapture` — full package: one **pre-existing, unrelated
    flake** (`TestCapturer_CompositePKOrder`, a slot-timing flake
    already tracked in this repo's history — composite-PK row-event
    collection timeout unrelated to LSN anchoring), confirmed to pass
    cleanly on immediate re-run and on a second full-package re-run.
    Not touched by this diff.
- [x] `go test -tags integration ./internal/reconstruct/... ./internal/cli/...` against the local MySQL test container — pass (sanity check on the doc/gap-check-comment-only changes in those packages).


