### PR TITLE
pg: capture TRUNCATE as a durable schema_changes audit + reconstruct refusal (#827)

### DIFF
--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -529,12 +529,15 @@ your own round-trip.
   if the child table is published**. If a published parent has an unpublished
   cascade child, the cascade rewrites are not captured — bintrail-pg warns (startup
   + doctor); add the child to the publication.
-- **`TRUNCATE` is not captured at all — not even as an audit trail.** Unlike
-  MySQL's DDL, which lands a `schema_changes` row bintrail can at least warn
-  about, a PostgreSQL `TRUNCATE` produces only a transient `Warn` log line at
-  capture time ("TRUNCATE not indexed") and nothing persisted. There is
-  nothing for `recover` to put back, and — unlike the MySQL path — no durable
-  record that the truncate happened at all.
+- **`TRUNCATE` is captured as an audit record, not as reversible row events.** A
+  PostgreSQL `TRUNCATE` lands a durable `schema_changes` row (one per truncated
+  table, `ddl_type = 'TRUNCATE TABLE'`) — the same audit trail MySQL's DDL gets.
+  It is visible via `list_schema_changes` (MCP) and `bintrail status`, and
+  reconstruct / baseline-anchored `verify` **refuse to cross it** rather than
+  silently resurrecting the truncated rows from an older baseline. It is *not*
+  replayed as row-level events, so `recover` has nothing to put back for the
+  truncated rows themselves — restore those from a baseline taken before the
+  truncate.
 - **Sequence cursors are not captured.** The materialized id values in your rows
   *are* captured; the sequence's own `last_value` (a separate catalog object) is
   not — logical decoding does not replicate sequences. After a restore, re-point

--- a/internal/pgcapture/capturer.go
+++ b/internal/pgcapture/capturer.go
@@ -264,12 +264,14 @@ func (c *Capturer) receiveLoop(ctx context.Context, replConn *pgconn.PgConn, dec
 				// A malformed logical message is stream desync, not noise — fail loud.
 				return fmt.Errorf("pgcapture: parse logical message at %s: %w", xld.WALStart, err)
 			}
-			ev, emit, err := decoder.Decode(logmsg)
+			evs, err := decoder.Decode(logmsg)
 			if err != nil {
 				return err
 			}
-			if emit {
-				if err := c.emit(ctx, replConn, out, ev, standbyTicker); err != nil {
+			// One message can yield several events (a TRUNCATE of multiple tables
+			// emits one EventDDL per in-scope relation); emit them in order.
+			for i := range evs {
+				if err := c.emit(ctx, replConn, out, evs[i], standbyTicker); err != nil {
 					return err
 				}
 			}

--- a/internal/pgcapture/decoder.go
+++ b/internal/pgcapture/decoder.go
@@ -98,24 +98,27 @@ func NewDecoder(resolvePK PKResolver, filters event.Filters, logger *slog.Logger
 	return d
 }
 
-// Decode processes one pgoutput message. It returns:
-//   - (event, true, nil) when the message produces a row or commit event;
-//   - (zero, false, nil) when the message is consumed for internal state only
-//     (Begin/Relation) or is deliberately not indexed (Truncate/Type/Origin);
-//   - (zero, false, err) on a decode-invariant violation (unknown relation, a row
-//     outside a transaction, a binary tuple datum, a tuple column-count mismatch,
-//     or a primary-key lookup failure). The caller must treat a non-nil error as
-//     fatal — never skip the message and continue, or the stream desynchronizes.
-func (d *Decoder) Decode(msg pglogrepl.Message) (event.Event, bool, error) {
+// Decode processes one pgoutput message and returns the source-neutral events it
+// produces, in order:
+//   - a one-element slice for a row, commit, or relation event;
+//   - a MULTI-element slice for a TRUNCATE of several tables — one EventDDL per
+//     in-scope truncated relation (schema_changes is one row per table);
+//   - an empty (nil) slice when the message is consumed for internal state only
+//     (Begin), carries no row data (Type/Origin), or is a filtered-out relation;
+//   - (nil, err) on a decode-invariant violation (unknown relation, a row outside
+//     a transaction, a binary tuple datum, a tuple column-count mismatch, or a
+//     primary-key lookup failure). The caller must treat a non-nil error as fatal
+//     — never skip the message and continue, or the stream desynchronizes.
+func (d *Decoder) Decode(msg pglogrepl.Message) ([]event.Event, error) {
 	switch m := msg.(type) {
 	case *pglogrepl.BeginMessage:
 		// FinalLSN is the transaction's commit LSN; CommitTime its commit timestamp.
 		d.txn = txnContext{commitLSN: m.FinalLSN, commitTime: m.CommitTime, open: true}
-		return event.Event{}, false, nil
+		return nil, nil
 
 	case *pglogrepl.RelationMessage:
 		if err := d.cacheRelation(m); err != nil {
-			return event.Event{}, false, err
+			return nil, err
 		}
 		// Emit a schema snapshot for the consumer to persist (#533), but only for an
 		// in-scope relation: cacheRelation caches EVERY relation so row decoding can
@@ -123,9 +126,9 @@ func (d *Decoder) Decode(msg pglogrepl.Message) (event.Event, bool, error) {
 		// stamp a SchemaVersion. Gate the EMIT, not the cache.
 		rel := d.relations[m.RelationID]
 		if !d.filters.Matches(rel.schema, rel.table) {
-			return event.Event{}, false, nil
+			return nil, nil
 		}
-		return relationEvent(rel), true, nil
+		return []event.Event{relationEvent(rel)}, nil
 
 	case *pglogrepl.InsertMessage:
 		return d.decodeInsert(m)
@@ -148,20 +151,15 @@ func (d *Decoder) Decode(msg pglogrepl.Message) (event.Event, bool, error) {
 			EventType:  event.EventCommit,
 		}
 		d.txn = txnContext{}
-		return ev, true, nil
+		return []event.Event{ev}, nil
 
 	case *pglogrepl.TruncateMessage:
-		// DDL replay on the PostgreSQL path is out of #530 scope; surface a TRUNCATE
-		// loudly so it is never silently invisible in the index. (Open question:
-		// map to EventDDL/DDLTruncateTable later.)
-		d.logger.Warn("pgcapture: TRUNCATE not indexed (DDL replay out of scope)",
-			"relations", len(m.RelationIDs))
-		return event.Event{}, false, nil
+		return d.decodeTruncate(m)
 
 	case *pglogrepl.TypeMessage, *pglogrepl.OriginMessage:
 		// No row data. Type/Origin are not needed for capture fidelity under
 		// proto_version 1 (column names + text values arrive regardless).
-		return event.Event{}, false, nil
+		return nil, nil
 
 	default:
 		// The slice-2 capturer requests proto_version 1, which emits no in-progress-
@@ -170,8 +168,52 @@ func (d *Decoder) Decode(msg pglogrepl.Message) (event.Event, bool, error) {
 		// future bump to proto v2 would route real row-bearing stream messages here —
 		// revisit this branch before negotiating v2.
 		d.logger.Debug("pgcapture: ignoring unhandled message", "type", fmt.Sprintf("%T", msg))
-		return event.Event{}, false, nil
+		return nil, nil
 	}
+}
+
+// decodeTruncate turns a pgoutput TRUNCATE into one EventDDL per in-scope
+// truncated relation, so the destructive DDL lands a durable schema_changes
+// audit row (queryable via list_schema_changes / status) and reconstruct /
+// baseline-anchored verify REFUSE to cross it (reconstruct.CheckDestructiveDDL)
+// instead of silently resurrecting the truncated rows from a baseline. This
+// mirrors the MySQL parser, which records TRUNCATE as an EventDDL /
+// DDLTruncateTable audit entry (parser.parseDDL) — no row-level events to
+// replay, but a durable, queryable record that the truncate happened.
+//
+// A `TRUNCATE a, b, c` carries several relation OIDs, so this returns one event
+// per in-scope table (CheckDestructiveDDL matches by schema_name/table_name).
+// Out-of-scope relations — published but excluded by --schemas/--tables — are
+// skipped, exactly like row events. An unknown OID is a protocol-invariant
+// violation (pgoutput emits a Relation message before a relation's first change,
+// TRUNCATE included) and fails loud via relationFor, which also enforces that a
+// TRUNCATE arrives inside an open transaction so its events carry the commit
+// timestamp (the correct event_timestamp for partitioning).
+func (d *Decoder) decodeTruncate(m *pglogrepl.TruncateMessage) ([]event.Event, error) {
+	var evs []event.Event
+	for _, oid := range m.RelationIDs {
+		rel, err := d.relationFor(oid)
+		if err != nil {
+			return nil, err
+		}
+		if !d.filters.Matches(rel.schema, rel.table) {
+			continue
+		}
+		lsn := d.txn.commitLSN.String()
+		evs = append(evs, event.Event{
+			BinlogFile: lsn,
+			StartPos:   uint64(d.txn.commitLSN),
+			EndPos:     uint64(d.txn.commitLSN),
+			Timestamp:  d.txn.commitTime,
+			GTID:       lsn,
+			Schema:     rel.schema,
+			Table:      rel.table,
+			EventType:  event.EventDDL,
+			DDLType:    event.DDLTruncateTable,
+			DDLQuery:   fmt.Sprintf("TRUNCATE TABLE %s.%s", rel.schema, rel.table),
+		})
+	}
+	return evs, nil
 }
 
 // cacheRelation records (or refreshes) a relation's columns + primary key. PG emits
@@ -324,30 +366,30 @@ func relationEvent(rel *relationInfo) event.Event {
 	}
 }
 
-func (d *Decoder) decodeInsert(m *pglogrepl.InsertMessage) (event.Event, bool, error) {
+func (d *Decoder) decodeInsert(m *pglogrepl.InsertMessage) ([]event.Event, error) {
 	rel, err := d.relationFor(m.RelationID)
 	if err != nil {
-		return event.Event{}, false, err
+		return nil, err
 	}
 	if !d.filters.Matches(rel.schema, rel.table) {
-		return event.Event{}, false, nil
+		return nil, nil
 	}
 	// INSERT carries only a new tuple, fully written — pgoutput never emits 'u' in
 	// an INSERT, so there is no before-image to resolve from.
 	after, err := d.decodeTuple(rel, m.Tuple, roleAfter, nil)
 	if err != nil {
-		return event.Event{}, false, err
+		return nil, err
 	}
-	return d.rowEvent(rel, event.EventInsert, nil, after), true, nil
+	return []event.Event{d.rowEvent(rel, event.EventInsert, nil, after)}, nil
 }
 
-func (d *Decoder) decodeUpdate(m *pglogrepl.UpdateMessage) (event.Event, bool, error) {
+func (d *Decoder) decodeUpdate(m *pglogrepl.UpdateMessage) ([]event.Event, error) {
 	rel, err := d.relationFor(m.RelationID)
 	if err != nil {
-		return event.Event{}, false, err
+		return nil, err
 	}
 	if !d.filters.Matches(rel.schema, rel.table) {
-		return event.Event{}, false, nil
+		return nil, nil
 	}
 	// OldTuple is the full old tuple ('O') under REPLICA IDENTITY FULL, a key-only
 	// tuple ('K') when a replica-identity column changed under a weaker identity, or
@@ -359,7 +401,7 @@ func (d *Decoder) decodeUpdate(m *pglogrepl.UpdateMessage) (event.Event, bool, e
 	if m.OldTuple != nil {
 		before, err = d.decodeTuple(rel, m.OldTuple, roleBefore, nil)
 		if err != nil {
-			return event.Event{}, false, err
+			return nil, err
 		}
 	}
 	// Resolve any 'u' in the new tuple from the before-image (Option B): under RI
@@ -368,18 +410,18 @@ func (d *Decoder) decodeUpdate(m *pglogrepl.UpdateMessage) (event.Event, bool, e
 	// changed_columns correct and needing zero downstream handling.
 	after, err := d.decodeTuple(rel, m.NewTuple, roleAfter, before)
 	if err != nil {
-		return event.Event{}, false, err
+		return nil, err
 	}
-	return d.rowEvent(rel, event.EventUpdate, before, after), true, nil
+	return []event.Event{d.rowEvent(rel, event.EventUpdate, before, after)}, nil
 }
 
-func (d *Decoder) decodeDelete(m *pglogrepl.DeleteMessage) (event.Event, bool, error) {
+func (d *Decoder) decodeDelete(m *pglogrepl.DeleteMessage) ([]event.Event, error) {
 	rel, err := d.relationFor(m.RelationID)
 	if err != nil {
-		return event.Event{}, false, err
+		return nil, err
 	}
 	if !d.filters.Matches(rel.schema, rel.table) {
-		return event.Event{}, false, nil
+		return nil, nil
 	}
 	// A DELETE's before-image is the ONLY source for its reversal INSERT. pgoutput
 	// always sends an old tuple for a DELETE (its decode requires 'K' or 'O'), and a
@@ -387,26 +429,27 @@ func (d *Decoder) decodeDelete(m *pglogrepl.DeleteMessage) (event.Event, bool, e
 	// replication at all — so a missing old tuple is a broken invariant, not a
 	// supported case: fail loud rather than index an un-keyed, un-reversible row.
 	if m.OldTuple == nil {
-		return event.Event{}, false, fmt.Errorf("pgcapture: DELETE on %s.%s carries no before-image (no replica identity?) — cannot index an un-reversible delete", rel.schema, rel.table)
+		return nil, fmt.Errorf("pgcapture: DELETE on %s.%s carries no before-image (no replica identity?) — cannot index an un-reversible delete", rel.schema, rel.table)
 	}
 	before, err := d.decodeTuple(rel, m.OldTuple, roleBefore, nil)
 	if err != nil {
-		return event.Event{}, false, err
+		return nil, err
 	}
-	return d.rowEvent(rel, event.EventDelete, before, nil), true, nil
+	return []event.Event{d.rowEvent(rel, event.EventDelete, before, nil)}, nil
 }
 
-// relationFor returns the cached relation for a row message, erroring if no
-// RelationMessage preceded it (a protocol invariant) or if no transaction is open
-// (a row must arrive between Begin and Commit; without an open txn the event would
-// get a zero commit timestamp and land in the wrong partition).
+// relationFor returns the cached relation for a change message (a row event or a
+// TRUNCATE), erroring if no RelationMessage preceded it (a protocol invariant) or
+// if no transaction is open (a change must arrive between Begin and Commit;
+// without an open txn the event would get a zero commit timestamp and land in the
+// wrong partition).
 func (d *Decoder) relationFor(oid uint32) (*relationInfo, error) {
 	if !d.txn.open {
-		return nil, fmt.Errorf("pgcapture: row event for relation OID %d outside a transaction (no preceding Begin)", oid)
+		return nil, fmt.Errorf("pgcapture: change for relation OID %d outside a transaction (no preceding Begin)", oid)
 	}
 	rel, ok := d.relations[oid]
 	if !ok {
-		return nil, fmt.Errorf("pgcapture: row event for unknown relation OID %d (no preceding Relation message)", oid)
+		return nil, fmt.Errorf("pgcapture: change for unknown relation OID %d (no preceding Relation message)", oid)
 	}
 	return rel, nil
 }

--- a/internal/pgcapture/decoder_test.go
+++ b/internal/pgcapture/decoder_test.go
@@ -70,11 +70,17 @@ func pkResolver(pkNames ...string) pgcapture.PKResolver {
 
 func mustDecode(t *testing.T, d *pgcapture.Decoder, msg pglogrepl.Message) (event.Event, bool) {
 	t.Helper()
-	ev, emit, err := d.Decode(msg)
+	evs, err := d.Decode(msg)
 	if err != nil {
 		t.Fatalf("Decode(%T): unexpected error: %v", msg, err)
 	}
-	return ev, emit
+	if len(evs) == 0 {
+		return event.Event{}, false
+	}
+	if len(evs) > 1 {
+		t.Fatalf("Decode(%T): mustDecode expects at most one event, got %d — use Decode directly for multi-event messages (TRUNCATE)", msg, len(evs))
+	}
+	return evs[0], true
 }
 
 // ─── happy-path decoding ──────────────────────────────────────────────────────
@@ -155,7 +161,7 @@ func TestDecode_Commit(t *testing.T) {
 	}
 
 	// After Commit the transaction is closed: a row without a fresh Begin must fail.
-	_, _, err := d.Decode(&pglogrepl.InsertMessage{RelationID: 1, Tuple: tuple(textCol("1"))})
+	_, err := d.Decode(&pglogrepl.InsertMessage{RelationID: 1, Tuple: tuple(textCol("1"))})
 	if err == nil {
 		t.Error("expected error for row event after Commit closed the transaction")
 	}
@@ -306,7 +312,7 @@ func TestDecode_BinaryDatumFailsLoud(t *testing.T) {
 	mustDecode(t, d, relMsg(1, "public", "t", "id", "v"))
 	mustDecode(t, d, beginMsg())
 
-	_, _, err := d.Decode(&pglogrepl.InsertMessage{
+	_, err := d.Decode(&pglogrepl.InsertMessage{
 		RelationID: 1, Tuple: tuple(textCol("1"), binaryCol([]byte{0x00, 0x01})),
 	})
 	if err == nil {
@@ -317,7 +323,7 @@ func TestDecode_BinaryDatumFailsLoud(t *testing.T) {
 func TestDecode_UnknownRelationFailsLoud(t *testing.T) {
 	d := pgcapture.NewDecoder(pkResolver("id"), event.Filters{}, nil)
 	mustDecode(t, d, beginMsg())
-	_, _, err := d.Decode(&pglogrepl.InsertMessage{RelationID: 99, Tuple: tuple(textCol("1"))})
+	_, err := d.Decode(&pglogrepl.InsertMessage{RelationID: 99, Tuple: tuple(textCol("1"))})
 	if err == nil {
 		t.Error("expected error for a row event referencing an unknown relation OID")
 	}
@@ -327,7 +333,7 @@ func TestDecode_RowOutsideTransactionFailsLoud(t *testing.T) {
 	d := pgcapture.NewDecoder(pkResolver("id"), event.Filters{}, nil)
 	mustDecode(t, d, relMsg(1, "public", "t", "id"))
 	// No Begin → no commit timestamp → would land in the wrong partition.
-	_, _, err := d.Decode(&pglogrepl.InsertMessage{RelationID: 1, Tuple: tuple(textCol("1"))})
+	_, err := d.Decode(&pglogrepl.InsertMessage{RelationID: 1, Tuple: tuple(textCol("1"))})
 	if err == nil {
 		t.Error("expected error for a row event outside a transaction")
 	}
@@ -337,7 +343,7 @@ func TestDecode_PKColumnDriftFailsLoud(t *testing.T) {
 	// The catalog reports a PK column absent from the relation's in-band columns
 	// (schema drift during stream lag) → fail loud rather than build a wrong PK.
 	d := pgcapture.NewDecoder(pkResolver("ghost"), event.Filters{}, nil)
-	_, _, err := d.Decode(relMsg(1, "public", "t", "id", "v"))
+	_, err := d.Decode(relMsg(1, "public", "t", "id", "v"))
 	if err == nil {
 		t.Error("expected error when a PK column is absent from the relation columns")
 	}
@@ -351,7 +357,7 @@ func TestDecode_NonFullReplicaIdentityRelationFailsLoud(t *testing.T) {
 	d := pgcapture.NewDecoder(pkResolver("id"), event.Filters{}, nil)
 	rel := relMsg(1, "public", "t", "id", "v")
 	rel.ReplicaIdentity = 'd' // default, not FULL
-	_, _, err := d.Decode(rel)
+	_, err := d.Decode(rel)
 	if err == nil {
 		t.Fatal("expected error for a relation not at REPLICA IDENTITY FULL")
 	}
@@ -365,7 +371,7 @@ func TestDecode_PKResolverErrorFailsLoud(t *testing.T) {
 		return nil, errBoom
 	})
 	d := pgcapture.NewDecoder(boom, event.Filters{}, nil)
-	_, _, err := d.Decode(relMsg(1, "public", "t", "id"))
+	_, err := d.Decode(relMsg(1, "public", "t", "id"))
 	if err == nil {
 		t.Error("expected error to propagate from a failing PKResolver (no silent empty PK)")
 	}
@@ -377,7 +383,7 @@ func TestDecode_ColumnCountMismatchFailsLoud(t *testing.T) {
 	d := pgcapture.NewDecoder(pkResolver("id"), event.Filters{}, nil)
 	mustDecode(t, d, relMsg(1, "public", "t", "id", "v")) // 2 columns
 	mustDecode(t, d, beginMsg())
-	_, _, err := d.Decode(&pglogrepl.InsertMessage{
+	_, err := d.Decode(&pglogrepl.InsertMessage{
 		RelationID: 1, Tuple: tuple(textCol("1")), // 1 column
 	})
 	if err == nil {
@@ -393,7 +399,7 @@ func TestDecode_UnchangedToastInUpdateBeforeImageFailsLoud(t *testing.T) {
 	d := pgcapture.NewDecoder(pkResolver("id"), event.Filters{}, nil)
 	mustDecode(t, d, relMsg(1, "public", "t", "id", "body"))
 	mustDecode(t, d, beginMsg())
-	_, _, err := d.Decode(&pglogrepl.UpdateMessage{
+	_, err := d.Decode(&pglogrepl.UpdateMessage{
 		RelationID:   1,
 		OldTupleType: pglogrepl.UpdateMessageTupleTypeOld,
 		OldTuple:     tuple(textCol("1"), toastCol()), // 'u' in the BEFORE image
@@ -408,7 +414,7 @@ func TestDecode_UnchangedToastInDeleteBeforeImageFailsLoud(t *testing.T) {
 	d := pgcapture.NewDecoder(pkResolver("id"), event.Filters{}, nil)
 	mustDecode(t, d, relMsg(1, "public", "t", "id", "body"))
 	mustDecode(t, d, beginMsg())
-	_, _, err := d.Decode(&pglogrepl.DeleteMessage{
+	_, err := d.Decode(&pglogrepl.DeleteMessage{
 		RelationID:   1,
 		OldTupleType: pglogrepl.DeleteMessageTupleTypeOld,
 		OldTuple:     tuple(textCol("1"), toastCol()), // 'u' in the DELETE before-image
@@ -424,22 +430,101 @@ func TestDecode_DeleteWithoutBeforeImageFailsLoud(t *testing.T) {
 	d := pgcapture.NewDecoder(pkResolver("id"), event.Filters{}, nil)
 	mustDecode(t, d, relMsg(1, "public", "t", "id"))
 	mustDecode(t, d, beginMsg())
-	_, _, err := d.Decode(&pglogrepl.DeleteMessage{RelationID: 1, OldTuple: nil})
+	_, err := d.Decode(&pglogrepl.DeleteMessage{RelationID: 1, OldTuple: nil})
 	if err == nil {
 		t.Error("expected fail-loud error for a DELETE carrying no before-image")
 	}
 }
 
-func TestDecode_TruncateNotIndexed(t *testing.T) {
-	// TRUNCATE has a real behavioral contract: it must be surfaced (warned) but
-	// NEVER indexed as a row event (DDL replay on the PG path is out of #530 scope).
+func TestDecode_TruncateIndexedAsDDL(t *testing.T) {
+	// TRUNCATE is now captured as a durable schema_changes audit entry (#827):
+	// one EventDDL / DDLTruncateTable per truncated table, stamped with the
+	// transaction's commit coordinates, so reconstruct/verify refuse to cross it.
 	d := pgcapture.NewDecoder(pkResolver("id"), event.Filters{}, nil)
-	_, emit, err := d.Decode(&pglogrepl.TruncateMessage{RelationNum: 1, RelationIDs: []uint32{1}})
+	mustDecode(t, d, relMsg(1, "public", "t", "id"))
+	mustDecode(t, d, beginMsg())
+
+	evs, err := d.Decode(&pglogrepl.TruncateMessage{RelationNum: 1, RelationIDs: []uint32{1}})
 	if err != nil {
 		t.Fatalf("TRUNCATE: unexpected error: %v", err)
 	}
-	if emit {
-		t.Error("TRUNCATE must not be indexed (DDL replay out of #530 scope) — emit should be false")
+	if len(evs) != 1 {
+		t.Fatalf("TRUNCATE of one table must emit exactly one event, got %d", len(evs))
+	}
+	ev := evs[0]
+	if ev.EventType != event.EventDDL {
+		t.Errorf("EventType = %v, want EventDDL", ev.EventType)
+	}
+	if ev.DDLType != event.DDLTruncateTable {
+		t.Errorf("DDLType = %q, want %q", ev.DDLType, event.DDLTruncateTable)
+	}
+	if ev.Schema != "public" || ev.Table != "t" {
+		t.Errorf("schema.table = %s.%s, want public.t", ev.Schema, ev.Table)
+	}
+	if ev.DDLQuery != "TRUNCATE TABLE public.t" {
+		t.Errorf("DDLQuery = %q, want %q", ev.DDLQuery, "TRUNCATE TABLE public.t")
+	}
+	if !ev.Timestamp.Equal(txnTime) {
+		t.Errorf("Timestamp = %s, want the commit time %s", ev.Timestamp, txnTime)
+	}
+	if ev.GTID != txnLSN.String() || ev.EndPos != uint64(txnLSN) {
+		t.Errorf("commit coords = GTID %q / EndPos %d, want %q / %d", ev.GTID, ev.EndPos, txnLSN.String(), uint64(txnLSN))
+	}
+}
+
+func TestDecode_TruncateMultiTable(t *testing.T) {
+	// TRUNCATE a, b carries several relation OIDs; each in-scope one gets its own
+	// event (schema_changes is one row per table), in the order pgoutput lists them.
+	d := pgcapture.NewDecoder(pkResolver("id"), event.Filters{}, nil)
+	mustDecode(t, d, relMsg(1, "public", "a", "id"))
+	mustDecode(t, d, relMsg(2, "public", "b", "id"))
+	mustDecode(t, d, beginMsg())
+
+	evs, err := d.Decode(&pglogrepl.TruncateMessage{RelationNum: 2, RelationIDs: []uint32{1, 2}})
+	if err != nil {
+		t.Fatalf("TRUNCATE multi: unexpected error: %v", err)
+	}
+	if len(evs) != 2 {
+		t.Fatalf("TRUNCATE of two tables must emit two events, got %d", len(evs))
+	}
+	if evs[0].Table != "a" || evs[1].Table != "b" {
+		t.Errorf("tables/order = %q,%q, want a,b", evs[0].Table, evs[1].Table)
+	}
+	for _, ev := range evs {
+		if ev.EventType != event.EventDDL || ev.DDLType != event.DDLTruncateTable {
+			t.Errorf("event %s.%s not an EventDDL/TRUNCATE: %+v", ev.Schema, ev.Table, ev)
+		}
+	}
+}
+
+func TestDecode_TruncateSkipsOutOfScope(t *testing.T) {
+	// A published-but-filtered-out table (excluded by --tables) is cached so its
+	// OID resolves, but must NOT produce a truncate audit event — exactly like row
+	// events skip it.
+	d := pgcapture.NewDecoder(pkResolver("id"),
+		event.Filters{Tables: map[string]bool{"public.a": true}}, nil)
+	mustDecode(t, d, relMsg(1, "public", "a", "id"))
+	mustDecode(t, d, relMsg(2, "public", "b", "id")) // cached (any OID resolvable), filtered out of emit
+	mustDecode(t, d, beginMsg())
+
+	evs, err := d.Decode(&pglogrepl.TruncateMessage{RelationNum: 2, RelationIDs: []uint32{1, 2}})
+	if err != nil {
+		t.Fatalf("TRUNCATE mixed-scope: unexpected error: %v", err)
+	}
+	if len(evs) != 1 || evs[0].Table != "a" {
+		t.Fatalf("only the in-scope table should emit; got %d events %+v", len(evs), evs)
+	}
+}
+
+func TestDecode_TruncateUnknownRelationFailsLoud(t *testing.T) {
+	// An OID with no preceding RelationMessage is a protocol-invariant violation —
+	// pgoutput emits a Relation before a relation's first change, TRUNCATE included.
+	// Fail loud like relationFor rather than silently drop a destructive DDL.
+	d := pgcapture.NewDecoder(pkResolver("id"), event.Filters{}, nil)
+	mustDecode(t, d, beginMsg())
+	_, err := d.Decode(&pglogrepl.TruncateMessage{RelationNum: 1, RelationIDs: []uint32{99}})
+	if err == nil {
+		t.Error("expected fail-loud error for a TRUNCATE of an unknown relation OID")
 	}
 }
 
@@ -652,7 +737,7 @@ func TestDecode_AttrResolverErrorFailsLoud(t *testing.T) {
 		pgcapture.WithAttrResolver(func(_ uint32, _, _ string) (map[string]pgcapture.ColumnAttrs, error) {
 			return nil, errBoom
 		}))
-	_, _, err := d.Decode(relMsg(1, "public", "t", "id", "v"))
+	_, err := d.Decode(relMsg(1, "public", "t", "id", "v"))
 	if err == nil {
 		t.Fatal("expected a loud error when the AttrResolver fails")
 	}
@@ -763,7 +848,7 @@ func TestDecode_TimescaleChunk_WarnsBeforeReplicaIdentityAbort(t *testing.T) {
 
 	rel := relMsg(10, "_timescaledb_internal", "_hyper_1_1_chunk", "ts", "v")
 	rel.ReplicaIdentity = 'd' // NOT full → cacheRelation will abort
-	_, _, err := d.Decode(rel)
+	_, err := d.Decode(rel)
 	if err == nil {
 		t.Fatal("expected a REPLICA IDENTITY FULL error for a non-FULL chunk relation")
 	}

--- a/internal/pgstreamrun/pgstreamrun.go
+++ b/internal/pgstreamrun/pgstreamrun.go
@@ -444,10 +444,30 @@ func streamLoopPG(
 				// batch (pgoutput delivers them before the commit).
 				lastCommitLSN = ev.EndPos
 			case event.EventDDL:
+				// A destructive DDL on the PG path (today: TRUNCATE). Flush any
+				// batched rows that precede it so they are durable first, then
+				// persist a schema_changes audit row so the DDL is visible
+				// (list_schema_changes / status) and reconstruct + baseline-anchored
+				// verify REFUSE to cross it (reconstruct.CheckDestructiveDDL) instead
+				// of silently resurrecting the truncated rows from a baseline.
+				// snapshotID=nil: a TRUNCATE does not invalidate the schema snapshot
+				// (mirrors the MySQL consumer, streamrun.go). Its own txn, like the
+				// EventRelation snapshot write above — a crash before the next
+				// checkpoint re-delivers and re-inserts a benign duplicate audit row.
+				//
+				// The cursor is NOT advanced here: a TRUNCATE arrives inside its
+				// transaction, BEFORE the CommitMessage, and its EndPos is that txn's
+				// (not-yet-seen) commit LSN. Advancing lastCommitLSN now would let a
+				// ticker checkpoint ack that LSN to PostgreSQL (releasing WAL) while
+				// rows AFTER the truncate in the same transaction are still incoming —
+				// a crash would then lose them. The EventCommit that closes the txn
+				// advances the cursor to the same LSN once the whole txn is drained.
 				if err := flush(); err != nil {
 					return err
 				}
-				lastCommitLSN = ev.EndPos
+				if err := indexer.InsertSchemaChange(indexDB, ev, nil); err != nil {
+					return fmt.Errorf("pgstreamrun: persist schema change (%s on %s.%s): %w", ev.DDLType, ev.Schema, ev.Table, err)
+				}
 			case event.EventRelation:
 				// A relation's shape (#533): persist it as a schema snapshot and record
 				// its snapshot_id for stamping this table's subsequent rows. The snapshot

--- a/internal/pgstreamrun/truncate_audit_integration_test.go
+++ b/internal/pgstreamrun/truncate_audit_integration_test.go
@@ -1,0 +1,133 @@
+//go:build integration
+
+package pgstreamrun_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/dbtrail/dbtrail/internal/pgstreamrun"
+	"github.com/dbtrail/dbtrail/internal/reconstruct"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestOne_TruncateAudited is the #827 proof: a PostgreSQL TRUNCATE on a captured
+// table lands a durable schema_changes audit row (ddl_type='TRUNCATE TABLE',
+// one per truncated table), and reconstruct.CheckDestructiveDDL then REFUSES to
+// cross it — the guard that stops a baseline+delta reconstruct from silently
+// resurrecting the truncated rows. Before #827 a PG TRUNCATE produced only a
+// transient Warn and nothing was persisted, so the destructive DDL was invisible
+// to the read plane and reconstruct would have resurrected the rows.
+//
+// CI-only: needs a live PostgreSQL source (BINTRAIL_TEST_PG_DSN) + MySQL index.
+func TestOne_TruncateAudited(t *testing.T) {
+	pgDSN := testutil.SkipIfNoPostgres(t)
+	testutil.SkipIfNoMySQL(t)
+	ctx := context.Background()
+
+	indexDB, dbName := testutil.CreateTestDB(t)
+	indexDSN := testutil.BaseDSN() + "/" + dbName
+
+	const slot = "bintrail_pgsr_trunc"
+	const pub = "bintrail_pgsr_trunc_pub"
+	const tbl = "pgsr_trunc_t"
+
+	pg, err := pgx.Connect(ctx, pgDSN)
+	if err != nil {
+		t.Fatalf("connect PG: %v", err)
+	}
+	t.Cleanup(func() { pg.Close(context.Background()) })
+
+	dropAll := func() {
+		bg := context.Background()
+		_, _ = pg.Exec(bg, "DROP PUBLICATION IF EXISTS "+pub)
+		_, _ = pg.Exec(bg, "DROP TABLE IF EXISTS "+tbl)
+		_, _ = pg.Exec(bg, "SELECT pg_drop_replication_slot($1) WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name=$1)", slot)
+	}
+	dropAll()
+	t.Cleanup(dropAll)
+
+	mustExec := func(sql string, args ...any) {
+		t.Helper()
+		if _, err := pg.Exec(ctx, sql, args...); err != nil {
+			t.Fatalf("exec %q: %v", sql, err)
+		}
+	}
+	mustExec(fmt.Sprintf("CREATE TABLE %s (id int PRIMARY KEY, v text)", tbl))
+	mustExec(fmt.Sprintf("ALTER TABLE %s REPLICA IDENTITY FULL", tbl))
+	// A default publication publishes truncate too (publish = insert,update,delete,truncate).
+	mustExec(fmt.Sprintf("CREATE PUBLICATION %s FOR TABLE %s", pub, tbl))
+
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	cfg := pgstreamrun.Config{
+		IndexDSN: indexDSN, ReplDSN: replDSN(pgDSN), QueryDSN: pgDSN,
+		SlotName: slot, Publication: pub, ServerID: 54,
+		Tables: "public." + tbl, BatchSize: 100, Checkpoint: 200 * time.Millisecond,
+	}
+	runErr := make(chan error, 1)
+	go func() { runErr <- pgstreamrun.One(runCtx, cfg) }()
+
+	waitFor(t, 15*time.Second, func() bool {
+		var active bool
+		if err := pg.QueryRow(ctx, "SELECT active FROM pg_replication_slots WHERE slot_name=$1", slot).Scan(&active); err != nil {
+			return false
+		}
+		return active
+	}, "replication slot active")
+
+	mustExec(fmt.Sprintf("INSERT INTO %s VALUES (1, 'a'), (2, 'b')", tbl))
+	waitFor(t, 15*time.Second, func() bool {
+		var n int
+		_ = indexDB.QueryRow("SELECT COUNT(*) FROM binlog_events WHERE table_name = ?", tbl).Scan(&n)
+		return n >= 2
+	}, "INSERTs indexed")
+
+	mustExec(fmt.Sprintf("TRUNCATE TABLE %s", tbl))
+	waitFor(t, 15*time.Second, func() bool {
+		var n int
+		_ = indexDB.QueryRow("SELECT COUNT(*) FROM schema_changes WHERE table_name = ? AND ddl_type = 'TRUNCATE TABLE'", tbl).Scan(&n)
+		return n >= 1
+	}, "TRUNCATE audited into schema_changes")
+
+	cancel()
+	if err := <-runErr; err != nil {
+		t.Fatalf("One returned error: %v", err)
+	}
+
+	// The audit row carries schema_name='public' (CheckDestructiveDDL matches on it).
+	var schemaName string
+	if err := indexDB.QueryRow(
+		"SELECT schema_name FROM schema_changes WHERE table_name = ? AND ddl_type = 'TRUNCATE TABLE'", tbl,
+	).Scan(&schemaName); err != nil {
+		t.Fatalf("read schema_changes row: %v", err)
+	}
+	if schemaName != "public" {
+		t.Errorf("schema_name = %q, want public", schemaName)
+	}
+
+	// TRUNCATE is an audit record, not a row event — it must NOT land in binlog_events.
+	var truncRows int
+	if err := indexDB.QueryRow(
+		"SELECT COUNT(*) FROM binlog_events WHERE table_name = ? AND event_type = 4", tbl,
+	).Scan(&truncRows); err != nil {
+		t.Fatalf("count EventDDL rows in binlog_events: %v", err)
+	}
+	if truncRows != 0 {
+		t.Errorf("found %d EventDDL rows in binlog_events, want 0 (TRUNCATE is a schema_changes audit, not a row event)", truncRows)
+	}
+
+	// The guard: reconstruct refuses to cross the truncate. A wide, clock-skew-proof
+	// window brackets the commit-time detected_at.
+	window := time.Hour
+	err = reconstruct.CheckDestructiveDDL(ctx, indexDB, "public", tbl,
+		time.Now().Add(-window), time.Now().Add(window))
+	if !errors.Is(err, reconstruct.ErrDestructiveDDL) {
+		t.Fatalf("CheckDestructiveDDL over the truncate window = %v, want ErrDestructiveDDL", err)
+	}
+}


### PR DESCRIPTION
closes #827

## Problem
A PostgreSQL `TRUNCATE` was discarded by the decoder with a transient `Warn` and **nothing persisted**. It was invisible to the read plane (`query` / `status` / `list_schema_changes`), and — the data-loss edge — a baseline+delta `reconstruct` or a baseline-anchored `verify` would **silently resurrect the truncated rows**, because no event marked the destructive DDL for `reconstruct.CheckDestructiveDDL` to refuse.

## Fix — capture it as an audit record, mirroring the MySQL path
- **decoder** (`internal/pgcapture/decoder.go`): `TruncateMessage` now emits one `EventDDL` / `DDLTruncateTable` per **in-scope** truncated relation, stamped with the transaction's commit coordinates. `Decode` now returns `[]event.Event` — a `TRUNCATE a, b, c` yields N events (`schema_changes` is one row per table, and `CheckDestructiveDDL` matches by `schema_name`/`table_name`). Out-of-scope (published-but-filtered) relations are skipped like row events; an unknown relation OID fails loud like `relationFor`.
- **capturer** (`internal/pgcapture/capturer.go`): the receive loop emits every event a message produces.
- **consumer** (`internal/pgstreamrun/pgstreamrun.go`): the `EventDDL` branch persists via `indexer.InsertSchemaChange(indexDB, ev, nil)` (snapshotID=nil — a TRUNCATE doesn't invalidate the schema snapshot). It does **not** advance the cursor: a TRUNCATE arrives *before* its `CommitMessage`, so acking its commit LSN early could release WAL while later rows of the same txn are still incoming (crash → loss). The `EventCommit` advances the cursor once the txn is fully drained.
- **docs** (`docs/postgres.md`): the TRUNCATE limitation now describes the audit-record behavior.

`query` still shows nothing for the truncated rows (as before — TRUNCATE is not a reversible row event), but the truncate is now a durable, queryable audit entry and `reconstruct`/`verify` refuse to cross it.

## Dependency
This is the prerequisite for un-gating single-row PG reconstruct/`_snapshot` (#593 slice D): without a durable TRUNCATE record, un-gating would ship the silent row-resurrection this PR closes.

## Test plan
- [x] Unit (`internal/pgcapture/decoder_test.go`): TRUNCATE indexed as `EventDDL` with correct schema/table/coords; multi-table → N events in order; out-of-scope relation skipped; unknown OID fails loud.
- [x] Integration (`internal/pgstreamrun/truncate_audit_integration_test.go`, CI-only — needs `BINTRAIL_TEST_PG_DSN` + MySQL index): a live PG `TRUNCATE` lands a `schema_changes` row, does **not** land in `binlog_events`, and `CheckDestructiveDDL` returns `ErrDestructiveDDL` across the truncate window.
- [x] `go build ./...`, `go vet`, and unit suites for `pgcapture` / `pgstreamrun` / `reconstruct` / `indexer` green.
- [x] Adversarial review (correctness/silent-failure · Decode-signature blast-radius · pgoutput protocol/ordering): **ship-as-is**, zero blocking findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
