### PR TITLE
rotation: re-check partition row count before drop (archive->drop TOCTOU, #779)

### DIFF
--- a/internal/rotation/rotation.go
+++ b/internal/rotation/rotation.go
@@ -298,6 +298,52 @@ func Perform(ctx context.Context, db *sql.DB, dbName string, opts Options) (Resu
 						continue
 					}
 
+					// ── TOCTOU guard: the partition must be unchanged since it ──
+					// was archived. binlog_events is append-only — DROP PARTITION
+					// is the only thing that ever removes rows — so any difference
+					// between the count captured at archive time
+					// (archive_state.row_count == the rows written to the Parquet)
+					// and the partition's current live count means rows were
+					// INSERTED after the archive SELECT and during the
+					// possibly-minutes-long upload. That happens when a backfilled
+					// gap is replayed with original binlog timestamps and lands in
+					// this old RANGE partition while rotation is archiving it.
+					// Dropping now would erase those rows from BOTH the index and
+					// the archive. Instead defer the drop and discard the now-stale
+					// archive so the next cycle re-archives the full partition; the
+					// built-in loop's deferred-streak escalation surfaces a
+					// partition that keeps growing.
+					archived, err := archivedRowCount(ctx, db, name, opts.BintrailID)
+					if err != nil {
+						return Result{}, fmt.Errorf("read archived row count for %s: %w", name, err)
+					}
+					live, err := partitionRowCount(ctx, db, dbName, name)
+					if err != nil {
+						return Result{}, fmt.Errorf("recount partition %s before drop: %w", name, err)
+					}
+					if !archivedPartitionUnchanged(archived, live) {
+						slog.Warn("partition changed since it was archived; deferring drop and discarding the stale archive for re-archive next cycle",
+							"partition", name, "archived_rows", archived.Int64, "live_rows", live)
+						if opts.Format != "json" {
+							fmt.Fprintf(os.Stdout, "skipped drop for %s (partition changed since archive: %d → %d rows; will re-archive next cycle)\n",
+								name, archived.Int64, live)
+						}
+						// Discard the incomplete staged archive and its
+						// archive_state row so (a) --retry re-archives instead of
+						// trusting the stale file, and (b) no later drop-only cycle
+						// trusts this partition as safely archived.
+						if _, derr := db.ExecContext(ctx,
+							`DELETE FROM archive_state WHERE partition_name = ? AND bintrail_id = ?`,
+							name, opts.BintrailID); derr != nil {
+							return Result{}, fmt.Errorf("invalidate stale archive state for %s: %w", name, derr)
+						}
+						if rerr := os.Remove(outPath); rerr != nil && !os.IsNotExist(rerr) {
+							slog.Warn("could not remove stale local archive after deferring drop", "partition", name, "error", rerr)
+						}
+						deferredCount++
+						continue
+					}
+
 					// Drop this partition immediately after archiving.
 					if err := dropPartitions(ctx, db, dbName, []string{name}); err != nil {
 						return Result{}, fmt.Errorf("failed to drop partition %s: %w", name, err)
@@ -481,6 +527,41 @@ func partitionArchived(ctx context.Context, db *sql.DB, partition string) (bool,
 		`SELECT EXISTS (SELECT 1 FROM archive_state WHERE partition_name = ?)`,
 		partition).Scan(&has)
 	return has, err
+}
+
+// archivedRowCount returns the row count archive_state recorded for a
+// partition — the number of rows written to its Parquet archive at the moment
+// it was taken. A missing archive_state row yields an invalid NullInt64, which
+// archivedPartitionUnchanged treats as "cannot verify" (never safe to drop).
+func archivedRowCount(ctx context.Context, db *sql.DB, partition, bintrailID string) (sql.NullInt64, error) {
+	var rc sql.NullInt64
+	err := db.QueryRowContext(ctx,
+		`SELECT row_count FROM archive_state WHERE partition_name = ? AND bintrail_id = ?`,
+		partition, bintrailID).Scan(&rc)
+	if errors.Is(err, sql.ErrNoRows) {
+		return sql.NullInt64{}, nil
+	}
+	return rc, err
+}
+
+// partitionRowCount returns the live row count of a single binlog_events
+// partition. Used by the archive-then-drop path to re-check, right before
+// DROP PARTITION, that no rows landed in the partition after it was archived
+// (the archive→drop TOCTOU, issue #779).
+func partitionRowCount(ctx context.Context, db *sql.DB, dbName, partition string) (int64, error) {
+	q := fmt.Sprintf("SELECT COUNT(*) FROM `%s`.`binlog_events` PARTITION (`%s`)", dbName, partition)
+	var c int64
+	err := db.QueryRowContext(ctx, q).Scan(&c)
+	return c, err
+}
+
+// archivedPartitionUnchanged reports whether a partition is safe to drop after
+// archiving: only when its archived snapshot row count is known AND still
+// equals the partition's current live row count. binlog_events is append-only,
+// so any difference means rows were inserted after the archive SELECT and would
+// be lost by the drop; an unknown archived count is never safe.
+func archivedPartitionUnchanged(archived sql.NullInt64, live int64) bool {
+	return archived.Valid && archived.Int64 == live
 }
 
 // fileExists reports whether a file exists and has a size greater than zero.

--- a/internal/rotation/rotation_integration_test.go
+++ b/internal/rotation/rotation_integration_test.go
@@ -750,13 +750,21 @@ func TestPerformRotation_TruncatedArchiveRetryReArchives(t *testing.T) {
 	}
 }
 
-// TestPerformRotation_ValidExistingArchiveRetrySkips pins the side of the
-// issue #802 fix that must NOT regress: a genuinely complete prior archive —
-// a Parquet file whose footer row count matches what archive_state recorded
-// for it — is still trusted and skipped under --retry, not needlessly
-// re-archived. The stricter verification added for #802 must reject only
-// unverifiable/corrupt files, never a legitimately complete one.
-func TestPerformRotation_ValidExistingArchiveRetrySkips(t *testing.T) {
+// TestPerformRotation_GrownAfterArchiveDefersDropAndReArchives is the archive→
+// drop TOCTOU regression (issue #779), and simultaneously pins the #802 side
+// that must NOT regress: a genuinely complete prior archive — a Parquet file
+// whose footer row count matches what archive_state recorded — is still trusted
+// and skipped under --retry, never needlessly re-archived.
+//
+// Scenario: a valid 1-row archive already exists; then a second live row lands
+// in the same partition after the archive was taken (a backfilled gap replayed
+// with original binlog timestamps into the oldest RANGE partition). Cycle 1
+// under --retry correctly SKIPS re-archiving the still-valid file (#802), but
+// the drop must be DEFERRED, not taken: dropping now would erase the second row
+// from BOTH the index and the archive (#779). The now-incomplete staged archive
+// is discarded so cycle 2 re-archives the full (2-row) partition and only then
+// drops it — proving the "leave for the next cycle" path converges.
+func TestPerformRotation_GrownAfterArchiveDefersDropAndReArchives(t *testing.T) {
 	db, dbName := testutil.CreateTestDB(t)
 	testutil.InitIndexTables(t, db)
 
@@ -766,15 +774,16 @@ func TestPerformRotation_ValidExistingArchiveRetrySkips(t *testing.T) {
 	testutil.InsertEvent(t, db, "binlog.000001", 100, 200, ts1, nil, "testdb", "users", 1, "1", nil, nil, []byte(`{"id":1}`))
 
 	archiveDir := t.TempDir()
-	bintrailID := "test-uuid-valid-skip"
-	outPath, _ := HiveArchivePath(archiveDir, bintrailID, indexer.PartitionName(h1))
+	bintrailID := "test-uuid-toctou"
+	partName := indexer.PartitionName(h1)
+	outPath, _ := HiveArchivePath(archiveDir, bintrailID, partName)
 	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	// Seed a genuinely complete, valid 1-row archive up front (as a prior
 	// successful run would have left it) and record it in archive_state —
 	// the state a legitimate --retry skip depends on.
-	if _, err := archive.ArchivePartition(context.Background(), db, dbName, indexer.PartitionName(h1), outPath, "none"); err != nil {
+	if _, err := archive.ArchivePartition(context.Background(), db, dbName, partName, outPath, "none"); err != nil {
 		t.Fatalf("seed ArchivePartition: %v", err)
 	}
 	origBytes, err := os.ReadFile(outPath)
@@ -783,11 +792,9 @@ func TestPerformRotation_ValidExistingArchiveRetrySkips(t *testing.T) {
 	}
 	testutil.MustExec(t, db, `INSERT INTO archive_state
 		(partition_name, bintrail_id, local_path, row_count)
-		VALUES (?, ?, ?, 1)`, indexer.PartitionName(h1), bintrailID, outPath)
+		VALUES (?, ?, ?, 1)`, partName, bintrailID, outPath)
 
-	// A second live row lands in the partition after the archive was taken;
-	// it must NOT force a re-archive under --retry — the recorded row_count
-	// (1) still matches the file's own footer, so the file stays trusted.
+	// The second live row lands in the partition AFTER the archive was taken.
 	ts2 := h1.Add(40 * time.Minute).Format("2006-01-02 15:04:05")
 	testutil.InsertEvent(t, db, "binlog.000001", 300, 400, ts2, nil, "testdb", "users", 1, "2", nil, nil, []byte(`{"id":2}`))
 
@@ -803,7 +810,7 @@ func TestPerformRotation_ValidExistingArchiveRetrySkips(t *testing.T) {
 	}
 	t.Cleanup(func() { uploadFileFunc = prev })
 
-	res, err := Perform(context.Background(), db, dbName, Options{
+	opts := Options{
 		RetainDur:          24 * time.Hour,
 		ArchiveDir:         archiveDir,
 		ArchiveS3:          "s3://fake-bucket/prefix/",
@@ -813,27 +820,96 @@ func TestPerformRotation_ValidExistingArchiveRetrySkips(t *testing.T) {
 		Format:             "json",
 		NoReplace:          true,
 		Retry:              true,
-	})
+	}
+
+	// ── Cycle 1: the partition grew since it was archived → defer the drop. ──
+	res, err := Perform(context.Background(), db, dbName, opts)
 	if err != nil {
-		t.Fatalf("Perform: %v", err)
+		t.Fatalf("Perform cycle 1: %v", err)
 	}
-	if res.Dropped != 1 {
-		t.Errorf("Dropped = %d, want 1", res.Dropped)
+	if res.Dropped != 0 {
+		t.Errorf("cycle 1 Dropped = %d, want 0 (partition grew since archive; must not be dropped)", res.Dropped)
 	}
+	if res.Deferred != 1 {
+		t.Errorf("cycle 1 Deferred = %d, want 1 (TOCTOU guard)", res.Deferred)
+	}
+	// #802 half: the still-valid 1-row file was skipped, not re-archived —
+	// the bytes uploaded are the original 1-row archive, unchanged.
 	if !bytes.Equal(uploadedBytes, origBytes) {
 		t.Error("a valid, already-recorded archive was re-archived (bytes changed) instead of being skipped")
 	}
-
-	var rowCount int64
+	// #779 half: the partition (and both rows) must survive the deferral.
+	if !partitionExists(t, db, dbName, partName) {
+		t.Errorf("partition %s must NOT have been dropped after the guard deferred it", partName)
+	}
+	if got := livePartitionCount(t, db, dbName, partName); got != 2 {
+		t.Errorf("live partition row count = %d, want 2 (both rows must survive the deferral)", got)
+	}
+	// The incomplete staged archive is discarded: no archive_state row and no
+	// local file, so cycle 2 re-archives from scratch rather than trusting it.
+	var stillRecorded bool
 	if err := db.QueryRow(
-		`SELECT row_count FROM archive_state WHERE partition_name = ? AND bintrail_id = ?`,
-		indexer.PartitionName(h1), bintrailID,
-	).Scan(&rowCount); err != nil {
-		t.Fatalf("read archive_state: %v", err)
+		`SELECT EXISTS(SELECT 1 FROM archive_state WHERE partition_name = ? AND bintrail_id = ?)`,
+		partName, bintrailID,
+	).Scan(&stillRecorded); err != nil {
+		t.Fatalf("check archive_state: %v", err)
 	}
-	if rowCount != 1 {
-		t.Errorf("archive_state.row_count = %d, want unchanged at 1 (a re-archive would have recomputed it to 2)", rowCount)
+	if stillRecorded {
+		t.Error("stale archive_state row must be discarded on deferral so --retry re-archives next cycle")
 	}
+	if _, statErr := os.Stat(outPath); !os.IsNotExist(statErr) {
+		t.Errorf("stale local archive %s must be removed on deferral; stat err = %v", outPath, statErr)
+	}
+
+	// ── Cycle 2: re-archive the full partition, then drop it (convergence). ──
+	uploadedBytes = nil
+	res, err = Perform(context.Background(), db, dbName, opts)
+	if err != nil {
+		t.Fatalf("Perform cycle 2: %v", err)
+	}
+	if res.Dropped != 1 {
+		t.Errorf("cycle 2 Dropped = %d, want 1 (re-archived the full partition, then dropped)", res.Dropped)
+	}
+	if partitionExists(t, db, dbName, partName) {
+		t.Errorf("partition %s should have been dropped in cycle 2 after a complete re-archive", partName)
+	}
+	if uploadedBytes == nil {
+		t.Fatal("cycle 2 must re-upload the re-archived partition")
+	}
+	pf, err := parquet.OpenFile(bytes.NewReader(uploadedBytes), int64(len(uploadedBytes)))
+	if err != nil {
+		t.Fatalf("cycle 2 uploaded bytes are not a valid parquet file: %v", err)
+	}
+	if pf.NumRows() != 2 {
+		t.Errorf("cycle 2 uploaded parquet NumRows = %d, want 2 (the full grown partition)", pf.NumRows())
+	}
+}
+
+// partitionExists reports whether binlog_events still has the named partition.
+func partitionExists(t *testing.T, db *sql.DB, dbName, name string) bool {
+	t.Helper()
+	parts, err := listPartitions(context.Background(), db, dbName)
+	if err != nil {
+		t.Fatalf("listPartitions: %v", err)
+	}
+	for _, p := range parts {
+		if p.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// livePartitionCount returns the live row count of a single partition.
+func livePartitionCount(t *testing.T, db *sql.DB, dbName, name string) int64 {
+	t.Helper()
+	var c int64
+	if err := db.QueryRow(
+		fmt.Sprintf("SELECT COUNT(*) FROM `%s`.`binlog_events` PARTITION (`%s`)", dbName, name),
+	).Scan(&c); err != nil {
+		t.Fatalf("count partition %s: %v", name, err)
+	}
+	return c
 }
 
 // TestPerformRotation_LocalOnlyArchiveNotPruned pins the inverse invariant: with

--- a/internal/rotation/rotation_test.go
+++ b/internal/rotation/rotation_test.go
@@ -1,6 +1,7 @@
 package rotation
 
 import (
+	"database/sql"
 	"os"
 	"strings"
 	"testing"
@@ -8,6 +9,36 @@ import (
 
 	"github.com/dbtrail/dbtrail/internal/indexer"
 )
+
+// ─── archive→drop TOCTOU guard decision (issue #779) ─────────────────────────
+
+// TestArchivedPartitionUnchanged pins the pure decision behind the guard that
+// refuses to drop a partition whose live row count has drifted from what was
+// archived. binlog_events is append-only, so a mismatch means rows landed after
+// the archive SELECT (e.g. a backfilled gap replayed with original timestamps
+// into the oldest RANGE partition during the upload window) and dropping would
+// destroy them. An unknown archived count is never safe to drop on.
+func TestArchivedPartitionUnchanged(t *testing.T) {
+	cases := []struct {
+		name     string
+		archived sql.NullInt64
+		live     int64
+		want     bool
+	}{
+		{"unchanged → safe to drop", sql.NullInt64{Int64: 100, Valid: true}, 100, true},
+		{"grew during upload → defer", sql.NullInt64{Int64: 100, Valid: true}, 150, false},
+		{"shrank (tampered/impossible) → defer", sql.NullInt64{Int64: 100, Valid: true}, 50, false},
+		{"empty partition unchanged → safe", sql.NullInt64{Int64: 0, Valid: true}, 0, true},
+		{"unknown archived count → defer", sql.NullInt64{Valid: false}, 100, false},
+		{"unknown archived, zero live → defer", sql.NullInt64{Valid: false}, 0, false},
+	}
+	for _, c := range cases {
+		if got := archivedPartitionUnchanged(c.archived, c.live); got != c.want {
+			t.Errorf("%s: archivedPartitionUnchanged(%+v, %d) = %v, want %v",
+				c.name, c.archived, c.live, got, c.want)
+		}
+	}
+}
 
 // ─── nextPartitionStart ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

`ArchivePartition` takes its `SELECT` snapshot of a partition, then rotation uploads the resulting Parquet to S3 — a possibly-minutes-long step — before running `ALTER TABLE ... DROP PARTITION`. Nothing verified the partition was unchanged in that window.

`binlog_events` is range-partitioned by `TO_SECONDS(event_timestamp)`, and the first partition's bound captures everything below it. A backfilled gap replayed with **original** binlog timestamps therefore lands in the oldest partition. If the built-in rotation loop is concurrently archiving that partition, rows inserted **after** the archive `SELECT` and **before** the `DROP` vanish from **both** the index and the Parquet archive — silently.

## Fix

Additive guard right before the per-partition `DROP` in the archive branch (`internal/rotation/rotation.go`):

- Compare the partition's current live `COUNT(*)` against the row count captured at archive time (`archive_state.row_count`, which equals the rows written to the Parquet). `binlog_events` is append-only — `DROP PARTITION` is the only thing that ever removes rows — so any difference (or a missing/unverifiable archived count) means rows landed after the snapshot.
- On mismatch: **do not drop.** Emit a loud `slog.Warn`, increment `Deferred` (so the built-in loop's unhealthy-streak escalation fires on a partition that keeps growing), and discard the now-incomplete staged archive — delete its `archive_state` row and remove the local Parquet — so (a) `--retry` re-archives the full partition next cycle instead of trusting the stale file, and (b) no later drop-only cycle trusts the partition as safely archived.
- The happy path (unchanged partitions) drops exactly as before.

The re-check is the primary guard the issue asked for; the discard-and-defer makes "leave it for the next cycle" actually converge.

## Test

- `TestArchivedPartitionUnchanged` — pure table-driven unit test of the guard decision (unchanged → drop; grew/shrank/unknown → defer). Runs without Docker.
- `TestPerformRotation_GrownAfterArchiveDefersDropAndReArchives` (integration) — seeds a valid 1-row archive, lands a second row after it (the TOCTOU), then asserts: cycle 1 **skips** the re-archive of the still-valid file (the #802 invariant) yet **defers** the drop with both rows surviving in the index (#779), and the stale archive is discarded; cycle 2 re-archives the full 2-row partition and only then drops it (convergence). This replaces the former `TestPerformRotation_ValidExistingArchiveRetrySkips`, which asserted the drop in exactly this grown-partition scenario — i.e. it blessed the data loss.

Closes #779
