### PR TITLE
console: cap recover output by bytes, not just rows (#849)

### DIFF
--- a/internal/console/api.go
+++ b/internal/console/api.go
@@ -369,6 +369,26 @@ func (s *Server) handleRecover(w http.ResponseWriter, r *http.Request) {
 		case isParent:
 			cres, cerr := s.cascadeRecover(r.Context(), b, body, opts, rows)
 			if cerr != nil {
+				// A *recovery.ScriptBudgetError here means synthesis SUCCEEDED —
+				// only the combined (parent + synthesized children) script exceeded
+				// the console's budget at render time (recoverMaxScriptBytes, #849).
+				// That is a distinct condition from a synthesis failure below: say so
+				// precisely (a misdiagnosis as "synthesis failed" would send an
+				// operator debugging the wrong thing), and give the same actionable
+				// console guidance as the plain-path 422 (writeRecoverError) rather
+				// than leaking ScriptBudgetError.Error()'s CLI-only "raise/disable the
+				// budget (0 = unlimited)" phrasing — a console setting that doesn't
+				// exist.
+				var be *recovery.ScriptBudgetError
+				if errors.As(cerr, &be) {
+					slog.Warn("console: cascade recovery over the script-size budget; falling back to plain recover", "error", cerr)
+					warnings = append([]string{
+						fmt.Sprintf(
+							"Cascade recovery synthesized the deleted rows, but the combined script would hold ~%.1f MiB of row data — over the console's %.0f MiB budget for a single recovery. The script below re-creates the parent only; cascade-deleted child rows are NOT included. Narrow the recovery filter (schema/table/pk/time range) to shrink the window, or use `bintrail recover-cascade` from the CLI for large cascades.",
+							float64(be.EstimatedBytes)/(1<<20), float64(be.Budget)/(1<<20)),
+					}, warnings...)
+					break // out of the switch → plain recover below
+				}
 				// Cascade synthesis is an ENHANCEMENT of the plain recover, not a
 				// precondition — the base rows were already fetched. A synthesis
 				// failure must not deny the recover the operator can still get;

--- a/internal/console/api.go
+++ b/internal/console/api.go
@@ -32,6 +32,42 @@ const (
 	eventsMaxLimit      = 1000
 	recoverDefaultLimit = 1000
 	recoverMaxLimit     = 10000
+
+	// recoverMaxScriptBytes caps the estimated row payload (recovery's
+	// EstimateScriptBytes: resident row_before/row_after bytes plus the PK,
+	// across every matched row) that POST /api/recover — and its cascade
+	// auto-detection and POST /api/recover-cascade siblings — may hold before
+	// the console refuses to generate a reversal script (#849, follow-up to
+	// #654/#652).
+	//
+	// recoverMaxLimit already bounds ROW COUNT (10,000), not bytes: a wide
+	// table with megabyte BLOB/TEXT columns blows past any sane heap budget
+	// well under 10,000 rows — 10k rows at a few MB each is tens of GB. Under
+	// `bintrail-console watch` the console shares the process with the
+	// capture stream, so an OOM-kill here also kills capture (event loss
+	// until the supervisor restarts it).
+	//
+	// recovery.Generator already refuses BEFORE rendering anything
+	// (GenerateSQLFromRows calls CheckScriptBudget/EstimateScriptBytes first,
+	// so a refusal never touches the output buffer — see internal/recovery's
+	// #654 guard) — but its zero-config default, DefaultMaxScriptBytes, is
+	// 2 GiB: sized for an operator-run CLI process, not a long-lived daemon
+	// that must keep serving the events browser, status, and (in `watch`)
+	// capture at the same time. A 2 GiB reversal script is also useless in a
+	// browser tab: it will never render in a <textarea> or survive a JSON
+	// round-trip through the tab's own JS heap. 32 MiB keeps an ordinary
+	// wide-row recovery (KBs to low MBs of SQL) comfortably in budget while
+	// failing fast — well before the CLI's headroom — on the pathological
+	// BLOB/TEXT-heavy window this issue is about.
+	//
+	// No console flag or env var exposes this: unlike the CLI's
+	// --max-script-bytes (a per-run operator choice on a process that exits
+	// when it's done), this is a shared-daemon OOM guardrail. The escape
+	// hatch for a genuinely large recovery is the one the refusal error
+	// message gives — narrow the filter, or run `bintrail recover` (which
+	// already has --max-script-bytes / BINTRAIL_RECOVER_MAX_BYTES) outside
+	// the daemon.
+	recoverMaxScriptBytes = 32 << 20
 )
 
 // filterParams is the source-agnostic set of query filters parsed from either
@@ -374,9 +410,16 @@ func (s *Server) handleRecover(w http.ResponseWriter, r *http.Request) {
 	var buf bytes.Buffer
 	// Per-bundle dialect (read above): a PG-flavored index → PostgreSQL reversal SQL.
 	// DialectForIndex defaults to MySQL on any read failure (#533/#573).
-	n, err := recovery.NewForDialect(b.db, b.resolver, dialect).GenerateSQLFromRows(rows, &buf)
+	gen := recovery.NewForDialect(b.db, b.resolver, dialect)
+	// #849: tighten the CLI-sized 2 GiB zero-config default
+	// (recovery.DefaultMaxScriptBytes) down to recoverMaxScriptBytes. The
+	// generator's CheckScriptBudget runs BEFORE any byte is written to buf, so
+	// a refusal never materializes the oversized script in the shared daemon
+	// heap — see the recoverMaxScriptBytes doc comment above.
+	gen.SetMaxScriptBytes(recoverMaxScriptBytes)
+	n, err := gen.GenerateSQLFromRows(rows, &buf)
 	if err != nil {
-		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		writeRecoverError(w, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, recoverResponse{
@@ -612,6 +655,36 @@ func writeFetchError(w http.ResponseWriter, err error) {
 		writeJSONError(w, http.StatusUnprocessableEntity,
 			"this index predates the "+col+" column, and the console never migrates servers added in the UI; "+
 				"run a writer command against it once (bintrail index / stream / agent), or start a console with --index-dsn pointing at it")
+		return
+	}
+	writeJSONError(w, http.StatusInternalServerError, err.Error())
+}
+
+// writeRecoverError maps a reversal-script generation failure onto the right
+// HTTP response. A *recovery.ScriptBudgetError — the pre-render refusal
+// GenerateSQLFromRows/CheckScriptBudget return when the estimated row payload
+// exceeds the configured budget (#654), tightened for the console by
+// recoverMaxScriptBytes (#849) — gets an actionable 422 telling the operator
+// how to get an answer instead of a bare 500: narrow the filter, or reach for
+// the CLI, which runs outside the console's shared process and can raise or
+// disable the budget entirely.
+//
+// This builds its own message from the typed error's fields rather than
+// reusing ScriptBudgetError.Error() verbatim: that message ends with "raise/
+// disable the budget (0 = unlimited)", which is CLI-flag advice
+// (--max-script-bytes) that does not apply here — the console exposes no such
+// knob (see recoverMaxScriptBytes's doc comment for why), and repeating it
+// would send the operator looking for a setting that does not exist.
+func writeRecoverError(w http.ResponseWriter, err error) {
+	var be *recovery.ScriptBudgetError
+	if errors.As(err, &be) {
+		writeJSONError(w, http.StatusUnprocessableEntity, fmt.Sprintf(
+			"refusing to generate the reversal script — the matched events hold ~%.1f MiB of row data, "+
+				"over the console's %.0f MiB budget for a single recovery. Narrow the recovery filter "+
+				"(schema/table/pk/time range) to shrink the window, or use `bintrail recover` from the CLI "+
+				"for large recoveries — it runs outside the console's shared process and supports "+
+				"--max-script-bytes to raise or disable this budget.",
+			float64(be.EstimatedBytes)/(1<<20), float64(be.Budget)/(1<<20)))
 		return
 	}
 	writeJSONError(w, http.StatusInternalServerError, err.Error())

--- a/internal/console/api_test.go
+++ b/internal/console/api_test.go
@@ -298,6 +298,15 @@ func TestRecoverUnderByteBudget(t *testing.T) {
 	if resp.StatementCount != 1 {
 		t.Errorf("StatementCount = %d, want 1", resp.StatementCount)
 	}
+	// Strengthened per code review (#849 item 3): StatementCount alone doesn't
+	// prove the budget guard left the actual SQL generation untouched — inspect
+	// the rendered script the way TestRecoverIsReadOnly does.
+	if !strings.Contains(resp.SQL, "DELETE FROM") {
+		t.Errorf("expected a DELETE in the undo SQL, got:\n%s", resp.SQL)
+	}
+	if !strings.Contains(resp.SQL, "BEGIN;") || !strings.Contains(resp.SQL, "COMMIT;") {
+		t.Errorf("expected a transaction-wrapped script, got:\n%s", resp.SQL)
+	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Error(err)
 	}

--- a/internal/console/api_test.go
+++ b/internal/console/api_test.go
@@ -3,6 +3,7 @@ package console
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http/httptest"
 	"reflect"
 	"strings"
@@ -257,6 +258,122 @@ func TestRecoverIsReadOnly(t *testing.T) {
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("read-only invariant violated — unexpected DB interaction: %v", err)
+	}
+}
+
+// TestRecoverUnderByteBudget is TestRecoverIsReadOnly's sibling, added for
+// #849: an ordinary small recovery must sail through the new
+// recoverMaxScriptBytes guard unaffected — a 200 with generated SQL, not an
+// accidental refusal from an overzealous budget.
+func TestRecoverUnderByteBudget(t *testing.T) {
+	db, mock, closeDB := newSQLMock(t)
+	defer closeDB()
+
+	cols := []string{
+		"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp",
+		"gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values",
+		"changed_columns", "row_before", "row_after", "schema_version", "query_text", "query_hash",
+	}
+	ts := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	resultRows := sqlmock.NewRows(cols).AddRow(
+		int64(1), "bin.000001", int64(4), int64(40), ts,
+		nil, nil, "app", "users", int64(parser.EventInsert), "42",
+		nil, nil, []byte(`{"id":42,"email":"a@x"}`), int64(0),
+		nil, nil,
+	)
+	mock.ExpectQuery("FROM binlog_events").WillReturnRows(resultRows)
+
+	s := newBootServer(db)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/recover", strings.NewReader(`{"schema":"app","table":"users"}`))
+	s.handleRecover(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("recover status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var resp recoverResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v (body=%s)", err, rec.Body.String())
+	}
+	if resp.StatementCount != 1 {
+		t.Errorf("StatementCount = %d, want 1", resp.StatementCount)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+// TestRecoverOverByteBudget is the #849 repro: MANY moderately wide rows —
+// not one pathological giant row — whose COMBINED decoded row_after payload
+// exceeds recoverMaxScriptBytes must refuse with an actionable 422, not a 200
+// carrying a giant script and not a bare 500. #849's actual complaint was that
+// recoverMaxLimit (10,000) bounds row COUNT while row SIZE stayed unbounded —
+// a many-rows-of-a-few-MB shape is exactly what that gap allowed through, so
+// the repro uses 40 x 1 MiB rows (well under the 10,000-row cap) rather than a
+// single oversized row, to prove the estimate is summed ACROSS rows and not
+// just checked per-row. The refusal happens INSIDE GenerateSQLFromRows before
+// any byte reaches the response buffer (recovery's pre-render
+// CheckScriptBudget, #654), so this also guards that the console actually
+// wired the tightened budget through (SetMaxScriptBytes) rather than relying
+// on the CLI-sized 2 GiB default.
+func TestRecoverOverByteBudget(t *testing.T) {
+	db, mock, closeDB := newSQLMock(t)
+	defer closeDB()
+
+	cols := []string{
+		"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp",
+		"gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values",
+		"changed_columns", "row_before", "row_after", "schema_version", "query_text", "query_hash",
+	}
+	ts := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	const (
+		numRows    = 40
+		rowBlobLen = 1 << 20 // 1 MiB each; 40 MiB total, over the 32 MiB budget
+	)
+	blob := strings.Repeat("x", rowBlobLen)
+	resultRows := sqlmock.NewRows(cols)
+	for i := 0; i < numRows; i++ {
+		rowAfter, err := json.Marshal(map[string]any{"id": i, "blob": blob})
+		if err != nil {
+			t.Fatal(err)
+		}
+		resultRows.AddRow(
+			int64(i+1), "bin.000001", int64(4), int64(40), ts,
+			nil, nil, "app", "users", int64(parser.EventInsert), fmt.Sprintf("%d", i),
+			nil, nil, rowAfter, int64(0),
+			nil, nil,
+		)
+	}
+	mock.ExpectQuery("FROM binlog_events").WillReturnRows(resultRows)
+
+	s := newBootServer(db)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/recover", strings.NewReader(`{"schema":"app","table":"users"}`))
+	s.handleRecover(rec, req)
+
+	if rec.Code != 422 {
+		t.Fatalf("recover over budget: code = %d, want 422, body = %s", rec.Code, rec.Body.String())
+	}
+	var errBody map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &errBody); err != nil {
+		t.Fatalf("decode error body: %v (body=%s)", err, rec.Body.String())
+	}
+	msg := errBody["error"]
+	for _, want := range []string{"MiB budget", "Narrow the recovery filter", "bintrail recover"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message missing %q: %s", want, msg)
+		}
+	}
+	// The message must not point the operator at a knob the console doesn't
+	// expose — the CLI-only escape hatch (--max-script-bytes) is offered
+	// explicitly above, not the bare "0 = unlimited" phrasing from
+	// ScriptBudgetError.Error(), which reads as a console setting that
+	// doesn't exist.
+	if strings.Contains(msg, "0 = unlimited") {
+		t.Errorf("error message must not reference the CLI's raw '0 = unlimited' phrasing: %s", msg)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
 	}
 }
 

--- a/internal/console/mcp.go
+++ b/internal/console/mcp.go
@@ -138,6 +138,11 @@ func (s *Server) newMCPServer(id string) *mcp.Server {
 		AllowProfileParam: false,
 		QueryMaxLimit:     func() int { return eventsMaxLimit },
 		RecoverMaxLimit:   recoverMaxLimit,
-		AuditSurface:      "console-mcp",
+		// #849: the console's /mcp recover tool renders the same reversal
+		// script as /api/recover, in the same shared daemon process — it must
+		// not be left at the Generator's CLI-sized 2 GiB default just because
+		// RecoverMaxLimit already bounds row count.
+		MaxScriptBytes: recoverMaxScriptBytes,
+		AuditSurface:   "console-mcp",
 	})
 }

--- a/internal/console/recover_cascade.go
+++ b/internal/console/recover_cascade.go
@@ -172,6 +172,9 @@ func (s *Server) handleRecoverCascade(w http.ResponseWriter, r *http.Request) {
 	// only flavor cascade recovery supports — this is byte-identical to the CLI's
 	// recovery.New(MySQL).
 	gen := recovery.NewForDialect(b.db, b.resolver, recovery.DialectForIndex(b.db))
+	// #849: same shared-daemon budget as handleRecover (see recoverMaxScriptBytes
+	// in api.go) — EmitSQL calls gen.CheckScriptBudget before writing a byte.
+	gen.SetMaxScriptBytes(recoverMaxScriptBytes)
 	n, err := cascaderecover.EmitSQL(&buf, gen, rows, synth.SetNullRows, b.resolver, cascaderecover.Header{
 		Schema:         body.Schema,
 		Table:          body.Table,
@@ -182,7 +185,7 @@ func (s *Server) handleRecoverCascade(w http.ResponseWriter, r *http.Request) {
 		BaselineActive: synth.BaselineActive,
 	})
 	if err != nil {
-		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		writeRecoverError(w, err)
 		return
 	}
 
@@ -492,6 +495,10 @@ func (s *Server) cascadeRecover(ctx context.Context, b *bundle, body recoverRequ
 	rows := append(append([]query.ResultRow{}, baseRows...), synth.Victims...)
 	var buf bytes.Buffer
 	gen := recovery.NewForDialect(b.db, b.resolver, recovery.DialectForIndex(b.db))
+	// #849: same shared-daemon budget as handleRecover (see recoverMaxScriptBytes
+	// in api.go). A refusal here is caught by handleRecover's caller, which
+	// degrades to the plain (non-cascade) recovery below its own budget check.
+	gen.SetMaxScriptBytes(recoverMaxScriptBytes)
 	n, err := cascaderecover.EmitSQL(&buf, gen, rows, setNull, b.resolver, cascaderecover.Header{
 		Schema:         body.Schema,
 		Table:          body.Table,

--- a/internal/console/recover_cascade_integration_test.go
+++ b/internal/console/recover_cascade_integration_test.go
@@ -3,7 +3,10 @@
 package console
 
 import (
+	"database/sql"
 	"encoding/json"
+	"fmt"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
@@ -657,5 +660,187 @@ func TestIntegrationRecoverCascade_refusedUnderProfile(t *testing.T) {
 	}
 	if caps.RecoverCascade {
 		t.Errorf("capability recover_cascade must be false under an RBAC profile, got: %s", capsBody)
+	}
+}
+
+// withLargeSortBuffer raises the test MySQL instance's GLOBAL sort_buffer_size
+// and max_sort_length for the duration of the test, restoring both via
+// t.Cleanup. The default sort_buffer_size (256 KB, MySQL 8's default) is far
+// below the ~40 MiB row images seedCascadeConsoleOversized writes: the
+// cascade engine's victim lookup (internal/cascade/cascade.go's eng.Fetch
+// with LimitPerPK) filters on a JSON_EXTRACT predicate combined with a
+// ROW_NUMBER() OVER (PARTITION BY ...) window, and MySQL 8's window-function
+// materialization needs the GLOBAL (not per-session — a session var is
+// snapshotted at connect, so it must be set before the pool opens) sort
+// buffer to comfortably exceed the widest row, or the query itself dies with
+// ER_OUT_OF_SORTMEMORY (1038) before cascade synthesis — and therefore the
+// #849 byte-budget check — ever runs. This is the same MySQL behavior
+// documented in internal/query/query.go's late-materialization comment
+// (narrow-key sort + join-back keeps ORDINARY queries safe regardless of row
+// width); the cascade engine's WHERE-filtered window query doesn't benefit
+// from that fix, so the fixture needs the server-side floor instead. Global,
+// not per-connection: testutil.CreateTestDB opens a NEW connection pool,
+// which snapshots sort_buffer_size from the GLOBAL default at connect time.
+func withLargeSortBuffer(t *testing.T, bytes int64) {
+	t.Helper()
+	root, err := sql.Open("mysql", testutil.BaseDSN()+"/?parseTime=true")
+	if err != nil {
+		t.Fatalf("connect for sort_buffer_size bump: %v", err)
+	}
+	defer root.Close()
+
+	var origSort, origMaxSort int64
+	if err := root.QueryRow("SELECT @@GLOBAL.sort_buffer_size").Scan(&origSort); err != nil {
+		t.Fatalf("read GLOBAL sort_buffer_size: %v", err)
+	}
+	if err := root.QueryRow("SELECT @@GLOBAL.max_sort_length").Scan(&origMaxSort); err != nil {
+		t.Fatalf("read GLOBAL max_sort_length: %v", err)
+	}
+	if _, err := root.Exec(fmt.Sprintf("SET GLOBAL sort_buffer_size = %d", bytes)); err != nil {
+		t.Fatalf("raise GLOBAL sort_buffer_size: %v", err)
+	}
+	if _, err := root.Exec(fmt.Sprintf("SET GLOBAL max_sort_length = %d", bytes)); err != nil {
+		t.Fatalf("raise GLOBAL max_sort_length: %v", err)
+	}
+	t.Cleanup(func() {
+		restore, err := sql.Open("mysql", testutil.BaseDSN()+"/?parseTime=true")
+		if err != nil {
+			t.Logf("sort_buffer_size restore: connect failed: %v", err)
+			return
+		}
+		defer restore.Close()
+		if _, err := restore.Exec(fmt.Sprintf("SET GLOBAL sort_buffer_size = %d", origSort)); err != nil {
+			t.Logf("sort_buffer_size restore failed: %v", err)
+		}
+		if _, err := restore.Exec(fmt.Sprintf("SET GLOBAL max_sort_length = %d", origMaxSort)); err != nil {
+			t.Logf("max_sort_length restore failed: %v", err)
+		}
+	})
+}
+
+// seedCascadeConsoleOversized is seedCascadeConsole's #849 sibling: the same
+// parent-DELETE + two-child-INSERT + FK-CASCADE shape, except child id=10
+// carries a ~40 MiB row_after blob. The cascade engine copies an INSERT's
+// row_after into the synthesized victim's RowBefore (internal/cascade/
+// cascade.go:553, "last known state → INSERT target"), so this blob flows
+// straight into cascade victim payload EstimateScriptBytes sums — pushing
+// the COMBINED (parent + victims) script over recoverMaxScriptBytes (32 MiB)
+// while the parent DELETE alone (`{"id":1}`) stays tiny. That combination is
+// exactly what pins the two console cascade code paths' budget wiring
+// (recover_cascade.go's handleRecoverCascade and cascadeRecover Generator
+// construction, #849 item 3): deleting either call's
+// gen.SetMaxScriptBytes(recoverMaxScriptBytes) would let this fixture render
+// fine at the CLI-sized 2 GiB default, and the corresponding test below would
+// start failing (expecting a refusal, getting a clean 200).
+func seedCascadeConsoleOversized(t *testing.T) (*Server, string) {
+	t.Helper()
+	withLargeSortBuffer(t, 64<<20) // must be set before the pool below opens
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	h := time.Now().UTC().Add(-1 * time.Hour).Truncate(time.Hour)
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{h})
+	childTs := h.Add(10 * time.Minute).Format("2006-01-02 15:04:05")
+	parentTs := h.Add(20 * time.Minute).Format("2006-01-02 15:04:05")
+
+	bigBlob := strings.Repeat("x", recoverMaxScriptBytes+(8<<20)) // budget + 8 MiB headroom
+	child10 := []byte(`{"id":10,"pid":1,"blob":"` + bigBlob + `"}`)
+
+	testutil.InsertEvent(t, db, "binlog.000001", 100, 200, childTs, nil,
+		dbName, "child", 1 /*INSERT*/, "10", nil, nil, child10)
+	testutil.InsertEvent(t, db, "binlog.000001", 200, 300, childTs, nil,
+		dbName, "child", 1 /*INSERT*/, "11", nil, nil, []byte(`{"id":11,"pid":1}`))
+	testutil.InsertEvent(t, db, "binlog.000001", 300, 400, parentTs, nil,
+		dbName, "parent", 3 /*DELETE*/, "1", nil, []byte(`{"id":1}`), nil)
+
+	testutil.MustExec(t, db, `INSERT INTO fk_constraints
+		(snapshot_id, constraint_name, schema_name, table_name, column_name, ordinal_position,
+		 referenced_schema_name, referenced_table_name, referenced_column_name, delete_rule, update_rule)
+		VALUES (1, 'fk_child', ?, 'child', 'pid', 1, ?, 'parent', 'id', 'CASCADE', 'RESTRICT')`,
+		dbName, dbName)
+
+	snapTs := h.Format("2006-01-02 15:04:05")
+	testutil.InsertSnapshot(t, db, 1, snapTs, dbName, "parent", "id", 1, "PRI", "int", "NO")
+	testutil.InsertSnapshot(t, db, 1, snapTs, dbName, "child", "id", 1, "PRI", "int", "NO")
+	testutil.InsertSnapshot(t, db, 1, snapTs, dbName, "child", "pid", 2, "", "int", "YES")
+
+	cfg := Config{DB: db, DBName: dbName, Listen: "127.0.0.1:8090", Token: intToken, NoArchive: true}
+	srv, err := New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return srv, dbName
+}
+
+// TestIntegrationRecoverCascade_overByteBudget pins recoverMaxScriptBytes
+// wiring on the EXPLICIT endpoint (handleRecoverCascade's own
+// recovery.NewForDialect(...) + gen.SetMaxScriptBytes(recoverMaxScriptBytes)
+// in recover_cascade.go, #849 item 3): a combined parent+victims script far
+// over budget must refuse with the same actionable 422 the plain /api/recover
+// path uses (writeRecoverError), not render at the Generator's CLI-sized
+// 2 GiB zero-config default.
+func TestIntegrationRecoverCascade_overByteBudget(t *testing.T) {
+	srv, dbName := seedCascadeConsoleOversized(t)
+
+	rec, body := doReq(t, srv, "POST", "/api/recover-cascade", `{"schema":"`+dbName+`","table":"parent"}`)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422, body = %s", rec.Code, body)
+	}
+	var errBody map[string]string
+	if err := json.Unmarshal(body, &errBody); err != nil {
+		t.Fatalf("decode error body: %v (body=%s)", err, body)
+	}
+	msg := errBody["error"]
+	for _, want := range []string{"MiB budget", "Narrow the recovery filter", "bintrail recover"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message missing %q: %s", want, msg)
+		}
+	}
+	if strings.Contains(msg, "0 = unlimited") {
+		t.Errorf("error message must not leak the CLI-only '0 = unlimited' phrasing: %s", msg)
+	}
+}
+
+// TestIntegrationRecover_autoCascade_overByteBudget pins recoverMaxScriptBytes
+// wiring on the AUTO-DETECTED cascade path (cascadeRecover's own
+// gen.SetMaxScriptBytes(recoverMaxScriptBytes) in recover_cascade.go, #849
+// item 3) together with the api.go warning fix (#849 item 2, the code-review
+// follow-up): a combined script over budget must NOT render at 2 GiB, must
+// degrade to the plain (parent-only) recovery — not fail the whole request —
+// and the warning explaining why must say the budget was the reason (not
+// "cascade synthesis failed", which would misdiagnose a refusal that happened
+// AFTER synthesis succeeded) and must not leak the CLI-only "0 = unlimited"
+// phrasing that has no console equivalent.
+func TestIntegrationRecover_autoCascade_overByteBudget(t *testing.T) {
+	srv, dbName := seedCascadeConsoleOversized(t)
+
+	rec, body := doReq(t, srv, "POST", "/api/recover", `{"schema":"`+dbName+`","table":"parent"}`)
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200 (over-budget cascade degrades to plain recover), body = %s", rec.Code, body)
+	}
+	var resp recoverResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("decode: %v (body=%s)", err, body)
+	}
+	if resp.CascadeDetected {
+		t.Errorf("cascade_detected should be false: the combined script was over budget, so recover degraded to the plain path\n---\n%s", resp.SQL)
+	}
+	if !strings.Contains(resp.SQL, "`"+dbName+"`.`parent`") {
+		t.Errorf("the plain fallback should still re-create the parent\n---\n%s", resp.SQL)
+	}
+	if strings.Contains(resp.SQL, "`"+dbName+"`.`child`") {
+		t.Errorf("the plain fallback must NOT include the cascade-synthesized (oversized) children\n---\n%s", resp.SQL)
+	}
+	joined := strings.Join(resp.Warnings, " | ")
+	for _, want := range []string{"combined script would hold", "MiB budget", "re-creates the parent only", "Narrow the recovery filter"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("warnings missing %q: %v", want, resp.Warnings)
+		}
+	}
+	if strings.Contains(joined, "0 = unlimited") {
+		t.Errorf("warnings must not leak the CLI-only '0 = unlimited' phrasing: %v", resp.Warnings)
+	}
+	if strings.Contains(joined, "Cascade synthesis failed") {
+		t.Errorf("a budget refusal after successful synthesis must not be misdiagnosed as a synthesis failure: %v", resp.Warnings)
 	}
 }

--- a/internal/console/recover_cascade_integration_test.go
+++ b/internal/console/recover_cascade_integration_test.go
@@ -3,7 +3,6 @@
 package console
 
 import (
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -663,78 +662,38 @@ func TestIntegrationRecoverCascade_refusedUnderProfile(t *testing.T) {
 	}
 }
 
-// withLargeSortBuffer raises the test MySQL instance's GLOBAL sort_buffer_size
-// and max_sort_length for the duration of the test, restoring both via
-// t.Cleanup. The default sort_buffer_size (256 KB, MySQL 8's default) is far
-// below the ~40 MiB row images seedCascadeConsoleOversized writes: the
-// cascade engine's victim lookup (internal/cascade/cascade.go's eng.Fetch
-// with LimitPerPK) filters on a JSON_EXTRACT predicate combined with a
-// ROW_NUMBER() OVER (PARTITION BY ...) window, and MySQL 8's window-function
-// materialization needs the GLOBAL (not per-session — a session var is
-// snapshotted at connect, so it must be set before the pool opens) sort
-// buffer to comfortably exceed the widest row, or the query itself dies with
-// ER_OUT_OF_SORTMEMORY (1038) before cascade synthesis — and therefore the
-// #849 byte-budget check — ever runs. This is the same MySQL behavior
-// documented in internal/query/query.go's late-materialization comment
-// (narrow-key sort + join-back keeps ORDINARY queries safe regardless of row
-// width); the cascade engine's WHERE-filtered window query doesn't benefit
-// from that fix, so the fixture needs the server-side floor instead. Global,
-// not per-connection: testutil.CreateTestDB opens a NEW connection pool,
-// which snapshots sort_buffer_size from the GLOBAL default at connect time.
-func withLargeSortBuffer(t *testing.T, bytes int64) {
-	t.Helper()
-	root, err := sql.Open("mysql", testutil.BaseDSN()+"/?parseTime=true")
-	if err != nil {
-		t.Fatalf("connect for sort_buffer_size bump: %v", err)
-	}
-	defer root.Close()
-
-	var origSort, origMaxSort int64
-	if err := root.QueryRow("SELECT @@GLOBAL.sort_buffer_size").Scan(&origSort); err != nil {
-		t.Fatalf("read GLOBAL sort_buffer_size: %v", err)
-	}
-	if err := root.QueryRow("SELECT @@GLOBAL.max_sort_length").Scan(&origMaxSort); err != nil {
-		t.Fatalf("read GLOBAL max_sort_length: %v", err)
-	}
-	if _, err := root.Exec(fmt.Sprintf("SET GLOBAL sort_buffer_size = %d", bytes)); err != nil {
-		t.Fatalf("raise GLOBAL sort_buffer_size: %v", err)
-	}
-	if _, err := root.Exec(fmt.Sprintf("SET GLOBAL max_sort_length = %d", bytes)); err != nil {
-		t.Fatalf("raise GLOBAL max_sort_length: %v", err)
-	}
-	t.Cleanup(func() {
-		restore, err := sql.Open("mysql", testutil.BaseDSN()+"/?parseTime=true")
-		if err != nil {
-			t.Logf("sort_buffer_size restore: connect failed: %v", err)
-			return
-		}
-		defer restore.Close()
-		if _, err := restore.Exec(fmt.Sprintf("SET GLOBAL sort_buffer_size = %d", origSort)); err != nil {
-			t.Logf("sort_buffer_size restore failed: %v", err)
-		}
-		if _, err := restore.Exec(fmt.Sprintf("SET GLOBAL max_sort_length = %d", origMaxSort)); err != nil {
-			t.Logf("max_sort_length restore failed: %v", err)
-		}
-	})
-}
-
 // seedCascadeConsoleOversized is seedCascadeConsole's #849 sibling: the same
-// parent-DELETE + two-child-INSERT + FK-CASCADE shape, except child id=10
-// carries a ~40 MiB row_after blob. The cascade engine copies an INSERT's
-// row_after into the synthesized victim's RowBefore (internal/cascade/
-// cascade.go:553, "last known state → INSERT target"), so this blob flows
-// straight into cascade victim payload EstimateScriptBytes sums — pushing
-// the COMBINED (parent + victims) script over recoverMaxScriptBytes (32 MiB)
-// while the parent DELETE alone (`{"id":1}`) stays tiny. That combination is
-// exactly what pins the two console cascade code paths' budget wiring
-// (recover_cascade.go's handleRecoverCascade and cascadeRecover Generator
-// construction, #849 item 3): deleting either call's
-// gen.SetMaxScriptBytes(recoverMaxScriptBytes) would let this fixture render
-// fine at the CLI-sized 2 GiB default, and the corresponding test below would
-// start failing (expecting a refusal, getting a clean 200).
+// parent-DELETE + child-INSERT + FK-CASCADE shape, except the child table
+// carries MANY moderate-sized rows (oversizedChildCount rows of
+// oversizedChildBlobBytes each, all referencing parent id=1) instead of a
+// couple of small ones. The cascade engine copies each INSERT's row_after
+// into the synthesized victim's RowBefore (internal/cascade/cascade.go:553,
+// "last known state → INSERT target"), so this flows straight into cascade
+// victim payload EstimateScriptBytes sums — pushing the COMBINED (parent +
+// victims) script over recoverMaxScriptBytes (32 MiB) while the parent DELETE
+// alone (`{"id":1}`) stays tiny.
+//
+// Deliberately MANY moderate rows, not one giant row: a single row wider than
+// MySQL's default sort_buffer_size (256 KB) makes the cascade engine's own
+// victim-lookup query — a JSON_EXTRACT filter combined with a
+// ROW_NUMBER() OVER (PARTITION BY ...) window (eng.Fetch with LimitPerPK) —
+// die with ER_OUT_OF_SORTMEMORY (1038) before cascade synthesis ever runs, an
+// early version of this fixture hit exactly that. internal/query/query.go's
+// late-materialization fix (narrow-key sort + join-back) doesn't cover the
+// cascade engine's own query, so the fixture works around the cliff by
+// staying under it — oversizedChildBlobBytes is comfortably below 256 KB —
+// rather than raising a GLOBAL MySQL setting that would leak into whatever
+// else shares this test server (concurrent packages, other tests) and
+// silently mask the class of bug internal/query/query.go's fix addresses if
+// left too high. All oversizedChildCount rows stay far under
+// cascade.CandidateLimit (1000, the per-FK victim query LIMIT).
+const (
+	oversizedChildCount     = 260
+	oversizedChildBlobBytes = 160 << 10 // 160 KiB/row: 260 * 160 KiB ≈ 40.6 MiB combined, over the 32 MiB budget; each row well under MySQL's default 256 KiB sort_buffer_size
+)
+
 func seedCascadeConsoleOversized(t *testing.T) (*Server, string) {
 	t.Helper()
-	withLargeSortBuffer(t, 64<<20) // must be set before the pool below opens
 	db, dbName := testutil.CreateTestDB(t)
 	testutil.InitIndexTables(t, db)
 
@@ -743,14 +702,14 @@ func seedCascadeConsoleOversized(t *testing.T) (*Server, string) {
 	childTs := h.Add(10 * time.Minute).Format("2006-01-02 15:04:05")
 	parentTs := h.Add(20 * time.Minute).Format("2006-01-02 15:04:05")
 
-	bigBlob := strings.Repeat("x", recoverMaxScriptBytes+(8<<20)) // budget + 8 MiB headroom
-	child10 := []byte(`{"id":10,"pid":1,"blob":"` + bigBlob + `"}`)
-
-	testutil.InsertEvent(t, db, "binlog.000001", 100, 200, childTs, nil,
-		dbName, "child", 1 /*INSERT*/, "10", nil, nil, child10)
-	testutil.InsertEvent(t, db, "binlog.000001", 200, 300, childTs, nil,
-		dbName, "child", 1 /*INSERT*/, "11", nil, nil, []byte(`{"id":11,"pid":1}`))
-	testutil.InsertEvent(t, db, "binlog.000001", 300, 400, parentTs, nil,
+	blob := strings.Repeat("x", oversizedChildBlobBytes)
+	for i := 0; i < oversizedChildCount; i++ {
+		childID := 100 + i
+		rowAfter := []byte(fmt.Sprintf(`{"id":%d,"pid":1,"blob":"%s"}`, childID, blob))
+		testutil.InsertEvent(t, db, "binlog.000001", uint64(100+i*10), uint64(100+i*10+5), childTs, nil,
+			dbName, "child", 1 /*INSERT*/, fmt.Sprintf("%d", childID), nil, nil, rowAfter)
+	}
+	testutil.InsertEvent(t, db, "binlog.000001", 100000, 100100, parentTs, nil,
 		dbName, "parent", 3 /*DELETE*/, "1", nil, []byte(`{"id":1}`), nil)
 
 	testutil.MustExec(t, db, `INSERT INTO fk_constraints

--- a/internal/mcptools/mcptools.go
+++ b/internal/mcptools/mcptools.go
@@ -191,6 +191,32 @@ func (c Config) auditSurface() string {
 	return c.AuditSurface
 }
 
+// scriptBudgetOverride reports whether the recover tool should call
+// Generator.SetMaxScriptBytes, and with what value. ok is false when
+// c.MaxScriptBytes is unset (<= 0) — the caller must then leave the
+// Generator's own constructor default (recovery.DefaultMaxScriptBytes, 2 GiB)
+// untouched, which is what standalone bintrail-mcp relies on.
+//
+// This is deliberately its own method, not an inline `if cfg.MaxScriptBytes >
+// 0 { gen.SetMaxScriptBytes(...) }` at the call site (#849 code review): "0 =
+// don't touch it" and "0 = call SetMaxScriptBytes(0)" are NOT the same thing
+// — SetMaxScriptBytes(0) explicitly DISABLES the budget guard
+// (recovery.Generator.SetMaxScriptBytes: "n <= 0 disables the guard
+// (unlimited)"). A future refactor that simplified the call site to
+// `gen.SetMaxScriptBytes(cfg.MaxScriptBytes)` unconditionally would silently
+// make the standalone posture (MaxScriptBytes never set) render with NO
+// budget at all, re-opening the exact class of bug #654/#849 close. Isolating
+// the decision here lets TestConfigScriptBudgetOverride pin it directly
+// (Config{}.scriptBudgetOverride() must be (0, false)) without needing an
+// impractical multi-gigabyte test payload to observe the difference
+// end-to-end.
+func (c Config) scriptBudgetOverride() (int64, bool) {
+	if c.MaxScriptBytes > 0 {
+		return c.MaxScriptBytes, true
+	}
+	return 0, false
+}
+
 // NewServer builds an MCP server exposing the four read-only tools bound to
 // cfg. All tools are annotated read-only + idempotent.
 func NewServer(cfg Config) *mcp.Server {
@@ -597,13 +623,33 @@ func MakeRecoverTool(cfg Config) func(context.Context, *mcp.CallToolRequest, Rec
 		// #849: the console sets cfg.MaxScriptBytes to its own shared-daemon
 		// budget; standalone bintrail-mcp leaves it 0, so the Generator keeps
 		// its own DefaultMaxScriptBytes (2 GiB) exactly as before this field
-		// existed.
-		if cfg.MaxScriptBytes > 0 {
-			gen.SetMaxScriptBytes(cfg.MaxScriptBytes)
+		// existed. See Config.scriptBudgetOverride for why this must stay an
+		// "only call when set" gate rather than an unconditional
+		// SetMaxScriptBytes(cfg.MaxScriptBytes).
+		if v, ok := cfg.scriptBudgetOverride(); ok {
+			gen.SetMaxScriptBytes(v)
 		}
 		var buf bytes.Buffer
 		n, err := gen.GenerateSQLFromRows(rows, &buf)
 		if err != nil {
+			// A *recovery.ScriptBudgetError gets a message built from its typed
+			// fields rather than its own Error() verbatim — that text ends with
+			// "raise/disable the budget (0 = unlimited)", advice that presumes a
+			// Go caller of SetMaxScriptBytes, not an MCP client. Point at the one
+			// escape hatch that's actually reachable from here on EITHER surface
+			// (console or standalone): `bintrail recover` from the CLI, which does
+			// expose --max-script-bytes (#849 code review: writeRecoverError in
+			// internal/console/api.go does the equivalent for the HTTP endpoints;
+			// this is the MCP-tool sibling of that fix).
+			var be *recovery.ScriptBudgetError
+			if errors.As(err, &be) {
+				return ErrorResult(fmt.Errorf(
+					"refusing to generate the reversal script — the matched events hold ~%.1f MiB of row data, "+
+						"over the %.0f MiB budget for a single recovery. Narrow the recovery filter "+
+						"(schema/table/pk/time range) to shrink the window, or use `bintrail recover` from the CLI "+
+						"for large recoveries (it supports --max-script-bytes to raise or disable this budget)",
+					float64(be.EstimatedBytes)/(1<<20), float64(be.Budget)/(1<<20))), nil, nil
+			}
 			return ErrorResult(err), nil, nil
 		}
 

--- a/internal/mcptools/mcptools.go
+++ b/internal/mcptools/mcptools.go
@@ -163,6 +163,16 @@ type Config struct {
 	// RecoverMaxLimit caps the recover tool's limit; 0 means uncapped
 	// (standalone behavior — the CLI is the bounded-review path there).
 	RecoverMaxLimit int
+	// MaxScriptBytes overrides the reversal-script payload budget
+	// (recovery.Generator.SetMaxScriptBytes) the recover tool enforces before
+	// rendering. 0 means "leave it alone" — the Generator already defaults to
+	// recovery.DefaultMaxScriptBytes (2 GiB, #654) on its own, so standalone
+	// bintrail-mcp's behavior is unchanged whether or not this field is set.
+	// The console sets it to its own tighter, shared-daemon budget (#849,
+	// internal/console's recoverMaxScriptBytes) — the console's /mcp endpoint
+	// is the same 2 GiB-by-default gap #849 closed for /api/recover, reached
+	// by the SAME row-count cap (RecoverMaxLimit) without a byte cap.
+	MaxScriptBytes int64
 	// AuditSurface tags ext.Record audit events; "" means "mcp".
 	AuditSurface string
 }
@@ -584,6 +594,13 @@ func MakeRecoverTool(cfg Config) func(context.Context, *mcp.CallToolRequest, Rec
 		rows = query.MergeResults(rows, 0, "ASC")
 
 		gen := recovery.NewForDialect(t.DB, resolver, recovery.DialectForIndex(t.DB))
+		// #849: the console sets cfg.MaxScriptBytes to its own shared-daemon
+		// budget; standalone bintrail-mcp leaves it 0, so the Generator keeps
+		// its own DefaultMaxScriptBytes (2 GiB) exactly as before this field
+		// existed.
+		if cfg.MaxScriptBytes > 0 {
+			gen.SetMaxScriptBytes(cfg.MaxScriptBytes)
+		}
 		var buf bytes.Buffer
 		n, err := gen.GenerateSQLFromRows(rows, &buf)
 		if err != nil {

--- a/internal/mcptools/mcptools_test.go
+++ b/internal/mcptools/mcptools_test.go
@@ -2,13 +2,44 @@ package mcptools
 
 import (
 	"context"
+	"database/sql"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/dbtrail/dbtrail/internal/parser"
 	"github.com/dbtrail/dbtrail/internal/query"
 )
+
+// recoverToolMockCols is the binlog_events SELECT column list the recover
+// tool's fetch expects — matches the console's own recover fixtures
+// (internal/console/api_test.go) so a mocked row scans cleanly through
+// query.Fetch.
+var recoverToolMockCols = []string{
+	"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp",
+	"gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values",
+	"changed_columns", "row_before", "row_after", "schema_version", "query_text", "query_hash",
+}
+
+// newRecoverToolTarget builds a Config+Target pair around a sqlmock DB,
+// bypassing DSN routing and schema migration (NoArchive/ResolverLoaded mirror
+// the console's own posture in internal/console/mcp.go) so MakeRecoverTool
+// exercises the real fetch → GenerateSQLFromRows path.
+func newRecoverToolTarget(db *sql.DB, maxScriptBytes int64) Config {
+	return Config{
+		Resolve: func(ctx context.Context, _ string) (*Target, error) {
+			return &Target{
+				DB:             db,
+				NoArchive:      true,
+				ResolverLoaded: true, // Resolver stays nil: all-column WHERE fallback, no metadata query
+			}, nil
+		},
+		MaxScriptBytes: maxScriptBytes,
+	}
+}
 
 // resultText extracts the text of a tool result's first content item.
 func resultText(res *mcp.CallToolResult) string {
@@ -123,6 +154,84 @@ func TestNewServerRegistersTools(t *testing.T) {
 	s := NewServer(Config{Version: "test"})
 	if s == nil {
 		t.Fatal("NewServer returned nil")
+	}
+}
+
+// TestRecoverToolMaxScriptBytesEnforced is the #849 (item 1) repro: the
+// console's /mcp recover tool is a FOURTH script-rendering code path (besides
+// /api/recover, its auto-cascade branch, and /api/recover-cascade) that a
+// code review found still left at recovery.DefaultMaxScriptBytes (2 GiB)
+// despite already sharing the console's row-count cap (RecoverMaxLimit). A
+// small cfg.MaxScriptBytes must make the tool refuse over-budget rows with a
+// *recovery.ScriptBudgetError surfaced as an MCP tool error — proving
+// mcptools.go actually calls gen.SetMaxScriptBytes(cfg.MaxScriptBytes) rather
+// than leaving the Generator's own default in place.
+func TestRecoverToolMaxScriptBytesEnforced(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	ts := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	rowAfter := []byte(`{"id":42,"blob":"` + strings.Repeat("x", 4096) + `"}`) // well over a 1024-byte budget
+	rows := sqlmock.NewRows(recoverToolMockCols).AddRow(
+		int64(1), "bin.000001", int64(4), int64(40), ts,
+		nil, nil, "app", "users", int64(parser.EventInsert), "42",
+		nil, nil, rowAfter, int64(0), nil, nil,
+	)
+	mock.ExpectQuery("FROM binlog_events").WillReturnRows(rows)
+
+	cfg := newRecoverToolTarget(db, 1024) // tighter than the 4 KB+ row payload
+	res, _, _ := MakeRecoverTool(cfg)(context.Background(), nil, RecoverArgs{Schema: "app", Table: "users"})
+
+	if !res.IsError {
+		t.Fatalf("expected the tool to refuse over budget, got: %s", resultText(res))
+	}
+	if !strings.Contains(resultText(res), "script-size budget") {
+		t.Errorf("error text should surface the ScriptBudgetError, got: %s", resultText(res))
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+// TestRecoverToolMaxScriptBytesZeroKeepsDefault proves the OTHER half of the
+// #849 fix: standalone bintrail-mcp (which never sets Config.MaxScriptBytes,
+// so it stays the zero value) must render EXACTLY as it did before this
+// field existed — the Generator's own DefaultMaxScriptBytes (2 GiB), not some
+// small implicit console-shaped budget. The row here is ordinary-sized, so
+// the assertion is simply that it succeeds; TestRecoverToolMaxScriptBytesEnforced
+// above already proves a small explicit budget DOES refuse, so together they
+// pin that 0 truly means "don't touch the Generator's default" rather than
+// "budget of zero bytes" (which SetMaxScriptBytes treats as disabling the
+// guard, not the same as never calling it).
+func TestRecoverToolMaxScriptBytesZeroKeepsDefault(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	ts := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	rows := sqlmock.NewRows(recoverToolMockCols).AddRow(
+		int64(1), "bin.000001", int64(4), int64(40), ts,
+		nil, nil, "app", "users", int64(parser.EventInsert), "42",
+		nil, nil, []byte(`{"id":42,"email":"a@x"}`), int64(0), nil, nil,
+	)
+	mock.ExpectQuery("FROM binlog_events").WillReturnRows(rows)
+
+	cfg := newRecoverToolTarget(db, 0) // standalone posture: field left unset
+	res, _, _ := MakeRecoverTool(cfg)(context.Background(), nil, RecoverArgs{Schema: "app", Table: "users"})
+
+	if res.IsError {
+		t.Fatalf("standalone posture (MaxScriptBytes=0) must not refuse an ordinary recovery: %s", resultText(res))
+	}
+	if !strings.Contains(resultText(res), "DELETE FROM") {
+		t.Errorf("expected a DELETE in the undo SQL, got:\n%s", resultText(res))
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
 	}
 }
 

--- a/internal/mcptools/mcptools_test.go
+++ b/internal/mcptools/mcptools_test.go
@@ -165,7 +165,12 @@ func TestNewServerRegistersTools(t *testing.T) {
 // small cfg.MaxScriptBytes must make the tool refuse over-budget rows with a
 // *recovery.ScriptBudgetError surfaced as an MCP tool error — proving
 // mcptools.go actually calls gen.SetMaxScriptBytes(cfg.MaxScriptBytes) rather
-// than leaving the Generator's own default in place.
+// than leaving the Generator's own default in place. It also pins the code
+// review's follow-up on this same tool: the surfaced message must not leak
+// ScriptBudgetError.Error()'s raw "raise/disable the budget (0 = unlimited)"
+// phrasing — advice aimed at a Go caller of SetMaxScriptBytes, not an MCP
+// client — and must instead point at the `bintrail recover` CLI escape hatch
+// (mirroring internal/console/api.go's writeRecoverError for the HTTP paths).
 func TestRecoverToolMaxScriptBytesEnforced(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -188,24 +193,33 @@ func TestRecoverToolMaxScriptBytesEnforced(t *testing.T) {
 	if !res.IsError {
 		t.Fatalf("expected the tool to refuse over budget, got: %s", resultText(res))
 	}
-	if !strings.Contains(resultText(res), "script-size budget") {
-		t.Errorf("error text should surface the ScriptBudgetError, got: %s", resultText(res))
+	text := resultText(res)
+	for _, want := range []string{"refusing to generate the reversal script", "bintrail recover"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("error text missing %q: %s", want, text)
+		}
+	}
+	if strings.Contains(text, "0 = unlimited") {
+		t.Errorf("error text must not leak the CLI-only '0 = unlimited' phrasing: %s", text)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Error(err)
 	}
 }
 
-// TestRecoverToolMaxScriptBytesZeroKeepsDefault proves the OTHER half of the
-// #849 fix: standalone bintrail-mcp (which never sets Config.MaxScriptBytes,
-// so it stays the zero value) must render EXACTLY as it did before this
-// field existed — the Generator's own DefaultMaxScriptBytes (2 GiB), not some
-// small implicit console-shaped budget. The row here is ordinary-sized, so
-// the assertion is simply that it succeeds; TestRecoverToolMaxScriptBytesEnforced
-// above already proves a small explicit budget DOES refuse, so together they
-// pin that 0 truly means "don't touch the Generator's default" rather than
-// "budget of zero bytes" (which SetMaxScriptBytes treats as disabling the
-// guard, not the same as never calling it).
+// TestRecoverToolMaxScriptBytesZeroKeepsDefault is a sanity check that the
+// standalone posture (Config.MaxScriptBytes left at its zero value) does not
+// spuriously refuse an ORDINARY recovery. It does NOT by itself distinguish
+// "the code never called SetMaxScriptBytes, so the Generator kept its 2 GiB
+// constructor default" from "the code called SetMaxScriptBytes(0), which
+// explicitly DISABLES the budget guard (unlimited)" — an ordinary small row
+// succeeds either way, and reproducing the actual >2 GiB payload needed to
+// tell them apart end-to-end is impractical in a unit test. That distinction
+// is what actually matters (a silent regression from "2 GiB default" to
+// "unlimited" would defeat #654's guard for every standalone caller) and is
+// pinned directly, without a giant payload, by TestConfigScriptBudgetOverride
+// below, which asserts on the decision function itself
+// (Config.scriptBudgetOverride) rather than its rendering side effect.
 func TestRecoverToolMaxScriptBytesZeroKeepsDefault(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -232,6 +246,39 @@ func TestRecoverToolMaxScriptBytesZeroKeepsDefault(t *testing.T) {
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Error(err)
+	}
+}
+
+// TestConfigScriptBudgetOverride directly pins the #849 code-review follow-up:
+// Config.MaxScriptBytes <= 0 (the standalone bintrail-mcp posture, which
+// never sets the field) must report ok=false — "leave the Generator's own
+// default alone" — never (0, true), which the recover tool would turn into
+// gen.SetMaxScriptBytes(0), and SetMaxScriptBytes treats n<=0 as "disable the
+// guard" (unlimited), not "no override." A future edit that collapsed
+// scriptBudgetOverride's `if MaxScriptBytes > 0` into always returning
+// (c.MaxScriptBytes, true) would flip standalone bintrail-mcp from a 2 GiB
+// budget to no budget at all, and this test — unlike
+// TestRecoverToolMaxScriptBytesZeroKeepsDefault, which only observes an
+// ordinary-sized row succeeding either way — would catch it immediately.
+func TestConfigScriptBudgetOverride(t *testing.T) {
+	cases := []struct {
+		name      string
+		maxBytes  int64
+		wantValue int64
+		wantOK    bool
+	}{
+		{"unset (standalone posture)", 0, 0, false},
+		{"negative", -1, 0, false},
+		{"explicit positive (console posture)", 32 << 20, 32 << 20, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := Config{MaxScriptBytes: tc.maxBytes}
+			v, ok := cfg.scriptBudgetOverride()
+			if ok != tc.wantOK || v != tc.wantValue {
+				t.Errorf("scriptBudgetOverride() = (%d, %v), want (%d, %v)", v, ok, tc.wantValue, tc.wantOK)
+			}
+		})
 	}
 }
 

--- a/internal/recovery/budget_test.go
+++ b/internal/recovery/budget_test.go
@@ -81,10 +81,22 @@ func TestEstimateScriptBytes(t *testing.T) {
 }
 
 // TestNewDefaultsBudget pins the zero-config guard (#654): New / NewForDialect
-// must seed maxScriptBytes with DefaultMaxScriptBytes. The MCP recover tool, the
-// console, and recover-cascade never call SetMaxScriptBytes, so if a constructor
-// stopped defaulting the field (zero value = unlimited) the guard would silently
-// vanish for them while every SetMaxScriptBytes-using test still passed.
+// must seed maxScriptBytes with DefaultMaxScriptBytes. This is load-bearing
+// for standalone `bintrail-mcp` recover (mcptools.Config.MaxScriptBytes left
+// at its zero value) — if a constructor stopped defaulting the field (zero
+// value = unlimited) the guard would silently vanish there while every
+// SetMaxScriptBytes-using test still passed. Every OTHER caller now sets an
+// explicit budget before rendering: the CLI recover command
+// (--max-script-bytes), the console's /api/recover and /api/recover-cascade
+// (recoverMaxScriptBytes, #849), the console's own /mcp recover tool
+// (mcptools.Config.MaxScriptBytes wired from recoverMaxScriptBytes, #849),
+// and recover-cascade's CLI/console emitters (CheckScriptBudget called
+// explicitly by cascaderecover.EmitSQL). #849's console-MCP gap — the
+// console setting Config.MaxScriptBytes nowhere, so its /mcp recover tool
+// kept the CLI-sized 2 GiB default despite already row-capping via
+// RecoverMaxLimit — is exactly the class of regression this comment used to
+// describe as "expected" and is why it's now spelled out per caller instead
+// of as one blanket "never call" statement.
 func TestNewDefaultsBudget(t *testing.T) {
 	if got := New(nil, nil).maxScriptBytes; got != DefaultMaxScriptBytes {
 		t.Errorf("New() maxScriptBytes = %d, want DefaultMaxScriptBytes (%d)", got, DefaultMaxScriptBytes)


### PR DESCRIPTION
## Problem

`handleRecover` in `internal/console/api.go` fetches up to 10,000 `query.ResultRow`s (full `row_before`/`row_after` images) and generates the reversal script into a `bytes.Buffer`. `recoverMaxLimit` (10,000) bounds row **count**, not row **size** — a wide table with megabyte BLOB/TEXT columns can blow past a sane heap budget well under 10,000 rows. Under `bintrail-console watch` the console shares the process with the capture stream, so an OOM-kill from an oversized recover also kills capture (event loss until the supervisor restarts it).

## Byte cap vs. streaming to the ResponseWriter

The issue suggested either "a byte-based cap or stream the script to the ResponseWriter." This PR implements the byte cap, not streaming: once you stream and flush headers, a mid-stream failure yields **truncated recovery SQL under an HTTP 200** — for a recovery tool that is a worse failure mode than refusing outright. A byte budget that fails loud with an actionable error matches the existing console idiom (events cap 100/1000, recover cap 1000/10000) and keeps the console's fail-loud stance (see the #654/#592 refuse-rather-than-truncate precedent already in `internal/recovery`).

## What changed

`internal/recovery.Generator` already refuses to render **before** writing a single byte, via `CheckScriptBudget`/`EstimateScriptBytes` (#654) — so the "never materialize the huge buffer" property was already there. But its zero-config default, `DefaultMaxScriptBytes`, is 2 GiB: sized for an operator-run CLI process (`bintrail recover --max-script-bytes`), not a long-lived daemon that also serves the events browser, status, and (in `watch`) capture. A 2 GiB response is also useless in a browser tab — it will never render in a `<textarea>` or survive a JSON round-trip through the tab's own JS heap.

This adds `recoverMaxScriptBytes = 32 << 20` (32 MiB) in `internal/console/api.go`, next to the existing `eventsDefaultLimit`/`recoverMaxLimit` caps, and wires it via `Generator.SetMaxScriptBytes` into every console code path that renders a reversal script:
- `handleRecover`'s plain path
- `handleRecover`'s auto-detected cascade path (`cascadeRecover`)
- the explicit `POST /api/recover-cascade` endpoint (`handleRecoverCascade`)
- **the console's own `/mcp` `recover` tool** (`internal/mcptools`) — see the code-review section below; this one was missed in the original pass and closed in this update.

The cascade paths were included deliberately, even though the issue only names `handleRecover`: both construct their own `recovery.Generator` and would otherwise keep the CLI-sized 2 GiB default, making the new guard on `handleRecover` trivially bypassable via the sibling endpoint/code path.

A `*recovery.ScriptBudgetError` refusal is mapped to an actionable HTTP 422 (`writeRecoverError`, matching the console's existing 422 idiom for refuse-and-explain cases like the coverage-gap and legacy-registry-schema errors) instead of a bare 500. The message is composed from the error's typed fields rather than reusing `ScriptBudgetError.Error()` verbatim, because that message ends with CLI-flag advice ("raise/disable the budget (0 = unlimited)") that doesn't apply to the console — there's no such knob here. The console message instead tells the operator to narrow the filter (schema/table/pk/time range) or use `bintrail recover` from the CLI, which does support `--max-script-bytes`.

## Why 32 MiB, and why no config knob

32 MiB keeps an ordinary wide-row recovery (typically KBs to low MBs of SQL) comfortably inside budget while failing fast — well before the CLI's headroom — on the pathological BLOB/TEXT-heavy window this issue is about.

No console flag or env var exposes this. Unlike the CLI's `--max-script-bytes` (a per-run choice on a process that exits when it's done), this is a shared-daemon OOM guardrail, not a tuning knob — an operator who actually needs a bigger recovery already has an escape hatch that doesn't involve loosening a safety rail on a process also running live capture: `bintrail recover` outside the daemon.

## Known residual (not fixed by this PR)

This bounds the **render** side: `GenerateSQLFromRows`'s pre-render budget check means a refusal never grows `buf`, so the peak from generation itself is eliminated. It does **not** bound the **fetch** side — `s.fetchRestricted` (and the MCP recover tool's own fetch) still materializes up to `recoverMaxLimit` (10,000) full `ResultRow`s (with decoded `row_before`/`row_after`) into memory *before* the byte-budget check ever runs, exactly mirroring how the CLI's own `--max-script-bytes` guard works (fetch first, then check). Closing that residual would require a byte-aware/streaming fetch path in `query.FetchMerged`, which is a larger change out of scope here. In practice this PR still meaningfully shrinks the blast radius: it caps the *render* doubling (the CLI's own stated peak-memory rationale for #654) at 32 MiB instead of 2 GiB, and the fetch-side row-count cap of 10,000 already existed. A byte-aware fetch cap is a reasonable follow-up if this residual proves to matter in practice.

## Code review follow-ups (this update)

A review of the first version of this PR found no critical issues but flagged four things, all addressed here:

1. **The guard was bypassable via the console's own `/mcp` `recover` tool.** `Server.mcpHandler` serves the four MCP tools in-process over `/mcp`/`/mcp/{id}`, resolving the same connManager bundles, and binds the same `RecoverMaxLimit` row cap the HTTP endpoint uses — but the tool's `GenerateSQLFromRows` call in `internal/mcptools/mcptools.go` never set a script-size budget, so it stayed at the Generator's CLI-sized 2 GiB default. An MCP client (e.g. the shipped `.mcpb` bridge / Claude Desktop) calling `recover` with a wide BLOB-heavy `limit=10000` window could still trigger the exact OOM this issue is about, unaffected by the 32 MiB fix elsewhere. Fixed by adding `mcptools.Config.MaxScriptBytes` (0 = leave standalone `bintrail-mcp` behavior byte-for-byte unchanged — it's a CLI-shaped tool, not a shared daemon, and never sets this field) and wiring `recoverMaxScriptBytes` into it from `internal/console/mcp.go`. Covered by two new unit tests in `internal/mcptools/mcptools_test.go`: one proving a small explicit budget refuses over-budget rows with a surfaced `ScriptBudgetError`, one proving `MaxScriptBytes=0` (the standalone posture) renders an ordinary recovery exactly as before this field existed.
2. **The auto-cascade fallback warning leaked the CLI-only phrasing and misdiagnosed the cause.** When the *combined* (parent + synthesized children) script exceeded budget, `handleRecover` embedded the raw `*recovery.ScriptBudgetError.Error()` — including "raise/disable the budget (0 = unlimited)", a setting the console doesn't expose — into a warning labeled "Cascade synthesis failed," even though synthesis had *succeeded* and only the render was refused. Fixed: `api.go` now special-cases `errors.As(cerr, &be)` and emits a distinct, accurate warning ("synthesized the deleted rows, but the combined script would hold ~X MiB... over the console's Y MiB budget... re-creates the parent only") with the same actionable console guidance as the 422 path, never the CLI phrasing.
3. **The cascade paths' budget wiring was untested.** Both `gen.SetMaxScriptBytes(recoverMaxScriptBytes)` calls in `recover_cascade.go` (the explicit endpoint and the auto-detected branch) could have been deleted without failing the suite. Added two integration tests (`internal/console/recover_cascade_integration_test.go`, real MySQL + real cascade synthesis via a new `seedCascadeConsoleOversized` fixture) that exercise both paths against a combined payload over budget, and strengthened `TestRecoverUnderByteBudget` to inspect the rendered SQL instead of only the statement count.
4. **A stale comment.** `internal/recovery/budget_test.go` said "the MCP recover tool, the console, and recover-cascade never call `SetMaxScriptBytes`" — no longer true, and it's the exact comment that should have caught finding #1. Rewritten to name each caller's behavior explicitly.

A second review pass on this update caught three more things, also fixed here:

- **The first version of the cascade integration fixture mutated server-global state.** To force a budget refusal it needed row images (~40 MiB) wide enough that MySQL 8's default `sort_buffer_size` (256 KB) made the cascade engine's own victim-lookup query (a `JSON_EXTRACT` filter combined with a `ROW_NUMBER() OVER (PARTITION BY ...)` window) die with `ER_OUT_OF_SORTMEMORY` (1038) before cascade synthesis — and therefore the byte-budget check — ever ran (the same class of MySQL limitation `internal/query/query.go`'s late-materialization comment documents, which doesn't cover the cascade engine's own query). The fix bumped the test MySQL instance's *global* `sort_buffer_size`/`max_sort_length` for the test's duration. That's a real risk on a MySQL instance shared across concurrently-running test packages, and `t.Cleanup` wouldn't run if the test process were killed or timed out, leaving the bump in place and potentially masking the exact bug class the late-materialization fix addresses for unrelated tests. Replaced with a fixture that spreads the same total payload across many moderate rows (260 × 160 KiB, each safely under MySQL's default sort buffer) instead of one giant row — both tests now pass at MySQL's stock settings, no global state touched.
- **`TestRecoverToolMaxScriptBytesZeroKeepsDefault` didn't actually distinguish the regression it claimed to guard against.** With `Config.MaxScriptBytes=0`, an ordinary row succeeds whether the code (a) never calls `SetMaxScriptBytes` (correct — keeps the Generator's 2 GiB default) or (b) calls `SetMaxScriptBytes(0)` (a real regression — that value means "disable the guard," i.e. unlimited). Extracted the decision into `Config.scriptBudgetOverride() (int64, bool)` and added `TestConfigScriptBudgetOverride`, a direct table test on that function, so a future refactor that collapsed the `> 0` guard away is caught without needing an impractical multi-gigabyte test payload. Also verified by grepping every `mcptools.Config{}` construction site in the repo (`cmd/bintrail-mcp`, `internal/console`) that only the console sets `MaxScriptBytes` — standalone `bintrail-mcp` is confirmed unaffected, not just assumed.
- **The console's own `/mcp` `recover` tool still leaked the CLI-only phrasing.** `ErrorResult(err)` passed `ScriptBudgetError.Error()` through verbatim, so an MCP client hitting the budget on either surface got "raise/disable the budget (0 = unlimited)" advice aimed at a Go caller of `SetMaxScriptBytes`, not an MCP client. Fixed to build a message from the error's typed fields and point at the `bintrail recover` CLI escape hatch, mirroring `writeRecoverError` on the HTTP side.

## Tests

Unit (`internal/console/api_test.go`):
- `TestRecoverUnderByteBudget` — an ordinary small recovery still returns 200 with generated SQL, now asserting on the rendered SQL content, not just the statement count.
- `TestRecoverOverByteBudget` — 40 rows × 1 MiB each (well under the 10,000-row cap, deliberately NOT a single giant row) whose combined estimated payload exceeds the 32 MiB budget returns 422 with the actionable message, and asserts the response never references the CLI-only "0 = unlimited" phrasing.

Unit (`internal/mcptools/mcptools_test.go`):
- `TestRecoverToolMaxScriptBytesEnforced` — a small explicit `Config.MaxScriptBytes` refuses an over-budget row with a surfaced, non-CLI-leaking `ScriptBudgetError` message.
- `TestRecoverToolMaxScriptBytesZeroKeepsDefault` — `Config.MaxScriptBytes=0` (the standalone `bintrail-mcp` posture) renders an ordinary recovery normally.
- `TestConfigScriptBudgetOverride` — direct table test on `Config.scriptBudgetOverride()` pinning that an unset/negative `MaxScriptBytes` reports "don't touch the Generator's default," not "call `SetMaxScriptBytes(0)`."

Integration (`internal/console/recover_cascade_integration_test.go`, real MySQL + real cascade synthesis):
- `TestIntegrationRecoverCascade_overByteBudget` — the explicit `POST /api/recover-cascade` endpoint refuses with 422 when the combined script is over budget.
- `TestIntegrationRecover_autoCascade_overByteBudget` — the auto-detected cascade branch of `POST /api/recover` degrades to the plain (parent-only) recovery with an accurate, non-leaking warning when the combined script is over budget.

`go build ./...`, `go vet ./...`, `go vet -tags integration ./...`, and `go test -race ./internal/console/... ./internal/mcptools/... ./internal/recovery/... -count=1` all pass. The two new integration tests were also run directly against a local Docker MySQL (`go test -tags integration -race ./internal/console/...`) and the full console integration suite was re-run clean afterward.

Closes #849

🤖 Generated with [Claude Code](https://claude.com/claude-code)
