### PR TITLE
baseline: decode --hex-blob binary columns; map GEOMETRY to bytes (#503)

### DIFF
--- a/internal/baseline/hexblob503_test.go
+++ b/internal/baseline/hexblob503_test.go
@@ -1,0 +1,79 @@
+package baseline
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Item 1 (#503): a --hex-blob binary column (0x<hex>) decodes to the real bytes,
+// a non-binary column keeps the 0x… literal, and GEOMETRY routes through the
+// binary path (item 2 decode). 0x612C6229 = 'a',',','b',')'.
+func TestConvertValue_HexBlobDecodesForBinaryFamily(t *testing.T) {
+	want := []byte{0x61, 0x2c, 0x62, 0x29}
+
+	binaryTypes := []string{
+		"varbinary", "binary", "blob", "tinyblob", "mediumblob", "longblob", "bit",
+		"geometry", "point", "linestring", "polygon", "multipolygon",
+	}
+	for _, typ := range binaryTypes {
+		v, err := convertValue(Column{Name: "c", MySQLType: typ}, "0x612C6229")
+		if err != nil {
+			t.Fatalf("%s: convertValue: %v", typ, err)
+		}
+		if got := v.ByteArray(); !bytes.Equal(got, want) {
+			t.Errorf("%s: stored %q (%x), want real bytes %q (%x) — hex-blob not decoded (#503 item 1)",
+				typ, got, got, want, want)
+		}
+	}
+
+	// A non-binary column keeps 0x… verbatim (there 0x is a legitimate literal,
+	// never a hex-blob), so it must NOT be decoded.
+	v, err := convertValue(Column{Name: "c", MySQLType: "varchar"}, "0x612C6229")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(v.ByteArray()); got != "0x612C6229" {
+		t.Errorf("varchar: 0x literal was decoded (%q); non-binary columns must keep it verbatim", got)
+	}
+}
+
+func TestDecodeBinaryLiteral_Fallbacks(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []byte
+	}{
+		{"0x612C6229", []byte{0x61, 0x2c, 0x62, 0x29}}, // even hex → decode
+		{"0x", []byte("0x")},                           // no digits → verbatim
+		{"0xZZ", []byte("0xZZ")},                        // invalid hex → verbatim
+		{"0x612", []byte("0x612")},                      // odd length → verbatim (DecodeString errors)
+		{"plain", []byte("plain")},                      // not hex → verbatim
+		{"", []byte("")},                                // empty → verbatim
+	}
+	for _, c := range cases {
+		if got := decodeBinaryLiteral(c.in); !bytes.Equal(got, c.want) {
+			t.Errorf("decodeBinaryLiteral(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// Item 1 (#503): the reader strips the _binary introducer from `_binary 0x…` and
+// yields the 0x… literal (convertValue then decodes it). Pre-fix the whole
+// "_binary 0x…" token was captured as the value.
+func TestReadSQLFile_BinaryIntroducerHex(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "d.sql")
+	if err := os.WriteFile(p, []byte("INSERT INTO `t` (`id`,`vb`) VALUES(1,_binary 0x612C6229);\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var got []string
+	if err := ReadSQLFile(p, func(values []string, nulls []bool) error {
+		got = append([]string(nil), values...)
+		return nil
+	}); err != nil {
+		t.Fatalf("ReadSQLFile: %v", err)
+	}
+	if len(got) != 2 || got[1] != "0x612C6229" {
+		t.Errorf("_binary 0x… → vb=%q, want %q", got, "0x612C6229")
+	}
+}

--- a/internal/baseline/hexblob503_test.go
+++ b/internal/baseline/hexblob503_test.go
@@ -77,3 +77,30 @@ func TestReadSQLFile_BinaryIntroducerHex(t *testing.T) {
 		t.Errorf("_binary 0x… → vb=%q, want %q", got, "0x612C6229")
 	}
 }
+
+// Item 2 (#503): GEOMETRY and its subtypes must map to a binary Parquet leaf
+// (like blob), NOT the UTF-8 String default — otherwise non-UTF-8 WKB bytes would
+// be written under a STRING annotation. Guards the schema-node half of the fix,
+// which the convertValue test cannot see (it builds Columns with no ParquetType).
+func TestGeometryMapsToBinaryNode(t *testing.T) {
+	blob := MysqlToParquetNode2("blob", false)
+	str := MysqlToParquetNode2("varchar", false)
+	// Sanity: the assertion below must be able to tell a binary leaf from STRING
+	// in this parquet-go version, else it would false-pass.
+	if (blob.Type().LogicalType() == nil) == (str.Type().LogicalType() == nil) {
+		t.Fatal("cannot distinguish binary leaf from STRING via LogicalType — revisit the assertion")
+	}
+	for _, typ := range []string{
+		"geometry", "point", "linestring", "polygon",
+		"multipoint", "multilinestring", "multipolygon",
+		"geometrycollection", "geomcollection",
+	} {
+		node := MysqlToParquetNode2(typ, false)
+		if node.Type().Kind() != blob.Type().Kind() {
+			t.Errorf("%s: node kind %v, want %v (binary leaf like blob)", typ, node.Type().Kind(), blob.Type().Kind())
+		}
+		if (node.Type().LogicalType() == nil) != (blob.Type().LogicalType() == nil) {
+			t.Errorf("%s: logical-type annotation differs from blob — likely mapped to STRING, storing WKB as UTF-8", typ)
+		}
+	}
+}

--- a/internal/baseline/reader_sql.go
+++ b/internal/baseline/reader_sql.go
@@ -259,12 +259,12 @@ func parseSQLValue(s string, pos int) (string, bool, int, error) {
 		return parseDefaultValue(s, pos)
 
 	case s[pos] == '0' && pos+1 < len(s) && (s[pos+1] == 'x' || s[pos+1] == 'X'):
-		// Hex literal: 0x...
-		end := pos + 2
-		for end < len(s) && isHexDigit(s[end]) {
-			end++
+		// Hex literal: 0x... Returned as the literal token; convertValue does the
+		// type-aware decode to bytes for binary-family columns (#503 item 1).
+		if end, ok := scanHexLiteral(s, pos); ok {
+			return s[pos:end], false, end, nil
 		}
-		return s[pos:end], false, end, nil
+		return parseDefaultValue(s, pos)
 
 	default:
 		return parseDefaultValue(s, pos)
@@ -321,8 +321,33 @@ func parseIntroducedString(s string, pos int) (val string, end int, ok bool, err
 		v, e, perr := parseSQLDoubleString(s, i+1)
 		return v, e, true, perr
 	default:
+		// _binary 0x<hex> — an introducer before a --hex-blob literal. Return the
+		// 0x… token undecoded so convertValue does the type-aware hex decode
+		// (#503 item 1). Without this the whole "_binary 0x…" string was captured
+		// as the column value.
+		if end, ok := scanHexLiteral(s, i); ok {
+			return s[i:end], end, true, nil
+		}
 		return "", pos, false, nil
 	}
+}
+
+// scanHexLiteral reports whether s[pos:] begins with a 0x<hex-digits> literal and
+// returns the offset just past it. A bare "0x" with no following hex digit is not
+// a literal (ok=false). mydumper/mysqldump --hex-blob renders binary columns as
+// exactly this form.
+func scanHexLiteral(s string, pos int) (int, bool) {
+	if pos+2 > len(s) || s[pos] != '0' || (s[pos+1] != 'x' && s[pos+1] != 'X') {
+		return pos, false
+	}
+	end := pos + 2
+	for end < len(s) && isHexDigit(s[end]) {
+		end++
+	}
+	if end == pos+2 {
+		return pos, false
+	}
+	return end, true
 }
 
 // parseConvertExpr handles mydumper's JSON encoding CONVERT("<json>" USING

--- a/internal/baseline/schema.go
+++ b/internal/baseline/schema.go
@@ -179,7 +179,13 @@ func mysqlToParquetNode(typeToken string, unsigned bool) parquet.Node {
 		"enum", "set", "json":
 		return parquet.Optional(parquet.String())
 	case "binary", "varbinary", "tinyblob", "blob", "mediumblob", "longblob",
-		"bit":
+		"bit",
+		// GEOMETRY and its subtypes carry WKB bytes: store as a binary leaf, not
+		// the STRING default (which would place non-UTF-8 bytes in a UTF-8 column).
+		// #503 item 2. The exact mydumper spatial encoding is unverified end-to-end
+		// here; the binary type mapping is the safe floor.
+		"geometry", "point", "linestring", "polygon",
+		"multipoint", "multilinestring", "multipolygon", "geometrycollection":
 		return parquet.Optional(parquet.Leaf(parquet.ByteArrayType))
 	default:
 		// Unknown type — treat as string to avoid data loss.

--- a/internal/baseline/schema.go
+++ b/internal/baseline/schema.go
@@ -185,7 +185,8 @@ func mysqlToParquetNode(typeToken string, unsigned bool) parquet.Node {
 		// #503 item 2. The exact mydumper spatial encoding is unverified end-to-end
 		// here; the binary type mapping is the safe floor.
 		"geometry", "point", "linestring", "polygon",
-		"multipoint", "multilinestring", "multipolygon", "geometrycollection":
+		"multipoint", "multilinestring", "multipolygon",
+		"geometrycollection", "geomcollection": // MySQL 8.0 canonicalizes the former to the latter
 		return parquet.Optional(parquet.Leaf(parquet.ByteArrayType))
 	default:
 		// Unknown type — treat as string to avoid data loss.

--- a/internal/baseline/writer.go
+++ b/internal/baseline/writer.go
@@ -110,12 +110,12 @@ func NewWriter(path string, cols []Column, cfg WriterConfig) (*Writer, error) {
 // WriteRow converts a row of string values (in MySQL column order) into a
 // Parquet row and writes it to the file.
 func (w *Writer) WriteRow(values []string, nulls []bool) error {
-	// #503 item 4 (value/column-count desync) is enforced UPSTREAM of every
-	// WriteRow caller: the mydumper path fails loud on a strict len(values) !=
-	// len(cols) at baseline.go (issue #767), and the other callers (archive,
-	// buffer, byos, pgbaseline) build fixed-arity value slices by construction.
-	// WriteRow keeps its defensive NULL-pad for a short row (a bounds check, not
-	// a supported layout) and does not re-check here.
+	// #503 item 4 (value/column-count desync): every WriteRow caller must supply
+	// exactly len(cols) values. That invariant is enforced UPSTREAM — the mydumper
+	// path fails loud on a strict len(values) != len(cols) at baseline.go (issue
+	// #767, test-pinned), and the remaining callers build fixed-arity value slices
+	// by construction — so WriteRow does not re-check here; it keeps only its
+	// defensive NULL-pad for a short row (a bounds check, not a supported layout).
 	row := make(parquet.Row, len(w.parquetCols))
 	for parquetIdx, col := range w.parquetCols {
 		mysqlIdx := w.mysqlOrder[parquetIdx]
@@ -306,7 +306,8 @@ func convertValue(col Column, raw string) (parquet.Value, error) {
 		// for spatial columns is not verified end-to-end here (mydumper unavailable
 		// in the unit env); the type mapping is the safe floor.
 		"geometry", "point", "linestring", "polygon",
-		"multipoint", "multilinestring", "multipolygon", "geometrycollection":
+		"multipoint", "multilinestring", "multipolygon",
+		"geometrycollection", "geomcollection": // MySQL 8.0 canonicalizes the former to the latter
 		return parquet.ByteArrayValue(decodeBinaryLiteral(raw)), nil
 
 	default:

--- a/internal/baseline/writer.go
+++ b/internal/baseline/writer.go
@@ -1,6 +1,7 @@
 package baseline
 
 import (
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -109,6 +110,12 @@ func NewWriter(path string, cols []Column, cfg WriterConfig) (*Writer, error) {
 // WriteRow converts a row of string values (in MySQL column order) into a
 // Parquet row and writes it to the file.
 func (w *Writer) WriteRow(values []string, nulls []bool) error {
+	// #503 item 4 (value/column-count desync) is enforced UPSTREAM of every
+	// WriteRow caller: the mydumper path fails loud on a strict len(values) !=
+	// len(cols) at baseline.go (issue #767), and the other callers (archive,
+	// buffer, byos, pgbaseline) build fixed-arity value slices by construction.
+	// WriteRow keeps its defensive NULL-pad for a short row (a bounds check, not
+	// a supported layout) and does not re-check here.
 	row := make(parquet.Row, len(w.parquetCols))
 	for parquetIdx, col := range w.parquetCols {
 		mysqlIdx := w.mysqlOrder[parquetIdx]
@@ -292,13 +299,53 @@ func convertValue(col Column, raw string) (parquet.Value, error) {
 		}
 		return parquet.Int32Value(int32(n)), nil
 
-	case "binary", "varbinary", "tinyblob", "blob", "mediumblob", "longblob", "bit":
-		return parquet.ByteArrayValue([]byte(raw)), nil
+	case "binary", "varbinary", "tinyblob", "blob", "mediumblob", "longblob", "bit",
+		// GEOMETRY and its subtypes carry WKB (binary) bytes; route them through
+		// the binary path so a --hex-blob dump decodes and the value is stored as
+		// bytes, not UTF-8 text (#503 item 2). NOTE: the exact form mydumper emits
+		// for spatial columns is not verified end-to-end here (mydumper unavailable
+		// in the unit env); the type mapping is the safe floor.
+		"geometry", "point", "linestring", "polygon",
+		"multipoint", "multilinestring", "multipolygon", "geometrycollection":
+		return parquet.ByteArrayValue(decodeBinaryLiteral(raw)), nil
 
 	default:
 		// String types and fallback.
 		return parquet.ByteArrayValue([]byte(raw)), nil
 	}
+}
+
+// decodeBinaryLiteral converts a mydumper/mysqldump binary-column literal into the
+// raw column bytes. A --hex-blob dump renders binary columns as 0x<hex>; this
+// decodes them to the real bytes. Any other input — the escaped _binary "…" form,
+// which the reader has already unescaped to raw bytes — is returned verbatim.
+//
+// Applied ONLY to binary-family columns (its callers). A --hex-blob dump emits
+// binary values exclusively as 0x<hex>, and a non-hex-blob dump emits them as
+// _binary "…" (never a bare 0x…), so a 0x<hex> reaching a binary column is
+// unambiguously a hex-blob value.
+//
+// Two accepted residuals, both requiring provenance the caller has already
+// discarded (the reader hands convertValue a plain string; baseline.go hashes
+// that same string for the #633 source-fidelity digest, so the value text must
+// stay verbatim and provenance can't be threaded through it):
+//   - A binary value whose actual bytes are the ASCII text "0x<even-hex>", dumped
+//     WITHOUT --hex-blob (so it arrived via _binary "…"), is indistinguishable
+//     from a hex-blob literal and would be decoded.
+//   - An odd-length / non-hex 0x… token (hex.DecodeString errors) falls back to
+//     verbatim rather than failing loud. From a bare 0x… literal that shape means
+//     a malformed/non-mydumper dump (a real --hex-blob value is always valid even
+//     hex) and could justify a loud abort — but the same raw string can also be a
+//     legit _binary "0x1" value, so a naive fail-loud here would false-abort a
+//     real baseline. Both are strictly better than the pre-#503 behavior (which
+//     never decoded at all); a provenance-flag fix is deferred.
+func decodeBinaryLiteral(raw string) []byte {
+	if len(raw) > 2 && raw[0] == '0' && (raw[1] == 'x' || raw[1] == 'X') {
+		if b, err := hex.DecodeString(raw[2:]); err == nil {
+			return b
+		}
+	}
+	return []byte(raw)
 }
 
 // isZeroDate reports whether raw is MySQL's all-zero date pseudo-NULL sentinel:


### PR DESCRIPTION
closes #503

## Summary
Hardens the baseline SQL→Parquet path against the open items of #503. Verified item-by-item with a live reproduction before coding, then adversarially reviewed (code-reviewer + silent-failure-hunter).

**Item 1 — hex-blob binary → ASCII (the P1, real silent corruption).** A mydumper/mysqldump `--hex-blob` dump renders binary columns as `0x<hex>`. The type-blind reader yielded the literal `"0x612C6229"`, and `convertValue` stored those **10 ASCII bytes** into a binary column instead of the **4 real bytes** `a,b)`. A baseline silently holding the wrong value → recovery/time-travel from it returns garbage. Reproduced live against `main`:
```
binary column stored 10 bytes: "0x612C6229"   ← ASCII, wrong
a faithful baseline would store 4 bytes: "a,b)"
```
Fix: `convertValue` decodes `0x<hex>` → bytes **for binary-family columns only** (a `--hex-blob` dump emits binary values exclusively as `0x<hex>`; a non-hex-blob dump emits them as `_binary "…"`, never bare `0x…`). The reader also strips the introducer from the `_binary 0x<hex>` form. Non-binary columns keep `0x…` verbatim (there it is a legitimate literal, e.g. `0x10` = 16 for an int).
- *Documented residual:* an odd-length/invalid `0x…`, or an ASCII `"0x…"` value dumped **without** `--hex-blob`, falls back verbatim rather than failing loud — distinguishing these needs reader provenance the `#633` digest tap can't carry. Both are strictly better than the prior never-decode behavior.

**Item 2 — GEOMETRY.** Spatial types now map to a **binary** Parquet leaf (not the STRING default that would place non-UTF-8 WKB bytes in a UTF-8 column) and route through the binary decode path.
- *Caveat:* mydumper is unavailable in the unit env, so the exact spatial dump encoding is not verified end-to-end; the binary type mapping is the safe floor.

**Items 3 & 4 — already resolved upstream, no new code.** Item 3 (silent NULL on convert error) was already fixed (`writer.go` fails loud). Item 4 (value/column-count desync) is already enforced by the strict `len(values) != len(cols)` guard at `baseline.go` (#767) on the dump path, and the other `WriteRow` callers build fixed-arity slices by construction. The review confirmed a `WriteRow`-level guard would be redundant, so none was added.

## Test plan
- [x] Live reproduction of item 1 against `main` (hex-blob binary → ASCII) — confirmed present, now decodes correctly
- [x] New regression tests: `TestConvertValue_HexBlobDecodesForBinaryFamily`, `TestDecodeBinaryLiteral_Fallbacks`, `TestReadSQLFile_BinaryIntroducerHex`
- [x] Existing binary round-trip + `TestReadSQLRowHexLiteral` still green (reader stays type-blind)
- [x] `go build ./...` + unit suite `go test ./... -count=1` green
- [x] Adversarial review (code-reviewer + silent-failure-hunter): correctness superset, no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)
