### PR TITLE
ext: extension seam for MCP tools

### DIFF
--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -194,6 +194,13 @@ automatically.
 All five are read-only — annotated `ReadOnlyHint: true` and `IdempotentHint: true`,
 so the client knows they're safe to call repeatedly and never modify state.
 
+If your client lists tools beyond these five, you are running a build that
+registers extras through the extension seam (`ext/mcpext`) — a distribution
+that wraps this core, not the stock binary. Such tools resolve their index
+through the same routing as the built-in five, so they read the server you
+selected and inherit its posture, including the console's refusal of a
+tool-level `index_dsn`.
+
 The same five tools are also served by the web console at `/mcp` (Streamable
 HTTP, console-token auth, per-server routing by URL path) — if you already run
 `bintrail-console`, you may not need this binary at all; see

--- a/ext/mcpext/mcpext.go
+++ b/ext/mcpext/mcpext.go
@@ -1,0 +1,87 @@
+// Package mcpext is the extension seam for MCP tools: an embedding
+// distribution registers a provider here and its tools appear on every MCP
+// server the core builds — the standalone bintrail-mcp binary and the web
+// console's /mcp endpoint alike.
+//
+// It is a SUBPACKAGE of ext rather than part of it because the seam is typed
+// in terms of the MCP SDK. Keeping it separate is what stops `bintrail` (which
+// links ext for the audit sink, doctor checks and source jobs, and links no
+// MCP code today) from pulling the SDK in — the same discipline that keeps the
+// core binary free of the console.
+package mcpext
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// ToolContext is the per-call index access an extension MCP tool receives.
+// The serving surface resolves it exactly the way it resolves its own tools'
+// target — the standalone server opens a connection per call from the DSN it
+// was configured with; the console resolves the selected registry server —
+// so an extension tool always reads the same index the built-in tools would.
+type ToolContext struct {
+	// DB is the open index connection. Never nil on a successful resolve.
+	// Ownership stays with the resolver: call Close (below) when done, never
+	// DB.Close directly, and do not retain DB beyond the call.
+	DB *sql.DB
+	// DBName is the index database name. Empty when the surface's DSN carries
+	// none; a tool that needs it (partition inspection, query planning) must
+	// say so rather than assume a default.
+	DBName string
+	// SourceDSN is the captured source's DSN when the serving surface knows
+	// one — the standalone server's configured source, or the selected
+	// registry entry's. Empty means "no source available", not an error: a
+	// tool that reads only the index works regardless, and a tool that needs
+	// the live source should degrade with a clear message.
+	SourceDSN string
+	// Close releases whatever the resolve allocated. Always non-nil; it is a
+	// no-op on surfaces whose connection is pool-owned (the console), and it
+	// closes the per-call connection on the standalone server. A tool that
+	// forgets to call it leaks a connection per invocation on the standalone
+	// surface.
+	Close func()
+}
+
+// ToolContextFunc resolves the ToolContext for one tool call. argDSN is
+// the tool-level index_dsn argument when the surface accepts one (standalone)
+// and empty when it does not (the console rejects DSN parameters outright — an
+// authenticated MCP client must not be able to point it at another database).
+type ToolContextFunc func(ctx context.Context, argDSN string) (ToolContext, error)
+
+// ToolProvider registers additional tools on an MCP server being built. It
+// receives the server to register on (use mcp.AddTool, exactly like the core
+// tools) and the resolver its handlers should call per invocation.
+//
+// It runs once per constructed server — the console builds one per selected
+// target — so it must not assume process-wide singleton state.
+type ToolProvider func(server *mcp.Server, resolve ToolContextFunc)
+
+// providers is empty in the OSS build: RunProviders is a no-op and the stock
+// MCP surfaces expose exactly their built-in tools.
+var providers []ToolProvider
+
+// Register registers a provider that adds tools to every MCP server
+// the core builds — the standalone bintrail-mcp server and the console's /mcp
+// endpoint alike. Same startup-only contract as the other seams: call from
+// main() before command dispatch; not safe for concurrent use with a server
+// being constructed. Registering a nil provider panics immediately so the
+// misuse fails at startup rather than at the first tool call.
+func Register(p ToolProvider) {
+	if p == nil {
+		panic("mcpext: nil MCP tool provider")
+	}
+	providers = append(providers, p)
+}
+
+// RunProviders lets every registered provider add its tools to server.
+// Called by the core after the built-in tools are registered, so a provider
+// registering a duplicate name is the provider's own error, not a silent
+// override of a core tool. Safe to call with nothing registered.
+func RunProviders(server *mcp.Server, resolve ToolContextFunc) {
+	for _, p := range providers {
+		p(server, resolve)
+	}
+}

--- a/ext/mcpext/mcpext_test.go
+++ b/ext/mcpext/mcpext_test.go
@@ -1,0 +1,70 @@
+package mcpext
+
+import (
+	"context"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// swapProviders isolates a test from the package-global registry (and from
+// whatever any other test registered).
+func swapProviders(t *testing.T) {
+	t.Helper()
+	orig := providers
+	providers = nil
+	t.Cleanup(func() { providers = orig })
+}
+
+func TestRunProvidersWithNothingRegisteredIsNoop(t *testing.T) {
+	swapProviders(t)
+	// The stock binaries take this path on every server they build: it must
+	// not panic and must not require a usable resolver.
+	RunProviders(mcp.NewServer(&mcp.Implementation{Name: "t"}, nil), nil)
+}
+
+func TestRunProvidersPassesServerAndResolver(t *testing.T) {
+	swapProviders(t)
+
+	want := ToolContext{DBName: "bintrail_index", SourceDSN: "u:p@tcp(src:3306)/", Close: func() {}}
+	resolve := func(context.Context, string) (ToolContext, error) { return want, nil }
+
+	var gotServer *mcp.Server
+	var gotCtx ToolContext
+	calls := 0
+	Register(func(s *mcp.Server, r ToolContextFunc) {
+		calls++
+		gotServer = s
+		gotCtx, _ = r(context.Background(), "")
+	})
+	// A second provider must also run: registration is additive, and a
+	// distribution may split its tools across packages.
+	second := 0
+	Register(func(*mcp.Server, ToolContextFunc) { second++ })
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "t"}, nil)
+	RunProviders(server, resolve)
+
+	if calls != 1 || second != 1 {
+		t.Fatalf("providers ran %d and %d times, want 1 each", calls, second)
+	}
+	if gotServer != server {
+		t.Error("provider received a different server than the one being built")
+	}
+	if gotCtx.DBName != want.DBName || gotCtx.SourceDSN != want.SourceDSN {
+		t.Errorf("provider's resolver returned %+v, want the surface's context (%+v)", gotCtx, want)
+	}
+}
+
+// A nil provider is a programming error at startup. Failing there beats a nil
+// dereference on the first tool call, which would surface as a dead MCP
+// endpoint in production.
+func TestRegisterNilPanics(t *testing.T) {
+	swapProviders(t)
+	defer func() {
+		if recover() == nil {
+			t.Error("Register(nil) did not panic")
+		}
+	}()
+	Register(nil)
+}

--- a/ext/mcpext/testing.go
+++ b/ext/mcpext/testing.go
@@ -1,0 +1,8 @@
+package mcpext
+
+// ResetForTest clears the provider registry so tests in other packages can
+// register fixtures without polluting later tests in the same binary. Mirrors
+// ext.ResetForTest. Test helper ONLY — the registry is startup-only by
+// contract (set once from main(), never mutated during command execution), and
+// production code must never call this.
+func ResetForTest() { providers = nil }

--- a/internal/console/mcp.go
+++ b/internal/console/mcp.go
@@ -119,9 +119,19 @@ func (s *Server) newMCPServer(id string) *mcp.Server {
 			if err != nil {
 				return nil, err
 			}
+			// The selected entry's source DSN, when it has one: extension
+			// tools (ext/mcpext) may need the live source, and this is the
+			// same value the extension VIEW seam hands a provider. Read from
+			// the registry, never from a tool argument. Empty for the boot
+			// entry and for a selection with no source configured.
+			sourceDSN := ""
+			if e, ok := s.cm.reg.Get(id); ok {
+				sourceDSN = e.SourceDSN
+			}
 			return &mcptools.Target{
-				DB:     b.db,
-				DBName: b.dbName,
+				DB:        b.db,
+				DBName:    b.dbName,
+				SourceDSN: sourceDSN,
 				// Time travel (#953): the bundle's own lookup, NOT
 				// reconstruct.FindBaseline — the method carries the #766
 				// local→S3 fallback, and binding the package function directly

--- a/internal/mcptools/extension_test.go
+++ b/internal/mcptools/extension_test.go
@@ -1,0 +1,164 @@
+package mcptools
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/dbtrail/dbtrail/ext/mcpext"
+)
+
+// The extension seam's value is that a distribution's tools reach the SAME
+// index the built-in tools would, under the same posture. These tests pin the
+// properties that carry that: a provider runs on every server NewServer
+// builds, the context it resolves mirrors the surface's own target, and
+// connection OWNERSHIP survives the adaptation — a per-call standalone
+// connection is closed, a console-pooled one is not.
+
+func withCleanProviders(t *testing.T) {
+	t.Helper()
+	mcpext.ResetForTest()
+	t.Cleanup(mcpext.ResetForTest)
+}
+
+// standaloneLikeConfig mirrors the standalone surface: DSN parameter accepted,
+// connection opened per call and owned by the handler. EnsureSchema stays off
+// so the fixture needs no migration round trip.
+func standaloneLikeConfig(db *sql.DB, sourceDSN string) Config {
+	return Config{
+		AllowDSNParam: true,
+		Resolve: func(context.Context, string) (*Target, error) {
+			return &Target{
+				DB:        db,
+				DBName:    "bintrail_index",
+				SourceDSN: sourceDSN,
+				CloseDB:   true,
+			}, nil
+		},
+	}
+}
+
+func TestNewServerRunsExtensionProviders(t *testing.T) {
+	withCleanProviders(t)
+
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	var (
+		gotServer *mcp.Server
+		gotCtx    mcpext.ToolContext
+		gotErr    error
+		ran       int
+	)
+	mcpext.Register(func(s *mcp.Server, resolve mcpext.ToolContextFunc) {
+		ran++
+		gotServer = s
+		gotCtx, gotErr = resolve(context.Background(), "")
+	})
+
+	server := NewServer(standaloneLikeConfig(db, "u:p@tcp(src:3306)/shop"))
+
+	if ran != 1 {
+		t.Fatalf("provider ran %d times, want 1", ran)
+	}
+	if gotServer != server {
+		t.Error("provider was handed a different server than NewServer returned")
+	}
+	if gotErr != nil {
+		t.Fatalf("resolve: %v", gotErr)
+	}
+	if gotCtx.DB != db {
+		t.Error("resolved context does not carry the surface's index connection")
+	}
+	if gotCtx.DBName != "bintrail_index" {
+		t.Errorf("DBName = %q, want bintrail_index", gotCtx.DBName)
+	}
+	// The source DSN is the one thing an extension tool cannot get any other
+	// way: the built-in tools never touch the source, so nothing else would
+	// notice it being dropped in the adaptation.
+	if gotCtx.SourceDSN != "u:p@tcp(src:3306)/shop" {
+		t.Errorf("SourceDSN = %q, want the surface's source DSN", gotCtx.SourceDSN)
+	}
+	if gotCtx.Close == nil {
+		t.Error("Close is nil — the seam documents it as always callable")
+	}
+}
+
+// TestExtToolContextClosesOnlyOwnedConnections: Close must close a per-call
+// standalone connection and do NOTHING to a console-pooled one. Getting this
+// backwards is invisible in a smoke test and catastrophic in production —
+// either a connection leak per tool call, or a live daemon's pooled handle
+// closed out from under every other request.
+func TestExtToolContextClosesOnlyOwnedConnections(t *testing.T) {
+	tests := []struct {
+		name       string
+		closeDB    bool
+		wantClosed bool
+	}{
+		{name: "standalone owns the connection", closeDB: true, wantClosed: true},
+		{name: "console pool owns the connection", closeDB: false, wantClosed: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("sqlmock: %v", err)
+			}
+			defer db.Close()
+			if tc.wantClosed {
+				mock.ExpectClose()
+			}
+
+			resolve := extToolContext(Config{
+				AllowDSNParam: true,
+				Resolve: func(context.Context, string) (*Target, error) {
+					return &Target{DB: db, DBName: "idx", CloseDB: tc.closeDB}, nil
+				},
+			})
+			tctx, err := resolve(context.Background(), "")
+			if err != nil {
+				t.Fatalf("resolve: %v", err)
+			}
+			tctx.Close()
+
+			err = mock.ExpectationsWereMet()
+			if tc.wantClosed && err != nil {
+				t.Errorf("the per-call connection was not closed: %v", err)
+			}
+			if !tc.wantClosed {
+				// Nothing was expected; a Close would have been an
+				// unexpected call and surfaced here.
+				if err != nil {
+					t.Errorf("a pooled connection must not be closed by the seam: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// TestExtToolContextRejectsDSNParamOnRoutingSurfaces: the console refuses
+// tool-level index_dsn on its own tools so an authenticated MCP client cannot
+// point the daemon at an arbitrary database. An extension tool must not become
+// the way around that.
+func TestExtToolContextRejectsDSNParamOnRoutingSurfaces(t *testing.T) {
+	var sawDSN string
+	resolve := extToolContext(Config{
+		AllowDSNParam: false,
+		Resolve: func(_ context.Context, argDSN string) (*Target, error) {
+			sawDSN = argDSN
+			return &Target{DB: nil, DBName: "idx"}, nil
+		},
+	})
+	if _, err := resolve(context.Background(), "attacker:pw@tcp(evil:3306)/x"); err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if sawDSN != "" {
+		t.Errorf("the surface's resolver received argDSN = %q; a routing surface must never see one", sawDSN)
+	}
+}

--- a/internal/mcptools/mcptools.go
+++ b/internal/mcptools/mcptools.go
@@ -38,6 +38,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/dbtrail/dbtrail/ext"
+	"github.com/dbtrail/dbtrail/ext/mcpext"
 	"github.com/dbtrail/dbtrail/internal/cliutil"
 	"github.com/dbtrail/dbtrail/internal/config"
 	"github.com/dbtrail/dbtrail/internal/indexer"
@@ -66,6 +67,11 @@ type Target struct {
 	// the standalone surface when the DSN carries no database name — the
 	// status tool then refuses with an actionable error.
 	DBName string
+	// SourceDSN is the captured source's DSN when the serving surface knows
+	// one. The built-in tools never use it — they read the index only — but
+	// it is handed to extension tools (ext/mcpext), which may need the live
+	// source. Empty means "no source available", not an error.
+	SourceDSN string
 	// CloseDB is true when the connection was opened for this call and the
 	// handler must close it (standalone). False when the connection is owned
 	// by a long-lived pool (console connManager bundles).
@@ -320,7 +326,52 @@ func NewServer(cfg Config) *mcp.Server {
 		}, MakeReconstructTool(cfg))
 	}
 
+	// Extension tools (mcpext.Register) are added AFTER the built-ins, so a
+	// provider that reuses a core tool name collides visibly instead of
+	// silently replacing it. They resolve their target through the same
+	// Config.Resolve this surface uses, which is what keeps an extension tool
+	// reading the index the operator selected rather than one of its own
+	// choosing. No-op in the stock binaries.
+	mcpext.RunProviders(server, extToolContext(cfg))
+
 	return server
+}
+
+// extToolContext adapts this surface's ResolveTarget into the seam's resolver.
+// Two things are deliberately preserved across the adaptation: the schema
+// migration the surface would run for its own tools (so an extension tool sees
+// the same columns), and connection OWNERSHIP — Close closes a per-call
+// standalone connection and does nothing for a console-pooled one, so a
+// provider has one correct thing to call either way.
+func extToolContext(cfg Config) mcpext.ToolContextFunc {
+	return func(ctx context.Context, argDSN string) (mcpext.ToolContext, error) {
+		if !cfg.AllowDSNParam {
+			// The console rejects DSN parameters on its own tools for the same
+			// reason: an authenticated MCP client must not be able to point the
+			// daemon at an arbitrary database. Extension tools inherit that.
+			argDSN = ""
+		}
+		t, err := cfg.Resolve(ctx, argDSN)
+		if err != nil {
+			return mcpext.ToolContext{}, err
+		}
+		closeFn := func() {}
+		if t.CloseDB {
+			closeFn = func() { t.DB.Close() }
+		}
+		if t.EnsureSchema {
+			if err := indexer.EnsureSchema(t.DB); err != nil {
+				closeFn()
+				return mcpext.ToolContext{}, fmt.Errorf("schema migration: %w", err)
+			}
+		}
+		return mcpext.ToolContext{
+			DB:        t.DB,
+			DBName:    t.DBName,
+			SourceDSN: t.SourceDSN,
+			Close:     closeFn,
+		}, nil
+	}
 }
 
 // DSNTarget adapts a DSN resolution function (override > tool arg > env var,
@@ -342,8 +393,14 @@ func DSNTarget(resolve func(argDSN string) (string, error)) ResolveTarget {
 			return nil, err
 		}
 		return &Target{
-			DB:                  db,
-			DBName:              cfg.DBName,
+			DB:     db,
+			DBName: cfg.DBName,
+			// The standalone server has no per-request server selection, so
+			// its source — when the operator configured one — is the process
+			// environment's. Only extension tools read it; the built-in tools
+			// never touch the source (reconstruct included — it folds a
+			// baseline snapshot with indexed events, never the live server).
+			SourceDSN:           os.Getenv("BINTRAIL_SOURCE_DSN"),
 			CloseDB:             true,
 			EnsureSchema:        true,
 			EnvArchiveDiscovery: true,


### PR DESCRIPTION
## Problem

The MCP surfaces were the last extension point a distribution built on this core could not reach. `cliapp.AddCommands` adds CLI commands, `ext.ConsoleViewProvider` adds a console view, `ext.RegisterSourceJob` adds daemon work — but the tool set on `bintrail-mcp` and on the console's `/mcp` endpoint was fixed. Anything a distribution wanted to expose to an MCP client needed a **second server** in the client's config, with its own connection routing and its own auth.

## Change

`ext/mcpext`: a provider registers at startup and its tools appear on **every** MCP server the core builds — standalone and console alike — resolving their target through the same `Config.Resolve` the built-in four use.

That last part is the point: an extension tool reads the index the operator actually selected, including the console's per-URL server routing, instead of a database of its own choosing.

Three properties are carried across the adaptation deliberately:

- **Connection ownership.** `ToolContext.Close` closes a per-call standalone connection and does nothing to a console-pooled one. Backwards is invisible in a smoke test and bad in production either way: a leak per tool call, or a live daemon's pooled handle closed under every other request.
- **The DSN-parameter refusal.** A surface that routes connections itself never sees a tool-level `index_dsn` — an extension tool cannot become the way around the console's "an authenticated MCP client must not point the daemon at an arbitrary database".
- **The schema migration** the surface would run for its own tools, so an extension tool sees the same columns.

`ToolContext` also carries `SourceDSN` (the standalone server's configured source, or the selected registry entry's), mirroring the console view seam. The built-in tools never touch the source, so nothing else would notice it being dropped.

## Why a subpackage of `ext`

The seam is typed in terms of the MCP SDK. `bintrail` links `ext` today and links **no** MCP code; `go list -deps ./cmd/bintrail | grep -c modelcontextprotocol` still reports `0` after this change. Same discipline that keeps the core binary free of the console.

## Tests

`ext/mcpext`: no-op with nothing registered, providers run additively with the server and resolver they were promised, `Register(nil)` panics at startup rather than nil-dereferencing at the first tool call.

`internal/mcptools`: a provider runs on a server built by `NewServer` and its resolved context carries the surface's DB / DBName / SourceDSN; the close-ownership matrix (standalone closes, pooled does not) via sqlmock `ExpectClose`; and a routing surface never passes `argDSN` through.

No behavior change in the stock binaries: with nothing registered, `RunProviders` is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)