### PR TITLE
telemetry: metadata-only spool-based usage reporting (core + consent + command)

### DIFF
--- a/cliapp/root.go
+++ b/cliapp/root.go
@@ -12,6 +12,7 @@ import (
 	"github.com/dbtrail/dbtrail/internal/agent"
 	"github.com/dbtrail/dbtrail/internal/cli"
 	"github.com/dbtrail/dbtrail/internal/observe"
+	"github.com/dbtrail/dbtrail/internal/telemetry"
 )
 
 var (
@@ -54,6 +55,10 @@ func init() {
 	// package and self-registered via init(); they moved to internal/cli so both
 	// binaries expose them.
 	cli.AddMaintenanceCommands(rootCmd)
+	// Usage telemetry control surface (status/show/on/off). Registered on every
+	// binary that can report, so `telemetry off` works from whichever one the
+	// operator has on PATH.
+	cli.AddTelemetryCommand(rootCmd)
 }
 
 // AddCommands registers additional top-level commands on the bintrail root
@@ -72,6 +77,7 @@ func AddCommands(cmds ...*cobra.Command) {
 func Main(version, commitSHA, buildDate string) int {
 	Version, CommitSHA, BuildDate = version, commitSHA, buildDate
 	rootCmd.Version = fmt.Sprintf("%s (commit %s, built %s)", Version, CommitSHA, BuildDate)
+	telemetry.SetVersion(version)
 
 	err := rootCmd.Execute()
 	if err == nil {

--- a/cliapp/root.go
+++ b/cliapp/root.go
@@ -47,6 +47,7 @@ binlog files still existing on disk.`,
 func init() {
 	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "Log level: debug, info, warn, error")
 	rootCmd.PersistentFlags().StringVar(&logFormat, "log-format", "text", "Log format: text or json")
+	rootCmd.PersistentFlags().String("telemetry", "", "Usage telemetry: on or off (overrides BINTRAIL_TELEMETRY; DO_NOT_TRACK=1 overrides everything)")
 	// Register the source-agnostic read commands that have moved to internal/cli
 	// (#529) so a future bintrail-pg can register the same set. Today: status.
 	cli.AddReadCommands(rootCmd)

--- a/cmd/bintrail-pg/main.go
+++ b/cmd/bintrail-pg/main.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/dbtrail/dbtrail/internal/cli"
 	"github.com/dbtrail/dbtrail/internal/observe"
+	"github.com/dbtrail/dbtrail/internal/telemetry"
 )
 
 var (
@@ -72,6 +73,9 @@ func init() {
 	// the same index DSN (#951). `bintrail-pg stream` additionally runs the
 	// built-in rotation loop for safe-by-default retention.
 	cli.AddMaintenanceCommands(rootCmd)
+	// Usage telemetry control surface, same set as the core binary.
+	cli.AddTelemetryCommand(rootCmd)
+	telemetry.SetVersion(Version)
 }
 
 func main() {

--- a/cmd/bintrail-pg/main.go
+++ b/cmd/bintrail-pg/main.go
@@ -63,6 +63,7 @@ func init() {
 	rootCmd.Version = fmt.Sprintf("%s (commit %s, built %s)", Version, CommitSHA, BuildDate)
 	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "Log level: debug, info, warn, error")
 	rootCmd.PersistentFlags().StringVar(&logFormat, "log-format", "text", "Log format: text or json")
+	rootCmd.PersistentFlags().String("telemetry", "", "Usage telemetry: on or off (overrides BINTRAIL_TELEMETRY; DO_NOT_TRACK=1 overrides everything)")
 	// The source-agnostic read plane (status/query/recover/reconstruct/shim),
 	// shared verbatim with the core binary. The PostgreSQL capture command
 	// (stream) is registered in stream.go's init().

--- a/consoleapp/root.go
+++ b/consoleapp/root.go
@@ -65,6 +65,7 @@ yourself.`,
 func init() {
 	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "Log level: debug, info, warn, error")
 	rootCmd.PersistentFlags().StringVar(&logFormat, "log-format", "text", "Log format: text or json")
+	rootCmd.PersistentFlags().String("telemetry", "", "Usage telemetry: on or off (overrides BINTRAIL_TELEMETRY; DO_NOT_TRACK=1 overrides everything)")
 	// Usage telemetry control surface, same set as the core binary.
 	cli.AddTelemetryCommand(rootCmd)
 }

--- a/consoleapp/root.go
+++ b/consoleapp/root.go
@@ -24,6 +24,9 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/dbtrail/dbtrail/internal/cli"
+	"github.com/dbtrail/dbtrail/internal/telemetry"
+
 	"github.com/spf13/cobra"
 
 	"github.com/dbtrail/dbtrail/internal/observe"
@@ -62,6 +65,8 @@ yourself.`,
 func init() {
 	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "Log level: debug, info, warn, error")
 	rootCmd.PersistentFlags().StringVar(&logFormat, "log-format", "text", "Log format: text or json")
+	// Usage telemetry control surface, same set as the core binary.
+	cli.AddTelemetryCommand(rootCmd)
 }
 
 // Main configures build metadata and runs the bintrail-console root command,
@@ -71,6 +76,7 @@ func init() {
 func Main(version, commitSHA, buildDate string) int {
 	appVersion = version
 	rootCmd.Version = fmt.Sprintf("%s (commit %s, built %s)", version, commitSHA, buildDate)
+	telemetry.SetVersion(version)
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 1

--- a/internal/cli/telemetry.go
+++ b/internal/cli/telemetry.go
@@ -29,8 +29,8 @@ error class. No identifier is stored or sent, and never your data, schemas,
 tables, DSNs, hostnames, IPs or file paths. Run "telemetry show" to see the
 exact bytes that would be sent.
 
-Precedence, highest first: DO_NOT_TRACK, --telemetry, BINTRAIL_TELEMETRY,
-the config file, then the default (on).`,
+Precedence, highest first: DO_NOT_TRACK, --telemetry=on|off,
+BINTRAIL_TELEMETRY, the config file, then the default (on).`,
 }
 
 var telemetryStatusCmd = &cobra.Command{
@@ -50,6 +50,12 @@ var telemetryStatusCmd = &cobra.Command{
 		reporting := decision.Enabled && !isCI && ep != "" && dirErr == nil
 
 		if telFormat == "json" {
+			// With no home directory there is no spool; emit empty rather than
+			// a bare relative path that looks like a real location.
+			spool := ""
+			if dirErr == nil {
+				spool = telemetry.SpoolDir(dir)
+			}
 			return cliutil.OutputJSON(map[string]any{
 				"reporting":      reporting,
 				"consent":        decision.Enabled,
@@ -57,7 +63,7 @@ var telemetryStatusCmd = &cobra.Command{
 				"endpoint_set":   ep != "",
 				"ci_detected":    isCI,
 				"config_dir":     dir,
-				"spool_dir":      telemetry.SpoolDir(dir),
+				"spool_dir":      spool,
 				"schema_version": telemetry.SchemaVersion,
 			})
 		}
@@ -126,11 +132,23 @@ func setTelemetry(cmd *cobra.Command, enabled bool) error {
 	if err := telemetry.SetEnabled(dir, enabled); err != nil {
 		return err
 	}
+	if !enabled {
+		// Events spooled before this decision would otherwise sit on disk
+		// forever: the drain only ever runs while telemetry is ENABLED, so
+		// nothing would ever send them or age them out. Reported as an error
+		// rather than swallowed — telling an operator "nothing will be sent"
+		// while their events are still on disk is the kind of half-truth this
+		// whole feature cannot afford.
+		if err := telemetry.PurgeSpool(dir); err != nil {
+			return fmt.Errorf("telemetry is now off, but discarding already-spooled events failed: %w", err)
+		}
+	}
 	fmt.Fprintf(cmd.OutOrStdout(), "Telemetry %s (recorded in %s).\n",
 		onOff(enabled), telemetry.StatePath(dir))
 	if !enabled {
 		fmt.Fprintln(cmd.OutOrStdout(),
-			"Nothing further will be recorded or sent from this account.\n"+
+			"Nothing further will be recorded or sent, and anything already\n"+
+				"spooled locally has been discarded.\n"+
 				"To disable telemetry for every tool on this machine, set DO_NOT_TRACK=1.")
 	}
 	return nil

--- a/internal/cli/telemetry.go
+++ b/internal/cli/telemetry.go
@@ -1,0 +1,165 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dbtrail/dbtrail/internal/cliutil"
+	"github.com/dbtrail/dbtrail/internal/telemetry"
+)
+
+var telFormat string
+
+// AddTelemetryCommand registers the telemetry control surface on root. Every
+// binary that can report registers it, so `telemetry off` works from whichever
+// one the operator happens to have on PATH.
+func AddTelemetryCommand(root *cobra.Command) {
+	root.AddCommand(telemetryCmd)
+}
+
+var telemetryCmd = &cobra.Command{
+	Use:   "telemetry",
+	Short: "Inspect and control usage telemetry",
+	Long: `Inspect and control bintrail's usage telemetry.
+
+Telemetry is metadata-only: command names, version, OS/arch and a bounded
+error class. No identifier is stored or sent, and never your data, schemas,
+tables, DSNs, hostnames, IPs or file paths. Run "telemetry show" to see the
+exact bytes that would be sent.
+
+Precedence, highest first: DO_NOT_TRACK, --telemetry, BINTRAIL_TELEMETRY,
+the config file, then the default (on).`,
+}
+
+var telemetryStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show whether telemetry is on, and what decided it",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if !cliutil.IsValidOutputFormat(telFormat) {
+			return fmt.Errorf("invalid --format %q: must be text or json", telFormat)
+		}
+		dir, dirErr := telemetry.ConfigDir()
+		decision := telemetry.Resolve(telemetryFlagValue(cmd), dir)
+		isCI := telemetry.IsCI()
+		ep := telemetry.Endpoint()
+
+		// Reporting requires consent AND a build that can send AND not being in
+		// CI. Keep the reasons separate so "off" is never mysterious.
+		reporting := decision.Enabled && !isCI && ep != "" && dirErr == nil
+
+		if telFormat == "json" {
+			return cliutil.OutputJSON(map[string]any{
+				"reporting":      reporting,
+				"consent":        decision.Enabled,
+				"decided_by":     string(decision.Source),
+				"endpoint_set":   ep != "",
+				"ci_detected":    isCI,
+				"config_dir":     dir,
+				"spool_dir":      telemetry.SpoolDir(dir),
+				"schema_version": telemetry.SchemaVersion,
+			})
+		}
+
+		state := "OFF"
+		if reporting {
+			state = "ON"
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Telemetry:    %s\n", state)
+		fmt.Fprintf(cmd.OutOrStdout(), "Consent:      %s (decided by: %s)\n",
+			onOff(decision.Enabled), decision.Source)
+		if ep == "" {
+			fmt.Fprintln(cmd.OutOrStdout(), "Endpoint:     not compiled in — this build cannot send anything")
+		} else {
+			fmt.Fprintf(cmd.OutOrStdout(), "Endpoint:     %s\n", ep)
+		}
+		if isCI {
+			fmt.Fprintln(cmd.OutOrStdout(), "CI detected:  yes — reporting suppressed regardless of consent")
+		}
+		if dirErr != nil {
+			fmt.Fprintln(cmd.OutOrStdout(), "Config dir:   unavailable (no home directory) — telemetry disabled")
+		} else {
+			fmt.Fprintf(cmd.OutOrStdout(), "Spool:        %s\n", telemetry.SpoolDir(dir))
+		}
+		return nil
+	},
+}
+
+var telemetryShowCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Print the exact JSON that would be sent (sends nothing)",
+	Long: `Print a representative event, byte for byte as it would be transmitted.
+
+This command performs no network access. It exists so the payload can be
+inspected without trusting the documentation: what you see here is the
+complete set of fields the wire format permits.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out, err := json.MarshalIndent(telemetry.SampleEvent(), "", "  ")
+		if err != nil {
+			return fmt.Errorf("render sample event: %w", err)
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "%s\n\nFields permitted on the wire: %v\n",
+			out, telemetry.AllowedFields)
+		fmt.Fprintf(cmd.OutOrStdout(), "Sent to: %s\n", endpointDescription())
+		return nil
+	},
+}
+
+var telemetryOnCmd = &cobra.Command{
+	Use:   "on",
+	Short: "Enable usage telemetry",
+	RunE:  func(cmd *cobra.Command, args []string) error { return setTelemetry(cmd, true) },
+}
+
+var telemetryOffCmd = &cobra.Command{
+	Use:   "off",
+	Short: "Disable usage telemetry",
+	RunE:  func(cmd *cobra.Command, args []string) error { return setTelemetry(cmd, false) },
+}
+
+func setTelemetry(cmd *cobra.Command, enabled bool) error {
+	dir, err := telemetry.ConfigDir()
+	if err != nil {
+		return fmt.Errorf("locate config directory: %w", err)
+	}
+	if err := telemetry.SetEnabled(dir, enabled); err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Telemetry %s (recorded in %s).\n",
+		onOff(enabled), telemetry.StatePath(dir))
+	if !enabled {
+		fmt.Fprintln(cmd.OutOrStdout(),
+			"Nothing further will be recorded or sent from this account.\n"+
+				"To disable telemetry for every tool on this machine, set DO_NOT_TRACK=1.")
+	}
+	return nil
+}
+
+// telemetryFlagValue reads the root --telemetry flag if the binary defines one.
+// Absent flag means "unset", which falls through to the next control.
+func telemetryFlagValue(cmd *cobra.Command) string {
+	if f := cmd.Root().PersistentFlags().Lookup("telemetry"); f != nil {
+		return f.Value.String()
+	}
+	return ""
+}
+
+func endpointDescription() string {
+	if ep := telemetry.Endpoint(); ep != "" {
+		return ep
+	}
+	return "nowhere — this build has no endpoint compiled in"
+}
+
+func onOff(b bool) string {
+	if b {
+		return "on"
+	}
+	return "off"
+}
+
+func init() {
+	telemetryStatusCmd.Flags().StringVar(&telFormat, "format", "text", "Output format: text or json")
+	telemetryCmd.AddCommand(telemetryStatusCmd, telemetryShowCmd, telemetryOnCmd, telemetryOffCmd)
+}

--- a/internal/telemetry/consent.go
+++ b/internal/telemetry/consent.go
@@ -1,0 +1,203 @@
+package telemetry
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Source names which control decided the resolved state. Reported by
+// `bintrail telemetry status` so an operator never has to guess why telemetry
+// is on or off on a given box.
+type Source string
+
+const (
+	SourceDoNotTrack Source = "DO_NOT_TRACK"
+	SourceFlag       Source = "flag"
+	SourceEnv        Source = "BINTRAIL_TELEMETRY"
+	SourceConfig     Source = "config file"
+	SourceDefault    Source = "default"
+)
+
+// Decision is the resolved consent state and what decided it.
+type Decision struct {
+	Enabled bool
+	Source  Source
+}
+
+// EnvVar is the environment control. Read directly rather than through
+// internal/cli's flag-to-env bindings: those resolve against a specific
+// command's flag set, and telemetry is resolved once at root level before any
+// subcommand's flags exist. Same direct-read pattern the console uses for
+// BINTRAIL_CONSOLE_LISTEN.
+const EnvVar = "BINTRAIL_TELEMETRY"
+
+// ciEnvVars are the CI markers checked as defense in depth. A CI run is not a
+// human deciding anything, so it never sends — regardless of consent state.
+// These NEVER enable telemetry; they only suppress it.
+var ciEnvVars = []string{
+	"CI", "GITHUB_ACTIONS", "TF_BUILD", "TRAVIS",
+	"CIRCLECI", "JENKINS_URL", "BUILDKITE", "GITLAB_CI",
+}
+
+// IsCI reports whether the process looks like it is running in CI.
+func IsCI() bool {
+	for _, v := range ciEnvVars {
+		if val := os.Getenv(v); val != "" && val != "0" && !strings.EqualFold(val, "false") {
+			return true
+		}
+	}
+	return false
+}
+
+// state is the on-disk consent record. It carries NO identifier and never goes
+// on the wire — the only thing telemetry ever writes outside the spool.
+type state struct {
+	// Enabled is nil when the operator has never made an explicit choice, which
+	// is distinct from an explicit "on": only the former shows the notice.
+	Enabled     *bool  `json:"enabled,omitempty"`
+	NoticeShown bool   `json:"notice_shown"`
+	DecidedAt   string `json:"decided_at,omitempty"`
+}
+
+// ConfigDir returns ~/.config/bintrail. An error here (no home directory:
+// distroless, systemd DynamicUser, a scrubbed environment) disables telemetry
+// entirely and silently — mirroring how the env-file loader skips rather than
+// failing a command the operator actually asked for.
+func ConfigDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".config", "bintrail"), nil
+}
+
+// StatePath returns the consent file path inside dir.
+func StatePath(dir string) string { return filepath.Join(dir, "telemetry.json") }
+
+// loadState reads the consent file. A missing, empty or corrupt file is "no
+// decision recorded", never an error: telemetry must not be able to fail a
+// command, and a hand-edited file should degrade to the default rather than
+// breaking the CLI.
+func loadState(dir string) state {
+	var s state
+	data, err := os.ReadFile(StatePath(dir))
+	if err != nil || len(data) == 0 {
+		return s
+	}
+	if err := json.Unmarshal(data, &s); err != nil {
+		return state{}
+	}
+	return s
+}
+
+// saveState writes the consent file atomically: temp file in the same
+// directory, fsync, rename — the pattern internal/console/registry.go uses for
+// the server registry. Unlike the spool (a hot path, plain appends), this is
+// written at most once per operator decision, so the fsync is free.
+func saveState(dir string, s state) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create config directory %s: %w", dir, err)
+	}
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal telemetry state: %w", err)
+	}
+	data = append(data, '\n')
+
+	tmp, err := os.CreateTemp(dir, ".telemetry-*.json")
+	if err != nil {
+		return fmt.Errorf("create temp telemetry state: %w", err)
+	}
+	defer os.Remove(tmp.Name()) // no-op after a successful rename
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return fmt.Errorf("chmod temp telemetry state: %w", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write telemetry state: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return fmt.Errorf("sync telemetry state: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp telemetry state: %w", err)
+	}
+	if err := os.Rename(tmp.Name(), StatePath(dir)); err != nil {
+		return fmt.Errorf("replace telemetry state %s: %w", StatePath(dir), err)
+	}
+	return nil
+}
+
+// SetEnabled records an explicit operator decision. Backs `bintrail telemetry
+// on|off`.
+func SetEnabled(dir string, enabled bool) error {
+	s := loadState(dir)
+	s.Enabled = &enabled
+	s.NoticeShown = true // an explicit choice makes the first-run notice moot
+	s.DecidedAt = time.Now().UTC().Format(time.RFC3339)
+	return saveState(dir, s)
+}
+
+// parseOnOff accepts the spellings an operator is likely to type. Returns
+// ok=false for anything else, so a typo falls through to the next control
+// rather than silently meaning "off".
+func parseOnOff(v string) (enabled, ok bool) {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "on", "1", "true", "yes", "enabled":
+		return true, true
+	case "off", "0", "false", "no", "disabled":
+		return false, true
+	}
+	return false, false
+}
+
+// Resolve determines the telemetry state. Highest control wins:
+//
+//  1. DO_NOT_TRACK  — hard off, checked before any file I/O
+//  2. flagValue     — --telemetry=on|off / --no-telemetry
+//  3. BINTRAIL_TELEMETRY
+//  4. the consent file
+//  5. default: ON
+//
+// dir may be "" when no home directory is available; the file step is then
+// skipped and the default applies.
+func Resolve(flagValue, dir string) Decision {
+	if v := os.Getenv("DO_NOT_TRACK"); v != "" && v != "0" && !strings.EqualFold(v, "false") {
+		return Decision{Enabled: false, Source: SourceDoNotTrack}
+	}
+	if enabled, ok := parseOnOff(flagValue); ok {
+		return Decision{Enabled: enabled, Source: SourceFlag}
+	}
+	if enabled, ok := parseOnOff(os.Getenv(EnvVar)); ok {
+		return Decision{Enabled: enabled, Source: SourceEnv}
+	}
+	if dir != "" {
+		if s := loadState(dir); s.Enabled != nil {
+			return Decision{Enabled: *s.Enabled, Source: SourceConfig}
+		}
+	}
+	return Decision{Enabled: true, Source: SourceDefault}
+}
+
+// Notice is the first-run disclosure. It states plainly that telemetry is on
+// and how to turn it off, and is shown before this machine has delivered
+// anything: a command only appends to the local spool, and delivery happens on
+// a LATER run, so an operator who reads this and runs `telemetry off` has sent
+// nothing.
+const Notice = `bintrail sends metadata-only usage stats — command names, version,
+OS/arch, and success/error class. No identifier is stored or sent, and
+NEVER your data, schemas, tables, DSNs, hostnames, IPs, or file paths.
+
+Telemetry is currently ON.
+  bintrail telemetry off     turn it off
+  bintrail telemetry show    see exactly what is sent (sends nothing)
+  DO_NOT_TRACK=1             disable telemetry entirely
+
+Details: https://github.com/dbtrail/dbtrail/blob/main/TELEMETRY.md
+`

--- a/internal/telemetry/consent.go
+++ b/internal/telemetry/consent.go
@@ -160,7 +160,7 @@ func parseOnOff(v string) (enabled, ok bool) {
 // Resolve determines the telemetry state. Highest control wins:
 //
 //  1. DO_NOT_TRACK  — hard off, checked before any file I/O
-//  2. flagValue     — --telemetry=on|off / --no-telemetry
+//  2. flagValue     — --telemetry=on|off
 //  3. BINTRAIL_TELEMETRY
 //  4. the consent file
 //  5. default: ON

--- a/internal/telemetry/debug.go
+++ b/internal/telemetry/debug.go
@@ -1,0 +1,25 @@
+package telemetry
+
+import (
+	"fmt"
+	"os"
+)
+
+// DebugEnvVar turns on a diagnostic trace to stderr.
+//
+// Telemetry swallows every error by design — it must never change a command's
+// behaviour, output, or exit code. The cost is that a subsystem which is on by
+// default can be silently inert for a bad reason (unwritable spool, a
+// permanently failing endpoint, a claim nobody can clean up) with no signal to
+// the operator or to us. This flag is that signal, opt-in and off by default so
+// the contract still holds for everyone who does not ask for it.
+const DebugEnvVar = "BINTRAIL_TELEMETRY_DEBUG"
+
+// debugf writes one diagnostic line when DebugEnvVar is set. Deliberately the
+// ONLY place telemetry may write to stderr outside the first-run notice.
+func debugf(format string, args ...any) {
+	if v := os.Getenv(DebugEnvVar); v == "" || v == "0" {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "telemetry: "+format+"\n", args...)
+}

--- a/internal/telemetry/errclass.go
+++ b/internal/telemetry/errclass.go
@@ -1,0 +1,116 @@
+package telemetry
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"net"
+
+	"github.com/go-sql-driver/mysql"
+)
+
+// Error classes. This is the complete taxonomy — ClassifyError never returns
+// anything else, and in particular never returns err.Error(): bintrail error
+// strings routinely carry DSNs, hostnames, schema and table names, and file
+// paths.
+const (
+	ClassDBConnection   = "db_connection"
+	ClassDBPermission   = "db_permission"
+	ClassBinlogParse    = "binlog_parse"
+	ClassBinlogNotFound = "binlog_not_found"
+	ClassSchemaMismatch = "schema_mismatch"
+	ClassConfigInvalid  = "config_invalid"
+	ClassFlagInvalid    = "flag_invalid"
+	ClassStorageIO      = "storage_io"
+	ClassNetwork        = "network"
+	ClassNotFound       = "not_found"
+	ClassInternal       = "internal"
+	ClassUnknown        = "unknown"
+)
+
+// classes is the set ClassifyError and SetError may emit. Anything outside it
+// is coerced to ClassUnknown rather than trusted onto the wire.
+var classes = map[string]bool{
+	ClassDBConnection:   true,
+	ClassDBPermission:   true,
+	ClassBinlogParse:    true,
+	ClassBinlogNotFound: true,
+	ClassSchemaMismatch: true,
+	ClassConfigInvalid:  true,
+	ClassFlagInvalid:    true,
+	ClassStorageIO:      true,
+	ClassNetwork:        true,
+	ClassNotFound:       true,
+	ClassInternal:       true,
+	ClassUnknown:        true,
+}
+
+// MySQL server error numbers worth distinguishing. Only the number is read —
+// MySQLError.Message can contain schema, table and user names.
+const (
+	erDBAccessDenied     = 1044
+	erAccessDenied       = 1045
+	erTableAccessDenied  = 1142
+	erColumnAccessDenied = 1143
+	erSpecificAccess     = 1227
+	erBadDB              = 1049
+	erNoSuchTable        = 1146
+)
+
+// ClassifyError maps an error to a bounded class using structural checks
+// (errors.Is/errors.As) only — never string matching, which would couple the
+// taxonomy to message wording and tempt someone into shipping the message.
+//
+// Deliberately conservative: callers that know more about the failure should
+// pass a precise class to Span.SetError instead of relying on this. An honest
+// "unknown" beats a confidently wrong bucket.
+func ClassifyError(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	var myErr *mysql.MySQLError
+	if errors.As(err, &myErr) {
+		switch myErr.Number {
+		case erAccessDenied, erDBAccessDenied, erTableAccessDenied, erColumnAccessDenied, erSpecificAccess:
+			return ClassDBPermission
+		case erBadDB, erNoSuchTable:
+			return ClassNotFound
+		}
+		// The server answered, so this is not a connectivity problem, but the
+		// specific failure is not one we have a bucket for.
+		return ClassUnknown
+	}
+
+	// A driver-level failure (bad host, refused, TLS) surfaces as a net error
+	// wrapped by the driver rather than a MySQLError.
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return ClassDBConnection
+	}
+	if errors.Is(err, mysql.ErrInvalidConn) || errors.Is(err, context.DeadlineExceeded) {
+		return ClassDBConnection
+	}
+
+	if errors.Is(err, fs.ErrNotExist) {
+		return ClassNotFound
+	}
+	if errors.Is(err, fs.ErrPermission) {
+		return ClassStorageIO
+	}
+	var pathErr *fs.PathError
+	if errors.As(err, &pathErr) {
+		return ClassStorageIO
+	}
+
+	return ClassUnknown
+}
+
+// normalizeClass coerces an arbitrary caller-supplied class to the taxonomy,
+// so a typo or a future refactor cannot smuggle free text onto the wire.
+func normalizeClass(class string) string {
+	if classes[class] {
+		return class
+	}
+	return ClassUnknown
+}

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -13,9 +13,13 @@
 //     survives a careless future contributor, which a field allowlist alone
 //     does not (an allowlist is blind to where a value came from).
 //
-// No identifier is ever written to disk. RunID is per-process and in-memory,
-// exists only so the ingestion side can dedup a re-sent spool file, and is
-// absent from daemon beacons entirely.
+// There is no PERSISTENT identifier: nothing that survives the process or
+// identifies the install is created, and the only file telemetry writes
+// outside the spool is the consent record, which carries no id. RunID is
+// generated per process, lives in the spooled event until that batch is
+// delivered or aged out (so ingestion can dedup a re-sent file), and never
+// appears in a daemon beacon — a months-lived process's run_id would be
+// exactly the longitudinal key this design refuses to produce.
 package telemetry
 
 import (

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -1,0 +1,143 @@
+// Package telemetry implements bintrail's usage telemetry: a metadata-only,
+// spool-based reporter for command mix and error classes.
+//
+// Two invariants make the privacy claims verifiable from source rather than
+// from documentation:
+//
+//   - The wire payload is a closed allowlist (Event below, AllowedFields).
+//     Nothing reaches the network that is not one of those keys.
+//   - This package must not import internal/config, internal/parser,
+//     internal/indexer, internal/query, internal/recovery, internal/byos or
+//     any server-identity package. A package that cannot reach them cannot
+//     read a DSN, a row, or a server UUID — a structural guarantee that
+//     survives a careless future contributor, which a field allowlist alone
+//     does not (an allowlist is blind to where a value came from).
+//
+// No identifier is ever written to disk. RunID is per-process and in-memory,
+// exists only so the ingestion side can dedup a re-sent spool file, and is
+// absent from daemon beacons entirely.
+package telemetry
+
+import (
+	"regexp"
+	"strings"
+	"time"
+)
+
+// SchemaVersion is bumped when a field is added; the ingestion side keys off
+// it. Additive evolution only — removing a field is a breaking change for
+// existing aggregates.
+const SchemaVersion = 1
+
+// Event types.
+const (
+	EventCommandRun   = "command_run"
+	EventCommandError = "command_error"
+	EventDaemonBeacon = "daemon_beacon"
+)
+
+// Outcomes.
+const (
+	OutcomeOK    = "ok"
+	OutcomeError = "error"
+)
+
+// Event is the ENTIRE wire payload. Adding a field here without adding it to
+// AllowedFields fails the allowlist test; adding it to both is a deliberate
+// act that must also update TELEMETRY.md.
+//
+// Never add: DSNs, hostnames, IPs, schema/table/column names, PK values, row
+// data, query text, file paths, server ids or UUIDs, GTIDs, binlog names or
+// positions, flag values, positional args, verbatim error or panic strings,
+// row counts, or credentials.
+type Event struct {
+	SchemaVersion  int    `json:"schema_version"`
+	EventType      string `json:"event_type"`
+	Command        string `json:"command"`
+	Outcome        string `json:"outcome"`
+	ErrorClass     string `json:"error_class,omitempty"`
+	DurationBucket string `json:"duration_bucket,omitempty"`
+	Version        string `json:"version"`
+	IsRelease      bool   `json:"is_release"`
+	OS             string `json:"os"`
+	Arch           string `json:"arch"`
+	IsCI           bool   `json:"is_ci"`
+	IsInteractive  bool   `json:"is_interactive"`
+	RunID          string `json:"run_id,omitempty"`
+}
+
+// AllowedFields is the complete set of JSON keys that may appear on the wire,
+// in struct order. The allowlist test reflects over Event and fails on any
+// mismatch in either direction.
+var AllowedFields = []string{
+	"schema_version",
+	"event_type",
+	"command",
+	"outcome",
+	"error_class",
+	"duration_bucket",
+	"version",
+	"is_release",
+	"os",
+	"arch",
+	"is_ci",
+	"is_interactive",
+	"run_id",
+}
+
+// durationBucket coarsens a command's wall time. The tail collapses at >10m
+// rather than reporting real durations: a precise runtime on a long-running
+// index or reconstruct is a proxy for the operator's data volume.
+func durationBucket(d time.Duration) string {
+	switch {
+	case d < 100*time.Millisecond:
+		return "<100ms"
+	case d < time.Second:
+		return "100ms-1s"
+	case d < 10*time.Second:
+		return "1s-10s"
+	case d < time.Minute:
+		return "10s-1m"
+	case d < 10*time.Minute:
+		return "1m-10m"
+	default:
+		return ">10m"
+	}
+}
+
+// releaseVersionRE matches the versions GoReleaser injects. Anything else is a
+// source build.
+var releaseVersionRE = regexp.MustCompile(`^v?(\d+)\.(\d+)\.\d+$`)
+
+// minorVersion truncates a release version to major.minor. Patch-level
+// adoption is answerable from release download counts, and the full triple was
+// a quasi-identifier: joined with os/arch/command-mix it singles out installs
+// at low-hundreds scale.
+//
+// Anything that is not a release version reports "unknown" rather than passing
+// an arbitrary -ldflags string through — a custom or dev version string can be
+// near-unique on its own. IsRelease already carries the source-build signal.
+func minorVersion(v string) string {
+	m := releaseVersionRE.FindStringSubmatch(strings.TrimSpace(v))
+	if m == nil {
+		return "unknown"
+	}
+	return m[1] + "." + m[2]
+}
+
+// isReleaseVersion reports whether v looks like an official build.
+func isReleaseVersion(v string) bool {
+	return releaseVersionRE.MatchString(strings.TrimSpace(v))
+}
+
+// coarseArch collapses GOARCH to the three buckets that inform platform
+// priorities. Exotic architectures are rare enough that reporting them
+// verbatim would single their operators out.
+func coarseArch(a string) string {
+	switch a {
+	case "amd64", "arm64":
+		return a
+	default:
+		return "other"
+	}
+}

--- a/internal/telemetry/send.go
+++ b/internal/telemetry/send.go
@@ -1,0 +1,36 @@
+package telemetry
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// postNDJSON delivers a spooled batch.
+//
+// This client is deliberately minimal and deliberately NOT internal/byos's
+// MetadataClient: that one attaches `Authorization: Bearer <apiKey>` and posts
+// to the authenticated data plane. An account-linked credential on the
+// telemetry wire would make the metadata-only claim false and would let usage
+// data be joined to a customer.
+//
+// No Authorization header, no cookie, no account identifier — ever. The
+// no-credential CI test asserts exactly that against this function.
+func postNDJSON(ctx context.Context, client *http.Client, endpoint string, body []byte) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("build telemetry request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-ndjson")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("send telemetry: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("telemetry endpoint returned %s", resp.Status)
+	}
+	return nil
+}

--- a/internal/telemetry/spool.go
+++ b/internal/telemetry/spool.go
@@ -28,9 +28,13 @@ const (
 	// claimReclaimAfter is how long a claim may sit before another run adopts
 	// it. It exists for a drainer that died mid-flight — which is the COMMON
 	// case, not an exotic one: a sub-100ms command's process exits while its
-	// detached drain goroutine is still in its HTTP call. Comfortably longer
-	// than drainDeadline, so it can never steal from a drainer still working.
-	claimReclaimAfter = 5 * time.Minute
+	// detached drain goroutine is still in its HTTP call.
+	//
+	// It must exceed drainDeadline so it can never steal from a drainer that is
+	// genuinely still working; 30x that leaves ample margin while keeping
+	// recovery quick enough that an abandoned batch is not stranded for an
+	// afternoon.
+	claimReclaimAfter = time.Minute
 )
 
 // SpoolDir returns the spool directory inside dir.

--- a/internal/telemetry/spool.go
+++ b/internal/telemetry/spool.go
@@ -2,9 +2,12 @@ package telemetry
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -22,17 +25,32 @@ const (
 	// maxSpoolAge bounds how long an undelivered event lingers on disk.
 	maxSpoolAge = 7 * 24 * time.Hour
 
-	// claimReclaimAfter is how long a claimed file may sit untouched before a
-	// later run adopts it. It only ever fires for a drainer that died
-	// mid-flight — which is the COMMON case, not an exotic one: a sub-100ms
-	// command's process exits while its detached drain goroutine is still in
-	// its HTTP call. Comfortably longer than drainDeadline, so it can never
-	// steal a file from a drainer that is genuinely still working.
+	// claimReclaimAfter is how long a claim may sit before another run adopts
+	// it. It exists for a drainer that died mid-flight — which is the COMMON
+	// case, not an exotic one: a sub-100ms command's process exits while its
+	// detached drain goroutine is still in its HTTP call. Comfortably longer
+	// than drainDeadline, so it can never steal from a drainer still working.
 	claimReclaimAfter = 5 * time.Minute
 )
 
 // SpoolDir returns the spool directory inside dir.
 func SpoolDir(dir string) string { return filepath.Join(dir, spoolDirName) }
+
+// PurgeSpool removes every locally spooled event.
+//
+// Needed because drain runs ONLY while telemetry is enabled: without this, an
+// operator who runs `telemetry off` would leave whatever was spooled before
+// their decision sitting on disk indefinitely — never sent, never aged out —
+// belonging to precisely the person who asked for none.
+func PurgeSpool(dir string) error {
+	if dir == "" {
+		return nil
+	}
+	if err := os.RemoveAll(SpoolDir(dir)); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("remove telemetry spool: %w", err)
+	}
+	return nil
+}
 
 // appendEvent writes one NDJSON line. Plain O_APPEND with no fsync: this runs
 // at the end of every command, and an fsync per invocation is exactly the kind
@@ -52,7 +70,8 @@ func appendEvent(spoolDir string, e Event, now time.Time) error {
 	path := filepath.Join(spoolDir, now.UTC().Format("2006-01-02")+spoolSuffix)
 
 	if fi, err := os.Stat(path); err == nil && fi.Size() >= maxSpoolFileBytes {
-		return nil // over cap: drop rather than grow
+		debugf("spool file at cap, dropping event")
+		return nil
 	}
 	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {
@@ -65,14 +84,52 @@ func appendEvent(spoolDir string, e Event, now time.Time) error {
 	return nil
 }
 
-// drain delivers every spooled file and removes it, whether or not the send
-// succeeded.
+// claimName builds a claim path for base, stamped with this process and
+// instant so the name itself records when the claim was taken.
+func claimName(spoolDir, base string, now time.Time) string {
+	return filepath.Join(spoolDir, base+claimedMark+strconv.Itoa(os.Getpid())+"-"+strconv.FormatInt(now.UnixNano(), 10))
+}
+
+// unclaimedBase strips any claim suffix, so re-claiming a file does not append
+// suffix after suffix.
+func unclaimedBase(name string) string {
+	if i := strings.Index(name, claimedMark); i >= 0 {
+		return name[:i]
+	}
+	return name
+}
+
+// claimStamp recovers when a claim was taken, from the claim's own name.
 //
-// Concurrency is handled by claim-by-rename: the drainer atomically renames a
-// spool file to a unique name and works on that immutable snapshot. Two
-// drainers racing (a cron run and a human run sharing $HOME) cannot both claim
-// the same file, so no event is sent twice and none is lost to a
-// read-then-truncate window. No lock is held across network I/O.
+// The claim time canNOT be read from the file's mtime: os.Rename preserves it,
+// so a freshly claimed file still carries the time of its last APPEND. For any
+// prior-day spool file — the normal drain target — that is hours or days ago,
+// which would mark a just-created claim as abandoned instantly and let a second
+// drainer adopt and re-send a batch that is still in flight.
+func claimStamp(name string) (time.Time, bool) {
+	i := strings.LastIndex(name, claimedMark)
+	if i < 0 {
+		return time.Time{}, false
+	}
+	suffix := name[i+len(claimedMark):]
+	j := strings.LastIndex(suffix, "-")
+	if j < 0 {
+		return time.Time{}, false
+	}
+	nanos, err := strconv.ParseInt(suffix[j+1:], 10, 64)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return time.Unix(0, nanos), true
+}
+
+// drain delivers every spooled batch and removes it.
+//
+// Exclusion is by claim-by-rename: a drainer atomically renames a file to a
+// unique claim and works on that immutable snapshot. rename(2) fails once the
+// source is gone, so of two racing drainers exactly one wins — including when
+// the file being claimed is itself an abandoned claim being adopted, which is
+// why adoption re-renames rather than working in place.
 //
 // Delivery failures drop the batch rather than retrying: an offline box must
 // not accumulate a backlog it will one day flush all at once, and losing
@@ -88,33 +145,36 @@ func drain(spoolDir string, now time.Time, send func([]byte) error) {
 		}
 		name := entry.Name()
 		path := filepath.Join(spoolDir, name)
+		isClaim := strings.Contains(name, claimedMark)
+		if !isClaim && !strings.HasSuffix(name, spoolSuffix) {
+			continue
+		}
 		info, err := entry.Info()
 		if err != nil {
 			continue
 		}
-		if now.Sub(info.ModTime()) > maxSpoolAge {
+
+		// Age a claim from when it was claimed and a spool file from its last
+		// append. A claim whose name predates this scheme falls back to mtime,
+		// which only delays its expiry.
+		stamp, haveStamp := claimStamp(name)
+		age := now.Sub(info.ModTime())
+		if isClaim && haveStamp {
+			age = now.Sub(stamp)
+		}
+		if age > maxSpoolAge {
+			debugf("dropping spool file older than %s: %s", maxSpoolAge, name)
 			os.Remove(path)
 			continue
 		}
-
-		var claimed string
-		switch {
-		case strings.Contains(name, claimedMark):
-			// Left behind by a drainer that died mid-flight. Adopt it once it is
-			// old enough that no live drainer could still be working on it.
-			if now.Sub(info.ModTime()) < claimReclaimAfter {
-				continue
-			}
-			claimed = path
-		case strings.HasSuffix(name, spoolSuffix):
-			claimed = path + claimedMark + fmt.Sprintf("%d-%d", os.Getpid(), now.UnixNano())
-			if err := os.Rename(path, claimed); err != nil {
-				continue // another drainer claimed it first
-			}
-		default:
-			continue
+		if isClaim && (!haveStamp || now.Sub(stamp) < claimReclaimAfter) {
+			continue // a live drainer may still hold this
 		}
 
+		claimed := claimName(spoolDir, unclaimedBase(name), now)
+		if err := os.Rename(path, claimed); err != nil {
+			continue // another drainer claimed it first
+		}
 		data, readErr := os.ReadFile(claimed)
 		if readErr != nil || len(data) == 0 {
 			os.Remove(claimed)
@@ -126,9 +186,7 @@ func drain(spoolDir string, now time.Time, send func([]byte) error) {
 		// events vanishing into a delete that already happened.
 		os.Remove(claimed)
 		if sendErr != nil {
-			// Drop-on-fail by design — no retry queue, so an offline box never
-			// builds a backlog it flushes all at once. Stop here rather than
-			// hammering an endpoint that just refused us.
+			debugf("send failed, dropping batch and stopping: %v", sendErr)
 			return
 		}
 	}

--- a/internal/telemetry/spool.go
+++ b/internal/telemetry/spool.go
@@ -1,0 +1,135 @@
+package telemetry
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	spoolDirName = "telemetry-spool"
+	spoolSuffix  = ".ndjson"
+	claimedMark  = ".claimed-"
+
+	// maxSpoolFileBytes caps a single day's spool. A box that never reaches the
+	// network must not grow unbounded; past the cap events are dropped, which is
+	// the correct tradeoff for aggregate usage data.
+	maxSpoolFileBytes = 5 << 20 // 5 MiB
+
+	// maxSpoolAge bounds how long an undelivered event lingers on disk.
+	maxSpoolAge = 7 * 24 * time.Hour
+
+	// claimReclaimAfter is how long a claimed file may sit untouched before a
+	// later run adopts it. It only ever fires for a drainer that died
+	// mid-flight — which is the COMMON case, not an exotic one: a sub-100ms
+	// command's process exits while its detached drain goroutine is still in
+	// its HTTP call. Comfortably longer than drainDeadline, so it can never
+	// steal a file from a drainer that is genuinely still working.
+	claimReclaimAfter = 5 * time.Minute
+)
+
+// SpoolDir returns the spool directory inside dir.
+func SpoolDir(dir string) string { return filepath.Join(dir, spoolDirName) }
+
+// appendEvent writes one NDJSON line. Plain O_APPEND with no fsync: this runs
+// at the end of every command, and an fsync per invocation is exactly the kind
+// of hot-path tax telemetry must never impose. A single write of a short line
+// is atomic enough that concurrent appenders interleave whole lines rather
+// than corrupting each other.
+//
+// There is deliberately NO network call on this path, ever.
+func appendEvent(spoolDir string, e Event, now time.Time) error {
+	line, err := json.Marshal(e)
+	if err != nil {
+		return fmt.Errorf("marshal telemetry event: %w", err)
+	}
+	if err := os.MkdirAll(spoolDir, 0o700); err != nil {
+		return fmt.Errorf("create spool directory: %w", err)
+	}
+	path := filepath.Join(spoolDir, now.UTC().Format("2006-01-02")+spoolSuffix)
+
+	if fi, err := os.Stat(path); err == nil && fi.Size() >= maxSpoolFileBytes {
+		return nil // over cap: drop rather than grow
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("open spool file: %w", err)
+	}
+	defer f.Close()
+	if _, err := f.Write(append(line, '\n')); err != nil {
+		return fmt.Errorf("append telemetry event: %w", err)
+	}
+	return nil
+}
+
+// drain delivers every spooled file and removes it, whether or not the send
+// succeeded.
+//
+// Concurrency is handled by claim-by-rename: the drainer atomically renames a
+// spool file to a unique name and works on that immutable snapshot. Two
+// drainers racing (a cron run and a human run sharing $HOME) cannot both claim
+// the same file, so no event is sent twice and none is lost to a
+// read-then-truncate window. No lock is held across network I/O.
+//
+// Delivery failures drop the batch rather than retrying: an offline box must
+// not accumulate a backlog it will one day flush all at once, and losing
+// aggregate usage counts costs nothing worth a retry queue.
+func drain(spoolDir string, now time.Time, send func([]byte) error) {
+	entries, err := os.ReadDir(spoolDir)
+	if err != nil {
+		return // no spool yet, or unreadable — nothing to do, never an error
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		path := filepath.Join(spoolDir, name)
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		if now.Sub(info.ModTime()) > maxSpoolAge {
+			os.Remove(path)
+			continue
+		}
+
+		var claimed string
+		switch {
+		case strings.Contains(name, claimedMark):
+			// Left behind by a drainer that died mid-flight. Adopt it once it is
+			// old enough that no live drainer could still be working on it.
+			if now.Sub(info.ModTime()) < claimReclaimAfter {
+				continue
+			}
+			claimed = path
+		case strings.HasSuffix(name, spoolSuffix):
+			claimed = path + claimedMark + fmt.Sprintf("%d-%d", os.Getpid(), now.UnixNano())
+			if err := os.Rename(path, claimed); err != nil {
+				continue // another drainer claimed it first
+			}
+		default:
+			continue
+		}
+
+		data, readErr := os.ReadFile(claimed)
+		if readErr != nil || len(data) == 0 {
+			os.Remove(claimed)
+			continue
+		}
+		sendErr := send(data)
+		// Removed only AFTER the send attempt: if this process exits mid-send
+		// the file survives as a claim and a later run adopts it, instead of the
+		// events vanishing into a delete that already happened.
+		os.Remove(claimed)
+		if sendErr != nil {
+			// Drop-on-fail by design — no retry queue, so an offline box never
+			// builds a backlog it flushes all at once. Stop here rather than
+			// hammering an endpoint that just refused us.
+			return
+		}
+	}
+}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -99,6 +99,7 @@ func Init(cfg Config) (c *Client) {
 	c = &Client{decision: Decision{Enabled: false, Source: SourceDefault}}
 	defer func() {
 		if r := recover(); r != nil {
+			debugf("init panicked, telemetry disabled for this run")
 			c = &Client{decision: Decision{Enabled: false, Source: SourceDefault}}
 		}
 	}()
@@ -178,7 +179,10 @@ func (c *Client) maybeShowNotice(w io.Writer) {
 		return
 	}
 	s.NoticeShown = true
-	_ = saveState(c.dir, s)
+	if err := saveState(c.dir, s); err != nil {
+		// Harmless direction to fail in: the notice simply shows again.
+		debugf("could not record that the notice was shown: %v", err)
+	}
 }
 
 // drainAsync delivers previously spooled events. It runs detached from the
@@ -188,7 +192,14 @@ func (c *Client) maybeShowNotice(w io.Writer) {
 // NEXT invocation — the same model the Go toolchain uses, and the price of
 // keeping the network entirely off the request path.
 func (c *Client) drainAsync() {
-	defer func() { _ = recover() }()
+	// Required, not decorative: an unhandled panic in a detached goroutine
+	// takes the whole process down, which is the one thing telemetry must
+	// never do to a command.
+	defer func() {
+		if r := recover(); r != nil {
+			debugf("drain panicked")
+		}
+	}()
 	ctx, cancel := context.WithTimeout(context.Background(), drainDeadline)
 	defer cancel()
 	drain(c.spoolDir, c.now(), func(body []byte) error {
@@ -284,7 +295,9 @@ func (s *Span) Finish() {
 	} else {
 		e.EventType, e.Outcome, e.ErrorClass = EventCommandError, OutcomeError, s.class
 	}
-	_ = appendEvent(s.c.spoolDir, e, s.c.now())
+	if err := appendEvent(s.c.spoolDir, e, s.c.now()); err != nil {
+		debugf("could not spool command event: %v", err)
+	}
 }
 
 // Beacon records that a long-running daemon is alive, at most once per UTC
@@ -318,7 +331,9 @@ func (c *Client) Beacon(daemon string) {
 	e.EventType = EventDaemonBeacon
 	e.Command = sanitizeCommand(daemon)
 	e.Outcome = OutcomeOK
-	_ = appendEvent(c.spoolDir, e, now)
+	if err := appendEvent(c.spoolDir, e, now); err != nil {
+		debugf("could not spool beacon: %v", err)
+	}
 }
 
 func sameUTCDay(a, b time.Time) bool {

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -1,0 +1,355 @@
+package telemetry
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"golang.org/x/term"
+)
+
+// endpoint is the ingestion URL, injected at build time:
+//
+//	-ldflags "-X github.com/dbtrail/dbtrail/internal/telemetry.endpoint=https://telemetry.dbtrail.io/v1/events"
+//
+// It is EMPTY by default, which makes telemetry inert by construction: a
+// plain `go build`, `go test`, or a distribution packager's build produces a
+// binary with no endpoint to send to and therefore no network path at all.
+// Only official release builds set it. This is the one-line assertion a distro
+// packager or a skeptical reviewer can check, and it is why the test suite —
+// including the E2E test that builds and runs the real binary — can never
+// emit telemetry.
+var endpoint string
+
+// buildVersion is the binary's version, set once at startup by each binary's
+// Main. Startup-only contract, like the ext package's setters: not safe for
+// concurrent use with command execution.
+var buildVersion = "dev"
+
+// SetVersion records the -ldflags version for telemetry. Call once from Main
+// before executing commands.
+func SetVersion(v string) {
+	if v != "" {
+		buildVersion = v
+	}
+}
+
+// Endpoint reports the compiled-in ingestion URL ("" when this build cannot
+// send). Exposed so `bintrail telemetry status` can tell an operator whether
+// the binary is even capable of reporting.
+func Endpoint() string { return endpoint }
+
+// drainDeadline bounds the startup drain. It runs concurrently with the
+// command body and never blocks it; if the endpoint is slow or unreachable
+// the attempt is abandoned and the events wait for a later run.
+const drainDeadline = 2 * time.Second
+
+// Config parameterises Init. Every field has a sane zero value; tests override
+// the endpoint, directory, clock and TTY detection.
+type Config struct {
+	// Flag is the resolved --telemetry value ("on", "off" or "" for unset).
+	Flag string
+	// Version overrides the package-level build version.
+	Version string
+	// Dir overrides the config directory (default ~/.config/bintrail).
+	Dir string
+	// Endpoint overrides the build-time endpoint. Tests only — production
+	// builds must go through -ldflags so an inert build stays provably inert.
+	Endpoint string
+	// Stderr receives the first-run notice (default os.Stderr).
+	Stderr io.Writer
+	// Interactive overrides TTY detection.
+	Interactive *bool
+	// Now overrides the clock.
+	Now func() time.Time
+}
+
+// Client records usage events. The zero value and a nil *Client are both safe
+// and inert, so callers never need a nil check.
+type Client struct {
+	enabled     bool
+	decision    Decision
+	isCI        bool
+	dir         string
+	spoolDir    string
+	endpoint    string
+	version     string
+	interactive bool
+	runID       string
+	now         func() time.Time
+	http        *http.Client
+
+	mu         sync.Mutex
+	lastBeacon time.Time
+}
+
+// Init resolves consent, shows the first-run notice when warranted, and kicks
+// off an asynchronous drain of events spooled by earlier runs.
+//
+// It never fails and never blocks: any panic below is swallowed and yields an
+// inert client. Telemetry must not be able to change a command's behaviour,
+// output, or exit code — that is worth more than any event it might record.
+func Init(cfg Config) (c *Client) {
+	c = &Client{decision: Decision{Enabled: false, Source: SourceDefault}}
+	defer func() {
+		if r := recover(); r != nil {
+			c = &Client{decision: Decision{Enabled: false, Source: SourceDefault}}
+		}
+	}()
+
+	now := cfg.Now
+	if now == nil {
+		now = time.Now
+	}
+	version := cfg.Version
+	if version == "" {
+		version = buildVersion
+	}
+	ep := cfg.Endpoint
+	if ep == "" {
+		ep = endpoint
+	}
+	dir := cfg.Dir
+	if dir == "" {
+		// No home directory (distroless, systemd DynamicUser, scrubbed env):
+		// disable everything silently rather than warning about a subsystem the
+		// operator did not ask about.
+		if d, err := ConfigDir(); err == nil {
+			dir = d
+		}
+	}
+	stderr := cfg.Stderr
+	if stderr == nil {
+		stderr = os.Stderr
+	}
+	interactive := isInteractive(stderr)
+	if cfg.Interactive != nil {
+		interactive = *cfg.Interactive
+	}
+
+	decision := Resolve(cfg.Flag, dir)
+	isCI := IsCI()
+
+	c = &Client{
+		// A CI run is nobody deciding anything, and an empty endpoint or missing
+		// config dir means there is nowhere to send or spool. All three suppress
+		// only — they can never turn telemetry ON.
+		enabled:     decision.Enabled && !isCI && ep != "" && dir != "",
+		decision:    decision,
+		isCI:        isCI,
+		dir:         dir,
+		spoolDir:    SpoolDir(dir),
+		endpoint:    ep,
+		version:     version,
+		interactive: interactive,
+		runID:       uuid.NewString(),
+		now:         now,
+		http:        &http.Client{Timeout: drainDeadline},
+	}
+
+	if !c.enabled {
+		return c
+	}
+	c.maybeShowNotice(stderr)
+	go c.drainAsync()
+	return c
+}
+
+// maybeShowNotice prints the first-run disclosure once, on an interactive
+// terminal, and only while telemetry is running on the DEFAULT — an operator
+// who has already chosen has nothing to be told. The sentinel is recorded
+// best-effort: if it cannot be persisted the notice simply shows again, which
+// is the harmless direction to fail in.
+func (c *Client) maybeShowNotice(w io.Writer) {
+	if !c.interactive || c.decision.Source != SourceDefault {
+		return
+	}
+	s := loadState(c.dir)
+	if s.NoticeShown {
+		return
+	}
+	if _, err := io.WriteString(w, "\n"+Notice+"\n"); err != nil {
+		return
+	}
+	s.NoticeShown = true
+	_ = saveState(c.dir, s)
+}
+
+// drainAsync delivers previously spooled events. It runs detached from the
+// command body and is bounded by drainDeadline; if the process exits first,
+// the in-flight file is picked up by a later run (see drain's claim
+// reclamation). Sub-100ms commands therefore deliver their own events on the
+// NEXT invocation — the same model the Go toolchain uses, and the price of
+// keeping the network entirely off the request path.
+func (c *Client) drainAsync() {
+	defer func() { _ = recover() }()
+	ctx, cancel := context.WithTimeout(context.Background(), drainDeadline)
+	defer cancel()
+	drain(c.spoolDir, c.now(), func(body []byte) error {
+		return postNDJSON(ctx, c.http, c.endpoint, body)
+	})
+}
+
+// Enabled reports whether this client will record anything.
+func (c *Client) Enabled() bool { return c != nil && c.enabled }
+
+// Decision reports the resolved consent state and what decided it.
+func (c *Client) Decision() Decision {
+	if c == nil {
+		return Decision{Enabled: false, Source: SourceDefault}
+	}
+	return c.decision
+}
+
+// baseEvent fills the fields common to every event type.
+func (c *Client) baseEvent() Event {
+	return Event{
+		SchemaVersion: SchemaVersion,
+		Version:       minorVersion(c.version),
+		IsRelease:     isReleaseVersion(c.version),
+		OS:            runtime.GOOS,
+		Arch:          coarseArch(runtime.GOARCH),
+		IsCI:          c.isCI,
+		IsInteractive: c.interactive,
+	}
+}
+
+// SampleEvent returns a representative event for `bintrail telemetry show`.
+// The host-derived fields (version, os, arch, ci, tty) carry this machine's
+// REAL values rather than placeholders, so an operator inspecting the payload
+// sees what their box would actually transmit — not a sanitised illustration.
+func SampleEvent() Event {
+	return Event{
+		SchemaVersion:  SchemaVersion,
+		EventType:      EventCommandRun,
+		Command:        "status",
+		Outcome:        OutcomeOK,
+		DurationBucket: "100ms-1s",
+		Version:        minorVersion(buildVersion),
+		IsRelease:      isReleaseVersion(buildVersion),
+		OS:             runtime.GOOS,
+		Arch:           coarseArch(runtime.GOARCH),
+		IsCI:           IsCI(),
+		IsInteractive:  isInteractive(os.Stderr),
+		RunID:          uuid.NewString(),
+	}
+}
+
+// Span measures one command invocation. A nil *Span is safe and inert.
+type Span struct {
+	c       *Client
+	command string
+	start   time.Time
+	class   string
+}
+
+// RecordCommand starts a span for a command. Returns nil when telemetry is
+// off; every Span method tolerates a nil receiver, so callers need no branch.
+func (c *Client) RecordCommand(command string) *Span {
+	if !c.Enabled() {
+		return nil
+	}
+	return &Span{c: c, command: sanitizeCommand(command), start: c.now()}
+}
+
+// SetError marks the span as failed with a bounded class. Anything outside the
+// taxonomy is coerced to "unknown" rather than trusted onto the wire.
+func (s *Span) SetError(class string) {
+	if s == nil {
+		return
+	}
+	s.class = normalizeClass(class)
+}
+
+// Finish records the span to the local spool. It NEVER touches the network —
+// that is what makes it safe to call on every command's exit path.
+func (s *Span) Finish() {
+	if s == nil || !s.c.Enabled() {
+		return
+	}
+	defer func() { _ = recover() }()
+
+	e := s.c.baseEvent()
+	e.Command = s.command
+	e.RunID = s.c.runID
+	e.DurationBucket = durationBucket(s.c.now().Sub(s.start))
+	if s.class == "" {
+		e.EventType, e.Outcome = EventCommandRun, OutcomeOK
+	} else {
+		e.EventType, e.Outcome, e.ErrorClass = EventCommandError, OutcomeError, s.class
+	}
+	_ = appendEvent(s.c.spoolDir, e, s.c.now())
+}
+
+// Beacon records that a long-running daemon is alive, at most once per UTC
+// day. The cadence is deliberately coarse: a finer beat would reconstruct a
+// daemon's uptime and maintenance windows.
+//
+// Beacons carry NO run_id. A months-lived process's run_id would be a
+// longitudinal key — exactly the persistent identifier this design refuses to
+// create.
+//
+// The original design had Beacon spawn its own goroutine so a POST could never
+// land on a daemon's event loop or heartbeat tick. The spool model makes that
+// unnecessary: this only appends a line to a local file, so it is safe to call
+// directly from a ticker.
+func (c *Client) Beacon(daemon string) {
+	if !c.Enabled() {
+		return
+	}
+	defer func() { _ = recover() }()
+
+	now := c.now().UTC()
+	c.mu.Lock()
+	if !c.lastBeacon.IsZero() && sameUTCDay(c.lastBeacon, now) {
+		c.mu.Unlock()
+		return
+	}
+	c.lastBeacon = now
+	c.mu.Unlock()
+
+	e := c.baseEvent()
+	e.EventType = EventDaemonBeacon
+	e.Command = sanitizeCommand(daemon)
+	e.Outcome = OutcomeOK
+	_ = appendEvent(c.spoolDir, e, now)
+}
+
+func sameUTCDay(a, b time.Time) bool {
+	ay, am, ad := a.UTC().Date()
+	by, bm, bd := b.UTC().Date()
+	return ay == by && am == bm && ad == bd
+}
+
+// sanitizeCommand bounds what can reach the `command` field. In practice the
+// value is a cobra command name — a compile-time constant — but constraining
+// it here means no future caller can turn this field into a channel for
+// arbitrary text, without anyone having to maintain a hand-written list of
+// every command bintrail will ever have.
+func sanitizeCommand(name string) string {
+	name = strings.TrimSpace(strings.ToLower(name))
+	if name == "" || len(name) > 32 {
+		return "other"
+	}
+	for _, r := range name {
+		if (r < 'a' || r > 'z') && (r < '0' || r > '9') && r != '-' {
+			return "other"
+		}
+	}
+	return name
+}
+
+// isInteractive reports whether w is a terminal.
+func isInteractive(w io.Writer) bool {
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	return term.IsTerminal(int(f.Fd()))
+}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -50,6 +50,16 @@ func Endpoint() string { return endpoint }
 // the attempt is abandoned and the events wait for a later run.
 const drainDeadline = 2 * time.Second
 
+// shutdownGrace bounds how long a caller waits at exit for an in-flight drain.
+//
+// Without such a wait telemetry effectively never delivers for short commands:
+// the process exits microseconds after the drain goroutine starts, killing it
+// mid-POST and leaving a claim that the next fast run cannot adopt either.
+//
+// The cost is bounded and usually zero — a drain over an empty spool returns
+// at once, so a caller with nothing pending waits not at all.
+const shutdownGrace = 250 * time.Millisecond
+
 // Config parameterises Init. Every field has a sane zero value; tests override
 // the endpoint, directory, clock and TTY detection.
 type Config struct {
@@ -84,6 +94,9 @@ type Client struct {
 	runID       string
 	now         func() time.Time
 	http        *http.Client
+
+	// drained closes when the startup drain finishes; Shutdown waits on it.
+	drained chan struct{}
 
 	mu         sync.Mutex
 	lastBeacon time.Time
@@ -158,8 +171,30 @@ func Init(cfg Config) (c *Client) {
 		return c
 	}
 	c.maybeShowNotice(stderr)
-	go c.drainAsync()
+	c.drained = make(chan struct{})
+	go func() {
+		defer close(c.drained)
+		c.drainAsync()
+	}()
 	return c
+}
+
+// Shutdown gives an in-flight drain a brief chance to finish. Callers run it on
+// their exit path; it is safe to call more than once, and on a nil or disabled
+// client.
+//
+// It waits at most shutdownGrace and never returns an error: a drain that does
+// not make it is abandoned, its claim is adopted by a later run, and the
+// caller's exit is unaffected either way.
+func (c *Client) Shutdown() {
+	if !c.Enabled() || c.drained == nil {
+		return
+	}
+	select {
+	case <-c.drained:
+	case <-time.After(shutdownGrace):
+		debugf("drain still running at exit; leaving it for a later run")
+	}
 }
 
 // maybeShowNotice prints the first-run disclosure once, on an interactive

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -1,0 +1,811 @@
+package telemetry
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-sql-driver/mysql"
+)
+
+// clearEnv neutralises every environment control so a test starts from a known
+// state. Without this the suite's own result would depend on whether it runs
+// on a laptop or in CI.
+func clearEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("DO_NOT_TRACK", "")
+	t.Setenv(EnvVar, "")
+	for _, v := range ciEnvVars {
+		t.Setenv(v, "")
+	}
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+// ── The wire contract ────────────────────────────────────────
+
+// TestAllowlistMatchesStruct is the field allowlist guarantee: a field added to
+// Event without being added to AllowedFields (or vice versa) fails here. It is
+// the reason a reviewer can read AllowedFields and know it is the whole story.
+func TestAllowlistMatchesStruct(t *testing.T) {
+	typ := reflect.TypeOf(Event{})
+	var got []string
+	for i := range typ.NumField() {
+		tag := typ.Field(i).Tag.Get("json")
+		if tag == "" || tag == "-" {
+			t.Fatalf("field %s has no json tag; every wire field must be explicit", typ.Field(i).Name)
+		}
+		got = append(got, strings.Split(tag, ",")[0])
+	}
+	if !reflect.DeepEqual(got, AllowedFields) {
+		t.Errorf("Event JSON keys and AllowedFields disagree:\n  struct:    %v\n  allowlist: %v", got, AllowedFields)
+	}
+}
+
+// TestMarshalledEventHasOnlyAllowedKeys checks the actual serialized bytes,
+// not just the struct definition — an embedded type or a custom marshaller
+// could add keys the reflection test above would miss.
+func TestMarshalledEventHasOnlyAllowedKeys(t *testing.T) {
+	clearEnv(t)
+	data, err := json.Marshal(SampleEvent())
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	allowed := make(map[string]bool, len(AllowedFields))
+	for _, f := range AllowedFields {
+		allowed[f] = true
+	}
+	for k := range m {
+		if !allowed[k] {
+			t.Errorf("serialized event carries key %q, which is not on the allowlist", k)
+		}
+	}
+}
+
+// TestRequestCarriesNoCredential is the no-credential guarantee. Telemetry
+// posting an Authorization header would make the metadata-only claim false and
+// would let usage data be joined to a customer account.
+func TestRequestCarriesNoCredential(t *testing.T) {
+	var got http.Header
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	if err := postNDJSON(context.Background(), srv.Client(), srv.URL, []byte("{}\n")); err != nil {
+		t.Fatalf("postNDJSON: %v", err)
+	}
+	for _, banned := range []string{"Authorization", "Cookie", "X-Api-Key", "X-Bintrail-Server-Uuid"} {
+		if v := got.Get(banned); v != "" {
+			t.Errorf("telemetry request carried %s: %q", banned, v)
+		}
+	}
+	if ct := got.Get("Content-Type"); ct != "application/x-ndjson" {
+		t.Errorf("Content-Type = %q, want application/x-ndjson", ct)
+	}
+}
+
+// ── Field coarsening ─────────────────────────────────────────
+
+func TestDurationBucket(t *testing.T) {
+	cases := []struct {
+		d    time.Duration
+		want string
+	}{
+		{0, "<100ms"},
+		{99 * time.Millisecond, "<100ms"},
+		{100 * time.Millisecond, "100ms-1s"},
+		{999 * time.Millisecond, "100ms-1s"},
+		{time.Second, "1s-10s"},
+		{9 * time.Second, "1s-10s"},
+		{10 * time.Second, "10s-1m"},
+		{59 * time.Second, "10s-1m"},
+		{time.Minute, "1m-10m"},
+		{9 * time.Minute, "1m-10m"},
+		{10 * time.Minute, ">10m"},
+		{48 * time.Hour, ">10m"}, // tail collapses: real durations leak data volume
+	}
+	for _, c := range cases {
+		if got := durationBucket(c.d); got != c.want {
+			t.Errorf("durationBucket(%v) = %q, want %q", c.d, got, c.want)
+		}
+	}
+}
+
+func TestMinorVersionAndIsRelease(t *testing.T) {
+	cases := []struct {
+		in        string
+		want      string
+		isRelease bool
+	}{
+		{"0.40.0", "0.40", true},
+		{"v1.2.3", "1.2", true},
+		{"10.11.12", "10.11", true},
+		{"dev", "unknown", false},
+		{"", "unknown", false},
+		// A custom -ldflags string can be near-unique, so it must never pass
+		// through verbatim.
+		{"0.40.0-acme-internal-build-7", "unknown", false},
+		{"0.40", "unknown", false},
+	}
+	for _, c := range cases {
+		if got := minorVersion(c.in); got != c.want {
+			t.Errorf("minorVersion(%q) = %q, want %q", c.in, got, c.want)
+		}
+		if got := isReleaseVersion(c.in); got != c.isRelease {
+			t.Errorf("isReleaseVersion(%q) = %v, want %v", c.in, got, c.isRelease)
+		}
+	}
+}
+
+func TestCoarseArch(t *testing.T) {
+	for in, want := range map[string]string{
+		"amd64": "amd64", "arm64": "arm64",
+		"riscv64": "other", "386": "other", "": "other",
+	} {
+		if got := coarseArch(in); got != want {
+			t.Errorf("coarseArch(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestSanitizeCommand(t *testing.T) {
+	for in, want := range map[string]string{
+		"status": "status", "recover-cascade": "recover-cascade", "UP": "up",
+		"": "other",
+		// Anything that is not a plain command name is refused rather than
+		// forwarded — the field must never become a channel for free text.
+		"query --index-dsn=user:pass@tcp(h)/db": "other",
+		"/etc/passwd":                           "other",
+		strings.Repeat("a", 33):                 "other",
+	} {
+		if got := sanitizeCommand(in); got != want {
+			t.Errorf("sanitizeCommand(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// ── Error classification ─────────────────────────────────────
+
+func TestClassifyError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"nil", nil, ""},
+		{"access denied", &mysql.MySQLError{Number: 1045}, ClassDBPermission},
+		{"table denied", &mysql.MySQLError{Number: 1142}, ClassDBPermission},
+		{"unknown database", &mysql.MySQLError{Number: 1049}, ClassNotFound},
+		{"no such table", &mysql.MySQLError{Number: 1146}, ClassNotFound},
+		{"syntax error", &mysql.MySQLError{Number: 1064}, ClassUnknown},
+		{"wrapped mysql", fmt.Errorf("query failed: %w", &mysql.MySQLError{Number: 1045}), ClassDBPermission},
+		{"missing file", fmt.Errorf("open: %w", fs.ErrNotExist), ClassNotFound},
+		{"permission", fmt.Errorf("open: %w", fs.ErrPermission), ClassStorageIO},
+		{"deadline", context.DeadlineExceeded, ClassDBConnection},
+		{"plain", errors.New("something went wrong"), ClassUnknown},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := ClassifyError(c.err); got != c.want {
+				t.Errorf("ClassifyError = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+// TestClassifyErrorNeverLeaksMessage is the load-bearing property: bintrail
+// error strings routinely carry DSNs and table names, and none of that may
+// reach the wire under any input.
+func TestClassifyErrorNeverLeaksMessage(t *testing.T) {
+	secret := "root:hunter2@tcp(db.internal:3306)/customer_orders"
+	err := fmt.Errorf("connect %s: %w", secret, &mysql.MySQLError{Number: 1045, Message: secret})
+	got := ClassifyError(err)
+	if strings.Contains(got, "hunter2") || strings.Contains(got, "customer_orders") || strings.Contains(got, "db.internal") {
+		t.Fatalf("ClassifyError leaked the error message: %q", got)
+	}
+	if !classes[got] {
+		t.Fatalf("ClassifyError returned %q, which is outside the taxonomy", got)
+	}
+}
+
+func TestNormalizeClassRejectsFreeText(t *testing.T) {
+	if got := normalizeClass("db_connection"); got != ClassDBConnection {
+		t.Errorf("known class was altered: %q", got)
+	}
+	if got := normalizeClass("failed to open /var/lib/mysql/binlog.000042"); got != ClassUnknown {
+		t.Errorf("free text was not coerced: %q", got)
+	}
+}
+
+// ── Consent resolution ───────────────────────────────────────
+
+func TestResolvePrecedence(t *testing.T) {
+	t.Run("default is on", func(t *testing.T) {
+		clearEnv(t)
+		got := Resolve("", t.TempDir())
+		if !got.Enabled || got.Source != SourceDefault {
+			t.Errorf("got %+v, want enabled via default", got)
+		}
+	})
+
+	t.Run("config file overrides default", func(t *testing.T) {
+		clearEnv(t)
+		dir := t.TempDir()
+		if err := SetEnabled(dir, false); err != nil {
+			t.Fatalf("SetEnabled: %v", err)
+		}
+		got := Resolve("", dir)
+		if got.Enabled || got.Source != SourceConfig {
+			t.Errorf("got %+v, want disabled via config file", got)
+		}
+	})
+
+	t.Run("env overrides config file", func(t *testing.T) {
+		clearEnv(t)
+		dir := t.TempDir()
+		if err := SetEnabled(dir, false); err != nil {
+			t.Fatalf("SetEnabled: %v", err)
+		}
+		t.Setenv(EnvVar, "on")
+		got := Resolve("", dir)
+		if !got.Enabled || got.Source != SourceEnv {
+			t.Errorf("got %+v, want enabled via env", got)
+		}
+	})
+
+	t.Run("flag overrides env", func(t *testing.T) {
+		clearEnv(t)
+		t.Setenv(EnvVar, "on")
+		got := Resolve("off", t.TempDir())
+		if got.Enabled || got.Source != SourceFlag {
+			t.Errorf("got %+v, want disabled via flag", got)
+		}
+	})
+
+	t.Run("DO_NOT_TRACK beats everything", func(t *testing.T) {
+		clearEnv(t)
+		dir := t.TempDir()
+		if err := SetEnabled(dir, true); err != nil {
+			t.Fatalf("SetEnabled: %v", err)
+		}
+		t.Setenv(EnvVar, "on")
+		t.Setenv("DO_NOT_TRACK", "1")
+		got := Resolve("on", dir)
+		if got.Enabled || got.Source != SourceDoNotTrack {
+			t.Errorf("got %+v, want disabled via DO_NOT_TRACK", got)
+		}
+	})
+
+	t.Run("DO_NOT_TRACK=0 does not disable", func(t *testing.T) {
+		clearEnv(t)
+		t.Setenv("DO_NOT_TRACK", "0")
+		if got := Resolve("", t.TempDir()); !got.Enabled {
+			t.Errorf("got %+v, want the 0 value ignored", got)
+		}
+	})
+
+	t.Run("unparseable values fall through", func(t *testing.T) {
+		clearEnv(t)
+		dir := t.TempDir()
+		if err := SetEnabled(dir, false); err != nil {
+			t.Fatalf("SetEnabled: %v", err)
+		}
+		t.Setenv(EnvVar, "maybe")
+		// A typo must not silently mean "off" — it falls through to the config
+		// file, which here says off, via SourceConfig not SourceEnv.
+		if got := Resolve("", dir); got.Source != SourceConfig {
+			t.Errorf("got %+v, want fall-through to the config file", got)
+		}
+	})
+}
+
+// TestCorruptStateFileFallsBackToDefault: a hand-edited or truncated consent
+// file must degrade to the default, never fail a command the operator asked
+// for.
+func TestCorruptStateFileFallsBackToDefault(t *testing.T) {
+	clearEnv(t)
+	dir := t.TempDir()
+	if err := os.WriteFile(StatePath(dir), []byte("{not json"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if got := Resolve("", dir); !got.Enabled || got.Source != SourceDefault {
+		t.Errorf("got %+v, want the default", got)
+	}
+}
+
+func TestStateFilePermissions(t *testing.T) {
+	clearEnv(t)
+	dir := t.TempDir()
+	if err := SetEnabled(dir, false); err != nil {
+		t.Fatalf("SetEnabled: %v", err)
+	}
+	fi, err := os.Stat(StatePath(dir))
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := fi.Mode().Perm(); perm != 0o600 {
+		t.Errorf("consent file mode = %o, want 600", perm)
+	}
+}
+
+func TestIsCI(t *testing.T) {
+	clearEnv(t)
+	if IsCI() {
+		t.Fatal("IsCI true with every marker cleared")
+	}
+	t.Setenv("GITHUB_ACTIONS", "true")
+	if !IsCI() {
+		t.Error("IsCI false with GITHUB_ACTIONS=true")
+	}
+}
+
+// ── Spool ────────────────────────────────────────────────────
+
+func TestAppendAndDrain(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2026, 7, 21, 10, 0, 0, 0, time.UTC)
+	for i := range 3 {
+		e := Event{SchemaVersion: SchemaVersion, EventType: EventCommandRun, Command: fmt.Sprintf("cmd%d", i)}
+		if err := appendEvent(dir, e, now); err != nil {
+			t.Fatalf("appendEvent: %v", err)
+		}
+	}
+
+	var received [][]byte
+	drain(dir, now, func(b []byte) error {
+		received = append(received, b)
+		return nil
+	})
+	if len(received) != 1 {
+		t.Fatalf("got %d batches, want 1", len(received))
+	}
+	if n := strings.Count(strings.TrimSpace(string(received[0])), "\n") + 1; n != 3 {
+		t.Errorf("batch has %d lines, want 3", n)
+	}
+	left, _ := os.ReadDir(dir)
+	if len(left) != 0 {
+		t.Errorf("spool not emptied after a successful drain: %v", left)
+	}
+}
+
+func TestSpoolFilePermissions(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+	if err := appendEvent(dir, Event{}, now); err != nil {
+		t.Fatalf("appendEvent: %v", err)
+	}
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 1 {
+		t.Fatalf("want 1 spool file, got %d", len(entries))
+	}
+	fi, err := entries[0].Info()
+	if err != nil {
+		t.Fatalf("info: %v", err)
+	}
+	if perm := fi.Mode().Perm(); perm != 0o600 {
+		t.Errorf("spool file mode = %o, want 600", perm)
+	}
+}
+
+// TestSpoolCapDropsRatherThanGrows: a box that never reaches the network must
+// not fill its disk with telemetry.
+func TestSpoolCapDropsRatherThanGrows(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+	path := filepath.Join(dir, now.UTC().Format("2006-01-02")+spoolSuffix)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, bytes.Repeat([]byte("x"), maxSpoolFileBytes+1), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	before, _ := os.Stat(path)
+	if err := appendEvent(dir, Event{Command: "status"}, now); err != nil {
+		t.Fatalf("appendEvent: %v", err)
+	}
+	after, _ := os.Stat(path)
+	if after.Size() != before.Size() {
+		t.Errorf("spool grew past the cap: %d -> %d", before.Size(), after.Size())
+	}
+}
+
+// TestDrainReclaimsAbandonedClaim covers the common case, not an exotic one: a
+// fast command's process exits while its detached drain goroutine is still in
+// its HTTP call, leaving a claimed file behind. A later run must pick it up
+// rather than let the events evaporate.
+func TestDrainReclaimsAbandonedClaim(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	abandoned := filepath.Join(dir, "2026-07-20"+spoolSuffix+claimedMark+"999-1")
+	if err := os.WriteFile(abandoned, []byte(`{"command":"status"}`+"\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	old := time.Now().Add(-10 * time.Minute)
+	if err := os.Chtimes(abandoned, old, old); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	var received [][]byte
+	drain(dir, time.Now(), func(b []byte) error {
+		received = append(received, b)
+		return nil
+	})
+	if len(received) != 1 {
+		t.Fatalf("abandoned claim was not reclaimed (got %d batches)", len(received))
+	}
+	if _, err := os.Stat(abandoned); !os.IsNotExist(err) {
+		t.Error("reclaimed file still on disk")
+	}
+}
+
+// TestDrainLeavesFreshClaimAlone: a claim younger than claimReclaimAfter may
+// still belong to a live drainer, so stealing it would send the batch twice.
+func TestDrainLeavesFreshClaimAlone(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	fresh := filepath.Join(dir, "2026-07-20"+spoolSuffix+claimedMark+"111-2")
+	if err := os.WriteFile(fresh, []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	called := 0
+	drain(dir, time.Now(), func([]byte) error { called++; return nil })
+	if called != 0 {
+		t.Errorf("a fresh claim was stolen from a possibly-live drainer (%d sends)", called)
+	}
+	if _, err := os.Stat(fresh); err != nil {
+		t.Errorf("fresh claim was removed: %v", err)
+	}
+}
+
+// TestDrainExpiresAncientSpool: undelivered events must not linger forever.
+func TestDrainExpiresAncientSpool(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	stale := filepath.Join(dir, "2020-01-01"+spoolSuffix)
+	if err := os.WriteFile(stale, []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	old := time.Now().Add(-maxSpoolAge - time.Hour)
+	if err := os.Chtimes(stale, old, old); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+	called := 0
+	drain(dir, time.Now(), func([]byte) error { called++; return nil })
+	if called != 0 {
+		t.Errorf("expired events were sent (%d batches)", called)
+	}
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Error("expired spool file was not removed")
+	}
+}
+
+// TestConcurrentDrainSendsEachBatchOnce is the claim-by-rename guarantee: a
+// cron run and a human run sharing $HOME must not double-report.
+func TestConcurrentDrainSendsEachBatchOnce(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+	for i := range 5 {
+		if err := appendEvent(dir, Event{Command: fmt.Sprintf("c%d", i)}, now); err != nil {
+			t.Fatalf("appendEvent: %v", err)
+		}
+	}
+	var mu sync.Mutex
+	var lines int
+	var wg sync.WaitGroup
+	for range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			drain(dir, time.Now(), func(b []byte) error {
+				mu.Lock()
+				defer mu.Unlock()
+				lines += strings.Count(string(b), "\n")
+				return nil
+			})
+		}()
+	}
+	wg.Wait()
+	if lines != 5 {
+		t.Errorf("delivered %d lines, want exactly 5 (duplicated or lost)", lines)
+	}
+}
+
+func TestDrainMissingDirIsNotAnError(t *testing.T) {
+	drain(filepath.Join(t.TempDir(), "does-not-exist"), time.Now(), func([]byte) error {
+		t.Fatal("send called with no spool present")
+		return nil
+	})
+}
+
+// ── Client lifecycle ─────────────────────────────────────────
+
+// TestInertWithoutEndpoint is the build-time kill switch: no endpoint compiled
+// in means no spool, no network, nothing. This is what makes `go build` and the
+// whole test suite incapable of emitting telemetry.
+func TestInertWithoutEndpoint(t *testing.T) {
+	clearEnv(t)
+	dir := t.TempDir()
+	c := Init(Config{Dir: dir, Interactive: boolPtr(true), Stderr: &bytes.Buffer{}})
+	if c.Enabled() {
+		t.Fatal("client enabled with no endpoint compiled in")
+	}
+	c.RecordCommand("status").Finish()
+	c.Beacon("stream")
+	if entries, _ := os.ReadDir(SpoolDir(dir)); len(entries) != 0 {
+		t.Errorf("inert client wrote to the spool: %v", entries)
+	}
+}
+
+func TestDisabledByConsentWritesNothing(t *testing.T) {
+	clearEnv(t)
+	t.Setenv(EnvVar, "off")
+	dir := t.TempDir()
+	c := Init(Config{Dir: dir, Endpoint: "http://127.0.0.1:1", Stderr: &bytes.Buffer{}, Interactive: boolPtr(false)})
+	if c.Enabled() {
+		t.Fatal("client enabled while consent says off")
+	}
+	c.RecordCommand("status").Finish()
+	if entries, _ := os.ReadDir(SpoolDir(dir)); len(entries) != 0 {
+		t.Errorf("disabled client wrote to the spool: %v", entries)
+	}
+}
+
+func TestCISuppressesReporting(t *testing.T) {
+	clearEnv(t)
+	t.Setenv("CI", "true")
+	dir := t.TempDir()
+	c := Init(Config{Dir: dir, Endpoint: "http://127.0.0.1:1", Stderr: &bytes.Buffer{}, Interactive: boolPtr(false)})
+	if c.Enabled() {
+		t.Fatal("telemetry active in CI")
+	}
+	if d := c.Decision(); !d.Enabled {
+		t.Error("CI detection must suppress reporting without rewriting the consent decision")
+	}
+}
+
+func TestSpanRecordsToSpool(t *testing.T) {
+	clearEnv(t)
+	dir := t.TempDir()
+	c := Init(Config{
+		Dir: dir, Endpoint: "http://127.0.0.1:1", Version: "0.40.0",
+		Stderr: &bytes.Buffer{}, Interactive: boolPtr(false),
+	})
+	if !c.Enabled() {
+		t.Fatal("client not enabled")
+	}
+	s := c.RecordCommand("query")
+	s.SetError(ClassDBPermission)
+	s.Finish()
+
+	e := readOneSpooledEvent(t, SpoolDir(dir))
+	if e.Command != "query" || e.EventType != EventCommandError || e.Outcome != OutcomeError {
+		t.Errorf("unexpected event: %+v", e)
+	}
+	if e.ErrorClass != ClassDBPermission {
+		t.Errorf("error_class = %q, want %q", e.ErrorClass, ClassDBPermission)
+	}
+	if e.Version != "0.40" || !e.IsRelease {
+		t.Errorf("version = %q is_release = %v, want 0.40/true", e.Version, e.IsRelease)
+	}
+	if e.RunID == "" {
+		t.Error("command events should carry a run_id for ingestion-side dedup")
+	}
+}
+
+// TestBeaconCarriesNoRunID: a daemon lives for months, so its run_id would be a
+// longitudinal identifier — precisely what this design refuses to create.
+func TestBeaconCarriesNoRunID(t *testing.T) {
+	clearEnv(t)
+	dir := t.TempDir()
+	c := Init(Config{Dir: dir, Endpoint: "http://127.0.0.1:1", Stderr: &bytes.Buffer{}, Interactive: boolPtr(false)})
+	c.Beacon("stream")
+
+	e := readOneSpooledEvent(t, SpoolDir(dir))
+	if e.EventType != EventDaemonBeacon || e.Command != "stream" {
+		t.Errorf("unexpected beacon: %+v", e)
+	}
+	if e.RunID != "" {
+		t.Errorf("beacon carries run_id %q; it must not", e.RunID)
+	}
+}
+
+// TestBeaconAtMostOncePerUTCDay: a finer beat would reconstruct a daemon's
+// uptime and maintenance windows.
+func TestBeaconAtMostOncePerUTCDay(t *testing.T) {
+	clearEnv(t)
+	dir := t.TempDir()
+	now := time.Date(2026, 7, 21, 8, 0, 0, 0, time.UTC)
+	c := Init(Config{
+		Dir: dir, Endpoint: "http://127.0.0.1:1", Stderr: &bytes.Buffer{},
+		Interactive: boolPtr(false), Now: func() time.Time { return now },
+	})
+	for range 50 {
+		c.Beacon("stream")
+	}
+	if n := countSpooledEvents(t, SpoolDir(dir)); n != 1 {
+		t.Fatalf("same-day beacons recorded %d events, want 1", n)
+	}
+
+	now = now.Add(24 * time.Hour)
+	c.Beacon("stream")
+	if n := countSpooledEvents(t, SpoolDir(dir)); n != 2 {
+		t.Errorf("next-day beacon recorded %d events total, want 2", n)
+	}
+}
+
+func TestNoticeShownOnceOnDefault(t *testing.T) {
+	clearEnv(t)
+	dir := t.TempDir()
+	cfg := func(w *bytes.Buffer) Config {
+		return Config{Dir: dir, Endpoint: "http://127.0.0.1:1", Stderr: w, Interactive: boolPtr(true)}
+	}
+	var first bytes.Buffer
+	Init(cfg(&first))
+	if !strings.Contains(first.String(), "Telemetry is currently ON") {
+		t.Fatalf("first run did not disclose the default:\n%s", first.String())
+	}
+	if !strings.Contains(first.String(), "telemetry off") {
+		t.Error("notice does not tell the operator how to turn it off")
+	}
+	var second bytes.Buffer
+	Init(cfg(&second))
+	if second.Len() != 0 {
+		t.Errorf("notice repeated on the second run:\n%s", second.String())
+	}
+}
+
+func TestNoticeSuppressedWhenNotInteractive(t *testing.T) {
+	clearEnv(t)
+	var out bytes.Buffer
+	Init(Config{Dir: t.TempDir(), Endpoint: "http://127.0.0.1:1", Stderr: &out, Interactive: boolPtr(false)})
+	if out.Len() != 0 {
+		t.Errorf("notice printed into non-interactive output:\n%s", out.String())
+	}
+}
+
+// TestNoticeSuppressedAfterExplicitChoice: an operator who already chose has
+// nothing to be told.
+func TestNoticeSuppressedAfterExplicitChoice(t *testing.T) {
+	clearEnv(t)
+	dir := t.TempDir()
+	if err := SetEnabled(dir, true); err != nil {
+		t.Fatalf("SetEnabled: %v", err)
+	}
+	var out bytes.Buffer
+	Init(Config{Dir: dir, Endpoint: "http://127.0.0.1:1", Stderr: &out, Interactive: boolPtr(true)})
+	if out.Len() != 0 {
+		t.Errorf("notice shown despite an explicit choice:\n%s", out.String())
+	}
+}
+
+// TestNilSafety: every entry point tolerates a nil client or span, so callers
+// never need a guard and a telemetry mistake can never panic a command.
+func TestNilSafety(t *testing.T) {
+	var c *Client
+	c.RecordCommand("status").Finish()
+	c.Beacon("stream")
+	if c.Enabled() {
+		t.Error("nil client reported enabled")
+	}
+	var s *Span
+	s.SetError(ClassInternal)
+	s.Finish()
+}
+
+// TestEndToEndDelivery exercises the whole path: a first run spools, a second
+// run drains and delivers over HTTP.
+func TestEndToEndDelivery(t *testing.T) {
+	clearEnv(t)
+	var mu sync.Mutex
+	var body []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		body, _ = readAll(r)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	cfg := Config{Dir: dir, Endpoint: srv.URL, Version: "0.40.0", Stderr: &bytes.Buffer{}, Interactive: boolPtr(false)}
+
+	c := Init(cfg)
+	c.RecordCommand("status").Finish()
+
+	// A later invocation drains what the first one spooled.
+	Init(cfg)
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		got := len(body)
+		mu.Unlock()
+		if got > 0 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(body) == 0 {
+		t.Fatal("nothing delivered to the endpoint")
+	}
+	var e Event
+	if err := json.Unmarshal([]byte(strings.SplitN(strings.TrimSpace(string(body)), "\n", 2)[0]), &e); err != nil {
+		t.Fatalf("delivered payload is not NDJSON: %v", err)
+	}
+	if e.Command != "status" {
+		t.Errorf("delivered command = %q, want status", e.Command)
+	}
+}
+
+// ── helpers ──────────────────────────────────────────────────
+
+func readAll(r *http.Request) ([]byte, error) {
+	defer r.Body.Close()
+	var buf bytes.Buffer
+	_, err := buf.ReadFrom(r.Body)
+	return buf.Bytes(), err
+}
+
+func spooledLines(t *testing.T, spoolDir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(spoolDir)
+	if err != nil {
+		t.Fatalf("read spool dir: %v", err)
+	}
+	var lines []string
+	for _, entry := range entries {
+		data, err := os.ReadFile(filepath.Join(spoolDir, entry.Name()))
+		if err != nil {
+			t.Fatalf("read spool file: %v", err)
+		}
+		for _, l := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+			if l != "" {
+				lines = append(lines, l)
+			}
+		}
+	}
+	return lines
+}
+
+func countSpooledEvents(t *testing.T, spoolDir string) int {
+	t.Helper()
+	return len(spooledLines(t, spoolDir))
+}
+
+func readOneSpooledEvent(t *testing.T, spoolDir string) Event {
+	t.Helper()
+	lines := spooledLines(t, spoolDir)
+	if len(lines) != 1 {
+		t.Fatalf("want exactly 1 spooled event, got %d", len(lines))
+	}
+	var e Event
+	if err := json.Unmarshal([]byte(lines[0]), &e); err != nil {
+		t.Fatalf("unmarshal spooled event: %v", err)
+	}
+	return e
+}

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -436,14 +437,7 @@ func TestDrainReclaimsAbandonedClaim(t *testing.T) {
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
-	abandoned := filepath.Join(dir, "2026-07-20"+spoolSuffix+claimedMark+"999-1")
-	if err := os.WriteFile(abandoned, []byte(`{"command":"status"}`+"\n"), 0o600); err != nil {
-		t.Fatalf("write: %v", err)
-	}
-	old := time.Now().Add(-10 * time.Minute)
-	if err := os.Chtimes(abandoned, old, old); err != nil {
-		t.Fatalf("chtimes: %v", err)
-	}
+	abandoned := writeClaim(t, dir, "2026-07-20", time.Now().Add(-10*time.Minute))
 
 	var received [][]byte
 	drain(dir, time.Now(), func(b []byte) error {
@@ -460,15 +454,23 @@ func TestDrainReclaimsAbandonedClaim(t *testing.T) {
 
 // TestDrainLeavesFreshClaimAlone: a claim younger than claimReclaimAfter may
 // still belong to a live drainer, so stealing it would send the batch twice.
+//
+// The file's mtime is deliberately set an hour into the past. A real claim
+// always looks like this — os.Rename preserves mtime, so a claim of yesterday's
+// spool file carries yesterday's timestamp — and an implementation that judges
+// claim age by mtime instead of by the stamp in the claim's name passes every
+// other test in this file while failing this one.
 func TestDrainLeavesFreshClaimAlone(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
-	fresh := filepath.Join(dir, "2026-07-20"+spoolSuffix+claimedMark+"111-2")
-	if err := os.WriteFile(fresh, []byte("{}\n"), 0o600); err != nil {
-		t.Fatalf("write: %v", err)
+	fresh := writeClaim(t, dir, "2026-07-20", time.Now())
+	old := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(fresh, old, old); err != nil {
+		t.Fatalf("chtimes: %v", err)
 	}
+
 	called := 0
 	drain(dir, time.Now(), func([]byte) error { called++; return nil })
 	if called != 0 {
@@ -477,6 +479,89 @@ func TestDrainLeavesFreshClaimAlone(t *testing.T) {
 	if _, err := os.Stat(fresh); err != nil {
 		t.Errorf("fresh claim was removed: %v", err)
 	}
+}
+
+func TestClaimStamp(t *testing.T) {
+	want := time.Unix(0, 1753084800123456789)
+	name := "2026-07-21" + spoolSuffix + claimedMark + "4211-" + strconv.FormatInt(want.UnixNano(), 10)
+	got, ok := claimStamp(name)
+	if !ok || !got.Equal(want) {
+		t.Errorf("claimStamp(%q) = %v, %v; want %v, true", name, got, ok, want)
+	}
+	if _, ok := claimStamp("2026-07-21" + spoolSuffix); ok {
+		t.Error("a plain spool name should not yield a claim stamp")
+	}
+	if _, ok := claimStamp("2026-07-21" + spoolSuffix + claimedMark + "garbage"); ok {
+		t.Error("an unparseable claim suffix should not yield a stamp")
+	}
+}
+
+// TestDrainDropsBatchOnSendFailure covers the documented drop-on-fail
+// behaviour AND that a refusing endpoint is not hammered: the loop stops after
+// the first failure rather than working through every remaining file.
+func TestDrainDropsBatchOnSendFailure(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	for _, day := range []string{"2026-07-18", "2026-07-19"} {
+		if err := os.WriteFile(filepath.Join(dir, day+spoolSuffix), []byte("{}\n"), 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	calls := 0
+	drain(dir, time.Now(), func([]byte) error {
+		calls++
+		return errors.New("endpoint refused")
+	})
+	if calls != 1 {
+		t.Errorf("kept sending to a refusing endpoint: %d calls, want 1", calls)
+	}
+	// The attempted batch is dropped rather than requeued (no backlog to flush
+	// later), and the file the loop never reached is still there for a later
+	// run — so exactly one of the two remains.
+	left, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read spool dir: %v", err)
+	}
+	if len(left) != 1 {
+		t.Fatalf("want 1 file left (the unattempted one), got %d: %v", len(left), left)
+	}
+	if left[0].Name() != "2026-07-19"+spoolSuffix {
+		t.Errorf("the failed batch was requeued instead of dropped: %s remains", left[0].Name())
+	}
+}
+
+func TestPurgeSpool(t *testing.T) {
+	dir := t.TempDir()
+	if err := appendEvent(SpoolDir(dir), Event{Command: "status"}, time.Now()); err != nil {
+		t.Fatalf("appendEvent: %v", err)
+	}
+	if err := PurgeSpool(dir); err != nil {
+		t.Fatalf("PurgeSpool: %v", err)
+	}
+	if _, err := os.Stat(SpoolDir(dir)); !os.IsNotExist(err) {
+		t.Error("spool directory survived the purge")
+	}
+	// Purging an already-absent spool is not an error — `telemetry off` must
+	// work on a machine that has never spooled anything.
+	if err := PurgeSpool(dir); err != nil {
+		t.Errorf("purging an absent spool errored: %v", err)
+	}
+	if err := PurgeSpool(""); err != nil {
+		t.Errorf("purging with no config dir errored: %v", err)
+	}
+}
+
+// writeClaim creates a claim file whose name carries stamp, the way drain
+// names its own claims.
+func writeClaim(t *testing.T, dir, day string, stamp time.Time) string {
+	t.Helper()
+	path := filepath.Join(dir, day+spoolSuffix+claimedMark+"999-"+strconv.FormatInt(stamp.UnixNano(), 10))
+	if err := os.WriteFile(path, []byte(`{"command":"status"}`+"\n"), 0o600); err != nil {
+		t.Fatalf("write claim: %v", err)
+	}
+	return path
 }
 
 // TestDrainExpiresAncientSpool: undelivered events must not linger forever.
@@ -513,20 +598,40 @@ func TestConcurrentDrainSendsEachBatchOnce(t *testing.T) {
 			t.Fatalf("appendEvent: %v", err)
 		}
 	}
+	// Age the spool file before the drainers run. This is what an ordinary
+	// prior-day spool file looks like, and it is what makes this test capable
+	// of failing: rename preserves mtime, so an implementation that ages claims
+	// by mtime sees every claim of this file as instantly abandoned and lets a
+	// second drainer adopt and re-send a batch that is still in flight.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read spool dir: %v", err)
+	}
+	old := now.Add(-30 * time.Minute)
+	for _, e := range entries {
+		if err := os.Chtimes(filepath.Join(dir, e.Name()), old, old); err != nil {
+			t.Fatalf("chtimes: %v", err)
+		}
+	}
+
 	var mu sync.Mutex
 	var lines int
 	var wg sync.WaitGroup
-	for range 4 {
+	for i := range 4 {
 		wg.Add(1)
-		go func() {
+		go func(i int) {
 			defer wg.Done()
+			// Stagger, so later drainers scan while an earlier claim is live
+			// rather than all racing on the pre-claim name.
+			time.Sleep(time.Duration(i) * 50 * time.Millisecond)
 			drain(dir, time.Now(), func(b []byte) error {
+				time.Sleep(150 * time.Millisecond) // hold the claim, like a real POST
 				mu.Lock()
 				defer mu.Unlock()
 				lines += strings.Count(string(b), "\n")
 				return nil
 			})
-		}()
+		}(i)
 	}
 	wg.Wait()
 	if lines != 5 {

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -553,6 +554,45 @@ func TestPurgeSpool(t *testing.T) {
 	}
 }
 
+// initDrained builds a client whose startup drain has already run to
+// completion.
+//
+// Necessary for any test that writes events and then inspects the spool: the
+// drain is a background goroutine, and if it scans AFTER the test has appended,
+// it legitimately claims that file, fails to deliver it to the dead endpoint,
+// and drops it — leaving the test reading an empty spool. Waiting costs nothing
+// here, since a drain over an empty spool returns immediately.
+func initDrained(t *testing.T, cfg Config) *Client {
+	t.Helper()
+	c := Init(cfg)
+	c.Shutdown()
+	return c
+}
+
+func TestShutdownIsSafeOnEveryClient(t *testing.T) {
+	clearEnv(t)
+	var nilClient *Client
+	nilClient.Shutdown() // must not panic
+
+	// Disabled client: no goroutine was ever started, so there is nothing to
+	// wait for and Shutdown must return at once rather than block for the grace
+	// period.
+	disabled := Init(Config{Dir: t.TempDir(), Stderr: &bytes.Buffer{}, Interactive: boolPtr(false)})
+	start := time.Now()
+	disabled.Shutdown()
+	disabled.Shutdown() // idempotent
+	if elapsed := time.Since(start); elapsed > shutdownGrace {
+		t.Errorf("Shutdown on a disabled client blocked for %v", elapsed)
+	}
+
+	enabled := Init(Config{
+		Dir: t.TempDir(), Endpoint: "http://127.0.0.1:1",
+		Stderr: &bytes.Buffer{}, Interactive: boolPtr(false),
+	})
+	enabled.Shutdown()
+	enabled.Shutdown()
+}
+
 // writeClaim creates a claim file whose name carries stamp, the way drain
 // names its own claims.
 func writeClaim(t *testing.T, dir, day string, stamp time.Time) string {
@@ -695,7 +735,7 @@ func TestCISuppressesReporting(t *testing.T) {
 func TestSpanRecordsToSpool(t *testing.T) {
 	clearEnv(t)
 	dir := t.TempDir()
-	c := Init(Config{
+	c := initDrained(t, Config{
 		Dir: dir, Endpoint: "http://127.0.0.1:1", Version: "0.40.0",
 		Stderr: &bytes.Buffer{}, Interactive: boolPtr(false),
 	})
@@ -726,7 +766,7 @@ func TestSpanRecordsToSpool(t *testing.T) {
 func TestBeaconCarriesNoRunID(t *testing.T) {
 	clearEnv(t)
 	dir := t.TempDir()
-	c := Init(Config{Dir: dir, Endpoint: "http://127.0.0.1:1", Stderr: &bytes.Buffer{}, Interactive: boolPtr(false)})
+	c := initDrained(t, Config{Dir: dir, Endpoint: "http://127.0.0.1:1", Stderr: &bytes.Buffer{}, Interactive: boolPtr(false)})
 	c.Beacon("stream")
 
 	e := readOneSpooledEvent(t, SpoolDir(dir))
@@ -743,10 +783,17 @@ func TestBeaconCarriesNoRunID(t *testing.T) {
 func TestBeaconAtMostOncePerUTCDay(t *testing.T) {
 	clearEnv(t)
 	dir := t.TempDir()
-	now := time.Date(2026, 7, 21, 8, 0, 0, 0, time.UTC)
-	c := Init(Config{
+	base := time.Date(2026, 7, 21, 8, 0, 0, 0, time.UTC)
+
+	// The clock is atomic because Config.Now is called from the background drain
+	// goroutine as well as from this test — a plain variable is a data race that
+	// only -race reports, and CI runs with it.
+	var clock atomic.Int64
+	clock.Store(base.UnixNano())
+	c := initDrained(t, Config{
 		Dir: dir, Endpoint: "http://127.0.0.1:1", Stderr: &bytes.Buffer{},
-		Interactive: boolPtr(false), Now: func() time.Time { return now },
+		Interactive: boolPtr(false),
+		Now:         func() time.Time { return time.Unix(0, clock.Load()).UTC() },
 	})
 	for range 50 {
 		c.Beacon("stream")
@@ -755,7 +802,7 @@ func TestBeaconAtMostOncePerUTCDay(t *testing.T) {
 		t.Fatalf("same-day beacons recorded %d events, want 1", n)
 	}
 
-	now = now.Add(24 * time.Hour)
+	clock.Store(base.Add(24 * time.Hour).UnixNano())
 	c.Beacon("stream")
 	if n := countSpooledEvents(t, SpoolDir(dir)); n != 2 {
 		t.Errorf("next-day beacon recorded %d events total, want 2", n)


### PR DESCRIPTION
closes #1056
closes #1057
closes #1058

Part of the telemetry epic #1054. Depends on #1063 (demo image guard) landing first.

The three issues are one PR because they are one unit: the core cannot be exercised without consent resolution, and neither is inspectable without the command. Splitting them would ship two PRs of dead code.

## What this is

`internal/telemetry` — event schema, error taxonomy, consent resolution, local spool, sender, build-time kill switch — plus the `telemetry` command registered on all three binaries. **No command records anything yet**; wiring the root hook is #1059.

## The guarantees, and how each is enforced

| Guarantee | Mechanism |
|---|---|
| Closed field allowlist | `AllowedFields` + a reflection test **and** a test over the serialized bytes (a custom marshaller could add keys reflection alone would miss) |
| No credential on the wire | `postNDJSON` sets only `Content-Type`; test asserts no `Authorization`/`Cookie`/api-key/server-uuid. Deliberately **not** `byos.MetadataClient` |
| No persistent identifier | Nothing but the consent file is written; `run_id` is per-process and in-memory, and beacons omit it |
| Source builds cannot send | `endpoint` is `-ldflags`-injected, empty by default → `Init` returns an inert client, no spool, no network |
| Telemetry cannot break a command | `recover()` at every entry point; nil `*Client`/`*Span` are safe; a corrupt consent file degrades to the default |
| Nothing on the request path | `Finish` appends one local NDJSON line; delivery happens on a **later** run, detached, 2s deadline |

## Verified against the real binary

```
$ go build ./cmd/bintrail && bintrail telemetry status
Telemetry:    OFF
Consent:      on (decided by: default)
Endpoint:     not compiled in — this build cannot send anything
```

With an endpoint injected it reports `ON` and the URL; `telemetry off` records the choice and `DO_NOT_TRACK=1` overrides everything (`decided by: DO_NOT_TRACK`). `telemetry show` prints the exact 13-field payload and performs no network access.

## Two design decisions worth a look

**Claimed spool files are removed only after the send attempt.** The first cut removed before sending, which loses data in the *common* case, not an exotic one: a sub-100ms command's process exits while the detached drain goroutine is still in its HTTP call. Now such a file survives as a claim and a later run adopts it (`TestDrainReclaimsAbandonedClaim`), while a claim younger than 5 minutes is left alone so a live drainer is never robbed (`TestDrainLeavesFreshClaimAlone`).

**`Beacon` takes no context and spawns no goroutine.** The design sketch had it spawn one so a POST could never land on a daemon's event loop. The spool model already guarantees that — a beacon is a local append — so the goroutine was ceremony.

## Test plan

- [x] `go test ./... -count=1` — full suite passes
- [x] `go vet` clean, `gofmt` clean
- [x] Package tests: allowlist (×2), no-credential, precedence matrix (6 cases), CI suppression, corrupt/absent state file, 0600 permissions on both files, spool cap, claim-by-rename under 4 concurrent drainers (exactly-once), abandoned-claim reclamation, age expiry, beacon ≤1/UTC day with day rollover, notice-once, nil safety, end-to-end HTTP delivery
- [x] Manual CLI exercise of status/show/on/off with a temp HOME, with and without a compiled-in endpoint
- [ ] Structural CI trust tests (import boundary via `go list -deps`, single-hook walk, MCP exclusion) — those are #1061

🤖 Generated with [Claude Code](https://claude.com/claude-code)