### PR TITLE
stream: safe position-mode checkpoint, never mid-statement (#775)

### DIFF
--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -97,6 +97,16 @@ type Event struct {
 	// consumer persists it as a schema snapshot and stamps subsequent rows'
 	// SchemaVersion. nil for every other event type; never written to binlog_events.
 	Relation *metadata.PGRelationSchema
+	// StmtEnd is true on the row events of the ROWS_EVENT that carries STMT_END_F —
+	// the last chunk of a statement. A statement larger than
+	// binlog_row_event_max_size (8 KiB default) is split into several ROWS_EVENTs
+	// under ONE TABLE_MAP, and only the last one sets STMT_END_F. The stream
+	// consumer keys its POSITION-mode safe checkpoint off this flag so a resume
+	// never lands on a byte offset BETWEEN two chunks — a mid-statement position
+	// has no preceding TABLE_MAP for the live syncer and closes the stream with
+	// "invalid table id, no corresponding table map event" (#775). Transient:
+	// never written to binlog_events.
+	StmtEnd bool
 }
 
 // Filters controls which schemas and tables produce events.

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -525,22 +525,27 @@ func handleRows(
 	endPos := uint64(binlogEv.Header.LogPos)
 	ts := time.Unix(int64(binlogEv.Header.Timestamp), 0).UTC()
 	pkCols := tm.PKColumnMetas()
+	// stmtEnd marks the last ROWS_EVENT of a statement (STMT_END_F). endPos is a
+	// valid POSITION-mode resume point only at a statement boundary — the stream
+	// consumer stamps this onto every emitted row event so its safe checkpoint
+	// never lands between the chunks of a split statement (#775).
+	stmtEnd := rowsEv.Flags&replication.RowsEventStmtEndFlag != 0
 
 	switch binlogEv.Header.EventType {
 	case replication.WRITE_ROWS_EVENTv0,
 		replication.WRITE_ROWS_EVENTv1,
 		replication.WRITE_ROWS_EVENTv2:
-		return emitInserts(ctx, logger, resolver, rowsEv.Rows, schema, table, filename, currentGTID, connectionID, queryText, startPos, endPos, ts, pkCols, schemaVersion, out)
+		return emitInserts(ctx, logger, resolver, rowsEv.Rows, schema, table, filename, currentGTID, connectionID, queryText, startPos, endPos, ts, pkCols, schemaVersion, stmtEnd, out)
 
 	case replication.DELETE_ROWS_EVENTv0,
 		replication.DELETE_ROWS_EVENTv1,
 		replication.DELETE_ROWS_EVENTv2:
-		return emitDeletes(ctx, logger, resolver, rowsEv.Rows, schema, table, filename, currentGTID, connectionID, queryText, startPos, endPos, ts, pkCols, schemaVersion, out)
+		return emitDeletes(ctx, logger, resolver, rowsEv.Rows, schema, table, filename, currentGTID, connectionID, queryText, startPos, endPos, ts, pkCols, schemaVersion, stmtEnd, out)
 
 	case replication.UPDATE_ROWS_EVENTv0,
 		replication.UPDATE_ROWS_EVENTv1,
 		replication.UPDATE_ROWS_EVENTv2:
-		return emitUpdates(ctx, logger, resolver, rowsEv.Rows, schema, table, filename, currentGTID, connectionID, queryText, startPos, endPos, ts, pkCols, schemaVersion, out)
+		return emitUpdates(ctx, logger, resolver, rowsEv.Rows, schema, table, filename, currentGTID, connectionID, queryText, startPos, endPos, ts, pkCols, schemaVersion, stmtEnd, out)
 
 	default:
 		// A RowsEvent whose type matches none of the above — e.g. MariaDB's
@@ -574,6 +579,7 @@ func emitInserts(
 	ts time.Time,
 	pkCols []metadata.ColumnMeta,
 	schemaVersion uint32,
+	stmtEnd bool,
 	out chan<- Event,
 ) error {
 	for _, row := range rows {
@@ -590,6 +596,7 @@ func emitInserts(
 			PKValues:      BuildPKValues(pkCols, named),
 			RowAfter:      named,
 			SchemaVersion: schemaVersion,
+			StmtEnd:       stmtEnd,
 		}
 		select {
 		case out <- ev:
@@ -612,6 +619,7 @@ func emitDeletes(
 	ts time.Time,
 	pkCols []metadata.ColumnMeta,
 	schemaVersion uint32,
+	stmtEnd bool,
 	out chan<- Event,
 ) error {
 	for _, row := range rows {
@@ -628,6 +636,7 @@ func emitDeletes(
 			PKValues:      BuildPKValues(pkCols, named),
 			RowBefore:     named,
 			SchemaVersion: schemaVersion,
+			StmtEnd:       stmtEnd,
 		}
 		select {
 		case out <- ev:
@@ -650,6 +659,7 @@ func emitUpdates(
 	ts time.Time,
 	pkCols []metadata.ColumnMeta,
 	schemaVersion uint32,
+	stmtEnd bool,
 	out chan<- Event,
 ) error {
 	// go-mysql delivers UPDATE rows as interleaved before/after pairs:
@@ -675,6 +685,7 @@ func emitUpdates(
 			RowBefore:     before,
 			RowAfter:      after,
 			SchemaVersion: schemaVersion,
+			StmtEnd:       stmtEnd,
 		}
 		select {
 		case out <- ev:

--- a/internal/parser/stream_test.go
+++ b/internal/parser/stream_test.go
@@ -360,6 +360,55 @@ func TestStreamParser_mariadbGTIDThenXIDEmitsCommit(t *testing.T) {
 	}
 }
 
+// ─── STMT_END_F / split-statement boundary (#775) ────────────────────────────
+
+// TestStreamParser_stmtEndFlagMarksStatementBoundary verifies that Event.StmtEnd
+// mirrors the ROWS_EVENT's STMT_END_F flag. A statement larger than
+// binlog_row_event_max_size is split into several ROWS_EVENTs under ONE
+// TABLE_MAP, and only the LAST one sets STMT_END_F. The stream consumer keys its
+// POSITION-mode safe checkpoint off StmtEnd so a resume never lands on the byte
+// offset between two chunks (#775): the first (non-STMT_END) chunk must report
+// StmtEnd=false, the last (STMT_END) chunk StmtEnd=true.
+func TestStreamParser_stmtEndFlagMarksStatementBoundary(t *testing.T) {
+	sp := NewStreamParser(makeOrdersResolver(), Filters{}, nil)
+	streamer := replication.NewBinlogStreamer()
+	out := make(chan Event, 10)
+
+	mkChunk := func(logPos uint32, stmtEnd bool) *replication.BinlogEvent {
+		var flags uint16
+		if stmtEnd {
+			flags = replication.RowsEventStmtEndFlag
+		}
+		return &replication.BinlogEvent{
+			Header: &replication.EventHeader{EventType: replication.WRITE_ROWS_EVENTv2, LogPos: logPos, EventSize: 100},
+			Event: &replication.RowsEvent{
+				Flags: flags,
+				Table: &replication.TableMapEvent{Schema: []byte("shop"), Table: []byte("orders"), ColumnCount: 2},
+				Rows:  [][]any{{int64(1), int64(10)}},
+			},
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// One split statement: first chunk (mid-statement, no STMT_END_F), then the
+	// last chunk (STMT_END_F set) — both under the same implied TABLE_MAP.
+	feedThenCancel(t, streamer, cancel, mkChunk(300, false), mkChunk(500, true))
+	if err := sp.Run(ctx, streamer, out); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	evs := drainAll(out)
+	if len(evs) != 2 {
+		t.Fatalf("expected 2 row events, got %d: %v", len(evs), typesOf(evs))
+	}
+	if evs[0].StmtEnd {
+		t.Errorf("mid-statement ROWS_EVENT (no STMT_END_F, pos %d) must have StmtEnd=false", evs[0].EndPos)
+	}
+	if !evs[1].StmtEnd {
+		t.Errorf("final ROWS_EVENT (STMT_END_F, pos %d) must have StmtEnd=true", evs[1].EndPos)
+	}
+}
+
 // ─── QueryEvent / DDL ────────────────────────────────────────────────────────
 
 // TestStreamParser_queryEventNonDDL verifies that a non-DDL QUERY_EVENT

--- a/internal/streamrun/streamrun.go
+++ b/internal/streamrun/streamrun.go
@@ -32,9 +32,20 @@ import (
 // streamState holds the current replication position and counters used for
 // checkpointing. It is persisted to stream_state after each checkpoint interval.
 type streamState struct {
-	mode          string // "position" or "gtid"
-	binlogFile    string
-	binlogPos     uint64
+	mode       string // "position" or "gtid"
+	binlogFile string
+	binlogPos  uint64 // per-EVENT byte offset — advances on every event (metrics/display; GTID-mode checkpoint + dedup)
+	// safeFile/safePos hold the last POSITION-mode SAFE resume point: a byte
+	// offset that only advances at a statement (STMT_END_F) / commit / DDL
+	// boundary, never mid-statement. saveCheckpoint persists these in position
+	// mode so a resume can never land between the ROWS_EVENTs of one split
+	// statement and crash StartSync with "invalid table id, no corresponding
+	// table map event" (#775). Mirrors the commit-only gtidSet semantics of #491,
+	// but works for non-GTID sources too (which emit no EventCommit). Unused in
+	// GTID mode (that path keeps checkpointing the per-event binlogPos, which
+	// deleteEventsSinceCheckpointGTID relies on).
+	safeFile      string
+	safePos       uint64
 	gtidSet       string // serialized GTID set (GTID mode only)
 	flavor        string // source flavor: "mysql" (default) or "mariadb"; selects the GTID parser on resume
 	eventsIndexed int64
@@ -75,6 +86,36 @@ func loadStreamState(db *sql.DB) (*streamState, error) {
 	return &s, nil
 }
 
+// checkpointPosition returns the (binlog_file, binlog_position) to persist for a
+// checkpoint. POSITION mode persists the last statement/commit/DDL boundary
+// (safeFile/safePos) instead of the per-event binlogFile/binlogPos, so a resume
+// never lands on a byte offset mid-statement — StartSync from between the
+// ROWS_EVENTs of one split statement closes the stream with "invalid table id, no
+// corresponding table map event" and crash-loops the supervisor (#775). GTID mode
+// keeps persisting the per-event binlogPos: its resume is transaction-aligned
+// (StartSyncGTID) and deleteEventsSinceCheckpointGTID relies on that offset. The
+// safeFile=="" fallback keeps external/test callers that never populate safe*
+// (e.g. a hand-built streamState) on the pre-#775 behavior.
+func checkpointPosition(state *streamState) (string, uint64) {
+	if state.mode == "position" && state.safeFile != "" {
+		return state.safeFile, state.safePos
+	}
+	return state.binlogFile, state.binlogPos
+}
+
+// isPositionCheckpointBoundary reports whether an event marks a valid POSITION-mode
+// resume point: a statement end (a row event of the ROWS_EVENT carrying STMT_END_F),
+// a transaction commit (EventCommit), or a DDL (EventDDL). Every other position —
+// notably the byte offset between two ROWS_EVENTs of one split statement — is unsafe
+// to resume from (#775).
+func isPositionCheckpointBoundary(ev parser.Event) bool {
+	switch ev.EventType {
+	case parser.EventCommit, parser.EventDDL:
+		return true
+	}
+	return ev.StmtEnd
+}
+
 // saveCheckpoint persists the current stream state to the stream_state table.
 func saveCheckpoint(db *sql.DB, state *streamState) error {
 	var gtidSet any
@@ -95,6 +136,9 @@ func saveCheckpoint(db *sql.DB, state *streamState) error {
 	if err != nil {
 		return err
 	}
+	// #775: in position mode this persists the last safe boundary, not the
+	// per-event offset (see checkpointPosition).
+	file, pos := checkpointPosition(state)
 	_, err = db.Exec(`
 		INSERT INTO stream_state
 		    (id, mode, binlog_file, binlog_position, gtid_set, flavor,
@@ -110,7 +154,7 @@ func saveCheckpoint(db *sql.DB, state *streamState) error {
 		    last_checkpoint = UTC_TIMESTAMP(),
 		    server_id       = VALUES(server_id),
 		    bintrail_id     = VALUES(bintrail_id)`,
-		state.mode, state.binlogFile, state.binlogPos, gtidSet, flavor,
+		state.mode, file, pos, gtidSet, flavor,
 		state.eventsIndexed, lastEventTime, state.serverID, bintrailIDArg)
 	return err
 }
@@ -1147,6 +1191,13 @@ func streamLoop(
 				state.binlogFile = ev.BinlogFile
 			}
 			state.binlogPos = ev.EndPos
+			// Advance the POSITION-mode safe checkpoint only at statement/commit/DDL
+			// boundaries, never mid-statement — a resume from between the ROWS_EVENTs
+			// of one split statement crashes StartSync (#775). The per-event
+			// binlogPos above stays for metrics/display and GTID-mode checkpointing.
+			if isPositionCheckpointBoundary(ev) {
+				state.safeFile, state.safePos = state.binlogFile, ev.EndPos
+			}
 			if !ev.Timestamp.IsZero() {
 				state.lastEventTime = sql.NullTime{Time: ev.Timestamp, Valid: true}
 			}
@@ -1562,6 +1613,8 @@ func One(ctx context.Context, cfg Config) error {
 					mode:          mode,
 					binlogFile:    startFile,
 					binlogPos:     uint64(startPos),
+					safeFile:      startFile,
+					safePos:       uint64(startPos),
 					gtidSet:       startGTIDStr,
 					flavor:        cfg.Flavor,
 					serverID:      cfg.ServerID,
@@ -1657,9 +1710,14 @@ func One(ctx context.Context, cfg Config) error {
 		mode: mode,
 		// Seed the position with the resolved start so the first ticker
 		// checkpoint (which fires even before any event arrives) persists a
-		// valid resume point instead of an empty file / position 0.
+		// valid resume point instead of an empty file / position 0. safeFile/
+		// safePos seed identically — the resolved start is always a boundary, and
+		// this keeps the position-mode checkpoint at a valid resume point until the
+		// first statement/commit/DDL boundary advances it (#775).
 		binlogFile: startFile,
 		binlogPos:  uint64(startPos),
+		safeFile:   startFile,
+		safePos:    uint64(startPos),
 		flavor:     cfg.Flavor,
 		serverID:   cfg.ServerID,
 		accGTID:    accGTID,

--- a/internal/streamrun/streamrun_test.go
+++ b/internal/streamrun/streamrun_test.go
@@ -1490,3 +1490,90 @@ func TestDeleteEventsSinceCheckpointGTID_deletesStragglers(t *testing.T) {
 		t.Errorf("unmet expectations: %v", err)
 	}
 }
+
+// ─── #775: position-mode safe checkpoint never mid-statement ──────────────────
+
+// TestPositionCheckpoint_neverMidStatement is the unit guard for #775. In
+// POSITION mode the persisted checkpoint must be the last statement/commit/DDL
+// boundary, never a byte offset between the ROWS_EVENTs of one split statement
+// (a statement > binlog_row_event_max_size is split into several ROWS_EVENTs
+// under ONE TABLE_MAP — resuming StartSync mid-statement hits a rows event with
+// no preceding TABLE_MAP and crash-loops). It drives the same two decisions
+// streamLoop makes per event — the per-event binlogPos advance and the
+// boundary-gated safePos advance — then asserts checkpointPosition (what
+// saveCheckpoint persists) tracks the committed boundary.
+func TestPositionCheckpoint_neverMidStatement(t *testing.T) {
+	const file = "binlog.000001"
+	// Seeded at the resolved start boundary (pos 100), as One() does.
+	state := &streamState{mode: "position", binlogFile: file, binlogPos: 100, safeFile: file, safePos: 100}
+
+	// apply mirrors streamLoop's per-event position bookkeeping.
+	apply := func(ev parser.Event) {
+		if ev.BinlogFile != "" {
+			state.binlogFile = ev.BinlogFile
+		}
+		state.binlogPos = ev.EndPos
+		if isPositionCheckpointBoundary(ev) {
+			state.safeFile, state.safePos = state.binlogFile, ev.EndPos
+		}
+	}
+
+	// A bulk UPDATE split across two ROWS_EVENTs under one TABLE_MAP: the first
+	// chunk (no STMT_END) then a second chunk, still not the statement end.
+	apply(parser.Event{EventType: parser.EventUpdate, BinlogFile: file, EndPos: 300, StmtEnd: false})
+	apply(parser.Event{EventType: parser.EventUpdate, BinlogFile: file, EndPos: 500, StmtEnd: false})
+
+	// A ticker checkpoint fires HERE — mid-statement. It must persist the prior
+	// committed boundary (100), not the per-event offset (500).
+	if f, p := checkpointPosition(state); f != file || p != 100 {
+		t.Fatalf("mid-statement checkpoint must stay at the committed boundary %s:100, got %s:%d", file, f, p)
+	}
+	if state.binlogPos != 500 {
+		t.Fatalf("per-event binlogPos should still track the latest event for metrics/display, got %d", state.binlogPos)
+	}
+
+	// The statement's last chunk (STMT_END_F) arrives — safePos may now advance.
+	apply(parser.Event{EventType: parser.EventUpdate, BinlogFile: file, EndPos: 700, StmtEnd: true})
+	if _, p := checkpointPosition(state); p != 700 {
+		t.Fatalf("after STMT_END the safe checkpoint must advance to 700, got %d", p)
+	}
+
+	// EventGTID (transaction-start marker) is NOT a boundary.
+	apply(parser.Event{EventType: parser.EventGTID, BinlogFile: file, EndPos: 720})
+	if _, p := checkpointPosition(state); p != 700 {
+		t.Fatalf("EventGTID must not advance the safe checkpoint; want 700, got %d", p)
+	}
+
+	// EventCommit (XID) IS a boundary.
+	apply(parser.Event{EventType: parser.EventCommit, BinlogFile: file, EndPos: 750})
+	if _, p := checkpointPosition(state); p != 750 {
+		t.Fatalf("after commit the safe checkpoint must advance to 750, got %d", p)
+	}
+
+	// EventDDL (auto-commit) IS a boundary, and carries the new file after a rotate.
+	apply(parser.Event{EventType: parser.EventDDL, BinlogFile: "binlog.000002", EndPos: 900})
+	if f, p := checkpointPosition(state); f != "binlog.000002" || p != 900 {
+		t.Fatalf("EventDDL must advance the safe checkpoint to binlog.000002:900, got %s:%d", f, p)
+	}
+}
+
+// TestCheckpointPosition_gtidModeUsesPerEventPos pins that #775 does NOT change
+// GTID-mode checkpointing: there the per-event binlogPos is persisted (its resume
+// is transaction-aligned and deleteEventsSinceCheckpointGTID depends on the
+// offset), even when a stale safePos is present.
+func TestCheckpointPosition_gtidModeUsesPerEventPos(t *testing.T) {
+	state := &streamState{mode: "gtid", binlogFile: "binlog.000009", binlogPos: 4096, safeFile: "binlog.000009", safePos: 100}
+	if f, p := checkpointPosition(state); f != "binlog.000009" || p != 4096 {
+		t.Fatalf("GTID mode must persist the per-event position 4096, got %s:%d", f, p)
+	}
+}
+
+// TestCheckpointPosition_positionFallback pins the backward-compat fallback: a
+// position-mode state that never populated safe* (external/test callers) keeps
+// the pre-#775 behavior of persisting binlogFile/binlogPos.
+func TestCheckpointPosition_positionFallback(t *testing.T) {
+	state := &streamState{mode: "position", binlogFile: "binlog.000001", binlogPos: 4}
+	if f, p := checkpointPosition(state); f != "binlog.000001" || p != 4 {
+		t.Fatalf("unseeded safe* must fall back to binlog*, got %s:%d", f, p)
+	}
+}


### PR DESCRIPTION
## Problem

A statement larger than `binlog_row_event_max_size` (8 KiB default) is split by MySQL into several `ROWS_EVENT`s under **one** `TABLE_MAP`; only the last carries `STMT_END_F`. In position mode, `streamLoop` advanced `state.binlogPos = ev.EndPos` on **every** event, so the ticker checkpoint could persist a byte offset *between* two chunks of one statement.

On crash + resume, `StartSync(file, pos)` from that mid-statement offset hands the live syncer a rows event with no preceding `TABLE_MAP`:

```
invalid table id, no corresponding table map event
```

The live syncer then **closes** the stream (no skip) → `streamrun.One` fails → the supervisor restarts to the *same* checkpoint → the same error → a permanent crash-loop. The only escape is `--reset`, which discards events.

`#491` protected `gtidSet` (advances only at commit); `binlogPos` had no such protection.

## Fix

Additive, mirroring the `#491` commit-only semantics for the position checkpoint:

- Add `safeFile`/`safePos` to `streamState`. They advance **only** at a statement (`STMT_END_F`) / commit / DDL boundary (`isPositionCheckpointBoundary`), never mid-statement.
- `checkpointPosition` persists `safeFile`/`safePos` in **position** mode; per-event `binlogPos` stays for metrics/display. **GTID mode is unchanged** — it keeps checkpointing the per-event `binlogPos` (its resume is transaction-aligned and `deleteEventsSinceCheckpointGTID` depends on that offset).
- The boundary signal for **non-GTID** sources: `emitCommit` no-ops without a GTID (`gtid_mode=OFF` emits no `EventCommit`), so a commit-only rule would freeze the checkpoint. Instead the parser surfaces `STMT_END_F` on `Event.StmtEnd` (transient, never written to `binlog_events`), which works for every source config.
- `checkpointPosition` falls back to `binlogFile`/`binlogPos` when `safe*` is unseeded, keeping external/test callers on pre-`#775` behavior.

No new events are emitted, so the agent/BYOS/buffer paths and all existing event-sequence tests are unaffected.

## Test

- `internal/parser`: `TestStreamParser_stmtEndFlagMarksStatementBoundary` — two `ROWS_EVENT`s of one split statement; the non-`STMT_END` chunk reports `StmtEnd=false`, the `STMT_END_F` chunk `StmtEnd=true`.
- `internal/streamrun`: `TestPositionCheckpoint_neverMidStatement` — drives the exact `streamLoop` bookkeeping over `TABLE_MAP, rows, rows (no commit)`; a checkpoint firing mid-statement persists the prior committed boundary, not the per-event offset; boundaries (`STMT_END`, commit, DDL+rotate) advance it, `EventGTID` does not. Plus `TestCheckpointPosition_gtidModeUsesPerEventPos` (GTID unchanged) and `TestCheckpointPosition_positionFallback` (backward-compat).

Closes #775