### PR TITLE
cascade: load cross-schema FK children by parent schema (#833)

### DIFF
--- a/docs/query-and-recovery.md
+++ b/docs/query-and-recovery.md
@@ -307,11 +307,13 @@ bintrail recover-cascade --index-dsn "..." \
   refuses Phase-2 baseline augmentation (flagged as a coverage gap) rather than
   risk a silent zero-match — so a `BINARY(16)`/UUID-as-binary FK loses Phase-2
   entirely and falls back to Phase-1 (binlog-window only).
-- **Cross-schema FK children are excluded.** `recover-cascade` loads the FK
-  graph scoped to the parent's own `--schema` only; a child table living in a
-  *different* schema is never loaded, so its cascade victims are silently
-  absent from the graph rather than flagged. Point `--schema` at the child's
-  schema in a separate run if a cascade crosses a schema boundary.
+- **Cross-schema FK children are included.** A child table in a *different*
+  schema with an `ON DELETE CASCADE` / `SET NULL` FK to the `--schema` parent is
+  legal in MySQL (common in multi-tenant / reporting layouts) and is
+  reconstructed: `recover-cascade` scopes the FK-graph load by the *parent*
+  schema (`referenced_schema_name`) and walks it transitively, so multi-level
+  cross-schema cascades are covered too. (Earlier releases scoped the load by the
+  child's own schema and silently dropped cross-schema children — [#833](https://github.com/dbtrail/dbtrail/issues/833).)
 - **The FK graph reflects the latest schema snapshot, not the one in effect at
   the delete being recovered.** If DDL changed the FK topology between the
   delete and now, synthesis uses the newer graph. Acceptable in practice

--- a/internal/cascade/cascade.go
+++ b/internal/cascade/cascade.go
@@ -621,6 +621,113 @@ func LoadCascadeFKs(ctx context.Context, indexDB *sql.DB, schemas []string) ([]C
 	return out, rows.Err()
 }
 
+// LoadCascadeFKsForParent loads the FK edges needed to reconstruct cascades rooted
+// at a DELETE in parentSchema — the loader the CLI/console cascade paths use.
+//
+// Unlike LoadCascadeFKs (which scopes by the CHILD schema, `schema_name`), this
+// scopes by the PARENT schema, `referenced_schema_name`. A child in schema B with
+// an ON DELETE CASCADE / SET NULL FK to a parent in schema A is legal in MySQL
+// (common in multi-tenant / reporting layouts). Scoping the load by the child's
+// schema silently drops that edge, so its cascade-deleted rows are never
+// synthesized and the run exits 0 "complete" — silent data-loss (#833). Scoping by
+// the referenced (parent) schema includes cross-schema children.
+//
+// It also walks the referenced-schema frontier TRANSITIVELY so multi-level
+// cross-schema cascades are covered: a grandchild in schema C whose FK references a
+// cross-schema child in schema B (which in turn references parentSchema A) is only
+// reachable once B is loaded as a parent schema. Starting from parentSchema, each
+// CASCADE/SET NULL edge's CHILD schema is added to the frontier (those children can
+// themselves be deleted and cascade further); RESTRICT/NO ACTION children never
+// cascade, so they do not widen the frontier. The closure terminates because each
+// schema is scoped at most once. Edges dedup by (schema, table, constraint, column).
+//
+// SynthesizeVictims keys its FK graph by the fully-qualified referenced
+// schema.table, so once these edges are loaded it traverses cross-schema children
+// with no further change. Over-inclusion (edges to non-victim tables in a scoped
+// schema) is harmless — byParent is only consulted for tables that actually appear
+// as a parent DELETE or a synthesized victim — so this never fabricates a victim; it
+// only stops dropping real ones.
+func LoadCascadeFKsForParent(ctx context.Context, indexDB *sql.DB, parentSchema string) ([]CascadeFK, error) {
+	return loadCascadeClosure(ctx, parentSchema, func(ctx context.Context, refSchemas []string) ([]CascadeFK, error) {
+		return loadCascadeFKsByReferencedSchema(ctx, indexDB, refSchemas)
+	})
+}
+
+// referencedSchemaLoader loads the FK edges whose PARENT (referenced_schema_name) is
+// in refSchemas. It is injected into loadCascadeClosure so the transitive-closure
+// orchestration is unit-testable without a database.
+type referencedSchemaLoader func(ctx context.Context, refSchemas []string) ([]CascadeFK, error)
+
+// loadCascadeClosure computes the transitive set of FK edges reachable from a DELETE
+// in parentSchema by expanding the referenced-schema frontier through the child
+// schemas of CASCADE/SET NULL edges. See LoadCascadeFKsForParent for the rationale.
+func loadCascadeClosure(ctx context.Context, parentSchema string, load referencedSchemaLoader) ([]CascadeFK, error) {
+	frontier := []string{parentSchema}
+	scoped := map[string]bool{parentSchema: true} // referenced schemas already loaded
+	seenEdge := map[string]bool{}
+	var out []CascadeFK
+	for len(frontier) > 0 {
+		batch, err := load(ctx, frontier)
+		if err != nil {
+			return nil, err
+		}
+		var next []string
+		for _, fk := range batch {
+			ek := fk.Schema + "\x00" + fk.Table + "\x00" + fk.ConstraintName + "\x00" + fk.Column
+			if !seenEdge[ek] {
+				seenEdge[ek] = true
+				out = append(out, fk)
+			}
+			// Only a CASCADE/SET NULL child can itself be deleted and cascade
+			// further, so only its schema widens the frontier.
+			if (fk.DeleteRule == "CASCADE" || fk.DeleteRule == "SET NULL") && !scoped[fk.Schema] {
+				scoped[fk.Schema] = true
+				next = append(next, fk.Schema)
+			}
+		}
+		frontier = next
+	}
+	return out, nil
+}
+
+// loadCascadeFKsByReferencedSchema reads every FK edge whose PARENT is in
+// refSchemas from the latest FK snapshot. It mirrors LoadCascadeFKs's SELECT (all
+// edges, rules included — SynthesizeVictims gates on DeleteRule) but filters on
+// referenced_schema_name instead of schema_name.
+func loadCascadeFKsByReferencedSchema(ctx context.Context, indexDB *sql.DB, refSchemas []string) ([]CascadeFK, error) {
+	if len(refSchemas) == 0 {
+		return nil, nil
+	}
+	placeholders := strings.TrimRight(strings.Repeat("?,", len(refSchemas)), ",")
+	q := `SELECT schema_name, table_name, constraint_name, column_name,
+	       referenced_schema_name, referenced_table_name, referenced_column_name,
+	       delete_rule, update_rule
+	FROM fk_constraints
+	WHERE snapshot_id = (SELECT MAX(snapshot_id) FROM fk_constraints)
+	  AND referenced_schema_name IN (` + placeholders + `)
+	ORDER BY schema_name, table_name, constraint_name, ordinal_position`
+	args := make([]any, 0, len(refSchemas))
+	for _, s := range refSchemas {
+		args = append(args, s)
+	}
+	rows, err := indexDB.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("load cascade FKs by referenced schema: %w", err)
+	}
+	defer rows.Close()
+	var out []CascadeFK
+	for rows.Next() {
+		var fk CascadeFK
+		if err := rows.Scan(&fk.Schema, &fk.Table, &fk.ConstraintName, &fk.Column,
+			&fk.ReferencedSchema, &fk.ReferencedTable, &fk.ReferencedColumn,
+			&fk.DeleteRule, &fk.UpdateRule); err != nil {
+			return nil, fmt.Errorf("scan cascade FK row: %w", err)
+		}
+		out = append(out, fk)
+	}
+	return out, rows.Err()
+}
+
 // valToString renders a JSON-decoded value the way MySQL's
 // JSON_UNQUOTE(JSON_EXTRACT(...)) does, so comparisons line up with the
 // ColumnEq SQL. The index read path decodes JSON numbers as json.Number

--- a/internal/cascade/cascade_internal_test.go
+++ b/internal/cascade/cascade_internal_test.go
@@ -1,11 +1,128 @@
 package cascade
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
+	"sort"
 	"testing"
 
 	"github.com/dbtrail/dbtrail/internal/query"
 )
+
+// TestLoadCascadeClosure pins the cross-schema FK loader (#833). Scoping the FK
+// graph by the child's own schema silently dropped a child living in a different
+// schema, so its cascade victims were never synthesized and the run exited 0
+// "complete" — silent data-loss. loadCascadeClosure scopes by the PARENT schema
+// (referenced_schema_name) and expands the referenced-schema frontier through the
+// child schemas of CASCADE/SET NULL edges, so direct AND multi-level cross-schema
+// children are loaded. The DB access is injected so this needs no database.
+func TestLoadCascadeClosure(t *testing.T) {
+	fk := func(childSchema, childTable, parentSchema, parentTable, rule string) CascadeFK {
+		return CascadeFK{
+			Schema: childSchema, Table: childTable, ConstraintName: "fk_" + childTable, Column: "pid",
+			ReferencedSchema: parentSchema, ReferencedTable: parentTable, ReferencedColumn: "id",
+			DeleteRule: rule, UpdateRule: "RESTRICT",
+		}
+	}
+	edgeKey := func(f CascadeFK) string { return f.Schema + "." + f.Table + "->" + f.ReferencedSchema + "." + f.ReferencedTable }
+
+	// graph indexes edges by their referenced (parent) schema — the frontier key.
+	byRef := func(edges ...CascadeFK) map[string][]CascadeFK {
+		m := map[string][]CascadeFK{}
+		for _, e := range edges {
+			m[e.ReferencedSchema] = append(m[e.ReferencedSchema], e)
+		}
+		return m
+	}
+	loaderFor := func(graph map[string][]CascadeFK) referencedSchemaLoader {
+		return func(_ context.Context, refSchemas []string) ([]CascadeFK, error) {
+			var out []CascadeFK
+			for _, s := range refSchemas {
+				out = append(out, graph[s]...)
+			}
+			return out, nil
+		}
+	}
+
+	cases := []struct {
+		name  string
+		graph map[string][]CascadeFK
+		want  []string // edgeKey set expected in the closure from parent schema "a"
+	}{
+		{
+			name:  "direct cross-schema child is loaded (the #833 regression)",
+			graph: byRef(fk("b", "reports", "a", "orders", "CASCADE")),
+			want:  []string{"b.reports->a.orders"},
+		},
+		{
+			name: "multi-level cross-schema grandchild in a third schema",
+			graph: byRef(
+				fk("b", "reports", "a", "orders", "CASCADE"),
+				fk("c", "lines", "b", "reports", "CASCADE"),
+			),
+			want: []string{"b.reports->a.orders", "c.lines->b.reports"},
+		},
+		{
+			name: "same-schema multi-level is loaded by the first query, unchanged",
+			graph: byRef(
+				fk("a", "orders", "a", "customers", "CASCADE"),
+				fk("a", "lines", "a", "orders", "CASCADE"),
+			),
+			want: []string{"a.orders->a.customers", "a.lines->a.orders"},
+		},
+		{
+			name: "RESTRICT cross-schema child does not widen the frontier",
+			graph: byRef(
+				fk("b", "reports", "a", "orders", "RESTRICT"),
+				fk("c", "lines", "b", "reports", "CASCADE"), // unreachable: b is a RESTRICT child
+			),
+			// The RESTRICT edge is still returned (SynthesizeVictims gates on the rule),
+			// but schema b is never scoped, so c.lines is not loaded.
+			want: []string{"b.reports->a.orders"},
+		},
+		{
+			name: "cycle terminates (a<->b) and dedups edges",
+			graph: byRef(
+				fk("b", "t1", "a", "t0", "CASCADE"),
+				fk("a", "t2", "b", "t1", "CASCADE"),
+			),
+			want: []string{"b.t1->a.t0", "a.t2->b.t1"},
+		},
+	}
+	for _, c := range cases {
+		got, err := loadCascadeClosure(context.Background(), "a", loaderFor(c.graph))
+		if err != nil {
+			t.Fatalf("%s: loadCascadeClosure: %v", c.name, err)
+		}
+		var keys []string
+		for _, e := range got {
+			keys = append(keys, edgeKey(e))
+		}
+		sort.Strings(keys)
+		want := append([]string(nil), c.want...)
+		sort.Strings(want)
+		if len(keys) != len(want) {
+			t.Fatalf("%s: got edges %v, want %v", c.name, keys, want)
+		}
+		for i := range want {
+			if keys[i] != want[i] {
+				t.Fatalf("%s: got edges %v, want %v", c.name, keys, want)
+			}
+		}
+	}
+}
+
+// TestLoadCascadeClosureLoaderError surfaces a loader failure instead of returning a
+// partial closure — a cascade recovery must never silently under-load its FK graph.
+func TestLoadCascadeClosureLoaderError(t *testing.T) {
+	boom := errors.New("index unreachable")
+	_, err := loadCascadeClosure(context.Background(), "a",
+		func(context.Context, []string) ([]CascadeFK, error) { return nil, boom })
+	if !errors.Is(err, boom) {
+		t.Fatalf("want loader error propagated, got %v", err)
+	}
+}
 
 // TestValToString covers every branch of the value renderer that backs the
 // re-parented comparison. The index read path decodes numbers as json.Number

--- a/internal/cli/recover.go
+++ b/internal/cli/recover.go
@@ -201,22 +201,41 @@ func runRecover(cmd *cobra.Command, args []string) error {
 	if rSchema != "" {
 		cascadeScope = []string{rSchema}
 	}
+	warnCascade := false
+	var childTables []string
 	if edges, cerr := metadata.CascadeConstraintsInIndex(db, cascadeScope); cerr != nil {
 		slog.Warn("could not check the index for FK cascade constraints", "error", cerr)
 	} else if len(edges) > 0 {
+		warnCascade = true
 		seen := map[string]bool{}
-		var tables []string
 		for _, e := range edges {
 			if k := e.Schema + "." + e.Table; !seen[k] {
 				seen[k] = true
-				tables = append(tables, k)
+				childTables = append(childTables, k)
 			}
 		}
-		slog.Warn("target schema has FK ON DELETE CASCADE/SET NULL (or ON UPDATE CASCADE) "+
-			"constraints; plain `recover` cannot reconstruct cascade-deleted child rows or "+
-			"SET NULL'd FKs (they are never binlogged, MySQL Bug #32506); use "+
-			"`bintrail recover-cascade` to reconstruct them",
-			"cascade_child_tables", strings.Join(tables, ", "))
+	}
+	// Cross-schema parent side (#833): CascadeConstraintsInIndex scopes by the
+	// CHILD schema (schema_name = rSchema), so a parent whose only cascade
+	// children live in a DIFFERENT schema is invisible to it — the exact silent
+	// data-loss class this closes. Also probe whether the target table is the
+	// REFERENCED (parent) side via the same cross-schema-aware signal the console
+	// uses to auto-route (metadata.IsCascadeParentInIndex, matching
+	// referenced_schema_name + referenced_table_name), so a plain recover of a
+	// cross-schema cascade parent still gets nudged to `recover-cascade`.
+	if rSchema != "" && rTable != "" {
+		if isParent, perr := metadata.IsCascadeParentInIndex(db, rSchema, rTable); perr != nil {
+			slog.Warn("could not check the index for cross-schema FK cascade parents", "error", perr)
+		} else if isParent {
+			warnCascade = true
+		}
+	}
+	if warnCascade {
+		slog.Warn("target has FK ON DELETE CASCADE/SET NULL (or ON UPDATE CASCADE) "+
+			"constraints (including cross-schema children); plain `recover` cannot "+
+			"reconstruct cascade-deleted child rows or SET NULL'd FKs (they are never "+
+			"binlogged, MySQL Bug #32506); use `bintrail recover-cascade` to reconstruct them",
+			"cascade_child_tables", strings.Join(childTables, ", "))
 	}
 
 	if rProfile != "" {

--- a/internal/cli/recover_cascade.go
+++ b/internal/cli/recover_cascade.go
@@ -329,7 +329,7 @@ func runRecoverCascade(cmd *cobra.Command, args []string) error {
 	var res cascade.Result
 	var synthErr error
 	if len(parentDeletes) > 0 {
-		fks, lerr := cascade.LoadCascadeFKs(cmd.Context(), db, []string{rcSchema})
+		fks, lerr := cascade.LoadCascadeFKsForParent(cmd.Context(), db, rcSchema)
 		if lerr != nil {
 			return fmt.Errorf("load FK graph: %w", lerr)
 		}

--- a/internal/console/recover_cascade.go
+++ b/internal/console/recover_cascade.go
@@ -338,7 +338,7 @@ func (s *Server) synthesizeCascade(ctx context.Context, b *bundle, p cascadeSynt
 	var res cascade.Result
 	var synthErr error
 	if len(parentDeletes) > 0 {
-		fks, lerr := cascade.LoadCascadeFKs(ctx, b.db, []string{p.Schema})
+		fks, lerr := cascade.LoadCascadeFKsForParent(ctx, b.db, p.Schema)
 		if lerr != nil {
 			return cascadeSynthResult{}, fmt.Errorf("load FK graph: %w", lerr)
 		}
@@ -367,20 +367,13 @@ func (s *Server) synthesizeCascade(ctx context.Context, b *bundle, p cascadeSynt
 // cascadeParentDetect reports whether schema.table is the referenced (parent)
 // side of an ON DELETE CASCADE / SET NULL edge in the latest FK snapshot — the
 // cheap, one-index-query signal that a DELETE on it may have cascaded below the
-// binlog. Scoped to the parent's own schema, matching the synthesis (cascade only
-// reconstructs same-schema children). A detection error is returned so the caller
-// can log it and fall back to a plain recover; it must never abort one.
+// binlog. Matches on referenced_schema_name + referenced_table_name so a child in a
+// DIFFERENT schema is detected too (#833): a parent whose only cascade children are
+// cross-schema must still auto-route through cascade synthesis, not silently fall
+// back to plain recover. A detection error is returned so the caller can log it and
+// fall back to a plain recover; it must never abort one.
 func (s *Server) cascadeParentDetect(b *bundle, schema, table string) (bool, error) {
-	edges, err := metadata.CascadeConstraintsInIndex(b.db, []string{schema})
-	if err != nil {
-		return false, err
-	}
-	for _, e := range edges {
-		if e.ReferencedTable == table && (e.DeleteRule == "CASCADE" || e.DeleteRule == "SET NULL") {
-			return true, nil
-		}
-	}
-	return false, nil
+	return metadata.IsCascadeParentInIndex(b.db, schema, table)
 }
 
 // rowsContainDeleteOn reports whether any row is a DELETE on the given table — the

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -1335,6 +1335,41 @@ func CascadeConstraintsInIndex(indexDB *sql.DB, schemas []string) ([]FKCascadeEd
 	return out, rows.Err()
 }
 
+// IsCascadeParentInIndex reports whether schema.table is the REFERENCED (parent)
+// side of an ON DELETE CASCADE / SET NULL foreign key in the latest FK snapshot,
+// INCLUDING children that live in a DIFFERENT schema (a cross-schema FK to
+// schema.table is legal in MySQL, #833). It matches on referenced_schema_name +
+// referenced_table_name, so it is not fooled by a same-named table in another
+// schema, and it is not scoped to the parent's own schema the way the child-scoped
+// CascadeConstraintsInIndex is. Used by the console to decide whether a DELETE on
+// schema.table should auto-route through cascade synthesis: a parent whose only
+// cascade children are cross-schema would otherwise report false and silently fall
+// back to plain recover, missing the cascade victims.
+//
+// Returns false (not an error) when fk_constraints is absent (index predates it).
+func IsCascadeParentInIndex(indexDB *sql.DB, schema, table string) (bool, error) {
+	var exists bool
+	if err := indexDB.QueryRow(
+		"SELECT COUNT(*) > 0 FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'fk_constraints'",
+	).Scan(&exists); err != nil {
+		return false, fmt.Errorf("failed to check fk_constraints table: %w", err)
+	}
+	if !exists {
+		return false, nil
+	}
+	var isParent bool
+	if err := indexDB.QueryRow(
+		`SELECT COUNT(*) > 0 FROM fk_constraints
+			WHERE snapshot_id = (SELECT MAX(snapshot_id) FROM fk_constraints)
+			  AND referenced_schema_name = ? AND referenced_table_name = ?
+			  AND delete_rule IN ('CASCADE', 'SET NULL')`,
+		schema, table,
+	).Scan(&isParent); err != nil {
+		return false, fmt.Errorf("failed to query cascade parent constraints: %w", err)
+	}
+	return isParent, nil
+}
+
 // EnsureResolver returns a Resolver loaded from the latest snapshot, taking a
 // new snapshot automatically if none exists (requires sourceDB != nil).
 func EnsureResolver(indexDB, sourceDB *sql.DB, schemas []string) (*Resolver, error) {


### PR DESCRIPTION
## Problem

`recover-cascade` (and the console cascade path) loaded the FK graph scoped to the **child** schema: `LoadCascadeFKs(db, []string{parentSchema})` filters `fk_constraints.schema_name = the parent's schema`. A child table in schema **B** with an `ON DELETE CASCADE` / `SET NULL` FK to a parent in schema **A** — legal in MySQL, common in multi-tenant/reporting layouts — was never loaded. Its cascade-deleted rows were not synthesized, no caveat was emitted, and the run exited `0` "complete": silent data-loss.

The console auto-route had the twin defect: `cascadeParentDetect` scoped to the parent's own schema and reported `isParent=false` when the only cascade children were cross-schema, silently falling back to plain `recover`.

## Fix

- Add `cascade.LoadCascadeFKsForParent`, scoping the FK-graph load by the **parent** schema (`referenced_schema_name`) and walking the referenced-schema frontier **transitively** through the child schemas of CASCADE/SET NULL edges — so direct *and* multi-level cross-schema children are loaded. The closure orchestration (`loadCascadeClosure`) takes an injected edge loader so it is unit-testable without a database.
- `SynthesizeVictims` already keys its FK graph by the fully-qualified `referenced schema.table`, so it traverses the newly-loaded cross-schema children with no further change. Over-inclusion is harmless — `byParent` is only consulted for tables that actually appear as a parent DELETE or a synthesized victim — so this never fabricates a victim; it only stops dropping real ones.
- Switch both call sites (`internal/cli/recover_cascade.go`, `internal/console/recover_cascade.go`) to the new loader — kept in sync.
- Add `metadata.IsCascadeParentInIndex` (matches `referenced_schema_name` + `referenced_table_name`, cross-schema-aware, not fooled by a same-named table in another schema) and route `cascadeParentDetect` through it.
- Same-schema path is unchanged: `referenced_schema = parent schema` loads the same edges as before. `LoadCascadeFKs` is retained for its direct tests.
- Docs: update the `recover-cascade` limitation from "cross-schema FK children are excluded" to "included".

## Test

- New table-driven unit test `TestLoadCascadeClosure` (`internal/cascade/cascade_internal_test.go`, no DB — injected loader): direct cross-schema child loaded (the regression), multi-level cross-schema grandchild in a third schema, same-schema multi-level unchanged, RESTRICT child does not widen the frontier, and a self-referential cycle terminates with dedup. `TestLoadCascadeClosureLoaderError` asserts a loader failure propagates rather than returning a partial (under-loaded) graph.
- `CGO_ENABLED=1 go build` + `go test` + `go vet` pass on `internal/cascade`, `internal/cli`, `internal/console`, `internal/metadata`.

Closes #833
