### PR TITLE
cmd/bintrail-mcp: keep newest events when --limit truncates recover window

### DIFF
--- a/cmd/bintrail-mcp/integration_test.go
+++ b/cmd/bintrail-mcp/integration_test.go
@@ -6,8 +6,10 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -446,6 +448,60 @@ func TestRecoverTool_statementCount(t *testing.T) {
 	text := callToolText(t, result)
 	if !strings.Contains(text, "3 reversal statement(s)") {
 		t.Errorf("expected '3 reversal statement(s)' in output, got: %s", text)
+	}
+}
+
+// TestRecoverTool_limitKeepsNewestEvents pins #982 (the MCP recover tool's
+// mirror of #785/#927): when --limit truncates the matched window, the
+// reversal script must undo the most RECENT events, not the oldest prefix
+// that the missing Order="DESC" used to leave behind. Seeds 4 chained
+// UPDATEs on one row (v0→v1→v2→v3→v4) at one-minute intervals, so a
+// truncating limit=2 has an unambiguous newest-suffix (v2→v3, v3→v4) versus
+// oldest-prefix (v0→v1, v1→v2); v0/v1 appear ONLY in the oldest two events.
+func TestRecoverTool_limitKeepsNewestEvents(t *testing.T) {
+	db, _, dsn := setupTestDB(t)
+	ctx := context.Background()
+
+	base := "2026-02-19 10:00:00"
+	baseTime, err := time.Parse("2006-01-02 15:04:05", base)
+	if err != nil {
+		t.Fatalf("parse base time: %v", err)
+	}
+	for i := 1; i <= 4; i++ {
+		ts := baseTime.Add(time.Duration(i) * time.Minute).Format("2006-01-02 15:04:05")
+		before := fmt.Sprintf(`{"id":1,"v":"v%d"}`, i-1)
+		after := fmt.Sprintf(`{"id":1,"v":"v%d"}`, i)
+		testutil.InsertEvent(t, db, "mysql-bin.000001", uint64(i*100), uint64(i*100+50), ts, nil,
+			"mydb", "orders", 2 /* UPDATE */, "1",
+			[]byte(`["v"]`), []byte(before), []byte(after))
+	}
+
+	session := connectMCP(t)
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name: "recover",
+		Arguments: map[string]any{
+			"index_dsn": dsn,
+			"schema":    "mydb",
+			"table":     "orders",
+			"limit":     2,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("tool error: %s", callToolText(t, result))
+	}
+
+	text := callToolText(t, result)
+	// Newest two events are v2→v3 and v3→v4; their reversals reference v2..v4.
+	if !strings.Contains(text, `'v3'`) || !strings.Contains(text, `'v2'`) {
+		t.Errorf("expected reversals of the two NEWEST updates (v2→v3, v3→v4), got:\n%s", text)
+	}
+	// v0/v1 exist only in the oldest two events — any occurrence means the
+	// truncation kept the oldest prefix (the #982/#785 bug).
+	if strings.Contains(text, `'v0'`) || strings.Contains(text, `'v1'`) {
+		t.Errorf("script reversed the OLDEST events; --limit must keep the newest suffix of the window:\n%s", text)
 	}
 }
 

--- a/cmd/bintrail-mcp/main.go
+++ b/cmd/bintrail-mcp/main.go
@@ -464,6 +464,12 @@ func makeRecoverTool(connect connectFunc) func(context.Context, *mcp.CallToolReq
 		if err != nil {
 			return errorResult(err), nil, nil
 		}
+		// When --limit truncates the matched window it must keep the most
+		// RECENT events (#785/#927): the ASC default would keep the OLDEST
+		// prefix, undoing old events underneath later un-reverted ones — a
+		// state that never historically existed. Rows are re-sorted ascending
+		// after the fetch, before generation (see below).
+		opts.Order = "DESC"
 
 		if args.Profile != "" {
 			denyTables, redactCols, err := query.LoadProfileRules(ctx, db, args.Profile)
@@ -512,6 +518,12 @@ func makeRecoverTool(connect connectFunc) func(context.Context, *mcp.CallToolReq
 				return errorResult(err), nil, nil
 			}
 		}
+
+		// The fetch above ran Order=DESC so --limit kept the newest suffix of
+		// the window (#785/#927). Restore ascending order: GenerateSQLFromRows
+		// expects ASC input and reverses it internally to undo most-recent
+		// first.
+		rows = query.MergeResults(rows, 0, "ASC")
 
 		gen := recovery.NewForDialect(db, resolver, recovery.DialectForIndex(db))
 		var buf bytes.Buffer


### PR DESCRIPTION
## Summary

- The MCP `recover` tool's archive-merge and non-archive fetch paths in `cmd/bintrail-mcp/main.go` (`makeRecoverTool`'s closure) never set `query.Options.Order`, so it stayed at the Go zero value `""`, which `internal/query`'s `OrderDirection` treats as ASC.
- When `--limit` truncates the matched event window, the fetch/merge kept the OLDEST N events instead of the newest N. Reverting only the oldest N events of a truncated window leaves the newest events still applied, so the generated reversal script does not correspond to any historically-consistent state (e.g. a reverse UPDATE's `WHERE row_after` clause can be silently matched by 0 rows because a later un-reverted event already changed it).
- This is the same inconsistent-partial-state bug as #785, already fixed for the CLI (`internal/cli/recover.go`) via #927. This PR mirrors that fix for the MCP server:
  - Set `opts.Order = "DESC"` right after `buildQueryOptions` so `--limit` keeps the newest suffix of the matched window (`buildQueryOptions` itself is untouched — it's shared with `queryTool`, which keeps its default order behavior).
  - After the existing archive-merge/non-archive fetch branches, add one `rows = query.MergeResults(rows, 0, "ASC")` resort covering both paths before `recovery.NewForDialect(...)`/`GenerateSQLFromRows`, which expects ASC/chronological input and reverses internally to undo most-recent first.
  - The existing truncation-warning logic (`n >= opts.Limit`) is unchanged — only the ordering direction changed, not the truncation count.

closes #982

## Test plan

- [x] Added `TestRecoverTool_limitKeepsNewestEvents` in `cmd/bintrail-mcp/integration_test.go`: seeds 4 chained UPDATEs on one row (v0→v1→v2→v3→v4) at one-minute intervals, calls the `recover` tool with `limit=2`, and asserts the returned SQL contains v2/v3 (the newest suffix) and does NOT contain v0/v1 (the oldest prefix).
- [x] Verified the test is a real negative control: stashed the `main.go` fix and confirmed the new test fails (script contained `'v0'`), then restored the fix and confirmed it passes.
- [x] `go test -tags integration ./cmd/bintrail-mcp/... -run TestRecoverTool -v -count=1` — all pass (Docker MySQL on 127.0.0.1:13306).
- [x] `go test ./... -count=1` — all packages pass.
- [x] `go vet ./...` — clean.
- [x] `gofmt -l` on changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
