### PR TITLE
parser: index MariaDB compressed row events (log_bin_compress=ON) instead of skipping them

### DIFF
--- a/docs/mariadb.md
+++ b/docs/mariadb.md
@@ -137,6 +137,10 @@ silently become the write key for every server. Two caveats:
 - **File-based `bintrail index`** over MariaDB binlog files.
 - All row events (INSERT/UPDATE/DELETE) with before/after images, including
   `UNSIGNED`, `DECIMAL`, and DDL detection / auto-snapshot.
+- **Compressed row events** (`log_bin_compress = ON`): MariaDB's
+  `WRITE/UPDATE/DELETE_ROWS_COMPRESSED_V1` events are decompressed and indexed
+  exactly like their uncompressed siblings, on both the streaming and
+  file-based paths.
 - **Statement capture** (`query_text`/`query_hash`): MariaDB's `Annotate_rows`
   event carries the originating SQL statement and is captured like MySQL's
   `ROWS_QUERY_EVENT`. `binlog_annotate_row_events` is ON by default since
@@ -157,10 +161,6 @@ silently become the write key for every server. Two caveats:
 - **The source flavor is fixed per checkpoint.** Resuming a saved MariaDB
   checkpoint requires the same `--source-flavor mariadb`. A mismatch is rejected
   with an actionable error; use `--reset` to start fresh.
-- **Compressed row events are skipped.** With `log_bin_compress = ON`, MariaDB's
-  compressed row events are not yet decoded — bintrail logs a loud warning
-  (`rows_skipped`) rather than indexing them. Leave `log_bin_compress = OFF` on
-  the source for now.
 - **Mid-capture primary failover is untested.** Gap detection compares GTID
   sequences per domain (correct for single-server and multi-domain topologies),
   but a primary failover that changes the `server_id` *within* a domain mid-stream

--- a/internal/parser/mariadb_compress_integration_test.go
+++ b/internal/parser/mariadb_compress_integration_test.go
@@ -1,0 +1,177 @@
+//go:build integration
+
+package parser_test
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-mysql-org/go-mysql/replication"
+
+	"github.com/dbtrail/dbtrail/internal/config"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/parser"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestParseFile_realBinlog_mariadbLogBinCompress is the #520 fixture: a MariaDB
+// source with log_bin_compress=ON emits MARIADB_WRITE/UPDATE/DELETE_ROWS_
+// COMPRESSED_EVENT_V1 instead of the standard rows events. Before #520 these
+// hit handleRows' warn-and-skip default arm — the rows were never indexed
+// (silent data loss). go-mysql decompresses them during decode, so the fix is
+// dispatch-only; this test proves the whole path against a REAL compressed
+// binlog: it produces one on the source container, verifies the compressed
+// event types are actually present in the file (so the test cannot pass
+// vacuously if compression fails to engage), then parses it with bintrail's
+// file parser and asserts the exact DML mix WITH before/after images.
+//
+// Mirrors TestParseFile_realBinlog_mariadb (the uncompressed sibling) against
+// bintrail-test-mariadb (13307). The stream path shares handleRows — the one
+// dispatch this exercises — so the file-based fixture covers both.
+func TestParseFile_realBinlog_mariadbLogBinCompress(t *testing.T) {
+	sourceDB, sourceName := testutil.CreateTestMariaDB(t)
+	indexDB, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, indexDB)
+
+	// log_bin_compress only compresses events LARGER than
+	// log_bin_compress_min_len (default 256 bytes), so pin the threshold to its
+	// minimum (10) and use a padded payload — compression then engages
+	// deterministically. Both are dynamic GLOBALs; capture and restore the
+	// previous values so the shared container is left exactly as found. (This
+	// t.Cleanup is registered after CreateTestMariaDB's, so it runs BEFORE the
+	// connection is closed.)
+	var prevCompress, prevMinLen int
+	if err := sourceDB.QueryRow(
+		"SELECT @@GLOBAL.log_bin_compress, @@GLOBAL.log_bin_compress_min_len",
+	).Scan(&prevCompress, &prevMinLen); err != nil {
+		t.Fatalf("reading log_bin_compress globals: %v", err)
+	}
+	testutil.MustExec(t, sourceDB, "SET GLOBAL log_bin_compress = ON")
+	testutil.MustExec(t, sourceDB, "SET GLOBAL log_bin_compress_min_len = 10")
+	t.Cleanup(func() {
+		sourceDB.Exec(fmt.Sprintf("SET GLOBAL log_bin_compress = %d", prevCompress))
+		sourceDB.Exec(fmt.Sprintf("SET GLOBAL log_bin_compress_min_len = %d", prevMinLen))
+	})
+
+	testutil.MustExec(t, sourceDB, `CREATE TABLE orders (
+		id       INT PRIMARY KEY AUTO_INCREMENT,
+		customer VARCHAR(100)  NOT NULL,
+		amount   INT           NOT NULL,
+		pad      VARCHAR(1000) NOT NULL
+	)`)
+
+	stats, err := metadata.TakeSnapshot(sourceDB, indexDB, []string{sourceName})
+	if err != nil {
+		t.Fatalf("TakeSnapshot: %v", err)
+	}
+	res, err := metadata.NewResolver(indexDB, stats.SnapshotID)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+
+	// Flush to a clean boundary, note the file, do DML, seal it.
+	pad := strings.Repeat("x", 400)
+	testutil.MustExec(t, sourceDB, "FLUSH BINARY LOGS")
+	currentBinlog, _, err := config.CurrentBinlogPosition(sourceDB)
+	if err != nil {
+		t.Fatalf("CurrentBinlogPosition (MariaDB): %v", err)
+	}
+	testutil.MustExec(t, sourceDB, "INSERT INTO orders (customer, amount, pad) VALUES ('Alice', 1, ?)", pad)
+	testutil.MustExec(t, sourceDB, "INSERT INTO orders (customer, amount, pad) VALUES ('Bob', 2, ?)", pad)
+	testutil.MustExec(t, sourceDB, "UPDATE orders SET amount = 42 WHERE customer = 'Alice'")
+	testutil.MustExec(t, sourceDB, "DELETE FROM orders WHERE customer = 'Bob'")
+	testutil.MustExec(t, sourceDB, "FLUSH BINARY LOGS")
+
+	tmpDir := t.TempDir()
+	cpCmd := exec.Command("docker", "cp",
+		fmt.Sprintf("bintrail-test-mariadb:/var/lib/mysql/%s", currentBinlog),
+		filepath.Join(tmpDir, currentBinlog),
+	)
+	if out, err := cpCmd.CombinedOutput(); err != nil {
+		testutil.SkipOrFailMariaDB(t, "docker cp %s from bintrail-test-mariadb failed: %v\n%s", currentBinlog, err, out)
+	}
+
+	// Vacuity guard: assert the binlog REALLY contains compressed row events.
+	// Without this, a compression knob that silently failed to engage would
+	// leave only standard rows events and the test would green-light the
+	// pre-#520 warn-and-skip code. Raw mode reads headers without decoding.
+	var compressedRowEvents int
+	rawP := replication.NewBinlogParser()
+	rawP.SetRawMode(true)
+	err = rawP.ParseFile(filepath.Join(tmpDir, currentBinlog), 0, func(ev *replication.BinlogEvent) error {
+		switch ev.Header.EventType {
+		case replication.MARIADB_WRITE_ROWS_COMPRESSED_EVENT_V1,
+			replication.MARIADB_UPDATE_ROWS_COMPRESSED_EVENT_V1,
+			replication.MARIADB_DELETE_ROWS_COMPRESSED_EVENT_V1:
+			compressedRowEvents++
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("raw header scan of %s: %v", currentBinlog, err)
+	}
+	if compressedRowEvents == 0 {
+		t.Fatalf("fixture produced no MARIADB_*_ROWS_COMPRESSED_EVENT_V1 in %s — log_bin_compress did not engage; the test would be vacuous", currentBinlog)
+	}
+
+	p := parser.New(tmpDir, res, parser.Filters{Schemas: map[string]bool{sourceName: true}}, nil)
+	events := make(chan parser.Event, 100)
+	errCh := make(chan error, 1)
+	go func() {
+		defer close(events)
+		errCh <- p.ParseFile(context.Background(), currentBinlog, events)
+	}()
+	all := drainEvents(events)
+	if err := <-errCh; err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+
+	dml := dmlEvents(all)
+	var ins, upd, del []parser.Event
+	for _, ev := range dml {
+		switch ev.EventType {
+		case parser.EventInsert:
+			ins = append(ins, ev)
+		case parser.EventUpdate:
+			upd = append(upd, ev)
+		case parser.EventDelete:
+			del = append(del, ev)
+		}
+	}
+	if len(ins) != 2 || len(upd) != 1 || len(del) != 1 {
+		t.Fatalf("expected 2 INSERT/1 UPDATE/1 DELETE from compressed MariaDB binlog, got ins=%d upd=%d del=%d (total dml %d) — compressed row events were skipped, not indexed (#520)",
+			len(ins), len(upd), len(del), len(dml))
+	}
+
+	// Images must be complete and correct — decompressed content, not just
+	// event counts.
+	for _, ev := range ins {
+		if ev.RowBefore != nil || ev.RowAfter == nil {
+			t.Fatalf("INSERT image shape wrong: before=%v after=%v", ev.RowBefore, ev.RowAfter)
+		}
+		if got := fmt.Sprint(ev.RowAfter["pad"]); got != pad {
+			t.Fatalf("INSERT after-image pad mismatch: got %d bytes, want %d", len(got), len(pad))
+		}
+		if ev.PKValues == "" {
+			t.Fatal("INSERT event carries no PK values")
+		}
+	}
+	u := upd[0]
+	if u.RowBefore == nil || u.RowAfter == nil {
+		t.Fatalf("UPDATE must carry both images: before=%v after=%v", u.RowBefore, u.RowAfter)
+	}
+	if b, a := fmt.Sprint(u.RowBefore["amount"]), fmt.Sprint(u.RowAfter["amount"]); b != "1" || a != "42" {
+		t.Fatalf("UPDATE before/after amount = %s/%s, want 1/42", b, a)
+	}
+	d := del[0]
+	if d.RowBefore == nil || d.RowAfter != nil {
+		t.Fatalf("DELETE must carry only a before image: before=%v after=%v", d.RowBefore, d.RowAfter)
+	}
+	if got := fmt.Sprint(d.RowBefore["customer"]); got != "Bob" {
+		t.Fatalf("DELETE before-image customer = %q, want Bob", got)
+	}
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -531,31 +531,39 @@ func handleRows(
 	// never lands between the chunks of a split statement (#775).
 	stmtEnd := rowsEv.Flags&replication.RowsEventStmtEndFlag != 0
 
+	// MariaDB's MARIADB_*_ROWS_COMPRESSED_EVENT_V1 (log_bin_compress=ON, #520)
+	// dispatch alongside their uncompressed siblings: go-mysql v1.13.0 already
+	// routes them into RowsEvent decoding and decompresses the payload
+	// (mysql.DecompressMariadbData in RowsEvent.DecodeData), so by the time the
+	// event reaches handleRows its Rows/SkippedColumns are fully decoded — only
+	// the header EventType still says "compressed".
 	switch binlogEv.Header.EventType {
 	case replication.WRITE_ROWS_EVENTv0,
 		replication.WRITE_ROWS_EVENTv1,
-		replication.WRITE_ROWS_EVENTv2:
+		replication.WRITE_ROWS_EVENTv2,
+		replication.MARIADB_WRITE_ROWS_COMPRESSED_EVENT_V1:
 		return emitInserts(ctx, logger, resolver, rowsEv.Rows, schema, table, filename, currentGTID, connectionID, queryText, startPos, endPos, ts, pkCols, schemaVersion, stmtEnd, out)
 
 	case replication.DELETE_ROWS_EVENTv0,
 		replication.DELETE_ROWS_EVENTv1,
-		replication.DELETE_ROWS_EVENTv2:
+		replication.DELETE_ROWS_EVENTv2,
+		replication.MARIADB_DELETE_ROWS_COMPRESSED_EVENT_V1:
 		return emitDeletes(ctx, logger, resolver, rowsEv.Rows, schema, table, filename, currentGTID, connectionID, queryText, startPos, endPos, ts, pkCols, schemaVersion, stmtEnd, out)
 
 	case replication.UPDATE_ROWS_EVENTv0,
 		replication.UPDATE_ROWS_EVENTv1,
-		replication.UPDATE_ROWS_EVENTv2:
+		replication.UPDATE_ROWS_EVENTv2,
+		replication.MARIADB_UPDATE_ROWS_COMPRESSED_EVENT_V1:
 		return emitUpdates(ctx, logger, resolver, rowsEv.Rows, schema, table, filename, currentGTID, connectionID, queryText, startPos, endPos, ts, pkCols, schemaVersion, stmtEnd, out)
 
 	default:
-		// A RowsEvent whose type matches none of the above — e.g. MariaDB's
-		// MARIADB_WRITE/UPDATE/DELETE_ROWS_COMPRESSED_EVENT_V1 (log_bin_compress=ON),
-		// or PARTIAL_UPDATE_ROWS_EVENT which a MySQL source emits under
+		// A RowsEvent whose type matches none of the above — e.g.
+		// PARTIAL_UPDATE_ROWS_EVENT, which a MySQL source emits under
 		// binlog_row_value_options=PARTIAL_JSON (out of support; binlog_row_image=FULL
 		// is required). Decoding these is deferred; warn loudly — including how many
 		// rows were skipped — rather than dropping them silently (a data-loss class).
-		// Standard MySQL ROW DML always matches a specific case above.
-		logger.Warn("unhandled row event type — rows skipped (e.g. MariaDB compressed-row events are not yet decoded)",
+		// Standard MySQL and MariaDB ROW DML always matches a specific case above.
+		logger.Warn("unhandled row event type — rows skipped",
 			"file", filename,
 			"pos", binlogEv.Header.LogPos,
 			"schema", schema,

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -168,14 +168,15 @@ func TestFormatGTID_anonymousEvent(t *testing.T) {
 	}
 }
 
-// ─── handleRows: unhandled (e.g. MariaDB compressed) row event type ───────────
+// ─── handleRows: unhandled row event type ─────────────────────────────────────
 
 // TestHandleRows_unhandledEventTypeLogsNotSilent verifies that a row event type
-// handleRows does not recognize — e.g. MariaDB's MARIADB_WRITE_ROWS_COMPRESSED_
-// EVENT_V1 — is logged at warn instead of being silently dropped. Before the
-// default arm the switch fell through to `return nil`, dropping every row with
-// no trace (a silent data-loss class). Decoding compressed rows is deferred to
-// beta; the alpha guarantee is only that they are never dropped silently.
+// handleRows does not recognize — e.g. PARTIAL_UPDATE_ROWS_EVENT, emitted under
+// binlog_row_value_options=PARTIAL_JSON (out of support) — is logged at warn
+// instead of being silently dropped. Before the default arm the switch fell
+// through to `return nil`, dropping every row with no trace (a silent data-loss
+// class). The guarantee is that unrecognized row events are never dropped
+// silently.
 func TestHandleRows_unhandledEventTypeLogsNotSilent(t *testing.T) {
 	tm := &metadata.TableMeta{
 		Schema:    "shop",
@@ -190,7 +191,7 @@ func TestHandleRows_unhandledEventTypeLogsNotSilent(t *testing.T) {
 
 	binlogEv := &replication.BinlogEvent{
 		Header: &replication.EventHeader{
-			EventType: replication.MARIADB_WRITE_ROWS_COMPRESSED_EVENT_V1,
+			EventType: replication.PARTIAL_UPDATE_ROWS_EVENT,
 			LogPos:    200,
 			EventSize: 100,
 		},
@@ -221,6 +222,121 @@ func TestHandleRows_unhandledEventTypeLogsNotSilent(t *testing.T) {
 	}
 	if len(out) != 0 {
 		t.Errorf("unhandled event must emit no rows downstream, got %d", len(out))
+	}
+}
+
+// ─── handleRows: MariaDB compressed row event types (#520) ────────────────────
+
+// TestHandleRows_mariadbCompressedRowTypes verifies that MariaDB's
+// MARIADB_WRITE/UPDATE/DELETE_ROWS_COMPRESSED_EVENT_V1 (log_bin_compress=ON)
+// dispatch to the same emit path as their uncompressed siblings instead of the
+// warn-and-skip default arm (#520 — silent data loss). go-mysql v1.13.0
+// decompresses the payload during RowsEvent decoding, so handleRows receives
+// fully-decoded Rows with only the header EventType still saying "compressed" —
+// exactly what these fixtures model.
+func TestHandleRows_mariadbCompressedRowTypes(t *testing.T) {
+	tm := &metadata.TableMeta{
+		Schema: "shop",
+		Table:  "orders",
+		Columns: []metadata.ColumnMeta{
+			{Name: "id", OrdinalPosition: 1, IsPK: true, DataType: "int"},
+			{Name: "amount", OrdinalPosition: 2, DataType: "int"},
+		},
+		PKColumns: []string{"id"},
+	}
+
+	cases := []struct {
+		name      string
+		eventType replication.EventType
+		rows      [][]any
+		wantType  EventType
+		check     func(t *testing.T, ev Event)
+	}{
+		{
+			name:      "write_compressed",
+			eventType: replication.MARIADB_WRITE_ROWS_COMPRESSED_EVENT_V1,
+			rows:      [][]any{{int64(1), int64(100)}},
+			wantType:  EventInsert,
+			check: func(t *testing.T, ev Event) {
+				if ev.RowBefore != nil || ev.RowAfter == nil {
+					t.Fatalf("INSERT must carry only an after image, got before=%v after=%v", ev.RowBefore, ev.RowAfter)
+				}
+				if got := ev.RowAfter["amount"]; got != int64(100) {
+					t.Errorf("after image amount = %v, want 100", got)
+				}
+			},
+		},
+		{
+			name:      "update_compressed",
+			eventType: replication.MARIADB_UPDATE_ROWS_COMPRESSED_EVENT_V1,
+			rows:      [][]any{{int64(1), int64(100)}, {int64(1), int64(200)}}, // before, after
+			wantType:  EventUpdate,
+			check: func(t *testing.T, ev Event) {
+				if ev.RowBefore == nil || ev.RowAfter == nil {
+					t.Fatalf("UPDATE must carry both images, got before=%v after=%v", ev.RowBefore, ev.RowAfter)
+				}
+				if b, a := ev.RowBefore["amount"], ev.RowAfter["amount"]; b != int64(100) || a != int64(200) {
+					t.Errorf("before/after amount = %v/%v, want 100/200", b, a)
+				}
+			},
+		},
+		{
+			name:      "delete_compressed",
+			eventType: replication.MARIADB_DELETE_ROWS_COMPRESSED_EVENT_V1,
+			rows:      [][]any{{int64(1), int64(100)}},
+			wantType:  EventDelete,
+			check: func(t *testing.T, ev Event) {
+				if ev.RowBefore == nil || ev.RowAfter != nil {
+					t.Fatalf("DELETE must carry only a before image, got before=%v after=%v", ev.RowBefore, ev.RowAfter)
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resolver := metadata.NewResolverFromTables(1, map[string]*metadata.TableMeta{"shop.orders": tm})
+
+			var buf bytes.Buffer
+			logger := newTestLogger(&buf)
+
+			binlogEv := &replication.BinlogEvent{
+				Header: &replication.EventHeader{
+					EventType: tc.eventType,
+					LogPos:    400,
+					EventSize: 100,
+				},
+				Event: &replication.RowsEvent{
+					Table: &replication.TableMapEvent{
+						Schema:      []byte("shop"),
+						Table:       []byte("orders"),
+						ColumnCount: 2,
+					},
+					Rows: tc.rows,
+				},
+			}
+			rowsEv := binlogEv.Event.(*replication.RowsEvent)
+
+			out := make(chan Event, 4)
+			if err := handleRows(context.Background(), logger, resolver, &Filters{}, binlogEv, rowsEv, "mariadb-bin.000001", "0-1-1", 0, "", 1, out, nil); err != nil {
+				t.Fatalf("handleRows: %v", err)
+			}
+
+			if logged := buf.String(); strings.Contains(strings.ToLower(logged), "unhandled") {
+				t.Fatalf("compressed row event hit the warn-and-skip default arm, logs: %q", logged)
+			}
+			if len(out) != 1 {
+				t.Fatalf("expected exactly 1 emitted event, got %d", len(out))
+			}
+			ev := <-out
+			if ev.EventType != tc.wantType {
+				t.Fatalf("event type = %v, want %v", ev.EventType, tc.wantType)
+			}
+			if ev.PKValues == "" {
+				t.Error("emitted event carries no PK values")
+			}
+			tc.check(t, ev)
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

With `log_bin_compress=ON` a MariaDB source emits `MARIADB_WRITE/UPDATE/DELETE_ROWS_COMPRESSED_EVENT_V1` instead of the standard rows events. These hit `handleRows`' warn-and-skip default arm (`internal/parser/parser.go`), so their rows were never indexed — the last active silent-data-loss item for MariaDB sources (beta gate #2 of #517).

**Build-plan item 1 (verify go-mysql):** go-mysql v1.13.0 already routes the three compressed types into `RowsEvent` decoding (`replication/parser.go`) and decompresses the payload (`mysql.DecompressMariadbData` in `RowsEvent.DecodeData`), so by the time an event reaches `handleRows` its `Rows`/`SkippedColumns` are fully decoded — only the header `EventType` still says "compressed". No decompression code was needed in bintrail.

**The fix is dispatch-only:** add the three event types to the existing WRITE/DELETE/UPDATE cases of the `handleRows` event-type switch — the one switch shared by the file parser (`bintrail index`) and the stream parser (`bintrail stream`). Both paths already dispatch on the Go type `*replication.RowsEvent`, and the `STMT_END_F` statement-boundary handling keys on `Flags`, not the event type, so no other change is required. All downstream guards (partial-image #493, column-count, schema-drift #700) apply unchanged.

**`MARIADB_QUERY_COMPRESSED_EVENT` needs no change:** go-mysql decodes it into `*replication.QueryEvent` with the query already decompressed, and both parsers dispatch on the Go type — `connection_id`/DDL/statement-DML extraction already handled it. Covered by the go-mysql decode, not by new bintrail code.

Also removes the now-obsolete "Compressed row events are skipped" alpha limitation from `docs/mariadb.md` (moved to "What works").

## Tests

**Unit** (`internal/parser/parser_test.go`):
- `TestHandleRows_mariadbCompressedRowTypes` — the three compressed types route to the emit path with correct event types, PK values, and before/after image shapes/values, and never hit the warn-and-skip arm.
- `TestHandleRows_unhandledEventTypeLogsNotSilent` — the anti-silent-data-loss contract of the default arm (warn + `rows_skipped`, nothing emitted) is re-pinned on `PARTIAL_UPDATE_ROWS_EVENT`, which stays unhandled.

**Integration** (`internal/parser/mariadb_compress_integration_test.go`, build-plan item 2): a real `log_bin_compress=ON` fixture against the MariaDB 11.4 source container. `log_bin_compress` and `log_bin_compress_min_len` are dynamic GLOBALs — the test sets them (min_len pinned to 10 so compression engages deterministically; the default 256 would leave small rows uncompressed) and restores the previous values via `t.Cleanup`, so **no CI workflow change is needed**. A raw go-mysql header scan asserts the produced binlog genuinely contains `MARIADB_*_ROWS_COMPRESSED_EVENT_V1` (vacuity guard — the test cannot green-light if compression fails to engage), then bintrail's file parser must index the exact DML mix with correct images. Assertions are scoped to the test's own schema, never total counts.

**Red/green verified:** with the dispatch change reverted, the fixture fails with `ins=0 upd=0 del=0 — compressed row events were skipped, not indexed (#520)`; with it applied, it passes.

## Real test results

```
go build ./...                                        ok
go vet ./internal/parser/...                          ok
go test ./internal/parser/... -count=1                ok (2.039s)

# new fixture in isolation (MariaDB 11.4 @ 13307)
go test -tags=integration -count=1 \
  -run TestParseFile_realBinlog_mariadbLogBinCompress ./internal/parser/
--- PASS (0.32s)

# full MariaDB-source suite, exact CI command
BINTRAIL_REQUIRE_MARIADB=1 go test -tags=integration -race -p 1 -count=1 \
  -run 'MariaDB|Mariadb|mariadb|Flavor|FourColumns' ./...
ok  internal/parser 4.530s   (all packages ok, exit 0)

# MySQL no-regression (MySQL 8.4 @ 13306)
go test -tags integration ./internal/parser/... -count=1
ok  internal/parser 14.076s
```

Closes #520

🤖 Generated with [Claude Code](https://claude.com/claude-code)
