### PR TITLE
telemetry: keep beacons alive in long-running daemons

### DIFF
--- a/cliapp/agent.go
+++ b/cliapp/agent.go
@@ -289,6 +289,10 @@ func runAgent(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithCancel(cmd.Context())
 	defer cancel()
 
+	// See runStream: a long-lived process needs its own drain, off the
+	// heartbeat and reconnect paths.
+	go tel.Client().RunDaemon(ctx, cmd.Name())
+
 	var flushState *flushPipelineState
 
 	if byosMode {

--- a/cliapp/stream.go
+++ b/cliapp/stream.go
@@ -145,6 +145,12 @@ func runStream(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithCancel(cmd.Context())
 	defer cancel()
 
+	// Usage telemetry for a process that may live for months: Init's drain runs
+	// once, at startup, so without this loop a daemon's beacons would spool and
+	// age out undelivered. Own goroutine — never on the replication path. Also
+	// covers `up`, which delegates here.
+	go tel.Client().RunDaemon(ctx, cmd.Name())
+
 	// Graceful shutdown on SIGINT/SIGTERM: cancel the context so streamrun.One
 	// flushes its batch and writes a final checkpoint. (Installed before
 	// startup rather than after StartSync as it historically was — a signal

--- a/cmd/bintrail-pg/stream.go
+++ b/cmd/bintrail-pg/stream.go
@@ -199,6 +199,11 @@ func runPGStream(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithCancel(cmd.Context())
 	defer cancel()
 
+	// Usage telemetry for a months-lived process: Init's drain runs once, so
+	// without this loop a daemon's beacons would never be delivered. Own
+	// goroutine — never on the replication path.
+	go tel.Client().RunDaemon(ctx, cmd.Name())
+
 	// Graceful shutdown on SIGINT/SIGTERM: cancel the context so pgstreamrun.One
 	// flushes its batch and writes a final checkpoint before returning.
 	sigCh := make(chan os.Signal, 1)

--- a/consoleapp/watch.go
+++ b/consoleapp/watch.go
@@ -390,6 +390,10 @@ func runUpConsoleOnly(cmd *cobra.Command) error {
 	ctx, stop := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
+	// Usage telemetry for a months-lived process: Init's drain runs once, so
+	// without this loop a daemon's beacons would spool and age out undelivered.
+	go tel.Client().RunDaemon(ctx, cmd.Name())
+
 	supervisor := newMonitorSupervisor(ctx, upIndexDSN, registry, upRotationCfg.Retain)
 	cfg.MonitorCtrl = supervisor
 	if upConsoleBaselineTrigger {
@@ -535,6 +539,9 @@ func runUpStreamWithConsole(cmd *cobra.Command, args []string) error {
 
 	ctx, stop := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
+
+	// See runUpConsoleOnly: the daemon telemetry loop, off the stream path.
+	go tel.Client().RunDaemon(ctx, cmd.Name())
 
 	// The control-plane supervisor: "+ Add server" in the console starts real
 	// monitoring through it. Streams live on the daemon context (ctx), not on

--- a/internal/cli/telemetry.go
+++ b/internal/cli/telemetry.go
@@ -76,6 +76,11 @@ func uninstrumented(cmd *cobra.Command) bool {
 		strings.HasPrefix(name, "__") // __complete, __completeNoDesc
 }
 
+// Client exposes the resolved client, for long-running commands that need the
+// daemon loop (telemetry.Client.RunDaemon). Nil when the command is exempt or
+// Start was never called; every Client method tolerates that.
+func (h *TelemetryHook) Client() *telemetry.Client { return h.client }
+
 // Execute runs the command tree and records how it ended.
 //
 // A panic is recorded as an internal error and then re-raised: the panic value

--- a/internal/telemetry/daemon_test.go
+++ b/internal/telemetry/daemon_test.go
@@ -1,0 +1,181 @@
+package telemetry
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// withDaemonTick shortens the daemon loop for the duration of a test.
+func withDaemonTick(t *testing.T, d time.Duration) {
+	t.Helper()
+	prev := daemonTick
+	daemonTick = d
+	t.Cleanup(func() { daemonTick = prev })
+}
+
+func TestRunDaemonStopsOnContextCancel(t *testing.T) {
+	clearEnv(t)
+	withDaemonTick(t, time.Hour) // must not be what ends the loop
+
+	c := initDrained(t, Config{
+		Dir: t.TempDir(), Endpoint: "http://127.0.0.1:1",
+		Stderr: &bytes.Buffer{}, Interactive: boolPtr(false),
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() { defer close(done); c.RunDaemon(ctx, "stream") }()
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunDaemon did not return after ctx cancel — daemon shutdown would hang")
+	}
+}
+
+// TestRunDaemonDoesNotBeaconBeforeFirstTick pins the crash-loop protection: the
+// per-day cap is process-local, so a daemon that beaconed at startup would emit
+// one per restart. Waiting a full tick means a crash loop never beacons.
+func TestRunDaemonDoesNotBeaconBeforeFirstTick(t *testing.T) {
+	clearEnv(t)
+	withDaemonTick(t, 400*time.Millisecond)
+
+	// Count what arrives rather than what is on disk: each tick beacons AND
+	// drains, so the spool is empty again moments later either way.
+	var mu sync.Mutex
+	var delivered int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := readAll(r)
+		mu.Lock()
+		delivered += strings.Count(strings.TrimSpace(string(body)), "\n") + 1
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	count := func() int { mu.Lock(); defer mu.Unlock(); return delivered }
+
+	dir := t.TempDir()
+	c := initDrained(t, Config{
+		Dir: dir, Endpoint: srv.URL,
+		Stderr: &bytes.Buffer{}, Interactive: boolPtr(false),
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() { defer close(done); c.RunDaemon(ctx, "stream") }()
+	// Registered after withDaemonTick so it runs BEFORE the tick is restored
+	// (cleanups are LIFO): the loop must be finished before anything writes
+	// daemonTick, including on the assertion-failure path.
+	t.Cleanup(func() { cancel(); <-done })
+
+	// Well inside the first tick: a daemon that dies here (a crash loop) must
+	// have produced nothing at all — neither spooled nor sent.
+	time.Sleep(80 * time.Millisecond)
+	if n := countSpooledEvents(t, SpoolDir(dir)); n != 0 {
+		t.Fatalf("spooled %d events before the first tick", n)
+	}
+	if n := count(); n != 0 {
+		t.Fatalf("delivered %d events before the first tick", n)
+	}
+
+	// Past the first tick, exactly one beacon.
+	time.Sleep(600 * time.Millisecond)
+	if n := count(); n != 1 {
+		t.Errorf("after one tick: %d events delivered, want 1", n)
+	}
+
+	// Later ticks the same UTC day add nothing — the per-day cap holds inside
+	// the loop, so a daemon cannot beat out a fine-grained uptime trace.
+	time.Sleep(900 * time.Millisecond)
+	if n := count(); n != 1 {
+		t.Errorf("repeated ticks delivered %d events, want 1 (the per-day cap)", n)
+	}
+}
+
+// TestRunDaemonDelivers is the point of the whole loop: Init drains once at
+// startup, so a process that lives for months needs its own drain or its
+// beacons are never delivered and simply age out.
+func TestRunDaemonDelivers(t *testing.T) {
+	clearEnv(t)
+	withDaemonTick(t, 150*time.Millisecond)
+
+	var mu sync.Mutex
+	var got []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := readAll(r)
+		mu.Lock()
+		got = append(got, string(body))
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	c := initDrained(t, Config{
+		Dir: dir, Endpoint: srv.URL,
+		Stderr: &bytes.Buffer{}, Interactive: boolPtr(false),
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() { defer close(done); c.RunDaemon(ctx, "stream") }()
+	t.Cleanup(func() { cancel(); <-done })
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		n := len(got)
+		mu.Unlock()
+		if n > 0 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	cancel()
+	<-done
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(got) == 0 {
+		t.Fatal("the daemon loop delivered nothing; beacons would age out unsent")
+	}
+	if !strings.Contains(got[0], `"event_type":"daemon_beacon"`) {
+		t.Errorf("delivered payload is not a beacon: %s", got[0])
+	}
+	if strings.Contains(got[0], `"run_id"`) {
+		t.Errorf("beacon carried a run_id — a months-lived process's run_id is a longitudinal key: %s", got[0])
+	}
+}
+
+func TestRunDaemonIsInertWhenDisabled(t *testing.T) {
+	clearEnv(t)
+	withDaemonTick(t, 10*time.Millisecond)
+
+	dir := t.TempDir()
+	// No endpoint compiled in: the client is inert, so the loop must return at
+	// once rather than tick forever in the background of every daemon.
+	c := Init(Config{Dir: dir, Stderr: &bytes.Buffer{}, Interactive: boolPtr(false)})
+
+	done := make(chan struct{})
+	go func() { defer close(done); c.RunDaemon(context.Background(), "stream") }()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("RunDaemon on a disabled client did not return")
+	}
+	if entries, err := os.ReadDir(SpoolDir(dir)); err == nil && len(entries) > 0 {
+		t.Errorf("disabled daemon wrote to the spool: %v", entries)
+	}
+
+	var nilClient *Client
+	nilClient.RunDaemon(context.Background(), "stream") // must not panic
+}

--- a/internal/telemetry/daemon_test.go
+++ b/internal/telemetry/daemon_test.go
@@ -44,12 +44,12 @@ func TestRunDaemonStopsOnContextCancel(t *testing.T) {
 // TestRunDaemonDoesNotBeaconBeforeFirstTick pins the crash-loop protection: the
 // per-day cap is process-local, so a daemon that beaconed at startup would emit
 // one per restart. Waiting a full tick means a crash loop never beacons.
-func TestRunDaemonDoesNotBeaconBeforeFirstTick(t *testing.T) {
-	clearEnv(t)
-	withDaemonTick(t, 400*time.Millisecond)
-
-	// Count what arrives rather than what is on disk: each tick beacons AND
-	// drains, so the spool is empty again moments later either way.
+// deliveryCounter is a receiving endpoint that tallies NDJSON lines.
+//
+// Counting what arrives beats inspecting the spool: each tick beacons AND
+// drains, so the file is gone again moments later either way.
+func deliveryCounter(t *testing.T) (url string, count func() int) {
+	t.Helper()
 	var mu sync.Mutex
 	var delivered int
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -59,42 +59,79 @@ func TestRunDaemonDoesNotBeaconBeforeFirstTick(t *testing.T) {
 		mu.Unlock()
 		w.WriteHeader(http.StatusOK)
 	}))
-	defer srv.Close()
-	count := func() int { mu.Lock(); defer mu.Unlock(); return delivered }
+	t.Cleanup(srv.Close)
+	return srv.URL, func() int { mu.Lock(); defer mu.Unlock(); return delivered }
+}
 
-	dir := t.TempDir()
-	c := initDrained(t, Config{
-		Dir: dir, Endpoint: srv.URL,
-		Stderr: &bytes.Buffer{}, Interactive: boolPtr(false),
-	})
+// startDaemon runs the loop and stops it during cleanup.
+//
+// The cleanup is registered AFTER withDaemonTick's, and cleanups are LIFO, so
+// the loop is always finished before the tick is restored — including on the
+// assertion-failure path, where a Fatal would otherwise leave the goroutine
+// reading daemonTick while the restore writes it.
+func startDaemon(t *testing.T, c *Client) {
+	t.Helper()
 	ctx, cancel := context.WithCancel(context.Background())
-
 	done := make(chan struct{})
 	go func() { defer close(done); c.RunDaemon(ctx, "stream") }()
-	// Registered after withDaemonTick so it runs BEFORE the tick is restored
-	// (cleanups are LIFO): the loop must be finished before anything writes
-	// daemonTick, including on the assertion-failure path.
 	t.Cleanup(func() { cancel(); <-done })
+}
 
-	// Well inside the first tick: a daemon that dies here (a crash loop) must
-	// have produced nothing at all — neither spooled nor sent.
-	time.Sleep(80 * time.Millisecond)
+// TestRunDaemonDoesNotBeaconBeforeFirstTick pins the crash-loop protection: the
+// per-day cap is process-local, so a daemon that beaconed at startup would emit
+// one per restart. Waiting a full tick means a crash loop never beacons.
+//
+// The tick is deliberately far longer than the observation window. Contention
+// can only make the loop LATE, never early, so a wide margin cannot produce a
+// false failure in either direction.
+func TestRunDaemonDoesNotBeaconBeforeFirstTick(t *testing.T) {
+	clearEnv(t)
+	withDaemonTick(t, 30*time.Second)
+
+	url, count := deliveryCounter(t)
+	dir := t.TempDir()
+	c := initDrained(t, Config{
+		Dir: dir, Endpoint: url, Stderr: &bytes.Buffer{}, Interactive: boolPtr(false),
+	})
+	startDaemon(t, c)
+
+	// A daemon that dies here — a crash loop — must have produced nothing.
+	time.Sleep(250 * time.Millisecond)
 	if n := countSpooledEvents(t, SpoolDir(dir)); n != 0 {
-		t.Fatalf("spooled %d events before the first tick", n)
+		t.Errorf("spooled %d events before the first tick", n)
 	}
 	if n := count(); n != 0 {
-		t.Fatalf("delivered %d events before the first tick", n)
+		t.Errorf("delivered %d events before the first tick", n)
 	}
+}
 
-	// Past the first tick, exactly one beacon.
-	time.Sleep(600 * time.Millisecond)
+// TestRunDaemonBeaconsOncePerDay covers the other half: after a tick a beacon
+// is delivered, and further ticks the same UTC day add nothing — so a daemon
+// cannot emit a fine-grained uptime trace.
+func TestRunDaemonBeaconsOncePerDay(t *testing.T) {
+	clearEnv(t)
+	withDaemonTick(t, 50*time.Millisecond)
+
+	url, count := deliveryCounter(t)
+	c := initDrained(t, Config{
+		Dir: t.TempDir(), Endpoint: url, Stderr: &bytes.Buffer{}, Interactive: boolPtr(false),
+	})
+	startDaemon(t, c)
+
+	// Poll rather than sleep a fixed span: under load the tick, the POST and
+	// the handler are all late, and a fixed budget for them is what makes a
+	// test like this flake on a busy CI runner.
+	deadline := time.Now().Add(10 * time.Second)
+	for count() == 0 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
 	if n := count(); n != 1 {
-		t.Errorf("after one tick: %d events delivered, want 1", n)
+		t.Fatalf("after the first tick: %d events delivered, want 1", n)
 	}
 
-	// Later ticks the same UTC day add nothing — the per-day cap holds inside
-	// the loop, so a daemon cannot beat out a fine-grained uptime trace.
-	time.Sleep(900 * time.Millisecond)
+	// Many more ticks' worth of time. Contention only means FEWER ticks fire,
+	// so this can fail only if the per-day cap is genuinely broken.
+	time.Sleep(500 * time.Millisecond)
 	if n := count(); n != 1 {
 		t.Errorf("repeated ticks delivered %d events, want 1 (the per-day cap)", n)
 	}
@@ -123,14 +160,9 @@ func TestRunDaemonDelivers(t *testing.T) {
 		Dir: dir, Endpoint: srv.URL,
 		Stderr: &bytes.Buffer{}, Interactive: boolPtr(false),
 	})
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	startDaemon(t, c)
 
-	done := make(chan struct{})
-	go func() { defer close(done); c.RunDaemon(ctx, "stream") }()
-	t.Cleanup(func() { cancel(); <-done })
-
-	deadline := time.Now().Add(3 * time.Second)
+	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
 		mu.Lock()
 		n := len(got)
@@ -138,10 +170,8 @@ func TestRunDaemonDelivers(t *testing.T) {
 		if n > 0 {
 			break
 		}
-		time.Sleep(20 * time.Millisecond)
+		time.Sleep(10 * time.Millisecond)
 	}
-	cancel()
-	<-done
 
 	mu.Lock()
 	defer mu.Unlock()

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -3,6 +3,7 @@ package telemetry
 import (
 	"context"
 	"io"
+	"log/slog"
 	"net/http"
 	"os"
 	"runtime"
@@ -235,11 +236,75 @@ func (c *Client) drainAsync() {
 			debugf("drain panicked")
 		}
 	}()
+	c.drainOnce()
+}
+
+// drainOnce delivers spooled events synchronously, bounded by drainDeadline.
+// Callers are responsible for being off the hot path already.
+func (c *Client) drainOnce() {
 	ctx, cancel := context.WithTimeout(context.Background(), drainDeadline)
 	defer cancel()
 	drain(c.spoolDir, c.now(), func(body []byte) error {
 		return postNDJSON(ctx, c.http, c.endpoint, body)
 	})
+}
+
+// daemonTick is how often a daemon revisits its beacon and delivers what has
+// accumulated. Beacons are capped at one per UTC day regardless, so this
+// governs delivery latency rather than beacon frequency.
+//
+// A var rather than a const so tests can shorten it; nothing in production
+// writes it.
+var daemonTick = time.Hour
+
+// RunDaemon keeps telemetry alive for a long-running process. Run it in its own
+// goroutine; it returns when ctx is done.
+//
+// Daemons need it because Init's drain runs ONCE, at startup. A process that
+// lives for months would append beacons to a spool that nothing ever delivers,
+// and they would age out after maxSpoolAge — the liveness signal, which is the
+// entire point of a beacon, would silently never work.
+//
+// The first beacon is emitted after a full tick rather than at startup. That is
+// deliberate: the per-day cap is process-local, so a crash-looping daemon that
+// beaconed on start would emit one per restart, bounded only by the spool cap.
+// Waiting an hour means a crash loop never beacons at all, and "alive for at
+// least an hour" is the more honest liveness signal anyway.
+func (c *Client) RunDaemon(ctx context.Context, daemon string) {
+	if !c.Enabled() {
+		return
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			debugf("daemon telemetry loop panicked")
+		}
+	}()
+
+	c.logDaemonNotice()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(daemonTick):
+		}
+		c.Beacon(daemon)
+		c.drainOnce()
+	}
+}
+
+// logDaemonNotice is a daemon's one disclosure. Daemons are not interactive, so
+// they never see the first-run notice; this is their equivalent.
+//
+// It carries the cloned-image warning because that is the realistic way a
+// daemon ends up reporting without anyone on this host having chosen it: one
+// operator's opt-in baked into an AMI or a container layer becomes a whole
+// fleet's, and the machine it runs on may belong to someone who never saw the
+// prompt.
+func (c *Client) logDaemonNotice() {
+	slog.Info("usage telemetry is on; sending metadata only (command name, version, OS/arch, error class) — never your data, schemas, DSNs or hostnames",
+		"disable", "BINTRAIL_TELEMETRY=off, DO_NOT_TRACK=1, or `bintrail telemetry off`",
+		"cloned_hosts", "an image-baked setting travels with the image; see TELEMETRY.md")
 }
 
 // Enabled reports whether this client will record anything.

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -301,8 +301,14 @@ func (c *Client) RunDaemon(ctx context.Context, daemon string) {
 // operator's opt-in baked into an AMI or a container layer becomes a whole
 // fleet's, and the machine it runs on may belong to someone who never saw the
 // prompt.
+// Logged at WARN, not INFO. This is the ONLY disclosure a daemon ever makes,
+// and the host most likely to need it — one cloned from an image, where nobody
+// present chose this — is also the host most likely to be running
+// --log-level warn on a fleet. An INFO line would be silenced exactly where it
+// matters most. It stays a structured slog record rather than a raw stderr
+// write so it cannot corrupt a JSON log stream.
 func (c *Client) logDaemonNotice() {
-	slog.Info("usage telemetry is on; sending metadata only (command name, version, OS/arch, error class) — never your data, schemas, DSNs or hostnames",
+	slog.Warn("usage telemetry is on; sending metadata only (command name, version, OS/arch, error class) — never your data, schemas, DSNs or hostnames",
 		"disable", "BINTRAIL_TELEMETRY=off, DO_NOT_TRACK=1, or `bintrail telemetry off`",
 		"cloned_hosts", "an image-baked setting travels with the image; see TELEMETRY.md")
 }

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -926,6 +926,9 @@ func readAll(r *http.Request) ([]byte, error) {
 func spooledLines(t *testing.T, spoolDir string) []string {
 	t.Helper()
 	entries, err := os.ReadDir(spoolDir)
+	if os.IsNotExist(err) {
+		return nil // never spooled anything: zero events, not a failure
+	}
 	if err != nil {
 		t.Fatalf("read spool dir: %v", err)
 	}


### PR DESCRIPTION
closes #1060

Part of the telemetry epic #1054. Builds on #1064/#1066 (already merged).

## The problem this fixes

`Init`'s drain runs **exactly once**, at startup. A daemon lives for months, so its beacons would append to a spool that nothing ever delivers, and then age out after `maxSpoolAge`. The liveness signal — the entire point of a beacon — would silently never work, while looking healthy.

## What it does

`Client.RunDaemon(ctx, name)` is the loop: beacon + drain on its own goroutine, never on the replication, heartbeat or reconnect paths. Wired into `stream`, `agent`, `watch` and `bintrail-pg stream`; `up` is covered for free because it delegates to `runStream`. Each site passes `cmd.Name()`, so a beacon's `command` matches what that command's own event would have said.

**The first beacon comes after a full tick, not at startup.** The per-day cap is process-local, so a daemon that beaconed on start would emit one per restart, bounded only by the spool cap. Waiting an hour means a crash loop never beacons at all — and "alive for at least an hour" is the more honest liveness signal anyway.

**Daemons get one disclosure line at startup**, since they are not interactive and never see the first-run notice. It carries the cloned-image warning, because an image-baked opt-in travelling with the AMI is the realistic way a host ends up reporting without anyone there having chosen it.

## Two test-side defects found while writing this

- `spooledLines` treated a never-created spool directory as fatal instead of as zero events. That `Fatalf` then fired cleanup while the daemon goroutine was still reading `daemonTick` — a data race that only `-race` reports. Both fixed.
- The first version of the crash-loop test asserted on the spool, which is wrong: each tick beacons **and** drains, so the file is gone moments later either way. It now counts what an `httptest` endpoint actually receives.

## Test plan

- [x] `go test ./... -race -count=1` — full suite passes (CI's flags); `go vet`, `gofmt` clean
- [x] 10 consecutive `-race` runs of `internal/telemetry`
- [x] **Verified the crash-loop test fails against a beacon-at-startup loop** — `delivered 1 events before the first tick` — so it is a real guard, not decoration
- [x] Covered: returns on ctx cancel (a hanging loop would hang daemon shutdown), no beacon before the first tick, exactly one per UTC day across repeated ticks, delivery actually reaches the endpoint, beacons carry no `run_id`, and the loop is inert (returns at once) on a disabled or nil client

🤖 Generated with [Claude Code](https://claude.com/claude-code)