### PR TITLE
verify: pad fixed BINARY(n) event values and decode spatial columns

### DIFF
--- a/internal/reconstruct/base64decode_test.go
+++ b/internal/reconstruct/base64decode_test.go
@@ -89,3 +89,23 @@ func TestBase64StoredKind_binaryVarbinary(t *testing.T) {
 		}
 	}
 }
+
+// TestBase64StoredKind_spatialAndVector pins the #1136 entries: the spatial
+// family and VECTOR are delivered by go-mysql as []byte (SRID+WKB / packed
+// floats) and stored base64 like BLOB, so they must decode as binary here.
+// This guards against drift between this copy and the deliberately-untouched
+// sibling copies (internal/recovery, internal/shim) without needing Docker.
+func TestBase64StoredKind_spatialAndVector(t *testing.T) {
+	for _, dt := range []string{
+		"geometry", "point", "linestring", "polygon",
+		"multipoint", "multilinestring", "multipolygon",
+		"geometrycollection", "geomcollection",
+		"vector",
+		"GEOMETRY", "Point", // case-insensitive
+	} {
+		binary, ok := base64StoredKind(dt)
+		if !ok || !binary {
+			t.Errorf("base64StoredKind(%q) = (%v,%v), want (true,true)", dt, binary, ok)
+		}
+	}
+}

--- a/internal/reconstruct/fulltable.go
+++ b/internal/reconstruct/fulltable.go
@@ -1767,9 +1767,24 @@ func droppedBaselineColumns(imageCols map[string]struct{}, sawImage bool, colNam
 // wrong bytes with no error — astronomically unlikely for random binary
 // content, but plausible for a VARBINARY column storing ASCII-like data. See
 // the fuller rationale on the sibling copy in internal/recovery/recovery.go.
+// The spatial family + VECTOR are included (binary) since #1136: go-mysql
+// delivers them via decodeBlob as []byte — a geometry is MySQL's internal
+// 4-byte SRID + WKB, a VECTOR is packed floats — so they take the same
+// []byte-to-base64 storage path as BLOB and must be decoded the same way.
+// Decoding restores exactly the bytes a raw source SELECT and a mydumper
+// baseline carry, which is what makes them comparable (verify) and
+// restorable (reconstruct --output-format mydumper). The retroactive-
+// reclassification risk above does NOT apply to them: like BLOB they were
+// []byte-and-base64 from the day they were first captured.
 func base64StoredKind(dataType string) (binary, ok bool) {
 	switch strings.ToLower(dataType) {
-	case "blob", "tinyblob", "mediumblob", "longblob", "binary", "varbinary":
+	case "blob", "tinyblob", "mediumblob", "longblob", "binary", "varbinary",
+		"geometry", "point", "linestring", "polygon",
+		"multipoint", "multilinestring", "multipolygon",
+		// MySQL 8.0.11+ reports a GEOMETRYCOLLECTION column's DATA_TYPE as
+		// "geomcollection"; MariaDB and pre-8.0.11 report "geometrycollection".
+		"geometrycollection", "geomcollection",
+		"vector":
 		return true, true
 	case "text", "tinytext", "mediumtext", "longtext", "json":
 		return false, true

--- a/internal/verify/classify_test.go
+++ b/internal/verify/classify_test.go
@@ -1,51 +1,81 @@
 package verify
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/metadata"
+)
 
 func TestClassify(t *testing.T) {
 	const (
 		dA = "v1:aaaa"
 		dB = "v1:bbbb"
+		// A non-empty deferredDetail turns an equal-row-count content
+		// difference into Inconclusive; the string itself is built by
+		// deferredReprDetail at the call sites (see its own test below).
+		deferred = "an event carried a value for column \"v\" (point) that could not be normalized"
 	)
 	cases := []struct {
-		name         string
-		srcDigest    string
-		srcRows      int64
-		reconDigest  string
-		reconRows    int64
-		deferredRepr bool
-		want         Status
+		name           string
+		srcDigest      string
+		srcRows        int64
+		reconDigest    string
+		reconRows      int64
+		deferredDetail string
+		want           Status
 	}{
-		{"equal digest + equal rows → match", dA, 10, dA, 10, false, StatusMatch},
-		{"digest differs, equal rows, no deferred → mismatch", dA, 10, dB, 10, false, StatusMismatch},
-		{"digest differs, equal rows, deferred → inconclusive", dA, 10, dB, 10, true, StatusInconclusive},
+		{"equal digest + equal rows → match", dA, 10, dA, 10, "", StatusMatch},
+		{"digest differs, equal rows, no deferred → mismatch", dA, 10, dB, 10, "", StatusMismatch},
+		{"digest differs, equal rows, deferred → inconclusive", dA, 10, dB, 10, deferred, StatusInconclusive},
 		// The load-bearing guard: a row-count difference is a conclusive mismatch
 		// even when a deferred-repr column is present — data loss must never be
 		// masked as inconclusive.
-		{"row count differs + deferred → still mismatch", dA, 10, dA, 7, true, StatusMismatch},
-		{"row count differs, no deferred → mismatch", dA, 10, dA, 7, false, StatusMismatch},
-		// Equal digest must win even under deferredRepr (a deferred column that
+		{"row count differs + deferred → still mismatch", dA, 10, dA, 7, deferred, StatusMismatch},
+		{"row count differs, no deferred → mismatch", dA, 10, dA, 7, "", StatusMismatch},
+		// Equal digest must win even under deferredDetail (a deferred column that
 		// did not actually diverge still matches).
-		{"equal digest + deferred → match", dA, 10, dA, 10, true, StatusMatch},
+		{"equal digest + deferred → match", dA, 10, dA, 10, deferred, StatusMatch},
 		// #792 digest-contract skew: a persisted pre-pin v1 digest compared
 		// against a current v2 scan byte-differs even on identical data, so it
 		// must degrade to inconclusive (needs-rebaseline), NEVER a false mismatch.
-		{"version skew, same hash bytes → inconclusive not mismatch", "v1:aaaa", 10, "v2:aaaa", 10, false, StatusInconclusive},
-		{"version skew, different hash bytes → inconclusive not mismatch", "v1:aaaa", 10, "v2:bbbb", 10, false, StatusInconclusive},
-		{"untagged legacy vs tagged → inconclusive", "aaaa", 10, "v2:aaaa", 10, false, StatusInconclusive},
+		{"version skew, same hash bytes → inconclusive not mismatch", "v1:aaaa", 10, "v2:aaaa", 10, "", StatusInconclusive},
+		{"version skew, different hash bytes → inconclusive not mismatch", "v1:aaaa", 10, "v2:bbbb", 10, "", StatusInconclusive},
+		{"untagged legacy vs tagged → inconclusive", "aaaa", 10, "v2:aaaa", 10, "", StatusInconclusive},
 		// Row loss stays conclusive UNDER a version skew: row count is version-
 		// independent and checked first, so real loss is never masked as needs-rebaseline.
-		{"version skew but row count differs → still mismatch", "v1:aaaa", 10, "v2:aaaa", 7, false, StatusMismatch},
+		{"version skew but row count differs → still mismatch", "v1:aaaa", 10, "v2:aaaa", 7, "", StatusMismatch},
 		// Same (current) contract on both sides compares normally.
-		{"same v2 contract, equal → match", "v2:aaaa", 10, "v2:aaaa", 10, false, StatusMatch},
-		{"same v2 contract, differ → mismatch", "v2:aaaa", 10, "v2:bbbb", 10, false, StatusMismatch},
+		{"same v2 contract, equal → match", "v2:aaaa", 10, "v2:aaaa", 10, "", StatusMatch},
+		{"same v2 contract, differ → mismatch", "v2:aaaa", 10, "v2:bbbb", 10, "", StatusMismatch},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, _ := classify(tc.srcDigest, tc.srcRows, tc.reconDigest, tc.reconRows, tc.deferredRepr)
+			got, detail := classify(tc.srcDigest, tc.srcRows, tc.reconDigest, tc.reconRows, tc.deferredDetail)
 			if got != tc.want {
 				t.Errorf("classify = %q, want %q", got, tc.want)
 			}
+			// The deferred downgrade must report the caller's reason verbatim
+			// — that is what carries the column name to the operator (#1136).
+			if got == StatusInconclusive && tc.deferredDetail != "" && detail != tc.deferredDetail {
+				t.Errorf("detail = %q, want the deferredDetail passed in (%q)", detail, tc.deferredDetail)
+			}
 		})
+	}
+}
+
+// TestDeferredReprDetail pins the #1136 message contract: the Inconclusive
+// reason must name the actual unresolved column and its type — the earlier
+// static list ("ENUM/SET, JSON, binary or BIT") named types a spatial-only
+// table does not have.
+func TestDeferredReprDetail(t *testing.T) {
+	got := deferredReprDetail(metadata.ColumnMeta{Name: "v", DataType: "POINT"})
+	for _, want := range []string{`column "v" (point)`, "could not be normalized", "not conclusive"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("deferredReprDetail = %q; want it to contain %q", got, want)
+		}
+	}
+	if strings.Contains(got, "ENUM/SET") {
+		t.Errorf("deferredReprDetail = %q; must not carry the old static type list", got)
 	}
 }

--- a/internal/verify/deferred_test.go
+++ b/internal/verify/deferred_test.go
@@ -18,9 +18,9 @@ func TestIsDeferredType(t *testing.T) {
 	deferred := []string{
 		"enum", "set", "json",
 		"binary", "varbinary", "blob", "tinyblob", "mediumblob", "longblob", "bit",
-		// #793: spatial family + VECTOR — binary (WKB / packed floats) in the
-		// event image, same base64-vs-raw gap as BLOB, so they must defer to
-		// Inconclusive rather than report a conclusive false-MISMATCH.
+		// #793/#1136: spatial family + VECTOR — binary (SRID+WKB / packed
+		// floats) in the event image, decoded by DecodeEventBinaries like BLOB
+		// but still deferred for when the epoch-typed decode degrades.
 		"geometry", "point", "linestring", "polygon",
 		"multipoint", "multilinestring", "multipolygon",
 		"geometrycollection", "geomcollection", // MySQL 8.0.11+ reports the latter
@@ -46,7 +46,7 @@ func TestIsDeferredType(t *testing.T) {
 // TestDeferredReprUnresolved pins the #769/#791 gate: the deferred downgrade
 // stays on ONLY for a value the event-side normalization passes provably could
 // not resolve (unmapped ENUM ordinal, width-less BIT, numbered/uncanonical
-// JSON, untyped binary, spatial) — never merely because the table contains a
+// JSON, untyped binary/spatial, width-less fixed BINARY) — never merely because the table contains a
 // deferred column, and never for a value already normalized to the
 // baseline/source form (mapped label, width-known BIT, number-free JSON,
 // decoded binary).
@@ -59,6 +59,10 @@ func TestDeferredReprUnresolved(t *testing.T) {
 	jsonCol := metadata.ColumnMeta{Name: "meta", DataType: "json"}
 	blobCol := metadata.ColumnMeta{Name: "payload", DataType: "blob"}
 	geoCol := metadata.ColumnMeta{Name: "loc", DataType: "geometry"}
+	pointCol := metadata.ColumnMeta{Name: "loc", DataType: "point", ColumnType: "point"}
+	binCol := metadata.ColumnMeta{Name: "v", DataType: "binary", ColumnType: "binary(16)"}
+	binNoWidth := metadata.ColumnMeta{Name: "v", DataType: "binary"} // pre-#212 snapshot
+	varbinCol := metadata.ColumnMeta{Name: "v", DataType: "varbinary"}
 
 	ch := func(rows ...*query.ResultRow) map[string]*query.ResultRow {
 		m := map[string]*query.ResultRow{}
@@ -125,14 +129,49 @@ func TestDeferredReprUnresolved(t *testing.T) {
 		{"blob with typing unavailable", []metadata.ColumnMeta{blobCol},
 			ch(upd(map[string]any{"payload": "cmF3"})), false, true},
 
-		// Spatial: no event-side decode exists (#793) — always unresolved.
-		{"geometry present", []metadata.ColumnMeta{geoCol},
-			ch(upd(map[string]any{"loc": "AAAA"})), true, true},
+		// Fixed BINARY(n): the event image strips trailing 0x00 padding, which
+		// renderCell reverses by padding to the declared width (#1135) — so a
+		// decoded value resolves ONLY when the width is parseable. A pre-#212
+		// snapshot's empty ColumnType leaves the pad width unknown → honest
+		// Inconclusive instead of a false MISMATCH.
+		{"binary decoded with declared width", []metadata.ColumnMeta{binCol},
+			ch(upd(map[string]any{"v": []byte{0xab, 0xcd}})), true, false},
+		{"binary without ColumnType width", []metadata.ColumnMeta{binNoWidth},
+			ch(upd(map[string]any{"v": []byte{0xab, 0xcd}})), true, true},
+		{"binary with typing unavailable", []metadata.ColumnMeta{binCol},
+			ch(upd(map[string]any{"v": "q80="})), false, true},
+		// VARBINARY has no padding, hence no width requirement — like BLOB.
+		{"varbinary decoded (typed)", []metadata.ColumnMeta{varbinCol},
+			ch(upd(map[string]any{"v": []byte{0xab}})), true, false},
+
+		// Spatial: decoded by DecodeEventBinaries like BLOB since #1136 — a
+		// decoded value resolves; an untyped epoch stays unresolved.
+		{"geometry decoded (typed)", []metadata.ColumnMeta{geoCol},
+			ch(upd(map[string]any{"loc": []byte{0, 0, 0, 0, 1}})), true, false},
+		{"point decoded (typed)", []metadata.ColumnMeta{pointCol},
+			ch(upd(map[string]any{"loc": "AAAA"})), true, false},
+		{"geometry with typing unavailable", []metadata.ColumnMeta{geoCol},
+			ch(upd(map[string]any{"loc": "AAAA"})), false, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := deferredReprUnresolved(tc.cols, tc.changes, tc.binTyped); got != tc.want {
+			col, got := deferredReprUnresolved(tc.cols, tc.changes, tc.binTyped)
+			if got != tc.want {
 				t.Errorf("deferredReprUnresolved = %v, want %v", got, tc.want)
+			}
+			// The reported column must be the unresolved one (#1136): with a
+			// single deferred column per case, unresolved=true must name it.
+			if got && len(tc.cols) > 0 {
+				want := ""
+				for _, c := range tc.cols {
+					if isDeferredType(c.DataType) {
+						want = c.Name
+						break
+					}
+				}
+				if col.Name != want {
+					t.Errorf("unresolved column = %q, want %q", col.Name, want)
+				}
 			}
 		})
 	}

--- a/internal/verify/deferred_test.go
+++ b/internal/verify/deferred_test.go
@@ -19,8 +19,10 @@ func TestIsDeferredType(t *testing.T) {
 		"enum", "set", "json",
 		"binary", "varbinary", "blob", "tinyblob", "mediumblob", "longblob", "bit",
 		// #793/#1136: spatial family + VECTOR — binary (SRID+WKB / packed
-		// floats) in the event image, decoded by DecodeEventBinaries like BLOB
-		// but still deferred for when the epoch-typed decode degrades.
+		// floats) in the event image, decoded by DecodeEventBinaries like
+		// BLOB. Spatial defers for when the epoch-typed decode degrades;
+		// VECTOR stays permanently unresolved (the baseline side does not
+		// store its raw bytes — see deferredValueUnresolved).
 		"geometry", "point", "linestring", "polygon",
 		"multipoint", "multilinestring", "multipolygon",
 		"geometrycollection", "geomcollection", // MySQL 8.0.11+ reports the latter
@@ -60,6 +62,7 @@ func TestDeferredReprUnresolved(t *testing.T) {
 	blobCol := metadata.ColumnMeta{Name: "payload", DataType: "blob"}
 	geoCol := metadata.ColumnMeta{Name: "loc", DataType: "geometry"}
 	pointCol := metadata.ColumnMeta{Name: "loc", DataType: "point", ColumnType: "point"}
+	vectorCol := metadata.ColumnMeta{Name: "emb", DataType: "vector", ColumnType: "vector(4)"}
 	binCol := metadata.ColumnMeta{Name: "v", DataType: "binary", ColumnType: "binary(16)"}
 	binNoWidth := metadata.ColumnMeta{Name: "v", DataType: "binary"} // pre-#212 snapshot
 	varbinCol := metadata.ColumnMeta{Name: "v", DataType: "varbinary"}
@@ -152,6 +155,14 @@ func TestDeferredReprUnresolved(t *testing.T) {
 			ch(upd(map[string]any{"loc": "AAAA"})), true, false},
 		{"geometry with typing unavailable", []metadata.ColumnMeta{geoCol},
 			ch(upd(map[string]any{"loc": "AAAA"})), false, true},
+
+		// VECTOR: unresolved even when decoded — the baseline side stores the
+		// literal dump token, not the raw packed-float bytes, so a decoded
+		// event value can never be byte-faithful to the baseline rendering.
+		{"vector decoded stays unresolved", []metadata.ColumnMeta{vectorCol},
+			ch(upd(map[string]any{"emb": []byte{0, 0, 128, 63}})), true, true},
+		{"vector with typing unavailable", []metadata.ColumnMeta{vectorCol},
+			ch(upd(map[string]any{"emb": "AACAPw=="})), false, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/verify/render.go
+++ b/internal/verify/render.go
@@ -68,6 +68,25 @@ func renderCell(v any, col metadata.ColumnMeta) []byte {
 			return b
 		}
 	}
+	// A fixed BINARY(n) value from a binlog event image arrives STRIPPED of
+	// its trailing 0x00 padding: MySQL's ROW image length-prefixes
+	// MYSQL_TYPE_STRING with the ACTUAL stored length (go-mysql decodeString
+	// reads exactly that), while the baseline Parquet (mydumper) and the live
+	// source's protocol both carry the full padded n bytes. Right-pad to the
+	// declared width so a value that merely ends in 0x00 doesn't render
+	// shorter than the identical source value — every such row was a
+	// conclusive false MISMATCH (#1135). Baseline-origin values are already
+	// full width, so padding is a no-op there; on the live-scan side
+	// (normalizeRenderedBytes) the source value is always exactly n bytes, so
+	// the transform is identity by construction and needs no hook.
+	if strings.EqualFold(strings.TrimSpace(col.DataType), "binary") {
+		switch x := v.(type) {
+		case []byte:
+			return padFixedBinary(x, col)
+		case string:
+			return padFixedBinary([]byte(x), col)
+		}
+	}
 	switch x := v.(type) {
 	case json.Number:
 		// Binlog event integers/decimals are JSON-decoded as json.Number, whose
@@ -178,6 +197,32 @@ func renderBitBytes(v any, col metadata.ColumnMeta) ([]byte, bool) {
 	var buf [8]byte
 	binary.BigEndian.PutUint64(buf[:], u)
 	return buf[8-width:], true
+}
+
+// padFixedBinary right-pads b with 0x00 up to the declared width of a fixed
+// BINARY(n) column. When the width is unavailable (pre-#212 snapshot with an
+// empty ColumnType) b returns untouched — deferredValueUnresolved reports such
+// a value unresolved, so the comparison degrades to an honest Inconclusive
+// instead of a false MISMATCH. A value at or beyond the declared width is
+// NEVER truncated: it returns at its natural length, so a genuinely divergent
+// longer value still differs.
+func padFixedBinary(b []byte, col metadata.ColumnMeta) []byte {
+	width := fixedBinaryWidth(col.ColumnType)
+	if width == 0 || len(b) >= width {
+		return b
+	}
+	out := make([]byte, width) // zero-filled; copy leaves the 0x00 tail
+	copy(out, b)
+	return out
+}
+
+// fixedBinaryWidth returns the declared byte width of a "binary(N)"
+// column-type declaration, 0 when unavailable. Reuses temporalPrecision's
+// parenthesized-integer extraction — same "(N)" shape (cf. bitByteWidth).
+// BINARY(0) is legal but reported as unavailable; its only value is the empty
+// string, which renders identically on both sides anyway.
+func fixedBinaryWidth(columnType string) int {
+	return temporalPrecision(columnType)
 }
 
 // bitByteWidth returns ceil(M/8) for a "bit(M)" column-type declaration, 0

--- a/internal/verify/render.go
+++ b/internal/verify/render.go
@@ -206,6 +206,14 @@ func renderBitBytes(v any, col metadata.ColumnMeta) ([]byte, bool) {
 // instead of a false MISMATCH. A value at or beyond the declared width is
 // NEVER truncated: it returns at its natural length, so a genuinely divergent
 // longer value still differs.
+//
+// Unlike the adjacent BIT branch — which converts only numeric (i.e.
+// event-origin) values, leaving baseline-origin []byte untouched — this
+// padding is origin-blind: a baseline value that is short for some
+// non-padding reason would be silently padded too. Accepted because MySQL
+// only ever strips trailing 0x00 from a stored fixed BINARY(n) value, so
+// re-padding a short value reproduces the stored value exactly regardless of
+// which side produced it.
 func padFixedBinary(b []byte, col metadata.ColumnMeta) []byte {
 	width := fixedBinaryWidth(col.ColumnType)
 	if width == 0 || len(b) >= width {

--- a/internal/verify/render_test.go
+++ b/internal/verify/render_test.go
@@ -14,6 +14,67 @@ func col(dataType, columnType string) metadata.ColumnMeta {
 	return metadata.ColumnMeta{Name: "c", DataType: dataType, ColumnType: columnType}
 }
 
+// TestRenderCell_FixedBinaryPadding pins the #1135 fix: MySQL's ROW image
+// strips trailing 0x00 padding from a fixed BINARY(n) value (length-prefixed
+// with the actual stored length — empirically confirmed against MySQL 8.0),
+// while the baseline Parquet and the live source both carry the full n bytes.
+// renderCell must right-pad an event-origin value back to the declared width,
+// and must never truncate.
+func TestRenderCell_FixedBinaryPadding(t *testing.T) {
+	full := bytes.Repeat([]byte{0xab}, 16)
+	stripped := full[:15] // as captured when the 16th byte is 0x00
+	padded := append(bytes.Repeat([]byte{0xab}, 15), 0x00)
+
+	cases := []struct {
+		name string
+		v    any
+		col  metadata.ColumnMeta
+		want []byte
+	}{
+		{"short []byte padded to width", stripped, col("binary", "binary(16)"), padded},
+		{"short string padded to width", string(stripped), col("binary", "binary(16)"), padded},
+		{"full-width value is a no-op", full, col("binary", "binary(16)"), full},
+		{"longer value never truncated", bytes.Repeat([]byte{0xcd}, 20), col("binary", "binary(16)"), bytes.Repeat([]byte{0xcd}, 20)},
+		{"empty value padded to all-zero", []byte{}, col("binary", "binary(4)"), []byte{0, 0, 0, 0}},
+		{"unparseable ColumnType left untouched", stripped, col("binary", ""), stripped},
+		{"varbinary never padded", stripped, col("varbinary", "varbinary(16)"), stripped},
+		{"blob never padded", stripped, col("blob", "blob"), stripped},
+		{"NULL stays NULL", nil, col("binary", "binary(16)"), nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := renderCell(tc.v, tc.col); !bytes.Equal(got, tc.want) {
+				t.Errorf("renderCell = %x, want %x", got, tc.want)
+			}
+		})
+	}
+
+	// The normalized renderer (both verify modes and --explain render through
+	// it) must inherit the padding.
+	if got := renderCellNormalized(stripped, col("binary", "binary(16)")); !bytes.Equal(got, padded) {
+		t.Errorf("renderCellNormalized = %x, want %x", got, padded)
+	}
+}
+
+func TestFixedBinaryWidth(t *testing.T) {
+	cases := []struct {
+		columnType string
+		want       int
+	}{
+		{"binary(16)", 16},
+		{"binary(1)", 1},
+		{"binary", 0},
+		{"", 0},
+		{"binary()", 0},
+		{"binary(x)", 0},
+	}
+	for _, tc := range cases {
+		if got := fixedBinaryWidth(tc.columnType); got != tc.want {
+			t.Errorf("fixedBinaryWidth(%q) = %d, want %d", tc.columnType, got, tc.want)
+		}
+	}
+}
+
 func TestRenderCell_MatchesTextProtocolForm(t *testing.T) {
 	ts := time.Date(2021, 1, 1, 0, 0, 0, 123456000, time.UTC) // .123456
 	dt0 := time.Date(2022, 6, 15, 12, 30, 45, 0, time.UTC)

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -227,7 +227,11 @@ func VerifyTable(ctx context.Context, cfg Config, schema, table string) (TableRe
 	// divergence on an unrelated non-deferred column as Inconclusive whenever
 	// any event existed in the window. A row-count difference is always
 	// conclusive (real loss/gain) and is never masked by this.
-	deferredRepr := deferredReprUnresolved(orderedCols, changes, binariesTyped)
+	deferredCol, deferredRepr := deferredReprUnresolved(orderedCols, changes, binariesTyped)
+	var deferredDetail string
+	if deferredRepr {
+		deferredDetail = deferredReprDetail(deferredCol)
+	}
 
 	// Live-source verify is MySQL-only (PostgreSQL is refused upstream), so the
 	// PK canonicalizer always applies here — pgTextPK is false.
@@ -242,7 +246,7 @@ func VerifyTable(ctx context.Context, cfg Config, schema, table string) (TableRe
 	}
 
 	// 6. Compare.
-	status, detail := classify(res.SourceDigest, res.SourceRows, res.ReconstructDigest, res.ReconstructRows, deferredRepr)
+	status, detail := classify(res.SourceDigest, res.SourceRows, res.ReconstructDigest, res.ReconstructRows, deferredDetail)
 	res.Status = status
 	if detail != "" {
 		res.Detail = detail // a real reason overrides the coverage note
@@ -252,12 +256,13 @@ func VerifyTable(ctx context.Context, cfg Config, schema, table string) (TableRe
 
 // classify is the pure comparison core. Row count is checked first: a difference
 // is always a conclusive mismatch (real row loss/gain) and is NEVER downgraded by
-// deferredRepr — that ordering is the guard against masking data loss on a table
+// deferredDetail — that ordering is the guard against masking data loss on a table
 // that merely contains an ENUM/SET/JSON/binary column. At equal row count a
-// content difference is a mismatch, except when deferredRepr is set (a deferred
-// column may have changed and its event image isn't normalized yet), where it is
-// inconclusive rather than a false alarm.
-func classify(srcDigest string, srcRows int64, reconDigest string, reconRows int64, deferredRepr bool) (Status, string) {
+// content difference is a mismatch, except when deferredDetail is non-empty (a
+// deferred column carried a value the normalization passes could not resolve —
+// see deferredReprDetail, which names the column), where it is inconclusive
+// rather than a false alarm and deferredDetail is the reported reason.
+func classify(srcDigest string, srcRows int64, reconDigest string, reconRows int64, deferredDetail string) (Status, string) {
 	if reconRows != srcRows {
 		return StatusMismatch, fmt.Sprintf("row count differs: source=%d reconstructed=%d", srcRows, reconRows)
 	}
@@ -274,8 +279,8 @@ func classify(srcDigest string, srcRows int64, reconDigest string, reconRows int
 	if reconDigest == srcDigest {
 		return StatusMatch, ""
 	}
-	if deferredRepr {
-		return StatusInconclusive, "an event carried an ENUM/SET, JSON, binary or BIT value that could not be normalized to the baseline/source representation, so this content difference is not conclusive"
+	if deferredDetail != "" {
+		return StatusInconclusive, deferredDetail
 	}
 	return StatusMismatch, "content digest differs at equal row count (in-place value divergence)"
 }
@@ -340,7 +345,11 @@ func inconclusive(res TableResult, detail string) TableResult {
 // DecodeEventBinaries' report — false means some event's BLOB/BINARY values
 // may still be stored base64 (epoch typing unavailable), so any non-nil
 // binary-family value stays unresolved.
-func deferredReprUnresolved(cols []metadata.ColumnMeta, changes map[string]*query.ResultRow, binariesTyped bool) bool {
+//
+// On unresolved=true, col is the first unresolved column found — so the
+// Inconclusive reason can name the actual column and type instead of a generic
+// type list that may name none of the table's columns (#1136).
+func deferredReprUnresolved(cols []metadata.ColumnMeta, changes map[string]*query.ResultRow, binariesTyped bool) (col metadata.ColumnMeta, unresolved bool) {
 	var deferredCols []metadata.ColumnMeta
 	for _, c := range cols {
 		if isDeferredType(c.DataType) {
@@ -348,7 +357,7 @@ func deferredReprUnresolved(cols []metadata.ColumnMeta, changes map[string]*quer
 		}
 	}
 	if len(deferredCols) == 0 {
-		return false
+		return metadata.ColumnMeta{}, false
 	}
 	for _, ev := range changes {
 		if ev.EventType != event.EventInsert && ev.EventType != event.EventUpdate {
@@ -360,11 +369,22 @@ func deferredReprUnresolved(cols []metadata.ColumnMeta, changes map[string]*quer
 				continue // absent/NULL renders identically on both sides
 			}
 			if deferredValueUnresolved(v, c, binariesTyped) {
-				return true
+				return c, true
 			}
 		}
 	}
-	return false
+	return metadata.ColumnMeta{}, false
+}
+
+// deferredReprDetail is the Inconclusive reason for an unresolved
+// deferred-representation value, naming the specific column and its type. The
+// static list this replaced ("an ENUM/SET, JSON, binary or BIT value") was
+// actively misleading on a table whose unresolved column is none of those —
+// e.g. a POINT column (#1136) sent the reader hunting for an ENUM that does
+// not exist.
+func deferredReprDetail(c metadata.ColumnMeta) string {
+	return fmt.Sprintf("an event carried a value for column %q (%s) that could not be normalized to the baseline/source representation, so this content difference is not conclusive",
+		c.Name, strings.ToLower(strings.TrimSpace(c.DataType)))
 }
 
 // deferredValueUnresolved reports whether one deferred-typed value is still in
@@ -405,7 +425,34 @@ func deferredValueUnresolved(v any, c metadata.ColumnMeta, binariesTyped bool) b
 		// source/baseline text keeps "1.0" — and after the round-trip the
 		// integer form is indistinguishable from a genuine integer.
 		return !jsonRenderConclusive(renderCell(v, c))
-	case "binary", "varbinary", "blob", "tinyblob", "mediumblob", "longblob":
+	case "binary":
+		// Fixed BINARY(n): the event image strips trailing 0x00 padding
+		// (MySQL length-prefixes MYSQL_TYPE_STRING with the actual stored
+		// length), which renderCell reverses by right-padding to the declared
+		// width (#1135). Resolvable only when the decode pass had epoch
+		// typing AND the width is known: an empty/unparseable ColumnType
+		// (pre-#212 snapshot) leaves the pad width unknown, so the value
+		// stays unresolved — an honest Inconclusive instead of a false
+		// MISMATCH on any value that merely ends in 0x00.
+		if !binariesTyped {
+			return true // may still be stored base64 — DecodeEventBinaries degraded
+		}
+		switch v.(type) {
+		case string, []byte:
+			return fixedBinaryWidth(c.ColumnType) == 0
+		default:
+			return true // #736 mis-promotion leftover the decode pass could not restore
+		}
+	case "varbinary", "blob", "tinyblob", "mediumblob", "longblob",
+		// Spatial family + VECTOR: binary in the event image (4-byte SRID +
+		// WKB / packed floats), decoded by the same DecodeEventBinaries pass
+		// as BLOB since #1136. Once decoded, the raw bytes are exactly what
+		// the source SELECT and the mydumper baseline carry — no padding
+		// concern (spatial values have no fixed declared width), so they
+		// resolve like BLOB.
+		"geometry", "point", "linestring", "polygon",
+		"multipoint", "multilinestring", "multipolygon",
+		"geometrycollection", "geomcollection", "vector":
 		if !binariesTyped {
 			return true // may still be stored base64 — DecodeEventBinaries degraded
 		}
@@ -416,8 +463,8 @@ func deferredValueUnresolved(v any, c metadata.ColumnMeta, binariesTyped bool) b
 			return true // #736 mis-promotion leftover the decode pass could not restore
 		}
 	default:
-		// Spatial family + VECTOR: []byte (WKB / packed floats) → stored
-		// base64, and no event-side decode exists for them yet (#793).
+		// isDeferredType enumerates every deferred type in the cases above;
+		// anything else reaching here is unknown — unsure means unresolved.
 		return true
 	}
 }
@@ -470,8 +517,9 @@ func isASCII(s string) bool {
 // from how the baseline/source renders it in a way this version doesn't yet
 // normalize: ENUM/SET (ordinal vs label), JSON (MySQL-canonical text), binary
 // families (base64 in the event image vs raw bytes), BIT, and the spatial and
-// VECTOR types — whose values are binary (WKB / packed floats) in the event
-// image and so carry the same base64-vs-raw representation gap as BLOB (#793).
+// VECTOR types — binary (SRID+WKB / packed floats) in the event image, decoded
+// by DecodeEventBinaries like BLOB since #1136 but still gated here for when
+// the epoch-typed decode degrades (binariesTyped=false), same as BLOB.
 //
 // TEXT is deliberately NOT here, despite being decoded by the same
 // DecodeEventBinaries call as BLOB (#672): once decoded, a TEXT value is just
@@ -488,7 +536,9 @@ func isDeferredType(dataType string) bool {
 	case "enum", "set", "json",
 		"binary", "varbinary", "blob", "tinyblob", "mediumblob", "longblob", "bit",
 		// Spatial family (DATA_TYPE as reported by information_schema.COLUMNS)
-		// plus MySQL 9.0+ VECTOR: binary in the event image, no normalization yet.
+		// plus MySQL 9.0+ VECTOR: binary in the event image, decoded by
+		// DecodeEventBinaries like BLOB (#1136) — still deferred for the
+		// binariesTyped=false degradation, same as the binary families above.
 		"geometry", "point", "linestring", "polygon",
 		"multipoint", "multilinestring", "multipolygon",
 		// MySQL 8.0.11+ (WL#2388) reports a GEOMETRYCOLLECTION column's DATA_TYPE

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -359,11 +359,17 @@ func deferredReprUnresolved(cols []metadata.ColumnMeta, changes map[string]*quer
 	if len(deferredCols) == 0 {
 		return metadata.ColumnMeta{}, false
 	}
-	for _, ev := range changes {
-		if ev.EventType != event.EventInsert && ev.EventType != event.EventUpdate {
-			continue
-		}
-		for _, c := range deferredCols {
+	// Column-outer iteration (not changes-outer): changes is a map, whose
+	// iteration order varies run to run, so with more than one unresolved
+	// column a map-outer walk would name a different column on each run —
+	// making the Inconclusive Detail (and verify --format json) non-
+	// reproducible. Walking deferredCols first pins the named column to the
+	// source column order the caller passed in.
+	for _, c := range deferredCols {
+		for _, ev := range changes {
+			if ev.EventType != event.EventInsert && ev.EventType != event.EventUpdate {
+				continue
+			}
 			v, present := ev.RowAfter[c.Name]
 			if !present || v == nil {
 				continue // absent/NULL renders identically on both sides
@@ -444,15 +450,16 @@ func deferredValueUnresolved(v any, c metadata.ColumnMeta, binariesTyped bool) b
 			return true // #736 mis-promotion leftover the decode pass could not restore
 		}
 	case "varbinary", "blob", "tinyblob", "mediumblob", "longblob",
-		// Spatial family + VECTOR: binary in the event image (4-byte SRID +
-		// WKB / packed floats), decoded by the same DecodeEventBinaries pass
-		// as BLOB since #1136. Once decoded, the raw bytes are exactly what
-		// the source SELECT and the mydumper baseline carry — no padding
-		// concern (spatial values have no fixed declared width), so they
-		// resolve like BLOB.
+		// Spatial family: binary in the event image (4-byte SRID + WKB),
+		// decoded by the same DecodeEventBinaries pass as BLOB since #1136.
+		// Once decoded, the raw bytes are exactly what the source SELECT and
+		// the mydumper baseline carry — internal/baseline routes the spatial
+		// family through its binary/decodeBinaryLiteral path, so baseline
+		// bytes == decoded event bytes. No padding concern (spatial values
+		// have no fixed declared width), so they resolve like BLOB.
 		"geometry", "point", "linestring", "polygon",
 		"multipoint", "multilinestring", "multipolygon",
-		"geometrycollection", "geomcollection", "vector":
+		"geometrycollection", "geomcollection":
 		if !binariesTyped {
 			return true // may still be stored base64 — DecodeEventBinaries degraded
 		}
@@ -462,6 +469,18 @@ func deferredValueUnresolved(v any, c metadata.ColumnMeta, binariesTyped bool) b
 		default:
 			return true // #736 mis-promotion leftover the decode pass could not restore
 		}
+	case "vector":
+		// VECTOR (MySQL 9.0+) is decoded by DecodeEventBinaries like BLOB
+		// (base64StoredKind), but it stays UNRESOLVED here because of a
+		// baseline-side asymmetry the spatial family does not have:
+		// internal/baseline's binary column list (mysqlToParquetNode's
+		// ByteArray case and the writer's decodeBinaryLiteral routing) covers
+		// geometry and its subtypes but NOT "vector", so a VECTOR baseline
+		// column stores the literal dump token (e.g. the ASCII "0x…" text of
+		// a --hex-blob dump), not the raw packed-float bytes. Resolving the
+		// event side would turn today's honest Inconclusive into a conclusive
+		// false MISMATCH on identical data.
+		return true
 	default:
 		// isDeferredType enumerates every deferred type in the cases above;
 		// anything else reaching here is unknown — unsure means unresolved.
@@ -516,10 +535,12 @@ func isASCII(s string) bool {
 // isDeferredType reports whether a column's event-image representation can differ
 // from how the baseline/source renders it in a way this version doesn't yet
 // normalize: ENUM/SET (ordinal vs label), JSON (MySQL-canonical text), binary
-// families (base64 in the event image vs raw bytes), BIT, and the spatial and
-// VECTOR types — binary (SRID+WKB / packed floats) in the event image, decoded
-// by DecodeEventBinaries like BLOB since #1136 but still gated here for when
-// the epoch-typed decode degrades (binariesTyped=false), same as BLOB.
+// families (base64 in the event image vs raw bytes), BIT, the spatial family —
+// binary (SRID+WKB) in the event image, decoded by DecodeEventBinaries like
+// BLOB since #1136 but still gated here for when the epoch-typed decode
+// degrades (binariesTyped=false) — and VECTOR, which additionally stays
+// permanently unresolved (see deferredValueUnresolved's vector case: the
+// baseline side does not store its raw bytes).
 //
 // TEXT is deliberately NOT here, despite being decoded by the same
 // DecodeEventBinaries call as BLOB (#672): once decoded, a TEXT value is just
@@ -537,8 +558,9 @@ func isDeferredType(dataType string) bool {
 		"binary", "varbinary", "blob", "tinyblob", "mediumblob", "longblob", "bit",
 		// Spatial family (DATA_TYPE as reported by information_schema.COLUMNS)
 		// plus MySQL 9.0+ VECTOR: binary in the event image, decoded by
-		// DecodeEventBinaries like BLOB (#1136) — still deferred for the
-		// binariesTyped=false degradation, same as the binary families above.
+		// DecodeEventBinaries like BLOB (#1136). Spatial defers only for the
+		// binariesTyped=false degradation; VECTOR is permanently unresolved
+		// (see deferredValueUnresolved's vector case).
 		"geometry", "point", "linestring", "polygon",
 		"multipoint", "multilinestring", "multipolygon",
 		// MySQL 8.0.11+ (WL#2388) reports a GEOMETRYCOLLECTION column's DATA_TYPE

--- a/internal/verify/verify_baseline.go
+++ b/internal/verify/verify_baseline.go
@@ -237,7 +237,11 @@ func VerifyBaselinePair(ctx context.Context, cfg BaselineConfig, p BaselinePair)
 	// that old gate: a FULL row image carries every column, so what matters is
 	// whether a deferred value an event CARRIED is still unmappable — not
 	// whether the column was listed as changed.
-	deferredRepr := deferredReprUnresolved(orderedCols, changes, binariesTyped)
+	deferredCol, deferredRepr := deferredReprUnresolved(orderedCols, changes, binariesTyped)
+	var deferredDetail string
+	if deferredRepr {
+		deferredDetail = deferredReprDetail(deferredCol)
+	}
 
 	// Recovery side: reconstruct the previous baseline forward to the anchor.
 	// renderCellNormalized (not plain renderCell): both operands here come
@@ -260,7 +264,7 @@ func VerifyBaselinePair(ctx context.Context, cfg BaselineConfig, p BaselinePair)
 	res.ReconstructDigest = reconDigest
 	res.ReconstructRows = reconCount
 
-	res.Status, res.Detail = classify(newDigest, newCount, reconDigest, reconCount, deferredRepr)
+	res.Status, res.Detail = classify(newDigest, newCount, reconDigest, reconCount, deferredDetail)
 	return res, nil
 }
 

--- a/internal/verify/verify_binary_spatial_integration_test.go
+++ b/internal/verify/verify_binary_spatial_integration_test.go
@@ -1,0 +1,207 @@
+//go:build integration
+
+package verify
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/baseline"
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// MySQL's internal geometry representation (4-byte SRID + WKB) for two POINT
+// values, captured from a real MySQL 8.0 `SELECT` / binlog row image. The
+// binlog event image, a raw source SELECT, and a mydumper baseline all carry
+// exactly these bytes.
+const (
+	pointHex3040 = "0000000001010000000000000000003e400000000000004440" // POINT(30, 40)
+	pointHex1020 = "000000000101000000000000000000244000000000000034c0" // POINT(10, -20)
+)
+
+// binarySpatialFixture builds the shared harness for the #1135/#1136
+// live-source verify repros: an index DB with schema snapshot + partitions +
+// stream_state, a live source table, a one-row-per-PK baseline Parquet, and
+// one UPDATE event for pk=1. colType is the snapshot's COLUMN_TYPE for the
+// value column v (e.g. "binary(16)", "point", or "" for a pre-#212 snapshot).
+//
+// baselineVals are hex-encoded raw bytes per PK; sourceVals are SQL value
+// expressions per PK (UNHEX(...) for binary, POINT(...) for spatial — a
+// geometry column rejects raw bytes on INSERT); eventAfterHex is the hex of
+// the bytes the binlog row image carries for pk=1's new value — stored
+// base64-encoded in row_after exactly as marshalRow stores a []byte.
+func binarySpatialFixture(t *testing.T, dataType, colType, createColSQL string, baselineVals, sourceVals map[string]string, eventAfterHex, eventBeforeHex string) (Config, string) {
+	t.Helper()
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	testutil.MustExec(t, db, `INSERT INTO schema_snapshots
+		(snapshot_id, snapshot_time, schema_name, table_name, column_name, ordinal_position, column_key, data_type, column_type, is_nullable, is_generated)
+		VALUES (1, UTC_TIMESTAMP(), ?, 'orders', 'id', 1, 'PRI', 'int', 'int', 'NO', 0)`, dbName)
+	testutil.MustExec(t, db, `INSERT INTO schema_snapshots
+		(snapshot_id, snapshot_time, schema_name, table_name, column_name, ordinal_position, column_key, data_type, column_type, is_nullable, is_generated)
+		VALUES (1, UTC_TIMESTAMP(), ?, 'orders', 'v', 2, '', ?, ?, 'YES', 0)`, dbName, dataType, colType)
+
+	// ── live SOURCE table at the FINAL (post-event) state ──
+	testutil.MustExec(t, db, fmt.Sprintf(
+		"CREATE TABLE `%s`.`orders` (`id` INT PRIMARY KEY, `v` %s)", dbName, createColSQL))
+	for pk, expr := range sourceVals {
+		testutil.MustExec(t, db, fmt.Sprintf(
+			"INSERT INTO `%s`.`orders` (id, v) VALUES (%s, %s)", dbName, pk, expr))
+	}
+
+	// ── baseline Parquet at the INITIAL state ──
+	createSQL := fmt.Sprintf("CREATE TABLE `orders` (\n  `id` INT NOT NULL,\n  `v` %s,\n  PRIMARY KEY (`id`)\n);\n", createColSQL)
+	baselineDir := t.TempDir()
+	now := time.Now().UTC()
+	curHour := now.Truncate(time.Hour)
+	h1 := curHour.Add(-time.Hour)
+	h2 := curHour
+	tsDir := strings.ReplaceAll(h1.Format(time.RFC3339), ":", "-")
+	parquetDir := filepath.Join(baselineDir, tsDir, dbName)
+	if err := os.MkdirAll(parquetDir, 0o755); err != nil {
+		t.Fatalf("mkdir baseline: %v", err)
+	}
+	cols := []baseline.Column{
+		{Name: "id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
+		{Name: "v", MySQLType: dataType, ParquetType: baseline.MysqlToParquetNode(dataType)},
+	}
+	bw, err := baseline.NewWriter(filepath.Join(parquetDir, "orders.parquet"), cols,
+		baseline.WriterConfig{Compression: "zstd", RowGroupSize: 100,
+			Metadata: map[string]string{baseline.MetaKeyCreateTableSQL: createSQL}})
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	for pk, hx := range baselineVals {
+		// "0x<hex>" is the mydumper --hex-blob literal form the baseline
+		// writer decodes for binary-family columns.
+		if err := bw.WriteRow([]string{pk, "0x" + strings.ToUpper(hx)}, []bool{false, false}); err != nil {
+			t.Fatalf("WriteRow: %v", err)
+		}
+	}
+	if err := bw.Close(); err != nil {
+		t.Fatalf("baseline close: %v", err)
+	}
+
+	// ── binlog event: pk=1's v updated; []byte values are stored base64 ──
+	b64hex := func(hx string) string {
+		raw, err := hex.DecodeString(hx)
+		if err != nil {
+			t.Fatalf("bad hex %q: %v", hx, err)
+		}
+		return base64.StdEncoding.EncodeToString(raw)
+	}
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{h1, h2})
+	ts := now.Add(-1 * time.Minute).Format("2006-01-02 15:04:05")
+	testutil.InsertEvent(t, db, "binlog.000001", 100, 200, ts, nil, dbName, "orders", 2 /*UPDATE*/, "1", []byte(`["v"]`),
+		[]byte(fmt.Sprintf(`{"id":1,"v":"%s"}`, b64hex(eventBeforeHex))),
+		[]byte(fmt.Sprintf(`{"id":1,"v":"%s"}`, b64hex(eventAfterHex))))
+
+	// ── stream_state with a GTID superset so the coverage check passes ──
+	var uuid string
+	if err := db.QueryRow("SELECT @@server_uuid").Scan(&uuid); err != nil {
+		t.Fatalf("server_uuid: %v", err)
+	}
+	testutil.MustExec(t, db, `INSERT INTO stream_state
+		(id, mode, gtid_set, last_checkpoint, server_id)
+		VALUES (1, 'gtid', ?, UTC_TIMESTAMP(), 1)`, uuid+":1-1000000")
+
+	resolver, err := metadata.NewResolver(db, 1)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+	return Config{
+		SourceDB: db, IndexDB: db, Resolver: resolver,
+		BaselineSource: baselineDir, IndexDBName: dbName, NoArchive: true,
+	}, dbName
+}
+
+// TestVerifyTable_FixedBinaryTrailingZero_Match is the #1135 repro: a
+// BINARY(16) value whose stored bytes end in 0x00 is captured STRIPPED of that
+// trailing padding in the ROW image (MySQL length-prefixes MYSQL_TYPE_STRING
+// with the actual stored length — empirically confirmed against MySQL 8.0),
+// while the live source and the baseline carry the full 16 bytes. Without the
+// renderCell padding, the event-touched row rendered 15 bytes against the
+// source's 16 and every such table was a conclusive false MISMATCH.
+func TestVerifyTable_FixedBinaryTrailingZero_Match(t *testing.T) {
+	newVal := strings.Repeat("ab", 15) + "00" // 16 bytes, ends in 0x00
+	oldVal := strings.Repeat("cd", 16)        // 16 bytes, no trailing zero
+	untouched := strings.Repeat("ef", 14) + "0000"
+
+	cfg, dbName := binarySpatialFixture(t, "binary", "binary(16)", "BINARY(16)",
+		map[string]string{"1": oldVal, "2": untouched},
+		map[string]string{"1": "UNHEX('" + newVal + "')", "2": "UNHEX('" + untouched + "')"},
+		newVal[:30], // captured image: trailing 0x00 stripped → 15 bytes
+		oldVal)      // before-image: no trailing zero → full 16 bytes
+
+	got, err := VerifyTable(context.Background(), cfg, dbName, "orders")
+	if err != nil {
+		t.Fatalf("VerifyTable: %v", err)
+	}
+	if got.Status != StatusMatch {
+		t.Fatalf("status = %q (%s); want match — the event-touched BINARY(16) value ending in 0x00 must render at the declared width",
+			got.Status, got.Detail)
+	}
+}
+
+// TestVerifyTable_FixedBinaryNoWidth_InconclusiveNamesColumn: with a pre-#212
+// snapshot (empty COLUMN_TYPE) the pad width is unknown, so the same repro
+// must degrade to an HONEST Inconclusive — never a conclusive false MISMATCH —
+// and the reason must name the actual column and type (#1136 part 1), not the
+// old static "ENUM/SET, JSON, binary or BIT" list.
+func TestVerifyTable_FixedBinaryNoWidth_InconclusiveNamesColumn(t *testing.T) {
+	newVal := strings.Repeat("ab", 15) + "00"
+	oldVal := strings.Repeat("cd", 16)
+
+	cfg, dbName := binarySpatialFixture(t, "binary", "" /* pre-#212 snapshot */, "BINARY(16)",
+		map[string]string{"1": oldVal},
+		map[string]string{"1": "UNHEX('" + newVal + "')"},
+		newVal[:30],
+		oldVal)
+
+	got, err := VerifyTable(context.Background(), cfg, dbName, "orders")
+	if err != nil {
+		t.Fatalf("VerifyTable: %v", err)
+	}
+	if got.Status != StatusInconclusive {
+		t.Fatalf("status = %q (%s); want inconclusive (unknown pad width must not be a conclusive mismatch)", got.Status, got.Detail)
+	}
+	if !strings.Contains(got.Detail, `column "v" (binary)`) {
+		t.Errorf("detail = %q; want it to name the unresolved column and type (column \"v\" (binary))", got.Detail)
+	}
+}
+
+// TestVerifyTable_PointEventDecoded_Match is the #1136 repro: a POINT column
+// touched by an UPDATE must verify `match`. The event image's []byte (4-byte
+// SRID + WKB) is stored base64 like BLOB; with the spatial family added to
+// base64StoredKind, DecodeEventBinaries restores exactly the bytes a raw
+// source SELECT and the baseline carry, so the digests agree. Before the fix
+// this table was permanently `inconclusive` the moment it took a write.
+func TestVerifyTable_PointEventDecoded_Match(t *testing.T) {
+	cfg, dbName := binarySpatialFixture(t, "point", "point", "POINT",
+		map[string]string{"1": pointHex1020},
+		map[string]string{"1": "POINT(30, 40)"},
+		pointHex3040,
+		pointHex1020)
+
+	got, err := VerifyTable(context.Background(), cfg, dbName, "orders")
+	if err != nil {
+		t.Fatalf("VerifyTable: %v", err)
+	}
+	if got.Status != StatusMatch {
+		t.Fatalf("status = %q (%s); want match — the event's POINT bytes must decode to the same SRID+WKB the source serves",
+			got.Status, got.Detail)
+	}
+}


### PR DESCRIPTION
Closes #1135
Closes #1136

## Root cause 1 — BINARY(n) false MISMATCH (#1135)

MySQL's ROW binlog image length-prefixes `MYSQL_TYPE_STRING` (CHAR/BINARY) values with the **actual stored length**, stripping the trailing `0x00` padding of a fixed `BINARY(n)` value. Empirically confirmed against MySQL 8.0 through the real capture path: a `BINARY(16)` value ending in one `0x00` arrives in the row image as 15 bytes; two trailing zeros → 14 bytes. The live source scan and the mydumper baseline both carry the full padded n bytes, so any event-touched row whose value merely ends in `0x00` (~1/256 of random values, matching the issue's ~300-updated-rows repro) rendered shorter on the reconstruct side and produced a **conclusive false mismatch**. `VARBINARY`/`BLOB` have no padding, which is why they verified fine.

Fix (`internal/verify/render.go`, `verify.go`):
- `renderCell` right-pads an event-origin fixed `BINARY` value with `0x00` to the declared width parsed from `ColumnType` (`binary(16)` → 16, same parenthesized-integer extraction as `temporalPrecision`/`bitByteWidth`). Baseline-origin values are already full width (no-op); a longer value is **never truncated**; the live-scan side needs no hook because a source value is always exactly n bytes.
- `deferredValueUnresolved`: a fixed `BINARY` value resolves only when the width is parseable; an empty/unparseable `ColumnType` (pre-#212 snapshot) reports unresolved → honest `inconclusive` instead of a false mismatch.
- This also closes the same false-diff in the baseline-pair mode and `--explain`, which render through `renderCellNormalized` → `renderCell`.

## Root cause 2 — spatial columns (#1136)

go-mysql delivers the spatial family + `VECTOR` as `[]byte` (MySQL's internal 4-byte SRID + WKB / packed floats — confirmed: a captured `POINT` is exactly the 25 bytes a raw source `SELECT` returns), which the indexer stores base64 like BLOB. But those types were missing from `base64StoredKind`, so `DecodeEventBinaries` never decoded them and any event-touched spatial table was **permanently inconclusive** — with a reason naming "ENUM/SET, JSON, binary or BIT", types the table need not contain.

Fix:
- `internal/reconstruct/fulltable.go`: spatial family + `vector` added to `base64StoredKind` as binary, so `DecodeEventBinaries` restores the raw SRID+WKB bytes — exactly what the source `SELECT` and the mydumper baseline carry (the issue's untouched-table `match` proves baseline == source representation), so these tables now verify `match`.
- `internal/verify`: the spatial family moves out of the always-unresolved branch into the binary-family case (resolved when the epoch-typed decode succeeded); it stays in `isDeferredType` for when the decode degrades. **`VECTOR` deliberately stays unresolved** (review finding): `internal/baseline` does not route `vector` through its binary/`decodeBinaryLiteral` path, so a VECTOR baseline column stores the literal dump token rather than raw bytes — resolving the event side would turn today's honest Inconclusive into a conclusive false MISMATCH on identical data. It keeps the `base64StoredKind` decode (reconstruct/mydumper benefit) with a comment naming the baseline-side asymmetry.
- The Inconclusive reason now names the actual column: `deferredReprUnresolved` returns the unresolved column, and `classify` reports e.g. `an event carried a value for column "v" (point) that could not be normalized to the baseline/source representation, so this content difference is not conclusive` — in both live-source and baseline-pair modes.

## Behavior change outside verify

`DecodeEventBinaries` consumers (single-row and full-table reconstruct, console Time-travel, MCP `reconstruct`, shim `_snapshot` fold path) now emit **raw geometry bytes** instead of the stored base64 text. That is the correct value: JSON output re-base64s `[]byte` via `json.Marshal` (unchanged on the wire), and mydumper output becomes actually restorable. The sibling `base64StoredKind` copies in `internal/recovery` and `internal/shim` are deliberately untouched — the remaining gaps there (shim spatial decode; recover VECTOR reversal — geometry reversal was already handled via `ST_GeomFromWKB`, #788) are tracked in #1144.

## Review follow-ups (second commit)

- VECTOR back to unresolved in `deferredValueUnresolved` (baseline-side asymmetry above).
- Deterministic Inconclusive detail: `deferredReprUnresolved` walks deferred columns in the outer loop (schema order), so the named column no longer depends on map iteration order.
- `padFixedBinary` documents that the padding is origin-blind (accepted: MySQL only ever strips trailing 0x00, so re-padding reproduces the stored value exactly).
- Unit test pinning the spatial/vector `base64StoredKind` entries in `internal/reconstruct`; vector cases added to the deferred-gate table test.

## Tests

- New integration repros (written first, confirmed to fail on unfixed code with exactly the issues' symptoms): `TestVerifyTable_FixedBinaryTrailingZero_Match` (was `mismatch`), `TestVerifyTable_FixedBinaryNoWidth_InconclusiveNamesColumn` (was `mismatch`), `TestVerifyTable_PointEventDecoded_Match` (was `inconclusive` with the misleading message).
- New unit tests: `renderCell` padding matrix (pad/no-op/never-truncate/unparseable width/varbinary-blob untouched), `fixedBinaryWidth`, `deferredReprDetail` message contract, updated `deferredReprUnresolved` and `classify` tables (including: the deferred detail passes through verbatim, row-count loss still conclusive).
- `go build ./...`, `go vet ./...`, `go vet -tags integration ./...`, full unit suite, `-race` on `internal/verify` + `internal/reconstruct`, and integration suites for `internal/verify`, `internal/reconstruct`, `internal/shim`, `internal/mcptools`, `internal/console`, `internal/cli` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
