### PR TITLE
cascade: close the remaining silent-zero paths after the ON UPDATE work

### DIFF
--- a/internal/cascade/cascade.go
+++ b/internal/cascade/cascade.go
@@ -627,17 +627,26 @@ func SynthesizeVictims(
 	// checkKeyChain flags the ONE case the "children's last logged image still
 	// carries the old key" inference cannot see: an EARLIER UPDATE inside the
 	// window that moved this referenced key INTO the parent (A→B before the
-	// root's B→C). That earlier cascade rewrote the children below the binlog
-	// too, so their last INDEXED image carries the pre-chain key — the ColumnEq
-	// scan for this root's old key then matches nothing and would report a clean
-	// zero-child Complete. Never silent (#618).
+	// root's B→C, or before the root DELETE of the row holding B). That earlier
+	// cascade rewrote the children below the binlog too, so their last INDEXED
+	// image carries the pre-chain key — the ColumnEq scan for this root's key
+	// then matches nothing and would report a clean zero-child Complete. Never
+	// silent (#618).
 	//
-	// Probed for ROOT updates only (depth 0): deeper items are synthesized here,
+	// Both root kinds consult it (#1125): an UPDATE root probes its OLD key
+	// (what the children were scanned by), and a DELETE root probes the deleted
+	// row's key when the edge is ON UPDATE CASCADE — the only rule under which
+	// an earlier key move dragged the children along invisibly, leaving the
+	// delete-cascade scan with nothing to match. `consequence` names what a
+	// hidden chain means for that root kind, so the caveat reads correctly in
+	// both.
+	//
+	// Probed for ROOTS only (depth 0): deeper items are synthesized here,
 	// with the correct pre-cascade image by construction, so a "prior update"
 	// found for them would be about the child's own logged history, not a hidden
 	// cascade chain. The root's own event is skipped by EventID.
 	upd := event.EventUpdate
-	checkKeyChain := func(fk CascadeFK, pev query.ResultRow, parentOldKey string, rootTS time.Time, rootKey string) {
+	checkKeyChain := func(fk CascadeFK, pev query.ResultRow, parentOldKey string, rootTS time.Time, rootKey, consequence string) {
 		memo := pev.SchemaName + "." + pev.TableName + "|" + fk.ReferencedColumn + "|" + parentOldKey + "|" + rootKey
 		if keyChainChecked[memo] {
 			return
@@ -703,10 +712,23 @@ func SynthesizeVictims(
 			}
 			addIncomplete("keychain:"+pev.SchemaName+"."+pev.TableName+"."+fk.ReferencedColumn, fmt.Sprintf(
 				"%s.%s had an EARLIER update of referenced column %q INTO %s inside the window; that cascade rewrote its "+
-					"children below the binlog too, so their last indexed image no longer carries this update's old key — "+
-					"some ON UPDATE cascade children may NOT be reconstructed (a zero result here is not proof of none)",
-				pev.SchemaName, pev.TableName, fk.ReferencedColumn, parentOldKey))
+					"children below the binlog too, so their last indexed image no longer carries the key this root was "+
+					"scanned by — %s (a zero result here is not proof of none)",
+				pev.SchemaName, pev.TableName, fk.ReferencedColumn, parentOldKey, consequence))
 			return
+		}
+		// #1125: a bounded probe must not support an unbounded conclusion. The
+		// fetch was capped at keyChainProbeLimit and none of the returned events
+		// was the arrival — but with a FULL page the arrival may sit beyond the
+		// cap (e.g. a row parked on the key accumulating unrelated-column
+		// updates ahead of it in ASC order). That is "could not rule a chain
+		// out", never "no chain" — the same shape the skewSampleLimit probe
+		// avoids by leaving an empty sample unmemoized.
+		if len(prior) == keyChainProbeLimit {
+			addIncomplete("keychaintrunc:"+pev.SchemaName+"."+pev.TableName+"."+fk.ReferencedColumn, fmt.Sprintf(
+				"%s.%s had at least %d updates matching referenced column %q = %s in the window — the key-chain probe's "+
+					"cap — so an earlier key move into %s could not be ruled out; %s (a zero result here is not proof of none)",
+				pev.SchemaName, pev.TableName, keyChainProbeLimit, fk.ReferencedColumn, parentOldKey, parentOldKey, consequence))
 		}
 	}
 
@@ -826,7 +848,8 @@ func SynthesizeVictims(
 					parentOldKey := valToString(oldVal)
 					cascadedHere = true
 					if depth == 0 {
-						checkKeyChain(fk, pev, parentOldKey, item.rootTS, rootKey)
+						checkKeyChain(fk, pev, parentOldKey, item.rootTS, rootKey,
+							"some ON UPDATE cascade children may NOT be reconstructed")
 					}
 
 					scan := scanChildren(fk, parentOldKey, item.rootTS)
@@ -924,6 +947,21 @@ func SynthesizeVictims(
 					continue
 				}
 				parentPK := valToString(refVal)
+				if depth == 0 && fk.UpdateRule == "CASCADE" {
+					// #1125: the delete-path analog of the key-chain blind spot.
+					// If an earlier UPDATE moved the referenced key INTO the value
+					// this row carried at delete time, the ON UPDATE CASCADE that
+					// ran then rewrote the children below the binlog — their last
+					// indexed image carries the PRE-move key, so the scan by
+					// parentPK below finds none of them and would claim a clean
+					// Complete while every child stays orphaned. Only an ON UPDATE
+					// CASCADE edge drags children along a key move invisibly
+					// (SET NULL leaves them NULL, genuinely untouched by the later
+					// delete; RESTRICT/NO ACTION blocks the move while children
+					// exist), hence the rule gate.
+					checkKeyChain(fk, pev, parentPK, item.rootTS, rootKey,
+						"some cascade-deleted children may NOT be reconstructed")
+				}
 
 				scan := scanChildren(fk, parentPK, item.rootTS)
 				if scan.failed {

--- a/internal/cascade/cascade_silentzero_integration_test.go
+++ b/internal/cascade/cascade_silentzero_integration_test.go
@@ -1,0 +1,164 @@
+//go:build integration
+
+package cascade_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/cascade"
+	"github.com/dbtrail/dbtrail/internal/query"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// The remaining silent-zero paths (#1125): the delete-path analog of the
+// key-chain blind spot, and the key-chain probe's own truncation. Both must
+// surface Incomplete instead of a clean zero.
+
+// probeLimit mirrors cascade.keyChainProbeLimit (unexported). If the constant
+// ever changes, TestSynthesizeKeyUpdate_probeCapFlagged fails loudly at the
+// KeyUpdates assertion rather than silently probing the wrong budget.
+const probeLimit = 8
+
+// TestSynthesizeDelete_priorKeyMoveFlagged pins the DELETE-root analog of the
+// key-chain blind spot (#1125): the parent's referenced key moved A → B under
+// ON UPDATE CASCADE (children rewritten below the binlog), then the parent was
+// DELETEd. The delete-cascade scan searches children by the pre-delete key (B),
+// but their last INDEXED image still says A — zero matches. A clean
+// "0 victims, Complete" would tell the operator the recovery is complete while
+// every child is orphaned; the run must be flagged Incomplete.
+func TestSynthesizeDelete_priorKeyMoveFlagged(t *testing.T) {
+	e := newUpdEnv(t)
+	// The child's last logged image predates the parent key move: pcode = 'A'.
+	testutil.InsertEvent(t, e.db, "b.000001", 10, 20, e.ts, nil, e.dbName, "child", 1, "10", nil, nil, []byte(`{"id":10,"pcode":"A"}`))
+	// The earlier parent key update (A → B), which IS in the index.
+	testutil.InsertEvent(t, e.db, "b.000001", 20, 30, e.ts, nil, e.dbName, "parent", 2, "1",
+		nil, []byte(`{"id":1,"code":"A"}`), []byte(`{"id":1,"code":"B"}`))
+
+	fks := []cascade.CascadeFK{{
+		Schema: e.dbName, Table: "child", ConstraintName: "fk", Column: "pcode",
+		ReferencedSchema: e.dbName, ReferencedTable: "parent", ReferencedColumn: "code",
+		DeleteRule: "CASCADE", UpdateRule: "CASCADE",
+	}}
+	// The ROOT is the later DELETE of the parent, whose before-image carries B.
+	roots := []query.ResultRow{{
+		SchemaName: e.dbName, TableName: "parent", EventType: 3 /* DELETE */, PKValues: "1",
+		RowBefore:      map[string]any{"id": json.Number("1"), "code": "B"},
+		EventTimestamp: e.T,
+	}}
+	res, err := cascade.SynthesizeVictims(context.Background(), e.eng, fks, roots, cascade.Options{})
+	if err != nil {
+		t.Fatalf("SynthesizeVictims: %v", err)
+	}
+	if len(res.Victims) != 0 {
+		t.Fatalf("the child's indexed image still says A, so nothing matches B; got %v", victimList(res.Victims))
+	}
+	joined := strings.Join(res.Incomplete, " ")
+	if res.Complete() || !strings.Contains(joined, "EARLIER update of referenced column") {
+		t.Errorf("a prior key move hides the delete-cascade's children and MUST be flagged; Incomplete=%v", res.Incomplete)
+	}
+	if !strings.Contains(joined, "cascade-deleted children") {
+		t.Errorf("the caveat must name the DELETE-root consequence (cascade-deleted children), got %v", res.Incomplete)
+	}
+}
+
+// TestSynthesizeDelete_priorKeyMoveNotFlaggedWithoutUpdateCascade is the
+// control pinning the rule gate: the same prior key move under ON UPDATE
+// SET NULL nulled the children instead of dragging them to the new key, so at
+// delete time nothing pointed at B and the zero-child result is genuinely
+// correct — it must stay Complete, not manufacture a false caveat.
+func TestSynthesizeDelete_priorKeyMoveNotFlaggedWithoutUpdateCascade(t *testing.T) {
+	e := newUpdEnv(t)
+	testutil.InsertEvent(t, e.db, "b.000001", 10, 20, e.ts, nil, e.dbName, "child", 1, "10", nil, nil, []byte(`{"id":10,"pcode":"A"}`))
+	testutil.InsertEvent(t, e.db, "b.000001", 20, 30, e.ts, nil, e.dbName, "parent", 2, "1",
+		nil, []byte(`{"id":1,"code":"A"}`), []byte(`{"id":1,"code":"B"}`))
+
+	fks := []cascade.CascadeFK{{
+		Schema: e.dbName, Table: "child", ConstraintName: "fk", Column: "pcode",
+		ReferencedSchema: e.dbName, ReferencedTable: "parent", ReferencedColumn: "code",
+		DeleteRule: "CASCADE", UpdateRule: "SET NULL",
+	}}
+	roots := []query.ResultRow{{
+		SchemaName: e.dbName, TableName: "parent", EventType: 3 /* DELETE */, PKValues: "1",
+		RowBefore:      map[string]any{"id": json.Number("1"), "code": "B"},
+		EventTimestamp: e.T,
+	}}
+	res, err := cascade.SynthesizeVictims(context.Background(), e.eng, fks, roots, cascade.Options{})
+	if err != nil {
+		t.Fatalf("SynthesizeVictims: %v", err)
+	}
+	if len(res.Victims) != 0 {
+		t.Fatalf("want no victims, got %v", victimList(res.Victims))
+	}
+	if !res.Complete() {
+		t.Errorf("ON UPDATE SET NULL cannot have moved children onto the deleted key; want Complete, got %v", res.Incomplete)
+	}
+}
+
+// TestSynthesizeKeyUpdate_probeCapFlagged pins the bounded-probe fix (#1125):
+// the key-chain probe fetches at most keyChainProbeLimit prior UPDATEs, ASC. A
+// parent row parked on the key accumulating unrelated-column updates fills the
+// whole page without any of them being the arrival, so a chain beyond the cap
+// cannot be ruled out — the run must be flagged Incomplete rather than let the
+// bounded probe support an unbounded "no chain" conclusion.
+func TestSynthesizeKeyUpdate_probeCapFlagged(t *testing.T) {
+	e := newUpdEnv(t)
+	// The child genuinely points at B — the restore itself is the positive anchor.
+	testutil.InsertEvent(t, e.db, "b.000001", 10, 20, e.ts, nil, e.dbName, "child", 1, "10", nil, nil, []byte(`{"id":10,"pcode":"B"}`))
+	// Exactly probeLimit unrelated-column updates while the parent sat on B:
+	// every one matches the ColumnEq probe for code=B, none moved the key.
+	for i := 0; i < probeLimit; i++ {
+		testutil.InsertEvent(t, e.db, "b.000001", uint64(100+i*10), uint64(110+i*10), e.ts, nil, e.dbName, "parent", 2, "1",
+			nil, []byte(fmt.Sprintf(`{"id":1,"code":"B","n":%d}`, i)), []byte(fmt.Sprintf(`{"id":1,"code":"B","n":%d}`, i+1)))
+	}
+
+	fks := []cascade.CascadeFK{{
+		Schema: e.dbName, Table: "child", ConstraintName: "fk", Column: "pcode",
+		ReferencedSchema: e.dbName, ReferencedTable: "parent", ReferencedColumn: "code",
+		DeleteRule: "RESTRICT", UpdateRule: "CASCADE",
+	}}
+	roots := parentKeyUpdate(e.dbName, "code", "B", "C", e.T)
+	res, err := cascade.SynthesizeVictims(context.Background(), e.eng, fks, roots, cascade.Options{})
+	if err != nil {
+		t.Fatalf("SynthesizeVictims: %v", err)
+	}
+	if len(res.KeyUpdates) != 1 {
+		t.Fatalf("want the one restore for child 10 (probeLimit=%d must match cascade.keyChainProbeLimit), got %+v",
+			probeLimit, res.KeyUpdates)
+	}
+	if res.Complete() || !strings.Contains(strings.Join(res.Incomplete, " "), "could not be ruled out") {
+		t.Errorf("a probe that exhausted its cap without a verdict must flag Incomplete; got %v", res.Incomplete)
+	}
+}
+
+// TestSynthesizeKeyUpdate_probeUnderCapNotFlagged is the control for the cap:
+// one fewer matching prior UPDATE leaves headroom in the page, so "no arrival
+// in the window" is a real conclusion and the run stays Complete.
+func TestSynthesizeKeyUpdate_probeUnderCapNotFlagged(t *testing.T) {
+	e := newUpdEnv(t)
+	testutil.InsertEvent(t, e.db, "b.000001", 10, 20, e.ts, nil, e.dbName, "child", 1, "10", nil, nil, []byte(`{"id":10,"pcode":"B"}`))
+	for i := 0; i < probeLimit-1; i++ {
+		testutil.InsertEvent(t, e.db, "b.000001", uint64(100+i*10), uint64(110+i*10), e.ts, nil, e.dbName, "parent", 2, "1",
+			nil, []byte(fmt.Sprintf(`{"id":1,"code":"B","n":%d}`, i)), []byte(fmt.Sprintf(`{"id":1,"code":"B","n":%d}`, i+1)))
+	}
+
+	fks := []cascade.CascadeFK{{
+		Schema: e.dbName, Table: "child", ConstraintName: "fk", Column: "pcode",
+		ReferencedSchema: e.dbName, ReferencedTable: "parent", ReferencedColumn: "code",
+		DeleteRule: "RESTRICT", UpdateRule: "CASCADE",
+	}}
+	roots := parentKeyUpdate(e.dbName, "code", "B", "C", e.T)
+	res, err := cascade.SynthesizeVictims(context.Background(), e.eng, fks, roots, cascade.Options{})
+	if err != nil {
+		t.Fatalf("SynthesizeVictims: %v", err)
+	}
+	if len(res.KeyUpdates) != 1 {
+		t.Fatalf("want the one restore for child 10, got %+v", res.KeyUpdates)
+	}
+	if !res.Complete() {
+		t.Errorf("an under-cap probe with no arrival is conclusive; want Complete, got %v", res.Incomplete)
+	}
+}

--- a/internal/console/recover_cascade.go
+++ b/internal/console/recover_cascade.go
@@ -23,9 +23,11 @@ import (
 )
 
 // recoverCascadeRequest is the JSON body accepted by POST /api/recover-cascade.
-// Schema/Table identify the PARENT table whose delete cascaded; the handler
-// synthesizes the invisible child victims (ON DELETE CASCADE / SET NULL that
-// InnoDB ran below the binlog) and returns reversal SQL — never executing it.
+// Schema/Table identify the PARENT table whose delete or referenced-key update
+// cascaded; the handler synthesizes the invisible child-side effects InnoDB ran
+// below the binlog (ON DELETE CASCADE / SET NULL victims and nulled FKs, plus
+// ON UPDATE CASCADE / SET NULL FK rewrites, #1002) and returns reversal SQL —
+// never executing it.
 type recoverCascadeRequest struct {
 	Schema   string   `json:"schema"`
 	Table    string   `json:"table"`
@@ -76,8 +78,9 @@ func (s *Server) rbacActive() bool {
 }
 
 // handleRecoverCascade serves POST /api/recover-cascade — generates reversal SQL
-// for rows hit by a foreign-key ON DELETE CASCADE / SET NULL that InnoDB ran
-// below the binlog (MySQL Bug #32506). Like /api/recover it NEVER executes the
+// for rows hit by a foreign-key cascade that InnoDB ran below the binlog (MySQL
+// Bug #32506): ON DELETE CASCADE / SET NULL child deletions and nulled FKs, and
+// ON UPDATE CASCADE / SET NULL FK rewrites (#1002). Like /api/recover it NEVER executes the
 // SQL: it synthesizes the invisible victims from the index, builds the script in
 // a buffer, and returns it as text for the operator to review.
 func (s *Server) handleRecoverCascade(w http.ResponseWriter, r *http.Request) {

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -1253,7 +1253,10 @@ func DetectFlavor(db *sql.DB) string {
 }
 
 // buildFKCascadeQuery returns the REFERENTIAL_CONSTRAINTS query (and its args)
-// used to find CASCADE foreign keys. When schemas is non-empty the scan is
+// used to find cascading foreign keys — a DELETE_RULE or UPDATE_RULE of CASCADE
+// or SET NULL, the four referential actions whose child-side effects InnoDB
+// applies below the binlog and recover-cascade synthesizes (aligned with
+// CascadeConstraintsInIndex, #1125). When schemas is non-empty the scan is
 // scoped to exactly those schemas — the operator explicitly asked us to index
 // them, so we police them as named. When schemas is empty we scan every schema
 // except (a) MySQL's own system schemas and (b) bintrail's own index schemas.
@@ -1269,7 +1272,7 @@ func DetectFlavor(db *sql.DB) string {
 func buildFKCascadeQuery(schemas []string) (string, []any) {
 	query := `SELECT CONSTRAINT_SCHEMA, CONSTRAINT_NAME, DELETE_RULE, UPDATE_RULE
 		FROM information_schema.REFERENTIAL_CONSTRAINTS
-		WHERE (DELETE_RULE = 'CASCADE' OR UPDATE_RULE = 'CASCADE')`
+		WHERE (DELETE_RULE IN ('CASCADE', 'SET NULL') OR UPDATE_RULE IN ('CASCADE', 'SET NULL'))`
 
 	var args []any
 	if len(schemas) > 0 {
@@ -1304,7 +1307,8 @@ func buildFKCascadeQuery(schemas []string) (string, []any) {
 var ErrFKCascadesFound = errors.New("FK cascade constraints present on source")
 
 // ValidateNoFKCascades checks that none of the targeted schemas contain foreign
-// key constraints with CASCADE rules. When schemas is empty, all non-system,
+// key constraints with cascading (CASCADE / SET NULL) referential rules, on
+// either the DELETE or the UPDATE action. When schemas is empty, all non-system,
 // non-bintrail-internal schemas are checked (see buildFKCascadeQuery). FK
 // cascades produce invisible side-effect row changes that make reversal SQL
 // unreliable. A cascade finding is returned wrapped in ErrFKCascadesFound; any
@@ -1423,10 +1427,10 @@ func CascadeConstraintsInIndex(indexDB *sql.DB, schemas []string) ([]FKCascadeEd
 // schema.table is legal in MySQL, #833). It matches on referenced_schema_name +
 // referenced_table_name, so it is not fooled by a same-named table in another
 // schema, and it is not scoped to the parent's own schema the way the child-scoped
-// CascadeConstraintsInIndex is. Used by the console to decide whether a DELETE on
-// schema.table should auto-route through cascade synthesis: a parent whose only
-// cascade children are cross-schema would otherwise report false and silently fall
-// back to plain recover, missing the cascade victims.
+// CascadeConstraintsInIndex is. It is the ON DELETE half only — a convenience
+// wrapper for callers that care about that single action; the console and CLI
+// auto-routing consult CascadeParentRulesInIndex directly, which reports the
+// ON UPDATE side too (#1002).
 //
 // Returns false (not an error) when fk_constraints is absent (index predates it).
 func IsCascadeParentInIndex(indexDB *sql.DB, schema, table string) (bool, error) {

--- a/internal/metadata/metadata_integration_test.go
+++ b/internal/metadata/metadata_integration_test.go
@@ -657,6 +657,47 @@ func TestValidateNoFKCascades_cascade(t *testing.T) {
 	}
 }
 
+// ON DELETE SET NULL and ON UPDATE SET NULL are cascading actions bintrail's
+// recover-cascade synthesizes, so the doctor/pre-flight must report them too
+// (#1125) — matching CASCADE alone silently under-reported these schemas.
+func TestValidateNoFKCascades_setNull(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+
+	testutil.MustExec(t, db, `CREATE TABLE users (
+		id INT PRIMARY KEY AUTO_INCREMENT
+	)`)
+	testutil.MustExec(t, db, `CREATE TABLE posts (
+		id      INT PRIMARY KEY AUTO_INCREMENT,
+		user_id INT,
+		CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL
+	)`)
+
+	err := ValidateNoFKCascades(db, []string{dbName})
+	if err == nil {
+		t.Fatal("expected error for schema with ON DELETE SET NULL, got nil")
+	}
+	if !errors.Is(err, ErrFKCascadesFound) {
+		t.Errorf("SET NULL finding must wrap ErrFKCascadesFound, got: %v", err)
+	}
+}
+
+func TestValidateNoFKCascades_updateSetNull(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+
+	testutil.MustExec(t, db, `CREATE TABLE tags (
+		id INT PRIMARY KEY AUTO_INCREMENT
+	)`)
+	testutil.MustExec(t, db, `CREATE TABLE tagged (
+		id     INT PRIMARY KEY AUTO_INCREMENT,
+		tag_id INT,
+		CONSTRAINT fk_tag FOREIGN KEY (tag_id) REFERENCES tags(id) ON UPDATE SET NULL
+	)`)
+
+	if err := ValidateNoFKCascades(db, []string{dbName}); err == nil {
+		t.Fatal("expected error for schema with ON UPDATE SET NULL, got nil")
+	}
+}
+
 func TestValidateNoFKCascades_updateCascade(t *testing.T) {
 	db, dbName := testutil.CreateTestDB(t)
 

--- a/internal/metadata/metadata_test.go
+++ b/internal/metadata/metadata_test.go
@@ -480,6 +480,22 @@ func TestBuildFKCascadeQuery_withSchemas(t *testing.T) {
 	}
 }
 
+// The pre-flight must match every cascading referential action recover-cascade
+// synthesizes — SET NULL included, on BOTH rules (#1125). Matching CASCADE only
+// silently under-reports schemas whose FKs use ON DELETE / ON UPDATE SET NULL.
+func TestBuildFKCascadeQuery_matchesSetNull(t *testing.T) {
+	query, _ := buildFKCascadeQuery(nil)
+
+	for _, want := range []string{
+		"DELETE_RULE IN ('CASCADE', 'SET NULL')",
+		"UPDATE_RULE IN ('CASCADE', 'SET NULL')",
+	} {
+		if !strings.Contains(query, want) {
+			t.Errorf("expected query to match %s, got query:\n%s", want, query)
+		}
+	}
+}
+
 // With no schemas filter the scan excludes MySQL system schemas AND bintrail's
 // own index schemas. The latter are recognised structurally — a schema is
 // bintrail-internal only if it holds all of binlog_events, schema_snapshots and


### PR DESCRIPTION
Closes #1125

Three fixes, all turning a silent clean-zero into an explicit `Incomplete` caveat, plus the stale-comment cleanup the issue lists. The file-split refactor mentioned as "related cleanup" is deliberately left out (out of minimal scope).

## 1. Delete-path analog of the key-chain blind spot (`internal/cascade/cascade.go`)

Sequence: parent key UPDATEd at t1 under ON UPDATE CASCADE (InnoDB rewrote the children below the binlog), parent DELETEd at t2. The delete-cascade scan searches children by the pre-delete key, but their last indexed image still carries the pre-update key — zero victims, `Complete() == true`, children orphaned.

DELETE roots (depth 0) now run the same `checkKeyChain` probe UPDATE roots already run, asking "did this key ARRIVE here from somewhere else inside the window?". Gated on the edge's `update_rule == CASCADE` — the only rule under which a key move drags children along invisibly (`SET NULL` leaves them NULL and genuinely untouched by the later delete; `RESTRICT`/`NO ACTION` blocks the move while children exist), so the control test pins that no false caveat is manufactured. The probe's `consequence` string is parameterized so the caveat names the right outcome per root kind ("cascade-deleted children" vs "ON UPDATE cascade children").

## 2. `keyChainProbeLimit` truncation is now reported

The probe fetches at most 8 prior UPDATEs (ASC). A page filled to the cap with no arrival found is "could not rule a chain out", never "no chain" — a bounded probe must not support an unbounded conclusion (the same shape the `skewSampleLimit` probe avoids by leaving empty samples unmemoized). `len(prior) == keyChainProbeLimit` with no chain found now flags `Incomplete`.

## 3. `buildFKCascadeQuery` matches both `SET NULL` variants (`internal/metadata/metadata.go`)

The doctor / pre-flight matched only `DELETE_RULE = 'CASCADE' OR UPDATE_RULE = 'CASCADE'`, silently under-reporting schemas whose FKs use `ON DELETE SET NULL` / `ON UPDATE SET NULL` — both of which `recover-cascade` synthesizes. Now `IN ('CASCADE', 'SET NULL')` on both rules, aligned with `CascadeConstraintsInIndex` (#1116).

## Comment cleanup

Refreshed the stale delete-only-scope comments: `internal/console/recover_cascade.go` (request + handler docs now name the ON UPDATE half, #1002) and `metadata.IsCascadeParentInIndex` (no longer claims the console uses it — auto-routing consults `CascadeParentRulesInIndex`).

## Tests

All new Incomplete paths are exercised through the real entry points, each with a positive-anchor control so a reverted fix fails a test:

- `TestSynthesizeDelete_priorKeyMoveFlagged` — fix 1 (revert → clean Complete → fails); `..._priorKeyMoveNotFlaggedWithoutUpdateCascade` pins the `SET NULL` rule gate (no false caveat).
- `TestSynthesizeKeyUpdate_probeCapFlagged` — fix 2 (8 cap-filling unrelated updates; also asserts the real restore still emits); `..._probeUnderCapNotFlagged` pins the 7-event boundary.
- `TestValidateNoFKCascades_setNull` / `_updateSetNull` — fix 3 through the production pre-flight against a real server; `TestBuildFKCascadeQuery_matchesSetNull` pins the predicate without Docker.

Results: `go build ./...` OK; `go test -race -tags integration ./internal/cascade/... ./internal/metadata/...` OK (426s / 244s against the Docker MySQL); `go vet -tags integration ./...` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)