### PR TITLE
agent: fetch archived table once per resolve_pk batch, not per pk_hash

### DIFF
--- a/internal/agent/handler.go
+++ b/internal/agent/handler.go
@@ -76,8 +76,19 @@ type DefaultHandler struct {
 	// resolve_pk and recover check the buffer first (fastest path).
 	Buffer *buffer.Buffer
 
+	// ArchiveFetcher fetches events from one Parquet archive source. Nil →
+	// parquetquery.Fetch (the container-safe DuckDB budget). A seam for tests.
+	ArchiveFetcher query.ArchiveFetcher
+
 	// Logger for handler operations. Nil falls back to slog.Default().
 	Logger *slog.Logger
+}
+
+func (h *DefaultHandler) archiveFetcher() query.ArchiveFetcher {
+	if h.ArchiveFetcher != nil {
+		return h.ArchiveFetcher
+	}
+	return parquetquery.Fetch
 }
 
 func (h *DefaultHandler) logger() *slog.Logger {
@@ -93,6 +104,13 @@ func (h *DefaultHandler) HandleResolvePK(ctx context.Context, req ResolvePKReque
 	if h.IndexDB == nil && len(h.ArchiveSources) == 0 && h.Buffer == nil {
 		return nil, fmt.Errorf("no data sources configured (need --index-dsn, --archive-dir/--archive-s3, or buffer)")
 	}
+
+	// pk_hash → pk_values per (source, schema, table), built from ONE
+	// full-table archive fetch and reused for every batch item (#818):
+	// Parquet archives have no SHA2 index, so the archive fallback scans
+	// the whole table client-side — doing that per item multiplied the
+	// full-table fetch by the batch size.
+	archiveIdx := make(map[archiveTableKey]map[string]string)
 
 	results := make([]PKResult, len(req.Items))
 	for i, item := range req.Items {
@@ -122,7 +140,7 @@ func (h *DefaultHandler) HandleResolvePK(ctx context.Context, req ResolvePKReque
 
 		// Fall back to Parquet archives.
 		for _, src := range h.ArchiveSources {
-			pkVal, err := h.resolvePKFromArchive(ctx, item, src)
+			pkVal, err := h.resolvePKFromArchive(ctx, item, src, archiveIdx)
 			if err != nil {
 				h.logger().Warn("archive query failed, skipping", "source", src, "error", err)
 				continue
@@ -157,25 +175,41 @@ func (h *DefaultHandler) resolvePKFromMySQL(ctx context.Context, item PKItem) (s
 	return pkValues, err
 }
 
-// resolvePKFromArchive scans Parquet archive rows for the given pk_hash.
-// Since Parquet files have no SHA2 index, we fetch all rows for the
-// schema.table and compute SHA-256 client-side to find the match.
-func (h *DefaultHandler) resolvePKFromArchive(ctx context.Context, item PKItem, source string) (string, error) {
-	opts := query.Options{
-		Schema: item.Schema,
-		Table:  item.Table,
-		Limit:  0, // no limit — need to scan for the hash
-	}
-	rows, err := parquetquery.Fetch(ctx, opts, source)
-	if err != nil {
-		return "", err
-	}
-	for _, r := range rows {
-		if byosPKHash(r.PKValues) == item.PKHash {
-			return r.PKValues, nil
+// archiveTableKey identifies one archived table within one archive source —
+// the memoization unit for resolve_pk's client-side hash index.
+type archiveTableKey struct {
+	source, schema, table string
+}
+
+// resolvePKFromArchive resolves a pk_hash against Parquet archive rows.
+// Since Parquet files have no SHA2 index, the first lookup for a
+// (source, schema, table) fetches all of the table's rows, hashes pk_values
+// client-side into cache, and every later item in the batch resolves against
+// that map instead of re-fetching the whole table (#818). Fetch errors are
+// not cached — a later item retries the source.
+func (h *DefaultHandler) resolvePKFromArchive(ctx context.Context, item PKItem, source string, cache map[archiveTableKey]map[string]string) (string, error) {
+	key := archiveTableKey{source: source, schema: item.Schema, table: item.Table}
+	idx, ok := cache[key]
+	if !ok {
+		opts := query.Options{
+			Schema: item.Schema,
+			Table:  item.Table,
+			Limit:  0, // no limit — need every row's pk_values to hash
 		}
+		rows, err := h.archiveFetcher()(ctx, opts, source)
+		if err != nil {
+			return "", err
+		}
+		idx = make(map[string]string, len(rows))
+		for _, r := range rows {
+			hash := byosPKHash(r.PKValues)
+			if _, seen := idx[hash]; !seen { // first match wins, as the pre-memoization scan did
+				idx[hash] = r.PKValues
+			}
+		}
+		cache[key] = idx
 	}
-	return "", nil
+	return idx[item.PKHash], nil
 }
 
 // recoverEventLimit caps the number of events a single recover call may

--- a/internal/agent/handler_test.go
+++ b/internal/agent/handler_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/dbtrail/dbtrail/internal/buffer"
 	"github.com/dbtrail/dbtrail/internal/parser"
+	"github.com/dbtrail/dbtrail/internal/query"
 )
 
 // makeRecoverEvent builds a single INSERT-style parser.Event for the buffer.
@@ -301,5 +302,98 @@ func TestRecoverRequestJSON_backwardCompat(t *testing.T) {
 	}
 	if req.TimeStart.IsZero() {
 		t.Errorf("TimeStart should be parsed from JSON")
+	}
+}
+
+// TestHandleResolvePK_archiveFetchedOncePerTable is the regression test for
+// #818: the archive fallback used to fetch the ENTIRE archived table once
+// per batch item (per source). It must fetch each (source, schema, table)
+// exactly once per resolve_pk command and reuse the hash index for every
+// item in the batch.
+func TestHandleResolvePK_archiveFetchedOncePerTable(t *testing.T) {
+	calls := map[string]int{}
+	h := &DefaultHandler{
+		ArchiveSources: []string{"srcA"},
+		ArchiveFetcher: func(ctx context.Context, opts query.Options, source string) ([]query.ResultRow, error) {
+			calls[source+"|"+opts.Schema+"|"+opts.Table]++
+			if opts.Schema == "shop" && opts.Table == "orders" {
+				return []query.ResultRow{
+					{PKValues: "1"},
+					{PKValues: "1"}, // duplicate pk across events
+					{PKValues: "2"},
+				}, nil
+			}
+			return nil, nil
+		},
+	}
+
+	req := ResolvePKRequest{Items: []PKItem{
+		{PKHash: byosPKHash("1"), Schema: "shop", Table: "orders"},
+		{PKHash: byosPKHash("2"), Schema: "shop", Table: "orders"},
+		{PKHash: byosPKHash("999"), Schema: "shop", Table: "orders"}, // miss
+		{PKHash: byosPKHash("u1"), Schema: "shop", Table: "users"},   // different table
+	}}
+	results, err := h.HandleResolvePK(context.Background(), req)
+	if err != nil {
+		t.Fatalf("HandleResolvePK: %v", err)
+	}
+
+	if got := calls["srcA|shop|orders"]; got != 1 {
+		t.Errorf("shop.orders fetched %d times, want exactly 1 for the whole batch", got)
+	}
+	if got := calls["srcA|shop|users"]; got != 1 {
+		t.Errorf("shop.users fetched %d times, want 1", got)
+	}
+
+	want := []PKResult{
+		{PKHash: byosPKHash("1"), PKValues: "1", Found: true},
+		{PKHash: byosPKHash("2"), PKValues: "2", Found: true},
+		{PKHash: byosPKHash("999")},
+		{PKHash: byosPKHash("u1")},
+	}
+	for i, w := range want {
+		if results[i] != w {
+			t.Errorf("results[%d] = %+v, want %+v", i, results[i], w)
+		}
+	}
+}
+
+// TestHandleResolvePK_archiveErrorNotCached: a failing source is skipped for
+// the current item (warn-and-continue, unchanged behavior) and the failure is
+// NOT memoized — the next item retries it, and a later healthy source still
+// resolves the hash.
+func TestHandleResolvePK_archiveErrorNotCached(t *testing.T) {
+	fetches := map[string]int{}
+	h := &DefaultHandler{
+		ArchiveSources: []string{"bad", "good"},
+		ArchiveFetcher: func(ctx context.Context, opts query.Options, source string) ([]query.ResultRow, error) {
+			fetches[source]++
+			if source == "bad" {
+				return nil, fmt.Errorf("boom")
+			}
+			return []query.ResultRow{{PKValues: "42"}}, nil
+		},
+	}
+
+	req := ResolvePKRequest{Items: []PKItem{
+		{PKHash: byosPKHash("42"), Schema: "shop", Table: "orders"},
+		{PKHash: byosPKHash("nope"), Schema: "shop", Table: "orders"},
+	}}
+	results, err := h.HandleResolvePK(context.Background(), req)
+	if err != nil {
+		t.Fatalf("HandleResolvePK: %v", err)
+	}
+
+	if !results[0].Found || results[0].PKValues != "42" {
+		t.Errorf("results[0] = %+v, want found via healthy source", results[0])
+	}
+	if results[1].Found {
+		t.Errorf("results[1] = %+v, want not found", results[1])
+	}
+	if got := fetches["bad"]; got != 2 {
+		t.Errorf("failing source fetched %d times, want 2 (errors must not be cached)", got)
+	}
+	if got := fetches["good"]; got != 1 {
+		t.Errorf("healthy source fetched %d times, want 1 (memoized)", got)
 	}
 }


### PR DESCRIPTION
## What

`DefaultHandler.HandleResolvePK`'s archive fallback (`resolvePKFromArchive`, `internal/agent/handler.go`) fetched **all** rows of `schema.table` from the Parquet archive (`Limit: 0` — no SHA2 index in Parquet) and hashed `pk_values` client-side, **per request item and per `ArchiveSource`**. A `resolve_pk` command with 50 hashes against a large archived table meant 50 sequential full-table fetches on the BYOS agent, which runs alongside the client workload.

## Fix

Memoize the client-side hash index per `(source, schema, table)` within one `HandleResolvePK` call: the first item to reach a table fetches it once and builds a `pk_hash → pk_values` map (first match wins, as the pre-memoization scan did); every later batch item resolves against the map. Behavior is otherwise identical:

- fetch errors are **not** cached — the existing per-item warn-and-skip retry semantics are preserved;
- source precedence per item (buffer → MySQL index → archives in order, break on found) is unchanged;
- the memoized map holds only distinct `pk_hash → pk_values` strings, strictly smaller than the row slice it replaces.

The new `ArchiveFetcher` field on `DefaultHandler` (nil → `parquetquery.Fetch`) reuses the existing `query.ArchiveFetcher` seam already used by `internal/verify` and `internal/reconstruct`; it exists so the tests can count fetches without DuckDB.

## Tests

- `TestHandleResolvePK_archiveFetchedOncePerTable` — 3 items on one table + 1 on another: each table fetched exactly once, found/not-found results correct (fails on the old per-item code with fetch count 3).
- `TestHandleResolvePK_archiveErrorNotCached` — failing source retried per item (2 fetches), healthy source memoized (1 fetch), hash still resolved.

```
go build ./...                                        ok
go vet ./internal/agent/                              ok
go test ./internal/agent/... -count=1                 ok (6.0s)
go test -tags integration ./internal/agent/... -count=1  ok (6.0s)
```

Closes #818

🤖 Generated with [Claude Code](https://claude.com/claude-code)