### PR TITLE
cli: surface S3 setup/verify failures in `init --format json` (#810)

### DIFF
--- a/cliapp/init.go
+++ b/cliapp/init.go
@@ -114,11 +114,16 @@ func runInit(cmd *cobra.Command, args []string) error {
 	}
 
 	var s3Result *string
+	// s3Err captures a bucket setup/verify failure so it can be surfaced in
+	// JSON mode (an s3_error field + a non-zero exit). In text mode it stays
+	// non-fatal: a human reads the stderr warning and remediation and acts.
+	var s3Err error
 	if initS3Bucket != "" {
 		if initFormat != "json" {
 			fmt.Printf("\nSetting up S3 bucket...\n")
 		}
 		if err := setupS3Bucket(cmd.Context(), initS3Bucket, initS3Region); err != nil {
+			s3Err = err
 			if initFormat != "json" {
 				fmt.Fprintf(os.Stderr, "Warning: could not create S3 bucket %q: %v\n\n", initS3Bucket, err)
 				fmt.Fprint(os.Stderr, s3Instructions(initS3Bucket, initS3Region))
@@ -137,6 +142,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 			fmt.Printf("\nVerifying existing S3 bucket...\n")
 		}
 		if err := verifyS3Bucket(cmd.Context(), s3ARNBucket, initS3Region); err != nil {
+			s3Err = err
 			if initFormat != "json" {
 				fmt.Fprintf(os.Stderr, "Warning: could not verify S3 bucket %q: %v\n\n", s3ARNBucket, err)
 				fmt.Fprint(os.Stderr, s3IAMInstructions(s3ARNBucket, s3ARNPartition))
@@ -151,20 +157,46 @@ func runInit(cmd *cobra.Command, args []string) error {
 	}
 
 	if initFormat == "json" {
-		result := struct {
-			Database      string   `json:"database"`
-			TablesCreated []string `json:"tables_created"`
-			S3Bucket      *string  `json:"s3_bucket,omitempty"`
-		}{
-			Database:      dbName,
-			TablesCreated: tablesCreated,
-			S3Bucket:      s3Result,
+		result := buildInitResult(dbName, tablesCreated, s3Result, s3Err)
+		if err := cliutil.OutputJSON(result); err != nil {
+			return err
 		}
-		return cliutil.OutputJSON(result)
+		// Fail hard in JSON mode so exit-code-only automation gets a signal:
+		// a zero exit with a silently-omitted bucket would make a pipeline
+		// believe archiving is provisioned when it is not (issue #810). Text
+		// mode stays non-fatal by design — the warning above is for a human.
+		if s3Err != nil {
+			return fmt.Errorf("S3 bucket setup failed: %w", s3Err)
+		}
+		return nil
 	}
 
 	fmt.Printf("\nInitialization complete. Index database: %s\n", dbName)
 	return nil
+}
+
+// initJSONResult is the --format json payload for the init command.
+type initJSONResult struct {
+	Database      string   `json:"database"`
+	TablesCreated []string `json:"tables_created"`
+	S3Bucket      *string  `json:"s3_bucket,omitempty"`
+	S3Error       *string  `json:"s3_error,omitempty"`
+}
+
+// buildInitResult assembles the JSON payload. A non-nil s3Err is surfaced in
+// the s3_error field so JSON consumers never see a silently-omitted bucket
+// (issue #810). s3Result and s3Err are mutually exclusive per invocation.
+func buildInitResult(dbName string, tables []string, s3Result *string, s3Err error) initJSONResult {
+	r := initJSONResult{
+		Database:      dbName,
+		TablesCreated: tables,
+		S3Bucket:      s3Result,
+	}
+	if s3Err != nil {
+		msg := s3Err.Error()
+		r.S3Error = &msg
+	}
+	return r
 }
 
 // setupS3Bucket creates a private S3 bucket with a 1-year lifecycle expiry policy.

--- a/cliapp/init_test.go
+++ b/cliapp/init_test.go
@@ -1,6 +1,8 @@
 package cliapp
 
 import (
+	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 )
@@ -285,5 +287,45 @@ func TestRunInit_missingDBName(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "--index-dsn must include a database name") {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// ─── init --format json S3 error surfacing (issue #810) ───────────────────────
+
+func TestBuildInitResult_s3ErrorSurfaced(t *testing.T) {
+	r := buildInitResult("idx", []string{"binlog_events"}, nil, errors.New("head bucket: AccessDenied"))
+	if r.S3Bucket != nil {
+		t.Errorf("expected nil S3Bucket on error, got %v", *r.S3Bucket)
+	}
+	if r.S3Error == nil {
+		t.Fatal("expected S3Error to be populated on S3 failure")
+	}
+	if *r.S3Error != "head bucket: AccessDenied" {
+		t.Errorf("unexpected S3Error: %q", *r.S3Error)
+	}
+	b, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(b), `"s3_error":"head bucket: AccessDenied"`) {
+		t.Errorf("s3_error missing from JSON payload: %s", b)
+	}
+}
+
+func TestBuildInitResult_noS3Error_omitted(t *testing.T) {
+	s := "my-bucket (region: us-east-1)"
+	r := buildInitResult("idx", []string{"binlog_events"}, &s, nil)
+	if r.S3Error != nil {
+		t.Errorf("expected nil S3Error, got %v", *r.S3Error)
+	}
+	b, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), "s3_error") {
+		t.Errorf("s3_error should be omitted when no S3 failure: %s", b)
+	}
+	if !strings.Contains(string(b), `"s3_bucket":"my-bucket (region: us-east-1)"`) {
+		t.Errorf("s3_bucket missing from JSON payload: %s", b)
 	}
 }


### PR DESCRIPTION
## Problem

`bintrail init --format json --s3-bucket b` (or `--s3-arn`) **silently swallowed** S3 bucket setup/verify failures. The stderr warning + remediation were gated behind `initFormat != "json"` (`cliapp/init.go` ~:121 and ~:139), so in JSON mode a failed `CreateBucket`/`HeadBucket`:

- emitted **no** error in the JSON payload (`s3_bucket` was simply omitted), and
- exited **0**.

Automation reads "success", believes archiving is provisioned, and only discovers the hole months later when `rotate` archives to a nonexistent bucket or the first long restore finds no archives. Issue #810.

## Fix (additive)

- Capture the setup/verify error into a new `s3Err` variable in both blocks.
- Add an `s3_error` field to the JSON output (new named type `initJSONResult` + a small pure `buildInitResult` helper — the test seam).
- In JSON mode, after emitting the payload, **return non-zero** when `s3Err != nil` so exit-code-only pipelines also get a signal.

Result in JSON mode on S3 failure: stdout gets the full result with `"s3_error": "..."`, stderr gets `{"error":"..."}` (from `Main()`), exit 1.

## Intentional asymmetry (please note at review)

Text mode is **unchanged**: S3 setup is best-effort by design — the index tables (the core deliverable) are already created, and text mode warns to stderr + prints manual remediation, then **exits 0**. This PR keeps that untouched and only makes **JSON** mode fail hard.

The issue text ("exit non-zero, matching text mode") is internally inconsistent — text mode actually exits 0. I followed the explicit directive (non-zero in JSON) because it's the half of the fix that addresses the stated harm (exit-0 → pipeline believes archiving is provisioned). The `interactive-warns / machine-fails-hard` split maps to audience: a human reads the warning and acts; automation needs a hard signal. A code comment at the `return` documents this so it isn't mistaken for an accident.

## Tests

`cliapp/init_test.go`:
- `TestBuildInitResult_s3ErrorSurfaced` — `s3Err != nil` → `S3Error` populated, JSON contains `"s3_error":...`, `s3_bucket` nil.
- `TestBuildInitResult_noS3Error_omitted` — no failure → `s3_error` omitted (`omitempty`), `s3_bucket` present.

`go vet ./cliapp/` clean; targeted `go test ./cliapp/` green.
