### PR TITLE
status: surface stream_state read failure as continuity=unavailable (#815)

### DIFF
--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -133,6 +133,8 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	if stFailOnGap {
 		cmd.SilenceUsage = true
 		switch {
+		case data.StreamErr != nil:
+			return fmt.Errorf("stream continuity: could not read stream state (%w); failing closed under --fail-on-gap", data.StreamErr)
 		case data.Stream == nil:
 			return fmt.Errorf("stream continuity: could not confirm gap state (no stream state loaded); failing closed under --fail-on-gap")
 		case !data.Stream.GapColumnsPresent:

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -422,6 +422,14 @@ type StatusData struct {
 	Servers   []ServerInfo
 	Stream    *StreamStateInfo
 	Baselines []BaselineInfo
+	// StreamErr records a failure to READ stream_state (transient timeout, revoked
+	// permission, an unexpected loadSourceHealth error) — as distinct from an empty
+	// table (Stream==nil, StreamErr==nil = no active stream). When set, the continuity
+	// verdict could not be evaluated: the output must show it as "unavailable" rather
+	// than silently omit the Stream section and its permanent-loss banner (fail visible,
+	// not silent). json:"-" — StatusData is rendered via the manual jsonSummary mapping,
+	// never marshalled directly; the tag is insurance against a future direct marshal.
+	StreamErr error `json:"-"`
 }
 
 // BaselineInfo holds metadata about a discovered baseline Parquet file.
@@ -465,6 +473,10 @@ func CollectStatus(ctx context.Context, db *sql.DB, dbName string) (*StatusData,
 
 	if stream, err := LoadStreamState(ctx, db); err != nil {
 		slog.Warn("could not load stream state", "error", err)
+		// Record the read failure so the continuity verdict reports "unavailable"
+		// instead of the output silently omitting the Stream section (and its
+		// permanent-loss banner) — a swallowed error must not read as "no stream".
+		d.StreamErr = err
 	} else {
 		d.Stream = stream
 	}
@@ -511,12 +523,27 @@ func LoadIndexSizeBytes(ctx context.Context, db *sql.DB, dbName string) (int64, 
 // Write writes the status data as a human-readable report to w.
 func (d *StatusData) Write(w io.Writer) {
 	WriteStatus(w, d.Files, d.Parts, d.Archives, d.Coverage, d.Servers, d.Stream)
+	if d.Stream == nil && d.StreamErr != nil {
+		writeStreamUnavailable(w, d.StreamErr)
+	}
 	writeBaselines(w, d.Baselines)
+}
+
+// writeStreamUnavailable renders a visible Stream block when stream_state could not
+// be READ (StreamErr set, Stream nil). Distinct from an empty table (no block): here
+// the continuity verdict — and any permanent-loss banner — could not be evaluated, so
+// the operator sees "unavailable" rather than an absence they'd misread as "no loss".
+func writeStreamUnavailable(w io.Writer, err error) {
+	fmt.Fprintln(w, "=== Stream ===")
+	fmt.Fprintf(w, "  Continuity:      ⚠ unavailable (could not read stream state: %v)\n", err)
+	fmt.Fprintln(w, "  The gap/continuity state could not be read from the index; a permanent-loss")
+	fmt.Fprintln(w, "  banner can neither be shown nor ruled out. Re-run status to retry.")
+	fmt.Fprintln(w)
 }
 
 // WriteJSON writes the status data as JSON to w.
 func (d *StatusData) WriteJSON(w io.Writer) error {
-	return writeStatusJSONFull(w, d.Files, d.Parts, d.Archives, d.Coverage, d.Servers, d.Stream, d.Baselines)
+	return writeStatusJSONFull(w, d.Files, d.Parts, d.Archives, d.Coverage, d.Servers, d.Stream, d.Baselines, d.StreamErr)
 }
 
 // WriteStatus writes a multi-section status report (Servers, Stream, Indexed Files, Partitions, Archives, Coverage, Summary) to w.
@@ -783,10 +810,10 @@ func Truncate(s string, n int) string {
 
 // WriteStatusJSON writes the status data as a JSON object to w.
 func WriteStatusJSON(w io.Writer, files []IndexStateRow, parts []PartitionStat, archives *ArchiveStats, coverage *CoverageInfo, servers []ServerInfo, stream *StreamStateInfo) error {
-	return writeStatusJSONFull(w, files, parts, archives, coverage, servers, stream, nil)
+	return writeStatusJSONFull(w, files, parts, archives, coverage, servers, stream, nil, nil)
 }
 
-func writeStatusJSONFull(w io.Writer, files []IndexStateRow, parts []PartitionStat, archives *ArchiveStats, coverage *CoverageInfo, servers []ServerInfo, stream *StreamStateInfo, baselines []BaselineInfo) error {
+func writeStatusJSONFull(w io.Writer, files []IndexStateRow, parts []PartitionStat, archives *ArchiveStats, coverage *CoverageInfo, servers []ServerInfo, stream *StreamStateInfo, baselines []BaselineInfo, streamErr error) error {
 	type jsonFile struct {
 		BinlogFile    string  `json:"binlog_file"`
 		Status        string  `json:"status"`
@@ -875,15 +902,25 @@ func writeStatusJSONFull(w io.Writer, files []IndexStateRow, parts []PartitionSt
 		Size         int64   `json:"size_bytes,omitempty"`
 		SizeHuman    string  `json:"size_human,omitempty"`
 	}
+	// jsonStreamError is emitted (under a distinct key, never a fake `stream` object —
+	// jsonStream's non-omitempty events_indexed:0/mode:"" would read as a real empty
+	// stream) when stream_state could not be READ. continuity.status is "unavailable":
+	// a consumer switching on continuity keeps the gap state OUT of "ok", and one that
+	// only checks stream presence still finds this loud sibling instead of silence.
+	type jsonStreamError struct {
+		Continuity jsonContinuity `json:"continuity"`
+		Error      string         `json:"error"`
+	}
 	type jsonSummary struct {
-		Servers   []jsonServer    `json:"servers,omitempty"`
-		Stream    *jsonStream     `json:"stream,omitempty"`
-		Files     []jsonFile      `json:"files"`
-		Parts     []jsonPartition `json:"partitions"`
-		Total     int64           `json:"total_events_estimate"`
-		Archives  *jsonArchives   `json:"archives,omitempty"`
-		Coverage  *jsonCoverage   `json:"coverage,omitempty"`
-		Baselines []jsonBaseline  `json:"baselines,omitempty"`
+		Servers     []jsonServer     `json:"servers,omitempty"`
+		Stream      *jsonStream      `json:"stream,omitempty"`
+		StreamError *jsonStreamError `json:"stream_error,omitempty"`
+		Files       []jsonFile       `json:"files"`
+		Parts       []jsonPartition  `json:"partitions"`
+		Total       int64            `json:"total_events_estimate"`
+		Archives    *jsonArchives    `json:"archives,omitempty"`
+		Coverage    *jsonCoverage    `json:"coverage,omitempty"`
+		Baselines   []jsonBaseline   `json:"baselines,omitempty"`
 	}
 
 	jf := make([]jsonFile, len(files))
@@ -969,6 +1006,13 @@ func writeStatusJSONFull(w io.Writer, files []IndexStateRow, parts []PartitionSt
 			jstr.SourceHealth = json.RawMessage(stream.SourceHealth.String)
 		}
 		out.Stream = jstr
+	} else if streamErr != nil {
+		// stream_state could not be READ (nil stream + error) — surface it as a distinct
+		// "unavailable" verdict so the omitted Stream section is not misread as "no loss".
+		out.StreamError = &jsonStreamError{
+			Continuity: jsonContinuity{Status: "unavailable"},
+			Error:      streamErr.Error(),
+		}
 	}
 	if archives != nil && archives.TotalFiles > 0 {
 		out.Archives = &jsonArchives{

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -334,9 +334,11 @@ func LoadStreamState(ctx context.Context, db *sql.DB) (*StreamStateInfo, error) 
 	// that has gap_lost but not yet source_health down to the base fallback (losing the
 	// loss record). The separate query degrades to "no health" on the unknown-column error
 	// (a legacy/un-migrated index) or an empty row; any OTHER error surfaces, since the core
-	// load already proved the DB reachable.
+	// load already proved the DB reachable; any hard error here is logged and ignored,
+	// keeping the already-loaded stream state (including gap_lost) visible rather than
+	// discarding it — that would re-hide the very GAP LOST banner #815 exists to surface.
 	if err := loadSourceHealth(ctx, db, s); err != nil {
-		return nil, err
+		slog.Warn("could not load source_health; keeping stream state without it", "error", err)
 	}
 	return s, nil
 }

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"strconv"
 	"strings"
 	"testing"
@@ -1304,5 +1305,72 @@ func TestWriteStatusJSON_sourceHealth(t *testing.T) {
 	}
 	if strings.Contains(buf2.String(), "source_health") {
 		t.Errorf("a stream with no health snapshot must omit source_health:\n%s", buf2.String())
+	}
+}
+
+// ─── stream-state read failure (#815) ───────────────────────────────────────────
+//
+// A FAILURE to read stream_state (StreamErr set, Stream nil) must be distinguished
+// from an empty table (both nil = no active stream): the former could not evaluate
+// the continuity verdict, so it must surface "unavailable" — never silently omit the
+// Stream section and its permanent-loss banner, which an operator would misread as
+// "no loss". The empty-table happy path must stay clean (no false "unavailable").
+func TestStatusData_streamReadError_text(t *testing.T) {
+	// Read error → visible "unavailable" continuity block.
+	var buf bytes.Buffer
+	(&StatusData{StreamErr: errors.New("Error 1142: SELECT command denied on stream_state")}).Write(&buf)
+	out := buf.String()
+	for _, want := range []string{"=== Stream ===", "Continuity:", "unavailable", "SELECT command denied"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("a stream-state read error must surface %q in the text report\n--- output ---\n%s", want, out)
+		}
+	}
+
+	// Empty table (no error) → NO stream block, NO false "unavailable".
+	var empty bytes.Buffer
+	(&StatusData{}).Write(&empty)
+	if strings.Contains(empty.String(), "unavailable") || strings.Contains(empty.String(), "=== Stream ===") {
+		t.Errorf("an empty stream_state (no read error) must not render a stream/unavailable block:\n%s", empty.String())
+	}
+}
+
+func TestStatusData_streamReadError_json(t *testing.T) {
+	// Read error → stream_error object with continuity.status "unavailable".
+	var buf bytes.Buffer
+	if err := (&StatusData{StreamErr: errors.New("read timeout")}).WriteJSON(&buf); err != nil {
+		t.Fatal(err)
+	}
+	var result struct {
+		Stream      *json.RawMessage `json:"stream"`
+		StreamError *struct {
+			Continuity struct {
+				Status string `json:"status"`
+			} `json:"continuity"`
+			Error string `json:"error"`
+		} `json:"stream_error"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, buf.String())
+	}
+	if result.Stream != nil {
+		t.Errorf("a read error must not fabricate a stream object (would read as a real empty stream):\n%s", buf.String())
+	}
+	if result.StreamError == nil {
+		t.Fatalf("stream_error missing — the read failure was silently omitted:\n%s", buf.String())
+	}
+	if result.StreamError.Continuity.Status != "unavailable" {
+		t.Errorf("stream_error.continuity.status = %q, want \"unavailable\"", result.StreamError.Continuity.Status)
+	}
+	if !strings.Contains(result.StreamError.Error, "read timeout") {
+		t.Errorf("stream_error.error must carry the underlying cause, got %q", result.StreamError.Error)
+	}
+
+	// Empty table (no error) → stream_error omitted, and no false "ok" anywhere.
+	var empty bytes.Buffer
+	if err := (&StatusData{}).WriteJSON(&empty); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(empty.String(), "stream_error") || strings.Contains(empty.String(), "unavailable") {
+		t.Errorf("an empty stream_state (no read error) must omit stream_error:\n%s", empty.String())
 	}
 }


### PR DESCRIPTION
## Problem

`CollectStatus` degrades a `LoadStreamState` read failure (transient timeout, revoked
`SELECT` on `stream_state`, an unexpected `loadSourceHealth` error) to a `slog.Warn` on
stderr and leaves `StatusData.Stream` nil — indistinguishable from an empty table (no
active stream). Both text and JSON output then omit the **entire Stream section**,
including the always-present Continuity verdict and the `=== ⚠ EVENTS PERMANENTLY LOST ===`
banner. On an index with `gap_lost` stamped + a transient read error, the operator (or a
JSON consumer, where `stream` is simply absent) reads the omission as "no active stream /
no loss". The only trace is a stderr warning. Fail-silent on a data-loss signal.

## Fix (additive, fail-visible)

Thread the read error into `StatusData.StreamErr` (new field, `json:"-"`) and surface it as
a distinct **"unavailable"** continuity verdict instead of silence:

- **Text** (`StatusData.Write`): a visible `=== Stream ===` block —
  `Continuity: ⚠ unavailable (could not read stream state: <err>)` plus a note that the
  permanent-loss banner can neither be shown nor ruled out.
- **JSON** (`StatusData.WriteJSON`): a distinct top-level `stream_error` object with
  `continuity.status = "unavailable"` and the underlying error. Deliberately **not** a
  fabricated `stream` object — `jsonStream`'s non-omitempty `events_indexed:0`/`mode:""`
  would read as a real empty stream, which is worse than the bug.

The happy path is untouched: an empty `stream_state` (Stream nil, StreamErr nil) renders
no block / omits `stream_error` exactly as before. The console green badge (keys on
`stream.continuity.status == "ok"`) stays non-green when `stream` is absent, and
`--fail-on-gap` already fails closed on `data.Stream == nil` — this change only makes the
failure **visible in the report itself**. As a bonus it also un-hides the `loadSourceHealth`
error branch, which previously discarded an already-read `gap_lost` and swallowed the error.

Exported `WriteStatus`/`WriteStatusJSON` signatures are unchanged; only the unexported
`writeStatusJSONFull` gains a `streamErr` param (2 in-package callers).

## Test

`TestStatusData_streamReadError_text` / `_json` pin **both halves** of the discriminator at
the rendering level (no live DB): a read error surfaces "unavailable" in text and JSON,
while a genuine empty table stays clean with no false "unavailable".

`go test ./internal/status/ -count=1` → ok.

Closes #815
