### PR TITLE
reconstruct: share the fixed BINARY(n) PK reconciler across all surfaces, epoch-anchor its width

### DIFF
--- a/docs/query-and-recovery.md
+++ b/docs/query-and-recovery.md
@@ -60,15 +60,21 @@ Three things to know:
   instead of reporting them `inconclusive`. One wrinkle is handled for you: a
   fixed `BINARY(n)` column is padded with `0x00` on storage but the binlog row
   image drops that padding, so the two stores want the key spelled differently.
-  `bintrail reconstruct` reconciles both directions for you — it re-pads to the
-  declared width for the baseline lookup and trims back for the event fetch —
-  so either spelling resolves. Three surfaces do **not** have that reconciler
-  and need the exact spelling: `--baseline-only` (never opens the index, so
-  there is no column width to pad to — pass the full-width
-  `SELECT CONCAT('0x', HEX(pk_col))` form), and the console `/api/reconstruct`
-  and MCP `reconstruct` tool (which call the baseline reader directly — pass
-  the full-width form there too). `FLOAT`/`DOUBLE`, `BIT`, `JSON` and spatial
-  primary keys remain unsupported.
+  The baseline reader re-pads the key to its declared width when the exact
+  lookup misses, so the stripped `pk_values` spelling — the one `bintrail
+  query`, the console events view, and the MCP `query` tool display — resolves
+  on every surface that reads the index: `reconstruct --pk`, the console
+  `/api/reconstruct`, and the MCP `reconstruct` tool
+  ([#1157](https://github.com/dbtrail/dbtrail/issues/1157)). The CLI
+  additionally trims a full-width `SELECT CONCAT('0x', HEX(pk_col))` key back
+  to the stored spelling for its event fetch, so either form works there. The
+  declared width is read from the schema snapshot in effect when the baseline
+  was taken, so widening the key with a later `ALTER` does not break lookups
+  against older baselines
+  ([#1159](https://github.com/dbtrail/dbtrail/issues/1159)). The one surface
+  without the reconciler is `--baseline-only`, which never opens the index and
+  so has no declared width to pad to — pass the full-width `HEX()` form there.
+  `FLOAT`/`DOUBLE`, `BIT`, `JSON` and spatial primary keys remain unsupported.
 
 ### `--column-eq` Filter
 

--- a/docs/query-and-recovery.md
+++ b/docs/query-and-recovery.md
@@ -60,14 +60,15 @@ Three things to know:
   instead of reporting them `inconclusive`. One wrinkle is handled for you: a
   fixed `BINARY(n)` column is padded with `0x00` on storage but the binlog row
   image drops that padding, so the two stores want the key spelled differently.
-  The baseline reader re-pads the key to its declared width when the exact
-  lookup misses, so the stripped `pk_values` spelling — the one `bintrail
-  query`, the console events view, and the MCP `query` tool display — resolves
-  on every surface that reads the index: `reconstruct --pk`, the console
-  `/api/reconstruct`, and the MCP `reconstruct` tool
-  ([#1157](https://github.com/dbtrail/dbtrail/issues/1157)). The CLI
-  additionally trims a full-width `SELECT CONCAT('0x', HEX(pk_col))` key back
-  to the stored spelling for its event fetch, so either form works there. The
+  All three index-reading surfaces — `reconstruct --pk`, the console
+  `/api/reconstruct`, and the MCP `reconstruct` tool — reconcile both
+  directions ([#1157](https://github.com/dbtrail/dbtrail/issues/1157)): the
+  baseline reader re-pads the key to its declared width when the exact lookup
+  misses, and the event fetch re-spells it back to the stored `pk_values` form
+  (stripped, uppercase). So the stripped spelling the events views display, a
+  lowercase paste of it, and the full-width
+  `SELECT CONCAT('0x', HEX(pk_col))` form all resolve — and all fold the
+  post-baseline deltas, never silently answering with baseline-era state. The
   declared width is read from the schema snapshot in effect when the baseline
   was taken, so widening the key with a later `ALTER` does not break lookups
   against older baselines

--- a/internal/cli/reconstruct.go
+++ b/internal/cli/reconstruct.go
@@ -2,18 +2,14 @@ package cli
 
 import (
 	"context"
-	"database/sql"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
 	"log/slog"
-	"maps"
 	"os"
 	"strconv"
 	"strings"
 	"time"
-	"unicode/utf8"
 
 	mysqldriver "github.com/go-sql-driver/mysql"
 	"github.com/spf13/cobra"
@@ -41,25 +37,6 @@ func pkChangeSuspected(events []query.ResultRow) bool {
 	return len(events) > 0 && events[0].EventType != event.EventInsert
 }
 
-// resolvePKMetas loads the searched table's primary-key column metadata from
-// the latest schema snapshot. Best-effort by design: every caller below only
-// uses it to IMPROVE a lookup or an error message, so a missing/unreadable
-// snapshot degrades to the pre-#1155 behaviour instead of failing a
-// reconstruct that would otherwise have worked.
-func resolvePKMetas(db *sql.DB, schema, table string) []metadata.ColumnMeta {
-	res, err := metadata.NewResolver(db, 0)
-	if err != nil {
-		slog.Debug("could not load schema snapshot for PK metadata", "error", err)
-		return nil
-	}
-	tm, err := res.Resolve(schema, table)
-	if err != nil {
-		slog.Debug("could not resolve table for PK metadata", "error", err)
-		return nil
-	}
-	return tm.PKColumnMetas()
-}
-
 // unsupportedPKType returns the first primary-key column whose type the
 // baseline canonicalizer cannot handle, or nil when every column is supported.
 //
@@ -79,136 +56,6 @@ func unsupportedPKType(pkMetas []metadata.ColumnMeta) *metadata.ColumnMeta {
 		}
 	}
 	return nil
-}
-
-// indexPKSpelling rewrites a --pk value into the spelling the indexer stored in
-// binlog_events.pk_values, so the event fetch matches what the operator typed.
-//
-// Only fixed-width BINARY(n) components are touched, and this is the INVERSE of
-// padFixedBinaryFilter — the two run in opposite directions on purpose, because
-// they target different stores. Reproducing event.formatPKValue exactly:
-// trailing 0x00 padding is stripped (the ROW image never carries it), and the
-// hex is uppercased, but ONLY when the trimmed bytes are not valid UTF-8 —
-// formatPKValue is content-gated, so a binary key whose bytes are printable
-// ASCII is stored verbatim and must stay that way.
-//
-// Everything else — every other column type, and every component that is
-// already in the stored spelling — is returned untouched, so this cannot
-// disturb a lookup that resolves today.
-func indexPKSpelling(pk string, pkMetas []metadata.ColumnMeta) string {
-	if pk == "" || len(pkMetas) == 0 {
-		return pk
-	}
-	parts := strings.Split(pk, "|")
-	if len(parts) != len(pkMetas) {
-		// --pk/--pk-columns arity is validated against the operator's
-		// --pk-columns, not against the snapshot; if the two disagree, leave
-		// the value alone rather than re-spell the wrong component.
-		return pk
-	}
-	changed := false
-	for i, c := range pkMetas {
-		if !strings.EqualFold(strings.TrimSpace(c.DataType), "binary") {
-			continue
-		}
-		raw, isHex := decodeHexPKValue(parts[i])
-		if !isHex {
-			continue // already the verbatim/stored spelling
-		}
-		trimmed := reconstruct.TrimFixedBinaryPad(raw)
-		var spelled string
-		if utf8.Valid(trimmed) {
-			spelled = string(trimmed)
-		} else {
-			spelled = "0x" + strings.ToUpper(hex.EncodeToString(trimmed))
-		}
-		if spelled != parts[i] {
-			parts[i] = spelled
-			changed = true
-		}
-	}
-	if !changed {
-		return pk
-	}
-	return strings.Join(parts, "|")
-}
-
-// padFixedBinaryFilter re-spells a fixed-width BINARY(n) filter value back to
-// the width the baseline stores, returning false when nothing needs re-spelling.
-//
-// This is the INVERSE of reconstruct.TrimFixedBinaryPad, and the direction is
-// deliberate: pk_values holds the binlog ROW image's spelling, which has every
-// trailing 0x00 stripped, while the baseline Parquet holds the full n bytes
-// MySQL padded on storage. An operator who copies a key out of the index — the
-// workflow #1155 reports — therefore hands us a value SHORTER than the one to
-// match. Re-padding it is exact (MySQL only ever pads a BINARY(n) with 0x00),
-// and it is only ever attempted after an exact lookup already came back empty,
-// so it cannot turn a correct hit into a different row.
-func padFixedBinaryFilter(pkFilter map[string]string, pkMetas []metadata.ColumnMeta) (map[string]string, bool) {
-	out := make(map[string]string, len(pkFilter))
-	maps.Copy(out, pkFilter)
-	changed := false
-	for _, c := range pkMetas {
-		if !strings.EqualFold(strings.TrimSpace(c.DataType), "binary") {
-			continue
-		}
-		width := reconstruct.FixedBinaryWidth(c.ColumnType)
-		if width == 0 {
-			// Pre-#212 snapshot with no COLUMN_TYPE: the pad width is
-			// unknowable, so leave the value alone rather than guess.
-			continue
-		}
-		// --pk-columns is operator-typed and MySQL column names are
-		// case-insensitive, so an exact-only match would silently skip the
-		// retry for `--pk-columns K` against column `k`. (The lookup underneath
-		// is case-insensitive on both links since #1155: DuckDB resolves the
-		// quoted identifier, and parquetBlobColumns is keyed lowercase.)
-		key, ok := filterKeyFor(out, c.Name)
-		if !ok {
-			continue
-		}
-		val := out[key]
-		raw, isHex := decodeHexPKValue(val)
-		if !isHex {
-			raw = []byte(val)
-		}
-		if len(raw) >= width {
-			continue
-		}
-		padded := make([]byte, width)
-		copy(padded, raw)
-		out[key] = "0x" + strings.ToUpper(hex.EncodeToString(padded))
-		changed = true
-	}
-	return out, changed
-}
-
-// filterKeyFor finds the filter entry naming column col, preferring an exact
-// match and falling back to a case-insensitive one.
-func filterKeyFor(filter map[string]string, col string) (string, bool) {
-	if _, ok := filter[col]; ok {
-		return col, true
-	}
-	for k := range filter {
-		if strings.EqualFold(k, col) {
-			return k, true
-		}
-	}
-	return "", false
-}
-
-// decodeHexPKValue decodes the "0x"+hex spelling event.formatPKValue produces
-// for non-UTF-8 PK bytes (#1132). A value that is not in that shape is not
-// hex-encoded — it is the raw key text — and is reported as such.
-func decodeHexPKValue(s string) ([]byte, bool) {
-	if len(s) < 4 || len(s)%2 != 0 || !strings.HasPrefix(s, "0x") {
-		return nil, false
-	}
-	b, err := hex.DecodeString(s[2:])
-	if err != nil {
-		return nil, false
-	}
-	return b, true
 }
 
 var reconstructCmd = &cobra.Command{
@@ -420,20 +267,22 @@ func runReconstruct(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	baselineRow, err := reconstruct.ReadBaselineRow(cmd.Context(), baselinePath, pkFilter)
-	if err != nil {
-		return fmt.Errorf("read baseline: %w", err)
-	}
-	// A nil baselineRow (this PK absent from the snapshot) is NOT resolved here
-	// anymore: it flows past the event fetch below so the "no row found" error
-	// can be told apart from a PK-changing UPDATE that stored the row under a
-	// different (before-image) PK (#782). Baseline-only mode has no events to
-	// consult, so it keeps the original error immediately.
+	// ── Baseline-only mode ─────────────────────────────────────────────────────
+	// The index is never opened here, so no declared column widths are
+	// available and the fixed BINARY(n) pad-and-retry inside ReadBaselineRow
+	// is structurally excluded (nil metas): pass the full-width
+	// `SELECT CONCAT('0x', HEX(pk_col))` spelling (documented in
+	// docs/query-and-recovery.md). Unlike the full path below, a nil row is
+	// final immediately — there are no events to consult for the #782
+	// PK-changing-UPDATE diagnosis.
 	if recBaselineOnly {
+		baselineRow, err := reconstruct.ReadBaselineRow(cmd.Context(), baselinePath, pkFilter, nil)
+		if err != nil {
+			return fmt.Errorf("read baseline: %w", err)
+		}
 		if baselineRow == nil {
 			return fmt.Errorf("no row found in baseline %q matching pk filter %v", baselinePath, pkFilter)
 		}
-		// ── Baseline-only mode ───────────────────────────────────────────────────
 		if err := writeReconstructOutput(baselineRow, nil, snapshotTime, at, false, recFormat, os.Stdout); err != nil {
 			return err
 		}
@@ -521,12 +370,23 @@ func runReconstruct(cmd *cobra.Command, args []string) error {
 		dbName = cfg.DBName
 	}
 
-	// PK column metadata from the schema snapshot, resolved before BOTH lookups
-	// that need it: the event fetch just below (which matches
-	// binlog_events.pk_values) and the baseline retry further down (which
+	// PK column metadata from the schema snapshot in effect when the BASELINE
+	// was taken (#1159, metadata.EpochAt — not the latest snapshot, whose
+	// declared width is wrong after a PK-widening ALTER), resolved before BOTH
+	// lookups that need it: the event fetch just below (which matches
+	// binlog_events.pk_values) and the baseline read (whose internal retry
 	// matches the Parquet column). The two want the key spelled DIFFERENTLY —
-	// see indexPKSpelling and padFixedBinaryFilter (#1155).
-	pkMetas := resolvePKMetas(db, recSchema, recTable)
+	// see reconstruct.IndexPKSpelling and ReadBaselineRow (#1155/#1157).
+	pkMetas := reconstruct.ResolvePKMetasAt(db, recSchema, recTable, snapshotTime)
+
+	// A nil baselineRow (this PK absent from the snapshot) is NOT resolved here:
+	// it flows past the event fetch below so the "no row found" error can be
+	// told apart from a PK-changing UPDATE that stored the row under a
+	// different (before-image) PK (#782).
+	baselineRow, err := reconstruct.ReadBaselineRow(cmd.Context(), baselinePath, pkFilter, pkMetas)
+	if err != nil {
+		return fmt.Errorf("read baseline: %w", err)
+	}
 
 	opts := query.Options{
 		Schema: recSchema,
@@ -538,7 +398,7 @@ func runReconstruct(cmd *cobra.Command, args []string) error {
 		// that is silent and wrong rather than loud: the baseline lookup above
 		// resolves such a key, the fetch returns zero events, and ApplyAt then
 		// renders baseline-era state as the state at --at.
-		PKValues: indexPKSpelling(recPK, pkMetas),
+		PKValues: reconstruct.IndexPKSpelling(recPK, pkMetas),
 		Since:    &snapshotTime,
 		Until:    &at,
 	}
@@ -572,21 +432,8 @@ func runReconstruct(cmd *cobra.Command, args []string) error {
 	}
 	slog.Debug("fetched binlog events", "count", len(events))
 
-	// A fixed BINARY(n) key copied out of binlog_events.pk_values carries the
-	// ROW image's trailing-0x00-stripped spelling, which is SHORTER than the
-	// padded value the baseline stores. Retry once at the storage width — only
-	// after the exact lookup came back empty, so a hit is never overridden.
-	if baselineRow == nil {
-		if padded, ok := padFixedBinaryFilter(pkFilter, pkMetas); ok {
-			slog.Debug("retrying baseline lookup with the fixed BINARY(n) storage padding", "pk_filter", padded)
-			baselineRow, err = reconstruct.ReadBaselineRow(cmd.Context(), baselinePath, padded)
-			if err != nil {
-				return fmt.Errorf("read baseline: %w", err)
-			}
-		}
-	}
-
-	// Still no baseline row for this PK. Refuse — but tell a genuinely-absent
+	// No baseline row for this PK (the fixed BINARY(n) pad-and-retry already
+	// ran inside ReadBaselineRow). Refuse — but tell a genuinely-absent
 	// row apart from one whose existence traces to a PK-changing UPDATE the
 	// change map can't fold (#782): such an UPDATE is stored under its
 	// BEFORE-image PK, so a fetch by the (new) searched PK never retrieves it

--- a/internal/cli/reconstruct_binarypk_1155_test.go
+++ b/internal/cli/reconstruct_binarypk_1155_test.go
@@ -1,116 +1,15 @@
 package cli
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/dbtrail/dbtrail/internal/metadata"
 )
 
-// TestPadFixedBinaryFilter covers the retry that lets an operator paste a key
-// straight out of binlog_events.pk_values: that spelling is the ROW image's,
-// with trailing 0x00 stripped, while the baseline stores the padded value.
-func TestPadFixedBinaryFilter(t *testing.T) {
-	binary16 := metadata.ColumnMeta{Name: "k", DataType: "binary", ColumnType: "binary(16)", IsPK: true}
-
-	t.Run("stripped hex key is re-padded to the storage width", func(t *testing.T) {
-		got, changed := padFixedBinaryFilter(map[string]string{"k": "0x11223344556677889900AABB"}, []metadata.ColumnMeta{binary16})
-		if !changed {
-			t.Fatal("padFixedBinaryFilter reported no change for a short BINARY(16) key")
-		}
-		if got["k"] != "0x11223344556677889900AABB00000000" {
-			t.Errorf("padded key = %q, want %q", got["k"], "0x11223344556677889900AABB00000000")
-		}
-	})
-
-	t.Run("plain-text key is re-padded as bytes", func(t *testing.T) {
-		// pk_values stores a binary key VERBATIM when its bytes are valid
-		// UTF-8 (formatPKValue is content-gated), so the retry must handle a
-		// value with no 0x prefix too.
-		got, changed := padFixedBinaryFilter(map[string]string{"k": "AB"}, []metadata.ColumnMeta{binary16})
-		if !changed {
-			t.Fatal("padFixedBinaryFilter reported no change for a short plain-text BINARY(16) key")
-		}
-		if got["k"] != "0x41420000000000000000000000000000" {
-			t.Errorf("padded key = %q, want %q", got["k"], "0x41420000000000000000000000000000")
-		}
-	})
-
-	t.Run("full-width key is left alone", func(t *testing.T) {
-		full := "0xB2815CC3C200FF7C0102030405060780"
-		_, changed := padFixedBinaryFilter(map[string]string{"k": full}, []metadata.ColumnMeta{binary16})
-		if changed {
-			t.Error("a full-width key must not be re-spelled — the exact lookup already covers it")
-		}
-	})
-
-	t.Run("varbinary is never padded", func(t *testing.T) {
-		vb := metadata.ColumnMeta{Name: "k", DataType: "varbinary", ColumnType: "varbinary(16)", IsPK: true}
-		_, changed := padFixedBinaryFilter(map[string]string{"k": "0xAABB"}, []metadata.ColumnMeta{vb})
-		if changed {
-			t.Error("VARBINARY has no storage padding — padding it would look for a key that cannot exist")
-		}
-	})
-
-	t.Run("unknown column width is left alone", func(t *testing.T) {
-		// Pre-#212 snapshot: no COLUMN_TYPE, so the pad width is unknowable.
-		noWidth := metadata.ColumnMeta{Name: "k", DataType: "binary", IsPK: true}
-		_, changed := padFixedBinaryFilter(map[string]string{"k": "0xAABB"}, []metadata.ColumnMeta{noWidth})
-		if changed {
-			t.Error("padded a BINARY column with no declared width — the pad length would be a guess")
-		}
-	})
-
-	t.Run("column name matching is case-insensitive", func(t *testing.T) {
-		// --pk-columns is operator-typed; MySQL column names are
-		// case-insensitive and so is the DuckDB lookup that already ran, so
-		// the retry must not be the one link that cares about case.
-		got, changed := padFixedBinaryFilter(map[string]string{"K": "0xAABB"}, []metadata.ColumnMeta{binary16})
-		if !changed {
-			t.Fatal("padFixedBinaryFilter skipped a differently-cased column name")
-		}
-		if got["K"] != "0xAABB"+strings.Repeat("00", 14) {
-			t.Errorf("padded key = %q", got["K"])
-		}
-	})
-
-	t.Run("no PK metadata is a no-op", func(t *testing.T) {
-		_, changed := padFixedBinaryFilter(map[string]string{"k": "0xAABB"}, nil)
-		if changed {
-			t.Error("padFixedBinaryFilter must be inert without PK metadata")
-		}
-	})
-
-	t.Run("non-PK filter columns are untouched", func(t *testing.T) {
-		got, changed := padFixedBinaryFilter(map[string]string{"k": "0xAABB", "other": "7"}, []metadata.ColumnMeta{binary16})
-		if !changed {
-			t.Fatal("expected the BINARY column to be padded")
-		}
-		if got["other"] != "7" {
-			t.Errorf("unrelated filter column was rewritten: %q", got["other"])
-		}
-	})
-}
-
-func TestDecodeHexPKValue(t *testing.T) {
-	cases := []struct {
-		in     string
-		wantOK bool
-	}{
-		{"0xAABB", true},
-		{"0xaabb", true},
-		{"0xAAB", false}, // odd digit count is not a byte string
-		{"0xZZ", false},  // not hex
-		{"AABB", false},  // no prefix: raw key text
-		{"0x", false},    // no payload
-		{"", false},
-	}
-	for _, tc := range cases {
-		if _, ok := decodeHexPKValue(tc.in); ok != tc.wantOK {
-			t.Errorf("decodeHexPKValue(%q) ok = %v, want %v", tc.in, ok, tc.wantOK)
-		}
-	}
-}
+// The #1155 reconciler tests (padFixedBinaryFilter, IndexPKSpelling) moved to
+// internal/reconstruct with the reconcilers themselves (#1157) — see
+// internal/reconstruct/pk_filter_test.go. Only the CLI-side diagnosis helper
+// remains here.
 
 // TestUnsupportedPKType guards the #1155 misdiagnosis fix: the PK-changing-
 // UPDATE explanation may only be reached when the lookup was capable of
@@ -147,89 +46,5 @@ func TestUnsupportedPKType(t *testing.T) {
 	pg := []metadata.ColumnMeta{{Name: "id", DataType: "", ColumnType: ""}}
 	if c := unsupportedPKType(pg); c != nil {
 		t.Errorf("unsupportedPKType flagged an empty DataType (%q) — that is the PostgreSQL snapshot signature, not an unsupported type", c.Name)
-	}
-}
-
-// TestIndexPKSpelling covers the OTHER direction of the #1155 asymmetry: the
-// event fetch matches binlog_events.pk_values, which holds the ROW image's
-// spelling. An operator who produces the full-width key with
-// `SELECT CONCAT('0x', HEX(k))` would otherwise resolve the baseline row and
-// fetch ZERO events — rendering baseline-era state as the state at --at, with
-// no error. That is a fail-loud-to-fail-silent regression, so it is pinned.
-func TestIndexPKSpelling(t *testing.T) {
-	binary16 := metadata.ColumnMeta{Name: "k", DataType: "binary", ColumnType: "binary(16)", IsPK: true}
-
-	cases := []struct {
-		name  string
-		in    string
-		metas []metadata.ColumnMeta
-		want  string
-	}{
-		{
-			name:  "full-width key is trimmed to the stored spelling",
-			in:    "0x11223344556677889900AABB00000000",
-			metas: []metadata.ColumnMeta{binary16},
-			want:  "0x11223344556677889900AABB",
-		},
-		{
-			name:  "lowercase hex is uppercased to match pk_values",
-			in:    "0xb2815cc3c200ff7c0102030405060780",
-			metas: []metadata.ColumnMeta{binary16},
-			want:  "0xB2815CC3C200FF7C0102030405060780",
-		},
-		{
-			// formatPKValue is content-gated: once trimmed, printable ASCII is
-			// stored VERBATIM with no 0x prefix. Re-spelling it as hex would
-			// miss every event.
-			name:  "printable-ASCII payload becomes the verbatim spelling",
-			in:    "0x41420000000000000000000000000000",
-			metas: []metadata.ColumnMeta{binary16},
-			want:  "AB",
-		},
-		{
-			name:  "already-stored spelling is untouched",
-			in:    "0x11223344556677889900AABB",
-			metas: []metadata.ColumnMeta{binary16},
-			want:  "0x11223344556677889900AABB",
-		},
-		{
-			name:  "varbinary is never trimmed",
-			in:    "0xAABB0000",
-			metas: []metadata.ColumnMeta{{Name: "k", DataType: "varbinary", ColumnType: "varbinary(16)"}},
-			want:  "0xAABB0000",
-		},
-		{
-			name:  "non-binary PK is untouched",
-			in:    "12345",
-			metas: []metadata.ColumnMeta{{Name: "id", DataType: "int"}},
-			want:  "12345",
-		},
-		{
-			name:  "no metadata is a no-op",
-			in:    "0x11223344556677889900AABB00000000",
-			metas: nil,
-			want:  "0x11223344556677889900AABB00000000",
-		},
-		{
-			// The composite component that is NOT binary must survive verbatim,
-			// including a value that merely looks hex-ish.
-			name:  "composite key re-spells only the binary component",
-			in:    "77|0x11223344556677889900AABB00000000",
-			metas: []metadata.ColumnMeta{{Name: "tenant", DataType: "int"}, binary16},
-			want:  "77|0x11223344556677889900AABB",
-		},
-		{
-			name:  "arity mismatch leaves the value alone",
-			in:    "0x11223344556677889900AABB00000000",
-			metas: []metadata.ColumnMeta{{Name: "tenant", DataType: "int"}, binary16},
-			want:  "0x11223344556677889900AABB00000000",
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := indexPKSpelling(tc.in, tc.metas); got != tc.want {
-				t.Errorf("indexPKSpelling(%q) = %q, want %q", tc.in, got, tc.want)
-			}
-		})
 	}
 }

--- a/internal/console/reconstruct.go
+++ b/internal/console/reconstruct.go
@@ -348,9 +348,17 @@ func (s *Server) handleReconstruct(w http.ResponseWriter, r *http.Request) {
 	//    deltas, at) reconstructs it correctly. Reporting found=false before
 	//    fetching would mislabel that common case as "never existed".
 	opts := query.Options{
-		Schema:   schema,
-		Table:    table,
-		PKValues: pk,
+		Schema: schema,
+		Table:  table,
+		// The event fetch matches binlog_events.pk_values, which stores a
+		// fixed BINARY(n) key stripped of its 0x00 padding and uppercased —
+		// while the baseline lookup above reconciles the OTHER direction
+		// (re-pad). Without this respell, a lowercase or full-width hex key
+		// resolves the baseline but fetches ZERO events, and the fold silently
+		// presents baseline-era state as the state at `at` — a fail-loud to
+		// fail-silent regression (#1155's indexPKSpelling hazard, same as the
+		// CLI).
+		PKValues: reconstruct.IndexPKSpelling(pk, pkMetas),
 		Since:    &snapshotTime,
 		Until:    &atTime,
 		Order:    "", // ASC: ApplyAt/BuildHistory require chronological input.

--- a/internal/console/reconstruct.go
+++ b/internal/console/reconstruct.go
@@ -325,7 +325,15 @@ func (s *Server) handleReconstruct(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusInternalServerError, "find baseline: "+err.Error())
 		return
 	}
-	baselineRow, err := reconstruct.ReadBaselineRow(ctx, path, pkFilter)
+	// PK column metadata from the snapshot in effect when the baseline was
+	// taken (#1159), enabling the fixed BINARY(n) pad-and-retry inside
+	// ReadBaselineRow (#1155/#1157): a key copied out of the events view
+	// carries the trailing-0x00-stripped pk_values spelling, while the
+	// baseline stores the padded width — without the retry this endpoint
+	// answered "the row did not exist" for such a key while the CLI answered
+	// correctly. Best-effort: nil metas keep the exact-match behavior.
+	pkMetas := reconstruct.ResolvePKMetasAt(b.db, schema, table, snapshotTime)
+	baselineRow, err := reconstruct.ReadBaselineRow(ctx, path, pkFilter, pkMetas)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "read baseline: "+err.Error())
 		return

--- a/internal/console/reconstruct_integration_test.go
+++ b/internal/console/reconstruct_integration_test.go
@@ -397,3 +397,63 @@ func TestIntegrationReconstructBlobText(t *testing.T) {
 		t.Errorf("history[1] body = %v, want decoded 'updated bio ☃'", r.History[1].State["body"])
 	}
 }
+
+// TestIntegrationReconstructBinaryPK pins #1157 on the console surface: a fixed
+// BINARY(16) key whose stored value ends in 0x00, with NO deltas in the window,
+// must resolve from the baseline by its trailing-0x00-stripped pk_values
+// spelling — the spelling the events view displays and an operator copies.
+// Before the fix the pad-and-retry lived only in the CLI, so this endpoint
+// proceeded with baselineRow==nil into ApplyAt(nil, no deltas, at) and answered
+// found=false ("the row did not exist at that time") while `bintrail
+// reconstruct` answered correctly for the identical key.
+func TestIntegrationReconstructBinaryPK(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	// Typed snapshot rows: the declared binary(16) width is what the
+	// pad-and-retry pads to (testutil.InsertSnapshot predates column_type).
+	testutil.MustExec(t, db, `INSERT INTO schema_snapshots
+		(snapshot_id, snapshot_time, schema_name, table_name, column_name,
+		 ordinal_position, column_key, data_type, column_type, is_nullable)
+		VALUES (1, '2026-06-01 00:00:00', 'app', 'vault', 'k',   1, 'PRI', 'binary',  'binary(16)',  'NO'),
+		       (1, '2026-06-01 00:00:00', 'app', 'vault', 'val', 2, '',    'varchar', 'varchar(32)', 'YES')`)
+
+	// Baseline: the FULL storage width, padding included — what mydumper
+	// --hex-blob dumps for a BINARY(16) column (the writer decodes the 0x
+	// literal to raw bytes).
+	baseDir := t.TempDir()
+	tsDir := strings.ReplaceAll(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339), ":", "-")
+	dir := filepath.Join(baseDir, tsDir, "app")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cols := []baseline.Column{
+		{Name: "k", MySQLType: "binary", ParquetType: baseline.MysqlToParquetNode("binary")},
+		{Name: "val", MySQLType: "varchar", ParquetType: baseline.MysqlToParquetNode("varchar")},
+	}
+	w, err := baseline.NewWriter(filepath.Join(dir, "vault.parquet"), cols,
+		baseline.WriterConfig{Compression: "none", RowGroupSize: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := w.WriteRow([]string{"0x11223344556677889900AABB00000000", "sealed"}, []bool{false, false}); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	srv, err := New(Config{DB: db, DBName: dbName, Listen: "127.0.0.1:8090", Token: intToken, BaselineDir: baseDir})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The stripped pk_values spelling — 12 bytes of a 16-byte key.
+	r := reconstructAt(t, srv, "schema=app&table=vault&pk=0x11223344556677889900AABB&at=2026-06-01%2012:00:00&allow_gaps=true")
+	if !r.Found || r.Deleted {
+		t.Fatalf("stripped BINARY(16) spelling: found=%v deleted=%v, want the baseline row (#1157)", r.Found, r.Deleted)
+	}
+	if got := fmt.Sprint(r.State["val"]); got != "sealed" {
+		t.Errorf("state val=%v, want sealed", got)
+	}
+}

--- a/internal/console/reconstruct_integration_test.go
+++ b/internal/console/reconstruct_integration_test.go
@@ -4,6 +4,7 @@ package console
 
 import (
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -399,13 +400,19 @@ func TestIntegrationReconstructBlobText(t *testing.T) {
 }
 
 // TestIntegrationReconstructBinaryPK pins #1157 on the console surface: a fixed
-// BINARY(16) key whose stored value ends in 0x00, with NO deltas in the window,
-// must resolve from the baseline by its trailing-0x00-stripped pk_values
-// spelling — the spelling the events view displays and an operator copies.
-// Before the fix the pad-and-retry lived only in the CLI, so this endpoint
-// proceeded with baselineRow==nil into ApplyAt(nil, no deltas, at) and answered
-// found=false ("the row did not exist at that time") while `bintrail
-// reconstruct` answered correctly for the identical key.
+// BINARY(16) key whose stored value ends in 0x00 must resolve from the baseline
+// by its trailing-0x00-stripped pk_values spelling — the spelling the events
+// view displays and an operator copies. Before the fix the pad-and-retry lived
+// only in the CLI, so this endpoint proceeded with baselineRow==nil into
+// ApplyAt(nil, deltas, at) and answered found=false ("the row did not exist at
+// that time") while `bintrail reconstruct` answered correctly.
+//
+// The delta half is the sharper edge: the event fetch matches pk_values, which
+// wants the key spelled the OPPOSITE way from the baseline (stripped+uppercase
+// vs padded). A lowercase or full-width hex key that resolves the baseline but
+// fetches zero events would silently present baseline-era state as the state
+// at `at` — so those spellings are asserted against the DELTA-applied value,
+// which only comes back when both lookups resolve.
 func TestIntegrationReconstructBinaryPK(t *testing.T) {
 	db, dbName := testutil.CreateTestDB(t)
 	testutil.InitIndexTables(t, db)
@@ -417,6 +424,20 @@ func TestIntegrationReconstructBinaryPK(t *testing.T) {
 		 ordinal_position, column_key, data_type, column_type, is_nullable)
 		VALUES (1, '2026-06-01 00:00:00', 'app', 'vault', 'k',   1, 'PRI', 'binary',  'binary(16)',  'NO'),
 		       (1, '2026-06-01 00:00:00', 'app', 'vault', 'val', 2, '',    'varchar', 'varchar(32)', 'YES')`)
+
+	// Post-baseline UPDATE, keyed and imaged exactly as the indexer stores a
+	// binary PK: pk_values carries the stripped+uppercased 0x spelling, the
+	// row images carry the []byte value base64-encoded (marshalRow).
+	kStripped, err := hex.DecodeString("11223344556677889900AABB")
+	if err != nil {
+		t.Fatal(err)
+	}
+	kB64 := base64.StdEncoding.EncodeToString(kStripped)
+	testutil.InsertEvent(t, db, "bin.000001", 4, 40, "2026-06-01 12:00:00", nil, "app", "vault", 2,
+		"0x11223344556677889900AABB",
+		[]byte(`["val"]`),
+		[]byte(`{"k":"`+kB64+`","val":"sealed"}`),
+		[]byte(`{"k":"`+kB64+`","val":"resealed"}`))
 
 	// Baseline: the FULL storage width, padding included — what mydumper
 	// --hex-blob dumps for a BINARY(16) column (the writer decodes the 0x
@@ -448,12 +469,33 @@ func TestIntegrationReconstructBinaryPK(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// The stripped pk_values spelling — 12 bytes of a 16-byte key.
-	r := reconstructAt(t, srv, "schema=app&table=vault&pk=0x11223344556677889900AABB&at=2026-06-01%2012:00:00&allow_gaps=true")
+	// Before the delta, by the stored (stripped, uppercase) spelling: the
+	// baseline value, via the pad-and-retry.
+	r := reconstructAt(t, srv, "schema=app&table=vault&pk=0x11223344556677889900AABB&at=2026-06-01%2011:00:00&allow_gaps=true")
 	if !r.Found || r.Deleted {
 		t.Fatalf("stripped BINARY(16) spelling: found=%v deleted=%v, want the baseline row (#1157)", r.Found, r.Deleted)
 	}
 	if got := fmt.Sprint(r.State["val"]); got != "sealed" {
-		t.Errorf("state val=%v, want sealed", got)
+		t.Errorf("at 11:00: val=%v, want the baseline value sealed", got)
+	}
+
+	// After the delta, every legitimate spelling of the same key must return
+	// the DELTA-applied state. "sealed" here means the baseline resolved but
+	// the event fetch matched nothing — the silent fail-loud-to-fail-silent
+	// regression this test exists to catch: both lookups must respell, each in
+	// its own direction.
+	for name, pk := range map[string]string{
+		"stored spelling":     "0x11223344556677889900AABB",
+		"lowercase spelling":  "0x11223344556677889900aabb",
+		"full-width spelling": "0x11223344556677889900AABB00000000",
+	} {
+		r := reconstructAt(t, srv, "schema=app&table=vault&pk="+pk+"&at=2026-06-01%2013:00:00&allow_gaps=true")
+		if !r.Found || r.Deleted {
+			t.Errorf("%s at 13:00: found=%v deleted=%v, want the row", name, r.Found, r.Deleted)
+			continue
+		}
+		if got := fmt.Sprint(r.State["val"]); got != "resealed" {
+			t.Errorf("%s at 13:00: val=%v, want the delta-applied resealed (a baseline-era answer means the event fetch silently matched nothing)", name, got)
+		}
 	}
 }

--- a/internal/mcptools/reconstruct.go
+++ b/internal/mcptools/reconstruct.go
@@ -335,9 +335,18 @@ func MakeReconstructTool(cfg Config) func(context.Context, *mcp.CallToolRequest,
 		//    "never existed".
 		fmOpts := query.FetchMergedOptions{
 			Opts: query.Options{
-				Schema:   args.Schema,
-				Table:    args.Table,
-				PKValues: args.PK,
+				Schema: args.Schema,
+				Table:  args.Table,
+				// The event fetch matches binlog_events.pk_values, which
+				// stores a fixed BINARY(n) key stripped of its 0x00 padding
+				// and uppercased — while the baseline lookup above reconciles
+				// the OTHER direction (re-pad). Without this respell, a
+				// lowercase or full-width hex key resolves the baseline but
+				// fetches ZERO events, and the fold silently presents
+				// baseline-era state as the state at `at` — a fail-loud to
+				// fail-silent regression (#1155's indexPKSpelling hazard,
+				// same as the CLI).
+				PKValues: reconstruct.IndexPKSpelling(args.PK, pkMetas),
 				Since:    &snapshotTime,
 				Until:    &atTime,
 				Order:    "", // ASC: ApplyAt/BuildHistory require chronological input.

--- a/internal/mcptools/reconstruct.go
+++ b/internal/mcptools/reconstruct.go
@@ -288,7 +288,14 @@ func MakeReconstructTool(cfg Config) func(context.Context, *mcp.CallToolRequest,
 			}
 			return ErrorResult(fmt.Errorf("find baseline: %w", err)), nil, nil
 		}
-		baselineRow, err := reconstruct.ReadBaselineRow(ctx, path, pkFilter)
+		// PK column metadata from the snapshot in effect when the baseline was
+		// taken (#1159), enabling the fixed BINARY(n) pad-and-retry inside
+		// ReadBaselineRow (#1155/#1157): the pk an agent copies out of the
+		// query tool carries the trailing-0x00-stripped pk_values spelling,
+		// while the baseline stores the padded width. Best-effort: nil metas
+		// keep the exact-match behavior.
+		pkMetas := reconstruct.ResolvePKMetasAt(t.DB, args.Schema, args.Table, snapshotTime)
+		baselineRow, err := reconstruct.ReadBaselineRow(ctx, path, pkFilter, pkMetas)
 		if err != nil {
 			return ErrorResult(fmt.Errorf("read baseline: %w", err)), nil, nil
 		}

--- a/internal/mcptools/reconstruct_integration_test.go
+++ b/internal/mcptools/reconstruct_integration_test.go
@@ -292,6 +292,65 @@ func TestIntegrationReconstructToolEventCapRefused(t *testing.T) {
 	}
 }
 
+// TestIntegrationReconstructToolBinaryPK pins #1157 on the MCP surface: a fixed
+// BINARY(16) key whose stored value ends in 0x00, with NO deltas in the window,
+// must resolve from the baseline by its trailing-0x00-stripped pk_values
+// spelling — the spelling the query tool hands an agent. Before the fix the
+// pad-and-retry lived only in the CLI, so this tool proceeded with
+// baselineRow==nil into ApplyAt(nil, no deltas, at) and answered found=false
+// while `bintrail reconstruct` answered correctly for the identical key.
+func TestIntegrationReconstructToolBinaryPK(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	// Typed snapshot rows: the declared binary(16) width is what the
+	// pad-and-retry pads to (testutil.InsertSnapshot predates column_type).
+	testutil.MustExec(t, db, `INSERT INTO schema_snapshots
+		(snapshot_id, snapshot_time, schema_name, table_name, column_name,
+		 ordinal_position, column_key, data_type, column_type, is_nullable)
+		VALUES (1, '2026-06-01 00:00:00', 'app', 'vault', 'k',   1, 'PRI', 'binary',  'binary(16)',  'NO'),
+		       (1, '2026-06-01 00:00:00', 'app', 'vault', 'val', 2, '',    'varchar', 'varchar(32)', 'YES')`)
+
+	// Baseline: the FULL storage width, padding included — what mydumper
+	// --hex-blob dumps for a BINARY(16) column (the writer decodes the 0x
+	// literal to raw bytes).
+	baseDir := t.TempDir()
+	dir := filepath.Join(baseDir,
+		strings.ReplaceAll(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339), ":", "-"), "app")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cols := []baseline.Column{
+		{Name: "k", MySQLType: "binary", ParquetType: baseline.MysqlToParquetNode("binary")},
+		{Name: "val", MySQLType: "varchar", ParquetType: baseline.MysqlToParquetNode("varchar")},
+	}
+	w, err := baseline.NewWriter(filepath.Join(dir, "vault.parquet"), cols,
+		baseline.WriterConfig{Compression: "none", RowGroupSize: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := w.WriteRow([]string{"0x11223344556677889900AABB00000000", "sealed"}, []bool{false, false}); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	cs := reconstructSession(t, db, dbName)
+
+	// The stripped pk_values spelling — 12 bytes of a 16-byte key.
+	r := decodeReconstruct(t, callReconstructTool(t, cs, map[string]any{
+		"schema": "app", "table": "vault", "pk": "0x11223344556677889900AABB",
+		"at": "2026-06-01 12:00:00", "baseline_dir": baseDir, "allow_gaps": true,
+	}))
+	if !r.Found || r.Deleted {
+		t.Fatalf("stripped BINARY(16) spelling: found=%v deleted=%v, want the baseline row (#1157)", r.Found, r.Deleted)
+	}
+	if r.State["val"] != "sealed" {
+		t.Errorf("state val=%v, want sealed", r.State["val"])
+	}
+}
+
 // stampCaptureGap records a PERMANENT capture loss (#765) in stream_state — the
 // state `bintrail status` renders as "GAP LOST": events that no longer exist in
 // live MySQL, in an archive, or anywhere else.

--- a/internal/mcptools/reconstruct_integration_test.go
+++ b/internal/mcptools/reconstruct_integration_test.go
@@ -5,6 +5,8 @@ package mcptools
 import (
 	"context"
 	"database/sql"
+	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -293,12 +295,18 @@ func TestIntegrationReconstructToolEventCapRefused(t *testing.T) {
 }
 
 // TestIntegrationReconstructToolBinaryPK pins #1157 on the MCP surface: a fixed
-// BINARY(16) key whose stored value ends in 0x00, with NO deltas in the window,
-// must resolve from the baseline by its trailing-0x00-stripped pk_values
-// spelling — the spelling the query tool hands an agent. Before the fix the
-// pad-and-retry lived only in the CLI, so this tool proceeded with
-// baselineRow==nil into ApplyAt(nil, no deltas, at) and answered found=false
-// while `bintrail reconstruct` answered correctly for the identical key.
+// BINARY(16) key whose stored value ends in 0x00 must resolve from the baseline
+// by its trailing-0x00-stripped pk_values spelling — the spelling the query
+// tool hands an agent. Before the fix the pad-and-retry lived only in the CLI,
+// so this tool proceeded with baselineRow==nil into ApplyAt(nil, deltas, at)
+// and answered found=false while `bintrail reconstruct` answered correctly.
+//
+// The delta half is the sharper edge: the event fetch matches pk_values, which
+// wants the key spelled the OPPOSITE way from the baseline (stripped+uppercase
+// vs padded). A lowercase or full-width hex key that resolves the baseline but
+// fetches zero events would silently present baseline-era state as the state
+// at `at` — so those spellings are asserted against the DELTA-applied value,
+// which only comes back when both lookups resolve.
 func TestIntegrationReconstructToolBinaryPK(t *testing.T) {
 	db, dbName := testutil.CreateTestDB(t)
 	testutil.InitIndexTables(t, db)
@@ -310,6 +318,20 @@ func TestIntegrationReconstructToolBinaryPK(t *testing.T) {
 		 ordinal_position, column_key, data_type, column_type, is_nullable)
 		VALUES (1, '2026-06-01 00:00:00', 'app', 'vault', 'k',   1, 'PRI', 'binary',  'binary(16)',  'NO'),
 		       (1, '2026-06-01 00:00:00', 'app', 'vault', 'val', 2, '',    'varchar', 'varchar(32)', 'YES')`)
+
+	// Post-baseline UPDATE, keyed and imaged exactly as the indexer stores a
+	// binary PK: pk_values carries the stripped+uppercased 0x spelling, the
+	// row images carry the []byte value base64-encoded (marshalRow).
+	kStripped, err := hex.DecodeString("11223344556677889900AABB")
+	if err != nil {
+		t.Fatal(err)
+	}
+	kB64 := base64.StdEncoding.EncodeToString(kStripped)
+	testutil.InsertEvent(t, db, "bin.000001", 4, 40, "2026-06-01 12:00:00", nil, "app", "vault", 2,
+		"0x11223344556677889900AABB",
+		[]byte(`["val"]`),
+		[]byte(`{"k":"`+kB64+`","val":"sealed"}`),
+		[]byte(`{"k":"`+kB64+`","val":"resealed"}`))
 
 	// Baseline: the FULL storage width, padding included — what mydumper
 	// --hex-blob dumps for a BINARY(16) column (the writer decodes the 0x
@@ -338,16 +360,40 @@ func TestIntegrationReconstructToolBinaryPK(t *testing.T) {
 
 	cs := reconstructSession(t, db, dbName)
 
-	// The stripped pk_values spelling — 12 bytes of a 16-byte key.
+	// Before the delta, by the stored (stripped, uppercase) spelling: the
+	// baseline value, via the pad-and-retry.
 	r := decodeReconstruct(t, callReconstructTool(t, cs, map[string]any{
 		"schema": "app", "table": "vault", "pk": "0x11223344556677889900AABB",
-		"at": "2026-06-01 12:00:00", "baseline_dir": baseDir, "allow_gaps": true,
+		"at": "2026-06-01 11:00:00", "baseline_dir": baseDir, "allow_gaps": true,
 	}))
 	if !r.Found || r.Deleted {
 		t.Fatalf("stripped BINARY(16) spelling: found=%v deleted=%v, want the baseline row (#1157)", r.Found, r.Deleted)
 	}
 	if r.State["val"] != "sealed" {
-		t.Errorf("state val=%v, want sealed", r.State["val"])
+		t.Errorf("at 11:00: val=%v, want the baseline value sealed", r.State["val"])
+	}
+
+	// After the delta, every legitimate spelling of the same key must return
+	// the DELTA-applied state. "sealed" here means the baseline resolved but
+	// the event fetch matched nothing — the silent fail-loud-to-fail-silent
+	// regression this test exists to catch: both lookups must respell, each in
+	// its own direction.
+	for name, pk := range map[string]string{
+		"stored spelling":     "0x11223344556677889900AABB",
+		"lowercase spelling":  "0x11223344556677889900aabb",
+		"full-width spelling": "0x11223344556677889900AABB00000000",
+	} {
+		r := decodeReconstruct(t, callReconstructTool(t, cs, map[string]any{
+			"schema": "app", "table": "vault", "pk": pk,
+			"at": "2026-06-01 13:00:00", "baseline_dir": baseDir, "allow_gaps": true,
+		}))
+		if !r.Found || r.Deleted {
+			t.Errorf("%s at 13:00: found=%v deleted=%v, want the row", name, r.Found, r.Deleted)
+			continue
+		}
+		if r.State["val"] != "resealed" {
+			t.Errorf("%s at 13:00: val=%v, want the delta-applied resealed (a baseline-era answer means the event fetch silently matched nothing)", name, r.State["val"])
+		}
 	}
 }
 

--- a/internal/pgstreamrun/typematrix_fold_integration_test.go
+++ b/internal/pgstreamrun/typematrix_fold_integration_test.go
@@ -338,7 +338,7 @@ func TestOne_PGTypeMatrixThroughReconstructFold(t *testing.T) {
 
 			fold := func(id string, wantEvents int) string {
 				t.Helper()
-				row, err := reconstruct.ReadBaselineRow(ctx, path, map[string]string{"id": id})
+				row, err := reconstruct.ReadBaselineRow(ctx, path, map[string]string{"id": id}, nil)
 				if err != nil {
 					t.Fatalf("ReadBaselineRow id=%s: %v", id, err)
 				}

--- a/internal/reconstruct/baseline.go
+++ b/internal/reconstruct/baseline.go
@@ -18,6 +18,7 @@ import (
 	"github.com/dbtrail/dbtrail/internal/baseline"
 	"github.com/dbtrail/dbtrail/internal/baselineintegrity"
 	"github.com/dbtrail/dbtrail/internal/duckdbutil"
+	"github.com/dbtrail/dbtrail/internal/metadata"
 )
 
 // ErrNoBaseline is returned by FindBaseline when no baseline snapshot exists
@@ -58,8 +59,30 @@ func FindBaseline(ctx context.Context, source, schema, table string, at time.Tim
 // ReadBaselineRow opens the Parquet file at path using DuckDB and returns the
 // first row matching pkFilter (column name → value string). Returns nil when
 // no row matches. Loads the httpfs extension automatically for s3:// paths.
-func ReadBaselineRow(ctx context.Context, path string, pkFilter map[string]string) (map[string]any, error) {
+//
+// pkMetas, when non-empty, are the searched table's primary-key column metas
+// (see ResolvePKMetasAt) and enable the fixed BINARY(n) reconciliation
+// (#1155/#1157): a key copied out of binlog_events.pk_values carries the ROW
+// image's trailing-0x00-stripped spelling, which is SHORTER than the padded
+// value the baseline stores, so after an exact miss the lookup is retried once
+// with every fixed BINARY(n) component re-padded to its declared width. The
+// retry runs only on a miss, so it can never override a correct hit. Callers
+// with no index open — and therefore no declared column widths — pass nil and
+// keep the exact-match-only behavior.
+func ReadBaselineRow(ctx context.Context, path string, pkFilter map[string]string, pkMetas []metadata.ColumnMeta) (map[string]any, error) {
 	rows, err := ReadBaselineRows(ctx, path, pkFilter, 1)
+	if err != nil {
+		return nil, err
+	}
+	if len(rows) > 0 {
+		return rows[0], nil
+	}
+	padded, changed := padFixedBinaryFilter(pkFilter, pkMetas)
+	if !changed {
+		return nil, nil
+	}
+	slog.Debug("retrying baseline lookup with the fixed BINARY(n) storage padding", "pk_filter", padded)
+	rows, err = ReadBaselineRows(ctx, path, padded, 1)
 	if err != nil || len(rows) == 0 {
 		return nil, err
 	}

--- a/internal/reconstruct/baseline_tz_test.go
+++ b/internal/reconstruct/baseline_tz_test.go
@@ -76,7 +76,7 @@ func runTemporalPKBaselineChild(t *testing.T) {
 			t.Fatalf("%s Close: %v", tc.name, err)
 		}
 
-		row, err := ReadBaselineRow(ctx, path, map[string]string{"k": tc.pkVal})
+		row, err := ReadBaselineRow(ctx, path, map[string]string{"k": tc.pkVal}, nil)
 		if err != nil {
 			t.Fatalf("%s ReadBaselineRow: %v", tc.name, err)
 		}

--- a/internal/reconstruct/binarypk_1155_integration_test.go
+++ b/internal/reconstruct/binarypk_1155_integration_test.go
@@ -222,9 +222,15 @@ func TestBinaryPKBaselineJoin_endToEnd(t *testing.T) {
 		}
 		path := filepath.Join(baselineDir, sourceName, "bp.parquet")
 
-		// The stripped spelling cannot match the padded baseline value — that
-		// is precisely why the CLI re-pads and retries (padFixedBinaryFilter).
-		row, err := reconstruct.ReadBaselineRow(ctx, path, map[string]string{"k": stored})
+		tm, err := res.Resolve(sourceName, "bp")
+		if err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		pkMetas := tm.PKColumnMetas()
+
+		// The stripped spelling cannot match the padded baseline value exactly
+		// — with nil metas (no declared width) the lookup stays a miss.
+		row, err := reconstruct.ReadBaselineRow(ctx, path, map[string]string{"k": stored}, nil)
 		if err != nil {
 			t.Fatalf("ReadBaselineRow: %v", err)
 		}
@@ -232,14 +238,25 @@ func TestBinaryPKBaselineJoin_endToEnd(t *testing.T) {
 			t.Log("note: the stored spelling resolved directly — this key had no trailing padding")
 		}
 
-		// Padded to the storage width it must resolve. Before #1155 this
-		// failed too: the 0x… string was bound as text against a BLOB column.
+		// With the PK metas, ReadBaselineRow's own pad-and-retry (#1157) must
+		// resolve the stripped spelling — the same reconciliation every
+		// surface (CLI, console, MCP) now gets.
+		row, err = reconstruct.ReadBaselineRow(ctx, path, map[string]string{"k": stored}, pkMetas)
+		if err != nil {
+			t.Fatalf("ReadBaselineRow (metas): %v", err)
+		}
+		if row == nil {
+			t.Fatalf("no baseline row for the stored pk_values spelling %s with PK metas — the pad-and-retry did not run (#1157)", stored)
+		}
+
+		// Padded to the storage width it must resolve too. Before #1155 this
+		// failed as well: the 0x… string was bound as text against a BLOB column.
 		var padded string
 		if err := sourceDB.QueryRow(`SELECT CONCAT('0x', HEX(k)) FROM bp
 			WHERE CONCAT('0x', UPPER(HEX(k))) LIKE CONCAT(?, '%')`, stored).Scan(&padded); err != nil {
 			t.Fatalf("read padded key from source: %v", err)
 		}
-		row, err = reconstruct.ReadBaselineRow(ctx, path, map[string]string{"k": padded})
+		row, err = reconstruct.ReadBaselineRow(ctx, path, map[string]string{"k": padded}, pkMetas)
 		if err != nil {
 			t.Fatalf("ReadBaselineRow (padded): %v", err)
 		}

--- a/internal/reconstruct/binarypk_1155_test.go
+++ b/internal/reconstruct/binarypk_1155_test.go
@@ -215,7 +215,7 @@ func TestReadBaselineRow_binaryPKHexSpelling(t *testing.T) {
 	}
 
 	// The spelling an operator copies out of binlog_events.pk_values.
-	row, err := ReadBaselineRow(ctx, path, map[string]string{"k": "0xB2815CC3C200FF7C0102030405060780"})
+	row, err := ReadBaselineRow(ctx, path, map[string]string{"k": "0xB2815CC3C200FF7C0102030405060780"}, nil)
 	if err != nil {
 		t.Fatalf("ReadBaselineRow: %v", err)
 	}
@@ -228,7 +228,7 @@ func TestReadBaselineRow_binaryPKHexSpelling(t *testing.T) {
 
 	// Lowercase must resolve too — an operator pasting a key from another tool
 	// should not silently get "row not found".
-	row, err = ReadBaselineRow(ctx, path, map[string]string{"k": "0xb2815cc3c200ff7c0102030405060780"})
+	row, err = ReadBaselineRow(ctx, path, map[string]string{"k": "0xb2815cc3c200ff7c0102030405060780"}, nil)
 	if err != nil {
 		t.Fatalf("ReadBaselineRow (lowercase): %v", err)
 	}
@@ -240,7 +240,7 @@ func TestReadBaselineRow_binaryPKHexSpelling(t *testing.T) {
 	// matched as literal text. Decoding by value shape alone (rather than by
 	// the column's actual Parquet type) would silently look for the two bytes
 	// {0x41,0x42} here and return the wrong answer.
-	row, err = ReadBaselineRow(ctx, path, map[string]string{"txt": "0x4142"})
+	row, err = ReadBaselineRow(ctx, path, map[string]string{"txt": "0x4142"}, nil)
 	if err != nil {
 		t.Fatalf("ReadBaselineRow (varchar control): %v", err)
 	}
@@ -250,7 +250,7 @@ func TestReadBaselineRow_binaryPKHexSpelling(t *testing.T) {
 
 	// Control: a bytes-valued key that is NOT present must still miss. Guards
 	// against a decode that accidentally widens the predicate.
-	row, err = ReadBaselineRow(ctx, path, map[string]string{"k": "0xDEADBEEF"})
+	row, err = ReadBaselineRow(ctx, path, map[string]string{"k": "0xDEADBEEF"}, nil)
 	if err != nil {
 		t.Fatalf("ReadBaselineRow (absent): %v", err)
 	}
@@ -263,7 +263,7 @@ func TestReadBaselineRow_binaryPKHexSpelling(t *testing.T) {
 	// must be too. Keyed exactly, a differently-cased --pk-columns binds the
 	// hex as text against a BLOB and silently misses: the one link that cares
 	// about case, on the one PK type this change added.
-	row, err = ReadBaselineRow(ctx, path, map[string]string{"K": "0xB2815CC3C200FF7C0102030405060780"})
+	row, err = ReadBaselineRow(ctx, path, map[string]string{"K": "0xB2815CC3C200FF7C0102030405060780"}, nil)
 	if err != nil {
 		t.Fatalf("ReadBaselineRow (mixed-case column): %v", err)
 	}
@@ -325,7 +325,7 @@ func TestReadBaselineRow_binaryHexTextSymmetry(t *testing.T) {
 	}
 
 	// And the round trip closes: the same spelling an operator types resolves.
-	row, err := ReadBaselineRow(ctx, path, map[string]string{"k": "0xDEADBEEF"})
+	row, err := ReadBaselineRow(ctx, path, map[string]string{"k": "0xDEADBEEF"}, nil)
 	if err != nil {
 		t.Fatalf("ReadBaselineRow: %v", err)
 	}

--- a/internal/reconstruct/pk_filter.go
+++ b/internal/reconstruct/pk_filter.go
@@ -1,0 +1,184 @@
+package reconstruct
+
+import (
+	"database/sql"
+	"encoding/hex"
+	"log/slog"
+	"maps"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/dbtrail/dbtrail/internal/metadata"
+)
+
+// This file holds the two reconcilers for the one spelling asymmetry a fixed
+// BINARY(n) primary key has (#1155), plus the metadata resolution they need.
+// They moved here from internal/cli (#1157) so every ReadBaselineRow caller —
+// the CLI, the console's /api/reconstruct, and the MCP reconstruct tool —
+// resolves such a key instead of only the CLI.
+//
+// The two run in OPPOSITE directions on purpose, because they target different
+// stores — do not "unify" them:
+//
+//   - IndexPKSpelling TRIMS: binlog_events.pk_values holds the ROW image's
+//     spelling, with every trailing 0x00 stripped.
+//   - padFixedBinaryFilter RE-PADS: the baseline Parquet holds the full n
+//     bytes MySQL padded on storage.
+
+// ResolvePKMetasAt loads schema.table's primary-key column metadata from the
+// schema snapshot in effect at `at` — metadata.EpochAt over the snapshot
+// history, the same per-instant rule the ENUM/SET decode path uses (#475) —
+// rather than from the latest snapshot (#1159). The metas' declared widths
+// drive padFixedBinaryFilter, so the anchor should be the instant whose schema
+// produced the bytes being matched: callers pass the BASELINE snapshot time,
+// because the pad must reach the width the baseline file actually stores. A
+// latest-snapshot width is wrong whenever the column was widened after that
+// instant (BINARY(16) → BINARY(32)): the retry would pad to 32 against a
+// 16-byte stored value and miss silently.
+//
+// When the instant predates every snapshot, EpochAt answers the FIRST epoch —
+// the closest available description; with no epoch history at all, the latest
+// snapshot is used.
+//
+// Best-effort by design: every caller only uses the result to IMPROVE a lookup
+// or an error message, so a missing/unreadable snapshot degrades to nil (no
+// reconciliation — the pre-#1155 behavior) instead of failing a reconstruct
+// that would otherwise have worked.
+func ResolvePKMetasAt(db *sql.DB, schema, table string, at time.Time) []metadata.ColumnMeta {
+	snapshotID := 0 // latest, when the epoch history is unavailable
+	if epochs, err := metadata.LoadSnapshotEpochs(db); err != nil {
+		slog.Debug("could not load schema snapshot epochs for PK metadata; using the latest snapshot", "error", err)
+	} else if id, ok := metadata.EpochAt(epochs, at); ok {
+		snapshotID = id
+	}
+	res, err := metadata.NewResolver(db, snapshotID)
+	if err != nil {
+		slog.Debug("could not load schema snapshot for PK metadata", "error", err)
+		return nil
+	}
+	tm, err := res.Resolve(schema, table)
+	if err != nil {
+		slog.Debug("could not resolve table for PK metadata", "error", err)
+		return nil
+	}
+	return tm.PKColumnMetas()
+}
+
+// IndexPKSpelling rewrites a user-supplied PK value into the spelling the
+// indexer stored in binlog_events.pk_values, so an event fetch matches what
+// the operator typed.
+//
+// Only fixed-width BINARY(n) components are touched, and this is the INVERSE
+// of padFixedBinaryFilter — the two run in opposite directions on purpose,
+// because they target different stores. Reproducing event.formatPKValue
+// exactly: trailing 0x00 padding is stripped (the ROW image never carries it),
+// and the hex is uppercased, but ONLY when the trimmed bytes are not valid
+// UTF-8 — formatPKValue is content-gated, so a binary key whose bytes are
+// printable ASCII is stored verbatim and must stay that way.
+//
+// Everything else — every other column type, and every component that is
+// already in the stored spelling — is returned untouched, so this cannot
+// disturb a lookup that resolves today.
+func IndexPKSpelling(pk string, pkMetas []metadata.ColumnMeta) string {
+	if pk == "" || len(pkMetas) == 0 {
+		return pk
+	}
+	parts := strings.Split(pk, "|")
+	if len(parts) != len(pkMetas) {
+		// The pk/pk-columns arity is validated against the caller's column
+		// list, not against the snapshot; if the two disagree, leave the
+		// value alone rather than re-spell the wrong component.
+		return pk
+	}
+	changed := false
+	for i, c := range pkMetas {
+		if !strings.EqualFold(strings.TrimSpace(c.DataType), "binary") {
+			continue
+		}
+		raw, isHex := decodeHexPKLiteral(parts[i])
+		if !isHex {
+			continue // already the verbatim/stored spelling
+		}
+		trimmed := TrimFixedBinaryPad(raw)
+		var spelled string
+		if utf8.Valid(trimmed) {
+			spelled = string(trimmed)
+		} else {
+			spelled = "0x" + strings.ToUpper(hex.EncodeToString(trimmed))
+		}
+		if spelled != parts[i] {
+			parts[i] = spelled
+			changed = true
+		}
+	}
+	if !changed {
+		return pk
+	}
+	return strings.Join(parts, "|")
+}
+
+// padFixedBinaryFilter re-spells a fixed-width BINARY(n) filter value back to
+// the width the baseline stores, returning false when nothing needs re-spelling.
+//
+// This is the INVERSE of TrimFixedBinaryPad, and the direction is deliberate:
+// pk_values holds the binlog ROW image's spelling, which has every trailing
+// 0x00 stripped, while the baseline Parquet holds the full n bytes MySQL
+// padded on storage. An operator who copies a key out of the index — the
+// workflow #1155 reports — therefore hands us a value SHORTER than the one to
+// match. Re-padding it is exact (MySQL only ever pads a BINARY(n) with 0x00),
+// and ReadBaselineRow only ever attempts it after an exact lookup already came
+// back empty, so it cannot turn a correct hit into a different row.
+func padFixedBinaryFilter(pkFilter map[string]string, pkMetas []metadata.ColumnMeta) (map[string]string, bool) {
+	out := make(map[string]string, len(pkFilter))
+	maps.Copy(out, pkFilter)
+	changed := false
+	for _, c := range pkMetas {
+		if !strings.EqualFold(strings.TrimSpace(c.DataType), "binary") {
+			continue
+		}
+		width := FixedBinaryWidth(c.ColumnType)
+		if width == 0 {
+			// Pre-#212 snapshot with no COLUMN_TYPE: the pad width is
+			// unknowable, so leave the value alone rather than guess.
+			continue
+		}
+		// Filter keys are operator-typed and MySQL column names are
+		// case-insensitive, so an exact-only match would silently skip the
+		// retry for column name `K` against snapshot column `k`. (The lookup
+		// underneath is case-insensitive on both links since #1155: DuckDB
+		// resolves the quoted identifier, and parquetBlobColumns is keyed
+		// lowercase.)
+		key, ok := filterKeyFor(out, c.Name)
+		if !ok {
+			continue
+		}
+		val := out[key]
+		raw, isHex := decodeHexPKLiteral(val)
+		if !isHex {
+			raw = []byte(val)
+		}
+		if len(raw) >= width {
+			continue
+		}
+		padded := make([]byte, width)
+		copy(padded, raw)
+		out[key] = "0x" + strings.ToUpper(hex.EncodeToString(padded))
+		changed = true
+	}
+	return out, changed
+}
+
+// filterKeyFor finds the filter entry naming column col, preferring an exact
+// match and falling back to a case-insensitive one.
+func filterKeyFor(filter map[string]string, col string) (string, bool) {
+	if _, ok := filter[col]; ok {
+		return col, true
+	}
+	for k := range filter {
+		if strings.EqualFold(k, col) {
+			return k, true
+		}
+	}
+	return "", false
+}

--- a/internal/reconstruct/pk_filter_test.go
+++ b/internal/reconstruct/pk_filter_test.go
@@ -1,0 +1,299 @@
+package reconstruct
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/baseline"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+)
+
+// These tests moved here from internal/cli with the reconcilers themselves
+// (#1157): padFixedBinaryFilter and IndexPKSpelling now live beside
+// ReadBaselineRow so every surface — CLI, console, MCP — shares one
+// implementation.
+
+// TestPadFixedBinaryFilter covers the retry that lets an operator paste a key
+// straight out of binlog_events.pk_values: that spelling is the ROW image's,
+// with trailing 0x00 stripped, while the baseline stores the padded value.
+func TestPadFixedBinaryFilter(t *testing.T) {
+	binary16 := metadata.ColumnMeta{Name: "k", DataType: "binary", ColumnType: "binary(16)", IsPK: true}
+
+	t.Run("stripped hex key is re-padded to the storage width", func(t *testing.T) {
+		got, changed := padFixedBinaryFilter(map[string]string{"k": "0x11223344556677889900AABB"}, []metadata.ColumnMeta{binary16})
+		if !changed {
+			t.Fatal("padFixedBinaryFilter reported no change for a short BINARY(16) key")
+		}
+		if got["k"] != "0x11223344556677889900AABB00000000" {
+			t.Errorf("padded key = %q, want %q", got["k"], "0x11223344556677889900AABB00000000")
+		}
+	})
+
+	t.Run("plain-text key is re-padded as bytes", func(t *testing.T) {
+		// pk_values stores a binary key VERBATIM when its bytes are valid
+		// UTF-8 (formatPKValue is content-gated), so the retry must handle a
+		// value with no 0x prefix too.
+		got, changed := padFixedBinaryFilter(map[string]string{"k": "AB"}, []metadata.ColumnMeta{binary16})
+		if !changed {
+			t.Fatal("padFixedBinaryFilter reported no change for a short plain-text BINARY(16) key")
+		}
+		if got["k"] != "0x41420000000000000000000000000000" {
+			t.Errorf("padded key = %q, want %q", got["k"], "0x41420000000000000000000000000000")
+		}
+	})
+
+	t.Run("full-width key is left alone", func(t *testing.T) {
+		full := "0xB2815CC3C200FF7C0102030405060780"
+		_, changed := padFixedBinaryFilter(map[string]string{"k": full}, []metadata.ColumnMeta{binary16})
+		if changed {
+			t.Error("a full-width key must not be re-spelled — the exact lookup already covers it")
+		}
+	})
+
+	t.Run("varbinary is never padded", func(t *testing.T) {
+		vb := metadata.ColumnMeta{Name: "k", DataType: "varbinary", ColumnType: "varbinary(16)", IsPK: true}
+		_, changed := padFixedBinaryFilter(map[string]string{"k": "0xAABB"}, []metadata.ColumnMeta{vb})
+		if changed {
+			t.Error("VARBINARY has no storage padding — padding it would look for a key that cannot exist")
+		}
+	})
+
+	t.Run("unknown column width is left alone", func(t *testing.T) {
+		// Pre-#212 snapshot: no COLUMN_TYPE, so the pad width is unknowable.
+		noWidth := metadata.ColumnMeta{Name: "k", DataType: "binary", IsPK: true}
+		_, changed := padFixedBinaryFilter(map[string]string{"k": "0xAABB"}, []metadata.ColumnMeta{noWidth})
+		if changed {
+			t.Error("padded a BINARY column with no declared width — the pad length would be a guess")
+		}
+	})
+
+	t.Run("column name matching is case-insensitive", func(t *testing.T) {
+		// Filter keys are operator-typed; MySQL column names are
+		// case-insensitive and so is the DuckDB lookup that already ran, so
+		// the retry must not be the one link that cares about case.
+		got, changed := padFixedBinaryFilter(map[string]string{"K": "0xAABB"}, []metadata.ColumnMeta{binary16})
+		if !changed {
+			t.Fatal("padFixedBinaryFilter skipped a differently-cased column name")
+		}
+		if got["K"] != "0xAABB"+strings.Repeat("00", 14) {
+			t.Errorf("padded key = %q", got["K"])
+		}
+	})
+
+	t.Run("no PK metadata is a no-op", func(t *testing.T) {
+		_, changed := padFixedBinaryFilter(map[string]string{"k": "0xAABB"}, nil)
+		if changed {
+			t.Error("padFixedBinaryFilter must be inert without PK metadata")
+		}
+	})
+
+	t.Run("non-PK filter columns are untouched", func(t *testing.T) {
+		got, changed := padFixedBinaryFilter(map[string]string{"k": "0xAABB", "other": "7"}, []metadata.ColumnMeta{binary16})
+		if !changed {
+			t.Fatal("expected the BINARY column to be padded")
+		}
+		if got["other"] != "7" {
+			t.Errorf("unrelated filter column was rewritten: %q", got["other"])
+		}
+	})
+}
+
+// TestIndexPKSpelling covers the OTHER direction of the #1155 asymmetry: the
+// event fetch matches binlog_events.pk_values, which holds the ROW image's
+// spelling. An operator who produces the full-width key with
+// `SELECT CONCAT('0x', HEX(k))` would otherwise resolve the baseline row and
+// fetch ZERO events — rendering baseline-era state as the state at --at, with
+// no error. That is a fail-loud-to-fail-silent regression, so it is pinned.
+func TestIndexPKSpelling(t *testing.T) {
+	binary16 := metadata.ColumnMeta{Name: "k", DataType: "binary", ColumnType: "binary(16)", IsPK: true}
+
+	cases := []struct {
+		name  string
+		in    string
+		metas []metadata.ColumnMeta
+		want  string
+	}{
+		{
+			name:  "full-width key is trimmed to the stored spelling",
+			in:    "0x11223344556677889900AABB00000000",
+			metas: []metadata.ColumnMeta{binary16},
+			want:  "0x11223344556677889900AABB",
+		},
+		{
+			name:  "lowercase hex is uppercased to match pk_values",
+			in:    "0xb2815cc3c200ff7c0102030405060780",
+			metas: []metadata.ColumnMeta{binary16},
+			want:  "0xB2815CC3C200FF7C0102030405060780",
+		},
+		{
+			// formatPKValue is content-gated: once trimmed, printable ASCII is
+			// stored VERBATIM with no 0x prefix. Re-spelling it as hex would
+			// miss every event.
+			name:  "printable-ASCII payload becomes the verbatim spelling",
+			in:    "0x41420000000000000000000000000000",
+			metas: []metadata.ColumnMeta{binary16},
+			want:  "AB",
+		},
+		{
+			name:  "already-stored spelling is untouched",
+			in:    "0x11223344556677889900AABB",
+			metas: []metadata.ColumnMeta{binary16},
+			want:  "0x11223344556677889900AABB",
+		},
+		{
+			name:  "varbinary is never trimmed",
+			in:    "0xAABB0000",
+			metas: []metadata.ColumnMeta{{Name: "k", DataType: "varbinary", ColumnType: "varbinary(16)"}},
+			want:  "0xAABB0000",
+		},
+		{
+			name:  "non-binary PK is untouched",
+			in:    "12345",
+			metas: []metadata.ColumnMeta{{Name: "id", DataType: "int"}},
+			want:  "12345",
+		},
+		{
+			name:  "no metadata is a no-op",
+			in:    "0x11223344556677889900AABB00000000",
+			metas: nil,
+			want:  "0x11223344556677889900AABB00000000",
+		},
+		{
+			// The composite component that is NOT binary must survive verbatim,
+			// including a value that merely looks hex-ish.
+			name:  "composite key re-spells only the binary component",
+			in:    "77|0x11223344556677889900AABB00000000",
+			metas: []metadata.ColumnMeta{{Name: "tenant", DataType: "int"}, binary16},
+			want:  "77|0x11223344556677889900AABB",
+		},
+		{
+			name:  "arity mismatch leaves the value alone",
+			in:    "0x11223344556677889900AABB00000000",
+			metas: []metadata.ColumnMeta{{Name: "tenant", DataType: "int"}, binary16},
+			want:  "0x11223344556677889900AABB00000000",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IndexPKSpelling(tc.in, tc.metas); got != tc.want {
+				t.Errorf("IndexPKSpelling(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDecodeHexPKLiteral(t *testing.T) {
+	cases := []struct {
+		in     string
+		wantOK bool
+	}{
+		{"0xAABB", true},
+		{"0xaabb", true},
+		{"0xAAB", false}, // odd digit count is not a byte string
+		{"0xZZ", false},  // not hex
+		{"AABB", false},  // no prefix: raw key text
+		{"0x", false},    // no payload
+		{"", false},
+	}
+	for _, tc := range cases {
+		if _, ok := decodeHexPKLiteral(tc.in); ok != tc.wantOK {
+			t.Errorf("decodeHexPKLiteral(%q) ok = %v, want %v", tc.in, ok, tc.wantOK)
+		}
+	}
+}
+
+// TestReadBaselineRow_fixedBinaryPadRetry pins the #1157 fix at its new home:
+// the pad-and-retry runs INSIDE ReadBaselineRow, so every caller that supplies
+// PK metas — the CLI, the console's /api/reconstruct, the MCP reconstruct tool
+// — resolves a fixed BINARY(n) key by its stripped pk_values spelling, and a
+// caller that cannot supply them (nil metas) keeps the exact-match behavior.
+func TestReadBaselineRow_fixedBinaryPadRetry(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	cols := []baseline.Column{
+		{Name: "k", MySQLType: "binary", ParquetType: baseline.MysqlToParquetNode("binary")},
+		{Name: "v", MySQLType: "varchar", ParquetType: baseline.MysqlToParquetNode("varchar")},
+	}
+	path := filepath.Join(dir, "padded.parquet")
+	w, err := baseline.NewWriter(path, cols, baseline.WriterConfig{Compression: "none", RowGroupSize: 100})
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	// The baseline holds the FULL storage width, padding included — what
+	// mydumper --hex-blob dumps for a BINARY(16) column.
+	rows := [][]string{
+		{"0x11223344556677889900AABB00000000", "hit"},
+		{"0x41420000000000000000000000000000", "ascii"},
+	}
+	for _, r := range rows {
+		if err := w.WriteRow(r, []bool{false, false}); err != nil {
+			t.Fatalf("WriteRow: %v", err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	metas := []metadata.ColumnMeta{{Name: "k", DataType: "binary", ColumnType: "binary(16)", IsPK: true}}
+	stripped := "0x11223344556677889900AABB" // the pk_values spelling: padding stripped
+
+	t.Run("stripped spelling resolves with PK metas", func(t *testing.T) {
+		row, err := ReadBaselineRow(ctx, path, map[string]string{"k": stripped}, metas)
+		if err != nil {
+			t.Fatalf("ReadBaselineRow: %v", err)
+		}
+		if row == nil {
+			t.Fatal("no baseline row for the stripped BINARY(16) spelling — the pad-and-retry did not run (#1157)")
+		}
+		if row["v"] != "hit" {
+			t.Errorf("matched the wrong row: v=%v", row["v"])
+		}
+	})
+
+	t.Run("nil metas keep the exact-match-only behavior", func(t *testing.T) {
+		// The structural exclusion (--baseline-only, the shim) must stay a
+		// miss, not become a guess.
+		row, err := ReadBaselineRow(ctx, path, map[string]string{"k": stripped}, nil)
+		if err != nil {
+			t.Fatalf("ReadBaselineRow: %v", err)
+		}
+		if row != nil {
+			t.Errorf("stripped spelling resolved WITHOUT metas: %v — the retry must require a declared width", row)
+		}
+	})
+
+	t.Run("verbatim ASCII spelling resolves with PK metas", func(t *testing.T) {
+		// formatPKValue stores printable payloads verbatim, so "AB" is the
+		// spelling an operator copies for the second row.
+		row, err := ReadBaselineRow(ctx, path, map[string]string{"k": "AB"}, metas)
+		if err != nil {
+			t.Fatalf("ReadBaselineRow: %v", err)
+		}
+		if row == nil || row["v"] != "ascii" {
+			t.Errorf("verbatim spelling did not resolve, got %v", row)
+		}
+	})
+
+	t.Run("full-width spelling still resolves exactly", func(t *testing.T) {
+		row, err := ReadBaselineRow(ctx, path, map[string]string{"k": "0x11223344556677889900AABB00000000"}, metas)
+		if err != nil {
+			t.Fatalf("ReadBaselineRow: %v", err)
+		}
+		if row == nil || row["v"] != "hit" {
+			t.Errorf("full-width spelling regressed, got %v", row)
+		}
+	})
+
+	t.Run("absent key still misses after the retry", func(t *testing.T) {
+		row, err := ReadBaselineRow(ctx, path, map[string]string{"k": "0xDEADBEEF"}, metas)
+		if err != nil {
+			t.Fatalf("ReadBaselineRow: %v", err)
+		}
+		if row != nil {
+			t.Errorf("absent key matched a row after padding: %v", row)
+		}
+	})
+}

--- a/internal/reconstruct/pk_metas_epoch_integration_test.go
+++ b/internal/reconstruct/pk_metas_epoch_integration_test.go
@@ -1,0 +1,111 @@
+//go:build integration
+
+package reconstruct_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/baseline"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/reconstruct"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestIntegrationResolvePKMetasAt_epochWidth pins the #1159 fix: the PK metas
+// that drive the fixed BINARY(n) pad width must come from the schema snapshot
+// in effect at the anchor instant (metadata.EpochAt), not from the latest
+// snapshot. Scenario: a BINARY(16) PK is widened to BINARY(32) after the
+// baseline was taken; the baseline file stores 16-byte values forever, so a
+// pad width read from the latest snapshot (32) makes the retry look for a
+// 32-byte key the baseline cannot contain — a silent miss.
+func TestIntegrationResolvePKMetasAt_epochWidth(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	ctx := context.Background()
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	// Snapshot history: BINARY(16) on 06-01, widened to BINARY(32) on 06-03.
+	testutil.MustExec(t, db, `INSERT INTO schema_snapshots
+		(snapshot_id, snapshot_time, schema_name, table_name, column_name,
+		 ordinal_position, column_key, data_type, column_type, is_nullable)
+		VALUES (1, '2026-06-01 00:00:00', 'app', 'vault', 'k',   1, 'PRI', 'binary',  'binary(16)',  'NO'),
+		       (1, '2026-06-01 00:00:00', 'app', 'vault', 'val', 2, '',    'varchar', 'varchar(32)', 'YES'),
+		       (2, '2026-06-03 00:00:00', 'app', 'vault', 'k',   1, 'PRI', 'binary',  'binary(32)',  'NO'),
+		       (2, '2026-06-03 00:00:00', 'app', 'vault', 'val', 2, '',    'varchar', 'varchar(32)', 'YES')`)
+
+	// Control first, so the scenario is proven non-vacuous: the LATEST
+	// snapshot really does declare the wider width — the answer the pre-#1159
+	// resolver would have used.
+	latestRes, err := metadata.NewResolver(db, 0)
+	if err != nil {
+		t.Fatalf("NewResolver(latest): %v", err)
+	}
+	latestTM, err := latestRes.Resolve("app", "vault")
+	if err != nil {
+		t.Fatalf("resolve latest: %v", err)
+	}
+	latestMetas := latestTM.PKColumnMetas()
+	if w := reconstruct.FixedBinaryWidth(latestMetas[0].ColumnType); w != 32 {
+		t.Fatalf("latest snapshot width = %d, want 32 — the fixture no longer distinguishes the epoch anchor from the latest snapshot", w)
+	}
+
+	// The anchor: the baseline was taken on 06-02, between the two snapshots.
+	baselineTime := time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC)
+	metas := reconstruct.ResolvePKMetasAt(db, "app", "vault", baselineTime)
+	if len(metas) != 1 {
+		t.Fatalf("ResolvePKMetasAt returned %d PK metas, want 1", len(metas))
+	}
+	if w := reconstruct.FixedBinaryWidth(metas[0].ColumnType); w != 16 {
+		t.Fatalf("width at the baseline instant = %d, want 16 (the snapshot in effect on 06-02 declares binary(16))", w)
+	}
+
+	// An instant predating every snapshot falls back to the FIRST epoch — the
+	// closest available description of the schema.
+	early := reconstruct.ResolvePKMetasAt(db, "app", "vault", time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
+	if len(early) != 1 || reconstruct.FixedBinaryWidth(early[0].ColumnType) != 16 {
+		t.Errorf("pre-history instant: metas = %+v, want the first epoch's binary(16)", early)
+	}
+
+	// End to end through ReadBaselineRow: the width-16 padded baseline row
+	// must resolve by its stripped pk_values spelling with the epoch metas.
+	dir := t.TempDir()
+	cols := []baseline.Column{
+		{Name: "k", MySQLType: "binary", ParquetType: baseline.MysqlToParquetNode("binary")},
+		{Name: "val", MySQLType: "varchar", ParquetType: baseline.MysqlToParquetNode("varchar")},
+	}
+	path := filepath.Join(dir, "vault.parquet")
+	w, err := baseline.NewWriter(path, cols, baseline.WriterConfig{Compression: "none", RowGroupSize: 100})
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	if err := w.WriteRow([]string{"0x11223344556677889900AABB00000000", "sealed"}, []bool{false, false}); err != nil {
+		t.Fatalf("WriteRow: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	stripped := map[string]string{"k": "0x11223344556677889900AABB"}
+	row, err := reconstruct.ReadBaselineRow(ctx, path, stripped, metas)
+	if err != nil {
+		t.Fatalf("ReadBaselineRow (epoch metas): %v", err)
+	}
+	if row == nil || row["val"] != "sealed" {
+		t.Fatalf("epoch metas did not resolve the width-16 baseline row, got %v", row)
+	}
+
+	// The discriminating control: the latest snapshot's width-32 metas pad the
+	// same key to 32 bytes, which the width-16 baseline cannot contain — the
+	// silent miss #1159 files. If this ever starts matching, the anchor stopped
+	// mattering and the test above passes vacuously.
+	row, err = reconstruct.ReadBaselineRow(ctx, path, stripped, latestMetas)
+	if err != nil {
+		t.Fatalf("ReadBaselineRow (latest metas): %v", err)
+	}
+	if row != nil {
+		t.Fatalf("latest-snapshot metas resolved the row (%v) — the fixture no longer exercises the epoch anchor", row)
+	}
+}

--- a/internal/shim/resolve.go
+++ b/internal/shim/resolve.go
@@ -270,8 +270,11 @@ func (h *Handler) ResolveSnapshotRow(ctx context.Context, q TimeTravelQuery) (ma
 
 	// q.PKValue is passed RAW here — Parquet baseline rows store actual column
 	// values, not event.BuildPKValues-encoded pk_values, so this seam must NOT
-	// apply event.EscapePKValue (unlike the delta fetch below).
-	baselineRow, err := reconstruct.ReadBaselineRow(ctx, baselinePath, map[string]string{q.PKColumn: q.PKValue})
+	// apply event.EscapePKValue (unlike the delta fetch below). pkMetas nil:
+	// binary-family PKs never reach this call (baselinePKStringMatchable routed
+	// them to the binlog-only path above), so ReadBaselineRow's fixed BINARY(n)
+	// pad-and-retry (#1157) has nothing to reconcile on this path.
+	baselineRow, err := reconstruct.ReadBaselineRow(ctx, baselinePath, map[string]string{q.PKColumn: q.PKValue}, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
closes #1157
closes #1159

## Summary

#1155 taught `reconstruct --pk` to reconcile the two spellings a fixed `BINARY(n)` primary key has — padded to the storage width in the baseline Parquet, trailing-`0x00`-stripped in `binlog_events.pk_values` — but the reconcilers lived in `internal/cli`, so only the CLI benefited. For a `BINARY(16)` key whose stored value ends in `0x00` and has no deltas in the window, the console `GET /api/reconstruct` and the MCP `reconstruct` tool proceeded on `baselineRow == nil` straight into `ApplyAt(nil, deltas, at)` and answered **"the row did not exist at that time"** while the CLI answered correctly. Two surfaces, same index, same baseline, contradictory answers, neither warning.

### What moved where

- **`padFixedBinaryFilter`** (baseline direction: re-pad to the declared width) moved to `internal/reconstruct/pk_filter.go` and now runs **inside `ReadBaselineRow`**, which gained a parameter:

  ```go
  func ReadBaselineRow(ctx context.Context, path string, pkFilter map[string]string, pkMetas []metadata.ColumnMeta) (map[string]any, error)
  ```

  The retry only ever runs after an exact miss, so it can never override a correct hit. `ReadBaselineRows` (the FK-scan entry cascade Phase-2 uses) is unchanged — it is not a PK lookup.
- **`indexPKSpelling` → `reconstruct.IndexPKSpelling`** (event-fetch direction: trim back to the stored spelling) moved alongside and is now wired into **all three** event fetches — CLI, console, MCP. The two directions remain deliberately opposite and separate: review of the first commit showed that adopting only the baseline-side retry turned fail-loud into fail-silent on console/MCP (a lowercase or full-width hex key resolved the baseline but matched zero events, so the fold presented baseline-era state as the state at `at` with no warning). Both lookups must respell, each in its own direction.
- The CLI's local copies (`resolvePKMetas`, `indexPKSpelling`, `padFixedBinaryFilter`, `filterKeyFor`, `decodeHexPKValue` — a duplicate of the package's existing `decodeHexPKLiteral`) are deleted; `internal/cli/reconstruct.go` shrinks by ~200 lines and its single-row path now does one `ReadBaselineRow` call instead of read-then-maybe-retry.

### Epoch-anchored width (#1159)

The metas now come from a shared helper:

```go
func ResolvePKMetasAt(db *sql.DB, schema, table string, at time.Time) []metadata.ColumnMeta
```

It picks the schema snapshot **in effect at the anchor instant** via the existing `metadata.EpochAt` (the same per-instant rule the ENUM/SET decode path #475 uses), instead of `metadata.NewResolver(db, 0)` = latest. All three surfaces pass the **baseline snapshot time** as the anchor. #1159 suggested anchoring at `--at`; the baseline instant is strictly better for this use and covers the filed case: the pad width must match the bytes the baseline file actually stores, that file was written under the schema in effect at the snapshot instant, and snapshot-time ≤ `--at`, so a widening ALTER after `--at` (the filed scenario) *and* one between the baseline and `--at` are both handled. An instant predating every snapshot falls back to the first epoch; no epoch history falls back to the latest snapshot; any failure degrades to nil metas (exact-match-only, the pre-#1155 behavior) — never a failed reconstruct.

### Per-caller decision

| `ReadBaselineRow` caller | Decision |
|---|---|
| `internal/cli` single-row reconstruct | metas from `ResolvePKMetasAt(db, schema, table, snapshotTime)`; also feeds `IndexPKSpelling` for the event fetch and the `unsupportedPKType` diagnosis |
| `internal/console/reconstruct.go` | metas from `ResolvePKMetasAt(b.db, …, snapshotTime)`; event fetch respelled via `IndexPKSpelling` — fixed |
| `internal/mcptools/reconstruct.go` | metas from `ResolvePKMetasAt(t.DB, …, snapshotTime)`; event fetch respelled via `IndexPKSpelling` — fixed |
| `internal/cli` `--baseline-only` | `nil` — structurally excluded (the index is never opened, so no declared width exists); documented in `docs/query-and-recovery.md` and pinned by a unit subtest |
| `internal/shim/resolve.go` (`_snapshot` single-row) | `nil` — binary-family PKs never reach the call: `baselinePKStringMatchable` routes them to the binlog-only path first (deliberate #1155 shape, unchanged) |
| `internal/cascadebaseline` (via `ReadBaselineRows`) | untouched — an FK-column scan, not a PK lookup |

So on every index-reading surface the stored `pk_values` spelling, a lowercase paste of it, and the full-width `HEX()` form all resolve the baseline **and** fold the post-baseline deltas. The single respelled fetch also feeds history mode and `TrimPartialTailTransaction`, so no second fetch needed the change. `docs/query-and-recovery.md` states this.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go vet -tags integration ./...` clean
- [x] `go test ./... -count=1` green
- [x] `go test -race -count=1` on `internal/reconstruct`, `internal/cli`, `internal/console`, `internal/mcptools`, `internal/shim`
- [x] Integration (Docker MySQL): full `internal/reconstruct`, `internal/cli`, `internal/shim`, `internal/console`, `internal/mcptools` suites green

New/moved coverage:

- `internal/reconstruct/pk_filter_test.go` — the #1155 unit tests moved with the code (`TestPadFixedBinaryFilter`, `TestIndexPKSpelling`, hex-literal cases), plus `TestReadBaselineRow_fixedBinaryPadRetry`: stripped spelling resolves **with** metas, stays a miss **without** them (pins the structural exclusions), verbatim-ASCII and full-width spellings still resolve, absent keys still miss after padding.
- `TestIntegrationReconstructBinaryPK` (console) and `TestIntegrationReconstructToolBinaryPK` (MCP): the filed scenario through the real HTTP handler / MCP session, plus a post-baseline delta asserted for the stored, lowercase, and full-width spellings — the answer must be the DELTA-applied state, so a baseline hit with a silently-empty event fetch fails the test. Verified to fail with the event-fetch respell reverted (both surfaces answered the baseline-era value on the lowercase and full-width cases).
- `TestIntegrationResolvePKMetasAt_epochWidth` (#1159): snapshot history `binary(16)` → `binary(32)`, baseline between them; asserts the latest snapshot really declares 32 (non-vacuous), the anchor instant resolves 16, the end-to-end lookup hits with epoch metas, and — as the discriminating control — misses with latest-snapshot metas.
- `TestBinaryPKBaselineJoin_endToEnd`'s single-row subtest now additionally asserts the stored `pk_values` spelling resolves through `ReadBaselineRow` with real server-derived metas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
