### PR TITLE
bintrail-pg: index-rotation plane (built-in loop + rotate/archive commands) (#951)

### DIFF
--- a/cliapp/root.go
+++ b/cliapp/root.go
@@ -49,6 +49,11 @@ func init() {
 	// Register the source-agnostic read commands that have moved to internal/cli
 	// (#529) so a future bintrail-pg can register the same set. Today: status.
 	cli.AddReadCommands(rootCmd)
+	// Index-side maintenance (rotate, archive reconcile) — source-agnostic, so
+	// bintrail-pg registers the same set (#951). Previously these lived in this
+	// package and self-registered via init(); they moved to internal/cli so both
+	// binaries expose them.
+	cli.AddMaintenanceCommands(rootCmd)
 	// Forensics commands are MySQL-family-only (performance_schema, audit
 	// plugins), so they register here — like doctor — and NOT via
 	// AddReadCommands, which bintrail-pg shares (#706).

--- a/cliapp/upload.go
+++ b/cliapp/upload.go
@@ -6,15 +6,14 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 
+	"github.com/dbtrail/dbtrail/internal/archive"
 	"github.com/dbtrail/dbtrail/internal/cliutil"
 	"github.com/dbtrail/dbtrail/internal/config"
-	"github.com/dbtrail/dbtrail/internal/indexer"
 	"github.com/dbtrail/dbtrail/internal/storage"
 )
 
@@ -73,43 +72,6 @@ func init() {
 	bindCommandEnv(uploadCmd)
 
 	rootCmd.AddCommand(uploadCmd)
-}
-
-// archivePathRe matches the Hive-partitioned archive path pattern produced by
-// rotate --archive-dir: bintrail_id=<uuid>/event_date=YYYY-MM-DD/event_hour=HH/events.parquet
-// archivePathRe accepts ANY non-empty id segment — exactly what the writer
-// produces: rotate's --bintrail-id takes an arbitrary string verbatim, and
-// the discovery side (extractBasePath, buildGlob) matches on the
-// `bintrail_id=` marker alone. A scanner stricter than the writer (this
-// regex used to demand a 36-char lowercase UUID) silently skipped every
-// file under an uppercase or human-named id — harmless for upload's
-// UPDATE-only flow, but blinding for `archive reconcile`, where a blind
-// scan plus --prune would wipe the registry of healthy archives (#392
-// review).
-var archivePathRe = regexp.MustCompile(
-	`bintrail_id=([^/]+)/event_date=(\d{4}-\d{2}-\d{2})/event_hour=(0[0-9]|1[0-9]|2[0-3])/[^/]+\.parquet$`,
-)
-
-// parseArchivePath extracts the bintrail_id and partition name from a
-// Hive-partitioned archive file path. Returns empty strings if the path
-// does not match the expected pattern.
-func parseArchivePath(path string) (bintrailID, partName string) {
-	// Normalise to forward slashes so the regex works on Windows too.
-	m := archivePathRe.FindStringSubmatch(filepath.ToSlash(path))
-	if m == nil {
-		return "", ""
-	}
-	id := m[1]
-	date := m[2]
-	hour := m[3]
-	t, err := time.Parse("2006-01-02", date)
-	if err != nil {
-		return "", ""
-	}
-	h := 0
-	fmt.Sscanf(hour, "%d", &h)
-	t = t.Add(time.Duration(h) * time.Hour)
-	return id, indexer.PartitionName(t)
 }
 
 func runUpload(cmd *cobra.Command, args []string) error {
@@ -185,7 +147,7 @@ func runUpload(cmd *cobra.Command, args []string) error {
 		}
 
 		if uplIndexDSN != "" {
-			bintrailID, partName := parseArchivePath(path)
+			bintrailID, partName := archive.ParseArchivePath(path)
 			if bintrailID != "" && partName != "" {
 				dbUpdates = append(dbUpdates, uploadedFile{
 					s3Key:      key,

--- a/cliapp/upload_test.go
+++ b/cliapp/upload_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/archive"
 )
 
 // ─── cobra command wiring ─────────────────────────────────────────────────────
@@ -210,7 +212,7 @@ func TestParseArchivePath(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			gotID, gotPart := parseArchivePath(tc.path)
+			gotID, gotPart := archive.ParseArchivePath(tc.path)
 			if gotID != tc.wantID {
 				t.Errorf("bintrailID = %q, want %q", gotID, tc.wantID)
 			}

--- a/cmd/bintrail-pg/main.go
+++ b/cmd/bintrail-pg/main.go
@@ -66,6 +66,12 @@ func init() {
 	// shared verbatim with the core binary. The PostgreSQL capture command
 	// (stream) is registered in stream.go's init().
 	cli.AddReadCommands(rootCmd)
+	// The index-side maintenance plane (rotate, archive reconcile) — also
+	// source-agnostic, so a PostgreSQL-only install can bound its index growth
+	// with `bintrail-pg rotate` instead of needing the core MySQL binary against
+	// the same index DSN (#951). `bintrail-pg stream` additionally runs the
+	// built-in rotation loop for safe-by-default retention.
+	cli.AddMaintenanceCommands(rootCmd)
 }
 
 func main() {

--- a/cmd/bintrail-pg/stream.go
+++ b/cmd/bintrail-pg/stream.go
@@ -16,6 +16,7 @@ import (
 	"github.com/dbtrail/dbtrail/internal/cli"
 	"github.com/dbtrail/dbtrail/internal/indexer"
 	"github.com/dbtrail/dbtrail/internal/pgstreamrun"
+	"github.com/dbtrail/dbtrail/internal/rotation"
 )
 
 var streamCmd = &cobra.Command{
@@ -70,6 +71,10 @@ var (
 	pgBatchSize   int
 	pgCheckpoint  int
 	pgPartitions  int
+
+	pgRotateRetain    string
+	pgRotateInterval  string
+	pgRotateAddFuture int
 )
 
 func init() {
@@ -86,6 +91,14 @@ func init() {
 	streamCmd.Flags().DurationVar(&indexer.WriteTimeout, "write-timeout", indexer.DefaultWriteTimeout, "Deadline for each index write (batch INSERT, checkpoint, schema snapshot). A mid-statement network stall surfaces as an error within this window instead of freezing the stream on kernel TCP retransmission (~13-16 min). Raise for very large batches over a slow link")
 	streamCmd.Flags().IntVar(&pgCheckpoint, "checkpoint", 5, "Checkpoint interval in seconds")
 	streamCmd.Flags().IntVar(&pgPartitions, "partitions", 48, "binlog_events partitions for the one-time index bootstrap")
+	// Built-in index rotation (mirrors the core `up`/`watch` daemons). Because
+	// bintrail-pg has no `up` command, `stream` is a PostgreSQL install's only
+	// long-running daemon and must keep the index bounded itself (#951). Names,
+	// defaults, and env vars (BINTRAIL_ROTATE_*, already in cli.EnvBindings) match
+	// `up` so operators tune rotation identically across binaries.
+	streamCmd.Flags().StringVar(&pgRotateRetain, "rotate-retain", "30d", "Built-in rotation: drop index partitions older than this (Nd/Nh; \"off\" disables)")
+	streamCmd.Flags().StringVar(&pgRotateInterval, "rotate-interval", "1h", "Built-in rotation: how often to run a rotation cycle")
+	streamCmd.Flags().IntVar(&pgRotateAddFuture, "rotate-add-future", 3, "Built-in rotation: keep at least N future hourly partitions ready")
 	// index-dsn and server-id live in cli.EnvBindings, so BindCommandEnv both
 	// loads the env file (.bintrail.env) AND sets these flags from
 	// BINTRAIL_INDEX_DSN/BINTRAIL_SERVER_ID — which marks them Changed, so
@@ -170,6 +183,19 @@ func runPGStream(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Parse the built-in rotation settings before opening any connection so a
+	// typo fails fast. `explicit` (was --rotate-retain set on the CLI or via
+	// BINTRAIL_ROTATE_RETAIN?) drives the upgrade guard: an existing PG-beta
+	// index that predates built-in rotation has piled everything into p_future,
+	// and when this version first starts rotating at the 30d default the guard is
+	// the only thing preventing a surprise drop of deep history — it holds drops
+	// (still tops up future partitions) until the operator chooses a retention.
+	rotSettings, err := rotation.ParseSettings(pgRotateRetain, pgRotateInterval, pgRotateAddFuture,
+		cmd.Flags().Changed("rotate-retain"))
+	if err != nil {
+		return err
+	}
+
 	ctx, cancel := context.WithCancel(cmd.Context())
 	defer cancel()
 
@@ -186,6 +212,23 @@ func runPGStream(cmd *cobra.Command, args []string) error {
 		case <-ctx.Done():
 		}
 	}()
+
+	// Built-in index rotation on the daemon lifecycle. Started on the same
+	// signal-cancellable ctx as the stream (so SIGINT/SIGTERM stops both) right
+	// before the blocking capture call. The loop only touches the MySQL index
+	// (source-agnostic), reads its settings once, and never fails the stream —
+	// rotation failures are logged and self-heal on the next tick. It is
+	// drop-only: a single static target with no per-source S3 archive config,
+	// mirroring core `up`; the standalone `bintrail-pg rotate --archive-s3`
+	// covers the archive-then-drop path.
+	//
+	// On a brand-new install the first cycle can briefly race pgstreamrun.One's
+	// index bootstrap (table not yet created); that cycle just logs a transient
+	// failure and self-heals on the next tick, well within the 48 hours of
+	// partitions the bootstrap lays down.
+	rotation.StartLoop(ctx,
+		func() rotation.Settings { return rotSettings },
+		func() []rotation.RotateTarget { return []rotation.RotateTarget{{DSN: cfg.IndexDSN}} })
 
 	return pgstreamrun.One(ctx, cfg)
 }

--- a/cmd/bintrail-pg/stream_test.go
+++ b/cmd/bintrail-pg/stream_test.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/jackc/pglogrepl"
+
+	"github.com/dbtrail/dbtrail/internal/rotation"
 )
 
 // resetPGFlags restores the stream command's package-global flag vars to their
@@ -195,6 +198,9 @@ func TestPGStreamCmd_defaults(t *testing.T) {
 		{"batch-size", "1000"},
 		{"checkpoint", "5"},
 		{"partitions", "48"},
+		{"rotate-retain", "30d"},
+		{"rotate-interval", "1h"},
+		{"rotate-add-future", "3"},
 	}
 	for _, tc := range cases {
 		f := streamCmd.Flag(tc.flag)
@@ -205,6 +211,50 @@ func TestPGStreamCmd_defaults(t *testing.T) {
 		if f.DefValue != tc.want {
 			t.Errorf("flag --%s: expected default %q, got %q", tc.flag, tc.want, f.DefValue)
 		}
+	}
+}
+
+// TestPGStreamCmd_rotationDefaultsEnableRetention pins the load-bearing #951
+// contract: the registered --rotate-* flag defaults must parse into an ENABLED
+// 30d rotation, so a fresh `bintrail-pg stream` bounds its own index without any
+// operator action (a PG install has no `up` command — stream is its only
+// daemon). explicit=false (running on the built-in default, not operator-set)
+// arms the upgrade guard that protects a pre-existing index's deep history.
+func TestPGStreamCmd_rotationDefaultsEnableRetention(t *testing.T) {
+	retain := streamCmd.Flag("rotate-retain").DefValue
+	interval := streamCmd.Flag("rotate-interval").DefValue
+	addFuture, err := strconv.Atoi(streamCmd.Flag("rotate-add-future").DefValue)
+	if err != nil {
+		t.Fatalf("rotate-add-future default not an int: %v", err)
+	}
+	s, err := rotation.ParseSettings(retain, interval, addFuture, false)
+	if err != nil {
+		t.Fatalf("the registered rotation defaults must parse: %v", err)
+	}
+	if !s.Enabled {
+		t.Error("built-in rotation must be enabled by default (safe-by-default retention, #951)")
+	}
+	if s.Retain != 30*24*time.Hour {
+		t.Errorf("default retain = %v, want 720h (30d)", s.Retain)
+	}
+	if s.AddFuture != 3 {
+		t.Errorf("default add-future = %d, want 3", s.AddFuture)
+	}
+	if s.Explicit {
+		t.Error("Explicit must be false for the built-in default so the upgrade guard stays armed")
+	}
+}
+
+// TestPGStreamCmd_rotationOffDisables confirms `--rotate-retain off` fully
+// disables the built-in loop, the documented opt-out for operators who run
+// retention separately (e.g. a standalone `bintrail-pg rotate` daemon).
+func TestPGStreamCmd_rotationOffDisables(t *testing.T) {
+	s, err := rotation.ParseSettings("off", "1h", 3, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.Enabled {
+		t.Error(`--rotate-retain "off" must disable the built-in rotation loop`)
 	}
 }
 

--- a/cmd/bintrail-pg/stream_test.go
+++ b/cmd/bintrail-pg/stream_test.go
@@ -258,6 +258,60 @@ func TestPGStreamCmd_rotationOffDisables(t *testing.T) {
 	}
 }
 
+// TestMaintenanceCommandsRegisteredOnRoot pins the #951 contract on the REAL
+// bintrail-pg root: a PostgreSQL-only install must expose both `rotate` and
+// `archive` so it can bound its index without the core MySQL binary. This walks
+// the actual rootCmd (populated by main.go's init → cli.AddMaintenanceCommands),
+// not a throwaway command, so dropping the registration call — or one of the two
+// commands from it — fails here.
+func TestMaintenanceCommandsRegisteredOnRoot(t *testing.T) {
+	got := map[string]bool{}
+	for _, c := range rootCmd.Commands() {
+		got[c.Name()] = true
+	}
+	for _, want := range []string{"rotate", "archive"} {
+		if !got[want] {
+			t.Errorf("bintrail-pg root is missing the %q command (cli.AddMaintenanceCommands not wired?)", want)
+		}
+	}
+}
+
+// TestPGStreamCmd_rotateRetainExplicitWiring pins the flag `runPGStream` reads to
+// arm the upgrade guard. Setting --rotate-retain on streamCmd must flip
+// Changed("rotate-retain") to true, which is exactly the `explicit` argument
+// passed to rotation.ParseSettings — a wrong flag name there would engage the
+// guard even when the operator DID choose a retention, silently refusing drops.
+// Mirrors cliapp/up_rotation_test.go's TestRunUp_explicitRetentionWiring.
+func TestPGStreamCmd_rotateRetainExplicitWiring(t *testing.T) {
+	flag := streamCmd.Flags().Lookup("rotate-retain")
+	if flag == nil {
+		t.Fatal("--rotate-retain not registered on streamCmd")
+	}
+	savedChanged, savedValue := flag.Changed, flag.Value.String()
+	t.Cleanup(func() {
+		flag.Changed = savedChanged
+		_ = flag.Value.Set(savedValue)
+	})
+
+	// Never set → not explicit (guard armed, protects deep history).
+	flag.Changed = false
+	if s, _ := rotation.ParseSettings(flag.Value.String(), "1h", 3, streamCmd.Flags().Changed("rotate-retain")); s.Explicit {
+		t.Error("Explicit must be false when --rotate-retain was never set")
+	}
+
+	// Set through the flag set, exactly like CLI/env (BindCommandEnv) would.
+	if err := streamCmd.Flags().Set("rotate-retain", "7d"); err != nil {
+		t.Fatalf("Set(rotate-retain): %v", err)
+	}
+	s, err := rotation.ParseSettings(flag.Value.String(), "1h", 3, streamCmd.Flags().Changed("rotate-retain"))
+	if err != nil {
+		t.Fatalf("ParseSettings: %v", err)
+	}
+	if !s.Explicit {
+		t.Error(`Explicit must be true once --rotate-retain is set — the Changed("rotate-retain") call site is broken`)
+	}
+}
+
 // setPGRequired fills the PG-specific required settings so a test can exercise
 // downstream parsing (e.g. --start-lsn) without tripping the missing-settings
 // guard. Callers must resetPGFlags() first.

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -260,6 +260,9 @@ a final checkpoint).
 | `--batch-size` | no | Events per batch insert (default 1000). |
 | `--checkpoint` | no | Checkpoint interval in seconds (default 5). |
 | `--partitions` | no | Index partitions for the one-time bootstrap (default 48). |
+| `--rotate-retain` | no | Built-in rotation: drop index partitions older than this (`Nd`/`Nh`; `off` disables). Default `30d` (env `BINTRAIL_ROTATE_RETAIN`). |
+| `--rotate-interval` | no | Built-in rotation: how often a rotation cycle runs (default `1h`, env `BINTRAIL_ROTATE_INTERVAL`). |
+| `--rotate-add-future` | no | Built-in rotation: keep at least N future hourly partitions ready (default `3`, env `BINTRAIL_ROTATE_ADD_FUTURE`). |
 
 Every flag has a `BINTRAIL_*` environment equivalent and can be set in a
 `.bintrail.env` file (see [the env-file convention](install.md)).
@@ -294,6 +297,49 @@ Under the hood it is the two-system teardown that otherwise has to be done by ha
 (`SELECT pg_drop_replication_slot('bintrail_shop')` on the source +
 `DELETE FROM stream_state WHERE id = 1` on the index). After a reset, re-seed the
 baseline and re-run `bintrail-pg stream`.
+
+### Index rotation and retention
+
+The index table `binlog_events` is split into **hourly partitions**. New hours
+need new partitions or every event eventually lands in the catch-all `p_future`
+partition, which can never be dropped — so without rotation the index grows until
+the disk fills.
+
+`bintrail-pg stream` runs a **built-in rotation loop** so this is handled for you:
+by default it drops partitions older than **30 days** and keeps a few future
+partitions ready, running one cycle at startup and then every hour. Tune it with
+`--rotate-retain` / `--rotate-interval` / `--rotate-add-future` (or the
+`BINTRAIL_ROTATE_*` env vars), or turn it off with `--rotate-retain off` if you
+prefer to run retention separately.
+
+The built-in loop is **drop-only** — it does not archive partitions to S3 before
+dropping them. For an archive-then-drop retention policy, or for manual/offline
+maintenance, run the standalone command against the same index (it is the same
+index-side command the core `bintrail` binary exposes, now available on
+`bintrail-pg` too):
+
+```bash
+# One-off: drop partitions older than 7 days
+bintrail-pg rotate --index-dsn "$IDX" --retain 7d
+
+# Daemon: archive each expired partition to S3, then drop it
+bintrail-pg rotate --index-dsn "$IDX" --retain 30d --daemon \
+  --archive-dir /var/lib/bintrail/archives --archive-s3 s3://my-bucket/archives/
+
+# Re-sync the archive registry with the files actually on disk / in S3
+bintrail-pg archive reconcile --index-dsn "$IDX" \
+  --archive-dir /var/lib/bintrail/archives --archive-s3 s3://my-bucket/archives/
+```
+
+> **Upgrading an existing PostgreSQL install that predates built-in rotation.**
+> If you ran `bintrail-pg stream` before this feature, its index has no future
+> partitions and everything has piled into `p_future`. No data is lost — the loop
+> refuses to drop deep history until you choose a retention explicitly, and it
+> back-fills the missing partitions — but the first catch-up can be slow because
+> each cycle rewrites the large `p_future`. To catch up in one pass instead, run a
+> standalone rotation with enough headroom before (or alongside) the stream, e.g.
+> `bintrail-pg rotate --index-dsn "$IDX" --add-future <hours-since-first-event>`,
+> then set `--rotate-retain` explicitly (e.g. `30d`) so the loop begins pruning.
 
 ---
 

--- a/internal/archive/path.go
+++ b/internal/archive/path.go
@@ -1,0 +1,50 @@
+package archive
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/indexer"
+)
+
+// archivePathRe matches the Hive-partitioned archive path pattern produced by
+// rotate --archive-dir: bintrail_id=<uuid>/event_date=YYYY-MM-DD/event_hour=HH/events.parquet
+// archivePathRe accepts ANY non-empty id segment — exactly what the writer
+// produces: rotate's --bintrail-id takes an arbitrary string verbatim, and
+// the discovery side (extractBasePath, buildGlob) matches on the
+// `bintrail_id=` marker alone. A scanner stricter than the writer (this
+// regex used to demand a 36-char lowercase UUID) silently skipped every
+// file under an uppercase or human-named id — harmless for upload's
+// UPDATE-only flow, but blinding for `archive reconcile`, where a blind
+// scan plus --prune would wipe the registry of healthy archives (#392
+// review).
+var archivePathRe = regexp.MustCompile(
+	`bintrail_id=([^/]+)/event_date=(\d{4}-\d{2}-\d{2})/event_hour=(0[0-9]|1[0-9]|2[0-3])/[^/]+\.parquet$`,
+)
+
+// ParseArchivePath extracts the bintrail_id and partition name from a
+// Hive-partitioned archive file path. Returns empty strings if the path
+// does not match the expected pattern. It is the inverse of the writer's
+// Hive layout (rotation.HiveArchivePath) and is shared by the `upload` and
+// `archive reconcile` scanners so both derive the same partition name from a
+// scanned file.
+func ParseArchivePath(path string) (bintrailID, partName string) {
+	// Normalise to forward slashes so the regex works on Windows too.
+	m := archivePathRe.FindStringSubmatch(filepath.ToSlash(path))
+	if m == nil {
+		return "", ""
+	}
+	id := m[1]
+	date := m[2]
+	hour := m[3]
+	t, err := time.Parse("2006-01-02", date)
+	if err != nil {
+		return "", ""
+	}
+	h := 0
+	fmt.Sscanf(hour, "%d", &h)
+	t = t.Add(time.Duration(h) * time.Hour)
+	return id, indexer.PartitionName(t)
+}

--- a/internal/cli/archive.go
+++ b/internal/cli/archive.go
@@ -1,4 +1,4 @@
-package cliapp
+package cli
 
 import (
 	"context"
@@ -97,9 +97,8 @@ func init() {
 	archiveReconcileCmd.Flags().DurationVar(&arcPruneMinAge, "prune-min-age", time.Hour, "Never prune rows whose archived_at is younger than this (concurrent-rotate safety margin)")
 	archiveReconcileCmd.Flags().StringVar(&arcFormat, "format", "text", "Output format: text or json")
 	_ = archiveReconcileCmd.MarkFlagRequired("index-dsn")
-	bindCommandEnv(archiveReconcileCmd)
+	BindCommandEnv(archiveReconcileCmd)
 	archiveCmd.AddCommand(archiveReconcileCmd)
-	rootCmd.AddCommand(archiveCmd)
 }
 
 func runArchiveReconcile(cmd *cobra.Command, args []string) error {
@@ -194,7 +193,7 @@ func scanLocalArchive(root string) ([]archive.ScannedFile, error) {
 		if d.IsDir() || !strings.HasSuffix(d.Name(), ".parquet") {
 			return nil
 		}
-		id, part := parseArchivePath(path)
+		id, part := archive.ParseArchivePath(path)
 		if id == "" {
 			slog.Debug("reconcile: parquet outside the archive layout, ignoring", "path", path)
 			return nil
@@ -299,7 +298,7 @@ func scanS3Archive(ctx context.Context, s3URL, region string, deep bool) ([]arch
 			if obj.Key == nil || !strings.HasSuffix(*obj.Key, ".parquet") {
 				continue
 			}
-			id, part := parseArchivePath(*obj.Key)
+			id, part := archive.ParseArchivePath(*obj.Key)
 			if id == "" {
 				slog.Debug("reconcile: s3 parquet outside the archive layout, ignoring", "key", *obj.Key)
 				continue

--- a/internal/cli/archive_integration_test.go
+++ b/internal/cli/archive_integration_test.go
@@ -1,6 +1,6 @@
 //go:build integration
 
-package cliapp
+package cli
 
 import (
 	"context"
@@ -224,7 +224,7 @@ func TestParseArchivePathRoundTrip(t *testing.T) {
 		if err != nil {
 			t.Fatalf("rotation.HiveArchivePath(%v): %v", h, err)
 		}
-		gotID, gotPart := parseArchivePath(p)
+		gotID, gotPart := archive.ParseArchivePath(p)
 		if gotID != id || gotPart != indexer.PartitionName(h) {
 			t.Errorf("round-trip(%s): got (%s, %s), want (%s, %s)", p, gotID, gotPart, id, indexer.PartitionName(h))
 		}

--- a/internal/cli/archive_test.go
+++ b/internal/cli/archive_test.go
@@ -1,4 +1,4 @@
-package cliapp
+package cli
 
 import (
 	"bytes"

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -24,6 +24,21 @@ func AddReadCommands(root *cobra.Command) {
 	root.AddCommand(shimCmd)
 }
 
+// AddMaintenanceCommands registers the index-side maintenance commands: rotate
+// and archive reconcile. Both operate purely on the shared MySQL index
+// (partition rotation, archive_state reconciliation) and are source-agnostic,
+// so every capture binary registers them — the core bintrail AND bintrail-pg
+// (#951). Without this, a PostgreSQL-only install has no way to bound index
+// growth: its named partitions fill within ~2 days and every later event piles
+// into p_future unbounded, the disk-full mode #406/#420 closed for MySQL. The
+// long-running daemons (up, watch, and now bintrail-pg stream) additionally run
+// the built-in rotation loop; these standalone commands cover offline/manual
+// maintenance and the archive-then-drop retention path the loop does not.
+func AddMaintenanceCommands(root *cobra.Command) {
+	root.AddCommand(rotateCmd)
+	root.AddCommand(archiveCmd)
+}
+
 // AddForensicsCommands registers the forensics read commands: who-changed,
 // user-activity, and connection-history (#706).
 //

--- a/internal/cli/rotate.go
+++ b/internal/cli/rotate.go
@@ -1,4 +1,4 @@
-package cliapp
+package cli
 
 import (
 	"context"
@@ -86,9 +86,7 @@ func init() {
 	rotateCmd.Flags().StringVar(&rotFormat, "format", "text", "Output format: text or json")
 	rotateCmd.Flags().BoolVar(&rotRetry, "retry", false, "Skip archiving partitions whose Parquet file already exists and S3 uploads that already succeeded")
 	_ = rotateCmd.MarkFlagRequired("index-dsn")
-	bindCommandEnv(rotateCmd)
-
-	rootCmd.AddCommand(rotateCmd)
+	BindCommandEnv(rotateCmd)
 }
 
 // errNoArchiveBintrailID is the precondition error from resolveArchiveBintrailID

--- a/internal/cli/rotate_test.go
+++ b/internal/cli/rotate_test.go
@@ -13,17 +13,20 @@ import (
 // ─── cobra command wiring ────────────────────────────────────────────────────
 
 func TestRotateCmd_registered(t *testing.T) {
+	// AddMaintenanceCommands must register BOTH rotate and archive — the #951
+	// contract is that a PostgreSQL-only install gains both `rotate` AND
+	// `archive reconcile`. Asserting only rotate would let a dropped
+	// archiveCmd registration pass CI while reconcile silently vanishes.
 	root := &cobra.Command{Use: "test"}
 	AddMaintenanceCommands(root)
-	found := false
+	got := map[string]bool{}
 	for _, cmd := range root.Commands() {
-		if cmd.Use == "rotate" {
-			found = true
-			break
-		}
+		got[cmd.Use] = true
 	}
-	if !found {
-		t.Error("expected 'rotate' command to be registered by AddMaintenanceCommands")
+	for _, want := range []string{"rotate", "archive"} {
+		if !got[want] {
+			t.Errorf("expected %q command to be registered by AddMaintenanceCommands", want)
+		}
 	}
 }
 

--- a/internal/cli/rotate_test.go
+++ b/internal/cli/rotate_test.go
@@ -1,4 +1,4 @@
-package cliapp
+package cli
 
 import (
 	"context"
@@ -7,20 +7,23 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/spf13/cobra"
 )
 
 // ─── cobra command wiring ────────────────────────────────────────────────────
 
 func TestRotateCmd_registered(t *testing.T) {
+	root := &cobra.Command{Use: "test"}
+	AddMaintenanceCommands(root)
 	found := false
-	for _, cmd := range rootCmd.Commands() {
+	for _, cmd := range root.Commands() {
 		if cmd.Use == "rotate" {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Error("expected 'rotate' command to be registered under rootCmd")
+		t.Error("expected 'rotate' command to be registered by AddMaintenanceCommands")
 	}
 }
 


### PR DESCRIPTION
closes #951

## Summary
A PostgreSQL-only install (`bintrail-pg`) had no index-rotation plane: it registered only the read plane, `rotate`/`archive reconcile` lived in `cliapp` (core-only), and `pgstreamrun` did the one-time 48-partition bootstrap with zero maintenance. After ~2 days every event piled into `p_future` (which rotate can never drop) → unbounded index growth, the disk-full mode #406/#420 closed for MySQL.

This does **both** fixes the issue proposed (they were offered as alternatives):

- **Move `rotate` + `archive reconcile` into `internal/cli`** behind a new `cli.AddMaintenanceCommands(root)`, registered on **both** `bintrail` (`cliapp/root.go`) and `bintrail-pg` (`cmd/bintrail-pg/main.go`). These commands are index-side and source-agnostic. PG operators can now run `bintrail-pg rotate` / `bintrail-pg archive reconcile` (incl. the archive-then-drop `--archive-s3` path) without the core MySQL binary.
- **Share `parseArchivePath`** as exported `archive.ParseArchivePath` (`internal/archive/path.go`), used by both `cliapp/upload.go` and the moved `internal/cli/archive.go` (no duplication; no import cycle — `indexer` does not import `archive`).
- **Wire the built-in `rotation.StartLoop` into `bintrail-pg stream`** (its only long-running daemon — PG has no `up`), safe-by-default `30d`, mirroring core `up`. `explicit = cmd.Flags().Changed("rotate-retain")` arms the upgrade guard so an existing piled-up index keeps its deep history until a retention is chosen explicitly. Drop-only single target, matching core `up`.
- **docs/postgres.md**: rotation/retention section, flags, the `off` opt-out, the standalone-command archive path, and an upgrade caveat for existing beta installs with an accumulated `p_future`.

## Design notes
- `rotation.StartLoop` is reused verbatim — it only touches the MySQL index, stops on ctx-cancel, and never fails the stream (failures logged, unhealthy-streak escalation).
- The loop's first cycle can briefly race the index bootstrap on a fresh install; that cycle logs a transient failure and self-heals (48h of bootstrap runway). Documented in-code.

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] `go vet -tags integration ./...` clean (moved integration test compiles)
- [x] Full build (`go build ./...`) incl. `bintrail-pg`
- New tests: `--rotate-*` flag defaults; registered defaults parse into an enabled 30d rotation with the upgrade guard armed; `off` disables; `AddMaintenanceCommands` registers `rotate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
