### PR TITLE
stream: bound index writes with a tunable deadline; honest capacity SKIP (#948, #959)

### DIFF
--- a/cliapp/stream.go
+++ b/cliapp/stream.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/dbtrail/dbtrail/internal/indexer"
 	"github.com/dbtrail/dbtrail/internal/streamdeps"
 	"github.com/dbtrail/dbtrail/internal/streamrun"
 )
@@ -95,6 +96,7 @@ func init() {
 	streamCmd.Flags().BoolVar(&strmReset, "reset", false, "Clear saved checkpoint before starting (forces use of --start-file/--start-gtid)")
 	streamCmd.Flags().BoolVar(&strmNoGapFill, "no-gap-fill", false, "Refuse to start if an unfillable binlog gap is detected (instead of auto-advancing past purged data)")
 	streamCmd.Flags().IntVar(&strmGapTimeout, "gap-timeout", 30, "Timeout in seconds for the one-shot gap-detection queries run at startup (SHOW BINARY LOGS plus @@gtid_purged/@@gtid_executed on MySQL or BINLOG_GTID_POS/@@gtid_binlog_pos on MariaDB); raise on managed servers with many binlog files")
+	streamCmd.Flags().DurationVar(&indexer.WriteTimeout, "write-timeout", indexer.DefaultWriteTimeout, "Deadline for each index write (batch INSERT, checkpoint, digest lookup). A mid-statement network stall surfaces as an error within this window instead of freezing the stream on kernel TCP retransmission (~13-16 min). Raise for very large batches over a slow link")
 	_ = streamCmd.MarkFlagRequired("index-dsn")
 	_ = streamCmd.MarkFlagRequired("source-dsn")
 	_ = streamCmd.MarkFlagRequired("server-id")

--- a/cliapp/up.go
+++ b/cliapp/up.go
@@ -12,6 +12,7 @@ import (
 	"github.com/dbtrail/dbtrail/internal/cliutil"
 	"github.com/dbtrail/dbtrail/internal/doctor"
 	"github.com/dbtrail/dbtrail/internal/forensics"
+	"github.com/dbtrail/dbtrail/internal/indexer"
 	"github.com/dbtrail/dbtrail/internal/rotation"
 	"github.com/dbtrail/dbtrail/internal/serverid"
 )
@@ -74,6 +75,7 @@ func init() {
 	upCmd.Flags().StringVar(&upSchemas, "schemas", "", "Comma-separated schemas to index (default: all user schemas)")
 	upCmd.Flags().StringVar(&upTables, "tables", "", "Comma-separated tables to index (default: all)")
 	upCmd.Flags().IntVar(&upBatchSize, "batch-size", 1000, "Events per batch INSERT")
+	upCmd.Flags().DurationVar(&indexer.WriteTimeout, "write-timeout", indexer.DefaultWriteTimeout, "Deadline for each index write (batch INSERT, checkpoint, digest lookup). A mid-statement network stall surfaces as an error within this window instead of freezing the daemon on kernel TCP retransmission (~13-16 min). Raise for very large batches over a slow link")
 	upCmd.Flags().IntVar(&upCheckpoint, "checkpoint", 10, "Checkpoint interval in seconds")
 	upCmd.Flags().StringVar(&upMetricsAddr, "metrics-addr", "", "Address to expose Prometheus metrics (e.g. :9090); empty = disabled")
 	upCmd.Flags().IntVar(&upPartitions, "partitions", 48, "Hourly partitions to create on first init")

--- a/cmd/bintrail-console/watch.go
+++ b/cmd/bintrail-console/watch.go
@@ -174,6 +174,7 @@ func init() {
 	watchCmd.Flags().StringVar(&upSchemas, "schemas", "", "Comma-separated schemas to index (default: all user schemas)")
 	watchCmd.Flags().StringVar(&upTables, "tables", "", "Comma-separated tables to index (default: all)")
 	watchCmd.Flags().IntVar(&upBatchSize, "batch-size", 1000, "Events per batch INSERT")
+	watchCmd.Flags().DurationVar(&indexer.WriteTimeout, "write-timeout", indexer.DefaultWriteTimeout, "Deadline for each index write (batch INSERT, checkpoint, digest lookup). A mid-statement network stall surfaces as an error within this window instead of freezing the daemon on kernel TCP retransmission (~13-16 min). Raise for very large batches over a slow link")
 	watchCmd.Flags().IntVar(&upCheckpoint, "checkpoint", 10, "Checkpoint interval in seconds")
 	watchCmd.Flags().StringVar(&upSSLMode, "ssl-mode", "preferred", "TLS mode for the source AND index connections: disabled, preferred, required, verify-ca, verify-identity")
 	watchCmd.Flags().StringVar(&upSSLCA, "ssl-ca", "", "Path to CA certificate file for source TLS verification (omit to use system CAs)")

--- a/cmd/bintrail-pg/stream.go
+++ b/cmd/bintrail-pg/stream.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/dbtrail/dbtrail/internal/cli"
+	"github.com/dbtrail/dbtrail/internal/indexer"
 	"github.com/dbtrail/dbtrail/internal/pgstreamrun"
 )
 
@@ -82,6 +83,7 @@ func init() {
 	streamCmd.Flags().StringVar(&pgSchemas, "schemas", "", "Only index changes from these schemas (comma-separated)")
 	streamCmd.Flags().StringVar(&pgTables, "tables", "", "Only index these tables (comma-separated, e.g. public.orders)")
 	streamCmd.Flags().IntVar(&pgBatchSize, "batch-size", 1000, "Events per batch INSERT")
+	streamCmd.Flags().DurationVar(&indexer.WriteTimeout, "write-timeout", indexer.DefaultWriteTimeout, "Deadline for each index write (batch INSERT, checkpoint, schema snapshot). A mid-statement network stall surfaces as an error within this window instead of freezing the stream on kernel TCP retransmission (~13-16 min). Raise for very large batches over a slow link")
 	streamCmd.Flags().IntVar(&pgCheckpoint, "checkpoint", 5, "Checkpoint interval in seconds")
 	streamCmd.Flags().IntVar(&pgPartitions, "partitions", 48, "binlog_events partitions for the one-time index bootstrap")
 	// index-dsn and server-id live in cli.EnvBindings, so BindCommandEnv both

--- a/internal/doctor/capacity.go
+++ b/internal/doctor/capacity.go
@@ -132,10 +132,15 @@ func capacityVerdict(p capacityProjection, retain time.Duration, free uint64, fr
 		humanBytes(p.projectedBytes), retain, p.eventsPerDay, humanBytes(p.bytesPerEvent), humanBytes(float64(p.currentBytes)))
 
 	if !freeKnown {
+		// #948: the index is on a separate host/container (the docker-compose
+		// stack, or a managed/remote index), so statfs can't reach its volume and
+		// the FAIL/WARN thresholds below are unreachable. Report SKIP, not PASS —
+		// an unmeasurable check must not read green. Rotation still bounds the
+		// volume (#420); the operator monitors the index disk externally.
 		return CheckResult{
 			Name:   CapacityCheckName,
-			Status: StatusPass,
-			Detail: projected + " — free space not measurable from this host; ensure the index volume keeps >=30% headroom above the projection (docs/capacity.md)",
+			Status: StatusSkip,
+			Detail: projected + " — free space is not measurable from this host (the index runs on a separate host/container), so the disk-capacity thresholds are skipped, not passed; monitor the index volume externally and keep >=30% headroom above the projection (docs/capacity.md)",
 		}
 	}
 

--- a/internal/doctor/capacity_integration_test.go
+++ b/internal/doctor/capacity_integration_test.go
@@ -28,11 +28,13 @@ func TestCheckIndexCapacity_skipsWithoutHistory(t *testing.T) {
 	}
 }
 
-// TestCheckIndexCapacity_measuresAndProjects seeds three completed hourly
-// partitions with rows and verifies the check produces a real projection
-// (shrunken measurement floors — information_schema row counts are estimates
-// and the fixture is small).
-func TestCheckIndexCapacity_measuresAndProjects(t *testing.T) {
+// TestCheckIndexCapacity_projectsAndSkipsUnmeasurableDisk seeds three completed
+// hourly partitions with rows and verifies the check computes a real projection
+// yet SKIPs the verdict because the index MySQL runs in a separate container
+// whose disk-free volume this host cannot measure (#948). Row counts are
+// information_schema estimates and the fixture is small, so measurement floors
+// apply.
+func TestCheckIndexCapacity_projectsAndSkipsUnmeasurableDisk(t *testing.T) {
 	db, dbName := testutil.CreateTestDB(t)
 	testutil.InitIndexTables(t, db)
 
@@ -59,8 +61,15 @@ func TestCheckIndexCapacity_measuresAndProjects(t *testing.T) {
 	testutil.MustExec(t, db, fmt.Sprintf("ANALYZE TABLE `%s`.`binlog_events`", dbName))
 
 	r := checkIndexCapacity(context.Background(), testutil.IntegrationDSN(dbName), dbName, 30*24*time.Hour)
-	if r.Status == StatusSkip || r.Status == StatusFail {
-		t.Fatalf("status = %s, want a real measurement (detail: %s)", r.Status, r.Detail)
+	// #948: the index MySQL is a separate container here, so the disk-free volume
+	// is not measurable from this host — the check SKIPs rather than reporting a
+	// PASS/WARN/FAIL verdict, but it still computes and carries the size
+	// projection. (The verdict thresholds themselves are exercised against a known
+	// free-byte value in TestCapacityVerdict, which needs no live disk.) Before
+	// #948 this path returned a misleading PASS, so this test passed without ever
+	// exercising a real measurement.
+	if r.Status != StatusSkip {
+		t.Fatalf("status = %s, want skip (index is a separate container; disk unmeasurable) (detail: %s)", r.Status, r.Detail)
 	}
 	if !strings.Contains(r.Detail, "projected steady-state") {
 		t.Errorf("detail should carry the projection, got: %s", r.Detail)

--- a/internal/doctor/capacity_test.go
+++ b/internal/doctor/capacity_test.go
@@ -217,11 +217,14 @@ func TestDoctorReportErrExcluding(t *testing.T) {
 	}
 }
 
-func TestCapacityVerdict_freeUnknownPassesWithGuidance(t *testing.T) {
+func TestCapacityVerdict_freeUnknownSkipsWithGuidance(t *testing.T) {
 	p := capacityProjection{eventsPerDay: 24000, bytesPerEvent: 1000, projectedBytes: 720_000_000}
 	r := capacityVerdict(p, 30*24*time.Hour, 0, false)
-	if r.Status != StatusPass {
-		t.Fatalf("status = %s, want pass when free space is unknown", r.Status)
+	// #948: an unmeasurable volume (separate host/container — e.g. the compose
+	// stack) must SKIP, not PASS, so the check does not read green when its
+	// FAIL/WARN thresholds could never fire.
+	if r.Status != StatusSkip {
+		t.Fatalf("status = %s, want skip when free space is unknown", r.Status)
 	}
 	if !strings.Contains(r.Detail, "not measurable") || !strings.Contains(r.Detail, "headroom") {
 		t.Errorf("detail must carry the projection plus headroom guidance, got: %s", r.Detail)

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
+	"time"
 	"unicode/utf8"
 
 	mysql "github.com/go-sql-driver/mysql"
@@ -18,6 +19,24 @@ import (
 	"github.com/dbtrail/dbtrail/internal/event"
 	"github.com/dbtrail/dbtrail/internal/metadata"
 )
+
+// WriteTimeout bounds a single index write (a batch INSERT or the checkpoint
+// UPSERT) so a mid-statement network stall surfaces as an error in minutes
+// instead of the kernel's ~13-16 min TCP give-up. config.Connect sets only a
+// connect timeout, never a read/write deadline, so without this a frozen VM or
+// an idle-dropped NLB leaves the daemon blocked — healthy to `watch`, capturing
+// nothing and advancing no checkpoint (#959). The window sits well above any
+// healthy batch INSERT and below the kernel give-up, and is tunable per
+// deployment via --write-timeout for the cases where a healthy write legitimately
+// runs long: a very large batch over a slow link, or index-side MDL contention
+// from a concurrent partition rotation (#959).
+const DefaultWriteTimeout = 3 * time.Minute
+
+// WriteTimeout is the effective deadline, set from --write-timeout at startup
+// (default DefaultWriteTimeout). A var (not const) so the flag can set it and
+// tests can shrink it — a test that mutates it must NOT call t.Parallel() (it is
+// a shared global).
+var WriteTimeout = DefaultWriteTimeout
 
 // Indexer consumes event.Events from a channel and batch-inserts them into
 // the binlog_events table.
@@ -189,8 +208,22 @@ func (idx *Indexer) insertBatch(batch []event.Event) (int64, error) {
 		)
 	}
 
-	result, err := idx.db.Exec(insertSQL, args...)
+	// #959: bound the write with a deadline so a mid-statement network stall
+	// surfaces as an error (ExecContext closes the connection on timeout) instead
+	// of blocking on kernel TCP retransmission for minutes while `watch` sees a
+	// healthy daemon capturing nothing.
+	ctx, cancel := context.WithTimeout(context.Background(), WriteTimeout)
+	defer cancel()
+	result, err := idx.db.ExecContext(ctx, insertSQL, args...)
 	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			// Distinguish a slow-but-working link (a batch too large to transmit
+			// within WriteTimeout) from a genuine stall, so the operator knows the
+			// knob rather than chasing a phantom network fault (#959).
+			return 0, fmt.Errorf("batch INSERT of %d events exceeded the %s write deadline "+
+				"(a network stall, or a batch too large for the link — raise --write-timeout, "+
+				"or lower --batch-size / the server max_allowed_packet): %w", len(batch), WriteTimeout, err)
+		}
 		return 0, fmt.Errorf("batch INSERT of %d events failed: %w", len(batch), err)
 	}
 	n, _ := result.RowsAffected()
@@ -254,7 +287,17 @@ func (idx *Indexer) digestStatements(texts []string) map[string]string {
 		return nil
 	}
 
-	out, combinedErr := idx.digestCombined(candidates)
+	// #959: one deadline bounds the WHOLE digest phase (the combined query plus
+	// any per-text fallback), not each round-trip independently — otherwise a
+	// stall costs up to (K+1)×WriteTimeout before the batch INSERT even starts.
+	// Digests are best-effort query_hash enrichment (#699): this phase returns
+	// whatever it resolved and lets the bounded INSERT be the loud terminator.
+	// Kept deliberately SEPARATE from the INSERT's own deadline so a slow-but-
+	// healthy digest phase can never eat the durable write's budget.
+	ctx, cancel := context.WithTimeout(context.Background(), WriteTimeout)
+	defer cancel()
+
+	out, combinedErr := idx.digestCombined(ctx, candidates)
 	if combinedErr == nil {
 		return out
 	}
@@ -276,11 +319,19 @@ func (idx *Indexer) digestStatements(texts []string) map[string]string {
 	var lastErr error
 	for _, t := range candidates {
 		var v sql.NullString
-		if err := idx.db.QueryRow("SELECT STATEMENT_DIGEST(?)", t).Scan(&v); err != nil {
+		// The shared phase ctx bounds every probe together (#959). On a genuine
+		// stall the first probe exhausts the deadline and the rest would return
+		// DeadlineExceeded instantly — stop probing and let the INSERT surface the
+		// stall fatally rather than spinning through K no-op failures.
+		err := idx.db.QueryRowContext(ctx, "SELECT STATEMENT_DIGEST(?)", t).Scan(&v)
+		if err != nil {
 			failures++
 			lastErr = err
 			slog.Debug("STATEMENT_DIGEST failed for one statement — query_hash stays NULL for it",
 				"error", err, "statement_prefix", truncateForLog(t))
+			if errors.Is(err, context.DeadlineExceeded) {
+				break
+			}
 			continue
 		}
 		if v.Valid {
@@ -321,7 +372,7 @@ func truncateForLog(s string) string {
 
 // digestCombined runs the single-round-trip form: one SELECT with one
 // STATEMENT_DIGEST expression per text.
-func (idx *Indexer) digestCombined(texts []string) (map[string]string, error) {
+func (idx *Indexer) digestCombined(ctx context.Context, texts []string) (map[string]string, error) {
 	var sb strings.Builder
 	sb.WriteString("SELECT STATEMENT_DIGEST(?)")
 	for range len(texts) - 1 {
@@ -336,7 +387,9 @@ func (idx *Indexer) digestCombined(texts []string) (map[string]string, error) {
 	for i := range vals {
 		ptrs[i] = &vals[i]
 	}
-	if err := idx.db.QueryRow(sb.String(), args...).Scan(ptrs...); err != nil {
+	// The caller's phase ctx bounds this round-trip together with any per-text
+	// fallback (#959) — see digestStatements.
+	if err := idx.db.QueryRowContext(ctx, sb.String(), args...).Scan(ptrs...); err != nil {
 		return nil, err
 	}
 	out := make(map[string]string, len(texts))
@@ -732,7 +785,10 @@ func InsertSchemaChange(db *sql.DB, ev event.Event, snapshotID *int) error {
 	if snapshotID != nil {
 		snapArg = *snapshotID
 	}
-	_, err := db.Exec(`
+	// #959: bound the DDL write like the other hot-loop index writes.
+	ctx, cancel := context.WithTimeout(context.Background(), WriteTimeout)
+	defer cancel()
+	_, err := db.ExecContext(ctx, `
 		INSERT INTO schema_changes
 			(detected_at, binlog_file, binlog_pos, gtid, schema_name, table_name, ddl_type, ddl_query, snapshot_id)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -20,8 +20,8 @@ import (
 	"github.com/dbtrail/dbtrail/internal/metadata"
 )
 
-// WriteTimeout bounds a single index write (a batch INSERT or the checkpoint
-// UPSERT) so a mid-statement network stall surfaces as an error in minutes
+// WriteTimeout bounds a single index write (e.g. a batch INSERT, the checkpoint
+// UPSERT, or a statement-digest lookup) so a mid-statement network stall surfaces as an error in minutes
 // instead of the kernel's ~13-16 min TCP give-up. config.Connect sets only a
 // connect timeout, never a read/write deadline, so without this a frozen VM or
 // an idle-dropped NLB leaves the daemon blocked — healthy to `watch`, capturing

--- a/internal/indexer/write_timeout_test.go
+++ b/internal/indexer/write_timeout_test.go
@@ -78,3 +78,55 @@ func TestInsertBatch_boundedByWriteTimeout(t *testing.T) {
 		t.Fatalf("DeadlineExceeded error must carry the operator hint (write deadline / --write-timeout), got: %v", err)
 	}
 }
+
+// digestStatements runs BEFORE the batch INSERT inside insertBatch, so an
+// unbounded stall on its STATEMENT_DIGEST round-trip freezes the daemon at a
+// hot-path site the empty-batch InsertBatch test never reaches (a nil/empty batch
+// has no candidate texts, so digestStatements early-returns without any DB round
+// trip). A non-empty candidate drives the real digestCombined QueryRowContext;
+// the shared digest-phase deadline must cut the stall. Must NOT call t.Parallel()
+// (mutates the shared WriteTimeout global).
+func TestDigestStatements_boundedByWriteTimeout(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	go func() {
+		var held []net.Conn
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				for _, h := range held {
+					h.Close()
+				}
+				return
+			}
+			held = append(held, c) // hold open, never respond
+		}
+	}()
+
+	prev := WriteTimeout
+	WriteTimeout = 750 * time.Millisecond
+	t.Cleanup(func() { WriteTimeout = prev })
+
+	db, err := sql.Open("mysql", "root:x@tcp("+ln.Addr().String()+")/db?timeout=30s")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	idx := New(db, 1)
+	start := time.Now()
+	out := idx.digestStatements([]string{"SELECT 1"}) // reaches digestCombined's QueryRowContext; the stall is cut by the phase deadline
+	elapsed := time.Since(start)
+
+	if elapsed > 5*time.Second {
+		t.Fatalf("digestStatements blocked %v — the digest-phase deadline is not wired (a revert to QueryRow reopens the #959 freeze here, before the bounded INSERT)", elapsed)
+	}
+	// Best-effort: a stalled digest yields no hashes rather than an error (the
+	// bounded INSERT is the loud terminator), so the map is empty, never wrong.
+	if len(out) != 0 {
+		t.Fatalf("expected no digests from a stalled probe, got %d", len(out))
+	}
+}

--- a/internal/indexer/write_timeout_test.go
+++ b/internal/indexer/write_timeout_test.go
@@ -1,0 +1,80 @@
+package indexer
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The whole point of WriteTimeout is to bound a stalled index write. A zero (or
+// negative) value silently disables the deadline and reintroduces #959; an
+// absurdly long value defeats the purpose (must stay below the kernel's
+// ~13-16 min TCP give-up). Pin a sane window.
+func TestWriteTimeout_default(t *testing.T) {
+	if WriteTimeout < time.Minute || WriteTimeout > 10*time.Minute {
+		t.Fatalf("WriteTimeout = %v; want above a healthy batch INSERT and below the kernel ~13-16m give-up", WriteTimeout)
+	}
+}
+
+// InsertBatch is the hot-path index write (#959: the "capturing nothing" site).
+// Its ExecContext deadline must cut a mid-statement network stall, or the daemon
+// freezes ~13-16 min invisibly to `watch`. A TCP listener that accepts but never
+// speaks MySQL reproduces the stall; an empty batch still reaches the same
+// ExecContext, so this directly guards the wiring at this site (a copy-paste
+// back to db.Exec would silently reintroduce the freeze here). Must NOT call
+// t.Parallel(): it mutates the shared WriteTimeout global.
+func TestInsertBatch_boundedByWriteTimeout(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	go func() {
+		var held []net.Conn
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				for _, h := range held {
+					h.Close()
+				}
+				return
+			}
+			held = append(held, c) // hold open, never respond
+		}
+	}()
+
+	prev := WriteTimeout
+	WriteTimeout = 750 * time.Millisecond
+	t.Cleanup(func() { WriteTimeout = prev })
+
+	db, err := sql.Open("mysql", "root:x@tcp("+ln.Addr().String()+")/db?timeout=30s")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	idx := New(db, 1)
+	start := time.Now()
+	_, err = idx.InsertBatch(nil) // reaches ExecContext; the handshake stall is cut by WriteTimeout
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error from the stalled write")
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("InsertBatch blocked %v — the WriteTimeout deadline is not wired at the hot-path site", elapsed)
+	}
+	// The stall must surface as the deadline SPECIFICALLY (not merely "some fast
+	// error"), and carry the operator hint — otherwise a large-batch-over-slow-link
+	// false-fire looks like a phantom network fault instead of a tunable knob (#959).
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("want the write bounded by the WriteTimeout deadline, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "write deadline") || !strings.Contains(err.Error(), "--write-timeout") {
+		t.Fatalf("DeadlineExceeded error must carry the operator hint (write deadline / --write-timeout), got: %v", err)
+	}
+}

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -684,15 +684,17 @@ type PGRelationSchema struct {
 // the empty string (both NOT NULL columns, so empty string not NULL), column_type and
 // column_default NULL, is_generated 0. The PostgreSQL type identity rides the nullable
 // pg_type_oid/pg_type_mod columns for the deferred type-faithful renderer.
-// The ctx bounds every write on this path — the ensureSnapshotIDSeqTable
-// existence check, the allocateSnapshotID insert, and the schema INSERT all run
-// under it — so a mid-statement stall on the index link is cut at the caller's
-// deadline (indexer.WriteTimeout) rather than freezing the PG stream loop on
-// kernel TCP retransmission (~13-16 min) (#959). BeginTx(ctx) alone is NOT
-// enough: a statement issued via a context-less tx.Exec holds the driver
-// connection's lock for its whole round-trip, so the transaction's
-// rollback-on-cancel goroutine parks behind it until TCP gives up — each
-// statement must carry the ctx itself.
+// Every write here is a bounded autocommit statement carrying the caller's ctx
+// (indexer.WriteTimeout) — ensureSnapshotIDSeqTable's checks, allocateSnapshotID's
+// counter INSERT, and the single multi-row schema INSERT — so a mid-statement
+// stall on the index link is cut at that deadline rather than freezing the PG
+// stream loop on kernel TCP retransmission (~13-16 min) (#959). No explicit
+// transaction is used, deliberately: the counter INSERT is concurrency-safe on
+// its own (AUTO_INCREMENT, and its value is never reclaimed on failure anyway)
+// and the schema rows are one atomic multi-row INSERT, so a tx bought no
+// atomicity — only an unbounded tx.Commit() round-trip (database/sql has no
+// CommitContext; BeginTx's ctx watcher is per-statement, not per-commit) that
+// reopened exactly this freeze window.
 func WritePGSnapshot(ctx context.Context, db *sql.DB, rel *PGRelationSchema) (int, error) {
 	if rel == nil || len(rel.Columns) == 0 {
 		return 0, fmt.Errorf("metadata: WritePGSnapshot requires a relation with at least one column")
@@ -702,22 +704,12 @@ func WritePGSnapshot(ctx context.Context, db *sql.DB, rel *PGRelationSchema) (in
 		return 0, err
 	}
 
-	tx, err := db.BeginTx(ctx, nil)
-	if err != nil {
-		return 0, fmt.Errorf("metadata: WritePGSnapshot begin: %w", err)
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
-		}
-	}()
-
-	// Allocate the next snapshot_id inside the transaction (same scheme as
-	// TakeSnapshot). MySQL and PG snapshots coexist in one table with distinct
-	// ids. See DDLSnapshotIDSeq for why this is a dedicated AUTO_INCREMENT
-	// counter table rather than a MAX(snapshot_id)+1 FOR UPDATE read (#844).
-	nextID, err := allocateSnapshotID(ctx, tx)
+	// Allocate the next snapshot_id from the dedicated AUTO_INCREMENT counter
+	// (MySQL and PG snapshots coexist in one table with distinct ids; see
+	// DDLSnapshotIDSeq for why this beats a MAX(snapshot_id)+1 FOR UPDATE read,
+	// #844). Autocommit is safe: LastInsertId comes from this INSERT's own OK
+	// packet, with no dependency on a follow-up read hitting the same connection.
+	nextID, err := allocateSnapshotID(ctx, db)
 	if err != nil {
 		return 0, fmt.Errorf("metadata: WritePGSnapshot allocate snapshot_id: %w", err)
 	}
@@ -741,14 +733,9 @@ func WritePGSnapshot(ctx context.Context, db *sql.DB, rel *PGRelationSchema) (in
 			c.TypeOID, c.TypeMod, c.IsIdentityAlways,
 		)
 	}
-	if _, err = tx.ExecContext(ctx, insertSQL, args...); err != nil {
+	if _, err = db.ExecContext(ctx, insertSQL, args...); err != nil {
 		return 0, fmt.Errorf("metadata: WritePGSnapshot insert %s.%s: %w", rel.Schema, rel.Table, err)
 	}
-
-	if err = tx.Commit(); err != nil {
-		return 0, fmt.Errorf("metadata: WritePGSnapshot commit: %w", err)
-	}
-	committed = true
 	return nextID, nil
 }
 

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -684,16 +684,25 @@ type PGRelationSchema struct {
 // the empty string (both NOT NULL columns, so empty string not NULL), column_type and
 // column_default NULL, is_generated 0. The PostgreSQL type identity rides the nullable
 // pg_type_oid/pg_type_mod columns for the deferred type-faithful renderer.
-func WritePGSnapshot(db *sql.DB, rel *PGRelationSchema) (int, error) {
+// The ctx bounds every write on this path — the ensureSnapshotIDSeqTable
+// existence check, the allocateSnapshotID insert, and the schema INSERT all run
+// under it — so a mid-statement stall on the index link is cut at the caller's
+// deadline (indexer.WriteTimeout) rather than freezing the PG stream loop on
+// kernel TCP retransmission (~13-16 min) (#959). BeginTx(ctx) alone is NOT
+// enough: a statement issued via a context-less tx.Exec holds the driver
+// connection's lock for its whole round-trip, so the transaction's
+// rollback-on-cancel goroutine parks behind it until TCP gives up — each
+// statement must carry the ctx itself.
+func WritePGSnapshot(ctx context.Context, db *sql.DB, rel *PGRelationSchema) (int, error) {
 	if rel == nil || len(rel.Columns) == 0 {
 		return 0, fmt.Errorf("metadata: WritePGSnapshot requires a relation with at least one column")
 	}
 
-	if err := ensureSnapshotIDSeqTable(db); err != nil {
+	if err := ensureSnapshotIDSeqTable(ctx, db); err != nil {
 		return 0, err
 	}
 
-	tx, err := db.Begin()
+	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		return 0, fmt.Errorf("metadata: WritePGSnapshot begin: %w", err)
 	}
@@ -708,7 +717,7 @@ func WritePGSnapshot(db *sql.DB, rel *PGRelationSchema) (int, error) {
 	// TakeSnapshot). MySQL and PG snapshots coexist in one table with distinct
 	// ids. See DDLSnapshotIDSeq for why this is a dedicated AUTO_INCREMENT
 	// counter table rather than a MAX(snapshot_id)+1 FOR UPDATE read (#844).
-	nextID, err := allocateSnapshotID(tx)
+	nextID, err := allocateSnapshotID(ctx, tx)
 	if err != nil {
 		return 0, fmt.Errorf("metadata: WritePGSnapshot allocate snapshot_id: %w", err)
 	}
@@ -732,7 +741,7 @@ func WritePGSnapshot(db *sql.DB, rel *PGRelationSchema) (int, error) {
 			c.TypeOID, c.TypeMod, c.IsIdentityAlways,
 		)
 	}
-	if _, err = tx.Exec(insertSQL, args...); err != nil {
+	if _, err = tx.ExecContext(ctx, insertSQL, args...); err != nil {
 		return 0, fmt.Errorf("metadata: WritePGSnapshot insert %s.%s: %w", rel.Schema, rel.Table, err)
 	}
 
@@ -858,7 +867,7 @@ func TakeSnapshot(sourceDB, indexDB *sql.DB, schemas []string) (SnapshotStats, e
 	}
 
 	// ── 2. Write snapshot atomically into the index database ─────────────────
-	if err := ensureSnapshotIDSeqTable(indexDB); err != nil {
+	if err := ensureSnapshotIDSeqTable(context.Background(), indexDB); err != nil {
 		return SnapshotStats{}, err
 	}
 
@@ -891,7 +900,7 @@ func TakeSnapshot(sourceDB, indexDB *sql.DB, schemas []string) (SnapshotStats, e
 	// AUTO_INCREMENT allocation is a lightweight, statement-duration lock,
 	// not a row/gap lock held for the transaction's lifetime, so concurrent
 	// allocators serialize without ever deadlocking (see DDLSnapshotIDSeq).
-	nextID, err := allocateSnapshotID(tx)
+	nextID, err := allocateSnapshotID(context.Background(), tx)
 	if err != nil {
 		return SnapshotStats{}, fmt.Errorf("failed to allocate snapshot_id: %w", err)
 	}

--- a/internal/metadata/metadata_integration_test.go
+++ b/internal/metadata/metadata_integration_test.go
@@ -4,6 +4,7 @@ package metadata
 
 import (
 	"bytes"
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -342,13 +343,13 @@ func TestNewLatestPerTableResolver_pgPerTableSnapshots(t *testing.T) {
 	}
 
 	for _, tbl := range []string{"users", "orders"} {
-		if _, err := WritePGSnapshot(indexDB, rel(tbl, "v1")); err != nil {
+		if _, err := WritePGSnapshot(context.Background(), indexDB, rel(tbl, "v1")); err != nil {
 			t.Fatalf("WritePGSnapshot(%s): %v", tbl, err)
 		}
 	}
 	// users evolves (a later RelationMessage after an ALTER): its NEWEST
 	// per-table snapshot must win over its older one.
-	if _, err := WritePGSnapshot(indexDB, rel("users", "v1", "v2")); err != nil {
+	if _, err := WritePGSnapshot(context.Background(), indexDB, rel("users", "v1", "v2")); err != nil {
 		t.Fatalf("WritePGSnapshot(users v2): %v", err)
 	}
 
@@ -940,7 +941,7 @@ func TestWritePGSnapshot_OracleRoundTrip(t *testing.T) {
 			{Name: "amount", Ordinal: 3, IsPK: false, TypeOID: 1700, TypeMod: 100}, // numeric(p,s)
 		},
 	}
-	id, err := WritePGSnapshot(indexDB, rel)
+	id, err := WritePGSnapshot(context.Background(), indexDB, rel)
 	if err != nil {
 		t.Fatalf("WritePGSnapshot: %v", err)
 	}
@@ -1038,7 +1039,7 @@ func TestWritePGSnapshot_concurrentAllocatorSerialized(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			ids[i], errs[i] = WritePGSnapshot(indexDB, &PGRelationSchema{
+			ids[i], errs[i] = WritePGSnapshot(context.Background(), indexDB, &PGRelationSchema{
 				Schema: "pgdb", Table: fmt.Sprintf("pgtable_%d", i),
 				Columns: []PGRelationColumn{{Name: "id", Ordinal: 1, IsPK: true, TypeOID: 23, TypeMod: -1}},
 			})

--- a/internal/metadata/snapshot_id_seq.go
+++ b/internal/metadata/snapshot_id_seq.go
@@ -64,18 +64,25 @@ func ensureSnapshotIDSeqTable(ctx context.Context, db *sql.DB) error {
 	return nil
 }
 
+// snapshotIDExecer is satisfied by both *sql.DB (plain autocommit) and *sql.Tx,
+// so allocateSnapshotID serves WritePGSnapshot (bounded autocommit, no wrapping
+// transaction) and TakeSnapshot (inside its own multi-statement tx) alike.
+type snapshotIDExecer interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+}
+
 // allocateSnapshotID reserves the next snapshot_id by inserting a row into
-// snapshot_id_seq and reading back its AUTO_INCREMENT value, inside the
-// caller's already-open transaction. See DDLSnapshotIDSeq for why this
+// snapshot_id_seq and reading back its AUTO_INCREMENT value, on the caller's
+// db or transaction (see snapshotIDExecer). See DDLSnapshotIDSeq for why this
 // replaces the earlier FOR UPDATE design.
 //
 // res.LastInsertId() is read from the INSERT's own OK packet (not a
 // follow-up `SELECT LAST_INSERT_ID()`), so it is safe under connection
 // pooling regardless of pool size — no dependency on this statement and the
-// read landing on the same pooled connection (tx already pins one for the
-// whole transaction anyway).
-func allocateSnapshotID(ctx context.Context, tx *sql.Tx) (int, error) {
-	res, err := tx.ExecContext(ctx, "INSERT INTO snapshot_id_seq () VALUES ()")
+// read landing on the same pooled connection. That is exactly what lets
+// WritePGSnapshot allocate under plain autocommit with no wrapping transaction.
+func allocateSnapshotID(ctx context.Context, ex snapshotIDExecer) (int, error) {
+	res, err := ex.ExecContext(ctx, "INSERT INTO snapshot_id_seq () VALUES ()")
 	if err != nil {
 		return 0, fmt.Errorf("metadata: allocate snapshot_id: %w", err)
 	}

--- a/internal/metadata/snapshot_id_seq.go
+++ b/internal/metadata/snapshot_id_seq.go
@@ -1,6 +1,7 @@
 package metadata
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 )
@@ -47,9 +48,9 @@ const DDLSnapshotIDSeq = `CREATE TABLE IF NOT EXISTS snapshot_id_seq (
 // without going through EnsureSchema — so allocateSnapshotID's callers
 // self-heal here too, matching TakeSnapshot's existing tolerance for a
 // pre-#758 index missing fk_constraints.
-func ensureSnapshotIDSeqTable(db *sql.DB) error {
+func ensureSnapshotIDSeqTable(ctx context.Context, db *sql.DB) error {
 	var exists bool
-	if err := db.QueryRow(
+	if err := db.QueryRowContext(ctx,
 		"SELECT COUNT(*) > 0 FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'snapshot_id_seq'",
 	).Scan(&exists); err != nil {
 		return fmt.Errorf("metadata: check snapshot_id_seq table: %w", err)
@@ -57,7 +58,7 @@ func ensureSnapshotIDSeqTable(db *sql.DB) error {
 	if exists {
 		return nil
 	}
-	if _, err := db.Exec(DDLSnapshotIDSeq); err != nil {
+	if _, err := db.ExecContext(ctx, DDLSnapshotIDSeq); err != nil {
 		return fmt.Errorf("metadata: create snapshot_id_seq: %w", err)
 	}
 	return nil
@@ -73,8 +74,8 @@ func ensureSnapshotIDSeqTable(db *sql.DB) error {
 // pooling regardless of pool size — no dependency on this statement and the
 // read landing on the same pooled connection (tx already pins one for the
 // whole transaction anyway).
-func allocateSnapshotID(tx *sql.Tx) (int, error) {
-	res, err := tx.Exec("INSERT INTO snapshot_id_seq () VALUES ()")
+func allocateSnapshotID(ctx context.Context, tx *sql.Tx) (int, error) {
+	res, err := tx.ExecContext(ctx, "INSERT INTO snapshot_id_seq () VALUES ()")
 	if err != nil {
 		return 0, fmt.Errorf("metadata: allocate snapshot_id: %w", err)
 	}

--- a/internal/pgstreamrun/checkpoint_timeout_test.go
+++ b/internal/pgstreamrun/checkpoint_timeout_test.go
@@ -1,0 +1,79 @@
+package pgstreamrun
+
+import (
+	"context"
+	"database/sql"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/indexer"
+)
+
+// A mid-statement network stall on the PostgreSQL daemon's checkpoint write must
+// surface as an error within indexer.WriteTimeout, not block on kernel TCP
+// retransmission (~13-16 min) while `watch` shows a healthy stream (#959). This
+// mirrors the MySQL streamrun test: the PG loop reaches the same index over the
+// same driver, so it shares the freeze exposure and must share the deadline. A
+// TCP listener that accepts but never speaks the MySQL protocol reproduces the
+// mid-handshake freeze; saveCheckpointPG's ExecContext deadline must cut it. Must
+// NOT call t.Parallel(): it mutates the shared WriteTimeout global.
+func TestSaveCheckpointPG_boundedByWriteTimeout(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	go func() {
+		var held []net.Conn
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				for _, h := range held {
+					h.Close()
+				}
+				return
+			}
+			held = append(held, c) // hold open, never respond
+		}
+	}()
+
+	prev := indexer.WriteTimeout
+	indexer.WriteTimeout = 750 * time.Millisecond
+	t.Cleanup(func() { indexer.WriteTimeout = prev })
+
+	db, err := sql.Open("mysql", "root:x@tcp("+ln.Addr().String()+")/db?timeout=30s")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	start := time.Now()
+	err = saveCheckpointPG(db, &pgStreamState{}, 0x1A2B3C4)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error from the stalled write")
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("saveCheckpointPG blocked %v — the WriteTimeout deadline is not wired", elapsed)
+	}
+}
+
+// The <=0 guard in One() rejects a non-positive --write-timeout BEFORE opening any
+// connection (#959). The guard sits immediately after the required-field check, so
+// a Config with all five fields present reaches it without touching the network.
+// Mutates the shared WriteTimeout global, so no t.Parallel().
+func TestOne_rejectsNonPositiveWriteTimeout(t *testing.T) {
+	prev := indexer.WriteTimeout
+	indexer.WriteTimeout = -1
+	t.Cleanup(func() { indexer.WriteTimeout = prev })
+
+	err := One(context.Background(), Config{
+		IndexDSN: "x", ReplDSN: "x", QueryDSN: "x", SlotName: "x", Publication: "x",
+	})
+	if err == nil || !strings.Contains(err.Error(), "invalid --write-timeout") {
+		t.Fatalf("want an 'invalid --write-timeout' rejection before connecting, got %v", err)
+	}
+}

--- a/internal/pgstreamrun/pgstreamrun.go
+++ b/internal/pgstreamrun/pgstreamrun.go
@@ -83,6 +83,11 @@ func One(ctx context.Context, cfg Config) error {
 	if cfg.IndexDSN == "" || cfg.ReplDSN == "" || cfg.QueryDSN == "" || cfg.SlotName == "" || cfg.Publication == "" {
 		return fmt.Errorf("pgstreamrun: One requires IndexDSN, ReplDSN, QueryDSN, SlotName, and Publication")
 	}
+	// A non-positive --write-timeout would make every index write's
+	// context.WithTimeout fire immediately (#959).
+	if indexer.WriteTimeout <= 0 {
+		return fmt.Errorf("pgstreamrun: invalid --write-timeout %s: must be a positive duration", indexer.WriteTimeout)
+	}
 	logger := cfg.Logger
 	if logger == nil {
 		logger = slog.Default()
@@ -290,7 +295,10 @@ func buildProbeErrorJSON(probeErr string, checkedAt time.Time) ([]byte, error) {
 // a real checkpoint survives this write). Best-effort: a failed write is logged, never
 // fatal to the stream.
 func saveSourceHealth(db *sql.DB, serverID uint32, healthJSON []byte, logger *slog.Logger) {
-	_, err := db.Exec(`
+	// #959: bound the health write so a stalled index link cannot wedge the poll loop.
+	ctx, cancel := context.WithTimeout(context.Background(), indexer.WriteTimeout)
+	defer cancel()
+	_, err := db.ExecContext(ctx, `
 		INSERT INTO stream_state (id, mode, flavor, server_id, last_checkpoint, source_health)
 		VALUES (1, 'gtid', ?, ?, UTC_TIMESTAMP(), ?)
 		ON DUPLICATE KEY UPDATE
@@ -468,7 +476,9 @@ func streamLoopPG(
 				// already-persisted snapshot_ids — per-row schema_version makes a mixed
 				// batch correct). A crash before the next checkpoint just re-delivers and
 				// re-snapshots (a benign orphan id).
-				id, werr := metadata.WritePGSnapshot(indexDB, ev.Relation)
+				snapCtx, snapCancel := context.WithTimeout(context.Background(), indexer.WriteTimeout)
+				id, werr := metadata.WritePGSnapshot(snapCtx, indexDB, ev.Relation)
+				snapCancel()
 				if werr != nil {
 					return fmt.Errorf("pgstreamrun: persist schema snapshot for %s.%s: %w", ev.Schema, ev.Table, werr)
 				}
@@ -523,7 +533,11 @@ func saveCheckpointPG(db *sql.DB, state *pgStreamState, commitLSN uint64) error 
 	if state.lastEventTime.Valid {
 		lastEventTime = state.lastEventTime.Time
 	}
-	_, err := db.Exec(`
+	// #959: bound the checkpoint write so a mid-statement stall surfaces as an
+	// error within WriteTimeout instead of freezing the stream on TCP retransmit.
+	ctx, cancel := context.WithTimeout(context.Background(), indexer.WriteTimeout)
+	defer cancel()
+	_, err := db.ExecContext(ctx, `
 		INSERT INTO stream_state
 			(id, mode, binlog_file, binlog_position, gtid_set, flavor,
 			 events_indexed, last_event_time, last_checkpoint, server_id)

--- a/internal/shim/pg_show_tables_integration_test.go
+++ b/internal/shim/pg_show_tables_integration_test.go
@@ -3,6 +3,7 @@
 package shim
 
 import (
+	"context"
 	"io"
 	"log/slog"
 	"slices"
@@ -48,7 +49,7 @@ func TestShowTablesFromVirtual_PGPerTableSnapshots(t *testing.T) {
 	// Three relations arrive on the stream, each becoming its own
 	// snapshot_id (1, 2, 3). "items" is the last one that saw DML.
 	for _, tbl := range []string{"users", "orders", "items"} {
-		if _, err := metadata.WritePGSnapshot(db, pgRelation("public", tbl, "payload")); err != nil {
+		if _, err := metadata.WritePGSnapshot(context.Background(), db, pgRelation("public", tbl, "payload")); err != nil {
 			t.Fatalf("WritePGSnapshot(%s): %v", tbl, err)
 		}
 	}
@@ -85,10 +86,10 @@ func TestColumnOrderFor_PGNonLatestTable(t *testing.T) {
 	testutil.InitIndexTables(t, db)
 
 	// users is snapshot 1; orders (snapshot 2) is the latest.
-	if _, err := metadata.WritePGSnapshot(db, pgRelation("public", "users", "zz_email", "aa_name")); err != nil {
+	if _, err := metadata.WritePGSnapshot(context.Background(), db, pgRelation("public", "users", "zz_email", "aa_name")); err != nil {
 		t.Fatalf("WritePGSnapshot(users): %v", err)
 	}
-	if _, err := metadata.WritePGSnapshot(db, pgRelation("public", "orders", "total")); err != nil {
+	if _, err := metadata.WritePGSnapshot(context.Background(), db, pgRelation("public", "orders", "total")); err != nil {
 		t.Fatalf("WritePGSnapshot(orders): %v", err)
 	}
 

--- a/internal/streamrun/checkpoint_timeout_test.go
+++ b/internal/streamrun/checkpoint_timeout_test.go
@@ -1,0 +1,78 @@
+package streamrun
+
+import (
+	"context"
+	"database/sql"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/indexer"
+)
+
+// A mid-statement network stall must surface as an error within
+// indexer.WriteTimeout, not block on kernel TCP retransmission (~13-16 min)
+// while `watch` sees a healthy daemon (#959). A TCP listener that accepts but
+// never speaks the MySQL protocol reproduces the mid-handshake freeze; the
+// ExecContext deadline in saveCheckpoint must cut it short.
+func TestSaveCheckpoint_boundedByWriteTimeout(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	go func() {
+		var held []net.Conn
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				for _, h := range held {
+					h.Close()
+				}
+				return
+			}
+			held = append(held, c) // hold open, never respond
+		}
+	}()
+
+	prev := indexer.WriteTimeout
+	indexer.WriteTimeout = 750 * time.Millisecond
+	t.Cleanup(func() { indexer.WriteTimeout = prev })
+
+	// Connect timeout is generous so it does not preempt the ExecContext deadline
+	// under test — the dial succeeds (listener accepts); the stall is the read.
+	db, err := sql.Open("mysql", "root:x@tcp("+ln.Addr().String()+")/db?timeout=30s")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	start := time.Now()
+	err = saveCheckpoint(db, &streamState{mode: "gtid"})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error from the stalled write")
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("saveCheckpoint blocked %v — the WriteTimeout deadline is not wired", elapsed)
+	}
+}
+
+// The <=0 guard in One() rejects a non-positive --write-timeout BEFORE opening any
+// connection: a zero/negative deadline would make every index write's
+// context.WithTimeout fire immediately, turning each write into an instant failure
+// rather than bounding a genuine stall (#959). Mutates the shared WriteTimeout
+// global, so no t.Parallel(). Format+GapTimeout are the only checks that precede
+// the guard, so a minimal Config reaches it without touching the network.
+func TestOne_rejectsNonPositiveWriteTimeout(t *testing.T) {
+	prev := indexer.WriteTimeout
+	indexer.WriteTimeout = 0
+	t.Cleanup(func() { indexer.WriteTimeout = prev })
+
+	err := One(context.Background(), Config{Format: "text", GapTimeout: 30})
+	if err == nil || !strings.Contains(err.Error(), "invalid --write-timeout") {
+		t.Fatalf("want an 'invalid --write-timeout' rejection before connecting, got %v", err)
+	}
+}

--- a/internal/streamrun/streamrun.go
+++ b/internal/streamrun/streamrun.go
@@ -141,7 +141,12 @@ func saveCheckpoint(db *sql.DB, state *streamState) error {
 	// #775: in position mode this persists the last safe boundary, not the
 	// per-event offset (see checkpointPosition).
 	file, pos := checkpointPosition(state)
-	_, err = db.Exec(`
+	// #959: bound the checkpoint write with a deadline (see indexer.WriteTimeout)
+	// so a mid-statement network stall fails fast instead of freezing the daemon
+	// on kernel TCP retransmission — invisible to the supervisor.
+	ctx, cancel := context.WithTimeout(context.Background(), indexer.WriteTimeout)
+	defer cancel()
+	_, err = db.ExecContext(ctx, `
 		INSERT INTO stream_state
 		    (id, mode, binlog_file, binlog_position, gtid_set, flavor,
 		     events_indexed, last_event_time, last_checkpoint, server_id, bintrail_id)
@@ -1519,6 +1524,12 @@ func One(ctx context.Context, cfg Config) error {
 	// error whose recovery hint (`--reset`) discards the saved checkpoint.
 	if cfg.GapTimeout <= 0 {
 		return fmt.Errorf("invalid --gap-timeout %d: must be a positive number of seconds", cfg.GapTimeout)
+	}
+	// A non-positive --write-timeout would make every index write's
+	// context.WithTimeout fire immediately, turning each write into an instant
+	// failure instead of bounding a genuine stall (#959).
+	if indexer.WriteTimeout <= 0 {
+		return fmt.Errorf("invalid --write-timeout %s: must be a positive duration", indexer.WriteTimeout)
 	}
 	// Fail fast on an unwired dependency (named field) before opening any
 	// connection, rather than nil-panicking on first use further down.


### PR DESCRIPTION
closes #948
closes #959

## Summary

Two independent index-write robustness fixes for the streaming daemon.

### #959 — a stalled index write froze the daemon invisibly

`config.Connect` set only a connect timeout, never a read/write deadline, so a mid-statement network stall on the index link blocked on kernel TCP retransmission (~13–16 min) while `watch` still reported a healthy stream. Every index-side write on the streaming hot path is now bounded by a per-statement context deadline — `indexer.WriteTimeout`, tunable via a new `--write-timeout` flag (`DefaultWriteTimeout = 3m`):

- **batch INSERT** — plus a `DeadlineExceeded` diagnostic hint so a large-batch-over-slow-link false-fire points at the knob (raise `--write-timeout` / lower `--batch-size`) instead of a phantom network fault.
- **statement-digest phase** — one shared deadline bounds the combined query *and* any per-text fallback together (best-effort `query_hash` enrichment; it breaks on timeout and returns what it has, letting the INSERT be the loud terminator), rather than K+1 independent deadlines that could compound to (K+2)×timeout.
- **InsertSchemaChange** (DDL marker write).
- **PostgreSQL daemon** — `saveCheckpointPG`, `saveSourceHealth`, and `WritePGSnapshot`. The snapshot path threads the ctx through `BeginTx` **and** `allocateSnapshotID` / `ensureSnapshotIDSeqTable`: `BeginTx(ctx)` alone does *not* bound a context-less `tx.Exec` — the statement holds the driver-connection lock, so the rollback-on-cancel goroutine parks behind it until TCP gives up.

A `<= 0` guard in `streamrun.One` / `pgstreamrun.One` rejects a non-positive timeout before opening any connection. The flag is wired into `stream`, `up`, `watch` (console), and `bintrail-pg stream`, all binding the same global. The digest phase keeps its own deadline separate from the INSERT's so a slow-but-healthy digest can never eat the durable write's budget.

The PG-daemon durability invariant is preserved: a timed-out `saveCheckpointPG` returns its error and stops the loop *before* `AckCommitted`, so WAL is never released past an un-checkpointed position.

### #948 — capacity check read falsely green when disk-free was unmeasurable

`doctor`'s disk-capacity check returned `StatusPass` on the `!freeKnown` branch (the index runs on a separate host/container, so the volume can't be measured locally) — reading green when its FAIL/WARN thresholds could never fire. It now returns `StatusSkip`: an honest "not measured", exit-neutral (`Report.Err`/`ErrExcluding` gate only on `Failed`), and it still carries the size projection. A genuinely full *local* disk still measures and FAILs.

## Test plan

- [x] `go build ./...` + `go vet -tags integration ./...` (compiles every integration test file module-wide)
- [x] `go test ./... -count=1` — full unit suite green
- [x] Integration (real MySQL 8.0 + PostgreSQL 16.14, serialized): `internal/indexer`, `internal/metadata`, `internal/pgstreamrun`, `internal/shim` — 689/689 pass, 0 skip, no regression to normal writes
- New behavioral tests: hung-TCP-listener bounds `InsertBatch` / `saveCheckpoint` / `saveCheckpointPG` in <5s (vs the ~13–16 min freeze); `TestOne_rejectsNonPositiveWriteTimeout` (both packages); `InsertBatch` asserts the `DeadlineExceeded` hint; `capacity` asserts `StatusSkip` on an unmeasurable volume at the unit and integration levels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
