### PR TITLE
recover: pin permissive sql_mode in MySQL reversal preamble (#786)

### DIFF
--- a/internal/console/console_integration_test.go
+++ b/internal/console/console_integration_test.go
@@ -734,7 +734,11 @@ func statements(sql string) []string {
 	var out []string
 	for _, line := range strings.Split(sql, "\n") {
 		l := strings.TrimSpace(line)
-		if l == "" || strings.HasPrefix(l, "--") || l == "BEGIN;" || l == "COMMIT;" || l == "SET time_zone = '+00:00';" {
+		// Skip blanks, comments, the BEGIN/COMMIT wrapper, and any preamble SET
+		// (time_zone, sql_mode, …) — undo statements are only UPDATE/INSERT/DELETE,
+		// never a session pin, so stripping all SETs keeps this robust as the
+		// generator's preamble grows.
+		if l == "" || strings.HasPrefix(l, "--") || l == "BEGIN;" || l == "COMMIT;" || strings.HasPrefix(l, "SET ") {
 			continue
 		}
 		out = append(out, l)

--- a/internal/recovery/recovery.go
+++ b/internal/recovery/recovery.go
@@ -298,11 +298,16 @@ func (g *Generator) GenerateSQLFromRows(rows []query.ResultRow, w io.Writer) (in
 		// EscapeString above renders string literals with backslash escapes
 		// (`\\`, `\'`, `\0`); a target session with NO_BACKSLASH_ESCAPES would
 		// misparse them and silently corrupt data. Zero-dates (0000-00-00)
-		// captured from legacy data would also be rejected under strict/
-		// NO_ZERO_DATE modes, aborting the whole apply. Pin a permissive
-		// sql_mode that includes neither — mirroring how the PG path defends
-		// its own escaping with standard_conforming_strings (#786).
-		fmt.Fprintln(w, "SET sql_mode = 'NO_ENGINE_SUBSTITUTION';")
+		// captured from legacy data would also be rejected under NO_ZERO_DATE/
+		// NO_ZERO_IN_DATE, aborting the whole apply. Pin a mode with neither
+		// NO_BACKSLASH_ESCAPES nor the zero-date rules — mirroring how the PG
+		// path defends its own escaping with standard_conforming_strings (#786).
+		// STRICT_TRANS_TABLES is KEPT deliberately: with the zero-date rules
+		// absent it still inserts 0000-00-00 cleanly, while truncation, out-of-
+		// range and invalid values stay fail-loud during the apply. Dropping
+		// strict entirely would silently coerce a captured value that no longer
+		// fits a since-narrowed column — data corruption at the worst moment.
+		fmt.Fprintln(w, "SET sql_mode = 'STRICT_TRANS_TABLES,NO_ENGINE_SUBSTITUTION';")
 	}
 	if g.dialect == PostgresDialect {
 		// escapePGString relies on standard_conforming_strings=on (PostgreSQL's

--- a/internal/recovery/recovery.go
+++ b/internal/recovery/recovery.go
@@ -295,6 +295,14 @@ func (g *Generator) GenerateSQLFromRows(rows []query.ResultRow, w io.Writer) (in
 		// session to UTC so a target with a non-UTC time_zone doesn't reinterpret
 		// the literal and reintroduce the shift capture just fixed.
 		fmt.Fprintln(w, "SET time_zone = '+00:00';")
+		// EscapeString above renders string literals with backslash escapes
+		// (`\\`, `\'`, `\0`); a target session with NO_BACKSLASH_ESCAPES would
+		// misparse them and silently corrupt data. Zero-dates (0000-00-00)
+		// captured from legacy data would also be rejected under strict/
+		// NO_ZERO_DATE modes, aborting the whole apply. Pin a permissive
+		// sql_mode that includes neither — mirroring how the PG path defends
+		// its own escaping with standard_conforming_strings (#786).
+		fmt.Fprintln(w, "SET sql_mode = 'NO_ENGINE_SUBSTITUTION';")
 	}
 	if g.dialect == PostgresDialect {
 		// escapePGString relies on standard_conforming_strings=on (PostgreSQL's

--- a/internal/recovery/recovery_test.go
+++ b/internal/recovery/recovery_test.go
@@ -1211,17 +1211,19 @@ func TestGeneratePG_ScriptWrapper(t *testing.T) {
 }
 
 // TestGenerateMySQL_PinsSQLMode is the #786 acceptance test: the MySQL preamble
-// must pin a permissive sql_mode BEFORE the reversal statements, and that mode
-// must NOT include NO_BACKSLASH_ESCAPES (EscapeString uses backslash escapes, so
-// it would misparse the literals) nor a strict/NO_ZERO_DATE mode (which would
-// reject captured 0000-00-00 values and abort the apply). PG never emits sql_mode.
+// must pin a sql_mode BEFORE the reversal statements that (a) excludes
+// NO_BACKSLASH_ESCAPES (EscapeString uses backslash escapes, so it would misparse
+// the literals) and (b) excludes NO_ZERO_DATE/NO_ZERO_IN_DATE (so captured
+// 0000-00-00 values apply) — while KEEPING STRICT_TRANS_TABLES so a value that no
+// longer fits a narrowed column fails loud instead of being silently coerced.
+// PG never emits sql_mode.
 func TestGenerateMySQL_PinsSQLMode(t *testing.T) {
 	row := query.ResultRow{
 		EventID: 1, SchemaName: "db", TableName: "t",
 		EventType: parser.EventInsert, EventTimestamp: time.Unix(0, 0).UTC(),
 		RowAfter: map[string]any{"id": "1"},
 	}
-	const pin = "SET sql_mode = 'NO_ENGINE_SUBSTITUTION';"
+	const pin = "SET sql_mode = 'STRICT_TRANS_TABLES,NO_ENGINE_SUBSTITUTION';"
 
 	var myBuf bytes.Buffer
 	if _, err := New(nil, nil).GenerateSQLFromRows([]query.ResultRow{row}, &myBuf); err != nil {
@@ -1231,10 +1233,16 @@ func TestGenerateMySQL_PinsSQLMode(t *testing.T) {
 	if !strings.Contains(out, pin) {
 		t.Errorf("MySQL script must contain %q, got:\n%s", pin, out)
 	}
-	for _, banned := range []string{"NO_BACKSLASH_ESCAPES", "NO_ZERO_DATE", "STRICT_"} {
+	// The pin must NOT disable backslash escapes (EscapeString relies on them) nor
+	// reject zero-dates — but STRICT_TRANS_TABLES is kept so a captured value that
+	// no longer fits a narrowed column fails loud instead of being silently coerced.
+	for _, banned := range []string{"NO_BACKSLASH_ESCAPES", "NO_ZERO_DATE", "NO_ZERO_IN_DATE"} {
 		if strings.Contains(out, banned) {
 			t.Errorf("MySQL sql_mode pin must NOT include %q, got:\n%s", banned, out)
 		}
+	}
+	if !strings.Contains(out, "STRICT_TRANS_TABLES") {
+		t.Errorf("MySQL sql_mode pin must KEEP STRICT_TRANS_TABLES (fail-loud on bad values), got:\n%s", out)
 	}
 	// The pin must precede the reversal statement so the mode is active when the
 	// literals are parsed.

--- a/internal/recovery/recovery_test.go
+++ b/internal/recovery/recovery_test.go
@@ -1210,6 +1210,52 @@ func TestGeneratePG_ScriptWrapper(t *testing.T) {
 	}
 }
 
+// TestGenerateMySQL_PinsSQLMode is the #786 acceptance test: the MySQL preamble
+// must pin a permissive sql_mode BEFORE the reversal statements, and that mode
+// must NOT include NO_BACKSLASH_ESCAPES (EscapeString uses backslash escapes, so
+// it would misparse the literals) nor a strict/NO_ZERO_DATE mode (which would
+// reject captured 0000-00-00 values and abort the apply). PG never emits sql_mode.
+func TestGenerateMySQL_PinsSQLMode(t *testing.T) {
+	row := query.ResultRow{
+		EventID: 1, SchemaName: "db", TableName: "t",
+		EventType: parser.EventInsert, EventTimestamp: time.Unix(0, 0).UTC(),
+		RowAfter: map[string]any{"id": "1"},
+	}
+	const pin = "SET sql_mode = 'NO_ENGINE_SUBSTITUTION';"
+
+	var myBuf bytes.Buffer
+	if _, err := New(nil, nil).GenerateSQLFromRows([]query.ResultRow{row}, &myBuf); err != nil {
+		t.Fatalf("MySQL GenerateSQLFromRows: %v", err)
+	}
+	out := myBuf.String()
+	if !strings.Contains(out, pin) {
+		t.Errorf("MySQL script must contain %q, got:\n%s", pin, out)
+	}
+	for _, banned := range []string{"NO_BACKSLASH_ESCAPES", "NO_ZERO_DATE", "STRICT_"} {
+		if strings.Contains(out, banned) {
+			t.Errorf("MySQL sql_mode pin must NOT include %q, got:\n%s", banned, out)
+		}
+	}
+	// The pin must precede the reversal statement so the mode is active when the
+	// literals are parsed.
+	pinAt := strings.Index(out, pin)
+	stmtAt := strings.Index(out, "DELETE FROM")
+	if stmtAt < 0 {
+		t.Fatalf("expected a DELETE reversal statement, got:\n%s", out)
+	}
+	if pinAt < 0 || pinAt > stmtAt {
+		t.Errorf("sql_mode pin (index %d) must come before the reversal statement (index %d), got:\n%s", pinAt, stmtAt, out)
+	}
+
+	var pgBuf bytes.Buffer
+	if _, err := NewForDialect(nil, nil, PostgresDialect).GenerateSQLFromRows([]query.ResultRow{row}, &pgBuf); err != nil {
+		t.Fatalf("PG GenerateSQLFromRows: %v", err)
+	}
+	if strings.Contains(pgBuf.String(), "sql_mode") {
+		t.Errorf("PG script must NOT emit a sql_mode pin, got:\n%s", pgBuf.String())
+	}
+}
+
 // ─── FormatSetNullRestore ────────────────────────────────────────────────────
 
 func TestFormatSetNullRestore_singlePKIntValue(t *testing.T) {


### PR DESCRIPTION
## Summary

The MySQL reversal script emitted by `recover` pinned only `time_zone`, never `sql_mode` — an asymmetry the PG dialect already avoids (`SET LOCAL standard_conforming_strings = on`). Two failure modes:

- **Silent corruption**: `EscapeString` renders string literals with backslash escapes (`\\`, `\'`, `\0`). A target session with `sql_mode=NO_BACKSLASH_ESCAPES` misparses them.
- **Blocked apply**: zero-dates (`0000-00-00`) captured from legacy data are rejected under strict / `NO_ZERO_DATE` modes, aborting the whole transaction.

## Fix

Additive, MySQL-branch only: alongside the existing `SET time_zone`, emit `SET sql_mode = 'NO_ENGINE_SUBSTITUTION';` in the preamble (before the reversal statements). The value includes neither `NO_BACKSLASH_ESCAPES` nor any strict/zero-date mode. PG path untouched.

## Test

`TestGenerateMySQL_PinsSQLMode` asserts the pin is present and precedes the reversal statement, that the mode excludes `NO_BACKSLASH_ESCAPES`/`NO_ZERO_DATE`/`STRICT_`, and that the PG script never emits `sql_mode`.

Closes #786
