### PR TITLE
stream: auto-discover GTID mode on first run against a gtid_mode=ON source

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -351,7 +351,7 @@ bintrail baseline --input /path/to/mydumper-output --output /tmp/baselines \
 
 **Situation:** continuous real-time indexing from a managed service with no binlog file access.
 
-Grant `REPLICATION SLAVE, REPLICATION CLIENT` (plus `SELECT` for schema snapshots) on the source — see [the source user](quickstart.md#prerequisites) — then start streaming. `bintrail up` (or `stream`) auto-discovers the current binlog position on first run and resumes from its checkpoint afterward:
+Grant `REPLICATION SLAVE, REPLICATION CLIENT` (plus `SELECT` for schema snapshots) on the source — see [the source user](quickstart.md#prerequisites) — then start streaming. `bintrail up` (or `stream`) auto-discovers the start point on first run — GTID mode when the source reports `gtid_mode=ON` (so live-source `verify` works out of the box), the current binlog position otherwise — and resumes from its checkpoint afterward:
 
 ```sh
 bintrail up \

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -71,6 +71,8 @@ When MySQL runs as primary in a replication setup, replicas connect using the `C
 - **Position mode** (`--start-file`, `--start-pos`): The traditional approach — a filename and byte offset. Simple but tied to a specific server instance.
 - **GTID mode** (`--start-gtid`): Each transaction gets a globally unique ID (`server-uuid:sequence-number`). MySQL tracks which GTIDs have been executed and resumes from the right point even after a failover. Use GTID mode on any setup where GTID replication is enabled (which is most managed MySQL services).
 
+**First-run auto-discovery**: with no `--start-file`/`--start-gtid` and no saved checkpoint, `bintrail stream` (and `bintrail up` / `bintrail-console watch`, which take no start flags) discovers the start point from the source. On a MySQL source with `gtid_mode=ON` it reads `@@GLOBAL.gtid_executed` and starts in **GTID mode** — which is what makes live-source `bintrail verify --source-dsn` work without any flags. Otherwise it falls back to the current binlog file/position and starts in position mode: when GTIDs are off, when the executed set is empty (a fresh server with zero transactions — starting from an empty set would replay the binlog from the beginning instead of from now), or on a MariaDB source (MariaDB keeps position-only auto-discovery; pass `--start-gtid` explicitly for MariaDB GTID mode).
+
 ---
 
 ## Checkpointing and `stream_state`
@@ -116,7 +118,7 @@ bintrail stream \
 
 `--reset` discards the saved checkpoint in `stream_state` and replaces it once the new start position is resolved, forcing the command to use the `--start-file`/`--start-gtid` flags from the command line. Without `--reset`, the saved checkpoint always takes precedence.
 
-**`--reset` skips history permanently.** Every event between the discarded checkpoint and the new start position is never indexed. A reset that lands anywhere other than the discarded checkpoint's exact coordinates — including an *earlier* position (direction is not inferred) — is durably recorded as a continuity loss (`gap_lost_at` / `gap_lost_detail` in `stream_state`): `bintrail status` shows the `EVENTS PERMANENTLY LOST` banner and `status --fail-on-gap` exits non-zero, exactly as after an unfillable-gap auto-advance. Such a reset also replaces the detail text of any earlier, still-unacknowledged loss record. A reset that lands on the same coordinates it discarded records nothing and leaves any prior loss record untouched — note the check is coordinates-only: after a source rebuild (`RESET MASTER` + restore) the same coordinates can name a different history.
+**`--reset` skips history permanently.** Every event between the discarded checkpoint and the new start position is never indexed. A reset that lands anywhere other than the discarded checkpoint's exact coordinates — including an *earlier* position (direction is not inferred) — is durably recorded as a continuity loss (`gap_lost_at` / `gap_lost_detail` in `stream_state`): `bintrail status` shows the `EVENTS PERMANENTLY LOST` banner and `status --fail-on-gap` exits non-zero, exactly as after an unfillable-gap auto-advance. Such a reset also replaces the detail text of any earlier, still-unacknowledged loss record. A reset that lands on the same coordinates it discarded records nothing and leaves any prior loss record untouched — note the check is coordinates-only: after a source rebuild (`RESET MASTER` + restore) the same coordinates can name a different history. One cross-mode refinement: a reset that discards a **position**-mode checkpoint and restarts in **auto-discovered GTID mode** (the source has `gtid_mode=ON` and no start flags were given) compares the discarded checkpoint against the source's *current* binlog coordinates — equal means nothing was skipped and no loss is recorded; unequal, or the source unreadable, records the loss conservatively.
 
 **When to use `--reset`:**
 - Switching from position mode to GTID mode (or vice versa)
@@ -169,7 +171,9 @@ pre-advance coordinates would destroy already-captured rows below the purge floo
 If any events in the advanced-over window had already been indexed before the
 crash, MySQL may re-send some of them and they will be inserted a second time
 under new `event_id`s. Recovery SQL generated across such a window can therefore
-replay the same row change twice.
+replay the same row change twice. Because fresh streams on a `gtid_mode=ON`
+source now select GTID mode automatically, this window applies to default
+(no-flags) deployments too — not only to operators who passed `--start-gtid`.
 
 **Why it is not closed.** The dedup deletes everything at or beyond the position
 the stream will actually replay from. After an auto-advance, that new start

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"strconv"
 	"strings"
@@ -110,11 +111,23 @@ func scanBinlogStatus(db *sql.DB, stmt string) (file string, pos uint32, err err
 //
 // MySQL formats gtid_executed with '\n' between UUID blocks; all whitespace
 // is stripped so the value is usable as a replication start set as-is.
-// The query targets MySQL system variables; MariaDB sources must not call it
-// (streamrun gates the call on the mysql flavor).
+//
+// A server without the gtid_mode variable at all — Error 1193
+// ER_UNKNOWN_SYSTEM_VARIABLE, which is what MariaDB returns — also yields
+// ("", nil): such a server structurally cannot supply a MySQL GTID set, so
+// falling back to position discovery is correct. This matters because a
+// MariaDB source can reach this call under the DEFAULT mysql flavor
+// (streamrun gates on the configured flavor, and e.g. `bintrail-console
+// watch` exposes no --source-flavor for its main source); a hard failure
+// here would crash-loop that daemon at startup. Genuine connection/query
+// failures remain errors — the caller treats them as fatal by design.
 func CurrentGTIDExecuted(db *sql.DB) (string, error) {
 	var gtidMode string
 	if err := db.QueryRow("SELECT @@GLOBAL.gtid_mode").Scan(&gtidMode); err != nil {
+		var mysqlErr *mysql.MySQLError
+		if errors.As(err, &mysqlErr) && mysqlErr.Number == 1193 { // ER_UNKNOWN_SYSTEM_VARIABLE
+			return "", nil
+		}
 		return "", fmt.Errorf("SELECT @@GLOBAL.gtid_mode: %w", err)
 	}
 	if !strings.EqualFold(gtidMode, "ON") {
@@ -126,7 +139,15 @@ func CurrentGTIDExecuted(db *sql.DB) (string, error) {
 	}
 	// strings.Fields splits on any whitespace (spaces, '\n', tabs); joining
 	// with "" removes it all.
-	return strings.Join(strings.Fields(executed), ""), nil
+	set := strings.Join(strings.Fields(executed), "")
+	if set == "" {
+		// The "" return sends the caller down position-mode discovery; on a
+		// GTID-enabled source that has a user-visible consequence worth naming.
+		slog.Warn("source is gtid_mode=ON but @@GLOBAL.gtid_executed is empty; " +
+			"starting in position mode — live-source verify will stay inconclusive " +
+			"until the stream is restarted with --start-gtid")
+	}
+	return set, nil
 }
 
 // defaultTimeout is the TCP connect timeout applied when the DSN does not

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -91,6 +91,44 @@ func scanBinlogStatus(db *sql.DB, stmt string) (file string, pos uint32, err err
 	return file, pos, nil
 }
 
+// CurrentGTIDExecuted returns the source server's executed GTID set
+// (@@GLOBAL.gtid_executed) when GTID mode is fully enabled, for first-run
+// start-position auto-discovery (the GTID sibling of CurrentBinlogPosition).
+//
+// It returns "" (no error) in two cases the caller must fall back to
+// position-based discovery for:
+//
+//   - @@GLOBAL.gtid_mode is anything other than "ON" (OFF, OFF_PERMISSIVE,
+//     ON_PERMISSIVE): the executed set is absent or may not cover every
+//     transaction, so it cannot anchor GTID replication. Note gtid_executed
+//     can be non-empty even with gtid_mode=OFF (a server that once ran with
+//     GTIDs on), which is why gtid_mode gates the read.
+//   - the executed set is empty (fresh server, zero transactions): starting
+//     GTID replication from an empty set replays the binlog from the very
+//     beginning, which is NOT the "start from now" contract of first-run
+//     auto-discovery.
+//
+// MySQL formats gtid_executed with '\n' between UUID blocks; all whitespace
+// is stripped so the value is usable as a replication start set as-is.
+// The query targets MySQL system variables; MariaDB sources must not call it
+// (streamrun gates the call on the mysql flavor).
+func CurrentGTIDExecuted(db *sql.DB) (string, error) {
+	var gtidMode string
+	if err := db.QueryRow("SELECT @@GLOBAL.gtid_mode").Scan(&gtidMode); err != nil {
+		return "", fmt.Errorf("SELECT @@GLOBAL.gtid_mode: %w", err)
+	}
+	if !strings.EqualFold(gtidMode, "ON") {
+		return "", nil
+	}
+	var executed string
+	if err := db.QueryRow("SELECT @@GLOBAL.gtid_executed").Scan(&executed); err != nil {
+		return "", fmt.Errorf("SELECT @@GLOBAL.gtid_executed: %w", err)
+	}
+	// strings.Fields splits on any whitespace (spaces, '\n', tabs); joining
+	// with "" removes it all.
+	return strings.Join(strings.Fields(executed), ""), nil
+}
+
 // defaultTimeout is the TCP connect timeout applied when the DSN does not
 // specify one. Prevents indefinite hangs when MySQL is unreachable.
 const defaultTimeout = 10 * time.Second

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -455,3 +455,109 @@ func TestParseSourceDSN_portOutOfRange(t *testing.T) {
 		t.Errorf("expected 'port' in error message, got: %v", err)
 	}
 }
+
+// ─── CurrentGTIDExecuted ────────────────────────────────────────────────────
+
+// TestCurrentGTIDExecuted_onStripsWhitespace verifies the happy path:
+// gtid_mode=ON returns @@GLOBAL.gtid_executed with ALL whitespace stripped —
+// MySQL formats the variable with '\n' between UUID blocks, and the value
+// must be usable as a replication start set as-is.
+func TestCurrentGTIDExecuted_onStripsWhitespace(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery(`SELECT @@GLOBAL.gtid_mode`).WillReturnRows(
+		sqlmock.NewRows([]string{"@@GLOBAL.gtid_mode"}).AddRow("ON"))
+	mock.ExpectQuery(`SELECT @@GLOBAL.gtid_executed`).WillReturnRows(
+		sqlmock.NewRows([]string{"@@GLOBAL.gtid_executed"}).
+			AddRow("3e11fa47-71ca-11e1-9e33-c80aa9429562:1-77,\n8f9e146f-0000-1111-2222-333344445555:1-5"))
+
+	got, err := CurrentGTIDExecuted(db)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-77,8f9e146f-0000-1111-2222-333344445555:1-5"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// TestCurrentGTIDExecuted_gtidModeNotOn verifies every non-ON gtid_mode
+// (OFF, OFF_PERMISSIVE, ON_PERMISSIVE) returns "" with NO error and never
+// queries gtid_executed. gtid_executed can be non-empty even with
+// gtid_mode=OFF (a server that once ran with GTIDs on), so gating on
+// gtid_mode — not on the set being non-empty — is load-bearing.
+func TestCurrentGTIDExecuted_gtidModeNotOn(t *testing.T) {
+	for _, modeVal := range []string{"OFF", "OFF_PERMISSIVE", "ON_PERMISSIVE"} {
+		t.Run(modeVal, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("sqlmock: %v", err)
+			}
+			defer db.Close()
+
+			mock.ExpectQuery(`SELECT @@GLOBAL.gtid_mode`).WillReturnRows(
+				sqlmock.NewRows([]string{"@@GLOBAL.gtid_mode"}).AddRow(modeVal))
+
+			got, err := CurrentGTIDExecuted(db)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != "" {
+				t.Errorf("got %q, want empty for gtid_mode=%s", got, modeVal)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("gtid_executed must not be queried when gtid_mode is not ON: %v", err)
+			}
+		})
+	}
+}
+
+// TestCurrentGTIDExecuted_emptyExecutedSet verifies a fresh server
+// (gtid_mode=ON, zero transactions) returns "" with no error, so the caller
+// falls back to position discovery instead of replaying the binlog from the
+// beginning.
+func TestCurrentGTIDExecuted_emptyExecutedSet(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery(`SELECT @@GLOBAL.gtid_mode`).WillReturnRows(
+		sqlmock.NewRows([]string{"@@GLOBAL.gtid_mode"}).AddRow("ON"))
+	mock.ExpectQuery(`SELECT @@GLOBAL.gtid_executed`).WillReturnRows(
+		sqlmock.NewRows([]string{"@@GLOBAL.gtid_executed"}).AddRow(""))
+
+	got, err := CurrentGTIDExecuted(db)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "" {
+		t.Errorf("got %q, want empty for an empty executed set", got)
+	}
+}
+
+// TestCurrentGTIDExecuted_queryErrorPropagates verifies a query failure is a
+// real error (the streamrun caller treats it as fatal — it must not silently
+// degrade a GTID source to position mode).
+func TestCurrentGTIDExecuted_queryErrorPropagates(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery(`SELECT @@GLOBAL.gtid_mode`).WillReturnError(
+		errors.New("connection reset"))
+
+	if _, err := CurrentGTIDExecuted(db); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -544,6 +544,35 @@ func TestCurrentGTIDExecuted_emptyExecutedSet(t *testing.T) {
 	}
 }
 
+// TestCurrentGTIDExecuted_unknownVariableIsNotAnError covers a server without
+// the gtid_mode variable at all — Error 1193 ER_UNKNOWN_SYSTEM_VARIABLE, which
+// is what MariaDB returns. Such a server structurally cannot supply a MySQL
+// GTID set, so the result is ("", nil): position fallback, not a fatal error.
+// This is reachable in production because a MariaDB source can sit behind the
+// DEFAULT mysql flavor (e.g. `bintrail-console watch` exposes no
+// --source-flavor for its main source); a hard failure here would crash-loop
+// that daemon at startup.
+func TestCurrentGTIDExecuted_unknownVariableIsNotAnError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery(`SELECT @@GLOBAL.gtid_mode`).WillReturnError(&mysql.MySQLError{
+		Number:  1193,
+		Message: "Unknown system variable 'gtid_mode'",
+	})
+
+	got, err := CurrentGTIDExecuted(db)
+	if err != nil {
+		t.Fatalf("expected 1193 to map to a clean position fallback, got error: %v", err)
+	}
+	if got != "" {
+		t.Errorf("got %q, want empty for a server without gtid_mode", got)
+	}
+}
+
 // TestCurrentGTIDExecuted_queryErrorPropagates verifies a query failure is a
 // real error (the streamrun caller treats it as fatal — it must not silently
 // degrade a GTID source to position mode).

--- a/internal/streamrun/crash_restart_integration_test.go
+++ b/internal/streamrun/crash_restart_integration_test.go
@@ -307,7 +307,11 @@ func TestIntegrationCrashRestartExactlyOnce_position(t *testing.T) {
 
 	// ── run 1: clean, establishes the durable checkpoint ──────────────────
 	// No --start-file/--start-gtid and no checkpoint: One auto-discovers the
-	// source's current binlog position and runs in POSITION mode.
+	// start point. GTID discovery is tried first (#1131), but this suite's
+	// MySQL runs gtid_mode=OFF, so CurrentGTIDExecuted returns "" and One
+	// falls back to position discovery and runs in POSITION mode. (On a
+	// gtid_mode=ON source a fresh run would checkpoint in GTID mode instead —
+	// covered by unit tests with stubbed discovery callbacks.)
 	cfg1 := baseCfg(serverIDBase)
 	if err := runOneUntil(t, cfg1, true, insert(1, 5), indexedThrough(5)); err != nil {
 		t.Fatalf("run 1 (clean): %v", err)

--- a/internal/streamrun/gtid_autodiscover_integration_test.go
+++ b/internal/streamrun/gtid_autodiscover_integration_test.go
@@ -1,0 +1,188 @@
+//go:build integration
+
+// Integration coverage for #1131: a fresh stream (no checkpoint, no
+// --start-file/--start-gtid) against a gtid_mode=ON source must auto-discover
+// the executed GTID set, checkpoint in GTID mode, and resume from that
+// checkpoint on restart.
+//
+// The shared integration MySQL runs gtid_mode=OFF, so this test steps it up
+// online (OFF → OFF_PERMISSIVE → ON_PERMISSIVE → ON, MySQL 8.0's documented
+// no-restart transition) and steps it back down afterward so the rest of the
+// suite is unaffected. Tests within this package run sequentially, so no other
+// test in the package can observe the ON window; a cross-PACKAGE integration
+// run executed in parallel against the same container could, which is why the
+// window is kept as short as the two streaming runs allow.
+package streamrun
+
+import (
+	"database/sql"
+	"strconv"
+	"strings"
+	"testing"
+
+	gomysql "github.com/go-mysql-org/go-mysql/mysql"
+
+	"github.com/dbtrail/dbtrail/internal/config"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// stepGTIDModeOn steps the shared MySQL server's gtid_mode from OFF to ON
+// online and registers a cleanup that steps it back down and restores
+// enforce_gtid_consistency. It skips the test when the server refuses the
+// stepping (missing SUPER/SYSTEM_VARIABLES_ADMIN, or an unexpected starting
+// state) — refusal must never fail the suite, only reduce its coverage.
+func stepGTIDModeOn(t *testing.T, db *sql.DB) {
+	t.Helper()
+
+	var mode string
+	if err := db.QueryRow("SELECT @@GLOBAL.gtid_mode").Scan(&mode); err != nil {
+		t.Skipf("cannot read gtid_mode: %v", err)
+	}
+	if strings.EqualFold(mode, "ON") {
+		return // already ON (e.g. a dedicated GTID container); nothing to restore
+	}
+	if !strings.EqualFold(mode, "OFF") {
+		t.Skipf("gtid_mode=%s: not a state this test steps from", mode)
+	}
+	var enforce string
+	if err := db.QueryRow("SELECT @@GLOBAL.enforce_gtid_consistency").Scan(&enforce); err != nil {
+		t.Skipf("cannot read enforce_gtid_consistency: %v", err)
+	}
+
+	if _, err := db.Exec("SET GLOBAL enforce_gtid_consistency = ON"); err != nil {
+		t.Skipf("SET GLOBAL refused (%v); cannot step gtid_mode online", err)
+	}
+	// Registered before the upward steps so a partial climb (skip mid-loop)
+	// is also walked back. Each downward step is a no-op when already at or
+	// below that state; errors are deliberately ignored (best-effort restore),
+	// but a failed restore is loudly logged — a container left at gtid_mode=ON
+	// would make position-mode assertions elsewhere flake mysteriously.
+	t.Cleanup(func() {
+		for _, m := range []string{"ON_PERMISSIVE", "OFF_PERMISSIVE", "OFF"} {
+			db.Exec("SET GLOBAL gtid_mode = " + m)
+		}
+		db.Exec("SET GLOBAL enforce_gtid_consistency = " + enforce)
+		var restored string
+		if err := db.QueryRow("SELECT @@GLOBAL.gtid_mode").Scan(&restored); err == nil &&
+			!strings.EqualFold(restored, "OFF") {
+			t.Logf("WARNING: could not step gtid_mode back down (still %s); later position-mode tests on this container may misbehave", restored)
+		}
+	})
+	for _, m := range []string{"OFF_PERMISSIVE", "ON_PERMISSIVE", "ON"} {
+		if _, err := db.Exec("SET GLOBAL gtid_mode = " + m); err != nil {
+			t.Skipf("SET GLOBAL gtid_mode = %s refused (%v); cannot step online", m, err)
+		}
+	}
+}
+
+// TestIntegrationFirstRunAutoDiscoversGTIDMode is the headline #1131 path
+// against a real server: real CurrentGTIDExecuted discovery, a real GTID-mode
+// checkpoint round-tripped through stream_state, and a restart that resumes
+// from it exactly-once. The stubbed unit tests in streamrun_test.go pin the
+// resolver's branch logic; this pins that One() wires the real discovery
+// callbacks and that the resulting checkpoint actually drives a resume.
+func TestIntegrationFirstRunAutoDiscoversGTIDMode(t *testing.T) {
+	indexDB, indexName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, indexDB)
+
+	sourceDB, sourceName := testutil.CreateTestDB(t)
+	sourceDSN := testutil.IntegrationDSN(sourceName)
+	const serverIDBase = 99860
+
+	var logBin string
+	if err := sourceDB.QueryRow("SELECT @@log_bin").Scan(&logBin); err != nil || logBin != "1" {
+		t.Skip("skipping: binary logging not enabled on test MySQL")
+	}
+
+	stepGTIDModeOn(t, sourceDB)
+
+	// Created AFTER the step to ON so at least this DDL transaction owns a
+	// GTID — @@GLOBAL.gtid_executed is then provably non-empty and discovery
+	// cannot fall into the empty-set position fallback.
+	testutil.MustExec(t, sourceDB, `CREATE TABLE orders (
+		id     INT PRIMARY KEY,
+		amount INT NOT NULL
+	)`)
+
+	// Sanity-check the production helper against the real server before
+	// spending two streaming runs on it.
+	set, err := config.CurrentGTIDExecuted(sourceDB)
+	if err != nil {
+		t.Fatalf("CurrentGTIDExecuted against gtid_mode=ON source: %v", err)
+	}
+	if set == "" {
+		t.Fatal("CurrentGTIDExecuted returned empty on a gtid_mode=ON source that has executed transactions")
+	}
+	if strings.ContainsAny(set, " \n\t") {
+		t.Fatalf("CurrentGTIDExecuted returned a set with whitespace: %q", set)
+	}
+
+	baseCfg := func(serverID uint32) Config {
+		return Config{
+			IndexDSN:   testutil.IntegrationDSN(indexName),
+			SourceDSN:  sourceDSN,
+			Flavor:     gomysql.MySQLFlavor,
+			ServerID:   serverID,
+			BatchSize:  1,
+			Schemas:    sourceName,
+			Checkpoint: 1,
+			GapTimeout: 30,
+			Format:     "text",
+			SSLMode:    "preferred",
+			Deps:       testStreamDeps(),
+		}
+	}
+	insert := func(lo, hi int) func() {
+		return func() {
+			for i := lo; i <= hi; i++ {
+				testutil.MustExec(t, sourceDB, "INSERT INTO orders (id, amount) VALUES (?, ?)", i, i*10)
+			}
+		}
+	}
+	indexedThrough := func(hi int) func() bool {
+		return func() bool {
+			var n int
+			if err := indexDB.QueryRow(`SELECT COUNT(*) FROM binlog_events
+				WHERE schema_name = ? AND table_name = 'orders' AND pk_values = ?`,
+				sourceName, strconv.Itoa(hi)).Scan(&n); err != nil {
+				t.Fatalf("poll indexed pk %d: %v", hi, err)
+			}
+			return n > 0
+		}
+	}
+
+	// ── run 1: first run, no flags — must select GTID mode by discovery ───
+	if err := runOneUntil(t, baseCfg(serverIDBase), true, insert(1, 5), indexedThrough(5)); err != nil {
+		t.Fatalf("run 1 (first-run GTID discovery): %v", err)
+	}
+	saved, err := loadStreamState(indexDB)
+	if err != nil {
+		t.Fatalf("loadStreamState after run 1: %v", err)
+	}
+	if saved == nil {
+		t.Fatal("run 1 saved no checkpoint")
+	}
+	if saved.mode != "gtid" {
+		t.Fatalf("run 1 checkpoint mode = %q, want \"gtid\" — first-run auto-discovery did not select GTID mode on a gtid_mode=ON source", saved.mode)
+	}
+	if strings.TrimSpace(saved.gtidSet) == "" {
+		t.Fatal("run 1 checkpointed in GTID mode with an EMPTY gtid_set — live-source verify would still be inconclusive")
+	}
+	assertExactlyOnce(t, indexedPKs(t, indexDB, sourceName, "orders"), pkRange(1, 5))
+
+	// ── run 2: restart — must RESUME from the GTID checkpoint ─────────────
+	// waitAttached=false: on a resume the start point comes from the saved
+	// checkpoint, so writes issued immediately are replayed once attached.
+	if err := runOneUntil(t, baseCfg(serverIDBase+1), false, insert(6, 8), indexedThrough(8)); err != nil {
+		t.Fatalf("run 2 (resume from GTID checkpoint): %v", err)
+	}
+	resumed, err := loadStreamState(indexDB)
+	if err != nil {
+		t.Fatalf("loadStreamState after run 2: %v", err)
+	}
+	if resumed.mode != "gtid" {
+		t.Fatalf("run 2 checkpoint mode = %q, want \"gtid\" (resume must not fall back to position mode)", resumed.mode)
+	}
+	// Exactly-once across the restart: nothing lost, nothing re-delivered.
+	assertExactlyOnce(t, indexedPKs(t, indexDB, sourceName, "orders"), pkRange(1, 8))
+}

--- a/internal/streamrun/streamrun.go
+++ b/internal/streamrun/streamrun.go
@@ -785,18 +785,37 @@ func resolveStartWithAutoDiscover(
 	startFile, startGTID string, startPos uint32,
 	saved *streamState,
 	autoDiscover func() (string, uint32, error),
+	gtidAutoDiscover func() (string, error),
 ) (mode, file, gtidStr string, pos uint32, accGTID gomysql.GTIDSet, err error) {
-	return resolveStartWithAutoDiscoverForFlavor(startFile, startGTID, startPos, saved, gomysql.MySQLFlavor, autoDiscover)
+	return resolveStartWithAutoDiscoverForFlavor(startFile, startGTID, startPos, saved, gomysql.MySQLFlavor, autoDiscover, gtidAutoDiscover)
 }
 
 // resolveStartWithAutoDiscoverForFlavor is the flavor-aware variant of
 // resolveStartWithAutoDiscover; see that function for the contract. flavor is
 // threaded into resolveStartForFlavor so saved/flag GTID sets parse with the
 // right flavor.
+//
+// gtidAutoDiscover is tried BEFORE the position callback, and only for the
+// MySQL flavor: a non-empty executed set selects GTID mode (parsed with the
+// same flavor-aware parser as the --start-gtid branch), so a fresh stream on a
+// gtid_mode=ON source checkpoints in GTID mode and live-source verify works
+// out of the box (#1131). An empty set — gtid_mode not ON, or a fresh server
+// with zero transactions — falls back to the position callback unchanged
+// (starting GTID replication from an empty set would replay the binlog from
+// the beginning, not "start from now"). A gtidAutoDiscover ERROR is fatal, not
+// a fallback: an operator on a GTID source must not silently end up in
+// position mode.
+//
+// MariaDB deliberately keeps position-only auto-discovery: its GTID
+// coordinates (domain-server-seq, @@gtid_current_pos) have different discovery
+// semantics, and the live-source verify coverage check that motivates GTID
+// mode only consumes MySQL GTID sets — auto-selecting GTID mode there would be
+// an untested behavior change with no consumer.
 func resolveStartWithAutoDiscoverForFlavor(
 	startFile, startGTID string, startPos uint32,
 	saved *streamState, flavor string,
 	autoDiscover func() (string, uint32, error),
+	gtidAutoDiscover func() (string, error),
 ) (mode, file, gtidStr string, pos uint32, accGTID gomysql.GTIDSet, err error) {
 	mode, file, gtidStr, pos, accGTID, err = resolveStartForFlavor(startFile, startGTID, startPos, saved, flavor)
 	if err == nil {
@@ -806,14 +825,42 @@ func resolveStartWithAutoDiscoverForFlavor(
 	// "no start position" case (saved == nil and no flags). Other errors
 	// (mutually-exclusive flags, invalid GTID, corrupt saved state) must
 	// propagate so the operator sees the real problem.
-	if autoDiscover == nil || saved != nil || startFile != "" || startGTID != "" {
+	if saved != nil || startFile != "" || startGTID != "" {
 		return
+	}
+	if gtidAutoDiscover != nil && flavor == gomysql.MySQLFlavor {
+		set, dErr := gtidAutoDiscover()
+		if dErr != nil {
+			return "", "", "", 0, nil, fmt.Errorf("auto-discover executed GTID set: %w", dErr)
+		}
+		if set != "" {
+			set = normalizeGTIDForFlavor(flavor, set)
+			gs, parseErr := parseGTIDSetForFlavor(flavor, set)
+			if parseErr != nil {
+				return "", "", "", 0, nil, fmt.Errorf("auto-discovered gtid_executed %q is unparseable: %w", set, parseErr)
+			}
+			return "gtid", "", set, 0, gs, nil
+		}
+		// Empty set: fall through to position discovery below.
+	}
+	if autoDiscover == nil {
+		return // the original "no start position" error
 	}
 	af, ap, dErr := autoDiscover()
 	if dErr != nil {
 		return "", "", "", 0, nil, fmt.Errorf("auto-discover binlog position: %w", dErr)
 	}
 	return "position", af, "", ap, nil, nil
+}
+
+// truncateForDisplay shortens s for a single terminal line. GTID sets are
+// ASCII, so byte slicing cannot split a rune. Callers log the full value via
+// slog before printing the truncated form.
+func truncateForDisplay(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "… (truncated; full set in the log)"
 }
 
 // ─── Gap detection ──────────────────────────────────────────────────────────────
@@ -1773,15 +1820,25 @@ func One(ctx context.Context, cfg Config) error {
 
 	mode, startFile, startGTIDStr, startPos, accGTID, err := resolveStartWithAutoDiscoverForFlavor(
 		cfg.StartFile, cfg.StartGTID, cfg.StartPos, saved, cfg.Flavor,
-		func() (string, uint32, error) { return config.CurrentBinlogPosition(sourceDB) })
+		func() (string, uint32, error) { return config.CurrentBinlogPosition(sourceDB) },
+		func() (string, error) { return config.CurrentGTIDExecuted(sourceDB) })
 	if err != nil {
 		return err
 	}
-	// Surface the auto-discovered position when this was a first-run, no-flags
-	// invocation. Mirrors the agent BYOS startup checkmark style.
-	if saved == nil && cfg.StartFile == "" && cfg.StartGTID == "" && mode == "position" {
-		slog.Info("auto-discovered current binlog position", "file", startFile, "pos", startPos)
-		fmt.Printf("Start position: auto-discovered %s:%d ✓\n", startFile, startPos)
+	// Surface the auto-discovered start point when this was a first-run,
+	// no-flags invocation. Mirrors the agent BYOS startup checkmark style.
+	if saved == nil && cfg.StartFile == "" && cfg.StartGTID == "" {
+		switch mode {
+		case "position":
+			slog.Info("auto-discovered current binlog position", "file", startFile, "pos", startPos)
+			fmt.Printf("Start position: auto-discovered %s:%d ✓\n", startFile, startPos)
+		case "gtid":
+			// The full set goes to the structured log; the terminal line is
+			// truncated (a long-lived multi-source server's gtid_executed can
+			// span many UUID blocks).
+			slog.Info("auto-discovered executed GTID set (gtid_mode=ON)", "gtid_set", startGTIDStr)
+			fmt.Printf("Start position: auto-discovered GTID set %s ✓\n", truncateForDisplay(startGTIDStr, 120))
+		}
 	}
 
 	// Persist the --reset discard now that the new start position is known

--- a/internal/streamrun/streamrun.go
+++ b/internal/streamrun/streamrun.go
@@ -367,6 +367,43 @@ func resetJumpDetail(old *streamState, flavor, mode, file string, pos uint32, gt
 		describeCheckpoint(mode, file, uint64(pos), gtidSet))
 }
 
+// classifyResetDiscard wraps resetJumpDetail with one refinement: a --reset
+// that discarded a POSITION-mode checkpoint and restarted in AUTO-DISCOVERED
+// GTID mode (the #1131 first-run path on a gtid_mode=ON source) always lands
+// in resetJumpDetail's cross-mode arm, which cannot compare coordinates and
+// so reports a jump — stamping gap_lost_at and printing "permanently lost"
+// even when the old checkpoint sits exactly at the source's current position,
+// i.e. nothing was skipped. That stamp is sticky: it permanently fails
+// `status --fail-on-gap` and degrades `verify --check recover` to
+// inconclusive, a false-alarm class worse than the noise it prevents.
+//
+// For exactly that combination (old.mode=="position", new mode=="gtid",
+// start point auto-discovered, not operator-specified) the source's current
+// binlog position is consulted: old == current ⇒ no-op, no stamp. On any
+// discovery error or coordinate inequality the conservative jump
+// classification stands — over-reporting a gap is recoverable review noise;
+// under-reporting one is silent data loss.
+func classifyResetDiscard(old *streamState, flavor, mode, file string, pos uint32, gtidSet string,
+	autoDiscovered bool, currentPosition func() (string, uint32, error),
+) (noop bool, detail string) {
+	noop, detail = resetJumpDetail(old, flavor, mode, file, pos, gtidSet)
+	if noop || !autoDiscovered || old.mode != "position" || mode != "gtid" || currentPosition == nil {
+		return noop, detail
+	}
+	curFile, curPos, err := currentPosition()
+	if err != nil {
+		slog.Warn("could not read the source's current binlog position to refine the reset classification; keeping the conservative gap record",
+			"error", err)
+		return noop, detail
+	}
+	if old.binlogFile == curFile && old.binlogPos == uint64(curPos) {
+		slog.Info("reset switched position→GTID mode at the source's current coordinates; no events were skipped",
+			"file", curFile, "pos", curPos)
+		return true, ""
+	}
+	return noop, detail
+}
+
 // persistResetDiscard durably persists a --reset checkpoint discard once the
 // new start position is resolved. A jump is recorded exactly like an
 // unfillable-gap auto-advance: gap_lost stamp FIRST, then the fresh
@@ -1859,7 +1896,9 @@ func One(ctx context.Context, cfg Config) error {
 			serverID:   cfg.ServerID,
 			bintrailID: bintrailID,
 		}
-		noop, detail := resetJumpDetail(resetDiscarded, cfg.Flavor, mode, startFile, startPos, startGTIDStr)
+		noop, detail := classifyResetDiscard(resetDiscarded, cfg.Flavor, mode, startFile, startPos, startGTIDStr,
+			cfg.StartFile == "" && cfg.StartGTID == "",
+			func() (string, uint32, error) { return config.CurrentBinlogPosition(sourceDB) })
 		if err := persistResetDiscard(indexDB, fresh, noop, detail, cfg.Hooks); err != nil {
 			return err
 		}

--- a/internal/streamrun/streamrun_test.go
+++ b/internal/streamrun/streamrun_test.go
@@ -1296,7 +1296,7 @@ func TestResolveStartWithAutoDiscover_firesOnFirstRun(t *testing.T) {
 		func() (string, uint32, error) {
 			called = true
 			return "mysql-bin.000042", 1234, nil
-		})
+		}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1317,7 +1317,7 @@ func TestResolveStartWithAutoDiscover_skippedWhenFlagSet(t *testing.T) {
 		func() (string, uint32, error) {
 			called = true
 			return "should-not-be-used", 999, nil
-		})
+		}, gtidDiscoverMustNotBeCalled(t))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1343,7 +1343,7 @@ func TestResolveStartWithAutoDiscover_skippedWhenGTIDFlagSet(t *testing.T) {
 		func() (string, uint32, error) {
 			called = true
 			return "should-not-be-used", 999, nil
-		})
+		}, gtidDiscoverMustNotBeCalled(t))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1372,7 +1372,7 @@ func TestResolveStartWithAutoDiscover_skippedWhenSavedExists(t *testing.T) {
 		func() (string, uint32, error) {
 			called = true
 			return "should-not-be-used", 999, nil
-		})
+		}, gtidDiscoverMustNotBeCalled(t))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1389,7 +1389,7 @@ func TestResolveStartWithAutoDiscover_skippedWhenSavedExists(t *testing.T) {
 // that when no callback is wired and no flags/saved exist, the original
 // "no start position" error still surfaces (back-compat).
 func TestResolveStartWithAutoDiscover_nilCallbackPreservesOriginalError(t *testing.T) {
-	_, _, _, _, _, err := resolveStartWithAutoDiscover("", "", 4, nil, nil)
+	_, _, _, _, _, err := resolveStartWithAutoDiscover("", "", 4, nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected error when nil callback and no flags/saved, got nil")
 	}
@@ -1405,7 +1405,7 @@ func TestResolveStartWithAutoDiscover_discoveryErrorWrapped(t *testing.T) {
 	_, _, _, _, _, err := resolveStartWithAutoDiscover("", "", 4, nil,
 		func() (string, uint32, error) {
 			return "", 0, stubErr
-		})
+		}, nil)
 	if err == nil {
 		t.Fatal("expected discovery error to surface, got nil")
 	}
@@ -1426,7 +1426,7 @@ func TestResolveStartWithAutoDiscover_mutuallyExclusiveFlagsErrorPropagates(t *t
 		func() (string, uint32, error) {
 			called = true
 			return "", 0, nil
-		})
+		}, gtidDiscoverMustNotBeCalled(t))
 	if err == nil {
 		t.Fatal("expected mutually-exclusive error, got nil")
 	}
@@ -1435,6 +1435,155 @@ func TestResolveStartWithAutoDiscover_mutuallyExclusiveFlagsErrorPropagates(t *t
 	}
 	if !strings.Contains(err.Error(), "mutually exclusive") {
 		t.Errorf("expected mutually-exclusive error, got: %v", err)
+	}
+}
+
+// gtidDiscoverMustNotBeCalled returns a GTID auto-discover stub that fails the
+// test if invoked. Used on paths (saved checkpoint, explicit flags, MariaDB
+// flavor, non-discovery errors) where GTID discovery must never fire.
+func gtidDiscoverMustNotBeCalled(t *testing.T) func() (string, error) {
+	t.Helper()
+	return func() (string, error) {
+		t.Error("gtid auto-discover must not be called on this path")
+		return "", nil
+	}
+}
+
+// TestResolveStartWithAutoDiscover_gtidDiscoveredSelectsGTIDMode verifies the
+// #1131 fix: on a first run with no flags, a non-empty executed GTID set from
+// the GTID callback selects GTID mode, and the position callback is never
+// consulted.
+func TestResolveStartWithAutoDiscover_gtidDiscoveredSelectsGTIDMode(t *testing.T) {
+	const set = "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-77"
+	posCalled := false
+	mode, file, gtidStr, _, accGTID, err := resolveStartWithAutoDiscover("", "", 4, nil,
+		func() (string, uint32, error) {
+			posCalled = true
+			return "should-not-be-used", 999, nil
+		},
+		func() (string, error) { return set, nil })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if posCalled {
+		t.Error("position auto-discover must not be called when a GTID set was discovered")
+	}
+	if mode != "gtid" {
+		t.Errorf("mode = %q, want gtid", mode)
+	}
+	if gtidStr != set {
+		t.Errorf("gtidStr = %q, want %q", gtidStr, set)
+	}
+	if file != "" {
+		t.Errorf("file = %q, want empty in gtid mode", file)
+	}
+	if accGTID == nil {
+		t.Error("expected non-nil pre-parsed accGTID in gtid mode")
+	}
+}
+
+// TestResolveStartWithAutoDiscover_gtidEmptyFallsBackToPosition verifies that
+// an empty executed set (gtid_mode not ON, or a fresh server with zero
+// transactions) falls back to position auto-discovery — starting GTID
+// replication from an empty set would replay the binlog from the beginning
+// instead of "starting from now".
+func TestResolveStartWithAutoDiscover_gtidEmptyFallsBackToPosition(t *testing.T) {
+	gtidCalled := false
+	mode, file, _, pos, _, err := resolveStartWithAutoDiscover("", "", 4, nil,
+		func() (string, uint32, error) { return "mysql-bin.000042", 1234, nil },
+		func() (string, error) {
+			gtidCalled = true
+			return "", nil
+		})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !gtidCalled {
+		t.Error("expected the GTID callback to be tried first")
+	}
+	if mode != "position" || file != "mysql-bin.000042" || pos != 1234 {
+		t.Errorf("got mode=%q file=%q pos=%d, want position/mysql-bin.000042/1234",
+			mode, file, pos)
+	}
+}
+
+// TestResolveStartWithAutoDiscover_gtidErrorIsFatal verifies that a GTID
+// discovery FAILURE is a hard error, not a silent fallback to position mode —
+// an operator on a GTID source must not silently end up with an index that
+// live-source verify calls inconclusive (the exact dead end of #1131).
+func TestResolveStartWithAutoDiscover_gtidErrorIsFatal(t *testing.T) {
+	stubErr := errors.New("SELECT @@GLOBAL.gtid_mode: connection reset")
+	posCalled := false
+	_, _, _, _, _, err := resolveStartWithAutoDiscover("", "", 4, nil,
+		func() (string, uint32, error) {
+			posCalled = true
+			return "mysql-bin.000042", 1234, nil
+		},
+		func() (string, error) { return "", stubErr })
+	if err == nil {
+		t.Fatal("expected GTID discovery error to surface, got nil")
+	}
+	if !errors.Is(err, stubErr) {
+		t.Errorf("expected wrapped stubErr via errors.Is, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "auto-discover executed GTID set") {
+		t.Errorf("expected GTID-discovery wrap prefix, got: %v", err)
+	}
+	if posCalled {
+		t.Error("position auto-discover must not run after a GTID discovery failure")
+	}
+}
+
+// TestResolveStartWithAutoDiscover_gtidUnparseableIsFatal verifies that a
+// discovered set the flavor parser rejects fails loud instead of degrading to
+// position mode.
+func TestResolveStartWithAutoDiscover_gtidUnparseableIsFatal(t *testing.T) {
+	_, _, _, _, _, err := resolveStartWithAutoDiscover("", "", 4, nil,
+		func() (string, uint32, error) { return "mysql-bin.000042", 1234, nil },
+		func() (string, error) { return "not-a-gtid-set", nil })
+	if err == nil {
+		t.Fatal("expected parse error for unparseable discovered set, got nil")
+	}
+	if !strings.Contains(err.Error(), "unparseable") {
+		t.Errorf("expected unparseable-set error, got: %v", err)
+	}
+}
+
+// TestResolveStartWithAutoDiscoverForFlavor_mariadbSkipsGTIDDiscovery verifies
+// MariaDB keeps today's position-only auto-discovery: the GTID callback is
+// never invoked for the mariadb flavor (its GTID coordinates have different
+// discovery semantics, and live-source verify only consumes MySQL GTID sets).
+func TestResolveStartWithAutoDiscoverForFlavor_mariadbSkipsGTIDDiscovery(t *testing.T) {
+	mode, file, _, pos, _, err := resolveStartWithAutoDiscoverForFlavor("", "", 4, nil,
+		gomysql.MariaDBFlavor,
+		func() (string, uint32, error) { return "mariadb-bin.000002", 1483, nil },
+		gtidDiscoverMustNotBeCalled(t))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mode != "position" || file != "mariadb-bin.000002" || pos != 1483 {
+		t.Errorf("got mode=%q file=%q pos=%d, want position/mariadb-bin.000002/1483",
+			mode, file, pos)
+	}
+}
+
+// TestResolveStartWithAutoDiscover_gtidSkippedWhenSavedExists verifies a saved
+// checkpoint bypasses BOTH discovery callbacks — resuming must never
+// re-discover.
+func TestResolveStartWithAutoDiscover_gtidSkippedWhenSavedExists(t *testing.T) {
+	saved := &streamState{mode: "position", binlogFile: "saved.000007", binlogPos: 500}
+	mode, file, _, pos, _, err := resolveStartWithAutoDiscover("", "", 4, saved,
+		func() (string, uint32, error) {
+			t.Error("position auto-discover must not be called with a saved checkpoint")
+			return "", 0, nil
+		},
+		gtidDiscoverMustNotBeCalled(t))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mode != "position" || file != "saved.000007" || pos != 500 {
+		t.Errorf("got mode=%q file=%q pos=%d, want position/saved.000007/500",
+			mode, file, pos)
 	}
 }
 

--- a/internal/streamrun/streamrun_test.go
+++ b/internal/streamrun/streamrun_test.go
@@ -1587,6 +1587,92 @@ func TestResolveStartWithAutoDiscover_gtidSkippedWhenSavedExists(t *testing.T) {
 	}
 }
 
+// ─── classifyResetDiscard ────────────────────────────────────────────────────
+
+// TestClassifyResetDiscard_positionToGTIDAtCurrentIsNoop verifies the
+// spurious-loss fix: --reset on a gtid_mode=ON source whose old checkpoint was
+// position mode, landing (via auto-discovery) exactly at the source's current
+// coordinates, is a NO-OP — no gap_lost stamp, no "permanently lost" banner.
+func TestClassifyResetDiscard_positionToGTIDAtCurrentIsNoop(t *testing.T) {
+	old := &streamState{mode: "position", binlogFile: "mysql-bin.000003", binlogPos: 2410667}
+	noop, detail := classifyResetDiscard(old, gomysql.MySQLFlavor,
+		"gtid", "", 0, "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-77",
+		true,
+		func() (string, uint32, error) { return "mysql-bin.000003", 2410667, nil })
+	if !noop {
+		t.Errorf("expected noop=true when the old position checkpoint equals the source's current coordinates; detail=%q", detail)
+	}
+	if detail != "" {
+		t.Errorf("expected empty detail for a no-op, got %q", detail)
+	}
+}
+
+// TestClassifyResetDiscard_positionToGTIDGenuineJumpStamps verifies a real
+// jump (old checkpoint behind the source's current position) keeps the
+// conservative gap record.
+func TestClassifyResetDiscard_positionToGTIDGenuineJumpStamps(t *testing.T) {
+	old := &streamState{mode: "position", binlogFile: "mysql-bin.000002", binlogPos: 1000}
+	noop, detail := classifyResetDiscard(old, gomysql.MySQLFlavor,
+		"gtid", "", 0, "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-77",
+		true,
+		func() (string, uint32, error) { return "mysql-bin.000003", 2410667, nil })
+	if noop {
+		t.Error("expected noop=false for a genuine position→GTID jump")
+	}
+	if !strings.Contains(detail, "permanently lost") {
+		t.Errorf("expected the permanent-loss detail, got %q", detail)
+	}
+}
+
+// TestClassifyResetDiscard_discoveryErrorKeepsConservativeStamp verifies that
+// when the source's current position cannot be read, the classification stays
+// conservative (stamp) rather than assuming a no-op.
+func TestClassifyResetDiscard_discoveryErrorKeepsConservativeStamp(t *testing.T) {
+	old := &streamState{mode: "position", binlogFile: "mysql-bin.000003", binlogPos: 2410667}
+	noop, _ := classifyResetDiscard(old, gomysql.MySQLFlavor,
+		"gtid", "", 0, "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-77",
+		true,
+		func() (string, uint32, error) { return "", 0, errors.New("source unreachable") })
+	if noop {
+		t.Error("expected noop=false when the current position cannot be confirmed")
+	}
+}
+
+// TestClassifyResetDiscard_explicitStartGTIDNotRefined verifies an
+// operator-specified --start-gtid (autoDiscovered=false) never consults the
+// source: the operator chose the start point, so the cross-mode jump keeps
+// resetJumpDetail's conservative classification untouched.
+func TestClassifyResetDiscard_explicitStartGTIDNotRefined(t *testing.T) {
+	old := &streamState{mode: "position", binlogFile: "mysql-bin.000003", binlogPos: 2410667}
+	noop, _ := classifyResetDiscard(old, gomysql.MySQLFlavor,
+		"gtid", "", 0, "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-77",
+		false,
+		func() (string, uint32, error) {
+			t.Error("currentPosition must not be consulted for an explicit --start-gtid")
+			return "", 0, nil
+		})
+	if noop {
+		t.Error("expected noop=false for an explicit cross-mode reset")
+	}
+}
+
+// TestClassifyResetDiscard_sameModeNoopUnchanged verifies the refinement does
+// not disturb resetJumpDetail's existing same-mode no-op arm (and never
+// consults the source there).
+func TestClassifyResetDiscard_sameModeNoopUnchanged(t *testing.T) {
+	old := &streamState{mode: "position", binlogFile: "mysql-bin.000003", binlogPos: 2410667}
+	noop, detail := classifyResetDiscard(old, gomysql.MySQLFlavor,
+		"position", "mysql-bin.000003", 2410667, "",
+		true,
+		func() (string, uint32, error) {
+			t.Error("currentPosition must not be consulted when resetJumpDetail already classified a no-op")
+			return "", 0, nil
+		})
+	if !noop || detail != "" {
+		t.Errorf("expected same-position no-op to pass through, got noop=%v detail=%q", noop, detail)
+	}
+}
+
 // TestDeleteEventsSinceCheckpoint_noPriorCheckpointIsNoop verifies the
 // dedup-on-resume helper (#759) skips the DELETE entirely (and never touches
 // db) when there is no prior checkpoint file — the first-run case where

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -530,7 +530,7 @@ func indexCovers(ctx context.Context, indexDB *sql.DB, srcGTID string) (bool, st
 		return false, "could not read index coverage: " + err.Error()
 	}
 	if !idxGTID.Valid || strings.TrimSpace(idxGTID.String) == "" {
-		return false, "index has not checkpointed any GTID yet"
+		return false, "index has not checkpointed any GTID yet (the stream is checkpointing in position mode; restart it with --start-gtid \"$(mysql -N -e 'SELECT @@GLOBAL.gtid_executed')\" to enable live-source verify — fresh streams on a GTID-enabled source now select GTID mode automatically)"
 	}
 	idxSet, err := gomysql.ParseMysqlGTIDSet(idxGTID.String)
 	if err != nil {

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -530,7 +530,7 @@ func indexCovers(ctx context.Context, indexDB *sql.DB, srcGTID string) (bool, st
 		return false, "could not read index coverage: " + err.Error()
 	}
 	if !idxGTID.Valid || strings.TrimSpace(idxGTID.String) == "" {
-		return false, "index has not checkpointed any GTID yet (the stream is checkpointing in position mode; restart it with --start-gtid \"$(mysql -N -e 'SELECT @@GLOBAL.gtid_executed')\" to enable live-source verify — fresh streams on a GTID-enabled source now select GTID mode automatically)"
+		return false, "index has no GTID checkpoint (the stream is running in position mode, or no stream has run against this index); if a stream is running, restart it with --start-gtid \"$(mysql -N -e 'SELECT @@GLOBAL.gtid_executed')\""
 	}
 	idxSet, err := gomysql.ParseMysqlGTIDSet(idxGTID.String)
 	if err != nil {


### PR DESCRIPTION
Closes #1131

## What changed

On a source with `gtid_mode=ON`, a fresh `bintrail up` / `bintrail stream` with no explicit start flags auto-discovered only the binlog file/position and always checkpointed in **position** mode. `bintrail verify --source-dsn` requires a GTID checkpoint (`indexCovers`), so the documented happy path left live-source verify `inconclusive` on every table — and `up` exposes no `--start-gtid` to fix it.

- **`internal/config`**: new `CurrentGTIDExecuted(db)` next to `CurrentBinlogPosition`. Reads `@@GLOBAL.gtid_mode`; anything other than `ON` returns `""` (no error). Otherwise returns `@@GLOBAL.gtid_executed` with **all whitespace stripped** (MySQL formats the variable with `\n` between UUID blocks). Error 1193 `ER_UNKNOWN_SYSTEM_VARIABLE` — what MariaDB returns for `gtid_mode` — also maps to `""` (no error): a server without the variable structurally cannot supply a MySQL GTID set, and a MariaDB source can sit behind the **default** mysql flavor (e.g. `bintrail-console watch` exposes no `--source-flavor` for its main source), where a fatal error here would crash-loop the daemon at startup. Genuine connection/query failures stay fatal. When `gtid_mode=ON` but the executed set is empty, a `slog.Warn` names the consequence (position mode; live-source verify stays inconclusive until the stream is restarted with `--start-gtid`).
- **`internal/streamrun`**: `resolveStartWithAutoDiscoverForFlavor` takes an additional GTID auto-discover callback, tried **before** the position callback, only on the first-run/no-flags path (`saved == nil`, no `--start-file`/`--start-gtid`) and only for the MySQL flavor. A non-empty set selects GTID mode, parsed with the same flavor-aware parser as the `--start-gtid` branch. A callback **error is fatal** — an operator on a GTID source must not silently end up in position mode. All other paths (saved checkpoint, explicit flags, error propagation) are unchanged.
- **`One`**: wires the new callback and extends the first-run startup print with a GTID line (`Start position: auto-discovered GTID set … ✓`, truncated for the terminal; the full set goes to the structured log).
- **`internal/verify`**: the `indexCovers` GTID-less-checkpoint detail no longer asserts what the function cannot know (a file-mode `bintrail index` index has no stream at all). It now reads: `index has no GTID checkpoint (the stream is running in position mode, or no stream has run against this index); if a stream is running, restart it with --start-gtid "$(mysql -N -e 'SELECT @@GLOBAL.gtid_executed')"`. Only that string changed in the file.
- **No new flags on `up`.** It still clears the stream start flags; auto-discovery now covers GTID sources for `up` and `bintrail-console watch` (both go through `streamrun.One`).
- **Docs**: `docs/streaming.md` (first-run auto-discovery paragraph, `--reset` cross-mode note, and the accepted duplicate-rows-after-GTID-auto-advance window now applying to default/no-flags deployments) and `docs/guide.md` Scenario J.

## Cross-mode `--reset` semantics (spurious-loss guard)

A `--reset` that discards a **position**-mode checkpoint on a `gtid_mode=ON` source now restarts in auto-discovered **GTID** mode, which always lands in `resetJumpDetail`'s cross-mode arm — previously that would unconditionally stamp `gap_lost_at` and print "permanently lost" even when the discarded checkpoint sat exactly at the source's current coordinates (nothing skipped). That stamp is sticky: it permanently fails `status --fail-on-gap` and degrades `verify --check recover` to inconclusive. New `classifyResetDiscard` refines exactly this combination (old mode `position`, new mode `gtid`, start point auto-discovered — never operator-specified): it reads the source's **current** binlog coordinates and classifies old == current as a no-op (no stamp). Any discovery error or coordinate inequality keeps the conservative stamp — over-reporting a gap is recoverable noise, under-reporting is silent loss. All other reset combinations are byte-for-byte unchanged.

## Why empty-set falls back to position

`@@GLOBAL.gtid_executed` is empty on a fresh server with zero transactions. Starting GTID replication from an empty set replays the binlog **from the beginning**, which is not the "start from now" contract of first-run auto-discovery — so an empty set (and any `gtid_mode` other than `ON`, including the permissive modes whose executed set may not cover every transaction) falls back to today's position discovery. Note `gtid_executed` can be non-empty even with `gtid_mode=OFF` (a server that once ran with GTIDs on), which is why `gtid_mode` gates the read.

## Why MariaDB is excluded

MariaDB keeps today's position-only auto-discovery, deliberately: its GTID coordinates (domain-server-seq, `@@gtid_current_pos`) have different discovery and gap semantics, and the live-source verify coverage check that motivates GTID mode only consumes MySQL GTID sets. Auto-selecting GTID mode there would be an untested behavior change with no consumer. The 1193 mapping above additionally makes a MariaDB source safe under the default mysql flavor (position fallback instead of a startup crash-loop).

## Tests

- `go build ./...`, `go vet ./...`, `go vet -tags integration ./...` — clean.
- Unit + `-race`: `internal/streamrun`, `internal/config`, `internal/verify` — pass. New unit coverage: GTID selection, empty-set fallback, saved-checkpoint/explicit-flag/MariaDB skips, fail-loud discovery errors and unparseable sets, the 1193 MariaDB mapping, and all four `classifyResetDiscard` arms (no-op at current coordinates, genuine jump, discovery error, explicit `--start-gtid`).
- Integration (shared Docker MySQL 8.0.46 on 13306): full `internal/streamrun`, `internal/config`, `internal/verify` suites pass. New `TestIntegrationFirstRunAutoDiscoversGTIDMode` steps the shared server's `gtid_mode` up **online** (`OFF → OFF_PERMISSIVE → ON_PERMISSIVE → ON`, no restart), runs a real first-run discovery through `One` (real `CurrentGTIDExecuted`, real GTID-mode checkpoint round-tripped through `stream_state`), restarts and asserts an exactly-once GTID-mode resume, then steps the server back down in cleanup (verified restored to `OFF` after the run; the test skips cleanly if `SET GLOBAL` is refused). Residual caveat: a cross-**package** integration run executed in parallel against the same container could observe the short `gtid_mode=ON` window; within the package tests run sequentially. The pre-existing crash-restart test still pins the position-fallback path end to end (`gtid_mode=OFF` outside that window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
