### PR TITLE
consoleapp: export the console entrypoint for embedding builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
               - '.github/workflows/ci.yml'
             console:
               - 'internal/console/**'
+              - 'consoleapp/**'
               - 'cmd/bintrail-console/**'
 
   unit:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Exported `consoleapp` package**: the web console's command layer (root command plus the `serve`/`watch`/`user` subcommands) moved from `cmd/bintrail-console` into the importable top-level `consoleapp` package, with `consoleapp.Main(version, commitSHA, buildDate)` as the entrypoint — the console sibling of `cliapp.Main`, for embedding distributions that import the OSS core and wrap it. `cmd/bintrail-console` is now a thin wrapper (the `-ldflags`-injected `main.*` build vars plus `os.Exit(consoleapp.Main(...))`), pinned by a guard test; binary behavior, flags, and the version string are unchanged.
+
 ## [0.34.0] - 2026-07-16
 
 ### Added

--- a/cmd/bintrail-console/main.go
+++ b/cmd/bintrail-console/main.go
@@ -12,15 +12,17 @@
 // ~/.config/bintrail/config.env) file is loaded on startup and the
 // BINTRAIL_INDEX_DSN / BINTRAIL_CONSOLE_* env vars are honored with
 // flag > env > default precedence.
+//
+// All command behavior lives in the importable consoleapp package; this
+// main exists only to receive the -ldflags-injected build metadata (which
+// must target main.* so the Makefile and .goreleaser.yaml ldflags keep
+// working unchanged) and to own the process exit.
 package main
 
 import (
-	"fmt"
 	"os"
 
-	"github.com/spf13/cobra"
-
-	"github.com/dbtrail/dbtrail/internal/observe"
+	"github.com/dbtrail/dbtrail/consoleapp"
 )
 
 // Build-time variables injected via -ldflags. The names are deliberately the
@@ -32,39 +34,6 @@ var (
 	BuildDate = "unknown"
 )
 
-var (
-	logLevel  string
-	logFormat string
-)
-
-var rootCmd = &cobra.Command{
-	Use:   "bintrail-console",
-	Short: "Read-only web console over the Bintrail binlog index",
-	Long: `bintrail-console serves a local, read-only web UI over the binlog index:
-browse indexed row events with full before/after diffs, generate recovery
-(undo) SQL, and run point-in-time reconstruct when baselines are configured.
-
-It is the web console's own binary (formerly the core CLI's "console"
-command), shipped separately so the core bintrail CLI carries no web UI. The
-console NEVER executes SQL; recover produces a script you review and apply
-yourself.`,
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		observe.Setup(os.Stderr, logFormat, logLevel)
-		return nil
-	},
-	SilenceErrors: true, // we handle error output ourselves in main()
-	SilenceUsage:  true, // don't print usage/help on errors — users can use --help
-}
-
-func init() {
-	rootCmd.Version = fmt.Sprintf("%s (commit %s, built %s)", Version, CommitSHA, BuildDate)
-	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "Log level: debug, info, warn, error")
-	rootCmd.PersistentFlags().StringVar(&logFormat, "log-format", "text", "Log format: text or json")
-}
-
 func main() {
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
+	os.Exit(consoleapp.Main(Version, CommitSHA, BuildDate))
 }

--- a/consoleapp/baseline.go
+++ b/consoleapp/baseline.go
@@ -1,4 +1,4 @@
-package main
+package consoleapp
 
 import (
 	"context"

--- a/consoleapp/baseline_pg_test.go
+++ b/consoleapp/baseline_pg_test.go
@@ -1,4 +1,4 @@
-package main
+package consoleapp
 
 import (
 	"strings"

--- a/consoleapp/baseline_test.go
+++ b/consoleapp/baseline_test.go
@@ -1,4 +1,4 @@
-package main
+package consoleapp
 
 import (
 	"context"

--- a/consoleapp/env.go
+++ b/consoleapp/env.go
@@ -1,4 +1,4 @@
-package main
+package consoleapp
 
 import (
 	"bufio"

--- a/consoleapp/flashback.go
+++ b/consoleapp/flashback.go
@@ -1,4 +1,4 @@
-package main
+package consoleapp
 
 import (
 	"context"
@@ -18,7 +18,7 @@ import (
 )
 
 // This file is the MySQL-protocol serving layer for the embedded time-travel
-// port (issue #996). It lives in the binary — NOT in internal/console — because
+// port (issue #996). It lives in consoleapp — NOT in internal/console — because
 // it links go-mysql and internal/shim, which the read-layer guard (#528,
 // TestReadLayerDoesNotLinkGoMySQL) bars from internal/console. It consumes the
 // go-mysql-free seam console.Server exposes (Token, ResolveFlashback).

--- a/consoleapp/flashback_integration_test.go
+++ b/consoleapp/flashback_integration_test.go
@@ -1,6 +1,6 @@
 //go:build integration
 
-package main
+package consoleapp
 
 import (
 	"context"

--- a/consoleapp/flashback_test.go
+++ b/consoleapp/flashback_test.go
@@ -1,4 +1,4 @@
-package main
+package consoleapp
 
 import (
 	"context"

--- a/consoleapp/monitor.go
+++ b/consoleapp/monitor.go
@@ -1,4 +1,4 @@
-package main
+package consoleapp
 
 import (
 	"context"

--- a/consoleapp/monitor_integration_test.go
+++ b/consoleapp/monitor_integration_test.go
@@ -1,6 +1,6 @@
 //go:build integration
 
-package main
+package consoleapp
 
 import (
 	"context"

--- a/consoleapp/monitor_pg_test.go
+++ b/consoleapp/monitor_pg_test.go
@@ -1,4 +1,4 @@
-package main
+package consoleapp
 
 import (
 	"strings"

--- a/consoleapp/monitor_replica.go
+++ b/consoleapp/monitor_replica.go
@@ -1,4 +1,4 @@
-package main
+package consoleapp
 
 import (
 	"context"

--- a/consoleapp/monitor_test.go
+++ b/consoleapp/monitor_test.go
@@ -1,4 +1,4 @@
-package main
+package consoleapp
 
 import (
 	"context"

--- a/consoleapp/root.go
+++ b/consoleapp/root.go
@@ -1,0 +1,71 @@
+// Package consoleapp implements the bintrail-console command layer — the
+// web console's cobra root command and its subcommands (serve, watch,
+// user). cmd/bintrail-console is a thin wrapper around it; embedding
+// distributions — builds that import the OSS core and wrap it — call
+// Main from their own main() the same way, passing their
+// -ldflags-injected build metadata.
+//
+// Same startup-only contract as cliapp: package-level state (the root
+// command, subcommand registration via init()) is assembled before
+// dispatch and is not safe for concurrent use with command execution.
+package consoleapp
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dbtrail/dbtrail/internal/observe"
+)
+
+// Build metadata, set by Main from the caller's -ldflags-injected values.
+var (
+	Version   = "dev"
+	CommitSHA = "none"
+	BuildDate = "unknown"
+)
+
+var (
+	logLevel  string
+	logFormat string
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "bintrail-console",
+	Short: "Read-only web console over the Bintrail binlog index",
+	Long: `bintrail-console serves a local, read-only web UI over the binlog index:
+browse indexed row events with full before/after diffs, generate recovery
+(undo) SQL, and run point-in-time reconstruct when baselines are configured.
+
+It is the web console's own binary (formerly the core CLI's "console"
+command), shipped separately so the core bintrail CLI carries no web UI. The
+console NEVER executes SQL; recover produces a script you review and apply
+yourself.`,
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		observe.Setup(os.Stderr, logFormat, logLevel)
+		return nil
+	},
+	SilenceErrors: true, // we handle error output ourselves in Main()
+	SilenceUsage:  true, // don't print usage/help on errors — users can use --help
+}
+
+func init() {
+	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "Log level: debug, info, warn, error")
+	rootCmd.PersistentFlags().StringVar(&logFormat, "log-format", "text", "Log format: text or json")
+}
+
+// Main configures build metadata and runs the bintrail-console root command,
+// returning the process exit code. Callers (cmd/bintrail-console, and
+// external distributions embedding the console) are expected to pass their
+// -ldflags-injected version values and os.Exit with the result.
+func Main(version, commitSHA, buildDate string) int {
+	Version, CommitSHA, BuildDate = version, commitSHA, buildDate
+	rootCmd.Version = fmt.Sprintf("%s (commit %s, built %s)", Version, CommitSHA, BuildDate)
+
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	return 0
+}

--- a/consoleapp/serve.go
+++ b/consoleapp/serve.go
@@ -1,4 +1,4 @@
-package main
+package consoleapp
 
 import (
 	"database/sql"

--- a/consoleapp/serve_test.go
+++ b/consoleapp/serve_test.go
@@ -1,4 +1,4 @@
-package main
+package consoleapp
 
 import (
 	"os"

--- a/consoleapp/thinwrapper_test.go
+++ b/consoleapp/thinwrapper_test.go
@@ -23,14 +23,27 @@ func TestConsoleBinaryIsThinWrapper(t *testing.T) {
 		t.Fatalf("go list -json: %v\n%s", err, out)
 	}
 	var pkg struct {
-		GoFiles []string
-		Imports []string
+		GoFiles        []string
+		CgoFiles       []string
+		IgnoredGoFiles []string
+		Imports        []string
 	}
 	if err := json.Unmarshal(out, &pkg); err != nil {
 		t.Fatalf("decoding go list -json output: %v", err)
 	}
 	if !slices.Equal(pkg.GoFiles, []string{"main.go"}) {
 		t.Errorf("cmd/bintrail-console compiles %v — the wrapper must stay exactly [main.go]; new command code belongs in consoleapp", pkg.GoFiles)
+	}
+	// GoFiles alone is blind to files the current build context excludes:
+	// go list reports cgo files under CgoFiles and build-constrained files
+	// (e.g. //go:build windows glue) under IgnoredGoFiles. Either would ship
+	// command logic in some build of the binary without ever appearing in
+	// GoFiles on the platform running this test.
+	if len(pkg.CgoFiles) != 0 {
+		t.Errorf("cmd/bintrail-console has cgo files %v — the wrapper must stay exactly [main.go]; new command code belongs in consoleapp", pkg.CgoFiles)
+	}
+	if len(pkg.IgnoredGoFiles) != 0 {
+		t.Errorf("cmd/bintrail-console has build-constrained files %v excluded on this platform — the wrapper must stay exactly [main.go] on every platform; new command code belongs in consoleapp", pkg.IgnoredGoFiles)
 	}
 	const seam = "github.com/dbtrail/dbtrail/consoleapp"
 	if !slices.Contains(pkg.Imports, seam) {

--- a/consoleapp/thinwrapper_test.go
+++ b/consoleapp/thinwrapper_test.go
@@ -1,0 +1,39 @@
+package consoleapp
+
+import (
+	"encoding/json"
+	"os/exec"
+	"slices"
+	"testing"
+)
+
+// TestConsoleBinaryIsThinWrapper is the export guard (the consoleapp sibling
+// of cliapp's TestCoreBinaryIsUIFree): cmd/bintrail-console must stay a thin
+// wrapper — exactly one Go file (main.go, holding only the -ldflags-injected
+// build vars and os.Exit) delegating to this package's Main. Command logic
+// creeping back into the cmd directory would put it out of reach of builds
+// that import consoleapp and wrap the OSS core.
+//
+// The module path is deliberate: `go test` runs with the package directory as
+// cwd, and the module path resolves identically from anywhere.
+func TestConsoleBinaryIsThinWrapper(t *testing.T) {
+	out, err := exec.Command("go", "list", "-json",
+		"github.com/dbtrail/dbtrail/cmd/bintrail-console").Output()
+	if err != nil {
+		t.Fatalf("go list -json: %v\n%s", err, out)
+	}
+	var pkg struct {
+		GoFiles []string
+		Imports []string
+	}
+	if err := json.Unmarshal(out, &pkg); err != nil {
+		t.Fatalf("decoding go list -json output: %v", err)
+	}
+	if !slices.Equal(pkg.GoFiles, []string{"main.go"}) {
+		t.Errorf("cmd/bintrail-console compiles %v — the wrapper must stay exactly [main.go]; new command code belongs in consoleapp", pkg.GoFiles)
+	}
+	const seam = "github.com/dbtrail/dbtrail/consoleapp"
+	if !slices.Contains(pkg.Imports, seam) {
+		t.Errorf("cmd/bintrail-console imports %v — it must delegate to %s", pkg.Imports, seam)
+	}
+}

--- a/consoleapp/user.go
+++ b/consoleapp/user.go
@@ -1,4 +1,4 @@
-package main
+package consoleapp
 
 import (
 	"bufio"

--- a/consoleapp/user_test.go
+++ b/consoleapp/user_test.go
@@ -1,4 +1,4 @@
-package main
+package consoleapp
 
 import (
 	"os"

--- a/consoleapp/verify.go
+++ b/consoleapp/verify.go
@@ -1,4 +1,4 @@
-package main
+package consoleapp
 
 import (
 	"bytes"

--- a/consoleapp/verify_test.go
+++ b/consoleapp/verify_test.go
@@ -1,4 +1,4 @@
-package main
+package consoleapp
 
 import (
 	"context"

--- a/consoleapp/watch.go
+++ b/consoleapp/watch.go
@@ -1,4 +1,4 @@
-package main
+package consoleapp
 
 import (
 	"context"

--- a/consoleapp/watch_test.go
+++ b/consoleapp/watch_test.go
@@ -1,4 +1,4 @@
-package main
+package consoleapp
 
 import (
 	"context"


### PR DESCRIPTION
## What

Moves the `bintrail-console` command layer out of `cmd/bintrail-console` (package `main`) into a new importable top-level **`consoleapp`** package — the console sibling of `cliapp`:

- **`consoleapp/root.go`**: the cobra root command, its persistent flags (`--log-level`/`--log-format`), and an exported `Main(version, commitSHA, buildDate string) int` that mirrors `cliapp.Main` — sets the build-metadata vars, formats `rootCmd.Version` identically to before, executes, prints the error to stderr itself, and returns the exit code. Same startup-only concurrency contract as `cliapp` / the `ext` seams.
- All command files moved via `git mv` (`serve.go`, `watch.go`, `monitor.go`, `monitor_replica.go`, `baseline.go`, `verify.go`, `flashback.go`, `user.go`, `env.go`) together with every `*_test.go`, including the `//go:build integration` ones. Subcommand `init()` registration on `rootCmd` is unchanged.
- **`cmd/bintrail-console/main.go`** is now a thin wrapper: the three `-ldflags`-injected build vars — names stay `main.Version`/`main.CommitSHA`/`main.BuildDate`, so the Makefile's `BINTRAIL_LDFLAGS` and the `.goreleaser.yaml` ldflags block keep working unchanged, as does the `./cmd/bintrail-console` build path — plus `os.Exit(consoleapp.Main(Version, CommitSHA, BuildDate))`.
- **Guard test** `consoleapp/thinwrapper_test.go` (`TestConsoleBinaryIsThinWrapper`, in the style of `cliapp`'s `TestCoreBinaryIsUIFree`): asserts via `go list -json` that `cmd/bintrail-console` compiles exactly one Go file (`main.go`) and imports `github.com/dbtrail/dbtrail/consoleapp`, pinning the thin-wrapper contract against regression.

## Why

Embedding distributions — builds that import `cliapp` and wrap the OSS core — could already wrap the core CLI (`cliapp.Main`) but not the console binary, whose behavior was locked inside `package main`. Exporting the entrypoint gives the console the same seam.

This is the **console slice of #943**; the mcp/pg entrypoints are left for a follow-up, so the issue stays open. Refs #943.

## Behavior-identical

`--version`, `--help`, and the unknown-command error path were verified **byte-for-byte identical** against a build of the unmodified tree; an ldflags-injected build prints `bintrail-console version 9.9.9-test (commit abc1234, built 2026-07-16)` as before. Forced edits beyond the package split (the complete list):

- `.github/workflows/ci.yml`: the `console` path filter gains `consoleapp/**` (console code no longer lives only under `cmd/bintrail-console/`).
- `consoleapp/flashback.go`: one file-local comment now says "It lives in consoleapp" instead of "in the binary".
- `consoleapp/root.go`: the `SilenceErrors` comment now says `Main()` instead of `main()`; `rootCmd.Version` formatting moved from `init()` to `Main` (same string, mirroring `cliapp`).

No logic edits otherwise.

## Test evidence

- `gofmt -l consoleapp cmd/bintrail-console` — clean
- `go build ./...` — OK
- `go test ./... -count=1` — 42 packages ok, 0 failures
- `go vet -tags integration ./...` — clean (integration-tagged files are never compiled by `go build`)
- `go test -tags integration ./consoleapp/ -count=1` — ok (Docker MySQL on 13306)
- `go run ./cmd/bintrail-console --version` / `--help` — diffed against the pre-change tree: identical (commands listed: `serve`, `watch`, `user`, `completion`, `help`)

Refs #943

🤖 Generated with [Claude Code](https://claude.com/claude-code)
