### PR TITLE
baseline: --retry must re-convert a truncated Parquet, not skip it

### DIFF
--- a/internal/baseline/baseline.go
+++ b/internal/baseline/baseline.go
@@ -154,22 +154,37 @@ func Run(ctx context.Context, cfg Config) (Stats, error) {
 
 			if cfg.Retry {
 				if fi, err := os.Stat(outPath); err == nil && fi.Size() > 0 {
-					// A retry-skipped file keeps whatever digest it already has.
-					// A file written before #633 (or by an older binary across a
-					// mid-baseline upgrade) has none, and re-running --retry will
-					// not heal it — surface that so the operator knows the
-					// snapshot won't be fully verifiable without a fresh run.
-					if existing, mErr := ReadParquetMetadata(outPath); mErr == nil && existing.ContentDigest == "" {
-						slog.Warn("skipped existing file has no content digest; this table won't be verifiable without a fresh baseline",
+					// Size>0 alone is NOT proof the file is a usable Parquet
+					// (#798): an OOM/SIGKILL mid-processTable can leave a
+					// nonzero-but-truncated file with no footer. ReadParquetMetadata
+					// parses the footer, so its error is the exact signal that this
+					// "existing" file is corrupt — re-convert rather than bless the
+					// truncated bytes (WriteManifest would otherwise CRC them and
+					// publish _SUCCESS, exploding only at restore time). Only skip
+					// when the file both exists AND parses as valid Parquet.
+					existing, mErr := ReadParquetMetadata(outPath)
+					if mErr != nil {
+						slog.Warn("existing baseline file did not parse as valid Parquet (truncated/corrupt) — re-converting instead of skipping (--retry)",
+							"db", tf.Database, "table", tf.Table, "file", outPath, "error", mErr)
+						// fall through to re-convert
+					} else {
+						// A retry-skipped file keeps whatever digest it already has.
+						// A file written before #633 (or by an older binary across a
+						// mid-baseline upgrade) has none, and re-running --retry will
+						// not heal it — surface that so the operator knows the
+						// snapshot won't be fully verifiable without a fresh run.
+						if existing.ContentDigest == "" {
+							slog.Warn("skipped existing file has no content digest; this table won't be verifiable without a fresh baseline",
+								"db", tf.Database, "table", tf.Table, "file", outPath)
+						}
+						slog.Info("skipping existing file (--retry)",
 							"db", tf.Database, "table", tf.Table, "file", outPath)
+						mu.Lock()
+						stats.TablesProcessed++
+						stats.FilesWritten++
+						mu.Unlock()
+						return
 					}
-					slog.Info("skipping existing file (--retry)",
-						"db", tf.Database, "table", tf.Table, "file", outPath)
-					mu.Lock()
-					stats.TablesProcessed++
-					stats.FilesWritten++
-					mu.Unlock()
-					return
 				}
 			}
 

--- a/internal/baseline/baseline_test.go
+++ b/internal/baseline/baseline_test.go
@@ -1806,6 +1806,72 @@ func TestRunRetrySkipsExistingFiles(t *testing.T) {
 	}
 }
 
+// TestRunRetryReconvertsTruncatedParquet is the #798 guard: on --retry a
+// nonzero-but-truncated Parquet (no footer, e.g. from an OOM/SIGKILL mid
+// processTable) must be RE-CONVERTED, not skipped. The pre-fix skip decision
+// was size-only, so it blessed the corrupt bytes; WriteManifest then CRC'd them
+// and _SUCCESS was published, exploding only at restore time. The skip must now
+// honor ReadParquetMetadata (footer parse) — skip only a file that parses.
+func TestRunRetryReconvertsTruncatedParquet(t *testing.T) {
+	inputDir := t.TempDir()
+	outputDir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(inputDir, "metadata"), []byte(sampleMetadata), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(inputDir, "shop.orders-schema.sql"), []byte(sampleSchema), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	const sqlData = "INSERT INTO `orders` VALUES(1,10,'9.99','note','2025-01-01 00:00:00','2025-01-15');\n"
+	if err := os.WriteFile(filepath.Join(inputDir, "shop.orders.00000.sql"), []byte(sqlData), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := Config{
+		InputDir:     inputDir,
+		OutputDir:    outputDir,
+		Compression:  "none",
+		RowGroupSize: 100,
+	}
+
+	// First run: creates a valid Parquet file.
+	if _, err := Run(context.Background(), cfg); err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+
+	outPath := filepath.Join(snapDir(t, outputDir), "shop", "orders.parquet")
+	if _, err := ReadParquetMetadata(outPath); err != nil {
+		t.Fatalf("sanity: first-run Parquet should parse, got %v", err)
+	}
+
+	// Simulate an OOM/SIGKILL that left a truncated (footerless) file: nonzero
+	// size but not a parseable Parquet.
+	if err := os.Truncate(outPath, 8); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	if fi, err := os.Stat(outPath); err != nil || fi.Size() == 0 {
+		t.Fatalf("truncated file must remain nonzero size (stat err=%v)", err)
+	}
+	if _, err := ReadParquetMetadata(outPath); err == nil {
+		t.Fatal("sanity: truncated Parquet must fail to parse (the re-convert signal)")
+	}
+
+	// Retry run: must RE-CONVERT the corrupt file, not skip it. The skip path
+	// leaves RowsWritten==0; a re-conversion writes the row again.
+	cfg.Retry = true
+	stats, err := Run(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("retry Run: %v", err)
+	}
+	if stats.RowsWritten != 1 {
+		t.Errorf("retry Run: RowsWritten = %d, want 1 (truncated file must be re-converted, not skipped)", stats.RowsWritten)
+	}
+	// The healed file must parse again.
+	if _, err := ReadParquetMetadata(outPath); err != nil {
+		t.Errorf("after retry the Parquet should parse, got %v", err)
+	}
+}
+
 // ─── ReadParquetMetadata ─────────────────────────────────────────────────────
 
 func TestReadParquetMetadata(t *testing.T) {


### PR DESCRIPTION
## Problem

On `--retry`, `baseline.Run` decided whether to skip an existing table
Parquet using `os.Stat` size only (`fi.Size() > 0`). A
nonzero-but-truncated `.parquet` — e.g. left behind by an OOM/SIGKILL
mid-`processTable`, before the footer was written — passed that check and
was treated as "already done" and skipped. `WriteManifest` then CRC'd the
corrupt bytes and `_SUCCESS` was published, so the corruption only
surfaced at restore time.

The exact signal that would have caught it was already computed:
`ReadParquetMetadata(outPath)` parses the Parquet footer and fails on a
truncated file, but its error was discarded — it only fed the
missing-content-digest warning.

## Fix

Honor the `ReadParquetMetadata` result in the skip decision. Skip only
when the file both exists AND parses as a valid Parquet; on a parse error
(truncated / corrupt / no footer) fall through and re-convert the table.
`NewWriter` opens with `os.Create`, which truncates, so re-conversion
cleanly overwrites the partial file. A valid Parquet that merely lacks
bintrail metadata keys still parses without error, so legacy baselines are
not needlessly re-converted. Minimal, additive, fail-loud.

## Test

`TestRunRetryReconvertsTruncatedParquet`: writes a valid baseline, truncates
its Parquet to 8 bytes (nonzero, footerless), asserts `ReadParquetMetadata`
now errors, then runs `--retry` and asserts the table is re-converted
(`RowsWritten == 1`, not the skip path's `0`) and the healed file parses
again. Existing `TestRunRetrySkipsExistingFiles` still passes (a valid file
is still skipped). Full `internal/baseline` unit suite green.

Closes #798
