### PR TITLE
console: fix telemetry spool race in recordAction tests (flaky TestRecordActionStatusClassification)

### DIFF
--- a/internal/console/telemetry_api_test.go
+++ b/internal/console/telemetry_api_test.go
@@ -34,6 +34,11 @@ func enableRealTelemetry(t *testing.T) (*telemetry.Client, string) {
 	if !c.Enabled() {
 		t.Fatalf("telemetry client not enabled after clearing env; decision=%+v", c.Decision())
 	}
+	// Init kicks off an async drain of the spool dir. If it runs after this
+	// test appends an event, it claims the fresh file, fails to deliver it to
+	// the dead endpoint, and drops it — readSpooledEvents then finds the file
+	// renamed or gone. Wait it out; over an empty spool it returns immediately.
+	c.WaitStartupDrain()
 	return c, dir
 }
 

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -201,6 +201,23 @@ func (c *Client) Shutdown() {
 	}
 }
 
+// WaitStartupDrain blocks until the startup drain kicked off by Init has
+// finished. It returns at once on a nil, disabled, or never-drained client,
+// and it cannot hang: the drain itself is bounded by drainDeadline.
+//
+// It exists for tests that append events and then read the spool back. The
+// startup drain runs on its own goroutine, and if the scheduler runs it AFTER
+// the test has appended, it legitimately claims the fresh spool file, fails to
+// deliver it to the test's dead endpoint, and drops it — the reader then finds
+// the file renamed or already gone. Shutdown is not a substitute: it gives up
+// after shutdownGrace, which turns that race into "rare" instead of "never".
+func (c *Client) WaitStartupDrain() {
+	if c == nil || c.drained == nil {
+		return
+	}
+	<-c.drained
+}
+
 // maybeShowNotice prints the first-run disclosure once, on an interactive
 // terminal, and only while telemetry is running on the DEFAULT — an operator
 // who has already chosen has nothing to be told. The sentinel is recorded

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -561,11 +561,13 @@ func TestPurgeSpool(t *testing.T) {
 // drain is a background goroutine, and if it scans AFTER the test has appended,
 // it legitimately claims that file, fails to deliver it to the dead endpoint,
 // and drops it — leaving the test reading an empty spool. Waiting costs nothing
-// here, since a drain over an empty spool returns immediately.
+// here, since a drain over an empty spool returns immediately. Wait without a
+// deadline (not Shutdown, which abandons the drain after shutdownGrace) so the
+// race stays impossible rather than merely rare under scheduler load.
 func initDrained(t *testing.T, cfg Config) *Client {
 	t.Helper()
 	c := Init(cfg)
-	c.Shutdown()
+	c.WaitStartupDrain()
 	return c
 }
 


### PR DESCRIPTION
Closes #1084

## Root cause

`enableRealTelemetry` builds a real `telemetry.Client`, and `telemetry.Init` kicks off an **async startup-drain goroutine** over the same spool dir the test then writes to and reads back. When the scheduler runs that drain AFTER the test's `Span.Finish` has appended the day file, the drain legitimately **claims the file by rename**, fails to deliver it to the test's dead endpoint (`http://127.0.0.1:1`), and **removes it** (delivery failures drop the batch by design). `readSpooledEvents` then either hits ENOENT between `ReadDir` and `ReadFile` — the exact CI signature — or finds 0 events.

This also explains why a **different subtest fails each time**: every subtest runs its own `Init`, so whichever one's drain goroutine gets scheduled late (only under CI load) loses. The sibling `TestRecordActionSpoolsRunIDFreeEvent` has the identical latent race.

Not a production bug: in a real process a late startup drain claiming a just-written event simply delivers (or drops, within the documented aggregate-data tolerance) it early — no product guarantee depends on that ordering. The telemetry package's own tests already knew this race and used `initDrained` (Init + `Shutdown`); the console test skipped the wait entirely.

## Repro (repro > cita)

Reproduces locally on the very first try — `-race` scheduler perturbation is enough, no CI load needed:

```
$ go test -race -run 'TestRecordActionStatusClassification|TestRecordActionSpoolsRunIDFreeEvent' ./internal/console/ -count=30
--- FAIL: TestRecordActionStatusClassification/writeOnlyDefaults200
    telemetry_api_test.go:335: read spool file: open .../telemetry-spool/2026-07-23.ndjson: no such file or directory
--- FAIL: TestRecordActionSpoolsRunIDFreeEvent
    telemetry_api_test.go:264: spooled 0 events, want 2: []
```

Across 6 such runs before the fix: failures in `ok200`, `writeOnlyDefaults200`, `notFound404`, `firstWriteHeaderWins` — different subtests each run, matching the CI evidence. One mode (`spooled 1 events, want 2`, only the second event surviving) proves the race window is **per-append**, not just at read time — so the fix must complete the drain before the first append, not poll at read time.

## Fix

- **`internal/telemetry/telemetry.go`**: new `Client.WaitStartupDrain()` — unbounded wait on the startup drain's completion channel (the drain itself is bounded by `drainDeadline`, so it cannot hang; immediate return on nil/disabled/never-drained clients).
- **`internal/console/telemetry_api_test.go`**: `enableRealTelemetry` calls `WaitStartupDrain()` after `Init`, before returning — the drain (over a still-empty spool) is fully done before any subtest appends. Fixes both `TestRecordActionStatusClassification` and `TestRecordActionSpoolsRunIDFreeEvent`.
- **`internal/telemetry/telemetry_test.go`**: `initDrained` now uses `WaitStartupDrain()` instead of `Shutdown()` — Shutdown abandons the drain after `shutdownGrace` (250 ms), which left the telemetry package's own version of this race "rare" instead of "impossible".

No sleeps, no polling; the test synchronizes on the one async thing `Init` starts.

## Validation (all green)

- 6× `go test -race -run 'TestRecordActionStatusClassification|TestRecordActionSpoolsRunIDFreeEvent' ./internal/console/ -count=30` (180 iterations; failed within the first 30 before the fix)
- `go test -race -tags integration ./internal/console/ -run TestRecordActionStatusClassification -count=50`
- `go test -race ./internal/console/ ./internal/telemetry/ -count=5`
- `go test ./... -count=1`
- `go vet -tags integration ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
