### PR TITLE
verify: pin character_set_results=binary in checksum scan (#792)

### DIFF
--- a/docs/verify.md
+++ b/docs/verify.md
@@ -86,7 +86,9 @@ Results are **per table**, one of:
 - **inconclusive** — verify could not prove the table either way, and this is
   **never reported as a failure**. Causes include: no predecessor baseline yet,
   the index is behind the baseline anchor, an unsupported primary key, a coverage
-  gap, or a value class this version cannot yet compare.
+  gap, a digest-contract skew between a pre-pin baseline and the current scan
+  (regenerate the baseline — see below), or a value class this version cannot yet
+  compare.
 
 ## Exit codes (for cron / CI)
 
@@ -142,20 +144,32 @@ See also: the stream-continuity "no data lost" signal in
 [`bintrail status`](rotation-and-status.md#stream-continuity-no-data-lost), which
 verifies the *other* half — that no events were dropped from the capture stream.
 
-## Connection charset affects the digest
+## Charset contract: raw stored bytes
 
 The row-content fingerprint is computed over the bytes MySQL returns for each
-column, which depend on the **connection's charset** (`character_set_results`
-and friends) at read time. Two digests are only directly comparable when
-computed against the same connection charset. On a source with non-`utf8mb4`
-columns (`latin1`, `sjis`, binary-collation `VARBINARY`-as-text, etc.), reading
-the two sides of a comparison under different effective charsets can produce a
-false **MISMATCH** even though the underlying bytes are identical — the digest
-differs because the client-side re-encoding differs, not because the data
-does. If you see mismatches concentrated on legacy-charset tables, this is the
-first thing to rule out; a future release will pin
-`character_set_results=binary` so the comparison is charset-independent by
-construction.
+column. To make that byte stream independent of the connection charset, the
+checksum scan pins `character_set_results = binary`, so the server returns each
+string column's **raw stored bytes** with no transcoding — the same contract
+mydumper's `SET NAMES binary` writes the baseline Parquet under. A `latin1` `é`
+(byte `0xE9`) therefore hashes as `0xE9` on both the live-scan side and the
+baseline side, instead of the server transcoding it to utf8mb4 (`0xC3 0xA9`) on
+one side only. Without this pin, every non-ASCII row of a legacy-charset
+(`latin1`, `sjis`, …) table would differ in bytes even under a byte-correct
+restore — a permanent, conclusive false **MISMATCH**. The pin removes the
+charset dependency by construction.
+
+### Digest version tag
+
+Each digest carries a leading version tag (currently `v2:`) recording the
+contract it was computed under — the Go-side encoding plus the MySQL-side
+rendering (text protocol, session time zone UTC, and
+`character_set_results = binary`). Pinning the binary charset bumped the tag
+from `v1:` to `v2:`. Two digests are only byte-comparable when their tags match;
+a **version skew** — e.g. a persisted `v1:` baseline digest written before the
+pin, compared against a current `v2:` scan — is reported as **inconclusive**
+with a "regenerate the baseline" hint, never as a false MISMATCH. Re-run
+`bintrail baseline` to refresh the tag: the raw-byte content is unchanged, only
+the contract tag differs.
 
 ## Notes per source
 

--- a/internal/consistency/checksum.go
+++ b/internal/consistency/checksum.go
@@ -81,12 +81,15 @@ type TableChecksum struct {
 // UNSIGNED integers print unsigned, DATETIME/TIMESTAMP carry their declared
 // fractional precision, DECIMAL is pre-formatted, JSON is normalized (MySQL;
 // MariaDB stores JSON as LONGTEXT and renders it verbatim) — so no
-// per-type canonicalization is reimplemented here. The Parquet side of the
-// comparison (#634) must reproduce this same contract: "MySQL text rendering,
-// session time zone UTC". Two digests are only comparable when computed against
-// the same connection charset and server family — string transcoding and
-// FLOAT/DOUBLE text rendering depend on both — which is the natural case since
-// the baseline and its verify run against the same source.
+// per-type canonicalization is reimplemented here. String columns are read with
+// character_set_results = binary, so their RAW STORED BYTES are hashed (no
+// transcoding to the connection charset) — matching mydumper's `SET NAMES
+// binary` dump contract (issue #792). The Parquet side of the comparison (#634)
+// must reproduce this same contract: "MySQL text rendering, session time zone
+// UTC, raw string bytes". Two digests remain FLOAT/DOUBLE-text-rendering and
+// server-family dependent, which is the natural case since the baseline and its
+// verify run against the same source; the charset dependency is now removed by
+// the binary pin.
 //
 // Generated columns (VIRTUAL/STORED) are excluded: mydumper does not dump them,
 // so they are absent from the baseline Parquet and must be absent here too.
@@ -135,6 +138,19 @@ func consistentTableChecksum(ctx context.Context, db *sql.DB, schema, table stri
 	// (TIMESTAMP is stored in UTC and rendered in the session zone).
 	if _, err := conn.ExecContext(ctx, "SET SESSION time_zone = '+00:00'"); err != nil {
 		return res, fmt.Errorf("set session time_zone: %w", err)
+	}
+
+	// Pin character_set_results = binary so the server returns each string
+	// column's RAW STORED BYTES without transcoding them to the connection
+	// charset (go-sql-driver's default is utf8mb4). This matches mydumper's
+	// `SET NAMES binary` dump contract, which the baseline Parquet is written
+	// under: a latin1 'é' (0xE9) then hashes as 0xE9 on BOTH the baseline side
+	// and this live-scan side, instead of the server transcoding it to utf8mb4
+	// (0xC3A9) here and producing a permanent, conclusive false-MISMATCH on
+	// every non-ASCII row of a legacy-charset table (issue #792). The pin is the
+	// v2 half of the digest contract — see digestVersion.
+	if _, err := conn.ExecContext(ctx, "SET SESSION character_set_results = binary"); err != nil {
+		return res, fmt.Errorf("set session character_set_results: %w", err)
 	}
 
 	// Open the consistent snapshot. Everything below reads the same view.
@@ -226,13 +242,39 @@ func consistentTableChecksum(ctx context.Context, db *sql.DB, schema, table stri
 
 // digestVersion tags the digest with the contract it was computed under — both
 // the Go-side encoding (field tagging, FNV-1a/64, additive fold) and the
-// MySQL-side rendering (text protocol, session tz UTC). Two digests are only
-// comparable when their tags match; because #634 compares with plain ==, an
-// incompatible contract fails loud instead of producing a false mismatch that
-// reads like real corruption. Persisted baselines (#633) carry this tag, so the
-// only free moment to introduce it is before the first baseline is written. Bump
-// to "v2:" if the encoding or rendering contract ever changes.
-const digestVersion = "v1:"
+// MySQL-side rendering (text protocol, session tz UTC, and
+// character_set_results = binary so string columns hash as their raw stored
+// bytes). Two digests are only comparable when their tags match; a version skew
+// must be treated as needs-rebaseline, not a false mismatch — DigestVersionOf
+// lets a consumer detect the skew before it byte-compares (see the verify
+// capstone's classify). Persisted baselines (#633) carry this tag.
+//
+// Bumped v1 → v2 for the character_set_results = binary pin (issue #792): the v1
+// live scan transcoded string columns to the connection charset (utf8mb4) while
+// the persisted baseline digest was always over mydumper's raw `SET NAMES
+// binary` bytes, so the two silently disagreed for any non-ASCII legacy-charset
+// value. v2 makes both sides read raw bytes. A v1 baseline digest is NOT
+// byte-comparable to a v2 scan — regenerate the baseline (its raw-byte content
+// is unchanged; only the tag differs).
+const digestVersion = "v2:"
+
+// DigestVersion is the current digest contract tag (see digestVersion). Exported
+// so a consumer comparing a persisted digest against a freshly computed one can
+// tell whether they share a contract.
+const DigestVersion = digestVersion
+
+// DigestVersionOf returns the "vN:" version-tag prefix of a digest produced by
+// this package (ConsistentTableChecksum / Hasher.Digest) — the text up to and
+// including the first ':'. It returns "" when the string carries no recognizable
+// tag (e.g. an empty or pre-tag legacy value). Comparing two digests whose tags
+// differ would byte-differ even on identical data, so a consumer must degrade to
+// a needs-rebaseline signal rather than report a false mismatch.
+func DigestVersionOf(digest string) string {
+	if i := strings.IndexByte(digest, ':'); i >= 0 {
+		return digest[:i+1]
+	}
+	return ""
+}
 
 // capturedGTID reads @@gtid_executed inside the snapshot. MySQL always exposes
 // this variable (empty string when gtid_mode=OFF); MariaDB does not have it, in

--- a/internal/consistency/checksum_integration_test.go
+++ b/internal/consistency/checksum_integration_test.go
@@ -290,6 +290,35 @@ func TestConsistentTableChecksum_MultibyteStringsDiffer(t *testing.T) {
 	}
 }
 
+func TestConsistentTableChecksum_Latin1RawBytesNotTranscoded(t *testing.T) {
+	db, schema := testutil.CreateTestDB(t)
+	// #792: the scan pins character_set_results = binary, so a latin1 column's
+	// stored bytes are hashed RAW (matching mydumper's SET NAMES binary dump
+	// contract the baseline Parquet is written under), NOT transcoded to the
+	// connection's utf8mb4. 'é' is one byte 0xE9 in latin1; under a transcode it
+	// would become two bytes 0xC3 0xA9. Proven by hashing a VARBINARY column that
+	// stores the raw byte X'E9' and asserting the two digests MATCH — they only
+	// match if no transcoding happened. Without the pin this is the permanent,
+	// conclusive false-MISMATCH class #792 describes.
+	testutil.MustExec(t, db, "CREATE TABLE lat (id INT PRIMARY KEY, s VARCHAR(8) CHARACTER SET latin1)")
+	testutil.MustExec(t, db, "CREATE TABLE raw (id INT PRIMARY KEY, s VARBINARY(8))")
+	testutil.MustExec(t, db, "INSERT INTO lat VALUES (1, _latin1 X'E9')") // 'é' → stored byte 0xE9
+	testutil.MustExec(t, db, "INSERT INTO raw VALUES (1, X'E9')")         // raw byte 0xE9
+
+	ctx := context.Background()
+	cl, err := ConsistentTableChecksum(ctx, db, schema, "lat")
+	if err != nil {
+		t.Fatalf("checksum lat: %v", err)
+	}
+	cr, err := ConsistentTableChecksum(ctx, db, schema, "raw")
+	if err != nil {
+		t.Fatalf("checksum raw: %v", err)
+	}
+	if cl.Digest != cr.Digest {
+		t.Errorf("latin1 byte was transcoded (charset pin not applied): latin1=%s raw=%s", cl.Digest, cr.Digest)
+	}
+}
+
 func TestConsistentTableChecksum_NullDistinctFromEmpty(t *testing.T) {
 	db, schema := testutil.CreateTestDB(t)
 	testutil.MustExec(t, db, "CREATE TABLE a (id INT PRIMARY KEY, name VARCHAR(64))")
@@ -317,7 +346,7 @@ func TestConsistentTableChecksum_EmptyTable(t *testing.T) {
 	if c.RowCount != 0 {
 		t.Errorf("RowCount = %d, want 0", c.RowCount)
 	}
-	if c.Digest != "v1:0000000000000000" {
+	if c.Digest != digestVersion+"0000000000000000" {
 		t.Errorf("Digest = %q, want version-tagged all-zero for empty table", c.Digest)
 	}
 }

--- a/internal/consistency/checksum_test.go
+++ b/internal/consistency/checksum_test.go
@@ -96,6 +96,30 @@ func TestRowHasher_EmptyTable(t *testing.T) {
 	}
 }
 
+func TestDigestVersionOf(t *testing.T) {
+	cases := map[string]string{
+		"v2:0011223344556677": "v2:", // current contract tag
+		"v1:deadbeef":         "v1:", // a persisted pre-pin baseline digest
+		"":                    "",    // empty
+		"deadbeef":            "",    // untagged legacy value (no ':')
+		":abc":                ":",   // degenerate but tagged
+	}
+	for in, want := range cases {
+		if got := DigestVersionOf(in); got != want {
+			t.Errorf("DigestVersionOf(%q) = %q, want %q", in, got, want)
+		}
+	}
+	// The exported contract tag must round-trip through DigestVersionOf, so a
+	// consumer comparing a freshly computed digest can detect its own version.
+	if got := DigestVersionOf(DigestVersion + "0000000000000000"); got != DigestVersion {
+		t.Errorf("DigestVersionOf(current digest) = %q, want %q", got, DigestVersion)
+	}
+	// Pin the #792 bump so an accidental revert to v1 is caught.
+	if DigestVersion != "v2:" {
+		t.Errorf("DigestVersion = %q, want \"v2:\" (charset-pin contract, #792)", DigestVersion)
+	}
+}
+
 func TestQuoteIdent(t *testing.T) {
 	cases := map[string]string{
 		"id":       "`id`",

--- a/internal/verify/classify_test.go
+++ b/internal/verify/classify_test.go
@@ -27,6 +27,18 @@ func TestClassify(t *testing.T) {
 		// Equal digest must win even under deferredRepr (a deferred column that
 		// did not actually diverge still matches).
 		{"equal digest + deferred → match", dA, 10, dA, 10, true, StatusMatch},
+		// #792 digest-contract skew: a persisted pre-pin v1 digest compared
+		// against a current v2 scan byte-differs even on identical data, so it
+		// must degrade to inconclusive (needs-rebaseline), NEVER a false mismatch.
+		{"version skew, same hash bytes → inconclusive not mismatch", "v1:aaaa", 10, "v2:aaaa", 10, false, StatusInconclusive},
+		{"version skew, different hash bytes → inconclusive not mismatch", "v1:aaaa", 10, "v2:bbbb", 10, false, StatusInconclusive},
+		{"untagged legacy vs tagged → inconclusive", "aaaa", 10, "v2:aaaa", 10, false, StatusInconclusive},
+		// Row loss stays conclusive UNDER a version skew: row count is version-
+		// independent and checked first, so real loss is never masked as needs-rebaseline.
+		{"version skew but row count differs → still mismatch", "v1:aaaa", 10, "v2:aaaa", 7, false, StatusMismatch},
+		// Same (current) contract on both sides compares normally.
+		{"same v2 contract, equal → match", "v2:aaaa", 10, "v2:aaaa", 10, false, StatusMatch},
+		{"same v2 contract, differ → mismatch", "v2:aaaa", 10, "v2:bbbb", 10, false, StatusMismatch},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -217,6 +217,16 @@ func classify(srcDigest string, srcRows int64, reconDigest string, reconRows int
 	if reconRows != srcRows {
 		return StatusMismatch, fmt.Sprintf("row count differs: source=%d reconstructed=%d", srcRows, reconRows)
 	}
+	// Equal row count — the byte comparison below is only meaningful when both
+	// digests were produced under the SAME contract version (consistency.
+	// DigestVersion). A version skew (e.g. a persisted pre-charset-pin v1 baseline
+	// digest against a current v2 scan, issue #792) byte-differs even on identical
+	// data, so it must degrade to a needs-rebaseline signal, never a false
+	// MISMATCH. Row count is version-independent, so it stays checked first: real
+	// row loss/gain is still conclusive under a version skew.
+	if sv, rv := consistency.DigestVersionOf(srcDigest), consistency.DigestVersionOf(reconDigest); sv != rv {
+		return StatusInconclusive, fmt.Sprintf("digest contract skew (%q vs %q): the compared digests were produced under different versions; regenerate the baseline (bintrail baseline) so both sides use the current contract", sv, rv)
+	}
 	if reconDigest == srcDigest {
 		return StatusMatch, ""
 	}


### PR DESCRIPTION
## Problem

The consistency checksum scan (`internal/consistency/checksum.go`) pinned the session `time_zone` but **not** the result charset, so string columns were transcoded to the connection charset (go-sql-driver's `utf8mb4` default). The baseline Parquet, however, is written by mydumper under `SET NAMES binary` — raw stored bytes.

For a legacy `latin1` table with any non-ASCII text this made every intact row byte-differ between the two sides: a `latin1` `é` (`0xE9`) hashed as `0xE9` on the baseline side but as `0xC3 0xA9` on the live-scan side. Result: a permanent, **conclusive** false MISMATCH on every non-ASCII row — even under a byte-correct restore — in both live-source and baseline-time comparisons. The package doc already stated the two digests are only comparable at the same connection charset; nothing enforced it.

## Fix

- Pin `character_set_results = binary` in the checksum session so string columns hash as their **raw stored bytes** on both sides, matching mydumper's `SET NAMES binary` contract.
- Bump the digest contract tag `v1:` → `v2:` and **guard version skew**: `classify` treats a tag mismatch (e.g. a persisted pre-pin `v1:` baseline digest vs a current `v2:` scan) as **Inconclusive** with a "regenerate the baseline" hint — never a false MISMATCH. Row-count differences are still checked first, so real row loss/gain stays conclusive under a skew.
- Export `DigestVersion` / `DigestVersionOf` so a consumer can detect the skew before it byte-compares.

Additive only — no rewrite of the existing scan/compare logic.

## Test

- Unit: `TestDigestVersionOf` (tag extraction + current-contract round-trip + pins the `v2:` bump), and new `TestClassify` cases for the version-skew paths (skew → inconclusive; skew + row-count diff → still mismatch; same-`v2:` → normal compare).
- Integration: `TestConsistentTableChecksum_Latin1RawBytesNotTranscoded` — a `latin1` column holding `é` (`0xE9`) hashes to the **same** digest as a `VARBINARY` column holding `X'E9'`, proving the byte is hashed un-transcoded (a transcode would yield `0xC3 0xA9` and a different digest).
- Docs: charset contract and version-tag / needs-rebaseline semantics documented in `docs/verify.md`.

`CGO_ENABLED=1 go build` + unit tests pass for `internal/consistency`, `internal/verify`, and all downstream importers; the integration test compiles under `-tags integration`.

Closes #792
