### PR TITLE
console: set Options.ProfileActive under a named profile + refuse unknown profile

### DIFF
--- a/cmd/bintrail-console/serve.go
+++ b/cmd/bintrail-console/serve.go
@@ -202,6 +202,17 @@ func runServe(cmd *cobra.Command, args []string) error {
 	var denyTables []query.SchemaTable
 	var redactCols []query.SchemaTableColumn
 	if conProfile != "" {
+		// LoadProfileRules resolves a nonexistent profile to zero rules WITHOUT
+		// an error, so a typo would start the console with RBAC that enforces
+		// nothing while the operator believes a profile is active. Refuse loudly
+		// on an unknown name before loading rules (#838).
+		exists, perr := query.ProfileExists(cmd.Context(), db, conProfile)
+		if perr != nil {
+			return fmt.Errorf("check profile %q: %w", conProfile, perr)
+		}
+		if !exists {
+			return fmt.Errorf("profile %q does not exist in the index; create it (bintrail flag/profile/access) or fix the typo — refusing to start with an RBAC profile that enforces nothing", conProfile)
+		}
 		denyTables, redactCols, err = query.LoadProfileRules(cmd.Context(), db, conProfile)
 		if err != nil {
 			return fmt.Errorf("load profile %q: %w", conProfile, err)
@@ -218,6 +229,9 @@ func runServe(cmd *cobra.Command, args []string) error {
 		NoArchive:     conNoArchive || conProfile != "",
 		DenyTables:    denyTables,
 		RedactColumns: redactCols,
+		// A named profile — even one resolving to zero rules — forces query_text
+		// withholding on every query (#699/#838).
+		ProfileActive: conProfile != "",
 		AllowedHosts:  conAllowedHosts,
 		BaselineDir:   conBaselineDir,
 		BaselineS3:    conBaselineS3,

--- a/internal/console/api.go
+++ b/internal/console/api.go
@@ -140,6 +140,12 @@ func (s *Server) buildOptions(p filterParams, defaultLimit, maxLimit int) (query
 		Order:         order,
 		DenyTables:    s.denyTables,
 		RedactColumns: s.redactCols,
+		// ProfileActive forces the redaction pass even for a named profile that
+		// resolved to zero rules, so QueryText/QueryHash are withheld under EVERY
+		// named profile per the #699 contract (matching the CLI/MCP). Without
+		// this a `--profile <typo>` would leave query_text with sensitive
+		// literals visible (#838).
+		ProfileActive: s.profileActive,
 	}, nil
 }
 

--- a/internal/console/api_test.go
+++ b/internal/console/api_test.go
@@ -101,6 +101,34 @@ func TestBuildOptionsAttachesRBAC(t *testing.T) {
 	}
 }
 
+// TestBuildOptionsThreadsProfileActive guards the #838 fix: a named profile —
+// even one that resolved to ZERO deny/redact rules — must set
+// query.Options.ProfileActive so the redaction pass fires and QueryText/
+// QueryHash are withheld (#699). Without a profile it must stay false so
+// query_text is visible on an unrestricted console.
+func TestBuildOptionsThreadsProfileActive(t *testing.T) {
+	// profileActive true even with no deny/redact rules → a zero-rule named
+	// profile still withholds query_text.
+	active := &Server{profileActive: true}
+	opts, err := active.buildOptions(filterParams{Schema: "app"}, 100, 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !opts.ProfileActive {
+		t.Error("ProfileActive must be true when a profile name was supplied (zero-rule profile still withholds query_text)")
+	}
+
+	// No profile → ProfileActive false (query_text visible).
+	none := &Server{}
+	opts, err = none.buildOptions(filterParams{Schema: "app"}, 100, 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opts.ProfileActive {
+		t.Error("ProfileActive must be false with no profile configured")
+	}
+}
+
 // TestEventsHandlerIncludesConnectionID exercises handleEvents at the HTTP
 // layer with sqlmock and asserts the #701 D1 boundary move holds over real
 // data flow: the source row carries connection_id, and the response now does

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -66,6 +66,14 @@ type Config struct {
 	// applied to every query the console runs — on EVERY server.
 	DenyTables    []query.SchemaTable
 	RedactColumns []query.SchemaTableColumn
+	// ProfileActive is set by the caller whenever a profile NAME was supplied,
+	// even if it resolved to ZERO deny/redact rules (an empty profile). It forces
+	// query.Options.ProfileActive on every query so QueryText/QueryHash are
+	// withheld under EVERY named profile (#699), and — since Parquet archives do
+	// not run the redaction pass — couples with NoArchive so archive rows cannot
+	// leak that statement text either (#838). Independent of the rule count,
+	// which stays the signal for rbacActive() (cascade/reconstruct gating).
+	ProfileActive bool
 	// AllowedHosts is an optional allowlist of hostnames accepted in the Host
 	// header (in addition to IP literals and localhost), for operators who
 	// front the console with a DNS name.
@@ -136,11 +144,15 @@ type RotationDefaults struct {
 // gates) lives in a connManager bundle resolved per request from the
 // X-Bintrail-Server header.
 type Server struct {
-	listen       string
-	token        string
-	denyTables   []query.SchemaTable
-	redactCols   []query.SchemaTableColumn
-	allowedHosts []string
+	listen     string
+	token      string
+	denyTables []query.SchemaTable
+	redactCols []query.SchemaTableColumn
+	// profileActive is true when a profile NAME was supplied (even zero-rule).
+	// buildOptions threads it into query.Options.ProfileActive so query_text is
+	// withheld under every named profile (#699/#838).
+	profileActive bool
+	allowedHosts  []string
 	// monitorCtrl: non-nil only when this process is a control-plane
 	// supervisor (see Config.MonitorCtrl).
 	monitorCtrl MonitorController
@@ -252,14 +264,17 @@ func New(cfg Config) (*Server, error) {
 	// deny-table / redact-column rule must also disable archive auto-discovery
 	// — on every server, not just the boot entry. cmd/bintrail also sets
 	// NoArchive when a profile is active; this makes the invariant structural
-	// rather than caller-dependent.
-	profileActive := len(cfg.DenyTables) > 0 || len(cfg.RedactColumns) > 0
+	// rather than caller-dependent. A NAMED profile that resolved to zero rules
+	// counts too (cfg.ProfileActive): its query_text withholding (#699) must not
+	// be defeated by archive rows, which skip the redaction pass (#838).
+	profileActive := cfg.ProfileActive || len(cfg.DenyTables) > 0 || len(cfg.RedactColumns) > 0
 
 	s := &Server{
 		listen:           listen,
 		token:            token,
 		denyTables:       cfg.DenyTables,
 		redactCols:       cfg.RedactColumns,
+		profileActive:    profileActive,
 		allowedHosts:     cfg.AllowedHosts,
 		monitorCtrl:      cfg.MonitorCtrl,
 		baselineCtrl:     cfg.BaselineCtrl,

--- a/internal/query/profileactive_test.go
+++ b/internal/query/profileactive_test.go
@@ -49,3 +49,42 @@ func TestFetch_profileActiveBlanksQueryText(t *testing.T) {
 		t.Error("row images must not be touched when no redact rule matches")
 	}
 }
+
+// TestProfileExists pins the #838 detection primitive: LoadProfileRules cannot
+// distinguish an empty profile from a nonexistent one (both → zero rules, no
+// error), so callers that must refuse an unknown profile probe ProfileExists.
+// The console `serve` command turns a false result into a loud startup refusal.
+func TestProfileExists(t *testing.T) {
+	cases := []struct {
+		name  string
+		count int64
+		want  bool
+	}{
+		{"present", 1, true},
+		{"absent (typo)", 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("sqlmock: %v", err)
+			}
+			defer db.Close()
+
+			mock.ExpectQuery("SELECT EXISTS").
+				WithArgs("analysts").
+				WillReturnRows(sqlmock.NewRows([]string{"e"}).AddRow(tc.count))
+
+			got, err := ProfileExists(context.Background(), db, "analysts")
+			if err != nil {
+				t.Fatalf("ProfileExists: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("ProfileExists = %v, want %v", got, tc.want)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("unmet expectations: %v", err)
+			}
+		})
+	}
+}

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -103,6 +103,21 @@ func LoadProfileRules(ctx context.Context, db *sql.DB, profile string) ([]Schema
 	return denyTables, redactCols, nil
 }
 
+// ProfileExists reports whether a named RBAC profile row is present in the
+// profiles table. LoadProfileRules returns empty deny/redact slices WITHOUT an
+// error for a nonexistent profile name (a typo resolves to "enforce nothing"),
+// so a caller that must refuse an unknown profile — rather than silently
+// starting with RBAC that enforces nothing — probes existence with this first
+// (#838).
+func ProfileExists(ctx context.Context, db *sql.DB, profile string) (bool, error) {
+	var exists bool
+	if err := db.QueryRowContext(ctx,
+		`SELECT EXISTS(SELECT 1 FROM profiles WHERE name = ?)`, profile).Scan(&exists); err != nil {
+		return false, fmt.Errorf("check profile existence: %w", err)
+	}
+	return exists, nil
+}
+
 // ─── Options ─────────────────────────────────────────────────────────────────
 
 // BinlogPos is a binlog coordinate: a file name plus a byte position. It is used


### PR DESCRIPTION
## Problem

`bintrail-console serve --profile <name>` never set `query.Options.ProfileActive`. A named RBAC profile that resolved to **zero** deny/redact rules — an empty profile, or a typo like `--profile analysts_typo` — therefore skipped the redaction pass entirely:

- The #699 contract (`query_text`/`query_hash` withheld under ANY named profile) was defeated: statement text with sensitive literals stayed visible.
- No table was denied.
- The operator believed RBAC was active.

The CLI (`internal/cli/query.go:251`, `internal/cli/recover.go:229`) and MCP (`cmd/bintrail-mcp/main.go`) both set `ProfileActive=true` whenever a profile NAME is supplied; the console never did. A nonexistent profile was also accepted silently, because `LoadProfileRules` returns empty slices without an error for an unknown name.

## Fix

Two additive halves.

**(a) Thread `ProfileActive`.** New `console.Config.ProfileActive` (set by `serve` from `conProfile != ""`) is stored on the `Server` and threaded into `buildOptions`' `query.Options`, so a zero-rule named profile still withholds `query_text` on every query. It is also folded into the server-level `profileActive` that drives the `NoArchive` coupling — Parquet archive rows bypass `applyRedaction` (only `engine.Fetch` redacts), so without forcing no-archive a registry server under a zero-rule profile would leak `query_text` via archive rows. `rbacActive()` stays rule-count-based, so cascade / reconstruct gating is unchanged.

**(b) Refuse an unknown profile at startup.** `LoadProfileRules` cannot distinguish an empty profile from a nonexistent one (both resolve to zero rules, no error), so `serve` now probes the new `query.ProfileExists` first and fails loud on a typo rather than silently starting with RBAC that enforces nothing. `watch` takes no `--profile` flag, so only `serve` is affected.

## Test

- `internal/console/api_test.go` `TestBuildOptionsThreadsProfileActive`: `ProfileActive` is true when a profile name was supplied (even zero-rule) and false without one.
- `internal/query/profileactive_test.go` `TestProfileExists`: returns true/false for present/absent profile names (sqlmock) — the detection primitive behind the startup refusal.

Build (`CGO_ENABLED=1`) and full unit suites pass for `internal/query`, `internal/console`, `cmd/bintrail-console`.

Closes #838
