### PR TITLE
verify: defer spatial + VECTOR types to Inconclusive, not false-MISMATCH (#793)

### DIFF
--- a/internal/verify/deferred_test.go
+++ b/internal/verify/deferred_test.go
@@ -17,7 +17,13 @@ func TestIsDeferredType(t *testing.T) {
 	deferred := []string{
 		"enum", "set", "json",
 		"binary", "varbinary", "blob", "tinyblob", "mediumblob", "longblob", "bit",
-		"BLOB", "Enum", // case-insensitive
+		// #793: spatial family + VECTOR — binary (WKB / packed floats) in the
+		// event image, same base64-vs-raw gap as BLOB, so they must defer to
+		// Inconclusive rather than report a conclusive false-MISMATCH.
+		"geometry", "point", "linestring", "polygon",
+		"multipoint", "multilinestring", "multipolygon", "geometrycollection",
+		"vector",
+		"BLOB", "Enum", "GEOMETRY", // case-insensitive
 	}
 	for _, dt := range deferred {
 		if !isDeferredType(dt) {

--- a/internal/verify/deferred_test.go
+++ b/internal/verify/deferred_test.go
@@ -21,7 +21,8 @@ func TestIsDeferredType(t *testing.T) {
 		// event image, same base64-vs-raw gap as BLOB, so they must defer to
 		// Inconclusive rather than report a conclusive false-MISMATCH.
 		"geometry", "point", "linestring", "polygon",
-		"multipoint", "multilinestring", "multipolygon", "geometrycollection",
+		"multipoint", "multilinestring", "multipolygon",
+		"geometrycollection", "geomcollection", // MySQL 8.0.11+ reports the latter
 		"vector",
 		"BLOB", "Enum", "GEOMETRY", // case-insensitive
 	}

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -279,7 +279,9 @@ func hasDeferredRepr(cols []metadata.ColumnMeta) bool {
 // isDeferredType reports whether a column's event-image representation can differ
 // from how the baseline/source renders it in a way this version doesn't yet
 // normalize: ENUM/SET (ordinal vs label), JSON (MySQL-canonical text), binary
-// families (base64 in the event image vs raw bytes), BIT.
+// families (base64 in the event image vs raw bytes), BIT, and the spatial and
+// VECTOR types — whose values are binary (WKB / packed floats) in the event
+// image and so carry the same base64-vs-raw representation gap as BLOB (#793).
 //
 // TEXT is deliberately NOT here, despite being decoded by the same
 // DecodeEventBinaries call as BLOB (#672): once decoded, a TEXT value is just
@@ -294,7 +296,12 @@ func hasDeferredRepr(cols []metadata.ColumnMeta) bool {
 func isDeferredType(dataType string) bool {
 	switch strings.ToLower(dataType) {
 	case "enum", "set", "json",
-		"binary", "varbinary", "blob", "tinyblob", "mediumblob", "longblob", "bit":
+		"binary", "varbinary", "blob", "tinyblob", "mediumblob", "longblob", "bit",
+		// Spatial family (DATA_TYPE as reported by information_schema.COLUMNS)
+		// plus MySQL 9.0+ VECTOR: binary in the event image, no normalization yet.
+		"geometry", "point", "linestring", "polygon",
+		"multipoint", "multilinestring", "multipolygon", "geometrycollection",
+		"vector":
 		return true
 	}
 	return false

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -300,7 +300,10 @@ func isDeferredType(dataType string) bool {
 		// Spatial family (DATA_TYPE as reported by information_schema.COLUMNS)
 		// plus MySQL 9.0+ VECTOR: binary in the event image, no normalization yet.
 		"geometry", "point", "linestring", "polygon",
-		"multipoint", "multilinestring", "multipolygon", "geometrycollection",
+		"multipoint", "multilinestring", "multipolygon",
+		// MySQL 8.0.11+ (WL#2388) reports a GEOMETRYCOLLECTION column's DATA_TYPE
+		// as "geomcollection"; MariaDB and pre-8.0.11 report "geometrycollection".
+		"geometrycollection", "geomcollection",
 		"vector":
 		return true
 	}


### PR DESCRIPTION
## Problem
`verify` reports a **conclusive false-MISMATCH** on any table that touches — or merely carries — a spatial or `VECTOR` column. Their values are binary (WKB / packed floats) in the binlog event image, so they never match the baseline/source rendering — the same base64-vs-raw representation gap already handled for `BLOB`/`BINARY`/`BIT`. `isDeferredType` simply didn't list them.

## Fix (Occam-minimal, additive)
Add the spatial family (`geometry`/`point`/`linestring`/`polygon`/`multipoint`/`multilinestring`/`multipolygon`/`geometrycollection`) and MySQL 9.0+ `vector` to the existing `isDeferredType` switch. A false-MISMATCH becomes an honest **Inconclusive** — identical treatment to the binary/BIT entries beside it. No working path changes output.

## Test
Extended `TestIsDeferredType` to pin the new type names (+ a case-insensitive `GEOMETRY`). `go test ./internal/verify/` passes.

Closes #793

🤖 Generated with [Claude Code](https://claude.com/claude-code)
