### PR TITLE
verify: default mode reports never-baselined snapshot tables as inconclusive instead of going green

### DIFF
--- a/docs/verify.md
+++ b/docs/verify.md
@@ -120,7 +120,7 @@ diff tool involved.
 | `--source-dsn` | *(empty)* | Live source DSN. Pass it for **live-source** mode; omit for **baseline-anchored** mode |
 | `--baseline-dir` | *(empty)* | Local directory of baseline Parquet snapshots |
 | `--baseline-s3` | *(empty)* | S3 URL prefix of baseline snapshots (e.g. `s3://bucket/baselines/`) |
-| `--tables` | *(all)* | Comma-separated `schema.table` list (default: all tables in the latest schema snapshot) |
+| `--tables` | *(all)* | Comma-separated `schema.table` list (default: all tables in the latest schema snapshot; in baseline-anchored mode, snapshot tables with no baseline report `inconclusive` — "never baselined") |
 | `--no-archive` | `false` | Query live MySQL partitions only; skip Parquet archive discovery |
 | `--explain` | `false` | On a baseline-anchored mismatch, print a per-row drill-down |
 

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -219,15 +219,37 @@ func runVerifyBaselinePair(cmd *cobra.Command, indexDB *sql.DB, resolver *metada
 	for _, d := range prevOnly {
 		covered[d.Schema+"."+d.Table] = true
 	}
+	var uncovered []*metadata.TableMeta
 	for _, tm := range resolver.AllTables() {
 		key := tm.Schema + "." + tm.Table
 		if covered[key] || (want != nil && !want[key]) {
 			continue
 		}
-		results = append(results, verify.TableResult{
-			Schema: tm.Schema, Table: tm.Table, Status: verify.StatusInconclusive,
-			Detail: "never baselined; unrecoverable via reconstruct (extend the baseline job to cover this table)",
-		})
+		uncovered = append(uncovered, tm)
+	}
+	if len(uncovered) > 0 {
+		// A table can be absent from the two most recent snapshots yet still
+		// have an older one on disk/S3 — reconstruct.FindBaseline's
+		// stale-fallback path will still find and use it (with a
+		// StaleWarning), so it's recoverable, just not verifiable against
+		// the current top-2 window. Distinguish that from a table with zero
+		// baselines ever, which reconstruct genuinely cannot serve, so the
+		// message doesn't send an operator into unnecessary re-baselining
+		// panic for a table that's actually fine (just stale).
+		everBaselined, err := verify.EverBaselinedTables(cmd.Context(), baselineSrc)
+		if err != nil {
+			return fmt.Errorf("list baselines: %w", err)
+		}
+		for _, tm := range uncovered {
+			detail := "never baselined; unrecoverable via reconstruct (extend the baseline job to cover this table)"
+			if everBaselined[tm.Schema+"."+tm.Table] {
+				detail = "not covered by the two most recent baselines; reconstruct will fall back to an older snapshot (stale)"
+			}
+			results = append(results, verify.TableResult{
+				Schema: tm.Schema, Table: tm.Table, Status: verify.StatusInconclusive,
+				Detail: detail,
+			})
+		}
 	}
 	// A table named in --tables that is absent from the paired and unpaired
 	// sets AND the schema snapshot was never iterated above, so it would

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -202,12 +202,40 @@ func runVerifyBaselinePair(cmd *cobra.Command, indexDB *sql.DB, resolver *metada
 			Detail: "present in the previous baseline but absent from the newest snapshot (dropped, or the newest baseline was run with --tables); not verified",
 		})
 	}
-	// A table named in --tables that is absent from BOTH the paired and unpaired
-	// sets was never iterated above, so it would silently vanish from the report
-	// while the run still exited 0 on the other tables' matches — the exact
-	// silent-omission this command exists to prevent (and asymmetric with live
-	// mode, where a bogus --tables entry reaches VerifyTable and gates the exit).
-	// Surface each unseen request as an error so it appears and fails the run.
+	// Tables in the latest schema snapshot that appear in NEITHER baseline
+	// snapshot — the baseline job never covered them (scoped with --database/
+	// --tables, or the table was created after the job was configured). Without
+	// this pass they produced no row at all and a default run exited 0 "N match"
+	// — false assurance over precisely the tables reconstruct cannot materialize
+	// either (no baseline = no never-touched rows). Reported inconclusive, like
+	// prevOnly: visible, but not by itself a failure (#770).
+	covered := make(map[string]bool, len(pairs)+len(unpaired)+len(prevOnly))
+	for _, p := range pairs {
+		covered[p.Schema+"."+p.Table] = true
+	}
+	for _, u := range unpaired {
+		covered[u.Schema+"."+u.Table] = true
+	}
+	for _, d := range prevOnly {
+		covered[d.Schema+"."+d.Table] = true
+	}
+	for _, tm := range resolver.AllTables() {
+		key := tm.Schema + "." + tm.Table
+		if covered[key] || (want != nil && !want[key]) {
+			continue
+		}
+		results = append(results, verify.TableResult{
+			Schema: tm.Schema, Table: tm.Table, Status: verify.StatusInconclusive,
+			Detail: "never baselined; unrecoverable via reconstruct (extend the baseline job to cover this table)",
+		})
+	}
+	// A table named in --tables that is absent from the paired and unpaired
+	// sets AND the schema snapshot was never iterated above, so it would
+	// silently vanish from the report while the run still exited 0 on the other
+	// tables' matches — the exact silent-omission this command exists to prevent
+	// (and asymmetric with live mode, where a bogus --tables entry reaches
+	// VerifyTable and gates the exit). Surface each unseen request as an error
+	// so it appears and fails the run.
 	if want != nil {
 		seen := make(map[string]bool, len(results))
 		for _, r := range results {
@@ -220,7 +248,7 @@ func runVerifyBaselinePair(cmd *cobra.Command, indexDB *sql.DB, resolver *metada
 			schema, table, _ := strings.Cut(key, ".")
 			results = append(results, verify.TableResult{
 				Schema: schema, Table: table, Status: verify.StatusError,
-				Detail: "requested via --tables but not present in the latest baseline pair",
+				Detail: "requested via --tables but not present in the latest baseline pair or the latest schema snapshot",
 			})
 		}
 	}

--- a/internal/cli/verify_baseline_integration_test.go
+++ b/internal/cli/verify_baseline_integration_test.go
@@ -171,6 +171,79 @@ func TestRunVerifyBaselinePair_EndToEnd_Mismatch(t *testing.T) {
 	}
 }
 
+// TestRunVerifyBaselinePair_EndToEnd_NeverBaselined locks the #770 fix on the
+// DEFAULT (no --tables) path: a table present in the latest schema snapshot
+// but absent from every baseline (baseline job scoped narrower than the
+// snapshot, or the table was created after the job was configured) must appear
+// in the report as inconclusive ("never baselined"). Before the fix it
+// produced no row at all and the run exited 0 with "1 match" — false assurance
+// over precisely the table reconstruct cannot materialize either. The exit
+// stays 0 (inconclusive, like prevOnly, does not by itself fail a run with
+// real matches) — the contract is visibility, not failure.
+func TestRunVerifyBaselinePair_EndToEnd_NeverBaselined(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	for _, c := range []struct {
+		table, name, key, dt string
+		ord                  int
+	}{
+		{"orders", "id", "PRI", "int", 1}, {"orders", "status", "", "varchar", 2},
+		// payments is in the snapshot but will get NO baseline.
+		{"payments", "id", "PRI", "int", 1},
+	} {
+		testutil.MustExec(t, db, `INSERT INTO schema_snapshots
+			(snapshot_id, snapshot_time, schema_name, table_name, column_name,
+			 ordinal_position, column_key, data_type, column_type, is_nullable, is_generated)
+			VALUES (1, UTC_TIMESTAMP(), ?, ?, ?, ?, ?, ?, ?, 'YES', 0)`,
+			dbName, c.table, c.name, c.ord, c.key, c.dt, c.dt)
+	}
+
+	baseDir := t.TempDir()
+	now := time.Now().UTC()
+	prevTS := now.Truncate(time.Hour).Add(-2 * time.Hour)
+	newTS := prevTS.Add(time.Hour)
+	createSQL := "CREATE TABLE `orders` (\n  `id` INT NOT NULL,\n  `status` VARCHAR(64),\n  PRIMARY KEY (`id`)\n);\n"
+	cols := []baseline.Column{
+		{Name: "id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
+		{Name: "status", MySQLType: "varchar", ParquetType: baseline.MysqlToParquetNode("varchar")},
+	}
+	writeCLIBaseline(t, baseDir, prevTS, dbName, "orders", createSQL, cols, [][]string{{"1", "a"}, {"2", "b"}}, 200)
+	writeCLIBaseline(t, baseDir, newTS, dbName, "orders", createSQL, cols, [][]string{{"1", "a"}, {"2", "shipped"}}, 300)
+
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{prevTS, newTS, now.Truncate(time.Hour)})
+	testutil.InsertEvent(t, db, "binlog.000001", 200, 300, prevTS.Add(30*time.Minute).Format("2006-01-02 15:04:05"),
+		nil, dbName, "orders", 2 /*UPDATE*/, "2", nil,
+		[]byte(`{"id":2,"status":"b"}`), []byte(`{"id":2,"status":"shipped"}`))
+
+	resolver, err := metadata.NewResolver(db, 1)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+	vfyNoArchive = true
+	t.Cleanup(func() { vfyNoArchive = false })
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := runVerifyBaselinePair(cmd, db, resolver, dbName, baseDir, duckdbutil.Tuning{}); err != nil {
+		t.Fatalf("runVerifyBaselinePair: %v\noutput:\n%s", err, out.String())
+	}
+	o := out.String()
+	if !strings.Contains(o, "1 match") {
+		t.Errorf("expected '1 match' (orders still verified) in report, got:\n%s", o)
+	}
+	if !strings.Contains(o, dbName+".payments") || !strings.Contains(o, "never baselined") {
+		t.Errorf("expected the never-baselined payments table reported inconclusive, got:\n%s", o)
+	}
+	if !strings.Contains(o, "1 inconclusive") {
+		t.Errorf("expected '1 inconclusive' in the summary, got:\n%s", o)
+	}
+}
+
 // TestRunVerifyBaselinePair_Explain pins the --explain CLI wiring: on a mismatch
 // the drill-down prints BELOW the report, names the exact diff, AND the run still
 // exits non-zero on the mismatch — a drill-down must never mask the verdict's exit

--- a/internal/cli/verify_baseline_integration_test.go
+++ b/internal/cli/verify_baseline_integration_test.go
@@ -244,6 +244,107 @@ func TestRunVerifyBaselinePair_EndToEnd_NeverBaselined(t *testing.T) {
 	}
 }
 
+// TestRunVerifyBaselinePair_EndToEnd_StaleButRecoverable locks the accuracy fix
+// on top of _NeverBaselined: a table absent from the two most recent baseline
+// snapshots but present in an OLDER one (3rd-most-recent here) is NOT
+// "unrecoverable via reconstruct" — reconstruct.FindBaseline's documented
+// stale-fallback path will still find and use that older snapshot. Before this
+// fix, "payments" (baselined at t1 only, not t2/t3) fell into the same
+// never-baselined loop as a table baselined nowhere, ever, and got told it was
+// unrecoverable — false, and liable to send an operator into unnecessary
+// urgent re-baselining. It must get the distinct "stale" message instead,
+// while a table with zero baselines anywhere still gets the original one.
+func TestRunVerifyBaselinePair_EndToEnd_StaleButRecoverable(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	for _, c := range []struct {
+		table, name, key, dt string
+		ord                  int
+	}{
+		{"orders", "id", "PRI", "int", 1}, {"orders", "status", "", "varchar", 2},
+		// payments gets a baseline only at t1 (3rd-most-recent) — stale but real.
+		{"payments", "id", "PRI", "int", 1},
+		// ghosts gets NO baseline at any snapshot time — truly never baselined.
+		{"ghosts", "id", "PRI", "int", 1},
+	} {
+		testutil.MustExec(t, db, `INSERT INTO schema_snapshots
+			(snapshot_id, snapshot_time, schema_name, table_name, column_name,
+			 ordinal_position, column_key, data_type, column_type, is_nullable, is_generated)
+			VALUES (1, UTC_TIMESTAMP(), ?, ?, ?, ?, ?, ?, ?, 'YES', 0)`,
+			dbName, c.table, c.name, c.ord, c.key, c.dt, c.dt)
+	}
+
+	baseDir := t.TempDir()
+	now := time.Now().UTC()
+	t1 := now.Truncate(time.Hour).Add(-3 * time.Hour)
+	t2 := now.Truncate(time.Hour).Add(-2 * time.Hour)
+	t3 := now.Truncate(time.Hour).Add(-1 * time.Hour)
+	ordersSQL := "CREATE TABLE `orders` (\n  `id` INT NOT NULL,\n  `status` VARCHAR(64),\n  PRIMARY KEY (`id`)\n);\n"
+	paymentsSQL := "CREATE TABLE `payments` (\n  `id` INT NOT NULL,\n  PRIMARY KEY (`id`)\n);\n"
+	ordersCols := []baseline.Column{
+		{Name: "id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
+		{Name: "status", MySQLType: "varchar", ParquetType: baseline.MysqlToParquetNode("varchar")},
+	}
+	paymentsCols := []baseline.Column{
+		{Name: "id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
+	}
+	// t1: orders + payments.
+	writeCLIBaseline(t, baseDir, t1, dbName, "orders", ordersSQL, ordersCols, [][]string{{"1", "a"}}, 100)
+	writeCLIBaseline(t, baseDir, t1, dbName, "payments", paymentsSQL, paymentsCols, [][]string{{"1"}}, 100)
+	// t2, t3: orders only — payments never re-baselined after t1.
+	writeCLIBaseline(t, baseDir, t2, dbName, "orders", ordersSQL, ordersCols, [][]string{{"1", "a"}, {"2", "b"}}, 200)
+	writeCLIBaseline(t, baseDir, t3, dbName, "orders", ordersSQL, ordersCols, [][]string{{"1", "a"}, {"2", "shipped"}}, 300)
+
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{t1, t2, t3, now.Truncate(time.Hour)})
+	testutil.InsertEvent(t, db, "binlog.000001", 200, 300, t2.Add(30*time.Minute).Format("2006-01-02 15:04:05"),
+		nil, dbName, "orders", 2 /*UPDATE*/, "2", nil,
+		[]byte(`{"id":2,"status":"b"}`), []byte(`{"id":2,"status":"shipped"}`))
+
+	resolver, err := metadata.NewResolver(db, 1)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+	vfyNoArchive = true
+	t.Cleanup(func() { vfyNoArchive = false })
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := runVerifyBaselinePair(cmd, db, resolver, dbName, baseDir, duckdbutil.Tuning{}); err != nil {
+		t.Fatalf("runVerifyBaselinePair: %v\noutput:\n%s", err, out.String())
+	}
+	o := out.String()
+	if !strings.Contains(o, "1 match") {
+		t.Errorf("expected '1 match' (orders still verified), got:\n%s", o)
+	}
+	var paymentsLine, ghostsLine string
+	for _, line := range strings.Split(o, "\n") {
+		if strings.Contains(line, dbName+".payments") {
+			paymentsLine = line
+		}
+		if strings.Contains(line, dbName+".ghosts") {
+			ghostsLine = line
+		}
+	}
+	if paymentsLine == "" || !strings.Contains(paymentsLine, "not covered by the two most recent baselines") ||
+		!strings.Contains(paymentsLine, "stale") {
+		t.Errorf("expected payments reported as stale-but-recoverable, got line:\n%q\nfull output:\n%s", paymentsLine, o)
+	}
+	if strings.Contains(paymentsLine, "unrecoverable via reconstruct") {
+		t.Errorf("payments has an older baseline (t1) — must not be reported as unrecoverable, got line:\n%s", paymentsLine)
+	}
+	if ghostsLine == "" || !strings.Contains(ghostsLine, "never baselined; unrecoverable via reconstruct") {
+		t.Errorf("expected ghosts (zero baselines ever) reported as never baselined/unrecoverable, got line:\n%q\nfull output:\n%s", ghostsLine, o)
+	}
+	if !strings.Contains(o, "2 inconclusive") {
+		t.Errorf("expected '2 inconclusive' in the summary (payments + ghosts), got:\n%s", o)
+	}
+}
+
 // TestRunVerifyBaselinePair_Explain pins the --explain CLI wiring: on a mismatch
 // the drill-down prints BELOW the report, names the exact diff, AND the run still
 // exits non-zero on the mismatch — a drill-down must never mask the verdict's exit

--- a/internal/cli/verify_baseline_test.go
+++ b/internal/cli/verify_baseline_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/dbtrail/dbtrail/internal/baseline"
 	"github.com/dbtrail/dbtrail/internal/duckdbutil"
+	"github.com/dbtrail/dbtrail/internal/metadata"
 )
 
 // writeMinimalBaseline writes one complete baseline snapshot (one table, one
@@ -95,11 +96,11 @@ func TestRunVerifyBaselinePair_SingleBaseline(t *testing.T) {
 
 // TestRunVerifyBaselinePair_TablesAbsent locks the no-silent-omission contract
 // for --tables: a requested table that exists in neither the paired nor the
-// unpaired set must surface as an error and fail the run, not vanish while the
-// other tables' matches keep the exit at 0. Two baselines for `orders` form a
-// real pair; --tables names a table that isn't there, so every real pair is
-// filtered out (the index is never touched — nil DBs are safe) and the unseen
-// request is the only result, as a StatusError.
+// unpaired set NOR the schema snapshot must surface as an error and fail the
+// run, not vanish while the other tables' matches keep the exit at 0. Two
+// baselines for `orders` form a real pair; --tables names a table that isn't
+// there, so every real pair is filtered out (the index is never touched — a
+// nil DB is safe) and the unseen request is the only result, as a StatusError.
 func TestRunVerifyBaselinePair_TablesAbsent(t *testing.T) {
 	baseDir := t.TempDir()
 	base := time.Now().UTC().Truncate(time.Hour)
@@ -114,12 +115,53 @@ func TestRunVerifyBaselinePair_TablesAbsent(t *testing.T) {
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 
-	err := runVerifyBaselinePair(cmd, nil, nil, "", baseDir, duckdbutil.Tuning{})
+	err := runVerifyBaselinePair(cmd, nil, metadata.NewResolverFromTables(1, nil), "", baseDir, duckdbutil.Tuning{})
 	if err == nil {
 		t.Fatalf("want a non-nil error (non-zero exit) for an absent --tables request, got nil; output:\n%s", out.String())
 	}
 	if !strings.Contains(out.String(), "1 error") ||
 		!strings.Contains(out.String(), "not present in the latest baseline pair") {
 		t.Errorf("want the ghost table surfaced as an error, got output:\n%s", out.String())
+	}
+}
+
+// TestRunVerifyBaselinePair_NeverBaselined locks the #770 fix: a table that IS
+// in the latest schema snapshot but appears in NO baseline snapshot must show
+// up in the report as inconclusive ("never baselined"), not silently produce
+// no row. --tables filters to the never-baselined table only, so the real
+// `orders` pair is skipped and the index is never touched (a nil DB is safe);
+// before the fix this request fell through to the --tables-absent StatusError
+// path instead of the snapshot-aware inconclusive.
+func TestRunVerifyBaselinePair_NeverBaselined(t *testing.T) {
+	baseDir := t.TempDir()
+	base := time.Now().UTC().Truncate(time.Hour)
+	writeMinimalBaseline(t, baseDir, "mydb", "orders", base.Add(-2*time.Hour))
+	writeMinimalBaseline(t, baseDir, "mydb", "orders", base.Add(-1*time.Hour))
+
+	resolver := metadata.NewResolverFromTables(1, map[string]*metadata.TableMeta{
+		"mydb.orders":   {Schema: "mydb", Table: "orders"},
+		"mydb.payments": {Schema: "mydb", Table: "payments"},
+	})
+
+	vfyTables = "mydb.payments"
+	t.Cleanup(func() { vfyTables = "" })
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	// Non-zero exit is expected here, but from the "nothing proven" gate (the
+	// only result is inconclusive), NOT from the --tables-absent error path.
+	err := runVerifyBaselinePair(cmd, nil, resolver, "", baseDir, duckdbutil.Tuning{})
+	if err == nil {
+		t.Fatalf("want a non-nil error (all-inconclusive run proves nothing), got nil; output:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "never baselined") ||
+		!strings.Contains(out.String(), "1 inconclusive") {
+		t.Errorf("want mydb.payments reported inconclusive as never baselined, got output:\n%s", out.String())
+	}
+	if strings.Contains(out.String(), "not present in the latest baseline pair") {
+		t.Errorf("a snapshot table must not hit the --tables-absent error path, got output:\n%s", out.String())
 	}
 }

--- a/internal/metadata/alltables_test.go
+++ b/internal/metadata/alltables_test.go
@@ -1,0 +1,29 @@
+package metadata
+
+import "testing"
+
+// TestAllTables verifies the full-universe enumeration is complete and
+// deterministically sorted by schema then table (map iteration order must
+// never leak into report ordering).
+func TestAllTables(t *testing.T) {
+	r := NewResolverFromTables(1, map[string]*TableMeta{
+		"beta.users":    {Schema: "beta", Table: "users"},
+		"alpha.orders":  {Schema: "alpha", Table: "orders"},
+		"alpha.invoice": {Schema: "alpha", Table: "invoice"},
+	})
+	got := r.AllTables()
+	want := []struct{ schema, table string }{
+		{"alpha", "invoice"}, {"alpha", "orders"}, {"beta", "users"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("AllTables returned %d tables, want %d", len(got), len(want))
+	}
+	for i, w := range want {
+		if got[i].Schema != w.schema || got[i].Table != w.table {
+			t.Errorf("AllTables[%d] = %s.%s, want %s.%s", i, got[i].Schema, got[i].Table, w.schema, w.table)
+		}
+	}
+	if n := len(NewResolverFromTables(1, nil).AllTables()); n != 0 {
+		t.Errorf("empty resolver: got %d tables, want 0", n)
+	}
+}

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -395,6 +395,24 @@ func (r *Resolver) Tables(schema string) []*TableMeta {
 	return out
 }
 
+// AllTables returns every TableMeta in the snapshot, sorted by schema then
+// table for deterministic output. Used by verify's baseline-anchored mode to
+// enumerate the full table universe, so a snapshot table with no baseline
+// surfaces in the report instead of silently producing no row.
+func (r *Resolver) AllTables() []*TableMeta {
+	out := make([]*TableMeta, 0, len(r.tables))
+	for _, t := range r.tables {
+		out = append(out, t)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Schema != out[j].Schema {
+			return out[i].Schema < out[j].Schema
+		}
+		return out[i].Table < out[j].Table
+	})
+	return out
+}
+
 // Resolve returns metadata for a given schema.table.
 // Returns an error if the table is not found in the snapshot.
 func (r *Resolver) Resolve(schema, table string) (*TableMeta, error) {

--- a/internal/verify/verify_baseline.go
+++ b/internal/verify/verify_baseline.go
@@ -207,6 +207,35 @@ func deferredReprChanged(cols []metadata.ColumnMeta, changes map[string]*query.R
 // run (exactly one baseline, no predecessor yet → genuinely nothing to compare).
 // FindBaselinePair collapses both into nil, nil, nil, so the distinction has to
 // be recovered here.
+// EverBaselinedTables returns the set of "schema.table" keys that appear in
+// AT LEAST ONE baseline snapshot under source, at ANY snapshot time — not
+// just the two most recent ones FindBaselinePair uses to build its
+// pairs/unpaired/prevOnly sets. A table absent from that top-2 window but
+// present here still has an older snapshot on disk/S3: reconstruct.FindBaseline
+// (the function `bintrail reconstruct` and the shim's `_snapshot` actually use)
+// will fall back to it and return a StaleWarning, so the table IS recoverable
+// via reconstruct — just not verifiable against the current two-snapshot
+// window. Callers use this to distinguish that from a table with zero
+// baselines at any point in time, which reconstruct genuinely cannot serve.
+func EverBaselinedTables(ctx context.Context, source string) (map[string]bool, error) {
+	files, err := reconstruct.ListBaselines(ctx, source)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]bool, len(files))
+	for _, f := range files {
+		out[f.Schema+"."+f.Table] = true
+	}
+	return out, nil
+}
+
+// AnyBaseline reports whether at least one complete baseline snapshot exists
+// under source. The CLI uses it on the "nothing to verify" path to tell two
+// physically different causes apart: a misconfigured or empty source (no
+// baselines at all — a broken baseline job → fail loud) from a legitimate first
+// run (exactly one baseline, no predecessor yet → genuinely nothing to compare).
+// FindBaselinePair collapses both into nil, nil, nil, so the distinction has to
+// be recovered here.
 func AnyBaseline(ctx context.Context, source string) (bool, error) {
 	files, err := reconstruct.ListBaselines(ctx, source)
 	if err != nil {


### PR DESCRIPTION
## What

`runVerifyBaselinePair` (baseline-anchored default mode) derived its table universe solely from `verify.FindBaselinePair`, i.e. from the baseline files on disk/S3. A table present in the source and in the latest `schema_snapshots` but NEVER baselined — baseline job scoped with `--database`/`--tables`, or the table created after the job was configured — produced **no row** in the report and the run exited 0 with "N match": exactly the false assurance `printVerifyReport` exists to prevent, over precisely the table that is also irrecoverable via `reconstruct` (no baseline = no never-touched rows).

## Fix

- New `metadata.Resolver.AllTables()` enumerates the loaded snapshot's full table set (sorted schema, table). `runVerifyBaselinePair` crosses it against the `pairs`/`unpaired`/`prevOnly` sets and reports each never-baselined table as **inconclusive** with the detail `never baselined; unrecoverable via reconstruct (extend the baseline job to cover this table)` — mirroring the existing `prevOnly` handling: visible, but not by itself a failure (a default run with real matches still exits 0; an all-inconclusive run still fails via the existing "nothing proven" gate). The resolver is the same latest-snapshot resolver `runVerify` already loads — no extra index query.
- A `--tables` request naming a never-baselined snapshot table now lands on that inconclusive row; the absent-request `StatusError` path now fires only for tables present in **neither** the baselines **nor** the snapshot (its detail says so).
- `docs/verify.md`: the `--tables` flags-table default claim ("all tables in the latest schema snapshot") was only true in live mode; with this change it holds in baseline-anchored mode too, and the row now states the never-baselined-inconclusive behavior explicitly (the "What it does not prove" section already promised this reporting — the code now matches it).

## Tests

- `TestRunVerifyBaselinePair_NeverBaselined` (unit): snapshot has `orders`+`payments`, baselines only `orders`; `payments` must report inconclusive "never baselined", not the `--tables`-absent error. **Fails before the fix** (old output: `mydb.payments error ... requested via --tables but not present in the latest baseline pair`).
- `TestRunVerifyBaselinePair_EndToEnd_NeverBaselined` (integration): DEFAULT no-`--tables` path against real MySQL — report shows `1 match` (orders verified), `payments` inconclusive "never baselined", `1 inconclusive`, exit 0. **Fails before the fix** (old output: `1 match, 0 mismatch, 0 inconclusive, 0 error` with `payments` absent — the exact false green from the issue).
- `TestAllTables` (unit): full, deterministically sorted enumeration; empty resolver.
- `TestRunVerifyBaselinePair_TablesAbsent` updated to pass an (empty) in-memory resolver; its fail-loud contract is unchanged.

```
go build ./...                                                          ok
go vet ./internal/cli/ ./internal/metadata/                             ok
go test ./internal/cli/... ./internal/metadata/... -count=1             ok
go test -tags integration ./internal/cli/... ./internal/metadata/... -count=1  ok (MySQL 13306)
```

Closes #770

🤖 Generated with [Claude Code](https://claude.com/claude-code)
