### PR TITLE
shim: fold PostgreSQL baselines in single-row _snapshot (#1006)

### DIFF
--- a/internal/shim/snapshot.go
+++ b/internal/shim/snapshot.go
@@ -496,7 +496,9 @@ func (h *Handler) fullTableTextCell(schema, table, column string, v any) any {
 // canonicalization in the offline merge), so it is kept as a separate
 // matcher: a future change to one path's type support must not silently
 // move the other. Types reconstruct rejects outright (FLOAT, BLOB, BIT,
-// JSON, …) are not listed and therefore fall back to the binlog-only path.
+// JSON, …) are not listed and therefore fall back to the binlog-only path —
+// for MySQL-family sources. A PostgreSQL source bypasses this matcher entirely
+// (its data_type is "" and its baseline is raw text — see runSnapshotPointInTime).
 func baselinePKStringMatchable(dataType string) bool {
 	switch strings.ToLower(strings.TrimSpace(dataType)) {
 	case "int", "integer", "smallint", "tinyint", "mediumint", "bigint",
@@ -520,8 +522,10 @@ func baselinePKStringMatchable(dataType string) bool {
 // It falls back to the binlog-only point-lookup (runPointInTime) — with
 // a log line so the degradation is visible — in four cases:
 //   - no baseline source configured (the pre-#355 default),
-//   - the PK column's type isn't one the baseline matcher supports
-//     (a typed WHERE would silently miss the row),
+//   - the PK column's type isn't one the baseline matcher supports AND the
+//     source isn't PostgreSQL (a PG source carries an empty data_type but its
+//     raw-text baseline makes every PK a string-identity match — see the flavor
+//     bypass below; a typed WHERE would otherwise silently miss the row),
 //   - the schema resolver is unavailable (can't determine the PK type),
 //   - no baseline exists for this table at-or-before AsOf.
 //
@@ -554,10 +558,35 @@ func (h *Handler) runSnapshotPointInTime(q TimeTravelQuery) (*mysql.Result, erro
 			"schema", q.Schema, "table", q.Table, "pk_column", q.PKColumn)
 		return h.runPointInTime(q)
 	}
+	// PostgreSQL baselines store every column as raw pgoutput text
+	// (baseline.Column.RawText, #593), so ReadBaselineRow's string-bound
+	// `pkColumn = ?` match is a string-identity join that can only recover the
+	// right row or find nothing — never a wrong row — the same reason the offline
+	// reconstruct path treats all PG PK columns as string-matchable (#593 slice
+	// D). The MySQL DATA_TYPE token is empty for a PG source
+	// (schema_snapshots.data_type is "" — PG records pg_type_oid, not the MySQL
+	// type), so without this flavor bypass every PG _snapshot would silently
+	// degrade to binlog-only and the baseline fold the docs promise would never
+	// run (#1006). The flavor read is short-circuited so the MySQL hot path (a
+	// matchable type) never pays for the extra query.
 	if !baselinePKStringMatchable(dataType) {
-		h.logger.Warn("shim: _snapshot PK type not safe for baseline lookup; using binlog-only path",
-			"schema", q.Schema, "table", q.Table, "pk_column", q.PKColumn, "pk_type", dataType)
-		return h.runPointInTime(q)
+		if flavor := query.SourceFlavor(h.indexDB); flavor != "postgres" {
+			if dataType == "" {
+				// The empty data_type is the PostgreSQL shape, so reaching here
+				// means a PG source whose flavor could not be confirmed (a
+				// transient stream_state read failure, or a legacy index missing
+				// the flavor column). Name that as the reason — blaming the
+				// (irrelevant, empty) PK type only misleads an operator debugging
+				// an empty _snapshot result.
+				h.logger.Warn("shim: _snapshot could not confirm a postgres source flavor (stream_state read empty or failed); "+
+					"baseline fold skipped, using binlog-only path — a row untouched within the binlog window will read as absent",
+					"schema", q.Schema, "table", q.Table, "pk_column", q.PKColumn, "flavor", flavor)
+			} else {
+				h.logger.Warn("shim: _snapshot PK type not safe for baseline lookup; using binlog-only path",
+					"schema", q.Schema, "table", q.Table, "pk_column", q.PKColumn, "pk_type", dataType)
+			}
+			return h.runPointInTime(q)
+		}
 	}
 
 	ctx, cancel := h.queryContext()

--- a/internal/shim/snapshot_integration_test.go
+++ b/internal/shim/snapshot_integration_test.go
@@ -1321,3 +1321,155 @@ func TestSnapshotBaseline_EnumLabelsAcrossBaselineAndDeltas(t *testing.T) {
 		t.Errorf("_snapshot full-table = %v, want id=1 'pending' (baseline) and id=2 'shipped' (mapped delta)", got)
 	}
 }
+
+// setSourceFlavor stamps stream_state so query.SourceFlavor(db) reports the
+// given flavor. The single-row _snapshot PostgreSQL baseline bypass (#1006)
+// keys off it.
+func setSourceFlavor(t *testing.T, db *sql.DB, flavor string) {
+	t.Helper()
+	if _, err := db.Exec(`INSERT INTO stream_state (id, mode, flavor, last_checkpoint, server_id)
+		VALUES (1, 'gtid', ?, NOW(), 5001)
+		ON DUPLICATE KEY UPDATE flavor = VALUES(flavor)`, flavor); err != nil {
+		t.Fatalf("set source flavor: %v", err)
+	}
+}
+
+// TestSnapshotBaseline_PostgresPKTypeBypass is the #1006 guard. For a
+// PostgreSQL source, schema_snapshots.data_type is "" (PG records pg_type_oid,
+// not the MySQL type token), which the MySQL PK-type gate rejects. Without the
+// flavor bypass the single-row _snapshot silently degrades to binlog-only, so a
+// row present in the baseline but never touched in the binlog window resolves to
+// zero rows — the baseline fold the docs promise never runs. With
+// flavor='postgres' the fold runs (PG baselines are raw-text, so the PK match is
+// an identity string join for any type) and the row resolves, while _flashback
+// (binlog-only) still returns nothing for the same query.
+func TestSnapshotBaseline_PostgresPKTypeBypass(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	setSourceFlavor(t, db, "postgres")
+
+	hourTop := time.Now().UTC().Truncate(time.Hour)
+	addHourlyPartition(t, db, hourTop)
+	snapTime := hourTop.Add(1 * time.Minute)
+	asOf := hourTop.Add(10 * time.Minute)
+
+	// PG-style schema snapshot: PRI id with an EMPTY data_type — the exact
+	// shape that tripped the gate — plus a plain column.
+	ts := snapTime.UTC().Format("2006-01-02 15:04:05")
+	testutil.InsertSnapshot(t, db, 1, ts, "public", "orders", "id", 1, "PRI", "", "NO")
+	testutil.InsertSnapshot(t, db, 1, ts, "public", "orders", "amount", 2, "", "", "YES")
+
+	// PG baselines store values as raw pgoutput text — represent id/amount as
+	// strings.
+	cols := []baseline.Column{
+		{Name: "id", MySQLType: "varchar", ParquetType: baseline.MysqlToParquetNode("varchar")},
+		{Name: "amount", MySQLType: "varchar", ParquetType: baseline.MysqlToParquetNode("varchar")},
+	}
+	// id=7 is in the baseline and never touched afterwards (pass-through fold).
+	// id=8 is in the baseline AND updated after it (delta fold) — the case that
+	// proves post-snapshot deltas actually merge onto a PG baseline through the
+	// bypassed gate, not just that the baseline was read.
+	baselineDir := writeBaselineSnapshot(t, snapTime, "public", "orders", cols, [][]string{
+		{"7", "77.77"},
+		{"8", "88.88"},
+	})
+	eventTS := hourTop.Add(5 * time.Minute).Format("2006-01-02 15:04:05")
+	testutil.InsertEvent(t, db, "pg-0/1000", 100, 200, eventTS, nil,
+		"public", "orders", 2 /*update*/, "8", nil,
+		[]byte(`{"id":"8","amount":"88.88"}`), []byte(`{"id":"8","amount":"314.15"}`))
+
+	h := NewHandlerWithConfig(db, Config{
+		AllowGaps:   true,
+		NoArchive:   true,
+		IndexDBName: dbName,
+		BaselineDir: baselineDir,
+	}, slog.Default())
+
+	// _snapshot must fold the baseline (id=7 never touched → baseline image).
+	res, err := h.runSnapshot(TimeTravelQuery{Type: TypeSnapshot, Schema: "public", Table: "orders", PKColumn: "id", PKValue: "7", AsOf: asOf})
+	if err != nil {
+		t.Fatalf("_snapshot id=7: %v", err)
+	}
+	cells := rowCells(t, res.Resultset)
+	if len(cells) != 1 {
+		t.Fatalf("_snapshot id=7: expected 1 row from the baseline fold, got %d (PG bypass regressed → binlog-only)", len(cells))
+	}
+	if want := []string{"7", "77.77"}; !slices.Equal(cells[0], want) {
+		t.Errorf("_snapshot id=7 row = %v, want %v", cells[0], want)
+	}
+
+	// _flashback (binlog-only) sees nothing for the never-touched row — the
+	// divergence that proves _snapshot actually consulted the baseline.
+	flash, err := h.runPointInTime(TimeTravelQuery{Type: TypeFlashback, Schema: "public", Table: "orders", PKColumn: "id", PKValue: "7", AsOf: asOf})
+	if err != nil {
+		t.Fatalf("_flashback id=7: %v", err)
+	}
+	if got := len(flash.Resultset.RowDatas); got != 0 {
+		t.Errorf("_flashback id=7 (never touched): expected 0 rows, got %d — divergence with _snapshot lost", got)
+	}
+
+	// id=8: present in the baseline AND updated after it → the post-snapshot
+	// UPDATE folds onto the PG baseline image (delta wins). Proves the deltas
+	// actually merge on the PG path, not just that the baseline was read.
+	res8, err := h.runSnapshot(TimeTravelQuery{Type: TypeSnapshot, Schema: "public", Table: "orders", PKColumn: "id", PKValue: "8", AsOf: asOf})
+	if err != nil {
+		t.Fatalf("_snapshot id=8: %v", err)
+	}
+	if cells8 := rowCells(t, res8.Resultset); len(cells8) != 1 || !slices.Equal(cells8[0], []string{"8", "314.15"}) {
+		t.Errorf("_snapshot id=8 = %v, want [[8 314.15]] (post-baseline UPDATE must fold onto the PG baseline)", cells8)
+	}
+}
+
+// TestSnapshotBaseline_NonPostgresPKTypeStaysGated is the load-bearing
+// complement to the #1006 PostgreSQL bypass: a NON-PostgreSQL source with a
+// non-matchable PK type must STILL degrade to binlog-only. This pins the flavor
+// term — a refactor that widened the gate for every source (dropping the
+// `!= "postgres"` clause, or bypassing on any empty/unsupported type) would let
+// a MySQL non-string PK reach the baseline match, the exact silent-wrong-answer
+// baselinePKStringMatchable exists to prevent. A never-touched baseline row must
+// therefore resolve to zero rows here, not to its baseline image.
+func TestSnapshotBaseline_NonPostgresPKTypeStaysGated(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	setSourceFlavor(t, db, "mysql")
+
+	hourTop := time.Now().UTC().Truncate(time.Hour)
+	addHourlyPartition(t, db, hourTop)
+	snapTime := hourTop.Add(1 * time.Minute)
+	asOf := hourTop.Add(10 * time.Minute)
+
+	// A MySQL source with a JSON primary key — non-matchable via
+	// baselinePKStringMatchable, and NOT postgres, so the gate must hold.
+	ts := snapTime.UTC().Format("2006-01-02 15:04:05")
+	testutil.InsertSnapshot(t, db, 1, ts, "myapp", "items", "id", 1, "PRI", "json", "NO")
+
+	cols := []baseline.Column{
+		{Name: "id", MySQLType: "varchar", ParquetType: baseline.MysqlToParquetNode("varchar")},
+	}
+	baselineDir := writeBaselineSnapshot(t, snapTime, "myapp", "items", cols, [][]string{
+		{"7"},
+	})
+
+	h := NewHandlerWithConfig(db, Config{
+		AllowGaps:   true,
+		NoArchive:   true,
+		IndexDBName: dbName,
+		BaselineDir: baselineDir,
+	}, slog.Default())
+
+	// id=7 is in the baseline but never touched; with the gate held (non-PG,
+	// non-matchable type) _snapshot degrades to binlog-only → zero rows.
+	res, err := h.runSnapshot(TimeTravelQuery{Type: TypeSnapshot, Schema: "myapp", Table: "items", PKColumn: "id", PKValue: "7", AsOf: asOf})
+	if err != nil {
+		t.Fatalf("_snapshot id=7: %v", err)
+	}
+	if got := len(res.Resultset.RowDatas); got != 0 {
+		t.Errorf("_snapshot id=7 (non-PG, non-matchable PK): expected 0 rows (gate must hold), got %d — the PG bypass leaked to a non-PG source", got)
+	}
+}


### PR DESCRIPTION
Closes #1006.

## Problem
The shim's single-row `_snapshot` silently degraded to binlog-only for every PostgreSQL source: `schema_snapshots.data_type` is `""` for PG (it records `pg_type_oid`, not the MySQL type token), so `baselinePKStringMatchable("")` was always false and the handler fell back to `runPointInTime`. A row present in the baseline but never touched in the binlog window resolved to zero rows — the baseline fold `docs/postgres.md` promises never ran. Also affects the embedded flashback port in `bintrail-console watch` (#996, same `internal/shim/snapshot.go` path).

## Fix
Bypass the PK-type gate in `runSnapshotPointInTime` when `query.SourceFlavor(h.indexDB) == "postgres"`. PG baselines store every column as raw pgoutput text (`baseline.Column.RawText`, #593), so `ReadBaselineRow`'s string-bound `pkColumn = ?` match is a byte-for-byte identity join for any PK type — the same reason the offline `reconstruct` path treats all PG PK columns as string-matchable (#593 slice D). The flavor read is short-circuited so the MySQL hot path (a matchable type) never pays for it.

Full-table `_snapshot` already fails *loud* for PG (out of GA scope); only the single-row path degraded silently. CLI `reconstruct` and the console HTTP `/api/reconstruct` use `reconstruct.ApplyAt` and were unaffected.

## Test
`TestSnapshotBaseline_PostgresPKTypeBypass` (integration): PG-flavored `stream_state`, `schema_snapshots` with empty `data_type`, a baseline row never touched afterwards — asserts `_snapshot` folds the baseline (id resolves) while `_flashback` returns nothing. Fails before the fix (0 rows), passes after.

## Validated live on RDS PostgreSQL 16.14
Built this branch, ran the shim against a real RDS source with a `bintrail-pg baseline`, witness row `id=7` updated after the baseline:

| query (`WHERE id=7`) | before fix | after fix |
|---|---|---|
| `_snapshot AS OF <pre-update>`  | (empty) | **77.77 / 7.0000007 / new** (baseline) |
| `_snapshot AS OF <post-update>` | 314.15  | 314.15 / 2.718281828 / paid (delta) |
| `_flashback AS OF <pre-update>` | (empty) | (empty) — binlog-only, unchanged |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
