### PR TITLE
audit: wire bintrail-pg flashback and reconstruct --baseline-only, harden the contract

### DIFF
--- a/consoleapp/flashback.go
+++ b/consoleapp/flashback.go
@@ -244,11 +244,16 @@ func bindFlashbackHandler(ctx context.Context, srv *console.Server, proxy *routi
 	// the INNER handler (routingHandler forwards HandleQuery to it), so its
 	// streamed rows and go-mysql's trailing EOF share one packet sequence.
 	h.BindConn(mysqlConn)
-	// The flashback port routes BY username, so the same value that selected the
-	// target server is also this connection's audit identity — without this bind
-	// every audit event from the console's flashback port would carry the
-	// unbound-actor sentinel (mirrors internal/cli/shim.go's standalone bind).
-	h.BindActor(user)
+	// The flashback port routes BY username: flashbackCreds accepts ANY username
+	// and authenticates on the shared console token alone, so `user` is a server
+	// selector (registry id/name, or the reserved boot id), not a person — every
+	// human holding the token connects under whatever server name they target.
+	// It is still bound as the audit identity (without it every event from this
+	// port would carry the unbound-actor sentinel), but PREFIXED so a sink
+	// treating Actor as a principal cannot attribute the read to a "person"
+	// named after a database (#1123). The standalone shim and the PG front-end
+	// bind their real per-tenant credential, unprefixed.
+	h.BindActor("server:" + user)
 	// Seed the source schema so fully qualified `_flashback.<table>` queries
 	// work without a prior `USE <db>` (mirrors the standalone shim's #263
 	// behaviour). Best-effort: the boot entry has no registry SourceDSN.

--- a/consoleapp/flashback_integration_test.go
+++ b/consoleapp/flashback_integration_test.go
@@ -14,6 +14,7 @@ import (
 
 	_ "github.com/go-sql-driver/mysql"
 
+	"github.com/dbtrail/dbtrail/internal/audittest"
 	"github.com/dbtrail/dbtrail/internal/baseline"
 	"github.com/dbtrail/dbtrail/internal/console"
 	"github.com/dbtrail/dbtrail/internal/indexer"
@@ -91,14 +92,30 @@ func TestIntegrationFlashbackRoutesByServer(t *testing.T) {
 	asOf := now.Add(10 * time.Minute).Format("2006-01-02 15:04:05")
 	q := fmt.Sprintf("SELECT * FROM _flashback.users AS OF '%s' WHERE id = 1", asOf)
 
-	for _, tc := range []struct{ user, want string }{
+	// Recording audit sink: the flashback port authenticates on the shared
+	// console token and its username is a server-ROUTING key, so the audit
+	// Actor must be the prefixed "server:<name>" sentinel — never the bare
+	// username, which a sink would misread as a person (#1123).
+	rec := audittest.Install(t)
+
+	routeCases := []struct{ user, want string }{
 		{entA.ID, "alice"},
 		{entB.ID, "bob"},
 		{"srva", "alice"}, // by display name too
 		{"srvb", "bob"},
-	} {
+	}
+	for _, tc := range routeCases {
 		if got := queryFlashbackName(t, ln.Addr().String(), tc.user, "tok", "", q); got != tc.want {
 			t.Errorf("user %q: name = %q, want %q (routed to the wrong index?)", tc.user, got, tc.want)
+		}
+	}
+	auditEvs := rec.Events()
+	if len(auditEvs) != len(routeCases) {
+		t.Fatalf("recorded %d audit events, want %d (one per served query): %+v", len(auditEvs), len(routeCases), auditEvs)
+	}
+	for i, tc := range routeCases {
+		if want := "server:" + tc.user; auditEvs[i].Actor != want {
+			t.Errorf("audit actor for user %q = %q, want %q", tc.user, auditEvs[i].Actor, want)
 		}
 	}
 

--- a/ext/audit.go
+++ b/ext/audit.go
@@ -21,13 +21,20 @@ import (
 //     reconstruct.run, verify.explain. bintrail-pg shares
 //     these command implementations (internal/cli) and so
 //     reports the same "cli" surface; there is no "pg" surface.
-//   - "mcp"     — query.run, recover.generate (internal/mcptools; the
-//     console's /mcp endpoint reuses the same handlers with
-//     Surface "console").
+//   - "mcp"     — query.run, recover.generate, reconstruct.row
+//     (internal/mcptools; the console's /mcp endpoint reuses the
+//     same handlers with Surface "console").
 //   - "shim"    — timetravel.query, for every virtual schema that returns
-//     row images (_flashback, _snapshot, _diff), from the
-//     standalone `bintrail shim` AND the console's embedded
-//     flashback port. Actor is the authenticated MySQL user.
+//     row images (_flashback, _snapshot, _diff), from all THREE
+//     serving layers: the standalone `bintrail shim`, the
+//     console's embedded flashback port, and the PostgreSQL wire
+//     front-end (`bintrail-pg flashback`, internal/pgshim). Actor
+//     is the authenticated per-tenant credential on the standalone
+//     shim and the PG front-end; the console's flashback port
+//     authenticates on the shared console token and its username
+//     is a server-ROUTING key, so its Actor is "server:<name>" —
+//     the routing target, prefixed so a sink cannot mistake it for
+//     a person.
 //   - "console" — query.run, recover.generate, recover.cascade,
 //     reconstruct.run, verify.explain, plus two refusals that
 //     are not data reads: authz.denied (the session's policy
@@ -39,9 +46,11 @@ import (
 //   - metadata-only reads that return no row images: the shim's
 //     SHOW TABLES FROM <virtual schema>, and the console's
 //     status/schemas/capabilities/storage/baselines endpoints.
-//   - `verify` without --explain: it compares fingerprints and reports
-//     match/mismatch per table; only the --explain drill-down surfaces
-//     row-level data, and that is what emits verify.explain.
+//   - `verify` without --explain — including `--check recover`, which
+//     READS before/after images to compare them but reports only per-table
+//     verdicts and chain-break locators (event id, primary key, column
+//     name), never the images themselves. Only the --explain drill-down
+//     surfaces row-level data, and that is what emits verify.explain.
 //   - the capture plane (index, snapshot, stream, agent, rotate,
 //     archive): those write or maintain the index, they do not read
 //     historical row data back out.
@@ -49,7 +58,7 @@ type AuditEvent struct {
 	Time    time.Time         // stamped by Record when zero
 	Surface string            // "cli", "mcp", "shim", "console"
 	Action  string            // e.g. "query.run", "recover.generate"
-	Actor   string            // see ProcessActor; shim uses its authenticated user
+	Actor   string            // see ProcessActor; shim semantics per the Surface list above
 	Schema  string            // schema filter/target, may be empty
 	Table   string            // table filter/target, may be empty
 	Detail  map[string]string // action-specific fields (statements, dry_run, gtid, ...)

--- a/internal/audittest/audittest.go
+++ b/internal/audittest/audittest.go
@@ -60,6 +60,15 @@ const (
 	// OwnerMCP: internal/mcptools/audit_contract_test.go — the tool handlers
 	// over a sqlmock index.
 	OwnerMCP Owner = "internal/mcptools (unit)"
+	// OwnerMCPIntegration: internal/mcptools/reconstruct_integration_test.go —
+	// the reconstruct tool needs a real index plus a baseline Parquet, so its
+	// contract case lives in the integration tier (which CI runs on every
+	// pull request as a required check).
+	OwnerMCPIntegration Owner = "internal/mcptools (integration)"
+	// OwnerPGShim: internal/pgshim/audit_contract_integration_test.go — the
+	// PostgreSQL wire front-end drives a real pgx client against a seeded
+	// index, the same real-code-path posture as the other owners.
+	OwnerPGShim Owner = "internal/pgshim (integration)"
 )
 
 // Requirement is one emission the core must make, and where it is pinned.
@@ -70,10 +79,13 @@ type Requirement struct {
 	Why string
 }
 
-// Required is the exact set of audit emissions the core guarantees. Adding a
-// surface means adding a row here AND exercising it in that owner's contract
-// test; removing one means deleting the row and correcting the ext/audit.go
-// docstring, which enumerates the same set in prose.
+// Required is the exact set of audit emissions the core guarantees, keyed by
+// (pair, owner) — one pair may appear under two owners when two independent
+// serving layers emit it (shim/timetravel.query: the MySQL command loop and
+// the PostgreSQL front-end). Adding a surface means adding a row here AND
+// exercising it in that owner's contract test; removing one means deleting
+// the row and correcting the ext/audit.go docstring, which enumerates the
+// same set in prose.
 var Required = []Requirement{
 	{
 		Pair:  Pair{Surface: "cli", Action: "query.run"},
@@ -111,9 +123,29 @@ var Required = []Requirement{
 		Why:   "an LLM client generating a reversal script",
 	},
 	{
+		Pair:  Pair{Surface: "mcp", Action: "reconstruct.row"},
+		Owner: OwnerMCPIntegration,
+		Why:   "an LLM client reading point-in-time row state (baseline + deltas)",
+	},
+	{
+		Pair:  Pair{Surface: "console", Action: "reconstruct.row"},
+		Owner: OwnerMCPIntegration,
+		Why:   "the console's /mcp endpoint mounts the same reconstruct handler with Surface console",
+	},
+	{
 		Pair:  Pair{Surface: "shim", Action: "timetravel.query"},
 		Owner: OwnerShim,
 		Why:   "network time-travel reads (_flashback/_snapshot/_diff) by an authenticated tenant",
+	},
+	{
+		// The SAME pair again, under a second owner: bintrail-pg flashback
+		// serves the same virtual schemas through the exported resolve seam,
+		// BYPASSING Handler.HandleQuery — so the MySQL command loop's
+		// contract test proves nothing about this serving layer's emission
+		// (#1123). One pair, two independently pinned emission paths.
+		Pair:  Pair{Surface: "shim", Action: "timetravel.query"},
+		Owner: OwnerPGShim,
+		Why:   "the PostgreSQL wire front-end serves the same row images outside HandleQuery",
 	},
 	{
 		Pair:  Pair{Surface: "console", Action: "query.run"},
@@ -217,10 +249,20 @@ func Install(t *testing.T) *Recorder {
 	return rec
 }
 
-// CheckCoverage fails t unless the observed pairs are exactly the pairs owner
-// is required to emit: every requirement seen at least once (a dropped
-// emission site fails here), and nothing observed that Required does not
-// list (a NEW audited surface has to be declared, not smuggled in).
+// CheckCoverage fails t unless the observed pairs cover the pairs owner is
+// required to emit: every requirement seen at least once, and no observed
+// pair that Required does not list anywhere.
+//
+// Know exactly what that proves (#1123). At-least-once catches a DELETED
+// emission for a pair; it is structurally blind to a NEW unaudited mode of
+// a command that already has an audited one (reconstruct --baseline-only
+// slipped through exactly this way). And the undeclared arm fails only on
+// an undeclared emission FROM AN EXERCISED PATH — an emission on a handler
+// no contract case drives, or a pair declared for a different owner, is
+// invisible here. TestAuditRecordCallSitesAccounted (callsites_test.go) is
+// the source-level backstop for the call-site half of that blindness; a
+// new MODE reusing an existing call site still needs a hand-added emission
+// and contract case.
 func CheckCoverage(t *testing.T, owner Owner, observed []Pair) {
 	t.Helper()
 	want := map[Pair]bool{}

--- a/internal/audittest/callsites_test.go
+++ b/internal/audittest/callsites_test.go
@@ -1,0 +1,124 @@
+package audittest
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// recordCallSites is the explicit accounted-for list of every `ext.Record(`
+// call site in non-test source, keyed by module-relative path. It is the
+// source-level backstop CheckCoverage's behavioural coverage structurally
+// lacks (#1123): behavioural coverage catches a DELETED emission, but a NEW
+// unaudited call site — or a call site whose pair no owner declares, like
+// mcp/reconstruct.row was — only trips a test if some contract case happens
+// to execute it. Counting call sites trips at BUILD-TEST time instead.
+//
+// When this test fails because you ADDED a call site: declare it here, add
+// its (surface, action) pair to Required, and exercise it in that owner's
+// contract test. When it fails because a count DROPPED: an emission was
+// deleted or moved — put it back, or remove the pair from Required and fix
+// the ext/audit.go docstring in the same change.
+//
+// What this still cannot catch: a new data-serving MODE that returns
+// through an existing command without reaching its existing emission
+// (reconstruct --baseline-only's original bug). That class has no
+// mechanical guard — adding a mode means adding the emission by hand.
+var recordCallSites = map[string]int{
+	"internal/cli/query.go":            1, // cli/query.run
+	"internal/cli/recover.go":          1, // cli/recover.generate
+	"internal/cli/recover_cascade.go":  1, // cli/recover.cascade
+	"internal/cli/reconstruct.go":      1, // cli/reconstruct.run (auditReconstruct — all five modes)
+	"internal/cli/verify.go":           1, // cli/verify.explain
+	"internal/console/audit.go":        1, // console data reads (recordConsoleAudit helper)
+	"internal/console/authz.go":        1, // console/authz.denied + console/profile.denied
+	"internal/mcptools/mcptools.go":    2, // mcp|console query.run + recover.generate
+	"internal/mcptools/reconstruct.go": 1, // mcp|console reconstruct.row
+	"internal/shim/handler.go":         1, // shim/timetravel.query (recordTimeTravel — all three serving layers)
+}
+
+// TestAuditRecordCallSitesAccounted walks the module source tree and asserts
+// the set of files containing `ext.Record(` — and the occurrence count per
+// file — matches recordCallSites exactly. Plain text counting is deliberate
+// (simple, zero dependencies); a comment containing the literal `ext.Record(`
+// would be counted too — reword the comment or account for it.
+func TestAuditRecordCallSitesAccounted(t *testing.T) {
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := map[string]int{}
+	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		name := d.Name()
+		if d.IsDir() {
+			// Skip hidden/underscore dirs (worktrees, editor state), vendored
+			// code, fixtures, and build output — none of it is the module's
+			// shipping source.
+			if path != root && (strings.HasPrefix(name, ".") || strings.HasPrefix(name, "_") ||
+				name == "vendor" || name == "testdata" || name == "node_modules" ||
+				strings.HasPrefix(name, "dist")) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			return nil
+		}
+		src, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if n := strings.Count(string(src), "ext.Record("); n > 0 {
+			rel, err := filepath.Rel(root, path)
+			if err != nil {
+				return err
+			}
+			found[filepath.ToSlash(rel)] = n
+		}
+		return nil
+	})
+	if walkErr != nil {
+		t.Fatalf("walking %s: %v", root, walkErr)
+	}
+
+	for _, f := range sortedKeys(found) {
+		want, declared := recordCallSites[f]
+		if !declared {
+			t.Errorf("unaccounted ext.Record call site: %s has %d occurrence(s) — declare it in recordCallSites, "+
+				"add its (surface, action) pair to Required, and exercise it in that owner's contract test", f, found[f])
+			continue
+		}
+		if found[f] != want {
+			t.Errorf("%s has %d ext.Record occurrence(s), recordCallSites declares %d — "+
+				"update the declaration and check Required and the owner's contract test still tell the truth",
+				f, found[f], want)
+		}
+	}
+	for _, f := range sortedKeys(recordCallSites) {
+		if _, ok := found[f]; !ok {
+			t.Errorf("declared call site %s no longer contains ext.Record — the emission was deleted or moved; "+
+				"restore it, or remove its pair from Required and fix the ext/audit.go docstring in the same change", f)
+		}
+	}
+
+	// Guard the guard: an empty walk (wrong root after a layout change) must
+	// not read as "no call sites, all accounted".
+	if len(found) == 0 {
+		t.Fatalf("found no ext.Record call sites at all under %s — the walk root is wrong", root)
+	}
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/cli/audit_contract_integration_test.go
+++ b/internal/cli/audit_contract_integration_test.go
@@ -106,7 +106,11 @@ func TestIntegrationAuditContract_CLI(t *testing.T) {
 		name   string
 		action string
 		table  string
-		call   func(t *testing.T)
+		// wantMode, when set, pins Detail["mode"] — the per-mode contract the
+		// pair-level CheckCoverage cannot see (#1123: --baseline-only was an
+		// unaudited fifth mode behind an already-covered pair).
+		wantMode string
+		call     func(t *testing.T)
 	}{
 		{
 			name:   "query",
@@ -148,9 +152,10 @@ func TestIntegrationAuditContract_CLI(t *testing.T) {
 			},
 		},
 		{
-			name:   "reconstruct",
-			action: "reconstruct.run",
-			table:  "orders",
+			name:     "reconstruct",
+			action:   "reconstruct.run",
+			table:    "orders",
+			wantMode: "row",
 			call: func(t *testing.T) {
 				_, dbName, dsn, baseDir, snapTime := auditOrdersBaseline(t, false)
 				resetReconstructGlobals(t)
@@ -163,6 +168,24 @@ func TestIntegrationAuditContract_CLI(t *testing.T) {
 				recAt = snapTime.Add(time.Hour).Format("2006-01-02 15:04:05")
 				if err := runReconstruct(newQueryTestCmd(), nil); err != nil {
 					t.Fatalf("runReconstruct: %v", err)
+				}
+			},
+		},
+		{
+			// The fifth reconstruct mode: --baseline-only prints the raw
+			// baseline row (no deltas, no index connection) and used to return
+			// before the emission (#1123).
+			name:     "reconstruct --baseline-only",
+			action:   "reconstruct.run",
+			table:    "orders",
+			wantMode: "baseline-only",
+			call: func(t *testing.T) {
+				_, dbName, _, baseDir, _ := auditOrdersBaseline(t, false)
+				resetReconstructGlobals(t)
+				recSchema, recTable, recPK, recPKColumns = dbName, "orders", "1", "id"
+				recBaselineDir, recBaselineOnly = baseDir, true
+				if err := runReconstruct(newQueryTestCmd(), nil); err != nil {
+					t.Fatalf("runReconstruct --baseline-only: %v", err)
 				}
 			},
 		},
@@ -206,6 +229,9 @@ func TestIntegrationAuditContract_CLI(t *testing.T) {
 			}
 			if ev.Table != tc.table {
 				t.Errorf("table = %q, want %q", ev.Table, tc.table)
+			}
+			if tc.wantMode != "" && ev.Detail["mode"] != tc.wantMode {
+				t.Errorf("detail[mode] = %q, want %q", ev.Detail["mode"], tc.wantMode)
 			}
 			// A locally invoked command has no authenticated caller, so the
 			// actor is the process identity — "os:<user>" per ext.ProcessActor.

--- a/internal/cli/reconstruct.go
+++ b/internal/cli/reconstruct.go
@@ -437,6 +437,11 @@ func runReconstruct(cmd *cobra.Command, args []string) error {
 		if err := writeReconstructOutput(baselineRow, nil, snapshotTime, at, false, recFormat, os.Stdout); err != nil {
 			return err
 		}
+		auditReconstruct(cmd.Context(), "baseline-only", recSchema, recTable, map[string]string{
+			"pk":     recPK,
+			"at":     at.UTC().Format(time.RFC3339),
+			"format": recFormat,
+		})
 		slog.Info("reconstruct complete",
 			"mode", "baseline-only",
 			"snapshot", snapshotTime.UTC().Format(time.RFC3339),
@@ -935,9 +940,13 @@ func runReconstructFullTable(cmd *cobra.Command, start time.Time) error {
 // names. ext.Record is a no-op unless an embedding distribution installed a
 // sink, and it cannot fail the command (see ext/audit.go).
 //
-// mode distinguishes the four shapes the one command serves: "row"
-// (single-row AS OF), "history" (--history), "full-table" (--output-format
-// mydumper) and "sql" (--sql, a direct read of the baseline Parquet).
+// mode distinguishes the five shapes the one command serves: "row"
+// (single-row AS OF), "history" (--history), "baseline-only"
+// (--baseline-only: the raw baseline row, no deltas applied — it prints a
+// row image straight out of the Parquet snapshot, so it is audited like
+// the others; it was the unaudited fifth mode of #1123), "full-table"
+// (--output-format mydumper) and "sql" (--sql, a direct read of the
+// baseline Parquet).
 // reconstruct has no --profile flag, so the actor carries no RBAC profile.
 func auditReconstruct(ctx context.Context, mode, schema, table string, detail map[string]string) {
 	if detail == nil {

--- a/internal/mcptools/reconstruct_integration_test.go
+++ b/internal/mcptools/reconstruct_integration_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/dbtrail/dbtrail/internal/audittest"
 	"github.com/dbtrail/dbtrail/internal/baseline"
 	"github.com/dbtrail/dbtrail/internal/metadata"
 	"github.com/dbtrail/dbtrail/internal/testutil"
@@ -172,6 +173,75 @@ func TestIntegrationReconstructToolPointInTime(t *testing.T) {
 	if r.Found || r.Deleted {
 		t.Errorf("pk=999: found=%v deleted=%v, want neither", r.Found, r.Deleted)
 	}
+}
+
+// TestIntegrationAuditContract_MCPReconstruct is the reconstruct tool's half
+// of the audit contract. The tool's mcp/reconstruct.row emission shipped
+// without a Required row or a contract case — live but undeclared, the exact
+// blindness #1123 documents (CheckCoverage's undeclared arm only fires on an
+// exercised path) — so this pins it, for both surface tags the one handler
+// serves: the standalone "mcp" default and the console's /mcp mount, which
+// re-tags Surface "console" via Config.AuditSurface (the same override
+// mechanism TestAuditContract_MCPSurfaceOverride pins for the query tool).
+//
+// No t.Parallel(): ext's sink is process-wide (audittest.Install).
+func TestIntegrationAuditContract_MCPReconstruct(t *testing.T) {
+	db, dbName, baseDir := seedReconstructIndex(t)
+	rec := audittest.Install(t)
+
+	resolver, err := metadata.NewResolver(db, 0)
+	if err != nil {
+		t.Fatalf("load resolver: %v", err)
+	}
+	cfg := Config{
+		Version:             "test",
+		Reconstruct:         true,
+		AllowBaselineParams: true,
+		Resolve: func(ctx context.Context, _ string) (*Target, error) {
+			return &Target{DB: db, DBName: dbName, Resolver: resolver, ResolverLoaded: true}, nil
+		},
+	}
+	args := ReconstructArgs{
+		Schema: "app", Table: "users", PK: "1",
+		At: "2026-06-01 12:30:00", BaselineDir: baseDir, AllowGaps: true,
+	}
+
+	var observed []audittest.Pair
+	for _, tc := range []struct {
+		name        string
+		surfaceTag  string // Config.AuditSurface; "" = the standalone default
+		wantSurface string
+	}{
+		{name: "standalone mcp", surfaceTag: "", wantSurface: "mcp"},
+		{name: "console /mcp mount", surfaceTag: "console", wantSurface: "console"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec.Reset()
+			c := cfg
+			c.AuditSurface = tc.surfaceTag
+			res, _, _ := MakeReconstructTool(c)(context.Background(), nil, args)
+			if res.IsError {
+				t.Fatalf("reconstruct tool failed: %s", resultText(res))
+			}
+			evs := rec.Events()
+			if len(evs) != 1 {
+				t.Fatalf("recorded %d audit events, want exactly 1: %+v", len(evs), evs)
+			}
+			ev := evs[0]
+			if ev.Surface != tc.wantSurface || ev.Action != "reconstruct.row" {
+				t.Errorf("event = %s/%s, want %s/reconstruct.row", ev.Surface, ev.Action, tc.wantSurface)
+			}
+			if ev.Schema != "app" || ev.Table != "users" {
+				t.Errorf("schema/table = %q/%q, want app/users", ev.Schema, ev.Table)
+			}
+			if ev.Actor == "" {
+				t.Error("actor must not be empty")
+			}
+			observed = append(observed, audittest.Pair{Surface: ev.Surface, Action: ev.Action})
+		})
+	}
+
+	audittest.CheckCoverage(t, audittest.OwnerMCPIntegration, observed)
 }
 
 // TestIntegrationReconstructToolHistory pins history mode: the baseline entry

--- a/internal/pgshim/audit_contract_integration_test.go
+++ b/internal/pgshim/audit_contract_integration_test.go
@@ -1,0 +1,136 @@
+//go:build integration
+
+package pgshim
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/audittest"
+	"github.com/dbtrail/dbtrail/internal/event"
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/shim"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestIntegrationAuditContract_PGShim is the PostgreSQL front-end's half of
+// the shim audit contract (#1123): this serving layer answers time-travel
+// queries through the exported resolve seam (ResolveFlashbackRow /
+// ResolveSnapshotRow), BYPASSING Handler.HandleQuery — so the MySQL command
+// loop's contract test (internal/shim/audit_contract_test.go) proves nothing
+// about it, and before #1123 it served row images with zero emissions and an
+// unbound actor.
+//
+// Real code path end-to-end: a REAL pgx client over the wire, against a real
+// seeded index, with a recording sink installed. The actor must be the
+// authenticated per-tenant credential — pgshim authenticates a real user
+// (unlike the console flashback port, whose username is a routing key).
+//
+// No t.Parallel(): ext's sink is process-wide (audittest.Install).
+func TestIntegrationAuditContract_PGShim(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	rec := audittest.Install(t)
+
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	hour := time.Now().UTC().Truncate(time.Hour)
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{hour})
+	snapTS := hour.Format("2006-01-02 15:04:05")
+	testutil.InsertSnapshot(t, db, 1, snapTS, "public", "users", "id", 1, "PRI", "int", "NO")
+	testutil.InsertSnapshot(t, db, 1, snapTS, "public", "users", "name", 2, "", "varchar", "YES")
+	t0 := hour.Add(5 * time.Minute)
+	testutil.InsertEvent(t, db, "mysql-bin.000001", 100, 200, t0.Format("2006-01-02 15:04:05"), nil,
+		"public", "users", uint8(event.EventInsert), "1", nil, nil, []byte(`{"id":1,"name":"alice"}`))
+
+	addr := serveAddrWithDB(t, Config{
+		IndexDB:    db,
+		ShimConfig: shim.Config{NoArchive: true, IndexDBName: dbName},
+		Auth:       testAuth(t),
+	})
+	conn, err := connectPGWire(t, addr, testUser, testPass)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	asOf := t0.Add(5 * time.Minute).Format("2006-01-02 15:04:05")
+
+	cases := []struct {
+		name      string
+		virtual   string
+		pk        string
+		wantRows  string
+		wantFound bool
+	}{
+		{name: "flashback single row", virtual: "_flashback", pk: "1", wantRows: "1", wantFound: true},
+		{name: "snapshot single row", virtual: "_snapshot", pk: "1", wantRows: "1", wantFound: true},
+		// A row absent at AsOf is still a served time-travel read (a real
+		// zero-row resultset went to the client), so it is audited with rows=0
+		// — same posture as the MySQL front-end's empty resultsets.
+		{name: "row absent at AsOf", virtual: "_flashback", pk: "999", wantRows: "0", wantFound: false},
+	}
+
+	var observed []audittest.Pair
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec.Reset()
+			rows, err := conn.Query(ctx, "SELECT * FROM "+tc.virtual+".users AS OF '"+asOf+"' WHERE id = "+tc.pk)
+			if err != nil {
+				t.Fatalf("query: %v", err)
+			}
+			got := rows.Next()
+			rows.Close()
+			if err := rows.Err(); err != nil {
+				t.Fatalf("rows err: %v", err)
+			}
+			if got != tc.wantFound {
+				t.Fatalf("row found = %v, want %v (seed problem?)", got, tc.wantFound)
+			}
+			evs := rec.Events()
+			if len(evs) != 1 {
+				t.Fatalf("recorded %d audit events, want exactly 1: %+v", len(evs), evs)
+			}
+			ev := evs[0]
+			if ev.Surface != "shim" || ev.Action != "timetravel.query" {
+				t.Errorf("event = %s/%s, want shim/timetravel.query", ev.Surface, ev.Action)
+			}
+			// The authenticated tenant, not the daemon's process owner and not
+			// the unbound sentinel: pgshim.handleConn must BindActor post-auth.
+			if ev.Actor != testUser {
+				t.Errorf("actor = %q, want the authenticated tenant %q", ev.Actor, testUser)
+			}
+			if ev.Schema != "public" || ev.Table != "users" {
+				t.Errorf("schema/table = %q/%q, want public/users", ev.Schema, ev.Table)
+			}
+			if gotType := ev.Detail["query_type"]; gotType != tc.virtual {
+				t.Errorf("detail[query_type] = %q, want %q", gotType, tc.virtual)
+			}
+			if gotRows := ev.Detail["rows"]; gotRows != tc.wantRows {
+				t.Errorf("detail[rows] = %q, want %q", gotRows, tc.wantRows)
+			}
+			if ev.Detail["scope"] != "single_row" {
+				t.Errorf("detail[scope] = %q, want single_row", ev.Detail["scope"])
+			}
+			observed = append(observed, audittest.Pair{Surface: ev.Surface, Action: ev.Action})
+		})
+	}
+
+	// Refusals read no rows and must record nothing: a full-table AS OF (the
+	// PG front-end refuses it) and a non-time-travel statement.
+	rec.Reset()
+	if _, err := conn.Exec(ctx, "SELECT * FROM _flashback.users AS OF '"+asOf+"'"); err == nil {
+		t.Fatal("full-table AS OF must be refused on the PG front-end")
+	}
+	if _, err := conn.Exec(ctx, "SELECT 1"); err == nil {
+		t.Fatal("a non-time-travel query must be refused")
+	}
+	if evs := rec.Events(); len(evs) != 0 {
+		t.Errorf("refused queries recorded %d audit events, want 0: %+v", len(evs), evs)
+	}
+
+	audittest.CheckCoverage(t, audittest.OwnerPGShim, observed)
+}

--- a/internal/pgshim/pgshim.go
+++ b/internal/pgshim/pgshim.go
@@ -205,6 +205,11 @@ func handleConn(ctx context.Context, c net.Conn, cfg Config, logger *slog.Logger
 
 	h := shim.NewHandlerWithConfig(cfg.IndexDB, cfg.ShimConfig, logger)
 	h.BindConnContext(connCtx)
+	// This front-end authenticates a real per-tenant credential (shim.yaml),
+	// so — exactly like the standalone MySQL shim (internal/cli/shim.go) —
+	// the audit identity for every time-travel query on this connection is
+	// that tenant. Post-auth: user is only trustworthy here.
+	h.BindActor(user)
 	// currentDB = the connect database param (the bintrail schema). Empty is
 	// allowed: queries must then schema-qualify the table (<schema>.<table>).
 	_ = h.UseDB(database)

--- a/internal/pgshim/session.go
+++ b/internal/pgshim/session.go
@@ -111,7 +111,11 @@ func (s *session) resolve(qstr string) (cols []string, rows [][][]byte, tag stri
 		cols = s.h.ColumnsFor(image, q)
 		if image == nil {
 			// Row did not exist at AsOf (never created, or a DELETE tail): a real
-			// resultset with the table's columns and zero rows.
+			// resultset with the table's columns and zero rows. Still a served
+			// time-travel read, so it is audited like the MySQL front-end's
+			// empty resultsets (side channel on the success path, see
+			// ext/audit.go; a refusal above emits nothing).
+			s.h.AuditResolve(q, 0)
 			return cols, nil, "SELECT 0", nil
 		}
 		cells, cerr := imageCells(image, cols)
@@ -120,6 +124,7 @@ func (s *session) resolve(qstr string) (cols []string, rows [][][]byte, tag stri
 			// the marker's JSON as a value.
 			return nil, nil, "", &pgErr{"XX000", cerr.Error()}
 		}
+		s.h.AuditResolve(q, 1)
 		return cols, [][][]byte{cells}, "SELECT 1", nil
 	default:
 		return nil, nil, "", &pgErr{"XX000", fmt.Sprintf("unsupported query type: %s", q.Type)}

--- a/internal/shim/handler.go
+++ b/internal/shim/handler.go
@@ -395,10 +395,13 @@ func (h *Handler) BindConn(conn packetWriter) {
 // and before serving commands — same lifecycle as BindConn, same
 // no-lock-needed reasoning.
 //
-// Both serving layers must call it: the standalone shim
-// (internal/cli/shim.go) and the console's embedded flashback port
-// (consoleapp/flashback.go), which routes BY username. A handler nobody
-// bound reports unboundActor.
+// All three serving layers must call it: the standalone shim
+// (internal/cli/shim.go), the PostgreSQL wire front-end
+// (internal/pgshim) — both binding their authenticated per-tenant user —
+// and the console's embedded flashback port (consoleapp/flashback.go),
+// which authenticates on the shared console token and routes BY username,
+// so it binds the "server:<name>" routing sentinel instead of a person.
+// A handler nobody bound reports unboundActor.
 func (h *Handler) BindActor(user string) {
 	h.actor = user
 }
@@ -526,6 +529,35 @@ func (h *Handler) auditTimeTravel(q TimeTravelQuery, res *mysql.Result) {
 	if !ext.Auditing() {
 		return
 	}
+	rows := -1
+	if res != nil && res.Resultset != nil {
+		rows = len(res.Resultset.Values)
+	}
+	h.recordTimeTravel(q, rows)
+}
+
+// AuditResolve is the emission for a wire front-end that serves time-travel
+// queries through the exported resolve seam (ResolveFlashbackRow /
+// ResolveSnapshotRow) instead of HandleQuery — today the PostgreSQL
+// front-end (internal/pgshim, #1008), whose command loop renders its own
+// wire format and so never reaches auditTimeTravel. rows is the number of
+// row images rendered to the client; negative omits the count.
+//
+// Same contract as auditTimeTravel: call it on the success path only, after
+// the reply the client asked for has been built, and never on a refusal.
+// Guarded by ext.Auditing() first, so a build with no sink installed pays
+// one nil check per query and allocates nothing.
+func (h *Handler) AuditResolve(q TimeTravelQuery, rows int) {
+	if !ext.Auditing() {
+		return
+	}
+	h.recordTimeTravel(q, rows)
+}
+
+// recordTimeTravel builds and records the shim/timetravel.query event —
+// the shared tail of auditTimeTravel and AuditResolve. Callers must have
+// checked ext.Auditing() already (the zero-allocation hot-path guard).
+func (h *Handler) recordTimeTravel(q TimeTravelQuery, rows int) {
 	actor := h.actor
 	if actor == "" {
 		actor = unboundActor
@@ -545,8 +577,8 @@ func (h *Handler) auditTimeTravel(q TimeTravelQuery, res *mysql.Result) {
 	} else {
 		detail["scope"] = "single_row"
 	}
-	if res != nil && res.Resultset != nil {
-		detail["rows"] = strconv.Itoa(len(res.Resultset.Values))
+	if rows >= 0 {
+		detail["rows"] = strconv.Itoa(rows)
 	}
 	// WithoutCancel: the resultset is already built by the time this runs,
 	// but baseCtx is the per-connection context, canceled on client


### PR DESCRIPTION
closes #1123

## 1. `bintrail-pg flashback` — the third serving layer now emits and binds its actor

`internal/pgshim/session.go` answers time-travel queries through the exported resolve seam (`PKColumnCheck` → `ResolveSnapshotRow`/`ResolveFlashbackRow` → `ColumnsFor`), bypassing `Handler.HandleQuery` — so the emission there was unreachable, and no actor was ever bound.

- `Handler` now exports **`AuditResolve(q, rows)`**: `auditTimeTravel` and `AuditResolve` share one `recordTimeTravel` tail, both behind the `ext.Auditing()` guard first, so the `AllocsPerRun`-pinned zero-allocation no-sink hot path is unchanged (`TestAuditContract_ShimNoSinkNoAlloc` still green).
- `session.resolve` emits on the success path only — after the reply is built, including the **zero-row** "row absent at AsOf" resultset (`SELECT 0`), matching the MySQL front-end's posture; refusals (full-table, `_diff`, malformed, TOAST marker) emit nothing.
- `pgshim.handleConn` calls **`BindActor(user)` post-auth**: this front-end authenticates a real per-tenant cleartext credential (shim.yaml), exactly like the standalone MySQL shim, so the actor is that tenant.

**Surface choice: `shim`/`timetravel.query`, not a new surface.** The precedent that `bintrail-pg` reuses `internal/cli` and reports Surface `"cli"` generalizes: the taxonomy axis is *which engine served the read*, not the wire protocol — this daemon is `internal/shim`'s engine behind a PostgreSQL wire, serving the same virtual schemas under the same per-tenant auth as `bintrail shim`. Inventing a `"pgshim"` surface would fork the vocabulary for a render-layer difference. `Detail` (query_type/scope/as_of/rows) is identical across all three layers.

Because this layer emits **outside** `HandleQuery`, the pair gets a second owner in `audittest.Required` (`OwnerPGShim`) with its own contract test (`internal/pgshim/audit_contract_integration_test.go`): a real pgx client over the wire against a seeded index — flashback, snapshot, row-absent (rows=0), actor = the authenticated tenant, and refusals-emit-nothing, ending in `CheckCoverage`.

## 2. `reconstruct --baseline-only` — the fifth mode now emits

The `--baseline-only` early return emits `cli/reconstruct.run` with `mode=baseline-only` after the output is written; `auditReconstruct`'s docstring now counts five shapes. The CLI contract test grows a `--baseline-only` case and a new `wantMode` pin on `Detail["mode"]` for both reconstruct cases — the per-mode assertion pair-level coverage cannot express.

## 3. Contract-test honesty + source-level backstop

- `CheckCoverage`'s docs now say exactly what it proves: at-least-once catches a **deleted** emission, is structurally blind to a **new unaudited mode** behind an already-covered pair, and the undeclared arm fires only for an emission **from an exercised path**.
- New `internal/audittest/callsites_test.go` (`TestAuditRecordCallSitesAccounted`): walks the module tree (skipping hidden/underscore dirs, vendor, testdata, dist*) counting `ext.Record(` occurrences in non-test source against an explicit per-file accounted-for map with a comment tying each site to its pair(s). An unaccounted call site — or a declared one whose count changes — fails at build-test time with remediation in the message. Chosen over `len(Required)+helpers` arithmetic because helpers fan one call site into several pairs (console `audit.go` serves five); the per-file map stays exact and reviewable. Mutation-verified: a smuggled `ext.Record(` in `internal/cli` fails with "unaccounted ext.Record call site".
- What it still cannot catch (stated in the test comment): a new mode that returns through an existing command without reaching its existing emission — that class has no mechanical guard; the emission is added by hand.

**The backstop immediately paid for itself**: accounting the call sites surfaced `internal/mcptools/reconstruct.go`'s `reconstruct.row` emission — live since the MCP reconstruct tool landed, but never declared in `Required`, never named in `ext/audit.go`, and never exercised by a contract case (the undeclared-arm blindness, verbatim). Now declared under both surface tags — `mcp/reconstruct.row` and `console/reconstruct.row` (the console's `/mcp` mount re-tags via `Config.AuditSurface`) — and pinned by `TestIntegrationAuditContract_MCPReconstruct`, which drives the real handler under both tags over a seeded index + baseline.

## 4. Console flashback actor is a routing key — now prefixed

`consoleapp/flashback.go` binds **`server:<name>`**: that port authenticates any username on the shared console token and resolves the username as a server selector, so the bare value would read as a person in a sink's principal column when it is a database target. The routing integration test now installs the recording sink and asserts one prefixed event per served query. No existing test asserted the unprefixed value. The standalone shim and the PG front-end keep binding their real per-tenant credential, unprefixed.

## 5. `ext/audit.go` enumeration

Names all **three** shim serving layers and the per-layer Actor semantics; adds `reconstruct.row` to the mcp bullet; and extends the deliberately-not-audited block: `verify --check recover` reads before/after images to *compare* them but reports only per-table verdicts and chain-break locators (event id, PK, column name), never the images — the row-serving verify output remains `--explain`, which emits. `Handler.BindActor`'s docstring aligned with all of the above.

## Testing

- `go build ./...`, `go vet ./...`, `go vet -tags integration ./...` clean
- `go test ./... -count=1` green; `go test -race -count=1` on `internal/{shim,pgshim,cli,audittest,mcptools}`, `consoleapp`, `ext` green
- `go test -tags integration -count=1 ./internal/{shim,console,pgshim,mcptools,cli} ./consoleapp` green against MySQL 8.0 on :13306
- Backstop mutation-tested (planted call site → fails; removed → passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)