### PR TITLE
env: raise scanner buffer to 1MiB and surface Scanner errors in env-file loader

### DIFF
--- a/consoleapp/env.go
+++ b/consoleapp/env.go
@@ -52,6 +52,9 @@ func loadEnvFile() {
 // Variables already set in the environment are not overwritten.
 func parseAndSetEnv(data string) {
 	scanner := bufio.NewScanner(strings.NewReader(data))
+	// Allow long values (base64 keys, DSN lists): the default 64KiB token
+	// limit would abort the scan silently. See scanner.Err() check below.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if line == "" || line[0] == '#' {
@@ -77,5 +80,8 @@ func parseAndSetEnv(data string) {
 		if _, exists := os.LookupEnv(key); !exists {
 			os.Setenv(key, val)
 		}
+	}
+	if err := scanner.Err(); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: stopped reading env file (%v): variables after this point were NOT loaded\n", err)
 	}
 }

--- a/consoleapp/env_test.go
+++ b/consoleapp/env_test.go
@@ -1,0 +1,72 @@
+package consoleapp
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+// captureStderr runs fn with os.Stderr redirected to a pipe and returns
+// everything fn wrote to it.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = w
+	defer func() { os.Stderr = old }()
+	fn()
+	w.Close()
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(out)
+}
+
+func TestParseAndSetEnvLongLines(t *testing.T) {
+	t.Run("100KiB value loads and later vars survive", func(t *testing.T) {
+		// Exceeds bufio.Scanner's default 64KiB token limit: before the
+		// buffer raise this dropped LONG and every variable after it.
+		t.Setenv("TEST_CONSOLE_PARSE_LONG", "")
+		os.Unsetenv("TEST_CONSOLE_PARSE_LONG")
+		t.Setenv("TEST_CONSOLE_PARSE_AFTER_LONG", "")
+		os.Unsetenv("TEST_CONSOLE_PARSE_AFTER_LONG")
+		longVal := strings.Repeat("a", 100*1024)
+		stderr := captureStderr(t, func() {
+			parseAndSetEnv("TEST_CONSOLE_PARSE_LONG=" + longVal + "\nTEST_CONSOLE_PARSE_AFTER_LONG=survived")
+		})
+		if got := os.Getenv("TEST_CONSOLE_PARSE_LONG"); got != longVal {
+			t.Errorf("long value: got %d bytes, want %d", len(got), len(longVal))
+		}
+		if got := os.Getenv("TEST_CONSOLE_PARSE_AFTER_LONG"); got != "survived" {
+			t.Errorf("var after long line: got %q, want %q", got, "survived")
+		}
+		if strings.Contains(stderr, "NOT loaded") {
+			t.Errorf("unexpected scanner warning for 100KiB value: %s", stderr)
+		}
+	})
+
+	t.Run("line over 1MiB warns loudly", func(t *testing.T) {
+		t.Setenv("TEST_CONSOLE_PARSE_BEFORE_HUGE", "")
+		os.Unsetenv("TEST_CONSOLE_PARSE_BEFORE_HUGE")
+		t.Setenv("TEST_CONSOLE_PARSE_AFTER_HUGE", "")
+		os.Unsetenv("TEST_CONSOLE_PARSE_AFTER_HUGE")
+		hugeVal := strings.Repeat("a", 1024*1024+1)
+		stderr := captureStderr(t, func() {
+			parseAndSetEnv("TEST_CONSOLE_PARSE_BEFORE_HUGE=ok\nTEST_CONSOLE_PARSE_HUGE=" + hugeVal + "\nTEST_CONSOLE_PARSE_AFTER_HUGE=lost")
+		})
+		if got := os.Getenv("TEST_CONSOLE_PARSE_BEFORE_HUGE"); got != "ok" {
+			t.Errorf("var before huge line: got %q, want %q", got, "ok")
+		}
+		if !strings.Contains(stderr, "NOT loaded") {
+			t.Errorf("expected loud warning about unloaded variables, got: %q", stderr)
+		}
+		if _, ok := os.LookupEnv("TEST_CONSOLE_PARSE_AFTER_HUGE"); ok {
+			t.Error("var after huge line unexpectedly loaded; warning would be a lie")
+		}
+	})
+}

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -104,6 +104,9 @@ func loadEnvFile() {
 // Variables already set in the environment are not overwritten.
 func parseAndSetEnv(data string) {
 	scanner := bufio.NewScanner(strings.NewReader(data))
+	// Allow long values (base64 keys, DSN lists): the default 64KiB token
+	// limit would abort the scan silently. See scanner.Err() check below.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if line == "" || line[0] == '#' {
@@ -129,6 +132,9 @@ func parseAndSetEnv(data string) {
 		if _, exists := os.LookupEnv(key); !exists {
 			os.Setenv(key, val)
 		}
+	}
+	if err := scanner.Err(); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: stopped reading env file (%v): variables after this point were NOT loaded\n", err)
 	}
 }
 

--- a/internal/cli/env_test.go
+++ b/internal/cli/env_test.go
@@ -1,11 +1,33 @@
 package cli
 
 import (
+	"io"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
 )
+
+// captureStderr runs fn with os.Stderr redirected to a pipe and returns
+// everything fn wrote to it.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = w
+	defer func() { os.Stderr = old }()
+	fn()
+	w.Close()
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(out)
+}
 
 func TestParseAndSetEnv(t *testing.T) {
 	t.Run("basic key=value", func(t *testing.T) {
@@ -79,6 +101,48 @@ func TestParseAndSetEnv(t *testing.T) {
 		parseAndSetEnv("  TEST_PARSE_WS  =  trimmed  ")
 		if got := os.Getenv("TEST_PARSE_WS"); got != "trimmed" {
 			t.Errorf("got %q, want %q", got, "trimmed")
+		}
+	})
+
+	t.Run("100KiB value loads and later vars survive", func(t *testing.T) {
+		// Exceeds bufio.Scanner's default 64KiB token limit: before the
+		// buffer raise this dropped LONG and every variable after it.
+		t.Setenv("TEST_PARSE_LONG", "")
+		os.Unsetenv("TEST_PARSE_LONG")
+		t.Setenv("TEST_PARSE_AFTER_LONG", "")
+		os.Unsetenv("TEST_PARSE_AFTER_LONG")
+		longVal := strings.Repeat("a", 100*1024)
+		stderr := captureStderr(t, func() {
+			parseAndSetEnv("TEST_PARSE_LONG=" + longVal + "\nTEST_PARSE_AFTER_LONG=survived")
+		})
+		if got := os.Getenv("TEST_PARSE_LONG"); got != longVal {
+			t.Errorf("long value: got %d bytes, want %d", len(got), len(longVal))
+		}
+		if got := os.Getenv("TEST_PARSE_AFTER_LONG"); got != "survived" {
+			t.Errorf("var after long line: got %q, want %q", got, "survived")
+		}
+		if strings.Contains(stderr, "NOT loaded") {
+			t.Errorf("unexpected scanner warning for 100KiB value: %s", stderr)
+		}
+	})
+
+	t.Run("line over 1MiB warns loudly", func(t *testing.T) {
+		t.Setenv("TEST_PARSE_BEFORE_HUGE", "")
+		os.Unsetenv("TEST_PARSE_BEFORE_HUGE")
+		t.Setenv("TEST_PARSE_AFTER_HUGE", "")
+		os.Unsetenv("TEST_PARSE_AFTER_HUGE")
+		hugeVal := strings.Repeat("a", 1024*1024+1)
+		stderr := captureStderr(t, func() {
+			parseAndSetEnv("TEST_PARSE_BEFORE_HUGE=ok\nTEST_PARSE_HUGE=" + hugeVal + "\nTEST_PARSE_AFTER_HUGE=lost")
+		})
+		if got := os.Getenv("TEST_PARSE_BEFORE_HUGE"); got != "ok" {
+			t.Errorf("var before huge line: got %q, want %q", got, "ok")
+		}
+		if !strings.Contains(stderr, "NOT loaded") {
+			t.Errorf("expected loud warning about unloaded variables, got: %q", stderr)
+		}
+		if _, ok := os.LookupEnv("TEST_PARSE_AFTER_HUGE"); ok {
+			t.Error("var after huge line unexpectedly loaded; warning would be a lie")
 		}
 	})
 


### PR DESCRIPTION
Closes #964

## Problem

Both copies of the env-file loader iterate `for scanner.Scan()` over a default 64KiB `bufio.Scanner` and never call `scanner.Err()`. A value line over 64KiB makes `Scan()` return `false` with `ErrTooLong` — indistinguishable from EOF — so **every variable after it is silently dropped**. One oversized value (base64 key, long DSN list) silently unsets `BINTRAIL_INDEX_DSN`/`BINTRAIL_CONSOLE_TOKEN` below it.

## Fix (minimal, both copies)

Applied identically to `internal/cli/env.go` and `consoleapp/env.go` (the console copy moved there from `cmd/bintrail-console/env.go` since the issue was filed):

1. `scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)` — realistic long values (up to 1MiB) now just work.
2. After the loop, check `scanner.Err()` and warn loudly on stderr: `warning: stopped reading env file (...): variables after this point were NOT loaded`.

**Why a warning, not a returned error:** `parseAndSetEnv`'s only caller is `loadEnvFile`, a best-effort loader fired via `sync.Once` from flag-binding paths with no error return; it already warns-and-continues on unreadable files. Returning an error would ripple a signature change through `BindCommandEnv` with no caller able to do anything but print it anyway.

**Why not the dedup refactor:** the issue offers it as an alternative; the copies live in different top-level packages and the consoleapp copy's own comment already tracks consolidation as a separate follow-up. Two 6-line identical fixes are smaller than a cross-package extraction.

## Tests (both packages)

- `~100KiB` value line: previously dropped everything from that line on; now must load **all** variables including ones after it, with no warning (mutation-killer for the buffer raise).
- `>1MiB` line (exceeds even the raised buffer): warning must appear, variables before it load, variables after it verified NOT loaded (so the warning tells the truth).

Both exercise the real `parseAndSetEnv` loader with stderr captured via pipe.

## Verification

- `go build ./...` clean
- `go test -race ./internal/cli/...` ok
- `go test -race ./consoleapp/...` ok (isolated run; a shared-load run tripped the known pre-existing `TestServeFlashbackDrainsActiveConn` local flake, untouched by this change)
- `cmd/bintrail-console` has no test files (thin wrapper over `consoleapp`)
- No exported signatures changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)