### PR TITLE
console: exempt loopback peers from the global login-failure gate

### DIFF
--- a/internal/console/ratelimit.go
+++ b/internal/console/ratelimit.go
@@ -2,6 +2,7 @@ package console
 
 import (
 	"log/slog"
+	"net"
 	"sync"
 	"time"
 )
@@ -82,7 +83,12 @@ func (l *loginLimiter) Allow(ip string) (bool, time.Duration) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	if l.global.observe(now, globalWindow) >= globalMax {
+	// The global window caps attacker-driven bcrypt CPU, but it must never
+	// lock out the operator (the file's throttle-only invariant). A loopback
+	// peer is the operator on the same host — ip is the real socket peer from
+	// r.RemoteAddr (never a spoofable X-Forwarded-For), so exempt it from the
+	// global gate. The per-IP gate below still applies to loopback callers.
+	if !isLoopbackIP(ip) && l.global.observe(now, globalWindow) >= globalMax {
 		l.logThrottledLocked(now, "global")
 		return false, l.global.retryAfter(now, globalWindow)
 	}
@@ -99,6 +105,14 @@ func (l *loginLimiter) Allow(ip string) (bool, time.Duration) {
 		return false, w.long.retryAfter(now, ipLongWindow)
 	}
 	return true, 0
+}
+
+// isLoopbackIP reports whether ip (the host part of r.RemoteAddr) is a
+// loopback address. A non-parseable value (never a real socket peer) is not
+// treated as loopback, so it stays subject to the global gate.
+func isLoopbackIP(ip string) bool {
+	parsed := net.ParseIP(ip)
+	return parsed != nil && parsed.IsLoopback()
 }
 
 // Fail records a failed attempt from ip.

--- a/internal/console/ratelimit_test.go
+++ b/internal/console/ratelimit_test.go
@@ -78,6 +78,42 @@ func TestLimiterGlobalWindow(t *testing.T) {
 	}
 }
 
+func TestLimiterGlobalWindowExemptsLoopback(t *testing.T) {
+	l, _ := fakeLimiter(t)
+	// Drive the global counter to its cap using rotating REMOTE IPs, so no
+	// loopback IP accrues any per-IP failures — the only gate that could then
+	// deny loopback is the global one.
+	for i := 0; i < globalMax; i++ {
+		l.Fail(fmt.Sprintf("10.0.%d.%d", i/250, i%250))
+	}
+	// A remote IP is still gated by the tripped global window.
+	if ok, _ := l.Allow("192.168.1.1"); ok {
+		t.Error("remote IP not gated by the global window")
+	}
+	// Loopback callers (the operator on the same host) are exempt from the
+	// global gate — a sustained brute force must never lock them out.
+	for _, ip := range []string{"127.0.0.1", "::1"} {
+		if ok, _ := l.Allow(ip); !ok {
+			t.Errorf("loopback %s denied by the global window — operator locked out", ip)
+		}
+	}
+}
+
+func TestLimiterLoopbackStillPerIPThrottled(t *testing.T) {
+	l, _ := fakeLimiter(t)
+	// The loopback exemption is ONLY for the global gate; the per-IP gate must
+	// still apply to loopback callers.
+	for i := 0; i < ipShortMax; i++ {
+		if ok, _ := l.Allow("127.0.0.1"); !ok {
+			t.Fatalf("attempt %d denied early", i)
+		}
+		l.Fail("127.0.0.1")
+	}
+	if ok, _ := l.Allow("127.0.0.1"); ok {
+		t.Error("loopback escaped the per-IP short window — exemption too broad")
+	}
+}
+
 func TestLimiterSuccessClearsIP(t *testing.T) {
 	l, _ := fakeLimiter(t)
 	for i := 0; i < ipShortMax; i++ {


### PR DESCRIPTION
## Problem

`loginLimiter.Allow` (internal/console/ratelimit.go) checks the global 30-failures/min window BEFORE the per-IP window and, once tripped, denies **every** caller — including loopback, i.e. the operator on the same host.

On a non-loopback bind an attacker who sustains 30 failed `/api/auth/login` POSTs per minute (change-password goes through the same limiter) keeps the operator in `429` indefinitely. That is precisely the self-DoS the file's own throttle-only invariant forbids ("never a lockout: locking the single user out would hand an attacker a trivial DoS against the operator").

## Fix

Exempt **loopback** peers from the **global** gate only:

```go
if !isLoopbackIP(ip) && l.global.observe(now, globalWindow) >= globalMax {
```

- The IP is the real socket peer: `clientIP` derives it from `net.SplitHostPort(r.RemoteAddr)` and never consults `X-Forwarded-For` / `X-Real-IP`, so the exemption cannot be spoofed by a header.
- The per-IP short/long windows still apply to loopback, so brute force from localhost stays throttled.
- The guard lives in `Allow`, so all three bcrypt-verifying call sites (login and both change-password paths) inherit it with no per-site change.

Minimal additive guard — no existing logic rewritten.

## Test

`internal/console/ratelimit_test.go`:

- `TestLimiterGlobalWindowExemptsLoopback` — drive the global counter to its cap with rotating **remote** IPs (so no loopback per-IP failures accrue), then assert a remote IP is still `429` while `127.0.0.1` and `::1` are both allowed.
- `TestLimiterLoopbackStillPerIPThrottled` — loopback is still denied by the per-IP short window after `ipShortMax` failures, pinning that the exemption covers only the global gate.

`go build` + `go test ./internal/console/` pass.

Closes #847
