### PR TITLE
baseline: parse giant rows; reject compressed dumps with actionable guidance

### DIFF
--- a/internal/baseline/baseline_test.go
+++ b/internal/baseline/baseline_test.go
@@ -688,6 +688,37 @@ func TestReadSQLRowMultiLineLayouts(t *testing.T) {
 	}
 }
 
+func TestReadSQLRowOversizedLine(t *testing.T) {
+	// A single tuple carrying a value larger than the old fixed 8 MB scanner
+	// buffer must parse, not abort with bufio.ErrTooLong. mydumper emits one
+	// tuple per physical line, so a LONGBLOB/JSON column produces exactly this
+	// shape (#801). The growable bufio.Reader has no artificial per-line cap.
+	big := strings.Repeat("A", 12<<20) // 12 MB, well over the old 8 MB limit
+	sqlData := "INSERT INTO `docs` VALUES(1,'" + big + "');\n"
+	dir := t.TempDir()
+	path := filepath.Join(dir, "shop.docs.00000.sql")
+	if err := os.WriteFile(path, []byte(sqlData), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var rows [][]string
+	if err := ReadSQLFile(path, func(values []string, nulls []bool) error {
+		rows = append(rows, append([]string(nil), values...))
+		return nil
+	}); err != nil {
+		t.Fatalf("ReadSQLFile on oversized line: %v", err)
+	}
+	if len(rows) != 1 || len(rows[0]) != 2 {
+		t.Fatalf("got rows=%d cols, want 1 row with 2 cols", len(rows))
+	}
+	if rows[0][0] != "1" {
+		t.Errorf("col 0 = %q, want 1", rows[0][0])
+	}
+	if len(rows[0][1]) != len(big) {
+		t.Errorf("col 1 length = %d, want %d (large value truncated/dropped)", len(rows[0][1]), len(big))
+	}
+}
+
 func TestReadSQLRowUnexpectedToken(t *testing.T) {
 	// A stray token where a tuple or ';' is expected must surface as a loud
 	// error, not silently truncate the fragment. With cross-line state, a

--- a/internal/baseline/discover.go
+++ b/internal/baseline/discover.go
@@ -41,6 +41,17 @@ func DiscoverTables(inputDir string) ([]TableFiles, error) {
 		name := e.Name()
 		path := filepath.Join(inputDir, name)
 
+		// Compressed mydumper output (--compress GZIP/ZSTD) writes
+		// <db>.<table>.<chunk>.sql.gz / .sql.zst (and matching -schema.sql.gz).
+		// The baseline readers parse plain SQL/TSV only, so such a file would
+		// fall through the classifier below and be silently skipped — the whole
+		// dump then surfaces as an unhelpful "no tables found". Fail loud with
+		// actionable guidance instead.
+		if isCompressedDump(name) {
+			return nil, fmt.Errorf("compressed mydumper dump detected (%s): compressed dumps are not supported — "+
+				"re-run mydumper without --compress, or decompress the dump first (e.g. gunzip *.gz / unzstd *.zst)", name)
+		}
+
 		// Schema file: <db>.<table>-schema.sql
 		if strings.HasSuffix(name, "-schema.sql") {
 			base := strings.TrimSuffix(name, "-schema.sql")
@@ -170,6 +181,20 @@ func isView(schemaPath string) bool {
 	}
 	// No CREATE statement found or I/O error — assume table rather than
 	// silently skipping, which is the exact failure mode of issue #226.
+	return false
+}
+
+// isCompressedDump reports whether name is a mydumper data or schema file
+// written with --compress: GZIP → ".gz", ZSTD → ".zst". Matching the full
+// ".sql.gz"/".dat.zst" shape (not a bare ".gz") avoids false-positives on
+// unrelated files that happen to sit in the dump directory.
+func isCompressedDump(name string) bool {
+	lower := strings.ToLower(name)
+	for _, suf := range []string{".sql.gz", ".sql.zst", ".dat.gz", ".dat.zst"} {
+		if strings.HasSuffix(lower, suf) {
+			return true
+		}
+	}
 	return false
 }
 

--- a/internal/baseline/discover_test.go
+++ b/internal/baseline/discover_test.go
@@ -3,6 +3,7 @@ package baseline
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -142,6 +143,58 @@ func TestIsView(t *testing.T) {
 			t.Errorf("isView(missing) = %v, want false", got)
 		}
 	})
+}
+
+func TestDiscoverTables_CompressedDumpRejected(t *testing.T) {
+	// mydumper --compress writes .sql.gz / .sql.zst; the baseline readers parse
+	// plain SQL/TSV only. Such a dump must fail loud with actionable guidance
+	// rather than fall through the classifier into an unhelpful "no tables
+	// found" (#801).
+	cases := []struct {
+		name       string
+		schemaFile string
+		dataFile   string
+	}{
+		{"gzip", "shop.orders-schema.sql.gz", "shop.orders.00000.sql.gz"},
+		{"zstd", "shop.orders-schema.sql.zst", "shop.orders.00000.sql.zst"},
+		{"tab-gzip", "shop.orders-schema.sql.gz", "shop.orders.00000.dat.gz"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFile(t, dir, tc.schemaFile, "compressed bytes")
+			writeFile(t, dir, tc.dataFile, "compressed bytes")
+
+			_, err := DiscoverTables(dir)
+			if err == nil {
+				t.Fatal("expected error for compressed dump, got nil")
+			}
+			if !strings.Contains(err.Error(), "compressed") || !strings.Contains(err.Error(), "--compress") {
+				t.Errorf("error = %v, want it to mention 'compressed' and '--compress' guidance", err)
+			}
+		})
+	}
+}
+
+func TestIsCompressedDump(t *testing.T) {
+	tests := map[string]bool{
+		"shop.orders.00000.sql.gz":  true,
+		"shop.orders.00000.sql.zst": true,
+		"shop.orders.00000.dat.gz":  true,
+		"shop.orders.00000.dat.zst": true,
+		"shop.orders-schema.sql.gz": true,
+		"SHOP.ORDERS.00000.SQL.GZ":  true, // case-insensitive
+		"shop.orders.00000.sql":     false,
+		"shop.orders.00000.dat":     false,
+		"shop.orders-schema.sql":    false,
+		"metadata":                  false,
+		"unrelated-archive.tar.gz":  false, // bare .gz without .sql/.dat is not a dump file
+	}
+	for name, want := range tests {
+		if got := isCompressedDump(name); got != want {
+			t.Errorf("isCompressedDump(%q) = %v, want %v", name, got, want)
+		}
+	}
 }
 
 func writeFile(t *testing.T, dir, name, content string) {

--- a/internal/baseline/reader_sql.go
+++ b/internal/baseline/reader_sql.go
@@ -2,7 +2,9 @@ package baseline
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 )
@@ -37,63 +39,85 @@ func ReadSQLFile(path string, fn func(values []string, nulls []bool) error) erro
 	}
 	defer f.Close()
 
-	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 8<<20), 8<<20) // 8 MB per line
+	// A growable reader (not a fixed-buffer bufio.Scanner) so a single physical
+	// line larger than any preset cap — a LONGBLOB/JSON tuple, which mydumper
+	// emits as one tuple per line — parses instead of aborting with
+	// bufio.ErrTooLong. ReadString grows its buffer to the line length on
+	// demand; there is no artificial per-line limit (#801).
+	reader := bufio.NewReader(f)
 	lineNum := 0
 	inStatement := false // inside an INSERT whose ';' terminator hasn't been seen
-	for scanner.Scan() {
-		lineNum++
-		trimmed := strings.TrimSpace(scanner.Text())
-		if trimmed == "" {
-			continue
-		}
-
-		var fragment string
-		if inStatement {
-			// Continuation line of a multi-row INSERT: ",(...)" tuples, the
-			// last ending in ';'.
-			fragment = trimmed
-		} else {
-			upper := strings.ToUpper(trimmed)
-			// mysqldump --replace and mydumper --replace emit REPLACE INTO
-			// instead of INSERT INTO; both carry row data the same way. Skipping
-			// REPLACE lines silently dropped every such row.
-			if !strings.HasPrefix(upper, "INSERT") && !strings.HasPrefix(upper, "REPLACE") {
-				continue
+	for {
+		line, readErr := reader.ReadString('\n')
+		if len(line) > 0 {
+			lineNum++
+			if err := readSQLLine(path, lineNum, line, &inStatement, fn); err != nil {
+				return err
 			}
-			// Find VALUES keyword (after any column list).
-			valIdx := strings.Index(upper, " VALUES")
-			if valIdx < 0 {
-				// The line opens an INSERT/REPLACE but carries no VALUES clause.
-				// In a complete mydumper/mysqldump data file every INSERT/REPLACE
-				// statement has VALUES on this same line — so this is a truncated
-				// statement (a partial trailing line, #468 shape 1) or an
-				// unsupported layout (VALUES wrapped to a continuation line).
-				// Silently `continue`ing past it drops every row the statement
-				// carried with a clean exit and a short count — the #461 silent
-				// data-loss class at row granularity. Fail loud, matching the
-				// unterminated-INSERT guard below.
-				return fmt.Errorf("%s line %d: INSERT/REPLACE statement without a VALUES clause "+
-					"— dump file may be truncated or in an unsupported layout: %q",
-					path, lineNum, truncateForError(trimmed))
+		}
+		if readErr != nil {
+			if errors.Is(readErr, io.EOF) {
+				break
 			}
-			fragment = strings.TrimSpace(trimmed[valIdx+7:])
+			return fmt.Errorf("%s: reading line %d: %w", path, lineNum+1, readErr)
 		}
-
-		terminated, err := parseSQLTuples(fragment, fn)
-		if err != nil {
-			return fmt.Errorf("%s line %d: %w", path, lineNum, err)
-		}
-		inStatement = !terminated
-	}
-	if err := scanner.Err(); err != nil {
-		return err
 	}
 	// A file that ends mid-statement (no ';') is truncated: fail loudly rather
 	// than report a silently short row count.
 	if inStatement {
 		return fmt.Errorf("%s: unterminated INSERT statement (missing ';') — dump file may be truncated", path)
 	}
+	return nil
+}
+
+// readSQLLine processes one physical line of a mydumper SQL data file, feeding
+// its tuples to fn and advancing the cross-line *inStatement flag. Blank and
+// non-INSERT/REPLACE lines are no-ops. Extracted from ReadSQLFile's read loop so
+// the loop can use a growable bufio.Reader (see #801) without the two skip
+// branches tangling with EOF handling.
+func readSQLLine(path string, lineNum int, line string, inStatement *bool, fn func(values []string, nulls []bool) error) error {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" {
+		return nil
+	}
+
+	var fragment string
+	if *inStatement {
+		// Continuation line of a multi-row INSERT: ",(...)" tuples, the
+		// last ending in ';'.
+		fragment = trimmed
+	} else {
+		upper := strings.ToUpper(trimmed)
+		// mysqldump --replace and mydumper --replace emit REPLACE INTO
+		// instead of INSERT INTO; both carry row data the same way. Skipping
+		// REPLACE lines silently dropped every such row.
+		if !strings.HasPrefix(upper, "INSERT") && !strings.HasPrefix(upper, "REPLACE") {
+			return nil
+		}
+		// Find VALUES keyword (after any column list).
+		valIdx := strings.Index(upper, " VALUES")
+		if valIdx < 0 {
+			// The line opens an INSERT/REPLACE but carries no VALUES clause.
+			// In a complete mydumper/mysqldump data file every INSERT/REPLACE
+			// statement has VALUES on this same line — so this is a truncated
+			// statement (a partial trailing line, #468 shape 1) or an
+			// unsupported layout (VALUES wrapped to a continuation line).
+			// Silently skipping past it drops every row the statement carried
+			// with a clean exit and a short count — the #461 silent data-loss
+			// class at row granularity. Fail loud, matching the
+			// unterminated-INSERT guard below.
+			return fmt.Errorf("%s line %d: INSERT/REPLACE statement without a VALUES clause "+
+				"— dump file may be truncated or in an unsupported layout: %q",
+				path, lineNum, truncateForError(trimmed))
+		}
+		fragment = strings.TrimSpace(trimmed[valIdx+7:])
+	}
+
+	terminated, err := parseSQLTuples(fragment, fn)
+	if err != nil {
+		return fmt.Errorf("%s line %d: %w", path, lineNum, err)
+	}
+	*inStatement = !terminated
 	return nil
 }
 


### PR DESCRIPTION
## Problem

`internal/baseline` had two failure modes when converting a mydumper dump to Parquet:

1. **Giant rows.** `ReadSQLFile` read lines with a fixed 8 MB `bufio.Scanner` buffer. mydumper emits one tuple per physical line, so a legal table with a `LONGBLOB`/`JSON` value larger than 8 MB aborted the whole conversion with `bufio.ErrTooLong` — that table could not be baselined at all. `scanner.Err()` was returned raw, with no file path or line number.

2. **Compressed dumps.** `DiscoverTables` only matched `.sql`/`.dat`. A `--compress` dump (`.sql.gz`/`.sql.zst`/`.dat.gz`/`.dat.zst`) fell through the classifier and was silently skipped, surfacing later as an unhelpful `no tables found`.

## Fix

- **Growable reader:** swap the fixed-buffer scanner for a `bufio.Reader` + `ReadString('\n')`, which grows to the line length on demand — no artificial per-line cap, so multi-MB tuples parse. The per-line logic moves to a `readSQLLine` helper so the read loop keeps EOF handling separate from the blank/non-INSERT skip branches. All existing multi-line/escaping/truncation semantics are preserved.
- **Read-error context:** the read-error path now wraps with file path and line number.
- **Compressed-dump rejection:** `DiscoverTables` detects `.sql.gz`/`.sql.zst`/`.dat.gz`/`.dat.zst` and fails loud with actionable guidance (`re-run mydumper without --compress, or decompress the dump first`). Matching the full `.sql.gz`/`.dat.zst` shape (not a bare `.gz`) avoids false-positives on unrelated files in the dump directory. Transparent decompression was deliberately not added — clear rejection is preferred.

Minimal and additive: no behavior change on well-formed uncompressed dumps.

## Test

- `TestReadSQLRowOversizedLine`: a 12 MB single-tuple value (over the old 8 MB cap) parses with the full value intact.
- `TestDiscoverTables_CompressedDumpRejected` + `TestIsCompressedDump`: gzip/zstd `.sql`/`.dat` dumps rejected with the `compressed` + `--compress` guidance; plain `.sql`/`.dat` and unrelated `.tar.gz` are not misclassified.
- Full `go test ./internal/baseline/` passes; `go vet` clean.

Closes #801