### PR TITLE
verify: normalize TIME fsp padding and FLOAT/DOUBLE text rendering false-MISMATCHes

### DIFF
--- a/internal/consistency/checksum.go
+++ b/internal/consistency/checksum.go
@@ -181,10 +181,14 @@ func consistentTableChecksum(ctx context.Context, db *sql.DB, schema, table stri
 	}
 
 	// Scan every row, hashing as we stream — no full-table buffering.
+	//
+	// promoteFloat is scoped to the normalize != nil (cross-renderer) callers
+	// only — see selectExpr's FLOAT case for why.
+	promoteFloat := normalize != nil
 	selectList := make([]string, len(cols))
 	res.Columns = make([]string, len(cols))
 	for i, c := range cols {
-		selectList[i] = selectExpr(c)
+		selectList[i] = selectExpr(c, promoteFloat)
 		res.Columns[i] = c.name
 	}
 	query := fmt.Sprintf("SELECT %s FROM %s.%s",
@@ -349,11 +353,35 @@ func tableColumns(ctx context.Context, conn *sql.Conn, schema, table string) ([]
 // which is NOT what mydumper dumps or the binlog carries — so the digest would
 // not match a baseline. The CAST makes the canonical form parseTime-independent.
 // Other types (including TIME and YEAR, which the driver never parses) are read
-// as-is.
-func selectExpr(c column) string {
-	switch c.dataType {
-	case "date", "datetime", "timestamp":
+// as-is, EXCEPT FLOAT when promoteFloat is set (see below).
+//
+// promoteFloat controls a FLOAT-only widening: bare `SELECT f` renders through
+// MySQL's my_gcvt truncated to ~6 significant digits (FLT_DIG) — lossy
+// relative to the underlying binary float32 for any value that needs more
+// precision to round-trip (#795). `f+0e0` promotes the read to DOUBLE
+// arithmetic, so my_gcvt renders the value's full double-precision decimal
+// expansion (enough digits to identify the exact float32), which
+// canonicalFloatText(_, 32) then folds back to the same shortest float32
+// text a Go-side renderer produces for the identical stored value — closing
+// the gap without touching the recon side (see internal/verify/render.go's
+// canonicalFloatText doc).
+//
+// Scoped to promoteFloat (wired to normalize != nil, i.e. only
+// ConsistentTableChecksumNormalized's live-source verify caller) rather than
+// applied unconditionally: ConsistentTableChecksum's un-normalized digest must
+// stay byte-identical to mydumper's own FLOAT text (both MySQL's ordinary
+// my_gcvt truncation, matching today) so the baseline-dump-time fidelity
+// check (internal/baseline, #633) keeps comparing like renderings — widening
+// unconditionally would turn THAT comparison into a false MISMATCH instead
+// of fixing this one. `f+0e0` (not CAST(f AS DOUBLE), which needs MySQL
+// 8.0.17+) is plain arithmetic promotion, safe on the whole MySQL 8.0+ floor
+// and on MariaDB.
+func selectExpr(c column, promoteFloat bool) string {
+	switch {
+	case c.dataType == "date" || c.dataType == "datetime" || c.dataType == "timestamp":
 		return "CAST(" + quoteIdent(c.name) + " AS CHAR)"
+	case c.dataType == "float" && promoteFloat:
+		return quoteIdent(c.name) + "+0e0"
 	default:
 		return quoteIdent(c.name)
 	}

--- a/internal/consistency/checksum_test.go
+++ b/internal/consistency/checksum_test.go
@@ -120,6 +120,31 @@ func TestDigestVersionOf(t *testing.T) {
 	}
 }
 
+// TestSelectExpr_FloatPromotion pins selectExpr's scoping of the #795 FLOAT
+// widening: unconditional promotion would break the byte-identity
+// ConsistentTableChecksum (nil normalize, baseline-dump-time fidelity check)
+// promises against mydumper's own unpromoted FLOAT text, so promoteFloat must
+// gate strictly on the cross-renderer (normalize != nil) caller.
+func TestSelectExpr_FloatPromotion(t *testing.T) {
+	f := column{name: "f", dataType: "float"}
+	if got, want := selectExpr(f, false), "`f`"; got != want {
+		t.Errorf("selectExpr(float, promoteFloat=false) = %q, want %q", got, want)
+	}
+	if got, want := selectExpr(f, true), "`f`+0e0"; got != want {
+		t.Errorf("selectExpr(float, promoteFloat=true) = %q, want %q", got, want)
+	}
+	// DOUBLE is unaffected either way — my_gcvt already renders it losslessly.
+	d := column{name: "d", dataType: "double"}
+	if got, want := selectExpr(d, true), "`d`"; got != want {
+		t.Errorf("selectExpr(double, promoteFloat=true) = %q, want %q", got, want)
+	}
+	// DATE/DATETIME/TIMESTAMP keep their CAST regardless of promoteFloat.
+	ts := column{name: "ts", dataType: "timestamp"}
+	if got, want := selectExpr(ts, true), "CAST(`ts` AS CHAR)"; got != want {
+		t.Errorf("selectExpr(timestamp, promoteFloat=true) = %q, want %q", got, want)
+	}
+}
+
 func TestQuoteIdent(t *testing.T) {
 	cases := map[string]string{
 		"id":       "`id`",

--- a/internal/verify/render.go
+++ b/internal/verify/render.go
@@ -36,10 +36,20 @@ import (
 // inconclusive rather than as a failure (see VerifyTable). FLOAT/DOUBLE are not
 // in the deferred set — there is intentionally no float-inconclusive downgrade
 // (that would create a masking path). Their known representation-only gap
-// (MySQL's my_gcvt vs Go's strconv exponent form, #795) is instead closed by
+// (MySQL's my_gcvt vs Go's strconv exponent form, #795) is closed by
 // canonicalFloatText's value-preserving parse+reformat in renderCellNormalized,
 // so whatever divergence survives normalization is a genuine value difference
-// and surfaces as a (safe) mismatch, never as a false match.
+// and surfaces as a (safe) mismatch, never as a false match. For FLOAT
+// specifically, canonicalFloatText alone is not sufficient on the live-source
+// side: MySQL's bare `SELECT f` already truncates FLOAT text to ~6
+// significant digits (FLT_DIG) before it ever reaches this package, which is
+// lossy relative to the true float32 value and cannot be recovered by
+// reformatting after the fact. Closing that requires reading more precision
+// from the source in the first place — internal/consistency's selectExpr
+// promotes FLOAT reads to DOUBLE arithmetic (`f+0e0`) specifically for the
+// cross-renderer (normalize != nil) caller VerifyTable uses, so the text
+// canonicalFloatText receives already carries enough digits to identify the
+// exact float32.
 func renderCell(v any, col metadata.ColumnMeta) []byte {
 	if v == nil {
 		return nil
@@ -317,7 +327,10 @@ func walkForDuplicateKeys(dec *json.Decoder) (bool, error) {
 //     pad it to the declared fsp (#794).
 //   - a FLOAT/DOUBLE text rendering (see canonicalFloatText) — MySQL's
 //     my_gcvt and Go's strconv disagree on exponent form and thresholds for
-//     the same stored value (#795).
+//     the same stored value (#795). For FLOAT, this also depends on the
+//     source having been read with enough precision in the first place —
+//     see internal/consistency's selectExpr (promoteFloat) — since a
+//     truncated MySQL text can't be recovered by reformatting alone.
 //   - a DATE/DATETIME/TIMESTAMP zero-date sentinel (see isZeroDateSentinel)
 //     — internal/baseline.Writer.WriteRow deliberately maps MySQL's
 //     '0000-00-00'-family pseudo-NULL to Parquet NULL, unconditionally, for
@@ -437,6 +450,18 @@ func trimTimeFractionZeros(b []byte) []byte {
 // not parse as a float of that width (never produced by either renderer for
 // an intact value) return unchanged and fall through to the raw byte
 // comparison.
+//
+// This function is value-preserving only when its input already carries
+// enough precision to identify the stored value uniquely. For DOUBLE, MySQL's
+// bare text protocol always does. For FLOAT it does NOT: a bare `SELECT f`
+// truncates to ~6 significant digits (my_gcvt's FLT_DIG default), which is
+// lossy for any float32 that needs more digits to round-trip — no reformat of
+// already-truncated text can recover the missing digits. That gap is closed
+// one layer up, at the SQL text this function receives: internal/consistency's
+// selectExpr promotes FLOAT reads to DOUBLE arithmetic (`f+0e0`) for the
+// cross-renderer (normalize != nil) caller, so by the time a FLOAT value's
+// text reaches here it already carries full double-precision digits and
+// parses back to the exact original float32.
 func canonicalFloatText(b []byte, bitSize int) []byte {
 	f, err := strconv.ParseFloat(string(b), bitSize)
 	if err != nil {

--- a/internal/verify/render.go
+++ b/internal/verify/render.go
@@ -34,9 +34,12 @@ import (
 // MySQL normalizes differently than Go) renders best-effort and, for columns the
 // caller marks as deferred-representation, a resulting mismatch is reported
 // inconclusive rather than as a failure (see VerifyTable). FLOAT/DOUBLE are not
-// in the deferred set, so a float-only divergence surfaces as a (safe) mismatch,
-// never as a false match — there is intentionally no float-inconclusive downgrade
-// (that would create a masking path).
+// in the deferred set — there is intentionally no float-inconclusive downgrade
+// (that would create a masking path). Their known representation-only gap
+// (MySQL's my_gcvt vs Go's strconv exponent form, #795) is instead closed by
+// canonicalFloatText's value-preserving parse+reformat in renderCellNormalized,
+// so whatever divergence survives normalization is a genuine value difference
+// and surfaces as a (safe) mismatch, never as a false match.
 func renderCell(v any, col metadata.ColumnMeta) []byte {
 	if v == nil {
 		return nil
@@ -300,7 +303,7 @@ func walkForDuplicateKeys(dec *json.Decoder) (bool, error) {
 }
 
 // renderCellNormalized renders a cell like renderCell, additionally
-// normalizing two known representation gaps between an event-image value and
+// normalizing the known representation gaps between an event-image value and
 // the SAME underlying data rendered independently on the comparison's other
 // side, so a pure representation difference doesn't register as a content
 // difference:
@@ -308,6 +311,13 @@ func walkForDuplicateKeys(dec *json.Decoder) (bool, error) {
 //   - a JSON object/array value (see canonicalizeJSONContainer) — Go's
 //     map[string]any decode loses object key order, which renderCell's
 //     default case then re-serializes alphabetically.
+//   - a TIME value's fractional suffix (see trimTimeFractionZeros) —
+//     go-mysql's event-image renderer omits the fraction entirely for an
+//     integer-second value while MySQL's text protocol and mydumper always
+//     pad it to the declared fsp (#794).
+//   - a FLOAT/DOUBLE text rendering (see canonicalFloatText) — MySQL's
+//     my_gcvt and Go's strconv disagree on exponent form and thresholds for
+//     the same stored value (#795).
 //   - a DATE/DATETIME/TIMESTAMP zero-date sentinel (see isZeroDateSentinel)
 //     — internal/baseline.Writer.WriteRow deliberately maps MySQL's
 //     '0000-00-00'-family pseudo-NULL to Parquet NULL, unconditionally, for
@@ -373,8 +383,64 @@ func normalizeRenderedBytes(b []byte, dataType string) []byte {
 	if isZeroDateSentinel(b, col) {
 		return nil
 	}
+	// TIME/FLOAT/DOUBLE values are never JSON containers, so returning from
+	// these arms skips canonicalizeJSONContainer harmlessly.
+	switch strings.ToLower(strings.TrimSpace(dataType)) {
+	case "time":
+		return trimTimeFractionZeros(b)
+	case "float":
+		return canonicalFloatText(b, 32)
+	case "double":
+		return canonicalFloatText(b, 64)
+	}
 	if canon, ok := canonicalizeJSONContainer(b); ok {
 		return canon
 	}
 	return b
+}
+
+// trimTimeFractionZeros canonicalizes a TIME value's fractional suffix by
+// trimming trailing fractional zeros (and a then-empty '.') — the minimal
+// rendering of the same value. The renderers feeding a TIME comparison
+// disagree only in trailing zeros: MySQL's text protocol and mydumper pad
+// the fraction to the declared fsp ("09:00:00.000" for TIME(3)), while
+// go-mysql v1.13.0's timeFormat — the event-image renderer — omits the
+// suffix ENTIRELY when the microsecond part is zero (and pads to the fsp
+// otherwise), so every integer-second TIME(fsp>0) value was a conclusive
+// false MISMATCH in both verify modes (#794). Trimming rather than padding
+// to the fsp because the fsp isn't available here — the live-scan hook
+// carries only information_schema DATA_TYPE (see
+// ConsistentTableChecksumNormalized) — and it also holds for pre-#212
+// snapshots whose ColumnType is empty. Value-preserving by construction:
+// removing trailing zeros after the '.' never collapses two DIFFERENT
+// values. Bytes without a '.' return untouched — an unguarded TrimRight
+// would eat an integer-second value's own trailing zeros ("10:00:00" →
+// "10:00:").
+func trimTimeFractionZeros(b []byte) []byte {
+	if bytes.IndexByte(b, '.') < 0 {
+		return b
+	}
+	t := bytes.TrimRight(b, "0")
+	return bytes.TrimSuffix(t, []byte("."))
+}
+
+// canonicalFloatText re-renders a FLOAT/DOUBLE text value through Go's
+// shortest-round-trip formatter at the column's own width (32-bit for FLOAT,
+// 64-bit for DOUBLE), so MySQL's my_gcvt rendering ("1e16", "0.00001") and
+// Go's strconv rendering ("1e+16", "1e-05") of the SAME stored value compare
+// equal (#795) — live mode was a permanent conclusive MISMATCH on any intact
+// float outside the coinciding-render range. Distinct storable values of the
+// column's width have distinct shortest renderings, so parse+reformat
+// collapses representation only, never a value divergence — which is why
+// FLOAT/DOUBLE can stay OUT of the deferred-representation set (see the
+// renderCell doc: no inconclusive downgrade, no masking path). Bytes that do
+// not parse as a float of that width (never produced by either renderer for
+// an intact value) return unchanged and fall through to the raw byte
+// comparison.
+func canonicalFloatText(b []byte, bitSize int) []byte {
+	f, err := strconv.ParseFloat(string(b), bitSize)
+	if err != nil {
+		return b
+	}
+	return []byte(strconv.FormatFloat(f, 'g', -1, bitSize))
 }

--- a/internal/verify/render_test.go
+++ b/internal/verify/render_test.go
@@ -264,3 +264,121 @@ func TestTemporalPrecision(t *testing.T) {
 		}
 	}
 }
+
+// TestNormalizeRenderedBytes_TimeFractionCanonical is the #794 fix: go-mysql's
+// timeFormat renders an integer-second TIME without any fractional suffix
+// regardless of the declared fsp, while MySQL's text protocol and mydumper pad
+// the fraction to the fsp ("09:00:00.000" for TIME(3)) — a conclusive false
+// MISMATCH in both verify modes. Every rendering of the same value must
+// normalize to the same minimal form, without needing the fsp (the live-scan
+// hook carries DATA_TYPE only), and value-bearing fraction digits must
+// survive so two DIFFERENT values never collapse.
+func TestNormalizeRenderedBytes_TimeFractionCanonical(t *testing.T) {
+	cases := []struct {
+		name     string
+		dataType string
+		in       string
+		want     string
+	}{
+		{"mysql/mydumper padded fsp3", "time", "09:00:00.000", "09:00:00"},
+		{"go-mysql integer-second", "time", "09:00:00", "09:00:00"},
+		{"padded nonzero fraction", "time", "09:00:00.120", "09:00:00.12"},
+		{"minimal nonzero fraction", "time", "09:00:00.12", "09:00:00.12"},
+		{"value-bearing trailing digit", "time", "09:00:00.001", "09:00:00.001"},
+		{"fsp6 all-zero fraction", "time", "-838:59:59.000000", "-838:59:59"},
+		{"seconds end in zero, no dot", "time", "10:00:20", "10:00:20"}, // TrimRight guard: must NOT become "10:00:2"
+		{"seconds end in zero, zero fraction", "time", "10:00:20.000", "10:00:20"},
+		{"case-insensitive DataType", "TIME", "09:00:00.000", "09:00:00"},
+		{"non-time dataType untouched", "varchar", "09:00:00.000", "09:00:00.000"},
+		{"decimal untouched", "decimal", "1.500", "1.500"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := normalizeRenderedBytes([]byte(tc.in), tc.dataType)
+			if !bytes.Equal(got, []byte(tc.want)) {
+				t.Errorf("normalizeRenderedBytes(%q, %q) = %q, want %q", tc.in, tc.dataType, got, tc.want)
+			}
+		})
+	}
+
+	// Anti-masking pin: two genuinely different TIME values stay different.
+	a := normalizeRenderedBytes([]byte("09:00:00.100"), "time")
+	b := normalizeRenderedBytes([]byte("09:00:00.010"), "time")
+	if bytes.Equal(a, b) {
+		t.Errorf("normalization collapsed distinct TIME values: %q == %q", a, b)
+	}
+}
+
+// TestRenderCellNormalized_TimeIntegerSecond_BothSidesAgree pins the #794
+// scenario end-to-end through the recon renderer: the event image's go-mysql
+// text and the baseline's mydumper text of the same TIME(3) value must render
+// identically.
+func TestRenderCellNormalized_TimeIntegerSecond_BothSidesAgree(t *testing.T) {
+	c := col("time", "time(3)")
+	event := renderCellNormalized("09:00:00", c)        // go-mysql event-image text
+	baseline := renderCellNormalized("09:00:00.000", c) // mydumper/baseline text
+	if !bytes.Equal(event, baseline) {
+		t.Errorf("event render %q != baseline render %q for the same TIME value", event, baseline)
+	}
+}
+
+// TestNormalizeRenderedBytes_FloatDoubleCanonical is the #795 fix: MySQL's
+// my_gcvt and Go's strconv render the same stored FLOAT/DOUBLE with different
+// exponent forms and thresholds ("1e16" vs "1e+16"), a permanent conclusive
+// false MISMATCH in live mode. Both texts must canonicalize to one rendering
+// at the column's own width; anything that isn't clean float text stays
+// untouched, and distinct values stay distinct (floats remain OUT of the
+// deferred set — this normalizes representation, it must never mask a value
+// divergence).
+func TestNormalizeRenderedBytes_FloatDoubleCanonical(t *testing.T) {
+	cases := []struct {
+		name     string
+		dataType string
+		in       string
+		want     string
+	}{
+		{"double mysql exponent", "double", "1e16", "1e+16"},
+		{"double go exponent stable", "double", "1e+16", "1e+16"},
+		{"double decimal-vs-exponent threshold", "double", "0.00001", "1e-05"},
+		{"double plain stable", "double", "2.25", "2.25"},
+		{"double integer-valued", "double", "12345", "12345"},
+		{"double negative zero", "double", "-0", "-0"},
+		{"float parsed at 32 bits", "float", "0.30000001192092896", "0.3"},
+		{"float plain stable", "float", "1.5", "1.5"},
+		{"case-insensitive DataType", "DOUBLE", "1e16", "1e+16"},
+		{"unparsable unchanged", "double", "not-a-float", "not-a-float"},
+		{"whitespace unchanged", "double", " 1e16", " 1e16"},
+		{"non-float dataType untouched", "varchar", "1e16", "1e16"},
+		{"decimal untouched", "decimal", "1.50", "1.50"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := normalizeRenderedBytes([]byte(tc.in), tc.dataType)
+			if !bytes.Equal(got, []byte(tc.want)) {
+				t.Errorf("normalizeRenderedBytes(%q, %q) = %q, want %q", tc.in, tc.dataType, got, tc.want)
+			}
+		})
+	}
+
+	// Anti-masking pin: two distinct float64 values keep distinct canonical
+	// forms — a real corruption still surfaces as a mismatch.
+	a := normalizeRenderedBytes([]byte("1e16"), "double")
+	b := normalizeRenderedBytes([]byte("1.0000000000000002e16"), "double")
+	if bytes.Equal(a, b) {
+		t.Errorf("normalization collapsed distinct DOUBLE values: %q == %q", a, b)
+	}
+}
+
+// TestRenderCellNormalized_DoubleEventAndBaselineAgree pins that all three
+// origins of the same DOUBLE value converge: a baseline float64 (DuckDB), an
+// event image's json.Number literal, and MySQL's my_gcvt raw text (through
+// normalizeRenderedBytes, as ConsistentTableChecksumNormalized applies it).
+func TestRenderCellNormalized_DoubleEventAndBaselineAgree(t *testing.T) {
+	c := col("double", "double")
+	fromBaseline := renderCellNormalized(float64(1e16), c)
+	fromEvent := renderCellNormalized(json.Number("1e+16"), c)
+	fromMySQL := normalizeRenderedBytes([]byte("1e16"), "double")
+	if !bytes.Equal(fromBaseline, fromEvent) || !bytes.Equal(fromEvent, fromMySQL) {
+		t.Errorf("renderings diverge: baseline=%q event=%q mysql=%q", fromBaseline, fromEvent, fromMySQL)
+	}
+}

--- a/internal/verify/render_test.go
+++ b/internal/verify/render_test.go
@@ -345,6 +345,17 @@ func TestNormalizeRenderedBytes_FloatDoubleCanonical(t *testing.T) {
 		{"double negative zero", "double", "-0", "-0"},
 		{"float parsed at 32 bits", "float", "0.30000001192092896", "0.3"},
 		{"float plain stable", "float", "1.5", "1.5"},
+		// #795 FLOAT gap: MySQL's bare `SELECT f` truncates FLOAT text to ~6
+		// significant digits (my_gcvt's FLT_DIG), losing the 7th digit of a
+		// value like the float32 1.234567 entirely — no reformat of the
+		// already-truncated "1.23457" can recover it. The fix lives in
+		// internal/consistency's selectExpr (promoteFloat, `f+0e0`), which
+		// widens the SELECT to DOUBLE arithmetic so my_gcvt renders the full
+		// double-precision expansion; THAT text is what reaches this function.
+		// This case pins that once the source hands over enough digits,
+		// canonicalFloatText folds it to the same shortest float32 rendering
+		// the Go-side recon renderer (renderCell's float32 case) produces.
+		{"float promoted-source text folds to shortest float32 form", "float", "1.2345670461654663", "1.234567"},
 		{"case-insensitive DataType", "DOUBLE", "1e16", "1e+16"},
 		{"unparsable unchanged", "double", "not-a-float", "not-a-float"},
 		{"whitespace unchanged", "double", " 1e16", " 1e16"},
@@ -380,5 +391,33 @@ func TestRenderCellNormalized_DoubleEventAndBaselineAgree(t *testing.T) {
 	fromMySQL := normalizeRenderedBytes([]byte("1e16"), "double")
 	if !bytes.Equal(fromBaseline, fromEvent) || !bytes.Equal(fromEvent, fromMySQL) {
 		t.Errorf("renderings diverge: baseline=%q event=%q mysql=%q", fromBaseline, fromEvent, fromMySQL)
+	}
+}
+
+// TestRenderCellNormalized_FloatEventAndPromotedMySQLTextAgree is the FLOAT
+// sibling of TestRenderCellNormalized_DoubleEventAndBaselineAgree, pinning
+// the #795 fix end-to-end: a recon-side float32 (whether from a baseline or
+// an event image) must converge with MySQL's live-source text ONLY once that
+// text carries the extra precision internal/consistency's selectExpr
+// (promoteFloat, `f+0e0`) now supplies — a bare, un-promoted `SELECT f`
+// truncated to 6 significant digits never converges, which is the false
+// MISMATCH #795 was filed to eliminate.
+func TestRenderCellNormalized_FloatEventAndPromotedMySQLTextAgree(t *testing.T) {
+	c := col("float", "float")
+	fromBaseline := renderCellNormalized(float32(1.234567), c)
+	fromEvent := renderCellNormalized(json.Number("1.234567"), c)
+	// The text selectExpr(_, promoteFloat=true) now produces for this value
+	// (`f+0e0` widens the read to DOUBLE arithmetic).
+	fromPromotedMySQL := normalizeRenderedBytes([]byte("1.2345670461654663"), "float")
+	if !bytes.Equal(fromBaseline, fromEvent) || !bytes.Equal(fromEvent, fromPromotedMySQL) {
+		t.Errorf("renderings diverge: baseline=%q event=%q mysql(promoted)=%q", fromBaseline, fromEvent, fromPromotedMySQL)
+	}
+
+	// Anti-regression: the OLD un-promoted 6-sig-fig text must NOT match —
+	// pinning that this test would have failed before the selectExpr fix,
+	// so a future revert of promoteFloat is caught here too.
+	fromUnpromotedMySQL := normalizeRenderedBytes([]byte("1.23457"), "float")
+	if bytes.Equal(fromEvent, fromUnpromotedMySQL) {
+		t.Errorf("unpromoted 6-sig-fig MySQL text %q unexpectedly matched recon %q — this would hide a regression of selectExpr's promoteFloat", fromUnpromotedMySQL, fromEvent)
 	}
 }

--- a/internal/verify/verify_integration_test.go
+++ b/internal/verify/verify_integration_test.go
@@ -776,3 +776,132 @@ func TestVerifyTable_StaleZeroDateVsGenuineNull_AcceptedRisk(t *testing.T) {
 		t.Fatalf("status = %q (%s); this test pins the accepted-risk behavior — if this now fails, the zero-date normalization's blast radius changed and this comment/test pair needs re-evaluating, not just updating the assertion", got.Status, got.Detail)
 	}
 }
+
+// TestVerifyTable_TimeFspAndFloatText_IsAMatch is the live-source regression
+// for #794 + #795 through the real ConsistentTableChecksumNormalized scan:
+//
+//   - #794: an in-window event image carries go-mysql's integer-second TIME
+//     text ("11:00:00" — timeFormat omits the fractional suffix when the
+//     microsecond part is zero) while MySQL's text protocol pads to the
+//     declared fsp ("11:00:00.000" for TIME(3)).
+//   - #795: a baseline-origin DOUBLE holding 1e16 renders "1e+16" through Go's
+//     strconv on the recon side but "1e16" through my_gcvt on the live scan.
+//
+// Both were conclusive false MISMATCHes (neither type is in the deferred
+// set). After normalization the table must MATCH — and a genuinely different
+// float value must still MISMATCH (the normalization is representation-only,
+// never a masking path).
+func TestVerifyTable_TimeFspAndFloatText_IsAMatch(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	for _, c := range []struct {
+		name             string
+		ord              int
+		key, dt, colType string
+	}{
+		{"id", 1, "PRI", "int", "int"},
+		{"start", 2, "", "time", "time(3)"},
+		{"factor", 3, "", "double", "double"},
+	} {
+		testutil.MustExec(t, db, `INSERT INTO schema_snapshots
+			(snapshot_id, snapshot_time, schema_name, table_name, column_name,
+			 ordinal_position, column_key, data_type, column_type, is_nullable, is_generated)
+			VALUES (1, UTC_TIMESTAMP(), ?, 'appointments', ?, ?, ?, ?, ?, 'NO', 0)`,
+			dbName, c.name, c.ord, c.key, c.dt, c.colType)
+	}
+
+	// Live SOURCE at the final state: row 1 untouched since the baseline (its
+	// DOUBLE exercises #795), row 2 updated in-window to an integer-second
+	// TIME (exercises #794).
+	testutil.MustExec(t, db, fmt.Sprintf(
+		"CREATE TABLE `%s`.`appointments` (`id` INT PRIMARY KEY, `start` TIME(3), `factor` DOUBLE)", dbName))
+	testutil.MustExec(t, db, fmt.Sprintf(
+		"INSERT INTO `%s`.`appointments` VALUES (1,'09:30:00.250',1e16),(2,'11:00:00',2.25)", dbName))
+
+	// Baseline Parquet at the initial state, in mydumper's text forms: TIME
+	// padded to the declared fsp, DOUBLE as MySQL renders it.
+	baselineDir := t.TempDir()
+	now := time.Now().UTC()
+	curHour := now.Truncate(time.Hour)
+	h1 := curHour.Add(-time.Hour)
+	h2 := curHour
+	snapshotTS := h1
+	tsDir := strings.ReplaceAll(snapshotTS.Format(time.RFC3339), ":", "-")
+	parquetDir := filepath.Join(baselineDir, tsDir, dbName)
+	if err := os.MkdirAll(parquetDir, 0o755); err != nil {
+		t.Fatalf("mkdir baseline: %v", err)
+	}
+	createSQL := "CREATE TABLE `appointments` (\n  `id` INT NOT NULL,\n  `start` TIME(3),\n  `factor` DOUBLE,\n  PRIMARY KEY (`id`)\n);\n"
+	cols := []baseline.Column{
+		{Name: "id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
+		{Name: "start", MySQLType: "time", ParquetType: baseline.MysqlToParquetNode("time")},
+		{Name: "factor", MySQLType: "double", ParquetType: baseline.MysqlToParquetNode("double")},
+	}
+	bw, err := baseline.NewWriter(filepath.Join(parquetDir, "appointments.parquet"), cols,
+		baseline.WriterConfig{Compression: "zstd", RowGroupSize: 100,
+			Metadata: map[string]string{baseline.MetaKeyCreateTableSQL: createSQL}})
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	for _, row := range [][]string{
+		{"1", "09:30:00.250", "1e16"},
+		{"2", "10:30:00.000", "2.25"},
+	} {
+		if err := bw.WriteRow(row, []bool{false, false, false}); err != nil {
+			t.Fatalf("WriteRow: %v", err)
+		}
+	}
+	if err := bw.Close(); err != nil {
+		t.Fatalf("baseline close: %v", err)
+	}
+
+	// In-window UPDATE on row 2. The TIME texts are go-mysql's timeFormat
+	// output: integer-second values carry NO fractional suffix.
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{h1, h2})
+	ts1 := now.Add(-2 * time.Minute).Format("2006-01-02 15:04:05")
+	testutil.InsertEvent(t, db, "binlog.000001", 100, 200, ts1, nil, dbName, "appointments", 2 /*UPDATE*/, "2", nil,
+		[]byte(`{"id":2,"start":"10:30:00","factor":2.25}`),
+		[]byte(`{"id":2,"start":"11:00:00","factor":2.25}`))
+
+	var uuid string
+	if err := db.QueryRow("SELECT @@server_uuid").Scan(&uuid); err != nil {
+		t.Fatalf("server_uuid: %v", err)
+	}
+	testutil.MustExec(t, db, `INSERT INTO stream_state
+		(id, mode, gtid_set, last_checkpoint, server_id)
+		VALUES (1, 'gtid', ?, UTC_TIMESTAMP(), 1)`, uuid+":1-1000000")
+
+	resolver, err := metadata.NewResolver(db, 1)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+	cfg := Config{
+		SourceDB: db, IndexDB: db, Resolver: resolver,
+		BaselineSource: baselineDir, IndexDBName: dbName, NoArchive: true,
+	}
+	ctx := context.Background()
+
+	got, err := VerifyTable(ctx, cfg, dbName, "appointments")
+	if err != nil {
+		t.Fatalf("VerifyTable: %v", err)
+	}
+	if got.Status != StatusMatch {
+		t.Fatalf("status = %q (%s); want match\n  source=%s rows=%d\n  recon =%s rows=%d",
+			got.Status, got.Detail, got.SourceDigest, got.SourceRows, got.ReconstructDigest, got.ReconstructRows)
+	}
+
+	// A genuinely different DOUBLE (one ulp away at 1e16) must still surface.
+	testutil.MustExec(t, db, fmt.Sprintf(
+		"UPDATE `%s`.`appointments` SET factor=1.0000000000000002e16 WHERE id=1", dbName))
+	got2, err := VerifyTable(ctx, cfg, dbName, "appointments")
+	if err != nil {
+		t.Fatalf("VerifyTable (2): %v", err)
+	}
+	if got2.Status != StatusMismatch {
+		t.Errorf("after float tampering status = %q (%s); want mismatch", got2.Status, got2.Detail)
+	}
+}

--- a/internal/verify/verify_integration_test.go
+++ b/internal/verify/verify_integration_test.go
@@ -786,6 +786,12 @@ func TestVerifyTable_StaleZeroDateVsGenuineNull_AcceptedRisk(t *testing.T) {
 //     declared fsp ("11:00:00.000" for TIME(3)).
 //   - #795: a baseline-origin DOUBLE holding 1e16 renders "1e+16" through Go's
 //     strconv on the recon side but "1e16" through my_gcvt on the live scan.
+//   - #795 (FLOAT): a baseline-origin FLOAT holding 1.234567 (needing 7
+//     significant digits) is truncated by a bare `SELECT gauge` to "1.23457"
+//     (my_gcvt's ~6-sig-fig default) — lossy, not just differently
+//     formatted, so canonicalFloatText's parse+reformat alone cannot recover
+//     it. This exercises internal/consistency's selectExpr promoteFloat
+//     widening (`gauge+0e0`) end-to-end through the real live-source scan.
 //
 // Both were conclusive false MISMATCHes (neither type is in the deferred
 // set). After normalization the table must MATCH — and a genuinely different
@@ -806,6 +812,7 @@ func TestVerifyTable_TimeFspAndFloatText_IsAMatch(t *testing.T) {
 		{"id", 1, "PRI", "int", "int"},
 		{"start", 2, "", "time", "time(3)"},
 		{"factor", 3, "", "double", "double"},
+		{"gauge", 4, "", "float", "float"},
 	} {
 		testutil.MustExec(t, db, `INSERT INTO schema_snapshots
 			(snapshot_id, snapshot_time, schema_name, table_name, column_name,
@@ -818,12 +825,20 @@ func TestVerifyTable_TimeFspAndFloatText_IsAMatch(t *testing.T) {
 	// DOUBLE exercises #795), row 2 updated in-window to an integer-second
 	// TIME (exercises #794).
 	testutil.MustExec(t, db, fmt.Sprintf(
-		"CREATE TABLE `%s`.`appointments` (`id` INT PRIMARY KEY, `start` TIME(3), `factor` DOUBLE)", dbName))
+		"CREATE TABLE `%s`.`appointments` (`id` INT PRIMARY KEY, `start` TIME(3), `factor` DOUBLE, `gauge` FLOAT)", dbName))
+	// Row 1's gauge (2.25) needs no more than 6 significant digits, so it
+	// renders identically whether or not the SELECT is promoted — it is a
+	// control value, not an exercise of the fix. Row 2's gauge (1.234567)
+	// needs 7 — its final state comes from the in-window event below, not
+	// from the baseline, so it exercises the #795 FLOAT fix against an
+	// event-sourced value (the scenario the fix actually targets) without
+	// conflating it with mydumper's own separate, orthogonal FLOAT capture
+	// precision at dump time (see the baseline WriteRow comment below).
 	testutil.MustExec(t, db, fmt.Sprintf(
-		"INSERT INTO `%s`.`appointments` VALUES (1,'09:30:00.250',1e16),(2,'11:00:00',2.25)", dbName))
+		"INSERT INTO `%s`.`appointments` VALUES (1,'09:30:00.250',1e16,2.25),(2,'11:00:00',2.25,1.234567)", dbName))
 
 	// Baseline Parquet at the initial state, in mydumper's text forms: TIME
-	// padded to the declared fsp, DOUBLE as MySQL renders it.
+	// padded to the declared fsp, DOUBLE/FLOAT as MySQL renders them.
 	baselineDir := t.TempDir()
 	now := time.Now().UTC()
 	curHour := now.Truncate(time.Hour)
@@ -835,11 +850,12 @@ func TestVerifyTable_TimeFspAndFloatText_IsAMatch(t *testing.T) {
 	if err := os.MkdirAll(parquetDir, 0o755); err != nil {
 		t.Fatalf("mkdir baseline: %v", err)
 	}
-	createSQL := "CREATE TABLE `appointments` (\n  `id` INT NOT NULL,\n  `start` TIME(3),\n  `factor` DOUBLE,\n  PRIMARY KEY (`id`)\n);\n"
+	createSQL := "CREATE TABLE `appointments` (\n  `id` INT NOT NULL,\n  `start` TIME(3),\n  `factor` DOUBLE,\n  `gauge` FLOAT,\n  PRIMARY KEY (`id`)\n);\n"
 	cols := []baseline.Column{
 		{Name: "id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
 		{Name: "start", MySQLType: "time", ParquetType: baseline.MysqlToParquetNode("time")},
 		{Name: "factor", MySQLType: "double", ParquetType: baseline.MysqlToParquetNode("double")},
+		{Name: "gauge", MySQLType: "float", ParquetType: baseline.MysqlToParquetNode("float")},
 	}
 	bw, err := baseline.NewWriter(filepath.Join(parquetDir, "appointments.parquet"), cols,
 		baseline.WriterConfig{Compression: "zstd", RowGroupSize: 100,
@@ -847,11 +863,14 @@ func TestVerifyTable_TimeFspAndFloatText_IsAMatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewWriter: %v", err)
 	}
+	// Row 2's baseline gauge (2.25, mydumper text) is superseded by the
+	// in-window event's row_after below (last-write-wins) — its exact value
+	// here is irrelevant to the final reconstructed state.
 	for _, row := range [][]string{
-		{"1", "09:30:00.250", "1e16"},
-		{"2", "10:30:00.000", "2.25"},
+		{"1", "09:30:00.250", "1e16", "2.25"},
+		{"2", "10:30:00.000", "2.25", "2.25"},
 	} {
-		if err := bw.WriteRow(row, []bool{false, false, false}); err != nil {
+		if err := bw.WriteRow(row, []bool{false, false, false, false}); err != nil {
 			t.Fatalf("WriteRow: %v", err)
 		}
 	}
@@ -864,8 +883,8 @@ func TestVerifyTable_TimeFspAndFloatText_IsAMatch(t *testing.T) {
 	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{h1, h2})
 	ts1 := now.Add(-2 * time.Minute).Format("2006-01-02 15:04:05")
 	testutil.InsertEvent(t, db, "binlog.000001", 100, 200, ts1, nil, dbName, "appointments", 2 /*UPDATE*/, "2", nil,
-		[]byte(`{"id":2,"start":"10:30:00","factor":2.25}`),
-		[]byte(`{"id":2,"start":"11:00:00","factor":2.25}`))
+		[]byte(`{"id":2,"start":"10:30:00","factor":2.25,"gauge":2.25}`),
+		[]byte(`{"id":2,"start":"11:00:00","factor":2.25,"gauge":1.234567}`))
 
 	var uuid string
 	if err := db.QueryRow("SELECT @@server_uuid").Scan(&uuid); err != nil {


### PR DESCRIPTION
## What

Two conclusive false-MISMATCH classes in `bintrail verify` were pure representation gaps — same stored value, different text renderer on each side of the comparison:

- **#794 — TIME(fsp>0) with integer seconds.** go-mysql v1.13.0's `timeFormat` omits the fractional suffix entirely when the microsecond part is zero (and pads it to the declared fsp otherwise), while MySQL's text protocol and mydumper always pad: `"09:00:00"` vs `"09:00:00.000"` for TIME(3). False MISMATCH in both verify modes; TIME is not in the deferred set, so it was conclusive.
- **#795 — FLOAT/DOUBLE in live mode.** MySQL's my_gcvt text (`"1e16"`, `"0.00001"`) vs Go's strconv (`"1e+16"`, `"1e-05"`) for the same intact value → permanent conclusive MISMATCH on any table with floats outside the coinciding-render range.

## Fix

Both normalized in `normalizeRenderedBytes` (`internal/verify/render.go`) — the seam already shared symmetrically by `renderCellNormalized` (recon side) and the `ConsistentTableChecksumNormalized` hook (live-scan side), same recipe shape as the existing zero-date/JSON normalizations. Keyed by `information_schema` DATA_TYPE:

- **`time`**: trim trailing fractional zeros (and a then-empty `.`) to the minimal value-preserving form. Trim rather than pad-to-fsp because the live-scan hook carries only DATA_TYPE (no COLUMN_TYPE/fsp), and trimming also covers pre-#212 snapshots whose ColumnType is empty. Since go-mysql pads any non-zero fraction to the fsp, the omitted all-zero suffix is the only divergence; removing trailing fractional zeros can never collapse two different values.
- **`float`/`double`**: parse + reformat through Go's shortest-round-trip formatter at the column's own width (32-bit FLOAT / 64-bit DOUBLE). Distinct storable values keep distinct shortest renderings, so only representation collapses. **FLOAT/DOUBLE stay OUT of the deferred-representation set** — the documented no-masking decision in the `renderCell` contract holds; a surviving divergence is a genuine value difference and still reports as a (safe) mismatch. Unparsable bytes return unchanged and fall through to the raw byte comparison.

## Tests

Unit (`render_test.go`): normalization matrices for both types incl. anti-masking pins (distinct TIME fractions and one-ulp-apart doubles stay distinct; non-time/float dataTypes untouched; unparsable/whitespace floats untouched), plus cross-origin agreement (baseline float64 / event `json.Number` / MySQL raw text). Integration (`verify_integration_test.go`): `TestVerifyTable_TimeFspAndFloatText_IsAMatch` runs the real live-source scan — TIME(3) integer-second event image + baseline-origin DOUBLE 1e16 must MATCH, and a tampered `1.0000000000000002e16` must still MISMATCH.

Verified fail-before: with `render.go` reverted to HEAD, the new unit tests and the integration test all fail (`"1e16" != "1e+16"`, `"09:00:00" != "09:00:00.000"`, `VerifyTable` = mismatch).

```
go build ./...                                                        ok
go vet ./internal/verify/                                             ok
go test ./internal/verify/... ./internal/consistency/... -count=1    ok
go test -tags integration ./internal/verify/... ./internal/consistency/... -count=1   ok (MySQL 13306)
```

Closes #794
Closes #795

🤖 Generated with [Claude Code](https://claude.com/claude-code)
