### PR TITLE
reconstruct: warn on baseline↔first-event gap in full-table path

### DIFF
--- a/internal/reconstruct/fulltable.go
+++ b/internal/reconstruct/fulltable.go
@@ -438,6 +438,16 @@ func ReconstructTable(
 	// slice (reconstruct warns, never refuses — the OOM at scale is unreproduced).
 	maybeWarnEventVolume(schema, table, len(events), cfg.WarnEventThreshold)
 
+	// Warn on a gap between the baseline anchor and the first indexed event.
+	// The single-row path already does this (cli/reconstruct.go); the full-table
+	// path previously emitted a dump silently missing that gap with no signal
+	// (#781). Same call/semantics as single-row: warn-only, --allow-gaps governs
+	// the coverage-gap fetch above and CheckCaptureGap, not this
+	// baseline-vs-first-event visibility warning. bmeta was read in step 2.
+	if len(events) > 0 {
+		WarnBaselineFirstEventGap(query.SourceFlavor(db), bmeta, events[0], schema, table)
+	}
+
 	// ENUM/SET ordinals → labels (#476), each delta decoded with the
 	// snapshot in effect at its event time (#475). Must run before the
 	// merge so the mydumper output writes labels — the same form the

--- a/internal/reconstruct/gap.go
+++ b/internal/reconstruct/gap.go
@@ -1,5 +1,12 @@
 package reconstruct
 
+import (
+	"log/slog"
+
+	"github.com/dbtrail/dbtrail/internal/baseline"
+	"github.com/dbtrail/dbtrail/internal/query"
+)
+
 // GapDetected reports whether there is a gap between a baseline's recorded
 // anchor and the first indexed event available for replay: events between the
 // anchor and the first event are missing from the reconstruction, so callers
@@ -45,4 +52,70 @@ func GapDetected(flavor string, eventFile string, eventStartPos uint64, baseline
 	}
 	return eventFile > baselineFile ||
 		(eventFile == baselineFile && eventStartPos > uint64(baselinePos))
+}
+
+// WarnBaselineFirstEventGap emits the baseline↔first-event gap warning for
+// callers that live in this package — the full-table reconstruct path (#781),
+// which previously produced a dump silently missing that gap while single-row
+// reconstruct at least warned. It is a DIRECT port of the check the single-row
+// CLI path runs (cli/reconstruct.go: resolveGapCheck + the GapDetected switch),
+// duplicated here because that logic lives in package cli, which this package
+// cannot import (cli imports reconstruct).
+//
+// Warn-only, identical to single-row: this check gates a WARNING, never the
+// reconstruction itself, so --allow-gaps is deliberately not consulted here —
+// it governs the coverage-gap fetch (query.FetchMerged) and CheckCaptureGap,
+// which run separately, not this baseline-vs-first-event visibility warning.
+//
+// flavor is query.SourceFlavor(db). first is the earliest fetched event
+// (events sorted by (event_timestamp, event_id)). schema/table are added to
+// every record so the warning is attributable when several tables reconstruct
+// concurrently.
+func WarnBaselineFirstEventGap(flavor string, bmeta baseline.DumpMetadata, first query.ResultRow, schema, table string) {
+	// Mirror of cli.resolveGapCheck: force PG semantics when the flavor read
+	// came back empty but the baseline carries an LSN anchor (its lineage is
+	// provably PostgreSQL — LSN text must never be compared lexically), then
+	// pick the flavor-correct anchor/position presence signals.
+	lineageGuard := false
+	if flavor == "" && bmeta.LSN != 0 {
+		flavor = "postgres"
+		lineageGuard = true
+	}
+	anchorPresent := bmeta.BinlogFile != ""
+	eventPosMissing := first.BinlogFile == ""
+	if flavor == "postgres" {
+		anchorPresent = bmeta.LSN != 0
+		eventPosMissing = first.StartPos == 0
+	}
+
+	if lineageGuard {
+		slog.Warn("source flavor unknown but baseline carries an LSN anchor — treating source as postgres for gap detection (LSN text is never compared lexically)",
+			"schema", schema, "table", table, "baseline_lsn", bmeta.LSN)
+	}
+	switch {
+	case !anchorPresent && flavor == "postgres":
+		slog.Warn("gap detection unavailable — this baseline predates LSN anchoring (no bintrail.baseline_lsn metadata); a gap between the baseline and the first indexed event would go undetected",
+			"schema", schema, "table", table, "flavor", flavor)
+	case !anchorPresent:
+		slog.Info("gap detection skipped — baseline lacks position metadata; consider re-running 'bintrail baseline' to embed position data",
+			"schema", schema, "table", table, "flavor", flavor)
+	case eventPosMissing:
+		slog.Warn("gap detection skipped — first indexed event lacks position metadata",
+			"schema", schema, "table", table,
+			"event_id", first.EventID,
+			"baseline_file", bmeta.BinlogFile,
+			"baseline_pos", bmeta.BinlogPos,
+			"baseline_lsn", bmeta.LSN,
+			"flavor", flavor)
+	case GapDetected(flavor, first.BinlogFile, first.StartPos, bmeta.BinlogFile, bmeta.BinlogPos, bmeta.LSN):
+		slog.Warn("gap between baseline and first indexed event — reconstruction may be incomplete",
+			"schema", schema, "table", table,
+			"baseline_file", bmeta.BinlogFile,
+			"baseline_pos", bmeta.BinlogPos,
+			"baseline_gtid", bmeta.GTIDSet,
+			"baseline_lsn", bmeta.LSN,
+			"first_event_file", first.BinlogFile,
+			"first_event_pos", first.StartPos,
+			"flavor", flavor)
+	}
 }

--- a/internal/reconstruct/gap_test.go
+++ b/internal/reconstruct/gap_test.go
@@ -1,6 +1,114 @@
 package reconstruct
 
-import "testing"
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/baseline"
+	"github.com/dbtrail/dbtrail/internal/query"
+)
+
+const gapReportedMsg = "gap between baseline and first indexed event"
+
+// TestWarnBaselineFirstEventGap exercises the #781 full-table gap warning: the
+// baseline↔first-event check ported from the single-row path. It captures slog
+// output and asserts the "gap between baseline and first indexed event" warning
+// fires exactly when GapDetected would, honoring the same flavor-dependent
+// anchor/position skip cases as the single-row switch. Not parallel: it swaps
+// the process-global default logger (safe only in the sequential test phase).
+func TestWarnBaselineFirstEventGap(t *testing.T) {
+	cases := []struct {
+		name            string
+		flavor          string
+		bmeta           baseline.DumpMetadata
+		first           query.ResultRow
+		wantGapReported bool
+	}{
+		{
+			// The core #781 case: baseline pos precedes the first event by a gap.
+			name:   "mysql same file, first event past baseline pos = gap reported",
+			flavor: "mysql",
+			bmeta:  baseline.DumpMetadata{BinlogFile: "binlog.000042", BinlogPos: 1000},
+			first:  query.ResultRow{BinlogFile: "binlog.000042", StartPos: 5000, EventID: 7},
+
+			wantGapReported: true,
+		},
+		{
+			name:   "mysql later first-event file = gap reported",
+			flavor: "mysql",
+			bmeta:  baseline.DumpMetadata{BinlogFile: "binlog.000042", BinlogPos: 99999},
+			first:  query.ResultRow{BinlogFile: "binlog.000043", StartPos: 4, EventID: 8},
+
+			wantGapReported: true,
+		},
+		{
+			name:   "mysql first event at baseline pos = no gap",
+			flavor: "mysql",
+			bmeta:  baseline.DumpMetadata{BinlogFile: "binlog.000042", BinlogPos: 5000},
+			first:  query.ResultRow{BinlogFile: "binlog.000042", StartPos: 5000, EventID: 7},
+
+			wantGapReported: false,
+		},
+		{
+			// Anchor absent → the check is skipped (info), never a gap report.
+			name:   "mysql baseline lacks anchor = skipped, no gap reported",
+			flavor: "mysql",
+			bmeta:  baseline.DumpMetadata{},
+			first:  query.ResultRow{BinlogFile: "binlog.000042", StartPos: 5000, EventID: 7},
+
+			wantGapReported: false,
+		},
+		{
+			// First event lacks a comparable position (#318) → skipped, not a gap.
+			name:   "mysql first event NULL binlog_file = skipped, no gap reported",
+			flavor: "mysql",
+			bmeta:  baseline.DumpMetadata{BinlogFile: "binlog.000042", BinlogPos: 1000},
+			first:  query.ResultRow{BinlogFile: "", StartPos: 0, EventID: 7},
+
+			wantGapReported: false,
+		},
+		{
+			// PG numeric LSN compare: event past the baseline floor = gap.
+			name:   "postgres first event past baseline LSN = gap reported",
+			flavor: "postgres",
+			bmeta:  baseline.DumpMetadata{LSN: 0x1000},
+			first:  query.ResultRow{BinlogFile: "0/2000", StartPos: 0x2000, EventID: 9},
+
+			wantGapReported: true,
+		},
+		{
+			// PG lineage forced by the LSN anchor even with an empty flavor read.
+			name:   "empty flavor but baseline LSN proves PG lineage, event past floor = gap reported",
+			flavor: "",
+			bmeta:  baseline.DumpMetadata{LSN: 0x9},
+			first:  query.ResultRow{BinlogFile: "0/10", StartPos: 0x10, EventID: 9},
+
+			wantGapReported: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			prev := slog.Default()
+			slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+			defer slog.SetDefault(prev)
+
+			WarnBaselineFirstEventGap(tc.flavor, tc.bmeta, tc.first, "mydb", "orders")
+
+			out := buf.String()
+			reported := strings.Contains(out, gapReportedMsg)
+			if reported != tc.wantGapReported {
+				t.Errorf("gap reported = %v, want %v; log output:\n%s", reported, tc.wantGapReported, out)
+			}
+			if tc.wantGapReported && !strings.Contains(out, "level=WARN") {
+				t.Errorf("expected the gap report at WARN level; log output:\n%s", out)
+			}
+		})
+	}
+}
 
 func TestGapDetected(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
## Problem

Single-row `reconstruct` warns when the baseline anchor precedes the first indexed event by a gap — events in that window are missing from the reconstruction. Full-table `reconstruct` (`--output-format mydumper`) read the baseline binlog file/pos (`bmeta`, step 2) but never ran the gap check, so it produced a mydumper dump silently missing that gap with no signal.

## Fix

Port the check into `ReconstructTable` (`internal/reconstruct/fulltable.go`), using the `bmeta` already read in step 2 and the first fetched event. New `WarnBaselineFirstEventGap` in `internal/reconstruct/gap.go` is a direct port of the `resolveGapCheck` + `GapDetected` switch in `cli/reconstruct.go` — duplicated because that logic lives in package `cli`, which `internal/reconstruct` cannot import (cli imports reconstruct). It preserves the same flavor-dependent behavior (MySQL/MariaDB two-key binlog compare, PostgreSQL numeric-LSN compare, LSN-lineage guard, anchor/position skip cases).

Warn-only, identical to single-row: this check gates a warning, never the reconstruction, so `--allow-gaps` is deliberately not consulted here — it governs the coverage-gap fetch (`query.FetchMerged`) and `CheckCaptureGap`, which run separately. `schema`/`table` are added to each record so the warning is attributable when several tables reconstruct concurrently. The binlog-only fallback path is intentionally untouched (no baseline anchor exists there).

## Test

`TestWarnBaselineFirstEventGap` (table-driven, `internal/reconstruct/gap_test.go`) captures slog output and asserts the "gap between baseline and first indexed event" WARN fires exactly when the baseline pos precedes the first event by a gap, and is skipped (no false report) for at-pos, missing-anchor, and missing-event-position cases; covers MySQL and PostgreSQL flavors. Package builds under `CGO_ENABLED=1` and the full `internal/reconstruct` suite passes under `-race`.

Closes #781
