### PR TITLE
telemetry: record every command from the three root hooks

### DIFF
--- a/cliapp/root.go
+++ b/cliapp/root.go
@@ -20,6 +20,10 @@ var (
 	logFormat string
 )
 
+// tel records one usage event per invocation. Wired at the root so every
+// command — including ones added later — is covered without touching them.
+var tel cli.TelemetryHook
+
 // Build metadata, set by Main from the caller's -ldflags-injected values.
 // Package-level because commands (e.g. the agent's hello frame) read them
 // at runtime.
@@ -38,6 +42,7 @@ capabilities. The index is self-contained — recovery does not depend on
 binlog files still existing on disk.`,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		observe.Setup(os.Stderr, logFormat, logLevel)
+		tel.Start(cmd)
 		return nil
 	},
 	SilenceErrors: true, // we handle error output ourselves in main()
@@ -80,7 +85,7 @@ func Main(version, commitSHA, buildDate string) int {
 	rootCmd.Version = fmt.Sprintf("%s (commit %s, built %s)", Version, CommitSHA, BuildDate)
 	telemetry.SetVersion(version)
 
-	err := rootCmd.Execute()
+	err := tel.Execute(rootCmd)
 	if err == nil {
 		return 0
 	}

--- a/cmd/bintrail-pg/main.go
+++ b/cmd/bintrail-pg/main.go
@@ -29,6 +29,10 @@ var (
 	logFormat string
 )
 
+// tel records one usage event per invocation, wired at the root like the core
+// binary's.
+var tel cli.TelemetryHook
+
 // Build-time variables injected via -ldflags. These are the SAME names the core
 // bintrail binary uses (main.Version/CommitSHA/BuildDate), so the Makefile's
 // BINTRAIL_LDFLAGS applies to this binary verbatim — exactly as bintrail-console
@@ -53,6 +57,7 @@ before-image (and de-TOASTed unchanged values) is present in the WAL. See
 'bintrail-pg stream --help'.`,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		observe.Setup(os.Stderr, logFormat, logLevel)
+		tel.Start(cmd)
 		return nil
 	},
 	SilenceErrors: true, // we handle error output ourselves in main()
@@ -80,7 +85,7 @@ func init() {
 }
 
 func main() {
-	err := rootCmd.Execute()
+	err := tel.Execute(rootCmd)
 	if err == nil {
 		return
 	}

--- a/consoleapp/root.go
+++ b/consoleapp/root.go
@@ -43,6 +43,10 @@ var (
 // the running build (rootCmd.Version carries the human-formatted variant).
 var appVersion = "dev"
 
+// tel records one usage event per invocation, wired at the root like the core
+// binary's.
+var tel cli.TelemetryHook
+
 var rootCmd = &cobra.Command{
 	Use:   "bintrail-console",
 	Short: "Read-only web console over the Bintrail binlog index",
@@ -56,6 +60,7 @@ console NEVER executes SQL; recover produces a script you review and apply
 yourself.`,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		observe.Setup(os.Stderr, logFormat, logLevel)
+		tel.Start(cmd)
 		return nil
 	},
 	SilenceErrors: true, // we handle error output ourselves in Main()
@@ -78,7 +83,7 @@ func Main(version, commitSHA, buildDate string) int {
 	appVersion = version
 	rootCmd.Version = fmt.Sprintf("%s (commit %s, built %s)", version, commitSHA, buildDate)
 	telemetry.SetVersion(version)
-	if err := rootCmd.Execute(); err != nil {
+	if err := tel.Execute(rootCmd); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 1
 	}

--- a/internal/cli/telemetry.go
+++ b/internal/cli/telemetry.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -17,6 +18,107 @@ var telFormat string
 // one the operator happens to have on PATH.
 func AddTelemetryCommand(root *cobra.Command) {
 	root.AddCommand(telemetryCmd)
+}
+
+// TelemetryHook wires usage telemetry into one binary's root command: a binary
+// declares one, starts a span from its root PersistentPreRunE, and runs its
+// command tree through Execute.
+//
+// This is deliberately the ONLY instrumentation point. Cobra funnels every
+// subcommand through the root's PersistentPreRunE, so a new command needs no
+// telemetry code at all. The flip side: cobra runs only the CLOSEST hook, so a
+// subcommand that defined its own PersistentPreRunE would silently
+// un-instrument its whole subtree. A CI guard for that is tracked in #1061 —
+// until it lands, nothing but review catches it.
+type TelemetryHook struct {
+	client *telemetry.Client
+	span   *telemetry.Span
+}
+
+// Start resolves consent and begins recording the command about to run, unless
+// the command is one of the exempt trees (see uninstrumented).
+func (h *TelemetryHook) Start(cmd *cobra.Command) {
+	if uninstrumented(cmd) {
+		return
+	}
+	h.client = telemetry.Init(telemetry.Config{Flag: telemetryFlagValue(cmd)})
+	h.span = h.client.RecordCommand(commandPath(cmd))
+}
+
+// uninstrumented reports whether cmd belongs to a tree that must not be
+// recorded. Two kinds:
+//
+// The `telemetry` subtree — initialising there would drain and deliver the
+// spooled backlog moments before `telemetry off` discards it, so an operator
+// opting out would watch the tool phone home on its way out.
+//
+// Cobra's completion machinery, which is not user work. `__complete` is an
+// ordinary child of root, so the root hook fires for it: every TAB press in a
+// shell with completion installed would spool an event, attempt a POST, and pay
+// up to shutdownGrace of latency on a keystroke. It would also poison the
+// aggregates — sanitizeCommand rejects underscores, so `__complete` lands in
+// "other", which would then be the largest bucket in the dataset on any
+// developer's machine with nothing to distinguish it from a real unknown
+// command.
+func uninstrumented(cmd *cobra.Command) bool {
+	// Walk to the top-level command (the direct child of root).
+	top := cmd
+	for top.HasParent() && top.Parent().HasParent() {
+		top = top.Parent()
+	}
+	if !top.HasParent() {
+		return false // the root itself
+	}
+	name := top.Name()
+	return name == telemetryCmd.Name() ||
+		name == "help" ||
+		name == "completion" ||
+		strings.HasPrefix(name, "__") // __complete, __completeNoDesc
+}
+
+// Execute runs the command tree and records how it ended.
+//
+// A panic is recorded as an internal error and then re-raised: the panic value
+// and the exit status are unchanged and the original frames are preserved,
+// though Go marks the trace "[recovered, repanicked]" and prepends this
+// function's own two frames. The panic VALUE is never recorded — panic messages
+// routinely carry DSNs, table names and file paths.
+func (h *TelemetryHook) Execute(root *cobra.Command) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			h.span.SetError(telemetry.ClassInternal)
+			h.span.Finish()
+			h.client.Shutdown()
+			panic(r)
+		}
+	}()
+	err = root.Execute()
+	if err != nil {
+		h.span.SetError(telemetry.ClassifyError(err))
+	}
+	h.span.Finish()
+	// Give any in-flight delivery of EARLIER runs' events a bounded moment to
+	// land. Without it a short command's process exits before its own detached
+	// drain can finish, and telemetry never delivers at all for anyone whose
+	// commands are quick. Costs nothing when there is no backlog.
+	h.client.Shutdown()
+	return err
+}
+
+// commandPath renders the invoked command as a hyphenated path — "archive
+// reconcile" becomes "archive-reconcile" — so sibling subcommands stay
+// distinguishable in the aggregates. It is built from cobra command NAMES,
+// which are compile-time constants, and so can never carry an argument or a
+// flag value.
+func commandPath(cmd *cobra.Command) string {
+	var parts []string
+	for c := cmd; c != nil && c.HasParent(); c = c.Parent() {
+		parts = append([]string{c.Name()}, parts...)
+	}
+	if len(parts) == 0 {
+		return "root"
+	}
+	return strings.Join(parts, "-")
 }
 
 var telemetryCmd = &cobra.Command{

--- a/internal/cli/telemetry_wiring_test.go
+++ b/internal/cli/telemetry_wiring_test.go
@@ -1,0 +1,122 @@
+package cli
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestCommandPath(t *testing.T) {
+	root := &cobra.Command{Use: "bintrail"}
+	status := &cobra.Command{Use: "status"}
+	archive := &cobra.Command{Use: "archive"}
+	reconcile := &cobra.Command{Use: "reconcile"}
+	root.AddCommand(status, archive)
+	archive.AddCommand(reconcile)
+
+	if got := commandPath(status); got != "status" {
+		t.Errorf("commandPath(status) = %q, want status", got)
+	}
+	// Sibling subcommands must stay distinguishable: a bare leaf name would
+	// bucket every "reconcile"-like subcommand together.
+	if got := commandPath(reconcile); got != "archive-reconcile" {
+		t.Errorf("commandPath(archive reconcile) = %q, want archive-reconcile", got)
+	}
+	if got := commandPath(root); got != "root" {
+		t.Errorf("commandPath(root) = %q, want root", got)
+	}
+}
+
+// TestTelemetrySubtreeIsNotInstrumented: initialising telemetry while running
+// `telemetry off` would drain and deliver the spooled backlog moments before
+// the command discards it — an operator opting out would watch the tool phone
+// home on its way out.
+func TestTelemetrySubtreeIsNotInstrumented(t *testing.T) {
+	root := &cobra.Command{Use: "bintrail"}
+	AddTelemetryCommand(root)
+
+	for _, cmd := range []*cobra.Command{telemetryCmd, telemetryStatusCmd, telemetryOffCmd, telemetryShowCmd} {
+		var h TelemetryHook
+		h.Start(cmd)
+		if h.client != nil || h.span != nil {
+			t.Errorf("%q was instrumented; the telemetry control surface must not be", commandPath(cmd))
+		}
+	}
+
+	// A normal command still is (there is no endpoint compiled in during tests,
+	// so the client is inert — but it must exist).
+	other := &cobra.Command{Use: "status"}
+	root.AddCommand(other)
+	var h TelemetryHook
+	h.Start(other)
+	if h.client == nil {
+		t.Error("an ordinary command was not instrumented")
+	}
+}
+
+// TestCompletionMachineryIsNotInstrumented: cobra's __complete is an ordinary
+// child of root, so the root hook fires for it. Recording it would spool an
+// event on every TAB press, attempt a POST, and pay the shutdown wait on a
+// keystroke — and since sanitizeCommand rejects underscores it would all land
+// in "other", making that the largest bucket in the dataset.
+func TestCompletionMachineryIsNotInstrumented(t *testing.T) {
+	root := &cobra.Command{Use: "bintrail"}
+	// Names cobra generates itself, plus the ones it adds on demand.
+	for _, use := range []string{"__complete", "__completeNoDesc", "completion", "help"} {
+		cmd := &cobra.Command{Use: use}
+		root.AddCommand(cmd)
+		var h TelemetryHook
+		h.Start(cmd)
+		if h.client != nil || h.span != nil {
+			t.Errorf("%q was instrumented; it is not user work", use)
+		}
+		// Nested (e.g. `completion zsh`) must be exempt too.
+		sub := &cobra.Command{Use: "zsh"}
+		cmd.AddCommand(sub)
+		var hs TelemetryHook
+		hs.Start(sub)
+		if hs.client != nil {
+			t.Errorf("%q zsh was instrumented", use)
+		}
+	}
+}
+
+func TestTelemetryHookReturnsCommandErrorUnchanged(t *testing.T) {
+	want := errors.New("index unreachable")
+	root := &cobra.Command{
+		Use:           "x",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE:          func(*cobra.Command, []string) error { return want },
+	}
+	root.SetArgs(nil)
+	var h TelemetryHook
+	if got := h.Execute(root); !errors.Is(got, want) {
+		t.Errorf("Execute returned %v, want the command's own error", got)
+	}
+}
+
+// TestTelemetryHookRepanics: a crash must reach the user byte-for-byte as it
+// would without telemetry. Recording it must not turn a panic into a silent
+// exit, and the panic VALUE must not be swallowed or rewritten.
+func TestTelemetryHookRepanics(t *testing.T) {
+	root := &cobra.Command{
+		Use:  "x",
+		RunE: func(*cobra.Command, []string) error { panic("boom: /var/lib/mysql/binlog.000042") },
+	}
+	root.SetArgs(nil)
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("telemetry swallowed a panic")
+		}
+		if s, _ := r.(string); s != "boom: /var/lib/mysql/binlog.000042" {
+			t.Errorf("panic value was altered: %v", r)
+		}
+	}()
+
+	var h TelemetryHook // span is nil — Execute must be nil-safe on this path too
+	_ = h.Execute(root)
+}


### PR DESCRIPTION
closes #1059

Part of the telemetry epic #1054.

> **Stacked on #1064** — merge that first. Until it lands, this PR's diff also shows #1064's commits; it shrinks to just the wiring once #1064 is in. Branched off #1064's branch but targeting `main`, so merging #1064 with branch deletion will not close this PR.

## What this does

Wires the engine into `cliapp`, `consoleapp` and `cmd/bintrail-pg`. Cobra funnels every subcommand through the root's `PersistentPreRunE`, so this is the **only** instrumentation point — a new command needs no telemetry code at all.

`TelemetryHook` holds the shared plumbing so the recover/classify logic exists once instead of three times. Each binary gains two lines: `tel.Start(cmd)` in its hook, and `tel.Execute(rootCmd)` in place of `rootCmd.Execute()`.

- **Panics** are recorded as `error_class=internal` and re-raised, so the user-visible crash is byte-for-byte unchanged. The panic *value* is never recorded — panic messages routinely carry DSNs, table names and paths.
- **Command names** become hyphenated paths (`archive reconcile` → `archive-reconcile`), built from cobra command names, which are compile-time constants and can never carry an argument or flag value.
- **The `telemetry` subtree is exempt.** Initialising there would drain and deliver the spooled backlog moments before `telemetry off` discards it — an operator opting out would watch the tool phone home on its way out.
- **MCP server untouched**: `cmd/bintrail-mcp` has no root hook and is not wired. The structural guard for that is #1061.

## A defect this surfaced

Delivery only becomes reachable once something calls `Init`, and measured against a local endpoint it did not work: a `status` that failed in **2 ms delivered nothing** across repeated runs. The process exits microseconds after the drain goroutine starts, killing it mid-POST and leaving a claim the next fast run cannot adopt either. Telemetry would have been permanently dead for anyone whose commands are quick — while appearing healthy.

Fix: `Client.Shutdown`, a bounded 250 ms wait for an in-flight drain, plus claim reclamation dropped from 5 minutes to 1 (still 30× the drain deadline).

Re-measured with a local receiver:

| | result |
|---|---|
| run 1 (2 ms command) | event spooled, **nothing sent** — no network on the request path |
| run 2 | delivers run 1's event, total **28 ms** (~5 ms of wait) |
| run 3 (no backlog) | **23 ms** — a drain over an empty spool returns immediately, so no cost |

Received headers on the wire were `accept-encoding, content-length, content-type, host, user-agent` — the no-credential guarantee confirmed against a real listener, not just a unit test.

## Test plan

- [x] `go test ./... -count=1` — full suite passes; `go vet` and `gofmt` clean
- [x] New tests: `commandPath` including nested subcommands, the telemetry-subtree exemption, error passthrough, and that a panic is re-raised with its value intact (also exercising the nil-span path)
- [x] End-to-end against a local HTTP receiver: spool-then-deliver across runs, timings above, headers inspected
- [x] Real classification verified on a real failure: a refused index connection recorded `error_class=db_connection`

🤖 Generated with [Claude Code](https://claude.com/claude-code)