### PR TITLE
streamrun: make the gap_lost stamp an upsert so a missing row cannot lose it

### DIFF
--- a/internal/streamrun/mariadb_gtid_gap_test.go
+++ b/internal/streamrun/mariadb_gtid_gap_test.go
@@ -400,11 +400,18 @@ func advancedTestState() *streamState {
 	return &streamState{mode: "gtid", binlogFile: "mariadb-bin.000005", gtidSet: "0-2-71", flavor: gomysql.MariaDBFlavor, serverID: 99}
 }
 
+// Both persistGapAutoAdvance statements are INSERT INTO stream_state upserts
+// since #1081, so sqlmock expectations distinguish them by shape: the stamp
+// carries gap_lost_at, the checkpoint's UPDATE arm starts with mode.
+const (
+	stampStmtRE      = `(?s)INSERT INTO stream_state.*gap_lost_at`
+	checkpointStmtRE = `(?s)INSERT INTO stream_state.*ON DUPLICATE KEY UPDATE\s+mode\s+= VALUES\(mode\)`
+)
+
 // TestPersistGapAutoAdvance_stampsBeforeAdvance pins the data-loss-safety ordering
-// invariant: the gap_lost_at stamp (UPDATE) must be written BEFORE the advanced
-// checkpoint (the INSERT...ON DUPLICATE KEY upsert). sqlmock matches expectations
-// in order by default, so declaring UPDATE-then-INSERT fails if the code advances
-// the checkpoint first.
+// invariant: the gap_lost_at stamp must be written BEFORE the advanced checkpoint
+// (saveCheckpoint's upsert). sqlmock matches expectations in order by default, so
+// declaring stamp-then-checkpoint fails if the code advances the checkpoint first.
 func TestPersistGapAutoAdvance_stampsBeforeAdvance(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -412,10 +419,9 @@ func TestPersistGapAutoAdvance_stampsBeforeAdvance(t *testing.T) {
 	}
 	defer db.Close()
 
-	mock.ExpectExec("UPDATE stream_state").
-		WithArgs("events lost").
+	mock.ExpectExec(stampStmtRE).
 		WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectExec("INSERT INTO stream_state").
+	mock.ExpectExec(checkpointStmtRE).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	if err := persistGapAutoAdvance(db, advancedTestState(), "events lost"); err != nil {
@@ -426,11 +432,42 @@ func TestPersistGapAutoAdvance_stampsBeforeAdvance(t *testing.T) {
 	}
 }
 
+// TestPersistGapAutoAdvance_stampIsUpsert pins the #1081 fix: the stamp must be
+// an INSERT…ON DUPLICATE KEY UPDATE so a missing stream_state row still gets the
+// loss record (a bare UPDATE would match zero rows and the subsequent checkpoint
+// upsert would seed a fresh row with NULL gap_lost_* columns). The end-anchored
+// regex also pins that the existing-row arm touches ONLY the gap_lost_* columns
+// — the checkpoint advance must land exclusively in the second statement.
+func TestPersistGapAutoAdvance_stampIsUpsert(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec(`(?s)INSERT INTO stream_state\s+\(id, mode,.*gap_lost_at, gap_lost_detail\)` +
+		`.*ON DUPLICATE KEY UPDATE\s+` +
+		`gap_lost_at\s+= UTC_TIMESTAMP\(\),\s+gap_lost_detail = VALUES\(gap_lost_detail\)\s*$`).
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
+			sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
+			sqlmock.AnyArg(), "events lost").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(checkpointStmtRE).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := persistGapAutoAdvance(db, advancedTestState(), "events lost"); err != nil {
+		t.Fatalf("persistGapAutoAdvance: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("stamp must be an upsert whose UPDATE arm touches only gap_lost_*: %v", err)
+	}
+}
+
 // TestPersistGapAutoAdvance_abortsOnStampFailure is the core of the #402 fix: if
 // the gap_lost_at stamp fails, the function must return an error and must NOT
 // advance the checkpoint — otherwise the next restart would see no gap with no
-// durable trace of the loss. The INSERT is deliberately NOT expected; sqlmock
-// errors if the code issues it after the failed UPDATE.
+// durable trace of the loss. The checkpoint upsert is deliberately NOT expected;
+// sqlmock errors if the code issues it after the failed stamp.
 func TestPersistGapAutoAdvance_abortsOnStampFailure(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -438,9 +475,9 @@ func TestPersistGapAutoAdvance_abortsOnStampFailure(t *testing.T) {
 	}
 	defer db.Close()
 
-	mock.ExpectExec("UPDATE stream_state").
+	mock.ExpectExec(stampStmtRE).
 		WillReturnError(errors.New("index DB transient error"))
-	// No ExpectExec for the INSERT — the checkpoint must not be advanced.
+	// No ExpectExec for the checkpoint upsert — the checkpoint must not be advanced.
 
 	if err := persistGapAutoAdvance(db, advancedTestState(), "events lost"); err == nil {
 		t.Fatal("expected an error when the gap-loss stamp fails (checkpoint must not advance)")

--- a/internal/streamrun/reset_test.go
+++ b/internal/streamrun/reset_test.go
@@ -103,9 +103,9 @@ func freshResetState() *streamState {
 }
 
 // TestPersistResetDiscard_jumpStampsBeforeCheckpoint pins the branch wiring:
-// a jump must go through the gap_lost stamp (UPDATE) BEFORE the fresh
-// checkpoint (INSERT upsert) — sqlmock matches in order — and must fire the
-// supervisor hook only after both writes succeeded.
+// a jump must go through the gap_lost stamp (the gap_lost_at upsert, #1081)
+// BEFORE the fresh checkpoint (saveCheckpoint's upsert) — sqlmock matches in
+// order — and must fire the supervisor hook only after both writes succeeded.
 func TestPersistResetDiscard_jumpStampsBeforeCheckpoint(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -113,10 +113,12 @@ func TestPersistResetDiscard_jumpStampsBeforeCheckpoint(t *testing.T) {
 	}
 	defer db.Close()
 
-	mock.ExpectExec("UPDATE stream_state").
-		WithArgs("events lost via reset").
+	mock.ExpectExec(stampStmtRE).
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
+			sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
+			sqlmock.AnyArg(), "events lost via reset").
 		WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectExec("INSERT INTO stream_state").
+	mock.ExpectExec(checkpointStmtRE).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	var hooked string
@@ -133,8 +135,9 @@ func TestPersistResetDiscard_jumpStampsBeforeCheckpoint(t *testing.T) {
 }
 
 // TestPersistResetDiscard_noopWritesOnlyCheckpoint: a no-op discard must not
-// stamp gap_lost (no UPDATE — sqlmock errors on unexpected statements) and
-// must not fire the loss hook.
+// stamp gap_lost and must not fire the loss hook. The single expectation is
+// pinned to saveCheckpoint's upsert shape — a wrongly-issued stamp (also an
+// INSERT since #1081) would not match it and sqlmock errors on order.
 func TestPersistResetDiscard_noopWritesOnlyCheckpoint(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -142,7 +145,7 @@ func TestPersistResetDiscard_noopWritesOnlyCheckpoint(t *testing.T) {
 	}
 	defer db.Close()
 
-	mock.ExpectExec("INSERT INTO stream_state").
+	mock.ExpectExec(checkpointStmtRE).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	hooks := &Hooks{OnGapAutoAdvance: func(string) { t.Error("loss hook must not fire on a no-op reset") }}
@@ -164,7 +167,7 @@ func TestPersistResetDiscard_hookSkippedOnPersistFailure(t *testing.T) {
 	}
 	defer db.Close()
 
-	mock.ExpectExec("UPDATE stream_state").
+	mock.ExpectExec(stampStmtRE).
 		WillReturnError(errors.New("index DB down"))
 
 	hooks := &Hooks{OnGapAutoAdvance: func(string) { t.Error("loss hook must not fire when the durable record failed") }}

--- a/internal/streamrun/streamrun.go
+++ b/internal/streamrun/streamrun.go
@@ -300,8 +300,12 @@ func deleteEventsSinceCheckpointGTID(db *sql.DB, file string, pos uint64, savedS
 // checkpoint advanced, loss unrecorded. The existing-row arm updates ONLY the
 // gap_lost_* columns — the checkpoint advance still lands exclusively in the
 // second statement, preserving the stamp-before-advance ordering; the
-// missing-row arm seeds the advanced state and the stamp atomically, so the
-// advance cannot land without the stamp. Deliberately no RowsAffected check:
+// missing-row arm seeds the advanced state and the stamp atomically, so on that
+// arm the advance cannot land without the stamp. That guarantee is per-arm, not
+// per-pair: a row DELETEd between an existing-row stamp and saveCheckpoint is
+// re-seeded by saveCheckpoint's INSERT arm without gap_lost_* — a residual
+// milliseconds-wide window (vs the minutes-wide one this closes) that only a
+// single combined stamp+advance statement would eliminate. Deliberately no RowsAffected check:
 // go-sql-driver reports CHANGED rows, not matched, so an identical re-stamp
 // within the same UTC_TIMESTAMP() second (supervisor crash-loop) would report 0
 // and abort a healthy startup.

--- a/internal/streamrun/streamrun.go
+++ b/internal/streamrun/streamrun.go
@@ -118,8 +118,15 @@ func isPositionCheckpointBoundary(ev parser.Event) bool {
 	return ev.StmtEnd
 }
 
-// saveCheckpoint persists the current stream state to the stream_state table.
-func saveCheckpoint(db *sql.DB, state *streamState) error {
+// checkpointInsertArgs builds the placeholder arguments for the shared
+// stream_state INSERT column list (id=1, mode, binlog_file, binlog_position,
+// gtid_set, flavor, events_indexed, last_event_time, last_checkpoint=UTC_TIMESTAMP(),
+// server_id, bintrail_id) used by saveCheckpoint and the persistGapAutoAdvance
+// stamp: NULLs for empty gtid_set/last_event_time/bintrail_id, the flavor
+// canonicalized (empty→mysql; an invalid flavor fails loud rather than
+// persisting garbage into the NOT NULL column), and the #775 safe-boundary
+// position (see checkpointPosition).
+func checkpointInsertArgs(state *streamState) ([]any, error) {
 	var gtidSet any
 	if state.gtidSet != "" {
 		gtidSet = state.gtidSet
@@ -132,18 +139,24 @@ func saveCheckpoint(db *sql.DB, state *streamState) error {
 	if state.bintrailID != "" {
 		bintrailIDArg = state.bintrailID
 	}
-	// Canonicalize the flavor (empty→mysql) so the NOT NULL column never receives
-	// an empty string; an invalid flavor fails loud rather than persisting garbage.
 	flavor, err := normalizeFlavor(state.flavor)
+	if err != nil {
+		return nil, err
+	}
+	file, pos := checkpointPosition(state)
+	return []any{state.mode, file, pos, gtidSet, flavor,
+		state.eventsIndexed, lastEventTime, state.serverID, bintrailIDArg}, nil
+}
+
+// saveCheckpoint persists the current stream state to the stream_state table.
+func saveCheckpoint(db *sql.DB, state *streamState) error {
+	args, err := checkpointInsertArgs(state)
 	if err != nil {
 		return err
 	}
-	// #775: in position mode this persists the last safe boundary, not the
-	// per-event offset (see checkpointPosition).
 	// mode is in the UPDATE arm for the cross-mode --reset path (#1079): the
 	// reset no longer DELETEs the row, so the mode switch must land through
 	// this upsert. For every other caller mode is invariant across the run.
-	file, pos := checkpointPosition(state)
 	// #959: bound the checkpoint write with a deadline (see indexer.WriteTimeout)
 	// so a mid-statement network stall fails fast instead of freezing the daemon
 	// on kernel TCP retransmission — invisible to the supervisor.
@@ -165,8 +178,7 @@ func saveCheckpoint(db *sql.DB, state *streamState) error {
 		    last_checkpoint = UTC_TIMESTAMP(),
 		    server_id       = VALUES(server_id),
 		    bintrail_id     = VALUES(bintrail_id)`,
-		state.mode, file, pos, gtidSet, flavor,
-		state.eventsIndexed, lastEventTime, state.serverID, bintrailIDArg)
+		args...)
 	return err
 }
 
@@ -279,10 +291,37 @@ func deleteEventsSinceCheckpointGTID(db *sql.DB, file string, pos uint64, savedS
 // not touch the gap_lost_* columns, so the stamp survives it. Cleared by an
 // explicit monitor Stop; a jumping --reset re-stamps it with the discarded
 // range (#1079) and a same-position --reset leaves it intact.
+//
+// The stamp is an INSERT…ON DUPLICATE KEY UPDATE, not a bare UPDATE (#1081): the
+// stream_state row can vanish between loadStreamState and this stamp (operator
+// DELETE, a concurrent pre-#1079 --reset, a concurrent bintrail-pg reset on a
+// shared index) — a bare UPDATE would match zero rows without error and the
+// subsequent saveCheckpoint would seed a fresh row with NULL gap_lost_* columns:
+// checkpoint advanced, loss unrecorded. The existing-row arm updates ONLY the
+// gap_lost_* columns — the checkpoint advance still lands exclusively in the
+// second statement, preserving the stamp-before-advance ordering; the
+// missing-row arm seeds the advanced state and the stamp atomically, so the
+// advance cannot land without the stamp. Deliberately no RowsAffected check:
+// go-sql-driver reports CHANGED rows, not matched, so an identical re-stamp
+// within the same UTC_TIMESTAMP() second (supervisor crash-loop) would report 0
+// and abort a healthy startup.
 func persistGapAutoAdvance(db *sql.DB, advanced *streamState, gapMessage string) error {
-	if _, err := db.Exec(`UPDATE stream_state
-		SET gap_lost_at = UTC_TIMESTAMP(), gap_lost_detail = ?
-		WHERE id = 1`, gapMessage); err != nil {
+	args, err := checkpointInsertArgs(advanced)
+	if err != nil {
+		return fmt.Errorf("failed to persist gap-loss record before auto-advance: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), indexer.WriteTimeout)
+	defer cancel()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO stream_state
+		    (id, mode, binlog_file, binlog_position, gtid_set, flavor,
+		     events_indexed, last_event_time, last_checkpoint, server_id, bintrail_id,
+		     gap_lost_at, gap_lost_detail)
+		VALUES (1, ?, ?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(), ?, ?, UTC_TIMESTAMP(), ?)
+		ON DUPLICATE KEY UPDATE
+		    gap_lost_at     = UTC_TIMESTAMP(),
+		    gap_lost_detail = VALUES(gap_lost_detail)`,
+		append(args, gapMessage)...); err != nil {
 		return fmt.Errorf("failed to persist gap-loss record before auto-advance: %w", err)
 	}
 	if err := saveCheckpoint(db, advanced); err != nil {


### PR DESCRIPTION
Closes #1081

## Problem

`persistGapAutoAdvance` recorded a permanent event loss with a bare `UPDATE stream_state SET gap_lost_at = UTC_TIMESTAMP(), gap_lost_detail = ? WHERE id = 1`. If the `stream_state` row was missing at that moment (operator `DELETE`, a concurrent pre-#1079 binary's `stream --reset`, a concurrent `bintrail-pg reset` on a shared index), the UPDATE matched zero rows without error and the subsequent `saveCheckpoint` upsert INSERTed a fresh row with NULL `gap_lost_*` columns — checkpoint advanced past permanently lost events with no durable loss record, the exact failure mode the #402 stamp-before-advance ordering exists to prevent.

## Fix

- The stamp is now `INSERT ... ON DUPLICATE KEY UPDATE` (option 1 from the issue, mirroring the PG sibling `persistSlotLostPG`): the INSERT arm carries the full advanced-state column list plus `gap_lost_at`/`gap_lost_detail`, so a missing row gets the stamp and the state atomically; the existing-row arm updates **only** the `gap_lost_*` columns — the checkpoint advance still lands exclusively in the second statement (`saveCheckpoint`), preserving the ordering invariant.
- Deliberately no `RowsAffected` check: go-sql-driver reports *changed* rows, not *matched*, so an identical re-stamp within the same `UTC_TIMESTAMP()` second (supervisor crash-loop) would report 0 and abort a healthy startup.
- Shared INSERT-arm argument building (NULL handling for `gtid_set`/`last_event_time`/`bintrail_id`, `normalizeFlavor`, `checkpointPosition`) extracted into `checkpointInsertArgs`, reused by `saveCheckpoint` and the stamp; the stamp also gains the same `indexer.WriteTimeout` deadline (#959 pattern).

## Tests

Both statements now start with `INSERT INTO stream_state`, so the sqlmock expectations distinguish them by shape via shared regexes: `stampStmtRE` (matches `gap_lost_at`) and `checkpointStmtRE` (matches the `mode = VALUES(mode)` UPDATE arm).

- `TestPersistGapAutoAdvance_stampsBeforeAdvance` / `_abortsOnStampFailure` and `TestPersistResetDiscard_jumpStampsBeforeCheckpoint` / `_hookSkippedOnPersistFailure` updated to the new shapes, keeping the ordering / abort assertions.
- New `TestPersistGapAutoAdvance_stampIsUpsert` pins that the stamp is an INSERT…ODKU whose end-anchored UPDATE arm touches only `gap_lost_*`, with the detail as the final argument.
- `TestPersistResetDiscard_noopWritesOnlyCheckpoint` tightened to `checkpointStmtRE` so a wrongly-issued stamp (also an INSERT now) cannot satisfy its single expectation.

## Verification

`go build ./...`, `go vet ./internal/streamrun/`, `go test -race ./internal/streamrun/ -count=1`, `go test ./... -count=1` (45 ok), `go vet -tags integration ./...` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)