### PR TITLE
demo image: force-disable telemetry (DO_NOT_TRACK=1) + smoke assertion

### DIFF
--- a/demo/image/Dockerfile
+++ b/demo/image/Dockerfile
@@ -93,4 +93,13 @@ RUN chmod +x /usr/local/bin/entrypoint.sh /usr/local/bin/traffic.sh
 # 6033 = ProxySQL (Time Travel SQL entry point), 3306 = raw MySQL.
 EXPOSE 6033 3306
 
+# The demo image never reports usage telemetry, whatever the binary's
+# default is. Two layers, covering different holes: this ENV reaches ANY
+# process in the container (including `docker exec` and `--entrypoint
+# bash` pokes by an evaluator), while entrypoint.sh re-exports it so the
+# demo stack itself stays covered even if the ENV is overridden with
+# `docker run -e`. An evaluation image phoning home from someone's
+# laptop is the worst failure mode this project has.
+ENV DO_NOT_TRACK=1
+
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/demo/image/entrypoint.sh
+++ b/demo/image/entrypoint.sh
@@ -17,6 +17,13 @@
 
 set -euo pipefail
 
+# No usage telemetry from the demo image, ever — whatever the binary's
+# default is, and even if the Dockerfile's DO_NOT_TRACK ENV was
+# overridden with `docker run -e`. Must stay ABOVE every process this
+# script starts: exported after a child boots, it would not reach it.
+# smoke-test.sh asserts this on the live process environments.
+export DO_NOT_TRACK=1
+
 log() { echo "[demo image] $(date '+%H:%M:%S') $*"; }
 
 BINTRAIL_DSN='bintrail:bintrail@tcp(127.0.0.1:3306)'

--- a/demo/image/smoke-test.sh
+++ b/demo/image/smoke-test.sh
@@ -70,20 +70,24 @@ sleep 70
 # no check. DO_NOT_TRACK=1 in the environ of every bintrail process is
 # deterministic and catches the realistic regression (the export moved
 # below a child's start, or a child spawned with a scrubbed env).
+# Processes are identified by their executable (/proc/PID/exe), NOT by a
+# substring of their command line: this scanning shell's own argv contains
+# the script text below, so a cmdline match would count the scanner itself
+# and the "no bintrail process found" assertion could never fire. Matching
+# the exe also skips transient `mysql ... bintrail_index` clients.
 log "Asserting the telemetry guard on live processes..."
 GUARD=$(docker exec "$NAME" sh -c '
     total=0; guarded=0
     for d in /proc/[0-9]*; do
-        [ -r "$d/cmdline" ] || continue
-        case "$(tr "\0" " " < "$d/cmdline")" in
-            *bintrail*) total=$((total+1)) ;;
+        case "$(readlink "$d/exe" 2>/dev/null)" in
+            */bintrail) total=$((total+1)) ;;
             *) continue ;;
         esac
         if tr "\0" "\n" < "$d/environ" 2>/dev/null | grep -qx "DO_NOT_TRACK=1"; then
             guarded=$((guarded+1))
         fi
     done
-    echo "$total $guarded"')
+    echo "$total $guarded"') || { log "FAIL: could not inspect processes in the container"; exit 1; }
 read -r TOTAL GUARDED <<<"$GUARD"
 log "bintrail processes: ${TOTAL:-0}, of them with DO_NOT_TRACK=1: ${GUARDED:-0}"
 [ "${TOTAL:-0}" -ge 1 ] \

--- a/demo/image/smoke-test.sh
+++ b/demo/image/smoke-test.sh
@@ -18,6 +18,16 @@ NAME="bintrail-demo-smoke"
 
 log() { echo "[smoke] $(date '+%H:%M:%S') $*"; }
 
+# ── Telemetry guard, static half (#1055) ────────────────────
+# Checked before the build so a dropped guard fails in a second rather
+# than three minutes. Both layers are pinned: either one alone satisfies
+# the live check below, so only asserting the effect would let one rot
+# unnoticed.
+grep -q '^export DO_NOT_TRACK=1' demo/image/entrypoint.sh \
+    || { log "FAIL: entrypoint.sh no longer exports DO_NOT_TRACK=1"; exit 1; }
+grep -q '^ENV DO_NOT_TRACK=1' demo/image/Dockerfile \
+    || { log "FAIL: Dockerfile no longer sets ENV DO_NOT_TRACK=1"; exit 1; }
+
 if [ -z "${SKIP_BUILD:-}" ]; then
     # Build for the host's native architecture (Percona Server + ProxySQL
     # both ship arm64, so this works on Graviton/Apple Silicon too). Override
@@ -52,6 +62,34 @@ done
 mysql_demo "SELECT 1" &>/dev/null || { log "FAIL: stack never answered on :$PORT"; docker logs "$NAME" | tail -40; exit 1; }
 log "Stack is answering. Letting traffic build history (70s)..."
 sleep 70
+
+# ── Telemetry guard, live half (#1055) ──────────────────────
+# Assert the MECHANISM on the running processes, not sampled network
+# connections: a telemetry POST lasts milliseconds, so a sampled
+# connection check would pass by luck — false confidence is worse than
+# no check. DO_NOT_TRACK=1 in the environ of every bintrail process is
+# deterministic and catches the realistic regression (the export moved
+# below a child's start, or a child spawned with a scrubbed env).
+log "Asserting the telemetry guard on live processes..."
+GUARD=$(docker exec "$NAME" sh -c '
+    total=0; guarded=0
+    for d in /proc/[0-9]*; do
+        [ -r "$d/cmdline" ] || continue
+        case "$(tr "\0" " " < "$d/cmdline")" in
+            *bintrail*) total=$((total+1)) ;;
+            *) continue ;;
+        esac
+        if tr "\0" "\n" < "$d/environ" 2>/dev/null | grep -qx "DO_NOT_TRACK=1"; then
+            guarded=$((guarded+1))
+        fi
+    done
+    echo "$total $guarded"')
+read -r TOTAL GUARDED <<<"$GUARD"
+log "bintrail processes: ${TOTAL:-0}, of them with DO_NOT_TRACK=1: ${GUARDED:-0}"
+[ "${TOTAL:-0}" -ge 1 ] \
+    || { log "FAIL: no bintrail process found — the guard check proved nothing"; exit 1; }
+[ "${TOTAL:-0}" = "${GUARDED:-0}" ] \
+    || { log "FAIL: $((TOTAL - GUARDED)) bintrail process(es) missing DO_NOT_TRACK=1"; exit 1; }
 
 LIVE=$(mysql_demo "SELECT status, total FROM orders WHERE id = 1")
 log "live row:        ${LIVE:-<empty>}"


### PR DESCRIPTION
closes #1055

First issue of the telemetry epic (#1054). Lands **before** any telemetry send code exists in the tree, so a demo image phoning home from an evaluator's laptop is impossible by sequencing rather than by review vigilance.

## Summary

- `Dockerfile`: `ENV DO_NOT_TRACK=1` — reaches any process in the container, including `docker exec` and `--entrypoint bash` pokes.
- `entrypoint.sh`: `export DO_NOT_TRACK=1` above every child process — survives a `docker run -e DO_NOT_TRACK=0` override for the demo stack itself.
- `smoke-test.sh`: both layers asserted. The static half (grep on the two files) runs **before** the build, so a dropped guard fails in a second instead of three minutes; the live half checks `DO_NOT_TRACK=1` in the environ of every `bintrail` process in the running container.

## Design note

The live check asserts the **mechanism** rather than sampling network connections. A telemetry POST lasts milliseconds, so a sampled connection check would pass by luck — false confidence is worse than no check. Both static assertions are kept because either layer alone satisfies the live check, so asserting only the effect would let one layer rot unnoticed.

## Test plan

- [x] `go test ./... -count=1` passes (no Go code changed)
- [x] `bash -n` clean on both scripts
- [x] Static assertions pass against the new files
- [x] `/proc` scan logic validated against a synthetic proc tree: correctly ignores non-bintrail processes (mysqld), and flags a bintrail process missing the guard
- [ ] Full `demo/image/smoke-test.sh` run (needs Docker; not available in this session — CI/manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)