### PR TITLE
recover: emit LIMIT 1 on all-columns-fallback DELETE/UPDATE so duplicate rows aren't all hit

### DIFF
--- a/docs/query-and-recovery.md
+++ b/docs/query-and-recovery.md
@@ -362,16 +362,17 @@ For `UPDATE` and `DELETE` reversals, the generator needs a `WHERE` clause to ide
 UPDATE `mydb`.`orders` SET `status` = 'draft' WHERE `id` = 42
 ```
 
-**Without a snapshot (fallback)**: Uses every column in the row image. This is verbose, and is **not** a guarantee of correctness even for tables without duplicate rows:
+**Without a snapshot (fallback)**: Uses every column in the row image, capped at one row:
 
 ```sql
 UPDATE `mydb`.`orders`
 SET `status` = 'draft'
-WHERE `id` = 42 AND `status` = 'published' AND `created_at` = '2026-02-19 14:01:00' AND `notes` IS NULL
+WHERE `id` = 42 AND `status` = 'published' AND `created_at` = '2026-02-19 14:01:00' AND `notes` IS NULL LIMIT 1
 ```
 
-- A `NULL` column renders as `IS NULL` (not `= NULL`, which never matches in SQL) — but a row whose *other* columns are all non-`NULL` and identical to another row (no natural key, no snapshot) will match **both** rows, and the reversal over-applies. There is no runtime detection of this: the generator has no way to know the table has (or doesn't have) duplicate rows.
-- "Without duplicate rows" is a precondition the generator assumes, not something it checks. If you rely on this fallback (no schema snapshot available), verify the table has a natural uniqueness property before applying the generated script.
+- A `NULL` column renders as `IS NULL` (not `= NULL`, which never matches in SQL).
+- An all-columns `WHERE` matches **every byte-identical duplicate row** (PK-less table, no natural key), while the original event touched exactly one row. Fallback `UPDATE`/`DELETE` reversals therefore carry `LIMIT 1` on the MySQL dialect, so reversing one `INSERT` removes one copy instead of silently deleting all duplicates. Which physical copy is affected is undefined — and irrelevant, since the matching rows are identical on every referenced column.
+- PostgreSQL has no `UPDATE`/`DELETE ... LIMIT`, so PostgreSQL-dialect fallback statements remain unbounded: with byte-identical duplicate rows the reversal still over-applies there. If you rely on this fallback against PostgreSQL, verify the table has a natural uniqueness property before applying the generated script.
 
 The resolver is loaded best-effort in the `recover` command — a failure logs a warning and falls back to the all-columns strategy.
 

--- a/docs/query-and-recovery.md
+++ b/docs/query-and-recovery.md
@@ -372,7 +372,7 @@ WHERE `id` = 42 AND `status` = 'published' AND `created_at` = '2026-02-19 14:01:
 
 - A `NULL` column renders as `IS NULL` (not `= NULL`, which never matches in SQL).
 - An all-columns `WHERE` matches **every byte-identical duplicate row** (PK-less table, no natural key), while the original event touched exactly one row. Fallback `UPDATE`/`DELETE` reversals therefore carry `LIMIT 1` on the MySQL dialect, so reversing one `INSERT` removes one copy instead of silently deleting all duplicates. Which physical copy is affected is undefined — and irrelevant, since the matching rows are identical on every referenced column.
-- PostgreSQL has no `UPDATE`/`DELETE ... LIMIT`, so PostgreSQL-dialect fallback statements remain unbounded: with byte-identical duplicate rows the reversal still over-applies there. If you rely on this fallback against PostgreSQL, verify the table has a natural uniqueness property before applying the generated script.
+- PostgreSQL has no `UPDATE`/`DELETE ... LIMIT`, so PostgreSQL-dialect fallback statements remain unbounded: with byte-identical duplicate rows the reversal still over-applies there. The generated script flags each affected statement with a leading `-- WARNING: unbounded all-columns WHERE, no per-statement row cap on this dialect ...` comment so the risk is visible in `--dry-run`/`--output` review, not just here. If you rely on this fallback against PostgreSQL, verify the table has a natural uniqueness property before applying the generated script.
 
 The resolver is loaded best-effort in the `recover` command — a failure logs a warning and falls back to the all-columns strategy.
 

--- a/internal/recovery/recovery.go
+++ b/internal/recovery/recovery.go
@@ -892,14 +892,16 @@ func (g *Generator) buildUpdate(row query.ResultRow) (string, []string, error) {
 
 	// WHERE uses row_after (current state), so the UPDATE finds the right row
 	// even if the PK itself was changed in the original UPDATE.
-	whereParts, whereCols := g.pkWhereClause(r, row.SchemaName, row.TableName, row.RowAfter)
+	whereParts, whereCols, allCols := g.pkWhereClause(r, row.SchemaName, row.TableName, row.RowAfter)
 	cols = append(cols, whereCols...)
 
-	return fmt.Sprintf("UPDATE %s.%s SET %s WHERE %s",
+	stmt := fmt.Sprintf("UPDATE %s.%s SET %s WHERE %s",
 		g.quoteName(row.SchemaName), g.quoteName(row.TableName),
 		strings.Join(setParts, ", "),
 		strings.Join(whereParts, " AND "),
-	), cols, nil
+	)
+	stmt += g.rowLimitSuffix(allCols)
+	return stmt, cols, nil
 }
 
 // generateDelete reverses an INSERT event: delete the inserted row using its
@@ -914,11 +916,26 @@ func (g *Generator) buildDelete(row query.ResultRow) (string, []string, error) {
 		return "", nil, fmt.Errorf("row_after is nil for INSERT event (event_id=%d)", row.EventID)
 	}
 	r := g.resolverForRow(row)
-	whereParts, whereCols := g.pkWhereClause(r, row.SchemaName, row.TableName, row.RowAfter)
-	return fmt.Sprintf("DELETE FROM %s.%s WHERE %s",
+	whereParts, whereCols, allCols := g.pkWhereClause(r, row.SchemaName, row.TableName, row.RowAfter)
+	stmt := fmt.Sprintf("DELETE FROM %s.%s WHERE %s",
 		g.quoteName(row.SchemaName), g.quoteName(row.TableName),
 		strings.Join(whereParts, " AND "),
-	), whereCols, nil
+	)
+	stmt += g.rowLimitSuffix(allCols)
+	return stmt, whereCols, nil
+}
+
+// rowLimitSuffix returns " LIMIT 1" for a reverse UPDATE/DELETE whose WHERE fell
+// back to all columns. The original row event touched exactly ONE row, but an
+// all-columns WHERE matches every byte-identical duplicate (PK-less table, no
+// snapshot) — without the cap, reversing one INSERT deletes ALL copies (#789).
+// MySQL-dialect only: PostgreSQL has no UPDATE/DELETE ... LIMIT, so the PG
+// fallback stays unbounded (documented caveat in docs/query-and-recovery.md).
+func (g *Generator) rowLimitSuffix(allColsFallback bool) string {
+	if allColsFallback && g.dialect == MySQLDialect {
+		return " LIMIT 1"
+	}
+	return ""
 }
 
 // generatedColsFromResolver returns the set of STORED/VIRTUAL generated column
@@ -987,8 +1004,10 @@ func updateSetSkipCols(resolver *metadata.Resolver, schema, table string) map[st
 // It returns both the rendered clauses and the column names they reference, so
 // schema-drift detection (#601) checks exactly the columns the WHERE emits — a PK-scoped
 // WHERE whose PK still exists carries no drifted column even when some other column was
-// dropped, so that recovery is (correctly) not refused.
-func (g *Generator) pkWhereClause(resolver *metadata.Resolver, schema, table string, row map[string]any) (clauses []string, cols []string) {
+// dropped, so that recovery is (correctly) not refused. allColumns reports whether the
+// all-columns fallback was taken — callers cap those statements with LIMIT 1 (#789),
+// since an all-columns WHERE matches every byte-identical duplicate, not one row.
+func (g *Generator) pkWhereClause(resolver *metadata.Resolver, schema, table string, row map[string]any) (clauses []string, cols []string, allColumns bool) {
 	if resolver != nil {
 		tm, err := resolver.Resolve(schema, table)
 		if err != nil {
@@ -1017,14 +1036,17 @@ func (g *Generator) pkWhereClause(resolver *metadata.Resolver, schema, table str
 					names = append(names, pk.Name)
 				}
 				if allFound {
-					return parts, names
+					return parts, names, false
 				}
 			}
 		}
 	}
-	// Fallback: all columns — verbose but always uniquely identifies the row
-	// (assuming the table has no duplicates, which is true for well-formed data).
-	return g.allColsWhere(row)
+	// Fallback: all columns — verbose, and NOT unique when byte-identical
+	// duplicate rows exist (PK-less table, no snapshot). Callers bound the
+	// statement with LIMIT 1 on MySQL so the reversal touches exactly one
+	// row, like the original event did (#789).
+	clauses, cols = g.allColsWhere(row)
+	return clauses, cols, true
 }
 
 func (g *Generator) allColsWhere(row map[string]any) (clauses []string, cols []string) {

--- a/internal/recovery/recovery.go
+++ b/internal/recovery/recovery.go
@@ -901,7 +901,7 @@ func (g *Generator) buildUpdate(row query.ResultRow) (string, []string, error) {
 		strings.Join(whereParts, " AND "),
 	)
 	stmt += g.rowLimitSuffix(allCols)
-	return stmt, cols, nil
+	return g.allColsFallbackWarningComment(allCols) + stmt, cols, nil
 }
 
 // generateDelete reverses an INSERT event: delete the inserted row using its
@@ -922,7 +922,7 @@ func (g *Generator) buildDelete(row query.ResultRow) (string, []string, error) {
 		strings.Join(whereParts, " AND "),
 	)
 	stmt += g.rowLimitSuffix(allCols)
-	return stmt, whereCols, nil
+	return g.allColsFallbackWarningComment(allCols) + stmt, whereCols, nil
 }
 
 // rowLimitSuffix returns " LIMIT 1" for a reverse UPDATE/DELETE whose WHERE fell
@@ -934,6 +934,22 @@ func (g *Generator) buildDelete(row query.ResultRow) (string, []string, error) {
 func (g *Generator) rowLimitSuffix(allColsFallback bool) string {
 	if allColsFallback && g.dialect == MySQLDialect {
 		return " LIMIT 1"
+	}
+	return ""
+}
+
+// allColsFallbackWarningComment returns a leading SQL comment line flagging that the
+// statement below has no per-row cap, for the one dialect where rowLimitSuffix can't
+// supply one. PostgreSQL has no UPDATE/DELETE ... LIMIT, so the all-columns fallback
+// stays unbounded there (#789) with zero runtime signal otherwise — a PK-less table
+// with duplicate rows silently over-applies (reversing one INSERT deletes every
+// byte-identical copy) and the only prior warning was a docs paragraph. The comment
+// is emitted (rather than only a slog.Warn) because it travels with the script into
+// --dry-run/--output, which is where an operator actually reviews before applying.
+func (g *Generator) allColsFallbackWarningComment(allColsFallback bool) string {
+	if allColsFallback && g.dialect == PostgresDialect {
+		return "-- WARNING: unbounded all-columns WHERE, no per-statement row cap on this dialect " +
+			"- may affect every byte-identical duplicate row, not just the one this event touched\n"
 	}
 	return ""
 }

--- a/internal/recovery/recovery_test.go
+++ b/internal/recovery/recovery_test.go
@@ -407,6 +407,76 @@ func TestGenerateUpdate_allColsFallbackLimit1(t *testing.T) {
 	}
 }
 
+// TestGenerateDelete_allColsFallbackPGWarning pins the PostgreSQL-dialect follow-up to
+// #789: PostgreSQL has no DELETE ... LIMIT, so the all-columns fallback stays unbounded
+// — the generated statement must carry a leading warning comment instead, since that's
+// the only runtime signal that reaches an operator reviewing --dry-run/--output.
+func TestGenerateDelete_allColsFallbackPGWarning(t *testing.T) {
+	g := NewForDialect(nil, nil, PostgresDialect)
+	row := query.ResultRow{
+		EventID:    5,
+		SchemaName: "mydb",
+		TableName:  "orders",
+		EventType:  parser.EventInsert,
+		RowAfter:   map[string]any{"id": float64(99), "status": "new"},
+	}
+	stmt, err := g.generateDelete(row)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.HasPrefix(stmt, "-- WARNING:") {
+		t.Errorf("PG all-columns fallback DELETE must carry a leading warning comment: %s", stmt)
+	}
+	if strings.Contains(stmt, "LIMIT") {
+		t.Errorf("PostgreSQL dialect must never emit LIMIT: %s", stmt)
+	}
+}
+
+// TestGenerateUpdate_allColsFallbackPGWarning covers the same PG warning-comment
+// requirement for UPDATE reversals.
+func TestGenerateUpdate_allColsFallbackPGWarning(t *testing.T) {
+	g := NewForDialect(nil, nil, PostgresDialect)
+	row := query.ResultRow{
+		EventID:    6,
+		SchemaName: "mydb",
+		TableName:  "orders",
+		EventType:  parser.EventUpdate,
+		RowBefore:  map[string]any{"id": float64(1), "status": "pending"},
+		RowAfter:   map[string]any{"id": float64(1), "status": "shipped"},
+	}
+	stmt, err := g.generateUpdate(row)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.HasPrefix(stmt, "-- WARNING:") {
+		t.Errorf("PG all-columns fallback UPDATE must carry a leading warning comment: %s", stmt)
+	}
+	if strings.Contains(stmt, "LIMIT") {
+		t.Errorf("PostgreSQL dialect must never emit LIMIT: %s", stmt)
+	}
+}
+
+// TestGeneratePG_pkResolved_noWarningComment ensures the warning comment is scoped to
+// the all-columns fallback only — a PK-resolved statement (the common case) must stay
+// clean.
+func TestGeneratePG_pkResolved_noWarningComment(t *testing.T) {
+	g := NewForDialect(nil, identityGenResolver(), PostgresDialect)
+	row := query.ResultRow{
+		EventID:    7,
+		SchemaName: "public",
+		TableName:  "t",
+		EventType:  parser.EventInsert,
+		RowAfter:   map[string]any{"id": float64(99), "v": "new"},
+	}
+	stmt, err := g.generateDelete(row)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(stmt, "WARNING") {
+		t.Errorf("PK-resolved PG statement must not carry the all-columns warning comment: %s", stmt)
+	}
+}
+
 // TestPKScopedWhere_noLimit: a PK-scoped WHERE uniquely identifies the row, so
 // no LIMIT is emitted — the clean statement shape documented in
 // docs/query-and-recovery.md stays unchanged.

--- a/internal/recovery/recovery_test.go
+++ b/internal/recovery/recovery_test.go
@@ -362,6 +362,108 @@ func TestGenerateUpdate_allColsFallbackNullColumn(t *testing.T) {
 	}
 }
 
+// ─── #789: all-columns fallback caps reversal at one row (LIMIT 1) ───────────
+
+// TestGenerateDelete_allColsFallbackLimit1 pins #789: with the all-columns
+// WHERE fallback (no resolver), byte-identical duplicate rows all match — the
+// reverse DELETE of ONE INSERT must not delete every copy, so the MySQL
+// dialect emits a trailing LIMIT 1.
+func TestGenerateDelete_allColsFallbackLimit1(t *testing.T) {
+	g := newGen()
+	row := query.ResultRow{
+		EventID:    3,
+		SchemaName: "mydb",
+		TableName:  "orders",
+		EventType:  parser.EventInsert,
+		RowAfter:   map[string]any{"id": float64(99), "status": "new"},
+	}
+	stmt, err := g.generateDelete(row)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.HasSuffix(stmt, " LIMIT 1") {
+		t.Errorf("all-columns fallback DELETE must end with LIMIT 1 (#789): %s", stmt)
+	}
+}
+
+// TestGenerateUpdate_allColsFallbackLimit1 covers the same #789 cap for UPDATE
+// reversals — an unbounded all-columns WHERE would modify every duplicate.
+func TestGenerateUpdate_allColsFallbackLimit1(t *testing.T) {
+	g := newGen()
+	row := query.ResultRow{
+		EventID:    4,
+		SchemaName: "mydb",
+		TableName:  "orders",
+		EventType:  parser.EventUpdate,
+		RowBefore:  map[string]any{"id": float64(1), "status": "pending"},
+		RowAfter:   map[string]any{"id": float64(1), "status": "shipped"},
+	}
+	stmt, err := g.generateUpdate(row)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.HasSuffix(stmt, " LIMIT 1") {
+		t.Errorf("all-columns fallback UPDATE must end with LIMIT 1 (#789): %s", stmt)
+	}
+}
+
+// TestPKScopedWhere_noLimit: a PK-scoped WHERE uniquely identifies the row, so
+// no LIMIT is emitted — the clean statement shape documented in
+// docs/query-and-recovery.md stays unchanged.
+func TestPKScopedWhere_noLimit(t *testing.T) {
+	g := newGenWithResolver()
+	del := query.ResultRow{
+		EventID:    5,
+		SchemaName: "shop",
+		TableName:  "order_items",
+		EventType:  parser.EventInsert,
+		RowAfter:   map[string]any{"order_id": float64(5), "quantity": float64(3)},
+	}
+	stmt, err := g.generateDelete(del)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(stmt, "LIMIT") {
+		t.Errorf("PK-scoped DELETE must not carry LIMIT: %s", stmt)
+	}
+	upd := query.ResultRow{
+		EventID:    6,
+		SchemaName: "shop",
+		TableName:  "order_items",
+		EventType:  parser.EventUpdate,
+		RowBefore:  map[string]any{"order_id": float64(5), "quantity": float64(2)},
+		RowAfter:   map[string]any{"order_id": float64(5), "quantity": float64(3)},
+	}
+	stmt, err = g.generateUpdate(upd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(stmt, "LIMIT") {
+		t.Errorf("PK-scoped UPDATE must not carry LIMIT: %s", stmt)
+	}
+}
+
+// TestGenerateDelete_pgFallbackNoLimit: PostgreSQL has no DELETE/UPDATE ...
+// LIMIT, so the PG-dialect fallback must stay unbounded (documented caveat)
+// rather than emit invalid SQL.
+func TestGenerateDelete_pgFallbackNoLimit(t *testing.T) {
+	g := NewForDialect(nil, nil, PostgresDialect)
+	row := query.ResultRow{
+		EventID:    7,
+		SchemaName: "mydb",
+		TableName:  "orders",
+		EventType:  parser.EventInsert,
+		RowAfter:   map[string]any{"id": float64(99), "status": "new"},
+	}
+	stmt, err := g.generateDelete(row)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(stmt, "LIMIT") {
+		t.Errorf("PostgreSQL DELETE must not carry LIMIT (invalid syntax): %s", stmt)
+	}
+}
+
 // ─── GenerateSQL integration (no DB, exercising the output wrapper) ────────────
 
 func TestGenerateSQL_noRows(t *testing.T) {


### PR DESCRIPTION
## What

`pkWhereClause` now reports when it fell back to the all-columns WHERE (PK-less table, unresolvable table, or PK column missing from the row image), and `buildDelete`/`buildUpdate` append ` LIMIT 1` to those statements in the MySQL dialect.

## Why

The all-columns fallback WHERE matches **every byte-identical duplicate row**, while the row event being reversed touched exactly one row. Reversing one INSERT therefore deleted ALL duplicate copies (silent loss of pre-existing rows), and a reverse UPDATE modified them all. `DELETE`/`UPDATE ... LIMIT 1` caps the reversal at one row; which physical copy is affected is undefined and irrelevant, since the matching rows are identical on every column the WHERE references.

- PK-scoped WHEREs (resolver present, PK resolves): unchanged, no LIMIT.
- PostgreSQL dialect: unchanged — PG has no `UPDATE`/`DELETE ... LIMIT`, so the fallback stays unbounded there and `docs/query-and-recovery.md` now documents that residual caveat explicitly (the old "assumes no duplicate rows" claim is replaced by the LIMIT 1 behavior for MySQL).

## Tests

New unit tests: fallback DELETE and UPDATE end with ` LIMIT 1`; PK-scoped DELETE/UPDATE carry no LIMIT; PostgreSQL-dialect fallback carries no LIMIT (invalid syntax there).

- `go build ./...` — ok
- `go vet ./internal/recovery/` — ok
- `go test ./internal/recovery/... -count=1` — ok
- `go test ./internal/cascaderecover/ ./internal/cli/ ./internal/console/ ./internal/query/ ./internal/baseline/ -count=1` — ok (dependent packages)
- `go test -tags integration ./internal/recovery/... -count=1` — ok (MySQL 13306)

Closes #789

🤖 Generated with [Claude Code](https://claude.com/claude-code)