### PR TITLE
console(pg): PostgreSQL control-plane parity — monitor / baseline / verify (#1018)

### DIFF
--- a/cmd/bintrail-console/baseline.go
+++ b/cmd/bintrail-console/baseline.go
@@ -12,8 +12,10 @@ import (
 	"time"
 
 	"github.com/dbtrail/dbtrail/internal/baseline"
+	"github.com/dbtrail/dbtrail/internal/cliutil"
 	"github.com/dbtrail/dbtrail/internal/config"
 	"github.com/dbtrail/dbtrail/internal/console"
+	"github.com/dbtrail/dbtrail/internal/pgbaseline"
 )
 
 // baselineSupervisor implements console.BaselineController by running the
@@ -96,6 +98,9 @@ func (s *baselineSupervisor) run(req console.BaselineRequest) {
 // uploaded; for an S3 destination it is staged under a fresh temp dir, uploaded,
 // and the staging removed (so a re-run never re-uploads an old snapshot).
 func (s *baselineSupervisor) execute(req console.BaselineRequest) (baseline.Stats, int, error) {
+	if req.Flavor == console.FlavorPostgres {
+		return s.executePG(req)
+	}
 	if err := os.MkdirAll(s.stagingDir, 0o755); err != nil {
 		return baseline.Stats{}, 0, fmt.Errorf("create staging dir: %w", err)
 	}
@@ -147,6 +152,71 @@ func (s *baselineSupervisor) execute(req console.BaselineRequest) (baseline.Stat
 		}
 	}
 	return stats, uploaded, nil
+}
+
+// executePG produces a PostgreSQL baseline in-process via internal/pgbaseline —
+// COPY straight to Parquet, anchored at the slot's consistent-point LSN. No
+// mydumper subprocess and no #768 timestamp skew: pgbaseline self-stamps the
+// snapshot time from the database's own now(). Destination handling mirrors
+// execute(): a local dir is written persistently; S3-only stages in a temp dir,
+// uploads via the same source-agnostic baseline.Upload, and discards the staging.
+func (s *baselineSupervisor) executePG(req console.BaselineRequest) (baseline.Stats, int, error) {
+	if err := os.MkdirAll(s.stagingDir, 0o755); err != nil {
+		return baseline.Stats{}, 0, fmt.Errorf("create staging dir: %w", err)
+	}
+	outputDir := req.LocalDir
+	if outputDir == "" { // S3-only: stage then upload, discard staging
+		var err error
+		outputDir, err = os.MkdirTemp(s.stagingDir, "pgbaseline-")
+		if err != nil {
+			return baseline.Stats{}, 0, fmt.Errorf("create baseline staging dir: %w", err)
+		}
+		defer os.RemoveAll(outputDir)
+	}
+
+	cfg, err := pgBaselineConfig(req, outputDir)
+	if err != nil {
+		return baseline.Stats{}, 0, err
+	}
+	pgStats, err := pgbaseline.Run(s.ctx, cfg)
+	if err != nil {
+		return baseline.Stats{}, 0, fmt.Errorf("pg baseline: %w", err)
+	}
+
+	var uploaded int
+	if req.S3 != "" {
+		uploaded, err = baseline.Upload(s.ctx, outputDir, req.S3, "", false)
+		if err != nil {
+			return baseline.Stats{}, 0, fmt.Errorf("upload: %w", err)
+		}
+	}
+	return baseline.Stats{
+		TablesProcessed: pgStats.TablesProcessed,
+		RowsWritten:     pgStats.RowsWritten,
+		FilesWritten:    pgStats.FilesWritten,
+	}, uploaded, nil
+}
+
+// pgBaselineConfig builds the pgbaseline.Config for a PG source, mirroring
+// cmd/bintrail-pg's pgBaselineConfigFromFlags. The replication DSN is derived
+// from the stored query DSN (console.PGReplDSN — the one home for that
+// derivation), needed so pgbaseline can CREATE the slot when a user baselines
+// BEFORE the first monitor start; harmless if the slot already exists. Pure —
+// unit-testable without a live PG. The registry carries only a schema filter.
+func pgBaselineConfig(req console.BaselineRequest, outputDir string) (pgbaseline.Config, error) {
+	replDSN, err := console.PGReplDSN(req.SourceDSN)
+	if err != nil {
+		return pgbaseline.Config{}, err
+	}
+	return pgbaseline.Config{
+		QueryDSN:    req.SourceDSN,
+		ReplDSN:     replDSN,
+		SlotName:    req.Slot,
+		Publication: req.Publication,
+		Filters:     cliutil.BuildIndexFilters(strings.Join(req.Schemas, ","), ""),
+		OutputDir:   outputDir,
+		Compression: "zstd",
+	}, nil
 }
 
 // runMydumper invokes the bundled mydumper binary against the source DSN, writing

--- a/cmd/bintrail-console/baseline_pg_test.go
+++ b/cmd/bintrail-console/baseline_pg_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/console"
+)
+
+func TestPGBaselineConfig(t *testing.T) {
+	req := console.BaselineRequest{
+		SourceDSN:   "postgres://repl:secret@pg:5432/appdb",
+		Slot:        "bintrail_slot",
+		Publication: "bintrail_pub",
+		Schemas:     []string{"public", "shop"},
+		Flavor:      "postgres",
+	}
+	cfg, err := pgBaselineConfig(req, "/out")
+	if err != nil {
+		t.Fatalf("pgBaselineConfig: %v", err)
+	}
+	if cfg.QueryDSN != req.SourceDSN {
+		t.Errorf("QueryDSN = %q, want the source DSN", cfg.QueryDSN)
+	}
+	if !strings.Contains(cfg.ReplDSN, "replication=database") {
+		t.Errorf("ReplDSN missing replication=database: %q", cfg.ReplDSN)
+	}
+	if cfg.SlotName != "bintrail_slot" || cfg.Publication != "bintrail_pub" {
+		t.Errorf("slot/publication wrong: %q / %q", cfg.SlotName, cfg.Publication)
+	}
+	if cfg.OutputDir != "/out" || cfg.Compression != "zstd" {
+		t.Errorf("output/compression wrong: %q / %q", cfg.OutputDir, cfg.Compression)
+	}
+}
+
+func TestPGBaselineConfig_badDSN(t *testing.T) {
+	// A DSN already carrying replication is rejected by PGReplDSN.
+	if _, err := pgBaselineConfig(console.BaselineRequest{SourceDSN: "postgres://h:5432/db?replication=database"}, "/out"); err == nil {
+		t.Error("expected error for a repl-carrying source DSN")
+	}
+}

--- a/cmd/bintrail-console/monitor.go
+++ b/cmd/bintrail-console/monitor.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"log/slog"
 	"regexp"
 	"sync"
@@ -17,6 +18,7 @@ import (
 	"github.com/dbtrail/dbtrail/internal/doctor"
 	"github.com/dbtrail/dbtrail/internal/forensics"
 	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/pgstreamrun"
 	"github.com/dbtrail/dbtrail/internal/serverid"
 	"github.com/dbtrail/dbtrail/internal/streamdeps"
 	"github.com/dbtrail/dbtrail/internal/streamrun"
@@ -53,9 +55,12 @@ type monitorSupervisor struct {
 	// Doctor capacity projection assumes it (0 = rotation disabled). Set at
 	// construction so the supervisor never reads the cmd-layer upRotationCfg global.
 	rotateRetain time.Duration
-	// streamFn runs one supervised stream; a seam for unit tests, streamrun.One
-	// in production.
+	// streamFn runs one supervised MySQL/MariaDB stream; a seam for unit tests,
+	// streamrun.One in production.
 	streamFn func(ctx context.Context, cfg streamrun.Config) error
+	// pgStreamFn runs one supervised PostgreSQL stream; pgstreamrun.One in
+	// production, a seam for tests. Selected when the entry's flavor is postgres.
+	pgStreamFn func(ctx context.Context, cfg pgstreamrun.Config) error
 
 	mu   sync.Mutex
 	jobs map[string]*monitorJob
@@ -148,12 +153,23 @@ func (j *monitorJob) markLostPosition(detail string) {
 	j.mu.Unlock()
 }
 
-// streamHooks wires this job as its stream's liveness observer.
+// streamHooks wires this job as its MySQL stream's liveness observer.
 func (j *monitorJob) streamHooks() *streamrun.Hooks {
 	return &streamrun.Hooks{
 		OnCheckpoint:     j.progress,
 		OnIndexed:        func(int64) { j.progress() },
 		OnGapAutoAdvance: j.markLostPosition,
+	}
+}
+
+// pgStreamHooks wires this job as its PostgreSQL stream's liveness observer.
+// No OnGapAutoAdvance: a lost PG slot is fatal (pgstreamrun.One returns it and
+// the supervisor reconnects), not a continue-after-loss — the durable
+// gap_lost_detail persisted by the capturer is re-hydrated by Start instead.
+func (j *monitorJob) pgStreamHooks() *pgstreamrun.Hooks {
+	return &pgstreamrun.Hooks{
+		OnCheckpoint: j.progress,
+		OnIndexed:    func(int64) { j.progress() },
 	}
 }
 
@@ -193,6 +209,7 @@ func newMonitorSupervisor(baseCtx context.Context, bootIndexDSN string, reg *con
 		registry:     reg,
 		rotateRetain: retain,
 		streamFn:     streamrun.One,
+		pgStreamFn:   pgstreamrun.One,
 		jobs:         map[string]*monitorJob{},
 	}
 }
@@ -226,7 +243,23 @@ func (m *monitorSupervisor) Doctor(ctx context.Context, e console.ServerEntry) (
 	}
 	// The per-source databases are rotated by the daemon's built-in loop, so
 	// the capacity projection uses its window (0 when rotation is disabled).
-	r := doctor.Build(ctx, e.SourceDSN, e.DSN, e.Schemas, m.rotateRetain)
+	// PostgreSQL runs the pgstreamrun preflight (slot / wal_level / publication
+	// coverage / REPLICA IDENTITY FULL) instead, which returns the identical
+	// *doctor.Report shape so the mapping loop below is unchanged. A missing slot
+	// is a Skip (never blocks first start); a publication that doesn't cover the
+	// tables is a Fail — the operator must CREATE it (validate-don't-create).
+	var r *doctor.Report
+	switch e.SourceFlavor() {
+	case console.FlavorPostgres:
+		r = pgstreamrun.BuildPGReport(ctx, pgstreamrun.PGDoctorConfig{
+			QueryDSN:    e.SourceDSN,
+			SlotName:    e.SourceSlot,
+			Publication: e.SourcePublication,
+			Schemas:     e.Schemas,
+		})
+	default:
+		r = doctor.Build(ctx, e.SourceDSN, e.DSN, e.Schemas, m.rotateRetain)
+	}
 	out := &console.DoctorReport{
 		Passed:   r.Passed,
 		Failed:   r.Failed,
@@ -379,20 +412,80 @@ func (m *monitorSupervisor) Start(ctx context.Context, e console.ServerEntry) er
 	job.lockDB = lockDB
 
 	// ── Launch the supervised stream ─────────────────────────────────────
-	serverID := e.SourceServerID
-	if serverID == 0 {
-		serverID, err = serverid.DeriveServerID(e.SourceDSN)
-		if err != nil {
-			lockDB.Close()
-			return fail(fmt.Errorf("derive server id: %w", err))
-		}
+	// One circuit-breaker loop (run) drives either engine; the flavor only
+	// selects which One is called with which config + liveness hooks.
+	flavor := e.SourceFlavor()
+	serverID, err := m.deriveSourceIdentity(e, flavor)
+	if err != nil {
+		lockDB.Close()
+		return fail(err)
 	}
-	cfg := sourceStreamConfig(e, serverID)
-	cfg.Hooks = job.streamHooks()
+	var runOnce func(context.Context) error
+	switch flavor {
+	case console.FlavorPostgres:
+		pgcfg, cErr := sourcePGStreamConfig(e, serverID)
+		if cErr != nil {
+			lockDB.Close()
+			return fail(cErr)
+		}
+		pgcfg.Hooks = job.pgStreamHooks()
+		runOnce = func(c context.Context) error { return m.pgStreamFn(c, pgcfg) }
+	default:
+		cfg := sourceStreamConfig(e, serverID)
+		cfg.Hooks = job.streamHooks()
+		runOnce = func(c context.Context) error { return m.streamFn(c, cfg) }
+	}
 
 	m.wg.Add(1)
-	go m.run(jobCtx, job, e, cfg)
+	go m.run(jobCtx, job, e, flavor, runOnce)
 	return nil
+}
+
+// deriveSourceIdentity resolves the stream's server_id. MySQL/MariaDB derive it
+// from the source DSN (serverid.DeriveServerID parses a MySQL DSN and fails on a
+// postgres:// connstring). PostgreSQL identity is the replication slot, so
+// server_id is only a stream_state label — an explicit SourceServerID wins,
+// else a stable non-zero hash of the (registry-unique) entry id.
+func (m *monitorSupervisor) deriveSourceIdentity(e console.ServerEntry, flavor string) (uint32, error) {
+	if e.SourceServerID != 0 {
+		return e.SourceServerID, nil
+	}
+	if flavor == console.FlavorPostgres {
+		h := fnv.New32a()
+		_, _ = h.Write([]byte(e.ID))
+		if id := h.Sum32(); id != 0 {
+			return id, nil
+		}
+		return 1, nil
+	}
+	id, err := serverid.DeriveServerID(e.SourceDSN)
+	if err != nil {
+		return 0, fmt.Errorf("derive server id: %w", err)
+	}
+	return id, nil
+}
+
+// sourcePGStreamConfig builds the supervised PG stream's pgstreamrun.Config from
+// a registry entry (Hooks attached by the caller). The replication DSN is
+// derived from the stored query DSN (console.PGReplDSN adds replication=database
+// — the one place that derivation lives); the slot and publication are the
+// operator-supplied stored fields. Pure — unit-testable without a live DB.
+func sourcePGStreamConfig(e console.ServerEntry, serverID uint32) (pgstreamrun.Config, error) {
+	replDSN, err := console.PGReplDSN(e.SourceDSN)
+	if err != nil {
+		return pgstreamrun.Config{}, err
+	}
+	return pgstreamrun.Config{
+		IndexDSN:    e.DSN,
+		ReplDSN:     replDSN,
+		QueryDSN:    e.SourceDSN,
+		SlotName:    e.SourceSlot,
+		Publication: e.SourcePublication,
+		ServerID:    serverID,
+		BatchSize:   1000,
+		Schemas:     e.Schemas,
+		Checkpoint:  10 * time.Second,
+	}, nil
 }
 
 // sourceStreamConfig builds the supervised stream's streamrun.Config from a
@@ -436,7 +529,7 @@ func sourceStreamConfig(e console.ServerEntry, serverID uint32) streamrun.Config
 // breaker: permanent "failed", no more retries, advisory lock released —
 // Start (or a daemon restart) re-arms it. Cancellation (stop verb / daemon
 // shutdown) exits cleanly.
-func (m *monitorSupervisor) run(ctx context.Context, job *monitorJob, e console.ServerEntry, cfg streamrun.Config) {
+func (m *monitorSupervisor) run(ctx context.Context, job *monitorJob, e console.ServerEntry, flavor string, runOnce func(context.Context) error) {
 	defer m.wg.Done()
 	defer close(job.done)
 	defer func() {
@@ -453,7 +546,9 @@ func (m *monitorSupervisor) run(ctx context.Context, job *monitorJob, e console.
 	// the events gap-fill indexes afterwards. Gate-checked at the surface
 	// (#701 D1); --attribution-retention 0 disables it inside the poller.
 	// The SourceDSN guard keeps direct run() callers (tests) poller-free.
-	if forensics.Enabled() && e.SourceDSN != "" {
+	// MySQL-only: pgoutput carries no connection id to attribute, and the poller
+	// opens e.SourceDSN with the MySQL driver, which errors on a postgres:// DSN.
+	if flavor != console.FlavorPostgres && forensics.Enabled() && e.SourceDSN != "" {
 		pollerCtx, stopPoller := context.WithCancel(ctx)
 		defer stopPoller()
 		forensics.StartConnCachePoller(pollerCtx, forensics.ConnCacheConfig{
@@ -468,7 +563,7 @@ func (m *monitorSupervisor) run(ctx context.Context, job *monitorJob, e console.
 	for {
 		job.set("pending", "")
 		started := time.Now()
-		err := m.streamFn(ctx, cfg)
+		err := runOnce(ctx)
 		if ctx.Err() != nil || err == nil {
 			job.set("stopped", "")
 			return

--- a/cmd/bintrail-console/monitor_pg_test.go
+++ b/cmd/bintrail-console/monitor_pg_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/console"
+)
+
+func TestSourcePGStreamConfig(t *testing.T) {
+	e := console.ServerEntry{
+		DSN:               "root:pw@tcp(idx:3306)/bintrail_idx_e1",
+		SourceDSN:         "postgres://repl:secret@pg:5432/appdb",
+		SourceSlot:        "bintrail_slot",
+		SourcePublication: "bintrail_pub",
+		Schemas:           "public",
+		Flavor:            "postgres",
+	}
+	cfg, err := sourcePGStreamConfig(e, 42)
+	if err != nil {
+		t.Fatalf("sourcePGStreamConfig: %v", err)
+	}
+	if cfg.IndexDSN != e.DSN || cfg.QueryDSN != e.SourceDSN {
+		t.Errorf("dsn wiring wrong: index=%q query=%q", cfg.IndexDSN, cfg.QueryDSN)
+	}
+	if !strings.Contains(cfg.ReplDSN, "replication=database") {
+		t.Errorf("repl DSN missing replication=database: %q", cfg.ReplDSN)
+	}
+	if cfg.SlotName != "bintrail_slot" || cfg.Publication != "bintrail_pub" {
+		t.Errorf("slot/publication wrong: %q / %q", cfg.SlotName, cfg.Publication)
+	}
+	if cfg.ServerID != 42 || cfg.Schemas != "public" || cfg.BatchSize != 1000 {
+		t.Errorf("config wrong: %+v", cfg)
+	}
+	if cfg.Checkpoint != 10*time.Second {
+		t.Errorf("checkpoint = %v, want 10s", cfg.Checkpoint)
+	}
+}
+
+func TestSourcePGStreamConfig_badDSN(t *testing.T) {
+	// A DSN already carrying replication is rejected by PGReplDSN (would double it).
+	if _, err := sourcePGStreamConfig(console.ServerEntry{SourceDSN: "postgres://h:5432/db?replication=database"}, 1); err == nil {
+		t.Error("expected error for a repl-carrying DSN")
+	}
+}
+
+func TestDeriveSourceIdentity(t *testing.T) {
+	m := &monitorSupervisor{}
+
+	// An explicit SourceServerID wins for any flavor.
+	if id, err := m.deriveSourceIdentity(console.ServerEntry{SourceServerID: 7}, console.FlavorPostgres); err != nil || id != 7 {
+		t.Errorf("explicit server id should win: id=%d err=%v", id, err)
+	}
+
+	// PG with 0 → a stable non-zero hash of the (registry-unique) entry id.
+	a, err := m.deriveSourceIdentity(console.ServerEntry{ID: "abc123"}, console.FlavorPostgres)
+	if err != nil || a == 0 {
+		t.Fatalf("pg identity: id=%d err=%v", a, err)
+	}
+	b, _ := m.deriveSourceIdentity(console.ServerEntry{ID: "abc123"}, console.FlavorPostgres)
+	if a != b {
+		t.Errorf("pg identity not stable across calls: %d vs %d", a, b)
+	}
+	if c, _ := m.deriveSourceIdentity(console.ServerEntry{ID: "xyz789"}, console.FlavorPostgres); a == c {
+		t.Errorf("distinct entry ids collided on %d", a)
+	}
+
+	// MySQL with 0 delegates to DeriveServerID (needs a parseable MySQL DSN).
+	if _, err := m.deriveSourceIdentity(console.ServerEntry{SourceDSN: "u:p@tcp(h:3306)/"}, console.FlavorMySQL); err != nil {
+		t.Errorf("mysql identity: %v", err)
+	}
+}

--- a/cmd/bintrail-console/monitor_replica.go
+++ b/cmd/bintrail-console/monitor_replica.go
@@ -49,6 +49,12 @@ type peerIdentity struct {
 // other monitored registry entry. Returns nil when there is nothing to
 // compare (no registry, no peers) — no card is shown then.
 func (m *monitorSupervisor) replicaOverlapCheck(ctx context.Context, e console.ServerEntry) *console.DoctorCheck {
+	// GTID-lineage overlap is a MySQL/MariaDB concept, read over a MySQL
+	// connection (@@gtid_mode / @@server_uuid); a PostgreSQL source has no analog
+	// and config.Connect would fail on its postgres:// DSN. Skip silently.
+	if e.SourceFlavor() == console.FlavorPostgres {
+		return nil
+	}
 	if m.registry == nil {
 		return nil
 	}

--- a/cmd/bintrail-console/monitor_test.go
+++ b/cmd/bintrail-console/monitor_test.go
@@ -200,7 +200,7 @@ func TestMonitorRun_circuitBreakerGivesUp(t *testing.T) {
 	m.jobs["e1"] = job
 
 	m.wg.Add(1)
-	m.run(ctx, job, console.ServerEntry{ID: "e1", Name: "prod"}, streamrun.Config{})
+	m.run(ctx, job, console.ServerEntry{ID: "e1", Name: "prod"}, console.FlavorMySQL, func(c context.Context) error { return m.streamFn(c, streamrun.Config{}) })
 
 	select {
 	case <-job.done:
@@ -232,7 +232,7 @@ func TestMonitorRun_cleanStopBypassesBreaker(t *testing.T) {
 	job.set("pending", "")
 
 	m.wg.Add(1)
-	m.run(ctx, job, console.ServerEntry{ID: "e2", Name: "x"}, streamrun.Config{})
+	m.run(ctx, job, console.ServerEntry{ID: "e2", Name: "x"}, console.FlavorMySQL, func(c context.Context) error { return m.streamFn(c, streamrun.Config{}) })
 
 	if st := job.snapshot(); st.State != "stopped" {
 		t.Fatalf("state = %q, want stopped on cancellation", st.State)
@@ -395,7 +395,7 @@ func TestMonitorRun_healthyRunResetsBreaker(t *testing.T) {
 	job.set("pending", "")
 
 	m.wg.Add(1)
-	go m.run(ctx, job, console.ServerEntry{ID: "e3", Name: "flappy"}, streamrun.Config{})
+	go m.run(ctx, job, console.ServerEntry{ID: "e3", Name: "flappy"}, console.FlavorMySQL, func(c context.Context) error { return m.streamFn(c, streamrun.Config{}) })
 
 	// Let it flap well past monitorGiveUpAfter in wall-clock time.
 	time.Sleep(150 * time.Millisecond)

--- a/cmd/bintrail-console/verify.go
+++ b/cmd/bintrail-console/verify.go
@@ -138,7 +138,7 @@ func (s *verifySupervisor) Explain(serverID, schema, table string) (*console.Ver
 		return nil, fmt.Errorf("connect index: %w", err)
 	}
 	defer db.Close()
-	resolver, err := metadata.NewResolver(db, 0)
+	resolver, err := verify.ResolverFor(db)
 	if err != nil {
 		return nil, fmt.Errorf("load schema snapshot: %w", err)
 	}
@@ -147,6 +147,7 @@ func (s *verifySupervisor) Explain(serverID, schema, table string) (*console.Ver
 	cfg := verify.BaselineConfig{
 		IndexDB: db, Resolver: resolver, IndexDBName: indexDBName(indexDSN),
 		NoArchive: noArchive, ArchiveFetcher: parquetquery.Fetch,
+		SourceFlavor: query.SourceFlavor(db),
 	}
 
 	ex, err := verify.ExplainBaselinePairMismatch(s.ctx, cfg, pair)
@@ -191,7 +192,7 @@ func (s *verifySupervisor) run(req console.VerifyRequest, baselineSrc string) {
 		return
 	}
 	defer db.Close()
-	resolver, err := metadata.NewResolver(db, 0)
+	resolver, err := verify.ResolverFor(db)
 	if err != nil {
 		// Hard requirement, no fallback — mirrors internal/cli/verify.go: a
 		// missing schema snapshot means verify cannot resolve primary keys.
@@ -199,18 +200,27 @@ func (s *verifySupervisor) run(req console.VerifyRequest, baselineSrc string) {
 		return
 	}
 	dbName := indexDBName(req.IndexDSN)
+	flavor := query.SourceFlavor(db)
 
 	var runErr error
 	switch req.Mode {
 	case console.VerifyModeLiveSource:
-		runErr = s.runLiveSource(req, db, resolver, dbName)
+		// Live-source verify fingerprints the source with MySQL-only SQL; a PG
+		// source is refused with a clear verdict (not a misleading inconclusive).
+		// Baseline-anchored is the supported PG path. This is an engine-truth
+		// backstop; handleVerifyTrigger already rejects it at the API boundary.
+		if flavor == console.FlavorPostgres {
+			runErr = fmt.Errorf("live-source verify is not supported for PostgreSQL sources; use baseline-anchored verify")
+		} else {
+			runErr = s.runLiveSource(req, db, resolver, dbName)
+		}
 	default:
-		runErr = s.runBaselineAnchored(req, baselineSrc, db, resolver, dbName)
+		runErr = s.runBaselineAnchored(req, baselineSrc, db, resolver, dbName, flavor)
 	}
 	s.finish(req.ServerID, runErr)
 }
 
-func (s *verifySupervisor) runBaselineAnchored(req console.VerifyRequest, baselineSrc string, indexDB *sql.DB, resolver *metadata.Resolver, dbName string) error {
+func (s *verifySupervisor) runBaselineAnchored(req console.VerifyRequest, baselineSrc string, indexDB *sql.DB, resolver *metadata.Resolver, dbName, flavor string) error {
 	ctx := s.ctx
 	pairs, unpaired, prevOnly, err := verify.FindBaselinePair(ctx, baselineSrc)
 	if err != nil {
@@ -238,6 +248,7 @@ func (s *verifySupervisor) runBaselineAnchored(req console.VerifyRequest, baseli
 	cfg := verify.BaselineConfig{
 		IndexDB: indexDB, Resolver: resolver, IndexDBName: dbName,
 		NoArchive: req.NoArchive, ArchiveFetcher: parquetquery.Fetch,
+		SourceFlavor: flavor,
 	}
 
 	for _, p := range pairs {

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -14,6 +14,7 @@ import (
 	"github.com/dbtrail/dbtrail/internal/duckdbutil"
 	"github.com/dbtrail/dbtrail/internal/indexer"
 	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/query"
 	"github.com/dbtrail/dbtrail/internal/verify"
 )
 
@@ -112,7 +113,7 @@ func runVerify(cmd *cobra.Command, _ []string) error {
 	if cfg, parseErr := mysqldriver.ParseDSN(vfyIndexDSN); parseErr == nil {
 		indexDBName = cfg.DBName
 	}
-	resolver, err := metadata.NewResolver(indexDB, 0)
+	resolver, err := verify.ResolverFor(indexDB)
 	if err != nil {
 		return fmt.Errorf("load schema snapshot from index: %w", err)
 	}
@@ -121,15 +122,21 @@ func runVerify(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
+	flavor := query.SourceFlavor(indexDB)
 	if vfySourceDSN != "" {
+		// Live-source verify fingerprints the source with MySQL-only SQL; refuse
+		// a PG source up front rather than reach a misleading inconclusive.
+		if flavor == "postgres" {
+			return fmt.Errorf("live-source verify (--source-dsn) is not supported for PostgreSQL sources; omit it to run baseline-anchored verify")
+		}
 		return runVerifyLive(cmd, indexDB, resolver, indexDBName, baselineSrc, duckTuning)
 	}
-	return runVerifyBaselinePair(cmd, indexDB, resolver, indexDBName, baselineSrc, duckTuning)
+	return runVerifyBaselinePair(cmd, indexDB, resolver, indexDBName, baselineSrc, duckTuning, flavor)
 }
 
 // runVerifyBaselinePair is the default, drift-free mode: compare the two most
 // recent baselines (#642). It reads no live source.
-func runVerifyBaselinePair(cmd *cobra.Command, indexDB *sql.DB, resolver *metadata.Resolver, indexDBName, baselineSrc string, duckTuning duckdbutil.Tuning) error {
+func runVerifyBaselinePair(cmd *cobra.Command, indexDB *sql.DB, resolver *metadata.Resolver, indexDBName, baselineSrc string, duckTuning duckdbutil.Tuning, flavor string) error {
 	pairs, unpaired, prevOnly, err := verify.FindBaselinePair(cmd.Context(), baselineSrc)
 	if err != nil {
 		return fmt.Errorf("discover baseline pair: %w", err)
@@ -162,6 +169,7 @@ func runVerifyBaselinePair(cmd *cobra.Command, indexDB *sql.DB, resolver *metada
 		IndexDBName:    indexDBName,
 		NoArchive:      vfyNoArchive,
 		ArchiveFetcher: TunedArchiveFetcher(duckTuning),
+		SourceFlavor:   flavor,
 	}
 
 	results := make([]verify.TableResult, 0, len(pairs)+len(unpaired))

--- a/internal/cli/verify_baseline_integration_test.go
+++ b/internal/cli/verify_baseline_integration_test.go
@@ -97,7 +97,7 @@ func TestRunVerifyBaselinePair_EndToEnd(t *testing.T) {
 	cmd.SetContext(context.Background())
 	var out bytes.Buffer
 	cmd.SetOut(&out)
-	if err := runVerifyBaselinePair(cmd, db, resolver, dbName, baseDir, duckdbutil.Tuning{}); err != nil {
+	if err := runVerifyBaselinePair(cmd, db, resolver, dbName, baseDir, duckdbutil.Tuning{}, ""); err != nil {
 		t.Fatalf("runVerifyBaselinePair: %v\noutput:\n%s", err, out.String())
 	}
 	if !strings.Contains(out.String(), "1 match") {
@@ -162,7 +162,7 @@ func TestRunVerifyBaselinePair_EndToEnd_Mismatch(t *testing.T) {
 	cmd.SetContext(context.Background())
 	var out bytes.Buffer
 	cmd.SetOut(&out)
-	err = runVerifyBaselinePair(cmd, db, resolver, dbName, baseDir, duckdbutil.Tuning{})
+	err = runVerifyBaselinePair(cmd, db, resolver, dbName, baseDir, duckdbutil.Tuning{}, "")
 	if err == nil {
 		t.Fatalf("want a non-nil error (non-zero exit) on divergence, got nil\noutput:\n%s", out.String())
 	}
@@ -229,7 +229,7 @@ func TestRunVerifyBaselinePair_EndToEnd_NeverBaselined(t *testing.T) {
 	cmd.SetContext(context.Background())
 	var out bytes.Buffer
 	cmd.SetOut(&out)
-	if err := runVerifyBaselinePair(cmd, db, resolver, dbName, baseDir, duckdbutil.Tuning{}); err != nil {
+	if err := runVerifyBaselinePair(cmd, db, resolver, dbName, baseDir, duckdbutil.Tuning{}, ""); err != nil {
 		t.Fatalf("runVerifyBaselinePair: %v\noutput:\n%s", err, out.String())
 	}
 	o := out.String()
@@ -314,7 +314,7 @@ func TestRunVerifyBaselinePair_EndToEnd_StaleButRecoverable(t *testing.T) {
 	cmd.SetContext(context.Background())
 	var out bytes.Buffer
 	cmd.SetOut(&out)
-	if err := runVerifyBaselinePair(cmd, db, resolver, dbName, baseDir, duckdbutil.Tuning{}); err != nil {
+	if err := runVerifyBaselinePair(cmd, db, resolver, dbName, baseDir, duckdbutil.Tuning{}, ""); err != nil {
 		t.Fatalf("runVerifyBaselinePair: %v\noutput:\n%s", err, out.String())
 	}
 	o := out.String()
@@ -395,7 +395,7 @@ func TestRunVerifyBaselinePair_Explain(t *testing.T) {
 	cmd.SetContext(context.Background())
 	var out bytes.Buffer
 	cmd.SetOut(&out)
-	err = runVerifyBaselinePair(cmd, db, resolver, dbName, baseDir, duckdbutil.Tuning{})
+	err = runVerifyBaselinePair(cmd, db, resolver, dbName, baseDir, duckdbutil.Tuning{}, "")
 	if err == nil {
 		t.Fatalf("--explain must not swallow the mismatch exit status, got nil error\noutput:\n%s", out.String())
 	}

--- a/internal/cli/verify_baseline_test.go
+++ b/internal/cli/verify_baseline_test.go
@@ -61,7 +61,7 @@ func TestRunVerifyBaselinePair_NoBaselines(t *testing.T) {
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 
-	err := runVerifyBaselinePair(cmd, nil, nil, "", t.TempDir(), duckdbutil.Tuning{})
+	err := runVerifyBaselinePair(cmd, nil, nil, "", t.TempDir(), duckdbutil.Tuning{}, "")
 	if err == nil {
 		t.Fatalf("want a non-nil error (non-zero exit) for zero baselines, got nil; output:\n%s", out.String())
 	}
@@ -85,7 +85,7 @@ func TestRunVerifyBaselinePair_SingleBaseline(t *testing.T) {
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 
-	err := runVerifyBaselinePair(cmd, nil, nil, "", baseDir, duckdbutil.Tuning{})
+	err := runVerifyBaselinePair(cmd, nil, nil, "", baseDir, duckdbutil.Tuning{}, "")
 	if err != nil {
 		t.Fatalf("want nil error (exit 0) for a single baseline, got %v\noutput:\n%s", err, out.String())
 	}
@@ -115,7 +115,7 @@ func TestRunVerifyBaselinePair_TablesAbsent(t *testing.T) {
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 
-	err := runVerifyBaselinePair(cmd, nil, metadata.NewResolverFromTables(1, nil), "", baseDir, duckdbutil.Tuning{})
+	err := runVerifyBaselinePair(cmd, nil, metadata.NewResolverFromTables(1, nil), "", baseDir, duckdbutil.Tuning{}, "")
 	if err == nil {
 		t.Fatalf("want a non-nil error (non-zero exit) for an absent --tables request, got nil; output:\n%s", out.String())
 	}
@@ -153,7 +153,7 @@ func TestRunVerifyBaselinePair_NeverBaselined(t *testing.T) {
 
 	// Non-zero exit is expected here, but from the "nothing proven" gate (the
 	// only result is inconclusive), NOT from the --tables-absent error path.
-	err := runVerifyBaselinePair(cmd, nil, resolver, "", baseDir, duckdbutil.Tuning{})
+	err := runVerifyBaselinePair(cmd, nil, resolver, "", baseDir, duckdbutil.Tuning{}, "")
 	if err == nil {
 		t.Fatalf("want a non-nil error (all-inconclusive run proves nothing), got nil; output:\n%s", out.String())
 	}

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -2729,7 +2729,7 @@ async function loadServers() {
       const ordered = servers.filter((s) => s.kind !== "ephemeral")
         .concat(servers.filter((s) => s.kind === "ephemeral"));
       ordered.forEach((s) => {
-        const o = opt(s.id, serverLabel(s));
+        const o = opt(s.id, serverLabel(s) + (s.flavor && s.flavor !== "mysql" ? " · " + (s.flavor === "postgres" ? "PG" : "MariaDB") : ""));
         if (s.kind === "ephemeral") o.title = "The daemon's own index database (set with --index-dsn on the command line)";
         sel.append(o);
       });
@@ -2891,9 +2891,10 @@ function serverRow(s) {
   if (s.kind === "ephemeral") item.append(el("span", { class: "chip chip-cli", text: "CLI", title: "Set from the command line with --index-dsn" }));
   if (s.reconstruct) item.append(el("span", { class: "chip chip-tt", text: "TT", title: "Baseline configured: Time-travel available" }));
   if (s.monitor_state) item.append(el("span", { class: "chip chip-mon", text: s.monitor_state.replace("_", " ").toUpperCase(), title: MON_STATE_TITLES[s.monitor_state] || ("monitoring " + s.monitor_state) }));
+  if (s.flavor && s.flavor !== "mysql") item.append(el("span", { class: "chip", text: s.flavor === "postgres" ? "PG" : s.flavor.toUpperCase(), title: "Source type: " + s.flavor }));
 
   let desc;
-  if (s.has_source && s.source_host) desc = "watching " + s.source_user + "@" + s.source_host + ":" + (s.source_port || "3306") + (s.schemas ? " [" + s.schemas + "]" : "");
+  if (s.has_source && s.source_host) desc = "watching " + s.source_user + "@" + s.source_host + ":" + (s.source_port || (s.flavor === "postgres" ? "5432" : "3306")) + (s.source_database ? "/" + s.source_database : "") + (s.schemas ? " [" + s.schemas + "]" : "");
   else if (s.host) desc = s.user + "@" + s.host + ":" + (s.port || "3306") + "/" + s.dbname;
   else desc = s.dbname || "";
   item.append(el("span", { class: "srv-desc conn", text: desc }));
@@ -2924,6 +2925,20 @@ function srvField(label, name, opts) {
     el("input", { class: "input", name, type: opts.type || "text", placeholder: opts.placeholder || "", autocomplete: opts.autocomplete }));
 }
 
+// tagFlavor marks a form node visible only for the given space-separated source
+// families (e.g. "postgres" or "mysql mariadb"); applyFlavor toggles .flavor-on.
+function tagFlavor(node, families) { node.setAttribute("data-flavor", families); return node; }
+
+// applyFlavor reveals the [data-flavor] nodes matching the selected source
+// family, mirroring the capability cap-on gating EXACTLY — a class toggle over a
+// CSS :not() default-hide, never a [hidden]/style="display:none" toggle (the
+// documented display-bug class this codebase already hit).
+function applyFlavor(form) {
+  const f = (form.elements.flavor && form.elements.flavor.value) || "mysql";
+  $all("[data-flavor]", form).forEach((n) =>
+    n.classList.toggle("flavor-on", n.dataset.flavor.split(" ").includes(f)));
+}
+
 function buildServerForm() {
   const form = el("form", { class: "filters", id: "server-form", style: "display:block;margin-top:18px" });
   form.append(el("input", { type: "hidden", name: "id" }));
@@ -2935,27 +2950,51 @@ function buildServerForm() {
   form.append(top);
 
   const mon = el("fieldset", { class: "form-section", "data-capability": "monitor" });
-  mon.append(el("legend", { class: "form-legend", text: "Monitor a source MySQL" }));
+  mon.append(el("legend", { class: "form-legend", text: "Monitor a source database" }));
   mon.append(el("p", { class: "form-hint", text: "Paste the server you want to watch — dbtrail checks that it's ready, creates an index database for it automatically, and starts capturing changes. Nothing else to fill in beyond a name." }));
   const monGrid = el("div", { class: "form-grid" });
+  // Source family selector — reveals the PostgreSQL-only fields below.
+  monGrid.append(el("label", { class: "field" },
+    el("span", { class: "field-label", text: "Source type" }),
+    el("select", { class: "input", name: "flavor" },
+      opt("mysql", "MySQL"), opt("postgres", "PostgreSQL"), opt("mariadb", "MariaDB"))));
   monGrid.append(srvField("Source host", "source_host", { placeholder: "db.example.com" }));
   monGrid.append(srvField("Source port", "source_port", { placeholder: "3306" }));
   monGrid.append(srvField("Source user", "source_user", { placeholder: "repl" }));
   monGrid.append(srvField("Source password", "source_password", { type: "password", autocomplete: "new-password" }));
+  // PostgreSQL-only: a logical-replication connection is per-database, and the
+  // slot/publication are operator-created (validate-don't-create).
+  monGrid.append(tagFlavor(srvField("Database", "source_database", { placeholder: "appdb" }), "postgres"));
+  monGrid.append(tagFlavor(srvField("Replication slot", "source_slot", { placeholder: "bintrail_slot" }), "postgres"));
+  monGrid.append(tagFlavor(srvField("Publication", "source_publication", { placeholder: "bintrail_pub" }), "postgres"));
   monGrid.append(srvField("Schemas", "schemas", { placeholder: "(optional) shop,billing" }));
   monGrid.append(srvField("Archive to S3", "archive_s3", { placeholder: "(optional) s3://bucket/prefix/" }));
   mon.append(monGrid);
   // The source user is the #1 friction point — spell out the grant inline,
   // never behind a <details>. REPLICATION SLAVE/CLIENT drive the stream;
   // SELECT covers the information_schema snapshot of columns/PKs/FKs.
-  const grantHint = el("p", { class: "form-hint", style: "margin-top:10px" });
+  const grantHint = tagFlavor(el("p", { class: "form-hint", style: "margin-top:10px" }), "mysql mariadb");
   grantHint.append("Source user needs ");
   grantHint.append(el("code", { text: "REPLICATION SLAVE, REPLICATION CLIENT, SELECT" }));
   grantHint.append(". Create one on the source MySQL — copy and run:");
   mon.append(grantHint);
-  mon.append(el("pre", { class: "form-code", text:
+  mon.append(tagFlavor(el("pre", { class: "form-code", text:
     "CREATE USER 'dbtrail'@'%' IDENTIFIED BY 'strong-password';\n" +
-    "GRANT REPLICATION SLAVE, REPLICATION CLIENT, SELECT ON *.* TO 'dbtrail'@'%';" }));
+    "GRANT REPLICATION SLAVE, REPLICATION CLIENT, SELECT ON *.* TO 'dbtrail'@'%';" }), "mysql mariadb"));
+  // PostgreSQL prerequisites — the console reads them, it never runs CREATE
+  // PUBLICATION / ALTER SYSTEM (validate-don't-create; capture is pgoutput-only).
+  const pgHint = tagFlavor(el("p", { class: "form-hint", style: "margin-top:10px" }), "postgres");
+  pgHint.append("PostgreSQL source needs ");
+  pgHint.append(el("code", { text: "wal_level=logical" }));
+  pgHint.append(", a role with the ");
+  pgHint.append(el("code", { text: "REPLICATION" }));
+  pgHint.append(" attribute, a publication you create, and ");
+  pgHint.append(el("code", { text: "REPLICA IDENTITY FULL" }));
+  pgHint.append(" on replicated tables — copy and run on the source:");
+  mon.append(pgHint);
+  mon.append(tagFlavor(el("pre", { class: "form-code", text:
+    "CREATE PUBLICATION bintrail_pub FOR ALL TABLES;\n" +
+    "ALTER TABLE your_table REPLICA IDENTITY FULL;" }), "postgres"));
   mon.append(el("p", { class: "form-hint", style: "margin-top:10px", text: "Archive to S3: old data is uploaded here before it's deleted locally, so your history is kept and can still be searched. Needs AWS credentials set up on the daemon (environment variables or an IAM role)." }));
   form.append(mon);
 
@@ -2999,6 +3038,7 @@ function showServerForm(prefill) {
   $("#server-cancel", form).addEventListener("click", hideServerForm);
   $("#server-test", form).addEventListener("click", () => testServerForm(form));
   form.addEventListener("submit", (e) => { e.preventDefault(); saveServer(form); });
+  form.elements.flavor.addEventListener("change", () => applyFlavor(form));
 
   // Where the index connection is the whole form (serve-only process: no
   // monitor capability), or the entry being edited carries index fields,
@@ -3021,13 +3061,18 @@ function showServerForm(prefill) {
 
   if (prefill) {
     form.elements.id.value = prefill.id || "";
-    ["name", "host", "port", "user", "dbname", "baseline_dir", "baseline_s3", "archive_s3", "source_host", "source_port", "source_user", "schemas"].forEach((k) => {
+    ["name", "host", "port", "user", "dbname", "baseline_dir", "baseline_s3", "archive_s3", "source_host", "source_port", "source_user", "schemas", "source_database", "source_slot", "source_publication"].forEach((k) => {
       if (form.elements[k] && prefill[k] != null) form.elements[k].value = prefill[k];
     });
     if (form.elements.no_archive) form.elements.no_archive.checked = !!prefill.no_archive;
     form.elements.password.placeholder = prefill.has_password ? "(unchanged — leave blank to keep)" : "(none)";
     form.elements.source_password.placeholder = prefill.has_source_password ? "(unchanged — leave blank to keep)" : "";
   }
+  // Flavor init runs for both add and edit; it's immutable after create (the
+  // backend rejects a change on PUT), so disable the selector when editing.
+  form.elements.flavor.value = (prefill && prefill.flavor) || "mysql";
+  if (prefill && prefill.id) form.elements.flavor.disabled = true;
+  applyFlavor(form);
   form.elements.name.focus();
 }
 function hideServerForm() {
@@ -3048,12 +3093,15 @@ function serverFormBody(form) {
   const f = form.elements;
   const body = {
     name: f.name.value.trim(),
+    flavor: f.flavor.value,
     host: f.host.value.trim(), port: f.port.value.trim(), user: f.user.value.trim(), dbname: f.dbname.value.trim(),
     baseline_dir: f.baseline_dir.value.trim(), baseline_s3: f.baseline_s3.value.trim(),
     no_archive: !!f.no_archive.checked,
     archive_s3: f.archive_s3.value.trim(),
     source_host: f.source_host.value.trim(), source_port: f.source_port.value.trim(),
     source_user: f.source_user.value.trim(), schemas: f.schemas.value.trim(),
+    source_database: f.source_database.value.trim(),
+    source_slot: f.source_slot.value.trim(), source_publication: f.source_publication.value.trim(),
   };
   if (f.password.value !== "") body.password = f.password.value;
   if (f.source_password.value !== "") body.source_password = f.source_password.value;

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -1112,6 +1112,10 @@ button { font-family: inherit; }
    .cap-on. The :not() + !important hides by default and restores the
    element's own display once gated on — no flash, no per-element value. */
 [data-capability]:not(.cap-on) { display: none !important; }
+/* Source-family gating: a [data-flavor] form field is hidden until applyFlavor
+   marks it .flavor-on for the selected source type. Same :not() + !important
+   default-hide as capability gating — a class toggle, never a [hidden] toggle. */
+[data-flavor]:not(.flavor-on) { display: none !important; }
 
 /* Auth-kind gating, same pattern: [data-auth="session"] surfaces (the logout
    button) show only when applyAuthGate() confirms this tab holds a login

--- a/internal/console/baseline_trigger.go
+++ b/internal/console/baseline_trigger.go
@@ -45,6 +45,16 @@ type BaselineRequest struct {
 	// the ambient AWS chain (env / ~/.aws / IAM role), like the rest of the
 	// console's S3 access.
 	S3 string
+	// Flavor selects the baseline producer: "postgres" runs internal/pgbaseline
+	// (COPY + the slot's pgoutput anchor); anything else runs mydumper. Plain
+	// strings keep internal/console pgx-free (the read-layer dependency guard).
+	Flavor string
+	// Slot / Publication are the PostgreSQL replication slot and publication
+	// (postgres flavor only); the producer stamps the snapshot at the slot's
+	// consistent-point LSN so Time-travel/reconstruct can replay deltas from it.
+	// Empty for MySQL/MariaDB.
+	Slot        string
+	Publication string
 }
 
 // BaselineStatus is the pollable state of a server's most recent baseline job.
@@ -82,14 +92,22 @@ func (s *Server) handleBaselineTrigger(w http.ResponseWriter, r *http.Request) {
 			"this server has no baseline location set up; set a baseline directory or S3 location first (Edit → Advanced)")
 		return
 	}
+	if e.IsPostgres() && (e.SourceSlot == "" || e.SourcePublication == "") {
+		writeJSONError(w, http.StatusBadRequest,
+			"this PostgreSQL server has no replication slot/publication configured; set them first (Edit → Source)")
+		return
+	}
 
 	req := BaselineRequest{
-		ServerID:   e.ID,
-		ServerName: e.Name,
-		SourceDSN:  e.SourceDSN,
-		Schemas:    splitSchemas(e.Schemas),
-		LocalDir:   e.BaselineDir,
-		S3:         e.BaselineS3,
+		ServerID:    e.ID,
+		ServerName:  e.Name,
+		SourceDSN:   e.SourceDSN,
+		Schemas:     splitSchemas(e.Schemas),
+		LocalDir:    e.BaselineDir,
+		S3:          e.BaselineS3,
+		Flavor:      e.SourceFlavor(),
+		Slot:        e.SourceSlot,
+		Publication: e.SourcePublication,
 	}
 	if err := s.baselineCtrl.Trigger(req); err != nil {
 		if errors.Is(err, ErrBaselineRunning) {

--- a/internal/console/baseline_trigger_test.go
+++ b/internal/console/baseline_trigger_test.go
@@ -204,6 +204,58 @@ func TestBaselineStatus_returnsControllerState(t *testing.T) {
 }
 
 // TestSplitSchemas covers the comma-separated parse used to build the request.
+// addPGBaselineEntry adds a PostgreSQL registry entry (source + slot/publication
+// + a local baseline destination) and returns its generated id.
+func addPGBaselineEntry(t *testing.T, srv *Server, slot, publication string) string {
+	t.Helper()
+	e, err := srv.cm.reg.Add(ServerEntry{
+		Name:              "pgwp",
+		DSN:               "idx:idxpw@tcp(127.0.0.1:3306)/binlog_index",
+		SourceDSN:         "postgres://repl:secret@pg:5432/appdb",
+		BaselineDir:       t.TempDir(),
+		Flavor:            FlavorPostgres,
+		SourceSlot:        slot,
+		SourcePublication: publication,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return e.ID
+}
+
+// TestBaselineTrigger_postgresHappy: a PG entry with a slot + publication triggers
+// a baseline whose request carries the flavor/slot/publication the PG producer needs.
+func TestBaselineTrigger_postgresHappy(t *testing.T) {
+	srv, ctrl := newBaselineTriggerServer(t)
+	id := addPGBaselineEntry(t, srv, "bintrail_slot", "bintrail_pub")
+	rec, _ := doServersReq(t, srv, "POST", "/api/servers/"+id+"/baseline", "")
+	if rec.Code != 202 {
+		t.Fatalf("pg happy: code=%d, want 202", rec.Code)
+	}
+	if len(ctrl.triggered) != 1 {
+		t.Fatalf("want 1 triggered request, got %d", len(ctrl.triggered))
+	}
+	got := ctrl.triggered[0]
+	if got.Flavor != FlavorPostgres || got.Slot != "bintrail_slot" || got.Publication != "bintrail_pub" {
+		t.Errorf("PG baseline request missing flavor/slot/publication: %+v", got)
+	}
+}
+
+// TestBaselineTrigger_postgresRequiresSlot: a PG entry with no slot/publication
+// cannot be baselined — a clear 400 (not a mydumper "no source" mislabel), and
+// the controller is never triggered.
+func TestBaselineTrigger_postgresRequiresSlot(t *testing.T) {
+	srv, ctrl := newBaselineTriggerServer(t)
+	id := addPGBaselineEntry(t, srv, "", "bintrail_pub")
+	rec, _ := doServersReq(t, srv, "POST", "/api/servers/"+id+"/baseline", "")
+	if rec.Code != 400 {
+		t.Fatalf("pg without slot: code=%d, want 400", rec.Code)
+	}
+	if len(ctrl.triggered) != 0 {
+		t.Fatal("controller must not be triggered for a PG entry without a slot")
+	}
+}
+
 func TestSplitSchemas(t *testing.T) {
 	cases := map[string][]string{
 		"":              nil,

--- a/internal/console/flavor.go
+++ b/internal/console/flavor.go
@@ -1,0 +1,232 @@
+package console
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+)
+
+// Source-family flavors. The registry records which capture engine a source
+// needs: MySQL and MariaDB both index through the go-mysql binlog path (MariaDB
+// differs only by GTID dialect at stream time, --source-flavor mariadb), while
+// PostgreSQL indexes through pgstreamrun. The string values are deliberately the
+// SAME literals stream_state.flavor stores (see internal/query.SourceFlavor and
+// recovery.DialectForFlavor) so a registry-declared flavor and the index-read
+// flavor never disagree. Empty is treated as MySQL so every pre-#1019 registry
+// entry keeps working — the same additive discipline as an empty SSLMode.
+const (
+	FlavorMySQL    = "mysql"
+	FlavorMariaDB  = "mariadb"
+	FlavorPostgres = "postgres"
+)
+
+// NormalizeFlavor maps a request/registry flavor string to a canonical value.
+// Empty → mysql; "postgresql" is accepted as an alias for "postgres". An
+// unrecognized value is an error so a create/update rejects a typo rather than
+// silently mis-routing capture.
+func NormalizeFlavor(s string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", FlavorMySQL:
+		return FlavorMySQL, nil
+	case FlavorMariaDB:
+		return FlavorMariaDB, nil
+	case FlavorPostgres, "postgresql":
+		return FlavorPostgres, nil
+	default:
+		return "", fmt.Errorf("unknown source flavor %q (want mysql, mariadb, or postgres)", s)
+	}
+}
+
+// SourceFlavor returns the entry's normalized source family, defaulting a blank
+// (pre-#1019) entry to mysql. Consumed by the monitor supervisor (#1020), the
+// baseline trigger (#1021), and the console UI gating. A stored value that no
+// longer normalizes (only reachable via a hand-edit — create/update validate on
+// write) degrades to mysql, which fails loudly at doctor time rather than
+// silently corrupting anything.
+func (e ServerEntry) SourceFlavor() string {
+	f, err := NormalizeFlavor(e.Flavor)
+	if err != nil {
+		return FlavorMySQL
+	}
+	return f
+}
+
+// IsPostgres reports whether the entry's source is PostgreSQL.
+func (e ServerEntry) IsPostgres() bool { return e.SourceFlavor() == FlavorPostgres }
+
+// validatePGSourceMonitorConfig enforces that a monitorable PostgreSQL source
+// (flavor postgres with a source DSN configured) also names a replication slot
+// and a publication — capture cannot start without both, and the operator must
+// create the publication itself (validate-don't-create). An index-only PG entry
+// (no source DSN) needs neither. A no-op for MySQL/MariaDB.
+func validatePGSourceMonitorConfig(flavor, sourceDSN, slot, publication string) error {
+	if flavor != FlavorPostgres || sourceDSN == "" {
+		return nil
+	}
+	if strings.TrimSpace(slot) == "" || strings.TrimSpace(publication) == "" {
+		return errors.New("a monitored PostgreSQL source requires both a replication slot and a publication")
+	}
+	return nil
+}
+
+// PGReplDSN derives the replication (walsender) connection string from a stored
+// PostgreSQL query DSN by adding replication=database. pgcapture/pgstreamrun and
+// pgbaseline require a distinct replication connection (a CopyBoth conn that
+// cannot run ordinary SQL); the console stores only the query DSN and derives
+// this one, so the replication-param logic lives in exactly one place. Consumed
+// by the monitor supervisor (#1020) and the baseline trigger (#1021).
+//
+// Pure net/url — no pgx: internal/console is on the read side of the
+// dependency-guard (internal/event/depguard_test.go) and must never link the
+// PostgreSQL capture libraries. A postgres:// URL round-trips through net/url
+// and re-parses cleanly in pgconn.ParseConfig downstream.
+func PGReplDSN(queryDSN string) (string, error) {
+	u, err := url.Parse(queryDSN)
+	if err != nil {
+		return "", errors.New("invalid PostgreSQL source DSN")
+	}
+	q := u.Query()
+	if q.Get("replication") != "" {
+		return "", errors.New("source DSN already carries a replication parameter; store the ordinary query DSN and let the console derive the replication connection")
+	}
+	q.Set("replication", "database")
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+// pgURL assembles a canonical postgres:// DSN from structured parts. rawQuery
+// (already URL-encoded, e.g. carried forward from a stored DSN) is appended
+// verbatim; pass "" for a fresh build. Port defaults to 5432.
+func pgURL(host, port, user, password, dbname, rawQuery string) (string, error) {
+	if host == "" {
+		return "", errors.New("source host is required")
+	}
+	if user == "" {
+		return "", errors.New("source user is required")
+	}
+	if dbname == "" {
+		return "", errors.New("source database is required for a PostgreSQL source (a logical-replication connection is per-database)")
+	}
+	if port == "" {
+		port = "5432"
+	}
+	u := &url.URL{
+		Scheme:   "postgres",
+		Host:     net.JoinHostPort(host, port),
+		Path:     "/" + dbname,
+		RawQuery: rawQuery,
+	}
+	if password == "" {
+		u.User = url.User(user)
+	} else {
+		u.User = url.UserPassword(user, password)
+	}
+	return u.String(), nil
+}
+
+// validatePGQueryDSN checks a raw pasted PostgreSQL source DSN: it must be a
+// postgres:// URL (libpq key=value strings aren't accepted here), name a
+// database, and NOT carry a replication parameter (the console derives the
+// replication connection itself). The parse error is never echoed — it could
+// embed the password.
+func validatePGQueryDSN(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return errors.New("invalid PostgreSQL source_dsn (expected postgres://user:pass@host:5432/dbname)")
+	}
+	if u.Scheme != "postgres" && u.Scheme != "postgresql" {
+		return errors.New("PostgreSQL source_dsn must be a postgres:// URL (paste a postgres:// URL, not a libpq key=value string)")
+	}
+	if strings.TrimPrefix(u.Path, "/") == "" {
+		return errors.New("PostgreSQL source_dsn must include a database name (postgres://user:pass@host:5432/dbname)")
+	}
+	if u.Query().Get("replication") != "" {
+		return errors.New("PostgreSQL source_dsn must be an ordinary (query) connection; drop replication=database — the console derives the replication connection automatically")
+	}
+	return nil
+}
+
+// buildPGSourceDSN assembles the stored PostgreSQL SOURCE DSN (the query DSN)
+// for a create/update request, mirroring buildSourceDSN's tri-state on
+// req.SourceDSN. Unlike a MySQL source DSN (server-level, no database), a PG
+// query DSN MUST name a database because logical replication is per-database.
+// TLS beyond the libpq default is configured by pasting a raw source_dsn (the
+// #879 hand-edit precedent), not a dedicated form field.
+func buildPGSourceDSN(req serverRequest, stored string) (string, error) {
+	if req.SourceDSN != nil {
+		raw := strings.TrimSpace(*req.SourceDSN)
+		if raw == "" {
+			return "", nil // explicit clear
+		}
+		if req.SourcePassword != nil {
+			return "", errors.New("specify either source_dsn or the structured source_password field, not both (a dsn carries its own password)")
+		}
+		if err := validatePGQueryDSN(raw); err != nil {
+			return "", err
+		}
+		return raw, nil
+	}
+
+	// No raw DSN and no structured source fields → keep the stored config as-is.
+	if req.SourceHost == "" && req.SourcePort == "" && req.SourceUser == "" &&
+		req.SourceDatabase == "" && req.SourcePassword == nil {
+		return stored, nil
+	}
+
+	// Structured build/merge: decompose the stored DSN (if any) with net/url and
+	// overlay the request fields. Stored query params (e.g. sslmode from a raw
+	// paste) are carried forward so a later host-only edit doesn't silently drop
+	// TLS settings.
+	host, port, user, dbname := req.SourceHost, req.SourcePort, req.SourceUser, req.SourceDatabase
+	password, rawQuery := "", ""
+	if stored != "" {
+		if su, err := url.Parse(stored); err == nil {
+			if host == "" {
+				host = su.Hostname()
+			}
+			if port == "" {
+				port = su.Port()
+			}
+			if su.User != nil {
+				if user == "" {
+					user = su.User.Username()
+				}
+				if pw, ok := su.User.Password(); ok {
+					password = pw
+				}
+			}
+			if dbname == "" {
+				dbname = strings.TrimPrefix(su.Path, "/")
+			}
+			rawQuery = su.RawQuery
+		}
+	}
+	if req.SourcePassword != nil {
+		password = *req.SourcePassword
+	}
+	return pgURL(host, port, user, password, dbname, rawQuery)
+}
+
+// fillPGSourceDSNParts decomposes a PostgreSQL query DSN into the masked DTO
+// fields — the credentials themselves never leave the process. Parse failures
+// leave the parts blank rather than leaking the raw DSN.
+func fillPGSourceDSNParts(dto *serverDTO, dsn string) {
+	if dsn == "" {
+		return
+	}
+	dto.HasSource = true
+	u, err := url.Parse(dsn)
+	if err != nil {
+		return
+	}
+	dto.SourceHost = u.Hostname()
+	dto.SourcePort = u.Port()
+	if u.User != nil {
+		dto.SourceUser = u.User.Username()
+		_, hasPw := u.User.Password()
+		dto.HasSourcePassword = hasPw
+	}
+	dto.SourceDatabase = strings.TrimPrefix(u.Path, "/")
+}

--- a/internal/console/flavor.go
+++ b/internal/console/flavor.go
@@ -149,8 +149,9 @@ func validatePGQueryDSN(raw string) error {
 }
 
 // buildPGSourceDSN assembles the stored PostgreSQL SOURCE DSN (the query DSN)
-// for a create/update request, mirroring buildSourceDSN's tri-state on
-// req.SourceDSN. Unlike a MySQL source DSN (server-level, no database), a PG
+// for a create/update request, mirroring buildMySQLSourceDSN's tri-state on
+// req.SourceDSN (buildSourceDSN itself is now just the flavor dispatcher).
+// Unlike a MySQL source DSN (server-level, no database), a PG
 // query DSN MUST name a database because logical replication is per-database.
 // TLS beyond the libpq default is configured by pasting a raw source_dsn (the
 // #879 hand-edit precedent), not a dedicated form field.

--- a/internal/console/flavor_test.go
+++ b/internal/console/flavor_test.go
@@ -191,6 +191,47 @@ func TestFillPGSourceDSNParts(t *testing.T) {
 	}
 }
 
+// TestPGSourceDSN_specialCharsRoundTrip drives a password carrying URL-significant
+// characters (@ : / — the classic DSN-corruption case) through the full path a
+// real source takes: structured build → stored query DSN → PGReplDSN (which
+// re-runs url.String() + q.Encode()) and → fillPGSourceDSNParts (the DTO decode).
+// url.UserPassword/u.User.Password() percent-encode/decode asymmetries are exactly
+// where a mis-encode would corrupt the live connection or the DTO echo.
+func TestPGSourceDSN_specialCharsRoundTrip(t *testing.T) {
+	const pw = "p@ss:w/rd"
+	stored, err := buildPGSourceDSN(serverRequest{
+		SourceHost: "pg.prod", SourceUser: "repl", SourcePassword: strPtr(pw), SourceDatabase: "appdb",
+	}, "")
+	if err != nil {
+		t.Fatalf("structured build: %v", err)
+	}
+	// The stored query DSN must decode back to the exact password.
+	if got, _ := mustParse(t, stored).User.Password(); got != pw {
+		t.Errorf("stored password did not round-trip: got %q want %q (dsn %q)", got, pw, stored)
+	}
+	// The derived replication DSN re-encodes the whole URL — creds must survive it.
+	repl, err := PGReplDSN(stored)
+	if err != nil {
+		t.Fatalf("PGReplDSN: %v", err)
+	}
+	ru := mustParse(t, repl)
+	if got, _ := ru.User.Password(); got != pw {
+		t.Errorf("repl password did not round-trip: got %q want %q (dsn %q)", got, pw, repl)
+	}
+	if ru.Query().Get("replication") != "database" {
+		t.Errorf("repl DSN missing replication=database: %q", repl)
+	}
+	// The DTO decode exposes host/user/db but never a raw password substring.
+	var dto serverDTO
+	fillPGSourceDSNParts(&dto, stored)
+	if dto.SourceUser != "repl" || dto.SourceHost != "pg.prod" || dto.SourceDatabase != "appdb" || !dto.HasSourcePassword {
+		t.Errorf("DTO decode wrong with special chars: %+v", dto)
+	}
+	if strings.Contains(dto.SourceHost+dto.SourceUser+dto.SourceDatabase+dto.SourcePort, "p@ss") {
+		t.Error("raw password substring leaked into a DTO part")
+	}
+}
+
 func TestBuildSourceDSNDispatch(t *testing.T) {
 	// buildSourceDSN routes postgres to the PG builder and mysql/mariadb to the
 	// MySQL builder (dbname-less server-level DSN).

--- a/internal/console/flavor_test.go
+++ b/internal/console/flavor_test.go
@@ -1,0 +1,219 @@
+package console
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeFlavor(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"", FlavorMySQL, false},
+		{"mysql", FlavorMySQL, false},
+		{"MySQL", FlavorMySQL, false},
+		{"  mysql  ", FlavorMySQL, false},
+		{"mariadb", FlavorMariaDB, false},
+		{"postgres", FlavorPostgres, false},
+		{"postgresql", FlavorPostgres, false},
+		{"POSTGRES", FlavorPostgres, false},
+		{"oracle", "", true},
+		{"pg", "", true},
+	}
+	for _, tc := range cases {
+		got, err := NormalizeFlavor(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("NormalizeFlavor(%q): expected error, got %q", tc.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("NormalizeFlavor(%q): unexpected error %v", tc.in, err)
+		}
+		if got != tc.want {
+			t.Errorf("NormalizeFlavor(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestServerEntrySourceFlavor(t *testing.T) {
+	if got := (ServerEntry{}).SourceFlavor(); got != FlavorMySQL {
+		t.Errorf("blank flavor should default to mysql, got %q", got)
+	}
+	if got := (ServerEntry{Flavor: "postgres"}).SourceFlavor(); got != FlavorPostgres {
+		t.Errorf("postgres flavor = %q", got)
+	}
+	if !(ServerEntry{Flavor: "postgres"}).IsPostgres() {
+		t.Error("IsPostgres should be true for postgres")
+	}
+	if (ServerEntry{Flavor: "mysql"}).IsPostgres() {
+		t.Error("IsPostgres should be false for mysql")
+	}
+	// A hand-edited junk value degrades to mysql rather than crashing.
+	if got := (ServerEntry{Flavor: "nonsense"}).SourceFlavor(); got != FlavorMySQL {
+		t.Errorf("junk flavor should degrade to mysql, got %q", got)
+	}
+}
+
+func TestPGReplDSN(t *testing.T) {
+	// URL with no existing query → replication=database is added.
+	got, err := PGReplDSN("postgres://u:p@h:5432/appdb")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if q := mustQuery(t, got).Get("replication"); q != "database" {
+		t.Errorf("replication param = %q, want database (%q)", q, got)
+	}
+
+	// Existing query params are preserved.
+	got, err = PGReplDSN("postgres://u:p@h:5432/appdb?sslmode=require")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	qv := mustQuery(t, got)
+	if qv.Get("replication") != "database" || qv.Get("sslmode") != "require" {
+		t.Errorf("expected both replication and sslmode, got %q", got)
+	}
+
+	// A DSN that already carries a replication param is rejected (would double it).
+	if _, err := PGReplDSN("postgres://u:p@h:5432/appdb?replication=database"); err == nil {
+		t.Error("expected error for a DSN already carrying replication")
+	}
+}
+
+func TestBuildPGSourceDSN(t *testing.T) {
+	// Raw postgres:// DSN is stored verbatim after validation.
+	got, err := buildPGSourceDSN(serverRequest{SourceDSN: strPtr("postgres://u:p@h:5432/appdb")}, "")
+	if err != nil {
+		t.Fatalf("raw valid: %v", err)
+	}
+	if got != "postgres://u:p@h:5432/appdb" {
+		t.Errorf("raw should be verbatim, got %q", got)
+	}
+
+	// Explicit clear.
+	if got, err := buildPGSourceDSN(serverRequest{SourceDSN: strPtr("")}, "postgres://x/y"); err != nil || got != "" {
+		t.Errorf("clear: got %q err %v", got, err)
+	}
+
+	// Errors: raw missing dbname, raw with replication, raw+structured password,
+	// non-postgres scheme, structured missing dbname.
+	badRaw := []serverRequest{
+		{SourceDSN: strPtr("postgres://u:p@h:5432/")},
+		{SourceDSN: strPtr("postgres://u:p@h:5432/appdb?replication=database")},
+		{SourceDSN: strPtr("postgres://u:p@h:5432/appdb"), SourcePassword: strPtr("x")},
+		{SourceDSN: strPtr("mysql://u:p@h/appdb")},
+		{SourceHost: "h", SourceUser: "u"}, // structured, no database
+	}
+	for i, req := range badRaw {
+		if _, err := buildPGSourceDSN(req, ""); err == nil {
+			t.Errorf("badRaw[%d]: expected error", i)
+		}
+	}
+
+	// Structured build → canonical postgres:// URL, default port 5432.
+	got, err = buildPGSourceDSN(serverRequest{SourceHost: "h", SourceUser: "u", SourcePassword: strPtr("p"), SourceDatabase: "appdb"}, "")
+	if err != nil {
+		t.Fatalf("structured: %v", err)
+	}
+	u := mustParse(t, got)
+	if u.Scheme != "postgres" || u.Hostname() != "h" || u.Port() != "5432" || strings.TrimPrefix(u.Path, "/") != "appdb" {
+		t.Errorf("structured build wrong: %q", got)
+	}
+	if pw, _ := u.User.Password(); pw != "p" || u.User.Username() != "u" {
+		t.Errorf("structured creds wrong: %q", got)
+	}
+
+	// Keep-stored: all-empty request returns the stored DSN unchanged.
+	if got, err := buildPGSourceDSN(serverRequest{}, "postgres://u:p@h:5432/appdb"); err != nil || got != "postgres://u:p@h:5432/appdb" {
+		t.Errorf("keep-stored: got %q err %v", got, err)
+	}
+
+	// Merge: host-only edit keeps the stored port, password, and query params.
+	got, err = buildPGSourceDSN(serverRequest{SourceHost: "newhost"}, "postgres://u:secret@h:6000/appdb?sslmode=require")
+	if err != nil {
+		t.Fatalf("merge: %v", err)
+	}
+	u = mustParse(t, got)
+	if u.Hostname() != "newhost" || u.Port() != "6000" {
+		t.Errorf("merge host/port wrong: %q", got)
+	}
+	if pw, _ := u.User.Password(); pw != "secret" {
+		t.Errorf("merge should keep stored password: %q", got)
+	}
+	if u.Query().Get("sslmode") != "require" {
+		t.Errorf("merge should preserve query params: %q", got)
+	}
+}
+
+func TestValidatePGSourceMonitorConfig(t *testing.T) {
+	// PG source with a DSN but no slot/publication is rejected.
+	if err := validatePGSourceMonitorConfig(FlavorPostgres, "postgres://x/y", "", "pub"); err == nil {
+		t.Error("expected error: PG monitored source without a slot")
+	}
+	if err := validatePGSourceMonitorConfig(FlavorPostgres, "postgres://x/y", "slot", ""); err == nil {
+		t.Error("expected error: PG monitored source without a publication")
+	}
+	// PG source with both is fine.
+	if err := validatePGSourceMonitorConfig(FlavorPostgres, "postgres://x/y", "slot", "pub"); err != nil {
+		t.Errorf("PG with slot+pub should pass: %v", err)
+	}
+	// Index-only PG entry (no source DSN) needs neither.
+	if err := validatePGSourceMonitorConfig(FlavorPostgres, "", "", ""); err != nil {
+		t.Errorf("index-only PG should pass: %v", err)
+	}
+	// MySQL never triggers the gate.
+	if err := validatePGSourceMonitorConfig(FlavorMySQL, "u:p@tcp(h:3306)/", "", ""); err != nil {
+		t.Errorf("mysql should pass: %v", err)
+	}
+}
+
+func TestFillPGSourceDSNParts(t *testing.T) {
+	var dto serverDTO
+	fillPGSourceDSNParts(&dto, "postgres://repl:secret@h:5432/appdb")
+	if !dto.HasSource || dto.SourceHost != "h" || dto.SourcePort != "5432" ||
+		dto.SourceUser != "repl" || dto.SourceDatabase != "appdb" || !dto.HasSourcePassword {
+		t.Errorf("decompose wrong: %+v", dto)
+	}
+	// No password → HasSourcePassword false.
+	var dto2 serverDTO
+	fillPGSourceDSNParts(&dto2, "postgres://repl@h:5432/appdb")
+	if dto2.HasSourcePassword {
+		t.Error("no-password DSN should report HasSourcePassword=false")
+	}
+	// The raw DSN never leaks into any DTO field.
+	if strings.Contains(dto.SourceHost+dto.SourceUser+dto.SourceDatabase, "secret") {
+		t.Error("password leaked into DTO parts")
+	}
+}
+
+func TestBuildSourceDSNDispatch(t *testing.T) {
+	// buildSourceDSN routes postgres to the PG builder and mysql/mariadb to the
+	// MySQL builder (dbname-less server-level DSN).
+	pg, err := buildSourceDSN(serverRequest{SourceHost: "h", SourceUser: "u", SourcePassword: strPtr("p"), SourceDatabase: "db"}, "", FlavorPostgres)
+	if err != nil || !strings.HasPrefix(pg, "postgres://") {
+		t.Errorf("postgres dispatch: got %q err %v", pg, err)
+	}
+	my, err := buildSourceDSN(serverRequest{SourceHost: "h", SourceUser: "u"}, "", FlavorMariaDB)
+	if err != nil || strings.HasPrefix(my, "postgres://") {
+		t.Errorf("mariadb should route through MySQL builder: got %q err %v", my, err)
+	}
+}
+
+func mustParse(t *testing.T, s string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(s)
+	if err != nil {
+		t.Fatalf("parse %q: %v", s, err)
+	}
+	return u
+}
+
+func mustQuery(t *testing.T, s string) url.Values {
+	t.Helper()
+	return mustParse(t, s).Query()
+}

--- a/internal/console/registry.go
+++ b/internal/console/registry.go
@@ -67,6 +67,19 @@ type ServerEntry struct {
 	// Schemas is the optional comma-separated schema filter for monitoring.
 	Schemas string `yaml:"schemas,omitempty"`
 
+	// ── Source family (#1019) ──
+	// Flavor selects the capture engine: "" or "mysql" (MySQL), "mariadb"
+	// (MySQL DSN, MariaDB GTID at stream), "postgres" (pgstreamrun). Empty →
+	// mysql keeps every pre-#1019 entry working (mirrors an empty SSLMode).
+	// This is the generic "which source family" field #623 (MariaDB) also
+	// needs — one implementation, not two. Accessed via SourceFlavor().
+	Flavor string `yaml:"flavor,omitempty"`
+	// SourceSlot / SourcePublication configure PostgreSQL logical replication
+	// (postgres flavor only): the operator-created publication and the
+	// replication slot the capturer streams from. Empty for MySQL/MariaDB.
+	SourceSlot        string `yaml:"source_slot,omitempty"`
+	SourcePublication string `yaml:"source_publication,omitempty"`
+
 	// ── Source TLS (#879) ──
 	// SSLMode/SSLCA/SSLCert/SSLKey configure the TLS the supervisor uses when
 	// connecting to the SOURCE MySQL. Empty SSLMode = the daemon default

--- a/internal/console/servers_api.go
+++ b/internal/console/servers_api.go
@@ -50,6 +50,15 @@ type serverDTO struct {
 	SourceServerID    uint32 `json:"source_server_id,omitempty"`
 	Schemas           string `json:"schemas,omitempty"`
 	MonitorDesired    bool   `json:"monitor_desired"`
+	// Flavor is the source family ("mysql" | "mariadb" | "postgres"); the
+	// frontend gates per-server without opening the index. SourceDatabase /
+	// SourceSlot / SourcePublication are the PostgreSQL-only source parts (the
+	// database is decomposed from the source DSN — PG replication is
+	// per-database; slot/publication are stored fields). All non-secret.
+	Flavor            string `json:"flavor"`
+	SourceDatabase    string `json:"source_database,omitempty"`
+	SourceSlot        string `json:"source_slot,omitempty"`
+	SourcePublication string `json:"source_publication,omitempty"`
 	// MonitorState is the supervisor's live view (stopped|pending|running|
 	// stalled|lost_position|failed — see console.MonitorStatus); present only
 	// on a supervisor process for entries with a source.
@@ -100,6 +109,15 @@ type serverRequest struct {
 	SourcePassword *string `json:"source_password"`
 	SourceServerID uint32  `json:"source_server_id"`
 	Schemas        string  `json:"schemas"`
+	// Source family + PostgreSQL-only source config (#1019). Flavor is
+	// immutable after create (PUT rejects a change). SourceDatabase feeds the
+	// per-database PG query DSN; SourceSlot/SourcePublication are stored on the
+	// entry and always resent by the form (keep-semantics like Schemas, not
+	// the password's omitted=keep dance).
+	Flavor            string `json:"flavor"`
+	SourceDatabase    string `json:"source_database"`
+	SourceSlot        string `json:"source_slot"`
+	SourcePublication string `json:"source_publication"`
 }
 
 // testResponse is the probe result. HasIndex/SchemaCurrent are tri-state
@@ -179,8 +197,17 @@ func (s *Server) handleServersCreate(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 		return
 	}
-	sourceDSN, err := buildSourceDSN(req, "")
+	flavor, err := NormalizeFlavor(req.Flavor)
 	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	sourceDSN, err := buildSourceDSN(req, "", flavor)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if err := validatePGSourceMonitorConfig(flavor, sourceDSN, req.SourceSlot, req.SourcePublication); err != nil {
 		writeJSONError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -196,15 +223,18 @@ func (s *Server) handleServersCreate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	entry := ServerEntry{
-		Name:           strings.TrimSpace(req.Name),
-		DSN:            dsn,
-		BaselineDir:    req.BaselineDir,
-		BaselineS3:     req.BaselineS3,
-		NoArchive:      req.NoArchive,
-		ArchiveS3:      strings.TrimSpace(req.ArchiveS3),
-		SourceDSN:      sourceDSN,
-		SourceServerID: req.SourceServerID,
-		Schemas:        req.Schemas,
+		Name:              strings.TrimSpace(req.Name),
+		DSN:               dsn,
+		BaselineDir:       req.BaselineDir,
+		BaselineS3:        req.BaselineS3,
+		NoArchive:         req.NoArchive,
+		ArchiveS3:         strings.TrimSpace(req.ArchiveS3),
+		SourceDSN:         sourceDSN,
+		SourceServerID:    req.SourceServerID,
+		Schemas:           req.Schemas,
+		Flavor:            flavor,
+		SourceSlot:        strings.TrimSpace(req.SourceSlot),
+		SourcePublication: strings.TrimSpace(req.SourcePublication),
 	}
 	added, err := s.cm.reg.Add(entry)
 	if err != nil {
@@ -254,8 +284,26 @@ func (s *Server) handleServersUpdate(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	sourceDSN, err := buildSourceDSN(req, old.SourceDSN)
+	// Flavor is immutable: the capture engine, per-source index DB layout, and
+	// stream_state are all keyed to it. Changing it means a fresh entry.
+	flavor := old.SourceFlavor()
+	if req.Flavor != "" {
+		reqFlavor, ferr := NormalizeFlavor(req.Flavor)
+		if ferr != nil {
+			writeJSONError(w, http.StatusBadRequest, ferr.Error())
+			return
+		}
+		if reqFlavor != flavor {
+			writeJSONError(w, http.StatusBadRequest, "source flavor cannot be changed; delete and re-create the server")
+			return
+		}
+	}
+	sourceDSN, err := buildSourceDSN(req, old.SourceDSN, flavor)
 	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if err := validatePGSourceMonitorConfig(flavor, sourceDSN, req.SourceSlot, req.SourcePublication); err != nil {
 		writeJSONError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -277,9 +325,12 @@ func (s *Server) handleServersUpdate(w http.ResponseWriter, r *http.Request) {
 		SourceDSN:   sourceDSN,
 		// The verbs that flip monitoring intent arrive with the supervisor
 		// (phase 3); a plain edit must not silently start or stop anything.
-		MonitorDesired: old.MonitorDesired,
-		SourceServerID: req.SourceServerID,
-		Schemas:        req.Schemas,
+		MonitorDesired:    old.MonitorDesired,
+		SourceServerID:    req.SourceServerID,
+		Schemas:           req.Schemas,
+		Flavor:            flavor,
+		SourceSlot:        strings.TrimSpace(req.SourceSlot),
+		SourcePublication: strings.TrimSpace(req.SourcePublication),
 		// Source TLS (#879) has no request field yet — it is hand-edited into
 		// the registry YAML. Carry it over from the stored entry so a plain UI
 		// edit does not wipe a configured verify-ca / mutual-TLS source
@@ -688,15 +739,25 @@ func buildDSN(req serverRequest, stored string) (string, error) {
 	return cfg.FormatDSN(), nil
 }
 
-// buildSourceDSN assembles the stored SOURCE DSN (replication credentials)
-// for a create/update request. Tri-state on req.SourceDSN: nil → build from
-// the structured source fields layered over the stored source DSN (keep
-// semantics, password merged via req.SourcePassword's own tri-state); "" →
-// clear the source config entirely (back to a view-only entry); a value →
-// used verbatim. Validation differs from the index DSN: replication needs a
-// TCP address and a user, but NO database name (a source DSN is server-level,
-// e.g. user:pass@tcp(host:3306)/).
-func buildSourceDSN(req serverRequest, stored string) (string, error) {
+// buildSourceDSN assembles the stored SOURCE DSN for a create/update request,
+// dispatching on the source family. PostgreSQL builds a postgres:// query DSN
+// (per-database, buildPGSourceDSN in flavor.go); MySQL/MariaDB build a go-mysql
+// source DSN (buildMySQLSourceDSN below).
+func buildSourceDSN(req serverRequest, stored, flavor string) (string, error) {
+	if flavor == FlavorPostgres {
+		return buildPGSourceDSN(req, stored)
+	}
+	return buildMySQLSourceDSN(req, stored)
+}
+
+// buildMySQLSourceDSN assembles the stored MySQL/MariaDB SOURCE DSN (replication
+// credentials). Tri-state on req.SourceDSN: nil → build from the structured
+// source fields layered over the stored source DSN (keep semantics, password
+// merged via req.SourcePassword's own tri-state); "" → clear the source config
+// entirely (back to a view-only entry); a value → used verbatim. Validation
+// differs from the index DSN: replication needs a TCP address and a user, but NO
+// database name (a source DSN is server-level, e.g. user:pass@tcp(host:3306)/).
+func buildMySQLSourceDSN(req serverRequest, stored string) (string, error) {
 	if req.SourceDSN != nil {
 		raw := *req.SourceDSN
 		if raw == "" {
@@ -771,23 +832,26 @@ func buildSourceDSN(req serverRequest, stored string) (string, error) {
 // plus has_password. The DSN string itself never leaves the process.
 func (s *Server) entryDTO(e ServerEntry) serverDTO {
 	dto := serverDTO{
-		ID:             e.ID,
-		Name:           e.Name,
-		Kind:           "registry",
-		BaselineDir:    e.BaselineDir,
-		BaselineS3:     e.BaselineS3,
-		NoArchive:      e.NoArchive,
-		ArchiveS3:      e.ArchiveS3,
-		Reconstruct:    s.cm.capability(e),
-		Editable:       !s.cm.reg.ReadOnly(),
-		Deletable:      !s.cm.reg.ReadOnly(),
-		Connected:      s.cm.cached(e.ID),
-		SourceServerID: e.SourceServerID,
-		Schemas:        e.Schemas,
-		MonitorDesired: e.MonitorDesired,
+		ID:                e.ID,
+		Name:              e.Name,
+		Kind:              "registry",
+		BaselineDir:       e.BaselineDir,
+		BaselineS3:        e.BaselineS3,
+		NoArchive:         e.NoArchive,
+		ArchiveS3:         e.ArchiveS3,
+		Reconstruct:       s.cm.capability(e),
+		Editable:          !s.cm.reg.ReadOnly(),
+		Deletable:         !s.cm.reg.ReadOnly(),
+		Connected:         s.cm.cached(e.ID),
+		SourceServerID:    e.SourceServerID,
+		Schemas:           e.Schemas,
+		MonitorDesired:    e.MonitorDesired,
+		Flavor:            e.SourceFlavor(),
+		SourceSlot:        e.SourceSlot,
+		SourcePublication: e.SourcePublication,
 	}
 	fillDSNParts(&dto, e.DSN)
-	fillSourceDSNParts(&dto, e.SourceDSN)
+	fillSourceDSNParts(&dto, e.SourceDSN, e.SourceFlavor())
 	if s.monitorCtrl != nil && e.SourceDSN != "" {
 		dto.MonitorState = s.monitorCtrl.Status(e.ID).State
 	}
@@ -797,7 +861,11 @@ func (s *Server) entryDTO(e ServerEntry) serverDTO {
 // fillSourceDSNParts decomposes the source DSN into the masked DTO fields —
 // the replication credentials themselves never leave the process. Parse
 // failures leave the parts blank rather than leaking the raw string.
-func fillSourceDSNParts(dto *serverDTO, dsn string) {
+func fillSourceDSNParts(dto *serverDTO, dsn, flavor string) {
+	if flavor == FlavorPostgres {
+		fillPGSourceDSNParts(dto, dsn)
+		return
+	}
 	if dsn == "" {
 		return
 	}

--- a/internal/console/servers_api_test.go
+++ b/internal/console/servers_api_test.go
@@ -516,13 +516,13 @@ func TestBuildSourceDSNValidation(t *testing.T) {
 		{"structured without user", serverRequest{SourceHost: "h"}},
 	}
 	for _, tc := range cases {
-		if _, err := buildSourceDSN(tc.req, ""); err == nil {
+		if _, err := buildSourceDSN(tc.req, "", FlavorMySQL); err == nil {
 			t.Errorf("%s: expected error", tc.name)
 		}
 	}
 
 	// A source DSN needs NO database name (server-level), unlike the index DSN.
-	got, err := buildSourceDSN(serverRequest{SourceHost: "h", SourceUser: "repl"}, "")
+	got, err := buildSourceDSN(serverRequest{SourceHost: "h", SourceUser: "repl"}, "", FlavorMySQL)
 	if err != nil {
 		t.Fatalf("dbname-less source must be valid: %v", err)
 	}

--- a/internal/console/servers_pg_test.go
+++ b/internal/console/servers_pg_test.go
@@ -51,14 +51,25 @@ func TestHandleServersCreate_postgres(t *testing.T) {
 
 // TestHandleServersCreate_postgresRequiresSlotPublication: a monitorable PG
 // source (a source DSN configured) with no slot/publication is a clear 400 —
-// capture cannot start without them.
+// capture cannot start without them. Missing either half fails (symmetric on the
+// slot/publication ||), and — the stronger contract — no incomplete entry is
+// persisted: a rejected create must not leave a half-written PG source behind.
 func TestHandleServersCreate_postgresRequiresSlotPublication(t *testing.T) {
 	srv := newRegistryServer(t)
-	body := `{"name":"pgnoslot","host":"idx","user":"bt","password":"ipw","dbname":"binlog_index",` +
-		`"flavor":"postgres","source_host":"pg.prod","source_user":"repl","source_password":"p","source_database":"appdb"}`
-	rec, resp := doServersReq(t, srv, "POST", "/api/servers", body)
-	if rec.Code != 400 {
-		t.Fatalf("pg create without slot/publication: code=%d, want 400 (body=%s)", rec.Code, resp)
+	const base = `{"name":"pgnoslot","host":"idx","user":"bt","password":"ipw","dbname":"binlog_index",` +
+		`"flavor":"postgres","source_host":"pg.prod","source_user":"repl","source_password":"p","source_database":"appdb"`
+	for _, tc := range []struct{ name, extra string }{
+		{"neither", `}`},
+		{"slot only", `,"source_slot":"bt_slot"}`},
+		{"publication only", `,"source_publication":"bt_pub"}`},
+	} {
+		rec, resp := doServersReq(t, srv, "POST", "/api/servers", base+tc.extra)
+		if rec.Code != 400 {
+			t.Fatalf("%s: code=%d, want 400 (body=%s)", tc.name, rec.Code, resp)
+		}
+	}
+	if n := srv.cm.reg.Len(); n != 0 {
+		t.Fatalf("a rejected PG create must not persist an entry, registry has %d", n)
 	}
 }
 

--- a/internal/console/servers_pg_test.go
+++ b/internal/console/servers_pg_test.go
@@ -1,0 +1,90 @@
+package console
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestHandleServersCreate_postgres drives the +Add server handler end-to-end for
+// a PostgreSQL source: the DTO echoes flavor + the decomposed non-secret source
+// parts (slot/publication/database), the source password never leaks, and the
+// stored source DSN is a postgres:// QUERY DSN (no replication param — that is
+// derived at monitor/baseline time).
+func TestHandleServersCreate_postgres(t *testing.T) {
+	srv := newRegistryServer(t)
+	const srcPW = "srcpw-should-not-leak"
+	body := `{"name":"pgprod","host":"idx","user":"bt","password":"ipw","dbname":"binlog_index",` +
+		`"flavor":"postgres","source_host":"pg.prod","source_port":"5432","source_user":"repl",` +
+		`"source_password":"` + srcPW + `","source_database":"appdb","source_slot":"bt_slot","source_publication":"bt_pub"}`
+	rec, resp := doServersReq(t, srv, "POST", "/api/servers", body)
+	if rec.Code != 201 {
+		t.Fatalf("pg create code=%d body=%s", rec.Code, resp)
+	}
+	if strings.Contains(string(resp), srcPW) {
+		t.Fatal("create response leaked the source password")
+	}
+	var dto serverDTO
+	if err := json.Unmarshal(resp, &dto); err != nil {
+		t.Fatal(err)
+	}
+	if dto.Flavor != FlavorPostgres {
+		t.Errorf("flavor = %q, want postgres", dto.Flavor)
+	}
+	if dto.SourceHost != "pg.prod" || dto.SourcePort != "5432" || dto.SourceUser != "repl" || dto.SourceDatabase != "appdb" {
+		t.Errorf("decomposed source parts wrong: %+v", dto)
+	}
+	if dto.SourceSlot != "bt_slot" || dto.SourcePublication != "bt_pub" {
+		t.Errorf("slot/publication wrong: slot=%q pub=%q", dto.SourceSlot, dto.SourcePublication)
+	}
+	if !dto.HasSourcePassword {
+		t.Error("has_source_password should be true")
+	}
+	e, ok := srv.cm.reg.Get(dto.ID)
+	if !ok {
+		t.Fatal("entry not stored")
+	}
+	if !strings.HasPrefix(e.SourceDSN, "postgres://") || strings.Contains(e.SourceDSN, "replication=") {
+		t.Errorf("stored source DSN must be a postgres:// query DSN with no replication param, got %q", e.SourceDSN)
+	}
+}
+
+// TestHandleServersCreate_postgresRequiresSlotPublication: a monitorable PG
+// source (a source DSN configured) with no slot/publication is a clear 400 —
+// capture cannot start without them.
+func TestHandleServersCreate_postgresRequiresSlotPublication(t *testing.T) {
+	srv := newRegistryServer(t)
+	body := `{"name":"pgnoslot","host":"idx","user":"bt","password":"ipw","dbname":"binlog_index",` +
+		`"flavor":"postgres","source_host":"pg.prod","source_user":"repl","source_password":"p","source_database":"appdb"}`
+	rec, resp := doServersReq(t, srv, "POST", "/api/servers", body)
+	if rec.Code != 400 {
+		t.Fatalf("pg create without slot/publication: code=%d, want 400 (body=%s)", rec.Code, resp)
+	}
+}
+
+// TestHandleServersUpdate_flavorImmutable: flavor is fixed at create (the capture
+// engine, per-source index DB layout, and stream_state are all keyed to it). A
+// PUT changing it is refused with a clear 400.
+func TestHandleServersUpdate_flavorImmutable(t *testing.T) {
+	srv := newRegistryServer(t)
+	rec, resp := doServersReq(t, srv, "POST", "/api/servers",
+		`{"name":"m1","host":"idx","user":"bt","password":"ipw","dbname":"binlog_index"}`)
+	if rec.Code != 201 {
+		t.Fatalf("create code=%d body=%s", rec.Code, resp)
+	}
+	var dto serverDTO
+	if err := json.Unmarshal(resp, &dto); err != nil {
+		t.Fatal(err)
+	}
+	if dto.Flavor != FlavorMySQL {
+		t.Fatalf("a flavor-less create should default to mysql, got %q", dto.Flavor)
+	}
+	rec, resp = doServersReq(t, srv, "PUT", "/api/servers/"+dto.ID,
+		`{"name":"m1","host":"idx","user":"bt","password":"ipw","dbname":"binlog_index","flavor":"postgres"}`)
+	if rec.Code != 400 {
+		t.Fatalf("flavor change: code=%d, want 400 (body=%s)", rec.Code, resp)
+	}
+	if !strings.Contains(string(resp), "flavor cannot be changed") {
+		t.Errorf("want a clear immutability message, got: %s", resp)
+	}
+}

--- a/internal/console/verify_trigger.go
+++ b/internal/console/verify_trigger.go
@@ -201,6 +201,15 @@ func (s *Server) handleVerifyTrigger(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusBadRequest, "this server has no source configured; set the source connection first")
 		return
 	}
+	// Live-source verify fingerprints the source with MySQL-only SQL. For a PG
+	// source, baseline-anchored verify (the default) is the supported path; a
+	// live-source request is refused with a clear message, not a misleading
+	// inconclusive (#1009). The engine backstops this in cmd/bintrail-console.
+	if mode == VerifyModeLiveSource && e.IsPostgres() {
+		writeJSONError(w, http.StatusBadRequest,
+			"live-source verify is not supported for PostgreSQL sources; use baseline-anchored (the default) instead")
+		return
+	}
 
 	req := VerifyRequest{
 		ServerID: e.ID, ServerName: e.Name, Mode: mode, Tables: body.Tables,

--- a/internal/console/verify_trigger_test.go
+++ b/internal/console/verify_trigger_test.go
@@ -281,6 +281,59 @@ func TestVerifyTrigger_unknownServer(t *testing.T) {
 	}
 }
 
+// addVerifyEntryPG adds a PostgreSQL registry entry (source + baseline set) so
+// the flavor-scoped verify branches can be exercised without a live PG.
+func addVerifyEntryPG(t *testing.T, srv *Server) string {
+	t.Helper()
+	e, err := srv.cm.reg.Add(ServerEntry{
+		Name:       "pg",
+		DSN:        "idx:idxpw@tcp(127.0.0.1:3306)/binlog_index",
+		Flavor:     FlavorPostgres,
+		SourceDSN:  "postgres://repl:p@pg.prod:5432/appdb",
+		BaselineS3: "s3://b/baselines/",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return e.ID
+}
+
+// TestVerifyTrigger_postgresRefusesLiveSource: live-source verify fingerprints
+// the source with MySQL-only SQL, so a PostgreSQL source is refused with a hard
+// 400 (deferred to #1024) — a clear message, never a misleading inconclusive,
+// and the controller is never triggered. A baseline destination is set so this
+// branch (not the earlier baseline gate) is what fires. No live PG needed.
+func TestVerifyTrigger_postgresRefusesLiveSource(t *testing.T) {
+	srv, ctrl := newVerifyTriggerServer(t)
+	id := addVerifyEntryPG(t, srv)
+	rec, body := doServersReq(t, srv, "POST", "/api/servers/"+id+"/verify", `{"mode":"live-source"}`)
+	if rec.Code != 400 {
+		t.Fatalf("PG live-source: code=%d, want 400 (body=%s)", rec.Code, body)
+	}
+	if !strings.Contains(string(body), "not supported for PostgreSQL") {
+		t.Errorf("want the clear PG-refusal message, got: %s", body)
+	}
+	if len(ctrl.triggered) != 0 {
+		t.Fatal("controller must never be triggered for a PG live-source request")
+	}
+}
+
+// TestVerifyTrigger_postgresAllowsBaselineAnchored: the refusal above is scoped
+// to live-source ONLY. The default mode (baseline-anchored) reads the index, not
+// the live source, so it IS supported for PG and reaches the controller — this
+// is the parity the refusal must not overreach and break.
+func TestVerifyTrigger_postgresAllowsBaselineAnchored(t *testing.T) {
+	srv, ctrl := newVerifyTriggerServer(t)
+	id := addVerifyEntryPG(t, srv)
+	rec, body := doServersReq(t, srv, "POST", "/api/servers/"+id+"/verify", "")
+	if rec.Code != 202 {
+		t.Fatalf("PG baseline-anchored: code=%d, want 202 (body=%s)", rec.Code, body)
+	}
+	if len(ctrl.triggered) != 1 {
+		t.Fatalf("baseline-anchored PG verify must trigger the controller, got %d", len(ctrl.triggered))
+	}
+}
+
 // TestVerifyTrigger_happy: a fully-configured entry triggers a default
 // (baseline-anchored) run (202), the controller receives the index DSN and
 // baseline destination, and the HTTP response never leaks the index password.

--- a/internal/pgstreamrun/health_wiring_integration_test.go
+++ b/internal/pgstreamrun/health_wiring_integration_test.go
@@ -38,7 +38,7 @@ func driveHealthOnce(t *testing.T, probe func(context.Context) (pgcapture.Health
 
 	done := make(chan error, 1)
 	go func() {
-		done <- streamLoopPG(ctx, events, idx, indexDB, nil, time.Hour, probe, 15*time.Millisecond, state, slog.New(slog.DiscardHandler))
+		done <- streamLoopPG(ctx, events, idx, indexDB, nil, time.Hour, probe, 15*time.Millisecond, state, slog.New(slog.DiscardHandler), nil)
 	}()
 
 	present := false

--- a/internal/pgstreamrun/hooks_internal_test.go
+++ b/internal/pgstreamrun/hooks_internal_test.go
@@ -1,0 +1,52 @@
+package pgstreamrun
+
+import (
+	"context"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/event"
+	"github.com/dbtrail/dbtrail/internal/indexer"
+)
+
+// TestStreamLoopPGHooks_idleCheckpointLiveness proves the load-bearing liveness
+// invariant behind console-driven PG capture (#1020): a connected-but-idle
+// source (nothing committed, lastCommitLSN==0) still fires OnCheckpoint on the
+// ticker, so a supervised job flips out of "pending" even before the first row.
+// checkpoint() early-returns at lastCommitLSN==0, which is exactly why the hook
+// fires on the ticker branch and not inside checkpoint(). No live DB: an empty
+// batch never flushes, so the nil-db indexer is never touched.
+func TestStreamLoopPGHooks_idleCheckpointLiveness(t *testing.T) {
+	var checkpoints, indexed int64
+	hooks := &Hooks{
+		OnCheckpoint: func() { atomic.AddInt64(&checkpoints, 1) },
+		OnIndexed:    func(n int64) { atomic.AddInt64(&indexed, n) },
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	events := make(chan event.Event) // stays open, never receives — a silent, connected source
+	idx := indexer.New(nil, 1)       // BatchSize() only reads a field; never flushes here
+	state := &pgStreamState{serverID: 1}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- streamLoopPG(ctx, events, idx, nil /*indexDB*/, nil /*cap*/, 5*time.Millisecond, nil /*probe*/, time.Hour, state, slog.New(slog.DiscardHandler), hooks)
+	}()
+
+	time.Sleep(60 * time.Millisecond) // ~12 ticker ticks
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("streamLoopPG did not return after cancel")
+	}
+
+	if atomic.LoadInt64(&checkpoints) == 0 {
+		t.Error("OnCheckpoint never fired for an idle source — a supervised PG job would be stuck pending forever")
+	}
+	if got := atomic.LoadInt64(&indexed); got != 0 {
+		t.Errorf("OnIndexed fired (%d) with no rows streamed", got)
+	}
+}

--- a/internal/pgstreamrun/pgstreamrun.go
+++ b/internal/pgstreamrun/pgstreamrun.go
@@ -64,6 +64,24 @@ type Config struct {
 	Partitions  int           // binlog_events partitions for the one-time bootstrap (0 → 48)
 	Checkpoint  time.Duration // checkpoint interval (0 → 5s)
 	Logger      *slog.Logger
+	// Hooks, when non-nil, lets a supervisor observe this stream's liveness —
+	// a console-started PG stream flips pending→running once rows index or the
+	// checkpoint ticker fires. Mirrors streamrun.Hooks MINUS OnGapAutoAdvance: a
+	// lost PG slot is fatal (One returns it; the supervisor reconnects), not a
+	// continue-after-loss.
+	Hooks *Hooks
+}
+
+// Hooks are liveness callbacks a supervisor attaches to one PG stream. Both are
+// optional and invoked synchronously from the stream loop — keep them fast.
+type Hooks struct {
+	// OnCheckpoint fires after each successful checkpoint tick, INCLUDING an
+	// idle source with nothing committed (the ticker fires regardless) — the
+	// "attached and healthy" signal that flips a supervised job pending→running
+	// even before the first row.
+	OnCheckpoint func()
+	// OnIndexed fires after a batch flush that wrote rows.
+	OnIndexed func(n int64)
 }
 
 // pgStreamState mirrors the streamrun checkpoint row, scoped to what a PG source
@@ -164,7 +182,7 @@ func One(ctx context.Context, cfg Config) error {
 	probe := func(c context.Context) (pgcapture.HealthSnapshot, error) {
 		return pgcapture.ProbeHealth(c, cfg.QueryDSN, cfg.SlotName, cfg.Publication)
 	}
-	loopErr := streamLoopPG(ctx, events, idx, indexDB, cap, checkpointInterval, probe, healthPollInterval, state, logger)
+	loopErr := streamLoopPG(ctx, events, idx, indexDB, cap, checkpointInterval, probe, healthPollInterval, state, logger, cfg.Hooks)
 	cancel() // loop exited first → unblock the capturer's emit/receive so it returns
 
 	// Run returns nil on ctx-cancel; only a real capture error matters.
@@ -330,6 +348,7 @@ func streamLoopPG(
 	healthInterval time.Duration,
 	state *pgStreamState,
 	logger *slog.Logger,
+	hooks *Hooks,
 ) error {
 	batch := make([]event.Event, 0, idx.BatchSize())
 	ticker := time.NewTicker(checkpointInterval)
@@ -397,6 +416,10 @@ func streamLoopPG(
 		// checkpoint. If a future change ever retries or continues past a flush
 		// error, this clear must move into the success branch or those rows are lost.
 		batch = batch[:0]
+		// Liveness: any rows indexed flip a supervised job pending→running.
+		if err == nil && n > 0 && hooks != nil && hooks.OnIndexed != nil {
+			hooks.OnIndexed(n)
+		}
 		return err
 	}
 
@@ -427,6 +450,12 @@ func streamLoopPG(
 		case <-ticker.C:
 			if err := checkpoint(); err != nil {
 				return err
+			}
+			// Fire on the ticker, NOT inside checkpoint(): checkpoint early-returns
+			// at lastCommitLSN==0 for a connected-but-idle source, and liveness must
+			// still signal so the supervised job leaves "pending".
+			if hooks != nil && hooks.OnCheckpoint != nil {
+				hooks.OnCheckpoint()
 			}
 
 		case <-healthC:

--- a/internal/reconstruct/fulltable.go
+++ b/internal/reconstruct/fulltable.go
@@ -720,6 +720,9 @@ type mergeCore struct {
 	Table             string
 	PKCols            []metadata.ColumnMeta
 	Changes           map[string]*query.ResultRow
+	// PGTextPK skips the MySQL PK canonicalizer for a PostgreSQL source (text
+	// PK on both baseline and delta sides). See SnapshotFullTableInput.PGTextPK.
+	PGTextPK bool
 }
 
 // mergeStats counts what mergeBaselineImages did, for the offline
@@ -807,9 +810,17 @@ func mergeBaselineImages(ctx context.Context, in mergeCore, emit func(map[string
 		// go-mysql-formatted string (#212). canonicalizePKMap does not
 		// mutate rowMap, so the emitted pass-through row keeps its original
 		// values.
-		pkMap, err := canonicalizePKMap(rowMap, in.PKCols)
-		if err != nil {
-			return stats, fmt.Errorf("canonicalize baseline PK for %s.%s: %w", in.Schema, in.Table, err)
+		// PostgreSQL: baseline COPY text and delta pgoutput text are the same
+		// bytes, so the PK match is string-identity — skip the MySQL DATA_TYPE
+		// canonicalizer, which errors on PG's empty DATA_TYPE token. MySQL still
+		// canonicalizes (DuckDB returns time.Time for a DATETIME/TIMESTAMP PK,
+		// which must become the indexer's stored string, #212).
+		pkMap := rowMap
+		if !in.PGTextPK {
+			var err error
+			if pkMap, err = canonicalizePKMap(rowMap, in.PKCols); err != nil {
+				return stats, fmt.Errorf("canonicalize baseline PK for %s.%s: %w", in.Schema, in.Table, err)
+			}
 		}
 		pk := event.BuildPKValues(in.PKCols, pkMap)
 
@@ -893,6 +904,13 @@ type SnapshotFullTableInput struct {
 	// per PK by the query, so their detection is bounded by that fetch; nil
 	// falls back to the map-only backstop (pkChangingUpdate).
 	Events []query.ResultRow
+	// PGTextPK marks a PostgreSQL source: the baseline Parquet and the delta
+	// pk_values BOTH store every column as raw text (pgbaseline COPY text ==
+	// pgoutput text), so the PK match is string-identity — skip the MySQL
+	// DATA_TYPE canonicalizer, which errors on PG's empty DATA_TYPE token. A
+	// caller that sets this must have skipped the SupportedPKType precondition
+	// accordingly. Zero value (false) preserves the MySQL path verbatim.
+	PGTextPK bool
 }
 
 // SnapshotFullTableImages reconstructs the full row state of a table at the
@@ -941,6 +959,7 @@ func SnapshotFullTableImages(ctx context.Context, in SnapshotFullTableInput, emi
 		Table:             in.Table,
 		PKCols:            in.PKCols,
 		Changes:           in.Changes,
+		PGTextPK:          in.PGTextPK,
 	}, emit)
 	return err
 }

--- a/internal/reconstruct/fulltable_pgtextpk_test.go
+++ b/internal/reconstruct/fulltable_pgtextpk_test.go
@@ -1,0 +1,102 @@
+package reconstruct
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/baseline"
+	"github.com/dbtrail/dbtrail/internal/event"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/query"
+)
+
+// writePGTextBaseline writes a baseline whose columns are stored as text, the
+// way pgbaseline's COPY-text output lands them — DuckDB scans them back as Go
+// strings, matching the pgoutput-text pk_values the delta side stored. This is
+// the fixture behind the PGTextPK string-identity PK match.
+func writePGTextBaseline(t *testing.T, rows [][]string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "baseline.parquet")
+	cols := []baseline.Column{
+		{Name: "id", MySQLType: "varchar", ParquetType: baseline.MysqlToParquetNode("varchar")},
+		{Name: "status", MySQLType: "varchar", ParquetType: baseline.MysqlToParquetNode("varchar")},
+	}
+	w, err := baseline.NewWriter(path, cols, baseline.WriterConfig{Compression: "none", RowGroupSize: 10})
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	for _, r := range rows {
+		if err := w.WriteRow(r, []bool{false, false}); err != nil {
+			t.Fatalf("WriteRow: %v", err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	return path
+}
+
+// pgTextPKCols is a PostgreSQL-style PK descriptor: DataType is EMPTY (a PG
+// column carries no MySQL DATA_TYPE token). That empty token is exactly what
+// makes the MySQL canonicalizer error and what PGTextPK bypasses.
+func pgTextPKCols() []metadata.ColumnMeta {
+	return []metadata.ColumnMeta{{Name: "id", OrdinalPosition: 1, IsPK: true, DataType: ""}}
+}
+
+// TestSnapshotFullTableImages_pgTextPK_match proves the #1022 core: a PostgreSQL
+// full-table merge (baseline + deltas) succeeds with an empty-DATA_TYPE PK and
+// matches the delta events to baseline rows by string identity — no live PG,
+// pure Parquet + change map. This is the first full-table PG merge; the MySQL
+// canonicalizer is bypassed via PGTextPK.
+func TestSnapshotFullTableImages_pgTextPK_match(t *testing.T) {
+	baselinePath := writePGTextBaseline(t, [][]string{{"1", "new"}, {"2", "paid"}, {"3", "shipped"}})
+	pkCols := pgTextPKCols()
+	changes := map[string]*query.ResultRow{
+		event.BuildPKValues(pkCols, map[string]any{"id": "2"}): {
+			EventType: event.EventUpdate, SchemaName: "app", TableName: "orders",
+			PKValues: "2", RowAfter: map[string]any{"id": "2", "status": "DONE"},
+		},
+		event.BuildPKValues(pkCols, map[string]any{"id": "4"}): {
+			EventType: event.EventInsert, SchemaName: "app", TableName: "orders",
+			PKValues: "4", RowAfter: map[string]any{"id": "4", "status": "NEW"},
+		},
+	}
+
+	got := map[string]string{}
+	err := SnapshotFullTableImages(context.Background(), SnapshotFullTableInput{
+		BaselinePath: baselinePath, Schema: "app", Table: "orders",
+		PKCols: pkCols, Changes: changes, PGTextPK: true,
+	}, func(row map[string]any) error {
+		got[fmt.Sprint(row["id"])] = fmt.Sprint(row["status"])
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("PGTextPK merge must succeed for an empty-DATA_TYPE PK: %v", err)
+	}
+	want := map[string]string{"1": "new", "2": "DONE", "3": "shipped", "4": "NEW"}
+	if len(got) != len(want) {
+		t.Fatalf("row count = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for id, st := range want {
+		if got[id] != st {
+			t.Errorf("id=%s status=%q, want %q (full: %v)", id, got[id], st, got)
+		}
+	}
+}
+
+// TestSnapshotFullTableImages_pgTextPK_falseStillCanonicalizes proves the flag —
+// not some unrelated change — is what bypasses the canonicalizer, and that the
+// MySQL path stays intact: with PGTextPK=false the same empty-DATA_TYPE PK hits
+// the canonicalizer and errors loudly.
+func TestSnapshotFullTableImages_pgTextPK_falseStillCanonicalizes(t *testing.T) {
+	baselinePath := writePGTextBaseline(t, [][]string{{"1", "new"}})
+	err := SnapshotFullTableImages(context.Background(), SnapshotFullTableInput{
+		BaselinePath: baselinePath, Schema: "app", Table: "orders",
+		PKCols: pgTextPKCols(), Changes: map[string]*query.ResultRow{}, PGTextPK: false,
+	}, func(map[string]any) error { return nil })
+	if err == nil {
+		t.Fatal("expected a canonicalize error for an empty-DATA_TYPE PK when PGTextPK=false")
+	}
+}

--- a/internal/verify/explain_baseline.go
+++ b/internal/verify/explain_baseline.go
@@ -126,17 +126,24 @@ func ExplainBaselinePairMismatch(ctx context.Context, cfg BaselineConfig, p Base
 	// VerifyBaselinePair reconstructs the recovery side over (#797: PrevAnchor,
 	// when recorded, replaces the imprecise PrevSnapshot DATETIME lower bound —
 	// see VerifyBaselinePair's comment).
+	pg := cfg.SourceFlavor == flavorPostgres
 	engine := query.New(cfg.IndexDB)
 	fetchOpts := query.Options{
 		Schema:     p.Schema,
 		Table:      p.Table,
 		Since:      &p.PrevSnapshot,
 		Until:      &p.NewSnapshot,
-		UntilPos:   &p.NewAnchor,
 		LimitPerPK: 1,
 	}
-	if p.PrevAnchor.File != "" && p.PrevAnchor.Pos != 0 {
-		fetchOpts.SincePos = &p.PrevAnchor
+	if pg {
+		// Time-bounded delta window for PostgreSQL (non-monotonic LSN in
+		// binlog_file); mirrors VerifyBaselinePair so the drill-down sees exactly
+		// the rows the verdict's digest saw.
+	} else {
+		fetchOpts.UntilPos = &p.NewAnchor
+		if p.PrevAnchor.File != "" && p.PrevAnchor.Pos != 0 {
+			fetchOpts.SincePos = &p.PrevAnchor
+		}
 	}
 	rows, _, err := query.FetchMerged(ctx, cfg.IndexDB, engine, query.FetchMergedOptions{
 		Opts:           fetchOpts,
@@ -160,14 +167,14 @@ func ExplainBaselinePairMismatch(ctx context.Context, cfg BaselineConfig, p Base
 
 	// Truth side held fully (the new baseline as-is); recovery streamed against it
 	// so only one side is materialized in memory at a time.
-	truth, err := collectRowsByPK(ctx, p.NewPath, p.Schema, p.Table, pkCols, orderedCols, map[string]*query.ResultRow{})
+	truth, err := collectRowsByPK(ctx, p.NewPath, p.Schema, p.Table, pkCols, orderedCols, map[string]*query.ResultRow{}, pg)
 	if err != nil {
 		return nil, fmt.Errorf("read new baseline %s.%s: %w", p.Schema, p.Table, err)
 	}
 
-	ex := &MismatchExplanation{Schema: p.Schema, Table: p.Table, Anchor: fmt.Sprintf("%s:%d", p.NewAnchor.File, p.NewAnchor.Pos)}
+	ex := &MismatchExplanation{Schema: p.Schema, Table: p.Table, Anchor: anchorLabel(pg, p)}
 	seen := make(map[string]bool, len(truth))
-	err = streamRowsByPK(ctx, p.PrevPath, p.Schema, p.Table, pkCols, orderedCols, changes, rows, func(key string, rec rowCells) error {
+	err = streamRowsByPK(ctx, p.PrevPath, p.Schema, p.Table, pkCols, orderedCols, changes, rows, pg, func(key string, rec rowCells) error {
 		seen[key] = true
 		t, ok := truth[key]
 		if !ok {
@@ -222,7 +229,7 @@ func ExplainBaselinePairMismatch(ctx context.Context, cfg BaselineConfig, p Base
 // the SAME renderCellNormalized reconstructDigest's baseline-anchored callers
 // use, so a row this drill-down shows as differing is exactly a row the digest
 // that flagged the mismatch also saw as differing (cellEqual's invariant).
-func streamRowsByPK(ctx context.Context, baselinePath, schema, table string, pkCols, orderedCols []metadata.ColumnMeta, changes map[string]*query.ResultRow, events []query.ResultRow, emit func(key string, r rowCells) error) error {
+func streamRowsByPK(ctx context.Context, baselinePath, schema, table string, pkCols, orderedCols []metadata.ColumnMeta, changes map[string]*query.ResultRow, events []query.ResultRow, pgTextPK bool, emit func(key string, r rowCells) error) error {
 	return reconstruct.SnapshotFullTableImages(ctx, reconstruct.SnapshotFullTableInput{
 		BaselinePath: baselinePath,
 		Schema:       schema,
@@ -230,6 +237,7 @@ func streamRowsByPK(ctx context.Context, baselinePath, schema, table string, pkC
 		PKCols:       pkCols,
 		Changes:      changes,
 		Events:       events,
+		PGTextPK:     pgTextPK,
 	}, func(rowMap map[string]any) error {
 		key, pk := pkKeyAndDisplay(rowMap, pkCols)
 		cells := make(map[string][]byte, len(orderedCols))
@@ -240,9 +248,9 @@ func streamRowsByPK(ctx context.Context, baselinePath, schema, table string, pkC
 	})
 }
 
-func collectRowsByPK(ctx context.Context, baselinePath, schema, table string, pkCols, orderedCols []metadata.ColumnMeta, changes map[string]*query.ResultRow) (map[string]rowCells, error) {
+func collectRowsByPK(ctx context.Context, baselinePath, schema, table string, pkCols, orderedCols []metadata.ColumnMeta, changes map[string]*query.ResultRow, pgTextPK bool) (map[string]rowCells, error) {
 	out := make(map[string]rowCells)
-	err := streamRowsByPK(ctx, baselinePath, schema, table, pkCols, orderedCols, changes, nil, func(key string, r rowCells) error {
+	err := streamRowsByPK(ctx, baselinePath, schema, table, pkCols, orderedCols, changes, nil, pgTextPK, func(key string, r rowCells) error {
 		out[key] = r
 		return nil
 	})

--- a/internal/verify/explain_baseline.go
+++ b/internal/verify/explain_baseline.go
@@ -128,23 +128,9 @@ func ExplainBaselinePairMismatch(ctx context.Context, cfg BaselineConfig, p Base
 	// see VerifyBaselinePair's comment).
 	pg := cfg.SourceFlavor == flavorPostgres
 	engine := query.New(cfg.IndexDB)
-	fetchOpts := query.Options{
-		Schema:     p.Schema,
-		Table:      p.Table,
-		Since:      &p.PrevSnapshot,
-		Until:      &p.NewSnapshot,
-		LimitPerPK: 1,
-	}
-	if pg {
-		// Time-bounded delta window for PostgreSQL (non-monotonic LSN in
-		// binlog_file); mirrors VerifyBaselinePair so the drill-down sees exactly
-		// the rows the verdict's digest saw.
-	} else {
-		fetchOpts.UntilPos = &p.NewAnchor
-		if p.PrevAnchor.File != "" && p.PrevAnchor.Pos != 0 {
-			fetchOpts.SincePos = &p.PrevAnchor
-		}
-	}
+	// Same window as VerifyBaselinePair (time-bounded, position cut for MySQL
+	// only) so the drill-down sees exactly the rows the verdict's digest saw.
+	fetchOpts := baselineFetchOptions(p, pg)
 	rows, _, err := query.FetchMerged(ctx, cfg.IndexDB, engine, query.FetchMergedOptions{
 		Opts:           fetchOpts,
 		DBName:         cfg.IndexDBName,

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -213,7 +213,9 @@ func VerifyTable(ctx context.Context, cfg Config, schema, table string) (TableRe
 	// conclusive (real loss/gain) and is never masked by this.
 	deferredRepr := deferredReprUnresolved(orderedCols, changes, binariesTyped)
 
-	reconDigest, reconCount, emitErr := reconstructDigest(ctx, baselinePath, schema, table, pkCols, changes, rows, orderedCols, renderCellNormalized)
+	// Live-source verify is MySQL-only (PostgreSQL is refused upstream), so the
+	// PK canonicalizer always applies here — pgTextPK is false.
+	reconDigest, reconCount, emitErr := reconstructDigest(ctx, baselinePath, schema, table, pkCols, changes, rows, orderedCols, false, renderCellNormalized)
 	if emitErr != nil {
 		return res, fmt.Errorf("reconstruct %s.%s: %w", schema, table, emitErr)
 	}
@@ -271,7 +273,7 @@ func classify(srcDigest string, srcRows int64, reconDigest string, reconRows int
 // side of its own comparison): both sides of any one comparison must be
 // produced with the SAME render func so the digests are byte-comparable by
 // construction.
-func reconstructDigest(ctx context.Context, baselinePath, schema, table string, pkCols []metadata.ColumnMeta, changes map[string]*query.ResultRow, events []query.ResultRow, orderedCols []metadata.ColumnMeta, render func(any, metadata.ColumnMeta) []byte) (string, int64, error) {
+func reconstructDigest(ctx context.Context, baselinePath, schema, table string, pkCols []metadata.ColumnMeta, changes map[string]*query.ResultRow, events []query.ResultRow, orderedCols []metadata.ColumnMeta, pgTextPK bool, render func(any, metadata.ColumnMeta) []byte) (string, int64, error) {
 	hasher := consistency.NewHasher()
 	err := reconstruct.SnapshotFullTableImages(ctx, reconstruct.SnapshotFullTableInput{
 		BaselinePath: baselinePath,
@@ -280,6 +282,7 @@ func reconstructDigest(ctx context.Context, baselinePath, schema, table string, 
 		PKCols:       pkCols,
 		Changes:      changes,
 		Events:       events,
+		PGTextPK:     pgTextPK,
 	}, func(rowMap map[string]any) error {
 		cells := make([][]byte, len(orderedCols))
 		for i, c := range orderedCols {

--- a/internal/verify/verify_baseline.go
+++ b/internal/verify/verify_baseline.go
@@ -59,6 +59,34 @@ func anchorLabel(pg bool, p BaselinePair) string {
 	return fmt.Sprintf("%s:%d", p.NewAnchor.File, p.NewAnchor.Pos)
 }
 
+// baselineFetchOptions builds the delta-window query for reconstructing the
+// previous baseline forward to the new one. The window is ALWAYS time-bounded
+// (Since/Until on event_timestamp). MySQL additionally pins the exact binlog-
+// position cut — UntilPos at the new anchor, SincePos at the prev anchor when it
+// recorded one (#797). PostgreSQL does NOT: its events carry a non-monotonic
+// "X/Y" LSN in binlog_file that the length-lexicographic position filter cannot
+// bound correctly, so a PG window is time-bounded only (accepting the (prev,new]
+// boundary drift the live-source path documents; a numeric-LSN position filter
+// is a deferred refinement, #1022). "PG never sets a position bound" is the
+// load-bearing correctness invariant — kept in ONE place, shared by
+// VerifyBaselinePair and ExplainBaselinePairMismatch.
+func baselineFetchOptions(p BaselinePair, pg bool) query.Options {
+	opts := query.Options{
+		Schema:     p.Schema,
+		Table:      p.Table,
+		Since:      &p.PrevSnapshot,
+		Until:      &p.NewSnapshot,
+		LimitPerPK: 1,
+	}
+	if !pg {
+		opts.UntilPos = &p.NewAnchor
+		if p.PrevAnchor.File != "" && p.PrevAnchor.Pos != 0 {
+			opts.SincePos = &p.PrevAnchor
+		}
+	}
+	return opts
+}
+
 // BaselinePair is one table's previous + new baseline, with the new baseline's
 // recorded binlog anchor and the previous baseline's snapshot time — everything
 // VerifyBaselinePair needs to reconstruct prev→anchor and compare to new.
@@ -169,25 +197,7 @@ func VerifyBaselinePair(ctx context.Context, cfg BaselineConfig, p BaselinePair)
 	// lower-bound artifact. A reported MATCH is unaffected either way (a too-wide
 	// lower bound can only add a superseded older event, never drop a real one).
 	engine := query.New(cfg.IndexDB)
-	fetchOpts := query.Options{
-		Schema:     p.Schema,
-		Table:      p.Table,
-		Since:      &p.PrevSnapshot,
-		Until:      &p.NewSnapshot, // coarse time bound: partition pruning + gap planner
-		LimitPerPK: 1,
-	}
-	if pg {
-		// PostgreSQL events carry a non-monotonic "X/Y" LSN in binlog_file, which
-		// the (length-lexicographic) position filter can't bound correctly, so the
-		// delta window is time-bounded only (Since/Until on event_timestamp). This
-		// accepts the (prev,new] boundary drift the live-source path already
-		// documents; a numeric-LSN position filter is a deferred refinement (#1022).
-	} else {
-		fetchOpts.UntilPos = &p.NewAnchor // exact cut at the new baseline's binlog point
-		if p.PrevAnchor.File != "" && p.PrevAnchor.Pos != 0 {
-			fetchOpts.SincePos = &p.PrevAnchor
-		}
-	}
+	fetchOpts := baselineFetchOptions(p, pg)
 	rows, _, err := query.FetchMerged(ctx, cfg.IndexDB, engine, query.FetchMergedOptions{
 		Opts:           fetchOpts,
 		DBName:         cfg.IndexDBName,

--- a/internal/verify/verify_baseline.go
+++ b/internal/verify/verify_baseline.go
@@ -24,6 +24,39 @@ type BaselineConfig struct {
 	IndexDBName    string
 	NoArchive      bool
 	ArchiveFetcher query.ArchiveFetcher
+	// SourceFlavor is the index's source family (query.SourceFlavor: "postgres"
+	// selects the PG path — LSN anchor, text-identity PK, time-bounded delta
+	// window; "" / "mysql" / "mariadb" keep the MySQL path). Set once per run by
+	// the caller from the index, never the registry field — the index is truth.
+	SourceFlavor string
+}
+
+// flavorPostgres is the stream_state.flavor value for a PostgreSQL-source index
+// (matches internal/query.SourceFlavor). Verify keys its PG branches on the
+// index-read flavor, not the console registry field — the index is authoritative.
+const flavorPostgres = "postgres"
+
+// ResolverFor picks the schema resolver for the index's source flavor. A PG index
+// stores one relation per snapshot_id (#603 / WritePGSnapshot), so
+// metadata.NewResolver(db, 0) would resolve only the newest relation and every
+// other table would StatusError; the per-table resolver folds each relation's own
+// MAX snapshot_id into one whole-schema view. MySQL keeps the latest-snapshot
+// resolver. This is the #1018-wide resolver seam — any console reconstruct
+// surface for PG hits the same one-table-per-id trap.
+func ResolverFor(db *sql.DB) (*metadata.Resolver, error) {
+	if query.SourceFlavor(db) == flavorPostgres {
+		return metadata.NewLatestPerTableResolver(db)
+	}
+	return metadata.NewResolver(db, 0)
+}
+
+// anchorLabel renders the human anchor string for a result: an LSN for a
+// PostgreSQL baseline, the binlog file:pos for MySQL.
+func anchorLabel(pg bool, p BaselinePair) string {
+	if pg {
+		return fmt.Sprintf("LSN:%d", p.NewLSN)
+	}
+	return fmt.Sprintf("%s:%d", p.NewAnchor.File, p.NewAnchor.Pos)
 }
 
 // BaselinePair is one table's previous + new baseline, with the new baseline's
@@ -41,6 +74,11 @@ type BaselinePair struct {
 	// previous baseline predates position recording; callers must check before
 	// using it as a query.Options.SincePos, same convention as NewAnchor.
 	PrevAnchor query.BinlogPos
+	// NewLSN / PrevLSN are the PostgreSQL WAL LSN anchors (baseline.MetaKeyLSN)
+	// of the new and previous baselines — the PG equivalent of NewAnchor/
+	// PrevAnchor. 0 = a MySQL baseline or a pre-#593 PG baseline (no LSN).
+	NewLSN  uint64
+	PrevLSN uint64
 }
 
 // VerifyBaselinePair proves, drift-free, that the recovery chain reproduces a
@@ -54,8 +92,8 @@ type BaselinePair struct {
 // not taken from #633's persisted value). Neither side reads the live source, so
 // there is no snapshot drift, no off-peak requirement, and no production impact.
 func VerifyBaselinePair(ctx context.Context, cfg BaselineConfig, p BaselinePair) (TableResult, error) {
-	res := TableResult{Schema: p.Schema, Table: p.Table,
-		Anchor: fmt.Sprintf("%s:%d", p.NewAnchor.File, p.NewAnchor.Pos)}
+	pg := cfg.SourceFlavor == flavorPostgres
+	res := TableResult{Schema: p.Schema, Table: p.Table, Anchor: anchorLabel(pg, p)}
 
 	tm, err := cfg.Resolver.Resolve(p.Schema, p.Table)
 	if err != nil {
@@ -65,17 +103,28 @@ func VerifyBaselinePair(ctx context.Context, cfg BaselineConfig, p BaselinePair)
 	if len(pkCols) == 0 {
 		return inconclusive(res, "table has no primary key"), nil
 	}
-	for _, c := range pkCols {
-		if !reconstruct.SupportedPKType(c.DataType) {
-			return inconclusive(res, fmt.Sprintf("primary-key column %q has type %q unsupported by the baseline canonicalizer", c.Name, c.DataType)), nil
+	// MySQL's PK canonicalizer only handles a known type surface. PostgreSQL
+	// stores every PK column as raw text on BOTH the baseline (COPY text) and
+	// delta (pgoutput text) sides, so the match is string-identity — the
+	// canonicalizer, and this type gate, are bypassed. A genuinely unhandled PG
+	// type is #1009's message concern, not a false inconclusive here.
+	if !pg {
+		for _, c := range pkCols {
+			if !reconstruct.SupportedPKType(c.DataType) {
+				return inconclusive(res, fmt.Sprintf("primary-key column %q has type %q unsupported by the baseline canonicalizer", c.Name, c.DataType)), nil
+			}
 		}
 	}
-	// A real baseline anchor is never at binlog position 0; an empty file or a
-	// zero position means the anchor wasn't recorded (pre-#633) or its metadata
-	// is corrupt (the reader keeps the file but zeroes an unparseable position).
-	// Bounding the reconstruction at position 0 would cut it short and could pass
-	// a window that touched no rows as a (false) match — refuse instead.
-	if p.NewAnchor.File == "" || p.NewAnchor.Pos == 0 {
+	// The reconstruction is bounded at the new baseline's exact anchor. MySQL
+	// uses the binlog file:pos; PostgreSQL uses the slot consistent-point LSN
+	// (MetaKeyLSN). A zero anchor means it was never recorded (pre-#633 MySQL /
+	// pre-#593 PG) or is corrupt — refuse rather than pass a too-short window as
+	// a false match.
+	if pg {
+		if p.NewLSN == 0 {
+			return inconclusive(res, "new PostgreSQL baseline has no usable LSN anchor; cannot bound the reconstruction"), nil
+		}
+	} else if p.NewAnchor.File == "" || p.NewAnchor.Pos == 0 {
 		return inconclusive(res, "new baseline has no usable binlog anchor (missing or zero position); cannot bound the reconstruction"), nil
 	}
 	if !p.PrevSnapshot.Before(p.NewSnapshot) {
@@ -125,11 +174,19 @@ func VerifyBaselinePair(ctx context.Context, cfg BaselineConfig, p BaselinePair)
 		Table:      p.Table,
 		Since:      &p.PrevSnapshot,
 		Until:      &p.NewSnapshot, // coarse time bound: partition pruning + gap planner
-		UntilPos:   &p.NewAnchor,   // exact cut at the new baseline's binlog point
 		LimitPerPK: 1,
 	}
-	if p.PrevAnchor.File != "" && p.PrevAnchor.Pos != 0 {
-		fetchOpts.SincePos = &p.PrevAnchor
+	if pg {
+		// PostgreSQL events carry a non-monotonic "X/Y" LSN in binlog_file, which
+		// the (length-lexicographic) position filter can't bound correctly, so the
+		// delta window is time-bounded only (Since/Until on event_timestamp). This
+		// accepts the (prev,new] boundary drift the live-source path already
+		// documents; a numeric-LSN position filter is a deferred refinement (#1022).
+	} else {
+		fetchOpts.UntilPos = &p.NewAnchor // exact cut at the new baseline's binlog point
+		if p.PrevAnchor.File != "" && p.PrevAnchor.Pos != 0 {
+			fetchOpts.SincePos = &p.PrevAnchor
+		}
 	}
 	rows, _, err := query.FetchMerged(ctx, cfg.IndexDB, engine, query.FetchMergedOptions{
 		Opts:           fetchOpts,
@@ -173,12 +230,12 @@ func VerifyBaselinePair(ctx context.Context, cfg BaselineConfig, p BaselinePair)
 	// way on both sides closes the false-mismatch gap a TEXT/JSON column's
 	// event-image round-trip can otherwise open (see its doc comment) without
 	// risking the live-source comparison, which this function is not used for.
-	reconDigest, reconCount, err := reconstructDigest(ctx, p.PrevPath, p.Schema, p.Table, pkCols, changes, rows, orderedCols, renderCellNormalized)
+	reconDigest, reconCount, err := reconstructDigest(ctx, p.PrevPath, p.Schema, p.Table, pkCols, changes, rows, orderedCols, pg, renderCellNormalized)
 	if err != nil {
 		return res, fmt.Errorf("reconstruct prev %s.%s: %w", p.Schema, p.Table, err)
 	}
 	// Truth side: the new baseline as-is (no events), via the same path.
-	newDigest, newCount, err := reconstructDigest(ctx, p.NewPath, p.Schema, p.Table, pkCols, map[string]*query.ResultRow{}, nil, orderedCols, renderCellNormalized)
+	newDigest, newCount, err := reconstructDigest(ctx, p.NewPath, p.Schema, p.Table, pkCols, map[string]*query.ResultRow{}, nil, orderedCols, pg, renderCellNormalized)
 	if err != nil {
 		return res, fmt.Errorf("read new baseline %s.%s: %w", p.Schema, p.Table, err)
 	}
@@ -315,6 +372,8 @@ func FindBaselinePair(ctx context.Context, source string) (pairs []BaselinePair,
 			NewSnapshot:  tNew,
 			NewAnchor:    query.BinlogPos{File: meta.BinlogFile, Pos: uint64(meta.BinlogPos)},
 			PrevAnchor:   query.BinlogPos{File: prevMeta.BinlogFile, Pos: uint64(prevMeta.BinlogPos)},
+			NewLSN:       meta.LSN,
+			PrevLSN:      prevMeta.LSN,
 		})
 	}
 	// Symmetric to unpaired: tables in the prev snapshot the new one no longer

--- a/internal/verify/verify_baseline_pg_test.go
+++ b/internal/verify/verify_baseline_pg_test.go
@@ -1,0 +1,65 @@
+package verify
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/metadata"
+)
+
+// pgResolver stubs a one-table schema whose PK column has an EMPTY DataType —
+// the PostgreSQL shape (no MySQL DATA_TYPE token). SupportedPKType("") is false,
+// so on the MySQL path this table is inconclusive; on the PG path the type gate
+// is bypassed entirely.
+func pgResolver() *metadata.Resolver {
+	return metadata.NewResolverFromTables(1, map[string]*metadata.TableMeta{
+		"app.orders": {Schema: "app", Table: "orders", Columns: []metadata.ColumnMeta{
+			{Name: "id", OrdinalPosition: 1, IsPK: true, DataType: ""},
+		}},
+	})
+}
+
+// TestVerifyBaselinePair_pgBypassesPKTypeGate proves B1: with SourceFlavor
+// "postgres" the SupportedPKType gate is skipped, so an empty-DATA_TYPE PK does
+// NOT go inconclusive as "unsupported by the canonicalizer" — it proceeds to the
+// LSN-anchor precondition (B3) and reports the LSN reason instead. No index DB is
+// touched (the anchor check returns before any fetch), so IndexDB stays nil.
+func TestVerifyBaselinePair_pgBypassesPKTypeGate(t *testing.T) {
+	cfg := BaselineConfig{Resolver: pgResolver(), SourceFlavor: flavorPostgres}
+	// NewLSN == 0 → the PG anchor precondition fires (B3), which is only reachable
+	// if the PK-type gate (B1) was skipped first.
+	res, err := VerifyBaselinePair(context.Background(), cfg, BaselinePair{Schema: "app", Table: "orders", NewLSN: 0})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Status != StatusInconclusive {
+		t.Fatalf("status = %q, want inconclusive", res.Status)
+	}
+	if strings.Contains(res.Detail, "unsupported by the baseline canonicalizer") {
+		t.Errorf("PG must bypass the PK-type gate, but got the MySQL type message: %q", res.Detail)
+	}
+	if !strings.Contains(res.Detail, "LSN anchor") {
+		t.Errorf("want the PG LSN-anchor reason, got: %q", res.Detail)
+	}
+	if !strings.HasPrefix(res.Anchor, "LSN:") {
+		t.Errorf("PG anchor label = %q, want an LSN: form", res.Anchor)
+	}
+}
+
+// TestVerifyBaselinePair_mysqlKeepsPKTypeGate is the contrast: the SAME
+// empty-DATA_TYPE PK on the MySQL path still trips the SupportedPKType gate, so
+// the flag — not some unrelated change — is what gates B1.
+func TestVerifyBaselinePair_mysqlKeepsPKTypeGate(t *testing.T) {
+	cfg := BaselineConfig{Resolver: pgResolver(), SourceFlavor: ""} // "" == mysql
+	res, err := VerifyBaselinePair(context.Background(), cfg, BaselinePair{Schema: "app", Table: "orders"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Status != StatusInconclusive {
+		t.Fatalf("status = %q, want inconclusive", res.Status)
+	}
+	if !strings.Contains(res.Detail, "unsupported by the baseline canonicalizer") {
+		t.Errorf("MySQL must keep the PK-type gate, got: %q", res.Detail)
+	}
+}

--- a/internal/verify/verify_baseline_pg_test.go
+++ b/internal/verify/verify_baseline_pg_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/query"
 )
 
 // pgResolver stubs a one-table schema whose PK column has an EMPTY DataType —
@@ -61,5 +63,43 @@ func TestVerifyBaselinePair_mysqlKeepsPKTypeGate(t *testing.T) {
 	}
 	if !strings.Contains(res.Detail, "unsupported by the baseline canonicalizer") {
 		t.Errorf("MySQL must keep the PK-type gate, got: %q", res.Detail)
+	}
+}
+
+// TestBaselineFetchOptions_pgNeverBoundsByPosition guards the load-bearing B4
+// invariant that VerifyBaselinePair and ExplainBaselinePairMismatch share: a PG
+// delta window is time-bounded ONLY (its binlog_file is a non-monotonic "X/Y"
+// LSN the position filter can't order), while MySQL pins the exact binlog cut.
+// A refactor that set a position bound for PG — the exact regression the review
+// flagged — fails here without a live DB.
+func TestBaselineFetchOptions_pgNeverBoundsByPosition(t *testing.T) {
+	p := BaselinePair{
+		Schema: "app", Table: "orders",
+		PrevSnapshot: time.Unix(100, 0).UTC(), NewSnapshot: time.Unix(200, 0).UTC(),
+		NewAnchor:  query.BinlogPos{File: "mysql-bin.000007", Pos: 4242},
+		PrevAnchor: query.BinlogPos{File: "mysql-bin.000006", Pos: 100},
+	}
+
+	pgOpts := baselineFetchOptions(p, true)
+	if pgOpts.UntilPos != nil || pgOpts.SincePos != nil {
+		t.Errorf("PG window must set NO position bound: UntilPos=%v SincePos=%v", pgOpts.UntilPos, pgOpts.SincePos)
+	}
+	if pgOpts.Since == nil || pgOpts.Until == nil || pgOpts.LimitPerPK != 1 {
+		t.Errorf("PG window must keep the time bounds + LimitPerPK: %+v", pgOpts)
+	}
+
+	myOpts := baselineFetchOptions(p, false)
+	if myOpts.UntilPos == nil || *myOpts.UntilPos != p.NewAnchor {
+		t.Errorf("MySQL window must cut at the new anchor, got %v", myOpts.UntilPos)
+	}
+	if myOpts.SincePos == nil || *myOpts.SincePos != p.PrevAnchor {
+		t.Errorf("MySQL window must lower-bound at the prev anchor, got %v", myOpts.SincePos)
+	}
+
+	// A MySQL baseline with no recorded prev anchor (#797) falls back to the time
+	// lower bound — SincePos stays nil.
+	p.PrevAnchor = query.BinlogPos{}
+	if got := baselineFetchOptions(p, false); got.SincePos != nil {
+		t.Errorf("a zero prev anchor must not set SincePos, got %v", got.SincePos)
 	}
 }


### PR DESCRIPTION
## Console PostgreSQL control-plane parity (epic #1018)

Brings the console **write control-plane** to capability parity for PostgreSQL sources: a PG source added in the console can now be **monitored, baselined, and verified** from the console, exactly like a MySQL source. The read/time-travel side already shipped (#595/#593); this is the remaining write surface.

Parity here is **capability parity, not identical UI** — PG capture uses a replication slot + publication where MySQL uses binlog/GTID, so the +Add form and capture path differ by construction.

Closes #1019 · Closes #1020 · Closes #1021 · Closes #1022

### Slices (one commit each — reviewable independently)

**A — registry source-flavor field + PG-aware form (#1019, foundational).**
`ServerEntry` gains a generic `Flavor` (mysql|mariadb|postgres) + PG-only `SourceSlot`/`SourcePublication` (additive yaml; empty flavor = mysql, so every pre-#1019 entry keeps working — this also satisfies the registry half of #623/MariaDB). `internal/console/flavor.go` holds the shared PG DSN seam — `PGReplDSN` (derives the walsender repl DSN by adding `replication=database`), `buildPGSourceDSN`, `NormalizeFlavor`, `ServerEntry.SourceFlavor()`. **All pure `net/url` — NO pgx:** `internal/console` is on the read side of the dependency guard (`internal/event/depguard_test.go` bans `jackc/pgx` there), so the PG DSN logic stays stdlib-only and the derived DSN re-parses cleanly in pgconn downstream. `buildSourceDSN` dispatches on flavor; the form reveals PG-only fields via a `.flavor-on` class toggle (the proven cap-on pattern, never a `[hidden]` toggle).

**B — monitor supervisor drives PG capture (#1020).** `pgstreamrun` gains a `Hooks` seam (mirrors `streamrun.Hooks` minus OnGapAutoAdvance — a lost PG slot is fatal). The supervisor's `Doctor`/`Start` dispatch on flavor → `pgstreamrun.BuildPGReport` + `pgstreamrun.One`, under the **same** circuit-breaker/lifecycle. `OnCheckpoint` fires on the ticker (not inside `checkpoint()`, which early-returns for an idle source) so a connected-but-idle PG stream still flips pending→running. Read-side lights up for free: `pgstreamrun` stamps `stream_state.flavor` + `source_health`, so the existing #599 panel populates.

**C — baseline-trigger produces PG baselines (#1021).** `execute()` dispatches on flavor → `internal/pgbaseline` in-process (COPY straight to Parquet, LSN-anchored). No mydumper subprocess, no #768 timestamp skew. Time-travel/reconstruct consume it unchanged (byte-identical `MetaKeyLSN` Parquet).

**D — verify engine PG type/PK (#1022).** "Run verification" reaches a real MATCH/MISMATCH (baseline-anchored) for PG instead of the misleading inconclusive (#1009 symptom). This slice writes the **first full-table PG merge** and clears five stacked MySQL assumptions (PK-type gate, PK canonicalizer, LSN vs binlog anchor, delta-window bounding, one-table-per-id resolver).

### Reviewer notes

- **Shared `reconstruct/fulltable.go` change is contained by design:** `PGTextPK` is a new bool on `SnapshotFullTableInput`/`mergeCore` whose **zero value (false) preserves the MySQL path verbatim** (canonicalize + the SupportedPKType precondition). The mydumper writer path never sets it (and still refuses PG per #597). PG's string-identity PK match is correct because pgbaseline COPY text == delta pgoutput text. Proven by a **live-DB-free** unit test (matches with empty-DATA_TYPE PK when true; still errors when false).
- **`cmd/bintrail-console` now links the PG capture stack (pgstreamrun/pgx) by design** for #1020/#1021. The `pg-free`/`ui-free` guards for `cmd/bintrail` and the **pgx-free read-layer guard (`internal/console`) all stay green.**
- **Deferred parity edge:** live-source verify (`--source-dsn`) stays MySQL-only (its checksum is MySQL SQL). A PG source is refused with a clear message at the API, CLI, and engine layers — strictly better than the old misleading inconclusive, aligned with #1009. Baseline-anchored is the drift-free default and the full-parity path; PG live-source verify (a native PG consistency-checksum engine) is filed as a follow-up.

### Testing

`go build ./...`, `go vet ./...`, `go vet -tags integration ./...`, and the full unit suite (`go test ./...`, 42 pkgs) all green. New unit tests are live-DB-free where possible (flavor/DSN helpers, pgstreamrun idle-checkpoint liveness, PG full-table merge, verify PG PK-gate bypass). Live-PG integration tests are build-tagged for CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
