### PR TITLE
event: hex-encode PK bytes that utf8mb4 cannot store

### DIFF
--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -222,10 +222,25 @@ const hexPKPrefix = "0x"
 //     (invalid bytes could never have been written), so no existing row's
 //     pk_values — and therefore no existing pk_hash — changes spelling. Only
 //     values that today stop capture get a new representation. A non-strict
-//     sql_mode index server would instead have stored a silently TRUNCATED
-//     prefix — the same pk_hash-over-a-truncated-value mechanic that
+//     sql_mode index server would instead have stored the value with its
+//     invalid bytes replaced — the same pk_hash-over-a-mangled-value mechanic
 //     checkPKValuesLength's comment documents for the LENGTH case (#944) — so
 //     those rows were already unrecoverable, not working.
+//
+// BYOS IS OUTSIDE THAT INVARIANT, and deliberately so — the same index-vs-BYOS
+// split MaxPKValuesLen's comment already draws. internal/byos and
+// internal/buffer call BuildPKValues too, but write pk_values to customer-owned
+// Parquet with no utf8mb4 column anywhere in the path, so a pure-BYOS agent
+// (cliapp/agent.go permits BYOS with no --index-dsn) has been durably
+// persisting the RAW spelling for binary PKs and never saw error 1366. For
+// those keys the spelling — and therefore byos.PKHash, the metadata↔payload
+// correlation key — changes at this boundary, so pre-fix payload Parquet stops
+// correlating with post-fix metadata. Within a single event both sides are
+// still stamped from the same value, so live correlation is unaffected; it is
+// the cross-boundary lookups (internal/agent/handler.go's resolve_pk,
+// buffer.ResolvePK) that silently miss rather than error. Tracked separately —
+// hex pk_values beats a dead daemon, and this PR's reported bug is the MySQL
+// path.
 //
 // Both halves are pinned at runtime by TestInsertBatch_binaryPrimaryKey, which
 // checks the utf8mb4 premise against information_schema and asserts the raw

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -11,6 +11,7 @@
 package event
 
 import (
+	"encoding/hex"
 	"fmt"
 	"reflect"
 	"sort"
@@ -169,6 +170,20 @@ func EscapePKValue(val string) string {
 // against a large production binlog_events table.
 const MaxPKValuesLen = 512
 
+// hexPKPrefix marks a PK component that formatPKValue hex-encoded because its
+// raw bytes are not storable in binlog_events.pk_values (#1132). "0x" is the
+// spelling MySQL itself uses for a binary literal, so the stored form is
+// reproducible from the source with SELECT CONCAT('0x', HEX(<pk_col>)) and can
+// be pasted straight into `--pk`.
+//
+// Note that hex DOUBLES the component's length against the MaxPKValuesLen
+// ceiling: a BINARY(16) UUID PK lands at 34 characters (fine), but a wide
+// VARBINARY or a wide composite binary PK can now exceed 512 and trip
+// indexer.checkPKValuesLength instead. That is the pre-existing wide-PK limit
+// (#944), not a new failure introduced here — it is just reachable by a
+// narrower set of PKs than the utf8mb4 rejection was.
+const hexPKPrefix = "0x"
+
 // formatPKValue renders a single PK value for BuildPKValues. []byte needs its
 // own case: since #756, metadata.MapRow hands back a BINARY/VARBINARY value as
 // []byte (routing it through marshalRow's base64-safe path instead of a raw Go
@@ -178,8 +193,41 @@ const MaxPKValuesLen = 512
 // raw bytes, which would silently change pk_hash/pk_values for every row with
 // such a PK. string(b) reproduces exactly what "%v" printed for that same
 // value before #756 (when it was still a raw Go string of the same bytes).
+//
+// #1132: raw bytes that are not valid UTF-8 cannot be stored at all —
+// binlog_events.pk_values is VARCHAR(512) CHARACTER SET utf8mb4, so MySQL
+// rejects the whole multi-row INSERT with error 1366 and, because a batch
+// failure is fail-loud by contract (see internal/streamrun's flush, #652),
+// ONE table with a BINARY/VARBINARY PK takes the entire stream daemon down
+// and capture stops for every table in the source. Those bytes are therefore
+// hex-encoded (hexPKPrefix + uppercase hex, i.e. exactly what MySQL's own
+// CONCAT('0x', HEX(col)) produces, so an operator can reproduce a stored
+// pk_values straight from the source table and feed it back to --pk).
+//
+// The check is on CONTENT, not on the column's declared type, and that is
+// what makes this change strictly additive for the indexed-MySQL path: a
+// pk_values already in binlog_events is necessarily valid UTF-8 (invalid
+// bytes could never have been written), so no existing row's pk_values —
+// and therefore no existing pk_hash — changes spelling. Only values that
+// today kill the daemon get a new representation. (A non-strict sql_mode
+// index server would instead have stored a silently TRUNCATED prefix, whose
+// pk_hash never matched the full value anyway — see checkPKValuesLength's
+// comment; those rows were already unrecoverable, not working.)
+//
+// Residual, accepted ambiguity, same class as coerceTextEncoding's
+// latin1-that-is-coincidentally-valid-UTF-8 case and marshalRow's
+// looksLikeJSONContainer gate: a VARBINARY PK holding the literal ASCII text
+// "0xDEAD" is valid UTF-8, so it is stored verbatim and collides with the
+// encoding of the two raw bytes {0xDE,0xAD}. Distinguishing them would need a
+// type-gated rule (always hex a BINARY/VARBINARY column), which would change
+// the spelling of PK values that store and query correctly today — a real
+// regression traded for a contrived collision. Content-gating is the narrower
+// change and is the one taken.
 func formatPKValue(v any) string {
 	if b, ok := v.([]byte); ok {
+		if !utf8.Valid(b) {
+			return hexPKPrefix + strings.ToUpper(hex.EncodeToString(b))
+		}
 		return string(b)
 	}
 	return fmt.Sprintf("%v", v)

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -194,25 +194,43 @@ const hexPKPrefix = "0x"
 // such a PK. string(b) reproduces exactly what "%v" printed for that same
 // value before #756 (when it was still a raw Go string of the same bytes).
 //
-// #1132: raw bytes that are not valid UTF-8 cannot be stored at all —
-// binlog_events.pk_values is VARCHAR(512) CHARACTER SET utf8mb4, so MySQL
-// rejects the whole multi-row INSERT with error 1366 and, because a batch
-// failure is fail-loud by contract (see internal/streamrun's flush, #652),
-// ONE table with a BINARY/VARBINARY PK takes the entire stream daemon down
-// and capture stops for every table in the source. Those bytes are therefore
-// hex-encoded (hexPKPrefix + uppercase hex, i.e. exactly what MySQL's own
-// CONCAT('0x', HEX(col)) produces, so an operator can reproduce a stored
-// pk_values straight from the source table and feed it back to --pk).
+// #1132: raw bytes that are not valid UTF-8 cannot be stored at all.
+// binlog_events.pk_values is VARCHAR(512) with NO declared CHARACTER SET
+// (internal/indexer/schema.go) — it inherits utf8mb4 from the MySQL 8.0+
+// server default, and config.Connect sets no charset DSN parameter either, so
+// the driver's utf8mb4 handshake collation applies on every index connection.
+// MySQL therefore rejects the whole multi-row INSERT with error 1366, and
+// because a batch flush failure is fail-loud by contract (internal/streamrun's
+// flush, #652) ONE table with a BINARY/VARBINARY PK stops capture for every
+// table in that source, not just the offending one: `bintrail stream` exits
+// the process outright, while under `bintrail-console watch` that source
+// crash-loops on backoff and then goes permanently failed (consoleapp/
+// monitor.go). Those bytes are therefore hex-encoded (hexPKPrefix + uppercase
+// hex, i.e. exactly what MySQL's own CONCAT('0x', HEX(col)) produces, so an
+// operator can reproduce a stored pk_values straight from the source table
+// and feed it back to --pk).
 //
-// The check is on CONTENT, not on the column's declared type, and that is
-// what makes this change strictly additive for the indexed-MySQL path: a
-// pk_values already in binlog_events is necessarily valid UTF-8 (invalid
-// bytes could never have been written), so no existing row's pk_values —
-// and therefore no existing pk_hash — changes spelling. Only values that
-// today kill the daemon get a new representation. (A non-strict sql_mode
-// index server would instead have stored a silently TRUNCATED prefix, whose
-// pk_hash never matched the full value anyway — see checkPKValuesLength's
-// comment; those rows were already unrecoverable, not working.)
+// The check is on CONTENT, not on the column's declared type. Two consequences
+// worth being explicit about:
+//
+//   - It is BROADER than BINARY/VARBINARY. go-mysql delivers TEXT/BLOB as
+//     []byte and coerceTextEncoding passes those through untouched, so a
+//     latin1 TEXT prefix PK or a BLOB prefix PK lands here too — and also
+//     stops killing capture. BINARY/VARBINARY is just the reported shape.
+//   - It is what makes the change strictly additive for the indexed-MySQL
+//     path: a pk_values already in binlog_events is necessarily valid UTF-8
+//     (invalid bytes could never have been written), so no existing row's
+//     pk_values — and therefore no existing pk_hash — changes spelling. Only
+//     values that today stop capture get a new representation. A non-strict
+//     sql_mode index server would instead have stored a silently TRUNCATED
+//     prefix — the same pk_hash-over-a-truncated-value mechanic that
+//     checkPKValuesLength's comment documents for the LENGTH case (#944) — so
+//     those rows were already unrecoverable, not working.
+//
+// Both halves are pinned at runtime by TestInsertBatch_binaryPrimaryKey, which
+// checks the utf8mb4 premise against information_schema and asserts the raw
+// form is still rejected. The charset is inherited, not declared, so it is not
+// safe to assume.
 //
 // Residual, accepted ambiguity, same class as coerceTextEncoding's
 // latin1-that-is-coincidentally-valid-UTF-8 case and marshalRow's

--- a/internal/event/event_test.go
+++ b/internal/event/event_test.go
@@ -34,9 +34,9 @@ func TestBuildPKValues(t *testing.T) {
 		// #1132: 0xB2 is a UTF-8 continuation byte, so it can never lead a
 		// sequence — these bytes are unstorable in the utf8mb4 pk_values
 		// column. Written verbatim, MySQL rejected the whole batch INSERT with
-		// error 1366 and, batch failures being fail-loud by contract, killed
-		// the stream daemon for EVERY table in the source. Hex-encoded, the row
-		// is storable.
+		// error 1366 and, batch failures being fail-loud by contract, stopped
+		// capture for EVERY table in that source. Hex-encoded, the row is
+		// storable.
 		{"binary PK bytes hex-encoded when not valid UTF-8", []metadata.ColumnMeta{{Name: "id"}},
 			map[string]any{"id": []byte{0xB2, 0x81}}, "0xB281"},
 		// A full BINARY(16) PK — the shape reported in #1132 (MD5/binary UUID).
@@ -53,6 +53,13 @@ func TestBuildPKValues(t *testing.T) {
 		// A composite PK mixing an int with unstorable bytes still joins on "|".
 		{"composite with binary component", []metadata.ColumnMeta{{Name: "a"}, {Name: "b"}},
 			map[string]any{"a": 7, "b": []byte{0xFF, 0xFE}}, "7|0xFFFE"},
+		// A []byte that IS valid UTF-8 takes the verbatim path and therefore
+		// still goes through EscapePKValue — the delimiter escaping must not
+		// be skipped just because the value arrived as bytes. (Only the hex
+		// path is escape-free, and only because hex digits contain neither
+		// character.)
+		{"valid-UTF-8 bytes still get delimiter-escaped", []metadata.ColumnMeta{{Name: "k"}},
+			map[string]any{"k": []byte(`x|y\z`)}, `x\|y\\z`},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/event/event_test.go
+++ b/internal/event/event_test.go
@@ -24,9 +24,35 @@ func TestBuildPKValues(t *testing.T) {
 		// []byte prints Go's bracketed decimal representation
 		// (e.g. "[222 173]"), not the raw bytes — BuildPKValues must special-
 		// case it so pk_values/pk_hash stay exactly what they were when the
-		// same bytes arrived as a string.
+		// same bytes arrived as a string. UNCHANGED by #1132: {0xDE,0xAD} is a
+		// well-formed 2-byte UTF-8 sequence (U+07AD), so utf8mb4 accepts it and
+		// the verbatim spelling — and therefore the pk_hash — must stay exactly
+		// as it was. This is the regression guard for "hex-encoding only ever
+		// touches values that could not be stored at all".
 		{"binary PK bytes preserved raw", []metadata.ColumnMeta{{Name: "id"}},
 			map[string]any{"id": []byte{0xDE, 0xAD}}, string([]byte{0xDE, 0xAD})},
+		// #1132: 0xB2 is a UTF-8 continuation byte, so it can never lead a
+		// sequence — these bytes are unstorable in the utf8mb4 pk_values
+		// column. Written verbatim, MySQL rejected the whole batch INSERT with
+		// error 1366 and, batch failures being fail-loud by contract, killed
+		// the stream daemon for EVERY table in the source. Hex-encoded, the row
+		// is storable.
+		{"binary PK bytes hex-encoded when not valid UTF-8", []metadata.ColumnMeta{{Name: "id"}},
+			map[string]any{"id": []byte{0xB2, 0x81}}, "0xB281"},
+		// A full BINARY(16) PK — the shape reported in #1132 (MD5/binary UUID).
+		// 0x5C is a literal backslash and 0x7C would be a pipe: hex-encoding
+		// runs BEFORE EscapePKValue, so the delimiter escaping is a no-op on a
+		// hex component. (The issue's error message shows the "\\" escape
+		// working on the raw form — the destination charset was the problem,
+		// not the escaping.)
+		{"binary(16) PK hex-encoded", []metadata.ColumnMeta{{Name: "k"}},
+			map[string]any{"k": []byte{
+				0xB2, 0x81, 0x5C, 0xC3, 0xC2, 0x00, 0xFF, 0x7C,
+				0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x80}},
+			"0xB2815CC3C200FF7C0102030405060780"},
+		// A composite PK mixing an int with unstorable bytes still joins on "|".
+		{"composite with binary component", []metadata.ColumnMeta{{Name: "a"}, {Name: "b"}},
+			map[string]any{"a": 7, "b": []byte{0xFF, 0xFE}}, "7|0xFFFE"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/indexer/binarypk_integration_test.go
+++ b/internal/indexer/binarypk_integration_test.go
@@ -1,0 +1,173 @@
+//go:build integration
+
+package indexer
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/event"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestInsertBatch_binaryPrimaryKey pins #1132: a table whose PRIMARY KEY is
+// BINARY/VARBINARY used to take the WHOLE stream daemon down. Its raw key bytes
+// were written verbatim into binlog_events.pk_values — VARCHAR(512) CHARACTER
+// SET utf8mb4 — so MySQL rejected the multi-row INSERT with error 1366
+// ("Incorrect string value"), and because a batch flush failure is fail-loud by
+// contract (internal/streamrun, #652) the process exited and capture stopped
+// for every table in the source, not just the offending one.
+//
+// The assertion has to run against a REAL utf8mb4 index: a unit test on
+// event.BuildPKValues can prove the hex spelling but never touches a charset,
+// so it cannot prove error 1366 is gone. This drives the production chain end
+// to end — go-mysql's raw bytes → metadata.MapRow (which reinterprets a
+// BINARY/VARBINARY column as []byte, #756) → event.BuildPKValues →
+// Indexer.InsertBatch → MySQL — and then reads the row back.
+func TestInsertBatch_binaryPrimaryKey(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	// The bytes from the issue's own error message. 0xB2 is a UTF-8
+	// continuation byte and can never lead a sequence, so this is exactly the
+	// unstorable shape a BINARY(16) MD5/UUID key produces in practice.
+	keyBytes := []byte{
+		0xB2, 0x81, 0x5C, 0xC3, 0xC2, 0x00, 0xFF, 0x7C,
+		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x80,
+	}
+	const wantPK = "0xB2815CC3C200FF7C0102030405060780"
+
+	// A resolver over the repro schema: BINARY(16) PK + a VARCHAR payload.
+	// Building the event through MapRow rather than hand-writing PKValues is
+	// the point — it is MapRow's #756 string→[]byte reinterpretation that
+	// feeds formatPKValue, and hand-writing the encoded string would test the
+	// literal instead of the code path that produces it.
+	tm := &metadata.TableMeta{
+		Schema: "mydb", Table: "t_pk_binary",
+		Columns: []metadata.ColumnMeta{
+			{Name: "k", DataType: "binary", ColumnType: "binary(16)", IsPK: true},
+			{Name: "val", DataType: "varchar", ColumnType: "varchar(255)", CharacterSet: "utf8mb4"},
+		},
+		PKColumns: []string{"k"},
+	}
+	res := metadata.NewResolverFromTables(1, map[string]*metadata.TableMeta{"mydb.t_pk_binary": tm})
+
+	// go-mysql delivers a BINARY column as a Go string of raw source bytes.
+	row, err := res.MapRow("mydb", "t_pk_binary", []any{string(keyBytes), "bin pk 1"})
+	if err != nil {
+		t.Fatalf("MapRow: %v", err)
+	}
+	if _, ok := row["k"].([]byte); !ok {
+		t.Fatalf("MapRow returned %T for the BINARY PK column, want []byte "+
+			"(the #756 coercion is what routes this value into formatPKValue)", row["k"])
+	}
+
+	pkValues := event.BuildPKValues(tm.PKColumnMetas(), row)
+	if pkValues != wantPK {
+		t.Fatalf("BuildPKValues = %q, want %q", pkValues, wantPK)
+	}
+
+	idx := New(db, 1000)
+	ts := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+	n, err := idx.InsertBatch([]event.Event{{
+		BinlogFile: "binlog.000001", StartPos: 100, EndPos: 200,
+		Timestamp: ts, Schema: "mydb", Table: "t_pk_binary",
+		EventType: event.EventDelete, PKValues: pkValues,
+		RowBefore: row,
+	}})
+	// Before the fix this is where the daemon died: Error 1366 on pk_values.
+	if err != nil {
+		t.Fatalf("InsertBatch with a BINARY(16) PK failed (#1132 regression): %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("InsertBatch inserted %d rows, want 1", n)
+	}
+
+	// Read back through the exact predicate every read path uses: pk_hash for
+	// the index scan AND pk_values for the collision guard (CLAUDE.md). If the
+	// stored spelling and the rebuilt one ever diverged, this returns zero rows
+	// — the silent-miss failure mode, not a loud one.
+	var got string
+	err = db.QueryRow(
+		`SELECT pk_values FROM binlog_events WHERE pk_hash = SHA2(?, 256) AND pk_values = ?`,
+		pkValues, pkValues).Scan(&got)
+	if err != nil {
+		t.Fatalf("indexed row is not findable by its own pk_values: %v", err)
+	}
+	if got != wantPK {
+		t.Errorf("stored pk_values = %q, want %q", got, wantPK)
+	}
+
+	// The stored form must be reproducible from the source table, which is the
+	// whole reason for the "0x" + uppercase-HEX spelling: an operator can run
+	// SELECT CONCAT('0x', HEX(k)) on the source and paste the result into --pk.
+	var mysqlSpelling string
+	if err := db.QueryRow(`SELECT CONCAT('0x', HEX(?))`, keyBytes).Scan(&mysqlSpelling); err != nil {
+		t.Fatalf("HEX() probe: %v", err)
+	}
+	if mysqlSpelling != wantPK {
+		t.Errorf("stored pk_values %q does not match MySQL's own CONCAT('0x', HEX(k)) = %q",
+			wantPK, mysqlSpelling)
+	}
+}
+
+// TestInsertBatch_binaryPrimaryKeyValidUTF8Unchanged is the other half of
+// #1132's contract: hex-encoding is content-gated, so a BINARY/VARBINARY PK
+// whose bytes ARE valid UTF-8 keeps the byte-identical spelling it had before
+// the fix. Those rows store and query correctly today; changing their
+// pk_values would change their generated pk_hash and orphan every row already
+// indexed under the old spelling.
+func TestInsertBatch_binaryPrimaryKeyValidUTF8Unchanged(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	// Valid UTF-8: 7-bit ASCII, plus U+07AD written as the 2-byte sequence
+	// {0xDE,0xAD} — the literal case the #756 unit test pinned.
+	keyBytes := append([]byte("id-"), 0xDE, 0xAD)
+	wantPK := string(keyBytes)
+
+	tm := &metadata.TableMeta{
+		Schema: "mydb", Table: "t_pk_varbinary",
+		Columns: []metadata.ColumnMeta{
+			{Name: "k", DataType: "varbinary", ColumnType: "varbinary(32)", IsPK: true},
+		},
+		PKColumns: []string{"k"},
+	}
+	res := metadata.NewResolverFromTables(1, map[string]*metadata.TableMeta{"mydb.t_pk_varbinary": tm})
+
+	row, err := res.MapRow("mydb", "t_pk_varbinary", []any{string(keyBytes)})
+	if err != nil {
+		t.Fatalf("MapRow: %v", err)
+	}
+	pkValues := event.BuildPKValues(tm.PKColumnMetas(), row)
+	if pkValues != wantPK {
+		t.Fatalf("BuildPKValues = %q, want the unchanged raw spelling %q "+
+			"(hex-encoding must only touch bytes utf8mb4 cannot store)", pkValues, wantPK)
+	}
+
+	idx := New(db, 1000)
+	n, err := idx.InsertBatch([]event.Event{{
+		BinlogFile: "binlog.000001", StartPos: 100, EndPos: 200,
+		Timestamp: time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC),
+		Schema:    "mydb", Table: "t_pk_varbinary",
+		EventType: event.EventInsert, PKValues: pkValues,
+		RowAfter:  row,
+	}})
+	if err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("InsertBatch inserted %d rows, want 1", n)
+	}
+
+	var got string
+	if err := db.QueryRow(
+		`SELECT pk_values FROM binlog_events WHERE pk_hash = SHA2(?, 256) AND pk_values = ?`,
+		pkValues, pkValues).Scan(&got); err != nil {
+		t.Fatalf("indexed row is not findable by its own pk_values: %v", err)
+	}
+	if got != wantPK {
+		t.Errorf("stored pk_values = %q, want %q", got, wantPK)
+	}
+}

--- a/internal/indexer/binarypk_integration_test.go
+++ b/internal/indexer/binarypk_integration_test.go
@@ -3,6 +3,7 @@
 package indexer
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -99,16 +100,59 @@ func TestInsertBatch_binaryPrimaryKey(t *testing.T) {
 		t.Errorf("stored pk_values = %q, want %q", got, wantPK)
 	}
 
-	// The stored form must be reproducible from the source table, which is the
+	// The stored form must be reproducible FROM THE SOURCE TABLE, which is the
 	// whole reason for the "0x" + uppercase-HEX spelling: an operator can run
 	// SELECT CONCAT('0x', HEX(k)) on the source and paste the result into --pk.
-	var mysqlSpelling string
-	if err := db.QueryRow(`SELECT CONCAT('0x', HEX(?))`, keyBytes).Scan(&mysqlSpelling); err != nil {
-		t.Fatalf("HEX() probe: %v", err)
+	//
+	// HEX() must be applied to a real BINARY(16) COLUMN, not to a placeholder
+	// parameter: `SELECT CONCAT('0x', HEX(?))` hexes whatever the driver
+	// transmits under whatever charset the server types the expression as,
+	// which is a different code path from the operator affordance being
+	// claimed here — it could pass for a reason unrelated to the claim.
+	testutil.MustExec(t, db, `CREATE TABLE t_pk_binary_src (k BINARY(16) NOT NULL PRIMARY KEY)`)
+	testutil.MustExec(t, db, `INSERT INTO t_pk_binary_src (k) VALUES (?)`, keyBytes)
+	var sourceSpelling string
+	if err := db.QueryRow(`SELECT CONCAT('0x', HEX(k)) FROM t_pk_binary_src`).Scan(&sourceSpelling); err != nil {
+		t.Fatalf("HEX() probe on a real BINARY(16) column: %v", err)
 	}
-	if mysqlSpelling != wantPK {
-		t.Errorf("stored pk_values %q does not match MySQL's own CONCAT('0x', HEX(k)) = %q",
-			wantPK, mysqlSpelling)
+	if sourceSpelling != wantPK {
+		t.Errorf("stored pk_values %q does not match the source table's CONCAT('0x', HEX(k)) = %q "+
+			"— an operator could not reproduce the stored key to feed it back to --pk", wantPK, sourceSpelling)
+	}
+
+	// pk_values is utf8mb4 with a case-INSENSITIVE collation, so "0xAB…" and
+	// "0xab…" compare EQUAL on that column alone. The uppercase spelling is
+	// therefore load-bearing, and the pk_hash half of the predicate is what
+	// actually disambiguates (SHA2 is byte-exact). Insert the lowercase
+	// spelling as a second row and pin that the AND-predicate still resolves
+	// to exactly the uppercase one — if a future change ever let a second
+	// producer emit lowercase hex, this is the silent wrong-row/zero-row
+	// failure it would cause.
+	lower := "0x" + strings.ToLower(wantPK[2:])
+	if _, err := idx.InsertBatch([]event.Event{{
+		BinlogFile: "binlog.000001", StartPos: 300, EndPos: 400,
+		Timestamp: ts, Schema: "mydb", Table: "t_pk_binary",
+		EventType: event.EventDelete, PKValues: lower,
+		RowBefore: map[string]any{"k": lower},
+	}}); err != nil {
+		t.Fatalf("InsertBatch of the lowercase spelling: %v", err)
+	}
+	var matched int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM binlog_events WHERE pk_values = ?`, pkValues).Scan(&matched); err != nil {
+		t.Fatalf("collation probe: %v", err)
+	}
+	if matched != 2 {
+		t.Fatalf("pk_values = ? matched %d rows, want 2 — the premise of this check is that the "+
+			"column's collation is case-insensitive; if it is not, the pk_hash guard below is untested", matched)
+	}
+	if err := db.QueryRow(
+		`SELECT pk_values FROM binlog_events WHERE pk_hash = SHA2(?, 256) AND pk_values = ?`,
+		pkValues, pkValues).Scan(&got); err != nil {
+		t.Fatalf("pk_hash failed to disambiguate two case-variant pk_values: %v", err)
+	}
+	if got != wantPK {
+		t.Errorf("AND-predicate resolved to %q, want the uppercase %q", got, wantPK)
 	}
 }
 

--- a/internal/indexer/binarypk_integration_test.go
+++ b/internal/indexer/binarypk_integration_test.go
@@ -13,12 +13,14 @@ import (
 )
 
 // TestInsertBatch_binaryPrimaryKey pins #1132: a table whose PRIMARY KEY is
-// BINARY/VARBINARY used to take the WHOLE stream daemon down. Its raw key bytes
-// were written verbatim into binlog_events.pk_values — VARCHAR(512) CHARACTER
-// SET utf8mb4 — so MySQL rejected the multi-row INSERT with error 1366
-// ("Incorrect string value"), and because a batch flush failure is fail-loud by
-// contract (internal/streamrun, #652) the process exited and capture stopped
-// for every table in the source, not just the offending one.
+// BINARY/VARBINARY used to stop capture for the WHOLE source. Its raw key bytes
+// were written verbatim into binlog_events.pk_values (VARCHAR(512), utf8mb4 by
+// server default — the DDL declares no charset), so MySQL rejected the
+// multi-row INSERT with error 1366 ("Incorrect string value"), and because a
+// batch flush failure is fail-loud by contract (internal/streamrun, #652) that
+// took down every table in the source, not just the offending one —
+// `bintrail stream` exits the process, `bintrail-console watch` crash-loops the
+// source on backoff and then marks it permanently failed.
 //
 // The assertion has to run against a REAL utf8mb4 index: a unit test on
 // event.BuildPKValues can prove the hex spelling but never touches a charset,
@@ -71,6 +73,42 @@ func TestInsertBatch_binaryPrimaryKey(t *testing.T) {
 
 	idx := New(db, 1000)
 	ts := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+
+	// ── Premise check + negative control ─────────────────────────────────────
+	// Everything below is only meaningful if pk_values actually rejects these
+	// bytes. That is NOT a declared schema fact: schema.go:119 declares
+	// `pk_values VARCHAR(512) NOT NULL` with no CHARACTER SET and no
+	// table-level DEFAULT CHARSET, and testutil.CreateTestDB issues a bare
+	// CREATE DATABASE — so the charset is inherited from the server default all
+	// the way down. On a latin1-default server this whole test would pass green
+	// having exercised no charset rejection at all, and the "hex-encoding only
+	// ever touches values that could not be stored" claim would be untested
+	// prose. Assert the premise, then assert the rejection.
+	var charset string
+	if err := db.QueryRow(`SELECT CHARACTER_SET_NAME FROM information_schema.COLUMNS
+		WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'binlog_events' AND COLUMN_NAME = 'pk_values'`).
+		Scan(&charset); err != nil {
+		t.Fatalf("reading pk_values charset: %v", err)
+	}
+	if charset != "utf8mb4" {
+		t.Fatalf("this test's premise is a utf8mb4 pk_values column, got %q — the column declares no "+
+			"CHARACTER SET, so it inherits the server default; on this server the charset rejection "+
+			"under test does not happen and nothing below is proving anything", charset)
+	}
+	// The raw form is what #1132 reported. Driving it through the SAME
+	// production insert path pins the pre-fix failure permanently instead of
+	// leaving it as a manual verification someone has to redo.
+	if _, err := idx.InsertBatch([]event.Event{{
+		BinlogFile: "binlog.000001", StartPos: 1, EndPos: 2,
+		Timestamp: ts, Schema: "mydb", Table: "t_pk_binary",
+		EventType: event.EventDelete, PKValues: string(keyBytes),
+		RowBefore: row,
+	}}); err == nil {
+		t.Fatal("InsertBatch accepted RAW (non-UTF-8) PK bytes — this is the #1132 failure the hex " +
+			"encoding exists to avoid; if the column stopped rejecting them, the encoding is now " +
+			"changing spellings for no reason")
+	}
+
 	n, err := idx.InsertBatch([]event.Event{{
 		BinlogFile: "binlog.000001", StartPos: 100, EndPos: 200,
 		Timestamp: ts, Schema: "mydb", Table: "t_pk_binary",
@@ -85,10 +123,18 @@ func TestInsertBatch_binaryPrimaryKey(t *testing.T) {
 		t.Fatalf("InsertBatch inserted %d rows, want 1", n)
 	}
 
-	// Read back through the exact predicate every read path uses: pk_hash for
-	// the index scan AND pk_values for the collision guard (CLAUDE.md). If the
-	// stored spelling and the rebuilt one ever diverged, this returns zero rows
-	// — the silent-miss failure mode, not a loud one.
+	// Read back through the predicate the single-PK live-MySQL lookup builds
+	// (internal/query/query.go:420): pk_hash for the index scan AND pk_values
+	// for the collision guard (CLAUDE.md). If the stored spelling and the
+	// rebuilt one ever diverged, this returns zero rows — the silent-miss
+	// failure mode, not a loud one.
+	//
+	// NOT every read path uses this pair: the multi-PK --pks filter builds a
+	// bare `pk_values IN (…)` with no pk_hash term (query.go:433), and the
+	// Parquet archive path likewise matches on pk_values alone
+	// (internal/parquetquery/parquetquery.go:929,937). Those two are exactly
+	// where the case-collation reasoning below would bite, since nothing
+	// disambiguates two case-variant spellings there.
 	var got string
 	err = db.QueryRow(
 		`SELECT pk_values FROM binlog_events WHERE pk_hash = SHA2(?, 256) AND pk_values = ?`,
@@ -184,6 +230,16 @@ func TestInsertBatch_binaryPrimaryKeyValidUTF8Unchanged(t *testing.T) {
 	if err != nil {
 		t.Fatalf("MapRow: %v", err)
 	}
+	// Without this the guard can go VACUOUS without failing: if MapRow's #756
+	// coercion ever stopped returning []byte, the value would take
+	// formatPKValue's fmt.Sprintf("%v", …) path, print identically, and this
+	// test would keep passing while no longer exercising the branch it guards.
+	// This test IS the regression guard for the PR's central safety claim, so
+	// it must not be able to quietly stop guarding.
+	if _, ok := row["k"].([]byte); !ok {
+		t.Fatalf("MapRow returned %T for the VARBINARY PK column, want []byte — this test no longer "+
+			"exercises formatPKValue's []byte branch and is not guarding anything", row["k"])
+	}
 	pkValues := event.BuildPKValues(tm.PKColumnMetas(), row)
 	if pkValues != wantPK {
 		t.Fatalf("BuildPKValues = %q, want the unchanged raw spelling %q "+
@@ -213,5 +269,63 @@ func TestInsertBatch_binaryPrimaryKeyValidUTF8Unchanged(t *testing.T) {
 	}
 	if got != wantPK {
 		t.Errorf("stored pk_values = %q, want %q", got, wantPK)
+	}
+}
+
+// TestInsertBatch_binaryPrimaryKeyOverLengthLimit pins the reachability change
+// #1132 introduces, which is otherwise only asserted in prose on hexPKPrefix:
+// hex DOUBLES a component's length, so a wide binary PK that used to die on
+// error 1366 now trips indexer.checkPKValuesLength instead. That is the
+// pre-existing wide-PK limit (#944) becoming reachable by a narrower set of
+// PKs — not a new failure mode — but "which guard fires" is exactly the kind
+// of claim that rots silently.
+//
+// TestInsertBatch_oversizedPKValues already covers the guard itself, with a
+// hand-built strings.Repeat("a", 513). What is unproven without this test is
+// that a HEX-EXPANDED binary PK reaches that guard and yields its actionable
+// message rather than some other failure.
+func TestInsertBatch_binaryPrimaryKeyOverLengthLimit(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	// 300 invalid-UTF-8 bytes: "0x" + 600 hex characters = 602 > 512.
+	keyBytes := make([]byte, 300)
+	for i := range keyBytes {
+		keyBytes[i] = 0xB2 // a UTF-8 continuation byte can never lead a sequence
+	}
+
+	tm := &metadata.TableMeta{
+		Schema: "mydb", Table: "t_pk_wide_binary",
+		Columns: []metadata.ColumnMeta{
+			{Name: "k", DataType: "varbinary", ColumnType: "varbinary(300)", IsPK: true},
+		},
+		PKColumns: []string{"k"},
+	}
+	res := metadata.NewResolverFromTables(1, map[string]*metadata.TableMeta{"mydb.t_pk_wide_binary": tm})
+	row, err := res.MapRow("mydb", "t_pk_wide_binary", []any{string(keyBytes)})
+	if err != nil {
+		t.Fatalf("MapRow: %v", err)
+	}
+	pkValues := event.BuildPKValues(tm.PKColumnMetas(), row)
+	if len(pkValues) != 602 {
+		t.Fatalf("hex-encoded PK is %d characters, want 602 — the doubling this test exists to "+
+			"pin did not happen", len(pkValues))
+	}
+
+	idx := New(db, 1000)
+	_, err = idx.InsertBatch([]event.Event{{
+		BinlogFile: "binlog.000001", StartPos: 100, EndPos: 200,
+		Timestamp: time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC),
+		Schema:    "mydb", Table: "t_pk_wide_binary",
+		EventType: event.EventInsert, PKValues: pkValues,
+		RowAfter:  row,
+	}})
+	if err == nil {
+		t.Fatal("InsertBatch accepted a 602-character pk_values, want the checkPKValuesLength refusal")
+	}
+	// The actionable #944 message, not a raw MySQL error: the operator needs to
+	// be told the PK is too wide, not handed error 1406.
+	if !strings.Contains(err.Error(), "exceeding the 512-character limit") {
+		t.Errorf("error did not come from checkPKValuesLength: %v", err)
 	}
 }


### PR DESCRIPTION
closes #1132

## Summary

A `BINARY`/`VARBINARY` primary key killed the whole stream daemon. `event.formatPKValue` wrote the raw key bytes verbatim into `binlog_events.pk_values` — `VARCHAR(512) CHARACTER SET utf8mb4` — so MySQL rejected the multi-row INSERT with `Error 1366`, and because a batch flush failure is fail-loud by contract (`internal/streamrun`, #652) the process exited and capture stopped for **every** table in the source.

- A `[]byte` PK component that is **not valid UTF-8** is now stored as `0x` + uppercase hex — exactly what MySQL's own `CONCAT('0x', HEX(col))` produces, so the stored form is reproducible from the source table and can be pasted straight into `--pk`.
- The gate is on **content**, not on the column's declared type. That is what makes this strictly additive for the indexed-MySQL path: a `pk_values` already in `binlog_events` is necessarily valid UTF-8 (invalid bytes could never have been written), so no existing row's `pk_values` — and therefore no existing `pk_hash` — changes spelling. Only values that today kill the daemon get a new representation.

A type-gated rule ("always hex a BINARY column") was considered and rejected: it would have rewritten the spelling of BINARY/VARBINARY PKs that store and query correctly today — a real regression traded for a contrived collision. The residual ambiguity that leaves (a `VARBINARY` PK holding the literal ASCII text `"0xDEAD"` collides with the encoding of the bytes `{0xDE,0xAD}`) is documented in the code and is the same accepted class as `coerceTextEncoding`'s latin1-that-is-coincidentally-valid-UTF-8 case and `marshalRow`'s `looksLikeJSONContainer` gate.

## Seam audit (the other two `BuildPKValues` producers — neither changes)

- `internal/cascadebaseline` — goes through `CanonicalizePKMap`, which already **rejects** binary PK types, so a binary PK never reaches `BuildPKValues` there; DuckDB also returns `string`, not `[]byte`.
- `internal/pgcapture` — pgoutput delivers **text** format, so a `bytea` arrives as `\x…` ASCII (always valid UTF-8). `bintrail-pg` does not have this bug and is untouched.

## Deliberately not done

- **Issue suggestion 3** (per-event fallback / skip poison rows on a failed batch): `streamLoop`'s fail-loud contract *is* the fix for #652, where swallowing a flush error silently dropped events. Reintroducing skip-on-error reopens a closed data-loss bug.
- **Migrating the column to `VARBINARY(512)`**: a full table rebuild triggered silently at startup — the same thing #944 rejected for widening.
- **Issue suggestion 2** (a `doctor`/`snapshot` preflight for unsupported PK types): out of scope here. After this fix those tables capture fine; what remains is that baseline-anchored `verify`/`reconstruct` still don't support them, which `verify` already reports. Worth its own issue if wanted.

## Known residual

**BYOS spelling divergence — tracked as #1137.** The "strictly additive" claim above is scoped to the **indexed-MySQL** path on purpose. `internal/byos` and `internal/buffer` call the same `BuildPKValues`, and customer-owned Parquet has no utf8mb4 gate — so a BYOS deployment has been storing raw binary `pk_values` successfully, and newly-written files now diverge in spelling from older ones. Within a single event this is harmless: `byos.PKHash` correlates `MetadataRecord` to `PayloadRecord` and both are stamped from the same value. A cross-time lookup of the same row's PK across the boundary will not match. (`MaxPKValuesLen`'s comment already draws this same index-vs-BYOS distinction.) Confirmed empirically during review: `buffer.WriteParquet` with raw non-UTF-8 `pk_values` succeeds and writes a file, and `cliapp/agent.go:166` permits BYOS with no `--index-dsn`, so this path genuinely never hit error 1366. Scoped explicitly in `formatPKValue`'s doc comment.

**New `--pk` spelling is undocumented — tracked as #1138.** `0x` + uppercase hex is user-facing and `docs/query-and-recovery.md` does not mention it.

**Wide binary PKs.** Hex doubles a component's length against `MaxPKValuesLen`. A `BINARY(16)` UUID/MD5 PK — the reported shape — lands at 34 chars and is fine, but a wide `VARBINARY` or a wide composite binary PK can now exceed 512 and trip `indexer.checkPKValuesLength` instead. That is the pre-existing wide-PK limit (#944) becoming reachable by a narrower set of PKs, not a new failure mode. Documented on `hexPKPrefix`.

## Review round (3 agents, 1 round)

Findings applied:

- **The PR's own central safety claim was the only premise carried in prose.** Every other premise in the integration test got a runtime check; the utf8mb4 one did not. `pk_values` declares no `CHARACTER SET` (`schema.go:119`) and `testutil.CreateTestDB` issues a bare `CREATE DATABASE`, so on a latin1-default server the whole test passed green having exercised no charset rejection. Now asserted against `information_schema`, plus a **negative control** that drives the raw bytes through the same `InsertBatch` path and asserts they are still rejected — converting a manual verification into a permanent guard.
- **The unchanged-spelling guard could go vacuous without failing** — added the `[]byte` type assertion its sibling already had. If `MapRow`'s #756 coercion ever stopped returning `[]byte`, the value would take the `fmt.Sprintf` path, print identically, and the test would keep passing while guarding nothing.
- **New test for the reachability change**: a hex-expanded wide binary PK reaches `checkPKValuesLength` and yields its actionable #944 message — previously asserted only in a comment.
- **Four factual errors in my own comments, all verified against the cited code**: (1) "takes the entire stream daemon down" is wrong under `bintrail-console watch`, where `monitor.go` supervises with crash-loop backoff and the process survives — capture stopping for the whole *source* is what is accurate on both paths; (2) `CHARACTER SET utf8mb4` is inherited, not declared; (3) "the exact predicate every read path uses" is wrong — `--pks` (`query.go:433`) and the Parquet path match on `pk_values` with no `pk_hash` term; (4) the `checkPKValuesLength` cross-reference documents the *length* case, not charset.
- **The content gate is broader than the title suggests**: `TEXT`/`BLOB` arrive as `[]byte` too, so a latin1 `TEXT` prefix PK or a `BLOB` prefix PK also stops killing capture. Documented.

Cleared on review, for the record: no other call site compares a rebuilt `pk_values` against a stored one where a `[]byte` could reach `formatPKValue` (the only two — `reconstruct/fulltable.go:1032` and `cascadebaseline/provider.go:130` — sit behind `canonicalizePKMap`, which hard-errors on binary PK types); nothing decodes `pk_values` back into bytes; and the `utf8.Valid` gate matches utf8mb4's rejection set in both directions (probed against the live server with embedded NUL, 4-byte emoji, U+FFFF, U+10FFFF, C1 and ASCII controls — all round-trip byte-exact).

## Test plan

- [x] Unit tests pass (`go test ./... -count=1`)
- [x] `-race` on `internal/{event,indexer,parser,metadata}`
- [x] Integration on `internal/{indexer,parser,streamrun,shim}` against MySQL 8.0
- [x] New integration test drives the **real** production chain — go-mysql raw bytes → `metadata.MapRow` (#756 `[]byte` coercion) → `event.BuildPKValues` → `Indexer.InsertBatch` → real utf8mb4 MySQL → read back via the `pk_hash = SHA2(?)` **AND** `pk_values = ?` predicate. A unit test can pin the hex spelling but never touches a charset, so it could not prove 1366 is gone.
- [x] The `HEX()` reproducibility probe runs against a **real `BINARY(16)` column**, not a placeholder parameter (a parameterized `HEX(?)` hexes whatever the driver transmits under whatever charset the server types the expression as — it could pass for an unrelated reason).
- [x] Pins the case hazard as a measured fact: `pk_values` is utf8mb4 **case-insensitive**, so `0xAB…` and `0xab…` compare equal on that column alone (the test asserts both spellings match); the uppercase spelling is load-bearing and byte-exact `pk_hash` is what resolves the AND-predicate to the right row.
- [x] **Verified the new test fails without the fix** (reverting `formatPKValue` reproduces the issue's exact raw-byte string).
- [x] Companion integration test pins that a BINARY PK whose bytes *are* valid UTF-8 keeps its byte-identical pre-fix spelling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

