### PR TITLE
recover: --limit keeps the most recent events; truncated flag in JSON output

### DIFF
--- a/internal/cli/recover.go
+++ b/internal/cli/recover.go
@@ -179,6 +179,15 @@ func runRecover(cmd *cobra.Command, args []string) error {
 		Flag:       rFlag,
 		Limit:      rLimit,
 		LimitPerPK: rLimitPerPK,
+		// When --limit truncates the window it must keep the most RECENT
+		// events (#785): reversing a newest-suffix rolls the data back to a
+		// consistent intermediate point, whereas the ASC default would keep
+		// the OLDEST prefix — undoing old events underneath later un-reverted
+		// ones maps to no state that ever existed (the reverse UPDATE's
+		// row_after WHERE no longer matches, or the reverse DELETE removes a
+		// row a later event rewrote). The rows are re-sorted ascending after
+		// the fetch, before generation.
+		Order: "DESC",
 	}
 
 	// ── Connect to index database ─────────────────────────────────────────────
@@ -300,6 +309,18 @@ func runRecover(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// The fetch above ran Order=DESC so --limit kept the newest suffix of the
+	// window (#785). Detect truncation on the FETCHED row count — before
+	// generation, so the warning fires even when generation later refuses —
+	// then restore ascending order: GenerateSQLFromRows expects ASC input and
+	// reverses it internally to undo most-recent first.
+	truncated := rLimit > 0 && len(rows) >= rLimit
+	if truncated {
+		slog.Warn("matched events truncated at --limit; only the most recent events of the window are reversed",
+			"limit", rLimit)
+	}
+	rows = query.MergeResults(rows, 0, "ASC")
+
 	// ── Generate recovery SQL ─────────────────────────────────────────────────
 	// Select the SQL dialect from the source flavor recorded in the index
 	// (single-source per stream_state) — PostgreSQL needs double-quoted identifiers
@@ -326,8 +347,9 @@ func runRecover(cmd *cobra.Command, args []string) error {
 			return cliutil.OutputJSON(struct {
 				Statements int    `json:"statements"`
 				DryRun     bool   `json:"dry_run"`
+				Truncated  bool   `json:"truncated"`
 				SQL        string `json:"sql"`
-			}{Statements: n, DryRun: true, SQL: buf.String()})
+			}{Statements: n, DryRun: true, Truncated: truncated, SQL: buf.String()})
 		}
 
 		n, err := gen.GenerateSQLFromRows(rows, os.Stdout)
@@ -341,8 +363,8 @@ func runRecover(cmd *cobra.Command, args []string) error {
 		if n > 0 {
 			fmt.Fprintf(os.Stderr, "\n%d reversal statement(s) generated.\n", n)
 		}
-		if n >= rLimit {
-			fmt.Fprintf(os.Stderr, "Warning: results truncated at %d rows. Use a narrower time range or --limit to adjust.\n", rLimit)
+		if truncated {
+			fmt.Fprintf(os.Stderr, "Warning: results truncated at %d events; only the most recent events of the window are reversed. Use a narrower time range or --limit to adjust.\n", rLimit)
 		}
 		return nil
 	}
@@ -372,8 +394,9 @@ func runRecover(cmd *cobra.Command, args []string) error {
 		return cliutil.OutputJSON(struct {
 			Statements int    `json:"statements"`
 			DryRun     bool   `json:"dry_run"`
+			Truncated  bool   `json:"truncated"`
 			Output     string `json:"output"`
-		}{Statements: n, DryRun: false, Output: rOutput})
+		}{Statements: n, DryRun: false, Truncated: truncated, Output: rOutput})
 	}
 
 	if n == 0 {
@@ -381,8 +404,8 @@ func runRecover(cmd *cobra.Command, args []string) error {
 	} else {
 		fmt.Fprintf(os.Stderr, "%d reversal statement(s) written to %s\n", n, rOutput)
 	}
-	if n >= rLimit {
-		fmt.Fprintf(os.Stderr, "Warning: results truncated at %d rows. Use a narrower time range or --limit to adjust.\n", rLimit)
+	if truncated {
+		fmt.Fprintf(os.Stderr, "Warning: results truncated at %d events; only the most recent events of the window are reversed. Use a narrower time range or --limit to adjust.\n", rLimit)
 	}
 	return nil
 }

--- a/internal/cli/recover_limit_integration_test.go
+++ b/internal/cli/recover_limit_integration_test.go
@@ -1,0 +1,173 @@
+//go:build integration
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// seedRecoverUpdates seeds a chain of 4 UPDATE events on the same row
+// (v0→v1→v2→v3→v4) at one-minute intervals, so a truncating --limit has an
+// unambiguous "newest suffix" (v2→v3, v3→v4) and "oldest prefix" (v0→v1,
+// v1→v2). The values v0/v1 appear ONLY in the oldest two events, making
+// their presence in a reversal script a direct proof of oldest-prefix
+// truncation (#785).
+func seedRecoverUpdates(t *testing.T) (dbName, dsn string) {
+	t.Helper()
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	h := time.Now().UTC().Add(-1 * time.Hour).Truncate(time.Hour)
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{h})
+	for i := 1; i <= 4; i++ {
+		ts := h.Add(time.Duration(i) * time.Minute).Format("2006-01-02 15:04:05")
+		before := fmt.Sprintf(`{"id":1,"v":"v%d"}`, i-1)
+		after := fmt.Sprintf(`{"id":1,"v":"v%d"}`, i)
+		testutil.InsertEvent(t, db, "binlog.000001", uint64(i*100), uint64(i*100+50), ts, nil,
+			dbName, "orders", 2 /* UPDATE */, "1",
+			[]byte(`["v"]`), []byte(before), []byte(after))
+	}
+	return dbName, testutil.IntegrationDSN(dbName)
+}
+
+// resetRecoverGlobals snapshots every recover command global, restores them on
+// cleanup, and sets flag-default values for a clean programmatic run.
+func resetRecoverGlobals(t *testing.T) {
+	t.Helper()
+	sIndexDSN, sSchema, sTable, sPK := rIndexDSN, rSchema, rTable, rPK
+	sPKs, sLimitPerPK, sEventType, sGTID := rPKs, rLimitPerPK, rEventType, rGTID
+	sSince, sUntil, sFlag, sOutput := rSince, rUntil, rFlag, rOutput
+	sDryRun, sLimit, sProfile, sFormat := rDryRun, rLimit, rProfile, rFormat
+	sNoArchive, sColumnEq, sMaxScriptBytes, sAllowGaps := rNoArchive, rColumnEq, rMaxScriptBytes, rAllowGaps
+	t.Cleanup(func() {
+		rIndexDSN, rSchema, rTable, rPK = sIndexDSN, sSchema, sTable, sPK
+		rPKs, rLimitPerPK, rEventType, rGTID = sPKs, sLimitPerPK, sEventType, sGTID
+		rSince, rUntil, rFlag, rOutput = sSince, sUntil, sFlag, sOutput
+		rDryRun, rLimit, rProfile, rFormat = sDryRun, sLimit, sProfile, sFormat
+		rNoArchive, rColumnEq, rMaxScriptBytes, rAllowGaps = sNoArchive, sColumnEq, sMaxScriptBytes, sAllowGaps
+	})
+
+	rIndexDSN, rSchema, rTable, rPK = "", "", "", ""
+	rPKs, rLimitPerPK, rEventType, rGTID = nil, 0, "", ""
+	rSince, rUntil, rFlag, rOutput = "", "", "", ""
+	rDryRun, rLimit, rProfile, rFormat = false, 1000, "", "text"
+	rNoArchive, rColumnEq, rMaxScriptBytes, rAllowGaps = true, nil, "2GB", false
+}
+
+func newRecoverTestCmd() *cobra.Command {
+	c := &cobra.Command{}
+	c.SetContext(context.Background())
+	AddDuckDBTuningFlags(c)
+	return c
+}
+
+// TestRecover_limitKeepsNewestEvents pins #785: when --limit truncates the
+// matched window, the reversal script must undo the most RECENT events (a
+// rollback to a consistent intermediate point), not the oldest prefix that the
+// old ASC fetch kept — undoing old events underneath later un-reverted ones
+// maps to no state that ever existed.
+func TestRecover_limitKeepsNewestEvents(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	dbName, dsn := seedRecoverUpdates(t)
+	resetRecoverGlobals(t)
+
+	out := t.TempDir() + "/recovery.sql"
+	rIndexDSN, rSchema, rTable = dsn, dbName, "orders"
+	rOutput, rLimit = out, 2
+
+	if err := runRecover(newRecoverTestCmd(), nil); err != nil {
+		t.Fatalf("runRecover: %v", err)
+	}
+	b, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	script := string(b)
+
+	// Newest two events are v2→v3 and v3→v4; their reversals reference v2..v4.
+	if !strings.Contains(script, `'v3'`) || !strings.Contains(script, `'v2'`) {
+		t.Errorf("expected reversals of the two NEWEST updates (v2→v3, v3→v4), got:\n%s", script)
+	}
+	// v0/v1 exist only in the oldest two events — any occurrence means the
+	// truncation kept the oldest prefix (the #785 bug).
+	if strings.Contains(script, `'v0'`) || strings.Contains(script, `'v1'`) {
+		t.Errorf("script reversed the OLDEST events; --limit must keep the newest suffix of the window:\n%s", script)
+	}
+	// Most-recent undone first: the reverse of v3→v4 (its WHERE carries 'v4')
+	// must precede the reverse of v2→v3 (its SET carries 'v2').
+	i4, i2 := strings.Index(script, `'v4'`), strings.Index(script, `'v2'`)
+	if i4 == -1 || i2 == -1 || i4 > i2 {
+		t.Errorf("expected the newest event's reversal first (most-recent undone first), got:\n%s", script)
+	}
+}
+
+// TestRecover_jsonCarriesTruncatedFlag pins the observability half of #785:
+// --format json must carry a `truncated` flag (the old stderr-only warning was
+// emitted after the JSON branch returned, so automated consumers never saw it),
+// and the truncated dry-run SQL must also keep the newest suffix.
+func TestRecover_jsonCarriesTruncatedFlag(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	dbName, dsn := seedRecoverUpdates(t)
+
+	run := func(limit int) (statements int, truncated bool, sqlText string) {
+		t.Helper()
+		resetRecoverGlobals(t)
+		rIndexDSN, rSchema, rTable = dsn, dbName, "orders"
+		rDryRun, rFormat, rLimit = true, "json", limit
+
+		old := os.Stdout
+		r, w, err := os.Pipe()
+		if err != nil {
+			t.Fatalf("pipe: %v", err)
+		}
+		os.Stdout = w
+		runErr := runRecover(newRecoverTestCmd(), nil)
+		w.Close()
+		os.Stdout = old
+		outBytes, readErr := io.ReadAll(r)
+		if runErr != nil {
+			t.Fatalf("runRecover: %v", runErr)
+		}
+		if readErr != nil {
+			t.Fatalf("read captured stdout: %v", readErr)
+		}
+		var payload struct {
+			Statements int    `json:"statements"`
+			DryRun     bool   `json:"dry_run"`
+			Truncated  bool   `json:"truncated"`
+			SQL        string `json:"sql"`
+		}
+		if err := json.Unmarshal(outBytes, &payload); err != nil {
+			t.Fatalf("unmarshal JSON output %q: %v", outBytes, err)
+		}
+		return payload.Statements, payload.Truncated, payload.SQL
+	}
+
+	n, trunc, sqlText := run(2)
+	if n != 2 || !trunc {
+		t.Errorf("limit=2 over 4 events: got statements=%d truncated=%v, want 2/true", n, trunc)
+	}
+	if strings.Contains(sqlText, `'v0'`) || strings.Contains(sqlText, `'v1'`) {
+		t.Errorf("truncated dry-run reversed the OLDEST events, want newest suffix:\n%s", sqlText)
+	}
+
+	n, trunc, _ = run(1000)
+	if n != 4 || trunc {
+		t.Errorf("limit=1000 over 4 events: got statements=%d truncated=%v, want 4/false", n, trunc)
+	}
+}

--- a/internal/console/api.go
+++ b/internal/console/api.go
@@ -251,7 +251,15 @@ func (s *Server) handleRecover(w http.ResponseWriter, r *http.Request) {
 	// Recovery requires chronological (oldest-first) input: GenerateSQLFromRows
 	// reverses internally so the most-recent event is undone first. The browsing
 	// default (DESC) would invert the undo order for a PK touched multiple times.
-	// Forcing ASC here also makes the LIMIT select the oldest N, matching the CLI.
+	//
+	// Forcing ASC here also means a LIMIT truncation keeps the OLDEST N events,
+	// NOT the newest N -- unlike the CLI, which fixed this for #785 by fetching
+	// DESC (newest-first, so LIMIT keeps the newest suffix) then re-sorting ASC
+	// before generation. The console still has the pre-#785 bug: a truncated
+	// console recover reverses only the earliest part of the matched window,
+	// leaving the target in the same kind of inconsistent partial state #785
+	// fixed for the CLI. Not addressed here -- see #785 and #927 for context
+	// on a follow-up fix.
 	opts.Order = ""
 
 	// Coverage gaps come back in plan.GapHours and are surfaced as warnings


### PR DESCRIPTION
## What

`recover` never set `query.Options.Order`, so the fetch ordered ASC and `--limit` (default 1000) kept the **oldest** N events of the window. Reversing only that prefix leaves the newer events applied — the partial script maps to no historical state (a reverse UPDATE's `row_after` WHERE silently matches 0 rows that a later un-reverted event rewrote; a reverse DELETE removes a row a later event modified).

- Set `Order: "DESC"` on the recover fetch so the SQL `LIMIT` keeps the most recent **suffix** of the window — reverting a newest-suffix is a rollback to a consistent intermediate point. The whole pipeline (`buildQuery`, `sortResults`, `MergeAndTrim`, `parquetquery`) already honors `Order=DESC`, so the change is confined to the recover command layer.
- Restore ascending order after the fetch (`query.MergeResults(rows, 0, "ASC")`) before generation — `GenerateSQLFromRows` expects ASC input and reverses internally to undo most-recent first.
- Make the truncation warning reliable: truncation is detected on the **fetched** row count before generation (fires even when generation later refuses) and emitted as a `slog.Warn` for every format; both `--format json` payloads (dry-run and file-output) now carry a `truncated` field. Previously the stderr-only warning was emitted after the JSON branch returned, so automated consumers never saw it.

## Why

Issue #785 (full-codebase audit finding): a truncated reversal script that undoes the oldest prefix is a silently inconsistent recovery — the worst failure mode for a recovery tool.

## Tests

New integration tests (`internal/cli/recover_limit_integration_test.go`) seed a 4-event UPDATE chain (v0→v1→v2→v3→v4) and pin both halves:

- `TestRecover_limitKeepsNewestEvents`: with `--limit 2` the script must reverse only the newest two events, most-recent first. **Fails on the old ASC ordering** (verified by temporarily flipping `Order` back: `script reversed the OLDEST events`).
- `TestRecover_jsonCarriesTruncatedFlag`: `--format json --dry-run` payload reports `truncated=true, statements=2` when capped and `truncated=false, statements=4` when not.

```
go build ./...                                        ok
go vet ./internal/cli/                                ok
go test ./internal/cli/... -count=1                   ok (1.5s)
go test -tags integration ./internal/cli/... -count=1 ok (19.6s, MySQL 13306)
```

## Notes

The MCP `recover` tool (`cmd/bintrail-mcp/main.go` recoverTool) has the same oldest-prefix truncation shape (no `Order` on its fetch, warning as a trailing SQL comment) — sibling surface, left out of this PR to keep it scoped to the cited finding.

Closes #785

🤖 Generated with [Claude Code](https://claude.com/claude-code)
