### PR TITLE
pg: record TRUNCATE as a schema_changes audit marker

### DIFF
--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -529,12 +529,17 @@ your own round-trip.
   if the child table is published**. If a published parent has an unpublished
   cascade child, the cascade rewrites are not captured — bintrail-pg warns (startup
   + doctor); add the child to the publication.
-- **`TRUNCATE` is not captured at all — not even as an audit trail.** Unlike
-  MySQL's DDL, which lands a `schema_changes` row bintrail can at least warn
-  about, a PostgreSQL `TRUNCATE` produces only a transient `Warn` log line at
-  capture time ("TRUNCATE not indexed") and nothing persisted. There is
-  nothing for `recover` to put back, and — unlike the MySQL path — no durable
-  record that the truncate happened at all.
+- **`TRUNCATE` is recorded as an audit marker, not a reversible change.** A
+  PostgreSQL `TRUNCATE` emits no per-row `DELETE`, so left uncaptured it would be
+  indistinguishable from "nothing happened". bintrail-pg records it as a
+  `schema_changes` row (`ddl_type = TRUNCATE TABLE`) — the same durable audit
+  trail MySQL's DDL leaves — surfaced by the `list_schema_changes` MCP tool and in
+  the `schema_changes` table. It is a *record that the truncate happened*, not a
+  reversible event: `recover` has no per-row before-images to put back, and a
+  `reconstruct` that crosses the truncate does not yet consume the marker (it can
+  still resurrect the pre-truncate rows from baseline + deltas). A multi-table
+  `TRUNCATE a, b` records one marker per published table; a truncate of an
+  out-of-scope table records nothing.
 - **Sequence cursors are not captured.** The materialized id values in your rows
   *are* captured; the sequence's own `last_value` (a separate catalog object) is
   not — logical decoding does not replicate sequences. After a restore, re-point

--- a/internal/pgcapture/capturer.go
+++ b/internal/pgcapture/capturer.go
@@ -273,6 +273,14 @@ func (c *Capturer) receiveLoop(ctx context.Context, replConn *pgconn.PgConn, dec
 					return err
 				}
 			}
+			// Drain any events the message produced beyond its single return value.
+			// Only a multi-relation TRUNCATE (`TRUNCATE a, b`) fills this — one marker
+			// per in-scope relation past the first — so none is silently dropped (#827).
+			for _, pev := range decoder.TakePending() {
+				if err := c.emit(ctx, replConn, out, pev, standbyTicker); err != nil {
+					return err
+				}
+			}
 		}
 	}
 }

--- a/internal/pgcapture/decoder.go
+++ b/internal/pgcapture/decoder.go
@@ -41,6 +41,13 @@ type Decoder struct {
 	relations map[uint32]*relationInfo
 	txn       txnContext
 
+	// pending buffers events a single Decode produced beyond its one return value.
+	// Only a multi-relation TRUNCATE fills it: `TRUNCATE a, b` arrives as ONE
+	// pgoutput message covering several relations, but Decode returns a single
+	// event — so the first in-scope marker is returned and the rest are queued here
+	// for the caller to drain via TakePending after every Decode (#827).
+	pending []event.Event
+
 	// timescaleWarned makes the TimescaleDB out-of-scope guard (#559) warn ONCE per
 	// stream: a busy hypertable has many chunk relations, and one warning per chunk
 	// would flood the log.
@@ -99,13 +106,19 @@ func NewDecoder(resolvePK PKResolver, filters event.Filters, logger *slog.Logger
 }
 
 // Decode processes one pgoutput message. It returns:
-//   - (event, true, nil) when the message produces a row or commit event;
+//   - (event, true, nil) when the message produces a row, commit, or DDL-marker
+//     event (a TRUNCATE covering several relations returns its first marker here
+//     and queues the rest for TakePending);
 //   - (zero, false, nil) when the message is consumed for internal state only
-//     (Begin/Relation) or is deliberately not indexed (Truncate/Type/Origin);
+//     (Begin/Relation) or produces nothing to index (Type/Origin, or a TRUNCATE
+//     whose relations are all out of scope);
 //   - (zero, false, err) on a decode-invariant violation (unknown relation, a row
 //     outside a transaction, a binary tuple datum, a tuple column-count mismatch,
 //     or a primary-key lookup failure). The caller must treat a non-nil error as
 //     fatal — never skip the message and continue, or the stream desynchronizes.
+//
+// After every Decode the caller MUST drain TakePending: a multi-relation TRUNCATE
+// buffers all but its first marker there.
 func (d *Decoder) Decode(msg pglogrepl.Message) (event.Event, bool, error) {
 	switch m := msg.(type) {
 	case *pglogrepl.BeginMessage:
@@ -151,12 +164,41 @@ func (d *Decoder) Decode(msg pglogrepl.Message) (event.Event, bool, error) {
 		return ev, true, nil
 
 	case *pglogrepl.TruncateMessage:
-		// DDL replay on the PostgreSQL path is out of #530 scope; surface a TRUNCATE
-		// loudly so it is never silently invisible in the index. (Open question:
-		// map to EventDDL/DDLTruncateTable later.)
-		d.logger.Warn("pgcapture: TRUNCATE not indexed (DDL replay out of scope)",
-			"relations", len(m.RelationIDs))
-		return event.Event{}, false, nil
+		// A TRUNCATE removes every row of each listed relation but emits NO per-row
+		// DELETE — so left uncaptured it is indistinguishable from "nothing happened",
+		// and a later reconstruct crossing it would silently resurrect the rows (#827).
+		// Record it as a durable audit MARKER: an EventDDL(DDLTruncateTable) the
+		// consumer writes to schema_changes, the source-neutral analog of the MySQL
+		// DDL path. This is a RECORD that the truncate happened, not a replayable
+		// change (DDL replay stays out of #530 scope; recover has no per-row images to
+		// put back). One message can list several relations (TRUNCATE a, b); emit one
+		// marker per in-scope relation, returning the first and buffering the rest for
+		// TakePending so none is silently dropped.
+		var first event.Event
+		haveFirst := false
+		for _, oid := range m.RelationIDs {
+			rel, ok := d.relations[oid]
+			if !ok {
+				// No cached shape (no preceding Relation message) — the relation cannot
+				// be named, so there is nothing meaningful to record. Warn rather than
+				// fabricate a blank marker.
+				d.logger.Warn("pgcapture: TRUNCATE on uncached relation OID — not recorded", "oid", oid)
+				continue
+			}
+			if !d.filters.Matches(rel.schema, rel.table) {
+				continue
+			}
+			ev := d.truncateEvent(rel)
+			if !haveFirst {
+				first, haveFirst = ev, true
+				continue
+			}
+			d.pending = append(d.pending, ev)
+		}
+		if !haveFirst {
+			return event.Event{}, false, nil
+		}
+		return first, true, nil
 
 	case *pglogrepl.TypeMessage, *pglogrepl.OriginMessage:
 		// No row data. Type/Origin are not needed for capture fidelity under
@@ -519,6 +561,41 @@ func (d *Decoder) rowEvent(rel *relationInfo, typ event.EventType, before, after
 		RowBefore:  before,
 		RowAfter:   after,
 	}
+}
+
+// truncateEvent builds the EventDDL(DDLTruncateTable) audit marker for one
+// truncated relation (#827), stamped with the in-flight transaction's commit LSN
+// and timestamp — a TRUNCATE always arrives between Begin and Commit, so d.txn
+// carries them. DDLQuery is a synthetic statement (pgoutput carries no SQL text)
+// so the schema_changes row reads naturally. Carries no row data: recover has
+// nothing to reverse; it is a record that the truncate happened.
+func (d *Decoder) truncateEvent(rel *relationInfo) event.Event {
+	lsn := d.txn.commitLSN.String()
+	return event.Event{
+		BinlogFile: lsn,
+		StartPos:   uint64(d.txn.commitLSN),
+		EndPos:     uint64(d.txn.commitLSN),
+		Timestamp:  d.txn.commitTime,
+		GTID:       lsn,
+		Schema:     rel.schema,
+		Table:      rel.table,
+		EventType:  event.EventDDL,
+		DDLType:    event.DDLTruncateTable,
+		DDLQuery:   fmt.Sprintf("TRUNCATE TABLE %s.%s", rel.schema, rel.table),
+	}
+}
+
+// TakePending returns and clears the events the last Decode buffered beyond its
+// single return value, then empties the buffer. Only a multi-relation TRUNCATE
+// fills it (one marker per in-scope relation past the first). The caller drains it
+// after every Decode; a nil return is the common no-op case.
+func (d *Decoder) TakePending() []event.Event {
+	if len(d.pending) == 0 {
+		return nil
+	}
+	p := d.pending
+	d.pending = nil
+	return p
 }
 
 // unchangedToastMarker is the structurally-distinct stand-in for an unchanged-TOAST

--- a/internal/pgcapture/decoder_test.go
+++ b/internal/pgcapture/decoder_test.go
@@ -430,16 +430,76 @@ func TestDecode_DeleteWithoutBeforeImageFailsLoud(t *testing.T) {
 	}
 }
 
-func TestDecode_TruncateNotIndexed(t *testing.T) {
-	// TRUNCATE has a real behavioral contract: it must be surfaced (warned) but
-	// NEVER indexed as a row event (DDL replay on the PG path is out of #530 scope).
+func TestDecode_TruncateEmitsAuditMarker(t *testing.T) {
+	// A TRUNCATE emits no per-row DELETE, so it must be recorded as a durable
+	// audit marker — an EventDDL(DDLTruncateTable) the consumer writes to
+	// schema_changes — carrying the truncated table and stamped with the txn's
+	// commit LSN/time (#827).
 	d := pgcapture.NewDecoder(pkResolver("id"), event.Filters{}, nil)
-	_, emit, err := d.Decode(&pglogrepl.TruncateMessage{RelationNum: 1, RelationIDs: []uint32{1}})
-	if err != nil {
-		t.Fatalf("TRUNCATE: unexpected error: %v", err)
+	mustDecode(t, d, relMsg(1, "public", "orders", "id", "amount"))
+	mustDecode(t, d, beginMsg())
+
+	ev, emit := mustDecode(t, d, &pglogrepl.TruncateMessage{RelationNum: 1, RelationIDs: []uint32{1}})
+	if !emit {
+		t.Fatal("TRUNCATE must emit an audit marker")
 	}
+	if ev.EventType != event.EventDDL || ev.DDLType != event.DDLTruncateTable {
+		t.Fatalf("TRUNCATE marker: type=%d ddl=%q, want EventDDL / %q", ev.EventType, ev.DDLType, event.DDLTruncateTable)
+	}
+	if ev.Schema != "public" || ev.Table != "orders" {
+		t.Fatalf("TRUNCATE marker table = %s.%s, want public.orders", ev.Schema, ev.Table)
+	}
+	if ev.DDLQuery != "TRUNCATE TABLE public.orders" {
+		t.Errorf("TRUNCATE marker DDLQuery = %q, want %q", ev.DDLQuery, "TRUNCATE TABLE public.orders")
+	}
+	if ev.EndPos != uint64(txnLSN) || !ev.Timestamp.Equal(txnTime) {
+		t.Errorf("TRUNCATE marker stamped EndPos=%d ts=%v, want %d / %v (commit coords)", ev.EndPos, ev.Timestamp, uint64(txnLSN), txnTime)
+	}
+	if p := d.TakePending(); len(p) != 0 {
+		t.Errorf("single-relation TRUNCATE must not buffer pending markers, got %d", len(p))
+	}
+}
+
+func TestDecode_TruncateMultiRelationBuffersPending(t *testing.T) {
+	// `TRUNCATE a, b` arrives as ONE message covering both relations; Decode
+	// returns the first marker and the second surfaces via TakePending so neither
+	// is silently dropped (#827).
+	d := pgcapture.NewDecoder(pkResolver("id"), event.Filters{}, nil)
+	mustDecode(t, d, relMsg(1, "public", "orders", "id"))
+	mustDecode(t, d, relMsg(2, "public", "items", "id"))
+	mustDecode(t, d, beginMsg())
+
+	ev, emit := mustDecode(t, d, &pglogrepl.TruncateMessage{RelationNum: 2, RelationIDs: []uint32{1, 2}})
+	if !emit || ev.Table != "orders" || ev.DDLType != event.DDLTruncateTable {
+		t.Fatalf("first marker = %s.%s (%q, emit=%v), want public.orders TRUNCATE TABLE", ev.Schema, ev.Table, ev.DDLType, emit)
+	}
+	pending := d.TakePending()
+	if len(pending) != 1 {
+		t.Fatalf("TakePending len = %d, want 1 (second truncated relation)", len(pending))
+	}
+	if pending[0].Table != "items" || pending[0].DDLType != event.DDLTruncateTable {
+		t.Errorf("pending marker = %s.%s (%q), want public.items TRUNCATE TABLE", pending[0].Schema, pending[0].Table, pending[0].DDLType)
+	}
+	if p := d.TakePending(); p != nil {
+		t.Errorf("TakePending must empty the buffer, second call returned %d events", len(p))
+	}
+}
+
+func TestDecode_TruncateFilteredOutRecordsNothing(t *testing.T) {
+	// A TRUNCATE of a table outside the capture filter records no marker (and
+	// buffers nothing) — the filter decides scope, same as the row paths.
+	d := pgcapture.NewDecoder(pkResolver("id"),
+		event.Filters{Tables: map[string]bool{"public.keep": true}}, nil)
+	mustDecode(t, d, relMsg(1, "public", "keep", "id"))
+	mustDecode(t, d, relMsg(2, "public", "skip", "id"))
+	mustDecode(t, d, beginMsg())
+
+	ev, emit := mustDecode(t, d, &pglogrepl.TruncateMessage{RelationNum: 1, RelationIDs: []uint32{2}})
 	if emit {
-		t.Error("TRUNCATE must not be indexed (DDL replay out of #530 scope) — emit should be false")
+		t.Errorf("TRUNCATE of a filtered-out table must not emit a marker, got %s.%s", ev.Schema, ev.Table)
+	}
+	if p := d.TakePending(); len(p) != 0 {
+		t.Errorf("filtered-out TRUNCATE must buffer no pending markers, got %d", len(p))
 	}
 }
 

--- a/internal/pgstreamrun/pgstreamrun.go
+++ b/internal/pgstreamrun/pgstreamrun.go
@@ -444,10 +444,20 @@ func streamLoopPG(
 				// batch (pgoutput delivers them before the commit).
 				lastCommitLSN = ev.EndPos
 			case event.EventDDL:
-				if err := flush(); err != nil {
-					return err
+				// A DDL marker — on the PostgreSQL path today only a TRUNCATE audit
+				// record (#827). Persist it to schema_changes immediately, the
+				// source-neutral analog of the MySQL DDL path, so the truncate is a
+				// durable, queryable record (bintrail-mcp list_schema_changes / the
+				// schema_changes table) rather than a transient warn. Like the
+				// EventRelation snapshot it commits in its own statement, OUTSIDE the
+				// batch→checkpoint→ack sequence: it does NOT advance lastCommitLSN (the
+				// TRUNCATE is mid-transaction; the following EventCommit advances the
+				// cursor) and does NOT force a flush of the in-flight batch. A crash
+				// before the next checkpoint re-delivers the TRUNCATE and re-records a
+				// benign duplicate marker.
+				if err := indexer.InsertSchemaChange(indexDB, ev, nil); err != nil {
+					return fmt.Errorf("pgstreamrun: record TRUNCATE marker for %s.%s: %w", ev.Schema, ev.Table, err)
 				}
-				lastCommitLSN = ev.EndPos
 			case event.EventRelation:
 				// A relation's shape (#533): persist it as a schema snapshot and record
 				// its snapshot_id for stamping this table's subsequent rows. The snapshot


### PR DESCRIPTION
## Problem

A PostgreSQL `TRUNCATE` emits no per-row `DELETE`. The pgcapture decoder dropped the `TruncateMessage` with only a `logger.Warn`, so **nothing** landed in the index:

- `list_schema_changes` / the `schema_changes` table showed no trace — indistinguishable from "nothing happened".
- A `reconstruct` crossing the truncate would silently resurrect the pre-truncate rows from baseline + deltas.
- `docs/postgres.md` claimed TRUNCATE is "not captured at all — not even as an audit trail".

## Fix

Map a `TruncateMessage` to a durable audit **marker** — the source-neutral analog of the MySQL DDL path (`schema_changes` row), consistent with the "one index schema for all source families" boundary.

- **`internal/pgcapture/decoder.go`**: the `TruncateMessage` case now builds one `EventDDL(DDLTruncateTable)` per in-scope relation, stamped with the transaction's commit LSN/time and a synthetic `TRUNCATE TABLE schema.table` `DDLQuery`. One pgoutput message can list several relations (`TRUNCATE a, b`) but `Decode` returns a single event, so the first marker is returned and the rest are buffered in a new `pending` slice, drained via the new `TakePending()`. Out-of-scope relations (filter miss) and uncached OIDs record nothing (the latter warns).
- **`internal/pgcapture/capturer.go`**: `receiveLoop` drains `TakePending()` after every `Decode`, so no multi-relation marker is silently dropped.
- **`internal/pgstreamrun/pgstreamrun.go`**: the `EventDDL` case records the marker via `indexer.InsertSchemaChange` in its own statement (like the `EventRelation` snapshot), **outside** the batch→checkpoint→ack sequence — it does not advance the commit cursor (the TRUNCATE is mid-transaction; the following `EventCommit` does) and does not force a flush. A crash before checkpoint re-delivers and re-records a benign duplicate marker.
- **`docs/postgres.md`**: corrected the false claim.

### Scope / limits

This is a durable, queryable record *that the truncate happened*, not a replayable change: `recover` has no per-row before-images to put back, and `reconstruct` does **not yet** consume the marker (a follow-up). This matches the MySQL DDL path exactly (TRUNCATE → `schema_changes`, surfaced by `list_schema_changes`, not `query`/`binlog_events`).

## Test

`internal/pgcapture/decoder_test.go` — replaced `TestDecode_TruncateNotIndexed` (which pinned the dropped behavior) with:

- `TestDecode_TruncateEmitsAuditMarker` — single relation emits an `EventDDL`/`DDLTruncateTable` marker carrying the table and commit coords; nothing buffered.
- `TestDecode_TruncateMultiRelationBuffersPending` — `TRUNCATE a, b` returns the first marker and surfaces the second via `TakePending`, which then empties.
- `TestDecode_TruncateFilteredOutRecordsNothing` — a truncate of an out-of-scope table emits and buffers nothing.

`CGO_ENABLED=1 go test ./internal/pgcapture/ ./internal/pgstreamrun/` and `go vet` pass.

Closes #827
