### PR TITLE
console: serve the four read-only MCP tools at /mcp (Streamable HTTP, token auth, per-server routing)

### DIFF
--- a/cmd/bintrail-mcp/main.go
+++ b/cmd/bintrail-mcp/main.go
@@ -20,10 +20,14 @@
 //
 //	Set BINTRAIL_INDEX_DSN to the MySQL DSN for the index database,
 //	or pass index_dsn as a parameter on each tool call.
+//
+// The tool implementations live in internal/mcptools, shared with the
+// console's /mcp endpoint; this binary binds them to the standalone posture
+// (per-call DSN resolution, fresh connection per call, env-var archive
+// discovery, per-call profile parameter).
 package main
 
 import (
-	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -34,24 +38,13 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"strconv"
-	"strings"
 	"syscall"
-	"time"
 
-	mysqldriver "github.com/go-sql-driver/mysql"
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
-	"github.com/dbtrail/dbtrail/ext"
-	"github.com/dbtrail/dbtrail/internal/cliutil"
-	"github.com/dbtrail/dbtrail/internal/config"
-	"github.com/dbtrail/dbtrail/internal/indexer"
-	"github.com/dbtrail/dbtrail/internal/metadata"
-	"github.com/dbtrail/dbtrail/internal/parquetquery"
+	"github.com/dbtrail/dbtrail/internal/mcptools"
 	"github.com/dbtrail/dbtrail/internal/query"
-	"github.com/dbtrail/dbtrail/internal/recovery"
-	"github.com/dbtrail/dbtrail/internal/status"
 )
 
 // mcpVersion is injected at build time via -ldflags.
@@ -70,15 +63,6 @@ func newServer() *mcp.Server {
 // variable and tool-level index_dsn parameter. This is used in multi-tenant
 // mode where the gateway resolves the DSN from the X-Bintrail-Tenant header.
 func newServerWithDSN(dsnOverride string) *mcp.Server {
-	server := mcp.NewServer(&mcp.Implementation{
-		Name:    "bintrail",
-		Version: mcpVersion,
-	}, &mcp.ServerOptions{
-		Instructions: "Bintrail MCP server for querying indexed MySQL binlog events, " +
-			"generating recovery SQL, and viewing index status. " +
-			"Set BINTRAIL_INDEX_DSN environment variable or pass index_dsn on each tool call.",
-	})
-
 	// resolveFn picks the DSN: forced override > tool arg > env var.
 	resolveFn := func(argDSN string) (string, error) {
 		if dsnOverride != "" {
@@ -86,64 +70,21 @@ func newServerWithDSN(dsnOverride string) *mcp.Server {
 		}
 		return resolveDSN(argDSN)
 	}
-	connectFn := func(argDSN string) (*sql.DB, error) {
-		dsn, err := resolveFn(argDSN)
-		if err != nil {
-			return nil, err
-		}
-		return config.Connect(dsn)
+	return mcptools.NewServer(standaloneConfig(mcptools.DSNTarget(resolveFn)))
+}
+
+// standaloneConfig is the standalone-server tool posture: DSN and profile
+// parameters accepted, env-tunable query ceiling, uncapped recover limit.
+func standaloneConfig(resolve mcptools.ResolveTarget) mcptools.Config {
+	return mcptools.Config{
+		Version: mcpVersion,
+		Instructions: "Bintrail MCP server for querying indexed MySQL binlog events, " +
+			"generating recovery SQL, and viewing index status. " +
+			"Set BINTRAIL_INDEX_DSN environment variable or pass index_dsn on each tool call.",
+		Resolve:           resolve,
+		AllowDSNParam:     true,
+		AllowProfileParam: true,
 	}
-
-	mcp.AddTool(server, &mcp.Tool{
-		Name: "query",
-		Description: "Search indexed MySQL binlog events with filters. " +
-			"Returns matching events showing row changes (before/after images), timestamps, and metadata. " +
-			"Use json format for full row data or table format for a human-readable summary.",
-		Annotations: &mcp.ToolAnnotations{
-			Title:          "Search binlog events",
-			ReadOnlyHint:   true,
-			IdempotentHint: true,
-		},
-	}, makeQueryTool(connectFn))
-
-	mcp.AddTool(server, &mcp.Tool{
-		Name: "recover",
-		Description: "Generate reversal SQL to undo matching binlog events (dry-run only). " +
-			"Produces a BEGIN/COMMIT-wrapped SQL script that reverses events in reverse chronological order (most recent first): " +
-			"DELETE->INSERT, UPDATE->reverse UPDATE, INSERT->DELETE. " +
-			"Review carefully before applying to production.",
-		Annotations: &mcp.ToolAnnotations{
-			Title:          "Generate recovery SQL",
-			ReadOnlyHint:   true,
-			IdempotentHint: true,
-		},
-	}, makeRecoverTool(connectFn))
-
-	mcp.AddTool(server, &mcp.Tool{
-		Name: "status",
-		Description: "Show the current state of the binlog index: " +
-			"which files have been indexed, partition layout with estimated row counts, " +
-			"and aggregate summary of indexed events.",
-		Annotations: &mcp.ToolAnnotations{
-			Title:          "Index status",
-			ReadOnlyHint:   true,
-			IdempotentHint: true,
-		},
-	}, makeStatusTool(resolveFn))
-
-	mcp.AddTool(server, &mcp.Tool{
-		Name: "list_schema_changes",
-		Description: "List DDL schema changes (CREATE, ALTER, DROP, RENAME, TRUNCATE) " +
-			"recorded during binlog indexing or streaming. " +
-			"Returns the full DDL statement, binlog coordinates, and timestamp for each change.",
-		Annotations: &mcp.ToolAnnotations{
-			Title:          "List schema changes",
-			ReadOnlyHint:   true,
-			IdempotentHint: true,
-		},
-	}, makeSchemaChangesTool(connectFn))
-
-	return server
 }
 
 func main() {
@@ -262,56 +203,19 @@ func isClientDisconnect(err error) bool {
 	return errors.As(err, &wireErr) && wireErr.Code == errCodeServerClosing
 }
 
-// ─── Tool argument types ─────────────────────────────────────────────────────
+// ─── Compatibility shims over internal/mcptools ──────────────────────────────
+//
+// The tool argument types, handler factories, and helpers moved to
+// internal/mcptools (shared with the console's /mcp endpoint). The aliases
+// below keep this package's historical surface — exercised extensively by its
+// tests — identical, and pin the standalone posture the adapters bake in.
 
-type queryArgs struct {
-	IndexDSN      string   `json:"index_dsn,omitempty" jsonschema:"MySQL DSN for the index database. Overrides BINTRAIL_INDEX_DSN env var."`
-	Schema        string   `json:"schema,omitempty" jsonschema:"Filter by database schema name"`
-	Table         string   `json:"table,omitempty" jsonschema:"Filter by table name"`
-	PK            string   `json:"pk,omitempty" jsonschema:"Filter by primary key value (pipe-delimited for composite keys e.g. 123 or 123|2)"`
-	EventType     string   `json:"event_type,omitempty" jsonschema:"Filter by event type: INSERT UPDATE or DELETE"`
-	GTID          string   `json:"gtid,omitempty" jsonschema:"Filter by GTID (e.g. uuid:42)"`
-	Since         string   `json:"since,omitempty" jsonschema:"Filter events at or after this time (YYYY-MM-DD HH:MM:SS or RFC 3339)"`
-	Until         string   `json:"until,omitempty" jsonschema:"Filter events at or before this time (YYYY-MM-DD HH:MM:SS or RFC 3339)"`
-	ChangedColumn string   `json:"changed_column,omitempty" jsonschema:"Filter UPDATE events that modified this column"`
-	ColumnEq      []string `json:"column_eq,omitempty" jsonschema:"Filter events where a column in row_after or row_before equals the given value. Each entry is column=value. Repeat for AND. Literal NULL matches JSON null."`
-	Flag          string   `json:"flag,omitempty" jsonschema:"Filter events from tables or columns carrying this flag"`
-	Format        string   `json:"format,omitempty" jsonschema:"Output format: json table or csv (default: json)"`
-	Limit         int      `json:"limit,omitempty" jsonschema:"Maximum number of events to return (default: 100)"`
-	Profile       string   `json:"profile,omitempty" jsonschema:"Apply RBAC access rules for this profile (table-level deny and column-level redaction)"`
-	NoArchive     bool     `json:"no_archive,omitempty" jsonschema:"Disable auto-routing to Parquet archives (MySQL-only results)"`
-}
-
-type recoverArgs struct {
-	IndexDSN      string   `json:"index_dsn,omitempty" jsonschema:"MySQL DSN for the index database. Overrides BINTRAIL_INDEX_DSN env var."`
-	Schema        string   `json:"schema,omitempty" jsonschema:"Filter by database schema name"`
-	Table         string   `json:"table,omitempty" jsonschema:"Filter by table name"`
-	PK            string   `json:"pk,omitempty" jsonschema:"Filter by primary key value (pipe-delimited for composite keys)"`
-	EventType     string   `json:"event_type,omitempty" jsonschema:"Filter by event type: INSERT UPDATE or DELETE"`
-	GTID          string   `json:"gtid,omitempty" jsonschema:"Filter by GTID (e.g. uuid:42)"`
-	Since         string   `json:"since,omitempty" jsonschema:"Filter events at or after this time (YYYY-MM-DD HH:MM:SS or RFC 3339)"`
-	Until         string   `json:"until,omitempty" jsonschema:"Filter events at or before this time (YYYY-MM-DD HH:MM:SS or RFC 3339)"`
-	ChangedColumn string   `json:"changed_column,omitempty" jsonschema:"Filter UPDATE events that modified this column"`
-	ColumnEq      []string `json:"column_eq,omitempty" jsonschema:"Filter events where a column in row_after or row_before equals the given value. Each entry is column=value. Repeat for AND. Literal NULL matches JSON null."`
-	Flag          string   `json:"flag,omitempty" jsonschema:"Filter events from tables or columns carrying this flag"`
-	Limit         int      `json:"limit,omitempty" jsonschema:"Maximum number of events to reverse (default: 1000)"`
-	Profile       string   `json:"profile,omitempty" jsonschema:"Apply RBAC access rules for this profile (table-level deny and column-level redaction)"`
-	NoArchive     bool     `json:"no_archive,omitempty" jsonschema:"Disable auto-routing to Parquet archives (MySQL-only results)"`
-}
-
-type statusArgs struct {
-	IndexDSN string `json:"index_dsn,omitempty" jsonschema:"MySQL DSN for the index database. Overrides BINTRAIL_INDEX_DSN env var."`
-}
-
-type schemaChangesArgs struct {
-	IndexDSN string `json:"index_dsn,omitempty" jsonschema:"MySQL DSN for the index database. Overrides BINTRAIL_INDEX_DSN env var."`
-	Schema   string `json:"schema,omitempty" jsonschema:"Filter by database schema name"`
-	Table    string `json:"table,omitempty" jsonschema:"Filter by table name"`
-	DDLType  string `json:"ddl_type,omitempty" jsonschema:"Filter by DDL type: CREATE ALTER DROP RENAME or TRUNCATE"`
-	Since    string `json:"since,omitempty" jsonschema:"Filter changes at or after this time (YYYY-MM-DD HH:MM:SS or RFC 3339)"`
-	Until    string `json:"until,omitempty" jsonschema:"Filter changes at or before this time (YYYY-MM-DD HH:MM:SS or RFC 3339)"`
-	Limit    int    `json:"limit,omitempty" jsonschema:"Maximum number of changes to return (default: 100)"`
-}
+type (
+	queryArgs         = mcptools.QueryArgs
+	recoverArgs       = mcptools.RecoverArgs
+	statusArgs        = mcptools.StatusArgs
+	schemaChangesArgs = mcptools.SchemaChangesArgs
+)
 
 // connectFunc abstracts DSN resolution and DB connection for tool handlers.
 type connectFunc func(argDSN string) (*sql.DB, error)
@@ -319,413 +223,39 @@ type connectFunc func(argDSN string) (*sql.DB, error)
 // resolveFunc abstracts DSN resolution for handlers that need the raw DSN.
 type resolveFunc func(argDSN string) (string, error)
 
-// ─── Tool handler factories ──────────────────────────────────────────────────
-//
-// Each factory returns a closure that captures the DSN resolution function.
-// In single-tenant mode, the resolution falls through to the env var.
-// In multi-tenant mode, the DSN override is baked in at server creation time.
+// targetFromConnect adapts a connectFunc into the mcptools resolution seam
+// with the standalone posture: the call owns (and closes) the connection,
+// runs the idempotent schema migration, and consults the archive env vars.
+func targetFromConnect(connect connectFunc) mcptools.ResolveTarget {
+	return func(ctx context.Context, argDSN string) (*mcptools.Target, error) {
+		db, err := connect(argDSN)
+		if err != nil {
+			return nil, err
+		}
+		return &mcptools.Target{
+			DB:                  db,
+			CloseDB:             true,
+			EnsureSchema:        true,
+			EnvArchiveDiscovery: true,
+		}, nil
+	}
+}
 
 func makeQueryTool(connect connectFunc) func(context.Context, *mcp.CallToolRequest, queryArgs) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, args queryArgs) (*mcp.CallToolResult, any, error) {
-		db, err := connect(args.IndexDSN)
-		if err != nil {
-			return errorResult(err), nil, nil
-		}
-		defer db.Close()
-
-		// Same idempotent migration as the recover tool below: the query
-		// engine SELECTs post-initial-schema binlog_events columns
-		// (query_text/query_hash, #699) and the MCP server opens a fresh DB
-		// per tool call, so the migration has to run here.
-		if err := indexer.EnsureSchema(db); err != nil {
-			return errorResult(indexer.WrapSchemaMigrationErr(err)), nil, nil
-		}
-
-		opts, err := buildQueryOptions(args.Schema, args.Table, args.PK, args.EventType,
-			args.GTID, args.Since, args.Until, args.ChangedColumn, args.ColumnEq, args.Flag, args.Limit, 100)
-		if err != nil {
-			return errorResult(err), nil, nil
-		}
-
-		// Hard ceiling on an explicit, oversized limit (#654). buildQueryOptions
-		// already coerces limit<=0 to the default, so this only bounds a large
-		// EXPLICIT value an agent might pass. It is applied here, per-tool, on the
-		// local opts — NOT in the shared buildQueryOptions, because the recover
-		// tool must refuse on size, not silently cap a read.
-		ceiling := mcpQueryMaxLimit()
-		requestedLimit := opts.Limit
-		ceilingApplied := false
-		if c, did := applyQueryCeiling(opts.Limit, ceiling); did {
-			opts.Limit = c
-			ceilingApplied = true
-		}
-
-		if args.Profile != "" {
-			denyTables, redactCols, err := query.LoadProfileRules(ctx, db, args.Profile)
-			if err != nil {
-				return errorResult(fmt.Errorf("load profile rules: %w", err)), nil, nil
-			}
-			opts.DenyTables = denyTables
-			opts.RedactColumns = redactCols
-			opts.ProfileActive = true
-		}
-
-		format := args.Format
-		if format == "" {
-			format = "json"
-		}
-		if !cliutil.IsValidFormat(format) {
-			return errorResult(fmt.Errorf("invalid format %q; must be json, table, or csv", format)), nil, nil
-		}
-
-		engine := query.New(db)
-
-		// Skip archive auto-discovery when --no-archive is set or when RBAC
-		// profile is active (archive queries do not enforce rules).
-		var archSources []string
-		if !args.NoArchive && args.Profile == "" {
-			archSources = resolveArchiveSources(ctx, db)
-		}
-
-		var buf bytes.Buffer
-		var n int
-
-		if len(archSources) == 0 {
-			// Fast path: no archives, fetch and format in one step.
-			n, err = engine.Run(ctx, opts, format, &buf)
-			if err != nil {
-				return errorResult(err), nil, nil
-			}
-		} else {
-			// Fetch from live index + archives, merge, then format.
-			fetchOpts := opts
-			results, err := engine.Fetch(ctx, fetchOpts)
-			if err != nil {
-				return errorResult(err), nil, nil
-			}
-			for _, src := range archSources {
-				ar, err := parquetquery.Fetch(ctx, fetchOpts, src)
-				if err != nil {
-					slog.Warn("archive query failed, skipping", "source", src, "error", err)
-					continue
-				}
-				results = append(results, ar...)
-			}
-			results = query.MergeResults(results, opts.Limit, opts.Order)
-			n, err = query.Format(results, format, &buf)
-			if err != nil {
-				return errorResult(err), nil, nil
-			}
-		}
-
-		text := buf.String()
-		if n > 0 && format != "json" {
-			text += fmt.Sprintf("\n%d row(s)\n", n)
-		}
-		text += queryResultNotice(ceilingApplied, requestedLimit, ceiling, n, opts.Limit)
-
-		ext.Record(ctx, ext.AuditEvent{
-			Surface: "mcp",
-			Action:  "query.run",
-			Actor:   ext.ProcessActor(args.Profile),
-			Schema:  args.Schema,
-			Table:   args.Table,
-			Detail:  map[string]string{"results": strconv.Itoa(n), "format": format},
-		})
-
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				&mcp.TextContent{Text: text},
-			},
-		}, nil, nil
-	}
+	return mcptools.MakeQueryTool(standaloneConfig(targetFromConnect(connect)))
 }
 
 func makeRecoverTool(connect connectFunc) func(context.Context, *mcp.CallToolRequest, recoverArgs) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, args recoverArgs) (*mcp.CallToolResult, any, error) {
-		db, err := connect(args.IndexDSN)
-		if err != nil {
-			return errorResult(err), nil, nil
-		}
-		defer db.Close()
-
-		// Run the idempotent schema migration before NewResolver. Since
-		// #212 NewResolver reads schema_snapshots.column_type and fails on
-		// pre-migration databases with Error 1054. Other long-running
-		// commands call EnsureSchema at startup; the MCP server opens a
-		// fresh DB per tool call, so the migration has to run here.
-		if err := indexer.EnsureSchema(db); err != nil {
-			return errorResult(indexer.WrapSchemaMigrationErr(err)), nil, nil
-		}
-
-		defaultLimit := 1000
-		opts, err := buildQueryOptions(args.Schema, args.Table, args.PK, args.EventType,
-			args.GTID, args.Since, args.Until, args.ChangedColumn, args.ColumnEq, args.Flag, args.Limit, defaultLimit)
-		if err != nil {
-			return errorResult(err), nil, nil
-		}
-		// When --limit truncates the matched window it must keep the most
-		// RECENT events (#785/#927): the ASC default would keep the OLDEST
-		// prefix, undoing old events underneath later un-reverted ones — a
-		// state that never historically existed. Rows are re-sorted ascending
-		// after the fetch, before generation (see below).
-		opts.Order = "DESC"
-
-		if args.Profile != "" {
-			denyTables, redactCols, err := query.LoadProfileRules(ctx, db, args.Profile)
-			if err != nil {
-				return errorResult(fmt.Errorf("load profile rules: %w", err)), nil, nil
-			}
-			opts.DenyTables = denyTables
-			opts.RedactColumns = redactCols
-			opts.ProfileActive = true
-		}
-
-		// Load schema resolver best-effort for PK-only WHERE clauses.
-		resolver, resolverErr := metadata.NewResolver(db, 0)
-		if resolverErr != nil {
-			resolver = nil
-		}
-
-		// Fetch events from live index + archives.
-		// Skip archive auto-discovery when --no-archive is set or when RBAC
-		// profile is active (archive queries do not enforce rules).
-		engine := query.New(db)
-		var archSources []string
-		if !args.NoArchive && args.Profile == "" {
-			archSources = resolveArchiveSources(ctx, db)
-		}
-
-		var rows []query.ResultRow
-		if len(archSources) > 0 {
-			fetchOpts := opts
-			rows, err = engine.Fetch(ctx, fetchOpts)
-			if err != nil {
-				return errorResult(err), nil, nil
-			}
-			for _, src := range archSources {
-				ar, err := parquetquery.Fetch(ctx, fetchOpts, src)
-				if err != nil {
-					slog.Warn("archive query failed, skipping", "source", src, "error", err)
-					continue
-				}
-				rows = append(rows, ar...)
-			}
-			rows = query.MergeResults(rows, opts.Limit, opts.Order)
-		} else {
-			rows, err = engine.Fetch(ctx, opts)
-			if err != nil {
-				return errorResult(err), nil, nil
-			}
-		}
-
-		// The fetch above ran Order=DESC so --limit kept the newest suffix of
-		// the window (#785/#927). Restore ascending order: GenerateSQLFromRows
-		// expects ASC input and reverses it internally to undo most-recent
-		// first.
-		rows = query.MergeResults(rows, 0, "ASC")
-
-		gen := recovery.NewForDialect(db, resolver, recovery.DialectForIndex(db))
-		var buf bytes.Buffer
-		n, err := gen.GenerateSQLFromRows(rows, &buf)
-		if err != nil {
-			return errorResult(err), nil, nil
-		}
-
-		text := buf.String()
-		if resolverErr != nil {
-			text += fmt.Sprintf("\n-- Note: schema snapshot unavailable (%v); WHERE clauses use all columns.\n", resolverErr)
-		}
-		if n > 0 {
-			text += fmt.Sprintf("\n-- %d reversal statement(s) generated.\n", n)
-		}
-		if n >= opts.Limit {
-			text += fmt.Sprintf("\n-- Warning: results truncated at %d rows. Use a narrower since/until range or increase the limit to see more.\n", opts.Limit)
-		}
-
-		ext.Record(ctx, ext.AuditEvent{
-			Surface: "mcp",
-			Action:  "recover.generate",
-			Actor:   ext.ProcessActor(args.Profile),
-			Schema:  args.Schema,
-			Table:   args.Table,
-			Detail: map[string]string{
-				"statements": strconv.Itoa(n),
-				"dry_run":    "true", // MCP recover always returns the script, never applies it
-				"gtid":       args.GTID,
-			},
-		})
-
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				&mcp.TextContent{Text: text},
-			},
-		}, nil, nil
-	}
+	return mcptools.MakeRecoverTool(standaloneConfig(targetFromConnect(connect)))
 }
 
 func makeStatusTool(resolve resolveFunc) func(context.Context, *mcp.CallToolRequest, statusArgs) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, args statusArgs) (*mcp.CallToolResult, any, error) {
-		dsn, err := resolve(args.IndexDSN)
-		if err != nil {
-			return errorResult(err), nil, nil
-		}
-
-		cfg, err := mysqldriver.ParseDSN(dsn)
-		if err != nil {
-			return errorResult(fmt.Errorf("invalid DSN: %w", err)), nil, nil
-		}
-		dbName := cfg.DBName
-		if dbName == "" {
-			return errorResult(fmt.Errorf("DSN must include a database name")), nil, nil
-		}
-
-		db, err := config.Connect(dsn)
-		if err != nil {
-			return errorResult(fmt.Errorf("failed to connect: %w", err)), nil, nil
-		}
-		defer db.Close()
-
-		data, err := status.CollectStatus(ctx, db, dbName)
-		if err != nil {
-			return errorResult(err), nil, nil
-		}
-
-		var buf bytes.Buffer
-		data.Write(&buf)
-
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				&mcp.TextContent{Text: buf.String()},
-			},
-		}, nil, nil
-	}
+	return mcptools.MakeStatusTool(standaloneConfig(mcptools.DSNTarget(resolve)))
 }
 
 func makeSchemaChangesTool(connect connectFunc) func(context.Context, *mcp.CallToolRequest, schemaChangesArgs) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, args schemaChangesArgs) (*mcp.CallToolResult, any, error) {
-		// Validate inputs before connecting.
-		sinceT, err := cliutil.ParseTime(args.Since)
-		if err != nil {
-			return errorResult(fmt.Errorf("invalid since: %w", err)), nil, nil
-		}
-		untilT, err := cliutil.ParseTime(args.Until)
-		if err != nil {
-			return errorResult(fmt.Errorf("invalid until: %w", err)), nil, nil
-		}
-
-		if args.DDLType != "" {
-			upper := strings.ToUpper(args.DDLType)
-			switch upper {
-			case "CREATE", "ALTER", "DROP", "RENAME", "TRUNCATE":
-				// valid
-			default:
-				return errorResult(fmt.Errorf("invalid ddl_type %q; must be CREATE, ALTER, DROP, RENAME, or TRUNCATE", args.DDLType)), nil, nil
-			}
-		}
-
-		limit := args.Limit
-		if limit <= 0 {
-			limit = 100
-		}
-
-		db, err := connect(args.IndexDSN)
-		if err != nil {
-			return errorResult(err), nil, nil
-		}
-		defer db.Close()
-
-		q := "SELECT id, detected_at, schema_name, table_name, ddl_type, ddl_query, binlog_file, binlog_pos, gtid FROM schema_changes WHERE 1=1"
-		var params []any
-
-		if args.Schema != "" {
-			q += " AND schema_name = ?"
-			params = append(params, args.Schema)
-		}
-		if args.Table != "" {
-			q += " AND table_name = ?"
-			params = append(params, args.Table)
-		}
-		if args.DDLType != "" {
-			// Match prefix: "ALTER" matches "ALTER TABLE", etc.
-			q += " AND ddl_type LIKE ?"
-			params = append(params, strings.ToUpper(args.DDLType)+"%")
-		}
-		if sinceT != nil {
-			q += " AND detected_at >= ?"
-			params = append(params, *sinceT)
-		}
-		if untilT != nil {
-			q += " AND detected_at <= ?"
-			params = append(params, *untilT)
-		}
-		q += " ORDER BY detected_at DESC LIMIT ?"
-		params = append(params, limit)
-
-		rows, err := db.QueryContext(ctx, q, params...)
-		if err != nil {
-			if strings.Contains(err.Error(), "doesn't exist") || strings.Contains(err.Error(), "1146") {
-				return errorResult(fmt.Errorf("schema_changes table not found; run `bintrail init` to create it")), nil, nil
-			}
-			return errorResult(fmt.Errorf("query schema_changes: %w", err)), nil, nil
-		}
-		defer rows.Close()
-
-		type schemaChange struct {
-			ID         int64  `json:"id"`
-			DetectedAt string `json:"detected_at"`
-			Schema     string `json:"schema_name"`
-			Table      string `json:"table_name"`
-			DDLType    string `json:"ddl_type"`
-			Statement  string `json:"statement"`
-			BinlogFile string `json:"binlog_file"`
-			BinlogPos  int64  `json:"binlog_pos"`
-			GTID       string `json:"gtid,omitempty"`
-		}
-
-		var results []schemaChange
-		for rows.Next() {
-			var sc schemaChange
-			var detectedAt time.Time
-			var gtid sql.NullString
-			if err := rows.Scan(&sc.ID, &detectedAt, &sc.Schema, &sc.Table, &sc.DDLType, &sc.Statement, &sc.BinlogFile, &sc.BinlogPos, &gtid); err != nil {
-				return errorResult(fmt.Errorf("scan: %w", err)), nil, nil
-			}
-			sc.DetectedAt = detectedAt.UTC().Format("2006-01-02 15:04:05")
-			if gtid.Valid {
-				sc.GTID = gtid.String
-			}
-			results = append(results, sc)
-		}
-		if err := rows.Err(); err != nil {
-			return errorResult(fmt.Errorf("rows iteration: %w", err)), nil, nil
-		}
-
-		out, err := json.MarshalIndent(results, "", "  ")
-		if err != nil {
-			return errorResult(fmt.Errorf("marshal: %w", err)), nil, nil
-		}
-
-		text := string(out)
-		n := len(results)
-		if n > 0 {
-			text += fmt.Sprintf("\n\n%d schema change(s)", n)
-		} else {
-			text = "No schema changes found."
-		}
-		if n >= limit {
-			text += fmt.Sprintf("\nWarning: results truncated at %d rows. Use a narrower since/until range or increase the limit to see more.", limit)
-		}
-
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				&mcp.TextContent{Text: text},
-			},
-		}, nil, nil
-	}
+	return mcptools.MakeSchemaChangesTool(standaloneConfig(targetFromConnect(connect)))
 }
-
-// ─── Shared helpers ──────────────────────────────────────────────────────────
 
 func resolveDSN(override string) (string, error) {
 	if override != "" {
@@ -738,130 +268,24 @@ func resolveDSN(override string) (string, error) {
 	return dsn, nil
 }
 
-func errorResult(err error) *mcp.CallToolResult {
-	return &mcp.CallToolResult{
-		Content: []mcp.Content{
-			&mcp.TextContent{Text: err.Error()},
-		},
-		IsError: true,
-	}
-}
+func errorResult(err error) *mcp.CallToolResult { return mcptools.ErrorResult(err) }
 
-// resolveArchiveSources returns Parquet archive source paths for use with
-// parquetquery.Fetch. It checks env vars BINTRAIL_ARCHIVE_S3 + BINTRAIL_ID
-// first (for explicit configuration — both must be set), then falls back to
-// auto-discovery from archive_state in the index database.
 func resolveArchiveSources(ctx context.Context, db *sql.DB) []string {
-	archiveS3 := os.Getenv("BINTRAIL_ARCHIVE_S3")
-	bintrailID := os.Getenv("BINTRAIL_ID")
-	if archiveS3 != "" && bintrailID != "" {
-		base := strings.TrimSuffix(archiveS3, "/") + "/bintrail_id=" + bintrailID
-		return []string{base}
-	}
-	if archiveS3 != "" || bintrailID != "" {
-		slog.Warn("partial archive env var config; both BINTRAIL_ARCHIVE_S3 and BINTRAIL_ID must be set",
-			"BINTRAIL_ARCHIVE_S3", archiveS3, "BINTRAIL_ID", bintrailID)
-	}
-
-	sources, err := query.ResolveArchiveSources(ctx, db)
-	if err != nil {
-		// The MCP tools are deliberately permissive (their own per-source
-		// fetch loops warn-and-continue too) — log and serve without
-		// archives rather than failing the tool call.
-		slog.Warn("archive auto-discovery failed; proceeding without archives", "error", err)
-		return nil
-	}
-	return sources
+	return mcptools.EnvArchiveSources(ctx, db)
 }
 
-// defaultMCPQueryMaxLimit is the hard row ceiling for the MCP query tool (#654):
-// a backstop against a pathological explicit limit OOMing the long-lived server.
-// ~1M rows is multiple GB worst-case at the project's per-row sizing — far above
-// any legitimate agent query, yet bounded. The unbounded escape hatch is the
-// `bintrail query` CLI, so this is deliberately not disengageable via env.
-const defaultMCPQueryMaxLimit = 1_000_000
+const defaultMCPQueryMaxLimit = mcptools.DefaultQueryMaxLimit
 
-// mcpQueryMaxLimit returns the MCP query-tool row ceiling. BINTRAIL_MCP_QUERY_MAX_LIMIT
-// raises or lowers it; an empty/invalid/<=0 value falls back to the default
-// rather than disabling the ceiling (the CLI is the unbounded path, not the
-// agent-facing tool).
-func mcpQueryMaxLimit() int {
-	if v := os.Getenv("BINTRAIL_MCP_QUERY_MAX_LIMIT"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n > 0 {
-			return n
-		}
-	}
-	return defaultMCPQueryMaxLimit
-}
+func mcpQueryMaxLimit() int { return mcptools.EnvQueryMaxLimit() }
 
-// applyQueryCeiling caps limit to max, returning the (possibly capped) limit and
-// whether a cap was applied. max <= 0 disables capping.
 func applyQueryCeiling(limit, max int) (int, bool) {
-	if max > 0 && limit > max {
-		return max, true
-	}
-	return limit, false
+	return mcptools.ApplyQueryCeiling(limit, max)
 }
 
-// queryResultNotice composes the trailing warning appended to a query-tool
-// result. When the ceiling fired it SUPERSEDES the generic truncation notice —
-// telling an agent to "increase the limit" would be wrong, since the limit it
-// asked for is exactly the one that was capped (and after a cap n == limit makes
-// the generic arm true too, so order matters). Returns "" when no notice applies.
 func queryResultNotice(ceilingApplied bool, requestedLimit, ceiling, n, limit int) string {
-	switch {
-	case ceilingApplied:
-		return fmt.Sprintf("\nWarning: requested limit %d exceeds the MCP query ceiling of %d rows; capped to %d. "+
-			"Narrow your filters/time range, or run the `bintrail query` CLI for an unbounded export.\n", requestedLimit, ceiling, ceiling)
-	case n >= limit:
-		return fmt.Sprintf("\nWarning: results truncated at %d rows. Use a narrower since/until range or increase the limit to see more.\n", limit)
-	}
-	return ""
+	return mcptools.QueryResultNotice(ceilingApplied, requestedLimit, ceiling, n, limit)
 }
 
 func buildQueryOptions(schema, table, pk, eventType, gtid, since, until, changedCol string, columnEq []string, flagVal string, limit, defaultLimit int) (query.Options, error) {
-	if pk != "" && (schema == "" || table == "") {
-		return query.Options{}, fmt.Errorf("pk requires both schema and table")
-	}
-	if changedCol != "" && (schema == "" || table == "") {
-		return query.Options{}, fmt.Errorf("changed_column requires both schema and table")
-	}
-	if len(columnEq) > 0 && (schema == "" || table == "") {
-		return query.Options{}, fmt.Errorf("column_eq requires both schema and table")
-	}
-
-	et, err := cliutil.ParseEventType(eventType)
-	if err != nil {
-		return query.Options{}, err
-	}
-	sinceT, err := cliutil.ParseTime(since)
-	if err != nil {
-		return query.Options{}, fmt.Errorf("invalid since: %w", err)
-	}
-	untilT, err := cliutil.ParseTime(until)
-	if err != nil {
-		return query.Options{}, fmt.Errorf("invalid until: %w", err)
-	}
-	parsedEq, err := query.ParseColumnEqs(columnEq)
-	if err != nil {
-		return query.Options{}, err
-	}
-
-	if limit <= 0 {
-		limit = defaultLimit
-	}
-
-	return query.Options{
-		Schema:        schema,
-		Table:         table,
-		PKValues:      pk,
-		EventType:     et,
-		GTID:          gtid,
-		Since:         sinceT,
-		Until:         untilT,
-		ChangedColumn: changedCol,
-		ColumnEq:      parsedEq,
-		Flag:          flagVal,
-		Limit:         limit,
-	}, nil
+	return mcptools.BuildQueryOptions(schema, table, pk, eventType, gtid, since, until, changedCol, columnEq, flagVal, limit, defaultLimit)
 }

--- a/docs/console.md
+++ b/docs/console.md
@@ -631,6 +631,55 @@ per server as `source` in [`/api/capabilities`](#api), derived from
   **probe failing** with the reason rather than disappearing. For an on-demand,
   always-live check, use `bintrail-pg doctor`.
 
+## MCP endpoint
+
+The console serves the same four read-only MCP tools as
+[`bintrail-mcp`](mcp-server.md) — `query`, `recover`, `status`,
+`list_schema_changes` — over **Streamable HTTP**, on both `bintrail-console
+serve` and `bintrail-console watch`:
+
+| URL | Target |
+|---|---|
+| `/mcp` | The console's **default server** (same selection rules as the browser UI). |
+| `/mcp/{id-or-name}` | A named server from the registry (`default` = the command-line entry). Unknown → `404`. |
+
+MCP clients cannot reliably send custom headers, so the server choice lives in
+the URL path (mirroring how the [time-travel port](time-travel-sql.md) routes
+by username) instead of the `X-Bintrail-Server` header.
+
+Point any Streamable-HTTP-capable MCP client at it with the console token as a
+Bearer credential:
+
+```json
+{
+  "mcpServers": {
+    "bintrail-console": {
+      "type": "http",
+      "url": "http://127.0.0.1:8090/mcp",
+      "headers": { "Authorization": "Bearer <console token>" }
+    }
+  }
+}
+```
+
+Rules that differ from the standalone `bintrail-mcp` server:
+
+- **A static token is required.** Like the time-travel port, `/mcp` needs
+  `--token` / `BINTRAIL_CONSOLE_TOKEN`: password login is a browser credential
+  and cannot authenticate a headless MCP client. Without a configured token
+  the endpoint refuses every request with an actionable error.
+- **`index_dsn` and `profile` tool parameters are rejected.** Connections are
+  managed in the console (registry + path routing), and the RBAC posture is
+  fixed by the console process — an authenticated MCP client cannot point the
+  console at an arbitrary DSN or change redaction rules.
+- **The console's read boundary applies.** Result caps match the API (events
+  100 default / 1000 max, recover 1000 / 10000), each server's archive and
+  baseline posture is honored, and `query_text` / `query_hash` are withheld
+  from query results exactly as on the events API.
+
+The host-header allowlist (`--allowed-hosts`) covers `/mcp` like every other
+route.
+
 ## API
 
 All endpoints return JSON. `/api/*` (except `healthz`) require

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -120,6 +120,11 @@ mobile; tokens refresh automatically.
 
 All four are read-only — annotated `ReadOnlyHint: true` and `IdempotentHint: true`,
 so the client knows they're safe to call repeatedly and never modify state.
+
+The same four tools are also served by the web console at `/mcp` (Streamable
+HTTP, console-token auth, per-server routing by URL path) — if you already run
+`bintrail-console`, you may not need this binary at all; see
+[console.md](console.md#mcp-endpoint).
 `list_schema_changes` accepts `schema`, `table`, `ddl_type`
 (`CREATE`/`ALTER`/`DROP`/`RENAME`/`TRUNCATE`, prefix-matched so `ALTER` matches
 `ALTER TABLE`), `since`, `until`, and `limit` (default 100); results come back

--- a/internal/console/mcp.go
+++ b/internal/console/mcp.go
@@ -1,0 +1,137 @@
+package console
+
+import (
+	"context"
+	"crypto/subtle"
+	"net/http"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/dbtrail/dbtrail/internal/mcptools"
+)
+
+// The console serves the four read-only MCP tools (query, recover, status,
+// list_schema_changes) over Streamable HTTP (#1039):
+//
+//	/mcp                → the default server (same selection rules as the
+//	                      rest of the console, including HideBoot semantics)
+//	/mcp/{id-or-name}   → that registry server ("default" = the boot entry)
+//
+// MCP clients cannot reliably send custom headers, so the server choice lives
+// in the URL path — mirroring how the flashback port routes by connection
+// username — instead of the X-Bintrail-Server header the browser API uses.
+//
+// Auth: the static console token as a Bearer credential, compared in constant
+// time. Like the flashback port, the endpoint requires a token to be
+// CONFIGURED — login sessions are a browser credential and the bcrypt
+// password store cannot authenticate a headless MCP client — so under
+// password-only or no auth the endpoint refuses with an actionable error.
+// The host-header allowlist and security headers apply like every route
+// (the handler is mounted on the guarded root mux).
+//
+// Read boundary: tool calls resolve the per-server connManager bundle at call
+// time, so the bundle's posture applies exactly as on the API — per-server
+// no-archive (which already folds in the process RBAC profile), the
+// process-global deny/redact rules, and the console result caps (events
+// 100/1000, recover 1000/10000). query_text/query_hash are withheld from
+// query results to match the events API's eventDTO, and the index_dsn /
+// profile tool parameters are rejected: an authenticated MCP client must not
+// point the console at an arbitrary DSN or vary the process's RBAC posture.
+func (s *Server) mcpHandler() http.Handler {
+	streamable := mcp.NewStreamableHTTPHandler(
+		func(r *http.Request) *mcp.Server {
+			// The selector was validated before delegation; a race with a
+			// registry delete surfaces as ErrUnknownServer on the tool call.
+			id, _ := s.mcpServerID(r.PathValue("server"))
+			return s.newMCPServer(id)
+		},
+		nil,
+	)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if s.token == "" {
+			// Mirror the flashback-port precedent: no static token configured
+			// means MCP clients have no credential that could authenticate
+			// them — refuse with the remediation, never serve open.
+			writeJSONError(w, http.StatusForbidden,
+				"the MCP endpoint requires a static console token: start with --token / BINTRAIL_CONSOLE_TOKEN "+
+					"(password login is a browser credential and cannot authenticate MCP clients)")
+			return
+		}
+		got := bearerToken(r)
+		if got == "" || subtle.ConstantTimeCompare([]byte(got), []byte(s.token)) != 1 {
+			writeJSONError(w, http.StatusUnauthorized, "unauthorized: missing or invalid token")
+			return
+		}
+		if _, ok := s.mcpServerID(r.PathValue("server")); !ok {
+			writeJSONError(w, http.StatusNotFound,
+				"unknown server: use /mcp for the default server, or /mcp/{id-or-name} for a server from the console registry")
+			return
+		}
+		streamable.ServeHTTP(w, r)
+	})
+}
+
+// mcpServerID maps the /mcp/{server} path selector to the canonical
+// connManager id, reporting whether it names a selectable server. The empty
+// selector (the bare /mcp endpoint) resolves like a header-less API request —
+// the console default, falling back to a hidden boot bundle — and is valid
+// whenever any server exists at all. Non-empty selectors accept a registry
+// id, a registry display name, or "default" for the boot entry, exactly like
+// the flashback port's username routing.
+func (s *Server) mcpServerID(selector string) (string, bool) {
+	if selector == "" {
+		if s.cm.defaultID() != "" {
+			return "", true
+		}
+		// Source-less watch with an empty registry: no default id, but
+		// Resolve("") still lands on the hidden boot bundle.
+		if b, _ := s.cm.bootInfo(); b != nil {
+			return "", true
+		}
+		return "", false
+	}
+	return s.flashbackTarget(selector)
+}
+
+// newMCPServer builds the per-session MCP server bound to one console server
+// selection. The bundle is resolved per tool call (lazily opening registry
+// connections, exactly like the API), so a server edited or added mid-session
+// behaves the same as on every other console surface.
+func (s *Server) newMCPServer(id string) *mcp.Server {
+	return mcptools.NewServer(mcptools.Config{
+		Version: "console",
+		Instructions: "Bintrail console MCP endpoint for querying indexed binlog events, " +
+			"generating recovery SQL, and viewing index status. " +
+			"The target server is chosen by URL path: /mcp for the console's default server, " +
+			"/mcp/{id-or-name} for a named server from the console registry.",
+		Resolve: func(ctx context.Context, _ string) (*mcptools.Target, error) {
+			b, err := s.cm.Resolve(ctx, id)
+			if err != nil {
+				return nil, err
+			}
+			return &mcptools.Target{
+				DB:     b.db,
+				DBName: b.dbName,
+				// The connection is owned by the connManager; never closed
+				// per call, never schema-migrated (registry servers are
+				// deliberately not EnsureSchema'd — the console's read-only
+				// contract confines DDL to the command-line DSN).
+				CloseDB:             false,
+				EnsureSchema:        false,
+				NoArchive:           b.noArchive,
+				EnvArchiveDiscovery: false,
+				DenyTables:          s.denyTables,
+				RedactColumns:       s.redactCols,
+				ProfileActive:       s.profileActive,
+				Resolver:            b.resolver,
+				ResolverLoaded:      true,
+				RedactStatementText: true,
+			}, nil
+		},
+		AllowDSNParam:     false,
+		AllowProfileParam: false,
+		QueryMaxLimit:     func() int { return eventsMaxLimit },
+		RecoverMaxLimit:   recoverMaxLimit,
+		AuditSurface:      "console-mcp",
+	})
+}

--- a/internal/console/mcp_integration_test.go
+++ b/internal/console/mcp_integration_test.go
@@ -1,0 +1,232 @@
+//go:build integration
+
+package console
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// bearerTransport injects the console token into every MCP HTTP request.
+type bearerTransport struct{ token string }
+
+func (b bearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	req.Header.Set("Authorization", "Bearer "+b.token)
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+// mcpConnect opens a real Streamable HTTP MCP session against endpoint.
+func mcpConnect(t *testing.T, endpoint, token string) *mcp.ClientSession {
+	t.Helper()
+	client := mcp.NewClient(&mcp.Implementation{Name: "it", Version: "1"}, nil)
+	session, err := client.Connect(context.Background(), &mcp.StreamableClientTransport{
+		Endpoint:   endpoint,
+		HTTPClient: &http.Client{Transport: bearerTransport{token}},
+	}, nil)
+	if err != nil {
+		t.Fatalf("MCP client Connect: %v", err)
+	}
+	t.Cleanup(func() { session.Close() })
+	return session
+}
+
+func mcpToolText(t *testing.T, res *mcp.CallToolResult) string {
+	t.Helper()
+	if len(res.Content) == 0 {
+		return ""
+	}
+	tc, ok := res.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("expected *mcp.TextContent, got %T", res.Content[0])
+	}
+	return tc.Text
+}
+
+// seedMCPConsole seeds an index with an INSERT+UPDATE on app.users pk=1,
+// stamps captured statement text on every event (the redaction subject), and
+// returns a token-authenticated console over it.
+func seedMCPConsole(t *testing.T) (*Server, *sql.DB, string) {
+	t.Helper()
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	testutil.InsertEvent(t, db, "bin.000001", 4, 40, "2026-06-01 12:00:00", nil,
+		"app", "users", 1 /*INSERT*/, "1",
+		nil, nil, []byte(`{"id":1,"name":"alice"}`))
+	testutil.InsertEvent(t, db, "bin.000001", 40, 80, "2026-06-01 12:05:00", nil,
+		"app", "users", 2 /*UPDATE*/, "1",
+		[]byte(`["name"]`), []byte(`{"id":1,"name":"alice"}`), []byte(`{"id":1,"name":"alicia"}`))
+
+	// Captured statement text — present in the index, redacted by the console
+	// read boundary (the events API's eventDTO omits it, #699).
+	if _, err := db.Exec(`UPDATE binlog_events SET query_text = 'UPDATE users SET name = ''SECRET_LITERAL''', query_hash = 'cafe0199'`); err != nil {
+		t.Fatalf("stamp query_text: %v", err)
+	}
+
+	srv, err := New(Config{
+		DB:        db,
+		DBName:    dbName,
+		Listen:    "127.0.0.1:8090",
+		Token:     intToken,
+		NoArchive: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return srv, db, dbName
+}
+
+func TestIntegrationMCPEndpoint(t *testing.T) {
+	srv, _, _ := seedMCPConsole(t)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+	ctx := context.Background()
+
+	session := mcpConnect(t, ts.URL+"/mcp", intToken)
+
+	// Tool listing: exactly the four read-only tools.
+	tools, err := session.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	names := map[string]bool{}
+	for _, tool := range tools.Tools {
+		names[tool.Name] = true
+	}
+	for _, want := range []string{"query", "recover", "status", "list_schema_changes"} {
+		if !names[want] {
+			t.Errorf("tool %q not listed; got %v", want, names)
+		}
+	}
+	if len(tools.Tools) != 4 {
+		t.Errorf("expected 4 tools, got %d", len(tools.Tools))
+	}
+
+	// Query round-trip: both events come back, statement text does not.
+	res, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "query",
+		Arguments: map[string]any{"schema": "app", "table": "users"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool query: %v", err)
+	}
+	text := mcpToolText(t, res)
+	if res.IsError {
+		t.Fatalf("query IsError: %s", text)
+	}
+	if !strings.Contains(text, "alicia") {
+		t.Errorf("query result missing row data: %s", text)
+	}
+	if strings.Contains(text, "SECRET_LITERAL") || strings.Contains(text, "cafe0199") {
+		t.Errorf("query result leaks statement text the console API redacts: %s", text)
+	}
+
+	// index_dsn is rejected: the console routes connections itself.
+	res, err = session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "query",
+		Arguments: map[string]any{"index_dsn": "u:p@tcp(127.0.0.1:13306)/other"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool query(index_dsn): %v", err)
+	}
+	if !res.IsError || !strings.Contains(mcpToolText(t, res), "index_dsn is not accepted") {
+		t.Errorf("index_dsn must be rejected, got: %s", mcpToolText(t, res))
+	}
+
+	// The console events cap (1000) applies as the query ceiling.
+	res, err = session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "query",
+		Arguments: map[string]any{"schema": "app", "table": "users", "limit": 5000},
+	})
+	if err != nil {
+		t.Fatalf("CallTool query(limit): %v", err)
+	}
+	if !strings.Contains(mcpToolText(t, res), "ceiling of 1000") {
+		t.Errorf("oversized limit must be capped at the console events cap: %s", mcpToolText(t, res))
+	}
+
+	// Recover round-trip: reversal SQL for the UPDATE restores "alice".
+	res, err = session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "recover",
+		Arguments: map[string]any{"schema": "app", "table": "users", "pk": "1"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool recover: %v", err)
+	}
+	text = mcpToolText(t, res)
+	if res.IsError {
+		t.Fatalf("recover IsError: %s", text)
+	}
+	if !strings.Contains(text, "alice") {
+		t.Errorf("recover script missing reversal data: %s", text)
+	}
+
+	// Status round-trip.
+	res, err = session.CallTool(ctx, &mcp.CallToolParams{Name: "status", Arguments: map[string]any{}})
+	if err != nil {
+		t.Fatalf("CallTool status: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("status IsError: %s", mcpToolText(t, res))
+	}
+	if mcpToolText(t, res) == "" {
+		t.Error("status returned empty text")
+	}
+}
+
+func TestIntegrationMCPWrongTokenRefused(t *testing.T) {
+	srv, _, _ := seedMCPConsole(t)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "it", Version: "1"}, nil)
+	session, err := client.Connect(context.Background(), &mcp.StreamableClientTransport{
+		Endpoint:   ts.URL + "/mcp",
+		HTTPClient: &http.Client{Transport: bearerTransport{"not-the-token"}},
+	}, nil)
+	if err == nil {
+		session.Close()
+		t.Fatal("MCP connect with a wrong token must fail")
+	}
+}
+
+func TestIntegrationMCPRoutesByServerName(t *testing.T) {
+	srv, _, dbName := seedMCPConsole(t)
+	reg, err := LoadRegistry("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := reg.Add(ServerEntry{Name: "reg-target", DSN: testutil.SnapshotDSN(dbName), NoArchive: true}); err != nil {
+		t.Fatal(err)
+	}
+	// Rebuild the console over the registry (same index behind both names).
+	srv.cm.reg = reg
+
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+	ctx := context.Background()
+
+	session := mcpConnect(t, ts.URL+"/mcp/reg-target", intToken)
+	res, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "query",
+		Arguments: map[string]any{"schema": "app", "table": "users"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool via /mcp/reg-target: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("query via named server IsError: %s", mcpToolText(t, res))
+	}
+	if !strings.Contains(mcpToolText(t, res), "alicia") {
+		t.Errorf("named-server query missing row data: %s", mcpToolText(t, res))
+	}
+}

--- a/internal/console/mcp_integration_test.go
+++ b/internal/console/mcp_integration_test.go
@@ -88,7 +88,12 @@ func seedMCPConsole(t *testing.T) (*Server, *sql.DB, string) {
 func TestIntegrationMCPEndpoint(t *testing.T) {
 	srv, _, _ := seedMCPConsole(t)
 	ts := httptest.NewServer(srv.Handler())
-	defer ts.Close()
+	// Cleanup, not defer: the streamable client holds a standalone SSE GET open
+	// for the session lifetime, and httptest Close blocks until every
+	// connection drains. Registering ts.Close BEFORE the session connects makes
+	// the LIFO cleanup order close the session (registered later, inside
+	// mcpConnect) first.
+	t.Cleanup(ts.Close)
 	ctx := context.Background()
 
 	session := mcpConnect(t, ts.URL+"/mcp", intToken)
@@ -186,7 +191,12 @@ func TestIntegrationMCPEndpoint(t *testing.T) {
 func TestIntegrationMCPWrongTokenRefused(t *testing.T) {
 	srv, _, _ := seedMCPConsole(t)
 	ts := httptest.NewServer(srv.Handler())
-	defer ts.Close()
+	// Cleanup, not defer: the streamable client holds a standalone SSE GET open
+	// for the session lifetime, and httptest Close blocks until every
+	// connection drains. Registering ts.Close BEFORE the session connects makes
+	// the LIFO cleanup order close the session (registered later, inside
+	// mcpConnect) first.
+	t.Cleanup(ts.Close)
 
 	client := mcp.NewClient(&mcp.Implementation{Name: "it", Version: "1"}, nil)
 	session, err := client.Connect(context.Background(), &mcp.StreamableClientTransport{
@@ -212,7 +222,12 @@ func TestIntegrationMCPRoutesByServerName(t *testing.T) {
 	srv.cm.reg = reg
 
 	ts := httptest.NewServer(srv.Handler())
-	defer ts.Close()
+	// Cleanup, not defer: the streamable client holds a standalone SSE GET open
+	// for the session lifetime, and httptest Close blocks until every
+	// connection drains. Registering ts.Close BEFORE the session connects makes
+	// the LIFO cleanup order close the session (registered later, inside
+	// mcpConnect) first.
+	t.Cleanup(ts.Close)
 	ctx := context.Background()
 
 	session := mcpConnect(t, ts.URL+"/mcp/reg-target", intToken)

--- a/internal/console/mcp_test.go
+++ b/internal/console/mcp_test.go
@@ -1,0 +1,166 @@
+package console
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/query"
+)
+
+// mcpInitializeBody is a minimal, valid JSON-RPC initialize request — the one
+// MCP exchange that never touches the index, so mux-level tests (auth,
+// routing) can assert the endpoint accepted a session without a database.
+const mcpInitializeBody = `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}`
+
+// doMCP posts an initialize request to path with the given bearer token
+// ("" = no Authorization header) and returns the recorder.
+func doMCP(t *testing.T, s *Server, path, token string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("POST", "http://127.0.0.1:8090"+path, strings.NewReader(mcpInitializeBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	rec := httptest.NewRecorder()
+	s.mux.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestMCP_requiresConfiguredToken(t *testing.T) {
+	db, _, closer := newSQLMock(t)
+	defer closer()
+	// Password-only / no-auth posture: no static token configured.
+	s := &Server{token: "", cm: newConnManager(nil, false)}
+	s.cm.boot = &bundle{db: db, engine: query.New(db), noArchive: true}
+	s.mux = s.buildHandler()
+
+	rec := doMCP(t, s, "/mcp", "whatever")
+	if rec.Code != 403 {
+		t.Fatalf("token-less console /mcp = %d, want 403; body: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "BINTRAIL_CONSOLE_TOKEN") {
+		t.Errorf("refusal must name the remediation, got: %s", rec.Body.String())
+	}
+}
+
+func TestMCP_authMissingToken(t *testing.T) {
+	db, _, closer := newSQLMock(t)
+	defer closer()
+	s := newBootServer(db)
+
+	if rec := doMCP(t, s, "/mcp", ""); rec.Code != 401 {
+		t.Fatalf("/mcp without credential = %d, want 401", rec.Code)
+	}
+}
+
+func TestMCP_authWrongToken(t *testing.T) {
+	db, _, closer := newSQLMock(t)
+	defer closer()
+	s := newBootServer(db)
+
+	if rec := doMCP(t, s, "/mcp", "not-the-token"); rec.Code != 401 {
+		t.Fatalf("/mcp with wrong token = %d, want 401", rec.Code)
+	}
+}
+
+func TestMCP_authRightTokenInitializes(t *testing.T) {
+	db, _, closer := newSQLMock(t)
+	defer closer()
+	s := newBootServer(db) // token "t"
+
+	rec := doMCP(t, s, "/mcp", "t")
+	if rec.Code != 200 {
+		t.Fatalf("/mcp initialize = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "serverInfo") {
+		t.Errorf("initialize response missing serverInfo: %s", rec.Body.String())
+	}
+}
+
+func TestMCP_routingUnknownServer404(t *testing.T) {
+	db, _, closer := newSQLMock(t)
+	defer closer()
+	s := newBootServer(db)
+
+	rec := doMCP(t, s, "/mcp/no-such-server", "t")
+	if rec.Code != 404 {
+		t.Fatalf("/mcp/no-such-server = %d, want 404; body: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "unknown server") {
+		t.Errorf("404 body should say unknown server, got: %s", rec.Body.String())
+	}
+}
+
+func TestMCP_routingByIDNameAndDefault(t *testing.T) {
+	db, _, closer := newSQLMock(t)
+	defer closer()
+	reg, err := LoadRegistry("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry, err := reg.Add(ServerEntry{Name: "prod", DSN: "u:p@tcp(127.0.0.1:3306)/idx"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := &Server{token: "t", cm: newConnManager(reg, false)}
+	s.cm.boot = &bundle{db: db, engine: query.New(db), noArchive: true}
+	s.mux = s.buildHandler()
+
+	// Initialize never opens the server's connection, so a routing accept
+	// (200) proves selector resolution without a live MySQL.
+	for _, path := range []string{"/mcp", "/mcp/" + entry.ID, "/mcp/prod", "/mcp/default"} {
+		if rec := doMCP(t, s, path, "t"); rec.Code != 200 {
+			t.Errorf("%s initialize = %d, want 200; body: %s", path, rec.Code, rec.Body.String())
+		}
+	}
+}
+
+func TestMCP_defaultWithNoServers404(t *testing.T) {
+	// No boot entry, empty registry: nothing to route to.
+	s := &Server{token: "t", cm: newConnManager(nil, false)}
+	s.mux = s.buildHandler()
+
+	if rec := doMCP(t, s, "/mcp", "t"); rec.Code != 404 {
+		t.Fatalf("empty console /mcp = %d, want 404; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestMCP_hiddenBootStillBacksDefault(t *testing.T) {
+	// Source-less watch posture: boot hidden, empty registry. The bare /mcp
+	// endpoint must still resolve to the hidden boot bundle, mirroring
+	// header-less API requests.
+	db, _, closer := newSQLMock(t)
+	defer closer()
+	s := &Server{token: "t", cm: newConnManager(nil, false)}
+	s.cm.hideBoot = true
+	s.cm.boot = &bundle{db: db, engine: query.New(db), noArchive: true}
+	s.mux = s.buildHandler()
+
+	if rec := doMCP(t, s, "/mcp", "t"); rec.Code != 200 {
+		t.Fatalf("hidden-boot /mcp initialize = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+	// But the hidden boot must NOT be addressable as "default" — it is not a
+	// selectable server anywhere else in the console either.
+	if rec := doMCP(t, s, "/mcp/default", "t"); rec.Code != 404 {
+		t.Fatalf("hidden-boot /mcp/default = %d, want 404", rec.Code)
+	}
+}
+
+func TestMCP_hostGuardApplies(t *testing.T) {
+	db, _, closer := newSQLMock(t)
+	defer closer()
+	s := newBootServer(db)
+
+	req := httptest.NewRequest("POST", "http://attacker.example/mcp", strings.NewReader(mcpInitializeBody))
+	req.Host = "attacker.example"
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("Authorization", "Bearer t")
+	rec := httptest.NewRecorder()
+	s.mux.ServeHTTP(rec, req)
+	if rec.Code != 403 {
+		t.Fatalf("domain-name Host on /mcp = %d, want 403 (DNS-rebinding guard)", rec.Code)
+	}
+}

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -450,7 +450,14 @@ func (s *Server) buildHandler() http.Handler {
 		}
 	}
 	root.Handle("/api/", s.tokenMiddleware(api)) // credential on all other /api/*
-	root.Handle("/", assetHandler())             // static shell + assets
+	// MCP endpoint (#1039): the four read-only tools over Streamable HTTP,
+	// static-token-authenticated, routed per server by URL path. Carries its
+	// own auth check (token-only — see mcp.go) instead of tokenMiddleware,
+	// and sits on root so it inherits hostGuard + securityHeaders.
+	mcpH := s.mcpHandler()
+	root.Handle("/mcp", mcpH)
+	root.Handle("/mcp/{server}", mcpH)
+	root.Handle("/", assetHandler()) // static shell + assets
 
 	return s.hostGuard(securityHeaders(root))
 }

--- a/internal/event/depguard_test.go
+++ b/internal/event/depguard_test.go
@@ -44,6 +44,7 @@ func TestReadLayerDoesNotLinkGoMySQL(t *testing.T) {
 		"github.com/dbtrail/dbtrail/internal/archive",
 		"github.com/dbtrail/dbtrail/internal/agent",
 		"github.com/dbtrail/dbtrail/internal/status",
+		"github.com/dbtrail/dbtrail/internal/mcptools",
 	}
 	for _, pkg := range readPkgs {
 		out, err := exec.Command("go", "list", "-deps", pkg).CombinedOutput()

--- a/internal/mcptools/mcptools.go
+++ b/internal/mcptools/mcptools.go
@@ -1,0 +1,919 @@
+// Package mcptools implements the four read-only Bintrail MCP tools —
+// query, recover, status, and list_schema_changes — decoupled from how the
+// index connection is obtained.
+//
+// Two surfaces consume it:
+//
+//   - cmd/bintrail-mcp (standalone server): the index is resolved per tool
+//     call from a DSN (tool-level index_dsn parameter, BINTRAIL_INDEX_DSN env
+//     var, or a multi-tenant override), a fresh connection is opened and
+//     closed around every call, and the idempotent schema migration runs on
+//     it (the server owns no long-lived connection).
+//   - internal/console (/mcp endpoint): the index is a long-lived connManager
+//     bundle owned by the console, the DSN parameters are rejected (an
+//     authenticated MCP client must not be able to point the console at an
+//     arbitrary DSN), and the console's read boundary applies — result caps,
+//     process-global RBAC posture, and query_text/query_hash withheld to
+//     match the events API's eventDTO.
+//
+// The seam is ResolveTarget: a callback mapping the (possibly empty) tool
+// index_dsn argument to a Target carrying the connection plus the posture the
+// serving surface imposes on it.
+package mcptools
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	mysqldriver "github.com/go-sql-driver/mysql"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/dbtrail/dbtrail/ext"
+	"github.com/dbtrail/dbtrail/internal/cliutil"
+	"github.com/dbtrail/dbtrail/internal/config"
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/parquetquery"
+	"github.com/dbtrail/dbtrail/internal/query"
+	"github.com/dbtrail/dbtrail/internal/recovery"
+	"github.com/dbtrail/dbtrail/internal/status"
+)
+
+// DefaultQueryLimit and DefaultRecoverLimit are the per-tool defaults applied
+// when the caller passes no limit (or a non-positive one). They match the CLI
+// defaults and the console API's default caps.
+const (
+	DefaultQueryLimit   = 100
+	DefaultRecoverLimit = 1000
+)
+
+// Target is one resolved index a tool call runs against: the open connection
+// plus the read posture the serving surface imposes on it.
+type Target struct {
+	// DB is the open index connection. Never nil on a successful resolve.
+	DB *sql.DB
+	// DBName is the index database name, required by the status tool (the
+	// query planner and partition inspection scope to it). May be empty on
+	// the standalone surface when the DSN carries no database name — the
+	// status tool then refuses with an actionable error.
+	DBName string
+	// CloseDB is true when the connection was opened for this call and the
+	// handler must close it (standalone). False when the connection is owned
+	// by a long-lived pool (console connManager bundles).
+	CloseDB bool
+	// EnsureSchema runs the idempotent indexer schema migration before the
+	// query/recover engines touch binlog_events (they SELECT
+	// post-initial-schema columns). True on the standalone surface, which
+	// opens a fresh connection per call. False on the console: the boot entry
+	// is migrated by the cmd layer at startup, and registry servers are
+	// deliberately NEVER migrated (the console's read-only contract confines
+	// DDL to the command-line DSN).
+	EnsureSchema bool
+	// EnvArchiveDiscovery consults BINTRAIL_ARCHIVE_S3 + BINTRAIL_ID before
+	// falling back to archive_state auto-discovery (standalone behavior).
+	// False on the console, whose archive posture is per-server.
+	EnvArchiveDiscovery bool
+	// NoArchive disables Parquet archive auto-discovery outright — the
+	// console bundle's per-server posture (its own flag OR an active RBAC
+	// profile, which archives do not enforce).
+	NoArchive bool
+	// DenyTables / RedactColumns / ProfileActive are RBAC rules the surface
+	// attaches to every query (the console's process-global profile). The
+	// standalone surface leaves them empty and loads rules from the tool's
+	// profile parameter instead.
+	DenyTables    []query.SchemaTable
+	RedactColumns []query.SchemaTableColumn
+	ProfileActive bool
+	// Resolver is a preloaded schema resolver for recovery WHERE clauses.
+	// Consulted only when ResolverLoaded is true (the console preloads its
+	// per-bundle resolver, which may legitimately be nil); otherwise the
+	// recover tool loads the latest snapshot best-effort per call.
+	Resolver       *metadata.Resolver
+	ResolverLoaded bool
+	// RedactStatementText blanks query_text/query_hash on every fetched row
+	// before formatting, so the query tool's output carries the same field
+	// content as the console events API (whose eventDTO omits statement text,
+	// #699). Set by the console surface only.
+	RedactStatementText bool
+}
+
+// release closes the connection when this call owns it.
+func (t *Target) release() {
+	if t.CloseDB && t.DB != nil {
+		_ = t.DB.Close()
+	}
+}
+
+// stripStatementText enforces RedactStatementText on a fetched row set.
+func (t *Target) stripStatementText(rows []query.ResultRow) {
+	if !t.RedactStatementText {
+		return
+	}
+	for i := range rows {
+		rows[i].QueryText = nil
+		rows[i].QueryHash = nil
+	}
+}
+
+// archiveSources returns Parquet archive source paths for this target, or nil
+// when archives are disabled or discovery fails (the MCP tools are
+// deliberately permissive: serve without archives rather than fail the call).
+func (t *Target) archiveSources(ctx context.Context) []string {
+	if t.NoArchive {
+		return nil
+	}
+	if t.EnvArchiveDiscovery {
+		return EnvArchiveSources(ctx, t.DB)
+	}
+	return stateArchiveSources(ctx, t.DB)
+}
+
+// ResolveTarget maps the tool-level index_dsn argument (empty on surfaces
+// that reject it) to the Target the call runs against.
+type ResolveTarget func(ctx context.Context, argDSN string) (*Target, error)
+
+// Config assembles an MCP server over the four read-only tools.
+type Config struct {
+	// Version is the reported mcp.Implementation version.
+	Version string
+	// Instructions is the server-level usage hint sent to clients.
+	Instructions string
+	// Resolve obtains the Target for each tool call.
+	Resolve ResolveTarget
+	// AllowDSNParam accepts the tool-level index_dsn parameter (standalone).
+	// When false the parameter is rejected with an explicit error — the
+	// serving surface owns connection routing (console).
+	AllowDSNParam bool
+	// AllowProfileParam accepts the tool-level profile parameter
+	// (standalone). When false it is rejected — the surface's RBAC posture
+	// is fixed at process start (console).
+	AllowProfileParam bool
+	// QueryMaxLimit returns the hard row ceiling for the query tool. nil
+	// means EnvQueryMaxLimit (the standalone default, #654).
+	QueryMaxLimit func() int
+	// RecoverMaxLimit caps the recover tool's limit; 0 means uncapped
+	// (standalone behavior — the CLI is the bounded-review path there).
+	RecoverMaxLimit int
+	// AuditSurface tags ext.Record audit events; "" means "mcp".
+	AuditSurface string
+}
+
+func (c Config) queryMaxLimit() int {
+	if c.QueryMaxLimit != nil {
+		return c.QueryMaxLimit()
+	}
+	return EnvQueryMaxLimit()
+}
+
+func (c Config) auditSurface() string {
+	if c.AuditSurface == "" {
+		return "mcp"
+	}
+	return c.AuditSurface
+}
+
+// NewServer builds an MCP server exposing the four read-only tools bound to
+// cfg. All tools are annotated read-only + idempotent.
+func NewServer(cfg Config) *mcp.Server {
+	server := mcp.NewServer(&mcp.Implementation{
+		Name:    "bintrail",
+		Version: cfg.Version,
+	}, &mcp.ServerOptions{
+		Instructions: cfg.Instructions,
+	})
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "query",
+		Description: "Search indexed MySQL binlog events with filters. " +
+			"Returns matching events showing row changes (before/after images), timestamps, and metadata. " +
+			"Use json format for full row data or table format for a human-readable summary.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:          "Search binlog events",
+			ReadOnlyHint:   true,
+			IdempotentHint: true,
+		},
+	}, MakeQueryTool(cfg))
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "recover",
+		Description: "Generate reversal SQL to undo matching binlog events (dry-run only). " +
+			"Produces a BEGIN/COMMIT-wrapped SQL script that reverses events in reverse chronological order (most recent first): " +
+			"DELETE->INSERT, UPDATE->reverse UPDATE, INSERT->DELETE. " +
+			"Review carefully before applying to production.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:          "Generate recovery SQL",
+			ReadOnlyHint:   true,
+			IdempotentHint: true,
+		},
+	}, MakeRecoverTool(cfg))
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "status",
+		Description: "Show the current state of the binlog index: " +
+			"which files have been indexed, partition layout with estimated row counts, " +
+			"and aggregate summary of indexed events.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:          "Index status",
+			ReadOnlyHint:   true,
+			IdempotentHint: true,
+		},
+	}, MakeStatusTool(cfg))
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "list_schema_changes",
+		Description: "List DDL schema changes (CREATE, ALTER, DROP, RENAME, TRUNCATE) " +
+			"recorded during binlog indexing or streaming. " +
+			"Returns the full DDL statement, binlog coordinates, and timestamp for each change.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:          "List schema changes",
+			ReadOnlyHint:   true,
+			IdempotentHint: true,
+		},
+	}, MakeSchemaChangesTool(cfg))
+
+	return server
+}
+
+// DSNTarget adapts a DSN resolution function (override > tool arg > env var,
+// on the standalone surface) into a ResolveTarget that opens a fresh
+// connection per call with the standalone posture: caller-closed, schema
+// migration on, env-var archive discovery.
+func DSNTarget(resolve func(argDSN string) (string, error)) ResolveTarget {
+	return func(ctx context.Context, argDSN string) (*Target, error) {
+		dsn, err := resolve(argDSN)
+		if err != nil {
+			return nil, err
+		}
+		cfg, err := mysqldriver.ParseDSN(dsn)
+		if err != nil {
+			return nil, fmt.Errorf("invalid DSN: %w", err)
+		}
+		db, err := config.Connect(dsn)
+		if err != nil {
+			return nil, err
+		}
+		return &Target{
+			DB:                  db,
+			DBName:              cfg.DBName,
+			CloseDB:             true,
+			EnsureSchema:        true,
+			EnvArchiveDiscovery: true,
+		}, nil
+	}
+}
+
+// ─── Tool argument types ─────────────────────────────────────────────────────
+
+// QueryArgs are the query tool's parameters.
+type QueryArgs struct {
+	IndexDSN      string   `json:"index_dsn,omitempty" jsonschema:"MySQL DSN for the index database. Overrides BINTRAIL_INDEX_DSN env var. Rejected on servers that route connections themselves (the console /mcp endpoint)."`
+	Schema        string   `json:"schema,omitempty" jsonschema:"Filter by database schema name"`
+	Table         string   `json:"table,omitempty" jsonschema:"Filter by table name"`
+	PK            string   `json:"pk,omitempty" jsonschema:"Filter by primary key value (pipe-delimited for composite keys e.g. 123 or 123|2)"`
+	EventType     string   `json:"event_type,omitempty" jsonschema:"Filter by event type: INSERT UPDATE or DELETE"`
+	GTID          string   `json:"gtid,omitempty" jsonschema:"Filter by GTID (e.g. uuid:42)"`
+	Since         string   `json:"since,omitempty" jsonschema:"Filter events at or after this time (YYYY-MM-DD HH:MM:SS or RFC 3339)"`
+	Until         string   `json:"until,omitempty" jsonschema:"Filter events at or before this time (YYYY-MM-DD HH:MM:SS or RFC 3339)"`
+	ChangedColumn string   `json:"changed_column,omitempty" jsonschema:"Filter UPDATE events that modified this column"`
+	ColumnEq      []string `json:"column_eq,omitempty" jsonschema:"Filter events where a column in row_after or row_before equals the given value. Each entry is column=value. Repeat for AND. Literal NULL matches JSON null."`
+	Flag          string   `json:"flag,omitempty" jsonschema:"Filter events from tables or columns carrying this flag"`
+	Format        string   `json:"format,omitempty" jsonschema:"Output format: json table or csv (default: json)"`
+	Limit         int      `json:"limit,omitempty" jsonschema:"Maximum number of events to return (default: 100)"`
+	Profile       string   `json:"profile,omitempty" jsonschema:"Apply RBAC access rules for this profile (table-level deny and column-level redaction)"`
+	NoArchive     bool     `json:"no_archive,omitempty" jsonschema:"Disable auto-routing to Parquet archives (MySQL-only results)"`
+}
+
+// RecoverArgs are the recover tool's parameters.
+type RecoverArgs struct {
+	IndexDSN      string   `json:"index_dsn,omitempty" jsonschema:"MySQL DSN for the index database. Overrides BINTRAIL_INDEX_DSN env var. Rejected on servers that route connections themselves (the console /mcp endpoint)."`
+	Schema        string   `json:"schema,omitempty" jsonschema:"Filter by database schema name"`
+	Table         string   `json:"table,omitempty" jsonschema:"Filter by table name"`
+	PK            string   `json:"pk,omitempty" jsonschema:"Filter by primary key value (pipe-delimited for composite keys)"`
+	EventType     string   `json:"event_type,omitempty" jsonschema:"Filter by event type: INSERT UPDATE or DELETE"`
+	GTID          string   `json:"gtid,omitempty" jsonschema:"Filter by GTID (e.g. uuid:42)"`
+	Since         string   `json:"since,omitempty" jsonschema:"Filter events at or after this time (YYYY-MM-DD HH:MM:SS or RFC 3339)"`
+	Until         string   `json:"until,omitempty" jsonschema:"Filter events at or before this time (YYYY-MM-DD HH:MM:SS or RFC 3339)"`
+	ChangedColumn string   `json:"changed_column,omitempty" jsonschema:"Filter UPDATE events that modified this column"`
+	ColumnEq      []string `json:"column_eq,omitempty" jsonschema:"Filter events where a column in row_after or row_before equals the given value. Each entry is column=value. Repeat for AND. Literal NULL matches JSON null."`
+	Flag          string   `json:"flag,omitempty" jsonschema:"Filter events from tables or columns carrying this flag"`
+	Limit         int      `json:"limit,omitempty" jsonschema:"Maximum number of events to reverse (default: 1000)"`
+	Profile       string   `json:"profile,omitempty" jsonschema:"Apply RBAC access rules for this profile (table-level deny and column-level redaction)"`
+	NoArchive     bool     `json:"no_archive,omitempty" jsonschema:"Disable auto-routing to Parquet archives (MySQL-only results)"`
+}
+
+// StatusArgs are the status tool's parameters.
+type StatusArgs struct {
+	IndexDSN string `json:"index_dsn,omitempty" jsonschema:"MySQL DSN for the index database. Overrides BINTRAIL_INDEX_DSN env var. Rejected on servers that route connections themselves (the console /mcp endpoint)."`
+}
+
+// SchemaChangesArgs are the list_schema_changes tool's parameters.
+type SchemaChangesArgs struct {
+	IndexDSN string `json:"index_dsn,omitempty" jsonschema:"MySQL DSN for the index database. Overrides BINTRAIL_INDEX_DSN env var. Rejected on servers that route connections themselves (the console /mcp endpoint)."`
+	Schema   string `json:"schema,omitempty" jsonschema:"Filter by database schema name"`
+	Table    string `json:"table,omitempty" jsonschema:"Filter by table name"`
+	DDLType  string `json:"ddl_type,omitempty" jsonschema:"Filter by DDL type: CREATE ALTER DROP RENAME or TRUNCATE"`
+	Since    string `json:"since,omitempty" jsonschema:"Filter changes at or after this time (YYYY-MM-DD HH:MM:SS or RFC 3339)"`
+	Until    string `json:"until,omitempty" jsonschema:"Filter changes at or before this time (YYYY-MM-DD HH:MM:SS or RFC 3339)"`
+	Limit    int    `json:"limit,omitempty" jsonschema:"Maximum number of changes to return (default: 100)"`
+}
+
+// rejectSurfaceParams enforces the surface's parameter policy: a non-nil
+// result is the tool error to return. The messages are deliberately explicit
+// — an agent must learn the surface's routing model, not retry blindly.
+func rejectSurfaceParams(cfg Config, indexDSN, profile string) *mcp.CallToolResult {
+	if !cfg.AllowDSNParam && indexDSN != "" {
+		return ErrorResult(errors.New(
+			"index_dsn is not accepted here: this server routes connections itself " +
+				"(select a server via the /mcp/{id-or-name} URL path; connections are managed in the console)"))
+	}
+	if !cfg.AllowProfileParam && profile != "" {
+		return ErrorResult(errors.New(
+			"profile is not accepted here: the RBAC posture is fixed by the serving process configuration"))
+	}
+	return nil
+}
+
+// ─── Tool handler factories ──────────────────────────────────────────────────
+//
+// Each factory returns a closure over the Config: the target resolution seam
+// plus the surface's caps and parameter policy.
+
+// MakeQueryTool returns the query tool handler.
+func MakeQueryTool(cfg Config) func(context.Context, *mcp.CallToolRequest, QueryArgs) (*mcp.CallToolResult, any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, args QueryArgs) (*mcp.CallToolResult, any, error) {
+		if res := rejectSurfaceParams(cfg, args.IndexDSN, args.Profile); res != nil {
+			return res, nil, nil
+		}
+		t, err := cfg.Resolve(ctx, args.IndexDSN)
+		if err != nil {
+			return ErrorResult(err), nil, nil
+		}
+		defer t.release()
+
+		// Same idempotent migration as the recover tool below: the query
+		// engine SELECTs post-initial-schema binlog_events columns
+		// (query_text/query_hash, #699). Standalone-only — the console never
+		// migrates its servers (see Target.EnsureSchema).
+		if t.EnsureSchema {
+			if err := indexer.EnsureSchema(t.DB); err != nil {
+				return ErrorResult(indexer.WrapSchemaMigrationErr(err)), nil, nil
+			}
+		}
+
+		opts, err := BuildQueryOptions(args.Schema, args.Table, args.PK, args.EventType,
+			args.GTID, args.Since, args.Until, args.ChangedColumn, args.ColumnEq, args.Flag, args.Limit, DefaultQueryLimit)
+		if err != nil {
+			return ErrorResult(err), nil, nil
+		}
+
+		// Hard ceiling on an explicit, oversized limit (#654). BuildQueryOptions
+		// already coerces limit<=0 to the default, so this only bounds a large
+		// EXPLICIT value an agent might pass. It is applied here, per-tool, on the
+		// local opts — NOT in the shared BuildQueryOptions, because the recover
+		// tool must refuse on size, not silently cap a read.
+		ceiling := cfg.queryMaxLimit()
+		requestedLimit := opts.Limit
+		ceilingApplied := false
+		if c, did := ApplyQueryCeiling(opts.Limit, ceiling); did {
+			opts.Limit = c
+			ceilingApplied = true
+		}
+
+		// The surface's RBAC posture always applies (the console's
+		// process-global profile); the per-call profile parameter — standalone
+		// only — layers the named profile's rules on top.
+		opts.DenyTables = t.DenyTables
+		opts.RedactColumns = t.RedactColumns
+		opts.ProfileActive = t.ProfileActive
+		if args.Profile != "" {
+			denyTables, redactCols, err := query.LoadProfileRules(ctx, t.DB, args.Profile)
+			if err != nil {
+				return ErrorResult(fmt.Errorf("load profile rules: %w", err)), nil, nil
+			}
+			opts.DenyTables = denyTables
+			opts.RedactColumns = redactCols
+			opts.ProfileActive = true
+		}
+
+		format := args.Format
+		if format == "" {
+			format = "json"
+		}
+		if !cliutil.IsValidFormat(format) {
+			return ErrorResult(fmt.Errorf("invalid format %q; must be json, table, or csv", format)), nil, nil
+		}
+
+		engine := query.New(t.DB)
+
+		// Skip archive auto-discovery when no_archive is set or when an RBAC
+		// profile is active (archive queries do not enforce rules). The
+		// target's own posture (console per-server no-archive, which already
+		// folds the process profile in) is enforced inside archiveSources.
+		var archSources []string
+		if !args.NoArchive && args.Profile == "" {
+			archSources = t.archiveSources(ctx)
+		}
+
+		var buf bytes.Buffer
+		var n int
+
+		if len(archSources) == 0 && !t.RedactStatementText {
+			// Fast path: no archives and no post-fetch redaction — fetch and
+			// format in one step.
+			n, err = engine.Run(ctx, opts, format, &buf)
+			if err != nil {
+				return ErrorResult(err), nil, nil
+			}
+		} else {
+			// Fetch from live index (+ archives when present), merge, redact,
+			// then format.
+			fetchOpts := opts
+			results, err := engine.Fetch(ctx, fetchOpts)
+			if err != nil {
+				return ErrorResult(err), nil, nil
+			}
+			for _, src := range archSources {
+				ar, err := parquetquery.Fetch(ctx, fetchOpts, src)
+				if err != nil {
+					slog.Warn("archive query failed, skipping", "source", src, "error", err)
+					continue
+				}
+				results = append(results, ar...)
+			}
+			if len(archSources) > 0 {
+				results = query.MergeResults(results, opts.Limit, opts.Order)
+			}
+			t.stripStatementText(results)
+			n, err = query.Format(results, format, &buf)
+			if err != nil {
+				return ErrorResult(err), nil, nil
+			}
+		}
+
+		text := buf.String()
+		if n > 0 && format != "json" {
+			text += fmt.Sprintf("\n%d row(s)\n", n)
+		}
+		text += QueryResultNotice(ceilingApplied, requestedLimit, ceiling, n, opts.Limit)
+
+		ext.Record(ctx, ext.AuditEvent{
+			Surface: cfg.auditSurface(),
+			Action:  "query.run",
+			Actor:   ext.ProcessActor(args.Profile),
+			Schema:  args.Schema,
+			Table:   args.Table,
+			Detail:  map[string]string{"results": strconv.Itoa(n), "format": format},
+		})
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: text},
+			},
+		}, nil, nil
+	}
+}
+
+// MakeRecoverTool returns the recover tool handler.
+func MakeRecoverTool(cfg Config) func(context.Context, *mcp.CallToolRequest, RecoverArgs) (*mcp.CallToolResult, any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, args RecoverArgs) (*mcp.CallToolResult, any, error) {
+		if res := rejectSurfaceParams(cfg, args.IndexDSN, args.Profile); res != nil {
+			return res, nil, nil
+		}
+		t, err := cfg.Resolve(ctx, args.IndexDSN)
+		if err != nil {
+			return ErrorResult(err), nil, nil
+		}
+		defer t.release()
+
+		// Run the idempotent schema migration before NewResolver. Since
+		// #212 NewResolver reads schema_snapshots.column_type and fails on
+		// pre-migration databases with Error 1054. Standalone-only — see
+		// Target.EnsureSchema.
+		if t.EnsureSchema {
+			if err := indexer.EnsureSchema(t.DB); err != nil {
+				return ErrorResult(indexer.WrapSchemaMigrationErr(err)), nil, nil
+			}
+		}
+
+		opts, err := BuildQueryOptions(args.Schema, args.Table, args.PK, args.EventType,
+			args.GTID, args.Since, args.Until, args.ChangedColumn, args.ColumnEq, args.Flag, args.Limit, DefaultRecoverLimit)
+		if err != nil {
+			return ErrorResult(err), nil, nil
+		}
+		// The surface's hard cap on the reversal window (console: same cap as
+		// the /api/recover endpoint). The truncation warning below fires when
+		// the capped limit is reached, so a clipped window is never silent.
+		if cfg.RecoverMaxLimit > 0 && opts.Limit > cfg.RecoverMaxLimit {
+			opts.Limit = cfg.RecoverMaxLimit
+		}
+		// When --limit truncates the matched window it must keep the most
+		// RECENT events (#785/#927): the ASC default would keep the OLDEST
+		// prefix, undoing old events underneath later un-reverted ones — a
+		// state that never historically existed. Rows are re-sorted ascending
+		// after the fetch, before generation (see below).
+		opts.Order = "DESC"
+
+		opts.DenyTables = t.DenyTables
+		opts.RedactColumns = t.RedactColumns
+		opts.ProfileActive = t.ProfileActive
+		if args.Profile != "" {
+			denyTables, redactCols, err := query.LoadProfileRules(ctx, t.DB, args.Profile)
+			if err != nil {
+				return ErrorResult(fmt.Errorf("load profile rules: %w", err)), nil, nil
+			}
+			opts.DenyTables = denyTables
+			opts.RedactColumns = redactCols
+			opts.ProfileActive = true
+		}
+
+		// Schema resolver for PK-only WHERE clauses: preloaded by the surface
+		// (console bundles), else loaded best-effort per call.
+		resolver := t.Resolver
+		var resolverErr error
+		if !t.ResolverLoaded {
+			resolver, resolverErr = metadata.NewResolver(t.DB, 0)
+			if resolverErr != nil {
+				resolver = nil
+			}
+		}
+
+		// Fetch events from live index + archives. Archive skip conditions
+		// mirror the query tool above.
+		engine := query.New(t.DB)
+		var archSources []string
+		if !args.NoArchive && args.Profile == "" {
+			archSources = t.archiveSources(ctx)
+		}
+
+		var rows []query.ResultRow
+		if len(archSources) > 0 {
+			fetchOpts := opts
+			rows, err = engine.Fetch(ctx, fetchOpts)
+			if err != nil {
+				return ErrorResult(err), nil, nil
+			}
+			for _, src := range archSources {
+				ar, err := parquetquery.Fetch(ctx, fetchOpts, src)
+				if err != nil {
+					slog.Warn("archive query failed, skipping", "source", src, "error", err)
+					continue
+				}
+				rows = append(rows, ar...)
+			}
+			rows = query.MergeResults(rows, opts.Limit, opts.Order)
+		} else {
+			rows, err = engine.Fetch(ctx, opts)
+			if err != nil {
+				return ErrorResult(err), nil, nil
+			}
+		}
+
+		// The fetch above ran Order=DESC so --limit kept the newest suffix of
+		// the window (#785/#927). Restore ascending order: GenerateSQLFromRows
+		// expects ASC input and reverses it internally to undo most-recent
+		// first.
+		rows = query.MergeResults(rows, 0, "ASC")
+
+		gen := recovery.NewForDialect(t.DB, resolver, recovery.DialectForIndex(t.DB))
+		var buf bytes.Buffer
+		n, err := gen.GenerateSQLFromRows(rows, &buf)
+		if err != nil {
+			return ErrorResult(err), nil, nil
+		}
+
+		text := buf.String()
+		if resolverErr != nil {
+			text += fmt.Sprintf("\n-- Note: schema snapshot unavailable (%v); WHERE clauses use all columns.\n", resolverErr)
+		}
+		if n > 0 {
+			text += fmt.Sprintf("\n-- %d reversal statement(s) generated.\n", n)
+		}
+		if n >= opts.Limit {
+			text += fmt.Sprintf("\n-- Warning: results truncated at %d rows. Use a narrower since/until range or increase the limit to see more.\n", opts.Limit)
+		}
+
+		ext.Record(ctx, ext.AuditEvent{
+			Surface: cfg.auditSurface(),
+			Action:  "recover.generate",
+			Actor:   ext.ProcessActor(args.Profile),
+			Schema:  args.Schema,
+			Table:   args.Table,
+			Detail: map[string]string{
+				"statements": strconv.Itoa(n),
+				"dry_run":    "true", // MCP recover always returns the script, never applies it
+				"gtid":       args.GTID,
+			},
+		})
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: text},
+			},
+		}, nil, nil
+	}
+}
+
+// MakeStatusTool returns the status tool handler.
+func MakeStatusTool(cfg Config) func(context.Context, *mcp.CallToolRequest, StatusArgs) (*mcp.CallToolResult, any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, args StatusArgs) (*mcp.CallToolResult, any, error) {
+		if res := rejectSurfaceParams(cfg, args.IndexDSN, ""); res != nil {
+			return res, nil, nil
+		}
+		t, err := cfg.Resolve(ctx, args.IndexDSN)
+		if err != nil {
+			return ErrorResult(err), nil, nil
+		}
+		defer t.release()
+
+		if t.DBName == "" {
+			return ErrorResult(fmt.Errorf("DSN must include a database name")), nil, nil
+		}
+
+		data, err := status.CollectStatus(ctx, t.DB, t.DBName)
+		if err != nil {
+			return ErrorResult(err), nil, nil
+		}
+
+		var buf bytes.Buffer
+		data.Write(&buf)
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: buf.String()},
+			},
+		}, nil, nil
+	}
+}
+
+// MakeSchemaChangesTool returns the list_schema_changes tool handler.
+func MakeSchemaChangesTool(cfg Config) func(context.Context, *mcp.CallToolRequest, SchemaChangesArgs) (*mcp.CallToolResult, any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, args SchemaChangesArgs) (*mcp.CallToolResult, any, error) {
+		if res := rejectSurfaceParams(cfg, args.IndexDSN, ""); res != nil {
+			return res, nil, nil
+		}
+		// Validate inputs before connecting.
+		sinceT, err := cliutil.ParseTime(args.Since)
+		if err != nil {
+			return ErrorResult(fmt.Errorf("invalid since: %w", err)), nil, nil
+		}
+		untilT, err := cliutil.ParseTime(args.Until)
+		if err != nil {
+			return ErrorResult(fmt.Errorf("invalid until: %w", err)), nil, nil
+		}
+
+		if args.DDLType != "" {
+			upper := strings.ToUpper(args.DDLType)
+			switch upper {
+			case "CREATE", "ALTER", "DROP", "RENAME", "TRUNCATE":
+				// valid
+			default:
+				return ErrorResult(fmt.Errorf("invalid ddl_type %q; must be CREATE, ALTER, DROP, RENAME, or TRUNCATE", args.DDLType)), nil, nil
+			}
+		}
+
+		limit := args.Limit
+		if limit <= 0 {
+			limit = 100
+		}
+
+		t, err := cfg.Resolve(ctx, args.IndexDSN)
+		if err != nil {
+			return ErrorResult(err), nil, nil
+		}
+		defer t.release()
+
+		q := "SELECT id, detected_at, schema_name, table_name, ddl_type, ddl_query, binlog_file, binlog_pos, gtid FROM schema_changes WHERE 1=1"
+		var params []any
+
+		if args.Schema != "" {
+			q += " AND schema_name = ?"
+			params = append(params, args.Schema)
+		}
+		if args.Table != "" {
+			q += " AND table_name = ?"
+			params = append(params, args.Table)
+		}
+		if args.DDLType != "" {
+			// Match prefix: "ALTER" matches "ALTER TABLE", etc.
+			q += " AND ddl_type LIKE ?"
+			params = append(params, strings.ToUpper(args.DDLType)+"%")
+		}
+		if sinceT != nil {
+			q += " AND detected_at >= ?"
+			params = append(params, *sinceT)
+		}
+		if untilT != nil {
+			q += " AND detected_at <= ?"
+			params = append(params, *untilT)
+		}
+		q += " ORDER BY detected_at DESC LIMIT ?"
+		params = append(params, limit)
+
+		rows, err := t.DB.QueryContext(ctx, q, params...)
+		if err != nil {
+			if strings.Contains(err.Error(), "doesn't exist") || strings.Contains(err.Error(), "1146") {
+				return ErrorResult(fmt.Errorf("schema_changes table not found; run `bintrail init` to create it")), nil, nil
+			}
+			return ErrorResult(fmt.Errorf("query schema_changes: %w", err)), nil, nil
+		}
+		defer rows.Close()
+
+		type schemaChange struct {
+			ID         int64  `json:"id"`
+			DetectedAt string `json:"detected_at"`
+			Schema     string `json:"schema_name"`
+			Table      string `json:"table_name"`
+			DDLType    string `json:"ddl_type"`
+			Statement  string `json:"statement"`
+			BinlogFile string `json:"binlog_file"`
+			BinlogPos  int64  `json:"binlog_pos"`
+			GTID       string `json:"gtid,omitempty"`
+		}
+
+		var results []schemaChange
+		for rows.Next() {
+			var sc schemaChange
+			var detectedAt time.Time
+			var gtid sql.NullString
+			if err := rows.Scan(&sc.ID, &detectedAt, &sc.Schema, &sc.Table, &sc.DDLType, &sc.Statement, &sc.BinlogFile, &sc.BinlogPos, &gtid); err != nil {
+				return ErrorResult(fmt.Errorf("scan: %w", err)), nil, nil
+			}
+			sc.DetectedAt = detectedAt.UTC().Format("2006-01-02 15:04:05")
+			if gtid.Valid {
+				sc.GTID = gtid.String
+			}
+			results = append(results, sc)
+		}
+		if err := rows.Err(); err != nil {
+			return ErrorResult(fmt.Errorf("rows iteration: %w", err)), nil, nil
+		}
+
+		out, err := json.MarshalIndent(results, "", "  ")
+		if err != nil {
+			return ErrorResult(fmt.Errorf("marshal: %w", err)), nil, nil
+		}
+
+		text := string(out)
+		n := len(results)
+		if n > 0 {
+			text += fmt.Sprintf("\n\n%d schema change(s)", n)
+		} else {
+			text = "No schema changes found."
+		}
+		if n >= limit {
+			text += fmt.Sprintf("\nWarning: results truncated at %d rows. Use a narrower since/until range or increase the limit to see more.", limit)
+		}
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: text},
+			},
+		}, nil, nil
+	}
+}
+
+// ─── Shared helpers ──────────────────────────────────────────────────────────
+
+// ErrorResult wraps an error as a tool-level MCP error result.
+func ErrorResult(err error) *mcp.CallToolResult {
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: err.Error()},
+		},
+		IsError: true,
+	}
+}
+
+// EnvArchiveSources returns Parquet archive source paths for use with
+// parquetquery.Fetch. It checks env vars BINTRAIL_ARCHIVE_S3 + BINTRAIL_ID
+// first (for explicit configuration — both must be set), then falls back to
+// auto-discovery from archive_state in the index database.
+func EnvArchiveSources(ctx context.Context, db *sql.DB) []string {
+	archiveS3 := os.Getenv("BINTRAIL_ARCHIVE_S3")
+	bintrailID := os.Getenv("BINTRAIL_ID")
+	if archiveS3 != "" && bintrailID != "" {
+		base := strings.TrimSuffix(archiveS3, "/") + "/bintrail_id=" + bintrailID
+		return []string{base}
+	}
+	if archiveS3 != "" || bintrailID != "" {
+		slog.Warn("partial archive env var config; both BINTRAIL_ARCHIVE_S3 and BINTRAIL_ID must be set",
+			"BINTRAIL_ARCHIVE_S3", archiveS3, "BINTRAIL_ID", bintrailID)
+	}
+	return stateArchiveSources(ctx, db)
+}
+
+// stateArchiveSources auto-discovers archive sources from archive_state,
+// warn-and-continue on failure (the MCP tools are deliberately permissive —
+// their own per-source fetch loops warn-and-continue too).
+func stateArchiveSources(ctx context.Context, db *sql.DB) []string {
+	sources, err := query.ResolveArchiveSources(ctx, db)
+	if err != nil {
+		slog.Warn("archive auto-discovery failed; proceeding without archives", "error", err)
+		return nil
+	}
+	return sources
+}
+
+// DefaultQueryMaxLimit is the hard row ceiling for the MCP query tool (#654):
+// a backstop against a pathological explicit limit OOMing the long-lived server.
+// ~1M rows is multiple GB worst-case at the project's per-row sizing — far above
+// any legitimate agent query, yet bounded. The unbounded escape hatch is the
+// `bintrail query` CLI, so this is deliberately not disengageable via env.
+const DefaultQueryMaxLimit = 1_000_000
+
+// EnvQueryMaxLimit returns the standalone MCP query-tool row ceiling.
+// BINTRAIL_MCP_QUERY_MAX_LIMIT raises or lowers it; an empty/invalid/<=0 value
+// falls back to the default rather than disabling the ceiling (the CLI is the
+// unbounded path, not the agent-facing tool).
+func EnvQueryMaxLimit() int {
+	if v := os.Getenv("BINTRAIL_MCP_QUERY_MAX_LIMIT"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return DefaultQueryMaxLimit
+}
+
+// ApplyQueryCeiling caps limit to max, returning the (possibly capped) limit and
+// whether a cap was applied. max <= 0 disables capping.
+func ApplyQueryCeiling(limit, max int) (int, bool) {
+	if max > 0 && limit > max {
+		return max, true
+	}
+	return limit, false
+}
+
+// QueryResultNotice composes the trailing warning appended to a query-tool
+// result. When the ceiling fired it SUPERSEDES the generic truncation notice —
+// telling an agent to "increase the limit" would be wrong, since the limit it
+// asked for is exactly the one that was capped (and after a cap n == limit makes
+// the generic arm true too, so order matters). Returns "" when no notice applies.
+func QueryResultNotice(ceilingApplied bool, requestedLimit, ceiling, n, limit int) string {
+	switch {
+	case ceilingApplied:
+		return fmt.Sprintf("\nWarning: requested limit %d exceeds the MCP query ceiling of %d rows; capped to %d. "+
+			"Narrow your filters/time range, or run the `bintrail query` CLI for an unbounded export.\n", requestedLimit, ceiling, ceiling)
+	case n >= limit:
+		return fmt.Sprintf("\nWarning: results truncated at %d rows. Use a narrower since/until range or increase the limit to see more.\n", limit)
+	}
+	return ""
+}
+
+// BuildQueryOptions converts the shared tool filter parameters into a
+// query.Options, validating cross-field requirements and applying the default
+// limit to a non-positive request.
+func BuildQueryOptions(schema, table, pk, eventType, gtid, since, until, changedCol string, columnEq []string, flagVal string, limit, defaultLimit int) (query.Options, error) {
+	if pk != "" && (schema == "" || table == "") {
+		return query.Options{}, fmt.Errorf("pk requires both schema and table")
+	}
+	if changedCol != "" && (schema == "" || table == "") {
+		return query.Options{}, fmt.Errorf("changed_column requires both schema and table")
+	}
+	if len(columnEq) > 0 && (schema == "" || table == "") {
+		return query.Options{}, fmt.Errorf("column_eq requires both schema and table")
+	}
+
+	et, err := cliutil.ParseEventType(eventType)
+	if err != nil {
+		return query.Options{}, err
+	}
+	sinceT, err := cliutil.ParseTime(since)
+	if err != nil {
+		return query.Options{}, fmt.Errorf("invalid since: %w", err)
+	}
+	untilT, err := cliutil.ParseTime(until)
+	if err != nil {
+		return query.Options{}, fmt.Errorf("invalid until: %w", err)
+	}
+	parsedEq, err := query.ParseColumnEqs(columnEq)
+	if err != nil {
+		return query.Options{}, err
+	}
+
+	if limit <= 0 {
+		limit = defaultLimit
+	}
+
+	return query.Options{
+		Schema:        schema,
+		Table:         table,
+		PKValues:      pk,
+		EventType:     et,
+		GTID:          gtid,
+		Since:         sinceT,
+		Until:         untilT,
+		ChangedColumn: changedCol,
+		ColumnEq:      parsedEq,
+		Flag:          flagVal,
+		Limit:         limit,
+	}, nil
+}

--- a/internal/mcptools/mcptools_test.go
+++ b/internal/mcptools/mcptools_test.go
@@ -1,0 +1,146 @@
+package mcptools
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/dbtrail/dbtrail/internal/query"
+)
+
+// resultText extracts the text of a tool result's first content item.
+func resultText(res *mcp.CallToolResult) string {
+	if res == nil || len(res.Content) == 0 {
+		return ""
+	}
+	tc, ok := res.Content[0].(*mcp.TextContent)
+	if !ok {
+		return ""
+	}
+	return tc.Text
+}
+
+// makeRowsWithStatement builds two rows: one carrying captured statement
+// text, one without (the nil case must stay nil after stripping).
+func makeRowsWithStatement(qt, qh string) []query.ResultRow {
+	return []query.ResultRow{
+		{EventID: 1, QueryText: &qt, QueryHash: &qh},
+		{EventID: 2},
+	}
+}
+
+// rejectingConfig is the console-style posture: DSN/profile parameters
+// refused. Resolve fails the test if a handler reaches it despite the
+// rejection — the whole point is that the surface never dereferences a
+// client-supplied DSN.
+func rejectingConfig(t *testing.T) Config {
+	t.Helper()
+	return Config{
+		Resolve: func(ctx context.Context, argDSN string) (*Target, error) {
+			t.Fatalf("Resolve must not be called for a rejected parameter (argDSN=%q)", argDSN)
+			return nil, nil
+		},
+		AllowDSNParam:     false,
+		AllowProfileParam: false,
+	}
+}
+
+func TestIndexDSNParamRejected(t *testing.T) {
+	cfg := rejectingConfig(t)
+	ctx := context.Background()
+
+	cases := []struct {
+		tool string
+		call func() (isErr bool, text string)
+	}{
+		{"query", func() (bool, string) {
+			res, _, _ := MakeQueryTool(cfg)(ctx, nil, QueryArgs{IndexDSN: "u:p@tcp(1.2.3.4:3306)/x"})
+			return res.IsError, resultText(res)
+		}},
+		{"recover", func() (bool, string) {
+			res, _, _ := MakeRecoverTool(cfg)(ctx, nil, RecoverArgs{IndexDSN: "u:p@tcp(1.2.3.4:3306)/x"})
+			return res.IsError, resultText(res)
+		}},
+		{"status", func() (bool, string) {
+			res, _, _ := MakeStatusTool(cfg)(ctx, nil, StatusArgs{IndexDSN: "u:p@tcp(1.2.3.4:3306)/x"})
+			return res.IsError, resultText(res)
+		}},
+		{"list_schema_changes", func() (bool, string) {
+			res, _, _ := MakeSchemaChangesTool(cfg)(ctx, nil, SchemaChangesArgs{IndexDSN: "u:p@tcp(1.2.3.4:3306)/x"})
+			return res.IsError, resultText(res)
+		}},
+	}
+	for _, tc := range cases {
+		isErr, text := tc.call()
+		if !isErr {
+			t.Errorf("%s: index_dsn must be rejected when AllowDSNParam is false", tc.tool)
+		}
+		if !strings.Contains(text, "index_dsn is not accepted") {
+			t.Errorf("%s: rejection must be explicit, got: %s", tc.tool, text)
+		}
+	}
+}
+
+func TestProfileParamRejected(t *testing.T) {
+	cfg := rejectingConfig(t)
+	ctx := context.Background()
+
+	res, _, _ := MakeQueryTool(cfg)(ctx, nil, QueryArgs{Profile: "auditor"})
+	if !res.IsError || !strings.Contains(resultText(res), "profile is not accepted") {
+		t.Errorf("query: profile must be rejected when AllowProfileParam is false, got: %s", resultText(res))
+	}
+	res, _, _ = MakeRecoverTool(cfg)(ctx, nil, RecoverArgs{Profile: "auditor"})
+	if !res.IsError || !strings.Contains(resultText(res), "profile is not accepted") {
+		t.Errorf("recover: profile must be rejected when AllowProfileParam is false, got: %s", resultText(res))
+	}
+}
+
+func TestParamsAcceptedOnStandalonePosture(t *testing.T) {
+	// With both params allowed, rejection must not fire; the call proceeds to
+	// Resolve (which errors here, proving the gate was passed).
+	cfg := Config{
+		Resolve: func(ctx context.Context, argDSN string) (*Target, error) {
+			if argDSN != "dsn-under-test" {
+				t.Errorf("argDSN = %q, want it passed through", argDSN)
+			}
+			return nil, context.Canceled // any error: stops before touching a DB
+		},
+		AllowDSNParam:     true,
+		AllowProfileParam: true,
+	}
+	res, _, _ := MakeQueryTool(cfg)(context.Background(), nil, QueryArgs{IndexDSN: "dsn-under-test", Profile: "p"})
+	if !res.IsError {
+		t.Fatal("expected the resolver error to surface")
+	}
+	if strings.Contains(resultText(res), "not accepted") {
+		t.Errorf("params must not be rejected on the standalone posture: %s", resultText(res))
+	}
+}
+
+func TestNewServerRegistersTools(t *testing.T) {
+	s := NewServer(Config{Version: "test"})
+	if s == nil {
+		t.Fatal("NewServer returned nil")
+	}
+}
+
+func TestStripStatementText(t *testing.T) {
+	qt, qh := "UPDATE t SET secret = 1", "abc123"
+	rows := makeRowsWithStatement(qt, qh)
+
+	off := &Target{RedactStatementText: false}
+	off.stripStatementText(rows)
+	if rows[0].QueryText == nil {
+		t.Fatal("strip must be a no-op when RedactStatementText is false")
+	}
+
+	on := &Target{RedactStatementText: true}
+	on.stripStatementText(rows)
+	for i, r := range rows {
+		if r.QueryText != nil || r.QueryHash != nil {
+			t.Errorf("row %d: query_text/query_hash must be blanked, got %v/%v", i, r.QueryText, r.QueryHash)
+		}
+	}
+}


### PR DESCRIPTION
Serves the four read-only MCP tools (`query`, `recover`, `status`, `list_schema_changes`) from `bintrail-console` — both `serve` and `watch` — over **Streamable HTTP** at `/mcp`, authenticated with the console token and routed per registry server.

## Seam extraction

The tool registration and the four handlers move from `cmd/bintrail-mcp/main.go` into a new **`internal/mcptools`** package, parameterized by a `ResolveTarget` seam: a callback mapping the (possibly empty) tool `index_dsn` argument to a `Target` carrying the connection plus the read posture the serving surface imposes on it — connection ownership (`CloseDB`), schema migration (`EnsureSchema`), archive discovery mode, RBAC rules, a preloaded schema resolver, and statement-text redaction.

- `cmd/bintrail-mcp` becomes a thin wrapper (`DSNTarget` posture: per-call DSN resolution with env fallback, fresh connection per call closed after use, idempotent `EnsureSchema`, env-var archive discovery, per-call `profile`, env-tunable query ceiling). Behavior, flags (`--http`, `--tenant-dsns`), and the stdio disconnect handling are unchanged; the package keeps compatibility aliases so its existing test files run without modification.
- `internal/console` binds the tools to its `connManager` bundles (`internal/console/mcp.go`), resolved **per tool call** — lazy registry opens, mid-session edits, and per-server capability changes behave exactly like every other console surface. `internal/mcptools` is added to the `TestReadLayerDoesNotLinkGoMySQL` enumeration.

## Routing

- `POST/GET /mcp` → the console's default server, using the same selection rules as header-less API requests (including HideBoot: a source-less `watch` with an empty registry still resolves to the hidden boot bundle, but `/mcp/default` stays 404 there — the hidden boot is not selectable anywhere else either).
- `/mcp/{id-or-name}` → that registry server, by id, display name, or `default` for the boot entry — the same resolution the flashback port uses for its username routing. Unknown selector → 404 JSON before the request reaches the MCP handler.

The server choice lives in the URL path because MCP clients cannot reliably send custom headers (the browser API's `X-Bintrail-Server` header is not an option).

## Security posture

- **Auth**: `Authorization: Bearer <console token>`, `subtle.ConstantTimeCompare`, same as the API. Login sessions are deliberately **not** accepted: they are a browser credential.
- **Token required**: mirroring the flashback-port precedent, `/mcp` requires a static token to be configured. Under password-only or no auth the endpoint refuses every request with an actionable 403 naming the remediation (`--token` / `BINTRAIL_CONSOLE_TOKEN`); it never serves open.
- **Host-header allowlist and security headers** apply — the handler mounts on the guarded root mux.
- **`index_dsn` rejected** (decision per the issue): an authenticated MCP client must not be able to point the console at an arbitrary DSN. The rejection is an explicit tool error pointing at the path-routing model, and fires before the resolver runs. **`profile` is rejected the same way**: the console's RBAC posture is fixed at process start (process-global rules attach to every query), and a per-call profile parameter would let a client vary it.

## Read boundary

- Result caps match the console API: events 100 default / 1000 hard (enforced via the query-ceiling mechanism, with the explicit capped notice), recover 1000 / 10000 (clamped like `/api/recover`).
- The per-server bundle posture applies: `noArchive` (which already folds in an active RBAC profile) disables archive auto-routing; env-var archive discovery is standalone-only.
- `query_text` / `query_hash` are stripped from query results, matching the events API's `eventDTO` (the JSON keys render as `null`, same as the redaction pass under an active profile — the values never leave the server).
- Console targets are never `EnsureSchema`'d: the boot entry is migrated by the cmd layer at startup, and registry servers keep the console's no-DDL contract (a legacy index surfaces the fetch error on the tool call).

## Tests

- Unit (`internal/console/mcp_test.go`): token-not-configured refusal (403 + remediation), missing/wrong/right token (401/401/200), routing (default, by id, by name, `default`, unknown → 404, empty console → 404, hidden-boot default fallback), host-guard coverage on `/mcp`.
- Unit (`internal/mcptools/mcptools_test.go`): `index_dsn`/`profile` rejection on all four tools without ever invoking the resolver, pass-through on the standalone posture, statement-text stripping.
- Integration (`internal/console/mcp_integration_test.go`, `//go:build integration`): a real go-sdk Streamable HTTP client against a seeded index — tool listing (exactly 4), query round-trip asserting row data present and stamped `query_text`/`query_hash` values absent, `index_dsn` rejection, the 1000-row ceiling notice, recover and status round-trips, wrong-token connect failure, and `/mcp/{name}` registry routing.

`go build ./...`, `go test ./... -count=1`, `go vet ./...` and `go vet -tags integration ./...` all pass. The integration tests could not be executed in this environment: port 13306 is currently held by an unrelated local port-forward, so the standard test MySQL container is unavailable (the new tests skip cleanly via `SkipIfNoMySQL`); they compile under `-tags integration` vet.

## Notes / deviations

- The tool input schemas still advertise `index_dsn`/`profile` (the argument structs are shared with the standalone server); the console rejects them at call time with an explicit error, per the issue's chosen posture.
- MCP query/recover through the console use the shared mcptools fetch path (live + discovered archives, merge) rather than the API's planner-backed `FetchMerged`, so coverage-gap warnings are not emitted on this surface — same as the standalone MCP server today.
- Docs: new "MCP endpoint" section in `docs/console.md` and a pointer from `docs/mcp-server.md`.

Closes #1039

🤖 Generated with [Claude Code](https://claude.com/claude-code)
