### PR TITLE
rotate/archive: content-derived pruning keeps backfilled events time-queryable after archiving (#1037)

### DIFF
--- a/cliapp/cmd_integration_test.go
+++ b/cliapp/cmd_integration_test.go
@@ -299,8 +299,8 @@ func TestArchivePartition(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ArchivePartition: %v", err)
 	}
-	if n != 2 {
-		t.Errorf("expected 2 rows archived, got %d", n)
+	if n.Rows != 2 {
+		t.Errorf("expected 2 rows archived, got %d", n.Rows)
 	}
 
 	// Verify the file exists.
@@ -343,8 +343,8 @@ func TestArchivePartition_empty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ArchivePartition on empty partition: %v", err)
 	}
-	if n != 0 {
-		t.Errorf("expected 0 rows for empty partition, got %d", n)
+	if n.Rows != 0 {
+		t.Errorf("expected 0 rows for empty partition, got %d", n.Rows)
 	}
 
 	// File should still be created (valid empty Parquet).

--- a/docs/query-and-recovery.md
+++ b/docs/query-and-recovery.md
@@ -195,6 +195,8 @@ WARN query covers hours with no data (rotated and not archived): 2026-02-10 00:0
 
 The planner also optimizes routing: if the entire queried time range is covered by archives (no live MySQL partitions needed), the MySQL query is skipped entirely.
 
+Archive coverage is **content-derived, not label-derived**: each `archive_state` row records the `MIN`/`MAX(event_timestamp)` of the rows actually archived, and the planner counts every hour in that range as covered. This matters for backfills — events replayed after a capture stall land in the *oldest live partition* and get archived under its hour label, so the file's `event_date=`/`event_hour=` path can be days newer than the rows inside it. The planner reports such mislabeled files to the archive fetcher, which then includes them in date-scoped S3 listings and Hive-path pruning even though their labels fall outside the queried window (row-level time filters still bound the result). Archives written before `min_event_ts`/`max_event_ts` existed fall back to label-only coverage. See [Backfilled events and the hour label](rotation-and-status.md#backfilled-events-and-the-hour-label).
+
 ### How merged results are deduplicated
 
 When archives are in play, live MySQL and archive (Parquet) results are combined, deduplicated by `event_id` (the live MySQL row wins on a duplicate), sorted chronologically, and **`--limit` is applied once after the merge** — so no events are dropped before deduplication.

--- a/docs/rotation-and-status.md
+++ b/docs/rotation-and-status.md
@@ -146,9 +146,42 @@ Each archived partition is recorded in the `archive_state` table (created by `bi
 | `s3_bucket` | S3 bucket (when uploaded) |
 | `s3_key` | S3 object key (when uploaded) |
 | `s3_uploaded_at` | When the S3 upload completed |
+| `min_event_ts` / `max_event_ts` | Content-derived `MIN`/`MAX(event_timestamp)` of the archived rows (NULL on archives written before this column existed, or registered by `upload`/`archive reconcile`) |
 | `archived_at` | When the archive was created |
 
 The `--retry` flag on rotate uses this table to determine which S3 uploads can be skipped.
+
+#### Backfilled events and the hour label
+
+A partition's *name* is not a reliable statement of what it holds. When a
+stream backfills events whose hourly partitions were already rotated away
+(e.g. resuming from an old checkpoint after a multi-day capture stall, with
+`--retain` shorter than the stall), MySQL's RANGE partitioning files those
+old rows into the **oldest live partition** — and rotation then archives that
+partition under its own hour label, so the Parquet file's
+`event_date=`/`event_hour=` path disagrees with the timestamps of the rows
+inside it.
+
+That is why rotation records `min_event_ts`/`max_event_ts` at archive time:
+the query planner counts every hour in that content range as archive-covered,
+and time-scoped reads are told to open the mislabeled file even when its hour
+label falls outside the queried window (date-scoped S3 listings included).
+Row-level time filters still bound what the file contributes.
+
+When a partition's content range escapes its hour label, rotation also logs:
+
+```
+WARN archived partition contains events outside its hour label (backfilled rows);
+     recording true content time range so time-scoped archive reads still find them
+     partition=p_2026072401 min_event_ts=2026-07-22T19:10:00Z max_event_ts=2026-07-24T01:30:00Z
+```
+
+Archives created **before** this column existed have NULL ranges and keep the
+old label-only pruning; if such an archive is known to contain backfilled
+rows, re-populate the columns manually (`UPDATE archive_state SET
+min_event_ts=..., max_event_ts=... WHERE partition_name=...`) using the
+Parquet file's own footer statistics (see [Parquet
+debugging](parquet-debugging.md)).
 
 ### Archiving directly to S3
 

--- a/internal/agent/handler.go
+++ b/internal/agent/handler.go
@@ -296,6 +296,19 @@ func (h *DefaultHandler) HandleRecover(ctx context.Context, req RecoverRequest) 
 		}
 		rows = append(rows, r...)
 	}
+	if len(h.ArchiveSources) > 0 && h.IndexDB != nil {
+		// Misfiled archives (#1037): archives whose content-derived range
+		// (archive_state.min/max_event_ts) overlaps the window despite an
+		// out-of-range hour label must survive date/file pruning. Best-effort:
+		// without an index DB (archive-only handlers) this stays nil and
+		// pruning falls back to labels.
+		hours, mErr := query.MisfiledArchiveHours(ctx, h.IndexDB, opts.Since, opts.Until)
+		if mErr != nil {
+			h.logger().Warn("could not check archive_state for misfiled archives", "error", mErr)
+		} else {
+			opts.ExtraArchiveHours = hours
+		}
+	}
 	for _, src := range h.ArchiveSources {
 		r, err := parquetquery.Fetch(ctx, opts, src)
 		if err != nil {

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -51,10 +51,26 @@ var BinlogEventColumns = []baseline.Column{
 	{Name: "commit_ts_us", MySQLType: "bigint", Unsigned: true, ParquetType: baseline.MysqlToParquetNode2("bigint", true)},
 }
 
+// Stats summarizes what ArchivePartition wrote: the row count and the
+// content-derived event_timestamp range of the archived rows. MinEventTS and
+// MaxEventTS are the zero time when the partition had no rows (or none with a
+// non-NULL event_timestamp). They exist because a partition's NAME is not a
+// reliable statement of what it holds (#1037): backfilled events older than
+// the oldest live RANGE partition boundary land in that oldest partition, so
+// the file archived under its hour label can contain rows from much earlier
+// hours. Callers record this true range in archive_state so time-scoped
+// pruning consults content, not just the label.
+type Stats struct {
+	Rows       int64
+	MinEventTS time.Time
+	MaxEventTS time.Time
+}
+
 // ArchivePartition writes all rows from the named partition of binlog_events
 // to a Parquet file at outputPath. The db must have been opened with
 // parseTime=true (i.e. via config.Connect) so DATETIME columns scan as
-// time.Time. Returns the number of rows written.
+// time.Time. Returns Stats for the rows written (count + content min/max
+// event_timestamp).
 //
 // The file is written to outputPath+".tmp" and atomically renamed into place
 // only after the write completes and the writer is closed (issue #802): a
@@ -65,7 +81,7 @@ var BinlogEventColumns = []baseline.Column{
 // truncates it) and is otherwise ignored — nothing ever reads from it.
 //
 // On error the partial .tmp output file is removed before returning.
-func ArchivePartition(ctx context.Context, db *sql.DB, dbName, partition, outputPath, compression string) (int64, error) {
+func ArchivePartition(ctx context.Context, db *sql.DB, dbName, partition, outputPath, compression string) (Stats, error) {
 	tmpPath := outputPath + ".tmp"
 	cfg := baseline.WriterConfig{
 		Compression:  compression,
@@ -79,7 +95,7 @@ func ArchivePartition(ctx context.Context, db *sql.DB, dbName, partition, output
 
 	w, err := baseline.NewWriter(tmpPath, BinlogEventColumns, cfg)
 	if err != nil {
-		return 0, fmt.Errorf("create parquet writer: %w", err)
+		return Stats{}, fmt.Errorf("create parquet writer: %w", err)
 	}
 
 	var closed bool
@@ -99,11 +115,11 @@ func ArchivePartition(ctx context.Context, db *sql.DB, dbName, partition, output
 	)
 	rows, err := db.QueryContext(ctx, q)
 	if err != nil {
-		return 0, fmt.Errorf("query partition %s: %w", partition, err)
+		return Stats{}, fmt.Errorf("query partition %s: %w", partition, err)
 	}
 	defer rows.Close()
 
-	var rowCount int64
+	var stats Stats
 	for rows.Next() {
 		// Every NOT NULL column is scanned defensively and its
 		// Valid bit is propagated into the nulls[] slice so the Parquet
@@ -137,7 +153,7 @@ func ArchivePartition(ctx context.Context, db *sql.DB, dbName, partition, output
 			&changedColumns, &rowBefore, &rowAfter, &schemaVersion, &queryText, &queryHash,
 			&commitTsUS,
 		); err != nil {
-			return rowCount, fmt.Errorf("scan row: %w", err)
+			return stats, fmt.Errorf("scan row: %w", err)
 		}
 
 		connIDStr := ""
@@ -150,7 +166,17 @@ func ArchivePartition(ctx context.Context, db *sql.DB, dbName, partition, output
 		}
 		eventTimestampStr := ""
 		if eventTimestamp.Valid {
-			eventTimestampStr = eventTimestamp.Time.UTC().Format("2006-01-02 15:04:05")
+			ts := eventTimestamp.Time.UTC()
+			eventTimestampStr = ts.Format("2006-01-02 15:04:05")
+			// Content-derived time range of the file (#1037). Tracked from the
+			// exact rows written — not a separate MIN()/MAX() query — so the
+			// recorded range can never disagree with the file's contents.
+			if stats.MinEventTS.IsZero() || ts.Before(stats.MinEventTS) {
+				stats.MinEventTS = ts
+			}
+			if stats.MaxEventTS.IsZero() || ts.After(stats.MaxEventTS) {
+				stats.MaxEventTS = ts
+			}
 		}
 
 		values := []string{
@@ -195,24 +221,24 @@ func ArchivePartition(ctx context.Context, db *sql.DB, dbName, partition, output
 		}
 
 		if err := w.WriteRow(values, nulls); err != nil {
-			return rowCount, fmt.Errorf("write row: %w", err)
+			return stats, fmt.Errorf("write row: %w", err)
 		}
-		rowCount++
+		stats.Rows++
 	}
 	if err := rows.Err(); err != nil {
-		return rowCount, fmt.Errorf("iterate rows: %w", err)
+		return stats, fmt.Errorf("iterate rows: %w", err)
 	}
 
 	closed = true
 	if err := w.Close(); err != nil {
 		os.Remove(tmpPath) //nolint
-		return rowCount, fmt.Errorf("close writer: %w", err)
+		return stats, fmt.Errorf("close writer: %w", err)
 	}
 	if err := os.Rename(tmpPath, outputPath); err != nil {
 		os.Remove(tmpPath) //nolint
-		return rowCount, fmt.Errorf("rename %s into place: %w", tmpPath, err)
+		return stats, fmt.Errorf("rename %s into place: %w", tmpPath, err)
 	}
-	return rowCount, nil
+	return stats, nil
 }
 
 // ValidateArchiveFile opens the Parquet file at path just far enough to read

--- a/internal/archive/archive_integration_test.go
+++ b/internal/archive/archive_integration_test.go
@@ -46,8 +46,8 @@ func TestArchivePartition_nullBinlogFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ArchivePartition failed: %v", err)
 	}
-	if n != 2 {
-		t.Errorf("rowCount = %d, want 2", n)
+	if n.Rows != 2 {
+		t.Errorf("rowCount = %d, want 2", n.Rows)
 	}
 
 	// Verify NULL semantics at the Parquet layer: row 0 (the non-NULL row,
@@ -164,8 +164,8 @@ func TestArchivePartition_queryTextRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ArchivePartition failed: %v", err)
 	}
-	if n != 2 {
-		t.Fatalf("rowCount = %d, want 2", n)
+	if n.Rows != 2 {
+		t.Fatalf("rowCount = %d, want 2", n.Rows)
 	}
 
 	rf, err := os.Open(outPath)
@@ -233,8 +233,8 @@ func TestArchivePartition_commitTsRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ArchivePartition failed: %v", err)
 	}
-	if n != 2 {
-		t.Fatalf("rowCount = %d, want 2", n)
+	if n.Rows != 2 {
+		t.Fatalf("rowCount = %d, want 2", n.Rows)
 	}
 
 	rf, err := os.Open(outPath)

--- a/internal/cli/archive_integration_test.go
+++ b/internal/cli/archive_integration_test.go
@@ -50,8 +50,8 @@ func TestArchiveReconcileRebuild(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ArchivePartition: %v", err)
 	}
-	if n != 1 {
-		t.Fatalf("expected 1 archived row, got %d", n)
+	if n.Rows != 1 {
+		t.Fatalf("expected 1 archived row, got %d", n.Rows)
 	}
 
 	// The registry is LOST (index rebuilt): archive_state is empty.

--- a/internal/cli/query.go
+++ b/internal/cli/query.go
@@ -377,6 +377,12 @@ func runQuery(cmd *cobra.Command, args []string) error {
 	// the helper. The helper's doc comment documents its own half of this
 	// contract.
 	if len(archSources) > 0 {
+		if plan != nil {
+			// Misfiled archives (#1037): files whose hour label lies outside
+			// the window but whose content overlaps it must survive the
+			// fetcher's date/file pruning.
+			fetchOpts.ExtraArchiveHours = plan.MisfiledArchiveHours
+		}
 		archResults, err := queryArchiveSources(
 			cmd.Context(),
 			archSources,

--- a/internal/cli/reconstruct_integration_test.go
+++ b/internal/cli/reconstruct_integration_test.go
@@ -80,8 +80,8 @@ func TestFetchMerged_archiveAware(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ArchivePartition: %v", err)
 	}
-	if archivedRows != 1 {
-		t.Fatalf("expected 1 archived row, got %d", archivedRows)
+	if archivedRows.Rows != 1 {
+		t.Fatalf("expected 1 archived row, got %d", archivedRows.Rows)
 	}
 
 	// Register the archive in archive_state so ResolveArchiveSources can find it.

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -651,6 +651,28 @@ func EnsureSchema(db *sql.DB) error {
 	); err != nil {
 		return err
 	}
+	// min_event_ts/max_event_ts record the content-derived event_timestamp
+	// range of each archived partition (#1037). A backfill after a capture
+	// stall lands old events in the OLDEST live RANGE partition, so the
+	// Parquet file archived under that partition's hour label can hold rows
+	// from much earlier hours; any pruning that trusts the label alone
+	// (planner hour mapping, date-scoped S3 listings) then silently skips
+	// them. The planner reads these columns to expand archive coverage and to
+	// tell the archive fetcher which mislabeled files a time-scoped read must
+	// still open. NULL on rows written before this column existed (or by
+	// upload/reconcile, which do not scan row contents): the planner falls
+	// back to label-only pruning for those rows, exactly the pre-#1037
+	// behavior.
+	if err := ensureColumn(db, "archive_state", "min_event_ts",
+		`ALTER TABLE archive_state ADD COLUMN min_event_ts DATETIME DEFAULT NULL COMMENT 'MIN(event_timestamp) of the archived rows; NULL for archives written before #1037 or registered by upload/reconcile. Content-derived pruning: may precede the partition hour label when backfilled events landed in the partition' AFTER s3_uploaded_at`,
+	); err != nil {
+		return err
+	}
+	if err := ensureColumn(db, "archive_state", "max_event_ts",
+		`ALTER TABLE archive_state ADD COLUMN max_event_ts DATETIME DEFAULT NULL COMMENT 'MAX(event_timestamp) of the archived rows; see min_event_ts (#1037)' AFTER min_event_ts`,
+	); err != nil {
+		return err
+	}
 	// gap_lost_at/_detail record an unfillable-gap auto-advance durably
 	// (#402): the advanced checkpoint is persisted, so without these columns
 	// the only trace of the permanently lost events would be an in-memory

--- a/internal/indexer/schema.go
+++ b/internal/indexer/schema.go
@@ -215,6 +215,8 @@ const ddlArchiveState = `CREATE TABLE IF NOT EXISTS archive_state (
     s3_bucket       VARCHAR(255),
     s3_key          VARCHAR(1024),
     s3_uploaded_at  DATETIME,
+    min_event_ts    DATETIME DEFAULT NULL COMMENT 'MIN(event_timestamp) of the archived rows; NULL for archives written before #1037 or registered by upload/reconcile. Content-derived pruning: may precede the partition hour label when backfilled events landed in the partition',
+    max_event_ts    DATETIME DEFAULT NULL COMMENT 'MAX(event_timestamp) of the archived rows; see min_event_ts (#1037)',
     archived_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     UNIQUE KEY uq_partition (partition_name, bintrail_id)
 ) ENGINE=InnoDB`

--- a/internal/mcptools/mcptools.go
+++ b/internal/mcptools/mcptools.go
@@ -574,6 +574,9 @@ func MakeQueryTool(cfg Config) func(context.Context, *mcp.CallToolRequest, Query
 			// Fetch from live index (+ archives when present), merge, redact,
 			// then format.
 			fetchOpts := opts
+			if len(archSources) > 0 {
+				fetchOpts.ExtraArchiveHours = misfiledArchiveHoursOrWarn(ctx, t.DB, opts.Since, opts.Until)
+			}
 			results, err := engine.Fetch(ctx, fetchOpts)
 			if err != nil {
 				return ErrorResult(err), nil, nil
@@ -694,6 +697,7 @@ func MakeRecoverTool(cfg Config) func(context.Context, *mcp.CallToolRequest, Rec
 		var rows []query.ResultRow
 		if len(archSources) > 0 {
 			fetchOpts := opts
+			fetchOpts.ExtraArchiveHours = misfiledArchiveHoursOrWarn(ctx, t.DB, opts.Since, opts.Until)
 			rows, err = engine.Fetch(ctx, fetchOpts)
 			if err != nil {
 				return ErrorResult(err), nil, nil
@@ -973,6 +977,19 @@ func EnvArchiveSources(ctx context.Context, db *sql.DB) []string {
 			"BINTRAIL_ARCHIVE_S3", archiveS3, "BINTRAIL_ID", bintrailID)
 	}
 	return stateArchiveSources(ctx, db)
+}
+
+// misfiledArchiveHoursOrWarn wraps query.MisfiledArchiveHours (#1037) with the
+// MCP tools' warn-and-continue posture: on a registry read failure the fetch
+// proceeds with label-only pruning (the pre-#1037 behavior) rather than
+// failing the whole tool call.
+func misfiledArchiveHoursOrWarn(ctx context.Context, db *sql.DB, since, until *time.Time) []time.Time {
+	hours, err := query.MisfiledArchiveHours(ctx, db, since, until)
+	if err != nil {
+		slog.Warn("could not check archive_state for misfiled archives (backfilled events); time-scoped archive pruning may skip them", "error", err)
+		return nil
+	}
+	return hours
 }
 
 // stateArchiveSources auto-discovers archive sources from archive_state,

--- a/internal/parquetquery/parquetquery.go
+++ b/internal/parquetquery/parquetquery.go
@@ -92,13 +92,15 @@ func FetchWithTuning(ctx context.Context, opts query.Options, source string, tun
 		// away the very file a position-anchored fetch needs (see
 		// sinceLowerBoundHint).
 		sinceHint := sinceLowerBoundHint(opts)
-		files, maxSize, region, s3Client, err := listS3ParquetScoped(ctx, source, sinceHint, opts.Until)
+		files, maxSize, region, s3Client, err := listS3ParquetScoped(ctx, source, sinceHint, opts.Until, opts.ExtraArchiveHours)
 		if err != nil {
 			return nil, fmt.Errorf("list S3 archive files: %w", err)
 		}
 		// Pre-filter files by Hive partition values (event_date/event_hour)
 		// to avoid downloading parquet files outside the requested time range.
-		files = filterFilesByTimeRange(files, sinceHint, opts.Until)
+		// ExtraArchiveHours (#1037) exempts misfiled files — archives whose
+		// label hour lies outside the range but whose content overlaps it.
+		files = filterFilesByTimeRange(files, sinceHint, opts.Until, opts.ExtraArchiveHours)
 		// Sort chronologically so we can terminate early when --limit is satisfied.
 		files = sortFilesByHour(files)
 		slog.Debug("files after time-range pruning", "count", len(files))
@@ -157,7 +159,7 @@ func FetchWithTuning(ctx context.Context, opts query.Options, source string, tun
 			// Per-file early termination: stop as soon as no remaining file
 			// can produce a row earlier than what we already have.
 			if opts.Limit > 0 && len(results) >= opts.Limit && i+1 < len(files) {
-				if canTerminateEarly(results, files[i+1:], opts.Limit, opts.Order) {
+				if canTerminateEarly(results, files[i+1:], opts.Limit, opts.Order, opts.ExtraArchiveHours) {
 					slog.Debug("early termination: collected enough results",
 						"collected", len(results), "limit", opts.Limit,
 						"remaining_files", len(files)-i-1)
@@ -288,7 +290,7 @@ func parquetColumnsFromFiles(ctx context.Context, db *sql.DB, files []string) (m
 // This avoids listing all files in the archive when only a narrow time range is needed.
 // It returns the S3 client configured for the bucket's region so callers can reuse
 // it for downloads without loading the AWS config again.
-func listS3ParquetScoped(ctx context.Context, source string, since, until *time.Time) (files []string, maxSize int64, region string, client *s3.Client, err error) {
+func listS3ParquetScoped(ctx context.Context, source string, since, until *time.Time, extraHours []time.Time) (files []string, maxSize int64, region string, client *s3.Client, err error) {
 	bucket, prefix, err := parseS3Source(source)
 	if err != nil {
 		return nil, 0, "", nil, err
@@ -336,7 +338,7 @@ func listS3ParquetScoped(ctx context.Context, source string, since, until *time.
 
 	// Generate date-scoped prefixes when time range is narrow enough.
 	// This avoids listing thousands of irrelevant files for large archives.
-	datePrefixes := generateDatePrefixes(prefix, since, until)
+	datePrefixes := generateDatePrefixes(prefix, since, until, extraHours)
 	if datePrefixes == nil {
 		// Wide range or no time bounds — list everything under the base prefix.
 		datePrefixes = []string{prefix}
@@ -457,7 +459,12 @@ const maxScopedDays = 31
 // HandleRecover, which is TimeEnd-only). The real tradeoff: this trades some
 // S3 listing performance on that reachable path for correctness — no
 // listing scope narrower than "everything" is safe without a lower bound.
-func generateDatePrefixes(basePrefix string, since, until *time.Time) []string {
+// extraHours (#1037) are misfiled-archive hour labels whose files must be
+// findable even though those labels fall outside [since, until]: their DATE
+// prefixes are appended to the scoped listing so the files get listed at all.
+// They never shrink the listing — with scoping disabled (nil return)
+// everything is listed and no extra prefixes are needed.
+func generateDatePrefixes(basePrefix string, since, until *time.Time, extraHours []time.Time) []string {
 	if since == nil {
 		return nil
 	}
@@ -478,10 +485,19 @@ func generateDatePrefixes(basePrefix string, since, until *time.Time) []string {
 		return nil
 	}
 
-	prefixes := make([]string, 0, days)
+	seen := make(map[string]bool, days+len(extraHours))
+	prefixes := make([]string, 0, days+len(extraHours))
+	add := func(day string) {
+		if !seen[day] {
+			seen[day] = true
+			prefixes = append(prefixes, basePrefix+"event_date="+day+"/")
+		}
+	}
 	for d := range days {
-		day := start.AddDate(0, 0, d)
-		prefixes = append(prefixes, basePrefix+"event_date="+day.Format("2006-01-02")+"/")
+		add(start.AddDate(0, 0, d).Format("2006-01-02"))
+	}
+	for _, h := range extraHours {
+		add(h.UTC().Format("2006-01-02"))
 	}
 	return prefixes
 }
@@ -739,7 +755,14 @@ func sortFilesByHour(files []string) []string {
 // and the desired row order are inverted, so DESC simply never terminates
 // early — every candidate file is read and the final global sort+limit
 // (query.MergeAndTrim) picks the true newest rows. Correctness over speed.
-func canTerminateEarly(results []query.ResultRow, remainingFiles []string, limit int, order string) bool {
+// extraHours (#1037) disables early termination entirely: a misfiled archive
+// file sorts by its LABEL hour (late) yet can hold the window's EARLIEST rows,
+// so a label-ordered cutoff would wrongly stop before reading it. Misfiled
+// archives only exist after a backfill, so the cost is confined to that case.
+func canTerminateEarly(results []query.ResultRow, remainingFiles []string, limit int, order string, extraHours []time.Time) bool {
+	if len(extraHours) > 0 {
+		return false
+	}
 	if query.OrderDirection(order) == "DESC" {
 		return false
 	}
@@ -1090,16 +1113,27 @@ func buildQueryForFile(path string, opts query.Options, cols map[string]bool) (s
 // filterFilesByTimeRange prunes the file list based on Hive partition values
 // (event_date=YYYY-MM-DD/event_hour=HH) extracted from the paths. Files whose
 // hour does not overlap with [since, until] are excluded. Files without
-// parseable partition values are kept (safe fallback).
-func filterFilesByTimeRange(files []string, since, until *time.Time) []string {
+// parseable partition values are kept (safe fallback). Files whose hour label
+// appears in extraHours are always kept (#1037): those are misfiled archives
+// whose CONTENT overlaps the range even though the label does not — the
+// row-level time filters downstream still bound what they contribute.
+func filterFilesByTimeRange(files []string, since, until *time.Time, extraHours []time.Time) []string {
 	if since == nil && until == nil {
 		return files
+	}
+	extra := make(map[time.Time]bool, len(extraHours))
+	for _, h := range extraHours {
+		extra[h.UTC().Truncate(time.Hour)] = true
 	}
 	var filtered []string
 	for _, f := range files {
 		hourStart, ok := parseFileHour(f)
 		if !ok {
 			filtered = append(filtered, f) // can't determine; include to be safe
+			continue
+		}
+		if extra[hourStart] {
+			filtered = append(filtered, f) // misfiled archive: content overlaps
 			continue
 		}
 		hourEnd := hourStart.Add(time.Hour)

--- a/internal/parquetquery/parquetquery_test.go
+++ b/internal/parquetquery/parquetquery_test.go
@@ -623,7 +623,7 @@ func TestFilterFilesByTimeRange(t *testing.T) {
 
 	since := time.Date(2026, 3, 9, 11, 0, 0, 0, time.UTC)
 	until := time.Date(2026, 3, 9, 12, 0, 0, 0, time.UTC)
-	got := filterFilesByTimeRange(files, &since, &until)
+	got := filterFilesByTimeRange(files, &since, &until, nil)
 	// hour=10 ends at 11:00 which is not Before 11:00 → included
 	// hour=11 overlaps → included
 	// hour=12 starts at 12:00 which is not After 12:00 → included
@@ -633,20 +633,20 @@ func TestFilterFilesByTimeRange(t *testing.T) {
 	}
 
 	// Since only
-	got = filterFilesByTimeRange(files, &since, nil)
+	got = filterFilesByTimeRange(files, &since, nil, nil)
 	if len(got) != 4 { // hour=10 ends at 11:00 (not before since), all included
 		t.Errorf("since-only: expected 4, got %d", len(got))
 	}
 
 	// Until only — until=10:30 should include hour=10 only
 	until1030 := time.Date(2026, 3, 9, 10, 30, 0, 0, time.UTC)
-	got = filterFilesByTimeRange(files, nil, &until1030)
+	got = filterFilesByTimeRange(files, nil, &until1030, nil)
 	if len(got) != 1 {
 		t.Errorf("until-only 10:30: expected 1, got %d: %v", len(got), got)
 	}
 
 	// No filters
-	got = filterFilesByTimeRange(files, nil, nil)
+	got = filterFilesByTimeRange(files, nil, nil, nil)
 	if len(got) != 4 {
 		t.Errorf("no filters: expected 4, got %d", len(got))
 	}
@@ -664,7 +664,7 @@ func TestFilterFilesByTimeRange_untilOnlyKeepsVeryOldFiles(t *testing.T) {
 		"s3://b/event_date=2020-01-15/event_hour=10/e.parquet", // ~6 years before "now"
 	}
 	until := time.Date(2026, 5, 20, 0, 0, 0, 0, time.UTC)
-	got := filterFilesByTimeRange(files, nil, &until)
+	got := filterFilesByTimeRange(files, nil, &until, nil)
 	if len(got) != 1 {
 		t.Errorf("until-only should keep a file far older than 31 days when it satisfies until, got %d: %v", len(got), got)
 	}
@@ -673,7 +673,7 @@ func TestFilterFilesByTimeRange_untilOnlyKeepsVeryOldFiles(t *testing.T) {
 func TestFilterFilesByTimeRangeUnparseable(t *testing.T) {
 	files := []string{"s3://bucket/no-hive/events.parquet"}
 	since := time.Date(2026, 3, 9, 11, 0, 0, 0, time.UTC)
-	got := filterFilesByTimeRange(files, &since, nil)
+	got := filterFilesByTimeRange(files, &since, nil, nil)
 	if len(got) != 1 {
 		t.Errorf("unparseable files should be kept, got %d", len(got))
 	}
@@ -687,7 +687,7 @@ func TestGenerateDatePrefixes(t *testing.T) {
 	t.Run("both bounds same day", func(t *testing.T) {
 		since := time.Date(2026, 4, 12, 10, 0, 0, 0, time.UTC)
 		until := time.Date(2026, 4, 12, 22, 0, 0, 0, time.UTC)
-		got := generateDatePrefixes(base, &since, &until)
+		got := generateDatePrefixes(base, &since, &until, nil)
 		if len(got) != 1 {
 			t.Fatalf("expected 1 prefix, got %d: %v", len(got), got)
 		}
@@ -699,7 +699,7 @@ func TestGenerateDatePrefixes(t *testing.T) {
 	t.Run("two day span", func(t *testing.T) {
 		since := time.Date(2026, 4, 12, 23, 0, 0, 0, time.UTC)
 		until := time.Date(2026, 4, 13, 1, 0, 0, 0, time.UTC)
-		got := generateDatePrefixes(base, &since, &until)
+		got := generateDatePrefixes(base, &since, &until, nil)
 		if len(got) != 2 {
 			t.Fatalf("expected 2 prefixes, got %d: %v", len(got), got)
 		}
@@ -714,7 +714,7 @@ func TestGenerateDatePrefixes(t *testing.T) {
 	t.Run("cross month boundary", func(t *testing.T) {
 		since := time.Date(2026, 3, 31, 0, 0, 0, 0, time.UTC)
 		until := time.Date(2026, 4, 1, 23, 0, 0, 0, time.UTC)
-		got := generateDatePrefixes(base, &since, &until)
+		got := generateDatePrefixes(base, &since, &until, nil)
 		if len(got) != 2 {
 			t.Fatalf("expected 2 prefixes, got %d: %v", len(got), got)
 		}
@@ -729,7 +729,7 @@ func TestGenerateDatePrefixes(t *testing.T) {
 	t.Run("exactly 31 days returns prefixes", func(t *testing.T) {
 		since := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
 		until := time.Date(2026, 3, 31, 0, 0, 0, 0, time.UTC)
-		got := generateDatePrefixes(base, &since, &until)
+		got := generateDatePrefixes(base, &since, &until, nil)
 		if got == nil {
 			t.Fatal("expected prefixes for exactly 31 days, got nil")
 		}
@@ -741,7 +741,7 @@ func TestGenerateDatePrefixes(t *testing.T) {
 	t.Run("exceeds max days returns nil", func(t *testing.T) {
 		since := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 		until := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
-		got := generateDatePrefixes(base, &since, &until)
+		got := generateDatePrefixes(base, &since, &until, nil)
 		if got != nil {
 			t.Errorf("expected nil for wide range, got %d prefixes", len(got))
 		}
@@ -751,7 +751,7 @@ func TestGenerateDatePrefixes(t *testing.T) {
 		// Use yesterday as since — should produce 2 prefixes (yesterday + today).
 		yesterday := time.Now().UTC().Truncate(24*time.Hour).AddDate(0, 0, -1)
 		since := yesterday.Add(10 * time.Hour) // yesterday 10:00
-		got := generateDatePrefixes(base, &since, nil)
+		got := generateDatePrefixes(base, &since, nil, nil)
 		if got == nil {
 			t.Fatal("expected prefixes for since-only, got nil")
 		}
@@ -770,7 +770,7 @@ func TestGenerateDatePrefixes(t *testing.T) {
 	// (filterFilesByTimeRange).
 	t.Run("until only, until within 31 days returns nil (no invented start, #774)", func(t *testing.T) {
 		fiveDaysAgo := time.Now().UTC().Truncate(24*time.Hour).AddDate(0, 0, -5)
-		got := generateDatePrefixes(base, nil, &fiveDaysAgo)
+		got := generateDatePrefixes(base, nil, &fiveDaysAgo, nil)
 		if got != nil {
 			t.Errorf("expected nil for until-only (recent), got %d prefixes: %v", len(got), got)
 		}
@@ -778,14 +778,14 @@ func TestGenerateDatePrefixes(t *testing.T) {
 
 	t.Run("until only, until older than 31 days returns nil, not a bogus single-day clamp (#774)", func(t *testing.T) {
 		old := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
-		got := generateDatePrefixes(base, nil, &old)
+		got := generateDatePrefixes(base, nil, &old, nil)
 		if got != nil {
 			t.Errorf("expected nil for until-only (old), got %d prefixes: %v", len(got), got)
 		}
 	})
 
 	t.Run("no bounds returns nil", func(t *testing.T) {
-		got := generateDatePrefixes(base, nil, nil)
+		got := generateDatePrefixes(base, nil, nil, nil)
 		if got != nil {
 			t.Errorf("expected nil for no bounds, got %d prefixes", len(got))
 		}
@@ -868,7 +868,7 @@ func TestCanTerminateEarly(t *testing.T) {
 			mkRow(time.Date(2026, 3, 9, 10, 45, 0, 0, time.UTC), 3),
 		}
 		remaining := []string{"s3://b/event_date=2026-03-09/event_hour=11/e.parquet"}
-		if !canTerminateEarly(results, remaining, 3, "") {
+		if !canTerminateEarly(results, remaining, 3, "", nil) {
 			t.Error("expected early termination: next hour=11 is after all results in hour=10")
 		}
 	})
@@ -887,11 +887,11 @@ func TestCanTerminateEarly(t *testing.T) {
 			mkRow(time.Date(2026, 3, 9, 10, 45, 0, 0, time.UTC), 3),
 		}
 		remaining := []string{"s3://b/event_date=2026-03-09/event_hour=11/e.parquet"}
-		if canTerminateEarly(results, remaining, 3, "DESC") {
+		if canTerminateEarly(results, remaining, 3, "DESC", nil) {
 			t.Error("DESC must never terminate early: the newest hour (11) hasn't been read yet")
 		}
 		// Case-insensitivity mirrors query.OrderDirection elsewhere in this package.
-		if canTerminateEarly(results, remaining, 3, "desc") {
+		if canTerminateEarly(results, remaining, 3, "desc", nil) {
 			t.Error("DESC check must be case-insensitive (lowercase \"desc\")")
 		}
 	})
@@ -903,7 +903,7 @@ func TestCanTerminateEarly(t *testing.T) {
 			mkRow(time.Date(2026, 3, 9, 11, 45, 0, 0, time.UTC), 3),
 		}
 		remaining := []string{"s3://b/event_date=2026-03-09/event_hour=11/e.parquet"}
-		if canTerminateEarly(results, remaining, 2, "") {
+		if canTerminateEarly(results, remaining, 2, "", nil) {
 			t.Error("should not terminate: limit-th result is at 11:30, next hour starts at 11:00")
 		}
 	})
@@ -913,7 +913,7 @@ func TestCanTerminateEarly(t *testing.T) {
 			mkRow(time.Date(2026, 3, 9, 10, 15, 0, 0, time.UTC), 1),
 		}
 		remaining := []string{"s3://b/event_date=2026-03-09/event_hour=12/e.parquet"}
-		if canTerminateEarly(results, remaining, 5, "") {
+		if canTerminateEarly(results, remaining, 5, "", nil) {
 			t.Error("should not terminate: not enough results")
 		}
 	})
@@ -923,7 +923,7 @@ func TestCanTerminateEarly(t *testing.T) {
 			mkRow(time.Date(2026, 3, 9, 10, 15, 0, 0, time.UTC), 1),
 		}
 		remaining := []string{"s3://b/no-hive/events.parquet"}
-		if canTerminateEarly(results, remaining, 1, "") {
+		if canTerminateEarly(results, remaining, 1, "", nil) {
 			t.Error("should not terminate: can't parse remaining file's hour")
 		}
 	})
@@ -937,7 +937,7 @@ func TestCanTerminateEarly(t *testing.T) {
 			mkRow(time.Date(2026, 3, 9, 10, 30, 0, 0, time.UTC), 3),
 		}
 		remaining := []string{"s3://b/event_date=2026-03-09/event_hour=11/e.parquet"}
-		if !canTerminateEarly(results, remaining, 2, "") {
+		if !canTerminateEarly(results, remaining, 2, "", nil) {
 			t.Error("expected early termination: sorted 2nd result (10:30) is before hour=11")
 		}
 	})
@@ -949,7 +949,7 @@ func TestCanTerminateEarly(t *testing.T) {
 			mkRow(time.Date(2026, 3, 9, 11, 0, 0, 0, time.UTC), 1),
 		}
 		remaining := []string{"s3://b/event_date=2026-03-09/event_hour=11/e.parquet"}
-		if canTerminateEarly(results, remaining, 1, "") {
+		if canTerminateEarly(results, remaining, 1, "", nil) {
 			t.Error("should not terminate: cutoff is exactly at next hour start")
 		}
 	})
@@ -958,7 +958,7 @@ func TestCanTerminateEarly(t *testing.T) {
 		results := []query.ResultRow{
 			mkRow(time.Date(2026, 3, 9, 10, 15, 0, 0, time.UTC), 1),
 		}
-		if canTerminateEarly(results, nil, 1, "") {
+		if canTerminateEarly(results, nil, 1, "", nil) {
 			t.Error("should not terminate: no remaining files")
 		}
 	})
@@ -976,7 +976,7 @@ func TestCanTerminateEarly(t *testing.T) {
 		remaining := []string{"s3://b/event_date=2026-03-09/event_hour=11/e.parquet"}
 		// limit=3 means we'd need 3 real-timestamp rows to ground a cutoff,
 		// but we only have 1. Must not terminate.
-		if canTerminateEarly(results, remaining, 3, "") {
+		if canTerminateEarly(results, remaining, 3, "", nil) {
 			t.Error("should not terminate: only 1 non-drift row, cannot ground cutoff")
 		}
 	})
@@ -993,7 +993,7 @@ func TestCanTerminateEarly(t *testing.T) {
 			mkRow(time.Date(2026, 3, 9, 10, 45, 0, 0, time.UTC), 3),
 		}
 		remaining := []string{"s3://b/event_date=2026-03-09/event_hour=11/e.parquet"}
-		if !canTerminateEarly(results, remaining, 2, "") {
+		if !canTerminateEarly(results, remaining, 2, "", nil) {
 			t.Error("expected early termination: 2nd real row (10:30) is before hour=11, drift rows filtered out")
 		}
 	})
@@ -1399,7 +1399,7 @@ func TestClassifyEmptyS3Listing(t *testing.T) {
 	})
 
 	// TestClassifyEmptyS3Listing/until-only (post-review fix to #774, #876
-	// review): generateDatePrefixes(prefix, nil, old) now unconditionally
+	// review): generateDatePrefixes(prefix, nil, old, nil) now unconditionally
 	// returns nil for since==nil (correctly makes listS3ParquetScoped list
 	// the FULL prefix rather than inventing a bogus window). But that nil-ness
 	// is no longer the right signal for whether classifyEmptyS3Listing should
@@ -1469,4 +1469,84 @@ func TestClassifyEmptyS3Listing(t *testing.T) {
 			t.Errorf("got rows=%v err=%v, want nil/nil (healthy empty range, real data exists elsewhere)", rows, err)
 		}
 	})
+}
+
+// ─── misfiled-archive file scoping (#1037) ──────────────────────────────────
+
+func TestFilterFilesByTimeRange_extraHoursKeepMisfiledFile(t *testing.T) {
+	// A backfill scenario: the queried window is 2026-07-20, but the rows
+	// live in a file archived under the oldest live partition's label two
+	// days later (event_date=2026-07-22/event_hour=01).
+	misfiled := "s3://b/x/bintrail_id=u/event_date=2026-07-22/event_hour=01/events.parquet"
+	inRange := "s3://b/x/bintrail_id=u/event_date=2026-07-20/event_hour=10/events.parquet"
+	outOfRange := "s3://b/x/bintrail_id=u/event_date=2026-07-23/event_hour=05/events.parquet"
+	files := []string{inRange, misfiled, outOfRange}
+
+	since := time.Date(2026, 7, 20, 9, 0, 0, 0, time.UTC)
+	until := time.Date(2026, 7, 20, 23, 0, 0, 0, time.UTC)
+
+	// Without the hint the misfiled file is pruned — the pre-#1037 hole.
+	got := filterFilesByTimeRange(files, &since, &until, nil)
+	if len(got) != 1 || got[0] != inRange {
+		t.Fatalf("without extra hours: got %v, want [%s]", got, inRange)
+	}
+
+	// With the hint (its label hour) it must survive; unrelated out-of-range
+	// files must still be pruned.
+	extra := []time.Time{time.Date(2026, 7, 22, 1, 0, 0, 0, time.UTC)}
+	got = filterFilesByTimeRange(files, &since, &until, extra)
+	if len(got) != 2 || got[0] != inRange || got[1] != misfiled {
+		t.Fatalf("with extra hours: got %v, want [%s %s]", got, inRange, misfiled)
+	}
+}
+
+func TestGenerateDatePrefixes_extraHoursAppendDates(t *testing.T) {
+	base := "archives/bintrail_id=u/"
+	since := time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC)
+	until := time.Date(2026, 7, 20, 23, 0, 0, 0, time.UTC)
+	extra := []time.Time{
+		time.Date(2026, 7, 22, 1, 0, 0, 0, time.UTC),  // misfiled label, new day
+		time.Date(2026, 7, 20, 15, 0, 0, 0, time.UTC), // same day as window: no dup
+	}
+	got := generateDatePrefixes(base, &since, &until, extra)
+	want := []string{
+		base + "event_date=2026-07-20/",
+		base + "event_date=2026-07-22/",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("generateDatePrefixes = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("prefix[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestGenerateDatePrefixes_extraHoursIrrelevantWhenUnscoped(t *testing.T) {
+	extra := []time.Time{time.Date(2026, 7, 22, 1, 0, 0, 0, time.UTC)}
+	// No since → unscoped listing: everything is listed anyway.
+	if got := generateDatePrefixes("base/", nil, nil, extra); got != nil {
+		t.Fatalf("expected nil (unscoped) even with extra hours, got %v", got)
+	}
+}
+
+func TestCanTerminateEarly_disabledWithExtraHours(t *testing.T) {
+	// Enough early results to satisfy the limit, and the next file's LABEL
+	// hour is after the cutoff — without extra hours this would terminate.
+	results := []query.ResultRow{
+		{EventID: 1, EventTimestamp: time.Date(2026, 7, 20, 10, 5, 0, 0, time.UTC)},
+		{EventID: 2, EventTimestamp: time.Date(2026, 7, 20, 10, 6, 0, 0, time.UTC)},
+	}
+	remaining := []string{"bintrail_id=u/event_date=2026-07-22/event_hour=01/events.parquet"}
+
+	if !canTerminateEarly(results, remaining, 2, "", nil) {
+		t.Fatal("sanity: expected early termination without extra hours")
+	}
+	// A misfiled file may hold the window's EARLIEST rows despite its late
+	// label — label-order termination is unsound while any hint is present.
+	extra := []time.Time{time.Date(2026, 7, 22, 1, 0, 0, 0, time.UTC)}
+	if canTerminateEarly(results, remaining, 2, "", extra) {
+		t.Fatal("early termination must be disabled while misfiled-archive hints are present")
+	}
 }

--- a/internal/query/fetchmerged.go
+++ b/internal/query/fetchmerged.go
@@ -363,6 +363,10 @@ func warnSkippedSources(skipped []string) {
 type mergeSources struct {
 	archSources []string
 	plan        *QueryPlan
+	// misfiledHours is plan.MisfiledArchiveHours, kept separately so fetchPage
+	// can forward it to every archive fetch (as Options.ExtraArchiveHours)
+	// even on paginated walks where per-page Options are rebuilt (#1037).
+	misfiledHours []time.Time
 }
 
 // resolveMergeSources discovers archive sources, runs the coverage planner and
@@ -401,6 +405,13 @@ func resolveMergeSources(ctx context.Context, db *sql.DB, o FetchMergedOptions) 
 			slog.Warn("query planner failed; coverage gaps may not be detected", "error", err)
 		} else {
 			src.plan = p
+			if p != nil {
+				// Archives whose content escapes their hour label but overlaps
+				// the window (#1037): every archive fetch below must be told to
+				// include these files despite their out-of-range labels, or a
+				// date-pruned S3 read silently skips the backfilled rows.
+				src.misfiledHours = p.MisfiledArchiveHours
+			}
 		}
 	}
 
@@ -453,8 +464,13 @@ func fetchPage(
 		rows = r
 	}
 
+	// Archive fetches get the misfiled-archive file-scoping hint (#1037); the
+	// MySQL fetch above deliberately does not (partition pruning there reads
+	// live partition boundaries, which are always label-accurate).
+	archOpts := o.Opts
+	archOpts.ExtraArchiveHours = src.misfiledHours
 	for _, s := range src.archSources {
-		ar, aerr := o.ArchiveFetcher(ctx, o.Opts, s)
+		ar, aerr := o.ArchiveFetcher(ctx, archOpts, s)
 		if aerr == nil && len(ar) == 0 {
 			// This source has nothing left for the walk. Sound to retire it:
 			// the cursor only ever moves forward, so every later page applies a

--- a/internal/query/fetchmerged_test.go
+++ b/internal/query/fetchmerged_test.go
@@ -230,3 +230,43 @@ func TestFetchMergedResolverFailure(t *testing.T) {
 		}
 	})
 }
+
+// ─── misfiled-archive hint threading (#1037) ────────────────────────────────
+
+// TestFetchPage_forwardsMisfiledHoursToArchiveFetcher pins the seam that makes
+// content-derived pruning reach the archive fetcher: the misfiled hour labels
+// resolved once per walk (mergeSources.misfiledHours, from
+// QueryPlan.MisfiledArchiveHours) must arrive on every archive fetch as
+// Options.ExtraArchiveHours. Losing this hop silently reopens #1037 — the
+// date-scoped S3 listing would prune the very file holding backfilled rows.
+func TestFetchPage_forwardsMisfiledHoursToArchiveFetcher(t *testing.T) {
+	misfiled := []time.Time{time.Date(2026, 7, 22, 1, 0, 0, 0, time.UTC)}
+	var got [][]time.Time
+	fetcher := func(ctx context.Context, opts Options, source string) ([]ResultRow, error) {
+		got = append(got, opts.ExtraArchiveHours)
+		return []ResultRow{{EventID: 1}}, nil
+	}
+	src := mergeSources{
+		archSources:   []string{"srcA", "srcB"},
+		misfiledHours: misfiled,
+		// Empty plan: SkipMySQL()==true, so the nil engine is never touched.
+		plan: &QueryPlan{},
+	}
+	o := FetchMergedOptions{Opts: Options{}, AllowGaps: true, ArchiveFetcher: fetcher}
+
+	rows, skipped, exhausted, err := fetchPage(context.Background(), nil, o, src)
+	if err != nil {
+		t.Fatalf("fetchPage: %v", err)
+	}
+	if len(rows) == 0 || len(skipped) != 0 || len(exhausted) != 0 {
+		t.Fatalf("unexpected fetch outcome: rows=%d skipped=%v exhausted=%v", len(rows), skipped, exhausted)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 archive fetches, got %d", len(got))
+	}
+	for i, hours := range got {
+		if len(hours) != 1 || !hours[0].Equal(misfiled[0]) {
+			t.Errorf("fetch %d: ExtraArchiveHours = %v, want %v", i, hours, misfiled)
+		}
+	}
+}

--- a/internal/query/planner.go
+++ b/internal/query/planner.go
@@ -3,10 +3,14 @@ package query
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 	"time"
+
+	"github.com/go-sql-driver/mysql"
 )
 
 // TimeRange represents a contiguous UTC time range at hour granularity.
@@ -37,6 +41,17 @@ type QueryPlan struct {
 	// index younger than the queried window, every pre-install hour is a
 	// "gap" that was never captured in the first place (#1126).
 	OldestKnownHour time.Time
+
+	// MisfiledArchiveHours are the hour LABELS of archived partitions whose
+	// content-derived time range (archive_state.min/max_event_ts, #1037)
+	// escapes the label hour AND overlaps the queried range. Backfilled
+	// events land in the oldest live RANGE partition and get archived under
+	// its hour label, so a time-scoped read that prunes archive files by
+	// label alone would skip the very file holding those rows. Callers must
+	// copy this into Options.ExtraArchiveHours for their archive fetches so
+	// file/date scoping still opens those files; row-level time filters keep
+	// the result set correct.
+	MisfiledArchiveHours []time.Time
 }
 
 // Plan builds a QueryPlan for the given time range by inspecting live partition
@@ -85,16 +100,20 @@ func Plan(ctx context.Context, db *sql.DB, dbName string, since, until *time.Tim
 	// Skipped entirely when noArchive: those archives are excluded from the
 	// fetch, so reading their coverage here would only mislabel rotated hours as
 	// covered. Leaving archivedHours nil makes buildPlan classify them as gaps.
-	var archivedHours []time.Time
+	var cov []archiveCoverage
 	if !noArchive {
-		archivedHours, err = loadArchivedHours(ctx, db)
+		cov, err = loadArchiveCoverage(ctx, db)
 		if err != nil {
 			slog.Debug("archive_state not available for planning", "error", err)
-			archivedHours = nil
+			cov = nil
 		}
 	}
 
-	return buildPlan(liveHours, archivedHours, rangeStart, rangeEnd, noArchive), nil
+	plan := buildPlan(liveHours, expandArchiveHours(cov), rangeStart, rangeEnd, noArchive)
+	if plan != nil && !noArchive {
+		plan.MisfiledArchiveHours = misfiledHours(cov, rangeStart, rangeEnd)
+	}
+	return plan, nil
 }
 
 // buildPlan is the pure-logic core of the planner. It classifies each hour in
@@ -280,9 +299,64 @@ func loadLivePartitionHours(ctx context.Context, db *sql.DB, dbName string) ([]t
 	return hours, rows.Err()
 }
 
-// loadArchivedHours returns the sorted set of hours that have been archived
-// to Parquet (from archive_state partition names).
-func loadArchivedHours(ctx context.Context, db *sql.DB) ([]time.Time, error) {
+// archiveCoverage describes one archive_state row's time coverage: the hour
+// parsed from its partition_name label plus the content-derived
+// min/max_event_ts range of the archived rows (#1037). Min/Max are the zero
+// time when unknown — rows written before the columns existed, or registered
+// by upload/reconcile, which never scan row contents.
+type archiveCoverage struct {
+	Label    time.Time
+	Min, Max time.Time
+}
+
+// maxCoverageSpan bounds how far a single archive's content range may expand
+// its claimed hour coverage. A corrupt/zero-date min_event_ts would otherwise
+// make expandArchiveHours enumerate millions of hours. Rows exceeding it fall
+// back to label-only coverage (the pre-#1037 behavior).
+const maxCoverageSpan = 20 * 366 * 24 * time.Hour
+
+// loadArchiveCoverage returns per-row archive coverage from archive_state.
+// On an index whose archive_state predates the min/max_event_ts columns
+// (error 1054 — the migration only runs where EnsureSchema does, e.g. rotate),
+// it falls back to label-only coverage so planning keeps working unchanged.
+func loadArchiveCoverage(ctx context.Context, db *sql.DB) ([]archiveCoverage, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT partition_name, min_event_ts, max_event_ts
+		FROM archive_state
+		ORDER BY partition_name`)
+	if err != nil {
+		var myErr *mysql.MySQLError
+		if errors.As(err, &myErr) && myErr.Number == 1054 {
+			return loadArchiveCoverageLegacy(ctx, db)
+		}
+		return nil, err
+	}
+	defer rows.Close()
+
+	var cov []archiveCoverage
+	for rows.Next() {
+		var name string
+		var minTS, maxTS sql.NullTime
+		if err := rows.Scan(&name, &minTS, &maxTS); err != nil {
+			return nil, err
+		}
+		t, ok := ParsePartitionName(name)
+		if !ok {
+			continue
+		}
+		c := archiveCoverage{Label: t}
+		if minTS.Valid && maxTS.Valid {
+			c.Min = minTS.Time.UTC()
+			c.Max = maxTS.Time.UTC()
+		}
+		cov = append(cov, c)
+	}
+	return cov, rows.Err()
+}
+
+// loadArchiveCoverageLegacy is loadArchiveCoverage for pre-#1037 archive_state
+// schemas: partition names only, no content range.
+func loadArchiveCoverageLegacy(ctx context.Context, db *sql.DB) ([]archiveCoverage, error) {
 	rows, err := db.QueryContext(ctx, `
 		SELECT DISTINCT partition_name
 		FROM archive_state
@@ -292,17 +366,108 @@ func loadArchivedHours(ctx context.Context, db *sql.DB) ([]time.Time, error) {
 	}
 	defer rows.Close()
 
-	var hours []time.Time
+	var cov []archiveCoverage
 	for rows.Next() {
 		var name string
 		if err := rows.Scan(&name); err != nil {
 			return nil, err
 		}
 		if t, ok := ParsePartitionName(name); ok {
-			hours = append(hours, t)
+			cov = append(cov, archiveCoverage{Label: t})
 		}
 	}
-	return hours, rows.Err()
+	return cov, rows.Err()
+}
+
+// expandArchiveHours converts archive coverage rows into the sorted, deduped
+// set of hours the archives actually hold data for: each row's label hour,
+// widened to every hour in its content range [Min, Max] when known (#1037).
+// The widening is sound for gap classification: RANGE partitioning routes any
+// captured event older than a partition's upper bound into the oldest live
+// partition, so events inside a misfiled archive's content range have no
+// other place they could live — an hour in that span with no events anywhere
+// is exactly as empty as an unlabeled hour today.
+func expandArchiveHours(cov []archiveCoverage) []time.Time {
+	seen := make(map[time.Time]bool, len(cov))
+	var hours []time.Time
+	add := func(h time.Time) {
+		if !seen[h] {
+			seen[h] = true
+			hours = append(hours, h)
+		}
+	}
+	for _, c := range cov {
+		add(c.Label)
+		if c.Min.IsZero() || c.Max.IsZero() || c.Max.Before(c.Min) {
+			continue
+		}
+		if c.Max.Sub(c.Min) > maxCoverageSpan {
+			slog.Debug("archive content range implausibly wide; using label-only coverage",
+				"partition_hour", c.Label, "min_event_ts", c.Min, "max_event_ts", c.Max)
+			continue
+		}
+		for h := c.Min.Truncate(time.Hour); !h.After(c.Max); h = h.Add(time.Hour) {
+			add(h)
+		}
+	}
+	slices.SortFunc(hours, func(a, b time.Time) int { return a.Compare(b) })
+	return hours
+}
+
+// misfiledHours returns the sorted, deduped hour LABELS of archives whose
+// content range escapes their label hour AND overlaps [rangeStart, rangeEnd)
+// (#1037). Zero rangeStart/rangeEnd mean an open bound. These are the files a
+// label-pruning archive fetch would wrongly skip for this range, so callers
+// forward them as Options.ExtraArchiveHours.
+func misfiledHours(cov []archiveCoverage, rangeStart, rangeEnd time.Time) []time.Time {
+	seen := make(map[time.Time]bool)
+	var hours []time.Time
+	for _, c := range cov {
+		if c.Min.IsZero() || c.Max.IsZero() || c.Max.Before(c.Min) {
+			continue
+		}
+		// Content within the label hour → the label already prunes correctly.
+		if !c.Min.Before(c.Label) && c.Max.Before(c.Label.Add(time.Hour)) {
+			continue
+		}
+		// Content range must overlap the queried range.
+		if !rangeEnd.IsZero() && !c.Min.Before(rangeEnd) {
+			continue
+		}
+		if !rangeStart.IsZero() && c.Max.Before(rangeStart) {
+			continue
+		}
+		if !seen[c.Label] {
+			seen[c.Label] = true
+			hours = append(hours, c.Label)
+		}
+	}
+	slices.SortFunc(hours, func(a, b time.Time) int { return a.Compare(b) })
+	return hours
+}
+
+// MisfiledArchiveHours is the standalone form of QueryPlan.MisfiledArchiveHours
+// for callers that fetch archives without running the full planner (e.g. the
+// MCP query/recover tools). It reads archive_state coverage and returns the
+// hour labels of misfiled archives overlapping [since, until]; nil bounds are
+// open. Returns (nil, nil) when db is nil or no time bound is set (no pruning
+// happens then, so nothing can be missed).
+func MisfiledArchiveHours(ctx context.Context, db *sql.DB, since, until *time.Time) ([]time.Time, error) {
+	if db == nil || (since == nil && until == nil) {
+		return nil, nil
+	}
+	cov, err := loadArchiveCoverage(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	var rangeStart, rangeEnd time.Time
+	if since != nil {
+		rangeStart = since.Truncate(time.Hour)
+	}
+	if until != nil {
+		rangeEnd = until.Truncate(time.Hour).Add(time.Hour)
+	}
+	return misfiledHours(cov, rangeStart, rangeEnd), nil
 }
 
 // ParsePartitionName converts a partition name like "p_2026021914" to the

--- a/internal/query/planner_test.go
+++ b/internal/query/planner_test.go
@@ -378,3 +378,128 @@ func TestBuildPlan_noBoundsReturnsNil(t *testing.T) {
 		t.Errorf("expected nil for zero-value bounds, got %+v", plan)
 	}
 }
+
+// ─── archive content coverage (#1037) ───────────────────────────────────────
+
+func TestExpandArchiveHours_contentRangeWidensCoverage(t *testing.T) {
+	label := time.Date(2026, 7, 22, 1, 0, 0, 0, time.UTC)
+	// Backfilled partition: content starts 3 hours before the label hour.
+	cov := []archiveCoverage{{
+		Label: label,
+		Min:   label.Add(-3 * time.Hour).Add(10 * time.Minute),
+		Max:   label.Add(45 * time.Minute),
+	}}
+	got := expandArchiveHours(cov)
+	want := []time.Time{
+		label.Add(-3 * time.Hour),
+		label.Add(-2 * time.Hour),
+		label.Add(-time.Hour),
+		label,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("expandArchiveHours = %v, want %v", got, want)
+	}
+	for i := range want {
+		if !got[i].Equal(want[i]) {
+			t.Errorf("hour[%d] = %v, want %v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestExpandArchiveHours_labelOnlyFallbacks(t *testing.T) {
+	label := time.Date(2026, 7, 22, 1, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name string
+		cov  archiveCoverage
+	}{
+		{"zero min/max (pre-#1037 row)", archiveCoverage{Label: label}},
+		{"inverted range", archiveCoverage{Label: label, Min: label.Add(time.Hour), Max: label}},
+		{"implausibly wide range", archiveCoverage{
+			Label: label,
+			Min:   label.Add(-maxCoverageSpan - time.Hour),
+			Max:   label,
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := expandArchiveHours([]archiveCoverage{tc.cov})
+			if len(got) != 1 || !got[0].Equal(label) {
+				t.Errorf("expandArchiveHours = %v, want just the label hour %v", got, label)
+			}
+		})
+	}
+}
+
+func TestExpandArchiveHours_dedupesAcrossRows(t *testing.T) {
+	l1 := time.Date(2026, 7, 22, 1, 0, 0, 0, time.UTC)
+	l2 := l1.Add(time.Hour)
+	cov := []archiveCoverage{
+		{Label: l1, Min: l1, Max: l2.Add(30 * time.Minute)}, // spills into l2
+		{Label: l2, Min: l2, Max: l2.Add(59 * time.Minute)},
+	}
+	got := expandArchiveHours(cov)
+	if len(got) != 2 || !got[0].Equal(l1) || !got[1].Equal(l2) {
+		t.Errorf("expandArchiveHours = %v, want [%v %v]", got, l1, l2)
+	}
+}
+
+func TestMisfiledHours(t *testing.T) {
+	label := time.Date(2026, 7, 22, 1, 0, 0, 0, time.UTC)
+	// Misfiled: content spans two days before the label (the #1037 backfill).
+	misfiled := archiveCoverage{
+		Label: label,
+		Min:   label.Add(-48 * time.Hour),
+		Max:   label.Add(30 * time.Minute),
+	}
+	// Well-filed: content inside its own label hour.
+	wellFiled := archiveCoverage{
+		Label: label.Add(time.Hour),
+		Min:   label.Add(time.Hour),
+		Max:   label.Add(time.Hour + 59*time.Minute),
+	}
+	// Unknown content (pre-#1037 row): never reported misfiled.
+	unknown := archiveCoverage{Label: label.Add(2 * time.Hour)}
+	cov := []archiveCoverage{misfiled, wellFiled, unknown}
+
+	t.Run("window over backfilled hours returns the misfiled label", func(t *testing.T) {
+		start := label.Add(-40 * time.Hour)
+		end := label.Add(-39 * time.Hour)
+		got := misfiledHours(cov, start, end)
+		if len(got) != 1 || !got[0].Equal(label) {
+			t.Fatalf("misfiledHours = %v, want [%v]", got, label)
+		}
+	})
+
+	t.Run("window not overlapping content returns nothing", func(t *testing.T) {
+		start := label.Add(-80 * time.Hour)
+		end := label.Add(-72 * time.Hour)
+		if got := misfiledHours(cov, start, end); len(got) != 0 {
+			t.Fatalf("misfiledHours = %v, want empty", got)
+		}
+	})
+
+	t.Run("open start bound", func(t *testing.T) {
+		got := misfiledHours(cov, time.Time{}, label.Add(-39*time.Hour))
+		if len(got) != 1 || !got[0].Equal(label) {
+			t.Fatalf("misfiledHours = %v, want [%v]", got, label)
+		}
+	})
+
+	t.Run("open end bound", func(t *testing.T) {
+		got := misfiledHours(cov, label.Add(-40*time.Hour), time.Time{})
+		if len(got) != 1 || !got[0].Equal(label) {
+			t.Fatalf("misfiledHours = %v, want [%v]", got, label)
+		}
+	})
+
+	t.Run("well-filed archives never reported", func(t *testing.T) {
+		// Window covering exactly the well-filed hour — past the misfiled
+		// archive's content max, so only wellFiled/unknown are candidates,
+		// and neither may be reported.
+		start := wellFiled.Min
+		end := wellFiled.Min.Add(time.Hour)
+		if got := misfiledHours(cov, start, end); len(got) != 0 {
+			t.Fatalf("misfiledHours = %v, want empty (content within label hour)", got)
+		}
+	})
+}

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -241,11 +241,22 @@ type Options struct {
 	// rather than returning a silently truncated stream.
 	//
 	// nil = no cursor (fetch from the start of the window).
-	AfterEvent    *EventCursor
-	ChangedColumn string     // column name; matched via JSON_CONTAINS
-	ColumnEq      []ColumnEq // match against values inside row_after / row_before
-	Flag          string     // return events from tables/columns carrying this flag
-	Limit         int        // 0 → no limit (no LIMIT clause emitted)
+	AfterEvent *EventCursor
+	// ExtraArchiveHours lists the hour LABELS of archive files whose CONTENT
+	// time range overlaps the query window even though their partition/Hive
+	// path label does not (#1037: backfilled events archived under the oldest
+	// live partition's label). It is a FILE-SCOPING hint consumed only by the
+	// archive fetcher (parquetquery): date-scoped S3 listings and Hive-path
+	// pruning include these labels' files, and label-order early termination
+	// is disabled while any are present. It is NEVER a row filter — Since /
+	// Until / SincePos / UntilPos still bound the returned events — and the
+	// MySQL engine ignores it. Populated from QueryPlan.MisfiledArchiveHours
+	// (or query.MisfiledArchiveHours) by callers that prune archives by time.
+	ExtraArchiveHours []time.Time
+	ChangedColumn     string     // column name; matched via JSON_CONTAINS
+	ColumnEq          []ColumnEq // match against values inside row_after / row_before
+	Flag              string     // return events from tables/columns carrying this flag
+	Limit             int        // 0 → no limit (no LIMIT clause emitted)
 	// LimitPerPK caps the number of latest events returned per pk_values value.
 	// 0 = unlimited. Applied via ROW_NUMBER OVER (PARTITION BY pk_values
 	// ORDER BY event_timestamp DESC, event_id DESC) so the kept events are

--- a/internal/rotation/rotation.go
+++ b/internal/rotation/rotation.go
@@ -141,6 +141,7 @@ func Perform(ctx context.Context, db *sql.DB, dbName string, opts Options) (Resu
 						return Result{}, fmt.Errorf("create archive directory for %s: %w", name, err)
 					}
 					var n int64
+					var minTS, maxTS time.Time
 					skipped := false
 					if opts.Retry && fileExists(outPath) {
 						// A file existing at outPath with size>0 is NOT sufficient
@@ -172,9 +173,23 @@ func Perform(ctx context.Context, db *sql.DB, dbName string, opts Options) (Resu
 							fmt.Fprintf(os.Stdout, "skipped partition %s (already archived) → %s\n", name, outPath)
 						}
 					} else {
-						n, err = archive.ArchivePartition(ctx, db, dbName, name, outPath, opts.ArchiveCompression)
-						if err != nil {
-							return Result{}, fmt.Errorf("archive partition %s: %w", name, err)
+						st, aerr := archive.ArchivePartition(ctx, db, dbName, name, outPath, opts.ArchiveCompression)
+						if aerr != nil {
+							return Result{}, fmt.Errorf("archive partition %s: %w", name, aerr)
+						}
+						n, minTS, maxTS = st.Rows, st.MinEventTS, st.MaxEventTS
+						// A partition whose CONTENT escapes its hour label holds
+						// backfilled events (#1037): old rows replayed after a
+						// capture stall land in the oldest live RANGE partition.
+						// The true range is recorded in archive_state below so
+						// time-scoped reads still find these rows; the warning
+						// gives the operator the same fact for pre-existing
+						// misfiled archives and monitoring.
+						if escapesLabelHour(name, minTS, maxTS) {
+							slog.Warn("archived partition contains events outside its hour label (backfilled rows); recording true content time range so time-scoped archive reads still find them",
+								"partition", name,
+								"min_event_ts", minTS.UTC().Format(time.RFC3339),
+								"max_event_ts", maxTS.UTC().Format(time.RFC3339))
 						}
 						if opts.Format != "json" {
 							fmt.Fprintf(os.Stdout, "archived partition %s (%d rows) → %s\n", name, n, outPath)
@@ -207,17 +222,29 @@ func Perform(ctx context.Context, db *sql.DB, dbName string, opts Options) (Resu
 							insertBucket = s3Bucket
 							insertKey = s3Key
 						}
+						// min/max_event_ts: the content-derived range of the
+						// archived rows (#1037). NULL for an empty partition —
+						// the planner then falls back to the hour label.
+						var insertMin, insertMax any
+						if !minTS.IsZero() {
+							insertMin = minTS.UTC()
+						}
+						if !maxTS.IsZero() {
+							insertMax = maxTS.UTC()
+						}
 						if _, err := db.ExecContext(ctx,
 							`INSERT INTO archive_state
-								(partition_name, bintrail_id, local_path, file_size_bytes, row_count, s3_bucket, s3_key)
-							VALUES (?, ?, ?, ?, ?, ?, ?)
+								(partition_name, bintrail_id, local_path, file_size_bytes, row_count, s3_bucket, s3_key, min_event_ts, max_event_ts)
+							VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 							ON DUPLICATE KEY UPDATE
 								local_path = VALUES(local_path),
 								file_size_bytes = VALUES(file_size_bytes),
 								row_count = VALUES(row_count),
 								s3_bucket = COALESCE(VALUES(s3_bucket), s3_bucket),
-								s3_key = COALESCE(VALUES(s3_key), s3_key)`,
-							name, opts.BintrailID, outPath, fileSize, n, insertBucket, insertKey,
+								s3_key = COALESCE(VALUES(s3_key), s3_key),
+								min_event_ts = VALUES(min_event_ts),
+								max_event_ts = VALUES(max_event_ts)`,
+							name, opts.BintrailID, outPath, fileSize, n, insertBucket, insertKey, insertMin, insertMax,
 						); err != nil {
 							return Result{}, fmt.Errorf("record archive state for %s: %w", name, err)
 						}
@@ -562,6 +589,20 @@ func partitionRowCount(ctx context.Context, db *sql.DB, dbName, partition string
 // be lost by the drop; an unknown archived count is never safe.
 func archivedPartitionUnchanged(archived sql.NullInt64, live int64) bool {
 	return archived.Valid && archived.Int64 == live
+}
+
+// escapesLabelHour reports whether an archived partition's content-derived
+// event_timestamp range [minTS, maxTS] extends outside the hour its name
+// labels (#1037). False when the range is unknown (zero — empty partition) or
+// the name is not an hourly partition.
+func escapesLabelHour(partitionName string, minTS, maxTS time.Time) bool {
+	label, ok := indexer.PartitionDate(partitionName)
+	if !ok || minTS.IsZero() || maxTS.IsZero() {
+		return false
+	}
+	labelStart := label.UTC()
+	labelEnd := labelStart.Add(time.Hour)
+	return minTS.UTC().Before(labelStart) || !maxTS.UTC().Before(labelEnd)
 }
 
 // fileExists reports whether a file exists and has a size greater than zero.

--- a/internal/rotation/rotation_integration_test.go
+++ b/internal/rotation/rotation_integration_test.go
@@ -17,6 +17,8 @@ import (
 
 	"github.com/dbtrail/dbtrail/internal/archive"
 	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/parquetquery"
+	"github.com/dbtrail/dbtrail/internal/query"
 	"github.com/dbtrail/dbtrail/internal/testutil"
 )
 
@@ -945,5 +947,101 @@ func TestPerformRotation_LocalOnlyArchiveNotPruned(t *testing.T) {
 	}
 	if _, err := os.Stat(outPath); err != nil {
 		t.Errorf("local-only archive %s must survive (it is the durable copy); stat err = %v", outPath, err)
+	}
+}
+
+// ─── backfill archived under the wrong hour label (#1037) ────────────────────
+
+// TestPerformRotation_BackfilledPartitionStaysTimeQueryable reproduces #1037
+// end-to-end: a capture stall is recovered by replaying two-day-old events,
+// which RANGE partitioning files into the OLDEST live partition; rotation then
+// archives that partition under its own hour label. Before the fix any
+// time-scoped read for the backfilled window missed those rows — the planner
+// classified the hours as gaps (label-only archive coverage → strict mode
+// aborted with a GapError) and label-pruned S3 listings skipped the file.
+//
+// With content-derived pruning, rotation records the archive's true
+// MIN/MAX(event_timestamp) in archive_state; the planner counts the spanned
+// hours as covered and reports the misfiled label so the fetch opens the file.
+func TestPerformRotation_BackfilledPartitionStaysTimeQueryable(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	// Oldest (and only named) live partition, already past retention.
+	h1 := time.Now().UTC().Add(-48 * time.Hour).Truncate(time.Hour)
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{h1})
+
+	// Backfilled events carry their ORIGINAL binlog timestamps, two days and
+	// one day before h1 — far older than the partition's hour label. The
+	// native event belongs to h1's own hour.
+	backfillOld := h1.Add(-48 * time.Hour).Add(10 * time.Minute)
+	backfillMid := h1.Add(-24 * time.Hour).Add(20 * time.Minute)
+	native := h1.Add(30 * time.Minute)
+	const tsFmt = "2006-01-02 15:04:05"
+	testutil.InsertEvent(t, db, "binlog.000001", 100, 200, backfillOld.Format(tsFmt), nil, "testdb", "users", 1, "1", nil, nil, []byte(`{"id":1}`))
+	testutil.InsertEvent(t, db, "binlog.000001", 200, 300, backfillMid.Format(tsFmt), nil, "testdb", "users", 1, "2", nil, nil, []byte(`{"id":2}`))
+	testutil.InsertEvent(t, db, "binlog.000001", 300, 400, native.Format(tsFmt), nil, "testdb", "users", 1, "3", nil, nil, []byte(`{"id":3}`))
+
+	archiveDir := t.TempDir()
+	bintrailID := "test-uuid-1037"
+	res, err := Perform(context.Background(), db, dbName, Options{
+		RetainDur:          24 * time.Hour,
+		ArchiveDir:         archiveDir,
+		BintrailID:         bintrailID,
+		ArchiveCompression: "none",
+		Format:             "text",
+		NoReplace:          true,
+	})
+	if err != nil {
+		t.Fatalf("Perform: %v", err)
+	}
+	if res.Dropped != 1 {
+		t.Fatalf("expected 1 partition dropped, got %d", res.Dropped)
+	}
+
+	// archive_state must record the CONTENT time range, not the label hour.
+	var minTS, maxTS sql.NullTime
+	if err := db.QueryRow(
+		`SELECT min_event_ts, max_event_ts FROM archive_state WHERE partition_name = ? AND bintrail_id = ?`,
+		indexer.PartitionName(h1), bintrailID,
+	).Scan(&minTS, &maxTS); err != nil {
+		t.Fatalf("read archive_state content range: %v", err)
+	}
+	if !minTS.Valid || !minTS.Time.UTC().Equal(backfillOld) {
+		t.Errorf("min_event_ts = %v (valid=%v), want %v", minTS.Time, minTS.Valid, backfillOld)
+	}
+	if !maxTS.Valid || !maxTS.Time.UTC().Equal(native) {
+		t.Errorf("max_event_ts = %v (valid=%v), want %v", maxTS.Time, maxTS.Valid, native)
+	}
+
+	// The mutation-killer: a STRICT time-scoped read of the backfilled
+	// window must find the replayed event. On pre-#1037 main this failed
+	// twice over — FetchMerged returned a GapError (the hours counted as
+	// uncovered) and label-based file pruning skipped the archive.
+	since := backfillOld.Add(-time.Minute)
+	until := backfillOld.Add(time.Hour)
+	rows, plan, err := query.FetchMerged(context.Background(), db, query.New(db), query.FetchMergedOptions{
+		Opts:           query.Options{Schema: "testdb", Table: "users", Since: &since, Until: &until},
+		DBName:         dbName,
+		AllowGaps:      false,
+		ArchiveFetcher: parquetquery.Fetch,
+	})
+	if err != nil {
+		t.Fatalf("strict FetchMerged over the backfilled window: %v", err)
+	}
+	if len(rows) != 1 || rows[0].PKValues != "1" {
+		t.Fatalf("expected exactly the backfilled event (pk=1), got %d rows: %+v", len(rows), rows)
+	}
+	if plan == nil {
+		t.Fatal("expected a query plan")
+	}
+	foundLabel := false
+	for _, h := range plan.MisfiledArchiveHours {
+		if h.Equal(h1) {
+			foundLabel = true
+		}
+	}
+	if !foundLabel {
+		t.Errorf("plan.MisfiledArchiveHours = %v, want to include the misfiled label hour %v", plan.MisfiledArchiveHours, h1)
 	}
 }

--- a/internal/rotation/rotation_test.go
+++ b/internal/rotation/rotation_test.go
@@ -375,3 +375,37 @@ func TestHiveArchivePath_invalidPartition(t *testing.T) {
 		t.Fatal("expected error for p_future, got nil")
 	}
 }
+
+// ─── content range vs hour label (#1037) ─────────────────────────────────────
+
+// TestEscapesLabelHour pins the trigger for the backfill warning and the
+// content-range recording: a partition whose archived rows' [min, max]
+// event_timestamp range extends outside its p_YYYYMMDDHH label hour holds
+// backfilled events, which label-based archive pruning would lose.
+func TestEscapesLabelHour(t *testing.T) {
+	label := time.Date(2026, 7, 22, 1, 0, 0, 0, time.UTC)
+	name := "p_" + label.Format("2006010215")
+
+	cases := []struct {
+		name     string
+		min, max time.Time
+		want     bool
+	}{
+		{"content inside label hour", label.Add(time.Minute), label.Add(59 * time.Minute), false},
+		{"backfilled: min two days early", label.Add(-48 * time.Hour), label.Add(30 * time.Minute), true},
+		{"max spills into next hour", label, label.Add(time.Hour), true},
+		{"empty partition (zero range)", time.Time{}, time.Time{}, false},
+		{"exact hour boundaries", label, label.Add(59*time.Minute + 59*time.Second), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := escapesLabelHour(name, tc.min, tc.max); got != tc.want {
+				t.Errorf("escapesLabelHour(%s, %v, %v) = %v, want %v", name, tc.min, tc.max, got, tc.want)
+			}
+		})
+	}
+
+	if escapesLabelHour("p_future", label.Add(-time.Hour), label) {
+		t.Error("p_future has no hour label; must never report an escape")
+	}
+}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -384,6 +384,8 @@ func InitIndexTables(t *testing.T, db *sql.DB) {
 		s3_bucket       VARCHAR(255),
 		s3_key          VARCHAR(1024),
 		s3_uploaded_at  DATETIME,
+		min_event_ts    DATETIME DEFAULT NULL,
+		max_event_ts    DATETIME DEFAULT NULL,
 		archived_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
 		UNIQUE KEY uq_partition (partition_name, bintrail_id)
 	) ENGINE=InnoDB`)


### PR DESCRIPTION
Closes #1037

## Problem

When a stream backfills events whose hourly partitions were already rotated away, the old rows land in the **oldest live RANGE partition** and rotation archives that partition under its own hour label. The Parquet file's `event_date=`/`event_hour=` path and its `archive_state.partition_name` then disagree with the timestamps of the rows inside it, and every time-scoped read that prunes by the label silently skips the file:

- the **planner** (`ParsePartitionName` over `archive_state`) classified the backfilled hours as *gaps* → strict reads (`reconstruct`, `AllowGaps=false`) aborted with a spurious `GapError`, permissive ones warned and returned nothing from S3;
- **date-scoped S3 listings** never listed the file's prefix for the old window;
- **Hive-path file filtering** and **label-order early termination** pruned/stopped before the file.

A silent restore-coverage hole created precisely while recovering from a capture gap.

## Fix — issue option 1: content-derived pruning

At archive time, compute the true content range and record it where pruning already looks (`archive_state`), then teach each pruning site to honor it:

- `archive.ArchivePartition` returns `Stats{Rows, MinEventTS, MaxEventTS}`, tracked from the exact rows written — the range can never disagree with the file.
- Rotation records `min_event_ts`/`max_event_ts` in `archive_state` (new nullable columns: init DDL + `EnsureSchema` migration) and emits a **WARN** when a partition's content escapes its hour label — operators see misfiling as it happens.
- The planner expands archive coverage across each archive's content range (hours in `[min, max]` count as covered → no more spurious `GapError`; sound because RANGE partitioning gives events in that span no other place to live) and reports misfiled labels overlapping the window on `QueryPlan.MisfiledArchiveHours`.
- `Options.ExtraArchiveHours` threads those labels to `parquetquery` as a **file-scoping-only** hint: date-scoped S3 listings add the labels' dates, Hive-path filtering keeps the labeled files, label-order early termination is disabled while hints are present. Row-level `Since`/`Until` filters still bound the returned events.
- Wired at every archive read surface that has an index DB: `FetchMerged`/`FetchMergedStream` (recover, reconstruct, shim, console, verify), `bintrail query`, the MCP query/recover tools, and the agent handler.

Why not option 2 (split/re-label placement): a single misfiled partition can span days, and one file can only live under one `event_date=` prefix — correct placement would mean per-hour file splitting, which breaks the one-file-per-partition invariants that `--retry` verification, the S3 upload flow, the TOCTOU drop guard, and `archive reconcile` are all built on. Recording the true range in the metadata pruning already consults is strictly smaller.

## Backward compatibility

- Pre-existing `archive_state` rows (NULL range) and rows registered by `upload`/`archive reconcile` fall back to label-only pruning — exactly the old behavior.
- Reading an index whose `archive_state` predates the migration (error 1054) falls back to the legacy label-only query.
- Docs: `rotation-and-status.md` (new "Backfilled events and the hour label" section, incl. manual remediation for pre-existing misfiled archives) and `query-and-recovery.md` (planner coverage is content-derived).

## Tests

- **End-to-end mutation killer** (`TestPerformRotation_BackfilledPartitionStaysTimeQueryable`, integration): reproduces the incident — 2-day-old rows filed into the oldest live partition, archived, partition dropped — then asserts a strict time-scoped `FetchMerged` over the backfilled window returns the rows and the plan reports the misfiled label. Verified to **fail with the exact pre-fix `GapError`** when coverage is forced label-only.
- Unit: coverage expansion + fallbacks (zero/inverted/implausible ranges), misfiled-label detection (open/closed bounds, well-filed never reported), `fetchPage` hint threading, `escapesLabelHour`, and each parquetquery pruning site (`filterFilesByTimeRange`, `generateDatePrefixes`, `canTerminateEarly`).
- `go build ./...`, `go vet -tags integration ./...`, `-race` unit + integration suites green on all touched packages (`query`, `parquetquery`, `rotation`, `archive`, `indexer`, `cli`, `cliapp`, `mcptools`, `agent`, plus downstream `shim`/`reconstruct`/`verify`/`consoleapp`/`streamrun`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
