### PR TITLE
console: "Connect AI" settings card (MCP URL, token guidance, bundle download)

### DIFF
--- a/consoleapp/root.go
+++ b/consoleapp/root.go
@@ -34,6 +34,12 @@ var (
 	logFormat string
 )
 
+// appVersion is the bare -ldflags-injected version ("0.36.0", or "dev"),
+// captured by Main for surfaces that need it un-decorated — the console
+// reports it in /api/capabilities so the UI can link release artifacts for
+// the running build (rootCmd.Version carries the human-formatted variant).
+var appVersion = "dev"
+
 var rootCmd = &cobra.Command{
 	Use:   "bintrail-console",
 	Short: "Read-only web console over the Bintrail binlog index",
@@ -63,6 +69,7 @@ func init() {
 // external distributions embedding the console) are expected to pass their
 // -ldflags-injected version values and os.Exit with the result.
 func Main(version, commitSHA, buildDate string) int {
+	appVersion = version
 	rootCmd.Version = fmt.Sprintf("%s (commit %s, built %s)", version, commitSHA, buildDate)
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/consoleapp/serve.go
+++ b/consoleapp/serve.go
@@ -239,6 +239,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		TLSCert:       conTLSCert,
 		TLSKey:        conTLSKey,
 		AllowSetup:    conAllowSetup,
+		Version:       appVersion,
 		// MonitorCtrl is intentionally left nil: bintrail-console serve is the
 		// read-only standalone console. A write-capable control-plane daemon
 		// wires a supervisor here instead; with nil, /api/capabilities reports

--- a/consoleapp/watch.go
+++ b/consoleapp/watch.go
@@ -982,6 +982,7 @@ func upConsoleConfig(db *sql.DB, indexDSN string, opts consoleOpts) (console.Con
 			Enabled:   upRotationCfg.Enabled,
 		},
 		AllowSetup: opts.AllowSetup,
+		Version:    appVersion,
 		// MonitorCtrl (the control-plane supervisor) is wired by the caller —
 		// runUpStreamWithConsole / runUpConsoleOnly — because it needs the
 		// registry and the daemon lifecycle context, which this config builder

--- a/docs/console.md
+++ b/docs/console.md
@@ -680,6 +680,13 @@ Rules that differ from the standalone `bintrail-mcp` server:
 The host-header allowlist (`--allowed-hosts`) covers `/mcp` like every other
 route.
 
+The UI's **Settings → Connect AI** page assembles all of this for you: the
+ready-to-copy `/mcp` URL for the selected server (the per-server form when
+more than one server is registered), the `.mcpb` bundle download for the
+running version, and the raw-config fallback above. When no token is
+configured it explains how to set one instead — the token value itself is
+never displayed.
+
 ## API
 
 All endpoints return JSON. `/api/*` (except `healthz`) require

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -39,7 +39,7 @@ const EVENT_CSV_COLUMNS = [
 const BADGE_CLASS = { UPDATE: "b-update", INSERT: "b-insert", DELETE: "b-delete" };
 function badgeClass(t) { return BADGE_CLASS[t] || "b-baseline"; }
 
-const ROUTES = ["overview", "events", "timetravel", "recover", "status", "storage"];
+const ROUTES = ["overview", "events", "timetravel", "recover", "status", "storage", "connect"];
 
 const MON_STATE_TITLES = {
   failed: "connection is failing and retrying automatically; press Start for details",
@@ -635,6 +635,7 @@ function renderRoute() {
     case "recover": return renderRecover(params);
     case "status": return renderStatus();
     case "storage": return renderStorage();
+    case "connect": return renderConnect();
     default: return renderOverview();
   }
 }
@@ -2405,6 +2406,155 @@ function updateSrvNote() {
   if (n) n.hidden = !(serversEmpty && capsCache.monitor);
 }
 
+// ── Connect AI client (#1041) ────────────────────────────────────────────────
+//
+// Settings view for wiring an MCP client (Claude Desktop, claude.ai custom
+// connectors, any Streamable-HTTP client) to this console's /mcp endpoint.
+// Availability comes from capabilities.mcp — a static token is configured,
+// the endpoint's only accepted credential — and the token VALUE is never
+// rendered anywhere in this view.
+
+async function renderConnect() {
+  const gen = serverGen;
+  viewLoading();
+  // The server list only picks between /mcp and /mcp/{id-or-name}; a failure
+  // (or the registry-only 404 on an empty console) degrades to the bare
+  // default-server URL instead of blanking the page.
+  let servers = [];
+  try { servers = (await api("/api/servers")).servers || []; } catch (_) {}
+  if (gen !== serverGen) return;
+  try {
+    buildConnect(servers);
+  } catch (err) {
+    const v = VIEW(); clear(v); v.append(pageHead("Connect AI", null)); renderError(v, err);
+  }
+}
+
+// mcpSelector maps a server entry to its /mcp/{id-or-name} path selector: the
+// registry display name when set (readable), the id otherwise, and the
+// reserved "default" selector for the ephemeral boot (cli) entry.
+function mcpSelector(entry) {
+  if (!entry) return "";
+  if (entry.kind === "ephemeral") return "default";
+  return entry.name || entry.id || "";
+}
+
+// mcpURL builds the ready-to-copy endpoint URL from the BROWSER's origin, so
+// it is correct behind a reverse proxy for the common case. With one listed
+// server the bare /mcp (the console's default server) is enough; with several,
+// the per-server form pins the server currently selected in the sidebar.
+function mcpURL(servers) {
+  let path = "/mcp";
+  if ((servers || []).length > 1) {
+    const cur = servers.find((s) => s.id === (currentServer || defaultServerId));
+    const sel = mcpSelector(cur);
+    if (sel) path += "/" + encodeURIComponent(sel);
+  }
+  return location.origin + path;
+}
+
+function copyText(text, what) {
+  navigator.clipboard.writeText(text).then(() => toast(what + " copied to clipboard"), () => toast("Copy failed."));
+}
+
+function buildConnect(servers) {
+  const v = VIEW(); clear(v);
+  const sub = el("p", { class: "page-sub" },
+    "Let an AI assistant query this console — the same read-only tools and result caps as this UI. ",
+    el("b", { text: "Your token is never shown here." }));
+  v.append(pageHead("Connect AI", sub));
+
+  const cards = el("div", { class: "cards" });
+  cards.append(mcpEndpointCard(servers));
+  cards.append(bundleCard());
+  v.append(cards);
+  if (capsCache.mcp) v.append(otherClientsPanel(servers));
+  viewEnter();
+}
+
+// mcpEndpointCard: the ready-to-copy URL when the endpoint is usable, or the
+// how-to-enable explanation when no token is configured (capabilities.mcp) —
+// never a URL presented as ready that would only ever answer 403.
+function mcpEndpointCard(servers) {
+  const card = el("div", { class: "card" }, el("div", { class: "card-title", text: "MCP endpoint" }));
+  if (!capsCache.mcp) {
+    card.append(el("p", { class: "stg-hint", text:
+      "MCP is not available: this console has no access token configured. The MCP endpoint authenticates with the console's static token — password login is a browser credential and cannot be used by an MCP client." }));
+    card.append(el("p", { class: "form-hint", text:
+      "To enable it, start the console with --token (or the BINTRAIL_CONSOLE_TOKEN environment variable; TOKEN in the compose stack) and reload this page." }));
+    return card;
+  }
+  const url = mcpURL(servers);
+  card.append(el("div", { class: "cn-urlrow" },
+    el("code", { class: "stg-code cn-url", text: url }),
+    el("button", { class: "btn btn-sm", type: "button", text: "Copy", onclick: () => copyText(url, "MCP URL") })));
+  if ((servers || []).length > 1) {
+    card.append(el("p", { class: "form-hint", text:
+      "This URL targets the server selected in the sidebar; the bare /mcp targets the console's default server. Switch servers to get each one's URL." }));
+  }
+  card.append(el("p", { class: "form-hint", text:
+    "The credential is the console access token, sent as an Authorization: Bearer header — the same value set with --token / BINTRAIL_CONSOLE_TOKEN. It is never displayed here." }));
+  return card;
+}
+
+// bundleCard links the .mcpb bundle (one-click Claude Desktop install) for the
+// RUNNING version. Best-effort: a release that predates the bundle artifact
+// 404s the direct link, so a releases-page path is always offered too.
+function bundleCard() {
+  const card = el("div", { class: "card" }, el("div", { class: "card-title", text: "Claude Desktop bundle" }));
+  const ver = String(capsCache.version || "").replace(/^v/, "");
+  const released = /^\d+\.\d+\.\d+$/.test(ver);
+  card.append(el("p", { class: "stg-hint", text:
+    "Install the bundle in Claude Desktop (double-click), then paste the URL above and your console token — no config files to edit." }));
+  if (released) {
+    const asset = "dbtrail-" + guessPlatform() + ".mcpb";
+    card.append(el("div", { class: "cn-links" },
+      el("a", { class: "btn btn-sm", href: "https://github.com/dbtrail/dbtrail/releases/download/v" + ver + "/" + asset, text: "Download " + asset }),
+      el("a", { class: "btn btn-sm btn-ghost", href: "https://github.com/dbtrail/dbtrail/releases/tag/v" + ver, target: "_blank", rel: "noopener", text: "All downloads for v" + ver })));
+    card.append(el("p", { class: "form-hint", text:
+      "The link matches this console's version (v" + ver + "). Older releases don't carry the bundle — if the download 404s, pick a newer release from the releases page." }));
+  } else {
+    card.append(el("div", { class: "cn-links" },
+      el("a", { class: "btn btn-sm", href: "https://github.com/dbtrail/dbtrail/releases", target: "_blank", rel: "noopener", text: "Open the releases page" })));
+    card.append(el("p", { class: "form-hint", text:
+      "This console is an unversioned build, so no exact bundle link can be derived — pick the bundle matching your platform from the latest release." }));
+  }
+  return card;
+}
+
+// guessPlatform maps the browser's environment to a release-artifact os-arch
+// pair. Best-effort presentation only (Apple Silicon is assumed on macOS); the
+// all-downloads link covers every other combination.
+function guessPlatform() {
+  const ua = navigator.userAgent || "";
+  if (/Windows/i.test(ua)) return "windows-amd64";
+  if (/Mac/i.test(ua)) return "darwin-arm64";
+  return "linux-amd64";
+}
+
+// otherClientsPanel: collapsed raw-config fallback for MCP clients that don't
+// install .mcpb bundles. The snippet carries a PLACEHOLDER for the token — the
+// real value is never rendered.
+function otherClientsPanel(servers) {
+  const url = mcpURL(servers);
+  const snippet = JSON.stringify({
+    mcpServers: {
+      dbtrail: { command: "bintrail-mcp", args: ["--connect", url, "--token", "YOUR_CONSOLE_TOKEN"] },
+    },
+  }, null, 2);
+  const panel = el("section", { class: "ov-panel cn-other", style: "margin-top:18px" });
+  const adv = el("details", { class: "form-advanced", style: "margin-top:0" },
+    el("summary", { class: "form-adv-summary", text: "Other clients (raw config)" }));
+  adv.append(el("p", { class: "form-hint", text:
+    "For claude_desktop_config.json — or any client that launches stdio MCP servers — bintrail-mcp bridges stdio to this console. Replace the placeholder with your console token:" }));
+  adv.append(el("pre", { class: "stg-code cn-snippet", text: snippet }));
+  adv.append(el("button", { class: "btn btn-sm", type: "button", text: "Copy snippet", onclick: () => copyText(snippet, "Config snippet") }));
+  adv.append(el("p", { class: "form-hint", text:
+    "If this console is reachable over public HTTPS, the same URL also works directly as a claude.ai custom connector — no bridge needed." }));
+  panel.append(adv);
+  return panel;
+}
+
 // ── capabilities gating ────────────────────────────────────────────────────
 
 async function gateCapabilities() {
@@ -3040,6 +3190,7 @@ function cmdkCommands() {
   ];
   if (capsCache.reconstruct) cmds.push({ group: "Navigate", label: "Time-travel", run: () => navigate("timetravel") });
   if (capsCache.monitor) cmds.push({ group: "Navigate", label: "Storage", run: () => navigate("storage") });
+  cmds.push({ group: "Navigate", label: "Connect AI", run: () => navigate("connect") });
   cmds.push({ group: "Actions", label: "Manage servers", run: () => { closeCmdk(); openServersModal(); } });
   if (capsCache.monitor) cmds.push({ group: "Actions", label: "Configure rotation…", run: () => { closeCmdk(); showRotationDialog(); } });
   if (capsCache.auth) {

--- a/internal/console/assets/index.html
+++ b/internal/console/assets/index.html
@@ -79,18 +79,24 @@
             <span>Status</span>
           </a>
         </div>
-        <!-- Settings exists only on the watch daemon (the process that runs
-             rotation and archiving) — gated like the Time-travel item. The
-             Rotation entry is a modal trigger, not a route: it has no
-             data-route, and init() binds it separately (the generic .nav-item
-             handler skips route-less items). -->
-        <div class="nav-group" data-capability="monitor">
+        <!-- Settings group. Storage and Rotation exist only on the watch
+             daemon (the process that runs rotation and archiving) — gated
+             per-item like the Time-travel item, so the always-available
+             Connect AI entry keeps the group visible on the standalone serve
+             too (#1041). The Rotation entry is a modal trigger, not a route:
+             it has no data-route, and init() binds it separately (the generic
+             .nav-item handler skips route-less items). -->
+        <div class="nav-group">
           <div class="nav-label">Settings</div>
-          <a class="nav-item" data-route="storage" href="/storage">
+          <a class="nav-item" data-route="connect" href="/connect">
+            <span class="ni-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M9 7V3M15 7V3"/><path d="M6 7h12v5a6 6 0 0 1-12 0z"/><path d="M12 18v3"/></svg></span>
+            <span>Connect AI</span>
+          </a>
+          <a class="nav-item" data-route="storage" href="/storage" data-capability="monitor">
             <span class="ni-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="5" rx="8" ry="3"/><path d="M4 5v14c0 1.66 3.58 3 8 3s8-1.34 8-3V5"/><path d="M4 12c0 1.66 3.58 3 8 3s8-1.34 8-3"/></svg></span>
             <span>Storage</span>
           </a>
-          <button class="nav-item" id="nav-rotation" type="button">
+          <button class="nav-item" id="nav-rotation" type="button" data-capability="monitor">
             <span class="ni-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 0 1 15.5-6.2L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-15.5 6.2L3 16"/><path d="M3 21v-5h5"/></svg></span>
             <span>Rotation</span>
           </button>

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -1326,6 +1326,13 @@ button { font-family: inherit; }
   align-self: flex-start; overflow-x: auto; max-width: 100%;
 }
 
+/* Connect AI client (#1041) */
+.cn-urlrow { display: flex; gap: 8px; align-items: center; margin: 4px 0 10px; }
+.cn-url { flex: 1; align-self: auto; white-space: nowrap; }
+.cn-links { display: flex; gap: 8px; flex-wrap: wrap; margin: 10px 0; }
+.cn-snippet { display: block; margin: 8px 0 10px; white-space: pre; }
+.cn-other .form-hint { margin-top: 8px; }
+
 /* ============================================================
    date/time picker (Since/Until/At filters)
    ============================================================ */

--- a/internal/console/mcp_test.go
+++ b/internal/console/mcp_test.go
@@ -1,6 +1,7 @@
 package console
 
 import (
+	"encoding/json"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -145,6 +146,54 @@ func TestMCP_hiddenBootStillBacksDefault(t *testing.T) {
 	// selectable server anywhere else in the console either.
 	if rec := doMCP(t, s, "/mcp/default", "t"); rec.Code != 404 {
 		t.Fatalf("hidden-boot /mcp/default = %d, want 404", rec.Code)
+	}
+}
+
+// TestMCP_capabilityGatedOnToken: /api/capabilities advertises mcp iff a
+// static token is configured (the endpoint's only accepted credential — the
+// same condition mcpHandler refuses on), plus the running build version the
+// Connect AI card derives release links from.
+func TestMCP_capabilityGatedOnToken(t *testing.T) {
+	db, _, closer := newSQLMock(t)
+	defer closer()
+
+	caps := func(s *Server) capabilitiesResponse {
+		t.Helper()
+		rec := httptest.NewRecorder()
+		s.handleCapabilities(rec, httptest.NewRequest("GET", "/api/capabilities", nil))
+		if rec.Code != 200 {
+			t.Fatalf("capabilities = %d, want 200; body: %s", rec.Code, rec.Body.String())
+		}
+		var resp capabilitiesResponse
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatal(err)
+		}
+		return resp
+	}
+
+	// Token configured: mcp advertised, version passed through.
+	s := newBootServer(db) // token "t"
+	s.version = "1.2.3"
+	got := caps(s)
+	if !got.MCP {
+		t.Error("mcp = false with a configured token, want true")
+	}
+	if got.Version != "1.2.3" {
+		t.Errorf("version = %q, want %q", got.Version, "1.2.3")
+	}
+
+	// Password-only / no-auth posture (no static token): mcp must be false —
+	// mcpHandler refuses every request there (TestMCP_requiresConfiguredToken),
+	// so advertising it would point the card at a dead endpoint.
+	s2 := &Server{token: "", cm: newConnManager(nil, false)}
+	s2.cm.boot = &bundle{db: db, engine: query.New(db), noArchive: true}
+	s2.mux = s2.buildHandler()
+	got2 := caps(s2)
+	if got2.MCP {
+		t.Error("mcp = true with no token configured, want false")
+	}
+	if got2.Version != "" {
+		t.Errorf("version = %q, want empty for an unversioned build", got2.Version)
 	}
 }
 

--- a/internal/console/reconstruct.go
+++ b/internal/console/reconstruct.go
@@ -87,6 +87,15 @@ type capabilitiesResponse struct {
 	// per entry. Generic by construction — the core names no specific view.
 	ExtensionViews []extensionViewDTO `json:"extension_views,omitempty"`
 	Auth           authCapsInfo       `json:"auth"`
+	// MCP: the /mcp endpoint is usable — a static console token is configured
+	// (the endpoint's only accepted credential; see mcp.go). Process-global,
+	// like Monitor. The frontend's "Connect AI client" card keys its
+	// ready-vs-explain state on this instead of ever probing /mcp itself.
+	MCP bool `json:"mcp"`
+	// Version is the running build's version string ("0.36.0"; "dev" or empty
+	// on unversioned builds). Presentation-only: the Connect AI client card
+	// derives the release-asset download link for the RUNNING version from it.
+	Version string `json:"version,omitempty"`
 	// Source names the selected server's source database family — "postgresql"
 	// or "mysql" — derived per-server from stream_state.flavor (the same field
 	// DialectForIndex reads). It drives source-aware PRESENTATION only: the
@@ -141,6 +150,10 @@ func (s *Server) handleCapabilities(w http.ResponseWriter, r *http.Request) {
 		// only by the RBAC profile (which would make synthesis leak redacted data).
 		RecoverCascade: !s.rbacActive(),
 		Auth:           authCapsInfo{PasswordSet: s.passwordLoginEnabled(), AuthKind: kind},
+		// The MCP endpoint accepts only the static token (mcp.go refuses with
+		// 403 when none is configured), so token presence IS the capability.
+		MCP:     s.token != "",
+		Version: s.version,
 		// Default until the bundle resolves: a degraded console renders MySQL
 		// vocabulary (the common case), never a blank source.
 		Source: sourceMySQL,

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -124,6 +124,11 @@ type Config struct {
 	// daemon; zero on the standalone serve (which runs no rotation loop and
 	// hides the panel).
 	RotationDefaults RotationDefaults
+	// Version is the running build's version string ("0.36.0", or "dev" on
+	// unversioned builds), reported in /api/capabilities so the frontend can
+	// link release artifacts (the .mcpb bundle) matching the running binary.
+	// Optional; empty reads as an unversioned build.
+	Version string
 }
 
 // RotationDefaults is the daemon-side built-in-rotation policy, surfaced to the
@@ -164,7 +169,9 @@ type Server struct {
 	// rotationDefaults are the daemon's --rotate-* values, the fallback GET
 	// /api/rotation reports when no console override is saved.
 	rotationDefaults RotationDefaults
-	cm               *connManager
+	// version is the running build's version string (Config.Version).
+	version string
+	cm      *connManager
 	mux              http.Handler
 	// Password login: authPath is the credential file (re-read per login so a
 	// live `user set-password` applies without restart); passwordCfg is its
@@ -290,6 +297,7 @@ func New(cfg Config) (*Server, error) {
 		baselineCtrl:     cfg.BaselineCtrl,
 		verifyCtrl:       cfg.VerifyCtrl,
 		rotationDefaults: cfg.RotationDefaults,
+		version:          cfg.Version,
 		cm:               newConnManager(cfg.Registry, profileActive),
 		authPath:         authPath,
 		passwordCfg:      passwordCfg,


### PR DESCRIPTION
Stacked on #1042 (the `/mcp` endpoint this card documents); merge that first.

## What

- New **Settings → Connect AI** route (serve and watch): ready-to-copy `/mcp` URL built from the browser origin (per-server `/mcp/{id-or-name}` form when more than one server is listed, pinned to the sidebar selection), a Claude Desktop `.mcpb` bundle download for the running version, and a collapsed raw-config fallback (`bintrail-mcp --connect` snippet with a token placeholder) plus a note that a public HTTPS console URL works directly as a claude.ai custom connector.
- `capabilities.mcp` (token configured — the endpoint's only accepted credential) gates the ready-vs-explain state; `capabilities.version` (bare ldflags version threaded through `consoleapp`) derives the release-asset link, degrading to the releases page on unversioned builds. The token value is never rendered anywhere in the view.
- Settings nav gating moves from the group to its items (`data-capability` per item), so Connect AI shows on the standalone read-only serve while Storage/Rotation stay watch-only.

## Verification

- `go build ./...`, `go test ./internal/console ./consoleapp -count=1`, `go vet -tags integration ./...` — pass.
- Browser-render verified with real headless Chrome (playwright-core, `channel:'chrome'`) against a live index: token-configured state (URL card, copy button, unversioned-build bundle fallback, snippet with placeholder) and no-token state (explanation + enable instructions, no URL) both assert green, including a page-wide token-leak check.

Closes #1041

🤖 Generated with [Claude Code](https://claude.com/claude-code)