### PR TITLE
archive: share one region-pinned DuckDB session across reconcile --deep footer probes

### DIFF
--- a/cliapp/archive.go
+++ b/cliapp/archive.go
@@ -249,9 +249,29 @@ func scanS3Archive(ctx context.Context, s3URL, region string, deep bool) ([]arch
 	if err != nil {
 		return nil, err
 	}
-	client, err := storage.NewS3Client(ctx, region)
+	cfg, err := storage.LoadAWSConfig(ctx, region)
 	if err != nil {
 		return nil, err
+	}
+	client := s3.NewFromConfig(cfg)
+
+	// ONE DuckDB session serves every --deep footer probe of the scan (#807):
+	// extension install and credential-chain resolution happen once, not per
+	// object (a year of hourly archives = thousands of sessions and IMDS
+	// round-trips otherwise), and the chain secret pins the listing's resolved
+	// region (#511) so probes on a cross-region bucket don't 301 every object
+	// into DeepUnverified. A failed open degrades exactly like a failed probe:
+	// row counts stay unset (warned) and the decision layer counts each object
+	// deep-unverified (#469) — the scan itself still completes.
+	var footerDB *sql.DB
+	if deep {
+		fdb, err := openS3FooterSession(ctx, cfg.Region)
+		if err != nil {
+			slog.Warn("reconcile: cannot open DuckDB session for --deep footer reads; row counts left unset", "error", err)
+		} else {
+			footerDB = fdb
+			defer footerDB.Close()
+		}
 	}
 
 	var out []archive.ScannedFile
@@ -282,8 +302,8 @@ func scanS3Archive(ctx context.Context, s3URL, region string, deep bool) ([]arch
 			if obj.LastModified != nil {
 				f.LastModified = obj.LastModified.UTC()
 			}
-			if deep {
-				if n, err := s3ParquetRowCount(ctx, bucket, *obj.Key); err == nil {
+			if deep && footerDB != nil {
+				if n, err := duckdbParquetRowCount(ctx, footerDB, "s3://"+bucket+"/"+*obj.Key); err == nil {
 					f.RowCount = sql.NullInt64{Int64: n, Valid: true}
 				} else {
 					slog.Warn("reconcile: cannot read s3 parquet footer, row_count left unset",
@@ -300,19 +320,32 @@ func scanS3Archive(ctx context.Context, s3URL, region string, deep bool) ([]arch
 	return out, nil
 }
 
-// s3ParquetRowCount reads num_rows from a Parquet footer in S3 via DuckDB
-// httpfs (the ReadParquetMetadataAny pattern in internal/baseline).
-func s3ParquetRowCount(ctx context.Context, bucket, key string) (int64, error) {
+// openS3FooterSession opens the DuckDB session shared by all --deep S3 footer
+// probes of one scan: httpfs loaded and the credential-chain secret created
+// with the scan's region pinned (duckdbutil.EnableS3CredentialChainRegion,
+// #511 — the chain otherwise resolves region from the AWS SDK config, not the
+// bucket, and a mismatch 301s every probe).
+func openS3FooterSession(ctx context.Context, region string) (*sql.DB, error) {
 	db, err := sql.Open("duckdb", "")
 	if err != nil {
-		return 0, fmt.Errorf("open duckdb: %w", err)
+		return nil, fmt.Errorf("open duckdb: %w", err)
 	}
-	defer db.Close()
+	// Probes run sequentially; a single connection guarantees each one sees
+	// the loaded extension and the secret regardless of pool scoping.
+	db.SetMaxOpenConns(1)
 	if err := duckdbutil.LoadHTTPFS(ctx, db); err != nil {
-		return 0, fmt.Errorf("load httpfs extension: %w", err)
+		db.Close()
+		return nil, fmt.Errorf("load httpfs extension: %w", err)
 	}
-	duckdbutil.EnableS3CredentialChain(ctx, db)
-	safe := strings.ReplaceAll("s3://"+bucket+"/"+key, "'", "''")
+	duckdbutil.EnableS3CredentialChainRegion(ctx, db, region)
+	return db, nil
+}
+
+// duckdbParquetRowCount reads num_rows from a Parquet footer on the given
+// session (the ReadParquetMetadataAny pattern in internal/baseline). path is
+// an s3:// URI on the reconcile path; local paths work too (tests).
+func duckdbParquetRowCount(ctx context.Context, db *sql.DB, path string) (int64, error) {
+	safe := strings.ReplaceAll(path, "'", "''")
 	var n int64
 	if err := db.QueryRowContext(ctx,
 		fmt.Sprintf("SELECT num_rows FROM parquet_file_metadata('%s')", safe)).Scan(&n); err != nil {

--- a/cliapp/archive.go
+++ b/cliapp/archive.go
@@ -263,13 +263,25 @@ func scanS3Archive(ctx context.Context, s3URL, region string, deep bool) ([]arch
 	// into DeepUnverified. A failed open degrades exactly like a failed probe:
 	// row counts stay unset (warned) and the decision layer counts each object
 	// deep-unverified (#469) — the scan itself still completes.
+	//
+	// The chain secret resolves credentials at CREATE time, not per request
+	// (duckdbutil.EnableS3CredentialChain's docs explicitly warn against
+	// reusing it on a long-lived session under expiring roles). A large scan
+	// (thousands of hourly objects, 15-45min) can outlive an IMDS/STS role's
+	// credential lifetime, so the secret is re-issued periodically
+	// (s3FooterSecretRefreshInterval) instead of being frozen for the whole
+	// session — otherwise every remaining probe would 403 once the original
+	// credentials expire, degrading into the exact DeepUnverified symptom
+	// #807 was filed to fix.
 	var footerDB *sql.DB
+	var secretIssuedAt time.Time
 	if deep {
 		fdb, err := openS3FooterSession(ctx, cfg.Region)
 		if err != nil {
 			slog.Warn("reconcile: cannot open DuckDB session for --deep footer reads; row counts left unset", "error", err)
 		} else {
 			footerDB = fdb
+			secretIssuedAt = time.Now()
 			defer footerDB.Close()
 		}
 	}
@@ -303,6 +315,10 @@ func scanS3Archive(ctx context.Context, s3URL, region string, deep bool) ([]arch
 				f.LastModified = obj.LastModified.UTC()
 			}
 			if deep && footerDB != nil {
+				if dueForS3SecretRefresh(secretIssuedAt, time.Now(), s3FooterSecretRefreshInterval) {
+					duckdbutil.EnableS3CredentialChainRegion(ctx, footerDB, cfg.Region)
+					secretIssuedAt = time.Now()
+				}
 				if n, err := duckdbParquetRowCount(ctx, footerDB, "s3://"+bucket+"/"+*obj.Key); err == nil {
 					f.RowCount = sql.NullInt64{Int64: n, Valid: true}
 				} else {
@@ -320,11 +336,29 @@ func scanS3Archive(ctx context.Context, s3URL, region string, deep bool) ([]arch
 	return out, nil
 }
 
+// s3FooterSecretRefreshInterval bounds how long the shared --deep session's
+// AWS credential-chain secret is trusted before being re-issued. Chosen well
+// under the shortest common STS/IMDS credential lifetime (IMDS role
+// credentials ~6h, default STS session minimum 15min) so a rotation mid-scan
+// is caught before the original credentials expire — assuming the chain was
+// resolved from a session with at least that much life left when the scan
+// started; a knob, not a hard guarantee for every possible role config.
+var s3FooterSecretRefreshInterval = 10 * time.Minute
+
+// dueForS3SecretRefresh reports whether the shared footer session's
+// credential-chain secret, last (re)issued at last, is due for re-issuing at
+// now given interval. Split out from the scan loop so the threshold logic is
+// testable without a live DuckDB/AWS session.
+func dueForS3SecretRefresh(last, now time.Time, interval time.Duration) bool {
+	return !now.Before(last.Add(interval))
+}
+
 // openS3FooterSession opens the DuckDB session shared by all --deep S3 footer
 // probes of one scan: httpfs loaded and the credential-chain secret created
 // with the scan's region pinned (duckdbutil.EnableS3CredentialChainRegion,
 // #511 — the chain otherwise resolves region from the AWS SDK config, not the
-// bucket, and a mismatch 301s every probe).
+// bucket, and a mismatch 301s every probe). The scan loop re-issues the same
+// secret periodically (dueForS3SecretRefresh) as credentials age.
 func openS3FooterSession(ctx context.Context, region string) (*sql.DB, error) {
 	db, err := sql.Open("duckdb", "")
 	if err != nil {

--- a/cliapp/archive_test.go
+++ b/cliapp/archive_test.go
@@ -2,7 +2,11 @@ package cliapp
 
 import (
 	"bytes"
+	"context"
+	"database/sql"
 	"encoding/json"
+	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -145,5 +149,73 @@ func TestReconcileWiringFromReportDeepUnverified(t *testing.T) {
 	}
 	if !strings.Contains(textBuf.String(), "could not be deep-verified") {
 		t.Fatalf("text output must warn: %s", textBuf.String())
+	}
+}
+
+// TestDuckDBParquetRowCountSharedSession pins the #807 refactor: footer probes
+// run on ONE caller-owned DuckDB session (no per-object open/INSTALL/secret),
+// so successive probes — including a path needing quote-escaping — must all
+// work on the same handle. Local files stand in for S3 objects; only the
+// transport differs (the parquetquery queryFileList precedent).
+func TestDuckDBParquetRowCountSharedSession(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	db.SetMaxOpenConns(1)
+	ctx := context.Background()
+
+	dir := t.TempDir()
+	files := map[string]int64{"a.parquet": 3, "b.parquet": 5, "it's.parquet": 1}
+	for name, n := range files {
+		p := strings.ReplaceAll(filepath.Join(dir, name), "'", "''")
+		if _, err := db.ExecContext(ctx,
+			fmt.Sprintf("COPY (SELECT * FROM range(%d)) TO '%s' (FORMAT PARQUET)", n, p)); err != nil {
+			t.Fatalf("write test parquet %s: %v", name, err)
+		}
+	}
+	for name, want := range files {
+		got, err := duckdbParquetRowCount(ctx, db, filepath.Join(dir, name))
+		if err != nil {
+			t.Fatalf("probe %s on the shared session: %v", name, err)
+		}
+		if got != want {
+			t.Errorf("%s: row count %d, want %d", name, got, want)
+		}
+	}
+}
+
+// TestOpenS3FooterSessionRegionPin pins the #807 region fix: the shared --deep
+// session must come up usable and carry the scan's region IN the chain secret
+// (EnableS3CredentialChainRegion, #511) — without the pin, every probe on a
+// cross-region bucket 301s into permanent DeepUnverified. Dummy env creds make
+// the chain resolvable on creds-less CI; offline hosts skip (extension
+// download), mirroring the duckdbutil test convention.
+func TestOpenS3FooterSessionRegionPin(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY_ID", "AKIATESTDUMMY0000000")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "testdummysecret")
+	t.Setenv("BINTRAIL_DUCKDB_NO_AWS_EXT", "")
+
+	db, err := openS3FooterSession(context.Background(), "eu-west-1")
+	if err != nil {
+		t.Skipf("httpfs unavailable (offline host?): %v", err)
+	}
+	defer db.Close()
+
+	var one int
+	if err := db.QueryRow("SELECT 1").Scan(&one); err != nil || one != 1 {
+		t.Fatalf("session unusable after openS3FooterSession: %v (got %d)", err, one)
+	}
+	var loaded bool
+	if err := db.QueryRow("SELECT loaded FROM duckdb_extensions() WHERE extension_name = 'aws'").Scan(&loaded); err != nil || !loaded {
+		t.Skip("aws extension unavailable (offline host) — region pin not exercised")
+	}
+	var secretStr string
+	if err := db.QueryRow("SELECT secret_string FROM duckdb_secrets() WHERE name = 'bintrail_s3_chain'").Scan(&secretStr); err != nil {
+		t.Fatalf("chain secret missing after openS3FooterSession: %v", err)
+	}
+	if !strings.Contains(secretStr, "region=eu-west-1") {
+		t.Fatalf("chain secret does not carry the pinned region; got %q", secretStr)
 	}
 }

--- a/cliapp/archive_test.go
+++ b/cliapp/archive_test.go
@@ -9,8 +9,10 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/dbtrail/dbtrail/internal/archive"
+	"github.com/dbtrail/dbtrail/internal/duckdbutil"
 )
 
 // TestReconcileDryRunErrFlagsDeepUnverified pins #469: a --deep dry-run with
@@ -217,5 +219,72 @@ func TestOpenS3FooterSessionRegionPin(t *testing.T) {
 	}
 	if !strings.Contains(secretStr, "region=eu-west-1") {
 		t.Fatalf("chain secret does not carry the pinned region; got %q", secretStr)
+	}
+}
+
+// TestDueForS3SecretRefresh pins the follow-up to #807: the shared --deep
+// footer session's credential-chain secret must not be frozen for the whole
+// scan (duckdbutil.EnableS3CredentialChain explicitly warns it resolves
+// credentials at CREATE time, not per request), or an expiring IMDS/STS role
+// 403s every remaining probe partway through a long scan — the same
+// DeepUnverified symptom #807 was filed to fix.
+func TestDueForS3SecretRefresh(t *testing.T) {
+	last := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	interval := 10 * time.Minute
+
+	cases := []struct {
+		name string
+		now  time.Time
+		want bool
+	}{
+		{"just issued", last, false},
+		{"well within interval", last.Add(5 * time.Minute), false},
+		{"one second before due", last.Add(interval - time.Second), false},
+		{"exactly at interval", last.Add(interval), true},
+		{"well past interval", last.Add(45 * time.Minute), true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := dueForS3SecretRefresh(last, c.now, interval); got != c.want {
+				t.Errorf("dueForS3SecretRefresh(%v, %v, %v) = %v, want %v", last, c.now, interval, got, c.want)
+			}
+		})
+	}
+}
+
+// TestS3FooterSessionSecretReissue pins the mechanism the #807 follow-up
+// relies on: re-issuing the credential-chain secret on an ALREADY-OPEN shared
+// session (not a fresh one) must succeed and leave the session usable, so a
+// long --deep scan can pick up rotated credentials mid-scan the same way the
+// pre-#807 per-object sessions did.
+func TestS3FooterSessionSecretReissue(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY_ID", "<redacted>")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "testdummysecret")
+	t.Setenv("BINTRAIL_DUCKDB_NO_AWS_EXT", "")
+
+	db, err := openS3FooterSession(context.Background(), "eu-west-1")
+	if err != nil {
+		t.Skipf("httpfs unavailable (offline host?): %v", err)
+	}
+	defer db.Close()
+
+	var loaded bool
+	if err := db.QueryRow("SELECT loaded FROM duckdb_extensions() WHERE extension_name = 'aws'").Scan(&loaded); err != nil || !loaded {
+		t.Skip("aws extension unavailable (offline host) — secret reissue not exercised")
+	}
+
+	// Simulate the scan loop's periodic refresh on the SAME session.
+	duckdbutil.EnableS3CredentialChainRegion(context.Background(), db, "eu-west-1")
+
+	var one int
+	if err := db.QueryRow("SELECT 1").Scan(&one); err != nil || one != 1 {
+		t.Fatalf("session unusable after re-issuing the secret: %v (got %d)", err, one)
+	}
+	var secretStr string
+	if err := db.QueryRow("SELECT secret_string FROM duckdb_secrets() WHERE name = 'bintrail_s3_chain'").Scan(&secretStr); err != nil {
+		t.Fatalf("chain secret missing after re-issue: %v", err)
+	}
+	if !strings.Contains(secretStr, "region=eu-west-1") {
+		t.Fatalf("re-issued chain secret does not carry the pinned region; got %q", secretStr)
 	}
 }


### PR DESCRIPTION
## What

`archive reconcile --deep` opened a fresh DuckDB session per S3 object in `s3ParquetRowCount` — `sql.Open("duckdb")` + `INSTALL/LOAD httpfs` + `INSTALL/LOAD aws` + `CREATE SECRET` for every footer probe — and created the credential-chain secret with no region pin.

Two consequences:

- **Cost**: a monthly `--deep` over a year of hourly archives ≈ 8760 sessions, each paying extension setup and credential-chain resolution (IMDS/SSO round trips) for a millisecond footer read.
- **Correctness**: without a region pin the chain secret resolves region from the AWS SDK config (e.g. `AWS_REGION`), not the bucket. On a cross-region bucket every probe fails with 301/PermanentRedirect, every object falls to `DeepUnverified`, and the cron monitor is permanently red with no explanation.

## How

- `scanS3Archive` now opens **one** DuckDB session for the whole scan (`openS3FooterSession`: single pooled connection, httpfs loaded once) and passes it to each probe (`duckdbParquetRowCount`).
- The session's chain secret pins the scan's resolved region via `duckdbutil.EnableS3CredentialChainRegion` (the #511 precedent). The region comes from the same `storage.LoadAWSConfig` resolution (flag > env/config > IMDS fallback) that backs the `ListObjectsV2` listing — a successful listing already proves that region matches the bucket, since the SDK does not follow S3's cross-region redirects.
- Failure semantics unchanged: if the shared session cannot be opened, the scan warns once and completes with row counts unset, and the decision layer counts each object deep-unverified (#469) exactly as a per-object failure did before.

## Tests

- `TestDuckDBParquetRowCountSharedSession` — multiple footer probes (incl. a quote-escaped path) on one caller-owned session, over local parquet written by DuckDB itself.
- `TestOpenS3FooterSessionRegionPin` — the shared session comes up usable and the chain secret carries `region=eu-west-1` (stripping the pin fails this test); offline hosts skip, mirroring the `internal/duckdbutil` convention.

```
go build ./...                                  ok
go vet ./cliapp/                                ok
go test ./cliapp/... -count=1                   ok (8.2s)
go test -tags integration ./cliapp/... -count=1 ok (12.2s)
```

Both new tests ran non-skipped locally (extensions cached).

Closes #807

🤖 Generated with [Claude Code](https://claude.com/claude-code)
