### PR TITLE
reconstruct: read baseline metadata from S3, refuse PG full-table with no baseline (#916)

### DIFF
--- a/internal/cli/reconstruct.go
+++ b/internal/cli/reconstruct.go
@@ -209,14 +209,19 @@ func runReconstruct(cmd *cobra.Command, args []string) error {
 	}
 	slog.Debug("found baseline snapshot", "path", baselinePath, "snapshot_time", snapshotTime.UTC().Format(time.RFC3339))
 
-	// Read baseline binlog position metadata (local files only).
+	// Read baseline position metadata (binlog file/pos for MySQL, the WAL LSN
+	// anchor for PG). ReadParquetMetadataAny reads S3 too — the same reader the
+	// full-table path uses (fulltable.go) — so an S3 baseline populates bmeta,
+	// which the old local-only read silently skipped: without it, gap detection
+	// and the PG beta warn below were disabled for every S3 baseline (#916). A
+	// read failure is non-fatal — warn and proceed with a zero bmeta (gap
+	// detection then reports "unavailable", the pre-#916 S3 behavior).
 	var bmeta baseline.DumpMetadata
-	if !strings.HasPrefix(baselinePath, "s3://") {
-		var metaErr error
-		bmeta, metaErr = baseline.ReadParquetMetadata(baselinePath)
-		if metaErr != nil {
-			slog.Warn("could not read baseline metadata", "error", metaErr)
-		} else if bmeta.BinlogFile != "" {
+	if bm, metaErr := baseline.ReadParquetMetadataAny(cmd.Context(), baselinePath); metaErr != nil {
+		slog.Warn("could not read baseline metadata", "error", metaErr)
+	} else {
+		bmeta = bm
+		if bmeta.BinlogFile != "" {
 			slog.Debug("baseline binlog position",
 				"file", bmeta.BinlogFile, "pos", bmeta.BinlogPos, "gtid", bmeta.GTIDSet)
 		}
@@ -268,13 +273,12 @@ func runReconstruct(cmd *cobra.Command, args []string) error {
 	// GUC-sensitive and container types are beta and not yet proven end-to-end
 	// through the baseline↔delta fold (#593 slice D). Warn — never refuse (the
 	// path is honest-best-effort and a refusal would break the surface that DOES
-	// work). Detect PG by the recorded flavor OR the baseline's LSN anchor. This
-	// path reads baseline metadata LOCAL-only (see the ReadParquetMetadata guard
-	// above), so bmeta.LSN is 0 for an S3 baseline: the flavor clause catches S3
-	// PG baselines (and pre-#593 local baselines with LSN==0), while the LSN
-	// clause catches a LOCAL PG baseline whose flavor probe returns "" (an index
-	// with no stream_state row). Both clauses are load-bearing. --baseline-only
-	// returns above, before the DB is ever opened, so it never reaches this warn.
+	// work). Detect PG by the recorded flavor OR the baseline's LSN anchor (read
+	// from S3 too since #916). Both clauses are load-bearing: the LSN clause
+	// catches any PG baseline carrying an anchor (post-#593, local or S3); the
+	// flavor clause catches a pre-#593 PG baseline with LSN==0 (no anchor) and
+	// backstops a baseline whose metadata read failed. --baseline-only returns
+	// above, before the DB is ever opened, so it never reaches this warn.
 	if pgReconstructBeta(query.SourceFlavor(db), bmeta.LSN) {
 		slog.Warn("single-row reconstruct for a PostgreSQL source is beta — validated for canonical types (int/numeric/bool/uuid/text/json/enum and the common PK types) but not yet proven end-to-end for timestamptz/float/bytea/interval/array types; verify the round-trip before relying on it (#593)")
 	}
@@ -659,10 +663,10 @@ func resolveGapCheck(flavor string, bmeta baseline.DumpMetadata, firstFile strin
 // pgReconstructBeta reports whether a single-row reconstruct is running against
 // a PostgreSQL source — gate for the beta warning. Either the index records the
 // source flavor as "postgres", or the baseline carries an LSN anchor. Both
-// clauses are load-bearing: the flavor clause catches an S3 PG baseline (the
-// single-row path reads baseline metadata local-only, so bmeta.LSN is 0 for S3)
-// and a pre-#593 local baseline with LSN==0; the LSN clause catches a local PG
-// baseline whose flavor probe returns "" (an index with no stream_state row).
+// clauses are load-bearing: the LSN clause catches any PG baseline carrying an
+// anchor (post-#593, local or S3 — metadata is read from S3 too since #916); the
+// flavor clause catches a pre-#593 PG baseline with LSN==0 (no anchor) and
+// backstops a baseline whose metadata read failed.
 func pgReconstructBeta(flavor string, baselineLSN uint64) bool {
 	return flavor == "postgres" || baselineLSN != 0
 }

--- a/internal/cli/reconstruct_pgbeta_test.go
+++ b/internal/cli/reconstruct_pgbeta_test.go
@@ -4,10 +4,9 @@ import "testing"
 
 // TestPGReconstructBeta pins the #829 beta-warn gate: single-row reconstruct
 // warns for a PostgreSQL source, detected by the recorded flavor OR the
-// baseline's LSN anchor. Both clauses are load-bearing: the flavor clause
-// catches an S3 PG baseline (bmeta.LSN is 0 for S3 on this local-only-metadata
-// path) and a pre-#593 local baseline (LSN==0); the LSN clause catches a local
-// PG baseline whose flavor probe returns "".
+// baseline's LSN anchor. Both clauses are load-bearing: the LSN clause catches
+// any PG baseline carrying an anchor (local or S3, since #916 reads S3 metadata);
+// the flavor clause catches a pre-#593 PG baseline with LSN==0.
 func TestPGReconstructBeta(t *testing.T) {
 	cases := []struct {
 		name   string
@@ -16,7 +15,7 @@ func TestPGReconstructBeta(t *testing.T) {
 		want   bool
 	}{
 		{"postgres flavor, no lsn", "postgres", 0, true},
-		{"empty flavor, lsn set (local baseline, probe blank)", "", 42, true},
+		{"empty flavor, lsn set (anchored baseline, probe blank)", "", 42, true},
 		{"postgres flavor and lsn", "postgres", 99, true},
 		{"empty flavor, no lsn (MySQL file-index)", "", 0, false},
 		{"mysql flavor", "mysql", 0, false},

--- a/internal/reconstruct/fulltable.go
+++ b/internal/reconstruct/fulltable.go
@@ -316,6 +316,17 @@ func ReconstructTable(
 		if !errors.Is(err, ErrNoBaseline) {
 			return nil, fmt.Errorf("find baseline: %w", err)
 		}
+		// Full-table reconstruct is out of GA scope for PostgreSQL (#597). With no
+		// baseline found the LSN anchor is unavailable, so detect PG by the recorded
+		// source flavor and refuse here too — otherwise a PG full-table reconstruct
+		// of a table absent from the baseline would fall through to the binlog-only
+		// (delta-only) report below, mislabeled as a full-table reconstruct (#916).
+		// Mirrors the with-baseline PG gate further down.
+		if query.SourceFlavor(db) == "postgres" {
+			return nil, fmt.Errorf(
+				"full-table reconstruct is not yet supported for PostgreSQL sources (#597); " +
+					"use single-row `reconstruct` or the shim `_flashback` for PostgreSQL time-travel")
+		}
 		// No baseline exists for this table. This can happen when: (1) the
 		// table was empty at dump time and the baseline predates 0-row
 		// Parquet support, or (2) the table was created after the last

--- a/internal/reconstruct/fulltable_pg_gate_test.go
+++ b/internal/reconstruct/fulltable_pg_gate_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DATA-DOG/go-sqlmock"
+
 	"github.com/dbtrail/dbtrail/internal/baseline"
 )
 
@@ -80,5 +82,34 @@ func TestReconstructTable_mysqlMissingCreateTableSQLUnchanged(t *testing.T) {
 	}
 	if strings.Contains(err.Error(), "PostgreSQL") {
 		t.Fatalf("MySQL baseline must not get the PG message: %v", err)
+	}
+}
+
+// TestReconstructTable_pgNoBaselineRefused is the #916 secondary guard: a
+// full-table reconstruct of a PG-flavored source (stream_state.flavor='postgres')
+// for a table with NO baseline must refuse (#597), not fall through to a
+// binlog-only report mislabeled as full-table. With no baseline there is no LSN
+// anchor, so detection is by the recorded source flavor alone.
+func TestReconstructTable_pgNoBaselineRefused(t *testing.T) {
+	dir := t.TempDir() // empty baseline source → FindBaseline returns ErrNoBaseline
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+	mock.ExpectQuery("SELECT flavor FROM stream_state").
+		WillReturnRows(sqlmock.NewRows([]string{"flavor"}).AddRow("postgres"))
+
+	cfg := FullTableConfig{BaselineSrc: dir, At: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)}
+	_, err = ReconstructTable(context.Background(), cfg, "shop", "orders", db, nil, nil, nil, "")
+	if err == nil {
+		t.Fatal("expected the PG no-baseline refusal, got nil")
+	}
+	if !strings.Contains(err.Error(), "not yet supported for PostgreSQL sources (#597)") {
+		t.Fatalf("PG no-baseline reconstruct got the wrong error: %v", err)
+	}
+	if merr := mock.ExpectationsWereMet(); merr != nil {
+		t.Errorf("unmet sqlmock expectations: %v", merr)
 	}
 }


### PR DESCRIPTION
closes #916

Two PG reconstruct gaps surfaced during the #829/#830 review (both shipped-as-deferred there).

## 1. Single-row reconstruct read baseline metadata **local-only**
`internal/cli/reconstruct.go` read metadata under `if !strings.HasPrefix(baselinePath, "s3://")` → for an S3 baseline `bmeta` stayed zero:
- **PG beta warn (#829) could not fire for an S3 PG baseline** — the gate is `SourceFlavor(db)=="postgres" || bmeta.LSN != 0`; with `bmeta.LSN==0` for S3, detection rested entirely on the flavor probe, so a `""` probe (index with no `stream_state` row / old schema / transient blip) left beta-fidelity PG output with **no caveat** (the warn is the only guardrail — warn-not-refuse).
- **Gap detection was disabled for every S3 baseline** (MySQL and PG) — `resolveGapCheck` had no anchor.

**Fix:** use `baseline.ReadParquetMetadataAny` (S3-capable — the exact reader `fulltable.go` already uses). An S3 baseline now populates `bmeta`, so the LSN clause is load-bearing for S3 and gap detection runs against its anchor. Read failure stays non-fatal. **Local behavior is unchanged** (`ReadParquetMetadataAny` delegates to `ReadParquetMetadata` for non-`s3://`). #829's beta-warn / `pgReconstructBeta` / test comments updated to match.

## 2. Full-table PG reconstruct with no baseline fell through instead of refusing
`fulltable.go`'s `ErrNoBaseline → reconstructBinlogOnly` fallback ran **before** the PG gate (#830), so a PG full-table reconstruct of a table absent from the baseline produced a binlog-only (delta-only) report mislabeled as full-table. Added the PG-flavor refusal in that branch too (no baseline → no LSN, detect by flavor), mirroring the with-baseline gate.

## Testing
- Local metadata read is a **proven no-op** — covered by the existing reconstruct integration test.
- The **S3-transport** behavior is validated-by-reuse: the same `ReadParquetMetadataAny` S3 branch `fulltable.go` already ships. This repo has no local S3/minio harness (a documented repo-wide gap — see `parquetquery_s3direct_integration_test.go`).
- The two `SourceFlavor(db)=="postgres"` branches need a live PG-flavored index (the same accepted gap as #830's existing flavor clause).
- `go build ./...` / `go vet` / `gofmt` clean; `reconstruct` + `cli` unit suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
