### PR TITLE
bintrail-pg: reset preserves gap_lost continuity records instead of DELETEing stream_state

### DIFF
--- a/cmd/bintrail-pg/reset.go
+++ b/cmd/bintrail-pg/reset.go
@@ -28,16 +28,18 @@ It performs the two-system teardown that otherwise has to be done by hand:
 
   1. drops the replication slot on the SOURCE (--query-dsn) — a slot left behind
      keeps pinning WAL and can fill the source disk;
-  2. clears the durable checkpoint in the INDEX (--index-dsn): the position
-     columns of the stream_state row are cleared (the row is never DELETEd), so
-     the next 'bintrail-pg stream' starts from a fresh slot.
+  2. clears the durable checkpoint in the INDEX (--index-dsn): the position and
+     counter columns of the stream_state row are cleared (the row is never
+     DELETEd), so the next 'bintrail-pg stream' starts from a fresh slot.
 
 Continuity: dropping and recreating a slot inherently skips whatever the old
 slot had not yet streamed, so discarding a real checkpoint is durably recorded
 as a permanent continuity loss (gap_lost_at/gap_lost_detail in stream_state,
 naming the discarded LSN) — 'bintrail status' shows the EVENTS PERMANENTLY LOST
-banner and 'status --fail-on-gap' exits non-zero. A previously recorded,
-still-unacknowledged loss record always survives the reset.
+banner and 'status --fail-on-gap' exits non-zero. The loss always remains
+recorded: a real-checkpoint reset replaces a prior unacknowledged record's
+detail with its own; only a no-checkpoint reset preserves a prior record
+verbatim. Run reset with the stream stopped.
 
 The slot is dropped first: if the run is interrupted between the two steps, the
 safe state is "slot gone, checkpoint stale" (the next stream fails loud) rather
@@ -198,13 +200,26 @@ type clearOutcome struct {
 //
 //   - real checkpoint: dropping and recreating the slot skips whatever the old slot had
 //     not yet streamed past that LSN, so the discard is stamped as a permanent loss IN
-//     THE SAME STATEMENT that clears the cursor — stamp and clear can never be torn
-//     apart (the stamp-then-advance ordering invariant from PR #1080's MySQL --reset).
-//     A prior unacknowledged record's detail is replaced by the reset detail (#1080
-//     jump semantics); the loss flag itself is never cleared here.
+//     THE SAME STATEMENT that clears the cursor — one atomic write, which satisfies the
+//     safety property PR #1080's MySQL --reset enforces by ordering (stamp before
+//     advance): the clear can never become durable without the stamp. A prior
+//     unacknowledged record's detail is replaced by the reset detail (#1080 jump
+//     semantics); the loss flag itself is never cleared here.
 //   - no checkpoint (row seeded by a lost-slot stamp or a pre-commit health snapshot,
 //     or an earlier reset): nothing is discarded — clear only the position/counter
 //     columns and leave any prior gap_lost_* record untouched (#1080's no-op path).
+//     Residual by design: a crash inside the first checkpoint interval can leave
+//     indexed events with pos still 0; a reset then discards the surviving slot's
+//     un-streamed WAL without a stamp — softened by "re-seed the baseline" being the
+//     documented post-reset contract.
+//
+// The load and the write run in one transaction with the row locked (FOR UPDATE): the
+// branch decision is made on the read, and saveCheckpointPG's upsert landing a FIRST
+// checkpoint between a bare read and the write would get cleared UN-stamped — the exact
+// laundering this function exists to prevent. The lock serializes against every
+// stream_state writer and guarantees the row still exists at write time, which is what
+// makes the rows:1 report honest (RowsAffected is no substitute: the driver reports
+// CHANGED rows, so an identical same-second re-clear would read as 0).
 //
 // Either way the cleared row reads as first-run to the stream (loadStreamStatePG
 // treats a zero-position row as no checkpoint), so a fresh slot is created on the next
@@ -212,8 +227,17 @@ type clearOutcome struct {
 // exist (MySQL 1146) — a never-streamed index, or an --index-dsn pointing at the wrong
 // database.
 func clearCheckpoint(ctx context.Context, db *sql.DB) (clearOutcome, error) {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return clearOutcome{}, err
+	}
+	defer tx.Rollback()
+
+	var flavor string
 	var pos uint64
-	err := db.QueryRowContext(ctx, "SELECT binlog_position FROM stream_state WHERE id = 1").Scan(&pos)
+	err = tx.QueryRowContext(ctx,
+		"SELECT flavor, binlog_position FROM stream_state WHERE id = 1 FOR UPDATE").
+		Scan(&flavor, &pos)
 	switch {
 	case errors.Is(err, sql.ErrNoRows):
 		return clearOutcome{}, nil
@@ -222,9 +246,18 @@ func clearCheckpoint(ctx context.Context, db *sql.DB) (clearOutcome, error) {
 	case err != nil:
 		return clearOutcome{}, err
 	}
+	// Mirror loadStreamStatePG's flavor guard ("postgres" = pgstreamrun's pgFlavor):
+	// --index-dsn pointed at a MySQL/MariaDB-source index is the same wrong-database
+	// mistake the 1146 message calls out, and clearing a foreign checkpoint here would
+	// stamp a MySQL byte offset rendered as a PG LSN — a durable forensic lie on a
+	// live stream's index.
+	if flavor != "postgres" {
+		return clearOutcome{}, fmt.Errorf(
+			"index holds a %q checkpoint, not \"postgres\" — refusing to reset a non-PostgreSQL stream's state (is --index-dsn pointing at the right database?)", flavor)
+	}
 
 	if pos == 0 {
-		if _, err := db.ExecContext(ctx, `
+		if _, err := tx.ExecContext(ctx, `
 			UPDATE stream_state SET
 				binlog_file     = '',
 				binlog_position = 0,
@@ -235,13 +268,16 @@ func clearCheckpoint(ctx context.Context, db *sql.DB) (clearOutcome, error) {
 			WHERE id = 1`); err != nil {
 			return clearOutcome{}, err
 		}
+		if err := tx.Commit(); err != nil {
+			return clearOutcome{}, err
+		}
 		return clearOutcome{rows: 1}, nil
 	}
 
 	detail := fmt.Sprintf(
-		"checkpoint discarded via `bintrail-pg reset`: was LSN %s; the replication slot is dropped and recreated, so events past that LSN not yet streamed by the old slot are permanently lost",
+		"checkpoint discarded via `bintrail-pg reset`: was LSN %s; the replication slot is (or was already) dropped and will be recreated, so events past that LSN not yet streamed by the old slot are permanently lost",
 		pglogrepl.LSN(pos))
-	if _, err := db.ExecContext(ctx, `
+	if _, err := tx.ExecContext(ctx, `
 		UPDATE stream_state SET
 			gap_lost_at     = UTC_TIMESTAMP(),
 			gap_lost_detail = ?,
@@ -252,6 +288,9 @@ func clearCheckpoint(ctx context.Context, db *sql.DB) (clearOutcome, error) {
 			last_event_time = NULL,
 			last_checkpoint = UTC_TIMESTAMP()
 		WHERE id = 1`, detail); err != nil {
+		return clearOutcome{}, err
+	}
+	if err := tx.Commit(); err != nil {
 		return clearOutcome{}, err
 	}
 	return clearOutcome{rows: 1, lossDetail: detail}, nil

--- a/cmd/bintrail-pg/reset.go
+++ b/cmd/bintrail-pg/reset.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/go-sql-driver/mysql"
+	"github.com/jackc/pglogrepl"
 	"github.com/jackc/pgx/v5"
 	"github.com/spf13/cobra"
 
@@ -27,8 +28,16 @@ It performs the two-system teardown that otherwise has to be done by hand:
 
   1. drops the replication slot on the SOURCE (--query-dsn) — a slot left behind
      keeps pinning WAL and can fill the source disk;
-  2. clears the durable checkpoint in the INDEX (--index-dsn): DELETE the
-     stream_state row, so the next 'bintrail-pg stream' starts from a fresh slot.
+  2. clears the durable checkpoint in the INDEX (--index-dsn): the position
+     columns of the stream_state row are cleared (the row is never DELETEd), so
+     the next 'bintrail-pg stream' starts from a fresh slot.
+
+Continuity: dropping and recreating a slot inherently skips whatever the old
+slot had not yet streamed, so discarding a real checkpoint is durably recorded
+as a permanent continuity loss (gap_lost_at/gap_lost_detail in stream_state,
+naming the discarded LSN) — 'bintrail status' shows the EVENTS PERMANENTLY LOST
+banner and 'status --fail-on-gap' exits non-zero. A previously recorded,
+still-unacknowledged loss record always survives the reset.
 
 The slot is dropped first: if the run is interrupted between the two steps, the
 safe state is "slot gone, checkpoint stale" (the next stream fails loud) rather
@@ -103,10 +112,10 @@ func runPGReset(cmd *cobra.Command, args []string) error {
 		defer conn.Close(ctx)
 		return pgcapture.DropSlot(ctx, conn, pgResetSlot)
 	}
-	clearFn := func(ctx context.Context) (int64, bool, error) {
+	clearFn := func(ctx context.Context) (clearOutcome, error) {
 		idx, err := config.Connect(pgResetIndexDSN)
 		if err != nil {
-			return 0, false, fmt.Errorf("connect to index: %w", err)
+			return clearOutcome{}, fmt.Errorf("connect to index: %w", err)
 		}
 		defer idx.Close()
 		return clearCheckpoint(ctx, idx)
@@ -129,7 +138,7 @@ func resetPlan(
 	slot string,
 	out io.Writer,
 	dropFn func(context.Context) (bool, error),
-	clearFn func(context.Context) (rows int64, tableMissing bool, err error),
+	clearFn func(context.Context) (clearOutcome, error),
 ) error {
 	slotHandled := false
 	if indexOnly {
@@ -147,7 +156,7 @@ func resetPlan(
 		}
 	}
 
-	rows, tableMissing, err := clearFn(ctx)
+	res, err := clearFn(ctx)
 	if err != nil {
 		if slotHandled {
 			// The source slot is already gone; tell the operator how to finish so they
@@ -156,31 +165,96 @@ func resetPlan(
 		}
 		return fmt.Errorf("clearing the index checkpoint: %w", err)
 	}
-	if tableMissing {
+	if res.tableMissing {
 		// 1146 also fires when --index-dsn points at the wrong database, so don't claim
 		// success unconditionally — name the ambiguity.
 		fmt.Fprintln(out, "No stream_state table in this index — either it was never streamed, or --index-dsn points at the wrong database. Nothing cleared.")
 		fmt.Fprintln(out, "Done.")
 		return nil
 	}
-	fmt.Fprintf(out, "Cleared %d index checkpoint row(s).\n", rows)
+	fmt.Fprintf(out, "Cleared %d index checkpoint row(s).\n", res.rows)
+	if res.lossDetail != "" {
+		fmt.Fprintf(out, "Recorded the discarded checkpoint as a permanent continuity loss: %s\n", res.lossDetail)
+		fmt.Fprintln(out, "`bintrail status` shows the loss until it is acknowledged; the record survives this reset by design.")
+	}
 	fmt.Fprintln(out, "Done. Re-seed the baseline, then run `bintrail-pg stream` to start fresh.")
 	return nil
 }
 
-// clearCheckpoint deletes the stream_state checkpoint row. It returns tableMissing=true
-// with a nil error when the stream_state table does not exist (MySQL 1146) — a
-// never-streamed index, or an --index-dsn pointing at the wrong database.
-func clearCheckpoint(ctx context.Context, db *sql.DB) (rows int64, tableMissing bool, err error) {
-	res, err := db.ExecContext(ctx, "DELETE FROM stream_state WHERE id = 1")
-	if err != nil {
-		if isTableMissingErr(err) {
-			return 0, true, nil
-		}
-		return 0, false, err
+// clearOutcome reports what clearing the index checkpoint did.
+type clearOutcome struct {
+	rows         int64  // stream_state rows cleared (0 = the row never existed)
+	tableMissing bool   // stream_state table absent (MySQL 1146)
+	lossDetail   string // non-empty when a discarded checkpoint was durably stamped as a permanent continuity loss
+}
+
+// clearCheckpoint clears the stream_state checkpoint so the next `bintrail-pg stream`
+// starts fresh, WITHOUT DELETEing the row (#1082): a blind DELETE would also erase any
+// recorded gap_lost_at/gap_lost_detail continuity-loss record, letting a reset silently
+// launder a real, still-unacknowledged loss out of `bintrail status --fail-on-gap`.
+//
+// It loads the existing row first and branches on whether a real checkpoint (a non-zero
+// LSN cursor — saveCheckpointPG never writes 0) is being discarded:
+//
+//   - real checkpoint: dropping and recreating the slot skips whatever the old slot had
+//     not yet streamed past that LSN, so the discard is stamped as a permanent loss IN
+//     THE SAME STATEMENT that clears the cursor — stamp and clear can never be torn
+//     apart (the stamp-then-advance ordering invariant from PR #1080's MySQL --reset).
+//     A prior unacknowledged record's detail is replaced by the reset detail (#1080
+//     jump semantics); the loss flag itself is never cleared here.
+//   - no checkpoint (row seeded by a lost-slot stamp or a pre-commit health snapshot,
+//     or an earlier reset): nothing is discarded — clear only the position/counter
+//     columns and leave any prior gap_lost_* record untouched (#1080's no-op path).
+//
+// Either way the cleared row reads as first-run to the stream (loadStreamStatePG
+// treats a zero-position row as no checkpoint), so a fresh slot is created on the next
+// start. tableMissing=true with a nil error means the stream_state table does not
+// exist (MySQL 1146) — a never-streamed index, or an --index-dsn pointing at the wrong
+// database.
+func clearCheckpoint(ctx context.Context, db *sql.DB) (clearOutcome, error) {
+	var pos uint64
+	err := db.QueryRowContext(ctx, "SELECT binlog_position FROM stream_state WHERE id = 1").Scan(&pos)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return clearOutcome{}, nil
+	case isTableMissingErr(err):
+		return clearOutcome{tableMissing: true}, nil
+	case err != nil:
+		return clearOutcome{}, err
 	}
-	n, _ := res.RowsAffected()
-	return n, false, nil
+
+	if pos == 0 {
+		if _, err := db.ExecContext(ctx, `
+			UPDATE stream_state SET
+				binlog_file     = '',
+				binlog_position = 0,
+				gtid_set        = NULL,
+				events_indexed  = 0,
+				last_event_time = NULL,
+				last_checkpoint = UTC_TIMESTAMP()
+			WHERE id = 1`); err != nil {
+			return clearOutcome{}, err
+		}
+		return clearOutcome{rows: 1}, nil
+	}
+
+	detail := fmt.Sprintf(
+		"checkpoint discarded via `bintrail-pg reset`: was LSN %s; the replication slot is dropped and recreated, so events past that LSN not yet streamed by the old slot are permanently lost",
+		pglogrepl.LSN(pos))
+	if _, err := db.ExecContext(ctx, `
+		UPDATE stream_state SET
+			gap_lost_at     = UTC_TIMESTAMP(),
+			gap_lost_detail = ?,
+			binlog_file     = '',
+			binlog_position = 0,
+			gtid_set        = NULL,
+			events_indexed  = 0,
+			last_event_time = NULL,
+			last_checkpoint = UTC_TIMESTAMP()
+		WHERE id = 1`, detail); err != nil {
+		return clearOutcome{}, err
+	}
+	return clearOutcome{rows: 1, lossDetail: detail}, nil
 }
 
 // isTableMissingErr reports whether err is MySQL error 1146 (ER_NO_SUCH_TABLE), i.e.

--- a/cmd/bintrail-pg/reset_integration_test.go
+++ b/cmd/bintrail-pg/reset_integration_test.go
@@ -32,7 +32,7 @@ func TestClearCheckpoint_Integration(t *testing.T) {
 		INSERT INTO stream_state
 			(id, mode, flavor, binlog_file, binlog_position, gtid_set,
 			 events_indexed, server_id, last_checkpoint, gap_lost_at, gap_lost_detail)
-		VALUES (1, 'gtid', 'postgres', '0/1A2B3C4', 27439044, '0/1A2B3C4',
+		VALUES (1, 'gtid', 'postgres', '0/1A2B3C4', 27440068, '0/1A2B3C4',
 			 42, 9, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'prior slot loss')`); err != nil {
 		t.Fatalf("seed checkpoint: %v", err)
 	}

--- a/cmd/bintrail-pg/reset_integration_test.go
+++ b/cmd/bintrail-pg/reset_integration_test.go
@@ -4,6 +4,8 @@ package main
 
 import (
 	"context"
+	"database/sql"
+	"strings"
 	"testing"
 
 	"github.com/dbtrail/dbtrail/internal/indexer"
@@ -11,8 +13,11 @@ import (
 )
 
 // TestClearCheckpoint_Integration covers the index half of `bintrail-pg reset` against
-// a real MySQL index: a present checkpoint clears (1 row), a second clear is a no-op
-// (0 rows), and a missing stream_state table reports tableMissing rather than erroring.
+// a real MySQL index (#1082 semantics): discarding a real checkpoint clears the cursor
+// AND stamps the discard as a permanent continuity loss in the SAME row (replacing a
+// prior unacknowledged record's detail, never erasing the record); a second clear is a
+// no-checkpoint clear that leaves the loss record untouched; and a missing stream_state
+// table reports tableMissing rather than erroring.
 func TestClearCheckpoint_Integration(t *testing.T) {
 	testutil.SkipIfNoMySQL(t)
 	ctx := context.Background()
@@ -21,26 +26,67 @@ func TestClearCheckpoint_Integration(t *testing.T) {
 		t.Fatalf("CreateIndexTables: %v", err)
 	}
 
-	if _, err := db.ExecContext(ctx,
-		"INSERT INTO stream_state (id, mode, server_id, last_checkpoint) VALUES (1, 'gtid', 9, UTC_TIMESTAMP())"); err != nil {
+	// A real PG checkpoint (LSN 0/1A2B3C4) WITH a prior, still-unacknowledged loss
+	// record — the exact state the old DELETE used to silently launder away.
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO stream_state
+			(id, mode, flavor, binlog_file, binlog_position, gtid_set,
+			 events_indexed, server_id, last_checkpoint, gap_lost_at, gap_lost_detail)
+		VALUES (1, 'gtid', 'postgres', '0/1A2B3C4', 27439044, '0/1A2B3C4',
+			 42, 9, UTC_TIMESTAMP(), UTC_TIMESTAMP(), 'prior slot loss')`); err != nil {
 		t.Fatalf("seed checkpoint: %v", err)
 	}
 
-	rows, missing, err := clearCheckpoint(ctx, db)
-	if err != nil || missing || rows != 1 {
-		t.Fatalf("clear present checkpoint = (rows=%d, missing=%t, err=%v), want (1, false, nil)", rows, missing, err)
+	res, err := clearCheckpoint(ctx, db)
+	if err != nil || res.tableMissing || res.rows != 1 {
+		t.Fatalf("clear real checkpoint = (%+v, %v), want rows=1", res, err)
+	}
+	if !strings.Contains(res.lossDetail, "0/1A2B3C4") {
+		t.Errorf("loss detail should name the discarded LSN, got %q", res.lossDetail)
 	}
 
-	rows, missing, err = clearCheckpoint(ctx, db)
-	if err != nil || missing || rows != 0 {
-		t.Fatalf("second clear = (rows=%d, missing=%t, err=%v), want (0, false, nil)", rows, missing, err)
+	var (
+		pos       uint64
+		file      string
+		gtidSet   sql.NullString
+		events    int64
+		gapAt     sql.NullTime
+		gapDetail sql.NullString
+	)
+	readBack := func() {
+		t.Helper()
+		if err := db.QueryRowContext(ctx, `
+			SELECT binlog_position, binlog_file, gtid_set, events_indexed, gap_lost_at, gap_lost_detail
+			FROM stream_state WHERE id = 1`).
+			Scan(&pos, &file, &gtidSet, &events, &gapAt, &gapDetail); err != nil {
+			t.Fatalf("the stream_state row must SURVIVE a reset (never DELETEd): %v", err)
+		}
+	}
+	readBack()
+	if pos != 0 || file != "" || gtidSet.Valid || events != 0 {
+		t.Errorf("cursor not cleared: pos=%d file=%q gtid=%v events=%d", pos, file, gtidSet, events)
+	}
+	if !gapAt.Valid || gapDetail.String != res.lossDetail {
+		t.Errorf("discard not stamped: gap_lost_at=%v detail=%q (want %q)", gapAt, gapDetail.String, res.lossDetail)
+	}
+
+	// Second clear: no checkpoint left to discard — the loss record from the first
+	// reset must survive verbatim (the no-op path never touches gap_lost_*).
+	resetDetail := gapDetail.String
+	res2, err := clearCheckpoint(ctx, db)
+	if err != nil || res2.rows != 1 || res2.lossDetail != "" {
+		t.Fatalf("second clear = (%+v, %v), want rows=1 and no new loss", res2, err)
+	}
+	readBack()
+	if !gapAt.Valid || gapDetail.String != resetDetail {
+		t.Errorf("no-checkpoint clear erased/altered the loss record: at=%v detail=%q", gapAt, gapDetail.String)
 	}
 
 	if _, err := db.ExecContext(ctx, "DROP TABLE stream_state"); err != nil {
 		t.Fatalf("drop stream_state: %v", err)
 	}
-	rows, missing, err = clearCheckpoint(ctx, db)
-	if err != nil || !missing {
-		t.Fatalf("clear with no table = (rows=%d, missing=%t, err=%v), want (_, true, nil)", rows, missing, err)
+	res3, err := clearCheckpoint(ctx, db)
+	if err != nil || !res3.tableMissing {
+		t.Fatalf("clear with no table = (%+v, %v), want tableMissing", res3, err)
 	}
 }

--- a/cmd/bintrail-pg/reset_test.go
+++ b/cmd/bintrail-pg/reset_test.go
@@ -3,10 +3,12 @@ package main
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"errors"
 	"strings"
 	"testing"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/go-sql-driver/mysql"
 	"github.com/spf13/cobra"
 )
@@ -98,8 +100,8 @@ func TestPGResetConfig_IndexOnlySkipsQuerySlot(t *testing.T) {
 // ─── resetPlan orchestration (seam-injected; no live DBs) ───────────────────────
 
 // okClear is a clearFn that records invocation and reports n rows cleared.
-func recordingClear(n int64, called *bool) func(context.Context) (int64, bool, error) {
-	return func(context.Context) (int64, bool, error) { *called = true; return n, false, nil }
+func recordingClear(n int64, called *bool) func(context.Context) (clearOutcome, error) {
+	return func(context.Context) (clearOutcome, error) { *called = true; return clearOutcome{rows: n}, nil }
 }
 
 // TestResetPlan_DropFailureLeavesCheckpoint is the load-bearing ordering guarantee
@@ -166,7 +168,7 @@ func TestResetPlan_AbsentSlot(t *testing.T) {
 func TestResetPlan_TableMissingNamesAmbiguity(t *testing.T) {
 	var out bytes.Buffer
 	dropFn := func(context.Context) (bool, error) { return true, nil }
-	clearFn := func(context.Context) (int64, bool, error) { return 0, true, nil } // 1146
+	clearFn := func(context.Context) (clearOutcome, error) { return clearOutcome{tableMissing: true}, nil } // 1146
 	if err := resetPlan(context.Background(), false, "s", &out, dropFn, clearFn); err != nil {
 		t.Fatalf("resetPlan: %v", err)
 	}
@@ -178,10 +180,126 @@ func TestResetPlan_TableMissingNamesAmbiguity(t *testing.T) {
 
 func TestResetPlan_ClearFailsAfterDropMentionsIndexOnly(t *testing.T) {
 	dropFn := func(context.Context) (bool, error) { return true, nil }
-	clearFn := func(context.Context) (int64, bool, error) { return 0, false, errors.New("index unreachable") }
+	clearFn := func(context.Context) (clearOutcome, error) { return clearOutcome{}, errors.New("index unreachable") }
 	err := resetPlan(context.Background(), false, "s", &bytes.Buffer{}, dropFn, clearFn)
 	if err == nil || !strings.Contains(err.Error(), "--index-only") {
 		t.Fatalf("a clear failure after a successful drop must hint --index-only, got %v", err)
+	}
+}
+
+// TestResetPlan_LossDetailSurfacesInOutput: when the clear stamped a continuity
+// loss, the operator-facing output must say so and carry the detail — a silent
+// stamp would leave the operator to discover the status banner by surprise.
+func TestResetPlan_LossDetailSurfacesInOutput(t *testing.T) {
+	var out bytes.Buffer
+	dropFn := func(context.Context) (bool, error) { return true, nil }
+	clearFn := func(context.Context) (clearOutcome, error) {
+		return clearOutcome{rows: 1, lossDetail: "was LSN 0/1A2B3C4"}, nil
+	}
+	if err := resetPlan(context.Background(), false, "s", &out, dropFn, clearFn); err != nil {
+		t.Fatalf("resetPlan: %v", err)
+	}
+	for _, want := range []string{"permanent continuity loss", "was LSN 0/1A2B3C4", "bintrail status"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("output missing %q: %s", want, out.String())
+		}
+	}
+}
+
+// ─── clearCheckpoint (sqlmock; #1082 stamp-don't-DELETE contract) ───────────────
+
+// TestClearCheckpoint_RealCheckpointStampsLoss: discarding a real checkpoint must
+// stamp gap_lost_* IN the same UPDATE that clears the cursor (a single atomic
+// statement — stamp and clear can never be torn apart) and report the discarded
+// LSN in the loss detail.
+func TestClearCheckpoint_RealCheckpointStampsLoss(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT binlog_position FROM stream_state").
+		WillReturnRows(sqlmock.NewRows([]string{"binlog_position"}).AddRow(uint64(0x1A2B3C4)))
+	mock.ExpectExec(`UPDATE stream_state SET\s+gap_lost_at\s+= UTC_TIMESTAMP\(\)`).
+		WithArgs(sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	res, err := clearCheckpoint(context.Background(), db)
+	if err != nil || res.tableMissing || res.rows != 1 {
+		t.Fatalf("clearCheckpoint = (%+v, %v), want rows=1", res, err)
+	}
+	for _, want := range []string{"0/1A2B3C4", "bintrail-pg reset", "permanently lost"} {
+		if !strings.Contains(res.lossDetail, want) {
+			t.Errorf("lossDetail %q missing %q", res.lossDetail, want)
+		}
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("a real checkpoint must be stamped as lost while clearing: %v", err)
+	}
+}
+
+// TestClearCheckpoint_NoCheckpointPreservesPriorLoss: a row without a durable
+// checkpoint (position 0 — a lost-slot stamp, a pre-commit health snapshot, or an
+// earlier reset) discards nothing: the clear must NOT touch gap_lost_* (the
+// expected UPDATE starts at binlog_file; a stamping UPDATE would go unmatched)
+// and no loss is reported.
+func TestClearCheckpoint_NoCheckpointPreservesPriorLoss(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT binlog_position FROM stream_state").
+		WillReturnRows(sqlmock.NewRows([]string{"binlog_position"}).AddRow(0))
+	mock.ExpectExec(`UPDATE stream_state SET\s+binlog_file`).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	res, err := clearCheckpoint(context.Background(), db)
+	if err != nil || res.rows != 1 || res.lossDetail != "" {
+		t.Fatalf("clearCheckpoint = (%+v, %v), want rows=1 and no loss detail", res, err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("a no-checkpoint clear must leave gap_lost_* untouched: %v", err)
+	}
+}
+
+// TestClearCheckpoint_NoRow: never streamed → nothing to clear, nothing to stamp
+// (sqlmock would error on any unexpected UPDATE).
+func TestClearCheckpoint_NoRow(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT binlog_position FROM stream_state").WillReturnError(sql.ErrNoRows)
+
+	res, err := clearCheckpoint(context.Background(), db)
+	if err != nil || res.rows != 0 || res.tableMissing || res.lossDetail != "" {
+		t.Fatalf("clearCheckpoint = (%+v, %v), want the zero outcome", res, err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("no row must mean no writes: %v", err)
+	}
+}
+
+// TestClearCheckpoint_TableMissing: MySQL 1146 on the load reports tableMissing
+// rather than erroring, matching the old DELETE behavior.
+func TestClearCheckpoint_TableMissing(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT binlog_position FROM stream_state").
+		WillReturnError(&mysql.MySQLError{Number: 1146})
+
+	res, err := clearCheckpoint(context.Background(), db)
+	if err != nil || !res.tableMissing {
+		t.Fatalf("clearCheckpoint = (%+v, %v), want tableMissing", res, err)
 	}
 }
 

--- a/cmd/bintrail-pg/reset_test.go
+++ b/cmd/bintrail-pg/reset_test.go
@@ -219,11 +219,13 @@ func TestClearCheckpoint_RealCheckpointStampsLoss(t *testing.T) {
 	}
 	defer db.Close()
 
-	mock.ExpectQuery("SELECT binlog_position FROM stream_state").
-		WillReturnRows(sqlmock.NewRows([]string{"binlog_position"}).AddRow(uint64(0x1A2B3C4)))
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT flavor, binlog_position FROM stream_state.*FOR UPDATE").
+		WillReturnRows(sqlmock.NewRows([]string{"flavor", "binlog_position"}).AddRow("postgres", uint64(0x1A2B3C4)))
 	mock.ExpectExec(`UPDATE stream_state SET\s+gap_lost_at\s+= UTC_TIMESTAMP\(\)`).
 		WithArgs(sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
 
 	res, err := clearCheckpoint(context.Background(), db)
 	if err != nil || res.tableMissing || res.rows != 1 {
@@ -251,10 +253,12 @@ func TestClearCheckpoint_NoCheckpointPreservesPriorLoss(t *testing.T) {
 	}
 	defer db.Close()
 
-	mock.ExpectQuery("SELECT binlog_position FROM stream_state").
-		WillReturnRows(sqlmock.NewRows([]string{"binlog_position"}).AddRow(0))
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT flavor, binlog_position FROM stream_state.*FOR UPDATE").
+		WillReturnRows(sqlmock.NewRows([]string{"flavor", "binlog_position"}).AddRow("postgres", 0))
 	mock.ExpectExec(`UPDATE stream_state SET\s+binlog_file`).
 		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
 
 	res, err := clearCheckpoint(context.Background(), db)
 	if err != nil || res.rows != 1 || res.lossDetail != "" {
@@ -274,7 +278,9 @@ func TestClearCheckpoint_NoRow(t *testing.T) {
 	}
 	defer db.Close()
 
-	mock.ExpectQuery("SELECT binlog_position FROM stream_state").WillReturnError(sql.ErrNoRows)
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT flavor, binlog_position FROM stream_state").WillReturnError(sql.ErrNoRows)
+	mock.ExpectRollback()
 
 	res, err := clearCheckpoint(context.Background(), db)
 	if err != nil || res.rows != 0 || res.tableMissing || res.lossDetail != "" {
@@ -294,12 +300,40 @@ func TestClearCheckpoint_TableMissing(t *testing.T) {
 	}
 	defer db.Close()
 
-	mock.ExpectQuery("SELECT binlog_position FROM stream_state").
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT flavor, binlog_position FROM stream_state").
 		WillReturnError(&mysql.MySQLError{Number: 1146})
+	mock.ExpectRollback()
 
 	res, err := clearCheckpoint(context.Background(), db)
 	if err != nil || !res.tableMissing {
 		t.Fatalf("clearCheckpoint = (%+v, %v), want tableMissing", res, err)
+	}
+}
+
+// TestClearCheckpoint_FlavorGuardRefusesForeignIndex: --index-dsn pointed at a
+// MySQL/MariaDB-source index (the wrong-database mistake) must refuse loud —
+// clearing a foreign checkpoint would stamp a MySQL byte offset rendered as a
+// PG LSN onto a live stream's state. No UPDATE may be issued (sqlmock errors
+// on unexpected statements).
+func TestClearCheckpoint_FlavorGuardRefusesForeignIndex(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT flavor, binlog_position FROM stream_state.*FOR UPDATE").
+		WillReturnRows(sqlmock.NewRows([]string{"flavor", "binlog_position"}).AddRow("mysql", uint64(193)))
+	mock.ExpectRollback()
+
+	_, err = clearCheckpoint(context.Background(), db)
+	if err == nil || !strings.Contains(err.Error(), "refusing") {
+		t.Fatalf("expected a loud flavor refusal, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("no write may touch a foreign-flavor index: %v", err)
 	}
 }
 

--- a/cmd/bintrail-pg/stream.go
+++ b/cmd/bintrail-pg/stream.go
@@ -52,8 +52,9 @@ position — --start-lsn cannot rewind to an earlier point (the older WAL may ha
 been reclaimed). To force a fresh start, run 'bintrail-pg reset' (drops the slot
 and clears the stream_state checkpoint columns), then re-run. Discarding a real
 checkpoint that way is durably recorded as a permanent continuity loss — the
-recreated slot skips whatever the old one had not yet streamed — and any prior
-loss record survives the reset.
+recreated slot skips whatever the old one had not yet streamed — and a prior
+loss record is never erased by a reset (a real-checkpoint reset replaces its
+detail with the reset's own).
 
 Graceful shutdown: send SIGINT or SIGTERM to flush the current batch and write a
 final checkpoint before exiting.`,

--- a/cmd/bintrail-pg/stream.go
+++ b/cmd/bintrail-pg/stream.go
@@ -49,9 +49,11 @@ run (before any checkpoint exists); thereafter the checkpoint always wins.
 
 Re-seeding: once a checkpoint and slot exist, PostgreSQL resumes from the slot's
 position — --start-lsn cannot rewind to an earlier point (the older WAL may have
-been reclaimed). To force a fresh start, drop the replication slot on the source
-and clear the stream_state checkpoint row (DELETE FROM stream_state WHERE id=1),
-then re-run.
+been reclaimed). To force a fresh start, run 'bintrail-pg reset' (drops the slot
+and clears the stream_state checkpoint columns), then re-run. Discarding a real
+checkpoint that way is durably recorded as a permanent continuity loss — the
+recreated slot skips whatever the old one had not yet streamed — and any prior
+loss record survives the reset.
 
 Graceful shutdown: send SIGINT or SIGTERM to flush the current batch and write a
 final checkpoint before exiting.`,

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -327,9 +327,18 @@ bintrail-pg reset --index-dsn "$IDX" --index-only --force
 
 This removes only capture-resume state; the index's recovery data is untouched.
 Under the hood it is the two-system teardown that otherwise has to be done by hand
-(`SELECT pg_drop_replication_slot('bintrail_shop')` on the source +
-`DELETE FROM stream_state WHERE id = 1` on the index). After a reset, re-seed the
-baseline and re-run `bintrail-pg stream`.
+(`SELECT pg_drop_replication_slot('bintrail_shop')` on the source + clearing the
+position columns of the `stream_state` row on the index — the row is never
+DELETEd, so a recorded `gap_lost_at`/`gap_lost_detail` continuity-loss record
+always survives the reset).
+
+**A reset that discards a real checkpoint is itself recorded as a permanent
+continuity loss**: dropping and recreating the slot skips whatever the old slot
+had not yet streamed, so the discarded LSN is stamped into
+`gap_lost_at`/`gap_lost_detail` — `bintrail status` shows the
+`EVENTS PERMANENTLY LOST` banner and `status --fail-on-gap` exits non-zero,
+exactly as after a slot invalidation. After a reset, re-seed the baseline and
+re-run `bintrail-pg stream`.
 
 ### Index rotation and retention
 

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -328,9 +328,11 @@ bintrail-pg reset --index-dsn "$IDX" --index-only --force
 This removes only capture-resume state; the index's recovery data is untouched.
 Under the hood it is the two-system teardown that otherwise has to be done by hand
 (`SELECT pg_drop_replication_slot('bintrail_shop')` on the source + clearing the
-position columns of the `stream_state` row on the index — the row is never
-DELETEd, so a recorded `gap_lost_at`/`gap_lost_detail` continuity-loss record
-always survives the reset).
+position/counter columns of the `stream_state` row on the index — the row is
+never DELETEd, so a recorded `gap_lost_at`/`gap_lost_detail` continuity-loss
+record is never erased by a reset; a real-checkpoint reset replaces the
+record's detail with the reset's own, a no-checkpoint reset preserves it
+verbatim).
 
 **A reset that discards a real checkpoint is itself recorded as a permanent
 continuity loss**: dropping and recreating the slot skips whatever the old slot

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -593,7 +593,7 @@ func EnsureSchema(db *sql.DB) error {
 	// the only trace of the permanently lost events would be an in-memory
 	// flag that a daemon restart silently discards.
 	if err := ensureColumn(db, "stream_state", "gap_lost_at",
-		`ALTER TABLE stream_state ADD COLUMN gap_lost_at DATETIME DEFAULT NULL COMMENT 'when an unfillable binlog gap forced an auto-advance (events permanently lost); cleared by an explicit monitor Stop or --reset' AFTER bintrail_id`,
+		`ALTER TABLE stream_state ADD COLUMN gap_lost_at DATETIME DEFAULT NULL COMMENT 'when an unfillable binlog gap forced an auto-advance (events permanently lost); cleared only by an explicit monitor Stop; --reset re-stamps or preserves it' AFTER bintrail_id`,
 	); err != nil {
 		return err
 	}

--- a/internal/indexer/schema.go
+++ b/internal/indexer/schema.go
@@ -183,7 +183,7 @@ const ddlStreamState = `CREATE TABLE IF NOT EXISTS stream_state (
     last_checkpoint  DATETIME        NOT NULL,
     server_id        INT UNSIGNED    NOT NULL,
     bintrail_id      CHAR(36)        NULL DEFAULT NULL,
-    gap_lost_at      DATETIME        DEFAULT NULL COMMENT 'when an unfillable binlog gap forced an auto-advance (events permanently lost); cleared by an explicit monitor Stop or --reset',
+    gap_lost_at      DATETIME        DEFAULT NULL COMMENT 'when an unfillable binlog gap forced an auto-advance (events permanently lost); cleared only by an explicit monitor Stop; --reset re-stamps or preserves it',
     gap_lost_detail  TEXT            DEFAULT NULL COMMENT 'human-readable description of the lost gap',
     source_health    JSON            DEFAULT NULL COMMENT 'latest source-side health snapshot (PostgreSQL: replication-slot wal_status/lag + REPLICA IDENTITY coverage) with an embedded checked_at; serialized payload, source-agnostic column',
     CONSTRAINT single_row CHECK (id = 1)

--- a/internal/pgstreamrun/pgstreamrun.go
+++ b/internal/pgstreamrun/pgstreamrun.go
@@ -550,6 +550,17 @@ func loadStreamStatePG(db *sql.DB) (*pgStreamState, error) {
 	if flavor != pgFlavor {
 		return nil, fmt.Errorf("pgstreamrun: index database holds a %q checkpoint, not %q — refusing to stream a PostgreSQL source into a non-PostgreSQL index", flavor, pgFlavor)
 	}
+	if lsn == 0 {
+		// A row without a durable LSN cursor is NOT a resumable checkpoint.
+		// saveCheckpointPG never writes position 0 (the loop skips lastCommitLSN==0,
+		// and 0/0 is not a valid PostgreSQL LSN), so a zero-position row was seeded
+		// by persistSlotLostPG/saveSourceHealth before any commit, or is the cleared
+		// row `bintrail-pg reset` leaves behind (#1082: reset preserves the row so a
+		// gap_lost_* continuity-loss record survives it). Treat it as first-run —
+		// the capturer creates a fresh slot instead of demanding the one reset just
+		// dropped — and leave the loss record untouched for `status` to surface.
+		return nil, nil
+	}
 	return &pgStreamState{lsn: lsn, eventsIndexed: eventsIndexed, serverID: serverID, lastEventTime: lastEventTime}, nil
 }
 

--- a/internal/pgstreamrun/pgstreamrun_internal_test.go
+++ b/internal/pgstreamrun/pgstreamrun_internal_test.go
@@ -4,9 +4,11 @@ import (
 	"database/sql"
 	"encoding/json"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/jackc/pglogrepl"
 
 	"github.com/dbtrail/dbtrail/internal/pgcapture"
@@ -112,6 +114,70 @@ func TestBuildProbeErrorJSON(t *testing.T) {
 	}
 	if _, present := gm["probe_error"]; present {
 		t.Errorf("a healthy snapshot must omit probe_error, got %v", gm["probe_error"])
+	}
+}
+
+// ─── loadStreamStatePG (sqlmock; the #1082 fresh-start contract) ────────────────
+
+func mockStateRows(flavor string, lsn uint64) *sqlmock.Rows {
+	return sqlmock.NewRows([]string{"flavor", "binlog_position", "events_indexed", "server_id", "last_event_time"}).
+		AddRow(flavor, lsn, 12, 9, nil)
+}
+
+// TestLoadStreamStatePG_ZeroPositionIsFresh (#1082): a stream_state row without a
+// durable LSN cursor — seeded by a lost-slot stamp or a pre-commit health snapshot,
+// or the cleared row `bintrail-pg reset` leaves behind so gap_lost_* survives — must
+// read as "no checkpoint" (nil), so the capturer creates a fresh slot instead of
+// demanding the one reset just dropped (ExpectExistingSlot stays false).
+func TestLoadStreamStatePG_ZeroPositionIsFresh(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+	mock.ExpectQuery("SELECT flavor, binlog_position").WillReturnRows(mockStateRows("postgres", 0))
+
+	saved, err := loadStreamStatePG(db)
+	if err != nil {
+		t.Fatalf("loadStreamStatePG: %v", err)
+	}
+	if saved != nil {
+		t.Fatalf("a zero-position row must read as first-run (nil), got %+v", saved)
+	}
+}
+
+// TestLoadStreamStatePG_RealCheckpointResumes: the ordinary resume path is untouched
+// by the #1082 change — a non-zero cursor loads as a resumable checkpoint.
+func TestLoadStreamStatePG_RealCheckpointResumes(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+	mock.ExpectQuery("SELECT flavor, binlog_position").WillReturnRows(mockStateRows("postgres", 27439044))
+
+	saved, err := loadStreamStatePG(db)
+	if err != nil || saved == nil {
+		t.Fatalf("loadStreamStatePG = (%+v, %v), want a checkpoint", saved, err)
+	}
+	if saved.lsn != 27439044 || saved.eventsIndexed != 12 || saved.serverID != 9 {
+		t.Errorf("checkpoint misloaded: %+v", saved)
+	}
+}
+
+// TestLoadStreamStatePG_FlavorGuardBeatsZeroPosition: the flavor guard stays FIRST —
+// even a zero-position row of another flavor refuses loud (a cleared MySQL checkpoint
+// still marks a MySQL index; treating it as PG-fresh would clobber a foreign index).
+func TestLoadStreamStatePG_FlavorGuardBeatsZeroPosition(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+	mock.ExpectQuery("SELECT flavor, binlog_position").WillReturnRows(mockStateRows("mysql", 0))
+
+	if _, err := loadStreamStatePG(db); err == nil || !strings.Contains(err.Error(), `"mysql"`) {
+		t.Fatalf("a non-postgres row must refuse loud even at position 0, got %v", err)
 	}
 }
 


### PR DESCRIPTION
Closes #1082

## Problem

`bintrail-pg reset` cleared the checkpoint with a hard `DELETE FROM stream_state WHERE id = 1`, which also destroyed any recorded `gap_lost_at`/`gap_lost_detail` continuity-loss record. After the reset, `status` reported clean continuity and `--fail-on-gap` exited 0 — a previously detected, still-unacknowledged permanent loss was silently erased. This is the PG sibling of #1079, fixed for the MySQL binary in PR #1080 (stamp-the-discard-then-write, never DELETE-and-lose-history).

## Fix

**`cmd/bintrail-pg/reset.go`** — `clearCheckpoint` loads the existing row first and never DELETEs it:

- **Real checkpoint discarded** (non-zero LSN): dropping and recreating the slot inherently skips whatever the old slot had not yet streamed, so the discard is stamped as a permanent continuity loss (`gap_lost_at = UTC_TIMESTAMP()` + a detail naming the discarded LSN) **in the same UPDATE that clears the cursor** — stamp and clear can never be torn apart. A prior unacknowledged record's detail is replaced by the reset detail (PR #1080 jump semantics); the loss flag itself never clears here (monitor Stop remains the acknowledgment path).
- **No durable checkpoint** (row seeded by `persistSlotLostPG`/`saveSourceHealth` before any commit, or an earlier reset): nothing is discarded — only the position/counter columns are cleared and any prior `gap_lost_*` record is left untouched (PR #1080's no-op path).
- Table-missing (1146) / no-row behavior is unchanged.

**`internal/pgstreamrun/pgstreamrun.go`** — the subtle part: `loadStreamStatePG` previously returned non-nil for any row, and `saved != nil` drives `ExpectExistingSlot` — a surviving row would have made the next `stream` demand the slot reset just dropped (`ErrSlotMissingOnResume`). It now treats a **zero-position row as "no checkpoint"** (return nil): `saveCheckpointPG` never writes position 0 (the loop skips `lastCommitLSN==0`, and `0/0` is not a valid PostgreSQL LSN), so a zero-position row is exactly the seeded/cleared shape. The next stream start creates a fresh slot, and the loss record stays for `status` to surface. The flavor guard stays FIRST: a cleared non-postgres row still refuses loud.

**User-facing text**: reset output now reports the recorded loss; the `reset`/`stream` help text and `docs/postgres.md` no longer document the DELETE and describe the loss-recording semantics.

## Tests

- `cmd/bintrail-pg/reset_test.go` (sqlmock, mirrors PR #1080's `reset_test.go`): real-checkpoint discard stamps `gap_lost_*` in the clearing UPDATE with the discarded LSN in the detail; a no-checkpoint clear must not touch `gap_lost_*`; no-row and 1146 paths; loss detail surfaces in `resetPlan` output.
- `cmd/bintrail-pg/reset_integration_test.go` (real MySQL): a checkpoint with a prior unacknowledged loss record → reset clears the cursor, stamps the reset detail, the row survives; a second reset preserves the loss record verbatim; table-missing still reports cleanly.
- `internal/pgstreamrun/pgstreamrun_internal_test.go`: zero-position row loads as fresh (nil), real checkpoint still resumes, flavor guard beats the zero-position check.

## Verification

`go build ./...`, `go vet ./cmd/bintrail-pg/ ./internal/pgstreamrun/`, `go test -race ./cmd/bintrail-pg/... ./internal/pgstreamrun/... -count=1`, `go test ./... -count=1` (45 pkgs ok), `go vet -tags integration ./...` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)