### PR TITLE
shim: interpret MySQL escape sequences in string PK literals

### DIFF
--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -133,12 +133,22 @@ func (f *Filters) Matches(schema, table string) bool {
 func BuildPKValues(pkColumns []metadata.ColumnMeta, row map[string]any) string {
 	parts := make([]string, 0, len(pkColumns))
 	for _, col := range pkColumns {
-		val := formatPKValue(row[col.Name])
-		val = strings.ReplaceAll(val, `\`, `\\`)
-		val = strings.ReplaceAll(val, `|`, `\|`)
-		parts = append(parts, val)
+		parts = append(parts, EscapePKValue(formatPKValue(row[col.Name])))
 	}
 	return strings.Join(parts, "|")
+}
+
+// EscapePKValue applies the pipe/backslash escaping BuildPKValues uses for
+// each individual PK column value. Exported so callers holding a raw,
+// already-decoded single-column PK value (e.g. internal/shim, after
+// MySQL-unescaping a SQL string literal) can re-encode it into the same
+// at-rest form stored in binlog_events.pk_values before using it as a match
+// filter — the string-literal unescaping and this pipe-delimiter escaping
+// are two unrelated encodings, and neither implies the other.
+func EscapePKValue(val string) string {
+	val = strings.ReplaceAll(val, `\`, `\\`)
+	val = strings.ReplaceAll(val, `|`, `\|`)
+	return val
 }
 
 // formatPKValue renders a single PK value for BuildPKValues. []byte needs its

--- a/internal/shim/handler.go
+++ b/internal/shim/handler.go
@@ -452,12 +452,18 @@ func (h *Handler) runPointInTime(q TimeTravelQuery) (*mysql.Result, error) {
 	// ROW_NUMBER OVER (PARTITION BY pk_values ORDER BY event_timestamp
 	// DESC, event_id DESC) so the kept event for each PK is the most
 	// recent one — exactly what _flashback "row state at AsOf" needs.
+	// q.PKValue is the raw, MySQL-unescaped literal value (stripQuotes /
+	// unescapeStringLiteral, #826). Options.PKValues is matched against
+	// binlog_events.pk_values, which is stored in event.BuildPKValues-encoded
+	// form (backslash/pipe escaped). Re-encode with event.EscapePKValue here
+	// so a backslash- or pipe-containing PK still matches instead of
+	// silently missing (#826 follow-up).
 	engine := query.New(h.indexDB)
 	rows, _, err := query.FetchMerged(ctx, h.indexDB, engine, query.FetchMergedOptions{
 		Opts: query.Options{
 			Schema:     q.Schema,
 			Table:      q.Table,
-			PKValues:   q.PKValue,
+			PKValues:   event.EscapePKValue(q.PKValue),
 			Until:      &q.AsOf,
 			LimitPerPK: 1,
 		},
@@ -1377,12 +1383,15 @@ func (h *Handler) runDiff(q TimeTravelQuery) (*mysql.Result, error) {
 	// hand the customer a partial audit history with no signal — worse than
 	// the rare cost of a few thousand rows for an unusually hot row.
 	// Customers needing pagination can narrow the BETWEEN range.
+	// See the matching comment in runPointInTime: q.PKValue is raw/unescaped
+	// (#826); binlog_events.pk_values is BuildPKValues-encoded, so re-encode
+	// before matching.
 	engine := query.New(h.indexDB)
 	rows, _, err := query.FetchMerged(ctx, h.indexDB, engine, query.FetchMergedOptions{
 		Opts: query.Options{
 			Schema:   q.Schema,
 			Table:    q.Table,
-			PKValues: q.PKValue,
+			PKValues: event.EscapePKValue(q.PKValue),
 			Since:    &q.Since,
 			Until:    &q.Until,
 		},

--- a/internal/shim/parser.go
+++ b/internal/shim/parser.go
@@ -438,11 +438,72 @@ func parseTimeLiteral(s string) (time.Time, error) {
 	return time.Time{}, fmt.Errorf("must be one of: %s (zone-less forms are interpreted as UTC), or a relative literal like '5 minutes ago'", strings.Join(timeFormats, ", "))
 }
 
+// stripQuotes converts a regex-captured WHERE value into the raw bytes
+// matched against pk_values. Quoted string literals get standard MySQL
+// escape semantics (#826): without unescaping, a backslash-containing
+// PK — `WHERE path = 'C:\\temp\\new'` escaped MySQL-style — would
+// search for the literal escaped bytes, miss, and return an empty
+// resultset, which the documented AS OF semantics read as "the row
+// didn't exist at that instant" — a false forensic conclusion.
+// Unquoted (numeric) values pass through unchanged.
 func stripQuotes(s string) string {
 	if len(s) >= 2 && s[0] == '\'' && s[len(s)-1] == '\'' {
-		return s[1 : len(s)-1]
+		return unescapeStringLiteral(s[1 : len(s)-1])
 	}
 	return s
+}
+
+// unescapeStringLiteral interprets the escape sequences MySQL recognises
+// inside a single-quoted string literal (String Literals, MySQL 8.0
+// reference §9.1.1): \0 \b \n \r \t \Z \\ \' \" translate to their
+// character; \% and \_ keep the backslash (they are only special in
+// LIKE patterns); a backslash before any other character is dropped
+// (escapes are case-sensitive: \Z is Ctrl+Z, \z is z); a doubled quote
+// ('') collapses to a single quote.
+//
+// Note the value regexes ('[^']*') cannot capture a literal containing
+// a quote character — such statements miss the full matcher and keep
+// the fail-loud 1064 path — so the \' and '' branches are for MySQL-
+// semantics completeness, not reachable through Parse today.
+func unescapeStringLiteral(s string) string {
+	if !strings.ContainsAny(s, `\'`) {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c == '\\' && i+1 < len(s):
+			i++
+			switch s[i] {
+			case '0':
+				b.WriteByte(0)
+			case 'b':
+				b.WriteByte('\b')
+			case 'n':
+				b.WriteByte('\n')
+			case 'r':
+				b.WriteByte('\r')
+			case 't':
+				b.WriteByte('\t')
+			case 'Z':
+				b.WriteByte(0x1A)
+			case '%', '_':
+				b.WriteByte('\\')
+				b.WriteByte(s[i])
+			default:
+				// \\ \' \" and any other \x → x.
+				b.WriteByte(s[i])
+			}
+		case c == '\'' && i+1 < len(s) && s[i+1] == '\'':
+			b.WriteByte('\'')
+			i++
+		default:
+			b.WriteByte(c)
+		}
+	}
+	return b.String()
 }
 
 // parseAsOfRealTable handles the bare time-travel form on a real table

--- a/internal/shim/parser_test.go
+++ b/internal/shim/parser_test.go
@@ -183,6 +183,137 @@ func TestParseStringPK(t *testing.T) {
 	}
 }
 
+// TestParseStringPKEscapes pins MySQL escape semantics inside string
+// literals (#826): the captured bytes must be the value MySQL would
+// store, not the escaped source text, or a backslash-containing PK
+// misses pk_values and AS OF falsely reports "the row didn't exist".
+func TestParseStringPKEscapes(t *testing.T) {
+	cases := []struct {
+		name string
+		sql  string
+		want string
+	}{
+		{
+			"backslash path",
+			`SELECT * FROM _flashback.files AS OF '2026-05-02' WHERE path = 'C:\\temp\\new'`,
+			`C:\temp\new`,
+		},
+		{
+			"newline and tab",
+			`SELECT * FROM _flashback.t AS OF '2026-05-02' WHERE k = 'a\nb\tc'`,
+			"a\nb\tc",
+		},
+		{
+			"cr nul backspace ctrlZ",
+			`SELECT * FROM _flashback.t AS OF '2026-05-02' WHERE k = 'a\rb\0c\bd\Ze'`,
+			"a\rb\x00c\bd\x1ae",
+		},
+		{
+			"escaped double quote",
+			`SELECT * FROM _flashback.t AS OF '2026-05-02' WHERE k = 'a\"b'`,
+			`a"b`,
+		},
+		{
+			"LIKE escapes keep backslash",
+			`SELECT * FROM _flashback.t AS OF '2026-05-02' WHERE k = '100\%\_x'`,
+			`100\%\_x`,
+		},
+		{
+			"backslash before ordinary char dropped, case-sensitive z",
+			`SELECT * FROM _flashback.t AS OF '2026-05-02' WHERE k = '\a\z'`,
+			"az",
+		},
+		{
+			"no escapes untouched",
+			`SELECT * FROM _flashback.t AS OF '2026-05-02' WHERE k = 'plain value'`,
+			"plain value",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			q, err := Parse(tc.sql, "myapp")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if q.PKValue != tc.want {
+				t.Errorf("PKValue = %q, want %q", q.PKValue, tc.want)
+			}
+		})
+	}
+}
+
+// TestParseStringPKEscapesAllForms proves every stripQuotes call site —
+// _diff, the hint-comment form, and the bare AS OF form — unescapes,
+// not just the _flashback/_snapshot matcher.
+func TestParseStringPKEscapesAllForms(t *testing.T) {
+	const want = `C:\temp`
+	cases := []struct {
+		name string
+		sql  string
+	}{
+		{
+			"_diff",
+			`SELECT * FROM _diff.files BETWEEN '2026-05-01' AND '2026-05-02' WHERE path = 'C:\\temp'`,
+		},
+		{
+			"hint form",
+			`SELECT /*+ DBTRAIL_AT='2026-05-02' */ * FROM files WHERE path = 'C:\\temp'`,
+		},
+		{
+			"bare AS OF real table",
+			`SELECT * FROM files WHERE path = 'C:\\temp' AS OF '2026-05-02'`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			q, err := Parse(tc.sql, "myapp")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if q.PKValue != want {
+				t.Errorf("PKValue = %q, want %q", q.PKValue, want)
+			}
+		})
+	}
+}
+
+// TestUnescapeStringLiteral covers branches unreachable through Parse
+// (the value regexes cannot capture a quote character): doubled quotes
+// and \' must still collapse per MySQL semantics, and a trailing lone
+// backslash must not be lost or panic.
+func TestUnescapeStringLiteral(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{`O''Brien`, `O'Brien`},
+		{`O\'Brien`, `O'Brien`},
+		{`trailing\`, `trailing\`},
+		{``, ``},
+	}
+	for _, tc := range cases {
+		if got := unescapeStringLiteral(tc.in); got != tc.want {
+			t.Errorf("unescapeStringLiteral(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestParseQuoteInStringPKStaysFailLoud pins that a literal containing
+// a quote character still misses the matcher and errors (1064 path) —
+// #826 must not silently change the fail-loud behavior into a
+// partial-parse.
+func TestParseQuoteInStringPKStaysFailLoud(t *testing.T) {
+	_, err := Parse(
+		`SELECT * FROM _flashback.t AS OF '2026-05-02' WHERE k = 'O\'Brien'`,
+		"myapp",
+	)
+	if err == nil {
+		t.Fatal("expected error for quote-containing literal, got nil")
+	}
+	if errors.Is(err, ErrNotTimeTravel) {
+		t.Fatalf("want malformed-query error (1064 path), got ErrNotTimeTravel")
+	}
+}
+
 func TestParseNegativePK(t *testing.T) {
 	q, err := Parse(
 		"SELECT * FROM _flashback.t AS OF '2026-05-02' WHERE id = -42",

--- a/internal/shim/pk_escape_seam_integration_test.go
+++ b/internal/shim/pk_escape_seam_integration_test.go
@@ -1,0 +1,180 @@
+//go:build integration
+
+package shim
+
+import (
+	"encoding/json"
+	"log/slog"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/baseline"
+	"github.com/dbtrail/dbtrail/internal/event"
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestPKValueEscapeSeam_BackslashAndPipe pins the regression both
+// adversarial reviews of PR #928 found: stripQuotes/unescapeStringLiteral
+// (#826) hands runPointInTime/runDiff a RAW, MySQL-unescaped PK literal, but
+// binlog_events.pk_values is stored in event.BuildPKValues-ENCODED form
+// (backslash doubled, pipe escaped). Without re-encoding the value at the
+// match seam, a backslash- or pipe-containing PK silently misses —
+// regressing the exact "false empty resultset" scenario #826 was filed to
+// fix. This test seeds a REAL pk_values-encoded row and drives it through
+// Parse() plus the real handler methods, so a fix that only pins the parser
+// layer (as PR #928's own tests did) cannot go green over this bug.
+func TestPKValueEscapeSeam_BackslashAndPipe(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	hourTop := time.Now().UTC().Truncate(time.Hour)
+	addHourlyPartition(t, db, hourTop)
+	eventTS := hourTop.Add(5 * time.Minute)
+	asOf := hourTop.Add(10 * time.Minute)
+
+	cases := []struct {
+		name    string
+		rawPK   string // what stripQuotes/unescapeStringLiteral hands back
+		literal string // the MySQL string literal as written in SQL
+	}{
+		{"backslash path", `C:\temp\new`, `'C:\\temp\\new'`},
+		{"pipe-containing PK", `a|b`, `'a|b'`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// This is exactly what a real capture writes for this PK value —
+			// event.BuildPKValues is the single source of truth for the
+			// at-rest encoding.
+			encodedPK := event.EscapePKValue(tc.rawPK)
+			rowAfter, err := json.Marshal(map[string]any{"path": tc.rawPK, "name": "n"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			testutil.InsertEvent(t, db, "mysql-bin.000001", 100, 200,
+				eventTS.Format("2006-01-02 15:04:05"), nil,
+				"myapp", "files", 1 /*insert*/, encodedPK, nil, nil, rowAfter)
+
+			h := NewHandlerWithConfig(db, Config{
+				AllowGaps:   true,
+				NoArchive:   true,
+				IndexDBName: dbName,
+			}, slog.Default())
+
+			sqlText := "SELECT * FROM _flashback.files AS OF '" +
+				asOf.Format("2006-01-02 15:04:05") + "' WHERE path = " + tc.literal
+			q, perr := Parse(sqlText, "myapp")
+			if perr != nil {
+				t.Fatalf("Parse: %v", perr)
+			}
+			if q.PKValue != tc.rawPK {
+				t.Fatalf("sanity: Parse PKValue = %q, want %q (parser-layer contract from #826)", q.PKValue, tc.rawPK)
+			}
+
+			// _flashback and _diff go through independent match seams
+			// (handler.go's two separate PKValues assignments) — run each
+			// as its own subtest so a regression isolated to just one of
+			// them still shows up, instead of one Fatalf hiding the other.
+			t.Run("_flashback", func(t *testing.T) {
+				res, err := h.runPointInTime(q)
+				if err != nil {
+					t.Fatalf("runPointInTime: %v", err)
+				}
+				if got := len(res.Resultset.RowDatas); got != 1 {
+					t.Fatalf("_flashback: expected 1 row for PK %q (stored pk_values=%q), got %d — encoding seam regression", tc.rawPK, encodedPK, got)
+				}
+			})
+
+			t.Run("_diff", func(t *testing.T) {
+				diffQ := q
+				diffQ.Type = TypeDiff
+				diffQ.Since = eventTS.Add(-time.Minute)
+				diffQ.Until = asOf
+				diffRes, err := h.runDiff(diffQ)
+				if err != nil {
+					t.Fatalf("runDiff: %v", err)
+				}
+				if got := len(diffRes.Resultset.RowDatas); got != 1 {
+					t.Fatalf("_diff: expected 1 row for PK %q, got %d — encoding seam regression", tc.rawPK, got)
+				}
+			})
+		})
+	}
+}
+
+// TestSnapshotBaseline_BackslashPK_DeltaAppliesAfterBaseline pins the
+// second, more dangerous half of the regression: on _snapshot,
+// ReadBaselineRow correctly receives the RAW PK value (baseline Parquet
+// rows store actual column values, not the encoded pk_values form), so the
+// baseline lookup matches — but the post-baseline DELTA fetch was, before
+// this fix, ALSO issued with the raw value and therefore never matched the
+// event.BuildPKValues-encoded pk_values a post-baseline UPDATE is stored
+// under. That silently serves the (now-stale) baseline image as the answer
+// instead of applying the delta — worse than an empty resultset, because it
+// looks like a valid answer.
+func TestSnapshotBaseline_BackslashPK_DeltaAppliesAfterBaseline(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	hourTop := time.Now().UTC().Truncate(time.Hour)
+	addHourlyPartition(t, db, hourTop)
+	snapTime := hourTop.Add(1 * time.Minute)
+	asOf := hourTop.Add(10 * time.Minute)
+	eventTS := hourTop.Add(5 * time.Minute).Format("2006-01-02 15:04:05")
+
+	rawPK := `C:\temp\new`
+	encodedPK := event.EscapePKValue(rawPK)
+
+	snapTS := snapTime.UTC().Format("2006-01-02 15:04:05")
+	testutil.InsertSnapshot(t, db, 1, snapTS, "myapp", "files", "path", 1, "PRI", "varchar", "NO")
+	testutil.InsertSnapshot(t, db, 1, snapTS, "myapp", "files", "owner", 2, "", "varchar", "YES")
+
+	cols := []baseline.Column{
+		{Name: "path", MySQLType: "varchar", ParquetType: baseline.MysqlToParquetNode("varchar")},
+		{Name: "owner", MySQLType: "varchar", ParquetType: baseline.MysqlToParquetNode("varchar")},
+	}
+	baselineDir := writeBaselineSnapshot(t, snapTime, "myapp", "files", cols, [][]string{
+		{rawPK, "alice"},
+	})
+
+	// Post-baseline UPDATE changes owner. Stored pk_values is the ENCODED
+	// form — exactly what a real capture writes via event.BuildPKValues.
+	rowBefore, err := json.Marshal(map[string]any{"path": rawPK, "owner": "alice"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rowAfter, err := json.Marshal(map[string]any{"path": rawPK, "owner": "bob"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	testutil.InsertEvent(t, db, "mysql-bin.000001", 100, 200, eventTS, nil,
+		"myapp", "files", 2 /*update*/, encodedPK, nil, rowBefore, rowAfter)
+
+	h := NewHandlerWithConfig(db, Config{
+		AllowGaps:   true,
+		NoArchive:   true,
+		IndexDBName: dbName,
+		BaselineDir: baselineDir,
+	}, slog.Default())
+
+	q := TimeTravelQuery{Type: TypeSnapshot, Schema: "myapp", Table: "files", PKColumn: "path", PKValue: rawPK, AsOf: asOf}
+	res, err := h.runSnapshot(q)
+	if err != nil {
+		t.Fatalf("runSnapshot: %v", err)
+	}
+	cells := rowCells(t, res.Resultset)
+	if len(cells) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(cells))
+	}
+	if want := []string{rawPK, "bob"}; !slices.Equal(cells[0], want) {
+		t.Errorf("_snapshot row = %v, want %v — post-baseline UPDATE not applied (stale baseline served)", cells[0], want)
+	}
+}

--- a/internal/shim/snapshot.go
+++ b/internal/shim/snapshot.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-mysql-org/go-mysql/mysql"
 
+	"github.com/dbtrail/dbtrail/internal/event"
 	"github.com/dbtrail/dbtrail/internal/metadata"
 	"github.com/dbtrail/dbtrail/internal/query"
 	"github.com/dbtrail/dbtrail/internal/reconstruct"
@@ -429,6 +430,9 @@ func (h *Handler) runSnapshotPointInTime(q TimeTravelQuery) (*mysql.Result, erro
 		return nil, err
 	}
 
+	// q.PKValue is passed RAW (unescaped) here — Parquet baseline rows store
+	// actual column values, not event.BuildPKValues-encoded pk_values, so this
+	// seam must NOT apply event.EscapePKValue (unlike the delta fetch below).
 	baselineRow, err := reconstruct.ReadBaselineRow(ctx, baselinePath, map[string]string{q.PKColumn: q.PKValue})
 	if err != nil {
 		return nil, err
@@ -456,10 +460,18 @@ func (h *Handler) runSnapshotPointInTime(q TimeTravelQuery) (*mysql.Result, erro
 		Since:  &snapshotTime,
 		Until:  &q.AsOf,
 	}
+	// q.PKValue is raw/unescaped (#826). Unlike ReadBaselineRow above (which
+	// matches actual Parquet column values and must keep the raw value), this
+	// delta fetch matches binlog_events.pk_values, which is
+	// event.BuildPKValues-encoded — re-encode with event.EscapePKValue so a
+	// backslash- or pipe-containing PK's post-baseline events are found
+	// instead of silently missing (which would serve a stale baseline image
+	// as the answer at AsOf).
+	encoded := event.EscapePKValue(q.PKValue)
 	if q.PKValue != "" {
-		opts.PKValues = q.PKValue
+		opts.PKValues = encoded
 	} else {
-		opts.PKValuesIn = []string{q.PKValue}
+		opts.PKValuesIn = []string{encoded}
 	}
 	engine := query.New(h.indexDB)
 	rows, _, err := query.FetchMerged(ctx, h.indexDB, engine, query.FetchMergedOptions{


### PR DESCRIPTION
## What

`stripQuotes` in `internal/shim/parser.go` only removed the outer quotes of a captured WHERE value. A string PK containing a backslash — `WHERE path = 'C:\\temp\\new'` escaped MySQL-style — was matched against `pk_values` as the literal escaped bytes (`C:\\temp\\new`), missed, and returned an empty resultset. Under the documented AS OF semantics an empty resultset means "the row didn't exist at that instant" — a false forensic conclusion with no signal.

## Fix

Quoted literals now pass through `unescapeStringLiteral`, which applies standard MySQL string-literal semantics (MySQL 8.0 reference §9.1.1):

- `\0` `\b` `\n` `\r` `\t` `\Z` `\\` `\'` `\"` translate to their character
- `\%` and `\_` keep the backslash (only special in LIKE patterns)
- a backslash before any other character is dropped (escapes are case-sensitive: `\Z` is Ctrl+Z, `\z` is `z`)
- `''` collapses to `'`

Applied at the single `stripQuotes` seam, so all four call sites benefit: `_flashback`/`_snapshot`, `_diff`, the `DBTRAIL_AT` hint form, and the bare `AS OF` form. Numeric (unquoted) values pass through unchanged.

Unchanged by design: literals containing a quote character (`'O\'Brien'`, `'O''Brien'`) still cannot be captured by the value regexes (`'[^']*'`) — they miss the full matcher and keep the fail-loud ER_PARSE_ERROR (1064) path, pinned by `TestParseQuoteInStringPKStaysFailLoud`. The `\'`/`''` branches in the unescaper are for MySQL-semantics completeness (unit-tested directly).

## Tests

- `TestParseStringPKEscapes` — escape matrix through `Parse` (backslash path, `\n`/`\t`, `\r`/`\0`/`\b`/`\Z`, `\"`, LIKE escapes, case-sensitive `\z`, plain value)
- `TestParseStringPKEscapesAllForms` — `_diff`, hint form, bare AS OF form all unescape
- `TestUnescapeStringLiteral` — `''`, `\'`, trailing lone backslash, empty
- `TestParseQuoteInStringPKStaysFailLoud` — 1064 behavior preserved

Verified fail-before: with the unescape call reverted, the new tests fail with `PKValue = "C:\\\\temp", want "C:\\temp"`.

```
go build ./...                                        ok
go vet ./internal/shim/                               ok
go test ./internal/shim/ -count=1                     ok (1.5s)
go test -tags integration ./internal/shim/... -count=1  ok (12.2s, MySQL 13306)
```

Closes #826

🤖 Generated with [Claude Code](https://claude.com/claude-code)
