### PR TITLE
mcp: --connect stdio↔HTTP bridge mode + .mcpb release bundles

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -51,6 +51,15 @@ builds:
     ldflags:
       - -s -w
       - -X main.mcpVersion={{.Version}}
+    # Package each bintrail-mcp binary as an MCP Bundle (.mcpb) — the Claude
+    # Desktop one-click install format (#1040): a zip of manifest.json +
+    # server/bintrail-mcp whose config form asks for the console URL + token
+    # and runs the binary in `--connect` bridge mode. The script validates the
+    # produced bundle (manifest fields, entry binary), so a malformed bundle
+    # fails the release. Published via release.extra_files below.
+    hooks:
+      post:
+        - cmd: bash scripts/build-mcpb.sh "{{ .Path }}" "{{ .Os }}" "{{ .Arch }}" "{{ .Version }}"
 
   # bintrail-console links DuckDB (console → query → parquetquery), so it is
   # CGO like the core binary — and uses the SAME main.* ldflags var names, so
@@ -131,12 +140,20 @@ archives:
 
 checksum:
   name_template: "checksums.txt"
+  # Include the .mcpb bundles (built by the bintrail-mcp post hook, published
+  # via release.extra_files) in checksums.txt.
+  extra_files:
+    - glob: dist/mcpb/*.mcpb
 
 # Auto-detect prereleases from the tag (e.g. v0.7.12-rc1) and mark the
 # GitHub release "prerelease" so an RC never claims the "Latest" badge.
 # Pairs with skip_push: auto on the :latest Docker manifest below.
 release:
   prerelease: auto
+  # .mcpb MCP Bundles (Claude Desktop one-click install) — produced by the
+  # bintrail-mcp build post hook, one per platform in the build matrix.
+  extra_files:
+    - glob: dist/mcpb/*.mcpb
 
 # ── Linux packages (deb/rpm) ───────────────────────────────
 # Attached to the GitHub release as downloadable assets. No external

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ GATEWAY_LDFLAGS=-ldflags "-X main.gatewayVersion=$(VERSION)"
 # bintrail-console and bintrail-pg both reuse BINTRAIL_LDFLAGS: they inject the
 # same main.Version/CommitSHA/BuildDate vars as the core binary.
 
-.PHONY: all build build-mcp build-gateway build-console build-pg clean test console-e2e lint install build-all tidy deps notices check-notices
+.PHONY: all build build-mcp build-gateway build-console build-pg clean test console-e2e lint install build-all tidy deps notices check-notices mcpb validate-mcpb
 
 all: build build-mcp build-gateway build-console build-pg
 
@@ -84,6 +84,18 @@ build-all:
 	GOOS=linux   GOARCH=arm64 CGO_ENABLED=0 go build $(GATEWAY_LDFLAGS) -o dist/$(GATEWAY_BINARY)-linux-arm64 ./cmd/mcp-gateway
 	GOOS=darwin  GOARCH=amd64 CGO_ENABLED=0 go build $(GATEWAY_LDFLAGS) -o dist/$(GATEWAY_BINARY)-darwin-amd64 ./cmd/mcp-gateway
 	GOOS=darwin  GOARCH=arm64 CGO_ENABLED=0 go build $(GATEWAY_LDFLAGS) -o dist/$(GATEWAY_BINARY)-darwin-arm64 ./cmd/mcp-gateway
+
+# Build + validate an .mcpb MCP Bundle (the Claude Desktop one-click install
+# format) for the HOST platform, e.g. dist/mcpb/dbtrail-darwin-arm64.mcpb on
+# an Apple Silicon Mac. Release bundles are produced per release-matrix
+# platform by GoReleaser (scripts/build-mcpb.sh runs as a bintrail-mcp
+# post-build hook and validates each bundle).
+mcpb: build-mcp
+	bash scripts/build-mcpb.sh $(MCP_BINARY) $(shell go env GOOS) $(shell go env GOARCH) $(VERSION)
+
+# Re-validate already-built bundles (unzip + manifest + entry-binary checks).
+validate-mcpb:
+	bash scripts/validate-mcpb.sh dist/mcpb/*.mcpb
 
 tidy:
 	go mod tidy

--- a/cmd/bintrail-mcp/bridge.go
+++ b/cmd/bintrail-mcp/bridge.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -55,14 +56,21 @@ func validateBridgeFlags(connectURL, httpAddr, tenantDSNsFile, token string) err
 	return nil
 }
 
-// bearerTransport injects an Authorization: Bearer header on every request to
-// the remote endpoint.
+// bearerTransport injects an Authorization: Bearer header on requests to the
+// configured endpoint host. Scoping by host matters: header stripping on
+// cross-host redirects happens in http.Client above the Transport layer, so a
+// transport that stamped the token unconditionally would re-attach it to a
+// redirect aimed at a different host.
 type bearerTransport struct {
 	token string
+	host  string
 	base  http.RoundTripper
 }
 
 func (t *bearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.URL.Host != t.host {
+		return t.base.RoundTrip(req)
+	}
 	// Per RoundTripper contract the request must not be mutated; clone first.
 	r := req.Clone(req.Context())
 	r.Header.Set("Authorization", "Bearer "+t.token)
@@ -86,7 +94,11 @@ type bridge struct {
 func newBridge(ctx context.Context, endpoint, token string) (*bridge, error) {
 	httpClient := http.DefaultClient
 	if token != "" {
-		httpClient = &http.Client{Transport: &bearerTransport{token: token, base: http.DefaultTransport}}
+		u, err := url.Parse(endpoint)
+		if err != nil {
+			return nil, fmt.Errorf("invalid --connect URL %q: %w", endpoint, err)
+		}
+		httpClient = &http.Client{Transport: &bearerTransport{token: token, host: u.Host, base: http.DefaultTransport}}
 	}
 	transport := &mcp.StreamableClientTransport{
 		Endpoint:   endpoint,
@@ -158,10 +170,15 @@ func (b *bridge) resync(ctx context.Context) error {
 
 	seen := map[string]bool{}
 	for _, tool := range remote {
+		// AddTool panics on a non-object input schema — and on a present,
+		// non-object output schema; a malformed remote tool must not take the
+		// whole bridge down.
 		if !isObjectSchema(tool.InputSchema) {
-			// AddTool panics on a non-object input schema; a malformed remote
-			// tool must not take the whole bridge down.
 			slog.Warn("bridge: skipping remote tool with non-object input schema", "tool", tool.Name)
+			continue
+		}
+		if tool.OutputSchema != nil && !isObjectSchema(tool.OutputSchema) {
+			slog.Warn("bridge: skipping remote tool with non-object output schema", "tool", tool.Name)
 			continue
 		}
 		b.server.AddTool(tool, b.forward(tool.Name))

--- a/cmd/bintrail-mcp/bridge.go
+++ b/cmd/bintrail-mcp/bridge.go
@@ -1,0 +1,231 @@
+// Bridge mode (--connect): a stdio ↔ Streamable-HTTP proxy.
+//
+// The process runs as a local stdio MCP server — what Claude Desktop and
+// similar clients launch — and forwards every tool call to a remote bintrail
+// Streamable-HTTP MCP endpoint (a `bintrail-mcp --http` server or a console
+// `/mcp` endpoint). The tool set is a dynamic passthrough: tools are listed
+// from the remote at startup and re-exposed verbatim (names, descriptions,
+// schemas, annotations), and re-synced when the remote emits a
+// tools/list_changed notification — the bridge never carries its own tool
+// declarations, so it cannot drift from the server it fronts.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// bridgeConnectTimeout bounds the initial connect + tool listing against the
+// remote endpoint. An unreachable URL or a hung server must produce a fast,
+// loud exit — Claude Desktop surfaces stderr, not a silent hang. The
+// StreamableClientTransport detaches its connection lifetime from this
+// context (verified against go-sdk v1.3.1), so the timeout does not kill an
+// established session.
+const bridgeConnectTimeout = 15 * time.Second
+
+// validateBridgeFlags enforces the flag contract around --connect: bridge
+// mode is mutually exclusive with --http (the process is a client of a remote
+// HTTP server, not an HTTP server itself) and with --tenant-dsns (DSN-based
+// operation happens on the remote end), and --token is meaningless without
+// --connect.
+func validateBridgeFlags(connectURL, httpAddr, tenantDSNsFile, token string) error {
+	if connectURL == "" {
+		if token != "" {
+			return fmt.Errorf("--token requires --connect")
+		}
+		return nil
+	}
+	if httpAddr != "" {
+		return fmt.Errorf("--connect and --http are mutually exclusive: the bridge is a stdio front-end for a remote HTTP endpoint")
+	}
+	if tenantDSNsFile != "" {
+		return fmt.Errorf("--connect and --tenant-dsns are mutually exclusive: in bridge mode DSNs are resolved by the remote server")
+	}
+	if !strings.HasPrefix(connectURL, "http://") && !strings.HasPrefix(connectURL, "https://") {
+		return fmt.Errorf("--connect URL must start with http:// or https:// (got %q)", connectURL)
+	}
+	return nil
+}
+
+// bearerTransport injects an Authorization: Bearer header on every request to
+// the remote endpoint.
+type bearerTransport struct {
+	token string
+	base  http.RoundTripper
+}
+
+func (t *bearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Per RoundTripper contract the request must not be mutated; clone first.
+	r := req.Clone(req.Context())
+	r.Header.Set("Authorization", "Bearer "+t.token)
+	return t.base.RoundTrip(r)
+}
+
+// bridge proxies tool listings and calls between a local MCP server (stdio
+// side) and a remote client session (HTTP side).
+type bridge struct {
+	endpoint string
+	session  *mcp.ClientSession
+	server   *mcp.Server
+
+	mu    sync.Mutex
+	tools map[string]bool // tool names currently registered on the local server
+}
+
+// newBridge connects to the remote endpoint, mirrors its tool set onto a
+// local proxy server, and returns the bridge. It is factored out of runBridge
+// so tests can drive the proxy server over in-memory transports.
+func newBridge(ctx context.Context, endpoint, token string) (*bridge, error) {
+	httpClient := http.DefaultClient
+	if token != "" {
+		httpClient = &http.Client{Transport: &bearerTransport{token: token, base: http.DefaultTransport}}
+	}
+	transport := &mcp.StreamableClientTransport{
+		Endpoint:   endpoint,
+		HTTPClient: httpClient,
+	}
+
+	b := &bridge{endpoint: endpoint, tools: map[string]bool{}}
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "bintrail-mcp-bridge", Version: mcpVersion}, &mcp.ClientOptions{
+		// Re-sync the mirrored tool set when the remote's changes, so a
+		// long-lived Desktop session tracks server-side updates.
+		ToolListChangedHandler: func(ctx context.Context, req *mcp.ToolListChangedRequest) {
+			if err := b.resync(ctx); err != nil {
+				slog.Warn("bridge: tool re-sync after list_changed failed", "endpoint", b.endpoint, "error", err)
+			}
+		},
+	})
+
+	connectCtx, cancel := context.WithTimeout(ctx, bridgeConnectTimeout)
+	defer cancel()
+
+	session, err := client.Connect(connectCtx, transport, nil)
+	if err != nil {
+		return nil, fmt.Errorf("cannot connect to %s: %w%s", endpoint, err, authHint(err))
+	}
+	b.session = session
+
+	// Mirror the remote server's instructions so the stdio client sees the
+	// same guidance it would get connecting directly.
+	instructions := ""
+	if ir := session.InitializeResult(); ir != nil {
+		instructions = ir.Instructions
+	}
+	b.server = mcp.NewServer(&mcp.Implementation{Name: "bintrail", Version: mcpVersion}, &mcp.ServerOptions{
+		Instructions: instructions,
+	})
+
+	if err := b.resync(connectCtx); err != nil {
+		session.Close()
+		return nil, fmt.Errorf("cannot list tools on %s: %w%s", endpoint, err, authHint(err))
+	}
+	return b, nil
+}
+
+// Close terminates the remote session.
+func (b *bridge) Close() error { return b.session.Close() }
+
+// toolCount returns the number of currently mirrored tools.
+func (b *bridge) toolCount() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.tools)
+}
+
+// resync lists the remote tools and reconciles the local proxy server's tool
+// set: every remote tool is (re-)registered verbatim with a forwarding
+// handler, and local tools that disappeared from the remote are removed.
+func (b *bridge) resync(ctx context.Context) error {
+	var remote []*mcp.Tool
+	for tool, err := range b.session.Tools(ctx, nil) {
+		if err != nil {
+			return err
+		}
+		remote = append(remote, tool)
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	seen := map[string]bool{}
+	for _, tool := range remote {
+		if !isObjectSchema(tool.InputSchema) {
+			// AddTool panics on a non-object input schema; a malformed remote
+			// tool must not take the whole bridge down.
+			slog.Warn("bridge: skipping remote tool with non-object input schema", "tool", tool.Name)
+			continue
+		}
+		b.server.AddTool(tool, b.forward(tool.Name))
+		seen[tool.Name] = true
+	}
+	var stale []string
+	for name := range b.tools {
+		if !seen[name] {
+			stale = append(stale, name)
+		}
+	}
+	if len(stale) > 0 {
+		b.server.RemoveTools(stale...)
+	}
+	b.tools = seen
+	return nil
+}
+
+// forward returns a ToolHandler that relays the raw call to the remote tool
+// and returns the remote result unchanged (including IsError results).
+func (b *bridge) forward(name string) mcp.ToolHandler {
+	return func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		params := &mcp.CallToolParams{Name: name}
+		if len(req.Params.Arguments) > 0 {
+			params.Arguments = json.RawMessage(req.Params.Arguments)
+		}
+		return b.session.CallTool(ctx, params)
+	}
+}
+
+// isObjectSchema reports whether a listed tool's input schema is a JSON
+// object schema — the only shape Server.AddTool accepts.
+func isObjectSchema(schema any) bool {
+	raw, err := json.Marshal(schema)
+	if err != nil {
+		return false
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return false
+	}
+	return m["type"] == "object"
+}
+
+// authHint appends a token hint when the remote rejected the request with an
+// auth-shaped status, so the one-line stderr message is actionable.
+func authHint(err error) string {
+	msg := err.Error()
+	if strings.Contains(msg, "401") || strings.Contains(msg, "403") ||
+		strings.Contains(msg, "Unauthorized") || strings.Contains(msg, "Forbidden") {
+		return " (authentication rejected — check --token)"
+	}
+	return ""
+}
+
+// runBridge runs bridge mode: connect to the remote endpoint, then serve the
+// mirrored tool set over stdio until the client disconnects.
+func runBridge(ctx context.Context, endpoint, token string) error {
+	b, err := newBridge(ctx, endpoint, token)
+	if err != nil {
+		return err
+	}
+	defer b.Close()
+
+	slog.Info("bridge connected", "endpoint", endpoint, "tools", b.toolCount())
+	return b.server.Run(ctx, &mcp.StdioTransport{})
+}

--- a/cmd/bintrail-mcp/bridge_integration_test.go
+++ b/cmd/bintrail-mcp/bridge_integration_test.go
@@ -1,0 +1,245 @@
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// startRemote serves an MCP server over Streamable HTTP the way
+// `bintrail-mcp --http` does. When requireToken is non-empty, every request
+// must carry `Authorization: Bearer <requireToken>` or it is rejected with
+// 401 — the shape of a token-authenticated console `/mcp` endpoint. The
+// returned server instance is shared across sessions so tests can mutate its
+// tool set.
+func startRemote(t *testing.T, requireToken string) (*httptest.Server, *mcp.Server) {
+	t.Helper()
+	remote := newServer()
+	handler := mcp.NewStreamableHTTPHandler(
+		func(*http.Request) *mcp.Server { return remote },
+		nil,
+	)
+	mux := http.NewServeMux()
+	mux.Handle("/mcp", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if requireToken != "" && r.Header.Get("Authorization") != "Bearer "+requireToken {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		handler.ServeHTTP(w, r)
+	}))
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+	return ts, remote
+}
+
+// connectBridgeClient starts the bridge's proxy server over in-memory
+// transports and returns a client session speaking to it — the in-process
+// equivalent of Claude Desktop driving the bridge over stdio.
+func connectBridgeClient(t *testing.T, b *bridge) *mcp.ClientSession {
+	t.Helper()
+	ctx := context.Background()
+	t1, t2 := mcp.NewInMemoryTransports()
+	if _, err := b.server.Connect(ctx, t1, nil); err != nil {
+		t.Fatalf("bridge server Connect: %v", err)
+	}
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-desktop", Version: "v1.0.0"}, nil)
+	session, err := client.Connect(ctx, t2, nil)
+	if err != nil {
+		t.Fatalf("client Connect: %v", err)
+	}
+	t.Cleanup(func() { session.Close() })
+	return session
+}
+
+// TestIntegrationBridgePassthrough verifies the bridge mirrors the remote
+// tool set verbatim and round-trips a tool call, with the token accepted by
+// an authenticated remote.
+func TestIntegrationBridgePassthrough(t *testing.T) {
+	ctx := context.Background()
+	ts, _ := startRemote(t, "s3cret")
+
+	b, err := newBridge(ctx, ts.URL+"/mcp", "s3cret")
+	if err != nil {
+		t.Fatalf("newBridge: %v", err)
+	}
+	t.Cleanup(func() { b.Close() })
+
+	session := connectBridgeClient(t, b)
+
+	// Tool listing must match the remote server's set, schemas included.
+	res, err := session.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	var names []string
+	for _, tool := range res.Tools {
+		names = append(names, tool.Name)
+		if tool.Description == "" {
+			t.Errorf("tool %s: empty description (not mirrored)", tool.Name)
+		}
+		raw, _ := json.Marshal(tool.InputSchema)
+		var schema map[string]any
+		if err := json.Unmarshal(raw, &schema); err != nil || schema["type"] != "object" {
+			t.Errorf("tool %s: input schema not mirrored as an object: %s", tool.Name, raw)
+		}
+	}
+	sort.Strings(names)
+	want := []string{"list_schema_changes", "query", "recover", "status"}
+	if strings.Join(names, ",") != strings.Join(want, ",") {
+		t.Fatalf("mirrored tools = %v, want %v", names, want)
+	}
+
+	// The query tool's schema must carry the remote's properties verbatim.
+	for _, tool := range res.Tools {
+		if tool.Name != "query" {
+			continue
+		}
+		raw, _ := json.Marshal(tool.InputSchema)
+		if !strings.Contains(string(raw), "changed_column") {
+			t.Errorf("query input schema lost remote properties: %s", raw)
+		}
+	}
+
+	// Round-trip a call through bridge → HTTP → remote handler. An IsError
+	// result (unreachable DSN) still proves the full forwarding path: the
+	// text is produced by the remote server's tool handler.
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "status",
+		Arguments: map[string]any{"index_dsn": "baduser:badpass@tcp(127.0.0.1:1)/nope"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool status: %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("expected IsError result for unreachable DSN, got %+v", result)
+	}
+	if text := callToolText(t, result); text == "" {
+		t.Fatal("empty error text from forwarded tool call")
+	}
+}
+
+// TestIntegrationBridgeToolCallRealDB round-trips a successful query call
+// against a real index database through the bridge.
+func TestIntegrationBridgeToolCallRealDB(t *testing.T) {
+	_, _, dsn := setupTestDB(t)
+
+	ctx := context.Background()
+	ts, _ := startRemote(t, "")
+
+	b, err := newBridge(ctx, ts.URL+"/mcp", "")
+	if err != nil {
+		t.Fatalf("newBridge: %v", err)
+	}
+	t.Cleanup(func() { b.Close() })
+
+	session := connectBridgeClient(t, b)
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "query",
+		Arguments: map[string]any{"index_dsn": dsn, "limit": 5},
+	})
+	if err != nil {
+		t.Fatalf("CallTool query: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("query via bridge failed: %s", callToolText(t, result))
+	}
+}
+
+// TestIntegrationBridgeToolListResync verifies the dynamic passthrough: a
+// tool added on the remote after the bridge is up appears on the bridge via
+// the tools/list_changed notification, without re-declaring anything locally.
+func TestIntegrationBridgeToolListResync(t *testing.T) {
+	ctx := context.Background()
+	ts, remote := startRemote(t, "")
+
+	b, err := newBridge(ctx, ts.URL+"/mcp", "")
+	if err != nil {
+		t.Fatalf("newBridge: %v", err)
+	}
+	t.Cleanup(func() { b.Close() })
+	session := connectBridgeClient(t, b)
+
+	remote.AddTool(&mcp.Tool{
+		Name:        "late_tool",
+		Description: "added after the bridge connected",
+		InputSchema: map[string]any{"type": "object"},
+	}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "late"}}}, nil
+	})
+
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		res, err := session.ListTools(ctx, nil)
+		if err != nil {
+			t.Fatalf("ListTools: %v", err)
+		}
+		for _, tool := range res.Tools {
+			if tool.Name == "late_tool" {
+				return // resynced
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("late_tool never appeared on the bridge after remote AddTool")
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// TestIntegrationBridgeWrongToken verifies a rejected token fails fast with a
+// clear, actionable error instead of hanging.
+func TestIntegrationBridgeWrongToken(t *testing.T) {
+	ctx := context.Background()
+	ts, _ := startRemote(t, "s3cret")
+
+	start := time.Now()
+	_, err := newBridge(ctx, ts.URL+"/mcp", "wrong")
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("newBridge succeeded with a wrong token")
+	}
+	if !strings.Contains(err.Error(), "cannot connect to") {
+		t.Errorf("error lacks endpoint context: %v", err)
+	}
+	if !strings.Contains(err.Error(), "check --token") {
+		t.Errorf("401 error lacks the token hint: %v", err)
+	}
+	if elapsed > bridgeConnectTimeout+5*time.Second {
+		t.Errorf("wrong-token failure took %v; expected fast failure", elapsed)
+	}
+}
+
+// TestIntegrationBridgeRefusedConnection verifies an unreachable endpoint
+// fails within the connect timeout instead of hanging.
+func TestIntegrationBridgeRefusedConnection(t *testing.T) {
+	// Reserve a port and close it so the connection is refused.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := l.Addr().String()
+	l.Close()
+
+	ctx := context.Background()
+	start := time.Now()
+	_, err = newBridge(ctx, "http://"+addr+"/mcp", "")
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("newBridge succeeded against a closed port")
+	}
+	if !strings.Contains(err.Error(), "cannot connect to") {
+		t.Errorf("error lacks endpoint context: %v", err)
+	}
+	if elapsed > bridgeConnectTimeout+5*time.Second {
+		t.Errorf("refused-connection failure took %v; expected failure within the connect timeout", elapsed)
+	}
+}

--- a/cmd/bintrail-mcp/bridge_test.go
+++ b/cmd/bintrail-mcp/bridge_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestValidateBridgeFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		connect string
+		http    string
+		tenants string
+		token   string
+		wantErr string // substring; "" = no error
+	}{
+		{name: "no bridge flags", wantErr: ""},
+		{name: "plain http mode", http: ":8080", wantErr: ""},
+		{name: "bridge alone", connect: "http://host:8090/mcp", wantErr: ""},
+		{name: "bridge with token", connect: "https://host/mcp", token: "s3cret", wantErr: ""},
+		{name: "token without connect", token: "s3cret", wantErr: "--token requires --connect"},
+		{name: "connect plus http", connect: "http://host:8090/mcp", http: ":8080", wantErr: "mutually exclusive"},
+		{name: "connect plus tenant dsns", connect: "http://host:8090/mcp", tenants: "dsns.json", wantErr: "mutually exclusive"},
+		{name: "connect without scheme", connect: "host:8090/mcp", wantErr: "http://"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateBridgeFlags(tt.connect, tt.http, tt.tenants, tt.token)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error %q does not contain %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestIsObjectSchema(t *testing.T) {
+	if !isObjectSchema(map[string]any{"type": "object"}) {
+		t.Error("object schema rejected")
+	}
+	if isObjectSchema(map[string]any{"type": "string"}) {
+		t.Error("string schema accepted")
+	}
+	if isObjectSchema(nil) {
+		t.Error("nil schema accepted")
+	}
+	if isObjectSchema(make(chan int)) {
+		t.Error("unmarshalable schema accepted")
+	}
+}
+
+func TestAuthHint(t *testing.T) {
+	if hint := authHint(errors.New("unexpected status: 401 Unauthorized")); !strings.Contains(hint, "--token") {
+		t.Errorf("401 error produced no token hint: %q", hint)
+	}
+	if hint := authHint(errors.New("dial tcp: connection refused")); hint != "" {
+		t.Errorf("network error produced a token hint: %q", hint)
+	}
+}

--- a/cmd/bintrail-mcp/main.go
+++ b/cmd/bintrail-mcp/main.go
@@ -9,6 +9,12 @@
 //	bintrail-mcp                   # stdio (default)
 //	bintrail-mcp --http :8080      # HTTP on all interfaces, port 8080
 //
+// Bridge mode (stdio ↔ Streamable HTTP): serve MCP over stdio locally and
+// proxy every request to a remote bintrail MCP endpoint. This is what the
+// released .mcpb bundle runs under Claude Desktop:
+//
+//	bintrail-mcp --connect http://host:8090/mcp --token <token>
+//
 // Multi-tenant mode (for shared backends behind mcp-gateway):
 //
 //	bintrail-mcp --http :8080 --tenant-dsns tenant-dsns.json
@@ -149,7 +155,29 @@ func newServerWithDSN(dsnOverride string) *mcp.Server {
 func main() {
 	httpAddr := flag.String("http", "", "HTTP listen address (e.g. :8080); omit to use stdio")
 	tenantDSNsFile := flag.String("tenant-dsns", "", "JSON file mapping tenant IDs to index DSNs (multi-tenant mode)")
+	connectURL := flag.String("connect", "", "Bridge mode: serve MCP over stdio and proxy to a remote bintrail Streamable-HTTP MCP endpoint (e.g. http://host:8090/mcp)")
+	connectToken := flag.String("token", "", "Bearer token sent to the --connect endpoint (Authorization: Bearer)")
 	flag.Parse()
+
+	if err := validateBridgeFlags(*connectURL, *httpAddr, *tenantDSNsFile, *connectToken); err != nil {
+		fmt.Fprintf(os.Stderr, "bintrail-mcp: %v\n", err)
+		os.Exit(2)
+	}
+
+	if *connectURL != "" {
+		err := runBridge(context.Background(), *connectURL, *connectToken)
+		if err == nil {
+			return
+		}
+		if isClientDisconnect(err) {
+			// Same clean-shutdown classification as plain stdio mode (#473).
+			slog.Info("MCP client disconnected; shutting down", "cause", err)
+			return
+		}
+		// One clear line on stderr: Claude Desktop surfaces this in its logs.
+		fmt.Fprintf(os.Stderr, "bintrail-mcp: bridge failed: %v\n", err)
+		os.Exit(1)
+	}
 
 	// Load tenant DSN map if provided.
 	if *tenantDSNsFile != "" {

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -29,6 +29,10 @@ You need two things on the machine where Claude runs:
 2. **Your index DSN** — the same `BINTRAIL_INDEX_DSN` your dbtrail stack uses,
    e.g. `user:pass@tcp(127.0.0.1:3306)/binlog_index`.
 
+Using the [one-click bundle](#claude-desktop-one-click) or
+[bridge mode](#bridge-mode---connect)? Skip both — you only need the remote
+endpoint's URL and token; the DSN stays on the server side.
+
 ---
 
 ## Connect Claude
@@ -59,6 +63,56 @@ tools appear — now ask: *"What changed in the orders table in the last hour?"*
 > `"command": "go", "args": ["run", "./cmd/bintrail-mcp"]` instead — no separate
 > install needed.
 
+### Claude Desktop (one-click)
+
+Every release publishes **MCP Bundle** artifacts — `dbtrail-<os>-<arch>.mcpb`
+files on the [releases page](https://github.com/dbtrail/dbtrail/releases) —
+that Claude Desktop installs without any JSON editing:
+
+1. Download the `.mcpb` matching the machine where Claude Desktop runs.
+2. Double-click it (or Claude Desktop → **Settings → Extensions**, drop the
+   file in).
+3. Fill in the two-field form:
+   - **Console / MCP endpoint URL** — your bintrail MCP endpoint, e.g.
+     `http://localhost:8090/mcp` (a `bintrail-mcp --http` server; keep the
+     `/mcp` path)
+   - **Access token** — sent as an `Authorization: Bearer` header; stored by
+     Claude Desktop as a sensitive value
+
+Under the hood the bundle runs the bundled `bintrail-mcp` in bridge mode
+(`--connect`, next section), so it works against a LAN/VPN/tunneled deployment
+— the endpoint never needs to be publicly exposed. No DSN appears anywhere:
+the remote endpoint owns the database connection.
+
+Release bundles currently cover the release build matrix (Linux amd64/arm64).
+On macOS or Windows, build a host-native bundle from source with `make mcpb`
+(output in `dist/mcpb/`), or configure bridge mode by hand as shown below.
+
+### Bridge mode (`--connect`)
+
+`bintrail-mcp --connect <url>` is what the bundle runs, and you can use it
+directly with any stdio MCP client: the process serves MCP over stdio locally
+and proxies every request to a remote bintrail Streamable-HTTP MCP endpoint,
+forwarding the remote's tools verbatim.
+
+```json
+{
+  "mcpServers": {
+    "bintrail": {
+      "command": "bintrail-mcp",
+      "args": ["--connect", "http://192.168.1.10:8080/mcp", "--token", "YOUR-TOKEN"]
+    }
+  }
+}
+```
+
+`--token` is optional (a plain `bintrail-mcp --http` server today has no
+auth); when set, it is sent as `Authorization: Bearer`. `--connect` cannot be
+combined with `--http` or `--tenant-dsns`, and no DSN is needed — the remote
+end resolves it. If the endpoint is unreachable or the token is rejected, the
+bridge exits non-zero with a one-line error (visible in Claude Desktop's MCP
+logs) instead of hanging.
+
 ### Claude Desktop (local index)
 
 Same idea, in Claude Desktop's config file
@@ -86,7 +140,10 @@ BINTRAIL_INDEX_DSN='user:pass@tcp(127.0.0.1:3306)/binlog_index' \
   bintrail-mcp --http :8080
 ```
 
-Then bridge Claude Desktop to it from your laptop with `proxy.py` — see
+Then connect from your laptop with the one-click bundle or
+[bridge mode](#bridge-mode---connect) above (`--connect
+http://192.168.1.10:8080/mcp`). If you'd rather not install a binary locally,
+the Python `proxy.py` does the same job — see
 [proxy.py (remote bridge)](#proxypy-remote-bridge) below.
 
 ### claude.ai and Claude mobile

--- a/packaging/mcpb/manifest.template.json
+++ b/packaging/mcpb/manifest.template.json
@@ -1,0 +1,68 @@
+{
+  "manifest_version": "0.4",
+  "name": "dbtrail",
+  "display_name": "dbtrail",
+  "version": "__MCPB_VERSION__",
+  "description": "Ask your database change history anything: search indexed row changes, generate recovery SQL, and check index status on a self-hosted bintrail deployment.",
+  "long_description": "Connects Claude Desktop to a self-hosted bintrail deployment through its MCP endpoint (a bintrail console `/mcp` URL or a `bintrail-mcp --http` server). The bundled binary runs locally as a stdio↔HTTP bridge, so a LAN/VPN/tunneled deployment works without public exposure. All tools are read-only: recovery SQL is generated, never executed.",
+  "author": {
+    "name": "dbtrail",
+    "url": "https://github.com/dbtrail/dbtrail"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dbtrail/dbtrail"
+  },
+  "homepage": "https://github.com/dbtrail/dbtrail",
+  "license": "Apache-2.0",
+  "keywords": ["mysql", "postgresql", "binlog", "recovery", "time-travel", "database"],
+  "server": {
+    "type": "binary",
+    "entry_point": "server/bintrail-mcp",
+    "mcp_config": {
+      "command": "${__dirname}/server/bintrail-mcp",
+      "args": [
+        "--connect",
+        "${user_config.console_url}",
+        "--token",
+        "${user_config.token}"
+      ]
+    }
+  },
+  "tools": [
+    {
+      "name": "query",
+      "description": "Search indexed row changes (before/after images) with filters"
+    },
+    {
+      "name": "recover",
+      "description": "Generate reversal SQL for matching events (never executes it)"
+    },
+    {
+      "name": "status",
+      "description": "Show index status: files, partitions, continuity, summary"
+    },
+    {
+      "name": "list_schema_changes",
+      "description": "List recorded DDL changes with statements and binlog coordinates"
+    }
+  ],
+  "compatibility": {
+    "platforms": ["__MCPB_PLATFORM__"]
+  },
+  "user_config": {
+    "console_url": {
+      "type": "string",
+      "title": "Console / MCP endpoint URL",
+      "description": "URL of your bintrail console MCP endpoint or a bintrail-mcp --http server, e.g. http://localhost:8090/mcp",
+      "required": true
+    },
+    "token": {
+      "type": "string",
+      "title": "Access token",
+      "description": "The console access token; sent as an Authorization: Bearer header",
+      "required": true,
+      "sensitive": true
+    }
+  }
+}

--- a/packaging/mcpb/manifest.template.json
+++ b/packaging/mcpb/manifest.template.json
@@ -18,9 +18,9 @@
   "keywords": ["mysql", "postgresql", "binlog", "recovery", "time-travel", "database"],
   "server": {
     "type": "binary",
-    "entry_point": "server/bintrail-mcp",
+    "entry_point": "server/__MCPB_ENTRY__",
     "mcp_config": {
-      "command": "${__dirname}/server/bintrail-mcp",
+      "command": "${__dirname}/server/__MCPB_ENTRY__",
       "args": [
         "--connect",
         "${user_config.console_url}",

--- a/scripts/build-mcpb.sh
+++ b/scripts/build-mcpb.sh
@@ -54,6 +54,7 @@ chmod 0755 "$STAGE/server/$ENTRY"
 
 sed -e "s/__MCPB_VERSION__/$VERSION/" \
     -e "s/__MCPB_PLATFORM__/$PLATFORM/" \
+    -e "s/__MCPB_ENTRY__/$ENTRY/" \
     "$TEMPLATE" > "$STAGE/manifest.json"
 
 mkdir -p "$OUT_DIR"

--- a/scripts/build-mcpb.sh
+++ b/scripts/build-mcpb.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# build-mcpb.sh — package a bintrail-mcp binary as an MCP Bundle (.mcpb).
+#
+# An .mcpb is a zip archive with a manifest.json that Claude Desktop installs
+# on double-click (spec: https://github.com/modelcontextprotocol/mcpb). The
+# bundle runs the binary in bridge mode:
+#   bintrail-mcp --connect <console_url> --token <token>
+#
+# Invoked by GoReleaser as a per-artifact post-build hook on the bintrail-mcp
+# build (see .goreleaser.yaml), and usable standalone:
+#
+#   scripts/build-mcpb.sh <binary-path> <goos> <goarch> <version>
+#
+# Output: dist/mcpb/dbtrail-<goos>-<goarch>.mcpb (validated before exiting).
+set -euo pipefail
+
+if [ $# -ne 4 ]; then
+    echo "usage: $0 <binary-path> <goos> <goarch> <version>" >&2
+    exit 2
+fi
+
+BINARY="$1"
+GOOS="$2"
+GOARCH="$3"
+VERSION="$4"
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TEMPLATE="$REPO_ROOT/packaging/mcpb/manifest.template.json"
+OUT_DIR="$REPO_ROOT/dist/mcpb"
+OUT="$OUT_DIR/dbtrail-$GOOS-$GOARCH.mcpb"
+
+[ -f "$BINARY" ] || { echo "build-mcpb: binary not found: $BINARY" >&2; exit 1; }
+[ -f "$TEMPLATE" ] || { echo "build-mcpb: manifest template not found: $TEMPLATE" >&2; exit 1; }
+
+# Map GOOS to the mcpb platform identifier (node process.platform names).
+case "$GOOS" in
+    linux)   PLATFORM=linux ;;
+    darwin)  PLATFORM=darwin ;;
+    windows) PLATFORM=win32 ;;
+    *) echo "build-mcpb: unsupported GOOS: $GOOS" >&2; exit 1 ;;
+esac
+
+# The manifest version must be bare semver (no leading v).
+VERSION="${VERSION#v}"
+
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"' EXIT
+
+mkdir -p "$STAGE/server"
+ENTRY="bintrail-mcp"
+[ "$GOOS" = "windows" ] && ENTRY="bintrail-mcp.exe"
+cp "$BINARY" "$STAGE/server/$ENTRY"
+chmod 0755 "$STAGE/server/$ENTRY"
+
+sed -e "s/__MCPB_VERSION__/$VERSION/" \
+    -e "s/__MCPB_PLATFORM__/$PLATFORM/" \
+    "$TEMPLATE" > "$STAGE/manifest.json"
+
+mkdir -p "$OUT_DIR"
+rm -f "$OUT"
+(cd "$STAGE" && zip -q -r -X "$OUT" manifest.json server)
+
+"$REPO_ROOT/scripts/validate-mcpb.sh" "$OUT"
+echo "build-mcpb: wrote $OUT"

--- a/scripts/validate-mcpb.sh
+++ b/scripts/validate-mcpb.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# validate-mcpb.sh — sanity-check one or more .mcpb bundles.
+#
+# For each bundle: unzip it, parse manifest.json, verify the required manifest
+# fields, and check the declared entry-point binary exists in the archive and
+# is executable. Runs in the release pipeline (called from build-mcpb.sh, so a
+# malformed bundle fails the release) and standalone via `make validate-mcpb`.
+#
+# Requires: unzip, python3 (both present on GitHub ubuntu runners and macOS).
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+    echo "usage: $0 <bundle.mcpb> [...]" >&2
+    exit 2
+fi
+
+fail=0
+for BUNDLE in "$@"; do
+    if [ ! -f "$BUNDLE" ]; then
+        echo "validate-mcpb: FAIL $BUNDLE: file not found" >&2
+        fail=1
+        continue
+    fi
+
+    WORK="$(mktemp -d)"
+    if ! unzip -q "$BUNDLE" -d "$WORK"; then
+        echo "validate-mcpb: FAIL $BUNDLE: not a valid zip archive" >&2
+        rm -rf "$WORK"
+        fail=1
+        continue
+    fi
+
+    if ERR=$(python3 - "$WORK" "$BUNDLE" 2>&1 <<'PYEOF'
+import json, os, stat, sys
+
+work, bundle = sys.argv[1], sys.argv[2]
+manifest_path = os.path.join(work, "manifest.json")
+if not os.path.isfile(manifest_path):
+    sys.exit("manifest.json missing from bundle root")
+
+with open(manifest_path) as f:
+    m = json.load(f)
+
+for field in ("manifest_version", "name", "version", "description", "author", "server"):
+    if field not in m:
+        sys.exit(f"manifest.json missing required field: {field}")
+
+server = m["server"]
+if server.get("type") != "binary":
+    sys.exit(f"server.type = {server.get('type')!r}, want 'binary'")
+
+entry = server.get("entry_point")
+if not entry:
+    sys.exit("server.entry_point missing")
+entry_path = os.path.join(work, entry)
+if not os.path.isfile(entry_path):
+    sys.exit(f"entry point binary not in bundle: {entry}")
+if not entry.endswith(".exe") and not os.stat(entry_path).st_mode & stat.S_IXUSR:
+    sys.exit(f"entry point binary not executable: {entry}")
+
+cfg = server.get("mcp_config", {})
+args = cfg.get("args", [])
+for required_arg in ("--connect", "${user_config.console_url}", "--token", "${user_config.token}"):
+    if required_arg not in args:
+        sys.exit(f"mcp_config.args missing {required_arg!r}: {args}")
+
+uc = m.get("user_config", {})
+for key in ("console_url", "token"):
+    if key not in uc:
+        sys.exit(f"user_config missing {key!r}")
+    if not uc[key].get("required"):
+        sys.exit(f"user_config.{key} must be required")
+if not uc["token"].get("sensitive"):
+    sys.exit("user_config.token must be sensitive")
+
+if "__MCPB_" in json.dumps(m):
+    sys.exit("unsubstituted template placeholder left in manifest")
+PYEOF
+    ); then
+        echo "validate-mcpb: OK   $BUNDLE"
+    else
+        echo "validate-mcpb: FAIL $BUNDLE: $ERR" >&2
+        fail=1
+    fi
+    rm -rf "$WORK"
+done
+exit $fail


### PR DESCRIPTION
Implements the two halves of #1040: a stdio↔Streamable-HTTP bridge mode in `bintrail-mcp`, and per-platform `.mcpb` MCP Bundle artifacts in the release pipeline.

## Half 1 — `bintrail-mcp --connect <url> [--token <t>]` (bridge mode)

`cmd/bintrail-mcp/bridge.go`. The process serves MCP over stdio (what Claude Desktop launches) and proxies to a remote bintrail Streamable-HTTP MCP endpoint — a `bintrail-mcp --http` server today, the console `/mcp` endpoint (#1039) once it lands; this slice has no dependency on it.

**Design**

- **Dynamic passthrough, not a re-declared tool list.** At startup the bridge lists the remote's tools (`ClientSession.Tools`, paginated) and registers each `*mcp.Tool` verbatim — name, description, input/output schema, annotations — on a local proxy `mcp.Server` with a raw `ToolHandler` that forwards `req.Params.Arguments` untouched and returns the remote `CallToolResult` unchanged (including `IsError` results). A `ToolListChangedHandler` re-syncs the mirrored set (add/replace + `RemoveTools` of stale names) when the remote emits `tools/list_changed`, so a long-lived Desktop session tracks server-side changes. The remote's `Instructions` are mirrored onto the proxy server too.
- **Auth.** `--token` is injected as `Authorization: Bearer` via a `RoundTripper` wrapper on the streamable client transport.
- **Fail fast and loud.** Initial connect + tool listing run under a 15s timeout (`StreamableClientTransport` detaches the session lifetime from that context, verified against go-sdk v1.3.1, so the timeout does not kill an established session). Unreachable URL / 401 / 403 produce a non-zero exit with a one-line stderr message; auth-shaped failures append a `check --token` hint. Clean stdin EOF keeps the existing #473 exit-0 classification.
- **Flag contract.** `--connect` is mutually exclusive with `--http` and `--tenant-dsns` (exit 2 with a clear message); `--token` without `--connect` is rejected; the URL must be `http(s)://`. DSN-based operation is untouched — in bridge mode the remote end owns the DSN. All existing modes are unchanged.
- A remote tool with a non-object input schema is skipped with a warning instead of letting `Server.AddTool` panic the bridge.

## Half 2 — `.mcpb` bundles in the release pipeline

`.mcpb` is the MCP Bundle format (ex-DXT). Verified against the current spec and examples at https://github.com/modelcontextprotocol/mcpb (`MANIFEST.md` + `examples/`): `manifest_version` is a string (current `"0.4"`), `server.type: "binary"` with `entry_point` + `mcp_config.command/args`, `${__dirname}` / `${user_config.x}` substitution, `user_config` entries with `type/title/description/required/sensitive`, `compatibility.platforms` using node platform names (`darwin`/`win32`/`linux`), and a top-level `tools` descriptor list.

- `packaging/mcpb/manifest.template.json` — name `dbtrail`, version substituted from the release tag, repository URL, the four tools declared (`query`, `recover`, `status`, `list_schema_changes`), and a two-field `user_config`: `console_url` (required) + `token` (required, `sensitive: true`, → OS keychain). `mcp_config` runs `${__dirname}/server/bintrail-mcp --connect ${user_config.console_url} --token ${user_config.token}`.
- `scripts/build-mcpb.sh` — runs as a GoReleaser **post-build hook** on the `bintrail-mcp` build (one invocation per platform artifact): stages `manifest.json` + `server/bintrail-mcp`, zips to `dist/mcpb/dbtrail-<goos>-<goarch>.mcpb`, then validates.
- `scripts/validate-mcpb.sh` — unzips the bundle, parses the manifest, and checks required fields, `server.type: binary`, the entry binary's presence/executability, the `--connect`/`--token` arg wiring, the `user_config` contract, and that no template placeholder survived. Because it runs inside the build hook, a malformed bundle **fails the release** — that is the CI wiring. Also runnable standalone: `make validate-mcpb`; `make mcpb` builds a host-native bundle.
- `.goreleaser.yaml` — bundles published via `release.extra_files` and included in `checksums.txt` via `checksum.extra_files`.
- `docs/mcp-server.md` — new "Claude Desktop (one-click)" and "Bridge mode (`--connect`)" sections; the remote-index path now points at the bundle/bridge first, with `proxy.py` kept as the no-binary alternative.

**Platform coverage:** the existing release build matrix is linux/amd64 + linux/arm64 (CGO — DuckDB — with an aarch64 cross-compiler; there are no darwin/windows release builds today), so the published bundles follow that matrix: `dbtrail-linux-amd64.mcpb` and `dbtrail-linux-arm64.mcpb`. The manifest/script already handle `darwin`/`win32` (platform mapping, `.exe` entry point), so darwin/windows bundles appear automatically if the build matrix ever grows; until then `make mcpb` covers macOS from source. This is the one deviation from the issue's platform list, and it is inherited from the release pipeline, not from the bundle packaging.

## Tests

- `cmd/bintrail-mcp/bridge_test.go` (unit): flag mutual-exclusion matrix, object-schema guard, auth-hint mapping.
- `cmd/bintrail-mcp/bridge_integration_test.go` (`//go:build integration`): an `httptest`-hosted Streamable-HTTP remote (with an optional Bearer-token middleware) + the bridge in-process, driven by an MCP client over `mcp.NewInMemoryTransports()`:
  - tool listing mirrored verbatim (names, descriptions, schema properties) + a tool-call round-trip through bridge → HTTP → remote handler;
  - a successful `query` round-trip against a real index DB (skips when the Docker MySQL is absent);
  - live re-sync: a tool added on the remote after connect appears on the bridge via `tools/list_changed`;
  - wrong token → fast failure with endpoint context and the `check --token` hint;
  - refused connection → failure within the connect timeout.
- `go build ./...`, `go test ./... -count=1`, `go vet -tags integration ./...`: pass. Integration bridge tests pass locally (the real-DB one skipped: no local Docker MySQL; CI runs it). `goreleaser check`: config validated (only the pre-existing `dockers`/`docker_manifests` deprecation notices).
- Packaging exercised end-to-end locally: `scripts/build-mcpb.sh` on a built binary produced a valid bundle (`manifest.json` + `server/bintrail-mcp`), and the validator rejects a bundle with an unsubstituted manifest with a non-zero exit.

Closes #1040

🤖 Generated with [Claude Code](https://claude.com/claude-code)
