### PR TITLE
pgshim: PostgreSQL wire-protocol front-end for single-row time-travel (#1008)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,11 +336,13 @@ jobs:
         run: |
           set -o pipefail
           go test -tags=integration -race -p 1 -count=1 -v \
-            ./internal/pgcapture/ ./internal/pgstreamrun/ ./internal/pgbaseline/ 2>&1 | tee /tmp/pg-it.out
+            ./internal/pgcapture/ ./internal/pgstreamrun/ ./internal/pgbaseline/ ./internal/pgshim/ 2>&1 | tee /tmp/pg-it.out
           grep -q -- '--- PASS: TestOne_EndToEnd_PostgresToIndexToRecovery' /tmp/pg-it.out \
             || { echo "FATAL: PG end-to-end integration test did not run — false-green tripwire" >&2; exit 1; }
           grep -q -- '--- PASS: TestPGBaseline_Integration' /tmp/pg-it.out \
             || { echo "FATAL: pgbaseline integration suite did not run — false-green tripwire" >&2; exit 1; }
+          grep -q -- '--- PASS: TestPGWire_PostgresSourceRoundTrip' /tmp/pg-it.out \
+            || { echo "FATAL: pgwire PostgreSQL-source E2E did not run — false-green tripwire" >&2; exit 1; }
 
   console-e2e:
     # Headless-Chrome regression guard for the console SPA: go test never

--- a/cmd/bintrail-pg/flashback.go
+++ b/cmd/bintrail-pg/flashback.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"os/signal"
+	"syscall"
+	"time"
+
+	drivermysql "github.com/go-sql-driver/mysql"
+	"github.com/spf13/cobra"
+
+	"github.com/dbtrail/dbtrail/internal/cli"
+	"github.com/dbtrail/dbtrail/internal/config"
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/pgshim"
+	"github.com/dbtrail/dbtrail/internal/shim"
+)
+
+var flashbackCmd = &cobra.Command{
+	Use:   "flashback",
+	Short: "Serve single-row AS OF time-travel over the PostgreSQL wire protocol (psql)",
+	Long: `Serves the bintrail time-travel engine over the PostgreSQL wire protocol so a
+PostgreSQL operator can run single-row AS OF queries from psql or a PG driver,
+reading the same out-of-band index (and optional baseline) the MySQL shim uses —
+the original binlog/WAL files are never needed.
+
+  psql "host=127.0.0.1 port=5433 user=<tenant> dbname=<schema>"
+  SELECT * FROM _flashback.orders AS OF '5 minutes ago' WHERE id = 42;
+  SELECT * FROM _snapshot.orders  AS OF '5 minutes ago' WHERE id = 42;
+  SELECT * FROM orders AS OF '5 minutes ago' WHERE id = 42;   -- bare form
+
+Addressing: connect with dbname=<your schema> (e.g. public). Choose flashback vs
+snapshot semantics with the _flashback. / _snapshot. table prefix in the query,
+exactly like the MySQL shim; _snapshot additionally consults --baseline-dir /
+--baseline-s3 so a row untouched in the retained window still resolves.
+
+Scope: single-row AS OF (WHERE <primary-key> = <value>) only. Full-table AS OF is
+refused with remediation (PostgreSQL full-table time-travel is deferred). Use the
+simple query protocol — psql does this natively; a pgx client sets
+QueryExecModeSimpleProtocol.
+
+Auth mirrors the shim: a cleartext credential validated per tenant from
+--shim-config (shim.yaml). This is loopback-default; front a TLS terminator for a
+non-loopback bind (same posture as the MySQL shim behind ProxySQL).`,
+	RunE: runFlashback,
+}
+
+var (
+	fbIndexDSN     string
+	fbListen       string
+	fbShimConfig   string
+	fbNoArchive    bool
+	fbAllowGaps    bool
+	fbBaselineDir  string
+	fbBaselineS3   string
+	fbQueryTimeout time.Duration
+	fbMaxConns     int
+)
+
+func init() {
+	flashbackCmd.Flags().StringVar(&fbIndexDSN, "index-dsn", "", "DSN for the index MySQL database (required; env BINTRAIL_INDEX_DSN)")
+	flashbackCmd.Flags().StringVar(&fbListen, "listen", "127.0.0.1:5433", "Address to listen on for PostgreSQL-protocol clients (env BINTRAIL_PG_FLASHBACK_LISTEN)")
+	flashbackCmd.Flags().StringVar(&fbShimConfig, "shim-config", "shim.yaml", "Tenant auth config, same format as the MySQL shim (env BINTRAIL_PG_SHIM_CONFIG)")
+	flashbackCmd.Flags().BoolVar(&fbNoArchive, "no-archive", false, "Disable archive auto-discovery (index-only results)")
+	flashbackCmd.Flags().BoolVar(&fbAllowGaps, "allow-gaps", false, "Downgrade coverage gaps / archive failures to warnings and return partial results instead of aborting the query")
+	flashbackCmd.Flags().StringVar(&fbBaselineDir, "baseline-dir", "", "Local baseline snapshot directory enabling _snapshot (env BINTRAIL_PG_BASELINE_DIR)")
+	flashbackCmd.Flags().StringVar(&fbBaselineS3, "baseline-s3", "", "S3 baseline snapshot prefix enabling _snapshot; takes precedence over --baseline-dir (env BINTRAIL_PG_BASELINE_S3)")
+	flashbackCmd.Flags().DurationVar(&fbQueryTimeout, "query-timeout", 30*time.Second, "Per-query deadline; 0 disables")
+	flashbackCmd.Flags().IntVar(&fbMaxConns, "max-connections", 0, "Cap concurrent connections; 0 = unlimited")
+
+	// index-dsn lives in cli.EnvBindings, so BindCommandEnv both loads the env
+	// file and sets it from BINTRAIL_INDEX_DSN (marking it Changed so the env-only
+	// path satisfies MarkFlagRequired). The other flags' BINTRAIL_PG_* fallback is
+	// applied in runFlashback (the env file is loaded by then).
+	_ = flashbackCmd.MarkFlagRequired("index-dsn")
+	cli.BindCommandEnv(flashbackCmd)
+
+	rootCmd.AddCommand(flashbackCmd)
+}
+
+// runFlashback is the `bintrail-pg flashback` entrypoint. It mirrors the MySQL
+// shim's startup (load tenants → connect + ping + migrate the index → listen)
+// minus the ProxySQL-specific machinery, then serves the PostgreSQL wire
+// front-end. The engine and data layer are index-only, so no live PostgreSQL
+// source is contacted here.
+func runFlashback(cmd *cobra.Command, args []string) error {
+	applyEnvFallback(&fbListen, "BINTRAIL_PG_FLASHBACK_LISTEN")
+	applyEnvFallback(&fbShimConfig, "BINTRAIL_PG_SHIM_CONFIG")
+	applyEnvFallback(&fbBaselineDir, "BINTRAIL_PG_BASELINE_DIR")
+	applyEnvFallback(&fbBaselineS3, "BINTRAIL_PG_BASELINE_S3")
+
+	tenantCfgs, err := shim.LoadTenantConfigs(fbShimConfig)
+	if err != nil {
+		return err
+	}
+	users := make(map[string]string, len(tenantCfgs))
+	for _, t := range tenantCfgs {
+		users[t.MySQLUser] = t.MySQLPassword
+	}
+	auth, err := shim.NewTenantAuth(users)
+	if err != nil {
+		return err
+	}
+
+	db, err := config.Connect(fbIndexDSN)
+	if err != nil {
+		return fmt.Errorf("connect to index: %w", err)
+	}
+	defer db.Close()
+
+	// Eager ping so a misconfigured DSN fails at startup, not at the first query.
+	pingCtx, pingCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	err = db.PingContext(pingCtx)
+	pingCancel()
+	if err != nil {
+		return fmt.Errorf("ping index DB: %w", err)
+	}
+
+	// Idempotent schema migration on the CLI-typed DSN — the engine SELECTs
+	// post-initial-schema columns (query_text/query_hash, #699).
+	if err := indexer.EnsureSchema(db); err != nil {
+		return indexer.WrapSchemaMigrationErr(err)
+	}
+
+	dsnCfg, err := drivermysql.ParseDSN(fbIndexDSN)
+	if err != nil {
+		return fmt.Errorf("parse index DSN: %w", err)
+	}
+	if dsnCfg.DBName == "" {
+		return fmt.Errorf("index DSN must include the database name (e.g. /bintrail_index)")
+	}
+
+	listener, err := net.Listen("tcp", fbListen)
+	if err != nil {
+		return fmt.Errorf("listen on %s: %w", fbListen, err)
+	}
+	defer listener.Close()
+
+	if !isLoopbackListenAddr(listener.Addr()) {
+		slog.Warn("bintrail-pg flashback is bound to a non-loopback address and authenticates with a CLEARTEXT password; "+
+			"front a TLS terminator or restrict network access to this port",
+			"addr", listener.Addr().String())
+	}
+
+	slog.Info("bintrail-pg flashback listening",
+		"addr", listener.Addr().String(),
+		"tenants", len(tenantCfgs),
+		"snapshot_baseline", fbBaselineDir != "" || fbBaselineS3 != "")
+
+	ctx, cancel := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+	go func() {
+		<-ctx.Done()
+		slog.Info("bintrail-pg flashback shutting down")
+		listener.Close()
+	}()
+
+	cfg := pgshim.Config{
+		IndexDB: db,
+		ShimConfig: shim.Config{
+			AllowGaps:    fbAllowGaps,
+			NoArchive:    fbNoArchive,
+			IndexDBName:  dsnCfg.DBName,
+			BaselineDir:  fbBaselineDir,
+			BaselineS3:   fbBaselineS3,
+			QueryTimeout: fbQueryTimeout,
+		},
+		Auth:     auth,
+		Logger:   slog.Default(),
+		MaxConns: fbMaxConns,
+	}
+	return pgshim.Serve(ctx, listener, cfg)
+}
+
+// isLoopbackListenAddr reports whether the bound address is loopback, so a
+// non-loopback bind (where cleartext auth is exposed) can be warned about.
+func isLoopbackListenAddr(addr net.Addr) bool {
+	host, _, err := net.SplitHostPort(addr.String())
+	if err != nil {
+		return false
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}

--- a/cmd/bintrail-pg/main.go
+++ b/cmd/bintrail-pg/main.go
@@ -6,7 +6,7 @@
 //
 // Why a separate binary rather than a subcommand of bintrail: the PostgreSQL
 // capture path links jackc/pgx + pglogrepl, which the core MySQL binary must
-// stay free of (cmd/bintrail/pgfree_test.go enforces this). Splitting the
+// stay free of (cliapp/pgfree_test.go enforces this). Splitting the
 // capture plane per source keeps each binary's dependency surface honest while
 // the read plane is shared code. The user wants a distinct `bintrail-pg` as the
 // recognizable artifact for the Postgres-recovery niche (#534).

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -406,7 +406,11 @@ Scope and behaviour track PostgreSQL's current time-travel maturity:
   the `CREATE TABLE` metadata full-table reconstruct needs (the same limit as
   `reconstruct --output-format mydumper` and baseline-anchored `verify`).
 - Columns render as **text** (the conservative first cut): read each one as a
-  string, or let your driver text-parse it into a typed target.
+  string, or let your driver text-parse it into a typed target. One caveat: a
+  binary/`bytea` value containing a `0x00` byte truncates at the first NUL in
+  `psql`/libpq (their text protocol uses NUL-terminated C strings); a driver that
+  reads the raw value (e.g. `pgx` scanning into `[]byte`) round-trips it intact.
+  Per-column type OIDs (so `bytea` arrives as `bytea`) are a follow-up.
 - Use the **simple query protocol** — `psql` does this by default; a `pgx`
   client sets `QueryExecModeSimpleProtocol`. The extended (prepared-statement)
   protocol is not yet implemented.

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -368,6 +368,57 @@ directly.
 > release — see [Beta limitations](#beta-limitations) for the complete
 > picture.
 
+### Interactive `AS OF` from `psql`
+
+The `_flashback` / `_snapshot` / `AS OF` time-travel grammar is also available
+over the **PostgreSQL wire protocol**, so you can run single-row time-travel
+straight from `psql` (or any PostgreSQL driver) rather than the MySQL-wire shim:
+
+```bash
+bintrail-pg flashback \
+  --index-dsn 'root:…@tcp(127.0.0.1:3306)/bintrail_index' \
+  --shim-config shim.yaml \
+  --baseline-dir ./baselines      # optional; enables _snapshot
+  # --listen 127.0.0.1:5433 is the default
+```
+
+Then connect and query. **Set `dbname` to your PostgreSQL schema** (e.g.
+`public`); choose flashback-vs-snapshot with the `_flashback.` / `_snapshot.`
+table prefix in the query, exactly like the MySQL shim:
+
+```
+psql "host=127.0.0.1 port=5433 user=<tenant> dbname=public"
+
+-- binlog-only view of one row at a past instant:
+SELECT * FROM _flashback.orders AS OF '5 minutes ago' WHERE id = 42;
+
+-- baseline-aware view (also resolves rows untouched in the retained window):
+SELECT * FROM _snapshot.orders  AS OF '2026-07-01 09:00:00' WHERE id = 42;
+
+-- the bare form on the real table works too:
+SELECT * FROM orders AS OF '5 minutes ago' WHERE id = 42;
+```
+
+Scope and behaviour track PostgreSQL's current time-travel maturity:
+
+- **Single-row `AS OF` only** — a `WHERE <primary-key> = <value>` predicate.
+  Full-table `AS OF` is refused with remediation: a PG baseline does not carry
+  the `CREATE TABLE` metadata full-table reconstruct needs (the same limit as
+  `reconstruct --output-format mydumper` and baseline-anchored `verify`).
+- Columns render as **text** (the conservative first cut): read each one as a
+  string, or let your driver text-parse it into a typed target.
+- Use the **simple query protocol** — `psql` does this by default; a `pgx`
+  client sets `QueryExecModeSimpleProtocol`. The extended (prepared-statement)
+  protocol is not yet implemented.
+- **Auth** mirrors the shim: a cleartext password per tenant from
+  `--shim-config` (`shim.yaml`). The default listen address is loopback; for a
+  non-loopback bind, front a TLS terminator — the same posture as the MySQL
+  shim behind ProxySQL.
+
+`bintrail-pg` still ships the MySQL-wire `shim` command as well, if you prefer
+to reach the index from MySQL tooling. See
+[Time-Travel SQL Setup](time-travel-sql.md) for the full grammar.
+
 ---
 
 ## Sequences after recovery

--- a/docs/time-travel-sql.md
+++ b/docs/time-travel-sql.md
@@ -42,6 +42,11 @@ in *how the client connects*:
    `AS OF` queries on the same endpoint. ProxySQL routes virtual-schema queries
    to the shim and everything else to your real MySQL.
 
+All three speak the **MySQL** protocol. A **PostgreSQL** operator can instead run
+single-row `AS OF` over the **PostgreSQL wire protocol** from `psql` with
+`bintrail-pg flashback` — same grammar, no MySQL client required. See
+[Interactive `AS OF` from `psql`](postgres.md#interactive-as-of-from-psql).
+
 ### The embedded port (multi-source)
 
 `bintrail-console watch` already holds the time-travel engine and, through its

--- a/internal/pgshim/pgshim.go
+++ b/internal/pgshim/pgshim.go
@@ -1,0 +1,341 @@
+// Package pgshim is the PostgreSQL wire-protocol front-end for bintrail's
+// time-travel engine (#1008). It lets a PostgreSQL operator run single-row
+// AS OF queries from psql / a PG driver:
+//
+//	psql "host=127.0.0.1 port=5433 user=<tenant> dbname=<schema>"
+//	SELECT * FROM _flashback.orders AS OF '5 minutes ago' WHERE id = 42;
+//	SELECT * FROM _snapshot.orders  AS OF '5 minutes ago' WHERE id = 42;
+//	SELECT * FROM orders AS OF '5 minutes ago' WHERE id = 42;   -- bare form
+//
+// and get rows back over the PostgreSQL protocol, served from the SAME
+// out-of-band index + baseline the MySQL shim uses. It reuses internal/shim
+// verbatim: the parser (shim.Parse → a protocol-neutral TimeTravelQuery) and the
+// wire-neutral resolve seam (Handler.ResolveFlashbackRow / ResolveSnapshotRow /
+// ColumnsFor / PKColumnCheck, resolve.go). Only the render is PostgreSQL-typed
+// here — RowDescription / DataRow / CommandComplete instead of *mysql.Result.
+//
+// Scope (matches the current PostgreSQL time-travel maturity, #593):
+//   - single-row AS OF (WHERE <pk> = <value>) for _flashback and _snapshot.
+//   - full-table AS OF is REFUSED with actionable remediation (the PostgreSQL
+//     baseline still omits CREATE TABLE, slice E) — never a silent partial.
+//   - _diff is refused (use `bintrail-pg reconstruct --history`).
+//   - simple query protocol only (psql uses it natively; a pgx client sets
+//     QueryExecModeSimpleProtocol). The extended query protocol is declined with
+//     a clear error and a resync, so a default-mode client is not left hanging.
+//
+// Addressing: the connect `database` parameter is the bintrail SCHEMA (the
+// PostgreSQL schema name, e.g. `public`); flashback-vs-snapshot semantics are
+// selected by the `_flashback.` / `_snapshot.` table prefix in the query, exactly
+// like the MySQL shim. (This differs from the issue's tentative
+// `dbname=_flashback` note, which the engine's schema-from-connection model does
+// not support without a parser change; the query-prefix model needs none and is
+// strictly more capable — one connection reaches every virtual schema.)
+//
+// Auth mirrors the MySQL shim: a cleartext credential validated per tenant
+// against shim.yaml. This is loopback-default; front a TLS terminator (or run on
+// loopback behind a local proxy) for a non-loopback bind — the same posture as
+// the MySQL shim behind ProxySQL. Package placement is deliberate: pgproto3 is
+// github.com/jackc/pgx/v5/pgproto3, which the cliapp pgfree guard bans from the
+// core bintrail binary, so this front-end is linked ONLY by cmd/bintrail-pg.
+package pgshim
+
+import (
+	"context"
+	"crypto/subtle"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgproto3"
+
+	"github.com/dbtrail/dbtrail/internal/shim"
+)
+
+// pgtypeText is the PostgreSQL type OID for `text`. The first cut renders every
+// column as text (the issue's conservative choice): a numeric value goes on the
+// wire as its literal string, bytea/blob bytes verbatim, timestamps formatted.
+// A client reads each column as a string (or text-parses it into a typed target,
+// which pgx does). Refining per-column OIDs is a follow-up.
+const pgtypeText = uint32(25)
+
+// fullTableRefusalMsg is returned for a full-table AS OF (no PK-qualified
+// WHERE). Full-table PostgreSQL time-travel is deferred (slice E: the PostgreSQL
+// baseline omits CREATE TABLE, #593/#901), so we refuse loudly with a path
+// forward rather than serve a partial/empty table.
+const fullTableRefusalMsg = "full-table AS OF is not supported over the PostgreSQL wire front-end " +
+	"(PostgreSQL full-table time-travel is deferred — the baseline omits CREATE TABLE, issue #593 slice E); " +
+	"query a single row with WHERE <primary-key> = <value>, or use `bintrail-pg reconstruct` / the console for full-table state"
+
+// Config carries everything the front-end needs. The engine lives in
+// internal/shim; this package only speaks the wire.
+type Config struct {
+	// IndexDB is the open, migrated bintrail index the engine reads.
+	IndexDB *sql.DB
+	// ShimConfig is the engine config (IndexDBName, BaselineDir/S3, NoArchive,
+	// AllowGaps, QueryTimeout). FullTableGate is unused here — full-table is
+	// refused — and AuthMethod is a MySQL concept, also unused.
+	ShimConfig shim.Config
+	// Auth validates the per-tenant cleartext password (loaded from shim.yaml).
+	Auth shim.TenantAuth
+	// Logger; nil → slog.Default().
+	Logger *slog.Logger
+	// MaxConns caps concurrent connections; 0 = unlimited.
+	MaxConns int
+}
+
+// Serve accepts PostgreSQL wire-protocol connections until ctx is canceled or
+// the listener closes. Mirrors internal/cli.serveLoop: one goroutine per
+// connection, each with its own shim.Handler; exponential accept backoff so a
+// transient listener hiccup does not burn CPU; an optional connection cap.
+func Serve(ctx context.Context, ln net.Listener, cfg Config) error {
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	var sem chan struct{}
+	if cfg.MaxConns > 0 {
+		sem = make(chan struct{}, cfg.MaxConns)
+	}
+
+	var backoff time.Duration
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			if ctx.Err() != nil || errors.Is(err, net.ErrClosed) {
+				return nil // graceful shutdown
+			}
+			backoff = nextBackoff(backoff)
+			logger.Error("pgshim accept failed", "err", err, "backoff", backoff)
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-time.After(backoff):
+			}
+			continue
+		}
+		backoff = 0
+		if sem != nil {
+			select {
+			case sem <- struct{}{}:
+			default:
+				// Cap breached pre-handshake: no clean way to send a PG
+				// ErrorResponse before the client's startup, so close. Rare.
+				logger.Warn("pgshim connection refused: --max-connections reached",
+					"remote", conn.RemoteAddr(), "max_connections", cfg.MaxConns)
+				conn.Close()
+				continue
+			}
+		}
+		wg.Add(1)
+		go func(c net.Conn) {
+			defer wg.Done()
+			if sem != nil {
+				defer func() { <-sem }()
+			}
+			handleConn(ctx, c, cfg, logger)
+		}(conn)
+	}
+}
+
+// nextBackoff mirrors the MySQL serveLoop's accept backoff: 100ms → 5s cap.
+func nextBackoff(cur time.Duration) time.Duration {
+	const cap = 5 * time.Second
+	if cur == 0 {
+		return 100 * time.Millisecond
+	}
+	if n := cur * 2; n < cap {
+		return n
+	}
+	return cap
+}
+
+// handleConn runs one connection: startup negotiation (incl. the SSLRequest
+// decline), cleartext auth, then a simple-query command loop over its own
+// shim.Handler.
+func handleConn(ctx context.Context, c net.Conn, cfg Config, logger *slog.Logger) {
+	defer c.Close()
+
+	// Per-connection context so shutdown / a mid-query client disconnect cancels
+	// in-flight resolves (QueryTimeout is the other backstop).
+	connCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	be := pgproto3.NewBackend(c, c)
+
+	startup, err := negotiateStartup(c, be)
+	if err != nil {
+		logger.Debug("pgshim startup failed", "err", err, "remote", c.RemoteAddr())
+		return
+	}
+	if startup == nil {
+		return // CancelRequest / clean close
+	}
+
+	user := startup.Parameters["user"]
+	database := startup.Parameters["database"]
+
+	if err := authenticate(be, cfg.Auth, user); err != nil {
+		logger.Info("pgshim auth denied", "user", user, "remote", c.RemoteAddr())
+		return
+	}
+
+	sendAuthOK(be)
+	if err := be.Flush(); err != nil {
+		return
+	}
+
+	h := shim.NewHandlerWithConfig(cfg.IndexDB, cfg.ShimConfig, logger)
+	h.BindConnContext(connCtx)
+	// currentDB = the connect database param (the bintrail schema). Empty is
+	// allowed: queries must then schema-qualify the table (<schema>.<table>).
+	_ = h.UseDB(database)
+
+	sess := &session{be: be, h: h, currentDB: database, logger: logger}
+
+	// skipUntilSync implements the PostgreSQL extended-query error rule: once we
+	// reject an extended-protocol message we must discard everything until the
+	// client's Sync, then release it with ReadyForQuery.
+	skipUntilSync := false
+	for {
+		msg, rerr := be.Receive()
+		if rerr != nil {
+			return // client disconnect / read error
+		}
+		if skipUntilSync {
+			switch msg.(type) {
+			case *pgproto3.Sync:
+				skipUntilSync = false
+				if err := sess.readyFlush(); err != nil {
+					return
+				}
+			case *pgproto3.Terminate:
+				return
+			}
+			continue
+		}
+		switch m := msg.(type) {
+		case *pgproto3.Query:
+			if err := sess.handleSimpleQuery(m.String); err != nil {
+				return
+			}
+		case *pgproto3.Terminate:
+			return
+		case *pgproto3.Sync:
+			// A stray Sync (some clients send one after startup): acknowledge.
+			if err := sess.readyFlush(); err != nil {
+				return
+			}
+		default:
+			// Extended query protocol (Parse/Bind/Describe/Execute/Close/Flush)
+			// or an unrecognised message. Not supported in the first cut; emit one
+			// error and skip to the client's Sync so it is not left hanging.
+			sess.errorResponse("0A000", "this endpoint supports only the simple query protocol; "+
+				"psql uses it natively — with pgx set QueryExecModeSimpleProtocol")
+			if err := be.Flush(); err != nil {
+				return
+			}
+			skipUntilSync = true
+		}
+	}
+}
+
+// negotiateStartup returns the client's StartupMessage, declining an SSLRequest
+// or GSSEncRequest with a single 'N' byte (we terminate no TLS here) and then
+// re-reading. A CancelRequest returns (nil, nil): we run no query registry, so
+// there is nothing to cancel — the caller closes.
+func negotiateStartup(c net.Conn, be *pgproto3.Backend) (*pgproto3.StartupMessage, error) {
+	for {
+		msg, err := be.ReceiveStartupMessage()
+		if err != nil {
+			return nil, err
+		}
+		switch m := msg.(type) {
+		case *pgproto3.StartupMessage:
+			return m, nil
+		case *pgproto3.SSLRequest:
+			if _, err := c.Write([]byte{'N'}); err != nil {
+				return nil, err
+			}
+		case *pgproto3.GSSEncRequest:
+			if _, err := c.Write([]byte{'N'}); err != nil {
+				return nil, err
+			}
+		case *pgproto3.CancelRequest:
+			return nil, nil
+		default:
+			return nil, fmt.Errorf("unexpected startup message %T", m)
+		}
+	}
+}
+
+// authenticate performs the cleartext-password exchange and validates it against
+// the tenant store. On failure it sends a FATAL 28P01 and returns an error; the
+// caller closes the connection. An unknown user and a wrong password are rejected
+// with a byte-identical 28P01 message, so the error content never reveals which
+// usernames exist. The password check uses subtle.ConstantTimeCompare to avoid a
+// per-byte timing oracle on a known user's password — the MySQL shim's
+// ER_ACCESS_DENIED posture; it does not attempt to equalise the cost of the
+// tenant-map lookup itself (the endpoint is loopback-default / TLS-fronted).
+func authenticate(be *pgproto3.Backend, auth shim.TenantAuth, user string) error {
+	be.Send(&pgproto3.AuthenticationCleartextPassword{})
+	if err := be.Flush(); err != nil {
+		return err
+	}
+	if err := be.SetAuthType(pgproto3.AuthTypeCleartextPassword); err != nil {
+		return err
+	}
+	msg, err := be.Receive()
+	if err != nil {
+		return err
+	}
+	pw, ok := msg.(*pgproto3.PasswordMessage)
+	if !ok {
+		sendFatal(be, "08P01", fmt.Sprintf("expected a password message, got %T", msg))
+		return fmt.Errorf("expected PasswordMessage, got %T", msg)
+	}
+	expected, found, cerr := auth.GetCredential(user)
+	match := found && cerr == nil &&
+		subtle.ConstantTimeCompare([]byte(pw.Password), []byte(expected)) == 1
+	if !match {
+		sendFatal(be, "28P01", fmt.Sprintf("password authentication failed for user %q", user))
+		return fmt.Errorf("auth failed for user %q", user)
+	}
+	return nil
+}
+
+// sendAuthOK finishes the handshake: AuthenticationOk, the ParameterStatus set a
+// PostgreSQL client reads at startup, then ReadyForQuery(idle). BackendKeyData is
+// intentionally omitted — it only backs query cancellation, which we do not
+// implement.
+func sendAuthOK(be *pgproto3.Backend) {
+	be.Send(&pgproto3.AuthenticationOk{})
+	for _, ps := range startupParameters {
+		be.Send(&pgproto3.ParameterStatus{Name: ps[0], Value: ps[1]})
+	}
+	be.Send(&pgproto3.ReadyForQuery{TxStatus: 'I'})
+}
+
+// startupParameters are the ParameterStatus values psql/libpq expect after
+// AuthenticationOk. server_version carries a leading numeric psql parses.
+var startupParameters = [][2]string{
+	{"server_version", "14.0 (bintrail time-travel)"},
+	{"server_encoding", "UTF8"},
+	{"client_encoding", "UTF8"},
+	{"DateStyle", "ISO, MDY"},
+	{"standard_conforming_strings", "on"},
+	{"integer_datetimes", "on"},
+	{"TimeZone", "UTC"},
+}
+
+func sendFatal(be *pgproto3.Backend, code, msg string) {
+	be.Send(&pgproto3.ErrorResponse{Severity: "FATAL", SeverityUnlocalized: "FATAL", Code: code, Message: msg})
+	_ = be.Flush()
+}

--- a/internal/pgshim/pgshim.go
+++ b/internal/pgshim/pgshim.go
@@ -163,10 +163,21 @@ func nextBackoff(cur time.Duration) time.Duration {
 func handleConn(ctx context.Context, c net.Conn, cfg Config, logger *slog.Logger) {
 	defer c.Close()
 
-	// Per-connection context so shutdown / a mid-query client disconnect cancels
-	// in-flight resolves (QueryTimeout is the other backstop).
+	// Per-connection context: cancelling it aborts an in-flight resolve
+	// (QueryTimeout is the other backstop).
 	connCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
+
+	// A blocking be.Receive() / ReceiveStartupMessage() is a ctx-unaware socket
+	// read, so cancelling connCtx alone cannot unblock an IDLE connection parked
+	// between queries (or pre-auth). Close the socket when connCtx ends — on
+	// SIGTERM shutdown or the deferred cancel on return — so the parked read
+	// errors out and this goroutine exits; otherwise Serve's wg.Wait() would hang
+	// graceful shutdown on every idle psql session. Mirrors the MySQL shim's
+	// watchConn (internal/cli/shim.go). stopClose prevents the AfterFunc from
+	// racing the normal-return path (it is a no-op once the func has run).
+	stopClose := context.AfterFunc(connCtx, func() { _ = c.Close() })
+	defer stopClose()
 
 	be := pgproto3.NewBackend(c, c)
 

--- a/internal/pgshim/pgshim_integration_test.go
+++ b/internal/pgshim/pgshim_integration_test.go
@@ -1,0 +1,133 @@
+//go:build integration
+
+package pgshim
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/dbtrail/dbtrail/internal/event"
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/shim"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestPGWire_SingleRowRoundTrip is the acceptance path against a real seeded
+// index driven by a REAL pgx client (default sslmode=prefer, so the SSLRequest
+// negotiation runs): a single-row _flashback / _snapshot AS OF returns the
+// correct row state at the queried instant, and full-table AS OF is refused.
+// Version-independent (it exercises the wire → shared-engine → row-state path
+// over the MySQL index, no live PostgreSQL), so it runs in the MySQL integration
+// matrix. The PostgreSQL-source, version-dependent E2E lives in
+// TestPGWire_PostgresSourceRoundTrip.
+func TestPGWire_SingleRowRoundTrip(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	hour := time.Now().UTC().Truncate(time.Hour)
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{hour})
+
+	// PK snapshot so PKColumnCheck admits `WHERE id = 1`.
+	snapTS := hour.Format("2006-01-02 15:04:05")
+	testutil.InsertSnapshot(t, db, 1, snapTS, "public", "users", "id", 1, "PRI", "int", "NO")
+	testutil.InsertSnapshot(t, db, 1, snapTS, "public", "users", "name", 2, "", "varchar", "YES")
+
+	// Row 1: INSERT alice at t0, UPDATE to bob at t1.
+	t0 := hour.Add(5 * time.Minute)
+	t1 := hour.Add(15 * time.Minute)
+	testutil.InsertEvent(t, db, "mysql-bin.000001", 100, 200, t0.Format("2006-01-02 15:04:05"), nil,
+		"public", "users", uint8(event.EventInsert), "1", nil, nil, []byte(`{"id":1,"name":"alice"}`))
+	testutil.InsertEvent(t, db, "mysql-bin.000001", 200, 300, t1.Format("2006-01-02 15:04:05"), nil,
+		"public", "users", uint8(event.EventUpdate), "1", []byte(`["name"]`),
+		[]byte(`{"id":1,"name":"alice"}`), []byte(`{"id":1,"name":"bob"}`))
+
+	addr := serveAddrWithDB(t, Config{
+		IndexDB:    db,
+		ShimConfig: shim.Config{NoArchive: true, IndexDBName: dbName},
+		Auth:       testAuth(t),
+	})
+	conn, err := connectPGWire(t, addr, testUser, testPass)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// _flashback AS OF between the two events → the pre-update image (alice).
+	between := t0.Add(5 * time.Minute).Format("2006-01-02 15:04:05")
+	if got := queryName(t, ctx, conn, "_flashback", between); got != "alice" {
+		t.Errorf("_flashback AS OF %s: name=%q, want alice", between, got)
+	}
+	// _flashback AS OF after the update → the post-update image (bob).
+	after := t1.Add(5 * time.Minute).Format("2006-01-02 15:04:05")
+	if got := queryName(t, ctx, conn, "_flashback", after); got != "bob" {
+		t.Errorf("_flashback AS OF %s: name=%q, want bob", after, got)
+	}
+	// _snapshot with no baseline configured degrades to the same binlog-only
+	// answer — proves the _snapshot route reaches the shared engine.
+	if got := queryName(t, ctx, conn, "_snapshot", between); got != "alice" {
+		t.Errorf("_snapshot AS OF %s: name=%q, want alice", between, got)
+	}
+
+	// Full-table AS OF (no WHERE) is refused with actionable remediation.
+	_, err = conn.Exec(ctx, "SELECT * FROM _flashback.users AS OF '"+after+"'")
+	pgErr := requirePgError(t, err)
+	if pgErr.Code != "0A000" || !contains(pgErr.Message, "full-table") {
+		t.Errorf("full-table refusal: code=%s msg=%s", pgErr.Code, pgErr.Message)
+	}
+}
+
+// queryName runs a single-row AS OF for id=1 against the given virtual schema and
+// returns the `name` column as text. Columns come back as text (OID 25), so we
+// scan into strings — the conservative all-text encoding the front-end uses.
+func queryName(t *testing.T, ctx context.Context, conn *pgx.Conn, virtualSchema, asOf string) string {
+	t.Helper()
+	sqlText := "SELECT * FROM " + virtualSchema + ".users AS OF '" + asOf + "' WHERE id = 1"
+	rows, err := conn.Query(ctx, sqlText)
+	if err != nil {
+		t.Fatalf("query %s: %v", sqlText, err)
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			t.Fatalf("query %s: %v", sqlText, err)
+		}
+		t.Fatalf("query %s: no row returned", sqlText)
+	}
+	var id, name string
+	if err := rows.Scan(&id, &name); err != nil {
+		t.Fatalf("scan %s: %v", sqlText, err)
+	}
+	if id != "1" {
+		t.Errorf("id = %q, want 1", id)
+	}
+	return name
+}
+
+func serveAddrWithDB(t *testing.T, cfg Config) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = discardLogger()
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { defer close(done); _ = Serve(ctx, ln, cfg) }()
+	t.Cleanup(func() {
+		cancel()
+		_ = ln.Close()
+		<-done
+	})
+	return ln.Addr().String()
+}

--- a/internal/pgshim/pgshim_integration_test.go
+++ b/internal/pgshim/pgshim_integration_test.go
@@ -4,12 +4,17 @@ package pgshim
 
 import (
 	"context"
+	"fmt"
 	"net"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 
+	"github.com/dbtrail/dbtrail/internal/baseline"
 	"github.com/dbtrail/dbtrail/internal/event"
 	"github.com/dbtrail/dbtrail/internal/indexer"
 	"github.com/dbtrail/dbtrail/internal/shim"
@@ -63,18 +68,65 @@ func TestPGWire_SingleRowRoundTrip(t *testing.T) {
 
 	// _flashback AS OF between the two events → the pre-update image (alice).
 	between := t0.Add(5 * time.Minute).Format("2006-01-02 15:04:05")
-	if got := queryName(t, ctx, conn, "_flashback", between); got != "alice" {
+	if got := queryName(t, ctx, conn, "_flashback", between, "1"); got != "alice" {
 		t.Errorf("_flashback AS OF %s: name=%q, want alice", between, got)
 	}
 	// _flashback AS OF after the update → the post-update image (bob).
 	after := t1.Add(5 * time.Minute).Format("2006-01-02 15:04:05")
-	if got := queryName(t, ctx, conn, "_flashback", after); got != "bob" {
+	if got := queryName(t, ctx, conn, "_flashback", after, "1"); got != "bob" {
 		t.Errorf("_flashback AS OF %s: name=%q, want bob", after, got)
 	}
 	// _snapshot with no baseline configured degrades to the same binlog-only
-	// answer — proves the _snapshot route reaches the shared engine.
-	if got := queryName(t, ctx, conn, "_snapshot", between); got != "alice" {
+	// answer — proves the _snapshot route reaches the shared engine. (The
+	// baseline-materialisation path is TestPGWire_SnapshotBaselineRow.)
+	if got := queryName(t, ctx, conn, "_snapshot", between, "1"); got != "alice" {
 		t.Errorf("_snapshot AS OF %s: name=%q, want alice", between, got)
+	}
+
+	// A PK that never existed at AsOf → a real resultset with column headers but
+	// zero rows and a "SELECT 0" tag (not an empty/errored reply).
+	absent, err := conn.Query(ctx, "SELECT * FROM _flashback.users AS OF '"+after+"' WHERE id = 999")
+	if err != nil {
+		t.Fatalf("row-absent query: %v", err)
+	}
+	if len(absent.FieldDescriptions()) == 0 {
+		t.Error("row-absent resultset must still carry column headers")
+	}
+	if absent.Next() {
+		t.Error("expected zero rows for a never-existent PK")
+	}
+	absent.Close()
+	if err := absent.Err(); err != nil {
+		t.Fatalf("row-absent rows err: %v", err)
+	}
+	if tag := absent.CommandTag().String(); tag != "SELECT 0" {
+		t.Errorf("row-absent command tag = %q, want SELECT 0", tag)
+	}
+
+	// Explicit projection is emitted verbatim; a column absent from the image
+	// (never present / dropped since AsOf) renders as SQL NULL — the "column
+	// dropped after AS OF" semantic.
+	proj, err := conn.Query(ctx, "SELECT name, ghost FROM _flashback.users AS OF '"+after+"' WHERE id = 1")
+	if err != nil {
+		t.Fatalf("projection query: %v", err)
+	}
+	fds := proj.FieldDescriptions()
+	if len(fds) != 2 || fds[0].Name != "name" || fds[1].Name != "ghost" {
+		t.Fatalf("projection columns = %v, want [name ghost]", fieldNames(fds))
+	}
+	if !proj.Next() {
+		t.Fatal("projection: no row returned")
+	}
+	vals, err := proj.Values()
+	proj.Close()
+	if err != nil {
+		t.Fatalf("projection values: %v", err)
+	}
+	if fmt.Sprint(vals[0]) != "bob" {
+		t.Errorf("projected name = %v, want bob", vals[0])
+	}
+	if vals[1] != nil {
+		t.Errorf("projected missing column ghost = %v, want SQL NULL (nil)", vals[1])
 	}
 
 	// Full-table AS OF (no WHERE) is refused with actionable remediation.
@@ -88,9 +140,9 @@ func TestPGWire_SingleRowRoundTrip(t *testing.T) {
 // queryName runs a single-row AS OF for id=1 against the given virtual schema and
 // returns the `name` column as text. Columns come back as text (OID 25), so we
 // scan into strings — the conservative all-text encoding the front-end uses.
-func queryName(t *testing.T, ctx context.Context, conn *pgx.Conn, virtualSchema, asOf string) string {
+func queryName(t *testing.T, ctx context.Context, conn *pgx.Conn, virtualSchema, asOf, pk string) string {
 	t.Helper()
-	sqlText := "SELECT * FROM " + virtualSchema + ".users AS OF '" + asOf + "' WHERE id = 1"
+	sqlText := "SELECT * FROM " + virtualSchema + ".users AS OF '" + asOf + "' WHERE id = " + pk
 	rows, err := conn.Query(ctx, sqlText)
 	if err != nil {
 		t.Fatalf("query %s: %v", sqlText, err)
@@ -106,8 +158,8 @@ func queryName(t *testing.T, ctx context.Context, conn *pgx.Conn, virtualSchema,
 	if err := rows.Scan(&id, &name); err != nil {
 		t.Fatalf("scan %s: %v", sqlText, err)
 	}
-	if id != "1" {
-		t.Errorf("id = %q, want 1", id)
+	if id != pk {
+		t.Errorf("id = %q, want %s", id, pk)
 	}
 	return name
 }
@@ -130,4 +182,101 @@ func serveAddrWithDB(t *testing.T, cfg Config) string {
 		<-done
 	})
 	return ln.Addr().String()
+}
+
+// TestPGWire_SnapshotBaselineRow distinguishes _snapshot from _flashback OVER THE
+// WIRE: a baseline row whose PK has ZERO binlog events resolves under _snapshot
+// (baseline-aware) but is absent under _flashback (binlog-only). The no-baseline
+// _snapshot case in TestPGWire_SingleRowRoundTrip only proves routing; this
+// proves the baseline fold is actually delivered over the PG protocol.
+func TestPGWire_SnapshotBaselineRow(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	hour := time.Now().UTC().Truncate(time.Hour)
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{hour})
+	snapTS := hour.Format("2006-01-02 15:04:05")
+	testutil.InsertSnapshot(t, db, 1, snapTS, "public", "users", "id", 1, "PRI", "int", "NO")
+	testutil.InsertSnapshot(t, db, 1, snapTS, "public", "users", "name", 2, "", "varchar", "YES")
+
+	// Baseline anchored inside the partitioned hour (so the Since→AsOf delta scan
+	// has no coverage gap), carrying id=42 which has NO binlog events — only
+	// _snapshot's baseline fold can surface it.
+	baselineDir := writePGWireBaseline(t, hour.Add(time.Minute), "public", "users",
+		[]baseline.Column{
+			{Name: "id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
+			{Name: "name", MySQLType: "varchar", ParquetType: baseline.MysqlToParquetNode("varchar")},
+		},
+		[][]string{{"42", "ghost"}})
+
+	addr := serveAddrWithDB(t, Config{
+		IndexDB:    db,
+		ShimConfig: shim.Config{NoArchive: true, IndexDBName: dbName, BaselineDir: baselineDir},
+		Auth:       testAuth(t),
+	})
+	conn, err := connectPGWire(t, addr, testUser, testPass)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	asOf := hour.Add(30 * time.Minute).Format("2006-01-02 15:04:05")
+	if got := queryName(t, ctx, conn, "_snapshot", asOf, "42"); got != "ghost" {
+		t.Errorf("_snapshot baseline-only row: name=%q, want ghost", got)
+	}
+	// _flashback is binlog-only: id=42 has no events → zero rows.
+	fb, err := conn.Query(ctx, "SELECT * FROM _flashback.users AS OF '"+asOf+"' WHERE id = 42")
+	if err != nil {
+		t.Fatalf("_flashback query: %v", err)
+	}
+	got := fb.Next()
+	fb.Close()
+	if err := fb.Err(); err != nil {
+		t.Fatalf("_flashback rows err: %v", err)
+	}
+	if got {
+		t.Error("_flashback must return zero rows for a baseline-only PK (binlog-only)")
+	}
+}
+
+// writePGWireBaseline writes a minimal `bintrail baseline` Parquet snapshot at
+// the FindBaseline directory layout (<root>/<name>Z/<schema>/<table>.parquet) so
+// a _snapshot query can fold it. Mirrors internal/shim's writeBaselineSnapshot.
+func writePGWireBaseline(t *testing.T, snapTime time.Time, schema, table string, cols []baseline.Column, rows [][]string) string {
+	t.Helper()
+	root := t.TempDir()
+	dir := filepath.Join(root, snapTime.UTC().Format("2006-01-02T15-04-05")+"Z", schema)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir baseline layout: %v", err)
+	}
+	w, err := baseline.NewWriter(filepath.Join(dir, table+".parquet"), cols, baseline.WriterConfig{
+		Compression:  "none",
+		RowGroupSize: 100,
+	})
+	if err != nil {
+		t.Fatalf("baseline.NewWriter: %v", err)
+	}
+	nulls := make([]bool, len(cols))
+	for _, r := range rows {
+		if err := w.WriteRow(r, nulls); err != nil {
+			t.Fatalf("WriteRow: %v", err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("baseline writer close: %v", err)
+	}
+	return root
+}
+
+func fieldNames(fds []pgconn.FieldDescription) []string {
+	out := make([]string, len(fds))
+	for i, f := range fds {
+		out[i] = f.Name
+	}
+	return out
 }

--- a/internal/pgshim/pgshim_test.go
+++ b/internal/pgshim/pgshim_test.go
@@ -1,0 +1,348 @@
+package pgshim
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgproto3"
+
+	"github.com/dbtrail/dbtrail/internal/event"
+	"github.com/dbtrail/dbtrail/internal/shim"
+)
+
+// ---- pure unit tests (no DB, no wire) ------------------------------------
+
+func TestTextCell(t *testing.T) {
+	tests := []struct {
+		name string
+		in   any
+		want []byte // nil = SQL NULL
+	}{
+		{"nil is NULL", nil, nil},
+		{"string", "hello", []byte("hello")},
+		{"bytes verbatim", []byte{0x00, 0x01, 0xff}, []byte{0x00, 0x01, 0xff}},
+		{"json.Number int", json.Number("42"), []byte("42")},
+		{"json.Number float", json.Number("3.14"), []byte("3.14")},
+		{"bool true", true, []byte("t")},
+		{"bool false", false, []byte("f")},
+		{"time UTC", time.Date(2026, 7, 12, 1, 2, 3, 0, time.UTC), []byte("2026-07-12 01:02:03")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := textCell("c", tt.in)
+			if err != nil {
+				t.Fatalf("textCell(%v) error: %v", tt.in, err)
+			}
+			if string(got) != string(tt.want) || (got == nil) != (tt.want == nil) {
+				t.Fatalf("textCell(%v) = %q (nil=%v), want %q (nil=%v)", tt.in, got, got == nil, tt.want, tt.want == nil)
+			}
+		})
+	}
+}
+
+func TestTextCellToastMarkerRefused(t *testing.T) {
+	marker := map[string]any{event.UnchangedToastKey: true}
+	if _, err := textCell("payload", marker); err == nil {
+		t.Fatal("textCell must refuse a residual unchanged-TOAST marker, not serialise it")
+	}
+}
+
+func TestImageCellsOrderingAndMissingKey(t *testing.T) {
+	image := map[string]any{"id": json.Number("7"), "name": "ada"}
+	cells, err := imageCells(image, []string{"id", "name", "dropped"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(cells[0]) != "7" || string(cells[1]) != "ada" {
+		t.Fatalf("cells = %q", cells)
+	}
+	// A column missing from the image is SQL NULL.
+	if cells[2] != nil {
+		t.Fatalf("missing key must be NULL, got %q", cells[2])
+	}
+}
+
+func TestPGResolveErrorClasses(t *testing.T) {
+	cases := []struct {
+		class    shim.ResolveErrClass
+		wantCode string
+	}{
+		{shim.ResolveGap, "22023"},
+		{shim.ResolveTimeout, "57014"},
+		{shim.ResolveCanceled, "57014"},
+		{shim.ResolveFault, "XX000"},
+	}
+	for _, c := range cases {
+		re := &shim.ResolveError{Class: c.class, QType: shim.TypeFlashback, Err: errors.New("boom")}
+		got := pgResolveError(re)
+		if got.code != c.wantCode {
+			t.Errorf("class %d → code %s, want %s", c.class, got.code, c.wantCode)
+		}
+	}
+	// A raw (non-ResolveError) data-fault is an internal error.
+	if got := pgResolveError(errors.New("toast")); got.code != "XX000" {
+		t.Errorf("raw fault code = %s, want XX000", got.code)
+	}
+}
+
+func TestProbeReply(t *testing.T) {
+	yes := map[string]string{
+		"SET client_encoding='UTF8'": "SET",
+		"set  application_name = x":  "SET",
+		"BEGIN":                      "BEGIN",
+		"begin transaction":          "BEGIN",
+		"COMMIT;":                    "COMMIT",
+		"rollback":                   "ROLLBACK",
+	}
+	for in, want := range yes {
+		if tag, ok := probeReply(in); !ok || tag != want {
+			t.Errorf("probeReply(%q) = (%q,%v), want (%q,true)", in, tag, ok, want)
+		}
+	}
+	for _, in := range []string{"SELECT 1", "SELECT * FROM orders", "DELETE FROM x"} {
+		if _, ok := probeReply(in); ok {
+			t.Errorf("probeReply(%q) must not be treated as a benign probe", in)
+		}
+	}
+}
+
+func TestNextBackoff(t *testing.T) {
+	if got := nextBackoff(0); got != 100*time.Millisecond {
+		t.Errorf("first backoff = %v", got)
+	}
+	if got := nextBackoff(4 * time.Second); got != 5*time.Second {
+		t.Errorf("cap = %v", got)
+	}
+	if got := nextBackoff(6 * time.Second); got != 5*time.Second {
+		t.Errorf("over-cap = %v", got)
+	}
+}
+
+func TestFullTableRefusalMessageIsActionable(t *testing.T) {
+	for _, want := range []string{"full-table", "WHERE", "reconstruct"} {
+		if !contains(fullTableRefusalMsg, want) {
+			t.Errorf("full-table refusal message must mention %q: %q", want, fullTableRefusalMsg)
+		}
+	}
+}
+
+// ---- protocol conformance (real pgx client over net.Pipe, no index DB) ---
+//
+// These exercise the wire framing end-to-end with a REAL pgx client: the
+// SSLRequest→'N' negotiation (pgx defaults to sslmode=prefer, so the FIRST bytes
+// it sends are an SSLRequest — the acceptance path, not covered by
+// sslmode=disable), cleartext auth, the ParameterStatus set, and that every
+// reply — success or error — ends with ReadyForQuery so pgx returns to ready.
+// They are DB-free: full-table refusal, malformed AS OF, non-time-travel
+// rejection, and SET probes never reach the index, so cfg.IndexDB may be nil.
+
+const (
+	testUser = "tester"
+	testPass = "s3cret"
+)
+
+// serveAddr stands up a real TCP listener running Serve and returns its address.
+// A real socket (not net.Pipe) is required because a pgx client under the
+// default sslmode=prefer, on a TLS refusal, RECONNECTS for the plaintext
+// attempt — the acceptance path — which a single fixed pipe cannot model. This
+// also exercises Serve's accept loop. cfg.IndexDB is nil, so callers must only
+// run queries that never touch the index.
+func serveAddr(t *testing.T, auth shim.TenantAuth) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { defer close(done); _ = Serve(ctx, ln, Config{Auth: auth, Logger: discardLogger()}) }()
+	t.Cleanup(func() {
+		cancel()
+		_ = ln.Close()
+		<-done
+	})
+	return ln.Addr().String()
+}
+
+// dialPGWire connects a real pgx client (simple protocol, default sslmode=prefer
+// so the SSLRequest→'N' negotiation is exercised) to a fresh Serve listener.
+func dialPGWire(t *testing.T, auth shim.TenantAuth, user, pass string) *pgx.Conn {
+	t.Helper()
+	conn, err := connectPGWire(t, serveAddr(t, auth), user, pass)
+	if err != nil {
+		t.Fatalf("pgx connect: %v", err)
+	}
+	return conn
+}
+
+// connectPGWire connects a pgx client to addr, returning the raw error so
+// negative auth tests can assert on it.
+func connectPGWire(t *testing.T, addr, user, pass string) (*pgx.Conn, error) {
+	t.Helper()
+	cfg, err := pgx.ParseConfig(fmt.Sprintf("postgres://%s:%s@%s/public", user, pass, addr))
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	cfg.DefaultQueryExecMode = pgx.QueryExecModeSimpleProtocol // the first cut is simple-protocol only
+	dialCtx, dialCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer dialCancel()
+	conn, err := pgx.ConnectConfig(dialCtx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	t.Cleanup(func() {
+		cc, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = conn.Close(cc)
+	})
+	return conn, nil
+}
+
+func testAuth(t *testing.T) shim.TenantAuth {
+	t.Helper()
+	a, err := shim.NewTenantAuth(map[string]string{testUser: testPass})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return a
+}
+
+func TestPGWire_ConnectNegotiatesSSLAndAuthenticates(t *testing.T) {
+	// A successful connect proves: SSLRequest→'N' negotiation, cleartext auth,
+	// the ParameterStatus set pgx reads, and ReadyForQuery. A SET probe returns
+	// cleanly (CommandComplete "SET" + ReadyForQuery).
+	conn := dialPGWire(t, testAuth(t), testUser, testPass)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	tag, err := conn.Exec(ctx, "SET client_encoding='UTF8'")
+	if err != nil {
+		t.Fatalf("SET probe: %v", err)
+	}
+	if tag.String() != "SET" {
+		t.Fatalf("SET tag = %q, want SET", tag.String())
+	}
+}
+
+func TestPGWire_AuthFailureIsRejected(t *testing.T) {
+	addr := serveAddr(t, testAuth(t))
+	if _, err := connectPGWire(t, addr, testUser, "wrongpass"); err == nil {
+		t.Fatal("connect with a wrong password must fail")
+	}
+	if _, err := connectPGWire(t, addr, "ghost", testPass); err == nil {
+		t.Fatal("connect as an unknown user must fail")
+	}
+}
+
+// TestPGWire_SSLRequestGetsN asserts the negotiation byte directly at the raw
+// TCP level (advisor lock): a client that opens with an SSLRequest — what psql
+// and libpq/pgx send first under the default sslmode=prefer — must get a single
+// 'N' back (we terminate no TLS), after which it proceeds in plaintext.
+func TestPGWire_SSLRequestGetsN(t *testing.T) {
+	addr := serveAddr(t, testAuth(t))
+	c, err := net.DialTimeout("tcp", addr, 5*time.Second)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer c.Close()
+
+	// SSLRequest is a fixed 8-byte message: int32 length=8, int32 code=80877103.
+	sslReq, err := (&pgproto3.SSLRequest{}).Encode(nil)
+	if err != nil {
+		t.Fatalf("encode SSLRequest: %v", err)
+	}
+	if _, err := c.Write(sslReq); err != nil {
+		t.Fatalf("write SSLRequest: %v", err)
+	}
+	_ = c.SetReadDeadline(time.Now().Add(5 * time.Second))
+	buf := make([]byte, 1)
+	if _, err := io.ReadFull(c, buf); err != nil {
+		t.Fatalf("read SSL negotiation byte: %v", err)
+	}
+	if buf[0] != 'N' {
+		t.Fatalf("SSL negotiation byte = %q, want 'N'", buf[0])
+	}
+}
+
+func TestPGWire_FullTableAsOfRefused(t *testing.T) {
+	conn := dialPGWire(t, testAuth(t), testUser, testPass)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// No WHERE → full-table shape. Must be refused (0A000) with remediation,
+	// never a silent partial. DB-free: the refusal fires before any index read.
+	_, err := conn.Exec(ctx, "SELECT * FROM _flashback.orders AS OF 'now'")
+	pgErr := requirePgError(t, err)
+	if pgErr.Code != "0A000" {
+		t.Fatalf("code = %s, want 0A000; msg=%s", pgErr.Code, pgErr.Message)
+	}
+	if !contains(pgErr.Message, "full-table") || !contains(pgErr.Message, "WHERE") {
+		t.Fatalf("refusal message not actionable: %s", pgErr.Message)
+	}
+	// The connection survives the error (ReadyForQuery was sent): a follow-up
+	// probe still works.
+	if _, err := conn.Exec(ctx, "SET x=1"); err != nil {
+		t.Fatalf("connection did not recover after an error (missing ReadyForQuery?): %v", err)
+	}
+}
+
+func TestPGWire_MalformedAsOfIsSyntaxError(t *testing.T) {
+	conn := dialPGWire(t, testAuth(t), testUser, testPass)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := conn.Exec(ctx, "SELECT * FROM _flashback.orders AS OF 'not-a-timestamp'")
+	pgErr := requirePgError(t, err)
+	if pgErr.Code != "42601" {
+		t.Fatalf("code = %s, want 42601 (syntax_error); msg=%s", pgErr.Code, pgErr.Message)
+	}
+}
+
+func TestPGWire_NonTimeTravelRejected(t *testing.T) {
+	conn := dialPGWire(t, testAuth(t), testUser, testPass)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := conn.Exec(ctx, "SELECT 1")
+	pgErr := requirePgError(t, err)
+	if pgErr.Code != "0A000" {
+		t.Fatalf("code = %s, want 0A000; msg=%s", pgErr.Code, pgErr.Message)
+	}
+}
+
+// ---- helpers -------------------------------------------------------------
+
+func requirePgError(t *testing.T, err error) *pgconn.PgError {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) {
+		t.Fatalf("expected *pgconn.PgError, got %T: %v", err, err)
+	}
+	return pgErr
+}
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func contains(s, sub string) bool {
+	return len(sub) == 0 || (len(s) >= len(sub) && indexOf(s, sub) >= 0)
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/pgshim/pgshim_test.go
+++ b/internal/pgshim/pgshim_test.go
@@ -35,6 +35,12 @@ func TestTextCell(t *testing.T) {
 		{"bool true", true, []byte("t")},
 		{"bool false", false, []byte("f")},
 		{"time UTC", time.Date(2026, 7, 12, 1, 2, 3, 0, time.UTC), []byte("2026-07-12 01:02:03")},
+		// Native numerics (baseline-origin cells): decimal/shortest round-trip,
+		// never the default fmt path's %g rounding surprises.
+		{"float64 plain", float64(1.5), []byte("1.5")},
+		{"float64 large", float64(1e21), []byte("1e+21")},
+		{"int64 max", int64(9223372036854775807), []byte("9223372036854775807")},
+		{"uint64 max", uint64(18446744073709551615), []byte("18446744073709551615")},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -234,11 +240,61 @@ func TestPGWire_ConnectNegotiatesSSLAndAuthenticates(t *testing.T) {
 
 func TestPGWire_AuthFailureIsRejected(t *testing.T) {
 	addr := serveAddr(t, testAuth(t))
-	if _, err := connectPGWire(t, addr, testUser, "wrongpass"); err == nil {
-		t.Fatal("connect with a wrong password must fail")
+	// Both a wrong password and an unknown user must be rejected with SQLSTATE
+	// 28P01 (invalid_password), so the CODE never reveals which usernames exist.
+	// (The message echoes the SUPPLIED username — as real PostgreSQL does — which
+	// the client already knows; do not assert message equality across the two.)
+	for _, tc := range []struct{ user, pass string }{
+		{testUser, "wrongpass"},
+		{"ghost", testPass},
+	} {
+		_, err := connectPGWire(t, addr, tc.user, tc.pass)
+		pgErr := requirePgError(t, err)
+		if pgErr.Code != "28P01" {
+			t.Errorf("auth failure for %q: code = %s, want 28P01; msg=%s", tc.user, pgErr.Code, pgErr.Message)
+		}
 	}
-	if _, err := connectPGWire(t, addr, "ghost", testPass); err == nil {
-		t.Fatal("connect as an unknown user must fail")
+}
+
+// TestPGWire_ExtendedProtocolDeclinedThenResyncs pins the documented invariant
+// on the DEFAULT pgx client path (pgshim.go: "a default-mode client is not left
+// hanging"): a first cut speaks only the simple query protocol, so an
+// extended-protocol query is declined with 0A000 — NOT a hang — and the
+// connection resyncs on the client's trailing Sync so a following simple-protocol
+// query on the SAME connection succeeds.
+func TestPGWire_ExtendedProtocolDeclinedThenResyncs(t *testing.T) {
+	addr := serveAddr(t, testAuth(t))
+	cfg, err := pgx.ParseConfig(fmt.Sprintf("postgres://%s:%s@%s/public", testUser, testPass, addr))
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	// DEFAULT exec mode = extended protocol (Parse/Bind/Describe/Execute/Sync) —
+	// the mode a naive pgx/ORM client uses.
+	dialCtx, dialCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer dialCancel()
+	conn, err := pgx.ConnectConfig(dialCtx, cfg)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() {
+		cc, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = conn.Close(cc)
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	// Prepare unambiguously sends a Parse (a zero-arg Exec would be optimised to
+	// the simple protocol by pgx). The Parse is declined (not hung).
+	_, err = conn.Prepare(ctx, "probe_stmt", "SELECT 1")
+	pgErr := requirePgError(t, err)
+	if pgErr.Code != "0A000" {
+		t.Fatalf("extended-protocol decline: code = %s, want 0A000; msg=%s", pgErr.Code, pgErr.Message)
+	}
+	// The connection resynced (ReadyForQuery on the trailing Sync): a
+	// simple-protocol query on the SAME conn works.
+	if _, err := conn.Exec(ctx, "SET x=1", pgx.QueryExecModeSimpleProtocol); err != nil {
+		t.Fatalf("connection did not resync after the extended-protocol decline: %v", err)
 	}
 }
 

--- a/internal/pgshim/pgwire_pg_integration_test.go
+++ b/internal/pgshim/pgwire_pg_integration_test.go
@@ -1,0 +1,172 @@
+//go:build integration
+
+package pgshim
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/dbtrail/dbtrail/internal/pgstreamrun"
+	"github.com/dbtrail/dbtrail/internal/shim"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestPGWire_PostgresSourceRoundTrip is the PostgreSQL-source, version-dependent
+// acceptance test (#1008): a live PostgreSQL change streams through
+// pgstreamrun.One into the MySQL index, then a real pgx client connects over the
+// pgwire front-end and a single-row _flashback AS OF returns the row with
+// numeric / bytea / timestamptz values intact. It reuses the proven streaming
+// harness from internal/pgstreamrun's end-to-end test.
+//
+// Needs BOTH a live MySQL index (BINTRAIL_TEST_DSN) and a live PostgreSQL source
+// (BINTRAIL_TEST_PG_DSN); it skips on the MySQL-only jobs and runs in the
+// PostgreSQL 14–17 matrix — this is the "PG CI matrix" the acceptance asks for.
+func TestPGWire_PostgresSourceRoundTrip(t *testing.T) {
+	pgDSN := testutil.SkipIfNoPostgres(t)
+	testutil.SkipIfNoMySQL(t)
+	ctx := context.Background()
+
+	indexDB, dbName := testutil.CreateTestDB(t)
+	indexDSN := testutil.BaseDSN() + "/" + dbName
+
+	const slot = "bintrail_pgwire_it"
+	const pub = "bintrail_pgwire_it_pub"
+	const tbl = "pgwire_it_t"
+
+	pg, err := pgx.Connect(ctx, pgDSN)
+	if err != nil {
+		t.Fatalf("connect PG: %v", err)
+	}
+	t.Cleanup(func() { pg.Close(context.Background()) })
+
+	dropAll := func() {
+		bg := context.Background()
+		_, _ = pg.Exec(bg, "DROP PUBLICATION IF EXISTS "+pub)
+		_, _ = pg.Exec(bg, "DROP TABLE IF EXISTS "+tbl)
+		_, _ = pg.Exec(bg, "SELECT pg_drop_replication_slot($1) WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name=$1)", slot)
+	}
+	dropAll()
+	t.Cleanup(dropAll)
+
+	mustExec := func(sql string, args ...any) {
+		t.Helper()
+		if _, err := pg.Exec(ctx, sql, args...); err != nil {
+			t.Fatalf("exec %q: %v", sql, err)
+		}
+	}
+	mustExec(fmt.Sprintf("CREATE TABLE %s (id int PRIMARY KEY, n numeric, b bytea, ts timestamptz)", tbl))
+	mustExec(fmt.Sprintf("ALTER TABLE %s REPLICA IDENTITY FULL", tbl))
+	mustExec(fmt.Sprintf("CREATE PUBLICATION %s FOR TABLE %s", pub, tbl))
+
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	cfg := pgstreamrun.Config{
+		IndexDSN:    indexDSN,
+		ReplDSN:     withReplication(pgDSN),
+		QueryDSN:    pgDSN,
+		SlotName:    slot,
+		Publication: pub,
+		ServerID:    51,
+		Tables:      "public." + tbl,
+		BatchSize:   100,
+		Checkpoint:  200 * time.Millisecond,
+	}
+	runErr := make(chan error, 1)
+	go func() { runErr <- pgstreamrun.One(runCtx, cfg) }()
+
+	waitForCond(t, 15*time.Second, func() bool {
+		var active bool
+		if err := pg.QueryRow(ctx, "SELECT active FROM pg_replication_slots WHERE slot_name=$1", slot).Scan(&active); err != nil {
+			return false
+		}
+		return active
+	}, "replication slot active")
+
+	// bytea via the hex literal; timestamptz mid-month so a timezone offset in the
+	// walsender's pinned representation cannot shift the asserted year-month.
+	mustExec(fmt.Sprintf("INSERT INTO %s VALUES (1, 123.45, '\\xdeadbeef', '2027-03-15 12:34:56+00')", tbl))
+
+	waitForCond(t, 15*time.Second, func() bool {
+		var n int
+		if err := indexDB.QueryRow("SELECT COUNT(*) FROM binlog_events WHERE table_name = ?", tbl).Scan(&n); err != nil {
+			return false
+		}
+		return n >= 1
+	}, "INSERT indexed into binlog_events")
+
+	cancel()
+	if err := <-runErr; err != nil {
+		t.Fatalf("pgstreamrun.One returned error: %v", err)
+	}
+
+	// Now serve the pgwire front-end over the populated index and query it.
+	addr := serveAddrWithDB(t, Config{
+		IndexDB:    indexDB,
+		ShimConfig: shim.Config{NoArchive: true, IndexDBName: dbName},
+		Auth:       testAuth(t),
+	})
+	conn, err := connectPGWire(t, addr, testUser, testPass)
+	if err != nil {
+		t.Fatalf("connect pgwire: %v", err)
+	}
+	qctx, qcancel := context.WithTimeout(ctx, 10*time.Second)
+	defer qcancel()
+
+	rows, err := conn.Query(qctx, fmt.Sprintf("SELECT * FROM _flashback.%s AS OF 'now' WHERE id = 1", tbl))
+	if err != nil {
+		t.Fatalf("pgwire query: %v", err)
+	}
+	defer rows.Close()
+	fields := rows.FieldDescriptions()
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			t.Fatalf("pgwire rows: %v", err)
+		}
+		t.Fatal("pgwire query returned no row")
+	}
+	vals, err := rows.Values()
+	if err != nil {
+		t.Fatalf("pgwire values: %v", err)
+	}
+	got := make(map[string]string, len(fields))
+	for i, f := range fields {
+		got[f.Name] = fmt.Sprint(vals[i])
+	}
+
+	if got["id"] != "1" {
+		t.Errorf("id = %q, want 1", got["id"])
+	}
+	if got["n"] != "123.45" {
+		t.Errorf("numeric n = %q, want 123.45", got["n"])
+	}
+	if !strings.Contains(got["b"], "deadbeef") {
+		t.Errorf("bytea b = %q, want to contain deadbeef", got["b"])
+	}
+	if !strings.Contains(got["ts"], "2027-03") {
+		t.Errorf("timestamptz ts = %q, want to contain 2027-03", got["ts"])
+	}
+}
+
+func withReplication(base string) string {
+	if strings.Contains(base, "?") {
+		return base + "&replication=database"
+	}
+	return base + "?replication=database"
+}
+
+func waitForCond(t *testing.T, timeout time.Duration, cond func() bool, what string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}

--- a/internal/pgshim/session.go
+++ b/internal/pgshim/session.go
@@ -1,0 +1,256 @@
+package pgshim
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgproto3"
+
+	"github.com/dbtrail/dbtrail/internal/event"
+	"github.com/dbtrail/dbtrail/internal/shim"
+)
+
+// session is the per-connection query state: the backend it writes to, the
+// engine handler, and the currently-selected schema.
+type session struct {
+	be        *pgproto3.Backend
+	h         *shim.Handler
+	currentDB string
+	logger    *slog.Logger
+}
+
+// pgErr is a query-level failure carrying a 5-char SQLSTATE and a message.
+type pgErr struct {
+	code string
+	msg  string
+}
+
+// handleSimpleQuery answers one simple-protocol Query. It returns a non-nil
+// error ONLY on a wire write failure (the caller then closes); a query-level
+// failure is sent as an ErrorResponse and returns nil. Every path ends with
+// ReadyForQuery so the client is never left hanging (advisor invariant).
+func (s *session) handleSimpleQuery(qstr string) error {
+	if strings.TrimSpace(qstr) == "" {
+		s.be.Send(&pgproto3.EmptyQueryResponse{})
+		return s.readyFlush()
+	}
+
+	cols, rows, tag, perr := s.resolve(qstr)
+	if perr != nil {
+		s.errorResponse(perr.code, perr.msg)
+		return s.readyFlush()
+	}
+	// cols == nil marks a non-row reply (a handshake/setup probe like SET): no
+	// RowDescription, just the CommandComplete tag. A real query — even one that
+	// resolves to zero rows (row absent at AsOf) — has a non-nil cols and emits
+	// the RowDescription so the client sees the real column header.
+	if cols != nil {
+		s.rowDescription(cols)
+		for _, r := range rows {
+			s.dataRow(r)
+		}
+	}
+	s.commandComplete(tag)
+	return s.readyFlush()
+}
+
+// resolve parses and runs a query through the shared engine, returning the
+// column list, the (zero or one) rendered rows, the CommandComplete tag, and a
+// query-level error. Single-row AS OF only; full-table and _diff are refused.
+func (s *session) resolve(qstr string) (cols []string, rows [][][]byte, tag string, perr *pgErr) {
+	q, err := shim.Parse(qstr, s.currentDB)
+	if err != nil {
+		if !errors.Is(err, shim.ErrNotTimeTravel) {
+			// Recognised as a time-travel query but malformed (bad AS OF literal,
+			// missing schema, bad grammar) → syntax_error.
+			return nil, nil, "", &pgErr{"42601", err.Error()}
+		}
+		// Not a time-travel query. Tolerate the handful of setup statements a
+		// client fires on connect; reject anything else (we are not a general
+		// PostgreSQL engine).
+		if t, ok := probeReply(qstr); ok {
+			return nil, nil, t, nil
+		}
+		return nil, nil, "", &pgErr{"0A000", fmt.Sprintf(
+			"this endpoint serves only _flashback / _snapshot AS OF time-travel queries; got: %s",
+			strings.TrimSpace(qstr))}
+	}
+
+	// PK-column validation is shared with the MySQL front-end (#296/#821): a
+	// WHERE whose column is not the table's single-column PK is refused so a
+	// non-PK filter cannot silently return the wrong row.
+	if msg, reject := s.h.PKColumnCheck(q); reject {
+		return nil, nil, "", &pgErr{"42601", msg}
+	}
+
+	switch q.Type {
+	case shim.TypeDiff:
+		return nil, nil, "", &pgErr{"0A000",
+			"_diff is not supported over the PostgreSQL wire front-end; use `bintrail-pg reconstruct --history` for a row's per-event history"}
+	case shim.TypeFlashback, shim.TypeSnapshot:
+		if q.PKColumn == "" {
+			return nil, nil, "", &pgErr{"0A000", fullTableRefusalMsg}
+		}
+		ctx, cancel := s.h.QueryContext()
+		defer cancel()
+		var image map[string]any
+		var rerr error
+		if q.Type == shim.TypeSnapshot {
+			image, rerr = s.h.ResolveSnapshotRow(ctx, q)
+		} else {
+			image, rerr = s.h.ResolveFlashbackRow(ctx, q)
+		}
+		if rerr != nil {
+			return nil, nil, "", pgResolveError(rerr)
+		}
+		cols = s.h.ColumnsFor(image, q)
+		if image == nil {
+			// Row did not exist at AsOf (never created, or a DELETE tail): a real
+			// resultset with the table's columns and zero rows.
+			return cols, nil, "SELECT 0", nil
+		}
+		cells, cerr := imageCells(image, cols)
+		if cerr != nil {
+			// Residual unchanged-TOAST marker (#592) — refuse rather than serve
+			// the marker's JSON as a value.
+			return nil, nil, "", &pgErr{"XX000", cerr.Error()}
+		}
+		return cols, [][][]byte{cells}, "SELECT 1", nil
+	default:
+		return nil, nil, "", &pgErr{"XX000", fmt.Sprintf("unsupported query type: %s", q.Type)}
+	}
+}
+
+// pgResolveError maps the wire-neutral *shim.ResolveError (or a raw data-fault)
+// to a PostgreSQL SQLSTATE. The class split mirrors the MySQL front-end's
+// wire-code mapping; only the codes differ.
+func pgResolveError(err error) *pgErr {
+	var re *shim.ResolveError
+	if errors.As(err, &re) {
+		switch re.Class {
+		case shim.ResolveGap:
+			return &pgErr{"22023", fmt.Sprintf(
+				"resolve %s: %s — the AS OF instant is outside the history this index retains (rotated and not archived)",
+				re.QType, re.Err)}
+		case shim.ResolveTimeout:
+			return &pgErr{"57014", fmt.Sprintf(
+				"resolve %s: query exceeded --query-timeout and was aborted; narrow the AS OF range, filter by PK, or raise --query-timeout",
+				re.QType)}
+		case shim.ResolveCanceled:
+			return &pgErr{"57014", fmt.Sprintf(
+				"resolve %s: query canceled (client disconnected or server shutting down)", re.QType)}
+		default:
+			return &pgErr{"XX000", re.Error()}
+		}
+	}
+	// Raw data-fault (ApplyAt / baseline read, e.g. a TOAST marker).
+	return &pgErr{"XX000", err.Error()}
+}
+
+// imageCells renders a row image to PostgreSQL text-format cells in cols order.
+// A key missing from the image is SQL NULL (nil cell) — the same "column dropped
+// since AsOf" semantic the MySQL verbatim path uses.
+func imageCells(image map[string]any, cols []string) ([][]byte, error) {
+	cells := make([][]byte, len(cols))
+	for i, c := range cols {
+		v, ok := image[c]
+		if !ok {
+			cells[i] = nil
+			continue
+		}
+		cell, err := textCell(c, v)
+		if err != nil {
+			return nil, err
+		}
+		cells[i] = cell
+	}
+	return cells, nil
+}
+
+// textCell renders one image value as a PostgreSQL text-format cell (nil = SQL
+// NULL). The image is post-ApplyAt: numbers arrive as json.Number, strings/bytes
+// pass through, and a residual unchanged-TOAST marker is refused (#592) rather
+// than serialised. Byte values go on the wire verbatim (the conservative
+// all-text encoding), so a bytea/blob round-trips its exact bytes.
+func textCell(col string, v any) ([]byte, error) {
+	if event.IsUnchangedToastMarker(v) {
+		return nil, event.UnresolvedToastError("", "", "", []string{col})
+	}
+	switch x := v.(type) {
+	case nil:
+		return nil, nil
+	case []byte:
+		return x, nil
+	case string:
+		return []byte(x), nil
+	case json.Number:
+		return []byte(x.String()), nil
+	case bool:
+		if x {
+			return []byte("t"), nil
+		}
+		return []byte("f"), nil
+	case time.Time:
+		return []byte(x.UTC().Format("2006-01-02 15:04:05")), nil
+	default:
+		return []byte(fmt.Sprint(x)), nil
+	}
+}
+
+// probeReply tolerates the setup statements a client may fire on connect that
+// are not time-travel queries, so the connection is not torn down by an error
+// the operator did not type. Deliberately narrow: an unrecognised statement
+// falls through to the "only time-travel queries" rejection.
+func probeReply(qstr string) (tag string, ok bool) {
+	q := strings.ToLower(strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(qstr), ";")))
+	switch {
+	case strings.HasPrefix(q, "set "):
+		return "SET", true
+	case q == "begin", strings.HasPrefix(q, "begin "):
+		return "BEGIN", true
+	case q == "commit":
+		return "COMMIT", true
+	case q == "rollback":
+		return "ROLLBACK", true
+	}
+	return "", false
+}
+
+// --- wire writers ---------------------------------------------------------
+
+func (s *session) rowDescription(cols []string) {
+	fields := make([]pgproto3.FieldDescription, len(cols))
+	for i, c := range cols {
+		fields[i] = pgproto3.FieldDescription{
+			Name:         []byte(c),
+			DataTypeOID:  pgtypeText,
+			DataTypeSize: -1, // variable-length
+			TypeModifier: -1,
+			Format:       pgproto3.TextFormat,
+		}
+	}
+	s.be.Send(&pgproto3.RowDescription{Fields: fields})
+}
+
+func (s *session) dataRow(cells [][]byte) {
+	s.be.Send(&pgproto3.DataRow{Values: cells})
+}
+
+func (s *session) commandComplete(tag string) {
+	s.be.Send(&pgproto3.CommandComplete{CommandTag: []byte(tag)})
+}
+
+func (s *session) errorResponse(code, msg string) {
+	s.be.Send(&pgproto3.ErrorResponse{Severity: "ERROR", SeverityUnlocalized: "ERROR", Code: code, Message: msg})
+}
+
+// readyFlush sends ReadyForQuery(idle) and flushes — the required end of every
+// simple-query cycle, success or failure.
+func (s *session) readyFlush() error {
+	s.be.Send(&pgproto3.ReadyForQuery{TxStatus: 'I'})
+	return s.be.Flush()
+}

--- a/internal/pgshim/session.go
+++ b/internal/pgshim/session.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"strings"
 	"time"
 
@@ -189,6 +190,28 @@ func textCell(col string, v any) ([]byte, error) {
 		return []byte(x), nil
 	case json.Number:
 		return []byte(x.String()), nil
+	// Native numeric types appear for a baseline-origin cell (ReadBaselineRow
+	// scans a typed Parquet column into a native Go value) — reachable when a
+	// MySQL/MariaDB-source index is served here and _snapshot returns a value
+	// untouched in the binlog window. Render them explicitly rather than via the
+	// default fmt path, whose %v on a float uses scientific notation for extreme
+	// magnitudes; strconv 'g'/-1 is the shortest round-trippable form and matches
+	// PostgreSQL's own float text. (A PG-source index stores every value as text,
+	// so it hits the string case above and never reaches here.)
+	case float64:
+		return strconv.AppendFloat(nil, x, 'g', -1, 64), nil
+	case float32:
+		return strconv.AppendFloat(nil, float64(x), 'g', -1, 32), nil
+	case int64:
+		return strconv.AppendInt(nil, x, 10), nil
+	case int32:
+		return strconv.AppendInt(nil, int64(x), 10), nil
+	case int:
+		return strconv.AppendInt(nil, int64(x), 10), nil
+	case uint64:
+		return strconv.AppendUint(nil, x, 10), nil
+	case uint32:
+		return strconv.AppendUint(nil, uint64(x), 10), nil
 	case bool:
 		if x {
 			return []byte("t"), nil

--- a/internal/shim/handler.go
+++ b/internal/shim/handler.go
@@ -23,7 +23,6 @@ import (
 	"github.com/dbtrail/dbtrail/internal/metadata"
 	"github.com/dbtrail/dbtrail/internal/parquetquery"
 	"github.com/dbtrail/dbtrail/internal/query"
-	"github.com/dbtrail/dbtrail/internal/reconstruct"
 )
 
 // showTablesFromVirtualRE matches the interactive `SHOW [FULL] TABLES
@@ -387,6 +386,14 @@ func (h *Handler) queryContext() (context.Context, context.CancelFunc) {
 	return context.WithCancel(base)
 }
 
+// QueryContext exposes queryContext so a second wire front-end (the pgwire
+// server in internal/pgshim, #1008) roots each resolve at the same
+// per-connection context + QueryTimeout deadline the MySQL command loop uses.
+// The returned cancel must be deferred.
+func (h *Handler) QueryContext() (context.Context, context.CancelFunc) {
+	return h.queryContext()
+}
+
 // UseDB stores the schema the client selected. _flashback queries
 // without an explicit schema use this value.
 func (h *Handler) UseDB(dbName string) error {
@@ -495,27 +502,11 @@ func (h *Handler) HandleQuery(qstr string) (*mysql.Result, error) {
 // though the client only sees "query interrupted"; nil logger is a no-op
 // for tests that don't care about log output.
 func wrapFetchError(ctx context.Context, qType QueryType, err error, logger *slog.Logger) error {
-	var gapErr *query.GapError
-	if errors.As(err, &gapErr) {
-		return mysql.NewError(mysql.ER_NO_PARTITION_FOR_GIVEN_VALUE,
-			fmt.Sprintf("resolve %s: %s", qType, gapErr.Error()))
-	}
-	if ctxErr := ctx.Err(); ctxErr != nil {
-		if logger != nil && !errors.Is(err, ctxErr) {
-			logger.Warn("shim: query context ended before fetch returned; discarding underlying error from the wire response",
-				"query_type", qType, "ctx_err", ctxErr, "underlying_err", err)
-		}
-		err = ctxErr
-	}
-	if errors.Is(err, context.DeadlineExceeded) {
-		return mysql.NewError(mysql.ER_QUERY_INTERRUPTED, fmt.Sprintf(
-			"resolve %s: query exceeded the shim's --query-timeout and was aborted; narrow the AS OF range, filter by PK, or raise --query-timeout", qType))
-	}
-	if errors.Is(err, context.Canceled) {
-		return mysql.NewError(mysql.ER_QUERY_INTERRUPTED, fmt.Sprintf(
-			"resolve %s: query canceled (client disconnected or shim shutting down)", qType))
-	}
-	return fmt.Errorf("resolve %s: %w", qType, err)
+	// Delegates to the wire-neutral classifier (#1008, resolve.go) so the MySQL
+	// and pgwire front-ends draw the SAME gap/deadline/cancel/fault split; the
+	// mysqlResolveError mapping keeps this byte-identical to the pre-#1008 form
+	// for every existing caller (runFullTable / runDiff / runSnapshotFullTable).
+	return mysqlResolveError(classifyFetchError(ctx, qType, err, logger))
 }
 
 // fullTableGateError converts a FullTableGate.Acquire failure into the
@@ -568,65 +559,17 @@ func (h *Handler) runPointInTime(q TimeTravelQuery) (*mysql.Result, error) {
 	ctx, cancel := h.queryContext()
 	defer cancel()
 
-	// Fetch the PK's full ordered event sequence up to AsOf and cut it at the
-	// TRANSACTION boundary, not the row (#988). event_timestamp is a
-	// statement's execution time, so a plain LimitPerPK=1 could surface the
-	// latest event of a multi-statement transaction that had not fully
-	// committed as of AsOf — a row state that never existed at AsOf.
-	// reconstruct.FetchEventsAtomic (the #783 machinery the single-row
-	// _snapshot path already uses) drops a straddling trailing transaction
-	// whole, and reconstruct.ApplyAt folds the surviving events (INSERT/UPDATE
-	// → row_after, DELETE → deleted) onto the state at AsOf. No LimitPerPK: the
-	// fold needs the sequence, and trimming a single LimitPerPK=1 row would
-	// leave nothing to fall back to. The fetch is one-PK-scoped, so its size is
-	// bounded by how often this row changed in the retained window — the same
-	// bound _diff and the single-row _snapshot path already accept.
-	opts := query.Options{
-		Schema: q.Schema,
-		Table:  q.Table,
-		Until:  &q.AsOf,
-	}
-	// q.PKValue may legitimately be "" (`WHERE name = ''` against a NOT-NULL
-	// string PK). buildQuery DISABLES the PK filter when Options.PKValues == "",
-	// which would fold every event for the WHOLE TABLE onto one state — a silent
-	// wrong answer. Route "" through PKValuesIn (`pk_values IN (?)`), which keeps
-	// the fetch scoped to the one row; keep the pk_hash fast path otherwise.
-	// Mirrors runSnapshotPointInTime. q.PKValue is raw/unescaped (#826);
-	// pk_values is event.BuildPKValues-encoded, so re-encode with EscapePKValue.
-	encoded := event.EscapePKValue(q.PKValue)
-	if q.PKValue != "" {
-		opts.PKValues = encoded
-	} else {
-		opts.PKValuesIn = []string{encoded}
-	}
-	engine := query.New(h.indexDB)
-	rows, _, err := reconstruct.FetchEventsAtomic(ctx, h.indexDB, engine, query.FetchMergedOptions{
-		Opts:           opts,
-		DBName:         h.cfg.IndexDBName,
-		NoArchive:      h.cfg.NoArchive,
-		AllowGaps:      h.cfg.AllowGaps,
-		ArchiveFetcher: h.archiveFetcher,
-	}, q.AsOf)
+	// The single-row fetch → ENUM/SET epoch map → transaction-atomic ApplyAt
+	// fold now lives in the wire-neutral ResolveFlashbackRow (#1008, resolve.go),
+	// shared with the pgwire front-end. A nil image means the row did not exist
+	// at AsOf (never created, or a DELETE tail); a fetch/coverage failure is a
+	// *ResolveError; an ApplyAt data-fault is raw. mysqlRenderErr maps both to
+	// the same wire codes the pre-#1008 inline path produced.
+	image, err := h.ResolveFlashbackRow(ctx, q)
 	if err != nil {
-		return nil, wrapFetchError(ctx, q.Type, err, h.logger)
+		return nil, mysqlRenderErr(err)
 	}
-
-	// ENUM/SET ordinals → labels (#472/#475) BEFORE the fold: ApplyAt replaces
-	// the image wholesale per event, so pre-mapped events make the final state
-	// carry labels the way the live table did when the event happened.
-	h.mapEventImages(q.Schema, q.Table, rows)
-	image, err := reconstruct.ApplyAt(nil, rows, q.AsOf)
-	if err != nil {
-		// Residual unchanged-TOAST marker (#592) — a capture-invariant
-		// violation, i.e. a server-side data fault: plain error →
-		// ER_UNKNOWN_ERROR (1105). Refusing beats serving the marker's JSON.
-		return nil, err
-	}
-	if len(image) == 0 {
-		// Row never existed at AsOf (no event in the window), or its latest
-		// surviving event was a DELETE. A non-DELETE tail that folds to empty is
-		// a corrupt/partial row image — surfaced as a Warn, not silently.
-		h.warnCorruptImageDrop(q.Schema, q.Table, rows)
+	if image == nil {
 		return emptyResult(), nil
 	}
 	// When q.Columns is set (#313 user-supplied projection), bypass
@@ -1048,63 +991,12 @@ func fullTableColumns(images []map[string]any, ddlOrder []string) []string {
 //   - single-column PK that does NOT match → 1064 with an actionable
 //     message naming both the expected and the user-supplied column.
 func (h *Handler) validatePKColumn(q TimeTravelQuery) error {
-	if q.PKColumn == "" {
-		return nil
-	}
-	if h.resolverFn == nil {
-		return nil
-	}
-	r, err := h.resolverCache.get(time.Now, resolverCacheTTL, h.resolverFn, h.logger)
-	if err != nil {
-		// Cannot confirm q.PKColumn is the table's PK. A
-		// column-qualified WHERE is guaranteed here (the full-table
-		// shape returned above), so fail loud rather than join the
-		// literal against pk_values and risk the wrong row (#821).
-		// ErrNoSnapshots (benign first-install state) still can't
-		// verify the PK, so it rejects too — only the no-WHERE
-		// full-table path is exempt. Was Debug/skip; raised to Warn.
-		reason := "schema_snapshots lookup failed"
-		if errors.Is(err, metadata.ErrNoSnapshots) {
-			reason = "no schema snapshots available yet"
-		}
-		h.logger.Warn("shim: cannot verify PK column; rejecting column-qualified WHERE",
-			"err", err, "reason", reason, "schema", q.Schema, "table", q.Table, "pk_column", q.PKColumn)
-		return mysql.NewError(mysql.ER_PARSE_ERROR, fmt.Sprintf(
-			"cannot verify WHERE column %s is the primary key of %s.%s (%s); refusing to run so a non-PK WHERE cannot silently return the wrong row",
-			q.PKColumn, q.Schema, q.Table, reason,
-		))
-	}
-	tm, err := r.Resolve(q.Schema, q.Table)
-	if err != nil {
-		// Table absent from every snapshot (created after the newest
-		// snapshot, or not yet seen on the stream). Can't verify the
-		// PK, so a column-qualified WHERE rejects rather than answer
-		// against pk_values and return a different row (#821). Re-run
-		// `bintrail snapshot`; the no-WHERE full-table path still works.
-		h.logger.Warn("shim: table not in any snapshot; rejecting column-qualified WHERE",
-			"err", err, "schema", q.Schema, "table", q.Table, "pk_column", q.PKColumn)
-		return mysql.NewError(mysql.ER_PARSE_ERROR, fmt.Sprintf(
-			"cannot verify WHERE column %s is the primary key of %s.%s (table not present in any indexed snapshot); refusing to run so a non-PK WHERE cannot silently return the wrong row",
-			q.PKColumn, q.Schema, q.Table,
-		))
-	}
-	if len(tm.PKColumns) == 0 {
-		return mysql.NewError(mysql.ER_PARSE_ERROR, fmt.Sprintf(
-			"%s.%s has no primary key declared in the indexed snapshot; cannot resolve %s by PK",
-			q.Schema, q.Table, q.Type,
-		))
-	}
-	if len(tm.PKColumns) > 1 {
-		return mysql.NewError(mysql.ER_PARSE_ERROR, fmt.Sprintf(
-			"%s.%s has a composite primary key (%s); WHERE %s = <value> shape supports only single-column PKs",
-			q.Schema, q.Table, strings.Join(tm.PKColumns, ", "), q.PKColumn,
-		))
-	}
-	if q.PKColumn != tm.PKColumns[0] {
-		return mysql.NewError(mysql.ER_PARSE_ERROR, fmt.Sprintf(
-			"WHERE column must be the primary key of %s.%s (expected %s, got %s)",
-			q.Schema, q.Table, tm.PKColumns[0], q.PKColumn,
-		))
+	// The check itself is wire-neutral (#1008): PKColumnCheck returns the reason
+	// string, shared with the pgwire front-end (which wraps it in SQLSTATE
+	// 42601). Here we keep the historical ER_PARSE_ERROR (1064) wrapping and the
+	// exact message text, so MySQL behaviour is unchanged.
+	if msg, reject := h.PKColumnCheck(q); reject {
+		return mysql.NewError(mysql.ER_PARSE_ERROR, msg)
 	}
 	return nil
 }

--- a/internal/shim/resolve.go
+++ b/internal/shim/resolve.go
@@ -1,0 +1,392 @@
+package shim
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/go-mysql-org/go-mysql/mysql"
+
+	"github.com/dbtrail/dbtrail/internal/event"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/query"
+	"github.com/dbtrail/dbtrail/internal/reconstruct"
+)
+
+// This file holds the WIRE-NEUTRAL time-travel seam (#1008). The single-row
+// _flashback / _snapshot resolve — fetch → ENUM/SET epoch map → ApplyAt fold —
+// produces a plain `map[string]any` row image and a `[]string` column order.
+// Neither depends on the MySQL wire protocol, so a second front-end (the
+// PostgreSQL wire server in internal/pgshim) reuses these methods verbatim and
+// inherits, for free, the ENUM/SET mapping (#472/#475), the residual-TOAST
+// refusal (#592), the transaction-atomic cut (#988), and the #1007 PostgreSQL
+// _snapshot baseline fold. Only the FINAL render (image → *mysql.Result) stays
+// MySQL-typed, in handler.go; the pgwire front-end renders the same image to
+// RowDescription/DataRow.
+//
+// Errors are returned in a wire-neutral shape too: a fetch / coverage failure
+// comes back as a *ResolveError carrying a protocol-independent Class, so each
+// front-end maps it to its own error code (MySQL 1526/1317/1105 here; PG
+// SQLSTATE in pgshim) without re-classifying. A data-fault from ApplyAt or the
+// baseline read (e.g. a residual TOAST marker) comes back RAW so it lands on the
+// "internal fault" branch of every front-end.
+
+// ResolveErrClass classifies a single-row resolve failure independent of the
+// wire protocol. It mirrors the branches wrapFetchError has always drawn.
+type ResolveErrClass int
+
+const (
+	// ResolveFault is an internal / server-side fault (index-DB outage,
+	// archive S3 error, a resultset-build bug). MySQL → ER_UNKNOWN_ERROR
+	// (1105); PG → SQLSTATE XX000 internal_error.
+	ResolveFault ResolveErrClass = iota
+	// ResolveGap is a coverage gap: the AS OF instant falls in a
+	// rotated-but-unarchived hole the index no longer retains. MySQL →
+	// ER_NO_PARTITION_FOR_GIVEN_VALUE (1526); PG → SQLSTATE 22023.
+	ResolveGap
+	// ResolveTimeout is a per-query deadline (QueryTimeout) expiry. MySQL →
+	// ER_QUERY_INTERRUPTED (1317); PG → SQLSTATE 57014 query_canceled.
+	ResolveTimeout
+	// ResolveCanceled is a client-disconnect / shutdown cancel. MySQL →
+	// ER_QUERY_INTERRUPTED (1317); PG → SQLSTATE 57014.
+	ResolveCanceled
+)
+
+// ResolveError wraps a classified single-row resolve failure so both wire
+// front-ends map it to their own protocol code without re-running the
+// gap/deadline/cancel classification. Unwrap exposes the underlying error for
+// errors.Is/As.
+type ResolveError struct {
+	Class ResolveErrClass
+	QType QueryType
+	Err   error
+}
+
+func (e *ResolveError) Error() string { return fmt.Sprintf("resolve %s: %s", e.QType, e.Err) }
+func (e *ResolveError) Unwrap() error { return e.Err }
+
+// classifyFetchError reproduces wrapFetchError's classification but returns a
+// wire-neutral *ResolveError instead of a *mysql.MyError, so the pgwire
+// front-end reuses it. A coverage gap wins first (it is a client-input concern
+// distinct from an internal failure); then, if the query context is already
+// dead, its error takes over regardless of what the driver surfaced (go-mysql
+// wraps ctx.Err() but sqlmock and the DuckDB archive path return their own
+// cancellation sentinels, and the wire code must reflect WHY the query died, not
+// which driver noticed first). The discarded underlying error is logged (Warn)
+// before it is overwritten so an operator can still find the real cause; nil
+// logger is a no-op.
+func classifyFetchError(ctx context.Context, qType QueryType, err error, logger *slog.Logger) *ResolveError {
+	var gapErr *query.GapError
+	if errors.As(err, &gapErr) {
+		return &ResolveError{Class: ResolveGap, QType: qType, Err: gapErr}
+	}
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		if logger != nil && !errors.Is(err, ctxErr) {
+			logger.Warn("shim: query context ended before fetch returned; discarding underlying error from the wire response",
+				"query_type", qType, "ctx_err", ctxErr, "underlying_err", err)
+		}
+		err = ctxErr
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return &ResolveError{Class: ResolveTimeout, QType: qType, Err: err}
+	}
+	if errors.Is(err, context.Canceled) {
+		return &ResolveError{Class: ResolveCanceled, QType: qType, Err: err}
+	}
+	return &ResolveError{Class: ResolveFault, QType: qType, Err: err}
+}
+
+// mysqlResolveError maps a classified *ResolveError to the MySQL wire error the
+// client sees. The messages are byte-identical to the pre-#1008 wrapFetchError
+// so no MySQL behaviour changes.
+func mysqlResolveError(rerr *ResolveError) error {
+	switch rerr.Class {
+	case ResolveGap:
+		return mysql.NewError(mysql.ER_NO_PARTITION_FOR_GIVEN_VALUE,
+			fmt.Sprintf("resolve %s: %s", rerr.QType, rerr.Err.Error()))
+	case ResolveTimeout:
+		return mysql.NewError(mysql.ER_QUERY_INTERRUPTED, fmt.Sprintf(
+			"resolve %s: query exceeded the shim's --query-timeout and was aborted; narrow the AS OF range, filter by PK, or raise --query-timeout", rerr.QType))
+	case ResolveCanceled:
+		return mysql.NewError(mysql.ER_QUERY_INTERRUPTED, fmt.Sprintf(
+			"resolve %s: query canceled (client disconnected or shim shutting down)", rerr.QType))
+	default:
+		return fmt.Errorf("resolve %s: %w", rerr.QType, rerr.Err)
+	}
+}
+
+// mysqlRenderErr maps a resolve error to the MySQL wire: a *ResolveError goes
+// through mysqlResolveError; a raw data-fault (ApplyAt / baseline read) passes
+// through unchanged so go-mysql/server emits ER_UNKNOWN_ERROR (1105) with the
+// original message — exactly what the pre-#1008 single-row paths did.
+func mysqlRenderErr(err error) error {
+	var rerr *ResolveError
+	if errors.As(err, &rerr) {
+		return mysqlResolveError(rerr)
+	}
+	return err
+}
+
+// ResolveFlashbackRow resolves a single-row _flashback query (binlog-only) to
+// its row image at q.AsOf, independent of the wire protocol. A nil map means the
+// row did not exist at AsOf (never created, or its latest surviving event was a
+// DELETE) — the caller renders a zero-row resultset. q MUST be a single-row
+// query (q.PKColumn != ""); routing the full-table shape (PKColumn == "") is the
+// caller's responsibility. Errors: a fetch/coverage failure is a *ResolveError;
+// an ApplyAt data-fault (residual TOAST marker, #592) is raw.
+//
+// The MySQL renderer (runPointInTime) and the pgwire renderer share this method,
+// so the transaction-atomic cut (#988), the raw-vs-encoded PK routing (#826),
+// and the ENUM/SET epoch mapping (#472/#475) live in exactly one place.
+func (h *Handler) ResolveFlashbackRow(ctx context.Context, q TimeTravelQuery) (map[string]any, error) {
+	opts := query.Options{
+		Schema: q.Schema,
+		Table:  q.Table,
+		Until:  &q.AsOf,
+	}
+	// q.PKValue may legitimately be "" (`WHERE name = ''` against a NOT-NULL
+	// string PK). buildQuery DISABLES the PK filter when Options.PKValues == "",
+	// which would fold every event for the WHOLE TABLE onto one state — a silent
+	// wrong answer. Route "" through PKValuesIn (`pk_values IN (?)`), which keeps
+	// the fetch scoped to the one row; keep the pk_hash fast path otherwise.
+	// q.PKValue is raw/unescaped (#826); pk_values is event.BuildPKValues-
+	// encoded, so re-encode with EscapePKValue.
+	encoded := event.EscapePKValue(q.PKValue)
+	if q.PKValue != "" {
+		opts.PKValues = encoded
+	} else {
+		opts.PKValuesIn = []string{encoded}
+	}
+	engine := query.New(h.indexDB)
+	rows, _, err := reconstruct.FetchEventsAtomic(ctx, h.indexDB, engine, query.FetchMergedOptions{
+		Opts:           opts,
+		DBName:         h.cfg.IndexDBName,
+		NoArchive:      h.cfg.NoArchive,
+		AllowGaps:      h.cfg.AllowGaps,
+		ArchiveFetcher: h.archiveFetcher,
+	}, q.AsOf)
+	if err != nil {
+		return nil, classifyFetchError(ctx, q.Type, err, h.logger)
+	}
+
+	// ENUM/SET ordinals → labels (#472/#475) BEFORE the fold: ApplyAt replaces
+	// the image wholesale per event, so pre-mapped events make the final state
+	// carry labels the way the live table did when the event happened.
+	h.mapEventImages(q.Schema, q.Table, rows)
+	image, err := reconstruct.ApplyAt(nil, rows, q.AsOf)
+	if err != nil {
+		// Residual unchanged-TOAST marker (#592) — a capture-invariant
+		// violation, i.e. a server-side data fault. Raw error → the caller's
+		// "internal fault" branch. Refusing beats serving the marker's JSON.
+		return nil, err
+	}
+	if len(image) == 0 {
+		// Row never existed at AsOf (no event in the window), or its latest
+		// surviving event was a DELETE. A non-DELETE tail that folds to empty is
+		// a corrupt/partial row image — surfaced as a Warn, not silently.
+		h.warnCorruptImageDrop(q.Schema, q.Table, rows)
+		return nil, nil
+	}
+	return image, nil
+}
+
+// ResolveSnapshotRow resolves a single-row _snapshot query (baseline-aware) to
+// its row image at q.AsOf, independent of the wire protocol. With no usable
+// baseline source it degrades to the binlog-only ResolveFlashbackRow — the same
+// fallback the MySQL path drew. A nil map means the row did not exist at AsOf.
+// Errors follow the same neutral shape as ResolveFlashbackRow.
+//
+// This carries the #1007 PostgreSQL fix (the flavor bypass at
+// baselinePKStringMatchable): a PG source's empty DATA_TYPE token would
+// otherwise silently degrade every PG _snapshot to binlog-only. Because the fix
+// lives here, the pgwire front-end inherits it for free — a second renderer must
+// NOT re-derive it.
+func (h *Handler) ResolveSnapshotRow(ctx context.Context, q TimeTravelQuery) (map[string]any, error) {
+	src := h.baselineSource()
+	if src == "" {
+		h.logger.Debug("shim: _snapshot has no baseline source configured; using binlog-only path",
+			"schema", q.Schema, "table", q.Table)
+		return h.ResolveFlashbackRow(ctx, q)
+	}
+
+	// Guard the PK type before attempting a baseline match. ReadBaselineRow
+	// binds q.PKValue as a string against the typed Parquet column and relies on
+	// DuckDB's implicit coercion; only types whose Parquet representation coerces
+	// cleanly from a string literal are safe here (see baselinePKStringMatchable),
+	// so for the rest we fall back to binlog-only with a signal.
+	dataType, ok := h.pkDataType(q.Schema, q.Table, q.PKColumn)
+	if !ok {
+		h.logger.Debug("shim: _snapshot cannot resolve PK type; using binlog-only path",
+			"schema", q.Schema, "table", q.Table, "pk_column", q.PKColumn)
+		return h.ResolveFlashbackRow(ctx, q)
+	}
+	// PostgreSQL baselines store every column as raw pgoutput text (#593), so
+	// ReadBaselineRow's string-bound match is a string-identity join that can
+	// only recover the right row or find nothing. The MySQL DATA_TYPE token is
+	// empty for a PG source (PG records pg_type_oid), so without this flavor
+	// bypass every PG _snapshot would silently degrade to binlog-only and the
+	// baseline fold the docs promise would never run (#1006/#1007). The flavor
+	// read is short-circuited so the MySQL hot path never pays for it.
+	if !baselinePKStringMatchable(dataType) {
+		if flavor := query.SourceFlavor(h.indexDB); flavor != "postgres" {
+			if dataType == "" {
+				h.logger.Warn("shim: _snapshot could not confirm a postgres source flavor (stream_state read empty or failed); "+
+					"baseline fold skipped, using binlog-only path — a row untouched within the binlog window will read as absent",
+					"schema", q.Schema, "table", q.Table, "pk_column", q.PKColumn, "flavor", flavor)
+			} else {
+				h.logger.Warn("shim: _snapshot PK type not safe for baseline lookup; using binlog-only path",
+					"schema", q.Schema, "table", q.Table, "pk_column", q.PKColumn, "pk_type", dataType)
+			}
+			return h.ResolveFlashbackRow(ctx, q)
+		}
+	}
+
+	// Stale-fallback warning (#466) discarded here — see the full-table path.
+	baselinePath, snapshotTime, _, err := reconstruct.FindBaseline(ctx, src, q.Schema, q.Table, q.AsOf)
+	if err != nil {
+		if errors.Is(err, reconstruct.ErrNoBaseline) {
+			h.logger.Debug("shim: _snapshot found no baseline at-or-before AsOf; using binlog-only path",
+				"schema", q.Schema, "table", q.Table)
+			return h.ResolveFlashbackRow(ctx, q)
+		}
+		// A real baseline-source failure (unreadable dir, S3 outage) is a
+		// server-side fault: raw error → the caller's "internal fault" branch.
+		return nil, err
+	}
+
+	// Refuse if a TRUNCATE/DROP/RENAME hit this table in the window: same blind
+	// spot as the full-table path — no row events to invalidate the baseline
+	// image, so the row would silently resolve as if it still existed (#764).
+	if err := reconstruct.CheckDestructiveDDL(ctx, h.indexDB, q.Schema, q.Table, snapshotTime, q.AsOf); err != nil {
+		return nil, err
+	}
+
+	// q.PKValue is passed RAW here — Parquet baseline rows store actual column
+	// values, not event.BuildPKValues-encoded pk_values, so this seam must NOT
+	// apply event.EscapePKValue (unlike the delta fetch below).
+	baselineRow, err := reconstruct.ReadBaselineRow(ctx, baselinePath, map[string]string{q.PKColumn: q.PKValue})
+	if err != nil {
+		return nil, err
+	}
+
+	opts := query.Options{
+		Schema:   q.Schema,
+		Table:    q.Table,
+		Since:    &snapshotTime,
+		SincePos: snapshotSincePos(ctx, baselinePath, h.logger, q.Schema, q.Table),
+		Until:    &q.AsOf,
+	}
+	// Delta fetch matches binlog_events.pk_values (BuildPKValues-encoded), so
+	// re-encode with EscapePKValue — the mirror of the raw ReadBaselineRow match
+	// above (#826). The empty-string PK routes through PKValuesIn for the same
+	// reason as ResolveFlashbackRow.
+	encoded := event.EscapePKValue(q.PKValue)
+	if q.PKValue != "" {
+		opts.PKValues = encoded
+	} else {
+		opts.PKValuesIn = []string{encoded}
+	}
+	engine := query.New(h.indexDB)
+	rows, _, err := reconstruct.FetchEventsAtomic(ctx, h.indexDB, engine, query.FetchMergedOptions{
+		Opts:           opts,
+		DBName:         h.cfg.IndexDBName,
+		NoArchive:      h.cfg.NoArchive,
+		AllowGaps:      h.cfg.AllowGaps,
+		ArchiveFetcher: h.archiveFetcher,
+	}, q.AsOf)
+	if err != nil {
+		return nil, classifyFetchError(ctx, q.Type, err, h.logger)
+	}
+
+	h.mapEventImages(q.Schema, q.Table, rows)
+	state, err := reconstruct.ApplyAt(baselineRow, rows, q.AsOf)
+	if err != nil {
+		return nil, err
+	}
+	if len(state) == 0 {
+		h.warnCorruptImageDrop(q.Schema, q.Table, rows)
+		return nil, nil
+	}
+	return state, nil
+}
+
+// ColumnsFor returns the wire column list for a single-row time-travel result,
+// independent of the wire protocol. An explicit projection (q.Columns) is used
+// verbatim; otherwise the table's newest-snapshot DDL order, with any image-only
+// keys (e.g. a column dropped since AsOf, #600) appended. A nil/empty image (row
+// absent at AsOf) yields the snapshot order alone, so a zero-row resultset still
+// carries the real column names.
+func (h *Handler) ColumnsFor(image map[string]any, q TimeTravelQuery) []string {
+	if q.Columns != nil {
+		return q.Columns
+	}
+	ddl := h.columnOrderFor(q.Schema, q.Table)
+	if len(image) == 0 {
+		return ddl
+	}
+	return orderColumns(image, ddl)
+}
+
+// PKColumnCheck reports whether q's WHERE column is a safe single-column PK
+// match, independent of the wire protocol (#296/#821). reject == true means the
+// query must be refused and msg carries the reason; each front-end wraps msg in
+// its own syntax-error code (MySQL ER_PARSE_ERROR 1064; PG SQLSTATE 42601). The
+// full-table shape (PKColumn == "") and a nil resolver are permissive here, as
+// they were in the original validatePKColumn.
+func (h *Handler) PKColumnCheck(q TimeTravelQuery) (msg string, reject bool) {
+	if q.PKColumn == "" {
+		return "", false
+	}
+	if h.resolverFn == nil {
+		return "", false
+	}
+	r, err := h.resolverCache.get(time.Now, resolverCacheTTL, h.resolverFn, h.logger)
+	if err != nil {
+		// Cannot confirm q.PKColumn is the table's PK. A column-qualified WHERE
+		// is guaranteed here (the full-table shape returned above), so fail loud
+		// rather than join the literal against pk_values and risk the wrong row
+		// (#821). ErrNoSnapshots (benign first-install state) still can't verify
+		// the PK, so it rejects too — only the no-WHERE full-table path is exempt.
+		reason := "schema_snapshots lookup failed"
+		if errors.Is(err, metadata.ErrNoSnapshots) {
+			reason = "no schema snapshots available yet"
+		}
+		h.logger.Warn("shim: cannot verify PK column; rejecting column-qualified WHERE",
+			"err", err, "reason", reason, "schema", q.Schema, "table", q.Table, "pk_column", q.PKColumn)
+		return fmt.Sprintf(
+			"cannot verify WHERE column %s is the primary key of %s.%s (%s); refusing to run so a non-PK WHERE cannot silently return the wrong row",
+			q.PKColumn, q.Schema, q.Table, reason,
+		), true
+	}
+	tm, err := r.Resolve(q.Schema, q.Table)
+	if err != nil {
+		h.logger.Warn("shim: table not in any snapshot; rejecting column-qualified WHERE",
+			"err", err, "schema", q.Schema, "table", q.Table, "pk_column", q.PKColumn)
+		return fmt.Sprintf(
+			"cannot verify WHERE column %s is the primary key of %s.%s (table not present in any indexed snapshot); refusing to run so a non-PK WHERE cannot silently return the wrong row",
+			q.PKColumn, q.Schema, q.Table,
+		), true
+	}
+	if len(tm.PKColumns) == 0 {
+		return fmt.Sprintf(
+			"%s.%s has no primary key declared in the indexed snapshot; cannot resolve %s by PK",
+			q.Schema, q.Table, q.Type,
+		), true
+	}
+	if len(tm.PKColumns) > 1 {
+		return fmt.Sprintf(
+			"%s.%s has a composite primary key (%s); WHERE %s = <value> shape supports only single-column PKs",
+			q.Schema, q.Table, strings.Join(tm.PKColumns, ", "), q.PKColumn,
+		), true
+	}
+	if q.PKColumn != tm.PKColumns[0] {
+		return fmt.Sprintf(
+			"WHERE column must be the primary key of %s.%s (expected %s, got %s)",
+			q.Schema, q.Table, tm.PKColumns[0], q.PKColumn,
+		), true
+	}
+	return "", false
+}

--- a/internal/shim/resolve.go
+++ b/internal/shim/resolve.go
@@ -105,8 +105,12 @@ func classifyFetchError(ctx context.Context, qType QueryType, err error, logger 
 func mysqlResolveError(rerr *ResolveError) error {
 	switch rerr.Class {
 	case ResolveGap:
+		// %s (not .Error()) so a would-be &ResolveError{Class: ResolveGap} with a
+		// nil Err formats safely instead of panicking — the PG renderer's Gap
+		// branch is already nil-robust this way. Byte-identical for the reachable
+		// case (classifyFetchError always sets a non-nil Err).
 		return mysql.NewError(mysql.ER_NO_PARTITION_FOR_GIVEN_VALUE,
-			fmt.Sprintf("resolve %s: %s", rerr.QType, rerr.Err.Error()))
+			fmt.Sprintf("resolve %s: %s", rerr.QType, rerr.Err))
 	case ResolveTimeout:
 		return mysql.NewError(mysql.ER_QUERY_INTERRUPTED, fmt.Sprintf(
 			"resolve %s: query exceeded the shim's --query-timeout and was aborted; narrow the AS OF range, filter by PK, or raise --query-timeout", rerr.QType))

--- a/internal/shim/snapshot.go
+++ b/internal/shim/snapshot.go
@@ -12,7 +12,6 @@ import (
 	"github.com/go-mysql-org/go-mysql/mysql"
 
 	"github.com/dbtrail/dbtrail/internal/baseline"
-	"github.com/dbtrail/dbtrail/internal/event"
 	"github.com/dbtrail/dbtrail/internal/metadata"
 	"github.com/dbtrail/dbtrail/internal/query"
 	"github.com/dbtrail/dbtrail/internal/reconstruct"
@@ -534,167 +533,20 @@ func baselinePKStringMatchable(dataType string) bool {
 // the never-touched-since-before-the-window row, which is exactly what
 // the baseline lookup recovers when it is available.
 func (h *Handler) runSnapshotPointInTime(q TimeTravelQuery) (*mysql.Result, error) {
-	src := h.baselineSource()
-	if src == "" {
-		h.logger.Debug("shim: _snapshot has no baseline source configured; using binlog-only path",
-			"schema", q.Schema, "table", q.Table)
-		return h.runPointInTime(q)
-	}
-
-	// Guard the PK type before attempting a baseline match. ReadBaselineRow
-	// matches `pkColumn = ?` against the *typed* Parquet column binding
-	// q.PKValue as a string and relying on DuckDB's implicit coercion — it
-	// does NOT canonicalize the way the full-table path does. Only types
-	// whose Parquet representation coerces cleanly from a string literal are
-	// safe here (see baselinePKStringMatchable); for the rest the comparison
-	// silently finds nothing and we would wrongly conclude the row never
-	// existed, so we fall back to the binlog-only path with a signal.
-	// validatePKColumn already confirmed q.PKColumn IS the table's
-	// single-column PK (or was permissive because the resolver was
-	// unavailable), so here we only need its type.
-	dataType, ok := h.pkDataType(q.Schema, q.Table, q.PKColumn)
-	if !ok {
-		h.logger.Debug("shim: _snapshot cannot resolve PK type; using binlog-only path",
-			"schema", q.Schema, "table", q.Table, "pk_column", q.PKColumn)
-		return h.runPointInTime(q)
-	}
-	// PostgreSQL baselines store every column as raw pgoutput text
-	// (baseline.Column.RawText, #593), so ReadBaselineRow's string-bound
-	// `pkColumn = ?` match is a string-identity join that can only recover the
-	// right row or find nothing — never a wrong row — the same reason the offline
-	// reconstruct path treats all PG PK columns as string-matchable (#593 slice
-	// D). The MySQL DATA_TYPE token is empty for a PG source
-	// (schema_snapshots.data_type is "" — PG records pg_type_oid, not the MySQL
-	// type), so without this flavor bypass every PG _snapshot would silently
-	// degrade to binlog-only and the baseline fold the docs promise would never
-	// run (#1006). The flavor read is short-circuited so the MySQL hot path (a
-	// matchable type) never pays for the extra query.
-	if !baselinePKStringMatchable(dataType) {
-		if flavor := query.SourceFlavor(h.indexDB); flavor != "postgres" {
-			if dataType == "" {
-				// The empty data_type is the PostgreSQL shape, so reaching here
-				// means a PG source whose flavor could not be confirmed (a
-				// transient stream_state read failure, or a legacy index missing
-				// the flavor column). Name that as the reason — blaming the
-				// (irrelevant, empty) PK type only misleads an operator debugging
-				// an empty _snapshot result.
-				h.logger.Warn("shim: _snapshot could not confirm a postgres source flavor (stream_state read empty or failed); "+
-					"baseline fold skipped, using binlog-only path — a row untouched within the binlog window will read as absent",
-					"schema", q.Schema, "table", q.Table, "pk_column", q.PKColumn, "flavor", flavor)
-			} else {
-				h.logger.Warn("shim: _snapshot PK type not safe for baseline lookup; using binlog-only path",
-					"schema", q.Schema, "table", q.Table, "pk_column", q.PKColumn, "pk_type", dataType)
-			}
-			return h.runPointInTime(q)
-		}
-	}
-
 	ctx, cancel := h.queryContext()
 	defer cancel()
 
-	// Stale-fallback warning (#466) discarded here — see the full-table path.
-	baselinePath, snapshotTime, _, err := reconstruct.FindBaseline(ctx, src, q.Schema, q.Table, q.AsOf)
+	// The baseline lookup, the #1007 PostgreSQL flavor bypass, the fetch, the
+	// ENUM/SET epoch map, and the ApplyAt fold now live in the wire-neutral
+	// ResolveSnapshotRow (#1008, resolve.go), shared with the pgwire front-end.
+	// A nil state means the row did not exist at AsOf; a fetch/coverage failure
+	// is a *ResolveError; a baseline/ApplyAt data-fault is raw. mysqlRenderErr
+	// keeps this byte-identical to the pre-#1008 inline path.
+	state, err := h.ResolveSnapshotRow(ctx, q)
 	if err != nil {
-		if errors.Is(err, reconstruct.ErrNoBaseline) {
-			h.logger.Debug("shim: _snapshot found no baseline at-or-before AsOf; using binlog-only path",
-				"schema", q.Schema, "table", q.Table,
-				"as_of", q.AsOf.UTC().Format(time.RFC3339))
-			return h.runPointInTime(q)
-		}
-		// A real baseline-source failure (unreadable dir, S3 outage) is a
-		// server-side fault: plain error → ER_UNKNOWN_ERROR (1105), the same
-		// user-vs-server split runPointInTime preserves for fetch failures.
-		return nil, err
+		return nil, mysqlRenderErr(err)
 	}
-
-	// Refuse if a TRUNCATE/DROP/RENAME hit this table in the window: same
-	// blind spot as the full-table path — no row events to invalidate the
-	// baseline image, so the row would silently resolve as if it still
-	// existed after being truncated away (#764).
-	if err := reconstruct.CheckDestructiveDDL(ctx, h.indexDB, q.Schema, q.Table, snapshotTime, q.AsOf); err != nil {
-		return nil, err
-	}
-
-	// q.PKValue is passed RAW (unescaped) here — Parquet baseline rows store
-	// actual column values, not event.BuildPKValues-encoded pk_values, so this
-	// seam must NOT apply event.EscapePKValue (unlike the delta fetch below).
-	baselineRow, err := reconstruct.ReadBaselineRow(ctx, baselinePath, map[string]string{q.PKColumn: q.PKValue})
-	if err != nil {
-		return nil, err
-	}
-
-	// Fetch every event for this PK from the snapshot instant up to AsOf.
-	// Unlike the binlog-only path (LimitPerPK=1), we want the full ordered
-	// sequence so ApplyAt folds them onto the baseline image in commit order
-	// — matching `bintrail reconstruct`'s single-row semantics. Since=
-	// snapshotTime drops pre-baseline events the baseline already supersedes,
-	// making this strictly more correct than the binlog-only path for a row
-	// whose only events predate the snapshot.
-	//
-	// PK filter: q.PKValue may legitimately be the empty string (e.g.
-	// `WHERE name = ''` against a NOT-NULL string PK — the shape
-	// runPointInTime documents). buildQuery DISABLES the PK filter entirely
-	// when Options.PKValues == "", which would fold every event for the whole
-	// table onto the single baseline row — a silent wrong answer. Route the
-	// empty case through PKValuesIn, which emits `pk_values IN (?)` and keeps
-	// the fetch scoped to the one row; keep the pk_hash fast path for the
-	// common non-empty case.
-	opts := query.Options{
-		Schema:   q.Schema,
-		Table:    q.Table,
-		Since:    &snapshotTime,
-		SincePos: snapshotSincePos(ctx, baselinePath, h.logger, q.Schema, q.Table),
-		Until:    &q.AsOf,
-	}
-	// q.PKValue is raw/unescaped (#826). Unlike ReadBaselineRow above (which
-	// matches actual Parquet column values and must keep the raw value), this
-	// delta fetch matches binlog_events.pk_values, which is
-	// event.BuildPKValues-encoded — re-encode with event.EscapePKValue so a
-	// backslash- or pipe-containing PK's post-baseline events are found
-	// instead of silently missing (which would serve a stale baseline image
-	// as the answer at AsOf).
-	encoded := event.EscapePKValue(q.PKValue)
-	if q.PKValue != "" {
-		opts.PKValues = encoded
-	} else {
-		opts.PKValuesIn = []string{encoded}
-	}
-	engine := query.New(h.indexDB)
-	// FetchEventsAtomic (not a plain query.FetchMerged) cuts the AsOf upper
-	// bound at the transaction boundary, not the row: a multi-statement
-	// transaction straddling AsOf is excluded whole rather than half-applied
-	// (#783).
-	rows, _, err := reconstruct.FetchEventsAtomic(ctx, h.indexDB, engine, query.FetchMergedOptions{
-		Opts:           opts,
-		DBName:         h.cfg.IndexDBName,
-		NoArchive:      h.cfg.NoArchive,
-		AllowGaps:      h.cfg.AllowGaps,
-		ArchiveFetcher: h.archiveFetcher,
-	}, q.AsOf)
-	if err != nil {
-		return nil, wrapFetchError(ctx, q.Type, err, h.logger)
-	}
-
-	// ENUM/SET ordinals → labels per event's snapshot epoch (#472/#475),
-	// BEFORE the fold: ApplyAt replaces the image wholesale per event, so
-	// pre-mapped events make the final state carry labels. Only deltas
-	// need this — the baseline image already carries labels (mydumper
-	// dumps strings) and string values pass through the mapper untouched.
-	h.mapEventImages(q.Schema, q.Table, rows)
-	state, err := reconstruct.ApplyAt(baselineRow, rows, q.AsOf)
-	if err != nil {
-		// A residual unchanged-TOAST marker (#592) — a capture-invariant
-		// violation, i.e. a server-side data fault: plain error →
-		// ER_UNKNOWN_ERROR (1105), same as a baseline-source failure above.
-		// Refusing beats serving the marker's JSON as the column value.
-		return nil, err
-	}
-	if len(state) == 0 {
-		// Either the row never existed at AsOf (no baseline image and no INSERT
-		// in the window) or its latest event was a DELETE. A non-DELETE tail that
-		// folds to empty is a corrupt/partial row image — surfaced as a Warn, not
-		// silently (mirrors runPointInTime).
-		h.warnCorruptImageDrop(q.Schema, q.Table, rows)
+	if state == nil {
 		return emptyResult(), nil
 	}
 


### PR DESCRIPTION
Closes #1008.

## What

Adds **`bintrail-pg flashback`**, a PostgreSQL wire-protocol front-end for the shim time-travel engine, so a PostgreSQL operator runs single-row `AS OF` straight from `psql` (or any PG driver) — served from the same out-of-band index + baseline the MySQL shim already uses:

```
psql "host=127.0.0.1 port=5433 user=<tenant> dbname=public"
SELECT * FROM _flashback.orders AS OF '5 minutes ago' WHERE id = 42;
SELECT * FROM _snapshot.orders  AS OF '2026-07-01 09:00:00' WHERE id = 42;
SELECT * FROM orders AS OF '5 minutes ago' WHERE id = 42;   -- bare form
```

## How (Occam: it's a wire-layer change, not an engine change)

The time-travel engine was already source-agnostic; MySQL was only skin-deep at the **render edge**. This PR extracts that seam and adds a second renderer:

- **`internal/shim/resolve.go` (new)** — a wire-neutral seam. `ResolveFlashbackRow` / `ResolveSnapshotRow` return a `map[string]any` image plus a **classified `*ResolveError`** (gap / timeout / cancel / fault). `ColumnsFor` and `PKColumnCheck` are the neutral column-order and PK-validation helpers.
- **MySQL path stays byte-identical**: `wrapFetchError` is re-expressed as `mysqlResolveError(classifyFetchError(…))`, `runPointInTime`/`runSnapshotPointInTime` call the resolve methods then render, and `validatePKColumn` wraps `PKColumnCheck`. Error **codes and messages are unchanged** (the shim + cli integration suites pass).
- The parser, reconstruct engine, ENUM/SET epoch mapping, transaction-atomic cut (#988), residual-TOAST refusal (#592), raw-vs-encoded PK routing (#826), and the #1007 PG `_snapshot` baseline fold are all **reused verbatim** — the PG renderer inherits them for free.
- **`internal/pgshim` (new)** — the pgwire server: a `pgproto3` accept loop with **`SSLRequest`→`'N'` negotiation**, cleartext per-tenant auth, the **simple query protocol**, and a text/OID-25 renderer (NULL for a missing key, cell-level TOAST refusal). Linked **only by `cmd/bintrail-pg`**, so `pgproto3` (`github.com/jackc/pgx/v5/pgproto3`) stays out of the core binary — the `cliapp` pgfree guard still passes.

`pgproto3` was already in the module graph as a subpackage of the required `pgx/v5` — **no new dependency**. (The issue's prose said `github.com/jackc/pgproto3`; the actual import is `github.com/jackc/pgx/v5/pgproto3`.)

## Scope (matches PG's current time-travel maturity, #593)

- **Single-row `AS OF` only** (`WHERE <pk> = <value>`).
- **Full-table `AS OF` is refused** with actionable remediation — the PG baseline still omits `CREATE TABLE` (slice E). **Never a silent partial.**
- `_diff` refused (pointer to `bintrail-pg reconstruct --history`).
- Extended (prepared-statement) protocol declined with a resync; use simple protocol (psql native; pgx sets `QueryExecModeSimpleProtocol`).

## Addressing

Connect with **`dbname` = your PostgreSQL schema** (e.g. `public`); select flashback-vs-snapshot with the `_flashback.` / `_snapshot.` prefix in the query, exactly like the MySQL shim. This differs from the issue's tentative `dbname=_flashback` note — the engine derives the schema from the connection, so that form would misparse; the query-prefix model needs no parser change and reaches every virtual schema from one connection.

## Auth

Cleartext password per tenant from `--shim-config` (`shim.yaml`), constant-time compare; loopback-default listener. For a non-loopback bind, front a TLS terminator — the same posture as the MySQL shim behind ProxySQL. (A conscious choice over the issue's "TLS-required" option, for shim parity.)

## Tests

- **Protocol conformance** (`internal/pgshim`, unit) — a **real pgx client** over TCP with default `sslmode=prefer`, so the `SSLRequest`→`'N'` negotiation and reconnect run: auth success/failure, full-table & malformed & non-time-travel rejections, a direct raw-TCP `SSLRequest`→`'N'` assertion, and that **every cycle ends with `ReadyForQuery`**.
- **Seeded-index round-trip** (integration, MySQL matrix) — a real pgx client gets the correct pre/post-update single-row `_flashback`/`_snapshot` state and a full-table refusal.
- **PostgreSQL-source E2E** (integration, **PG 14–17 matrix**) — streams a live PG row via `pgstreamrun.One`, then queries it over the pgwire front-end and asserts numeric / bytea / timestamptz survive. Added to `ci.yml` with a false-green tripwire.

Reviewed via a 4-lens adversarial pass (regression / protocol / security / coverage) with per-finding verification: the only surviving item was an over-claiming auth doc comment, now corrected. `psql` isn't installed on the dev box, but the pgx conformance tests drive the identical libpq-compatible negotiation.

## Docs

`docs/postgres.md` → "Interactive `AS OF` from `psql`", plus a pointer from `docs/time-travel-sql.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
