### PR TITLE
console: run extension source jobs under watch + monitor supervisor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Extension source jobs (`ext.RunSourceJobs`) now run under `bintrail-console watch` and its per-source monitor supervisor**, not only under `bintrail up`. A registered `ext.RegisterSourceJob` now fires for `watch`'s main `--source-dsn` stream and for every source the console control plane starts monitoring, each bound to that source's lifecycle context — so a job stops when its source stops (a monitored source's Stop, or daemon shutdown), and starts once per (re)start, never per stream reconnect. No behavior change for the stock binary: `RunSourceJobs` is a no-op with no registered jobs.
+
 ## [0.37.0] - 2026-07-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Extension source jobs (`ext.RunSourceJobs`) now run under `bintrail-console watch` and its per-source monitor supervisor**, not only under `bintrail up`. A registered `ext.RegisterSourceJob` now fires for `watch`'s main `--source-dsn` stream and for every source the console control plane starts monitoring, each bound to that source's lifecycle context — so a job stops when its source stops (a monitored source's Stop, or daemon shutdown), and starts once per (re)start, never per stream reconnect. No behavior change for the stock binary: `RunSourceJobs` is a no-op with no registered jobs.
+- **Extension source jobs (`ext.RunSourceJobs`) now run under `bintrail-console watch` and its per-source monitor supervisor**, not only under `bintrail up`. A registered `ext.RegisterSourceJob` now fires for `watch`'s main `--source-dsn` stream and for every source the console control plane starts monitoring, each bound to that source's lifecycle context — so a job stops when its source stops (a monitored source's Stop, daemon shutdown, or the supervised stream's own terminal exit) and starts once per (re)start, never per stream reconnect. The monitor binds the job's lifetime to the source's advisory lock: when a stream gives up or exits, its jobs are cancelled together with the lock's release, so a second daemon that re-acquires the freed lock never double-runs them. A console-monitored MariaDB source now also captures with the MariaDB GTID parser and reports the matching flavor to its source jobs. No behavior change for the stock binary: `RunSourceJobs` is a no-op with no registered jobs.
 
 ## [0.37.0] - 2026-07-17
 

--- a/consoleapp/monitor.go
+++ b/consoleapp/monitor.go
@@ -438,11 +438,14 @@ func (m *monitorSupervisor) Start(ctx context.Context, e console.ServerEntry) er
 
 	// Extension source jobs (ext.RegisterSourceJob) run alongside the supervised
 	// stream, bound to jobCtx — the per-source lifecycle context, created once per
-	// (re)start and cancelled on Stop or daemon shutdown. Placing this here (after
-	// index-DB provisioning and the advisory lock, before the stream goroutine)
-	// ties one set of jobs to each monitored source's lifetime: not per
-	// stream-reconnect (m.run reuses jobCtx, so no per-retry goroutine leak), and
-	// only for a source this daemon actually streams (the advisory lock holder).
+	// (re)start and cancelled on Stop, daemon shutdown, OR the supervised stream's
+	// own terminal exit (crash-loop give-up / clean return — m.run defers
+	// job.cancel(), see run). Placing this here (after index-DB provisioning and
+	// the advisory lock, before the stream goroutine) ties one set of jobs to each
+	// monitored source's lifetime: not per stream-reconnect (m.run reuses jobCtx,
+	// so no per-retry goroutine leak), and only for a source this daemon actually
+	// streams (the advisory lock holder) — jobCtx dies with the lock, so a second
+	// daemon that re-acquires the freed lock never double-runs these jobs.
 	// No-op in the stock binary.
 	ext.RunSourceJobs(jobCtx, ext.SourceJobInfo{SourceDSN: e.SourceDSN, IndexDSN: e.DSN, Flavor: flavor})
 
@@ -502,8 +505,13 @@ func sourcePGStreamConfig(e console.ServerEntry, serverID uint32) (pgstreamrun.C
 // registry entry (Hooks are attached by the caller — they need the live job).
 // The source connection's TLS comes from the entry's ssl_* fields (#879): an
 // empty SSLMode defaults to "preferred", preserving pre-#879 behavior for
-// entries with no TLS configured. Pure — extracted from Start so the
-// entry→config fan-out (SSL especially) is unit-testable without a live DB.
+// entries with no TLS configured. Flavor is the entry's resolved source flavor
+// ("mysql"/"mariadb" — this builder is only reached in the non-postgres branch):
+// without it the stream normalized an empty Flavor to "mysql", so a console-
+// monitored MariaDB source was captured with the MySQL GTID parser AND the ext
+// source job was told a flavor the pipeline did not actually run with. Pure —
+// extracted from Start so the entry→config fan-out (SSL especially) is
+// unit-testable without a live DB.
 func sourceStreamConfig(e console.ServerEntry, serverID uint32) streamrun.Config {
 	sslMode := e.SSLMode
 	if sslMode == "" {
@@ -513,6 +521,7 @@ func sourceStreamConfig(e console.ServerEntry, serverID uint32) streamrun.Config
 		IndexDSN:  e.DSN,
 		SourceDSN: e.SourceDSN,
 		ServerID:  serverID,
+		Flavor:    e.SourceFlavor(),
 		BatchSize: 1000,
 		Schemas:   e.Schemas,
 		// MetricsSource keys this stream's Prometheus series; MetricsAddr
@@ -539,6 +548,14 @@ func sourceStreamConfig(e console.ServerEntry, serverID uint32) streamrun.Config
 // breaker: permanent "failed", no more retries, advisory lock released —
 // Start (or a daemon restart) re-arms it. Cancellation (stop verb / daemon
 // shutdown) exits cleanly.
+//
+// Terminal exit (give-up or clean return) also cancels jobCtx via the
+// defer below, tearing down the ext source jobs launched on it in Start.
+// This keeps the job's lifetime bound to the advisory lock's: the deferred
+// lock release and the job cancellation fire together, so a source this
+// daemon stops streaming can never leave its source jobs running past the
+// lock — otherwise a second daemon that re-acquires the freed lock would
+// double-run them.
 func (m *monitorSupervisor) run(ctx context.Context, job *monitorJob, e console.ServerEntry, flavor string, runOnce func(context.Context) error) {
 	defer m.wg.Done()
 	defer close(job.done)
@@ -547,6 +564,12 @@ func (m *monitorSupervisor) run(ctx context.Context, job *monitorJob, e console.
 			job.lockDB.Close() // releases the advisory lock
 		}
 	}()
+	// Cancel jobCtx on every terminal return (give-up, clean exit, cancellation).
+	// Declared last so it runs first under LIFO — the ext source jobs stop before
+	// the advisory lock is released above. A no-op when jobCtx is already
+	// cancelled (Stop/Shutdown/daemon-cancel paths). Reconnects stay inside the
+	// for-loop below, so this never fires mid-retry.
+	defer job.cancel()
 
 	attempt := 0
 	var crashLoopSince time.Time // first failure of the current loop; zero = healthy

--- a/consoleapp/monitor.go
+++ b/consoleapp/monitor.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/go-sql-driver/mysql"
 
+	"github.com/dbtrail/dbtrail/ext"
 	"github.com/dbtrail/dbtrail/internal/config"
 	"github.com/dbtrail/dbtrail/internal/console"
 	"github.com/dbtrail/dbtrail/internal/doctor"
@@ -434,6 +435,16 @@ func (m *monitorSupervisor) Start(ctx context.Context, e console.ServerEntry) er
 		cfg.Hooks = job.streamHooks()
 		runOnce = func(c context.Context) error { return m.streamFn(c, cfg) }
 	}
+
+	// Extension source jobs (ext.RegisterSourceJob) run alongside the supervised
+	// stream, bound to jobCtx — the per-source lifecycle context, created once per
+	// (re)start and cancelled on Stop or daemon shutdown. Placing this here (after
+	// index-DB provisioning and the advisory lock, before the stream goroutine)
+	// ties one set of jobs to each monitored source's lifetime: not per
+	// stream-reconnect (m.run reuses jobCtx, so no per-retry goroutine leak), and
+	// only for a source this daemon actually streams (the advisory lock holder).
+	// No-op in the stock binary.
+	ext.RunSourceJobs(jobCtx, ext.SourceJobInfo{SourceDSN: e.SourceDSN, IndexDSN: e.DSN, Flavor: flavor})
 
 	m.wg.Add(1)
 	go m.run(jobCtx, job, e, flavor, runOnce)

--- a/consoleapp/monitor_integration_test.go
+++ b/consoleapp/monitor_integration_test.go
@@ -131,6 +131,77 @@ func TestIntegrationMonitorRunsExtSourceJob(t *testing.T) {
 	}
 }
 
+// TestIntegrationMonitorExtSourceJobTornDownOnStreamExit is the terminal-exit
+// half of THE LEAK CONTRACT that the Stop path above does NOT cover: when the
+// supervised stream ends on its own — here a clean return; the crash-loop
+// give-up shares the identical terminal path in run — the ext source job's
+// bound context must become Done with NO Stop call. run defers job.cancel(), so
+// jobCtx dies together with the advisory lock the deferred lockDB.Close()
+// releases. Without that defer the stream could exit and free the lock while the
+// source job kept running, and a second daemon re-acquiring the freed lock would
+// double-run it. The outer daemon ctx stays live throughout, so a Done here can
+// only come from the per-source cancel, not daemon teardown.
+func TestIntegrationMonitorExtSourceJobTornDownOnStreamExit(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, bootName := testutil.CreateTestDB(t)
+	bootDSN := testutil.IntegrationDSN(bootName)
+
+	sup := newMonitorSupervisor(ctx, bootDSN, nil, 0)
+	// A stream that returns nil immediately: run takes the clean-return terminal
+	// branch (err == nil) and, with the fix, cancels jobCtx via its defer.
+	sup.streamFn = func(_ context.Context, _ streamrun.Config) error { return nil }
+
+	sentinel := fmt.Sprintf("extjobexit%d", time.Now().UnixNano()%1e9)
+	infoCh, ctxCh := probeSourceJob(t, sentinel)
+
+	entry := console.ServerEntry{
+		ID:        sentinel,
+		Name:      "ext-source-job-exit",
+		SourceDSN: testutil.BaseDSN() + "/",
+	}
+	derived, err := sup.DeriveIndexDSN(entry.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry.DSN = derived
+	t.Cleanup(func() {
+		if db, err := sql.Open("mysql", bootDSN); err == nil {
+			_, _ = db.Exec("DROP DATABASE IF EXISTS bintrail_idx_" + entry.ID)
+			_ = db.Close()
+		}
+	})
+
+	if err := sup.Start(ctx, entry); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = sup.Stop(context.Background(), entry.ID) })
+
+	// The job fires once (RunSourceJobs is called once per Start, not per stream
+	// attempt). Capture its bound context — even if the stream already returned
+	// and cancelled jobCtx, the job still fired (RunSourceJobs launches
+	// unconditionally) and a cancelled context read here still reports Done.
+	var jobCtx context.Context
+	select {
+	case <-infoCh:
+		jobCtx = <-ctxCh
+	case <-time.After(15 * time.Second):
+		t.Fatal("ext source job never fired for the started source")
+	}
+
+	// THE CONTRACT: the stream exited on its own and no Stop was called, yet the
+	// job's bound context must be Done. The daemon ctx is still live, so this is
+	// the per-source cancel firing with the released advisory lock — not a leak.
+	select {
+	case <-jobCtx.Done():
+	case <-time.After(10 * time.Second):
+		t.Fatal("source job context still live after the stream exited on its own — job outlived the released advisory lock (leak)")
+	}
+}
+
 // TestIntegrationMonitorExtSourceJobPGFlavor proves a PostgreSQL source carries
 // Flavor="postgres" into the ext source job. The PG stream is stubbed (no
 // reachable PostgreSQL needed); provisioning still runs against the real MySQL

--- a/consoleapp/monitor_integration_test.go
+++ b/consoleapp/monitor_integration_test.go
@@ -10,10 +10,181 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dbtrail/dbtrail/ext"
 	"github.com/dbtrail/dbtrail/internal/config"
 	"github.com/dbtrail/dbtrail/internal/console"
+	"github.com/dbtrail/dbtrail/internal/pgstreamrun"
+	"github.com/dbtrail/dbtrail/internal/streamrun"
 	"github.com/dbtrail/dbtrail/internal/testutil"
 )
+
+// probeSourceJob registers an ext source job that captures the SourceJobInfo and
+// the bound context of every firing whose IndexDSN contains sentinel — the gate
+// keeps a Start elsewhere in the suite from misattributing a firing to this
+// test. The ext registry is process-global with no public deregister, so
+// ext.ResetForTest clears it both before registering (no prior bleed) and in
+// t.Cleanup (no bleed into later tests). Buffered so a fired job never blocks on
+// its own goroutine.
+func probeSourceJob(t *testing.T, sentinel string) (<-chan ext.SourceJobInfo, <-chan context.Context) {
+	t.Helper()
+	ext.ResetForTest()
+	t.Cleanup(ext.ResetForTest)
+	infoCh := make(chan ext.SourceJobInfo, 4)
+	ctxCh := make(chan context.Context, 4)
+	ext.RegisterSourceJob(func(jobCtx context.Context, src ext.SourceJobInfo) {
+		if !strings.Contains(src.IndexDSN, sentinel) {
+			return
+		}
+		infoCh <- src
+		ctxCh <- jobCtx
+	})
+	return infoCh, ctxCh
+}
+
+// TestIntegrationMonitorRunsExtSourceJob proves the monitor supervisor runs
+// registered ext source jobs alongside a supervised stream, bound to the
+// per-source lifecycle context. Start reaches the ext wiring (monitor.go, after
+// index-DB provisioning + the advisory lock) only against real MySQL, but the
+// stream itself is stubbed to block on its context, so no reachable source is
+// needed. Asserts: (a) the job fires ONCE with the entry's DSNs and resolved
+// flavor, (c) an idempotent Start for an already-running entry does not fire a
+// duplicate, and (b) THE LEAK CONTRACT — after Stop, the job's bound context is
+// Done, proving the job is torn down with the source and not merely with the
+// outer daemon context.
+func TestIntegrationMonitorRunsExtSourceJob(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, bootName := testutil.CreateTestDB(t)
+	bootDSN := testutil.IntegrationDSN(bootName)
+
+	sup := newMonitorSupervisor(ctx, bootDSN, nil, 0)
+	// Block until the job's lifecycle context is cancelled: this lets Start reach
+	// the ext wiring with only provisioning + the advisory lock done (real
+	// MySQL), never a reachable source, and keeps the stored state at "pending"
+	// so the idempotency assertion below has a running entry to collide with.
+	sup.streamFn = func(c context.Context, _ streamrun.Config) error { <-c.Done(); return c.Err() }
+
+	sentinel := fmt.Sprintf("extjob%d", time.Now().UnixNano()%1e9)
+	infoCh, ctxCh := probeSourceJob(t, sentinel)
+
+	entry := console.ServerEntry{
+		ID:        sentinel,
+		Name:      "ext-source-job",
+		SourceDSN: testutil.BaseDSN() + "/",
+	}
+	derived, err := sup.DeriveIndexDSN(entry.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry.DSN = derived
+	t.Cleanup(func() {
+		if db, err := sql.Open("mysql", bootDSN); err == nil {
+			_, _ = db.Exec("DROP DATABASE IF EXISTS bintrail_idx_" + entry.ID)
+			_ = db.Close()
+		}
+	})
+
+	if err := sup.Start(ctx, entry); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = sup.Stop(context.Background(), entry.ID) })
+
+	// (a) One firing, carrying the entry's source/index DSNs and the resolved
+	// (default → mysql) flavor.
+	var jobCtx context.Context
+	select {
+	case got := <-infoCh:
+		want := ext.SourceJobInfo{SourceDSN: entry.SourceDSN, IndexDSN: entry.DSN, Flavor: console.FlavorMySQL}
+		if got != want {
+			t.Fatalf("source job info = %+v, want %+v", got, want)
+		}
+		jobCtx = <-ctxCh
+	case <-time.After(15 * time.Second):
+		t.Fatal("ext source job never fired for the started source")
+	}
+
+	// (c) An idempotent Start (the entry is still "pending" — the stub never
+	// progressed it to running, and both are running-variants that early-return)
+	// must NOT re-provision or fire a second job.
+	if err := sup.Start(ctx, entry); err != nil {
+		t.Fatalf("idempotent Start: %v", err)
+	}
+	select {
+	case got := <-infoCh:
+		t.Fatalf("idempotent Start fired a duplicate source job: %+v", got)
+	case <-time.After(2 * time.Second):
+	}
+
+	// (b) The leak contract: Stop tears down the source; the job's bound context
+	// must become Done. The outer daemon ctx is still live (only deferred), so
+	// this proves per-source jobCtx binding, not daemon-ctx binding.
+	if err := sup.Stop(ctx, entry.ID); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	select {
+	case <-jobCtx.Done():
+	case <-time.After(10 * time.Second):
+		t.Fatal("source job context still live after Stop — job not bound to the source lifecycle")
+	}
+}
+
+// TestIntegrationMonitorExtSourceJobPGFlavor proves a PostgreSQL source carries
+// Flavor="postgres" into the ext source job. The PG stream is stubbed (no
+// reachable PostgreSQL needed); provisioning still runs against the real MySQL
+// index (the shared index schema for every source family).
+func TestIntegrationMonitorExtSourceJobPGFlavor(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, bootName := testutil.CreateTestDB(t)
+	bootDSN := testutil.IntegrationDSN(bootName)
+
+	sup := newMonitorSupervisor(ctx, bootDSN, nil, 0)
+	sup.pgStreamFn = func(c context.Context, _ pgstreamrun.Config) error { <-c.Done(); return c.Err() }
+
+	sentinel := fmt.Sprintf("extjobpg%d", time.Now().UnixNano()%1e9)
+	infoCh, _ := probeSourceJob(t, sentinel)
+
+	entry := console.ServerEntry{
+		ID:                sentinel,
+		Name:              "ext-source-job-pg",
+		SourceDSN:         "postgres://repl:secret@pg:5432/appdb",
+		SourceSlot:        "bintrail_slot",
+		SourcePublication: "bintrail_pub",
+		Flavor:            console.FlavorPostgres,
+	}
+	derived, err := sup.DeriveIndexDSN(entry.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry.DSN = derived
+	t.Cleanup(func() {
+		if db, err := sql.Open("mysql", bootDSN); err == nil {
+			_, _ = db.Exec("DROP DATABASE IF EXISTS bintrail_idx_" + entry.ID)
+			_ = db.Close()
+		}
+	})
+
+	if err := sup.Start(ctx, entry); err != nil {
+		t.Fatalf("Start (postgres): %v", err)
+	}
+	t.Cleanup(func() { _ = sup.Stop(context.Background(), entry.ID) })
+
+	select {
+	case got := <-infoCh:
+		want := ext.SourceJobInfo{SourceDSN: entry.SourceDSN, IndexDSN: entry.DSN, Flavor: console.FlavorPostgres}
+		if got != want {
+			t.Fatalf("pg source job info = %+v, want %+v", got, want)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("ext source job never fired for the started PostgreSQL source")
+	}
+}
 
 // waitStreamLive proves the supervised stream is attached and past its
 // auto-discovered start position before the test writes the rows it intends

--- a/consoleapp/monitor_test.go
+++ b/consoleapp/monitor_test.go
@@ -57,6 +57,11 @@ func TestSourceStreamConfig(t *testing.T) {
 		def.ServerID != 42 || def.Schemas != "shop" || def.BatchSize != 1000 || def.Checkpoint != 10 || def.GapTimeout != 30 {
 		t.Errorf("base fields wrong: %+v", def)
 	}
+	// No Flavor on the entry resolves to "mysql" — the stream must run with the
+	// explicit flavor, not the empty string streamrun would silently normalize.
+	if def.Flavor != console.FlavorMySQL {
+		t.Errorf("Flavor = %q, want mysql (unset default)", def.Flavor)
+	}
 	if def.Deps.ValidateBinlogFormat == nil {
 		t.Error("Deps must be wired (streamdeps.Default())")
 	}
@@ -68,6 +73,15 @@ func TestSourceStreamConfig(t *testing.T) {
 	}, 7)
 	if got.SSLMode != "verify-ca" || got.SSLCA != "/ca.pem" || got.SSLCert != "/cert.pem" || got.SSLKey != "/key.pem" {
 		t.Errorf("registry TLS did not propagate to the stream config: %+v", got)
+	}
+
+	// A MariaDB entry must run the stream with the MariaDB flavor, not the MySQL
+	// GTID parser — the stream Flavor and the ext source job's flavor must agree.
+	maria := sourceStreamConfig(console.ServerEntry{
+		ID: "e3", DSN: "idx-dsn", SourceDSN: "src-dsn", Flavor: console.FlavorMariaDB,
+	}, 9)
+	if maria.Flavor != console.FlavorMariaDB {
+		t.Errorf("Flavor = %q, want mariadb", maria.Flavor)
 	}
 }
 

--- a/consoleapp/watch.go
+++ b/consoleapp/watch.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-sql-driver/mysql"
 	"github.com/spf13/cobra"
 
+	"github.com/dbtrail/dbtrail/ext"
 	"github.com/dbtrail/dbtrail/internal/baseline"
 	"github.com/dbtrail/dbtrail/internal/cliutil"
 	"github.com/dbtrail/dbtrail/internal/config"
@@ -612,7 +613,18 @@ func runUpStreamWithConsole(cmd *cobra.Command, args []string) error {
 	// stream_state checkpoint.
 	go supervisor.Reconcile(registry)
 
-	streamErr := streamrun.One(ctx, watchStreamConfig(serverID))
+	// Extension source jobs (ext.RegisterSourceJob) for the daemon's MAIN source
+	// run alongside its stream on the daemon context (ctx) — the same secondary,
+	// never-fatal, daemon-scoped contract as `bintrail up` (cliapp/up.go) and the
+	// built-in rotation loop above. The supervised registry sources get their own
+	// jobs from the monitor supervisor (consoleapp/monitor.go); this call covers
+	// only the single main source `watch --source-dsn` streams. Flavor is the
+	// value the main stream below actually runs with (streamCfg.Flavor). No-op in
+	// the stock binary.
+	streamCfg := watchStreamConfig(serverID)
+	ext.RunSourceJobs(ctx, mainSourceJobInfo(upSourceDSN, upIndexDSN, streamCfg.Flavor))
+
+	streamErr := streamrun.One(ctx, streamCfg)
 	stop()                // drain the console even if the stream returned without a signal
 	<-consoleDone         // order the console goroutine's exit before the deferred db.Close()
 	stopFlashback()       // drain the flashback port before the deferred db.Close()
@@ -654,6 +666,21 @@ func watchStreamConfig(serverID uint32) streamrun.Config {
 		MetricsScrapeInterval: upMetricsScrapeInterval,
 		Deps:                  streamdeps.Default(),
 	}
+}
+
+// mainSourceJobInfo builds the ext.SourceJobInfo for `watch`'s main (non-registry)
+// source. Extracted from runUpStreamWithConsole so the flavor resolution is
+// unit-testable without a live daemon. streamFlavor is watchStreamConfig's
+// Flavor: `watch` exposes no --source-flavor for its main source, so it is empty
+// and streamrun.One normalizes it to "mysql" internally; we default it to the
+// same canonical value here so a registered job sees the non-empty flavor
+// `bintrail up` supplies (never "").
+func mainSourceJobInfo(sourceDSN, indexDSN, streamFlavor string) ext.SourceJobInfo {
+	flavor := streamFlavor
+	if flavor == "" {
+		flavor = console.FlavorMySQL
+	}
+	return ext.SourceJobInfo{SourceDSN: sourceDSN, IndexDSN: indexDSN, Flavor: flavor}
 }
 
 // resolveUpConsoleEnv applies the console-specific env vars to the upConsole*

--- a/consoleapp/watch_test.go
+++ b/consoleapp/watch_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/dbtrail/dbtrail/ext"
 	"github.com/dbtrail/dbtrail/internal/baseline"
 	"github.com/dbtrail/dbtrail/internal/console"
 	"github.com/dbtrail/dbtrail/internal/rotation"
@@ -579,5 +580,29 @@ func TestRunBaselinePruneCycle(t *testing.T) {
 		if c.Retain != 7*24*time.Hour {
 			t.Errorf("Retain = %v, want 7d", c.Retain)
 		}
+	}
+}
+
+// TestMainSourceJobInfo covers the pure flavor-resolution + SourceJobInfo
+// construction for watch's main source (the wiring in runUpStreamWithConsole
+// that fires ext.RunSourceJobs for the daemon's --source-dsn stream). The
+// live-daemon firing itself is covered in monitor_integration_test.go for the
+// supervised path; this pins the main-source construction without a daemon.
+func TestMainSourceJobInfo(t *testing.T) {
+	// Empty stream flavor (watchStreamConfig leaves Flavor unset; streamrun.One
+	// normalizes it to mysql) → the canonical non-empty "mysql", matching the
+	// value `bintrail up` supplies.
+	got := mainSourceJobInfo("user:pass@tcp(h:3306)/db", "idx-dsn", "")
+	want := ext.SourceJobInfo{SourceDSN: "user:pass@tcp(h:3306)/db", IndexDSN: "idx-dsn", Flavor: "mysql"}
+	if got != want {
+		t.Errorf("empty flavor: got %+v, want %+v", got, want)
+	}
+
+	// A non-empty stream flavor is carried through verbatim, so if watch ever
+	// grows a --source-flavor for its main source the job sees it unchanged.
+	got = mainSourceJobInfo("src", "idx", "mariadb")
+	want = ext.SourceJobInfo{SourceDSN: "src", IndexDSN: "idx", Flavor: "mariadb"}
+	if got != want {
+		t.Errorf("mariadb flavor: got %+v, want %+v", got, want)
 	}
 }


### PR DESCRIPTION
## What

Wires the `ext.RunSourceJobs` seam (`ext.RegisterSourceJob`) into the two console-capable capture paths that lost it in the console decouple, so a registered extension source job — an embedding distribution's per-source background job — runs alongside `bintrail-console watch` and its per-source monitor supervisor, not only under `bintrail up`.

No behavior change for the stock binary: `RunSourceJobs` is a no-op with no registered jobs.

## Why (generic)

The seam already existed and was wired at `bintrail up`'s daemon startup (`cliapp/up.go`), as secondary daemon-scoped work bound to the stream lifecycle (same contract as the built-in rotation loop). The console decouple moved the two console-capable daemons — `watch` and the control-plane monitor supervisor — onto their own code paths, so a registered job never ran alongside their streams. This restores parity: the job now runs for every source these daemons actually stream, each bound to that source's lifecycle so it stops with the source.

## The two wiring points

Both mirror `up`'s contract — a secondary, never-fatal, daemon-scoped job bound to the stream's lifecycle context:

1. **`consoleapp/monitor.go` (supervised registry sources).** In `Start`, immediately after index-DB provisioning + the advisory lock and before the stream goroutine, fire on `jobCtx` — the per-source lifecycle context. `jobCtx` is created once per genuine (re)start (the idempotent already-running early-returns never reach it) and reused across stream reconnects, so jobs are scoped to the source's lifetime: not per stream-reconnect (no per-retry goroutine leak) and only for a source this daemon actually streams. Flavor is the entry's resolved source family (`mysql` / `mariadb` / `postgres`).

2. **`consoleapp/watch.go` (the main `--source-dsn` stream).** Fire on the daemon context right before the stream handoff, with the flavor the main stream actually runs with (`streamCfg.Flavor`, defaulted empty→`mysql` to match `up`'s non-empty contract via the extracted, unit-testable `mainSourceJobInfo` helper). The source-less `watch` (`runUpConsoleOnly`) is deliberately **not** wired — it has no main source; its sources arrive through the supervisor above.

## The jobCtx-lifecycle rationale

Binding each set of jobs to `jobCtx` (the monitor) / the daemon `ctx` (watch's main source) is what makes them stop with their source: a monitored source's `Stop` cancels its `jobCtx`, and daemon shutdown cancels both. Placing the monitor call after provisioning + the lock (not before, not inside the reconnect loop `m.run`) means jobs can write to the already-provisioned per-source index, never double-fire per reconnect, and fire only for the advisory-lock holder at launch.

## Tests + coverage tiers

- **Unit (`consoleapp`, no build tag) — RUN & PASS:** `TestMainSourceJobInfo` covers the watch main-source `SourceJobInfo` construction + flavor resolution (empty→`mysql`, non-empty carried through) without a live daemon.
- **Integration (`consoleapp`, `//go:build integration`, `SkipIfNoMySQL`) — COMPILE-VERIFIED (`go vet -tags integration ./...`), SKIPPED at runtime** (no `root:testroot` test MySQL available in this environment):
  - `TestIntegrationMonitorRunsExtSourceJob` — the supervisor fires the job **once** for a started source with the entry's DSNs + resolved flavor; an idempotent `Start` does **not** fire a duplicate; and **the leak contract** — after `Stop`, the job's bound `jobCtx` is `Done` (proving per-source teardown, not merely daemon-ctx teardown, since the outer daemon ctx is still live).
  - `TestIntegrationMonitorExtSourceJobPGFlavor` — a PostgreSQL entry carries `Flavor="postgres"`.
  - Both stub the stream (`streamFn` / `pgStreamFn`), so they exercise the wiring against a real index without a reachable source.

## Verification

- `gofmt -l` clean · `go build ./...` · `go vet -tags integration ./...` (mandatory gate — passes, compiles the new integration tests) · `go test ./... -count=1` all green.
- The decouple guards stay green: `TestCoreBinaryIsUIFree`, `TestCoreBinaryIsPostgresFree`, attribution guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
