### PR TITLE
indexer: clamp batch size to MySQL's 65535 prepared-statement placeholder cap

### DIFF
--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -38,6 +38,25 @@ const DefaultWriteTimeout = 3 * time.Minute
 // a shared global).
 var WriteTimeout = DefaultWriteTimeout
 
+const (
+	// insertColumnCount is the number of columns (= placeholders per row) in
+	// insertBatch's multi-row INSERT.
+	insertColumnCount = 16
+	// maxPreparedStmtParams is MySQL's hard cap on placeholders in one
+	// prepared statement (ER_PS_MANY_PARAM, error 1390).
+	maxPreparedStmtParams = 65535
+	// MaxBatchSize is the largest batch whose INSERT stays under the
+	// placeholder cap. Derived from insertColumnCount so adding a column to
+	// the INSERT lowers the limit instead of silently re-breaking large
+	// batches (#956).
+	MaxBatchSize = maxPreparedStmtParams / insertColumnCount
+)
+
+// rowPlaceholders is one row's "(?,...,?)" tuple, derived from
+// insertColumnCount so the placeholder count and MaxBatchSize stay in
+// lockstep.
+var rowPlaceholders = "(" + strings.TrimSuffix(strings.Repeat("?,", insertColumnCount), ",") + ")"
+
 // Indexer consumes event.Events from a channel and batch-inserts them into
 // the binlog_events table.
 type Indexer struct {
@@ -65,6 +84,11 @@ type Indexer struct {
 func New(db *sql.DB, batchSize int) *Indexer {
 	if batchSize <= 0 {
 		batchSize = 1000
+	}
+	if batchSize > MaxBatchSize {
+		slog.Warn("batch size exceeds MySQL's prepared-statement placeholder cap, clamping",
+			"requested", batchSize, "max", MaxBatchSize)
+		batchSize = MaxBatchSize
 	}
 	return &Indexer{db: db, batchSize: batchSize}
 }
@@ -142,8 +166,7 @@ func (idx *Indexer) BatchSize() int {
 // event_id and pk_hash are omitted — they are AUTO_INCREMENT and STORED
 // generated respectively, so MySQL computes them on write.
 func (idx *Indexer) insertBatch(batch []event.Event) (int64, error) {
-	// 16 placeholders per row
-	valClause := strings.TrimRight(strings.Repeat("(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?),", len(batch)), ",")
+	valClause := strings.TrimRight(strings.Repeat(rowPlaceholders+",", len(batch)), ",")
 	insertSQL := `INSERT INTO binlog_events ` +
 		`(binlog_file, start_pos, end_pos, event_timestamp, gtid, connection_id, ` +
 		`schema_name, table_name, event_type, pk_values, ` +
@@ -167,7 +190,7 @@ func (idx *Indexer) insertBatch(batch []event.Event) (int64, error) {
 	}
 	digests := idx.digestStatements(distinct)
 
-	args := make([]any, 0, len(batch)*16)
+	args := make([]any, 0, len(batch)*insertColumnCount)
 	for i := range batch {
 		ev := &batch[i]
 

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -38,6 +38,12 @@ const DefaultWriteTimeout = 3 * time.Minute
 // a shared global).
 var WriteTimeout = DefaultWriteTimeout
 
+// insertColumnsSQL is the column list of insertBatch's multi-row INSERT.
+// insertColumnCount must equal its column count — pinned by a unit test.
+const insertColumnsSQL = `binlog_file, start_pos, end_pos, event_timestamp, gtid, connection_id, ` +
+	`schema_name, table_name, event_type, pk_values, ` +
+	`changed_columns, row_before, row_after, schema_version, query_text, query_hash`
+
 const (
 	// insertColumnCount is the number of columns (= placeholders per row) in
 	// insertBatch's multi-row INSERT.
@@ -167,10 +173,7 @@ func (idx *Indexer) BatchSize() int {
 // generated respectively, so MySQL computes them on write.
 func (idx *Indexer) insertBatch(batch []event.Event) (int64, error) {
 	valClause := strings.TrimRight(strings.Repeat(rowPlaceholders+",", len(batch)), ",")
-	insertSQL := `INSERT INTO binlog_events ` +
-		`(binlog_file, start_pos, end_pos, event_timestamp, gtid, connection_id, ` +
-		`schema_name, table_name, event_type, pk_values, ` +
-		`changed_columns, row_before, row_after, schema_version, query_text, query_hash) VALUES ` + valClause
+	insertSQL := `INSERT INTO binlog_events (` + insertColumnsSQL + `) VALUES ` + valClause
 
 	// Sanitize each event's captured statement text, then resolve the batch's
 	// DISTINCT texts to STATEMENT_DIGEST hashes in one round trip (#699).

--- a/internal/indexer/indexer_integration_test.go
+++ b/internal/indexer/indexer_integration_test.go
@@ -207,3 +207,30 @@ func TestInsertBatch_oversizedPKValues(t *testing.T) {
 		t.Errorf("expected no rows inserted (whole batch aborted before INSERT), got %d", n)
 	}
 }
+
+func TestInsertBatch_maxBatchSize(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	idx := New(db, MaxBatchSize)
+	ts := time.Date(2026, 2, 19, 12, 0, 0, 0, time.UTC)
+	batch := make([]parser.Event, MaxBatchSize)
+	for i := range batch {
+		batch[i] = parser.Event{
+			BinlogFile: "binlog.000001", StartPos: uint64(i * 100), EndPos: uint64((i + 1) * 100),
+			Timestamp: ts, Schema: "mydb", Table: "orders",
+			EventType: parser.EventInsert, PKValues: string(rune('0' + i%10)),
+			RowAfter: map[string]any{"id": float64(i)},
+		}
+	}
+
+	// The largest allowed batch must fit MySQL's 65535 prepared-statement
+	// placeholder cap in one multi-row INSERT (#956).
+	count, err := idx.InsertBatch(batch)
+	if err != nil {
+		t.Fatalf("InsertBatch at MaxBatchSize (%d rows) failed: %v", MaxBatchSize, err)
+	}
+	if count != int64(MaxBatchSize) {
+		t.Errorf("expected %d rows inserted, got %d", MaxBatchSize, count)
+	}
+}

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -46,6 +46,9 @@ func TestNew_maxBatchSizeAccepted(t *testing.T) {
 }
 
 func TestMaxBatchSize_derivedFromPlaceholders(t *testing.T) {
+	if got := strings.Count(insertColumnsSQL, ",") + 1; got != insertColumnCount {
+		t.Errorf("insertColumnsSQL lists %d columns, want insertColumnCount=%d — bump the constant when adding a column", got, insertColumnCount)
+	}
 	if got := strings.Count(rowPlaceholders, "?"); got != insertColumnCount {
 		t.Errorf("rowPlaceholders has %d placeholders, want insertColumnCount=%d", got, insertColumnCount)
 	}

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -31,6 +31,33 @@ func TestNew_customBatchSize(t *testing.T) {
 	}
 }
 
+func TestNew_clampsBatchSizeOverMax(t *testing.T) {
+	idx := New(nil, MaxBatchSize+1)
+	if idx.batchSize != MaxBatchSize {
+		t.Errorf("expected batchSize clamped to %d, got %d", MaxBatchSize, idx.batchSize)
+	}
+}
+
+func TestNew_maxBatchSizeAccepted(t *testing.T) {
+	idx := New(nil, MaxBatchSize)
+	if idx.batchSize != MaxBatchSize {
+		t.Errorf("expected batchSize %d kept as-is, got %d", MaxBatchSize, idx.batchSize)
+	}
+}
+
+func TestMaxBatchSize_derivedFromPlaceholders(t *testing.T) {
+	if got := strings.Count(rowPlaceholders, "?"); got != insertColumnCount {
+		t.Errorf("rowPlaceholders has %d placeholders, want insertColumnCount=%d", got, insertColumnCount)
+	}
+	if MaxBatchSize*insertColumnCount > maxPreparedStmtParams {
+		t.Errorf("MaxBatchSize %d x %d columns exceeds the %d placeholder cap",
+			MaxBatchSize, insertColumnCount, maxPreparedStmtParams)
+	}
+	if (MaxBatchSize+1)*insertColumnCount <= maxPreparedStmtParams {
+		t.Errorf("MaxBatchSize %d is not tight against the %d placeholder cap", MaxBatchSize, maxPreparedStmtParams)
+	}
+}
+
 // ─── marshalRow ──────────────────────────────────────────────────────────────
 
 func TestMarshalRow_nil(t *testing.T) {


### PR DESCRIPTION
closes #956

## Summary
- `--batch-size >= 4096` broke every batch INSERT with cryptic Error 1390: 16 placeholders/row × 4096 rows exceeds MySQL's 65535 prepared-statement parameter cap, crash-looping the daemon under `watch`.
- `indexer.New` now clamps oversized batch sizes to `MaxBatchSize` (65535/16 = 4095) and logs a startup warning — a daemon with `BINTRAIL_BATCH_SIZE=5000` keeps running instead of crash-looping.
- The cap and the per-row `(?,...,?)` tuple both derive from a single `insertColumnCount` constant, so adding a column to the INSERT automatically lowers the limit instead of silently re-breaking large batches.
- Single choke point: all three insert paths (`bintrail index`/`stream`/`up`, `bintrail-console watch`, `bintrail-pg stream`) construct their Indexer via `indexer.New`.

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] New tests: clamp above `MaxBatchSize`, exact `MaxBatchSize` accepted, cap tight against 65535 and consistent with the placeholder tuple

🤖 Generated with [Claude Code](https://claude.com/claude-code)