### PR TITLE
console: per-session authorization seam (roles→permissions enforced at the API layer)

### DIFF
--- a/ext/consoleauth.go
+++ b/ext/consoleauth.go
@@ -11,7 +11,16 @@ import (
 // bearer credential the browser presents on every /api call — the same
 // in-memory session a password login mints, with the same lifetime and
 // revocation behavior.
-type ConsoleSessionIssuer func(identity string) (token string, expiresAt time.Time, err error)
+//
+// policy scopes what the minted session may do (see AccessPolicy). Pass nil for
+// a full-access session — identical to what the built-in password login and the
+// static token mint. Only an EE build that maps roles onto permissions passes a
+// non-nil policy; the OSS core never does, so its sessions stay full-access.
+//
+// The policy parameter was added when per-session authorization landed. There is
+// no in-repo implementor of this seam, so the signature break is absorbed in one
+// release by the sole external caller (the SSO provider in the EE build).
+type ConsoleSessionIssuer func(identity string, policy *AccessPolicy) (token string, expiresAt time.Time, err error)
 
 // ConsoleAuthProvider plugs an external authentication flow (e.g. OIDC
 // single sign-on) into the web console's login surface. The console stays

--- a/ext/consoleauth_test.go
+++ b/ext/consoleauth_test.go
@@ -9,7 +9,7 @@ import (
 // The issuer contract is a plain func type — keep a compile-time pin on its
 // exact shape so an accidental signature change fails here, not only in the
 // console wiring.
-var _ ConsoleSessionIssuer = func(string) (string, time.Time, error) {
+var _ ConsoleSessionIssuer = func(string, *AccessPolicy) (string, time.Time, error) {
 	return "", time.Time{}, nil
 }
 

--- a/ext/consolepolicy.go
+++ b/ext/consolepolicy.go
@@ -1,0 +1,102 @@
+package ext
+
+import "slices"
+
+// Permission is a `verb:noun` capability string. Each authenticated console
+// route requires exactly one of these; a session's AccessPolicy carries the set
+// it holds. The strings are the stable contract between this OSS core (which
+// defines the permissions and enforces them per route) and an embedding EE build
+// (which maps its own role vocabulary — admin/operator/… — onto these strings
+// and attaches a policy via the session-issuer seam). The core deliberately
+// knows nothing about roles: it enforces permission SETS, never named roles.
+type Permission string
+
+// The initial permission set. Adding a permission here is additive; adding a new
+// authenticated /api route means classifying it against one of these (or marking
+// it as needing none) in the console's route table — an unclassified route is
+// refused for any policy-carrying session, never silently granted.
+const (
+	// PermStatusRead — read the health/status surface. The floor: a session with
+	// only this (and PermServersRead) sees operational state but no row data.
+	PermStatusRead Permission = "status:read"
+	// PermQueryExecute — read indexed row events (the events surface and the
+	// schema listing that drives it).
+	PermQueryExecute Permission = "query:execute"
+	// PermRecoverExecute — generate reversal SQL (recover and recover-cascade).
+	PermRecoverExecute Permission = "recover:execute"
+	// PermReconstructExecute — point-in-time reconstruction (time-travel).
+	PermReconstructExecute Permission = "reconstruct:execute"
+	// PermBaselineCreate — trigger operator maintenance actions that write no
+	// customer data but change server state (baseline snapshots, verify runs).
+	PermBaselineCreate Permission = "baseline:create"
+	// PermServersRead — read the server registry and per-server status.
+	PermServersRead Permission = "servers:read"
+	// PermServersWrite — mutate the server registry and control-plane state
+	// (create/update entries, start/stop monitoring, rotation override).
+	PermServersWrite Permission = "servers:write"
+	// PermServersDelete — remove a server registry entry.
+	PermServersDelete Permission = "servers:delete"
+	// PermSettingsRead — reach the settings/administration surfaces (storage and
+	// baseline listings, telemetry opt-out, the managed MCP token).
+	PermSettingsRead Permission = "settings:read"
+	// PermExtViewRead — reach an installed extension view's data routes.
+	PermExtViewRead Permission = "extview:read"
+)
+
+// allPermissions is every permission the core defines, in a stable order. The
+// console iterates it to report a session's effective grants to the SPA for UI
+// gating; tests iterate it to guard against typos in the route table.
+var allPermissions = []Permission{
+	PermStatusRead,
+	PermQueryExecute,
+	PermRecoverExecute,
+	PermReconstructExecute,
+	PermBaselineCreate,
+	PermServersRead,
+	PermServersWrite,
+	PermServersDelete,
+	PermSettingsRead,
+	PermExtViewRead,
+}
+
+// AllPermissions returns a copy of every permission the core defines. Callers
+// may not mutate the returned slice's effect on the package (it is a fresh copy).
+func AllPermissions() []Permission {
+	out := make([]Permission, len(allPermissions))
+	copy(out, allPermissions)
+	return out
+}
+
+// AccessPolicy is the optional authorization an external auth provider attaches
+// to the console session it mints (see ConsoleSessionIssuer). It has two
+// orthogonal dimensions:
+//
+//   - Permissions — the capability strings this session holds, gating which
+//     routes it may call. Enforced by the OSS core, per route.
+//   - Profile — the name of an existing RBAC data profile (the profiles/flags/
+//     access_rules the `bintrail flag|profile|access` commands manage), scoping
+//     what DATA the session sees. This struct only CARRIES the name; enforcing it
+//     (deny/redact, archive and reconstruct gates) is a separate concern the
+//     console wires per request.
+//
+// A nil *AccessPolicy means "no policy" — a full-access session, exactly what the
+// password login and the static token mint today. The OSS build never constructs
+// one, so its behavior is unchanged; only an installed provider (an EE build)
+// attaches a policy, and only then does per-route enforcement bite.
+type AccessPolicy struct {
+	// Permissions is the set this session holds. Order is irrelevant; duplicates
+	// are harmless. An empty (but non-nil policy) grants nothing beyond the
+	// permission-free routes.
+	Permissions []Permission
+	// Profile is the data-profile name to enforce, or "" for none.
+	Profile string
+}
+
+// Allows reports whether the policy grants p. A nil policy allows everything (no
+// policy = full access), so callers may invoke it on the nil value.
+func (p *AccessPolicy) Allows(perm Permission) bool {
+	if p == nil {
+		return true
+	}
+	return slices.Contains(p.Permissions, perm)
+}

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -2720,8 +2720,21 @@ async function gateCapabilities() {
   extViews = Array.isArray(capsCache.extension_views) ? capsCache.extension_views : [];
   syncExtNav();
   $all("[data-capability]").forEach((node) => node.classList.toggle("cap-on", !!capsCache[node.dataset.capability]));
+  gatePermissions();
   applyAuthGate();
   updateSrvNote(); // capsCache.monitor may have just changed
+}
+
+// gatePermissions hides a [data-perm] surface when the session's policy denies
+// that permission (per-session RBAC, #1074). Default is VISIBLE: a policy-less
+// session — the static token, the password login, every OSS session — reports
+// every permission true, so nothing is hidden and the UI is unchanged. A missing
+// permissions map (a degraded {} capabilities response) also leaves everything
+// visible: only an explicit `false` hides. The server's 403 is the real gate;
+// this just spares a scoped user a tab that would only error.
+function gatePermissions() {
+  const perms = capsCache.permissions || {};
+  $all("[data-perm]").forEach((node) => node.classList.toggle("perm-off", perms[node.dataset.perm] === false));
 }
 
 // syncExtNav rebuilds the extension-view nav group from extViews. Idempotent

--- a/internal/console/assets/index.html
+++ b/internal/console/assets/index.html
@@ -56,18 +56,18 @@
         </div>
         <div class="nav-group">
           <div class="nav-label">Investigate</div>
-          <a class="nav-item" data-route="events" href="/events">
+          <a class="nav-item" data-route="events" href="/events" data-perm="query:execute">
             <span class="ni-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 6h13M8 12h13M8 18h13"/><circle cx="3.5" cy="6" r="1.2"/><circle cx="3.5" cy="12" r="1.2"/><circle cx="3.5" cy="18" r="1.2"/></svg></span>
             <span>Events</span>
           </a>
-          <a class="nav-item" data-route="timetravel" href="/timetravel" data-capability="reconstruct">
+          <a class="nav-item" data-route="timetravel" href="/timetravel" data-capability="reconstruct" data-perm="reconstruct:execute">
             <span class="ni-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 5v5h5"/><path d="M3.5 10a9 9 0 1 1-.7 4"/><path d="M12 8v4l3 2"/></svg></span>
             <span>Time-travel</span>
           </a>
         </div>
         <div class="nav-group">
           <div class="nav-label">Resolve</div>
-          <a class="nav-item" data-route="recover" href="/recover">
+          <a class="nav-item" data-route="recover" href="/recover" data-perm="recover:execute">
             <span class="ni-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7v6h6"/><path d="M3 13a9 9 0 1 0 3-7.7L3 8"/></svg></span>
             <span>Recover</span>
           </a>

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -1112,6 +1112,14 @@ button { font-family: inherit; }
    .cap-on. The :not() + !important hides by default and restores the
    element's own display once gated on — no flash, no per-element value. */
 [data-capability]:not(.cap-on) { display: none !important; }
+/* Permission gating (per-session RBAC, #1074): a [data-perm] surface stays
+   VISIBLE by default and is hidden only when gatePermissions() marks it
+   .perm-off because the session's policy denies that permission. Opposite
+   default from capability gating on purpose: a policy-less session (the static
+   token, the password login, every OSS session) reports all permissions, so
+   nothing is ever marked .perm-off and the UI is unchanged. Server-side 403 is
+   the real gate; this only tidies the UI for a scoped EE session. */
+[data-perm].perm-off { display: none !important; }
 /* Source-family gating: a [data-flavor] form field is hidden until applyFlavor
    marks it .flavor-on for the selected source type. Same :not() + !important
    default-hide as capability gating — a class toggle, never a [hidden] toggle. */

--- a/internal/console/auth.go
+++ b/internal/console/auth.go
@@ -6,6 +6,8 @@ import (
 	"net"
 	"net/http"
 	"strings"
+
+	"github.com/dbtrail/dbtrail/ext"
 )
 
 // isLoopbackAddr reports whether a listen address binds only to the loopback
@@ -56,6 +58,18 @@ func authKindFrom(ctx context.Context) authKind {
 	return k
 }
 
+// policyCtxKey carries the authenticated session's access policy (from
+// sessionStore.Lookup) into the request. It is nil for the static token, the
+// password login, and any OSS session — a nil policy means full access, so the
+// authz middleware and capabilities report everything, preserving OSS behavior.
+// Only an EE build attaches a non-nil policy via the ext session issuer.
+type policyCtxKey struct{}
+
+func policyFrom(ctx context.Context) *ext.AccessPolicy {
+	p, _ := ctx.Value(policyCtxKey{}).(*ext.AccessPolicy)
+	return p
+}
+
 // tokenMiddleware requires a valid bearer credential on every wrapped
 // request: either the static access token or a login session. Both checks
 // run on the same path with no prefix branching, so response shape never
@@ -86,8 +100,10 @@ func (s *Server) tokenMiddleware(next http.Handler) http.Handler {
 			next.ServeHTTP(w, r.WithContext(context.WithValue(r.Context(), authKindCtxKey{}, authKindToken)))
 			return
 		}
-		if s.sessions.Validate(got) {
-			next.ServeHTTP(w, r.WithContext(context.WithValue(r.Context(), authKindCtxKey{}, authKindSession)))
+		if policy, ok := s.sessions.Lookup(got); ok {
+			ctx := context.WithValue(r.Context(), authKindCtxKey{}, authKindSession)
+			ctx = context.WithValue(ctx, policyCtxKey{}, policy)
+			next.ServeHTTP(w, r.WithContext(ctx))
 			return
 		}
 		writeJSONError(w, http.StatusUnauthorized, "unauthorized: missing or invalid token")

--- a/internal/console/auth_api.go
+++ b/internal/console/auth_api.go
@@ -69,8 +69,8 @@ func (s *Server) handleAuthInfo(w http.ResponseWriter, r *http.Request) {
 // the returned token is a normal console session (same TTLs, same revocation).
 // The identity is logged for the operator's audit trail and never stored.
 func (s *Server) extSessionIssuer() ext.ConsoleSessionIssuer {
-	return func(identity string) (string, time.Time, error) {
-		token, expires, err := s.sessions.Issue()
+	return func(identity string, policy *ext.AccessPolicy) (string, time.Time, error) {
+		token, expires, err := s.sessions.IssueWithPolicy(policy)
 		if err != nil {
 			return "", time.Time{}, err
 		}

--- a/internal/console/auth_ext_test.go
+++ b/internal/console/auth_ext_test.go
@@ -31,7 +31,7 @@ func (fakeAuthProvider) Handler(prefix string, issue ext.ConsoleSessionIssuer) h
 		w.WriteHeader(http.StatusOK)
 	})
 	mux.HandleFunc("GET "+prefix+"finish", func(w http.ResponseWriter, r *http.Request) {
-		token, _, err := issue("tester@example.com")
+		token, _, err := issue("tester@example.com", nil)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/internal/console/authz.go
+++ b/internal/console/authz.go
@@ -1,0 +1,196 @@
+package console
+
+import (
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/dbtrail/dbtrail/ext"
+)
+
+// This file is the per-session authorization layer (issue #1074). It is inert in
+// the OSS build: the built-in credentials mint policy-less (nil) sessions, and a
+// nil policy is full access — so authzMiddleware waves every request through and
+// the reported permission set is complete. Only an EE build that attaches an
+// ext.AccessPolicy to a session (via the session-issuer seam) makes any of this
+// bite. Enforcement is by PERMISSION, never by role: the core has no role
+// vocabulary; an embedding build maps its roles onto these permission strings.
+
+// permAny marks a route that any authenticated session may call regardless of
+// its policy — the capabilities oracle the SPA needs to gate its own UI, and the
+// session's own auth self-management (logout, change-password). It is the empty
+// permission on purpose: a route MUST be listed either with a real permission or
+// with permAny, never omitted (an omitted route is refused for policy sessions —
+// see authzMiddleware).
+const permAny ext.Permission = ""
+
+// routePerm binds one authenticated /api route to the permission it requires.
+// method is the HTTP method; pattern is the route's path with "{}" standing in
+// for a single path segment (an id). Matching is segment-based with an exact
+// segment-count requirement, so a pattern with a placeholder can never match a
+// path of a different depth — a sibling route never silently inherits a parent's
+// permission via prefix matching.
+type routePerm struct {
+	method  string
+	pattern string
+	perm    ext.Permission
+}
+
+// apiRoutePerms is the authoritative route→permission table, consulted on every
+// policy-carrying /api request. ORDER MATTERS: matching is first-match-wins, so
+// a route with a literal segment where another has a placeholder must be listed
+// FIRST (e.g. POST /api/servers/test before a hypothetical POST /api/servers/{}).
+// TestRouteTableCompleteness pins that every registered /api route appears here;
+// TestRoutePermFirstMatchWins pins the ordering invariant. The /api/ext/ subtree
+// is NOT here — it is matched by prefix in permForRoute (its depth is unbounded).
+//
+// Permission tiers (an EE build's roles map onto these): status:read and
+// servers:read are the read-only floor; query/reconstruct read data; recover and
+// baseline are operator actions; servers:write/delete and settings:read are the
+// administrative surface.
+var apiRoutePerms = []routePerm{
+	// Status + data reads.
+	{"GET", "/api/status", ext.PermStatusRead},
+	{"GET", "/api/events", ext.PermQueryExecute},
+	{"GET", "/api/schemas", ext.PermQueryExecute},
+	{"GET", "/api/reconstruct", ext.PermReconstructExecute},
+
+	// Recovery (reversal-SQL generation; never executes).
+	{"POST", "/api/recover", ext.PermRecoverExecute},
+	{"POST", "/api/recover-cascade", ext.PermRecoverExecute},
+
+	// Operator maintenance actions on a specific server. verify has no dedicated
+	// permission; it is an operator integrity action, tiered with baseline:create.
+	{"POST", "/api/servers/{}/baseline", ext.PermBaselineCreate},
+	{"POST", "/api/servers/{}/verify", ext.PermBaselineCreate},
+
+	// Server registry + control-plane. List/get/status/verify-read and the
+	// write-free test probe are reads; create/update/delete/monitor are writes.
+	// Literal-segment routes precede the {} ones at the same depth.
+	{"POST", "/api/servers/test", ext.PermServersRead},
+	{"GET", "/api/servers/{}/monitor", ext.PermServersRead},
+	{"POST", "/api/servers/{}/monitor/start", ext.PermServersWrite},
+	{"POST", "/api/servers/{}/monitor/stop", ext.PermServersWrite},
+	{"GET", "/api/servers/{}/baseline", ext.PermServersRead},
+	{"GET", "/api/servers/{}/verify", ext.PermServersRead},
+	{"GET", "/api/servers/{}/verify/explain", ext.PermServersRead},
+	{"POST", "/api/servers/{}/test", ext.PermServersRead},
+	{"GET", "/api/servers/{}", ext.PermServersRead},
+	{"PUT", "/api/servers/{}", ext.PermServersWrite},
+	{"DELETE", "/api/servers/{}", ext.PermServersDelete},
+	{"GET", "/api/servers", ext.PermServersRead},
+	{"POST", "/api/servers", ext.PermServersWrite},
+
+	// Settings / administration. rotation PUT is a control-plane config write;
+	// the storage/baseline listings, telemetry opt-out, and managed MCP token are
+	// the settings surface.
+	{"GET", "/api/rotation", ext.PermSettingsRead},
+	{"PUT", "/api/rotation", ext.PermServersWrite},
+	{"GET", "/api/baselines", ext.PermSettingsRead},
+	{"GET", "/api/storage", ext.PermSettingsRead},
+	{"GET", "/api/telemetry", ext.PermSettingsRead},
+	{"POST", "/api/telemetry", ext.PermSettingsRead},
+	{"GET", "/api/mcp-token", ext.PermSettingsRead},
+	{"POST", "/api/mcp-token", ext.PermSettingsRead},
+	{"DELETE", "/api/mcp-token", ext.PermSettingsRead},
+
+	// The capabilities oracle and the session's own auth self-management: any
+	// authenticated session, regardless of policy.
+	{"GET", "/api/capabilities", permAny},
+	{"POST", "/api/auth/logout", permAny},
+	{"POST", "/api/auth/password", permAny},
+}
+
+// extAPIPrefix is the mount prefix for an installed extension view's data routes
+// (see ext.ConsoleViewProvider). The whole subtree requires PermExtViewRead; its
+// depth is unbounded, so it is matched by prefix rather than an apiRoutePerms
+// row. rbacViewGuard additionally refuses it under an active data profile.
+const extAPIPrefix = "/api/ext/"
+
+// permForRoute returns the permission a (method, path) requires and whether the
+// route is classified at all. An unclassified route (classified=false) is a
+// programming error — every registered /api route must appear in apiRoutePerms
+// or under the ext prefix — and authzMiddleware fails it CLOSED for a policy
+// session rather than granting it.
+func permForRoute(method, path string) (perm ext.Permission, classified bool) {
+	if strings.HasPrefix(path, extAPIPrefix) {
+		return ext.PermExtViewRead, true
+	}
+	segs := strings.Split(strings.Trim(path, "/"), "/")
+	for _, rp := range apiRoutePerms {
+		if rp.method == method && segmentsMatch(rp.pattern, segs) {
+			return rp.perm, true
+		}
+	}
+	return permAny, false
+}
+
+// segmentsMatch reports whether path segments segs match a pattern, where a "{}"
+// pattern segment matches any single non-empty segment and every other segment
+// must be equal. The segment counts must be identical — the exact-depth rule that
+// stops a placeholder pattern from matching a longer or shorter sibling path.
+func segmentsMatch(pattern string, segs []string) bool {
+	ps := strings.Split(strings.Trim(pattern, "/"), "/")
+	if len(ps) != len(segs) {
+		return false
+	}
+	for i, p := range ps {
+		if p == "{}" {
+			if segs[i] == "" {
+				return false
+			}
+			continue
+		}
+		if p != segs[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// authzMiddleware enforces the session's access policy on every wrapped /api
+// request. It runs INSIDE tokenMiddleware, so the request is already
+// authenticated and any policy is already on the context.
+//
+//   - No policy (nil) → full access: the static token, the password login, and
+//     every OSS session land here, so OSS behavior is unchanged.
+//   - A policy-carrying session → the route's permission is looked up; a route
+//     with no classification is refused (fail closed), a permAny route is always
+//     allowed, and otherwise the policy must grant the permission or the request
+//     gets a 403 that names the missing permission (never a silent empty result).
+func (s *Server) authzMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pol := policyFrom(r.Context())
+		if pol == nil {
+			next.ServeHTTP(w, r)
+			return
+		}
+		perm, classified := permForRoute(r.Method, r.URL.Path)
+		if !classified {
+			// Every /api route must be classified; an omission must not silently
+			// grant a scoped session access it was never evaluated for.
+			slog.Error("console: unclassified /api route refused for a scoped session (fail closed)", "method", r.Method, "path", r.URL.Path)
+			writeJSONError(w, http.StatusForbidden, "forbidden: this route has no authorization policy")
+			return
+		}
+		if perm == permAny || pol.Allows(perm) {
+			next.ServeHTTP(w, r)
+			return
+		}
+		slog.Warn("console: request denied by session policy", "method", r.Method, "path", r.URL.Path, "missing_permission", string(perm))
+		writeJSONError(w, http.StatusForbidden, "forbidden: your role lacks the "+string(perm)+" permission")
+	})
+}
+
+// permissionsForPolicy reports the session's effective grant of every permission
+// the core defines, for the SPA to gate its UI. A nil policy (OSS, or any
+// full-access session) grants everything, so the map is all-true and the UI hides
+// nothing — the same UI the console has always shown.
+func permissionsForPolicy(pol *ext.AccessPolicy) map[string]bool {
+	perms := ext.AllPermissions()
+	m := make(map[string]bool, len(perms))
+	for _, p := range perms {
+		m[string(p)] = pol.Allows(p)
+	}
+	return m
+}

--- a/internal/console/authz_test.go
+++ b/internal/console/authz_test.go
@@ -1,0 +1,336 @@
+package console
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/ext"
+)
+
+// registeredAPIPatterns mirrors the authenticated /api routes registered on the
+// inner mux in buildHandler (server.go). It is the drift guard for the
+// route→permission table: every registered route must be classified, and the
+// table must carry no entry for a route that no longer exists. Keep this in sync
+// with buildHandler's api.HandleFunc calls. (The /api/ext/ subtree is matched by
+// prefix, not a table row, and is covered separately.)
+var registeredAPIPatterns = []struct{ method, pattern string }{
+	{"GET", "/api/status"},
+	{"GET", "/api/schemas"},
+	{"GET", "/api/events"},
+	{"POST", "/api/recover"},
+	{"POST", "/api/recover-cascade"},
+	{"GET", "/api/capabilities"},
+	{"GET", "/api/reconstruct"},
+	{"GET", "/api/baselines"},
+	{"GET", "/api/storage"},
+	{"GET", "/api/telemetry"},
+	{"POST", "/api/telemetry"},
+	{"GET", "/api/servers"},
+	{"POST", "/api/servers"},
+	{"POST", "/api/servers/test"},
+	{"GET", "/api/servers/{}"},
+	{"PUT", "/api/servers/{}"},
+	{"DELETE", "/api/servers/{}"},
+	{"POST", "/api/servers/{}/test"},
+	{"POST", "/api/servers/{}/monitor/start"},
+	{"POST", "/api/servers/{}/monitor/stop"},
+	{"GET", "/api/servers/{}/monitor"},
+	{"POST", "/api/servers/{}/baseline"},
+	{"GET", "/api/servers/{}/baseline"},
+	{"POST", "/api/servers/{}/verify"},
+	{"GET", "/api/servers/{}/verify"},
+	{"GET", "/api/servers/{}/verify/explain"},
+	{"GET", "/api/rotation"},
+	{"PUT", "/api/rotation"},
+	{"POST", "/api/auth/logout"},
+	{"POST", "/api/auth/password"},
+	{"GET", "/api/mcp-token"},
+	{"POST", "/api/mcp-token"},
+	{"DELETE", "/api/mcp-token"},
+}
+
+// concretePath turns a table pattern into a real path by giving every "{}" a
+// value, so permForRoute (which matches concrete request paths) can be exercised.
+func concretePath(pattern string) string {
+	return strings.ReplaceAll(pattern, "{}", "x")
+}
+
+// TestRouteTableClassifiesEveryRegisteredRoute pins that every registered /api
+// route resolves to a permission — the fail-closed contract: an unclassified
+// route must be impossible, not merely refused at runtime.
+func TestRouteTableClassifiesEveryRegisteredRoute(t *testing.T) {
+	for _, r := range registeredAPIPatterns {
+		path := concretePath(r.pattern)
+		if _, ok := permForRoute(r.method, path); !ok {
+			t.Errorf("registered route %s %s is not classified in apiRoutePerms", r.method, r.pattern)
+		}
+	}
+}
+
+// TestRouteTableHasNoDeadEntries pins the other direction: every apiRoutePerms
+// entry corresponds to a registered route, so the table never drifts into
+// classifying a route that no longer exists.
+func TestRouteTableHasNoDeadEntries(t *testing.T) {
+	registered := make(map[string]bool, len(registeredAPIPatterns))
+	for _, r := range registeredAPIPatterns {
+		registered[r.method+" "+r.pattern] = true
+	}
+	for _, rp := range apiRoutePerms {
+		if !registered[rp.method+" "+rp.pattern] {
+			t.Errorf("apiRoutePerms has %s %s, which is not a registered route (dead entry?)", rp.method, rp.pattern)
+		}
+	}
+}
+
+// TestRoutePermsUseKnownPermissions guards against a typo'd permission string in
+// the table: every entry must be permAny or one of the core's defined permissions.
+func TestRoutePermsUseKnownPermissions(t *testing.T) {
+	known := map[ext.Permission]bool{permAny: true}
+	for _, p := range ext.AllPermissions() {
+		known[p] = true
+	}
+	for _, rp := range apiRoutePerms {
+		if !known[rp.perm] {
+			t.Errorf("route %s %s uses unknown permission %q", rp.method, rp.pattern, rp.perm)
+		}
+	}
+}
+
+// TestRoutePermReachableAndOrdered gives each table entry a concrete path and
+// asserts permForRoute returns THAT entry's permission. This is the ordering
+// invariant: if an earlier, more generic pattern shadowed a later specific one,
+// the specific entry's concrete path would resolve to the wrong permission.
+func TestRoutePermReachableAndOrdered(t *testing.T) {
+	for _, rp := range apiRoutePerms {
+		got, ok := permForRoute(rp.method, concretePath(rp.pattern))
+		if !ok {
+			t.Errorf("%s %s: not classified", rp.method, rp.pattern)
+			continue
+		}
+		if got != rp.perm {
+			t.Errorf("%s %s resolved to %q, want %q — an earlier pattern is shadowing it", rp.method, rp.pattern, got, rp.perm)
+		}
+	}
+}
+
+// TestPermForRouteExactDepth pins the exact-segment-count rule: a placeholder
+// pattern must not match a path of a different depth. GET /api/servers/{} must
+// not swallow GET /api/servers (shallower) or GET /api/servers/x/monitor (deeper).
+func TestPermForRouteExactDepth(t *testing.T) {
+	// Shallower than /api/servers/{}: resolves to the /api/servers entry, not the
+	// placeholder one — different permission is not what we assert; classification
+	// and the placeholder-not-swallowing is. Deeper: an unregistered depth is
+	// unclassified (fail closed).
+	if _, ok := permForRoute("GET", "/api/servers/x/does-not-exist"); ok {
+		t.Error("GET /api/servers/x/does-not-exist should be unclassified (fail closed), got classified")
+	}
+	if p, ok := permForRoute("GET", "/api/servers/x"); !ok || p != ext.PermServersRead {
+		t.Errorf("GET /api/servers/x = (%q,%v), want (servers:read,true)", p, ok)
+	}
+}
+
+// TestPermForRouteExtPrefix pins that the whole /api/ext/ subtree, at any depth,
+// requires extview:read.
+func TestPermForRouteExtPrefix(t *testing.T) {
+	for _, path := range []string{"/api/ext/myview/", "/api/ext/myview/data", "/api/ext/a/b/c"} {
+		p, ok := permForRoute("GET", path)
+		if !ok || p != ext.PermExtViewRead {
+			t.Errorf("permForRoute(GET, %q) = (%q,%v), want (extview:read,true)", path, p, ok)
+		}
+	}
+}
+
+// TestPermForRouteUnknownIsFailClosed pins that an unrecognized /api path is
+// reported unclassified so authzMiddleware refuses it for a scoped session.
+func TestPermForRouteUnknownIsFailClosed(t *testing.T) {
+	if _, ok := permForRoute("GET", "/api/nonexistent"); ok {
+		t.Error("an unknown /api route must be unclassified (fail closed)")
+	}
+	// Right path, wrong method is also unclassified.
+	if _, ok := permForRoute("DELETE", "/api/status"); ok {
+		t.Error("a known path with the wrong method must be unclassified")
+	}
+}
+
+// withPolicy returns a request context carrying pol, as tokenMiddleware would.
+func withPolicy(pol *ext.AccessPolicy) context.Context {
+	return context.WithValue(context.Background(), policyCtxKey{}, pol)
+}
+
+// TestAuthzMiddlewarePolicyLessAllowsEverything pins the OSS regression guard: a
+// nil policy (static token, password login, every OSS session) reaches the
+// handler on every route, including ones no permission would grant.
+func TestAuthzMiddlewarePolicyLessAllowsEverything(t *testing.T) {
+	srv := &Server{}
+	reached := false
+	h := srv.authzMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	for _, r := range registeredAPIPatterns {
+		reached = false
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(r.method, concretePath(r.pattern), nil)
+		// No policy on the context — the policy-less case.
+		h.ServeHTTP(rec, req)
+		if !reached || rec.Code != http.StatusNoContent {
+			t.Errorf("policy-less %s %s: reached=%v code=%d, want reached=true code=204", r.method, r.pattern, reached, rec.Code)
+		}
+	}
+}
+
+// TestAuthzMiddlewareScopedSession pins enforcement for a scoped policy: a viewer
+// (status:read + servers:read) reaches allowed routes, is 403'd on routes needing
+// a permission it lacks (with the permission named), and always reaches permAny
+// routes.
+func TestAuthzMiddlewareScopedSession(t *testing.T) {
+	srv := &Server{}
+	viewer := &ext.AccessPolicy{Permissions: []ext.Permission{ext.PermStatusRead, ext.PermServersRead}}
+	reached := false
+	h := srv.authzMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	serve := func(method, path string) *httptest.ResponseRecorder {
+		reached = false
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(method, path, nil).WithContext(withPolicy(viewer))
+		h.ServeHTTP(rec, req)
+		return rec
+	}
+
+	// Allowed: a granted permission and a permAny route.
+	if rec := serve("GET", "/api/status"); !reached || rec.Code != http.StatusNoContent {
+		t.Errorf("viewer GET /api/status: reached=%v code=%d, want allowed", reached, rec.Code)
+	}
+	if rec := serve("GET", "/api/capabilities"); !reached || rec.Code != http.StatusNoContent {
+		t.Errorf("viewer GET /api/capabilities (permAny): reached=%v code=%d, want allowed", reached, rec.Code)
+	}
+
+	// Denied: events needs query:execute, which a viewer lacks. 403, handler never
+	// reached, and the body names the missing permission.
+	rec := serve("GET", "/api/events")
+	if reached {
+		t.Error("viewer reached the /api/events handler despite lacking query:execute")
+	}
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("viewer GET /api/events = %d, want 403", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), string(ext.PermQueryExecute)) {
+		t.Errorf("403 body %q does not name the missing permission %q", rec.Body.String(), ext.PermQueryExecute)
+	}
+}
+
+// TestAuthzMiddlewareUnclassifiedFailsClosed pins that a scoped session hitting a
+// route with no classification is refused, never granted.
+func TestAuthzMiddlewareUnclassifiedFailsClosed(t *testing.T) {
+	srv := &Server{}
+	pol := &ext.AccessPolicy{Permissions: ext.AllPermissions()} // even an all-powerful policy
+	reached := false
+	h := srv.authzMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+	}))
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/brand-new-route", nil).WithContext(withPolicy(pol))
+	h.ServeHTTP(rec, req)
+	if reached || rec.Code != http.StatusForbidden {
+		t.Errorf("unclassified route: reached=%v code=%d, want 403 fail-closed", reached, rec.Code)
+	}
+}
+
+// TestPermissionsForPolicy pins the capabilities grant map: nil → all true; a
+// subset policy → exactly those true.
+func TestPermissionsForPolicy(t *testing.T) {
+	all := permissionsForPolicy(nil)
+	for _, p := range ext.AllPermissions() {
+		if !all[string(p)] {
+			t.Errorf("nil policy: %q reported false, want true (full access)", p)
+		}
+	}
+
+	viewer := &ext.AccessPolicy{Permissions: []ext.Permission{ext.PermStatusRead, ext.PermServersRead}}
+	m := permissionsForPolicy(viewer)
+	if !m[string(ext.PermStatusRead)] || !m[string(ext.PermServersRead)] {
+		t.Error("viewer should hold status:read and servers:read")
+	}
+	if m[string(ext.PermRecoverExecute)] || m[string(ext.PermServersWrite)] {
+		t.Error("viewer should NOT hold recover:execute or servers:write")
+	}
+}
+
+// TestScopedSessionEnforcedEndToEnd wires a real server: a scoped session minted
+// via IssueWithPolicy is 403'd on a route its policy denies, while a full-access
+// session is not blocked by authz (it may fail later for lack of an index, but
+// never with authz's 403).
+func TestScopedSessionEnforcedEndToEnd(t *testing.T) {
+	srv, err := New(Config{Listen: "127.0.0.1:8090", Token: "static-tok", AuthPath: filepath.Join(t.TempDir(), "auth.yaml")})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	viewer := &ext.AccessPolicy{Permissions: []ext.Permission{ext.PermStatusRead, ext.PermServersRead}}
+	scoped, _, err := srv.sessions.IssueWithPolicy(viewer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	full, _, err := srv.sessions.Issue()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Scoped viewer: events denied at the authz layer (403), never reaching a DB.
+	if rec := getPath(t, srv, "127.0.0.1:8090", "/api/events", scoped); rec.Code != http.StatusForbidden {
+		t.Errorf("scoped viewer GET /api/events = %d, want 403", rec.Code)
+	}
+	// Full-access session: authz does not block events (any non-403 is fine — it
+	// may 5xx without an index, but authz must not be the thing that stops it).
+	if rec := getPath(t, srv, "127.0.0.1:8090", "/api/events", full); rec.Code == http.StatusForbidden {
+		t.Errorf("full-access GET /api/events = 403, authz should not block a policy-less session")
+	}
+	// The static token is also policy-less — never blocked by authz.
+	if rec := getPath(t, srv, "127.0.0.1:8090", "/api/capabilities", "static-tok"); rec.Code == http.StatusForbidden {
+		t.Errorf("static token GET /api/capabilities = 403, want not-403")
+	}
+}
+
+// TestCapabilitiesReportsScopedPermissions pins that /api/capabilities reflects a
+// scoped session's grants (so the SPA can gate its UI), and full grants for a
+// policy-less session.
+func TestCapabilitiesReportsScopedPermissions(t *testing.T) {
+	srv, err := New(Config{Listen: "127.0.0.1:8090", Token: "static-tok", AuthPath: filepath.Join(t.TempDir(), "auth.yaml")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	viewer := &ext.AccessPolicy{Permissions: []ext.Permission{ext.PermStatusRead, ext.PermServersRead}}
+	scoped, _, _ := srv.sessions.IssueWithPolicy(viewer)
+
+	rec := getPath(t, srv, "127.0.0.1:8090", "/api/capabilities", scoped)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /api/capabilities = %d", rec.Code)
+	}
+	var caps struct {
+		Permissions map[string]bool `json:"permissions"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &caps); err != nil {
+		t.Fatal(err)
+	}
+	if !caps.Permissions[string(ext.PermStatusRead)] || caps.Permissions[string(ext.PermQueryExecute)] {
+		t.Errorf("scoped capabilities.permissions = %v, want status:read true and query:execute false", caps.Permissions)
+	}
+
+	// Policy-less (static token): every permission reported true.
+	rec = getPath(t, srv, "127.0.0.1:8090", "/api/capabilities", "static-tok")
+	if err := json.Unmarshal(rec.Body.Bytes(), &caps); err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range ext.AllPermissions() {
+		if !caps.Permissions[string(p)] {
+			t.Errorf("policy-less capabilities missing %q=true", p)
+		}
+	}
+}

--- a/internal/console/reconstruct.go
+++ b/internal/console/reconstruct.go
@@ -87,6 +87,12 @@ type capabilitiesResponse struct {
 	// per entry. Generic by construction — the core names no specific view.
 	ExtensionViews []extensionViewDTO `json:"extension_views,omitempty"`
 	Auth           authCapsInfo       `json:"auth"`
+	// Permissions is this session's effective grant of every permission the core
+	// defines, for the SPA to gate its UI (hide tabs/buttons a scoped session
+	// cannot use). All-true for a policy-less session — the static token, the
+	// password login, and every OSS session — so the UI hides nothing there.
+	// Server-side 403 (authzMiddleware) is the real gate; this only tidies the UI.
+	Permissions map[string]bool `json:"permissions"`
 	// MCP: the /mcp endpoint is usable — a static console token or a
 	// UI-managed MCP token is configured (the endpoint's only accepted
 	// credentials; see mcp.go). Process-global, like Monitor. The frontend's
@@ -151,6 +157,7 @@ func (s *Server) handleCapabilities(w http.ResponseWriter, r *http.Request) {
 		// only by the RBAC profile (which would make synthesis leak redacted data).
 		RecoverCascade: !s.rbacActive(),
 		Auth:           authCapsInfo{PasswordSet: s.passwordLoginEnabled(), AuthKind: kind},
+		Permissions:    permissionsForPolicy(policyFrom(r.Context())),
 		// The MCP endpoint accepts the static token or the UI-managed one
 		// (mcp.go refuses with 403 when neither is configured), so token
 		// presence IS the capability.

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -510,7 +510,11 @@ func (s *Server) buildHandler() http.Handler {
 			api.Handle(dataPrefix, s.rbacViewGuard(p.DataHandler(dataPrefix, s.consoleQueryContext)))
 		}
 	}
-	root.Handle("/api/", s.tokenMiddleware(api)) // credential on all other /api/*
+	// credential on all other /api/* (tokenMiddleware), then per-session
+	// authorization (authzMiddleware). authz is inert for policy-less sessions —
+	// the static token, the password login, and every OSS session — so this only
+	// enforces when an EE build attaches a policy via the session-issuer seam.
+	root.Handle("/api/", s.tokenMiddleware(s.authzMiddleware(api)))
 	// MCP endpoint (#1039): the four read-only tools over Streamable HTTP,
 	// token-authenticated (static or UI-managed — #1052), routed per server
 	// by URL path. Carries its own auth check (tokens only, no sessions —

--- a/internal/console/sessions.go
+++ b/internal/console/sessions.go
@@ -6,6 +6,8 @@ import (
 	"encoding/hex"
 	"sync"
 	"time"
+
+	"github.com/dbtrail/dbtrail/ext"
 )
 
 // Session lifetime policy. Unexported constants on purpose — no knobs in v1
@@ -30,6 +32,10 @@ const sessionPrefix = "bcs_"
 type session struct {
 	createdAt time.Time
 	lastSeen  time.Time
+	// policy is the session's access scope, or nil for a full-access session
+	// (what the password login and the static token mint). Set only when an
+	// external auth provider passed one to IssueWithPolicy — i.e. an EE build.
+	policy *ext.AccessPolicy
 }
 
 // sessionStore holds the in-memory login sessions. Keys are
@@ -56,10 +62,17 @@ func newSessionStore() *sessionStore {
 // raw token out of the map means a heap dump yields hashes, not credentials.
 func sessionKey(token string) [32]byte { return sha256.Sum256([]byte(token)) }
 
-// Issue mints a new session token: sessionPrefix + 64 hex chars (256 bits of
-// crypto/rand entropy). It sweeps expired entries and, if the store is still
-// at capacity, evicts the earliest-expiring session.
+// Issue mints a new full-access (policy-less) session — what the password login
+// and the static token mint. See IssueWithPolicy for the scoped variant.
 func (s *sessionStore) Issue() (token string, expiresAt time.Time, err error) {
+	return s.IssueWithPolicy(nil)
+}
+
+// IssueWithPolicy mints a new session token: sessionPrefix + 64 hex chars (256
+// bits of crypto/rand entropy), carrying policy as its access scope (nil = full
+// access). It sweeps expired entries and, if the store is still at capacity,
+// evicts the earliest-expiring session.
+func (s *sessionStore) IssueWithPolicy(policy *ext.AccessPolicy) (token string, expiresAt time.Time, err error) {
 	b := make([]byte, 32)
 	if _, err := rand.Read(b); err != nil {
 		return "", time.Time{}, err
@@ -73,15 +86,24 @@ func (s *sessionStore) Issue() (token string, expiresAt time.Time, err error) {
 	if len(s.m) >= maxSessions {
 		s.evictEarliestLocked()
 	}
-	s.m[sessionKey(token)] = &session{createdAt: now, lastSeen: now}
+	s.m[sessionKey(token)] = &session{createdAt: now, lastSeen: now, policy: policy}
 	return token, now.Add(sessionAbsoluteTTL), nil
 }
 
 // Validate reports whether the presented token is a live session, refreshing
 // its idle timer (coarsely) on success. Expired entries are deleted lazily.
 func (s *sessionStore) Validate(token string) bool {
+	_, ok := s.Lookup(token)
+	return ok
+}
+
+// Lookup validates the presented token and, on success, returns its access
+// policy (nil for a full-access session). It refreshes the idle timer (coarsely)
+// and deletes an expired entry lazily — the same behavior Validate had; Validate
+// is now a thin wrapper. Nil-receiver-safe and fail-closed.
+func (s *sessionStore) Lookup(token string) (*ext.AccessPolicy, bool) {
 	if s == nil || token == "" {
-		return false
+		return nil, false
 	}
 	key := sessionKey(token)
 	now := s.now()
@@ -90,16 +112,16 @@ func (s *sessionStore) Validate(token string) bool {
 	defer s.mu.Unlock()
 	sess, ok := s.m[key]
 	if !ok {
-		return false
+		return nil, false
 	}
 	if s.expiredLocked(sess, now) {
 		delete(s.m, key)
-		return false
+		return nil, false
 	}
 	if now.Sub(sess.lastSeen) > lastSeenGranularity {
 		sess.lastSeen = now
 	}
-	return true
+	return sess.policy, true
 }
 
 // Revoke deletes the presented session, if any. Idempotent.


### PR DESCRIPTION
closes #1074

## Summary
- **`ext` seam (no-op default):** `AccessPolicy` (a set of `verb:noun` permission strings + a data-profile name) and the 10 permission constants. The core enforces permission **sets**, never named roles — an embedding EE build maps its own `admin/operator/analyst/viewer` vocabulary onto these strings. `ConsoleSessionIssuer` gains a `*AccessPolicy` parameter (nil = full access); no in-repo implementor, so the signature break is absorbed in one release.
- **Session carries the policy:** `sessionStore.IssueWithPolicy`/`Lookup`; `tokenMiddleware` threads the policy onto the request context.
- **Enforcement (`authzMiddleware`):** an ordered `(method, pattern) → permission` table with `{}` single-segment placeholders, exact segment-count matching, first-match-wins. An unclassified route is **403 fail-closed**; a denied permission is a 403 that names the missing permission plus a `warn` log. Inert for policy-less sessions.
- **UI gating:** `/api/capabilities` reports the session's effective grants (all-true when policy-less, so the OSS UI is unchanged); a `[data-perm]` surface hides only on an explicit deny. Server-side 403 remains the real gate.

## OSS behavior preserved
The password login and the static token mint **policy-less** sessions, and a nil policy is full access — so every OSS session reaches every route exactly as before. Only an installed provider (an EE build) attaches a policy. `TestAuthzMiddlewarePolicyLessAllowsEverything` pins this regression guard across every registered route.

## Not in this PR (per the epic)
- Data-profile enforcement (deny/redact, archive & reconstruct gates per session) — #1075.
- Pluggable credential backend for the password login — #1076.

## Test plan
- [x] `go build ./...` clean; `go vet -tags integration ./ext/... ./internal/console/...` clean
- [x] New `authz_test.go`: route-table completeness + no-dead-entries, unknown-permission guard, ordering/reachability, exact-depth, ext-prefix, fail-closed, policy-less-allows-everything, scoped-session 403 (names the permission), capabilities grant map, end-to-end scoped vs full session
- [x] `ext` package tests pass; full `internal/console` suite passes in isolation (a pre-existing async-telemetry-spool flake trips only under full-package load — `TestRecordAction*` pass isolated, and those tests never touch this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)