### PR TITLE
console: extension-view seam (ext.ConsoleViewProvider)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`ext.ConsoleView`: a pluggable extension-view seam for the web console.** Embedding distributions — builds that construct their console binary from the importable `consoleapp` package — can inject one additional console view (a nav item, a frontend ES module, and an authenticated data API) with `ext.SetConsoleView`, same startup-only contract as `ext.SetConsoleAuth`: call once from `main()` before `consoleapp.Main`. The view's static assets mount **unauthenticated** at `/ext/<id>/` (code always ships, like the console's own `app.js`); its data routes mount at `/api/ext/<id>/` behind the console's bearer-token middleware and are refused with 403 while an RBAC access-control profile is active (the console cannot guarantee a third-party handler honors table-deny / column-redaction rules). The data handler receives a per-request, per-selected-server index context — the selected server's index connection, the console's own cross-source (live + archive, gap-aware, RBAC-applied) fetch pipeline, and the selected registry entry's source DSN. `/api/capabilities` advertises the installed view (`extension_views`), and the SPA reveals a nav item + `ext-<id>` route that dynamically imports the module and calls its `render(mount, {apiBase, api})`. The provider id is constrained to `^[a-z0-9-]+$` and validated at mount time — an invalid id is skipped (logged, not mounted) rather than producing a broken route. The stock binary has no view: no nav item, `extension_views` omitted, and `/ext/*` / `/api/ext/*` are absent from the router.
+
+### Changed
+- The shared DuckDB resource-tuning helpers (`--ultrafast` / `--duckdb-threads` / `--duckdb-memory-limit` flag registration, resolution, and the archive-fetcher adapter) moved from `internal/cli` into a dedicated leaf package `internal/duckdbtuning`, so the public read-plane facade (`indexquery`) exposes them without importing the command layer. `indexquery`'s public API is unchanged (`AddDuckDBTuningFlags` / `DuckDBTuningFromFlags` / `TunedArchiveFetcher` remain, repointed); `internal/cli` keeps thin forwarders so its command layer is untouched.
+
 ## [0.35.0] - 2026-07-17
 
 ### Added

--- a/docs/console.md
+++ b/docs/console.md
@@ -527,6 +527,29 @@ first-run browser setup stays loopback-gated regardless. The standalone
 appears, and the provider routes (`/api/auth/ext/*`) simply require a normal
 credential like any other `/api` path.
 
+### Extension views
+
+Embedding distributions — builds that construct their console binary from the
+importable `consoleapp` package — may add one additional view to the console
+through the `ext.ConsoleView` seam: call `ext.SetConsoleView` once from
+`main()` before `consoleapp.Main`, like `ext.SetConsoleAuth`. An installed view
+contributes a nav item, a frontend module, and its own authenticated data API;
+the console reveals the nav item, routes to it, and loads the module in the same
+page (same origin, not an iframe).
+
+The view's static assets are served **unauthenticated** at `/ext/<id>/` (the
+code always ships, like the console's own `app.js`), while its data routes at
+`/api/ext/<id>/` require the same bearer credential as every other `/api` path
+and are **refused while an access-control profile is active** (the console can't
+guarantee a third-party handler honors table-deny / column-redaction rules, so
+it withholds the whole surface under a profile). Each data route reads the index
+of the server currently selected in the switcher, with the operator's profile
+applied.
+
+The standalone `bintrail-console` binary ships **no extension views**: no nav
+item appears, `/api/capabilities` advertises none, and `/ext/*` and
+`/api/ext/*` are absent from the router entirely.
+
 ## Security model
 
 The binary has no Supabase/RBAC backend to lean on, so the console defends

--- a/ext/consoleview.go
+++ b/ext/consoleview.go
@@ -1,0 +1,131 @@
+package ext
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"regexp"
+
+	"github.com/dbtrail/dbtrail/indexquery"
+)
+
+// ConsoleQueryContext is the per-request, per-selected-server index access a
+// ConsoleViewProvider's data handler receives. The console resolves it from the
+// request's selected server (the X-Bintrail-Server header, or the default) the
+// same way its own endpoints do, so an extension view reads exactly the index
+// the operator is looking at — never a different server.
+type ConsoleQueryContext struct {
+	// DB is the selected server's index connection. It is owned by the console
+	// (pooled and lazily opened per server); the provider must NOT close it, and
+	// must not assume it outlives the request.
+	DB *sql.DB
+	// Fetch runs the console's own cross-source read pipeline (live MySQL
+	// partitions plus Parquet archives, merged, sorted, gap-aware) already bound
+	// to the selected server. It applies whatever RBAC redaction the console was
+	// started with, so a provider that fetches through it inherits the operator's
+	// profile rather than having to reimplement redaction. Prefer it over
+	// querying DB directly whenever archive coverage or redaction matters.
+	Fetch func(ctx context.Context, opts indexquery.Options) ([]indexquery.ResultRow, *indexquery.QueryPlan, error)
+	// SourceDSN is the captured-source DSN of the selected registry entry, when
+	// one is configured — a provider that needs to reach the live source (not
+	// just the index) can use it. Empty for the boot/command-line entry and for a
+	// selection with no source configured; treat empty as "no source available",
+	// not an error.
+	SourceDSN string
+}
+
+// ConsoleQueryContextFunc resolves the ConsoleQueryContext for the selected
+// server behind a request. It mirrors the console's per-request bundle
+// resolution and returns the same errors: an unresolvable selection yields an
+// error whose message is already scrubbed of DSN secrets, safe to surface to
+// the client.
+type ConsoleQueryContextFunc func(r *http.Request) (ConsoleQueryContext, error)
+
+// ConsoleViewProvider injects one additional view into the web console: a nav
+// item, a capability entry, an authenticated data API, and a frontend module
+// that renders the view. It lets an embedding distribution — a build that
+// imports consoleapp and wraps the OSS core — add a console view the stock
+// binary does not ship, without forking the console.
+//
+// The console mounts a provider like this:
+//
+//   - Static assets at "/ext/<ID>/" — served UNAUTHENTICATED behind the host
+//     guard and security headers only, exactly like index.html and app.js. Code
+//     always ships; only DATA is gated. A browser must be able to load the
+//     module before it has authenticated.
+//   - Data routes at "/api/ext/<ID>/" — mounted behind the console's bearer-token
+//     middleware (so every data route inherits authentication) AND refused with
+//     403 before the provider's handler runs whenever an RBAC access-control
+//     profile is active (the console cannot guarantee a third-party handler
+//     honors table-deny / column-redaction rules, so it withholds the whole
+//     surface rather than risk a leak — the same posture recover-cascade takes).
+//   - A nav item labeled Label(), and a capability entry the SPA uses to reveal
+//     the nav item and route to the view.
+type ConsoleViewProvider interface {
+	// ID is a STABLE, lowercase, URL-safe key for this view. It is used three
+	// ways — as the capability key, as the "/ext/<ID>/" + "/api/ext/<ID>/" mount
+	// segment, and as the SPA route "ext-<ID>" — so it must match
+	// ^[a-z0-9-]+$ (see ValidConsoleViewID). It must not change across releases:
+	// the operator's bookmarks and the SPA route both key on it. A provider whose
+	// ID fails validation is skipped by the console (logged, not mounted) so a
+	// typo degrades to "no view" instead of a broken or injectable route.
+	ID() string
+	// Label is the human-readable nav text for the view.
+	Label() string
+	// Script is the URL of an ES module the SPA import()s and then calls
+	// render(mount, {apiBase, api}) on. It renders into the same document,
+	// same-origin — NOT an iframe (X-Frame-Options: DENY is global) — so the
+	// module runs with the console's own origin and shares its bearer credential
+	// via the api primitive the SPA passes in. Serve it from this provider's own
+	// StaticHandler subtree (e.g. "/ext/<ID>/view.js").
+	Script() string
+	// StaticHandler serves the view's frontend assets. The console mounts it at
+	// prefix ("/ext/<ID>/") UNAUTHENTICATED — it must expose only static,
+	// non-secret files (the module named by Script and whatever it loads). The
+	// handler sees requests whose path still carries prefix; strip it if needed.
+	StaticHandler(prefix string) http.Handler
+	// DataHandler serves the view's authenticated data routes. The console mounts
+	// it at prefix ("/api/ext/<ID>/") behind the bearer-token middleware and the
+	// RBAC guard described above. resolve yields the per-request, per-server
+	// ConsoleQueryContext; the handler calls it to read the index the operator
+	// has selected. The handler sees requests whose path still carries prefix.
+	DataHandler(prefix string, resolve ConsoleQueryContextFunc) http.Handler
+}
+
+// consoleViewIDRE constrains a provider ID to a lowercase, URL-safe token: the
+// ID flows into an HTTP path segment AND a DOM route/data-attribute, so an ID
+// with a slash, a space, or markup could produce a broken mount or an injected
+// route. Anchored, non-empty.
+var consoleViewIDRE = regexp.MustCompile(`^[a-z0-9-]+$`)
+
+// ValidConsoleViewID reports whether id is an acceptable ConsoleViewProvider ID
+// (matches ^[a-z0-9-]+$). The console calls it at mount time and skips a
+// provider that fails, rather than mounting a malformed route.
+func ValidConsoleViewID(id string) bool { return consoleViewIDRE.MatchString(id) }
+
+// consoleView is nil in the OSS build — the console ships no extension views.
+var consoleView ConsoleViewProvider
+
+// SetConsoleView installs the process-wide console extension-view provider.
+// Call once from main() before command dispatch, like SetConsoleAuth: the
+// console reads it when the server is constructed, so a later install is never
+// picked up. A bad ID is not rejected here — the console validates it at mount
+// time and skips the provider — so this setter cannot panic on a caller's typo.
+func SetConsoleView(p ConsoleViewProvider) {
+	consoleView = p
+}
+
+// ConsoleView returns the installed provider, or nil when none is installed
+// (the OSS build).
+func ConsoleView() ConsoleViewProvider {
+	return consoleView
+}
+
+// Content-Security-Policy invariant: the console sets NO Content-Security-Policy
+// header today (see internal/console securityHeaders — Referrer-Policy,
+// X-Content-Type-Options, and X-Frame-Options only). That is what lets the SPA
+// dynamically import() a provider's Script and lets the provider module fetch()
+// its own "/api/ext/<ID>/" data routes. If a CSP is ever added, its script-src
+// and connect-src MUST include 'self' (the modules and their data routes are
+// same-origin), or every extension view goes dark. Do not add a CSP without
+// accounting for this.

--- a/ext/consoleview_test.go
+++ b/ext/consoleview_test.go
@@ -1,0 +1,89 @@
+package ext
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/indexquery"
+)
+
+// Compile-time pin on the Fetch field's exact shape: an accidental signature
+// change (e.g. dropping the *QueryPlan return) fails here, not only in the
+// console wiring that constructs a ConsoleQueryContext.
+var _ = func(cqc ConsoleQueryContext) {
+	var _ func(context.Context, indexquery.Options) ([]indexquery.ResultRow, *indexquery.QueryPlan, error) = cqc.Fetch
+}
+
+type stubConsoleView struct{ id string }
+
+func (s stubConsoleView) ID() string                      { return s.id }
+func (stubConsoleView) Label() string                     { return "Example View" }
+func (stubConsoleView) Script() string                    { return "/ext/example/view.js" }
+func (stubConsoleView) StaticHandler(string) http.Handler { return http.NotFoundHandler() }
+func (stubConsoleView) DataHandler(string, ConsoleQueryContextFunc) http.Handler {
+	return http.NotFoundHandler()
+}
+
+func TestConsoleViewDefaultsNil(t *testing.T) {
+	if ConsoleView() != nil {
+		t.Fatal("ConsoleView() != nil by default — the OSS build must have no provider installed")
+	}
+}
+
+func TestSetConsoleViewRoundTrip(t *testing.T) {
+	SetConsoleView(stubConsoleView{id: "example"})
+	t.Cleanup(func() { SetConsoleView(nil) })
+
+	p := ConsoleView()
+	if p == nil {
+		t.Fatal("ConsoleView() = nil after SetConsoleView")
+	}
+	if got := p.ID(); got != "example" {
+		t.Errorf("ID() = %q, want %q", got, "example")
+	}
+	if got := p.Label(); got != "Example View" {
+		t.Errorf("Label() = %q, want %q", got, "Example View")
+	}
+
+	SetConsoleView(nil)
+	if ConsoleView() != nil {
+		t.Error("SetConsoleView(nil) did not clear the provider")
+	}
+}
+
+// SetConsoleView must never reject a bad ID — validation is the console's job at
+// mount time, so a provider with a typo'd ID installs cleanly here and the
+// console skips it (degrade, don't crash the daemon).
+func TestSetConsoleViewDoesNotValidateID(t *testing.T) {
+	SetConsoleView(stubConsoleView{id: "Bad ID/../x"})
+	t.Cleanup(func() { SetConsoleView(nil) })
+	if ConsoleView() == nil {
+		t.Fatal("SetConsoleView rejected a provider with an invalid ID; validation belongs to the console, not the setter")
+	}
+}
+
+func TestValidConsoleViewID(t *testing.T) {
+	valid := []string{"a", "example", "my-view", "view2", "0", "a-b-c-1"}
+	for _, id := range valid {
+		if !ValidConsoleViewID(id) {
+			t.Errorf("ValidConsoleViewID(%q) = false, want true", id)
+		}
+	}
+	invalid := []string{
+		"",         // empty
+		"Example",  // uppercase
+		"my_view",  // underscore
+		"my view",  // space
+		"a/b",      // slash — would break the URL mount
+		"a.b",      // dot
+		"ext-x\n",  // trailing newline
+		"héllo",    // non-ASCII
+		"<script>", // markup — would break the DOM route
+	}
+	for _, id := range invalid {
+		if ValidConsoleViewID(id) {
+			t.Errorf("ValidConsoleViewID(%q) = true, want false", id)
+		}
+	}
+}

--- a/indexquery/indexquery.go
+++ b/indexquery/indexquery.go
@@ -17,9 +17,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/dbtrail/dbtrail/internal/cli"
 	"github.com/dbtrail/dbtrail/internal/cliutil"
 	"github.com/dbtrail/dbtrail/internal/config"
+	"github.com/dbtrail/dbtrail/internal/duckdbtuning"
 	"github.com/dbtrail/dbtrail/internal/duckdbutil"
 	"github.com/dbtrail/dbtrail/internal/event"
 	"github.com/dbtrail/dbtrail/internal/indexer"
@@ -129,18 +129,18 @@ func WrapSchemaMigrationErr(err error) error { return indexer.WrapSchemaMigratio
 // AddDuckDBTuningFlags registers the shared DuckDB resource flags
 // (--ultrafast, --duckdb-threads, --duckdb-memory-limit) on an offline
 // read command.
-func AddDuckDBTuningFlags(cmd *cobra.Command) { cli.AddDuckDBTuningFlags(cmd) }
+func AddDuckDBTuningFlags(cmd *cobra.Command) { duckdbtuning.AddDuckDBTuningFlags(cmd) }
 
 // DuckDBTuningFromFlags resolves the effective DuckDB tuning for a command
 // carrying the flags registered by AddDuckDBTuningFlags. An invalid
 // --duckdb-memory-limit is a hard error.
 func DuckDBTuningFromFlags(cmd *cobra.Command) (Tuning, error) {
-	return cli.DuckDBTuningFromFlags(cmd)
+	return duckdbtuning.DuckDBTuningFromFlags(cmd)
 }
 
 // TunedArchiveFetcher adapts a DuckDB Tuning into an ArchiveFetcher suitable
 // for FetchMergedOptions.ArchiveFetcher.
-func TunedArchiveFetcher(t Tuning) ArchiveFetcher { return cli.TunedArchiveFetcher(t) }
+func TunedArchiveFetcher(t Tuning) ArchiveFetcher { return duckdbtuning.TunedArchiveFetcher(t) }
 
 // OutputJSON writes v to stdout as indented JSON.
 func OutputJSON(v any) error { return cliutil.OutputJSON(v) }

--- a/internal/cli/duckdbtuning.go
+++ b/internal/cli/duckdbtuning.go
@@ -1,108 +1,39 @@
 // Package cli holds command-layer building blocks intended to be shared across
-// bintrail binaries. It exists so a second binary (the planned PostgreSQL-native
+// bintrail binaries. It exists so a second binary (the PostgreSQL-native
 // bintrail-pg, #527/#529) can register the same source-agnostic read/recover
 // commands and their shared flag/helper infrastructure without duplicating the
 // command layer that lives in package main today.
-//
-// Today it holds only shared flag/helper infrastructure — this first file
-// extracts the DuckDB resource-tuning flags shared by the offline
-// query/recover/reconstruct commands (#510/#511), and cmd/bintrail is its only
-// importer. Subsequent slices of #529 move the env-binding helpers and the
-// source-agnostic commands themselves, at which point bintrail-pg becomes a
-// second importer.
 package cli
 
 import (
-	"context"
-	"fmt"
-	"regexp"
-	"strconv"
-	"strings"
-
 	"github.com/spf13/cobra"
 
+	"github.com/dbtrail/dbtrail/internal/duckdbtuning"
 	"github.com/dbtrail/dbtrail/internal/duckdbutil"
-	"github.com/dbtrail/dbtrail/internal/parquetquery"
 	"github.com/dbtrail/dbtrail/internal/query"
 )
 
-// duckDBMemoryLimitRE matches a number with a REQUIRED unit from the exact set
-// the linked DuckDB accepts as a memory_limit — decimal B/KB/MB/GB/TB or binary
-// KiB/MiB/GiB/TiB (verified empirically; DuckDB rejects PB/PiB, '%', and a
-// bare unitless number). Matching only what DuckDB honors is the whole point:
-// a value the regex accepts but DuckDB rejects (e.g. '80%') would pass this CLI
-// gate and then hit Apply's best-effort SET, which logs a WARN and silently
-// falls back to the default — the exact silent-fallback this validation exists
-// to prevent. A leading '-' has no match (DuckDB SILENTLY accepts a negative
-// limit as effectively unlimited), and a zero magnitude is rejected separately
-// in validateDuckDBMemoryLimit (DuckDB accepts e.g. '0GB' and uncaps).
-var duckDBMemoryLimitRE = regexp.MustCompile(`(?i)^(\d+(?:\.\d+)?)\s*(b|kb|mb|gb|tb|kib|mib|gib|tib)$`)
+// The DuckDB resource-tuning helpers used to live here. They now live in the
+// leaf package internal/duckdbtuning so the public read-plane facade
+// (indexquery) can expose them without importing this package — which imports
+// ext for the audit sink, and would otherwise close an
+// ext → indexquery → internal/cli → ext import cycle when an ext seam consumes
+// the facade. These thin forwarders keep the command layer and existing callers
+// (query/recover/reconstruct/verify and their tests) referencing the same
+// unqualified names.
 
-// validateDuckDBMemoryLimit rejects an operator-supplied --duckdb-memory-limit
-// that DuckDB would mishandle, turning a typo or a footgun into a clear CLI
-// error instead of a silent fall-back to the default (or a silent uncap).
-func validateDuckDBMemoryLimit(s string) error {
-	m := duckDBMemoryLimitRE.FindStringSubmatch(strings.TrimSpace(s))
-	if m == nil {
-		return fmt.Errorf("invalid --duckdb-memory-limit %q: expected a positive size with a unit, e.g. 16GB, 512MB, or 16GiB (units: B/KB/MB/GB/TB or KiB/MiB/GiB/TiB)", s)
-	}
-	if v, err := strconv.ParseFloat(m[1], 64); err != nil || v <= 0 {
-		return fmt.Errorf("invalid --duckdb-memory-limit %q: must be greater than zero (DuckDB treats a zero limit as unlimited)", s)
-	}
-	return nil
-}
+// AddDuckDBTuningFlags registers the shared --ultrafast / --duckdb-threads /
+// --duckdb-memory-limit flags. See duckdbtuning.AddDuckDBTuningFlags.
+func AddDuckDBTuningFlags(cmd *cobra.Command) { duckdbtuning.AddDuckDBTuningFlags(cmd) }
 
-// AddDuckDBTuningFlags registers the shared DuckDB resource flags on the
-// offline query/recover/reconstruct commands. They lift the conservative,
-// container-safe DuckDB budget (threads=2, memory_limit=4GB) that
-// parquetquery.Fetch applies by default — useful on a dedicated box with
-// plenty of RAM where the small-container defaults leave performance on the
-// table (#510). The long-lived shim/console daemons never register these, so
-// their archive reads keep the safe default (#509 non-goal).
-//
-// --duckdb-threads default -1 (not 0) so 0 stays a meaningful explicit value:
-// "let DuckDB pick one thread per core". --duckdb-memory-limit "" means unset.
-func AddDuckDBTuningFlags(cmd *cobra.Command) {
-	cmd.Flags().Bool("ultrafast", false,
-		"trade DuckDB memory-safety for speed: let DuckDB self-tune to the host (all cores, ~80% RAM) instead of the container-safe 2 threads / 4GB cap — for big boxes, not small containers")
-	cmd.Flags().Int("duckdb-threads", -1,
-		"override DuckDB thread count (0 = one per CPU core); -1 keeps the mode default")
-	cmd.Flags().String("duckdb-memory-limit", "",
-		"override DuckDB memory limit, e.g. 16GB (empty keeps the mode default)")
-}
-
-// DuckDBTuningFromFlags resolves the effective DuckDB tuning for a command.
-// Precedence: an explicit --duckdb-* flag wins over --ultrafast, which wins
-// over the conservative default. The granular flags let an operator tune to
-// their box without the all-or-nothing --ultrafast switch.
-//
-// An operator-supplied --duckdb-memory-limit is validated here, at the CLI
-// boundary, and a bad value is a hard error — DuckDB's SET memory_limit is
-// best-effort downstream and would either silently fall back to the default
-// (a typo) or silently uncap on a negative value, neither of which an operator
-// who explicitly asked for a budget should get without being told.
+// DuckDBTuningFromFlags resolves the effective DuckDB tuning for a command
+// carrying those flags. See duckdbtuning.DuckDBTuningFromFlags.
 func DuckDBTuningFromFlags(cmd *cobra.Command) (duckdbutil.Tuning, error) {
-	t := duckdbutil.DefaultTuning()
-	if ultrafast, _ := cmd.Flags().GetBool("ultrafast"); ultrafast {
-		t = duckdbutil.Ultrafast()
-	}
-	if threads, _ := cmd.Flags().GetInt("duckdb-threads"); threads >= 0 {
-		t.Threads = threads
-	}
-	if mem, _ := cmd.Flags().GetString("duckdb-memory-limit"); mem != "" {
-		if err := validateDuckDBMemoryLimit(mem); err != nil {
-			return duckdbutil.Tuning{}, err
-		}
-		t.MemoryLimit = mem
-	}
-	return t, nil
+	return duckdbtuning.DuckDBTuningFromFlags(cmd)
 }
 
-// TunedArchiveFetcher adapts a DuckDB Tuning into a query.ArchiveFetcher so the
-// CLI commands can inject their budget without changing parquetquery.Fetch's
-// signature (which other packages pass as a function value).
+// TunedArchiveFetcher adapts a DuckDB Tuning into a query.ArchiveFetcher. See
+// duckdbtuning.TunedArchiveFetcher.
 func TunedArchiveFetcher(t duckdbutil.Tuning) query.ArchiveFetcher {
-	return func(ctx context.Context, opts query.Options, source string) ([]query.ResultRow, error) {
-		return parquetquery.FetchWithTuning(ctx, opts, source, t)
-	}
+	return duckdbtuning.TunedArchiveFetcher(t)
 }

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -2422,8 +2422,8 @@ async function gateCapabilities() {
   if (gen !== serverGen) return;
   capsCache = caps || {};
   // Extension views advertised for this server (embedding builds; empty in the
-  // stock binary and under an active RBAC profile). Rebuild the nav before the
-  // route renders so a deep-linked ext route resolves.
+  // stock binary and under any active profile — the backend omits them there).
+  // Rebuild the nav before the route renders so a deep-linked ext route resolves.
   extViews = Array.isArray(capsCache.extension_views) ? capsCache.extension_views : [];
   syncExtNav();
   $all("[data-capability]").forEach((node) => node.classList.toggle("cap-on", !!capsCache[node.dataset.capability]));

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -54,6 +54,7 @@ const ICONS = {
   file: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" style="width:16px;height:16px"><path d="M14 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8z"></path><path d="M14 3v5h5"></path></svg>`,
   warn: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" style="width:15px;height:15px"><path d="M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z"/><path d="M12 9v4M12 17h.01"/></svg>`,
   calendar: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"></rect><path d="M8 3v4M16 3v4M3 10h18"></path></svg>`,
+  ext: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1.5"/><rect x="14" y="3" width="7" height="7" rx="1.5"/><rect x="3" y="14" width="7" height="7" rx="1.5"/><rect x="14" y="14" width="7" height="7" rx="1.5"/></svg>`,
 };
 
 // ── module state ─────────────────────────────────────────────────────────────
@@ -63,6 +64,7 @@ let currentServer = "";       // X-Bintrail-Server target ("" = backend default)
 let defaultServerId = "";
 let serverGen = 0;            // bumped on every server switch (staleness guard)
 let capsCache = {};           // last /api/capabilities for the selected server
+let extViews = [];            // extension views advertised for the selected server (embedding builds)
 let lastSQL = "";             // last generated undo SQL (for copy/download)
 let lastEvents = [];          // last rendered (filtered, capped) event page
 let pendingRecover = null;    // event context carried into Recover via "Undo"
@@ -584,13 +586,22 @@ function viewEnter() { const v = VIEW(); v.classList.remove("view-enter"); void 
 
 // ── router ─────────────────────────────────────────────────────────────────
 
+// isKnownRoute accepts the built-in ROUTES plus any live extension-view route
+// ("ext-<id>" advertised in the current server's capabilities). An "ext-" route
+// for a view the selected server does not expose is treated as unknown (the
+// caller redirects to overview), the same gating Time-travel/Storage get.
+function isKnownRoute(route) {
+  if (ROUTES.includes(route)) return true;
+  return route.startsWith("ext-") && extViews.some((v) => "ext-" + v.id === route);
+}
+
 function routeFromLocation() {
   const path = location.pathname.replace(/^\//, "").split("/")[0] || "overview";
-  return ROUTES.includes(path) ? path : "overview";
+  return isKnownRoute(path) ? path : "overview";
 }
 
 function navigate(route, params, push = true) {
-  if (!ROUTES.includes(route)) route = "overview";
+  if (!isKnownRoute(route)) route = "overview";
   // Reconstruct surface is gated; never navigate to a disabled Time-travel.
   if (route === "timetravel" && !capsCache.reconstruct) route = "overview";
   // Storage is a watch-daemon surface (rotation + archiving live there).
@@ -610,6 +621,13 @@ function renderRoute() {
   setActiveNav(route);
   cursorIdx = -1;
   const params = Object.fromEntries(new URLSearchParams(location.search));
+  // Extension views (embedding builds): "ext-<id>" dispatches to the provider's
+  // frontend module. routeFromLocation already redirected an unknown/ungated
+  // ext route to overview, so a match here is always a live view.
+  if (route.startsWith("ext-")) {
+    const view = extViews.find((v) => "ext-" + v.id === route);
+    return view ? renderExtensionView(view) : renderOverview();
+  }
   switch (route) {
     case "overview": return renderOverview();
     case "events": return renderEvents(params);
@@ -2403,9 +2421,72 @@ async function gateCapabilities() {
   }
   if (gen !== serverGen) return;
   capsCache = caps || {};
+  // Extension views advertised for this server (embedding builds; empty in the
+  // stock binary and under an active RBAC profile). Rebuild the nav before the
+  // route renders so a deep-linked ext route resolves.
+  extViews = Array.isArray(capsCache.extension_views) ? capsCache.extension_views : [];
+  syncExtNav();
   $all("[data-capability]").forEach((node) => node.classList.toggle("cap-on", !!capsCache[node.dataset.capability]));
   applyAuthGate();
   updateSrvNote(); // capsCache.monitor may have just changed
+}
+
+// syncExtNav rebuilds the extension-view nav group from extViews. Idempotent
+// across server switches: it drops the previously-injected group first, so a
+// server that exposes fewer (or no) extension views cannot leave stale items
+// behind. The group is anchored right after the built-in Monitor group (the one
+// holding Status). el()/textContent only — a view label is never markup.
+function syncExtNav() {
+  const prev = document.getElementById("ext-nav-group");
+  if (prev) prev.remove();
+  if (!extViews.length) return;
+  const nav = document.getElementById("nav");
+  if (!nav) return;
+  const group = el("div", { class: "nav-group", id: "ext-nav-group", "data-ext-nav": "1" });
+  group.append(el("div", { class: "nav-label", text: "Extensions" }));
+  for (const v of extViews) {
+    const route = "ext-" + v.id;
+    const item = el("a", {
+      class: "nav-item",
+      "data-ext-nav": "1",
+      "data-route": route,
+      href: "/" + route,
+      onclick: (e) => { e.preventDefault(); pendingRecover = null; navigate(route); },
+    }, icon("ext", "ni-icon"), el("span", { text: v.label }));
+    group.append(item);
+  }
+  const statusItem = $('.nav-item[data-route="status"]');
+  const anchor = statusItem ? statusItem.closest(".nav-group") : null;
+  if (anchor && anchor.parentNode) anchor.parentNode.insertBefore(group, anchor.nextSibling);
+  else nav.append(group);
+}
+
+// renderExtensionView loads a provider's ES module and hands it a mount node and
+// a small context: apiBase ("/api/ext/<id>/") and the console's own authed fetch
+// primitive (api), so the module reads its data routes with the operator's
+// bearer credential and selected-server header already applied. serverGen is
+// captured before the dynamic import and re-checked after: a server switch
+// mid-import abandons the render (no cross-server paint), matching every other
+// async view here.
+async function renderExtensionView(view) {
+  const gen = serverGen;
+  const v = VIEW();
+  clear(v);
+  v.append(pageHead(view.label, null));
+  const mount = el("div", { class: "ext-view-mount" });
+  v.append(mount);
+  try {
+    const mod = await import(view.script);
+    if (gen !== serverGen) return;
+    if (!mod || typeof mod.render !== "function") {
+      renderError(mount, "This extension view did not export a render() function.");
+      return;
+    }
+    mod.render(mount, { apiBase: "/api/ext/" + view.id + "/", api });
+  } catch (err) {
+    if (gen !== serverGen) return;
+    renderError(mount, err);
+  }
 }
 
 // ── server registry: switcher + modal CRUD ──────────────────────────────────

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -1383,3 +1383,8 @@ button { font-family: inherit; }
 
 .dt-foot { display: flex; gap: 8px; }
 .dt-foot .btn-primary { margin-left: auto; }
+
+/* Extension views (embedding builds) render their frontend module into this
+   mount; reserve a minimum height so an empty/slow module doesn't collapse the
+   view region to a bare page head. */
+.ext-view-mount { min-height: 240px; }

--- a/internal/console/extview.go
+++ b/internal/console/extview.go
@@ -1,0 +1,68 @@
+package console
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/dbtrail/dbtrail/ext"
+	"github.com/dbtrail/dbtrail/internal/query"
+)
+
+// consoleQueryContext resolves the per-request, per-selected-server index access
+// an installed ext.ConsoleViewProvider's data handler receives. It uses the same
+// bundle resolution the console's own endpoints do, so an extension view reads
+// exactly the server the operator has selected (X-Bintrail-Server, or the
+// default). The returned error is already DSN-scrubbed by the resolver, so it is
+// safe for the provider to surface to the client.
+func (s *Server) consoleQueryContext(r *http.Request) (ext.ConsoleQueryContext, error) {
+	b, err := s.resolve(r)
+	if err != nil {
+		return ext.ConsoleQueryContext{}, err
+	}
+	// SourceDSN is a registry-only hint (the boot entry has none); "not found"
+	// is not an error — the provider treats an empty DSN as "no source".
+	sourceDSN := ""
+	if e, ok := s.selectedEntry(r); ok {
+		sourceDSN = e.SourceDSN
+	}
+	return ext.ConsoleQueryContext{
+		DB:        b.db,
+		Fetch:     s.consoleFetch(b),
+		SourceDSN: sourceDSN,
+	}, nil
+}
+
+// consoleFetch returns the cross-source fetch closure handed to an extension
+// view, pre-bound to a selected server's bundle. It re-attaches the console's
+// RBAC rules to every Options as defense-in-depth: the RBAC guard already
+// refuses the whole extension surface while a profile is active (see
+// rbacViewGuard), but if that ever regresses, a provider fetching through this
+// closure still gets a redacted result set rather than raw rows. The field type
+// on ext.ConsoleQueryContext.Fetch is an alias of this signature, so the
+// returned value assigns directly.
+func (s *Server) consoleFetch(b *bundle) func(ctx context.Context, opts query.Options) ([]query.ResultRow, *query.QueryPlan, error) {
+	return func(ctx context.Context, opts query.Options) ([]query.ResultRow, *query.QueryPlan, error) {
+		opts.DenyTables = s.denyTables
+		opts.RedactColumns = s.redactCols
+		opts.ProfileActive = s.profileActive
+		return s.fetch(ctx, b, opts)
+	}
+}
+
+// rbacViewGuard wraps an extension view's data handler so it refuses with 403 —
+// BEFORE the provider handler runs — whenever an RBAC access-control profile is
+// active. The console cannot guarantee a third-party handler honors table-deny /
+// column-redaction rules on its own queries, so it withholds the entire surface
+// under a profile rather than risk a leak (the same posture recover-cascade
+// takes). This is the enforcement backstop; the SPA also hides the nav item
+// because capabilities omit the view under a profile.
+func (s *Server) rbacViewGuard(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if s.rbacActive() {
+			writeJSONError(w, http.StatusForbidden,
+				"this view is unavailable while an access-control profile is active")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/console/extview.go
+++ b/internal/console/extview.go
@@ -34,10 +34,12 @@ func (s *Server) consoleQueryContext(r *http.Request) (ext.ConsoleQueryContext, 
 
 // consoleFetch returns the cross-source fetch closure handed to an extension
 // view, pre-bound to a selected server's bundle. It re-attaches the console's
-// RBAC rules to every Options as defense-in-depth: the RBAC guard already
+// RBAC rules to every Options as defense-in-depth: the profile guard already
 // refuses the whole extension surface while a profile is active (see
 // rbacViewGuard), but if that ever regresses, a provider fetching through this
-// closure still gets a redacted result set rather than raw rows. The field type
+// closure still gets a redacted result set rather than raw rows. It also sets
+// ProfileActive so query_text/query_hash stay withheld under a NAMED zero-rule
+// profile (#699/#838) — the same signal the guard now keys on. The field type
 // on ext.ConsoleQueryContext.Fetch is an alias of this signature, so the
 // returned value assigns directly.
 func (s *Server) consoleFetch(b *bundle) func(ctx context.Context, opts query.Options) ([]query.ResultRow, *query.QueryPlan, error) {
@@ -50,15 +52,23 @@ func (s *Server) consoleFetch(b *bundle) func(ctx context.Context, opts query.Op
 }
 
 // rbacViewGuard wraps an extension view's data handler so it refuses with 403 —
-// BEFORE the provider handler runs — whenever an RBAC access-control profile is
-// active. The console cannot guarantee a third-party handler honors table-deny /
+// BEFORE the provider handler runs — whenever a profile is active. It keys on
+// s.profileActive (a NAMED profile was supplied, even one that resolved to zero
+// deny/redact rules — the #838 `--profile <typo>` state), NOT s.rbacActive()
+// (rule count > 0). That distinction matters because the seam hands the provider
+// a raw *sql.DB (ext.ConsoleQueryContext.DB): a handler could run
+// `SELECT query_text, query_hash FROM binlog_events` directly and return the
+// originating SQL literals a named profile is contracted to withhold (#699/#838)
+// — the console's own /api/events blanks those under EVERY named profile via
+// ProfileActive, so the raw-DB path must refuse under the same condition. The
+// console cannot guarantee a third-party handler honors table-deny /
 // column-redaction rules on its own queries, so it withholds the entire surface
-// under a profile rather than risk a leak (the same posture recover-cascade
+// under any profile rather than risk a leak (the same posture recover-cascade
 // takes). This is the enforcement backstop; the SPA also hides the nav item
 // because capabilities omit the view under a profile.
 func (s *Server) rbacViewGuard(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if s.rbacActive() {
+		if s.profileActive {
 			writeJSONError(w, http.StatusForbidden,
 				"this view is unavailable while an access-control profile is active")
 			return

--- a/internal/console/extview_test.go
+++ b/internal/console/extview_test.go
@@ -1,0 +1,211 @@
+package console
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/ext"
+	"github.com/dbtrail/dbtrail/internal/query"
+)
+
+// These tests mutate the process-global ext.ConsoleView seam, so none may run
+// in parallel; every install is restored with t.Cleanup. buildHandler reads the
+// seam at construction time (route mount), so the provider is always installed
+// BEFORE the server is built.
+
+// stubViewProvider is a minimal ext.ConsoleViewProvider. dataHit records whether
+// its DATA handler actually ran, so a test can prove the RBAC guard refuses
+// BEFORE the provider handler (not merely that the response is 403).
+type stubViewProvider struct {
+	id      string
+	dataHit *bool
+}
+
+func (p *stubViewProvider) ID() string    { return p.id }
+func (p *stubViewProvider) Label() string { return "Example View" }
+func (p *stubViewProvider) Script() string {
+	return "/ext/" + p.id + "/view.js"
+}
+
+func (p *stubViewProvider) StaticHandler(string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/javascript")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "export function render(){}")
+	})
+}
+
+func (p *stubViewProvider) DataHandler(_ string, resolve ext.ConsoleQueryContextFunc) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if p.dataHit != nil {
+			*p.dataHit = true
+		}
+		// Exercise the resolve wiring: the boot bundle resolves without error,
+		// and the returned context must carry a fetch closure.
+		if cqc, err := resolve(r); err == nil && cqc.Fetch == nil {
+			http.Error(w, "resolve returned a nil Fetch", http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"ok":true}`)
+	})
+}
+
+// newViewServer installs p (may be nil) and builds a token-authenticated server
+// whose boot bundle wraps a sqlmock DB. deny drives the RBAC profile: a non-empty
+// slice makes rbacActive() true.
+func newViewServer(t *testing.T, p ext.ConsoleViewProvider, deny []query.SchemaTable) *Server {
+	t.Helper()
+	ext.SetConsoleView(p)
+	t.Cleanup(func() { ext.SetConsoleView(nil) })
+
+	db, _, closer := newSQLMock(t)
+	t.Cleanup(closer)
+
+	profileActive := len(deny) > 0
+	s := &Server{token: "t", denyTables: deny, profileActive: profileActive, cm: newConnManager(nil, profileActive)}
+	s.cm.boot = &bundle{db: db, engine: query.New(db), noArchive: true}
+	s.mux = s.buildHandler()
+	return s
+}
+
+func capsJSON(t *testing.T, s *Server) map[string]any {
+	t.Helper()
+	rec := getPath(t, s, "127.0.0.1:8090", "/api/capabilities", "t")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /api/capabilities = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var caps map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &caps); err != nil {
+		t.Fatalf("unmarshal capabilities: %v", err)
+	}
+	return caps
+}
+
+// (a) capabilities advertises the view with a provider installed, and omits the
+// key entirely without one.
+func TestExtensionViewCapabilitiesAdvertised(t *testing.T) {
+	s := newViewServer(t, &stubViewProvider{id: "example"}, nil)
+	caps := capsJSON(t, s)
+	raw, ok := caps["extension_views"]
+	if !ok {
+		t.Fatalf("capabilities has no extension_views with a provider installed: %v", caps)
+	}
+	list, ok := raw.([]any)
+	if !ok || len(list) != 1 {
+		t.Fatalf("extension_views = %v, want a single entry", raw)
+	}
+	v, _ := list[0].(map[string]any)
+	if v["id"] != "example" || v["label"] != "Example View" || v["script"] != "/ext/example/view.js" {
+		t.Errorf("extension_views[0] = %v, want {id:example,label:Example View,script:/ext/example/view.js}", v)
+	}
+}
+
+func TestExtensionViewCapabilitiesOmittedWithoutProvider(t *testing.T) {
+	s := newViewServer(t, nil, nil)
+	caps := capsJSON(t, s)
+	if _, ok := caps["extension_views"]; ok {
+		t.Errorf("capabilities carries extension_views with no provider installed: %v", caps)
+	}
+}
+
+// (b) the data route is reachable WITH a bearer token and 401 WITHOUT.
+func TestExtensionViewDataHandlerRequiresAuth(t *testing.T) {
+	hit := false
+	s := newViewServer(t, &stubViewProvider{id: "example", dataHit: &hit}, nil)
+
+	if rec := getPath(t, s, "127.0.0.1:8090", "/api/ext/example/ping", "t"); rec.Code != http.StatusOK {
+		t.Errorf("data route with a bearer = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	if !hit {
+		t.Error("provider data handler did not run on an authenticated request")
+	}
+
+	hit = false
+	if rec := getPath(t, s, "127.0.0.1:8090", "/api/ext/example/ping", ""); rec.Code != http.StatusUnauthorized {
+		t.Errorf("data route without a bearer = %d, want 401", rec.Code)
+	}
+	if hit {
+		t.Error("provider data handler ran on an UNAUTHENTICATED request — tokenMiddleware did not gate it")
+	}
+}
+
+// (c) under an active RBAC profile the data route is refused 403 BEFORE the
+// provider handler runs.
+func TestExtensionViewDataHandlerRefusedUnderRBAC(t *testing.T) {
+	hit := false
+	deny := []query.SchemaTable{{Schema: "app", Table: "secrets"}}
+	s := newViewServer(t, &stubViewProvider{id: "example", dataHit: &hit}, deny)
+
+	rec := getPath(t, s, "127.0.0.1:8090", "/api/ext/example/ping", "t")
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("data route under an RBAC profile = %d body=%s, want 403", rec.Code, rec.Body.String())
+	}
+	if hit {
+		t.Error("provider data handler ran under an RBAC profile — rbacViewGuard must refuse BEFORE it")
+	}
+	// And capabilities must not advertise the view under a profile.
+	caps := capsJSON(t, s)
+	if _, ok := caps["extension_views"]; ok {
+		t.Errorf("capabilities advertises extension_views under an active RBAC profile: %v", caps)
+	}
+}
+
+// (d) the static route is reachable UNAUTHENTICATED (code always ships).
+func TestExtensionViewStaticHandlerUnauthenticated(t *testing.T) {
+	s := newViewServer(t, &stubViewProvider{id: "example"}, nil)
+	rec := getPath(t, s, "127.0.0.1:8090", "/ext/example/view.js", "")
+	if rec.Code != http.StatusOK {
+		t.Errorf("static asset without a bearer = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+}
+
+// (e) with no provider both subtrees are absent from the mux (404), not a
+// silently-served surface. The static probe uses the real asset path (with an
+// extension) so the SPA-fallback does not turn it into a 200 index.html.
+func TestExtensionViewRoutesAbsentWithoutProvider(t *testing.T) {
+	s := newViewServer(t, nil, nil)
+	if rec := getPath(t, s, "127.0.0.1:8090", "/api/ext/example/ping", "t"); rec.Code != http.StatusNotFound {
+		t.Errorf("data route with no provider = %d, want 404 (route absent)", rec.Code)
+	}
+	if rec := getPath(t, s, "127.0.0.1:8090", "/ext/example/view.js", ""); rec.Code != http.StatusNotFound {
+		t.Errorf("static asset with no provider = %d, want 404 (route absent)", rec.Code)
+	}
+}
+
+// (f) a provider whose ID fails validation is skipped (not mounted) and does not
+// panic at construction. "Example" is invalid (uppercase) per ^[a-z0-9-]+$.
+func TestExtensionViewInvalidIDSkipped(t *testing.T) {
+	s := newViewServer(t, &stubViewProvider{id: "Example"}, nil)
+	// Not advertised.
+	caps := capsJSON(t, s)
+	if _, ok := caps["extension_views"]; ok {
+		t.Errorf("capabilities advertises a view with an invalid id: %v", caps)
+	}
+	// Not mounted.
+	if rec := getPath(t, s, "127.0.0.1:8090", "/api/ext/Example/ping", "t"); rec.Code != http.StatusNotFound {
+		t.Errorf("data route for an invalid-id provider = %d, want 404 (not mounted)", rec.Code)
+	}
+	if rec := getPath(t, s, "127.0.0.1:8090", "/ext/Example/view.js", ""); rec.Code != http.StatusNotFound {
+		t.Errorf("static route for an invalid-id provider = %d, want 404 (not mounted)", rec.Code)
+	}
+}
+
+// (g) the DNS-rebinding host guard still covers the new routes: a domain Host is
+// refused before either handler runs.
+func TestExtensionViewRoutesBehindHostGuard(t *testing.T) {
+	hit := false
+	s := newViewServer(t, &stubViewProvider{id: "example", dataHit: &hit}, nil)
+
+	if rec := getPath(t, s, "attacker.example", "/ext/example/view.js", ""); rec.Code != http.StatusForbidden {
+		t.Errorf("static route with a domain Host = %d, want 403", rec.Code)
+	}
+	if rec := getPath(t, s, "attacker.example", "/api/ext/example/ping", "t"); rec.Code != http.StatusForbidden {
+		t.Errorf("data route with a domain Host = %d, want 403", rec.Code)
+	}
+	if hit {
+		t.Error("provider data handler ran despite a rejected Host")
+	}
+}

--- a/internal/console/extview_test.go
+++ b/internal/console/extview_test.go
@@ -54,9 +54,12 @@ func (p *stubViewProvider) DataHandler(_ string, resolve ext.ConsoleQueryContext
 }
 
 // newViewServer installs p (may be nil) and builds a token-authenticated server
-// whose boot bundle wraps a sqlmock DB. deny drives the RBAC profile: a non-empty
-// slice makes rbacActive() true.
-func newViewServer(t *testing.T, p ext.ConsoleViewProvider, deny []query.SchemaTable) *Server {
+// whose boot bundle wraps a sqlmock DB. deny drives the RBAC rules: a non-empty
+// slice makes rbacActive() true. profileActiveOverride, when supplied, forces
+// s.profileActive independently of the rule count — the only way to express the
+// NAMED-but-zero-rule profile (#838 `--profile <typo>`) where profileActive is
+// true but rbacActive() is false; otherwise profileActive derives from deny.
+func newViewServer(t *testing.T, p ext.ConsoleViewProvider, deny []query.SchemaTable, profileActiveOverride ...bool) *Server {
 	t.Helper()
 	ext.SetConsoleView(p)
 	t.Cleanup(func() { ext.SetConsoleView(nil) })
@@ -65,6 +68,9 @@ func newViewServer(t *testing.T, p ext.ConsoleViewProvider, deny []query.SchemaT
 	t.Cleanup(closer)
 
 	profileActive := len(deny) > 0
+	if len(profileActiveOverride) > 0 {
+		profileActive = profileActiveOverride[0]
+	}
 	s := &Server{token: "t", denyTables: deny, profileActive: profileActive, cm: newConnManager(nil, profileActive)}
 	s.cm.boot = &bundle{db: db, engine: query.New(db), noArchive: true}
 	s.mux = s.buildHandler()
@@ -150,6 +156,34 @@ func TestExtensionViewDataHandlerRefusedUnderRBAC(t *testing.T) {
 	caps := capsJSON(t, s)
 	if _, ok := caps["extension_views"]; ok {
 		t.Errorf("capabilities advertises extension_views under an active RBAC profile: %v", caps)
+	}
+}
+
+// (c2) a NAMED but ZERO-RULE profile (profileActive true, no deny/redact rules —
+// the #838 `--profile <typo>` / empty-profile state) must ALSO refuse the data
+// route and omit the view from capabilities. rbacActive() is false here, so a
+// guard keyed on rule count would serve the surface and let a provider read
+// query_text/query_hash straight off the raw cqc.DB — precisely what a named
+// profile withholds on /api/events. The guard therefore keys on profileActive.
+func TestExtensionViewDataHandlerRefusedUnderZeroRuleProfile(t *testing.T) {
+	hit := false
+	// deny is nil (rbacActive()==false) but the profile NAME is active.
+	s := newViewServer(t, &stubViewProvider{id: "example", dataHit: &hit}, nil, true)
+	if s.rbacActive() {
+		t.Fatal("test precondition broken: rbacActive() must be false under a zero-rule profile")
+	}
+
+	rec := getPath(t, s, "127.0.0.1:8090", "/api/ext/example/ping", "t")
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("data route under a zero-rule named profile = %d body=%s, want 403", rec.Code, rec.Body.String())
+	}
+	if hit {
+		t.Error("provider data handler ran under a zero-rule named profile — rbacViewGuard must refuse on profileActive, not rbacActive()")
+	}
+	// And capabilities must not advertise the view under a named profile either.
+	caps := capsJSON(t, s)
+	if _, ok := caps["extension_views"]; ok {
+		t.Errorf("capabilities advertises extension_views under a zero-rule named profile: %v", caps)
 	}
 }
 

--- a/internal/console/reconstruct.go
+++ b/internal/console/reconstruct.go
@@ -80,11 +80,11 @@ type capabilitiesResponse struct {
 	VerifyLiveSource bool `json:"verify_live_source"`
 	// ExtensionViews lists console views contributed by an installed
 	// extension-view provider (an embedding distribution — a build that wraps the
-	// OSS core). Omitted in the stock binary (no provider) and whenever an RBAC
-	// profile is active (the provider's data routes are refused then, so the SPA
-	// must not advertise a nav item that would 403). The SPA reveals one nav item
-	// + route ("ext-<id>") per entry. Generic by construction — the core names no
-	// specific view.
+	// OSS core). Omitted in the stock binary (no provider) and whenever any named
+	// profile is active — even a zero-rule one (the provider's data routes are
+	// refused then via rbacViewGuard/profileActive, so the SPA must not advertise a
+	// nav item that would 403). The SPA reveals one nav item + route ("ext-<id>")
+	// per entry. Generic by construction — the core names no specific view.
 	ExtensionViews []extensionViewDTO `json:"extension_views,omitempty"`
 	Auth           authCapsInfo       `json:"auth"`
 	// Source names the selected server's source database family — "postgresql"
@@ -177,10 +177,12 @@ func (s *Server) handleCapabilities(w http.ResponseWriter, r *http.Request) {
 	}
 	// Extension views (ext seam): advertise an installed provider's view so the
 	// SPA can reveal its nav item + route. Process-global, like Monitor. Suppressed
-	// under an active RBAC profile — the data routes are refused there (rbacViewGuard),
-	// so a nav item would only lead to a 403 — and for an invalid id, which
-	// buildHandler declined to mount (advertising it would 404 the data route).
-	if p := ext.ConsoleView(); p != nil && !s.rbacActive() && ext.ValidConsoleViewID(p.ID()) {
+	// under an active profile — keyed on s.profileActive (any named profile, even a
+	// zero-rule one) to match rbacViewGuard, which refuses the data routes there
+	// (advertising a nav item that only 403s would be a lie) — and for an invalid
+	// id, which buildHandler declined to mount (advertising it would 404 the data
+	// route).
+	if p := ext.ConsoleView(); p != nil && !s.profileActive && ext.ValidConsoleViewID(p.ID()) {
 		resp.ExtensionViews = []extensionViewDTO{{ID: p.ID(), Label: p.Label(), Script: p.Script()}}
 	}
 	writeJSON(w, http.StatusOK, resp)

--- a/internal/console/reconstruct.go
+++ b/internal/console/reconstruct.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dbtrail/dbtrail/ext"
 	"github.com/dbtrail/dbtrail/internal/cliutil"
 	"github.com/dbtrail/dbtrail/internal/parquetquery"
 	"github.com/dbtrail/dbtrail/internal/query"
@@ -76,8 +77,16 @@ type capabilitiesResponse struct {
 	Verify bool `json:"verify"`
 	// VerifyLiveSource: live-source verify is additionally usable — the
 	// selected server also has a source DSN configured. Per-server.
-	VerifyLiveSource bool         `json:"verify_live_source"`
-	Auth             authCapsInfo `json:"auth"`
+	VerifyLiveSource bool `json:"verify_live_source"`
+	// ExtensionViews lists console views contributed by an installed
+	// extension-view provider (an embedding distribution — a build that wraps the
+	// OSS core). Omitted in the stock binary (no provider) and whenever an RBAC
+	// profile is active (the provider's data routes are refused then, so the SPA
+	// must not advertise a nav item that would 403). The SPA reveals one nav item
+	// + route ("ext-<id>") per entry. Generic by construction — the core names no
+	// specific view.
+	ExtensionViews []extensionViewDTO `json:"extension_views,omitempty"`
+	Auth           authCapsInfo       `json:"auth"`
 	// Source names the selected server's source database family — "postgresql"
 	// or "mysql" — derived per-server from stream_state.flavor (the same field
 	// DialectForIndex reads). It drives source-aware PRESENTATION only: the
@@ -97,6 +106,16 @@ type capabilitiesResponse struct {
 type authCapsInfo struct {
 	PasswordSet bool   `json:"password_set"`
 	AuthKind    string `json:"auth_kind"` // "token" | "session"
+}
+
+// extensionViewDTO is the wire view of one console view contributed by an
+// installed ext.ConsoleViewProvider. id keys the nav item, the SPA route
+// ("ext-"+id), and the "/api/ext/<id>/" data mount; script is the ES module the
+// SPA import()s and calls render(mount, {apiBase, api}) on.
+type extensionViewDTO struct {
+	ID     string `json:"id"`
+	Label  string `json:"label"`
+	Script string `json:"script"`
 }
 
 // handleCapabilities reports which optional console surfaces are enabled.
@@ -155,6 +174,14 @@ func (s *Server) handleCapabilities(w http.ResponseWriter, r *http.Request) {
 		// strip Time-travel from the UI, so leave an operator trace. Mirrors
 		// the Debug/Warn split in connManager.Resolve.
 		slog.Warn("console: capabilities resolve failed; reporting reconstruct=false", "error", err)
+	}
+	// Extension views (ext seam): advertise an installed provider's view so the
+	// SPA can reveal its nav item + route. Process-global, like Monitor. Suppressed
+	// under an active RBAC profile — the data routes are refused there (rbacViewGuard),
+	// so a nav item would only lead to a 403 — and for an invalid id, which
+	// buildHandler declined to mount (advertising it would 404 the data route).
+	if p := ext.ConsoleView(); p != nil && !s.rbacActive() && ext.ValidConsoleViewID(p.ID()) {
+		resp.ExtensionViews = []extensionViewDTO{{ID: p.ID(), Label: p.Label(), Script: p.Script()}}
 	}
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -430,6 +430,25 @@ func (s *Server) buildHandler() http.Handler {
 	if p := ext.ConsoleAuth(); p != nil {
 		root.Handle(extAuthPrefix, p.Handler(extAuthPrefix, s.extSessionIssuer()))
 	}
+	// Extension view (ext seam): an embedding distribution can contribute one
+	// additional console view. Its static assets mount UNAUTHENTICATED on root at
+	// /ext/<id>/ (behind hostGuard + securityHeaders only — code always ships,
+	// only data is gated), and its data routes mount on the inner api mux at
+	// /api/ext/<id>/ so they inherit tokenMiddleware, wrapped in rbacViewGuard so
+	// the whole surface is refused (403) while an RBAC profile is active. The id
+	// flows into both URL paths and a DOM route, so an invalid one is skipped
+	// (logged, not mounted) rather than producing a broken/injectable route.
+	if p := ext.ConsoleView(); p != nil {
+		id := p.ID()
+		if !ext.ValidConsoleViewID(id) {
+			slog.Error("console: ignoring extension view with an invalid id (must match ^[a-z0-9-]+$)", "id", id)
+		} else {
+			staticPrefix := "/ext/" + id + "/"
+			dataPrefix := "/api/ext/" + id + "/"
+			root.Handle(staticPrefix, p.StaticHandler(staticPrefix))
+			api.Handle(dataPrefix, s.rbacViewGuard(p.DataHandler(dataPrefix, s.consoleQueryContext)))
+		}
+	}
 	root.Handle("/api/", s.tokenMiddleware(api)) // credential on all other /api/*
 	root.Handle("/", assetHandler())             // static shell + assets
 

--- a/internal/duckdbtuning/duckdbtuning.go
+++ b/internal/duckdbtuning/duckdbtuning.go
@@ -1,0 +1,110 @@
+// Package duckdbtuning holds the shared DuckDB resource-tuning flags used by the
+// offline query/recover/reconstruct/verify commands (#510/#511): the
+// --ultrafast / --duckdb-threads / --duckdb-memory-limit flag set, the
+// precedence resolution into a duckdbutil.Tuning, and the archive-fetcher
+// adapter that carries that budget into parquetquery.
+//
+// It is deliberately a leaf: its only dependencies are cobra plus the low-level
+// duckdbutil / query / parquetquery packages, and it imports nothing from the
+// command layer. That lets the public read-plane facade (indexquery) expose
+// these helpers WITHOUT pulling in internal/cli — which imports ext for the
+// audit sink — so an ext seam that consumes the facade does not create an
+// ext → indexquery → internal/cli → ext import cycle. internal/cli re-exports
+// the same three functions (thin forwarders) so its command layer and existing
+// callers are unchanged.
+package duckdbtuning
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dbtrail/dbtrail/internal/duckdbutil"
+	"github.com/dbtrail/dbtrail/internal/parquetquery"
+	"github.com/dbtrail/dbtrail/internal/query"
+)
+
+// duckDBMemoryLimitRE matches a number with a REQUIRED unit from the exact set
+// the linked DuckDB accepts as a memory_limit — decimal B/KB/MB/GB/TB or binary
+// KiB/MiB/GiB/TiB (verified empirically; DuckDB rejects PB/PiB, '%', and a
+// bare unitless number). Matching only what DuckDB honors is the whole point:
+// a value the regex accepts but DuckDB rejects (e.g. '80%') would pass this CLI
+// gate and then hit Apply's best-effort SET, which logs a WARN and silently
+// falls back to the default — the exact silent-fallback this validation exists
+// to prevent. A leading '-' has no match (DuckDB SILENTLY accepts a negative
+// limit as effectively unlimited), and a zero magnitude is rejected separately
+// in validateDuckDBMemoryLimit (DuckDB accepts e.g. '0GB' and uncaps).
+var duckDBMemoryLimitRE = regexp.MustCompile(`(?i)^(\d+(?:\.\d+)?)\s*(b|kb|mb|gb|tb|kib|mib|gib|tib)$`)
+
+// validateDuckDBMemoryLimit rejects an operator-supplied --duckdb-memory-limit
+// that DuckDB would mishandle, turning a typo or a footgun into a clear CLI
+// error instead of a silent fall-back to the default (or a silent uncap).
+func validateDuckDBMemoryLimit(s string) error {
+	m := duckDBMemoryLimitRE.FindStringSubmatch(strings.TrimSpace(s))
+	if m == nil {
+		return fmt.Errorf("invalid --duckdb-memory-limit %q: expected a positive size with a unit, e.g. 16GB, 512MB, or 16GiB (units: B/KB/MB/GB/TB or KiB/MiB/GiB/TiB)", s)
+	}
+	if v, err := strconv.ParseFloat(m[1], 64); err != nil || v <= 0 {
+		return fmt.Errorf("invalid --duckdb-memory-limit %q: must be greater than zero (DuckDB treats a zero limit as unlimited)", s)
+	}
+	return nil
+}
+
+// AddDuckDBTuningFlags registers the shared DuckDB resource flags on the
+// offline query/recover/reconstruct commands. They lift the conservative,
+// container-safe DuckDB budget (threads=2, memory_limit=4GB) that
+// parquetquery.Fetch applies by default — useful on a dedicated box with
+// plenty of RAM where the small-container defaults leave performance on the
+// table (#510). The long-lived shim/console daemons never register these, so
+// their archive reads keep the safe default (#509 non-goal).
+//
+// --duckdb-threads default -1 (not 0) so 0 stays a meaningful explicit value:
+// "let DuckDB pick one thread per core". --duckdb-memory-limit "" means unset.
+func AddDuckDBTuningFlags(cmd *cobra.Command) {
+	cmd.Flags().Bool("ultrafast", false,
+		"trade DuckDB memory-safety for speed: let DuckDB self-tune to the host (all cores, ~80% RAM) instead of the container-safe 2 threads / 4GB cap — for big boxes, not small containers")
+	cmd.Flags().Int("duckdb-threads", -1,
+		"override DuckDB thread count (0 = one per CPU core); -1 keeps the mode default")
+	cmd.Flags().String("duckdb-memory-limit", "",
+		"override DuckDB memory limit, e.g. 16GB (empty keeps the mode default)")
+}
+
+// DuckDBTuningFromFlags resolves the effective DuckDB tuning for a command.
+// Precedence: an explicit --duckdb-* flag wins over --ultrafast, which wins
+// over the conservative default. The granular flags let an operator tune to
+// their box without the all-or-nothing --ultrafast switch.
+//
+// An operator-supplied --duckdb-memory-limit is validated here, at the CLI
+// boundary, and a bad value is a hard error — DuckDB's SET memory_limit is
+// best-effort downstream and would either silently fall back to the default
+// (a typo) or silently uncap on a negative value, neither of which an operator
+// who explicitly asked for a budget should get without being told.
+func DuckDBTuningFromFlags(cmd *cobra.Command) (duckdbutil.Tuning, error) {
+	t := duckdbutil.DefaultTuning()
+	if ultrafast, _ := cmd.Flags().GetBool("ultrafast"); ultrafast {
+		t = duckdbutil.Ultrafast()
+	}
+	if threads, _ := cmd.Flags().GetInt("duckdb-threads"); threads >= 0 {
+		t.Threads = threads
+	}
+	if mem, _ := cmd.Flags().GetString("duckdb-memory-limit"); mem != "" {
+		if err := validateDuckDBMemoryLimit(mem); err != nil {
+			return duckdbutil.Tuning{}, err
+		}
+		t.MemoryLimit = mem
+	}
+	return t, nil
+}
+
+// TunedArchiveFetcher adapts a DuckDB Tuning into a query.ArchiveFetcher so the
+// CLI commands can inject their budget without changing parquetquery.Fetch's
+// signature (which other packages pass as a function value).
+func TunedArchiveFetcher(t duckdbutil.Tuning) query.ArchiveFetcher {
+	return func(ctx context.Context, opts query.Options, source string) ([]query.ResultRow, error) {
+		return parquetquery.FetchWithTuning(ctx, opts, source, t)
+	}
+}

--- a/internal/duckdbtuning/duckdbtuning_test.go
+++ b/internal/duckdbtuning/duckdbtuning_test.go
@@ -1,4 +1,4 @@
-package cli
+package duckdbtuning
 
 import (
 	"testing"

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -332,8 +332,15 @@ try {
     const realFetch = window.fetch;
     window.fetch = (path, opts) => {
       if (typeof path === "string" && path.startsWith("/api/capabilities")) {
+        // A realistic caps shape (incl. the always-present `auth` object) so the
+        // whole gateCapabilities() tail — applyAuthGate/updateSrvNote — runs as it
+        // would against the real backend, not just the extension_views read.
         return Promise.resolve(new Response(
-          JSON.stringify({ monitor: true, extension_views: [{ id: "gated", label: "Gated View", script: modURL("__extgate") }] }),
+          JSON.stringify({
+            monitor: true,
+            auth: { password_set: false, auth_kind: "token" },
+            extension_views: [{ id: "gated", label: "Gated View", script: modURL("__extgate") }],
+          }),
           { status: 200, headers: { "Content-Type": "application/json" } },
         ));
       }

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -322,6 +322,28 @@ try {
       { type: "text/javascript" },
     ));
 
+    // 0) Exercise gateCapabilities END-TO-END: the manual steps below fixture-drive
+    //    capsCache/extViews directly, which BYPASSES the one real backend→frontend
+    //    wiring line (extViews = capsCache.extension_views inside gateCapabilities).
+    //    Stub /api/capabilities so it advertises an extension view, call the real
+    //    gateCapabilities(), and assert extViews + the nav were populated FROM the
+    //    parsed response — so a one-sided read of a different property (or a rename)
+    //    fails a test instead of silently disabling the feature.
+    const realFetch = window.fetch;
+    window.fetch = (path, opts) => {
+      if (typeof path === "string" && path.startsWith("/api/capabilities")) {
+        return Promise.resolve(new Response(
+          JSON.stringify({ monitor: true, extension_views: [{ id: "gated", label: "Gated View", script: modURL("__extgate") }] }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ));
+      }
+      return realFetch(path, opts);
+    };
+    await gateCapabilities();
+    window.fetch = realFetch;
+    const gatedFromCaps = extViews.length === 1 && extViews[0].id === "gated";
+    const gatedNav = !!document.querySelector('.nav-item[data-route="ext-gated"]');
+
     // 1) Advertise one view and sync the nav (mirrors gateCapabilities).
     const script = modURL("__ext1");
     capsCache = { ...capsCache, extension_views: [{ id: "demo", label: "Demo View", script }] };
@@ -359,10 +381,15 @@ try {
     await p;
     const staleAborted = window.__ext2 === undefined;
 
-    // Leave the UI on a known-good route for the final no-errors assertion.
+    // Restore the console's REAL capabilities (the stock binary ships no provider,
+    // so this clears the stubbed ext nav) and leave the UI on a known-good route
+    // for the final no-errors assertion.
+    await gateCapabilities();
     navigate("overview");
-    return { navText, known, onRoute, mounted: !!mount, mountedText, rendered, navActive, navGone, redirected, staleAborted };
+    return { gatedFromCaps, gatedNav, navText, known, onRoute, mounted: !!mount, mountedText, rendered, navActive, navGone, redirected, staleAborted };
   });
+  extv.gatedFromCaps ? ok("ext-view: gateCapabilities populates extViews from /api/capabilities.extension_views") : bad("ext-view: gateCapabilities populates extViews from /api/capabilities.extension_views", "extViews not set from the parsed caps response");
+  extv.gatedNav ? ok("ext-view: gateCapabilities injects the nav item from the fetched caps") : bad("ext-view: gateCapabilities injects the nav item from the fetched caps", "no ext-gated nav item after gateCapabilities");
   extv.navText === "Demo View" ? ok("ext-view: nav item injected with the provider label") : bad("ext-view: nav item injected with the provider label", `navText=${extv.navText}`);
   extv.known ? ok("ext-view: isKnownRoute accepts a live ext-<id> route") : bad("ext-view: isKnownRoute accepts a live ext-<id> route", "ext-demo not known");
   extv.onRoute ? ok("ext-view: navigate routes to /ext-<id>") : bad("ext-view: navigate routes to /ext-<id>", "wrong route");

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -305,6 +305,76 @@ try {
   cred.rawRowCount === 4 ? ok("aws-creds: all four raw signal rows still render") : bad("aws-creds: all four raw signal rows still render", `rawRowCount=${cred.rawRowCount}`);
 
 
+  // Scenario 10 — extension views (embedding builds). The stock binary ships no
+  // ConsoleViewProvider, so this fixture-drives the pure client wiring (like
+  // scenarios 7-9): inject an advertised view into capsCache, then assert the
+  // nav item appears, the route "ext-<id>" mounts the module and calls its
+  // render(mount, {apiBase, api}), and a server switch both drops the nav item
+  // and abandons an in-flight render (serverGen staleness). Script() is stubbed
+  // with a blob-URL ES module — a same-document dynamic import, which works only
+  // because the console sets no Content-Security-Policy (the invariant documented
+  // on ext.ConsoleViewProvider.Script; a script-src CSP without 'self'/blob:
+  // would break this and every real extension view).
+  const extv = await page.evaluate(async () => {
+    const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+    const modURL = (marker) => URL.createObjectURL(new Blob(
+      [`export function render(mount, ctx){ window.${marker} = !!(mount && ctx && typeof ctx.api === "function" && ctx.apiBase); mount.append(document.createTextNode("ext-content")); }`],
+      { type: "text/javascript" },
+    ));
+
+    // 1) Advertise one view and sync the nav (mirrors gateCapabilities).
+    const script = modURL("__ext1");
+    capsCache = { ...capsCache, extension_views: [{ id: "demo", label: "Demo View", script }] };
+    extViews = capsCache.extension_views;
+    window.__ext1 = undefined;
+    syncExtNav();
+    const navItem = document.querySelector('.nav-item[data-route="ext-demo"]');
+    const navText = navItem ? navItem.textContent.trim() : null;
+    const known = isKnownRoute("ext-demo");
+
+    // 2) Navigate → the module mounts and render() runs with apiBase + api.
+    navigate("ext-demo");
+    await sleep(400);
+    const onRoute = location.pathname === "/ext-demo";
+    const mount = document.querySelector(".ext-view-mount");
+    const mountedText = mount ? mount.textContent : "";
+    const rendered = window.__ext1;
+    const navActive = navItem ? navItem.classList.contains("active") : false;
+
+    // 3) Server switch → the nav item is dropped and the now-unknown ext route
+    //    redirects to overview (unmount across a switch).
+    serverGen++;
+    extViews = [];
+    capsCache = { ...capsCache, extension_views: [] };
+    syncExtNav();
+    const navGone = !document.querySelector('.nav-item[data-route="ext-demo"]');
+    const redirected = routeFromLocation() === "overview";
+
+    // 4) Mid-import staleness: start a render, bump serverGen synchronously
+    //    (before the dynamic import resolves), and assert render() never runs.
+    extViews = [{ id: "demo2", label: "Demo Two", script: modURL("__ext2") }];
+    window.__ext2 = undefined;
+    const p = renderExtensionView(extViews[0]); // captures gen synchronously
+    serverGen++;                                // switch before the import settles
+    await p;
+    const staleAborted = window.__ext2 === undefined;
+
+    // Leave the UI on a known-good route for the final no-errors assertion.
+    navigate("overview");
+    return { navText, known, onRoute, mounted: !!mount, mountedText, rendered, navActive, navGone, redirected, staleAborted };
+  });
+  extv.navText === "Demo View" ? ok("ext-view: nav item injected with the provider label") : bad("ext-view: nav item injected with the provider label", `navText=${extv.navText}`);
+  extv.known ? ok("ext-view: isKnownRoute accepts a live ext-<id> route") : bad("ext-view: isKnownRoute accepts a live ext-<id> route", "ext-demo not known");
+  extv.onRoute ? ok("ext-view: navigate routes to /ext-<id>") : bad("ext-view: navigate routes to /ext-<id>", "wrong route");
+  extv.mounted ? ok("ext-view: a mount node is created") : bad("ext-view: a mount node is created", "no .ext-view-mount");
+  extv.rendered ? ok("ext-view: the module render() runs with {apiBase, api}") : bad("ext-view: the module render() runs with {apiBase, api}", `rendered=${extv.rendered}`);
+  /ext-content/.test(extv.mountedText) ? ok("ext-view: module content lands in the mount") : bad("ext-view: module content lands in the mount", `mountedText=${extv.mountedText}`);
+  extv.navActive ? ok("ext-view: the nav item is marked active on its route") : bad("ext-view: the nav item is marked active on its route", "not .active");
+  extv.navGone ? ok("ext-view: server switch removes the ext nav item (idempotent)") : bad("ext-view: server switch removes the ext nav item (idempotent)", "stale nav item remained");
+  extv.redirected ? ok("ext-view: an ext route the new server lacks redirects to overview") : bad("ext-view: an ext route the new server lacks redirects to overview", "did not redirect");
+  extv.staleAborted ? ok("ext-view: a server switch mid-import abandons the render (serverGen staleness)") : bad("ext-view: a server switch mid-import abandons the render (serverGen staleness)", "render ran after the switch");
+
+
   // No uncaught JS errors over the whole run.
   jsErrors.length === 0 ? ok("no uncaught JS errors") : bad("no uncaught JS errors", JSON.stringify(jsErrors));
 } catch (err) {


### PR DESCRIPTION
## What

Adds a generic **extension-view seam** for the web console: a build that imports
`consoleapp` and wraps the OSS core can inject **one additional console view** —
a nav item, a capability entry, an authenticated data API, and its own frontend
ES module — without forking the console. The stock binary ships no view.

It mirrors the existing `ext.ConsoleAuth` convention exactly: a process-global
package variable set once at startup, `nil`/no-op default in the OSS build.

## Why

The console already exposes a clean set of extension points (`ext.ConsoleAuth`,
`ext.RegisterSourceJob`, …) plus the `indexquery` read-plane facade. This adds
the one that was missing — a way for an embedding distribution to contribute a
whole additional **view** (frontend + data API) over the same index the operator
is looking at, reusing the console's auth, host guard, per-server resolution, and
RBAC posture rather than re-implementing them.

## Seam (`ext/consoleview.go`)

- `ConsoleViewProvider { ID, Label, Script, StaticHandler(prefix), DataHandler(prefix, resolve) }`
  plus `SetConsoleView` / `ConsoleView` (startup-only, nil default).
- `ConsoleQueryContext` — the per-request, per-selected-server index access the
  data handler receives: the selected server's index `*sql.DB`, the console's own
  cross-source `Fetch` (live MySQL + Parquet archives, merged, gap-aware, with
  RBAC redaction applied), and the selected registry entry's captured `SourceDSN`.
- `ConsoleQueryContextFunc` — resolves that context per request (DSN-scrubbed
  errors), mirroring the console's own bundle resolution.
- The `Fetch` field is typed with the sanctioned public `indexquery` read facade.

## Wiring (`internal/console`)

- Static assets mount **UNAUTHENTICATED** at `/ext/<id>/` (behind the host guard
  and security headers only — code always ships, like `app.js`; only data is
  gated).
- Data routes mount at `/api/ext/<id>/` on the inner token-middleware-wrapped mux
  and are wrapped in a **profile guard that refuses with 403 before the provider
  handler runs** whenever a profile is active — keyed on `profileActive` (any
  named profile, even one that resolved to zero deny/redact rules — the
  `--profile <typo>` state), so the raw `*sql.DB` handed to the provider can't be
  used to read `query_text`/`query_hash` a named profile withholds (a third-party
  handler can't be assumed to honor table-deny / column-redaction — same posture
  recover-cascade takes).
- `GET /api/capabilities` advertises the view (`extension_views: [{id,label,script}]`).
- The vanilla-JS SPA reveals a nav item + `ext-<id>` route that dynamically
  `import()`s the module and calls `render(mount, {apiBase, api})`, with
  `serverGen` staleness across server switches (nav is rebuilt idempotently; an
  `ext-<id>` route the newly-selected server lacks redirects to overview).

## Hardening

- **ID validation:** the provider id flows into a URL path segment *and* a DOM
  route, so it is constrained to `^[a-z0-9-]+$` and validated at mount time. An
  invalid id is **skipped (logged via `slog.Error`, not mounted)** rather than
  panicking the daemon or producing a broken/injectable route. `/api/capabilities`
  is gated on the same validation, so advertised and mounted views stay in
  lockstep.
- **CSP invariant:** the console still sets **no `Content-Security-Policy`**
  (verified: `securityHeaders` sets only `Referrer-Policy`,
  `X-Content-Type-Options`, `X-Frame-Options: DENY`). The dynamic `import()` and
  the module's same-origin `fetch()` rely on that; the invariant — that any future
  `script-src`/`connect-src` CSP must allow `'self'` or extension views go dark —
  is documented on `Script`'s doc comment. No CSP is added here.

## Refactor (breaks an import cycle)

Exposing the seam's `Fetch` with `indexquery` types created a real cycle:
`ext → indexquery → internal/cli → ext` (`internal/cli` imports `ext` for the
audit sink; `indexquery` imported `internal/cli` only for the shared DuckDB
tuning helpers). Confirmed empirically (`import cycle not allowed`).

Fix: the DuckDB tuning helpers moved from `internal/cli` into a dedicated leaf
package `internal/duckdbtuning` (deps: cobra + duckdbutil/parquetquery/query,
none import `ext`). `indexquery` repoints to it and no longer imports the command
layer. `internal/cli` keeps thin forwarders, so its command files and integration
tests are untouched. **`indexquery`'s public API is unchanged** — the three
wrappers remain, just repointed — so external consumers are unaffected.

## Tests

- `ext/consoleview_test.go`: nil default, `SetConsoleView`/`ConsoleView`
  round-trip, id-validation behavior, a compile-time pin on the `Fetch` signature.
- `internal/console/extview_test.go` (httptest, mirroring the existing ext-auth
  idioms): capabilities advertise-with / omit-without a provider; data route
  reachable with a bearer / 401 without; **403 under an active RBAC profile with
  the provider handler proven NOT to run**; **403 under a NAMED zero-rule profile
  (`profileActive` true, `rbacActive()` false — the `--profile <typo>` state)
  with the handler proven NOT to run and the view omitted from capabilities**;
  unauthenticated static reachable; route **absence** without a provider (404,
  like the retired-surface guard); invalid-id provider skipped (not mounted, no
  panic); host guard still rejects a domain Host on the new routes.
- The core UI-free decouple guard (`cliapp`) stays green — `ext` does not link
  `internal/console`.

## Render-check evidence

`assets/` changes need a real browser (httptest can't see CSS/DOM/state). I added
**Scenario 10** to `test/console-e2e/console_e2e.mjs` — the repo's existing
headless-Chrome harness — fixture-driving the extension-view wiring (nav
injection, module import + `render()` call, active state, idempotent nav removal
on server switch, unknown-route redirect, and mid-`import()` `serverGen`
staleness), consistent with how scenarios 7-9 unit-drive pure render functions.

**Transparency:** Docker's daemon was unreachable in the authoring environment,
so `run.sh`'s full harness (which uses `docker exec` against the test MySQL)
**did not execute there**. Scenario 10 is the durable artifact that runs under
`run.sh` where Docker exists. To actually verify the same logic in a real
browser, I ran an equivalent standalone static-server driver against
`internal/console/assets/` in headless system Chrome: **11/11 checks passed** (nav
label injected, `isKnownRoute` accepts `ext-<id>`, `/ext-<id>` mounts, module
`render({apiBase, api})` runs and its content lands in the mount, nav marked
active, server switch removes the nav item idempotently, unknown ext route
redirects to overview, mid-import switch abandons the render, no uncaught JS
errors).

## Verification

`gofmt` clean · `go build ./...` · `go vet -tags integration ./...` · `go test
./... -count=1` · integration for the touched packages (console/cli/indexquery/
duckdbtuning/ext) with the test MySQL up · UI-free decouple guard green · no CSP
confirmed.

## Review fixes

- **Gate the extension-view surface on `profileActive`, not `rbacActive()`.**
  `rbacViewGuard` and the capabilities advertisement previously keyed on
  `s.rbacActive()` (deny/redact rule count > 0), while the console's
  `query_text`/`query_hash` withholding boundary is `s.profileActive` (true for a
  named profile that resolved to **zero** rules — the `--profile <typo>` /
  empty-profile state). Those gates diverged exactly there: the guard passed, the
  view was advertised, and the seam handed the provider a raw `*sql.DB` a handler
  could use to `SELECT query_text, query_hash FROM binlog_events` directly —
  returning the SQL literals a named profile is contracted to withhold on
  `/api/events`. Both gates now key on `profileActive`, matching `consoleFetch`
  (which already set `Options.ProfileActive`). The change **widens** the refusal
  (`profileActive ⊇ rbacActive`), so the served path is unchanged. New test:
  `TestExtensionViewDataHandlerRefusedUnderZeroRuleProfile`.
- **Make the `capsCache.extension_views → extViews` wiring load-bearing.** Added
  an e2e step (Scenario 10) that drives the real `gateCapabilities()` against a
  stubbed `/api/capabilities`, so a one-sided property read/rename fails a test
  instead of silently disabling the nav item for real embedding builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

