### PR TITLE
doctor: honor ctx in source checks + flag binlog_row_value_options=PARTIAL_JSON (#813, #777)

### DIFF
--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -132,13 +132,14 @@ func Build(parent context.Context, sourceDSN, indexDSN, schemasCSV string, index
 	defer sourceDB.Close()
 
 	report.add(checkSourceConnection(ctx, sourceDB))
-	report.add(checkLogBin(sourceDB))
-	report.add(checkBinlogFormat(sourceDB))
-	report.add(checkBinlogRowImage(sourceDB))
-	report.add(checkBinlogRetention(sourceDB))
-	report.add(checkSyncBinlog(sourceDB))
-	report.add(checkStatementCapture(sourceDB))
-	report.add(checkRowMetadata(sourceDB))
+	report.add(checkLogBin(ctx, sourceDB))
+	report.add(checkBinlogFormat(ctx, sourceDB))
+	report.add(checkBinlogRowImage(ctx, sourceDB))
+	report.add(checkBinlogRetention(ctx, sourceDB))
+	report.add(checkSyncBinlog(ctx, sourceDB))
+	report.add(checkStatementCapture(ctx, sourceDB))
+	report.add(checkRowMetadata(ctx, sourceDB))
+	report.add(checkBinlogRowValueOptions(ctx, sourceDB))
 	report.add(checkReplicationGrants(ctx, sourceDB))
 	report.add(checkFKCascades(sourceDB, schemas))
 	report.add(checkSchemaVisibility(ctx, sourceDB, schemas))
@@ -198,9 +199,9 @@ func checkSourceConnection(ctx context.Context, db *sql.DB) CheckResult {
 	}
 }
 
-func checkLogBin(db *sql.DB) CheckResult {
+func checkLogBin(ctx context.Context, db *sql.DB) CheckResult {
 	var val string
-	err := db.QueryRow("SELECT @@log_bin").Scan(&val)
+	err := db.QueryRowContext(ctx, "SELECT @@log_bin").Scan(&val)
 	if err != nil {
 		return CheckResult{
 			Name:        "log_bin enabled",
@@ -224,8 +225,8 @@ func checkLogBin(db *sql.DB) CheckResult {
 	return CheckResult{Name: "log_bin enabled", Status: StatusPass, Detail: "ON"}
 }
 
-func checkBinlogFormat(db *sql.DB) CheckResult {
-	err := metadata.ValidateBinlogFormat(db)
+func checkBinlogFormat(ctx context.Context, db *sql.DB) CheckResult {
+	err := metadata.ValidateBinlogFormatContext(ctx, db)
 	if err != nil {
 		return CheckResult{
 			Name:   "binlog_format=ROW",
@@ -241,8 +242,8 @@ func checkBinlogFormat(db *sql.DB) CheckResult {
 	return CheckResult{Name: "binlog_format=ROW", Status: StatusPass, Detail: "ROW"}
 }
 
-func checkBinlogRowImage(db *sql.DB) CheckResult {
-	err := metadata.ValidateBinlogRowImage(db)
+func checkBinlogRowImage(ctx context.Context, db *sql.DB) CheckResult {
+	err := metadata.ValidateBinlogRowImageContext(ctx, db)
 	if err != nil {
 		return CheckResult{
 			Name:   "binlog_row_image=FULL",
@@ -260,17 +261,52 @@ func checkBinlogRowImage(db *sql.DB) CheckResult {
 	return CheckResult{Name: "binlog_row_image=FULL", Status: StatusPass, Detail: "FULL"}
 }
 
+// checkBinlogRowValueOptions warns when the source sets
+// binlog_row_value_options=PARTIAL_JSON. With that option MySQL logs partial
+// JSON updates (JSON_SET/JSON_REPLACE/JSON_REMOVE) as compact diff fragments in
+// the row image rather than the full column value; bintrail's parser cannot
+// apply those partial diffs and skips the affected JSON updates at runtime with
+// only a log warning — a silent capture gap for JSON columns (#777). Advisory
+// only (WARN, never FAIL): the option is harmless on sources with no
+// partially-updated JSON columns and is the operator's binlog-size tradeoff, but
+// they must know it can drop JSON updates. Absent variable (MySQL <8.0, MariaDB)
+// → SKIP; empty value (the default) → PASS.
+func checkBinlogRowValueOptions(ctx context.Context, db *sql.DB) CheckResult {
+	const name = "binlog_row_value_options (JSON capture)"
+	var val string
+	if err := db.QueryRowContext(ctx, "SELECT @@binlog_row_value_options").Scan(&val); err != nil {
+		// MySQL error 1193 (unknown system variable) means the server predates
+		// the option or is a flavor that lacks it — nothing to check, not a fault.
+		var myErr *mysql.MySQLError
+		if errors.As(err, &myErr) && myErr.Number == 1193 {
+			return CheckResult{Name: name, Status: StatusSkip, Detail: "binlog_row_value_options is not available on this server"}
+		}
+		return CheckResult{Name: name, Status: StatusWarn, Detail: "could not read binlog_row_value_options: " + err.Error()}
+	}
+	if strings.Contains(strings.ToUpper(val), "PARTIAL_JSON") {
+		return CheckResult{
+			Name:   name,
+			Status: StatusWarn,
+			Detail: fmt.Sprintf("binlog_row_value_options=%q — partial JSON updates are logged as diffs bintrail cannot apply, so those JSON updates are skipped at capture (silent for JSON columns)", val),
+			Remediation: "Disable partial-JSON binlog logging on the source so JSON updates are captured in full:\n\n" +
+				"  SET PERSIST binlog_row_value_options = '';\n\n" +
+				"This makes JSON UPDATEs log the whole column value (larger binlog) instead of an unappliable partial diff.",
+		}
+	}
+	return CheckResult{Name: name, Status: StatusPass, Detail: "full JSON row images"}
+}
+
 // checkBinlogRetention emits a WARN (not FAIL) when binlog retention is below
 // the 2-day recommendation in docs/streaming.md — short windows can leave
 // bintrail unable to fill gaps after a restart.
-func checkBinlogRetention(db *sql.DB) CheckResult {
+func checkBinlogRetention(ctx context.Context, db *sql.DB) CheckResult {
 	var raw string
 	// binlog_expire_logs_seconds is MySQL 8.0+; older servers use expire_logs_days.
-	err := db.QueryRow("SELECT @@binlog_expire_logs_seconds").Scan(&raw)
+	err := db.QueryRowContext(ctx, "SELECT @@binlog_expire_logs_seconds").Scan(&raw)
 	if err != nil {
 		// Try the legacy variable.
 		var days string
-		if dErr := db.QueryRow("SELECT @@expire_logs_days").Scan(&days); dErr == nil {
+		if dErr := db.QueryRowContext(ctx, "SELECT @@expire_logs_days").Scan(&days); dErr == nil {
 			d, parseErr := strconv.Atoi(days)
 			if parseErr != nil {
 				return CheckResult{
@@ -335,10 +371,10 @@ func checkBinlogRetention(db *sql.DB) CheckResult {
 // because the data never reached the binlog at all. This is advisory only
 // (never FAIL): it is the source operator's durability tradeoff, and the
 // cheapest thing bintrail can do is make sure they know about it.
-func checkSyncBinlog(db *sql.DB) CheckResult {
+func checkSyncBinlog(ctx context.Context, db *sql.DB) CheckResult {
 	const name = "Source sync_binlog=1 (crash-safety)"
 	var val string
-	if err := db.QueryRow("SELECT @@sync_binlog").Scan(&val); err != nil {
+	if err := db.QueryRowContext(ctx, "SELECT @@sync_binlog").Scan(&val); err != nil {
 		return CheckResult{
 			Name:   name,
 			Status: StatusWarn,
@@ -368,7 +404,7 @@ func checkSyncBinlog(db *sql.DB) CheckResult {
 // (validate, never set), variable absent on both probes → SKIP. Both probes use
 // SELECT @@var, which errors (MySQL 1193) rather than returning rows for a
 // variable the flavor doesn't have — the checkBinlogRetention fallback pattern.
-func checkStatementCapture(db *sql.DB) CheckResult {
+func checkStatementCapture(ctx context.Context, db *sql.DB) CheckResult {
 	const name = "Statement capture (query_text)"
 	isOn := func(val string) bool { return val == "1" || strings.EqualFold(val, "ON") }
 	// Only MySQL error 1193 (unknown system variable) means the variable is
@@ -380,7 +416,7 @@ func checkStatementCapture(db *sql.DB) CheckResult {
 	}
 
 	var val string
-	err := db.QueryRow("SELECT @@binlog_rows_query_log_events").Scan(&val)
+	err := db.QueryRowContext(ctx, "SELECT @@binlog_rows_query_log_events").Scan(&val)
 	if err == nil {
 		if isOn(val) {
 			return CheckResult{Name: name, Status: StatusPass, Detail: "binlog_rows_query_log_events=ON"}
@@ -404,7 +440,7 @@ func checkStatementCapture(db *sql.DB) CheckResult {
 	// MariaDB names the same capability binlog_annotate_row_events
 	// (default ON since 10.2.4). Note stream capture additionally requires
 	// `--source-flavor mariadb` so the syncer requests ANNOTATE events.
-	err = db.QueryRow("SELECT @@binlog_annotate_row_events").Scan(&val)
+	err = db.QueryRowContext(ctx, "SELECT @@binlog_annotate_row_events").Scan(&val)
 	if err == nil {
 		if isOn(val) {
 			return CheckResult{
@@ -446,10 +482,10 @@ func checkStatementCapture(db *sql.DB) CheckResult {
 // wrong column names. The setting is OPTIONAL, so this check never FAILs:
 // FULL → PASS, MINIMAL → WARN with an enable suggestion (validate, never
 // set), variable absent → SKIP.
-func checkRowMetadata(db *sql.DB) CheckResult {
+func checkRowMetadata(ctx context.Context, db *sql.DB) CheckResult {
 	const name = "Schema-drift detection (binlog_row_metadata)"
 	var val string
-	if err := db.QueryRow("SELECT @@binlog_row_metadata").Scan(&val); err != nil {
+	if err := db.QueryRowContext(ctx, "SELECT @@binlog_row_metadata").Scan(&val); err != nil {
 		// Only MySQL error 1193 (unknown system variable) means the server
 		// genuinely lacks the variable (MySQL 5.7, MariaDB <10.5). Any other
 		// failure is a read problem — surface the real error instead of a

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -283,7 +283,11 @@ func checkBinlogRowValueOptions(ctx context.Context, db *sql.DB) CheckResult {
 		}
 		return CheckResult{Name: name, Status: StatusWarn, Detail: "could not read binlog_row_value_options: " + err.Error()}
 	}
-	if strings.Contains(strings.ToUpper(val), "PARTIAL_JSON") {
+	up := strings.ToUpper(strings.TrimSpace(val))
+	if up == "" {
+		return CheckResult{Name: name, Status: StatusPass, Detail: "full JSON row images"}
+	}
+	if strings.Contains(up, "PARTIAL_JSON") {
 		return CheckResult{
 			Name:   name,
 			Status: StatusWarn,
@@ -293,7 +297,16 @@ func checkBinlogRowValueOptions(ctx context.Context, db *sql.DB) CheckResult {
 				"This makes JSON UPDATEs log the whole column value (larger binlog) instead of an unappliable partial diff.",
 		}
 	}
-	return CheckResult{Name: name, Status: StatusPass, Detail: "full JSON row images"}
+	// Any other non-empty value is unrecognized. A doctor check whose job is to
+	// surface capture gaps must not paint an unknown setting green — WARN rather
+	// than fall through to a reassuring PASS.
+	return CheckResult{
+		Name:   name,
+		Status: StatusWarn,
+		Detail: fmt.Sprintf("binlog_row_value_options=%q is unrecognized — verify it does not enable partial JSON row logging, or JSON updates may be skipped at capture", val),
+		Remediation: "If you did not set this deliberately, clear it for full JSON row images:\n\n" +
+			"  SET PERSIST binlog_row_value_options = '';",
+	}
 }
 
 // checkBinlogRetention emits a WARN (not FAIL) when binlog retention is below

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -2,12 +2,14 @@ package doctor
 
 import (
 	"bytes"
+	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/go-sql-driver/mysql"
@@ -168,7 +170,7 @@ func TestEveryFailCheckCarriesRemediation(t *testing.T) {
 		{
 			name:  "checkLogBin/query error",
 			setup: func(m sqlmock.Sqlmock) { m.ExpectQuery("SELECT @@log_bin").WillReturnError(forcedErr) },
-			run:   func(db sqlDB) CheckResult { return checkLogBin(db) },
+			run:   func(db sqlDB) CheckResult { return checkLogBin(ctx, db) },
 		},
 		{
 			name:  "checkReplicationGrants/SHOW GRANTS error",
@@ -266,7 +268,7 @@ func TestCheckLogBin(t *testing.T) {
 				exp.WillReturnRows(sqlmock.NewRows([]string{"@@log_bin"}).AddRow(tt.returnVal))
 			}
 
-			got := checkLogBin(db)
+			got := checkLogBin(t.Context(), db)
 			if got.Status != tt.wantStatus {
 				t.Errorf("Status = %q, want %q", got.Status, tt.wantStatus)
 			}
@@ -324,7 +326,7 @@ func TestCheckBinlogRetention(t *testing.T) {
 				tt.legacy.apply(lexpect, "@@expire_logs_days")
 			}
 
-			got := checkBinlogRetention(db)
+			got := checkBinlogRetention(t.Context(), db)
 			if got.Status != tt.wantStatus {
 				t.Errorf("Status = %q, want %q (detail=%q)", got.Status, tt.wantStatus, got.Detail)
 			}
@@ -369,7 +371,7 @@ func TestCheckSyncBinlog(t *testing.T) {
 			exp := mock.ExpectQuery("SELECT @@sync_binlog")
 			tt.resp.apply(exp, "@@sync_binlog")
 
-			got := checkSyncBinlog(db)
+			got := checkSyncBinlog(t.Context(), db)
 			if got.Status != tt.wantStatus {
 				t.Errorf("Status = %q, want %q (detail=%q)", got.Status, tt.wantStatus, got.Detail)
 			}
@@ -423,7 +425,7 @@ func TestCheckStatementCapture(t *testing.T) {
 				tt.mariaVar.apply(mexp, "@@binlog_annotate_row_events")
 			}
 
-			got := checkStatementCapture(db)
+			got := checkStatementCapture(t.Context(), db)
 			if got.Status != tt.wantStatus {
 				t.Errorf("Status = %q, want %q (detail=%q)", got.Status, tt.wantStatus, got.Detail)
 			}
@@ -444,6 +446,84 @@ func TestCheckStatementCapture(t *testing.T) {
 }
 
 func ptr[T any](v T) *T { return &v }
+
+// TestCheckBinlogRowValueOptions pins the #777 advisory check: PASS on the
+// empty default, WARN (never FAIL) on PARTIAL_JSON, SKIP when the variable is
+// absent (MySQL <8.0 / MariaDB), WARN on a transient read failure.
+func TestCheckBinlogRowValueOptions(t *testing.T) {
+	tests := []struct {
+		name            string
+		probe           mockSQLScalar
+		wantStatus      CheckStatus
+		wantDetailFrag  string
+		wantRemediation bool
+	}{
+		{"default empty", row(""), StatusPass, "full JSON row images", false},
+		{"PARTIAL_JSON", row("PARTIAL_JSON"), StatusWarn, `binlog_row_value_options="PARTIAL_JSON"`, true},
+		{"absent variable", mysqlErrResp(1193, "Unknown system variable 'binlog_row_value_options'"), StatusSkip, "not available", false},
+		{"transient read failure", errResp("driver: bad connection"), StatusWarn, "could not read binlog_row_value_options: driver: bad connection", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("sqlmock: %v", err)
+			}
+			defer db.Close()
+
+			exp := mock.ExpectQuery("SELECT @@binlog_row_value_options")
+			tt.probe.apply(exp, "@@binlog_row_value_options")
+
+			got := checkBinlogRowValueOptions(t.Context(), db)
+			if got.Status != tt.wantStatus {
+				t.Errorf("Status = %q, want %q (detail=%q)", got.Status, tt.wantStatus, got.Detail)
+			}
+			if !strings.Contains(got.Detail, tt.wantDetailFrag) {
+				t.Errorf("Detail = %q, want substring %q", got.Detail, tt.wantDetailFrag)
+			}
+			if tt.wantRemediation && got.Remediation == "" {
+				t.Error("expected remediation but got none")
+			}
+			if got.Status == StatusFail {
+				t.Error("binlog_row_value_options is optional — the check must never FAIL")
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("unmet expectations: %v", err)
+			}
+		})
+	}
+}
+
+// TestSourceChecksHonorContext pins #813: the source-side probes run their
+// queries under the caller's context, so a stalled source cannot hang doctor
+// indefinitely. With an already-canceled context and a query rigged to block,
+// checkLogBin returns at once (FAIL) instead of waiting on the socket — before
+// the fix these checks used QueryRow (no context) and would block on the delay.
+func TestSourceChecksHonorContext(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT @@log_bin").
+		WillDelayFor(time.Hour).
+		WillReturnRows(sqlmock.NewRows([]string{"@@log_bin"}).AddRow("1"))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already canceled: QueryRowContext must return ctx.Err() at once
+
+	done := make(chan CheckResult, 1)
+	go func() { done <- checkLogBin(ctx, db) }()
+	select {
+	case got := <-done:
+		if got.Status != StatusFail {
+			t.Errorf("expected FAIL on a canceled context, got %q (detail=%q)", got.Status, got.Detail)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("checkLogBin ignored the canceled context and blocked on the delayed query — a stalled source would hang doctor")
+	}
+}
 
 // TestCheckRowMetadata pins the #700 advisory check: PASS on FULL, WARN
 // (never FAIL) on MINIMAL, SKIP when the variable does not exist.
@@ -472,7 +552,7 @@ func TestCheckRowMetadata(t *testing.T) {
 			exp := mock.ExpectQuery("SELECT @@binlog_row_metadata")
 			tt.probe.apply(exp, "@@binlog_row_metadata")
 
-			got := checkRowMetadata(db)
+			got := checkRowMetadata(t.Context(), db)
 			if got.Status != tt.wantStatus {
 				t.Errorf("Status = %q, want %q (detail=%q)", got.Status, tt.wantStatus, got.Detail)
 			}

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -459,7 +459,9 @@ func TestCheckBinlogRowValueOptions(t *testing.T) {
 		wantRemediation bool
 	}{
 		{"default empty", row(""), StatusPass, "full JSON row images", false},
+		{"whitespace only treated as empty", row("  "), StatusPass, "full JSON row images", false},
 		{"PARTIAL_JSON", row("PARTIAL_JSON"), StatusWarn, `binlog_row_value_options="PARTIAL_JSON"`, true},
+		{"unrecognized non-empty value warns, never PASS", row("SOMETHING_NEW"), StatusWarn, "is unrecognized", true},
 		{"absent variable", mysqlErrResp(1193, "Unknown system variable 'binlog_row_value_options'"), StatusSkip, "not available", false},
 		{"transient read failure", errResp("driver: bad connection"), StatusWarn, "could not read binlog_row_value_options: driver: bad connection", false},
 	}

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -1110,8 +1110,14 @@ func validateTables(sourceDB *sql.DB, schemas []string, columns []columnRow) err
 
 // ValidateBinlogFormat checks that the source server has binlog_format=ROW.
 func ValidateBinlogFormat(db *sql.DB) error {
+	return ValidateBinlogFormatContext(context.Background(), db)
+}
+
+// ValidateBinlogFormatContext is ValidateBinlogFormat with a caller-supplied
+// context, so a stalled source cannot hang the probe indefinitely (#813).
+func ValidateBinlogFormatContext(ctx context.Context, db *sql.DB) error {
 	var varName, val string
-	err := db.QueryRow("SHOW VARIABLES LIKE 'binlog_format'").Scan(&varName, &val)
+	err := db.QueryRowContext(ctx, "SHOW VARIABLES LIKE 'binlog_format'").Scan(&varName, &val)
 	if errors.Is(err, sql.ErrNoRows) {
 		return fmt.Errorf("binlog_format not found on source server")
 	}
@@ -1126,8 +1132,14 @@ func ValidateBinlogFormat(db *sql.DB) error {
 
 // ValidateBinlogRowImage checks that the source server has binlog_row_image=FULL.
 func ValidateBinlogRowImage(db *sql.DB) error {
+	return ValidateBinlogRowImageContext(context.Background(), db)
+}
+
+// ValidateBinlogRowImageContext is ValidateBinlogRowImage with a caller-supplied
+// context (#813).
+func ValidateBinlogRowImageContext(ctx context.Context, db *sql.DB) error {
 	var varName, val string
-	err := db.QueryRow("SHOW VARIABLES LIKE 'binlog_row_image'").Scan(&varName, &val)
+	err := db.QueryRowContext(ctx, "SHOW VARIABLES LIKE 'binlog_row_image'").Scan(&varName, &val)
 	if errors.Is(err, sql.ErrNoRows) {
 		return fmt.Errorf("binlog_row_image not found on source server; MySQL 5.6+ with binlog_row_image=FULL is required")
 	}


### PR DESCRIPTION
Two safe, additive `doctor` hardening fixes (advisory tool — no data-path change).

## #813 — source checks ignored the 30s ctx
`checkLogBin` / `checkBinlogFormat` / `checkBinlogRowImage` / `checkBinlogRetention` / `checkSyncBinlog` / `checkStatementCapture` / `checkRowMetadata` probed with `QueryRow` (no context), so a stalled source could hang `doctor` **indefinitely** past its deadline. Each now threads the existing `ctx` (`QueryRowContext`).

The two metadata-delegating checks call **new additive** `ValidateBinlogFormatContext` / `ValidateBinlogRowImageContext`; the old `ValidateBinlogFormat`/`ValidateBinlogRowImage` stay as thin `context.Background()` wrappers, so the ~12 other callers (streamrun/streamdeps/cliapp/tests) are untouched — **zero blast radius**.

## #777 — no check for binlog_row_value_options=PARTIAL_JSON
With `PARTIAL_JSON`, MySQL logs partial JSON updates as diffs bintrail can't apply, silently skipping those updates at capture. New `checkBinlogRowValueOptions`: advisory **WARN** (never FAIL — harmless without JSON partial-updates, it's the operator's binlog-size tradeoff), **SKIP** when the variable is absent (MySQL <8.0 / MariaDB), **PASS** on the empty default.

## Tests
- `TestCheckBinlogRowValueOptions` — PASS / WARN+remediation / SKIP / read-error branches.
- `TestSourceChecksHonorContext` — a canceled ctx makes `checkLogBin` return at once instead of blocking on a `WillDelayFor(time.Hour)` query (guards the #813 regression).

`go vet` + `go test ./internal/doctor/ ./internal/metadata/` pass.

Closes #813, #777

🤖 Generated with [Claude Code](https://claude.com/claude-code)
