### PR TITLE
ext: run source jobs on the stream and agent daemons

### DIFF
--- a/cliapp/agent.go
+++ b/cliapp/agent.go
@@ -378,6 +378,16 @@ func runAgent(cmd *cobra.Command, args []string) error {
 		identPtr := &atomic.Pointer[byos.SourceIdentity]{}
 		identPtr.Store(&sourceIdent)
 
+		// Extension source jobs (ext.RegisterSourceJob) run alongside the BYOS
+		// stream, same contract as under `stream`/`up`: daemon-scoped
+		// secondary work, never fatal to capture, no-op in the stock binary.
+		// Only in BYOS mode — without --source-dsn there is no live source to
+		// observe — and only with an index, since a source job's persistence
+		// target is the index database (stateless BYOS keeps nothing local).
+		if src, ok := agentSourceJobInfo(); ok {
+			ext.RunSourceJobs(ctx, src)
+		}
+
 		streamErrCh := make(chan error, 1)
 		go func() {
 			streamErrCh <- runBYOSStream(ctx, handler.SourceDB, buf, &byosFlushConfig{
@@ -613,6 +623,27 @@ func (s *flushPipelineState) toFlushStatus() *agent.FlushStatus {
 		PayloadLostEvents:   s.payloadLostEvents,
 		PayloadLostBatches:  s.payloadLostBatches,
 	}
+}
+
+// agentSourceJobInfo describes the agent's capture source for the extension
+// source-job seam, and reports whether jobs should run at all. Extracted from
+// runAgent so the decision is unit-testable without a daemon (mirrors
+// streamSourceJobInfo).
+//
+// Both DSNs are required: --source-dsn is the live server a job observes, and
+// the index is the only place a job can persist what it observes — a stateless
+// BYOS agent (no --index-dsn) has neither a local destination nor a schema to
+// write into. Flavor is always MySQL: the agent carries no --source-flavor
+// flag, and its BYOS stream is the MySQL binlog reader.
+func agentSourceJobInfo() (ext.SourceJobInfo, bool) {
+	if agtSourceDSN == "" || agtIndexDSN == "" {
+		return ext.SourceJobInfo{}, false
+	}
+	return ext.SourceJobInfo{
+		SourceDSN: agtSourceDSN,
+		IndexDSN:  agtIndexDSN,
+		Flavor:    "mysql",
+	}, true
 }
 
 // ─── BYOS streaming ────────────────────────────────────────────────────────

--- a/cliapp/sourcejob_wiring_test.go
+++ b/cliapp/sourcejob_wiring_test.go
@@ -1,0 +1,129 @@
+package cliapp
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"strings"
+	"testing"
+)
+
+// The extension source-job seam (ext.RegisterSourceJob) exists so an
+// embedding distribution can run per-source background work — identity
+// capture, sidecar collectors — for as long as a capture daemon lives.
+// These tests pin the two properties the wiring must have: every long-lived
+// capture command reaches the seam, and it reaches it exactly once.
+
+func TestStreamSourceJobInfoCarriesTheStreamsSource(t *testing.T) {
+	// The seam gets what the stream actually runs with, including the values
+	// `up` copies in via populateStreamFlags.
+	origSource, origIndex, origFlavor := strmSourceDSN, strmIndexDSN, strmFlavor
+	t.Cleanup(func() { strmSourceDSN, strmIndexDSN, strmFlavor = origSource, origIndex, origFlavor })
+
+	strmSourceDSN = "u:p@tcp(src:3306)/"
+	strmIndexDSN = "u:p@tcp(idx:3306)/bintrail_index"
+	strmFlavor = "mariadb"
+
+	got := streamSourceJobInfo()
+	if got.SourceDSN != strmSourceDSN || got.IndexDSN != strmIndexDSN || got.Flavor != "mariadb" {
+		t.Errorf("streamSourceJobInfo() = %+v, want the strm* stream configuration", got)
+	}
+}
+
+func TestAgentSourceJobInfoRequiresSourceAndIndex(t *testing.T) {
+	origSource, origIndex := agtSourceDSN, agtIndexDSN
+	t.Cleanup(func() { agtSourceDSN, agtIndexDSN = origSource, origIndex })
+
+	tests := []struct {
+		name             string
+		source, index    string
+		wantOK           bool
+		wantSrc, wantIdx string
+	}{
+		{name: "both set", source: "u:p@tcp(src:3306)/", index: "u:p@tcp(idx:3306)/bintrail_index",
+			wantOK: true, wantSrc: "u:p@tcp(src:3306)/", wantIdx: "u:p@tcp(idx:3306)/bintrail_index"},
+		// Stateless BYOS: a live source, but nowhere to persist an
+		// observation — jobs must not start and then fail on an empty DSN.
+		{name: "no index", source: "u:p@tcp(src:3306)/", index: "", wantOK: false},
+		// Query-only agent: no live source to observe at all.
+		{name: "no source", source: "", index: "u:p@tcp(idx:3306)/bintrail_index", wantOK: false},
+		{name: "neither", source: "", index: "", wantOK: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			agtSourceDSN, agtIndexDSN = tc.source, tc.index
+			got, ok := agentSourceJobInfo()
+			if ok != tc.wantOK {
+				t.Fatalf("agentSourceJobInfo() ok = %v, want %v", ok, tc.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if got.SourceDSN != tc.wantSrc || got.IndexDSN != tc.wantIdx {
+				t.Errorf("agentSourceJobInfo() = %+v, want the agent's DSNs", got)
+			}
+			if got.Flavor != "mysql" {
+				t.Errorf("agentSourceJobInfo().Flavor = %q, want \"mysql\" (the agent streams MySQL binlogs and has no flavor flag)", got.Flavor)
+			}
+		})
+	}
+}
+
+// TestSourceJobsStartOncePerDaemon is the double-fire guard. `up` delegates to
+// runStream, so a second ext.RunSourceJobs call in runUpStream — the shape the
+// wiring had before stream/agent adopted the seam — would run every registered
+// job TWICE under `up`: two identity pollers on one source, each writing the
+// same intervals. Exactly two call sites are correct: runStream (stream + up)
+// and runAgent (BYOS).
+func TestSourceJobsStartOncePerDaemon(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read cliapp dir: %v", err)
+	}
+	fset := token.NewFileSet()
+	callers := map[string]int{}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, name, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok {
+				continue
+			}
+			ast.Inspect(fn, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				sel, ok := call.Fun.(*ast.SelectorExpr)
+				if !ok || sel.Sel.Name != "RunSourceJobs" {
+					return true
+				}
+				if ident, ok := sel.X.(*ast.Ident); !ok || ident.Name != "ext" {
+					return true
+				}
+				callers[fn.Name.Name]++
+				return true
+			})
+		}
+	}
+	want := map[string]int{"runStream": 1, "runAgent": 1}
+	for fn, n := range want {
+		if callers[fn] != n {
+			t.Errorf("ext.RunSourceJobs called %d time(s) in %s, want %d", callers[fn], fn, n)
+		}
+	}
+	for fn, n := range callers {
+		if _, expected := want[fn]; !expected {
+			t.Errorf("unexpected ext.RunSourceJobs call in %s (%d): source jobs share the stream's lifecycle — "+
+				"a caller that delegates to runStream must not start them again", fn, n)
+		}
+	}
+}

--- a/cliapp/stream.go
+++ b/cliapp/stream.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/dbtrail/dbtrail/ext"
 	"github.com/dbtrail/dbtrail/internal/indexer"
 	"github.com/dbtrail/dbtrail/internal/streamdeps"
 	"github.com/dbtrail/dbtrail/internal/streamrun"
@@ -171,5 +172,26 @@ func runStream(cmd *cobra.Command, args []string) error {
 		}
 	}()
 
+	// Extension source jobs (ext.RegisterSourceJob) run alongside the stream
+	// for its whole lifetime: same contract as rotation under `up` —
+	// daemon-scoped secondary work, never fatal to capture, no-op in the stock
+	// binary. This is the single wiring point for every daemon that ends up
+	// here, `bintrail stream` itself and `bintrail up` (which delegates to
+	// runStream after populateStreamFlags has copied its DSNs into the strm*
+	// globals). ctx is the signal-bound child installed above, so the jobs
+	// stop draining when the stream does.
+	ext.RunSourceJobs(ctx, streamSourceJobInfo())
+
 	return streamrun.One(ctx, streamConfigFromFlags())
+}
+
+// streamSourceJobInfo describes the stream's capture source for the extension
+// source-job seam. Extracted from runStream so the mapping is unit-testable
+// without starting a daemon (mirrors consoleapp's mainSourceJobInfo).
+func streamSourceJobInfo() ext.SourceJobInfo {
+	return ext.SourceJobInfo{
+		SourceDSN: strmSourceDSN,
+		IndexDSN:  strmIndexDSN,
+		Flavor:    strmFlavor,
+	}
 }

--- a/cliapp/up.go
+++ b/cliapp/up.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/dbtrail/dbtrail/ext"
 	"github.com/dbtrail/dbtrail/internal/cliutil"
 	"github.com/dbtrail/dbtrail/internal/doctor"
 	"github.com/dbtrail/dbtrail/internal/indexer"
@@ -203,15 +202,15 @@ func runUpStream(cmd *cobra.Command, args []string) error {
 	rotation.StartLoop(rotCtx, func() rotation.Settings { return upRotationCfg }, func() []rotation.RotateTarget {
 		return []rotation.RotateTarget{{DSN: upIndexDSN}}
 	})
-	// Extension source jobs (ext.RegisterSourceJob) share the same lifecycle
-	// and contract as rotation: secondary daemon-scoped
-	// work that must never be fatal to the stream. No-op in the stock binary.
-	// Flavor is the value the stream below actually runs with: `up` has no
-	// --source-flavor flag of its own, so strmFlavor holds streamCmd's default
-	// ("mysql") or the BINTRAIL_SOURCE_FLAVOR override, which bindCommandEnv
-	// (streamCmd) applied at flag-binding time; populateStreamFlags above
-	// deliberately leaves it untouched.
-	ext.RunSourceJobs(rotCtx, ext.SourceJobInfo{SourceDSN: upSourceDSN, IndexDSN: upIndexDSN, Flavor: strmFlavor})
+	// Extension source jobs (ext.RegisterSourceJob) are NOT started here: they
+	// share the stream's lifecycle, so runStream owns the one call site for
+	// both `up` and plain `stream` (starting them here too would run every
+	// registered job twice under `up`). populateStreamFlags above has already
+	// copied up's DSNs into the strm* globals runStream reads, and flavor is
+	// the value the stream actually runs with — `up` has no --source-flavor
+	// flag of its own, so strmFlavor holds streamCmd's default ("mysql") or
+	// the BINTRAIL_SOURCE_FLAVOR override that bindCommandEnv(streamCmd)
+	// applied at flag-binding time.
 	return runStream(cmd, args)
 }
 

--- a/ext/sourcejob.go
+++ b/ext/sourcejob.go
@@ -7,8 +7,10 @@ import (
 
 // SourceJobInfo describes one capture source at daemon startup, handed to
 // every registered source job. Flavor names the source family; core wiring
-// currently only ever carries "mysql" or "mariadb" (the flavor `bintrail up`
-// streams with).
+// currently only ever carries "mysql" or "mariadb" (the flavor the daemon
+// streams with; `bintrail agent` has no flavor flag and always reports
+// "mysql"). Both DSNs are populated by every core wiring point: a job that
+// needs somewhere to persist what it observes can rely on IndexDSN being set.
 type SourceJobInfo struct {
 	SourceDSN string
 	IndexDSN  string
@@ -19,8 +21,10 @@ type SourceJobInfo struct {
 var sourceJobs []func(ctx context.Context, src SourceJobInfo)
 
 // RegisterSourceJob registers a background job to run alongside the daemon
-// lifecycle. Today the only core wiring point is the `bintrail up` daemon;
-// other daemons may adopt it in the future. Same startup-only contract as the
+// lifecycle. Core wiring points: `bintrail stream` (which `bintrail up`
+// delegates to), `bintrail agent` in BYOS mode, and the console daemon's
+// `watch` main source plus every monitor-supervised source. Same
+// startup-only contract as the
 // other seams: call from main() before command dispatch; not safe for
 // concurrent use with command execution. Registering a nil job panics
 // immediately so the misuse fails at startup, not at daemon boot.
@@ -32,8 +36,9 @@ func RegisterSourceJob(job func(ctx context.Context, src SourceJobInfo)) {
 }
 
 // RunSourceJobs launches every registered source job, each on its own
-// goroutine, and returns immediately. Called by the core at `bintrail up`
-// startup, with a context bound to the daemon lifetime — the passed ctx
+// goroutine, and returns immediately. Called by the core once per capture
+// source at daemon startup, with a context bound to the daemon lifetime —
+// the passed ctx
 // bounds the jobs' lifetime. Jobs are secondary and must never be fatal to
 // the daemon; the core enforces that here: a panicking job is recovered and
 // logged, never propagated to the stream, and a slow job cannot block


### PR DESCRIPTION
## Problem

`ext.RegisterSourceJob` lets an embedding distribution run per-source background work for as long as a capture daemon lives. Only three wiring points ever called it: `bintrail up`, the console daemon's `watch` main source, and the console monitor's supervised streams.

The two capture paths a plain deployment actually runs — `bintrail stream` (the systemd unit) and `bintrail agent` (BYOS) — never started any source job. A distribution's per-source collector was simply absent there, with no warning anywhere: the daemon looks healthy and the job never existed.

## Change

- **`runStream`** starts the jobs on the stream's own signal-bound context. That makes it the single wiring point for both `stream` and `up`, which delegates to it after `populateStreamFlags` copies its DSNs into the `strm*` globals.
- **`up`'s own call is removed.** Keeping both would run every registered job twice on one source.
- **`runAgent`** starts them in BYOS mode when the agent has both a source and an index — a live server to observe, and somewhere to persist what it observes. A stateless BYOS agent (no `--index-dsn`) has neither.

The flags→`ext.SourceJobInfo` mapping is extracted into `streamSourceJobInfo` / `agentSourceJobInfo` so it is unit-testable without starting a daemon (mirrors `consoleapp`'s `mainSourceJobInfo`).

## Tests

- `TestStreamSourceJobInfoCarriesTheStreamsSource` / `TestAgentSourceJobInfoRequiresSourceAndIndex` — the mapping and the BYOS gating (both DSNs required, flavor always `mysql` since the agent has no `--source-flavor`).
- `TestSourceJobsStartOncePerDaemon` — a package-wide AST guard pinning exactly two call sites (`runStream`, `runAgent`). The double-fire hazard is invisible at review time otherwise, because `up` reaches the seam through delegation rather than a visible call.

`go test -race ./cliapp/... ./ext/...` green.

## Compatibility

No behavior change in the stock binary: with nothing registered, `RunSourceJobs` is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)