### PR TITLE
verify: honest verdicts for legacy and young indexes in --check recover

### DIFF
--- a/docs/verify.md
+++ b/docs/verify.md
@@ -120,8 +120,8 @@ that same key left behind**. Events superseded by a newer event on the same key
 are walked too; that is precisely the class `--check content` skips.
 
 It reads **the index only** — no baseline, no live source — so
-`--baseline-dir`/`--baseline-s3` are not required and `--source-dsn` is
-rejected.
+`--baseline-dir`/`--baseline-s3` are not required, and `--source-dsn` and
+`--explain` (a content-mode drill-down it could never print) are rejected.
 
 ```sh
 # Walk the last 7 days of chains for every table in the schema snapshot
@@ -197,6 +197,10 @@ discard every clean assertion beside it and fail the gate on a healthy index.
 > behavior, not a bug — but the fix is to **shorten `--lookback`** to your real
 > retention (or enable archiving), not to ignore the result. Since an
 > all-inconclusive run exits non-zero, a cron gate will tell you immediately.
+> An index **younger** than the lookback is called out explicitly: the reason
+> says the missing hours *predate the index's history* (nothing rotated away —
+> the index did not exist yet), and the remedy is the same — shorten
+> `--lookback` to the index's age or less.
 
 Memory bound: the walk loads at most `--max-events` events per table (default
 200,000) plus one row of state per distinct primary key seen. The cap is a
@@ -261,8 +265,11 @@ bintrail verify --index-dsn "$IDX" --baseline-dir /data/baselines --format json
 - `tables[].events_checked` / `chains_checked` / `chains_inconclusive` —
   present only under `--check recover` (omitted entirely otherwise, so a
   content-mode document is unchanged): how many events the chain walk visited,
-  how many distinct primary keys it walked, and how many of those began
-  mid-window with no predecessor to assert against. The row-count and digest
+  how many distinct primary keys it walked, and how many of those held at
+  least one event with no predecessor state to assert against — the chain
+  began mid-window, a PK-changing `UPDATE` moved the row off the key, or the
+  chain was restarted after a nil-image or unresolved-TOAST finding (the state
+  after such an event is unknowable). The row-count and digest
   fields stay absent in this mode — it compares no table content.
 - `explain[]` — present only with `--explain`: per mismatched table, the capped
   list of differing rows (`pk`, `kind`, and per-column `recovery` vs `baseline`
@@ -311,15 +318,18 @@ diff tool involved.
 | `--baseline-s3` | *(empty)* | S3 URL prefix of baseline snapshots (e.g. `s3://bucket/baselines/`) |
 | `--tables` | *(all)* | Comma-separated `schema.table` list (default: all tables in the latest schema snapshot; in baseline-anchored mode, snapshot tables with no baseline report `inconclusive` — "never baselined") |
 | `--no-archive` | `false` | Query live MySQL partitions only; skip Parquet archive discovery |
-| `--explain` | `false` | On a baseline-anchored mismatch, print a per-row drill-down |
+| `--explain` | `false` | On a baseline-anchored mismatch, print a per-row drill-down. Rejected under `--check recover` |
 | `--format` | `text` | Output format: `text` or `json` (see [Machine-readable output](#machine-readable-output---format-json)) |
 | `--check` | `content` | What to verify: `content` (reconstructed table content) or `recover` (`recover`'s before/after image inputs, index-only) |
-| `--lookback` | `30d` | `--check recover` only: how far back to walk each key's event chain (e.g. `30d`, `24h`) |
-| `--max-events` | `200000` | `--check recover` only: per-table cap on events loaded; exceeding it reports `inconclusive` rather than a partial check |
+| `--lookback` | `30d` | `--check recover` only: how far back to walk each key's event chain (e.g. `30d`, `24h`). Rejected under `--check content` |
+| `--max-events` | `200000` | `--check recover` only: per-table cap on events loaded; exceeding it reports `inconclusive` rather than a partial check. Rejected under `--check content` |
 
 One of `--baseline-dir` or `--baseline-s3` is **required** for `--check content`
 (both of its modes read baselines). `--check recover` reads the index only, so
-it requires neither — and rejects `--source-dsn`, which it would not use.
+it requires neither — and rejects `--source-dsn` and `--explain`, which it
+would not honour. Symmetrically, `--check content` rejects `--lookback` and
+`--max-events`, which only the recover-input walk reads: a flag that is
+accepted must be a flag that was honoured.
 
 It also accepts the shared DuckDB tuning flags (`--ultrafast`,
 `--duckdb-threads`, `--duckdb-memory-limit`) — see the DuckDB resource tuning

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -133,19 +133,18 @@ func runVerify(cmd *cobra.Command, _ []string) error {
 	default:
 		return fmt.Errorf("invalid --check %q; must be %s or %s", vfyCheck, checkContent, checkRecover)
 	}
+	if err := checkVerifyFlagScope(vfyCheck, vfySourceDSN, vfyExplain,
+		cmd.Flags().Changed("lookback"), cmd.Flags().Changed("max-events")); err != nil {
+		return err
+	}
 	baselineSrc := vfyBaselineDir
 	if baselineSrc == "" {
 		baselineSrc = vfyBaselineS3
 	}
 	// The recover-input check reads binlog_events and nothing else, so
 	// requiring a baseline it never opens would refuse a perfectly runnable
-	// verification. --source-dsn is likewise unused there: accepting it
-	// silently would imply the live source was consulted when it was not.
-	if vfyCheck == checkRecover {
-		if vfySourceDSN != "" {
-			return fmt.Errorf("--source-dsn is not used by --check recover (it verifies recover's inputs from the index alone); omit it")
-		}
-	} else if baselineSrc == "" {
+	// verification.
+	if vfyCheck != checkRecover && baselineSrc == "" {
 		return fmt.Errorf("one of --baseline-dir or --baseline-s3 is required")
 	}
 
@@ -497,6 +496,35 @@ func runVerifyRecoverInputs(cmd *cobra.Command, indexDB *sql.DB, resolver *metad
 		results = append(results, res)
 	}
 	return emitVerifyReport(cmd, verify.NewReport(verify.ModeRecoverInputs, results))
+}
+
+// checkVerifyFlagScope rejects flags the selected --check would silently
+// ignore. Accepting a flag implies it was honoured: --explain under --check
+// recover would promise a row-level drill-down that never prints, and
+// --lookback/--max-events under --check content would promise a window and an
+// event budget that content comparison does not have — the same reasoning
+// behind rejecting --source-dsn, which --check recover never opens (#1126).
+//
+// lookbackSet/maxEventsSet are pflag Changed() bits, not value comparisons,
+// because both flags carry non-zero defaults an operator could legitimately
+// re-state.
+func checkVerifyFlagScope(check, sourceDSN string, explain, lookbackSet, maxEventsSet bool) error {
+	if check == checkRecover {
+		if sourceDSN != "" {
+			return fmt.Errorf("--source-dsn is not used by --check recover (it verifies recover's inputs from the index alone); omit it")
+		}
+		if explain {
+			return fmt.Errorf("--explain is not used by --check recover (the row-level drill-down exists only for baseline-anchored content mismatches); omit it")
+		}
+		return nil
+	}
+	if lookbackSet {
+		return fmt.Errorf("--lookback is only used by --check recover; --check content always compares full reconstructed content, so omit it")
+	}
+	if maxEventsSet {
+		return fmt.Errorf("--max-events is only used by --check recover; --check content always compares full reconstructed content, so omit it")
+	}
+	return nil
 }
 
 // verifyTableFilter parses --tables into a "schema.table" set, or nil for all.

--- a/internal/cli/verify_test.go
+++ b/internal/cli/verify_test.go
@@ -2,9 +2,11 @@ package cli
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"github.com/dbtrail/dbtrail/internal/verify"
 )
@@ -50,4 +52,107 @@ func TestPrintVerifyReport_ExitCodes(t *testing.T) {
 			})
 		}
 	}
+}
+
+// TestCheckVerifyFlagScope pins the rule that an accepted flag is an honoured
+// flag (#1126): each --check rejects the other's flags instead of silently
+// ignoring them — the same reasoning that already rejected --source-dsn under
+// --check recover.
+func TestCheckVerifyFlagScope(t *testing.T) {
+	cases := []struct {
+		name                      string
+		check, sourceDSN          string
+		explain                   bool
+		lookbackSet, maxEventsSet bool
+		wantErr                   string // "" means accepted
+	}{
+		{name: "recover rejects --source-dsn", check: checkRecover, sourceDSN: "dsn", wantErr: "--source-dsn"},
+		{name: "recover rejects --explain", check: checkRecover, explain: true, wantErr: "--explain"},
+		{name: "recover accepts its own flags", check: checkRecover, lookbackSet: true, maxEventsSet: true},
+		{name: "content rejects --lookback", check: checkContent, lookbackSet: true, wantErr: "--lookback"},
+		{name: "content rejects --max-events", check: checkContent, maxEventsSet: true, wantErr: "--max-events"},
+		{name: "content accepts its own flags", check: checkContent, sourceDSN: "dsn", explain: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := checkVerifyFlagScope(tc.check, tc.sourceDSN, tc.explain, tc.lookbackSet, tc.maxEventsSet)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("want accepted, got %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("want an error naming %s, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+// restoreVerifyFlags snapshots every flag on the real verifyCmd (value and
+// Changed bit — the command globals are bound to them and never reset) and
+// restores both at cleanup, so driving the production flag parsing in one test
+// cannot leak into the next. Never call it from a t.Parallel() test.
+func restoreVerifyFlags(t *testing.T) {
+	t.Helper()
+	type saved struct {
+		val     string
+		changed bool
+	}
+	prev := map[string]saved{}
+	verifyCmd.Flags().VisitAll(func(f *pflag.Flag) {
+		prev[f.Name] = saved{f.Value.String(), f.Changed}
+	})
+	t.Cleanup(func() {
+		verifyCmd.Flags().VisitAll(func(f *pflag.Flag) {
+			s := prev[f.Name]
+			if err := f.Value.Set(s.val); err != nil {
+				t.Errorf("restore --%s: %v", f.Name, err)
+			}
+			f.Changed = s.changed
+		})
+	})
+}
+
+// TestRunVerify_RejectsFlagsTheCheckWouldIgnore drives the REAL command's flag
+// parsing (Changed() is how --lookback/--max-events are detected, since both
+// carry non-zero defaults) and asserts runVerify refuses before touching any
+// database.
+func TestRunVerify_RejectsFlagsTheCheckWouldIgnore(t *testing.T) {
+	cases := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{"explain under recover", []string{"--index-dsn", "x", "--check", "recover", "--explain"}, "--explain"},
+		{"source-dsn under recover", []string{"--index-dsn", "x", "--check", "recover", "--source-dsn", "y"}, "--source-dsn"},
+		{"lookback under content", []string{"--index-dsn", "x", "--baseline-dir", "/nowhere", "--lookback", "7d"}, "--lookback"},
+		{"max-events under content", []string{"--index-dsn", "x", "--baseline-dir", "/nowhere", "--max-events", "5"}, "--max-events"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			restoreVerifyFlags(t)
+			if err := verifyCmd.ParseFlags(tc.args); err != nil {
+				t.Fatalf("ParseFlags: %v", err)
+			}
+			err := runVerify(verifyCmd, nil)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("want a rejection naming %s, got %v", tc.wantErr, err)
+			}
+		})
+	}
+
+	// Positive control: the same flags under the check that DOES honour them
+	// must pass the scope gate (the run then fails later, on the bogus DSN —
+	// but not on the flags).
+	t.Run("lookback under recover is honoured", func(t *testing.T) {
+		restoreVerifyFlags(t)
+		if err := verifyCmd.ParseFlags([]string{"--index-dsn", "x", "--check", "recover", "--lookback", "7d", "--max-events", "5"}); err != nil {
+			t.Fatalf("ParseFlags: %v", err)
+		}
+		err := runVerify(verifyCmd, nil)
+		if err != nil && (strings.Contains(err.Error(), "--lookback") || strings.Contains(err.Error(), "--max-events")) {
+			t.Fatalf("recover must honour its own flags, got %v", err)
+		}
+	})
 }

--- a/internal/query/fetchmerged.go
+++ b/internal/query/fetchmerged.go
@@ -28,6 +28,12 @@ type ArchiveFetcher func(ctx context.Context, opts Options, source string) ([]Re
 // re-wrap at the call site.
 type GapError struct {
 	GapHours []time.Time
+
+	// OldestKnownHour is QueryPlan.OldestKnownHour: the earliest hour the
+	// index has ever held (zero when unknown). Callers can use it to word a
+	// gap honestly — a gap hour before it never rotated away, the index
+	// simply did not exist yet (#1126).
+	OldestKnownHour time.Time
 }
 
 func (e *GapError) Error() string {
@@ -401,7 +407,7 @@ func resolveMergeSources(ctx context.Context, db *sql.DB, o FetchMergedOptions) 
 	// Gap enforcement runs before any fetch so we fail fast in strict mode.
 	if src.plan != nil && len(src.plan.GapHours) > 0 {
 		if !o.AllowGaps {
-			return src, &GapError{GapHours: src.plan.GapHours}
+			return src, &GapError{GapHours: src.plan.GapHours, OldestKnownHour: src.plan.OldestKnownHour}
 		}
 		slog.Warn(FormatGapWarning(src.plan.GapHours))
 	}

--- a/internal/query/planner.go
+++ b/internal/query/planner.go
@@ -28,6 +28,15 @@ type QueryPlan struct {
 	// GapHours are hours where data has been rotated out of MySQL and no
 	// archive exists. Callers should emit a warning for these.
 	GapHours []time.Time
+
+	// OldestKnownHour is the earliest hour this index has ever held — the
+	// oldest live partition or archived hour the planner saw (post-noArchive
+	// filtering, so under --no-archive it is the oldest LIVE partition only).
+	// Zero when no partitions exist at all. It lets a caller tell a gap hour
+	// that ROTATED away from one that predates the index's existence — on an
+	// index younger than the queried window, every pre-install hour is a
+	// "gap" that was never captured in the first place (#1126).
+	OldestKnownHour time.Time
 }
 
 // Plan builds a QueryPlan for the given time range by inspecting live partition
@@ -152,6 +161,16 @@ func buildPlan(liveHours, archivedHours []time.Time, rangeStart, rangeEnd time.T
 	}
 
 	plan := &QueryPlan{GapHours: gaps}
+	for _, h := range liveHours {
+		if plan.OldestKnownHour.IsZero() || h.Before(plan.OldestKnownHour) {
+			plan.OldestKnownHour = h
+		}
+	}
+	for _, h := range archivedHours {
+		if plan.OldestKnownHour.IsZero() || h.Before(plan.OldestKnownHour) {
+			plan.OldestKnownHour = h
+		}
+	}
 
 	if needMySQL {
 		plan.MySQLRanges = buildContiguousRanges(liveHours, rangeStart, rangeEnd)

--- a/internal/query/planner_test.go
+++ b/internal/query/planner_test.go
@@ -178,6 +178,25 @@ func TestPlan_noTimeRange(t *testing.T) {
 
 // ─── buildPlan tests (core routing logic) ─────────────────────────────────────
 
+// OldestKnownHour lets GapError consumers tell a rotated hour from one that
+// predates the index's existence (#1126). It must reflect exactly the hours
+// the plan honours: under noArchive, archived history is excluded from the
+// fetch, so the oldest LIVE hour is the oldest this plan can vouch for.
+func TestBuildPlan_StampsOldestKnownHour(t *testing.T) {
+	live := []time.Time{h(6, 10), h(6, 11)}
+	archived := []time.Time{h(5, 3), h(5, 4)}
+
+	if plan := buildPlan(live, archived, h(5, 0), h(6, 12), false); !plan.OldestKnownHour.Equal(h(5, 3)) {
+		t.Errorf("archives honored: OldestKnownHour = %v, want %v", plan.OldestKnownHour, h(5, 3))
+	}
+	if plan := buildPlan(live, archived, h(5, 0), h(6, 12), true); !plan.OldestKnownHour.Equal(h(6, 10)) {
+		t.Errorf("noArchive: OldestKnownHour = %v, want oldest LIVE hour %v", plan.OldestKnownHour, h(6, 10))
+	}
+	if plan := buildPlan(nil, nil, h(5, 0), h(5, 2), false); !plan.OldestKnownHour.IsZero() {
+		t.Errorf("no partitions at all: OldestKnownHour must stay zero (unknown), got %v", plan.OldestKnownHour)
+	}
+}
+
 func h(day, hour int) time.Time {
 	return time.Date(2026, 1, day, hour, 0, 0, 0, time.UTC)
 }

--- a/internal/verify/recover_inputs.go
+++ b/internal/verify/recover_inputs.go
@@ -134,7 +134,7 @@ func VerifyRecoverInputs(ctx context.Context, cfg RecoverInputsConfig, schema, t
 	if err != nil {
 		var gap *query.GapError
 		if errors.As(err, &gap) {
-			return inconclusive(res, "coverage gap in the window: "+gap.Error()+"; a chain with an interior hole cannot be asserted against"), nil
+			return inconclusive(res, recoverGapDetail(gap, cfg.NoArchive)), nil
 		}
 		return res, fmt.Errorf("fetch events %s.%s: %w", schema, table, err)
 	}
@@ -209,6 +209,51 @@ func recoverInputsFetchOptions(schema, table string, since, until time.Time, max
 		Order:  "ASC",
 		Limit:  maxEvents + 1,
 	}
+}
+
+// recoverGapDetail words a coverage-gap abort for the operator. The generic
+// GapError text says the missing hours were "rotated and not archived" — false
+// for hours before the index's FIRST partition ever existed. Partitions are
+// created from install time forward, so on an index younger than --lookback
+// every pre-install hour is such a "gap"; claiming rotation would send the
+// operator hunting for a retention loss that never happened, and the standard
+// remedy (shorten --lookback) would read as unactionable when it is exactly
+// right (#1126). The planner stamps the oldest hour it has ever seen into the
+// GapError so the two cases can be told apart here.
+func recoverGapDetail(gap *query.GapError, noArchive bool) string {
+	generic := "coverage gap in the window: " + gap.Error() + "; a chain with an interior hole cannot be asserted against"
+	oldest := gap.OldestKnownHour
+	if oldest.IsZero() {
+		return generic
+	}
+	var preHistory, holes []time.Time
+	for _, h := range gap.GapHours {
+		if h.Before(oldest) {
+			preHistory = append(preHistory, h)
+		} else {
+			holes = append(holes, h)
+		}
+	}
+	if len(preHistory) == 0 {
+		return generic
+	}
+	const hourFmt = "2006-01-02 15:00"
+	var msg string
+	if noArchive {
+		// Under --no-archive the planner never reads archive_state, so
+		// "oldest" is the oldest LIVE partition — archived history older than
+		// it may exist but is excluded from this walk. Claiming the index has
+		// no history there would assert more than was checked.
+		msg = fmt.Sprintf("the window reaches back to %s but the oldest live partition holds %s; the hours before it are not available to this walk (--no-archive also excludes any archived history) — shorten --lookback, or drop --no-archive if archives cover them",
+			preHistory[0].UTC().Format(hourFmt), oldest.UTC().Format(hourFmt))
+	} else {
+		msg = fmt.Sprintf("the window reaches back to %s but the oldest hour this index has ever held (live or archived) is %s; the hours before it predate the index's history — nothing rotated away, the index did not exist yet — so shorten --lookback to the index's age or less",
+			preHistory[0].UTC().Format(hourFmt), oldest.UTC().Format(hourFmt))
+	}
+	if len(holes) > 0 {
+		msg += "; separately, " + query.FormatGapWarning(holes) + " — a chain with an interior hole cannot be asserted against"
+	}
+	return msg
 }
 
 // ─── Stamped capture gaps ─────────────────────────────────────────────────────
@@ -327,8 +372,10 @@ type recoverChainOutcome struct {
 	Events, Chains int
 	// ChainsNoPredecessor counts DISTINCT primary keys that held at least one
 	// event with no predecessor state to assert against — the window opened
-	// mid-history, or a PK-changing UPDATE moved the row out from under the
-	// key. Legitimately unverifiable, never a mismatch. Counted per key, not
+	// mid-history, a PK-changing UPDATE moved the row out from under the
+	// key, or the chain was restarted after a nil-image/unresolved-TOAST/
+	// unknown-type finding (the state after such an event is not knowable).
+	// Legitimately unverifiable, never a mismatch. Counted per key, not
 	// per event, so it can never exceed Chains.
 	ChainsNoPredecessor int
 	// Assertions is how many before-image comparisons were actually made:
@@ -382,7 +429,18 @@ func checkRecoverChains(in recoverChainInput) recoverChainOutcome {
 	out := recoverChainOutcome{Events: len(in.Events)}
 	states := make(map[string]*chainState)
 
-	var mismatches []string
+	// Only the FIRST mismatch detail and the total are ever reported
+	// (recoverChainVerdict), so keeping every formatted string would be an
+	// unbounded memory term on a systemically broken table — up to MaxEvents
+	// retained strings for no output anyone sees (#1126).
+	var mismatchCount int
+	var firstMismatch string
+	recordMismatch := func(detail string) {
+		if mismatchCount == 0 {
+			firstMismatch = detail
+		}
+		mismatchCount++
+	}
 	var unresolved int
 	var firstUnresolved string
 	noPredecessor := make(map[string]struct{})
@@ -415,7 +473,7 @@ func checkRecoverChains(in recoverChainInput) recoverChainOutcome {
 		// buildInsert/buildUpdate/buildDelete. An INSERT with a nil
 		// row_before is NORMAL (there is no prior row) and is not flagged.
 		if detail, bad := checkImagesPresent(ev); bad {
-			mismatches = append(mismatches, detail)
+			recordMismatch(detail)
 			// The chain's state after an event whose images are broken is
 			// not knowable; restart rather than cascade one defect into
 			// every later event on this PK.
@@ -425,7 +483,7 @@ func checkRecoverChains(in recoverChainInput) recoverChainOutcome {
 
 		// (2) The same unchanged-TOAST refusal recovery performs up front.
 		if err := event.CheckUnresolvedToast(ev.SchemaName, ev.TableName, ev.PKValues, ev.RowBefore, ev.RowAfter); err != nil {
-			mismatches = append(mismatches, fmt.Sprintf("event %d (pk=%s): %v", ev.EventID, ev.PKValues, err))
+			recordMismatch(fmt.Sprintf("event %d (pk=%s): %v", ev.EventID, ev.PKValues, err))
 			*st = chainState{}
 			continue
 		}
@@ -443,7 +501,7 @@ func checkRecoverChains(in recoverChainInput) recoverChainOutcome {
 			verdict, detail := assertBeforeImage(ev, st, in)
 			switch verdict {
 			case chainMismatch:
-				mismatches = append(mismatches, detail)
+				recordMismatch(detail)
 			case chainUnresolved:
 				unresolved++
 				if firstUnresolved == "" {
@@ -476,7 +534,7 @@ func checkRecoverChains(in recoverChainInput) recoverChainOutcome {
 			// A type recovery has no reversal for (it errors with "unknown
 			// event type"). Not silently skipped — an unwalkable event means
 			// the chain past it is not knowable.
-			mismatches = append(mismatches, fmt.Sprintf("event %d (pk=%s): unknown event type %d; recover cannot reverse it",
+			recordMismatch(fmt.Sprintf("event %d (pk=%s): unknown event type %d; recover cannot reverse it",
 				ev.EventID, ev.PKValues, ev.EventType))
 			*st = chainState{}
 		}
@@ -487,7 +545,7 @@ func checkRecoverChains(in recoverChainInput) recoverChainOutcome {
 	// rows must not report events "checked" that were never walked.
 	out.Events = len(in.Events) - out.UnwalkableEvents
 	out.ChainsNoPredecessor = len(noPredecessor)
-	out.Status, out.Detail = recoverChainVerdict(out, mismatches, unresolved, firstUnresolved, in.Truncated)
+	out.Status, out.Detail = recoverChainVerdict(out, mismatchCount, firstMismatch, unresolved, firstUnresolved, in.Truncated)
 	return out
 }
 
@@ -508,15 +566,15 @@ func checkRecoverChains(in recoverChainInput) recoverChainOutcome {
 // Truncation is the one exception that still collapses the table: there the
 // unchecked part is not a handful of values but the entire TAIL of the window,
 // which was never loaded at all.
-func recoverChainVerdict(out recoverChainOutcome, mismatches []string, unresolved int, firstUnresolved string, truncated bool) (Status, string) {
+func recoverChainVerdict(out recoverChainOutcome, mismatchCount int, firstMismatch string, unresolved int, firstUnresolved string, truncated bool) (Status, string) {
 	scope := fmt.Sprintf("%d event(s), %d chain(s), %d before-image assertion(s)", out.Events, out.Chains, out.Assertions)
 
 	// A mismatch is conclusive regardless of what else could not be checked:
 	// the events that WERE walked are real, and recover would consume them.
-	if len(mismatches) > 0 {
-		detail := fmt.Sprintf("%d recover-input inconsistency(ies) in %s: %s", len(mismatches), scope, mismatches[0])
-		if len(mismatches) > 1 {
-			detail += fmt.Sprintf(" (and %d more)", len(mismatches)-1)
+	if mismatchCount > 0 {
+		detail := fmt.Sprintf("%d recover-input inconsistency(ies) in %s: %s", mismatchCount, scope, firstMismatch)
+		if mismatchCount > 1 {
+			detail += fmt.Sprintf(" (and %d more)", mismatchCount-1)
 		}
 		return StatusMismatch, detail
 	}
@@ -529,7 +587,7 @@ func recoverChainVerdict(out recoverChainOutcome, mismatches []string, unresolve
 		notes = append(notes, fmt.Sprintf("%d chain(s) began mid-history and were not asserted", out.ChainsNoPredecessor))
 	}
 	if unresolved > 0 {
-		notes = append(notes, fmt.Sprintf("%d before-image comparison(s) were not conclusive because a value's representation could not be normalized: %s", unresolved, firstUnresolved))
+		notes = append(notes, fmt.Sprintf("%d before-image comparison(s) were not conclusive (a value representation or schema epoch that could not be resolved): %s", unresolved, firstUnresolved))
 	}
 	if out.UnwalkableEvents > 0 {
 		notes = append(notes, fmt.Sprintf("%d event(s) carry no primary key (drift rows) and belong to no chain, so they were not walked", out.UnwalkableEvents))
@@ -548,6 +606,12 @@ func recoverChainVerdict(out recoverChainOutcome, mismatches []string, unresolve
 	}
 	return StatusMatch, detail
 }
+
+// emptyImagePairMarker is compareImages' out-of-band signal that BOTH images
+// were empty — nothing to compare, so nothing was proven. It contains a NUL
+// byte, which no real MySQL column name can, so it can never collide with an
+// actual unresolved column.
+const emptyImagePairMarker = "\x00empty-images"
 
 // chainVerdict is one event's before-image assertion outcome.
 type chainVerdict int
@@ -582,8 +646,11 @@ func assertBeforeImage(ev *query.ResultRow, st *chainState, in recoverChainInput
 	switch {
 	case equal:
 		return chainAsserted, ""
+	case unresolvedCol == emptyImagePairMarker:
+		return chainUnresolved, fmt.Sprintf("event %d (pk=%s): both row images are empty, so their equality cannot be proven",
+			ev.EventID, ev.PKValues)
 	case unresolvedCol != "":
-		return chainUnresolved, fmt.Sprintf("event %d (pk=%s) column %q holds an ENUM/SET, JSON, binary, BIT or spatial value whose representation could not be normalized",
+		return chainUnresolved, fmt.Sprintf("event %d (pk=%s) column %q could not be compared conclusively (a value representation that could not be normalized, or a column-set difference whose schema epoch differs or is unknown)",
 			ev.EventID, ev.PKValues, unresolvedCol)
 	default:
 		return chainMismatch, fmt.Sprintf("event %d (pk=%s, %s): row_before does not match the state the previous event on this primary key left (column %s) — either the events in between were never captured, or the stored before-image is stale or corrupt; %s",
@@ -621,6 +688,14 @@ const chainBreakGuidance = "recover would build reversal SQL from a before-image
 // value whose event representation provably cannot be made byte-faithful, the
 // same gate deferredReprUnresolved applies in the content modes.
 func compareImages(prev, cur map[string]any, prevVer, curVer uint32, in recoverChainInput) (equal bool, unresolvedCol, diffCol string) {
+	// Two images with NO columns at all prove nothing about each other, so
+	// "equal" — a proven assertion — must not be reachable from emptiness.
+	// Unreachable in practice (#493's partial-row-image guard hard-errors on
+	// non-FULL binlog_row_image before such events could be indexed), but
+	// cheap to pin (#1126).
+	if len(prev) == 0 && len(cur) == 0 {
+		return false, emptyImagePairMarker, ""
+	}
 	cols := unionKeys(prev, cur)
 	for _, name := range cols {
 		_, inPrev := prev[name]
@@ -628,8 +703,16 @@ func compareImages(prev, cur map[string]any, prevVer, curVer uint32, in recoverC
 		if inPrev != inCur {
 			// The two images disagree on which columns exist. Across a schema
 			// version boundary that is DDL, not corruption; within one
-			// version it is a genuine structural divergence.
-			if prevVer != curVer {
+			// version it is a genuine structural divergence. A version of 0
+			// is NOT a version: query.ResultRow.SchemaVersion is documented
+			// as "0 for pre-migration data", so on a legacy index every event
+			// carries 0 and prevVer == curVer holds across a real DDL — which
+			// would turn an ADD/DROP COLUMN inside the window into a
+			// conclusive MISMATCH on a healthy index (#1126). Zero on either
+			// side means the epoch is unknown, and an unknown epoch cannot
+			// prove corruption, so it degrades to unresolved like the
+			// version-skew case.
+			if prevVer != curVer || prevVer == 0 || curVer == 0 {
 				return false, name, ""
 			}
 			return false, "", fmt.Sprintf("%q is present in one image and absent from the other", name)

--- a/internal/verify/recover_inputs_integration_test.go
+++ b/internal/verify/recover_inputs_integration_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/dbtrail/dbtrail/internal/indexer"
 	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/query"
 	"github.com/dbtrail/dbtrail/internal/testutil"
 )
 
@@ -134,5 +135,63 @@ func TestVerifyRecoverInputs_StampedCaptureGapIsInconclusiveNotMismatch(t *testi
 		t.Fatal("an unreadable capture-continuity record must surface as an error, not a verdict")
 	} else if !strings.Contains(err.Error(), "capture-continuity record") {
 		t.Errorf("error should name what could not be read, got: %v", err)
+	}
+}
+
+// TestVerifyRecoverInputs_WindowPredatingIndexHistorySaysSo pins the gap
+// wording for an index YOUNGER than the walk window (#1126). Partitions are
+// created from install time forward, so every hour before the index's first
+// partition is a planner "gap" — but nothing rotated away: the index did not
+// exist. The old reason ("rotated and not archived") sent operators hunting a
+// retention loss that never happened, and made the documented remedy (shorten
+// --lookback) read as unactionable when it was exactly right.
+func TestVerifyRecoverInputs_WindowPredatingIndexHistorySaysSo(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	testutil.MustExec(t, db, `INSERT INTO schema_snapshots
+		(snapshot_id, snapshot_time, schema_name, table_name, column_name,
+		 ordinal_position, column_key, data_type, column_type, is_nullable, is_generated)
+		VALUES (1, UTC_TIMESTAMP(), ?, 'orders', 'id', 1, 'PRI', 'int', 'int', 'NO', 0)`, dbName)
+
+	now := time.Now().UTC()
+	curHour := now.Truncate(time.Hour)
+	// The index's entire history: two partitions, created this hour and last.
+	h1, h2 := curHour.Add(-time.Hour), curHour
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{h1, h2})
+
+	resolver, err := metadata.NewResolver(db, 1)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+	res, err := VerifyRecoverInputs(context.Background(), RecoverInputsConfig{
+		IndexDB:     db,
+		Resolver:    resolver,
+		IndexDBName: dbName,
+		// Archives honored (none registered): the production default path.
+		ArchiveFetcher: func(context.Context, query.Options, string) ([]query.ResultRow, error) {
+			return nil, nil
+		},
+		// A lookback longer than the index has existed.
+		Since: h1.Add(-3 * time.Hour),
+		Until: now,
+	}, dbName, "orders")
+	if err != nil {
+		t.Fatalf("VerifyRecoverInputs: %v", err)
+	}
+
+	if res.Status != StatusInconclusive {
+		t.Fatalf("a window the index cannot cover is inconclusive, got %s (%s)", res.Status, res.Detail)
+	}
+	if strings.Contains(res.Detail, "rotated and not archived") {
+		t.Errorf("hours before the index existed never rotated, got: %s", res.Detail)
+	}
+	if !strings.Contains(res.Detail, "predate the index's history") {
+		t.Errorf("detail should say the window predates the index, got: %s", res.Detail)
+	}
+	if !strings.Contains(res.Detail, "--lookback") {
+		t.Errorf("detail should carry the actionable remedy, got: %s", res.Detail)
 	}
 }

--- a/internal/verify/recover_inputs_test.go
+++ b/internal/verify/recover_inputs_test.go
@@ -780,3 +780,173 @@ func TestNewReport_RecoverInputsCarriesChainCountsAndExits(t *testing.T) {
 		}
 	}
 }
+
+// ─── #1126: verdicts must not assert more than the data supports ─────────────
+
+// On a LEGACY index every event carries SchemaVersion 0 ("0 for pre-migration
+// data"), so prevVer == curVer holds across a real DDL and the column-set
+// escape hatch never fired: an ADD COLUMN inside the window read as a
+// conclusive MISMATCH on a healthy index. Zero on either side is an unknown
+// epoch and must degrade to unresolved (inconclusive), exactly like the
+// version-skew case.
+func TestCheckRecoverChains_LegacyIndexDDLIsInconclusiveNotMismatch(t *testing.T) {
+	// riEvent leaves SchemaVersion at its zero value — the legacy-index shape.
+	// The qty column appears between event 1's after-image and event 2's
+	// before-image: a real historical ADD COLUMN.
+	events := []query.ResultRow{
+		riEvent(1, event.EventInsert, "7", nil, map[string]any{"id": json.Number("7"), "name": "widget"}),
+		riEvent(2, event.EventUpdate, "7", riRow(7, "widget", 1), riRow(7, "widget", 2)),
+	}
+	out := checkRecoverChains(riInput(events))
+	if out.Status == StatusMismatch {
+		t.Fatalf("a column-set difference on a legacy (SchemaVersion 0) index must not be a conclusive mismatch: %s", out.Detail)
+	}
+	if out.Status != StatusInconclusive {
+		t.Fatalf("got %s (%s), want %s", out.Status, out.Detail, StatusInconclusive)
+	}
+	if !strings.Contains(out.Detail, `"qty"`) {
+		t.Errorf("detail should still name the column it could not compare, got: %s", out.Detail)
+	}
+
+	// Control: the SAME events on a post-migration index (both epochs known
+	// and equal) are a genuine structural divergence — the gate is
+	// content-gated on 0, not a blanket downgrade of column-set differences.
+	events[0].SchemaVersion = 1
+	events[1].SchemaVersion = 1
+	out = checkRecoverChains(riInput(events))
+	if out.Status != StatusMismatch {
+		t.Fatalf("within one KNOWN schema epoch a column-set difference stays conclusive: got %s (%s)", out.Status, out.Detail)
+	}
+}
+
+// The pure-comparison view of the rule above: 0 on either side (or both) is an
+// unknown epoch, never proof of corruption.
+func TestCompareImages_UnknownEpochColumnSetDifference(t *testing.T) {
+	in := riInput(nil)
+	prev := riRow(7, "widget", 1)
+	cur := map[string]any{"id": json.Number("7"), "name": "widget"} // qty absent
+
+	for _, vers := range [][2]uint32{{0, 0}, {0, 2}, {1, 0}} {
+		equal, unresolved, diff := compareImages(prev, cur, vers[0], vers[1], in)
+		if equal || unresolved != "qty" || diff != "" {
+			t.Errorf("versions %v: an unknown epoch must be inconclusive, got equal=%v unresolved=%q diff=%q",
+				vers, equal, unresolved, diff)
+		}
+	}
+}
+
+// Two non-nil-but-EMPTY images hold zero evidence, so they must never count as
+// a proven "equal". Unreachable in production today (the #493 guard refuses
+// non-FULL binlog_row_image), but "proven" must not be reachable from
+// emptiness.
+func TestCompareImages_EmptyImagesAreNotProvenEqual(t *testing.T) {
+	equal, unresolved, diff := compareImages(map[string]any{}, map[string]any{}, 1, 1, riInput(nil))
+	if equal {
+		t.Fatal("two empty images must not compare as proven equal")
+	}
+	if unresolved == "" || diff != "" {
+		t.Errorf("empty images must be inconclusive, not a mismatch: unresolved=%q diff=%q", unresolved, diff)
+	}
+}
+
+// The walk-level form: a chain of empty images asserts nothing, so the table
+// reports inconclusive — not a match it never earned, and not a mismatch.
+func TestCheckRecoverChains_EmptyImagesAssertNothing(t *testing.T) {
+	out := checkRecoverChains(riInput([]query.ResultRow{
+		riEvent(1, event.EventInsert, "7", nil, map[string]any{}),
+		riEvent(2, event.EventDelete, "7", map[string]any{}, nil),
+	}))
+	if out.Status == StatusMatch {
+		t.Fatalf("empty images must not prove a table: %s", out.Detail)
+	}
+	if out.Status != StatusInconclusive || out.Assertions != 0 {
+		t.Fatalf("got %s (%s) with %d assertion(s), want %s with 0", out.Status, out.Detail, out.Assertions, StatusInconclusive)
+	}
+	if !strings.Contains(out.Detail, "empty") {
+		t.Errorf("detail should say the images were empty, got: %s", out.Detail)
+	}
+}
+
+// Only the FIRST mismatch detail and the total are ever reported, so the walk
+// must not retain every formatted string (up to MaxEvents of them on a
+// systemically broken table). This pins the reported shape: first detail,
+// full count, and the rest summarized.
+func TestCheckRecoverChains_MismatchDetailKeepsFirstAndCountsRest(t *testing.T) {
+	out := checkRecoverChains(riInput([]query.ResultRow{
+		riEvent(1, event.EventInsert, "7", nil, riRow(7, "widget", 1)),
+		riEvent(2, event.EventUpdate, "7", riRow(7, "widget", 99), riRow(7, "widget", 100)),
+		riEvent(3, event.EventUpdate, "7", riRow(7, "widget", 55), riRow(7, "widget", 56)),
+		riEvent(4, event.EventUpdate, "7", riRow(7, "widget", 42), riRow(7, "widget", 43)),
+	}))
+	if out.Status != StatusMismatch {
+		t.Fatalf("got %s (%s), want %s", out.Status, out.Detail, StatusMismatch)
+	}
+	if !strings.Contains(out.Detail, "3 recover-input inconsistency(ies)") {
+		t.Errorf("detail must carry the full count, got: %s", out.Detail)
+	}
+	if !strings.Contains(out.Detail, "event 2") {
+		t.Errorf("detail must carry the FIRST finding, got: %s", out.Detail)
+	}
+	if strings.Contains(out.Detail, "event 3") || strings.Contains(out.Detail, "event 4") {
+		t.Errorf("later findings are summarized, not listed, got: %s", out.Detail)
+	}
+	if !strings.Contains(out.Detail, "(and 2 more)") {
+		t.Errorf("detail must summarize the rest, got: %s", out.Detail)
+	}
+}
+
+// A coverage gap on an index YOUNGER than the window is not rotation: the
+// hours before the index's first-ever partition were never captured at all,
+// and the wording must say so — with the remedy that actually works (shorten
+// --lookback below the index's age) instead of implying a retention loss.
+func TestRecoverGapDetail(t *testing.T) {
+	oldest := time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC)
+	pre := []time.Time{oldest.Add(-3 * time.Hour), oldest.Add(-2 * time.Hour), oldest.Add(-time.Hour)}
+	hole := oldest.Add(2 * time.Hour)
+
+	t.Run("window predates the index's history", func(t *testing.T) {
+		got := recoverGapDetail(&query.GapError{GapHours: pre, OldestKnownHour: oldest}, false)
+		if strings.Contains(got, "rotated and not archived") {
+			t.Errorf("pre-history hours never rotated, got: %s", got)
+		}
+		for _, want := range []string{"predate the index's history", "--lookback", "2026-07-20 10:00", "2026-07-20 07:00"} {
+			if !strings.Contains(got, want) {
+				t.Errorf("detail should contain %q, got: %s", want, got)
+			}
+		}
+	})
+
+	t.Run("a real interior hole keeps the rotation wording", func(t *testing.T) {
+		got := recoverGapDetail(&query.GapError{GapHours: []time.Time{hole}, OldestKnownHour: oldest}, false)
+		if !strings.Contains(got, "rotated and not archived") || strings.Contains(got, "predate") {
+			t.Errorf("an in-history gap IS rotated-and-not-archived, got: %s", got)
+		}
+	})
+
+	t.Run("mixed gaps report both, honestly", func(t *testing.T) {
+		got := recoverGapDetail(&query.GapError{GapHours: append(append([]time.Time{}, pre...), hole), OldestKnownHour: oldest}, false)
+		if !strings.Contains(got, "predate the index's history") || !strings.Contains(got, "rotated and not archived") {
+			t.Errorf("mixed gaps must name both causes, got: %s", got)
+		}
+	})
+
+	t.Run("unknown oldest hour falls back to the generic wording", func(t *testing.T) {
+		got := recoverGapDetail(&query.GapError{GapHours: pre}, false)
+		if !strings.Contains(got, "coverage gap in the window") {
+			t.Errorf("with no oldest-hour knowledge the wording must not claim a young index, got: %s", got)
+		}
+	})
+
+	t.Run("no-archive does not claim the index has no history", func(t *testing.T) {
+		// Under --no-archive the planner never saw archive_state, so archived
+		// history older than the oldest LIVE partition may exist — the
+		// wording must not assert the index did not exist.
+		got := recoverGapDetail(&query.GapError{GapHours: pre, OldestKnownHour: oldest}, true)
+		if strings.Contains(got, "predate the index's history") {
+			t.Errorf("--no-archive cannot prove the index had no history, got: %s", got)
+		}
+		if !strings.Contains(got, "--no-archive") || !strings.Contains(got, "--lookback") {
+			t.Errorf("detail should name the exclusion and the remedy, got: %s", got)
+		}
+	})
+}

--- a/internal/verify/report.go
+++ b/internal/verify/report.go
@@ -101,8 +101,11 @@ type TableReport struct {
 	EventsChecked int `json:"events_checked,omitempty"`
 	// ChainsChecked is the number of distinct primary keys walked.
 	ChainsChecked int `json:"chains_checked,omitempty"`
-	// ChainsInconclusive counts chains whose first event in the window was not
-	// an INSERT — no predecessor state exists, so they are legitimately
+	// ChainsInconclusive counts chains that held at least one event with no
+	// predecessor state to assert against: the window opened mid-history
+	// (first event on the key was not an INSERT), a PK-changing UPDATE moved
+	// the row out from under the key, or the chain was restarted after a
+	// nil-image/unresolved-TOAST/unknown-type finding. All are legitimately
 	// unverifiable rather than divergent.
 	ChainsInconclusive int `json:"chains_inconclusive,omitempty"`
 }


### PR DESCRIPTION
Closes #1126

All five items from the issue, minimal-fix versions:

## 1. Legacy index: a real historical DDL is no longer a conclusive MISMATCH
`compareImages` used `prevVer != curVer` as the DDL escape hatch, but `query.ResultRow.SchemaVersion` is 0 for pre-migration rows — on a legacy index every event carries 0, the branch never fired, and an ADD/DROP COLUMN in the window read as `"qty" is present in one image and absent from the other` MISMATCH on a healthy index. A `0` on either side is now an unknown epoch and degrades the comparison to unresolved (inconclusive), the same direction as the existing version-skew branch. Within a *known*, equal epoch a column-set difference stays a conclusive mismatch (pinned by a control test).

## 2. Young index: the gap reason no longer claims rotation
`buildPlan` now stamps `QueryPlan.OldestKnownHour` (oldest live/archived hour it saw; oldest LIVE only under `--no-archive`, since archive_state is not read there) and `FetchMerged` carries it on `GapError`. `--check recover` splits gap hours on it: hours before the index's first-ever partition are worded as *predating the index's history* (nothing rotated away — the index did not exist yet) with the remedy that actually works (shorten `--lookback` below the index's age); in-history holes keep the rotated-and-not-archived wording, and mixed windows report both. `GapError.Error()` itself is unchanged, so no other consumer's wording moves. The Since-clamping design change was deliberately NOT taken.

## 3. Unbounded `mismatches` slice → `first string` + `count int`
Only `[0]` and `len()` were ever consumed; a systemically broken table retained up to `--max-events` formatted strings for output nobody sees. Reported shape (first detail, full count, "and N more") is unchanged and now pinned by a test.

## 4. Two non-nil-but-empty images are never a proven `equal`
`compareImages` returns unresolved for a zero-column pair (out-of-band `\x00` marker that cannot collide with a real column name). Unreachable today behind the #493 non-FULL `binlog_row_image` guard, but "proven" is no longer reachable from zero evidence.

## 5. Flag scope: an accepted flag is an honoured flag
`--explain` is rejected under `--check recover`; `--lookback`/`--max-events` are rejected under `--check content` (detected via pflag `Changed()`, since both carry non-zero defaults) — same reasoning as the existing `--source-dsn` rejection, now centralized in `checkVerifyFlagScope`. Docs updated: flag table + compatibility notes, the `chains_inconclusive` description now also names chains restarted after nil-image/unresolved-TOAST findings (as does `TableResult.ChainsInconclusive`'s comment), and the young-index behaviour is called out in the lookback note.

## Tests
- Unit: legacy-index DDL → inconclusive (+ known-epoch control stays mismatch); unknown-epoch `compareImages` table; empty-image pair (direct + through the walk); first-mismatch/count reporting shape; `recoverGapDetail` wording (young index, real hole, mixed, unknown oldest, `--no-archive` does not overclaim); `buildPlan` `OldestKnownHour` stamping; `checkVerifyFlagScope` matrix + rejection through the real `verifyCmd` flag parsing with a positive control.
- Integration (Docker MySQL, run locally, both PASS with `-race`): new `TestVerifyRecoverInputs_WindowPredatingIndexHistorySaysSo` exercises the full production path (partitions → planner → GapError → verdict); pre-existing stamped-capture-gap test still passes.
- `go build ./...`, `go vet ./...`, `go vet -tags integration ./...`, `go test -race ./internal/verify/... ./internal/query/... ./internal/cli/...` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)