### PR TITLE
status: make sustained event skipping visible (Capture health verdict)

### DIFF
--- a/docs/rotation-and-status.md
+++ b/docs/rotation-and-status.md
@@ -285,6 +285,7 @@ about gap-**contiguity** of the captured range; it is **not** a liveness/lag che
   Last checkpoint: 2026-02-19 10:01:12
   Server ID:       100
   Continuity:      no gaps in the captured range (not a liveness check)
+  Capture health:  OK — no events skipped
 ```
 
 The verdict is one of four states:
@@ -331,6 +332,50 @@ top-level `stream_error` object — a **sibling** of `stream`, never a fake
 `stream` — shaped `{"continuity": {"status": "unavailable"}, "error": "..."}`.
 The jq check above stays fail-closed in this state: `.stream.continuity.status`
 is `null` because `stream` is absent.
+
+### Capture health (in-stream discards)
+
+The continuity verdict answers "did the stream **lose** events it never
+received?". Its sibling, the **`Capture health`** line right below it, answers
+"did the stream **discard** events it *did* receive?" — events the daemon read
+off the binlog and chose to skip, most often because the schema snapshot went
+stale or corrupt and the column-count guard rejected every row. That failure
+used to be invisible: the checkpoint stayed fresh and continuity honestly said
+"no gaps" while 100% of rows were being dropped.
+
+The daemon counts every skip by reason (monotonic, persisted with each
+checkpoint, surviving restarts) and `status` renders the verdict:
+
+```
+  Continuity:      no gaps in the captured range (not a liveness check)
+  Capture health:  ⚠ DEGRADED — 41,203 events skipped (column_count_mismatch), last 2026-07-17 12:24:12
+  Skipped events were read from the stream but NOT indexed — a restore window
+  over them is incomplete. Most often the schema snapshot is stale or corrupt:
+  run `bintrail snapshot` against the source, then check the daemon log.
+```
+
+| Text | Meaning |
+|---|---|
+| `OK — no events skipped` | A skip-aware daemon has evaluated the stream and dropped nothing |
+| `⚠ DEGRADED — N events skipped (<reasons>), last <ts>` | N events were read and discarded; the reasons and the most recent skip time follow |
+| *(line absent)* | Unknown — a legacy index, or one no skip-aware daemon has written; `OK` is never asserted from absent data |
+
+Skip reasons include `column_count_mismatch` (stale/corrupt snapshot),
+`table_not_in_snapshot`, `no_resolver`, `unhandled_row_event`, and
+`statement_format_dml` (a STATEMENT/MIXED-format DML whose row image is not in
+the binlog — requires `binlog_format=ROW`). Routine skips of system schemas
+the snapshot deliberately excludes (e.g. RDS's `mysql.rds_heartbeat2`) are
+**not** counted.
+
+In the daemon log, each skip still emits its per-event `WARN`; after 100
+**consecutive** skipped events one `ERROR` with remediation is emitted (once
+per degraded episode — it re-arms when an event is captured again).
+
+Under `--format json` the verdict is `stream.capture_health`:
+`{"status": "ok"}` or `{"status": "degraded", "total_skipped": N,
+"last_skip_at": "...", "skipped": {"<reason>": {"count": N, "last_at": "..."}}}`;
+the key is omitted when the verdict is unknown. The [web console](console.md)
+Overview shows an orange "Capture degraded" box in the same states.
 
 ### Sections in detail
 

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -1676,6 +1676,12 @@ async function renderStatus() {
   // permanent-loss alarm, or the affirmative all-clear, is the first thing read.
   const continuity = continuityBox(stream, pg);
   if (continuity) v.append(continuity);
+  // Capture-health surface (#1034): the continuity box's sibling for in-stream
+  // discards — events the daemon read and chose to drop. Only the degraded
+  // state renders (below the continuity box, above the cards); "ok" adds no
+  // second green box.
+  const captureHealth = captureHealthBox(stream);
+  if (captureHealth) v.append(captureHealth);
   v.append(cards);
   viewEnter();
 }
@@ -1721,6 +1727,26 @@ function continuityBox(stream, pg) {
     return ok;
   }
   return null;
+}
+
+// captureHealthBox renders the capture-health surface (#1034), or null when
+// there is nothing to warn about. It keys on stream.capture_health.status ===
+// "degraded" (newer backends only): the daemon READ these events off the
+// stream and chose to DROP them — e.g. the column-count guard rejecting every
+// row against a stale schema snapshot — so the stream can look "active" (fresh
+// checkpoint, green continuity) while indexing nothing. "ok", "unknown"
+// (missing field) and no stream all render nothing; the continuity box remains
+// the affirmative/loss surface. Pure and fixture-drivable like continuityBox.
+function captureHealthBox(stream) {
+  if (!stream || !stream.capture_health || stream.capture_health.status !== "degraded") return null;
+  const h = stream.capture_health;
+  const box = el("div", { class: "warn-box" });
+  box.append(el("b", { text: "⚠ Capture degraded — events are being skipped" }));
+  const reasons = Object.keys(h.skipped || {}).sort().join(", ");
+  box.append(el("div", { text: h.total_skipped + " event(s) were read from the stream but not indexed" +
+    (reasons ? " (" + reasons + ")" : "") + (h.last_skip_at ? "; last " + h.last_skip_at : "") + "." }));
+  box.append(el("div", { text: "Changes in those events are missing from the index. Most often the schema snapshot is stale — take a fresh snapshot on the source, then check the capture log." }));
+  return box;
 }
 
 // PG_HEALTH_STALE_SEC: a source_health snapshot older than this reads as STALE. The

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -1188,6 +1188,14 @@ button { font-family: inherit; }
   border-radius: var(--radius-sm); padding: 12px 14px; margin: 8px 0;
   white-space: pre-wrap;
 }
+/* capture-health degraded surface (#1034) — sustained in-stream skips: orange,
+   sitting between the green all-clear and the red permanent-loss record. */
+.warn-box {
+  font-family: var(--f-mono); font-size: 12.5px; color: var(--orange-2);
+  background: var(--orange-bg); border: 1px solid var(--ochre);
+  border-radius: var(--radius-sm); padding: 12px 14px; margin: 8px 0;
+  white-space: pre-wrap;
+}
 .warnings:empty { display: none; }
 .warn-item {
   display: flex; gap: 8px; align-items: flex-start;

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -675,6 +675,19 @@ func EnsureSchema(db *sql.DB) error {
 	); err != nil {
 		return err
 	}
+	// capture_skips counts events the streaming daemon READ and chose to DROP
+	// (#1034): per-reason monotonic counters ({"<reason>":{"count":N,
+	// "last_at":"RFC3339"}}), persisted with every checkpoint so the DEGRADED
+	// verdict survives daemon restarts and `status` can render Capture health.
+	// "{}" is the affirmative evaluated-and-clean marker; NULL (legacy index,
+	// or one no skip-aware daemon has written) means the verdict is unknown
+	// and status omits the line rather than asserting OK from absent data —
+	// the same never-a-false-ok philosophy as the gap_lost_* columns above.
+	if err := ensureColumn(db, "stream_state", "capture_skips",
+		`ALTER TABLE stream_state ADD COLUMN capture_skips JSON DEFAULT NULL COMMENT 'per-reason monotonic counters of events the daemon read and chose to drop (#1034): {"<reason>":{"count":N,"last_at":"RFC3339"}}; {} = evaluated and clean; NULL = no skip-aware daemon has written yet' AFTER source_health`,
+	); err != nil {
+		return err
+	}
 	// flavor records the source database flavor (mysql/mariadb) so a resume
 	// parses the saved gtid_set with the correct GTID parser. NOT NULL DEFAULT
 	// 'mysql' means existing rows read back as mysql with no data migration,

--- a/internal/indexer/schema.go
+++ b/internal/indexer/schema.go
@@ -187,6 +187,7 @@ const ddlStreamState = `CREATE TABLE IF NOT EXISTS stream_state (
     gap_lost_at      DATETIME        DEFAULT NULL COMMENT 'when an unfillable binlog gap forced an auto-advance (events permanently lost); cleared only by an explicit monitor Stop; --reset re-stamps or preserves it',
     gap_lost_detail  TEXT            DEFAULT NULL COMMENT 'human-readable description of the lost gap',
     source_health    JSON            DEFAULT NULL COMMENT 'latest source-side health snapshot (PostgreSQL: replication-slot wal_status/lag + REPLICA IDENTITY coverage) with an embedded checked_at; serialized payload, source-agnostic column',
+    capture_skips    JSON            DEFAULT NULL COMMENT 'per-reason monotonic counters of events the daemon read and chose to drop (#1034): {"<reason>":{"count":N,"last_at":"RFC3339"}}; {} = evaluated and clean; NULL = no skip-aware daemon has written yet',
     CONSTRAINT single_row CHECK (id = 1)
 ) ENGINE=InnoDB`
 

--- a/internal/parser/drift_test.go
+++ b/internal/parser/drift_test.go
@@ -67,7 +67,7 @@ func runHandleRowsWith(t *testing.T, resolver *metadata.Resolver, binlogEv *repl
 	t.Helper()
 	rowsEv := binlogEv.Event.(*replication.RowsEvent)
 	out := make(chan Event, 4)
-	err := handleRows(context.Background(), newTestLogger(logBuf), resolver, &Filters{}, binlogEv, rowsEv, "binlog.000001", "", 0, 0, "", 9, out, nil)
+	err := handleRows(context.Background(), newTestLogger(logBuf), resolver, &Filters{}, binlogEv, rowsEv, "binlog.000001", "", 0, 0, "", 9, out, nil, nil)
 	close(out)
 	var evs []Event
 	for ev := range out {
@@ -397,7 +397,7 @@ func TestHandleRows_schemaGapTrackerFileMode(t *testing.T) {
 			rowsEv := tc.ev.Event.(*replication.RowsEvent)
 			out := make(chan Event, 4)
 			err := handleRows(context.Background(), newTestLogger(&bytes.Buffer{}), timedOrdersResolver(snapT),
-				&Filters{}, tc.ev, rowsEv, "binlog.000007", "", 0, 0, "", 9, out, tracker)
+				&Filters{}, tc.ev, rowsEv, "binlog.000007", "", 0, 0, "", 9, out, tracker, nil)
 			close(out)
 			// A skip is never a hard error at the handleRows layer — the
 			// file-level failure is decided by ParseFile from the tracker.

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -222,7 +222,7 @@ func (p *Parser) ParseFile(ctx context.Context, filename string, events chan<- E
 			currentQueryText = event.SanitizeQueryText(string(ev.Query))
 
 		case *replication.RowsEvent:
-			err := handleRows(ctx, p.logger, p.resolver.Load(), &p.filters, binlogEv, ev, filename, currentGTID, currentConnectionID, currentCommitTsUS, currentQueryText, p.schemaVersion.Load(), events, &gaps)
+			err := handleRows(ctx, p.logger, p.resolver.Load(), &p.filters, binlogEv, ev, filename, currentGTID, currentConnectionID, currentCommitTsUS, currentQueryText, p.schemaVersion.Load(), events, &gaps, nil)
 			// The LAST rows event of a statement carries STMT_END_F — the
 			// actual statement boundary. Clearing here keeps one statement's
 			// text alive across its chained/split rows events, while a later
@@ -384,6 +384,13 @@ func isSnapshotExcludedSchema(schema string) bool {
 // the event is at-or-after the snapshot time (a stale snapshot), the skip is
 // recorded so ParseFile can fail the whole file rather than complete it with an
 // undetected gap (#778). The stream path passes nil.
+//
+// skips is the inverse split (#1034): non-nil only on the STREAM path, whose
+// warn-and-continue skips would otherwise be invisible to `status` — every
+// warn-and-skip return below records a per-reason counter, and every event
+// that clears the guards records a capture (breaking the consecutive-skip run
+// that escalates to one ERROR). The file path passes nil: its stale-snapshot
+// skips already fail the whole file via gapTracker.
 func handleRows(
 	ctx context.Context,
 	logger *slog.Logger,
@@ -398,6 +405,7 @@ func handleRows(
 	schemaVersion uint32,
 	out chan<- Event,
 	gapTracker *schemaGapTracker,
+	skips *SkipCounters,
 ) error {
 	schema := string(rowsEv.Table.Schema)
 	table := string(rowsEv.Table.Table)
@@ -410,6 +418,7 @@ func handleRows(
 		logger.Warn("no resolver available — skipping event",
 			"file", filename, "pos", binlogEv.Header.LogPos,
 			"schema", schema, "table", table)
+		skips.RecordSkip(SkipNoResolver)
 		return nil
 	}
 
@@ -431,6 +440,12 @@ func handleRows(
 				logger.Error("schema gap: skipping rows for a table absent from the snapshot at-or-after snapshot time — the snapshot is stale; this file will be marked failed (run `bintrail snapshot`, then re-index)",
 					"file", filename, "pos", binlogEv.Header.LogPos, "schema", schema, "table", table)
 			}
+		}
+		// Stream path (#1034): count the discard so `status` can show it —
+		// except for snapshot-excluded system schemas (e.g. mysql.rds_heartbeat2),
+		// a routine permanent skip that must never mark capture degraded.
+		if !isSnapshotExcludedSchema(schema) {
+			skips.RecordSkip(SkipTableNotInSnapshot)
 		}
 		return nil
 	}
@@ -457,6 +472,7 @@ func handleRows(
 					"file", filename, "pos", binlogEv.Header.LogPos, "schema", schema, "table", table)
 			}
 		}
+		skips.RecordSkip(SkipColumnCountMismatch)
 		return nil
 	}
 
@@ -573,18 +589,21 @@ func handleRows(
 		replication.WRITE_ROWS_EVENTv1,
 		replication.WRITE_ROWS_EVENTv2,
 		replication.MARIADB_WRITE_ROWS_COMPRESSED_EVENT_V1:
+		skips.RecordCaptured()
 		return emitInserts(ctx, logger, resolver, rowsEv.Rows, schema, table, filename, currentGTID, connectionID, commitTsUS, queryText, startPos, endPos, ts, pkCols, schemaVersion, stmtEnd, out)
 
 	case replication.DELETE_ROWS_EVENTv0,
 		replication.DELETE_ROWS_EVENTv1,
 		replication.DELETE_ROWS_EVENTv2,
 		replication.MARIADB_DELETE_ROWS_COMPRESSED_EVENT_V1:
+		skips.RecordCaptured()
 		return emitDeletes(ctx, logger, resolver, rowsEv.Rows, schema, table, filename, currentGTID, connectionID, commitTsUS, queryText, startPos, endPos, ts, pkCols, schemaVersion, stmtEnd, out)
 
 	case replication.UPDATE_ROWS_EVENTv0,
 		replication.UPDATE_ROWS_EVENTv1,
 		replication.UPDATE_ROWS_EVENTv2,
 		replication.MARIADB_UPDATE_ROWS_COMPRESSED_EVENT_V1:
+		skips.RecordCaptured()
 		return emitUpdates(ctx, logger, resolver, rowsEv.Rows, schema, table, filename, currentGTID, connectionID, commitTsUS, queryText, startPos, endPos, ts, pkCols, schemaVersion, stmtEnd, out)
 
 	default:
@@ -601,6 +620,7 @@ func handleRows(
 			"table", table,
 			"event_type", binlogEv.Header.EventType,
 			"rows_skipped", len(rowsEv.Rows))
+		skips.RecordSkip(SkipUnhandledRowEvent)
 	}
 
 	return nil

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -207,7 +207,7 @@ func TestHandleRows_unhandledEventTypeLogsNotSilent(t *testing.T) {
 	rowsEv := binlogEv.Event.(*replication.RowsEvent)
 
 	out := make(chan Event, 4)
-	if err := handleRows(context.Background(), logger, resolver, &Filters{}, binlogEv, rowsEv, "mariadb-bin.000001", "0-1-1", 0, 0, "", 1, out, nil); err != nil {
+	if err := handleRows(context.Background(), logger, resolver, &Filters{}, binlogEv, rowsEv, "mariadb-bin.000001", "0-1-1", 0, 0, "", 1, out, nil, nil); err != nil {
 		t.Fatalf("handleRows: %v", err)
 	}
 
@@ -318,7 +318,7 @@ func TestHandleRows_mariadbCompressedRowTypes(t *testing.T) {
 			rowsEv := binlogEv.Event.(*replication.RowsEvent)
 
 			out := make(chan Event, 4)
-			if err := handleRows(context.Background(), logger, resolver, &Filters{}, binlogEv, rowsEv, "mariadb-bin.000001", "0-1-1", 0, 0, "", 1, out, nil); err != nil {
+			if err := handleRows(context.Background(), logger, resolver, &Filters{}, binlogEv, rowsEv, "mariadb-bin.000001", "0-1-1", 0, 0, "", 1, out, nil, nil); err != nil {
 				t.Fatalf("handleRows: %v", err)
 			}
 
@@ -688,7 +688,7 @@ func TestHandleRows_partialImageFailsLoud(t *testing.T) {
 	rowsEv := binlogEv.Event.(*replication.RowsEvent)
 
 	out := make(chan Event, 4)
-	err := handleRows(context.Background(), newTestLogger(&bytes.Buffer{}), resolver, &Filters{}, binlogEv, rowsEv, "binlog.000001", "0-1-1", 0, 0, "", 1, out, nil)
+	err := handleRows(context.Background(), newTestLogger(&bytes.Buffer{}), resolver, &Filters{}, binlogEv, rowsEv, "binlog.000001", "0-1-1", 0, 0, "", 1, out, nil, nil)
 	if err == nil {
 		t.Fatal("expected handleRows to fail loud on a partial row image, got nil")
 	}
@@ -740,7 +740,7 @@ func TestHandleRows_fullImagePasses(t *testing.T) {
 	rowsEv := binlogEv.Event.(*replication.RowsEvent)
 
 	out := make(chan Event, 4)
-	if err := handleRows(context.Background(), newTestLogger(&bytes.Buffer{}), resolver, &Filters{}, binlogEv, rowsEv, "binlog.000001", "0-1-1", 0, 0, "", 1, out, nil); err != nil {
+	if err := handleRows(context.Background(), newTestLogger(&bytes.Buffer{}), resolver, &Filters{}, binlogEv, rowsEv, "binlog.000001", "0-1-1", 0, 0, "", 1, out, nil, nil); err != nil {
 		t.Fatalf("handleRows must not fail on a FULL image, got: %v", err)
 	}
 	select {

--- a/internal/parser/skips.go
+++ b/internal/parser/skips.go
@@ -1,0 +1,169 @@
+// Package parser — this file provides SkipCounters, the capture-time tally of
+// events the daemon READ from the stream and chose to DROP (#1034): per-reason
+// monotonic counters, persisted alongside the stream checkpoint so `bintrail
+// status` can render a Capture health verdict that survives daemon restarts.
+//
+// This is the sibling of the #649 continuity verdict: continuity answers "did
+// the stream LOSE events it never received?" (a binlog gap); these counters
+// answer "did the stream DISCARD events it did receive?" (e.g. the column-count
+// guard rejecting every row against a stale/corrupt snapshot). Both end the
+// same way for the user — a restore window they believe exists and doesn't —
+// but without these counters the second failure was invisible: the checkpoint
+// stayed fresh and continuity honestly reported "no gaps" while 100% of rows
+// were skipped.
+package parser
+
+import (
+	"encoding/json"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// Capture-skip reason identifiers. Stable strings: they are persisted verbatim
+// in stream_state.capture_skips and surfaced by `bintrail status` (text and
+// JSON), so renaming one silently splits its history into two counters.
+const (
+	// SkipColumnCountMismatch — the binlog TABLE_MAP column count diverged
+	// from the schema snapshot; indexing would map values to wrong names.
+	SkipColumnCountMismatch = "column_count_mismatch"
+	// SkipTableNotInSnapshot — the row's table is absent from the schema
+	// snapshot (system schemas the snapshot deliberately excludes are NOT
+	// counted — e.g. mysql.rds_heartbeat2 is a routine, permanent skip that
+	// must never mark capture degraded).
+	SkipTableNotInSnapshot = "table_not_in_snapshot"
+	// SkipNoResolver — no schema snapshot was available at all.
+	SkipNoResolver = "no_resolver"
+	// SkipUnhandledRowEvent — a RowsEvent type bintrail does not decode
+	// (e.g. PARTIAL_UPDATE_ROWS_EVENT under binlog_row_value_options).
+	SkipUnhandledRowEvent = "unhandled_row_event"
+	// SkipStatementFormatDML — a STATEMENT/MIXED-format DML whose row image
+	// is not in the binlog (#999); the change cannot be captured.
+	SkipStatementFormatDML = "statement_format_dml"
+)
+
+// SkipEscalationThreshold is the number of CONSECUTIVE skipped events (no
+// captured event in between) after which SkipCounters emits a single ERROR
+// with remediation guidance — the per-event WARNs blend into noise exactly
+// when they matter most (#1034 observed 100% skips for ~2 days). One ERROR
+// per degraded episode: the flag re-arms only after an event is captured.
+const SkipEscalationThreshold = 100
+
+// SkipStat is one reason's monotonic tally. The JSON field names are the
+// persistence format of stream_state.capture_skips — internal/status decodes
+// the same shape independently (it deliberately does not import this package).
+type SkipStat struct {
+	Count  int64     `json:"count"`
+	LastAt time.Time `json:"last_at"`
+}
+
+// SkipCounters aggregates capture-time skips by reason. Safe for concurrent
+// use; every method is nil-receiver-safe so the file-index path (which has its
+// own failure mechanism, the #778 gap tracker) can simply pass nil.
+type SkipCounters struct {
+	mu          sync.Mutex
+	logger      *slog.Logger
+	byReason    map[string]SkipStat
+	consecutive int64
+	escalated   bool
+}
+
+// NewSkipCounters creates an empty counter set. logger (nil = slog.Default())
+// receives the single escalation ERROR when SkipEscalationThreshold
+// consecutive events have been skipped.
+func NewSkipCounters(logger *slog.Logger) *SkipCounters {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &SkipCounters{logger: logger, byReason: map[string]SkipStat{}}
+}
+
+// Seed replaces the counters with a previously persisted Snapshot document, so
+// a daemon restart resumes the monotonic tallies instead of silently zeroing
+// the DEGRADED verdict. Empty raw is a no-op (nothing persisted yet); invalid
+// JSON is returned as an error and leaves the counters unchanged.
+func (c *SkipCounters) Seed(raw string) error {
+	if c == nil || raw == "" {
+		return nil
+	}
+	m := map[string]SkipStat{}
+	if err := json.Unmarshal([]byte(raw), &m); err != nil {
+		return err
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.byReason = m
+	return nil
+}
+
+// RecordSkip notes one skipped event under reason, stamping the current time.
+// When SkipEscalationThreshold consecutive events have been skipped it emits
+// ONE ERROR with remediation (re-armed by the next RecordCaptured).
+func (c *SkipCounters) RecordSkip(reason string) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	st := c.byReason[reason]
+	st.Count++
+	st.LastAt = time.Now().UTC()
+	c.byReason[reason] = st
+	c.consecutive++
+	if c.consecutive >= SkipEscalationThreshold && !c.escalated {
+		c.escalated = true
+		remediation := "the schema snapshot is likely stale or corrupt — run `bintrail snapshot` against the source, then restart the stream"
+		if reason == SkipStatementFormatDML {
+			remediation = "set binlog_format=ROW server-wide on the source (a STATEMENT/MIXED format or a session-level override is producing row-less events)"
+		}
+		c.logger.Error("sustained event skipping — capture is effectively stopped: every recent event was read from the stream and discarded, while the checkpoint keeps advancing past them; the skipped changes are NOT in the index",
+			"consecutive_skips", c.consecutive,
+			"reason", reason,
+			"remediation", remediation)
+	}
+}
+
+// RecordCaptured notes that an event cleared every guard and was emitted for
+// indexing: the consecutive-skip run is broken and the escalation re-arms.
+// The per-reason tallies are monotonic and deliberately NOT reset.
+func (c *SkipCounters) RecordCaptured() {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.consecutive = 0
+	c.escalated = false
+}
+
+// Snapshot returns the JSON document persisted to stream_state.capture_skips:
+// {"<reason>":{"count":N,"last_at":"RFC3339"}}. Always valid JSON — "{}" when
+// nothing was skipped, which is the affirmative evaluated-and-clean marker
+// that lets `status` print "Capture health: OK" (a NULL column means no
+// skip-aware daemon ever wrote, so OK must not be asserted).
+func (c *SkipCounters) Snapshot() (string, error) {
+	if c == nil {
+		return "{}", nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	b, err := json.Marshal(c.byReason)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// Total returns the sum of all per-reason counts (test/display helper).
+func (c *SkipCounters) Total() int64 {
+	if c == nil {
+		return 0
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var n int64
+	for _, st := range c.byReason {
+		n += st.Count
+	}
+	return n
+}

--- a/internal/parser/skips_test.go
+++ b/internal/parser/skips_test.go
@@ -1,0 +1,275 @@
+package parser
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-mysql-org/go-mysql/replication"
+)
+
+// ─── Capture-skip counters (#1034) ────────────────────────────────────────────
+//
+// SkipCounters make sustained event skipping visible: per-reason monotonic
+// tallies persisted with the stream checkpoint (so `status` can render a
+// Capture health verdict) plus a single escalation ERROR after
+// SkipEscalationThreshold consecutive skips.
+
+func TestSkipCounters_snapshotSeedRoundTrip(t *testing.T) {
+	c := NewSkipCounters(newTestLogger(&bytes.Buffer{}))
+	c.RecordSkip(SkipColumnCountMismatch)
+	c.RecordSkip(SkipColumnCountMismatch)
+	c.RecordSkip(SkipStatementFormatDML)
+
+	snap, err := c.Snapshot()
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	for _, want := range []string{SkipColumnCountMismatch, SkipStatementFormatDML, `"count":2`, `"count":1`} {
+		if !strings.Contains(snap, want) {
+			t.Errorf("snapshot missing %q: %s", want, snap)
+		}
+	}
+
+	// The restart path: a fresh counter set seeded from the persisted document
+	// resumes the monotonic tallies instead of zeroing them.
+	restarted := NewSkipCounters(newTestLogger(&bytes.Buffer{}))
+	if err := restarted.Seed(snap); err != nil {
+		t.Fatalf("Seed: %v", err)
+	}
+	if got := restarted.Total(); got != 3 {
+		t.Fatalf("Total after seed = %d, want 3", got)
+	}
+	restarted.RecordSkip(SkipColumnCountMismatch)
+	if got := restarted.Total(); got != 4 {
+		t.Fatalf("Total after seed+skip = %d, want 4 (counters must stay monotonic across restarts)", got)
+	}
+}
+
+func TestSkipCounters_seedEmptyAndInvalid(t *testing.T) {
+	c := NewSkipCounters(newTestLogger(&bytes.Buffer{}))
+	if err := c.Seed(""); err != nil {
+		t.Fatalf("Seed(\"\") must be a no-op, got %v", err)
+	}
+	c.RecordSkip(SkipNoResolver)
+	if err := c.Seed("{not json"); err == nil {
+		t.Fatal("Seed with invalid JSON must return an error")
+	}
+	if got := c.Total(); got != 1 {
+		t.Fatalf("a failed Seed must leave counters unchanged; Total = %d, want 1", got)
+	}
+	// A nil counter set snapshots to the evaluated-and-clean marker.
+	var nilC *SkipCounters
+	if snap, err := nilC.Snapshot(); err != nil || snap != "{}" {
+		t.Fatalf("nil Snapshot = (%q, %v), want ({}, nil)", snap, err)
+	}
+}
+
+// The escalation contract: exactly ONE ERROR per degraded episode, emitted at
+// SkipEscalationThreshold consecutive skips, re-armed only by a captured event.
+func TestSkipCounters_escalatesOncePerEpisode(t *testing.T) {
+	var buf bytes.Buffer
+	c := NewSkipCounters(newTestLogger(&buf))
+
+	for i := 0; i < SkipEscalationThreshold-1; i++ {
+		c.RecordSkip(SkipColumnCountMismatch)
+	}
+	if strings.Contains(buf.String(), "level=ERROR") {
+		t.Fatalf("ERROR emitted before the threshold:\n%s", buf.String())
+	}
+
+	c.RecordSkip(SkipColumnCountMismatch)
+	out := buf.String()
+	if got := strings.Count(out, "level=ERROR"); got != 1 {
+		t.Fatalf("expected exactly 1 ERROR at the threshold, got %d:\n%s", got, out)
+	}
+	for _, want := range []string{"sustained event skipping", "bintrail snapshot", SkipColumnCountMismatch} {
+		if !strings.Contains(out, want) {
+			t.Errorf("escalation ERROR missing %q:\n%s", want, out)
+		}
+	}
+
+	// More skips in the SAME episode must not re-emit.
+	for i := 0; i < 2*SkipEscalationThreshold; i++ {
+		c.RecordSkip(SkipColumnCountMismatch)
+	}
+	if got := strings.Count(buf.String(), "level=ERROR"); got != 1 {
+		t.Fatalf("ERROR re-emitted within one episode: %d", got)
+	}
+
+	// A captured event breaks the run and re-arms the escalation.
+	c.RecordCaptured()
+	for i := 0; i < SkipEscalationThreshold; i++ {
+		c.RecordSkip(SkipStatementFormatDML)
+	}
+	if got := strings.Count(buf.String(), "level=ERROR"); got != 2 {
+		t.Fatalf("expected a second ERROR after capture re-armed the escalation, got %d", got)
+	}
+	if !strings.Contains(buf.String(), "binlog_format=ROW") {
+		t.Errorf("statement-format escalation must carry the ROW-format remediation:\n%s", buf.String())
+	}
+}
+
+func TestSkipCounters_capturedDoesNotResetTallies(t *testing.T) {
+	c := NewSkipCounters(newTestLogger(&bytes.Buffer{}))
+	c.RecordSkip(SkipColumnCountMismatch)
+	c.RecordCaptured()
+	if got := c.Total(); got != 1 {
+		t.Fatalf("RecordCaptured must not reset the monotonic tallies; Total = %d, want 1", got)
+	}
+}
+
+// ─── The production counting sites ────────────────────────────────────────────
+//
+// Each site is pinned through the real code path (repo lesson: mutate each
+// site) — reverting a RecordSkip call fails the corresponding test.
+
+// mismatchRowsEvent builds a WRITE_ROWS event for shop.orders whose TABLE_MAP
+// column count (3) diverges from the driftResolver snapshot (2) — the #700
+// guard's skip, the exact failure mode of #1034.
+func mismatchRowsEvent() *replication.BinlogEvent {
+	return &replication.BinlogEvent{
+		Header: &replication.EventHeader{
+			EventType: replication.WRITE_ROWS_EVENTv2,
+			LogPos:    200,
+			EventSize: 100,
+		},
+		Event: &replication.RowsEvent{
+			Table: &replication.TableMapEvent{
+				Schema:      []byte("shop"),
+				Table:       []byte("orders"),
+				ColumnCount: 3,
+			},
+			Rows: [][]any{{int64(1), int64(10), int64(99)}},
+		},
+	}
+}
+
+func TestHandleRows_columnCountMismatchCountsSkip(t *testing.T) {
+	skips := NewSkipCounters(newTestLogger(&bytes.Buffer{}))
+	binlogEv := mismatchRowsEvent()
+	rowsEv := binlogEv.Event.(*replication.RowsEvent)
+	out := make(chan Event, 4)
+	logBuf := &bytes.Buffer{}
+	err := handleRows(context.Background(), newTestLogger(logBuf), driftResolver(), &Filters{}, binlogEv, rowsEv, "binlog.000001", "", 0, 0, "", 9, out, nil, skips)
+	if err != nil {
+		t.Fatalf("a column-count mismatch is warn-and-skip on the stream path, got error: %v", err)
+	}
+	if len(out) != 0 {
+		t.Fatalf("mismatch must emit nothing, got %d events", len(out))
+	}
+	snap, _ := skips.Snapshot()
+	if !strings.Contains(snap, SkipColumnCountMismatch) || skips.Total() != 1 {
+		t.Fatalf("column-count skip not counted (total=%d): %s", skips.Total(), snap)
+	}
+	if !strings.Contains(logBuf.String(), "column count mismatch") {
+		t.Errorf("the per-event WARN must be kept alongside the counter:\n%s", logBuf.String())
+	}
+}
+
+func TestHandleRows_tableNotInSnapshotCountsSkip(t *testing.T) {
+	skips := NewSkipCounters(newTestLogger(&bytes.Buffer{}))
+	binlogEv := driftRowsEvent(nil)
+	rowsEv := binlogEv.Event.(*replication.RowsEvent)
+	rowsEv.Table.Schema = []byte("unknowndb")
+	out := make(chan Event, 4)
+	err := handleRows(context.Background(), newTestLogger(&bytes.Buffer{}), driftResolver(), &Filters{}, binlogEv, rowsEv, "binlog.000001", "", 0, 0, "", 9, out, nil, skips)
+	if err != nil {
+		t.Fatalf("handleRows: %v", err)
+	}
+	snap, _ := skips.Snapshot()
+	if !strings.Contains(snap, SkipTableNotInSnapshot) {
+		t.Fatalf("table-not-in-snapshot skip not counted: %s", snap)
+	}
+}
+
+// A snapshot-excluded system schema (e.g. RDS's periodic mysql.rds_heartbeat2
+// UPDATEs) is a routine, permanent skip: counting it would mark every RDS
+// install DEGRADED forever.
+func TestHandleRows_excludedSchemaSkipNotCounted(t *testing.T) {
+	skips := NewSkipCounters(newTestLogger(&bytes.Buffer{}))
+	binlogEv := driftRowsEvent(nil)
+	rowsEv := binlogEv.Event.(*replication.RowsEvent)
+	rowsEv.Table.Schema = []byte("mysql")
+	rowsEv.Table.Table = []byte("rds_heartbeat2")
+	out := make(chan Event, 4)
+	err := handleRows(context.Background(), newTestLogger(&bytes.Buffer{}), driftResolver(), &Filters{}, binlogEv, rowsEv, "binlog.000001", "", 0, 0, "", 9, out, nil, skips)
+	if err != nil {
+		t.Fatalf("handleRows: %v", err)
+	}
+	if got := skips.Total(); got != 0 {
+		t.Fatalf("a snapshot-excluded schema skip must NOT count toward capture health, got total=%d", got)
+	}
+}
+
+// A successfully captured event must break the consecutive-skip run (the
+// RecordCaptured site at the emit dispatch).
+func TestHandleRows_captureBreaksEscalationRun(t *testing.T) {
+	var buf bytes.Buffer
+	skips := NewSkipCounters(newTestLogger(&buf))
+	mismatch := mismatchRowsEvent()
+	good := driftRowsEvent([]string{"id", "amount"})
+
+	run := func(binlogEv *replication.BinlogEvent) {
+		t.Helper()
+		rowsEv := binlogEv.Event.(*replication.RowsEvent)
+		out := make(chan Event, 4)
+		if err := handleRows(context.Background(), newTestLogger(&bytes.Buffer{}), driftResolver(), &Filters{}, binlogEv, rowsEv, "binlog.000001", "", 0, 0, "", 9, out, nil, skips); err != nil {
+			t.Fatalf("handleRows: %v", err)
+		}
+	}
+
+	// Interleave a captured event into every threshold-sized run of skips:
+	// the escalation must never fire.
+	for i := 0; i < 2*SkipEscalationThreshold; i++ {
+		run(mismatch)
+		if i%(SkipEscalationThreshold-1) == 0 {
+			run(good)
+		}
+	}
+	if strings.Contains(buf.String(), "level=ERROR") {
+		t.Fatalf("captured events must reset the consecutive-skip run:\n%s", buf.String())
+	}
+}
+
+// The #999 statement-format DML drop site inside StreamParser.Run.
+func TestStreamParser_statementDMLCountsSkip(t *testing.T) {
+	skips := NewSkipCounters(newTestLogger(&bytes.Buffer{}))
+	sp := NewStreamParser(makeOrdersResolver(), Filters{}, newTestLogger(&bytes.Buffer{}))
+	sp.SetSkipCounters(skips)
+	streamer := replication.NewBinlogStreamer()
+	out := make(chan Event, 10)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	feedThenCancel(t, streamer, cancel, makeQueryEvent("UPDATE shop.orders SET amount = 1"))
+	if err := sp.Run(ctx, streamer, out); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	snap, _ := skips.Snapshot()
+	if !strings.Contains(snap, SkipStatementFormatDML) || skips.Total() != 1 {
+		t.Fatalf("statement-format DML drop not counted (total=%d): %s", skips.Total(), snap)
+	}
+}
+
+// LastAt must be stamped with a real recent time so `status` can render
+// "last <ts>".
+func TestSkipCounters_lastAtStamped(t *testing.T) {
+	c := NewSkipCounters(newTestLogger(&bytes.Buffer{}))
+	before := time.Now().UTC().Add(-time.Minute)
+	c.RecordSkip(SkipColumnCountMismatch)
+	snap, err := c.Snapshot()
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	m := map[string]SkipStat{}
+	if err := json.Unmarshal([]byte(snap), &m); err != nil {
+		t.Fatalf("decode snapshot: %v", err)
+	}
+	st := m[SkipColumnCountMismatch]
+	if !st.LastAt.After(before) || st.LastAt.After(time.Now().UTC().Add(time.Minute)) {
+		t.Fatalf("last_at = %v, want a recent UTC timestamp", st.LastAt)
+	}
+}

--- a/internal/parser/stream.go
+++ b/internal/parser/stream.go
@@ -30,6 +30,14 @@ type StreamParser struct {
 	// decoded. See SetSyncDDLHook for why this must not move off the parse
 	// path, and why the ordering (hook, then emit) is load-bearing for #760.
 	onDDL atomic.Pointer[func(Event) error]
+	// skips, when set, tallies capture-time discards (#1034): every event Run
+	// reads and drops (column-count mismatch, table not in snapshot,
+	// statement-format DML, ...) is counted per reason so the stream consumer
+	// can persist the counters with its checkpoint and `status` can surface a
+	// Capture health verdict. Set via SetSkipCounters BEFORE Run starts (same
+	// happens-before contract as SetFlavor); nil = no counting (file parser,
+	// tests).
+	skips *SkipCounters
 	// flavor is the source flavor ("mysql" or "mariadb"; see SetFlavor), used
 	// only to word remediation text (GTIDExecutedHint) in the position-
 	// wraparound error inside Run. Never consulted for parsing decisions —
@@ -70,6 +78,14 @@ func (sp *StreamParser) SwapResolver(r *metadata.Resolver) {
 // defaults to MySQL wording.
 func (sp *StreamParser) SetFlavor(flavor string) {
 	sp.flavor = flavor
+}
+
+// SetSkipCounters wires the capture-skip tally (#1034) Run records discards
+// into. Must be called before the goroutine that runs Run is spawned — Run
+// reads it without synchronization, relying on the happens-before edge from
+// the spawning statement (the SetFlavor contract). nil disables counting.
+func (sp *StreamParser) SetSkipCounters(c *SkipCounters) {
+	sp.skips = c
 }
 
 // GTIDExecutedHint returns the flavor-appropriate system variable an
@@ -352,6 +368,7 @@ func (sp *StreamParser) Run(ctx context.Context, streamer *replication.BinlogStr
 					"statement_type", kw,
 					"connection_id", ev.SlaveProxyID)
 				observe.StatementDMLDropped()
+				sp.skips.RecordSkip(SkipStatementFormatDML)
 			}
 
 		case *replication.XIDEvent:
@@ -380,7 +397,7 @@ func (sp *StreamParser) Run(ctx context.Context, streamer *replication.BinlogStr
 			// nil gapTracker: the stream keeps its warn-and-continue skip
 			// behavior (the synchronous DDL hook, SetSyncDDLHook, is the
 			// stream's post-DDL correctness mechanism, not file-level failure).
-			err := handleRows(ctx, sp.logger, sp.resolver.Load(), &sp.filters, binlogEv, ev, currentFile, currentGTID, currentConnectionID, currentCommitTsUS, currentQueryText, sp.schemaVersion.Load(), out, nil)
+			err := handleRows(ctx, sp.logger, sp.resolver.Load(), &sp.filters, binlogEv, ev, currentFile, currentGTID, currentConnectionID, currentCommitTsUS, currentQueryText, sp.schemaVersion.Load(), out, nil, sp.skips)
 			// Statement boundary — see the file parser's RowsEvent case: the
 			// STMT_END_F clear prevents a ROWS_QUERY-less later statement in
 			// the same transaction from inheriting this statement's text.

--- a/internal/status/capture_health_test.go
+++ b/internal/status/capture_health_test.go
@@ -1,0 +1,162 @@
+package status
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ─── Capture health verdict (#1034) ───────────────────────────────────────────
+//
+// The continuity verdict's sibling for IN-STREAM discards: events the daemon
+// read and chose to drop while the checkpoint stayed fresh and continuity
+// honestly said "no gaps". Rendered from stream_state.capture_skips through
+// the same WriteStatus/WriteStatusJSON paths production uses.
+
+func captureStream(captureSkips any) *StreamStateInfo {
+	s := &StreamStateInfo{
+		Mode:              "gtid",
+		BinlogFile:        "binlog.000042",
+		BinlogPosition:    99012,
+		EventsIndexed:     986655,
+		LastCheckpoint:    time.Date(2026, 7, 17, 12, 30, 0, 0, time.UTC),
+		ServerID:          100,
+		GapColumnsPresent: true,
+	}
+	if raw, ok := captureSkips.(string); ok {
+		s.CaptureSkips = sql.NullString{String: raw, Valid: true}
+	}
+	return s
+}
+
+const degradedSkips = `{"column_count_mismatch":{"count":41203,"last_at":"2026-07-17T12:24:12Z"}}`
+
+func TestWriteStatus_captureHealthDegraded(t *testing.T) {
+	var buf bytes.Buffer
+	WriteStatus(&buf, nil, nil, nil, nil, nil, captureStream(degradedSkips))
+	out := buf.String()
+	for _, want := range []string{
+		"Capture health:  ⚠ DEGRADED — 41,203 events skipped (column_count_mismatch), last 2026-07-17 12:24:12",
+		"NOT indexed",
+		"bintrail snapshot",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("degraded status missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestWriteStatus_captureHealthMultipleReasons(t *testing.T) {
+	var buf bytes.Buffer
+	WriteStatus(&buf, nil, nil, nil, nil, nil, captureStream(
+		`{"column_count_mismatch":{"count":1200,"last_at":"2026-07-17T12:24:12Z"},`+
+			`"statement_format_dml":{"count":7,"last_at":"2026-07-18T01:00:00Z"}}`))
+	out := buf.String()
+	// Reasons sorted by count descending; the overall "last" is the max last_at.
+	if !strings.Contains(out, "1,207 events skipped (column_count_mismatch: 1,200, statement_format_dml: 7), last 2026-07-18 01:00:00") {
+		t.Errorf("multi-reason summary wrong:\n%s", out)
+	}
+}
+
+func TestWriteStatus_captureHealthOK(t *testing.T) {
+	var buf bytes.Buffer
+	WriteStatus(&buf, nil, nil, nil, nil, nil, captureStream("{}"))
+	out := buf.String()
+	if !strings.Contains(out, "Capture health:  OK — no events skipped") {
+		t.Errorf("evaluated-and-clean must render OK:\n%s", out)
+	}
+	if strings.Contains(out, "DEGRADED") {
+		t.Errorf("OK output must not contain DEGRADED:\n%s", out)
+	}
+}
+
+// NULL capture_skips (legacy index, or no skip-aware daemon): the verdict is
+// unknown — the line must be OMITTED, never asserted OK from absent data.
+func TestWriteStatus_captureHealthUnknownOmitted(t *testing.T) {
+	var buf bytes.Buffer
+	WriteStatus(&buf, nil, nil, nil, nil, nil, captureStream(nil))
+	if strings.Contains(buf.String(), "Capture health") {
+		t.Errorf("unknown capture health must omit the line:\n%s", buf.String())
+	}
+}
+
+// An unparseable payload is also "unknown" — omitted, not rendered as OK.
+func TestWriteStatus_captureHealthUnparseableOmitted(t *testing.T) {
+	var buf bytes.Buffer
+	WriteStatus(&buf, nil, nil, nil, nil, nil, captureStream("{corrupt"))
+	if strings.Contains(buf.String(), "Capture health") {
+		t.Errorf("unparseable capture_skips must omit the verdict:\n%s", buf.String())
+	}
+}
+
+func decodeStatusJSON(t *testing.T, stream *StreamStateInfo) map[string]any {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := WriteStatusJSON(&buf, nil, nil, nil, nil, nil, stream); err != nil {
+		t.Fatalf("WriteStatusJSON: %v", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return out
+}
+
+func TestWriteStatusJSON_captureHealthDegraded(t *testing.T) {
+	out := decodeStatusJSON(t, captureStream(degradedSkips))
+	stream := out["stream"].(map[string]any)
+	ch, ok := stream["capture_health"].(map[string]any)
+	if !ok {
+		t.Fatalf("capture_health missing: %v", stream)
+	}
+	if ch["status"] != "degraded" {
+		t.Errorf("status = %v, want degraded", ch["status"])
+	}
+	if ch["total_skipped"] != float64(41203) {
+		t.Errorf("total_skipped = %v, want 41203", ch["total_skipped"])
+	}
+	if ch["last_skip_at"] != "2026-07-17 12:24:12" {
+		t.Errorf("last_skip_at = %v", ch["last_skip_at"])
+	}
+	skipped := ch["skipped"].(map[string]any)
+	reason := skipped["column_count_mismatch"].(map[string]any)
+	if reason["count"] != float64(41203) {
+		t.Errorf("per-reason count = %v, want 41203", reason["count"])
+	}
+}
+
+func TestWriteStatusJSON_captureHealthOK(t *testing.T) {
+	out := decodeStatusJSON(t, captureStream("{}"))
+	stream := out["stream"].(map[string]any)
+	ch, ok := stream["capture_health"].(map[string]any)
+	if !ok {
+		t.Fatalf("capture_health missing on an evaluated-and-clean stream: %v", stream)
+	}
+	if ch["status"] != "ok" {
+		t.Errorf("status = %v, want ok", ch["status"])
+	}
+	if _, present := ch["skipped"]; present {
+		t.Errorf("ok verdict must omit the skipped map: %v", ch)
+	}
+}
+
+func TestWriteStatusJSON_captureHealthUnknownOmitted(t *testing.T) {
+	out := decodeStatusJSON(t, captureStream(nil))
+	stream := out["stream"].(map[string]any)
+	if _, present := stream["capture_health"]; present {
+		t.Errorf("unknown capture health must omit the key: %v", stream)
+	}
+}
+
+func TestCommaGroup(t *testing.T) {
+	for in, want := range map[int64]string{
+		0: "0", 7: "7", 999: "999", 1000: "1,000", 41203: "41,203", 1234567: "1,234,567",
+	} {
+		if got := commaGroup(in); got != want {
+			t.Errorf("commaGroup(%d) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"sort"
 	"strconv"
 	"strings"
 	"text/tabwriter"
@@ -104,6 +105,41 @@ type StreamStateInfo struct {
 	// the console renders it and computes staleness from checked_at. Invalid on a legacy
 	// index without the column or an index no daemon has polled.
 	SourceHealth sql.NullString
+	// CaptureSkips is the raw capture_skips JSON (#1034): per-reason monotonic
+	// counters of events the streaming daemon READ and chose to DROP (e.g. the
+	// column-count guard rejecting rows against a stale snapshot), shaped
+	// {"<reason>":{"count":N,"last_at":"RFC3339"}}. "{}" is the affirmative
+	// evaluated-and-clean marker written by a skip-aware daemon. Invalid on a
+	// legacy index without the column or one no such daemon has written — the
+	// Capture health verdict is then unknown and the line is omitted rather
+	// than asserting OK from absent data (the GapColumnsPresent philosophy).
+	CaptureSkips sql.NullString
+}
+
+// CaptureSkipStat is one reason's tally decoded from CaptureSkips. The JSON
+// field names mirror the persistence format written by the capture daemon
+// (parser.SkipStat) — kept as an independent decl so this display package does
+// not import the binlog parser.
+type CaptureSkipStat struct {
+	Count  int64     `json:"count"`
+	LastAt time.Time `json:"last_at"`
+}
+
+// ParseCaptureSkips decodes the persisted capture_skips document. ok is false
+// when the verdict is not evaluable (no column / no skip-aware daemon /
+// unparseable payload) — callers must then omit the Capture health verdict
+// entirely, never render OK. An empty map with ok=true is the affirmative
+// "evaluated, nothing skipped".
+func (s *StreamStateInfo) ParseCaptureSkips() (skips map[string]CaptureSkipStat, ok bool) {
+	if !s.CaptureSkips.Valid || strings.TrimSpace(s.CaptureSkips.String) == "" {
+		return nil, false
+	}
+	m := map[string]CaptureSkipStat{}
+	if err := json.Unmarshal([]byte(s.CaptureSkips.String), &m); err != nil {
+		slog.Warn("could not parse capture_skips; capture health shown as unknown", "error", err)
+		return nil, false
+	}
+	return m, true
 }
 
 // CoverageInfo summarizes the restore coverage of the index.
@@ -340,6 +376,12 @@ func LoadStreamState(ctx context.Context, db *sql.DB) (*StreamStateInfo, error) 
 	if err := loadSourceHealth(ctx, db, s); err != nil {
 		slog.Warn("could not load source_health; keeping stream state without it", "error", err)
 	}
+	// capture_skips (#1034) follows the same separate best-effort pattern (and
+	// the same rationale) as source_health above: newer than both, so folding
+	// it into either SELECT would drag older indexes down a fallback tier.
+	if err := loadCaptureSkips(ctx, db, s); err != nil {
+		slog.Warn("could not load capture_skips; keeping stream state without it", "error", err)
+	}
 	return s, nil
 }
 
@@ -378,6 +420,18 @@ func loadStreamStateCore(ctx context.Context, db *sql.DB) (*StreamStateInfo, err
 // error is returned, so a genuine fault is not silently hidden behind a blank panel.
 func loadSourceHealth(ctx context.Context, db *sql.DB, s *StreamStateInfo) error {
 	err := db.QueryRowContext(ctx, `SELECT source_health FROM stream_state WHERE id = 1`).Scan(&s.SourceHealth)
+	if isUnknownColumnErr(err) || errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	return err
+}
+
+// loadCaptureSkips augments an already-loaded StreamStateInfo with the
+// capture_skips column (#1034) — same tolerance contract as loadSourceHealth:
+// only the unknown-column error (legacy index) and an empty row leave
+// CaptureSkips invalid (verdict unknown); any other error is returned.
+func loadCaptureSkips(ctx context.Context, db *sql.DB, s *StreamStateInfo) error {
+	err := db.QueryRowContext(ctx, `SELECT capture_skips FROM stream_state WHERE id = 1`).Scan(&s.CaptureSkips)
 	if isUnknownColumnErr(err) || errors.Is(err, sql.ErrNoRows) {
 		return nil
 	}
@@ -608,6 +662,24 @@ func WriteStatus(w io.Writer, files []IndexStateRow, parts []PartitionStat, arch
 		default:
 			fmt.Fprintln(w, "  Continuity:      no gaps in the captured range (not a liveness check)")
 		}
+		// Capture health (#1034) — the continuity verdict's sibling for
+		// IN-STREAM discards: events the daemon read and chose to drop (e.g.
+		// the column-count guard rejecting every row against a stale snapshot)
+		// while the checkpoint stayed fresh and continuity honestly said "no
+		// gaps". Omitted (not asserted OK) when no skip-aware daemon has
+		// written the counters — same never-a-false-ok stance as Continuity's
+		// "not evaluated".
+		if skips, ok := stream.ParseCaptureSkips(); ok {
+			if total := totalCaptureSkips(skips); total > 0 {
+				fmt.Fprintf(w, "  Capture health:  ⚠ DEGRADED — %s events skipped (%s), last %s\n",
+					commaGroup(total), captureSkipReasons(skips), lastCaptureSkip(skips).Format(TSFmt))
+				fmt.Fprintln(w, "  Skipped events were read from the stream but NOT indexed — a restore window")
+				fmt.Fprintln(w, "  over them is incomplete. Most often the schema snapshot is stale or corrupt:")
+				fmt.Fprintln(w, "  run `bintrail snapshot` against the source, then check the daemon log.")
+			} else {
+				fmt.Fprintln(w, "  Capture health:  OK — no events skipped")
+			}
+		}
 		fmt.Fprintln(w)
 
 		// Loud, unmissable banner when the stream permanently lost data (an unfillable
@@ -802,6 +874,68 @@ func formatBytes(b int64) string {
 	}
 }
 
+// totalCaptureSkips sums the per-reason capture-skip counts.
+func totalCaptureSkips(skips map[string]CaptureSkipStat) int64 {
+	var n int64
+	for _, st := range skips {
+		n += st.Count
+	}
+	return n
+}
+
+// lastCaptureSkip returns the most recent per-reason last_at.
+func lastCaptureSkip(skips map[string]CaptureSkipStat) time.Time {
+	var last time.Time
+	for _, st := range skips {
+		if st.LastAt.After(last) {
+			last = st.LastAt
+		}
+	}
+	return last
+}
+
+// captureSkipReasons renders the non-zero reasons for the DEGRADED line: the
+// bare reason when there is one ("column_count_mismatch", the #1034 wording),
+// else "reason: count" pairs sorted by count descending (ties alphabetical).
+func captureSkipReasons(skips map[string]CaptureSkipStat) string {
+	var reasons []string
+	for r, st := range skips {
+		if st.Count > 0 {
+			reasons = append(reasons, r)
+		}
+	}
+	if len(reasons) == 1 {
+		return reasons[0]
+	}
+	sort.Slice(reasons, func(i, j int) bool {
+		if skips[reasons[i]].Count != skips[reasons[j]].Count {
+			return skips[reasons[i]].Count > skips[reasons[j]].Count
+		}
+		return reasons[i] < reasons[j]
+	})
+	parts := make([]string, len(reasons))
+	for i, r := range reasons {
+		parts[i] = fmt.Sprintf("%s: %s", r, commaGroup(skips[r].Count))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// commaGroup formats n with thousands separators ("41203" → "41,203").
+func commaGroup(n int64) string {
+	s := strconv.FormatInt(n, 10)
+	neg := strings.HasPrefix(s, "-")
+	if neg {
+		s = s[1:]
+	}
+	for i := len(s) - 3; i > 0; i -= 3 {
+		s = s[:i] + "," + s[i:]
+	}
+	if neg {
+		s = "-" + s
+	}
+	return s
+}
+
 // Truncate shortens s to at most n bytes, appending "…" if truncated.
 func Truncate(s string, n int) string {
 	if len(s) <= n {
@@ -877,6 +1011,21 @@ func writeStatusJSONFull(w io.Writer, files []IndexStateRow, parts []PartitionSt
 	type jsonContinuity struct {
 		Status string `json:"status"`
 	}
+	// jsonCaptureHealth is the machine-readable Capture health verdict (#1034)
+	// — the continuity verdict's sibling for in-stream discards. Present only
+	// when a skip-aware daemon has persisted the counters ("unknown" is an
+	// omitted key, never a false "ok"). status is "ok" or "degraded"; skipped
+	// carries the per-reason monotonic tallies.
+	type jsonSkipStat struct {
+		Count  int64  `json:"count"`
+		LastAt string `json:"last_at"`
+	}
+	type jsonCaptureHealth struct {
+		Status       string                  `json:"status"`
+		TotalSkipped int64                   `json:"total_skipped"`
+		LastSkipAt   string                  `json:"last_skip_at,omitempty"`
+		Skipped      map[string]jsonSkipStat `json:"skipped,omitempty"`
+	}
 	type jsonStream struct {
 		BintrailID     *string        `json:"bintrail_id"`
 		Mode           string         `json:"mode"`
@@ -892,7 +1041,8 @@ func writeStatusJSONFull(w io.Writer, files []IndexStateRow, parts []PartitionSt
 		// SourceHealth is the raw source_health JSON passed through verbatim (#599):
 		// the console knows its shape (slot wal_status/lag, replica_identity_not_full,
 		// checked_at), this layer does not. Omitted when no daemon has polled.
-		SourceHealth json.RawMessage `json:"source_health,omitempty"`
+		SourceHealth  json.RawMessage    `json:"source_health,omitempty"`
+		CaptureHealth *jsonCaptureHealth `json:"capture_health,omitempty"`
 	}
 	type jsonBaseline struct {
 		SnapshotTime string  `json:"snapshot_time"`
@@ -1006,6 +1156,21 @@ func writeStatusJSONFull(w io.Writer, files []IndexStateRow, parts []PartitionSt
 		}
 		if stream.SourceHealth.Valid && stream.SourceHealth.String != "" {
 			jstr.SourceHealth = json.RawMessage(stream.SourceHealth.String)
+		}
+		if skips, ok := stream.ParseCaptureSkips(); ok {
+			ch := &jsonCaptureHealth{Status: "ok"}
+			if total := totalCaptureSkips(skips); total > 0 {
+				ch.Status = "degraded"
+				ch.TotalSkipped = total
+				ch.LastSkipAt = lastCaptureSkip(skips).Format(TSFmt)
+				ch.Skipped = make(map[string]jsonSkipStat, len(skips))
+				for r, st := range skips {
+					if st.Count > 0 {
+						ch.Skipped[r] = jsonSkipStat{Count: st.Count, LastAt: st.LastAt.Format(TSFmt)}
+					}
+				}
+			}
+			jstr.CaptureHealth = ch
 		}
 		out.Stream = jstr
 	} else if streamErr != nil {

--- a/internal/streamrun/capture_skips_integration_test.go
+++ b/internal/streamrun/capture_skips_integration_test.go
@@ -1,0 +1,112 @@
+//go:build integration
+
+// Persistence coverage for the capture-skip counters (#1034): the tallies the
+// StreamParser records must survive a daemon restart via the checkpoint upsert
+// (saveCheckpoint) + re-seed (loadCaptureSkips/Seed), and `status` must render
+// the DEGRADED verdict from the SAME row through its own production read path
+// (status.LoadStreamState → WriteStatus/WriteJSON) — the end-to-end pin for
+// "sustained skipping is no longer invisible".
+package streamrun
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/parser"
+	"github.com/dbtrail/dbtrail/internal/status"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+func TestIntegrationCaptureSkipsPersistAndSurviveRestart(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	// ── First daemon run: skips recorded, checkpoint persisted ────────────
+	skips := parser.NewSkipCounters(nil)
+	skips.RecordSkip(parser.SkipColumnCountMismatch)
+	skips.RecordSkip(parser.SkipColumnCountMismatch)
+	skips.RecordSkip(parser.SkipStatementFormatDML)
+
+	state := &streamState{
+		mode:       "position",
+		binlogFile: "binlog.000001",
+		binlogPos:  4,
+		serverID:   100,
+		skips:      skips,
+	}
+	if err := saveCheckpoint(db, state); err != nil {
+		t.Fatalf("saveCheckpoint: %v", err)
+	}
+
+	// ── Restart: the persisted document seeds a fresh counter set ─────────
+	raw, err := loadCaptureSkips(db)
+	if err != nil {
+		t.Fatalf("loadCaptureSkips: %v", err)
+	}
+	restarted := parser.NewSkipCounters(nil)
+	if err := restarted.Seed(raw); err != nil {
+		t.Fatalf("Seed: %v", err)
+	}
+	if got := restarted.Total(); got != 3 {
+		t.Fatalf("counters did not survive restart: Total = %d, want 3", got)
+	}
+
+	// The restarted daemon keeps counting monotonically and re-persists.
+	restarted.RecordSkip(parser.SkipColumnCountMismatch)
+	state.skips = restarted
+	if err := saveCheckpoint(db, state); err != nil {
+		t.Fatalf("saveCheckpoint after restart: %v", err)
+	}
+	raw2, err := loadCaptureSkips(db)
+	if err != nil {
+		t.Fatalf("loadCaptureSkips: %v", err)
+	}
+	reread := parser.NewSkipCounters(nil)
+	if err := reread.Seed(raw2); err != nil {
+		t.Fatalf("Seed: %v", err)
+	}
+	if got := reread.Total(); got != 4 {
+		t.Fatalf("post-restart counts not monotonic: Total = %d, want 4", got)
+	}
+
+	// ── A skip-less checkpoint writer must PRESERVE the counters ──────────
+	// (--reset's fresh state and the gap auto-advance stamp build bare
+	// streamStates with skips == nil; the upsert's COALESCE keeps the column.)
+	bare := &streamState{mode: "position", binlogFile: "binlog.000002", binlogPos: 4, serverID: 100}
+	if err := saveCheckpoint(db, bare); err != nil {
+		t.Fatalf("saveCheckpoint (nil skips): %v", err)
+	}
+	raw3, err := loadCaptureSkips(db)
+	if err != nil {
+		t.Fatalf("loadCaptureSkips: %v", err)
+	}
+	if raw3 != raw2 {
+		t.Fatalf("a nil-skips checkpoint wiped the counters:\n was: %s\n now: %s", raw2, raw3)
+	}
+
+	// ── `status` renders DEGRADED from the same row (production read path) ──
+	ctx := context.Background()
+	stream, err := status.LoadStreamState(ctx, db)
+	if err != nil {
+		t.Fatalf("status.LoadStreamState: %v", err)
+	}
+	if stream == nil || !stream.CaptureSkips.Valid {
+		t.Fatalf("status did not load capture_skips: %+v", stream)
+	}
+	var text bytes.Buffer
+	status.WriteStatus(&text, nil, nil, nil, nil, nil, stream)
+	for _, want := range []string{"Capture health", "DEGRADED", "column_count_mismatch"} {
+		if !strings.Contains(text.String(), want) {
+			t.Errorf("status text missing %q:\n%s", want, text.String())
+		}
+	}
+	var js bytes.Buffer
+	if err := status.WriteStatusJSON(&js, nil, nil, nil, nil, nil, stream); err != nil {
+		t.Fatalf("WriteStatusJSON: %v", err)
+	}
+	if !strings.Contains(js.String(), `"status": "degraded"`) {
+		t.Errorf("status JSON missing degraded capture_health:\n%s", js.String())
+	}
+}

--- a/internal/streamrun/streamrun.go
+++ b/internal/streamrun/streamrun.go
@@ -55,6 +55,15 @@ type streamState struct {
 	serverID      uint32
 	bintrailID    string // resolved server identity (empty = unknown, stored as NULL)
 
+	// skips is the shared capture-skip tally (#1034): the StreamParser records
+	// every event it read and dropped (column-count mismatch, statement-format
+	// DML, ...) and saveCheckpoint persists the counters to
+	// stream_state.capture_skips alongside the position, so `status` can render
+	// the Capture health verdict. nil (external/test callers, --reset's fresh
+	// state, the gap auto-advance stamp) persists NULL, which the upsert's
+	// COALESCE turns into "preserve whatever is already there".
+	skips *parser.SkipCounters
+
 	// accGTID is the in-memory accumulated GTID set (GTID mode only).
 	// It is serialized to gtidSet on checkpoint. Typed as the gomysql.GTIDSet
 	// interface so it can hold either a *MysqlGTIDSet or, for a MariaDB source,
@@ -149,11 +158,26 @@ func checkpointInsertArgs(state *streamState) ([]any, error) {
 }
 
 // saveCheckpoint persists the current stream state to the stream_state table.
+//
+// capture_skips (#1034) rides every checkpoint — it is the only writer of that
+// column. A nil state.skips serializes to NULL and the update arm's COALESCE
+// preserves the existing value, so the checkpoint-shaped writers that build a
+// bare streamState (--reset's fresh state, the gap auto-advance stamp, tests)
+// never wipe the monotonic counters a daemon persisted.
 func saveCheckpoint(db *sql.DB, state *streamState) error {
 	args, err := checkpointInsertArgs(state)
 	if err != nil {
 		return err
 	}
+	var captureSkips any
+	if state.skips != nil {
+		snap, err := state.skips.Snapshot()
+		if err != nil {
+			return fmt.Errorf("serialize capture-skip counters: %w", err)
+		}
+		captureSkips = snap
+	}
+	args = append(args, captureSkips)
 	// mode is in the UPDATE arm for the cross-mode --reset path (#1079): the
 	// reset no longer DELETEs the row, so the mode switch must land through
 	// this upsert. For every other caller mode is invariant across the run.
@@ -165,8 +189,9 @@ func saveCheckpoint(db *sql.DB, state *streamState) error {
 	_, err = db.ExecContext(ctx, `
 		INSERT INTO stream_state
 		    (id, mode, binlog_file, binlog_position, gtid_set, flavor,
-		     events_indexed, last_event_time, last_checkpoint, server_id, bintrail_id)
-		VALUES (1, ?, ?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(), ?, ?)
+		     events_indexed, last_event_time, last_checkpoint, server_id, bintrail_id,
+		     capture_skips)
+		VALUES (1, ?, ?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(), ?, ?, ?)
 		ON DUPLICATE KEY UPDATE
 		    mode            = VALUES(mode),
 		    binlog_file     = VALUES(binlog_file),
@@ -177,9 +202,26 @@ func saveCheckpoint(db *sql.DB, state *streamState) error {
 		    last_event_time = VALUES(last_event_time),
 		    last_checkpoint = UTC_TIMESTAMP(),
 		    server_id       = VALUES(server_id),
-		    bintrail_id     = VALUES(bintrail_id)`,
+		    bintrail_id     = VALUES(bintrail_id),
+		    capture_skips   = COALESCE(VALUES(capture_skips), capture_skips)`,
 		args...)
 	return err
+}
+
+// loadCaptureSkips reads the persisted capture-skip counters (#1034) so a
+// restarting daemon resumes the monotonic tallies instead of zeroing the
+// DEGRADED verdict. Runs after EnsureSchema (One's step order), so the column
+// exists; an empty table returns "" (nothing persisted yet).
+func loadCaptureSkips(db *sql.DB) (string, error) {
+	var raw sql.NullString
+	err := db.QueryRow(`SELECT capture_skips FROM stream_state WHERE id = 1`).Scan(&raw)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return raw.String, nil
 }
 
 // deleteEventsSinceCheckpoint removes rows at or beyond (file, pos) from
@@ -2118,6 +2160,20 @@ func One(ctx context.Context, cfg Config) error {
 		state.gtidSet = startGTIDStr
 	}
 
+	// Capture-skip counters (#1034): shared between the StreamParser (which
+	// records each discarded event) and saveCheckpoint (which persists them).
+	// Re-seeded from the previous run's persisted document so a restart never
+	// silently zeroes the DEGRADED verdict `status` renders from them. A
+	// failed load/parse degrades to fresh counters with a warning — never a
+	// startup abort — since the tallies are observability, not correctness.
+	skips := parser.NewSkipCounters(nil)
+	if raw, err := loadCaptureSkips(indexDB); err != nil {
+		slog.Warn("could not load persisted capture-skip counters; starting from zero", "error", err)
+	} else if err := skips.Seed(raw); err != nil {
+		slog.Warn("could not parse persisted capture-skip counters; starting from zero", "error", err)
+	}
+	state.skips = skips
+
 	// ── 7. Parse source DSN for BinlogSyncer ─────────────────────────────
 	host, port, user, password, err := cfg.Deps.ParseSourceDSN(cfg.SourceDSN)
 	if err != nil {
@@ -2252,6 +2308,9 @@ func One(ctx context.Context, cfg Config) error {
 
 	// ── 10. StreamParser + its synchronous DDL hook ──────────────────────────
 	sp := parser.NewStreamParser(resolver, filters, nil)
+	// Wire the shared capture-skip tally (#1034) before Run's goroutine spawns
+	// (the SetFlavor happens-before contract).
+	sp.SetSkipCounters(state.skips)
 	// cfg.Flavor is normalized (empty→"mysql") by this point (step 1 above) —
 	// wires the source flavor into the live position-wraparound guard inside
 	// Run (internal/parser/stream.go) so its GTID-mode remediation names the

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -330,6 +330,7 @@ func InitIndexTables(t *testing.T, db *sql.DB) {
 		gap_lost_at      DATETIME        DEFAULT NULL,
 		gap_lost_detail  TEXT            DEFAULT NULL,
 		source_health    JSON            DEFAULT NULL,
+		capture_skips    JSON            DEFAULT NULL,
 		CONSTRAINT single_row CHECK (id = 1)
 	) ENGINE=InnoDB`)
 


### PR DESCRIPTION
Closes #1034

A stream could skip 100% of row events for days (column-count guard vs a corrupt snapshot) while `bintrail status` showed a fresh checkpoint and `Continuity: no gaps` — the only signal was per-event WARNs scrolling in the daemon log. This PR makes in-stream discards a first-class health verdict, the sibling of the #649 continuity verdict.

## What changed

**1. Count skips at capture time** (`internal/parser/skips.go`)
`SkipCounters`: thread-safe, per-reason **monotonic** counters + last-skip timestamp. Recorded at every stream warn-and-skip site:
- `column_count_mismatch` (the #700 guard — the #1034 failure mode)
- `table_not_in_snapshot` (snapshot-**excluded** system schemas like `mysql.rds_heartbeat2` are deliberately NOT counted — they would mark every RDS install degraded forever)
- `no_resolver`, `unhandled_row_event`
- `statement_format_dml` (the #999 drops)

A captured event breaks the consecutive run. The file-index path passes nil (its stale-snapshot skips already fail the whole file via the #778 gap tracker).

**2. Persist alongside `stream_state`** (mirroring how #649 persisted the gap verdict)
New `stream_state.capture_skips` JSON column (base DDL + `ensureColumn` migration, the `gap_lost_*`/`source_health` pattern). `saveCheckpoint` writes the counters with every checkpoint; the upsert uses `COALESCE(VALUES(capture_skips), capture_skips)` so nil-skips writers (`--reset`'s fresh state, the gap auto-advance stamp) preserve rather than wipe them. On startup the daemon re-seeds from the persisted document, so **counters survive restarts** — `{}` is the affirmative "evaluated and clean" marker, `NULL` means unknown.

**3. Surface in `bintrail status`**
```
  Continuity:      no gaps in the captured range (not a liveness check)
  Capture health:  ⚠ DEGRADED — 41,203 events skipped (column_count_mismatch), last 2026-07-17 12:24:12
```
`OK — no events skipped` when clean; the line is **omitted** (never a false OK) on a legacy index or one no skip-aware daemon has written — the `GapColumnsPresent` philosophy. Same data under `--format json` as `stream.capture_health` (`status`/`total_skipped`/`last_skip_at`/`skipped{reason→{count,last_at}}`), loaded via the same separate best-effort query pattern as `source_health` so legacy indexes degrade gracefully.

**4. Log escalation**
After **100 consecutive** skipped events, ONE `ERROR` with remediation (`bintrail snapshot` guidance; `binlog_format=ROW` for statement-format drops), re-armed only when an event is captured again. Per-event WARNs are kept unchanged (no rate limiting — it wasn't trivial to do without losing information).

**5. Console**
`/api/status` already reuses `status.CollectStatus + WriteJSON` verbatim, so `stream.capture_health` flows through the existing API with zero new pipeline. Overview renders an orange "Capture degraded" box (`captureHealthBox`, pure and fixture-drivable like `continuityBox`) only in the degraded state.

**Docs**: `docs/rotation-and-status.md` — Capture health subsection + updated Stream example.

## Out of scope (noted per issue)
- **PostgreSQL** (`pgstreamrun`) has its own checkpoint writer; it never writes `capture_skips`, so PG indexes correctly show the verdict as unknown (line omitted). Wiring the PG decoder's skip sites is a follow-up.
- The issue's optional `--fail-on-gap`-style opt-in exit code for cron was not added (minimal fix; the JSON verdict is scriptable with `jq -e '.stream.capture_health.status != "degraded"'`).

## Tests
- `skips_test.go`: snapshot/seed round-trip (restart survival), escalation exactly once per episode + re-arm, captured-does-not-reset-tallies, and **each production counting site pinned through the real path** (handleRows column-count mismatch / table-not-in-snapshot / excluded-schema-not-counted / capture-breaks-run; `StreamParser.Run` statement-DML via a real `BinlogStreamer`).
- `capture_health_test.go` (status): DEGRADED with counts/reason/last-ts, multi-reason ordering, OK, unknown-omitted, unparseable-omitted — text and JSON through `WriteStatus`/`WriteStatusJSON`.
- `capture_skips_integration_test.go` (streamrun, real MySQL): persist via `saveCheckpoint` → survive restart via `loadCaptureSkips`/`Seed` → monotonic across restarts → nil-skips checkpoint preserves the column → `status.LoadStreamState` + `WriteStatus`/`WriteJSON` render DEGRADED end-to-end.

`go build ./...`, `go vet ./...`, `go vet -tags integration ./...` clean. `go test -race` green on parser/status/streamrun/indexer/console/testutil; `-tags integration` green on streamrun/indexer/status/parser (parser flaked once only in the known #415 full-parallel mode, green in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)