### PR TITLE
test: assert every env binding resolves to a registered flag

### DIFF
--- a/cliapp/env_bindings_resolve_test.go
+++ b/cliapp/env_bindings_resolve_test.go
@@ -1,0 +1,70 @@
+package cliapp
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dbtrail/dbtrail/internal/cli"
+)
+
+// collectCommands returns cmd and every command reachable from it.
+func collectCommands(cmd *cobra.Command) []*cobra.Command {
+	cmds := []*cobra.Command{cmd}
+	for _, sub := range cmd.Commands() {
+		cmds = append(cmds, collectCommands(sub)...)
+	}
+	return cmds
+}
+
+// envBindingConditional lists bindings whose flag is deliberately NOT
+// registered anywhere on the bintrail command tree (e.g. a flag that exists
+// only on another binary or under a build tag). Every entry needs a comment
+// explaining why the exception is legitimate. Empty today: all bindings
+// resolve on this tree.
+var envBindingConditional = map[string]bool{}
+
+// TestEnvBindingsResolveToRegisteredFlags asserts every entry in
+// cli.EnvBindings names a flag that exists on at least one command in the
+// bintrail command tree. cli.BindCommandEnv silently no-ops when a binding's
+// flag is missing from the command it is called on, so a flag rename, move,
+// or a typo in the table would silently disconnect the BINTRAIL_* env var —
+// the documented configuration channel for containerized deployments — while
+// the flag itself kept working (#1130). This turns that silent disconnection
+// into a failing build.
+func TestEnvBindingsResolveToRegisteredFlags(t *testing.T) {
+	// Positive anchors: an empty table or an empty tree must fail, not pass
+	// vacuously.
+	if len(cli.EnvBindings) == 0 {
+		t.Fatal("cli.EnvBindings is empty; the walk below would pass vacuously")
+	}
+	cmds := collectCommands(rootCmd)
+	// The bintrail tree has 20+ commands; a walk that finds almost none means
+	// the tree was not constructed (init() not run, wrong root), not that the
+	// CLI shrank.
+	if len(cmds) < 10 {
+		t.Fatalf("command tree walk found only %d commands; expected the full bintrail tree", len(cmds))
+	}
+
+	for _, b := range cli.EnvBindings {
+		found := false
+		for _, cmd := range cmds {
+			// Same lookup order BindCommandEnv uses: local flags, then
+			// persistent flags.
+			if cmd.Flags().Lookup(b.Flag) != nil || cmd.PersistentFlags().Lookup(b.Flag) != nil {
+				found = true
+				break
+			}
+		}
+		if found {
+			if envBindingConditional[b.Flag] {
+				t.Errorf("binding %q -> %s is in envBindingConditional but its flag DOES resolve; remove the stale exception", b.Flag, b.EnvVar)
+			}
+			continue
+		}
+		if envBindingConditional[b.Flag] {
+			continue
+		}
+		t.Errorf("binding %q -> %s names a flag that no command registers; the env var is silently disconnected (BindCommandEnv no-ops on a missing flag)", b.Flag, b.EnvVar)
+	}
+}

--- a/consoleapp/watch_env_bindings_test.go
+++ b/consoleapp/watch_env_bindings_test.go
@@ -1,0 +1,21 @@
+package consoleapp
+
+import "testing"
+
+// TestWatchEnvBindingsResolveToRegisteredFlags asserts every entry in
+// watchEnvBindings names a flag registered on watchCmd. bindWatchEnv
+// silently skips a binding whose flag is missing (the same no-op hazard as
+// the core CLI's BindCommandEnv, #1130), so a flag rename or a typo in the
+// table would silently disconnect the BINTRAIL_* env var for the compose
+// path while the flag itself kept working.
+func TestWatchEnvBindingsResolveToRegisteredFlags(t *testing.T) {
+	// Positive anchor: an empty table must fail, not pass vacuously.
+	if len(watchEnvBindings) == 0 {
+		t.Fatal("watchEnvBindings is empty; the loop below would pass vacuously")
+	}
+	for _, b := range watchEnvBindings {
+		if watchCmd.Flags().Lookup(b.Flag) == nil {
+			t.Errorf("binding %q -> %s names a flag watch does not register; the env var is silently disconnected (bindWatchEnv skips a missing flag)", b.Flag, b.EnvVar)
+		}
+	}
+}


### PR DESCRIPTION
closes #1130

`BindCommandEnv` silently no-ops when an entry in `cli.EnvBindings` names a flag the command does not register: no error, no warning. A flag rename, a move between commands, or a typo in the table therefore silently disconnects the `BINTRAIL_*` env var — the documented configuration channel for containerized deployments — while the `--flag` form keeps working. `TestEnvBindingsAndSectionsConsistency` cannot catch this: both sides of its check are the table itself.

Test-only change, per the issue (making `bindCommandEnv` loud at `init()` time was considered and rejected there as too blunt).

## What this adds

**`cliapp/env_bindings_resolve_test.go`** — walks the full bintrail command tree from `rootCmd` (recursively via `cmd.Commands()`, checking local and persistent flag sets in the same lookup order `BindCommandEnv` uses) and asserts every `cli.EnvBindings` entry resolves on at least one command.

- Positive anchors: an empty binding table or a tree walk that finds fewer than 10 commands fails outright — an empty-tree bug cannot pass vacuously.
- `envBindingConditional` is an explicit allowlist for deliberately conditional bindings. It is **empty**: all ~45 bindings resolve on the bintrail tree today (`cmd/bintrail-pg` reuses the same commands via `internal/cli`, and its pg-only flags use the separate `BINTRAIL_PG_*` fallback, not this table). A stale allowlist entry whose flag *does* resolve also fails, so exceptions cannot outlive their reason.

**`consoleapp/watch_env_bindings_test.go`** — the structurally identical `watchEnvBindings` table in `consoleapp/watch.go` has the same hazard (`bindWatchEnv` does `continue` on a nil lookup), and it binds a single command, so the check is a direct loop over `watchCmd`'s flags. (The `cmd/bintrail/envload.go` table mentioned in older docs no longer exists — it moved to `internal/cli/env.go` in #529.)

## Mutation check (the tests bite)

- Typo'd `fetch-batch-size` → `fetch-batch-sizee` in `cli.EnvBindings`: `TestEnvBindingsResolveToRegisteredFlags` FAILS naming the binding and env var; reverted, passes.
- Typo'd `rotate-retain` → `rotate-retainn` in `watchEnvBindings`: `TestWatchEnvBindingsResolveToRegisteredFlags` FAILS; reverted, passes.
- Added `index-dsn` to the allowlist: FAILS with "remove the stale exception"; reverted, passes.

## Verification

- `go test ./... -count=1` — green (47 packages)
- `go vet ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)