### PR TITLE
stream: extend --ssl-mode to index/source connections; fix preferred downgrade (#946/#947)

### DIFF
--- a/cliapp/stream.go
+++ b/cliapp/stream.go
@@ -87,7 +87,7 @@ func init() {
 	streamCmd.Flags().IntVar(&strmCheckpoint, "checkpoint", 10, "Checkpoint interval in seconds")
 	streamCmd.Flags().StringVar(&strmMetricsAddr, "metrics-addr", "", "Address to expose Prometheus metrics (e.g. :9090); empty = disabled")
 	streamCmd.Flags().IntVar(&strmMetricsScrapeInterval, "metrics-scrape-interval", 60, "How often (seconds) to refresh the bintrail_index_* gauges from a status snapshot")
-	streamCmd.Flags().StringVar(&strmSSLMode, "ssl-mode", "preferred", "TLS mode: disabled, preferred, required, verify-ca, verify-identity")
+	streamCmd.Flags().StringVar(&strmSSLMode, "ssl-mode", "preferred", "TLS mode for the source AND index connections: disabled, preferred, required, verify-ca, verify-identity")
 	streamCmd.Flags().StringVar(&strmSSLCA, "ssl-ca", "", "Path to CA certificate file for TLS verification (omit to use system CAs)")
 	streamCmd.Flags().StringVar(&strmSSLCert, "ssl-cert", "", "Path to client certificate file for mutual TLS")
 	streamCmd.Flags().StringVar(&strmSSLKey, "ssl-key", "", "Path to client private key file for mutual TLS")

--- a/cmd/bintrail-console/watch.go
+++ b/cmd/bintrail-console/watch.go
@@ -175,7 +175,7 @@ func init() {
 	watchCmd.Flags().StringVar(&upTables, "tables", "", "Comma-separated tables to index (default: all)")
 	watchCmd.Flags().IntVar(&upBatchSize, "batch-size", 1000, "Events per batch INSERT")
 	watchCmd.Flags().IntVar(&upCheckpoint, "checkpoint", 10, "Checkpoint interval in seconds")
-	watchCmd.Flags().StringVar(&upSSLMode, "ssl-mode", "preferred", "TLS mode for the source connection: disabled, preferred, required, verify-ca, verify-identity")
+	watchCmd.Flags().StringVar(&upSSLMode, "ssl-mode", "preferred", "TLS mode for the source AND index connections: disabled, preferred, required, verify-ca, verify-identity")
 	watchCmd.Flags().StringVar(&upSSLCA, "ssl-ca", "", "Path to CA certificate file for source TLS verification (omit to use system CAs)")
 	watchCmd.Flags().StringVar(&upSSLCert, "ssl-cert", "", "Path to client certificate file for mutual TLS to the source")
 	watchCmd.Flags().StringVar(&upSSLKey, "ssl-key", "", "Path to client private key file for mutual TLS to the source")

--- a/docs/console.md
+++ b/docs/console.md
@@ -69,6 +69,16 @@ accepts `--ssl-mode` / `--ssl-ca` / `--ssl-cert` / `--ssl-key` (env
 The default stays `--ssl-mode preferred` (opportunistic, no certificate
 verification).
 
+> **Scope of `--ssl-mode` under `watch`.** The flag encrypts `watch`'s embedded
+> **stream** connections — the source replication and the index *write*. It does
+> **not** currently cover the console's own index *reads* (the connections the
+> multi-server manager opens to serve the web UI) or the embedded flashback port
+> (`--flashback-listen`). To encrypt those, add a `tls=` parameter to the
+> connection's DSN (`...?tls=true`, or `?tls=skip-verify` for self-signed dev
+> certs) — the same knob the offline read commands use. If your index MySQL is
+> reached over loopback or a private network this is moot; over an untrusted
+> network, set `tls=` on the index DSN in addition to `--ssl-mode`.
+
 Open that URL in a browser. A left **sidebar** groups the views (Time-travel
 appears only when a baseline is configured), with a **server switcher** at the
 top (see [Managing servers](#managing-servers)) and a **⌘K command palette**

--- a/docs/console.md
+++ b/docs/console.md
@@ -72,12 +72,15 @@ verification).
 > **Scope of `--ssl-mode` under `watch`.** The flag encrypts `watch`'s embedded
 > **stream** connections — the source replication and the index *write*. It does
 > **not** currently cover the console's own index *reads* (the connections the
-> multi-server manager opens to serve the web UI) or the embedded flashback port
-> (`--flashback-listen`). To encrypt those, add a `tls=` parameter to the
-> connection's DSN (`...?tls=true`, or `?tls=skip-verify` for self-signed dev
-> certs) — the same knob the offline read commands use. If your index MySQL is
-> reached over loopback or a private network this is moot; over an untrusted
-> network, set `tls=` on the index DSN in addition to `--ssl-mode`.
+> multi-server manager opens to serve the web UI) or the index reads behind the
+> embedded flashback port (`--flashback-listen`). Encrypt those index
+> connections by adding a `tls=` parameter to their DSN (`...?tls=true`, or
+> `?tls=skip-verify` for self-signed dev certs) — the same knob the offline read
+> commands use. (The flashback port's *inbound* MySQL-protocol listener — the
+> client→port leg — has no TLS option in this release; `tls=` only covers its
+> backend index reads.) If your index MySQL is reached over loopback or a
+> private network this is moot; over an untrusted network, set `tls=` on the
+> index DSN in addition to `--ssl-mode`.
 
 Open that URL in a browser. A left **sidebar** groups the views (Time-travel
 appears only when a baseline is configured), with a **server switcher** at the

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -455,7 +455,7 @@ INDEX_DSN="bintrail:password@tcp(index-mysql:3306)/bintrail_index?tls=true"
 SOURCE_DSN="bintrail:password@tcp(source-mysql:3306)/?tls=true"
 ```
 
-For richer **source** TLS on `bintrail stream` — CA verification or mutual TLS — use the dedicated `--ssl-mode`/`--ssl-ca`/`--ssl-cert`/`--ssl-key` flags instead of the DSN parameter; see [streaming.md → TLS/SSL for managed MySQL](streaming.md#tlsssl-for-managed-mysql-rds-aurora-cloud-sql).
+For richer TLS on the streaming daemon (`bintrail stream`/`up`/`bintrail-console watch`) — CA verification or mutual TLS on **both** the source and index connections — use the dedicated `--ssl-mode`/`--ssl-ca`/`--ssl-cert`/`--ssl-key` flags; `--ssl-mode required` (or stricter) makes TLS mandatory on both. The DSN `?tls=` parameter above still works, takes precedence when set, and is the only TLS knob for the offline read commands (`query`/`recover`/`reconstruct`/`verify`/`shim`), which have no `--ssl-mode`. See [streaming.md → TLS/SSL for managed MySQL](streaming.md#tlsssl-for-managed-mysql-rds-aurora-cloud-sql).
 
 ### Metrics endpoint security
 

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -237,7 +237,7 @@ RDS caps `binlog retention hours` at **720 (30 days)**. Values above the ceiling
 
 ### TLS/SSL for managed MySQL (RDS, Aurora, Cloud SQL)
 
-Managed MySQL services often require TLS. Use `--ssl-mode` to control the connection security:
+Managed MySQL services often require TLS. `--ssl-mode` controls the security of **both** connections the streaming daemon opens — the source replication stream **and** the index write connection, which carries full before/after row images (PII) plus the index credentials:
 
 | Mode | Behavior |
 |------|----------|
@@ -246,6 +246,8 @@ Managed MySQL services often require TLS. Use `--ssl-mode` to control the connec
 | `required` | TLS mandatory (no certificate verification), fail if unavailable |
 | `verify-ca` | Validate server certificate against CA (no hostname check) |
 | `verify-identity` | Full verification (certificate + hostname) |
+
+> **Scope.** `--ssl-mode` covers the streaming daemon (`stream`, `up`, `bintrail-console watch`) only. `required`/`verify-*` make TLS mandatory on both connections, so a server with TLS disabled fails fast with an actionable error rather than silently sending data in cleartext. The offline read commands (`query`, `recover`, `reconstruct`, `verify`, `shim`) have no `--ssl-mode` flag — encrypt their index connection with a DSN parameter instead (`...?tls=true`, or `?tls=skip-verify` for self-signed dev certs). An explicit `tls=` in a DSN always takes precedence over `--ssl-mode`.
 
 **Amazon RDS example** (download the [RDS CA bundle](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html) first):
 

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -247,7 +247,7 @@ Managed MySQL services often require TLS. `--ssl-mode` controls the security of 
 | `verify-ca` | Validate server certificate against CA (no hostname check) |
 | `verify-identity` | Full verification (certificate + hostname) |
 
-> **Scope.** `--ssl-mode` covers the streaming daemon (`stream`, `up`, `bintrail-console watch`) only. `required`/`verify-*` make TLS mandatory on both connections, so a server with TLS disabled fails fast with an actionable error rather than silently sending data in cleartext. The offline read commands (`query`, `recover`, `reconstruct`, `verify`, `shim`) have no `--ssl-mode` flag — encrypt their index connection with a DSN parameter instead (`...?tls=true`, or `?tls=skip-verify` for self-signed dev certs). An explicit `tls=` in a DSN always takes precedence over `--ssl-mode`.
+> **Scope.** `--ssl-mode` covers the streaming daemon (`stream`, `up`, `bintrail-console watch`) only. `required`/`verify-*` make TLS mandatory on both connections, so a server with TLS disabled fails fast with an actionable error rather than silently sending data in cleartext. The offline read commands (`query`, `recover`, `reconstruct`, `verify`, `shim`) have no `--ssl-mode` flag — encrypt their index connection with a DSN parameter instead (`...?tls=true`, or `?tls=skip-verify` for self-signed dev certs). An explicit `tls=` in a DSN takes precedence over `--ssl-mode` for the connections that honor it (the index write + source helper); the source **binlog replication stream** always uses `--ssl-mode` and ignores a `tls=` set on the source DSN.
 
 **Amazon RDS example** (download the [RDS CA bundle](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html) first):
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"crypto/tls"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -126,9 +127,21 @@ var driverDefaultMaxAllowedPacket = mysql.NewConfig().MaxAllowedPacket
 // into time.Time), Loc=UTC, a default connect timeout, and aligning the
 // client's max_allowed_packet with the server's.
 func buildDSN(dsn string) (string, error) {
+	cfg, err := normalizeDSN(dsn)
+	if err != nil {
+		return "", err
+	}
+	return cfg.FormatDSN(), nil
+}
+
+// normalizeDSN parses a user DSN and applies the same invariants as buildDSN,
+// returning the *mysql.Config so callers that need to attach a programmatic
+// *tls.Config (ConnectWithTLS) share the exact invariants without a DSN-string
+// round-trip.
+func normalizeDSN(dsn string) (*mysql.Config, error) {
 	cfg, err := mysql.ParseDSN(dsn)
 	if err != nil {
-		return "", fmt.Errorf("invalid DSN: %w", err)
+		return nil, fmt.Errorf("invalid DSN: %w", err)
 	}
 	cfg.ParseTime = true
 	cfg.Loc = time.UTC
@@ -158,7 +171,81 @@ func buildDSN(dsn string) (string, error) {
 	if cfg.MaxAllowedPacket == driverDefaultMaxAllowedPacket {
 		cfg.MaxAllowedPacket = 0
 	}
-	return cfg.FormatDSN(), nil
+	return cfg, nil
+}
+
+// ConnectWithTLS opens and verifies a MySQL connection like Connect, but also
+// attaches a programmatic TLS configuration to the connection. tlsCfg == nil
+// means no TLS (plaintext), identical to Connect.
+//
+// The connection FAILS (it never silently falls back to plaintext) if the server
+// cannot satisfy the requested TLS — the driver's own AllowFallbackToPlaintext is
+// deliberately NOT used. A caller that wants an opportunistic fallback must
+// detect the failure and retry with a nil tlsCfg itself, so any cleartext
+// downgrade is an explicit, loggable decision (#946/#947).
+//
+// An explicit tls= parameter already present in the DSN takes precedence: if the
+// parsed config already carries any TLS setting, tlsCfg is ignored so an
+// operator's own DSN choice always wins.
+//
+// Used by the stream path (internal/streamrun) so --ssl-mode protects the index
+// write connection (full row images = PII, plus index credentials) and the
+// source helper connection, not only the binlog replication stream (#946).
+func ConnectWithTLS(dsn string, tlsCfg *tls.Config) (*sql.DB, error) {
+	cfg, err := normalizeDSN(dsn)
+	if err != nil {
+		return nil, err
+	}
+	applyTLS(cfg, tlsCfg)
+
+	connector, err := mysql.NewConnector(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create MySQL connector: %w", err)
+	}
+	db := sql.OpenDB(connector)
+	if err := db.Ping(); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("failed to ping MySQL: %w", err)
+	}
+	return db, nil
+}
+
+// applyTLS attaches tlsCfg to cfg unless the DSN already specified TLS (either a
+// *tls.Config or a tls= name/mode), in which case the operator's choice wins.
+// Split out so the precedence rule is unit-testable without a live server.
+func applyTLS(cfg *mysql.Config, tlsCfg *tls.Config) {
+	if tlsCfg == nil || cfg.TLS != nil || cfg.TLSConfig != "" {
+		return
+	}
+	cfg.TLS = tlsCfg
+}
+
+// DSNHost returns the TCP host of a MySQL DSN, for use as a TLS ServerName
+// (verify-identity only). It is best-effort and never errors: an unparseable
+// DSN or a unix-socket DSN yields "" (hostname verification is meaningless over
+// a socket), and the subsequent connect surfaces any real DSN error with proper
+// context. Unlike ParseSourceDSN it imposes no TCP/port requirement, so it is
+// safe to call on an index DSN that may legitimately use a socket.
+func DSNHost(dsn string) string {
+	cfg, err := mysql.ParseDSN(dsn)
+	if err != nil || strings.EqualFold(cfg.Net, "unix") {
+		return ""
+	}
+	if h, _, err := net.SplitHostPort(cfg.Addr); err == nil {
+		return h
+	}
+	return cfg.Addr
+}
+
+// DSNHasExplicitTLS reports whether the DSN sets its own tls= parameter (any
+// value). Used to warn when a DSN's own TLS choice silently overrides a stronger
+// --ssl-mode on the same connection (#946).
+func DSNHasExplicitTLS(dsn string) bool {
+	cfg, err := mysql.ParseDSN(dsn)
+	if err != nil {
+		return false
+	}
+	return cfg.TLSConfig != "" || cfg.TLS != nil
 }
 
 // ParseSourceDSN decomposes a go-sql-driver DSN into host, port, user, and

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -178,11 +178,14 @@ func normalizeDSN(dsn string) (*mysql.Config, error) {
 // attaches a programmatic TLS configuration to the connection. tlsCfg == nil
 // means no TLS (plaintext), identical to Connect.
 //
-// The connection FAILS (it never silently falls back to plaintext) if the server
-// cannot satisfy the requested TLS — the driver's own AllowFallbackToPlaintext is
-// deliberately NOT used. A caller that wants an opportunistic fallback must
-// detect the failure and retry with a nil tlsCfg itself, so any cleartext
-// downgrade is an explicit, loggable decision (#946/#947).
+// For the programmatic tlsCfg path the connection FAILS (it never silently falls
+// back to plaintext) if the server cannot satisfy the requested TLS — this
+// function never sets the driver's own AllowFallbackToPlaintext. A caller that
+// wants an opportunistic fallback must detect the failure and retry with a nil
+// tlsCfg itself, so any cleartext downgrade is an explicit, loggable decision
+// (#946/#947). (An operator who puts tls=preferred in the DSN itself opts into
+// the driver's own silent fallback — the DSN-precedence rule below hands that
+// case to the driver by design.)
 //
 // An explicit tls= parameter already present in the DSN takes precedence: if the
 // parsed config already carries any TLS setting, tlsCfg is ignored so an

--- a/internal/config/config_tls_test.go
+++ b/internal/config/config_tls_test.go
@@ -1,0 +1,93 @@
+package config
+
+import (
+	"crypto/tls"
+	"testing"
+
+	"github.com/go-sql-driver/mysql"
+)
+
+// applyTLS must attach the given config only when the DSN itself specified no
+// TLS — the operator's own tls= choice always wins (#946).
+func TestApplyTLS_Precedence(t *testing.T) {
+	tc := &tls.Config{InsecureSkipVerify: true} //nolint:gosec // test fixture
+
+	t.Run("empty config gets the tls config", func(t *testing.T) {
+		cfg := &mysql.Config{}
+		applyTLS(cfg, tc)
+		if cfg.TLS != tc {
+			t.Fatalf("expected TLS attached, got %v", cfg.TLS)
+		}
+	})
+
+	t.Run("nil tls config is a no-op", func(t *testing.T) {
+		cfg := &mysql.Config{}
+		applyTLS(cfg, nil)
+		if cfg.TLS != nil {
+			t.Fatalf("nil tlsCfg must not mutate config: TLS=%v", cfg.TLS)
+		}
+	})
+
+	t.Run("explicit tls= name in DSN wins", func(t *testing.T) {
+		// A DSN like ...?tls=skip-verify parses into TLSConfig != "".
+		cfg := &mysql.Config{TLSConfig: "skip-verify"}
+		applyTLS(cfg, tc)
+		if cfg.TLS == tc {
+			t.Fatal("operator's tls= must not be overridden by tlsCfg")
+		}
+		if cfg.TLSConfig != "skip-verify" {
+			t.Fatalf("operator's TLSConfig mutated: %q", cfg.TLSConfig)
+		}
+	})
+
+	t.Run("pre-set programmatic TLS wins", func(t *testing.T) {
+		existing := &tls.Config{} //nolint:gosec // test fixture
+		cfg := &mysql.Config{TLS: existing}
+		applyTLS(cfg, tc)
+		if cfg.TLS != existing {
+			t.Fatal("pre-set cfg.TLS must not be overridden")
+		}
+	})
+}
+
+// DSNHost is best-effort and must never reject a DSN — a socket or unparseable
+// DSN yields "" rather than failing the connection (it is only a TLS
+// ServerName). This is why it replaced the stricter ParseSourceDSN on the index
+// connect path (#946).
+func TestDSNHost(t *testing.T) {
+	tests := []struct {
+		dsn  string
+		want string
+	}{
+		{"u:p@tcp(db.example.com:3306)/idx", "db.example.com"},
+		{"u:p@tcp(127.0.0.1:3306)/idx", "127.0.0.1"},
+		{"u:p@tcp(dbhost)/idx", "dbhost"}, // no explicit port
+		{"u:p@unix(/tmp/mysql.sock)/idx", ""},
+		{"@#$not a dsn", ""}, // unparseable → ""
+	}
+	for _, tt := range tests {
+		if got := DSNHost(tt.dsn); got != tt.want {
+			t.Errorf("DSNHost(%q) = %q, want %q", tt.dsn, got, tt.want)
+		}
+	}
+}
+
+// DSNHasExplicitTLS detects an operator's own tls= in the DSN so the stream can
+// warn when it silently overrides a stronger --ssl-mode (#946).
+func TestDSNHasExplicitTLS(t *testing.T) {
+	tests := []struct {
+		dsn  string
+		want bool
+	}{
+		{"u:p@tcp(h:3306)/idx", false},
+		{"u:p@tcp(h:3306)/idx?tls=true", true},
+		{"u:p@tcp(h:3306)/idx?tls=skip-verify", true},
+		{"u:p@tcp(h:3306)/idx?tls=false", true}, // explicit opt-out is still explicit
+		{"u:p@tcp(h:3306)/idx?parseTime=true", false},
+	}
+	for _, tt := range tests {
+		if got := DSNHasExplicitTLS(tt.dsn); got != tt.want {
+			t.Errorf("DSNHasExplicitTLS(%q) = %v, want %v", tt.dsn, got, tt.want)
+		}
+	}
+}

--- a/internal/config/config_tls_test.go
+++ b/internal/config/config_tls_test.go
@@ -91,3 +91,20 @@ func TestDSNHasExplicitTLS(t *testing.T) {
 		}
 	}
 }
+
+// Our TLS path must never enable the driver's own silent plaintext fallback —
+// flipping AllowFallbackToPlaintext to true is exactly the leak this pins
+// against, and no live test could catch it (the test MySQL has TLS on) (#946).
+func TestNormalizeDSN_NoSilentFallback(t *testing.T) {
+	cfg, err := normalizeDSN("u:p@tcp(h:3306)/db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.AllowFallbackToPlaintext {
+		t.Fatal("normalizeDSN must not enable AllowFallbackToPlaintext")
+	}
+	applyTLS(cfg, &tls.Config{InsecureSkipVerify: true}) //nolint:gosec // test fixture
+	if cfg.AllowFallbackToPlaintext {
+		t.Fatal("applyTLS must not enable AllowFallbackToPlaintext")
+	}
+}

--- a/internal/config/connect_tls_integration_test.go
+++ b/internal/config/connect_tls_integration_test.go
@@ -1,0 +1,48 @@
+//go:build integration
+
+package config
+
+import (
+	"crypto/tls"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// sessionSSLCipher returns the active TLS cipher for the connection's session.
+// An empty value means the connection is unencrypted.
+func sessionSSLCipher(t *testing.T, dsn string, tlsCfg *tls.Config) string {
+	t.Helper()
+	db, err := ConnectWithTLS(dsn, tlsCfg)
+	if err != nil {
+		t.Fatalf("ConnectWithTLS: %v", err)
+	}
+	defer db.Close()
+	// Pin one connection so the SHOW STATUS reflects the connection we opened.
+	db.SetMaxOpenConns(1)
+
+	var name, cipher string
+	if err := db.QueryRow("SHOW SESSION STATUS LIKE 'Ssl_cipher'").Scan(&name, &cipher); err != nil {
+		t.Fatalf("read Ssl_cipher: %v", err)
+	}
+	return cipher
+}
+
+// #946: ConnectWithTLS must actually encrypt the wire. Proven live against the
+// test MySQL (which supports TLS): a TLS connection reports a non-empty
+// Ssl_cipher; a plaintext connection reports an empty one.
+func TestConnectWithTLS_Encrypts(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	dsn := testutil.BaseDSN() + "/?parseTime=true"
+
+	//nolint:gosec // required/preferred bintrail modes skip cert verification by design
+	encrypted := sessionSSLCipher(t, dsn, &tls.Config{InsecureSkipVerify: true})
+	if encrypted == "" {
+		t.Fatal("ConnectWithTLS produced an UNENCRYPTED connection (Ssl_cipher empty)")
+	}
+	t.Logf("TLS connection cipher: %q", encrypted)
+
+	if plain := sessionSSLCipher(t, dsn, nil); plain != "" {
+		t.Fatalf("nil tlsCfg should be plaintext, but Ssl_cipher=%q", plain)
+	}
+}

--- a/internal/streamrun/streamrun.go
+++ b/internal/streamrun/streamrun.go
@@ -17,6 +17,7 @@ import (
 
 	gomysql "github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/go-mysql-org/go-mysql/replication"
+	drivermysql "github.com/go-sql-driver/mysql"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/dbtrail/dbtrail/internal/cliutil"
@@ -349,6 +350,79 @@ func buildTLSConfig(mode, ca, cert, key, serverName string) (*tls.Config, error)
 	}
 
 	return cfg, nil
+}
+
+// connectHelper opens an index or source helper connection (config.ConnectWithTLS)
+// honoring --ssl-mode, mirroring the binlog syncer's TLS via the same
+// buildTLSConfig. These connections carry full row images (PII) and credentials,
+// so --ssl-mode must protect them too — not only the replication stream (#946).
+// label names the connection in log/error messages.
+//
+// Under "preferred" it does the SAME explicit two-step as the syncer: try TLS,
+// and only if the server genuinely lacks TLS log a loud warning and retry in
+// cleartext — never the driver's OWN silent AllowFallbackToPlaintext, so every
+// connection that may send data unencrypted warns identically. required/verify-*
+// never retry: a TLS-incapable server fails closed with an actionable hint.
+func connectHelper(dsn, label, mode, ca, cert, key string) (*sql.DB, error) {
+	tlsCfg, err := buildTLSConfig(mode, ca, cert, key, config.DSNHost(dsn))
+	if err != nil {
+		return nil, err
+	}
+	// A tls= in the DSN wins (operator override) — but if it silently weakens a
+	// mandatory --ssl-mode, say so rather than failing open quietly (#946).
+	if tlsHint(mode) != "" && config.DSNHasExplicitTLS(dsn) {
+		slog.Warn("the DSN sets its own tls= parameter, which overrides --ssl-mode "+
+			"for this connection; remove tls= from the DSN to enforce --ssl-mode",
+			"connection", label, "ssl_mode", mode)
+	}
+
+	db, err := config.ConnectWithTLS(dsn, tlsCfg)
+	if err == nil {
+		return db, nil
+	}
+	if mode == "preferred" && isTLSUnsupportedError(err) {
+		slog.Warn("server does not support TLS; connecting WITHOUT encryption "+
+			"(--ssl-mode preferred) — credentials and data will be sent in cleartext",
+			"connection", label, "error", err)
+		return config.ConnectWithTLS(dsn, nil)
+	}
+	return nil, fmt.Errorf("connect %s%s: %w", label, tlsHint(mode), err)
+}
+
+// tlsHint returns a parenthetical remediation appended to a helper-connection
+// error when --ssl-mode mandates TLS, so a server that lacks TLS fails with an
+// actionable message instead of a bare handshake error (#946).
+func tlsHint(mode string) string {
+	switch mode {
+	case "required", "verify-ca", "verify-identity":
+		return fmt.Sprintf(" (--ssl-mode=%s requires TLS; enable TLS on the server, "+
+			"or use --ssl-mode=preferred to fall back to an unencrypted connection)", mode)
+	default:
+		return ""
+	}
+}
+
+// isTLSUnsupportedError reports whether err means the server does not support
+// TLS at all — the ONLY condition under which --ssl-mode=preferred may retry in
+// cleartext. The go-sql-driver helper connections return the sentinel
+// drivermysql.ErrNoTLS; the go-mysql binlog syncer returns a fixed message when
+// the server omits the CLIENT_SSL capability (client/auth.go); a mid-handshake
+// plaintext reply surfaces as tls.RecordHeaderError. Every other failure (auth
+// denied, unreachable host, bad binlog position) must NOT trigger a downgrade,
+// or credentials and data would be resent unencrypted on an unrelated error
+// (#947).
+func isTLSUnsupportedError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, drivermysql.ErrNoTLS) {
+		return true
+	}
+	var rhe tls.RecordHeaderError
+	if errors.As(err, &rhe) {
+		return true
+	}
+	return strings.Contains(err.Error(), "the MySQL Server does not support TLS")
 }
 
 // ─── Start position resolution ───────────────────────────────────────────────
@@ -1456,9 +1530,12 @@ func One(ctx context.Context, cfg Config) error {
 	defer cancel()
 
 	// ── 1. Connect to index database ─────────────────────────────────────────
-	indexDB, err := config.Connect(cfg.IndexDSN)
+	// #946: the index write connection carries full row images (PII) and the
+	// index credentials, so --ssl-mode must encrypt it too — not only the binlog
+	// syncer.
+	indexDB, err := connectHelper(cfg.IndexDSN, "index database", cfg.SSLMode, cfg.SSLCA, cfg.SSLCert, cfg.SSLKey)
 	if err != nil {
-		return fmt.Errorf("failed to connect to index database: %w", err)
+		return err
 	}
 	defer indexDB.Close()
 
@@ -1467,9 +1544,11 @@ func One(ctx context.Context, cfg Config) error {
 	}
 
 	// ── 2. Connect to source database: validate binlog_row_image ─────────────
-	sourceDB, err := config.Connect(cfg.SourceDSN)
+	// #946: same --ssl-mode TLS for the source helper connection (schema reads +
+	// source credentials) as for the binlog syncer built below.
+	sourceDB, err := connectHelper(cfg.SourceDSN, "source MySQL", cfg.SSLMode, cfg.SSLCA, cfg.SSLCert, cfg.SSLKey)
 	if err != nil {
-		return fmt.Errorf("failed to connect to source MySQL: %w", err)
+		return err
 	}
 	defer sourceDB.Close()
 
@@ -1835,17 +1914,21 @@ func One(ctx context.Context, cfg Config) error {
 
 	// ── 8. Start sync ───────────────────────────────────────────────────────────────
 	streamer, startErr := startStreamer()
-	if startErr != nil && cfg.SSLMode == "preferred" {
-		// preferred: TLS attempt failed — retry without TLS.
-		slog.Warn("initial connection failed; retrying without TLS (--ssl-mode preferred)", "error", startErr)
+	if startErr != nil && cfg.SSLMode == "preferred" && isTLSUnsupportedError(startErr) {
+		// #947: downgrade to plaintext ONLY when the server genuinely does not
+		// support TLS. Any other failure (auth denied, unreachable host, bad
+		// binlog position) must NOT retry unencrypted — that would resend the
+		// source credentials in the clear on an error unrelated to TLS. This
+		// path DOES transmit credentials unencrypted, so warn loudly.
+		slog.Warn("source does not support TLS; retrying WITHOUT encryption "+
+			"(--ssl-mode preferred) — credentials and data will be sent in cleartext",
+			"error", startErr)
 		syncer.Close()
 		syncerCfg.TLSConfig = nil
 		syncer = replication.NewBinlogSyncer(syncerCfg)
 		streamer, startErr = startStreamer()
-		if startErr != nil {
-			return startErr
-		}
-	} else if startErr != nil {
+	}
+	if startErr != nil {
 		return startErr
 	}
 

--- a/internal/streamrun/streamrun.go
+++ b/internal/streamrun/streamrun.go
@@ -368,11 +368,15 @@ func connectHelper(dsn, label, mode, ca, cert, key string) (*sql.DB, error) {
 	if err != nil {
 		return nil, err
 	}
-	// A tls= in the DSN wins (operator override) — but if it silently weakens a
-	// mandatory --ssl-mode, say so rather than failing open quietly (#946).
+	// A tls= in the DSN wins (operator override) — but under a mandatory
+	// --ssl-mode that override can silently WEAKEN the connection (e.g. a stale
+	// tls=skip-verify under --ssl-mode=verify-identity → encrypted but
+	// unauthenticated). Surface the precedence so it is a conscious choice. The
+	// message stays neutral: the DSN's own tls= may also be *stronger* than the
+	// mode, and we can't tell which here (#946).
 	if tlsHint(mode) != "" && config.DSNHasExplicitTLS(dsn) {
-		slog.Warn("the DSN sets its own tls= parameter, which overrides --ssl-mode "+
-			"for this connection; remove tls= from the DSN to enforce --ssl-mode",
+		slog.Warn("this connection's DSN sets its own tls= parameter, which takes "+
+			"precedence over --ssl-mode; verify it meets your security requirement",
 			"connection", label, "ssl_mode", mode)
 	}
 
@@ -380,11 +384,19 @@ func connectHelper(dsn, label, mode, ca, cert, key string) (*sql.DB, error) {
 	if err == nil {
 		return db, nil
 	}
+	// preferred: retry in cleartext ONLY when the server genuinely lacks TLS, and
+	// log it loudly (never the driver's silent AllowFallbackToPlaintext). An
+	// explicit tls= in the DSN survives this nil retry (applyTLS keeps it), so the
+	// retry re-attempts the same config and fails closed rather than downgrading.
 	if mode == "preferred" && isTLSUnsupportedError(err) {
 		slog.Warn("server does not support TLS; connecting WITHOUT encryption "+
 			"(--ssl-mode preferred) — credentials and data will be sent in cleartext",
 			"connection", label, "error", err)
-		return config.ConnectWithTLS(dsn, nil)
+		db, err = config.ConnectWithTLS(dsn, nil)
+		if err != nil {
+			return nil, fmt.Errorf("connect %s (cleartext retry): %w", label, err)
+		}
+		return db, nil
 	}
 	return nil, fmt.Errorf("connect %s%s: %w", label, tlsHint(mode), err)
 }

--- a/internal/streamrun/tls_test.go
+++ b/internal/streamrun/tls_test.go
@@ -5,6 +5,8 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"net"
+	"strings"
 	"testing"
 
 	drivermysql "github.com/go-sql-driver/mysql"
@@ -41,5 +43,62 @@ func TestIsTLSUnsupportedError(t *testing.T) {
 				t.Fatalf("isTLSUnsupportedError(%v) = %v, want %v", tt.err, got, tt.want)
 			}
 		})
+	}
+}
+
+// connectHelper wires --ssl-mode into the actual connect. A closed TCP port
+// (connection refused, deterministic — no MySQL needed) proves the security
+// composition: required surfaces the TLS-required hint and never yields a
+// connection, and preferred does NOT downgrade on a non-TLS error (#946/#947).
+func TestConnectHelper_FailsClosedNoSilentDowngrade(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := ln.Addr().String()
+	ln.Close() // now a closed port → connection refused
+	dsn := fmt.Sprintf("root:x@tcp(%s)/db?timeout=1s", addr)
+
+	t.Run("required surfaces the TLS-required hint, never a plaintext handle", func(t *testing.T) {
+		db, err := connectHelper(dsn, "index database", "required", "", "", "")
+		if db != nil {
+			db.Close()
+			t.Fatal("required must not return a connection to a dead endpoint")
+		}
+		if err == nil || !strings.Contains(err.Error(), "requires TLS") {
+			t.Fatalf("expected a --ssl-mode=required 'requires TLS' hint, got: %v", err)
+		}
+	})
+
+	t.Run("preferred does NOT downgrade on a non-TLS error", func(t *testing.T) {
+		db, err := connectHelper(dsn, "index database", "preferred", "", "", "")
+		if db != nil {
+			db.Close()
+			t.Fatal("preferred must not return a connection when the endpoint is down")
+		}
+		if err == nil {
+			t.Fatal("expected an error")
+		}
+		// A connection-refused (non-TLS) error must NOT take the cleartext-retry
+		// path — that path stamps "(cleartext retry)".
+		if strings.Contains(err.Error(), "cleartext retry") {
+			t.Fatalf("preferred downgraded on a non-TLS error (should not): %v", err)
+		}
+	})
+}
+
+// tlsHint is double-duty: it gates both the fail-closed error suffix and the
+// DSN-override warning. Pin its contract (#946).
+func TestTLSHint(t *testing.T) {
+	for _, m := range []string{"required", "verify-ca", "verify-identity"} {
+		h := tlsHint(m)
+		if h == "" || !strings.Contains(h, "requires TLS") || !strings.Contains(h, m) {
+			t.Errorf("tlsHint(%q) = %q, want non-empty naming the mode + 'requires TLS'", m, h)
+		}
+	}
+	for _, m := range []string{"disabled", "preferred", ""} {
+		if h := tlsHint(m); h != "" {
+			t.Errorf("tlsHint(%q) = %q, want empty", m, h)
+		}
 	}
 }

--- a/internal/streamrun/tls_test.go
+++ b/internal/streamrun/tls_test.go
@@ -1,0 +1,45 @@
+package streamrun
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"testing"
+
+	drivermysql "github.com/go-sql-driver/mysql"
+)
+
+// isTLSUnsupportedError gates the --ssl-mode=preferred plaintext downgrade: it
+// must return true ONLY for a genuine "server does not support TLS" condition,
+// never for auth/network/position errors — else credentials get resent in the
+// clear on an unrelated failure (#947). It covers both drivers: go-sql-driver's
+// ErrNoTLS sentinel (index/source helper connections) and go-mysql's exact
+// message (client/auth.go, binlog syncer).
+func TestIsTLSUnsupportedError(t *testing.T) {
+	goMySQLSentinel := errors.New("the MySQL Server does not support TLS required by the client")
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"go-sql-driver ErrNoTLS", drivermysql.ErrNoTLS, true},
+		{"go-sql-driver ErrNoTLS wrapped", fmt.Errorf("failed to ping MySQL: %w", drivermysql.ErrNoTLS), true},
+		{"go-mysql sentinel", goMySQLSentinel, true},
+		{"go-mysql sentinel wrapped", fmt.Errorf("StartSync(bin.0001, 4): %w", goMySQLSentinel), true},
+		{"record header (plaintext reply)", fmt.Errorf("dial: %w", tls.RecordHeaderError{Msg: "first record does not look like a TLS handshake"}), true},
+		{"access denied must NOT downgrade", errors.New("ERROR 1045 (28000): Access denied for user 'repl'@'%'"), false},
+		{"connection refused must NOT downgrade", errors.New("dial tcp 10.0.0.1:3306: connect: connection refused"), false},
+		{"deadline must NOT downgrade", context.DeadlineExceeded, false},
+		{"bad position must NOT downgrade", errors.New("StartSync(bin.0009, 999999): could not find first log file name in binary log index file"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isTLSUnsupportedError(tt.err); got != tt.want {
+				t.Fatalf("isTLSUnsupportedError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
closes #946
closes #947

## Summary
`--ssl-mode` was a half-guarantee: it encrypted only the binlog replication syncer, while the **index write** connection — full before/after row images (PII) plus the index credentials — and the source helper connection went **cleartext**, even under `--ssl-mode=required`. And `--ssl-mode=preferred` downgraded to plaintext on **any** connection error, resending credentials in the clear on failures unrelated to TLS. This makes one `--ssl-mode` knob govern all three stream-daemon connections, fail-secure, and narrows the preferred downgrade to a genuine no-TLS server.

Design decision (product-owner call): **reuse the single `--ssl-mode` flag** for source + index, fail-secure — see the compat note below.

### #946 — index/source connections now honor `--ssl-mode`
- New `config.ConnectWithTLS(dsn, *tls.Config)` attaches TLS via `mysql.NewConnector` + programmatic `cfg.TLS` (no global `RegisterTLSConfig` — no name collisions/leaks under `watch`'s many concurrent streams). It **never** silently falls back; an opportunistic fallback is the caller's explicit, logged decision.
- `streamrun.One` routes the index and source connections through a `connectHelper` that reuses the syncer's `buildTLSConfig`, so index/source/syncer share identical CA/verify/mTLS semantics.
- `required`/`verify-*` **fail closed** on a TLS-incapable server, with an actionable hint. `preferred` does the same explicit two-step as the syncer (try TLS → warn loudly → retry plaintext), so every connection that may send data in the clear warns identically.
- An explicit `tls=` in a DSN still wins (operator override), but now **warns** when it silently weakens a mandatory `--ssl-mode` (the MITM footgun where `?tls=skip-verify` + `--ssl-mode=verify-identity` would otherwise become encrypted-but-unauthenticated).

### #947 — `preferred` no longer downgrades on unrelated errors
`isTLSUnsupportedError` gates the plaintext retry to a genuine "server does not support TLS" condition only: `drivermysql.ErrNoTLS` (SQL connections), go-mysql's `client/auth.go` sentinel (syncer), or `tls.RecordHeaderError` (mid-handshake plaintext reply). Auth-denied / unreachable / bad-position errors propagate — never downgrade.

## Disclosures (reviewer-surfaced, worth a maintainer's eye)
1. **Compat change (intended, fail-secure):** a deployment running `--ssl-mode=required`/`verify-*` against an index with TLS **disabled** now fails to connect on upgrade (previously the index went cleartext regardless). This surfaces the exact misconfiguration `required` exists to prevent; MySQL 8.x ships TLS on by default, so the real blast radius is small. The error carries a `tlsHint`; a `doctor` pre-flight was considered and deferred in favor of the in-band hint at the point of failure.
2. **Default-mode behavior change:** under the default `preferred`, index connections that were *always* plaintext are now TLS-encrypted whenever the server supports it. A server that advertises SSL but fails the handshake (cipher/cert issue) now errors where plaintext previously connected — narrow, but a real default-path change.
3. **`watch` boundary (documented, not fixed):** `--ssl-mode` covers `watch`'s embedded **stream** (source + index write). The console's own index **reads** (multi-server manager) and the embedded **flashback port** still use the DSN's own `tls=`. Documented in `docs/console.md`; encrypting those under the same flag is a separate change.
4. **Fail-closed not proven live:** the integration test proves TLS-succeeds-encrypts (the test MySQL has TLS on). "`required` against a TLS-disabled server fails closed" is covered only at the unit level (mapping + classifier), not end-to-end — same caveat style as the mydumper-geometry note in #503.

## Test plan
- [x] Unit: `TestApplyTLS_Precedence`, `TestDSNHost`, `TestDSNHasExplicitTLS`, `TestIsTLSUnsupportedError` (both drivers' no-TLS sentinels + the must-NOT-downgrade cases)
- [x] Integration (live): `TestConnectWithTLS_Encrypts` — `Ssl_cipher=TLS_AES_128_GCM_SHA256` over TLS, empty over plaintext
- [x] Full CLI E2E (`bintrail stream` connect path) green
- [x] `go build ./...`, `go vet ./...`, full unit suite (42 pkgs) green
- [x] Adversarial review (code-reviewer + silent-failure-hunter): findings applied (symmetric warning, DSN-override warning, classifier narrowed, doc-comment fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
