### PR TITLE
indexer: capture the transaction's microsecond commit timestamp

### DIFF
--- a/docs/query-and-recovery.md
+++ b/docs/query-and-recovery.md
@@ -87,6 +87,21 @@ Notes:
 - Under an active `--profile`, `query_text` and `query_hash` are withheld on **every** row, not just rows of flagged tables — a single statement can touch several tables, so its text can embed values of a column your profile redacts even when the row itself belongs to another table.
 - The web console never shows these fields (same boundary as `connection_id`).
 
+### Commit time: `commit_ts_us`
+
+Every event carries an `event_timestamp` with **one-second** resolution — that is all the binlog's common event header holds. A busy server commits many transactions inside one second, so within that second you can see event *order* but not event *time*.
+
+MySQL 8.0.1 and later also write the transaction's commit instant in **microseconds** into the GTID event, and `bintrail` stores it as `commit_ts_us` (microseconds since the Unix epoch, shown in the `json` and `csv` output):
+
+```
+"event_timestamp": "2026-02-19 14:00:00",
+"commit_ts_us": 1771509600123456
+```
+
+It is captured with no configuration: GTIDs do **not** have to be enabled, because MySQL stamps the value on the anonymous GTID event it writes with `gtid_mode=OFF` too. `commit_ts_us` is `NULL` for events indexed before the column existed, on MariaDB (its GTID event carries no commit timestamp), and on MySQL older than 8.0.1 — treat `NULL` as "only the one-second timestamp is known for this event", never as a tie.
+
+Two things it makes possible that the second-resolution timestamp does not: ordering two changes that landed in the same second, and lining an indexed change up with any other microsecond-stamped record — an audit-log entry, an application trace, a slow-query log line.
+
 ---
 
 ## Parquet Archive Queries

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -45,6 +45,10 @@ var BinlogEventColumns = []baseline.Column{
 	{Name: "schema_version", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
 	{Name: "query_text", MySQLType: "text", ParquetType: baseline.MysqlToParquetNode("text")},
 	{Name: "query_hash", MySQLType: "varchar", ParquetType: baseline.MysqlToParquetNode("varchar")},
+	// commit_ts_us is BIGINT UNSIGNED microseconds since epoch (#18); the Int64
+	// Parquet node it maps to holds it losslessly (epoch µs stays far below
+	// 2^63 — year 294247).
+	{Name: "commit_ts_us", MySQLType: "bigint", Unsigned: true, ParquetType: baseline.MysqlToParquetNode2("bigint", true)},
 }
 
 // ArchivePartition writes all rows from the named partition of binlog_events
@@ -89,7 +93,7 @@ func ArchivePartition(ctx context.Context, db *sql.DB, dbName, partition, output
 	q := fmt.Sprintf(
 		"SELECT event_id, binlog_file, start_pos, end_pos, event_timestamp,"+
 			" gtid, connection_id, schema_name, table_name, event_type, pk_values,"+
-			" changed_columns, row_before, row_after, schema_version, query_text, query_hash"+
+			" changed_columns, row_before, row_after, schema_version, query_text, query_hash, commit_ts_us"+
 			" FROM `%s`.`binlog_events` PARTITION (`%s`) ORDER BY event_id",
 		dbName, partition,
 	)
@@ -125,11 +129,13 @@ func ArchivePartition(ctx context.Context, db *sql.DB, dbName, partition, output
 			schemaVersion  sql.NullInt32
 			queryText      sql.NullString
 			queryHash      sql.NullString
+			commitTsUS     sql.NullInt64
 		)
 		if err := rows.Scan(
 			&eventID, &binlogFile, &startPos, &endPos, &eventTimestamp,
 			&gtid, &connID, &schemaName, &tableName, &eventType, &pkValues,
 			&changedColumns, &rowBefore, &rowAfter, &schemaVersion, &queryText, &queryHash,
+			&commitTsUS,
 		); err != nil {
 			return rowCount, fmt.Errorf("scan row: %w", err)
 		}
@@ -137,6 +143,10 @@ func ArchivePartition(ctx context.Context, db *sql.DB, dbName, partition, output
 		connIDStr := ""
 		if connID.Valid {
 			connIDStr = strconv.FormatInt(connID.Int64, 10)
+		}
+		commitTsStr := ""
+		if commitTsUS.Valid {
+			commitTsStr = strconv.FormatInt(commitTsUS.Int64, 10)
 		}
 		eventTimestampStr := ""
 		if eventTimestamp.Valid {
@@ -161,6 +171,7 @@ func ArchivePartition(ctx context.Context, db *sql.DB, dbName, partition, output
 			strconv.FormatInt(int64(schemaVersion.Int32), 10),
 			queryText.String,
 			queryHash.String,
+			commitTsStr,
 		}
 		nulls := []bool{
 			false, // event_id (AUTO_INCREMENT, cannot be NULL)
@@ -180,6 +191,7 @@ func ArchivePartition(ctx context.Context, db *sql.DB, dbName, partition, output
 			!schemaVersion.Valid,
 			!queryText.Valid,
 			!queryHash.Valid,
+			!commitTsUS.Valid,
 		}
 
 		if err := w.WriteRow(values, nulls); err != nil {

--- a/internal/archive/archive_integration_test.go
+++ b/internal/archive/archive_integration_test.go
@@ -203,3 +203,65 @@ func TestArchivePartition_queryTextRoundTrip(t *testing.T) {
 			row[0][textIdx], row[0][hashIdx])
 	}
 }
+
+// TestArchivePartition_commitTsRoundTrip pins the #18 write half against a real
+// index: the microsecond stamp reaches the Parquet file EXACTLY, and an event
+// without one is written as a real Parquet NULL rather than a zero (which would
+// read back as the epoch). The scan/values/nulls triple in ArchivePartition is
+// positional — this is what catches a column added to the SELECT and forgotten
+// in one of the other two.
+func TestArchivePartition_commitTsRoundTrip(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	const stamped = uint64(1771509600123456)
+	ts := "2026-02-19 14:00:00"
+	if _, err := db.Exec(`INSERT INTO binlog_events
+		(binlog_file, start_pos, end_pos, event_timestamp,
+		 schema_name, table_name, event_type, pk_values, row_after, commit_ts_us)
+		VALUES (?, 100, 200, ?, 'mydb', 'orders', 2, '1', '{"id":1}', ?)`,
+		"binlog.000001", ts, stamped,
+	); err != nil {
+		t.Fatalf("insert row with commit_ts_us failed: %v", err)
+	}
+	// Second row: no commit timestamp (MariaDB, or pre-8.0.1 MySQL).
+	testutil.InsertEvent(t, db, "binlog.000001", 300, 400, ts, nil, "mydb", "orders", 1, "2",
+		nil, nil, []byte(`{"id":2}`))
+
+	outPath := filepath.Join(t.TempDir(), "p_future.parquet")
+	n, err := ArchivePartition(context.Background(), db, dbName, "p_future", outPath, "none")
+	if err != nil {
+		t.Fatalf("ArchivePartition failed: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("rowCount = %d, want 2", n)
+	}
+
+	rf, err := os.Open(outPath)
+	if err != nil {
+		t.Fatalf("open archived parquet: %v", err)
+	}
+	defer rf.Close()
+	info, _ := rf.Stat()
+	pf, err := parquet.OpenFile(rf, info.Size())
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+	idx := parquetColumnIndex(t, pf, "commit_ts_us")
+	reader := parquet.NewReader(pf)
+	defer reader.Close()
+
+	row := make([]parquet.Row, 1)
+	if _, err := reader.ReadRows(row); err != nil {
+		t.Fatalf("ReadRows row 0: %v", err)
+	}
+	if got := row[0][idx].Int64(); uint64(got) != stamped {
+		t.Errorf("row 0 commit_ts_us = %d, want %d", got, stamped)
+	}
+	if _, err := reader.ReadRows(row); err != nil {
+		t.Fatalf("ReadRows row 1: %v", err)
+	}
+	if !row[0][idx].IsNull() {
+		t.Errorf("row 1 commit_ts_us must be a real Parquet NULL, got %v", row[0][idx])
+	}
+}

--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -15,8 +15,8 @@ import (
 )
 
 func TestBinlogEventColumns_count(t *testing.T) {
-	if len(BinlogEventColumns) != 17 {
-		t.Errorf("expected 17 columns, got %d", len(BinlogEventColumns))
+	if len(BinlogEventColumns) != 18 {
+		t.Errorf("expected 18 columns, got %d", len(BinlogEventColumns))
 	}
 }
 
@@ -25,7 +25,7 @@ func TestBinlogEventColumns_names(t *testing.T) {
 		"event_id", "binlog_file", "start_pos", "end_pos",
 		"event_timestamp", "gtid", "connection_id", "schema_name", "table_name",
 		"event_type", "pk_values", "changed_columns", "row_before", "row_after",
-		"schema_version", "query_text", "query_hash",
+		"schema_version", "query_text", "query_hash", "commit_ts_us",
 	}
 	for i, want := range wantNames {
 		if i >= len(BinlogEventColumns) {

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -95,6 +95,11 @@ func (b *Buffer) Insert(events []event.Event) {
 		}
 
 		var queryText *string
+		var commitTsUS *uint64
+		if ev.CommitTsUS != 0 {
+			v := ev.CommitTsUS
+			commitTsUS = &v
+		}
 		if ev.QueryText != "" {
 			s := ev.QueryText
 			queryText = &s
@@ -116,6 +121,7 @@ func (b *Buffer) Insert(events []event.Event) {
 			RowAfter:       ev.RowAfter,
 			SchemaVersion:  ev.SchemaVersion,
 			QueryText:      queryText,
+			CommitTsUS:     commitTsUS,
 			// QueryHash stays nil: the digest is an index-side enrichment
 			// (STATEMENT_DIGEST on the index connection) and the BYOS buffer
 			// has no index database.

--- a/internal/console/api_test.go
+++ b/internal/console/api_test.go
@@ -148,13 +148,14 @@ func TestEventsHandlerIncludesConnectionID(t *testing.T) {
 		"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp",
 		"gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values",
 		"changed_columns", "row_before", "row_after", "schema_version", "query_text", "query_hash",
+		"commit_ts_us",
 	}
 	ts := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
 	rows := sqlmock.NewRows(cols).AddRow(
 		int64(1), "bin.000001", int64(4), int64(40), ts,
 		nil, int64(4242), "app", "users", int64(parser.EventUpdate), "7",
 		[]byte(`["email"]`), []byte(`{"email":"a@x"}`), []byte(`{"email":"b@x"}`), int64(0),
-		"UPDATE users SET email='b@x'", "cafe0000",
+		"UPDATE users SET email='b@x'", "cafe0000", int64(1767322445000123),
 	)
 	mock.ExpectQuery("FROM binlog_events").WillReturnRows(rows)
 
@@ -219,6 +220,7 @@ func TestRecoverIsReadOnly(t *testing.T) {
 		"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp",
 		"gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values",
 		"changed_columns", "row_before", "row_after", "schema_version", "query_text", "query_hash",
+		"commit_ts_us",
 	}
 	ts := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
 	// An INSERT event (event_type=1); its reversal is a DELETE built from
@@ -228,7 +230,7 @@ func TestRecoverIsReadOnly(t *testing.T) {
 		int64(1), "bin.000001", int64(4), int64(40), ts,
 		nil, nil, "app", "users", int64(parser.EventInsert), "42",
 		nil, nil, []byte(`{"id":42,"email":"a@x"}`), int64(0),
-		nil, nil,
+		nil, nil, nil,
 	)
 	mock.ExpectQuery("FROM binlog_events").WillReturnRows(resultRows)
 
@@ -273,13 +275,14 @@ func TestRecoverUnderByteBudget(t *testing.T) {
 		"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp",
 		"gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values",
 		"changed_columns", "row_before", "row_after", "schema_version", "query_text", "query_hash",
+		"commit_ts_us",
 	}
 	ts := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
 	resultRows := sqlmock.NewRows(cols).AddRow(
 		int64(1), "bin.000001", int64(4), int64(40), ts,
 		nil, nil, "app", "users", int64(parser.EventInsert), "42",
 		nil, nil, []byte(`{"id":42,"email":"a@x"}`), int64(0),
-		nil, nil,
+		nil, nil, nil,
 	)
 	mock.ExpectQuery("FROM binlog_events").WillReturnRows(resultRows)
 
@@ -333,6 +336,7 @@ func TestRecoverOverByteBudget(t *testing.T) {
 		"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp",
 		"gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values",
 		"changed_columns", "row_before", "row_after", "schema_version", "query_text", "query_hash",
+		"commit_ts_us",
 	}
 	ts := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
 	const (
@@ -350,7 +354,7 @@ func TestRecoverOverByteBudget(t *testing.T) {
 			int64(i+1), "bin.000001", int64(4), int64(40), ts,
 			nil, nil, "app", "users", int64(parser.EventInsert), fmt.Sprintf("%d", i),
 			nil, nil, rowAfter, int64(0),
-			nil, nil,
+			nil, nil, nil,
 		)
 	}
 	mock.ExpectQuery("FROM binlog_events").WillReturnRows(resultRows)

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -82,8 +82,27 @@ type Event struct {
 	// capture is opt-in on the source (#699). Statement-scoped: a multi-statement
 	// transaction stamps each statement's own text onto its rows.
 	QueryText string
-	Schema    string
-	Table     string
+	// CommitTsUS is the transaction's commit time in MICROSECONDS since the
+	// Unix epoch, read from the GTID event's immediate_commit_timestamp
+	// (MySQL 8.0.1+). Zero when unavailable: a MariaDB source (neither its GTID
+	// event nor its ANNOTATE_ROWS event carries one) or a MySQL older than
+	// 8.0.1. GTIDs do NOT have to be enabled — 8.0 stamps the value on the
+	// ANONYMOUS_GTID_EVENT it writes under gtid_mode=OFF as well, which the
+	// integration test in internal/parser pins against a live server.
+	//
+	// The common-header timestamp every event already carries resolves to one
+	// SECOND, which is far coarser than the rate at which a busy server
+	// commits — inside one second, event order is knowable but event TIME is
+	// not. Capturing the microsecond value keeps the fidelity the source
+	// wrote down instead of discarding it at the parser; correlating an
+	// indexed change against any other microsecond-stamped record (audit
+	// logs, application traces) is impossible after it is lost.
+	//
+	// Transaction-scoped, exactly like ConnectionID: set from the GTID event
+	// that opens the transaction and stamped on every row event inside it.
+	CommitTsUS uint64
+	Schema     string
+	Table      string
 	// EventType numeric values are a PERSISTENCE CONTRACT: stored as a number in
 	// binlog_events.event_type and filtered by it. Never renumber existing values.
 	EventType     EventType

--- a/internal/indexer/committs_integration_test.go
+++ b/internal/indexer/committs_integration_test.go
@@ -1,0 +1,120 @@
+//go:build integration
+
+package indexer
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/parser"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestEnsureSchemaAddsCommitTsColumn simulates a pre-#18 install by dropping
+// the column, then asserts EnsureSchema restores it nullable and is idempotent.
+// Nullability is the load-bearing part: every row indexed before this column
+// existed, and every row from a source that writes no commit timestamp, must
+// read back as NULL rather than as the epoch.
+func TestEnsureSchemaAddsCommitTsColumn(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	testutil.MustExec(t, db, `ALTER TABLE binlog_events DROP COLUMN commit_ts_us`)
+
+	if err := EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	var dataType, isNullable, columnType string
+	err := db.QueryRow(`SELECT DATA_TYPE, IS_NULLABLE, COLUMN_TYPE FROM information_schema.COLUMNS
+		WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'binlog_events' AND COLUMN_NAME = 'commit_ts_us'`).
+		Scan(&dataType, &isNullable, &columnType)
+	if err != nil {
+		t.Fatalf("commit_ts_us not found after EnsureSchema: %v", err)
+	}
+	if dataType != "bigint" {
+		t.Errorf("commit_ts_us DATA_TYPE = %q, want bigint", dataType)
+	}
+	if isNullable != "YES" {
+		t.Errorf("commit_ts_us IS_NULLABLE = %q, want YES (rows indexed before this column must read back NULL)", isNullable)
+	}
+	// Epoch microseconds already exceed 2^50 and grow; an accidental signed
+	// column would still fit, but unsigned is what the schema declares and the
+	// archive column mirrors, so a drift between the two is worth catching.
+	if columnType != "bigint unsigned" {
+		t.Errorf("commit_ts_us COLUMN_TYPE = %q, want \"bigint unsigned\"", columnType)
+	}
+
+	if err := EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema (second run): %v", err)
+	}
+}
+
+// TestInsertBatch_commitTsRoundTrip drives the #18 write path against a real
+// index MySQL: a captured microsecond stamp round-trips EXACTLY (no truncation
+// to seconds anywhere between the parser and the column), and an event without
+// one stores NULL — the two states a consumer has to tell apart.
+func TestInsertBatch_commitTsRoundTrip(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	// A stamp with non-zero sub-second digits: truncation to seconds anywhere
+	// in the path would land on ...000000 and this value would not survive.
+	const stamped = uint64(1767225600_123456)
+	ts := time.Unix(int64(stamped/1_000_000), 0).UTC()
+
+	idx := New(db, 100)
+	n, err := idx.InsertBatch([]parser.Event{
+		{
+			BinlogFile: "binlog.000001", StartPos: 100, EndPos: 200, Timestamp: ts,
+			CommitTsUS: stamped,
+			Schema:     "shop", Table: "orders", EventType: parser.EventInsert,
+			PKValues: "1", RowAfter: map[string]any{"id": 1},
+		},
+		{
+			// No commit timestamp: MariaDB, or MySQL older than 8.0.1.
+			BinlogFile: "binlog.000001", StartPos: 200, EndPos: 300, Timestamp: ts,
+			Schema:   "shop", Table: "orders", EventType: parser.EventInsert,
+			PKValues: "2", RowAfter: map[string]any{"id": 2},
+		},
+	})
+	if err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("InsertBatch wrote %d rows, want 2", n)
+	}
+
+	rows, err := db.Query(`SELECT pk_values, commit_ts_us FROM binlog_events ORDER BY pk_values`)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	defer rows.Close()
+
+	got := map[string]*uint64{}
+	for rows.Next() {
+		var pk string
+		var us *uint64
+		if err := rows.Scan(&pk, &us); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		got[pk] = us
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate: %v", err)
+	}
+
+	if got["1"] == nil {
+		t.Fatalf("row 1: commit_ts_us is NULL, want %d", stamped)
+	}
+	if *got["1"] != stamped {
+		t.Errorf("row 1: commit_ts_us = %d, want %d (exact microseconds, no rounding)", *got["1"], stamped)
+	}
+	if got["2"] != nil {
+		t.Errorf("row 2: commit_ts_us = %d, want NULL — a zero from the parser means "+
+			"\"this source wrote no commit timestamp\", and storing it as 0 would read as the epoch", *got["2"])
+	}
+}

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -42,12 +42,12 @@ var WriteTimeout = DefaultWriteTimeout
 // insertColumnCount must equal its column count — pinned by a unit test.
 const insertColumnsSQL = `binlog_file, start_pos, end_pos, event_timestamp, gtid, connection_id, ` +
 	`schema_name, table_name, event_type, pk_values, ` +
-	`changed_columns, row_before, row_after, schema_version, query_text, query_hash`
+	`changed_columns, row_before, row_after, schema_version, query_text, query_hash, commit_ts_us`
 
 const (
 	// insertColumnCount is the number of columns (= placeholders per row) in
 	// insertBatch's multi-row INSERT.
-	insertColumnCount = 16
+	insertColumnCount = 17
 	// maxPreparedStmtParams is MySQL's hard cap on placeholders in one
 	// prepared statement (ER_PS_MANY_PARAM, error 1390).
 	maxPreparedStmtParams = 65535
@@ -231,6 +231,7 @@ func (idx *Indexer) insertBatch(batch []event.Event) (int64, error) {
 			ev.SchemaVersion,
 			nullOrString(sanitized[i]),
 			nullOrString(digests[sanitized[i]]),
+			nullOrUint64(ev.CommitTsUS),
 		)
 	}
 
@@ -523,6 +524,16 @@ func nullOrUint32(v uint32) any {
 	return v
 }
 
+// nullOrUint64 mirrors nullOrUint32 for the microsecond commit timestamp: zero
+// is the parser's "the source wrote none" value (MariaDB, pre-8.0.1 MySQL), and
+// it must reach the column as NULL rather than as the epoch.
+func nullOrUint64(v uint64) any {
+	if v == 0 {
+		return nil
+	}
+	return v
+}
+
 // EnsureSchema adds any columns introduced after the initial schema to
 // binlog_events, schema_snapshots, and stream_state. It is idempotent — safe
 // to call on every startup.
@@ -611,6 +622,15 @@ func EnsureSchema(db *sql.DB) error {
 	}
 	if err := ensureColumn(db, "binlog_events", "query_hash",
 		`ALTER TABLE binlog_events ADD COLUMN query_hash CHAR(64) DEFAULT NULL COMMENT 'STATEMENT_DIGEST(query_text) computed on the index connection at index time; groups statements by normalized shape (#699)' AFTER query_text`,
+	); err != nil {
+		return err
+	}
+	// commit_ts_us carries the transaction's microsecond commit timestamp from
+	// the GTID event (#18). Nullable and additive: rows indexed before this
+	// column existed keep NULL, and so do rows from sources that never write
+	// the value (MariaDB, MySQL < 8.0.1).
+	if err := ensureColumn(db, "binlog_events", "commit_ts_us",
+		`ALTER TABLE binlog_events ADD COLUMN commit_ts_us BIGINT UNSIGNED DEFAULT NULL COMMENT 'transaction commit time in microseconds since epoch, from the GTID event immediate_commit_timestamp (MySQL 8.0.1+, anonymous GTID events included); NULL on MariaDB and pre-8.0.1 MySQL' AFTER query_hash`,
 	); err != nil {
 		return err
 	}

--- a/internal/indexer/schema.go
+++ b/internal/indexer/schema.go
@@ -124,6 +124,7 @@ func buildBinlogEventsDDL(parts []string, encrypt bool) string {
     schema_version  INT UNSIGNED     NOT NULL DEFAULT 0 COMMENT 'snapshot_id from schema_snapshots at index time; enables per-row resolver lookup for recovery',
     query_text      MEDIUMTEXT       DEFAULT NULL COMMENT 'original SQL statement from ROWS_QUERY/ANNOTATE_ROWS; NULL unless binlog_rows_query_log_events (MySQL) / binlog_annotate_row_events (MariaDB) is ON at the source (#699)',
     query_hash      CHAR(64)         DEFAULT NULL COMMENT 'STATEMENT_DIGEST(query_text) computed on the index connection at index time; groups statements by normalized shape (#699)',
+    commit_ts_us    BIGINT UNSIGNED  DEFAULT NULL COMMENT 'transaction commit time in microseconds since epoch, from the GTID event immediate_commit_timestamp (MySQL 8.0.1+, anonymous GTID events included); NULL on MariaDB and pre-8.0.1 MySQL',
     PRIMARY KEY (event_id, event_timestamp),
     INDEX idx_row_lookup (schema_name, table_name, event_timestamp),
     INDEX idx_pk_hash    (schema_name, table_name, pk_hash, event_timestamp),

--- a/internal/mcptools/mcptools_test.go
+++ b/internal/mcptools/mcptools_test.go
@@ -22,6 +22,7 @@ var recoverToolMockCols = []string{
 	"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp",
 	"gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values",
 	"changed_columns", "row_before", "row_after", "schema_version", "query_text", "query_hash",
+	"commit_ts_us",
 }
 
 // newRecoverToolTarget builds a Config+Target pair around a sqlmock DB,
@@ -183,7 +184,7 @@ func TestRecoverToolMaxScriptBytesEnforced(t *testing.T) {
 	rows := sqlmock.NewRows(recoverToolMockCols).AddRow(
 		int64(1), "bin.000001", int64(4), int64(40), ts,
 		nil, nil, "app", "users", int64(parser.EventInsert), "42",
-		nil, nil, rowAfter, int64(0), nil, nil,
+		nil, nil, rowAfter, int64(0), nil, nil, nil,
 	)
 	mock.ExpectQuery("FROM binlog_events").WillReturnRows(rows)
 
@@ -231,7 +232,7 @@ func TestRecoverToolMaxScriptBytesZeroKeepsDefault(t *testing.T) {
 	rows := sqlmock.NewRows(recoverToolMockCols).AddRow(
 		int64(1), "bin.000001", int64(4), int64(40), ts,
 		nil, nil, "app", "users", int64(parser.EventInsert), "42",
-		nil, nil, []byte(`{"id":42,"email":"a@x"}`), int64(0), nil, nil,
+		nil, nil, []byte(`{"id":42,"email":"a@x"}`), int64(0), nil, nil, nil,
 	)
 	mock.ExpectQuery("FROM binlog_events").WillReturnRows(rows)
 

--- a/internal/parquetquery/committs_roundtrip_test.go
+++ b/internal/parquetquery/committs_roundtrip_test.go
@@ -1,0 +1,89 @@
+package parquetquery
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/archive"
+	"github.com/dbtrail/dbtrail/internal/query"
+)
+
+// ─── #18 real-file round-trips through Fetch ─────────────────────────────────
+//
+// Adding a column to the archive schema has one failure mode that matters more
+// than the new column working: every archive already on disk lacks it. These
+// two tests cover both directions — a current file round-trips the microsecond
+// stamp, and a pre-#18 file reads back nil instead of Binder-erroring, which is
+// what the column probe's typed-NULL substitution exists for (the same
+// incident class as pre-v0.4.4 connection_id and pre-#699 query_text).
+
+func TestFetch_commitTsRoundTripCurrentSchema(t *testing.T) {
+	if os.Getenv("CGO_ENABLED") == "0" {
+		t.Skip("DuckDB requires CGO")
+	}
+	// Sub-second digits are the point of the column: a value ending in
+	// 000000 would survive a truncation bug unnoticed.
+	const stamped = "1767225600123456"
+	mkRow := func(id, pk, commitTs, commitNull string) [2][]string {
+		return [2][]string{
+			{id, "binlog.000001", "100", "200", "2026-02-19 14:00:00", "", "", "mydb", "orders", "2", pk, "", `{"id":` + pk + `}`, `{"id":` + pk + `,"amount":5}`, "0", "", "", commitTs},
+			{"0", "0", "0", "0", "0", "1", "1", "0", "0", "0", "0", "1", "0", "0", "0", "1", "1", commitNull},
+		}
+	}
+	dir := writeArchiveFixture(t, archive.BinlogEventColumns, [][2][]string{
+		mkRow("1", "1", stamped, "0"),
+		mkRow("2", "2", "", "1"),
+	})
+
+	rows, err := Fetch(context.Background(), query.Options{Schema: "mydb", Table: "orders", Limit: 10}, dir)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("rows = %d, want 2", len(rows))
+	}
+	if rows[0].CommitTsUS == nil {
+		t.Fatalf("row 1 CommitTsUS = nil, want %s", stamped)
+	}
+	if got := *rows[0].CommitTsUS; got != 1767225600123456 {
+		t.Errorf("row 1 CommitTsUS = %d, want 1767225600123456 (exact microseconds)", got)
+	}
+	if rows[1].CommitTsUS != nil {
+		t.Errorf("row 2 must read back a nil CommitTsUS, got %d", *rows[1].CommitTsUS)
+	}
+}
+
+func TestFetch_preCommitTsArchiveReadsNull(t *testing.T) {
+	if os.Getenv("CGO_ENABLED") == "0" {
+		t.Skip("DuckDB requires CGO")
+	}
+	// A REAL pre-#18 archive: the first 17 columns of the current schema —
+	// exactly what every rotate wrote between #699 and this change. An
+	// unguarded SELECT of commit_ts_us over it would Binder-error and take
+	// out archive reads for every existing installation.
+	oldCols := archive.BinlogEventColumns[:17]
+	if last := oldCols[len(oldCols)-1].Name; last != "query_hash" {
+		t.Fatalf("fixture assumption broken: 17th column is %q, want query_hash", last)
+	}
+	row := [2][]string{
+		{"1", "binlog.000001", "100", "200", "2026-02-19 14:00:00", "", "", "mydb", "orders", "1", "1", "", "", `{"id":1}`, "0", "", ""},
+		{"0", "0", "0", "0", "0", "1", "1", "0", "0", "0", "0", "1", "1", "0", "0", "1", "1"},
+	}
+	dir := writeArchiveFixture(t, oldCols, [][2][]string{row})
+
+	rows, err := Fetch(context.Background(), query.Options{Schema: "mydb", Table: "orders", Limit: 10}, dir)
+	if err != nil {
+		t.Fatalf("Fetch over a pre-#18 archive must not error: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want 1", len(rows))
+	}
+	if rows[0].CommitTsUS != nil {
+		t.Errorf("a pre-#18 file must read back a nil CommitTsUS, got %d", *rows[0].CommitTsUS)
+	}
+	// Scan alignment: a mis-positioned substitution shifts every field.
+	if rows[0].PKValues != "1" {
+		t.Errorf("PKValues = %q, want 1 (scan alignment)", rows[0].PKValues)
+	}
+}

--- a/internal/parquetquery/parquetquery.go
+++ b/internal/parquetquery/parquetquery.go
@@ -795,6 +795,7 @@ func buildQueryFromFiles(files []string, opts query.Options, cols map[string]boo
 		" gtid, " + optionalCol(cols, "connection_id", "INT32") + ", schema_name, table_name, event_type, pk_values," +
 		" changed_columns, row_before, row_after, schema_version," +
 		" " + optionalCol(cols, "query_text", "VARCHAR") + ", " + optionalCol(cols, "query_hash", "VARCHAR") +
+		", " + optionalCol(cols, "commit_ts_us", "BIGINT") +
 		" FROM parquet_scan(" + fileArrayLiteral(files) + ", hive_partitioning=true, union_by_name=true)"
 	if len(where) > 0 {
 		q += " WHERE " + strings.Join(where, " AND ")
@@ -834,7 +835,7 @@ func buildUnsortedQuery(path string, opts query.Options) (string, []any) {
 
 	q := "SELECT event_id, binlog_file, start_pos, end_pos, event_timestamp," +
 		" gtid, connection_id, schema_name, table_name, event_type, pk_values," +
-		" changed_columns, row_before, row_after, schema_version, query_text, query_hash" +
+		" changed_columns, row_before, row_after, schema_version, query_text, query_hash, commit_ts_us" +
 		" FROM parquet_scan('" + safePath + "', union_by_name=true)"
 	if len(where) > 0 {
 		q += " WHERE " + strings.Join(where, " AND ")
@@ -858,7 +859,7 @@ func buildQuery(glob string, opts query.Options) (string, []any) {
 
 	q := "SELECT event_id, binlog_file, start_pos, end_pos, event_timestamp," +
 		" gtid, connection_id, schema_name, table_name, event_type, pk_values," +
-		" changed_columns, row_before, row_after, schema_version, query_text, query_hash" +
+		" changed_columns, row_before, row_after, schema_version, query_text, query_hash, commit_ts_us" +
 		" FROM parquet_scan('" + safeGlob + "', hive_partitioning=true, union_by_name=true)"
 	if len(where) > 0 {
 		q += " WHERE " + strings.Join(where, " AND ")
@@ -1036,6 +1037,7 @@ func buildQueryForFile(path string, opts query.Options, cols map[string]bool) (s
 		" gtid, " + optionalCol(cols, "connection_id", "INT32") + ", schema_name, table_name, event_type, pk_values," +
 		" changed_columns, row_before, row_after, schema_version," +
 		" " + optionalCol(cols, "query_text", "VARCHAR") + ", " + optionalCol(cols, "query_hash", "VARCHAR") +
+		", " + optionalCol(cols, "commit_ts_us", "BIGINT") +
 		" FROM parquet_scan('" + safePath + "', hive_partitioning=true, union_by_name=true)"
 	if len(where) > 0 {
 		q += " WHERE " + strings.Join(where, " AND ")
@@ -1129,11 +1131,13 @@ func scanRows(rows *sql.Rows) ([]query.ResultRow, error) {
 			schemaVersion  sql.NullInt32
 			queryText      sql.NullString
 			queryHash      sql.NullString
+			commitTsUS     sql.NullInt64
 		)
 		if err := rows.Scan(
 			&eventID, &binlogFile, &startPos, &endPos, &eventTimestamp,
 			&gtid, &connID, &schemaName, &tableName, &eventType, &pkValues,
 			&changedCols, &rowBefore, &rowAfter, &schemaVersion, &queryText, &queryHash,
+			&commitTsUS,
 		); err != nil {
 			return nil, fmt.Errorf("scan parquet result: %w", err)
 		}
@@ -1162,6 +1166,14 @@ func scanRows(rows *sql.Rows) ([]query.ResultRow, error) {
 		}
 		if queryHash.Valid {
 			r.QueryHash = &queryHash.String
+		}
+		// Archives written before #18 have no commit_ts_us at all: optionalCol
+		// substitutes a typed NULL, which lands here as invalid and leaves the
+		// pointer nil — the same "only the one-second timestamp is known"
+		// signal a live row from a MariaDB source carries.
+		if commitTsUS.Valid && commitTsUS.Int64 > 0 {
+			v := uint64(commitTsUS.Int64)
+			r.CommitTsUS = &v
 		}
 		if changedCols.Valid && changedCols.String != "" {
 			_ = json.Unmarshal([]byte(changedCols.String), &r.ChangedColumns)

--- a/internal/parser/committs_integration_test.go
+++ b/internal/parser/committs_integration_test.go
@@ -1,0 +1,136 @@
+//go:build integration
+
+package parser_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/config"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/parser"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestParseFile_commitTimestampCapture drives the #18 capture path against a
+// REAL binlog. Two facts are worth proving on a live server rather than on a
+// hand-built event:
+//
+//  1. The value the server actually writes is microseconds since epoch — a
+//     unit error here would be invisible in a unit test that feeds back the
+//     same constant, and would produce timestamps off by a factor of 1000.
+//  2. MySQL 8.0 writes it into the ANONYMOUS_GTID_EVENT too, so capture does
+//     NOT require gtid_mode=ON. The suite's container runs with GTIDs off,
+//     which makes this test the evidence for that claim rather than an
+//     assumption in a doc comment.
+func TestParseFile_commitTimestampCapture(t *testing.T) {
+	sourceDB, sourceName := testutil.CreateTestDB(t)
+	indexDB, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, indexDB)
+
+	testutil.MustExec(t, sourceDB, `CREATE TABLE orders (
+		id       INT PRIMARY KEY AUTO_INCREMENT,
+		customer VARCHAR(100) NOT NULL,
+		amount   DECIMAL(10,2) NOT NULL
+	)`)
+
+	stats, err := metadata.TakeSnapshot(sourceDB, indexDB, []string{sourceName})
+	if err != nil {
+		t.Fatalf("TakeSnapshot failed: %v", err)
+	}
+	resolver, err := metadata.NewResolver(indexDB, stats.SnapshotID)
+	if err != nil {
+		t.Fatalf("NewResolver failed: %v", err)
+	}
+
+	testutil.MustExec(t, sourceDB, "FLUSH BINARY LOGS")
+	currentBinlog, _, err := config.CurrentBinlogPosition(sourceDB)
+	if err != nil {
+		t.Fatalf("CurrentBinlogPosition failed: %v", err)
+	}
+
+	// Bracket the writes with the server's own clock: the captured commit
+	// timestamp must land inside this window, which is what actually pins the
+	// UNIT (a value in milliseconds or nanoseconds falls outside it by orders
+	// of magnitude). Read from the source, not the test host, so a clock skew
+	// between the container and the host cannot fail the assertion.
+	before := serverNowMicros(t, sourceDB)
+	testutil.MustExec(t, sourceDB, "INSERT INTO orders (customer, amount) VALUES ('Alice', 99.99)")
+	testutil.MustExec(t, sourceDB, "UPDATE orders SET amount = 109.99 WHERE customer = 'Alice'")
+	after := serverNowMicros(t, sourceDB)
+
+	testutil.MustExec(t, sourceDB, "FLUSH BINARY LOGS")
+
+	tmpDir := t.TempDir()
+	cpCmd := exec.Command("docker", "cp",
+		fmt.Sprintf("bintrail-test-mysql:/var/lib/mysql/%s", currentBinlog),
+		filepath.Join(tmpDir, currentBinlog),
+	)
+	if out, err := cpCmd.CombinedOutput(); err != nil {
+		t.Fatalf("docker cp %s failed: %v\n%s", currentBinlog, err, out)
+	}
+
+	p := parser.New(tmpDir, resolver, parser.Filters{
+		Schemas: map[string]bool{sourceName: true},
+	}, nil)
+
+	events := make(chan parser.Event, 100)
+	done := make(chan error, 1)
+	go func() {
+		defer close(events)
+		done <- p.ParseFile(context.Background(), currentBinlog, events)
+	}()
+	all := drainEvents(events)
+	if err := <-done; err != nil {
+		t.Fatalf("ParseFile failed: %v", err)
+	}
+
+	dml := dmlEvents(all)
+	if len(dml) != 2 {
+		t.Fatalf("expected 2 DML events (1 INSERT + 1 UPDATE), got %d", len(dml))
+	}
+
+	for i, ev := range dml {
+		if ev.CommitTsUS == 0 {
+			t.Fatalf("event[%d]: CommitTsUS = 0 — this server writes a commit timestamp "+
+				"(MySQL 8.0.1+ stamps it on the ANONYMOUS_GTID_EVENT even with gtid_mode=OFF); "+
+				"a zero here means the parser dropped it", i)
+		}
+		if ev.CommitTsUS < before || ev.CommitTsUS > after {
+			t.Errorf("event[%d]: CommitTsUS = %d, outside the [%d, %d] microsecond window the "+
+				"statements ran in — the value is not microseconds since epoch",
+				i, ev.CommitTsUS, before, after)
+		}
+		// The whole point of the column: sub-second resolution the
+		// one-second common header cannot express.
+		if sec := uint64(ev.Timestamp.Unix()); ev.CommitTsUS/1_000_000 != sec {
+			t.Errorf("event[%d]: CommitTsUS %d truncates to epoch second %d, but the event's own "+
+				"timestamp is %d — the two clocks disagree",
+				i, ev.CommitTsUS, ev.CommitTsUS/1_000_000, sec)
+		}
+	}
+
+	// Two separate transactions commit at different instants; equal
+	// microsecond stamps would mean the value is being carried over rather
+	// than read per transaction.
+	if dml[0].CommitTsUS == dml[1].CommitTsUS {
+		t.Errorf("both events carry CommitTsUS = %d; two separate transactions cannot share "+
+			"a microsecond commit instant — the value is stale, not per-transaction", dml[0].CommitTsUS)
+	}
+}
+
+// serverNowMicros reads the SOURCE server's clock in microseconds since epoch,
+// so the window assertion above compares the captured stamp against the clock
+// that produced it rather than the test host's.
+func serverNowMicros(t *testing.T, db *sql.DB) uint64 {
+	t.Helper()
+	var us uint64
+	if err := db.QueryRow("SELECT ROUND(UNIX_TIMESTAMP(NOW(6)) * 1000000)").Scan(&us); err != nil {
+		t.Fatalf("read the source server clock: %v", err)
+	}
+	return us
+}

--- a/internal/parser/committs_test.go
+++ b/internal/parser/committs_test.go
@@ -1,0 +1,160 @@
+package parser
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/go-mysql-org/go-mysql/replication"
+)
+
+// ─── Microsecond commit timestamps (#18) ─────────────────────────────────────
+//
+// MySQL 8.0.1+ writes immediate_commit_timestamp — MICROSECONDS since epoch —
+// into every GTID event, while the common header every other event carries
+// resolves to one SECOND. These tests pin the transaction-scoped state machine
+// that carries the microsecond value onto row events, and the two ways it must
+// come back as "unknown" rather than as a wrong-but-precise number.
+
+// makeGTIDEventAt is makeGTIDEvent with an explicit immediate_commit_timestamp.
+func makeGTIDEventAt(gno int64, commitTsUS uint64) *replication.BinlogEvent {
+	ev := makeGTIDEvent(gno)
+	ev.Event.(*replication.GTIDEvent).ImmediateCommitTimestamp = commitTsUS
+	return ev
+}
+
+// TestStreamParser_commitTsAttachedToRows: the GTID event's microsecond
+// timestamp lands on the transaction's row events, and the NEXT transaction's
+// rows carry that transaction's own value — the failure that matters is a
+// stale carry-over, which would read as a precise time for the wrong commit.
+func TestStreamParser_commitTsAttachedToRows(t *testing.T) {
+	const (
+		trx1US = uint64(1767225600_123456)
+		trx2US = uint64(1767225600_987654)
+	)
+
+	sp := NewStreamParser(makeOrdersResolver(), Filters{}, nil)
+	streamer := replication.NewBinlogStreamer()
+	out := make(chan Event, 16)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	feedThenCancel(t, streamer, cancel,
+		makeRotate("binlog.000001"),
+		makeGTIDEventAt(1, trx1US),
+		makeQueryEvent("BEGIN"),
+		makeOrdersInsertEvent(1, 10),
+		makeXIDEvent(200),
+		makeGTIDEventAt(2, trx2US),
+		makeQueryEvent("BEGIN"),
+		makeOrdersInsertEvent(2, 20),
+		makeXIDEvent(600),
+	)
+
+	if err := sp.Run(ctx, streamer, out); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	dml := dmlOf(drainAll(out))
+	if len(dml) != 2 {
+		t.Fatalf("expected 2 DML events, got %d", len(dml))
+	}
+	if dml[0].CommitTsUS != trx1US {
+		t.Errorf("trx1 CommitTsUS = %d, want %d", dml[0].CommitTsUS, trx1US)
+	}
+	if dml[1].CommitTsUS != trx2US {
+		t.Errorf("trx2 CommitTsUS = %d, want %d (the second transaction's own stamp, not the first's)",
+			dml[1].CommitTsUS, trx2US)
+	}
+}
+
+// TestStreamParser_commitTsUnknownSources: both ways the value is genuinely
+// unknown must produce zero, never a carried-over stamp from the previous
+// transaction. A stale microsecond timestamp is worse than none: it reads as
+// precise, so any consumer correlating against it would silently trust it.
+func TestStreamParser_commitTsUnknownSources(t *testing.T) {
+	const trx1US = uint64(1767225600_123456)
+
+	tests := []struct {
+		name string
+		// second transaction's opening event, replacing a MySQL 8.0.1+ GTID
+		// event that would carry a timestamp
+		opener *replication.BinlogEvent
+	}{
+		// MariaDB's GTID event has no commit timestamp at all.
+		{name: "mariadb gtid event", opener: makeMariadbGTIDEvent(0, 1, 100)},
+		// MySQL older than 8.0.1: a GTID event whose timestamp field is zero.
+		{name: "pre-8.0.1 mysql gtid event", opener: makeGTIDEventAt(2, 0)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sp := NewStreamParser(makeOrdersResolver(), Filters{}, nil)
+			streamer := replication.NewBinlogStreamer()
+			out := make(chan Event, 16)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			feedThenCancel(t, streamer, cancel,
+				makeRotate("binlog.000001"),
+				// A first transaction WITH a stamp, so a leak has something to leak.
+				makeGTIDEventAt(1, trx1US),
+				makeQueryEvent("BEGIN"),
+				makeOrdersInsertEvent(1, 10),
+				makeXIDEvent(200),
+				tc.opener,
+				makeQueryEvent("BEGIN"),
+				makeOrdersInsertEvent(2, 20),
+				makeXIDEvent(600),
+			)
+
+			if err := sp.Run(ctx, streamer, out); err != nil {
+				t.Fatalf("Run: %v", err)
+			}
+			dml := dmlOf(drainAll(out))
+			if len(dml) != 2 {
+				t.Fatalf("expected 2 DML events, got %d", len(dml))
+			}
+			if dml[0].CommitTsUS != trx1US {
+				t.Errorf("trx1 CommitTsUS = %d, want %d", dml[0].CommitTsUS, trx1US)
+			}
+			if dml[1].CommitTsUS != 0 {
+				t.Errorf("trx2 CommitTsUS = %d, want 0 — this source wrote no commit timestamp, "+
+					"and the previous transaction's must not carry over", dml[1].CommitTsUS)
+			}
+		})
+	}
+}
+
+// TestStreamParser_unhandledEventTypeIsLogged pins the hygiene half of #18: an
+// event type the switch does not name is dropped, and until now it was dropped
+// in complete silence. ROWS_QUERY_EVENT carried the originating SQL for years
+// and nobody could see the parser was ignoring it — the log line is the only
+// thing that makes "the parser has no case for this" discoverable without
+// reading the source.
+func TestStreamParser_unhandledEventTypeIsLogged(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	sp := NewStreamParser(makeOrdersResolver(), Filters{}, logger)
+	streamer := replication.NewBinlogStreamer()
+	out := make(chan Event, 8)
+
+	unhandled := &replication.BinlogEvent{
+		Header: &replication.EventHeader{EventType: replication.FORMAT_DESCRIPTION_EVENT, LogPos: 123},
+		Event:  &replication.FormatDescriptionEvent{Version: 4},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	feedThenCancel(t, streamer, cancel, makeRotate("binlog.000001"), unhandled)
+
+	if err := sp.Run(ctx, streamer, out); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	logged := buf.String()
+	if !strings.Contains(logged, "not handled by the stream parser") {
+		t.Errorf("an unhandled event type produced no log line; got:\n%s", logged)
+	}
+	if !strings.Contains(logged, replication.FORMAT_DESCRIPTION_EVENT.String()) {
+		t.Errorf("the log line does not name the event type (%s), which is the only useful part; got:\n%s",
+			replication.FORMAT_DESCRIPTION_EVENT, logged)
+	}
+}

--- a/internal/parser/drift_test.go
+++ b/internal/parser/drift_test.go
@@ -67,7 +67,7 @@ func runHandleRowsWith(t *testing.T, resolver *metadata.Resolver, binlogEv *repl
 	t.Helper()
 	rowsEv := binlogEv.Event.(*replication.RowsEvent)
 	out := make(chan Event, 4)
-	err := handleRows(context.Background(), newTestLogger(logBuf), resolver, &Filters{}, binlogEv, rowsEv, "binlog.000001", "", 0, "", 9, out, nil)
+	err := handleRows(context.Background(), newTestLogger(logBuf), resolver, &Filters{}, binlogEv, rowsEv, "binlog.000001", "", 0, 0, "", 9, out, nil)
 	close(out)
 	var evs []Event
 	for ev := range out {
@@ -397,7 +397,7 @@ func TestHandleRows_schemaGapTrackerFileMode(t *testing.T) {
 			rowsEv := tc.ev.Event.(*replication.RowsEvent)
 			out := make(chan Event, 4)
 			err := handleRows(context.Background(), newTestLogger(&bytes.Buffer{}), timedOrdersResolver(snapT),
-				&Filters{}, tc.ev, rowsEv, "binlog.000007", "", 0, "", 9, out, tracker)
+				&Filters{}, tc.ev, rowsEv, "binlog.000007", "", 0, 0, "", 9, out, tracker)
 			close(out)
 			// A skip is never a hard error at the handleRows layer — the
 			// file-level failure is decided by ParseFile from the tracker.

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -110,6 +110,13 @@ func (p *Parser) ParseFile(ctx context.Context, filename string, events chan<- E
 	// recent QueryEvent. For DML transactions, this is the QUERY(BEGIN)
 	// event that precedes the row events.
 	var currentConnectionID uint32
+	// currentCommitTsUS holds the microsecond commit timestamp of the current
+	// transaction, from its GTID event. Transaction-scoped like currentGTID:
+	// set by the GTID event, zero when the source writes none (MariaDB, or
+	// MySQL < 8.0.1). With gtid_mode=OFF, MySQL 8.0 still emits an
+	// ANONYMOUS_GTID_EVENT carrying the stamp — go-mysql decodes it into the
+	// same GTIDEvent struct, so the value survives there too.
+	var currentCommitTsUS uint64
 	// currentQueryText holds the original SQL statement from the most recent
 	// ROWS_QUERY_EVENT (MySQL, binlog_rows_query_log_events=ON) or
 	// ANNOTATE_ROWS event (MariaDB, binlog_annotate_row_events=ON). It is
@@ -156,6 +163,10 @@ func (p *Parser) ParseFile(ctx context.Context, filename string, events chan<- E
 		case *replication.GTIDEvent:
 			currentGTID = formatGTID(binlogEv.Header.EventType, ev.SID, ev.GNO)
 			currentQueryText = "" // transaction boundary — statement text never crosses it
+			// immediate_commit_timestamp: microseconds since epoch, written by
+			// MySQL 8.0.1+. Zero on older servers, which is exactly the
+			// "unknown" value Event.CommitTsUS documents.
+			currentCommitTsUS = ev.ImmediateCommitTimestamp
 
 		case *replication.MariadbGTIDEvent:
 			// MariaDB source: the GTID arrives as domain-server-seq (e.g.
@@ -163,6 +174,11 @@ func (p *Parser) ParseFile(ctx context.Context, filename string, events chan<- E
 			// mirroring formatGTID's not-enabled behavior.
 			currentGTID = ev.GTID.String()
 			currentQueryText = ""
+			// MariaDB's GTID event carries no commit timestamp. Reset rather
+			// than leave the previous transaction's value in place: a stale
+			// microsecond stamp on the wrong transaction is worse than none,
+			// because it reads as precise.
+			currentCommitTsUS = 0
 
 		case *replication.QueryEvent:
 			currentConnectionID = ev.SlaveProxyID
@@ -206,7 +222,7 @@ func (p *Parser) ParseFile(ctx context.Context, filename string, events chan<- E
 			currentQueryText = event.SanitizeQueryText(string(ev.Query))
 
 		case *replication.RowsEvent:
-			err := handleRows(ctx, p.logger, p.resolver.Load(), &p.filters, binlogEv, ev, filename, currentGTID, currentConnectionID, currentQueryText, p.schemaVersion.Load(), events, &gaps)
+			err := handleRows(ctx, p.logger, p.resolver.Load(), &p.filters, binlogEv, ev, filename, currentGTID, currentConnectionID, currentCommitTsUS, currentQueryText, p.schemaVersion.Load(), events, &gaps)
 			// The LAST rows event of a statement carries STMT_END_F — the
 			// actual statement boundary. Clearing here keeps one statement's
 			// text alive across its chained/split rows events, while a later
@@ -225,6 +241,20 @@ func (p *Parser) ParseFile(ctx context.Context, filename string, events chan<- E
 					return err
 				}
 			}
+
+		default:
+			// Every event type this switch does not name is dropped — silently,
+			// until now. ROWS_QUERY_EVENT carried the originating SQL for years
+			// and was invisible for exactly this reason: nothing said the
+			// parser was seeing an event kind it had no case for. Debug level,
+			// because the common case is genuinely uninteresting (FORMAT_DESC,
+			// STOP, PREVIOUS_GTIDS…) and a busy binlog would flood any louder
+			// level; the point is that the information EXISTS when someone
+			// asks why a source's metadata is not showing up.
+			p.logger.Debug("binlog event type not handled by the parser",
+				"file", filename,
+				"pos", binlogEv.Header.LogPos,
+				"event_type", binlogEv.Header.EventType.String())
 		}
 		return nil
 	}
@@ -363,6 +393,7 @@ func handleRows(
 	rowsEv *replication.RowsEvent,
 	filename, currentGTID string,
 	connectionID uint32,
+	commitTsUS uint64,
 	queryText string,
 	schemaVersion uint32,
 	out chan<- Event,
@@ -542,19 +573,19 @@ func handleRows(
 		replication.WRITE_ROWS_EVENTv1,
 		replication.WRITE_ROWS_EVENTv2,
 		replication.MARIADB_WRITE_ROWS_COMPRESSED_EVENT_V1:
-		return emitInserts(ctx, logger, resolver, rowsEv.Rows, schema, table, filename, currentGTID, connectionID, queryText, startPos, endPos, ts, pkCols, schemaVersion, stmtEnd, out)
+		return emitInserts(ctx, logger, resolver, rowsEv.Rows, schema, table, filename, currentGTID, connectionID, commitTsUS, queryText, startPos, endPos, ts, pkCols, schemaVersion, stmtEnd, out)
 
 	case replication.DELETE_ROWS_EVENTv0,
 		replication.DELETE_ROWS_EVENTv1,
 		replication.DELETE_ROWS_EVENTv2,
 		replication.MARIADB_DELETE_ROWS_COMPRESSED_EVENT_V1:
-		return emitDeletes(ctx, logger, resolver, rowsEv.Rows, schema, table, filename, currentGTID, connectionID, queryText, startPos, endPos, ts, pkCols, schemaVersion, stmtEnd, out)
+		return emitDeletes(ctx, logger, resolver, rowsEv.Rows, schema, table, filename, currentGTID, connectionID, commitTsUS, queryText, startPos, endPos, ts, pkCols, schemaVersion, stmtEnd, out)
 
 	case replication.UPDATE_ROWS_EVENTv0,
 		replication.UPDATE_ROWS_EVENTv1,
 		replication.UPDATE_ROWS_EVENTv2,
 		replication.MARIADB_UPDATE_ROWS_COMPRESSED_EVENT_V1:
-		return emitUpdates(ctx, logger, resolver, rowsEv.Rows, schema, table, filename, currentGTID, connectionID, queryText, startPos, endPos, ts, pkCols, schemaVersion, stmtEnd, out)
+		return emitUpdates(ctx, logger, resolver, rowsEv.Rows, schema, table, filename, currentGTID, connectionID, commitTsUS, queryText, startPos, endPos, ts, pkCols, schemaVersion, stmtEnd, out)
 
 	default:
 		// A RowsEvent whose type matches none of the above — e.g.
@@ -582,6 +613,7 @@ func emitInserts(
 	rows [][]any,
 	schema, table, filename, gtid string,
 	connectionID uint32,
+	commitTsUS uint64,
 	queryText string,
 	startPos, endPos uint64,
 	ts time.Time,
@@ -599,7 +631,7 @@ func emitInserts(
 		}
 		ev := Event{
 			BinlogFile: filename, StartPos: startPos, EndPos: endPos,
-			Timestamp: ts, GTID: gtid, ConnectionID: connectionID, QueryText: queryText,
+			Timestamp: ts, GTID: gtid, ConnectionID: connectionID, CommitTsUS: commitTsUS, QueryText: queryText,
 			Schema: schema, Table: table, EventType: EventInsert,
 			PKValues:      BuildPKValues(pkCols, named),
 			RowAfter:      named,
@@ -622,6 +654,7 @@ func emitDeletes(
 	rows [][]any,
 	schema, table, filename, gtid string,
 	connectionID uint32,
+	commitTsUS uint64,
 	queryText string,
 	startPos, endPos uint64,
 	ts time.Time,
@@ -639,7 +672,7 @@ func emitDeletes(
 		}
 		ev := Event{
 			BinlogFile: filename, StartPos: startPos, EndPos: endPos,
-			Timestamp: ts, GTID: gtid, ConnectionID: connectionID, QueryText: queryText,
+			Timestamp: ts, GTID: gtid, ConnectionID: connectionID, CommitTsUS: commitTsUS, QueryText: queryText,
 			Schema: schema, Table: table, EventType: EventDelete,
 			PKValues:      BuildPKValues(pkCols, named),
 			RowBefore:     named,
@@ -662,6 +695,7 @@ func emitUpdates(
 	rows [][]any,
 	schema, table, filename, gtid string,
 	connectionID uint32,
+	commitTsUS uint64,
 	queryText string,
 	startPos, endPos uint64,
 	ts time.Time,
@@ -687,7 +721,7 @@ func emitUpdates(
 		}
 		ev := Event{
 			BinlogFile: filename, StartPos: startPos, EndPos: endPos,
-			Timestamp: ts, GTID: gtid, ConnectionID: connectionID, QueryText: queryText,
+			Timestamp: ts, GTID: gtid, ConnectionID: connectionID, CommitTsUS: commitTsUS, QueryText: queryText,
 			Schema: schema, Table: table, EventType: EventUpdate,
 			PKValues:      BuildPKValues(pkCols, before), // PK from before-image
 			RowBefore:     before,

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -207,7 +207,7 @@ func TestHandleRows_unhandledEventTypeLogsNotSilent(t *testing.T) {
 	rowsEv := binlogEv.Event.(*replication.RowsEvent)
 
 	out := make(chan Event, 4)
-	if err := handleRows(context.Background(), logger, resolver, &Filters{}, binlogEv, rowsEv, "mariadb-bin.000001", "0-1-1", 0, "", 1, out, nil); err != nil {
+	if err := handleRows(context.Background(), logger, resolver, &Filters{}, binlogEv, rowsEv, "mariadb-bin.000001", "0-1-1", 0, 0, "", 1, out, nil); err != nil {
 		t.Fatalf("handleRows: %v", err)
 	}
 
@@ -318,7 +318,7 @@ func TestHandleRows_mariadbCompressedRowTypes(t *testing.T) {
 			rowsEv := binlogEv.Event.(*replication.RowsEvent)
 
 			out := make(chan Event, 4)
-			if err := handleRows(context.Background(), logger, resolver, &Filters{}, binlogEv, rowsEv, "mariadb-bin.000001", "0-1-1", 0, "", 1, out, nil); err != nil {
+			if err := handleRows(context.Background(), logger, resolver, &Filters{}, binlogEv, rowsEv, "mariadb-bin.000001", "0-1-1", 0, 0, "", 1, out, nil); err != nil {
 				t.Fatalf("handleRows: %v", err)
 			}
 
@@ -688,7 +688,7 @@ func TestHandleRows_partialImageFailsLoud(t *testing.T) {
 	rowsEv := binlogEv.Event.(*replication.RowsEvent)
 
 	out := make(chan Event, 4)
-	err := handleRows(context.Background(), newTestLogger(&bytes.Buffer{}), resolver, &Filters{}, binlogEv, rowsEv, "binlog.000001", "0-1-1", 0, "", 1, out, nil)
+	err := handleRows(context.Background(), newTestLogger(&bytes.Buffer{}), resolver, &Filters{}, binlogEv, rowsEv, "binlog.000001", "0-1-1", 0, 0, "", 1, out, nil)
 	if err == nil {
 		t.Fatal("expected handleRows to fail loud on a partial row image, got nil")
 	}
@@ -740,7 +740,7 @@ func TestHandleRows_fullImagePasses(t *testing.T) {
 	rowsEv := binlogEv.Event.(*replication.RowsEvent)
 
 	out := make(chan Event, 4)
-	if err := handleRows(context.Background(), newTestLogger(&bytes.Buffer{}), resolver, &Filters{}, binlogEv, rowsEv, "binlog.000001", "0-1-1", 0, "", 1, out, nil); err != nil {
+	if err := handleRows(context.Background(), newTestLogger(&bytes.Buffer{}), resolver, &Filters{}, binlogEv, rowsEv, "binlog.000001", "0-1-1", 0, 0, "", 1, out, nil); err != nil {
 		t.Fatalf("handleRows must not fail on a FULL image, got: %v", err)
 	}
 	select {

--- a/internal/parser/stream.go
+++ b/internal/parser/stream.go
@@ -135,6 +135,11 @@ func (sp *StreamParser) Run(ctx context.Context, streamer *replication.BinlogStr
 	var currentFile string
 	var currentGTID string
 	var currentConnectionID uint32 // pseudo_thread_id from most recent QueryEvent
+	// currentCommitTsUS is the microsecond commit timestamp of the transaction
+	// in flight, from its GTID event. Transaction-scoped like currentGTID; zero
+	// when the source writes none (MariaDB, or MySQL < 8.0.1). gtid_mode=OFF
+	// still yields a value: 8.0 stamps the ANONYMOUS_GTID_EVENT too.
+	var currentCommitTsUS uint64
 	// lastLogPos tracks the highest EventHeader.LogPos seen since the last
 	// RotateEvent, to detect a same-file position wraparound (#845) live,
 	// during streaming — see the check at the top of handleEvent below.
@@ -269,6 +274,9 @@ func (sp *StreamParser) Run(ctx context.Context, streamer *replication.BinlogStr
 			}
 			currentGTID = formatGTID(binlogEv.Header.EventType, ev.SID, ev.GNO)
 			currentQueryText = "" // transaction boundary — statement text never crosses it
+			// immediate_commit_timestamp (µs since epoch), MySQL 8.0.1+; zero
+			// on older servers — the "unknown" value Event.CommitTsUS documents.
+			currentCommitTsUS = ev.ImmediateCommitTimestamp
 			if err := emitGTIDTracking(binlogEv.Header); err != nil {
 				return err
 			}
@@ -285,6 +293,10 @@ func (sp *StreamParser) Run(ctx context.Context, streamer *replication.BinlogStr
 			}
 			currentGTID = ev.GTID.String()
 			currentQueryText = ""
+			// MariaDB's GTID event has no commit timestamp: reset rather than
+			// carry the previous transaction's value forward — a stale
+			// microsecond stamp reads as precise and would be worse than none.
+			currentCommitTsUS = 0
 			if err := emitGTIDTracking(binlogEv.Header); err != nil {
 				return err
 			}
@@ -368,7 +380,7 @@ func (sp *StreamParser) Run(ctx context.Context, streamer *replication.BinlogStr
 			// nil gapTracker: the stream keeps its warn-and-continue skip
 			// behavior (the synchronous DDL hook, SetSyncDDLHook, is the
 			// stream's post-DDL correctness mechanism, not file-level failure).
-			err := handleRows(ctx, sp.logger, sp.resolver.Load(), &sp.filters, binlogEv, ev, currentFile, currentGTID, currentConnectionID, currentQueryText, sp.schemaVersion.Load(), out, nil)
+			err := handleRows(ctx, sp.logger, sp.resolver.Load(), &sp.filters, binlogEv, ev, currentFile, currentGTID, currentConnectionID, currentCommitTsUS, currentQueryText, sp.schemaVersion.Load(), out, nil)
 			// Statement boundary — see the file parser's RowsEvent case: the
 			// STMT_END_F clear prevents a ROWS_QUERY-less later statement in
 			// the same transaction from inheriting this statement's text.
@@ -384,6 +396,20 @@ func (sp *StreamParser) Run(ctx context.Context, streamer *replication.BinlogStr
 					return err
 				}
 			}
+
+		default:
+			// Unnamed event types are dropped. Say so at debug level: this
+			// switch's silence is how ROWS_QUERY_EVENT stayed invisible for
+			// years — nothing reported that the stream was seeing an event
+			// kind with no case. Debug, not info: the common unnamed types
+			// (FORMAT_DESCRIPTION, PREVIOUS_GTIDS, STOP, HEARTBEAT…) are
+			// uninteresting and frequent, so a louder level would be noise;
+			// the point is that the answer EXISTS when someone asks why some
+			// source metadata never appears in the index.
+			sp.logger.Debug("binlog event type not handled by the stream parser",
+				"file", currentFile,
+				"pos", binlogEv.Header.LogPos,
+				"event_type", binlogEv.Header.EventType.String())
 		}
 		return nil
 	}

--- a/internal/query/profileactive_test.go
+++ b/internal/query/profileactive_test.go
@@ -23,13 +23,14 @@ func TestFetch_profileActiveBlanksQueryText(t *testing.T) {
 		"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp",
 		"gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values",
 		"changed_columns", "row_before", "row_after", "schema_version", "query_text", "query_hash",
+		"commit_ts_us",
 	}
 	ts := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
 	rows := sqlmock.NewRows(cols).AddRow(
 		int64(1), "bin.000001", int64(4), int64(40), ts,
 		nil, nil, "app", "users", int64(2), "7",
 		nil, []byte(`{"ssn":"123-45-6789"}`), []byte(`{"ssn":"999"}`), int64(0),
-		"UPDATE app.users SET ssn='999' WHERE id=7", "cafe0000",
+		"UPDATE app.users SET ssn='999' WHERE id=7", "cafe0000", int64(1767322445000123),
 	)
 	mock.ExpectQuery("FROM binlog_events").WillReturnRows(rows)
 

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -232,6 +232,12 @@ type ResultRow struct {
 	SchemaVersion  uint32         // snapshot_id at index time; 0 for pre-migration data
 	QueryText      *string        // original SQL statement (#699); nil unless the source logs ROWS_QUERY/ANNOTATE events
 	QueryHash      *string        // STATEMENT_DIGEST of QueryText computed at index time (#699); nil when text absent or digest unavailable
+	// CommitTsUS is the transaction's commit time in MICROSECONDS since epoch,
+	// from the source's GTID event (#18). nil for events indexed before the
+	// column existed, and for sources that never write it (MariaDB, MySQL <
+	// 8.0.1) — so a consumer must treat nil as "only the one-second
+	// EventTimestamp is known here", never as an ordering tie.
+	CommitTsUS *uint64
 }
 
 // OrderDirection normalises an Options.Order value to a SQL direction keyword
@@ -513,7 +519,8 @@ func buildQuery(opts Options) (string, []any) {
 	// match 1:1 and lets MySQL prune partitions on the eq_ref lookup.
 	cols := `be.event_id, be.binlog_file, be.start_pos, be.end_pos, be.event_timestamp,
 	         be.gtid, be.connection_id, be.schema_name, be.table_name, be.event_type, be.pk_values,
-	         be.changed_columns, be.row_before, be.row_after, be.schema_version, be.query_text, be.query_hash`
+	         be.changed_columns, be.row_before, be.row_after, be.schema_version, be.query_text, be.query_hash,
+	         be.commit_ts_us`
 
 	dir := OrderDirection(opts.Order)
 	whereSQL := ""
@@ -612,6 +619,7 @@ func scanRows(rows *sql.Rows) ([]ResultRow, error) {
 			schemaVersion  sql.NullInt32
 			queryText      sql.NullString
 			queryHash      sql.NullString
+			commitTsUS     sql.NullInt64
 		)
 		var changedCols, rowBefore, rowAfter []byte
 
@@ -619,6 +627,7 @@ func scanRows(rows *sql.Rows) ([]ResultRow, error) {
 			&r.EventID, &binlogFile, &startPos, &endPos, &eventTimestamp,
 			&gtid, &connID, &schemaName, &tableName, &eventType, &pkValues,
 			&changedCols, &rowBefore, &rowAfter, &schemaVersion, &queryText, &queryHash,
+			&commitTsUS,
 		); err != nil {
 			return nil, fmt.Errorf("failed to scan result row: %w", err)
 		}
@@ -661,6 +670,12 @@ func scanRows(rows *sql.Rows) ([]ResultRow, error) {
 		}
 		if queryHash.Valid {
 			r.QueryHash = &queryHash.String
+		}
+		// BIGINT UNSIGNED microseconds scanned through NullInt64: epoch µs stays
+		// well inside int64 (year 294247), so the signed hop is lossless.
+		if commitTsUS.Valid && commitTsUS.Int64 > 0 {
+			v := uint64(commitTsUS.Int64)
+			r.CommitTsUS = &v
 		}
 		if changedCols != nil {
 			_ = json.Unmarshal(changedCols, &r.ChangedColumns)
@@ -762,6 +777,7 @@ type jsonRow struct {
 	RowAfter       map[string]any `json:"row_after"`
 	QueryText      *string        `json:"query_text"`
 	QueryHash      *string        `json:"query_hash"`
+	CommitTsUS     *uint64        `json:"commit_ts_us"`
 }
 
 func writeJSON(rows []ResultRow, w io.Writer) (int, error) {
@@ -784,6 +800,7 @@ func writeJSON(rows []ResultRow, w io.Writer) (int, error) {
 			RowAfter:       r.RowAfter,
 			QueryText:      r.QueryText,
 			QueryHash:      r.QueryHash,
+			CommitTsUS:     r.CommitTsUS,
 		}
 	}
 	enc := json.NewEncoder(w)
@@ -799,6 +816,7 @@ var csvHeaders = []string{
 	"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp",
 	"gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values",
 	"changed_columns", "row_before", "row_after", "query_text", "query_hash",
+	"commit_ts_us",
 }
 
 func writeCSV(rows []ResultRow, w io.Writer) (int, error) {
@@ -839,6 +857,10 @@ func writeCSV(rows []ResultRow, w io.Writer) (int, error) {
 		if r.QueryHash != nil {
 			queryHash = *r.QueryHash
 		}
+		commitTsUS := ""
+		if r.CommitTsUS != nil {
+			commitTsUS = fmt.Sprintf("%d", *r.CommitTsUS)
+		}
 		record := []string{
 			fmt.Sprintf("%d", r.EventID),
 			r.BinlogFile,
@@ -856,6 +878,7 @@ func writeCSV(rows []ResultRow, w io.Writer) (int, error) {
 			after,
 			queryText,
 			queryHash,
+			commitTsUS,
 		}
 		if err := cw.Write(record); err != nil {
 			return i, err

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -509,13 +509,18 @@ func TestWriteCSV_headersAndRow(t *testing.T) {
 	if !strings.Contains(lines[1], "DELETE") {
 		t.Errorf("expected DELETE in data row, got: %s", lines[1])
 	}
-	// #699: the two appended columns must stay in lockstep between csvHeaders
+	// #699/#18: every appended column must stay in lockstep between csvHeaders
 	// and the record slice — a one-sided append silently shifts CSV columns.
-	if !strings.HasSuffix(lines[0], ",query_text,query_hash") {
-		t.Errorf("expected header to end with query_text,query_hash, got: %s", lines[0])
+	// commit_ts_us is last and empty for this row (no GTID event behind it), so
+	// the data row ends with the hash followed by that empty field.
+	if !strings.HasSuffix(lines[0], ",query_text,query_hash,commit_ts_us") {
+		t.Errorf("expected header to end with query_text,query_hash,commit_ts_us, got: %s", lines[0])
 	}
-	if !strings.Contains(lines[1], qText) || !strings.HasSuffix(lines[1], ","+qHash) {
+	if !strings.Contains(lines[1], qText) || !strings.HasSuffix(lines[1], ","+qHash+",") {
 		t.Errorf("expected statement text and trailing hash in data row, got: %s", lines[1])
+	}
+	if got, want := len(strings.Split(lines[0], ",")), len(strings.Split(lines[1], ",")); got != want {
+		t.Errorf("header has %d fields, data row %d — csvHeaders and the record slice diverged", got, want)
 	}
 }
 

--- a/internal/shim/handler_test.go
+++ b/internal/shim/handler_test.go
@@ -703,7 +703,7 @@ func TestRunPointInTimeDispatchesByPKColumn(t *testing.T) {
 			rows.AddRow(int64(i+1), "binlog.000001", int64(100), int64(200), now,
 				nil, nil, "myapp", "orders", parser.EventInsert,
 				fmt.Sprintf("%d", i+1), nil, nil,
-				fmt.Sprintf(`{"id":%d,"sku":"X"}`, i+1), 0, nil, nil)
+				fmt.Sprintf(`{"id":%d,"sku":"X"}`, i+1), 0, nil, nil, nil)
 		}
 		mock.ExpectQuery("FROM binlog_events").WillReturnRows(rows)
 
@@ -738,7 +738,7 @@ func binlogEventsColumns() []string {
 		"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp",
 		"gtid", "connection_id", "schema_name", "table_name", "event_type",
 		"pk_values", "changed_columns", "row_before", "row_after", "schema_version",
-		"query_text", "query_hash",
+		"query_text", "query_hash", "commit_ts_us",
 	}
 }
 
@@ -1488,7 +1488,7 @@ func TestRunPointInTimeInvokesArchiveFetcher(t *testing.T) {
 	// Live MySQL fetch may or may not run depending on planner output;
 	// stub it permissive (no expected rows) so a call is fine.
 	mock.ExpectQuery("FROM binlog_events").
-		WillReturnRows(sqlmock.NewRows([]string{"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp", "gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values", "changed_columns", "row_before", "row_after", "schema_version", "query_text", "query_hash"}))
+		WillReturnRows(sqlmock.NewRows([]string{"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp", "gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values", "changed_columns", "row_before", "row_after", "schema_version", "query_text", "query_hash", "commit_ts_us"}))
 
 	called := false
 	fakeFetcher := func(ctx context.Context, opts query.Options, src string) ([]query.ResultRow, error) {
@@ -1566,7 +1566,7 @@ func TestRunFullTableEnforcesCostCap(t *testing.T) {
 			int64(i+1), "binlog.000001", int64(100), int64(200), now,
 			nil, nil, "myapp", "orders", parser.EventInsert,
 			fmt.Sprintf("%d", i+1), nil, nil,
-			fmt.Sprintf(`{"id":%d,"sku":"X"}`, i+1), 0, nil, nil,
+			fmt.Sprintf(`{"id":%d,"sku":"X"}`, i+1), 0, nil, nil, nil,
 		)
 	}
 	mock.ExpectQuery("FROM binlog_events").WillReturnRows(rows)
@@ -1629,7 +1629,7 @@ func TestRunFullTable_Limit(t *testing.T) {
 				int64(i+1), "binlog.000001", int64(100), int64(200), now,
 				nil, nil, "myapp", "orders", parser.EventInsert,
 				fmt.Sprintf("%d", i+1), nil, nil,
-				fmt.Sprintf(`{"id":%d,"sku":"X"}`, i+1), 0, nil, nil,
+				fmt.Sprintf(`{"id":%d,"sku":"X"}`, i+1), 0, nil, nil, nil,
 			)
 		}
 		mock.ExpectQuery("FROM binlog_events").WillReturnRows(rows)
@@ -1744,7 +1744,7 @@ func TestRunPointInTimeStrictModePropagatesArchiveError(t *testing.T) {
 	mock.ExpectQuery("information_schema.PARTITIONS").
 		WillReturnRows(sqlmock.NewRows([]string{"PARTITION_NAME", "PARTITION_DESCRIPTION"}))
 	mock.ExpectQuery("FROM binlog_events").
-		WillReturnRows(sqlmock.NewRows([]string{"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp", "gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values", "changed_columns", "row_before", "row_after", "schema_version", "query_text", "query_hash"}))
+		WillReturnRows(sqlmock.NewRows([]string{"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp", "gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values", "changed_columns", "row_before", "row_after", "schema_version", "query_text", "query_hash", "commit_ts_us"}))
 
 	archiveErr := errors.New("synthetic archive failure (e.g. S3 throttling)")
 	failingFetcher := func(ctx context.Context, opts query.Options, src string) ([]query.ResultRow, error) {
@@ -1800,7 +1800,7 @@ func TestPlannerScopesPartitionsToIndexDB(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"PARTITION_NAME"}).
 			AddRow("p_2026050415"))
 	mock.ExpectQuery("FROM binlog_events").
-		WillReturnRows(sqlmock.NewRows([]string{"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp", "gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values", "changed_columns", "row_before", "row_after", "schema_version", "query_text", "query_hash"}))
+		WillReturnRows(sqlmock.NewRows([]string{"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp", "gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values", "changed_columns", "row_before", "row_after", "schema_version", "query_text", "query_hash", "commit_ts_us"}))
 
 	h := &Handler{
 		indexDB: db,
@@ -1849,7 +1849,7 @@ func TestRunDiffScopesPartitionsToIndexDB(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"PARTITION_NAME"}).
 			AddRow("p_2026050415"))
 	mock.ExpectQuery("FROM binlog_events").
-		WillReturnRows(sqlmock.NewRows([]string{"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp", "gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values", "changed_columns", "row_before", "row_after", "schema_version", "query_text", "query_hash"}))
+		WillReturnRows(sqlmock.NewRows([]string{"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp", "gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values", "changed_columns", "row_before", "row_after", "schema_version", "query_text", "query_hash", "commit_ts_us"}))
 
 	h := &Handler{
 		indexDB: db,

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -270,6 +270,7 @@ func InitIndexTables(t *testing.T, db *sql.DB) {
 		schema_version  INT UNSIGNED     NOT NULL DEFAULT 0,
 		query_text      MEDIUMTEXT       DEFAULT NULL,
 		query_hash      CHAR(64)         DEFAULT NULL,
+		commit_ts_us    BIGINT UNSIGNED  DEFAULT NULL,
 		PRIMARY KEY (event_id, event_timestamp),
 		INDEX idx_row_lookup (schema_name, table_name, event_timestamp),
 		INDEX idx_pk_hash    (schema_name, table_name, pk_hash, event_timestamp),


### PR DESCRIPTION
## Problem

Every indexed event carries a one-second `event_timestamp` — that is all the binlog's common event header holds. A busy server commits many transactions inside one second, so within that second the index preserves event **order** but not event **time**, and an indexed change cannot be lined up with any record stamped more precisely: an audit-log entry, an application trace, a slow-query line.

MySQL 8.0.1+ already writes the commit instant in **microseconds** into the GTID event. The parser read that event for its GTID and threw the rest away.

## Change

A nullable `commit_ts_us BIGINT UNSIGNED` on `binlog_events`, carried per transaction exactly like `connection_id`.

- **Parser** (file *and* stream paths): set from the GTID event, **reset** on a MariaDB GTID event. The reset matters more than the capture — carrying the previous transaction's stamp forward would produce a value that *reads as precise* while belonging to a different commit.
- **Nullable end to end**, and a zero from the parser is stored as `NULL`: rows indexed before the column existed, MariaDB sources, and MySQL older than 8.0.1 must read back "unknown", never the epoch.
- Flows through `EnsureSchema`, the query SELECT/scan, JSON and CSV output, the in-memory buffer, and the Parquet archive schema. Archive reads substitute a typed NULL when the column is absent from the files, so **every archive already on disk keeps reading** (the pre-v0.4.4 `connection_id` incident class).

Capture needs no configuration: `gtid_mode` does **not** have to be ON, because 8.0 stamps the value on the `ANONYMOUS_GTID_EVENT` it writes with GTIDs off.

Also adds the `default:` arm both event switches lacked. An event type with no case was dropped in complete silence — exactly why `ROWS_QUERY_EVENT` went unnoticed for years. It now logs at debug level with the type named.

## Tests

- **Unit** (`internal/parser`): the stamp lands on the transaction's rows; a second transaction carries its own; both "unknown" sources (MariaDB GTID event, pre-8.0.1 zero) come back as 0 with no carry-over; the unhandled-event log line names the type.
- **Integration, live server**: two real commits bracketed by the **source's own** clock — which pins the *unit* (a millisecond or nanosecond value falls outside the window by orders of magnitude) and proves capture works with `gtid_mode=OFF`, rather than asserting it in a comment.
- **Round-trips**: exact microseconds through the indexer write path, NULL for an event without one; the same both ways through Parquet — including a **pre-#18 17-column archive fixture** that must read back nil instead of Binder-erroring. That fixture is not hypothetical: the integration suite caught the `values`/`nulls`/scan triple in `ArchivePartition` going out of sync while this PR was being written.

`go test ./...` and `go test -tags integration` over parser/indexer/query/parquetquery/archive/shim/console are green.

## Not included

**XID capture**, listed as optional in the originating issue. The XID arrives at commit — *after* the transaction's row events have already been emitted downstream — so stamping it onto rows would mean buffering every transaction in memory. The GTID already brackets the transaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)