### PR TITLE
ext/cliapp: extension seams for embedding distributions (commands, read-plane API, doctor checks, agent commands, source jobs)

### DIFF
--- a/cliapp/addcommands_test.go
+++ b/cliapp/addcommands_test.go
@@ -7,12 +7,27 @@ import (
 )
 
 func TestAddCommandsRegistersOnRoot(t *testing.T) {
-	cmd := &cobra.Command{Use: "ext-test-cmd", Run: func(*cobra.Command, []string) {}}
+	ran := false
+	cmd := &cobra.Command{Use: "ext-test-cmd", Run: func(*cobra.Command, []string) { ran = true }}
 	AddCommands(cmd)
-	t.Cleanup(func() { rootCmd.RemoveCommand(cmd) })
+	t.Cleanup(func() {
+		rootCmd.RemoveCommand(cmd)
+		rootCmd.SetArgs(nil) // restore cobra's default os.Args handling
+	})
 
 	found, _, err := rootCmd.Find([]string{"ext-test-cmd"})
 	if err != nil || found != cmd {
 		t.Fatalf("rootCmd.Find(ext-test-cmd) = (%v, %v), want the injected command", found, err)
+	}
+
+	// Execute through the real root so the injected command runs under the
+	// actual PersistentPreRun chain (log setup) — AddCommands must dispatch,
+	// not merely register.
+	rootCmd.SetArgs([]string{"ext-test-cmd"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("rootCmd.Execute() = %v", err)
+	}
+	if !ran {
+		t.Fatal("injected command did not run through rootCmd.Execute")
 	}
 }

--- a/cliapp/addcommands_test.go
+++ b/cliapp/addcommands_test.go
@@ -1,0 +1,18 @@
+package cliapp
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestAddCommandsRegistersOnRoot(t *testing.T) {
+	cmd := &cobra.Command{Use: "ext-test-cmd", Run: func(*cobra.Command, []string) {}}
+	AddCommands(cmd)
+	t.Cleanup(func() { rootCmd.RemoveCommand(cmd) })
+
+	found, _, err := rootCmd.Find([]string{"ext-test-cmd"})
+	if err != nil || found != cmd {
+		t.Fatalf("rootCmd.Find(ext-test-cmd) = (%v, %v), want the injected command", found, err)
+	}
+}

--- a/cliapp/agent.go
+++ b/cliapp/agent.go
@@ -18,6 +18,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
+	"github.com/dbtrail/dbtrail/ext"
 	"github.com/dbtrail/dbtrail/internal/agent"
 	"github.com/dbtrail/dbtrail/internal/buffer"
 	"github.com/dbtrail/dbtrail/internal/byos"
@@ -425,6 +426,16 @@ func runAgent(cmd *cobra.Command, args []string) error {
 		statusFn = flushState.toFlushStatus
 	}
 	ch := agent.NewChannel(cfg, handler, nil, statusFn)
+	// Connection handles for extension-registered commands
+	// (ext.RegisterAgentCommand), built once here and passed by the dispatch
+	// loop to every registry handler. Fields are nil/empty for whatever this
+	// agent wasn't configured with — handlers nil-check.
+	ch.ExtDeps = ext.AgentDeps{
+		IndexDB:    indexDB,
+		SourceDB:   sourceDB,
+		SourceDSN:  agtSourceDSN,
+		SourceHost: handler.SourceHost,
+	}
 
 	slog.Info("starting agent",
 		"endpoint", agtEndpoint,

--- a/cliapp/doctor.go
+++ b/cliapp/doctor.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 
+	"github.com/dbtrail/dbtrail/ext"
 	"github.com/dbtrail/dbtrail/internal/cliutil"
 	"github.com/dbtrail/dbtrail/internal/doctor"
 )
@@ -96,8 +98,38 @@ func runDoctorTo(parent context.Context, w io.Writer, format, sourceDSN, indexDS
 	if proxysqlAdminDSN != "" {
 		report.Add(doctor.CheckProxySQLRules(parent, proxysqlAdminDSN))
 	}
+	appendExtDoctorChecks(parent, report, sourceDSN, indexDSN)
 	if err := report.Write(w, format); err != nil {
 		return fmt.Errorf("write report: %w", err)
 	}
 	return report.Err()
+}
+
+// appendExtDoctorChecks appends the checks contributed by registered
+// extension check functions (ext.RegisterDoctorCheck) to report. No-op in
+// the stock binary, where nothing is registered. Both preflight surfaces —
+// `bintrail doctor` (runDoctorTo) and `bintrail up` phase 1 — call it, so a
+// registered check appears wherever the built-in checks do, with the same
+// FAIL-blocks-boot semantics.
+func appendExtDoctorChecks(ctx context.Context, report *doctor.Report, sourceDSN, indexDSN string) {
+	for _, c := range ext.RunDoctorChecks(ctx, sourceDSN, indexDSN) {
+		report.Add(extCheckResult(c))
+	}
+}
+
+// extCheckResult converts an ext.DoctorCheck (Status as a plain string) to a
+// doctor.CheckResult. An unknown status string is coerced to WARN with a note
+// appended to Detail — Report.Add would otherwise log the malformed entry and
+// leave it out of every counter, silently weakening the report.
+func extCheckResult(c ext.DoctorCheck) doctor.CheckResult {
+	status := doctor.CheckStatus(c.Status)
+	detail := c.Detail
+	switch status {
+	case doctor.StatusPass, doctor.StatusFail, doctor.StatusWarn, doctor.StatusSkip:
+	default:
+		note := fmt.Sprintf("registered check reported unknown status %q; treated as warn", c.Status)
+		detail = strings.TrimSpace(detail + " (" + note + ")")
+		status = doctor.StatusWarn
+	}
+	return doctor.CheckResult{Name: c.Name, Status: status, Detail: detail, Remediation: c.Remediation}
 }

--- a/cliapp/doctor.go
+++ b/cliapp/doctor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"strings"
 	"time"
@@ -105,24 +106,60 @@ func runDoctorTo(parent context.Context, w io.Writer, format, sourceDSN, indexDS
 	return report.Err()
 }
 
+// extDoctorBudget bounds all registered extension checks together, matching
+// doctor.Build's internal 30-second budget for the built-in checks — a
+// hanging registered check must not stall the report indefinitely.
+const extDoctorBudget = 30 * time.Second
+
 // appendExtDoctorChecks appends the checks contributed by registered
 // extension check functions (ext.RegisterDoctorCheck) to report. No-op in
 // the stock binary, where nothing is registered. Both preflight surfaces —
 // `bintrail doctor` (runDoctorTo) and `bintrail up` phase 1 — call it, so a
 // registered check appears wherever the built-in checks do, with the same
 // FAIL-blocks-boot semantics.
+//
+// The registered checks run under a 30s timeout (extDoctorBudget), and a
+// panicking check function is converted into a FAIL entry on the report —
+// the already-computed built-in checks must still render either way.
 func appendExtDoctorChecks(ctx context.Context, report *doctor.Report, sourceDSN, indexDSN string) {
-	for _, c := range ext.RunDoctorChecks(ctx, sourceDSN, indexDSN) {
+	ctx, cancel := context.WithTimeout(ctx, extDoctorBudget)
+	defer cancel()
+	checks, panicked := runExtDoctorChecks(ctx, sourceDSN, indexDSN)
+	for _, c := range checks {
 		report.Add(extCheckResult(c))
+	}
+	if panicked != nil {
+		report.Add(doctor.CheckResult{
+			Name:   "extension doctor checks",
+			Status: doctor.StatusFail,
+			Detail: fmt.Sprintf("registered check panicked: %v", panicked),
+		})
 	}
 }
 
+// runExtDoctorChecks runs the registered extension check functions,
+// converting a panic into a returned value instead of letting it unwind
+// through the caller's report rendering. On panic the returned checks slice
+// is nil (the in-flight concatenation is lost); the report keeps its
+// built-in checks either way and gains a FAIL entry naming the battery.
+func runExtDoctorChecks(ctx context.Context, sourceDSN, indexDSN string) (checks []ext.DoctorCheck, panicked any) {
+	defer func() {
+		if p := recover(); p != nil {
+			panicked = p
+		}
+	}()
+	return ext.RunDoctorChecks(ctx, sourceDSN, indexDSN), nil
+}
+
 // extCheckResult converts an ext.DoctorCheck (Status as a plain string) to a
-// doctor.CheckResult. An unknown status string is coerced to WARN with a note
-// appended to Detail — Report.Add would otherwise log the malformed entry and
-// leave it out of every counter, silently weakening the report.
+// doctor.CheckResult. The status is normalized (trimmed, lowercased) before
+// matching, so "PASS" / " Fail " count as their canonical forms. A truly
+// unknown status string is coerced to WARN with a note appended to Detail —
+// Report.Add would otherwise log the malformed entry and leave it out of
+// every counter, silently weakening the report — and logged so the downgrade
+// is greppable.
 func extCheckResult(c ext.DoctorCheck) doctor.CheckResult {
-	status := doctor.CheckStatus(c.Status)
+	status := doctor.CheckStatus(strings.ToLower(strings.TrimSpace(c.Status)))
 	detail := c.Detail
 	switch status {
 	case doctor.StatusPass, doctor.StatusFail, doctor.StatusWarn, doctor.StatusSkip:
@@ -130,6 +167,8 @@ func extCheckResult(c ext.DoctorCheck) doctor.CheckResult {
 		note := fmt.Sprintf("registered check reported unknown status %q; treated as warn", c.Status)
 		detail = strings.TrimSpace(detail + " (" + note + ")")
 		status = doctor.StatusWarn
+		slog.Warn("ext: doctor check reported unknown status",
+			"check", c.Name, "status", c.Status)
 	}
 	return doctor.CheckResult{Name: c.Name, Status: status, Detail: detail, Remediation: c.Remediation}
 }

--- a/cliapp/doctor_ext_test.go
+++ b/cliapp/doctor_ext_test.go
@@ -1,6 +1,7 @@
 package cliapp
 
 import (
+	"bytes"
 	"context"
 	"strings"
 	"testing"
@@ -18,24 +19,108 @@ func TestExtCheckResultKnownStatusesPassThrough(t *testing.T) {
 	}
 }
 
+// TestExtCheckResultStatusCaseInsensitive: the incoming status is normalized
+// (trimmed, lowercased) before matching, so any casing/padding of the four
+// canonical statuses passes through instead of degrading to WARN.
+func TestExtCheckResultStatusCaseInsensitive(t *testing.T) {
+	cases := map[string]doctor.CheckStatus{
+		"PASS":   doctor.StatusPass,
+		"Fail":   doctor.StatusFail,
+		" warn ": doctor.StatusWarn,
+		"SKIP":   doctor.StatusSkip,
+	}
+	for in, want := range cases {
+		got := extCheckResult(ext.DoctorCheck{Name: "n", Status: in, Detail: "d"})
+		if got.Status != want {
+			t.Errorf("status %q: got %q, want %q", in, got.Status, want)
+		}
+		if got.Detail != "d" {
+			t.Errorf("status %q: detail = %q, want it untouched", in, got.Detail)
+		}
+	}
+}
+
 func TestExtCheckResultUnknownStatusBecomesWarn(t *testing.T) {
-	// The doctor constants are lowercase; an uppercase "PASS" is unknown and
-	// must degrade to a counted WARN rather than an uncounted malformed entry.
-	got := extCheckResult(ext.DoctorCheck{Name: "n", Status: "PASS", Detail: "d"})
+	// "flaky" is not a canonical status in any casing — it must degrade to a
+	// counted WARN rather than an uncounted malformed entry.
+	got := extCheckResult(ext.DoctorCheck{Name: "n", Status: "flaky", Detail: "d"})
 	if got.Status != doctor.StatusWarn {
 		t.Fatalf("status = %q, want %q", got.Status, doctor.StatusWarn)
 	}
-	if !strings.Contains(got.Detail, `unknown status "PASS"`) || !strings.HasPrefix(got.Detail, "d") {
+	if !strings.Contains(got.Detail, `unknown status "flaky"`) || !strings.HasPrefix(got.Detail, "d") {
 		t.Errorf("detail = %q, want original detail plus an unknown-status note", got.Detail)
 	}
 }
 
 // TestAppendExtDoctorChecksDefaultNoop pins the stock-binary behavior: with
-// no registered checks the report is untouched.
+// no registered checks the report is untouched. ResetForTest first so the pin
+// holds regardless of what a sibling test registered before this one ran.
 func TestAppendExtDoctorChecksDefaultNoop(t *testing.T) {
+	ext.ResetForTest()
 	report := &doctor.Report{}
 	appendExtDoctorChecks(context.Background(), report, "src", "idx")
 	if len(report.Checks) != 0 || report.Warnings != 0 {
 		t.Fatalf("report changed with nothing registered: %+v", report)
+	}
+}
+
+// TestAppendExtDoctorChecksPanicBecomesFail: a panicking registered check
+// must not lose the already-computed report — it degrades to a FAIL entry
+// naming the extension battery, with the panic text in the detail.
+func TestAppendExtDoctorChecksPanicBecomesFail(t *testing.T) {
+	t.Cleanup(ext.ResetForTest)
+	ext.RegisterDoctorCheck(func(context.Context, string, string) []ext.DoctorCheck {
+		panic("check exploded")
+	})
+
+	report := &doctor.Report{}
+	report.Add(doctor.CheckResult{Name: "builtin", Status: doctor.StatusPass})
+	appendExtDoctorChecks(context.Background(), report, "src", "idx")
+
+	if len(report.Checks) != 2 {
+		t.Fatalf("report has %d checks, want the builtin plus the FAIL entry: %+v", len(report.Checks), report.Checks)
+	}
+	var found bool
+	for _, c := range report.Checks {
+		if c.Name != "extension doctor checks" {
+			continue
+		}
+		found = true
+		if c.Status != doctor.StatusFail {
+			t.Errorf("status = %q, want %q", c.Status, doctor.StatusFail)
+		}
+		if !strings.Contains(c.Detail, "check exploded") {
+			t.Errorf("detail = %q, want the panic text", c.Detail)
+		}
+	}
+	if !found {
+		t.Fatalf("no FAIL entry for the panicking battery; checks = %+v", report.Checks)
+	}
+}
+
+// TestRunDoctorToRendersRegisteredCheck drives the real doctor entry point
+// (runDoctorTo) with a registered extension check and asserts the check name
+// appears in BOTH rendered formats — pinning the appendExtDoctorChecks call
+// site inside runDoctorTo. The DSN points at a closed local port so the
+// built-in checks fail fast; only the presence of the registered check's
+// name is asserted, so built-in failures are irrelevant here.
+func TestRunDoctorToRendersRegisteredCheck(t *testing.T) {
+	t.Cleanup(ext.ResetForTest)
+	const name = "ext-e2e-preflight-check-93b1"
+	ext.RegisterDoctorCheck(func(context.Context, string, string) []ext.DoctorCheck {
+		return []ext.DoctorCheck{{Name: name, Status: "pass", Detail: "registered check ran"}}
+	})
+
+	// Port 1 on loopback refuses connections immediately — unreachable is
+	// fine (and fast) for this pin.
+	const badDSN = "root:x@tcp(127.0.0.1:1)/"
+	for _, format := range []string{"text", "json"} {
+		var buf bytes.Buffer
+		// The built-in checks fail against the unreachable DSN, so the
+		// returned error is expected; the rendered report is what matters.
+		_ = runDoctorTo(context.Background(), &buf, format, badDSN, "", "", 0, "")
+		if !strings.Contains(buf.String(), name) {
+			t.Errorf("%s output does not contain the registered check %q:\n%s", format, name, buf.String())
+		}
 	}
 }

--- a/cliapp/doctor_ext_test.go
+++ b/cliapp/doctor_ext_test.go
@@ -1,0 +1,41 @@
+package cliapp
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/ext"
+	"github.com/dbtrail/dbtrail/internal/doctor"
+)
+
+func TestExtCheckResultKnownStatusesPassThrough(t *testing.T) {
+	for _, status := range []string{"pass", "fail", "warn", "skip"} {
+		got := extCheckResult(ext.DoctorCheck{Name: "n", Status: status, Detail: "d", Remediation: "r"})
+		if got.Status != doctor.CheckStatus(status) || got.Name != "n" || got.Detail != "d" || got.Remediation != "r" {
+			t.Errorf("status %q: got %+v", status, got)
+		}
+	}
+}
+
+func TestExtCheckResultUnknownStatusBecomesWarn(t *testing.T) {
+	// The doctor constants are lowercase; an uppercase "PASS" is unknown and
+	// must degrade to a counted WARN rather than an uncounted malformed entry.
+	got := extCheckResult(ext.DoctorCheck{Name: "n", Status: "PASS", Detail: "d"})
+	if got.Status != doctor.StatusWarn {
+		t.Fatalf("status = %q, want %q", got.Status, doctor.StatusWarn)
+	}
+	if !strings.Contains(got.Detail, `unknown status "PASS"`) || !strings.HasPrefix(got.Detail, "d") {
+		t.Errorf("detail = %q, want original detail plus an unknown-status note", got.Detail)
+	}
+}
+
+// TestAppendExtDoctorChecksDefaultNoop pins the stock-binary behavior: with
+// no registered checks the report is untouched.
+func TestAppendExtDoctorChecksDefaultNoop(t *testing.T) {
+	report := &doctor.Report{}
+	appendExtDoctorChecks(context.Background(), report, "src", "idx")
+	if len(report.Checks) != 0 || report.Warnings != 0 {
+		t.Fatalf("report changed with nothing registered: %+v", report)
+	}
+}

--- a/cliapp/root.go
+++ b/cliapp/root.go
@@ -60,6 +60,15 @@ func init() {
 	cli.AddForensicsCommands(rootCmd)
 }
 
+// AddCommands registers additional top-level commands on the bintrail root
+// command. Embedding distributions call it from main() before Main so their
+// commands dispatch alongside the built-in set — the same startup-only
+// contract as the ext package's setters: not safe for concurrent use with
+// command execution.
+func AddCommands(cmds ...*cobra.Command) {
+	rootCmd.AddCommand(cmds...)
+}
+
 // Main configures build metadata and runs the bintrail root command,
 // returning the process exit code. Callers (cmd/bintrail, and external
 // distributions embedding the CLI) are expected to pass their

--- a/cliapp/up.go
+++ b/cliapp/up.go
@@ -223,7 +223,12 @@ func runUpStream(cmd *cobra.Command, args []string) error {
 	// Extension source jobs (ext.RegisterSourceJob) share the same lifecycle
 	// and contract as rotation and the poller above: secondary daemon-scoped
 	// work that must never be fatal to the stream. No-op in the stock binary.
-	ext.RunSourceJobs(rotCtx, ext.SourceJobInfo{SourceDSN: upSourceDSN, IndexDSN: upIndexDSN, Flavor: "mysql"})
+	// Flavor is the value the stream below actually runs with: `up` has no
+	// --source-flavor flag of its own, so strmFlavor holds streamCmd's default
+	// ("mysql") or the BINTRAIL_SOURCE_FLAVOR override, which bindCommandEnv
+	// (streamCmd) applied at flag-binding time; populateStreamFlags above
+	// deliberately leaves it untouched.
+	ext.RunSourceJobs(rotCtx, ext.SourceJobInfo{SourceDSN: upSourceDSN, IndexDSN: upIndexDSN, Flavor: strmFlavor})
 	return runStream(cmd, args)
 }
 

--- a/cliapp/up.go
+++ b/cliapp/up.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/dbtrail/dbtrail/ext"
 	"github.com/dbtrail/dbtrail/internal/cliutil"
 	"github.com/dbtrail/dbtrail/internal/doctor"
 	"github.com/dbtrail/dbtrail/internal/forensics"
@@ -124,6 +125,7 @@ func runUp(cmd *cobra.Command, args []string) error {
 		// there is still room). Standalone `doctor` keeps full FAIL
 		// semantics for CI.
 		preflight := doctor.Build(cmd.Context(), upSourceDSN, upIndexDSN, upSchemas, upRotationCfg.Retain)
+		appendExtDoctorChecks(cmd.Context(), preflight, upSourceDSN, upIndexDSN)
 		if err := preflight.Write(os.Stderr, "text"); err != nil {
 			return fmt.Errorf("write preflight report: %w", err)
 		}
@@ -218,6 +220,10 @@ func runUpStream(cmd *cobra.Command, args []string) error {
 			Retention: upAttributionRetention,
 		})
 	}
+	// Extension source jobs (ext.RegisterSourceJob) share the same lifecycle
+	// and contract as rotation and the poller above: secondary daemon-scoped
+	// work that must never be fatal to the stream. No-op in the stock binary.
+	ext.RunSourceJobs(rotCtx, ext.SourceJobInfo{SourceDSN: upSourceDSN, IndexDSN: upIndexDSN, Flavor: "mysql"})
 	return runStream(cmd, args)
 }
 

--- a/ext/agentcmd.go
+++ b/ext/agentcmd.go
@@ -20,7 +20,9 @@ type AgentDeps struct {
 // AgentCommandFunc handles one agent WebSocket command type. The payload is
 // the raw command data — unmarshalling it is the handler's job. The returned
 // value is marshalled into the response's data field; a returned error
-// becomes the response's error string.
+// becomes the response's error string. Returning (nil, nil) is a valid empty
+// success — the response omits the data field, so it is indistinguishable on
+// the wire from "no data".
 type AgentCommandFunc func(ctx context.Context, deps AgentDeps, payload json.RawMessage) (any, error)
 
 // agentCommands is empty in the OSS build — unknown command types keep
@@ -32,8 +34,12 @@ var agentCommands = map[string]AgentCommandFunc{}
 // win — the registry is consulted only when no built-in case matches).
 // Registering the same cmdType twice replaces the earlier handler (last
 // wins). Same startup-only contract as the other seams: call from main()
-// before command dispatch.
+// before command dispatch. Registering a nil handler panics immediately so
+// the misuse fails at startup, not at first dispatch.
 func RegisterAgentCommand(cmdType string, h AgentCommandFunc) {
+	if h == nil {
+		panic("ext: nil agent command handler")
+	}
 	agentCommands[cmdType] = h
 }
 

--- a/ext/agentcmd.go
+++ b/ext/agentcmd.go
@@ -1,0 +1,45 @@
+package ext
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+)
+
+// AgentDeps carries the connection handles the agent runner establishes at
+// startup, handed to every registered agent command at dispatch time. Any
+// field may be zero (the agent runs with whatever data sources it was
+// configured with) — handlers must nil-check what they use.
+type AgentDeps struct {
+	IndexDB    *sql.DB
+	SourceDB   *sql.DB
+	SourceDSN  string
+	SourceHost string // resolved host of the source server, "" when no source is configured
+}
+
+// AgentCommandFunc handles one agent WebSocket command type. The payload is
+// the raw command data — unmarshalling it is the handler's job. The returned
+// value is marshalled into the response's data field; a returned error
+// becomes the response's error string.
+type AgentCommandFunc func(ctx context.Context, deps AgentDeps, payload json.RawMessage) (any, error)
+
+// agentCommands is empty in the OSS build — unknown command types keep
+// failing with "unknown command type".
+var agentCommands = map[string]AgentCommandFunc{}
+
+// RegisterAgentCommand registers a handler for an agent WebSocket command
+// type that the core does not handle itself (built-in command types always
+// win — the registry is consulted only when no built-in case matches).
+// Registering the same cmdType twice replaces the earlier handler (last
+// wins). Same startup-only contract as the other seams: call from main()
+// before command dispatch.
+func RegisterAgentCommand(cmdType string, h AgentCommandFunc) {
+	agentCommands[cmdType] = h
+}
+
+// LookupAgentCommand returns the registered handler for cmdType. Called by
+// the core's agent dispatch loop for command types with no built-in case.
+func LookupAgentCommand(cmdType string) (AgentCommandFunc, bool) {
+	h, ok := agentCommands[cmdType]
+	return h, ok
+}

--- a/ext/agentcmd_test.go
+++ b/ext/agentcmd_test.go
@@ -1,0 +1,58 @@
+package ext
+
+import (
+	"context"
+	"encoding/json"
+	"maps"
+	"testing"
+)
+
+func TestLookupAgentCommandUnregistered(t *testing.T) {
+	if _, ok := LookupAgentCommand("ext_test_never_registered"); ok {
+		t.Fatal("unregistered command type found in registry")
+	}
+}
+
+func TestRegisterAgentCommandLastWins(t *testing.T) {
+	orig := agentCommands
+	agentCommands = maps.Clone(orig)
+	t.Cleanup(func() { agentCommands = orig })
+
+	RegisterAgentCommand("ext_test_dup", func(context.Context, AgentDeps, json.RawMessage) (any, error) {
+		return "first", nil
+	})
+	RegisterAgentCommand("ext_test_dup", func(context.Context, AgentDeps, json.RawMessage) (any, error) {
+		return "second", nil
+	})
+
+	h, ok := LookupAgentCommand("ext_test_dup")
+	if !ok {
+		t.Fatal("registered command not found")
+	}
+	got, err := h(context.Background(), AgentDeps{}, nil)
+	if err != nil || got != "second" {
+		t.Fatalf("handler = (%v, %v), want (second, nil): duplicate registration must be last-wins", got, err)
+	}
+}
+
+func TestRegisteredAgentCommandReceivesDepsAndPayload(t *testing.T) {
+	orig := agentCommands
+	agentCommands = maps.Clone(orig)
+	t.Cleanup(func() { agentCommands = orig })
+
+	RegisterAgentCommand("ext_test_echo", func(_ context.Context, deps AgentDeps, payload json.RawMessage) (any, error) {
+		return deps.SourceDSN + "|" + string(payload), nil
+	})
+
+	h, ok := LookupAgentCommand("ext_test_echo")
+	if !ok {
+		t.Fatal("registered command not found")
+	}
+	got, err := h(context.Background(), AgentDeps{SourceDSN: "sdsn"}, json.RawMessage(`{"x":1}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != `sdsn|{"x":1}` {
+		t.Errorf("handler saw %q", got)
+	}
+}

--- a/ext/doctorcheck.go
+++ b/ext/doctorcheck.go
@@ -1,0 +1,39 @@
+package ext
+
+import "context"
+
+// DoctorCheck is one preflight check result produced by a registered doctor
+// check function. Status must be one of the internal/doctor.CheckStatus
+// strings — "pass", "fail", "warn", or "skip"; the core coerces an unknown
+// value to a warn with a note so a drifting extension cannot silently
+// miscount the report.
+type DoctorCheck struct {
+	Name        string
+	Status      string
+	Detail      string
+	Remediation string
+}
+
+// doctorChecks is empty in the OSS build — RunDoctorChecks returns nothing.
+var doctorChecks []func(ctx context.Context, sourceDSN, indexDSN string) []DoctorCheck
+
+// RegisterDoctorCheck registers a function that contributes extra checks to
+// `bintrail doctor` and to preflight surfaces built on it (`bintrail up`).
+// Same startup-only contract as the other seams: call from main() before
+// command dispatch. Functions run in registration order.
+func RegisterDoctorCheck(fn func(ctx context.Context, sourceDSN, indexDSN string) []DoctorCheck) {
+	doctorChecks = append(doctorChecks, fn)
+}
+
+// RunDoctorChecks invokes every registered doctor check function and returns
+// the concatenated results. Called by the core after its own checks have run;
+// registered checks are advisory extensions of the report, and like the
+// built-in checks they must probe (validate, never set). Safe to call with
+// nothing registered — returns nil.
+func RunDoctorChecks(ctx context.Context, sourceDSN, indexDSN string) []DoctorCheck {
+	var out []DoctorCheck
+	for _, fn := range doctorChecks {
+		out = append(out, fn(ctx, sourceDSN, indexDSN)...)
+	}
+	return out
+}

--- a/ext/doctorcheck.go
+++ b/ext/doctorcheck.go
@@ -20,8 +20,13 @@ var doctorChecks []func(ctx context.Context, sourceDSN, indexDSN string) []Docto
 // RegisterDoctorCheck registers a function that contributes extra checks to
 // `bintrail doctor` and to preflight surfaces built on it (`bintrail up`).
 // Same startup-only contract as the other seams: call from main() before
-// command dispatch. Functions run in registration order.
+// command dispatch. Functions run in registration order. Registering a nil
+// function panics immediately so the misuse fails at startup, not at the
+// first doctor run.
 func RegisterDoctorCheck(fn func(ctx context.Context, sourceDSN, indexDSN string) []DoctorCheck) {
+	if fn == nil {
+		panic("ext: nil doctor check function")
+	}
 	doctorChecks = append(doctorChecks, fn)
 }
 

--- a/ext/doctorcheck_test.go
+++ b/ext/doctorcheck_test.go
@@ -1,0 +1,45 @@
+package ext
+
+import (
+	"context"
+	"testing"
+)
+
+func TestRunDoctorChecksNoRegistrationReturnsNil(t *testing.T) {
+	orig := doctorChecks
+	doctorChecks = nil
+	t.Cleanup(func() { doctorChecks = orig })
+
+	if got := RunDoctorChecks(context.Background(), "src", "idx"); got != nil {
+		t.Fatalf("RunDoctorChecks() = %v, want nil", got)
+	}
+}
+
+func TestRunDoctorChecksConcatenatesAndPassesDSNs(t *testing.T) {
+	orig := doctorChecks
+	doctorChecks = nil
+	t.Cleanup(func() { doctorChecks = orig })
+
+	var gotSource, gotIndex string
+	RegisterDoctorCheck(func(_ context.Context, sourceDSN, indexDSN string) []DoctorCheck {
+		gotSource, gotIndex = sourceDSN, indexDSN
+		return []DoctorCheck{
+			{Name: "a", Status: "pass"},
+			{Name: "b", Status: "warn", Detail: "d", Remediation: "r"},
+		}
+	})
+	RegisterDoctorCheck(func(_ context.Context, _, _ string) []DoctorCheck {
+		return []DoctorCheck{{Name: "c", Status: "fail"}}
+	})
+
+	checks := RunDoctorChecks(context.Background(), "src-dsn", "idx-dsn")
+	if len(checks) != 3 || checks[0].Name != "a" || checks[1].Name != "b" || checks[2].Name != "c" {
+		t.Fatalf("checks = %+v, want names a, b, c in order", checks)
+	}
+	if checks[1].Detail != "d" || checks[1].Remediation != "r" {
+		t.Errorf("check fields mangled: %+v", checks[1])
+	}
+	if gotSource != "src-dsn" || gotIndex != "idx-dsn" {
+		t.Errorf("check received (%q, %q), want (src-dsn, idx-dsn)", gotSource, gotIndex)
+	}
+}

--- a/ext/ext.go
+++ b/ext/ext.go
@@ -1,7 +1,8 @@
 // Package ext exposes the extension points that embedding distributions
 // — builds that import cliapp and wrap the OSS core — use to inject
-// behavior: an audit sink recording data-access operations, and
-// overrides for feature-entitlement gates.
+// behavior: an audit sink recording data-access operations, overrides
+// for feature-entitlement gates, extra doctor checks, agent WebSocket
+// commands, and daemon source jobs.
 //
 // Seams follow the same convention as the internal forensics.Enabled
 // gate: package-level variables set once at process startup (before any

--- a/ext/register_test.go
+++ b/ext/register_test.go
@@ -1,0 +1,48 @@
+package ext
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+// TestRegisterNilPanics pins the fail-at-startup contract: registering a nil
+// handler/function/job panics immediately in main(), instead of surfacing
+// hours later as a nil dereference at first dispatch.
+func TestRegisterNilPanics(t *testing.T) {
+	cases := map[string]func(){
+		"agent command": func() { RegisterAgentCommand("ext_test_nil", nil) },
+		"doctor check":  func() { RegisterDoctorCheck(nil) },
+		"source job":    func() { RegisterSourceJob(nil) },
+	}
+	for name, register := range cases {
+		t.Run(name, func(t *testing.T) {
+			defer func() {
+				if recover() == nil {
+					t.Errorf("registering a nil %s did not panic", name)
+				}
+			}()
+			register()
+		})
+	}
+}
+
+// TestResetForTestClearsRegistries pins the test helper other packages'
+// tests rely on for cleanup (the registries have no unregister by design).
+func TestResetForTestClearsRegistries(t *testing.T) {
+	origJobs, origChecks, origCmds := sourceJobs, doctorChecks, agentCommands
+	t.Cleanup(func() { sourceJobs, doctorChecks, agentCommands = origJobs, origChecks, origCmds })
+
+	RegisterSourceJob(func(context.Context, SourceJobInfo) {})
+	RegisterDoctorCheck(func(context.Context, string, string) []DoctorCheck { return nil })
+	RegisterAgentCommand("ext_test_reset", func(context.Context, AgentDeps, json.RawMessage) (any, error) {
+		return nil, nil
+	})
+
+	ResetForTest()
+
+	if len(sourceJobs) != 0 || len(doctorChecks) != 0 || len(agentCommands) != 0 {
+		t.Fatalf("ResetForTest left registrations behind: %d jobs, %d checks, %d commands",
+			len(sourceJobs), len(doctorChecks), len(agentCommands))
+	}
+}

--- a/ext/sourcejob.go
+++ b/ext/sourcejob.go
@@ -1,0 +1,34 @@
+package ext
+
+import "context"
+
+// SourceJobInfo describes one capture source at daemon startup, handed to
+// every registered source job. Flavor names the source family ("mysql",
+// "mariadb", "postgres").
+type SourceJobInfo struct {
+	SourceDSN string
+	IndexDSN  string
+	Flavor    string
+}
+
+// sourceJobs is empty in the OSS build — RunSourceJobs is a no-op.
+var sourceJobs []func(ctx context.Context, src SourceJobInfo)
+
+// RegisterSourceJob registers a background job to run alongside each capture
+// source's daemon lifecycle. Same startup-only contract as the other seams:
+// call from main() before command dispatch; not safe for concurrent use with
+// command execution. Jobs are invoked in registration order.
+func RegisterSourceJob(job func(ctx context.Context, src SourceJobInfo)) {
+	sourceJobs = append(sourceJobs, job)
+}
+
+// RunSourceJobs invokes every registered source job. Called by the core at
+// daemon startup wiring points, with a context bound to the daemon lifecycle;
+// jobs are secondary and must never be fatal — a job that needs to keep
+// working spawns its own goroutine and returns promptly, and a job that fails
+// logs rather than panics. Safe to call with nothing registered.
+func RunSourceJobs(ctx context.Context, src SourceJobInfo) {
+	for _, job := range sourceJobs {
+		job(ctx, src)
+	}
+}

--- a/ext/sourcejob.go
+++ b/ext/sourcejob.go
@@ -1,10 +1,14 @@
 package ext
 
-import "context"
+import (
+	"context"
+	"log/slog"
+)
 
 // SourceJobInfo describes one capture source at daemon startup, handed to
-// every registered source job. Flavor names the source family ("mysql",
-// "mariadb", "postgres").
+// every registered source job. Flavor names the source family; core wiring
+// currently only ever carries "mysql" or "mariadb" (the flavor `bintrail up`
+// streams with).
 type SourceJobInfo struct {
 	SourceDSN string
 	IndexDSN  string
@@ -14,21 +18,35 @@ type SourceJobInfo struct {
 // sourceJobs is empty in the OSS build — RunSourceJobs is a no-op.
 var sourceJobs []func(ctx context.Context, src SourceJobInfo)
 
-// RegisterSourceJob registers a background job to run alongside each capture
-// source's daemon lifecycle. Same startup-only contract as the other seams:
-// call from main() before command dispatch; not safe for concurrent use with
-// command execution. Jobs are invoked in registration order.
+// RegisterSourceJob registers a background job to run alongside the daemon
+// lifecycle. Today the only core wiring point is the `bintrail up` daemon;
+// other daemons may adopt it in the future. Same startup-only contract as the
+// other seams: call from main() before command dispatch; not safe for
+// concurrent use with command execution. Registering a nil job panics
+// immediately so the misuse fails at startup, not at daemon boot.
 func RegisterSourceJob(job func(ctx context.Context, src SourceJobInfo)) {
+	if job == nil {
+		panic("ext: nil source job")
+	}
 	sourceJobs = append(sourceJobs, job)
 }
 
-// RunSourceJobs invokes every registered source job. Called by the core at
-// daemon startup wiring points, with a context bound to the daemon lifecycle;
-// jobs are secondary and must never be fatal — a job that needs to keep
-// working spawns its own goroutine and returns promptly, and a job that fails
-// logs rather than panics. Safe to call with nothing registered.
+// RunSourceJobs launches every registered source job, each on its own
+// goroutine, and returns immediately. Called by the core at `bintrail up`
+// startup, with a context bound to the daemon lifetime — the passed ctx
+// bounds the jobs' lifetime. Jobs are secondary and must never be fatal to
+// the daemon; the core enforces that here: a panicking job is recovered and
+// logged, never propagated to the stream, and a slow job cannot block
+// startup. Safe to call with nothing registered.
 func RunSourceJobs(ctx context.Context, src SourceJobInfo) {
 	for _, job := range sourceJobs {
-		job(ctx, src)
+		go func() {
+			defer func() {
+				if p := recover(); p != nil {
+					slog.Error("ext: source job panicked", "panic", p)
+				}
+			}()
+			job(ctx, src)
+		}()
 	}
 }

--- a/ext/sourcejob_test.go
+++ b/ext/sourcejob_test.go
@@ -3,6 +3,7 @@ package ext
 import (
 	"context"
 	"testing"
+	"time"
 )
 
 func TestRunSourceJobsNoRegistrationIsNoop(t *testing.T) {
@@ -14,28 +15,52 @@ func TestRunSourceJobsNoRegistrationIsNoop(t *testing.T) {
 	RunSourceJobs(context.Background(), SourceJobInfo{SourceDSN: "s", IndexDSN: "i", Flavor: "mysql"})
 }
 
-func TestRunSourceJobsInvokesInRegistrationOrder(t *testing.T) {
+func TestRunSourceJobsRunsEveryJobWithInfo(t *testing.T) {
 	orig := sourceJobs
 	sourceJobs = nil
 	t.Cleanup(func() { sourceJobs = orig })
 
-	var order []string
-	var gotSrc SourceJobInfo
-	RegisterSourceJob(func(_ context.Context, src SourceJobInfo) {
-		order = append(order, "first")
-		gotSrc = src
-	})
-	RegisterSourceJob(func(_ context.Context, _ SourceJobInfo) {
-		order = append(order, "second")
-	})
+	// Jobs run on their own goroutines (no ordering guarantee), so collect
+	// through a channel and assert both fire with the exact SourceJobInfo.
+	got := make(chan SourceJobInfo, 2)
+	RegisterSourceJob(func(_ context.Context, src SourceJobInfo) { got <- src })
+	RegisterSourceJob(func(_ context.Context, src SourceJobInfo) { got <- src })
 
-	want := SourceJobInfo{SourceDSN: "user:pass@tcp(h:3306)/db", IndexDSN: "idx-dsn", Flavor: "mysql"}
+	want := SourceJobInfo{SourceDSN: "user:pass@tcp(h:3306)/db", IndexDSN: "idx-dsn", Flavor: "mariadb"}
 	RunSourceJobs(context.Background(), want)
 
-	if len(order) != 2 || order[0] != "first" || order[1] != "second" {
-		t.Fatalf("jobs ran %v, want [first second]", order)
+	for i := range 2 {
+		select {
+		case src := <-got:
+			if src != want {
+				t.Errorf("job received %+v, want %+v", src, want)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out waiting for registered job %d to run", i+1)
+		}
 	}
-	if gotSrc != want {
-		t.Errorf("job received %+v, want %+v", gotSrc, want)
+}
+
+// TestRunSourceJobsPanicDoesNotPropagate pins the H-contract the core
+// enforces: a panicking job is recovered on its own goroutine (never
+// propagated to the daemon) and sibling jobs still run.
+func TestRunSourceJobsPanicDoesNotPropagate(t *testing.T) {
+	orig := sourceJobs
+	sourceJobs = nil
+	t.Cleanup(func() { sourceJobs = orig })
+
+	survivorRan := make(chan struct{})
+	RegisterSourceJob(func(context.Context, SourceJobInfo) { panic("source job boom") })
+	RegisterSourceJob(func(context.Context, SourceJobInfo) { close(survivorRan) })
+
+	// Must not panic the caller — the panic is contained per-goroutine. An
+	// uncontained goroutine panic would crash the whole test binary, so the
+	// package passing at all is the real assertion.
+	RunSourceJobs(context.Background(), SourceJobInfo{Flavor: "mysql"})
+
+	select {
+	case <-survivorRan:
+	case <-time.After(5 * time.Second):
+		t.Fatal("surviving job did not run after a sibling panicked")
 	}
 }

--- a/ext/sourcejob_test.go
+++ b/ext/sourcejob_test.go
@@ -1,0 +1,41 @@
+package ext
+
+import (
+	"context"
+	"testing"
+)
+
+func TestRunSourceJobsNoRegistrationIsNoop(t *testing.T) {
+	orig := sourceJobs
+	sourceJobs = nil
+	t.Cleanup(func() { sourceJobs = orig })
+
+	// Must not panic.
+	RunSourceJobs(context.Background(), SourceJobInfo{SourceDSN: "s", IndexDSN: "i", Flavor: "mysql"})
+}
+
+func TestRunSourceJobsInvokesInRegistrationOrder(t *testing.T) {
+	orig := sourceJobs
+	sourceJobs = nil
+	t.Cleanup(func() { sourceJobs = orig })
+
+	var order []string
+	var gotSrc SourceJobInfo
+	RegisterSourceJob(func(_ context.Context, src SourceJobInfo) {
+		order = append(order, "first")
+		gotSrc = src
+	})
+	RegisterSourceJob(func(_ context.Context, _ SourceJobInfo) {
+		order = append(order, "second")
+	})
+
+	want := SourceJobInfo{SourceDSN: "user:pass@tcp(h:3306)/db", IndexDSN: "idx-dsn", Flavor: "mysql"}
+	RunSourceJobs(context.Background(), want)
+
+	if len(order) != 2 || order[0] != "first" || order[1] != "second" {
+		t.Fatalf("jobs ran %v, want [first second]", order)
+	}
+	if gotSrc != want {
+		t.Errorf("job received %+v, want %+v", gotSrc, want)
+	}
+}

--- a/ext/testing.go
+++ b/ext/testing.go
@@ -1,0 +1,13 @@
+package ext
+
+// ResetForTest clears every extension registry (doctor checks, source jobs,
+// agent commands) so tests in other packages can register fixtures without
+// polluting later tests in the same binary. Test helper ONLY — the
+// registries are startup-only by contract (set once from main(), never
+// mutated during command execution), and production code must never call
+// this.
+func ResetForTest() {
+	doctorChecks = nil
+	sourceJobs = nil
+	agentCommands = map[string]AgentCommandFunc{}
+}

--- a/indexquery/eventtype_test.go
+++ b/indexquery/eventtype_test.go
@@ -1,0 +1,30 @@
+package indexquery
+
+import "testing"
+
+// TestEventTypeNameVocabulary pins the exported event-type vocabulary and its
+// numeric values — a persistence contract (binlog_events.event_type): never
+// renumber.
+func TestEventTypeNameVocabulary(t *testing.T) {
+	cases := []struct {
+		et   EventType
+		num  uint8
+		want string
+	}{
+		{EventInsert, 1, "INSERT"},
+		{EventUpdate, 2, "UPDATE"},
+		{EventDelete, 3, "DELETE"},
+		{EventDDL, 4, "DDL"},
+		{EventGTID, 5, "GTID"},
+		{EventSnapshot, 6, "SNAPSHOT"},
+		{EventType(250), 250, "UNKNOWN"},
+	}
+	for _, tc := range cases {
+		if uint8(tc.et) != tc.num {
+			t.Errorf("EventType %s = %d, want %d (persistence contract)", tc.want, tc.et, tc.num)
+		}
+		if got := EventTypeName(tc.et); got != tc.want {
+			t.Errorf("EventTypeName(%d) = %q, want %q", tc.et, got, tc.want)
+		}
+	}
+}

--- a/indexquery/indexquery.go
+++ b/indexquery/indexquery.go
@@ -1,0 +1,97 @@
+// Package indexquery exposes read-only programmatic access to the bintrail
+// index — live MySQL partitions and Parquet archives merged — for tooling and
+// embedding distributions that import the core as a module.
+//
+// It is a thin facade over the internal query layer: type aliases to the
+// internal types (usable across module boundaries through the alias) plus
+// one-line wrappers over the internal entry points, so external code can run
+// the exact fetch/merge/gap-detection pipeline the CLI commands use. The
+// index schema stays owned by the core: EnsureSchema is the only sanctioned
+// migration entry point, and this package adds no write surface beyond it.
+package indexquery
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dbtrail/dbtrail/internal/cli"
+	"github.com/dbtrail/dbtrail/internal/cliutil"
+	"github.com/dbtrail/dbtrail/internal/config"
+	"github.com/dbtrail/dbtrail/internal/duckdbutil"
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/query"
+)
+
+// Aliases to the internal query types. FetchMergedOptions is fully
+// constructible through these (including its ArchiveFetcher field); GapError
+// and SourceEmptyError are aliased so callers can inspect FetchMerged
+// failures with errors.As.
+type (
+	Options            = query.Options
+	ResultRow          = query.ResultRow
+	Engine             = query.Engine
+	QueryPlan          = query.QueryPlan
+	FetchMergedOptions = query.FetchMergedOptions
+	ArchiveFetcher     = query.ArchiveFetcher
+	GapError           = query.GapError
+	SourceEmptyError   = query.SourceEmptyError
+	Tuning             = duckdbutil.Tuning
+)
+
+// New returns a query engine over the index database.
+func New(db *sql.DB) *Engine { return query.New(db) }
+
+// FetchMerged fetches events from live MySQL partitions and Parquet archives,
+// deduplicates and sorts them, and enforces coverage-gap detection according
+// to o.AllowGaps. See query.FetchMerged for the full failure-mode contract.
+func FetchMerged(ctx context.Context, db *sql.DB, engine *Engine, o FetchMergedOptions) ([]ResultRow, *QueryPlan, error) {
+	return query.FetchMerged(ctx, db, engine, o)
+}
+
+// FormatGapWarning renders the planner's gap hours as the standard
+// human-readable coverage warning.
+func FormatGapWarning(gaps []time.Time) string { return query.FormatGapWarning(gaps) }
+
+// Connect opens and verifies a MySQL connection with the core's connection
+// invariants applied (parseTime=true, UTC, default connect timeout). The
+// caller closes the returned *sql.DB.
+func Connect(dsn string) (*sql.DB, error) { return config.Connect(dsn) }
+
+// ParseSourceDSN decomposes a go-sql-driver DSN into host, port, user, and
+// password. It requires a TCP address and rejects unix-socket DSNs.
+func ParseSourceDSN(dsn string) (host string, port uint16, user, password string, err error) {
+	return config.ParseSourceDSN(dsn)
+}
+
+// EnsureSchema brings the index schema up to date (idempotent — safe to call
+// on every startup). This is the only schema-mutating entry point exposed
+// here; the schema definition itself stays owned by the core.
+func EnsureSchema(db *sql.DB) error { return indexer.EnsureSchema(db) }
+
+// WrapSchemaMigrationErr rewrites an EnsureSchema failure caused by a
+// read-only DSN (missing ALTER/CREATE privilege) into an actionable error.
+// Read-plane callers only — capture-plane callers must keep failing hard on
+// the raw error.
+func WrapSchemaMigrationErr(err error) error { return indexer.WrapSchemaMigrationErr(err) }
+
+// AddDuckDBTuningFlags registers the shared DuckDB resource flags
+// (--ultrafast, --duckdb-threads, --duckdb-memory-limit) on an offline
+// read command.
+func AddDuckDBTuningFlags(cmd *cobra.Command) { cli.AddDuckDBTuningFlags(cmd) }
+
+// DuckDBTuningFromFlags resolves the effective DuckDB tuning for a command
+// carrying the flags registered by AddDuckDBTuningFlags. An invalid
+// --duckdb-memory-limit is a hard error.
+func DuckDBTuningFromFlags(cmd *cobra.Command) (Tuning, error) {
+	return cli.DuckDBTuningFromFlags(cmd)
+}
+
+// TunedArchiveFetcher adapts a DuckDB Tuning into an ArchiveFetcher suitable
+// for FetchMergedOptions.ArchiveFetcher.
+func TunedArchiveFetcher(t Tuning) ArchiveFetcher { return cli.TunedArchiveFetcher(t) }
+
+// OutputJSON writes v to stdout as indented JSON.
+func OutputJSON(v any) error { return cliutil.OutputJSON(v) }

--- a/indexquery/indexquery.go
+++ b/indexquery/indexquery.go
@@ -21,6 +21,7 @@ import (
 	"github.com/dbtrail/dbtrail/internal/cliutil"
 	"github.com/dbtrail/dbtrail/internal/config"
 	"github.com/dbtrail/dbtrail/internal/duckdbutil"
+	"github.com/dbtrail/dbtrail/internal/event"
 	"github.com/dbtrail/dbtrail/internal/indexer"
 	"github.com/dbtrail/dbtrail/internal/query"
 )
@@ -41,12 +42,60 @@ type (
 	Tuning             = duckdbutil.Tuning
 )
 
+// EventType aliases the event-type vocabulary so external code can interpret
+// ResultRow.EventType without magic numbers. The numeric values are a
+// persistence contract (binlog_events.event_type) — never renumber.
+type EventType = event.EventType
+
+// The persisted event-type values a ResultRow can carry. (Capture-side
+// transient types — commit markers, PG relation messages — are never written
+// to binlog_events, so they cannot appear in query results.)
+const (
+	EventInsert   = event.EventInsert
+	EventUpdate   = event.EventUpdate
+	EventDelete   = event.EventDelete
+	EventDDL      = event.EventDDL
+	EventGTID     = event.EventGTID
+	EventSnapshot = event.EventSnapshot
+)
+
+// EventTypeName returns the canonical upper-case name for a persisted event
+// type ("INSERT", "UPDATE", "DELETE", "DDL", "GTID", "SNAPSHOT"), or
+// "UNKNOWN" for a value outside that vocabulary.
+func EventTypeName(t EventType) string {
+	switch t {
+	case EventInsert:
+		return "INSERT"
+	case EventUpdate:
+		return "UPDATE"
+	case EventDelete:
+		return "DELETE"
+	case EventDDL:
+		return "DDL"
+	case EventGTID:
+		return "GTID"
+	case EventSnapshot:
+		return "SNAPSHOT"
+	default:
+		return "UNKNOWN"
+	}
+}
+
 // New returns a query engine over the index database.
 func New(db *sql.DB) *Engine { return query.New(db) }
 
 // FetchMerged fetches events from live MySQL partitions and Parquet archives,
 // deduplicates and sorts them, and enforces coverage-gap detection according
 // to o.AllowGaps. See query.FetchMerged for the full failure-mode contract.
+//
+// Two caveats external callers cannot discover from the signature:
+//
+//   - Callers running with redaction options (an RBAC profile — DenyTables /
+//     RedactColumns / ProfileActive on o.Opts) must set o.NoArchive = true:
+//     Parquet archives store the raw rows, so the archive branch would serve
+//     unredacted columns.
+//   - The returned *QueryPlan may be nil when the planner didn't run (e.g. no
+//     DBName or no time range) — nil-check it before use.
 func FetchMerged(ctx context.Context, db *sql.DB, engine *Engine, o FetchMergedOptions) ([]ResultRow, *QueryPlan, error) {
 	return query.FetchMerged(ctx, db, engine, o)
 }

--- a/indexquery/indexquery_test.go
+++ b/indexquery/indexquery_test.go
@@ -1,0 +1,105 @@
+package indexquery
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// Compile-level pins for the wrappers that need a live database or write to
+// stdout — the exported signatures are the contract embedding code builds
+// against.
+var (
+	_ func(*sql.DB) *Engine = New
+	_ func(*sql.DB) error   = EnsureSchema
+	_ func(any) error       = OutputJSON
+)
+
+// TestFetchMergedValidatesBeforeAnyDBWork exercises the wrapper on the
+// validation path: NoArchive=false with a nil ArchiveFetcher is rejected up
+// front, so the nil db/engine prove no DB work happened.
+func TestFetchMergedValidatesBeforeAnyDBWork(t *testing.T) {
+	_, _, err := FetchMerged(context.Background(), nil, nil, FetchMergedOptions{})
+	if err == nil || !strings.Contains(err.Error(), "ArchiveFetcher") {
+		t.Fatalf("err = %v, want the ArchiveFetcher validation error", err)
+	}
+}
+
+// TestFetchMergedOptionsConstructibleThroughAliases pins that every field an
+// external module needs — including the ArchiveFetcher function type — is
+// reachable through the aliases.
+func TestFetchMergedOptionsConstructibleThroughAliases(t *testing.T) {
+	since := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	var fetcher ArchiveFetcher = func(context.Context, Options, string) ([]ResultRow, error) {
+		return nil, nil
+	}
+	o := FetchMergedOptions{
+		Opts:           Options{Schema: "shop", Table: "orders", Since: &since, Limit: 10},
+		DBName:         "bintrail_index",
+		AllowGaps:      true,
+		ArchiveFetcher: fetcher,
+	}
+	if o.Opts.Schema != "shop" || o.ArchiveFetcher == nil {
+		t.Fatal("alias construction lost fields")
+	}
+	if New(nil) == nil {
+		t.Fatal("New returned nil engine")
+	}
+}
+
+func TestConnectRejectsInvalidDSN(t *testing.T) {
+	if _, err := Connect("this is not a dsn"); err == nil {
+		t.Fatal("Connect accepted an invalid DSN")
+	}
+}
+
+func TestParseSourceDSN(t *testing.T) {
+	host, port, user, pass, err := ParseSourceDSN("u:p@tcp(db.example:3307)/shop")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if host != "db.example" || port != 3307 || user != "u" || pass != "p" {
+		t.Errorf("ParseSourceDSN = (%q, %d, %q, %q)", host, port, user, pass)
+	}
+	if _, _, _, _, err := ParseSourceDSN("not a dsn"); err == nil {
+		t.Error("ParseSourceDSN accepted garbage")
+	}
+}
+
+func TestDuckDBTuningWrappers(t *testing.T) {
+	cmd := &cobra.Command{Use: "x"}
+	AddDuckDBTuningFlags(cmd)
+	for _, name := range []string{"ultrafast", "duckdb-threads", "duckdb-memory-limit"} {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Fatalf("flag --%s not registered", name)
+		}
+	}
+	tuning, err := DuckDBTuningFromFlags(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if TunedArchiveFetcher(tuning) == nil {
+		t.Fatal("TunedArchiveFetcher returned nil")
+	}
+}
+
+func TestFormatGapWarningNonEmpty(t *testing.T) {
+	if FormatGapWarning([]time.Time{time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)}) == "" {
+		t.Fatal("FormatGapWarning returned empty string")
+	}
+}
+
+func TestWrapSchemaMigrationErr(t *testing.T) {
+	if WrapSchemaMigrationErr(nil) != nil {
+		t.Fatal("nil must stay nil")
+	}
+	base := errors.New("boom")
+	if wrapped := WrapSchemaMigrationErr(base); !errors.Is(wrapped, base) {
+		t.Fatalf("wrapped = %v, want a wrap of the base error", wrapped)
+	}
+}

--- a/internal/agent/channel.go
+++ b/internal/agent/channel.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/coder/websocket"
+
+	"github.com/dbtrail/dbtrail/ext"
 )
 
 // ─── Configuration ───────────────────────────────────────────────────────────
@@ -91,6 +93,12 @@ type Channel struct {
 	startAt        time.Time
 	logger         *slog.Logger
 	statusProvider func() *FlushStatus
+
+	// ExtDeps carries the connection handles handed to extension-registered
+	// commands (ext.RegisterAgentCommand) at dispatch time. Set once by the
+	// agent runner before Run — the same startup-only contract as the ext
+	// setters. The zero value is valid: registry handlers must nil-check.
+	ExtDeps ext.AgentDeps
 }
 
 // FlushStatus holds the current state of the BYOS flush pipeline,
@@ -309,7 +317,7 @@ func (ch *Channel) listenLoop(ctx context.Context, conn *websocket.Conn) error {
 			"command_id", cmd.ID,
 			"type", cmd.Type)
 
-		resp := dispatch(ctx, ch.handler, cmd)
+		resp := dispatch(ctx, ch.handler, cmd, ch.ExtDeps)
 
 		if err := writeJSON(ctx, conn, resp); err != nil {
 			return fmt.Errorf("write response: %w", err)

--- a/internal/agent/channel_test.go
+++ b/internal/agent/channel_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/coder/websocket"
 
+	"github.com/dbtrail/dbtrail/ext"
 	"github.com/dbtrail/dbtrail/internal/forensics"
 )
 
@@ -66,7 +67,7 @@ func TestDispatch_resolvePK(t *testing.T) {
 	data, _ := json.Marshal(ResolvePKRequest{Items: []PKItem{{PKHash: "abc", Schema: "db", Table: "t"}}})
 	cmd := Command{ID: "1", Type: "resolve_pk", Data: data}
 
-	resp := dispatch(context.Background(), h, cmd)
+	resp := dispatch(context.Background(), h, cmd, ext.AgentDeps{})
 
 	if resp.ID != "1" {
 		t.Errorf("ID = %q, want %q", resp.ID, "1")
@@ -92,7 +93,7 @@ func TestDispatch_recover(t *testing.T) {
 	data, _ := json.Marshal(RecoverRequest{Schema: "db", Table: "t", TimeStart: time.Now(), TimeEnd: time.Now()})
 	cmd := Command{ID: "2", Type: "recover", Data: data}
 
-	resp := dispatch(context.Background(), h, cmd)
+	resp := dispatch(context.Background(), h, cmd, ext.AgentDeps{})
 
 	if resp.Error != "" {
 		t.Fatalf("unexpected error: %s", resp.Error)
@@ -111,7 +112,7 @@ func TestDispatch_forensicsQuery(t *testing.T) {
 	data, _ := json.Marshal(ForensicsQueryRequest{Query: "recent_queries"})
 	cmd := Command{ID: "3", Type: "forensics_query", Data: data}
 
-	resp := dispatch(context.Background(), h, cmd)
+	resp := dispatch(context.Background(), h, cmd, ext.AgentDeps{})
 
 	if resp.Error != "" {
 		t.Fatalf("unexpected error: %s", resp.Error)
@@ -122,7 +123,7 @@ func TestDispatch_unknownType(t *testing.T) {
 	h := &stubHandler{}
 	cmd := Command{ID: "4", Type: "nope", Data: json.RawMessage(`{}`)}
 
-	resp := dispatch(context.Background(), h, cmd)
+	resp := dispatch(context.Background(), h, cmd, ext.AgentDeps{})
 
 	if !strings.Contains(resp.Error, "unknown command type") {
 		t.Errorf("error = %q, want 'unknown command type'", resp.Error)
@@ -133,7 +134,7 @@ func TestDispatch_invalidPayload(t *testing.T) {
 	h := &stubHandler{}
 	cmd := Command{ID: "5", Type: "resolve_pk", Data: json.RawMessage(`{invalid`)}
 
-	resp := dispatch(context.Background(), h, cmd)
+	resp := dispatch(context.Background(), h, cmd, ext.AgentDeps{})
 
 	if !strings.Contains(resp.Error, "invalid resolve_pk payload") {
 		t.Errorf("error = %q, want 'invalid resolve_pk payload'", resp.Error)
@@ -521,7 +522,7 @@ func TestDispatch_handlerError(t *testing.T) {
 	data, _ := json.Marshal(ResolvePKRequest{Items: []PKItem{{PKHash: "abc", Schema: "db", Table: "t"}}})
 	cmd := Command{ID: "err-1", Type: "resolve_pk", Data: data}
 
-	resp := dispatch(context.Background(), h, cmd)
+	resp := dispatch(context.Background(), h, cmd, ext.AgentDeps{})
 
 	if resp.ID != "err-1" {
 		t.Errorf("ID = %q, want %q", resp.ID, "err-1")

--- a/internal/agent/command.go
+++ b/internal/agent/command.go
@@ -28,6 +28,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/dbtrail/dbtrail/ext"
 	"github.com/dbtrail/dbtrail/internal/forensics"
 )
 
@@ -232,8 +233,12 @@ func forensicsAttributionGate(cmdType string) string {
 }
 
 // dispatch routes a Command to the appropriate Handler method and returns
-// the Response to send back.
-func dispatch(ctx context.Context, h Handler, cmd Command) Response {
+// the Response to send back. A command type with no builtin case is looked
+// up in the extension registry (ext.RegisterAgentCommand) — builtin types
+// always win — and only fails as unknown when the registry has no handler
+// either. deps carries the connection handles registry handlers receive;
+// the zero value is fine when nothing is registered.
+func dispatch(ctx context.Context, h Handler, cmd Command, deps ext.AgentDeps) Response {
 	resp := Response{ID: cmd.ID, Type: cmd.Type}
 
 	// Entitlement gate for the forensics attribution family (#701 D1) —
@@ -341,6 +346,15 @@ func dispatch(ctx context.Context, h Handler, cmd Command) Response {
 		resp.Data = result
 
 	default:
+		if handler, ok := ext.LookupAgentCommand(cmd.Type); ok {
+			result, err := handler(ctx, deps, cmd.Data)
+			if err != nil {
+				resp.Error = err.Error()
+				return resp
+			}
+			resp.Data = result
+			return resp
+		}
 		resp.Error = fmt.Sprintf("unknown command type %q", cmd.Type)
 	}
 	return resp

--- a/internal/agent/command.go
+++ b/internal/agent/command.go
@@ -347,15 +347,51 @@ func dispatch(ctx context.Context, h Handler, cmd Command, deps ext.AgentDeps) R
 
 	default:
 		if handler, ok := ext.LookupAgentCommand(cmd.Type); ok {
-			result, err := handler(ctx, deps, cmd.Data)
-			if err != nil {
-				resp.Error = err.Error()
-				return resp
-			}
-			resp.Data = result
-			return resp
+			return runExtCommand(ctx, handler, cmd, deps)
 		}
 		resp.Error = fmt.Sprintf("unknown command type %q", cmd.Type)
 	}
+	return resp
+}
+
+// runExtCommand invokes an extension-registered command handler with two
+// containment layers the builtin cases don't need:
+//
+//   - Panic containment: a registry handler is externally-registered code
+//     reachable by a remote command. A panic must degrade to a per-command
+//     error response and a normal return — never kill the agent process
+//     (the in-memory BYOS buffer dies with it).
+//   - Response pre-marshaling: the handler's result is marshalled HERE, so a
+//     value json.Marshal rejects (NaN, channel, cyclic structure, ...)
+//     becomes a per-command error on the wire instead of failing later in
+//     writeJSON — which would tear down the connection and enter a reconnect
+//     loop that dies the same way on every redelivery. Response.Data carries
+//     the pre-marshalled bytes as json.RawMessage; the envelope marshal
+//     splices them verbatim, so writeJSON can no longer fail on handler
+//     output.
+func runExtCommand(ctx context.Context, handler ext.AgentCommandFunc, cmd Command, deps ext.AgentDeps) (resp Response) {
+	resp = Response{ID: cmd.ID, Type: cmd.Type}
+	defer func() {
+		if p := recover(); p != nil {
+			resp.Data = nil
+			resp.Error = fmt.Sprintf("command handler for %q panicked: %v", cmd.Type, p)
+		}
+	}()
+	result, err := handler(ctx, deps, cmd.Data)
+	if err != nil {
+		resp.Error = err.Error()
+		return resp
+	}
+	if result == nil {
+		// (nil, nil) is a valid empty success: the response omits the data
+		// field entirely, indistinguishable on the wire from "no data".
+		return resp
+	}
+	data, err := json.Marshal(result)
+	if err != nil {
+		resp.Error = fmt.Sprintf("marshal response for %q: %v", cmd.Type, err)
+		return resp
+	}
+	resp.Data = json.RawMessage(data)
 	return resp
 }

--- a/internal/agent/extcmd_test.go
+++ b/internal/agent/extcmd_test.go
@@ -4,8 +4,15 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"math"
+	"net/http"
+	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
+	"time"
+
+	"github.com/coder/websocket"
 
 	"github.com/dbtrail/dbtrail/ext"
 )
@@ -18,7 +25,7 @@ import (
 // TestDispatchExtensionCommand pins the registry consultation in dispatch's
 // default branch: a command type with no builtin case routes to the
 // registered handler, which receives the channel deps and the raw payload
-// and whose return value lands in the response data.
+// and whose return value lands — pre-marshalled — in the response data.
 func TestDispatchExtensionCommand(t *testing.T) {
 	ext.RegisterAgentCommand("ext_test_ping", func(_ context.Context, deps ext.AgentDeps, payload json.RawMessage) (any, error) {
 		var req struct {
@@ -40,11 +47,17 @@ func TestDispatchExtensionCommand(t *testing.T) {
 	if resp.Error != "" {
 		t.Fatalf("unexpected error: %s", resp.Error)
 	}
-	got, ok := resp.Data.(map[string]any)
+	// The result is pre-marshalled at dispatch time (so writeJSON can never
+	// fail on handler output): Data carries the raw JSON bytes.
+	raw, ok := resp.Data.(json.RawMessage)
 	if !ok {
-		t.Fatalf("resp.Data = %T, want map", resp.Data)
+		t.Fatalf("resp.Data = %T, want json.RawMessage", resp.Data)
 	}
-	if got["n"] != 42 || got["source_host"] != "h:3306" {
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal resp.Data: %v", err)
+	}
+	if got["n"] != float64(42) || got["source_host"] != "h:3306" {
 		t.Errorf("resp.Data = %v, want n=42 source_host=h:3306", got)
 	}
 }
@@ -58,6 +71,75 @@ func TestDispatchExtensionCommandError(t *testing.T) {
 		Command{ID: "x2", Type: "ext_test_boom"}, ext.AgentDeps{})
 	if resp.Error != "boom" || resp.Data != nil {
 		t.Fatalf("resp = %+v, want Error=boom with nil Data", resp)
+	}
+}
+
+// TestDispatchExtensionCommandPanic pins the panic containment: a registered
+// handler that panics yields a per-command error response and a normal
+// return — the process (and with it the in-memory BYOS buffer) survives.
+func TestDispatchExtensionCommandPanic(t *testing.T) {
+	ext.RegisterAgentCommand("ext_test_panic", func(context.Context, ext.AgentDeps, json.RawMessage) (any, error) {
+		panic("handler exploded")
+	})
+
+	resp := dispatch(context.Background(), &DefaultHandler{},
+		Command{ID: "x5", Type: "ext_test_panic"}, ext.AgentDeps{})
+
+	if resp.ID != "x5" || resp.Type != "ext_test_panic" {
+		t.Fatalf("response envelope mangled: %+v", resp)
+	}
+	if !strings.Contains(resp.Error, `command handler for "ext_test_panic" panicked`) ||
+		!strings.Contains(resp.Error, "handler exploded") {
+		t.Errorf("error = %q, want the panic-containment message with the panic value", resp.Error)
+	}
+	if resp.Data != nil {
+		t.Errorf("resp.Data = %v, want nil after a panic", resp.Data)
+	}
+}
+
+// TestDispatchExtensionCommandUnmarshalableResult pins the response
+// pre-marshaling: a handler returning a value json.Marshal rejects (NaN here)
+// yields a per-command error — and the resulting Response envelope itself
+// still marshals cleanly, so writeJSON cannot fail and tear the connection
+// down into a reconnect death spiral.
+func TestDispatchExtensionCommandUnmarshalableResult(t *testing.T) {
+	ext.RegisterAgentCommand("ext_test_nan", func(context.Context, ext.AgentDeps, json.RawMessage) (any, error) {
+		return map[string]any{"bad": math.NaN()}, nil
+	})
+
+	resp := dispatch(context.Background(), &DefaultHandler{},
+		Command{ID: "x6", Type: "ext_test_nan"}, ext.AgentDeps{})
+
+	if !strings.Contains(resp.Error, `marshal response for "ext_test_nan"`) {
+		t.Errorf("error = %q, want the marshal-response error", resp.Error)
+	}
+	if resp.Data != nil {
+		t.Errorf("resp.Data = %v, want nil when the result cannot be marshalled", resp.Data)
+	}
+	if _, err := json.Marshal(resp); err != nil {
+		t.Errorf("Response envelope no longer marshals — writeJSON would fail: %v", err)
+	}
+}
+
+// TestDispatchExtensionCommandNilResult pins the (nil, nil) empty-success
+// contract: no error, and the wire response omits the data field entirely.
+func TestDispatchExtensionCommandNilResult(t *testing.T) {
+	ext.RegisterAgentCommand("ext_test_nilok", func(context.Context, ext.AgentDeps, json.RawMessage) (any, error) {
+		return nil, nil
+	})
+
+	resp := dispatch(context.Background(), &DefaultHandler{},
+		Command{ID: "x7", Type: "ext_test_nilok"}, ext.AgentDeps{})
+
+	if resp.Error != "" || resp.Data != nil {
+		t.Fatalf("resp = %+v, want empty success with nil Data", resp)
+	}
+	wire, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal envelope: %v", err)
+	}
+	if strings.Contains(string(wire), `"data"`) {
+		t.Errorf("wire response = %s, want the data field omitted on empty success", wire)
 	}
 }
 
@@ -88,5 +170,96 @@ func TestDispatchBuiltinWinsOverRegistry(t *testing.T) {
 	}
 	if !strings.Contains(resp.Error, "no data sources configured") {
 		t.Errorf("error = %q, want the builtin no-data-sources error", resp.Error)
+	}
+}
+
+// TestChannel_extCommandRoundTripDeps drives a registered extension command
+// through the REAL listenLoop over an in-process WebSocket (the same harness
+// as TestChannel_commandRoundTrip) and asserts the handler received the
+// Channel's populated ExtDeps — pinning the deps plumbing so a regression to
+// `dispatch(..., ext.AgentDeps{})` fails loudly.
+func TestChannel_extCommandRoundTripDeps(t *testing.T) {
+	ext.RegisterAgentCommand("ext_test_ws_deps", func(_ context.Context, deps ext.AgentDeps, _ json.RawMessage) (any, error) {
+		return deps.SourceDSN + "|" + deps.SourceHost, nil
+	})
+
+	var received Response
+	var mu sync.Mutex
+	done := make(chan struct{})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Logf("accept error: %v", err)
+			return
+		}
+		defer conn.CloseNow()
+
+		ctx := r.Context()
+
+		// Read and discard the initial heartbeat.
+		if _, _, err := conn.Read(ctx); err != nil {
+			t.Logf("read heartbeat error: %v", err)
+			return
+		}
+
+		// Send the extension command.
+		cmdBytes, _ := json.Marshal(Command{ID: "ext-ws-1", Type: "ext_test_ws_deps", Data: json.RawMessage(`{}`)})
+		if err := conn.Write(ctx, websocket.MessageText, cmdBytes); err != nil {
+			t.Logf("write error: %v", err)
+			return
+		}
+
+		// Read the response.
+		_, respBytes, err := conn.Read(ctx)
+		if err != nil {
+			t.Logf("read response error: %v", err)
+			return
+		}
+
+		mu.Lock()
+		json.Unmarshal(respBytes, &received)
+		mu.Unlock()
+
+		conn.Close(websocket.StatusNormalClosure, "done")
+		close(done)
+	}))
+	defer srv.Close()
+
+	cfg := ChannelConfig{
+		Endpoint:          "ws" + strings.TrimPrefix(srv.URL, "http"),
+		APIKey:            "test-key",
+		Version:           "test",
+		HeartbeatInterval: 10 * time.Second,
+		MaxReconnectDelay: 100 * time.Millisecond,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	go func() {
+		ch := NewChannel(cfg, &stubHandler{}, nil, nil)
+		ch.ExtDeps = ext.AgentDeps{SourceDSN: "user:pass@tcp(src:3306)/db", SourceHost: "src:3306"}
+		ch.Run(ctx)
+	}()
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for ext command round-trip")
+	}
+
+	cancel()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if received.ID != "ext-ws-1" {
+		t.Errorf("response ID = %q, want %q", received.ID, "ext-ws-1")
+	}
+	if received.Error != "" {
+		t.Errorf("unexpected error: %s", received.Error)
+	}
+	if received.Data != "user:pass@tcp(src:3306)/db|src:3306" {
+		t.Errorf("response Data = %v, want the ExtDeps echo — the Channel's deps did not reach the handler", received.Data)
 	}
 }

--- a/internal/agent/extcmd_test.go
+++ b/internal/agent/extcmd_test.go
@@ -1,0 +1,92 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/ext"
+)
+
+// The ext agent-command registry has no unregister API (startup-only
+// contract), so the command types registered by these tests are unique to
+// this file — a leftover registration cannot collide with any other test's
+// dispatch.
+
+// TestDispatchExtensionCommand pins the registry consultation in dispatch's
+// default branch: a command type with no builtin case routes to the
+// registered handler, which receives the channel deps and the raw payload
+// and whose return value lands in the response data.
+func TestDispatchExtensionCommand(t *testing.T) {
+	ext.RegisterAgentCommand("ext_test_ping", func(_ context.Context, deps ext.AgentDeps, payload json.RawMessage) (any, error) {
+		var req struct {
+			N int `json:"n"`
+		}
+		if err := json.Unmarshal(payload, &req); err != nil {
+			return nil, err
+		}
+		return map[string]any{"n": req.N + 1, "source_host": deps.SourceHost}, nil
+	})
+
+	deps := ext.AgentDeps{SourceDSN: "user:pass@tcp(h:3306)/db", SourceHost: "h:3306"}
+	resp := dispatch(context.Background(), &DefaultHandler{},
+		Command{ID: "x1", Type: "ext_test_ping", Data: json.RawMessage(`{"n":41}`)}, deps)
+
+	if resp.ID != "x1" || resp.Type != "ext_test_ping" {
+		t.Fatalf("response envelope mangled: %+v", resp)
+	}
+	if resp.Error != "" {
+		t.Fatalf("unexpected error: %s", resp.Error)
+	}
+	got, ok := resp.Data.(map[string]any)
+	if !ok {
+		t.Fatalf("resp.Data = %T, want map", resp.Data)
+	}
+	if got["n"] != 42 || got["source_host"] != "h:3306" {
+		t.Errorf("resp.Data = %v, want n=42 source_host=h:3306", got)
+	}
+}
+
+func TestDispatchExtensionCommandError(t *testing.T) {
+	ext.RegisterAgentCommand("ext_test_boom", func(context.Context, ext.AgentDeps, json.RawMessage) (any, error) {
+		return nil, errors.New("boom")
+	})
+
+	resp := dispatch(context.Background(), &DefaultHandler{},
+		Command{ID: "x2", Type: "ext_test_boom"}, ext.AgentDeps{})
+	if resp.Error != "boom" || resp.Data != nil {
+		t.Fatalf("resp = %+v, want Error=boom with nil Data", resp)
+	}
+}
+
+// TestDispatchUnregisteredTypeStillUnknown pins the OSS default: with nothing
+// registered for the type, dispatch keeps failing exactly as before.
+func TestDispatchUnregisteredTypeStillUnknown(t *testing.T) {
+	resp := dispatch(context.Background(), &DefaultHandler{},
+		Command{ID: "x3", Type: "ext_test_unregistered"}, ext.AgentDeps{})
+	if !strings.Contains(resp.Error, "unknown command type") {
+		t.Fatalf("error = %q, want unknown command type", resp.Error)
+	}
+}
+
+// TestDispatchBuiltinWinsOverRegistry pins the precedence contract: the
+// registry is consulted only in the default branch, so registering a builtin
+// type can never shadow the builtin handler.
+func TestDispatchBuiltinWinsOverRegistry(t *testing.T) {
+	ext.RegisterAgentCommand("resolve_pk", func(context.Context, ext.AgentDeps, json.RawMessage) (any, error) {
+		return "ext-shadowed", nil
+	})
+
+	// A DefaultHandler with no data sources: the builtin resolve_pk path
+	// errors, proving the registry handler above never ran.
+	resp := dispatch(context.Background(), &DefaultHandler{},
+		Command{ID: "x4", Type: "resolve_pk", Data: json.RawMessage(`{"items":[]}`)}, ext.AgentDeps{})
+	if resp.Data == "ext-shadowed" {
+		t.Fatal("registry handler shadowed the builtin resolve_pk case")
+	}
+	if !strings.Contains(resp.Error, "no data sources configured") {
+		t.Errorf("error = %q, want the builtin no-data-sources error", resp.Error)
+	}
+}

--- a/internal/agent/forensics_commands_integration_test.go
+++ b/internal/agent/forensics_commands_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/dbtrail/dbtrail/ext"
 	"github.com/dbtrail/dbtrail/internal/config"
 	"github.com/dbtrail/dbtrail/internal/forensics"
 	"github.com/dbtrail/dbtrail/internal/testutil"
@@ -36,7 +37,7 @@ func TestIntegrationDispatch_forensicsCapabilities(t *testing.T) {
 	h := integrationForensicsHandler(t)
 	ctx := t.Context()
 
-	resp := dispatch(ctx, h, Command{ID: "int-caps", Type: "forensics_capabilities"})
+	resp := dispatch(ctx, h, Command{ID: "int-caps", Type: "forensics_capabilities"}, ext.AgentDeps{})
 	if resp.Error != "" {
 		t.Fatalf("dispatch error: %s", resp.Error)
 	}
@@ -98,7 +99,7 @@ func TestIntegrationDispatch_forensicsEnrich(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal payload: %v", err)
 	}
-	resp := dispatch(ctx, h, Command{ID: "int-enrich", Type: "forensics_enrich", Data: payload})
+	resp := dispatch(ctx, h, Command{ID: "int-enrich", Type: "forensics_enrich", Data: payload}, ext.AgentDeps{})
 	if resp.Error != "" {
 		t.Fatalf("dispatch error: %s", resp.Error)
 	}
@@ -140,7 +141,7 @@ func TestIntegrationDispatch_forensicsEnrich(t *testing.T) {
 func TestIntegrationDispatch_forensicsUsers(t *testing.T) {
 	h := integrationForensicsHandler(t)
 
-	resp := dispatch(t.Context(), h, Command{ID: "int-users", Type: "forensics_users"})
+	resp := dispatch(t.Context(), h, Command{ID: "int-users", Type: "forensics_users"}, ext.AgentDeps{})
 	if resp.Error != "" {
 		t.Fatalf("dispatch error: %s", resp.Error)
 	}

--- a/internal/agent/forensics_commands_test.go
+++ b/internal/agent/forensics_commands_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/dbtrail/dbtrail/ext"
 	"github.com/dbtrail/dbtrail/internal/forensics"
 )
 
@@ -36,7 +37,7 @@ func TestDispatch_forensicsCapabilities(t *testing.T) {
 		},
 	}
 	// No payload beyond the envelope — Data intentionally absent.
-	resp := dispatch(context.Background(), h, Command{ID: "c1", Type: "forensics_capabilities"})
+	resp := dispatch(context.Background(), h, Command{ID: "c1", Type: "forensics_capabilities"}, ext.AgentDeps{})
 
 	if resp.Error != "" {
 		t.Fatalf("unexpected error: %s", resp.Error)
@@ -79,7 +80,7 @@ func TestDispatch_forensicsEnrich(t *testing.T) {
 	}
 	// SaaS wire shape: {"thread_ids": [...]}.
 	cmd := Command{ID: "e1", Type: "forensics_enrich", Data: json.RawMessage(`{"thread_ids":[42,7]}`)}
-	resp := dispatch(context.Background(), h, cmd)
+	resp := dispatch(context.Background(), h, cmd, ext.AgentDeps{})
 
 	if resp.Error != "" {
 		t.Fatalf("unexpected error: %s", resp.Error)
@@ -124,7 +125,7 @@ func TestDispatch_forensicsActivity(t *testing.T) {
 	raw := `{"query_type":"user_activity","user":"app","host":"10.0.0.5",` +
 		`"schema":"shop","since":"2026-07-01T00:00:00","until":"2026-07-02 00:00:00",` +
 		`"limit":25,"order":"ASC"}`
-	resp := dispatch(context.Background(), h, Command{ID: "a1", Type: "forensics_activity", Data: json.RawMessage(raw)})
+	resp := dispatch(context.Background(), h, Command{ID: "a1", Type: "forensics_activity", Data: json.RawMessage(raw)}, ext.AgentDeps{})
 
 	if resp.Error != "" {
 		t.Fatalf("unexpected error: %s", resp.Error)
@@ -147,7 +148,7 @@ func TestDispatch_forensicsUsers(t *testing.T) {
 			return ForensicsUsersResult{Users: []string{"app", "root"}}, nil
 		},
 	}
-	resp := dispatch(context.Background(), h, Command{ID: "u1", Type: "forensics_users"})
+	resp := dispatch(context.Background(), h, Command{ID: "u1", Type: "forensics_users"}, ext.AgentDeps{})
 
 	if resp.Error != "" {
 		t.Fatalf("unexpected error: %s", resp.Error)
@@ -188,7 +189,7 @@ func TestDispatch_forensicsAuditLog(t *testing.T) {
 	// which is OSS-only tuning.
 	raw := `{"since":"2026-07-01T00:00:00Z","user":"app","event_type":"query",` +
 		`"limit":100,"offset":10,"include_rotated":true,"tail_lines":5000}`
-	resp := dispatch(context.Background(), h, Command{ID: "l1", Type: "forensics_audit_log", Data: json.RawMessage(raw)})
+	resp := dispatch(context.Background(), h, Command{ID: "l1", Type: "forensics_audit_log", Data: json.RawMessage(raw)}, ext.AgentDeps{})
 
 	if resp.Error != "" {
 		t.Fatalf("unexpected error: %s", resp.Error)
@@ -229,7 +230,7 @@ func TestDispatch_forensicsMalformedPayloads(t *testing.T) {
 	h := &stubHandler{}
 	for _, cmdType := range []string{"forensics_enrich", "forensics_activity", "forensics_audit_log"} {
 		t.Run(cmdType, func(t *testing.T) {
-			resp := dispatch(context.Background(), h, Command{ID: "m1", Type: cmdType, Data: json.RawMessage(`{invalid`)})
+			resp := dispatch(context.Background(), h, Command{ID: "m1", Type: cmdType, Data: json.RawMessage(`{invalid`)}, ext.AgentDeps{})
 			if !strings.Contains(resp.Error, "invalid "+cmdType+" payload") {
 				t.Errorf("error = %q, want 'invalid %s payload'", resp.Error, cmdType)
 			}
@@ -249,7 +250,7 @@ func TestDispatch_forensicsGateClosed(t *testing.T) {
 		"forensics_users", "forensics_audit_log",
 	} {
 		t.Run(cmdType, func(t *testing.T) {
-			resp := dispatch(context.Background(), h, Command{ID: "g1", Type: cmdType, Data: json.RawMessage(`{}`)})
+			resp := dispatch(context.Background(), h, Command{ID: "g1", Type: cmdType, Data: json.RawMessage(`{}`)}, ext.AgentDeps{})
 			if resp.Error != "forensics disabled in this build" {
 				t.Errorf("error = %q, want 'forensics disabled in this build'", resp.Error)
 			}
@@ -276,7 +277,7 @@ func TestDispatch_forensicsGateClosed_legacyQueryUngated(t *testing.T) {
 			return &ForensicsResult{}, nil
 		},
 	}
-	resp := dispatch(context.Background(), h, Command{ID: "g2", Type: "forensics_query", Data: json.RawMessage(`{"query":"recent_queries"}`)})
+	resp := dispatch(context.Background(), h, Command{ID: "g2", Type: "forensics_query", Data: json.RawMessage(`{"query":"recent_queries"}`)}, ext.AgentDeps{})
 	if resp.Error != "" {
 		t.Fatalf("legacy forensics_query must not be gated, got error: %s", resp.Error)
 	}
@@ -294,7 +295,7 @@ func TestDispatch_forensicsGateClosed_unknownTypeFallthrough(t *testing.T) {
 		if disable {
 			withForensicsDisabled(t)
 		}
-		resp := dispatch(context.Background(), h, Command{ID: "g3", Type: "forensics_nope", Data: json.RawMessage(`{}`)})
+		resp := dispatch(context.Background(), h, Command{ID: "g3", Type: "forensics_nope", Data: json.RawMessage(`{}`)}, ext.AgentDeps{})
 		if !strings.Contains(resp.Error, "unknown command type") {
 			t.Errorf("gate disabled=%v: error = %q, want 'unknown command type'", disable, resp.Error)
 		}


### PR DESCRIPTION
Adds the extension seams an embedding distribution — a build that imports `cliapp`/`ext` and wraps the core — uses to inject behavior without patching the core. **Every seam defaults to a no-op: the stock binary's behavior is unchanged.** Follows the existing seam convention (`ext.SetAuditSink`, #730): package-level registration, set once from `main()` before command dispatch, startup-only concurrency contract stated on every setter.

### 1. `indexquery` — exported read-plane facade (new top-level package)

Read-only programmatic access to the index (live MySQL partitions + Parquet archives merged) for tooling and embedding distributions:

- Type aliases to the internal query types so external modules can construct them: `Options`, `ResultRow`, `Engine`, `QueryPlan`, `FetchMergedOptions`, `ArchiveFetcher`, `GapError`, `SourceEmptyError`, `Tuning`.
- One-line wrappers: `New`, `FetchMerged`, `FormatGapWarning`, `Connect`, `ParseSourceDSN`, `EnsureSchema`, `WrapSchemaMigrationErr`, `AddDuckDBTuningFlags`, `DuckDBTuningFromFlags`, `TunedArchiveFetcher`, `OutputJSON`.
- The index schema stays owned by the core — `EnsureSchema` is the only schema-mutating entry point exposed.

### 2. `cliapp.AddCommands(cmds ...*cobra.Command)`

Registers additional top-level commands on the root command; call from `main()` before `cliapp.Main`.

### 3. `ext.RegisterSourceJob` / `ext.RunSourceJobs`

Daemon-lifecycle jobs scoped to a capture source (`SourceJobInfo{SourceDSN, IndexDSN, Flavor}`). Wired at `up`'s phase-3 start next to the rotation loop; jobs are secondary and must never be fatal to the stream.

### 4. `ext.RegisterDoctorCheck` / `ext.RunDoctorChecks`

Extra preflight checks appended to the report on both surfaces — `bintrail doctor` and `bintrail up` phase 1 — with the same FAIL-blocks-boot semantics as built-in checks. Status strings must match `doctor.CheckStatus` (`pass`/`fail`/`warn`/`skip`); an unknown status degrades to a counted WARN with a note instead of an uncounted malformed entry.

### 5. `ext.RegisterAgentCommand` / `ext.LookupAgentCommand`

Registry for agent WebSocket command types. `dispatch` consults it only when no builtin case matches — builtin command types always win, and with nothing registered an unknown type fails exactly as before. Duplicate registration is last-wins (documented). The agent runner builds the handler deps (`ext.AgentDeps{IndexDB, SourceDB, SourceDSN, SourceHost}`) once and hands them to the dispatch loop via the new `Channel.ExtDeps` field; payload unmarshalling is the handler's job (raw `json.RawMessage` in, `any` out into the response data, error into the response error).

### Tests

Unit tests per seam: registration→effect and default→no-op (save/restore of the package registries, `ext_test.go` style); dispatch-level end-to-end routing for the agent registry including builtin-precedence and unregistered-type pins; compile-level signature pins plus no-DB-work paths for `indexquery`.

### Verification

- `go build ./...`
- `go test ./... -count=1` (unit tier, all green)
- `go vet -tags integration ./...` (clean — integration test call sites updated for the extended `dispatch` signature)
- `gofmt -l` clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)