### PR TITLE
verify: add a recover-input check that walks the before-image chain (#1001)

### DIFF
--- a/docs/verify.md
+++ b/docs/verify.md
@@ -146,6 +146,14 @@ oldest events were walked, so a clean result would be a partial check. A
 mismatch found inside a truncated window *is* still conclusive: the events that
 were walked are real.
 
+> **The `30d` default assumes your window is actually covered.** If partitions
+> older than your retention were rotated out of MySQL and never archived to
+> Parquet, a 30-day lookback covers hours that no longer exist, and *every*
+> table reports `inconclusive` with a coverage-gap reason. That is correct
+> behavior, not a bug — but the fix is to **shorten `--lookback`** to your real
+> retention (or enable archiving), not to ignore the result. Since an
+> all-inconclusive run exits non-zero, a cron gate will tell you immediately.
+
 Memory bound: the walk loads at most `--max-events` events per table (default
 200,000) plus one row of state per distinct primary key seen. The cap is a
 **row count, not a byte budget** — a BLOB/TEXT-heavy table is still large at a

--- a/docs/verify.md
+++ b/docs/verify.md
@@ -150,8 +150,10 @@ Three other conditions also report `inconclusive` rather than risk a false alarm
   continuity record cannot be read at all (one predating those columns) reports
   `inconclusive` for the same reason: *unknown* is not *no gap*;
 - a window that **exceeded `--max-events`** — only its oldest events were
-  walked, so a clean result would be a partial check. A mismatch found inside a
-  truncated window *is* still conclusive: the events that were walked are real.
+  walked, so a clean result would be a partial check.
+
+A mismatch found inside a truncated window *is* still conclusive: the events
+that were walked are real.
 
 **A chain break tells you the chain broke, not why.** A `mismatch` here means
 `row_before` did not match the state the previous event on that key left. Two

--- a/docs/verify.md
+++ b/docs/verify.md
@@ -139,12 +139,54 @@ that is the normal case for any retention window, not corruption. Later events
 on the same key *are* asserted, so a table is still proven as long as at least
 one comparison was made; a table where *none* was reports `inconclusive`.
 
-Two other conditions also report `inconclusive` rather than risk a false alarm:
-a **coverage gap** in the window (a chain with an interior hole cannot be
-asserted against), and a window that **exceeded `--max-events`** — only its
-oldest events were walked, so a clean result would be a partial check. A
-mismatch found inside a truncated window *is* still conclusive: the events that
-were walked are real.
+Three other conditions also report `inconclusive` rather than risk a false alarm:
+
+- a **coverage gap** in the window (a chain with an interior hole cannot be
+  asserted against);
+- a **recorded permanent loss** inside the window — `bintrail status` shows it
+  as `GAP LOST`, and it is stamped in `stream_state.gap_lost_at`. Those events
+  are gone from live MySQL *and* from every archive, so the chains that cross
+  the loss have a hole nothing can be asserted across. An index whose
+  continuity record cannot be read at all (one predating those columns) reports
+  `inconclusive` for the same reason: *unknown* is not *no gap*;
+- a window that **exceeded `--max-events`** — only its oldest events were
+  walked, so a clean result would be a partial check. A mismatch found inside a
+  truncated window *is* still conclusive: the events that were walked are real.
+
+**A chain break tells you the chain broke, not why.** A `mismatch` here means
+`row_before` did not match the state the previous event on that key left. Two
+explanations produce byte-identical evidence, and the check cannot choose
+between them:
+
+1. **The events in between were never captured.** Coverage detection is
+   *partition-existence* based, so a hole *inside* an hour whose partition
+   exists is invisible to it — an `ALTER` without a re-`snapshot` (the indexer
+   logs a column-count warning and *skips that table's events*), a mid-history
+   `--tables`/`--schemas` filter change, a `stream --reset`, or an outage
+   shorter than the pre-created partition horizon.
+2. **The stored before-image is stale or corrupt.**
+
+To tell them apart, check `bintrail status` continuity and the indexer/stream
+logs for skipped tables, filter changes, resets or downtime covering the
+window, and compare against the source's own binlog history. Do not start from
+the assumption that the images are corrupt — a capture hole is at least as
+likely.
+
+**Partial coverage annotates a verdict, it does not erase it.** A table is
+proven as soon as *one* before-image comparison was conclusive; everything that
+stayed unproven is carried as a note on that verdict (visible in `reason`)
+rather than collapsing the table:
+
+| Not checked | Effect |
+|---|---|
+| chains beginning mid-history | noted |
+| a value whose representation could not be normalized (an unmapped `ENUM` ordinal, a JSON document the event image cannot render faithfully) | noted |
+| **drift rows** — events the index holds with no primary key (`pk_values` NULL) | noted; they belong to no chain and are never walked |
+| the entire tail of the window (`--max-events` exceeded) | **collapses** the table to `inconclusive` |
+
+Only a table where *nothing* was conclusive reports `inconclusive`. This
+matters for CI: one unresolvable JSON value in a 200,000-event window used to
+discard every clean assertion beside it and fail the gate on a healthy index.
 
 > **The `30d` default assumes your window is actually covered.** If partitions
 > older than your retention were rotated out of MySQL and never archived to
@@ -168,7 +210,8 @@ Results are **per table**, one of:
 - **inconclusive** — verify could not prove the table either way, and this is
   **never reported as a failure**. Causes include: no predecessor baseline yet,
   the index is behind the baseline anchor, an unsupported primary key, a coverage
-  gap, a digest-contract skew between a pre-pin baseline and the current scan
+  gap, a recorded permanent loss (`gap_lost_at`) inside the window, a
+  digest-contract skew between a pre-pin baseline and the current scan
   (regenerate the baseline — see below), or a value class this version cannot yet
   compare.
 

--- a/docs/verify.md
+++ b/docs/verify.md
@@ -19,14 +19,28 @@ It is read-only and never writes to your source or your index.
   to write rows to the table being compared. A MATCH is strong evidence the
   capture-and-reconstruct pipeline works; it is not tamper-evident or
   forensic-grade proof.
-- **It does not exercise the `recover` path.** `verify` reconstructs full-table
-  state from the *latest* event per PK (`row_after`, `LimitPerPK=1`).
-  `recover`'s reversal SQL additionally depends on `row_before` images,
-  DELETE row images, and intermediate events later superseded by a newer event
-  on the same PK — none of which a table-content match touches. A corrupt
-  `row_before`, a corrupt DELETE image, or a corrupt superseded intermediate
-  event can all pass `verify` cleanly while still producing a wrong `recover`
-  reversal from that same data.
+- **The default (content) check does not exercise the `recover` path.** With
+  `--check content` — the default — `verify` reconstructs full-table state from
+  the *latest* event per PK (`row_after`, `LimitPerPK=1`). `recover`'s reversal
+  SQL additionally depends on `row_before` images, DELETE row images, and
+  intermediate events later superseded by a newer event on the same PK — none
+  of which a table-content match touches. A corrupt `row_before`, a corrupt
+  DELETE image, or a corrupt superseded intermediate event can all pass a
+  content check cleanly while still producing a wrong `recover` reversal from
+  that same data.
+
+  **`--check recover` closes exactly that hole** — see
+  [Recover-input](#recover-input---check-recover) below. It is a *separate
+  run*: a clean `--check content` still proves nothing about `recover`'s
+  inputs, and a clean `--check recover` proves nothing about full-table
+  content. Run both to cover both.
+- **`--check recover` proves internal consistency, not external truth.** It
+  asserts the stored images agree *with each other* along each primary key's
+  chain. It has no independent ground truth, so a chain that was captured
+  self-consistently but wrongly (e.g. every image for a row derived from the
+  same bad source read) still passes. It also cannot prove the reversal SQL
+  *applies* to today's schema — a column dropped after capture makes `recover`
+  refuse at generation time, which is a schema-drift concern, not an image one.
 - **It does not exercise point-in-time reconstruction to an arbitrary instant
   between two anchors.** Baseline-anchored mode compares two baseline anchors
   (or a baseline vs. the live source at scan time); there is no independent
@@ -43,7 +57,16 @@ It is read-only and never writes to your source or your index.
   reconstruction itself is correct — the live table simply kept moving during
   the read.
 
-## The two modes
+## The modes
+
+`--check` selects **what** is verified; within the default `--check content`,
+passing or omitting `--source-dsn` selects **what it is compared against**.
+
+| | Reads | Answers |
+|---|---|---|
+| `--check content` (default), no `--source-dsn` | two baselines + index | does the reconstruction match the next baseline? |
+| `--check content` + `--source-dsn` | baseline + index + live source | does the reconstruction match the live table? |
+| `--check recover` | index only | are the before/after images `recover` consumes internally consistent? |
 
 ### Baseline-anchored (default, drift-free)
 
@@ -76,6 +99,57 @@ reads the whole table off the live server, so **run it off-peak**.
 bintrail verify --source-dsn "$SRC" --index-dsn "$IDX" \
   --baseline-s3 s3://bucket/baselines --tables mydb.orders,mydb.users
 ```
+
+### Recover-input (`--check recover`)
+
+Pass `--check recover`. Instead of comparing table content, `verify` walks each
+primary key's **event chain** in time order and asserts the images are
+internally consistent — the data `bintrail recover` actually reads to build
+reversal SQL:
+
+| `recover` reverses | by reading |
+|---|---|
+| `DELETE` → `INSERT` | `row_before` (the deleted row) |
+| `UPDATE` → reverse `UPDATE` | `row_before` (the `SET`) **and** `row_after` (the `WHERE`) |
+| `INSERT` → `DELETE` | `row_after` (the `WHERE`) |
+
+So per event it checks that every image `recover` dereferences is present, that
+no unchanged-TOAST marker survived capture, and — the core assertion — that
+each `UPDATE`/`DELETE` **`row_before` equals the state the previous event on
+that same key left behind**. Events superseded by a newer event on the same key
+are walked too; that is precisely the class `--check content` skips.
+
+It reads **the index only** — no baseline, no live source — so
+`--baseline-dir`/`--baseline-s3` are not required and `--source-dsn` is
+rejected.
+
+```sh
+# Walk the last 7 days of chains for every table in the schema snapshot
+bintrail verify --index-dsn "$IDX" --check recover --lookback 7d
+
+# One table, machine-readable, for a CI gate
+bintrail verify --index-dsn "$IDX" --check recover \
+  --tables mydb.orders --format json
+```
+
+**A window that begins mid-history is `inconclusive`, never `mismatch`.** The
+first event on a key inside `--lookback` usually has no predecessor in the
+window (the row already existed), so there is nothing to assert against it —
+that is the normal case for any retention window, not corruption. Later events
+on the same key *are* asserted, so a table is still proven as long as at least
+one comparison was made; a table where *none* was reports `inconclusive`.
+
+Two other conditions also report `inconclusive` rather than risk a false alarm:
+a **coverage gap** in the window (a chain with an interior hole cannot be
+asserted against), and a window that **exceeded `--max-events`** — only its
+oldest events were walked, so a clean result would be a partial check. A
+mismatch found inside a truncated window *is* still conclusive: the events that
+were walked are real.
+
+Memory bound: the walk loads at most `--max-events` events per table (default
+200,000) plus one row of state per distinct primary key seen. The cap is a
+**row count, not a byte budget** — a BLOB/TEXT-heavy table is still large at a
+given event count, so lower `--max-events` or narrow `--lookback` for those.
 
 ## What it reports
 
@@ -123,7 +197,7 @@ bintrail verify --index-dsn "$IDX" --baseline-dir /data/baselines --format json
 }
 ```
 
-- `mode` — `baseline-anchored` or `live-source`.
+- `mode` — `baseline-anchored`, `live-source`, or `recover-inputs`.
 - `verdict` — the run outcome, matching the exit code: `verified` (exit 0),
   `mismatch`, `error`, `unproven` (tables reported, none proven — exit non-zero),
   or `no_predecessor` (only one baseline; reported, exit 0, with a `message`).
@@ -131,6 +205,12 @@ bintrail verify --index-dsn "$IDX" --baseline-dir /data/baselines --format json
   bucket counted in `summary`. `anchor` is the point the comparison was anchored
   to (a GTID set in live-source mode, a `file:pos` binlog coordinate in
   baseline-anchored mode); `reason` is the detail behind the verdict.
+- `tables[].events_checked` / `chains_checked` / `chains_inconclusive` —
+  present only under `--check recover` (omitted entirely otherwise, so a
+  content-mode document is unchanged): how many events the chain walk visited,
+  how many distinct primary keys it walked, and how many of those began
+  mid-window with no predecessor to assert against. The row-count and digest
+  fields stay absent in this mode — it compares no table content.
 - `explain[]` — present only with `--explain`: per mismatched table, the capped
   list of differing rows (`pk`, `kind`, and per-column `recovery` vs `baseline`
   values), `total_differing_rows`, `overflow_by_kind` for the rows beyond the
@@ -180,8 +260,13 @@ diff tool involved.
 | `--no-archive` | `false` | Query live MySQL partitions only; skip Parquet archive discovery |
 | `--explain` | `false` | On a baseline-anchored mismatch, print a per-row drill-down |
 | `--format` | `text` | Output format: `text` or `json` (see [Machine-readable output](#machine-readable-output---format-json)) |
+| `--check` | `content` | What to verify: `content` (reconstructed table content) or `recover` (`recover`'s before/after image inputs, index-only) |
+| `--lookback` | `30d` | `--check recover` only: how far back to walk each key's event chain (e.g. `30d`, `24h`) |
+| `--max-events` | `200000` | `--check recover` only: per-table cap on events loaded; exceeding it reports `inconclusive` rather than a partial check |
 
-One of `--baseline-dir` or `--baseline-s3` is **required** — `verify` always reads baselines, in both modes.
+One of `--baseline-dir` or `--baseline-s3` is **required** for `--check content`
+(both of its modes read baselines). `--check recover` reads the index only, so
+it requires neither — and rejects `--source-dsn`, which it would not use.
 
 It also accepts the shared DuckDB tuning flags (`--ultrafast`,
 `--duckdb-threads`, `--duckdb-memory-limit`) — see the DuckDB resource tuning
@@ -193,9 +278,12 @@ section in [Query & Recovery](query-and-recovery.md).
   (delta-only).
 - **`reconstruct`** materializes a *full table or row* at a point in time
   (baseline + deltas).
-- **`verify`** doesn't recover anything — it *checks* that the `reconstruct`
-  chain is sound, so you find out your recoveries are trustworthy **before** you
-  need them.
+- **`verify`** doesn't recover anything — it *checks* that these are sound, so
+  you find out your recoveries are trustworthy **before** you need them.
+  `--check content` checks the `reconstruct` chain (baseline + deltas → full
+  state); `--check recover` checks the images `recover` itself consumes
+  (`row_before`, DELETE pre-images, superseded events). They cover different
+  data and neither implies the other.
 
 See also: the stream-continuity "no data lost" signal in
 [`bintrail status`](rotation-and-status.md#stream-continuity-no-data-lost), which

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	mysqldriver "github.com/go-sql-driver/mysql"
 	"github.com/spf13/cobra"
@@ -28,6 +29,17 @@ var (
 	vfyNoArchive   bool
 	vfyExplain     bool
 	vfyFormat      string
+	vfyCheck       string
+	vfyLookback    string
+	vfyMaxEvents   int
+)
+
+// The --check values. checkContent is the historical behavior (reconstructed
+// full-table content vs a baseline or the live source); checkRecover is the
+// recover-input chain walk (#1001).
+const (
+	checkContent = "content"
+	checkRecover = "recover"
 )
 
 var verifyCmd = &cobra.Command{
@@ -54,6 +66,18 @@ on any mismatch or error, or when comparable tables existed but none could be
 proven (all inconclusive). A source with only one baseline — no predecessor yet
 — is reported and exits zero.
 
+Both of the above compare full-table CONTENT, reconstructed from the latest
+event per primary key. That cannot exercise the data "bintrail recover" reads
+to build reversal SQL — before-images, DELETE pre-images, and events a newer
+event on the same key superseded. Pass --check recover for that:
+
+  Recover-input — --check recover. Walks each primary key's event chain in time
+  order and asserts the images are internally consistent (every UPDATE/DELETE
+  before-image equals the state the previous event on that key left). Reads the
+  index ONLY: no baseline, no live source. A chain that begins mid-window has
+  no predecessor and is reported inconclusive, never as a mismatch. Bound the
+  window with --lookback and the per-table event budget with --max-events.
+
 Add --explain (baseline-anchored mode) to print, below the report, a row-level
 drill-down of each mismatch: which primary keys diverged and, for changed rows,
 the differing columns with the reconstructed value vs the new baseline's. It
@@ -74,7 +98,10 @@ Examples:
 
   # Live-source, specific tables, S3 baselines
   bintrail verify --source-dsn "..." --index-dsn "..." \
-    --baseline-s3 s3://bucket/baselines --tables mydb.orders,mydb.users`,
+    --baseline-s3 s3://bucket/baselines --tables mydb.orders,mydb.users
+
+  # Recover-input check over the last 7 days (no baseline needed)
+  bintrail verify --index-dsn "..." --check recover --lookback 7d`,
 	RunE: runVerify,
 }
 
@@ -87,6 +114,9 @@ func init() {
 	verifyCmd.Flags().BoolVar(&vfyNoArchive, "no-archive", false, "Query live MySQL partitions only; skip Parquet archive discovery")
 	verifyCmd.Flags().BoolVar(&vfyExplain, "explain", false, "On a baseline-anchored mismatch, print a row-level drill-down (which primary keys diverged and how) below the report")
 	verifyCmd.Flags().StringVar(&vfyFormat, "format", "text", "Output format: text or json")
+	verifyCmd.Flags().StringVar(&vfyCheck, "check", checkContent, "What to verify: content (reconstructed table content vs a baseline or the live source) or recover (recover's before/after image inputs, index-only)")
+	verifyCmd.Flags().StringVar(&vfyLookback, "lookback", "30d", "--check recover only: how far back to walk each primary key's event chain (e.g. 30d, 24h)")
+	verifyCmd.Flags().IntVar(&vfyMaxEvents, "max-events", verify.DefaultRecoverInputsMaxEvents, "--check recover only: per-table cap on events loaded for the chain walk; exceeding it reports inconclusive rather than a partial check")
 	AddDuckDBTuningFlags(verifyCmd)
 }
 
@@ -97,11 +127,24 @@ func runVerify(cmd *cobra.Command, _ []string) error {
 	if vfyIndexDSN == "" {
 		return fmt.Errorf("--index-dsn is required")
 	}
+	switch vfyCheck {
+	case checkContent, checkRecover:
+	default:
+		return fmt.Errorf("invalid --check %q; must be %s or %s", vfyCheck, checkContent, checkRecover)
+	}
 	baselineSrc := vfyBaselineDir
 	if baselineSrc == "" {
 		baselineSrc = vfyBaselineS3
 	}
-	if baselineSrc == "" {
+	// The recover-input check reads binlog_events and nothing else, so
+	// requiring a baseline it never opens would refuse a perfectly runnable
+	// verification. --source-dsn is likewise unused there: accepting it
+	// silently would imply the live source was consulted when it was not.
+	if vfyCheck == checkRecover {
+		if vfySourceDSN != "" {
+			return fmt.Errorf("--source-dsn is not used by --check recover (it verifies recover's inputs from the index alone); omit it")
+		}
+	} else if baselineSrc == "" {
 		return fmt.Errorf("one of --baseline-dir or --baseline-s3 is required")
 	}
 
@@ -131,6 +174,12 @@ func runVerify(cmd *cobra.Command, _ []string) error {
 	duckTuning, err := DuckDBTuningFromFlags(cmd)
 	if err != nil {
 		return err
+	}
+
+	if vfyCheck == checkRecover {
+		// Index-only, source-family agnostic: it walks stored event images,
+		// so it needs neither the source flavor nor a baseline.
+		return runVerifyRecoverInputs(cmd, indexDB, resolver, indexDBName, duckTuning)
 	}
 
 	flavor := query.SourceFlavor(indexDB)
@@ -385,6 +434,55 @@ func runVerifyLive(cmd *cobra.Command, indexDB *sql.DB, resolver *metadata.Resol
 	rep := verify.NewReport(verify.ModeLive, results)
 	rep.BaselineSource = baselineSrc
 	return emitVerifyReport(cmd, rep)
+}
+
+// runVerifyRecoverInputs is the recover-input check (#1001): for each table,
+// walk the per-PK event chains and assert the before/after images `recover`
+// consumes are internally consistent.
+//
+// It shares the report, the renderer and — critically — Report.ExitError with
+// the content modes, so a recover-input mismatch fails a CI/cron gate exactly
+// like any other mismatch instead of going through a second exit path.
+func runVerifyRecoverInputs(cmd *cobra.Command, indexDB *sql.DB, resolver *metadata.Resolver, indexDBName string, duckTuning duckdbutil.Tuning) error {
+	lookback, err := cliutil.ParseRetain(vfyLookback)
+	if err != nil {
+		return fmt.Errorf("--lookback: %w", err)
+	}
+	if vfyMaxEvents < 0 {
+		return fmt.Errorf("--max-events must be >= 0 (0 uses the default of %d)", verify.DefaultRecoverInputsMaxEvents)
+	}
+
+	tables, err := verifyTargetTables(cmd, indexDB)
+	if err != nil {
+		return err
+	}
+	if len(tables) == 0 {
+		return fmt.Errorf("no tables to verify (empty --tables and no schema snapshot)")
+	}
+
+	until := time.Now().UTC()
+	cfg := verify.RecoverInputsConfig{
+		IndexDB:        indexDB,
+		Resolver:       resolver,
+		IndexDBName:    indexDBName,
+		NoArchive:      vfyNoArchive,
+		ArchiveFetcher: TunedArchiveFetcher(duckTuning),
+		Since:          until.Add(-lookback),
+		Until:          until,
+		MaxEvents:      vfyMaxEvents,
+	}
+
+	results := make([]verify.TableResult, 0, len(tables))
+	for _, st := range tables {
+		res, err := verify.VerifyRecoverInputs(cmd.Context(), cfg, st.schema, st.table)
+		if err != nil {
+			// One table's hard error must not abort the run and hide the
+			// other tables' results (including real mismatches).
+			res = verify.TableResult{Schema: st.schema, Table: st.table, Status: verify.StatusError, Detail: err.Error()}
+		}
+		results = append(results, res)
+	}
+	return emitVerifyReport(cmd, verify.NewReport(verify.ModeRecoverInputs, results))
 }
 
 // verifyTableFilter parses --tables into a "schema.table" set, or nil for all.

--- a/internal/verify/recover_inputs.go
+++ b/internal/verify/recover_inputs.go
@@ -7,12 +7,14 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/dbtrail/dbtrail/internal/event"
 	"github.com/dbtrail/dbtrail/internal/metadata"
 	"github.com/dbtrail/dbtrail/internal/query"
 	"github.com/dbtrail/dbtrail/internal/reconstruct"
+	"github.com/dbtrail/dbtrail/internal/status"
 )
 
 // ─── Recover-input verification (#1001) ───────────────────────────────────────
@@ -65,7 +67,9 @@ type RecoverInputsConfig struct {
 // It fetches the window in ASCENDING time order with NO LimitPerPK — every
 // superseded intermediate event is visited, which is precisely the class the
 // content-comparison modes skip. Coverage gaps abort as INCONCLUSIVE (a chain
-// with an interior hole cannot be asserted against), never as a mismatch.
+// with an interior hole cannot be asserted against), never as a mismatch — and
+// so does a permanent loss stamped in stream_state.gap_lost_at, which the
+// partition-existence coverage check upstream cannot see.
 func VerifyRecoverInputs(ctx context.Context, cfg RecoverInputsConfig, schema, table string) (TableResult, error) {
 	res := TableResult{Schema: schema, Table: table}
 
@@ -86,6 +90,24 @@ func VerifyRecoverInputs(ctx context.Context, cfg RecoverInputsConfig, schema, t
 	// without the index database name.
 	if cfg.IndexDBName == "" {
 		return inconclusive(res, "index database name unavailable; coverage-gap detection cannot run, and an undetected gap would read as a false mismatch"), nil
+	}
+
+	// The coverage-gap guard below (query.FetchMerged's strict-mode GapError) is
+	// PARTITION-EXISTENCE based: query.buildPlan marks an hour covered iff a
+	// p_YYYYMMDDHH partition exists, never whether that partition received the
+	// events. A hole INSIDE a live partition is therefore invisible to it, and
+	// once the chain is walked a hole is indistinguishable from a corrupt
+	// before-image. stream_state.gap_lost_at (#765) is the one durable record of
+	// events this index KNOWS it lost permanently, so consult it before
+	// asserting anything — and treat an index that cannot answer as unknown,
+	// never as "no gap".
+	switch verdict, why := captureGapInWindow(ctx, cfg.IndexDB, cfg.Since, cfg.Until); verdict {
+	case captureGapStamped:
+		return inconclusive(res, "the index permanently lost events inside this window ("+why+
+			"); the chains here have a hole that no stored image can be asserted across"), nil
+	case captureGapUnknown:
+		return inconclusive(res, "the capture-continuity record could not be evaluated ("+why+
+			"), so a permanent loss inside the window could not be ruled out and would read as a false mismatch"), nil
 	}
 
 	maxEvents := cfg.MaxEvents
@@ -180,6 +202,72 @@ func recoverInputsFetchOptions(schema, table string, since, until time.Time, max
 	}
 }
 
+// ─── Stamped capture gaps ─────────────────────────────────────────────────────
+
+// captureGapVerdict is what stream_state can say about events this index lost
+// PERMANENTLY (not merely rotated out of MySQL — those are recoverable from an
+// archive and are what query.GapError covers) inside the walk window.
+type captureGapVerdict int
+
+const (
+	// captureGapNoneStamped: the record was readable and holds no permanent
+	// loss inside the window. NOTE this is NOT proof the window is whole — the
+	// common hole shapes (a table skipped after an un-re-snapshotted ALTER, a
+	// mid-history --tables/--schemas filter change, a `stream --reset`, a
+	// daemon outage shorter than the pre-created partition horizon) stamp
+	// nothing at all. That is why the mismatch detail this mode emits must
+	// never assert corruption as the cause.
+	captureGapNoneStamped captureGapVerdict = iota
+	// captureGapStamped: a permanent loss is recorded inside the window.
+	captureGapStamped
+	// captureGapUnknown: the record could not be evaluated (a legacy index
+	// predating the gap_lost_* columns, or an unreadable stream_state). Unknown
+	// is NOT "no gap".
+	captureGapUnknown
+)
+
+// captureGapInWindow consults stream_state's permanent-loss stamp for the walk
+// window. The classification is split out (classifyCaptureGap) so the boundary
+// and legacy-index rules are testable without a database.
+func captureGapInWindow(ctx context.Context, db *sql.DB, since, until time.Time) (captureGapVerdict, string) {
+	ss, err := status.LoadStreamState(ctx, db)
+	return classifyCaptureGap(ss, err, since, until)
+}
+
+// classifyCaptureGap is the pure half of captureGapInWindow.
+func classifyCaptureGap(ss *status.StreamStateInfo, loadErr error, since, until time.Time) (captureGapVerdict, string) {
+	switch {
+	case loadErr != nil:
+		// A read failure leaves the loss record unknown. Failing the table
+		// closed (inconclusive) rather than walking on is the same fail-safe
+		// choice the missing-IndexDBName branch makes.
+		return captureGapUnknown, fmt.Sprintf("stream_state could not be read: %v", loadErr)
+	case ss == nil:
+		// No stream_state row at all: no streaming daemon ever checkpointed
+		// against this index (a file-mode `bintrail index`), so there is no
+		// stamped loss to find. That is knowledge, unlike a legacy index whose
+		// record exists but cannot be read.
+		return captureGapNoneStamped, ""
+	case !ss.GapColumnsPresent:
+		return captureGapUnknown, "this index predates the stream_state.gap_lost_at/gap_lost_detail columns, so a recorded permanent loss cannot be ruled out"
+	case !ss.GapLostAt.Valid:
+		return captureGapNoneStamped, ""
+	}
+
+	at := ss.GapLostAt.Time
+	// Inclusive on BOTH ends, unlike reconstruct.gapInWindow's (since, until]:
+	// a loss stamped exactly at Since still means the events at the window's
+	// oldest edge are gone, and this gate is fail-safe by construction.
+	if at.Before(since) || at.After(until) {
+		return captureGapNoneStamped, ""
+	}
+	msg := fmt.Sprintf("stream_state.gap_lost_at is stamped %s, inside the walk window", at.UTC().Format(time.RFC3339))
+	if d := strings.TrimSpace(ss.GapLostDetail.String); d != "" {
+		msg += ": " + d
+	}
+	return captureGapStamped, msg
+}
+
 // dropSnapshotRows filters out EventSnapshot rows in place-ish (a fresh slice
 // is only allocated when at least one is present, the overwhelmingly common
 // case being none).
@@ -234,6 +322,10 @@ type recoverChainOutcome struct {
 	// Assertions is how many before-image comparisons were actually made:
 	// the real measure of what this run proved.
 	Assertions int
+	// UnwalkableEvents counts events that carry no primary key (drift rows,
+	// see the PKValues=="" guard in checkRecoverChains). They belong to no
+	// chain and are counted as unproven, never folded together.
+	UnwalkableEvents int
 }
 
 // chainState is one PK's reconstructed state between events.
@@ -285,6 +377,20 @@ func checkRecoverChains(in recoverChainInput) recoverChainOutcome {
 
 	for i := range in.Events {
 		ev := &in.Events[i]
+
+		// A row with an EMPTY pk_values is a DRIFT row: the indexer's defensive
+		// scan of NULL pk_values (#318) delivers those as "". They carry no
+		// chain identity, so keying them by pk_values would fold every
+		// unrelated drift row in the table into ONE chain and compare one row's
+		// row_before against another row's row_after — a guaranteed MISMATCH on
+		// any index that merely CONTAINS drift rows. internal/query/merge.go's
+		// LimitPerPK already gives each its own \x00drift:<event_id> bucket for
+		// exactly this reason; here the honest answer is that they are
+		// unwalkable, so they are skipped and counted as unproven.
+		if ev.PKValues == "" {
+			out.UnwalkableEvents++
+			continue
+		}
 
 		st, seen := states[ev.PKValues]
 		if !seen {
@@ -372,6 +478,20 @@ func checkRecoverChains(in recoverChainInput) recoverChainOutcome {
 // recoverChainVerdict collapses the walk's findings into a status + detail. Kept
 // separate (and pure) so the precedence between "found something wrong" and
 // "could not check everything" is stated in exactly one place.
+//
+// The rule for PARTIAL coverage is deliberate and documented in docs/verify.md:
+// a table is proven as soon as ONE before-image comparison was conclusive, and
+// everything that stayed unproven is carried as a NOTE on that verdict rather
+// than erasing it. A chain beginning mid-history, a value whose representation
+// could not be normalized, and a drift row with no primary key are all "this
+// part could not be checked" — none of them is evidence against the parts that
+// WERE checked, and collapsing the whole table on one of them would turn a
+// single unresolvable JSON value into a permanently red CI gate over an index
+// with hundreds of thousands of clean assertions.
+//
+// Truncation is the one exception that still collapses the table: there the
+// unchecked part is not a handful of values but the entire TAIL of the window,
+// which was never loaded at all.
 func recoverChainVerdict(out recoverChainOutcome, mismatches []string, unresolved int, firstUnresolved string, truncated bool) (Status, string) {
 	scope := fmt.Sprintf("%d event(s), %d chain(s), %d before-image assertion(s)", out.Events, out.Chains, out.Assertions)
 
@@ -387,15 +507,28 @@ func recoverChainVerdict(out recoverChainOutcome, mismatches []string, unresolve
 	if truncated {
 		return StatusInconclusive, fmt.Sprintf("checked %s with no inconsistency, but the window exceeded the event budget and only its oldest events were walked; narrow --since/--lookback or raise --max-events to verify it whole", scope)
 	}
-	if unresolved > 0 {
-		return StatusInconclusive, fmt.Sprintf("checked %s; %d before-image comparison(s) were not conclusive because a value's representation could not be normalized: %s", scope, unresolved, firstUnresolved)
+
+	var notes []string
+	if out.ChainsNoPredecessor > 0 {
+		notes = append(notes, fmt.Sprintf("%d chain(s) began mid-history and were not asserted", out.ChainsNoPredecessor))
 	}
+	if unresolved > 0 {
+		notes = append(notes, fmt.Sprintf("%d before-image comparison(s) were not conclusive because a value's representation could not be normalized: %s", unresolved, firstUnresolved))
+	}
+	if out.UnwalkableEvents > 0 {
+		notes = append(notes, fmt.Sprintf("%d event(s) carry no primary key (drift rows) and belong to no chain, so they were not walked", out.UnwalkableEvents))
+	}
+
 	if out.Assertions == 0 {
-		return StatusInconclusive, fmt.Sprintf("walked %s: no chain had a verifiable predecessor state in this window (every chain begins mid-history), so nothing was proven", scope)
+		detail := fmt.Sprintf("walked %s: nothing was proven — no before-image comparison in this window was conclusive", scope)
+		if len(notes) > 0 {
+			detail += "; " + strings.Join(notes, "; ")
+		}
+		return StatusInconclusive, detail
 	}
 	detail := fmt.Sprintf("checked %s", scope)
-	if out.ChainsNoPredecessor > 0 {
-		detail += fmt.Sprintf("; %d chain(s) began mid-history and were not asserted", out.ChainsNoPredecessor)
+	if len(notes) > 0 {
+		detail += "; " + strings.Join(notes, "; ")
 	}
 	return StatusMatch, detail
 }
@@ -426,8 +559,8 @@ func assertBeforeImage(ev *query.ResultRow, st *chainState, in recoverChainInput
 		// event carries a before-image for it. That is the chaining
 		// assertion failing in its starkest form: recover would re-INSERT or
 		// reverse-UPDATE a row the chain says did not exist.
-		return chainMismatch, fmt.Sprintf("event %d (pk=%s, %s): row_before is present but the chain established this row was deleted by an earlier event; recover would reverse it against state that does not exist",
-			ev.EventID, ev.PKValues, eventTypeLabel(ev.EventType))
+		return chainMismatch, fmt.Sprintf("event %d (pk=%s, %s): row_before is present but the chain established this row was deleted by an earlier event — either the re-INSERT in between was never captured, or the images are inconsistent; %s",
+			ev.EventID, ev.PKValues, eventTypeLabel(ev.EventType), chainBreakGuidance)
 	}
 	equal, unresolvedCol, diffCol := compareImages(st.row, ev.RowBefore, st.schemaVersion, ev.SchemaVersion, in)
 	switch {
@@ -437,10 +570,27 @@ func assertBeforeImage(ev *query.ResultRow, st *chainState, in recoverChainInput
 		return chainUnresolved, fmt.Sprintf("event %d (pk=%s) column %q holds an ENUM/SET, JSON, binary, BIT or spatial value whose representation could not be normalized",
 			ev.EventID, ev.PKValues, unresolvedCol)
 	default:
-		return chainMismatch, fmt.Sprintf("event %d (pk=%s, %s): row_before does not match the state the previous event on this primary key left (column %s); recover would generate reversal SQL from a stale or corrupt before-image",
-			ev.EventID, ev.PKValues, eventTypeLabel(ev.EventType), diffCol)
+		return chainMismatch, fmt.Sprintf("event %d (pk=%s, %s): row_before does not match the state the previous event on this primary key left (column %s) — either the events in between were never captured, or the stored before-image is stale or corrupt; %s",
+			ev.EventID, ev.PKValues, eventTypeLabel(ev.EventType), diffCol, chainBreakGuidance)
 	}
 }
+
+// chainBreakGuidance is the tail every chain-break finding carries.
+//
+// The walk sees a break in the chain; it CANNOT see why. A missing-events hole
+// and a corrupt image produce byte-identical evidence, and a hole is at least as
+// likely: the partition-existence coverage check upstream cannot see one that
+// falls INSIDE a live partition, which is what every common hole shape looks
+// like — a table whose events the indexer skipped after an ALTER with no
+// re-snapshot ("Column count mismatch: indexer logs warning and skips table's
+// events"), a mid-history --tables/--schemas filter change, a `stream --reset`,
+// or a daemon outage shorter than the pre-created future-partition horizon. An
+// earlier version of this string asserted "stale or corrupt before-image" as the
+// cause, which ruled out the more likely explanation and sent operators hunting
+// for corruption that was not there.
+const chainBreakGuidance = "recover would build reversal SQL from a before-image the chain cannot confirm. " +
+	"To tell the two apart: check `bintrail status` continuity and the indexer/stream logs for skipped tables, " +
+	"filter changes, resets or downtime covering this window, and compare against the source's own binlog history"
 
 // compareImages reports whether two event images hold the same data.
 //

--- a/internal/verify/recover_inputs.go
+++ b/internal/verify/recover_inputs.go
@@ -101,7 +101,16 @@ func VerifyRecoverInputs(ctx context.Context, cfg RecoverInputsConfig, schema, t
 	// events this index KNOWS it lost permanently, so consult it before
 	// asserting anything — and treat an index that cannot answer as unknown,
 	// never as "no gap".
-	switch verdict, why := captureGapInWindow(ctx, cfg.IndexDB, cfg.Since, cfg.Until); verdict {
+	verdict, why, err := captureGapInWindow(ctx, cfg.IndexDB, cfg.Since, cfg.Until)
+	if err != nil {
+		// A failed READ is not a statement about continuity, so it must not be
+		// dressed up as an inconclusive verdict about data never consulted —
+		// that would be a second door to the all-inconclusive non-zero exit
+		// this change exists to close. Surface it: the CLI turns one table's
+		// hard error into StatusError and keeps verifying the rest.
+		return res, fmt.Errorf("check the capture-continuity record for %s.%s: %w", schema, table, err)
+	}
+	switch verdict {
 	case captureGapStamped:
 		return inconclusive(res, "the index permanently lost events inside this window ("+why+
 			"); the chains here have a hole that no stored image can be asserted across"), nil
@@ -220,28 +229,31 @@ const (
 	captureGapNoneStamped captureGapVerdict = iota
 	// captureGapStamped: a permanent loss is recorded inside the window.
 	captureGapStamped
-	// captureGapUnknown: the record could not be evaluated (a legacy index
-	// predating the gap_lost_* columns, or an unreadable stream_state). Unknown
-	// is NOT "no gap".
+	// captureGapUnknown: a legacy index predating the gap_lost_* columns, whose
+	// loss record is STRUCTURALLY absent. Unknown is NOT "no gap". A failed
+	// read is deliberately NOT this verdict — see captureGapInWindow.
 	captureGapUnknown
 )
 
 // captureGapInWindow consults stream_state's permanent-loss stamp for the walk
 // window. The classification is split out (classifyCaptureGap) so the boundary
 // and legacy-index rules are testable without a database.
-func captureGapInWindow(ctx context.Context, db *sql.DB, since, until time.Time) (captureGapVerdict, string) {
+//
+// A read failure comes back as an ERROR, not as captureGapUnknown: it says
+// nothing about continuity, and turning it into a verdict would let a transient
+// fault read as a statement about the data.
+func captureGapInWindow(ctx context.Context, db *sql.DB, since, until time.Time) (captureGapVerdict, string, error) {
 	ss, err := status.LoadStreamState(ctx, db)
-	return classifyCaptureGap(ss, err, since, until)
+	if err != nil {
+		return captureGapUnknown, "", fmt.Errorf("read stream_state: %w", err)
+	}
+	v, why := classifyCaptureGap(ss, since, until)
+	return v, why, nil
 }
 
 // classifyCaptureGap is the pure half of captureGapInWindow.
-func classifyCaptureGap(ss *status.StreamStateInfo, loadErr error, since, until time.Time) (captureGapVerdict, string) {
+func classifyCaptureGap(ss *status.StreamStateInfo, since, until time.Time) (captureGapVerdict, string) {
 	switch {
-	case loadErr != nil:
-		// A read failure leaves the loss record unknown. Failing the table
-		// closed (inconclusive) rather than walking on is the same fail-safe
-		// choice the missing-IndexDBName branch makes.
-		return captureGapUnknown, fmt.Sprintf("stream_state could not be read: %v", loadErr)
 	case ss == nil:
 		// No stream_state row at all: no streaming daemon ever checkpointed
 		// against this index (a file-mode `bintrail index`), so there is no
@@ -470,6 +482,10 @@ func checkRecoverChains(in recoverChainInput) recoverChainOutcome {
 		}
 	}
 
+	// Events counts what the walk VISITED (report.go's events_checked), so the
+	// drift rows skipped above do not inflate it — a table of nothing but drift
+	// rows must not report events "checked" that were never walked.
+	out.Events = len(in.Events) - out.UnwalkableEvents
 	out.ChainsNoPredecessor = len(noPredecessor)
 	out.Status, out.Detail = recoverChainVerdict(out, mismatches, unresolved, firstUnresolved, in.Truncated)
 	return out

--- a/internal/verify/recover_inputs.go
+++ b/internal/verify/recover_inputs.go
@@ -1,0 +1,587 @@
+package verify
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/event"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/query"
+	"github.com/dbtrail/dbtrail/internal/reconstruct"
+)
+
+// ─── Recover-input verification (#1001) ───────────────────────────────────────
+//
+// The baseline-anchored and live-source modes both compare FULL-TABLE CONTENT
+// reconstructed from the LATEST event per PK (`row_after`, LimitPerPK=1). That
+// comparison structurally cannot touch the data `bintrail recover` actually
+// consumes to build reversal SQL (see internal/recovery):
+//
+//   - DELETE → INSERT   reads row_before  (buildInsert; nil row_before refuses)
+//   - UPDATE → UPDATE   reads row_before for SET **and** row_after for the WHERE
+//                       (buildUpdate; either nil refuses)
+//   - INSERT → DELETE   reads row_after   (buildDelete; nil row_after refuses)
+//
+// So a corrupt `row_before`, a corrupt DELETE pre-image, or a corrupt event that
+// a NEWER event on the same PK superseded all pass a content match cleanly while
+// `recover` would emit wrong reverse SQL from those same rows. This mode closes
+// that hole by walking each PK's event chain in time order and asserting the
+// images are internally consistent — a check buildable entirely from data
+// already in binlog_events, with no baseline and no live source.
+
+// DefaultRecoverInputsMaxEvents bounds how many events one table's chain walk
+// loads (see RecoverInputsConfig.MaxEvents).
+const DefaultRecoverInputsMaxEvents = 200_000
+
+// RecoverInputsConfig wires the single data source this mode needs: the index.
+// Unlike Config/BaselineConfig there is no baseline and no live source — the
+// whole point is that recover's inputs are verifiable from binlog_events alone.
+type RecoverInputsConfig struct {
+	IndexDB     *sql.DB
+	Resolver    *metadata.Resolver
+	IndexDBName string
+	NoArchive   bool
+	// ArchiveFetcher reads archived (Parquet) partitions, so a chain that
+	// extends back past the live retention window is still walked whole
+	// instead of reading as a truncated one. Required unless NoArchive.
+	ArchiveFetcher query.ArchiveFetcher
+	// Since/Until bound the window. Since is the operator's --lookback
+	// horizon; a chain whose first event in the window is not an INSERT has
+	// no predecessor state and is reported INCONCLUSIVE, never as a mismatch.
+	Since time.Time
+	Until time.Time
+	// MaxEvents caps the events loaded per table. 0 → DefaultRecoverInputsMaxEvents.
+	MaxEvents int
+}
+
+// VerifyRecoverInputs walks the per-PK event chains for one table and asserts
+// that the before/after images recover consumes are internally consistent.
+//
+// It fetches the window in ASCENDING time order with NO LimitPerPK — every
+// superseded intermediate event is visited, which is precisely the class the
+// content-comparison modes skip. Coverage gaps abort as INCONCLUSIVE (a chain
+// with an interior hole cannot be asserted against), never as a mismatch.
+func VerifyRecoverInputs(ctx context.Context, cfg RecoverInputsConfig, schema, table string) (TableResult, error) {
+	res := TableResult{Schema: schema, Table: table}
+
+	tm, err := cfg.Resolver.Resolve(schema, table)
+	if err != nil {
+		return res, fmt.Errorf("resolve %s.%s: %w", schema, table, err)
+	}
+	// Chains are keyed by pk_values, and a PK-changing UPDATE can only be
+	// recognized with the PK column list. Without a PK, recover itself falls
+	// back to an all-columns WHERE and there is no stable chain identity to
+	// walk — report it rather than pretend to have checked.
+	pkCols := tm.PKColumnMetas()
+	if len(pkCols) == 0 {
+		return inconclusive(res, "table has no primary key; recover falls back to an all-columns WHERE and the event chain has no stable identity to walk"), nil
+	}
+	// Gap detection is the guard that keeps a hole in the middle of a chain
+	// from reading as a corrupt before-image, and the planner cannot run
+	// without the index database name.
+	if cfg.IndexDBName == "" {
+		return inconclusive(res, "index database name unavailable; coverage-gap detection cannot run, and an undetected gap would read as a false mismatch"), nil
+	}
+
+	maxEvents := cfg.MaxEvents
+	if maxEvents <= 0 {
+		maxEvents = DefaultRecoverInputsMaxEvents
+	}
+
+	engine := query.New(cfg.IndexDB)
+	rows, _, err := query.FetchMerged(ctx, cfg.IndexDB, engine, query.FetchMergedOptions{
+		Opts:           recoverInputsFetchOptions(schema, table, cfg.Since, cfg.Until, maxEvents),
+		DBName:         cfg.IndexDBName,
+		NoArchive:      cfg.NoArchive,
+		ArchiveFetcher: cfg.ArchiveFetcher,
+	})
+	if err != nil {
+		var gap *query.GapError
+		if errors.As(err, &gap) {
+			return inconclusive(res, "coverage gap in the window: "+gap.Error()+"; a chain with an interior hole cannot be asserted against"), nil
+		}
+		return res, fmt.Errorf("fetch events %s.%s: %w", schema, table, err)
+	}
+
+	truncated := len(rows) > maxEvents
+	if truncated {
+		rows = rows[:maxEvents]
+	}
+
+	// Baseline (SNAPSHOT) rows live in binlog_events too, but they are
+	// read-only state, not deltas — recovery rejects them outright
+	// ("baseline rows are read-only"). Folding one into a chain as if it were
+	// a change would manufacture a mismatch out of nothing.
+	rows = dropSnapshotRows(rows)
+
+	// Normalize the event images exactly as the other reconstruction surfaces
+	// do BEFORE comparing them. Both sides of every comparison here are event
+	// images, but they can come from DIFFERENT schema epochs: event N-1's
+	// row_after may carry a raw ENUM ordinal while event N's row_before
+	// carries the label. Same data, different bytes — a false mismatch unless
+	// both are mapped through the same epoch-aware pass first.
+	reconstruct.MapEventEnumLabels(cfg.IndexDB, cfg.Resolver, schema, table, rows)
+	binariesTyped := reconstruct.DecodeEventBinaries(cfg.IndexDB, schema, table, rows)
+
+	colByName := make(map[string]metadata.ColumnMeta, len(tm.Columns))
+	for _, c := range tm.Columns {
+		colByName[c.Name] = c
+	}
+
+	out := checkRecoverChains(recoverChainInput{
+		Schema:        schema,
+		Table:         table,
+		Events:        rows,
+		PKCols:        pkCols,
+		ColByName:     colByName,
+		BinariesTyped: binariesTyped,
+		Truncated:     truncated,
+	})
+
+	res.Status = out.Status
+	res.Detail = out.Detail
+	res.EventsChecked = out.Events
+	res.ChainsChecked = out.Chains
+	res.ChainsInconclusive = out.ChainsNoPredecessor
+	return res, nil
+}
+
+// recoverInputsFetchOptions builds the event fetch for one table's chain walk.
+//
+// Two properties are load-bearing and are pinned by
+// TestRecoverInputsFetchOptions_VisitsSupersededEvents:
+//
+//   - LimitPerPK is UNSET. The content-comparison modes fetch LimitPerPK=1
+//     (latest event per PK), which is exactly why they cannot see a corrupt
+//     event that a newer event on the same key superseded. Setting it here
+//     would silently reduce this mode to the check it exists to complement.
+//   - Order is ASC. The walk reconstructs state forward in time, and the
+//     Limit below must therefore keep the OLDEST events. A prefix of the
+//     globally time-ordered stream is simultaneously a prefix of EVERY PK's
+//     chain, so each chain walked has no interior hole — which is what keeps a
+//     truncated window's findings conclusive.
+//
+// Limit is maxEvents+1 purely so truncation is DETECTABLE: getting the extra
+// row proves the window did not fit, and the walk then reports inconclusive
+// instead of silently blessing a partial check.
+func recoverInputsFetchOptions(schema, table string, since, until time.Time, maxEvents int) query.Options {
+	return query.Options{
+		Schema: schema,
+		Table:  table,
+		Since:  &since,
+		Until:  &until,
+		Order:  "ASC",
+		Limit:  maxEvents + 1,
+	}
+}
+
+// dropSnapshotRows filters out EventSnapshot rows in place-ish (a fresh slice
+// is only allocated when at least one is present, the overwhelmingly common
+// case being none).
+func dropSnapshotRows(rows []query.ResultRow) []query.ResultRow {
+	keep := rows[:0]
+	dropped := false
+	for _, r := range rows {
+		if r.EventType == event.EventSnapshot {
+			dropped = true
+			continue
+		}
+		keep = append(keep, r)
+	}
+	if !dropped {
+		return rows
+	}
+	return keep
+}
+
+// ─── The pure chain walk ──────────────────────────────────────────────────────
+
+// recoverChainInput is everything the walk needs. Deliberately free of *sql.DB
+// and context so the walk is a pure function — the same shape as classify and
+// NewReport, and testable without a database.
+type recoverChainInput struct {
+	Schema, Table string
+	// Events must be in ascending (event_timestamp, event_id) order and must
+	// contain no SNAPSHOT rows.
+	Events        []query.ResultRow
+	PKCols        []metadata.ColumnMeta
+	ColByName     map[string]metadata.ColumnMeta
+	BinariesTyped bool
+	// Truncated reports that the window did not fit the event budget, so the
+	// events here are a PREFIX of it.
+	Truncated bool
+}
+
+// recoverChainOutcome is the walk's verdict plus the counts that make an
+// operator able to tell "checked a lot and found nothing" from "checked
+// nothing".
+type recoverChainOutcome struct {
+	Status Status
+	Detail string
+	// Events is the number of events walked; Chains the distinct PKs.
+	Events, Chains int
+	// ChainsNoPredecessor counts DISTINCT primary keys that held at least one
+	// event with no predecessor state to assert against — the window opened
+	// mid-history, or a PK-changing UPDATE moved the row out from under the
+	// key. Legitimately unverifiable, never a mismatch. Counted per key, not
+	// per event, so it can never exceed Chains.
+	ChainsNoPredecessor int
+	// Assertions is how many before-image comparisons were actually made:
+	// the real measure of what this run proved.
+	Assertions int
+}
+
+// chainState is one PK's reconstructed state between events.
+//
+// The three states are distinct on purpose. "unknown" (known=false) means the
+// walk cannot say what the row held — the window started mid-history, or a
+// PK-changing UPDATE moved the row out from under this key; either way the next
+// event is a chain restart and asserts nothing. "absent" (known, !present)
+// means the chain positively established that the row does not exist (a
+// DELETE). "present" carries the row image itself.
+type chainState struct {
+	known   bool
+	present bool
+	row     map[string]any
+	// schemaVersion of the event that established this state, so a column-set
+	// difference across a DDL boundary is recognized as drift rather than
+	// reported as corruption.
+	schemaVersion uint32
+}
+
+// checkRecoverChains walks every PK's event chain and asserts the images
+// recover consumes are internally consistent. Pure: no IO, no globals.
+//
+// Per event, in ascending time order, it asserts what internal/recovery
+// actually requires:
+//
+//  1. The images recovery dereferences are non-nil (DELETE→row_before,
+//     UPDATE→both, INSERT→row_after). recovery refuses on a nil one, so a nil
+//     here is a recovery that cannot run: a conclusive mismatch.
+//  2. No residual unchanged-TOAST marker in either image — the same up-front
+//     scan GenerateSQLFromRows runs before it will render anything.
+//  3. UPDATE/DELETE row_before equals the state the chain established just
+//     before this event. This is the check the content-comparison modes have
+//     no way to make, and the reason a superseded intermediate event matters.
+//
+// Verdict precedence is deliberately fail-safe: a mismatch is always
+// conclusive and wins; otherwise anything that leaves part of the window
+// unproven (truncation, an unresolvable value representation, or nothing
+// asserted at all) degrades to inconclusive rather than reporting a match this
+// run did not earn.
+func checkRecoverChains(in recoverChainInput) recoverChainOutcome {
+	out := recoverChainOutcome{Events: len(in.Events)}
+	states := make(map[string]*chainState)
+
+	var mismatches []string
+	var unresolved int
+	var firstUnresolved string
+	noPredecessor := make(map[string]struct{})
+
+	for i := range in.Events {
+		ev := &in.Events[i]
+
+		st, seen := states[ev.PKValues]
+		if !seen {
+			st = &chainState{}
+			states[ev.PKValues] = st
+			out.Chains++
+		}
+
+		// (1) The nil-image contract, mirrored from internal/recovery's
+		// buildInsert/buildUpdate/buildDelete. An INSERT with a nil
+		// row_before is NORMAL (there is no prior row) and is not flagged.
+		if detail, bad := checkImagesPresent(ev); bad {
+			mismatches = append(mismatches, detail)
+			// The chain's state after an event whose images are broken is
+			// not knowable; restart rather than cascade one defect into
+			// every later event on this PK.
+			*st = chainState{}
+			continue
+		}
+
+		// (2) The same unchanged-TOAST refusal recovery performs up front.
+		if err := event.CheckUnresolvedToast(ev.SchemaName, ev.TableName, ev.PKValues, ev.RowBefore, ev.RowAfter); err != nil {
+			mismatches = append(mismatches, fmt.Sprintf("event %d (pk=%s): %v", ev.EventID, ev.PKValues, err))
+			*st = chainState{}
+			continue
+		}
+
+		// (3) The before-image chaining assertion.
+		switch ev.EventType {
+		case event.EventInsert:
+			// Nothing to assert: recovery reverses an INSERT using only
+			// row_after's PK, consuming no prior state. Asserting "the row
+			// did not exist" here would be pure false-positive surface
+			// (REPLACE INTO, PK reuse after a delete) for no coverage.
+			*st = chainState{known: true, present: true, row: ev.RowAfter, schemaVersion: ev.SchemaVersion}
+
+		case event.EventUpdate, event.EventDelete:
+			verdict, detail := assertBeforeImage(ev, st, in)
+			switch verdict {
+			case chainMismatch:
+				mismatches = append(mismatches, detail)
+			case chainUnresolved:
+				unresolved++
+				if firstUnresolved == "" {
+					firstUnresolved = detail
+				}
+			case chainNoPredecessor:
+				noPredecessor[ev.PKValues] = struct{}{}
+			case chainAsserted:
+				out.Assertions++
+			}
+
+			if ev.EventType == event.EventDelete {
+				// The chain now positively knows the row is gone.
+				*st = chainState{known: true, present: false, schemaVersion: ev.SchemaVersion}
+				continue
+			}
+			// UPDATE. A PK-CHANGING update is stored under the BEFORE-image
+			// PK (internal/parser: "PK from before-image"), so the assertion
+			// above was valid — but the row has now MOVED to a different key.
+			// Carrying row_after forward under this key would false-mismatch
+			// the very next event on it (the real `UPDATE pk 1→2; INSERT
+			// pk=1` sequence), so the state becomes unknown instead.
+			if pkChangedInEvent(ev, in.PKCols) {
+				*st = chainState{}
+				continue
+			}
+			*st = chainState{known: true, present: true, row: ev.RowAfter, schemaVersion: ev.SchemaVersion}
+
+		default:
+			// A type recovery has no reversal for (it errors with "unknown
+			// event type"). Not silently skipped — an unwalkable event means
+			// the chain past it is not knowable.
+			mismatches = append(mismatches, fmt.Sprintf("event %d (pk=%s): unknown event type %d; recover cannot reverse it",
+				ev.EventID, ev.PKValues, ev.EventType))
+			*st = chainState{}
+		}
+	}
+
+	out.ChainsNoPredecessor = len(noPredecessor)
+	out.Status, out.Detail = recoverChainVerdict(out, mismatches, unresolved, firstUnresolved, in.Truncated)
+	return out
+}
+
+// recoverChainVerdict collapses the walk's findings into a status + detail. Kept
+// separate (and pure) so the precedence between "found something wrong" and
+// "could not check everything" is stated in exactly one place.
+func recoverChainVerdict(out recoverChainOutcome, mismatches []string, unresolved int, firstUnresolved string, truncated bool) (Status, string) {
+	scope := fmt.Sprintf("%d event(s), %d chain(s), %d before-image assertion(s)", out.Events, out.Chains, out.Assertions)
+
+	// A mismatch is conclusive regardless of what else could not be checked:
+	// the events that WERE walked are real, and recover would consume them.
+	if len(mismatches) > 0 {
+		detail := fmt.Sprintf("%d recover-input inconsistency(ies) in %s: %s", len(mismatches), scope, mismatches[0])
+		if len(mismatches) > 1 {
+			detail += fmt.Sprintf(" (and %d more)", len(mismatches)-1)
+		}
+		return StatusMismatch, detail
+	}
+	if truncated {
+		return StatusInconclusive, fmt.Sprintf("checked %s with no inconsistency, but the window exceeded the event budget and only its oldest events were walked; narrow --since/--lookback or raise --max-events to verify it whole", scope)
+	}
+	if unresolved > 0 {
+		return StatusInconclusive, fmt.Sprintf("checked %s; %d before-image comparison(s) were not conclusive because a value's representation could not be normalized: %s", scope, unresolved, firstUnresolved)
+	}
+	if out.Assertions == 0 {
+		return StatusInconclusive, fmt.Sprintf("walked %s: no chain had a verifiable predecessor state in this window (every chain begins mid-history), so nothing was proven", scope)
+	}
+	detail := fmt.Sprintf("checked %s", scope)
+	if out.ChainsNoPredecessor > 0 {
+		detail += fmt.Sprintf("; %d chain(s) began mid-history and were not asserted", out.ChainsNoPredecessor)
+	}
+	return StatusMatch, detail
+}
+
+// chainVerdict is one event's before-image assertion outcome.
+type chainVerdict int
+
+const (
+	chainAsserted chainVerdict = iota
+	chainMismatch
+	chainUnresolved
+	chainNoPredecessor
+)
+
+// assertBeforeImage checks one UPDATE/DELETE's row_before against the state the
+// chain established just before it — the core of this mode.
+//
+// A chain that starts mid-window (state unknown) has no predecessor to compare
+// against and is reported as such, NEVER as a mismatch: a false MISMATCH on a
+// truncated retention window would make the whole mode untrustworthy, and a
+// window starting mid-history is the normal case, not an anomaly.
+func assertBeforeImage(ev *query.ResultRow, st *chainState, in recoverChainInput) (chainVerdict, string) {
+	if !st.known {
+		return chainNoPredecessor, ""
+	}
+	if !st.present {
+		// The chain positively established the row was DELETEd, yet this
+		// event carries a before-image for it. That is the chaining
+		// assertion failing in its starkest form: recover would re-INSERT or
+		// reverse-UPDATE a row the chain says did not exist.
+		return chainMismatch, fmt.Sprintf("event %d (pk=%s, %s): row_before is present but the chain established this row was deleted by an earlier event; recover would reverse it against state that does not exist",
+			ev.EventID, ev.PKValues, eventTypeLabel(ev.EventType))
+	}
+	equal, unresolvedCol, diffCol := compareImages(st.row, ev.RowBefore, st.schemaVersion, ev.SchemaVersion, in)
+	switch {
+	case equal:
+		return chainAsserted, ""
+	case unresolvedCol != "":
+		return chainUnresolved, fmt.Sprintf("event %d (pk=%s) column %q holds an ENUM/SET, JSON, binary, BIT or spatial value whose representation could not be normalized",
+			ev.EventID, ev.PKValues, unresolvedCol)
+	default:
+		return chainMismatch, fmt.Sprintf("event %d (pk=%s, %s): row_before does not match the state the previous event on this primary key left (column %s); recover would generate reversal SQL from a stale or corrupt before-image",
+			ev.EventID, ev.PKValues, eventTypeLabel(ev.EventType), diffCol)
+	}
+}
+
+// compareImages reports whether two event images hold the same data.
+//
+// It renders both sides through renderCellNormalized — this package's existing
+// canonicalizer, which already closes the JSON key-order, zero-date-vs-NULL,
+// TIME-fraction and FLOAT/DOUBLE exponent gaps that produced false MISMATCHes
+// in the other modes. Reusing it is deliberate: a fresh reflect.DeepEqual over
+// the decoded maps would reintroduce every one of those bugs.
+//
+// Returns (equal, unresolvedColumn, differingColumn). A non-empty
+// unresolvedColumn means the difference is NOT conclusive — a deferred-type
+// value whose event representation provably cannot be made byte-faithful, the
+// same gate deferredReprUnresolved applies in the content modes.
+func compareImages(prev, cur map[string]any, prevVer, curVer uint32, in recoverChainInput) (equal bool, unresolvedCol, diffCol string) {
+	cols := unionKeys(prev, cur)
+	for _, name := range cols {
+		_, inPrev := prev[name]
+		_, inCur := cur[name]
+		if inPrev != inCur {
+			// The two images disagree on which columns exist. Across a schema
+			// version boundary that is DDL, not corruption; within one
+			// version it is a genuine structural divergence.
+			if prevVer != curVer {
+				return false, name, ""
+			}
+			return false, "", fmt.Sprintf("%q is present in one image and absent from the other", name)
+		}
+	}
+
+	col := func(name string) metadata.ColumnMeta {
+		if c, ok := in.ColByName[name]; ok {
+			return c
+		}
+		// A column the current schema snapshot no longer carries. Both sides
+		// still render through the SAME (empty) metadata, so the comparison
+		// stays symmetric — the one property that matters here.
+		return metadata.ColumnMeta{Name: name}
+	}
+
+	for _, name := range cols {
+		c := col(name)
+		pv, cv := prev[name], cur[name]
+		if bytes.Equal(renderCellNormalized(pv, c), renderCellNormalized(cv, c)) {
+			continue
+		}
+		// The values differ. Before calling it a divergence, ask whether
+		// either side is a value class whose event representation this
+		// version cannot render faithfully — if so the difference is not
+		// conclusive.
+		if isDeferredType(c.DataType) &&
+			(valueUnresolved(pv, c, in.BinariesTyped) || valueUnresolved(cv, c, in.BinariesTyped)) {
+			return false, name, ""
+		}
+		return false, "", fmt.Sprintf("%q differs", name)
+	}
+	return true, "", ""
+}
+
+// valueUnresolved is deferredValueUnresolved with the nil case pinned to
+// "resolved": a nil renders as SQL NULL on both sides unambiguously, so a
+// NULL-vs-value difference is a real divergence, not a representation gap.
+func valueUnresolved(v any, c metadata.ColumnMeta, binariesTyped bool) bool {
+	if v == nil {
+		return false
+	}
+	return deferredValueUnresolved(v, c, binariesTyped)
+}
+
+// unionKeys returns the sorted union of two row images' column names, so the
+// comparison order (and therefore which column a mismatch names) is stable.
+func unionKeys(a, b map[string]any) []string {
+	seen := make(map[string]struct{}, len(a)+len(b))
+	for k := range a {
+		seen[k] = struct{}{}
+	}
+	for k := range b {
+		seen[k] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for k := range seen {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// checkImagesPresent mirrors internal/recovery's nil-image guards exactly:
+// buildInsert (reversing a DELETE) dereferences row_before, buildUpdate
+// dereferences both, buildDelete (reversing an INSERT) dereferences row_after.
+// Each of those refuses with an error, and #784 makes one refusal abort the
+// WHOLE script — so a nil image here is not a curiosity, it is a recovery that
+// cannot run at all for the window containing it.
+func checkImagesPresent(ev *query.ResultRow) (string, bool) {
+	switch ev.EventType {
+	case event.EventDelete:
+		if ev.RowBefore == nil {
+			return fmt.Sprintf("event %d (pk=%s): DELETE has a nil row_before; recover cannot re-INSERT the deleted row and refuses the whole script",
+				ev.EventID, ev.PKValues), true
+		}
+	case event.EventUpdate:
+		if ev.RowBefore == nil {
+			return fmt.Sprintf("event %d (pk=%s): UPDATE has a nil row_before; recover cannot build the reverse SET clause and refuses the whole script",
+				ev.EventID, ev.PKValues), true
+		}
+		if ev.RowAfter == nil {
+			return fmt.Sprintf("event %d (pk=%s): UPDATE has a nil row_after; recover cannot build the reverse WHERE clause and refuses the whole script",
+				ev.EventID, ev.PKValues), true
+		}
+	case event.EventInsert:
+		if ev.RowAfter == nil {
+			return fmt.Sprintf("event %d (pk=%s): INSERT has a nil row_after; recover cannot build the reverse DELETE and refuses the whole script",
+				ev.EventID, ev.PKValues), true
+		}
+	}
+	return "", false
+}
+
+// pkChangedInEvent reports whether an UPDATE moved the row to a different
+// primary key. Both keys are recomputed from the SAME event's images (never
+// compared against the stored pk_values), so a numeric-representation
+// difference between the parser-native stored key and the JSON-decoded images
+// cannot produce a false positive — the same construction internal/reconstruct
+// uses for its own PK-change detection (#782).
+func pkChangedInEvent(ev *query.ResultRow, pkCols []metadata.ColumnMeta) bool {
+	if ev.EventType != event.EventUpdate || ev.RowBefore == nil || ev.RowAfter == nil {
+		return false
+	}
+	return event.BuildPKValues(pkCols, ev.RowBefore) != event.BuildPKValues(pkCols, ev.RowAfter)
+}
+
+func eventTypeLabel(t event.EventType) string {
+	switch t {
+	case event.EventInsert:
+		return "INSERT"
+	case event.EventUpdate:
+		return "UPDATE"
+	case event.EventDelete:
+		return "DELETE"
+	case event.EventSnapshot:
+		return "SNAPSHOT"
+	default:
+		return "UNKNOWN"
+	}
+}

--- a/internal/verify/recover_inputs_integration_test.go
+++ b/internal/verify/recover_inputs_integration_test.go
@@ -1,0 +1,126 @@
+//go:build integration
+
+package verify
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestVerifyRecoverInputs_StampedCaptureGapIsInconclusiveNotMismatch is the
+// end-to-end form of this mode's sharpest failure mode.
+//
+// The chain below has a HOLE, not corruption: event 1 leaves qty=1, event 2
+// arrives with row_before qty=99, and the events that moved it were NEVER
+// CAPTURED. Every stored image is intact — the exact shape of the real incident
+// on record for this project (a 10-hour capture gap that lost 301 deletes and
+// 37 inserts with perfectly intact images).
+//
+// The upstream coverage guard cannot see it: query.buildPlan classifies an hour
+// as covered iff a p_YYYYMMDDHH partition EXISTS, and both hours here are
+// partitioned and live. So the walk reaches a break and — before the fix — the
+// table came back a conclusive MISMATCH.
+//
+// Phase 1 pins that false mismatch (it is what a chain break looks like with no
+// continuity record to consult). Phase 2 stamps stream_state.gap_lost_at inside
+// the window and pins that the SAME index, SAME events, now reports
+// INCONCLUSIVE. Phase 3 moves the stamp outside the window to prove the gate is
+// scoped and not a blanket disable.
+func TestVerifyRecoverInputs_StampedCaptureGapIsInconclusiveNotMismatch(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	for _, c := range []struct {
+		name             string
+		ord              int
+		key, dt, colType string
+	}{
+		{"id", 1, "PRI", "int", "int"},
+		{"name", 2, "", "varchar", "varchar(64)"},
+		{"qty", 3, "", "int", "int"},
+	} {
+		testutil.MustExec(t, db, `INSERT INTO schema_snapshots
+			(snapshot_id, snapshot_time, schema_name, table_name, column_name,
+			 ordinal_position, column_key, data_type, column_type, is_nullable, is_generated)
+			VALUES (1, UTC_TIMESTAMP(), ?, 'orders', ?, ?, ?, ?, ?, 'NO', 0)`,
+			dbName, c.name, c.ord, c.key, c.dt, c.colType)
+	}
+
+	now := time.Now().UTC()
+	curHour := now.Truncate(time.Hour)
+	h1, h2 := curHour.Add(-time.Hour), curHour
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{h1, h2})
+
+	const tsFmt = "2006-01-02 15:04:05"
+	testutil.InsertEvent(t, db, "binlog.000001", 100, 200,
+		now.Add(-3*time.Minute).Format(tsFmt), nil, dbName, "orders", 1 /*INSERT*/, "7", nil,
+		nil, []byte(`{"id":7,"name":"widget","qty":1}`))
+	// The updates that took qty 1 → 99 were never captured. Both images below
+	// are exactly what the source wrote.
+	testutil.InsertEvent(t, db, "binlog.000001", 200, 300,
+		now.Add(-2*time.Minute).Format(tsFmt), nil, dbName, "orders", 2 /*UPDATE*/, "7", nil,
+		[]byte(`{"id":7,"name":"widget","qty":99}`), []byte(`{"id":7,"name":"widget","qty":100}`))
+
+	resolver, err := metadata.NewResolver(db, 1)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+	cfg := RecoverInputsConfig{
+		IndexDB:     db,
+		Resolver:    resolver,
+		IndexDBName: dbName,
+		NoArchive:   true,
+		Since:       h1,
+		Until:       now,
+	}
+	run := func(t *testing.T) TableResult {
+		t.Helper()
+		res, err := VerifyRecoverInputs(context.Background(), cfg, dbName, "orders")
+		if err != nil {
+			t.Fatalf("VerifyRecoverInputs: %v", err)
+		}
+		return res
+	}
+
+	// ── Phase 1: no continuity record at all ──────────────────────────────────
+	res := run(t)
+	if res.Status != StatusMismatch {
+		t.Fatalf("premise: a chain break with no gap record should still be reported, got %s (%s)", res.Status, res.Detail)
+	}
+	// Even here the finding must not assert corruption as the cause — the
+	// missing events ARE the cause in this fixture.
+	if !strings.Contains(res.Detail, "never captured") {
+		t.Errorf("mismatch detail must name the missing-events explanation, got: %s", res.Detail)
+	}
+
+	// ── Phase 2: the loss is stamped inside the window ────────────────────────
+	testutil.MustExec(t, db, `INSERT INTO stream_state
+		(id, mode, last_checkpoint, server_id, gap_lost_at, gap_lost_detail)
+		VALUES (1, 'gtid', UTC_TIMESTAMP(), 1, ?, ?)`,
+		now.Add(-10*time.Minute).Format(tsFmt), "unfillable binlog gap; auto-advanced past the missing range")
+
+	res = run(t)
+	if res.Status != StatusInconclusive {
+		t.Fatalf("a stamped permanent loss inside the window must degrade the table to inconclusive, got %s (%s)", res.Status, res.Detail)
+	}
+	if !strings.Contains(res.Detail, "permanently lost") || !strings.Contains(res.Detail, "auto-advanced") {
+		t.Errorf("detail should name the stamped loss and carry its recorded reason, got: %s", res.Detail)
+	}
+
+	// ── Phase 3: the same stamp, outside the window ───────────────────────────
+	testutil.MustExec(t, db, `UPDATE stream_state SET gap_lost_at = ? WHERE id = 1`,
+		now.Add(-2*time.Hour).Format(tsFmt))
+
+	if res = run(t); res.Status != StatusMismatch {
+		t.Fatalf("a loss stamped OUTSIDE the window must not suppress the finding, got %s (%s)", res.Status, res.Detail)
+	}
+}

--- a/internal/verify/recover_inputs_integration_test.go
+++ b/internal/verify/recover_inputs_integration_test.go
@@ -123,4 +123,16 @@ func TestVerifyRecoverInputs_StampedCaptureGapIsInconclusiveNotMismatch(t *testi
 	if res = run(t); res.Status != StatusMismatch {
 		t.Fatalf("a loss stamped OUTSIDE the window must not suppress the finding, got %s (%s)", res.Status, res.Detail)
 	}
+
+	// ── Phase 4: the record cannot be READ ────────────────────────────────────
+	// A failed read says nothing about continuity, so it must surface as a hard
+	// error (the CLI renders it as this table's StatusError and keeps going) —
+	// NOT as an inconclusive verdict about data that was never consulted, which
+	// would be a second door to the all-inconclusive non-zero exit.
+	testutil.MustExec(t, db, "DROP TABLE stream_state")
+	if _, err := VerifyRecoverInputs(context.Background(), cfg, dbName, "orders"); err == nil {
+		t.Fatal("an unreadable capture-continuity record must surface as an error, not a verdict")
+	} else if !strings.Contains(err.Error(), "capture-continuity record") {
+		t.Errorf("error should name what could not be read, got: %v", err)
+	}
 }

--- a/internal/verify/recover_inputs_test.go
+++ b/internal/verify/recover_inputs_test.go
@@ -3,7 +3,6 @@ package verify
 import (
 	"database/sql"
 	"encoding/json"
-	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -546,15 +545,12 @@ func TestClassifyCaptureGap(t *testing.T) {
 	tests := []struct {
 		name      string
 		ss        *status.StreamStateInfo
-		loadErr   error
 		want      captureGapVerdict
 		wantWhy   string // substring, "" = don't care
 		wantNoWhy bool
 	}{
 		{name: "no stream_state row at all (file-mode index): nothing was ever stamped",
 			ss: nil, want: captureGapNoneStamped, wantNoWhy: true},
-		{name: "unreadable stream_state is unknown, not ok",
-			loadErr: errors.New("boom"), want: captureGapUnknown, wantWhy: "could not be read"},
 		{name: "legacy index without the gap columns cannot conclude no gap",
 			ss: &status.StreamStateInfo{GapColumnsPresent: false}, want: captureGapUnknown, wantWhy: "predates"},
 		{name: "migrated index with no stamp",
@@ -580,7 +576,7 @@ func TestClassifyCaptureGap(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, why := classifyCaptureGap(tc.ss, tc.loadErr, since, until)
+			got, why := classifyCaptureGap(tc.ss, since, until)
 			if got != tc.want {
 				t.Fatalf("verdict = %d, want %d (why=%q)", got, tc.want, why)
 			}

--- a/internal/verify/recover_inputs_test.go
+++ b/internal/verify/recover_inputs_test.go
@@ -1,0 +1,469 @@
+package verify
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/event"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/query"
+)
+
+// ─── fixtures ─────────────────────────────────────────────────────────────────
+
+// riCols is a small table: an INT primary key plus a VARCHAR and an INT.
+func riCols() []metadata.ColumnMeta {
+	return []metadata.ColumnMeta{
+		{Name: "id", DataType: "int", ColumnType: "int", IsPK: true},
+		{Name: "name", DataType: "varchar", ColumnType: "varchar(64)"},
+		{Name: "qty", DataType: "int", ColumnType: "int"},
+	}
+}
+
+func riInput(events []query.ResultRow) recoverChainInput {
+	cols := riCols()
+	byName := make(map[string]metadata.ColumnMeta, len(cols))
+	for _, c := range cols {
+		byName[c.Name] = c
+	}
+	var pk []metadata.ColumnMeta
+	for _, c := range cols {
+		if c.IsPK {
+			pk = append(pk, c)
+		}
+	}
+	return recoverChainInput{
+		Schema: "shop", Table: "orders",
+		Events:        events,
+		PKCols:        pk,
+		ColByName:     byName,
+		BinariesTyped: true,
+	}
+}
+
+// riRow builds a row image the way the query engine delivers one: numbers come
+// back as json.Number (query.UnmarshalRowImage uses UseNumber), so the fixtures
+// must too or the test would exercise a value shape production never sees.
+func riRow(id int, name string, qty int) map[string]any {
+	return map[string]any{
+		"id":   json.Number(itoa(id)),
+		"name": name,
+		"qty":  json.Number(itoa(qty)),
+	}
+}
+
+func itoa(n int) string {
+	b, _ := json.Marshal(n)
+	return string(b)
+}
+
+var riBase = time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC)
+
+func riEvent(id uint64, typ event.EventType, pk string, before, after map[string]any) query.ResultRow {
+	return query.ResultRow{
+		EventID:        id,
+		EventTimestamp: riBase.Add(time.Duration(id) * time.Second),
+		SchemaName:     "shop",
+		TableName:      "orders",
+		EventType:      typ,
+		PKValues:       pk,
+		RowBefore:      before,
+		RowAfter:       after,
+	}
+}
+
+// ─── the four required cases ─────────────────────────────────────────────────
+
+// A chain that starts with an INSERT and whose every before-image matches the
+// state the previous event left must pass, with the assertions actually counted
+// (a "pass" that asserted nothing would be false assurance).
+func TestCheckRecoverChains_CleanChainPasses(t *testing.T) {
+	events := []query.ResultRow{
+		riEvent(1, event.EventInsert, "7", nil, riRow(7, "widget", 1)),
+		riEvent(2, event.EventUpdate, "7", riRow(7, "widget", 1), riRow(7, "widget", 5)),
+		riEvent(3, event.EventUpdate, "7", riRow(7, "widget", 5), riRow(7, "gadget", 5)),
+		riEvent(4, event.EventDelete, "7", riRow(7, "gadget", 5), nil),
+	}
+	out := checkRecoverChains(riInput(events))
+
+	if out.Status != StatusMatch {
+		t.Fatalf("clean chain: got %s (%s), want %s", out.Status, out.Detail, StatusMatch)
+	}
+	if out.Assertions != 3 {
+		t.Errorf("want 3 before-image assertions (2 UPDATEs + 1 DELETE), got %d", out.Assertions)
+	}
+	if out.Chains != 1 || out.Events != 4 {
+		t.Errorf("want 1 chain / 4 events, got %d / %d", out.Chains, out.Events)
+	}
+	if out.ChainsNoPredecessor != 0 {
+		t.Errorf("chain starts with an INSERT, so it has a predecessor: got %d", out.ChainsNoPredecessor)
+	}
+}
+
+// A corrupt row_before on an UPDATE is invisible to a full-table content
+// comparison (the latest row_after is untouched) but makes recover emit a
+// reverse UPDATE that restores the wrong values. It must be a MISMATCH.
+func TestCheckRecoverChains_CorruptUpdateBeforeImageMismatches(t *testing.T) {
+	events := []query.ResultRow{
+		riEvent(1, event.EventInsert, "7", nil, riRow(7, "widget", 1)),
+		// qty=99 was never the row's state — event 1 left qty=1.
+		riEvent(2, event.EventUpdate, "7", riRow(7, "widget", 99), riRow(7, "widget", 5)),
+	}
+	out := checkRecoverChains(riInput(events))
+
+	if out.Status != StatusMismatch {
+		t.Fatalf("corrupt row_before: got %s (%s), want %s", out.Status, out.Detail, StatusMismatch)
+	}
+	if !strings.Contains(out.Detail, `"qty"`) {
+		t.Errorf("detail should name the diverging column, got: %s", out.Detail)
+	}
+	if !strings.Contains(out.Detail, "event 2") {
+		t.Errorf("detail should name the offending event, got: %s", out.Detail)
+	}
+}
+
+// A corrupt DELETE pre-image is the row recover re-INSERTs. A content
+// comparison never sees it (the row is absent from the reconstructed table
+// either way), so only this mode can catch it.
+func TestCheckRecoverChains_CorruptDeletePreImageMismatches(t *testing.T) {
+	events := []query.ResultRow{
+		riEvent(1, event.EventInsert, "7", nil, riRow(7, "widget", 1)),
+		// The row held name="widget"; recover would resurrect it as "WRONG".
+		riEvent(2, event.EventDelete, "7", riRow(7, "WRONG", 1), nil),
+	}
+	out := checkRecoverChains(riInput(events))
+
+	if out.Status != StatusMismatch {
+		t.Fatalf("corrupt DELETE pre-image: got %s (%s), want %s", out.Status, out.Detail, StatusMismatch)
+	}
+	if !strings.Contains(out.Detail, `"name"`) {
+		t.Errorf("detail should name the diverging column, got: %s", out.Detail)
+	}
+}
+
+// A retained window that begins mid-history has no predecessor state for its
+// first event. That is the NORMAL case, not corruption — reporting it as a
+// mismatch would make the whole mode untrustworthy.
+func TestCheckRecoverChains_WindowStartingMidHistoryIsInconclusive(t *testing.T) {
+	events := []query.ResultRow{
+		// No INSERT: the row already existed before the window opened.
+		riEvent(9, event.EventUpdate, "7", riRow(7, "widget", 1), riRow(7, "widget", 5)),
+		riEvent(10, event.EventUpdate, "7", riRow(7, "widget", 5), riRow(7, "widget", 6)),
+	}
+	out := checkRecoverChains(riInput(events))
+
+	if out.Status == StatusMismatch {
+		t.Fatalf("a window starting mid-history must never be a MISMATCH; got detail: %s", out.Detail)
+	}
+	if out.ChainsNoPredecessor != 1 {
+		t.Errorf("want 1 chain reported as having no predecessor, got %d", out.ChainsNoPredecessor)
+	}
+	// The second event DOES have a predecessor (event 9 established it), so the
+	// window is partially provable — the chain start alone must not suppress it.
+	if out.Assertions != 1 {
+		t.Errorf("want the post-start event asserted, got %d assertions", out.Assertions)
+	}
+	if out.Status != StatusMatch {
+		t.Errorf("one clean assertion was made, so the table is proven: got %s (%s)", out.Status, out.Detail)
+	}
+}
+
+// A chain whose ONLY event has no predecessor proves nothing, and must not read
+// as a match.
+func TestCheckRecoverChains_NothingAssertedIsInconclusive(t *testing.T) {
+	events := []query.ResultRow{
+		riEvent(9, event.EventUpdate, "7", riRow(7, "widget", 1), riRow(7, "widget", 5)),
+	}
+	out := checkRecoverChains(riInput(events))
+
+	if out.Status != StatusInconclusive {
+		t.Fatalf("nothing asserted: got %s (%s), want %s", out.Status, out.Detail, StatusInconclusive)
+	}
+	if !strings.Contains(out.Detail, "nothing was proven") {
+		t.Errorf("detail should say nothing was proven, got: %s", out.Detail)
+	}
+}
+
+// ─── superseded intermediate events ──────────────────────────────────────────
+
+// The regression this mode exists for: a corrupt event that a NEWER event on
+// the same PK overwrote. Under the content modes' LimitPerPK=1 fetch only the
+// last event survives, so the corruption is invisible. The walk must visit it.
+func TestCheckRecoverChains_SupersededIntermediateEventIsVisited(t *testing.T) {
+	latest := riRow(7, "final", 5)
+	events := []query.ResultRow{
+		riEvent(1, event.EventInsert, "7", nil, riRow(7, "widget", 1)),
+		// Corrupt, and superseded by event 3 below.
+		riEvent(2, event.EventUpdate, "7", riRow(7, "CORRUPT", 1), riRow(7, "widget", 3)),
+		riEvent(3, event.EventUpdate, "7", riRow(7, "widget", 3), latest),
+	}
+
+	out := checkRecoverChains(riInput(events))
+	if out.Status != StatusMismatch {
+		t.Fatalf("superseded corrupt event must be caught: got %s (%s)", out.Status, out.Detail)
+	}
+	if !strings.Contains(out.Detail, "event 2") {
+		t.Errorf("the SUPERSEDED event (2) is the one that diverged, got: %s", out.Detail)
+	}
+	if out.Events != 3 {
+		t.Errorf("all 3 events must be walked, got %d", out.Events)
+	}
+
+	// Prove the premise: keeping only the latest event per PK (what the content
+	// modes fetch) hides this entirely — that chain reports no divergence.
+	onlyLatest := checkRecoverChains(riInput([]query.ResultRow{events[2]}))
+	if onlyLatest.Status == StatusMismatch {
+		t.Fatal("premise broken: the latest-event-only view was expected to hide the corruption")
+	}
+}
+
+// The fetch must not silently apply LimitPerPK — the whole mode collapses into
+// the check it complements if it ever does.
+func TestRecoverInputsFetchOptions_VisitsSupersededEvents(t *testing.T) {
+	since := riBase
+	until := riBase.Add(time.Hour)
+	opts := recoverInputsFetchOptions("shop", "orders", since, until, 1000)
+
+	if opts.LimitPerPK != 0 {
+		t.Errorf("LimitPerPK must stay unset or superseded events are never fetched, got %d", opts.LimitPerPK)
+	}
+	if !strings.EqualFold(opts.Order, "ASC") {
+		t.Errorf("the walk reconstructs state forward in time, so Order must be ASC, got %q", opts.Order)
+	}
+	if opts.Limit != 1001 {
+		t.Errorf("Limit must be maxEvents+1 so truncation is detectable, got %d", opts.Limit)
+	}
+	if opts.Since == nil || !opts.Since.Equal(since) || opts.Until == nil || !opts.Until.Equal(until) {
+		t.Error("the window bounds must be carried through to the fetch")
+	}
+}
+
+// ─── truncation, nil images, PK moves, normalization ─────────────────────────
+
+// A window that did not fit the event budget must not read as a clean pass:
+// the tail was never walked.
+func TestCheckRecoverChains_TruncatedCleanWindowIsInconclusive(t *testing.T) {
+	in := riInput([]query.ResultRow{
+		riEvent(1, event.EventInsert, "7", nil, riRow(7, "widget", 1)),
+		riEvent(2, event.EventUpdate, "7", riRow(7, "widget", 1), riRow(7, "widget", 5)),
+	})
+	in.Truncated = true
+
+	out := checkRecoverChains(in)
+	if out.Status != StatusInconclusive {
+		t.Fatalf("truncated clean window: got %s (%s), want %s", out.Status, out.Detail, StatusInconclusive)
+	}
+	if !strings.Contains(out.Detail, "--max-events") {
+		t.Errorf("detail should tell the operator how to widen the budget, got: %s", out.Detail)
+	}
+}
+
+// A mismatch found inside a truncated window is still conclusive: the events
+// that WERE walked are real, and recover would consume them.
+func TestCheckRecoverChains_TruncationDoesNotMaskAMismatch(t *testing.T) {
+	in := riInput([]query.ResultRow{
+		riEvent(1, event.EventInsert, "7", nil, riRow(7, "widget", 1)),
+		riEvent(2, event.EventUpdate, "7", riRow(7, "widget", 99), riRow(7, "widget", 5)),
+	})
+	in.Truncated = true
+
+	if out := checkRecoverChains(in); out.Status != StatusMismatch {
+		t.Fatalf("truncation must not downgrade a real mismatch: got %s (%s)", out.Status, out.Detail)
+	}
+}
+
+// recovery refuses the WHOLE reversal script on a nil image it must
+// dereference (#784), so each of these is a recovery that cannot run.
+func TestCheckRecoverChains_NilImagesRecoveryNeedsAreMismatches(t *testing.T) {
+	tests := []struct {
+		name  string
+		event query.ResultRow
+		want  string
+	}{
+		{"delete without before-image", riEvent(1, event.EventDelete, "7", nil, nil), "nil row_before"},
+		{"update without before-image", riEvent(1, event.EventUpdate, "7", nil, riRow(7, "w", 1)), "nil row_before"},
+		{"update without after-image", riEvent(1, event.EventUpdate, "7", riRow(7, "w", 1), nil), "nil row_after"},
+		{"insert without after-image", riEvent(1, event.EventInsert, "7", nil, nil), "nil row_after"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			out := checkRecoverChains(riInput([]query.ResultRow{tc.event}))
+			if out.Status != StatusMismatch {
+				t.Fatalf("got %s (%s), want %s", out.Status, out.Detail, StatusMismatch)
+			}
+			if !strings.Contains(out.Detail, tc.want) {
+				t.Errorf("detail should mention %q, got: %s", tc.want, out.Detail)
+			}
+		})
+	}
+}
+
+// An INSERT legitimately has no before-image — flagging it would fail every
+// clean chain in existence.
+func TestCheckRecoverChains_InsertWithoutBeforeImageIsNormal(t *testing.T) {
+	out := checkRecoverChains(riInput([]query.ResultRow{
+		riEvent(1, event.EventInsert, "7", nil, riRow(7, "widget", 1)),
+		riEvent(2, event.EventDelete, "7", riRow(7, "widget", 1), nil),
+	}))
+	if out.Status != StatusMatch {
+		t.Fatalf("INSERT with nil row_before is normal: got %s (%s)", out.Status, out.Detail)
+	}
+}
+
+// A PK-changing UPDATE is stored under the BEFORE-image PK, so the old key can
+// be REUSED by a later INSERT. Carrying the moved row's after-image forward
+// under the old key would false-mismatch that sequence.
+func TestCheckRecoverChains_PKChangingUpdateThenKeyReuseIsNotAMismatch(t *testing.T) {
+	out := checkRecoverChains(riInput([]query.ResultRow{
+		riEvent(1, event.EventInsert, "1", nil, riRow(1, "widget", 1)),
+		// pk 1 → 2: filed under "1", the before-image key.
+		riEvent(2, event.EventUpdate, "1", riRow(1, "widget", 1), riRow(2, "widget", 1)),
+		// The freed key is reused, then updated. Neither may report a divergence.
+		riEvent(3, event.EventInsert, "1", nil, riRow(1, "fresh", 9)),
+		riEvent(4, event.EventUpdate, "1", riRow(1, "fresh", 9), riRow(1, "fresh", 10)),
+	}))
+	if out.Status == StatusMismatch {
+		t.Fatalf("PK move followed by key reuse must not be a mismatch: %s", out.Detail)
+	}
+	// The PK-changing UPDATE itself IS asserted (its before-image is under this
+	// key), as is the post-reuse UPDATE.
+	if out.Assertions != 2 {
+		t.Errorf("want 2 assertions (events 2 and 4), got %d", out.Assertions)
+	}
+}
+
+// An UPDATE against a key the chain established was DELETEd is the chaining
+// assertion failing outright.
+func TestCheckRecoverChains_EventAfterDeleteWithoutReinsertMismatches(t *testing.T) {
+	out := checkRecoverChains(riInput([]query.ResultRow{
+		riEvent(1, event.EventInsert, "7", nil, riRow(7, "widget", 1)),
+		riEvent(2, event.EventDelete, "7", riRow(7, "widget", 1), nil),
+		riEvent(3, event.EventUpdate, "7", riRow(7, "widget", 1), riRow(7, "widget", 2)),
+	}))
+	if out.Status != StatusMismatch {
+		t.Fatalf("got %s (%s), want %s", out.Status, out.Detail, StatusMismatch)
+	}
+	if !strings.Contains(out.Detail, "deleted by an earlier event") {
+		t.Errorf("detail should explain the chain said the row was gone, got: %s", out.Detail)
+	}
+}
+
+// Chains are independent: one PK's corruption must not contaminate another's,
+// and both must be counted.
+func TestCheckRecoverChains_ChainsAreIndependentPerPK(t *testing.T) {
+	out := checkRecoverChains(riInput([]query.ResultRow{
+		riEvent(1, event.EventInsert, "1", nil, riRow(1, "a", 1)),
+		riEvent(2, event.EventInsert, "2", nil, riRow(2, "b", 1)),
+		riEvent(3, event.EventUpdate, "1", riRow(1, "a", 1), riRow(1, "a", 2)),
+		riEvent(4, event.EventUpdate, "2", riRow(2, "b", 1), riRow(2, "b", 2)),
+	}))
+	if out.Status != StatusMatch {
+		t.Fatalf("interleaved clean chains: got %s (%s)", out.Status, out.Detail)
+	}
+	if out.Chains != 2 || out.Assertions != 2 {
+		t.Errorf("want 2 chains / 2 assertions, got %d / %d", out.Chains, out.Assertions)
+	}
+}
+
+// Two renderings of the same JSON object differing only in key order are the
+// same data. A fresh reflect.DeepEqual over the decoded maps would be fine
+// here, but the RENDERED comparison must not regress into a byte diff — this
+// is the false-MISMATCH class the package's canonicalizer already closed.
+func TestCompareImages_JSONKeyOrderIsNotADivergence(t *testing.T) {
+	cols := []metadata.ColumnMeta{
+		{Name: "id", DataType: "int", IsPK: true},
+		{Name: "doc", DataType: "json"},
+	}
+	byName := map[string]metadata.ColumnMeta{"id": cols[0], "doc": cols[1]}
+	in := recoverChainInput{ColByName: byName, BinariesTyped: true}
+
+	prev := map[string]any{"id": json.Number("1"), "doc": `{"a":1,"b":2}`}
+	cur := map[string]any{"id": json.Number("1"), "doc": `{"b":2,"a":1}`}
+
+	equal, unresolved, diff := compareImages(prev, cur, 1, 1, in)
+	if !equal {
+		t.Fatalf("key-order-only difference must compare equal (unresolved=%q diff=%q)", unresolved, diff)
+	}
+}
+
+// A column set that differs across a schema-version boundary is DDL, not
+// corruption; the same difference within one version is a real divergence.
+func TestCompareImages_ColumnSetDifference(t *testing.T) {
+	in := riInput(nil)
+	prev := riRow(7, "widget", 1)
+	cur := map[string]any{"id": json.Number("7"), "name": "widget"} // qty dropped
+
+	if equal, unresolved, _ := compareImages(prev, cur, 1, 2, in); equal || unresolved != "qty" {
+		t.Errorf("across a DDL boundary the column-set difference must be inconclusive, got equal=%v unresolved=%q", equal, unresolved)
+	}
+	if equal, unresolved, diff := compareImages(prev, cur, 1, 1, in); equal || unresolved != "" || diff == "" {
+		t.Errorf("within one schema version it is a real divergence, got equal=%v unresolved=%q diff=%q", equal, unresolved, diff)
+	}
+}
+
+// SNAPSHOT rows are read-only baseline state that recovery rejects outright —
+// folding one into a chain would manufacture a mismatch from nothing.
+func TestDropSnapshotRows(t *testing.T) {
+	rows := []query.ResultRow{
+		riEvent(1, event.EventInsert, "7", nil, riRow(7, "widget", 1)),
+		riEvent(2, event.EventSnapshot, "7", nil, riRow(7, "widget", 1)),
+		riEvent(3, event.EventUpdate, "7", riRow(7, "widget", 1), riRow(7, "widget", 2)),
+	}
+	got := dropSnapshotRows(rows)
+	if len(got) != 2 {
+		t.Fatalf("want 2 rows after dropping the snapshot, got %d", len(got))
+	}
+	for _, r := range got {
+		if r.EventType == event.EventSnapshot {
+			t.Error("a SNAPSHOT row survived the filter")
+		}
+	}
+	// A slice with no snapshot rows must come back untouched.
+	clean := rows[:1]
+	if len(dropSnapshotRows(clean)) != 1 {
+		t.Error("a snapshot-free slice must pass through unchanged")
+	}
+}
+
+// The recover-input mode must ride #1109's report types and, critically, its
+// single exit decision — not a second exit path.
+func TestNewReport_RecoverInputsCarriesChainCountsAndExits(t *testing.T) {
+	rep := NewReport(ModeRecoverInputs, []TableResult{
+		{Schema: "shop", Table: "orders", Status: StatusMismatch, Detail: "row_before diverged",
+			EventsChecked: 42, ChainsChecked: 7, ChainsInconclusive: 2},
+	})
+	if rep.Mode != ModeRecoverInputs {
+		t.Errorf("mode = %q, want %q", rep.Mode, ModeRecoverInputs)
+	}
+	got := rep.Tables[0]
+	if got.EventsChecked != 42 || got.ChainsChecked != 7 || got.ChainsInconclusive != 2 {
+		t.Errorf("chain counts not carried through NewReport: %+v", got)
+	}
+	// The counts must NOT be smuggled into the row-count fields, which mean
+	// "rows in a table" to every existing consumer.
+	if got.SourceRows != 0 || got.ReconstructRows != 0 {
+		t.Errorf("row-count fields must stay zero in this mode, got %d/%d", got.SourceRows, got.ReconstructRows)
+	}
+	if rep.Verdict != VerdictMismatch {
+		t.Errorf("verdict = %q, want %q", rep.Verdict, VerdictMismatch)
+	}
+	if rep.ExitError() == nil {
+		t.Error("a recover-input mismatch must fail the run through the shared ExitError")
+	}
+
+	// The new fields are omitempty, so the content modes' JSON is byte-identical
+	// to what #1109 emits.
+	blob, err := json.Marshal(NewReport(ModeBaselinePair, []TableResult{
+		{Schema: "shop", Table: "orders", Status: StatusMatch},
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []string{"events_checked", "chains_checked", "chains_inconclusive"} {
+		if strings.Contains(string(blob), field) {
+			t.Errorf("%q must be omitted from a content-mode report: %s", field, blob)
+		}
+	}
+}

--- a/internal/verify/recover_inputs_test.go
+++ b/internal/verify/recover_inputs_test.go
@@ -388,6 +388,102 @@ func TestCompareImages_JSONKeyOrderIsNotADivergence(t *testing.T) {
 	}
 }
 
+// riDeferredInput is a table carrying the value classes whose EVENT-IMAGE
+// representation differs from their at-rest one: TEXT and BLOB (stored base64),
+// and ENUM (stored as an ordinal).
+func riDeferredInput(events []query.ResultRow) recoverChainInput {
+	cols := []metadata.ColumnMeta{
+		{Name: "id", DataType: "int", ColumnType: "int", IsPK: true},
+		{Name: "body", DataType: "text", ColumnType: "text"},
+		{Name: "blob_col", DataType: "blob", ColumnType: "blob"},
+		{Name: "state", DataType: "enum", ColumnType: "enum('new','done')"},
+	}
+	byName := make(map[string]metadata.ColumnMeta, len(cols))
+	for _, c := range cols {
+		byName[c.Name] = c
+	}
+	return recoverChainInput{
+		Schema: "shop", Table: "notes",
+		Events:        events,
+		PKCols:        cols[:1],
+		ColByName:     byName,
+		BinariesTyped: true,
+	}
+}
+
+func riDeferredRow(id int, body, blobVal, state string) map[string]any {
+	return map[string]any{
+		"id":       json.Number(itoa(id)),
+		"body":     body,
+		"blob_col": blobVal,
+		"state":    state,
+	}
+}
+
+// This mode is the FIRST consumer to compare a previous event's row_after
+// against the next event's row_before, so the normalization passes it runs
+// (MapEventEnumLabels / DecodeEventBinaries) must touch BOTH images. They do —
+// and if that ever regressed to row_after-only, every table with a TEXT column
+// would report a conclusive MISMATCH on every event (TEXT is deliberately NOT
+// in the deferred set, so nothing would downgrade it to inconclusive). This
+// test walks a clean chain over exactly those value classes so the regression
+// cannot land silently.
+func TestCheckRecoverChains_DeferredTypeColumnsCleanChainPasses(t *testing.T) {
+	out := checkRecoverChains(riDeferredInput([]query.ResultRow{
+		riEvent(1, event.EventInsert, "7", nil, riDeferredRow(7, "hello", "\x00\x01raw", "new")),
+		riEvent(2, event.EventUpdate, "7",
+			riDeferredRow(7, "hello", "\x00\x01raw", "new"),
+			riDeferredRow(7, "goodbye", "\x00\x01raw", "done")),
+		riEvent(3, event.EventDelete, "7", riDeferredRow(7, "goodbye", "\x00\x01raw", "done"), nil),
+	}))
+	if out.Status != StatusMatch {
+		t.Fatalf("clean chain over TEXT/BLOB/ENUM columns: got %s (%s), want %s", out.Status, out.Detail, StatusMatch)
+	}
+	if out.Assertions != 2 {
+		t.Errorf("want 2 assertions, got %d", out.Assertions)
+	}
+}
+
+// TEXT is deliberately outside the deferred set, so a genuine TEXT divergence
+// in a before-image must stay a CONCLUSIVE mismatch — not be masked as
+// inconclusive just because the table also holds BLOB and ENUM columns.
+func TestCheckRecoverChains_TextDivergenceIsNotMaskedByDeferredNeighbours(t *testing.T) {
+	out := checkRecoverChains(riDeferredInput([]query.ResultRow{
+		riEvent(1, event.EventInsert, "7", nil, riDeferredRow(7, "hello", "\x00\x01raw", "new")),
+		riEvent(2, event.EventUpdate, "7",
+			riDeferredRow(7, "WRONG", "\x00\x01raw", "new"),
+			riDeferredRow(7, "goodbye", "\x00\x01raw", "done")),
+	}))
+	if out.Status != StatusMismatch {
+		t.Fatalf("a real TEXT divergence must stay conclusive: got %s (%s)", out.Status, out.Detail)
+	}
+	if !strings.Contains(out.Detail, `"body"`) {
+		t.Errorf("detail should name the TEXT column, got: %s", out.Detail)
+	}
+}
+
+// An ENUM value the epoch-aware label mapping could NOT resolve (still a bare
+// ordinal) must degrade a difference to inconclusive rather than fire a false
+// mismatch — the deferred gate the content modes already apply.
+func TestCheckRecoverChains_UnresolvedEnumOrdinalIsInconclusiveNotMismatch(t *testing.T) {
+	out := checkRecoverChains(riDeferredInput([]query.ResultRow{
+		riEvent(1, event.EventInsert, "7", nil, riDeferredRow(7, "hello", "raw", "new")),
+		riEvent(2, event.EventUpdate, "7",
+			// state came back as an unmapped ordinal, not the label "new".
+			map[string]any{"id": json.Number("7"), "body": "hello", "blob_col": "raw", "state": json.Number("1")},
+			riDeferredRow(7, "hello", "raw", "done")),
+	}))
+	if out.Status == StatusMismatch {
+		t.Fatalf("an unresolvable ENUM representation must not be a mismatch: %s", out.Detail)
+	}
+	if out.Status != StatusInconclusive {
+		t.Fatalf("got %s (%s), want %s", out.Status, out.Detail, StatusInconclusive)
+	}
+	if !strings.Contains(out.Detail, "not conclusive") {
+		t.Errorf("detail should explain why, got: %s", out.Detail)
+	}
+}
+
 // A column set that differs across a schema-version boundary is DDL, not
 // corruption; the same difference within one version is a real divergence.
 func TestCompareImages_ColumnSetDifference(t *testing.T) {

--- a/internal/verify/recover_inputs_test.go
+++ b/internal/verify/recover_inputs_test.go
@@ -1,7 +1,9 @@
 package verify
 
 import (
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -9,6 +11,7 @@ import (
 	"github.com/dbtrail/dbtrail/internal/event"
 	"github.com/dbtrail/dbtrail/internal/metadata"
 	"github.com/dbtrail/dbtrail/internal/query"
+	"github.com/dbtrail/dbtrail/internal/status"
 )
 
 // ─── fixtures ─────────────────────────────────────────────────────────────────
@@ -520,6 +523,224 @@ func TestDropSnapshotRows(t *testing.T) {
 	clean := rows[:1]
 	if len(dropSnapshotRows(clean)) != 1 {
 		t.Error("a snapshot-free slice must pass through unchanged")
+	}
+}
+
+// ─── capture gaps: a hole is not corruption ──────────────────────────────────
+
+// The gate that keeps a PERMANENT capture loss from reading as a corrupt
+// before-image. The partition-existence coverage check upstream cannot see a
+// hole inside a partition that exists, so stream_state's stamp is the only
+// durable record — and an index that cannot answer must read as UNKNOWN, never
+// as "no gap".
+func TestClassifyCaptureGap(t *testing.T) {
+	since := riBase
+	until := riBase.Add(2 * time.Hour)
+	stamped := func(at time.Time, colsPresent bool) *status.StreamStateInfo {
+		return &status.StreamStateInfo{
+			GapColumnsPresent: colsPresent,
+			GapLostAt:         sql.NullTime{Time: at, Valid: true},
+			GapLostDetail:     sql.NullString{String: "unfillable binlog gap; auto-advanced", Valid: true},
+		}
+	}
+	tests := []struct {
+		name      string
+		ss        *status.StreamStateInfo
+		loadErr   error
+		want      captureGapVerdict
+		wantWhy   string // substring, "" = don't care
+		wantNoWhy bool
+	}{
+		{name: "no stream_state row at all (file-mode index): nothing was ever stamped",
+			ss: nil, want: captureGapNoneStamped, wantNoWhy: true},
+		{name: "unreadable stream_state is unknown, not ok",
+			loadErr: errors.New("boom"), want: captureGapUnknown, wantWhy: "could not be read"},
+		{name: "legacy index without the gap columns cannot conclude no gap",
+			ss: &status.StreamStateInfo{GapColumnsPresent: false}, want: captureGapUnknown, wantWhy: "predates"},
+		{name: "migrated index with no stamp",
+			ss: &status.StreamStateInfo{GapColumnsPresent: true}, want: captureGapNoneStamped, wantNoWhy: true},
+		{name: "stamped inside the window",
+			ss: stamped(since.Add(time.Hour), true), want: captureGapStamped, wantWhy: "gap_lost_at is stamped"},
+		{name: "stamped detail is carried through",
+			ss: stamped(since.Add(time.Hour), true), want: captureGapStamped, wantWhy: "auto-advanced"},
+		{name: "stamped before the window is out of scope",
+			ss: stamped(since.Add(-time.Second), true), want: captureGapNoneStamped, wantNoWhy: true},
+		{name: "stamped after the window is out of scope",
+			ss: stamped(until.Add(time.Second), true), want: captureGapNoneStamped, wantNoWhy: true},
+		{name: "stamped exactly at Since is in scope (both ends inclusive)",
+			ss: stamped(since, true), want: captureGapStamped, wantWhy: "gap_lost_at is stamped"},
+		{name: "stamped exactly at Until is in scope",
+			ss: stamped(until, true), want: captureGapStamped, wantWhy: "gap_lost_at is stamped"},
+		// A legacy index that somehow carries a stamp still reads as unknown:
+		// GapColumnsPresent=false means the columns were never READ, so the
+		// zero-valued fields say nothing.
+		{name: "legacy index wins over an unread stamp",
+			ss:   &status.StreamStateInfo{GapColumnsPresent: false, GapLostAt: sql.NullTime{Time: since.Add(time.Hour), Valid: true}},
+			want: captureGapUnknown, wantWhy: "predates"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, why := classifyCaptureGap(tc.ss, tc.loadErr, since, until)
+			if got != tc.want {
+				t.Fatalf("verdict = %d, want %d (why=%q)", got, tc.want, why)
+			}
+			if tc.wantWhy != "" && !strings.Contains(why, tc.wantWhy) {
+				t.Errorf("reason %q should contain %q", why, tc.wantWhy)
+			}
+			if tc.wantNoWhy && why != "" {
+				t.Errorf("a no-gap verdict must carry no reason, got %q", why)
+			}
+		})
+	}
+}
+
+// The detail a chain break emits must NOT assert corruption as the cause.
+//
+// A hole in capture and a corrupt image produce byte-identical evidence, and a
+// hole is at least as likely: the coverage check upstream is partition-existence
+// based, so every hole that falls inside a live partition (a table skipped after
+// an un-re-snapshotted ALTER, a --tables filter change, `stream --reset`, a
+// short outage) is invisible to it. This project has a real instance on record —
+// a 10-hour capture gap where 301 deletes and 37 inserts were lost and every
+// stored image was intact. Naming only "stale or corrupt" would rule out the
+// true cause and send the operator hunting for corruption that is not there.
+func TestCheckRecoverChains_ChainBreakDetailDoesNotAssertCorruption(t *testing.T) {
+	// A chain with a HOLE: the updates that took qty 1 → 99 were never captured.
+	// The images are perfectly intact; only the events between them are missing.
+	holed := checkRecoverChains(riInput([]query.ResultRow{
+		riEvent(1, event.EventInsert, "7", nil, riRow(7, "widget", 1)),
+		riEvent(2, event.EventUpdate, "7", riRow(7, "widget", 99), riRow(7, "widget", 100)),
+	}))
+	// A DELETE against a key the chain says is gone: the re-INSERT went missing.
+	deleted := checkRecoverChains(riInput([]query.ResultRow{
+		riEvent(1, event.EventInsert, "7", nil, riRow(7, "widget", 1)),
+		riEvent(2, event.EventDelete, "7", riRow(7, "widget", 1), nil),
+		riEvent(3, event.EventDelete, "7", riRow(7, "widget", 2), nil),
+	}))
+
+	for _, tc := range []struct{ name, detail string }{
+		{"before-image break", holed.Detail},
+		{"event after a delete", deleted.Detail},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(tc.detail, "never captured") {
+				t.Errorf("detail must name the missing-events explanation, got: %s", tc.detail)
+			}
+			// The old wording asserted the cause outright.
+			if strings.Contains(tc.detail, "from a stale or corrupt before-image") {
+				t.Errorf("detail must not assert corruption as THE cause, got: %s", tc.detail)
+			}
+			if !strings.Contains(tc.detail, "bintrail status") {
+				t.Errorf("detail must point at what would distinguish the two, got: %s", tc.detail)
+			}
+		})
+	}
+}
+
+// ─── drift rows ──────────────────────────────────────────────────────────────
+
+// Drift rows (pk_values NULL in the index, delivered as "" — #318) carry no
+// chain identity. Keying them by pk_values folds every unrelated one into a
+// single chain and compares one row's row_before against another's row_after —
+// a guaranteed MISMATCH on any index that merely CONTAINS drift rows.
+// internal/query/merge.go's LimitPerPK already buckets them per event for the
+// same reason.
+func TestCheckRecoverChains_DriftRowsAreNotFoldedIntoOneChain(t *testing.T) {
+	out := checkRecoverChains(riInput([]query.ResultRow{
+		// Two unrelated drift rows. Under a shared "" chain, event 2's
+		// row_before (name="b") would be compared against event 1's row_after
+		// (name="a") and reported as a divergence.
+		riEvent(1, event.EventUpdate, "", riRow(1, "a", 1), riRow(1, "a", 2)),
+		riEvent(2, event.EventUpdate, "", riRow(2, "b", 1), riRow(2, "b", 2)),
+		riEvent(3, event.EventDelete, "", riRow(3, "c", 1), nil),
+	}))
+
+	if out.Status == StatusMismatch {
+		t.Fatalf("drift rows must never manufacture a mismatch: %s", out.Detail)
+	}
+	if out.Chains != 0 {
+		t.Errorf("a drift row belongs to no chain, got %d chain(s)", out.Chains)
+	}
+	if out.Assertions != 0 {
+		t.Errorf("nothing can be asserted about a drift row, got %d assertion(s)", out.Assertions)
+	}
+	if out.UnwalkableEvents != 3 {
+		t.Errorf("want 3 unwalkable drift events, got %d", out.UnwalkableEvents)
+	}
+	if out.Status != StatusInconclusive {
+		t.Fatalf("a table with only drift rows proves nothing: got %s (%s)", out.Status, out.Detail)
+	}
+	if !strings.Contains(out.Detail, "no primary key") {
+		t.Errorf("detail should explain drift rows were not walked, got: %s", out.Detail)
+	}
+}
+
+// Drift rows must not contaminate the real chains either: a clean keyed chain
+// alongside them still proves the table.
+func TestCheckRecoverChains_DriftRowsDoNotContaminateRealChains(t *testing.T) {
+	out := checkRecoverChains(riInput([]query.ResultRow{
+		riEvent(1, event.EventInsert, "7", nil, riRow(7, "widget", 1)),
+		riEvent(2, event.EventUpdate, "", riRow(1, "a", 1), riRow(1, "a", 2)),
+		riEvent(3, event.EventUpdate, "7", riRow(7, "widget", 1), riRow(7, "widget", 5)),
+	}))
+	if out.Status != StatusMatch {
+		t.Fatalf("a clean chain beside a drift row must still pass: got %s (%s)", out.Status, out.Detail)
+	}
+	if out.Chains != 1 || out.Assertions != 1 || out.UnwalkableEvents != 1 {
+		t.Errorf("want 1 chain / 1 assertion / 1 unwalkable, got %d / %d / %d",
+			out.Chains, out.Assertions, out.UnwalkableEvents)
+	}
+}
+
+// ─── proportionate verdicts ──────────────────────────────────────────────────
+
+// One value whose representation could not be normalized must not erase the
+// conclusive assertions made on the SAME table. deferredValueUnresolved's json
+// case rejects any document holding a numeric literal, so collapsing the table
+// on the first one turns a clean index into a permanently red CI gate.
+func TestCheckRecoverChains_UnresolvedValueDoesNotEraseConclusiveAssertions(t *testing.T) {
+	events := []query.ResultRow{
+		riEvent(1, event.EventInsert, "7", nil, riDeferredRow(7, "hello", "raw", "new")),
+		riEvent(2, event.EventUpdate, "7",
+			riDeferredRow(7, "hello", "raw", "new"),
+			riDeferredRow(7, "second", "raw", "new")),
+		riEvent(3, event.EventUpdate, "7",
+			riDeferredRow(7, "second", "raw", "new"),
+			riDeferredRow(7, "third", "raw", "new")),
+		// One unresolvable ENUM representation among otherwise clean events.
+		riEvent(4, event.EventUpdate, "7",
+			map[string]any{"id": json.Number("7"), "body": "third", "blob_col": "raw", "state": json.Number("1")},
+			riDeferredRow(7, "fourth", "raw", "done")),
+	}
+	out := checkRecoverChains(riDeferredInput(events))
+
+	if out.Status != StatusMatch {
+		t.Fatalf("2 conclusive assertions must survive 1 unresolvable value: got %s (%s)", out.Status, out.Detail)
+	}
+	if out.Assertions != 2 {
+		t.Errorf("want 2 conclusive assertions, got %d", out.Assertions)
+	}
+	// The unproven part is still reported — it is a note on the verdict, not a
+	// silent omission.
+	if !strings.Contains(out.Detail, "not conclusive") {
+		t.Errorf("the unresolved comparison must still be reported, got: %s", out.Detail)
+	}
+}
+
+// The flip side of the rule above: a table where NOTHING was conclusive is
+// still inconclusive, and still says why.
+func TestCheckRecoverChains_OnlyUnresolvedValuesStaysInconclusive(t *testing.T) {
+	out := checkRecoverChains(riDeferredInput([]query.ResultRow{
+		riEvent(1, event.EventInsert, "7", nil, riDeferredRow(7, "hello", "raw", "new")),
+		riEvent(2, event.EventUpdate, "7",
+			map[string]any{"id": json.Number("7"), "body": "hello", "blob_col": "raw", "state": json.Number("1")},
+			riDeferredRow(7, "hello", "raw", "done")),
+	}))
+	if out.Status != StatusInconclusive {
+		t.Fatalf("got %s (%s), want %s", out.Status, out.Detail, StatusInconclusive)
+	}
+	if !strings.Contains(out.Detail, "nothing was proven") || !strings.Contains(out.Detail, "not conclusive") {
+		t.Errorf("detail should say nothing was proven AND why, got: %s", out.Detail)
 	}
 }
 

--- a/internal/verify/report.go
+++ b/internal/verify/report.go
@@ -11,6 +11,11 @@ import (
 const (
 	ModeBaselinePair = "baseline-anchored"
 	ModeLive         = "live-source"
+	// ModeRecoverInputs is the recover-input check (#1001): a per-PK walk of
+	// the event chain asserting the before/after images `recover` consumes are
+	// internally consistent. It compares no table content, so its per-table
+	// rows carry the chain counts below instead of row counts and digests.
+	ModeRecoverInputs = "recover-inputs"
 )
 
 // Verdict is the run-level outcome — the exit code's reason, as a value.
@@ -84,6 +89,22 @@ type TableReport struct {
 	// Reason is the detail behind an inconclusive/mismatch/error verdict, or a
 	// note carried on a match.
 	Reason string `json:"reason,omitempty"`
+
+	// The three fields below are populated only by ModeRecoverInputs. They are
+	// separate from SourceRows/ReconstructRows on purpose: those two mean
+	// "rows in a table", and overloading them with event/chain counts would
+	// silently break every consumer already reading them.
+	//
+	// EventsChecked is how many binlog events the chain walk visited —
+	// including events a newer event on the same PK superseded, which the
+	// content-comparison modes never look at.
+	EventsChecked int `json:"events_checked,omitempty"`
+	// ChainsChecked is the number of distinct primary keys walked.
+	ChainsChecked int `json:"chains_checked,omitempty"`
+	// ChainsInconclusive counts chains whose first event in the window was not
+	// an INSERT — no predecessor state exists, so they are legitimately
+	// unverifiable rather than divergent.
+	ChainsInconclusive int `json:"chains_inconclusive,omitempty"`
 }
 
 // Summary is the run's per-status counts.
@@ -169,6 +190,10 @@ func NewReport(mode string, results []TableResult) *Report {
 			ReconstructDigest: r.ReconstructDigest,
 			Anchor:            r.Anchor,
 			Reason:            reason,
+
+			EventsChecked:      r.EventsChecked,
+			ChainsChecked:      r.ChainsChecked,
+			ChainsInconclusive: r.ChainsInconclusive,
 		})
 	}
 	rep.Summary.Total = len(rep.Tables)

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -52,6 +52,13 @@ type TableResult struct {
 	ReconstructRows   int64
 	Anchor            string // the point the comparison is anchored to: a GTID set (live-source path) or a binlog coordinate file:pos (baseline-pair path)
 	Detail            string // reason for inconclusive/mismatch, or a note carried on a match (e.g. coverage-unverified)
+
+	// Set only by the recover-input check (VerifyRecoverInputs, #1001), which
+	// compares no table content and so leaves the row counts and digests above
+	// zero. See TableReport for what each counts.
+	EventsChecked      int
+	ChainsChecked      int
+	ChainsInconclusive int
 }
 
 // Config wires the three data sources verify needs.


### PR DESCRIPTION
> **⚠️ This PR stacks on #1109 and must merge AFTER it.**
> Base branch is `worktree-agent-aa73a670535ad9d80` (#1109, `verify --format json`), not `main`. This PR emits through #1109's `Report`/`TableReport` types and its `Report.ExitError()`; merging it first would break the build.

closes #1001

## Audit first (STEP 0)

The issue's claims hold against the code as it stands — nothing was already done:

- `internal/verify/verify.go:158-170` and the baseline-pair path both fetch with `LimitPerPK: 1`, i.e. the latest event per PK only.
- `internal/recovery/recovery.go` confirms the dependency set exactly: `buildInsert` (reversing a DELETE) dereferences `row_before`; `buildUpdate` dereferences **both** images (`row_before` → SET, `row_after` → the PK WHERE); `buildDelete` (reversing an INSERT) dereferences `row_after`. Each refuses on a nil one, and #784 makes one refusal abort the whole script.
- `docs/verify.md:22` states plainly that verify does not exercise the recover path.

So a corrupt `row_before`, a corrupt DELETE pre-image, or a corrupt superseded intermediate event all pass verify today while `recover` would emit wrong reverse SQL from those same rows.

## What this adds

`bintrail verify --check recover` walks each primary key's event chain in ascending time order and asserts the images are internally consistent. Index-only — no baseline, no live source. Per event:

1. **The nil-image contract, mirrored from `internal/recovery`** — DELETE needs `row_before`, UPDATE needs both, INSERT needs `row_after`. (An INSERT with a nil `row_before` is normal and is *not* flagged.)
2. **`event.CheckUnresolvedToast` on both images** — the same up-front refusal `GenerateSQLFromRows` performs before it renders anything.
3. **The core assertion:** every UPDATE/DELETE `row_before` equals the state the previous event on that key left behind.

Superseded events are visited, which is precisely the class `LimitPerPK=1` skips.

## Getting "cannot check" vs "checked and wrong" right

A false MISMATCH on a truncated window would make the mode untrustworthy, so these are all **INCONCLUSIVE, never mismatch**:

- a chain whose first in-window event is not an INSERT (no predecessor state — the normal case for any retention window);
- a **coverage gap** (`AllowGaps: false` → `query.GapError`): a chain with an interior hole cannot be asserted against;
- a window that exceeded the event budget (only its oldest events were walked);
- a table with no PK, or an unavailable index DB name (gap detection could not run).

A mismatch found *inside* a truncated window **is** still conclusive — the events that were walked are real. And a table where no assertion could be made at all reports inconclusive rather than "match": an unproven run must never read as success.

## Normalization traps

Comparison reuses this package's existing canonicalizer (`renderCellNormalized`) and its deferred-type gate (`deferredValueUnresolved`) rather than a fresh `reflect.DeepEqual` — that keeps the JSON key-order, zero-date-vs-NULL, TIME-fraction, FLOAT/DOUBLE-exponent and BLOB/base64 fixes in force. Two extra traps specific to this mode:

- **Epoch drift.** Both operands are event images, but two events on one PK can carry different `SchemaVersion` — event N-1's `row_after` may hold a raw ENUM ordinal while event N's `row_before` holds the label. Same data, different bytes. Images go through `MapEventEnumLabels` + `DecodeEventBinaries` first (as `VerifyTable` does), and a residual unresolvable deferred value degrades to inconclusive.
- **PK-changing UPDATE.** The parser files an UPDATE under the **before-image** PK, so the assertion is valid — but the row has *moved*. State becomes unknown afterwards, or the real `UPDATE pk 1→2; INSERT pk=1` sequence (both stored under key `1`) would false-mismatch. Detection recomputes both keys from the same event's images, the same construction `internal/reconstruct` uses (#782).

`EventSnapshot` rows are filtered out — recovery rejects them outright ("baseline rows are read-only"), and folding one in as a delta would manufacture a mismatch from nothing.

## Memory bound

**`--max-events` (default 200,000) events per table, plus one state entry per distinct PK seen.** `Order: "ASC"` with `Limit: maxEvents+1` — the `+1` makes truncation *detectable* rather than silent.

The correctness argument for capping this way: a prefix of the globally time-ordered stream is simultaneously a prefix of *every* PK's chain, so no walked chain has an interior hole; findings in the prefix stay conclusive and a clean-but-truncated run degrades to inconclusive.

Honest limitation: the cap is a **row count, not a byte budget**, so a BLOB/TEXT-heavy table is still large at a given event count (documented in `docs/verify.md`). This deliberately does not add a new instance of #1097's class, but it does not fix it either.

## Report integration (extending #1109, not paralleling it)

- New `verify.ModeRecoverInputs` constant.
- Three **additive `omitempty`** fields — `events_checked`, `chains_checked`, `chains_inconclusive` — threaded through the existing `TableResult` → `NewReport` copy loop → `TableReport`. Why additive rather than reusing the existing shape: `source_rows`/`reconstruct_rows` mean "rows in a table" to every current consumer, and this mode compares no table content; overloading them would be a silent contract break. A test asserts the content modes' JSON is byte-identical (the new keys are absent).
- **No second report constructor and no second exit path** — the run goes through `NewReport` and `Report.ExitError()`, so a recover-input mismatch fails a CI gate exactly like any other. `writeVerifyText` is untouched; the counts ride in the DETAIL cell.

## CLI

`--check content|recover` (default `content`), `--lookback` (default `30d`, matching `recover-cascade`'s convention), `--max-events`. The `--baseline-dir`/`--baseline-s3` requirement is relaxed for `--check recover` (it never opens a baseline), and `--source-dsn` is **rejected** there rather than silently ignored — accepting it would imply the live source was consulted when it was not.

## Tests

All pure (no Docker), so they actually run under the `-race` suite CI uses:

| Case | Expected |
|---|---|
| clean chain | MATCH, with assertions counted |
| corrupted `row_before` | MISMATCH, naming column + event |
| corrupted DELETE pre-image | MISMATCH |
| window starting mid-history | INCONCLUSIVE (never mismatch) |
| superseded intermediate event | MISMATCH — plus the premise proven: the latest-event-only view hides it |
| `recoverInputsFetchOptions` | guard: `LimitPerPK` unset, `Order` ASC, `Limit` = max+1 |

Plus truncation (clean → inconclusive; mismatch → still conclusive), the four nil-image cases, INSERT-without-before-image is normal, PK move + key reuse, event-after-delete, per-PK independence, JSON key-order, column-set difference across vs within a schema version, and snapshot-row filtering.

`go build ./...`, `go test ./... -count=1 -race`, and `go vet -tags integration ./...` all pass.

## Deliberately left out

- **No integration test** for the fetch wiring — the value is in the pure walk, and the one property the DB path could regress (`LimitPerPK` creeping in) is pinned by a unit guard instead.
- **`--explain`-style row-level drill-down** for this mode. The mismatch detail already names the event, PK and column; a full drill-down is a separate surface.
- **No `driftedEmitted` mirror.** That check is about whether reversal SQL applies to *today's* schema — a schema-drift concern, not image consistency.
- **Not wired into `bintrail status` or the console.** CLI-only for now.
- **Console `/api/verify`** is untouched (still #677).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
