### PR TITLE
recovery: sanitize identifiers and PK values interpolated into `--` comments

### DIFF
--- a/internal/cascaderecover/emit.go
+++ b/internal/cascaderecover/emit.go
@@ -145,14 +145,16 @@ func EmitSQL(w io.Writer, gen *recovery.Generator, rows []query.ResultRow, setNu
 
 	var b strings.Builder
 	if hdr.Combined {
-		fmt.Fprintf(&b, "-- bintrail recover (cascade-aware): undo %s.%s, including the foreign-key\n", hdr.Schema, hdr.Table)
+		fmt.Fprintf(&b, "-- bintrail recover (cascade-aware): undo %s.%s, including the foreign-key\n",
+			recovery.SanitizeForComment(hdr.Schema), recovery.SanitizeForComment(hdr.Table))
 		b.WriteString("-- ON DELETE / ON UPDATE CASCADE / SET NULL side effects InnoDB ran below the\n")
 		b.WriteString("-- binlog (MySQL Bug #32506).\n")
 		fmt.Fprintf(&b, "-- Re-creates %d cascade-deleted child row(s), restores %d SET NULL'd FK(s) and %d\n", hdr.Children, len(setNullRows), len(keyUpdates))
 		b.WriteString("-- cascade-rewritten FK(s) alongside the reversal of the selected change(s).\n")
 		b.WriteString("-- NEVER auto-applied.\n")
 	} else {
-		fmt.Fprintf(&b, "-- bintrail recover-cascade: reverse ON DELETE / ON UPDATE CASCADE / SET NULL side effects on %s.%s\n", hdr.Schema, hdr.Table)
+		fmt.Fprintf(&b, "-- bintrail recover-cascade: reverse ON DELETE / ON UPDATE CASCADE / SET NULL side effects on %s.%s\n",
+			recovery.SanitizeForComment(hdr.Schema), recovery.SanitizeForComment(hdr.Table))
 		fmt.Fprintf(&b, "-- Reverses %d parent row change(s) and re-inserts %d cascade-deleted child row(s); restores\n", hdr.Parents, hdr.Children)
 		fmt.Fprintf(&b, "-- %d SET NULL'd FK(s) and %d cascade-rewritten FK(s) that InnoDB removed/nulled/rewrote\n", len(setNullRows), len(keyUpdates))
 		b.WriteString("-- below the binlog (MySQL Bug #32506). NEVER auto-applied.\n")
@@ -170,10 +172,15 @@ func EmitSQL(w io.Writer, gen *recovery.Generator, rows []query.ResultRow, setNu
 	b.WriteString("--\n")
 	b.WriteString("-- If you have already re-created a deleted parent, delete its INSERT below:\n")
 	b.WriteString("-- SET FOREIGN_KEY_CHECKS=0 does NOT suppress PRIMARY KEY violations.\n")
+	// Caveats and warnings are sanitized HERE rather than at their construction
+	// sites in internal/cascade (#1120): they are built from schema/table names
+	// and error text, and the same strings are also served as JSON by the
+	// console, where a newline is harmless. Sanitizing where a string meets the
+	// "--" keeps that path untouched and cannot be bypassed by a future caveat.
 	if len(hdr.Caveats) > 0 {
 		b.WriteString("--\n-- !!! INCOMPLETE RECOVERY — the result is provably partial:\n")
 		for _, c := range hdr.Caveats {
-			fmt.Fprintf(&b, "--   - %s\n", c)
+			fmt.Fprintf(&b, "--   - %s\n", recovery.SanitizeForComment(c))
 		}
 	}
 	// Warnings are deliberately NOT folded into the block above (#618): they are
@@ -182,7 +189,7 @@ func EmitSQL(w io.Writer, gen *recovery.Generator, rows []query.ResultRow, setNu
 	if len(hdr.Warnings) > 0 {
 		b.WriteString("--\n-- NOTE — advisory, recovery below is COMPLETE (nothing is missing):\n")
 		for _, note := range hdr.Warnings {
-			fmt.Fprintf(&b, "--   - %s\n", note)
+			fmt.Fprintf(&b, "--   - %s\n", recovery.SanitizeForComment(note))
 		}
 	}
 	b.WriteString("\nSET FOREIGN_KEY_CHECKS=0;\n\n")

--- a/internal/cascaderecover/emit.go
+++ b/internal/cascaderecover/emit.go
@@ -172,11 +172,14 @@ func EmitSQL(w io.Writer, gen *recovery.Generator, rows []query.ResultRow, setNu
 	b.WriteString("--\n")
 	b.WriteString("-- If you have already re-created a deleted parent, delete its INSERT below:\n")
 	b.WriteString("-- SET FOREIGN_KEY_CHECKS=0 does NOT suppress PRIMARY KEY violations.\n")
-	// Caveats and warnings are sanitized HERE rather than at their construction
-	// sites in internal/cascade (#1120): they are built from schema/table names
-	// and error text, and the same strings are also served as JSON by the
-	// console, where a newline is harmless. Sanitizing where a string meets the
-	// "--" keeps that path untouched and cannot be bypassed by a future caveat.
+	// Caveats and warnings are sanitized HERE, at the comment boundary, rather
+	// than at their construction sites (#1120) — of which there are many, spread
+	// across internal/cascade, internal/cli and internal/console, several
+	// formatting in a schema/table name or an error string. Two reasons: the same
+	// strings are also served as JSON by the console, where a line break is
+	// harmless, so the boundary is the only place the constraint actually
+	// applies; and a fix here cannot be bypassed by a future caveat added
+	// anywhere upstream.
 	if len(hdr.Caveats) > 0 {
 		b.WriteString("--\n-- !!! INCOMPLETE RECOVERY — the result is provably partial:\n")
 		for _, c := range hdr.Caveats {

--- a/internal/cascaderecover/emit_test.go
+++ b/internal/cascaderecover/emit_test.go
@@ -659,31 +659,46 @@ func TestMergeParentRoots_tiesBreakOnEventID(t *testing.T) {
 // unsanitized interpolation in it — not merely the two the fix touched.
 //
 // Both untrusted channels are exercised at once: the header identifiers, and a
-// caveat string (caveats are built in internal/cascade from schema/table names
-// and error text, and are sanitized here at the comment boundary rather than at
-// their ~10 construction sites, because the same strings are also served as JSON
-// by the console, where a newline is harmless).
+// caveat/warning string (those are built from schema/table names and error text
+// at many sites across internal/cascade, internal/cli and internal/console, and
+// are sanitized at the comment boundary instead — the same strings are also
+// served as JSON by the console, where a line break is harmless).
+// Both Combined branches are exercised. Combined:true has its OWN header
+// Fprintf, and no test in this repo had ever set it — its production caller is
+// the console's combined recover (internal/console/recover_cascade.go), a real
+// shipping path, so a sanitization reverted only on that branch would otherwise
+// ship green.
 func TestEmitSQL_commentInjectionCannotEscapeThePreamble(t *testing.T) {
-	hdr := cascaderecover.Header{
-		Schema: "shop", Table: "or\nders",
-		Parents: 1, Children: 0,
-		Caveats:  []string{"child shop.au\ndit was not covered"},
-		Warnings: []string{"baseline for shop.li\nnes is stale"},
-	}
-	got, _, err := emit(t, hdr, nil, nil, nil)
-	if err != nil {
-		t.Fatalf("EmitSQL: %v", err)
-	}
-
-	preamble, _, found := strings.Cut(got, "\nSET FOREIGN_KEY_CHECKS=0;")
-	if !found {
-		t.Fatalf("no SET FOREIGN_KEY_CHECKS=0 to anchor the preamble:\n%s", got)
-	}
-	for _, line := range strings.Split(preamble, "\n") {
-		trimmed := strings.TrimSpace(line)
-		if trimmed == "" || strings.HasPrefix(trimmed, "--") {
-			continue
+	for _, combined := range []bool{false, true} {
+		hdr := cascaderecover.Header{
+			Schema: "shop", Table: "or\nders",
+			Parents: 1, Children: 0,
+			Combined: combined,
+			Caveats:  []string{"child shop.au\ndit was not covered"},
+			Warnings: []string{"baseline for shop.li\nnes is stale"},
 		}
-		t.Errorf("preamble line escaped its comment and would execute: %q\npreamble:\n%s", line, preamble)
+		got, _, err := emit(t, hdr, nil, nil, nil)
+		if err != nil {
+			t.Fatalf("combined=%v: EmitSQL: %v", combined, err)
+		}
+
+		preamble, _, found := strings.Cut(got, "\nSET FOREIGN_KEY_CHECKS=0;")
+		if !found {
+			t.Fatalf("combined=%v: no SET FOREIGN_KEY_CHECKS=0 to anchor the preamble:\n%s", combined, got)
+		}
+		// Positive anchor: the flattened identifier must actually be in the
+		// preamble, or an empty/identifier-free preamble would satisfy the
+		// comment-only loop below without exercising anything.
+		if !strings.Contains(preamble, "shop.or ders") {
+			t.Errorf("combined=%v: preamble must name the table, space-substituted, got:\n%s", combined, preamble)
+		}
+		for _, line := range strings.Split(preamble, "\n") {
+			trimmed := strings.TrimSpace(line)
+			if trimmed == "" || strings.HasPrefix(trimmed, "--") {
+				continue
+			}
+			t.Errorf("combined=%v: preamble line escaped its comment and would execute: %q\npreamble:\n%s",
+				combined, line, preamble)
+		}
 	}
 }

--- a/internal/cascaderecover/emit_test.go
+++ b/internal/cascaderecover/emit_test.go
@@ -652,3 +652,38 @@ func TestMergeParentRoots_tiesBreakOnEventID(t *testing.T) {
 		t.Errorf("same-second roots must order by EventID, got %+v", got)
 	}
 }
+
+// TestEmitSQL_commentInjectionCannotEscapeThePreamble pins #1120 on the cascade
+// path. Everything the preamble emits before `SET FOREIGN_KEY_CHECKS=0;` is a
+// "--" comment by design, so asserting over that whole REGION catches any
+// unsanitized interpolation in it — not merely the two the fix touched.
+//
+// Both untrusted channels are exercised at once: the header identifiers, and a
+// caveat string (caveats are built in internal/cascade from schema/table names
+// and error text, and are sanitized here at the comment boundary rather than at
+// their ~10 construction sites, because the same strings are also served as JSON
+// by the console, where a newline is harmless).
+func TestEmitSQL_commentInjectionCannotEscapeThePreamble(t *testing.T) {
+	hdr := cascaderecover.Header{
+		Schema: "shop", Table: "or\nders",
+		Parents: 1, Children: 0,
+		Caveats:  []string{"child shop.au\ndit was not covered"},
+		Warnings: []string{"baseline for shop.li\nnes is stale"},
+	}
+	got, _, err := emit(t, hdr, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("EmitSQL: %v", err)
+	}
+
+	preamble, _, found := strings.Cut(got, "\nSET FOREIGN_KEY_CHECKS=0;")
+	if !found {
+		t.Fatalf("no SET FOREIGN_KEY_CHECKS=0 to anchor the preamble:\n%s", got)
+	}
+	for _, line := range strings.Split(preamble, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "--") {
+			continue
+		}
+		t.Errorf("preamble line escaped its comment and would execute: %q\npreamble:\n%s", line, preamble)
+	}
+}

--- a/internal/cascaderecover/emit_test.go
+++ b/internal/cascaderecover/emit_test.go
@@ -689,8 +689,8 @@ func TestEmitSQL_commentInjectionCannotEscapeThePreamble(t *testing.T) {
 		// Positive anchor: the flattened identifier must actually be in the
 		// preamble, or an empty/identifier-free preamble would satisfy the
 		// comment-only loop below without exercising anything.
-		if !strings.Contains(preamble, "shop.or ders") {
-			t.Errorf("combined=%v: preamble must name the table, space-substituted, got:\n%s", combined, preamble)
+		if !strings.Contains(preamble, `shop."or\nders"`) {
+			t.Errorf("combined=%v: preamble must name the table, losslessly escaped, got:\n%s", combined, preamble)
 		}
 		for _, line := range strings.Split(preamble, "\n") {
 			trimmed := strings.TrimSpace(line)

--- a/internal/reconstruct/fulltable.go
+++ b/internal/reconstruct/fulltable.go
@@ -29,6 +29,7 @@ import (
 	"github.com/dbtrail/dbtrail/internal/metadata"
 	"github.com/dbtrail/dbtrail/internal/parquetquery"
 	"github.com/dbtrail/dbtrail/internal/query"
+	"github.com/dbtrail/dbtrail/internal/recovery"
 )
 
 // FullTableConfig drives ReconstructTables — the full-table merge-on-read
@@ -1414,7 +1415,12 @@ func reconstructBinlogOnly(
 // binlogOnlySchemaPlaceholder is the schema-file text used when no captured
 // CREATE TABLE DDL is available: fabricating one from column metadata risks
 // silently shipping a wrong PK/engine/charset/index definition as fact.
+//
+// The whole return value is a "--" comment block, so the names are sanitized
+// (#1120): a newline in either would end the comment and leave the remainder of
+// the identifier as executable SQL in a schema file meant to be applied as-is.
 func binlogOnlySchemaPlaceholder(schema, table string) string {
+	schema, table = recovery.SanitizeForComment(schema), recovery.SanitizeForComment(table)
 	return fmt.Sprintf(
 		"-- bintrail: no baseline snapshot exists for %s.%s (table created after the last\n"+
 			"-- `bintrail baseline` run, or never baselined), and no CREATE TABLE statement for\n"+

--- a/internal/reconstruct/fulltable.go
+++ b/internal/reconstruct/fulltable.go
@@ -1417,8 +1417,12 @@ func reconstructBinlogOnly(
 // silently shipping a wrong PK/engine/charset/index definition as fact.
 //
 // The whole return value is a "--" comment block, so the names are sanitized
-// (#1120): a newline in either would end the comment and leave the remainder of
-// the identifier as executable SQL in a schema file meant to be applied as-is.
+// (#1120): a line break in either would end the comment and leave the remainder
+// of the identifier executing as SQL. That matters despite the body telling the
+// operator to create the table themselves — this text occupies the
+// <db>.<table>-schema.sql slot that myloader applies, so ANY non-comment line in
+// it runs. As at the AUTO_INCREMENT block, there is no executable sibling here
+// carrying the exact bytes; the comment is the whole artifact.
 func binlogOnlySchemaPlaceholder(schema, table string) string {
 	schema, table = recovery.SanitizeForComment(schema), recovery.SanitizeForComment(table)
 	return fmt.Sprintf(

--- a/internal/reconstruct/fulltable.go
+++ b/internal/reconstruct/fulltable.go
@@ -1421,8 +1421,13 @@ func reconstructBinlogOnly(
 // of the identifier executing as SQL. That matters despite the body telling the
 // operator to create the table themselves — this text occupies the
 // <db>.<table>-schema.sql slot that myloader applies, so ANY non-comment line in
-// it runs. As at the AUTO_INCREMENT block, there is no executable sibling here
-// carrying the exact bytes; the comment is the whole artifact.
+// it runs.
+//
+// There is no executable sibling here carrying the exact bytes: the comment is
+// the whole artifact, and the operator's task is precisely to read the name off
+// it. That is why SanitizeForComment renders losslessly rather than flattening —
+// the name a break-bearing table shows up under stays recoverable from the text,
+// instead of silently becoming a different, plausible-looking one.
 func binlogOnlySchemaPlaceholder(schema, table string) string {
 	schema, table = recovery.SanitizeForComment(schema), recovery.SanitizeForComment(table)
 	return fmt.Sprintf(

--- a/internal/reconstruct/fulltable_test.go
+++ b/internal/reconstruct/fulltable_test.go
@@ -718,3 +718,16 @@ func mustReadOnlyChunk(t *testing.T, dir string) string {
 	}
 	return string(b)
 }
+
+// TestBinlogOnlySchemaPlaceholder_commentInjection pins #1120 for the
+// binlog-only schema file: its entire contents are a "--" comment block, and it
+// is written for the operator to apply as-is, so a newline in either identifier
+// would leave the rest of the name executing as SQL.
+func TestBinlogOnlySchemaPlaceholder_commentInjection(t *testing.T) {
+	out := binlogOnlySchemaPlaceholder("my\ndb", "or\nders")
+	for _, line := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
+		if !strings.HasPrefix(line, "--") {
+			t.Errorf("placeholder line is not a comment and would execute: %q\nfull text:\n%s", line, out)
+		}
+	}
+}

--- a/internal/recovery/applycodegen_test.go
+++ b/internal/recovery/applycodegen_test.go
@@ -125,6 +125,73 @@ func TestRestoreAutoIncrement_MySQLOnlyAfterCommit(t *testing.T) {
 	}
 }
 
+// ─── Comment-injection defense (#1120) ────────────────────────────────────────
+
+// TestCommentInjection_PKNewlineCannotEscapeTheHeaderComment pins the vector
+// that ships today: a newline inside a VARCHAR primary key is ordinary data, and
+// the per-event header comment interpolated it raw. Because a "--" comment ends
+// at the first newline, everything after it became executable SQL INSIDE the
+// script's BEGIN/COMMIT.
+//
+// PKValues is the right probe for a whole-script assertion: it reaches the
+// header comment ONLY — the reversal's WHERE/VALUES clauses are rebuilt from the
+// row image — so the executable statements stay byte-identical to an ordinary
+// script and every remaining line must be a comment or one of them. That is what
+// makes this catch an unsanitized site anywhere in the body, not just the one
+// line the fix touched.
+func TestCommentInjection_PKNewlineCannotEscapeTheHeaderComment(t *testing.T) {
+	row := applyCodegenRow("db", "orders")
+	row.PKValues = "1\nDROP TABLE users;"
+
+	out := mustGenerate(t, New(nil, nil), []query.ResultRow{row})
+
+	// Every statement an ordinary MySQL reversal script is allowed to contain.
+	allowed := map[string]bool{
+		"BEGIN;":                    true,
+		"SET time_zone = '+00:00';": true,
+		"SET sql_mode = 'STRICT_TRANS_TABLES,NO_ENGINE_SUBSTITUTION';": true,
+		"COMMIT;": true,
+		"INSERT INTO `db`.`orders` (`id`) VALUES ('1');": true,
+	}
+	for _, line := range strings.Split(out, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "--") || allowed[trimmed] {
+			continue
+		}
+		t.Errorf("line escaped its comment and would execute: %q\nfull script:\n%s", line, out)
+	}
+}
+
+// TestCommentInjection_TableNewlineCannotEscapeTheAutoIncrementBlock covers the
+// sharpest case (#1110's opt-in block): there the "--" prefix is the ENTIRE
+// safety mechanism, and the block sits after COMMIT, so anything that breaks out
+// runs standalone rather than inside the transaction. MySQL permits any BMP
+// character except U+0000 in a backtick-quoted identifier, newline included.
+//
+// The assertion is over the whole post-COMMIT REGION — which is comment-only by
+// design — so a site in that block left unsanitized fails here even though the
+// fix never touched its Fprintf.
+func TestCommentInjection_TableNewlineCannotEscapeTheAutoIncrementBlock(t *testing.T) {
+	g := New(nil, nil)
+	g.SetRestoreAutoIncrement(true)
+	out := mustGenerate(t, g, []query.ResultRow{applyCodegenRow("db", "or\nders")})
+
+	_, after, found := strings.Cut(out, "\nCOMMIT;\n")
+	if !found {
+		t.Fatalf("script has no COMMIT to anchor the AUTO_INCREMENT block:\n%s", out)
+	}
+	if !strings.Contains(after, autoIncSection) {
+		t.Fatalf("opted-in script must emit the AUTO_INCREMENT block after COMMIT, got:\n%s", after)
+	}
+	for _, line := range strings.Split(after, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "--") {
+			continue
+		}
+		t.Errorf("post-COMMIT line is not commented and would execute: %q\nblock:\n%s", line, after)
+	}
+}
+
 // TestRestoreAutoIncrement_NoRowsEmitsNothing: with no matched events there is
 // no table whose counter could need restoring, and the early return must stay a
 // bare "no events" line rather than growing a checklist for an empty reversal.

--- a/internal/recovery/applycodegen_test.go
+++ b/internal/recovery/applycodegen_test.go
@@ -145,7 +145,22 @@ func TestCommentInjection_PKNewlineCannotEscapeTheHeaderComment(t *testing.T) {
 
 	out := mustGenerate(t, New(nil, nil), []query.ResultRow{row})
 
+	// Positive anchor FIRST: without it this test passes vacuously if the header
+	// ever stops rendering the PK — the payload would simply never appear, the
+	// loop below would find nothing to reject, and a script that no longer
+	// exercises the vector would report success. Asserting the SANITIZED form
+	// also pins the other half of the contract: the value is still there, only
+	// flattened.
+	if !strings.Contains(out, "pk=1 DROP TABLE users; at ") {
+		t.Fatalf("header must still carry the PK, space-substituted, got:\n%s", out)
+	}
+
 	// Every statement an ordinary MySQL reversal script is allowed to contain.
+	// Exact-string equality, so it can never ADMIT injected SQL. It is coupled to
+	// the MySQL preamble and to applyCodegenRow's single-column DELETE shape, so
+	// a new preamble statement or a different row shape makes it fail loud —
+	// brittle in the safe direction, but read a failure here as possible
+	// formatting drift, not only as an injection regression.
 	allowed := map[string]bool{
 		"BEGIN;":                    true,
 		"SET time_zone = '+00:00';": true,
@@ -159,6 +174,69 @@ func TestCommentInjection_PKNewlineCannotEscapeTheHeaderComment(t *testing.T) {
 			continue
 		}
 		t.Errorf("line escaped its comment and would execute: %q\nfull script:\n%s", line, out)
+	}
+}
+
+// TestCommentInjection_HeaderLineSurvivesLineBreaksInEveryField covers the
+// per-event header field-by-field. The whole-script test above cannot: it needs
+// a CLEAN table name, because a newline inside a backtick-quoted identifier is
+// legal MySQL and makes the executable INSERT legitimately span two lines, which
+// no "every line is a comment or a known statement" rule can accept.
+//
+// So this asserts the narrower, sharper invariant instead — the header renders
+// as EXACTLY ONE line, carrying every field flattened. Schema, table, PK and
+// GTID all reach this comment and nowhere else in the script, so reverting the
+// sanitization on any one of them breaks it here.
+//
+// The schema uses \r rather than \n on purpose: both collapse to the same space,
+// so the expectations are unchanged, and it buys carriage-return coverage
+// through the real production path — load-bearing because PostgreSQL's lexer
+// ends a "--" comment at a bare CR, where MySQL's does not.
+func TestCommentInjection_HeaderLineSurvivesLineBreaksInEveryField(t *testing.T) {
+	gtid := "3e11fa47-71ca-11e1-9e33-c80aa9429562:1\nDROP TABLE audit;"
+	row := applyCodegenRow("d\rb", "or\nders")
+	row.PKValues = "1\nDROP TABLE users;"
+	row.GTID = &gtid
+
+	out := mustGenerate(t, New(nil, nil), []query.ResultRow{row})
+
+	var headers []string
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, "-- [") {
+			headers = append(headers, line)
+		}
+	}
+	if len(headers) != 1 {
+		t.Fatalf("the header must render as exactly 1 line, got %d:\n%s", len(headers), out)
+	}
+	for _, want := range []string{
+		"on d b.or ders pk=",
+		"pk=1 DROP TABLE users; at ",
+		"gtid=3e11fa47-71ca-11e1-9e33-c80aa9429562:1 DROP TABLE audit;",
+	} {
+		if !strings.Contains(headers[0], want) {
+			t.Errorf("header line must contain %q (space-substituted), got:\n%s", want, headers[0])
+		}
+	}
+}
+
+// TestSanitizeForComment_lineBreakForms pins the helper's own contract, which the
+// production-path tests above cannot reach exhaustively: the \r-only and \r\n
+// forms, and the identity case that keeps every ordinary name byte-identical
+// (the property the existing golden-output tests rely on).
+func TestSanitizeForComment_lineBreakForms(t *testing.T) {
+	for _, tc := range []struct{ name, in, want string }{
+		{"lf", "a\nb", "a b"},
+		{"cr", "a\rb", "a b"},
+		{"crlf", "a\r\nb", "a  b"}, // two breaks -> two spaces; never rejoined
+		{"none", "orders", "orders"},
+		{"empty", "", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := SanitizeForComment(tc.in); got != tc.want {
+				t.Errorf("SanitizeForComment(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/recovery/applycodegen_test.go
+++ b/internal/recovery/applycodegen_test.go
@@ -151,8 +151,8 @@ func TestCommentInjection_PKNewlineCannotEscapeTheHeaderComment(t *testing.T) {
 	// exercises the vector would report success. Asserting the SANITIZED form
 	// also pins the other half of the contract: the value is still there, only
 	// flattened.
-	if !strings.Contains(out, "pk=1 DROP TABLE users; at ") {
-		t.Fatalf("header must still carry the PK, space-substituted, got:\n%s", out)
+	if !strings.Contains(out, `pk="1\nDROP TABLE users;" at `) {
+		t.Fatalf("header must still carry the PK, losslessly escaped, got:\n%s", out)
 	}
 
 	// Every statement an ordinary MySQL reversal script is allowed to contain.
@@ -210,12 +210,12 @@ func TestCommentInjection_HeaderLineSurvivesLineBreaksInEveryField(t *testing.T)
 		t.Fatalf("the header must render as exactly 1 line, got %d:\n%s", len(headers), out)
 	}
 	for _, want := range []string{
-		"on d b.or ders pk=",
-		"pk=1 DROP TABLE users; at ",
-		"gtid=3e11fa47-71ca-11e1-9e33-c80aa9429562:1 DROP TABLE audit;",
+		`on "d\rb"."or\nders" pk=`,
+		`pk="1\nDROP TABLE users;" at `,
+		`gtid="3e11fa47-71ca-11e1-9e33-c80aa9429562:1\nDROP TABLE audit;"`,
 	} {
 		if !strings.Contains(headers[0], want) {
-			t.Errorf("header line must contain %q (space-substituted), got:\n%s", want, headers[0])
+			t.Errorf("header line must contain %q (losslessly escaped), got:\n%s", want, headers[0])
 		}
 	}
 }
@@ -226,10 +226,16 @@ func TestCommentInjection_HeaderLineSurvivesLineBreaksInEveryField(t *testing.T)
 // (the property the existing golden-output tests rely on).
 func TestSanitizeForComment_lineBreakForms(t *testing.T) {
 	for _, tc := range []struct{ name, in, want string }{
-		{"lf", "a\nb", "a b"},
-		{"cr", "a\rb", "a b"},
-		{"crlf", "a\r\nb", "a  b"}, // two breaks -> two spaces; never rejoined
-		{"none", "orders", "orders"},
+		{"lf", "a\nb", `"a\nb"`},
+		{"cr", "a\rb", `"a\rb"`},
+		{"crlf", "a\r\nb", `"a\r\nb"`},
+		// U+2028 ALONE is left untouched deliberately: it terminates a "--"
+		// comment in neither lexer, so quoting it would churn legitimate data.
+		// Once a real terminator makes the helper fire, strconv.Quote escapes it
+		// too — the emitted line is then single-line under any definition.
+		{"line separator alone", "a\u2028b", "a\u2028b"},
+		{"line separator with lf", "a\u2028\nb", `"a\u2028\nb"`},
+		{"none", "orders", "orders"}, // identity: golden output depends on this
 		{"empty", "", ""},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/recovery/recovery.go
+++ b/internal/recovery/recovery.go
@@ -285,9 +285,10 @@ func (g *Generator) GenerateSQLFromRows(rows []query.ResultRow, w io.Writer) (in
 		if row.GTID != nil {
 			gtidSuffix = " gtid=" + SanitizeForComment(*row.GTID)
 		}
-		// Every interpolated value is sanitized (#1120): a newline in the table
-		// name or the PK would end this comment and turn the rest of the line
-		// into executable SQL sitting inside the BEGIN/COMMIT below.
+		// Every interpolated value is sanitized (#1120): a line break in the table
+		// name or the PK would end this comment, and the remainder would begin a
+		// new line executing inside the BEGIN/COMMIT below. This is the site that
+		// ships today — a newline in a VARCHAR primary key is ordinary data.
 		fmt.Fprintf(&body, "-- [%d] reverse %s on %s.%s pk=%s at %s%s\n",
 			row.EventID,
 			eventTypeName(row.EventType),
@@ -299,9 +300,16 @@ func (g *Generator) GenerateSQLFromRows(rows []query.ResultRow, w io.Writer) (in
 
 		stmt, cols, err := g.buildStatement(row)
 		if err != nil {
-			// Record the failure and keep the "-- ERROR ..." comment in the
-			// buffered body so the diagnosis lists EVERY un-generatable event,
-			// then refuse the whole script below (#784). Demoting the error to a
+			// Record the failure, then refuse the whole script below (#784).
+			//
+			// The "-- ERROR ..." line goes into the buffered body, which the
+			// refusal below DISCARDS before anything reaches w — the diagnosis is
+			// built from genFailures, not from this text, so this line can never
+			// reach an operator. It is kept for readability while debugging a
+			// rendered body, and sanitized (#1120) only as defense in depth: it
+			// is not a live injection vector the way the header above is.
+			//
+			// Demoting the error to a
 			// comment and returning success is a silent incomplete recovery: a
 			// SQL comment has no apply-time effect, so a partial script commits
 			// clean under BEGIN/COMMIT and the operator never learns an event
@@ -470,8 +478,17 @@ func (g *Generator) writeAutoIncrementSection(w io.Writer, touched map[string]bo
 		schema, table, _ := strings.Cut(k, "\x00")
 		// Sanitized once here (#1120) because all three uses below are comment
 		// lines: this block's ENTIRE safety mechanism is the "--" prefix, and it
-		// sits after COMMIT, so a newline-bearing identifier would run whatever
+		// sits after COMMIT, so a line-break-bearing identifier would run whatever
 		// followed it as a standalone statement.
+		//
+		// Unlike the header above, this block has no executable sibling carrying
+		// the exact bytes — the two commented statements ARE the deliverable, and
+		// the operator is told to uncomment and run them. A flattened identifier
+		// therefore reaches an ALTER the operator may execute; it fails loud there
+		// (ERROR 1146) instead of hitting the intended table, which is why
+		// flattening still beats leaving the injection open. MySQL has no escape
+		// for a line break inside a backtick identifier, so no rendering here is
+		// both single-line and runnable.
 		qualified := SanitizeForComment(QuoteName(schema) + "." + QuoteName(table))
 		fmt.Fprintln(w, "--")
 		fmt.Fprintf(w, "-- %s:\n", qualified)
@@ -1345,22 +1362,35 @@ func QuoteName(name string) string {
 }
 
 // SanitizeForComment makes s safe to interpolate into a "--" SQL comment line
-// (#1120). A "--" comment ends at the first newline, so a value carrying one
-// closes the comment and hands whatever follows to the parser as executable SQL.
-// No existing escaper defends against this: event.EscapePKValue escapes only
-// `\` and `|`, and QuoteName only the backtick — a newline is perfectly legal inside
-// a backtick-quoted MySQL identifier, and inside a VARCHAR primary key it is
-// ordinary data.
+// (#1120). A "--" comment ends at the first line break; a value carrying one
+// closes the comment, and what follows begins a NEW line that the parser reads
+// as executable SQL.
 //
-// The substitution is LOSSY on purpose, and only the annotation loses. Comments
-// carry an identifier or PK for the operator to read; the executable statement
-// beside them renders the same value through QuoteName/EscapeString, which keep
-// every byte. Refusing outright would instead deny recovery to a table that is
-// merely oddly named. Callers therefore apply this at the point a value meets a
-// "--", never to the value itself.
+// Both terminators are handled because this serves both dialects: MySQL ends the
+// comment at LF only, PostgreSQL at LF *or* a bare CR (its lexer defines the
+// comment body as [^\n\r]*). Nothing else terminates one — U+2028/U+2029 are not
+// line breaks to either lexer.
 //
-// Both ReplaceAll calls return s untouched (no allocation) when it holds no
-// line break, which is every ordinary name.
+// No existing escaper defends against this: event.EscapePKValue escapes only `\`
+// and `|`, QuoteName only the backtick, quoteNamePG only the double quote — and a
+// line break is legal inside a quoted identifier in either dialect, while inside
+// a VARCHAR primary key it is ordinary data.
+//
+// The substitution is LOSSY, and refusing outright would instead deny recovery to
+// a table that is merely oddly named. How much is lost varies BY SITE, so do not
+// read this as a blanket "only the annotation degrades" guarantee:
+//
+//   - Per-event header, cascade preamble: an executable statement rendered from
+//     the same value sits beside the comment and keeps every byte (quoteName /
+//     EscapeString are untouched by this). Only the annotation degrades.
+//   - AUTO_INCREMENT block, reconstruct's binlog-only schema placeholder: there
+//     is NO executable sibling — the commented text is itself the artifact. A
+//     flattened identifier there fails loud when applied (MySQL ERROR 1146,
+//     "table doesn't exist") rather than silently acting on the intended table.
+//
+// Callers apply this where a value meets a "--", never to the value itself.
+// TestSanitizeForComment_lineBreakForms pins the identity case, on which every
+// golden-output test in this package depends.
 func SanitizeForComment(s string) string {
 	s = strings.ReplaceAll(s, "\r", " ")
 	s = strings.ReplaceAll(s, "\n", " ")

--- a/internal/recovery/recovery.go
+++ b/internal/recovery/recovery.go
@@ -283,13 +283,16 @@ func (g *Generator) GenerateSQLFromRows(rows []query.ResultRow, w io.Writer) (in
 
 		gtidSuffix := ""
 		if row.GTID != nil {
-			gtidSuffix = " gtid=" + *row.GTID
+			gtidSuffix = " gtid=" + SanitizeForComment(*row.GTID)
 		}
+		// Every interpolated value is sanitized (#1120): a newline in the table
+		// name or the PK would end this comment and turn the rest of the line
+		// into executable SQL sitting inside the BEGIN/COMMIT below.
 		fmt.Fprintf(&body, "-- [%d] reverse %s on %s.%s pk=%s at %s%s\n",
 			row.EventID,
 			eventTypeName(row.EventType),
-			row.SchemaName, row.TableName,
-			row.PKValues,
+			SanitizeForComment(row.SchemaName), SanitizeForComment(row.TableName),
+			SanitizeForComment(row.PKValues),
 			row.EventTimestamp.Format("2006-01-02 15:04:05"),
 			gtidSuffix,
 		)
@@ -304,7 +307,8 @@ func (g *Generator) GenerateSQLFromRows(rows []query.ResultRow, w io.Writer) (in
 			// clean under BEGIN/COMMIT and the operator never learns an event
 			// was skipped. Same fail-loud stance as the schema-drift (#601) and
 			// script-budget (#654) refusals — refuse up front, write nothing.
-			fmt.Fprintf(&body, "-- ERROR generating reversal for event %d: %v\n", row.EventID, err)
+			fmt.Fprintf(&body, "-- ERROR generating reversal for event %d: %s\n",
+				row.EventID, SanitizeForComment(err.Error()))
 			genFailures = append(genFailures, genFailure{
 				eventID:    row.EventID,
 				schemaName: row.SchemaName,
@@ -464,7 +468,11 @@ func (g *Generator) writeAutoIncrementSection(w io.Writer, touched map[string]bo
 	fmt.Fprintln(w, "-- no-op, never data loss.")
 	for _, k := range keys {
 		schema, table, _ := strings.Cut(k, "\x00")
-		qualified := QuoteName(schema) + "." + QuoteName(table)
+		// Sanitized once here (#1120) because all three uses below are comment
+		// lines: this block's ENTIRE safety mechanism is the "--" prefix, and it
+		// sits after COMMIT, so a newline-bearing identifier would run whatever
+		// followed it as a standalone statement.
+		qualified := SanitizeForComment(QuoteName(schema) + "." + QuoteName(table))
 		fmt.Fprintln(w, "--")
 		fmt.Fprintf(w, "-- %s:\n", qualified)
 		fmt.Fprintf(w, "--   SELECT IFNULL(MAX(%s), 0) + 1 FROM %s;\n", QuoteName("<auto_increment_column>"), qualified)
@@ -1334,6 +1342,29 @@ func EscapeString(s string) string {
 // escaping any backticks in the name itself.
 func QuoteName(name string) string {
 	return "`" + strings.ReplaceAll(name, "`", "``") + "`"
+}
+
+// SanitizeForComment makes s safe to interpolate into a "--" SQL comment line
+// (#1120). A "--" comment ends at the first newline, so a value carrying one
+// closes the comment and hands whatever follows to the parser as executable SQL.
+// No existing escaper defends against this: event.EscapePKValue escapes only
+// `\` and `|`, and QuoteName only the backtick — a newline is perfectly legal inside
+// a backtick-quoted MySQL identifier, and inside a VARCHAR primary key it is
+// ordinary data.
+//
+// The substitution is LOSSY on purpose, and only the annotation loses. Comments
+// carry an identifier or PK for the operator to read; the executable statement
+// beside them renders the same value through QuoteName/EscapeString, which keep
+// every byte. Refusing outright would instead deny recovery to a table that is
+// merely oddly named. Callers therefore apply this at the point a value meets a
+// "--", never to the value itself.
+//
+// Both ReplaceAll calls return s untouched (no allocation) when it holds no
+// line break, which is every ordinary name.
+func SanitizeForComment(s string) string {
+	s = strings.ReplaceAll(s, "\r", " ")
+	s = strings.ReplaceAll(s, "\n", " ")
+	return s
 }
 
 // ─── Dialect dispatch (#533) ───────────────────────────────────────────────────

--- a/internal/recovery/recovery.go
+++ b/internal/recovery/recovery.go
@@ -483,12 +483,10 @@ func (g *Generator) writeAutoIncrementSection(w io.Writer, touched map[string]bo
 		//
 		// Unlike the header above, this block has no executable sibling carrying
 		// the exact bytes — the two commented statements ARE the deliverable, and
-		// the operator is told to uncomment and run them. A flattened identifier
-		// therefore reaches an ALTER the operator may execute; it fails loud there
-		// (ERROR 1146) instead of hitting the intended table, which is why
-		// flattening still beats leaving the injection open. MySQL has no escape
-		// for a line break inside a backtick identifier, so no rendering here is
-		// both single-line and runnable.
+		// the operator is told to uncomment and run them. For such a table the
+		// quoted rendering is not runnable as written, which is the intended
+		// outcome: it stops at a syntax error the operator must read, rather than
+		// naming a different table that might exist. See SanitizeForComment.
 		qualified := SanitizeForComment(QuoteName(schema) + "." + QuoteName(table))
 		fmt.Fprintln(w, "--")
 		fmt.Fprintf(w, "-- %s:\n", qualified)
@@ -1376,25 +1374,35 @@ func QuoteName(name string) string {
 // line break is legal inside a quoted identifier in either dialect, while inside
 // a VARCHAR primary key it is ordinary data.
 //
-// The substitution is LOSSY, and refusing outright would instead deny recovery to
-// a table that is merely oddly named. How much is lost varies BY SITE, so do not
-// read this as a blanket "only the annotation degrades" guarantee:
+// A value holding a break is rendered with strconv.Quote, which is LOSSLESS
+// (reversible via strconv.Unquote) and provably single-line — it escapes every
+// non-printable, U+2028/U+2029 included. Flattening the break to a space is the
+// obvious alternative and is worse: it makes "a\nb" and the perfectly ordinary
+// value "a b" indistinguishable, so an operator who copies a mangled PK into a
+// follow-up WHERE gets zero rows — and mid-incident, zero rows reads as "the row
+// is already gone", the opposite of the truth. The surrounding quotes are
+// themselves the signal that the rendering is escaped, so no separate marker is
+// needed. Refusing outright would instead deny recovery to a table that is merely
+// oddly named.
 //
-//   - Per-event header, cascade preamble: an executable statement rendered from
-//     the same value sits beside the comment and keeps every byte (quoteName /
-//     EscapeString are untouched by this). Only the annotation degrades.
-//   - AUTO_INCREMENT block, reconstruct's binlog-only schema placeholder: there
-//     is NO executable sibling — the commented text is itself the artifact. A
-//     flattened identifier there fails loud when applied (MySQL ERROR 1146,
-//     "table doesn't exist") rather than silently acting on the intended table.
+// A value with no break is returned unchanged, so ordinary scripts stay
+// byte-identical and every golden-output test in this package still holds;
+// TestSanitizeForComment_lineBreakForms pins that identity case.
+//
+// The quoted form is deliberately NOT valid SQL to uncomment. At the two sites
+// where the commented text is itself the artifact — the AUTO_INCREMENT block
+// below and reconstruct's binlog-only schema placeholder — that is the safer
+// failure. MySQL has no escape for a line break inside a backtick identifier, so
+// no rendering there can be both faithful and runnable, and a syntax error the
+// operator must look at beats an identifier that silently reads as a different,
+// possibly existing, table.
 //
 // Callers apply this where a value meets a "--", never to the value itself.
-// TestSanitizeForComment_lineBreakForms pins the identity case, on which every
-// golden-output test in this package depends.
 func SanitizeForComment(s string) string {
-	s = strings.ReplaceAll(s, "\r", " ")
-	s = strings.ReplaceAll(s, "\n", " ")
-	return s
+	if !strings.ContainsAny(s, "\r\n") {
+		return s
+	}
+	return strconv.Quote(s)
 }
 
 // ─── Dialect dispatch (#533) ───────────────────────────────────────────────────


### PR DESCRIPTION
closes #1120

## Summary

A `--` comment ends at the first newline, so a value carrying one closes the comment and hands whatever follows to the parser as **executable SQL**. No existing escaper defends against this: `event.EscapePKValue` escapes only `\` and `|`, `QuoteName` only the backtick — and a newline is legal inside a backtick-quoted MySQL identifier, while inside a VARCHAR primary key it is ordinary data that reaches the generator unfiltered.

This matters here specifically because `recover` never executes: the emitted text *is* the product, and an operator pastes it into a production restore under incident pressure.

Adds one shared helper, `recovery.SanitizeForComment` (`\r`/`\n` → a space), applied at **every** site that interpolates a schema, table, PK or derived string into a `--` comment:

| File | Site |
|---|---|
| `internal/recovery/recovery.go` | per-event header — **the vector that ships on `main` today** |
| `internal/recovery/recovery.go` | per-event generation-error comment |
| `internal/recovery/recovery.go` | `AUTO_INCREMENT` block (#1110) — sanitized once on `qualified`, since all three of its uses are comment lines |
| `internal/cascaderecover/emit.go` | preamble header, caveats, warnings |
| `internal/reconstruct/fulltable.go` | `binlogOnlySchemaPlaceholder` |

### Why `\r` is not decorative

MySQL ends a `--` comment at LF only, but PostgreSQL's lexer defines the comment body as `[^\n\r]*` — a **bare CR terminates it there**. The per-event header is dialect-independent and PG scripts go through it, so `\r` is a real injection path, not display hardening. Nothing else terminates a `--` in either dialect.

Worth naming the ceiling: on the PG side a surviving newline followed by `\!` or `\i` at line start is not merely SQL — those are **psql meta-commands** (shell execution, file inclusion).

## Design notes

- **Lossless, not flattening.** `SanitizeForComment` returns the value unchanged unless it actually holds a line break, and renders it with `strconv.Quote` when it does — reversible via `strconv.Unquote`, provably single-line, and self-signalling (the quotes say "escaped", so no separate marker or `slog.Warn` is needed):

  ```
  -- [42] reverse DELETE on db."or\nders" pk="1\nDROP TABLE users;" at ...
  ```

  Flattening to a space was the first cut and is worse: it makes `"a\nb"` and the perfectly ordinary value `"a b"` indistinguishable, so an operator copying a mangled PK into a follow-up `WHERE` gets zero rows — which mid-incident reads as *the row is already gone*, the opposite of the truth. Refusing outright would deny recovery to a merely oddly-named table.
- **No behavior change for ordinary input.** The helper short-circuits when the value holds no line break, so existing golden output is byte-identical — the cascade golden tests did not move.
- **Applied uniformly, including the `AUTO_INCREMENT` block.** The quoted form is not valid SQL to uncomment there, and that is intended: MySQL has no escape for a line break inside a backtick identifier, so no rendering can be both faithful and runnable, and stopping at a syntax error the operator must read beats an `ALTER` naming a different table that might exist.
- **`U+2028`/`U+2029` deliberately do not trigger it** — they terminate a `--` comment in neither lexer, so quoting them would churn legitimate data. Once a real terminator fires the helper, `Quote` escapes them too.
- **`QuoteName` and `EscapePKValue` are untouched.** They are correct for their own jobs; widening either would corrupt the executable SQL and the PK encoding respectively.
- **Cascade caveats/warnings are sanitized at the comment boundary**, not at their ~10 construction sites in `internal/cascade`. The same strings are served as JSON by `internal/console/recover_cascade.go`, where a newline is harmless, and a boundary fix cannot be bypassed by a future caveat.
- **One site is not currently reachable**: the `-- ERROR generating reversal…` comment never reaches the writer, because a non-empty `genFailures` returns `(0, err)` and discards the body buffer. Sanitized anyway as future-proofing — not claimed as a shipping vector.

## Test plan

Tests drive the real `GenerateSQLFromRows` / `EmitSQL` rather than the helper, and assert over whole **regions that are comment-only by design**, so they catch an unsanitized site the fix did not touch:

- `TestCommentInjection_PKNewlineCannotEscapeTheHeaderComment` — a newline in `PKValues` reaches the header comment *only* (the `WHERE`/`VALUES` clauses are rebuilt from the row image), so the executable statements stay byte-identical to an ordinary script and every remaining line must be a comment or one of them.
- `TestCommentInjection_TableNewlineCannotEscapeTheAutoIncrementBlock` — the entire post-`COMMIT` region must be comment lines.
- `TestEmitSQL_commentInjectionCannotEscapeThePreamble` — the entire cascade preamble before `SET FOREIGN_KEY_CHECKS=0;` must be comment lines; exercises both the header identifiers and a caveat/warning string.
- `TestBinlogOnlySchemaPlaceholder_commentInjection` — every line of the placeholder schema file must be a comment.

Verified by **per-site mutation**, not by the suite merely being green. Reverting each sanitize site one at a time, every one of the nine is now caught:

| Site reverted | Caught by |
|---|---|
| header schema/table | `…HeaderLineSurvivesLineBreaksInEveryField` |
| header `PKValues` | `…PKNewlineCannotEscapeTheHeaderComment` |
| header GTID suffix | `…HeaderLineSurvivesLineBreaksInEveryField` |
| `AUTO_INCREMENT` `qualified` | `…TableNewlineCannotEscapeTheAutoIncrementBlock` |
| cascade header, `Combined: false` and `true` | `TestEmitSQL_commentInjection…` |
| cascade caveats, warnings | `TestEmitSQL_commentInjection…` |
| reconstruct placeholder | `TestBinlogOnlySchemaPlaceholder…` |

Two gaps found and closed during review, both of which had been passing green:

- The **header's schema/table** — the ship-today vector — was uncovered. The whole-script test used a clean table name, and the `AUTO_INCREMENT` test discarded the half of the script the header lives in. It could not be fixed by widening that region: with a line break in the table name the executable `INSERT` legitimately spans two lines, so a separate header-line-specific assertion was needed.
- The whole-script test **passed vacuously** if the header stopped rendering the PK — the payload simply never appeared and the loop found nothing to reject. It now asserts the escaped value is present first.

Also newly covered: the `Combined: true` cascade branch (no test in the repo had ever set it, though the console's combined recover ships it), the GTID suffix, and `\r`/`\r\n`.

- [x] `go test ./... -count=1` — 46 packages ok, 0 failures
- [x] `go vet ./...` and `go vet -tags integration ./...` — clean
- [x] `go test -race` on the three touched packages — clean

Two claims verified by sweep rather than by reading:

- `PKValues` has **no statement-building consumer** in `internal/recovery` — only the TOAST check, the (now sanitized) comment, a `genFailure` record that feeds a returned Go error, and byte-budget accounting. That is what makes the whole-script allowlist assertion valid rather than overfit to one row shape.
- `internal/mcptools` and `internal/console` contain **zero** `--` comment literals, so every recover surface inherits this fix through the shared generator; no surface builds its own annotation line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
