### PR TITLE
byos: close EnsurePartitionKey check-then-write race with S3 conditional put

### DIFF
--- a/internal/byos/partition_key.go
+++ b/internal/byos/partition_key.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -56,10 +57,17 @@ func EnsurePartitionKey(ctx context.Context, b storage.Backend, serverID string)
 		if err != nil {
 			return fmt.Errorf("marshal partition-key marker: %w", err)
 		}
-		if err := b.Put(ctx, partitionKeyMarker, bytes.NewReader(body)); err != nil {
+		created, err := putMarker(ctx, b, body)
+		if err != nil {
 			return fmt.Errorf("write partition-key marker: %w", err)
 		}
-		return nil
+		if created {
+			return nil
+		}
+		// Lost the create race: another agent wrote the marker between the
+		// Exists check and our conditional write. Fall through to
+		// read-and-compare so the surviving marker is validated instead of
+		// silently overwritten (which would re-arm the #198 cutover).
 	}
 
 	rc, err := b.Get(ctx, partitionKeyMarker)
@@ -120,4 +128,21 @@ func EnsurePartitionKey(ctx context.Context, b storage.Backend, serverID string)
 		)
 	}
 	return nil
+}
+
+// putMarker writes the marker body, atomically when the backend supports
+// conditional writes. Returns created=false with a nil error when another
+// writer created the marker first (the caller must then re-read and compare).
+// Backends without ConditionalPutter keep the pre-existing non-atomic
+// Exists→Put window.
+func putMarker(ctx context.Context, b storage.Backend, body []byte) (bool, error) {
+	cp, ok := b.(storage.ConditionalPutter)
+	if !ok {
+		return true, b.Put(ctx, partitionKeyMarker, bytes.NewReader(body))
+	}
+	err := cp.PutIfAbsent(ctx, partitionKeyMarker, bytes.NewReader(body))
+	if errors.Is(err, storage.ErrObjectExists) {
+		return false, nil
+	}
+	return err == nil, err
 }

--- a/internal/byos/partition_key_test.go
+++ b/internal/byos/partition_key_test.go
@@ -5,10 +5,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/dbtrail/dbtrail/internal/storage"
 )
 
 func TestEnsurePartitionKey_FirstRun(t *testing.T) {
@@ -264,4 +267,105 @@ func mustGet(ctx context.Context, b storageBackendGetter) io.ReadCloser {
 
 type storageBackendGetter interface {
 	Get(ctx context.Context, key string) (io.ReadCloser, error)
+}
+
+// condMemBackend adds atomic create-if-absent on top of memBackend, mirroring
+// what S3Backend offers via conditional writes (If-None-Match: *).
+type condMemBackend struct {
+	*memBackend
+	putIfAbsentErr error // when set, PutIfAbsent returns it as-is
+}
+
+func (c *condMemBackend) PutIfAbsent(ctx context.Context, key string, r io.Reader) error {
+	if c.putIfAbsentErr != nil {
+		return c.putIfAbsentErr
+	}
+	ok, err := c.memBackend.Exists(ctx, key)
+	if err != nil {
+		return err
+	}
+	if ok {
+		return fmt.Errorf("put-if-absent %q: %w", key, storage.ErrObjectExists)
+	}
+	return c.memBackend.Put(ctx, key, r)
+}
+
+// staleExistsBackend simulates the Exists→Put race window: Exists reports
+// absent even though another writer already created the marker.
+type staleExistsBackend struct {
+	*condMemBackend
+}
+
+func (s *staleExistsBackend) Exists(context.Context, string) (bool, error) {
+	return false, nil
+}
+
+func TestEnsurePartitionKey_ConditionalBackendFirstRun(t *testing.T) {
+	b := &condMemBackend{memBackend: newMemBackend()}
+	ctx := context.Background()
+
+	if err := EnsurePartitionKey(ctx, b, "srv-A"); err != nil {
+		t.Fatalf("first run on conditional backend: %v", err)
+	}
+	if err := EnsurePartitionKey(ctx, b, "srv-A"); err != nil {
+		t.Fatalf("second run with matching serverID: %v", err)
+	}
+}
+
+func TestEnsurePartitionKey_LostCreateRaceMismatchRefused(t *testing.T) {
+	// Two agents race the same empty prefix: agent A's marker lands first,
+	// but agent B's Exists check raced ahead of it and still saw "absent".
+	// With a plain Put, B silently overwrote A's marker — re-arming the #198
+	// cutover for A. With the conditional write B loses the create, re-reads
+	// the surviving marker, and must refuse the mismatched serverID.
+	cond := &condMemBackend{memBackend: newMemBackend()}
+	ctx := context.Background()
+	if err := EnsurePartitionKey(ctx, cond, "srv-A"); err != nil {
+		t.Fatalf("seed srv-A marker: %v", err)
+	}
+	before, _ := io.ReadAll(mustGet(ctx, cond))
+
+	err := EnsurePartitionKey(ctx, &staleExistsBackend{cond}, "srv-B")
+	if err == nil {
+		t.Fatal("racing agent with different serverID returned nil, want mismatch error")
+	}
+	if !strings.Contains(err.Error(), "partition key mismatch") {
+		t.Errorf("want 'partition key mismatch'; got: %v", err)
+	}
+
+	after, _ := io.ReadAll(mustGet(ctx, cond))
+	if !bytes.Equal(before, after) {
+		t.Errorf("marker overwritten by racing agent:\n  before = %s\n  after  = %s", before, after)
+	}
+}
+
+func TestEnsurePartitionKey_LostCreateRaceMatchOK(t *testing.T) {
+	cond := &condMemBackend{memBackend: newMemBackend()}
+	ctx := context.Background()
+	if err := EnsurePartitionKey(ctx, cond, "srv-A"); err != nil {
+		t.Fatalf("seed srv-A marker: %v", err)
+	}
+	before, _ := io.ReadAll(mustGet(ctx, cond))
+
+	if err := EnsurePartitionKey(ctx, &staleExistsBackend{cond}, "srv-A"); err != nil {
+		t.Fatalf("racing agent with same serverID: %v", err)
+	}
+
+	after, _ := io.ReadAll(mustGet(ctx, cond))
+	if !bytes.Equal(before, after) {
+		t.Errorf("marker rewritten by racing agent with same serverID")
+	}
+}
+
+func TestEnsurePartitionKey_ConditionalPutError(t *testing.T) {
+	sentinel := errors.New("s3 throttled")
+	b := &condMemBackend{memBackend: newMemBackend(), putIfAbsentErr: sentinel}
+
+	err := EnsurePartitionKey(context.Background(), b, "srv-A")
+	if err == nil || !errors.Is(err, sentinel) {
+		t.Fatalf("want wrapped sentinel, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "write partition-key marker") {
+		t.Errorf("error should name the operation; got: %v", err)
+	}
 }

--- a/internal/storage/s3.go
+++ b/internal/storage/s3.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -155,10 +156,16 @@ func (b *S3Backend) Put(ctx context.Context, key string, r io.Reader) error {
 // PutIfAbsent uploads the content from r to the given key only if no object
 // exists there, using an S3 conditional write (If-None-Match: *). When an
 // object is already present S3 answers 412 and PutIfAbsent returns an error
-// wrapping ErrObjectExists. The body is buffered in memory — this is meant
-// for small control files (markers), not data uploads. S3-compatible services
-// that do not support conditional writes (NotImplemented/501) fall back to an
-// unconditional Put, i.e. the pre-conditional non-atomic behavior.
+// wrapping ErrObjectExists. S3 also documents a 409 ConditionalRequestConflict
+// response when a conflicting write races the same key during upload — the
+// exact two-writer scenario this method exists to protect — and that is
+// treated the same as the losing 412 case rather than surfaced as a hard
+// error. The body is buffered in memory — this is meant for small control
+// files (markers), not data uploads. S3-compatible services that do not
+// support conditional writes (NotImplemented/501) fall back to an
+// unconditional Put, i.e. the pre-conditional non-atomic behavior; that
+// fallback is logged so the loss of the atomicity guarantee is visible to
+// operators.
 func (b *S3Backend) PutIfAbsent(ctx context.Context, key string, r io.Reader) error {
 	if err := validateKey(key); err != nil {
 		return err
@@ -174,10 +181,13 @@ func (b *S3Backend) PutIfAbsent(ctx context.Context, key string, r io.Reader) er
 		IfNoneMatch: aws.String("*"),
 	})
 	if err != nil {
-		if isAPIErrorCode(err, "PreconditionFailed") || isHTTPStatus(err, http.StatusPreconditionFailed) {
+		if isAPIErrorCode(err, "PreconditionFailed") || isHTTPStatus(err, http.StatusPreconditionFailed) ||
+			isAPIErrorCode(err, "ConditionalRequestConflict") || isHTTPStatus(err, http.StatusConflict) {
 			return fmt.Errorf("storage: put-if-absent %q: %w", key, ErrObjectExists)
 		}
 		if isAPIErrorCode(err, "NotImplemented") || isHTTPStatus(err, http.StatusNotImplemented) {
+			slog.Warn("storage: backend does not support S3 conditional writes (If-None-Match); falling back to an unconditional Put — the put-if-absent atomicity guarantee is inactive for this key and a concurrent writer can silently overwrite it",
+				"key", key)
 			return b.Put(ctx, key, bytes.NewReader(body))
 		}
 		return fmt.Errorf("storage: put-if-absent %q: %w", key, err)

--- a/internal/storage/s3.go
+++ b/internal/storage/s3.go
@@ -1,15 +1,18 @@
 package storage
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 )
 
@@ -147,6 +150,53 @@ func (b *S3Backend) Put(ctx context.Context, key string, r io.Reader) error {
 		return fmt.Errorf("storage: put %q: %w", key, err)
 	}
 	return nil
+}
+
+// PutIfAbsent uploads the content from r to the given key only if no object
+// exists there, using an S3 conditional write (If-None-Match: *). When an
+// object is already present S3 answers 412 and PutIfAbsent returns an error
+// wrapping ErrObjectExists. The body is buffered in memory — this is meant
+// for small control files (markers), not data uploads. S3-compatible services
+// that do not support conditional writes (NotImplemented/501) fall back to an
+// unconditional Put, i.e. the pre-conditional non-atomic behavior.
+func (b *S3Backend) PutIfAbsent(ctx context.Context, key string, r io.Reader) error {
+	if err := validateKey(key); err != nil {
+		return err
+	}
+	body, err := io.ReadAll(r)
+	if err != nil {
+		return fmt.Errorf("storage: put-if-absent %q: read body: %w", key, err)
+	}
+	_, err = b.client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:      aws.String(b.bucket),
+		Key:         aws.String(b.fullKey(key)),
+		Body:        bytes.NewReader(body),
+		IfNoneMatch: aws.String("*"),
+	})
+	if err != nil {
+		if isAPIErrorCode(err, "PreconditionFailed") || isHTTPStatus(err, http.StatusPreconditionFailed) {
+			return fmt.Errorf("storage: put-if-absent %q: %w", key, ErrObjectExists)
+		}
+		if isAPIErrorCode(err, "NotImplemented") || isHTTPStatus(err, http.StatusNotImplemented) {
+			return b.Put(ctx, key, bytes.NewReader(body))
+		}
+		return fmt.Errorf("storage: put-if-absent %q: %w", key, err)
+	}
+	return nil
+}
+
+// isAPIErrorCode reports whether err carries the given S3 API error code.
+func isAPIErrorCode(err error, code string) bool {
+	var apiErr smithy.APIError
+	return errors.As(err, &apiErr) && apiErr.ErrorCode() == code
+}
+
+// isHTTPStatus reports whether err carries the given HTTP status. Some
+// S3-compatible backends surface errors as generic HTTP response errors
+// without an S3 error code.
+func isHTTPStatus(err error, status int) bool {
+	var re *smithyhttp.ResponseError
+	return errors.As(err, &re) && re.Response.StatusCode == status
 }
 
 // Get returns a reader for the content at the given key.

--- a/internal/storage/s3_test.go
+++ b/internal/storage/s3_test.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -14,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 )
 
@@ -27,6 +29,11 @@ type mockS3 struct {
 	headErr       error
 	deleteErr     error
 	listErr       error
+
+	// condUnsupported makes PutObject reject If-None-Match with
+	// NotImplemented, like S3-compatible services without conditional-write
+	// support.
+	condUnsupported bool
 
 	// Multipart-upload state, exercised by the managed Uploader for bodies
 	// larger than its part size. mpMu guards concurrent UploadPart calls.
@@ -53,6 +60,14 @@ func (m *mockS3) HeadBucket(_ context.Context, _ *s3.HeadBucketInput, _ ...func(
 func (m *mockS3) PutObject(_ context.Context, input *s3.PutObjectInput, _ ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
 	if m.putErr != nil {
 		return nil, m.putErr
+	}
+	if aws.ToString(input.IfNoneMatch) == "*" {
+		if m.condUnsupported {
+			return nil, &smithy.GenericAPIError{Code: "NotImplemented", Message: "conditional writes not supported"}
+		}
+		if _, exists := m.objects[*input.Key]; exists {
+			return nil, &smithy.GenericAPIError{Code: "PreconditionFailed", Message: "at least one of the pre-conditions you specified did not hold"}
+		}
 	}
 	data, err := io.ReadAll(input.Body)
 	if err != nil {
@@ -630,5 +645,78 @@ func TestUploadFileMultipart(t *testing.T) {
 	}
 	if got := mock.objects["archive/big.parquet"]; !bytes.Equal(got, payload) {
 		t.Fatalf("stored %d bytes, want %d (or wrong order)", len(got), len(payload))
+	}
+}
+
+func TestPutIfAbsentCreatesWhenAbsent(t *testing.T) {
+	mock := newMockS3()
+	b := newTestBackend(t, mock, "bintrail")
+	ctx := context.Background()
+
+	if err := b.PutIfAbsent(ctx, "marker", strings.NewReader("v1")); err != nil {
+		t.Fatalf("PutIfAbsent: %v", err)
+	}
+	if got := string(mock.objects["bintrail/marker"]); got != "v1" {
+		t.Errorf("stored content under prefixed key = %q, want v1", got)
+	}
+}
+
+func TestPutIfAbsentExistingObjectRefused(t *testing.T) {
+	mock := newMockS3()
+	b := newTestBackend(t, mock, "")
+	ctx := context.Background()
+	mock.objects["marker"] = []byte("original")
+
+	err := b.PutIfAbsent(ctx, "marker", strings.NewReader("intruder"))
+	if !errors.Is(err, ErrObjectExists) {
+		t.Fatalf("want ErrObjectExists, got: %v", err)
+	}
+	if got := string(mock.objects["marker"]); got != "original" {
+		t.Errorf("existing object was overwritten: %q", got)
+	}
+}
+
+func TestPutIfAbsentHTTP412Refused(t *testing.T) {
+	mock := newMockS3()
+	b := newTestBackend(t, mock, "")
+	// Some S3-compatible backends surface the conditional-write conflict as
+	// a generic HTTP 412 without an S3 error code.
+	mock.putErr = &smithyhttp.ResponseError{
+		Response: &smithyhttp.Response{
+			Response: &http.Response{StatusCode: http.StatusPreconditionFailed},
+		},
+		Err: fmt.Errorf("precondition failed"),
+	}
+
+	err := b.PutIfAbsent(context.Background(), "marker", strings.NewReader("x"))
+	if !errors.Is(err, ErrObjectExists) {
+		t.Fatalf("want ErrObjectExists for generic HTTP 412, got: %v", err)
+	}
+}
+
+func TestPutIfAbsentNotImplementedFallsBack(t *testing.T) {
+	mock := newMockS3()
+	mock.condUnsupported = true
+	b := newTestBackend(t, mock, "")
+	ctx := context.Background()
+
+	// Backends without conditional-write support degrade to a plain Put —
+	// the pre-conditional behavior — instead of failing the write.
+	if err := b.PutIfAbsent(ctx, "marker", strings.NewReader("v1")); err != nil {
+		t.Fatalf("PutIfAbsent with NotImplemented backend: %v", err)
+	}
+	if got := string(mock.objects["marker"]); got != "v1" {
+		t.Errorf("fallback Put did not store object, got %q", got)
+	}
+}
+
+func TestPutIfAbsentOtherErrorPropagates(t *testing.T) {
+	mock := newMockS3()
+	b := newTestBackend(t, mock, "")
+	mock.putErr = errors.New("s3 down")
+
+	err := b.PutIfAbsent(context.Background(), "marker", strings.NewReader("x"))
+	if err == nil || errors.Is(err, ErrObjectExists) {
+		t.Fatalf("want plain propagated error, got: %v", err)
 	}
 }

--- a/internal/storage/s3_test.go
+++ b/internal/storage/s3_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"slices"
 	"strings"
@@ -34,6 +35,12 @@ type mockS3 struct {
 	// NotImplemented, like S3-compatible services without conditional-write
 	// support.
 	condUnsupported bool
+
+	// condConflict makes PutObject reject If-None-Match with the 409
+	// ConditionalRequestConflict AWS documents for a write racing another
+	// conditional write to the same key, instead of the more common 412
+	// PreconditionFailed.
+	condConflict bool
 
 	// Multipart-upload state, exercised by the managed Uploader for bodies
 	// larger than its part size. mpMu guards concurrent UploadPart calls.
@@ -64,6 +71,9 @@ func (m *mockS3) PutObject(_ context.Context, input *s3.PutObjectInput, _ ...fun
 	if aws.ToString(input.IfNoneMatch) == "*" {
 		if m.condUnsupported {
 			return nil, &smithy.GenericAPIError{Code: "NotImplemented", Message: "conditional writes not supported"}
+		}
+		if m.condConflict {
+			return nil, &smithy.GenericAPIError{Code: "ConditionalRequestConflict", Message: "a conflicting conditional operation is currently in progress against this resource"}
 		}
 		if _, exists := m.objects[*input.Key]; exists {
 			return nil, &smithy.GenericAPIError{Code: "PreconditionFailed", Message: "at least one of the pre-conditions you specified did not hold"}
@@ -694,11 +704,59 @@ func TestPutIfAbsentHTTP412Refused(t *testing.T) {
 	}
 }
 
+// TestPutIfAbsentConditionalRequestConflictRefused pins the #806 review
+// finding: AWS documents a 409 ConditionalRequestConflict response (as
+// opposed to the more common 412 PreconditionFailed) when a conflicting
+// write races the same key during upload — the exact two-writer race this
+// method exists to protect. Before the fix this error code fell through to
+// the generic error branch, so the losing writer of the race got a hard
+// error instead of ErrObjectExists and the caller's read-and-compare
+// fallback was never reached.
+func TestPutIfAbsentConditionalRequestConflictRefused(t *testing.T) {
+	mock := newMockS3()
+	mock.condConflict = true
+	b := newTestBackend(t, mock, "")
+	ctx := context.Background()
+
+	err := b.PutIfAbsent(ctx, "marker", strings.NewReader("intruder"))
+	if !errors.Is(err, ErrObjectExists) {
+		t.Fatalf("want ErrObjectExists for 409 ConditionalRequestConflict, got: %v", err)
+	}
+}
+
+// TestPutIfAbsentHTTP409Refused mirrors TestPutIfAbsentHTTP412Refused for the
+// generic-HTTP-status form of the same 409 ConditionalRequestConflict case,
+// for backends that surface it without an S3 error code.
+func TestPutIfAbsentHTTP409Refused(t *testing.T) {
+	mock := newMockS3()
+	b := newTestBackend(t, mock, "")
+	mock.putErr = &smithyhttp.ResponseError{
+		Response: &smithyhttp.Response{
+			Response: &http.Response{StatusCode: http.StatusConflict},
+		},
+		Err: fmt.Errorf("conditional request conflict"),
+	}
+
+	err := b.PutIfAbsent(context.Background(), "marker", strings.NewReader("x"))
+	if !errors.Is(err, ErrObjectExists) {
+		t.Fatalf("want ErrObjectExists for generic HTTP 409, got: %v", err)
+	}
+}
+
 func TestPutIfAbsentNotImplementedFallsBack(t *testing.T) {
 	mock := newMockS3()
 	mock.condUnsupported = true
 	b := newTestBackend(t, mock, "")
 	ctx := context.Background()
+
+	// Capture slog to assert the degraded-guarantee warning fired — before
+	// the fix this fallback was silent, so operators on S3-compatible
+	// backends without conditional-write support had no signal that the
+	// put-if-absent atomicity guarantee was inactive.
+	var logBuf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	defer slog.SetDefault(prev)
 
 	// Backends without conditional-write support degrade to a plain Put —
 	// the pre-conditional behavior — instead of failing the write.
@@ -707,6 +765,9 @@ func TestPutIfAbsentNotImplementedFallsBack(t *testing.T) {
 	}
 	if got := string(mock.objects["marker"]); got != "v1" {
 		t.Errorf("fallback Put did not store object, got %q", got)
+	}
+	if !strings.Contains(logBuf.String(), "does not support S3 conditional writes") {
+		t.Errorf("want a warning logged for the NotImplemented fallback, got log output: %q", logBuf.String())
 	}
 }
 

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -9,8 +9,13 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"io"
 )
+
+// ErrObjectExists is returned by ConditionalPutter.PutIfAbsent when an object
+// already exists at the target key. Callers detect it with errors.Is.
+var ErrObjectExists = errors.New("storage: object already exists")
 
 // Backend defines the storage abstraction for Parquet file management.
 // All keys are relative paths (no leading slash). Implementations handle
@@ -36,4 +41,14 @@ type Backend interface {
 
 	// Exists checks whether an object exists at the given key.
 	Exists(ctx context.Context, key string) (bool, error)
+}
+
+// ConditionalPutter is an optional interface a Backend can implement when the
+// underlying service supports atomic create-if-absent writes. Callers assert
+// for it and fall back to a non-atomic Exists+Put when it is not implemented.
+type ConditionalPutter interface {
+	// PutIfAbsent uploads the content from r to the given key only if no
+	// object exists there, atomically. If an object is already present it
+	// returns an error wrapping ErrObjectExists and writes nothing.
+	PutIfAbsent(ctx context.Context, key string, r io.Reader) error
 }


### PR DESCRIPTION
The Exists→Put sequence in `EnsurePartitionKey` was not atomic: two agents starting simultaneously against the same empty prefix (duplicate deploy, or a migration with a different serverID) could both observe the marker as absent and each write their own, last-write-wins. The losing agent kept writing payloads under a partition key the surviving marker doesn't know, silently re-arming the #198 cutover the marker exists to prevent.

Adds an optional `storage.ConditionalPutter` seam (`PutIfAbsent` + sentinel `ErrObjectExists`). `S3Backend` implements it with a conditional PutObject (`If-None-Match: *`): the losing writer gets `PreconditionFailed`, and `EnsurePartitionKey` then falls through to the existing read-and-compare path instead of overwriting. Backends without the interface keep the prior non-atomic behavior; S3-compatible services that answer `NotImplemented` to conditional writes degrade to a plain Put.

Unit tests cover the winning/losing writer paths and the NotImplemented degradation.

Closes #806

🤖 Generated with [Claude Code](https://claude.com/claude-code)
