### PR TITLE
docs: document PostgreSQL as a first-class console source

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,18 @@ This downloads the Compose stack, brings it up, waits for the console, and print
 what to do next. Then:
 
 1. Open **http://127.0.0.1:8090** — on first run, create a username and password (that's your login from now on).
-2. Click **+ Add server** and paste the MySQL you want to watch — host, user, password. dbtrail runs preflight checks, provisions an index, and starts streaming within the minute.
+2. Click **+ Add server**, pick the **source type** (MySQL, MariaDB, or PostgreSQL), and paste the database you want to watch — host, user, password. dbtrail runs preflight checks, provisions an index, and starts streaming within the minute.
+
+### PostgreSQL (beta) & MariaDB (alpha) sources
+
+The same one-line install — the console captures **PostgreSQL** and **MariaDB**
+sources too, not just MySQL. In **+ Add server**, choose the source type;
+PostgreSQL reveals fields for the database, replication slot, and publication.
+PostgreSQL needs a one-time source-side setup first (`wal_level = logical`,
+`REPLICA IDENTITY FULL`, and a publication — dbtrail validates these and never
+runs DDL on your source). Full walkthrough, incl. managed RDS/Aurora/Cloud SQL:
+**[PostgreSQL source (beta)](docs/postgres.md)** · **[MariaDB source
+(alpha)](docs/mariadb.md)**.
 
 **Just curious?** One container, zero setup, time-travel SQL in 30 seconds:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -20,8 +20,10 @@ it's the first section — the same four lines as the README.
   bundles one).
 - **Other sources:** besides MySQL, dbtrail can also capture from **MariaDB**
   ([alpha](./mariadb.md) — 10.6+, 11.4 is the CI-tested target) and
-  **PostgreSQL** ([beta](./postgres.md) — 14+, via the separate `bintrail-pg`
-  binary). Each has its own prerequisites; see the linked guide.
+  **PostgreSQL** ([beta](./postgres.md) — 14+). Both are first-class sources in
+  the web console (**+ Add server** → pick the source type); PostgreSQL also
+  ships a standalone `bintrail-pg` binary for headless/CLI deployments. Each has
+  its own prerequisites; see the linked guide.
 - Go 1.25+ (the module targets `go 1.25.11`) — only when building from source. The default `GOTOOLCHAIN=auto` fetches the right toolchain for you.
 
 ## Docker Compose (the bundled default)
@@ -60,11 +62,13 @@ First run — open the URL and create your console username and password.
 ```
 
 Open it and use **+ Add server** (the Servers screen opens itself on a
-fresh install): paste the MySQL to watch — host, user, password, optional
-schema filter (`host.docker.internal` reaches a MySQL on this same machine
-from inside Docker). dbtrail runs the preflight (failures come back as
-remediation cards), provisions a dedicated index for that source, and starts
-streaming. Repeat per server; everything you add resumes automatically when
+fresh install): pick the **source type** (MySQL, MariaDB, or PostgreSQL) and
+paste the database to watch — host, user, password, optional schema filter
+(`host.docker.internal` reaches a database on this same machine from inside
+Docker; a PostgreSQL source adds database/slot/publication fields —
+see [postgres.md](./postgres.md)). dbtrail runs the preflight (failures come
+back as remediation cards), provisions a dedicated index for that source, and
+starts streaming. Repeat per server; everything you add resumes automatically when
 the container restarts.
 
 Prefer to start streaming one source immediately at boot? Set `SOURCE_DSN`

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -41,6 +41,39 @@ The index MySQL has the same requirements as for any source — see
 
 ## Install
 
+The console captures PostgreSQL as a **first-class source** — the same
+`bintrail-console watch` stack the [Compose quickstart](install.md) stands up.
+There are two ways in: the **web console** (recommended — zero binaries to place)
+or the standalone **`bintrail-pg`** binary (for an existing index or a headless
+CLI deployment).
+
+### The web console — "+ Add server" (recommended)
+
+If you brought up the [Docker Compose stack](install.md) — the *same*
+`install.sh` MySQL uses — you already have everything. Do the [source-side
+setup](#postgresql-side-setup) below first, then:
+
+1. Open the console (**http://127.0.0.1:8090**) and sign in.
+2. **+ Add server** → set **Source type** to **PostgreSQL**. The PostgreSQL-only
+   fields appear: **Database**, **Replication slot**, and **Publication**.
+3. Fill in host, port, user, password, the database, the slot name (created for
+   you on first run), and the publication (the one you created above).
+   Optionally restrict **Schemas**.
+4. **Save.** dbtrail provisions a dedicated MySQL index for that source and
+   starts capturing **in-process** (the console runs the same PostgreSQL
+   preflight as `bintrail-pg doctor` — `wal_level`, publication coverage,
+   `REPLICA IDENTITY FULL`, slot health — and surfaces any failure as a
+   remediation card). Capture resumes automatically on restart.
+
+The **index stays MySQL**; only the *source* is PostgreSQL. The source type is
+fixed once saved — to change a server's capture engine, delete and re-create it.
+The form lives in `bintrail-console watch` (the Compose default); the read-only
+`serve` console browses an existing PostgreSQL-sourced index but does not add
+sources.
+
+### Standalone binary / image
+
+Prefer a headless deployment, or capturing into an index you already run?
 `bintrail-pg` ships as its own artifact alongside the core `bintrail` binary.
 
 **Docker image:**


### PR DESCRIPTION
## What

v0.33.0 (#1018 / #1023) shipped **PostgreSQL as a first-class source in the web console** — `bintrail-console watch` captures PG in-process (flavor-dispatched to `pgstreamrun.One`, `monitor.go`) and **+ Add server** has a *Source type* selector (`app.js`) that reveals the PG-only fields (database, replication slot, publication) — but the install docs still said "paste the **MySQL** you want to watch."

This means a PostgreSQL user is already fully served by the **existing `install.sh`** + choosing PostgreSQL in the UI; no separate installer is needed. These docs now say so.

## Changes (docs-only)

- **README** `## Install`: step 2 mentions the source-type selector; new **"PostgreSQL (beta) & MariaDB (alpha) sources"** subsection.
- **docs/postgres.md**: new **"The web console — + Add server (recommended)"** section at the top of Install; the standalone `bintrail-pg` binary stays documented as the headless/CLI path.
- **docs/install.md**: the "Other sources" bullet and the Compose walkthrough no longer imply MySQL-only.

## Verification

Every claim checked against the v0.33.0 code:
- in-process capture: `cmd/bintrail-console/monitor.go` `pgStreamFn: pgstreamrun.One`, flavor-dispatched
- form fields + watch-only gating: `internal/console/assets/app.js` (`<select name="flavor">`, `data-capability="monitor"`)
- immutable-after-create flavor: `internal/console/servers_api.go`
- index stays MySQL (ratified red line)

No code changed. Markdown anchors/links validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)