### PR TITLE
Activate usage telemetry endpoint in release builds (#1577)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -30,6 +30,10 @@ builds:
       - -X main.Version={{.Version}}
       - -X main.CommitSHA={{.Commit}}
       - -X main.BuildDate={{.Date}}
+      # Telemetry ingestion endpoint (nethalo/dbtrail#1577). Empty in a plain
+      # `go build`; official release binaries point at the metadata-only
+      # ingestion host. bintrail-mcp is deliberately NOT instrumented.
+      - -X github.com/dbtrail/dbtrail/internal/telemetry.endpoint=https://telemetry.dbtrail.com/
 
   - id: bintrail-mcp
     binary: bintrail-mcp
@@ -88,6 +92,10 @@ builds:
       - -X main.Version={{.Version}}
       - -X main.CommitSHA={{.Commit}}
       - -X main.BuildDate={{.Date}}
+      # Telemetry ingestion endpoint (nethalo/dbtrail#1577). Empty in a plain
+      # `go build`; official release binaries point at the metadata-only
+      # ingestion host. bintrail-mcp is deliberately NOT instrumented.
+      - -X github.com/dbtrail/dbtrail/internal/telemetry.endpoint=https://telemetry.dbtrail.com/
 
   # bintrail-pg: the PostgreSQL-source binary (#534). Build-identical to
   # bintrail-console — it links DuckDB via the shared read plane (CGO) plus the
@@ -117,6 +125,10 @@ builds:
       - -X main.Version={{.Version}}
       - -X main.CommitSHA={{.Commit}}
       - -X main.BuildDate={{.Date}}
+      # Telemetry ingestion endpoint (nethalo/dbtrail#1577). Empty in a plain
+      # `go build`; official release binaries point at the metadata-only
+      # ingestion host. bintrail-mcp is deliberately NOT instrumented.
+      - -X github.com/dbtrail/dbtrail/internal/telemetry.endpoint=https://telemetry.dbtrail.com/
 
 archives:
   - formats:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Usage telemetry is now active in official release builds** (#1577). The ingestion endpoint (`internal/telemetry.endpoint`) is set via `-ldflags` for the `bintrail`, `bintrail-console`, and `bintrail-pg` release binaries — `bintrail-mcp` stays uninstrumented. Delivery goes to `https://telemetry.dbtrail.com`, a metadata-only ingestion host separate from the authenticated API: the request carries no credential and no account identifier, source IPs are stripped at the edge before any storage, and nothing beyond the closed 13-field allowlist (documented in `TELEMETRY.md`) is ever transmitted. A plain `go build` and the entire test suite remain inert (`telemetry status` → `not compiled in`). Opt out at any time with `bintrail telemetry off`, `DO_NOT_TRACK=1`, `BINTRAIL_TELEMETRY=off`, or `--telemetry=off`; run `bintrail telemetry show` to print the exact bytes that would be sent.
+
 ## [0.41.0] - 2026-07-21
 
 ### Added

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -147,7 +147,7 @@ appends one line to a local file. Delivery happens on a *later* run.
 - When several bintrail processes share a home directory, each batch is claimed
   by an atomic rename, so a batch is never sent twice or lost between them.
 
-Delivery goes to `https://telemetry.dbtrail.io` — a host separate from the
+Delivery goes to `https://telemetry.dbtrail.com` — a host separate from the
 authenticated dbtrail API, so telemetry traffic cannot be correlated with an
 account at the network layer. The request carries **no `Authorization` header,
 no cookie, and no account identifier**.

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -17,7 +17,7 @@ import (
 
 // endpoint is the ingestion URL, injected at build time:
 //
-//	-ldflags "-X github.com/dbtrail/dbtrail/internal/telemetry.endpoint=https://telemetry.dbtrail.io/v1/events"
+//	-ldflags "-X github.com/dbtrail/dbtrail/internal/telemetry.endpoint=https://telemetry.dbtrail.com/"
 //
 // It is EMPTY by default, which makes telemetry inert by construction: a
 // plain `go build`, `go test`, or a distribution packager's build produces a


### PR DESCRIPTION
Refs #1577. Turns on the metadata-only usage telemetry shipped inert in #1054 (v0.41.0).

## What changes
- `.goreleaser.yaml`: sets `-X github.com/dbtrail/dbtrail/internal/telemetry.endpoint=https://telemetry.dbtrail.com/` on the **bintrail**, **bintrail-console**, and **bintrail-pg** release builds. `bintrail-mcp` is deliberately left uninstrumented.
- Corrects two stale `telemetry.dbtrail.io/v1/events` references (deployed endpoint is `telemetry.dbtrail.com` root) in the package doc comment and `TELEMETRY.md`.
- `CHANGELOG.md`: `[Unreleased]` entry.

## Invariants preserved
- A plain `go build` and the full test suite remain **inert** — the endpoint is empty unless GoReleaser injects it, so `telemetry status` still reports `not compiled in` for non-release builds. The CI trust guards (no-credential, single-hook, MCP-can't-link, structural import boundary) are unchanged.
- The wire payload is still the closed 13-field allowlist; opt-out (`telemetry off` / `DO_NOT_TRACK=1` / `BINTRAIL_TELEMETRY=off` / `--telemetry=off`) is unchanged.

## Activation is a release, gated on verification
Telemetry only begins flowing when a release is cut with this on `main`. The ingestion backend is deployed and verified end-to-end (204, run_id-stripped, IP-free, date-only partition). The pre-cutover check — grep every log sink on the ingestion host for a client IP — must pass before the release tag is pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)