### PR TITLE
indexer: floor sub-second event times into event_timestamp instead of rounding

### DIFF
--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -218,7 +218,17 @@ func (idx *Indexer) insertBatch(batch []event.Event) (int64, error) {
 			ev.BinlogFile,
 			ev.StartPos,
 			ev.EndPos,
-			ev.Timestamp,
+			// FLOOR, never round, into event_timestamp's DATETIME(0) (#1025).
+			// MySQL's default sql_mode ROUNDS a bound sub-second fraction, so an
+			// event committed at …06.885 would be stored as …07 — up to a second
+			// AHEAD of its true time, and `AS OF 'now'` (fractional) would then
+			// evaluate `07 <= …06.885` as false and omit a row that already
+			// exists. Truncating here keeps the invariant every
+			// `event_timestamp <= X` comparison in the query path assumes:
+			// stored <= true event time < stored + 1s. No-op for MySQL/MariaDB
+			// sources (binlog event headers are whole seconds already); it is
+			// the Postgres capturer's microsecond commit time that this bites.
+			ev.Timestamp.Truncate(time.Second),
 			nullOrString(ev.GTID),
 			nullOrUint32(ev.ConnectionID),
 			ev.Schema,

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -218,15 +218,22 @@ func (idx *Indexer) insertBatch(batch []event.Event) (int64, error) {
 			ev.BinlogFile,
 			ev.StartPos,
 			ev.EndPos,
-			// FLOOR, never round, into event_timestamp's DATETIME(0) (#1025).
-			// MySQL's default sql_mode ROUNDS a bound sub-second fraction, so an
-			// event committed at …06.885 would be stored as …07 — up to a second
-			// AHEAD of its true time, and `AS OF 'now'` (fractional) would then
-			// evaluate `07 <= …06.885` as false and omit a row that already
-			// exists. Truncating here keeps the invariant every
-			// `event_timestamp <= X` comparison in the query path assumes:
-			// stored <= true event time < stored + 1s. No-op for MySQL/MariaDB
-			// sources (binlog event headers are whole seconds already); it is
+			// FLOOR into event_timestamp's DATETIME(0) — never let MySQL round
+			// (#1025). The default sql_mode rounds a bound sub-second fraction to
+			// the NEAREST second, so an event committed at …06.885 was stored as
+			// …07 (up to 0.5s AHEAD of its true time, approached as the fraction
+			// nears .500) and `AS OF 'now'` (fractional) then evaluated
+			// `07 <= …06.885` as false, omitting a row that already existed.
+			// Flooring gives stored <= true event time < stored + 1s. The cost is
+			// the mirror image, bounded by that same second: the event now also
+			// answers `event_timestamp <= …06.500`, and a `Since` of …06.885 no
+			// longer sees it. Rounding already did exactly that to every fraction
+			// below .500 — flooring makes the skew uniform instead of half-and-half,
+			// and the Since/Until bounds the query path actually receives (baseline
+			// anchors, the keyset cursor, shim literals) are second-granular.
+			// Correct ONLY while the column is DATETIME(0) (see schema.go):
+			// widening it makes this line silent data loss. No-op for MySQL and
+			// MariaDB, whose parsers build Timestamp from time.Unix(sec, 0); it is
 			// the Postgres capturer's microsecond commit time that this bites.
 			ev.Timestamp.Truncate(time.Second),
 			nullOrString(ev.GTID),

--- a/internal/indexer/indexer_integration_test.go
+++ b/internal/indexer/indexer_integration_test.go
@@ -236,12 +236,10 @@ func TestInsertBatch_maxBatchSize(t *testing.T) {
 }
 
 // TestInsertBatch_subSecondTimestampFloors pins #1025: a sub-second event time
-// must FLOOR into event_timestamp's DATETIME(0), not round. MySQL's default
-// sql_mode rounds .900 up to the next second, which would store the event ~0.1s
-// AHEAD of when it happened — and `AS OF 'now'` (a fractional time.Now()) would
-// then evaluate `event_timestamp <= now` as false and omit a row that already
-// exists. The .900 fraction is load-bearing: with a fraction below .500 MySQL
-// already truncates and the test would pass with or without the fix.
+// must FLOOR into event_timestamp's DATETIME(0), not round — see the bind site
+// in insertBatch for why. The .900 fraction is load-bearing: MySQL rounds to the
+// NEAREST second, so any fraction below .500 rounds DOWN, landing on the same
+// value the fix produces, and the test would pass with or without it.
 func TestInsertBatch_subSecondTimestampFloors(t *testing.T) {
 	db, _ := testutil.CreateTestDB(t)
 	testutil.InitIndexTables(t, db)

--- a/internal/indexer/indexer_integration_test.go
+++ b/internal/indexer/indexer_integration_test.go
@@ -234,3 +234,50 @@ func TestInsertBatch_maxBatchSize(t *testing.T) {
 		t.Errorf("expected %d rows inserted, got %d", MaxBatchSize, count)
 	}
 }
+
+// TestInsertBatch_subSecondTimestampFloors pins #1025: a sub-second event time
+// must FLOOR into event_timestamp's DATETIME(0), not round. MySQL's default
+// sql_mode rounds .900 up to the next second, which would store the event ~0.1s
+// AHEAD of when it happened — and `AS OF 'now'` (a fractional time.Now()) would
+// then evaluate `event_timestamp <= now` as false and omit a row that already
+// exists. The .900 fraction is load-bearing: with a fraction below .500 MySQL
+// already truncates and the test would pass with or without the fix.
+func TestInsertBatch_subSecondTimestampFloors(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	idx := New(db, 1000)
+	commit := time.Date(2026, 2, 19, 12, 0, 6, 900_000_000, time.UTC)
+	batch := []parser.Event{
+		{
+			BinlogFile: "binlog.000001", StartPos: 100, EndPos: 200,
+			Timestamp: commit, Schema: "mydb", Table: "orders",
+			EventType: parser.EventInsert, PKValues: "1",
+			RowAfter: map[string]any{"id": float64(1)},
+		},
+	}
+
+	if _, err := idx.InsertBatch(batch); err != nil {
+		t.Fatalf("InsertBatch failed: %v", err)
+	}
+
+	var stored time.Time
+	if err := db.QueryRow("SELECT event_timestamp FROM binlog_events").Scan(&stored); err != nil {
+		t.Fatalf("query event_timestamp failed: %v", err)
+	}
+	want := commit.Truncate(time.Second)
+	if !stored.Equal(want) {
+		t.Errorf("event_timestamp = %s, want %s (floored, not rounded)", stored.Format(time.RFC3339Nano), want.Format(time.RFC3339Nano))
+	}
+
+	// The symptom itself: the `event_timestamp <= at` predicate every AS OF
+	// path uses must find the row at its own commit instant.
+	var n int
+	if err := db.QueryRow("SELECT COUNT(*) FROM binlog_events WHERE event_timestamp <= ?", commit).Scan(&n); err != nil {
+		t.Fatalf("query with AS OF upper bound failed: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("row committed at %s is invisible to `event_timestamp <= %s`: got %d rows, want 1",
+			commit.Format(time.RFC3339Nano), commit.Format(time.RFC3339Nano), n)
+	}
+}

--- a/internal/pgshim/pgwire_pg_integration_test.go
+++ b/internal/pgshim/pgwire_pg_integration_test.go
@@ -117,20 +117,22 @@ func TestPGWire_PostgresSourceRoundTrip(t *testing.T) {
 	qctx, qcancel := context.WithTimeout(ctx, 10*time.Second)
 	defer qcancel()
 
-	// Anchor AS OF to the row's OWN stored event_timestamp, NOT 'now'. The index
-	// persists event_timestamp as DATETIME(0), so MySQL ROUNDS a row event's
-	// sub-second commit time to the nearest second (e.g. …06.885 → …07) — the
-	// stored value can sit up to a second AHEAD of the true commit instant. The
-	// reconstruct bounds the window at `event_timestamp <= AsOf`, so `AS OF 'now'`
-	// (time.Now(), fractional) excludes the just-committed row for the sub-second
-	// window before the wall clock crosses that rounded second — a timing flake on
-	// this immediate write-then-read (reproduces ~75% of the time on a fast host,
-	// as "pgwire query returned no row"). A far-future AS OF would dodge that but
-	// trips gap-detection (an AS OF past the retained history is rejected). Using
-	// the stored timestamp itself is inside coverage AND >= the event by
-	// construction, so it includes the row deterministically while exercising the
-	// identical capture → index → pgwire → reconstruct path. (Whether `AS OF 'now'`
-	// should exclude a row that exists "now" is a separate product question, #1025.)
+	// Anchor AS OF to the row's OWN stored event_timestamp, NOT 'now'. This began
+	// as a workaround for #1025: event_timestamp is DATETIME(0) and MySQL used to
+	// ROUND a row event's sub-second commit time UP (…06.885 → …07), so the stored
+	// value could sit up to a second AHEAD of the true commit instant. Reconstruct
+	// bounds the window at `event_timestamp <= AsOf`, so `AS OF 'now'` (time.Now(),
+	// fractional) excluded the just-committed row until the wall clock crossed that
+	// rounded second — a ~75% flake on a fast host, as "pgwire query returned no
+	// row". #1025 fixed that at the WRITE side: the indexer now floors instead of
+	// letting MySQL round (indexer.insertBatch, guarded by
+	// TestInsertBatch_subSecondTimestampFloors), so stored <= true commit time and
+	// that exclusion can no longer happen. The anchor stays because it is
+	// deterministic irrespective of capture timing: the stored timestamp is inside
+	// coverage AND >= the event by construction, and it exercises the identical
+	// capture → index → pgwire → reconstruct path. (A far-future AS OF would also
+	// have dodged the original flake, but trips gap-detection — an AS OF past the
+	// retained history is rejected.)
 	var asOf string
 	if err := indexDB.QueryRow("SELECT MAX(event_timestamp) FROM binlog_events WHERE table_name = ?", tbl).Scan(&asOf); err != nil {
 		t.Fatalf("read latest event_timestamp: %v", err)


### PR DESCRIPTION
closes #1025

## Summary

`AS OF 'now'` could exclude a row committed a fraction of a second earlier. `binlog_events.event_timestamp` is `DATETIME(0)` and MySQL's default `sql_mode` **rounds** a bound sub-second fraction, so an event committed at `…06.885` was stored as `…07` — up to a second *ahead* of its true time. `AS OF 'now'` (fractional `time.Now()`) then evaluated `07 <= …06.885` as false and omitted a row that already existed.

One-line fix at the single bind site in `insertBatch`: truncate to the second. This restores the invariant every `event_timestamp <= X` comparison in the query path already assumes but which was false: `stored <= true event time < stored + 1s`.

## Why fix (1) and not (2)

The issue asked for the (1)-vs-(2) evaluation. The discriminator is that **the bug only exists for one source family**: `internal/parser/stream.go` builds MySQL/MariaDB event times from `time.Unix(int64(hdr.Timestamp), 0)` — binlog event headers carry whole seconds, so those sources are already exact and the truncation is a no-op for them. Only `internal/pgcapture/decoder.go` (`m.CommitTime`, microseconds) carries a fraction.

Ceiling the `AS OF` upper bound at read time (candidate 2) would make `AS OF '…06.5'` include events stored at `07` — and for a MySQL source those events genuinely happened *at* second 07, i.e. half a second in the future. It would introduce a false inclusion on the source family that has no bug today, to fix one that only exists on Postgres capture. Candidate (3) untouched (wider blast radius via `_diff`, as the issue notes).

`sql_mode=TIME_TRUNCATE_FRACTIONAL` would do the same server-side, but it is MySQL-8.0-only, absent on MariaDB, and session-global. `Truncate(time.Second)` in Go is portable and testable.

## Deliberately not changed

- **`internal/buffer/buffer.go`** keeps full precision. Buffer filtering happens in Go at full precision, so a buffered event at `…06.885` is *correctly* excluded at `AS OF …06.5`; truncating there would make it less accurate. Please don't "fix" it later.
- **`InsertSchemaChange`'s `detected_at`** — not read by any `AS OF` comparison; out of scope.
- **No read-side change**, so rows already written under round-up are not repaired. The issue anticipates this.
- **No doc changes**: the existing one-second-granularity notes in `internal/reconstruct/boundary.go`, `docs/query-and-recovery.md` and `docs/time-travel-sql.md` remain accurate — nothing they claim became false. `TrimPartialTailTransaction`'s `at.Truncate(time.Second).Add(time.Second)` is already second-granularity arithmetic with no round-half-up assumption, so it is unaffected.

## Test plan

- [x] `TestInsertBatch_subSecondTimestampFloors` drives the real `InsertBatch` → MySQL path (the rounding happens in the driver→server coercion, so a helper unit test would prove nothing). The `.900` fraction is load-bearing — below `.500` MySQL already truncates and the test would pass either way.
- [x] **Verified the test fails without the fix**: `event_timestamp = …07, want …06` and, reproducing the reported symptom directly, `row committed at …06.9 is invisible to \`event_timestamp <= …06.9\`: got 0 rows, want 1`.
- [x] `go test ./... -count=1` — pass
- [x] `go vet -tags integration ./...` — clean
- [x] `go test -tags integration ./internal/indexer/ ./internal/query/ ./internal/reconstruct/ ./internal/shim/ -count=1` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)