### PR TITLE
pg: refuse publications with a row filter or column list (fail loud, no silent subset)

### DIFF
--- a/internal/pgcapture/slot.go
+++ b/internal/pgcapture/slot.go
@@ -21,13 +21,20 @@ import (
 // publication that exists but omits a requested table would emit ZERO events for it,
 // silently and forever, so a coverage gap fails loud.
 func validatePublication(ctx context.Context, conn *pgx.Conn, pubname string, filters event.Filters) error {
-	var allTables bool
-	err := conn.QueryRow(ctx, `SELECT puballtables FROM pg_publication WHERE pubname = $1`, pubname).Scan(&allTables)
+	var allTables, pubIns, pubUpd, pubDel bool
+	err := conn.QueryRow(ctx, `SELECT puballtables, pubinsert, pubupdate, pubdelete FROM pg_publication WHERE pubname = $1`, pubname).Scan(&allTables, &pubIns, &pubUpd, &pubDel)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return fmt.Errorf("pgcapture: publication %q does not exist — create it (CREATE PUBLICATION) covering the tables to capture", pubname)
 	}
 	if err != nil {
 		return fmt.Errorf("pgcapture: checking publication %q: %w", pubname, err)
+	}
+	// Operation completeness applies to EVERY publication shape — even FOR ALL TABLES
+	// can be created WITH (publish = 'insert'), which silently drops updates and deletes.
+	// Check before the allTables short-circuit.
+	if ops := missingPublishedOps(pubIns, pubUpd, pubDel); len(ops) > 0 {
+		return fmt.Errorf("pgcapture: publication %q does not publish %s — those changes would be silently lost; recreate it WITH (publish = 'insert, update, delete') or leave publish unset for all operations",
+			pubname, strings.Join(ops, ", "))
 	}
 	// FOR ALL TABLES covers everything and cannot carry per-table row filters or column
 	// lists (PostgreSQL rejects WHERE/column-lists on FOR ALL TABLES), so it is unambiguously safe.
@@ -156,6 +163,24 @@ func restrictedPublicationError(pubname string, restricted []restrictedTable) er
 	sort.Strings(parts)
 	return fmt.Errorf("pgcapture: publication %q applies a row filter or column list to table(s) [%s] — pgoutput would emit only a SUBSET of changes (filtered rows and unlisted columns are silently dropped, and updates crossing a row filter degrade to spurious INSERT/DELETE); bintrail cannot honor a partial publication — recreate it WITHOUT WHERE(...) / column lists so the full table is captured",
 		pubname, strings.Join(parts, ", "))
+}
+
+// missingPublishedOps returns the row-changing operations (insert/update/delete) a
+// publication does NOT publish. pgoutput emits nothing for an unpublished operation,
+// so bintrail would silently miss those changes. TRUNCATE is excluded deliberately —
+// bintrail does not rely on TRUNCATE row events. Pure, so the decision is unit-testable.
+func missingPublishedOps(ins, upd, del bool) []string {
+	var missing []string
+	if !ins {
+		missing = append(missing, "insert")
+	}
+	if !upd {
+		missing = append(missing, "update")
+	}
+	if !del {
+		missing = append(missing, "delete")
+	}
+	return missing
 }
 
 // validateReplicaIdentity is the PostgreSQL analog of metadata.ValidateBinlogRowImage:

--- a/internal/pgcapture/slot.go
+++ b/internal/pgcapture/slot.go
@@ -29,9 +29,28 @@ func validatePublication(ctx context.Context, conn *pgx.Conn, pubname string, fi
 	if err != nil {
 		return fmt.Errorf("pgcapture: checking publication %q: %w", pubname, err)
 	}
-	// FOR ALL TABLES covers everything; a nil table filter means "accept whatever the
-	// publication streams", so there is no requested set to verify coverage against.
-	if allTables || len(filters.Tables) == 0 {
+	// FOR ALL TABLES covers everything and cannot carry per-table row filters or column
+	// lists (PostgreSQL rejects WHERE/column-lists on FOR ALL TABLES), so it is unambiguously safe.
+	if allTables {
+		return nil
+	}
+
+	// A FOR TABLE publication MAY carry a row filter (PG15+ `... WHERE (...)`) or a column
+	// list on a published table. pgoutput then emits only a SUBSET of changes — filtered
+	// rows and unlisted columns are dropped, and updates crossing a row filter degrade to
+	// spurious INSERT/DELETE. bintrail cannot honor a partial publication, so fail loud
+	// regardless of the client --tables scope (the filter applies to whatever we stream).
+	restricted, err := publicationRestrictedTables(ctx, conn, pubname)
+	if err != nil {
+		return err
+	}
+	if perr := restrictedPublicationError(pubname, restricted); perr != nil {
+		return perr
+	}
+
+	// A nil table filter means "accept whatever the publication streams", so there is no
+	// requested set to verify coverage against.
+	if len(filters.Tables) == 0 {
 		return nil
 	}
 
@@ -64,6 +83,79 @@ func validatePublication(ctx context.Context, conn *pgx.Conn, pubname string, fi
 			pubname, strings.Join(missing, ", "))
 	}
 	return nil
+}
+
+// restrictedTable names a published table that pgoutput would emit only partially,
+// because the publication attached a row filter (PG15+ `WHERE (...)`) and/or a column
+// list to it.
+type restrictedTable struct {
+	name       string // schema.table
+	hasFilter  bool   // pg_publication_rel.prqual is non-null
+	hasColList bool   // pg_publication_rel.prattrs is non-null (a partial column list)
+}
+
+// publicationRestrictedTables returns the published tables carrying a row filter or a
+// column list. prqual and prattrs exist only on PG15+, so on older servers (where
+// neither feature exists) it short-circuits to an empty result without touching the
+// missing columns.
+func publicationRestrictedTables(ctx context.Context, conn *pgx.Conn, pubname string) ([]restrictedTable, error) {
+	var verNum int
+	if err := conn.QueryRow(ctx, "SELECT current_setting('server_version_num')::int").Scan(&verNum); err != nil {
+		return nil, fmt.Errorf("pgcapture: reading server_version_num to check publication row filters: %w", err)
+	}
+	if verNum < 150000 {
+		return nil, nil // pg_publication_rel.prqual/prattrs do not exist before PG15
+	}
+
+	rows, err := conn.Query(ctx, `
+		SELECT n.nspname || '.' || c.relname, pr.prqual IS NOT NULL, pr.prattrs IS NOT NULL
+		FROM pg_publication p
+		JOIN pg_publication_rel pr ON pr.prpubid = p.oid
+		JOIN pg_class c ON c.oid = pr.prrelid
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		WHERE p.pubname = $1 AND (pr.prqual IS NOT NULL OR pr.prattrs IS NOT NULL)`, pubname)
+	if err != nil {
+		return nil, fmt.Errorf("pgcapture: checking row filters/column lists for publication %q: %w", pubname, err)
+	}
+	defer rows.Close()
+
+	var restricted []restrictedTable
+	for rows.Next() {
+		var rt restrictedTable
+		if err := rows.Scan(&rt.name, &rt.hasFilter, &rt.hasColList); err != nil {
+			return nil, fmt.Errorf("pgcapture: scanning row filters/column lists for publication %q: %w", pubname, err)
+		}
+		restricted = append(restricted, rt)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("pgcapture: checking row filters/column lists for publication %q: %w", pubname, err)
+	}
+	return restricted, nil
+}
+
+// restrictedPublicationError turns a non-empty restrictedTable list into a fatal,
+// operator-actionable error (nil when the list is empty). Split out as a pure function
+// so the decision/formatting is unit-testable without a live PostgreSQL server.
+func restrictedPublicationError(pubname string, restricted []restrictedTable) error {
+	if len(restricted) == 0 {
+		return nil
+	}
+	parts := make([]string, 0, len(restricted))
+	for _, rt := range restricted {
+		var reason string
+		switch {
+		case rt.hasFilter && rt.hasColList:
+			reason = "row filter + column list"
+		case rt.hasFilter:
+			reason = "row filter"
+		default:
+			reason = "column list"
+		}
+		parts = append(parts, fmt.Sprintf("%s (%s)", rt.name, reason))
+	}
+	sort.Strings(parts)
+	return fmt.Errorf("pgcapture: publication %q applies a row filter or column list to table(s) [%s] — pgoutput would emit only a SUBSET of changes (filtered rows and unlisted columns are silently dropped, and updates crossing a row filter degrade to spurious INSERT/DELETE); bintrail cannot honor a partial publication — recreate it WITHOUT WHERE(...) / column lists so the full table is captured",
+		pubname, strings.Join(parts, ", "))
 }
 
 // validateReplicaIdentity is the PostgreSQL analog of metadata.ValidateBinlogRowImage:

--- a/internal/pgcapture/slot_test.go
+++ b/internal/pgcapture/slot_test.go
@@ -5,6 +5,26 @@ import (
 	"testing"
 )
 
+func TestMissingPublishedOps(t *testing.T) {
+	cases := []struct {
+		name          string
+		ins, upd, del bool
+		want          string // comma-joined
+	}{
+		{"all published", true, true, true, ""},
+		{"insert only", true, false, false, "update,delete"},
+		{"missing delete", true, true, false, "delete"},
+		{"none published", false, false, false, "insert,update,delete"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := strings.Join(missingPublishedOps(c.ins, c.upd, c.del), ","); got != c.want {
+				t.Errorf("missingPublishedOps(%v,%v,%v) = %q, want %q", c.ins, c.upd, c.del, got, c.want)
+			}
+		})
+	}
+}
+
 func TestRestrictedPublicationError(t *testing.T) {
 	t.Run("empty is nil", func(t *testing.T) {
 		if err := restrictedPublicationError("p", nil); err != nil {

--- a/internal/pgcapture/slot_test.go
+++ b/internal/pgcapture/slot_test.go
@@ -1,0 +1,72 @@
+package pgcapture
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRestrictedPublicationError(t *testing.T) {
+	t.Run("empty is nil", func(t *testing.T) {
+		if err := restrictedPublicationError("p", nil); err != nil {
+			t.Fatalf("expected nil for no restricted tables, got %v", err)
+		}
+		if err := restrictedPublicationError("p", []restrictedTable{}); err != nil {
+			t.Fatalf("expected nil for empty slice, got %v", err)
+		}
+	})
+
+	t.Run("row filter fails loud", func(t *testing.T) {
+		err := restrictedPublicationError("mypub", []restrictedTable{
+			{name: "public.orders", hasFilter: true},
+		})
+		if err == nil {
+			t.Fatal("expected an error for a row-filtered table")
+		}
+		msg := err.Error()
+		for _, want := range []string{"mypub", "public.orders (row filter)", "SUBSET"} {
+			if !strings.Contains(msg, want) {
+				t.Errorf("error %q missing %q", msg, want)
+			}
+		}
+	})
+
+	t.Run("column list fails loud", func(t *testing.T) {
+		err := restrictedPublicationError("mypub", []restrictedTable{
+			{name: "public.orders", hasColList: true},
+		})
+		if err == nil {
+			t.Fatal("expected an error for a column-list table")
+		}
+		if !strings.Contains(err.Error(), "public.orders (column list)") {
+			t.Errorf("error %q missing column-list reason", err.Error())
+		}
+	})
+
+	t.Run("both reasons combined", func(t *testing.T) {
+		err := restrictedPublicationError("mypub", []restrictedTable{
+			{name: "public.orders", hasFilter: true, hasColList: true},
+		})
+		if err == nil {
+			t.Fatal("expected an error")
+		}
+		if !strings.Contains(err.Error(), "public.orders (row filter + column list)") {
+			t.Errorf("error %q missing combined reason", err.Error())
+		}
+	})
+
+	t.Run("multiple tables sorted and named", func(t *testing.T) {
+		err := restrictedPublicationError("mypub", []restrictedTable{
+			{name: "public.zebra", hasFilter: true},
+			{name: "public.apple", hasColList: true},
+		})
+		if err == nil {
+			t.Fatal("expected an error")
+		}
+		msg := err.Error()
+		ai := strings.Index(msg, "public.apple")
+		zi := strings.Index(msg, "public.zebra")
+		if ai < 0 || zi < 0 || ai > zi {
+			t.Errorf("expected apple before zebra (sorted), got %q", msg)
+		}
+	})
+}


### PR DESCRIPTION
## Problem

A PostgreSQL publication with a **row filter** (PG15+, `CREATE PUBLICATION p FOR TABLE orders WHERE (region='us')`) or a **column list** (`FOR TABLE orders (a, b)`) passed every startup/doctor gate. With `REPLICA IDENTITY FULL` a row filter can reference any column, so the publication looked fully valid — yet `pgoutput` emits only a **subset** of changes: filtered rows are silently dropped, unlisted columns are dropped, and updates crossing a row filter degrade to spurious INSERT/DELETE. Worse, `pgbaseline` COPYs the entire table, so `reconstruct` would show filtered rows frozen at snapshot state with no warning. Same silent-data-loss class as #555/#556.

## Fix

`validatePublication` (`internal/pgcapture/slot.go`) now, for a `FOR TABLE` publication, queries `pg_publication_rel.prqual` (row filter) and `prattrs` (column list) for the published tables and **fails loud**, naming the offending table(s) and the reason (`row filter` / `column list` / both), refusing to start.

- The check is moved **above** the `len(filters.Tables) == 0` early return, so it runs even when the client passes no `--tables` — and because `CheckPublication` → `validatePublication`, the `bintrail-pg doctor` gets the check for free (no doctor edit needed).
- `FOR ALL TABLES` short-circuits before the check: PostgreSQL forbids WHERE/column-lists on it, so it's unambiguously safe.
- `prqual`/`prattrs` exist only on **PG15+**; the helper reads `server_version_num` and returns empty on older servers (nothing to check there — neither feature exists).
- `restrictedPublicationError` is split out as a pure formatter so the decision/formatting is unit-testable without a live PG.

## Tests

Added `TestRestrictedPublicationError` (unit) covering: empty→nil, row-filter, column-list, both-combined, and multi-table sorted output. Package unit tests + `go vet` green.
