### PR TITLE
reconstruct: refuse a full-table merge whose baseline and events are keyed apart

### DIFF
--- a/internal/cli/reconstruct.go
+++ b/internal/cli/reconstruct.go
@@ -152,7 +152,7 @@ func padFixedBinaryFilter(pkFilter map[string]string, pkMetas []metadata.ColumnM
 		if !strings.EqualFold(strings.TrimSpace(c.DataType), "binary") {
 			continue
 		}
-		width := fixedBinaryWidth(c.ColumnType)
+		width := reconstruct.FixedBinaryWidth(c.ColumnType)
 		if width == 0 {
 			// Pre-#212 snapshot with no COLUMN_TYPE: the pad width is
 			// unknowable, so leave the value alone rather than guess.
@@ -209,20 +209,6 @@ func decodeHexPKValue(s string) ([]byte, bool) {
 		return nil, false
 	}
 	return b, true
-}
-
-// fixedBinaryWidth extracts n from a "binary(n)" COLUMN_TYPE, returning 0 when
-// it is absent or unparseable.
-func fixedBinaryWidth(columnType string) int {
-	s := strings.ToLower(strings.TrimSpace(columnType))
-	if !strings.HasPrefix(s, "binary(") || !strings.HasSuffix(s, ")") {
-		return 0
-	}
-	n, err := strconv.Atoi(s[len("binary(") : len(s)-1])
-	if err != nil || n <= 0 {
-		return 0
-	}
-	return n
 }
 
 var reconstructCmd = &cobra.Command{

--- a/internal/cli/reconstruct_binarypk_1155_test.go
+++ b/internal/cli/reconstruct_binarypk_1155_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/reconstruct"
 )
 
 func TestFixedBinaryWidth(t *testing.T) {
@@ -21,8 +22,8 @@ func TestFixedBinaryWidth(t *testing.T) {
 		{"", 0},
 	}
 	for _, tc := range cases {
-		if got := fixedBinaryWidth(tc.columnType); got != tc.want {
-			t.Errorf("fixedBinaryWidth(%q) = %d, want %d", tc.columnType, got, tc.want)
+		if got := reconstruct.FixedBinaryWidth(tc.columnType); got != tc.want {
+			t.Errorf("FixedBinaryWidth(%q) = %d, want %d", tc.columnType, got, tc.want)
 		}
 	}
 }

--- a/internal/cli/reconstruct_binarypk_1155_test.go
+++ b/internal/cli/reconstruct_binarypk_1155_test.go
@@ -5,28 +5,7 @@ import (
 	"testing"
 
 	"github.com/dbtrail/dbtrail/internal/metadata"
-	"github.com/dbtrail/dbtrail/internal/reconstruct"
 )
-
-func TestFixedBinaryWidth(t *testing.T) {
-	cases := []struct {
-		columnType string
-		want       int
-	}{
-		{"binary(16)", 16},
-		{"BINARY(255)", 255},
-		{"binary", 0}, // no declared width to pad to
-		{"varbinary(16)", 0},
-		{"binary(0)", 0},
-		{"binary(x)", 0},
-		{"", 0},
-	}
-	for _, tc := range cases {
-		if got := reconstruct.FixedBinaryWidth(tc.columnType); got != tc.want {
-			t.Errorf("FixedBinaryWidth(%q) = %d, want %d", tc.columnType, got, tc.want)
-		}
-	}
-}
 
 // TestPadFixedBinaryFilter covers the retry that lets an operator paste a key
 // straight out of binlog_events.pk_values: that spelling is the ROW image's,

--- a/internal/cli/reconstruct_gapcheck_test.go
+++ b/internal/cli/reconstruct_gapcheck_test.go
@@ -20,30 +20,30 @@ func TestResolveGapCheck(t *testing.T) {
 		wantEventPosMissing bool
 	}{
 		{
-			name:   "mysql with binlog anchor and positioned event",
-			flavor: "mysql",
-			bmeta:  baseline.DumpMetadata{BinlogFile: "binlog.000042", BinlogPos: 12345},
+			name:      "mysql with binlog anchor and positioned event",
+			flavor:    "mysql",
+			bmeta:     baseline.DumpMetadata{BinlogFile: "binlog.000042", BinlogPos: 12345},
 			firstFile: "binlog.000042", firstStartPos: 20000,
 			wantFlavor: "mysql", wantAnchorPresent: true, wantEventPosMissing: false,
 		},
 		{
-			name:   "mysql missing anchor",
-			flavor: "mysql",
-			bmeta:  baseline.DumpMetadata{},
+			name:      "mysql missing anchor",
+			flavor:    "mysql",
+			bmeta:     baseline.DumpMetadata{},
 			firstFile: "binlog.000042", firstStartPos: 20000,
 			wantFlavor: "mysql", wantAnchorPresent: false, wantEventPosMissing: false,
 		},
 		{
-			name:   "mysql NULL binlog_file on first event (#318)",
-			flavor: "mysql",
-			bmeta:  baseline.DumpMetadata{BinlogFile: "binlog.000042", BinlogPos: 12345},
+			name:      "mysql NULL binlog_file on first event (#318)",
+			flavor:    "mysql",
+			bmeta:     baseline.DumpMetadata{BinlogFile: "binlog.000042", BinlogPos: 12345},
 			firstFile: "", firstStartPos: 0,
 			wantFlavor: "mysql", wantAnchorPresent: true, wantEventPosMissing: true,
 		},
 		{
-			name:   "empty flavor, no LSN = mysql semantics (no guard)",
-			flavor: "",
-			bmeta:  baseline.DumpMetadata{BinlogFile: "binlog.000042", BinlogPos: 12345},
+			name:      "empty flavor, no LSN = mysql semantics (no guard)",
+			flavor:    "",
+			bmeta:     baseline.DumpMetadata{BinlogFile: "binlog.000042", BinlogPos: 12345},
 			firstFile: "binlog.000042", firstStartPos: 20000,
 			wantFlavor: "", wantAnchorPresent: true, wantEventPosMissing: false,
 		},
@@ -53,16 +53,16 @@ func TestResolveGapCheck(t *testing.T) {
 			// semantics are forced and the lexical compare on LSN text is
 			// structurally unreachable (even if a future producer also fills
 			// BinlogFile with LSN text).
-			name:   "empty flavor but baseline LSN proves PG lineage = guard fires, postgres semantics",
-			flavor: "",
-			bmeta:  baseline.DumpMetadata{BinlogFile: "0/9", LSN: 0x9},
+			name:      "empty flavor but baseline LSN proves PG lineage = guard fires, postgres semantics",
+			flavor:    "",
+			bmeta:     baseline.DumpMetadata{BinlogFile: "0/9", LSN: 0x9},
 			firstFile: "0/10", firstStartPos: 0x10,
 			wantFlavor: "postgres", wantLineageGuard: true, wantAnchorPresent: true, wantEventPosMissing: false,
 		},
 		{
-			name:   "postgres with LSN anchor and positioned event",
-			flavor: "postgres",
-			bmeta:  baseline.DumpMetadata{LSN: 0x1000},
+			name:      "postgres with LSN anchor and positioned event",
+			flavor:    "postgres",
+			bmeta:     baseline.DumpMetadata{LSN: 0x1000},
 			firstFile: "0/2000", firstStartPos: 0x2000,
 			wantFlavor: "postgres", wantAnchorPresent: true, wantEventPosMissing: false,
 		},
@@ -70,25 +70,25 @@ func TestResolveGapCheck(t *testing.T) {
 			// Pre-slice-C PG baseline: no LSN key. Anchor absent even when the
 			// MySQL-shaped BinlogFile field is populated — PG must never anchor
 			// on file text.
-			name:   "postgres without LSN = anchor absent regardless of BinlogFile",
-			flavor: "postgres",
-			bmeta:  baseline.DumpMetadata{BinlogFile: "binlog.000042", BinlogPos: 12345},
+			name:      "postgres without LSN = anchor absent regardless of BinlogFile",
+			flavor:    "postgres",
+			bmeta:     baseline.DumpMetadata{BinlogFile: "binlog.000042", BinlogPos: 12345},
 			firstFile: "0/2000", firstStartPos: 0x2000,
 			wantFlavor: "postgres", wantAnchorPresent: false, wantEventPosMissing: false,
 		},
 		{
 			// 0 is not a valid WAL position: a PG event with zero StartPos has
 			// no comparable position even when its file text is non-empty.
-			name:   "postgres zero StartPos on first event = position missing",
-			flavor: "postgres",
-			bmeta:  baseline.DumpMetadata{LSN: 0x1000},
+			name:      "postgres zero StartPos on first event = position missing",
+			flavor:    "postgres",
+			bmeta:     baseline.DumpMetadata{LSN: 0x1000},
 			firstFile: "0/2000", firstStartPos: 0,
 			wantFlavor: "postgres", wantAnchorPresent: true, wantEventPosMissing: true,
 		},
 		{
-			name:   "mariadb keeps mysql semantics and ignores a stray LSN",
-			flavor: "mariadb",
-			bmeta:  baseline.DumpMetadata{BinlogFile: "mariadb-bin.000007", BinlogPos: 100, LSN: 42},
+			name:      "mariadb keeps mysql semantics and ignores a stray LSN",
+			flavor:    "mariadb",
+			bmeta:     baseline.DumpMetadata{BinlogFile: "mariadb-bin.000007", BinlogPos: 100, LSN: 42},
 			firstFile: "mariadb-bin.000007", firstStartPos: 900,
 			wantFlavor: "mariadb", wantAnchorPresent: true, wantEventPosMissing: false,
 		},

--- a/internal/reconstruct/fulltable.go
+++ b/internal/reconstruct/fulltable.go
@@ -1054,6 +1054,14 @@ func mergeBaselineImages(ctx context.Context, in mergeCore, emit func(map[string
 				stats.UpdatesApplied++
 			}
 		} else {
+			// This baseline row is about to be emitted verbatim because no
+			// event claimed it. Before trusting that, check the ONE other
+			// spelling its key could carry (#1158) — see altFixedBinaryPK.
+			if alt, ok := altFixedBinaryPK(in.PKCols, pkMap); ok {
+				if ev, pending := in.Changes[alt]; pending {
+					return stats, pkSpellingJoinErr(in.Schema, in.Table, pk, alt, ev.EventType)
+				}
+			}
 			if err := emit(rowMap); err != nil {
 				return stats, err
 			}
@@ -1289,6 +1297,35 @@ func pkChangingUpdateErr(schema, table, before, after string) error {
 			"would duplicate or resurrect rows in the output. Re-run `bintrail baseline` "+
 			"to capture a snapshot at or after the PK change, then reconstruct from there",
 		schema, table, before, after)
+}
+
+// pkSpellingJoinErr reports a baseline row and a pending event that denote the
+// same row under two different key spellings (#1158).
+//
+// This is a fail-loud guard, not a diagnosis of a data problem: it means
+// bintrail's own canonicalization and the spelling in binlog_events.pk_values
+// disagree, so the merge is about to emit the baseline row while the event that
+// supersedes it sits undrained. The consequences are asymmetric and the DELETE
+// one is why this refuses rather than warns:
+//
+//   - UPDATE/INSERT — the stale baseline row is emitted AND the event is
+//     appended as a new PK. A duplicate key, which a restore rejects with
+//     error 1062: loud, but only once the dump is being loaded.
+//   - DELETE — the event is skipped and the stale baseline row was already
+//     emitted, so a row deleted before the target instant is RESURRECTED into
+//     the output. Nothing downstream catches that: the dump restores cleanly
+//     and is simply wrong.
+func pkSpellingJoinErr(schema, table, canonical, alternate string, evType event.EventType) error {
+	kind, outcome := "UPDATE/INSERT", "emitted twice"
+	if evType == event.EventDelete {
+		kind, outcome = "DELETE", "resurrected after its DELETE"
+	}
+	return fmt.Errorf(
+		"full-table reconstruct: %s.%s has a baseline row keyed %q while an undrained %s event for the same row "+
+			"is keyed %q — the two spellings of a fixed BINARY(n) key (padded on storage, trailing-0x00-stripped in "+
+			"the binlog row image) are not being reconciled, so this row would be %s in the output. This is a bintrail "+
+			"canonicalization fault, not a problem with your data; please report it with the table's PK definition",
+		schema, table, canonical, kind, alternate, outcome)
 }
 
 // reconstructBinlogOnly is the ErrNoBaseline fallback for full-table

--- a/internal/reconstruct/fulltable.go
+++ b/internal/reconstruct/fulltable.go
@@ -791,9 +791,15 @@ type mergeInput struct {
 // it owns the MydumperWriter and turns each emitted row map into an ordered
 // tuple the writer expects.
 //
-// The writer's Close() is deferred as a fallback: on any early return it
-// still runs and unlinks half-written chunk files, so callers never observe
-// stray partial output on disk.
+// The writer's Close() is deferred so an early return always releases the
+// file handles. It does NOT undo the run: Close finalizes the current chunk
+// (terminating semicolon, flush) and only unlinks it when that write itself
+// fails, so an early return after rows have been written leaves a complete,
+// loadable chunk holding a PREFIX of the table, plus the schema file. The
+// run-level _INCOMPLETE marker is what tells a consumer not to trust the
+// directory; there is no in-file signal (#1162). The guards that predate the
+// writer opening — #602, #843 — sidestep this by refusing before any file
+// exists; a per-row guard like #1158 cannot.
 // GUARD PLACEMENT (#1097) — read before adding a check here.
 //
 // The two guards that inspect an event's BEFORE-image — #592 (residual
@@ -995,6 +1001,8 @@ func mergeBaselineImages(ctx context.Context, in mergeCore, emit func(map[string
 		return stats, fmt.Errorf("duckdb columns: %w", err)
 	}
 
+	warnUndetectableBinaryPK(in.Schema, in.Table, in.PKCols)
+
 	scan := make([]any, len(dcols))
 	ptrs := make([]any, len(dcols))
 	for i := range scan {
@@ -1032,6 +1040,22 @@ func mergeBaselineImages(ctx context.Context, in mergeCore, emit func(map[string
 		}
 		pk := event.BuildPKValues(in.PKCols, pkMap)
 
+		// Before deciding what claims this row, check the ONE other spelling
+		// its key could carry (#1158) — see altFixedBinaryPK.
+		//
+		// Hoisted above the branch on purpose. in.Changes is keyed by STRING,
+		// so two spellings of one logical row are two INDEPENDENT entries: an
+		// entry under the canonical spelling would send this row down the
+		// claimed branch while a sibling entry under the alternate one
+		// survives the scan and lands in the leftover tail, where a DELETE is
+		// dropped without a word. Checking only the unclaimed branch would
+		// leave exactly the resurrection this guard exists to stop.
+		if alt, ok := altFixedBinaryPK(in.PKCols, pkMap); ok {
+			if ev, pending := in.Changes[alt]; pending {
+				return stats, pkSpellingJoinErr(in.Schema, in.Table, pk, alt, ev.EventType)
+			}
+		}
+
 		if ev, ok := in.Changes[pk]; ok {
 			delete(in.Changes, pk)
 			switch ev.EventType {
@@ -1054,14 +1078,6 @@ func mergeBaselineImages(ctx context.Context, in mergeCore, emit func(map[string
 				stats.UpdatesApplied++
 			}
 		} else {
-			// This baseline row is about to be emitted verbatim because no
-			// event claimed it. Before trusting that, check the ONE other
-			// spelling its key could carry (#1158) — see altFixedBinaryPK.
-			if alt, ok := altFixedBinaryPK(in.PKCols, pkMap); ok {
-				if ev, pending := in.Changes[alt]; pending {
-					return stats, pkSpellingJoinErr(in.Schema, in.Table, pk, alt, ev.EventType)
-				}
-			}
 			if err := emit(rowMap); err != nil {
 				return stats, err
 			}
@@ -1318,14 +1334,38 @@ func pkChangingUpdateErr(schema, table, before, after string) error {
 func pkSpellingJoinErr(schema, table, canonical, alternate string, evType event.EventType) error {
 	kind, outcome := "UPDATE/INSERT", "emitted twice"
 	if evType == event.EventDelete {
-		kind, outcome = "DELETE", "resurrected after its DELETE"
+		kind, outcome = "DELETE", "kept alive past its DELETE"
 	}
 	return fmt.Errorf(
-		"full-table reconstruct: %s.%s has a baseline row keyed %q while an undrained %s event for the same row "+
+		"baseline merge: %s.%s has a baseline row keyed %q while an undrained %s event for the same row "+
 			"is keyed %q — the two spellings of a fixed BINARY(n) key (padded on storage, trailing-0x00-stripped in "+
-			"the binlog row image) are not being reconciled, so this row would be %s in the output. This is a bintrail "+
-			"canonicalization fault, not a problem with your data; please report it with the table's PK definition",
+			"the binlog row image) are not being reconciled, so this row would be %s in the reconstructed row set. "+
+			"First check that the schema snapshot matches the live column type (`bintrail snapshot`): a snapshot "+
+			"saying BINARY(n) for a column since ALTERed to VARBINARY(n) produces this same disagreement and is "+
+			"fixed by re-snapshotting. Otherwise this is a bintrail canonicalization fault — please report it with "+
+			"the table's PK definition",
 		schema, table, canonical, kind, alternate, outcome)
+}
+
+// warnUndetectableBinaryPK reports, once per table, that a fixed-binary PK
+// column carries no declared width so the #1158 key-spelling guard cannot run
+// for it. The CANONICAL key is unaffected — canonicalizePKValue trims without
+// reading the width — so this is not a correctness warning about the output; it
+// says the detector is off, which matters because the failure it detects is the
+// silent one. Mirrors the pre-#212 DATETIME-precision warning above.
+func warnUndetectableBinaryPK(schema, table string, pkCols []metadata.ColumnMeta) {
+	for _, c := range pkCols {
+		if !strings.EqualFold(strings.TrimSpace(c.DataType), "binary") {
+			continue
+		}
+		if FixedBinaryWidth(c.ColumnType) != 0 {
+			continue
+		}
+		slog.Warn("BINARY primary-key column has no column_type in the schema snapshot; the key-spelling guard (#1158) "+
+			"is disabled for this table — a baseline row and its event keyed under different spellings would go "+
+			"undetected. Re-run `bintrail snapshot` to capture column_type",
+			"schema", schema, "table", table, "column", c.Name)
+	}
 }
 
 // reconstructBinlogOnly is the ErrNoBaseline fallback for full-table

--- a/internal/reconstruct/fulltable_validation_test.go
+++ b/internal/reconstruct/fulltable_validation_test.go
@@ -18,9 +18,9 @@ import (
 // test runs without Docker/MySQL.
 func TestReconstructTables_validationErrors(t *testing.T) {
 	cases := []struct {
-		name     string
-		cfg      FullTableConfig
-		wantSub  string
+		name    string
+		cfg     FullTableConfig
+		wantSub string
 	}{
 		{
 			name: "missing IndexDSN",

--- a/internal/reconstruct/gap_test.go
+++ b/internal/reconstruct/gap_test.go
@@ -123,50 +123,50 @@ func TestGapDetected(t *testing.T) {
 	}{
 		// ── MySQL two-key compare ───────────────────────────────────────────
 		{
-			name:   "mysql same file, event past baseline pos = gap",
-			flavor: "mysql",
+			name:      "mysql same file, event past baseline pos = gap",
+			flavor:    "mysql",
 			eventFile: "binlog.000042", eventStartPos: 5000,
 			baselineFile: "binlog.000042", baselinePos: 1000,
 			want: true,
 		},
 		{
-			name:   "mysql same file, event at baseline pos = no gap",
-			flavor: "mysql",
+			name:      "mysql same file, event at baseline pos = no gap",
+			flavor:    "mysql",
 			eventFile: "binlog.000042", eventStartPos: 1000,
 			baselineFile: "binlog.000042", baselinePos: 1000,
 			want: false,
 		},
 		{
-			name:   "mysql later file = gap",
-			flavor: "mysql",
+			name:      "mysql later file = gap",
+			flavor:    "mysql",
 			eventFile: "binlog.000043", eventStartPos: 4,
 			baselineFile: "binlog.000042", baselinePos: 99999,
 			want: true, // later file always wins regardless of pos
 		},
 		{
-			name:   "mysql earlier file = no gap",
-			flavor: "mysql",
+			name:      "mysql earlier file = no gap",
+			flavor:    "mysql",
 			eventFile: "binlog.000041", eventStartPos: 99999,
 			baselineFile: "binlog.000042", baselinePos: 4,
 			want: false,
 		},
 		{
-			name:   "mariadb uses mysql semantics",
-			flavor: "mariadb",
+			name:      "mariadb uses mysql semantics",
+			flavor:    "mariadb",
 			eventFile: "mariadb-bin.000007", eventStartPos: 900,
 			baselineFile: "mariadb-bin.000007", baselinePos: 100,
 			want: true,
 		},
 		{
-			name:   "empty flavor falls back to mysql semantics",
-			flavor: "",
+			name:      "empty flavor falls back to mysql semantics",
+			flavor:    "",
 			eventFile: "binlog.000042", eventStartPos: 5000,
 			baselineFile: "binlog.000042", baselinePos: 1000,
 			want: true,
 		},
 		{
-			name:   "empty flavor, MySQL baselineLSN is ignored",
-			flavor: "",
+			name:      "empty flavor, MySQL baselineLSN is ignored",
+			flavor:    "",
 			eventFile: "binlog.000041", eventStartPos: 1,
 			baselineFile: "binlog.000042", baselinePos: 1000,
 			baselineLSN: 999, // must not be consulted outside the postgres branch
@@ -175,22 +175,22 @@ func TestGapDetected(t *testing.T) {
 
 		// ── PostgreSQL numeric LSN compare ──────────────────────────────────
 		{
-			name:   "pg event past baseline LSN = gap",
-			flavor: "postgres",
+			name:      "pg event past baseline LSN = gap",
+			flavor:    "postgres",
 			eventFile: "0/2000", eventStartPos: 0x2000,
 			baselineLSN: 0x1000,
 			want:        true,
 		},
 		{
-			name:   "pg event at baseline LSN = no gap",
-			flavor: "postgres",
+			name:      "pg event at baseline LSN = no gap",
+			flavor:    "postgres",
 			eventFile: "0/1000", eventStartPos: 0x1000,
 			baselineLSN: 0x1000,
 			want:        false,
 		},
 		{
-			name:   "pg event before baseline LSN = no gap",
-			flavor: "postgres",
+			name:      "pg event before baseline LSN = no gap",
+			flavor:    "postgres",
 			eventFile: "0/800", eventStartPos: 0x800,
 			baselineLSN: 0x1000,
 			want:        false,
@@ -199,8 +199,8 @@ func TestGapDetected(t *testing.T) {
 			// The lexical trap: "0/10" > "0/9" numerically (0x10=16 > 0x9=9)
 			// but "0/10" < "0/9" lexically. A file-text compare would report
 			// NO gap here; the numeric compare correctly reports one.
-			name:   "pg lexical trap: 0/10 event after 0/9 baseline = gap",
-			flavor: "postgres",
+			name:      "pg lexical trap: 0/10 event after 0/9 baseline = gap",
+			flavor:    "postgres",
 			eventFile: "0/10", eventStartPos: 0x10,
 			baselineFile: "0/9", baselinePos: 0, // file text present but must be ignored
 			baselineLSN: 0x9,
@@ -210,8 +210,8 @@ func TestGapDetected(t *testing.T) {
 			// Mirror of the trap: "0/9" event vs "0/10" baseline. Lexical
 			// compare on file text would FLAG a gap ("0/9" > "0/10"); the
 			// numeric compare correctly reports none.
-			name:   "pg lexical trap mirror: 0/9 event before 0/10 baseline = no gap",
-			flavor: "postgres",
+			name:      "pg lexical trap mirror: 0/9 event before 0/10 baseline = no gap",
+			flavor:    "postgres",
 			eventFile: "0/9", eventStartPos: 0x9,
 			baselineFile: "0/10", baselinePos: 0,
 			baselineLSN: 0x10,
@@ -220,8 +220,8 @@ func TestGapDetected(t *testing.T) {
 		{
 			// Pre-slice-A PG baseline: no LSN key → anchor unknown → never
 			// flag a gap (the check gates a warning only; callers log the skip).
-			name:   "pg baselineLSN zero = unknown anchor, no gap",
-			flavor: "postgres",
+			name:      "pg baselineLSN zero = unknown anchor, no gap",
+			flavor:    "postgres",
 			eventFile: "0/2000", eventStartPos: 0x2000,
 			baselineLSN: 0,
 			want:        false,

--- a/internal/reconstruct/mydumper_writer_test.go
+++ b/internal/reconstruct/mydumper_writer_test.go
@@ -176,14 +176,14 @@ func TestMydumperWriter_valueTypeMatrix(t *testing.T) {
 	content := string(b)
 
 	wants := []string{
-		"42",                             // int64
-		`'O\'Brien\\path'`,               // string with escapes
-		"NULL",                           // nil
-		"3.14",                           // float64
-		"'2026-04-11 14:30:45.500000'",   // time.Time
-		"X'deadbeef'",                    // []byte
-		`'{"k":"v"}'`,                    // map[string]any (JSON column)
-		"18446744073709551615",           // json.Number: bare numeric literal, exact
+		"42",                           // int64
+		`'O\'Brien\\path'`,             // string with escapes
+		"NULL",                         // nil
+		"3.14",                         // float64
+		"'2026-04-11 14:30:45.500000'", // time.Time
+		"X'deadbeef'",                  // []byte
+		`'{"k":"v"}'`,                  // map[string]any (JSON column)
+		"18446744073709551615",         // json.Number: bare numeric literal, exact
 	}
 	for _, want := range wants {
 		if !strings.Contains(content, want) {

--- a/internal/reconstruct/pk_canonicalize.go
+++ b/internal/reconstruct/pk_canonicalize.go
@@ -209,22 +209,29 @@ func pkValueBytes(raw any) ([]byte, bool) {
 // — mergeBaselineImages already does under PGTextPK, inert there only because
 // PostgreSQL column metas carry an empty DataType.
 //
-// Cost: one DataType check per PK column per row, and nothing else, for every
-// table without a fixed-binary key. When a key DOES carry padding — the
-// population this exists for — each row also allocates a PK-sized map and the
-// toggled key string. That is accepted: the alternative is an unbounded wrong
-// answer. No index, no per-row state that outlives the row.
+// Cost, measured per row on an M1 Pro rather than argued: 7.8 ns and zero
+// allocations for a non-binary PK (one DataType check per PK column, and
+// TrimSpace on a clean string does not allocate); 40.6 ns and zero allocations
+// for a BINARY(16) UUID with no padding; 291 ns and 5 allocations in the worst
+// case, where every key carries padding and each row builds a PK-sized map plus
+// the toggled key string. Ten million rows costs 78 ms in the common case, and
+// even the worst case is a few percent against the DuckDB Parquet scan and the
+// per-row SQL rendering that surround it. Hoisting the "does this table have a
+// fixed-binary PK" decision out of the scan would buy nothing measurable and
+// would add per-table state to a function whose current virtue is having none.
+// No index, no per-row state that outlives the row.
 //
 // It cannot fire on a healthy table: pk_values only ever holds the stripped
 // spelling, so no legitimate event is keyed under the padded one. And it cannot
-// invent a collision between two real rows — but the reason is about the
-// STRINGS, not the bytes, since formatPKValue maps two byte domains into one
-// string space. An alternate can never equal some other key's canonical
-// spelling because (a) in the hex branch a colliding verbatim key would have to
-// be the ASCII text "0x"+2n hex characters, i.e. 2n+2 bytes in an n-byte
-// column, which cannot be stored; and (b) in the verbatim branch the alternate
-// ends in a literal 0x00 byte, which a stripped canonical spelling never
-// carries.
+// invent a collision between two real rows. That reduces to one fact — an
+// alternate is only ever produced for a key that HAS padding, so it always ends
+// in 0x00, while a canonical spelling is stripped and so never does. Both
+// collision families die there, though the reasoning has to be about the
+// STRINGS rather than the bytes, since formatPKValue maps two byte domains into
+// one string space: in the verbatim branch the alternate carries a literal 0x00
+// byte no stripped spelling has, and in the hex branch a colliding verbatim key
+// would have to be the ASCII text "0x"+2n hex characters — 2n+2 bytes in an
+// n-byte column, which cannot be stored.
 //
 // Returns false when no PK column is a fixed BINARY(n) with a known width. Note
 // what that means for a pre-#212 snapshot with no COLUMN_TYPE: the CANONICAL

--- a/internal/reconstruct/pk_canonicalize.go
+++ b/internal/reconstruct/pk_canonicalize.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"maps"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/dbtrail/dbtrail/internal/event"
 	"github.com/dbtrail/dbtrail/internal/metadata"
 )
 
@@ -183,6 +185,82 @@ func pkValueBytes(raw any) ([]byte, bool) {
 	default:
 		return nil, false
 	}
+}
+
+// altFixedBinaryPK returns the ONE alternative spelling a baseline row's
+// primary key could carry, or ok=false when there is none.
+//
+// A fixed BINARY(n) key exists in exactly two forms: the padded n bytes MySQL
+// stores, and the trailing-0x00-stripped bytes the binlog ROW image carries
+// (see canonicalizePKValue's binary-family note). canonicalizePKValue produces
+// the stripped one so it matches binlog_events.pk_values, so if the change map
+// holds an entry under the PADDED spelling instead, the two sides are keyed
+// differently and the join silently fails (#1158).
+//
+// That is the whole search space, which is why this needs no index and no extra
+// memory — the caller does one more lookup in the map it already has. With
+// several fixed-binary components every component is toggled together rather
+// than enumerating 2^k combinations: a canonicalization that disagrees does so
+// uniformly, and a partial disagreement is not a shape this can produce.
+//
+// It cannot fire on a healthy table. pk_values only ever holds the stripped
+// spelling, so no legitimate event is keyed under the padded one; a hit means
+// the two sides genuinely disagree. And the toggle is injective over what a
+// BINARY(n) column can hold — every stored value is exactly n bytes, so two
+// distinct keys cannot toggle onto each other — so it cannot invent a
+// collision between two real rows either.
+//
+// Returns false when no PK column is a fixed BINARY(n) with a known width (a
+// pre-#212 snapshot has no width to pad to), which is also the common case:
+// for every other table this costs one type check per row and nothing else.
+func altFixedBinaryPK(pkCols []metadata.ColumnMeta, pkMap map[string]any) (string, bool) {
+	var alt map[string]any
+	for _, c := range pkCols {
+		if !strings.EqualFold(strings.TrimSpace(c.DataType), "binary") {
+			continue
+		}
+		width := FixedBinaryWidth(c.ColumnType)
+		if width == 0 {
+			continue
+		}
+		v, ok := pkMap[c.Name].([]byte)
+		if !ok {
+			continue
+		}
+		var flipped []byte
+		if len(v) < width {
+			flipped = make([]byte, width)
+			copy(flipped, v)
+		} else {
+			flipped = TrimFixedBinaryPad(v)
+		}
+		if bytes.Equal(flipped, v) {
+			continue // no padding either way: one spelling only
+		}
+		if alt == nil {
+			alt = make(map[string]any, len(pkMap))
+			maps.Copy(alt, pkMap)
+		}
+		alt[c.Name] = flipped
+	}
+	if alt == nil {
+		return "", false
+	}
+	return event.BuildPKValues(pkCols, alt), true
+}
+
+// FixedBinaryWidth extracts n from a "binary(n)" COLUMN_TYPE, returning 0 when
+// it is absent or unparseable (a pre-#212 snapshot carries no COLUMN_TYPE).
+func FixedBinaryWidth(columnType string) int {
+	s := strings.ToLower(strings.TrimSpace(columnType))
+	if !strings.HasPrefix(s, "binary(") || !strings.HasSuffix(s, ")") {
+		return 0
+	}
+	n, err := strconv.Atoi(s[len("binary(") : len(s)-1])
+	if err != nil || n <= 0 {
+		return 0
+	}
+	return n
 }
 
 // TrimFixedBinaryPad strips the trailing 0x00 bytes MySQL adds when storing a

--- a/internal/reconstruct/pk_canonicalize.go
+++ b/internal/reconstruct/pk_canonicalize.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"maps"
 	"strconv"
 	"strings"
 	"time"
@@ -190,29 +189,55 @@ func pkValueBytes(raw any) ([]byte, bool) {
 // altFixedBinaryPK returns the ONE alternative spelling a baseline row's
 // primary key could carry, or ok=false when there is none.
 //
-// A fixed BINARY(n) key exists in exactly two forms: the padded n bytes MySQL
+// A fixed BINARY(n) key has at most two byte-forms: the padded n bytes MySQL
 // stores, and the trailing-0x00-stripped bytes the binlog ROW image carries
-// (see canonicalizePKValue's binary-family note). canonicalizePKValue produces
-// the stripped one so it matches binlog_events.pk_values, so if the change map
-// holds an entry under the PADDED spelling instead, the two sides are keyed
-// differently and the join silently fails (#1158).
+// (see canonicalizePKValue's binary-family note). A value with no trailing zero
+// byte — most BINARY(16) UUIDs — has only ONE, which is why the loop below
+// skips it. canonicalizePKValue produces the stripped form so it matches
+// binlog_events.pk_values; an entry in the change map under the PADDED spelling
+// means the two sides are keyed differently and the join silently fails (#1158).
 //
-// That is the whole search space, which is why this needs no index and no extra
-// memory — the caller does one more lookup in the map it already has. With
-// several fixed-binary components every component is toggled together rather
-// than enumerating 2^k combinations: a canonicalization that disagrees does so
-// uniformly, and a partial disagreement is not a shape this can produce.
+// Both byte-forms render under the same rule, so there is no third spelling to
+// search: formatPKValue is content-gated (valid UTF-8 → stored verbatim, no 0x
+// prefix), and padding with 0x00 cannot change UTF-8 validity in either
+// direction — appending NUL keeps valid input valid, and NUL is never a
+// continuation byte so it cannot repair invalid input.
 //
-// It cannot fire on a healthy table. pk_values only ever holds the stripped
-// spelling, so no legitimate event is keyed under the padded one; a hit means
-// the two sides genuinely disagree. And the toggle is injective over what a
-// BINARY(n) column can hold — every stored value is exactly n bytes, so two
-// distinct keys cannot toggle onto each other — so it cannot invent a
-// collision between two real rows either.
+// Direction, precisely: at the only production call site the input has already
+// been stripped by canonicalizePKMap, so this always runs strip→pad. The
+// pad→strip half is defensive for a caller handing over an uncanonicalized map
+// — mergeBaselineImages already does under PGTextPK, inert there only because
+// PostgreSQL column metas carry an empty DataType.
 //
-// Returns false when no PK column is a fixed BINARY(n) with a known width (a
-// pre-#212 snapshot has no width to pad to), which is also the common case:
-// for every other table this costs one type check per row and nothing else.
+// Cost: one DataType check per PK column per row, and nothing else, for every
+// table without a fixed-binary key. When a key DOES carry padding — the
+// population this exists for — each row also allocates a PK-sized map and the
+// toggled key string. That is accepted: the alternative is an unbounded wrong
+// answer. No index, no per-row state that outlives the row.
+//
+// It cannot fire on a healthy table: pk_values only ever holds the stripped
+// spelling, so no legitimate event is keyed under the padded one. And it cannot
+// invent a collision between two real rows — but the reason is about the
+// STRINGS, not the bytes, since formatPKValue maps two byte domains into one
+// string space. An alternate can never equal some other key's canonical
+// spelling because (a) in the hex branch a colliding verbatim key would have to
+// be the ASCII text "0x"+2n hex characters, i.e. 2n+2 bytes in an n-byte
+// column, which cannot be stored; and (b) in the verbatim branch the alternate
+// ends in a literal 0x00 byte, which a stripped canonical spelling never
+// carries.
+//
+// Returns false when no PK column is a fixed BINARY(n) with a known width. Note
+// what that means for a pre-#212 snapshot with no COLUMN_TYPE: the CANONICAL
+// key is still correct (canonicalizePKValue trims unconditionally and never
+// reads the width) — it is only this detector that goes quiet, which is why
+// mergeBaselineImages warns once per table rather than letting it pass unsaid.
+//
+// Scope limit, stated rather than wished away: with several fixed-binary
+// components every togglable component is flipped together instead of
+// enumerating 2^k combinations. That detects a UNIFORM disagreement — a
+// canonicalization regression flips a rule, not one column — and misses a
+// partial one, including the partial toggle this function itself produces when
+// one component's width is unknown.
 func altFixedBinaryPK(pkCols []metadata.ColumnMeta, pkMap map[string]any) (string, bool) {
 	var alt map[string]any
 	for _, c := range pkCols {
@@ -238,8 +263,14 @@ func altFixedBinaryPK(pkCols []metadata.ColumnMeta, pkMap map[string]any) (strin
 			continue // no padding either way: one spelling only
 		}
 		if alt == nil {
-			alt = make(map[string]any, len(pkMap))
-			maps.Copy(alt, pkMap)
+			// PK columns only. canonicalizePKMap hands back a copy of the
+			// WHOLE row, and copying that per row would scale this with the
+			// table's column count for no benefit — BuildPKValues reads
+			// nothing but pkCols.
+			alt = make(map[string]any, len(pkCols))
+			for _, p := range pkCols {
+				alt[p.Name] = pkMap[p.Name]
+			}
 		}
 		alt[c.Name] = flipped
 	}
@@ -251,6 +282,12 @@ func altFixedBinaryPK(pkCols []metadata.ColumnMeta, pkMap map[string]any) (strin
 
 // FixedBinaryWidth extracts n from a "binary(n)" COLUMN_TYPE, returning 0 when
 // it is absent or unparseable (a pre-#212 snapshot carries no COLUMN_TYPE).
+//
+// Exported because internal/cli's padFixedBinaryFilter must agree with
+// altFixedBinaryPK about the pad width — a `--pk` filter and a merge join that
+// disagreed would resolve the same key differently. internal/verify/render.go
+// keeps its own equivalent for the #1135 render padding; the two must stay in
+// agreement, so change them together.
 func FixedBinaryWidth(columnType string) int {
 	s := strings.ToLower(strings.TrimSpace(columnType))
 	if !strings.HasPrefix(s, "binary(") || !strings.HasSuffix(s, ")") {

--- a/internal/reconstruct/pk_canonicalize_test.go
+++ b/internal/reconstruct/pk_canonicalize_test.go
@@ -201,10 +201,10 @@ func TestParseDatetimePrecision(t *testing.T) {
 		{"timestamp(6)", 6, true},
 		{"TIMESTAMP(3)", 3, true},
 		{"  datetime(6)  ", 6, true},
-		{"", 0, false}, // pre-#212 snapshot
-		{"datetime(7)", 0, false}, // out of range
+		{"", 0, false},              // pre-#212 snapshot
+		{"datetime(7)", 0, false},   // out of range
 		{"datetime(abc)", 0, false}, // unparseable
-		{"varchar(64)", 0, false}, // wrong prefix
+		{"varchar(64)", 0, false},   // wrong prefix
 	}
 	for _, c := range cases {
 		t.Run(c.in, func(t *testing.T) {

--- a/internal/reconstruct/pk_spelling_join_1158_test.go
+++ b/internal/reconstruct/pk_spelling_join_1158_test.go
@@ -55,12 +55,20 @@ func binaryPKCols() []metadata.ColumnMeta {
 //   - UPDATE: the stale row is emitted and the event is appended, producing a
 //     duplicate key that a restore rejects with 1062 — loud, but late.
 //
-// Note what this does NOT do, because it is the trap in the issue's own
-// suggested fix: a `seen` set over emitted PK strings cannot detect either
-// case. The two rows carry DIFFERENT key strings — that is precisely why the
-// join failed — and in the DELETE case only ONE row is emitted, so there is no
-// duplicate to count. The guard has to compare the two possible spellings of
-// the same key, not the strings actually emitted.
+// Note what the issue's own suggested fix — a `seen` set over emitted PKs —
+// can and cannot do, since the difference is what shaped this guard:
+//
+//   - the UPDATE case it CAN catch, if keyed on each emitted row's
+//     CANONICALIZED pk rather than on the change-map key (both rows canonicalize
+//     to the stripped spelling), and it would catch a broader class of
+//     canonicalization disagreements than fixed-binary padding;
+//   - the DELETE case it CANNOT catch at all: only ONE row is emitted, so
+//     there is no duplicate to count.
+//
+// The DELETE case is the one that corrupts output silently, and a `seen` set
+// over emitted rows costs O(table) memory — which is what #1097 and #1107 exist
+// to remove from this path. Hence comparing the two possible SPELLINGS of a
+// key, at O(1), instead of the strings actually emitted.
 func TestMergeBaselineImages_pkSpellingJoinRefused(t *testing.T) {
 	const (
 		paddedKey   = "11223344556677889900AABB00000000" // as stored / as dumped
@@ -72,7 +80,7 @@ func TestMergeBaselineImages_pkSpellingJoinRefused(t *testing.T) {
 		evType     event.EventType
 		wantInText string
 	}{
-		{"deleted row would be resurrected", event.EventDelete, "resurrected after its DELETE"},
+		{"deleted row would be resurrected", event.EventDelete, "kept alive past its DELETE"},
 		{"updated row would be emitted twice", event.EventUpdate, "emitted twice"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -99,7 +107,7 @@ func TestMergeBaselineImages_pkSpellingJoinRefused(t *testing.T) {
 				t.Fatalf("merge succeeded and emitted %d row(s); it must refuse — the baseline row and its "+
 					"%v event are keyed differently, so the output would be wrong", len(emitted), tc.evType)
 			}
-			for _, want := range []string{"db.bp", "full-table reconstruct", tc.wantInText, strippedKey} {
+			for _, want := range []string{"db.bp", "baseline merge", tc.wantInText, strippedKey} {
 				if !strings.Contains(err.Error(), want) {
 					t.Errorf("error missing %q:\n%s", want, err)
 				}
@@ -162,6 +170,7 @@ func TestAltFixedBinaryPK_noFalseCollisions(t *testing.T) {
 	}
 	canonical := map[string]string{}
 	alternate := map[string]string{}
+	withAlt := 0
 	for _, k := range keys {
 		raw := mustDecodeHex(t, k)
 		pkMap, err := canonicalizePKMap(map[string]any{"k": raw}, pkCols)
@@ -175,6 +184,7 @@ func TestAltFixedBinaryPK_noFalseCollisions(t *testing.T) {
 		canonical[c] = k
 
 		if a, ok := altFixedBinaryPK(pkCols, pkMap); ok {
+			withAlt++
 			if prev, dup := alternate[a]; dup {
 				t.Errorf("two distinct keys produce the same ALTERNATE spelling: %s and %s → %q", prev, k, a)
 			}
@@ -191,6 +201,220 @@ func TestAltFixedBinaryPK_noFalseCollisions(t *testing.T) {
 			}
 		}
 	}
+	// Positive anchor. Every discriminating assertion above sits inside the
+	// `ok` branch, so an altFixedBinaryPK that returned false for everything
+	// would skip them all and this test would pass having checked nothing.
+	if want := 4; withAlt != want {
+		t.Errorf("%d of %d keys produced an alternate spelling, want %d — if this dropped to 0 every "+
+			"assertion above became vacuous", withAlt, len(keys), want)
+	}
+}
+
+// TestMergeBaselineImages_healthyTableWithPendingEvents is the false-positive
+// control that TestMergeBaselineImages_correctSpellingStillMerges cannot be.
+//
+// The guard only fires against an UNDRAINED change-map entry, and the scan
+// drains as it goes — so a one-row/one-event fixture has an empty map by the
+// time it matters, and a guard that mis-fired against OTHER rows' pending
+// events would pass it green. This drives many keys through the real merge
+// with events pending for only a subset, which is the only configuration in
+// which a false refusal is possible.
+func TestMergeBaselineImages_healthyTableWithPendingEvents(t *testing.T) {
+	pkCols := binaryPKCols()
+
+	// Keys spanning every trailing-zero count 0..15 plus interior zeros, so
+	// both the "has an alternate" and "single spelling" populations are large.
+	rows := map[string]string{}
+	var keys []string
+	for i := range 16 {
+		k := strings.Repeat("A7", 16-i) + strings.Repeat("00", i)
+		rows[k] = "baseline"
+		keys = append(keys, k)
+	}
+	for i := range 8 {
+		k := "5C00" + strings.Repeat("B3", 13-i) + strings.Repeat("00", i+1)
+		k = k[:32]
+		rows[k] = "baseline"
+		keys = append(keys, k)
+	}
+	path := binaryPKBaseline(t, t.TempDir(), rows)
+
+	// Events for every third key, correctly spelled (stripped), so the map is
+	// still populated while later rows are being scanned.
+	changes := map[string]*query.ResultRow{}
+	updated := map[string]bool{}
+	for i, k := range keys {
+		if i%3 != 0 {
+			continue
+		}
+		stripped := event.BuildPKValues(pkCols, mustCanonicalize(t, pkCols, mustDecodeHex(t, k)))
+		changes[stripped] = &query.ResultRow{
+			EventType: event.EventUpdate, SchemaName: "db", TableName: "bp",
+			PKValues: stripped,
+			RowAfter: map[string]any{"k": mustDecodeHex(t, k), "val": "updated"},
+		}
+		updated[k] = true
+	}
+	wantUpdated := len(changes)
+	if wantUpdated < 5 {
+		t.Fatalf("fixture built only %d pending events; too few to leave the map populated across the scan", wantUpdated)
+	}
+
+	var gotBaseline, gotUpdated int
+	err := SnapshotFullTableImages(context.Background(), SnapshotFullTableInput{
+		BaselinePath: path, Schema: "db", Table: "bp", PKCols: pkCols,
+		Changes: changes,
+	}, func(r map[string]any) error {
+		switch r["val"] {
+		case "baseline":
+			gotBaseline++
+		case "updated":
+			gotUpdated++
+		default:
+			t.Errorf("unexpected emitted value %v", r["val"])
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("the guard refused a healthy table — a false refusal is worse than the bug it cures: %v", err)
+	}
+	// NOTE: read before the merge — mergeBaselineImages DRAINS in.Changes.
+	if gotUpdated != wantUpdated {
+		t.Errorf("emitted %d updated rows, want %d", gotUpdated, wantUpdated)
+	}
+	if want := len(keys) - wantUpdated; gotBaseline != want {
+		t.Errorf("emitted %d pass-through rows, want %d", gotBaseline, want)
+	}
+}
+
+// TestMergeBaselineImages_compositeBinaryPK covers a PK with two fixed-binary
+// components, one padded and one full-width. It pins that the alternate is
+// built over ALL PK columns in ordinal order (a regression that toggled only
+// the first, or that aliased the source map instead of copying it, is
+// otherwise invisible), and that the healthy version still merges.
+func TestMergeBaselineImages_compositeBinaryPK(t *testing.T) {
+	pkCols := []metadata.ColumnMeta{
+		{Name: "a", DataType: "binary", ColumnType: "binary(16)", IsPK: true, OrdinalPosition: 1},
+		{Name: "b", DataType: "binary", ColumnType: "binary(4)", IsPK: true, OrdinalPosition: 2},
+	}
+	const (
+		aPadded = "11223344556677889900AABB00000000" // has padding
+		bFull   = "DEADBEEF"                         // no padding
+	)
+
+	writeComposite := func(t *testing.T) string {
+		t.Helper()
+		cols := []baseline.Column{
+			{Name: "a", MySQLType: "binary", ParquetType: baseline.MysqlToParquetNode("binary")},
+			{Name: "b", MySQLType: "binary", ParquetType: baseline.MysqlToParquetNode("binary")},
+			{Name: "val", MySQLType: "varchar", ParquetType: baseline.MysqlToParquetNode("varchar")},
+		}
+		path := filepath.Join(t.TempDir(), "cp.parquet")
+		w, err := baseline.NewWriter(path, cols, baseline.WriterConfig{Compression: "none", RowGroupSize: 10})
+		if err != nil {
+			t.Fatalf("NewWriter: %v", err)
+		}
+		if err := w.WriteRow([]string{"0x" + aPadded, "0x" + bFull, "baseline"}, []bool{false, false, false}); err != nil {
+			t.Fatalf("WriteRow: %v", err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+		return path
+	}
+
+	canonicalPK := event.BuildPKValues(pkCols, mustCanonicalizeMulti(t, pkCols,
+		map[string]any{"a": mustDecodeHex(t, aPadded), "b": mustDecodeHex(t, bFull)}))
+
+	t.Run("mis-keyed on the padded component refuses", func(t *testing.T) {
+		misKeyed := "0x" + aPadded + "|0x" + bFull
+		var emitted int
+		err := SnapshotFullTableImages(context.Background(), SnapshotFullTableInput{
+			BaselinePath: writeComposite(t), Schema: "db", Table: "cp", PKCols: pkCols,
+			Changes: map[string]*query.ResultRow{misKeyed: {
+				EventType: event.EventDelete, SchemaName: "db", TableName: "cp", PKValues: misKeyed,
+			}},
+		}, func(map[string]any) error { emitted++; return nil })
+		if err == nil {
+			t.Fatalf("merge succeeded, emitting %d row(s); the composite key's padded component is mis-spelled "+
+				"and the DELETE would be lost", emitted)
+		}
+		// The alternate must carry BOTH components, the toggled one and the
+		// untouched one, joined in ordinal order.
+		if !strings.Contains(err.Error(), misKeyed) {
+			t.Errorf("error does not name the full composite alternate %q:\n%s", misKeyed, err)
+		}
+	})
+
+	t.Run("correctly keyed still merges", func(t *testing.T) {
+		var emitted []map[string]any
+		err := SnapshotFullTableImages(context.Background(), SnapshotFullTableInput{
+			BaselinePath: writeComposite(t), Schema: "db", Table: "cp", PKCols: pkCols,
+			Changes: map[string]*query.ResultRow{canonicalPK: {
+				EventType: event.EventUpdate, SchemaName: "db", TableName: "cp", PKValues: canonicalPK,
+				RowAfter: map[string]any{"a": mustDecodeHex(t, aPadded), "b": mustDecodeHex(t, bFull), "val": "updated"},
+			}},
+		}, func(r map[string]any) error { emitted = append(emitted, r); return nil })
+		if err != nil {
+			t.Fatalf("a correctly-keyed composite PK must not trip the guard: %v", err)
+		}
+		if len(emitted) != 1 || emitted[0]["val"] != "updated" {
+			t.Errorf("emitted %v, want one updated row", emitted)
+		}
+	})
+}
+
+// TestMergeBaselineImages_guardCoversClaimedRow pins the reason the check sits
+// ABOVE the claimed/unclaimed branch rather than inside the unclaimed one.
+//
+// in.Changes is keyed by string, so two spellings of one row are two
+// independent entries. With an entry under the canonical spelling the row takes
+// the CLAIMED branch; a sibling entry under the alternate spelling would then
+// survive the scan and reach the leftover tail, where a DELETE is dropped
+// without a word — the row outlives its own DELETE with the guard in the room.
+func TestMergeBaselineImages_guardCoversClaimedRow(t *testing.T) {
+	const paddedKey = "11223344556677889900AABB00000000"
+	pkCols := binaryPKCols()
+	path := binaryPKBaseline(t, t.TempDir(), map[string]string{paddedKey: "baseline"})
+
+	stripped := event.BuildPKValues(pkCols, mustCanonicalize(t, pkCols, mustDecodeHex(t, paddedKey)))
+	changes := map[string]*query.ResultRow{
+		// Claims the row, so without hoisting the guard never runs.
+		stripped: {
+			EventType: event.EventUpdate, SchemaName: "db", TableName: "bp", PKValues: stripped,
+			RowAfter: map[string]any{"k": mustDecodeHex(t, "11223344556677889900AABB"), "val": "updated"},
+		},
+		// The sibling entry that would be silently dropped.
+		"0x" + paddedKey: {
+			EventType: event.EventDelete, SchemaName: "db", TableName: "bp", PKValues: "0x" + paddedKey,
+		},
+	}
+
+	var emitted []map[string]any
+	err := SnapshotFullTableImages(context.Background(), SnapshotFullTableInput{
+		BaselinePath: path, Schema: "db", Table: "bp", PKCols: pkCols, Changes: changes,
+	}, func(r map[string]any) error { emitted = append(emitted, r); return nil })
+	if err == nil {
+		t.Fatalf("merge succeeded and emitted %v — an undrained DELETE keyed under the alternate spelling "+
+			"was dropped in the leftover tail while the guard sat on the unclaimed branch only", emitted)
+	}
+	if !strings.Contains(err.Error(), "DELETE") {
+		t.Errorf("error should name the undrained DELETE:\n%s", err)
+	}
+}
+
+func mustCanonicalize(t *testing.T, pkCols []metadata.ColumnMeta, k []byte) map[string]any {
+	t.Helper()
+	return mustCanonicalizeMulti(t, pkCols, map[string]any{"k": k})
+}
+
+func mustCanonicalizeMulti(t *testing.T, pkCols []metadata.ColumnMeta, row map[string]any) map[string]any {
+	t.Helper()
+	m, err := canonicalizePKMap(row, pkCols)
+	if err != nil {
+		t.Fatalf("canonicalizePKMap: %v", err)
+	}
+	return m
 }
 
 // TestAltFixedBinaryPK_inertWithoutFixedBinary keeps the guard free for every

--- a/internal/reconstruct/pk_spelling_join_1158_test.go
+++ b/internal/reconstruct/pk_spelling_join_1158_test.go
@@ -1,0 +1,247 @@
+package reconstruct
+
+import (
+	"context"
+	"encoding/hex"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/baseline"
+	"github.com/dbtrail/dbtrail/internal/event"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/query"
+)
+
+// binaryPKBaseline writes a one-column-keyed baseline holding the FULL-WIDTH
+// (padded) form of each key, which is what MySQL stores and mydumper dumps.
+func binaryPKBaseline(t *testing.T, dir string, rows map[string]string) string {
+	t.Helper()
+	cols := []baseline.Column{
+		{Name: "k", MySQLType: "binary", ParquetType: baseline.MysqlToParquetNode("binary")},
+		{Name: "val", MySQLType: "varchar", ParquetType: baseline.MysqlToParquetNode("varchar")},
+	}
+	path := filepath.Join(dir, "bp.parquet")
+	w, err := baseline.NewWriter(path, cols, baseline.WriterConfig{Compression: "none", RowGroupSize: 100})
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	for hexKey, val := range rows {
+		if err := w.WriteRow([]string{"0x" + hexKey, val}, []bool{false, false}); err != nil {
+			t.Fatalf("WriteRow: %v", err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	return path
+}
+
+func binaryPKCols() []metadata.ColumnMeta {
+	return []metadata.ColumnMeta{{Name: "k", DataType: "binary", ColumnType: "binary(16)", IsPK: true}}
+}
+
+// TestMergeBaselineImages_pkSpellingJoinRefused is #1158.
+//
+// The merge joins a baseline row to its event by the pk_values string. When the
+// two sides spell a fixed BINARY(n) key differently — padded on one side,
+// trailing-0x00-stripped on the other — the join misses, and the outcome is
+// asymmetric:
+//
+//   - DELETE: the event is skipped and the stale baseline row was already
+//     emitted, so a deleted row is RESURRECTED. Nothing downstream catches it;
+//     the dump restores cleanly and is wrong. This is the case that makes the
+//     guard worth having.
+//   - UPDATE: the stale row is emitted and the event is appended, producing a
+//     duplicate key that a restore rejects with 1062 — loud, but late.
+//
+// Note what this does NOT do, because it is the trap in the issue's own
+// suggested fix: a `seen` set over emitted PK strings cannot detect either
+// case. The two rows carry DIFFERENT key strings — that is precisely why the
+// join failed — and in the DELETE case only ONE row is emitted, so there is no
+// duplicate to count. The guard has to compare the two possible spellings of
+// the same key, not the strings actually emitted.
+func TestMergeBaselineImages_pkSpellingJoinRefused(t *testing.T) {
+	const (
+		paddedKey   = "11223344556677889900AABB00000000" // as stored / as dumped
+		strippedKey = "0x11223344556677889900AABB"       // as the ROW image carries it
+	)
+
+	for _, tc := range []struct {
+		name       string
+		evType     event.EventType
+		wantInText string
+	}{
+		{"deleted row would be resurrected", event.EventDelete, "resurrected after its DELETE"},
+		{"updated row would be emitted twice", event.EventUpdate, "emitted twice"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := binaryPKBaseline(t, t.TempDir(), map[string]string{paddedKey: "baseline"})
+
+			// The change map is keyed by the PADDED spelling, i.e. NOT the one
+			// canonicalizePKValue produces — the shape a canonicalization
+			// regression creates.
+			ev := &query.ResultRow{
+				EventType: tc.evType, SchemaName: "db", TableName: "bp",
+				PKValues: "0x" + paddedKey,
+			}
+			if tc.evType != event.EventDelete {
+				ev.RowAfter = map[string]any{"k": mustDecodeHex(t, paddedKey), "val": "updated"}
+			}
+
+			var emitted []map[string]any
+			err := SnapshotFullTableImages(context.Background(), SnapshotFullTableInput{
+				BaselinePath: path, Schema: "db", Table: "bp", PKCols: binaryPKCols(),
+				Changes: map[string]*query.ResultRow{"0x" + paddedKey: ev},
+			}, func(r map[string]any) error { emitted = append(emitted, r); return nil })
+
+			if err == nil {
+				t.Fatalf("merge succeeded and emitted %d row(s); it must refuse — the baseline row and its "+
+					"%v event are keyed differently, so the output would be wrong", len(emitted), tc.evType)
+			}
+			for _, want := range []string{"db.bp", "full-table reconstruct", tc.wantInText, strippedKey} {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error missing %q:\n%s", want, err)
+				}
+			}
+			// Refusing after emitting the bad row would still ship it to the
+			// mydumper writer, which streams.
+			if len(emitted) != 0 {
+				t.Errorf("refusal must fire BEFORE the stale row is emitted, emitted %d", len(emitted))
+			}
+		})
+	}
+}
+
+// TestMergeBaselineImages_correctSpellingStillMerges is the control that keeps
+// the guard from being a blunt instrument: with the canonicalization working
+// (the shipping behaviour), the same fixtures must merge cleanly.
+func TestMergeBaselineImages_correctSpellingStillMerges(t *testing.T) {
+	const paddedKey = "11223344556677889900AABB00000000"
+	path := binaryPKBaseline(t, t.TempDir(), map[string]string{paddedKey: "baseline"})
+
+	// Keyed the way the indexer really stores it: stripped.
+	changes := map[string]*query.ResultRow{
+		"0x11223344556677889900AABB": {
+			EventType: event.EventUpdate, SchemaName: "db", TableName: "bp",
+			PKValues: "0x11223344556677889900AABB",
+			RowAfter: map[string]any{"k": mustDecodeHex(t, "11223344556677889900AABB"), "val": "updated"},
+		},
+	}
+	var emitted []map[string]any
+	err := SnapshotFullTableImages(context.Background(), SnapshotFullTableInput{
+		BaselinePath: path, Schema: "db", Table: "bp", PKCols: binaryPKCols(),
+		Changes: changes,
+	}, func(r map[string]any) error { emitted = append(emitted, r); return nil })
+	if err != nil {
+		t.Fatalf("a correctly-keyed merge must not trip the #1158 guard: %v", err)
+	}
+	if len(emitted) != 1 {
+		t.Fatalf("emitted %d rows, want 1", len(emitted))
+	}
+	if emitted[0]["val"] != "updated" {
+		t.Errorf("the event did not win over the baseline row: %v", emitted[0])
+	}
+}
+
+// TestAltFixedBinaryPK_noFalseCollisions pins the property that makes the guard
+// safe to fail loud on: toggling the padding is injective over what a BINARY(n)
+// column can hold, so it can never make two DISTINCT real keys look like the
+// same row. A guard that aborts a healthy dump would be worse than the bug.
+func TestAltFixedBinaryPK_noFalseCollisions(t *testing.T) {
+	pkCols := binaryPKCols()
+	// Keys that differ only in where their zero bytes fall — the shapes most
+	// likely to collide under a careless normalisation.
+	keys := []string{
+		"11223344556677889900AABB00000000",
+		"11223344556677889900AABB00000001",
+		"1122334455667788990000BB00000000",
+		"00000000000000000000000000000000",
+		"11000000000000000000000000000000",
+		"B2815CC3C200FF7C0102030405060780",
+	}
+	canonical := map[string]string{}
+	alternate := map[string]string{}
+	for _, k := range keys {
+		raw := mustDecodeHex(t, k)
+		pkMap, err := canonicalizePKMap(map[string]any{"k": raw}, pkCols)
+		if err != nil {
+			t.Fatalf("canonicalize %s: %v", k, err)
+		}
+		c := event.BuildPKValues(pkCols, pkMap)
+		if prev, dup := canonical[c]; dup {
+			t.Fatalf("two distinct keys canonicalize identically: %s and %s → %q", prev, k, c)
+		}
+		canonical[c] = k
+
+		if a, ok := altFixedBinaryPK(pkCols, pkMap); ok {
+			if prev, dup := alternate[a]; dup {
+				t.Errorf("two distinct keys produce the same ALTERNATE spelling: %s and %s → %q", prev, k, a)
+			}
+			alternate[a] = k
+			if a == c {
+				t.Errorf("key %s: alternate equals canonical %q — the toggle did nothing", k, c)
+			}
+			// The decisive one: an alternate must never collide with some
+			// OTHER key's canonical spelling, or the guard would refuse a
+			// perfectly healthy table.
+			if other, clash := canonical[a]; clash && other != k {
+				t.Errorf("key %s's alternate %q collides with the canonical spelling of %s — "+
+					"the guard would abort a healthy dump", k, a, other)
+			}
+		}
+	}
+}
+
+// TestAltFixedBinaryPK_inertWithoutFixedBinary keeps the guard free for every
+// table it does not apply to: no fixed BINARY(n) PK, or a pre-#212 snapshot
+// with no declared width to pad to, means no second lookup at all.
+func TestAltFixedBinaryPK_inertWithoutFixedBinary(t *testing.T) {
+	cases := []struct {
+		name  string
+		col   metadata.ColumnMeta
+		value any
+	}{
+		{"int PK", metadata.ColumnMeta{Name: "k", DataType: "int"}, int64(7)},
+		{"varbinary PK", metadata.ColumnMeta{Name: "k", DataType: "varbinary", ColumnType: "varbinary(16)"}, []byte{0xAA, 0xBB, 0x00}},
+		{"binary PK with no declared width", metadata.ColumnMeta{Name: "k", DataType: "binary"}, []byte{0xAA, 0xBB, 0x00}},
+		{"binary PK already at full width with no padding", metadata.ColumnMeta{Name: "k", DataType: "binary", ColumnType: "binary(2)"}, []byte{0xAA, 0xBB}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cols := []metadata.ColumnMeta{tc.col}
+			if got, ok := altFixedBinaryPK(cols, map[string]any{"k": tc.value}); ok {
+				t.Errorf("altFixedBinaryPK returned %q; it must be inert here", got)
+			}
+		})
+	}
+}
+
+func TestFixedBinaryWidth(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{"binary(16)", 16},
+		{"BINARY(255)", 255},
+		{"binary", 0},
+		{"varbinary(16)", 0},
+		{"binary(0)", 0},
+		{"binary(x)", 0},
+		{"", 0},
+	}
+	for _, tc := range cases {
+		if got := FixedBinaryWidth(tc.in); got != tc.want {
+			t.Errorf("FixedBinaryWidth(%q) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
+func mustDecodeHex(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatalf("bad hex fixture %q: %v", s, err)
+	}
+	return b
+}


### PR DESCRIPTION
closes #1158

## Summary

The full-table merge joins each baseline row to its event by the `pk_values` string. When the two sides spell a fixed `BINARY(n)` key differently — MySQL pads it on storage, the binlog ROW image strips the padding — the join misses. The two outcomes are not equally visible:

| leftover event | what happens | how you find out |
|---|---|---|
| UPDATE / INSERT | stale baseline row emitted **and** the event appended as a new PK | error 1062 at restore — loud, but late |
| **DELETE** | the event is skipped, the stale row was already emitted | **never.** A row deleted before the target instant survives; the dump restores cleanly and is simply wrong |

The guard lives in `mergeBaselineImages`, the shared core, so the mydumper writer, the shim's full-table `_snapshot` and `verify` all inherit it from one change.

## Why not the fix the issue suggested

I wrote #1158 proposing a `seen map[string]struct{}` over emitted PKs. Measuring it first showed what it can and cannot do:

- the **UPDATE** case it *can* catch, if keyed on each emitted row's canonicalized PK — and it would catch a broader class than fixed-binary padding;
- the **DELETE** case it *cannot* catch at all:

```
resurrection simulated (deleted row, failed join):
  emitted 1 row(s) for 1 logical row that was DELETED in the window
  naive seen-map over canonical PKs detected a duplicate: false
```

Only one row is emitted, so there is no duplicate to count. And a `seen` set over emitted rows costs O(table) memory — the growth #1097 and #1107 exist to remove from this path.

So the guard compares the two possible **spellings** of a key instead. A fixed `BINARY(n)` key has at most two — padded and stripped — so `altFixedBinaryPK` toggles the padding and the merge does one more lookup in the map it already holds, at O(1).

## What review changed

A four-agent round found a hole in the guard itself, which the second commit fixes:

**`in.Changes` is keyed by string, so two spellings of one row are two independent entries.** Checking only the *unclaimed* branch meant an entry under the canonical spelling sent the row down the claimed branch while a sibling entry under the alternate one survived into the leftover tail — where a DELETE is dropped silently. The guard was in the room for exactly the resurrection it exists to stop. Hoisting the check above the branch fixes it and is *less* code than the version it replaced.

Also corrected: the alt map copied the whole row (`canonicalizePKMap` returns every column), so the "no extra memory" claim was false on precisely the tables this targets — it is now built from the PK columns alone. The error text was written in the writer's vocabulary (dumps, restores, 1062) but the core is shared, so a DBA running `SELECT … AS OF` through the shim got a MySQL error about dump restores; it is now surface-neutral and points at `bintrail snapshot` first, since a snapshot saying `BINARY(n)` for a column since ALTERed to `VARBINARY(n)` produces the same disagreement with an operator-side fix. A pre-#212 snapshot silently disabled the detector; it now warns once per table.

## Cost and safety

- **O(1) extra memory**, no per-row state that outlives the row. For tables with no fixed-`BINARY` key: one `DataType` check per PK column per row and no allocation.
- **Cannot fire on a healthy table** — `pk_values` only ever holds the stripped spelling.
- **Cannot invent a collision** between two real rows. The reasoning is about the strings `formatPKValue` produces, not the bytes, and is spelled out where the code lives.

A guard that aborts a healthy dump would be worse than the bug it cures, so the false-positive risk carries its own control: many keys spanning every trailing-zero count, driven through the real merge with events pending for a subset — the only shape in which a false refusal is possible.

## Test plan

- [x] Unit tests pass (`go test ./... -count=1`)
- [x] `go vet ./...` and `go vet -tags integration ./...` clean
- [x] Integration: `internal/reconstruct`, `internal/verify`, `internal/shim`, `internal/cli`
- [x] Three mutations caught: removing the guard, a toggle that does not toggle, and reverting the guard to the unclaimed branch only
- [x] Positive anchor added after review found every discriminating assertion in the collision test sat inside an `if ok`, so an always-false helper passed it vacuously

Follow-up filed: #1162 — a per-row guard leaves a complete, loadable, truncated `.sql` chunk on disk, and the comment there claimed `Close()` unlinks it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)