### PR TITLE
agent (BYOS): count permanent two-sink losses, escalate on drop

### DIFF
--- a/cliapp/agent.go
+++ b/cliapp/agent.go
@@ -512,9 +512,39 @@ type flushPipelineState struct {
 	payloadStatus     string // "ok" or "degraded"
 	lastMetadataFlush *time.Time
 	lastPayloadFlush  *time.Time
+
+	// Cumulative counts of events/batches permanently dropped after the
+	// in-process retries were exhausted. There is no on-disk spool yet (see
+	// the follow-up), so a batch that fails all retries is truncated and lost;
+	// these counters are the only durable, monotonic signal that this
+	// happened. The metadataStatus/payloadStatus bools flip back to "ok" on
+	// the next successful flush and erase the memory of the outage — the
+	// counters never reset. Metadata and payload are tracked separately
+	// because the two sinks fail independently: a nonzero skew between them
+	// means the hosted index and the client bucket now disagree about which
+	// row images exist.
+	metadataLostEvents  int64
+	metadataLostBatches int64
+	payloadLostEvents   int64
+	payloadLostBatches  int64
 }
 
-func (s *flushPipelineState) updateFlush(metaOK, payloadOK bool) {
+// flushLossTotals is a snapshot of the cumulative lost-event/lost-batch
+// counters, returned by updateFlush so the caller can log the running total
+// without re-acquiring the lock.
+type flushLossTotals struct {
+	metadataLostEvents  int64
+	metadataLostBatches int64
+	payloadLostEvents   int64
+	payloadLostBatches  int64
+}
+
+// updateFlush records the outcome of a sink flush. metaEvents/payloadEvents
+// are the batch sizes that were attempted; when a sink fails they are added to
+// its cumulative lost-event counter (the batch is dropped without a spool). It
+// returns a snapshot of the cumulative totals so the caller can log the
+// running total on a drop.
+func (s *flushPipelineState) updateFlush(metaOK, payloadOK bool, metaEvents, payloadEvents int) flushLossTotals {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	now := time.Now().UTC()
@@ -523,12 +553,22 @@ func (s *flushPipelineState) updateFlush(metaOK, payloadOK bool) {
 		s.lastMetadataFlush = &now
 	} else {
 		s.metadataStatus = "degraded"
+		s.metadataLostEvents += int64(metaEvents)
+		s.metadataLostBatches++
 	}
 	if payloadOK {
 		s.payloadStatus = "ok"
 		s.lastPayloadFlush = &now
 	} else {
 		s.payloadStatus = "degraded"
+		s.payloadLostEvents += int64(payloadEvents)
+		s.payloadLostBatches++
+	}
+	return flushLossTotals{
+		metadataLostEvents:  s.metadataLostEvents,
+		metadataLostBatches: s.metadataLostBatches,
+		payloadLostEvents:   s.payloadLostEvents,
+		payloadLostBatches:  s.payloadLostBatches,
 	}
 }
 
@@ -547,13 +587,17 @@ func (s *flushPipelineState) toFlushStatus() *agent.FlushStatus {
 	b := s.bufferBytes
 	e := s.sizeEvictions
 	return &agent.FlushStatus{
-		BufferEvents:      &n,
-		BufferBytes:       &b,
-		SizeEvictions:     &e,
-		MetadataStatus:    s.metadataStatus,
-		PayloadStatus:     s.payloadStatus,
-		LastMetadataFlush: s.lastMetadataFlush,
-		LastPayloadFlush:  s.lastPayloadFlush,
+		BufferEvents:        &n,
+		BufferBytes:         &b,
+		SizeEvictions:       &e,
+		MetadataStatus:      s.metadataStatus,
+		PayloadStatus:       s.payloadStatus,
+		LastMetadataFlush:   s.lastMetadataFlush,
+		LastPayloadFlush:    s.lastPayloadFlush,
+		MetadataLostEvents:  s.metadataLostEvents,
+		MetadataLostBatches: s.metadataLostBatches,
+		PayloadLostEvents:   s.payloadLostEvents,
+		PayloadLostBatches:  s.payloadLostBatches,
 	}
 }
 
@@ -823,7 +867,22 @@ func flushToSinks(ctx context.Context, batch []parser.Event, fc *byosFlushConfig
 	}
 
 	if fc.state != nil {
-		fc.state.updateFlush(metaOK, payloadOK)
+		totals := fc.state.updateFlush(metaOK, payloadOK, len(metaBatch), len(payloadBatch))
+		if !metaOK || !payloadOK {
+			// A batch failed all retries and was dropped without a spool —
+			// permanent, irrecoverable loss. Escalate above the per-sink
+			// errors above with the running cumulative totals so the loss is
+			// an observable, monotonic signal rather than a single lost line.
+			slog.Error("BYOS batch dropped after retries — events permanently lost (no on-disk spool)",
+				"metadata_dropped", !metaOK,
+				"payload_dropped", !payloadOK,
+				"batch_events", len(metaBatch),
+				"cumulative_metadata_lost_events", totals.metadataLostEvents,
+				"cumulative_metadata_lost_batches", totals.metadataLostBatches,
+				"cumulative_payload_lost_events", totals.payloadLostEvents,
+				"cumulative_payload_lost_batches", totals.payloadLostBatches,
+				"sink_skew_events", totals.metadataLostEvents-totals.payloadLostEvents)
+		}
 	}
 	return nil
 }

--- a/cliapp/agent_test.go
+++ b/cliapp/agent_test.go
@@ -244,7 +244,7 @@ func TestByosStreamLoopContextCancellation(t *testing.T) {
 func TestFlushPipelineStateToFlushStatus(t *testing.T) {
 	state := &flushPipelineState{}
 	state.setBufferStats(42, 8192, 5)
-	state.updateFlush(true, false)
+	state.updateFlush(true, false, 3, 3)
 
 	status := state.toFlushStatus()
 	if status.BufferEvents == nil || *status.BufferEvents != 42 {
@@ -267,6 +267,58 @@ func TestFlushPipelineStateToFlushStatus(t *testing.T) {
 	}
 	if status.LastPayloadFlush != nil {
 		t.Error("LastPayloadFlush should be nil when payload failed")
+	}
+	// The metadata sink succeeded, so nothing lost there; the payload sink
+	// failed with a 3-event batch, so exactly those are counted lost.
+	if status.MetadataLostEvents != 0 || status.MetadataLostBatches != 0 {
+		t.Errorf("metadata lost = (%d events, %d batches), want (0, 0)",
+			status.MetadataLostEvents, status.MetadataLostBatches)
+	}
+	if status.PayloadLostEvents != 3 || status.PayloadLostBatches != 1 {
+		t.Errorf("payload lost = (%d events, %d batches), want (3, 1)",
+			status.PayloadLostEvents, status.PayloadLostBatches)
+	}
+}
+
+// TestFlushPipelineStateLostCountersCumulative pins the durability guarantee:
+// the lost-event/lost-batch counters accumulate across flushes and are NOT
+// reset when a later flush succeeds (unlike the status strings, which flip
+// back to "ok" and erase the memory of the outage).
+func TestFlushPipelineStateLostCountersCumulative(t *testing.T) {
+	state := &flushPipelineState{}
+
+	// First outage: both sinks fail a 5-event batch.
+	got := state.updateFlush(false, false, 5, 5)
+	if got.metadataLostEvents != 5 || got.metadataLostBatches != 1 ||
+		got.payloadLostEvents != 5 || got.payloadLostBatches != 1 {
+		t.Fatalf("after first drop: %+v, want all (5 events, 1 batch)", got)
+	}
+
+	// Second outage: only the payload sink fails a 2-event batch. Metadata
+	// recovers ("ok") but its cumulative counter must NOT reset.
+	got = state.updateFlush(true, false, 2, 2)
+	if got.metadataLostEvents != 5 || got.metadataLostBatches != 1 {
+		t.Errorf("metadata counter reset on recovery: %+v, want (5 events, 1 batch)", got)
+	}
+	if got.payloadLostEvents != 7 || got.payloadLostBatches != 2 {
+		t.Errorf("payload lost = (%d events, %d batches), want (7, 2)",
+			got.payloadLostEvents, got.payloadLostBatches)
+	}
+
+	// A fully successful flush leaves the cumulative counters untouched even
+	// as it clears the degraded status.
+	got = state.updateFlush(true, true, 4, 4)
+	if got.metadataLostEvents != 5 || got.payloadLostEvents != 7 {
+		t.Errorf("counters changed on success: %+v, want metadata=5 payload=7", got)
+	}
+	status := state.toFlushStatus()
+	if status.MetadataStatus != "ok" || status.PayloadStatus != "ok" {
+		t.Errorf("status after success = (%q, %q), want (ok, ok)",
+			status.MetadataStatus, status.PayloadStatus)
+	}
+	if status.MetadataLostEvents != 5 || status.PayloadLostEvents != 7 {
+		t.Errorf("status lost = (meta %d, payload %d), want (5, 7)",
+			status.MetadataLostEvents, status.PayloadLostEvents)
 	}
 }
 

--- a/internal/agent/channel.go
+++ b/internal/agent/channel.go
@@ -103,6 +103,14 @@ type FlushStatus struct {
 	PayloadStatus     string // "ok" or "degraded"
 	LastMetadataFlush *time.Time
 	LastPayloadFlush  *time.Time
+
+	// Cumulative events/batches permanently dropped after retries were
+	// exhausted (no on-disk spool). Monotonic — never reset — unlike the
+	// status strings above, which flip back to "ok" on the next success.
+	MetadataLostEvents  int64
+	MetadataLostBatches int64
+	PayloadLostEvents   int64
+	PayloadLostBatches  int64
 }
 
 // NewChannel creates a Channel. The handler is called for each command
@@ -365,6 +373,10 @@ func (ch *Channel) sendHeartbeat(ctx context.Context, conn *websocket.Conn) erro
 			hb.PayloadStatus = s.PayloadStatus
 			hb.LastMetadataFlush = s.LastMetadataFlush
 			hb.LastPayloadFlush = s.LastPayloadFlush
+			hb.MetadataLostEvents = s.MetadataLostEvents
+			hb.MetadataLostBatches = s.MetadataLostBatches
+			hb.PayloadLostEvents = s.PayloadLostEvents
+			hb.PayloadLostBatches = s.PayloadLostBatches
 		}
 	}
 	return writeJSON(ctx, conn, hb)

--- a/internal/agent/command.go
+++ b/internal/agent/command.go
@@ -66,6 +66,13 @@ type Heartbeat struct {
 	PayloadStatus     string     `json:"payload_status,omitempty"`  // "ok" or "degraded"
 	LastMetadataFlush *time.Time `json:"last_metadata_flush,omitempty"`
 	LastPayloadFlush  *time.Time `json:"last_payload_flush,omitempty"`
+
+	// Cumulative events/batches permanently dropped after retries were
+	// exhausted (BYOS mode; no on-disk spool). Monotonic; omitted while zero.
+	MetadataLostEvents  int64 `json:"metadata_lost_events,omitempty"`
+	MetadataLostBatches int64 `json:"metadata_lost_batches,omitempty"`
+	PayloadLostEvents   int64 `json:"payload_lost_events,omitempty"`
+	PayloadLostBatches  int64 `json:"payload_lost_batches,omitempty"`
 }
 
 // ─── Command payloads ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

In BYOS mode, when a flush batch fails all retries, `flushBatch` truncates it (`batch = batch[:0]`) without any spool — the events are lost forever. The only prior signal was the per-sink `metadata_status`/`payload_status` bool, which flips back to `"ok"` on the next successful flush and erases the memory of the outage. A monitor watching only that never learns loss occurred.

The two sinks (hosted metadata API vs client S3 payload) fail **independently**, so the hosted index can end up referencing row images absent from the client bucket (or vice versa) with no durable trace of the divergence.

## Fix

Minimal, additive, fail-loud guard (the full on-disk-spool fix is out of scope here — see follow-up):

- `flushPipelineState` gains four cumulative, **monotonic** counters: `metadataLostEvents`/`metadataLostBatches` and `payloadLostEvents`/`payloadLostBatches`. Unlike the status strings, they never reset on recovery.
- `updateFlush(metaOK, payloadOK, metaEvents, payloadEvents)` increments the counters on a per-sink failure and returns a snapshot of the running totals.
- The totals are surfaced in `agent.FlushStatus` and the `Heartbeat` wire contract (new `metadata_lost_events`/`_batches`, `payload_lost_events`/`_batches`, `omitempty` — additive, older consumers ignore them).
- On any drop, `flushToSinks` escalates a loud `slog.Error` carrying the running cumulative totals and the metadata-vs-payload **skew** (the divergence signal), above the existing per-sink error lines (kept).

Batch truncation is intentionally left untouched — this turns silent permanent loss into an observable, monotonic signal without rewriting the working flush path.

## Test

- Extended `TestFlushPipelineStateToFlushStatus` to assert a failed payload flush counts exactly its batch size lost while the succeeding metadata sink counts zero.
- New `TestFlushPipelineStateLostCountersCumulative` pins the durability guarantee: counters accumulate across outages and are NOT reset when a later flush (or the other sink) recovers, while the status strings do flip back to `"ok"`.
- `CGO_ENABLED=1 go build ./cliapp/... ./internal/agent/...` and `go test` on both packages pass.

## Follow-up (out of scope)

On-disk spool + re-drain (or checkpoint rollback) to actually **recover** the dropped batch rather than only count it.

Closes #805