### PR TITLE
docs: --pk needs the 0x hex spelling for binary primary keys

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -267,6 +267,11 @@ bintrail query \
   --pk        '12345|2'
 ```
 
+For a `BINARY`/`VARBINARY` primary key whose bytes are not valid UTF-8, pass
+the stored `0x` + uppercase-hex spelling (reproducible from the source with
+`SELECT CONCAT('0x', HEX(pk_col))`) — see
+[Binary primary keys](query-and-recovery.md#binary-primary-keys-the-0x-hex-spelling).
+
 Results are in chronological order — you can trace the full lifecycle of the row from INSERT through every UPDATE to the final state (or DELETE).
 
 **Export a full audit record:**

--- a/docs/indexing.md
+++ b/docs/indexing.md
@@ -112,5 +112,9 @@ Indexed events go into `binlog_events`, range-partitioned by hour on
 `event_timestamp`. PK lookups are fast because `pk_hash`
 (`SHA2(pk_values, 256)`) is a stored, indexed column; queries match on
 `pk_hash` **and** the exact `pk_values` (the second check guards against the
-astronomically rare hash collision). Partition lifecycle, retention, and
+astronomically rare hash collision). `pk_values` is the pipe-delimited PK in
+column ordinal order; a PK value whose raw bytes are not valid UTF-8 (e.g. a
+`BINARY(16)` UUID) is stored as `0x` + uppercase hex — see
+[Binary primary keys](query-and-recovery.md#binary-primary-keys-the-0x-hex-spelling)
+for how to spell it in `--pk` lookups. Partition lifecycle, retention, and
 archiving to Parquet are covered in [Rotation and status](rotation-and-status.md).

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -232,6 +232,10 @@ both accept:
 - `profile` — RBAC table-deny + column-redaction
 - `no_archive` — disable Parquet archive auto-routing (see below)
 
+The `pk` parameter takes the stored `pk_values` spelling — for a binary PK
+whose bytes are not valid UTF-8 that is `0x` + uppercase hex, see
+[Binary primary keys](query-and-recovery.md#binary-primary-keys-the-0x-hex-spelling).
+
 `query` additionally takes `format` (`json`, `table`, or `csv`). Time values
 (`since` / `until`) accept MySQL datetime (`2006-01-02 15:04:05`), RFC 3339, or
 date-only (`2006-01-02`) — the same formats as the CLI.

--- a/docs/query-and-recovery.md
+++ b/docs/query-and-recovery.md
@@ -17,7 +17,47 @@ Filters: `--schema`, `--table`, `--pk`, `--event-type`, `--gtid`,
 `--column-eq` (events where a column has a given value — see below), and
 `--flag` (tables/columns labeled via [RBAC flags](server-identity.md)). A
 `--pk` lookup is fast and collision-safe — it matches a hash of the PK values
-plus the exact values.
+plus the exact values. Binary primary keys need a special spelling — see
+[the `0x` hex spelling](#binary-primary-keys-the-0x-hex-spelling) below.
+
+### Binary primary keys: the `0x` hex spelling
+
+A primary-key value whose bytes are **not valid UTF-8** — the typical case is
+a `BINARY`/`VARBINARY` PK such as a binary UUID, but a `BLOB` or latin1 `TEXT`
+prefix PK can land here too — is stored in `pk_values` as `0x` followed by
+**uppercase** hex. To look such a row up, pass that exact form to `--pk` (or
+`--pks`); the plain bytes will not match. This applies to `query`, `recover`,
+and `recover-cascade`.
+
+The spelling is deliberately identical to MySQL's own binary-literal syntax,
+so you can produce it straight from the source table:
+
+```sql
+SELECT CONCAT('0x', HEX(pk_col)) FROM app.t_pk_binary WHERE ...;
+```
+
+```sh
+bintrail recover --index-dsn "..." \
+  --schema app --table t_pk_binary \
+  --pk 0xB2815CC3C200FF7C0102030405060780 --dry-run
+```
+
+Three things to know:
+
+- **The `0x` form is content-dependent, not type-dependent.** A binary column
+  whose bytes happen to be valid UTF-8 (e.g. one holding ASCII text) is stored
+  **verbatim**, not hexed — so the `HEX()` recipe above is only right when the
+  raw bytes were unstorable. When in doubt, run `bintrail query` on the table
+  and copy the row's `pk_values` exactly as displayed; the stored spelling is
+  always the one that matches.
+- **Uppercase matters, especially with `--pks`.** The stored form is uppercase
+  hex, and the `--pks` filter (like the Parquet archive path) matches the
+  stored string byte-for-byte with no hash-based guard — `0xab...` will not
+  find a row stored as `0xAB...`. Type the hex exactly as `HEX()` prints it.
+- **Baseline-anchored `verify` and `reconstruct` do not support these PK
+  types** (binary/BLOB PKs are outside `reconstruct`'s supported PK set), so
+  the `0x` spelling helps with `query`/`recover`/`recover-cascade` but does
+  not unlock point-in-time reconstruction for such tables.
 
 ### `--column-eq` Filter
 
@@ -390,6 +430,8 @@ To reverse a specific set of primary keys, pass `--pks` (comma-separated) instea
 of a single `--pk`, and cap how many events are undone per key with
 `--limit-per-pk`. These compose with the shared event filters
 (`--schema`/`--table`/`--event-type`/`--since`/`--until`/`--column-eq`/`--gtid`/`--flag`).
+For binary primary keys, each entry must use the stored `0x` uppercase-hex
+spelling — see [the `0x` hex spelling](#binary-primary-keys-the-0x-hex-spelling).
 
 **PostgreSQL sources:** when the source is PostgreSQL, `recover` emits
 PostgreSQL-dialect reversal SQL (double-quoted identifiers and string/boolean literals) rather than


### PR DESCRIPTION
Closes #1138

Docs-only. Since #1132, a primary-key value whose bytes are not valid UTF-8 (typically `BINARY`/`VARBINARY`, but also `BLOB`/latin1-`TEXT` prefix PKs) is stored in `pk_values` as `0x` + **uppercase** hex, and `--pk`/`--pks` must use that spelling. No doc mentioned it.

## Changes

- **`docs/query-and-recovery.md`** — new authoritative section "Binary primary keys: the `0x` hex spelling" right under the filter overview, with a copy-pasteable `SELECT CONCAT('0x', HEX(pk_col))` recipe and worked `recover` example. Covers:
  - applies to `query`, `recover`, `recover-cascade` (`--pk`/`--pks`);
  - the encoding is content-gated, not type-gated — a binary column whose bytes are valid UTF-8 is stored verbatim, so the reliable move is to copy the stored `pk_values` from `bintrail query` output;
  - uppercase is load-bearing with `--pks` (the IN path — live and Parquet — matches the stored string byte-for-byte with no `pk_hash` guard);
  - baseline-anchored `verify`/`reconstruct` still do not support these PK types.
  - plus a one-line cross-reference from the `--pks` "Recovering many rows at once" section.
- Short cross-references where `--pk` is prominently documented: **`docs/guide.md`** (Scenario E audit-trail), **`docs/indexing.md`** (`pk_values` encoding in the `binlog_events` description), **`docs/mcp-server.md`** (`pk` tool parameter).

No code changes (`git diff --stat` is docs-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
