### PR TITLE
cli: ParseRetain rejects trailing garbage instead of silently truncating

### DIFF
--- a/internal/cliutil/retain.go
+++ b/internal/cliutil/retain.go
@@ -2,6 +2,7 @@ package cliutil
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 )
 
@@ -13,8 +14,10 @@ func ParseRetain(s string) (time.Duration, error) {
 	}
 	unit := s[len(s)-1]
 	numStr := s[:len(s)-1]
-	var n int
-	if _, err := fmt.Sscanf(numStr, "%d", &n); err != nil || n <= 0 {
+	// strconv.Atoi (unlike fmt.Sscanf "%d") rejects unconsumed input, so
+	// "1.5d" or "30 0d" fail loud instead of silently truncating retention.
+	n, err := strconv.Atoi(numStr)
+	if err != nil || n <= 0 {
 		return 0, fmt.Errorf("invalid format %q; expected Nd (days) or Nh (hours), e.g. 7d", s)
 	}
 	switch unit {

--- a/internal/cliutil/retain_test.go
+++ b/internal/cliutil/retain_test.go
@@ -41,9 +41,13 @@ func TestParseRetain_invalid(t *testing.T) {
 		"d",   // no number
 		"7x",  // unknown unit
 		"7",   // no unit
-		"-1d", // negative
-		"0d",  // zero
-		"0h",  // zero hours
+		"-1d",   // negative
+		"0d",    // zero
+		"0h",    // zero hours
+		"1.5d",  // fractional — Sscanf silently truncated to 1d (#817)
+		"30 0d", // embedded space — Sscanf silently truncated to 30d (#817)
+		"7dd",   // trailing garbage before unit
+		" 7d",   // leading whitespace
 	}
 	for _, c := range cases {
 		if _, err := ParseRetain(c); err == nil {


### PR DESCRIPTION
## What

`cliutil.ParseRetain` used `fmt.Sscanf(numStr, "%d", &n)`, which parses the leading integer without requiring the whole string to be consumed: `1.5d` parsed as 1 day, `30 0d` as 30 days. An operator configuring `--retain 1.5d` expecting 36h got 24h retention — rotate pruned events 12 hours early with no error, silently shrinking the restore window.

Replaced with `strconv.Atoi(numStr)`, which rejects unconsumed input (also leading whitespace), reusing the existing invalid-format error message. Callers affected: `rotate`, `recover-cascade --lookback`, `agent --buffer-retain`, rotation loop, console rotation API, `doctor`, baseline prune.

## Tests

Added `1.5d`, `30 0d`, `7dd`, ` 7d` to `TestParseRetain_invalid`. All four fail against the old code (verified via stash) and pass with the fix; existing valid-input tests unchanged.

- `go build ./...` — ok
- `go vet ./internal/cliutil/` — ok
- `go test ./internal/cliutil/... -count=1` — ok
- `go test -tags integration ./internal/cliutil/... -count=1` — ok

Closes #817

🤖 Generated with [Claude Code](https://claude.com/claude-code)