### PR TITLE
ci: guard the MySQL integration matrix against green-via-skip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,10 +153,33 @@ jobs:
             --log-bin=binlog \
             --server-id=1
           echo "Waiting for MySQL to accept connections..."
+          # Probe over the SAME path the tests use — host TCP 127.0.0.1:13306
+          # with full auth and a real query — NOT `docker exec ... mysqladmin
+          # ping`, which answers over the container's local socket. The
+          # official mysql image runs a TEMPORARY mysqld during first-init
+          # (to create the root user / run init scripts), then shuts it down
+          # and starts the real one; a socket-local ping can succeed against
+          # that temporary server and exit this loop while the real server on
+          # the mapped host port is still starting or mid-restart — the
+          # readiness race behind #949's `integration (8.0)` failure
+          # (TestEndToEnd_fullPipeline: "unexpected EOF" / "invalid
+          # connection" dialing 127.0.0.1:13306). Requiring THREE consecutive
+          # successful probes (not just one) rules out a probe that landed on
+          # the temporary server moments before the restart. The probe runs
+          # from a short-lived container on the SAME image tag as the server
+          # so it doesn't depend on whatever mysql client (if any) happens to
+          # be preinstalled on the runner.
+          consecutive=0
           for i in $(seq 1 60); do
-            if docker exec bintrail-test-mysql mysqladmin ping -u root -ptestroot --silent 2>/dev/null; then
-              echo "MySQL is ready."
-              exit 0
+            if docker run --rm --network host "mysql:${{ matrix.mysql }}" \
+                 mysql --protocol=TCP -h 127.0.0.1 -P 13306 -u root -ptestroot -e "SELECT 1" >/dev/null 2>&1; then
+              consecutive=$((consecutive + 1))
+              if [ "$consecutive" -ge 3 ]; then
+                echo "MySQL is ready (3 consecutive successful probes)."
+                exit 0
+              fi
+            else
+              consecutive=0
             fi
             sleep 2
           done
@@ -223,9 +246,17 @@ jobs:
             -p 13306:3306 \
             mysql:8.4 \
             --binlog-format=ROW --binlog-row-image=FULL --log-bin=binlog --server-id=1
+          # See the "integration" job's MySQL-start step for why this probes
+          # host TCP with full auth + a real query, requiring 3 consecutive
+          # successes, instead of `docker exec ... mysqladmin ping` (#949).
+          consecutive=0
           for i in $(seq 1 60); do
-            if docker exec bintrail-test-mysql mysqladmin ping -u root -ptestroot --silent 2>/dev/null; then
-              echo "MySQL index is ready."; exit 0
+            if docker run --rm --network host mysql:8.4 \
+                 mysql --protocol=TCP -h 127.0.0.1 -P 13306 -u root -ptestroot -e "SELECT 1" >/dev/null 2>&1; then
+              consecutive=$((consecutive + 1))
+              [ "$consecutive" -ge 3 ] && { echo "MySQL index is ready."; exit 0; }
+            else
+              consecutive=0
             fi
             sleep 2
           done
@@ -241,9 +272,17 @@ jobs:
             mariadb:11.4 \
             --log-bin=mariadb-bin --binlog-format=ROW --binlog-row-image=FULL \
             --server-id=2 --gtid-strict-mode=ON
+          # Same socket-vs-TCP readiness race as the MySQL-start steps (#949):
+          # probe host TCP with full auth + a real query, 3 consecutive
+          # successes, instead of `docker exec ... mariadb-admin ping`.
+          consecutive=0
           for i in $(seq 1 60); do
-            if docker exec bintrail-test-mariadb mariadb-admin ping -u root -ptestroot --silent 2>/dev/null; then
-              echo "MariaDB source is ready."; exit 0
+            if docker run --rm --network host mariadb:11.4 \
+                 mariadb --protocol=TCP -h 127.0.0.1 -P 13307 -u root -ptestroot -e "SELECT 1" >/dev/null 2>&1; then
+              consecutive=$((consecutive + 1))
+              [ "$consecutive" -ge 3 ] && { echo "MariaDB source is ready."; exit 0; }
+            else
+              consecutive=0
             fi
             sleep 2
           done
@@ -308,9 +347,17 @@ jobs:
             -p 13306:3306 \
             mysql:8.4 \
             --binlog-format=ROW --binlog-row-image=FULL --log-bin=binlog --server-id=1
+          # See the "integration" job's MySQL-start step for why this probes
+          # host TCP with full auth + a real query, requiring 3 consecutive
+          # successes, instead of `docker exec ... mysqladmin ping` (#949).
+          consecutive=0
           for i in $(seq 1 60); do
-            if docker exec bintrail-test-mysql mysqladmin ping -u root -ptestroot --silent 2>/dev/null; then
-              echo "MySQL index is ready."; exit 0
+            if docker run --rm --network host mysql:8.4 \
+                 mysql --protocol=TCP -h 127.0.0.1 -P 13306 -u root -ptestroot -e "SELECT 1" >/dev/null 2>&1; then
+              consecutive=$((consecutive + 1))
+              [ "$consecutive" -ge 3 ] && { echo "MySQL index is ready."; exit 0; }
+            else
+              consecutive=0
             fi
             sleep 2
           done
@@ -394,9 +441,17 @@ jobs:
             -p 13306:3306 \
             mysql:8.4 \
             --binlog-format=ROW --binlog-row-image=FULL --log-bin=binlog --server-id=1
+          # See the "integration" job's MySQL-start step for why this probes
+          # host TCP with full auth + a real query, requiring 3 consecutive
+          # successes, instead of `docker exec ... mysqladmin ping` (#949).
+          consecutive=0
           for i in $(seq 1 60); do
-            if docker exec bintrail-test-mysql mysqladmin ping -u root -ptestroot --silent 2>/dev/null; then
-              echo "MySQL is ready."; exit 0
+            if docker run --rm --network host mysql:8.4 \
+                 mysql --protocol=TCP -h 127.0.0.1 -P 13306 -u root -ptestroot -e "SELECT 1" >/dev/null 2>&1; then
+              consecutive=$((consecutive + 1))
+              [ "$consecutive" -ge 3 ] && { echo "MySQL is ready."; exit 0; }
+            else
+              consecutive=0
             fi
             sleep 2
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,12 @@ jobs:
       # Matches internal/testutil.DefaultDSN — set explicitly to mirror the
       # SaaS repo's `agent/` job and make the wiring obvious in logs.
       BINTRAIL_TEST_DSN: "root:testroot@tcp(127.0.0.1:13306)"
+      # A MySQL server is guaranteed present in this job (started below), so
+      # SkipIfNoMySQL must FAIL (not silently skip) on a dial/ping failure —
+      # otherwise a DSN or build-tag drift would exit 0 green with ZERO
+      # coverage of the flagship capture->index->query->recover pipeline.
+      # Mirrors BINTRAIL_REQUIRE_MARIADB / BINTRAIL_REQUIRE_POSTGRES (#949).
+      BINTRAIL_REQUIRE_MYSQL: "1"
 
     steps:
       # Step-level (not job-level) `if:` — see the note on the `changes` job.
@@ -163,9 +169,23 @@ jobs:
       # lets one package's DDL/DML leak into another's binlog window (the binlog
       # parser tests assert exact event counts). Serializing keeps each package
       # the sole writer during its run.
+      #
+      # BINTRAIL_REQUIRE_MYSQL=1 (above) only catches a dial/ping failure INSIDE
+      # a test that actually runs — a build-tag or path drift that silently
+      # dropped the integration tests from this run would still exit 0 green
+      # with ZERO MySQL coverage. Close that false-green the same way the
+      # PostgreSQL-source job does: assert the flagship end-to-end and
+      # caching_sha2 auth-seam tests genuinely ran, not merely that `go test`
+      # exited 0. pipefail keeps the go-test exit code through the tee.
       - name: Integration tests (-tags=integration)
         if: github.event_name == 'push' || needs.changes.outputs.go == 'true'
-        run: go test -tags=integration -race -p 1 -count=1 ./...
+        run: |
+          set -o pipefail
+          go test -tags=integration -race -p 1 -count=1 -v ./... 2>&1 | tee /tmp/mysql-it.out
+          grep -q -- '--- PASS: TestEndToEnd_fullPipeline' /tmp/mysql-it.out \
+            || { echo "FATAL: MySQL end-to-end integration test did not run — false-green tripwire" >&2; exit 1; }
+          grep -q -- '--- PASS: TestCachingSha2ColdAuthSeam' /tmp/mysql-it.out \
+            || { echo "FATAL: caching_sha2 cold-auth seam test did not run — false-green tripwire" >&2; exit 1; }
 
   integration-mariadb-source:
     # MariaDB-as-source alpha. A MariaDB-source test pairs a NEW MariaDB SOURCE

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,8 +112,21 @@ docker run -d --name bintrail-test-mysql \
   --log-bin=binlog \
   --server-id=1
 
-# Wait for MySQL to be ready
-until docker exec bintrail-test-mysql mysqladmin ping -u root -ptestroot --silent; do sleep 1; done
+# Wait for MySQL to be ready. Probe host TCP (the same path the tests use),
+# not `docker exec ... mysqladmin ping` — that answers over the container's
+# local socket, which can succeed against the mysql image's TEMPORARY
+# first-init server before the real one is listening on the mapped port
+# (see .github/workflows/ci.yml's MySQL-start steps and issue #949).
+consecutive=0
+until [ "$consecutive" -ge 3 ]; do
+  if docker run --rm --network host mysql:8.0 \
+       mysql --protocol=TCP -h 127.0.0.1 -P 13306 -u root -ptestroot -e "SELECT 1" >/dev/null 2>&1; then
+    consecutive=$((consecutive + 1))
+  else
+    consecutive=0
+  fi
+  sleep 1
+done
 
 # Initialise the index
 bintrail init --index-dsn "root:testroot@tcp(127.0.0.1:13306)/binlog_index"

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -37,18 +37,44 @@ func IntegrationDSN(dbName string) string {
 	return BaseDSN() + "/" + dbName + "?parseTime=true"
 }
 
-// SkipIfNoMySQL pings the MySQL server and calls t.Skip if unreachable.
-// This provides graceful degradation when no Docker container is running.
+// MySQLRequired reports whether MySQL integration tests must RUN (and fail
+// rather than skip) when the server is unreachable. The dedicated 8.0/8.4
+// integration matrix jobs set BINTRAIL_REQUIRE_MYSQL=1, where a MySQL server
+// is guaranteed present — so a silent skip there would be a false green that
+// hides a real regression in the flagship capture->index->query->recover
+// pipeline. Unset on developer machines, where graceful skipping is right.
+// Mirrors MariaDBRequired / PostgresRequired.
+func MySQLRequired() bool {
+	return os.Getenv("BINTRAIL_REQUIRE_MYSQL") == "1"
+}
+
+// SkipIfNoMySQL pings the MySQL server and calls t.Skip if unreachable, or
+// t.Fatal when MySQLRequired() — so a dial/ping failure never silently
+// passes as green in the CI job that guarantees a live MySQL server. This
+// provides graceful degradation when no Docker container is running.
 func SkipIfNoMySQL(t *testing.T) {
 	t.Helper()
 	db, err := sql.Open("mysql", BaseDSN()+"/?parseTime=true")
 	if err != nil {
-		t.Skipf("skipping: cannot open MySQL connection: %v", err)
+		skipOrFailMySQL(t, "cannot open MySQL connection: %v", err)
+		return
 	}
 	defer db.Close()
 	if err := db.Ping(); err != nil {
-		t.Skipf("skipping: MySQL not reachable: %v", err)
+		skipOrFailMySQL(t, "MySQL not reachable: %v", err)
 	}
+}
+
+// skipOrFailMySQL fails the test when MySQLRequired(), otherwise skips it.
+// Scoped to connectivity failures only (dial/ping) — callers must not use
+// this for other skip reasons (e.g. a version-gated feature), which must
+// stay t.Skip regardless of MySQLRequired().
+func skipOrFailMySQL(t *testing.T, format string, args ...any) {
+	t.Helper()
+	if MySQLRequired() {
+		t.Fatalf(format+" (BINTRAIL_REQUIRE_MYSQL=1 — the integration matrix job must provide a live MySQL server)", args...)
+	}
+	t.Skipf("skipping: "+format, args...)
 }
 
 // CreateTestDB creates a unique database for the calling test, returning

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -1,0 +1,36 @@
+package testutil
+
+import "testing"
+
+// TestMySQLRequired verifies the BINTRAIL_REQUIRE_MYSQL env-var gate mirrors
+// MariaDBRequired / PostgresRequired. This is the switch that turns a MySQL
+// connectivity failure in SkipIfNoMySQL from a silent t.Skip into a t.Fatal
+// (issue #949 — no green-via-skip on the flagship MySQL integration job).
+//
+// The actual t.Fatalf/t.Skipf call in skipOrFailMySQL is not exercised here:
+// a failing subtest propagates Fail() up to its parent (by the testing
+// package's own design), so simulating the "required" branch via t.Run would
+// make this test intentionally — and misleadingly — report FAIL. Neither the
+// MariaDB nor Postgres sibling guards test that call path either.
+func TestMySQLRequired(t *testing.T) {
+	t.Run("unset", func(t *testing.T) {
+		t.Setenv("BINTRAIL_REQUIRE_MYSQL", "")
+		if MySQLRequired() {
+			t.Fatal("expected MySQLRequired() to be false when BINTRAIL_REQUIRE_MYSQL is unset")
+		}
+	})
+
+	t.Run("set", func(t *testing.T) {
+		t.Setenv("BINTRAIL_REQUIRE_MYSQL", "1")
+		if !MySQLRequired() {
+			t.Fatal("expected MySQLRequired() to be true when BINTRAIL_REQUIRE_MYSQL=1")
+		}
+	})
+
+	t.Run("other_value_not_required", func(t *testing.T) {
+		t.Setenv("BINTRAIL_REQUIRE_MYSQL", "true")
+		if MySQLRequired() {
+			t.Fatal("expected MySQLRequired() to be false for any value other than \"1\" (matches MariaDBRequired/PostgresRequired's exact-match semantics)")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

`SkipIfNoMySQL` (`internal/testutil/testutil.go`) unconditionally `t.Skipf`'d on any dial/ping failure. If the DSN or build tags ever drifted, the flagship MySQL 8.0/8.4 integration job would exit 0 green with zero coverage of the capture→index→query→recover pipeline — the exact class of gap that `BINTRAIL_REQUIRE_MARIADB` (MariaDB) and `BINTRAIL_REQUIRE_POSTGRES` (Postgres) already guard against.

## Changes

- `internal/testutil/testutil.go`: added `MySQLRequired()` (reads `BINTRAIL_REQUIRE_MYSQL=1`), mirroring `MariaDBRequired`/`PostgresRequired`. `SkipIfNoMySQL` now routes dial/ping failures through a new `skipOrFailMySQL` helper — `t.Fatalf` when required, `t.Skipf` otherwise. This is scoped strictly to the connectivity path so a legitimate, unrelated skip elsewhere is never turned into a false failure.
- `.github/workflows/ci.yml`: set `BINTRAIL_REQUIRE_MYSQL: "1"` in the `integration` job's env (the 8.0/8.4 matrix, where a MySQL server is guaranteed present). Also added the same `--- PASS` tripwire the PostgreSQL-source job already uses (`grep '--- PASS: TestOne_EndToEnd_...'`) — asserting `TestEndToEnd_fullPipeline` and `TestCachingSha2ColdAuthSeam` genuinely ran, since `BINTRAIL_REQUIRE_MYSQL` alone only catches a failure *inside* a test that executes, not a build-tag/path drift that silently drops the integration tests from the run entirely.
- `internal/testutil/testutil_test.go` (new): `TestMySQLRequired` covers the env-var gate (unset / `"1"` / any other value). The actual `t.Fatalf` vs `t.Skipf` branch inside `skipOrFailMySQL` isn't unit-tested directly — a failing `t.Run` subtest propagates `Fail()` up to its parent by the `testing` package's own design, so simulating the "required" branch there would make the test intentionally (and misleadingly) report FAIL. Neither the MariaDB nor Postgres sibling guards test that call path either.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go vet -tags integration ./...` — clean
- `go test -race ./internal/testutil/... -count=1` — pass
- `go test ./... -count=1` — full unit suite pass
- `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/ci.yml'))"` — parses clean

Did **not** run the live Docker-MySQL integration suite (needs a container on port 13306, not available in this environment) — the workflow YAML and Go changes were verified statically as above.

## Update: the guard immediately proved itself

Once this PR's `BINTRAIL_REQUIRE_MYSQL=1` landed, `integration (8.0)` went **red** — for the first time ever, on a pre-existing bug:

```
=== RUN   TestEndToEnd_fullPipeline
[mysql] packets.go:58 unexpected EOF
    e2e_test.go:31: MySQL not reachable: invalid connection (BINTRAIL_REQUIRE_MYSQL=1 — the integration matrix job must provide a live MySQL server)
--- FAIL: TestEndToEnd_fullPipeline (0.00s)
```

This is exactly the "green-via-skip with ZERO coverage" failure mode #949 was filed to catch, caught on the flagship end-to-end test itself. `(8.4)` happened to pass — timing luck, not a real difference between the two cells, as the root cause below shows.

**Root cause**: every "Start MySQL/MariaDB" readiness loop in `ci.yml` probed with `docker exec <container> mysqladmin ping` (or `mariadb-admin ping`), which answers over the container's *local socket*. The official `mysql` image runs a TEMPORARY `mysqld` during first-init (to create the root user / run init scripts), then shuts it down and starts the real one. The socket-local ping can succeed against that temporary server and exit the readiness loop immediately, while the real server on the mapped host port (`127.0.0.1:13306`) is still starting or mid-restart — so the test runner's later TCP dial gets `unexpected EOF` / `invalid connection`. `t.Skipf` had been silently hiding this race indefinitely; `BINTRAIL_REQUIRE_MYSQL` is what finally surfaced it.

**Fix** (same commit as this PR, not a separate one): every readiness loop now probes the SAME path the tests use — host TCP, full auth, a real query (`mysql --protocol=TCP -h 127.0.0.1 -P <port> -u root -p... -e "SELECT 1"`, run from a short-lived container on the same image tag as the server so it doesn't depend on whatever client, if any, is preinstalled on the runner) — and requires 3 CONSECUTIVE successes before declaring ready, so a probe landing on the temporary server moments before its restart can't pass. Applied to every job with this pattern: `integration` (8.0/8.4 matrix), `integration-mariadb-source` (both the MySQL-index and MariaDB-source steps), `integration-postgres-source` (MySQL-index step), and `console-e2e`. Container names/images/args are unchanged. `CONTRIBUTING.md`'s local-dev snippet was updated to match so local and CI stay identical, per that step's original stated intent.

Verified: `bash -n` on every modified `run:` block (extracted via a small Python/PyYAML script) and on the `CONTRIBUTING.md` snippet — all pass. The `mysql --protocol=TCP ... -e "SELECT 1"` command itself was smoke-tested against a real local MySQL 8.0 container and confirmed to perform a full auth handshake + real query successfully. `--network host` could not be exercised end-to-end locally (Docker Desktop for macOS virtualizes networking differently than native Linux and doesn't route `--network host` to host-mapped container ports the same way) — this is a Docker-Desktop-for-Mac-specific limitation, not expected to affect the `ubuntu-22.04` GitHub-hosted runners, which run Docker natively on Linux where `--network host` shares the host's network namespace directly. Watching the live CI run on this PR is the real confirmation.

Closes #949

🤖 Generated with [Claude Code](https://claude.com/claude-code)
