### PR TITLE
console: make supervised source-stream TLS configurable (#879)

### DIFF
--- a/cmd/bintrail-console/monitor.go
+++ b/cmd/bintrail-console/monitor.go
@@ -387,7 +387,26 @@ func (m *monitorSupervisor) Start(ctx context.Context, e console.ServerEntry) er
 			return fail(fmt.Errorf("derive server id: %w", err))
 		}
 	}
-	cfg := streamrun.Config{
+	cfg := sourceStreamConfig(e, serverID)
+	cfg.Hooks = job.streamHooks()
+
+	m.wg.Add(1)
+	go m.run(jobCtx, job, e, cfg)
+	return nil
+}
+
+// sourceStreamConfig builds the supervised stream's streamrun.Config from a
+// registry entry (Hooks are attached by the caller — they need the live job).
+// The source connection's TLS comes from the entry's ssl_* fields (#879): an
+// empty SSLMode defaults to "preferred", preserving pre-#879 behavior for
+// entries with no TLS configured. Pure — extracted from Start so the
+// entry→config fan-out (SSL especially) is unit-testable without a live DB.
+func sourceStreamConfig(e console.ServerEntry, serverID uint32) streamrun.Config {
+	sslMode := e.SSLMode
+	if sslMode == "" {
+		sslMode = "preferred"
+	}
+	return streamrun.Config{
 		IndexDSN:  e.DSN,
 		SourceDSN: e.SourceDSN,
 		ServerID:  serverID,
@@ -398,16 +417,14 @@ func (m *monitorSupervisor) Start(ctx context.Context, e console.ServerEntry) er
 		// for all supervised streams (per-stream binds would conflict).
 		MetricsSource: e.ID,
 		Checkpoint:    10,
-		SSLMode:       "preferred",
+		SSLMode:       sslMode,
+		SSLCA:         e.SSLCA,
+		SSLCert:       e.SSLCert,
+		SSLKey:        e.SSLKey,
 		Format:        "text",
 		GapTimeout:    30,
-		Hooks:         job.streamHooks(),
 		Deps:          streamdeps.Default(),
 	}
-
-	m.wg.Add(1)
-	go m.run(jobCtx, job, e, cfg)
-	return nil
 }
 
 // run supervises one stream with crash-loop backoff: a stream that errors is

--- a/cmd/bintrail-console/monitor_test.go
+++ b/cmd/bintrail-console/monitor_test.go
@@ -37,6 +37,40 @@ func TestActiveJobs(t *testing.T) {
 	}
 }
 
+// TestSourceStreamConfig pins the registry-entry → supervised-stream config
+// fan-out, with the source-TLS wiring (#879) as the load-bearing case: an entry
+// with no ssl_* fields keeps the pre-#879 "preferred" default; an entry that
+// sets them propagates all four to the stream so the supervised source no
+// longer silently connects with an unauthenticated, unoverridable ssl-mode.
+func TestSourceStreamConfig(t *testing.T) {
+	// Default: no TLS config on the entry → "preferred", empty cert/key paths.
+	def := sourceStreamConfig(console.ServerEntry{
+		ID: "e1", DSN: "idx-dsn", SourceDSN: "src-dsn", Schemas: "shop",
+	}, 42)
+	if def.SSLMode != "preferred" {
+		t.Errorf("SSLMode = %q, want preferred (unset default)", def.SSLMode)
+	}
+	if def.SSLCA != "" || def.SSLCert != "" || def.SSLKey != "" {
+		t.Errorf("unset TLS paths must stay empty, got CA=%q Cert=%q Key=%q", def.SSLCA, def.SSLCert, def.SSLKey)
+	}
+	if def.IndexDSN != "idx-dsn" || def.SourceDSN != "src-dsn" || def.MetricsSource != "e1" ||
+		def.ServerID != 42 || def.Schemas != "shop" || def.BatchSize != 1000 || def.Checkpoint != 10 || def.GapTimeout != 30 {
+		t.Errorf("base fields wrong: %+v", def)
+	}
+	if def.Deps.ValidateBinlogFormat == nil {
+		t.Error("Deps must be wired (streamdeps.Default())")
+	}
+
+	// A registry entry's ssl_* fields propagate verbatim (#879).
+	got := sourceStreamConfig(console.ServerEntry{
+		ID: "e2", DSN: "idx-dsn", SourceDSN: "src-dsn",
+		SSLMode: "verify-ca", SSLCA: "/ca.pem", SSLCert: "/cert.pem", SSLKey: "/key.pem",
+	}, 7)
+	if got.SSLMode != "verify-ca" || got.SSLCA != "/ca.pem" || got.SSLCert != "/cert.pem" || got.SSLKey != "/key.pem" {
+		t.Errorf("registry TLS did not propagate to the stream config: %+v", got)
+	}
+}
+
 // ─── derived monitor states (#402) ───────────────────────────────────────────
 
 func TestMonitorJobSnapshot_stalledDerivation(t *testing.T) {

--- a/cmd/bintrail-console/watch.go
+++ b/cmd/bintrail-console/watch.go
@@ -62,6 +62,10 @@ var (
 	upTables                string
 	upBatchSize             int
 	upCheckpoint            int
+	upSSLMode               string
+	upSSLCA                 string
+	upSSLCert               string
+	upSSLKey                string
 	upMetricsAddr           string
 	upMetricsScrapeInterval int
 	upPartitions            int
@@ -122,6 +126,10 @@ var watchEnvBindings = []struct {
 	{"tables", "BINTRAIL_TABLES"},
 	{"server-id", "BINTRAIL_SERVER_ID"},
 	{"batch-size", "BINTRAIL_BATCH_SIZE"},
+	{"ssl-mode", "BINTRAIL_SSL_MODE"},
+	{"ssl-ca", "BINTRAIL_SSL_CA"},
+	{"ssl-cert", "BINTRAIL_SSL_CERT"},
+	{"ssl-key", "BINTRAIL_SSL_KEY"},
 	{"metrics-addr", "BINTRAIL_METRICS_ADDR"},
 	{"metrics-scrape-interval", "BINTRAIL_METRICS_SCRAPE_INTERVAL"},
 	{"rotate-retain", "BINTRAIL_ROTATE_RETAIN"},
@@ -160,6 +168,10 @@ func init() {
 	watchCmd.Flags().StringVar(&upTables, "tables", "", "Comma-separated tables to index (default: all)")
 	watchCmd.Flags().IntVar(&upBatchSize, "batch-size", 1000, "Events per batch INSERT")
 	watchCmd.Flags().IntVar(&upCheckpoint, "checkpoint", 10, "Checkpoint interval in seconds")
+	watchCmd.Flags().StringVar(&upSSLMode, "ssl-mode", "preferred", "TLS mode for the source connection: disabled, preferred, required, verify-ca, verify-identity")
+	watchCmd.Flags().StringVar(&upSSLCA, "ssl-ca", "", "Path to CA certificate file for source TLS verification (omit to use system CAs)")
+	watchCmd.Flags().StringVar(&upSSLCert, "ssl-cert", "", "Path to client certificate file for mutual TLS to the source")
+	watchCmd.Flags().StringVar(&upSSLKey, "ssl-key", "", "Path to client private key file for mutual TLS to the source")
 	watchCmd.Flags().StringVar(&upMetricsAddr, "metrics-addr", "", "Address to expose Prometheus metrics (e.g. :9090); empty = disabled")
 	watchCmd.Flags().IntVar(&upMetricsScrapeInterval, "metrics-scrape-interval", 60, "How often (seconds) to refresh the bintrail_index_* gauges from a status snapshot")
 	watchCmd.Flags().IntVar(&upPartitions, "partitions", 48, "Hourly partitions to create on first init")
@@ -568,12 +580,14 @@ func runUpStreamWithConsole(cmd *cobra.Command, args []string) error {
 }
 
 // watchStreamConfig snapshots watch's flag values into the main stream's
-// streamrun.Config. The pinned values (StartPos 4, SSLMode preferred,
-// GapTimeout 30, …) replicate what core `up` produced via its
-// populateStreamFlags → streamConfigFromFlags fan-out: `watch`, like `up`,
-// deliberately exposes only the quickstart subset of stream's flags.
-// MetricsAddr stays empty on purpose — the daemon serves ONE /metrics
-// endpoint for all streams (see runUpStreamWithConsole).
+// streamrun.Config. The pinned values (StartPos 4, GapTimeout 30, …)
+// replicate what core `up` produced via its populateStreamFlags →
+// streamConfigFromFlags fan-out: `watch`, like `up`, deliberately exposes only
+// the quickstart subset of stream's flags. The source TLS settings ARE
+// configurable (--ssl-mode/--ssl-ca/--ssl-cert/--ssl-key or BINTRAIL_SSL_*,
+// #879); SSLMode defaults to "preferred" only when left unset, so the previous
+// behavior is unchanged. MetricsAddr stays empty on purpose — the daemon serves
+// ONE /metrics endpoint for all streams (see runUpStreamWithConsole).
 func watchStreamConfig(serverID uint32) streamrun.Config {
 	return streamrun.Config{
 		IndexDSN:   upIndexDSN,
@@ -586,7 +600,10 @@ func watchStreamConfig(serverID uint32) streamrun.Config {
 		Schemas:    upSchemas,
 		Tables:     upTables,
 		Checkpoint: upCheckpoint,
-		SSLMode:    "preferred",
+		SSLMode:    upSSLMode,
+		SSLCA:      upSSLCA,
+		SSLCert:    upSSLCert,
+		SSLKey:     upSSLKey,
 		Format:     upFormat,
 		GapTimeout: 30,
 		// The daemon serves /metrics centrally, so the primary stream sets

--- a/cmd/bintrail-console/watch_test.go
+++ b/cmd/bintrail-console/watch_test.go
@@ -166,12 +166,14 @@ func TestResolveUpConsoleEnv(t *testing.T) {
 func TestWatchStreamConfig(t *testing.T) {
 	orig := struct {
 		src, idx, sch, tbl, fmtv, met string
+		ssl, sslCA, sslCert, sslKey   string
 		batch, chk, msi               int
-	}{upSourceDSN, upIndexDSN, upSchemas, upTables, upFormat, upMetricsAddr, upBatchSize, upCheckpoint, upMetricsScrapeInterval}
+	}{upSourceDSN, upIndexDSN, upSchemas, upTables, upFormat, upMetricsAddr, upSSLMode, upSSLCA, upSSLCert, upSSLKey, upBatchSize, upCheckpoint, upMetricsScrapeInterval}
 	t.Cleanup(func() {
 		upSourceDSN, upIndexDSN, upSchemas, upTables, upFormat = orig.src, orig.idx, orig.sch, orig.tbl, orig.fmtv
 		upBatchSize, upCheckpoint = orig.batch, orig.chk
 		upMetricsAddr, upMetricsScrapeInterval = orig.met, orig.msi
+		upSSLMode, upSSLCA, upSSLCert, upSSLKey = orig.ssl, orig.sslCA, orig.sslCert, orig.sslKey
 	})
 
 	upSourceDSN = "user:pass@tcp(source.example.com:3306)/src"
@@ -183,6 +185,13 @@ func TestWatchStreamConfig(t *testing.T) {
 	upFormat = "json"
 	upMetricsAddr = "" // primary stream gates index metrics on this being set
 	upMetricsScrapeInterval = 33
+	// Source TLS is user-configurable on watch (#879): set non-default values
+	// so a regression that re-hardcodes SSLMode or drops the cert/key wiring
+	// fails here rather than silently downgrading to unauthenticated TLS.
+	upSSLMode = "verify-ca"
+	upSSLCA = "/etc/ssl/ca.pem"
+	upSSLCert = "/etc/ssl/client-cert.pem"
+	upSSLKey = "/etc/ssl/client-key.pem"
 
 	const passedServerID uint32 = 4242424242
 	cfg := watchStreamConfig(passedServerID)
@@ -205,7 +214,11 @@ func TestWatchStreamConfig(t *testing.T) {
 	// Pinned defaults, not user-configurable from watch.
 	assertStr(t, "StartFile", cfg.StartFile, "")
 	assertStr(t, "StartGTID", cfg.StartGTID, "")
-	assertStr(t, "SSLMode", cfg.SSLMode, "preferred")
+	// Source TLS is user-configurable (#879) — it must propagate verbatim.
+	assertStr(t, "SSLMode", cfg.SSLMode, "verify-ca")
+	assertStr(t, "SSLCA", cfg.SSLCA, "/etc/ssl/ca.pem")
+	assertStr(t, "SSLCert", cfg.SSLCert, "/etc/ssl/client-cert.pem")
+	assertStr(t, "SSLKey", cfg.SSLKey, "/etc/ssl/client-key.pem")
 	// The daemon serves ONE /metrics endpoint for all streams; a per-stream
 	// bind here would conflict with it.
 	assertStr(t, "MetricsAddr", cfg.MetricsAddr, "")
@@ -286,6 +299,59 @@ func TestResolveUpConsoleEnvAuthTLS(t *testing.T) {
 	assertStr(t, "upConsoleAuthFile (flag)", upConsoleAuthFile, "/flag/auth.yaml")
 	assertStr(t, "upConsoleTLSCert (flag)", upConsoleTLSCert, "/flag/cert.pem")
 	assertStr(t, "upConsoleTLSKey (flag)", upConsoleTLSKey, "/flag/key.pem")
+}
+
+// TestWatchSSLEnvBinding locks the source-TLS override channel (#879): the
+// --ssl-mode/--ssl-ca/--ssl-cert/--ssl-key flags exist on the real watchCmd,
+// each is wired to its BINTRAIL_SSL_* env var in watchEnvBindings, and an env
+// value propagates to the up* globals via bindWatchEnv. Without this, watch's
+// source stream silently connects with ssl-mode=preferred and no override.
+func TestWatchSSLEnvBinding(t *testing.T) {
+	saved := [4]string{upSSLMode, upSSLCA, upSSLCert, upSSLKey}
+	t.Cleanup(func() { upSSLMode, upSSLCA, upSSLCert, upSSLKey = saved[0], saved[1], saved[2], saved[3] })
+
+	// The flags must exist on the REAL watchCmd — a rename in init() not
+	// mirrored in watchEnvBindings would silently drop the env override.
+	for _, name := range []string{"ssl-mode", "ssl-ca", "ssl-cert", "ssl-key"} {
+		if watchCmd.Flags().Lookup(name) == nil {
+			t.Fatalf("flag --%s not registered on watchCmd", name)
+		}
+	}
+	// …and each is mapped to its BINTRAIL_SSL_* env var.
+	wantEnv := map[string]string{
+		"ssl-mode": "BINTRAIL_SSL_MODE",
+		"ssl-ca":   "BINTRAIL_SSL_CA",
+		"ssl-cert": "BINTRAIL_SSL_CERT",
+		"ssl-key":  "BINTRAIL_SSL_KEY",
+	}
+	got := map[string]string{}
+	for _, b := range watchEnvBindings {
+		if _, ok := wantEnv[b.Flag]; ok {
+			got[b.Flag] = b.EnvVar
+		}
+	}
+	for flag, env := range wantEnv {
+		if got[flag] != env {
+			t.Errorf("watchEnvBindings[%q] = %q, want %q", flag, got[flag], env)
+		}
+	}
+
+	// bindWatchEnv applies the env to the bound flags (a throwaway cmd bound to
+	// the same globals, mirroring how init() binds watchCmd).
+	cmd := &cobra.Command{}
+	cmd.Flags().StringVar(&upSSLMode, "ssl-mode", "preferred", "")
+	cmd.Flags().StringVar(&upSSLCA, "ssl-ca", "", "")
+	cmd.Flags().StringVar(&upSSLCert, "ssl-cert", "", "")
+	cmd.Flags().StringVar(&upSSLKey, "ssl-key", "", "")
+	t.Setenv("BINTRAIL_SSL_MODE", "verify-identity")
+	t.Setenv("BINTRAIL_SSL_CA", "/env/ca.pem")
+	t.Setenv("BINTRAIL_SSL_CERT", "/env/cert.pem")
+	t.Setenv("BINTRAIL_SSL_KEY", "/env/key.pem")
+	bindWatchEnv(cmd)
+	assertStr(t, "upSSLMode (env)", upSSLMode, "verify-identity")
+	assertStr(t, "upSSLCA (env)", upSSLCA, "/env/ca.pem")
+	assertStr(t, "upSSLCert (env)", upSSLCert, "/env/cert.pem")
+	assertStr(t, "upSSLKey (env)", upSSLKey, "/env/key.pem")
 }
 
 // TestRotateTargets covers the per-source archive wiring: the boot index is

--- a/internal/console/registry.go
+++ b/internal/console/registry.go
@@ -66,6 +66,17 @@ type ServerEntry struct {
 	SourceServerID uint32 `yaml:"source_server_id,omitempty"`
 	// Schemas is the optional comma-separated schema filter for monitoring.
 	Schemas string `yaml:"schemas,omitempty"`
+
+	// ── Source TLS (#879) ──
+	// SSLMode/SSLCA/SSLCert/SSLKey configure the TLS the supervisor uses when
+	// connecting to the SOURCE MySQL. Empty SSLMode = the daemon default
+	// ("preferred"), preserving pre-#879 behavior; SSLCA/SSLCert/SSLKey are file
+	// paths on the daemon host (verify-ca / mutual TLS), not secrets like the
+	// DSNs. On binaries that predate these they round-trip untouched via Extra.
+	SSLMode string `yaml:"ssl_mode,omitempty"`
+	SSLCA   string `yaml:"ssl_ca,omitempty"`
+	SSLCert string `yaml:"ssl_cert,omitempty"`
+	SSLKey  string `yaml:"ssl_key,omitempty"`
 	// ArchiveS3 is the S3 destination (s3://bucket/prefix/) the daemon's
 	// built-in rotation uploads this source's rotated Parquet partitions to
 	// BEFORE dropping them — so the forensic record survives retention and

--- a/internal/console/registry_test.go
+++ b/internal/console/registry_test.go
@@ -202,6 +202,10 @@ func TestRegistrySourceFieldsRoundTrip(t *testing.T) {
 		SourceServerID: 4242,
 		Schemas:        "shop,billing",
 		MonitorDesired: true,
+		SSLMode:        "verify-ca",
+		SSLCA:          "/etc/ssl/ca.pem",
+		SSLCert:        "/etc/ssl/client-cert.pem",
+		SSLKey:         "/etc/ssl/client-key.pem",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -217,6 +221,11 @@ func TestRegistrySourceFieldsRoundTrip(t *testing.T) {
 	if got.SourceDSN != "repl:"+secretPW+"@tcp(db.prod:3306)/" ||
 		got.SourceServerID != 4242 || got.Schemas != "shop,billing" || !got.MonitorDesired {
 		t.Errorf("source fields round-trip mismatch: %+v", got)
+	}
+	// Source-TLS fields (#879) persist and reload like the other typed fields.
+	if got.SSLMode != "verify-ca" || got.SSLCA != "/etc/ssl/ca.pem" ||
+		got.SSLCert != "/etc/ssl/client-cert.pem" || got.SSLKey != "/etc/ssl/client-key.pem" {
+		t.Errorf("source TLS fields round-trip mismatch: %+v", got)
 	}
 }
 

--- a/internal/console/servers_api.go
+++ b/internal/console/servers_api.go
@@ -280,6 +280,15 @@ func (s *Server) handleServersUpdate(w http.ResponseWriter, r *http.Request) {
 		MonitorDesired: old.MonitorDesired,
 		SourceServerID: req.SourceServerID,
 		Schemas:        req.Schemas,
+		// Source TLS (#879) has no request field yet — it is hand-edited into
+		// the registry YAML. Carry it over from the stored entry so a plain UI
+		// edit does not wipe a configured verify-ca / mutual-TLS source
+		// connection. (These are typed fields now, so they no longer survive via
+		// the Extra catch-all the way an unknown key would.)
+		SSLMode: old.SSLMode,
+		SSLCA:   old.SSLCA,
+		SSLCert: old.SSLCert,
+		SSLKey:  old.SSLKey,
 	}
 	if err := s.cm.reg.Update(entry); err != nil {
 		writeJSONError(w, registryErrStatus(err), err.Error())

--- a/internal/console/servers_api_test.go
+++ b/internal/console/servers_api_test.go
@@ -468,6 +468,42 @@ func TestServersAPISourceSecrecy(t *testing.T) {
 	}
 }
 
+// TestServersAPIUpdatePreservesSSL guards the regression the #879 schema change
+// could introduce: source-TLS is hand-edited into the registry YAML (no request
+// field yet), so once it is a TYPED field it no longer round-trips through the
+// Extra catch-all. handleServersUpdate must carry it over from the stored entry
+// or a plain UI edit silently wipes a configured verify-ca / mutual-TLS source.
+func TestServersAPIUpdatePreservesSSL(t *testing.T) {
+	srv := newRegistryServer(t)
+	created, err := srv.cm.reg.Add(ServerEntry{
+		Name:      "prod",
+		DSN:       "u:p@tcp(h:3306)/binlog_index",
+		SourceDSN: "repl:" + secretPW + "@tcp(db.prod:3306)/",
+		SSLMode:   "verify-ca",
+		SSLCA:     "/etc/ssl/ca.pem",
+		SSLCert:   "/etc/ssl/client-cert.pem",
+		SSLKey:    "/etc/ssl/client-key.pem",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// An unrelated edit (rename) that carries no ssl_* fields must keep them.
+	rec, body := doServersReq(t, srv, "PUT", "/api/servers/"+created.ID,
+		`{"name":"prod-renamed","host":"h","user":"u","password":"p","dbname":"binlog_index"}`)
+	if rec.Code != 200 {
+		t.Fatalf("update: code=%d body=%s", rec.Code, body)
+	}
+	got, ok := srv.cm.reg.Get(created.ID)
+	if !ok {
+		t.Fatal("entry lost after update")
+	}
+	if got.SSLMode != "verify-ca" || got.SSLCA != "/etc/ssl/ca.pem" ||
+		got.SSLCert != "/etc/ssl/client-cert.pem" || got.SSLKey != "/etc/ssl/client-key.pem" {
+		t.Errorf("source TLS must survive an unrelated edit; got %+v", got)
+	}
+}
+
 func TestBuildSourceDSNValidation(t *testing.T) {
 	pw := "x"
 	cases := []struct {


### PR DESCRIPTION
## Problem

`bintrail-console watch`'s own stream and every console-managed ("+ Add server") source connected to the source MySQL with `ssl-mode=preferred` **hardcoded** — no certificate verification, silent plaintext fallback — with **no flag or env override**, even though `bintrail stream` / `up` already expose the full `--ssl-*` set (`BINTRAIL_SSL_MODE`/`_CA`/`_CERT`/`_KEY`).

## Fix

Additive; unset = current `preferred` behavior preserved.

- **watch.go**: add `--ssl-mode` / `--ssl-ca` / `--ssl-cert` / `--ssl-key` flags and the matching `BINTRAIL_SSL_MODE`/`_CA`/`_CERT`/`_KEY` entries in `watchEnvBindings` (mirroring `cliapp/up.go`'s post-#808 pattern), threaded into `watchStreamConfig`. `SSLMode` still defaults to `"preferred"` when unset.
- **registry.go**: add typed `ssl_mode` / `ssl_ca` / `ssl_cert` / `ssl_key` fields to the console server registry `ServerEntry`. Additive — pre-existing files round-trip them through the `Extra` inline catch-all, so no version bump.
- **monitor.go**: extract `sourceStreamConfig()` from `Start` and thread the entry's `ssl_*` into the per-source supervised stream (empty `ssl_mode` → `"preferred"`).
- **servers_api.go**: carry the `ssl_*` fields over from the stored entry on update — now that they are typed fields they no longer survive via `Extra`, so a plain UI edit would otherwise wipe a hand-edited verify-ca / mutual-TLS source connection.

## Test

New/extended unit tests (all pass, `go vet` clean):

- `TestWatchStreamConfig` — asserts `--ssl-*` propagate verbatim into the main stream config.
- `TestWatchSSLEnvBinding` — flags exist on `watchCmd`, are mapped in `watchEnvBindings`, and `bindWatchEnv` applies `BINTRAIL_SSL_*`.
- `TestSourceStreamConfig` — registry entry `ssl_*` propagate to the supervised per-source stream; empty `ssl_mode` defaults to `preferred`.
- `TestRegistrySourceFieldsRoundTrip` — SSL fields persist/reload across save/load.
- `TestServersAPIUpdatePreservesSSL` — a plain UI rename keeps hand-edited source TLS.

Closes #879
