### PR TITLE
shim: fail loud when full-table _snapshot baseline is configured but unusable

### DIFF
--- a/internal/shim/handler_test.go
+++ b/internal/shim/handler_test.go
@@ -2978,3 +2978,57 @@ func TestMapEventImagesDecodesExactlyOnce_boolRepair(t *testing.T) {
 		t.Errorf("flag = %#v, want \"true\" (repaired once, not corrupted by a second decode pass)", got)
 	}
 }
+
+// TestRunSnapshotFullTable_BaselineConfiguredRefusesWireError pins #822: when a
+// baseline source IS configured (the operator explicitly opted into full-table
+// completeness) but the baseline merge cannot run, full-table _snapshot must
+// FAIL LOUD with a wire error instead of silently degrading to the
+// binlog-activity-only set — a partial table indistinguishable from a complete
+// one. Two DB-free branches are exercised: no baseline at-or-before AsOf (a
+// valid PK resolves but the configured dir holds no snapshot → FindBaseline
+// returns ErrNoBaseline) and an unresolvable PK (the schema resolver errors).
+// Neither branch reaches indexDB before returning, so a nil DB is fine.
+func TestRunSnapshotFullTable_BaselineConfiguredRefusesWireError(t *testing.T) {
+	silent := slog.New(slog.NewTextHandler(io.Discard, nil))
+	usersResolver := func() (*metadata.Resolver, error) {
+		return metadata.NewResolverFromTables(1, map[string]*metadata.TableMeta{
+			"myapp.users": {Schema: "myapp", Table: "users", PKColumns: []string{"id"},
+				Columns: []metadata.ColumnMeta{
+					{Name: "id", OrdinalPosition: 1, DataType: "int", IsPK: true},
+					{Name: "name", OrdinalPosition: 2, DataType: "varchar"},
+				}},
+		}), nil
+	}
+	cases := []struct {
+		name       string
+		resolverFn func() (*metadata.Resolver, error)
+	}{
+		{"no baseline at-or-before AsOf", usersResolver},
+		{"unresolvable PK", func() (*metadata.Resolver, error) { return nil, errors.New("resolver unavailable") }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := &Handler{
+				logger: silent,
+				// A configured (but empty) baseline dir puts us past the
+				// no-source binlog-only branch; the empty dir makes FindBaseline
+				// return ErrNoBaseline for the valid-PK case.
+				cfg:        Config{BaselineDir: t.TempDir()},
+				resolverFn: tc.resolverFn,
+			}
+			_, err := h.runSnapshotFullTable(TimeTravelQuery{
+				Type: TypeSnapshot, Schema: "myapp", Table: "users", AsOf: time.Now(),
+			})
+			if err == nil {
+				t.Fatal("baseline configured but merge impossible: want a wire error, got nil (silent degrade)")
+			}
+			var myErr *gomysql.MyError
+			if !errors.As(err, &myErr) {
+				t.Fatalf("error = %T %v, want *mysql.MyError", err, err)
+			}
+			if myErr.Code != gomysql.ER_NO_PARTITION_FOR_GIVEN_VALUE {
+				t.Errorf("wire code = %d, want %d (ER_NO_PARTITION_FOR_GIVEN_VALUE)", myErr.Code, gomysql.ER_NO_PARTITION_FOR_GIVEN_VALUE)
+			}
+		})
+	}
+}

--- a/internal/shim/snapshot.go
+++ b/internal/shim/snapshot.go
@@ -59,19 +59,26 @@ var errFullTableCapExceeded = errors.New("full-table snapshot row cap exceeded")
 // the offline `bintrail reconstruct` produces, but streamed into an in-memory
 // resultset.
 //
-// It falls back to the binlog-only full-table path (runFullTable) — preserving
-// the documented "_snapshot degrades to _flashback" contract so a full-table
-// _snapshot never fails where _flashback would succeed — whenever a baseline
-// merge isn't possible:
-//   - no baseline source configured,
-//   - the table's PK can't be resolved from the schema snapshot, or it has no
-//     single/declared PK to canonicalize against,
+// When NO baseline source is configured it falls back to the binlog-only
+// full-table path (runFullTable) — the intended "_snapshot degrades to
+// _flashback" default, where binlog-only completeness is exactly what was
+// asked for.
+//
+// But when a baseline source IS configured the operator explicitly opted into
+// full-table completeness, so a merge that can't run must FAIL LOUD rather than
+// silently return a partial (binlog-activity-only) table indistinguishable from
+// a complete one — the same fail-loud contract as the shim's strict AllowGaps
+// default and the 1104 row cap (#822). These cases return an actionable wire
+// error (ER_NO_PARTITION_FOR_GIVEN_VALUE / 1526 — the same code wrapFetchError
+// uses for a coverage gap the index can't answer), pointing the operator at the
+// fix and at _flashback for a binlog-only view:
+//   - the table's PK can't be resolved from the schema snapshot (re-snapshot),
 //   - a PK column's type isn't supported by the baseline canonicalizer,
-//   - no baseline exists for this table at-or-before AsOf.
+//   - no baseline exists for this table at-or-before AsOf (take a baseline).
 //
 // Real faults (baseline source unreadable, fetch failure, a PK value the
-// canonicalizer can't translate) surface as errors, the same user-vs-server
-// split the single-row path preserves.
+// canonicalizer can't translate) surface as plain errors → ER_UNKNOWN_ERROR
+// (1105), the same user-vs-server split the single-row path preserves.
 func (h *Handler) runSnapshotFullTable(q TimeTravelQuery) (*mysql.Result, error) {
 	src := h.baselineSource()
 	if src == "" {
@@ -82,21 +89,32 @@ func (h *Handler) runSnapshotFullTable(q TimeTravelQuery) (*mysql.Result, error)
 
 	pkCols, ok := h.pkColumnMetas(q.Schema, q.Table)
 	if !ok || len(pkCols) == 0 {
-		// A baseline source IS configured, so the operator opted into
-		// full-table completeness — but we can't determine the table's PK to
-		// canonicalize baseline rows against, so the result silently loses
-		// every never-touched baseline row. Warn (not Debug) so the
-		// degradation is visible; the usual cause is a stale/absent schema
-		// snapshot, fixable with `bintrail snapshot`.
-		h.logger.Warn("shim: full-table _snapshot cannot resolve a PK for the table; degrading to binlog-only (never-touched rows omitted)",
-			"schema", q.Schema, "table", q.Table)
-		return h.runFullTable(q)
+		// A baseline source IS configured, so the operator opted into full-table
+		// completeness — but we can't determine the table's PK to canonicalize
+		// baseline rows against. Degrading to runFullTable here would silently
+		// drop every never-touched baseline row and return a partial table
+		// indistinguishable from a complete one; that contradicts the shim's
+		// fail-loud contract (strict AllowGaps, the 1104 row cap). Refuse with an
+		// actionable wire error instead (#822). The usual cause is a stale/absent
+		// schema snapshot, fixable with `bintrail snapshot`; _flashback stays
+		// available for a binlog-only view.
+		return nil, mysql.NewError(mysql.ER_NO_PARTITION_FOR_GIVEN_VALUE, fmt.Sprintf(
+			"resolve %s: cannot determine the primary key of %s.%s from the schema snapshot; "+
+				"_snapshot cannot return a complete table (never-touched rows would be omitted) — "+
+				"run `bintrail snapshot` to refresh the schema, or use _flashback for a binlog-only view",
+			q.Type, q.Schema, q.Table))
 	}
 	for _, c := range pkCols {
 		if !reconstruct.SupportedPKType(c.DataType) {
-			h.logger.Warn("shim: full-table _snapshot PK type not supported by the baseline canonicalizer; using binlog-only path",
-				"schema", q.Schema, "table", q.Table, "pk_column", c.Name, "pk_type", c.DataType)
-			return h.runFullTable(q)
+			// Baseline configured but this PK type can't be canonicalized for the
+			// merge — same fail-loud reasoning as the unresolved-PK branch (#822):
+			// silently returning binlog-only rows would be a partial table the
+			// operator can't distinguish from a complete one.
+			return nil, mysql.NewError(mysql.ER_NO_PARTITION_FOR_GIVEN_VALUE, fmt.Sprintf(
+				"resolve %s: primary key column %s of %s.%s has type %s, which the baseline merge cannot canonicalize; "+
+					"_snapshot cannot return a complete table (never-touched rows would be omitted) — "+
+					"use _flashback for a binlog-only view",
+				q.Type, c.Name, q.Schema, q.Table, c.DataType))
 		}
 	}
 
@@ -109,15 +127,19 @@ func (h *Handler) runSnapshotFullTable(q TimeTravelQuery) (*mysql.Result, error)
 	baselinePath, snapshotTime, _, err := reconstruct.FindBaseline(ctx, src, q.Schema, q.Table, q.AsOf)
 	if err != nil {
 		if errors.Is(err, reconstruct.ErrNoBaseline) {
-			// Source configured but no baseline exists for this table at-or-
-			// before AsOf (not yet baselined, or table created after the last
-			// snapshot). The full-table result then silently omits any
-			// never-touched row — Warn so the operator can tell the snapshot
-			// degraded to binlog-only rather than returning a complete table.
-			h.logger.Warn("shim: full-table _snapshot found no baseline at-or-before AsOf; degrading to binlog-only (never-touched rows omitted)",
-				"schema", q.Schema, "table", q.Table,
-				"as_of", q.AsOf.UTC().Format(time.RFC3339))
-			return h.runFullTable(q)
+			// Source configured but no baseline exists for this table at-or-before
+			// AsOf (not yet baselined, or the table was created after the last
+			// snapshot). Degrading to runFullTable would silently omit every
+			// never-touched row and return a partial table the caller can't
+			// distinguish from a complete one. Since the operator explicitly
+			// configured a baseline for full-table completeness, fail loud with an
+			// actionable wire error instead (#822) — mirroring the strict
+			// AllowGaps / 1104 row-cap contract.
+			return nil, mysql.NewError(mysql.ER_NO_PARTITION_FOR_GIVEN_VALUE, fmt.Sprintf(
+				"resolve %s: no baseline for %s.%s at or before %s; _snapshot cannot return a complete table "+
+					"(never-touched rows would be omitted) — take a baseline (`bintrail baseline`), "+
+					"or use _flashback for a binlog-only view",
+				q.Type, q.Schema, q.Table, q.AsOf.UTC().Format(time.RFC3339)))
 		}
 		// A real baseline-source failure is a server-side fault, same as the
 		// single-row path: plain error → ER_UNKNOWN_ERROR (1105).

--- a/internal/shim/snapshot_integration_test.go
+++ b/internal/shim/snapshot_integration_test.go
@@ -1089,19 +1089,19 @@ func TestSnapshotBaseline_FullTableDoubleMerge(t *testing.T) {
 	}
 }
 
-// The three tests below close the coverage gap on the configured-but-degraded
-// full-table fallback branches of runSnapshotFullTable. Each configures a
-// baseline source (so we are past the no-source Debug branch) and asserts the
-// result equals the binlog-only set — i.e. the query degrades to runFullTable
-// rather than erroring or silently mis-merging. A never-touched baseline row
-// (present only in the baseline) being ABSENT is the discriminator that proves
-// the merge did NOT run.
+// The three tests below cover the configured-but-can't-merge full-table
+// branches of runSnapshotFullTable. Each configures a baseline source (so we
+// are past the no-source binlog-only branch) — meaning the operator explicitly
+// opted into full-table completeness — and asserts the query FAILS LOUD with a
+// wire error (ER_NO_PARTITION_FOR_GIVEN_VALUE / 1526) rather than silently
+// degrading to the binlog-activity-only set, which would be a partial table
+// indistinguishable from a complete one (#822).
 
-// TestSnapshotBaseline_FullTableUnsupportedPKDegrades: an unsupported PK type
-// (FLOAT) is rejected by reconstruct.SupportedPKType, so full-table _snapshot
-// must fall through to binlog-only even though a baseline with a never-touched
-// row exists.
-func TestSnapshotBaseline_FullTableUnsupportedPKDegrades(t *testing.T) {
+// TestSnapshotBaseline_FullTableUnsupportedPKRefuses: an unsupported PK type
+// (FLOAT) is rejected by reconstruct.SupportedPKType, so the baseline merge
+// cannot canonicalize it. With a baseline configured, full-table _snapshot must
+// refuse with a wire error instead of silently returning binlog-only rows.
+func TestSnapshotBaseline_FullTableUnsupportedPKRefuses(t *testing.T) {
 	db, dbName := testutil.CreateTestDB(t)
 	testutil.InitIndexTables(t, db)
 	if err := indexer.EnsureSchema(db); err != nil {
@@ -1133,24 +1133,20 @@ func TestSnapshotBaseline_FullTableUnsupportedPKDegrades(t *testing.T) {
 		AllowGaps: true, NoArchive: true, IndexDBName: dbName, BaselineDir: baselineDir,
 	}, slog.Default())
 
-	res, err := h.runSnapshot(TimeTravelQuery{Type: TypeSnapshot, Schema: "myapp", Table: "readings", AsOf: asOf})
-	if err != nil {
-		t.Fatalf("full-table _snapshot (unsupported PK) must degrade, not error: %v", err)
+	_, err := h.runSnapshot(TimeTravelQuery{Type: TypeSnapshot, Schema: "myapp", Table: "readings", AsOf: asOf})
+	if err == nil {
+		t.Fatal("full-table _snapshot (unsupported PK, baseline configured) must refuse, got nil")
 	}
-	got := rowsByKey(t, res.Resultset)
-	if _, merged := got["1.5"]; merged {
-		t.Errorf("unsupported-PK full-table _snapshot merged the baseline (never-touched k=1.5 present); must degrade to binlog-only: %v", got)
-	}
-	if got["2.5"] != "fresh" {
-		t.Errorf("unsupported-PK full-table _snapshot = %v, want only the binlog row k=2.5 fresh", got)
+	if me, ok := err.(*mysql.MyError); !ok || me.Code != mysql.ER_NO_PARTITION_FOR_GIVEN_VALUE {
+		t.Errorf("unsupported-PK full-table _snapshot error = %v, want ER_NO_PARTITION_FOR_GIVEN_VALUE (1526)", err)
 	}
 }
 
-// TestSnapshotBaseline_FullTableUnresolvablePKDegrades: when the table is not
-// in the schema snapshot, pkColumnMetas can't determine the PK, so full-table
-// _snapshot must fall through to binlog-only rather than merging against an
-// empty/wrong PK set.
-func TestSnapshotBaseline_FullTableUnresolvablePKDegrades(t *testing.T) {
+// TestSnapshotBaseline_FullTableUnresolvablePKRefuses: when the table is not
+// in the schema snapshot, pkColumnMetas can't determine the PK. With a baseline
+// configured, full-table _snapshot must refuse with a wire error rather than
+// silently returning the binlog-only set (which omits never-touched rows).
+func TestSnapshotBaseline_FullTableUnresolvablePKRefuses(t *testing.T) {
 	db, dbName := testutil.CreateTestDB(t)
 	testutil.InitIndexTables(t, db)
 	if err := indexer.EnsureSchema(db); err != nil {
@@ -1174,25 +1170,23 @@ func TestSnapshotBaseline_FullTableUnresolvablePKDegrades(t *testing.T) {
 		AllowGaps: true, NoArchive: true, IndexDBName: dbName, BaselineDir: baselineDir,
 	}, slog.Default())
 
-	res, err := h.runSnapshot(TimeTravelQuery{Type: TypeSnapshot, Schema: "myapp", Table: "users", AsOf: asOf})
-	if err != nil {
-		t.Fatalf("full-table _snapshot (unresolvable PK) must degrade, not error: %v", err)
+	_, err := h.runSnapshot(TimeTravelQuery{Type: TypeSnapshot, Schema: "myapp", Table: "users", AsOf: asOf})
+	if err == nil {
+		t.Fatal("full-table _snapshot (unresolvable PK, baseline configured) must refuse, got nil")
 	}
-	got := rowsByKey(t, res.Resultset)
-	if _, merged := got["1"]; merged {
-		t.Errorf("unresolvable-PK full-table _snapshot merged the baseline (never-touched id=1 present); must degrade to binlog-only: %v", got)
-	}
-	if got["2"] != "fresh" {
-		t.Errorf("unresolvable-PK full-table _snapshot = %v, want only the binlog row id=2 fresh", got)
+	if me, ok := err.(*mysql.MyError); !ok || me.Code != mysql.ER_NO_PARTITION_FOR_GIVEN_VALUE {
+		t.Errorf("unresolvable-PK full-table _snapshot error = %v, want ER_NO_PARTITION_FOR_GIVEN_VALUE (1526)", err)
 	}
 }
 
-// TestSnapshotBaseline_FullTableNoBaselineAtOrBeforeAsOfDegrades: a baseline
+// TestSnapshotBaseline_FullTableNoBaselineAtOrBeforeAsOfRefuses: a baseline
 // source IS configured, the table IS in the snapshot, but the only baseline
-// snapshot is dated AFTER AsOf — so FindBaseline returns ErrNoBaseline and
-// full-table _snapshot must degrade to binlog-only (distinct from the
-// no-source-configured case in TestSnapshotBaseline_FullTableNoBaselineFallsBack).
-func TestSnapshotBaseline_FullTableNoBaselineAtOrBeforeAsOfDegrades(t *testing.T) {
+// snapshot is dated AFTER AsOf — so FindBaseline returns ErrNoBaseline. Because
+// the operator opted into completeness by configuring a baseline, full-table
+// _snapshot must refuse with a wire error rather than silently degrade to
+// binlog-only (distinct from the no-source-configured case in
+// TestSnapshotBaseline_FullTableNoBaselineFallsBack).
+func TestSnapshotBaseline_FullTableNoBaselineAtOrBeforeAsOfRefuses(t *testing.T) {
 	db, dbName := testutil.CreateTestDB(t)
 	testutil.InitIndexTables(t, db)
 	if err := indexer.EnsureSchema(db); err != nil {
@@ -1220,16 +1214,12 @@ func TestSnapshotBaseline_FullTableNoBaselineAtOrBeforeAsOfDegrades(t *testing.T
 		AllowGaps: true, NoArchive: true, IndexDBName: dbName, BaselineDir: baselineDir,
 	}, slog.Default())
 
-	res, err := h.runSnapshot(TimeTravelQuery{Type: TypeSnapshot, Schema: "myapp", Table: "users", AsOf: asOf})
-	if err != nil {
-		t.Fatalf("full-table _snapshot (no baseline at-or-before AsOf) must degrade, not error: %v", err)
+	_, err := h.runSnapshot(TimeTravelQuery{Type: TypeSnapshot, Schema: "myapp", Table: "users", AsOf: asOf})
+	if err == nil {
+		t.Fatal("full-table _snapshot (no baseline at-or-before AsOf, baseline configured) must refuse, got nil")
 	}
-	got := rowsByKey(t, res.Resultset)
-	if _, merged := got["1"]; merged {
-		t.Errorf("no-baseline-at-or-before-AsOf full-table _snapshot merged a future baseline (id=1 present); must degrade to binlog-only: %v", got)
-	}
-	if got["2"] != "fresh" {
-		t.Errorf("no-baseline-at-or-before-AsOf full-table _snapshot = %v, want only the binlog row id=2 fresh", got)
+	if me, ok := err.(*mysql.MyError); !ok || me.Code != mysql.ER_NO_PARTITION_FOR_GIVEN_VALUE {
+		t.Errorf("no-baseline-at-or-before-AsOf full-table _snapshot error = %v, want ER_NO_PARTITION_FOR_GIVEN_VALUE (1526)", err)
 	}
 }
 


### PR DESCRIPTION
## Problem

Full-table `_snapshot` seeds row state from a baseline Parquet snapshot so never-touched rows resolve. When a baseline source **is** configured but the merge cannot run, `runSnapshotFullTable` silently degraded to the binlog-only `runFullTable` path with only a server-side `Warn`, in three cases:

- `FindBaseline` returns `ErrNoBaseline` (not yet baselined, or the table was created after the last baseline),
- the table's PK can't be resolved from the schema snapshot,
- a PK column's type isn't supported by the baseline canonicalizer.

The result is a **partial table** — only rows with binlog activity in the window — indistinguishable from a complete one. That contradicts the shim's fail-loud contract (its strict `AllowGaps` default and the 1104 row cap, where "silent partial results are worse than a loud failure").

## Fix

Configuring `--baseline-dir`/`--baseline-s3` is an explicit opt-in to full-table completeness, so those three cases now return a **wire error** (`ER_NO_PARTITION_FOR_GIVEN_VALUE` / 1526 — the same code `wrapFetchError` already uses for a coverage gap the index can't answer) with an actionable message pointing at the fix (take a baseline / re-snapshot) and at `_flashback` for a binlog-only view.

Unchanged:
- the no-baseline-source-configured path — binlog-only is the intended `_snapshot degrades to _flashback` default there;
- the single-row `_snapshot` path.

## Test

- Added `TestRunSnapshotFullTable_BaselineConfiguredRefusesWireError` — a DB-free table-driven unit test asserting the 1526 wire error for the `ErrNoBaseline` and unresolvable-PK branches.
- Flipped the three integration tests that pinned the old silent-degrade behavior to assert the wire error instead.
- `CGO_ENABLED=1 go build ./...` and `go test ./internal/shim/` pass; the integration test file compiles under `-tags integration`.

Closes #822
