### PR TITLE
console: opt out of usage telemetry from the web UI (#1577)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Turn usage telemetry off from the web console** (#1577). The Storage page (under `bintrail-console watch`) grows a **Usage telemetry** card showing the current state and a one-click opt-out. Turning it off both persists the machine-wide choice to the consent file (honored by every bintrail process from its next run) **and** stops the running daemon's beacons immediately — no restart — via a new live-consent toggle on the telemetry client (`SetRuntimeConsent`, an atomically-flipped decision). When a higher-precedence control (`DO_NOT_TRACK`, `BINTRAIL_TELEMETRY`, or `--telemetry`) is in charge, the card explains that and leaves the toggle to that control. Writing the consent file is local machine config, not a data write, so the console's read-only-over-data boundary is unchanged. New `GET`/`POST /api/telemetry`.
+
 ### Changed
 - **Usage telemetry is now active in official release builds** (#1577). The ingestion endpoint (`internal/telemetry.endpoint`) is set via `-ldflags` for the `bintrail`, `bintrail-console`, and `bintrail-pg` release binaries — `bintrail-mcp` stays uninstrumented. Delivery goes to `https://telemetry.dbtrail.com`, a metadata-only ingestion host separate from the authenticated API: the request carries no credential and no account identifier, source IPs are stripped at the edge before any storage, and nothing beyond the closed 13-field allowlist (documented in `TELEMETRY.md`) is ever transmitted. A plain `go build` and the entire test suite remain inert (`telemetry status` → `not compiled in`). Opt out at any time with `bintrail telemetry off`, `DO_NOT_TRACK=1`, `BINTRAIL_TELEMETRY=off`, or `--telemetry=off`; run `bintrail telemetry show` to print the exact bytes that would be sent.
 

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -13,6 +13,11 @@ BINTRAIL_TELEMETRY=off      # this environment, e.g. in a systemd unit
 bintrail --telemetry=off …  # this one invocation
 ```
 
+Or, if you run the web console (`bintrail-console watch`): open **Storage →
+Usage telemetry** and click the toggle. It stops the running daemon's beacons
+immediately (no restart) and records the same machine-wide choice as
+`bintrail telemetry off`.
+
 To see exactly what would be sent, byte for byte, without sending anything:
 
 ```sh
@@ -175,8 +180,14 @@ one did.
 | `DO_NOT_TRACK=1` | Off. Checked before any file is read or written |
 | `--telemetry=on\|off` | Off (or on) for this invocation |
 | `BINTRAIL_TELEMETRY=on\|off` | Off (or on) for this environment |
-| `~/.config/bintrail/telemetry.json` | Written by `bintrail telemetry on\|off` |
+| `~/.config/bintrail/telemetry.json` | Written by `bintrail telemetry on\|off`, or by the web console's **Storage → Usage telemetry** toggle |
 | *(nothing set)* | **On** |
+
+The console toggle writes that same file (so every bintrail process on the
+machine honours it from its next run) *and* flips the running `watch` daemon's
+live decision, so its beacons stop the moment you opt out. When a
+higher-precedence control above is in charge, the console shows that and defers
+to it rather than pretending to override it.
 
 `bintrail telemetry off` also deletes anything already spooled locally, so
 opting out does not leave earlier events sitting on your disk waiting for a

--- a/consoleapp/watch.go
+++ b/consoleapp/watch.go
@@ -417,6 +417,9 @@ func runUpConsoleOnly(cmd *cobra.Command) error {
 		return err
 	}
 
+	// Wire the live telemetry client so the console's opt-out toggle stops this
+	// running daemon's beacons immediately, not just on the next start.
+	cfg.Telemetry = tel.Client()
 	srv, err := console.New(cfg)
 	if err != nil {
 		return err
@@ -581,6 +584,9 @@ func runUpStreamWithConsole(cmd *cobra.Command, args []string) error {
 		defer stopMetrics()
 	}
 
+	// Wire the live telemetry client so the console's opt-out toggle reaches
+	// this running daemon (see the other console.New site).
+	cfg.Telemetry = tel.Client()
 	srv, err := console.New(cfg)
 	if err != nil {
 		return err

--- a/docs/console.md
+++ b/docs/console.md
@@ -119,7 +119,8 @@ and searching events:
    was detected. Both fire for any source family. See
    [the continuity signal](rotation-and-status.md#stream-continuity-no-data-lost).
 6. **Settings** (under `watch` only) — **Storage** (rotation policy,
-   per-source S3 archiving, baseline snapshots, AWS credential signals — see
+   per-source S3 archiving, baseline snapshots, AWS credential signals, and a
+   usage-telemetry opt-out — see
    [The Storage page](#the-storage-page)) and **Rotation** (opens the
    rotation dialog).
 
@@ -319,6 +320,12 @@ across the rotation dialog and the per-server edit form):
   start from. The empty states explain how to produce a first baseline
   (`bintrail dump` → `bintrail baseline`). When the **Create baseline** button
   is enabled (see below) it sits in this panel's header.
+- **Usage telemetry** — the current state of dbtrail's metadata-only usage
+  telemetry and a one-click opt-out. Turning it off stops this `watch` daemon's
+  beacons immediately (no restart) and records the machine-wide choice, exactly
+  like `bintrail telemetry off`. When an environment variable (`DO_NOT_TRACK`,
+  `BINTRAIL_TELEMETRY`) or the `--telemetry` flag already controls it, the card
+  says so and defers to that. See [TELEMETRY.md](../TELEMETRY.md).
 
 #### Creating a baseline from the console
 

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -1810,23 +1810,24 @@ async function renderStorage() {
   // instead of one error wiping the whole page. (A 401 inside api() raises the
   // sign-in gate and bumps serverGen, so the stale-render guard below bails.)
   const asErr = (err) => ({ error: (err && err.message) || String(err) });
-  const [serversRes, rotation, storage, baselines] = await Promise.all([
+  const [serversRes, rotation, storage, baselines, telemetry] = await Promise.all([
     api("/api/servers").catch(asErr),
     api("/api/rotation").catch(asErr),
     api("/api/storage").catch(asErr),
     api("/api/baselines").catch(asErr),
+    api("/api/telemetry").catch(asErr),
   ]);
   if (gen !== serverGen) return;
   // Same guard as renderOverview: a throw inside the build must show an
   // error, never leave the "Loading…" skeleton up forever.
   try {
-    buildStorage(serversRes, rotation, storage, baselines);
+    buildStorage(serversRes, rotation, storage, baselines, telemetry);
   } catch (err) {
     const v = VIEW(); clear(v); v.append(pageHead("Storage", null)); renderError(v, err);
   }
 }
 
-function buildStorage(serversRes, rotation, storage, baselines) {
+function buildStorage(serversRes, rotation, storage, baselines, telemetry) {
   // serversRes is the raw /api/servers payload or {error} — archivingPanel
   // must be able to tell "failed to load" from "genuinely no sources", or a
   // transient 500 would render the affirmative "No monitored sources yet" lie.
@@ -1842,6 +1843,7 @@ function buildStorage(serversRes, rotation, storage, baselines) {
   const cur = servers.find((s) => s.id === (currentServer || defaultServerId));
   cards.append(rotationCard(rotation));
   cards.append(credentialsCard(storage));
+  cards.append(telemetryCard(telemetry));
   cards.append(baselineSummaryCard(baselines, cur));
   v.append(cards);
 
@@ -1899,6 +1901,49 @@ function credentialsCard(storage) {
   card.append(adv);
   card.append(el("p", { class: "form-hint", text: "Note: an IAM role can still be active even if none of the signals above show as set." }));
   return card;
+}
+
+// telemetryCard shows the machine-wide usage-telemetry state and an opt-out
+// toggle. Turning it off here stops THIS running daemon's beacons immediately
+// (the daemon wired its live client) and persists the choice for every bintrail
+// process on the machine.
+function telemetryCard(t) {
+  const card = el("div", { class: "card" }, el("div", { class: "card-title", text: "Usage telemetry" }));
+  if (!t || t.error) {
+    card.append(el("p", { class: "form-hint", text: "Could not read telemetry state" + (t && t.error ? ": " + t.error : ".") }));
+    return card;
+  }
+  if (!t.endpoint_set) {
+    card.append(el("p", { class: "stg-hint", text: "This build sends no telemetry — no endpoint is compiled in." }));
+    return card;
+  }
+  card.append(el("p", { class: "stg-hint", text: t.reporting
+    ? "Sending metadata-only usage stats (command names, version, OS/arch, a bounded error class) to help prioritize the roadmap. Never your data, schemas, tables, DSNs, IPs, or any identifier."
+    : "Not sending any usage telemetry." }));
+  kvRow(card, "status", (t.reporting ? "On" : "Off") + (t.ci_detected ? " (suppressed: CI detected)" : ""));
+  if (t.overridden) {
+    const by = t.decided_by === "DO_NOT_TRACK" ? "the DO_NOT_TRACK environment variable"
+      : t.decided_by === "BINTRAIL_TELEMETRY" ? "the BINTRAIL_TELEMETRY environment variable"
+      : "the --telemetry flag";
+    card.append(el("p", { class: "form-hint", text: "Set by " + by + " on the daemon, which overrides this toggle — change it there." }));
+    return card;
+  }
+  card.append(el("div", { class: "stg-cardfoot" },
+    el("button", { class: "btn btn-sm", type: "button",
+      text: t.consent ? "Turn telemetry off" : "Turn telemetry on",
+      onclick: () => setTelemetry(!t.consent) })));
+  return card;
+}
+
+async function setTelemetry(enabled) {
+  try {
+    await api("/api/telemetry", { method: "POST", body: JSON.stringify({ enabled: enabled }) });
+  } catch (e) {
+    toast("Could not change telemetry: " + ((e && e.message) || e));
+    return;
+  }
+  toast(enabled ? "Telemetry turned on." : "Telemetry turned off — this daemon stops beaconing now.");
+  renderStorage();
 }
 
 function baselineSummaryCard(b, cur) {

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -95,6 +95,11 @@ type Config struct {
 	// where the trigger endpoint refuses with 403 and /api/capabilities reports
 	// verify_trigger:false. Set together with MonitorCtrl (both control-plane).
 	VerifyCtrl VerifyController
+	// Telemetry is the live usage-telemetry client, wired in by
+	// `bintrail-console watch` so the UI opt-out toggle stops the running
+	// daemon's beacons immediately. nil on the read-only console (serve), where
+	// the toggle still persists the machine-wide choice to the consent file.
+	Telemetry TelemetryController
 	// BaselineDir / BaselineS3 enable point-in-time reconstruct (Phase 2) on
 	// the boot entry. When either is set (and no RBAC profile is active), the
 	// "Reconstruct" surface is exposed. BaselineDir takes precedence;
@@ -173,6 +178,9 @@ type Server struct {
 	// verifyCtrl: non-nil only when the watch daemon opted into in-process
 	// verify runs (see Config.VerifyCtrl).
 	verifyCtrl VerifyController
+	// telemetry: non-nil only when a long-running console wired its live
+	// telemetry client (see Config.Telemetry), so the UI opt-out reaches it.
+	telemetry TelemetryController
 	// rotationDefaults are the daemon's --rotate-* values, the fallback GET
 	// /api/rotation reports when no console override is saved.
 	rotationDefaults RotationDefaults
@@ -327,6 +335,7 @@ func New(cfg Config) (*Server, error) {
 		monitorCtrl:      cfg.MonitorCtrl,
 		baselineCtrl:     cfg.BaselineCtrl,
 		verifyCtrl:       cfg.VerifyCtrl,
+		telemetry:        cfg.Telemetry,
 		rotationDefaults: cfg.RotationDefaults,
 		version:          cfg.Version,
 		cm:               newConnManager(cfg.Registry, profileActive),
@@ -420,6 +429,11 @@ func (s *Server) buildHandler() http.Handler {
 	// booleans and non-secret names — never values).
 	api.HandleFunc("GET /api/baselines", s.handleBaselines)
 	api.HandleFunc("GET /api/storage", s.handleStorageInfo)
+	// Usage-telemetry opt-out: read the machine-wide state, and toggle it (a
+	// local config write, not a data write). Available on any console; the UI
+	// surfaces it on the watch daemon that actually beacons.
+	api.HandleFunc("GET /api/telemetry", s.handleTelemetryGet)
+	api.HandleFunc("POST /api/telemetry", s.handleTelemetrySet)
 	// Server management: CRUD over the local registry file (never a DB write)
 	// plus a write-free test-connection probe. Same token + host guard as the
 	// data endpoints.

--- a/internal/console/telemetry_api.go
+++ b/internal/console/telemetry_api.go
@@ -1,0 +1,110 @@
+package console
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+
+	"github.com/dbtrail/dbtrail/internal/telemetry"
+)
+
+// TelemetryController is the live usage-telemetry client a long-running console
+// (`bintrail-console watch`) wires in, so the UI opt-out toggle takes effect on
+// the running process immediately instead of only on the next start. Satisfied
+// by *telemetry.Client. nil on the read-only console, where the toggle still
+// persists the machine-wide choice to the consent file.
+type TelemetryController interface {
+	Enabled() bool
+	Decision() telemetry.Decision
+	SetRuntimeConsent(enabled bool)
+}
+
+// telemetryStateDTO reports machine-wide usage-telemetry state to the UI.
+//
+// Writing the telemetry consent file is not a data write: it is LOCAL MACHINE
+// CONFIG, the same category as the server registry and MCP token this console
+// already writes, so exposing an opt-out here does not cross the console's
+// read-only-over-data boundary.
+type telemetryStateDTO struct {
+	Reporting   bool   `json:"reporting"`    // actually sending right now
+	Consent     bool   `json:"consent"`      // the resolved on/off decision
+	DecidedBy   string `json:"decided_by"`   // which control decided it
+	EndpointSet bool   `json:"endpoint_set"` // this build can send at all
+	CIDetected  bool   `json:"ci_detected"`
+	// Overridden is true when a higher-precedence control (DO_NOT_TRACK, the
+	// --telemetry flag, or BINTRAIL_TELEMETRY) decides the outcome, so writing
+	// the config file from here would not change what happens. The UI disables
+	// the toggle and explains which control is in charge.
+	Overridden bool `json:"overridden"`
+}
+
+func (s *Server) telemetryState() telemetryStateDTO {
+	ep := telemetry.Endpoint()
+	ci := telemetry.IsCI()
+
+	var dec telemetry.Decision
+	var reporting bool
+	if s.telemetry != nil {
+		// The live daemon's own decision is the truth for a running process —
+		// it reflects the launch flag and any runtime toggle, which a fresh
+		// Resolve of the config file would miss.
+		dec = s.telemetry.Decision()
+		reporting = s.telemetry.Enabled()
+	} else if dir, err := telemetry.ConfigDir(); err == nil {
+		dec = telemetry.Resolve("", dir)
+		reporting = dec.Enabled && ep != "" && !ci
+	} else {
+		dec = telemetry.Resolve("", "")
+	}
+
+	return telemetryStateDTO{
+		Reporting:   reporting,
+		Consent:     dec.Enabled,
+		DecidedBy:   string(dec.Source),
+		EndpointSet: ep != "",
+		CIDetected:  ci,
+		Overridden: dec.Source == telemetry.SourceDoNotTrack ||
+			dec.Source == telemetry.SourceEnv ||
+			dec.Source == telemetry.SourceFlag,
+	}
+}
+
+// handleTelemetryGet serves GET /api/telemetry — the current machine-wide
+// telemetry state so the UI can render the opt-out toggle honestly.
+func (s *Server) handleTelemetryGet(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, s.telemetryState())
+}
+
+// handleTelemetrySet serves POST /api/telemetry {"enabled": bool}. It persists
+// the choice to the machine consent file (honored by every bintrail process
+// from its next run) AND flips the live client immediately, so a running
+// `watch` daemon stops beaconing the moment the operator opts out. Turning it
+// off also discards anything already spooled locally — matching `telemetry off`.
+func (s *Server) handleTelemetrySet(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Enabled bool `json:"enabled"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	dir, err := telemetry.ConfigDir()
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "no config directory to record the choice")
+		return
+	}
+	if err := telemetry.SetEnabled(dir, req.Enabled); err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "could not record the telemetry choice")
+		return
+	}
+	if !req.Enabled {
+		// A stranded spool would otherwise sit on disk forever (the drain runs
+		// only while enabled), so discard it — same as `telemetry off`.
+		_ = telemetry.PurgeSpool(dir)
+	}
+	if s.telemetry != nil {
+		s.telemetry.SetRuntimeConsent(req.Enabled)
+	}
+	writeJSON(w, http.StatusOK, s.telemetryState())
+}

--- a/internal/console/telemetry_api.go
+++ b/internal/console/telemetry_api.go
@@ -89,6 +89,16 @@ func (s *Server) handleTelemetrySet(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
+	// A higher-precedence control (DO_NOT_TRACK, --telemetry, or
+	// BINTRAIL_TELEMETRY) owns the decision: a config-file write here cannot
+	// change the outcome, and flipping the live client past that floor would
+	// break the precedence contract. Refuse — the UI already hides the toggle,
+	// this enforces it server-side.
+	if s.telemetryState().Overridden {
+		writeJSONError(w, http.StatusConflict,
+			"telemetry is controlled by an environment variable or launch flag on the daemon; change it there")
+		return
+	}
 	dir, err := telemetry.ConfigDir()
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "no config directory to record the choice")

--- a/internal/console/telemetry_api_test.go
+++ b/internal/console/telemetry_api_test.go
@@ -108,6 +108,24 @@ func TestHandleTelemetrySetWithoutLiveClient(t *testing.T) {
 	}
 }
 
+// A write under a higher-precedence control must be refused server-side (409),
+// never persisted, so a hand-crafted request can't flip the daemon past the
+// DO_NOT_TRACK / flag / env floor.
+func TestHandleTelemetrySetRefusesWhenOverridden(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("DO_NOT_TRACK", "1")
+	s := &Server{} // no live client → Resolve sees DO_NOT_TRACK → overridden
+	rec := httptest.NewRecorder()
+	s.handleTelemetrySet(rec, httptest.NewRequest("POST", "/api/telemetry", strings.NewReader(`{"enabled":true}`)))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status %d, want 409 Conflict", rec.Code)
+	}
+	dir, _ := telemetry.ConfigDir()
+	if telemetry.Resolve("", dir).Source == telemetry.SourceConfig {
+		t.Error("wrote the config file despite a higher-precedence override")
+	}
+}
+
 // An env override must be reported so the UI can disable the toggle and explain.
 func TestHandleTelemetryGetOverriddenByEnv(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())

--- a/internal/console/telemetry_api_test.go
+++ b/internal/console/telemetry_api_test.go
@@ -1,0 +1,125 @@
+package console
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/telemetry"
+)
+
+type fakeTelemetry struct {
+	enabled  bool
+	decision telemetry.Decision
+	setCalls []bool
+}
+
+func (f *fakeTelemetry) Enabled() bool                  { return f.enabled }
+func (f *fakeTelemetry) Decision() telemetry.Decision   { return f.decision }
+func (f *fakeTelemetry) SetRuntimeConsent(enabled bool) { f.enabled = enabled; f.setCalls = append(f.setCalls, enabled) }
+
+func decodeTelemetry(t *testing.T, rec *httptest.ResponseRecorder) telemetryStateDTO {
+	t.Helper()
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
+	}
+	var dto telemetryStateDTO
+	if err := json.Unmarshal(rec.Body.Bytes(), &dto); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return dto
+}
+
+// GET prefers the live client's own decision — the truth for a running daemon.
+func TestHandleTelemetryGetUsesLiveClient(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	ft := &fakeTelemetry{enabled: true, decision: telemetry.Decision{Enabled: true, Source: telemetry.SourceDefault}}
+	s := &Server{telemetry: ft}
+	rec := httptest.NewRecorder()
+	s.handleTelemetryGet(rec, httptest.NewRequest("GET", "/api/telemetry", nil))
+	dto := decodeTelemetry(t, rec)
+	if !dto.Reporting || !dto.Consent {
+		t.Errorf("expected reporting+consent from the live client: %+v", dto)
+	}
+	if dto.Overridden {
+		t.Errorf("default source must not read as overridden: %+v", dto)
+	}
+}
+
+// Turning it off must persist to the machine consent file AND flip the live
+// daemon immediately — the whole point of the UI opt-out.
+func TestHandleTelemetrySetOffPersistsAndStopsLiveClient(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("DO_NOT_TRACK", "")
+	t.Setenv("BINTRAIL_TELEMETRY", "")
+	ft := &fakeTelemetry{enabled: true}
+	s := &Server{telemetry: ft}
+	rec := httptest.NewRecorder()
+	s.handleTelemetrySet(rec, httptest.NewRequest("POST", "/api/telemetry", strings.NewReader(`{"enabled":false}`)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
+	}
+	if len(ft.setCalls) != 1 || ft.setCalls[0] != false {
+		t.Errorf("live client not disabled: %v", ft.setCalls)
+	}
+	dir, _ := telemetry.ConfigDir()
+	if d := telemetry.Resolve("", dir); d.Enabled || d.Source != telemetry.SourceConfig {
+		t.Errorf("choice not persisted off: %+v", d)
+	}
+}
+
+func TestHandleTelemetrySetOnPersists(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("DO_NOT_TRACK", "")
+	t.Setenv("BINTRAIL_TELEMETRY", "")
+	ft := &fakeTelemetry{enabled: false}
+	s := &Server{telemetry: ft}
+	rec := httptest.NewRecorder()
+	s.handleTelemetrySet(rec, httptest.NewRequest("POST", "/api/telemetry", strings.NewReader(`{"enabled":true}`)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d", rec.Code)
+	}
+	if len(ft.setCalls) != 1 || ft.setCalls[0] != true {
+		t.Errorf("live client not enabled: %v", ft.setCalls)
+	}
+	dir, _ := telemetry.ConfigDir()
+	if d := telemetry.Resolve("", dir); !d.Enabled {
+		t.Errorf("choice not persisted on: %+v", d)
+	}
+}
+
+// With no live client wired (the read-only console), the toggle still persists
+// the machine-wide choice and never panics.
+func TestHandleTelemetrySetWithoutLiveClient(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("DO_NOT_TRACK", "")
+	t.Setenv("BINTRAIL_TELEMETRY", "")
+	s := &Server{}
+	rec := httptest.NewRecorder()
+	s.handleTelemetrySet(rec, httptest.NewRequest("POST", "/api/telemetry", strings.NewReader(`{"enabled":false}`)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d", rec.Code)
+	}
+	dir, _ := telemetry.ConfigDir()
+	if telemetry.Resolve("", dir).Enabled {
+		t.Error("expected persisted off")
+	}
+}
+
+// An env override must be reported so the UI can disable the toggle and explain.
+func TestHandleTelemetryGetOverriddenByEnv(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("DO_NOT_TRACK", "1")
+	s := &Server{} // no live client → Resolve path exercises the env precedence
+	rec := httptest.NewRecorder()
+	s.handleTelemetryGet(rec, httptest.NewRequest("GET", "/api/telemetry", nil))
+	dto := decodeTelemetry(t, rec)
+	if !dto.Overridden || dto.Consent {
+		t.Errorf("expected overridden + off under DO_NOT_TRACK: %+v", dto)
+	}
+	if dto.DecidedBy != string(telemetry.SourceDoNotTrack) {
+		t.Errorf("decided_by = %q, want DO_NOT_TRACK", dto.DecidedBy)
+	}
+}

--- a/internal/telemetry/runtime_consent_test.go
+++ b/internal/telemetry/runtime_consent_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"sync"
 	"testing"
+	"time"
 )
 
 // TestSetRuntimeConsentTogglesLiveDecision pins the console opt-out: a running
@@ -19,9 +20,17 @@ func TestSetRuntimeConsentTogglesLiveDecision(t *testing.T) {
 	if c.Enabled() {
 		t.Error("still enabled after runtime opt-out — a live daemon would keep beaconing")
 	}
+	// The recorded Decision must track the toggle, not stay frozen at Init —
+	// otherwise `telemetry status` and the console button read the stale value.
+	if d := c.Decision(); d.Enabled || d.Source != SourceConfig {
+		t.Errorf("decision stale after opt-out: %+v", d)
+	}
 	c.SetRuntimeConsent(true)
 	if !c.Enabled() {
 		t.Error("not re-enabled after opting back in")
+	}
+	if d := c.Decision(); !d.Enabled || d.Source != SourceConfig {
+		t.Errorf("decision stale after opt-in: %+v", d)
 	}
 
 	// An inert build (no endpoint) can never be forced ON at runtime.
@@ -51,4 +60,36 @@ func TestSetRuntimeConsentRaceSafe(t *testing.T) {
 
 	var nc *Client
 	nc.SetRuntimeConsent(true) // nil receiver must not panic
+}
+
+// TestRunDaemonResumesAfterRuntimeOptIn pins the fix for the daemon loop: a
+// daemon booted consent-off (but on a build that CAN report) must keep its loop
+// alive so a later console opt-in resumes beaconing without a restart.
+func TestRunDaemonResumesAfterRuntimeOptIn(t *testing.T) {
+	clearEnv(t)
+	withDaemonTick(t, 30*time.Millisecond)
+
+	url, count := deliveryCounter(t)
+	c := Init(Config{Dir: t.TempDir(), Endpoint: url, Stderr: &bytes.Buffer{}, Interactive: boolPtr(false)})
+	c.SetRuntimeConsent(false) // opt out at boot; endpoint still set → loop stays alive
+	if c.Enabled() {
+		t.Fatal("expected disabled after opt-out")
+	}
+	startDaemon(t, c)
+
+	// Several ticks while off: nothing may be delivered.
+	time.Sleep(200 * time.Millisecond)
+	if n := count(); n != 0 {
+		t.Fatalf("beaconed %d times while opted out", n)
+	}
+
+	// Opt back in: the loop is still running and must resume beaconing.
+	c.SetRuntimeConsent(true)
+	deadline := time.Now().Add(10 * time.Second)
+	for count() == 0 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if count() == 0 {
+		t.Fatal("runtime opt-in did not resume beaconing — the loop had exited at boot")
+	}
 }

--- a/internal/telemetry/runtime_consent_test.go
+++ b/internal/telemetry/runtime_consent_test.go
@@ -1,0 +1,54 @@
+package telemetry
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+)
+
+// TestSetRuntimeConsentTogglesLiveDecision pins the console opt-out: a running
+// daemon must stop (and be able to resume) beaconing without a restart, and can
+// never be forced ON where Init suppressed it.
+func TestSetRuntimeConsentTogglesLiveDecision(t *testing.T) {
+	clearEnv(t)
+	c := Init(Config{Dir: t.TempDir(), Endpoint: "http://127.0.0.1:1", Stderr: &bytes.Buffer{}, Interactive: boolPtr(false)})
+	if !c.Enabled() {
+		t.Fatal("expected enabled at init")
+	}
+	c.SetRuntimeConsent(false)
+	if c.Enabled() {
+		t.Error("still enabled after runtime opt-out — a live daemon would keep beaconing")
+	}
+	c.SetRuntimeConsent(true)
+	if !c.Enabled() {
+		t.Error("not re-enabled after opting back in")
+	}
+
+	// An inert build (no endpoint) can never be forced ON at runtime.
+	inert := Init(Config{Dir: t.TempDir(), Stderr: &bytes.Buffer{}, Interactive: boolPtr(false)})
+	inert.SetRuntimeConsent(true)
+	if inert.Enabled() {
+		t.Error("runtime consent forced an endpoint-less build ON")
+	}
+}
+
+// TestSetRuntimeConsentRaceSafe runs the toggle concurrently with the reads the
+// beacon/record paths make — this is the reason enabled is atomic. `go test
+// -race` (CI) is what gives it teeth.
+func TestSetRuntimeConsentRaceSafe(t *testing.T) {
+	clearEnv(t)
+	c := Init(Config{Dir: t.TempDir(), Endpoint: "http://127.0.0.1:1", Stderr: &bytes.Buffer{}, Interactive: boolPtr(false)})
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() { defer wg.Done(); for j := 0; j < 1000; j++ { _ = c.Enabled() } }()
+	}
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() { defer wg.Done(); for j := 0; j < 1000; j++ { c.SetRuntimeConsent(j%2 == 0) } }()
+	}
+	wg.Wait()
+
+	var nc *Client
+	nc.SetRuntimeConsent(true) // nil receiver must not panic
+}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -274,7 +274,11 @@ var daemonTick = time.Hour
 // Waiting an hour means a crash loop never beacons at all, and "alive for at
 // least an hour" is the more honest liveness signal anyway.
 func (c *Client) RunDaemon(ctx context.Context, daemon string) {
-	if !c.Enabled() {
+	// Exit only when this build/environment can NEVER report — an inert build
+	// must not spin a ticker forever. A daemon that is merely consent-off keeps
+	// the loop so a runtime opt-in (the console toggle) resumes beaconing
+	// without a restart; Beacon and drainOnce no-op while consent is off.
+	if !c.canEverReport() {
 		return
 	}
 	defer func() {
@@ -283,13 +287,18 @@ func (c *Client) RunDaemon(ctx context.Context, daemon string) {
 		}
 	}()
 
-	c.logDaemonNotice()
+	if c.Enabled() {
+		c.logDaemonNotice()
+	}
 
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-time.After(daemonTick):
+		}
+		if !c.Enabled() {
+			continue // consent off right now; a runtime opt-in resumes us
 		}
 		c.Beacon(daemon)
 		c.drainOnce()
@@ -319,17 +328,30 @@ func (c *Client) logDaemonNotice() {
 // Enabled reports whether this client will record anything.
 func (c *Client) Enabled() bool { return c != nil && c.enabled.Load() }
 
+// canEverReport reports whether this build and environment could report at all,
+// independent of the current consent — false for an inert build (no endpoint),
+// no config dir, or CI. A runtime consent toggle can never change these.
+func (c *Client) canEverReport() bool {
+	return c != nil && c.endpoint != "" && c.dir != "" && !c.isCI
+}
+
 // SetRuntimeConsent flips THIS process's live reporting decision without a
 // restart — the console UI's opt-out toggle calls it so a long-running daemon
 // stops (or resumes) beaconing immediately instead of only on the next start.
-// It can never turn reporting ON where Init suppressed it (CI, no endpoint, no
-// config dir): those gates are re-applied. Persisting the choice across
-// restarts is the caller's job (SetEnabled); this only affects memory.
+// It can never turn reporting ON where the build/environment suppresses it
+// (canEverReport). It also updates the recorded Decision to the config-file
+// source, because the UI persists the choice there — so Decision() and
+// `telemetry status` stay truthful after the toggle instead of reporting the
+// frozen Init-time decision. Persisting across restarts is the caller's job
+// (SetEnabled); this only affects THIS process.
 func (c *Client) SetRuntimeConsent(enabled bool) {
 	if c == nil {
 		return
 	}
-	c.enabled.Store(enabled && !c.isCI && c.endpoint != "" && c.dir != "")
+	c.mu.Lock()
+	c.decision = Decision{Enabled: enabled, Source: SourceConfig}
+	c.mu.Unlock()
+	c.enabled.Store(enabled && c.canEverReport())
 }
 
 // Decision reports the resolved consent state and what decided it.
@@ -337,6 +359,8 @@ func (c *Client) Decision() Decision {
 	if c == nil {
 		return Decision{Enabled: false, Source: SourceDefault}
 	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	return c.decision
 }
 

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -84,7 +85,7 @@ type Config struct {
 // Client records usage events. The zero value and a nil *Client are both safe
 // and inert, so callers never need a nil check.
 type Client struct {
-	enabled     bool
+	enabled     atomic.Bool
 	decision    Decision
 	isCI        bool
 	dir         string
@@ -152,10 +153,6 @@ func Init(cfg Config) (c *Client) {
 	isCI := IsCI()
 
 	c = &Client{
-		// A CI run is nobody deciding anything, and an empty endpoint or missing
-		// config dir means there is nowhere to send or spool. All three suppress
-		// only — they can never turn telemetry ON.
-		enabled:     decision.Enabled && !isCI && ep != "" && dir != "",
 		decision:    decision,
 		isCI:        isCI,
 		dir:         dir,
@@ -167,8 +164,14 @@ func Init(cfg Config) (c *Client) {
 		now:         now,
 		http:        &http.Client{Timeout: drainDeadline},
 	}
+	// A CI run is nobody deciding anything, and an empty endpoint or missing
+	// config dir means there is nowhere to send or spool. All three suppress
+	// only — they can never turn telemetry ON. Stored atomically because a
+	// long-running daemon can flip consent at runtime (SetRuntimeConsent) while
+	// the beacon goroutine reads it.
+	c.enabled.Store(decision.Enabled && !isCI && ep != "" && dir != "")
 
-	if !c.enabled {
+	if !c.enabled.Load() {
 		return c
 	}
 	c.maybeShowNotice(stderr)
@@ -314,7 +317,20 @@ func (c *Client) logDaemonNotice() {
 }
 
 // Enabled reports whether this client will record anything.
-func (c *Client) Enabled() bool { return c != nil && c.enabled }
+func (c *Client) Enabled() bool { return c != nil && c.enabled.Load() }
+
+// SetRuntimeConsent flips THIS process's live reporting decision without a
+// restart — the console UI's opt-out toggle calls it so a long-running daemon
+// stops (or resumes) beaconing immediately instead of only on the next start.
+// It can never turn reporting ON where Init suppressed it (CI, no endpoint, no
+// config dir): those gates are re-applied. Persisting the choice across
+// restarts is the caller's job (SetEnabled); this only affects memory.
+func (c *Client) SetRuntimeConsent(enabled bool) {
+	if c == nil {
+		return
+	}
+	c.enabled.Store(enabled && !c.isCI && c.endpoint != "" && c.dir != "")
+}
 
 // Decision reports the resolved consent state and what decided it.
 func (c *Client) Decision() Decision {


### PR DESCRIPTION
Refs #1577. Adds a UI opt-out for usage telemetry — so a browser-only operator of the `watch` daemon can turn it off without shell/env access.

## What
- **Storage page → Usage telemetry card** with a one-click opt-out (`internal/console/assets/app.js`).
- Turning off **persists** the machine-wide choice (consent file) **and stops the running daemon's beacons immediately** — no restart.
- Telemetry client gains `SetRuntimeConsent(bool)` backed by an **atomic** `enabled` flag (was a plain bool) so the beacon goroutine and the HTTP handler don't race. Can never force reporting ON where `Init` suppressed it (CI / no endpoint / no config dir).
- `watch` wires its live client into `console.Config.Telemetry`; `serve` leaves it nil (toggle still persists to the file).
- A higher-precedence control (`DO_NOT_TRACK` / `BINTRAIL_TELEMETRY` / `--telemetry`) is reported as `overridden` — the card explains and defers to it.
- New `GET`/`POST /api/telemetry`. Writing the consent file is local machine config, not a data write; the read-only-over-data boundary is unchanged.

## Tests
- `internal/telemetry`: runtime toggle flips the live decision, can't force an inert build ON, nil-safe, and a concurrent read/write race test (`-race`).
- `internal/console`: GET uses the live client, POST off persists + stops the live client, POST on persists, the no-client (serve) path, and env-override reporting.
- `go vet ./...` clean; `internal/telemetry` + `internal/console` + `consoleapp` pass under `-race`.

## Not covered
Browser-render of the card in a live `watch` stack (needs an index DB + monitored server locally). The card uses the same `el()`/`kvRow()` DOM helpers as the existing `credentialsCard` and no capability/`[hidden]` gating, so the class of render bug that needs a real browser doesn't apply — but a live eyeball after deploy is worth it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)