### PR TITLE
console: enforce data profiles per session at request time

### DIFF
--- a/internal/console/api.go
+++ b/internal/console/api.go
@@ -201,7 +201,12 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	rows, plan, err := s.fetch(r.Context(), b, opts)
+	opts, err = s.applySessionProfile(r.Context(), r, b, opts)
+	if err != nil {
+		writeSessionProfileError(w, err)
+		return
+	}
+	rows, plan, err := s.fetchRestricted(r.Context(), r, b, opts)
 	if err != nil {
 		writeFetchError(w, err)
 		return
@@ -244,6 +249,11 @@ func (s *Server) handleRecover(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	opts, err = s.applySessionProfile(r.Context(), r, b, opts)
+	if err != nil {
+		writeSessionProfileError(w, err)
+		return
+	}
 	// Refuse to generate an undo script for the entire index; a recovery must
 	// be scoped to at least one schema.
 	if opts.Schema == "" {
@@ -267,7 +277,7 @@ func (s *Server) handleRecover(w http.ResponseWriter, r *http.Request) {
 	// Coverage gaps come back in plan.GapHours and are surfaced as warnings
 	// below — the recover UI renders them, so an incomplete-coverage undo is
 	// flagged to the operator rather than silently presented as complete.
-	rows, plan, err := s.fetch(r.Context(), b, opts)
+	rows, plan, err := s.fetchRestricted(r.Context(), r, b, opts)
 	if err != nil {
 		writeFetchError(w, err)
 		return
@@ -312,10 +322,11 @@ func (s *Server) handleRecover(w http.ResponseWriter, r *http.Request) {
 			warnings = append([]string{
 				"Could not check whether this table is a foreign-key parent (detection failed: " + derr.Error() + "). If it is, any cascade-deleted child rows are NOT included in the script below — retry, or use recover-cascade to reconstruct them.",
 			}, warnings...)
-		case isParent && s.rbacActive():
+		case isParent && s.rbacActiveFor(r):
 			// Synthesis can't honor redaction (it would leak denied/redacted child
-			// rows), so it stays disabled under a profile — but SAY so, so a
-			// parent-only script is never silently presented as a full restore.
+			// rows), so it stays disabled under a profile — startup OR per-session
+			// (#1075) — but SAY so, so a parent-only script is never silently
+			// presented as a full restore.
 			warnings = append([]string{
 				"This table has ON DELETE CASCADE / SET NULL children, but cascade synthesis is disabled while an RBAC redaction profile is active — the script below re-creates the parent only; cascade-deleted child rows are NOT included.",
 			}, warnings...)

--- a/internal/console/baselines_api.go
+++ b/internal/console/baselines_api.go
@@ -54,6 +54,14 @@ func (s *Server) handleBaselines(w http.ResponseWriter, r *http.Request) {
 	if b == nil {
 		return
 	}
+	// Baseline snapshot reads bypass RBAC redaction, so a session carrying a data
+	// profile is refused the listing (#1075) — the same invariant that gates
+	// reconstruct. A startup profile already forced baselineConfigured false.
+	if sessionRestricted(r) {
+		writeJSONError(w, http.StatusForbidden,
+			"baseline listings are unavailable while an access-control profile is active — baseline reads aren't redacted")
+		return
+	}
 	resp := baselinesResponse{Reconstruct: b.baselineConfigured, Snapshots: []baselineSnapshotDTO{}}
 	if b.baselineSrc == "" {
 		writeJSON(w, http.StatusOK, resp)

--- a/internal/console/extview.go
+++ b/internal/console/extview.go
@@ -91,7 +91,7 @@ func (s *Server) consoleFetch(b *bundle) func(ctx context.Context, opts query.Op
 // because capabilities omit the view under a profile.
 func (s *Server) rbacViewGuard(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if s.profileActive {
+		if s.profileActiveFor(r) {
 			writeJSONError(w, http.StatusForbidden,
 				"this view is unavailable while an access-control profile is active")
 			return

--- a/internal/console/reconstruct.go
+++ b/internal/console/reconstruct.go
@@ -155,7 +155,7 @@ func (s *Server) handleCapabilities(w http.ResponseWriter, r *http.Request) {
 		VerifyTrigger:   s.verifyCtrl != nil,
 		// recover-cascade is the free tier (like recover) and process-global, gated
 		// only by the RBAC profile (which would make synthesis leak redacted data).
-		RecoverCascade: !s.rbacActive(),
+		RecoverCascade: !s.rbacActiveFor(r),
 		Auth:           authCapsInfo{PasswordSet: s.passwordLoginEnabled(), AuthKind: kind},
 		Permissions:    permissionsForPolicy(policyFrom(r.Context())),
 		// The MCP endpoint accepts the static token or the UI-managed one
@@ -168,11 +168,15 @@ func (s *Server) handleCapabilities(w http.ResponseWriter, r *http.Request) {
 		Source: sourceMySQL,
 	}
 	if b, err := s.resolve(r); err == nil {
-		resp.Reconstruct = b.baselineConfigured
+		// A per-session data profile refuses reconstruct/cascade (baseline reads
+		// bypass redaction; cascade synthesis can't redact), so the advertised
+		// capabilities must go false for a profiled session too (#1075).
+		restricted := sessionRestricted(r)
+		resp.Reconstruct = b.baselineConfigured && !restricted
 		// Match the recover-cascade handler's Phase-2 gate exactly so the advertised
 		// capability can't over-promise (handler builds the provider only when both
 		// a baseline source and a resolver are present).
-		resp.RecoverCascadeBaseline = b.baselineConfigured && b.resolver != nil
+		resp.RecoverCascadeBaseline = b.baselineConfigured && b.resolver != nil && !restricted
 		// Verify's engine (baseline-anchored and live-source alike) carries no RBAC
 		// redaction — see verify_trigger.go — so this reuses baselineConfigured
 		// verbatim (not just b.baselineSrc != ""): that field already folds in
@@ -180,7 +184,7 @@ func (s *Server) handleCapabilities(w http.ResponseWriter, r *http.Request) {
 		// too, so a no-archive server would otherwise advertise verify:true and
 		// then reliably fail with a coverage-gap error on any window touching a
 		// rotated-out hour — worse than just hiding it, like Reconstruct does.
-		if s.verifyCtrl != nil && !s.rbacActive() {
+		if s.verifyCtrl != nil && !s.rbacActiveFor(r) {
 			resp.Verify = b.baselineConfigured
 			if e, ok := s.selectedEntry(r); ok {
 				resp.VerifyLiveSource = e.SourceDSN != ""
@@ -204,7 +208,7 @@ func (s *Server) handleCapabilities(w http.ResponseWriter, r *http.Request) {
 	// (advertising a nav item that only 403s would be a lie) — and for an invalid
 	// id, which buildHandler declined to mount (advertising it would 404 the data
 	// route).
-	if p := ext.ConsoleView(); p != nil && !s.profileActive && ext.ValidConsoleViewID(p.ID()) {
+	if p := ext.ConsoleView(); p != nil && !s.profileActiveFor(r) && ext.ValidConsoleViewID(p.ID()) {
 		resp.ExtensionViews = []extensionViewDTO{{ID: p.ID(), Label: p.Label(), Script: p.Script()}}
 	}
 	writeJSON(w, http.StatusOK, resp)
@@ -254,6 +258,15 @@ func (s *Server) handleReconstruct(w http.ResponseWriter, r *http.Request) {
 	// bundle's baselineConfigured; see newBundleDerived for why archive access
 	// is required). Per-server enforcement matters: baseline reads bypass RBAC
 	// redaction, so the gate must not leak from one server's config to another.
+	// A session carrying a data profile is refused: reconstruct reads the
+	// baseline snapshot, which bypasses RBAC redaction (#1075). The per-bundle
+	// baselineConfigured already folds in the STARTUP profile; this adds the
+	// per-session one.
+	if sessionRestricted(r) {
+		writeJSONError(w, http.StatusForbidden,
+			"time-travel is unavailable while an access-control profile is active — baseline reads aren't redacted")
+		return
+	}
 	if !b.baselineConfigured {
 		writeJSONError(w, http.StatusNotFound,
 			"time-travel isn't available for this server (no baseline is set up, an access-control profile is active, or archive access is disabled)")

--- a/internal/console/recover_cascade.go
+++ b/internal/console/recover_cascade.go
@@ -82,7 +82,7 @@ func (s *Server) handleRecoverCascade(w http.ResponseWriter, r *http.Request) {
 	// synthesis (#585), refuse cascade recovery whenever a profile is active. The
 	// capability gate is intended to hide the tab once the frontend lands (#580);
 	// this guard is the actual enforcement / defense-in-depth backstop.
-	if s.rbacActive() {
+	if s.rbacActiveFor(r) {
 		writeJSONError(w, http.StatusForbidden,
 			"recover-cascade is unavailable while an RBAC redaction profile is active "+
 				"(cascade victim synthesis cannot yet honor column redaction / table deny)")

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -202,6 +202,10 @@ type Server struct {
 	// generate/rotate/revoke handlers so changes apply without a restart.
 	mcpTokenPath string
 	managedTok   managedMCPToken
+	// sessionProfiles caches per-(server, profile) RBAC rules for per-session
+	// data-profile enforcement (#1075). Inert in OSS (no session ever carries a
+	// profile); populated lazily on the first profiled request.
+	sessionProfiles *profileRuleCache
 }
 
 // serverHeader selects the target server per request. Selection is stateless —
@@ -346,6 +350,7 @@ func New(cfg Config) (*Server, error) {
 		loginLimiter:     newLoginLimiter(),
 		tlsConf:          tlsConf,
 		mcpTokenPath:     mcpTokenPath,
+		sessionProfiles:  newProfileRuleCache(),
 	}
 	s.managedTok.initFromDisk(mcpTokenPath, mcpTokFile)
 	s.cm.hideBoot = cfg.HideBoot

--- a/internal/console/servers_api.go
+++ b/internal/console/servers_api.go
@@ -346,7 +346,8 @@ func (s *Server) handleServersUpdate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if dsn != old.DSN {
-		s.cm.evict(id) // connection points at the old DSN; close and reopen lazily
+		s.cm.evict(id)                    // connection points at the old DSN; close and reopen lazily
+		s.sessionProfiles.invalidate(id) // its cached profile rules were resolved against the old index (#1075)
 	} else {
 		s.cm.rebuildDerived(entry) // keep the db, recompute baseline/no-archive gates
 	}
@@ -369,6 +370,7 @@ func (s *Server) handleServersDelete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.cm.evict(id)
+	s.sessionProfiles.invalidate(id) // purge its cached profile rules (#1075)
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/internal/console/session_profile.go
+++ b/internal/console/session_profile.go
@@ -1,0 +1,220 @@
+package console
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/parquetquery"
+	"github.com/dbtrail/dbtrail/internal/query"
+)
+
+// Per-session data-profile enforcement (#1075). A session may carry a data
+// profile name (ext.AccessPolicy.Profile, attached by an EE build via the
+// session-issuer seam — #1074). When it does, the console resolves that profile
+// against the SELECTED server's index at request time and enforces it: redaction
+// on the data-read paths, and a hard refusal of every surface that reads raw or
+// baseline data the redaction pass cannot cover.
+//
+// The OSS build attaches no policy, so sessionProfileName is always "" and every
+// helper here is inert — behavior is unchanged.
+
+// sessionProfileTTL bounds how long a resolved (server, profile) rule set is
+// cached. Short on purpose: a profile edited via the CLI takes effect within one
+// TTL, and the rules are tiny so re-loading is cheap.
+const sessionProfileTTL = 30 * time.Second
+
+// sessionProfileName returns the data-profile name the request's session
+// carries, or "" when the session has no policy or an empty profile (the OSS
+// case, and any full-access session).
+func sessionProfileName(r *http.Request) string {
+	if p := policyFrom(r.Context()); p != nil {
+		return p.Profile
+	}
+	return ""
+}
+
+// sessionRestricted reports whether the request's session carries a data
+// profile. It is the single predicate the raw/baseline-data gates key on
+// (reconstruct, baselines, recover-cascade, verify, extension views): those
+// surfaces cannot honor per-column redaction, so a profiled session is refused
+// outright rather than shown unredacted data.
+func sessionRestricted(r *http.Request) bool {
+	return sessionProfileName(r) != ""
+}
+
+// rbacActiveFor folds the request's session profile into the process-global
+// rbacActive() signal. Gate sites that refused a surface under a startup profile
+// (recover-cascade, verify, reconstruct/verify capabilities) call this so they
+// refuse it for a profiled session too. Inert in OSS: sessionRestricted is false,
+// so it equals rbacActive().
+func (s *Server) rbacActiveFor(r *http.Request) bool {
+	return s.rbacActive() || sessionRestricted(r)
+}
+
+// profileActiveFor folds the request's session profile into the process-global
+// profileActive signal (a NAMED profile was supplied). The extension-view guard
+// and the extension-view capability suppression key on this, so a profiled
+// session is refused/hidden the raw-*sql.DB extension surface exactly as a
+// startup profile is. Inert in OSS.
+func (s *Server) profileActiveFor(r *http.Request) bool {
+	return s.profileActive || sessionRestricted(r)
+}
+
+// selectedID returns the server-selection key for the request (the
+// X-Bintrail-Server header, or the default). It is the per-server component of
+// the profile-rule cache key: the SAME profile name can resolve to DIFFERENT
+// rules on different servers' indexes, so the cache must not share entries
+// across servers.
+func (s *Server) selectedID(r *http.Request) string {
+	id := r.Header.Get(serverHeader)
+	if id == "" {
+		id = s.cm.defaultID()
+	}
+	return id
+}
+
+// writeSessionProfileError maps an applySessionProfile failure to a response: a
+// nonexistent profile is a 403 with an actionable message (the session's profile
+// is misconfigured — never silently enforce nothing); anything else is a logged
+// 500.
+func writeSessionProfileError(w http.ResponseWriter, err error) {
+	var nf *profileNotFoundError
+	if errors.As(err, &nf) {
+		writeJSONError(w, http.StatusForbidden, nf.Error())
+		return
+	}
+	slog.Error("console: session profile enforcement failed", "error", err)
+	writeJSONError(w, http.StatusInternalServerError, "couldn't apply your access profile — check the server log")
+}
+
+// profileNotFoundError signals that a session's data profile does not exist on
+// the selected server's index. Handlers map it to 403 — never "enforce nothing"
+// on a typo (the fail-loud posture the CLI/startup check takes, #838).
+type profileNotFoundError struct{ profile string }
+
+func (e *profileNotFoundError) Error() string {
+	return fmt.Sprintf("the data profile %q is not defined on this server", e.profile)
+}
+
+// profileRuleEntry is one cached (server, profile) resolution.
+type profileRuleEntry struct {
+	deny     []query.SchemaTable
+	redact   []query.SchemaTableColumn
+	exists   bool
+	loadedAt time.Time
+}
+
+// profileRuleCache caches resolved profile rules per (server, profile) with a
+// short TTL, so per-request enforcement does not re-query the index on every
+// events/recover call. Safe for concurrent use.
+type profileRuleCache struct {
+	mu  sync.Mutex
+	m   map[string]profileRuleEntry
+	now func() time.Time // injectable for tests
+}
+
+func newProfileRuleCache() *profileRuleCache {
+	return &profileRuleCache{m: make(map[string]profileRuleEntry), now: time.Now}
+}
+
+// load resolves the deny/redact rules for profile on db (the selected server's
+// index), caching the result under key for sessionProfileTTL. A cache entry
+// records existence too, so a nonexistent profile is cached (and re-checked on
+// expiry) rather than re-probed every request.
+func (c *profileRuleCache) load(ctx context.Context, key string, db *sql.DB, profile string) (profileRuleEntry, error) {
+	now := c.now()
+	c.mu.Lock()
+	if e, ok := c.m[key]; ok && now.Sub(e.loadedAt) < sessionProfileTTL {
+		c.mu.Unlock()
+		return e, nil
+	}
+	c.mu.Unlock()
+
+	// Resolve outside the lock (a DB round trip). A concurrent miss on the same
+	// key resolves twice; harmless (same result) and simpler than single-flight.
+	exists, err := query.ProfileExists(ctx, db, profile)
+	if err != nil {
+		return profileRuleEntry{}, err
+	}
+	e := profileRuleEntry{exists: exists, loadedAt: now}
+	if exists {
+		deny, redact, err := query.LoadProfileRules(ctx, db, profile)
+		if err != nil {
+			return profileRuleEntry{}, err
+		}
+		e.deny, e.redact = deny, redact
+	}
+
+	c.mu.Lock()
+	c.m[key] = e
+	c.mu.Unlock()
+	return e, nil
+}
+
+// invalidate drops every cached entry for a server (all its (server, profile)
+// keys), so a subsequent request re-resolves rules against that server's CURRENT
+// index. The console calls it wherever it evicts a server's connection bundle —
+// a DSN edit (the index may now be a DIFFERENT database) or a delete — so a
+// profiled session can never be enforced with rules resolved against the old
+// index against the new one (a stale under-redaction window otherwise).
+func (c *profileRuleCache) invalidate(id string) {
+	if c == nil {
+		return
+	}
+	prefix := id + "\x00"
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for k := range c.m {
+		if strings.HasPrefix(k, prefix) {
+			delete(c.m, k)
+		}
+	}
+}
+
+// applySessionProfile unions the request session's data-profile rules — resolved
+// against the selected server's index — onto opts, on top of the startup floor
+// buildOptions already set, and forces ProfileActive so query_text/query_hash
+// stay withheld (#699). A profile that does not exist on the selected server is a
+// *profileNotFoundError (handler → 403). No session profile → opts unchanged.
+func (s *Server) applySessionProfile(ctx context.Context, r *http.Request, b *bundle, opts query.Options) (query.Options, error) {
+	profile := sessionProfileName(r)
+	if profile == "" {
+		return opts, nil
+	}
+	e, err := s.sessionProfiles.load(ctx, s.selectedID(r)+"\x00"+profile, b.db, profile)
+	if err != nil {
+		return opts, fmt.Errorf("resolve session profile %q: %w", profile, err)
+	}
+	if !e.exists {
+		return opts, &profileNotFoundError{profile}
+	}
+	// Union with the startup floor: the startup profile is the floor, a session
+	// profile can only narrow further. Copy rather than append-in-place so the
+	// startup slices (shared across requests) are never mutated.
+	opts.DenyTables = append(append([]query.SchemaTable(nil), opts.DenyTables...), e.deny...)
+	opts.RedactColumns = append(append([]query.SchemaTableColumn(nil), opts.RedactColumns...), e.redact...)
+	opts.ProfileActive = true
+	return opts, nil
+}
+
+// fetchRestricted runs the shared cross-source fetch like fetch, but forces
+// archives OFF when the request's session carries a data profile: Parquet
+// archives do not run the redaction pass, so a profiled session must read live
+// MySQL only (the same reason a startup profile forces --no-archive process-wide).
+func (s *Server) fetchRestricted(ctx context.Context, r *http.Request, b *bundle, opts query.Options) ([]query.ResultRow, *query.QueryPlan, error) {
+	noArchive := b.noArchive || sessionRestricted(r)
+	return query.FetchMerged(ctx, b.db, b.engine, query.FetchMergedOptions{
+		Opts:           opts,
+		DBName:         b.dbName,
+		NoArchive:      noArchive,
+		AllowGaps:      true,
+		ArchiveFetcher: parquetquery.Fetch,
+	})
+}

--- a/internal/console/session_profile_integration_test.go
+++ b/internal/console/session_profile_integration_test.go
@@ -1,0 +1,118 @@
+//go:build integration
+
+package console
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/ext"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// seedSensitiveProfile creates a "sensitive" profile in the index that denies
+// the app.secrets table and redacts app.users.ssn — real profiles/table_flags/
+// access_rules rows, so query.ProfileExists/LoadProfileRules resolve it at
+// request time (the per-session enforcement path #1075 exercises).
+func seedSensitiveProfile(t *testing.T, srv *Server) {
+	t.Helper()
+	db := srv.cm.boot.db
+	testutil.MustExec(t, db, `INSERT INTO profiles (name) VALUES ('sensitive')`)
+	testutil.MustExec(t, db, `INSERT INTO table_flags (schema_name, table_name, column_name, flag) VALUES ('app','secrets','','f_secrets')`)
+	testutil.MustExec(t, db, `INSERT INTO table_flags (schema_name, table_name, column_name, flag) VALUES ('app','users','ssn','f_ssn')`)
+	testutil.MustExec(t, db, `INSERT INTO access_rules (profile_id, flag, permission) SELECT id, 'f_secrets', 'deny' FROM profiles WHERE name='sensitive'`)
+	testutil.MustExec(t, db, `INSERT INTO access_rules (profile_id, flag, permission) SELECT id, 'f_ssn', 'deny' FROM profiles WHERE name='sensitive'`)
+}
+
+// newProfileIndexServer builds a console over a fresh index seeded with an
+// app.users (with an ssn) and an app.secrets event, NO startup RBAC profile.
+func newProfileIndexServer(t *testing.T) *Server {
+	t.Helper()
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	testutil.InsertEvent(t, db, "bin.000001", 4, 40, "2026-06-01 12:00:00", nil,
+		"app", "users", 1 /*INSERT*/, "1",
+		nil, nil, []byte(`{"id":1,"email":"alice@example","ssn":"ssn-12345"}`))
+	testutil.InsertEvent(t, db, "bin.000001", 40, 80, "2026-06-01 12:01:00", nil,
+		"app", "secrets", 1 /*INSERT*/, "1",
+		nil, nil, []byte(`{"id":1,"value":"topsecret"}`))
+	srv, err := New(Config{DB: db, DBName: dbName, Listen: "127.0.0.1:8090", Token: "static-tok"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return srv
+}
+
+// scopedBearer mints a session holding all permissions (so route-tier authz
+// never masks the data-profile gate) plus the given data profile.
+func scopedBearer(t *testing.T, srv *Server, profile string) string {
+	t.Helper()
+	tok, _, err := srv.sessions.IssueWithPolicy(&ext.AccessPolicy{Permissions: ext.AllPermissions(), Profile: profile})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tok
+}
+
+// TestIntegrationSessionProfileRedaction pins the core of #1075: a session
+// carrying a data profile sees redacted results, resolved per request against
+// the selected server's index — while a policy-less credential on the SAME
+// server sees the raw data (proving it is per-session, not process-global).
+func TestIntegrationSessionProfileRedaction(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	srv := newProfileIndexServer(t)
+	seedSensitiveProfile(t, srv)
+	scoped := scopedBearer(t, srv, "sensitive")
+
+	// Denied table: the profiled session gets nothing from app.secrets.
+	if rec := getPath(t, srv, "127.0.0.1:8090", "/api/events?schema=app&table=secrets", scoped); strings.Contains(rec.Body.String(), "topsecret") {
+		t.Errorf("denied table app.secrets leaked to a profiled session: %s", rec.Body.String())
+	}
+	// The static token (no profile) still sees it — proves the redaction is the
+	// SESSION's, not the process's.
+	if rec := getPath(t, srv, "127.0.0.1:8090", "/api/events?schema=app&table=secrets", "static-tok"); !strings.Contains(rec.Body.String(), "topsecret") {
+		t.Errorf("policy-less credential should see the raw table; per-session redaction leaked to the process: %s", rec.Body.String())
+	}
+	// Redacted column: ssn nulled for the profiled session, email intact.
+	rec := getPath(t, srv, "127.0.0.1:8090", "/api/events?schema=app&table=users", scoped)
+	if strings.Contains(rec.Body.String(), "ssn-12345") {
+		t.Errorf("redacted column ssn leaked to a profiled session: %s", rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "alice@example") {
+		t.Errorf("non-redacted column email must remain: %s", rec.Body.String())
+	}
+}
+
+// TestIntegrationSessionProfileNonexistent pins the fail-loud path: a session
+// whose profile does not exist on the selected server is refused (403), never
+// silently served unredacted.
+func TestIntegrationSessionProfileNonexistent(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	srv := newProfileIndexServer(t)
+	// No profile seeded named "ghost".
+	scoped := scopedBearer(t, srv, "ghost")
+	rec := getPath(t, srv, "127.0.0.1:8090", "/api/events?schema=app&table=users", scoped)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("session with a nonexistent profile GET /api/events = %d, want 403: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestIntegrationSessionProfileGatesRawSurfaces pins that a profiled session is
+// refused the baseline-reading surfaces (reconstruct, baselines) whose reads
+// bypass redaction.
+func TestIntegrationSessionProfileGatesRawSurfaces(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	srv := newProfileIndexServer(t)
+	seedSensitiveProfile(t, srv)
+	scoped := scopedBearer(t, srv, "sensitive")
+
+	for _, path := range []string{
+		"/api/reconstruct?schema=app&table=users&pk=1",
+		"/api/baselines",
+	} {
+		if rec := getPath(t, srv, "127.0.0.1:8090", path, scoped); rec.Code != http.StatusForbidden {
+			t.Errorf("profiled session GET %s = %d, want 403: %s", path, rec.Code, rec.Body.String())
+		}
+	}
+}

--- a/internal/console/session_profile_test.go
+++ b/internal/console/session_profile_test.go
@@ -1,0 +1,158 @@
+package console
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/ext"
+	"github.com/dbtrail/dbtrail/internal/query"
+)
+
+// reqWithPolicy builds a request carrying pol, as tokenMiddleware would after a
+// scoped session authenticates.
+func reqWithPolicy(pol *ext.AccessPolicy) *http.Request {
+	r := httptest.NewRequest("GET", "http://127.0.0.1:8090/api/x", nil)
+	return r.WithContext(context.WithValue(r.Context(), policyCtxKey{}, pol))
+}
+
+func TestSessionRestricted(t *testing.T) {
+	cases := []struct {
+		name string
+		pol  *ext.AccessPolicy
+		want bool
+	}{
+		{"no policy (OSS)", nil, false},
+		{"policy, no profile", &ext.AccessPolicy{Permissions: ext.AllPermissions()}, false},
+		{"policy with profile", &ext.AccessPolicy{Profile: "sensitive"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sessionRestricted(reqWithPolicy(tc.pol)); got != tc.want {
+				t.Errorf("sessionRestricted = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRbacActiveForFoldsSession pins that the per-request helpers equal the
+// process-global signals in OSS (no session profile) and go true for a profiled
+// session even with no startup rules.
+func TestRbacActiveForFoldsSession(t *testing.T) {
+	s := &Server{} // no startup deny/redact rules, profileActive false
+	// OSS: no policy → identical to process-global (false).
+	if s.rbacActiveFor(reqWithPolicy(nil)) || s.profileActiveFor(reqWithPolicy(nil)) {
+		t.Error("with no startup rules and no session profile, both must be false (OSS unchanged)")
+	}
+	// Session profile → both true.
+	profiled := reqWithPolicy(&ext.AccessPolicy{Profile: "sensitive"})
+	if !s.rbacActiveFor(profiled) || !s.profileActiveFor(profiled) {
+		t.Error("a session profile must make rbacActiveFor and profileActiveFor true")
+	}
+	// A permissioned session WITHOUT a profile does not restrict data.
+	roleOnly := reqWithPolicy(&ext.AccessPolicy{Permissions: ext.AllPermissions()})
+	if s.rbacActiveFor(roleOnly) || s.profileActiveFor(roleOnly) {
+		t.Error("a role-only session (no data profile) must not restrict data")
+	}
+}
+
+// TestApplySessionProfileNoOp pins that a session with no data profile leaves
+// query.Options byte-for-byte as buildOptions produced them (the OSS path).
+func TestApplySessionProfileNoOp(t *testing.T) {
+	s := &Server{sessionProfiles: newProfileRuleCache()}
+	in := query.Options{DenyTables: []query.SchemaTable{{Schema: "a", Table: "b"}}, ProfileActive: false}
+	out, err := s.applySessionProfile(context.Background(), reqWithPolicy(nil), &bundle{}, in)
+	if err != nil {
+		t.Fatalf("applySessionProfile (no profile) err = %v", err)
+	}
+	if out.ProfileActive != false || len(out.DenyTables) != 1 {
+		t.Errorf("no-profile session must leave opts unchanged, got %+v", out)
+	}
+}
+
+func TestWriteSessionProfileError(t *testing.T) {
+	// A nonexistent profile → 403.
+	rec := httptest.NewRecorder()
+	writeSessionProfileError(rec, &profileNotFoundError{"ghost"})
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("profileNotFoundError → %d, want 403", rec.Code)
+	}
+	// Any other error → 500.
+	rec = httptest.NewRecorder()
+	writeSessionProfileError(rec, errors.New("db down"))
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("generic error → %d, want 500", rec.Code)
+	}
+}
+
+// TestProfileRuleCacheInvalidate pins that invalidate purges exactly the target
+// server's entries (so a DSN edit re-resolves against the new index), leaves
+// other servers' entries, and is nil-safe.
+func TestProfileRuleCacheInvalidate(t *testing.T) {
+	c := newProfileRuleCache()
+	c.m["srv1\x00p"] = profileRuleEntry{exists: true}
+	c.m["srv1\x00q"] = profileRuleEntry{exists: true}
+	c.m["srv2\x00p"] = profileRuleEntry{exists: true}
+	c.invalidate("srv1")
+	if _, ok := c.m["srv1\x00p"]; ok {
+		t.Error("srv1 profile p not purged")
+	}
+	if _, ok := c.m["srv1\x00q"]; ok {
+		t.Error("srv1 profile q not purged")
+	}
+	if _, ok := c.m["srv2\x00p"]; !ok {
+		t.Error("srv2 entry must survive invalidate(srv1)")
+	}
+	var nilC *profileRuleCache
+	nilC.invalidate("x") // must not panic
+}
+
+// scopedServer builds a token server and returns a bearer for a session that
+// holds all permissions (so route-tier authz never masks the data-profile gate)
+// plus the given data profile.
+func scopedServer(t *testing.T, profile string) (*Server, string) {
+	t.Helper()
+	srv, err := New(Config{Listen: "127.0.0.1:8090", Token: "static-tok", AuthPath: filepath.Join(t.TempDir(), "auth.yaml")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tok, _, err := srv.sessions.IssueWithPolicy(&ext.AccessPolicy{Permissions: ext.AllPermissions(), Profile: profile})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return srv, tok
+}
+
+// TestRecoverCascadeRefusedForSessionProfile pins the raw-data gate that fires
+// before any DB access: a profiled session is 403'd on recover-cascade.
+func TestRecoverCascadeRefusedForSessionProfile(t *testing.T) {
+	srv, tok := scopedServer(t, "sensitive")
+	rec := postJSON(t, srv, "/api/recover-cascade", tok, `{"schema":"app","table":"orders","pk":"1"}`)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("profiled session POST /api/recover-cascade = %d, want 403", rec.Code)
+	}
+}
+
+// TestCapabilitiesFalseForSessionProfile pins that the reconstruct/cascade
+// capabilities go false for a profiled session, so the SPA hides those surfaces.
+func TestCapabilitiesFalseForSessionProfile(t *testing.T) {
+	srv, tok := scopedServer(t, "sensitive")
+	rec := getPath(t, srv, "127.0.0.1:8090", "/api/capabilities", tok)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /api/capabilities = %d", rec.Code)
+	}
+	var caps struct {
+		Reconstruct    bool `json:"reconstruct"`
+		RecoverCascade bool `json:"recover_cascade"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &caps); err != nil {
+		t.Fatal(err)
+	}
+	if caps.Reconstruct || caps.RecoverCascade {
+		t.Errorf("profiled session capabilities: reconstruct=%v recover_cascade=%v, want both false", caps.Reconstruct, caps.RecoverCascade)
+	}
+}

--- a/internal/console/verify_trigger.go
+++ b/internal/console/verify_trigger.go
@@ -155,7 +155,7 @@ func (s *Server) handleVerifyTrigger(w http.ResponseWriter, r *http.Request) {
 			"verify from the console is not enabled; start the watch daemon with BINTRAIL_CONSOLE_VERIFY_TRIGGER=1")
 		return
 	}
-	if s.rbacActive() {
+	if s.rbacActiveFor(r) {
 		writeJSONError(w, http.StatusForbidden,
 			"verification isn't available while an access-control profile is active — baseline and live-source reads aren't redacted")
 		return
@@ -251,7 +251,7 @@ func (s *Server) handleVerifyExplain(w http.ResponseWriter, r *http.Request) {
 			"verify from the console is not enabled; start the watch daemon with BINTRAIL_CONSOLE_VERIFY_TRIGGER=1")
 		return
 	}
-	if s.rbacActive() {
+	if s.rbacActiveFor(r) {
 		writeJSONError(w, http.StatusForbidden,
 			"verification isn't available while an access-control profile is active — baseline reads aren't redacted")
 		return


### PR DESCRIPTION
closes #1075

## Summary
A session may carry a data-profile name (`ext.AccessPolicy.Profile`, from #1074). When it does, the console resolves that profile **against the selected server's index at request time** and enforces it. The OSS build attaches no policy, so every session is unprofiled and behavior is unchanged.

- **Redaction on data reads** (`/api/events`, `/api/recover`): the session profile's deny/redact rules are resolved (`query.ProfileExists` + `query.LoadProfileRules`, cached per `(server, profile)` with a 30s TTL) and **unioned** onto the startup floor — the startup `--profile` is the floor, a session profile only narrows further. `ProfileActive` is forced so `query_text`/`query_hash` stay withheld (#699). A profile that does not exist on the selected server is a **403** (never "enforce nothing" on a typo). Archives are forced **off** per request (Parquet reads bypass redaction).
- **Raw/baseline-data surfaces refused (403)** for a profiled session: reconstruct, baseline listings, recover-cascade, and verify — their reads bypass redaction or their synthesis can't honor it. Extension-view data routes are refused by `rbacViewGuard` too; the reconstruct/cascade/verify **capabilities** go false so the SPA hides them.
- **Two per-request helpers** — `rbacActiveFor(r)` / `profileActiveFor(r)` — fold the session profile into the process-global `rbacActive()`/`profileActive` signals; every gate site calls them, so a profiled session refuses/hides exactly as a startup profile does. Inert in OSS.

## Composition with the startup `--profile`
Both apply: the union of deny tables and redact columns. The startup profile stays the floor; a session profile can only add restrictions.

## Out of scope (per the epic)
The console `/mcp` endpoint and the flashback port authenticate by token (no session policy) — untouched.

## OSS behavior preserved
No session ever carries a profile in the OSS build, so `sessionRestricted` is always false and every helper/gate is inert — byte-for-byte unchanged. `TestSessionRestricted`/`TestRbacActiveForFoldsSession` pin the no-profile path.

## Test plan
- [x] `go build ./...` clean; `go vet -tags integration ./internal/console/` clean
- [x] Unit: helpers (restricted/rbacActiveFor/profileActiveFor), `applySessionProfile` no-op without a profile, `writeSessionProfileError` (403/500), recover-cascade 403 for a profiled session, capabilities reconstruct/cascade false
- [x] **Integration (run against real MySQL 8.0 — all pass):** per-session redaction (denied table hidden, `ssn` column nulled, email intact) with a policy-less credential on the SAME server still seeing raw data (proves per-session, not process-global); nonexistent profile → 403; reconstruct + baselines → 403
- [x] Existing `TestIntegrationProfileRBAC` / reconstruct / verify integration tests still pass (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)