### PR TITLE
console: fix recover/preview truncation order (#981, #967)

### DIFF
--- a/internal/console/api.go
+++ b/internal/console/api.go
@@ -58,8 +58,9 @@ type recoverRequest struct {
 	Until         string `json:"until"`
 	ChangedColumn string `json:"changed_column"`
 	// Order is accepted for request symmetry with /api/events but IGNORED by
-	// recover: handleRecover forces oldest-first (ASC) input, which the undo
-	// generator requires. A client-supplied value has no effect.
+	// recover: handleRecover forces newest-first (DESC) input so a LIMIT
+	// truncation keeps the newest suffix of the window (#981); rows are
+	// re-sorted ASC before generation. A client-supplied value has no effect.
 	Order string `json:"order"`
 	Limit int    `json:"limit"`
 }
@@ -248,19 +249,18 @@ func (s *Server) handleRecover(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Recovery requires chronological (oldest-first) input: GenerateSQLFromRows
-	// reverses internally so the most-recent event is undone first. The browsing
-	// default (DESC) would invert the undo order for a PK touched multiple times.
-	//
-	// Forcing ASC here also means a LIMIT truncation keeps the OLDEST N events,
-	// NOT the newest N -- unlike the CLI, which fixed this for #785 by fetching
-	// DESC (newest-first, so LIMIT keeps the newest suffix) then re-sorting ASC
-	// before generation. The console still has the pre-#785 bug: a truncated
-	// console recover reverses only the earliest part of the matched window,
-	// leaving the target in the same kind of inconsistent partial state #785
-	// fixed for the CLI. Not addressed here -- see #785 and #927 for context
-	// on a follow-up fix.
-	opts.Order = ""
+	// When --limit truncates the window it must keep the most RECENT events
+	// (#981, mirroring the CLI's #785 fix in internal/cli/recover.go): fetching
+	// DESC means a LIMIT truncation keeps the newest suffix, rolling the data
+	// back to a consistent intermediate point. The ASC default would instead
+	// keep the OLDEST prefix — undoing old events underneath later
+	// un-reverted ones maps to no state that ever existed (the reverse
+	// UPDATE's row_after WHERE no longer matches, or the reverse DELETE
+	// removes a row a later event rewrote). Rows are re-sorted ascending
+	// below, before generation: GenerateSQLFromRows expects chronological
+	// (ASC) input and reverses internally so the most-recent event is undone
+	// first.
+	opts.Order = "DESC"
 
 	// Coverage gaps come back in plan.GapHours and are surfaced as warnings
 	// below — the recover UI renders them, so an incomplete-coverage undo is
@@ -271,6 +271,17 @@ func (s *Server) handleRecover(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	warnings := gapWarnings(plan)
+
+	// The fetch above ran Order=DESC so the limit kept the newest suffix of
+	// the window (#981). Detect truncation on the FETCHED row count — before
+	// generation, so the warning fires even when generation later refuses —
+	// then restore ascending order for GenerateSQLFromRows and the
+	// cascade-detection logic below, both of which expect chronological input.
+	if opts.Limit > 0 && len(rows) >= opts.Limit {
+		warnings = append(warnings,
+			fmt.Sprintf("Matched events were truncated at the limit (%d); only the most recent events of the window are being reversed.", opts.Limit))
+	}
+	rows = query.MergeResults(rows, 0, "ASC")
 
 	// Per-bundle dialect (the console is multi-server): MySQLDialect covers MySQL +
 	// MariaDB, PostgresDialect a PG-flavored index. Read once and reused below.

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -1617,9 +1617,16 @@ function setSelectWhenReady(form, name, value, cb) {
 async function previewRecover(form) {
   const gen = serverGen;
   const container = $("#recover-preview", VIEW());
+  const warns = $("#recover-warnings", VIEW());
   const f = Object.fromEntries(new FormData(form).entries());
   const params = {};
   ["schema", "table", "pk", "since", "until"].forEach((k) => { if (f[k] && f[k].trim()) params[k] = f[k].trim(); });
+  // Mirror /api/recover's EFFECTIVE fetch window (#967) so the preview shows
+  // the same events the undo script will actually reverse: newest-first, same
+  // limit as recoverDefaultLimit in internal/console/api.go. Hardcoded here —
+  // there is no Go-to-JS constant-sharing mechanism in this codebase.
+  params.limit = "1000";
+  params.order = "desc";
   try {
     const data = await api("/api/events?" + new URLSearchParams(params).toString());
     if (gen !== serverGen) return;
@@ -1633,6 +1640,16 @@ async function previewRecover(form) {
     buildEventRows(rows, data.events || []);
     list.append(rows);
     container.append(list);
+    // Truncation warning (#967): more matches than the preview's limit means
+    // the actual undo script (same limit, applied server-side) may cover more
+    // events than are shown here.
+    if (data.count >= data.limit) {
+      renderWarnings(warns, [
+        "Only the newest " + data.limit + " events are shown. The actual undo script may include more if you increase the limit."
+      ]);
+    } else {
+      clear(warns);
+    }
   } catch (err) {
     if (gen !== serverGen) return;
     renderError(container, err);

--- a/internal/console/console_integration_test.go
+++ b/internal/console/console_integration_test.go
@@ -256,9 +256,20 @@ func TestIntegrationRecoverMatchesGenerator(t *testing.T) {
 		t.Errorf("second undo statement should reverse the INSERT event, got: %s", stmts[1])
 	}
 
-	// Equivalence with the generator. Recovery always fetches oldest-first
-	// (ASC, the zero value), which is exactly what the console forces for the
-	// recover path — so the two scripts must match statement-for-statement.
+	// Equivalence with the generator. The console now fetches DESC (newest
+	// first) so a LIMIT truncation keeps the most recent events (#981), then
+	// re-sorts ASC before generation — whereas the generator call below fetches
+	// ASC (oldest-first, the zero value) under the same limit. Those two
+	// orderings diverge once the match set exceeds the limit: ASC-then-cap
+	// keeps the OLDEST rows, DESC-then-cap keeps the NEWEST. They agree here
+	// only because this fixture's 2 events sit far under recoverDefaultLimit,
+	// so nothing is actually truncated on either side — this is a same-input
+	// sanity check, not a general proof of equivalence. Guard that assumption
+	// explicitly so a future larger fixture doesn't silently start comparing
+	// two different truncation windows.
+	if len(stmts) >= recoverDefaultLimit {
+		t.Fatalf("fixture has grown to %d events, at/above recoverDefaultLimit (%d); the ASC/DESC equivalence below no longer holds — rewrite this check against the console's actual DESC-then-resort behavior", len(stmts), recoverDefaultLimit)
+	}
 	var buf bytes.Buffer
 	opts := query.Options{Schema: "app", Table: "users", Order: "", Limit: recoverDefaultLimit}
 	if _, err := recovery.New(srv.cm.boot.db, srv.cm.boot.resolver).GenerateSQL(context.Background(), opts, &buf); err != nil {

--- a/internal/console/recover_cascade_integration_test.go
+++ b/internal/console/recover_cascade_integration_test.go
@@ -436,19 +436,19 @@ func TestIntegrationRecover_autoCascade_gtidScoped(t *testing.T) {
 //
 // Seeded on table "parent", in this exact chronological order, with the
 // recover request's limit set to 3:
-//  1. DELETE id=1         (rank 1 of ALL events, rank 1 of DELETEs)
-//  2. INSERT id=99, noise (rank 2 of ALL events)
-//  3. INSERT id=98, noise (rank 3 of ALL events)
-//  4. DELETE id=2         (rank 4 of ALL events — excluded by baseRows'
-//     Limit=3 cutoff — but rank 2 of DELETEs, well within a DELETE-only
-//     fetch's own Limit=3)
+//  1. DELETE id=1         (oldest — excluded by baseRows' Limit=3 cutoff,
+//     since #981 fetches DESC and keeps the NEWEST 3 of the 4 events)
+//  2. INSERT id=99, noise
+//  3. INSERT id=98, noise
+//  4. DELETE id=2         (newest — kept)
 //
-// baseRows (Limit=3, ASC, all event types) therefore contains only
-// [DELETE id=1, noise, noise] — it never sees id=2's DELETE. A DELETE-only
-// re-fetch with the same Limit=3 returns BOTH deletes. The combined recover
-// must synthesize victims ONLY for id=1's children: id=2's parent is never
-// re-created by this recover (it's outside baseRows), so synthesizing its
-// children would orphan them once FOREIGN_KEY_CHECKS is re-enabled.
+// baseRows (Limit=3, effectively newest-first under #981, all event types)
+// therefore contains only [noise, noise, DELETE id=2] — it never sees id=1's
+// DELETE. A DELETE-only re-fetch with the same Limit=3 returns BOTH deletes.
+// The combined recover must synthesize victims ONLY for id=2's children:
+// id=1's parent is never re-created by this recover (it's outside baseRows),
+// so synthesizing its children would orphan them once FOREIGN_KEY_CHECKS is
+// re-enabled.
 func TestIntegrationRecover_autoCascade_limitTruncated(t *testing.T) {
 	db, dbName := testutil.CreateTestDB(t)
 	testutil.InitIndexTables(t, db)
@@ -500,8 +500,9 @@ func TestIntegrationRecover_autoCascade_limitTruncated(t *testing.T) {
 	}
 
 	// Recover the whole table's history, capped at limit=3 — the exact numeric
-	// Limit that (pre-fix) let the internal DELETE-only parent-fetch see id=2's
-	// DELETE while baseRows' own Limit=3 cutoff never reached it.
+	// Limit that (pre-#772-fix) let the internal DELETE-only parent-fetch see
+	// id=1's DELETE even though baseRows' own Limit=3 cutoff (newest-first,
+	// #981) never reaches it.
 	rec, body := doReq(t, srv, "POST", "/api/recover",
 		`{"schema":"`+dbName+`","table":"parent","limit":3}`)
 	if rec.Code != 200 {
@@ -512,28 +513,28 @@ func TestIntegrationRecover_autoCascade_limitTruncated(t *testing.T) {
 		t.Fatalf("decode: %v (body=%s)", err, body)
 	}
 	if !resp.CascadeDetected {
-		t.Errorf("cascade_detected should be true (baseRows contains id=1's DELETE)")
+		t.Errorf("cascade_detected should be true (baseRows contains id=2's DELETE)")
 	}
 	if resp.VictimCount != 2 {
-		t.Errorf("victim_count = %d, want 2 (only id=1's children); a pre-fix regression would report 4 "+
-			"(id=2's children too, even though id=2's own parent is never re-inserted)\n---\n%s", resp.VictimCount, resp.SQL)
+		t.Errorf("victim_count = %d, want 2 (only id=2's children); a pre-fix regression would report 4 "+
+			"(id=1's children too, even though id=1's own parent is never re-inserted)\n---\n%s", resp.VictimCount, resp.SQL)
 	}
-	for _, want := range []string{"VALUES (10, 1)", "VALUES (11, 1)"} {
+	for _, want := range []string{"VALUES (20, 2)", "VALUES (21, 2)"} {
 		if !strings.Contains(resp.SQL, want) {
-			t.Errorf("SQL missing %q (id=1's own child)\n---\n%s", want, resp.SQL)
+			t.Errorf("SQL missing %q (id=2's own child)\n---\n%s", want, resp.SQL)
 		}
 	}
-	for _, notWant := range []string{"VALUES (20, 2)", "VALUES (21, 2)"} {
+	for _, notWant := range []string{"VALUES (10, 1)", "VALUES (11, 1)"} {
 		if strings.Contains(resp.SQL, notWant) {
-			t.Errorf("SQL must NOT include %q — id=2's parent fell outside baseRows' Limit-truncated "+
+			t.Errorf("SQL must NOT include %q — id=1's parent fell outside baseRows' Limit-truncated "+
 				"scope, so its children would be orphaned\n---\n%s", notWant, resp.SQL)
 		}
 	}
-	if strings.Contains(resp.SQL, "INSERT INTO `"+dbName+"`.`parent` (`id`) VALUES (2)") {
-		t.Errorf("SQL must NOT re-insert parent id=2 — it is outside this recover's Limit-truncated scope\n---\n%s", resp.SQL)
+	if strings.Contains(resp.SQL, "INSERT INTO `"+dbName+"`.`parent` (`id`) VALUES (1)") {
+		t.Errorf("SQL must NOT re-insert parent id=1 — it is outside this recover's Limit-truncated scope\n---\n%s", resp.SQL)
 	}
 	if c := strings.Count(resp.SQL, "`"+dbName+"`.`child`"); c != 2 {
-		t.Errorf("want exactly 2 child INSERTs (id=1's own), got %d\n---\n%s", c, resp.SQL)
+		t.Errorf("want exactly 2 child INSERTs (id=2's own), got %d\n---\n%s", c, resp.SQL)
 	}
 }
 

--- a/internal/console/recover_limit_integration_test.go
+++ b/internal/console/recover_limit_integration_test.go
@@ -1,0 +1,116 @@
+//go:build integration
+
+package console
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// seedRecoverLimitConsole seeds 4 chained UPDATEs on one row (v0→v1→v2→v3→v4),
+// mirroring internal/cli/recover_limit_integration_test.go's seedRecoverUpdates
+// so the two suites exercise the identical scenario across CLI and console.
+func seedRecoverLimitConsole(t *testing.T) (*Server, string) {
+	t.Helper()
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	h := time.Now().UTC().Add(-1 * time.Hour).Truncate(time.Hour)
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{h})
+	for i := 1; i <= 4; i++ {
+		ts := h.Add(time.Duration(i) * time.Minute).Format("2006-01-02 15:04:05")
+		before := fmt.Sprintf(`{"id":1,"v":"v%d"}`, i-1)
+		after := fmt.Sprintf(`{"id":1,"v":"v%d"}`, i)
+		testutil.InsertEvent(t, db, "binlog.000001", uint64(i*100), uint64(i*100+50), ts, nil,
+			dbName, "orders", 2 /*UPDATE*/, "1",
+			[]byte(`["v"]`), []byte(before), []byte(after))
+	}
+
+	srv, err := New(Config{
+		DB:        db,
+		DBName:    dbName,
+		Listen:    "127.0.0.1:8090",
+		Token:     intToken,
+		NoArchive: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return srv, dbName
+}
+
+// TestIntegrationRecover_limitKeepsNewestEvents is the console counterpart of
+// the CLI's TestRecover_limitKeepsNewestEvents (#785) for #981: POST
+// /api/recover with a truncating limit must reverse the NEWEST events of the
+// matched window, not the oldest, and must surface a truncation warning so a
+// partial-window recover is never presented as complete.
+func TestIntegrationRecover_limitKeepsNewestEvents(t *testing.T) {
+	srv, dbName := seedRecoverLimitConsole(t)
+
+	rec, body := doReq(t, srv, "POST", "/api/recover",
+		`{"schema":"`+dbName+`","table":"orders","limit":2}`)
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, body = %s", rec.Code, body)
+	}
+	var resp recoverResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("decode: %v (body=%s)", err, body)
+	}
+
+	if !strings.Contains(resp.SQL, `'v3'`) || !strings.Contains(resp.SQL, `'v2'`) {
+		t.Errorf("expected reversals of the two NEWEST updates (v2→v3, v3→v4), got:\n%s", resp.SQL)
+	}
+	// v0/v1 exist only in the oldest two events — any occurrence means the
+	// truncation kept the oldest prefix (the #981 bug).
+	if strings.Contains(resp.SQL, `'v0'`) || strings.Contains(resp.SQL, `'v1'`) {
+		t.Errorf("SQL reversed the OLDEST events; limit must keep the newest suffix of the window:\n%s", resp.SQL)
+	}
+	// Most-recent undone first: the reverse of v3→v4 (its WHERE carries 'v4')
+	// must precede the reverse of v2→v3 (its SET carries 'v2').
+	i4, i2 := strings.Index(resp.SQL, `'v4'`), strings.Index(resp.SQL, `'v2'`)
+	if i4 == -1 || i2 == -1 || i4 > i2 {
+		t.Errorf("expected the newest event's reversal first (most-recent undone first), got:\n%s", resp.SQL)
+	}
+
+	foundTruncationWarning := false
+	for _, w := range resp.Warnings {
+		if strings.Contains(strings.ToLower(w), "truncat") {
+			foundTruncationWarning = true
+			break
+		}
+	}
+	if !foundTruncationWarning {
+		t.Errorf("expected a truncation warning in the response, got warnings=%v", resp.Warnings)
+	}
+}
+
+// TestIntegrationRecover_limitNotTruncatedNoWarning pins the negative case: a
+// limit that comfortably covers the whole matched window must NOT emit a
+// truncation warning.
+func TestIntegrationRecover_limitNotTruncatedNoWarning(t *testing.T) {
+	srv, dbName := seedRecoverLimitConsole(t)
+
+	rec, body := doReq(t, srv, "POST", "/api/recover",
+		`{"schema":"`+dbName+`","table":"orders","limit":1000}`)
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, body = %s", rec.Code, body)
+	}
+	var resp recoverResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("decode: %v (body=%s)", err, body)
+	}
+
+	if !strings.Contains(resp.SQL, `'v0'`) || !strings.Contains(resp.SQL, `'v1'`) {
+		t.Errorf("expected the full window (including the oldest updates) when not truncated, got:\n%s", resp.SQL)
+	}
+	for _, w := range resp.Warnings {
+		if strings.Contains(strings.ToLower(w), "truncat") {
+			t.Errorf("did not expect a truncation warning when the limit exceeds the matched window, got warnings=%v", resp.Warnings)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- **#981**: `handleRecover` (`internal/console/api.go`) forced `opts.Order = ""` (ASC) before fetching. Combined with limit truncation (`recoverDefaultLimit=1000`/`recoverMaxLimit=10000`), this kept the OLDEST N events of the matched window instead of the newest N — reverting only the oldest N leaves the newest events still applied, so the reversal maps to no state that ever existed. This is the console counterpart of #785, already fixed for the CLI (PR #927). Fixed by fetching `Order: "DESC"` (keeping the newest suffix under truncation), then re-sorting `ASC` via `query.MergeResults(rows, 0, "ASC")` before generation and before the cascade-detection logic (both expect chronological input). Added a truncation warning to the response (`opts.Limit > 0 && len(rows) >= opts.Limit`) so a truncated recover is never silently presented as complete.
- **#967**: `previewRecover` in `internal/console/assets/app.js` GET `/api/events` with no limit/order, defaulting to newest ≤100 (DESC), while `generateUndo` POSTs `/api/recover`, which (pre-#981) used oldest ≤1000 (ASC). At >100 matches the preview showed the wrong 100; at >1100 matches the two sets were fully disjoint. Fixed by adding `limit=1000&order=desc` to the preview's `/api/events` request (matching `recoverDefaultLimit`/the post-#981 recover fetch), and by rendering a truncation warning (reusing the existing `#recover-warnings` / `renderWarnings` pattern used by `generateUndo`) when `data.count >= data.limit`.

Also updated `recover_cascade_integration_test.go`'s `TestIntegrationRecover_autoCascade_limitTruncated`: the DESC-first fetch order flips which parent DELETE survives truncation in that fixture (id=2 is now in scope instead of id=1). The underlying #772 safety property the test guards — never synthesize orphan cascade children for a parent outside `baseRows` — is unchanged; only the specific in-scope id shifted along with the truncation direction.

## Test plan

- [x] `go test ./... -count=1` — all packages pass
- [x] `go test -tags integration ./internal/console/... -count=1` (Docker MySQL on 127.0.0.1:13306) — all pass, including the new `TestIntegrationRecover_limitKeepsNewestEvents` / `TestIntegrationRecover_limitNotTruncatedNoWarning` and the updated cascade-limit test
- [x] `go vet ./...` — clean
- [ ] JS half (#967): this repo has no JS/frontend test harness (`internal/console/assets` has no `package.json`/test files — vanilla frontend, zero JS deps per CLAUDE.md), so no automated test was added for `previewRecover`. Verified by code inspection: the added `limit`/`order` params mirror the Go-side constant (`recoverDefaultLimit` in `internal/console/api.go`) and the existing `renderWarnings`/`#recover-warnings` pattern is reused unchanged. No dry-run mode or new backend endpoint was added (explicitly out of scope).

closes #981
closes #967
