### PR TITLE
console: pluggable credential backend seam for the password login

### DIFF
--- a/ext/consolecred.go
+++ b/ext/consolecred.go
@@ -1,0 +1,60 @@
+package ext
+
+// Credential is what a ConsoleCredentialProvider returns on a SUCCESSFUL
+// verification. Identity is a display/log string (e.g. a username or email);
+// it is logged, never stored. Policy is the optional access scope to attach to
+// the session the console mints (see AccessPolicy) — nil for a full-access
+// session, exactly what the built-in single-user login mints.
+type Credential struct {
+	Identity string
+	Policy   *AccessPolicy
+}
+
+// ConsoleCredentialProvider replaces the credential check behind the console's
+// built-in username/password login form. It is the seam an embedding EE build
+// uses to serve that form from a multi-user store (or a directory service)
+// instead of the single-user auth file, while the console keeps ownership of
+// everything around the check: the login route, the JSON/content-type gate, the
+// request-size cap, the rate limiter, and session minting/lifetime/revocation.
+//
+// When a backend is installed it SUPERSEDES the built-in auth file for
+// /api/auth/login — the file is not consulted for login. (The static token is a
+// separate credential and is unaffected; /api/auth/setup stays built-in-only —
+// a backend never handles first-run password creation.) An EE backend that
+// wants to keep the operator's built-in credential working must incorporate it
+// itself.
+//
+// consoleCred is nil in the OSS build, so the built-in single-user auth file is
+// the sole login authority and behavior is unchanged.
+type ConsoleCredentialProvider interface {
+	// Verify checks (username, password). It returns a non-nil *Credential on
+	// success, or nil on ANY failure — bad username, bad password, disabled
+	// account, backend unavailable. The console renders one uniform 401 for a nil
+	// result, so the backend MUST NOT let the caller distinguish these cases.
+	//
+	// To preserve the console's anti-enumeration and anti-timing guarantees the
+	// backend MUST spend a constant, password-hash-equivalent cost on every call
+	// regardless of whether the username exists — mirror how the built-in path
+	// runs a full bcrypt compare against a dummy hash for an unknown username.
+	// The console's login rate limiter and body/content-type caps run BEFORE
+	// Verify, so the backend need not reimplement those.
+	Verify(username, password string) *Credential
+}
+
+// consoleCred is nil in the OSS build — the console's login form is served only
+// by the built-in single-user auth file.
+var consoleCred ConsoleCredentialProvider
+
+// SetConsoleCredentialProvider installs the process-wide console credential
+// backend. Call once from main() before command dispatch, like SetConsoleAuth:
+// the console reads it when the server is constructed, so a later install is
+// never picked up.
+func SetConsoleCredentialProvider(b ConsoleCredentialProvider) {
+	consoleCred = b
+}
+
+// ConsoleCredential returns the installed backend, or nil when none is
+// installed (the OSS build).
+func ConsoleCredential() ConsoleCredentialProvider {
+	return consoleCred
+}

--- a/ext/consolecred_test.go
+++ b/ext/consolecred_test.go
@@ -1,0 +1,39 @@
+package ext
+
+import "testing"
+
+type stubCredBackend struct{ id string }
+
+func (s stubCredBackend) Verify(username, password string) *Credential {
+	if username == "known" && password == "pw" {
+		return &Credential{Identity: s.id}
+	}
+	return nil
+}
+
+func TestConsoleCredentialDefaultsNil(t *testing.T) {
+	if ConsoleCredential() != nil {
+		t.Fatal("ConsoleCredential() != nil by default — the OSS build must have no backend installed")
+	}
+}
+
+func TestSetConsoleCredentialRoundTrip(t *testing.T) {
+	SetConsoleCredentialProvider(stubCredBackend{id: "alice"})
+	t.Cleanup(func() { SetConsoleCredentialProvider(nil) })
+
+	b := ConsoleCredential()
+	if b == nil {
+		t.Fatal("ConsoleCredential() = nil after SetConsoleCredentialProvider")
+	}
+	if cred := b.Verify("known", "pw"); cred == nil || cred.Identity != "alice" {
+		t.Errorf("Verify(known,pw) = %+v, want an admitted alice credential", cred)
+	}
+	if cred := b.Verify("known", "wrong"); cred != nil {
+		t.Errorf("Verify(known,wrong) = %+v, want nil (uniform rejection)", cred)
+	}
+
+	SetConsoleCredentialProvider(nil)
+	if ConsoleCredential() != nil {
+		t.Error("SetConsoleCredentialProvider(nil) did not clear the backend")
+	}
+}

--- a/internal/console/auth_api.go
+++ b/internal/console/auth_api.go
@@ -83,6 +83,12 @@ func (s *Server) extSessionIssuer() ext.ConsoleSessionIssuer {
 // reads as enabled: login attempts against it fail loud (LoadAuthFile error)
 // rather than silently downgrading the console to token-only auth.
 func (s *Server) passwordLoginEnabled() bool {
+	// An installed credential backend serves the login form on its own — it
+	// supersedes the auth file, so its presence alone enables password login
+	// (and, via setupAllowed, closes first-run setup: a backend is a credential).
+	if ext.ConsoleCredential() != nil {
+		return true
+	}
 	if s.authPath == "" {
 		return false
 	}
@@ -195,6 +201,38 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 			status = http.StatusRequestEntityTooLarge
 		}
 		writeJSONError(w, status, "invalid JSON body")
+		return
+	}
+
+	// An installed credential backend (ext seam) SUPERSEDES the built-in auth
+	// file for login: the file is not consulted. The rate limiter, body cap, and
+	// content-type gate above already ran, and the backend owns the constant-time
+	// verify (its own dummy-hash-equivalent cost) — so the console only trades a
+	// non-nil result for a session, and renders one uniform 401 for a nil one.
+	if backend := ext.ConsoleCredential(); backend != nil {
+		cred := backend.Verify(req.Username, req.Password)
+		if cred == nil {
+			s.loginLimiter.Fail(ip)
+			// Uniform body, and the attempted username is NEVER logged (as with
+			// the built-in path — a password often lands in the username field).
+			slog.Warn("console login failed", "remote", ip)
+			writeJSONError(w, http.StatusUnauthorized, "invalid username or password")
+			return
+		}
+		s.loginLimiter.Success(ip)
+		token, expires, err := s.sessions.IssueWithPolicy(cred.Policy)
+		if err != nil {
+			slog.Error("console session issue failed", "error", err)
+			writeJSONError(w, http.StatusInternalServerError, "something went wrong signing you in — try again")
+			return
+		}
+		// The verified identity is the operator's audit trail (like the external
+		// auth issuer); logged only on SUCCESS, where it is a real identity.
+		slog.Info("console login", "remote", ip, "identity", cred.Identity)
+		writeJSON(w, http.StatusOK, map[string]string{
+			"token":      token,
+			"expires_at": expires.UTC().Format(time.RFC3339),
+		})
 		return
 	}
 

--- a/internal/console/consolecred_test.go
+++ b/internal/console/consolecred_test.go
@@ -1,0 +1,192 @@
+package console
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/ext"
+)
+
+// These tests mutate the process-global ext.ConsoleCredential seam, so none may
+// run in parallel; every install is restored with t.Cleanup. New() reads the
+// seam at construction (bind/setup policy), so the backend is installed BEFORE
+// console.New.
+
+// fakeCredBackend admits exactly one (user, pass) pair, attaching policy to the
+// minted session. Any other pair is a uniform nil (bad user and bad pass are
+// indistinguishable), mirroring the contract the real backend must honor.
+type fakeCredBackend struct {
+	user, pass string
+	policy     *ext.AccessPolicy
+}
+
+func (f fakeCredBackend) Verify(username, password string) *ext.Credential {
+	if username == f.user && password == f.pass {
+		return &ext.Credential{Identity: username, Policy: f.policy}
+	}
+	return nil
+}
+
+func installCredBackend(t *testing.T, b ext.ConsoleCredentialProvider) {
+	t.Helper()
+	ext.SetConsoleCredentialProvider(b)
+	t.Cleanup(func() { ext.SetConsoleCredentialProvider(nil) })
+}
+
+// newCredServer builds a loopback server whose only login authority is the
+// installed backend (no auth file, no token).
+func newCredServer(t *testing.T, b ext.ConsoleCredentialProvider) *Server {
+	t.Helper()
+	installCredBackend(t, b)
+	srv, err := New(Config{Listen: "127.0.0.1:8090", AuthPath: filepath.Join(t.TempDir(), "absent.yaml")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return srv
+}
+
+func TestBackendLoginIssuesSession(t *testing.T) {
+	srv := newCredServer(t, fakeCredBackend{user: "alice", pass: "s3cret-pass"})
+	tok := loginToken(t, srv, "alice", "s3cret-pass")
+	if !strings.HasPrefix(tok, sessionPrefix) {
+		t.Errorf("backend-issued token %q lacks the %s prefix", tok, sessionPrefix)
+	}
+	// The minted token is a working Bearer on an authenticated endpoint.
+	if rec := postJSON(t, srv, "/api/auth/logout", tok, `{}`); rec.Code != http.StatusNoContent {
+		t.Errorf("authed call with a backend session = %d, want 204", rec.Code)
+	}
+}
+
+func TestBackendLoginUniformFailure(t *testing.T) {
+	srv := newCredServer(t, fakeCredBackend{user: "alice", pass: "s3cret-pass"})
+	badPass := postJSON(t, srv, "/api/auth/login", "", `{"username":"alice","password":"wrong"}`)
+	badUser := postJSON(t, srv, "/api/auth/login", "", `{"username":"nobody","password":"wrong"}`)
+	if badPass.Code != http.StatusUnauthorized || badUser.Code != http.StatusUnauthorized {
+		t.Fatalf("codes = %d/%d, want 401/401", badPass.Code, badUser.Code)
+	}
+	if badPass.Body.String() != badUser.Body.String() {
+		t.Errorf("bad-password and bad-username bodies differ (enumeration oracle):\n%s\n%s", badPass.Body.String(), badUser.Body.String())
+	}
+}
+
+// TestBackendSupersedesAuthFile pins the precedence decision: with a backend
+// installed, the built-in auth file's credentials no longer log in — only the
+// backend's do.
+func TestBackendSupersedesAuthFile(t *testing.T) {
+	installCredBackend(t, fakeCredBackend{user: "alice", pass: "s3cret-pass"})
+	// newPasswordServer writes an admin/correct-horse-battery auth file and calls
+	// New with the backend already installed.
+	srv, _ := newPasswordServer(t, "", "admin", "correct-horse-battery")
+
+	// The file's own credentials are refused — the file is not consulted.
+	if rec := postJSON(t, srv, "/api/auth/login", "", `{"username":"admin","password":"correct-horse-battery"}`); rec.Code != http.StatusUnauthorized {
+		t.Errorf("auth-file login with a backend installed = %d, want 401 (backend supersedes)", rec.Code)
+	}
+	// The backend's credentials work.
+	tok := loginToken(t, srv, "alice", "s3cret-pass")
+	if !strings.HasPrefix(tok, sessionPrefix) {
+		t.Errorf("backend login token %q lacks the %s prefix", tok, sessionPrefix)
+	}
+}
+
+func TestBackendLoginRateLimited(t *testing.T) {
+	srv := newCredServer(t, fakeCredBackend{user: "alice", pass: "s3cret-pass"})
+	for i := 0; i < ipShortMax; i++ {
+		if rec := postJSON(t, srv, "/api/auth/login", "", `{"username":"alice","password":"wrong"}`); rec.Code != http.StatusUnauthorized {
+			t.Fatalf("attempt %d = %d, want 401", i, rec.Code)
+		}
+	}
+	// The throttle fires before Verify — even the correct password is denied.
+	rec := postJSON(t, srv, "/api/auth/login", "", `{"username":"alice","password":"s3cret-pass"}`)
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("throttled backend login = %d, want 429", rec.Code)
+	}
+}
+
+// TestBackendLoginContentTypeAndSize pins that the CSRF/size guards still run
+// BEFORE the backend's Verify.
+func TestBackendLoginContentTypeAndSize(t *testing.T) {
+	called := false
+	srv := newCredServer(t, credProbe{onVerify: func() { called = true }})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "http://127.0.0.1:8090/api/auth/login", strings.NewReader("username=alice&password=x"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnsupportedMediaType {
+		t.Errorf("form-encoded backend login = %d, want 415", rec.Code)
+	}
+	huge := `{"username":"alice","password":"` + strings.Repeat("a", maxLoginBody) + `"}`
+	if rec := postJSON(t, srv, "/api/auth/login", "", huge); rec.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("oversized backend login body = %d, want 413", rec.Code)
+	}
+	if called {
+		t.Error("backend Verify ran despite a rejected content-type / oversized body")
+	}
+}
+
+// credProbe records whether Verify was reached; it never admits.
+type credProbe struct{ onVerify func() }
+
+func (c credProbe) Verify(string, string) *ext.Credential {
+	if c.onVerify != nil {
+		c.onVerify()
+	}
+	return nil
+}
+
+// TestBackendAttachesPolicy ties #1076 to #1074: a policy the backend returns is
+// enforced on the minted session.
+func TestBackendAttachesPolicy(t *testing.T) {
+	viewer := &ext.AccessPolicy{Permissions: []ext.Permission{ext.PermStatusRead, ext.PermServersRead}}
+	srv := newCredServer(t, fakeCredBackend{user: "viewer", pass: "s3cret-pass", policy: viewer})
+	tok := loginToken(t, srv, "viewer", "s3cret-pass")
+	// The scoped session is denied a route its policy lacks (query:execute).
+	if rec := getPath(t, srv, "127.0.0.1:8090", "/api/events", tok); rec.Code != http.StatusForbidden {
+		t.Errorf("scoped backend session GET /api/events = %d, want 403", rec.Code)
+	}
+}
+
+// TestBackendLiftsNonLoopbackBind pins that an installed backend is a valid sole
+// credential path — it makes a credential-less non-loopback bind legal, like an
+// external auth provider does.
+func TestBackendLiftsNonLoopbackBind(t *testing.T) {
+	cfg := Config{Listen: "0.0.0.0:8090", AuthPath: filepath.Join(t.TempDir(), "absent.yaml")}
+	if _, err := New(cfg); err == nil {
+		t.Fatal("New() accepted a credential-less non-loopback bind without a backend")
+	}
+	installCredBackend(t, fakeCredBackend{user: "alice", pass: "s3cret-pass"})
+	if _, err := New(cfg); err != nil {
+		t.Fatalf("New() with a backend installed = %v, want success", err)
+	}
+}
+
+// TestBackendClosesSetup pins that an installed backend counts as a configured
+// credential: the login form shows, first-run setup is closed, and the
+// unauthenticated setup endpoint refuses.
+func TestBackendClosesSetup(t *testing.T) {
+	srv := newCredServer(t, fakeCredBackend{user: "alice", pass: "s3cret-pass"})
+
+	rec := getPath(t, srv, "127.0.0.1:8090", "/api/auth", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /api/auth = %d", rec.Code)
+	}
+	var info map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &info); err != nil {
+		t.Fatal(err)
+	}
+	if pw, _ := info["password_login"].(bool); !pw {
+		t.Errorf("password_login = %v with a backend installed, want true", info["password_login"])
+	}
+	if setup, _ := info["setup"].(bool); setup {
+		t.Errorf("setup = %v with a backend installed, want false", info["setup"])
+	}
+	// The unauthenticated setup endpoint is closed.
+	if rec := postJSON(t, srv, "/api/auth/setup", "", `{"username":"admin","password":"long-enough-pass"}`); rec.Code != http.StatusForbidden {
+		t.Errorf("POST /api/auth/setup with a backend installed = %d, want 403", rec.Code)
+	}
+}

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -275,8 +275,13 @@ func New(cfg Config) (*Server, error) {
 	// does — so it also lifts the non-loopback refusal. It does NOT change
 	// willSetup/setupAllowed: browser first-run password setup stays gated on
 	// loopback (or the explicit AllowSetup assertion) exactly as before.
+	// An installed credential backend (ext.ConsoleCredential) likewise is
+	// a credential path: it serves the login form, so it is folded into
+	// noCredential — a backend makes the bind legal AND closes first-run setup
+	// (a stray password file must not be creatable when a backend already holds
+	// the credentials), matching passwordLoginEnabled().
 	token := cfg.Token
-	noCredential := token == "" && !passwordCfg
+	noCredential := token == "" && !passwordCfg && ext.ConsoleCredential() == nil
 	willSetup := noCredential && (isLoopbackAddr(listen) || cfg.AllowSetup)
 	if noCredential && !willSetup && ext.ConsoleAuth() == nil {
 		return nil, fmt.Errorf("authentication is required when binding to a non-loopback address %q: set a console password with `bintrail-console user set-password`, set --token / BINTRAIL_CONSOLE_TOKEN for automation, or pass --allow-setup if this bind is access-controlled (e.g. published only on the host's loopback)", listen)


### PR DESCRIPTION
closes #1076

## Summary
- **`ext` seam (no-op default):** `ConsoleCredentialProvider` — `Verify(username, password) -> *Credential` (nil on any failure) — plus `Credential{Identity, *AccessPolicy}`. The contract requires a constant, password-hash-equivalent verify cost (mirror the built-in dummy-hash compare) so the anti-enumeration/anti-timing guarantees hold, and a uniform nil on bad-user/bad-pass alike. `SetConsoleCredentialProvider`/`ConsoleCredential`, same shape as `SetConsoleAuth`.
- **Precedence — supersede:** when a backend is installed it **supersedes** the built-in auth file for `/api/auth/login` (the file is not consulted). Single login authority, no ambiguity. An EE backend that wants the operator's built-in credential to keep working incorporates it itself (that's the EE multi-user store).
- **Hardening preserved:** the rate limiter, body cap, and `Content-Type: application/json` gate all run **before** `Verify`; the attempted username is never logged; the verified identity is logged only on success (like the external-auth issuer). The static token and `/api/auth/setup` (built-in-only, first-run) are unaffected.
- **Ties to #1074:** a successful login mints the session via `IssueWithPolicy(cred.Policy)`, so a policy the backend returns is enforced per route.
- **Credential path:** an installed backend enables password login (`/api/auth` probe), lifts the non-loopback bind refusal, and closes first-run setup (a backend already holds the credentials).

## OSS behavior preserved
No backend installed → the single-user auth file is the sole login authority, byte-for-byte as before. All existing login/setup/change-password tests pass unchanged.

## Not in this PR (per the epic)
- The multi-user store + `user` CLI that *implements* this backend — EE #51.
- Per-session data-profile enforcement — #1075.

## Test plan
- [x] `go build ./...` clean; `go vet -tags integration ./ext/... ./internal/console/... ./consoleapp/...` clean
- [x] New tests: backend issues a working session; uniform 401 (bad-user == bad-pass body); **supersede** (auth-file creds refused when a backend is installed); rate-limit + 415/413 fire before `Verify`; backend-attached policy enforced (403 on a denied route); backend lifts the non-loopback bind; backend closes first-run setup; `ext` default-nil + set/get round-trip
- [x] Full `internal/console` suite passes in isolation (pre-existing async-telemetry-spool flake trips only under full-package load, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)