### PR TITLE
ext: panic-safe audit Record, uncancelable emission contexts, honest session attribution (#1122)

### DIFF
--- a/ext/audit.go
+++ b/ext/audit.go
@@ -2,6 +2,8 @@ package ext
 
 import (
 	"context"
+	"log/slog"
+	"sync/atomic"
 	"time"
 )
 
@@ -60,13 +62,22 @@ type AuditSink interface {
 	Record(ctx context.Context, ev AuditEvent)
 }
 
-// sink is nil in the OSS build — auditing is a no-op.
-var sink AuditSink
+// sink holds the installed AuditSink; unset in the OSS build — auditing is
+// a no-op. Atomic because the shim reads it once per client round trip from
+// every connection goroutine while audittest.Install swaps it at test time;
+// the atomic load costs nothing on that hot path.
+var sink atomic.Pointer[AuditSink]
 
 // SetAuditSink installs the process-wide audit sink. Call once from
-// main() before command dispatch.
+// main() before command dispatch. The swap is atomic, so a test that
+// installs a sink may drive a surface from another goroutine without
+// racing concurrent Auditing/Record readers.
 func SetAuditSink(s AuditSink) {
-	sink = s
+	if s == nil {
+		sink.Store(nil)
+		return
+	}
+	sink.Store(&s)
 }
 
 // Auditing reports whether a sink is installed. Call it before BUILDING
@@ -75,22 +86,31 @@ func SetAuditSink(s AuditSink) {
 // its callers assemble is a real allocation the OSS build would pay for
 // nothing. Off the hot path, just call Record.
 func Auditing() bool {
-	return sink != nil
+	return sink.Load() != nil
 }
 
 // Record forwards an event to the installed sink, stamping Time when
 // unset. Safe to call with no sink installed.
 //
 // Recording is a side channel: Record returns nothing and AuditSink.Record
-// returns nothing, so a sink cannot fail a user's query by construction.
-// Call it on the success path, after the artifact the operator asked for
-// has been produced.
+// returns nothing, so a sink cannot fail a user's query by construction —
+// and a panicking sink is recovered here (logged at debug, event dropped),
+// so third-party sink code cannot unwind into a caller whose artifact was
+// already produced. Call it on the success path, after the artifact the
+// operator asked for has been produced.
 func Record(ctx context.Context, ev AuditEvent) {
-	if sink == nil {
+	s := sink.Load()
+	if s == nil {
 		return
 	}
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Debug("ext: audit sink panicked; event dropped",
+				"panic", r, "surface", ev.Surface, "action", ev.Action)
+		}
+	}()
 	if ev.Time.IsZero() {
 		ev.Time = time.Now().UTC()
 	}
-	sink.Record(ctx, ev)
+	(*s).Record(ctx, ev)
 }

--- a/ext/ext_test.go
+++ b/ext/ext_test.go
@@ -45,6 +45,42 @@ func TestRecordStampsTimeAndForwards(t *testing.T) {
 	}
 }
 
+type panicSink struct{}
+
+func (panicSink) Record(context.Context, AuditEvent) { panic("third-party sink exploded") }
+
+// TestRecordRecoversSinkPanic pins the docstring's claim: a sink cannot fail
+// a user's query. A panic in third-party sink code must be swallowed by
+// Record, never unwound into a caller whose artifact was already produced.
+func TestRecordRecoversSinkPanic(t *testing.T) {
+	SetAuditSink(panicSink{})
+	t.Cleanup(func() { SetAuditSink(nil) })
+
+	// Must not panic.
+	Record(context.Background(), AuditEvent{Surface: "cli", Action: "query.run"})
+}
+
+// TestAuditSinkSwapIsRaceSafe drives Record/Auditing concurrently with
+// SetAuditSink swaps — the audittest.Install pattern with a surface served on
+// another goroutine. Meaningful under -race (CI always runs it): the old
+// unsynchronized package var failed here.
+func TestAuditSinkSwapIsRaceSafe(t *testing.T) {
+	t.Cleanup(func() { SetAuditSink(nil) })
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range 1000 {
+			Auditing()
+			Record(context.Background(), AuditEvent{Surface: "cli", Action: "query.run"})
+		}
+	}()
+	for range 1000 {
+		SetAuditSink(&captureSink{})
+		SetAuditSink(nil)
+	}
+	<-done
+}
+
 func TestProcessActor(t *testing.T) {
 	a := ProcessActor("")
 	if !strings.HasPrefix(a, "os:") || a == "os:" {

--- a/internal/audittest/audittest.go
+++ b/internal/audittest/audittest.go
@@ -205,10 +205,10 @@ func (r *Recorder) Reset() {
 // Install registers a Recorder as the process-wide audit sink and removes it
 // when the test ends.
 //
-// The sink is a package-level variable in ext, so a test that installs one
-// must NOT call t.Parallel() — and neither may it drive a surface from
-// another goroutine (stand up handlers in-process rather than behind a
-// listener) or the swap races the reader under -race.
+// The sink is process-wide, so a test that installs one must NOT call
+// t.Parallel() — two parallel tests would observe each other's events. The
+// swap itself is atomic (ext keeps the sink behind an atomic.Pointer), so
+// driving a surface from another goroutine is race-safe.
 func Install(t *testing.T) *Recorder {
 	t.Helper()
 	rec := &Recorder{}

--- a/internal/console/audit.go
+++ b/internal/console/audit.go
@@ -1,6 +1,7 @@
 package console
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/dbtrail/dbtrail/ext"
@@ -13,16 +14,28 @@ import (
 // reads like a session whose identity went missing.
 const tokenActor = "token"
 
-// consoleActor is the audit identity of one HTTP request: the session's
-// verified login identity when the request carries a session, otherwise
-// tokenActor. The console is a network surface with real authentication, so —
-// like the shim — it records its authenticated user, never ext.ProcessActor
-// (the daemon's OS owner says nothing about who made the request).
+// sessionUnidentifiedActor is the audit identity of a session-authenticated
+// request whose issuer minted the session with no identity (identityFrom
+// returns ""). Recording it as tokenActor would claim the shared automation
+// token was used when it was not; this sentinel is honest about not knowing,
+// mirroring the shim's "mysql:unbound".
+const sessionUnidentifiedActor = "session:unidentified"
+
+// consoleActor is the audit identity of one HTTP request, decided by which
+// credential authenticated it (authKindFrom, stamped by tokenMiddleware): a
+// session records its verified login identity (or sessionUnidentifiedActor
+// when the session carries none), anything else records tokenActor. The
+// console is a network surface with real authentication, so — like the shim —
+// it records its authenticated user, never ext.ProcessActor (the daemon's OS
+// owner says nothing about who made the request).
 func consoleActor(r *http.Request) string {
+	if authKindFrom(r.Context()) != authKindSession {
+		return tokenActor
+	}
 	if id := identityFrom(r.Context()); id != "" {
 		return id
 	}
-	return tokenActor
+	return sessionUnidentifiedActor
 }
 
 // recordConsoleAccess emits one historical-data-access or
@@ -47,7 +60,12 @@ func recordConsoleAccess(r *http.Request, action, schema, table string, detail m
 	if id := r.Header.Get(serverHeader); id != "" {
 		detail["server"] = id
 	}
-	ext.Record(r.Context(), ext.AuditEvent{
+	// WithoutCancel: by the time this runs the rows were already read and
+	// the response produced, but r.Context() dies with the client — a
+	// disconnect mid-flush would make a ctx-aware sink drop exactly the
+	// aborted-mid-response reads an auditor most wants to see. Context
+	// VALUES (trace IDs, tenant) are preserved.
+	ext.Record(context.WithoutCancel(r.Context()), ext.AuditEvent{
 		Surface: "console",
 		Action:  action,
 		Actor:   consoleActor(r),

--- a/internal/console/audit_contract_test.go
+++ b/internal/console/audit_contract_test.go
@@ -206,16 +206,119 @@ func TestAuditContract_ConsoleSilentOnRefusal(t *testing.T) {
 	}
 }
 
-// TestAuditContract_ConsoleActorFallsBackToToken documents the identity
-// vocabulary: a session request records its verified login, a static-token
-// request records the token sentinel — never "".
-func TestAuditContract_ConsoleActorFallsBackToToken(t *testing.T) {
-	r := httptest.NewRequest("GET", "/api/events", nil)
-	if got := consoleActor(r); got != tokenActor {
-		t.Errorf("consoleActor(no session) = %q, want %q", got, tokenActor)
+// TestAuditContract_ConsoleActorAttribution documents the identity
+// vocabulary, driven through the real tokenMiddleware (the production code
+// that stamps authKind/identity into the context): a static-token request
+// records the token sentinel, a session records its verified login, and a
+// session minted with NO identity records the session-unidentified sentinel —
+// never "" and never "token", which would claim the shared automation token
+// was used when it was not (#1122).
+func TestAuditContract_ConsoleActorAttribution(t *testing.T) {
+	srv, err := New(Config{
+		Listen: "127.0.0.1:8090", Token: "static-tok",
+		AuthPath: filepath.Join(t.TempDir(), "auth.yaml"),
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
-	withID := r.WithContext(context.WithValue(r.Context(), identityCtxKey{}, "ana@example.com"))
-	if got := consoleActor(withID); got != "ana@example.com" {
-		t.Errorf("consoleActor(session) = %q, want the verified identity", got)
+	full := &ext.AccessPolicy{Permissions: ext.AllPermissions()}
+	withID, _, err := srv.sessions.IssueWithPolicy("ana@example.com", full)
+	if err != nil {
+		t.Fatal(err)
+	}
+	noID, _, err := srv.sessions.IssueWithPolicy("", full)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name   string
+		bearer string
+		want   string
+	}{
+		{"static token", "static-tok", tokenActor},
+		{"session with identity", withID, "ana@example.com"},
+		{"session without identity", noID, sessionUnidentifiedActor},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := "(handler never reached)"
+			probe := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				got = consoleActor(r)
+			})
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest("GET", "/api/events", nil)
+			r.Header.Set("Authorization", "Bearer "+tc.bearer)
+			srv.tokenMiddleware(probe).ServeHTTP(w, r)
+			if w.Code != http.StatusOK {
+				t.Fatalf("middleware refused the request: code=%d body=%s", w.Code, w.Body.String())
+			}
+			if got != tc.want {
+				t.Errorf("consoleActor = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// panickingSink is third-party (EE) sink code at its worst.
+type panickingSink struct{}
+
+func (panickingSink) Record(context.Context, ext.AuditEvent) { panic("EE sink exploded") }
+
+// TestAuditContract_ConsoleSinkPanicCannotFailRequest drives the real events
+// handler with a sink that panics: the response the operator asked for was
+// already produced, so the panic must die inside ext.Record — the request
+// still completes with a 200 and the full body (#1122).
+func TestAuditContract_ConsoleSinkPanicCannotFailRequest(t *testing.T) {
+	ext.SetAuditSink(panickingSink{})
+	t.Cleanup(func() { ext.SetAuditSink(nil) })
+
+	db, mock, closeDB := newSQLMock(t)
+	defer closeDB()
+	mock.ExpectQuery("FROM binlog_events").WillReturnRows(auditEventRow(t))
+	s := newBootServer(db)
+	w := httptest.NewRecorder()
+	s.handleEvents(w, httptest.NewRequest("GET", "/api/events?schema=app&table=users", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("a panicking audit sink failed the request: code=%d body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"users"`) {
+		t.Errorf("response body truncated by the sink panic: %s", w.Body.String())
+	}
+}
+
+// ctxObservingSink records whether the context handed to the sink was
+// already dead — what a realistic ctx-aware EE sink (HTTP POST, DB insert)
+// keys its I/O on.
+type ctxObservingSink struct {
+	events  int
+	ctxErrs []error
+}
+
+func (s *ctxObservingSink) Record(ctx context.Context, _ ext.AuditEvent) {
+	s.events++
+	s.ctxErrs = append(s.ctxErrs, ctx.Err())
+}
+
+// TestAuditContract_ConsoleRecordSurvivesCanceledRequest pins fix #2 of
+// #1122: recordConsoleAccess fires after the rows were already read, so a
+// client disconnect (r.Context() canceled) must not hand the sink a dead
+// context — those aborted-mid-response reads are exactly the population an
+// auditor wants recorded.
+func TestAuditContract_ConsoleRecordSurvivesCanceledRequest(t *testing.T) {
+	sink := &ctxObservingSink{}
+	ext.SetAuditSink(sink)
+	t.Cleanup(func() { ext.SetAuditSink(nil) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // the client is gone before the emission fires
+	r := httptest.NewRequest("GET", "/api/events?schema=app&table=users", nil).WithContext(ctx)
+	recordConsoleAccess(r, "query.run", "app", "users", nil)
+
+	if sink.events != 1 {
+		t.Fatalf("recorded %d events, want 1", sink.events)
+	}
+	if sink.ctxErrs[0] != nil {
+		t.Errorf("sink saw a canceled context (%v); a ctx-aware sink would drop the record", sink.ctxErrs[0])
 	}
 }

--- a/internal/shim/audit_contract_test.go
+++ b/internal/shim/audit_contract_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 
+	"github.com/dbtrail/dbtrail/ext"
 	"github.com/dbtrail/dbtrail/internal/audittest"
 	"github.com/dbtrail/dbtrail/internal/query"
 )
@@ -176,6 +177,45 @@ func TestAuditContract_ShimSilentOnRefusal(t *testing.T) {
 	}
 	if evs := rec.Events(); len(evs) != 0 {
 		t.Errorf("a refused query recorded %d audit events, want 0: %+v", len(evs), evs)
+	}
+}
+
+// disconnectObservingSink records whether the context handed to the sink was
+// already dead — what a ctx-aware EE sink (HTTP POST, DB insert) keys on.
+type disconnectObservingSink struct {
+	events  int
+	ctxErrs []error
+}
+
+func (s *disconnectObservingSink) Record(ctx context.Context, _ ext.AuditEvent) {
+	s.events++
+	s.ctxErrs = append(s.ctxErrs, ctx.Err())
+}
+
+// TestAuditContract_ShimRecordSurvivesDisconnect pins fix #2 of #1122: the
+// emission fires after the resultset was built, so a canceled per-connection
+// context (client disconnect / SIGTERM, see BindConnContext) must not hand
+// the sink a dead context — those aborted-mid-response reads are exactly the
+// records an auditor wants.
+func TestAuditContract_ShimRecordSurvivesDisconnect(t *testing.T) {
+	sink := &disconnectObservingSink{}
+	ext.SetAuditSink(sink)
+	t.Cleanup(func() { ext.SetAuditSink(nil) })
+
+	h := auditHandler(t)
+	h.BindActor("tenant_a")
+	ctx, cancel := context.WithCancel(context.Background())
+	h.BindConnContext(ctx)
+	cancel() // the client disconnected after the resultset was built
+
+	q := TimeTravelQuery{Type: TypeFlashback, Schema: "myapp", Table: "orders", PKColumn: "id", PKValue: "1"}
+	h.auditTimeTravel(q, nil)
+
+	if sink.events != 1 {
+		t.Fatalf("recorded %d events, want 1", sink.events)
+	}
+	if sink.ctxErrs[0] != nil {
+		t.Errorf("sink saw a canceled context (%v); a ctx-aware sink would drop the record", sink.ctxErrs[0])
 	}
 }
 

--- a/internal/shim/handler.go
+++ b/internal/shim/handler.go
@@ -548,9 +548,13 @@ func (h *Handler) auditTimeTravel(q TimeTravelQuery, res *mysql.Result) {
 	if res != nil && res.Resultset != nil {
 		detail["rows"] = strconv.Itoa(len(res.Resultset.Values))
 	}
-	ctx := h.baseCtx
-	if ctx == nil {
-		ctx = context.Background()
+	// WithoutCancel: the resultset is already built by the time this runs,
+	// but baseCtx is the per-connection context, canceled on client
+	// disconnect and SIGTERM — a ctx-aware sink would drop exactly the
+	// records for reads aborted mid-response. Context values survive.
+	ctx := context.Background()
+	if h.baseCtx != nil {
+		ctx = context.WithoutCancel(h.baseCtx)
 	}
 	ext.Record(ctx, ext.AuditEvent{
 		Surface: "shim",


### PR DESCRIPTION
Closes #1122

Four robustness fixes to the `ext.AuditSink` seam, all scoped to what the issue specifies:

## 1. `ext.Record` is now panic-safe
`Record` recovers a panicking sink (`slog.Debug`, event dropped), making the docstring's "a sink cannot fail a user's query by construction" claim true for third-party EE sink code. One recover covers all thirteen call sites — a sink panic can no longer fail a finished CLI recovery, kill a shim connection mid-resultset, or truncate a flushed console response.

## 2. Emission contexts survive client disconnect
- `internal/console/audit.go`: `recordConsoleAccess` wraps `r.Context()` with `context.WithoutCancel`.
- `internal/shim/handler.go` (`auditTimeTravel`): wraps `h.baseCtx` the same way.

By the time either fires, the rows were already read — a ctx-aware sink (HTTP POST / DB insert) would otherwise drop exactly the aborted-mid-response reads an auditor most wants recorded. Context values (trace IDs, tenant) are preserved.

## 3. `consoleActor` keys on `authKind`, not identity emptiness
A session-authenticated request whose issuer minted no identity now records `"session:unidentified"` (mirroring the shim's `mysql:unbound` sentinel) instead of `"token"` — which falsely claimed the shared automation token was used. Token requests still record `"token"`; sessions with identity still record the verified login.

## 4. Sink storage is an `atomic.Pointer`
`SetAuditSink`/`Auditing`/`Record` no longer race with `audittest.Install` swaps; the `audittest` docstring warning about driving surfaces from another goroutine is removed (the no-`t.Parallel()` rule stays — that one is about event isolation, not races).

## Tests
- Sink panic driven through the **real console events handler** (production path): request still returns 200 with a full body.
- Canceled request/connection contexts through both production emission helpers (`recordConsoleAccess`, `auditTimeTravel`): sink receives a live context.
- Actor attribution through the **real `tokenMiddleware`**: static token → `token`, session with identity → identity, identity-less session → `session:unidentified` (replaces the old hand-built-context test).
- `-race` swap loop in `ext` pinning the atomic sink.

`go build ./...`, `go vet -tags integration ./...`, and `go test -race -count=1` on `ext`, `internal/shim`, `internal/console` all pass (console needed an isolated rerun — the known local-load flake in the bcrypt auth tests, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)