### PR TITLE
doctor: opt-in ProxySQL routing-rules check; document the hint form's silent misroute

### DIFF
--- a/cliapp/doctor.go
+++ b/cliapp/doctor.go
@@ -30,16 +30,18 @@ the exit code so 'doctor' is safe to run in CI as a smoke test.
 Examples:
 
   bintrail doctor --source-dsn "user:pass@tcp(source:3306)/"
-  bintrail doctor --source-dsn "$SRC" --index-dsn "$IDX" --schemas mydb`,
+  bintrail doctor --source-dsn "$SRC" --index-dsn "$IDX" --schemas mydb
+  bintrail doctor --source-dsn "$SRC" --proxysql-admin "admin:admin@tcp(127.0.0.1:6032)/"`,
 	RunE: runDoctor,
 }
 
 var (
-	docSourceDSN string
-	docIndexDSN  string
-	docSchemas   string
-	docFormat    string
-	docRetain    string
+	docSourceDSN     string
+	docIndexDSN      string
+	docSchemas       string
+	docFormat        string
+	docRetain        string
+	docProxySQLAdmin string
 )
 
 func init() {
@@ -48,6 +50,7 @@ func init() {
 	doctorCmd.Flags().StringVar(&docSchemas, "schemas", "", "Comma-separated schemas to check (default: all user schemas)")
 	doctorCmd.Flags().StringVar(&docFormat, "format", "text", "Output format: text or json")
 	doctorCmd.Flags().StringVar(&docRetain, "retain", "30d", "Retention window assumed by the index capacity projection (Nd/Nh; \"off\" if you don't rotate)")
+	doctorCmd.Flags().StringVar(&docProxySQLAdmin, "proxysql-admin", "", "ProxySQL admin DSN, e.g. admin:pass@tcp(127.0.0.1:6032)/ (optional; verifies the dbtrail time-travel routing rules are live — advisory WARN only)")
 	_ = doctorCmd.MarkFlagRequired("source-dsn")
 	bindCommandEnv(doctorCmd)
 	rootCmd.AddCommand(doctorCmd)
@@ -61,7 +64,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return runDoctorTo(cmd.Context(), os.Stdout, docFormat, docSourceDSN, docIndexDSN, docSchemas, retain)
+	return runDoctorTo(cmd.Context(), os.Stdout, docFormat, docSourceDSN, docIndexDSN, docSchemas, retain, docProxySQLAdmin)
 }
 
 // parseDocRetain maps doctor's --retain value to the capacity projection's
@@ -83,11 +86,16 @@ func parseDocRetain(s string) (time.Duration, error) {
 // against sourceDSN (and optionally indexDSN), renders the report to w using
 // format ("text" or "json"), and returns a non-nil error iff any required
 // check failed. indexRetain is the rotation window the capacity projection
-// assumes (0 = no rotation). Callers wanting to route output (e.g. `bintrail
+// assumes (0 = no rotation). proxysqlAdminDSN, when non-empty, appends the
+// opt-in ProxySQL routing-rules check (#820; advisory, never affects the exit
+// code). Callers wanting to route output (e.g. `bintrail
 // up` sending preflight output to stderr to keep stdout clean for streaming)
 // pass their own writer here instead of going through the cobra entry point.
-func runDoctorTo(parent context.Context, w io.Writer, format, sourceDSN, indexDSN, schemasCSV string, indexRetain time.Duration) error {
+func runDoctorTo(parent context.Context, w io.Writer, format, sourceDSN, indexDSN, schemasCSV string, indexRetain time.Duration, proxysqlAdminDSN string) error {
 	report := doctor.Build(parent, sourceDSN, indexDSN, schemasCSV, indexRetain)
+	if proxysqlAdminDSN != "" {
+		report.Add(doctor.CheckProxySQLRules(parent, proxysqlAdminDSN))
+	}
 	if err := report.Write(w, format); err != nil {
 		return fmt.Errorf("write report: %w", err)
 	}

--- a/cliapp/doctor_proxysql_test.go
+++ b/cliapp/doctor_proxysql_test.go
@@ -1,0 +1,23 @@
+package cliapp
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// #820: --proxysql-admin is opt-in. It must exist on doctor and never be
+// required — the check it enables is advisory, and doctor must keep working
+// for deployments with no ProxySQL at all.
+func TestDoctorProxySQLAdminFlagOptional(t *testing.T) {
+	f := doctorCmd.Flags().Lookup("proxysql-admin")
+	if f == nil {
+		t.Fatal("doctor is missing the --proxysql-admin flag")
+	}
+	if f.DefValue != "" {
+		t.Errorf("--proxysql-admin default = %q, want empty (opt-in)", f.DefValue)
+	}
+	if req, ok := f.Annotations[cobra.BashCompOneRequiredFlag]; ok && len(req) > 0 && req[0] == "true" {
+		t.Error("--proxysql-admin must not be marked required")
+	}
+}

--- a/docs/time-travel-sql.md
+++ b/docs/time-travel-sql.md
@@ -311,6 +311,27 @@ SELECT * FROM _flashback.orders AS OF '2026-05-02 10:00:00';
 SELECT * FROM _diff.orders BETWEEN '2026-05-01' AND '2026-05-02' WHERE id = 12345;
 ```
 
+> **The hint form is the only one that degrades silently.** `/*+ DBTRAIL_AT=... */`
+> is 100% valid vanilla MySQL (an unknown optimizer hint raises a warning, not an
+> error), so if the query never reaches the shim — the client points at MySQL's
+> port instead of ProxySQL's `:6033`, rules 990001-990006 are missing (e.g.
+> ProxySQL restarted without `SAVE MYSQL QUERY RULES TO DISK`), or a
+> lower-`rule_id` operator rule intercepts first — MySQL executes it against the
+> live table and returns **present-day data with no error**. You believe you are
+> reading the past; you are reading the present. The other shapes fail loud on
+> the same misroute (`_flashback.*` → `ER_BAD_DB` 1049; bare `AS OF` → 1064), so
+> prefer them whenever the client can emit them — reserve the hint form for
+> ORM/query-builder paths that reject `AS OF` syntax, and verify routing after
+> any ProxySQL change:
+>
+> ```sh
+> bintrail doctor --source-dsn "$SRC" --proxysql-admin 'admin:<pass>@tcp(127.0.0.1:6032)/'
+> ```
+>
+> The check confirms all six dbtrail rules are live in
+> `runtime_mysql_query_rules` (advisory `WARN` when they aren't — it never
+> changes doctor's exit code).
+
 Every quoted time literal — in `AS OF`, `DBTRAIL_AT`, and the `BETWEEN` bounds — accepts four absolute formats (`'2026-05-02 10:00:00'`, RFC 3339 `'2026-05-02T10:00:00Z'`, zone-less `'2026-05-02T10:00:00'`, and date-only `'2026-05-02'`), plus `'now'` and relative forms `'<n> seconds|minutes|hours|days ago'` (e.g. `AS OF '5 minutes ago'`), resolved against the wall clock at parse time. Larger units (weeks, months) are deliberately not parsed — spell them as days.
 
 **All three zone-less forms (`'2026-05-02 10:00:00'`, the zone-less RFC-3339-shaped literal, and date-only) are interpreted as UTC** — only the `Z`-suffixed RFC 3339 form is unambiguous by construction. There is no per-session override: a `SET time_zone = ...` sent by the client is accepted (returned `OK`, matching a real MySQL server's handshake noise) but has **no effect** on how the shim parses `AS OF` literals — it is treated as connection setup noise and silently ignored. If your monitoring or incident timeline is in local time, convert to UTC before writing the literal, or use the unambiguous `Z`-suffixed form.
@@ -369,7 +390,9 @@ mysql -u admin -p -h 127.0.0.1 -P 6032 \
   -e "SELECT rule_id, match_pattern, destination_hostgroup FROM runtime_mysql_query_rules WHERE rule_id BETWEEN 990001 AND 990006;"
 ```
 
-You should see six rows targeting hostgroup 991 (one each for `_flashback.*`, `_diff.*`, `_snapshot.*`, the `/*+ DBTRAIL_AT=... */` hint-comment shape, `SHOW TABLES FROM` the virtual schemas, and the end-anchored bare `... AS OF '<ts>'` shape). If they're missing, re-apply `proxysql-setup.sql`. If they're present but the query still goes to MySQL, double-check that no operator rule with a smaller `rule_id` is intercepting `_flashback.*` first (ProxySQL evaluates rules in `rule_id` order).
+You should see six rows targeting hostgroup 991 (one each for `_flashback.*`, `_diff.*`, `_snapshot.*`, the `/*+ DBTRAIL_AT=... */` hint-comment shape, `SHOW TABLES FROM` the virtual schemas, and the end-anchored bare `... AS OF '<ts>'` shape). If they're missing, re-apply `proxysql-setup.sql`. If they're present but the query still goes to MySQL, double-check that no operator rule with a smaller `rule_id` is intercepting `_flashback.*` first (ProxySQL evaluates rules in `rule_id` order). `bintrail doctor --proxysql-admin '<admin-dsn>'` runs the six-rules check for you (advisory `WARN` when any is missing or inactive).
+
+Note this failure mode is only *visible* for the `_flashback.*`/`_diff.*`/`_snapshot.*` and bare `AS OF` shapes, which error out when misrouted to MySQL. The `/*+ DBTRAIL_AT */` hint form produces **no error at all** on the same misroute — MySQL treats the hint as unknown-and-ignorable and returns current data (see the warning under Step 6). If time-travel results ever look suspiciously like the present, check the rules above before trusting them.
 
 ### `connection refused` on the shim's port
 

--- a/internal/doctor/proxysql.go
+++ b/internal/doctor/proxysql.go
@@ -1,0 +1,158 @@
+package doctor
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-sql-driver/mysql"
+)
+
+const proxySQLRulesCheckName = "ProxySQL time-travel routing rules"
+
+// The ProxySQL query-rule id range `bintrail proxysql-config` installs
+// (990001-990006). Duplicated from cliapp/proxysql_config.go because cliapp
+// imports this package, so the constants cannot be shared without a cycle.
+const (
+	proxySQLRuleIDFirst = 990001
+	proxySQLRuleIDLast  = 990006
+)
+
+const proxySQLRulesRemediation = "Re-apply the dbtrail routing rules and persist them across ProxySQL restarts:\n\n" +
+	"  bintrail proxysql-config --out proxysql-setup.sql\n" +
+	"  mysql -u admin -p -h <proxysql-host> -P 6032 < proxysql-setup.sql\n\n" +
+	"The generated script LOADs the rules to runtime and SAVEs them to disk.\n" +
+	"Until the rules are live, time-travel queries fall through to the live MySQL:\n" +
+	"the /*+ DBTRAIL_AT */ hint form then silently returns PRESENT data (it is\n" +
+	"valid vanilla SQL), while the other statement shapes fail with an error."
+
+// CheckProxySQLRules verifies the six dbtrail query rules `bintrail
+// proxysql-config` installs are live (present AND active) in ProxySQL's
+// runtime_mysql_query_rules (#820). Opt-in via `doctor --proxysql-admin`;
+// advisory only — every outcome short of all-six-live is WARN, never FAIL,
+// because ProxySQL routing is an optional deployment and doctor's exit code
+// must not go red over it.
+//
+// The check exists chiefly for the /*+ DBTRAIL_AT */ hint form: it is valid
+// vanilla MySQL (an unknown optimizer hint is a warning, not an error), so
+// when routing is missing the query executes against the live table and
+// returns PRESENT data with no error — the only statement shape that
+// degrades silently on a misroute. The other forms fail loud
+// (`_flashback.*` → ER_BAD_DB 1049; bare AS OF → 1064).
+func CheckProxySQLRules(parent context.Context, adminDSN string) CheckResult {
+	ctx, cancel := context.WithTimeout(parent, 10*time.Second)
+	defer cancel()
+
+	db, err := connectProxySQLAdmin(ctx, adminDSN)
+	if err != nil {
+		return CheckResult{
+			Name:   proxySQLRulesCheckName,
+			Status: StatusWarn,
+			Detail: "could not connect to the ProxySQL admin interface: " + err.Error(),
+			Remediation: "Verify --proxysql-admin points at ProxySQL's ADMIN port (default 6032, not the MySQL\n" +
+				"traffic port 6033), e.g. admin:admin@tcp(127.0.0.1:6032)/ — and that the credentials\n" +
+				"match the admin_credentials in /etc/proxysql.cnf.",
+		}
+	}
+	defer db.Close()
+	return checkProxySQLRulesOn(ctx, db)
+}
+
+// connectProxySQLAdmin opens the ProxySQL admin interface. Deliberately NOT
+// config.Connect: that helper sets maxAllowedPacket=0, which makes the driver
+// probe `SELECT @@max_allowed_packet` during the handshake — a MySQL-server
+// system variable the SQLite-backed admin interface does not serve.
+func connectProxySQLAdmin(ctx context.Context, dsn string) (*sql.DB, error) {
+	cfg, err := mysql.ParseDSN(dsn)
+	if err != nil {
+		return nil, fmt.Errorf("invalid DSN: %w", err)
+	}
+	if cfg.Timeout == 0 {
+		cfg.Timeout = 10 * time.Second
+	}
+	db, err := sql.Open("mysql", cfg.FormatDSN())
+	if err != nil {
+		return nil, err
+	}
+	if err := db.PingContext(ctx); err != nil {
+		db.Close()
+		return nil, err
+	}
+	return db, nil
+}
+
+// checkProxySQLRulesOn runs the rule probe against an already-open admin
+// connection — the testable core (sqlmock in proxysql_test.go).
+func checkProxySQLRulesOn(ctx context.Context, db *sql.DB) CheckResult {
+	rows, err := db.QueryContext(ctx, fmt.Sprintf(
+		"SELECT rule_id, active FROM runtime_mysql_query_rules WHERE rule_id BETWEEN %d AND %d",
+		proxySQLRuleIDFirst, proxySQLRuleIDLast))
+	if err != nil {
+		return CheckResult{
+			Name:   proxySQLRulesCheckName,
+			Status: StatusWarn,
+			Detail: "could not query runtime_mysql_query_rules: " + err.Error(),
+			Remediation: "Confirm the DSN targets ProxySQL's ADMIN interface (default port 6032) — the MySQL\n" +
+				"traffic port (6033) and a plain MySQL server have no runtime_mysql_query_rules table.",
+		}
+	}
+	defer rows.Close()
+
+	// The admin interface is SQLite-backed and returns TEXT columns; scan as
+	// strings and compare rather than trusting numeric conversion.
+	live := map[string]bool{}
+	for rows.Next() {
+		var id, active string
+		if err := rows.Scan(&id, &active); err != nil {
+			return CheckResult{
+				Name:   proxySQLRulesCheckName,
+				Status: StatusWarn,
+				Detail: "could not scan runtime_mysql_query_rules row: " + err.Error(),
+			}
+		}
+		live[strings.TrimSpace(id)] = strings.TrimSpace(active) == "1"
+	}
+	if err := rows.Err(); err != nil {
+		return CheckResult{
+			Name:   proxySQLRulesCheckName,
+			Status: StatusWarn,
+			Detail: "could not read runtime_mysql_query_rules rows: " + err.Error(),
+		}
+	}
+
+	var missing, inactive []string
+	for id := proxySQLRuleIDFirst; id <= proxySQLRuleIDLast; id++ {
+		key := strconv.Itoa(id)
+		active, ok := live[key]
+		switch {
+		case !ok:
+			missing = append(missing, key)
+		case !active:
+			inactive = append(inactive, key)
+		}
+	}
+	if len(missing) == 0 && len(inactive) == 0 {
+		return CheckResult{
+			Name:   proxySQLRulesCheckName,
+			Status: StatusPass,
+			Detail: fmt.Sprintf("rules %d-%d live in runtime_mysql_query_rules", proxySQLRuleIDFirst, proxySQLRuleIDLast),
+		}
+	}
+	var frags []string
+	if len(missing) > 0 {
+		frags = append(frags, "missing: "+strings.Join(missing, ", "))
+	}
+	if len(inactive) > 0 {
+		frags = append(frags, "inactive: "+strings.Join(inactive, ", "))
+	}
+	return CheckResult{
+		Name:   proxySQLRulesCheckName,
+		Status: StatusWarn,
+		Detail: "rule(s) " + strings.Join(frags, "; ") +
+			" — time-travel queries fall through to the live MySQL; the /*+ DBTRAIL_AT */ hint form then silently returns PRESENT data (see docs/time-travel-sql.md)",
+		Remediation: proxySQLRulesRemediation,
+	}
+}

--- a/internal/doctor/proxysql_integration_test.go
+++ b/internal/doctor/proxysql_integration_test.go
@@ -1,0 +1,42 @@
+//go:build integration
+
+package doctor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestCheckProxySQLRulesAgainstPlainMySQL pins the most likely operator
+// mistake for --proxysql-admin: pointing it at a MySQL server (or ProxySQL's
+// traffic port) instead of the admin interface. A plain MySQL has no
+// runtime_mysql_query_rules table, so the check must WARN — never FAIL, and
+// never PASS — over the real wire protocol.
+func TestCheckProxySQLRulesAgainstPlainMySQL(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+
+	got := CheckProxySQLRules(t.Context(), testutil.BaseDSN()+"/")
+	if got.Status != StatusWarn {
+		t.Errorf("Status = %q (detail=%q), want WARN", got.Status, got.Detail)
+	}
+	if !strings.Contains(got.Detail, "runtime_mysql_query_rules") {
+		t.Errorf("Detail = %q, want it to name runtime_mysql_query_rules", got.Detail)
+	}
+	if !strings.Contains(got.Remediation, "6032") {
+		t.Errorf("Remediation = %q, want the admin-port hint", got.Remediation)
+	}
+}
+
+// TestCheckProxySQLRulesUnreachableWarns: a dead admin endpoint is WARN (the
+// check is advisory), not FAIL.
+func TestCheckProxySQLRulesUnreachableWarns(t *testing.T) {
+	got := CheckProxySQLRules(t.Context(), "admin:admin@tcp(127.0.0.1:1)/?timeout=1s")
+	if got.Status != StatusWarn {
+		t.Errorf("Status = %q (detail=%q), want WARN", got.Status, got.Detail)
+	}
+	if !strings.Contains(got.Detail, "could not connect") {
+		t.Errorf("Detail = %q, want the connect-failure prefix", got.Detail)
+	}
+}

--- a/internal/doctor/proxysql_test.go
+++ b/internal/doctor/proxysql_test.go
@@ -1,0 +1,137 @@
+package doctor
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestCheckProxySQLRulesOn(t *testing.T) {
+	forcedErr := errors.New("forced query failure")
+
+	// ruleRows builds a runtime_mysql_query_rules resultset. ProxySQL's admin
+	// interface serves TEXT columns, which is what the check scans.
+	ruleRows := func(pairs ...[2]string) *sqlmock.Rows {
+		rows := sqlmock.NewRows([]string{"rule_id", "active"})
+		for _, p := range pairs {
+			rows.AddRow(p[0], p[1])
+		}
+		return rows
+	}
+	allSix := func(active string) *sqlmock.Rows {
+		return ruleRows(
+			[2]string{"990001", active}, [2]string{"990002", active},
+			[2]string{"990003", active}, [2]string{"990004", active},
+			[2]string{"990005", active}, [2]string{"990006", active})
+	}
+
+	tests := []struct {
+		name           string
+		setup          func(m sqlmock.Sqlmock)
+		wantStatus     CheckStatus
+		wantDetailFrag string
+		wantRemedFrags []string
+	}{
+		{
+			name: "all six rules active passes",
+			setup: func(m sqlmock.Sqlmock) {
+				m.ExpectQuery("FROM runtime_mysql_query_rules").WillReturnRows(allSix("1"))
+			},
+			wantStatus:     StatusPass,
+			wantDetailFrag: "rules 990001-990006 live",
+		},
+		{
+			name: "missing hint rule warns naming the id and the silent-present hazard",
+			setup: func(m sqlmock.Sqlmock) {
+				m.ExpectQuery("FROM runtime_mysql_query_rules").WillReturnRows(ruleRows(
+					[2]string{"990001", "1"}, [2]string{"990002", "1"},
+					[2]string{"990003", "1"}, [2]string{"990005", "1"},
+					[2]string{"990006", "1"}))
+			},
+			wantStatus:     StatusWarn,
+			wantDetailFrag: "missing: 990004",
+			wantRemedFrags: []string{"bintrail proxysql-config", "DBTRAIL_AT"},
+		},
+		{
+			name: "present but inactive rule warns as inactive",
+			setup: func(m sqlmock.Sqlmock) {
+				rows := ruleRows(
+					[2]string{"990001", "1"}, [2]string{"990002", "1"},
+					[2]string{"990003", "1"}, [2]string{"990004", "0"},
+					[2]string{"990005", "1"}, [2]string{"990006", "1"})
+				m.ExpectQuery("FROM runtime_mysql_query_rules").WillReturnRows(rows)
+			},
+			wantStatus:     StatusWarn,
+			wantDetailFrag: "inactive: 990004",
+			wantRemedFrags: []string{"bintrail proxysql-config"},
+		},
+		{
+			name: "empty resultset warns with every rule missing",
+			setup: func(m sqlmock.Sqlmock) {
+				m.ExpectQuery("FROM runtime_mysql_query_rules").WillReturnRows(ruleRows())
+			},
+			wantStatus:     StatusWarn,
+			wantDetailFrag: "missing: 990001, 990002, 990003, 990004, 990005, 990006",
+		},
+		{
+			name: "query failure warns pointing at the admin-vs-traffic port confusion",
+			setup: func(m sqlmock.Sqlmock) {
+				m.ExpectQuery("FROM runtime_mysql_query_rules").WillReturnError(forcedErr)
+			},
+			wantStatus:     StatusWarn,
+			wantDetailFrag: "could not query runtime_mysql_query_rules",
+			wantRemedFrags: []string{"6032"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("sqlmock.New: %v", err)
+			}
+			defer db.Close()
+			tt.setup(mock)
+
+			got := checkProxySQLRulesOn(t.Context(), db)
+
+			if got.Name != proxySQLRulesCheckName {
+				t.Errorf("Name = %q, want %q", got.Name, proxySQLRulesCheckName)
+			}
+			if got.Status != tt.wantStatus {
+				t.Errorf("Status = %q (detail=%q), want %q", got.Status, got.Detail, tt.wantStatus)
+			}
+			// The check is advisory by contract (#820): it must never flip
+			// doctor's exit code.
+			if got.Status == StatusFail {
+				t.Errorf("Status = FAIL — the ProxySQL rules check must be warn-only")
+			}
+			if !strings.Contains(got.Detail, tt.wantDetailFrag) {
+				t.Errorf("Detail = %q, want fragment %q", got.Detail, tt.wantDetailFrag)
+			}
+			for _, frag := range tt.wantRemedFrags {
+				if !strings.Contains(got.Remediation, frag) {
+					t.Errorf("Remediation = %q, want fragment %q", got.Remediation, frag)
+				}
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("unmet sqlmock expectations: %v", err)
+			}
+		})
+	}
+}
+
+func TestCheckProxySQLRulesBadDSNWarns(t *testing.T) {
+	got := CheckProxySQLRules(t.Context(), "not a dsn")
+	if got.Status != StatusWarn {
+		t.Errorf("Status = %q, want WARN", got.Status)
+	}
+	if !strings.Contains(got.Detail, "could not connect to the ProxySQL admin interface") {
+		t.Errorf("Detail = %q, want the connect-failure prefix", got.Detail)
+	}
+	if !strings.Contains(got.Remediation, "6032") {
+		t.Errorf("Remediation = %q, want the admin-port hint", got.Remediation)
+	}
+}


### PR DESCRIPTION
## What

`SELECT /*+ DBTRAIL_AT='...' */ * FROM orders WHERE id=1` is 100% valid vanilla MySQL — an unknown optimizer hint yields a warning, not an error. If the query never routes through ProxySQL to the shim (client pointed at the direct MySQL port; rules 990001-990006 missing after a ProxySQL restart without `SAVE MYSQL QUERY RULES TO DISK`; a lower `rule_id` intercepting first), MySQL executes it against the live table and returns **present-day data with no error**. The other statement shapes fail loud on the same misroute (`_flashback.*` → ER_BAD_DB 1049; bare `AS OF` → 1064) — only the hint form degrades silently, and nothing shim-side can fix a query that never arrives.

- **Docs** (`docs/time-travel-sql.md`): a warning under Step 6 naming the hint form as the only silently-degrading shape, recommending the fail-loud forms whenever the client can emit them and reserving the hint form for ORM paths that reject `AS OF` syntax; plus a Troubleshooting note that a misrouted hint query produces *no* error at all.
- **Doctor** (`internal/doctor/proxysql.go`, opt-in via `bintrail doctor --proxysql-admin '<admin-dsn>'`): verifies all six dbtrail rules are present AND active in `runtime_mysql_query_rules`. Advisory by contract — every outcome short of all-six-live is WARN, never FAIL, so the exit code is unaffected. The flag is optional; `doctor.Build` and its `up`/`watch`/console-supervisor callers are untouched. The admin connection deliberately bypasses `config.Connect`: its `maxAllowedPacket=0` makes the driver probe `SELECT @@max_allowed_packet` during the handshake, which ProxySQL's SQLite-backed admin interface does not serve.

## Tests

- `TestCheckProxySQLRulesOn` (sqlmock): all-six-active → PASS; missing 990004 → WARN naming the id + remediation; present-but-inactive → WARN; empty resultset → all six missing; query failure → WARN with the admin-vs-traffic-port hint. Every case asserts the check never returns FAIL.
- `TestCheckProxySQLRulesBadDSNWarns`: unparseable DSN → WARN.
- Integration (MySQL 13306): `TestCheckProxySQLRulesAgainstPlainMySQL` pins the likely operator mistake (admin DSN pointing at a plain MySQL / the traffic port) as WARN over the real wire; `TestCheckProxySQLRulesUnreachableWarns` pins dead-endpoint → WARN.
- `TestDoctorProxySQLAdminFlagOptional`: the flag exists, defaults empty, is never required.

```
go build ./...                                             ok
go vet ./internal/doctor/ ./cliapp/                        ok
go test ./internal/doctor/ ./cliapp/ -count=1              ok (0.4s / 8.0s)
go test -tags integration ./internal/doctor/ ./cliapp/     ok (3.1s / 11.7s, MySQL 13306)
```

Live smoke: `doctor --source-dsn <13306> --proxysql-admin <13306>` adds exactly one `!` WARN line and leaves Passed/Failed unchanged.

Closes #820

🤖 Generated with [Claude Code](https://claude.com/claude-code)
