### PR TITLE
ci: gate releases on the integration matrix for the tagged ref

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,208 @@ permissions:
   id-token: write   # cosign keyless signing via OIDC
 
 jobs:
+  # --- Integration matrix, run against the TAGGED ref itself -----------------
+  #
+  # #950: release.yaml used to be gated on unit tests only (`go test ./...`,
+  # no `-tags=integration`, no service containers). The corruption/data-loss
+  # guards live in the integration suite (ci.yml), which only ran on PRs — and
+  # because merges are `--admin` squashes, the post-squash tree that actually
+  # gets tagged may never have been exercised by that matrix. These three jobs
+  # duplicate ci.yml's `integration` / `integration-mariadb-source` /
+  # `integration-postgres-source` jobs (minus the PR-only `changes`-based
+  # path-skip logic, which doesn't apply here — a release always runs the
+  # full matrix regardless of which files changed) and run on the exact commit
+  # the tag points at. The `release` job below `needs:` all three, so a red
+  # integration run blocks GoReleaser from publishing.
+  integration-mysql:
+    runs-on: ubuntu-22.04
+    # Job-level permissions override the workflow-level grant (contents:write,
+    # packages:write, id-token:write — needed only by the `release` job's
+    # publish steps). These test jobs only need read access to the tagged ref.
+    permissions:
+      contents: read
+
+    # Two supported cells: the BYO contract floor (8.0) and the bundled index
+    # engine (8.4). fail-fast: false so a regression on one version still
+    # reports the other. Mirrors ci.yml's `integration` job.
+    strategy:
+      fail-fast: false
+      matrix:
+        mysql: ["8.0", "8.4"]
+
+    env:
+      BINTRAIL_TEST_DSN: "root:testroot@tcp(127.0.0.1:13306)"
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Start MySQL (bintrail-test-mysql, ${{ matrix.mysql }})
+        run: |
+          docker run -d --name bintrail-test-mysql \
+            -e MYSQL_ROOT_PASSWORD=testroot \
+            -p 13306:3306 \
+            mysql:${{ matrix.mysql }} \
+            --binlog-format=ROW \
+            --binlog-row-image=FULL \
+            --log-bin=binlog \
+            --server-id=1
+          echo "Waiting for MySQL to accept connections..."
+          for i in $(seq 1 60); do
+            if docker exec bintrail-test-mysql mysqladmin ping -u root -ptestroot --silent 2>/dev/null; then
+              echo "MySQL is ready."
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "MySQL did not become ready in time" >&2
+          docker logs bintrail-test-mysql >&2 || true
+          exit 1
+
+      # -p 1 serializes package execution — see ci.yml's `integration` job for
+      # the full rationale (shared single binlog, exact-count assertions).
+      - name: Integration tests (-tags=integration)
+        run: go test -tags=integration -race -p 1 -count=1 ./...
+
+  integration-mariadb-source:
+    # Mirrors ci.yml's `integration-mariadb-source` job. See that job's
+    # comments for why MariaDB-as-source needs its own job (two containers,
+    # a shared-binlog-window constraint the 8.0/8.4 matrix can't absorb).
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+
+    env:
+      BINTRAIL_TEST_DSN: "root:testroot@tcp(127.0.0.1:13306)"
+      BINTRAIL_TEST_MARIADB_DSN: "root:testroot@tcp(127.0.0.1:13307)"
+      BINTRAIL_REQUIRE_MARIADB: "1"
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Start MySQL index (bintrail-test-mysql, 8.4)
+        run: |
+          docker run -d --name bintrail-test-mysql \
+            -e MYSQL_ROOT_PASSWORD=testroot \
+            -p 13306:3306 \
+            mysql:8.4 \
+            --binlog-format=ROW --binlog-row-image=FULL --log-bin=binlog --server-id=1
+          for i in $(seq 1 60); do
+            if docker exec bintrail-test-mysql mysqladmin ping -u root -ptestroot --silent 2>/dev/null; then
+              echo "MySQL index is ready."; exit 0
+            fi
+            sleep 2
+          done
+          echo "MySQL did not become ready in time" >&2
+          docker logs bintrail-test-mysql >&2 || true
+          exit 1
+
+      - name: Start MariaDB source (bintrail-test-mariadb, 11.4)
+        run: |
+          docker run -d --name bintrail-test-mariadb \
+            -e MARIADB_ROOT_PASSWORD=testroot \
+            -p 13307:3306 \
+            mariadb:11.4 \
+            --log-bin=mariadb-bin --binlog-format=ROW --binlog-row-image=FULL \
+            --server-id=2 --gtid-strict-mode=ON
+          for i in $(seq 1 60); do
+            if docker exec bintrail-test-mariadb mariadb-admin ping -u root -ptestroot --silent 2>/dev/null; then
+              echo "MariaDB source is ready."; exit 0
+            fi
+            sleep 2
+          done
+          echo "MariaDB did not become ready in time" >&2
+          docker logs bintrail-test-mariadb >&2 || true
+          exit 1
+
+      - name: MariaDB-source integration tests
+        run: go test -tags=integration -race -p 1 -count=1 -run 'MariaDB|Mariadb|mariadb|Flavor|FourColumns' ./...
+
+  integration-postgres-source:
+    # Mirrors ci.yml's `integration-postgres-source` job.
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+
+    # Spans the supported PostgreSQL range: 14 (declared minimum) through 17.
+    # fail-fast: false so a regression on one version still reports the others.
+    strategy:
+      fail-fast: false
+      matrix:
+        postgres: ["14", "15", "16", "17"]
+
+    env:
+      BINTRAIL_TEST_DSN: "root:testroot@tcp(127.0.0.1:13306)"
+      BINTRAIL_TEST_PG_DSN: "postgres://postgres:testpg@127.0.0.1:15432/pgtest?sslmode=disable"
+      BINTRAIL_REQUIRE_POSTGRES: "1"
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Start MySQL index (bintrail-test-mysql, 8.4)
+        run: |
+          docker run -d --name bintrail-test-mysql \
+            -e MYSQL_ROOT_PASSWORD=testroot \
+            -p 13306:3306 \
+            mysql:8.4 \
+            --binlog-format=ROW --binlog-row-image=FULL --log-bin=binlog --server-id=1
+          for i in $(seq 1 60); do
+            if docker exec bintrail-test-mysql mysqladmin ping -u root -ptestroot --silent 2>/dev/null; then
+              echo "MySQL index is ready."; exit 0
+            fi
+            sleep 2
+          done
+          echo "MySQL did not become ready in time" >&2
+          docker logs bintrail-test-mysql >&2 || true
+          exit 1
+
+      - name: Start PostgreSQL source (bintrail-test-postgres, ${{ matrix.postgres }})
+        run: |
+          docker run -d --name bintrail-test-postgres \
+            -e POSTGRES_PASSWORD=testpg \
+            -e POSTGRES_DB=pgtest \
+            -p 15432:5432 \
+            postgres:${{ matrix.postgres }} \
+            -c wal_level=logical -c max_replication_slots=10 -c max_wal_senders=10
+          # Probe TCP from inside the container — see ci.yml's equivalent step
+          # for why a socket-only pg_isready would false-ready during init.
+          for i in $(seq 1 60); do
+            if docker exec bintrail-test-postgres pg_isready -h 127.0.0.1 -U postgres -d pgtest --quiet 2>/dev/null; then
+              echo "PostgreSQL source is ready."; exit 0
+            fi
+            sleep 2
+          done
+          echo "PostgreSQL did not become ready in time" >&2
+          docker logs bintrail-test-postgres >&2 || true
+          exit 1
+
+      # Same false-green tripwire as ci.yml: assert the headline end-to-end
+      # tests genuinely ran, not merely that `go test` exited 0.
+      - name: PostgreSQL-source integration tests
+        run: |
+          set -o pipefail
+          go test -tags=integration -race -p 1 -count=1 -v \
+            ./internal/pgcapture/ ./internal/pgstreamrun/ ./internal/pgbaseline/ ./internal/pgshim/ 2>&1 | tee /tmp/pg-it.out
+          grep -q -- '--- PASS: TestOne_EndToEnd_PostgresToIndexToRecovery' /tmp/pg-it.out \
+            || { echo "FATAL: PG end-to-end integration test did not run — false-green tripwire" >&2; exit 1; }
+          grep -q -- '--- PASS: TestPGBaseline_Integration' /tmp/pg-it.out \
+            || { echo "FATAL: pgbaseline integration suite did not run — false-green tripwire" >&2; exit 1; }
+          grep -q -- '--- PASS: TestPGWire_PostgresSourceRoundTrip' /tmp/pg-it.out \
+            || { echo "FATAL: pgwire PostgreSQL-source E2E did not run — false-green tripwire" >&2; exit 1; }
+
   release:
+    needs: [integration-mysql, integration-mariadb-source, integration-postgres-source]
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,6 +24,23 @@ jobs:
   # full matrix regardless of which files changed) and run on the exact commit
   # the tag points at. The `release` job below `needs:` all three, so a red
   # integration run blocks GoReleaser from publishing.
+  #
+  # !!! KEEP IN SYNC WITH ci.yml !!!
+  # This is a hand-maintained COPY, not a shared definition (a workflow_call
+  # refactor was evaluated for #950 and rejected: reusable-workflow job names
+  # are reported as "<caller job> / <called job>", which would rename the
+  # `integration (8.0)` / `integration (8.4)` / etc. required-status-check
+  # contexts that branch protection on `main` currently pins by exact string —
+  # only a repo-admin settings change can accommodate that, so it was punted).
+  # Concretely: the readiness probes below MUST use host-TCP + a real query
+  # with 3 consecutive successes (NOT `docker exec ... mysqladmin/mariadb-admin
+  # ping`, which answers over the container's local socket and can return
+  # ready while the real server on the mapped host port is still starting or
+  # mid-restart during first-init — see #949, commit 95bd02e, and the matching
+  # comments in ci.yml's `integration` / `integration-mariadb-source` /
+  # `integration-postgres-source` jobs for the full story). If ci.yml's
+  # integration jobs change (readiness probes, env guards, tripwire test
+  # names, matrix versions), port the change here too.
   integration-mysql:
     runs-on: ubuntu-22.04
     # Job-level permissions override the workflow-level grant (contents:write,
@@ -42,6 +59,10 @@ jobs:
 
     env:
       BINTRAIL_TEST_DSN: "root:testroot@tcp(127.0.0.1:13306)"
+      # A MySQL server is guaranteed present in this job, so a dial/ping
+      # failure must FAIL the run, not silently skip (#949). Mirrors
+      # BINTRAIL_REQUIRE_MARIADB / BINTRAIL_REQUIRE_POSTGRES below.
+      BINTRAIL_REQUIRE_MYSQL: "1"
 
     steps:
       - uses: actions/checkout@v5
@@ -61,10 +82,20 @@ jobs:
             --log-bin=binlog \
             --server-id=1
           echo "Waiting for MySQL to accept connections..."
+          # Host-TCP probe with a real query, 3 consecutive successes — NOT
+          # `docker exec ... mysqladmin ping` (socket-local; can false-ready
+          # against the temporary first-init mysqld). See #949 / ci.yml.
+          consecutive=0
           for i in $(seq 1 60); do
-            if docker exec bintrail-test-mysql mysqladmin ping -u root -ptestroot --silent 2>/dev/null; then
-              echo "MySQL is ready."
-              exit 0
+            if docker run --rm --network host "mysql:${{ matrix.mysql }}" \
+                 mysql --protocol=TCP -h 127.0.0.1 -P 13306 -u root -ptestroot -e "SELECT 1" >/dev/null 2>&1; then
+              consecutive=$((consecutive + 1))
+              if [ "$consecutive" -ge 3 ]; then
+                echo "MySQL is ready (3 consecutive successful probes)."
+                exit 0
+              fi
+            else
+              consecutive=0
             fi
             sleep 2
           done
@@ -74,8 +105,16 @@ jobs:
 
       # -p 1 serializes package execution — see ci.yml's `integration` job for
       # the full rationale (shared single binlog, exact-count assertions).
+      # False-green tripwire mirrors ci.yml: assert the flagship end-to-end
+      # and caching_sha2 auth-seam tests genuinely ran (#949).
       - name: Integration tests (-tags=integration)
-        run: go test -tags=integration -race -p 1 -count=1 ./...
+        run: |
+          set -o pipefail
+          go test -tags=integration -race -p 1 -count=1 -v ./... 2>&1 | tee /tmp/mysql-it.out
+          grep -q -- '--- PASS: TestEndToEnd_fullPipeline' /tmp/mysql-it.out \
+            || { echo "FATAL: MySQL end-to-end integration test did not run — false-green tripwire" >&2; exit 1; }
+          grep -q -- '--- PASS: TestCachingSha2ColdAuthSeam' /tmp/mysql-it.out \
+            || { echo "FATAL: caching_sha2 cold-auth seam test did not run — false-green tripwire" >&2; exit 1; }
 
   integration-mariadb-source:
     # Mirrors ci.yml's `integration-mariadb-source` job. See that job's
@@ -104,9 +143,16 @@ jobs:
             -p 13306:3306 \
             mysql:8.4 \
             --binlog-format=ROW --binlog-row-image=FULL --log-bin=binlog --server-id=1
+          # Host-TCP probe, 3 consecutive successes — see the integration-mysql
+          # job above / #949 for why `docker exec ... mysqladmin ping` races.
+          consecutive=0
           for i in $(seq 1 60); do
-            if docker exec bintrail-test-mysql mysqladmin ping -u root -ptestroot --silent 2>/dev/null; then
-              echo "MySQL index is ready."; exit 0
+            if docker run --rm --network host mysql:8.4 \
+                 mysql --protocol=TCP -h 127.0.0.1 -P 13306 -u root -ptestroot -e "SELECT 1" >/dev/null 2>&1; then
+              consecutive=$((consecutive + 1))
+              [ "$consecutive" -ge 3 ] && { echo "MySQL index is ready."; exit 0; }
+            else
+              consecutive=0
             fi
             sleep 2
           done
@@ -122,9 +168,16 @@ jobs:
             mariadb:11.4 \
             --log-bin=mariadb-bin --binlog-format=ROW --binlog-row-image=FULL \
             --server-id=2 --gtid-strict-mode=ON
+          # Same socket-vs-TCP readiness race as the MySQL-start step (#949):
+          # host-TCP probe with a real query, 3 consecutive successes.
+          consecutive=0
           for i in $(seq 1 60); do
-            if docker exec bintrail-test-mariadb mariadb-admin ping -u root -ptestroot --silent 2>/dev/null; then
-              echo "MariaDB source is ready."; exit 0
+            if docker run --rm --network host mariadb:11.4 \
+                 mariadb --protocol=TCP -h 127.0.0.1 -P 13307 -u root -ptestroot -e "SELECT 1" >/dev/null 2>&1; then
+              consecutive=$((consecutive + 1))
+              [ "$consecutive" -ge 3 ] && { echo "MariaDB source is ready."; exit 0; }
+            else
+              consecutive=0
             fi
             sleep 2
           done
@@ -167,9 +220,16 @@ jobs:
             -p 13306:3306 \
             mysql:8.4 \
             --binlog-format=ROW --binlog-row-image=FULL --log-bin=binlog --server-id=1
+          # Host-TCP probe, 3 consecutive successes — see integration-mysql
+          # job above / #949 for why `docker exec ... mysqladmin ping` races.
+          consecutive=0
           for i in $(seq 1 60); do
-            if docker exec bintrail-test-mysql mysqladmin ping -u root -ptestroot --silent 2>/dev/null; then
-              echo "MySQL index is ready."; exit 0
+            if docker run --rm --network host mysql:8.4 \
+                 mysql --protocol=TCP -h 127.0.0.1 -P 13306 -u root -ptestroot -e "SELECT 1" >/dev/null 2>&1; then
+              consecutive=$((consecutive + 1))
+              [ "$consecutive" -ge 3 ] && { echo "MySQL index is ready."; exit 0; }
+            else
+              consecutive=0
             fi
             sleep 2
           done


### PR DESCRIPTION
## What changed

`.github/workflows/release.yaml` used to gate a tagged release on `go test ./...` only — no `-tags=integration`, no service containers. The corruption/data-loss guards live in the integration suite (MySQL 8.0/8.4, MariaDB-as-source, Postgres-as-source 14-17), which historically only ran on PRs via `ci.yml`. Because merges are `--admin` squashes, the post-squash tree that actually gets tagged may never have been exercised by that matrix.

This PR duplicates ci.yml's `integration` / `integration-mariadb-source` / `integration-postgres-source` jobs into `release.yaml` (minus the PR-only `changes`-based path-skip logic — a release always runs the full matrix regardless of which files changed) and makes the existing `release` job (GoReleaser/cosign/SBOM/publish) `needs: [integration-mysql, integration-mariadb-source, integration-postgres-source]`. A red or flaky integration cell now blocks publishing. The unit-test step (`go test ./...`) stays in the `release` job unchanged, as an extra fast-fail before the slower GoReleaser build.

Each new job is scoped to `permissions: { contents: read }` — the workflow-level `contents: write` / `packages: write` / `id-token: write` block is needed only by the `release` job's publish steps; job-level permissions override it, so the test jobs no longer run with a release-scoped token.

## UPDATE: rebased onto #1093 (issue #949) after review caught a live bug in the copy

The first version of this PR duplicated the integration jobs straight off `main`, which at the time still had the socket-local readiness race that #949/#1093 was filed to fix (`docker exec ... mysqladmin ping` answers over the container's *local socket*; the official mysql image runs a temporary mysqld during first-init and shuts it down before starting the real one, so the socket probe can report ready while the real server on the mapped host port is still starting — root cause of `TestEndToEnd_fullPipeline` silently skipping / EOF-ing on MySQL 8.0). #1093 fixed that in `ci.yml` (commit 95bd02e: host-TCP probe with a real query, 3 consecutive successes) plus added `BINTRAIL_REQUIRE_MYSQL=1` so the job can't go green-via-skip. My duplicate would have shipped the exact defect #949 exists to close, sitting in the *release* gate.

Fix applied here: **rebased this branch onto `fix/949-require-mysql-guard` (#1093)** and hand-ported the fixed readiness probes + `BINTRAIL_REQUIRE_MYSQL` + false-green tripwire into `release.yaml`'s copy verbatim. A prominent "KEEP IN SYNC WITH ci.yml" comment now sits at the top of the integration-jobs block in `release.yaml`.

**This means #1095 currently depends on #1093 and its diff includes #1093's commits** (you'll see `ci.yml`/`testutil.go`/`CONTRIBUTING.md` changes in this PR's diff too) — that resolves itself automatically once #1093 merges to `main` (the merge-base advances and the diff shrinks to just `release.yaml`); no further rebase should be needed on my end unless #1093 changes again first. **Do not merge #1095 before #1093.**

### Why not extract a shared `workflow_call` reusable workflow (considered and rejected)

I evaluated moving the integration jobs into a `.github/workflows/integration.yml` with `on: workflow_call`, called from both `ci.yml` and `release.yaml`, to eliminate the duplication that just proved itself dangerous. Confirmed via GitHub's own docs/community threads: **reusable-workflow job check names are reported as `<caller job name> / <called job name>`**, not the called job's bare name. `integration (8.0)`, `integration (8.4)`, `integration-mariadb-source`, `integration-postgres-source (14..17)` are REQUIRED status check contexts on this repo's branch protection, pinned by exact string. Refactoring into a reusable workflow would silently rename those contexts, leaving branch protection waiting forever on checks that no longer report — a repo-settings change only Dani can make (updating the required-checks list), not something to ship inside this PR. So I kept the duplication, but hardened it: the sync comment at the top of the block, and this PR itself demonstrating the failure mode of letting the copies drift.

## Deliberately left out

- **`console-e2e`** (headless-Chrome UI regression guard) is NOT included — it guards CSS/DOM/presentation bugs, not the corruption/data-loss guards this issue is about.

## Cost tradeoff

Releases now pay for the full integration matrix on every tag push: 2 MySQL cells (8.0/8.4) + 1 MariaDB-source job + 4 Postgres cells (14-17) = 7 additional jobs, each spinning up 1-2 Docker DB containers and running `-race` suites, running in parallel with each other but strictly before GoReleaser starts. This adds real wall-clock time and CI minutes to every release, in exchange for the tagged tree actually having passed the same matrix PRs are held to.

## Operational note for the release runbook

`/release` pushes the tag first, then this workflow runs. If an integration cell is red *or flaky* (this repo has known integration flakes — parser tests #415, PG slot-timing #607), the tag now exists on the remote with **no GitHub release published** until it's green. Recovery is to re-run the failed job (`gh run rerun --failed`, the same pattern already used for GoReleaser 502/503 flakes), not to delete and re-push the tag.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yaml'))"` — clean.
- `actionlint .github/workflows/release.yaml` — clean except pre-existing `SC2034` shellcheck warnings already present in `ci.yml`'s `for i in ...` retry loops (same pattern, not introduced here).
- This PR's own required checks are now running for real (not skip-green) because the stacked commits from #1093 trip `ci.yml`'s `changes` path-filter — `integration (8.0)`/`integration (8.4)`/`integration-mariadb-source`/`integration-postgres-source (14..17)`/`unit`/`console-e2e` are all live runs, visible on this PR.
- `release.yaml`'s new jobs themselves only get their first live exercise on the next tagged release (tag pushes are the only trigger for that workflow).

## Merge order

1. **#1093 (issue #949) first** — adds `BINTRAIL_REQUIRE_MYSQL` and the readiness-race fix this PR's `release.yaml` copy now depends on being real.
2. **#1095 (this PR) second.**

Closes #950

🤖 Generated with [Claude Code](https://claude.com/claude-code)