### PR TITLE
Privacy policy for the Claude Desktop extension (directory submission prep)

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,62 @@
+# Privacy Policy — dbtrail Claude Desktop extension (`dbtrail.mcpb`)
+
+*Last updated: 2026-07-18*
+
+This policy covers the **dbtrail desktop extension** — the `.mcpb` bundle that
+connects Claude Desktop to a self-hosted bintrail/dbtrail deployment — and the
+`bintrail-mcp` bridge binary it runs. It also describes, for completeness, how
+data moves when you use it.
+
+## The short version
+
+The extension is a local bridge to **your own infrastructure**. dbtrail (the
+project and its maintainers) operates no servers in this flow, and **collects
+nothing**: no telemetry, no analytics, no crash reports, no account, no
+phone-home of any kind.
+
+## What the extension does with data
+
+- **Where it connects.** The bundled binary makes network connections to
+  exactly one place: the console/MCP endpoint URL **you** configure at install
+  time (your own bintrail console, on your machine, LAN, VPN, or server). It
+  never connects to dbtrail, Anthropic, or any other third party on its own.
+- **Your access token** is entered once in Claude Desktop's configuration form
+  and stored by Claude Desktop as a sensitive value (in the operating system's
+  credential store). The extension sends it only to the endpoint you
+  configured, as an `Authorization: Bearer` header. It is never written to
+  disk by the extension and never appears in its logs.
+- **Query results** (row change history, recovery SQL, index status, schema
+  changes) flow from your deployment, through the local bridge, into your
+  Claude conversation. The extension does not store, cache, or copy them —
+  each response exists only in the conversation that requested it.
+
+## Data collection, usage, and storage
+
+**We collect nothing.** There is no data collection practice to describe
+beyond that: the extension has no telemetry and transmits nothing to the
+dbtrail project. All indexed database history lives in the deployment you
+operate, under your control and your retention rules (see the
+[rotation documentation](docs/rotation-and-status.md)).
+
+## Third-party sharing
+
+None by the extension. One flow you should be aware of, because it is inherent
+to using any AI assistant: tool results that enter your Claude conversation
+are processed by **Anthropic** as conversation content, under
+[Anthropic's own privacy policy](https://www.anthropic.com/legal/privacy).
+If your change history contains sensitive row data, dbtrail's
+[RBAC profiles](docs/query-and-recovery.md) and the console's redaction rules
+let you limit what the MCP surface can return before it ever reaches a
+conversation.
+
+## Data retention
+
+The extension retains no data. Uninstalling it from Claude Desktop removes the
+bundle and its stored configuration; your deployment and its index are
+untouched.
+
+## Contact
+
+Questions about this policy or the extension's data handling:
+[open an issue](https://github.com/dbtrail/dbtrail/issues) on the public
+repository.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ See [the demo image](docs/demo.md).
 | | [Connect an AI assistant](docs/connect-ai.md) · [MCP server](docs/mcp-server.md) | [Parquet debugging](docs/parquet-debugging.md) |
 | | [Dump & Baseline](docs/dump-and-baseline.md) · [DDL tracking](docs/ddl-tracking.md) | |
 
+## Privacy Policy
+
+bintrail runs entirely in your infrastructure and collects nothing — no
+telemetry, no analytics, no phone-home. The [privacy policy](PRIVACY.md)
+covers the Claude Desktop extension (`.mcpb`) and how data moves when an AI
+client queries your deployment.
+
 ## License
 
 [Apache-2.0](LICENSE) — free for any use, including commercial and production.

--- a/packaging/mcpb/manifest.template.json
+++ b/packaging/mcpb/manifest.template.json
@@ -15,6 +15,7 @@
   },
   "homepage": "https://github.com/dbtrail/dbtrail",
   "license": "Apache-2.0",
+  "privacy_policies": ["https://github.com/dbtrail/dbtrail/blob/main/PRIVACY.md"],
   "keywords": ["mysql", "postgresql", "binlog", "recovery", "time-travel", "database"],
   "server": {
     "type": "binary",


### PR DESCRIPTION
Prep for submitting the `.mcpb` extension to the Claude Connectors Directory, which requires local extensions to carry a privacy policy (README section + `privacy_policies` in the manifest, HTTPS URL) — see https://claude.com/docs/connectors/building/submission.

- **PRIVACY.md**: the extension is a local bridge to the operator's own deployment; it connects only to the user-configured endpoint, the token lives in the OS credential store via Claude Desktop, and the project collects nothing (no telemetry of any kind). Discloses the one inherent flow — tool results become Claude conversation content under Anthropic's policy — and points at RBAC/redaction for limiting what the MCP surface can return.
- README: short Privacy Policy section linking it.
- `packaging/mcpb/manifest.template.json`: `privacy_policies` array pointing at the canonical GitHub URL. Bundle packaging re-validated (`build-mcpb.sh` + validator pass with the new field).

Tool `title` + `readOnlyHint` annotations (the other hard directory requirement) already ship on all four tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)