### PR TITLE
shim: reject column-qualified WHERE when the table's PK can't be verified (#821)

### DIFF
--- a/internal/shim/handler.go
+++ b/internal/shim/handler.go
@@ -838,17 +838,22 @@ func fullTableColumns(images []map[string]any, ddlOrder []string) []string {
 //     happen in tests that build a bare &Handler{}. Permissive so
 //     those tests stay representative of legacy paths.
 //   - resolver load fails (DB blip, ErrNoSnapshots, sticky-fallback
-//     mid-outage) → permissive. Preserves the columnOrderFor
-//     graceful-degradation contract: a broken snapshot lookup must
-//     not turn a working query into a 1064 error. The fetch still
-//     runs, the wire response still degrades to alphabetical column
-//     order, and operators see the same Debug/Warn split logs they
-//     get from columnOrderFor for the same condition.
-//   - table not in any snapshot → permissive, same rationale.
+//     mid-outage) → REJECT with 1064 (#821). The shim cannot confirm
+//     q.PKColumn is the table's PK, and the documented guarantee
+//     (a WHERE on a non-PK column is rejected, never silently answered
+//     against the wrong row — docs/time-travel-sql.md) outweighs the
+//     old graceful-degradation convenience: permitting the WHERE would
+//     join the literal against pk_values and return a DIFFERENT row
+//     with zero signal, re-opening #296 in the no-snapshot window. The
+//     no-WHERE full-table AS OF path (q.PKColumn == "", handled above)
+//     is unaffected and still runs. Logged at Warn with the reason.
+//   - table not in any snapshot → REJECT with 1064, same rationale.
 //     Tables created after the most recent snapshot (MySQL) or that
 //     have not yet seen DML on the stream (PostgreSQL, whose
-//     snapshots are written per RelationMessage) are common and
-//     self-fix on the next snapshot / first DML.
+//     snapshots are written per RelationMessage) can't have their PK
+//     verified, so a column-qualified WHERE must fail loud rather than
+//     answer against pk_values. Re-running `bintrail snapshot`
+//     converges; the no-WHERE full-table query keeps working meanwhile.
 //   - len(PKColumns) == 0 → table snapshot is present but has no PK
 //     declared. The shim can't safely correlate row state without a
 //     PK, so reject with 1064. validateTables enforces PK presence
@@ -875,23 +880,37 @@ func (h *Handler) validatePKColumn(q TimeTravelQuery) error {
 	}
 	r, err := h.resolverCache.get(time.Now, resolverCacheTTL, h.resolverFn, h.logger)
 	if err != nil {
-		// Same split as columnOrderFor: ErrNoSnapshots is benign
-		// first-install state; anything else is a real config/infra
-		// problem the operator should see at default log-level info.
+		// Cannot confirm q.PKColumn is the table's PK. A
+		// column-qualified WHERE is guaranteed here (the full-table
+		// shape returned above), so fail loud rather than join the
+		// literal against pk_values and risk the wrong row (#821).
+		// ErrNoSnapshots (benign first-install state) still can't
+		// verify the PK, so it rejects too — only the no-WHERE
+		// full-table path is exempt. Was Debug/skip; raised to Warn.
+		reason := "schema_snapshots lookup failed"
 		if errors.Is(err, metadata.ErrNoSnapshots) {
-			h.logger.Debug("shim: no snapshots yet; skipping PK validation",
-				"schema", q.Schema, "table", q.Table)
-		} else {
-			h.logger.Warn("shim: schema_snapshots lookup failed; skipping PK validation",
-				"err", err, "schema", q.Schema, "table", q.Table)
+			reason = "no schema snapshots available yet"
 		}
-		return nil
+		h.logger.Warn("shim: cannot verify PK column; rejecting column-qualified WHERE",
+			"err", err, "reason", reason, "schema", q.Schema, "table", q.Table, "pk_column", q.PKColumn)
+		return mysql.NewError(mysql.ER_PARSE_ERROR, fmt.Sprintf(
+			"cannot verify WHERE column %s is the primary key of %s.%s (%s); refusing to run so a non-PK WHERE cannot silently return the wrong row",
+			q.PKColumn, q.Schema, q.Table, reason,
+		))
 	}
 	tm, err := r.Resolve(q.Schema, q.Table)
 	if err != nil {
-		h.logger.Debug("shim: table not in any snapshot; skipping PK validation",
-			"err", err, "schema", q.Schema, "table", q.Table)
-		return nil
+		// Table absent from every snapshot (created after the newest
+		// snapshot, or not yet seen on the stream). Can't verify the
+		// PK, so a column-qualified WHERE rejects rather than answer
+		// against pk_values and return a different row (#821). Re-run
+		// `bintrail snapshot`; the no-WHERE full-table path still works.
+		h.logger.Warn("shim: table not in any snapshot; rejecting column-qualified WHERE",
+			"err", err, "schema", q.Schema, "table", q.Table, "pk_column", q.PKColumn)
+		return mysql.NewError(mysql.ER_PARSE_ERROR, fmt.Sprintf(
+			"cannot verify WHERE column %s is the primary key of %s.%s (table not present in any indexed snapshot); refusing to run so a non-PK WHERE cannot silently return the wrong row",
+			q.PKColumn, q.Schema, q.Table,
+		))
 	}
 	if len(tm.PKColumns) == 0 {
 		return mysql.NewError(mysql.ER_PARSE_ERROR, fmt.Sprintf(

--- a/internal/shim/handler_test.go
+++ b/internal/shim/handler_test.go
@@ -2049,9 +2049,11 @@ func (h *recordingHandler) atLevel(level slog.Level) []slog.Record {
 //   - reject single-column PK mismatch / composite PK / no PK
 //     declared: each is a distinct 1064 with a message the operator
 //     can act on.
-//   - permissive on missing snapshot / unknown table: preserves
-//     columnOrderFor's degradation contract. A broken snapshot
-//     lookup must not turn a working query into a 1064.
+//   - reject on missing snapshot / unresolved table / loader failure
+//     (#821): the shim can't confirm the WHERE column is the PK, so a
+//     column-qualified WHERE fails loud rather than silently answering
+//     against pk_values and returning a different row. The no-WHERE
+//     full-table path stays permissive.
 //   - hint-comment + _snapshot + _diff: per-shape regression guards
 //     so a future per-type refactor can't re-introduce the bug for
 //     one shape in isolation.
@@ -2197,25 +2199,56 @@ func TestValidatePKColumnRejectsNonPKWhere(t *testing.T) {
 		}
 	})
 
-	t.Run("permissive_when_table_missing_from_snapshot", func(t *testing.T) {
-		// A table created after the latest snapshot is the common
-		// case. Rejecting would break fresh-table queries until the
-		// next `bintrail snapshot` runs — much worse than the rare
-		// silent-wrong-row case the validator is preventing.
+	t.Run("reject_when_table_missing_from_snapshot", func(t *testing.T) {
+		// #821: a table created after the latest snapshot can't have
+		// its PK verified. A column-qualified WHERE must fail loud —
+		// permitting it would join the literal against pk_values and
+		// return a DIFFERENT row (re-opening #296 in the no-snapshot
+		// window). Re-snapshot converges; the no-WHERE full-table path
+		// (asserted below) still works meanwhile.
 		emptyResolver := func() (*metadata.Resolver, error) {
 			return metadata.NewResolverFromTables(1, map[string]*metadata.TableMeta{}), nil
 		}
 		h := &Handler{logger: silent, resolverFn: emptyResolver}
 		err := h.validatePKColumn(TimeTravelQuery{
 			Type: TypeFlashback, Schema: "myapp", Table: "brand_new_table",
-			PKColumn: "anything", PKValue: "1",
+			PKColumn: "customer_id", PKValue: "1",
 		})
-		if err != nil {
-			t.Errorf("missing-from-snapshot must NOT reject (preserves columnOrderFor degradation contract); got %v", err)
+		if err == nil {
+			t.Fatal("unresolved table + column WHERE must reject (documented guarantee); got nil")
+		}
+		var myErr *gomysql.MyError
+		if !errors.As(err, &myErr) || myErr.Code != gomysql.ER_PARSE_ERROR {
+			t.Fatalf("expected ER_PARSE_ERROR, got %v", err)
+		}
+		for _, want := range []string{"customer_id", "myapp.brand_new_table", "snapshot"} {
+			if !strings.Contains(myErr.Message, want) {
+				t.Errorf("error should contain %q for actionability; got %q", want, myErr.Message)
+			}
 		}
 	})
 
-	t.Run("permissive_when_resolver_load_fails", func(t *testing.T) {
+	t.Run("allow_full_table_when_table_missing_from_snapshot", func(t *testing.T) {
+		// The no-WHERE full-table AS OF path must stay permissive even
+		// for an unresolved table: it never joins a literal against
+		// pk_values, so there's nothing to get wrong (#821).
+		emptyResolver := func() (*metadata.Resolver, error) {
+			return metadata.NewResolverFromTables(1, map[string]*metadata.TableMeta{}), nil
+		}
+		h := &Handler{logger: silent, resolverFn: emptyResolver}
+		err := h.validatePKColumn(TimeTravelQuery{
+			Type: TypeFlashback, Schema: "myapp", Table: "brand_new_table",
+			PKColumn: "", PKValue: "",
+		})
+		if err != nil {
+			t.Errorf("full-table shape (no WHERE) must pass even when unresolved; got %v", err)
+		}
+	})
+
+	t.Run("reject_when_resolver_load_fails", func(t *testing.T) {
+		// #821: a resolver blip can't confirm the PK either. A
+		// column-qualified WHERE fails loud rather than risk the
+		// wrong-row answer.
 		failingResolver := func() (*metadata.Resolver, error) {
 			return nil, errors.New("transient db blip")
 		}
@@ -2224,8 +2257,51 @@ func TestValidatePKColumnRejectsNonPKWhere(t *testing.T) {
 			Type: TypeFlashback, Schema: "myapp", Table: "orders",
 			PKColumn: "customer_id", PKValue: "1",
 		})
+		if err == nil {
+			t.Fatal("resolver-load failure + column WHERE must reject; got nil")
+		}
+		var myErr *gomysql.MyError
+		if !errors.As(err, &myErr) || myErr.Code != gomysql.ER_PARSE_ERROR {
+			t.Fatalf("expected ER_PARSE_ERROR, got %v", err)
+		}
+		if !strings.Contains(myErr.Message, "customer_id") {
+			t.Errorf("error should name the user-supplied column; got %q", myErr.Message)
+		}
+	})
+
+	t.Run("reject_when_no_snapshots_yet", func(t *testing.T) {
+		// ErrNoSnapshots (fresh install) also can't verify the PK, so
+		// a column-qualified WHERE rejects with a distinct reason.
+		noSnapResolver := func() (*metadata.Resolver, error) {
+			return nil, metadata.ErrNoSnapshots
+		}
+		h := &Handler{logger: silent, resolverFn: noSnapResolver}
+		err := h.validatePKColumn(TimeTravelQuery{
+			Type: TypeFlashback, Schema: "myapp", Table: "orders",
+			PKColumn: "customer_id", PKValue: "1",
+		})
+		if err == nil {
+			t.Fatal("no-snapshots + column WHERE must reject; got nil")
+		}
+		var myErr *gomysql.MyError
+		if !errors.As(err, &myErr) || myErr.Code != gomysql.ER_PARSE_ERROR {
+			t.Fatalf("expected ER_PARSE_ERROR, got %v", err)
+		}
+	})
+
+	t.Run("allow_full_table_when_resolver_load_fails", func(t *testing.T) {
+		// Full-table path returns before the resolver is consulted, so
+		// a resolver blip can't break it.
+		failingResolver := func() (*metadata.Resolver, error) {
+			return nil, errors.New("transient db blip")
+		}
+		h := &Handler{logger: silent, resolverFn: failingResolver}
+		err := h.validatePKColumn(TimeTravelQuery{
+			Type: TypeFlashback, Schema: "myapp", Table: "orders",
+			PKColumn: "", PKValue: "",
+		})
 		if err != nil {
-			t.Errorf("loader failure must NOT reject (preserves graceful degradation); got %v", err)
+			t.Errorf("full-table shape must pass despite resolver failure; got %v", err)
 		}
 	})
 


### PR DESCRIPTION
## Problem

`validatePKColumn` (`internal/shim/handler.go`) degraded permissively when the resolver failed to load OR the table was absent from every snapshot — it returned `nil`. With a column-qualified WHERE present, that let the fetch path join the literal against `binlog_events.pk_values` regardless of the column name the user typed, producing a well-formed resultset for a DIFFERENT row with zero signal. This re-opened #296 in the no-snapshot window: a table created after the last `bintrail snapshot`, or a transient resolver blip, would silently answer `WHERE customer_id=1` against the row whose PK equals `1`.

`docs/time-travel-sql.md` promises: "The WHERE column must match the table's primary key. A WHERE on a non-PK column is rejected with a parser error rather than silently returning the wrong row."

## Fix

Minimal additive fail-loud guard. When the table does NOT resolve (resolver load failure, `ErrNoSnapshots`, or table absent from every snapshot), reject a column-qualified WHERE with `ER_PARSE_ERROR`, naming the column, table, and reason. The no-WHERE full-table AS OF path (`q.PKColumn == ""`) returns before the resolver is consulted and is unchanged — it never joins a literal against `pk_values`, so it stays permissive and keeps working before the next snapshot. The previously-`Debug` "skipping PK validation" logs are raised to `Warn` and carry the reason. The resolves-fine accept/reject paths are untouched.

## Test

- Inverted the two permissive subtests (`table_missing_from_snapshot`, `resolver_load_fails`) to assert rejection with `ER_PARSE_ERROR` and an actionable message.
- Added `reject_when_no_snapshots_yet` (`ErrNoSnapshots` reason path).
- Added `allow_full_table_when_table_missing_from_snapshot` and `allow_full_table_when_resolver_load_fails` to pin that the no-WHERE full-table path still passes when the table is unresolved.
- `CGO_ENABLED=1 go build ./internal/shim/...` and `go test ./internal/shim/` (unit) pass.

Closes #821