### PR TITLE
metadata: dedupe corrupt snapshots with duplicated column rows instead of halting capture

### DIFF
--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -230,17 +230,20 @@ func scanSnapshotRows(rows *sql.Rows, tables map[string]*TableMeta) (snapshotSca
 		}
 		// Duplicate (schema, table, ordinal_position) rows within one snapshot:
 		// pre-#844 concurrent snapshot writers could share a snapshot_id and
-		// double-insert every column. Loading them verbatim inflates the column
-		// count, and the #700 drift guard then skips 100% of row events until
-		// an operator re-snapshots (#1033). Rows arrive ordered by ordinal, so
-		// duplicates are adjacent to the last kept column.
+		// re-insert every column (doubled or worse). Loading them verbatim
+		// inflates the column count, and the parser's column-count guard then
+		// skips every row event for the table ("column count mismatch") until
+		// an operator re-snapshots (#1033). Rows arrive ordered by ordinal
+		// (both callers' SELECTs ORDER BY ends with ordinal_position — any new
+		// caller must preserve that), so duplicates are adjacent to the last
+		// kept column.
 		if n := len(tm.Columns); n > 0 && tm.Columns[n-1].OrdinalPosition == ordinalPosition {
 			if tm.Columns[n-1] == col {
 				dupRows[key]++
 				continue
 			}
-			return stats, fmt.Errorf("snapshot is corrupt: %s has two different columns at ordinal_position %d (%q vs %q) — re-run `bintrail snapshot` to write a clean snapshot",
-				key, ordinalPosition, tm.Columns[n-1].Name, columnName)
+			return stats, fmt.Errorf("snapshot is corrupt: %s has two different columns at ordinal_position %d (%q %s vs %q %s) — re-run `bintrail snapshot` to write a clean snapshot; if the table no longer exists at the source, delete that snapshot's rows from schema_snapshots instead",
+				key, ordinalPosition, tm.Columns[n-1].Name, tm.Columns[n-1].ColumnType, columnName, columnType)
 		}
 
 		if columnType != "" {
@@ -280,7 +283,7 @@ func scanSnapshotRows(rows *sql.Rows, tables map[string]*TableMeta) (snapshotSca
 		if len(names) > nameCap {
 			names = names[:nameCap]
 		}
-		slog.Warn("snapshot contains duplicated column rows (pre-#844 concurrent snapshot writers); "+
+		slog.Warn("snapshot contains duplicated column rows (typically pre-#844 concurrent snapshot writers); "+
 			"loaded deduplicated — re-run `bintrail snapshot` to write a clean snapshot",
 			"duplicate_rows", total,
 			"table_count", len(dupRows),

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -200,6 +200,7 @@ func scanSnapshotRows(rows *sql.Rows, tables map[string]*TableMeta) (snapshotSca
 	var stats snapshotScanStats
 	tableSawColumnType := make(map[string]bool)
 	tableSawDataType := make(map[string]bool)
+	dupRows := make(map[string]int) // "schema.table" → identical duplicate rows dropped
 
 	for rows.Next() {
 		var schemaName, tableName, columnName, columnKey, dataType, columnType, characterSet string
@@ -227,6 +228,21 @@ func scanSnapshotRows(rows *sql.Rows, tables map[string]*TableMeta) (snapshotSca
 			IsIdentityAlways: isIdentityAlways,
 			CharacterSet:     characterSet,
 		}
+		// Duplicate (schema, table, ordinal_position) rows within one snapshot:
+		// pre-#844 concurrent snapshot writers could share a snapshot_id and
+		// double-insert every column. Loading them verbatim inflates the column
+		// count, and the #700 drift guard then skips 100% of row events until
+		// an operator re-snapshots (#1033). Rows arrive ordered by ordinal, so
+		// duplicates are adjacent to the last kept column.
+		if n := len(tm.Columns); n > 0 && tm.Columns[n-1].OrdinalPosition == ordinalPosition {
+			if tm.Columns[n-1] == col {
+				dupRows[key]++
+				continue
+			}
+			return stats, fmt.Errorf("snapshot is corrupt: %s has two different columns at ordinal_position %d (%q vs %q) — re-run `bintrail snapshot` to write a clean snapshot",
+				key, ordinalPosition, tm.Columns[n-1].Name, columnName)
+		}
+
 		if columnType != "" {
 			stats.sawColumnType = true
 			tableSawColumnType[key] = true
@@ -251,6 +267,25 @@ func scanSnapshotRows(rows *sql.Rows, tables map[string]*TableMeta) (snapshotSca
 		}
 	}
 	sort.Strings(stats.pre212Tables)
+
+	if len(dupRows) > 0 {
+		names := make([]string, 0, len(dupRows))
+		total := 0
+		for k, n := range dupRows {
+			names = append(names, k)
+			total += n
+		}
+		sort.Strings(names)
+		const nameCap = 20
+		if len(names) > nameCap {
+			names = names[:nameCap]
+		}
+		slog.Warn("snapshot contains duplicated column rows (pre-#844 concurrent snapshot writers); "+
+			"loaded deduplicated — re-run `bintrail snapshot` to write a clean snapshot",
+			"duplicate_rows", total,
+			"table_count", len(dupRows),
+			"tables", strings.Join(names, ", "))
+	}
 
 	return stats, nil
 }

--- a/internal/metadata/metadata_integration_test.go
+++ b/internal/metadata/metadata_integration_test.go
@@ -1108,3 +1108,74 @@ func TestTakeSnapshot_concurrentAllocatorSerialized(t *testing.T) {
 		}
 	}
 }
+
+// ─── #1033: corrupt snapshot with duplicated column rows ─────────────────────
+
+func TestNewResolver_dedupesDuplicatedSnapshotRows(t *testing.T) {
+	indexDB, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, indexDB)
+
+	// Pre-#844 concurrent writers sharing one snapshot_id: every column
+	// double-inserted. The resolver must report the real column count, or the
+	// #700 guard skips 100% of row events (#1033).
+	for range 2 {
+		testutil.InsertSnapshot(t, indexDB, 12, "2026-07-04 15:02:39", "mydb", "wp_options", "option_id", 1, "PRI", "bigint", "NO")
+		testutil.InsertSnapshot(t, indexDB, 12, "2026-07-04 15:02:39", "mydb", "wp_options", "option_name", 2, "", "varchar", "NO")
+		testutil.InsertSnapshot(t, indexDB, 12, "2026-07-04 15:02:39", "mydb", "wp_options", "option_value", 3, "", "longtext", "NO")
+		testutil.InsertSnapshot(t, indexDB, 12, "2026-07-04 15:02:39", "mydb", "wp_options", "autoload", 4, "", "varchar", "NO")
+	}
+
+	resolver, err := NewResolver(indexDB, 0)
+	if err != nil {
+		t.Fatalf("NewResolver failed: %v", err)
+	}
+	tm, err := resolver.Resolve("mydb", "wp_options")
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+	if len(tm.Columns) != 4 {
+		t.Errorf("expected 4 deduplicated columns, got %d", len(tm.Columns))
+	}
+	if len(tm.PKColumns) != 1 {
+		t.Errorf("expected 1 PK column, got %v", tm.PKColumns)
+	}
+}
+
+func TestNewLatestPerTableResolver_dedupesDuplicatedSnapshotRows(t *testing.T) {
+	indexDB, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, indexDB)
+
+	for range 2 {
+		testutil.InsertSnapshot(t, indexDB, 12, "2026-07-04 15:02:39", "mydb", "wp_options", "option_id", 1, "PRI", "bigint", "NO")
+		testutil.InsertSnapshot(t, indexDB, 12, "2026-07-04 15:02:39", "mydb", "wp_options", "option_name", 2, "", "varchar", "NO")
+	}
+
+	resolver, err := NewLatestPerTableResolver(indexDB)
+	if err != nil {
+		t.Fatalf("NewLatestPerTableResolver failed: %v", err)
+	}
+	tm, err := resolver.Resolve("mydb", "wp_options")
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+	if len(tm.Columns) != 2 {
+		t.Errorf("expected 2 deduplicated columns, got %d", len(tm.Columns))
+	}
+}
+
+func TestNewResolver_conflictingDuplicateRowsFailLoudIntegration(t *testing.T) {
+	indexDB, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, indexDB)
+
+	testutil.InsertSnapshot(t, indexDB, 12, "2026-07-04 15:02:39", "mydb", "orders", "id", 1, "PRI", "int", "NO")
+	testutil.InsertSnapshot(t, indexDB, 12, "2026-07-04 15:02:39", "mydb", "orders", "name", 2, "", "varchar", "NO")
+	testutil.InsertSnapshot(t, indexDB, 12, "2026-07-04 15:02:39", "mydb", "orders", "renamed", 2, "", "varchar", "NO")
+
+	_, err := NewResolver(indexDB, 0)
+	if err == nil {
+		t.Fatal("expected error for conflicting duplicate ordinal rows, got nil")
+	}
+	if !strings.Contains(err.Error(), "corrupt") {
+		t.Errorf("error should say the snapshot is corrupt, got: %v", err)
+	}
+}

--- a/internal/metadata/metadata_integration_test.go
+++ b/internal/metadata/metadata_integration_test.go
@@ -1117,7 +1117,7 @@ func TestNewResolver_dedupesDuplicatedSnapshotRows(t *testing.T) {
 
 	// Pre-#844 concurrent writers sharing one snapshot_id: every column
 	// double-inserted. The resolver must report the real column count, or the
-	// #700 guard skips 100% of row events (#1033).
+	// parser's column-count guard skips 100% of row events (#1033).
 	for range 2 {
 		testutil.InsertSnapshot(t, indexDB, 12, "2026-07-04 15:02:39", "mydb", "wp_options", "option_id", 1, "PRI", "bigint", "NO")
 		testutil.InsertSnapshot(t, indexDB, 12, "2026-07-04 15:02:39", "mydb", "wp_options", "option_name", 2, "", "varchar", "NO")

--- a/internal/metadata/metadata_test.go
+++ b/internal/metadata/metadata_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 )
@@ -586,5 +587,79 @@ func TestHasReplPrivileges(t *testing.T) {
 				t.Errorf("client = %v, want %v", gotClient, tt.wantClient)
 			}
 		})
+	}
+}
+
+// ─── #1033: corrupt snapshot with duplicated column rows ─────────────────────
+
+// snapshotCols is the column set of NewResolver's schema_snapshots SELECT.
+var snapshotCols = []string{
+	"schema_name", "table_name", "column_name", "ordinal_position",
+	"column_key", "data_type", "column_type",
+	"is_generated", "is_identity_always", "character_set_name",
+}
+
+func TestNewResolver_dedupesIdenticalDuplicateRows(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	// Pre-#844 concurrent writers: every column double-inserted verbatim.
+	rows := sqlmock.NewRows(snapshotCols)
+	for range 2 {
+		rows.AddRow("mydb", "wp_options", "option_id", 1, "PRI", "bigint", "bigint unsigned", false, false, "")
+	}
+	for range 2 {
+		rows.AddRow("mydb", "wp_options", "option_name", 2, "", "varchar", "varchar(191)", false, false, "utf8mb4")
+	}
+	for range 2 {
+		rows.AddRow("mydb", "wp_options", "option_value", 3, "", "longtext", "longtext", false, false, "utf8mb4")
+	}
+	for range 2 {
+		rows.AddRow("mydb", "wp_options", "autoload", 4, "", "varchar", "varchar(20)", false, false, "utf8mb4")
+	}
+	mock.ExpectQuery("SELECT schema_name, table_name").WithArgs(12).WillReturnRows(rows)
+	mock.ExpectQuery(`SELECT MIN\(snapshot_time\)`).WithArgs(12).
+		WillReturnRows(sqlmock.NewRows([]string{"MIN(snapshot_time)"}).AddRow(time.Date(2026, 7, 4, 15, 2, 39, 0, time.UTC)))
+
+	r, err := NewResolver(db, 12)
+	if err != nil {
+		t.Fatalf("NewResolver failed: %v", err)
+	}
+	tm, err := r.Resolve("mydb", "wp_options")
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+	if len(tm.Columns) != 4 {
+		t.Errorf("expected 4 deduplicated columns, got %d", len(tm.Columns))
+	}
+	if len(tm.PKColumns) != 1 || tm.PKColumns[0] != "option_id" {
+		t.Errorf("expected PKColumns [option_id], got %v", tm.PKColumns)
+	}
+}
+
+func TestNewResolver_conflictingDuplicateRowsFailLoud(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	rows := sqlmock.NewRows(snapshotCols).
+		AddRow("mydb", "orders", "id", 1, "PRI", "int", "int", false, false, "").
+		AddRow("mydb", "orders", "name", 2, "", "varchar", "varchar(50)", false, false, "utf8mb4").
+		AddRow("mydb", "orders", "renamed", 2, "", "varchar", "varchar(50)", false, false, "utf8mb4")
+	mock.ExpectQuery("SELECT schema_name, table_name").WithArgs(13).WillReturnRows(rows)
+	mock.ExpectQuery(`SELECT MIN\(snapshot_time\)`).WithArgs(13).
+		WillReturnRows(sqlmock.NewRows([]string{"MIN(snapshot_time)"}).AddRow(time.Date(2026, 7, 4, 15, 2, 39, 0, time.UTC)))
+
+	_, err = NewResolver(db, 13)
+	if err == nil {
+		t.Fatal("expected error for conflicting duplicate ordinal rows, got nil")
+	}
+	if !strings.Contains(err.Error(), "corrupt") || !strings.Contains(err.Error(), "mydb.orders") {
+		t.Errorf("error should name the corruption and table, got: %v", err)
 	}
 }

--- a/internal/metadata/metadata_test.go
+++ b/internal/metadata/metadata_test.go
@@ -663,3 +663,31 @@ func TestNewResolver_conflictingDuplicateRowsFailLoud(t *testing.T) {
 		t.Errorf("error should name the corruption and table, got: %v", err)
 	}
 }
+
+func TestNewResolver_sameNameDifferentTypeDuplicateFailsLoud(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	// The realistic pre-#844 conflict: two writers straddling a DDL capture
+	// the SAME column name at the same ordinal with different type metadata.
+	// Pins the full-struct comparison — a name-only dedupe would silently
+	// load the wrong signedness/charset.
+	rows := sqlmock.NewRows(snapshotCols).
+		AddRow("mydb", "orders", "id", 1, "PRI", "int", "int", false, false, "").
+		AddRow("mydb", "orders", "qty", 2, "", "int", "int", false, false, "").
+		AddRow("mydb", "orders", "qty", 2, "", "int", "int unsigned", false, false, "")
+	mock.ExpectQuery("SELECT schema_name, table_name").WithArgs(14).WillReturnRows(rows)
+	mock.ExpectQuery(`SELECT MIN\(snapshot_time\)`).WithArgs(14).
+		WillReturnRows(sqlmock.NewRows([]string{"MIN(snapshot_time)"}).AddRow(time.Date(2026, 7, 4, 15, 2, 39, 0, time.UTC)))
+
+	_, err = NewResolver(db, 14)
+	if err == nil {
+		t.Fatal("expected error for same-name different-type duplicate, got nil")
+	}
+	if !strings.Contains(err.Error(), "corrupt") || !strings.Contains(err.Error(), "int unsigned") {
+		t.Errorf("error should name the corruption and the diverging column types, got: %v", err)
+	}
+}


### PR DESCRIPTION
closes #1033

## Summary
- A pre-#844 index can carry a corrupt snapshot: concurrent snapshot writers shared a `snapshot_id` and double-inserted every column. The resolver loaded the duplicated rows verbatim, reported 2× the real column count, and the #700 drift guard then skipped **100% of row events indefinitely** (observed: ~2 days, ~85 MB of binlog read and discarded).
- `scanSnapshotRows` — the loader shared by `NewResolver` (stream/index paths) and `NewLatestPerTableResolver` (shim/console) — now detects duplicate `(schema, table, ordinal_position)` rows. Rows arrive ordered by ordinal, so the check is a single comparison against the last kept column.
- **Identical duplicates** (the observed pre-#844 double-insert): deduplicated, capture proceeds with the real column count; one `WARN` names the affected tables and suggests re-running `bintrail snapshot`.
- **Conflicting duplicates** (same ordinal, different definition): fail loud naming table, ordinal and both column names — an inflated/ambiguous table definition is never loaded.
- No signature changes, no new flags; the optional `--repair` path from the issue is unnecessary for the observed corruption since the resolver now loads it correctly.

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] Unit (sqlmock): identical dups → 4 columns + single PK; conflicting dups → loud error naming the table
- [x] Integration (real MySQL 8.0): reproduces the issue's scenario via duplicated `schema_snapshots` rows for both resolvers, plus the conflicting-dup failure path

🤖 Generated with [Claude Code](https://claude.com/claude-code)