### PR TITLE
console: embed a MySQL-protocol time-travel shim in `watch` (#996)

### DIFF
--- a/cmd/bintrail-console/flashback.go
+++ b/cmd/bintrail-console/flashback.go
@@ -1,0 +1,362 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"sync"
+	"time"
+
+	gomysql "github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/go-mysql-org/go-mysql/server"
+
+	"github.com/dbtrail/dbtrail/internal/console"
+	"github.com/dbtrail/dbtrail/internal/shim"
+)
+
+// This file is the MySQL-protocol serving layer for the embedded time-travel
+// port (issue #996). It lives in the binary — NOT in internal/console — because
+// it links go-mysql and internal/shim, which the read-layer guard (#528,
+// TestReadLayerDoesNotLinkGoMySQL) bars from internal/console. It consumes the
+// go-mysql-free seam console.Server exposes (Token, ResolveFlashback).
+
+// flashbackConfig tunes the embedded time-travel port. The zero value is the
+// production default: strict (a coverage gap / archive-fetch failure aborts the
+// client's query), a 5-minute per-query deadline, and at most 4 concurrent
+// full-table reconstructions.
+type flashbackConfig struct {
+	// AllowGaps mirrors shim.Config.AllowGaps: false (default) fails a query
+	// loudly on a coverage gap / archive failure; true downgrades to a
+	// server-side warning and returns partial rows.
+	AllowGaps bool
+	// QueryTimeout bounds each time-travel query end-to-end. It is the ONLY
+	// backstop against a runaway query on a dropped connection here — unlike the
+	// standalone shim, the embedded port runs no client-disconnect detection
+	// pump — so it must never be 0. withDefaults substitutes the 5-minute
+	// default when this is 0.
+	QueryTimeout time.Duration
+	// MaxFullTable caps concurrent full-table reconstructions across every
+	// connection of this port (0 → 4, the standalone default): a shared gate,
+	// exactly like the standalone shim's --max-fulltable-queries.
+	MaxFullTable int
+	// AuthMethod selects the MySQL auth plugin the port advertises. Empty
+	// (default) keeps mysql_native_password; see shim.NewMySQLServer for values.
+	AuthMethod string
+}
+
+const (
+	defaultFlashbackQueryTimeout = 5 * time.Minute
+	defaultFlashbackMaxFullTable = 4
+)
+
+// withDefaults resolves the zero-value fields to their production defaults.
+// QueryTimeout is the load-bearing one: 0 means "unbounded", but the embedded
+// port has no client-disconnect pump, so a runaway query on a dropped
+// connection would never be reclaimed — the 5-minute default is the only
+// backstop. serveFlashback always calls this, so the dangerous zero never
+// reaches the query path; keeping both substitutions here (rather than one
+// inline and one in a side variable) is why they can't drift apart.
+func (c flashbackConfig) withDefaults() flashbackConfig {
+	if c.QueryTimeout == 0 {
+		c.QueryTimeout = defaultFlashbackQueryTimeout
+	}
+	if c.MaxFullTable == 0 {
+		c.MaxFullTable = defaultFlashbackMaxFullTable
+	}
+	return c
+}
+
+// serveFlashback runs a MySQL-protocol time-travel server on ln, routing every
+// connection to a monitored server's per-source index by the connection's
+// USERNAME (issue #996). Reuse of the console's already-resolved connManager
+// (via console.Server.ResolveFlashback) is the whole point: `_flashback` /
+// `_snapshot` / `_diff` resolve against the same per-source index + baseline the
+// console's Time-travel tab shows, with no separate container and no hand-built
+// INDEX_DSN.
+//
+// Routing: the MySQL username selects the target server — its registry ID, its
+// display Name, or "default" for the command-line boot entry. The console's
+// static --token is the shared password for every server (the operator can see
+// all servers in the UI, so server selection is not a security boundary; the
+// token is). The client therefore connects as, e.g., `-u <server-id> -p<token>`.
+//
+// Auth requires a token: go-mysql validates the handshake by recomputing the
+// scramble from the cleartext GetCredential returns (the
+// compareNativePasswordAuthData path in go-mysql v1.13.0 server/auth.go), and
+// the console's bcrypt password store cannot produce that cleartext. Callers
+// that leave --token empty get an error here rather than an unauthenticated port.
+//
+// Blocks until ctx is cancelled (which closes ln and drains in-flight
+// connections) or ln fails unrecoverably.
+func serveFlashback(ctx context.Context, srv *console.Server, ln net.Listener, cfg flashbackConfig) error {
+	if srv.Token() == "" {
+		return errors.New("flashback port requires an automation token: set --token or BINTRAIL_CONSOLE_TOKEN (the console password store cannot drive MySQL-protocol authentication)")
+	}
+	cfg = cfg.withDefaults()
+
+	// One *server.Server for the whole port: it owns the caching_sha2_password
+	// cache and the RSA keypair (see shim.NewMySQLServer). One shared *Gate so
+	// the full-table cap is process-wide, not per-connection.
+	mysrv, err := shim.NewMySQLServer(cfg.AuthMethod)
+	if err != nil {
+		// ln is already bound by the caller; close it so a construction failure
+		// (an unsupported auth method) doesn't leak the listener nor leave the
+		// caller's "listening" banner pointing at a port that rejects every
+		// handshake. Unreachable from `watch` today (it passes an empty
+		// AuthMethod), but a latent trap if a --flashback-auth-method flag lands.
+		_ = ln.Close()
+		return fmt.Errorf("flashback: %w", err)
+	}
+	gate := shim.NewGate(cfg.MaxFullTable)
+	creds := flashbackCreds{srv: srv}
+	logger := slog.Default()
+
+	// Close the listener when the daemon context ends so Accept unblocks and
+	// the loop returns; the deferred wg.Wait then drains open connections.
+	go func() {
+		<-ctx.Done()
+		_ = ln.Close()
+	}()
+
+	// No per-connection cap (the standalone shim's --max-connections has no
+	// equivalent here): this is a loopback-default, token-gated operator port,
+	// and the shared FullTableGate already bounds the memory-heavy queries.
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	var backoff time.Duration
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			if ctx.Err() != nil || errors.Is(err, net.ErrClosed) {
+				return nil // graceful shutdown
+			}
+			backoff = nextFlashbackBackoff(backoff)
+			logger.Error("flashback accept failed", "err", err, "backoff", backoff)
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-time.After(backoff):
+			}
+			continue
+		}
+		backoff = 0
+		wg.Add(1)
+		go func(c net.Conn) {
+			defer wg.Done()
+			handleFlashbackConn(ctx, srv, c, mysrv, creds, gate, cfg, logger)
+		}(conn)
+	}
+}
+
+// handleFlashbackConn performs the handshake, then binds the connection's
+// Handler to the server the authenticated username selects. The Handler cannot
+// be built before the handshake — the username is only known afterwards, yet
+// go-mysql binds the Handler at construction — so a routingHandler proxy is
+// passed to NewCustomizedConn and its inner *shim.Handler is set once GetUser()
+// reveals the target. Commands are dispatched sequentially in this goroutine
+// strictly after that, so no synchronisation is needed.
+func handleFlashbackConn(ctx context.Context, srv *console.Server, c net.Conn, mysrv *server.Server, creds server.CredentialProvider, gate *shim.Gate, cfg flashbackConfig, logger *slog.Logger) {
+	defer c.Close()
+
+	// Cancel + close the socket when the daemon context dies (SIGTERM) or this
+	// goroutine returns, so a graceful shutdown and a stalled handshake can't
+	// wedge serveFlashback's wg.Wait. BindConnContext(connCtx) below ties any
+	// in-flight fetch to the same context, so shutdown also aborts a running
+	// query — QueryTimeout remains the backstop for a client that simply
+	// disappears mid-query without a shutdown signal.
+	connCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	stopCloser := context.AfterFunc(connCtx, func() { _ = c.Close() })
+	defer stopCloser()
+
+	proxy := &routingHandler{}
+	mysqlConn, err := server.NewCustomizedConn(c, mysrv, creds, proxy)
+	if err != nil {
+		level := slog.LevelWarn
+		if isFlashbackProbe(err) {
+			// Bare TCP probes (health checks, port scanners) close before the
+			// handshake completes; don't log those at WARN.
+			level = slog.LevelDebug
+		}
+		logger.Log(context.Background(), level, "flashback handshake failed", "err", err, "remote", c.RemoteAddr())
+		return
+	}
+
+	if err := bindFlashbackHandler(connCtx, srv, proxy, mysqlConn.GetUser(), gate, cfg, logger); err != nil {
+		// Auth already succeeded; surface the routing failure on the client's
+		// first query (a typed MySQL error) rather than a bare disconnect.
+		proxy.fail = err
+	}
+
+	for {
+		if err := mysqlConn.HandleCommand(); err != nil {
+			if !errors.Is(err, net.ErrClosed) {
+				logger.Debug("flashback connection ended", "err", err, "remote", c.RemoteAddr())
+			}
+			return
+		}
+	}
+}
+
+// bindFlashbackHandler resolves the target server from the authenticated
+// username (via the console's go-mysql-free seam) and wires proxy.inner to a
+// shim.Handler bound to that server's per-source index + baseline. A returned
+// error is a typed *mysql.MyError the caller stores on the proxy so the client
+// sees it on the first query.
+func bindFlashbackHandler(ctx context.Context, srv *console.Server, proxy *routingHandler, user string, gate *shim.Gate, cfg flashbackConfig, logger *slog.Logger) error {
+	tgt, err := srv.ResolveFlashback(ctx, user)
+	if err != nil {
+		if errors.Is(err, console.ErrUnknownServer) {
+			// Auth is the token alone (CheckUsername accepts any username), so an
+			// unknown or typo'd server name is the normal way we land here —
+			// report it as a missing database on the client's first query.
+			return gomysql.NewError(gomysql.ER_BAD_DB_ERROR, fmt.Sprintf("flashback: no such server %q", user))
+		}
+		// The connManager already scrubbed DSN secrets from the open error.
+		return gomysql.NewError(gomysql.ER_UNKNOWN_ERROR, fmt.Sprintf("flashback: cannot open server %q: %s", user, err))
+	}
+
+	shimCfg := shim.Config{
+		IndexDBName:   tgt.IndexDBName,
+		NoArchive:     tgt.NoArchive,
+		AllowGaps:     cfg.AllowGaps,
+		QueryTimeout:  cfg.QueryTimeout,
+		FullTableGate: gate,
+		AuthMethod:    cfg.AuthMethod,
+		// Already split by scheme and dir-preferred by ResolveFlashback so
+		// `_snapshot` matches the console's Time-travel tab.
+		BaselineDir: tgt.BaselineDir,
+		BaselineS3:  tgt.BaselineS3,
+	}
+
+	h := shim.NewHandlerWithConfig(tgt.IndexDB, shimCfg, logger)
+	h.BindConnContext(ctx)
+	// Seed the source schema so fully qualified `_flashback.<table>` queries
+	// work without a prior `USE <db>` (mirrors the standalone shim's #263
+	// behaviour). Best-effort: the boot entry has no registry SourceDSN.
+	if tgt.DefaultSchema != "" {
+		_ = h.UseDB(tgt.DefaultSchema)
+	}
+	// A default schema the client sent in the handshake (CLIENT_CONNECT_WITH_DB,
+	// stashed on the proxy before inner was bound) wins over the SourceDSN seed,
+	// matching the standalone shim where an explicit client USE overrides the
+	// #263 seed.
+	if proxy.pendingDB != "" {
+		_ = h.UseDB(proxy.pendingDB)
+	}
+	proxy.inner = h
+	return nil
+}
+
+// flashbackCreds authenticates the flashback port on the shared console token
+// alone: every username is accepted at the handshake (so the error code cannot
+// enumerate servers), and the target server is validated AFTER the handshake in
+// bindFlashbackHandler via console.Server.ResolveFlashback. It reads srv.Token()
+// live rather than snapshotting it.
+type flashbackCreds struct {
+	srv *console.Server
+}
+
+// CheckUsername accepts any username: authentication is the shared token, and
+// the target server is validated AFTER the handshake (bindFlashbackHandler).
+// Deciding validity here would leak which usernames name a real server through
+// the handshake's error code (unknown-user vs bad-password), letting an
+// unauthenticated client enumerate monitored servers. Returns false only when
+// no token is configured — a uniform denial of every connection.
+func (f flashbackCreds) CheckUsername(username string) (bool, error) {
+	return f.srv.Token() != "", nil
+}
+
+// GetCredential returns the shared console token for every username, so auth
+// turns on the token alone. found=false on an empty token is defence in depth
+// behind serveFlashback's startup guard: an empty token must never authorise a
+// passwordless MySQL handshake.
+func (f flashbackCreds) GetCredential(username string) (password string, found bool, err error) {
+	if f.srv.Token() == "" {
+		return "", false, nil
+	}
+	return f.srv.Token(), true, nil
+}
+
+// routingHandler is the go-mysql Handler passed to NewCustomizedConn before the
+// authenticated username (and thus the target server) is known. Its inner
+// *shim.Handler is set by bindFlashbackHandler once the handshake completes; if
+// routing failed, fail carries the typed error returned on the first command.
+// server.EmptyHandler supplies the commands shim.Handler itself does not
+// implement (field-list, prepared statements) — identical to a bare
+// shim.Handler, which embeds the same EmptyHandler.
+type routingHandler struct {
+	server.EmptyHandler
+	inner *shim.Handler
+	fail  error
+	// pendingDB holds a default schema the client sent in the handshake
+	// (CLIENT_CONNECT_WITH_DB): go-mysql invokes UseDB DURING the handshake,
+	// before bindFlashbackHandler binds inner. Stashing it (and returning nil)
+	// lets the handshake complete instead of failing it; bindFlashbackHandler
+	// replays it onto the real handler. Without this, any client that connects
+	// with a default schema (mysql -D, a DSN /db path, JDBC) is rejected before
+	// auth even runs.
+	pendingDB string
+}
+
+func (r *routingHandler) UseDB(dbName string) error {
+	switch {
+	case r.inner != nil:
+		return r.inner.UseDB(dbName)
+	case r.fail != nil:
+		// Routing failed after the handshake; reject a later USE too so the
+		// failure is consistent across commands.
+		return r.fail
+	default:
+		// Pre-bind: go-mysql calls UseDB during the handshake, before inner is
+		// set. Stash it (bindFlashbackHandler replays it) and let the handshake
+		// complete rather than aborting the connection.
+		r.pendingDB = dbName
+		return nil
+	}
+}
+
+func (r *routingHandler) HandleQuery(query string) (*gomysql.Result, error) {
+	if r.inner == nil {
+		return nil, r.unresolved()
+	}
+	return r.inner.HandleQuery(query)
+}
+
+func (r *routingHandler) unresolved() error {
+	if r.fail != nil {
+		return r.fail
+	}
+	return gomysql.NewError(gomysql.ER_UNKNOWN_ERROR, "flashback: no server bound to this connection")
+}
+
+// isFlashbackProbe reports whether a handshake error is a bare TCP probe
+// (health check / port scan) that closed before completing — logged at Debug
+// rather than Warn. Mirrors the `bintrail shim` command's classifyHandshakeErr
+// probe arm (internal/cli/shim.go) without the ProxySQL-monitor aggregator,
+// which does not apply to an embedded loopback port.
+func isFlashbackProbe(err error) bool {
+	return errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, gomysql.ErrBadConn)
+}
+
+const (
+	initialFlashbackBackoff = 100 * time.Millisecond
+	maxFlashbackBackoff     = 5 * time.Second
+)
+
+// nextFlashbackBackoff doubles the accept-retry sleep up to a cap; the zero
+// value seeds the first retry. Keeps a wedged listener from spinning the CPU or
+// flooding the log without delaying a SIGTERM more than the cap.
+func nextFlashbackBackoff(current time.Duration) time.Duration {
+	if current <= 0 {
+		return initialFlashbackBackoff
+	}
+	if next := current * 2; next < maxFlashbackBackoff {
+		return next
+	}
+	return maxFlashbackBackoff
+}

--- a/cmd/bintrail-console/flashback_integration_test.go
+++ b/cmd/bintrail-console/flashback_integration_test.go
@@ -1,6 +1,6 @@
 //go:build integration
 
-package console
+package main
 
 import (
 	"context"
@@ -12,6 +12,7 @@ import (
 
 	_ "github.com/go-sql-driver/mysql"
 
+	"github.com/dbtrail/dbtrail/internal/console"
 	"github.com/dbtrail/dbtrail/internal/indexer"
 	"github.com/dbtrail/dbtrail/internal/testutil"
 )
@@ -44,10 +45,10 @@ func seedFlashbackIndex(t *testing.T, name string, now time.Time) string {
 }
 
 // TestIntegrationFlashbackRoutesByServer proves the issue's acceptance criterion
-// 2: one embedded time-travel port, the same _flashback query, routed to two
-// monitored servers by the connection username, returns each server's own
-// per-source index data (#996). Auth is the shared console token; selection is
-// the username (registry id OR display name).
+// 2: one embedded time-travel port (serveFlashback), the same _flashback query,
+// routed to two monitored servers by the connection username, returns each
+// server's own per-source index data (#996). Auth is the shared console token;
+// selection is the username (registry id OR display name).
 func TestIntegrationFlashbackRoutesByServer(t *testing.T) {
 	testutil.SkipIfNoMySQL(t)
 	now := time.Now().UTC().Truncate(time.Hour)
@@ -55,22 +56,22 @@ func TestIntegrationFlashbackRoutesByServer(t *testing.T) {
 	dsnA := seedFlashbackIndex(t, "alice", now)
 	dsnB := seedFlashbackIndex(t, "bob", now)
 
-	reg, err := LoadRegistry(t.TempDir() + "/servers.yaml")
+	reg, err := console.LoadRegistry(t.TempDir() + "/servers.yaml")
 	if err != nil {
 		t.Fatal(err)
 	}
 	// NoArchive keeps _flashback index-only (no archive_state planner path);
 	// SourceDSN seeds the default schema so the wire client needs no USE.
-	entA, err := reg.Add(ServerEntry{Name: "srva", DSN: dsnA, SourceDSN: "r:p@tcp(x:3306)/myapp", NoArchive: true})
+	entA, err := reg.Add(console.ServerEntry{Name: "srva", DSN: dsnA, SourceDSN: "r:p@tcp(x:3306)/myapp", NoArchive: true})
 	if err != nil {
 		t.Fatal(err)
 	}
-	entB, err := reg.Add(ServerEntry{Name: "srvb", DSN: dsnB, SourceDSN: "r:p@tcp(x:3306)/myapp", NoArchive: true})
+	entB, err := reg.Add(console.ServerEntry{Name: "srvb", DSN: dsnB, SourceDSN: "r:p@tcp(x:3306)/myapp", NoArchive: true})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	srv, err := New(Config{Listen: "127.0.0.1:0", Token: "tok", Registry: reg})
+	srv, err := console.New(console.Config{Listen: "127.0.0.1:0", Token: "tok", Registry: reg})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,7 +82,7 @@ func TestIntegrationFlashbackRoutesByServer(t *testing.T) {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	served := make(chan struct{})
-	go func() { _ = srv.ServeFlashback(ctx, ln, FlashbackConfig{}); close(served) }()
+	go func() { _ = serveFlashback(ctx, srv, ln, flashbackConfig{}); close(served) }()
 	defer func() { cancel(); <-served }()
 
 	asOf := now.Add(10 * time.Minute).Format("2006-01-02 15:04:05")
@@ -106,7 +107,7 @@ func TestIntegrationFlashbackRoutesByServer(t *testing.T) {
 	// data is). This fails two ways if the code regresses: a rejected handshake
 	// (pre-bind UseDB not stashed) or the decoy schema winning (replay dropped),
 	// either of which returns no rows instead of "alice".
-	entC, err := reg.Add(ServerEntry{Name: "srvc", DSN: dsnA, SourceDSN: "r:p@tcp(x:3306)/decoyschema", NoArchive: true})
+	entC, err := reg.Add(console.ServerEntry{Name: "srvc", DSN: dsnA, SourceDSN: "r:p@tcp(x:3306)/decoyschema", NoArchive: true})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/bintrail-console/flashback_test.go
+++ b/cmd/bintrail-console/flashback_test.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"context"
+	"net"
 	"strings"
 	"testing"
 	"time"
 
+	gomysql "github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/spf13/cobra"
 
 	"github.com/dbtrail/dbtrail/internal/console"
@@ -13,6 +15,143 @@ import (
 
 // This file mutates up* package globals via save-and-restore. DO NOT add
 // t.Parallel() here — see watch_test.go's note.
+
+// newFlashbackConsole builds a console.Server with the given token for the
+// serving-layer tests (creds, serveFlashback). A loopback listen keeps a
+// no-token server legal (first-run setup).
+func newFlashbackConsole(t *testing.T, token string) *console.Server {
+	t.Helper()
+	srv, err := console.New(console.Config{Listen: "127.0.0.1:0", Token: token})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return srv
+}
+
+// TestFlashbackCreds: auth is the token alone. Every username — known or not —
+// gets the same token, so the handshake error code cannot leak which usernames
+// name a real server. An empty token uniformly denies.
+func TestFlashbackCreds(t *testing.T) {
+	creds := flashbackCreds{srv: newFlashbackConsole(t, "sekret")}
+	for _, u := range []string{"someid", "alpha", "", "ghost"} {
+		if ok, _ := creds.CheckUsername(u); !ok {
+			t.Fatalf("CheckUsername(%q) = false, want true (token-only auth)", u)
+		}
+		if pw, found, _ := creds.GetCredential(u); !found || pw != "sekret" {
+			t.Fatalf("GetCredential(%q) = (%q,%v), want (sekret,true)", u, pw, found)
+		}
+	}
+	credsNoTok := flashbackCreds{srv: newFlashbackConsole(t, "")}
+	if ok, _ := credsNoTok.CheckUsername("x"); ok {
+		t.Fatal("no token: CheckUsername must deny")
+	}
+	if _, found, _ := credsNoTok.GetCredential("x"); found {
+		t.Fatal("no token must never authorise a passwordless handshake")
+	}
+}
+
+// TestRoutingHandlerUnresolved: with no bound handler, HandleQuery errors
+// generically; once routing has set a fail, BOTH verbs return it verbatim.
+func TestRoutingHandlerUnresolved(t *testing.T) {
+	r := &routingHandler{}
+	if _, err := r.HandleQuery("SELECT 1"); err == nil {
+		t.Fatal("HandleQuery with nil inner must error")
+	}
+	want := gomysql.NewError(gomysql.ER_BAD_DB_ERROR, "boom")
+	r.fail = want
+	if _, err := r.HandleQuery("SELECT 1"); err != want {
+		t.Fatalf("HandleQuery returned %v, want the stored fail", err)
+	}
+	if err := r.UseDB("x"); err != want {
+		t.Fatalf("UseDB returned %v, want the stored fail (unresolvable connection must reject USE too)", err)
+	}
+}
+
+// TestRoutingHandlerPendingDB: a UseDB before inner is bound (the go-mysql
+// handshake path) is stashed and does not fail the connection.
+func TestRoutingHandlerPendingDB(t *testing.T) {
+	r := &routingHandler{}
+	if err := r.UseDB("shopdb"); err != nil {
+		t.Fatalf("pre-bind UseDB must not error (handshake would abort): %v", err)
+	}
+	if r.pendingDB != "shopdb" {
+		t.Fatalf("pendingDB = %q, want shopdb", r.pendingDB)
+	}
+}
+
+// TestFlashbackConfigWithDefaults pins the zero→default substitution — notably
+// QueryTimeout, which must never reach the query path as 0 (the only runaway
+// backstop) — and that explicit values are preserved.
+func TestFlashbackConfigWithDefaults(t *testing.T) {
+	got := flashbackConfig{}.withDefaults()
+	if got.QueryTimeout != defaultFlashbackQueryTimeout {
+		t.Fatalf("QueryTimeout default = %v, want %v", got.QueryTimeout, defaultFlashbackQueryTimeout)
+	}
+	if got.MaxFullTable != defaultFlashbackMaxFullTable {
+		t.Fatalf("MaxFullTable default = %d, want %d", got.MaxFullTable, defaultFlashbackMaxFullTable)
+	}
+	custom := flashbackConfig{QueryTimeout: time.Second, MaxFullTable: 9}.withDefaults()
+	if custom.QueryTimeout != time.Second || custom.MaxFullTable != 9 {
+		t.Fatalf("explicit values overwritten: %+v", custom)
+	}
+}
+
+// TestServeFlashbackRequiresToken: the port refuses to start without a token,
+// since MySQL-protocol auth cannot be driven by the bcrypt password store.
+func TestServeFlashbackRequiresToken(t *testing.T) {
+	err := serveFlashback(context.Background(), newFlashbackConsole(t, ""), nil, flashbackConfig{})
+	if err == nil || !strings.Contains(err.Error(), "token") {
+		t.Fatalf("empty token: err = %v, want a token-required error", err)
+	}
+}
+
+// TestServeFlashbackDrainsActiveConn: serveFlashback returns only after an
+// IN-FLIGHT connection has drained when ctx is cancelled — pinning the
+// wg.Add/wg.Wait drain (a naive no-connection test would pass even without it).
+func TestServeFlashbackDrainsActiveConn(t *testing.T) {
+	srv := newFlashbackConsole(t, "tok")
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- serveFlashback(ctx, srv, ln, flashbackConfig{}) }()
+
+	// Read the server's handshake greeting to confirm the accept loop spawned an
+	// in-flight handler goroutine (wg > 0) before cancelling.
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	if _, err := conn.Read(make([]byte, 1)); err != nil {
+		t.Fatalf("expected a handshake greeting from the flashback port: %v", err)
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("serveFlashback did not drain the in-flight connection on ctx cancel")
+	}
+}
+
+func TestNextFlashbackBackoff(t *testing.T) {
+	if got := nextFlashbackBackoff(0); got != initialFlashbackBackoff {
+		t.Fatalf("seed = %v, want %v", got, initialFlashbackBackoff)
+	}
+	if got := nextFlashbackBackoff(initialFlashbackBackoff); got != 2*initialFlashbackBackoff {
+		t.Fatalf("double = %v, want %v", got, 2*initialFlashbackBackoff)
+	}
+	if got := nextFlashbackBackoff(maxFlashbackBackoff); got != maxFlashbackBackoff {
+		t.Fatalf("at cap = %v, want %v", got, maxFlashbackBackoff)
+	}
+	if got := nextFlashbackBackoff(4 * time.Second); got != maxFlashbackBackoff {
+		t.Fatalf("past cap = %v, want %v", got, maxFlashbackBackoff)
+	}
+}
 
 // TestStartFlashbackPortDisabled: an empty --flashback-listen is a no-op that
 // returns a usable drain func (callers defer it unconditionally).

--- a/cmd/bintrail-console/flashback_test.go
+++ b/cmd/bintrail-console/flashback_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dbtrail/dbtrail/internal/console"
+)
+
+// This file mutates up* package globals via save-and-restore. DO NOT add
+// t.Parallel() here — see watch_test.go's note.
+
+// TestStartFlashbackPortDisabled: an empty --flashback-listen is a no-op that
+// returns a usable drain func (callers defer it unconditionally).
+func TestStartFlashbackPortDisabled(t *testing.T) {
+	saved := upConsoleFlashbackListen
+	t.Cleanup(func() { upConsoleFlashbackListen = saved })
+
+	upConsoleFlashbackListen = ""
+	srv, err := console.New(console.Config{Listen: "127.0.0.1:0", Token: "tok"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	stop, err := startFlashbackPort(context.Background(), srv)
+	if err != nil {
+		t.Fatalf("disabled port must not error: %v", err)
+	}
+	stop() // must be safe to call
+}
+
+// TestStartFlashbackPortRequiresToken: enabling the port without a console token
+// fails fast (MySQL-protocol auth cannot use the bcrypt password store).
+func TestStartFlashbackPortRequiresToken(t *testing.T) {
+	saved := upConsoleFlashbackListen
+	t.Cleanup(func() { upConsoleFlashbackListen = saved })
+
+	upConsoleFlashbackListen = "127.0.0.1:0"
+	// A loopback bind with no token is legal for the console (first-run setup),
+	// so New succeeds — but the flashback port must refuse it.
+	srv, err := console.New(console.Config{Listen: "127.0.0.1:0"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if srv.Token() != "" {
+		t.Fatal("precondition: expected an empty token")
+	}
+	_, err = startFlashbackPort(context.Background(), srv)
+	if err == nil || !strings.Contains(err.Error(), "token") {
+		t.Fatalf("no token: err = %v, want a token-required error", err)
+	}
+}
+
+// TestStartFlashbackPortBindAndDrain: the enabled port binds, serves on the
+// daemon context, and the returned drain func returns once ctx is cancelled —
+// pinning the shutdown-ordering contract (drain before the deferred db.Close)
+// against a regression that would hang the daemon.
+func TestStartFlashbackPortBindAndDrain(t *testing.T) {
+	saved := upConsoleFlashbackListen
+	t.Cleanup(func() { upConsoleFlashbackListen = saved })
+
+	upConsoleFlashbackListen = "127.0.0.1:0" // ephemeral
+	srv, err := console.New(console.Config{Listen: "127.0.0.1:0", Token: "tok"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	stop, err := startFlashbackPort(ctx, srv)
+	if err != nil {
+		t.Fatalf("bind failed: %v", err)
+	}
+
+	cancel() // daemon shutdown → ServeFlashback closes the listener and returns
+	drained := make(chan struct{})
+	go func() { stop(); close(drained) }()
+	select {
+	case <-drained:
+	case <-time.After(5 * time.Second):
+		t.Fatal("flashback drain did not return after ctx cancel (shutdown would hang)")
+	}
+}
+
+// TestResolveFlashbackEnv locks the --flashback-listen env fallback and its
+// flag > env precedence, guarding the Changed("flashback-listen") string against
+// a rename that would silently let the env override an explicit flag.
+func TestResolveFlashbackEnv(t *testing.T) {
+	saved := upConsoleFlashbackListen
+	t.Cleanup(func() { upConsoleFlashbackListen = saved })
+
+	if watchCmd.Flags().Lookup("flashback-listen") == nil {
+		t.Fatal("flag --flashback-listen not registered on watchCmd; resolveUpConsoleEnv's Changed would always be false")
+	}
+
+	newCmd := func() *cobra.Command {
+		cmd := &cobra.Command{}
+		cmd.Flags().StringVar(&upConsoleFlashbackListen, "flashback-listen", "", "")
+		return cmd
+	}
+
+	t.Setenv("BINTRAIL_CONSOLE_FLASHBACK_LISTEN", "127.0.0.1:3308")
+
+	// No flag set → env applies.
+	upConsoleFlashbackListen = ""
+	resolveUpConsoleEnv(newCmd())
+	if upConsoleFlashbackListen != "127.0.0.1:3308" {
+		t.Fatalf("env fallback: got %q, want 127.0.0.1:3308", upConsoleFlashbackListen)
+	}
+
+	// Explicit flag wins over env.
+	upConsoleFlashbackListen = "127.0.0.1:9000"
+	cmd := newCmd()
+	if err := cmd.Flags().Set("flashback-listen", "127.0.0.1:9000"); err != nil {
+		t.Fatal(err)
+	}
+	resolveUpConsoleEnv(cmd)
+	if upConsoleFlashbackListen != "127.0.0.1:9000" {
+		t.Fatalf("flag precedence: got %q, want 127.0.0.1:9000 (env leaked over an explicit flag)", upConsoleFlashbackListen)
+	}
+}

--- a/cmd/bintrail-console/watch.go
+++ b/cmd/bintrail-console/watch.go
@@ -476,7 +476,7 @@ func startFlashbackPort(ctx context.Context, srv *console.Server) (func(), error
 	}
 	done := make(chan struct{})
 	go func() {
-		if err := srv.ServeFlashback(ctx, ln, console.FlashbackConfig{}); err != nil {
+		if err := serveFlashback(ctx, srv, ln, flashbackConfig{}); err != nil {
 			slog.Warn("flashback port exited with error", "error", err)
 		}
 		close(done)

--- a/cmd/bintrail-console/watch.go
+++ b/cmd/bintrail-console/watch.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -83,7 +84,13 @@ var (
 	upConsoleTLSKey         string
 	upConsoleAllowedHost    []string
 	upConsoleAllowSetup     bool
-	upArchiveStageDir       string
+	// upConsoleFlashbackListen opts into the embedded MySQL-protocol time-travel
+	// port (#996): _flashback/_snapshot/_diff for every monitored server, routed
+	// by the connection username, with no separate `bintrail shim` container.
+	// Empty (default) = off. Requires a console token (MySQL-protocol auth can't
+	// use the bcrypt password store). Env BINTRAIL_CONSOLE_FLASHBACK_LISTEN.
+	upConsoleFlashbackListen string
+	upArchiveStageDir        string
 	// upConsoleBaselineTrigger opts into in-process baseline creation from the
 	// console (#613). Env-only (BINTRAIL_CONSOLE_BASELINE_TRIGGER=1) — off by
 	// default because it needs mydumper in the image and reaches the source DB.
@@ -188,6 +195,7 @@ func init() {
 	watchCmd.Flags().StringVar(&upConsoleTLSKey, "console-tls-key", "", "TLS private key file (PEM; requires --console-tls-cert)")
 	watchCmd.Flags().StringSliceVar(&upConsoleAllowedHost, "console-allowed-hosts", nil, "Extra hostnames allowed in the Host header (for a TLS-terminating reverse proxy); IP literals and localhost are always allowed")
 	watchCmd.Flags().BoolVar(&upConsoleAllowSetup, "console-allow-setup", false, "Allow browser first-run password setup on a non-loopback bind (assert the bind is access-controlled, e.g. published only on the host loopback)")
+	watchCmd.Flags().StringVar(&upConsoleFlashbackListen, "flashback-listen", "", "Serve an embedded MySQL-protocol time-travel port (_flashback/_snapshot/_diff) for every monitored server, routed by the connection username (server id or name); e.g. 127.0.0.1:3308. Requires --console-token. Empty = off. Env BINTRAIL_CONSOLE_FLASHBACK_LISTEN.")
 	watchCmd.Flags().StringVar(&upArchiveStageDir, "archive-staging-dir", "", "Local staging directory for S3 archive uploads (default: OS temp dir). Rotated Parquet is written here, uploaded to a source's configured Archive S3 bucket, then pruned.")
 	watchCmd.Flags().StringVar(&upRotateRetain, "rotate-retain", "30d", "Built-in rotation: drop index partitions older than this (Nd/Nh; \"off\" disables)")
 	watchCmd.Flags().StringVar(&upRotateInterval, "rotate-interval", "1h", "Built-in rotation: how often to run a rotation cycle")
@@ -430,12 +438,51 @@ func runUpConsoleOnly(cmd *cobra.Command) error {
 		defer stopMetrics()
 	}
 
+	stopFlashback, err := startFlashbackPort(ctx, srv)
+	if err != nil {
+		return err
+	}
 	printConsoleBanner(srv, "Console is running — open it and add the MySQL servers to watch:")
 	go supervisor.Reconcile(registry)
 
 	serveErr := srv.Serve(ctx, ln)
+	stop()                // cancel ctx so the flashback listener unblocks even if Serve returned a non-signal error
+	stopFlashback()       // drain the flashback port before the deferred db.Close
 	supervisor.Shutdown() // final checkpoints for every monitored stream
 	return serveErr
+}
+
+// startFlashbackPort binds and serves the embedded MySQL-protocol time-travel
+// port (#996) when --flashback-listen is set, routing each connection to a
+// monitored server by its username. It returns a drain func (a no-op when the
+// port is disabled) the caller must invoke before closing the shared index DB,
+// so an in-flight time-travel query never races the deferred db.Close.
+//
+// The bind is synchronous so a port conflict or a missing token fails `watch`
+// fast, exactly like the console bind. Serving runs on the daemon context: ctx
+// cancellation closes the listener and drains open connections. A mid-run crash
+// is logged, never propagated — the flashback port is strictly secondary to the
+// console and the capture stream.
+func startFlashbackPort(ctx context.Context, srv *console.Server) (func(), error) {
+	if upConsoleFlashbackListen == "" {
+		return func() {}, nil
+	}
+	if srv.Token() == "" {
+		return nil, fmt.Errorf("--flashback-listen %s requires a console token: set --console-token or BINTRAIL_CONSOLE_TOKEN (MySQL-protocol auth cannot use the console password)", upConsoleFlashbackListen)
+	}
+	ln, err := net.Listen("tcp", upConsoleFlashbackListen)
+	if err != nil {
+		return nil, fmt.Errorf("flashback: cannot bind %s: %w", upConsoleFlashbackListen, err)
+	}
+	done := make(chan struct{})
+	go func() {
+		if err := srv.ServeFlashback(ctx, ln, console.FlashbackConfig{}); err != nil {
+			slog.Warn("flashback port exited with error", "error", err)
+		}
+		close(done)
+	}()
+	fmt.Fprintf(os.Stderr, "Time-travel SQL (MySQL protocol) is listening on %s — connect a MySQL client with user=<server id or name>, password=<console token>.\n", ln.Addr())
+	return func() { <-done }, nil
 }
 
 // runUpStreamWithConsole serves the read-only web console in this same process,
@@ -552,6 +599,11 @@ func runUpStreamWithConsole(cmd *cobra.Command, args []string) error {
 		}
 		consoleDone <- struct{}{}
 	}()
+
+	stopFlashback, err := startFlashbackPort(ctx, srv)
+	if err != nil {
+		return err
+	}
 	printConsoleBanner(srv, "Console (read-only) is running. Open:")
 
 	// Resume whatever the operator had monitoring before the restart —
@@ -575,6 +627,7 @@ func runUpStreamWithConsole(cmd *cobra.Command, args []string) error {
 	streamErr := streamrun.One(ctx, watchStreamConfig(serverID))
 	stop()                // drain the console even if the stream returned without a signal
 	<-consoleDone         // order the console goroutine's exit before the deferred db.Close()
+	stopFlashback()       // drain the flashback port before the deferred db.Close()
 	supervisor.Shutdown() // final checkpoints for every monitored stream
 	return streamErr
 }
@@ -675,6 +728,11 @@ func resolveUpConsoleEnv(cmd *cobra.Command) {
 	if !cmd.Flags().Changed("console-allow-setup") {
 		if v := os.Getenv("BINTRAIL_CONSOLE_ALLOW_SETUP"); v == "1" || v == "true" {
 			upConsoleAllowSetup = true
+		}
+	}
+	if !cmd.Flags().Changed("flashback-listen") {
+		if v := os.Getenv("BINTRAIL_CONSOLE_FLASHBACK_LISTEN"); v != "" {
+			upConsoleFlashbackListen = v
 		}
 	}
 	if !cmd.Flags().Changed("archive-staging-dir") {

--- a/cmd/bintrail-console/watch.go
+++ b/cmd/bintrail-console/watch.go
@@ -589,6 +589,16 @@ func runUpStreamWithConsole(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("console: cannot bind %s: %w", upConsoleListen, err)
 	}
+	// Bind the flashback port BEFORE starting the console goroutine: its error
+	// (missing token, port conflict) must return before any goroutine touches
+	// the shared index db, so the deferred db.Close can never race an in-flight
+	// console request on a failed startup (runUpConsoleOnly binds it before its
+	// synchronous Serve for the same reason).
+	stopFlashback, err := startFlashbackPort(ctx, srv)
+	if err != nil {
+		return err
+	}
+
 	// The console is the secondary job: log a mid-run crash when it happens (not
 	// only at shutdown), but NEVER let it take down the stream, which is the
 	// primary data-capture job.
@@ -599,11 +609,6 @@ func runUpStreamWithConsole(cmd *cobra.Command, args []string) error {
 		}
 		consoleDone <- struct{}{}
 	}()
-
-	stopFlashback, err := startFlashbackPort(ctx, srv)
-	if err != nil {
-		return err
-	}
 	printConsoleBanner(srv, "Console (read-only) is running. Open:")
 
 	// Resume whatever the operator had monitoring before the restart —

--- a/docs/console.md
+++ b/docs/console.md
@@ -435,6 +435,10 @@ results a `verify` cron/CI run produced elsewhere:
   Off by default for a bare `watch` invocation; the bundled compose stack sets
   this on by default (see [docker.md](docker.md) — `VERIFY_TRIGGER=0` in
   `.env` opts out there).
+- `BINTRAIL_CONSOLE_FLASHBACK_LISTEN` (`watch` only) — same as `--flashback-listen`
+  (e.g. `127.0.0.1:3308`): serve an embedded MySQL-protocol time-travel port for
+  every monitored server, routed by the connection username. Off by default;
+  requires a console token. See [Time-travel over the MySQL protocol](#time-travel-over-the-mysql-protocol-flashback-port).
 
 There is deliberately **no** environment variable for the password itself —
 env vars leak through `docker inspect`, `ps e`, and `/proc`; the password is
@@ -720,6 +724,20 @@ truncated prefix.
 > aborts the strict-mode (`allow_gaps=false`) fetch — the request returns 500
 > naming the failed source — instead of folding an incomplete delta set into a
 > 200. Pass `allow_gaps=true` to fall back to warn-and-continue.
+
+### Time-travel over the MySQL protocol (flashback port)
+
+The reconstruct tab above is HTTP/browser-oriented. For a `mysql` client or an
+application that speaks `AS OF` SQL, `bintrail-console watch --flashback-listen
+<addr>` opens an embedded MySQL-protocol port that serves the `_flashback` /
+`_snapshot` / `_diff` virtual schemas for **every monitored server** — routed by
+the connection username (the server's registry id or display name), authenticated
+with the console token. It replaces running a separate `bintrail shim` per
+per-source index: the daemon already resolves each server's `bintrail_idx_<id>`
+and baseline, so one port covers them all. A token is required (`--console-token`
+/ `BINTRAIL_CONSOLE_TOKEN`) because MySQL-protocol auth cannot use the console's
+password store. Full setup, routing, and the `_snapshot` baseline-parity edge:
+[docs/time-travel-sql.md → the embedded port](time-travel-sql.md#the-embedded-port-multi-source).
 
 ### Coverage gaps and incomplete data
 

--- a/docs/time-travel-sql.md
+++ b/docs/time-travel-sql.md
@@ -19,21 +19,70 @@ The query is answered by `bintrail shim`, an in-process MySQL-protocol server (a
                                 └──────────┘                   └────────────┘
 ```
 
-## Two ways to run time-travel SQL
+## Three ways to run time-travel SQL
 
-There are two ways to put `AS OF` SQL in front of your data; they differ only in
-*how the client connects*:
+There are three ways to put `AS OF` SQL in front of your data; they differ only
+in *how the client connects*:
 
-1. **A dedicated terminal — point `mysql` straight at the shim (no ProxySQL).**
-   Simplest. The shim already speaks the MySQL protocol, so an analyst connects
-   a `mysql` client directly to it and runs `_flashback` / `_snapshot` / `_diff`
-   queries. Trade-off: that connection answers *only* time-travel queries (a
-   normal `SELECT` against a real table returns `ER_NOT_SUPPORTED_YET`, 1235).
-   Use it when a person or tool just needs to read historical state.
-2. **Transparent routing — ProxySQL in front (the rest of this guide).** Needed
+1. **Embedded in `bintrail-console watch` — one port for every monitored server
+   (multi-source).** If you already run the daemon, add `--flashback-listen`
+   and it serves `_flashback` / `_snapshot` / `_diff` for *every* server in the
+   console, routed by the connection username. No separate `bintrail shim`
+   process, no hand-built index DSN. See [the embedded port](#the-embedded-port-multi-source)
+   below. Start here if you run `watch`.
+2. **A dedicated terminal — point `mysql` straight at a standalone shim (no
+   ProxySQL).** Simplest for a single index. The shim already speaks the MySQL
+   protocol, so an analyst connects a `mysql` client directly to it and runs
+   `_flashback` / `_snapshot` / `_diff` queries. Trade-off: that connection
+   answers *only* time-travel queries (a normal `SELECT` against a real table
+   returns `ER_NOT_SUPPORTED_YET`, 1235). Use it when a person or tool just needs
+   to read historical state from one index.
+3. **Transparent routing — ProxySQL in front (the rest of this guide).** Needed
    only when an application's *normal* connection must mix live queries and
    `AS OF` queries on the same endpoint. ProxySQL routes virtual-schema queries
    to the shim and everything else to your real MySQL.
+
+### The embedded port (multi-source)
+
+`bintrail-console watch` already holds the time-travel engine and, through its
+control plane, a resolved connection to every monitored server's *own* per-source
+index (`bintrail_idx_<id>`). `--flashback-listen` exposes a MySQL-protocol port
+wired to that same map, so one endpoint time-travels any server you monitor —
+no `bintrail shim` container, no `--profile flashback`, no per-source DSN to
+discover:
+
+```sh
+bintrail-console watch \
+  --index-dsn 'root:pw@tcp(127.0.0.1:3306)/bintrail_index' \
+  --console-token "$BINTRAIL_CONSOLE_TOKEN" \
+  --flashback-listen 127.0.0.1:3308            # or env BINTRAIL_CONSOLE_FLASHBACK_LISTEN
+```
+
+**Routing is by username, auth is the console token.** Connect as the target
+server — its registry **ID** (robust; the `X-Bintrail-Server` value shown in the
+console) or its display **name** — with the console token as the password:
+
+```sh
+# the console shows each server's id/name in the switcher
+mysql -h 127.0.0.1 -P 3308 -u 7f4d577430b48821 -p"$BINTRAIL_CONSOLE_TOKEN"
+mysql> USE myapp;   -- optional: seeded from the server's source DSN when known
+mysql> SELECT * FROM _flashback.orders AS OF '2026-05-02 10:00:00' WHERE id = 12345;
+```
+
+Servers added in the console mid-session are reachable immediately (the registry
+is read live). A token is **required** — MySQL-protocol auth cannot use the
+console's password store — so set `--console-token` / `BINTRAIL_CONSOLE_TOKEN`;
+`watch` refuses to open the port otherwise. The default `127.0.0.1` bind keeps
+it host-local; do not expose it to untrusted networks.
+
+`_snapshot.*` parity: each server reads the baseline configured on its registry
+entry (or the daemon's `--baseline-dir` / `--baseline-s3`), exactly as the
+console's Time-travel tab does — with one edge: a server configured with *both*
+a local `--baseline-dir` **and** an `--baseline-s3` copy reads `_snapshot` only
+from the local dir on this port. If local baselines have been pruned (retention)
+while a durable S3 copy remains, use the console's Time-travel tab or a standalone
+shim pointed at the S3 prefix for those tables. Single-source baseline configs —
+the common case — have full parity.
 
 ### The dedicated terminal
 

--- a/internal/console/flashback.go
+++ b/internal/console/flashback.go
@@ -1,0 +1,387 @@
+package console
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"strings"
+	"sync"
+	"time"
+
+	gomysql "github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/go-mysql-org/go-mysql/server"
+	drivermysql "github.com/go-sql-driver/mysql"
+
+	"github.com/dbtrail/dbtrail/internal/shim"
+)
+
+// FlashbackConfig tunes the embedded time-travel port (issue #996). The zero
+// value is the production default: strict (a coverage gap or archive-fetch
+// failure aborts the client's query), a 5-minute per-query deadline, and at
+// most 4 concurrent full-table reconstructions.
+type FlashbackConfig struct {
+	// AllowGaps mirrors shim.Config.AllowGaps: false (default) fails a query
+	// loudly on a coverage gap / archive failure; true downgrades to a
+	// server-side warning and returns partial rows.
+	AllowGaps bool
+	// QueryTimeout bounds each time-travel query end-to-end. It is the ONLY
+	// backstop against a runaway query on a dropped connection here — unlike
+	// the standalone shim, the embedded port does not run the client-disconnect
+	// detection pump — so it must never be 0. ServeFlashback substitutes the
+	// 5-minute default when this is 0.
+	QueryTimeout time.Duration
+	// MaxFullTable caps concurrent full-table reconstructions across every
+	// connection of this port (0 → 4, the standalone default). A shared gate,
+	// exactly like the standalone shim's --max-fulltable-queries.
+	MaxFullTable int
+	// AuthMethod selects the MySQL auth plugin the port advertises. Empty
+	// (default) keeps mysql_native_password; see shim.NewMySQLServer for the
+	// accepted values.
+	AuthMethod string
+}
+
+const defaultFlashbackQueryTimeout = 5 * time.Minute
+
+// ServeFlashback runs a MySQL-protocol time-travel server on ln, routing every
+// connection to a monitored server's per-source index by the connection's
+// USERNAME (issue #996). Reuse of the console's already-resolved connManager is
+// the whole point: `_flashback` / `_snapshot` / `_diff` resolve against the
+// same per-source index + baseline the console's Time-travel tab shows, with no
+// separate container and no hand-built INDEX_DSN.
+//
+// Routing: the MySQL username selects the target server — its registry ID, its
+// display Name, or "default" for the command-line boot entry. The console's
+// static --token is the shared password for every server (the operator can see
+// all servers in the UI, so server selection is not a security boundary; the
+// token is). The connection's client library therefore connects as, e.g.,
+// `-u <server-id> -p<token>`.
+//
+// Auth requires a token: go-mysql recomputes the native / caching_sha2 scramble
+// server-side from the cleartext GetCredential returns (auth.go:57 in go-mysql
+// v1.13.0), and the console's bcrypt password store cannot produce that
+// cleartext. Callers that leave --token empty get an error here rather than an
+// unauthenticated port.
+//
+// Blocks until ctx is cancelled (which closes ln and drains in-flight
+// connections) or ln fails unrecoverably.
+func (s *Server) ServeFlashback(ctx context.Context, ln net.Listener, cfg FlashbackConfig) error {
+	if s.token == "" {
+		return errors.New("flashback port requires an automation token: set --token or BINTRAIL_CONSOLE_TOKEN (the console password store cannot drive MySQL-protocol authentication)")
+	}
+	if cfg.QueryTimeout == 0 {
+		cfg.QueryTimeout = defaultFlashbackQueryTimeout
+	}
+	gateN := cfg.MaxFullTable
+	if gateN == 0 {
+		gateN = 4
+	}
+
+	// One *server.Server for the whole port: it owns the caching_sha2_password
+	// cache and the RSA keypair (see shim.NewMySQLServer). One shared *Gate so
+	// the full-table cap is process-wide, not per-connection.
+	srv, err := shim.NewMySQLServer(cfg.AuthMethod)
+	if err != nil {
+		return fmt.Errorf("flashback: %w", err)
+	}
+	gate := shim.NewGate(gateN)
+	creds := flashbackCreds{s: s}
+	logger := slog.Default()
+
+	// Close the listener when the daemon context ends so Accept unblocks and
+	// the loop returns; the deferred wg.Wait then drains open connections.
+	go func() {
+		<-ctx.Done()
+		_ = ln.Close()
+	}()
+
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	var backoff time.Duration
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			if ctx.Err() != nil || errors.Is(err, net.ErrClosed) {
+				return nil // graceful shutdown
+			}
+			backoff = nextFlashbackBackoff(backoff)
+			logger.Error("flashback accept failed", "err", err, "backoff", backoff)
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-time.After(backoff):
+			}
+			continue
+		}
+		backoff = 0
+		wg.Add(1)
+		go func(c net.Conn) {
+			defer wg.Done()
+			s.handleFlashbackConn(ctx, c, srv, creds, gate, cfg, logger)
+		}(conn)
+	}
+}
+
+// handleFlashbackConn performs the handshake, then binds the connection's
+// Handler to the server the authenticated username selects. The Handler cannot
+// be built before the handshake — the username is only known afterwards, yet
+// go-mysql binds the Handler at construction — so a routingHandler proxy is
+// passed to NewCustomizedConn and its inner *shim.Handler is set once
+// GetUser() reveals the target. Commands are dispatched sequentially in this
+// goroutine strictly after that, so no synchronisation is needed.
+func (s *Server) handleFlashbackConn(ctx context.Context, c net.Conn, srv *server.Server, creds server.CredentialProvider, gate *shim.Gate, cfg FlashbackConfig, logger *slog.Logger) {
+	defer c.Close()
+
+	// Cancel + close the socket when the daemon context dies (SIGTERM) or this
+	// goroutine returns, so a graceful shutdown and a stalled handshake can't
+	// wedge ServeFlashback's wg.Wait. BindConnContext(connCtx) below ties any
+	// in-flight fetch to the same context, so shutdown also aborts a running
+	// query — QueryTimeout remains the backstop for a client that simply
+	// disappears mid-query without a shutdown signal.
+	connCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	stopCloser := context.AfterFunc(connCtx, func() { _ = c.Close() })
+	defer stopCloser()
+
+	proxy := &routingHandler{}
+	mysqlConn, err := server.NewCustomizedConn(c, srv, creds, proxy)
+	if err != nil {
+		level := slog.LevelWarn
+		if isFlashbackProbe(err) {
+			// Bare TCP probes (health checks, port scanners) close before the
+			// handshake completes; don't log those at WARN.
+			level = slog.LevelDebug
+		}
+		logger.Log(context.Background(), level, "flashback handshake failed", "err", err, "remote", c.RemoteAddr())
+		return
+	}
+
+	if err := s.bindFlashbackHandler(connCtx, proxy, mysqlConn.GetUser(), gate, cfg, logger); err != nil {
+		// Auth already succeeded; surface the routing failure on the client's
+		// first query (a typed MySQL error) rather than a bare disconnect.
+		proxy.fail = err
+	}
+
+	for {
+		if err := mysqlConn.HandleCommand(); err != nil {
+			if !errors.Is(err, net.ErrClosed) {
+				logger.Debug("flashback connection ended", "err", err, "remote", c.RemoteAddr())
+			}
+			return
+		}
+	}
+}
+
+// bindFlashbackHandler resolves the target server from the authenticated
+// username and wires proxy.inner to a shim.Handler bound to that server's
+// per-source index + baseline. A returned error is a typed *mysql.MyError the
+// caller stores on the proxy so the client sees it on the first query.
+func (s *Server) bindFlashbackHandler(ctx context.Context, proxy *routingHandler, user string, gate *shim.Gate, cfg FlashbackConfig, logger *slog.Logger) error {
+	id, ok := s.flashbackTarget(user)
+	if !ok {
+		// Auth is the token alone (CheckUsername accepts any username), so an
+		// unknown or typo'd server name is the normal way we land here — report
+		// it as a missing database on the client's first query.
+		return gomysql.NewError(gomysql.ER_BAD_DB_ERROR, fmt.Sprintf("flashback: no such server %q", user))
+	}
+	b, err := s.cm.Resolve(ctx, id)
+	if err != nil {
+		// scrubDSNError has already stripped secrets from connManager errors.
+		return gomysql.NewError(gomysql.ER_UNKNOWN_ERROR, fmt.Sprintf("flashback: cannot open server %q: %s", user, err))
+	}
+
+	shimCfg := shim.Config{
+		IndexDBName:   b.dbName,
+		NoArchive:     b.noArchive,
+		AllowGaps:     cfg.AllowGaps,
+		QueryTimeout:  cfg.QueryTimeout,
+		FullTableGate: gate,
+		AuthMethod:    cfg.AuthMethod,
+	}
+	// The console bundle's baselineSrc is already dir-preferred; map it onto the
+	// shim's dir/S3 fields by scheme so `_snapshot` reads the same source the
+	// console's Time-travel tab reads (see splitBaselineSource for the #766 edge).
+	shimCfg.BaselineDir, shimCfg.BaselineS3 = splitBaselineSource(b.baselineSrc)
+
+	h := shim.NewHandlerWithConfig(b.db, shimCfg, logger)
+	h.BindConnContext(ctx)
+	// Seed the source schema so fully qualified `_flashback.<table>` queries
+	// work without a prior `USE <db>` (mirrors the standalone shim's #263
+	// behaviour). Best-effort: the boot entry has no registry SourceDSN.
+	if schema := s.flashbackDefaultSchema(id); schema != "" {
+		_ = h.UseDB(schema)
+	}
+	// A default schema the client sent in the handshake (CLIENT_CONNECT_WITH_DB,
+	// stashed on the proxy before inner was bound) wins over the SourceDSN seed,
+	// matching the standalone shim where an explicit client USE overrides the
+	// #263 seed.
+	if proxy.pendingDB != "" {
+		_ = h.UseDB(proxy.pendingDB)
+	}
+	proxy.inner = h
+	return nil
+}
+
+// splitBaselineSource maps a resolved baseline source (the console bundle's
+// already dir-preferred baselineSrc) onto the shim's dir/S3 config fields by
+// scheme. The #766 local→S3 fallback the console bundle also carries is
+// deliberately NOT represented — a documented single-source-parity limitation
+// for the embedded port: a server with BOTH a local dir and an S3 copy reads
+// `_snapshot` only from the local dir here (see docs/time-travel-sql.md).
+func splitBaselineSource(src string) (dir, s3 string) {
+	if strings.HasPrefix(src, "s3://") {
+		return "", src
+	}
+	if src != "" {
+		return src, ""
+	}
+	return "", ""
+}
+
+// flashbackTarget maps a connection username to a canonical server id: a
+// registry ID, a registry display Name, or "default" for the boot entry. The
+// registry is read live so servers added in the UI mid-session are reachable
+// without restarting the port.
+func (s *Server) flashbackTarget(selector string) (string, bool) {
+	if selector == "" {
+		return "", false
+	}
+	if _, ok := s.cm.reg.Get(selector); ok {
+		return selector, true // matched by id
+	}
+	for _, e := range s.cm.reg.List() {
+		if e.Name == selector {
+			return e.ID, true // matched by display name
+		}
+	}
+	if selector == bootServerID && s.cm.bootSelectable() {
+		return bootServerID, true
+	}
+	return "", false
+}
+
+// flashbackDefaultSchema derives the source database name for a target server
+// from its registry SourceDSN, for `USE`-less fully qualified queries. Empty
+// for the boot entry (no registry SourceDSN) or an unparseable/absent DSN.
+func (s *Server) flashbackDefaultSchema(id string) string {
+	entry, ok := s.cm.reg.Get(id)
+	if !ok || entry.SourceDSN == "" {
+		return ""
+	}
+	cfg, err := drivermysql.ParseDSN(entry.SourceDSN)
+	if err != nil {
+		return ""
+	}
+	return cfg.DBName
+}
+
+// flashbackCreds authenticates the flashback port: any username that maps to a
+// selectable server is accepted, all sharing the console's static token as the
+// password. It holds *Server (not a snapshot) so the registry is consulted live
+// on every handshake.
+type flashbackCreds struct {
+	s *Server
+}
+
+// CheckUsername accepts any username: authentication is the shared token, and
+// the target server is validated AFTER the handshake (bindFlashbackHandler).
+// Deciding validity here would leak which usernames name a real server through
+// the handshake's error code (unknown-user vs bad-password), letting an
+// unauthenticated client enumerate monitored servers. Returns false only when
+// no token is configured — a uniform denial of every connection.
+func (f flashbackCreds) CheckUsername(username string) (bool, error) {
+	return f.s.token != "", nil
+}
+
+// GetCredential returns the shared console token for every username, so auth
+// turns on the token alone. found=false on an empty token is defence in depth
+// behind ServeFlashback's startup guard: an empty token must never authorise a
+// passwordless MySQL handshake.
+func (f flashbackCreds) GetCredential(username string) (password string, found bool, err error) {
+	if f.s.token == "" {
+		return "", false, nil
+	}
+	return f.s.token, true, nil
+}
+
+// routingHandler is the go-mysql Handler passed to NewCustomizedConn before the
+// authenticated username (and thus the target server) is known. Its inner
+// *shim.Handler is set by bindFlashbackHandler once the handshake completes; if
+// routing failed, fail carries the typed error returned on the first command.
+// server.EmptyHandler supplies the commands shim.Handler itself does not
+// implement (field-list, prepared statements) — identical to a bare
+// shim.Handler, which embeds the same EmptyHandler.
+type routingHandler struct {
+	server.EmptyHandler
+	inner *shim.Handler
+	fail  error
+	// pendingDB holds a default schema the client sent in the handshake
+	// (CLIENT_CONNECT_WITH_DB): go-mysql invokes UseDB DURING the handshake,
+	// before bindFlashbackHandler binds inner. Stashing it (and returning nil)
+	// lets the handshake complete instead of failing it; bindFlashbackHandler
+	// replays it onto the real handler. Without this, any client that connects
+	// with a default schema (mysql -D, a DSN /db path, JDBC) is rejected before
+	// auth even runs.
+	pendingDB string
+}
+
+func (r *routingHandler) UseDB(dbName string) error {
+	switch {
+	case r.inner != nil:
+		return r.inner.UseDB(dbName)
+	case r.fail != nil:
+		// Routing failed after the handshake; reject a later USE too so the
+		// failure is consistent across commands.
+		return r.fail
+	default:
+		// Pre-bind: go-mysql calls UseDB during the handshake, before inner is
+		// set. Stash it (bindFlashbackHandler replays it) and let the handshake
+		// complete rather than aborting the connection.
+		r.pendingDB = dbName
+		return nil
+	}
+}
+
+func (r *routingHandler) HandleQuery(query string) (*gomysql.Result, error) {
+	if r.inner == nil {
+		return nil, r.unresolved()
+	}
+	return r.inner.HandleQuery(query)
+}
+
+func (r *routingHandler) unresolved() error {
+	if r.fail != nil {
+		return r.fail
+	}
+	return gomysql.NewError(gomysql.ER_UNKNOWN_ERROR, "flashback: no server bound to this connection")
+}
+
+// isFlashbackProbe reports whether a handshake error is a bare TCP probe
+// (health check / port scan) that closed before completing — logged at Debug
+// rather than Warn. Mirrors the standalone shim's classifyHandshakeErr probe
+// arm without the ProxySQL-monitor aggregator, which does not apply to an
+// embedded loopback port.
+func isFlashbackProbe(err error) bool {
+	return errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, gomysql.ErrBadConn)
+}
+
+const (
+	initialFlashbackBackoff = 100 * time.Millisecond
+	maxFlashbackBackoff     = 5 * time.Second
+)
+
+// nextFlashbackBackoff doubles the accept-retry sleep up to a cap; the zero
+// value seeds the first retry. Keeps a wedged listener from spinning the CPU or
+// flooding the log without delaying a SIGTERM more than the cap.
+func nextFlashbackBackoff(current time.Duration) time.Duration {
+	if current <= 0 {
+		return initialFlashbackBackoff
+	}
+	if next := current * 2; next < maxFlashbackBackoff {
+		return next
+	}
+	return maxFlashbackBackoff
+}

--- a/internal/console/flashback.go
+++ b/internal/console/flashback.go
@@ -2,266 +2,68 @@ package console
 
 import (
 	"context"
-	"errors"
-	"fmt"
-	"io"
-	"log/slog"
-	"net"
+	"database/sql"
 	"strings"
-	"sync"
-	"time"
 
-	gomysql "github.com/go-mysql-org/go-mysql/mysql"
-	"github.com/go-mysql-org/go-mysql/server"
 	drivermysql "github.com/go-sql-driver/mysql"
-
-	"github.com/dbtrail/dbtrail/internal/shim"
 )
 
-// FlashbackConfig tunes the embedded time-travel port (issue #996). The zero
-// value is the production default: strict (a coverage gap or archive-fetch
-// failure aborts the client's query), a 5-minute per-query deadline, and at
-// most 4 concurrent full-table reconstructions.
-type FlashbackConfig struct {
-	// AllowGaps mirrors shim.Config.AllowGaps: false (default) fails a query
-	// loudly on a coverage gap / archive failure; true downgrades to a
-	// server-side warning and returns partial rows.
-	AllowGaps bool
-	// QueryTimeout bounds each time-travel query end-to-end. It is the ONLY
-	// backstop against a runaway query on a dropped connection here — unlike
-	// the standalone shim, the embedded port does not run the client-disconnect
-	// detection pump — so it must never be 0. ServeFlashback substitutes the
-	// 5-minute default when this is 0.
-	QueryTimeout time.Duration
-	// MaxFullTable caps concurrent full-table reconstructions across every
-	// connection of this port (0 → 4, the standalone default). A shared gate,
-	// exactly like the standalone shim's --max-fulltable-queries.
-	MaxFullTable int
-	// AuthMethod selects the MySQL auth plugin the port advertises. Empty
-	// (default) keeps mysql_native_password; see shim.NewMySQLServer for the
-	// accepted values.
-	AuthMethod string
-}
-
-const (
-	defaultFlashbackQueryTimeout = 5 * time.Minute
-	defaultFlashbackMaxFullTable = 4
-)
-
-// withDefaults resolves the zero-value fields to their production defaults.
-// QueryTimeout is the load-bearing one: 0 means "unbounded", but the embedded
-// port has no client-disconnect pump, so a runaway query on a dropped
-// connection would never be reclaimed — the 5-minute default is the only
-// backstop. ServeFlashback always calls this, so the dangerous zero never
-// reaches the query path; keeping both substitutions here (rather than one
-// inline and one in a side variable) is why they can't drift apart.
-func (c FlashbackConfig) withDefaults() FlashbackConfig {
-	if c.QueryTimeout == 0 {
-		c.QueryTimeout = defaultFlashbackQueryTimeout
-	}
-	if c.MaxFullTable == 0 {
-		c.MaxFullTable = defaultFlashbackMaxFullTable
-	}
-	return c
-}
-
-// ServeFlashback runs a MySQL-protocol time-travel server on ln, routing every
-// connection to a monitored server's per-source index by the connection's
-// USERNAME (issue #996). Reuse of the console's already-resolved connManager is
-// the whole point: `_flashback` / `_snapshot` / `_diff` resolve against the
-// same per-source index + baseline the console's Time-travel tab shows, with no
-// separate container and no hand-built INDEX_DSN.
+// FlashbackTarget is the go-mysql-free resolution of a flashback connection's
+// target server (issue #996): the per-source index handle, baseline source, and
+// default schema the MySQL-protocol serving layer needs to build a shim handler.
 //
-// Routing: the MySQL username selects the target server — its registry ID, its
-// display Name, or "default" for the command-line boot entry. The console's
-// static --token is the shared password for every server (the operator can see
-// all servers in the UI, so server selection is not a security boundary; the
-// token is). The connection's client library therefore connects as, e.g.,
-// `-u <server-id> -p<token>`.
-//
-// Auth requires a token: go-mysql validates the handshake by recomputing the
-// scramble from the cleartext GetCredential returns (the
-// compareNativePasswordAuthData path in go-mysql v1.13.0 server/auth.go), and
-// the console's bcrypt password store cannot produce that cleartext. Callers
-// that leave --token empty get an error here rather than an unauthenticated port.
-//
-// Blocks until ctx is cancelled (which closes ln and drains in-flight
-// connections) or ln fails unrecoverably.
-func (s *Server) ServeFlashback(ctx context.Context, ln net.Listener, cfg FlashbackConfig) error {
-	if s.token == "" {
-		return errors.New("flashback port requires an automation token: set --token or BINTRAIL_CONSOLE_TOKEN (the console password store cannot drive MySQL-protocol authentication)")
-	}
-	cfg = cfg.withDefaults()
-
-	// One *server.Server for the whole port: it owns the caching_sha2_password
-	// cache and the RSA keypair (see shim.NewMySQLServer). One shared *Gate so
-	// the full-table cap is process-wide, not per-connection.
-	srv, err := shim.NewMySQLServer(cfg.AuthMethod)
-	if err != nil {
-		// ln is already bound by the caller; close it so a construction failure
-		// (an unsupported auth method) doesn't leak the listener nor leave the
-		// caller's "listening" banner pointing at a port that rejects every
-		// handshake. Unreachable from `watch` today (it passes an empty
-		// AuthMethod), but a latent trap if a --flashback-auth-method flag lands.
-		_ = ln.Close()
-		return fmt.Errorf("flashback: %w", err)
-	}
-	gate := shim.NewGate(cfg.MaxFullTable)
-	creds := flashbackCreds{s: s}
-	logger := slog.Default()
-
-	// Close the listener when the daemon context ends so Accept unblocks and
-	// the loop returns; the deferred wg.Wait then drains open connections.
-	go func() {
-		<-ctx.Done()
-		_ = ln.Close()
-	}()
-
-	// No per-connection cap (the standalone shim's --max-connections has no
-	// equivalent here): this is a loopback-default, token-gated operator port,
-	// and the shared FullTableGate already bounds the memory-heavy queries.
-	var wg sync.WaitGroup
-	defer wg.Wait()
-
-	var backoff time.Duration
-	for {
-		conn, err := ln.Accept()
-		if err != nil {
-			if ctx.Err() != nil || errors.Is(err, net.ErrClosed) {
-				return nil // graceful shutdown
-			}
-			backoff = nextFlashbackBackoff(backoff)
-			logger.Error("flashback accept failed", "err", err, "backoff", backoff)
-			select {
-			case <-ctx.Done():
-				return nil
-			case <-time.After(backoff):
-			}
-			continue
-		}
-		backoff = 0
-		wg.Add(1)
-		go func(c net.Conn) {
-			defer wg.Done()
-			s.handleFlashbackConn(ctx, c, srv, creds, gate, cfg, logger)
-		}(conn)
-	}
+// It lives here — but the serving code does NOT — because internal/console is a
+// read-layer package barred from linking go-mysql (#528,
+// TestReadLayerDoesNotLinkGoMySQL). cmd/bintrail-console owns the protocol
+// server and consumes this plain struct; nothing here imports the protocol or
+// capture libraries.
+type FlashbackTarget struct {
+	// IndexDB is the open connection to the server's per-source index. It is
+	// owned by the connManager — the serving layer must not Close it.
+	IndexDB *sql.DB
+	// IndexDBName is the schema where binlog_events lives (the query planner
+	// scopes information_schema.PARTITIONS to it).
+	IndexDBName string
+	// BaselineDir / BaselineS3 are the resolved _snapshot baseline source, split
+	// by scheme (dir-preferred, mirroring the console's Time-travel tab). The
+	// #766 local→S3 fallback the console bundle also carries is intentionally
+	// dropped — a documented single-source-parity edge for the embedded port
+	// (see docs/time-travel-sql.md).
+	BaselineDir string
+	BaselineS3  string
+	// NoArchive disables archive auto-discovery for this server.
+	NoArchive bool
+	// DefaultSchema is the source database name (from the registry SourceDSN),
+	// seeded so USE-less `_flashback.<table>` queries resolve; empty for the
+	// boot entry (no registry SourceDSN).
+	DefaultSchema string
 }
 
-// handleFlashbackConn performs the handshake, then binds the connection's
-// Handler to the server the authenticated username selects. The Handler cannot
-// be built before the handshake — the username is only known afterwards, yet
-// go-mysql binds the Handler at construction — so a routingHandler proxy is
-// passed to NewCustomizedConn and its inner *shim.Handler is set once
-// GetUser() reveals the target. Commands are dispatched sequentially in this
-// goroutine strictly after that, so no synchronisation is needed.
-func (s *Server) handleFlashbackConn(ctx context.Context, c net.Conn, srv *server.Server, creds server.CredentialProvider, gate *shim.Gate, cfg FlashbackConfig, logger *slog.Logger) {
-	defer c.Close()
-
-	// Cancel + close the socket when the daemon context dies (SIGTERM) or this
-	// goroutine returns, so a graceful shutdown and a stalled handshake can't
-	// wedge ServeFlashback's wg.Wait. BindConnContext(connCtx) below ties any
-	// in-flight fetch to the same context, so shutdown also aborts a running
-	// query — QueryTimeout remains the backstop for a client that simply
-	// disappears mid-query without a shutdown signal.
-	connCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	stopCloser := context.AfterFunc(connCtx, func() { _ = c.Close() })
-	defer stopCloser()
-
-	proxy := &routingHandler{}
-	mysqlConn, err := server.NewCustomizedConn(c, srv, creds, proxy)
-	if err != nil {
-		level := slog.LevelWarn
-		if isFlashbackProbe(err) {
-			// Bare TCP probes (health checks, port scanners) close before the
-			// handshake completes; don't log those at WARN.
-			level = slog.LevelDebug
-		}
-		logger.Log(context.Background(), level, "flashback handshake failed", "err", err, "remote", c.RemoteAddr())
-		return
-	}
-
-	if err := s.bindFlashbackHandler(connCtx, proxy, mysqlConn.GetUser(), gate, cfg, logger); err != nil {
-		// Auth already succeeded; surface the routing failure on the client's
-		// first query (a typed MySQL error) rather than a bare disconnect.
-		proxy.fail = err
-	}
-
-	for {
-		if err := mysqlConn.HandleCommand(); err != nil {
-			if !errors.Is(err, net.ErrClosed) {
-				logger.Debug("flashback connection ended", "err", err, "remote", c.RemoteAddr())
-			}
-			return
-		}
-	}
-}
-
-// bindFlashbackHandler resolves the target server from the authenticated
-// username and wires proxy.inner to a shim.Handler bound to that server's
-// per-source index + baseline. A returned error is a typed *mysql.MyError the
-// caller stores on the proxy so the client sees it on the first query.
-func (s *Server) bindFlashbackHandler(ctx context.Context, proxy *routingHandler, user string, gate *shim.Gate, cfg FlashbackConfig, logger *slog.Logger) error {
-	id, ok := s.flashbackTarget(user)
+// ResolveFlashback maps a flashback connection username to its target server's
+// per-source index + baseline, opening the connection lazily via connManager.
+// The username selects the server by registry ID, display Name, or "default"
+// (the boot entry). Returns ErrUnknownServer when the selector matches no
+// selectable server — the serving layer turns that into a MySQL "no such
+// database" error on the client's first query. The registry is read live, so
+// servers added in the console mid-session are reachable without a restart.
+func (s *Server) ResolveFlashback(ctx context.Context, selector string) (FlashbackTarget, error) {
+	id, ok := s.flashbackTarget(selector)
 	if !ok {
-		// Auth is the token alone (CheckUsername accepts any username), so an
-		// unknown or typo'd server name is the normal way we land here — report
-		// it as a missing database on the client's first query.
-		return gomysql.NewError(gomysql.ER_BAD_DB_ERROR, fmt.Sprintf("flashback: no such server %q", user))
+		return FlashbackTarget{}, ErrUnknownServer
 	}
 	b, err := s.cm.Resolve(ctx, id)
 	if err != nil {
-		// scrubDSNError has already stripped secrets from connManager errors.
-		return gomysql.NewError(gomysql.ER_UNKNOWN_ERROR, fmt.Sprintf("flashback: cannot open server %q: %s", user, err))
+		return FlashbackTarget{}, err
 	}
-
-	shimCfg := shim.Config{
+	dir, s3 := splitBaselineSource(b.baselineSrc)
+	return FlashbackTarget{
+		IndexDB:       b.db,
 		IndexDBName:   b.dbName,
+		BaselineDir:   dir,
+		BaselineS3:    s3,
 		NoArchive:     b.noArchive,
-		AllowGaps:     cfg.AllowGaps,
-		QueryTimeout:  cfg.QueryTimeout,
-		FullTableGate: gate,
-		AuthMethod:    cfg.AuthMethod,
-	}
-	// The console bundle's baselineSrc is already dir-preferred; map it onto the
-	// shim's dir/S3 fields by scheme so `_snapshot` reads the same source the
-	// console's Time-travel tab reads (see splitBaselineSource for the #766 edge).
-	shimCfg.BaselineDir, shimCfg.BaselineS3 = splitBaselineSource(b.baselineSrc)
-
-	h := shim.NewHandlerWithConfig(b.db, shimCfg, logger)
-	h.BindConnContext(ctx)
-	// Seed the source schema so fully qualified `_flashback.<table>` queries
-	// work without a prior `USE <db>` (mirrors the standalone shim's #263
-	// behaviour). Best-effort: the boot entry has no registry SourceDSN.
-	if schema := s.flashbackDefaultSchema(id); schema != "" {
-		_ = h.UseDB(schema)
-	}
-	// A default schema the client sent in the handshake (CLIENT_CONNECT_WITH_DB,
-	// stashed on the proxy before inner was bound) wins over the SourceDSN seed,
-	// matching the standalone shim where an explicit client USE overrides the
-	// #263 seed.
-	if proxy.pendingDB != "" {
-		_ = h.UseDB(proxy.pendingDB)
-	}
-	proxy.inner = h
-	return nil
-}
-
-// splitBaselineSource maps a resolved baseline source (the console bundle's
-// already dir-preferred baselineSrc) onto the shim's dir/S3 config fields by
-// scheme. The #766 local→S3 fallback the console bundle also carries is
-// deliberately NOT represented — a documented single-source-parity limitation
-// for the embedded port: a server with BOTH a local dir and an S3 copy reads
-// `_snapshot` only from the local dir here (see docs/time-travel-sql.md).
-func splitBaselineSource(src string) (dir, s3 string) {
-	if strings.HasPrefix(src, "s3://") {
-		return "", src
-	}
-	if src != "" {
-		return src, ""
-	}
-	return "", ""
+		DefaultSchema: s.flashbackDefaultSchema(id),
+	}, nil
 }
 
 // flashbackTarget maps a connection username to a canonical server id: a
@@ -301,111 +103,18 @@ func (s *Server) flashbackDefaultSchema(id string) string {
 	return cfg.DBName
 }
 
-// flashbackCreds authenticates the flashback port on the shared console token
-// alone: every username is accepted at the handshake (so the error code cannot
-// enumerate servers), and the target server is validated AFTER the handshake in
-// bindFlashbackHandler, which reads the live registry via flashbackTarget. It
-// holds *Server to read s.token directly rather than snapshotting it.
-type flashbackCreds struct {
-	s *Server
-}
-
-// CheckUsername accepts any username: authentication is the shared token, and
-// the target server is validated AFTER the handshake (bindFlashbackHandler).
-// Deciding validity here would leak which usernames name a real server through
-// the handshake's error code (unknown-user vs bad-password), letting an
-// unauthenticated client enumerate monitored servers. Returns false only when
-// no token is configured — a uniform denial of every connection.
-func (f flashbackCreds) CheckUsername(username string) (bool, error) {
-	return f.s.token != "", nil
-}
-
-// GetCredential returns the shared console token for every username, so auth
-// turns on the token alone. found=false on an empty token is defence in depth
-// behind ServeFlashback's startup guard: an empty token must never authorise a
-// passwordless MySQL handshake.
-func (f flashbackCreds) GetCredential(username string) (password string, found bool, err error) {
-	if f.s.token == "" {
-		return "", false, nil
+// splitBaselineSource maps a resolved baseline source (the console bundle's
+// already dir-preferred baselineSrc) onto the shim's dir/S3 config fields by
+// scheme. The #766 local→S3 fallback the console bundle also carries is
+// deliberately NOT represented — a documented single-source-parity limitation
+// for the embedded port: a server with BOTH a local dir and an S3 copy reads
+// `_snapshot` only from the local dir here (see docs/time-travel-sql.md).
+func splitBaselineSource(src string) (dir, s3 string) {
+	if strings.HasPrefix(src, "s3://") {
+		return "", src
 	}
-	return f.s.token, true, nil
-}
-
-// routingHandler is the go-mysql Handler passed to NewCustomizedConn before the
-// authenticated username (and thus the target server) is known. Its inner
-// *shim.Handler is set by bindFlashbackHandler once the handshake completes; if
-// routing failed, fail carries the typed error returned on the first command.
-// server.EmptyHandler supplies the commands shim.Handler itself does not
-// implement (field-list, prepared statements) — identical to a bare
-// shim.Handler, which embeds the same EmptyHandler.
-type routingHandler struct {
-	server.EmptyHandler
-	inner *shim.Handler
-	fail  error
-	// pendingDB holds a default schema the client sent in the handshake
-	// (CLIENT_CONNECT_WITH_DB): go-mysql invokes UseDB DURING the handshake,
-	// before bindFlashbackHandler binds inner. Stashing it (and returning nil)
-	// lets the handshake complete instead of failing it; bindFlashbackHandler
-	// replays it onto the real handler. Without this, any client that connects
-	// with a default schema (mysql -D, a DSN /db path, JDBC) is rejected before
-	// auth even runs.
-	pendingDB string
-}
-
-func (r *routingHandler) UseDB(dbName string) error {
-	switch {
-	case r.inner != nil:
-		return r.inner.UseDB(dbName)
-	case r.fail != nil:
-		// Routing failed after the handshake; reject a later USE too so the
-		// failure is consistent across commands.
-		return r.fail
-	default:
-		// Pre-bind: go-mysql calls UseDB during the handshake, before inner is
-		// set. Stash it (bindFlashbackHandler replays it) and let the handshake
-		// complete rather than aborting the connection.
-		r.pendingDB = dbName
-		return nil
+	if src != "" {
+		return src, ""
 	}
-}
-
-func (r *routingHandler) HandleQuery(query string) (*gomysql.Result, error) {
-	if r.inner == nil {
-		return nil, r.unresolved()
-	}
-	return r.inner.HandleQuery(query)
-}
-
-func (r *routingHandler) unresolved() error {
-	if r.fail != nil {
-		return r.fail
-	}
-	return gomysql.NewError(gomysql.ER_UNKNOWN_ERROR, "flashback: no server bound to this connection")
-}
-
-// isFlashbackProbe reports whether a handshake error is a bare TCP probe
-// (health check / port scan) that closed before completing — logged at Debug
-// rather than Warn. Mirrors the `bintrail shim` command's classifyHandshakeErr
-// probe arm (internal/cli/shim.go) without the ProxySQL-monitor aggregator,
-// which does not apply to an embedded loopback port.
-func isFlashbackProbe(err error) bool {
-	return errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, gomysql.ErrBadConn)
-}
-
-const (
-	initialFlashbackBackoff = 100 * time.Millisecond
-	maxFlashbackBackoff     = 5 * time.Second
-)
-
-// nextFlashbackBackoff doubles the accept-retry sleep up to a cap; the zero
-// value seeds the first retry. Keeps a wedged listener from spinning the CPU or
-// flooding the log without delaying a SIGTERM more than the cap.
-func nextFlashbackBackoff(current time.Duration) time.Duration {
-	if current <= 0 {
-		return initialFlashbackBackoff
-	}
-	if next := current * 2; next < maxFlashbackBackoff {
-		return next
-	}
-	return maxFlashbackBackoff
+	return "", ""
 }

--- a/internal/console/flashback.go
+++ b/internal/console/flashback.go
@@ -43,7 +43,27 @@ type FlashbackConfig struct {
 	AuthMethod string
 }
 
-const defaultFlashbackQueryTimeout = 5 * time.Minute
+const (
+	defaultFlashbackQueryTimeout = 5 * time.Minute
+	defaultFlashbackMaxFullTable = 4
+)
+
+// withDefaults resolves the zero-value fields to their production defaults.
+// QueryTimeout is the load-bearing one: 0 means "unbounded", but the embedded
+// port has no client-disconnect pump, so a runaway query on a dropped
+// connection would never be reclaimed — the 5-minute default is the only
+// backstop. ServeFlashback always calls this, so the dangerous zero never
+// reaches the query path; keeping both substitutions here (rather than one
+// inline and one in a side variable) is why they can't drift apart.
+func (c FlashbackConfig) withDefaults() FlashbackConfig {
+	if c.QueryTimeout == 0 {
+		c.QueryTimeout = defaultFlashbackQueryTimeout
+	}
+	if c.MaxFullTable == 0 {
+		c.MaxFullTable = defaultFlashbackMaxFullTable
+	}
+	return c
+}
 
 // ServeFlashback runs a MySQL-protocol time-travel server on ln, routing every
 // connection to a monitored server's per-source index by the connection's
@@ -59,11 +79,11 @@ const defaultFlashbackQueryTimeout = 5 * time.Minute
 // token is). The connection's client library therefore connects as, e.g.,
 // `-u <server-id> -p<token>`.
 //
-// Auth requires a token: go-mysql recomputes the native / caching_sha2 scramble
-// server-side from the cleartext GetCredential returns (auth.go:57 in go-mysql
-// v1.13.0), and the console's bcrypt password store cannot produce that
-// cleartext. Callers that leave --token empty get an error here rather than an
-// unauthenticated port.
+// Auth requires a token: go-mysql validates the handshake by recomputing the
+// scramble from the cleartext GetCredential returns (the
+// compareNativePasswordAuthData path in go-mysql v1.13.0 server/auth.go), and
+// the console's bcrypt password store cannot produce that cleartext. Callers
+// that leave --token empty get an error here rather than an unauthenticated port.
 //
 // Blocks until ctx is cancelled (which closes ln and drains in-flight
 // connections) or ln fails unrecoverably.
@@ -71,22 +91,22 @@ func (s *Server) ServeFlashback(ctx context.Context, ln net.Listener, cfg Flashb
 	if s.token == "" {
 		return errors.New("flashback port requires an automation token: set --token or BINTRAIL_CONSOLE_TOKEN (the console password store cannot drive MySQL-protocol authentication)")
 	}
-	if cfg.QueryTimeout == 0 {
-		cfg.QueryTimeout = defaultFlashbackQueryTimeout
-	}
-	gateN := cfg.MaxFullTable
-	if gateN == 0 {
-		gateN = 4
-	}
+	cfg = cfg.withDefaults()
 
 	// One *server.Server for the whole port: it owns the caching_sha2_password
 	// cache and the RSA keypair (see shim.NewMySQLServer). One shared *Gate so
 	// the full-table cap is process-wide, not per-connection.
 	srv, err := shim.NewMySQLServer(cfg.AuthMethod)
 	if err != nil {
+		// ln is already bound by the caller; close it so a construction failure
+		// (an unsupported auth method) doesn't leak the listener nor leave the
+		// caller's "listening" banner pointing at a port that rejects every
+		// handshake. Unreachable from `watch` today (it passes an empty
+		// AuthMethod), but a latent trap if a --flashback-auth-method flag lands.
+		_ = ln.Close()
 		return fmt.Errorf("flashback: %w", err)
 	}
-	gate := shim.NewGate(gateN)
+	gate := shim.NewGate(cfg.MaxFullTable)
 	creds := flashbackCreds{s: s}
 	logger := slog.Default()
 
@@ -97,6 +117,9 @@ func (s *Server) ServeFlashback(ctx context.Context, ln net.Listener, cfg Flashb
 		_ = ln.Close()
 	}()
 
+	// No per-connection cap (the standalone shim's --max-connections has no
+	// equivalent here): this is a loopback-default, token-gated operator port,
+	// and the shared FullTableGate already bounds the memory-heavy queries.
 	var wg sync.WaitGroup
 	defer wg.Wait()
 
@@ -278,10 +301,11 @@ func (s *Server) flashbackDefaultSchema(id string) string {
 	return cfg.DBName
 }
 
-// flashbackCreds authenticates the flashback port: any username that maps to a
-// selectable server is accepted, all sharing the console's static token as the
-// password. It holds *Server (not a snapshot) so the registry is consulted live
-// on every handshake.
+// flashbackCreds authenticates the flashback port on the shared console token
+// alone: every username is accepted at the handshake (so the error code cannot
+// enumerate servers), and the target server is validated AFTER the handshake in
+// bindFlashbackHandler, which reads the live registry via flashbackTarget. It
+// holds *Server to read s.token directly rather than snapshotting it.
 type flashbackCreds struct {
 	s *Server
 }
@@ -361,9 +385,9 @@ func (r *routingHandler) unresolved() error {
 
 // isFlashbackProbe reports whether a handshake error is a bare TCP probe
 // (health check / port scan) that closed before completing — logged at Debug
-// rather than Warn. Mirrors the standalone shim's classifyHandshakeErr probe
-// arm without the ProxySQL-monitor aggregator, which does not apply to an
-// embedded loopback port.
+// rather than Warn. Mirrors the `bintrail shim` command's classifyHandshakeErr
+// probe arm (internal/cli/shim.go) without the ProxySQL-monitor aggregator,
+// which does not apply to an embedded loopback port.
 func isFlashbackProbe(err error) bool {
 	return errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, gomysql.ErrBadConn)
 }

--- a/internal/console/flashback_integration_test.go
+++ b/internal/console/flashback_integration_test.go
@@ -1,0 +1,170 @@
+//go:build integration
+
+package console
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// seedFlashbackIndex builds an index DB holding one myapp.users row (id=1) whose
+// name column carries `name`, and returns its DSN. The PK, the AS OF instant,
+// and the schema are shared across servers so a wire query distinguishes routing
+// purely by the returned name.
+func seedFlashbackIndex(t *testing.T, name string, now time.Time) string {
+	t.Helper()
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{now})
+
+	// PK snapshot so the wire parser can verify `WHERE id = 1` names the PK
+	// (the failure the multi-source footgun surfaced: an empty schema_snapshots
+	// fails closed with "cannot verify WHERE column is PK").
+	snapTS := now.Add(-time.Hour).Format("2006-01-02 15:04:05")
+	testutil.InsertSnapshot(t, db, 1, snapTS, "myapp", "users", "id", 1, "PRI", "int", "NO")
+	testutil.InsertSnapshot(t, db, 1, snapTS, "myapp", "users", "name", 2, "", "varchar", "YES")
+
+	eventTS := now.Add(5 * time.Minute).Format("2006-01-02 15:04:05")
+	testutil.InsertEvent(t, db, "mysql-bin.000001", 100, 200, eventTS, nil,
+		"myapp", "users", 1, "1", nil, nil,
+		[]byte(fmt.Sprintf(`{"id":1,"name":%q}`, name)))
+	return testutil.IntegrationDSN(dbName)
+}
+
+// TestIntegrationFlashbackRoutesByServer proves the issue's acceptance criterion
+// 2: one embedded time-travel port, the same _flashback query, routed to two
+// monitored servers by the connection username, returns each server's own
+// per-source index data (#996). Auth is the shared console token; selection is
+// the username (registry id OR display name).
+func TestIntegrationFlashbackRoutesByServer(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	now := time.Now().UTC().Truncate(time.Hour)
+
+	dsnA := seedFlashbackIndex(t, "alice", now)
+	dsnB := seedFlashbackIndex(t, "bob", now)
+
+	reg, err := LoadRegistry(t.TempDir() + "/servers.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// NoArchive keeps _flashback index-only (no archive_state planner path);
+	// SourceDSN seeds the default schema so the wire client needs no USE.
+	entA, err := reg.Add(ServerEntry{Name: "srva", DSN: dsnA, SourceDSN: "r:p@tcp(x:3306)/myapp", NoArchive: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	entB, err := reg.Add(ServerEntry{Name: "srvb", DSN: dsnB, SourceDSN: "r:p@tcp(x:3306)/myapp", NoArchive: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv, err := New(Config{Listen: "127.0.0.1:0", Token: "tok", Registry: reg})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	served := make(chan struct{})
+	go func() { _ = srv.ServeFlashback(ctx, ln, FlashbackConfig{}); close(served) }()
+	defer func() { cancel(); <-served }()
+
+	asOf := now.Add(10 * time.Minute).Format("2006-01-02 15:04:05")
+	q := fmt.Sprintf("SELECT * FROM _flashback.users AS OF '%s' WHERE id = 1", asOf)
+
+	for _, tc := range []struct{ user, want string }{
+		{entA.ID, "alice"},
+		{entB.ID, "bob"},
+		{"srva", "alice"}, // by display name too
+		{"srvb", "bob"},
+	} {
+		if got := queryFlashbackName(t, ln.Addr().String(), tc.user, "tok", "", q); got != tc.want {
+			t.Errorf("user %q: name = %q, want %q (routed to the wrong index?)", tc.user, got, tc.want)
+		}
+	}
+
+	// A client that sends a default database in the handshake
+	// (CLIENT_CONNECT_WITH_DB — mysql -D, a DSN /db path, JDBC) must connect:
+	// go-mysql calls UseDB DURING the handshake, before the handler is bound, so
+	// the proxy stashes it instead of aborting the connection (#996 review).
+	if got := queryFlashbackName(t, ln.Addr().String(), entA.ID, "tok", "myapp", q); got != "alice" {
+		t.Errorf("handshake with default DB: name = %q, want alice (pre-bind UseDB rejected the connection?)", got)
+	}
+
+	// A wrong password is rejected (auth is the console token).
+	if db := openFlashback(t, ln.Addr().String(), entA.ID, "wrong", ""); func() bool {
+		defer db.Close()
+		_, err := db.Query(q)
+		return err == nil
+	}() {
+		t.Error("a wrong password must be rejected")
+	}
+	// An unknown server username authenticates on the token but fails on the
+	// first query with "no such server" (validity is checked post-handshake).
+	if db := openFlashback(t, ln.Addr().String(), "ghost", "tok", ""); func() bool {
+		defer db.Close()
+		_, err := db.Query(q)
+		return err == nil
+	}() {
+		t.Error("an unknown server username must fail the query")
+	}
+}
+
+func openFlashback(t *testing.T, addr, user, pass, db string) *sql.DB {
+	t.Helper()
+	conn, err := sql.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s)/%s?parseTime=true&timeout=5s", user, pass, addr, db))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return conn
+}
+
+// queryFlashbackName runs q over a fresh flashback connection (optionally with a
+// handshake default database) and returns the `name` column of the row.
+func queryFlashbackName(t *testing.T, addr, user, pass, db, q string) string {
+	t.Helper()
+	conn := openFlashback(t, addr, user, pass, db)
+	defer conn.Close()
+	rows, err := conn.Query(q)
+	if err != nil {
+		t.Fatalf("user %q query: %v", user, err)
+	}
+	defer rows.Close()
+	cols, err := rows.Columns()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !rows.Next() {
+		t.Fatalf("user %q: no rows (routing or seed problem)", user)
+	}
+	vals := make([]sql.RawBytes, len(cols))
+	ptrs := make([]any, len(cols))
+	for i := range vals {
+		ptrs[i] = &vals[i]
+	}
+	if err := rows.Scan(ptrs...); err != nil {
+		t.Fatal(err)
+	}
+	for i, c := range cols {
+		if c == "name" {
+			return string(vals[i])
+		}
+	}
+	t.Fatalf("user %q: no name column in %v", user, cols)
+	return ""
+}

--- a/internal/console/flashback_integration_test.go
+++ b/internal/console/flashback_integration_test.go
@@ -99,11 +99,19 @@ func TestIntegrationFlashbackRoutesByServer(t *testing.T) {
 	}
 
 	// A client that sends a default database in the handshake
-	// (CLIENT_CONNECT_WITH_DB — mysql -D, a DSN /db path, JDBC) must connect:
-	// go-mysql calls UseDB DURING the handshake, before the handler is bound, so
-	// the proxy stashes it instead of aborting the connection (#996 review).
-	if got := queryFlashbackName(t, ln.Addr().String(), entA.ID, "tok", "myapp", q); got != "alice" {
-		t.Errorf("handshake with default DB: name = %q, want alice (pre-bind UseDB rejected the connection?)", got)
+	// (CLIENT_CONNECT_WITH_DB — mysql -D, a DSN /db path, JDBC) must connect AND
+	// its schema must WIN over the SourceDSN seed. entC points at server A's
+	// index but declares a DECOY source schema; connecting with handshake DB
+	// "myapp" must still resolve `_flashback.users` against myapp (where the
+	// data is). This fails two ways if the code regresses: a rejected handshake
+	// (pre-bind UseDB not stashed) or the decoy schema winning (replay dropped),
+	// either of which returns no rows instead of "alice".
+	entC, err := reg.Add(ServerEntry{Name: "srvc", DSN: dsnA, SourceDSN: "r:p@tcp(x:3306)/decoyschema", NoArchive: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := queryFlashbackName(t, ln.Addr().String(), entC.ID, "tok", "myapp", q); got != "alice" {
+		t.Errorf("handshake DB must win over the SourceDSN seed: name = %q, want alice", got)
 	}
 
 	// A wrong password is rejected (auth is the console token).

--- a/internal/console/flashback_test.go
+++ b/internal/console/flashback_test.go
@@ -2,17 +2,13 @@ package console
 
 import (
 	"context"
-	"net"
-	"strings"
+	"errors"
 	"testing"
-	"time"
-
-	gomysql "github.com/go-mysql-org/go-mysql/mysql"
 )
 
-// newFlashbackServer builds the minimal Server the flashback routing/auth code
+// newFlashbackServer builds the minimal Server the flashback resolution seam
 // touches: a connManager over reg plus a token. It bypasses New() (no HTTP mux,
-// no boot bundle) because flashbackTarget/flashbackCreds only read s.cm + s.token.
+// no boot bundle) because flashbackTarget/ResolveFlashback only read s.cm + s.token.
 func newFlashbackServer(t *testing.T, token string) (*Server, *Registry) {
 	t.Helper()
 	reg, err := LoadRegistry("")
@@ -58,65 +54,13 @@ func TestFlashbackTarget(t *testing.T) {
 	}
 }
 
-// TestFlashbackCreds: auth is the token alone. Every username — known or not —
-// gets the same token, so the handshake error code cannot leak which usernames
-// name a real server (validity is checked post-auth in bindFlashbackHandler).
-// An empty token uniformly refuses credentials (defence in depth behind the
-// ServeFlashback startup guard).
-func TestFlashbackCreds(t *testing.T) {
-	s, reg := newFlashbackServer(t, "sekret")
-	a, err := reg.Add(ServerEntry{Name: "alpha", DSN: "u:p@tcp(h:3306)/idxA"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	creds := flashbackCreds{s: s}
-
-	// A known username and an unknown one are indistinguishable at the handshake.
-	for _, u := range []string{a.ID, "alpha", "ghost", ""} {
-		if ok, _ := creds.CheckUsername(u); !ok {
-			t.Fatalf("CheckUsername(%q) = false, want true (token-only auth)", u)
-		}
-		if pw, found, _ := creds.GetCredential(u); !found || pw != "sekret" {
-			t.Fatalf("GetCredential(%q) = (%q,%v), want (sekret,true)", u, pw, found)
-		}
-	}
-
-	// No token: every connection is denied, including a valid server username.
-	s.token = ""
-	if ok, _ := creds.CheckUsername(a.ID); ok {
-		t.Fatal("no token: CheckUsername must deny")
-	}
-	if _, found, _ := creds.GetCredential(a.ID); found {
-		t.Fatal("no token must never authorise a passwordless handshake")
-	}
-}
-
-// TestSplitBaselineSource: a resolved baseline source maps to the shim's dir/S3
-// fields by scheme.
-func TestSplitBaselineSource(t *testing.T) {
-	for _, tc := range []struct {
-		src, dir, s3 string
-	}{
-		{"", "", ""},
-		{"/var/lib/baselines", "/var/lib/baselines", ""},
-		{"s3://bucket/prefix/", "", "s3://bucket/prefix/"},
-	} {
-		dir, s3 := splitBaselineSource(tc.src)
-		if dir != tc.dir || s3 != tc.s3 {
-			t.Errorf("splitBaselineSource(%q) = (%q,%q), want (%q,%q)", tc.src, dir, s3, tc.dir, tc.s3)
-		}
-	}
-}
-
-// TestRoutingHandlerPendingDB: a UseDB before inner is bound (the go-mysql
-// handshake path) is stashed and does not fail the connection.
-func TestRoutingHandlerPendingDB(t *testing.T) {
-	r := &routingHandler{}
-	if err := r.UseDB("shopdb"); err != nil {
-		t.Fatalf("pre-bind UseDB must not error (handshake would abort): %v", err)
-	}
-	if r.pendingDB != "shopdb" {
-		t.Fatalf("pendingDB = %q, want shopdb", r.pendingDB)
+// TestResolveFlashbackUnknown: an unknown selector is reported as
+// ErrUnknownServer (the serving layer maps it to a MySQL "no such database"),
+// without opening any connection.
+func TestResolveFlashbackUnknown(t *testing.T) {
+	s, _ := newFlashbackServer(t, "tok")
+	if _, err := s.ResolveFlashback(context.Background(), "ghost"); !errors.Is(err, ErrUnknownServer) {
+		t.Fatalf("ResolveFlashback(unknown) err = %v, want ErrUnknownServer", err)
 	}
 }
 
@@ -143,81 +87,18 @@ func TestFlashbackDefaultSchema(t *testing.T) {
 	}
 }
 
-// TestRoutingHandlerUnresolved: with no bound handler, HandleQuery errors
-// generically; once routing has set a fail, BOTH verbs return it verbatim.
-func TestRoutingHandlerUnresolved(t *testing.T) {
-	r := &routingHandler{}
-	if _, err := r.HandleQuery("SELECT 1"); err == nil {
-		t.Fatal("HandleQuery with nil inner must error")
-	}
-
-	want := gomysql.NewError(gomysql.ER_BAD_DB_ERROR, "boom")
-	r.fail = want
-	if _, err := r.HandleQuery("SELECT 1"); err != want {
-		t.Fatalf("HandleQuery returned %v, want the stored fail", err)
-	}
-	if err := r.UseDB("x"); err != want {
-		t.Fatalf("UseDB returned %v, want the stored fail (unresolvable connection must reject USE too)", err)
-	}
-}
-
-// TestServeFlashbackRequiresToken: the port refuses to start without a token,
-// since MySQL-protocol auth cannot be driven by the bcrypt password store.
-func TestServeFlashbackRequiresToken(t *testing.T) {
-	s, _ := newFlashbackServer(t, "")
-	err := s.ServeFlashback(context.Background(), nil, FlashbackConfig{})
-	if err == nil || !strings.Contains(err.Error(), "token") {
-		t.Fatalf("empty token: err = %v, want a token-required error", err)
-	}
-}
-
-// TestServeFlashbackDrainsActiveConn: ServeFlashback returns only after an
-// IN-FLIGHT connection has drained when ctx is cancelled — pinning the
-// wg.Add/wg.Wait drain (a regression dropping wg.Add would let ServeFlashback
-// return while a handler goroutine still runs, and this would still pass a
-// naive no-connection test).
-func TestServeFlashbackDrainsActiveConn(t *testing.T) {
-	s, _ := newFlashbackServer(t, "tok")
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	ctx, cancel := context.WithCancel(context.Background())
-	done := make(chan error, 1)
-	go func() { done <- s.ServeFlashback(ctx, ln, FlashbackConfig{}) }()
-
-	// Open a raw connection and read the server's handshake greeting: that
-	// confirms the accept loop has spawned an in-flight handler goroutine
-	// (wg > 0) before we cancel, so the drain is actually exercised.
-	conn, err := net.Dial("tcp", ln.Addr().String())
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer conn.Close()
-	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
-	if _, err := conn.Read(make([]byte, 1)); err != nil {
-		t.Fatalf("expected a handshake greeting from the flashback port: %v", err)
-	}
-
-	cancel() // daemon shutdown must drain the in-flight connection
-	select {
-	case <-done:
-	case <-time.After(5 * time.Second):
-		t.Fatal("ServeFlashback did not drain the in-flight connection on ctx cancel")
-	}
-}
-
-func TestNextFlashbackBackoff(t *testing.T) {
-	if got := nextFlashbackBackoff(0); got != initialFlashbackBackoff {
-		t.Fatalf("seed = %v, want %v", got, initialFlashbackBackoff)
-	}
-	if got := nextFlashbackBackoff(initialFlashbackBackoff); got != 2*initialFlashbackBackoff {
-		t.Fatalf("double = %v, want %v", got, 2*initialFlashbackBackoff)
-	}
-	if got := nextFlashbackBackoff(maxFlashbackBackoff); got != maxFlashbackBackoff {
-		t.Fatalf("at cap = %v, want %v", got, maxFlashbackBackoff)
-	}
-	if got := nextFlashbackBackoff(4 * time.Second); got != maxFlashbackBackoff {
-		t.Fatalf("past cap = %v, want %v", got, maxFlashbackBackoff)
+// TestSplitBaselineSource: a resolved baseline source maps to dir/S3 by scheme.
+func TestSplitBaselineSource(t *testing.T) {
+	for _, tc := range []struct {
+		src, dir, s3 string
+	}{
+		{"", "", ""},
+		{"/var/lib/baselines", "/var/lib/baselines", ""},
+		{"s3://bucket/prefix/", "", "s3://bucket/prefix/"},
+	} {
+		dir, s3 := splitBaselineSource(tc.src)
+		if dir != tc.dir || s3 != tc.s3 {
+			t.Errorf("splitBaselineSource(%q) = (%q,%q), want (%q,%q)", tc.src, dir, s3, tc.dir, tc.s3)
+		}
 	}
 }

--- a/internal/console/flashback_test.go
+++ b/internal/console/flashback_test.go
@@ -2,6 +2,7 @@ package console
 
 import (
 	"context"
+	"net"
 	"strings"
 	"testing"
 	"time"
@@ -167,6 +168,42 @@ func TestServeFlashbackRequiresToken(t *testing.T) {
 	err := s.ServeFlashback(context.Background(), nil, FlashbackConfig{})
 	if err == nil || !strings.Contains(err.Error(), "token") {
 		t.Fatalf("empty token: err = %v, want a token-required error", err)
+	}
+}
+
+// TestServeFlashbackDrainsActiveConn: ServeFlashback returns only after an
+// IN-FLIGHT connection has drained when ctx is cancelled — pinning the
+// wg.Add/wg.Wait drain (a regression dropping wg.Add would let ServeFlashback
+// return while a handler goroutine still runs, and this would still pass a
+// naive no-connection test).
+func TestServeFlashbackDrainsActiveConn(t *testing.T) {
+	s, _ := newFlashbackServer(t, "tok")
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- s.ServeFlashback(ctx, ln, FlashbackConfig{}) }()
+
+	// Open a raw connection and read the server's handshake greeting: that
+	// confirms the accept loop has spawned an in-flight handler goroutine
+	// (wg > 0) before we cancel, so the drain is actually exercised.
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	if _, err := conn.Read(make([]byte, 1)); err != nil {
+		t.Fatalf("expected a handshake greeting from the flashback port: %v", err)
+	}
+
+	cancel() // daemon shutdown must drain the in-flight connection
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ServeFlashback did not drain the in-flight connection on ctx cancel")
 	}
 }
 

--- a/internal/console/flashback_test.go
+++ b/internal/console/flashback_test.go
@@ -1,0 +1,186 @@
+package console
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	gomysql "github.com/go-mysql-org/go-mysql/mysql"
+)
+
+// newFlashbackServer builds the minimal Server the flashback routing/auth code
+// touches: a connManager over reg plus a token. It bypasses New() (no HTTP mux,
+// no boot bundle) because flashbackTarget/flashbackCreds only read s.cm + s.token.
+func newFlashbackServer(t *testing.T, token string) (*Server, *Registry) {
+	t.Helper()
+	reg, err := LoadRegistry("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &Server{cm: newConnManager(reg, false), token: token}, reg
+}
+
+// TestFlashbackTarget: a username resolves to a canonical server id by registry
+// ID, by display Name, or "default" for a visible boot entry — and to nothing
+// for an empty/unknown selector or a hidden boot.
+func TestFlashbackTarget(t *testing.T) {
+	s, reg := newFlashbackServer(t, "tok")
+	a, err := reg.Add(ServerEntry{Name: "alpha", DSN: "u:p@tcp(h:3306)/idxA"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id, ok := s.flashbackTarget(a.ID); !ok || id != a.ID {
+		t.Fatalf("by id: got (%q,%v), want (%q,true)", id, ok, a.ID)
+	}
+	if id, ok := s.flashbackTarget("alpha"); !ok || id != a.ID {
+		t.Fatalf("by name: got (%q,%v), want (%q,true)", id, ok, a.ID)
+	}
+	if _, ok := s.flashbackTarget("nope"); ok {
+		t.Fatal("unknown selector must not resolve")
+	}
+	if _, ok := s.flashbackTarget(""); ok {
+		t.Fatal("empty selector must not resolve")
+	}
+
+	// Boot: not a target until it exists AND is visible.
+	if _, ok := s.flashbackTarget(bootServerID); ok {
+		t.Fatal("absent boot must not resolve")
+	}
+	s.cm.boot = &bundle{}
+	if id, ok := s.flashbackTarget(bootServerID); !ok || id != bootServerID {
+		t.Fatalf("visible boot: got (%q,%v), want (%q,true)", id, ok, bootServerID)
+	}
+	s.cm.hideBoot = true
+	if _, ok := s.flashbackTarget(bootServerID); ok {
+		t.Fatal("hidden boot (source-less watch anchor) must not be a flashback target")
+	}
+}
+
+// TestFlashbackCreds: auth is the token alone. Every username — known or not —
+// gets the same token, so the handshake error code cannot leak which usernames
+// name a real server (validity is checked post-auth in bindFlashbackHandler).
+// An empty token uniformly refuses credentials (defence in depth behind the
+// ServeFlashback startup guard).
+func TestFlashbackCreds(t *testing.T) {
+	s, reg := newFlashbackServer(t, "sekret")
+	a, err := reg.Add(ServerEntry{Name: "alpha", DSN: "u:p@tcp(h:3306)/idxA"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	creds := flashbackCreds{s: s}
+
+	// A known username and an unknown one are indistinguishable at the handshake.
+	for _, u := range []string{a.ID, "alpha", "ghost", ""} {
+		if ok, _ := creds.CheckUsername(u); !ok {
+			t.Fatalf("CheckUsername(%q) = false, want true (token-only auth)", u)
+		}
+		if pw, found, _ := creds.GetCredential(u); !found || pw != "sekret" {
+			t.Fatalf("GetCredential(%q) = (%q,%v), want (sekret,true)", u, pw, found)
+		}
+	}
+
+	// No token: every connection is denied, including a valid server username.
+	s.token = ""
+	if ok, _ := creds.CheckUsername(a.ID); ok {
+		t.Fatal("no token: CheckUsername must deny")
+	}
+	if _, found, _ := creds.GetCredential(a.ID); found {
+		t.Fatal("no token must never authorise a passwordless handshake")
+	}
+}
+
+// TestSplitBaselineSource: a resolved baseline source maps to the shim's dir/S3
+// fields by scheme.
+func TestSplitBaselineSource(t *testing.T) {
+	for _, tc := range []struct {
+		src, dir, s3 string
+	}{
+		{"", "", ""},
+		{"/var/lib/baselines", "/var/lib/baselines", ""},
+		{"s3://bucket/prefix/", "", "s3://bucket/prefix/"},
+	} {
+		dir, s3 := splitBaselineSource(tc.src)
+		if dir != tc.dir || s3 != tc.s3 {
+			t.Errorf("splitBaselineSource(%q) = (%q,%q), want (%q,%q)", tc.src, dir, s3, tc.dir, tc.s3)
+		}
+	}
+}
+
+// TestRoutingHandlerPendingDB: a UseDB before inner is bound (the go-mysql
+// handshake path) is stashed and does not fail the connection.
+func TestRoutingHandlerPendingDB(t *testing.T) {
+	r := &routingHandler{}
+	if err := r.UseDB("shopdb"); err != nil {
+		t.Fatalf("pre-bind UseDB must not error (handshake would abort): %v", err)
+	}
+	if r.pendingDB != "shopdb" {
+		t.Fatalf("pendingDB = %q, want shopdb", r.pendingDB)
+	}
+}
+
+// TestFlashbackDefaultSchema derives the USE-less default schema from a
+// registry entry's SourceDSN; empty for a source-less entry or the boot entry.
+func TestFlashbackDefaultSchema(t *testing.T) {
+	s, reg := newFlashbackServer(t, "tok")
+	a, err := reg.Add(ServerEntry{Name: "alpha", DSN: "u:p@tcp(h:3306)/idxA", SourceDSN: "r:pw@tcp(src:3306)/shopdb"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := s.flashbackDefaultSchema(a.ID); got != "shopdb" {
+		t.Fatalf("default schema = %q, want shopdb", got)
+	}
+	b, err := reg.Add(ServerEntry{Name: "beta", DSN: "u:p@tcp(h:3306)/idxB"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := s.flashbackDefaultSchema(b.ID); got != "" {
+		t.Fatalf("source-less entry: default schema = %q, want empty", got)
+	}
+	if got := s.flashbackDefaultSchema(bootServerID); got != "" {
+		t.Fatalf("boot: default schema = %q, want empty", got)
+	}
+}
+
+// TestRoutingHandlerUnresolved: with no bound handler, HandleQuery errors
+// generically; once routing has set a fail, BOTH verbs return it verbatim.
+func TestRoutingHandlerUnresolved(t *testing.T) {
+	r := &routingHandler{}
+	if _, err := r.HandleQuery("SELECT 1"); err == nil {
+		t.Fatal("HandleQuery with nil inner must error")
+	}
+
+	want := gomysql.NewError(gomysql.ER_BAD_DB_ERROR, "boom")
+	r.fail = want
+	if _, err := r.HandleQuery("SELECT 1"); err != want {
+		t.Fatalf("HandleQuery returned %v, want the stored fail", err)
+	}
+	if err := r.UseDB("x"); err != want {
+		t.Fatalf("UseDB returned %v, want the stored fail (unresolvable connection must reject USE too)", err)
+	}
+}
+
+// TestServeFlashbackRequiresToken: the port refuses to start without a token,
+// since MySQL-protocol auth cannot be driven by the bcrypt password store.
+func TestServeFlashbackRequiresToken(t *testing.T) {
+	s, _ := newFlashbackServer(t, "")
+	err := s.ServeFlashback(context.Background(), nil, FlashbackConfig{})
+	if err == nil || !strings.Contains(err.Error(), "token") {
+		t.Fatalf("empty token: err = %v, want a token-required error", err)
+	}
+}
+
+func TestNextFlashbackBackoff(t *testing.T) {
+	if got := nextFlashbackBackoff(0); got != initialFlashbackBackoff {
+		t.Fatalf("seed = %v, want %v", got, initialFlashbackBackoff)
+	}
+	if got := nextFlashbackBackoff(initialFlashbackBackoff); got != 2*initialFlashbackBackoff {
+		t.Fatalf("double = %v, want %v", got, 2*initialFlashbackBackoff)
+	}
+	if got := nextFlashbackBackoff(maxFlashbackBackoff); got != maxFlashbackBackoff {
+		t.Fatalf("at cap = %v, want %v", got, maxFlashbackBackoff)
+	}
+	if got := nextFlashbackBackoff(4 * time.Second); got != maxFlashbackBackoff {
+		t.Fatalf("past cap = %v, want %v", got, maxFlashbackBackoff)
+	}
+}

--- a/internal/console/manager.go
+++ b/internal/console/manager.go
@@ -388,6 +388,18 @@ func (cm *connManager) bootHidden() bool {
 	return cm.hideBoot && cm.boot != nil
 }
 
+// bootSelectable reports whether the boot entry may be picked as a flashback
+// target: it exists AND is not hidden. Mirrors what the console's server
+// switcher lists, so `USE`-by-username on the flashback port only reaches the
+// same servers the operator sees in the UI (a hidden boot is the empty
+// control-plane anchor of a source-less watch — never a useful time-travel
+// source).
+func (cm *connManager) bootSelectable() bool {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	return cm.boot != nil && !cm.hideBoot
+}
+
 // CloseAll closes every cached registry connection. The boot entry's db is
 // NOT closed here — the cmd layer opened it and owns its defer Close().
 func (cm *connManager) CloseAll() {


### PR DESCRIPTION
## What

`bintrail-console watch --flashback-listen <addr>` exposes an embedded
MySQL-protocol time-travel port — `_flashback` / `_snapshot` / `_diff` for
**every monitored server**, routed by the connection **username** (a server's
registry id, display name, or `default` for the boot entry). It reuses the
console's `connManager`, which already resolves each server's own per-source
index (`bintrail_idx_<id>`) and baseline.

Closes #996.

### Before (the friction #996 describes)
To time-travel a source you already monitor in the console you had to: discover
the per-source index DB by hand, hand-build an `INDEX_DSN`, and run a **separate**
`bintrail shim` container per source (one shim = one index). All of that is
state the `watch` daemon already has resolved in memory.

### After
```sh
bintrail-console watch --index-dsn ... --console-token "$TOK" --flashback-listen 127.0.0.1:3308
mysql -h 127.0.0.1 -P 3308 -u <server-id-or-name> -p"$TOK"
mysql> USE myapp;   -- optional, seeded from the server's source DSN when known
mysql> SELECT * FROM _flashback.orders AS OF '2026-05-02 10:00:00' WHERE id = 12345;
```

## How
- **`internal/console/flashback.go`** (package `console`, for the unexported
  `connManager`/`bundle`): a compact accept loop + a `routingHandler` proxy + a
  token-only credential provider. Reuses `internal/shim` (`Handler`, `Config`,
  `NewMySQLServer`, `NewGate`) — no import cycle; standalone `bintrail shim` is
  untouched (additive).
- **Proxy handler**: go-mysql binds the `Handler` at `NewCustomizedConn` *before*
  `GetUser()` reveals the target server, so an empty `routingHandler` is passed
  and its `inner *shim.Handler` is set once the username is known. A default DB
  the client sends in the handshake (`CLIENT_CONNECT_WITH_DB`) is stashed and
  replayed onto the real handler (the client's schema wins over the SourceDSN
  seed).
- **Auth**: the console `--token` is the shared password (the bcrypt password
  store cannot drive native-password auth). A token is **required** — the port
  refuses to start otherwise, and `GetCredential` denies on an empty token.
  Server validity is checked *post-handshake* so the handshake error code can't
  enumerate monitored servers.
- **`watch.go`**: `--flashback-listen` + `BINTRAIL_CONSOLE_FLASHBACK_LISTEN`,
  bound synchronously (fails fast) and drained before the deferred index
  `db.Close()` in both the source-ful and source-less serve paths.

## Acceptance
- ✅ `watch --flashback-listen` serves the three virtual schemas for every
  monitored server, no extra container / no `INDEX_DSN`.
- ✅ Selecting a server routes to that server's per-source index + baseline
  (integration test: same query, two servers, distinct data).
- ✅ Standalone `bintrail shim` behavior unchanged.
- ✅ OSS only — the shim emits source-table rows, never `connection_id`/`query_text`.

## Review
Ran a 6-dimension adversarial review (find → refute-by-default verify). Fixed all
confirmed findings before this PR:
- **HIGH** a client connecting with a default DB was rejected at handshake →
  stash-and-replay the pre-bind `UseDB`.
- **MED** `runUpConsoleOnly` could hang on a non-signal `Serve` error → cancel
  ctx before draining the port.
- **MED** `startFlashbackPort` had no coverage → cmd-layer tests (token guard,
  bind+drain ordering, env fallback).
- **LOW** username enumeration via distinct error codes → token-only auth.
- **LOW** baseline mapping untested → extracted `splitBaselineSource` + unit test.

## Known limitation (documented)
`_snapshot` parity: a server configured with **both** a local `--baseline-dir`
**and** an `--baseline-s3` copy reads `_snapshot` only from the local dir on this
port — the #766 local→S3 fallback the console tab carries is not represented.
Single-source baseline configs (the common case) have full parity. For a pruned
local dir with a durable S3 copy, use the console Time-travel tab or a standalone
shim pointed at the S3 prefix.

## Tests
- Unit: routing/target resolution, token-only creds (+ empty-token denial),
  `routingHandler` stash/fail paths, `splitBaselineSource`, backoff, and the
  cmd-layer `startFlashbackPort` guard/drain/env.
- Integration (`//go:build integration`): two-server wire routing by id **and**
  name, handshake-with-default-DB, wrong-password + unknown-server rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
