### PR TITLE
docs: honesty sweep — source support, managed pointer, bundled-index backup, command table

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ before/after images in a searchable index:
 - **[MCP server](docs/mcp-server.md)** — Claude or any MCP client can search history and draft recoveries
 
 Works with **MySQL**, **Percona Server for MySQL**, **Amazon RDS for MySQL**,
-**Amazon Aurora MySQL**, and **Google Cloud SQL for MySQL** — dbtrail connects
+and **Amazon Aurora MySQL** (verified); **Google Cloud SQL for MySQL** is
+expected to work — please report issues. dbtrail connects
 over the replication protocol, so it never needs the binlog files on disk
 (that's what makes managed cloud databases work). Requires MySQL 8.0+ with
 `binlog_format=ROW` and `binlog_row_image=FULL`; `bintrail doctor` checks both
@@ -79,3 +80,8 @@ See [the demo image](docs/demo.md).
 [Apache-2.0](LICENSE) — free for any use, including commercial and production.
 Contributions welcome: see [CONTRIBUTING.md](CONTRIBUTING.md) (CLA required,
 prompted automatically on your first PR).
+
+Want the index server **operated** for you — sized, backed up, upgraded, kept
+alive on-call — instead of running it yourself? That is the managed service at
+[dbtrail.com](https://dbtrail.com). See [SUPPORT.md](SUPPORT.md) for the
+ship-vs-operate boundary.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -221,6 +221,65 @@ daemon is now `bintrail-console watch`, in its own image), so a
 and all data volumes (`bintrail-index-data`, `bintrail-index-secret`,
 `bintrail-state`, including saved console servers) carry over unchanged.
 
+### Backing up / restoring the bundled index
+
+The bundled `index-mysql` container is your forensic system of record
+(`binlog_events` with full before/after images). dbtrail **ships** this MySQL
+but does not **operate** it — backups are yours ([SUPPORT.md](../SUPPORT.md)).
+Two paths:
+
+**Logical dump (online, no downtime).** `mysqldump` runs inside the container,
+reading the generated root password from the `bintrail-index-secret` volume:
+
+```bash
+docker compose exec index-mysql sh -c \
+  'mysqldump -uroot -p"$(cat /run/secret/index_password)" \
+     --single-transaction --routines --all-databases' > index-backup.sql
+```
+
+Restore the same way (`-T` disables the pseudo-TTY so the redirected file is
+read as stdin):
+
+```bash
+docker compose exec -T index-mysql sh -c \
+  'mysql -uroot -p"$(cat /run/secret/index_password)"' < index-backup.sql
+```
+
+**Offline volume snapshot (crash-consistent).** Stop the writers first, then
+copy the datadir and its secret in **one** archive. The index password is baked
+into the datadir at first init (see the compose file header), so
+`bintrail-index-data` and `bintrail-index-secret` must always be backed up and
+restored **as a pair** — a datadir paired with a mismatched secret breaks
+authentication:
+
+```bash
+docker compose stop bintrail index-mysql
+docker run --rm --volumes-from "$(docker compose ps -aq index-mysql)" \
+  -v "$PWD":/backup alpine \
+  tar czf /backup/index-volumes.tgz /var/lib/mysql /run/secret
+docker compose start bintrail index-mysql
+```
+
+To restore that archive, bring the stack down (`docker compose down` keeps the
+named volumes), extract the tarball back into the two volumes while nothing is
+writing, then `docker compose up -d` — never reload a datadir without its
+matching secret.
+
+**Verify** either restore with `bintrail status`. The core `bintrail` binary
+lives in the core image (the console image omits it), and `index-mysql`
+publishes no host port, so run it as a throwaway container that shares
+`index-mysql`'s network and secret:
+
+```bash
+docker run --rm \
+  --network "container:$(docker compose ps -q index-mysql)" \
+  --volumes-from "$(docker compose ps -q index-mysql)" \
+  --entrypoint sh ghcr.io/dbtrail/bintrail:latest -c \
+  'bintrail status --index-dsn "root:$(cat /run/secret/index_password)@tcp(127.0.0.1:3306)/bintrail_index"'
+```
+
+A healthy index lists its servers, a recent stream position, and its partitions.
+
 ### Connecting to an external index MySQL (bring your own)
 
 To run your own index instead of the bundled 8.4, set `INDEX_DSN` in `.env` to a MySQL 8.0+ you operate and

--- a/docs/install.md
+++ b/docs/install.md
@@ -18,6 +18,10 @@ it's the first section — the same four lines as the README.
   and `SELECT`.
 - An **index MySQL 8.0+** database for dbtrail's data (the Compose stack
   bundles one).
+- **Other sources:** besides MySQL, dbtrail can also capture from **MariaDB**
+  ([alpha](./mariadb.md) — 10.6+, 11.4 is the CI-tested target) and
+  **PostgreSQL** ([beta](./postgres.md) — 14+, via the separate `bintrail-pg`
+  binary). Each has its own prerequisites; see the linked guide.
 - Go 1.25+ (the module targets `go 1.25.11`) — only when building from source. The default `GOTOOLCHAIN=auto` fetches the right toolchain for you.
 
 ## Docker Compose (the bundled default)
@@ -228,10 +232,14 @@ For cron, systemd units, and Ansible recipes, see [deployment.md](./deployment.m
 | `snapshot` | Capture table and column metadata from the source server |
 | `index` | Parse binlog files from disk and write row events to the index |
 | `stream` | Connect as a replica and index row events in real-time |
+| `agent` | Connect to dbtrail and listen for commands |
 | `query` | Search the index with flexible filters (schema, table, PK, time range, GTID) |
 | `recover` | Generate reversal SQL for matching events |
+| `recover-cascade` | Generate reversal SQL for rows hit by a foreign-key ON DELETE CASCADE / SET NULL |
 | `reconstruct` | Rebuild row state at a point in time from baselines + binlog events |
+| `verify` | Verify that a recovery would reproduce the source |
 | `rotate` | Drop old partitions, add new ones, optionally archive to Parquet |
+| `archive reconcile` | Re-sync archive_state with the Parquet files actually on disk / in S3 |
 | `status` | Show indexed files, partition sizes, and event counts |
 | `dump` | Invoke mydumper to create a logical dump of the source server |
 | `baseline` | Convert mydumper output to Parquet snapshots |
@@ -240,6 +248,9 @@ For cron, systemd units, and Ansible recipes, see [deployment.md](./deployment.m
 | `init-shim` | Generate a `shim.yaml` for the time-travel SQL shim |
 | `proxysql-config` | Generate ProxySQL setup SQL for time-travel SQL routing |
 | `shim` | Run the in-process MySQL-protocol server for `_flashback`/`_diff`/`_snapshot` queries |
+| `who-changed` | Attribute binlog row changes to the database sessions that made them |
+| `user-activity` | Show a MySQL user's recent statements from performance_schema |
+| `connection-history` | Show current connections and account history for a user or host |
 | `profile` | Manage RBAC access profiles for query and recover |
 | `flag` | Label tables and columns (e.g. `pii`, `sensitive`) for access rules |
 | `access` | Link flags to profiles with allow/deny permissions |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -80,6 +80,11 @@ export SRC="dbtrail:strong-password@tcp(127.0.0.1:3306)/"   # source MySQL
 export IDX="root:secret@tcp(127.0.0.1:3306)/binlog_index"   # the index
 ```
 
+> The example points both DSNs at one host for brevity. In production, run the
+> index on a **separate** MySQL instance — co-locating it on the source means a
+> source-disk failure takes the index down with it. See
+> [Deployment](./deployment.md#separate-server-recommended).
+
 **Start capturing changes** — one command runs the preflight, creates the index,
 snapshots the schema, and streams in real time (and rotates old partitions
 hourly):


### PR DESCRIPTION
Handles a batch of `documentation`-labeled issues. Every change is the **Occam-minimal edit that makes the docs match the code** — no code changes; over-promises corrected, gaps filled. Batched into one PR because several edit the same file (README ×2, install.md ×2), which per-issue PRs would collide on.

## Fixes

- **Closes #980** — README listed Google Cloud SQL for MySQL as equally supported next to RDS/Aurora; it has no CI smoke and no `doctor` handling. Now: RDS/Aurora *(verified)*, Cloud SQL *expected to work — please report issues*.
- **Closes #979** — install.md Requirements was MySQL-only. Adds one bullet noting MariaDB (alpha, 10.6+/11.4 CI target, `docs/mariadb.md`) and PostgreSQL (beta, 14+, via `bintrail-pg`, `docs/postgres.md`). Version floors verified against those docs.
- **Closes #978** — quickstart co-located the index on the source with no caveat. Adds a callout linking `deployment.md#separate-server-recommended`.
- **Closes #977** — README license section dead-ended. Adds a low-key, aseptic pointer to the managed option (dbtrail.com) + the ship-vs-operate boundary in SUPPORT.md.
- **Closes #974** — docker.md said "back up the two volumes together" with no command. Adds a runnable backup/restore section: in-container `mysqldump` reading the secret, offline volume snapshot as a **data+secret pair**, and `bintrail status` verification. Service/volume/DB names (`index-mysql`, `bintrail-index-data`, `bintrail-index-secret`, `bintrail_index`) and the core image tag (`ghcr.io/dbtrail/bintrail:latest`) verified against `docker-compose.yml` + `.goreleaser.yaml`.
- **Closes #955** — install.md "Every command" table omitted 7 shipped commands; adds `agent`, `recover-cascade`, `verify`, `archive reconcile`, `who-changed`, `user-activity`, `connection-history`.

## Not in this PR

Six sibling `documentation` issues (#856, #836, #825, #796, #787, #814) turned out to be **already fixed in-tree and left open** — closed separately with the code/doc line references as evidence, no change needed.

Docs-only; no CHANGELOG entry (house pattern reconstructs it at release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
