### PR TITLE
reconstruct: refuse full-table merge on post-baseline dropped column instead of mixed-epoch NULL-fill

### DIFF
--- a/internal/reconstruct/fulltable.go
+++ b/internal/reconstruct/fulltable.go
@@ -1424,25 +1424,45 @@ func postBaselineColumns(changes map[string]*query.ResultRow, colNames []string)
 
 // droppedBaselineColumns is the symmetric counterpart of postBaselineColumns:
 // it returns, sorted and de-duplicated, the baseline column names ABSENT (key
-// missing — not value NULL) from some non-DELETE event's row_after image,
-// i.e. columns DROPPED from the source table after the baseline snapshot.
-// binlog_row_image=FULL (validated at index time) guarantees a complete
-// after-image, so key absence means the column no longer existed at event
-// time; a genuinely-NULL value is present in the map as a nil value and is
-// never flagged. mergeBaselineIntoWriter calls this up front to refuse the
-// run instead of letting rowAfterOrdered NULL-fill the column row by row
-// (#843). DELETE events carry no row_after and are skipped.
+// missing — not value NULL) from some event's row image, i.e. columns DROPPED
+// from the source table after the baseline snapshot. binlog_row_image=FULL
+// (validated at index time) guarantees a complete image, so key absence means
+// the column no longer existed at event time; a genuinely-NULL value is
+// present in the map as a nil value and is never flagged. mergeBaselineIntoWriter
+// calls this up front to refuse the run instead of letting rowAfterOrdered
+// NULL-fill the column row by row (#843).
+//
+// Both row_after AND row_before are scanned (#843 follow-up): a window whose
+// last event for a post-drop-touched PK is a DELETE carries no row_after, but
+// its row_before is itself a post-drop image (the row as it existed just
+// before deletion) and so still lacks the dropped column — checking only
+// row_after let such a window sail through with zero warning, silently
+// re-emitting the stale pre-drop value on every untouched pass-through row.
+// Per-PK this collapsed-map scan is sufficient: changes is keyed by PK with
+// the chronologically LAST event surviving, and time only moves forward, so
+// if any event for a PK is post-drop then so is that surviving one — there is
+// no ordering in which an earlier post-drop event's signal is lost behind a
+// later pre-drop entry for the same key. A PK with zero post-drop activity in
+// the window remains undetectable by construction (no image ever samples the
+// post-drop schema for it) and is out of scope here.
 func droppedBaselineColumns(changes map[string]*query.ResultRow, colNames []string) []string {
 	dropped := make(map[string]struct{})
-	for _, ev := range changes {
-		if ev == nil || ev.EventType == event.EventDelete || ev.RowAfter == nil {
-			continue
+	scan := func(img map[string]any) {
+		if img == nil {
+			return
 		}
 		for _, col := range colNames {
-			if _, ok := ev.RowAfter[col]; !ok {
+			if _, ok := img[col]; !ok {
 				dropped[col] = struct{}{}
 			}
 		}
+	}
+	for _, ev := range changes {
+		if ev == nil {
+			continue
+		}
+		scan(ev.RowAfter)
+		scan(ev.RowBefore)
 	}
 	if len(dropped) == 0 {
 		return nil

--- a/internal/reconstruct/fulltable.go
+++ b/internal/reconstruct/fulltable.go
@@ -623,6 +623,28 @@ func mergeBaselineIntoWriter(ctx context.Context, in mergeInput, rep *TableRepor
 			in.Schema, in.Table, strings.Join(extra, ", "))
 	}
 
+	// Fail loud on a baseline column DROPPED after the baseline (#843), the
+	// symmetric direction of the #602 guard above: post-drop delta events stop
+	// carrying the column in row_after, so projecting them onto the baseline
+	// columns would NULL-fill it while never-touched pass-through rows keep
+	// the pre-drop value — one dump mixing two schema epochs (a state that
+	// never existed) under a CREATE TABLE header that still declares the
+	// column. Column ABSENCE from the image is the signal
+	// (binlog_row_image=FULL is a hard requirement, so an after-image always
+	// carries every column live at event time); a genuinely-NULL value is
+	// present in the map with a nil value and passes through untouched.
+	// Detected up front, aggregated over the whole change map — not the old
+	// per-row×column slog.Warn — and before the writer opens, so no partial
+	// chunk files are left on disk.
+	if missing := droppedBaselineColumns(in.Changes, colNames); len(missing) > 0 {
+		return fmt.Errorf(
+			"full-table reconstruct: %s.%s has baseline column(s) %s absent from delta-event row images "+
+				"(dropped from the source table after the baseline snapshot); emitting would mix schema epochs — "+
+				"rows touched after the drop would carry NULL while never-touched rows keep the pre-drop value — "+
+				"re-run `bintrail baseline` to capture a snapshot of the current schema",
+			in.Schema, in.Table, strings.Join(missing, ", "))
+	}
+
 	mw, err := NewMydumperWriter(in.OutputDir, in.Schema, in.Table, colNames, in.ChunkSize)
 	if err != nil {
 		return fmt.Errorf("open mydumper writer: %w", err)
@@ -651,8 +673,8 @@ func mergeBaselineIntoWriter(ctx context.Context, in mergeInput, rep *TableRepor
 	// order the writer was constructed with. For baseline pass-through rows
 	// the map is keyed by exactly those columns (so rowAfterOrdered is an
 	// order-preserving identity); for event after-images it aligns the
-	// event's row_after to the baseline schema, filling drift columns with
-	// NULL — identical to the pre-refactor behaviour.
+	// event's row_after to the baseline schema — drift in either direction
+	// was already refused up front (#602/#843), so the alignment is total.
 	stats, err := mergeBaselineImages(ctx, mergeCore{
 		LocalBaselinePath: in.LocalBaselinePath,
 		Schema:            in.Schema,
@@ -1400,6 +1422,39 @@ func postBaselineColumns(changes map[string]*query.ResultRow, colNames []string)
 	return out
 }
 
+// droppedBaselineColumns is the symmetric counterpart of postBaselineColumns:
+// it returns, sorted and de-duplicated, the baseline column names ABSENT (key
+// missing — not value NULL) from some non-DELETE event's row_after image,
+// i.e. columns DROPPED from the source table after the baseline snapshot.
+// binlog_row_image=FULL (validated at index time) guarantees a complete
+// after-image, so key absence means the column no longer existed at event
+// time; a genuinely-NULL value is present in the map as a nil value and is
+// never flagged. mergeBaselineIntoWriter calls this up front to refuse the
+// run instead of letting rowAfterOrdered NULL-fill the column row by row
+// (#843). DELETE events carry no row_after and are skipped.
+func droppedBaselineColumns(changes map[string]*query.ResultRow, colNames []string) []string {
+	dropped := make(map[string]struct{})
+	for _, ev := range changes {
+		if ev == nil || ev.EventType == event.EventDelete || ev.RowAfter == nil {
+			continue
+		}
+		for _, col := range colNames {
+			if _, ok := ev.RowAfter[col]; !ok {
+				dropped[col] = struct{}{}
+			}
+		}
+	}
+	if len(dropped) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(dropped))
+	for col := range dropped {
+		out = append(out, col)
+	}
+	sort.Strings(out)
+	return out
+}
+
 // These helpers reverse the storage-side base64 encoding of BLOB/TEXT
 // delta-event values for the mydumper reconstruct path (#653/#660). go-mysql
 // delivers BLOB and TEXT (both MYSQL_TYPE_BLOB) as []byte, which marshalRow
@@ -1512,13 +1567,15 @@ func binaryColsFromTableMeta(tm *metadata.TableMeta) map[string]bool {
 
 // rowAfterOrdered walks colNames and looks up each name in rowAfter (a
 // map[string]any from a binlog event's row_after image), returning a slice
-// of values aligned to the baseline Parquet column order. A baseline column
-// absent from this event's row_after becomes nil (SQL NULL) with an slog.Warn
-// — e.g. a column DROPPED after the baseline (newer events stop carrying it)
-// or a partial image. The opposite direction — a column ADDED after the
-// baseline, present in row_after but not in colNames — is handled up front by
-// the postBaselineColumns guard in mergeBaselineIntoWriter, which refuses the
-// run rather than letting this function drop the value silently (#602).
+// of values aligned to the baseline Parquet column order. On the baseline
+// merge path both schema-drift directions are refused up front by
+// mergeBaselineIntoWriter — a column ADDED after the baseline by the
+// postBaselineColumns guard (#602), a column DROPPED after the baseline by
+// the droppedBaselineColumns guard (#843) — so a missing key here is
+// unreachable there. The NULL-fill-with-warn below remains as
+// defense-in-depth and for the binlog-only fallback path
+// (writeBinlogOnlyChanges), whose colNames come from a resolver snapshot
+// rather than a baseline.
 //
 // Both baseline pass-through rows and delta-event after-images flow through
 // here, so it must NOT base64-decode BLOB/TEXT values: a baseline TEXT value is

--- a/internal/reconstruct/fulltable_validation_test.go
+++ b/internal/reconstruct/fulltable_validation_test.go
@@ -140,9 +140,11 @@ func TestZipMap_pairsAcrossColumns(t *testing.T) {
 	}
 }
 
-// TestRowAfterOrdered_missingColumnBecomesNull verifies the schema-drift
-// fallback: a column present in the baseline but absent from the event's
-// row_after image is filled with nil and warned about.
+// TestRowAfterOrdered_missingColumnBecomesNull verifies the NULL-fill
+// fallback kept for the binlog-only path (writeBinlogOnlyChanges): a column
+// in colNames but absent from the event's row_after image is filled with nil
+// and warned about. On the baseline merge path this is unreachable — both
+// drift directions are refused up front (#602/#843).
 func TestRowAfterOrdered_missingColumnBecomesNull(t *testing.T) {
 	cols := []string{"id", "status", "added_later"}
 	rowAfter := map[string]any{"id": float64(1), "status": "ok"} // added_later missing

--- a/internal/reconstruct/schema_drift_843_test.go
+++ b/internal/reconstruct/schema_drift_843_test.go
@@ -1,0 +1,202 @@
+package reconstruct
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/event"
+	"github.com/dbtrail/dbtrail/internal/parser"
+	"github.com/dbtrail/dbtrail/internal/query"
+)
+
+// TestReconstruct843_columnDroppedAfterBaselineFailsLoud is the regression for
+// #843, the symmetric direction of #602. A column DROPped from the source
+// table after the baseline snapshot stops appearing in delta events' row_after
+// images; rowAfterOrdered used to NULL-fill it (with a per-row warn), so the
+// dump mixed two schema epochs: touched rows NULL, never-touched pass-through
+// rows keeping the pre-drop value, under a CREATE TABLE still declaring the
+// column. The fix refuses the run loudly instead — and must do so BEFORE
+// writing any chunk file, so no partial output is left on disk.
+func TestReconstruct843_columnDroppedAfterBaselineFailsLoud(t *testing.T) {
+	baselinePath := writeTestBaseline(t, [][]string{
+		{"1", "new"},
+		{"2", "paid"},
+	})
+	outDir := t.TempDir()
+
+	// id=2 is UPDATEd after the `status` column was DROPped. The event
+	// row_after carries only id. status ∈ baseline columns (id, status).
+	changes := map[string]*query.ResultRow{
+		pkStrForInt(2): {
+			EventType: parser.EventUpdate,
+			PKValues:  pkStrForInt(2),
+			RowBefore: map[string]any{"id": float64(2)},
+			RowAfter:  map[string]any{"id": float64(2)},
+		},
+	}
+
+	rep := &TableReport{}
+	err := mergeBaselineIntoWriter(context.Background(), mergeInput{
+		LocalBaselinePath: baselinePath,
+		CreateTableSQL:    "-- test",
+		Schema:            "mydb",
+		Table:             "orders",
+		PKCols:            pkColsIntID(),
+		Changes:           changes,
+		OutputDir:         outDir,
+		ChunkSize:         0,
+	}, rep)
+
+	if err == nil {
+		t.Fatalf("expected a fail-loud error for the dropped 'status' column, got nil")
+	}
+	if !strings.Contains(err.Error(), "status") {
+		t.Errorf("error should name the dropped column %q, got: %v", "status", err)
+	}
+	if !strings.Contains(err.Error(), "bintrail baseline") {
+		t.Errorf("error should point at re-running `bintrail baseline`, got: %v", err)
+	}
+
+	// No partial output may be left on disk: the guard fires before the writer
+	// opens, so the output dir must contain no .sql chunk files.
+	entries, derr := os.ReadDir(outDir)
+	if derr != nil {
+		t.Fatalf("read output dir: %v", derr)
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".sql") {
+			t.Errorf("partial output left on disk after failed run: %s", e.Name())
+		}
+	}
+}
+
+// TestReconstruct843_nullValueIsNotADrop pins the column-absent-from-image vs
+// value-null distinction: an event whose row_after carries the column with a
+// nil value (a genuine SQL NULL under binlog_row_image=FULL) must NOT trip the
+// dropped-column refusal — it merges and emits NULL as before.
+func TestReconstruct843_nullValueIsNotADrop(t *testing.T) {
+	baselinePath := writeTestBaseline(t, [][]string{
+		{"1", "new"},
+		{"2", "paid"},
+	})
+	outDir := t.TempDir()
+
+	changes := map[string]*query.ResultRow{
+		pkStrForInt(2): {
+			EventType: parser.EventUpdate,
+			PKValues:  pkStrForInt(2),
+			RowBefore: map[string]any{"id": float64(2), "status": "paid"},
+			RowAfter:  map[string]any{"id": float64(2), "status": nil},
+		},
+	}
+
+	rep := &TableReport{}
+	err := mergeBaselineIntoWriter(context.Background(), mergeInput{
+		LocalBaselinePath: baselinePath,
+		CreateTableSQL:    "-- test",
+		Schema:            "mydb",
+		Table:             "orders",
+		PKCols:            pkColsIntID(),
+		Changes:           changes,
+		OutputDir:         outDir,
+		ChunkSize:         0,
+	}, rep)
+	if err != nil {
+		t.Fatalf("mergeBaselineIntoWriter refused a genuine NULL value: %v", err)
+	}
+	if rep.UpdatesApplied != 1 {
+		t.Errorf("UpdatesApplied = %d, want 1", rep.UpdatesApplied)
+	}
+
+	chunk := mustReadOnlyChunk(t, outDir)
+	if !strings.Contains(chunk, "(1, 'new')") {
+		t.Errorf("chunk missing passthrough row:\n%s", chunk)
+	}
+	if !strings.Contains(chunk, "(2, NULL)") {
+		t.Errorf("chunk missing NULL-status updated row:\n%s", chunk)
+	}
+}
+
+// TestDroppedBaselineColumns covers the pure detection helper directly.
+func TestDroppedBaselineColumns(t *testing.T) {
+	baseCols := []string{"id", "status"}
+
+	cases := []struct {
+		name    string
+		changes map[string]*query.ResultRow
+		want    []string
+	}{
+		{
+			name:    "no events",
+			changes: map[string]*query.ResultRow{},
+			want:    nil,
+		},
+		{
+			name: "no drift",
+			changes: map[string]*query.ResultRow{
+				"2": {EventType: event.EventUpdate, RowAfter: map[string]any{"id": 2, "status": "x"}},
+			},
+			want: nil,
+		},
+		{
+			name: "NULL value is not a drop",
+			changes: map[string]*query.ResultRow{
+				"2": {EventType: event.EventUpdate, RowAfter: map[string]any{"id": 2, "status": nil}},
+			},
+			want: nil,
+		},
+		{
+			name: "one dropped column",
+			changes: map[string]*query.ResultRow{
+				"2": {EventType: event.EventUpdate, RowAfter: map[string]any{"id": 2}},
+			},
+			want: []string{"status"},
+		},
+		{
+			name: "multiple dropped columns sorted and deduped across events",
+			changes: map[string]*query.ResultRow{
+				"2": {EventType: event.EventUpdate, RowAfter: map[string]any{}},
+				"3": {EventType: event.EventInsert, RowAfter: map[string]any{"status": "x"}},
+			},
+			want: []string{"id", "status"},
+		},
+		{
+			name: "DELETE events ignored (no row_after)",
+			changes: map[string]*query.ResultRow{
+				"2": {EventType: event.EventDelete, RowBefore: map[string]any{"id": 2}},
+			},
+			want: nil,
+		},
+		{
+			name: "nil row_after ignored",
+			changes: map[string]*query.ResultRow{
+				"2": {EventType: event.EventInsert, RowAfter: nil},
+			},
+			want: nil,
+		},
+		{
+			name: "nil event entry ignored",
+			changes: map[string]*query.ResultRow{
+				"2": nil,
+				"3": {EventType: event.EventUpdate, RowAfter: map[string]any{"id": 3}},
+			},
+			want: []string{"status"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := droppedBaselineColumns(c.changes, baseCols)
+			if len(got) != len(c.want) {
+				t.Fatalf("droppedBaselineColumns = %v, want %v", got, c.want)
+			}
+			for i := range got {
+				if got[i] != c.want[i] {
+					t.Fatalf("droppedBaselineColumns = %v, want %v", got, c.want)
+				}
+			}
+		})
+	}
+}

--- a/internal/reconstruct/schema_drift_843_test.go
+++ b/internal/reconstruct/schema_drift_843_test.go
@@ -72,6 +72,62 @@ func TestReconstruct843_columnDroppedAfterBaselineFailsLoud(t *testing.T) {
 	}
 }
 
+// TestReconstruct843_columnDroppedDeleteOnlyFailsLoud is the follow-up
+// regression: a window where the ONLY post-drop event for a touched PK is a
+// DELETE. DELETE events carry no row_after, so the original #843 guard (which
+// inspected row_after exclusively) skipped them and let the run through — a
+// pass-through row for a different, never-touched PK would then silently
+// re-emit the dropped column's stale pre-drop value (the exact PII
+// re-exposure scenario the #843 refusal exists to prevent). row_before on a
+// DELETE is itself a post-drop image (the row as it existed just before
+// deletion), so it carries the same detection signal as row_after.
+func TestReconstruct843_columnDroppedDeleteOnlyFailsLoud(t *testing.T) {
+	baselinePath := writeTestBaseline(t, [][]string{
+		{"1", "new"},
+		{"2", "paid"},
+	})
+	outDir := t.TempDir()
+
+	// id=2 is DELETEd after the `status` column was DROPped. The event
+	// row_before (post-drop image) carries only id — no row_after at all.
+	changes := map[string]*query.ResultRow{
+		pkStrForInt(2): {
+			EventType: parser.EventDelete,
+			PKValues:  pkStrForInt(2),
+			RowBefore: map[string]any{"id": float64(2)},
+		},
+	}
+
+	rep := &TableReport{}
+	err := mergeBaselineIntoWriter(context.Background(), mergeInput{
+		LocalBaselinePath: baselinePath,
+		CreateTableSQL:    "-- test",
+		Schema:            "mydb",
+		Table:             "orders",
+		PKCols:            pkColsIntID(),
+		Changes:           changes,
+		OutputDir:         outDir,
+		ChunkSize:         0,
+	}, rep)
+
+	if err == nil {
+		t.Fatalf("expected a fail-loud error for the dropped 'status' column (DELETE-only signal), got nil")
+	}
+	if !strings.Contains(err.Error(), "status") {
+		t.Errorf("error should name the dropped column %q, got: %v", "status", err)
+	}
+
+	entries, derr := os.ReadDir(outDir)
+	if derr != nil {
+		t.Fatalf("read output dir: %v", derr)
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".sql") {
+			t.Errorf("partial output left on disk after failed run: %s", e.Name())
+		}
+	}
+}
+
 // TestReconstruct843_nullValueIsNotADrop pins the column-absent-from-image vs
 // value-null distinction: an event whose row_after carries the column with a
 // nil value (a genuine SQL NULL under binlog_row_image=FULL) must NOT trip the
@@ -163,14 +219,21 @@ func TestDroppedBaselineColumns(t *testing.T) {
 			want: []string{"id", "status"},
 		},
 		{
-			name: "DELETE events ignored (no row_after)",
+			name: "DELETE row_before still detects a drop (#843 follow-up)",
 			changes: map[string]*query.ResultRow{
 				"2": {EventType: event.EventDelete, RowBefore: map[string]any{"id": 2}},
+			},
+			want: []string{"status"},
+		},
+		{
+			name: "DELETE row_before with no drift is not flagged",
+			changes: map[string]*query.ResultRow{
+				"2": {EventType: event.EventDelete, RowBefore: map[string]any{"id": 2, "status": "paid"}},
 			},
 			want: nil,
 		},
 		{
-			name: "nil row_after ignored",
+			name: "nil row_after and row_before ignored (INSERT with empty after somehow)",
 			changes: map[string]*query.ResultRow{
 				"2": {EventType: event.EventInsert, RowAfter: nil},
 			},


### PR DESCRIPTION
## What

`rowAfterOrdered` (`internal/reconstruct/fulltable.go`) NULL-filled baseline columns absent from a delta event's `row_after` image, warning once per row x column. After a `DROP COLUMN` post-baseline, a full-table reconstruct emitted a dump mixing two schema epochs: rows touched after the drop carried NULL while never-touched baseline pass-through rows kept the pre-drop value — under a `CREATE TABLE` header that still declared the column. That state never existed on the source, and it silently re-exposes a dropped (e.g. PII) column's stale values. 1M post-drop rows also meant 1M warn lines.

This was the deliberately-unresolved asymmetry of #602: added column = fail-loud refusal, dropped column = warn-and-emit.

## Fix

Match the #602 posture. New `droppedBaselineColumns` helper (symmetric counterpart of `postBaselineColumns`) scans the change map once, up front, and `mergeBaselineIntoWriter` refuses with an aggregated re-baseline error before the writer opens — no per-row spam, no partial chunk files on disk.

Column ABSENCE from the image is the signal: `binlog_row_image=FULL` (validated at index time) guarantees a complete after-image, so a missing key means the column no longer existed at event time. A genuinely-NULL value is present in the map with a nil value and merges exactly as before (pinned by test).

The NULL-fill-with-warn in `rowAfterOrdered` remains only for the binlog-only fallback path (`writeBinlogOnlyChanges`, #766), whose `colNames` come from a resolver snapshot rather than a baseline — re-baselining is not an answer there.

## Tests

- `TestReconstruct843_columnDroppedAfterBaselineFailsLoud` — refusal names the column, points at `bintrail baseline`, leaves no partial `.sql` output. Verified fail-before: with the guard neutered, the test fails (`got nil` + the old per-row WARN fires).
- `TestReconstruct843_nullValueIsNotADrop` — `row_after` carrying `status: nil` still merges and emits `(2, NULL)`.
- `TestDroppedBaselineColumns` — pure-helper matrix (no drift, NULL-not-a-drop, sorted/dedup across events, DELETE/nil-RowAfter/nil-entry ignored).

```
go build ./...                                          ok
go vet ./internal/reconstruct/                          ok
go test ./internal/reconstruct/... -count=1             ok (4.2s)
go test ./internal/cli/... ./internal/verify/... -count=1   ok
go test -tags integration ./internal/reconstruct/... -count=1   ok (4.9s, MySQL 13306)
go test -tags integration ./internal/shim/... -count=1          ok (11.0s)
```

Out of scope (same class, different surface): the shim's in-memory `_snapshot` full-table path (`SnapshotFullTableImages`) has no drift guard in either direction — #602 chose the mydumper writer path only, and this PR keeps that boundary.

Closes #843

🤖 Generated with [Claude Code](https://claude.com/claude-code)
