### PR TITLE
indexer: hard-fail the whole batch when a PK value would overflow pk_values (#944)

### DIFF
--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -151,6 +151,24 @@ func EscapePKValue(val string) string {
 	return val
 }
 
+// MaxPKValuesLen is the character-count ceiling of binlog_events.pk_values
+// (VARCHAR(512)). Measured in RUNES, not bytes: a multibyte utf8mb4 PK value
+// (e.g. a CJK VARCHAR primary key) occupies one VARCHAR(512) character per
+// rune regardless of how many UTF-8 bytes that rune takes, so a byte-length
+// check would false-trip on perfectly legal values that fit the column.
+//
+// Deliberately NOT enforced inside BuildPKValues — see internal/indexer's
+// insertBatch guard instead. BuildPKValues is also called by the BYOS
+// Parquet path (internal/byos), which writes pk_values to customer-owned
+// Parquet storage with no 512-character ceiling at all; a length check here
+// would wrongly reject valid BYOS rows that the indexed-MySQL path never
+// sees. The column is deliberately NOT widened either (see #944): moving
+// VARCHAR(512) to VARCHAR(3072)+ crosses MySQL's 1-byte/2-byte
+// length-prefix boundary, which is a full table rebuild, not an instant
+// DDL — unacceptable to trigger silently on a routine CLI invocation
+// against a large production binlog_events table.
+const MaxPKValuesLen = 512
+
 // formatPKValue renders a single PK value for BuildPKValues. []byte needs its
 // own case: since #756, metadata.MapRow hands back a BINARY/VARBINARY value as
 // []byte (routing it through marshalRow's base64-safe path instead of a raw Go

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -152,6 +152,10 @@ func (idx *Indexer) insertBatch(batch []event.Event) (int64, error) {
 	for i := range batch {
 		ev := &batch[i]
 
+		if err := checkPKValuesLength(ev.Schema, ev.Table, ev.PKValues); err != nil {
+			return 0, err
+		}
+
 		changed, err := marshalJSON(event.ChangedColumns(ev.RowBefore, ev.RowAfter))
 		if err != nil {
 			return 0, fmt.Errorf("marshal changed_columns for %s.%s: %w", ev.Schema, ev.Table, err)
@@ -191,6 +195,31 @@ func (idx *Indexer) insertBatch(batch []event.Event) (int64, error) {
 	}
 	n, _ := result.RowsAffected()
 	return n, nil
+}
+
+// checkPKValuesLength guards against a PK value that would overflow
+// binlog_events.pk_values (VARCHAR(512), event.MaxPKValuesLen). Without this
+// guard: under strict sql_mode (MySQL 8.0 default) the batch INSERT
+// hard-fails with an unhelpful Error 1406; under non-strict mode MySQL
+// silently truncates pk_values while pk_hash (a STORED generated column) is
+// computed over the truncated string and every read path binds the FULL
+// value — a permanent silent mismatch that makes the row invisible to
+// query/recover forever. This is not a new failure mode, just a clearer,
+// sql_mode-independent version of the failure strict mode already produces.
+//
+// Measured in runes (event.MaxPKValuesLen's contract), matching how VARCHAR
+// capacity is counted in characters, not bytes — a multibyte PK value must
+// not false-trip this on byte length alone.
+func checkPKValuesLength(schema, table, pkValues string) error {
+	if n := utf8.RuneCountInString(pkValues); n > event.MaxPKValuesLen {
+		return fmt.Errorf(
+			"event for %s.%s has a primary key %d characters long, exceeding the %d-character limit of binlog_events.pk_values (VARCHAR(%d)); "+
+				"this row's primary key (composite width or a wide single column) cannot be safely indexed — truncating it would silently corrupt "+
+				"the generated pk_hash and make the row permanently unrecoverable via query/recover; narrow the primary key (fewer or shorter "+
+				"columns) or contact support about a wider index schema",
+			schema, table, n, event.MaxPKValuesLen, event.MaxPKValuesLen)
+	}
+	return nil
 }
 
 // ─── Query-text enrichment (#699) ─────────────────────────────────────────────

--- a/internal/indexer/indexer_integration_test.go
+++ b/internal/indexer/indexer_integration_test.go
@@ -5,6 +5,7 @@ package indexer
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -166,5 +167,43 @@ func TestRun_contextCancellation(t *testing.T) {
 	_, err := idx.Run(ctx, events)
 	if err == nil {
 		t.Error("expected context cancellation error, got nil")
+	}
+}
+
+// TestInsertBatch_oversizedPKValues verifies the #944 hard guard: a batch
+// containing one event whose PK encoding exceeds pk_values' VARCHAR(512)
+// capacity fails the WHOLE batch with a descriptive error, rather than
+// letting MySQL truncate pk_values and silently corrupt the generated
+// pk_hash (or hard-fail with an unhelpful Error 1406 under strict sql_mode).
+func TestInsertBatch_oversizedPKValues(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	idx := New(db, 1000)
+	ts := time.Date(2026, 2, 19, 12, 0, 0, 0, time.UTC)
+	oversized := strings.Repeat("a", 513)
+	batch := []parser.Event{
+		{
+			BinlogFile: "binlog.000001", StartPos: 100, EndPos: 200,
+			Timestamp: ts, Schema: "mydb", Table: "wide_pk",
+			EventType: parser.EventInsert, PKValues: oversized,
+			RowAfter: map[string]any{"id": oversized},
+		},
+	}
+
+	_, err := idx.InsertBatch(batch)
+	if err == nil {
+		t.Fatal("expected error for oversized PK values, got nil")
+	}
+	if !strings.Contains(err.Error(), "mydb") || !strings.Contains(err.Error(), "wide_pk") {
+		t.Errorf("expected error to name schema/table, got: %v", err)
+	}
+
+	var n int
+	if scanErr := db.QueryRow("SELECT COUNT(*) FROM binlog_events").Scan(&n); scanErr != nil {
+		t.Fatalf("query failed: %v", scanErr)
+	}
+	if n != 0 {
+		t.Errorf("expected no rows inserted (whole batch aborted before INSERT), got %d", n)
 	}
 }

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -282,5 +283,42 @@ func TestNullOrUint32_nonZero(t *testing.T) {
 	got := nullOrUint32(42)
 	if got != uint32(42) {
 		t.Errorf("expected uint32(42), got %v", got)
+	}
+}
+
+// ─── checkPKValuesLength (#944) ──────────────────────────────────────────────
+
+func TestCheckPKValuesLength_multibyteAtLimit(t *testing.T) {
+	// 512 runes of a 3-byte-per-character UTF-8 string (CJK) — exactly at the
+	// rune limit, but ~1536 bytes. The guard is rune-based (matching how
+	// VARCHAR(512) counts capacity), so this must NOT trip even though its
+	// byte length is roughly 3x the limit.
+	pk := strings.Repeat("あ", 512)
+	if n := len(pk); n <= 512 {
+		t.Fatalf("test setup: expected byte length > 512, got %d", n)
+	}
+	if err := checkPKValuesLength("mydb", "orders", pk); err != nil {
+		t.Errorf("expected no error for 512 multibyte runes, got: %v", err)
+	}
+}
+
+func TestCheckPKValuesLength_asciiOverLimit(t *testing.T) {
+	// 513 ASCII runes — one over the limit, both by rune count and by byte
+	// count. Must trip, and the error must name the schema and table so an
+	// operator can find the offending source table.
+	pk := strings.Repeat("a", 513)
+	err := checkPKValuesLength("mydb", "orders", pk)
+	if err == nil {
+		t.Fatal("expected error for 513-rune ASCII PK, got nil")
+	}
+	if !strings.Contains(err.Error(), "mydb") || !strings.Contains(err.Error(), "orders") {
+		t.Errorf("expected error to name schema %q and table %q, got: %v", "mydb", "orders", err)
+	}
+}
+
+func TestCheckPKValuesLength_exactlyAtLimit(t *testing.T) {
+	pk := strings.Repeat("a", 512)
+	if err := checkPKValuesLength("mydb", "orders", pk); err != nil {
+		t.Errorf("expected no error at exactly the limit, got: %v", err)
 	}
 }


### PR DESCRIPTION
closes #944

## Summary
- `binlog_events.pk_values` is `VARCHAR(512)`, and `pk_hash` is a **STORED generated column** (`SHA2(pk_values, 256)`). A legal composite or wide single-column PK can exceed 512 characters. Under strict `sql_mode` (MySQL 8.0 default) this already hard-fails the batch INSERT with an unhelpful Error 1406. Under non-strict mode, MySQL silently truncates `pk_values`, `pk_hash` gets computed over the truncated string while the read path binds the full value — a permanent silent mismatch that makes the row invisible to `query`/`recover` forever.
- Added `event.MaxPKValuesLen = 512` in `internal/event/event.go`, documented as the character-count ceiling of `binlog_events.pk_values`, measured in **runes, not bytes**, so a multibyte utf8mb4 PK value doesn't false-trip on byte length alone.
- Added `checkPKValuesLength` in `internal/indexer/indexer.go`, called inside `insertBatch`'s per-event loop **before** the row's values are appended to the INSERT args. If `utf8.RuneCountInString(ev.PKValues)` exceeds the limit, the whole batch is aborted with an error naming the schema, table, actual rune count, and the limit, plus remediation guidance (narrow the PK, or contact support about a wider index schema). This matches the existing hard-fail precedent elsewhere in this file for structural PK/schema problems, and matches what strict `sql_mode` already does today for this exact case — so it's not a new failure mode, just a clearer, `sql_mode`-independent one with an actionable message.

## Explicit design decisions
- **Did NOT widen `pk_values`.** `VARCHAR(512)` to `VARCHAR(3072+)` crosses MySQL's 1-byte/2-byte length-prefix boundary, which is a full table rebuild, not an instant DDL. `EnsureSchema` (called by `index`/`stream`/`query`/`recover` startup) runs on every routine invocation — silently triggering a multi-minute rebuild of a large partitioned production `binlog_events` table on a routine CLI invocation would be worse than the bug, and conflicts with this project's "the binary never operates the index" red line.
- **Did NOT add the check inside `BuildPKValues`.** It's also called by the BYOS Parquet path (`internal/byos`), which writes to customer-owned Parquet storage with no 512-character ceiling at all; a check inside `BuildPKValues` would wrongly reject valid BYOS rows.
- **Skipped the optional `doctor` preflight warning** (the issue's secondary ask). Accurately estimating a table's worst-case encoded pk_values width from information_schema alone would require re-implementing formatPKValue's per-type rendering — CHARACTER_MAXIMUM_LENGTH is NULL for numeric/date/time PK columns, so an accurate estimate needs a type-based fallback table that duplicates runtime-only logic. An imperfect estimate risks false WARNs (against doctor's no-false-positive ethos) or false negatives either way. The indexer guard above is the authoritative, sql_mode-independent enforcement point and is the must-have deliverable; this is a clean scope cut, not a shortcut.

## Test plan
- [x] Unit tests pass: go test ./... -count=1 (all packages)
- [x] Integration tests pass: go test -tags integration ./internal/indexer/... -count=1, against Docker MySQL on 127.0.0.1:13306, including the new TestInsertBatch_oversizedPKValues
- [x] go vet ./... is clean
- Unit test TestCheckPKValuesLength_multibyteAtLimit specifically covers the rune-vs-byte distinction: a PK of exactly 512 multibyte (3-byte-per-char) runes does NOT trip the guard despite roughly 1536 bytes; TestCheckPKValuesLength_asciiOverLimit covers 513 ASCII runes tripping the guard with an error naming schema/table.

Generated with Claude Code
