### PR TITLE
console(ext): keep source-only extension views usable when the index is down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- A source-only console extension view (one whose data endpoints read only the live source, never the index) now stays usable while the selected server's index is unreachable or not yet created. `ext.ConsoleQueryContext` resolves the source DSN from the registry **without** opening the index, and on a failed index open with a source configured it hands the provider a usable context (`DB` nil, a `Fetch` that surfaces the index error, `SourceDSN` populated) instead of failing the whole request — so source-only investigation keeps working during an index outage. An index-backed view must nil-check `DB` or read through `Fetch`; the contract is documented on the type. With no source configured, a failed index open stays an error.
+
 ## [0.36.0] - 2026-07-17
 
 ### Added

--- a/ext/consoleview.go
+++ b/ext/consoleview.go
@@ -18,6 +18,15 @@ type ConsoleQueryContext struct {
 	// DB is the selected server's index connection. It is owned by the console
 	// (pooled and lazily opened per server); the provider must NOT close it, and
 	// must not assume it outlives the request.
+	//
+	// DB is NIL when the index cannot be opened (a dead entry, or a per-source
+	// index that does not exist yet) but the selected server DOES have a source
+	// configured — so a source-only view (one that reads only the live source,
+	// never the index) still resolves and runs during an index outage. An
+	// index-backed view MUST nil-check DB (or rely on Fetch, below) rather than
+	// dereference it. When the index opened successfully, DB is non-nil; when no
+	// source is configured AND the index cannot be opened, the resolve func
+	// returns an error instead of this struct.
 	DB *sql.DB
 	// Fetch runs the console's own cross-source read pipeline (live MySQL
 	// partitions plus Parquet archives, merged, sorted, gap-aware) already bound
@@ -25,12 +34,20 @@ type ConsoleQueryContext struct {
 	// started with, so a provider that fetches through it inherits the operator's
 	// profile rather than having to reimplement redaction. Prefer it over
 	// querying DB directly whenever archive coverage or redaction matters.
+	//
+	// Fetch is always non-nil (never call it on a nil value), but when DB is nil
+	// — the index-unreachable-but-source-configured case above — Fetch returns
+	// the underlying index error on every call. An index-backed view thus
+	// degrades with a real error instead of a nil-pointer panic or a false empty
+	// result.
 	Fetch func(ctx context.Context, opts indexquery.Options) ([]indexquery.ResultRow, *indexquery.QueryPlan, error)
 	// SourceDSN is the captured-source DSN of the selected registry entry, when
 	// one is configured — a provider that needs to reach the live source (not
 	// just the index) can use it. Empty for the boot/command-line entry and for a
 	// selection with no source configured; treat empty as "no source available",
-	// not an error.
+	// not an error. It is read from the registry WITHOUT opening the index, so it
+	// is populated even when the index is unreachable (the DB-nil case above) —
+	// that is what keeps a source-only view working during an index outage.
 	SourceDSN string
 }
 

--- a/internal/console/extview.go
+++ b/internal/console/extview.go
@@ -15,15 +15,38 @@ import (
 // default). The returned error is already DSN-scrubbed by the resolver, so it is
 // safe for the provider to surface to the client.
 func (s *Server) consoleQueryContext(r *http.Request) (ext.ConsoleQueryContext, error) {
-	b, err := s.resolve(r)
-	if err != nil {
-		return ext.ConsoleQueryContext{}, err
-	}
-	// SourceDSN is a registry-only hint (the boot entry has none); "not found"
-	// is not an error — the provider treats an empty DSN as "no source".
+	// Read the selected registry entry's source DSN FIRST — a pure registry
+	// lookup (selectedEntry) that never opens or pings the index. This ordering
+	// is load-bearing: a provider view with source-only endpoints (ones that read
+	// only the live source — never the index) must stay usable during the exact
+	// incident such a view exists for — the source is up but the per-source
+	// index is unreachable or not yet created. "not found" is not an error: an
+	// empty DSN means "no source", which the provider treats as not-configured.
 	sourceDSN := ""
 	if e, ok := s.selectedEntry(r); ok {
 		sourceDSN = e.SourceDSN
+	}
+
+	b, err := s.resolve(r)
+	if err != nil {
+		// The index could not be opened (dead entry, or a per-source index that
+		// does not exist yet). When a source IS configured, still hand the
+		// provider a usable context so its source-only endpoints work off
+		// SourceDSN: DB is nil and Fetch returns the resolve error (so
+		// index-backed endpoints degrade with a real error rather than silently
+		// pretending success), but SourceDSN is populated. With no source
+		// configured there is nothing to serve, so surface the (already
+		// DSN-scrubbed) resolve error unchanged.
+		if sourceDSN == "" {
+			return ext.ConsoleQueryContext{}, err
+		}
+		return ext.ConsoleQueryContext{
+			DB: nil,
+			Fetch: func(context.Context, query.Options) ([]query.ResultRow, *query.QueryPlan, error) {
+				return nil, nil, err
+			},
+			SourceDSN: sourceDSN,
+		}, nil
 	}
 	return ext.ConsoleQueryContext{
 		DB:        b.db,

--- a/internal/console/extview_test.go
+++ b/internal/console/extview_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/dbtrail/dbtrail/ext"
@@ -224,6 +225,70 @@ func TestExtensionViewInvalidIDSkipped(t *testing.T) {
 	}
 	if rec := getPath(t, s, "127.0.0.1:8090", "/ext/Example/view.js", ""); rec.Code != http.StatusNotFound {
 		t.Errorf("static route for an invalid-id provider = %d, want 404 (not mounted)", rec.Code)
+	}
+}
+
+// (h) consoleQueryContext degrades gracefully when the selected server's index
+// cannot be opened but a SOURCE is configured: it returns a usable context (nil
+// DB, populated SourceDSN, a Fetch that surfaces the index error) rather than
+// failing outright — so a provider's source-only endpoints keep working during
+// an index outage (source up, index down — the incident a source-only view exists for).
+func TestConsoleQueryContextSourceOnlyWhenIndexDown(t *testing.T) {
+	reg, err := LoadRegistry("")
+	if err != nil {
+		t.Fatalf("LoadRegistry: %v", err)
+	}
+	// Index DSN parses but refuses fast (port 1); the source DSN is what a
+	// source-only endpoint needs and must survive the failed index open.
+	entry, err := reg.Add(ServerEntry{
+		Name:      "prod",
+		DSN:       "u:p@tcp(127.0.0.1:1)/idx_missing",
+		SourceDSN: "r:p@tcp(src.example:3306)/",
+	})
+	if err != nil {
+		t.Fatalf("reg.Add: %v", err)
+	}
+	s := &Server{token: "t", cm: newConnManager(reg, false)}
+
+	r := httptest.NewRequest(http.MethodGet, "/api/ext/example/source-info", nil)
+	r.Header.Set(serverHeader, entry.ID)
+
+	qc, err := s.consoleQueryContext(r)
+	if err != nil {
+		t.Fatalf("consoleQueryContext returned an error for a configured source with a down index: %v", err)
+	}
+	if qc.DB != nil {
+		t.Error("DB must be nil when the index could not be opened")
+	}
+	if qc.SourceDSN != entry.SourceDSN {
+		t.Errorf("SourceDSN = %q, want %q (must survive the failed index open)", qc.SourceDSN, entry.SourceDSN)
+	}
+	if qc.Fetch == nil {
+		t.Fatal("Fetch must be non-nil even when the index is down (an index-backed view calls it unconditionally)")
+	}
+	if _, _, ferr := qc.Fetch(r.Context(), query.Options{}); ferr == nil {
+		t.Error("Fetch must return the index error when DB is nil, not a false empty result")
+	}
+}
+
+// (h2) with NO source configured, a failed index open is a genuine error — there
+// is nothing to serve, so the resolve func surfaces the (DSN-scrubbed) error.
+func TestConsoleQueryContextErrorsWhenIndexDownAndNoSource(t *testing.T) {
+	reg, err := LoadRegistry("")
+	if err != nil {
+		t.Fatalf("LoadRegistry: %v", err)
+	}
+	entry, err := reg.Add(ServerEntry{Name: "idx-only", DSN: "u:p@tcp(127.0.0.1:1)/idx_missing"})
+	if err != nil {
+		t.Fatalf("reg.Add: %v", err)
+	}
+	s := &Server{token: "t", cm: newConnManager(reg, false)}
+
+	r := httptest.NewRequest(http.MethodGet, "/api/ext/example/index-info", nil)
+	r.Header.Set(serverHeader, entry.ID)
+
+	if _, err := s.consoleQueryContext(r); err == nil {
+		t.Fatal("consoleQueryContext must error when the index is down and no source is configured")
 	}
 }
 


### PR DESCRIPTION
## Problem

`consoleQueryContext` (the per-request resolver handed to a `ConsoleViewProvider`'s data handler) resolved the selected server's **index** bundle first — `config.Connect` pings eagerly — and returned its error before reading the registry-only `SourceDSN`. So an extension view with **source-only** endpoints (routes that read only the live source, never the index) was denied its source DSN whenever the per-source index was unreachable or not yet created — precisely the "source up, index degraded" incident such a view exists to investigate.

## Fix

- Read `SourceDSN` from the registry **first** — a pure `selectedEntry` lookup that never opens or pings the index.
- On a failed index open **with a source configured**, hand the provider a usable `ext.ConsoleQueryContext`: `DB` is nil, `Fetch` returns the underlying index error on every call (so an index-backed view degrades with a real error instead of a nil-pointer panic or a false-empty result), and `SourceDSN` is populated.
- With **no source configured**, a failed index open stays an error (nothing to serve).
- Document the contract on `ext.ConsoleQueryContext`: `DB` may be nil (an index-backed view must nil-check it or read through `Fetch`); `Fetch` is always non-nil.

This restores the index-independent behavior source-only views had before the view surface moved onto the extension seam. The sole consumer of the seam today already reads only `SourceDSN` on its source-only routes and nil-checks the index handle.

## Tests

- `TestConsoleQueryContextSourceOnlyWhenIndexDown` — configured source + unreachable index ⇒ usable context (nil `DB`, populated `SourceDSN`, `Fetch` surfaces the index error).
- `TestConsoleQueryContextErrorsWhenIndexDownAndNoSource` — no source + unreachable index ⇒ error.
- `go build ./...`, `go vet`, `go test ./internal/console/ ./ext/` green under `GOWORK=off` (the module build CI resolves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)