### PR TITLE
parser: fail file-index loud on stale-snapshot row skips (#778)

### DIFF
--- a/internal/parser/drift_test.go
+++ b/internal/parser/drift_test.go
@@ -67,7 +67,7 @@ func runHandleRowsWith(t *testing.T, resolver *metadata.Resolver, binlogEv *repl
 	t.Helper()
 	rowsEv := binlogEv.Event.(*replication.RowsEvent)
 	out := make(chan Event, 4)
-	err := handleRows(context.Background(), newTestLogger(logBuf), resolver, &Filters{}, binlogEv, rowsEv, "binlog.000001", "", 0, "", 9, out)
+	err := handleRows(context.Background(), newTestLogger(logBuf), resolver, &Filters{}, binlogEv, rowsEv, "binlog.000001", "", 0, "", 9, out, nil)
 	close(out)
 	var evs []Event
 	for ev := range out {
@@ -307,5 +307,126 @@ func TestHandleRows_namesPresentCountDiffersTakesCountGuard(t *testing.T) {
 	}
 	if !strings.Contains(logBuf.String(), "column count mismatch") {
 		t.Errorf("expected the count-guard warn, got logs: %s", logBuf.String())
+	}
+}
+
+// ─── File-index schema-gap tracker (#778) ─────────────────────────────────────
+//
+// In file mode the DDL auto-snapshot resolver swap runs consumer-side, one
+// buffered channel behind the parser, so rows following an in-file CREATE/ALTER
+// can decode against a stale resolver and be skipped ("table not in snapshot" /
+// "column count mismatch") before the swap lands. handleRows records such a skip
+// on the passed schemaGapTracker ONLY when the event is at-or-after the snapshot
+// time (a stale snapshot with a converging remediation), mirroring the #700
+// name-drift asymmetry — never for a historical pre-snapshot event, and never
+// for the stream path (nil tracker). ParseFile turns a non-empty tracker into a
+// hard file-level error so the file is not silently marked 'completed'.
+
+// gapRowsEvent builds a WRITE_ROWS event with a controllable schema/table,
+// column count, and header timestamp. No column names → the #700 name check is
+// a no-op, isolating the table-absent / count-mismatch branches.
+func gapRowsEvent(schema, table string, columnCount uint64, ts uint32) *replication.BinlogEvent {
+	row := make([]any, columnCount)
+	for i := range row {
+		row[i] = int64(i + 1)
+	}
+	return &replication.BinlogEvent{
+		Header: &replication.EventHeader{
+			EventType: replication.WRITE_ROWS_EVENTv2,
+			LogPos:    200,
+			EventSize: 100,
+			Timestamp: ts,
+		},
+		Event: &replication.RowsEvent{
+			Table: &replication.TableMapEvent{
+				Schema:      []byte(schema),
+				Table:       []byte(table),
+				ColumnCount: columnCount,
+			},
+			Rows: [][]any{row},
+		},
+	}
+}
+
+// timedOrdersResolver returns a two-column shop.orders resolver stamped with
+// snapshotTime, so eventPredatesSnapshot can classify events by header time.
+func timedOrdersResolver(snapshotTime time.Time) *metadata.Resolver {
+	tm := &metadata.TableMeta{
+		Schema: "shop",
+		Table:  "orders",
+		Columns: []metadata.ColumnMeta{
+			{Name: "id", OrdinalPosition: 1, IsPK: true, DataType: "int"},
+			{Name: "amount", OrdinalPosition: 2, DataType: "int"},
+		},
+		PKColumns: []string{"id"},
+	}
+	return metadata.NewResolverFromTablesAt(9, snapshotTime, map[string]*metadata.TableMeta{"shop.orders": tm})
+}
+
+func TestHandleRows_schemaGapTrackerFileMode(t *testing.T) {
+	snapT := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	afterTS := uint32(snapT.Add(time.Hour).Unix())
+	beforeTS := uint32(snapT.Add(-time.Hour).Unix())
+
+	cases := []struct {
+		name       string
+		ev         *replication.BinlogEvent
+		nilTracker bool // stream path
+		wantRecord bool
+	}{
+		{"table-absent at-or-after snapshot records a gap", gapRowsEvent("shop", "widgets", 2, afterTS), false, true},
+		{"table-absent predating snapshot is a silent historical skip", gapRowsEvent("shop", "widgets", 2, beforeTS), false, false},
+		{"table-absent with unknown event time stays strict", gapRowsEvent("shop", "widgets", 2, 0), false, true},
+		{"column-count mismatch at-or-after snapshot records a gap", gapRowsEvent("shop", "orders", 1, afterTS), false, true},
+		{"column-count mismatch predating snapshot is a silent historical skip", gapRowsEvent("shop", "orders", 1, beforeTS), false, false},
+		{"nil tracker (stream path) never records", gapRowsEvent("shop", "widgets", 2, afterTS), true, false},
+		{"resolvable matching event records nothing", gapRowsEvent("shop", "orders", 2, afterTS), false, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var tracker *schemaGapTracker
+			if !tc.nilTracker {
+				tracker = &schemaGapTracker{}
+			}
+			rowsEv := tc.ev.Event.(*replication.RowsEvent)
+			out := make(chan Event, 4)
+			err := handleRows(context.Background(), newTestLogger(&bytes.Buffer{}), timedOrdersResolver(snapT),
+				&Filters{}, tc.ev, rowsEv, "binlog.000007", "", 0, "", 9, out, tracker)
+			close(out)
+			// A skip is never a hard error at the handleRows layer — the
+			// file-level failure is decided by ParseFile from the tracker.
+			if err != nil {
+				t.Fatalf("handleRows returned a hard error on a skip: %v", err)
+			}
+			got := tracker != nil && tracker.count > 0
+			if got != tc.wantRecord {
+				t.Fatalf("gap recorded = %v, want %v (tracker=%+v)", got, tc.wantRecord, tracker)
+			}
+		})
+	}
+}
+
+// A file with two stale-snapshot skips escalates the log exactly once (record
+// returns true only on the first gap) but counts every skipped event, so
+// ParseFile's error reports the full magnitude.
+func TestSchemaGapTracker_recordCountsAllEscalatesOnce(t *testing.T) {
+	var tr schemaGapTracker
+	if !tr.record("first gap") {
+		t.Fatal("first record must return true (escalate)")
+	}
+	if tr.record("second gap") {
+		t.Fatal("second record must return false (no re-escalation)")
+	}
+	if tr.count != 2 {
+		t.Fatalf("count = %d, want 2", tr.count)
+	}
+	if tr.first != "first gap" {
+		t.Fatalf("first = %q, want %q", tr.first, "first gap")
+	}
+	// Nil-safe: the stream path passes a nil tracker.
+	var nilTr *schemaGapTracker
+	if nilTr.record("x") {
+		t.Fatal("nil tracker record must return false")
 	}
 }

--- a/internal/parser/drift_test.go
+++ b/internal/parser/drift_test.go
@@ -375,6 +375,11 @@ func TestHandleRows_schemaGapTrackerFileMode(t *testing.T) {
 		wantRecord bool
 	}{
 		{"table-absent at-or-after snapshot records a gap", gapRowsEvent("shop", "widgets", 2, afterTS), false, true},
+		// System schemas are always excluded from any snapshot (TakeSnapshot's
+		// NOT IN list), so a mysql.rds_heartbeat2 row event at-or-after snapshot
+		// time is a routine, non-convergent skip — it must NOT record a gap or
+		// the RDS / offline-binlog file would be marked 'failed' forever (#778).
+		{"excluded system schema at-or-after snapshot never records a gap", gapRowsEvent("mysql", "rds_heartbeat2", 2, afterTS), false, false},
 		{"table-absent predating snapshot is a silent historical skip", gapRowsEvent("shop", "widgets", 2, beforeTS), false, false},
 		{"table-absent with unknown event time stays strict", gapRowsEvent("shop", "widgets", 2, 0), false, true},
 		{"column-count mismatch at-or-after snapshot records a gap", gapRowsEvent("shop", "orders", 1, afterTS), false, true},

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -315,6 +315,23 @@ func eventPredatesSnapshot(binlogEv *replication.BinlogEvent, resolver *metadata
 	return eventTime.Before(snapTime)
 }
 
+// snapshotExcludedSchemas are the system schemas metadata.TakeSnapshot always
+// omits (WHERE TABLE_SCHEMA NOT IN (...)). No resolver ever contains their
+// tables, so a row event on one of them (e.g. RDS binlogging periodic
+// mysql.rds_heartbeat2 UPDATEs with ~now timestamps) is a routine, permanent
+// skip with NO converging remediation — re-snapshotting still excludes them.
+// It must NOT escalate a file to 'failed' via the gap tracker (#778 regression),
+// only ever warn-and-skip. Keep this list byte-identical to the TakeSnapshot
+// NOT IN clause.
+func isSnapshotExcludedSchema(schema string) bool {
+	switch strings.ToLower(schema) {
+	case "information_schema", "performance_schema", "mysql", "sys":
+		return true
+	default:
+		return false
+	}
+}
+
 // handleRows processes a RowsEvent, resolving column names and dispatching to
 // the appropriate emit function. It is shared by Parser.ParseFile and StreamParser.Run.
 //
@@ -364,7 +381,7 @@ func handleRows(
 		// rows). Record it so ParseFile fails the file instead of completing it
 		// with an undetected gap (#778). Pre-snapshot events stay a warn-only
 		// historical skip.
-		if gapTracker != nil && !eventPredatesSnapshot(binlogEv, resolver) {
+		if gapTracker != nil && !isSnapshotExcludedSchema(schema) && !eventPredatesSnapshot(binlogEv, resolver) {
 			if gapTracker.record(fmt.Sprintf("%s.%s not in snapshot %d at %s:%d", schema, table, schemaVersion, filename, binlogEv.Header.LogPos)) {
 				logger.Error("schema gap: skipping rows for a table absent from the snapshot at-or-after snapshot time — the snapshot is stale; this file will be marked failed (run `bintrail snapshot`, then re-index)",
 					"file", filename, "pos", binlogEv.Header.LogPos, "schema", schema, "table", table)
@@ -389,7 +406,7 @@ func handleRows(
 		// and its consumer-side resolver swap landed too late for these buffered
 		// rows). Record it so ParseFile fails the file (#778). Pre-snapshot
 		// events stay a warn-only historical skip.
-		if gapTracker != nil && !eventPredatesSnapshot(binlogEv, resolver) {
+		if gapTracker != nil && !isSnapshotExcludedSchema(schema) && !eventPredatesSnapshot(binlogEv, resolver) {
 			if gapTracker.record(fmt.Sprintf("%s.%s column count %d vs snapshot %d at %s:%d", schema, table, rowsEv.Table.ColumnCount, len(tm.Columns), filename, binlogEv.Header.LogPos)) {
 				logger.Error("schema gap: skipping rows whose column count diverges from the snapshot at-or-after snapshot time — the snapshot is stale; this file will be marked failed (run `bintrail snapshot`, then re-index)",
 					"file", filename, "pos", binlogEv.Header.LogPos, "schema", schema, "table", table)

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -121,6 +121,16 @@ func (p *Parser) ParseFile(ctx context.Context, filename string, events chan<- E
 	// stale text when the variable is toggled off mid-transaction).
 	var currentQueryText string
 
+	// gaps records rows skipped because the snapshot is stale (a table absent
+	// from it, or a diverging column count) for events at-or-after the snapshot
+	// time. The file-mode DDL resolver swap runs consumer-side — one buffered
+	// channel behind the parser — so rows following an in-file CREATE/ALTER can
+	// decode against a stale resolver and be skipped before the swap lands. A
+	// non-empty tracker turns into a hard error below so the file is marked
+	// 'failed' (and re-indexed after a fresh snapshot) instead of silently
+	// 'completed' with an undetected gap (#778).
+	var gaps schemaGapTracker
+
 	bp := replication.NewBinlogParser()
 	// Pin TIMESTAMP-column string rendering to UTC. go-mysql's default (nil
 	// location) formats fracTime.String() using the raw time.Unix(...) value,
@@ -182,7 +192,7 @@ func (p *Parser) ParseFile(ctx context.Context, filename string, events chan<- E
 			currentQueryText = event.SanitizeQueryText(string(ev.Query))
 
 		case *replication.RowsEvent:
-			err := handleRows(ctx, p.logger, p.resolver.Load(), &p.filters, binlogEv, ev, filename, currentGTID, currentConnectionID, currentQueryText, p.schemaVersion.Load(), events)
+			err := handleRows(ctx, p.logger, p.resolver.Load(), &p.filters, binlogEv, ev, filename, currentGTID, currentConnectionID, currentQueryText, p.schemaVersion.Load(), events, &gaps)
 			// The LAST rows event of a statement carries STMT_END_F — the
 			// actual statement boundary. Clearing here keeps one statement's
 			// text alive across its chained/split rows events, while a later
@@ -205,7 +215,19 @@ func (p *Parser) ParseFile(ctx context.Context, filename string, events chan<- E
 		return nil
 	}
 
-	return bp.ParseFile(fullPath, 0, handleEvent)
+	if err := bp.ParseFile(fullPath, 0, handleEvent); err != nil {
+		return err
+	}
+	if gaps.count > 0 {
+		return fmt.Errorf(
+			"schema gap: %d row event(s) in %s were skipped because the schema snapshot is stale "+
+				"(first: %s) — these rows were NOT indexed. Run `bintrail snapshot` against the current "+
+				"schema and re-index this file (a failed file re-indexes from the start). This commonly "+
+				"follows a CREATE/ALTER TABLE within the file whose auto-snapshot landed too late for the "+
+				"buffered rows",
+			gaps.count, filename, gaps.first)
+	}
+	return nil
 }
 
 // rewriteInnerHeader stamps a Transaction_payload inner event's header with
@@ -246,8 +268,61 @@ func firstPartialImage(skipped [][]int) []int {
 	return nil
 }
 
+// schemaGapTracker records recoverable schema gaps: rows skipped because their
+// table is absent from the snapshot or its column count diverged, for an event
+// AT-OR-AFTER the snapshot time (a STALE snapshot, not a historical pre-snapshot
+// state). It is populated ONLY on the file-index path (Parser.ParseFile); the
+// stream path passes a nil tracker and keeps its warn-and-continue behavior,
+// which is backed by the synchronous DDL hook (SetSyncDDLHook). ParseFile turns
+// a non-empty tracker into a hard file-level error so the file is marked
+// 'failed' and re-indexed (after a fresh snapshot) rather than silently marked
+// 'completed' with an undetected gap — the file-mode DDL resolver swap runs
+// consumer-side, one buffered channel behind the parser, so post-DDL rows can
+// decode with a stale resolver and be skipped before the swap lands (#778).
+type schemaGapTracker struct {
+	count int
+	first string // human detail of the first gap, for the file-level error
+}
+
+// record notes one skipped-row schema gap and returns true if it was the first
+// (so callers escalate to a log line exactly once, not per skipped row). Nil-safe.
+func (t *schemaGapTracker) record(detail string) bool {
+	if t == nil {
+		return false
+	}
+	t.count++
+	if t.count == 1 {
+		t.first = detail
+		return true
+	}
+	return false
+}
+
+// eventPredatesSnapshot reports whether binlogEv safely predates the resolver's
+// snapshot — the lenient/historical case (mirrors the #700 name-drift
+// asymmetry). When true, a schema mismatch is a routine historical state
+// (re-indexing old binlogs, or a stream backlog written before a re-snapshot)
+// with no converging remediation, so it must NOT escalate to a file-level
+// failure. Unknown times (a zero event timestamp or a zero snapshot time) are
+// treated as NOT predating (strict), so an unknown age never takes the lenient
+// path.
+func eventPredatesSnapshot(binlogEv *replication.BinlogEvent, resolver *metadata.Resolver) bool {
+	snapTime := resolver.SnapshotTime()
+	if binlogEv.Header.Timestamp == 0 || snapTime.IsZero() {
+		return false
+	}
+	eventTime := time.Unix(int64(binlogEv.Header.Timestamp), 0).UTC()
+	return eventTime.Before(snapTime)
+}
+
 // handleRows processes a RowsEvent, resolving column names and dispatching to
 // the appropriate emit function. It is shared by Parser.ParseFile and StreamParser.Run.
+//
+// gapTracker is non-nil only on the file-index path: when a row event is skipped
+// because its table is absent from the snapshot or the column count diverged AND
+// the event is at-or-after the snapshot time (a stale snapshot), the skip is
+// recorded so ParseFile can fail the whole file rather than complete it with an
+// undetected gap (#778). The stream path passes nil.
 func handleRows(
 	ctx context.Context,
 	logger *slog.Logger,
@@ -260,6 +335,7 @@ func handleRows(
 	queryText string,
 	schemaVersion uint32,
 	out chan<- Event,
+	gapTracker *schemaGapTracker,
 ) error {
 	schema := string(rowsEv.Table.Schema)
 	table := string(rowsEv.Table.Table)
@@ -282,6 +358,18 @@ func handleRows(
 			"file", filename,
 			"pos", binlogEv.Header.LogPos,
 			"error", err)
+		// File-index path only: an at-or-after-snapshot skip is a stale
+		// snapshot (e.g. a table created by a DDL earlier in this same file
+		// whose consumer-side resolver swap landed too late for these buffered
+		// rows). Record it so ParseFile fails the file instead of completing it
+		// with an undetected gap (#778). Pre-snapshot events stay a warn-only
+		// historical skip.
+		if gapTracker != nil && !eventPredatesSnapshot(binlogEv, resolver) {
+			if gapTracker.record(fmt.Sprintf("%s.%s not in snapshot %d at %s:%d", schema, table, schemaVersion, filename, binlogEv.Header.LogPos)) {
+				logger.Error("schema gap: skipping rows for a table absent from the snapshot at-or-after snapshot time — the snapshot is stale; this file will be marked failed (run `bintrail snapshot`, then re-index)",
+					"file", filename, "pos", binlogEv.Header.LogPos, "schema", schema, "table", table)
+			}
+		}
 		return nil
 	}
 
@@ -296,6 +384,17 @@ func handleRows(
 			"table", table,
 			"binlog_columns", rowsEv.Table.ColumnCount,
 			"snapshot_columns", len(tm.Columns))
+		// File-index path only: an at-or-after-snapshot count divergence is a
+		// stale snapshot (a DDL earlier in this same file added/removed a column
+		// and its consumer-side resolver swap landed too late for these buffered
+		// rows). Record it so ParseFile fails the file (#778). Pre-snapshot
+		// events stay a warn-only historical skip.
+		if gapTracker != nil && !eventPredatesSnapshot(binlogEv, resolver) {
+			if gapTracker.record(fmt.Sprintf("%s.%s column count %d vs snapshot %d at %s:%d", schema, table, rowsEv.Table.ColumnCount, len(tm.Columns), filename, binlogEv.Header.LogPos)) {
+				logger.Error("schema gap: skipping rows whose column count diverges from the snapshot at-or-after snapshot time — the snapshot is stale; this file will be marked failed (run `bintrail snapshot`, then re-index)",
+					"file", filename, "pos", binlogEv.Header.LogPos, "schema", schema, "table", table)
+			}
+		}
 		return nil
 	}
 

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -206,7 +206,7 @@ func TestHandleRows_unhandledEventTypeLogsNotSilent(t *testing.T) {
 	rowsEv := binlogEv.Event.(*replication.RowsEvent)
 
 	out := make(chan Event, 4)
-	if err := handleRows(context.Background(), logger, resolver, &Filters{}, binlogEv, rowsEv, "mariadb-bin.000001", "0-1-1", 0, "", 1, out); err != nil {
+	if err := handleRows(context.Background(), logger, resolver, &Filters{}, binlogEv, rowsEv, "mariadb-bin.000001", "0-1-1", 0, "", 1, out, nil); err != nil {
 		t.Fatalf("handleRows: %v", err)
 	}
 
@@ -507,7 +507,7 @@ func TestHandleRows_partialImageFailsLoud(t *testing.T) {
 	rowsEv := binlogEv.Event.(*replication.RowsEvent)
 
 	out := make(chan Event, 4)
-	err := handleRows(context.Background(), newTestLogger(&bytes.Buffer{}), resolver, &Filters{}, binlogEv, rowsEv, "binlog.000001", "0-1-1", 0, "", 1, out)
+	err := handleRows(context.Background(), newTestLogger(&bytes.Buffer{}), resolver, &Filters{}, binlogEv, rowsEv, "binlog.000001", "0-1-1", 0, "", 1, out, nil)
 	if err == nil {
 		t.Fatal("expected handleRows to fail loud on a partial row image, got nil")
 	}
@@ -559,7 +559,7 @@ func TestHandleRows_fullImagePasses(t *testing.T) {
 	rowsEv := binlogEv.Event.(*replication.RowsEvent)
 
 	out := make(chan Event, 4)
-	if err := handleRows(context.Background(), newTestLogger(&bytes.Buffer{}), resolver, &Filters{}, binlogEv, rowsEv, "binlog.000001", "0-1-1", 0, "", 1, out); err != nil {
+	if err := handleRows(context.Background(), newTestLogger(&bytes.Buffer{}), resolver, &Filters{}, binlogEv, rowsEv, "binlog.000001", "0-1-1", 0, "", 1, out, nil); err != nil {
 		t.Fatalf("handleRows must not fail on a FULL image, got: %v", err)
 	}
 	select {

--- a/internal/parser/stream.go
+++ b/internal/parser/stream.go
@@ -280,7 +280,10 @@ func (sp *StreamParser) Run(ctx context.Context, streamer *replication.BinlogStr
 			currentQueryText = event.SanitizeQueryText(string(ev.Query))
 
 		case *replication.RowsEvent:
-			err := handleRows(ctx, sp.logger, sp.resolver.Load(), &sp.filters, binlogEv, ev, currentFile, currentGTID, currentConnectionID, currentQueryText, sp.schemaVersion.Load(), out)
+			// nil gapTracker: the stream keeps its warn-and-continue skip
+			// behavior (the synchronous DDL hook, SetSyncDDLHook, is the
+			// stream's post-DDL correctness mechanism, not file-level failure).
+			err := handleRows(ctx, sp.logger, sp.resolver.Load(), &sp.filters, binlogEv, ev, currentFile, currentGTID, currentConnectionID, currentQueryText, sp.schemaVersion.Load(), out, nil)
 			// Statement boundary — see the file parser's RowsEvent case: the
 			// STMT_END_F clear prevents a ROWS_QUERY-less later statement in
 			// the same transaction from inheriting this statement's text.


### PR DESCRIPTION
## Problem

In file mode (`bintrail index`) the DDL auto-snapshot resolver swap runs **consumer-side** — the `idx.SetOnDDL` handler calls `p.SwapResolver` only after events cross the buffered channel (up to 1000 events), while `handleRows`/`MapRow` runs on the parser side. So rows following an in-file `CREATE`/`ALTER TABLE` can decode against a **stale resolver** and get skipped as `table not in snapshot` or `column count mismatch`.

`handleRows` returned `nil` for those skips, so `ParseFile` completed the file, `index_state` was marked `completed`, and a subsequent re-index skipped it — a **permanent, unmarked gap** surfaced only as log warnings.

The true fix (a synchronous DDL hook in `ParseFile` mirroring the stream path's `SetSyncDDLHook`) is architectural, not an additive guard, and is intentionally out of scope here.

## Fix

Additive, file-path-scoped fail-loud guard:

- New `schemaGapTracker` populated **only** by `Parser.ParseFile`. The stream path (`StreamParser.Run`) passes `nil` and keeps its warn-and-continue behavior, which is already backed by the synchronous `SetSyncDDLHook`.
- When a row event is skipped for a table absent from the snapshot or a diverging column count **AND** the event is **at-or-after the snapshot time**, the skip is recorded; `ParseFile` then returns a hard error, so `indexFile` marks the file `failed` (not `completed`). Re-indexing after a fresh snapshot converges.
- The at-or-after gate mirrors the existing #700 name-drift asymmetry: a **pre-snapshot** event is a routine historical re-index (or a stream backlog) with no converging remediation, so it stays a warn-only skip — no permanent dead-end for archival binlogs referencing dropped tables. Unknown times (zero event ts / zero snapshot time) stay strict.
- The escalation log fires once per file, not per skipped row.

Shared `handleRows` skip **semantics are unchanged** for both paths — the pinned `TestHandleRows_namesPresentCountDiffersTakesCountGuard` (count-mismatch stays a non-fatal skip) still passes.

## Test

`internal/parser/drift_test.go`:
- `TestHandleRows_schemaGapTrackerFileMode` (table-driven): table-absent / column-count-mismatch x at-or-after / pre-snapshot / unknown-time; nil tracker (stream path) never records; resolvable matching event records nothing.
- `TestSchemaGapTracker_recordCountsAllEscalatesOnce`: counts every skip, escalates once, nil-safe.

`CGO_ENABLED=1 go build ./...` clean; `go test ./internal/parser/... ./cliapp/...` pass.

Closes #778
