### PR TITLE
shim: decode spatial event values to raw bytes; recover: emit VECTOR as X'hex'

### DIFF
--- a/internal/recovery/recovery.go
+++ b/internal/recovery/recovery.go
@@ -882,13 +882,18 @@ func (g *Generator) formatColumnValue(col string, v any, geom, b64 map[string]bo
 // base64StoredKind reports whether a column's DataType is in the BLOB or TEXT
 // family — the ones go-mysql delivers as []byte so marshalRow base64-encodes them
 // in storage — and if so whether it is binary (true → emit X'hex') or text
-// (false → emit a string literal). go-mysql also delivers GEOMETRY/VECTOR as
-// []byte, but they are NOT in this set: a bare X'hex'/string literal can't load
-// them. GEOMETRY is handled on its own path (geometryLiteral →
+// (false → emit a string literal). go-mysql also delivers GEOMETRY as []byte, but
+// it is NOT in this set: a bare X'hex' literal can't load a geometry column, so
+// GEOMETRY is handled on its own path (geometryLiteral →
 // ST_GeomFromWKB(X'<wkb>', <srid>), #788) because its at-rest form is SRID+WKB.
-// VECTOR is still left as-is (its base64 fails loud at apply time against a real
-// VECTOR column) pending a verified STRING_TO_VECTOR decode of its packed-float
-// at-rest form — see the #788 PR note.
+//
+// "vector" is included (binary) since #1144: go-mysql delivers VECTOR via
+// decodeBlob as the at-rest packed little-endian float32 bytes, and MySQL 9
+// accepts exactly those bytes back as a hex literal — verified empirically
+// against MySQL 9.7 that INSERT/UPDATE with X'<HEX(v)>' round-trips
+// byte-identically into a VECTOR column, while a quoted string literal is
+// rejected (ER 6136), which is why the pre-#1144 base64 emission failed the
+// whole BEGIN/COMMIT script at apply time.
 //
 // "json" is included (non-binary) as a defense-in-depth companion to #736:
 // marshalRow now only promotes a []byte to raw JSON when it looks like a
@@ -919,7 +924,8 @@ func (g *Generator) formatColumnValue(col string, v any, geom, b64 map[string]bo
 // documented historical-data ambiguity as the #736 nil-case gap below.
 func base64StoredKind(dataType string) (binary, ok bool) {
 	switch strings.ToLower(dataType) {
-	case "blob", "tinyblob", "mediumblob", "longblob", "binary", "varbinary":
+	case "blob", "tinyblob", "mediumblob", "longblob", "binary", "varbinary",
+		"vector":
 		return true, true
 	case "text", "tinytext", "mediumtext", "longtext", "json":
 		return false, true

--- a/internal/recovery/recovery_test.go
+++ b/internal/recovery/recovery_test.go
@@ -2133,3 +2133,86 @@ func TestBuildUpdate_geometryEmitsSTGeomFromWKB(t *testing.T) {
 		t.Errorf("geometry SET must emit %q, got:\n%s", wantLit, stmt)
 	}
 }
+
+// TestBase64StoredKind_vector pins #1144: VECTOR is decodable and binary, so a
+// reversal emits its packed-float bytes as X'hex' instead of the stored base64
+// as a quoted string (which a VECTOR column rejects, ER 6136, failing the whole
+// BEGIN/COMMIT script at apply time).
+func TestBase64StoredKind_vector(t *testing.T) {
+	for _, dt := range []string{"vector", "VECTOR"} {
+		binary, ok := base64StoredKind(dt)
+		if !ok || !binary {
+			t.Errorf("base64StoredKind(%q) = (%v,%v), want (true,true)", dt, binary, ok)
+		}
+	}
+}
+
+// TestBuildInsert_vectorEmitsHexLiteral is the #1144 acceptance for the VECTOR
+// half: a reverse INSERT for a table with a VECTOR column emits the at-rest
+// packed little-endian float32 bytes as X'hex' — verified against MySQL 9.7
+// that X'<HEX(v)>' round-trips byte-identically into a VECTOR column — instead
+// of the stored base64 as a string literal, which VECTOR cannot load.
+func TestBuildInsert_vectorEmitsHexLiteral(t *testing.T) {
+	// STRING_TO_VECTOR('[1,2,3]') at rest: float32 LE 1.0, 2.0, 3.0.
+	packed := []byte{
+		0x00, 0x00, 0x80, 0x3f,
+		0x00, 0x00, 0x00, 0x40,
+		0x00, 0x00, 0x40, 0x40,
+	}
+	stored := base64.StdEncoding.EncodeToString(packed)
+	g := New(nil, resolverWith(map[string]*metadata.TableMeta{
+		"db.items": {
+			Schema: "db", Table: "items",
+			Columns: []metadata.ColumnMeta{
+				{Name: "id", OrdinalPosition: 1, IsPK: true, DataType: "int"},
+				{Name: "embedding", OrdinalPosition: 2, DataType: "vector"},
+			},
+			PKColumns: []string{"id"},
+		},
+	}))
+	row := query.ResultRow{
+		EventID: 3, SchemaName: "db", TableName: "items",
+		EventType: parser.EventDelete,
+		RowBefore: map[string]any{"id": "1", "embedding": stored},
+	}
+	stmt, err := g.generateInsert(row)
+	if err != nil {
+		t.Fatalf("generateInsert: %v", err)
+	}
+	if want := "X'0000803f0000004000004040'"; !strings.Contains(stmt, want) {
+		t.Errorf("vector column must emit %q, got:\n%s", want, stmt)
+	}
+	if strings.Contains(stmt, "'"+stored+"'") {
+		t.Errorf("vector column must NOT emit the base64 string literal %q, got:\n%s", stored, stmt)
+	}
+}
+
+// TestBuildUpdate_vectorEmitsHexLiteral covers the reverse-UPDATE SET clause
+// for a VECTOR column (#1144).
+func TestBuildUpdate_vectorEmitsHexLiteral(t *testing.T) {
+	packed := []byte{0xcd, 0xcc, 0xcc, 0x3d} // float32 LE 0.1
+	stored := base64.StdEncoding.EncodeToString(packed)
+	g := New(nil, resolverWith(map[string]*metadata.TableMeta{
+		"db.items": {
+			Schema: "db", Table: "items",
+			Columns: []metadata.ColumnMeta{
+				{Name: "id", OrdinalPosition: 1, IsPK: true, DataType: "int"},
+				{Name: "embedding", OrdinalPosition: 2, DataType: "vector"},
+			},
+			PKColumns: []string{"id"},
+		},
+	}))
+	row := query.ResultRow{
+		EventID: 4, SchemaName: "db", TableName: "items",
+		EventType: parser.EventUpdate,
+		RowBefore: map[string]any{"id": "1", "embedding": stored},
+		RowAfter:  map[string]any{"id": "1", "embedding": base64.StdEncoding.EncodeToString([]byte{0, 0, 0, 0})},
+	}
+	stmt, err := g.generateUpdate(row)
+	if err != nil {
+		t.Fatalf("generateUpdate: %v", err)
+	}
+	if want := "`embedding` = X'cdcccc3d'"; !strings.Contains(stmt, want) {
+		t.Errorf("vector SET must emit %q, got:\n%s", want, stmt)
+	}
+}

--- a/internal/shim/handler.go
+++ b/internal/shim/handler.go
@@ -1278,8 +1278,19 @@ func (h *Handler) mapEventImages(schema, table string, rows []query.ResultRow) {
 // reconstruct (#663); duplicated because those copies are unexported (#661 is
 // the third consumer — a future refactor may hoist one shared copy).
 //
-// GEOMETRY/VECTOR are also delivered as []byte but deliberately out of scope
-// here, matching the recover/reconstruct fixes.
+// The spatial family is included (binary) since #1144, mirroring
+// internal/reconstruct (#1136/#1143): go-mysql delivers a geometry via
+// decodeBlob as []byte of MySQL's internal 4-byte SRID + WKB form, so decoding
+// the stored base64 back to those raw bytes serves exactly what a real server
+// serves for a geometry column over the MySQL protocol.
+//
+// VECTOR stays deliberately EXCLUDED here despite also arriving as []byte
+// (packed floats): internal/baseline does not route "vector" through its
+// binary path, so a baseline-seeded row's VECTOR value is the literal dump
+// token, not bytes. _snapshot merges baseline rows with event images —
+// decoding only the event side would serve two different representations of
+// the same column within one result set. Same asymmetry that keeps VECTOR
+// unresolved in internal/verify (see PR #1143).
 //
 // "json" is included (non-binary) as a defense-in-depth companion to #736:
 // marshalRow now only promotes a []byte to raw JSON when it looks like a
@@ -1303,7 +1314,12 @@ func (h *Handler) mapEventImages(schema, table string, rows []query.ResultRow) {
 // the fuller rationale on the sibling copy in internal/recovery/recovery.go.
 func base64StoredKind(dataType string) (binary, ok bool) {
 	switch strings.ToLower(dataType) {
-	case "blob", "tinyblob", "mediumblob", "longblob", "binary", "varbinary":
+	case "blob", "tinyblob", "mediumblob", "longblob", "binary", "varbinary",
+		"geometry", "point", "linestring", "polygon",
+		"multipoint", "multilinestring", "multipolygon",
+		// MySQL 8.0.11+ reports a GEOMETRYCOLLECTION column's DATA_TYPE as
+		// "geomcollection"; MariaDB and pre-8.0.11 report "geometrycollection".
+		"geometrycollection", "geomcollection":
 		return true, true
 	case "text", "tinytext", "mediumtext", "longtext", "json":
 		return false, true

--- a/internal/shim/handler_test.go
+++ b/internal/shim/handler_test.go
@@ -2751,11 +2751,16 @@ func TestMapEventImagesDecodesBlobText(t *testing.T) {
 					{Name: "id", OrdinalPosition: 1, DataType: "int", IsPK: true},
 					{Name: "body", OrdinalPosition: 2, DataType: "text"},
 					{Name: "payload", OrdinalPosition: 3, DataType: "blob"},
+					{Name: "location", OrdinalPosition: 4, DataType: "point"},
+					{Name: "embedding", OrdinalPosition: 5, DataType: "vector"},
 				}},
 			}), nil
 		},
 	}
 	rawBlob := "\x00\xff\x7f\x80" // arbitrary non-UTF-8 bytes must survive
+	// MySQL's internal geometry form: 4-byte little-endian SRID + WKB.
+	rawGeom := "\x02\x00\x00\x00\x01\x01\x00\x00\x00\xde\xad\xbe\xef"
+	rawVec := "\x00\x00\x80\x3f\x00\x00\x00\x40" // packed float32 LE [1,2]
 	rows := []query.ResultRow{{
 		SchemaName:     "appdb",
 		TableName:      "docs",
@@ -2765,6 +2770,7 @@ func TestMapEventImagesDecodesBlobText(t *testing.T) {
 		},
 		RowAfter: map[string]any{
 			"id": json.Number("1"), "body": b64("hello world"), "payload": b64(rawBlob),
+			"location": b64(rawGeom), "embedding": b64(rawVec),
 		},
 	}}
 	h.mapEventImages("appdb", "docs", rows)
@@ -2779,6 +2785,16 @@ func TestMapEventImagesDecodesBlobText(t *testing.T) {
 	// BLOB family → decoded raw []byte, arbitrary bytes intact.
 	if got, ok := rows[0].RowAfter["payload"].([]byte); !ok || string(got) != rawBlob {
 		t.Errorf("RowAfter payload = %#v, want decoded []byte %q", rows[0].RowAfter["payload"], rawBlob)
+	}
+	// Spatial family (#1144) → decoded raw []byte (SRID+WKB), what a real
+	// server serves over the wire — not the stored base64 text.
+	if got, ok := rows[0].RowAfter["location"].([]byte); !ok || string(got) != rawGeom {
+		t.Errorf("RowAfter location = %#v, want decoded []byte %q (raw SRID+WKB)", rows[0].RowAfter["location"], rawGeom)
+	}
+	// VECTOR stays deliberately excluded (baseline asymmetry — see the
+	// base64StoredKind comment): the stored base64 string is left untouched.
+	if got := rows[0].RowAfter["embedding"]; got != b64(rawVec) {
+		t.Errorf("RowAfter embedding = %#v, want untouched base64 string %q", got, b64(rawVec))
 	}
 	// Non-BLOB/TEXT column untouched.
 	if got := rows[0].RowAfter["id"]; got != json.Number("1") {
@@ -2832,7 +2848,14 @@ func TestMapEventImagesDecodeEdgeCases(t *testing.T) {
 // TestBase64StoredKind and TestBase64Cols pin the pure type predicates the
 // #661 decode is gated on.
 func TestBase64StoredKind(t *testing.T) {
-	binaryFamily := []string{"blob", "tinyblob", "mediumblob", "longblob", "binary", "varbinary"}
+	binaryFamily := []string{
+		"blob", "tinyblob", "mediumblob", "longblob", "binary", "varbinary",
+		// Spatial family decodes to raw SRID+WKB bytes since #1144, mirroring
+		// internal/reconstruct (#1136/#1143).
+		"geometry", "point", "linestring", "polygon",
+		"multipoint", "multilinestring", "multipolygon",
+		"geometrycollection", "geomcollection",
+	}
 	textFamily := []string{"text", "tinytext", "mediumtext", "longtext"}
 	for _, dt := range binaryFamily {
 		if binary, ok := base64StoredKind(dt); !ok || !binary {
@@ -2844,12 +2867,16 @@ func TestBase64StoredKind(t *testing.T) {
 			t.Errorf("base64StoredKind(%q) = (%v,%v), want (false,true)", dt, binary, ok)
 		}
 	}
-	// Case-insensitive, and unrelated types are not decoded (incl. the
-	// deliberately-excluded geometry/vector families).
+	// Case-insensitive, and unrelated types are not decoded. VECTOR stays
+	// deliberately excluded: internal/baseline does not route "vector"
+	// through its binary path, so a _snapshot baseline-seeded row carries the
+	// literal dump token — decoding only the event side would serve two
+	// representations of the same column within one result set (same
+	// asymmetry that keeps VECTOR unresolved in internal/verify, PR #1143).
 	if binary, ok := base64StoredKind("LONGTEXT"); !ok || binary {
 		t.Errorf("base64StoredKind is not case-insensitive: got (%v,%v)", binary, ok)
 	}
-	for _, dt := range []string{"int", "varchar", "geometry", "datetime", ""} {
+	for _, dt := range []string{"int", "varchar", "vector", "datetime", ""} {
 		if _, ok := base64StoredKind(dt); ok {
 			t.Errorf("base64StoredKind(%q) reported a decodable column, want none", dt)
 		}


### PR DESCRIPTION
Closes #1144. Follow-up to #1136 / PR #1143.

## 1. Shim: spatial event values now decode to raw bytes

`internal/shim/handler.go`'s local `base64StoredKind` copy now includes the spatial family (`geometry`, `point`, `linestring`, `polygon`, `multipoint`, `multilinestring`, `multipolygon`, `geometrycollection`, `geomcollection`) as binary, mirroring `internal/reconstruct` since PR #1143. `mapEventImages` therefore decodes the stored base64 of a geometry event value back to MySQL's internal 4-byte SRID + WKB bytes, so `_flashback`/`_snapshot`/`_diff` serve over the MySQL protocol what a real server serves — raw internal bytes, not base64 text — and stop diverging from what reconstruct/console/MCP return for the same row.

**VECTOR is deliberately NOT added in the shim**: `internal/baseline` does not route `vector` through its binary path, so a `_snapshot` baseline-seeded row's VECTOR value is the literal dump token, not bytes. Decoding only the event side would serve two different representations of the same column within one result set. This is the same baseline asymmetry that keeps VECTOR unresolved in `internal/verify` (PR #1143's `deferredValueUnresolved` note); the exclusion is documented in the code and pinned by test.

## 2. Recover: VECTOR reversal emits `X'<hex>'` instead of base64

Previously a reversal touching a VECTOR column emitted the stored base64 as a quoted string literal, which a VECTOR column cannot load — the whole `BEGIN`/`COMMIT` script failed at apply time. `internal/recovery`'s `base64StoredKind` now classifies `vector` as binary, so `decodeStoredBase64` restores the at-rest packed little-endian float32 bytes and `FormatSQLValue` emits them as a hex literal. Geometry keeps its own `ST_GeomFromWKB(X'<wkb>', <srid>)` path (#788), unchanged.

go-mysql delivers `MYSQL_TYPE_VECTOR` through `decodeBlob` as `[]byte` (row_event.go, same case as GEOMETRY), i.e. the at-rest packed bytes, so the stored base64 decodes to exactly the bytes `HEX(v)` shows.

### MySQL 9 verification transcript (throwaway `mysql:9` container, server 9.7.1)

```sql
CREATE DATABASE vtest; USE vtest;
CREATE TABLE t (id INT PRIMARY KEY, v VECTOR(3));
INSERT INTO t VALUES (1, STRING_TO_VECTOR('[1,2,3]'));
SELECT id, HEX(v), VECTOR_TO_STRING(v) FROM t;
-- 1  0000803F0000004000004040  [1.00000e+00,2.00000e+00,3.00000e+00]
SELECT DATA_TYPE FROM information_schema.COLUMNS
 WHERE TABLE_SCHEMA='vtest' AND TABLE_NAME='t' AND COLUMN_NAME='v';
-- vector

-- hex literal round-trip (INSERT and UPDATE)
INSERT INTO t VALUES (2, X'0000803F0000004000004040');
UPDATE t SET v = X'0000803F0000004000004040' WHERE id = 2;
SELECT HEX(t1.v) = HEX(t2.v) FROM t t1 JOIN t t2 ON t1.id=1 AND t2.id=2;
-- 1

-- non-trivial floats round-trip byte-identically too
INSERT INTO t VALUES (10, STRING_TO_VECTOR('[0.1,-2.5,3.14159]'));
SELECT HEX(v) FROM t WHERE id=10;
-- CDCCCC3D000020C0D00F4940
INSERT INTO t VALUES (11, X'CDCCCC3D000020C0D00F4940');
SELECT HEX(t1.v)=HEX(t2.v), VECTOR_TO_STRING(t2.v) FROM t t1 JOIN t t2 ON t1.id=10 AND t2.id=11;
-- 1  [1.00000e-01,-2.50000e+00,3.14159e+00]

-- negative control: the pre-fix emission (base64 as a string literal) fails
INSERT INTO t VALUES (3, 'AACAPwAAAEAAAEBA');
-- ERROR 6136 (HY000): Value of type 'string, size: 16' cannot be converted to 'vector' type.
```

`X'<hex>'` loads and round-trips byte-identically; the quoted base64 string is rejected — confirming both the fix and the pre-fix failure mode.

## 3. Stale test comment

`internal/shim/handler_test.go`'s `TestBase64StoredKind` called geometry/vector "deliberately-excluded families" — no longer true for geometry anywhere (reconstruct decodes it since PR #1143, recovery emits it via `ST_GeomFromWKB` since #788, the shim decodes it as of this PR). The spatial family moved into the binary assertion set; the exclusion comment now names only VECTOR, with the baseline-asymmetry reason.

## Tests

- Shim `mapEventImages` decode test extended with a `point` column asserting raw SRID+WKB `[]byte` is served (fails without the fix) and a `vector` column asserting the base64 is left untouched (pins the deliberate exclusion).
- Recovery tests pinning the exact emitted SQL for known packed-float byte patterns: reverse INSERT emits `X'0000803f0000004000004040'`, reverse UPDATE SET emits `` `embedding` = X'cdcccc3d' ``, and the base64 string literal never appears.
- Battery: `go build ./...`, `go vet ./...`, `go vet -tags integration ./...`, `go test ./internal/shim/... ./internal/recovery/... -count=1` (also with `-race`), `go test -tags integration ./internal/shim/...` against the shared MySQL 8.0 on 13306 — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
