### PR TITLE
query: count archive-only hours as gaps under --no-archive

### DIFF
--- a/internal/query/fetchmerged.go
+++ b/internal/query/fetchmerged.go
@@ -87,10 +87,14 @@ type FetchMergedOptions struct {
 	DBName string
 
 	// NoArchive skips archive auto-discovery and the archive fetch loop. The
-	// query planner still runs when DBName and a time range are set — the
-	// planner only reads information_schema.PARTITIONS and archive_state and
-	// does not touch the archives themselves, so gap detection remains
-	// available under --no-archive.
+	// query planner still runs when DBName and a time range are set — it only
+	// reads information_schema.PARTITIONS (and, when archives ARE included,
+	// archive_state), never the archives themselves. Under NoArchive the
+	// planner ignores archive_state coverage: hours rotated out of live MySQL
+	// but present only in archives are counted as GAPS, since those archives
+	// will not be fetched. This yields a *GapError under AllowGaps=false and an
+	// slog.Warn under AllowGaps=true — without it a strict reconstruct would
+	// silently omit the archived-only hours.
 	NoArchive bool
 
 	// AllowGaps controls what happens when the planner reports coverage gaps
@@ -178,13 +182,14 @@ func FetchMerged(
 
 	// The query planner runs whenever the caller supplied a DBName and either
 	// has a time range or has resolved archive sources. It runs regardless of
-	// NoArchive because it only reads information_schema.PARTITIONS and
-	// archive_state — no actual data fetch. This preserves gap detection for
-	// --no-archive callers (observability win for recover, correctness win
-	// for reconstruct under AllowGaps=false).
+	// NoArchive — no actual data fetch, just partition/archive_state metadata.
+	// o.NoArchive is threaded in so that when archives are excluded, archived-
+	// only hours are classified as gaps rather than covered. This preserves gap
+	// detection for --no-archive callers (observability win for recover,
+	// correctness win for reconstruct under AllowGaps=false).
 	var plan *QueryPlan
 	if o.DBName != "" && (len(archSources) > 0 || o.Opts.Since != nil || o.Opts.Until != nil) {
-		p, err := Plan(ctx, db, o.DBName, o.Opts.Since, o.Opts.Until)
+		p, err := Plan(ctx, db, o.DBName, o.Opts.Since, o.Opts.Until, o.NoArchive)
 		if err != nil {
 			if !o.AllowGaps {
 				return nil, nil, fmt.Errorf("query planner failed, cannot verify coverage: %w", err)

--- a/internal/query/planner.go
+++ b/internal/query/planner.go
@@ -37,7 +37,14 @@ type QueryPlan struct {
 // Returns (nil, nil) when planning is not applicable (nil DB, no time range).
 // Returns (nil, error) when planning fails due to a database error.
 // dbName is the MySQL database name (needed for information_schema queries).
-func Plan(ctx context.Context, db *sql.DB, dbName string, since, until *time.Time) (*QueryPlan, error) {
+//
+// noArchive mirrors the caller's decision to exclude Parquet archives from the
+// fetch (--no-archive or an active RBAC profile). When true, archive_state
+// coverage is NOT read or counted: hours rotated out of live MySQL but present
+// only in archives are then classified as GAPS, because those archives will not
+// be fetched. Counting them as covered would let a strict (AllowGaps=false)
+// reconstruct silently return incomplete state.
+func Plan(ctx context.Context, db *sql.DB, dbName string, since, until *time.Time, noArchive bool) (*QueryPlan, error) {
 	if db == nil || dbName == "" {
 		return nil, nil
 	}
@@ -65,19 +72,36 @@ func Plan(ctx context.Context, db *sql.DB, dbName string, since, until *time.Tim
 
 	// Load archived partition names. Failure is non-fatal: archive_state may
 	// not exist in older indexes. Gap detection still works from live partitions.
-	archivedHours, err := loadArchivedHours(ctx, db)
-	if err != nil {
-		slog.Debug("archive_state not available for planning", "error", err)
-		archivedHours = nil
+	//
+	// Skipped entirely when noArchive: those archives are excluded from the
+	// fetch, so reading their coverage here would only mislabel rotated hours as
+	// covered. Leaving archivedHours nil makes buildPlan classify them as gaps.
+	var archivedHours []time.Time
+	if !noArchive {
+		archivedHours, err = loadArchivedHours(ctx, db)
+		if err != nil {
+			slog.Debug("archive_state not available for planning", "error", err)
+			archivedHours = nil
+		}
 	}
 
-	return buildPlan(liveHours, archivedHours, rangeStart, rangeEnd), nil
+	return buildPlan(liveHours, archivedHours, rangeStart, rangeEnd, noArchive), nil
 }
 
 // buildPlan is the pure-logic core of the planner. It classifies each hour in
 // [rangeStart, rangeEnd) as live, archived, or gap, then builds a QueryPlan.
 // This function is extracted from Plan() for testability.
-func buildPlan(liveHours, archivedHours []time.Time, rangeStart, rangeEnd time.Time) *QueryPlan {
+func buildPlan(liveHours, archivedHours []time.Time, rangeStart, rangeEnd time.Time, noArchive bool) *QueryPlan {
+	// When archives are excluded from the fetch (--no-archive / active profile),
+	// archive_state coverage must NOT count toward classification or half-open
+	// range inference: those hours are rotated out of live MySQL and will not be
+	// fetched, so they are real gaps. Dropping archivedHours here is the single
+	// authority for that rule (Plan also skips the archive_state read). Without
+	// it a strict AllowGaps=false reconstruct would silently omit them.
+	if noArchive {
+		archivedHours = nil
+	}
+
 	// Build sets for fast lookup.
 	liveSet := make(map[time.Time]bool, len(liveHours))
 	for _, h := range liveHours {
@@ -164,7 +188,9 @@ func (p *QueryPlan) SkipMySQL() bool {
 //
 // parseDSN is a function that extracts the database name from the DSN.
 func RunPlanAndWarn(ctx context.Context, db *sql.DB, dbName string, since, until *time.Time) *QueryPlan {
-	plan, err := Plan(ctx, db, dbName, since, until)
+	// Callers that exclude archives (bintrail query --no-archive) skip planning
+	// entirely, so this warn path is always archive-aware (noArchive=false).
+	plan, err := Plan(ctx, db, dbName, since, until, false)
 	if err != nil {
 		slog.Warn("query planner failed; coverage gaps may not be detected", "error", err)
 		return nil

--- a/internal/query/planner_test.go
+++ b/internal/query/planner_test.go
@@ -156,7 +156,7 @@ func TestQueryPlan_SkipMySQL(t *testing.T) {
 
 func TestPlan_nilDB(t *testing.T) {
 	since := time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC)
-	p, err := Plan(t.Context(), nil, "testdb", &since, nil)
+	p, err := Plan(t.Context(), nil, "testdb", &since, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -167,7 +167,7 @@ func TestPlan_nilDB(t *testing.T) {
 
 func TestPlan_noTimeRange(t *testing.T) {
 	// Nil since and until should produce nil plan (no routing possible).
-	p, err := Plan(t.Context(), nil, "testdb", nil, nil)
+	p, err := Plan(t.Context(), nil, "testdb", nil, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -184,7 +184,7 @@ func h(day, hour int) time.Time {
 
 func TestBuildPlan_allLiveNoneArchived(t *testing.T) {
 	live := []time.Time{h(5, 10), h(5, 11), h(5, 12)}
-	plan := buildPlan(live, nil, h(5, 10), h(5, 13))
+	plan := buildPlan(live, nil, h(5, 10), h(5, 13), false)
 
 	if plan == nil {
 		t.Fatal("expected non-nil plan")
@@ -202,7 +202,7 @@ func TestBuildPlan_allLiveNoneArchived(t *testing.T) {
 
 func TestBuildPlan_allArchivedNoneLive(t *testing.T) {
 	archived := []time.Time{h(5, 10), h(5, 11), h(5, 12)}
-	plan := buildPlan(nil, archived, h(5, 10), h(5, 13))
+	plan := buildPlan(nil, archived, h(5, 10), h(5, 13), false)
 
 	if plan == nil {
 		t.Fatal("expected non-nil plan")
@@ -221,7 +221,7 @@ func TestBuildPlan_allArchivedNoneLive(t *testing.T) {
 func TestBuildPlan_mixedLiveAndArchived(t *testing.T) {
 	live := []time.Time{h(5, 12), h(5, 13)}
 	archived := []time.Time{h(5, 10), h(5, 11)}
-	plan := buildPlan(live, archived, h(5, 10), h(5, 14))
+	plan := buildPlan(live, archived, h(5, 10), h(5, 14), false)
 
 	if plan == nil {
 		t.Fatal("expected non-nil plan")
@@ -245,7 +245,7 @@ func TestBuildPlan_withGaps(t *testing.T) {
 	live := []time.Time{h(5, 10)}
 	archived := []time.Time{h(5, 13)}
 	// Range 10-14, live at 10, gap at 11-12, archived at 13
-	plan := buildPlan(live, archived, h(5, 10), h(5, 14))
+	plan := buildPlan(live, archived, h(5, 10), h(5, 14), false)
 
 	if plan == nil {
 		t.Fatal("expected non-nil plan")
@@ -265,7 +265,7 @@ func TestBuildPlan_overlappingLiveAndArchived(t *testing.T) {
 	// An hour exists in both live and archive — should not be a gap.
 	live := []time.Time{h(5, 10), h(5, 11)}
 	archived := []time.Time{h(5, 10), h(5, 11)}
-	plan := buildPlan(live, archived, h(5, 10), h(5, 12))
+	plan := buildPlan(live, archived, h(5, 10), h(5, 12), false)
 
 	if plan == nil {
 		t.Fatal("expected non-nil plan")
@@ -279,9 +279,67 @@ func TestBuildPlan_overlappingLiveAndArchived(t *testing.T) {
 	}
 }
 
+func TestBuildPlan_noArchiveArchivedHoursAreGaps(t *testing.T) {
+	// #837: under --no-archive / an active profile the archives are excluded
+	// from the fetch, so hours present ONLY in archive_state must be classified
+	// as gaps — not silently counted as covered. This is what populates
+	// GapHours (→ *GapError under AllowGaps=false, → slog.Warn otherwise) in
+	// FetchMerged for reconstruct/recover.
+	archived := []time.Time{h(5, 10), h(5, 11), h(5, 12)}
+
+	// Baseline: with archives honored these are covered, no gaps.
+	honored := buildPlan(nil, archived, h(5, 10), h(5, 13), false)
+	if len(honored.GapHours) != 0 {
+		t.Fatalf("noArchive=false: expected archived hours covered, got %d gaps", len(honored.GapHours))
+	}
+
+	// noArchive=true: the same archived-only hours become gaps.
+	plan := buildPlan(nil, archived, h(5, 10), h(5, 13), true)
+	if plan == nil {
+		t.Fatal("expected non-nil plan")
+	}
+	if len(plan.GapHours) != 3 {
+		t.Fatalf("noArchive=true: expected 3 gap hours, got %d: %v", len(plan.GapHours), plan.GapHours)
+	}
+	for i, want := range archived {
+		if !plan.GapHours[i].Equal(want) {
+			t.Errorf("gap[%d] = %v, want %v", i, plan.GapHours[i], want)
+		}
+	}
+	if plan.SkipMySQL() {
+		t.Error("should not skip MySQL when gaps exist")
+	}
+}
+
+func TestBuildPlan_noArchiveKeepsLiveHours(t *testing.T) {
+	// Mixed range: live at 10-11, archived-only at 12-13. Under noArchive the
+	// live hours stay live (MySQL is queried) and only the archived-only hours
+	// become gaps.
+	live := []time.Time{h(5, 10), h(5, 11)}
+	archived := []time.Time{h(5, 12), h(5, 13)}
+	plan := buildPlan(live, archived, h(5, 10), h(5, 14), true)
+
+	if plan == nil {
+		t.Fatal("expected non-nil plan")
+	}
+	if len(plan.GapHours) != 2 {
+		t.Fatalf("expected 2 gap hours, got %d: %v", len(plan.GapHours), plan.GapHours)
+	}
+	if !plan.GapHours[0].Equal(h(5, 12)) || !plan.GapHours[1].Equal(h(5, 13)) {
+		t.Errorf("gaps = %v, want [12:00, 13:00]", plan.GapHours)
+	}
+	if len(plan.MySQLRanges) != 1 {
+		t.Fatalf("expected 1 MySQL range for live hours, got %d", len(plan.MySQLRanges))
+	}
+	if !plan.MySQLRanges[0].Start.Equal(h(5, 10)) || !plan.MySQLRanges[0].End.Equal(h(5, 12)) {
+		t.Errorf("MySQL range = %v – %v, want 10:00 – 12:00",
+			plan.MySQLRanges[0].Start, plan.MySQLRanges[0].End)
+	}
+}
+
 func TestBuildPlan_allGaps(t *testing.T) {
 	// No live, no archived — everything is a gap.
-	plan := buildPlan(nil, nil, h(5, 10), h(5, 13))
+	plan := buildPlan(nil, nil, h(5, 10), h(5, 13), false)
 
 	if plan == nil {
 		t.Fatal("expected non-nil plan")
@@ -296,7 +354,7 @@ func TestBuildPlan_allGaps(t *testing.T) {
 }
 
 func TestBuildPlan_noBoundsReturnsNil(t *testing.T) {
-	plan := buildPlan(nil, nil, time.Time{}, time.Time{})
+	plan := buildPlan(nil, nil, time.Time{}, time.Time{}, false)
 	if plan != nil {
 		t.Errorf("expected nil for zero-value bounds, got %+v", plan)
 	}

--- a/internal/streamrun/index_metrics.go
+++ b/internal/streamrun/index_metrics.go
@@ -101,7 +101,7 @@ func scrapeIndexMetrics(ctx context.Context, db *sql.DB, dbName string, m *obser
 		archiveEarliest = data.Coverage.ArchiveEarliestHour
 	}
 	if since, until, ok := gapScrapeRange(snap.OldestEvent, archiveEarliest, newestExplicit); ok {
-		if plan, err := query.Plan(ctx, db, dbName, &since, &until); err != nil {
+		if plan, err := query.Plan(ctx, db, dbName, &since, &until, false); err != nil {
 			slog.Warn("index metrics scrape: could not plan gap hours", "error", err)
 		} else if plan != nil { // belt-and-suspenders: Plan can still return nil
 			snap.GapHours = len(plan.GapHours)


### PR DESCRIPTION
## Problem

The query planner (`internal/query/planner.go`) reads `archive_state` and classifies any hour present there as *covered*, regardless of whether the caller excluded archives from the fetch. But `FetchMerged` with `NoArchive=true` (set by `recover`/`reconstruct` under `--no-archive`, and by `recover` whenever a `--profile` is active) does **not** fetch those archives.

Result: for a `reconstruct --at ... --no-archive` (AllowGaps=false) over a range whose hours were rotated to Parquet, the planner sees them covered, so `GapHours` is empty, no `*GapError` fires, and `Fetch` returns only live data — an **incorrect reconstructed state with no error**. Under `AllowGaps=true` (recover / profile mode) there was zero signal at all — no warning about the archive-only hours that were silently dropped.

The `NoArchive` field doc already claimed gap detection stayed correct under `--no-archive`; the code did not honor it.

## Fix

Minimal, additive: thread the `NoArchive` fact into `Plan` and `buildPlan`.

- `Plan(..., noArchive bool)`: when true, skip the `loadArchivedHours` read entirely (excluded archives should not seed coverage).
- `buildPlan(..., noArchive bool)`: when true, drop `archivedHours` before classification and half-open range inference, so archive-only hours are classified as **gaps**.
- `FetchMerged` passes `o.NoArchive`; the two archive-aware callers (`RunPlanAndWarn` for `bintrail query`, the index-metrics scraper) pass `false`.

The populated `GapHours` then flow through the **existing** `FetchMerged` gap handling: `*GapError` under `AllowGaps=false`, `slog.Warn(FormatGapWarning(...))` under `AllowGaps=true`. This covers both the strict-reconstruct correctness case and the recover/profile warn-signal case with one change.

Behavior is byte-for-byte identical when `NoArchive=false`.

## Test

Added two `buildPlan` unit tests in `planner_test.go`:
- `TestBuildPlan_noArchiveArchivedHoursAreGaps` — same archived-only hours are covered with `noArchive=false` but become 3 gaps with `noArchive=true`.
- `TestBuildPlan_noArchiveKeepsLiveHours` — mixed range: live hours stay live (MySQL queried), only archive-only hours become gaps.

Existing planner tests updated for the new signature. `go build ./...` and `go test ./internal/query/...` pass.

Closes #837
