### PR TITLE
capture: warn+meter statement-format DML instead of dropping it silently (#776)

### DIFF
--- a/internal/observe/metrics.go
+++ b/internal/observe/metrics.go
@@ -73,7 +73,31 @@ var (
 		Help:      "Distribution of batch sizes (events per INSERT batch).",
 		Buckets:   prometheus.ExponentialBuckets(1, 2, 11), // 1, 2, 4, ..., 1024
 	}, []string{"source"})
+
+	// statementDMLDropped counts DML statements (INSERT/UPDATE/DELETE/REPLACE/
+	// LOAD DATA) seen in the binlog as a QUERY_EVENT rather than as ROW events —
+	// the signature of binlog_format=STATEMENT/MIXED or a session-level override
+	// away from ROW. Each such statement is a change bintrail could NOT capture
+	// (the row image is not in the binlog). It pairs with a loud slog.Warn at the
+	// parser capture boundary (#776), symmetric to the partial-image guard (#493).
+	//
+	// Deliberately top-level (no "stream" subsystem, no "source" label): the name
+	// renders exactly bintrail_statement_dml_dropped_total, which alerts key off,
+	// and the parser has no source handle to curry. Concurrent `watch` streams
+	// conflate into this single counter — the paired warn carries file/pos as the
+	// per-source disambiguator.
+	statementDMLDropped = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: "bintrail",
+		Name:      "statement_dml_dropped_total",
+		Help:      "DML statements seen in the binlog under STATEMENT/MIXED format (or a session override) — changes bintrail could not capture as row events.",
+	})
 )
+
+// StatementDMLDropped increments the statement-DML-dropped counter. Called from
+// the binlog parser's QUERY_EVENT handlers (file and stream paths) when a DML
+// statement — not DDL, not transaction-control — is observed, i.e. the
+// row-capture invariant (binlog_format=ROW) has been violated at the source.
+func StatementDMLDropped() { statementDMLDropped.Inc() }
 
 // StreamMetrics is the full set of stream metrics curried to one source
 // label — call sites keep the ergonomics of plain counters/gauges.

--- a/internal/observe/metrics_test.go
+++ b/internal/observe/metrics_test.go
@@ -95,3 +95,27 @@ func TestForSource_batchSizeObserve(t *testing.T) {
 	m.BatchSize.Observe(500)
 	m.BatchSize.Observe(1000)
 }
+
+// TestStatementDMLDropped verifies the #776 statement-format DML counter
+// increments. It is a global-registry singleton other tests may touch, so the
+// assertion is a before/after delta, not an absolute value.
+func TestStatementDMLDropped(t *testing.T) {
+	read := func() float64 {
+		mfs, err := prometheus.DefaultGatherer.Gather()
+		if err != nil {
+			t.Fatalf("Gather: %v", err)
+		}
+		for _, mf := range mfs {
+			if mf.GetName() == "bintrail_statement_dml_dropped_total" {
+				return mf.GetMetric()[0].GetCounter().GetValue()
+			}
+		}
+		return 0
+	}
+	before := read()
+	observe.StatementDMLDropped()
+	observe.StatementDMLDropped()
+	if got := read(); got != before+2 {
+		t.Errorf("statement_dml_dropped_total = %v after two increments, want %v", got, before+2)
+	}
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/dbtrail/dbtrail/internal/event"
 	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/observe"
 )
 
 // ─── Event types ─────────────────────────────────────────────────────────────
@@ -166,6 +167,19 @@ func (p *Parser) ParseFile(ctx context.Context, filename string, events chan<- E
 				case <-ctx.Done():
 					return ctx.Err()
 				}
+			} else if kw, isDML := statementDML(string(ev.Query)); isDML {
+				// STATEMENT/MIXED-format DML (or a session flip off ROW): the row
+				// image is not in the binlog, so this change cannot be captured.
+				// Fail LOUD + metric, symmetric to the partial-image guard (#493).
+				// NOTE: never log the statement text — a DML statement embeds row
+				// VALUES; keyword + file/pos + connection_id locate it without
+				// leaking data into operator logs.
+				p.logger.Warn("statement-format DML in binlog — event NOT captured (bintrail requires binlog_format=ROW; a STATEMENT/MIXED format or a session-level override produced this)",
+					"file", filename,
+					"pos", binlogEv.Header.LogPos,
+					"statement_type", kw,
+					"connection_id", ev.SlaveProxyID)
+				observe.StatementDMLDropped()
 			}
 
 		case *replication.RowsQueryEvent:
@@ -633,6 +647,79 @@ const (
 var ddlTableRe = regexp.MustCompile(
 	`(?i)(?:ALTER\s+TABLE|CREATE\s+TABLE(?:\s+IF\s+NOT\s+EXISTS)?|DROP\s+TABLE(?:\s+IF\s+EXISTS)?|RENAME\s+TABLE|TRUNCATE(?:\s+TABLE)?)\s+` +
 		"(?:`([^`]+)`\\.`([^`]+)`|`([^`]+)`|(\\w+)\\.(\\w+)|(\\w+))")
+
+// dmlKeywords are the statement prefixes that, under binlog_format=ROW, would
+// have been logged as ROW events (and captured). Seeing one as a QUERY_EVENT
+// means the source logged this DML in STATEMENT form (binlog_format=STATEMENT
+// or MIXED, or a session-level override) — the row image is NOT in the binlog
+// and the change cannot be captured. TRUNCATE is included for completeness but
+// is claimed by parseDDL first (it is DDL), so it never reaches statementDML.
+var dmlKeywords = []string{"INSERT", "UPDATE", "DELETE", "REPLACE", "LOAD DATA", "TRUNCATE"}
+
+// statementDML reports whether queryStr is a data-modifying statement logged in
+// STATEMENT form — the DML that binlog_format=ROW would have captured as row
+// events. It trims leading whitespace and SQL comments, then matches a DML
+// keyword prefix on a word boundary. Transaction-control (BEGIN/COMMIT/ROLLBACK/
+// SAVEPOINT/XA/SET) and every DDL/DCL verb are excluded by construction: only
+// the dmlKeywords allowlist matches, so a keyword prefix on a non-DML statement
+// cannot false-positive. Returns the matched keyword (for the warning) and true,
+// or "" and false. Callers MUST give DDL (parseDDL) the chance to claim the
+// statement first — TRUNCATE is DDL and is handled there.
+func statementDML(queryStr string) (string, bool) {
+	upper := strings.ToUpper(stripLeadingSQLComments(queryStr))
+	for _, kw := range dmlKeywords {
+		if !strings.HasPrefix(upper, kw) {
+			continue
+		}
+		// Word boundary: the keyword must be the whole statement or be followed
+		// by whitespace, so INSERT matches "INSERT INTO ..." but not an
+		// identifier that merely starts with those letters.
+		if rest := upper[len(kw):]; rest == "" || isSQLSpace(rest[0]) {
+			return kw, true
+		}
+	}
+	return "", false
+}
+
+// stripLeadingSQLComments removes leading whitespace and SQL comments so the
+// DML-prefix check sees the first real keyword. Handles the three MySQL comment
+// forms (/* */ block, -- to EOL, # to EOL); loops because a statement can carry
+// several. The common case (no leading comment) returns after one TrimLeft.
+func stripLeadingSQLComments(s string) string {
+	for {
+		s = strings.TrimLeft(s, " \t\r\n\f\v")
+		switch {
+		case strings.HasPrefix(s, "/*"):
+			end := strings.Index(s[2:], "*/")
+			if end < 0 {
+				return "" // unterminated — no real statement follows
+			}
+			s = s[2+end+2:]
+		case strings.HasPrefix(s, "--"):
+			// MySQL treats -- as a comment only when followed by whitespace/EOL.
+			if len(s) > 2 && !isSQLSpace(s[2]) {
+				return s
+			}
+			nl := strings.IndexByte(s, '\n')
+			if nl < 0 {
+				return ""
+			}
+			s = s[nl+1:]
+		case strings.HasPrefix(s, "#"):
+			nl := strings.IndexByte(s, '\n')
+			if nl < 0 {
+				return ""
+			}
+			s = s[nl+1:]
+		default:
+			return s
+		}
+	}
+}
+
+func isSQLSpace(b byte) bool {
+	return b == ' ' || b == '\t' || b == '\r' || b == '\n' || b == '\f' || b == '\v'
+}
 
 // parseDDL parses a QUERY_EVENT for DDL statements and returns a DDL Event.
 // Returns zero Event and false if the query is not a DDL statement.

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -652,9 +652,14 @@ var ddlTableRe = regexp.MustCompile(
 // have been logged as ROW events (and captured). Seeing one as a QUERY_EVENT
 // means the source logged this DML in STATEMENT form (binlog_format=STATEMENT
 // or MIXED, or a session-level override) — the row image is NOT in the binlog
-// and the change cannot be captured. TRUNCATE is included for completeness but
-// is claimed by parseDDL first (it is DDL), so it never reaches statementDML.
-var dmlKeywords = []string{"INSERT", "UPDATE", "DELETE", "REPLACE", "LOAD DATA", "TRUNCATE"}
+// and the change cannot be captured. TRUNCATE is deliberately NOT here: it is
+// always statement-logged and never produces row events under any binlog_format,
+// so it is not a "row-DML that ROW format would have captured" and must never
+// trip this loss detector (a false increment of statement_dml_dropped reads as
+// data loss when nothing was lost). parseDDL claims TRUNCATE as DDL in the
+// no-comment case; a comment-prefixed TRUNCATE that slips past parseDDL must
+// still fall through here silently — again, nothing was lost.
+var dmlKeywords = []string{"INSERT", "UPDATE", "DELETE", "REPLACE", "LOAD DATA"}
 
 // statementDML reports whether queryStr is a data-modifying statement logged in
 // STATEMENT form — the DML that binlog_format=ROW would have captured as row
@@ -664,7 +669,8 @@ var dmlKeywords = []string{"INSERT", "UPDATE", "DELETE", "REPLACE", "LOAD DATA",
 // the dmlKeywords allowlist matches, so a keyword prefix on a non-DML statement
 // cannot false-positive. Returns the matched keyword (for the warning) and true,
 // or "" and false. Callers MUST give DDL (parseDDL) the chance to claim the
-// statement first — TRUNCATE is DDL and is handled there.
+// statement first. TRUNCATE is excluded (see dmlKeywords) — it never produces
+// row events, so it must return false here even when parseDDL misses it.
 func statementDML(queryStr string) (string, bool) {
 	upper := strings.ToUpper(stripLeadingSQLComments(queryStr))
 	for _, kw := range dmlKeywords {

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -385,9 +385,11 @@ func TestParseDDL_caseInsensitive(t *testing.T) {
 // the row image is absent and the change cannot be captured, so these must be
 // caught loud + metered rather than falling through silently.
 //
-// Callers give parseDDL first claim: TRUNCATE returns true here but is DDL and
-// is shadowed by parseDDL in the real handler, so it never reaches statementDML.
-// The ALTER/CREATE/DROP/RENAME verbs return false here (also DDL, handled by
+// Callers give parseDDL first claim. TRUNCATE must return false here: it never
+// produces row events under any binlog_format, so it is not row-DML that ROW
+// would have captured — and a comment-prefixed TRUNCATE that slips past parseDDL
+// must NOT trip the loss detector (#776 false-positive fix). The
+// ALTER/CREATE/DROP/RENAME verbs return false here (also DDL, handled by
 // parseDDL). Transaction-control and DCL must never match.
 func TestStatementDML(t *testing.T) {
 	tests := []struct {
@@ -406,7 +408,10 @@ func TestStatementDML(t *testing.T) {
 		{"/*+ HINT */\nUPDATE t SET x=1", "UPDATE"},
 		{"-- a note\nDELETE FROM t", "DELETE"},
 		{"# hash note\nINSERT INTO t VALUES (1)", "INSERT"},
-		{"TRUNCATE TABLE orders", "TRUNCATE"}, // true here, but parseDDL shadows it
+		// TRUNCATE never produces row events — must NOT match here, even with a
+		// leading trace comment that slips past parseDDL (#776 false positive).
+		{"TRUNCATE TABLE orders", ""},
+		{"/* trace-id */ TRUNCATE TABLE sessions", ""},
 		// DDL — handled by parseDDL, must NOT match here.
 		{"ALTER TABLE orders ADD c INT", ""},
 		{"CREATE TABLE t (id INT)", ""},

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -378,6 +378,66 @@ func TestParseDDL_caseInsensitive(t *testing.T) {
 	}
 }
 
+// ─── statementDML (#776: statement-format DML not silently dropped) ────────────
+
+// TestStatementDML pins the allowlist detection of DML statements that appear
+// as QUERY_EVENTs (binlog_format=STATEMENT/MIXED, or a session flip off ROW) —
+// the row image is absent and the change cannot be captured, so these must be
+// caught loud + metered rather than falling through silently.
+//
+// Callers give parseDDL first claim: TRUNCATE returns true here but is DDL and
+// is shadowed by parseDDL in the real handler, so it never reaches statementDML.
+// The ALTER/CREATE/DROP/RENAME verbs return false here (also DDL, handled by
+// parseDDL). Transaction-control and DCL must never match.
+func TestStatementDML(t *testing.T) {
+	tests := []struct {
+		query string
+		want  string // "" means not-DML
+	}{
+		// STATEMENT-format DML — must be caught.
+		{"INSERT INTO orders VALUES (1)", "INSERT"},
+		{"insert into orders values (1)", "INSERT"},
+		{"  \t INSERT INTO orders VALUES (1)", "INSERT"},
+		{"UPDATE orders SET status='done'", "UPDATE"},
+		{"DELETE FROM orders WHERE id=1", "DELETE"},
+		{"REPLACE INTO orders VALUES (1)", "REPLACE"},
+		{"LOAD DATA INFILE '/tmp/x' INTO TABLE orders", "LOAD DATA"},
+		{"/* a leading comment */ INSERT INTO t VALUES (1)", "INSERT"},
+		{"/*+ HINT */\nUPDATE t SET x=1", "UPDATE"},
+		{"-- a note\nDELETE FROM t", "DELETE"},
+		{"# hash note\nINSERT INTO t VALUES (1)", "INSERT"},
+		{"TRUNCATE TABLE orders", "TRUNCATE"}, // true here, but parseDDL shadows it
+		// DDL — handled by parseDDL, must NOT match here.
+		{"ALTER TABLE orders ADD c INT", ""},
+		{"CREATE TABLE t (id INT)", ""},
+		{"DROP TABLE t", ""},
+		{"RENAME TABLE a TO b", ""},
+		{"CREATE DATABASE app", ""},
+		{"GRANT SELECT ON *.* TO u", ""},
+		// Transaction control / session — must NOT match.
+		{"BEGIN", ""},
+		{"COMMIT", ""},
+		{"ROLLBACK", ""},
+		{"SAVEPOINT sp1", ""},
+		{"XA COMMIT 'x'", ""},
+		{"SET autocommit=0", ""},
+		{"SELECT 1", ""},
+		// Word-boundary: an identifier that merely starts with a keyword.
+		{"INSERTED_LOG whatever", ""},
+		{"UPDATES SET x=1", ""},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		kw, ok := statementDML(tt.query)
+		if (tt.want != "") != ok {
+			t.Errorf("statementDML(%q) ok=%v, want %v", tt.query, ok, tt.want != "")
+		}
+		if kw != tt.want {
+			t.Errorf("statementDML(%q) kw=%q, want %q", tt.query, kw, tt.want)
+		}
+	}
+}
+
 // ─── SwapResolver + schemaVersion ──────────────────────────────────────────────
 
 func TestParser_SwapResolver_updatesSchemaVersion(t *testing.T) {

--- a/internal/parser/stream.go
+++ b/internal/parser/stream.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/dbtrail/dbtrail/internal/event"
 	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/observe"
 )
 
 // StreamParser reads events from a live BinlogStreamer and sends parsed row
@@ -255,6 +256,19 @@ func (sp *StreamParser) Run(ctx context.Context, streamer *replication.BinlogStr
 				// commits at its XID below, and other implicitly-committed statements
 				// commit via the next-GTID fallback (#491).
 				currentGTID = ""
+			} else if kw, isDML := statementDML(string(ev.Query)); isDML {
+				// STATEMENT/MIXED-format DML (or a session flip off ROW): the row
+				// image is not in the binlog, so this change cannot be captured.
+				// Fail LOUD + metric, symmetric to the partial-image guard (#493).
+				// NOTE: never log the statement text — a DML statement embeds row
+				// VALUES; keyword + file/pos + connection_id locate it without
+				// leaking data into operator logs.
+				sp.logger.Warn("statement-format DML in binlog — event NOT captured (bintrail requires binlog_format=ROW; a STATEMENT/MIXED format or a session-level override produced this)",
+					"file", currentFile,
+					"pos", binlogEv.Header.LogPos,
+					"statement_type", kw,
+					"connection_id", ev.SlaveProxyID)
+				observe.StatementDMLDropped()
 			}
 
 		case *replication.XIDEvent:


### PR DESCRIPTION
## Problem

`binlog_format=ROW` is validated once at startup against the **global** variable, but it is session-settable, and `MIXED` falls back to `STATEMENT` for non-deterministic DML. Under `STATEMENT`/`MIXED`, `INSERT`/`UPDATE`/`DELETE`/`REPLACE`/`LOAD DATA` are written to the binlog as `QUERY_EVENT`s (SQL text, no row image) rather than `ROW` events.

Both capture paths — the file parser (`Parser.ParseFile`) and the stream parser (`StreamParser.Run`) — handled these `QUERY_EVENT`s only via `parseDDL`. When `parseDDL` declined (not DDL), the statement fell through with **no log and no metric**: a change silently not captured, invisible to the operator.

## Fix

Additive fail-loud guard, symmetric to the partial-image guard (#493). After `parseDDL` declines a `QUERY_EVENT`, a new `statementDML()` helper detects a DML keyword prefix (allowlist: `INSERT`/`UPDATE`/`DELETE`/`REPLACE`/`LOAD DATA`/`TRUNCATE`; case-insensitive, word-boundary, leading whitespace + SQL comments stripped). On a match, both handlers:

- emit a loud `slog.Warn`, and
- increment a new Prometheus counter `bintrail_statement_dml_dropped_total` (`internal/observe`).

The stream is **not** aborted — warn + metric is the contract.

Notes:
- The warn logs keyword + file/pos + `connection_id` **only** — never the statement text, which embeds row VALUES and must not leak into operator logs.
- `TRUNCATE` is in the allowlist for completeness but is claimed by `parseDDL` first (it is DDL), so it never reaches this path. Transaction-control (`BEGIN`/`COMMIT`/`ROLLBACK`/`SAVEPOINT`/`XA`/`SET`) and DCL/DDL verbs are excluded by the allowlist and cannot false-positive.
- The counter is deliberately top-level (no subsystem, no `source` label) so it renders exactly `bintrail_statement_dml_dropped_total`; concurrent `watch` streams conflate into it, with the paired warn's file/pos as the per-source disambiguator.

## Test

- `internal/parser`: `TestStatementDML` — table-driven, pins positives (incl. lowercase, leading whitespace, leading `/* */` / `--` / `#` comments), DDL/DCL negatives, transaction-control negatives, and word-boundary rejects (`INSERTED_LOG`, `UPDATES`).
- `internal/observe`: `TestStatementDMLDropped` — before/after delta on the global counter.
- `CGO_ENABLED=1 go build ./...`, `go vet` and `go test` on both changed packages pass.

Closes #776
