### PR TITLE
security: keep source password off mydumper argv (ps/docker inspect leak)

### DIFF
--- a/cliapp/dump.go
+++ b/cliapp/dump.go
@@ -112,8 +112,11 @@ func resolveMydumper(cmd *cobra.Command) (dumpResolution, error) {
 // buildDockerArgs constructs the full argument slice for invoking mydumper via
 // docker run. The output directory is bind-mounted at the same absolute path so
 // downstream tools need no path translation. When encryptKeyPath is non-empty,
-// the key file is also bind-mounted into the container.
-func buildDockerArgs(image, outputDir, host string, mydumperArgs []string, encryptKeyPath string) []string {
+// the key file is also bind-mounted into the container. When defaultsFile is
+// non-empty it is likewise bind-mounted read-only at the same path so the
+// container's mydumper can read the source password from it via --defaults-file
+// (keeping the secret off argv and out of `docker inspect`, #811).
+func buildDockerArgs(image, outputDir, host string, mydumperArgs []string, encryptKeyPath, defaultsFile string) []string {
 	absOutput, err := filepath.Abs(outputDir)
 	if err != nil {
 		absOutput = outputDir
@@ -131,6 +134,14 @@ func buildDockerArgs(image, outputDir, host string, mydumperArgs []string, encry
 			absKey = encryptKeyPath
 		}
 		args = append(args, "-v", absKey+":"+absKey+":ro")
+	}
+
+	if defaultsFile != "" {
+		absDefaults, err := filepath.Abs(defaultsFile)
+		if err != nil {
+			absDefaults = defaultsFile
+		}
+		args = append(args, "-v", absDefaults+":"+absDefaults+":ro")
 	}
 
 	if isLocalhost(host) {
@@ -230,17 +241,38 @@ func runDump(cmd *cobra.Command, args []string) error {
 			supportsLockMode = false
 		}
 	}
-	mydumperArgs := buildMydumperArgs(host, port, user, password, dmpOutputDir, dmpThreads, schemas, tables, encryptKeyPath, supportsLockMode)
+	// The source password must never reach mydumper's argv (visible in
+	// `ps aux` / /proc/<pid>/cmdline and, under Docker, in `docker inspect`).
+	// Docker mode delivers it via a 0600 defaults-file bind-mounted read-only;
+	// local mode delivers it via MYSQL_PWD in the child env below (#811).
+	var defaultsFile string
+	if password != "" && res.mode == dumpModeDocker {
+		var cleanup func()
+		var derr error
+		defaultsFile, cleanup, derr = writeMydumperDefaultsFile(password)
+		if derr != nil {
+			return derr
+		}
+		defer cleanup()
+	}
+	mydumperArgs := buildMydumperArgs(host, port, user, defaultsFile, dmpOutputDir, dmpThreads, schemas, tables, encryptKeyPath, supportsLockMode)
 
 	// 7. Build the final command depending on resolution mode.
 	var c *exec.Cmd
 	switch res.mode {
 	case dumpModeDocker:
-		dockerArgs := buildDockerArgs(res.image, dmpOutputDir, host, mydumperArgs, encryptKeyPath)
+		dockerArgs := buildDockerArgs(res.image, dmpOutputDir, host, mydumperArgs, encryptKeyPath, defaultsFile)
 		c = exec.CommandContext(cmd.Context(), res.path, dockerArgs...)
 		slog.Info("starting dump via Docker", "image", res.image, "output_dir", dmpOutputDir)
 	default:
 		c = exec.CommandContext(cmd.Context(), res.path, mydumperArgs...)
+		// Pass the password out of band so it stays off argv. MYSQL_PWD is
+		// honored by the MySQL client library mydumper links against and sits
+		// in the child's mode-0400 /proc/<pid>/environ, not world-readable
+		// cmdline (#811).
+		if password != "" {
+			c.Env = append(os.Environ(), "MYSQL_PWD="+password)
+		}
 		slog.Info("starting dump", "path", res.path, "output_dir", dmpOutputDir)
 	}
 
@@ -340,7 +372,14 @@ func mydumperSupportsLockMode(major, minor int) bool {
 // Table filtering: --tables-list with a comma-joined list.
 // When encryptKeyPath is non-empty, --exec-per-thread and
 // --exec-per-thread-extension are added for AES-256-CBC encryption.
-func buildMydumperArgs(host string, port uint16, user, password, outputDir string,
+//
+// The source password is NEVER placed on argv — it would be world-readable via
+// `ps aux` / /proc/<pid>/cmdline and, under Docker, in `docker inspect`. It is
+// delivered out of band: locally via MYSQL_PWD in the child env, and under
+// Docker via a 0600 defaults-file bind-mounted read-only. When defaultsFile is
+// non-empty its path is referenced with --defaults-file so mydumper reads the
+// password from it (#811).
+func buildMydumperArgs(host string, port uint16, user, defaultsFile, outputDir string,
 	threads int, schemas, tables []string, encryptKeyPath string, supportsLockMode bool) []string {
 
 	args := []string{
@@ -356,8 +395,8 @@ func buildMydumperArgs(host string, port uint16, user, password, outputDir strin
 		args = append(args, "--sync-thread-lock-mode", "NO_LOCK", "--trx-tables")
 	}
 
-	if password != "" {
-		args = append(args, "--password", password)
+	if defaultsFile != "" {
+		args = append(args, "--defaults-file", defaultsFile)
 	}
 
 	switch len(schemas) {
@@ -389,6 +428,53 @@ func buildMydumperArgs(host string, port uint16, user, password, outputDir strin
 	args = append(args, "--outputdir", outputDir)
 
 	return args
+}
+
+// writeMydumperDefaultsFile writes the source password to a fresh temp file in
+// MySQL option-file format (0600) so mydumper can read it via --defaults-file
+// instead of taking it on argv. Used by Docker mode, where a passed-through
+// MYSQL_PWD would still surface in `docker inspect` Config.Env. The returned
+// cleanup removes the file and must be deferred by the caller even on a later
+// error. os.CreateTemp opens O_EXCL with mode 0600, so creation is atomic and
+// the secret is never briefly world-readable (#811).
+func writeMydumperDefaultsFile(password string) (path string, cleanup func(), err error) {
+	f, err := os.CreateTemp("", "bintrail-mydumper-*.cnf")
+	if err != nil {
+		return "", nil, fmt.Errorf("create mydumper defaults file: %w", err)
+	}
+	name := f.Name()
+	cleanup = func() { _ = os.Remove(name) }
+	// Defensive: CreateTemp already uses 0600, but pin it in case of an
+	// unusual umask/implementation.
+	if chmodErr := f.Chmod(0o600); chmodErr != nil {
+		_ = f.Close()
+		cleanup()
+		return "", nil, fmt.Errorf("chmod mydumper defaults file: %w", chmodErr)
+	}
+	// Password under both [client] and [mydumper] so any mydumper build picks
+	// it up regardless of which group it reads.
+	v := escapeMyCnfValue(password)
+	content := "[client]\npassword=" + v + "\n[mydumper]\npassword=" + v + "\n"
+	if _, werr := f.WriteString(content); werr != nil {
+		_ = f.Close()
+		cleanup()
+		return "", nil, fmt.Errorf("write mydumper defaults file: %w", werr)
+	}
+	if cerr := f.Close(); cerr != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("close mydumper defaults file: %w", cerr)
+	}
+	return name, cleanup, nil
+}
+
+// escapeMyCnfValue encodes a value for a MySQL option file. The value is wrapped
+// in double quotes (so a '#', ';', or whitespace is not misread as a comment or
+// truncated) with backslash and double-quote escaped, matching the escape
+// sequences the option-file parser recognizes inside a quoted value.
+func escapeMyCnfValue(v string) string {
+	v = strings.ReplaceAll(v, `\`, `\\`)
+	v = strings.ReplaceAll(v, `"`, `\"`)
+	return `"` + v + `"`
 }
 
 // extractSchemasFromTables derives unique schema names from a list of

--- a/cliapp/dump_test.go
+++ b/cliapp/dump_test.go
@@ -72,7 +72,7 @@ func TestDumpCmd_allFlagsRegistered(t *testing.T) {
 // ─── buildMydumperArgs ────────────────────────────────────────────────────────
 
 func TestBuildMydumperArgs_basic(t *testing.T) {
-	args := buildMydumperArgs("127.0.0.1", 3306, "root", "secret", "/tmp/dump", 4, nil, nil, "", true)
+	args := buildMydumperArgs("127.0.0.1", 3306, "root", "", "/tmp/dump", 4, nil, nil, "", true)
 	assertArgsContainPair(t, args, "--host", "127.0.0.1")
 	assertArgsContainPair(t, args, "--port", "3306")
 	assertArgsContainPair(t, args, "--user", "root")
@@ -177,10 +177,30 @@ func TestParseMydumperVersion(t *testing.T) {
 	}
 }
 
-func TestBuildMydumperArgs_noPassword(t *testing.T) {
-	args := buildMydumperArgs("127.0.0.1", 3306, "root", "", "/tmp/dump", 4, nil, nil, "", true)
-	if argsContain(args, "--password") {
-		t.Error("expected --password to be absent when password is empty")
+// TestBuildMydumperArgs_neverPassword asserts the source password is NEVER put
+// on argv, regardless of whether a defaults-file is used — the whole point of
+// #811 (a password on argv is world-readable via ps aux / /proc/cmdline). The
+// function no longer even accepts a password, so it cannot leak one.
+func TestBuildMydumperArgs_neverPassword(t *testing.T) {
+	for _, defaultsFile := range []string{"", "/tmp/bintrail-mydumper-xyz.cnf"} {
+		args := buildMydumperArgs("127.0.0.1", 3306, "root", defaultsFile, "/tmp/dump", 4, nil, nil, "", true)
+		if argsContain(args, "--password") {
+			t.Errorf("defaultsFile=%q: --password must never appear on argv: %v", defaultsFile, args)
+		}
+	}
+}
+
+// TestBuildMydumperArgs_defaultsFile verifies that a non-empty defaults-file
+// path is passed via --defaults-file (Docker mode delivers the secret this way),
+// and omitted when empty (local mode delivers it via MYSQL_PWD env).
+func TestBuildMydumperArgs_defaultsFile(t *testing.T) {
+	const path = "/tmp/bintrail-mydumper-abc.cnf"
+	args := buildMydumperArgs("127.0.0.1", 3306, "root", path, "/tmp/dump", 4, nil, nil, "", true)
+	assertArgsContainPair(t, args, "--defaults-file", path)
+
+	none := buildMydumperArgs("127.0.0.1", 3306, "root", "", "/tmp/dump", 4, nil, nil, "", true)
+	if argsContain(none, "--defaults-file") {
+		t.Errorf("expected --defaults-file to be absent when no defaults file given: %v", none)
 	}
 }
 
@@ -210,9 +230,16 @@ func TestBuildMydumperArgs_multipleSchemas(t *testing.T) {
 	}
 }
 
-func TestBuildMydumperArgs_withPassword(t *testing.T) {
-	args := buildMydumperArgs("127.0.0.1", 3306, "root", "s3cr3t", "/tmp/dump", 4, nil, nil, "", true)
-	assertArgsContainPair(t, args, "--password", "s3cr3t")
+// TestBuildMydumperArgs_passwordNeverLeaksToArgv is a regression guard for #811:
+// even a password-shaped value must never appear anywhere in the argv (the
+// function delivers credentials out of band, so it takes no password at all).
+func TestBuildMydumperArgs_passwordNeverLeaksToArgv(t *testing.T) {
+	args := buildMydumperArgs("127.0.0.1", 3306, "root", "", "/tmp/dump", 4, []string{"mydb"}, nil, "", true)
+	for _, a := range args {
+		if a == "s3cr3t" || a == "--password" {
+			t.Errorf("password-related token leaked to argv: %q in %v", a, args)
+		}
+	}
 }
 
 func TestBuildMydumperArgs_noSchemasOrTables(t *testing.T) {
@@ -287,7 +314,7 @@ func TestBuildMydumperArgs_outputDirIsLast(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			args := buildMydumperArgs("127.0.0.1", 3306, "root", "pw", "/data/backup", 4, tc.schemas, tc.tables, tc.encrypt, true)
+			args := buildMydumperArgs("127.0.0.1", 3306, "root", "", "/data/backup", 4, tc.schemas, tc.tables, tc.encrypt, true)
 			n := len(args)
 			if n < 2 {
 				t.Fatalf("args too short: %v", args)
@@ -672,7 +699,7 @@ func TestResolveMydumper_dockerFallback(t *testing.T) {
 
 func TestBuildDockerArgs_basic(t *testing.T) {
 	mydumperArgs := []string{"--host", "db.example.com", "--port", "3306", "--user", "root", "--outputdir", "/tmp/dump"}
-	args := buildDockerArgs("mydumper/mydumper:latest", "/tmp/dump", "db.example.com", mydumperArgs, "")
+	args := buildDockerArgs("mydumper/mydumper:latest", "/tmp/dump", "db.example.com", mydumperArgs, "", "")
 
 	// Should start with docker run --rm
 	if len(args) < 3 || args[0] != "run" || args[1] != "--rm" {
@@ -704,7 +731,7 @@ func TestBuildDockerArgs_basic(t *testing.T) {
 
 func TestBuildDockerArgs_localhostNetworkHost(t *testing.T) {
 	for _, host := range []string{"localhost", "127.0.0.1", "::1"} {
-		args := buildDockerArgs("mydumper/mydumper:latest", "/tmp/dump", host, nil, "")
+		args := buildDockerArgs("mydumper/mydumper:latest", "/tmp/dump", host, nil, "", "")
 
 		// On Linux, --network host should be added; on macOS it should not.
 		hasNetwork := argsContain(args, "--network")
@@ -787,7 +814,7 @@ func TestBuildMydumperArgs_noEncrypt(t *testing.T) {
 }
 
 func TestBuildDockerArgs_encryptKeyMount(t *testing.T) {
-	args := buildDockerArgs("mydumper/mydumper:latest", "/tmp/dump", "db.example.com", nil, "/path/to/key")
+	args := buildDockerArgs("mydumper/mydumper:latest", "/tmp/dump", "db.example.com", nil, "/path/to/key", "")
 	found := false
 	for i, a := range args {
 		if a == "-v" && i+1 < len(args) && strings.Contains(args[i+1], "/key") && strings.HasSuffix(args[i+1], ":ro") {
@@ -801,13 +828,13 @@ func TestBuildDockerArgs_encryptKeyMount(t *testing.T) {
 }
 
 func TestBuildDockerArgs_userFlag(t *testing.T) {
-	args := buildDockerArgs("mydumper/mydumper:latest", "/tmp/dump", "db.example.com", nil, "")
+	args := buildDockerArgs("mydumper/mydumper:latest", "/tmp/dump", "db.example.com", nil, "", "")
 	want := fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid())
 	assertArgsContainPair(t, args, "--user", want)
 }
 
 func TestBuildDockerArgs_noEncryptKeyMount(t *testing.T) {
-	args := buildDockerArgs("mydumper/mydumper:latest", "/tmp/dump", "db.example.com", nil, "")
+	args := buildDockerArgs("mydumper/mydumper:latest", "/tmp/dump", "db.example.com", nil, "", "")
 	// Should only have one -v (for output dir)
 	count := 0
 	for _, a := range args {
@@ -840,6 +867,168 @@ func TestResolveEncryptKey_defaultPath(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "generate-key") {
 		t.Errorf("expected 'generate-key' hint in error, got: %v", err)
+	}
+}
+
+// ─── password out-of-band delivery (#811) ────────────────────────────────────
+
+func TestBuildDockerArgs_defaultsFileMount(t *testing.T) {
+	const path = "/tmp/bintrail-mydumper-x.cnf"
+	args := buildDockerArgs("mydumper/mydumper:latest", "/tmp/dump", "db.example.com",
+		[]string{"--defaults-file", path}, "", path)
+	found := false
+	for i, a := range args {
+		if a == "-v" && i+1 < len(args) && strings.HasPrefix(args[i+1], path+":"+path) && strings.HasSuffix(args[i+1], ":ro") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected read-only bind mount for the defaults file, got %v", args)
+	}
+}
+
+func TestBuildDockerArgs_noDefaultsFileNoExtraMount(t *testing.T) {
+	// Without a defaults file, only the output-dir -v mount is present.
+	args := buildDockerArgs("mydumper/mydumper:latest", "/tmp/dump", "db.example.com", nil, "", "")
+	count := 0
+	for _, a := range args {
+		if a == "-v" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 -v mount without a defaults file, got %d: %v", count, args)
+	}
+}
+
+func TestEscapeMyCnfValue(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"simple", `"simple"`},
+		{"", `""`},
+		{`pa#ss;word`, `"pa#ss;word"`}, // # / ; safe inside quotes
+		{`a b`, `"a b"`},               // whitespace safe inside quotes
+		{`ba\ck`, `"ba\\ck"`},          // backslash escaped
+		{`quo"te`, `"quo\"te"`},        // double-quote escaped
+		{`x\y"z`, `"x\\y\"z"`},         // both, in order
+	}
+	for _, tc := range cases {
+		if got := escapeMyCnfValue(tc.in); got != tc.want {
+			t.Errorf("escapeMyCnfValue(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestWriteMydumperDefaultsFile(t *testing.T) {
+	const pw = `s3cr3t#p"w`
+	path, cleanup, err := writeMydumperDefaultsFile(pw)
+	if err != nil {
+		t.Fatalf("writeMydumperDefaultsFile: %v", err)
+	}
+	t.Cleanup(cleanup)
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat defaults file: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("defaults file mode = %o, want 0600", perm)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read defaults file: %v", err)
+	}
+	s := string(data)
+	for _, group := range []string{"[client]", "[mydumper]"} {
+		if !strings.Contains(s, group) {
+			t.Errorf("defaults file missing %s group: %q", group, s)
+		}
+	}
+	want := "password=" + escapeMyCnfValue(pw)
+	if !strings.Contains(s, want) {
+		t.Errorf("defaults file missing escaped password %q: %q", want, s)
+	}
+	// The raw (unescaped) password must not be written verbatim if it needs
+	// escaping — the escaped form differs, guarding against a naive write.
+	if strings.Contains(s, "password="+pw+"\n") {
+		t.Errorf("defaults file wrote unescaped password: %q", s)
+	}
+
+	// cleanup removes the file.
+	cleanup()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("expected defaults file removed by cleanup, stat err = %v", err)
+	}
+}
+
+// TestRunDump_localDeliversPasswordViaEnvNotArgv is the end-to-end regression
+// guard for #811: in local mode the password reaches the child as MYSQL_PWD and
+// never appears on argv (world-readable via ps aux / /proc/cmdline).
+func TestRunDump_localDeliversPasswordViaEnvNotArgv(t *testing.T) {
+	dir := t.TempDir()
+	record := filepath.Join(dir, "record.txt")
+	t.Setenv("BINTRAIL_TEST_RECORD", record)
+
+	fakeBin := filepath.Join(dir, "mydumper")
+	script := `#!/bin/bash
+if [ "$1" = "--version" ]; then
+  echo "mydumper 0.15.0"
+  exit 0
+fi
+{ echo "ARGS: $@"; echo "MYSQL_PWD=${MYSQL_PWD}"; } > "$BINTRAIL_TEST_RECORD"
+mkdir -p "${@: -1}"
+exit 0
+`
+	if err := os.WriteFile(fakeBin, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake mydumper: %v", err)
+	}
+
+	lockDir := t.TempDir()
+	savedLock := dumpLockDir
+	dumpLockDir = func() string { return lockDir }
+	t.Cleanup(func() { dumpLockDir = savedLock })
+
+	saved := struct{ path, dsn, outDir, format string }{dmpMydumperPath, dmpSourceDSN, dmpOutputDir, dmpFormat}
+	t.Cleanup(func() {
+		dmpMydumperPath = saved.path
+		dumpCmd.Flags().Set("mydumper-path", saved.path)
+		dmpSourceDSN = saved.dsn
+		dmpOutputDir = saved.outDir
+		dmpFormat = saved.format
+	})
+	dumpCmd.Flags().Set("mydumper-path", fakeBin)
+	const pw = "supersecretpw"
+	dmpSourceDSN = "root:" + pw + "@tcp(127.0.0.1:3306)/"
+	dmpOutputDir = filepath.Join(dir, "out")
+	dmpFormat = "text"
+
+	dumpCmd.SetContext(context.Background())
+	if err := runDump(dumpCmd, nil); err != nil {
+		t.Fatalf("runDump: %v", err)
+	}
+
+	data, err := os.ReadFile(record)
+	if err != nil {
+		t.Fatalf("read record: %v", err)
+	}
+	var argsLine, pwdLine string
+	for _, line := range strings.Split(string(data), "\n") {
+		switch {
+		case strings.HasPrefix(line, "ARGS: "):
+			argsLine = line
+		case strings.HasPrefix(line, "MYSQL_PWD="):
+			pwdLine = line
+		}
+	}
+	if strings.Contains(argsLine, pw) {
+		t.Errorf("password leaked onto argv: %q", argsLine)
+	}
+	if strings.Contains(argsLine, "--password") {
+		t.Errorf("--password must not appear on argv: %q", argsLine)
+	}
+	if pwdLine != "MYSQL_PWD="+pw {
+		t.Errorf("password not delivered via MYSQL_PWD env: got %q", pwdLine)
 	}
 }
 

--- a/cmd/bintrail-console/baseline.go
+++ b/cmd/bintrail-console/baseline.go
@@ -160,8 +160,15 @@ func runMydumper(ctx context.Context, sourceDSN string, schemas []string, dumpDi
 		return err
 	}
 
-	args := buildConsoleMydumperArgs(host, port, user, password, schemas, dumpDir)
+	args := buildConsoleMydumperArgs(host, port, user, schemas, dumpDir)
 	cmd := exec.CommandContext(ctx, "mydumper", args...)
+	// Deliver the source password out of band via MYSQL_PWD (honored by the
+	// MySQL client library mydumper links against) so it never lands on argv,
+	// where it would be world-readable in `ps aux` / /proc/<pid>/cmdline. The
+	// child's /proc/<pid>/environ is mode 0400 (#811).
+	if password != "" {
+		cmd.Env = append(os.Environ(), "MYSQL_PWD="+password)
+	}
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		if msg := strings.TrimSpace(string(out)); msg != "" {
@@ -188,7 +195,11 @@ const systemSchemaExcludeRegex = `^(?!(mysql|sys|performance_schema|information_
 // Schema selection: single → --database; multiple → an anchored --regex; none →
 // every user schema with the system schemas excluded. Extracted for unit testing
 // without a live mydumper.
-func buildConsoleMydumperArgs(host string, port uint16, user, password string, schemas []string, dumpDir string) []string {
+//
+// The source password is NEVER placed on argv (world-readable via `ps aux` /
+// /proc/<pid>/cmdline); runMydumper delivers it via MYSQL_PWD in the child env
+// (#811).
+func buildConsoleMydumperArgs(host string, port uint16, user string, schemas []string, dumpDir string) []string {
 	args := []string{
 		"--host", host,
 		"--port", strconv.Itoa(int(port)),
@@ -197,9 +208,6 @@ func buildConsoleMydumperArgs(host string, port uint16, user, password string, s
 		"--compress-protocol",
 		"--complete-insert",
 		"--sync-thread-lock-mode", "NO_LOCK", "--trx-tables",
-	}
-	if password != "" {
-		args = append(args, "--password", password)
 	}
 	switch {
 	case len(schemas) == 1:

--- a/cmd/bintrail-console/baseline_test.go
+++ b/cmd/bintrail-console/baseline_test.go
@@ -1,20 +1,24 @@
 package main
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
 )
 
 // TestBuildConsoleMydumperArgs covers the schema-filter branches and the
-// invariants the dump relies on: a password only when present, and --outputdir
-// last (docker wrappers read the final arg as the mount path).
+// invariants the dump relies on: --outputdir last (docker wrappers read the
+// final arg as the mount path) and — the #811 guard — that the password never
+// appears on argv (runMydumper delivers it via MYSQL_PWD in the child env).
 func TestBuildConsoleMydumperArgs(t *testing.T) {
 	t.Run("consistent lock-free flags always present", func(t *testing.T) {
 		// These let a least-privilege replication user (no RELOAD/FLUSH_TABLES)
 		// dump consistently — verified against a real Percona 8.0 source. Their
 		// absence is the bug that produced a schema-only dump.
-		args := buildConsoleMydumperArgs("h", 3306, "u", "pw", []string{"x"}, "/out")
+		args := buildConsoleMydumperArgs("h", 3306, "u", []string{"x"}, "/out")
 		if valueAfter(args, "--sync-thread-lock-mode") != "NO_LOCK" {
 			t.Errorf("missing --sync-thread-lock-mode NO_LOCK: %v", args)
 		}
@@ -24,7 +28,7 @@ func TestBuildConsoleMydumperArgs(t *testing.T) {
 	})
 
 	t.Run("no schema filter excludes system schemas", func(t *testing.T) {
-		args := buildConsoleMydumperArgs("h", 3306, "u", "pw", nil, "/out")
+		args := buildConsoleMydumperArgs("h", 3306, "u", nil, "/out")
 		if has(args, "--database") {
 			t.Errorf("no schema filter must not use --database: %v", args)
 		}
@@ -37,7 +41,7 @@ func TestBuildConsoleMydumperArgs(t *testing.T) {
 	})
 
 	t.Run("single schema uses --database", func(t *testing.T) {
-		args := buildConsoleMydumperArgs("h", 3306, "u", "pw", []string{"wordpress"}, "/out")
+		args := buildConsoleMydumperArgs("h", 3306, "u", []string{"wordpress"}, "/out")
 		if v := valueAfter(args, "--database"); v != "wordpress" {
 			t.Errorf("--database = %q, want wordpress: %v", v, args)
 		}
@@ -47,7 +51,7 @@ func TestBuildConsoleMydumperArgs(t *testing.T) {
 	})
 
 	t.Run("multiple schemas use anchored --regex", func(t *testing.T) {
-		args := buildConsoleMydumperArgs("h", 3306, "u", "pw", []string{"a", "b"}, "/out")
+		args := buildConsoleMydumperArgs("h", 3306, "u", []string{"a", "b"}, "/out")
 		if v := valueAfter(args, "--regex"); v != "^(a|b)\\." {
 			t.Errorf("--regex = %q, want ^(a|b)\\. : %v", v, args)
 		}
@@ -56,19 +60,65 @@ func TestBuildConsoleMydumperArgs(t *testing.T) {
 		}
 	})
 
-	t.Run("empty password omits --password", func(t *testing.T) {
-		args := buildConsoleMydumperArgs("h", 3306, "u", "", nil, "/out")
-		if has(args, "--password") {
-			t.Errorf("empty password must not add --password: %v", args)
+	t.Run("password never appears on argv (#811)", func(t *testing.T) {
+		for _, schemas := range [][]string{nil, {"wordpress"}, {"a", "b"}} {
+			args := buildConsoleMydumperArgs("h", 3306, "u", schemas, "/out")
+			if has(args, "--password") {
+				t.Errorf("schemas=%v: --password must never appear on argv: %v", schemas, args)
+			}
 		}
 	})
+}
 
-	t.Run("password present adds --password", func(t *testing.T) {
-		args := buildConsoleMydumperArgs("h", 3306, "u", "secret", nil, "/out")
-		if v := valueAfter(args, "--password"); v != "secret" {
-			t.Errorf("--password = %q, want secret", v)
+// TestRunMydumper_deliversPasswordViaEnvNotArgv is the end-to-end regression
+// guard for #811: the console's in-process dump passes the source password to
+// mydumper as MYSQL_PWD, never on argv (world-readable via ps aux / cmdline).
+func TestRunMydumper_deliversPasswordViaEnvNotArgv(t *testing.T) {
+	dir := t.TempDir()
+	record := filepath.Join(dir, "record.txt")
+	t.Setenv("BINTRAIL_TEST_RECORD", record)
+
+	// Fake `mydumper` resolved via PATH. Uses only bash builtins (printf,
+	// redirection) so it needs nothing else on PATH.
+	fakeBin := filepath.Join(dir, "mydumper")
+	script := `#!/bin/bash
+printf 'ARGS: %s\n' "$*" > "$BINTRAIL_TEST_RECORD"
+printf 'MYSQL_PWD=%s\n' "$MYSQL_PWD" >> "$BINTRAIL_TEST_RECORD"
+exit 0
+`
+	if err := os.WriteFile(fakeBin, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake mydumper: %v", err)
+	}
+	t.Setenv("PATH", dir)
+
+	const pw = "consolesecretpw"
+	err := runMydumper(context.Background(), "root:"+pw+"@tcp(127.0.0.1:3306)/", nil, filepath.Join(dir, "out"))
+	if err != nil {
+		t.Fatalf("runMydumper: %v", err)
+	}
+
+	data, err := os.ReadFile(record)
+	if err != nil {
+		t.Fatalf("read record: %v", err)
+	}
+	var argsLine, pwdLine string
+	for _, line := range strings.Split(string(data), "\n") {
+		switch {
+		case strings.HasPrefix(line, "ARGS: "):
+			argsLine = line
+		case strings.HasPrefix(line, "MYSQL_PWD="):
+			pwdLine = line
 		}
-	})
+	}
+	if strings.Contains(argsLine, pw) {
+		t.Errorf("password leaked onto argv: %q", argsLine)
+	}
+	if strings.Contains(argsLine, "--password") {
+		t.Errorf("--password must not appear on argv: %q", argsLine)
+	}
+	if pwdLine != "MYSQL_PWD="+pw {
+		t.Errorf("password not delivered via MYSQL_PWD env: got %q", pwdLine)
+	}
 }
 
 func has(args []string, flag string) bool { return slices.Contains(args, flag) }


### PR DESCRIPTION
## Problem

`bintrail dump` (`cliapp/dump.go`, `buildMydumperArgs`) and the console's
in-process baseline dump (`cmd/bintrail-console/baseline.go`,
`buildConsoleMydumperArgs`) both appended `--password <cleartext>` to mydumper's
argv. The source replication credential was therefore visible to **any** host
user via `ps aux` / `/proc/<pid>/cmdline` for the entire duration of the dump,
and — in Docker mode, where the mydumper args become the container command —
also in `docker inspect`. This is out of step with the rest of the codebase,
which is careful with secrets (DSNs kept out of errors; `shim.yaml` and
`proxysql-setup.sql` written `0600`).

## Fix

The password never touches argv anymore. `buildMydumperArgs` swaps its
`password` parameter for a `defaultsFile` path; `buildConsoleMydumperArgs` drops
the password parameter entirely — neither can emit a password on argv.

- **Local mode** (the CLI dump and the console dump): delivered via `MYSQL_PWD`
  in the child process environment. It is honored by the MySQL client library
  mydumper links against (works across all mydumper versions, no option-file
  escaping pitfalls) and lives in the child's mode-`0400` `/proc/<pid>/environ`
  rather than the world-readable `cmdline`.
- **Docker mode**: a passed-through `MYSQL_PWD` would still surface in
  `docker inspect` `Config.Env`, so the password is written to a fresh `0600`
  MySQL option file (atomic `O_EXCL` create, removed via deferred cleanup even
  on error) and bind-mounted read-only into the container; mydumper reads it via
  `--defaults-file`. The option-file value is quoted and backslash/quote-escaped.

Username, host, and port stay on argv as before.

## Test

`go test ./cliapp/ ./cmd/bintrail-console/` (unit) passes. New/updated unit tests:

- argv never contains `--password` or any password token (both functions).
- `--defaults-file` present iff a defaults path is supplied; read-only Docker
  bind mount for it.
- `writeMydumperDefaultsFile`: `0600` perms, `[client]`+`[mydumper]` groups,
  escaped value, cleanup removes the file; `escapeMyCnfValue` table.
- End-to-end with a fake mydumper: the secret arrives via `MYSQL_PWD` and is
  absent from argv — for both the CLI (`runDump`) and console (`runMydumper`)
  paths.

Closes #811
