### PR TITLE
cli: guard dump against destroying the output tree (#809)

### DIFF
--- a/cliapp/dump.go
+++ b/cliapp/dump.go
@@ -434,9 +434,22 @@ func prepareDumpOutputDir(dir string) (*dumpDirPrep, error) {
 			"Remove it yourself or point --output-dir elsewhere", dir, dumpDirMarkers[0])
 	}
 	// Recognizable prior dump: move it aside so a failed dump can restore it.
-	backup := filepath.Clean(dir) + ".old"
-	if err := os.RemoveAll(backup); err != nil {
-		return nil, fmt.Errorf("clear stale dump backup %q: %w", backup, err)
+	// Use a UNIQUE sibling path rather than a fixed dir.old — the earlier fixed
+	// name did an unconditional os.RemoveAll(dir.old), reintroducing exactly the
+	// unconditional-tree-deletion this guard exists to eliminate (#809 review):
+	//   (a) an operator's own precious backup at <dir>.old would be silently
+	//       destroyed the moment <dir> is recognized as a dump; and
+	//   (b) if a prior rollback() failed to remove partial output, the only good
+	//       copy of the previous dump is stranded at dir.old — and it IS a
+	//       recognizable dump — so the next run's RemoveAll(dir.old) would wipe
+	//       the last good copy before renaming the partial over it.
+	// A per-run suffix never collides with a pre-existing path, so we NEVER
+	// delete anything here — a leftover backup from a failed rollback stays put.
+	backup := fmt.Sprintf("%s.old-%d-%d", filepath.Clean(dir), os.Getpid(), time.Now().UnixNano())
+	if _, err := os.Lstat(backup); err == nil {
+		return nil, fmt.Errorf("dump backup path %q already exists; refusing to overwrite it", backup)
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("stat dump backup path %q: %w", backup, err)
 	}
 	if err := os.Rename(dir, backup); err != nil {
 		return nil, fmt.Errorf("move existing dump %q aside to %q: %w", dir, backup, err)

--- a/cliapp/dump.go
+++ b/cliapp/dump.go
@@ -14,6 +14,7 @@ import (
 	"syscall"
 	"time"
 
+	drivermysql "github.com/go-sql-driver/mysql"
 	"github.com/spf13/cobra"
 
 	"github.com/dbtrail/dbtrail/internal/baseline"
@@ -25,8 +26,11 @@ var dumpCmd = &cobra.Command{
 	Use:   "dump",
 	Short: "Invoke mydumper to create a logical dump of the source MySQL instance",
 	Long: `Invokes mydumper to create a logical dump of the source MySQL instance.
-Only one dump may run at a time (enforced by a lockfile). Any existing output
-directory is removed before the dump begins.`,
+Only one dump may run at a time (enforced by a lockfile). Source connectivity is
+verified before the output directory is touched. An existing output directory is
+only cleared when it is empty or a recognizable prior dump — a recognizable prior
+dump is moved aside and restored if this dump fails; a non-empty directory that
+is not a dump is refused rather than deleted.`,
 	RunE: runDump,
 }
 
@@ -204,6 +208,14 @@ func runDump(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// 2b. Validate source connectivity BEFORE the output directory is touched.
+	// A wrong host/port/credential (or an unreachable server) must fail here —
+	// never after the previous, only-good dump has already been destroyed
+	// (#809). Injectable via pingSource so unit tests can stub it.
+	if err := pingSource(dmpSourceDSN); err != nil {
+		return fmt.Errorf("cannot connect to source; refusing to touch --output-dir %q: %w", dmpOutputDir, err)
+	}
+
 	// 3. Parse schema and table filters.
 	schemas := cliutil.ParseSchemaList(dmpSchemas)
 	tables := cliutil.ParseSchemaList(dmpTables)
@@ -215,10 +227,25 @@ func runDump(cmd *cobra.Command, args []string) error {
 	}
 	defer releaseDumpLock(lockFile)
 
-	// 5. Remove existing output directory.
-	if err := os.RemoveAll(dmpOutputDir); err != nil {
-		return fmt.Errorf("failed to remove existing output directory %q: %w", dmpOutputDir, err)
+	// 5. Safely prepare the output directory (#809). Refuse to delete a
+	// non-empty directory that is not a recognizable prior mydumper/bintrail
+	// dump — a typo'd --output-dir (or a stray BINTRAIL_OUTPUT_DIR in a sibling
+	// .bintrail.env) must never wipe an arbitrary tree, including baselines
+	// that reconstruct/verify depend on. A recognizable prior dump is moved
+	// aside (dir → dir.old) and only deleted once THIS dump succeeds, so a
+	// failed dump restores the previous (only-good) output.
+	prep, err := prepareDumpOutputDir(dmpOutputDir)
+	if err != nil {
+		return err
 	}
+	dumpSucceeded := false
+	defer func() {
+		if dumpSucceeded {
+			prep.commit()
+		} else {
+			prep.rollback()
+		}
+	}()
 
 	// 6. Probe mydumper version and build args.
 	// --sync-thread-lock-mode and --trx-tables require mydumper >= 0.18 (see
@@ -304,6 +331,9 @@ func runDump(cmd *cobra.Command, args []string) error {
 	}
 
 	slog.Info("dump complete", "output_dir", dmpOutputDir)
+	// The dump succeeded: the deferred cleanup may now delete the moved-aside
+	// previous dump (dir.old) instead of restoring it (#809).
+	dumpSucceeded = true
 
 	// Best-effort: a write failure here just means baseline conversion falls
 	// back to mydumper's own (TZ-sensitive) "Started dump at" line rather
@@ -319,6 +349,128 @@ func runDump(cmd *cobra.Command, args []string) error {
 		}{OutputDir: dmpOutputDir})
 	}
 	return nil
+}
+
+// pingSource validates connectivity to the source before the dump does anything
+// destructive to --output-dir. It is a variable so tests can stub it without a
+// live server (mirroring dumpLockDir). #809.
+var pingSource = defaultPingSource
+
+// defaultPingSource opens and pings the source, then closes. The DSN's default
+// database is stripped: mydumper connects at the server level (it selects no
+// default schema and derives the dump set from --database/--regex/--tables-list),
+// so a database component that go-sql-driver would try to USE must not cause a
+// false "cannot connect" that blocks an otherwise-valid dump.
+func defaultPingSource(dsn string) error {
+	cfg, err := drivermysql.ParseDSN(dsn)
+	if err != nil {
+		return fmt.Errorf("invalid --source-dsn: %w", err)
+	}
+	cfg.DBName = ""
+	db, err := config.Connect(cfg.FormatDSN())
+	if err != nil {
+		return err
+	}
+	return db.Close()
+}
+
+// dumpDirMarkers are filenames whose presence in a non-empty --output-dir marks
+// it as a recognizable prior mydumper/bintrail dump — safe to clear. mydumper
+// writes "metadata" on success and "metadata.partial" while running or after a
+// crash; `bintrail dump` adds its own started-at sidecar.
+var dumpDirMarkers = []string{"metadata", "metadata.partial", baseline.StartedAtMarkerFile}
+
+// looksLikeDumpDir reports whether the directory listing carries any marker that
+// identifies it as a prior mydumper/bintrail dump (#809).
+func looksLikeDumpDir(entries []os.DirEntry) bool {
+	for _, e := range entries {
+		name := e.Name()
+		for _, m := range dumpDirMarkers {
+			if name == m {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// dumpDirPrep records how the output directory was prepared so the caller can
+// commit (delete the moved-aside previous dump) on success or roll back
+// (restore it) on failure. When backup is empty, nothing was moved aside — the
+// directory was absent or already empty — and commit/rollback are no-ops.
+type dumpDirPrep struct {
+	dir    string // the requested --output-dir
+	backup string // where a recognizable prior dump was moved (dir.old), or ""
+}
+
+// prepareDumpOutputDir readies --output-dir for a fresh dump without ever
+// unconditionally deleting it (#809). An absent or empty directory needs no
+// preparation. A non-empty directory that is NOT a recognizable prior dump is
+// REFUSED (no deletion) with an actionable error. A recognizable prior dump is
+// moved aside to dir.old so a failed dump can restore it; commit() deletes the
+// backup only once the new dump succeeds.
+func prepareDumpOutputDir(dir string) (*dumpDirPrep, error) {
+	info, err := os.Stat(dir)
+	if os.IsNotExist(err) {
+		return &dumpDirPrep{dir: dir}, nil // mydumper creates it
+	}
+	if err != nil {
+		return nil, fmt.Errorf("stat --output-dir %q: %w", dir, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("--output-dir %q exists and is not a directory; "+
+			"remove it yourself or point --output-dir elsewhere", dir)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("read --output-dir %q: %w", dir, err)
+	}
+	if len(entries) == 0 {
+		return &dumpDirPrep{dir: dir}, nil // empty: mydumper writes into it
+	}
+	if !looksLikeDumpDir(entries) {
+		return nil, fmt.Errorf("--output-dir %q is not empty and does not look like a prior "+
+			"bintrail/mydumper dump (no %q marker); refusing to delete it. "+
+			"Remove it yourself or point --output-dir elsewhere", dir, dumpDirMarkers[0])
+	}
+	// Recognizable prior dump: move it aside so a failed dump can restore it.
+	backup := filepath.Clean(dir) + ".old"
+	if err := os.RemoveAll(backup); err != nil {
+		return nil, fmt.Errorf("clear stale dump backup %q: %w", backup, err)
+	}
+	if err := os.Rename(dir, backup); err != nil {
+		return nil, fmt.Errorf("move existing dump %q aside to %q: %w", dir, backup, err)
+	}
+	return &dumpDirPrep{dir: dir, backup: backup}, nil
+}
+
+// commit finalizes a successful dump by deleting the moved-aside previous dump.
+// Best-effort: a leftover backup is a warning, not a failure of the dump.
+func (p *dumpDirPrep) commit() {
+	if p == nil || p.backup == "" {
+		return
+	}
+	if err := os.RemoveAll(p.backup); err != nil {
+		slog.Warn("dump succeeded but could not remove the previous dump's backup",
+			"backup", p.backup, "error", err)
+	}
+}
+
+// rollback restores the previous dump after a failed dump: it removes whatever
+// partial output the failed dump left, then renames the backup back into place.
+func (p *dumpDirPrep) rollback() {
+	if p == nil || p.backup == "" {
+		return
+	}
+	if err := os.RemoveAll(p.dir); err != nil {
+		slog.Warn("dump failed; could not remove partial output before restoring the previous dump — "+
+			"it remains at the backup path", "dir", p.dir, "backup", p.backup, "error", err)
+		return
+	}
+	if err := os.Rename(p.backup, p.dir); err != nil {
+		slog.Warn("dump failed; could not restore the previous dump from its backup — "+
+			"it remains at the backup path", "backup", p.backup, "dir", p.dir, "error", err)
+	}
 }
 
 // mydumperVersion runs `<path> --version` and parses the version triple via

--- a/cliapp/dump_test.go
+++ b/cliapp/dump_test.go
@@ -1210,6 +1210,53 @@ func TestPrepareDumpOutputDir_happyPaths(t *testing.T) {
 	})
 }
 
+// TestPrepareDumpOutputDir_preservesFixedDotOldBackup guards the #809 review
+// finding: moving a recognized prior dump aside must NOT delete a pre-existing
+// <dir>.old. The earlier fixed backup name did an unconditional
+// os.RemoveAll(<dir>.old), which would destroy either an operator's own backup
+// kept at that human-conventional suffix, or — in a failed-rollback chain — the
+// only good copy of the previous dump stranded there.
+func TestPrepareDumpOutputDir_preservesFixedDotOldBackup(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "out")
+	if err := os.MkdirAll(out, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(out, "metadata"), []byte("recognized dump"), 0o644); err != nil {
+		t.Fatalf("seed metadata: %v", err)
+	}
+	// A precious tree the user independently keeps at the conventional .old suffix.
+	precious := out + ".old"
+	if err := os.MkdirAll(precious, 0o755); err != nil {
+		t.Fatalf("mkdir precious: %v", err)
+	}
+	preciousFile := filepath.Join(precious, "do-not-delete.txt")
+	if err := os.WriteFile(preciousFile, []byte("keep me"), 0o644); err != nil {
+		t.Fatalf("seed precious: %v", err)
+	}
+
+	prep, err := prepareDumpOutputDir(out)
+	if err != nil {
+		t.Fatalf("prepareDumpOutputDir: %v", err)
+	}
+	// The fixed <dir>.old must be untouched.
+	if got, readErr := os.ReadFile(preciousFile); readErr != nil {
+		t.Fatalf("precious <dir>.old was deleted or altered: %v", readErr)
+	} else if string(got) != "keep me" {
+		t.Errorf("precious <dir>.old content changed = %q, want %q", got, "keep me")
+	}
+	// The backup must be a distinct unique sibling, never the fixed <dir>.old.
+	if prep.backup == precious {
+		t.Fatalf("backup collided with the pre-existing fixed <dir>.old: %q", prep.backup)
+	}
+	if prep.backup == "" {
+		t.Fatal("expected a backup path for a recognized prior dump")
+	}
+	if _, statErr := os.Stat(filepath.Join(prep.backup, "metadata")); statErr != nil {
+		t.Errorf("prior dump not preserved in unique backup: %v", statErr)
+	}
+}
+
 // ─── helpers ─────────────────────────────────────────────────────────────────
 
 // argsContain reports whether args contains the string s.

--- a/cliapp/dump_test.go
+++ b/cliapp/dump_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+
+	"github.com/dbtrail/dbtrail/internal/baseline"
 )
 
 // ─── Cobra command wiring ─────────────────────────────────────────────────────
@@ -576,6 +578,7 @@ exit 1
 	dmpSourceDSN = "root:rootpw@tcp(127.0.0.1:3306)/"
 	dmpOutputDir = filepath.Join(dir, "out")
 	dmpFormat = "text"
+	stubPingSource(t)
 
 	dumpCmd.SetContext(context.Background())
 	err := runDump(dumpCmd, nil)
@@ -1002,6 +1005,7 @@ exit 0
 	dmpSourceDSN = "root:" + pw + "@tcp(127.0.0.1:3306)/"
 	dmpOutputDir = filepath.Join(dir, "out")
 	dmpFormat = "text"
+	stubPingSource(t)
 
 	dumpCmd.SetContext(context.Background())
 	if err := runDump(dumpCmd, nil); err != nil {
@@ -1030,6 +1034,180 @@ exit 0
 	if pwdLine != "MYSQL_PWD="+pw {
 		t.Errorf("password not delivered via MYSQL_PWD env: got %q", pwdLine)
 	}
+}
+
+// ─── #809: destructive-op guard on --output-dir ───────────────────────────────
+
+// stubPingSource replaces the source connectivity check with a no-op for the
+// duration of the test, so end-to-end runDump tests using a fake mydumper do
+// not require a live MySQL on 127.0.0.1:3306.
+func stubPingSource(t *testing.T) {
+	t.Helper()
+	saved := pingSource
+	pingSource = func(string) error { return nil }
+	t.Cleanup(func() { pingSource = saved })
+}
+
+func TestLooksLikeDumpDir(t *testing.T) {
+	cases := []struct {
+		name  string
+		files []string
+		want  bool
+	}{
+		{"metadata", []string{"metadata", "db.t.00000.sql"}, true},
+		{"metadata_partial", []string{"metadata.partial", "db.t-schema.sql"}, true},
+		{"bintrail_marker", []string{baseline.StartedAtMarkerFile}, true},
+		{"only_data_no_marker", []string{"db.t.00000.sql", "db-schema-create.sql"}, false},
+		{"unrelated_tree", []string{"ibdata1", "mysql", "important.txt"}, false},
+		{"empty", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			for _, f := range tc.files {
+				if err := os.WriteFile(filepath.Join(dir, f), []byte("x"), 0o644); err != nil {
+					t.Fatalf("write %s: %v", f, err)
+				}
+			}
+			entries, err := os.ReadDir(dir)
+			if err != nil {
+				t.Fatalf("ReadDir: %v", err)
+			}
+			if got := looksLikeDumpDir(entries); got != tc.want {
+				t.Errorf("looksLikeDumpDir(%v) = %v, want %v", tc.files, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPrepareDumpOutputDir_refusesNonDumpDir is the core #809 guard: a non-empty
+// directory that is not a recognizable prior dump must be REFUSED with nothing
+// deleted — protecting an arbitrary tree hit by a typo'd --output-dir.
+func TestPrepareDumpOutputDir_refusesNonDumpDir(t *testing.T) {
+	dir := t.TempDir()
+	precious := filepath.Join(dir, "important.txt")
+	if err := os.WriteFile(precious, []byte("do not delete"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	prep, err := prepareDumpOutputDir(dir)
+	if err == nil {
+		t.Fatal("expected refusal for a non-dump non-empty directory, got nil")
+	}
+	if prep != nil {
+		t.Errorf("expected nil prep on refusal, got %+v", prep)
+	}
+	if !strings.Contains(err.Error(), "refusing to delete") {
+		t.Errorf("error should tell the user we refuse to delete, got: %v", err)
+	}
+	// Nothing was deleted.
+	if _, statErr := os.Stat(precious); statErr != nil {
+		t.Errorf("guard deleted a non-dump directory's contents: %v", statErr)
+	}
+}
+
+// TestPrepareDumpOutputDir_movesRecognizedDump verifies a recognizable prior
+// dump is moved aside (not deleted), and that commit deletes the backup while
+// rollback restores it.
+func TestPrepareDumpOutputDir_movesRecognizedDump(t *testing.T) {
+	t.Run("commit_deletes_backup", func(t *testing.T) {
+		dir := t.TempDir()
+		out := filepath.Join(dir, "out")
+		if err := os.MkdirAll(out, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(out, "metadata"), []byte("old"), 0o644); err != nil {
+			t.Fatalf("seed metadata: %v", err)
+		}
+
+		prep, err := prepareDumpOutputDir(out)
+		if err != nil {
+			t.Fatalf("prepareDumpOutputDir: %v", err)
+		}
+		if prep.backup == "" {
+			t.Fatal("expected a backup path for a recognized prior dump")
+		}
+		// The prior dump was moved aside, not deleted.
+		if _, statErr := os.Stat(filepath.Join(prep.backup, "metadata")); statErr != nil {
+			t.Errorf("prior dump not preserved in backup: %v", statErr)
+		}
+		if _, statErr := os.Stat(out); !os.IsNotExist(statErr) {
+			t.Errorf("expected original dir moved away, stat err = %v", statErr)
+		}
+
+		// Simulate a fresh successful dump, then commit.
+		if err := os.MkdirAll(out, 0o755); err != nil {
+			t.Fatalf("recreate out: %v", err)
+		}
+		prep.commit()
+		if _, statErr := os.Stat(prep.backup); !os.IsNotExist(statErr) {
+			t.Errorf("commit should have removed the backup, stat err = %v", statErr)
+		}
+	})
+
+	t.Run("rollback_restores_previous_dump", func(t *testing.T) {
+		dir := t.TempDir()
+		out := filepath.Join(dir, "out")
+		if err := os.MkdirAll(out, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(out, "metadata"), []byte("old-good"), 0o644); err != nil {
+			t.Fatalf("seed metadata: %v", err)
+		}
+
+		prep, err := prepareDumpOutputDir(out)
+		if err != nil {
+			t.Fatalf("prepareDumpOutputDir: %v", err)
+		}
+		// Simulate a failed dump that left partial output.
+		if err := os.MkdirAll(out, 0o755); err != nil {
+			t.Fatalf("recreate out: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(out, "metadata.partial"), []byte("junk"), 0o644); err != nil {
+			t.Fatalf("seed partial: %v", err)
+		}
+		prep.rollback()
+
+		// The previous good dump is back, and the backup is gone.
+		got, readErr := os.ReadFile(filepath.Join(out, "metadata"))
+		if readErr != nil {
+			t.Fatalf("previous dump not restored: %v", readErr)
+		}
+		if string(got) != "old-good" {
+			t.Errorf("restored metadata = %q, want %q", got, "old-good")
+		}
+		if _, statErr := os.Stat(filepath.Join(out, "metadata.partial")); !os.IsNotExist(statErr) {
+			t.Errorf("partial output should have been discarded, stat err = %v", statErr)
+		}
+		if _, statErr := os.Stat(prep.backup); !os.IsNotExist(statErr) {
+			t.Errorf("backup should be consumed by rollback, stat err = %v", statErr)
+		}
+	})
+}
+
+// TestPrepareDumpOutputDir_happyPaths verifies the non-destructive fast paths:
+// an absent or empty directory needs no preparation and yields no backup.
+func TestPrepareDumpOutputDir_happyPaths(t *testing.T) {
+	t.Run("absent", func(t *testing.T) {
+		out := filepath.Join(t.TempDir(), "does-not-exist")
+		prep, err := prepareDumpOutputDir(out)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if prep.backup != "" {
+			t.Errorf("expected no backup for an absent dir, got %q", prep.backup)
+		}
+	})
+	t.Run("empty", func(t *testing.T) {
+		out := t.TempDir() // exists and empty
+		prep, err := prepareDumpOutputDir(out)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if prep.backup != "" {
+			t.Errorf("expected no backup for an empty dir, got %q", prep.backup)
+		}
+	})
 }
 
 // ─── helpers ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

`bintrail dump` ran `os.RemoveAll(--output-dir)` **unconditionally** before mydumper validated anything:

- A typo (`--output-dir /var/lib/mysql`) or a stray `BINTRAIL_OUTPUT_DIR` in a sibling `.bintrail.env` destroyed an arbitrary tree with the user's permissions — including baselines that `reconstruct`/`verify` depend on.
- The `RemoveAll` ran **before** connectivity was checked, so a dump that then failed to connect had already wiped the previous (only-good) dump.

## Fix

Purely additive destructive-op safety guard in `runDump` (`cliapp/dump.go`):

- **Validate source connectivity before the output directory is touched.** Injectable via a `pingSource` package var (mirrors the existing `dumpLockDir` seam) so unit tests need no live server. The DSN's default database is stripped to mirror mydumper's server-level connect (it derives the dump set from `--database`/`--regex`/`--tables-list`, not the DSN schema), avoiding a false negative on a DSN whose default DB the user cannot `USE`.
- **Refuse to delete a non-empty `--output-dir` that is not a recognizable prior dump** — no `metadata` / `metadata.partial` / bintrail started-at marker → clear, actionable error ("refusing to delete it. Remove it yourself or point `--output-dir` elsewhere").
- **Move-then-delete-on-success** for a recognized prior dump: rename `dir` → `dir.old`, run the dump, delete `dir.old` only on success and restore it on failure (via a deferred `commit`/`rollback` keyed on a `dumpSucceeded` flag).

Happy paths (absent dir, empty dir, or a recognizable prior dump) are unchanged.

## Test

New unit tests in `cliapp/dump_test.go`:

- `TestLooksLikeDumpDir` — table-driven marker detection (metadata / metadata.partial / bintrail marker → yes; only-data and unrelated trees → no).
- `TestPrepareDumpOutputDir_refusesNonDumpDir` — non-dump non-empty dir is refused and nothing is deleted.
- `TestPrepareDumpOutputDir_movesRecognizedDump` — recognized dump is moved aside; `commit` deletes the backup, `rollback` restores the previous dump and discards partial output.
- `TestPrepareDumpOutputDir_happyPaths` — absent / empty dir yields no backup.

The two existing end-to-end `runDump` tests stub `pingSource` (fake-mydumper, no live server). Full `cliapp` unit suite + `go vet` pass.

Closes #809
