### PR TITLE
stream: escalate position-mode resume when a source rebuild is undetectable (#780)

### DIFF
--- a/internal/streamrun/streamrun.go
+++ b/internal/streamrun/streamrun.go
@@ -546,6 +546,17 @@ type gapResult struct {
 
 	// For unfillable gaps in GTID mode: the purged GTID set to use as base.
 	PurgedGTIDSet string
+
+	// RebuildUndetectable is set by position-mode gap detection when it resumes
+	// reading from an existing binlog at a valid offset (no gap, or a fillable
+	// gap). In that case a source rebuild (RESET MASTER + restore) that regrew a
+	// same-named binlog past the checkpoint offset is INVISIBLE here — the file
+	// exists and checkpointPos <= size, so the check passes and the stream reads
+	// a potentially DIFFERENT history. GTID mode detects this divergence (the
+	// executed-set comparison in detectGTIDGap); position mode has no identity
+	// signal at gap-detection time. Callers surface this as an escalated warning.
+	// Never set by the GTID detectors — GTID resumes stay false.
+	RebuildUndetectable bool
 }
 
 // detectPositionGap queries the source MySQL for available binary logs and
@@ -616,13 +627,17 @@ func detectPositionGap(sourceDB *sql.DB, checkpointFile string, checkpointPos ui
 				}, nil
 			}
 			// File still exists and position is valid — gap is fillable.
+			// Either way we resume reading the existing file from checkpointPos,
+			// so a same-named regrown binlog after a source rebuild is undetectable
+			// here (see gapResult.RebuildUndetectable).
 			currentFile := logs[len(logs)-1].name
 			if checkpointFile == currentFile {
-				return &gapResult{HasGap: false}, nil
+				return &gapResult{HasGap: false, RebuildUndetectable: true}, nil
 			}
 			return &gapResult{
-				HasGap:   true,
-				Fillable: true,
+				HasGap:              true,
+				Fillable:            true,
+				RebuildUndetectable: true,
 				Message: fmt.Sprintf(
 					"gap detected: checkpoint is at %s:%d, source is at %s; replaying missed events",
 					checkpointFile, checkpointPos, currentFile),
@@ -1567,6 +1582,29 @@ func One(ctx context.Context, cfg Config) error {
 					cfg.Hooks.OnGapAutoAdvance(gap.Message)
 				}
 			}
+		}
+
+		// Position-mode resume cannot detect a source rebuild. When the checkpoint
+		// file still exists and checkpointPos <= size (no gap, or a fillable gap),
+		// detectPositionGap resumes reading from checkpointPos — but if the source
+		// was rebuilt (RESET MASTER + restore) and a same-named binlog regrew past
+		// that offset, we would silently index a DIFFERENT binlog history. GTID
+		// mode detects this (the executed-set comparison in detectGTIDGap
+		// diverges); position mode has no identity signal at gap-detection time.
+		// Escalate loudly rather than resume silently. Non-blocking: a hard error
+		// here would break every legitimate position-mode resume.
+		if gap != nil && gap.RebuildUndetectable {
+			slog.Warn("position-mode resume cannot detect a source rebuild: if the source was "+
+				"rebuilt (RESET MASTER + restore) and a same-named binlog regrew past the checkpoint "+
+				"offset, streaming will silently index a divergent binlog history. GTID mode detects "+
+				"this; position mode does not. To protect against rebuilds, run in GTID mode "+
+				"(start with --start-gtid); if this source was already rebuilt, pass --reset to "+
+				"discard the stale checkpoint before restarting.",
+				"checkpoint_file", startFile, "checkpoint_pos", startPos)
+			fmt.Printf("Warning: position-mode resume cannot verify the source was not rebuilt "+
+				"(RESET MASTER + restore) at %s:%d; if it was, streaming will index a divergent "+
+				"history. GTID mode (--start-gtid) detects this; pass --reset if the source was rebuilt.\n",
+				startFile, startPos)
 		}
 	}
 

--- a/internal/streamrun/streamrun_test.go
+++ b/internal/streamrun/streamrun_test.go
@@ -863,6 +863,11 @@ func TestDetectPositionGap_noGap(t *testing.T) {
 	if gap.HasGap {
 		t.Error("expected no gap when checkpoint is on latest file")
 	}
+	// Resuming in place: a same-named regrown binlog after a source rebuild is
+	// undetectable here, so the guard flag must be set (#780).
+	if !gap.RebuildUndetectable {
+		t.Error("expected RebuildUndetectable=true on an in-place position-mode resume")
+	}
 }
 
 // TestDetectPositionGap_fillable verifies that a fillable gap is reported when
@@ -892,6 +897,11 @@ func TestDetectPositionGap_fillable(t *testing.T) {
 	}
 	if !strings.Contains(gap.Message, "mysql-bin.000001") {
 		t.Errorf("expected checkpoint file in message, got: %s", gap.Message)
+	}
+	// Fillable gap still resumes reading the existing checkpoint file — rebuild
+	// undetectable (#780).
+	if !gap.RebuildUndetectable {
+		t.Error("expected RebuildUndetectable=true on a fillable position-mode gap")
 	}
 }
 
@@ -931,6 +941,11 @@ func TestDetectPositionGap_unfillable(t *testing.T) {
 	if !strings.Contains(gap.Message, "mysql-bin.000038") {
 		t.Errorf("expected checkpoint file in message, got: %s", gap.Message)
 	}
+	// A purged (unfillable) gap is already surfaced loudly and auto-advanced, so
+	// the rebuild-undetectable guard must NOT fire here (#780).
+	if gap.RebuildUndetectable {
+		t.Error("expected RebuildUndetectable=false on an unfillable/purged gap")
+	}
 }
 
 // TestDetectPositionGap_extraColumns verifies that SHOW BINARY LOGS with extra
@@ -956,6 +971,65 @@ func TestDetectPositionGap_extraColumns(t *testing.T) {
 	}
 	if !gap.Fillable {
 		t.Error("expected fillable gap")
+	}
+	if !gap.RebuildUndetectable {
+		t.Error("expected RebuildUndetectable=true on a fillable position-mode gap")
+	}
+}
+
+// TestDetectPositionGap_rebuildUndetectable pins the #780 guard: the source was
+// rebuilt (RESET MASTER + restore) and the same-named checkpoint binlog regrew
+// PAST the checkpoint offset. The file exists and checkpointPos < size, so the
+// check passes and the stream would resume reading a divergent history. Position
+// mode cannot tell — the guard flag is the only signal, and it must be set.
+func TestDetectPositionGap_rebuildUndetectable(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	// Checkpoint was mysql-bin.000001:5000. After a rebuild the source only has a
+	// regenerated mysql-bin.000001 that has already grown to 20000 bytes.
+	mock.ExpectQuery("SHOW BINARY LOGS").WillReturnRows(
+		sqlmock.NewRows([]string{"Log_name", "File_size"}).
+			AddRow("mysql-bin.000001", 20000))
+
+	gap, err := detectPositionGap(db, "mysql-bin.000001", 5000, 10*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gap.HasGap {
+		t.Error("expected no reported gap (checkpoint file is the latest and pos <= size)")
+	}
+	if !gap.RebuildUndetectable {
+		t.Error("expected RebuildUndetectable=true: a regrown same-named binlog is undetectable in position mode")
+	}
+}
+
+// TestDetectPositionGap_posExceedsSize verifies the pos>size branch (a truncated
+// or freshly-regenerated shorter file) is treated as an unfillable gap and does
+// NOT set the rebuild-undetectable guard — that path is already loud (#780).
+func TestDetectPositionGap_posExceedsSize(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SHOW BINARY LOGS").WillReturnRows(
+		sqlmock.NewRows([]string{"Log_name", "File_size"}).
+			AddRow("mysql-bin.000001", 500))
+
+	gap, err := detectPositionGap(db, "mysql-bin.000001", 9000, 10*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !gap.HasGap || gap.Fillable {
+		t.Fatalf("expected an unfillable gap when checkpoint pos exceeds file size, got %+v", gap)
+	}
+	if gap.RebuildUndetectable {
+		t.Error("expected RebuildUndetectable=false on the loud pos>size branch")
 	}
 }
 


### PR DESCRIPTION
## Problem

`detectPositionGap` only flagged a "regenerated" binlog when the checkpoint position *exceeded* the file size. If the source was rebuilt (`RESET MASTER` + restore) and the **same-named** binlog regrew *past* the checkpoint offset, the file exists and `checkpointPos <= size`, so the check passes and the stream resumes reading a **different** binlog history silently. GTID mode is unaffected — the executed-set comparison in `detectGTIDGap` diverges and the rebuild is detected there.

## Fix

Minimal, additive, fail-loud guard (GTID path untouched):

- Add `gapResult.RebuildUndetectable`, set on the two position-mode *resume-in-place* outcomes: no gap (checkpoint file is latest, `pos <= size`) and a fillable gap (checkpoint file still present). Both resume reading the existing file from `checkpointPos`, so a same-named regrown binlog is invisible.
- In `One`, when the flag is set, emit an escalated `slog.Warn` plus a printed banner: position-mode resume cannot detect a source rebuild; recommend GTID mode (`--start-gtid`) or `--reset` if a rebuild is known.
- **Non-blocking** by design — a hard error here would break every legitimate position-mode resume on upgrade. The unfillable/purged and `pos > size` branches are already loud and do **not** set the flag; the GTID detectors never set it.

## Follow-up (deferred, noted per issue)

Identity comparison against a stored fingerprint is deferred. `SHOW BINLOG EVENTS ... LIMIT 1` exposes `Server_id` but no timestamp, and `server_id`/`@@server_uuid` are **invariant across a same-server `RESET MASTER`**, so they would miss exactly this scenario while giving false confidence. The only reliable rebuild signal is the binlog Format-Description-Event *creation timestamp*, which is not SQL-queryable and requires a separate binlog read — not cleanly reachable at gap-detection time (no stream is open yet). Tracked as a follow-up.

## Test

`go test ./internal/streamrun/` (unit). Pinned the new field in all existing `detectPositionGap` sqlmock tests (`_noGap`/`_fillable` → true, `_unfillable` → false) and added two dedicated tests:
- `TestDetectPositionGap_rebuildUndetectable` — same-named binlog regrew past the checkpoint offset → flag set.
- `TestDetectPositionGap_posExceedsSize` — the loud `pos > size` branch stays false.

Closes #780