### PR TITLE
telemetry: TELEMETRY.md, and correct the README's privacy claim

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # Privacy Policy — dbtrail Claude Desktop extension (`dbtrail.mcpb`)
 
-*Last updated: 2026-07-18*
+*Last updated: 2026-07-21*
 
 This policy covers the **dbtrail desktop extension** — the `.mcpb` bundle that
 connects Claude Desktop to a self-hosted bintrail/dbtrail deployment — and the
@@ -13,6 +13,18 @@ The extension is a local bridge to **your own infrastructure**. dbtrail (the
 project and its maintainers) operates no servers in this flow, and **collects
 nothing**: no telemetry, no analytics, no crash reports, no account, no
 phone-home of any kind.
+
+That is a hard exclusion, not a default. The `bintrail-mcp` bridge is invoked
+by an AI client rather than by a person, so there is nobody present to consent
+and no terminal on which a notice could appear; it is therefore built so that
+it *cannot* report — a CI test (`TestMCPServerIsTelemetryFree`) fails the build
+if the binary ever links the telemetry package at all.
+
+The bintrail **command-line tools** are a separate matter: official release
+builds send metadata-only usage statistics (command names, version, platform,
+error class — never your data), on by default and disableable in one line. That
+is documented in full, including how to turn it off, in
+[TELEMETRY.md](TELEMETRY.md). It does not apply to this extension.
 
 ## What the extension does with data
 

--- a/README.md
+++ b/README.md
@@ -85,12 +85,30 @@ See [the demo image](docs/demo.md).
 | | [Connect an AI assistant](docs/connect-ai.md) · [MCP server](docs/mcp-server.md) | [Parquet debugging](docs/parquet-debugging.md) |
 | | [Dump & Baseline](docs/dump-and-baseline.md) · [DDL tracking](docs/ddl-tracking.md) | |
 
-## Privacy Policy
+## Privacy
 
-bintrail runs entirely in your infrastructure and collects nothing — no
-telemetry, no analytics, no phone-home. The [privacy policy](PRIVACY.md)
-covers the Claude Desktop extension (`.mcpb`) and how data moves when an AI
-client queries your deployment.
+bintrail runs entirely in your infrastructure. **Your database data never
+leaves it** — not your rows, schemas, table names, queries, hostnames, DSNs, or
+file paths.
+
+Official release builds do report **metadata-only usage statistics**: which
+command ran, whether it succeeded, a coarse error class, and your version and
+platform. It is on by default and off in one line:
+
+```sh
+bintrail telemetry off      # or: DO_NOT_TRACK=1, BINTRAIL_TELEMETRY=off
+bintrail telemetry show     # see exactly what would be sent — sends nothing
+```
+
+No identifier of any kind is stored or transmitted, so there is nothing tying
+those statistics to you or your machine. A binary you build yourself has no
+reporting address compiled in and is incapable of sending anything.
+[TELEMETRY.md](TELEMETRY.md) documents every field, every control, and the CI
+tests that enforce both.
+
+The [privacy policy](PRIVACY.md) covers the Claude Desktop extension (`.mcpb`)
+— which reports nothing at all — and how data moves when an AI client queries
+your deployment.
 
 ## License
 

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,0 +1,327 @@
+# Telemetry
+
+bintrail reports **metadata-only** usage statistics: which commands you run,
+whether they succeeded, a coarse error class, and your version and platform.
+It is **on by default** in official release builds.
+
+Turn it off with any of these — the first one that applies wins:
+
+```sh
+bintrail telemetry off      # this account, permanently
+DO_NOT_TRACK=1              # every tool on this machine that honours the convention
+BINTRAIL_TELEMETRY=off      # this environment, e.g. in a systemd unit
+bintrail --telemetry=off …  # this one invocation
+```
+
+To see exactly what would be sent, byte for byte, without sending anything:
+
+```sh
+bintrail telemetry show
+bintrail telemetry status   # is it on, and what decided that
+```
+
+## Why this document is longer than you expect
+
+bintrail reads your binary logs. It sees your schemas, your table names, your
+row data, and your credentials. A tool in that position asking to phone home
+has to be specific about what it does and does not send, and it has to make
+those claims checkable rather than merely stated. That is what the rest of this
+document is for.
+
+The claim is precisely this, in two parts:
+
+- **The payload is metadata-only, and that is verifiable from the source.** The
+  wire format is a closed list of thirteen coarse fields, enforced by tests.
+- **Received data is anonymised at ingestion, and that is an operational
+  commitment.** It is a promise about how our servers behave, which you cannot
+  verify by reading the client. It is stated separately for that reason.
+
+We do not use the unqualified word "anonymous", because the second half is not
+something you can check.
+
+## What is sent
+
+This is the complete wire payload. There are no other fields.
+
+| Field | Example | Why |
+|---|---|---|
+| `schema_version` | `1` | Lets the format evolve additively |
+| `event_type` | `command_run` | One of `command_run`, `command_error`, `daemon_beacon` |
+| `command` | `archive-reconcile` | Which command ran. Built from cobra command *names*, which are compile-time constants — never arguments or flag values |
+| `outcome` | `ok` | `ok` or `error` |
+| `error_class` | `db_connection` | A bounded class (list below). **Never** the error message |
+| `duration_bucket` | `1s-10s` | `<100ms`, `100ms-1s`, `1s-10s`, `10s-1m`, `1m-10m`, `>10m` |
+| `version` | `0.40` | Truncated to major.minor |
+| `is_release` | `true` | Official build vs source build |
+| `os` | `linux` | `runtime.GOOS` |
+| `arch` | `arm64` | `amd64`, `arm64`, or `other` |
+| `is_ci` | `false` | Whether a CI environment was detected |
+| `is_interactive` | `true` | Whether stderr is a terminal |
+| `run_id` | a UUID | Ephemeral, per process. Lets ingestion discard a re-sent batch. **Absent from daemon beacons** |
+
+A real event looks like this:
+
+```json
+{
+  "schema_version": 1,
+  "event_type": "command_error",
+  "command": "status",
+  "outcome": "error",
+  "error_class": "db_connection",
+  "duration_bucket": "<100ms",
+  "version": "0.40",
+  "is_release": true,
+  "os": "linux",
+  "arch": "amd64",
+  "is_ci": false,
+  "is_interactive": true,
+  "run_id": "470a53a1-20c2-4819-aacc-b132e516fec8"
+}
+```
+
+`error_class` is one of exactly these, and nothing else:
+
+```
+db_connection   db_permission   binlog_parse   binlog_not_found
+schema_mismatch config_invalid  flag_invalid   storage_io
+network         not_found       internal       unknown
+```
+
+### Why the values are coarse
+
+`version` is truncated and `arch` is bucketed on purpose. Joined together,
+`{version × os × arch × command mix}` starts to single out individual installs
+once the population is small — which is exactly the situation a young project
+is in. Coarsening the inputs is what stops the aggregate from becoming an
+identifier.
+
+`duration_bucket` collapses everything past ten minutes for the same kind of
+reason: a precise runtime on a long `index` or `reconstruct` is a proxy for how
+much data you have.
+
+## What is never sent
+
+Not "is not currently sent" — cannot be, by the structure of the code:
+
+- Connection strings, DSNs, or any credential
+- Hostnames, IP addresses, or server identifiers (`bintrail_id`, server UUIDs)
+- Schema, table, or column names
+- Primary key values or any row data
+- Query text, or the SQL that produced a change
+- File paths, binlog file names, or binlog positions
+- GTIDs
+- Flag values or positional arguments
+- Verbatim error strings or panic messages
+- Row counts, table sizes, or any measure of your data volume
+
+## No persistent identifier
+
+Nothing that identifies your installation is written to disk or sent. There is
+no install UUID, no machine fingerprint, no account linkage.
+
+`run_id` is generated fresh in memory each time a command runs, lives in the
+spooled event only until that batch is delivered or expires, and never appears
+in a daemon beacon — a process that runs for months would otherwise carry one
+stable identifier for months, which is exactly the thing this design refuses to
+create.
+
+The cost is real and worth stating: **we cannot measure active users or
+retention.** Daily totals, version adoption, command mix, error rates and
+platform mix are what remain. That trade was made deliberately.
+
+## How it is sent
+
+**No command ever makes a network call to report itself.** Finishing a command
+appends one line to a local file. Delivery happens on a *later* run.
+
+- Events are appended to `~/.config/bintrail/telemetry-spool/<date>.ndjson`
+  (mode `0600`).
+- Starting a command kicks off a background attempt to deliver whatever earlier
+  runs left there, with a 2-second deadline, concurrent with your command.
+- On exit, a command waits at most 250 ms for a delivery already in flight.
+  When there is nothing pending this costs nothing.
+- If delivery fails, the batch is dropped. There is no retry queue, so an
+  offline machine never builds a backlog that floods out later.
+- The spool is capped at 5 MB per day and anything undelivered is discarded
+  after 7 days.
+- When several bintrail processes share a home directory, each batch is claimed
+  by an atomic rename, so a batch is never sent twice or lost between them.
+
+Delivery goes to `https://telemetry.dbtrail.io` — a host separate from the
+authenticated dbtrail API, so telemetry traffic cannot be correlated with an
+account at the network layer. The request carries **no `Authorization` header,
+no cookie, and no account identifier**.
+
+### Daemons
+
+Long-running commands (`stream`, `agent`, `up`, `watch`) send at most **one
+beacon per UTC day**, and the first only after they have been running for an
+hour. A finer cadence would reconstruct your uptime and maintenance windows; a
+beacon at startup would mean a crash-looping daemon emitted one per restart.
+
+Beacons carry no `run_id`.
+
+Because daemons have no terminal, they log one line at startup when telemetry
+is on. It is logged at `WARN` so that a host running at a raised log level — a
+fleet machine, typically — still sees it.
+
+## Controls
+
+The first that applies decides. `bintrail telemetry status` will tell you which
+one did.
+
+| | Effect |
+|---|---|
+| `DO_NOT_TRACK=1` | Off. Checked before any file is read or written |
+| `--telemetry=on\|off` | Off (or on) for this invocation |
+| `BINTRAIL_TELEMETRY=on\|off` | Off (or on) for this environment |
+| `~/.config/bintrail/telemetry.json` | Written by `bintrail telemetry on\|off` |
+| *(nothing set)* | **On** |
+
+`bintrail telemetry off` also deletes anything already spooled locally, so
+opting out does not leave earlier events sitting on your disk waiting for a
+delivery that will never come.
+
+Additionally, and only ever to suppress:
+
+- **CI is detected** (`CI`, `GITHUB_ACTIONS`, `TF_BUILD`, `TRAVIS`, `CIRCLECI`,
+  `JENKINS_URL`, `BUILDKITE`, `GITLAB_CI`) and reporting is disabled. A build
+  robot is not a person making a choice.
+- **No home directory** (distroless images, systemd `DynamicUser`, a scrubbed
+  environment) disables everything silently.
+
+None of these can turn telemetry *on*.
+
+`BINTRAIL_TELEMETRY` is intentionally absent from `bintrail config init`'s
+generated template. That file's variables are applied to command-line flags,
+and routing consent through it would make an environment setting
+indistinguishable from an explicit `--telemetry` flag in `telemetry status`.
+
+### Diagnosing
+
+Telemetry swallows every error by design, so that it can never change a
+command's behaviour, output, or exit code. If you want to see what it is doing:
+
+```sh
+BINTRAIL_TELEMETRY_DEBUG=1 bintrail status …
+```
+
+## Builds that cannot report at all
+
+The ingestion address is injected at build time. It is **empty by default**,
+which makes any binary you build yourself physically incapable of reporting —
+no address, no network path:
+
+```console
+$ go build ./cmd/bintrail && ./bintrail telemetry status
+Telemetry:    OFF
+Consent:      on (decided by: default)
+Endpoint:     not compiled in — this build cannot send anything
+```
+
+This is the assertion a distribution packager needs (Debian and Fedora both
+forbid phone-home *capability*, not merely phone-home behaviour), and it is why
+the test suite — including the end-to-end test that builds and runs the real
+binary — cannot emit telemetry.
+
+## Which surfaces report
+
+| Surface | Reports? | |
+|---|---|---|
+| `bintrail`, `bintrail-pg` commands | Yes, by default | |
+| Daemons (`stream`, `agent`, `up`, `watch`) | Yes, one beacon per day | |
+| `bintrail-console serve`, `bintrail shim` | Command events only | They record like any command; they do not beacon |
+| **Demo image** (`ghcr.io/dbtrail/bintrail-demo`) | **Never** | Hard-disabled in the image and in its entrypoint, and asserted by its smoke test. An evaluation image must not phone home from a laptop |
+| **MCP server** (`bintrail-mcp`) | **Never** | Invoked by an AI agent inside an editor or chat session — no human is present to consent and no terminal exists for a notice. It cannot link the telemetry package at all |
+| **Web console UI** | **Never** | No JavaScript beacon, ever. The console frontend has no third-party dependencies and makes no outbound requests |
+
+## Cloned machines — the honest caveat
+
+Telemetry state lives in a home directory. If you enable it, then bake that
+machine into an AMI, a container layer, or a golden image, **the setting travels
+with the image**. Every host cloned from it will report, and nobody on those
+hosts made that choice.
+
+There is no way for us to detect this, so: set `BINTRAIL_TELEMETRY=off` (or
+`DO_NOT_TRACK=1`) in your base image if that is your situation. Daemons log
+their startup disclosure partly so a cloned host is not silent about it.
+
+## What happens to received data
+
+These are operational commitments about our infrastructure, not properties you
+can verify by reading this repository. They are listed separately for that
+reason.
+
+- Source IP addresses are truncated or dropped at the edge **before anything is
+  persisted**, and are never joined to a payload. This includes load-balancer
+  and CDN logs, which retain client IPs independently of application settings.
+- `run_id` is used to discard duplicate batches at ingestion and is then dropped
+  from the retained store, so per-install command sequences cannot be
+  reconstructed.
+- Raw events are retained for at most 90 days, after which only aggregates
+  remain.
+
+## Not a sales channel
+
+Telemetry is **never** used for sales, lead generation, or targeting
+free-to-paid conversion — and is architecturally incapable of it. The requests
+are unauthenticated and carry no account identifier, so a received event cannot
+be attributed to a customer, a company, or a person even in principle.
+
+## Legal basis and your rights
+
+- **Controller**: dbtrail. Contact via the repository issue tracker or the
+  address published at <https://dbtrail.io>.
+- **Purposes**: deciding what to build next (which commands are actually used)
+  and finding reliability problems (which error classes are rising).
+- **Lawful basis**: legitimate interest in maintaining and improving the
+  software, with the objection right exercisable at any time by the one-line
+  opt-out above.
+- **Recipients**: nobody. Data is not sold, shared, or passed to advertising or
+  analytics third parties. There is no third-party analytics SDK in this
+  codebase.
+- **Retention**: raw events ≤ 90 days; aggregates indefinitely.
+- **Your rights**: access, erasure, restriction and objection. Because no
+  identifier is stored, we cannot locate "your" events to export or delete them
+  on request — which is a direct consequence of collecting no identifier, not an
+  evasion. Turning telemetry off stops all future collection immediately.
+
+Under CCPA/CPRA the payload is deidentified: it contains no identifier and no
+information reasonably linkable to a household or individual, and we make no
+attempt to reidentify it.
+
+## Counting downloads
+
+Release download counts and container image pulls are observed **server-side**,
+from ordinary web request logs with truncated IPs — the same way any download
+page works. That is a separate mechanism from everything above: it involves no
+code in the binary, nothing stored on your machine, and it happens whether or
+not you have telemetry enabled. It is what tells us how many installs exist;
+telemetry is only what tells us which commands they run.
+
+The binary sends no first-run or install ping.
+
+## Verifying the claims
+
+These run in CI on every change. They are the reason the guarantees above are
+statements of fact rather than intent.
+
+| Test | What it proves |
+|---|---|
+| `TestTelemetryImportsNothingFromThisModule` | The telemetry package links **no** other package in this repository. It cannot reach the code that knows about DSNs, rows, schemas, or server identity — whatever anyone later writes inside it |
+| `TestTelemetryPackagesAreSelfContained` | The same, for direct imports, so the boundary cannot be routed around via a helper package |
+| `TestAllowlistMatchesStruct` | The field list above is the whole field list |
+| `TestMarshalledEventHasOnlyAllowedKeys` | The serialized bytes contain nothing else either |
+| `TestRequestCarriesNoCredential` | No `Authorization`, cookie, API key, or server UUID on the request |
+| `TestClassifyErrorNeverLeaksMessage` | An error carrying a DSN and a table name still yields only a bounded class |
+| `TestRootHookIsNotShadowed` (×3 binaries) | Instrumentation cannot be silently lost from part of the command tree |
+| `TestMCPServerIsTelemetryFree` | The MCP server cannot link the telemetry package |
+| `TestRunDaemonDoesNotBeaconBeforeFirstTick` | A crash-looping daemon emits nothing |
+| `TestBeaconCarriesNoRunID` | Daemon beacons carry no identifier |
+| Demo image smoke test | The demo image's telemetry guard is present and applies to every process in the container |
+
+The most load-bearing of these is the first. A field allowlist alone cannot
+establish the metadata-only claim, because an allowlist checks field *names* and
+is blind to where a value came from — nothing in it would stop someone
+assigning a server UUID to `run_id`. A package that cannot import the code
+holding that UUID has no such option.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -585,3 +585,25 @@ If you see GTID-related errors:
 - Ensure `--server-id` is unique across all MySQL replication clients connected to the source
 - Do not use server IDs in the range the source MySQL uses (check `SHOW VARIABLES LIKE 'server_id'` on source)
 - For RDS/Aurora: use server IDs > 1000000 to avoid conflicts with AWS-managed replicas
+
+## Usage telemetry
+
+Official release builds report metadata-only usage statistics (command name,
+version, OS/arch, error class — never your data). Long-running units send at
+most one beacon per UTC day and log one line at startup when reporting is on.
+
+To disable it across a deployment, set it in the unit file rather than per
+host:
+
+```ini
+[Service]
+Environment=BINTRAIL_TELEMETRY=off
+```
+
+Note that telemetry state otherwise lives in a home directory, so **a setting
+baked into a golden image travels with the image** — every host cloned from it
+inherits the choice made on the machine the image was built from. Setting the
+environment variable in the unit is what makes that explicit.
+
+A binary you build yourself has no reporting address compiled in and cannot
+send anything at all. See [TELEMETRY.md](../TELEMETRY.md).

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -497,3 +497,20 @@ dbtrail depends on DuckDB (`duckdb-go`) for querying Parquet archives. DuckDB's 
 ## Full demo
 
 For a complete demo stack with traffic generation, Prometheus, and Grafana dashboards, see `demo/compose.yml` and `demo/README.md`.
+
+## Usage telemetry
+
+Official release images report metadata-only usage statistics (command name,
+version, OS/arch, error class — never your data). Disable it for a stack in
+`docker-compose.yml`:
+
+```yaml
+services:
+  bintrail:
+    environment:
+      BINTRAIL_TELEMETRY: "off"     # or DO_NOT_TRACK=1
+```
+
+The **demo image** (`ghcr.io/dbtrail/bintrail-demo`) never reports, regardless
+of configuration — it is hard-disabled in the image and asserted by its smoke
+test. See [TELEMETRY.md](../TELEMETRY.md).

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -325,3 +325,23 @@ The metrics HTTP server shuts down gracefully (5-second timeout) on command exit
 | **Suitable for systemd** | `Type=oneshot` | `Type=simple`, `Restart=always` |
 
 For managed MySQL, `stream` is the only option. For self-managed MySQL, both work — `index` is simpler for batch backfill, `stream` is better for continuous real-time indexing.
+
+## Usage telemetry
+
+`stream` reports metadata-only usage statistics in official release builds: at
+most one "still running" beacon per UTC day, plus the command's own outcome.
+Never your rows, schemas, table names, hostnames, DSNs, or binlog positions.
+
+It never runs on the replication path — events are appended to a local file and
+delivered by a background goroutine — so it cannot introduce replication lag.
+
+The daemon logs one line at startup when reporting is on. Disable it for a host
+or a fleet with either of:
+
+```sh
+BINTRAIL_TELEMETRY=off
+DO_NOT_TRACK=1
+```
+
+Full details, including every field and the tests that enforce them:
+[TELEMETRY.md](../TELEMETRY.md).

--- a/internal/telemetry/docs_test.go
+++ b/internal/telemetry/docs_test.go
@@ -1,0 +1,146 @@
+package telemetry
+
+import (
+	"os"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+)
+
+const telemetryDocPath = "../../TELEMETRY.md"
+
+// section returns the body of a "## <title>" section of the document.
+func section(t *testing.T, doc, title string) string {
+	t.Helper()
+	start := strings.Index(doc, "## "+title+"\n")
+	if start < 0 {
+		t.Fatalf("TELEMETRY.md has no %q section", title)
+	}
+	rest := doc[start+len("## "+title+"\n"):]
+	if end := strings.Index(rest, "\n## "); end >= 0 {
+		return rest[:end]
+	}
+	return rest
+}
+
+func readDoc(t *testing.T) string {
+	t.Helper()
+	data, err := os.ReadFile(telemetryDocPath)
+	if err != nil {
+		t.Fatalf("read TELEMETRY.md: %v", err)
+	}
+	return string(data)
+}
+
+var docFieldRow = regexp.MustCompile("(?m)^\\| `([a-z_]+)` \\|")
+
+// TestDocumentedFieldsMatchTheWireFormat is the anti-drift guard.
+//
+// TELEMETRY.md is the public promise about what leaves a user's machine. A
+// document that quietly falls behind the code is worse than no document,
+// because people act on it: someone reads the field table, sees nothing
+// alarming, and enables telemetry on a fleet. This test means the table cannot
+// fall behind — adding a field to the wire format without documenting it fails
+// here.
+func TestDocumentedFieldsMatchTheWireFormat(t *testing.T) {
+	body := section(t, readDoc(t), "What is sent")
+
+	var documented []string
+	for _, m := range docFieldRow.FindAllStringSubmatch(body, -1) {
+		documented = append(documented, m[1])
+	}
+	if len(documented) == 0 {
+		t.Fatal("found no field rows in the 'What is sent' table; the table's shape changed and this guard stopped guarding")
+	}
+
+	want := slices.Clone(AllowedFields)
+	slices.Sort(want)
+	got := slices.Clone(documented)
+	slices.Sort(got)
+
+	if !slices.Equal(got, want) {
+		for _, f := range want {
+			if !slices.Contains(got, f) {
+				t.Errorf("field %q is on the wire but not documented in TELEMETRY.md", f)
+			}
+		}
+		for _, f := range got {
+			if !slices.Contains(want, f) {
+				t.Errorf("TELEMETRY.md documents field %q, which is not on the wire", f)
+			}
+		}
+	}
+}
+
+// TestDocumentedErrorClassesMatchTheTaxonomy: the document lists the complete
+// set of error classes and says it is complete. Keep that true.
+func TestDocumentedErrorClassesMatchTheTaxonomy(t *testing.T) {
+	body := section(t, readDoc(t), "What is sent")
+
+	for class := range classes {
+		if !strings.Contains(body, class) {
+			t.Errorf("error class %q is emitted but not listed in TELEMETRY.md", class)
+		}
+	}
+}
+
+// TestDocumentedDurationBucketsMatch: same, for the duration buckets, which are
+// the other closed enumeration a reader is invited to rely on.
+func TestDocumentedDurationBucketsMatch(t *testing.T) {
+	body := section(t, readDoc(t), "What is sent")
+
+	for _, bucket := range []string{"<100ms", "100ms-1s", "1s-10s", "10s-1m", "1m-10m", ">10m"} {
+		if !strings.Contains(body, bucket) {
+			t.Errorf("duration bucket %q is emitted but not listed in TELEMETRY.md", bucket)
+		}
+	}
+}
+
+// TestReadmeDisclosesTelemetry guards a specific past mistake: the README used
+// to say bintrail "collects nothing — no telemetry, no analytics, no
+// phone-home", which stopped being true the day this feature shipped. For a
+// tool sold on data sovereignty, a front-page claim that contradicts the
+// binary's behaviour is worse than the behaviour itself.
+//
+// The README must therefore link the telemetry document and state the opt-out
+// where a reader looking for it would look.
+func TestReadmeDisclosesTelemetry(t *testing.T) {
+	data, err := os.ReadFile("../../README.md")
+	if err != nil {
+		t.Fatalf("read README.md: %v", err)
+	}
+	readme := string(data)
+
+	for _, want := range []string{"TELEMETRY.md", "bintrail telemetry off"} {
+		if !strings.Contains(readme, want) {
+			t.Errorf("README.md does not mention %q; telemetry must be disclosed and its opt-out reachable from the front page", want)
+		}
+	}
+	// The exact phrasing that became false. Catches a revert or a copy-paste
+	// from an older revision.
+	for _, stale := range []string{"no telemetry, no analytics", "no phone-home"} {
+		if strings.Contains(readme, stale) {
+			t.Errorf("README.md still claims %q, which is not true of release builds", stale)
+		}
+	}
+}
+
+// TestDocumentedControlsExist keeps the opt-out instructions honest: every
+// control the document tells a user to reach for must be one the code actually
+// honours. A stale instruction here is the worst kind of documentation bug —
+// someone believes they have opted out and has not.
+func TestDocumentedControlsExist(t *testing.T) {
+	doc := readDoc(t)
+	for _, control := range []string{
+		"DO_NOT_TRACK=1",
+		EnvVar + "=off",
+		"bintrail telemetry off",
+		"--telemetry=off",
+		DebugEnvVar,
+	} {
+		if !strings.Contains(doc, control) {
+			t.Errorf("TELEMETRY.md does not mention the %q control", control)
+		}
+	}
+}


### PR DESCRIPTION
closes #1062

Final issue of the telemetry epic #1054.

## The urgent part

The README claimed bintrail **"collects nothing — no telemetry, no analytics, no phone-home"**. That stopped being true the day this feature shipped. For a tool sold on data sovereignty, a front-page claim contradicting the binary's behaviour is worse than the behaviour it misdescribes — it is the single line a critic would screenshot.

Rewritten to say plainly what does and does not leave the machine, with the one-line opt-out where someone looking for it would look.

`PRIVACY.md` carried the same phrasing, but scoped to the Claude Desktop extension — where it **remains true**, since `bintrail-mcp` cannot link the telemetry package at all. A reader could reasonably generalise it, so it now explains that the exclusion is structural (CI-enforced) and points to TELEMETRY.md for the CLI.

## TELEMETRY.md

Every field with an example and a rationale; the complete never-sent list; spool and delivery mechanics; control precedence; the per-surface matrix; the cloned-image hazard; the ingestion commitments (labelled as operational promises, distinct from the source-verifiable client guarantees); GDPR Art 13 elements; and the explicit non-goal that telemetry is never used for sales or lead generation and is architecturally incapable of it.

It avoids the unqualified word "anonymous" throughout, because half the claim — what happens after receipt — is not something a reader can verify from this repository, and says so.

## Anti-drift tests

A document that quietly falls behind the code is worse than no document, because people act on it. Five tests:

| Test | Guards |
|---|---|
| `TestDocumentedFieldsMatchTheWireFormat` | The field table equals the wire allowlist, **both directions** |
| `TestDocumentedErrorClassesMatchTheTaxonomy` | Every emitted class is listed |
| `TestDocumentedDurationBucketsMatch` | Every emitted bucket is listed |
| `TestDocumentedControlsExist` | Every control the doc tells you to use is one the code honours — a stale opt-out instruction is the worst bug available here, because someone believes they opted out and did not |
| `TestReadmeDisclosesTelemetry` | README links TELEMETRY.md and states the opt-out, and **fails if the retired "no telemetry, no analytics" phrasing returns** |

Verified by deletion: removing the `is_ci` row fails with `field "is_ci" is on the wire but not documented in TELEMETRY.md`.

## Also

- `docs/streaming.md`, `docs/deployment.md`, `docs/docker.md` gain short, surface-appropriate notes — the systemd unit form, the compose form, and for streaming the fact that nothing runs on the replication path.
- `BINTRAIL_TELEMETRY` is deliberately **not** added to `config init`'s template: those variables are applied to flags, which would make an environment setting indistinguishable from an explicit `--telemetry` in `telemetry status`. Documented rather than papered over.

## Test plan

- [x] `go test ./... -race -count=1`, `go vet`, `gofmt` clean
- [x] All five doc guards pass; field guard verified to fail on a removed row

🤖 Generated with [Claude Code](https://claude.com/claude-code)