### PR TITLE
pg: pin rendering GUCs on capture + baseline sessions; fold-validated type matrix (#593 slice D)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,6 +339,8 @@ jobs:
             ./internal/pgcapture/ ./internal/pgstreamrun/ ./internal/pgbaseline/ 2>&1 | tee /tmp/pg-it.out
           grep -q -- '--- PASS: TestOne_EndToEnd_PostgresToIndexToRecovery' /tmp/pg-it.out \
             || { echo "FATAL: PG end-to-end integration test did not run — false-green tripwire" >&2; exit 1; }
+          grep -q -- '--- PASS: TestPGBaseline_Integration' /tmp/pg-it.out \
+            || { echo "FATAL: pgbaseline integration suite did not run — false-green tripwire" >&2; exit 1; }
 
   console-e2e:
     # Headless-Chrome regression guard for the console SPA: go test never

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,7 +336,7 @@ jobs:
         run: |
           set -o pipefail
           go test -tags=integration -race -p 1 -count=1 -v \
-            ./internal/pgcapture/ ./internal/pgstreamrun/ 2>&1 | tee /tmp/pg-it.out
+            ./internal/pgcapture/ ./internal/pgstreamrun/ ./internal/pgbaseline/ 2>&1 | tee /tmp/pg-it.out
           grep -q -- '--- PASS: TestOne_EndToEnd_PostgresToIndexToRecovery' /tmp/pg-it.out \
             || { echo "FATAL: PG end-to-end integration test did not run — false-green tripwire" >&2; exit 1; }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **PostgreSQL rendering GUCs pinned on capture and baseline sessions** (#593 slice D). The baseline+delta reconstruct design rests on the identity *baseline COPY text ≡ pgoutput delta text* — the PK join and last-write-wins merge are exact string operations — but both sides render values through PostgreSQL's session-GUC-dependent output functions, and neither session pinned any GUC: the same logical value could render as different text on the two sides, silently breaking the merge for `timestamptz`/`timestamp`/`date`/`time`, `real`/`double precision`, `bytea`, and `interval`. Every connection that renders row text — the logical-decoding (walsender) session and the baseline COPY connections — is now pinned via startup parameters to `TimeZone=UTC`, `DateStyle=ISO`, `extra_float_digits=3`, `bytea_output=hex`, `IntervalStyle=postgres`; the pinned set is stamped into the baseline Parquet metadata (`bintrail.render_gucs`), and single-row `reconstruct` warns when it reads a pre-pin baseline. The full type matrix is now validated **through the single-row reconstruct fold** under deliberately skewed session GUCs on the PG 14–17 CI matrix (`TestOne_PGTypeMatrixThroughReconstructFold`); the single-row PG beta warning narrows to container types only.
+
+  **Upgrade note:** on servers whose defaults differ from the pinned values, baselines taken **before** this release were rendered under the unpinned session defaults and their GUC-sensitive text will not text-join deltas captured **after** the upgrade (worst case, a `timestamptz`/`float` value silently stops matching in the fold). Re-run `bintrail-pg baseline` after upgrading. Events indexed before the upgrade keep their original rendering and cannot be re-rendered; a fold window spanning the upgrade on such a server can mix renderings.
+
 ## [0.29.2] - 2026-07-05
 
 ### Fixed

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -348,7 +348,13 @@ directly.
 > round-trip. **Re-baseline after upgrading:** baselines taken before the
 > rendering-GUC pin were rendered under your server's session defaults; on a
 > server whose defaults differ from the pinned values, re-run
-> `bintrail-pg baseline` — the baseline↔delta merge is an exact text join.
+> `bintrail-pg baseline` — the baseline↔delta merge is an exact text join
+> (the reader warns when it meets a pre-pin baseline). Events indexed
+> **before** the upgrade also keep their pre-pin rendering: on such a server a
+> GUC-sensitive primary key (`timestamptz`, `float`) has two text identities
+> across the upgrade, so `--pk` lookups and `--history` can split there;
+> re-baselining resolves this going forward (deltas before the new anchor are
+> not replayed).
 > **Full-table** `reconstruct` (`--output-format mydumper`) and
 > baseline-anchored `verify` remain deliberately out of scope: a PG baseline
 > does not carry the `CREATE TABLE` metadata full-table reconstruct needs.

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -335,17 +335,27 @@ directly.
 > MySQL.** `bintrail-pg baseline` takes a consistent Parquet snapshot directly
 > from a live PostgreSQL source, anchored to the replication slot's own LSN
 > floor. It feeds **single-row** `reconstruct` and the shim's **single-row**
-> `_snapshot` — both fold a PG baseline with binlog deltas with no
-> PostgreSQL-specific gate, so they run today. This path is **beta and
-> untested end-to-end** for PostgreSQL-specific types (`bytea`,
-> `timestamptz`, arrays) flowing through the fold — validate your own
-> round-trip before relying on it. **Full-table** `reconstruct`
-> (`--output-format mydumper`) and baseline-anchored `verify` remain
-> deliberately out of scope: a PG baseline does not carry the `CREATE TABLE`
-> metadata full-table reconstruct needs. `query` and `recover` (which work
-> from the indexed deltas alone, no baseline required) are the
-> fully-supported recovery surface for PostgreSQL in this release — see
-> [Beta limitations](#beta-limitations) for the complete picture.
+> `_snapshot` — both fold a PG baseline with binlog deltas. This fold is
+> **validated end-to-end for scalar types**: the canonical set (`int2/4/8`,
+> `numeric`, `bool`, `uuid`, `text`/`varchar`/`char`, `json`, `jsonb`, enums)
+> **and** the GUC-sensitive set (`timestamptz`, `timestamp`/`date`/`time`,
+> `real`/`double precision`, `bytea`, `interval`), whose text rendering is
+> pinned identically on the baseline COPY connections and the logical-decoding
+> session (`TimeZone=UTC`, `DateStyle=ISO`, `extra_float_digits=3`,
+> `bytea_output=hex`, `IntervalStyle=postgres`). Container types (arrays
+> beyond the tested `integer[]`/`text[]`, composite, range/multirange,
+> `hstore`, geometric) remain untested through the fold — validate your own
+> round-trip. **Re-baseline after upgrading:** baselines taken before the
+> rendering-GUC pin were rendered under your server's session defaults; on a
+> server whose defaults differ from the pinned values, re-run
+> `bintrail-pg baseline` — the baseline↔delta merge is an exact text join.
+> **Full-table** `reconstruct` (`--output-format mydumper`) and
+> baseline-anchored `verify` remain deliberately out of scope: a PG baseline
+> does not carry the `CREATE TABLE` metadata full-table reconstruct needs.
+> `query` and `recover` (which work from the indexed deltas alone, no baseline
+> required) are the fully-supported recovery surface for PostgreSQL in this
+> release — see [Beta limitations](#beta-limitations) for the complete
+> picture.
 
 ---
 
@@ -455,22 +465,24 @@ value is stored verbatim as text — never reparsed through a numeric type in th
 index — the `numeric`-via-`float64` precision class that the MySQL path had to guard
 against simply cannot occur here.
 
-The following types are **round-trip tested** — insert → capture → index → `recover`
-→ re-execute the reversal against live PostgreSQL, asserting the column's canonical
-`::text` is byte-for-byte identical — in `internal/pgstreamrun`
-(`TestOne_PGTypeRoundTripMatrix`, run across the PG 14/15/16/17 CI matrix):
+The following types are **round-trip tested** two ways — insert → capture → index →
+`recover` → re-execute the reversal against live PostgreSQL, asserting the column's
+canonical `::text` is byte-for-byte identical (`TestOne_PGTypeRoundTripMatrix`), and
+through the **baseline+delta reconstruct fold** under deliberately skewed session
+GUCs (`TestOne_PGTypeMatrixThroughReconstructFold`) — in `internal/pgstreamrun`,
+run across the PG 14/15/16/17 CI matrix:
 
 | Category | Types | Notes |
 |---|---|---|
 | Integer | `smallint`, `integer`, `bigint` | exact |
 | Arbitrary precision | `numeric` (`decimal` is its alias) | full **precision and scale** preserved — values > 2^53 and trailing zeros (`1.50`) survive |
-| Floating point | `real`, `double precision` | |
+| Floating point | `real`, `double precision` | rendered under pinned `extra_float_digits=3` (shortest-precise) on both capture and baseline sessions |
 | Character | `text`, `varchar(n)`, `char(n)` | single quotes and backslashes escaped correctly (`standard_conforming_strings`); `char(n)` round-trips (trailing blanks are insignificant in `bpchar` — PostgreSQL trims them on cast to text) |
 | Boolean | `boolean` | |
 | UUID | `uuid` | |
-| Binary | `bytea` | hex (`\x…`) form |
+| Binary | `bytea` | hex (`\x…`) form — guaranteed by the pinned `bytea_output=hex`, no longer default-dependent |
 | JSON | `json`, `jsonb` | `jsonb` tested with an embedded quote |
-| Date / time | `date`, `time`, `timestamp`, `timestamptz`, `interval` | a `timestamptz`'s text form follows the server timezone (consistent within an instance) |
+| Date / time | `date`, `time`, `timestamp`, `timestamptz`, `interval` | rendered under pinned `TimeZone=UTC` / `DateStyle=ISO` / `IntervalStyle=postgres` on both capture and baseline sessions — no longer dependent on server defaults |
 | Network | `inet`, `cidr`, `macaddr` | |
 | Bit string | `bit(n)`, `varbit` | |
 | Range | `int4range` | the other built-in range types share the same text mechanism |
@@ -487,9 +499,10 @@ for a PostgreSQL source.
 
 **Untested / best-effort:** `hstore` and other extension-provided types are covered
 under [Extensions and custom types](#extensions-and-custom-types) below. Composite
-types, multi-dimensional arrays, and arrays containing `NULL` are not yet in the
-round-trip suite — they are captured as text and are expected to coerce, but verify
-your own round-trip.
+types, range types beyond `int4range`, multirange, geometric types beyond `point`,
+arrays beyond the tested `integer[]`/`text[]` (multi-dimensional, `NULL`-containing)
+are not yet in the round-trip suite — they are captured as text and are expected to
+coerce, but verify your own round-trip.
 
 ---
 
@@ -551,8 +564,11 @@ your own round-trip.
 - **Full-table `reconstruct` and baseline-anchored `verify` are not wired for
   PostgreSQL** — a PG baseline deliberately omits the `CREATE TABLE` metadata
   full-table reconstruct needs (see above). **Single-row** `reconstruct` and
-  the shim's single-row `_snapshot` DO work against a PG baseline today, but
-  are beta/untested end-to-end for PostgreSQL-specific types. (`recover` and
+  the shim's single-row `_snapshot` work against a PG baseline and are
+  validated end-to-end for scalar types — including the GUC-sensitive set,
+  rendered under session GUCs pinned identically at capture and baseline;
+  container types remain beta (see
+  [Querying and recovering](#querying-and-recovering)). (`recover` and
   `recover-cascade` work unconditionally, with no baseline needed; cascades
   are captured as ordinary row changes — see
   [Querying and recovering](#querying-and-recovering).)
@@ -567,10 +583,11 @@ your own round-trip.
 
 The data-safety items that gated **beta** are now closed (type fidelity,
 identity/generated recovery, slot/WAL monitoring, RI-FULL validation, DDL-drift
-handling, and the silent-loss coverage guards above). Source-aware console
-presentation, including the live replication-health panel, shipped in v0.20.1.
-The remaining limitation — full-table `reconstruct` / time-travel via a
-PostgreSQL baseline — is tracked toward **GA** in
+handling, the silent-loss coverage guards above, and the baseline↔delta
+rendering-GUC identity with its fold-validated type matrix, #593). Source-aware
+console presentation, including the live replication-health panel, shipped in
+v0.20.1. The remaining limitation — **full-table** `reconstruct` / time-travel
+via a PostgreSQL baseline — is tracked toward **GA** in
 [#597](https://github.com/dbtrail/dbtrail/issues/597). The managed-PostgreSQL
 smoke covers RDS and Aurora — see
 [Managed PostgreSQL](#managed-postgresql).

--- a/internal/baseline/metadata.go
+++ b/internal/baseline/metadata.go
@@ -73,6 +73,15 @@ const (
 	MetaKeyRenderGUCs = "bintrail.render_gucs"
 )
 
+// RenderGUCsPinned is the canonical value the capture side stamps under
+// MetaKeyRenderGUCs (pgcapture.RenderGUCsStamp builds it from its pinned GUC
+// list; the two are cross-pinned by pgcapture's unit test). It lives here so
+// the READ layer can compare a baseline's stamp against the current pin
+// without importing pgcapture (which would link pgx into the MySQL binary).
+// A stamp that is absent OR different means the baseline's GUC-sensitive text
+// may not join deltas rendered under the current pin.
+const RenderGUCsPinned = "TimeZone=UTC;DateStyle=ISO;extra_float_digits=3;bytea_output=hex;IntervalStyle=postgres"
+
 // DumpMetadata contains information parsed from a mydumper metadata file or
 // from a baseline Parquet file's key-value metadata.
 type DumpMetadata struct {

--- a/internal/baseline/metadata.go
+++ b/internal/baseline/metadata.go
@@ -65,6 +65,12 @@ const (
 	// never returned in a trustworthy-digest / untrustworthy-count combination.
 	MetaKeyRowCount      = "bintrail.baseline_row_count"
 	MetaKeyContentDigest = "bintrail.baseline_content_digest"
+	// MetaKeyRenderGUCs records the pinned PostgreSQL rendering-GUC set the
+	// baseline's text was produced under (pgcapture.RenderGUCsStamp, #593
+	// slice D). Its ABSENCE on an LSN-anchored (PG) baseline marks a pre-pin
+	// baseline whose GUC-sensitive text may not join post-pin deltas — readers
+	// warn and recommend re-baselining. Absent on MySQL/MariaDB baselines.
+	MetaKeyRenderGUCs = "bintrail.render_gucs"
 )
 
 // DumpMetadata contains information parsed from a mydumper metadata file or
@@ -78,6 +84,7 @@ type DumpMetadata struct {
 	ContentDigest  string // version-tagged content fingerprint; set after #633, empty when absent (old baselines)
 	RowCount       int64  // rows ingested into this table's baseline; valid only when ContentDigest != ""
 	LSN            uint64 // PostgreSQL WAL LSN delta-replay floor, inclusive (MetaKeyLSN, see its doc comment / #771); 0 = absent (MySQL baseline, or pre-#593 PG baseline)
+	RenderGUCs     string // pinned rendering-GUC stamp (MetaKeyRenderGUCs, #593 slice D); "" = pre-pin PG baseline or MySQL baseline
 }
 
 // StartedAtMarkerFile is a bintrail-authored sidecar written into the mydumper
@@ -249,6 +256,9 @@ func ReadParquetMetadata(path string) (DumpMetadata, error) {
 	if v, ok := pf.Lookup(MetaKeyContentDigest); ok {
 		m.ContentDigest = v
 	}
+	if v, ok := pf.Lookup(MetaKeyRenderGUCs); ok {
+		m.RenderGUCs = v
+	}
 	if v, ok := pf.Lookup(MetaKeyRowCount); ok {
 		n, parseErr := strconv.ParseInt(v, 10, 64)
 		if parseErr != nil {
@@ -330,6 +340,8 @@ func ReadParquetMetadataAny(ctx context.Context, path string) (DumpMetadata, err
 			m.CreateTableSQL = val
 		case MetaKeyContentDigest:
 			m.ContentDigest = val
+		case MetaKeyRenderGUCs:
+			m.RenderGUCs = val
 		case MetaKeyRowCount:
 			if n, parseErr := strconv.ParseInt(val, 10, 64); parseErr == nil {
 				m.RowCount = n

--- a/internal/cli/reconstruct.go
+++ b/internal/cli/reconstruct.go
@@ -285,19 +285,30 @@ func runReconstruct(cmd *cobra.Command, args []string) error {
 	}
 
 	// Single-row reconstruct (and the shim's _snapshot) run generically for a
-	// PostgreSQL source — there is no PG-specific gate, so this path is live
-	// today. It is validated for canonical, session-GUC-independent types; the
-	// GUC-sensitive and container types are beta and not yet proven end-to-end
-	// through the baseline↔delta fold (#593 slice D). Warn — never refuse (the
-	// path is honest-best-effort and a refusal would break the surface that DOES
-	// work). Detect PG by the recorded flavor OR the baseline's LSN anchor (read
-	// from S3 too since #916). Both clauses are load-bearing: the LSN clause
-	// catches any PG baseline carrying an anchor (post-#593, local or S3); the
-	// flavor clause catches a pre-#593 PG baseline with LSN==0 (no anchor) and
+	// PostgreSQL source — there is no PG-specific gate. Scalar types INCLUDING
+	// the GUC-sensitive set (timestamptz/timestamp/date/time, float4/float8,
+	// bytea, interval) are proven end-to-end through the baseline↔delta fold
+	// under rendering GUCs pinned identically on the baseline COPY and
+	// walsender sessions (#593 slice D, pgcapture/gucpin.go,
+	// TestOne_PGTypeMatrixThroughReconstructFold); the residual beta surface
+	// is container types only. Warn — never refuse (the path is honest-best-
+	// effort and a refusal would break the surface that DOES work). Detect PG
+	// by the recorded flavor OR the baseline's LSN anchor (read from S3 too
+	// since #916). Both clauses are load-bearing: the LSN clause catches any
+	// PG baseline carrying an anchor (post-#593, local or S3); the flavor
+	// clause catches a pre-#593 PG baseline with LSN==0 (no anchor) and
 	// backstops a baseline whose metadata read failed. --baseline-only returns
-	// above, before the DB is ever opened, so it never reaches this warn.
+	// above, before the DB is ever opened, so it never reaches these warns.
 	if pgReconstructBeta(query.SourceFlavor(db), bmeta.LSN) {
-		slog.Warn("single-row reconstruct for a PostgreSQL source is beta — validated for canonical types (int/numeric/bool/uuid/text/json/enum and the common PK types) but not yet proven end-to-end for timestamptz/float/bytea/interval/array types; verify the round-trip before relying on it (#593)")
+		slog.Warn("single-row reconstruct for a PostgreSQL source: scalar types (including timestamptz/timestamp/date/time, float, bytea, interval — rendered under session GUCs pinned identically at capture and baseline) are validated end-to-end; container types (arrays beyond integer[]/text[], composite, range/multirange, hstore, geometric) remain beta — verify the round-trip before relying on them (#593)")
+		// A pre-pin PG baseline (LSN anchor present but no rendering-GUC
+		// stamp) was rendered under the server's session defaults; on a server
+		// whose defaults differ from the pin, its GUC-sensitive text will not
+		// join post-pin deltas — the merge is an exact text join. Warn with
+		// the remediation.
+		if bmeta.LSN != 0 && bmeta.RenderGUCs == "" {
+			slog.Warn("this baseline predates rendering-GUC pinning (#593) — on a server whose TimeZone/DateStyle/extra_float_digits/bytea_output/IntervalStyle defaults differ from the pinned values, its GUC-sensitive text will not match newer deltas; re-run `bintrail-pg baseline` to refresh it")
+		}
 	}
 
 	// Refuse if a TRUNCATE/DROP/RENAME hit this table in the window: it emits

--- a/internal/cli/reconstruct.go
+++ b/internal/cli/reconstruct.go
@@ -301,13 +301,16 @@ func runReconstruct(cmd *cobra.Command, args []string) error {
 	// above, before the DB is ever opened, so it never reaches these warns.
 	if pgReconstructBeta(query.SourceFlavor(db), bmeta.LSN) {
 		slog.Warn("single-row reconstruct for a PostgreSQL source: scalar types (including timestamptz/timestamp/date/time, float, bytea, interval — rendered under session GUCs pinned identically at capture and baseline) are validated end-to-end; container types (arrays beyond integer[]/text[], composite, range/multirange, hstore, geometric) remain beta — verify the round-trip before relying on them (#593)")
-		// A pre-pin PG baseline (LSN anchor present but no rendering-GUC
-		// stamp) was rendered under the server's session defaults; on a server
-		// whose defaults differ from the pin, its GUC-sensitive text will not
-		// join post-pin deltas — the merge is an exact text join. Warn with
-		// the remediation.
-		if bmeta.LSN != 0 && bmeta.RenderGUCs == "" {
-			slog.Warn("this baseline predates rendering-GUC pinning (#593) — on a server whose TimeZone/DateStyle/extra_float_digits/bytea_output/IntervalStyle defaults differ from the pinned values, its GUC-sensitive text will not match newer deltas; re-run `bintrail-pg baseline` to refresh it")
+		// A PG baseline whose rendering-GUC stamp is absent (pre-pin, rendered
+		// under the server's session defaults) OR different from the current
+		// pin was rendered under other GUCs; on a server whose defaults differ
+		// from the pin, its GUC-sensitive text will not join post-pin deltas —
+		// the merge is an exact text join. Warn with the remediation.
+		// (Comparing the VALUE, not mere presence, also catches a baseline
+		// produced by a binary with a different pinned set.)
+		if bmeta.LSN != 0 && bmeta.RenderGUCs != baseline.RenderGUCsPinned {
+			slog.Warn("this baseline's rendering-GUC stamp does not match the current pin (#593) — it predates GUC pinning or was produced under a different pin; on a server whose TimeZone/DateStyle/extra_float_digits/bytea_output/IntervalStyle defaults differ from the pinned values, its GUC-sensitive text will not match newer deltas; re-run `bintrail-pg baseline` to refresh it",
+				"baseline_render_gucs", bmeta.RenderGUCs)
 		}
 	}
 

--- a/internal/pgbaseline/pgbaseline.go
+++ b/internal/pgbaseline/pgbaseline.go
@@ -27,7 +27,13 @@
 // Values are stored as raw PostgreSQL text (Column.RawText — COPY text output,
 // unescaped): identical to the pgoutput text rendering the delta path indexes,
 // so the PK join between baseline and deltas is an identity string match. No
-// type conversion, ever.
+// type conversion, ever. That identity only holds because BOTH sessions render
+// under the SAME session GUCs: every COPY connection here and the walsender
+// session are pinned to the canonical rendering GUCs (#593 slice D,
+// pgcapture/gucpin.go — TimeZone=UTC, DateStyle=ISO, extra_float_digits=3,
+// bytea_output=hex, IntervalStyle=postgres), and the pinned set is stamped
+// into the Parquet metadata (baseline.MetaKeyRenderGUCs) so readers can tell a
+// pre-pin baseline from a pinned one.
 package pgbaseline
 
 import (
@@ -134,7 +140,12 @@ func Run(ctx context.Context, cfg Config) (Stats, error) {
 		compression = "zstd"
 	}
 
-	conn, err := pgx.Connect(ctx, cfg.QueryDSN)
+	// Pinned rendering GUCs (#593 slice D, pgcapture/gucpin.go): this anchor
+	// connection runs the COPY itself when Parallelism==1, so its session GUCs
+	// determine the baseline text — pinned identically to the walsender.
+	// Startup-packet placement keeps the REPEATABLE READ anchor below intact
+	// (the pin is in effect before BEGIN; no SET inside the transaction).
+	conn, err := pgcapture.ConnectQueryPinned(ctx, cfg.QueryDSN)
 	if err != nil {
 		return Stats{}, fmt.Errorf("pgbaseline: connect (query DSN): %w", err)
 	}
@@ -147,7 +158,8 @@ func Run(ctx context.Context, cfg Config) (Stats, error) {
 	var replConnect func(context.Context) (*pgconn.PgConn, error)
 	if cfg.ReplDSN != "" {
 		replConnect = func(ctx context.Context) (*pgconn.PgConn, error) {
-			return pgconn.Connect(ctx, cfg.ReplDSN)
+			// Renders no rows (slot creation only); pinned for uniformity.
+			return pgcapture.ConnectReplPinned(ctx, cfg.ReplDSN)
 		}
 	}
 	created, err := pgcapture.EnsureSlotExists(ctx, conn, cfg.SlotName, replConnect)
@@ -371,7 +383,9 @@ func Run(ctx context.Context, cfg Config) (Stats, error) {
 // openWorkerConn opens a connection whose transaction adopts the exported
 // snapshot, so a parallel worker sees exactly the anchor transaction's data.
 func openWorkerConn(ctx context.Context, dsn, snapshotID string) (*pgx.Conn, error) {
-	c, err := pgx.Connect(ctx, dsn)
+	// Every parallel worker runs COPYs — its session renders baseline text, so
+	// it gets the same rendering-GUC pin as the anchor (#593 slice D).
+	c, err := pgcapture.ConnectQueryPinned(ctx, dsn)
 	if err != nil {
 		return nil, fmt.Errorf("pgbaseline: connect parallel worker: %w", err)
 	}
@@ -416,6 +430,11 @@ func processTable(ctx context.Context, conn *pgx.Conn, t tableInfo, outputDir, t
 		// deliberately absent — it exists for full-table mydumper
 		// reconstruct, out of scope for PG.
 		baseline.MetaKeyLSN: strconv.FormatUint(deltaStartLSN, 10),
+		// The rendering-GUC stamp (#593 slice D): records that this baseline's
+		// text was rendered under the pinned canonical GUCs. Readers use its
+		// ABSENCE to detect a pre-pin baseline whose GUC-sensitive text may
+		// not join post-pin deltas (warn + re-baseline guidance).
+		baseline.MetaKeyRenderGUCs: pgcapture.RenderGUCsStamp(),
 	}
 
 	cols := make([]baseline.Column, len(t.Columns))

--- a/internal/pgcapture/capturer.go
+++ b/internal/pgcapture/capturer.go
@@ -113,7 +113,10 @@ func (c *Capturer) Run(ctx context.Context, out chan<- event.Event) error {
 		return fmt.Errorf("pgcapture: Run requires ReplDSN, QueryDSN, SlotName, and Publication")
 	}
 
-	replConn, err := pgconn.Connect(ctx, c.cfg.ReplDSN)
+	// Pinned rendering GUCs (#593 slice D, gucpin.go): the walsender session's
+	// GUCs determine pgoutput's tuple text, which must byte-match the baseline
+	// COPY text (pinned identically in internal/pgbaseline).
+	replConn, err := ConnectReplPinned(ctx, c.cfg.ReplDSN)
 	if err != nil {
 		return fmt.Errorf("pgcapture: connect replication: %w", err)
 	}

--- a/internal/pgcapture/gucpin.go
+++ b/internal/pgcapture/gucpin.go
@@ -1,0 +1,105 @@
+package pgcapture
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// Rendering-GUC pin (#593 slice D).
+//
+// The PostgreSQL baseline+delta design rests on one identity: the text a
+// baseline COPY renders for a value must equal the text pgoutput renders for
+// the same value on the delta path — reconstruct's PK join and last-write-wins
+// merge are exact string operations over that text (see the raw-text contract
+// in internal/pgbaseline). But BOTH sides render every datum through the
+// type's server-side OUTPUT FUNCTION, whose text depends on session GUCs
+// (TimeZone, DateStyle, extra_float_digits, bytea_output, IntervalStyle). Two
+// sessions with different settings render the SAME logical value as DIFFERENT
+// text — silently breaking the identity.
+//
+// Fix: every connection that renders row text — the logical-decoding
+// (walsender) session and the baseline COPY connections — is pinned to the
+// SAME canonical values via startup-packet parameters (RuntimeParams). Startup
+// parameters are applied at backend start as PGC_S_CLIENT, which outranks
+// ALTER DATABASE/ROLE defaults and is applied after the DSN's options string,
+// so the pin deterministically wins; an invalid value fails the connection
+// loudly (FATAL at connect) rather than leaving a session silently unpinned.
+// Startup placement also means the pin is in effect BEFORE any transaction
+// opens, so pgbaseline's REPEATABLE READ anchor / exported-snapshot workers
+// are untouched.
+//
+// Catalog-only connections (the capturer's PK-lookup queryConn, health probes,
+// doctor, reset) never render row text and are deliberately NOT pinned.
+//
+// renderGUCList is a fixed-order list (not a map) so RenderGUCsStamp is
+// deterministic.
+var renderGUCList = [5]struct{ name, value string }{
+	{"TimeZone", "UTC"},
+	{"DateStyle", "ISO"},
+	{"extra_float_digits", "3"}, // any value >= 1 selects shortest-precise floats
+	{"bytea_output", "hex"},
+	{"IntervalStyle", "postgres"},
+}
+
+// PinRenderGUCs injects the pinned rendering GUCs into a connection's startup
+// RuntimeParams, overriding any operator-supplied value for the same key (an
+// unpinned or differently-pinned rendering session is exactly the text-
+// mismatch corruption class this exists to kill; the override is logged).
+// params must be non-nil.
+func PinRenderGUCs(params map[string]string) {
+	for _, g := range renderGUCList {
+		if old, ok := params[g.name]; ok && old != g.value {
+			slog.Debug("pgcapture: overriding operator-supplied rendering GUC with the pinned value",
+				"guc", g.name, "operator", old, "pinned", g.value)
+		}
+		params[g.name] = g.value
+	}
+}
+
+// RenderGUCsStamp returns the canonical serialization of the pinned set, e.g.
+// "TimeZone=UTC;DateStyle=ISO;extra_float_digits=3;bytea_output=hex;IntervalStyle=postgres".
+// pgbaseline embeds it in the baseline Parquet metadata
+// (baseline.MetaKeyRenderGUCs) so readers can tell a pre-pin baseline (no
+// stamp) from a pinned one and warn instead of silently mis-joining.
+func RenderGUCsStamp() string {
+	parts := make([]string, len(renderGUCList))
+	for i, g := range renderGUCList {
+		parts[i] = g.name + "=" + g.value
+	}
+	return strings.Join(parts, ";")
+}
+
+// ConnectReplPinned opens a replication connection (pgconn) with the rendering
+// GUCs pinned in the startup packet. Use for every walsender session — its
+// session GUCs determine pgoutput's tuple text.
+func ConnectReplPinned(ctx context.Context, dsn string) (*pgconn.PgConn, error) {
+	cfg, err := pgconn.ParseConfig(dsn)
+	if err != nil {
+		return nil, fmt.Errorf("pgcapture: parse replication DSN: %w", err)
+	}
+	if cfg.RuntimeParams == nil {
+		cfg.RuntimeParams = make(map[string]string)
+	}
+	PinRenderGUCs(cfg.RuntimeParams)
+	return pgconn.ConnectConfig(ctx, cfg)
+}
+
+// ConnectQueryPinned opens an ordinary connection (pgx) with the rendering
+// GUCs pinned in the startup packet. Use for every connection that renders row
+// text server-side (the baseline COPY anchor and its parallel workers).
+func ConnectQueryPinned(ctx context.Context, dsn string) (*pgx.Conn, error) {
+	cc, err := pgx.ParseConfig(dsn)
+	if err != nil {
+		return nil, fmt.Errorf("pgcapture: parse query DSN: %w", err)
+	}
+	if cc.RuntimeParams == nil {
+		cc.RuntimeParams = make(map[string]string)
+	}
+	PinRenderGUCs(cc.RuntimeParams)
+	return pgx.ConnectConfig(ctx, cc)
+}

--- a/internal/pgcapture/gucpin.go
+++ b/internal/pgcapture/gucpin.go
@@ -51,11 +51,24 @@ var renderGUCList = [5]struct{ name, value string }{
 // unpinned or differently-pinned rendering session is exactly the text-
 // mismatch corruption class this exists to kill; the override is logged).
 // params must be non-nil.
+//
+// The purge below is CASE-INSENSITIVE on purpose: PostgreSQL GUC names are
+// case-insensitive but Go map keys are not, so an operator DSN carrying
+// `?timezone=...` lands under a DIFFERENT map key than the pinned "TimeZone".
+// Both would then reach the startup packet in random map-iteration order, and
+// the server applies them last-writer-wins at equal source priority — leaving
+// roughly half of all connections silently unpinned, per connection. Every
+// case-variant of a pinned key is deleted before the pin is inserted.
 func PinRenderGUCs(params map[string]string) {
 	for _, g := range renderGUCList {
-		if old, ok := params[g.name]; ok && old != g.value {
-			slog.Debug("pgcapture: overriding operator-supplied rendering GUC with the pinned value",
-				"guc", g.name, "operator", old, "pinned", g.value)
+		for k, old := range params {
+			if strings.EqualFold(k, g.name) {
+				if old != g.value {
+					slog.Debug("pgcapture: overriding operator-supplied rendering GUC with the pinned value",
+						"guc", k, "operator", old, "pinned", g.value)
+				}
+				delete(params, k)
+			}
 		}
 		params[g.name] = g.value
 	}

--- a/internal/pgcapture/gucpin_test.go
+++ b/internal/pgcapture/gucpin_test.go
@@ -1,0 +1,70 @@
+package pgcapture
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// TestPinRenderGUCs_exactSet pins the five canonical values — the identity
+// contract between the baseline COPY text and the pgoutput delta text (#593
+// slice D). Changing any value silently breaks the text join against data
+// captured under the old pin, so this test is a change detector on purpose.
+func TestPinRenderGUCs_exactSet(t *testing.T) {
+	params := map[string]string{}
+	PinRenderGUCs(params)
+	want := map[string]string{
+		"TimeZone":           "UTC",
+		"DateStyle":          "ISO",
+		"extra_float_digits": "3",
+		"bytea_output":       "hex",
+		"IntervalStyle":      "postgres",
+	}
+	if len(params) != len(want) {
+		t.Fatalf("pinned %d GUCs, want %d: %v", len(params), len(want), params)
+	}
+	for k, v := range want {
+		if params[k] != v {
+			t.Errorf("params[%q] = %q, want %q", k, params[k], v)
+		}
+	}
+}
+
+// TestPinRenderGUCs_overridesOperatorValue: a same-key value the operator put
+// in the DSN must LOSE to the pin (an unpinned rendering session is the
+// corruption class the pin kills), while unrelated params survive.
+func TestPinRenderGUCs_overridesOperatorValue(t *testing.T) {
+	cfg, err := pgconn.ParseConfig("postgres://u@h/db?TimeZone=America/New_York&application_name=myapp")
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	PinRenderGUCs(cfg.RuntimeParams)
+	if got := cfg.RuntimeParams["TimeZone"]; got != "UTC" {
+		t.Errorf("TimeZone = %q, want the pinned UTC (operator value must lose)", got)
+	}
+	if got := cfg.RuntimeParams["application_name"]; got != "myapp" {
+		t.Errorf("application_name = %q, want myapp (unrelated params must survive)", got)
+	}
+}
+
+// TestRenderGUCsStamp_canonical pins the stamp text: it is persisted into
+// baseline Parquet metadata (baseline.MetaKeyRenderGUCs), so a wording change
+// would make every existing pinned baseline read as unstamped.
+func TestRenderGUCsStamp_canonical(t *testing.T) {
+	const want = "TimeZone=UTC;DateStyle=ISO;extra_float_digits=3;bytea_output=hex;IntervalStyle=postgres"
+	if got := RenderGUCsStamp(); got != want {
+		t.Errorf("RenderGUCsStamp() = %q, want %q", got, want)
+	}
+}
+
+// TestConnectPinned_badDSNFailsWithoutDialing: an unparseable DSN errors at
+// parse time (no network).
+func TestConnectPinned_badDSNFailsWithoutDialing(t *testing.T) {
+	if _, err := ConnectReplPinned(context.Background(), "://not-a-dsn"); err == nil {
+		t.Error("ConnectReplPinned: expected a parse error for a bad DSN")
+	}
+	if _, err := ConnectQueryPinned(context.Background(), "://not-a-dsn"); err == nil {
+		t.Error("ConnectQueryPinned: expected a parse error for a bad DSN")
+	}
+}

--- a/internal/pgcapture/gucpin_test.go
+++ b/internal/pgcapture/gucpin_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/dbtrail/dbtrail/internal/baseline"
 )
 
 // TestPinRenderGUCs_exactSet pins the five canonical values — the identity
@@ -48,13 +50,40 @@ func TestPinRenderGUCs_overridesOperatorValue(t *testing.T) {
 	}
 }
 
-// TestRenderGUCsStamp_canonical pins the stamp text: it is persisted into
-// baseline Parquet metadata (baseline.MetaKeyRenderGUCs), so a wording change
-// would make every existing pinned baseline read as unstamped.
+// TestPinRenderGUCs_caseInsensitiveCollision: PostgreSQL GUC names are
+// case-insensitive but Go map keys are not — an operator DSN `?timezone=...`
+// lands under a different map key than the pinned "TimeZone", and BOTH would
+// reach the startup packet in random map order (server applies last-writer-
+// wins at equal priority → ~half of all connections silently unpinned). The
+// pin must purge every case-variant.
+func TestPinRenderGUCs_caseInsensitiveCollision(t *testing.T) {
+	cfg, err := pgconn.ParseConfig("postgres://u@h/db?timezone=America/New_York&datestyle=German")
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	PinRenderGUCs(cfg.RuntimeParams)
+	if v, ok := cfg.RuntimeParams["timezone"]; ok {
+		t.Errorf("lowercase 'timezone' key survived the pin (=%q) — both case-variants in the startup packet apply last-writer-wins in random order", v)
+	}
+	if v, ok := cfg.RuntimeParams["datestyle"]; ok {
+		t.Errorf("lowercase 'datestyle' key survived the pin (=%q)", v)
+	}
+	if got := cfg.RuntimeParams["TimeZone"]; got != "UTC" {
+		t.Errorf("TimeZone = %q, want UTC", got)
+	}
+	if got := cfg.RuntimeParams["DateStyle"]; got != "ISO" {
+		t.Errorf("DateStyle = %q, want ISO", got)
+	}
+}
+
+// TestRenderGUCsStamp_canonical cross-pins the stamp text against the read
+// layer's copy (baseline.RenderGUCsPinned — the read layer cannot import
+// pgcapture, so it carries the canonical value as a constant). The stamp is
+// persisted into baseline Parquet metadata (baseline.MetaKeyRenderGUCs); a
+// divergence would make every pinned baseline read as differently-pinned.
 func TestRenderGUCsStamp_canonical(t *testing.T) {
-	const want = "TimeZone=UTC;DateStyle=ISO;extra_float_digits=3;bytea_output=hex;IntervalStyle=postgres"
-	if got := RenderGUCsStamp(); got != want {
-		t.Errorf("RenderGUCsStamp() = %q, want %q", got, want)
+	if got := RenderGUCsStamp(); got != baseline.RenderGUCsPinned {
+		t.Errorf("RenderGUCsStamp() = %q, want baseline.RenderGUCsPinned %q — the capture-side stamp and the read-side constant have diverged", got, baseline.RenderGUCsPinned)
 	}
 }
 

--- a/internal/pgstreamrun/pgstreamrun_integration_test.go
+++ b/internal/pgstreamrun/pgstreamrun_integration_test.go
@@ -1047,43 +1047,11 @@ func TestOne_PGTypeRoundTripMatrix(t *testing.T) {
 	}
 	t.Cleanup(func() { pg.Close(context.Background()) })
 
-	// name → (column type DDL, value SQL as it appears in VALUES). Values are chosen
-	// scary-first: precision (>2^53), scale (trailing zero), escaping (quote+backslash),
-	// and the format-bearing types (bytea \x, arrays, ranges, bit, inet, json).
-	type tc struct{ name, typeDDL, valSQL string }
-	cases := []tc{
-		{"smallint", "smallint", "32767"},
-		{"integer", "integer", "-2147483648"},
-		{"bigint", "bigint", "9223372036854775807"},
-		{"numeric_big", "numeric", "18446744073709551615"}, // > 2^53, precision
-		{"numeric_scale", "numeric(12,2)", "1.50"},         // trailing-zero scale
-		{"real", "real", "3.5"},
-		{"double", "double precision", "2.5"},
-		{"text_tricky", "text", `'O''Brien \ C:\back'`}, // quote + backslash escaping
-		{"varchar", "varchar(32)", "'hello world'"},
-		{"char", "char(5)", "'ab'"}, // trailing blanks are insignificant in bpchar (trimmed on ::text); proves coercion, not padding-through-capture
-		{"boolean", "boolean", "true"},
-		{"uuid", "uuid", "'11111111-2222-3333-4444-555555555555'"},
-		{"bytea", "bytea", `'\xdeadbeef00'`},
-		{"json", "json", `'{"k": "v"}'`},
-		{"jsonb", "jsonb", `'{"k": "v''s"}'`}, // embedded quote
-		{"date", "date", "'2026-06-22'"},
-		{"time", "time", "'12:34:56'"},
-		{"timestamp", "timestamp", "'2026-06-22 12:34:56'"},
-		{"timestamptz", "timestamptz", "'2026-06-22 12:34:56+00'"},
-		{"interval", "interval", "'1 day 02:03:04'"},
-		{"inet", "inet", "'192.168.1.10'"},
-		{"cidr", "cidr", "'10.0.0.0/8'"},
-		{"macaddr", "macaddr", "'08:00:2b:01:02:03'"},
-		{"bit", "bit(4)", "'1010'"},
-		{"varbit", "varbit", "'101'"},
-		{"int4range", "int4range", "'[1,10)'"},
-		{"int_array", "integer[]", "'{1,2,3}'"},
-		{"text_array", "text[]", `'{"a","b,c"}'`}, // element with a comma
-		{"point", "point", "'(1,2)'"},
-		{"money", "money", "'1.50'"}, // locale-dependent output ('$1.50'); same instance, so stable
-		{"enum", "mood", "'happy'"},  // custom enum (created below)
-	}
+	// The shared type matrix (pgTypeMatrixCases, typematrix_fold_integration_
+	// test.go): name → (column type DDL, value SQL as it appears in VALUES),
+	// scary-first. This test uses valSQL only; the fold test also exercises
+	// each case's second literal (updSQL).
+	cases := pgTypeMatrixCases
 
 	tblOf := func(name string) string { return "pgtype_" + name }
 	dropAll := func() {

--- a/internal/pgstreamrun/typematrix_fold_integration_test.go
+++ b/internal/pgstreamrun/typematrix_fold_integration_test.go
@@ -203,10 +203,26 @@ func TestOne_PGTypeMatrixThroughReconstructFold(t *testing.T) {
 			t.Fatalf("oracle %s: %v", set, err)
 		}
 	}
+	// The oracle reads the OUTPUT-FUNCTION rendering, not a ::text cast: the
+	// simple protocol returns text-format results, whose wire bytes ARE the
+	// type's output function under this session's (pinned) GUCs — the exact
+	// text a correct fold must produce. A ::text CAST diverges for some types
+	// (bool::text = "true"/"false" vs boolout's "t"/"f"; inet::text appends
+	// /32 to a host address; bpchar::text trims the padding), which would
+	// flag internally-consistent fold output as a mismatch.
 	oracle := func(tbl string, id int) string {
 		t.Helper()
-		var got string
-		if err := oracleConn.QueryRow(ctx, fmt.Sprintf("SELECT val::text FROM %s WHERE id=%d", tbl, id)).Scan(&got); err != nil {
+		rows, err := oracleConn.Query(ctx, fmt.Sprintf("SELECT val FROM %s WHERE id=%d", tbl, id), pgx.QueryExecModeSimpleProtocol)
+		if err != nil {
+			t.Fatalf("oracle %s id=%d: %v", tbl, id, err)
+		}
+		defer rows.Close()
+		if !rows.Next() {
+			t.Fatalf("oracle %s id=%d: no row (err=%v)", tbl, id, rows.Err())
+		}
+		got := string(rows.RawValues()[0]) // copy before Close invalidates it
+		rows.Close()
+		if err := rows.Err(); err != nil {
 			t.Fatalf("oracle %s id=%d: %v", tbl, id, err)
 		}
 		return got
@@ -343,29 +359,23 @@ func TestOne_PGTypeMatrixThroughReconstructFold(t *testing.T) {
 				return valText(state["val"])
 			}
 
-			normalize := func(s string) string {
-				if c.name == "char" {
-					// bpchar: raw COPY/pgoutput text is space-padded to the
-					// declared width; ::text (the oracle) trims. Value
-					// equality modulo padding is the honest comparison.
-					return strings.TrimRight(s, " ")
-				}
-				return s
-			}
-
+			// Byte-equality against the output-function oracle — no per-type
+			// normalization needed (the simple-protocol oracle renders exactly
+			// what a correct fold produces, bpchar padding included).
+			//
 			// id=1 — baseline pass-through: the sharpest pre-pin failure (the
 			// baseline COPY rendered under the skewed session).
-			if got := fold("1", 0); normalize(got) != normalize(orig1[c.name]) {
+			if got := fold("1", 0); got != orig1[c.name] {
 				t.Errorf("id=1 baseline pass-through (%s):\n got  %q\n want %q", c.typeDDL, got, orig1[c.name])
 			}
 			// id=2 — baseline + UPDATE overlay: the delta row_after must win
 			// and be pin-rendered.
-			if got := fold("2", 1); normalize(got) != normalize(orig2[c.name]) {
+			if got := fold("2", 1); got != orig2[c.name] {
 				t.Errorf("id=2 baseline+delta overlay (%s):\n got  %q\n want %q", c.typeDDL, got, orig2[c.name])
 			}
 			// id=3 — delta-only: pre-pin failure under the DB-level skew (the
 			// walsender rendered under the skewed defaults).
-			if got := fold("3", 1); normalize(got) != normalize(orig3[c.name]) {
+			if got := fold("3", 1); got != orig3[c.name] {
 				t.Errorf("id=3 delta-only (%s):\n got  %q\n want %q", c.typeDDL, got, orig3[c.name])
 			}
 

--- a/internal/pgstreamrun/typematrix_fold_integration_test.go
+++ b/internal/pgstreamrun/typematrix_fold_integration_test.go
@@ -1,0 +1,387 @@
+//go:build integration
+
+package pgstreamrun_test
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/dbtrail/dbtrail/internal/pgbaseline"
+	"github.com/dbtrail/dbtrail/internal/pgstreamrun"
+	"github.com/dbtrail/dbtrail/internal/query"
+	"github.com/dbtrail/dbtrail/internal/reconstruct"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// pgTypeCase is one row of the shared PostgreSQL type-fidelity matrix, used by
+// BOTH TestOne_PGTypeRoundTripMatrix (recover round-trip) and
+// TestOne_PGTypeMatrixThroughReconstructFold (baseline+delta fold). valSQL is
+// the initial literal; updSQL is a SECOND literal used by the fold test for the
+// post-baseline UPDATE/INSERT deltas (empty ⇒ reuse valSQL). For the
+// GUC-sensitive types both literals are chosen SKEW-DIVERGENT: their text
+// rendering differs between the pinned rendering GUCs (#593 slice D) and the
+// skewed session the fold test sets up — so an unpinned reader fails the fold
+// assertions rather than passing vacuously.
+type pgTypeCase struct{ name, typeDDL, valSQL, updSQL string }
+
+// pgTypeMatrixCases: name → (column type DDL, value SQL as it appears in
+// VALUES). Values are chosen scary-first: precision (>2^53), scale (trailing
+// zero), escaping (quote+backslash), and the format-bearing types (bytea \x,
+// arrays, ranges, bit, inet, json). The float literals are extra_float_digits-
+// sensitive on purpose (a value like 3.5 renders identically under efd=0 and
+// shortest-precise, which would make the fold's fail-before leg vacuous).
+var pgTypeMatrixCases = []pgTypeCase{
+	{"smallint", "smallint", "32767", ""},
+	{"integer", "integer", "-2147483648", ""},
+	{"bigint", "bigint", "9223372036854775807", ""},
+	{"numeric_big", "numeric", "18446744073709551615", ""},                      // > 2^53, precision
+	{"numeric_scale", "numeric(12,2)", "1.50", ""},                              // trailing-zero scale
+	{"real", "real", "3.14159274", "2.7182817"},                                 // efd-sensitive (efd=0 → 6 sig digits)
+	{"double", "double precision", "0.30000000000000004", "0.7000000000000001"}, // efd-sensitive (efd=0 → "0.3"/"0.7")
+	{"text_tricky", "text", `'O''Brien \ C:\back'`, ""},                         // quote + backslash escaping
+	{"varchar", "varchar(32)", "'hello world'", ""},
+	{"char", "char(5)", "'ab'", ""}, // trailing blanks are insignificant in bpchar (trimmed on ::text); proves coercion, not padding-through-capture
+	{"boolean", "boolean", "true", ""},
+	{"uuid", "uuid", "'11111111-2222-3333-4444-555555555555'", ""},
+	{"bytea", "bytea", `'\xdeadbeef00'`, `'\xcafebabe'`}, // bytea_output-sensitive (escape vs hex)
+	{"json", "json", `'{"k": "v"}'`, ""},
+	{"jsonb", "jsonb", `'{"k": "v''s"}'`, ""},                                              // embedded quote
+	{"date", "date", "'2026-06-22'", "'2027-01-15'"},                                       // DateStyle-sensitive (German → 22.06.2026)
+	{"time", "time", "'12:34:56'", "'23:45:01'"},                                           // control: unaffected by the five pinned GUCs
+	{"timestamp", "timestamp", "'2026-06-22 12:34:56'", "'2027-01-15 23:45:01'"},           // DateStyle-sensitive
+	{"timestamptz", "timestamptz", "'2026-06-22 12:34:56+00'", "'2027-01-15 23:45:01+00'"}, // TimeZone-sensitive (highest severity)
+	{"interval", "interval", "'1 day 02:03:04'", "'2 days 03:04:05'"},                      // IntervalStyle-sensitive (sql_standard → "1 2:03:04")
+	{"inet", "inet", "'192.168.1.10'", ""},
+	{"cidr", "cidr", "'10.0.0.0/8'", ""},
+	{"macaddr", "macaddr", "'08:00:2b:01:02:03'", ""},
+	{"bit", "bit(4)", "'1010'", ""},
+	{"varbit", "varbit", "'101'", ""},
+	{"int4range", "int4range", "'[1,10)'", ""},
+	{"int_array", "integer[]", "'{1,2,3}'", ""},
+	{"text_array", "text[]", `'{"a","b,c"}'`, ""}, // element with a comma
+	{"point", "point", "'(1,2)'", ""},
+	{"money", "money", "'1.50'", ""}, // locale-dependent output ('$1.50'); lc_monetary deliberately NOT pinned — same instance, so stable
+	{"enum", "mood", "'happy'", "'sad'"},
+}
+
+// updOf returns the fold test's second literal for a case (falls back to valSQL).
+func updOf(c pgTypeCase) string {
+	if c.updSQL != "" {
+		return c.updSQL
+	}
+	return c.valSQL
+}
+
+// TestOne_PGTypeMatrixThroughReconstructFold is the #593 slice-D proof: the
+// baseline+delta identity — baseline COPY text ≡ pgoutput delta text — holds
+// for the full type matrix THROUGH the single-row reconstruct fold
+// (FindBaseline → ReadBaselineRow → query.Fetch → ApplyAt), because the
+// rendering GUCs are pinned identically on the baseline COPY connections and
+// the logical-decoding (walsender) session.
+//
+// The fail-before/pass-after oracle: the test deliberately SKEWS the rendering
+// GUCs two ways before anything connects —
+//   - database-level defaults (ALTER DATABASE ... SET), which every NEW
+//     backend inherits, INCLUDING the walsender and the baseline COPY conns;
+//   - an operator options=-c ... string on the baseline QueryDSN, which must
+//     LOSE to the pin (startup-packet GUCs are applied after the options
+//     string).
+//
+// The comparison oracle runs on a dedicated connection that explicitly SETs
+// the five pinned canonical values (TimeZone=UTC, DateStyle=ISO,
+// extra_float_digits=3, bytea_output=hex, IntervalStyle=postgres) — it must
+// NOT rely on session defaults, which the skew poisons. Without the pin
+// (#593 slice D), the GUC-sensitive subtests fail: the baseline leg renders
+// under the skew (id=1, id=2's baseline text) and the delta leg renders under
+// the skew (id=3, id=2's overlay). With the pin, every leg matches the
+// canonical oracle byte-for-byte.
+//
+// Three rows per type:
+//   - id=1: baseline pass-through (no post-baseline delta touches it);
+//   - id=2: baseline + UPDATE overlay (delta row_after must win, and its text
+//     must be pin-rendered);
+//   - id=3: delta-only (INSERTed after the baseline; no baseline row).
+//
+// CI-only: needs a live PostgreSQL source (BINTRAIL_TEST_PG_DSN) + MySQL index.
+func TestOne_PGTypeMatrixThroughReconstructFold(t *testing.T) {
+	pgDSN := testutil.SkipIfNoPostgres(t)
+	testutil.SkipIfNoMySQL(t)
+	ctx := context.Background()
+
+	indexDB, dbName := testutil.CreateTestDB(t)
+	indexDSN := testutil.BaseDSN() + "/" + dbName
+
+	const slot = "bintrail_pgtypesfold"
+	const pub = "bintrail_pgtypesfold_pub"
+	tblOf := func(name string) string { return "pgtypefold_" + name }
+
+	pg, err := pgx.Connect(ctx, pgDSN)
+	if err != nil {
+		t.Fatalf("connect PG: %v", err)
+	}
+	t.Cleanup(func() { pg.Close(context.Background()) })
+
+	// ── GUC skew (the fail-before oracle) ───────────────────────────────────
+	// Database-level defaults: every backend opened AFTER this — the baseline
+	// COPY conns and the walsender — inherits them. The test's own `pg` conn
+	// (already open) and the pinned oracle conn (explicit SETs) are unaffected.
+	var curDB string
+	if err := pg.QueryRow(ctx, "SELECT current_database()").Scan(&curDB); err != nil {
+		t.Fatalf("current_database: %v", err)
+	}
+	dbIdent := pgx.Identifier{curDB}.Sanitize()
+	skews := map[string]string{
+		"timezone":           "'America/New_York'",
+		"datestyle":          "'German'",
+		"intervalstyle":      "'sql_standard'",
+		"extra_float_digits": "0",
+		"bytea_output":       "'escape'",
+	}
+	for k, v := range skews {
+		if _, err := pg.Exec(ctx, fmt.Sprintf("ALTER DATABASE %s SET %s TO %s", dbIdent, k, v)); err != nil {
+			t.Fatalf("skew %s: %v", k, err)
+		}
+	}
+	t.Cleanup(func() {
+		bg := context.Background()
+		for k := range skews {
+			_, _ = pg.Exec(bg, fmt.Sprintf("ALTER DATABASE %s RESET %s", dbIdent, k))
+		}
+	})
+
+	dropAll := func() {
+		bg := context.Background()
+		_, _ = pg.Exec(bg, "DROP PUBLICATION IF EXISTS "+pub)
+		for _, c := range pgTypeMatrixCases {
+			_, _ = pg.Exec(bg, "DROP TABLE IF EXISTS "+tblOf(c.name))
+		}
+		_, _ = pg.Exec(bg, "DROP TYPE IF EXISTS mood")
+		_, _ = pg.Exec(bg, "SELECT pg_drop_replication_slot($1) WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name=$1)", slot)
+	}
+	dropAll()
+	t.Cleanup(dropAll)
+
+	mustExec := func(sqlStr string) {
+		t.Helper()
+		if _, err := pg.Exec(ctx, sqlStr); err != nil {
+			t.Fatalf("exec %q: %v", sqlStr, err)
+		}
+	}
+	mustExec("CREATE TYPE mood AS ENUM ('happy','sad')")
+	tbls := make([]string, len(pgTypeMatrixCases))
+	for i, c := range pgTypeMatrixCases {
+		tbl := tblOf(c.name)
+		tbls[i] = tbl
+		mustExec(fmt.Sprintf("CREATE TABLE %s (id int PRIMARY KEY, val %s)", tbl, c.typeDDL))
+		mustExec(fmt.Sprintf("ALTER TABLE %s REPLICA IDENTITY FULL", tbl))
+	}
+	mustExec("CREATE PUBLICATION " + pub + " FOR TABLE " + strings.Join(tbls, ", "))
+
+	// Pre-baseline rows: id=1 (never touched again) and id=2 (updated later).
+	for _, c := range pgTypeMatrixCases {
+		tbl := tblOf(c.name)
+		mustExec(fmt.Sprintf("INSERT INTO %s (id, val) VALUES (1, %s), (2, %s)", tbl, c.valSQL, c.valSQL))
+	}
+
+	// ── The pinned canonical oracle connection ──────────────────────────────
+	oracleConn, err := pgx.Connect(ctx, pgDSN)
+	if err != nil {
+		t.Fatalf("connect oracle: %v", err)
+	}
+	t.Cleanup(func() { oracleConn.Close(context.Background()) })
+	for _, set := range []string{
+		"SET TimeZone TO 'UTC'", "SET DateStyle TO 'ISO'", "SET extra_float_digits TO 3",
+		"SET bytea_output TO 'hex'", "SET IntervalStyle TO 'postgres'",
+	} {
+		if _, err := oracleConn.Exec(ctx, set); err != nil {
+			t.Fatalf("oracle %s: %v", set, err)
+		}
+	}
+	oracle := func(tbl string, id int) string {
+		t.Helper()
+		var got string
+		if err := oracleConn.QueryRow(ctx, fmt.Sprintf("SELECT val::text FROM %s WHERE id=%d", tbl, id)).Scan(&got); err != nil {
+			t.Fatalf("oracle %s id=%d: %v", tbl, id, err)
+		}
+		return got
+	}
+	orig1 := make(map[string]string, len(pgTypeMatrixCases))
+	for _, c := range pgTypeMatrixCases {
+		orig1[c.name] = oracle(tblOf(c.name), 1)
+	}
+
+	// ── Baseline (creates the slot; COPY conns run under the skewed DSN) ────
+	// The operator-DSN skew: an options string carrying the same five GUCs —
+	// the pin's startup-packet RuntimeParams must beat it (guc_options are
+	// applied after the options string).
+	skewOpts := url.QueryEscape("-c TimeZone=America/New_York -c datestyle=German -c extra_float_digits=0 -c bytea_output=escape -c intervalstyle=sql_standard")
+	sep := "?"
+	if strings.Contains(pgDSN, "?") {
+		sep = "&"
+	}
+	outDir := t.TempDir()
+	stats, err := pgbaseline.Run(ctx, pgbaseline.Config{
+		QueryDSN:    pgDSN + sep + "options=" + skewOpts,
+		ReplDSN:     replDSN(pgDSN),
+		SlotName:    slot,
+		Publication: pub,
+		OutputDir:   outDir,
+		Parallelism: 2, // exercises openWorkerConn's pinned path, not just the anchor conn
+	})
+	if err != nil {
+		t.Fatalf("pgbaseline.Run: %v", err)
+	}
+	if stats.TablesProcessed != len(pgTypeMatrixCases) {
+		t.Fatalf("baseline processed %d tables, want %d", stats.TablesProcessed, len(pgTypeMatrixCases))
+	}
+	if stats.DeltaStartLSN == 0 {
+		t.Fatal("baseline DeltaStartLSN is 0 — no LSN anchor")
+	}
+
+	// ── Stream deltas on the SAME slot the baseline created ────────────────
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	cfg := pgstreamrun.Config{
+		IndexDSN: indexDSN, ReplDSN: replDSN(pgDSN), QueryDSN: pgDSN,
+		SlotName: slot, Publication: pub, ServerID: 46,
+		BatchSize: 200, Checkpoint: 200 * time.Millisecond,
+	}
+	runErr := make(chan error, 1)
+	go func() { runErr <- pgstreamrun.One(runCtx, cfg) }()
+	waitFor(t, 15*time.Second, func() bool {
+		var active bool
+		if err := pg.QueryRow(ctx, "SELECT active FROM pg_replication_slots WHERE slot_name=$1", slot).Scan(&active); err != nil {
+			return false
+		}
+		return active
+	}, "replication slot active")
+
+	// Post-baseline deltas: UPDATE id=2 to the second literal, INSERT id=3.
+	for _, c := range pgTypeMatrixCases {
+		tbl := tblOf(c.name)
+		mustExec(fmt.Sprintf("UPDATE %s SET val = %s WHERE id = 2", tbl, updOf(c)))
+		mustExec(fmt.Sprintf("INSERT INTO %s (id, val) VALUES (3, %s)", tbl, updOf(c)))
+	}
+	orig2 := make(map[string]string, len(pgTypeMatrixCases))
+	orig3 := make(map[string]string, len(pgTypeMatrixCases))
+	for _, c := range pgTypeMatrixCases {
+		orig2[c.name] = oracle(tblOf(c.name), 2)
+		orig3[c.name] = oracle(tblOf(c.name), 3)
+	}
+
+	wantEvents := 2 * len(pgTypeMatrixCases) // UPDATE + INSERT per table
+	waitFor(t, 30*time.Second, func() bool {
+		var n int
+		if err := indexDB.QueryRow("SELECT COUNT(*) FROM binlog_events WHERE schema_name='public'").Scan(&n); err != nil {
+			return false
+		}
+		return n >= wantEvents
+	}, "all delta events indexed")
+
+	cancel()
+	if err := <-runErr; err != nil {
+		t.Fatalf("One returned error: %v", err)
+	}
+
+	// ── The fold: FindBaseline → ReadBaselineRow → Fetch → ApplyAt ─────────
+	at := time.Now().Add(time.Hour)
+	engine := query.New(indexDB)
+	// valText normalizes a fold output value for comparison (baseline values
+	// scan as string or []byte depending on the DuckDB driver path).
+	valText := func(v any) string {
+		switch x := v.(type) {
+		case nil:
+			return "<nil>"
+		case string:
+			return x
+		case []byte:
+			return string(x)
+		default:
+			return fmt.Sprint(x)
+		}
+	}
+	for _, c := range pgTypeMatrixCases {
+		t.Run(c.name, func(t *testing.T) {
+			tbl := tblOf(c.name)
+			path, snapTime, _, err := reconstruct.FindBaseline(ctx, outDir, "public", tbl, at)
+			if err != nil {
+				t.Fatalf("FindBaseline: %v", err)
+			}
+
+			fold := func(id string, wantEvents int) string {
+				t.Helper()
+				row, err := reconstruct.ReadBaselineRow(ctx, path, map[string]string{"id": id})
+				if err != nil {
+					t.Fatalf("ReadBaselineRow id=%s: %v", id, err)
+				}
+				if id == "3" && row != nil {
+					t.Fatalf("id=3 must have NO baseline row (inserted after the baseline), got %v", row)
+				}
+				events, err := engine.Fetch(ctx, query.Options{
+					Schema: "public", Table: tbl, PKValues: id,
+					Since: &snapTime, Until: &at, Order: "ASC",
+				})
+				if err != nil {
+					t.Fatalf("Fetch id=%s: %v", id, err)
+				}
+				if len(events) != wantEvents {
+					t.Fatalf("id=%s: %d indexed events in the window, want %d", id, len(events), wantEvents)
+				}
+				state, err := reconstruct.ApplyAt(row, events, at)
+				if err != nil {
+					t.Fatalf("ApplyAt id=%s: %v", id, err)
+				}
+				if state == nil {
+					t.Fatalf("id=%s: ApplyAt returned nil state", id)
+				}
+				return valText(state["val"])
+			}
+
+			normalize := func(s string) string {
+				if c.name == "char" {
+					// bpchar: raw COPY/pgoutput text is space-padded to the
+					// declared width; ::text (the oracle) trims. Value
+					// equality modulo padding is the honest comparison.
+					return strings.TrimRight(s, " ")
+				}
+				return s
+			}
+
+			// id=1 — baseline pass-through: the sharpest pre-pin failure (the
+			// baseline COPY rendered under the skewed session).
+			if got := fold("1", 0); normalize(got) != normalize(orig1[c.name]) {
+				t.Errorf("id=1 baseline pass-through (%s):\n got  %q\n want %q", c.typeDDL, got, orig1[c.name])
+			}
+			// id=2 — baseline + UPDATE overlay: the delta row_after must win
+			// and be pin-rendered.
+			if got := fold("2", 1); normalize(got) != normalize(orig2[c.name]) {
+				t.Errorf("id=2 baseline+delta overlay (%s):\n got  %q\n want %q", c.typeDDL, got, orig2[c.name])
+			}
+			// id=3 — delta-only: pre-pin failure under the DB-level skew (the
+			// walsender rendered under the skewed defaults).
+			if got := fold("3", 1); normalize(got) != normalize(orig3[c.name]) {
+				t.Errorf("id=3 delta-only (%s):\n got  %q\n want %q", c.typeDDL, got, orig3[c.name])
+			}
+
+			// bytea must surface as PostgreSQL hex text (\x…) through the fold
+			// on every leg — never base64, never octal-escape form.
+			if c.name == "bytea" {
+				for _, id := range []string{"1", "2", "3"} {
+					want := 0
+					if id != "1" {
+						want = 1
+					}
+					if got := fold(id, want); !strings.HasPrefix(got, `\x`) {
+						t.Errorf("bytea id=%s not in \\x hex form through the fold: %q", id, got)
+					}
+				}
+			}
+		})
+	}
+}

--- a/internal/pgstreamrun/typematrix_fold_integration_test.go
+++ b/internal/pgstreamrun/typematrix_fold_integration_test.go
@@ -143,17 +143,23 @@ func TestOne_PGTypeMatrixThroughReconstructFold(t *testing.T) {
 		"extra_float_digits": "0",
 		"bytea_output":       "'escape'",
 	}
+	// The RESET cleanup is registered BEFORE the skew loop: if an ALTER fails
+	// mid-loop (t.Fatalf), the already-applied skews still get reset rather
+	// than leaking database-level defaults into later tests of this `go test`
+	// invocation (-p 1 runs pgbaseline's package after this one).
+	t.Cleanup(func() {
+		bg := context.Background()
+		for k := range skews {
+			if _, err := pg.Exec(bg, fmt.Sprintf("ALTER DATABASE %s RESET %s", dbIdent, k)); err != nil {
+				t.Logf("skew cleanup: RESET %s failed: %v", k, err)
+			}
+		}
+	})
 	for k, v := range skews {
 		if _, err := pg.Exec(ctx, fmt.Sprintf("ALTER DATABASE %s SET %s TO %s", dbIdent, k, v)); err != nil {
 			t.Fatalf("skew %s: %v", k, err)
 		}
 	}
-	t.Cleanup(func() {
-		bg := context.Background()
-		for k := range skews {
-			_, _ = pg.Exec(bg, fmt.Sprintf("ALTER DATABASE %s RESET %s", dbIdent, k))
-		}
-	})
 
 	dropAll := func() {
 		bg := context.Background()


### PR DESCRIPTION
Closes #593 — slice D, the last open GA-gating item of epic #597.

## The correctness hole this closes

The PostgreSQL baseline+delta design rests on one identity: **baseline COPY text ≡ pgoutput delta text** — reconstruct's PK join and last-write-wins merge are exact string operations over that text. But both sides render every value through the type's server-side **output function**, whose text is **session-GUC-dependent** (`TimeZone`, `DateStyle`, `extra_float_digits`, `bytea_output`, `IntervalStyle`), and neither `internal/pgbaseline` (COPY connections) nor `internal/pgcapture` (walsender session) pinned any GUC. The same logical value could render as different text on the two sides — silently breaking the merge for `timestamptz`/`timestamp`/`date`/`time`, `real`/`double precision`, `bytea`, `interval`.

## The fix

**`internal/pgcapture/gucpin.go`**: every connection that renders row text is pinned to `TimeZone=UTC, DateStyle=ISO, extra_float_digits=3, bytea_output=hex, IntervalStyle=postgres` via **startup-packet RuntimeParams** — the same channel `replication=database` itself travels, so it provably reaches the walsender backend. Startup params apply as `PGC_S_CLIENT` (beats `ALTER DATABASE/ROLE` defaults and the DSN `options` string — both empirically proven by the test below); an invalid value FATALs at connect (never a silently-unpinned session); startup placement leaves pgbaseline's REPEATABLE READ anchor / exported-snapshot workers untouched. Wired: the walsender, the pgbaseline anchor conn, every parallel COPY worker, the slot-create conn. Catalog-only connections deliberately stay unpinned.

**Pre-pin baseline detection**: pgbaseline stamps the pinned set into the Parquet metadata (`bintrail.render_gucs`); single-row reconstruct warns (with re-baseline guidance) when an LSN-anchored baseline lacks the stamp.

**#829 beta warn narrowed**: scalars including the GUC-sensitive set are now fold-validated; the residual beta surface is container types only.

## Fail-before / pass-after evidence

The PR is two commits, per protocol:

- **Commit 1 (`272317b`) — fail-before**: the fold matrix (`TestOne_PGTypeMatrixThroughReconstructFold`: full type matrix through `FindBaseline → ReadBaselineRow → Fetch → ApplyAt`, three rows per type, under a two-sided GUC skew — `ALTER DATABASE` defaults hitting the walsender + baseline conns, and an operator `options=-c` string on the baseline DSN) ran **without the pin**. Result — [run 29055029997](https://github.com/dbtrail/dbtrail/actions/runs/29055029997): red on **exactly the GUC-sensitive set** (`timestamptz`, `timestamp`, `date`, `interval`, `real`, `double`, `bytea`) on all four PG versions (14/15/16/17); everything else green, including the newly-CI-enabled `internal/pgbaseline` integration suite. Two additional reds (`boolean`, `inet`) were **oracle-cast artifacts**, not fidelity bugs: the fold output was internally consistent (`t`/`t`, `192.168.1.10`/`192.168.1.10`), but the oracle's `::text` CAST diverges from the output function (`bool::text`="true" vs `boolout`="t"; `inet::text` appends `/32`). Commit 2 fixes the oracle to read the output-function rendering via the simple protocol (`RawValues`) — a no-op for the GUC-sensitive types (their cast IS the output function), so the recorded fail-before evidence stands.
- **Commit 2 (`c850720`) — pass-after**: the pin + the oracle fix + docs. The CI run at this commit must be green on all four PG cells — that green IS the empirical proof that (a) the walsender accepts startup GUCs on PG 14–17, and (b) the pin beats both `ALTER DATABASE` defaults and the DSN `options` string.

## Upgrade note (also in CHANGELOG)

On servers whose defaults differ from the pin, baselines taken before this release were rendered unpinned and will not text-join post-upgrade deltas for GUC-sensitive types — re-run `bintrail-pg baseline` after upgrading (the reader now warns on a pre-pin baseline). Events indexed pre-upgrade keep their old rendering.

## Out of scope (unchanged)

Full-table `reconstruct` / baseline-anchored `verify` stay gated for PG (#830/#916); container types (arrays beyond `integer[]`/`text[]`, composite, range/multirange, hstore, geometric) remain beta; `lc_monetary` deliberately not pinned (`money` keeps its locale caveat). Stock PG 14–17 in CI validates the GUC mechanics; the gated #594 managed-smoke workflow (RDS+Aurora, billed) can be triggered on the merged commit as additional closing evidence — owner's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
