### PR TITLE
cascade: flag child-side FK-column DDL-skew on zero-victim scans

### DIFF
--- a/internal/cascade/cascade.go
+++ b/internal/cascade/cascade.go
@@ -108,6 +108,39 @@ type Options struct {
 	ArchivesPresent bool
 }
 
+// skewSampleLimit bounds the child-side DDL-skew probe: how many child
+// row-images to sample when a candidate scan returns zero rows. A handful is
+// enough to tell "column exists under its snapshot name" from "renamed away";
+// the probe runs at most once per child FK column (skewChecked memo).
+const skewSampleLimit = 8
+
+// fkColumnAbsentFromAll reports whether col is present in NONE of the sampled
+// child row-images — the signal that the FK column was renamed/dropped since the
+// FK snapshot (DDL-skew) rather than that the parent genuinely had no children.
+// It returns false unless it actually inspected at least one image: an empty
+// sample (no child events in the window) or images with neither before nor after
+// map is inconclusive, never a skew claim (avoids flagging a legitimately empty
+// window). A single image carrying col — even for a different parent — proves the
+// column exists under its snapshot name, so it is not skew.
+func fkColumnAbsentFromAll(col string, sample []query.ResultRow) bool {
+	sawImage := false
+	for _, r := range sample {
+		if r.RowAfter != nil {
+			sawImage = true
+			if _, ok := r.RowAfter[col]; ok {
+				return false
+			}
+		}
+		if r.RowBefore != nil {
+			sawImage = true
+			if _, ok := r.RowBefore[col]; ok {
+				return false
+			}
+		}
+	}
+	return sawImage
+}
+
 func (o Options) withDefaults() Options {
 	if o.Lookback == 0 {
 		o.Lookback = 30 * 24 * time.Hour // CASCADE_LOOKBACK_DAYS=30
@@ -224,6 +257,12 @@ func SynthesizeVictims(
 
 	visited := map[string]bool{} // "schema.table|pkvalues" → processed as a parent
 	emitted := map[string]bool{} // "schema.table|pkvalues" → already emitted as a victim
+	// skewChecked memoizes the child-side DDL-skew probe per child FK column so a
+	// wide cascade with many childless parents samples each child table at most
+	// once. Only a CONCLUSIVE probe (a window that returned images) memoizes; an
+	// empty-window probe stays unmemoized so a later parent's window can detect
+	// skew (see the len(cands)==0 branch below).
+	skewChecked := map[string]bool{} // "schema.table.column" → skew probe already conclusive
 
 	// The cascade fires atomically at the ROOT delete's timestamp T, so every
 	// descendant existed at T and the lookback window must end at T for EVERY
@@ -340,6 +379,55 @@ func SynthesizeVictims(
 						"%s.%s has more than %d cascade victims for one parent; the excess (and their descendants) were NOT reconstructed",
 						fk.Schema, fk.Table, opts.CandidateLimit))
 					cands = cands[:opts.CandidateLimit]
+				}
+
+				// Child-side DDL-skew guard. A zero-candidate scan is ambiguous:
+				// either no child referenced this parent (normal — leave silent), or
+				// the child FK column was renamed since the FK snapshot so the
+				// ColumnEq JSON_EXTRACT('$.<snapshot-name>') never matched the old
+				// row-images (the column name in effect at event time differs). In
+				// the latter case synthesis would report 0 victims + Complete —
+				// indistinguishable from "no children existed". Mirror the parent-side
+				// "noref" caveat: sample the child images in the window WITHOUT the FK
+				// filter; if fk.Column is absent from every sampled image, the graph's
+				// column name doesn't exist here → flag, so a false-negative zero is
+				// never presented as a clean Complete.
+				if len(cands) == 0 {
+					skewKey := fk.Schema + "." + fk.Table + "." + fk.Column
+					if !skewChecked[skewKey] {
+						sample, serr := eng.Fetch(ctx, query.Options{
+							Schema: fk.Schema,
+							Table:  fk.Table,
+							Since:  &since,
+							Until:  &until,
+							Order:  "DESC",
+							Limit:  skewSampleLimit,
+						})
+						switch {
+						case serr != nil:
+							// Probe failure: the primary candidate scan already
+							// succeeded (0 rows), so this is not an operational error —
+							// only a caveat that we could not rule out skew here.
+							skewChecked[skewKey] = true
+							addIncomplete("skewprobe:"+skewKey, fmt.Sprintf(
+								"could not probe %s.%s for a renamed FK column %q (its zero-victim result is unverified): %v",
+								fk.Schema, fk.Table, fk.Column, serr))
+						case len(sample) == 0:
+							// No child events in this window: inconclusive. Leave
+							// unmemoized so another parent's window can still detect skew.
+						case fkColumnAbsentFromAll(fk.Column, sample):
+							skewChecked[skewKey] = true
+							addIncomplete("childskew:"+skewKey, fmt.Sprintf(
+								"FK column %q is absent from every sampled %s.%s row-image in the window "+
+									"(schema changed since the FK snapshot); its cascade-deleted rows could NOT be "+
+									"matched, so a zero-victim result here may be a false negative — NOT confirmation "+
+									"that no children existed",
+								fk.Column, fk.Schema, fk.Table))
+						default:
+							// fk.Column present under its snapshot name → not skewed.
+							skewChecked[skewKey] = true
+						}
+					}
 				}
 
 				// touched = every child PK with an event matching fk=parentPK in

--- a/internal/cascade/cascade_cases_integration_test.go
+++ b/internal/cascade/cascade_cases_integration_test.go
@@ -132,6 +132,80 @@ func TestSynthesizeVictims_ruleGate(t *testing.T) {
 	}
 }
 
+// TestSynthesizeVictims_childFKColumnSkew pins the child-side DDL-skew guard
+// (#832): when a cascade OLDER than a child FK-column rename ("pid" -> "parent_id")
+// is recovered, the candidate scan uses the LATEST snapshot's column name against
+// events whose row-images still carry the old name, so ColumnEq matches 0 rows —
+// indistinguishable from "no children existed". Synthesis must NOT report a clean
+// Complete; it must flag skew (mirroring the parent-side "noref" caveat).
+func TestSynthesizeVictims_childFKColumnSkew(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	eng := query.New(db)
+
+	T := time.Now().UTC()
+	h := T.Add(-30 * time.Minute).Truncate(time.Hour)
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{h})
+	ts := h.Add(10 * time.Minute).Format("2006-01-02 15:04:05")
+	// Child events predate the rename: their row-images carry the OLD name "pid".
+	// child 10 referenced parent 1 (via the column that is now called parent_id).
+	testutil.InsertEvent(t, db, "b.000001", 10, 20, ts, nil, dbName, "child", 1, "10", nil, nil, []byte(`{"id":10,"pid":1}`))
+
+	// The FK graph is the LATEST snapshot: the column is already renamed parent_id.
+	fks := []cascade.CascadeFK{{
+		Schema: dbName, Table: "child", ConstraintName: "fk", Column: "parent_id",
+		ReferencedSchema: dbName, ReferencedTable: "parent", ReferencedColumn: "id",
+		DeleteRule: "CASCADE",
+	}}
+	res, err := cascade.SynthesizeVictims(context.Background(), eng, fks, parentDelete(dbName, T), cascade.Options{})
+	if err != nil {
+		t.Fatalf("SynthesizeVictims: %v", err)
+	}
+	if len(res.Victims) != 0 {
+		t.Fatalf("renamed FK column must match 0 candidates, got %d: %v", len(res.Victims), victimList(res.Victims))
+	}
+	if res.Complete() || !strings.Contains(strings.Join(res.Incomplete, " "), "absent from every sampled") {
+		t.Errorf("child-side DDL-skew must flag incompleteness, not a clean Complete; Incomplete=%v", res.Incomplete)
+	}
+}
+
+// TestSynthesizeVictims_zeroChildrenNotFlaggedAsSkew is the control for the skew
+// guard: a parent with genuinely no matching children — but whose child table
+// carries the FK column under its snapshot name (referencing OTHER parents) — must
+// stay Complete. The skew probe must not turn a legitimate zero-victim result into
+// a false caveat.
+func TestSynthesizeVictims_zeroChildrenNotFlaggedAsSkew(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	eng := query.New(db)
+
+	T := time.Now().UTC()
+	h := T.Add(-30 * time.Minute).Truncate(time.Hour)
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{h})
+	ts := h.Add(10 * time.Minute).Format("2006-01-02 15:04:05")
+	// child 10 references parent 2 (NOT the deleted parent 1); the FK column
+	// parent_id is present under its snapshot name.
+	testutil.InsertEvent(t, db, "b.000001", 10, 20, ts, nil, dbName, "child", 1, "10", nil, nil, []byte(`{"id":10,"parent_id":2}`))
+
+	fks := []cascade.CascadeFK{{
+		Schema: dbName, Table: "child", ConstraintName: "fk", Column: "parent_id",
+		ReferencedSchema: dbName, ReferencedTable: "parent", ReferencedColumn: "id",
+		DeleteRule: "CASCADE",
+	}}
+	res, err := cascade.SynthesizeVictims(context.Background(), eng, fks, parentDelete(dbName, T), cascade.Options{})
+	if err != nil {
+		t.Fatalf("SynthesizeVictims: %v", err)
+	}
+	if len(res.Victims) != 0 {
+		t.Fatalf("parent 1 has no children, got %d victims: %v", len(res.Victims), victimList(res.Victims))
+	}
+	if !res.Complete() {
+		t.Errorf("a genuine no-children result (FK column present) must stay Complete, got Incomplete=%v", res.Incomplete)
+	}
+}
+
 // TestSynthesizeVictims_setNull pins ON DELETE SET NULL: a child that referenced
 // the deleted parent (and survives) becomes a SetNullRestore (not a victim), and
 // it is NOT recursed (no row was deleted). A child re-pointed away is excluded.

--- a/internal/cascade/cascade_internal_test.go
+++ b/internal/cascade/cascade_internal_test.go
@@ -3,6 +3,8 @@ package cascade
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/query"
 )
 
 // TestValToString covers every branch of the value renderer that backs the
@@ -29,6 +31,92 @@ func TestValToString(t *testing.T) {
 	for _, c := range cases {
 		if got := valToString(c.in); got != c.want {
 			t.Errorf("%s: valToString(%#v) = %q, want %q", c.name, c.in, got, c.want)
+		}
+	}
+}
+
+// TestFKColumnAbsentFromAll covers the child-side DDL-skew detector (#832). When
+// a cascade older than a child FK-column rename is recovered, the candidate scan
+// (ColumnEq on the LATEST snapshot's column name) matches 0 rows against events
+// keyed by the OLD name — an outcome indistinguishable from "no children
+// existed". The probe samples the child images without the FK filter and flags
+// skew only when the snapshot's column name is absent from every sampled image.
+func TestFKColumnAbsentFromAll(t *testing.T) {
+	rowAfter := func(m map[string]any) query.ResultRow { return query.ResultRow{RowAfter: m} }
+	rowBefore := func(m map[string]any) query.ResultRow { return query.ResultRow{RowBefore: m} }
+
+	cases := []struct {
+		name   string
+		col    string
+		sample []query.ResultRow
+		want   bool
+	}{
+		{
+			name:   "empty sample is inconclusive (no children, not skew)",
+			col:    "parent_id",
+			sample: nil,
+			want:   false,
+		},
+		{
+			name: "renamed FK column absent from all after-images → skew",
+			col:  "parent_id", // snapshot name; events use the old "pid"
+			sample: []query.ResultRow{
+				rowAfter(map[string]any{"id": json.Number("1"), "pid": json.Number("9")}),
+				rowAfter(map[string]any{"id": json.Number("2"), "pid": json.Number("9")}),
+			},
+			want: true,
+		},
+		{
+			name: "renamed FK column absent from delete before-images → skew",
+			col:  "parent_id",
+			sample: []query.ResultRow{
+				rowBefore(map[string]any{"id": json.Number("1"), "pid": json.Number("9")}),
+			},
+			want: true,
+		},
+		{
+			name: "column present in after-image → not skew",
+			col:  "parent_id",
+			sample: []query.ResultRow{
+				rowAfter(map[string]any{"id": json.Number("1"), "parent_id": json.Number("9")}),
+			},
+			want: false,
+		},
+		{
+			name: "column present in before-image → not skew",
+			col:  "parent_id",
+			sample: []query.ResultRow{
+				rowBefore(map[string]any{"id": json.Number("1"), "parent_id": json.Number("9")}),
+			},
+			want: false,
+		},
+		{
+			name: "mixed: at least one image carries the column → not skew",
+			col:  "parent_id",
+			sample: []query.ResultRow{
+				rowAfter(map[string]any{"id": json.Number("1"), "pid": json.Number("9")}),
+				rowAfter(map[string]any{"id": json.Number("2"), "parent_id": json.Number("9")}),
+			},
+			want: false,
+		},
+		{
+			name: "column present but NULL-valued still counts as present (not skew)",
+			col:  "parent_id",
+			sample: []query.ResultRow{
+				rowAfter(map[string]any{"id": json.Number("1"), "parent_id": nil}),
+			},
+			want: false,
+		},
+		{
+			name:   "sample rows with no images at all is inconclusive",
+			col:    "parent_id",
+			sample: []query.ResultRow{{}, {}},
+			want:   false,
+		},
+	}
+	for _, c := range cases {
+		if got := fkColumnAbsentFromAll(c.col, c.sample); got != c.want {
+			t.Errorf("%s: fkColumnAbsentFromAll(%q, …) = %v, want %v", c.name, c.col, got, c.want)
 		}
 	}
 }


### PR DESCRIPTION
## Problem

The cascade victim scan matches child rows via `ColumnEq` on `fk.Column` taken from the **latest** FK snapshot, but old events' row-images carry the column name in effect at event time (`schema_version`). When a child FK column is renamed (e.g. `pid` → `parent_id`), a snapshot is taken, and a cascade **older** than the rename is recovered, `JSON_EXTRACT('$.parent_id')` over `"pid"`-keyed events returns NULL. The scan matches 0 rows and synthesis reports 0 victims with a clean `Complete()` — indistinguishable from "no children existed".

The parent side already emits a `noref` caveat when the referenced column is absent from the parent image; the child side was silent, so a provably-partial recovery could be applied as if complete.

## Fix

Additive guard, no change to the emit/victim path. When the candidate scan returns zero rows, sample the child row-images in the same window **without** the FK filter (`fkColumnAbsentFromAll`, bounded by `skewSampleLimit`). If `fk.Column` is absent from every sampled image, the snapshot's column name does not exist there (rename/skew) → record an `Incomplete` caveat so a false-negative zero is never presented as `Complete`.

- A single sampled image carrying the column (even for another parent) proves the column exists under its snapshot name → normal path stays `Complete`.
- An empty window (no child events) is inconclusive → left unflagged (not skew).
- The probe runs at most once per child FK column (`skewChecked` memo; only conclusive windows memoize).

## Test

- Unit (`cascade_internal_test.go`): `TestFKColumnAbsentFromAll`, table-driven — empty/imageless samples are inconclusive; old-name-only images (before + after) flag skew; column present (incl. NULL-valued) does not; mixed samples do not.
- Integration (`cascade_cases_integration_test.go`): `TestSynthesizeVictims_childFKColumnSkew` (renamed FK column → 0 candidates → skew caveat, not `Complete`) and its control `TestSynthesizeVictims_zeroChildrenNotFlaggedAsSkew` (genuine no-children with the FK column present stays `Complete`).

`CGO_ENABLED=1 go build` + `go vet` + unit tests pass for `internal/cascade` and its dependents (`cli`, `console`, `cascaderecover`); integration tests compile under `-tags integration`.

Closes #832