### PR TITLE
stream: record continuity loss when --reset skips binlog history

### DIFF
--- a/cliapp/stream.go
+++ b/cliapp/stream.go
@@ -36,6 +36,9 @@ Use --reset to clear the saved checkpoint and force a new start position:
   bintrail stream --reset --start-file mysql-bin.000500 ...
 
 Without --reset, the checkpoint always wins (idempotent behavior is preserved).
+Resetting past a saved checkpoint permanently skips every event between the
+discarded checkpoint and the new start position; the skipped range is durably
+recorded as lost (surfaced by 'bintrail status' and its --fail-on-gap flag).
 
 Gap detection: on restart, bintrail checks whether the source still has the
 binlogs needed to resume from the checkpoint. If binlogs have been purged, it
@@ -93,7 +96,7 @@ func init() {
 	streamCmd.Flags().StringVar(&strmSSLCert, "ssl-cert", "", "Path to client certificate file for mutual TLS")
 	streamCmd.Flags().StringVar(&strmSSLKey, "ssl-key", "", "Path to client private key file for mutual TLS")
 	streamCmd.Flags().StringVar(&strmFormat, "format", "text", "Output format: text or json")
-	streamCmd.Flags().BoolVar(&strmReset, "reset", false, "Clear saved checkpoint before starting (forces use of --start-file/--start-gtid)")
+	streamCmd.Flags().BoolVar(&strmReset, "reset", false, "Clear saved checkpoint before starting (forces use of --start-file/--start-gtid); the skipped range is recorded as permanently lost")
 	streamCmd.Flags().BoolVar(&strmNoGapFill, "no-gap-fill", false, "Refuse to start if an unfillable binlog gap is detected (instead of auto-advancing past purged data)")
 	streamCmd.Flags().IntVar(&strmGapTimeout, "gap-timeout", 30, "Timeout in seconds for the one-shot gap-detection queries run at startup (SHOW BINARY LOGS plus @@gtid_purged/@@gtid_executed on MySQL or BINLOG_GTID_POS/@@gtid_binlog_pos on MariaDB); raise on managed servers with many binlog files")
 	streamCmd.Flags().DurationVar(&indexer.WriteTimeout, "write-timeout", indexer.DefaultWriteTimeout, "Deadline for each index write (batch INSERT, checkpoint, digest lookup). A mid-statement network stall surfaces as an error within this window instead of freezing the stream on kernel TCP retransmission (~13-16 min). Raise for very large batches over a slow link")

--- a/cliapp/stream.go
+++ b/cliapp/stream.go
@@ -36,8 +36,9 @@ Use --reset to clear the saved checkpoint and force a new start position:
   bintrail stream --reset --start-file mysql-bin.000500 ...
 
 Without --reset, the checkpoint always wins (idempotent behavior is preserved).
-Resetting past a saved checkpoint permanently skips every event between the
-discarded checkpoint and the new start position; the skipped range is durably
+Resetting to any position other than the saved checkpoint — later or earlier;
+direction is not inferred — permanently skips every event between the discarded
+checkpoint and the new start position, and the skipped range is durably
 recorded as lost (surfaced by 'bintrail status' and its --fail-on-gap flag).
 
 Gap detection: on restart, bintrail checks whether the source still has the

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -116,6 +116,8 @@ bintrail stream \
 
 `--reset` clears the saved checkpoint in `stream_state` before starting, forcing the command to use the `--start-file`/`--start-gtid` flags from the command line. Without `--reset`, the saved checkpoint always takes precedence.
 
+**`--reset` skips history permanently.** Every event between the discarded checkpoint and the new start position is never indexed. When the discard actually jumps over binlog history, the skipped range is durably recorded as a continuity loss (`gap_lost_at` / `gap_lost_detail` in `stream_state`) — `bintrail status` shows the `EVENTS PERMANENTLY LOST` banner and `status --fail-on-gap` exits non-zero, exactly as after an unfillable-gap auto-advance. A reset that lands on the same position it discarded records nothing (nothing was skipped).
+
 **When to use `--reset`:**
 - Switching from position mode to GTID mode (or vice versa)
 - Forcing a restart from a known position after a disaster recovery

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -114,9 +114,9 @@ bintrail stream \
   --reset
 ```
 
-`--reset` clears the saved checkpoint in `stream_state` before starting, forcing the command to use the `--start-file`/`--start-gtid` flags from the command line. Without `--reset`, the saved checkpoint always takes precedence.
+`--reset` discards the saved checkpoint in `stream_state` and replaces it once the new start position is resolved, forcing the command to use the `--start-file`/`--start-gtid` flags from the command line. Without `--reset`, the saved checkpoint always takes precedence.
 
-**`--reset` skips history permanently.** Every event between the discarded checkpoint and the new start position is never indexed. When the discard actually jumps over binlog history, the skipped range is durably recorded as a continuity loss (`gap_lost_at` / `gap_lost_detail` in `stream_state`) — `bintrail status` shows the `EVENTS PERMANENTLY LOST` banner and `status --fail-on-gap` exits non-zero, exactly as after an unfillable-gap auto-advance. A reset that lands on the same position it discarded records nothing (nothing was skipped).
+**`--reset` skips history permanently.** Every event between the discarded checkpoint and the new start position is never indexed. A reset that lands anywhere other than the discarded checkpoint's exact coordinates — including an *earlier* position (direction is not inferred) — is durably recorded as a continuity loss (`gap_lost_at` / `gap_lost_detail` in `stream_state`): `bintrail status` shows the `EVENTS PERMANENTLY LOST` banner and `status --fail-on-gap` exits non-zero, exactly as after an unfillable-gap auto-advance. Such a reset also replaces the detail text of any earlier, still-unacknowledged loss record. A reset that lands on the same coordinates it discarded records nothing and leaves any prior loss record untouched — note the check is coordinates-only: after a source rebuild (`RESET MASTER` + restore) the same coordinates can name a different history.
 
 **When to use `--reset`:**
 - Switching from position mode to GTID mode (or vice versa)

--- a/internal/streamrun/reset_test.go
+++ b/internal/streamrun/reset_test.go
@@ -1,25 +1,30 @@
 package streamrun
 
 import (
+	"errors"
 	"strings"
 	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	gomysql "github.com/go-mysql-org/go-mysql/mysql"
 )
 
 // TestResetJumpDetail_positionNoop: discarding a checkpoint and restarting at
 // the exact same file:pos skips nothing — no loss record must be written.
 func TestResetJumpDetail_positionNoop(t *testing.T) {
 	old := &streamState{mode: "position", binlogFile: "mysql-bin.000043", binlogPos: 1000}
-	noop, detail := resetJumpDetail(old, "position", "mysql-bin.000043", 1000, "")
+	noop, detail := resetJumpDetail(old, gomysql.MySQLFlavor, "position", "mysql-bin.000043", 1000, "")
 	if !noop {
 		t.Fatalf("same-position reset must be a noop, got detail %q", detail)
 	}
 }
 
-// TestResetJumpDetail_positionJump: a reset that lands anywhere else is a jump
-// and the detail must name both coordinates so gap_lost_detail is actionable.
+// TestResetJumpDetail_positionJump: a reset that lands anywhere else — later
+// OR earlier (direction is not inferred) — is a jump and the detail must name
+// both coordinates so gap_lost_detail is actionable.
 func TestResetJumpDetail_positionJump(t *testing.T) {
 	old := &streamState{mode: "position", binlogFile: "mysql-bin.000043", binlogPos: 1000}
-	noop, detail := resetJumpDetail(old, "position", "mysql-bin.000044", 4, "")
+	noop, detail := resetJumpDetail(old, gomysql.MySQLFlavor, "position", "mysql-bin.000044", 4, "")
 	if noop {
 		t.Fatal("jump to a different position must not be a noop")
 	}
@@ -28,13 +33,16 @@ func TestResetJumpDetail_positionJump(t *testing.T) {
 			t.Errorf("detail %q missing %q", detail, want)
 		}
 	}
+	if noop, _ := resetJumpDetail(old, gomysql.MySQLFlavor, "position", "mysql-bin.000001", 4, ""); noop {
+		t.Fatal("rewind to an earlier position must also be recorded, not treated as a noop")
+	}
 }
 
 // TestResetJumpDetail_gtidNoop: GTID sets are compared structurally, so
 // formatting differences (UUID case) must not fake a jump.
 func TestResetJumpDetail_gtidNoop(t *testing.T) {
 	old := &streamState{mode: "gtid", gtidSet: "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-5"}
-	noop, _ := resetJumpDetail(old, "gtid", "", 0, "3E11FA47-71CA-11E1-9E33-C80AA9429562:1-5")
+	noop, _ := resetJumpDetail(old, gomysql.MySQLFlavor, "gtid", "", 0, "3E11FA47-71CA-11E1-9E33-C80AA9429562:1-5")
 	if !noop {
 		t.Fatal("structurally equal GTID sets must be a noop")
 	}
@@ -44,7 +52,7 @@ func TestResetJumpDetail_gtidNoop(t *testing.T) {
 // detail carries both sets.
 func TestResetJumpDetail_gtidJump(t *testing.T) {
 	old := &streamState{mode: "gtid", gtidSet: "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-5"}
-	noop, detail := resetJumpDetail(old, "gtid", "", 0, "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-9000")
+	noop, detail := resetJumpDetail(old, gomysql.MySQLFlavor, "gtid", "", 0, "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-9000")
 	if noop {
 		t.Fatal("different GTID sets must not be a noop")
 	}
@@ -55,16 +63,137 @@ func TestResetJumpDetail_gtidJump(t *testing.T) {
 	}
 }
 
+// TestResetJumpDetail_mariadbGTIDNoop: MariaDB sets (domain-server-seq) never
+// parse as MySQL sets, so the comparison must dispatch by flavor — a
+// same-set MariaDB reset misclassified as a jump would stamp a false
+// "permanently lost" record and trip status --fail-on-gap forever.
+func TestResetJumpDetail_mariadbGTIDNoop(t *testing.T) {
+	old := &streamState{mode: "gtid", gtidSet: "0-1-100", flavor: gomysql.MariaDBFlavor}
+	noop, detail := resetJumpDetail(old, gomysql.MariaDBFlavor, "gtid", "", 0, "0-1-100")
+	if !noop {
+		t.Fatalf("same MariaDB GTID set must be a noop, got detail %q", detail)
+	}
+}
+
+// TestResetJumpDetail_mariadbGTIDJump: a genuinely different MariaDB set is
+// still recorded as a jump under the MariaDB comparator.
+func TestResetJumpDetail_mariadbGTIDJump(t *testing.T) {
+	old := &streamState{mode: "gtid", gtidSet: "0-1-100", flavor: gomysql.MariaDBFlavor}
+	if noop, _ := resetJumpDetail(old, gomysql.MariaDBFlavor, "gtid", "", 0, "0-1-900"); noop {
+		t.Fatal("different MariaDB GTID sets must not be a noop")
+	}
+}
+
 // TestResetJumpDetail_crossModeIsJump: position→gtid (and the reverse) have no
 // comparable coordinates; conservatively treat the discard as a jump so the
 // loss is recorded rather than silently assumed away.
 func TestResetJumpDetail_crossModeIsJump(t *testing.T) {
 	old := &streamState{mode: "position", binlogFile: "mysql-bin.000043", binlogPos: 1000}
-	if noop, _ := resetJumpDetail(old, "gtid", "", 0, "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-5"); noop {
+	if noop, _ := resetJumpDetail(old, gomysql.MySQLFlavor, "gtid", "", 0, "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-5"); noop {
 		t.Fatal("cross-mode reset must be treated as a jump")
 	}
 	oldGTID := &streamState{mode: "gtid", gtidSet: "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-5"}
-	if noop, _ := resetJumpDetail(oldGTID, "position", "mysql-bin.000050", 4, ""); noop {
+	if noop, _ := resetJumpDetail(oldGTID, gomysql.MySQLFlavor, "position", "mysql-bin.000050", 4, ""); noop {
 		t.Fatal("cross-mode reset must be treated as a jump")
+	}
+}
+
+func freshResetState() *streamState {
+	return &streamState{mode: "gtid", gtidSet: "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-9000", flavor: gomysql.MySQLFlavor, serverID: 99}
+}
+
+// TestPersistResetDiscard_jumpStampsBeforeCheckpoint pins the branch wiring:
+// a jump must go through the gap_lost stamp (UPDATE) BEFORE the fresh
+// checkpoint (INSERT upsert) — sqlmock matches in order — and must fire the
+// supervisor hook only after both writes succeeded.
+func TestPersistResetDiscard_jumpStampsBeforeCheckpoint(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec("UPDATE stream_state").
+		WithArgs("events lost via reset").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT INTO stream_state").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	var hooked string
+	hooks := &Hooks{OnGapAutoAdvance: func(detail string) { hooked = detail }}
+	if err := persistResetDiscard(db, freshResetState(), false, "events lost via reset", hooks); err != nil {
+		t.Fatalf("persistResetDiscard: %v", err)
+	}
+	if hooked != "events lost via reset" {
+		t.Errorf("supervisor hook not fired with the loss detail, got %q", hooked)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("jump must stamp gap_lost before the checkpoint: %v", err)
+	}
+}
+
+// TestPersistResetDiscard_noopWritesOnlyCheckpoint: a no-op discard must not
+// stamp gap_lost (no UPDATE — sqlmock errors on unexpected statements) and
+// must not fire the loss hook.
+func TestPersistResetDiscard_noopWritesOnlyCheckpoint(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec("INSERT INTO stream_state").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	hooks := &Hooks{OnGapAutoAdvance: func(string) { t.Error("loss hook must not fire on a no-op reset") }}
+	if err := persistResetDiscard(db, freshResetState(), true, "", hooks); err != nil {
+		t.Fatalf("persistResetDiscard: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("noop must write only the fresh checkpoint: %v", err)
+	}
+}
+
+// TestPersistResetDiscard_hookSkippedOnPersistFailure: if the durable record
+// fails, the error propagates and the in-memory supervisor signal must not
+// fire — an in-memory loss badge must never outlive a failed durable record.
+func TestPersistResetDiscard_hookSkippedOnPersistFailure(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec("UPDATE stream_state").
+		WillReturnError(errors.New("index DB down"))
+
+	hooks := &Hooks{OnGapAutoAdvance: func(string) { t.Error("loss hook must not fire when the durable record failed") }}
+	if err := persistResetDiscard(db, freshResetState(), false, "events lost via reset", hooks); err == nil {
+		t.Fatal("expected an error when the gap-loss stamp fails")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("checkpoint must not be written after a failed stamp: %v", err)
+	}
+}
+
+// TestSaveCheckpoint_upsertUpdatesMode pins the cross-mode --reset fix: the
+// stream_state row survives a reset now, so a position→gtid (or reverse)
+// switch must land through the upsert's UPDATE arm. Without mode in that arm
+// the next restart would silently resume in the OLD mode.
+func TestSaveCheckpoint_upsertUpdatesMode(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec(`ON DUPLICATE KEY UPDATE\s+mode\s+= VALUES\(mode\)`).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := saveCheckpoint(db, freshResetState()); err != nil {
+		t.Fatalf("saveCheckpoint: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("upsert must update mode on duplicate key: %v", err)
 	}
 }

--- a/internal/streamrun/reset_test.go
+++ b/internal/streamrun/reset_test.go
@@ -1,0 +1,70 @@
+package streamrun
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestResetJumpDetail_positionNoop: discarding a checkpoint and restarting at
+// the exact same file:pos skips nothing — no loss record must be written.
+func TestResetJumpDetail_positionNoop(t *testing.T) {
+	old := &streamState{mode: "position", binlogFile: "mysql-bin.000043", binlogPos: 1000}
+	noop, detail := resetJumpDetail(old, "position", "mysql-bin.000043", 1000, "")
+	if !noop {
+		t.Fatalf("same-position reset must be a noop, got detail %q", detail)
+	}
+}
+
+// TestResetJumpDetail_positionJump: a reset that lands anywhere else is a jump
+// and the detail must name both coordinates so gap_lost_detail is actionable.
+func TestResetJumpDetail_positionJump(t *testing.T) {
+	old := &streamState{mode: "position", binlogFile: "mysql-bin.000043", binlogPos: 1000}
+	noop, detail := resetJumpDetail(old, "position", "mysql-bin.000044", 4, "")
+	if noop {
+		t.Fatal("jump to a different position must not be a noop")
+	}
+	for _, want := range []string{"--reset", "mysql-bin.000043:1000", "mysql-bin.000044:4", "permanently lost"} {
+		if !strings.Contains(detail, want) {
+			t.Errorf("detail %q missing %q", detail, want)
+		}
+	}
+}
+
+// TestResetJumpDetail_gtidNoop: GTID sets are compared structurally, so
+// formatting differences (UUID case) must not fake a jump.
+func TestResetJumpDetail_gtidNoop(t *testing.T) {
+	old := &streamState{mode: "gtid", gtidSet: "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-5"}
+	noop, _ := resetJumpDetail(old, "gtid", "", 0, "3E11FA47-71CA-11E1-9E33-C80AA9429562:1-5")
+	if !noop {
+		t.Fatal("structurally equal GTID sets must be a noop")
+	}
+}
+
+// TestResetJumpDetail_gtidJump: a different executed set is a jump and the
+// detail carries both sets.
+func TestResetJumpDetail_gtidJump(t *testing.T) {
+	old := &streamState{mode: "gtid", gtidSet: "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-5"}
+	noop, detail := resetJumpDetail(old, "gtid", "", 0, "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-9000")
+	if noop {
+		t.Fatal("different GTID sets must not be a noop")
+	}
+	for _, want := range []string{"gtid_set 3e11fa47-71ca-11e1-9e33-c80aa9429562:1-5", "gtid_set 3e11fa47-71ca-11e1-9e33-c80aa9429562:1-9000"} {
+		if !strings.Contains(detail, want) {
+			t.Errorf("detail %q missing %q", detail, want)
+		}
+	}
+}
+
+// TestResetJumpDetail_crossModeIsJump: position→gtid (and the reverse) have no
+// comparable coordinates; conservatively treat the discard as a jump so the
+// loss is recorded rather than silently assumed away.
+func TestResetJumpDetail_crossModeIsJump(t *testing.T) {
+	old := &streamState{mode: "position", binlogFile: "mysql-bin.000043", binlogPos: 1000}
+	if noop, _ := resetJumpDetail(old, "gtid", "", 0, "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-5"); noop {
+		t.Fatal("cross-mode reset must be treated as a jump")
+	}
+	oldGTID := &streamState{mode: "gtid", gtidSet: "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-5"}
+	if noop, _ := resetJumpDetail(oldGTID, "position", "mysql-bin.000050", 4, ""); noop {
+		t.Fatal("cross-mode reset must be treated as a jump")
+	}
+}

--- a/internal/streamrun/streamrun.go
+++ b/internal/streamrun/streamrun.go
@@ -273,7 +273,8 @@ func deleteEventsSinceCheckpointGTID(db *sql.DB, file string, pos uint64, savedS
 // loud; a failed stamp aborts startup with the OLD checkpoint intact, so the gap
 // is re-detected and re-recorded on the next start. saveCheckpoint's upsert does
 // not touch the gap_lost_* columns, so the stamp survives it. Cleared by an
-// explicit monitor Stop or --reset.
+// explicit monitor Stop; --reset re-stamps it with the discarded range (#1079)
+// instead of clearing.
 func persistGapAutoAdvance(db *sql.DB, advanced *streamState, gapMessage string) error {
 	if _, err := db.Exec(`UPDATE stream_state
 		SET gap_lost_at = UTC_TIMESTAMP(), gap_lost_detail = ?
@@ -284,6 +285,38 @@ func persistGapAutoAdvance(db *sql.DB, advanced *streamState, gapMessage string)
 		return fmt.Errorf("failed to save advanced checkpoint: %w", err)
 	}
 	return nil
+}
+
+// resetJumpDetail classifies a --reset checkpoint discard. It returns
+// noop=true when the new start position equals the discarded checkpoint —
+// nothing was skipped. Otherwise it returns a human-readable description of
+// the jumped-over range, suitable for gap_lost_detail. Cross-mode discards
+// (position→gtid or the reverse) have no comparable coordinates and are
+// conservatively treated as a jump.
+func resetJumpDetail(old *streamState, mode, file string, pos uint32, gtidSet string) (noop bool, detail string) {
+	switch {
+	case old.mode == "position" && mode == "position":
+		if old.binlogFile == file && old.binlogPos == uint64(pos) {
+			return true, ""
+		}
+	case old.mode == "gtid" && mode == "gtid":
+		if gtidSetsEqual(old.gtidSet, gtidSet) {
+			return true, ""
+		}
+	}
+	return false, fmt.Sprintf(
+		"checkpoint discarded via --reset: was %s, restarting at %s; events in between were skipped and are permanently lost",
+		describeCheckpoint(old.mode, old.binlogFile, old.binlogPos, old.gtidSet),
+		describeCheckpoint(mode, file, uint64(pos), gtidSet))
+}
+
+// describeCheckpoint renders a checkpoint's coordinates for human-readable
+// loss records: "file:pos" in position mode, "gtid_set <set>" in GTID mode.
+func describeCheckpoint(mode, file string, pos uint64, gtidSet string) string {
+	if mode == "gtid" {
+		return fmt.Sprintf("gtid_set %s", gtidSet)
+	}
+	return fmt.Sprintf("%s:%d", file, pos)
 }
 
 // ─── TLS configuration ───────────────────────────────────────────────────────────────
@@ -1635,12 +1668,17 @@ func One(ctx context.Context, cfg Config) error {
 		return fmt.Errorf("failed to load stream state: %w", err)
 	}
 
+	// --reset discards the saved checkpoint so start resolution runs as a
+	// first run. The old state is kept aside instead of DELETEd here (#1079):
+	// the discard is persisted only after the new start position is known, so
+	// the jumped-over binlog range can be stamped as lost FIRST — and a
+	// startup failure in between leaves the old checkpoint (and any prior
+	// gap_lost record) intact.
+	var resetDiscarded *streamState
 	if cfg.Reset {
 		if saved != nil {
-			if _, err := indexDB.Exec(`DELETE FROM stream_state WHERE id = 1`); err != nil {
-				return fmt.Errorf("failed to reset stream state: %w", err)
-			}
-			slog.Warn("cleared saved checkpoint (--reset)", "old_mode", saved.mode,
+			resetDiscarded = saved
+			slog.Warn("discarding saved checkpoint (--reset)", "old_mode", saved.mode,
 				"old_file", saved.binlogFile, "old_pos", saved.binlogPos)
 			saved = nil
 		} else {
@@ -1659,6 +1697,45 @@ func One(ctx context.Context, cfg Config) error {
 	if saved == nil && cfg.StartFile == "" && cfg.StartGTID == "" && mode == "position" {
 		slog.Info("auto-discovered current binlog position", "file", startFile, "pos", startPos)
 		fmt.Printf("Start position: auto-discovered %s:%d ✓\n", startFile, startPos)
+	}
+
+	// Persist the --reset discard now that the new start position is known
+	// (#1079). A real jump is durably recorded exactly like an unfillable-gap
+	// auto-advance — gap_lost stamp FIRST, then the fresh checkpoint (the #402
+	// ordering invariant), plus the supervisor hook so the console reflects
+	// the loss. A no-op reset (new start equals the discarded checkpoint)
+	// skipped nothing, so only the fresh checkpoint is written; prior
+	// gap_lost history is preserved either way (monitor Stop remains the
+	// acknowledgment path — reset no longer erases loss records).
+	if resetDiscarded != nil {
+		fresh := &streamState{
+			mode:          mode,
+			binlogFile:    startFile,
+			binlogPos:     uint64(startPos),
+			safeFile:      startFile,
+			safePos:       uint64(startPos),
+			gtidSet:       startGTIDStr,
+			flavor:        cfg.Flavor,
+			serverID:      cfg.ServerID,
+			bintrailID:    bintrailID,
+			eventsIndexed: resetDiscarded.eventsIndexed,
+			lastEventTime: resetDiscarded.lastEventTime,
+		}
+		if noop, detail := resetJumpDetail(resetDiscarded, mode, startFile, startPos, startGTIDStr); noop {
+			if err := saveCheckpoint(indexDB, fresh); err != nil {
+				return fmt.Errorf("failed to persist reset checkpoint: %w", err)
+			}
+			slog.Info("--reset discarded a checkpoint at the same position; nothing was skipped")
+		} else {
+			slog.Warn("--reset is skipping binlog history", "detail", detail)
+			fmt.Printf("Reset: %s\n", detail)
+			if err := persistGapAutoAdvance(indexDB, fresh, detail); err != nil {
+				return err
+			}
+			if cfg.Hooks != nil && cfg.Hooks.OnGapAutoAdvance != nil {
+				cfg.Hooks.OnGapAutoAdvance(detail)
+			}
+		}
 	}
 
 	// ── 6b. Detect binlog gap ────────────────────────────────────────────

--- a/internal/streamrun/streamrun.go
+++ b/internal/streamrun/streamrun.go
@@ -140,6 +140,9 @@ func saveCheckpoint(db *sql.DB, state *streamState) error {
 	}
 	// #775: in position mode this persists the last safe boundary, not the
 	// per-event offset (see checkpointPosition).
+	// mode is in the UPDATE arm for the cross-mode --reset path (#1079): the
+	// reset no longer DELETEs the row, so the mode switch must land through
+	// this upsert. For every other caller mode is invariant across the run.
 	file, pos := checkpointPosition(state)
 	// #959: bound the checkpoint write with a deadline (see indexer.WriteTimeout)
 	// so a mid-statement network stall fails fast instead of freezing the daemon
@@ -152,6 +155,7 @@ func saveCheckpoint(db *sql.DB, state *streamState) error {
 		     events_indexed, last_event_time, last_checkpoint, server_id, bintrail_id)
 		VALUES (1, ?, ?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(), ?, ?)
 		ON DUPLICATE KEY UPDATE
+		    mode            = VALUES(mode),
 		    binlog_file     = VALUES(binlog_file),
 		    binlog_position = VALUES(binlog_position),
 		    gtid_set        = VALUES(gtid_set),
@@ -273,8 +277,8 @@ func deleteEventsSinceCheckpointGTID(db *sql.DB, file string, pos uint64, savedS
 // loud; a failed stamp aborts startup with the OLD checkpoint intact, so the gap
 // is re-detected and re-recorded on the next start. saveCheckpoint's upsert does
 // not touch the gap_lost_* columns, so the stamp survives it. Cleared by an
-// explicit monitor Stop; --reset re-stamps it with the discarded range (#1079)
-// instead of clearing.
+// explicit monitor Stop; a jumping --reset re-stamps it with the discarded
+// range (#1079) and a same-position --reset leaves it intact.
 func persistGapAutoAdvance(db *sql.DB, advanced *streamState, gapMessage string) error {
 	if _, err := db.Exec(`UPDATE stream_state
 		SET gap_lost_at = UTC_TIMESTAMP(), gap_lost_detail = ?
@@ -290,17 +294,27 @@ func persistGapAutoAdvance(db *sql.DB, advanced *streamState, gapMessage string)
 // resetJumpDetail classifies a --reset checkpoint discard. It returns
 // noop=true when the new start position equals the discarded checkpoint —
 // nothing was skipped. Otherwise it returns a human-readable description of
-// the jumped-over range, suitable for gap_lost_detail. Cross-mode discards
-// (position→gtid or the reverse) have no comparable coordinates and are
-// conservatively treated as a jump.
-func resetJumpDetail(old *streamState, mode, file string, pos uint32, gtidSet string) (noop bool, detail string) {
+// the jumped-over range, suitable for gap_lost_detail. The check is
+// deliberately conservative in three ways: cross-mode discards (position→gtid
+// or the reverse) have no comparable coordinates and are treated as a jump;
+// direction is not inferred, so a reset to an EARLIER position also records a
+// loss verdict; and equality is coordinates-only — after a source rebuild
+// (RESET MASTER + restore) the same coordinates can name a different history,
+// which no checkpoint comparison can see. GTID sets are compared structurally
+// with the parser for flavor (MySQL UUID sets vs MariaDB domain-server-seq),
+// so formatting differences never fake a jump on either flavor.
+func resetJumpDetail(old *streamState, flavor, mode, file string, pos uint32, gtidSet string) (noop bool, detail string) {
 	switch {
 	case old.mode == "position" && mode == "position":
 		if old.binlogFile == file && old.binlogPos == uint64(pos) {
 			return true, ""
 		}
 	case old.mode == "gtid" && mode == "gtid":
-		if gtidSetsEqual(old.gtidSet, gtidSet) {
+		equal := gtidSetsEqual
+		if flavor == gomysql.MariaDBFlavor {
+			equal = mariadbGTIDSetsEqual
+		}
+		if equal(old.gtidSet, gtidSet) {
 			return true, ""
 		}
 	}
@@ -308,6 +322,34 @@ func resetJumpDetail(old *streamState, mode, file string, pos uint32, gtidSet st
 		"checkpoint discarded via --reset: was %s, restarting at %s; events in between were skipped and are permanently lost",
 		describeCheckpoint(old.mode, old.binlogFile, old.binlogPos, old.gtidSet),
 		describeCheckpoint(mode, file, uint64(pos), gtidSet))
+}
+
+// persistResetDiscard durably persists a --reset checkpoint discard once the
+// new start position is resolved. A jump is recorded exactly like an
+// unfillable-gap auto-advance: gap_lost stamp FIRST, then the fresh
+// checkpoint (the #402 ordering invariant, via persistGapAutoAdvance),
+// user-visible output and the supervisor hook only after the record is
+// durable. A no-op discard skipped nothing, so only the fresh checkpoint is
+// written and any prior gap_lost record is left untouched; a jump replaces a
+// prior record's detail with the reset detail (the loss flag itself never
+// clears here — monitor Stop remains the acknowledgment path).
+func persistResetDiscard(db *sql.DB, fresh *streamState, noop bool, detail string, hooks *Hooks) error {
+	if noop {
+		if err := saveCheckpoint(db, fresh); err != nil {
+			return fmt.Errorf("failed to persist reset checkpoint: %w", err)
+		}
+		slog.Info("--reset discarded a checkpoint at the same position; nothing was skipped")
+		return nil
+	}
+	slog.Warn("--reset is skipping binlog history", "detail", detail)
+	if err := persistGapAutoAdvance(db, fresh, detail); err != nil {
+		return err
+	}
+	fmt.Printf("Reset: %s\n", detail)
+	if hooks != nil && hooks.OnGapAutoAdvance != nil {
+		hooks.OnGapAutoAdvance(detail)
+	}
+	return nil
 }
 
 // describeCheckpoint renders a checkpoint's coordinates for human-readable
@@ -1700,41 +1742,26 @@ func One(ctx context.Context, cfg Config) error {
 	}
 
 	// Persist the --reset discard now that the new start position is known
-	// (#1079). A real jump is durably recorded exactly like an unfillable-gap
-	// auto-advance — gap_lost stamp FIRST, then the fresh checkpoint (the #402
-	// ordering invariant), plus the supervisor hook so the console reflects
-	// the loss. A no-op reset (new start equals the discarded checkpoint)
-	// skipped nothing, so only the fresh checkpoint is written; prior
-	// gap_lost history is preserved either way (monitor Stop remains the
-	// acknowledgment path — reset no longer erases loss records).
+	// (#1079) — see persistResetDiscard for the jump/no-op semantics. The
+	// counters restart with the stream: the in-memory streaming state below
+	// starts from zero when saved is nil, so eventsIndexed/lastEventTime are
+	// deliberately NOT carried from the discarded checkpoint (the first
+	// checkpoint tick would overwrite a carried value anyway).
 	if resetDiscarded != nil {
 		fresh := &streamState{
-			mode:          mode,
-			binlogFile:    startFile,
-			binlogPos:     uint64(startPos),
-			safeFile:      startFile,
-			safePos:       uint64(startPos),
-			gtidSet:       startGTIDStr,
-			flavor:        cfg.Flavor,
-			serverID:      cfg.ServerID,
-			bintrailID:    bintrailID,
-			eventsIndexed: resetDiscarded.eventsIndexed,
-			lastEventTime: resetDiscarded.lastEventTime,
+			mode:       mode,
+			binlogFile: startFile,
+			binlogPos:  uint64(startPos),
+			safeFile:   startFile,
+			safePos:    uint64(startPos),
+			gtidSet:    startGTIDStr,
+			flavor:     cfg.Flavor,
+			serverID:   cfg.ServerID,
+			bintrailID: bintrailID,
 		}
-		if noop, detail := resetJumpDetail(resetDiscarded, mode, startFile, startPos, startGTIDStr); noop {
-			if err := saveCheckpoint(indexDB, fresh); err != nil {
-				return fmt.Errorf("failed to persist reset checkpoint: %w", err)
-			}
-			slog.Info("--reset discarded a checkpoint at the same position; nothing was skipped")
-		} else {
-			slog.Warn("--reset is skipping binlog history", "detail", detail)
-			fmt.Printf("Reset: %s\n", detail)
-			if err := persistGapAutoAdvance(indexDB, fresh, detail); err != nil {
-				return err
-			}
-			if cfg.Hooks != nil && cfg.Hooks.OnGapAutoAdvance != nil {
-				cfg.Hooks.OnGapAutoAdvance(detail)
-			}
+		noop, detail := resetJumpDetail(resetDiscarded, cfg.Flavor, mode, startFile, startPos, startGTIDStr)
+		if err := persistResetDiscard(indexDB, fresh, noop, detail, cfg.Hooks); err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
closes #1079

## Summary
- `--reset` no longer `DELETE`s the `stream_state` row up front. The old checkpoint is kept aside; the discard is persisted only once the new start position is resolved, so a startup failure in between leaves the old checkpoint (and any prior `gap_lost` record) intact.
- A reset that actually jumps over binlog history is durably recorded like an unfillable-gap auto-advance: `gap_lost_at`/`gap_lost_detail` stamped **first**, then the fresh checkpoint (`persistGapAutoAdvance`, same #402 stamp-then-advance invariant), plus the `OnGapAutoAdvance` supervisor hook so the console badge reflects the loss. `status` now shows the `EVENTS PERMANENTLY LOST` banner and `--fail-on-gap` exits non-zero after such a reset.
- A no-op reset (new start equals the discarded checkpoint — same file:pos, or structurally equal GTID sets) records nothing and just writes the fresh checkpoint. Cross-mode discards (position↔gtid) are conservatively treated as jumps.
- Reset can no longer erase prior loss history; monitor Stop remains the explicit acknowledgment path.
- `--reset` help text and `docs/streaming.md` now state that the skipped range is permanent and recorded.

## Test plan
- [x] New unit tests for `resetJumpDetail` (position noop/jump, GTID structural-equality noop/jump, cross-mode) — `internal/streamrun/reset_test.go`
- [x] `go test ./... -count=1` passes; `go test -race ./internal/streamrun/` passes
- [x] `go vet -tags integration ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)