### PR TITLE
console: fall back to the process --baseline-dir/--baseline-s3 for registry servers without their own

### DIFF
--- a/docs/console.md
+++ b/docs/console.md
@@ -166,7 +166,10 @@ How it behaves:
   server" — so two browser tabs can watch two different servers.
 - **Per-server Time-travel.** The reconstruct gate (baseline configured, no
   RBAC profile, archives enabled) is evaluated per server; the Time-travel view
-  appears and disappears as you switch.
+  appears and disappears as you switch. A server whose registry entry has no
+  baseline of its own inherits the process-wide `--baseline-dir`/`--baseline-s3`
+  (when set), so servers added from the UI get Time-travel and verify under a
+  single-baseline-dir deployment without extra configuration.
 - **Test connection.** Each server (saved or being typed) has a write-free
   probe: ping, MySQL version, latency, whether the database looks like a
   dbtrail index, and whether its schema is current.

--- a/internal/console/console_integration_test.go
+++ b/internal/console/console_integration_test.go
@@ -586,6 +586,57 @@ func TestIntegrationEvictOnDSNEdit(t *testing.T) {
 	}
 }
 
+// TestIntegrationRegistryServerInheritsProcessBaseline (#1010): a server
+// added through POST /api/servers (no baseline field) under a daemon started
+// with --baseline-dir must come up Time-travel-enabled through the REAL
+// lazy-open path: /api/capabilities on the new server reports
+// reconstruct:true. The same add under a daemon without a process baseline
+// stays gated off.
+func TestIntegrationRegistryServerInheritsProcessBaseline(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	dbName2 := seedSecondIndex(t)
+
+	for _, procBaseline := range []bool{true, false} {
+		cfg := Config{DB: db, DBName: dbName, Listen: "127.0.0.1:8090", Token: intToken}
+		if procBaseline {
+			cfg.BaselineDir = t.TempDir()
+		}
+		srv, err := New(cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(srv.cm.CloseAll)
+
+		rec, body := doReq(t, srv, "POST", "/api/servers",
+			`{"name":"second","dsn":"`+testutil.IntegrationDSN(dbName2)+`"}`)
+		if rec.Code/100 != 2 {
+			t.Fatalf("procBaseline=%v: create code=%d body=%s", procBaseline, rec.Code, body)
+		}
+		var created serverDTO
+		if err := json.Unmarshal(body, &created); err != nil {
+			t.Fatal(err)
+		}
+		if created.Reconstruct != procBaseline {
+			t.Errorf("procBaseline=%v: created DTO reconstruct=%v, want %v",
+				procBaseline, created.Reconstruct, procBaseline)
+		}
+
+		rec, body = doReqOn(t, srv, created.ID, "GET", "/api/capabilities", "")
+		if rec.Code != 200 {
+			t.Fatalf("procBaseline=%v: capabilities code=%d body=%s", procBaseline, rec.Code, body)
+		}
+		var caps capabilitiesResponse
+		if err := json.Unmarshal(body, &caps); err != nil {
+			t.Fatal(err)
+		}
+		if caps.Reconstruct != procBaseline {
+			t.Errorf("procBaseline=%v: lazy-opened registry server reconstruct=%v, want %v",
+				procBaseline, caps.Reconstruct, procBaseline)
+		}
+	}
+}
+
 // TestIntegrationRegistryOnlyConsole: no --index-dsn at all — the first saved
 // server is the default and serves every surface.
 func TestIntegrationRegistryOnlyConsole(t *testing.T) {

--- a/internal/console/manager.go
+++ b/internal/console/manager.go
@@ -71,6 +71,17 @@ type connManager struct {
 	// nor baseline reads apply RBAC redaction.
 	profileActive bool
 
+	// defaultBaselineDir / defaultBaselineS3 are the process-wide
+	// --baseline-dir / --baseline-s3 flags, used as the baseline source for
+	// registry entries that carry none of their own (#1010). Without this
+	// fallback, a server added from the UI (whose add form has no baseline
+	// field) could never enable Time-travel/reconstruct/verify even though the
+	// daemon was started with a usable --baseline-dir — the common
+	// single-baseline-dir deployment. Written once before serving
+	// (console.New), like profileActive; read-only afterwards.
+	defaultBaselineDir string
+	defaultBaselineS3  string
+
 	// hideBoot removes the boot entry from the UI entirely. Set by
 	// source-less `bintrail-console watch`: its boot index is only the
 	// control plane's anchor database — no stream ever writes to it — so a
@@ -187,7 +198,7 @@ func (cm *connManager) Resolve(ctx context.Context, id string) (*bundle, error) 
 			// Derive the published gates from the CURRENT entry: a
 			// baseline/no-archive-only edit during the open keeps this db but
 			// must not publish the stale entry's reconstruct gate.
-			nb := newBundleDerived(b.db, b.dbName, cur, cm.profileActive)
+			nb := newBundleDerived(b.db, b.dbName, cm.withBaselineDefaults(cur), cm.profileActive)
 			nb.resolver = b.resolver
 			nb.resolverUnavailable = b.resolverUnavailable
 			cm.bundles[id] = nb
@@ -223,9 +234,24 @@ func (cm *connManager) buildBundle(entry ServerEntry) (*bundle, error) {
 	if err != nil {
 		return nil, fmt.Errorf("server %q: %s", entry.Name, scrubDSNError(err, entry.DSN))
 	}
-	b := newBundleDerived(db, cfg.DBName, entry, cm.profileActive)
+	b := newBundleDerived(db, cfg.DBName, cm.withBaselineDefaults(entry), cm.profileActive)
 	b.resolver, b.resolverUnavailable = loadResolver(db)
 	return b, nil
+}
+
+// withBaselineDefaults returns the entry with the process-wide
+// --baseline-dir / --baseline-s3 filled in when it carries no baseline source
+// of its own (#1010). The fallback is all-or-nothing: an entry with its OWN
+// dir or S3 configured chose its baseline location explicitly, and mixing a
+// per-entry S3 with the process dir (or vice versa) would make findBaseline's
+// dir-over-S3 preference and #766 S3 retry read from a location the operator
+// never associated with that server.
+func (cm *connManager) withBaselineDefaults(entry ServerEntry) ServerEntry {
+	if entry.BaselineDir == "" && entry.BaselineS3 == "" {
+		entry.BaselineDir = cm.defaultBaselineDir
+		entry.BaselineS3 = cm.defaultBaselineS3
+	}
+	return entry
 }
 
 // newBundleDerived computes the pure-config per-server state shared by lazy
@@ -337,7 +363,7 @@ func (cm *connManager) rebuildDerived(entry ServerEntry) {
 	if !ok {
 		return
 	}
-	nb := newBundleDerived(old.db, old.dbName, entry, cm.profileActive)
+	nb := newBundleDerived(old.db, old.dbName, cm.withBaselineDefaults(entry), cm.profileActive)
 	nb.engine = old.engine
 	nb.resolver = old.resolver
 	nb.resolverUnavailable = old.resolverUnavailable
@@ -355,6 +381,7 @@ func (cm *connManager) cached(id string) bool {
 // capability reports the reconstruct gate for a registry entry as pure config —
 // no connection is opened, so /api/servers can label every entry instantly.
 func (cm *connManager) capability(entry ServerEntry) bool {
+	entry = cm.withBaselineDefaults(entry)
 	src := entry.BaselineDir
 	if src == "" {
 		src = entry.BaselineS3

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -359,6 +359,13 @@ func New(cfg Config) (*Server, error) {
 	}
 	s.managedTok.initFromDisk(mcpTokenPath, mcpTokFile)
 	s.cm.hideBoot = cfg.HideBoot
+	// Registry entries with no baseline of their own (every UI/API-added
+	// server — the add form has no baseline field) fall back to the process
+	// flags, so a daemon started with --baseline-dir/--baseline-s3 enables
+	// Time-travel/reconstruct/verify for them too, not just the boot entry
+	// (#1010).
+	s.cm.defaultBaselineDir = cfg.BaselineDir
+	s.cm.defaultBaselineS3 = cfg.BaselineS3
 
 	// Seed the ephemeral boot bundle when the caller supplied a command-line
 	// connection (or baseline config for it). Its derived state — noArchive

--- a/internal/console/servers_api_test.go
+++ b/internal/console/servers_api_test.go
@@ -891,24 +891,129 @@ func TestBuildDSNRejectsRawDSNPlusPassword(t *testing.T) {
 }
 
 // TestCapabilityMatrix: the pure-config reconstruct gate over
-// baseline × no_archive × profile.
+// baseline × no_archive × profile × process-wide baseline fallback (#1010).
 func TestCapabilityMatrix(t *testing.T) {
 	cases := []struct {
-		name    string
-		entry   ServerEntry
-		profile bool
-		want    bool
+		name       string
+		entry      ServerEntry
+		profile    bool
+		defaultDir string
+		want       bool
 	}{
-		{"baseline dir", ServerEntry{BaselineDir: "/b"}, false, true},
-		{"baseline s3", ServerEntry{BaselineS3: "s3://b/"}, false, true},
-		{"no baseline", ServerEntry{}, false, false},
-		{"no_archive kills it", ServerEntry{BaselineDir: "/b", NoArchive: true}, false, false},
-		{"profile kills it", ServerEntry{BaselineDir: "/b"}, true, false},
+		{"baseline dir", ServerEntry{BaselineDir: "/b"}, false, "", true},
+		{"baseline s3", ServerEntry{BaselineS3: "s3://b/"}, false, "", true},
+		{"no baseline", ServerEntry{}, false, "", false},
+		{"no_archive kills it", ServerEntry{BaselineDir: "/b", NoArchive: true}, false, "", false},
+		{"profile kills it", ServerEntry{BaselineDir: "/b"}, true, "", false},
+		// #1010: an entry with no baseline of its own inherits the process-wide
+		// --baseline-dir; no_archive and an active profile still gate it off.
+		{"process fallback", ServerEntry{}, false, "/proc/b", true},
+		{"fallback + no_archive", ServerEntry{NoArchive: true}, false, "/proc/b", false},
+		{"fallback + profile", ServerEntry{}, true, "/proc/b", false},
 	}
 	for _, tc := range cases {
 		cm := newConnManager(nil, tc.profile)
+		cm.defaultBaselineDir = tc.defaultDir
 		if got := cm.capability(tc.entry); got != tc.want {
 			t.Errorf("%s: capability = %v, want %v", tc.name, got, tc.want)
 		}
+	}
+}
+
+// TestRegistryBaselineFallbackAPI (#1010): a server added through the real
+// POST /api/servers path — which has no baseline field — must inherit the
+// process-wide --baseline-dir: its DTO reports reconstruct:true, and the
+// derived bundle (rebuildDerived shares newBundleDerived with the lazy open)
+// turns on both Reconstruct and Verify in /api/capabilities. Without a
+// process baseline dir, both stay off. The DTO's baseline_dir must stay the
+// entry's OWN (empty) value — echoing the default into the edit form would
+// persist it as per-server config on the next save.
+func TestRegistryBaselineFallbackAPI(t *testing.T) {
+	for _, procBaseline := range []bool{true, false} {
+		reg, err := LoadRegistry(t.TempDir() + "/console-servers.yaml")
+		if err != nil {
+			t.Fatal(err)
+		}
+		cfg := Config{
+			Listen: "127.0.0.1:8090", Token: "t", Registry: reg,
+			MonitorCtrl: &stubMonitorCtrl{}, VerifyCtrl: &stubVerifyCtrl{},
+		}
+		if procBaseline {
+			cfg.BaselineDir = "/var/bintrail/baselines"
+		}
+		srv, err := New(cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rec, body := doServersReq(t, srv, "POST", "/api/servers",
+			`{"name":"orders","dsn":"u:p@tcp(10.0.0.5:3306)/idx"}`)
+		if rec.Code/100 != 2 {
+			t.Fatalf("procBaseline=%v: create code=%d body=%s", procBaseline, rec.Code, body)
+		}
+		var created serverDTO
+		if err := json.Unmarshal(body, &created); err != nil {
+			t.Fatal(err)
+		}
+		if created.Reconstruct != procBaseline {
+			t.Errorf("procBaseline=%v: created DTO reconstruct=%v, want %v",
+				procBaseline, created.Reconstruct, procBaseline)
+		}
+		if created.BaselineDir != "" || created.BaselineS3 != "" {
+			t.Errorf("procBaseline=%v: DTO must report the entry's OWN baseline (empty), got dir=%q s3=%q",
+				procBaseline, created.BaselineDir, created.BaselineS3)
+		}
+
+		// Publish the entry's derived bundle the way the manager does (the
+		// unit suite can't dial the fake DSN a lazy open would need).
+		entry, ok := srv.cm.reg.Get(created.ID)
+		if !ok {
+			t.Fatal("created entry missing from registry")
+		}
+		srv.cm.bundles[created.ID] = &bundle{}
+		srv.cm.rebuildDerived(entry)
+
+		rec, body = doServersReqHeader(t, srv, "GET", "/api/capabilities", "", created.ID)
+		if rec.Code != 200 {
+			t.Fatalf("procBaseline=%v: capabilities code=%d body=%s", procBaseline, rec.Code, body)
+		}
+		var caps capabilitiesResponse
+		if err := json.Unmarshal(body, &caps); err != nil {
+			t.Fatal(err)
+		}
+		if caps.Reconstruct != procBaseline {
+			t.Errorf("procBaseline=%v: capabilities reconstruct=%v, want %v",
+				procBaseline, caps.Reconstruct, procBaseline)
+		}
+		if caps.Verify != procBaseline {
+			t.Errorf("procBaseline=%v: capabilities verify=%v, want %v",
+				procBaseline, caps.Verify, procBaseline)
+		}
+		if b := srv.cm.bundles[created.ID]; procBaseline && b.baselineSrc != "/var/bintrail/baselines" {
+			t.Errorf("bundle baselineSrc=%q, want the process --baseline-dir", b.baselineSrc)
+		}
+	}
+}
+
+// TestWithBaselineDefaultsAllOrNothing (#1010): the process fallback applies
+// only when the entry carries NO baseline of its own — an entry with its own
+// dir or S3 chose its location explicitly, and mixing in the process default
+// would make findBaseline read a location never associated with that server.
+func TestWithBaselineDefaultsAllOrNothing(t *testing.T) {
+	cm := newConnManager(nil, false)
+	cm.defaultBaselineDir = "/proc/b"
+	cm.defaultBaselineS3 = "s3://proc/"
+
+	got := cm.withBaselineDefaults(ServerEntry{})
+	if got.BaselineDir != "/proc/b" || got.BaselineS3 != "s3://proc/" {
+		t.Errorf("empty entry must inherit both defaults, got dir=%q s3=%q", got.BaselineDir, got.BaselineS3)
+	}
+	got = cm.withBaselineDefaults(ServerEntry{BaselineS3: "s3://own/"})
+	if got.BaselineDir != "" || got.BaselineS3 != "s3://own/" {
+		t.Errorf("own S3 must suppress BOTH defaults, got dir=%q s3=%q", got.BaselineDir, got.BaselineS3)
+	}
+	got = cm.withBaselineDefaults(ServerEntry{BaselineDir: "/own"})
+	if got.BaselineDir != "/own" || got.BaselineS3 != "" {
+		t.Errorf("own dir must suppress BOTH defaults, got dir=%q s3=%q", got.BaselineDir, got.BaselineS3)
 	}
 }

--- a/internal/console/verify_trigger.go
+++ b/internal/console/verify_trigger.go
@@ -167,6 +167,12 @@ func (s *Server) handleVerifyTrigger(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	// An entry with no baseline of its own inherits the process-wide
+	// --baseline-dir/--baseline-s3 (#1010), matching the reconstruct gate:
+	// the capabilities endpoint advertises Verify from the bundle's
+	// baselineConfigured, which applies the same fallback, so the trigger
+	// must accept what the UI was told is enabled.
+	e = s.cm.withBaselineDefaults(e)
 
 	var body struct {
 		Mode   string   `json:"mode"`

--- a/internal/console/verify_trigger_test.go
+++ b/internal/console/verify_trigger_test.go
@@ -227,6 +227,34 @@ func TestVerifyTrigger_requiresBaselineDestination(t *testing.T) {
 	}
 }
 
+// TestVerifyTrigger_processBaselineFallback (#1010): an entry with no
+// baseline of its own inherits the process-wide --baseline-dir — the trigger
+// accepts (matching the Verify capability the UI was shown) and the
+// VerifyRequest carries the fallback dir.
+func TestVerifyTrigger_processBaselineFallback(t *testing.T) {
+	reg, _ := LoadRegistry(t.TempDir() + "/console-servers.yaml")
+	ctrl := &stubVerifyCtrl{status: VerifyStatus{State: "idle"}}
+	srv, err := New(Config{
+		Listen: "127.0.0.1:8090", Token: "t", Registry: reg,
+		MonitorCtrl: &stubMonitorCtrl{}, VerifyCtrl: ctrl,
+		BaselineDir: "/var/bintrail/baselines",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := addVerifyEntry(t, srv, "u:p@tcp(127.0.0.1:3306)/", "", "")
+	rec, body := doServersReq(t, srv, "POST", "/api/servers/"+id+"/verify", "")
+	if rec.Code != 202 {
+		t.Fatalf("process baseline fallback: code=%d body=%s, want 202", rec.Code, body)
+	}
+	if len(ctrl.triggered) != 1 {
+		t.Fatalf("triggered %d runs, want 1", len(ctrl.triggered))
+	}
+	if got := ctrl.triggered[0].BaselineDir; got != "/var/bintrail/baselines" {
+		t.Errorf("VerifyRequest.BaselineDir=%q, want the process --baseline-dir", got)
+	}
+}
+
 // TestVerifyTrigger_requiresSourceForLiveSource: live-source mode needs a
 // source DSN — 400 without one, even with a baseline destination configured.
 func TestVerifyTrigger_requiresSourceForLiveSource(t *testing.T) {


### PR DESCRIPTION
Closes #1010

## Problem

A server added from the UI or `POST /api/servers` could never enable Time-travel/reconstruct/verify: the add form has no baseline field, so `entry.BaselineDir` was always empty, `newBundleDerived` computed `baselineConfigured=false`, and the process `--baseline-dir`/`--baseline-s3` flags were only ever consulted for the boot entry.

## Fix (issue's option b)

`connManager` now carries the process-wide baseline defaults (wired once in `console.New`, same pattern as `hideBoot`), and a new `withBaselineDefaults(entry)` fills them into any registry entry that carries **no** baseline source of its own, at every site that derives per-server state:

- the lazy open (`Resolve` publish + `buildBundle`),
- `rebuildDerived` (baseline/no-archive-only edits),
- `capability` (the pure-config `reconstruct` label on `/api/servers`),
- `handleVerifyTrigger` (destination gate + the `VerifyRequest` it enqueues), so the trigger accepts exactly what the capabilities endpoint advertises.

The existing gates are unchanged and still apply on top of the fallback: `no_archive` and an active RBAC profile keep reconstruct/verify off.

Deliberate boundaries:

- **All-or-nothing fallback**: an entry with its own dir *or* S3 chose its baseline location explicitly; mixing a per-entry source with a process default would make `findBaseline`'s dir-over-S3 preference (and the #766 S3 retry) read a location the operator never associated with that server.
- **The server DTO keeps reporting the entry's OWN (empty) baseline fields** — echoing the default into the edit form would persist it as per-server config on the next save.
- **Option (a) (a per-server baseline field on the +Add form) is deliberately NOT built** — bigger surface, not needed for the common single-baseline-dir deployment; can be added later if a mixed-baseline deployment asks for it.
- The `BINTRAIL_CONSOLE_BASELINE_TRIGGER=1` create-baseline endpoint still requires an explicit per-entry destination (writing snapshots somewhere is a behavior change beyond read-side gating, out of scope here).

## Tests

- `TestCapabilityMatrix` extended: process-fallback × `no_archive` × profile.
- `TestRegistryBaselineFallbackAPI`: real `POST /api/servers` (no baseline field) under a process `--baseline-dir` → DTO `reconstruct:true` and `/api/capabilities` `Reconstruct`/`Verify` true via the derived bundle; both stay false without the process flag; DTO baseline fields stay empty.
- `TestWithBaselineDefaultsAllOrNothing`: own dir/S3 suppresses both defaults.
- `TestVerifyTrigger_processBaselineFallback`: trigger returns 202 and the `VerifyRequest` carries the fallback dir (negative control: existing `TestVerifyTrigger_requiresBaselineDestination`).
- `TestIntegrationRegistryServerInheritsProcessBaseline`: end-to-end against real MySQL through the actual lazy-open path — registry-added server reports `reconstruct:true` under `--baseline-dir`, false without.

`go build ./...`, `go vet -tags integration ./...`, `go test -race ./internal/console/...` (full suite, 89s), and the neighboring integration tests (`ServerSwitching`, `EvictOnDSNEdit`) all pass, re-run after rebasing onto current main (over the #1150 `loadResolver` two-value change).

docs/console.md: the per-server Time-travel bullet now documents the inheritance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)