### PR TITLE
stream: fix MariaDB 11.4+ zero-LogPos corrupting positions and destroying the index on resume

### DIFF
--- a/cliapp/agent.go
+++ b/cliapp/agent.go
@@ -691,6 +691,12 @@ func runBYOSStream(ctx context.Context, sourceDB *sql.DB, buf *buffer.Buffer, fc
 		HeartbeatPeriod:         30 * time.Second,
 		MaxReconnectAttempts:    0,
 		TimestampStringLocation: time.UTC, // see internal/parser/parser.go (#757)
+		// MariaDB 11.4+ zero-LogPos compensation (#1117; see the syncer in
+		// internal/streamrun for the full rationale). Library-gated to the
+		// MariaDB flavor, so it is inert under this syncer's fixed "mysql"
+		// flavor today — set so the site stays correct if the agent ever
+		// grows a flavor flag.
+		FillZeroLogPos: true,
 	}
 	syncer := replication.NewBinlogSyncer(syncerCfg)
 	defer syncer.Close()

--- a/internal/parser/fillcorrect.go
+++ b/internal/parser/fillcorrect.go
@@ -1,0 +1,129 @@
+package parser
+
+import (
+	"github.com/go-mysql-org/go-mysql/replication"
+)
+
+// resumeFillCorrector undoes the constant position overshoot go-mysql's
+// FillZeroLogPos introduces right after a mid-file (re)connect (#1117).
+//
+// At connect the server sends an artificial RotateEvent naming the resume
+// offset R, then re-sends the file's FORMAT_DESCRIPTION event. On a mid-file
+// connect (R > 4) that FDE is a GHOST: it is not physically located at R, and
+// the server zeroes its end_log_pos on the wire. FillZeroLogPos (MariaDB
+// 11.4+ compensation) cannot know that and fills it to R+len(FDE), advancing
+// the library's internal running position past the resume point. Every
+// subsequent cache-buffered event (LogPos=0 on the wire: ANNOTATE, TABLE_MAP,
+// row events) is then filled len(FDE) bytes beyond its true offset, until the
+// first directly-written event (GTID, XID — genuine wire LogPos) snaps the
+// running position back. A resume that lands INSIDE a transaction — a #775
+// statement-boundary checkpoint, or go-mysql's own auto-resync after a
+// network error, which resumes from its internal per-event position — would
+// therefore store the transaction tail's rows with positions inflated by
+// exactly len(FDE) (values a persisted checkpoint would turn into a fatal
+// server error 1236 on the next restart, since they are not event
+// boundaries), and the genuine snap-back would read as a same-file backward
+// jump to the wraparound guard, killing the stream. Verified live against
+// MariaDB 11.4.12: resume at 1264 → FDE filled to 1516 → tail filled
+// 1584/1637/1680 (true offsets 1332/1385/1428) → XID genuine 1459.
+//
+// The corrector detects that signature and rewrites the filled headers back
+// to their true offsets. It is pure arithmetic on known quantities: the
+// artificial rotate names R; a binlog file is contiguous, so the first
+// post-FDE event's true end is R+size and each following one's is
+// prevTrue+size; an observed LogPos equal to true+len(FDE) is the poisoned
+// fill, equal to true is a genuine value (which also self-corrects the
+// library's running position, closing the window). Anything else is
+// unexpected: the corrector disarms WITHOUT rewriting — the wraparound guard
+// downstream stays the fail-loud backstop, and the handleRows underflow belt
+// stays the zero-position backstop.
+//
+// Cases that reduce to no-ops by construction:
+//   - MySQL flavor: FillZeroLogPos is library-gated to MariaDB, the ghost FDE
+//     keeps LogPos=0 on the wire, and the first real event matches its true
+//     offset → disarmed, nothing rewritten.
+//   - Connect at a transaction boundary (the common case): the first
+//     post-FDE event is a directly-written GTID event at its true offset →
+//     disarmed immediately.
+//   - Connect at a file start (R <= 4): the FDE is physically present and its
+//     (genuine or filled) LogPos equals the true offset → never armed as a
+//     ghost.
+//   - Transaction_payload inner events: their headers are rewritten to the
+//     outer event's coordinates before recursing, and the payload path is
+//     MySQL-only, where no window ever opens.
+type resumeFillCorrector struct {
+	// armed is true between an artificial rotate and the verdict on the first
+	// position-bearing event after the (ghost) FDE.
+	armed bool
+	// base is the resume offset R named by the artificial rotate.
+	base uint32
+	// ghost is the re-sent FDE's EventSize, once seen while armed; the
+	// overshoot magnitude if the window turns out to be poisoned.
+	ghost uint32
+	// adjust is the confirmed overshoot being subtracted; 0 = no open window.
+	adjust uint32
+	// prevTrue is the corrected end offset of the previous event in the window.
+	prevTrue uint32
+}
+
+// Observe inspects one streamed event and, when inside a confirmed poisoned
+// fill window, rewrites its header LogPos back to the true file offset.
+// Returns true when it rewrote the header.
+func (c *resumeFillCorrector) Observe(ev *replication.BinlogEvent) bool {
+	hdr := ev.Header
+	if rot, isRotate := ev.Event.(*replication.RotateEvent); isRotate {
+		if hdr.Flags&replication.LOG_EVENT_ARTIFICIAL_F != 0 {
+			// Connect-time fake rotate: arm at the resume offset it names.
+			*c = resumeFillCorrector{armed: true, base: uint32(rot.Position)}
+		} else {
+			// Real rotation: fresh file, the next FDE is physically present.
+			*c = resumeFillCorrector{}
+		}
+		return false
+	}
+	if hdr.Flags&replication.LOG_EVENT_ARTIFICIAL_F != 0 {
+		return false // heartbeats etc. — not file events, not filled
+	}
+	if _, isFDE := ev.Event.(*replication.FormatDescriptionEvent); isFDE {
+		if c.armed && c.base > 4 {
+			c.ghost = hdr.EventSize // mid-file connect: this FDE is a ghost
+		} else {
+			*c = resumeFillCorrector{} // physically-present FDE: nothing to correct
+		}
+		return false
+	}
+	if c.armed {
+		// First position-bearing event after the connect sequence.
+		armedGhost := c.ghost
+		base := c.base
+		*c = resumeFillCorrector{}
+		if armedGhost == 0 {
+			return false // no ghost FDE seen: nothing to correct
+		}
+		expected := base + hdr.EventSize
+		switch hdr.LogPos {
+		case expected + armedGhost: // the poisoned-fill signature
+			hdr.LogPos = expected
+			c.adjust, c.prevTrue = armedGhost, expected
+			return true
+		default: // genuine value (== expected), or unexpected: leave untouched
+			return false
+		}
+	}
+	if c.adjust != 0 {
+		expected := c.prevTrue + hdr.EventSize
+		switch hdr.LogPos {
+		case expected + c.adjust: // still inside the poisoned window
+			hdr.LogPos = expected
+			c.prevTrue = expected
+			return true
+		default:
+			// Genuine value (== expected — the library self-corrected) or an
+			// unexpected shape: close the window either way; the guard is the
+			// backstop for the latter.
+			*c = resumeFillCorrector{}
+			return false
+		}
+	}
+	return false
+}

--- a/internal/parser/fillcorrect_test.go
+++ b/internal/parser/fillcorrect_test.go
@@ -1,0 +1,174 @@
+package parser
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/go-mysql-org/go-mysql/replication"
+)
+
+// ─── #1117: post-reconnect FillZeroLogPos overshoot correction ────────────────
+//
+// The fixture below is the EXACT event sequence captured live from MariaDB
+// 11.4.12 for a position-mode resume landing mid-transaction (a legal #775
+// statement-boundary checkpoint at offset 1264, inside a 3-statement
+// transaction whose statements truly end at 1332/1385/1428 with the XID at
+// 1459): the server honors the offset, re-sends the file's FDE with LogPos
+// zeroed, FillZeroLogPos fills it to 1264+252=1516, and the transaction
+// tail's cache-buffered events arrive filled with a constant +252 overshoot
+// (1584/1637/1680) until the genuine XID (1459) snaps back. Without the
+// corrector, the tail row would be stored at [1637,1680] instead of
+// [1385,1428] — a value that is not an event boundary, so a checkpoint
+// persisting it turns into a fatal server error 1236 on the next restart —
+// and the genuine XID would read as a same-file backward jump, tripping the
+// wraparound guard on every such resume.
+
+// artificialRotate builds the connect-time fake rotate the server sends at
+// (re)connect: ARTIFICIAL flag set, Position naming the resume offset.
+func artificialRotate(nextFile string, position uint64) *replication.BinlogEvent {
+	return &replication.BinlogEvent{
+		Header: &replication.EventHeader{
+			EventType: replication.ROTATE_EVENT,
+			Flags:     replication.LOG_EVENT_ARTIFICIAL_F,
+		},
+		Event: &replication.RotateEvent{NextLogName: []byte(nextFile), Position: position},
+	}
+}
+
+func TestStreamParser_midTransactionResumeCorrectsFilledPositions(t *testing.T) {
+	sp := NewStreamParser(makeOrdersResolver(), Filters{}, nil)
+	sp.SetFlavor("mariadb")
+	streamer := replication.NewBinlogStreamer()
+	out := make(chan Event, 16)
+
+	fde := &replication.BinlogEvent{
+		Header: &replication.EventHeader{
+			EventType: replication.FORMAT_DESCRIPTION_EVENT,
+			LogPos:    1516, // filled: resume 1264 + FDE size 252
+			EventSize: 252,
+		},
+		Event: &replication.FormatDescriptionEvent{Version: 4},
+	}
+	annotate := &replication.BinlogEvent{
+		Header: &replication.EventHeader{
+			EventType: replication.MARIADB_ANNOTATE_ROWS_EVENT,
+			LogPos:    1584, // filled; true end 1332
+			EventSize: 68,
+		},
+		Event: &replication.MariadbAnnotateRowsEvent{Query: []byte("INSERT INTO orders (amount) VALUES (30)")},
+	}
+	tableMap := &replication.BinlogEvent{
+		Header: &replication.EventHeader{
+			EventType: replication.TABLE_MAP_EVENT,
+			LogPos:    1637, // filled; true end 1385
+			EventSize: 53,
+		},
+		Event: &replication.TableMapEvent{Schema: []byte("shop"), Table: []byte("orders"), ColumnCount: 2},
+	}
+	tailRows := &replication.BinlogEvent{
+		Header: &replication.EventHeader{
+			EventType: replication.WRITE_ROWS_EVENTv1,
+			LogPos:    1680, // filled; true [1385,1428]
+			EventSize: 43,
+			Flags:     0,
+		},
+		Event: &replication.RowsEvent{
+			Table: &replication.TableMapEvent{Schema: []byte("shop"), Table: []byte("orders"), ColumnCount: 2},
+			Rows:  [][]any{{int64(4), int64(30)}},
+			Flags: replication.RowsEventStmtEndFlag,
+		},
+	}
+	xid := &replication.BinlogEvent{
+		Header: &replication.EventHeader{EventType: replication.XID_EVENT, LogPos: 1459, EventSize: 31},
+		Event:  &replication.XIDEvent{XID: 7},
+	}
+	nextGTID := &replication.BinlogEvent{
+		Header: &replication.EventHeader{EventType: replication.MARIADB_GTID_EVENT, LogPos: 1501, EventSize: 42},
+		Event: &replication.MariadbGTIDEvent{
+			GTID: mysql.MariadbGTID{DomainID: 0, ServerID: 2, SequenceNumber: 8},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	feedThenCancel(t, streamer, cancel,
+		artificialRotate("mariadb-bin.000002", 1264),
+		fde, annotate, tableMap, tailRows, xid, nextGTID,
+	)
+
+	if err := sp.Run(ctx, streamer, out); err != nil {
+		t.Fatalf("Run: unexpected error on a mid-transaction resume (wraparound false-trip?): %v", err)
+	}
+	close(out)
+
+	var rows []Event
+	for ev := range out {
+		if ev.EventType == EventInsert {
+			rows = append(rows, ev)
+		}
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected the transaction-tail row to be emitted, got %d row events", len(rows))
+	}
+	// The corrected TRUE offsets, not the +252-inflated filled values.
+	if rows[0].StartPos != 1385 || rows[0].EndPos != 1428 {
+		t.Errorf("tail row positions = [%d, %d], want corrected true offsets [1385, 1428]",
+			rows[0].StartPos, rows[0].EndPos)
+	}
+}
+
+// TestResumeFillCorrector_genuineBoundaryResumeUntouched pins the common
+// case: a resume at a transaction boundary has a directly-written GTID event
+// (genuine LogPos) right after the ghost FDE, so the corrector must disarm
+// without rewriting anything (live capture: resume 938 → FDE filled 1190 →
+// GTID genuine 980 = 938+42).
+func TestResumeFillCorrector_genuineBoundaryResumeUntouched(t *testing.T) {
+	var c resumeFillCorrector
+
+	rot := artificialRotate("mariadb-bin.000002", 938)
+	fde := &replication.BinlogEvent{
+		Header: &replication.EventHeader{EventType: replication.FORMAT_DESCRIPTION_EVENT, LogPos: 1190, EventSize: 252},
+		Event:  &replication.FormatDescriptionEvent{Version: 4},
+	}
+	gtid := &replication.BinlogEvent{
+		Header: &replication.EventHeader{EventType: replication.MARIADB_GTID_EVENT, LogPos: 980, EventSize: 42},
+		Event:  &replication.MariadbGTIDEvent{GTID: mysql.MariadbGTID{DomainID: 0, ServerID: 2, SequenceNumber: 5}},
+	}
+
+	for _, ev := range []*replication.BinlogEvent{rot, fde, gtid} {
+		if c.Observe(ev) {
+			t.Fatalf("Observe rewrote %s — a genuine-boundary resume must stay untouched", ev.Header.EventType)
+		}
+	}
+	if gtid.Header.LogPos != 980 {
+		t.Errorf("genuine GTID LogPos changed to %d, want 980 untouched", gtid.Header.LogPos)
+	}
+	if c.adjust != 0 || c.armed {
+		t.Errorf("corrector should be fully disarmed after a genuine first event, got %+v", c)
+	}
+}
+
+// TestResumeFillCorrector_zeroLogPosLeftForBelt pins fail-open: without
+// FillZeroLogPos (or a non-MariaDB source), post-FDE cache-buffered events
+// arrive with LogPos=0 — the corrector must NOT invent positions for them
+// (that is the handleRows belt's job to reject, and the file parser's job to
+// fill for files); it disarms and leaves the header untouched.
+func TestResumeFillCorrector_zeroLogPosLeftForBelt(t *testing.T) {
+	var c resumeFillCorrector
+
+	c.Observe(artificialRotate("mariadb-bin.000002", 1264))
+	c.Observe(&replication.BinlogEvent{
+		Header: &replication.EventHeader{EventType: replication.FORMAT_DESCRIPTION_EVENT, LogPos: 1516, EventSize: 252},
+		Event:  &replication.FormatDescriptionEvent{Version: 4},
+	})
+	zeroRows := &replication.BinlogEvent{
+		Header: &replication.EventHeader{EventType: replication.WRITE_ROWS_EVENTv1, LogPos: 0, EventSize: 43},
+		Event:  &replication.RowsEvent{Table: &replication.TableMapEvent{Schema: []byte("shop"), Table: []byte("orders"), ColumnCount: 2}},
+	}
+	if c.Observe(zeroRows) {
+		t.Fatal("Observe rewrote a zero-LogPos event — must fail open to the underflow belt")
+	}
+	if zeroRows.Header.LogPos != 0 {
+		t.Errorf("zero LogPos was rewritten to %d, want 0 untouched", zeroRows.Header.LogPos)
+	}
+}

--- a/internal/parser/mariadb_integration_test.go
+++ b/internal/parser/mariadb_integration_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-mysql-org/go-mysql/replication"
+
 	"github.com/dbtrail/dbtrail/internal/config"
 	"github.com/dbtrail/dbtrail/internal/metadata"
 	"github.com/dbtrail/dbtrail/internal/parser"
@@ -105,22 +107,43 @@ func TestParseFile_realBinlog_mariadb(t *testing.T) {
 	// #1117: MariaDB 11.4+ writes cache-buffered events (TABLE_MAP, rows,
 	// ANNOTATE) with end_log_pos=0 IN THE FILE ITSELF — the running-offset fill
 	// in ParseFile must reconstruct real positions, never emit the underflowed
-	// start_pos = 2^64-EventSize / end_pos = 0 shape. Positions must also be
-	// monotonic within the (single) file.
-	var lastStart uint64
+	// start_pos = 2^64-EventSize / end_pos = 0 shape.
+	//
+	// The assertion is EXACT, not merely sane/monotonic: true offsets are
+	// reconstructed independently with a raw go-mysql parser by accumulating
+	// EventSize (a binlog file is contiguous), and every genuine stored
+	// end_log_pos in the file must agree with the accumulation — the
+	// fill-chain → directly-written junction check that catches any
+	// constant-offset inflation a monotonicity check would miss.
+	type span struct{ start, end uint64 }
+	var want []span
+	acc := uint32(4)
+	raw := replication.NewBinlogParser()
+	rawErr := raw.ParseFile(filepath.Join(tmpDir, currentBinlog), 0, func(e *replication.BinlogEvent) error {
+		prev := acc
+		acc += e.Header.EventSize
+		if e.Header.LogPos != 0 && e.Header.LogPos != acc {
+			t.Errorf("accumulated offset %d disagrees with the genuine stored end_log_pos %d of %s — junction mismatch",
+				acc, e.Header.LogPos, e.Header.EventType)
+		}
+		switch e.Header.EventType {
+		case replication.WRITE_ROWS_EVENTv1, replication.WRITE_ROWS_EVENTv2,
+			replication.UPDATE_ROWS_EVENTv1, replication.UPDATE_ROWS_EVENTv2,
+			replication.DELETE_ROWS_EVENTv1, replication.DELETE_ROWS_EVENTv2:
+			want = append(want, span{uint64(prev), uint64(acc)})
+		}
+		return nil
+	})
+	if rawErr != nil {
+		t.Fatalf("raw ground-truth parse: %v", rawErr)
+	}
+	if len(want) != len(dml) {
+		t.Fatalf("ground truth found %d row events, bintrail emitted %d DML events", len(want), len(dml))
+	}
 	for i, ev := range dml {
-		if ev.EndPos == 0 {
-			t.Errorf("dml[%d]: end_pos = 0 (zero-LogPos fill not applied)", i)
+		if ev.StartPos != want[i].start || ev.EndPos != want[i].end {
+			t.Errorf("dml[%d]: positions [%d, %d], want exactly [%d, %d]",
+				i, ev.StartPos, ev.EndPos, want[i].start, want[i].end)
 		}
-		if ev.StartPos >= ev.EndPos {
-			t.Errorf("dml[%d]: start_pos %d >= end_pos %d", i, ev.StartPos, ev.EndPos)
-		}
-		if ev.StartPos > uint64(^uint32(0)) {
-			t.Errorf("dml[%d]: start_pos %d exceeds the uint32 wire-format range (underflow)", i, ev.StartPos)
-		}
-		if ev.StartPos < lastStart {
-			t.Errorf("dml[%d]: start_pos %d went backward from %d", i, ev.StartPos, lastStart)
-		}
-		lastStart = ev.StartPos
 	}
 }

--- a/internal/parser/mariadb_integration_test.go
+++ b/internal/parser/mariadb_integration_test.go
@@ -101,4 +101,26 @@ func TestParseFile_realBinlog_mariadb(t *testing.T) {
 			t.Fatalf("indexed GTID %q is not MariaDB domain-server-seq form", ev.GTID)
 		}
 	}
+
+	// #1117: MariaDB 11.4+ writes cache-buffered events (TABLE_MAP, rows,
+	// ANNOTATE) with end_log_pos=0 IN THE FILE ITSELF — the running-offset fill
+	// in ParseFile must reconstruct real positions, never emit the underflowed
+	// start_pos = 2^64-EventSize / end_pos = 0 shape. Positions must also be
+	// monotonic within the (single) file.
+	var lastStart uint64
+	for i, ev := range dml {
+		if ev.EndPos == 0 {
+			t.Errorf("dml[%d]: end_pos = 0 (zero-LogPos fill not applied)", i)
+		}
+		if ev.StartPos >= ev.EndPos {
+			t.Errorf("dml[%d]: start_pos %d >= end_pos %d", i, ev.StartPos, ev.EndPos)
+		}
+		if ev.StartPos > uint64(^uint32(0)) {
+			t.Errorf("dml[%d]: start_pos %d exceeds the uint32 wire-format range (underflow)", i, ev.StartPos)
+		}
+		if ev.StartPos < lastStart {
+			t.Errorf("dml[%d]: start_pos %d went backward from %d", i, ev.StartPos, lastStart)
+		}
+		lastStart = ev.StartPos
+	}
 }

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -148,6 +148,19 @@ func (p *Parser) ParseFile(ctx context.Context, filename string, events chan<- E
 	// UTC at rest (#757).
 	bp.SetTimestampStringLocation(time.UTC)
 
+	// lastEnd tracks the end offset of the previous event, to reconstruct the
+	// positions MariaDB 11.4+ leaves out of the file itself (#1117): events
+	// written through the transaction or statement cache (TABLE_MAP, row
+	// events, ANNOTATE) are copied into the binlog with end_log_pos=0 — only
+	// directly-written events (GTID, XID) carry a real value. Binlog files are
+	// contiguous, so a zero-LogPos event's true end is exactly the previous
+	// event's end plus its own EventSize — the same computation go-mysql's
+	// FillZeroLogPos performs for the replication stream. Without this, every
+	// such row is stored with start_pos = 2^64-EventSize (underflow) and
+	// end_pos = 0. Parsing always begins at the file start (offset 4, after
+	// the magic), so the running offset is exact from the first event.
+	lastEnd := uint32(4)
+
 	// handleEvent processes one binlog event. It is recursive: with
 	// binlog_transaction_compression=ON the source wraps each transaction's
 	// events (BEGIN + TABLE_MAP + rows + XID) in a single zstd-compressed
@@ -157,6 +170,17 @@ func (p *Parser) ParseFile(ctx context.Context, filename string, events chan<- E
 	handleEvent = func(binlogEv *replication.BinlogEvent) error {
 		if ctx.Err() != nil {
 			return ctx.Err()
+		}
+
+		// Zero-LogPos fill (see lastEnd above). Transaction_payload inner
+		// events never take this branch: rewriteInnerHeader has already
+		// stamped them with the outer event's (non-zero) coordinates by the
+		// time they recurse through here.
+		if hdr := binlogEv.Header; hdr.LogPos == 0 && hdr.Flags&replication.LOG_EVENT_ARTIFICIAL_F == 0 {
+			hdr.LogPos = lastEnd + hdr.EventSize
+		}
+		if binlogEv.Header.LogPos > 0 {
+			lastEnd = binlogEv.Header.LogPos
 		}
 
 		switch ev := binlogEv.Event.(type) {
@@ -567,7 +591,22 @@ func handleRows(
 			len(firstSkipped), firstSkipped)
 	}
 
-	// LogPos points to the byte AFTER the event. Subtract EventSize to get start.
+	// LogPos points to the byte AFTER the event. Subtract EventSize to get
+	// start. A LogPos below EventSize would underflow into a ~2^64 start_pos —
+	// the corruption that made the resume-time dedup (start_pos >= checkpoint)
+	// delete every already-indexed row (#1117). Both producers now guarantee a
+	// real position (FillZeroLogPos on the MariaDB stream syncers; the running-
+	// offset fill in ParseFile), so this is a fail-loud belt: refuse to index a
+	// row whose position could not be established rather than store a value
+	// that later reads as "beyond every checkpoint".
+	if uint64(binlogEv.Header.LogPos) < uint64(binlogEv.Header.EventSize) {
+		return fmt.Errorf(
+			"row event at %s has end position %d smaller than its size %d (%s.%s) — the binlog position for "+
+				"this event could not be established (MariaDB 11.4+ writes cache-buffered events with end_log_pos=0; "+
+				"the zero-LogPos fill should have replaced it before this point); refusing to index the row with an "+
+				"underflowed start_pos, which the resume-time dedup would treat as beyond every checkpoint",
+			filename, binlogEv.Header.LogPos, binlogEv.Header.EventSize, schema, table)
+	}
 	startPos := uint64(binlogEv.Header.LogPos) - uint64(binlogEv.Header.EventSize)
 	endPos := uint64(binlogEv.Header.LogPos)
 	ts := time.Unix(int64(binlogEv.Header.Timestamp), 0).UTC()

--- a/internal/parser/stream.go
+++ b/internal/parser/stream.go
@@ -250,6 +250,20 @@ func (sp *StreamParser) Run(ctx context.Context, streamer *replication.BinlogStr
 		// math.MaxUint32; the wrap happens here, upstream, at the source).
 		if _, isRotate := binlogEv.Event.(*replication.RotateEvent); isRotate {
 			lastLogPos = 0 // new file (real or fake-resume rotate): positions restart
+		} else if _, isFDE := binlogEv.Event.(*replication.FormatDescriptionEvent); isFDE {
+			// A FORMAT_DESCRIPTION event neither trips the guard nor advances
+			// lastLogPos. At a mid-file (re)connect the server re-sends the
+			// file's FDE with LogPos zeroed on the wire (its physical offset is
+			// near the file START, not the resume point, so a real value would
+			// be wrong either way). Under FillZeroLogPos (#1117, MariaDB 11.4+)
+			// go-mysql fills that zero to resumePos+EventSize — a synthetic
+			// value that OVERSHOOTS the next transaction's real positions
+			// (verified live: resume at 938 → FDE filled to 1190 → next GTID
+			// event real 980), which read here as a backward jump and
+			// false-tripped the wraparound guard. Skipping the FDE costs no
+			// detection power: a genuine 4GiB wrap can never first manifest on
+			// an FDE — in-file FDEs sit at offset 4, immediately after a
+			// RotateEvent already reset lastLogPos to 0.
 		} else if hdr := binlogEv.Header; lastLogPos != 0 && hdr.LogPos != 0 && hdr.LogPos < lastLogPos {
 			return fmt.Errorf(
 				"binlog position wraparound detected in %q: position went from %d back to %d with no intervening "+

--- a/internal/parser/stream.go
+++ b/internal/parser/stream.go
@@ -160,6 +160,12 @@ func (sp *StreamParser) Run(ctx context.Context, streamer *replication.BinlogStr
 	// RotateEvent, to detect a same-file position wraparound (#845) live,
 	// during streaming — see the check at the top of handleEvent below.
 	var lastLogPos uint32
+	// fillCorr undoes the post-reconnect position overshoot FillZeroLogPos
+	// introduces when a resume lands mid-transaction on a MariaDB 11.4+
+	// source (#1117) — see resumeFillCorrector. It runs BEFORE the
+	// wraparound guard below so the guard (and everything downstream) only
+	// ever sees true file offsets.
+	var fillCorr resumeFillCorrector
 	// currentQueryText holds the original SQL statement from the most recent
 	// ROWS_QUERY_EVENT (MySQL, binlog_rows_query_log_events=ON) or
 	// ANNOTATE_ROWS event (MariaDB, binlog_annotate_row_events=ON; the syncer
@@ -226,6 +232,15 @@ func (sp *StreamParser) Run(ctx context.Context, streamer *replication.BinlogStr
 	// a graceful nil.
 	var handleEvent func(binlogEv *replication.BinlogEvent) error
 	handleEvent = func(binlogEv *replication.BinlogEvent) error {
+		// Post-reconnect fill correction (#1117) — must run before the
+		// wraparound guard so both the guard and the emitted events see true
+		// file offsets, not FillZeroLogPos's ghost-FDE overshoot.
+		if fillCorr.Observe(binlogEv) {
+			sp.logger.Debug("corrected a dynamically-filled binlog position inflated by the post-reconnect FDE overshoot",
+				"file", currentFile,
+				"event_type", binlogEv.Header.EventType.String(),
+				"pos", binlogEv.Header.LogPos)
+		}
 		// EventHeader.LogPos is a uint32 wire field (4 bytes, the SAME
 		// COM_BINLOG_DUMP format limit resolveStartForFlavor guards on resume,
 		// internal/streamrun/streamrun.go) — the position immediately after

--- a/internal/parser/wraparound_test.go
+++ b/internal/parser/wraparound_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/go-mysql-org/go-mysql/replication"
 )
 
@@ -89,6 +90,96 @@ func TestStreamParser_positionWraparound_mariadbHint(t *testing.T) {
 	}
 	if strings.Contains(err.Error(), "gtid_executed") {
 		t.Errorf("MariaDB error must not suggest MySQL's gtid_executed (unknown system variable on MariaDB), got: %v", err)
+	}
+}
+
+// TestStreamParser_filledFDEDoesNotFalseTripWraparound pins the #1117 guard
+// reconciliation: on a mid-file (re)connect the server re-sends the file's
+// FORMAT_DESCRIPTION event with LogPos zeroed on the wire, and go-mysql's
+// FillZeroLogPos (enabled for MariaDB 11.4+ sources) fills that zero to
+// resumePos+EventSize — a synthetic value that overshoots the next
+// transaction's real positions. Sequence verified live against MariaDB
+// 11.4.12: resume at 938 → fake rotate → FDE filled to 1190 → GTID event
+// real 980. Before the fix, the guard read 1190→980 as a same-file backward
+// jump and killed the stream; the FDE must neither trip the guard nor
+// advance its high-water mark.
+func TestStreamParser_filledFDEDoesNotFalseTripWraparound(t *testing.T) {
+	sp := NewStreamParser(nil, Filters{}, nil)
+	sp.SetFlavor("mariadb")
+	streamer := replication.NewBinlogStreamer()
+	out := make(chan Event, 16)
+
+	fde := &replication.BinlogEvent{
+		Header: &replication.EventHeader{
+			EventType: replication.FORMAT_DESCRIPTION_EVENT,
+			LogPos:    1190, // filled: resume pos 938 + EventSize 252
+			EventSize: 252,
+		},
+		Event: &replication.FormatDescriptionEvent{Version: 4},
+	}
+	gtid := &replication.BinlogEvent{
+		Header: &replication.EventHeader{EventType: replication.MARIADB_GTID_EVENT, LogPos: 980},
+		Event: &replication.MariadbGTIDEvent{
+			GTID: mysql.MariadbGTID{DomainID: 0, ServerID: 2, SequenceNumber: 42},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	feedThenCancel(t, streamer, cancel,
+		makeRotate("mariadb-bin.000002"), // fake resume rotate
+		fde,
+		gtid,
+		makeQueryEvent("BEGIN"),
+		makeXIDEvent(1175), // real commit position — below the filled FDE value
+	)
+
+	if err := sp.Run(ctx, streamer, out); err != nil {
+		t.Fatalf("Run: unexpected error after a filled connect-time FDE: %v", err)
+	}
+}
+
+// TestStreamParser_zeroLogPosRowFailsLoud pins the #1117 fail-loud belt: a row
+// event whose LogPos is below its EventSize (MariaDB 11.4+ sends
+// cache-buffered events with end_log_pos=0 when FillZeroLogPos is absent)
+// must abort the stream instead of being indexed with an underflowed
+// start_pos = 2^64-EventSize — a value the resume-time dedup treats as beyond
+// every checkpoint, deleting the whole file's rows on every restart.
+func TestStreamParser_zeroLogPosRowFailsLoud(t *testing.T) {
+	sp := NewStreamParser(makeOrdersResolver(), Filters{}, nil)
+	streamer := replication.NewBinlogStreamer()
+	out := make(chan Event, 16)
+
+	zeroPosRows := &replication.BinlogEvent{
+		Header: &replication.EventHeader{
+			EventType: replication.WRITE_ROWS_EVENTv1,
+			LogPos:    0, // as MariaDB 11.4+ writes it for cache-buffered events
+			EventSize: 53,
+		},
+		Event: &replication.RowsEvent{
+			Table: &replication.TableMapEvent{
+				Schema:      []byte("shop"),
+				Table:       []byte("orders"),
+				ColumnCount: 2,
+			},
+			Rows: [][]any{{int64(1), int64(10)}},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	feedThenCancel(t, streamer, cancel,
+		makeRotate("mariadb-bin.000002"),
+		zeroPosRows,
+	)
+
+	err := sp.Run(ctx, streamer, out)
+	if err == nil {
+		t.Fatal("expected a fail-loud error for a zero-LogPos row event, got nil")
+	}
+	if !strings.Contains(err.Error(), "could not be established") {
+		t.Errorf("error should say the position could not be established, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "shop.orders") {
+		t.Errorf("error should name the table, got: %v", err)
 	}
 }
 

--- a/internal/streamrun/mariadb_integration_test.go
+++ b/internal/streamrun/mariadb_integration_test.go
@@ -93,6 +93,10 @@ func TestStreamLoop_liveReplication_mariadb(t *testing.T) {
 		Port:     uint16(portN),
 		User:     mc.User,
 		Password: mc.Passwd,
+		// Mirrors the production syncer (#1117): MariaDB 11.4+ sends
+		// cache-buffered events with LogPos=0; without the fill the belt in
+		// handleRows rejects the rows rather than index underflowed positions.
+		FillZeroLogPos: true,
 	})
 	defer syncer.Close()
 
@@ -209,6 +213,7 @@ func TestStreamLoop_gtidAdvancesOnCommit_mariadb(t *testing.T) {
 	syncer := replication.NewBinlogSyncer(replication.BinlogSyncerConfig{
 		ServerID: 99996, Flavor: gomysql.MariaDBFlavor,
 		Host: hostStr, Port: uint16(portN), User: mc.User, Password: mc.Passwd,
+		FillZeroLogPos: true, // #1117 — mirrors the production syncer
 	})
 	defer syncer.Close()
 
@@ -256,6 +261,252 @@ func TestStreamLoop_gtidAdvancesOnCommit_mariadb(t *testing.T) {
 	// The persisted set must re-parse with the MariaDB parser (resume contract).
 	if _, err := parseGTIDSetForFlavor(gomysql.MariaDBFlavor, state.gtidSet); err != nil {
 		t.Errorf("accumulated MariaDB set %q does not re-parse: %v", state.gtidSet, err)
+	}
+}
+
+// TestStreamLoop_mariadbRowPositionsSaneAndMonotonic is the #1117 position
+// baseline: MariaDB 11.4+ writes cache-buffered events (TABLE_MAP, rows,
+// ANNOTATE) with end_log_pos=0 in the binlog, so without FillZeroLogPos every
+// captured row stored start_pos = 2^64-EventSize (underflow) and end_pos = 0.
+// This streams real traffic and asserts every indexed row carries sane,
+// monotonic positions. Starting mid-file (CurrentBinlogPosition of a server
+// with prior traffic) also exercises the connect-time FDE guard exemption
+// end-to-end: before the guard fix, FillZeroLogPos's filled FDE false-tripped
+// the wraparound detector on exactly this resume shape and Run failed loud.
+func TestStreamLoop_mariadbRowPositionsSaneAndMonotonic(t *testing.T) {
+	indexDB, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, indexDB)
+
+	sourceDB, sourceName := testutil.CreateTestMariaDB(t)
+
+	testutil.MustExec(t, sourceDB, `CREATE TABLE orders (
+		id INT PRIMARY KEY AUTO_INCREMENT, amount DECIMAL(10,2) NOT NULL)`)
+	if _, err := metadata.TakeSnapshot(sourceDB, indexDB, []string{sourceName}); err != nil {
+		t.Fatalf("TakeSnapshot: %v", err)
+	}
+
+	binlogFile, binlogPos, err := config.CurrentBinlogPosition(sourceDB)
+	if err != nil {
+		t.Fatalf("CurrentBinlogPosition: %v", err)
+	}
+
+	mc, err := drivermysql.ParseDSN(testutil.MariaDBBaseDSN() + "/" + sourceName + "?parseTime=true")
+	if err != nil {
+		t.Fatalf("ParseDSN: %v", err)
+	}
+	hostStr, portStr, _ := net.SplitHostPort(mc.Addr)
+	portN, _ := strconv.ParseUint(portStr, 10, 16)
+
+	for i := range 5 {
+		testutil.MustExec(t, sourceDB,
+			"INSERT INTO orders (amount) VALUES (?)", float64(i+1)*10.0)
+	}
+
+	syncer := replication.NewBinlogSyncer(replication.BinlogSyncerConfig{
+		ServerID: 99995, Flavor: gomysql.MariaDBFlavor,
+		Host: hostStr, Port: uint16(portN), User: mc.User, Password: mc.Passwd,
+		FillZeroLogPos: true, // #1117 — mirrors the production syncer
+	})
+	defer syncer.Close()
+
+	streamer, syncErr := syncer.StartSync(gomysql.Position{Name: binlogFile, Pos: binlogPos})
+	if syncErr != nil {
+		testutil.SkipOrFailMariaDB(t, "StartSync against MariaDB failed: %v", syncErr)
+	}
+
+	resolver, err := metadata.NewResolver(indexDB, 0)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+	sp := parser.NewStreamParser(resolver, parser.Filters{Schemas: map[string]bool{sourceName: true}}, nil)
+	sp.SetFlavor(gomysql.MariaDBFlavor)
+	idx := indexer.New(indexDB, 100)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	events := make(chan parser.Event, 100)
+	parseErrCh := make(chan error, 1)
+	go func() {
+		defer close(events)
+		parseErrCh <- sp.Run(ctx, streamer, events)
+	}()
+
+	state := &streamState{mode: "position", flavor: gomysql.MariaDBFlavor, serverID: 99995}
+	if err := streamLoop(ctx, events, idx, indexDB, time.Minute, state, observe.ForSource("test-mariadb-pos"), nil); err != nil {
+		t.Fatalf("streamLoop: %v", err)
+	}
+
+	parseErr := <-parseErrCh
+	if parseErr != nil &&
+		!errors.Is(parseErr, context.DeadlineExceeded) &&
+		!errors.Is(parseErr, context.Canceled) {
+		// A wraparound false-trip on the connect-time FDE lands here.
+		t.Fatalf("StreamParser error: %v", parseErr)
+	}
+
+	rows, err := indexDB.Query(
+		`SELECT binlog_file, start_pos, end_pos FROM binlog_events ORDER BY event_id`)
+	if err != nil {
+		t.Fatalf("query indexed positions: %v", err)
+	}
+	defer rows.Close()
+
+	var count int
+	lastByFile := map[string]uint64{}
+	for rows.Next() {
+		var file string
+		var start, end uint64
+		if err := rows.Scan(&file, &start, &end); err != nil {
+			t.Fatalf("scan positions: %v", err)
+		}
+		count++
+		// The corrupt shape this test exists to prevent: start ≈ 2^64, end = 0.
+		if end == 0 {
+			t.Errorf("row %d: end_pos = 0 (position was never established)", count)
+		}
+		if start >= end {
+			t.Errorf("row %d: start_pos %d >= end_pos %d", count, start, end)
+		}
+		// LogPos is a uint32 wire field; anything above 4GiB here is underflow.
+		if start > uint64(^uint32(0)) {
+			t.Errorf("row %d: start_pos %d exceeds the uint32 wire-format range (underflow)", count, start)
+		}
+		if prev, ok := lastByFile[file]; ok && start < prev {
+			t.Errorf("row %d: start_pos %d went backward from %d within %s", count, start, prev, file)
+		}
+		lastByFile[file] = start
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate positions: %v", err)
+	}
+	if count < 5 {
+		t.Fatalf("expected at least 5 indexed rows with positions to check, got %d", count)
+	}
+}
+
+// TestStreamLoop_mariadbResumeDedupDoesNotDeleteIndexedRows is the #1117
+// resume-safety acceptance (the GTID-mode half of #500's acceptance, which was
+// unrunnable while this bug corrupted start_pos): after streaming and
+// checkpointing MariaDB traffic, running the resume-time dedup against the
+// saved checkpoint — exactly what One does on restart — must delete NOTHING.
+// Before the fix, every row's start_pos (~2^64) satisfied `start_pos >= pos`
+// and the whole file's worth of indexed rows vanished on every restart.
+func TestStreamLoop_mariadbResumeDedupDoesNotDeleteIndexedRows(t *testing.T) {
+	indexDB, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, indexDB)
+
+	sourceDB, sourceName := testutil.CreateTestMariaDB(t)
+
+	testutil.MustExec(t, sourceDB, `CREATE TABLE orders (
+		id INT PRIMARY KEY AUTO_INCREMENT, amount DECIMAL(10,2) NOT NULL)`)
+	if _, err := metadata.TakeSnapshot(sourceDB, indexDB, []string{sourceName}); err != nil {
+		t.Fatalf("TakeSnapshot: %v", err)
+	}
+
+	binlogFile, binlogPos, err := config.CurrentBinlogPosition(sourceDB)
+	if err != nil {
+		t.Fatalf("CurrentBinlogPosition: %v", err)
+	}
+
+	var seedGTID string
+	if err := sourceDB.QueryRow("SELECT @@gtid_binlog_pos").Scan(&seedGTID); err != nil {
+		t.Fatalf("read @@gtid_binlog_pos: %v", err)
+	}
+	accGTID, err := parseGTIDSetForFlavor(gomysql.MariaDBFlavor, seedGTID)
+	if err != nil {
+		t.Fatalf("parse seed GTID %q: %v", seedGTID, err)
+	}
+
+	mc, err := drivermysql.ParseDSN(testutil.MariaDBBaseDSN() + "/" + sourceName + "?parseTime=true")
+	if err != nil {
+		t.Fatalf("ParseDSN: %v", err)
+	}
+	hostStr, portStr, _ := net.SplitHostPort(mc.Addr)
+	portN, _ := strconv.ParseUint(portStr, 10, 16)
+
+	testutil.MustExec(t, sourceDB, "INSERT INTO orders (amount) VALUES (10.0)")
+	testutil.MustExec(t, sourceDB, "INSERT INTO orders (amount) VALUES (20.0)")
+	testutil.MustExec(t, sourceDB, "INSERT INTO orders (amount) VALUES (30.0)")
+
+	syncer := replication.NewBinlogSyncer(replication.BinlogSyncerConfig{
+		ServerID: 99994, Flavor: gomysql.MariaDBFlavor,
+		Host: hostStr, Port: uint16(portN), User: mc.User, Password: mc.Passwd,
+		FillZeroLogPos: true, // #1117 — mirrors the production syncer
+	})
+	defer syncer.Close()
+
+	streamer, syncErr := syncer.StartSync(gomysql.Position{Name: binlogFile, Pos: binlogPos})
+	if syncErr != nil {
+		testutil.SkipOrFailMariaDB(t, "StartSync against MariaDB failed: %v", syncErr)
+	}
+
+	resolver, err := metadata.NewResolver(indexDB, 0)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+	sp := parser.NewStreamParser(resolver, parser.Filters{Schemas: map[string]bool{sourceName: true}}, nil)
+	sp.SetFlavor(gomysql.MariaDBFlavor)
+	idx := indexer.New(indexDB, 100)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	events := make(chan parser.Event, 100)
+	parseErrCh := make(chan error, 1)
+	go func() {
+		defer close(events)
+		parseErrCh <- sp.Run(ctx, streamer, events)
+	}()
+
+	state := &streamState{mode: "gtid", flavor: gomysql.MariaDBFlavor, serverID: 99994, accGTID: accGTID}
+	if err := streamLoop(ctx, events, idx, indexDB, time.Minute, state, observe.ForSource("test-mariadb-resume"), nil); err != nil {
+		t.Fatalf("streamLoop: %v", err)
+	}
+
+	parseErr := <-parseErrCh
+	if parseErr != nil &&
+		!errors.Is(parseErr, context.DeadlineExceeded) &&
+		!errors.Is(parseErr, context.Canceled) {
+		t.Fatalf("StreamParser error: %v", parseErr)
+	}
+
+	var indexed int
+	if err := indexDB.QueryRow("SELECT COUNT(*) FROM binlog_events").Scan(&indexed); err != nil {
+		t.Fatalf("count indexed rows: %v", err)
+	}
+	if indexed < 3 {
+		t.Fatalf("expected at least 3 indexed rows before the resume dedup, got %d", indexed)
+	}
+
+	saved, err := loadStreamState(indexDB)
+	if err != nil {
+		t.Fatalf("loadStreamState: %v", err)
+	}
+	if saved == nil {
+		t.Fatal("expected a saved checkpoint after streaming")
+	}
+	savedSet, err := parseGTIDSetForFlavor(gomysql.MariaDBFlavor, saved.gtidSet)
+	if err != nil {
+		t.Fatalf("re-parse saved GTID set %q: %v", saved.gtidSet, err)
+	}
+
+	// The exact resume-time cut One performs on restart, both modes. With sane
+	// start_pos values, nothing sits at-or-beyond the checkpoint.
+	n, err := deleteEventsSinceCheckpointGTID(indexDB, saved.binlogFile, saved.binlogPos, savedSet, gomysql.MariaDBFlavor)
+	if err != nil {
+		t.Fatalf("deleteEventsSinceCheckpointGTID: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("resume dedup deleted %d already-indexed rows; a restart must not destroy the index", n)
+	}
+
+	var after int
+	if err := indexDB.QueryRow("SELECT COUNT(*) FROM binlog_events").Scan(&after); err != nil {
+		t.Fatalf("count rows after dedup: %v", err)
+	}
+	if after != indexed {
+		t.Fatalf("row count changed across the resume dedup: %d -> %d", indexed, after)
 	}
 }
 

--- a/internal/streamrun/mariadb_integration_test.go
+++ b/internal/streamrun/mariadb_integration_test.go
@@ -510,6 +510,144 @@ func TestStreamLoop_mariadbResumeDedupDoesNotDeleteIndexedRows(t *testing.T) {
 	}
 }
 
+// TestStreamParser_mariadbMidTransactionResumeExactPositions is the #1117
+// review acceptance: a position-mode resume landing MID-TRANSACTION (a legal
+// #775 statement-boundary checkpoint) on MariaDB 11.4+. The server honors the
+// offset and re-sends the file's FDE with LogPos zeroed; FillZeroLogPos fills
+// that ghost to resumePos+len(FDE), and the transaction tail's cache-buffered
+// events inherit the overshoot until the genuine XID snaps back — so before
+// the resumeFillCorrector, the tail rows were stored inflated by exactly
+// len(FDE) (positions that are not event boundaries — a checkpoint persisting
+// one is a fatal 1236 on the next restart) and the snap-back tripped the
+// wraparound guard, killing the stream on every such resume.
+//
+// The test streams a 3-statement transaction twice: pass 1 from a
+// transaction boundary (known-good positions), pass 2 resuming from the
+// SECOND statement's end (mid-transaction). The tail row's positions in pass
+// 2 must EXACTLY equal pass 1's — the exactness anchor that catches any
+// constant-offset inflation a sane/monotonic check would miss.
+func TestStreamParser_mariadbMidTransactionResumeExactPositions(t *testing.T) {
+	indexDB, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, indexDB)
+
+	sourceDB, sourceName := testutil.CreateTestMariaDB(t)
+
+	testutil.MustExec(t, sourceDB, `CREATE TABLE orders (
+		id INT PRIMARY KEY AUTO_INCREMENT, amount DECIMAL(10,2) NOT NULL)`)
+	if _, err := metadata.TakeSnapshot(sourceDB, indexDB, []string{sourceName}); err != nil {
+		t.Fatalf("TakeSnapshot: %v", err)
+	}
+	resolver, err := metadata.NewResolver(indexDB, 0)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+
+	binlogFile, binlogPos, err := config.CurrentBinlogPosition(sourceDB)
+	if err != nil {
+		t.Fatalf("CurrentBinlogPosition: %v", err)
+	}
+
+	// One transaction, three statements — each statement is its own
+	// ANNOTATE/TABLE_MAP/rows(STMT_END_F) group in the binlog.
+	tx, err := sourceDB.Begin()
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	for i := range 3 {
+		if _, err := tx.Exec("INSERT INTO orders (amount) VALUES (?)", float64(i+1)*10.0); err != nil {
+			t.Fatalf("tx insert %d: %v", i, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	mc, err := drivermysql.ParseDSN(testutil.MariaDBBaseDSN() + "/" + sourceName + "?parseTime=true")
+	if err != nil {
+		t.Fatalf("ParseDSN: %v", err)
+	}
+	hostStr, portStr, _ := net.SplitHostPort(mc.Addr)
+	portN, _ := strconv.ParseUint(portStr, 10, 16)
+
+	// capture streams from (file, pos) with the production syncer config and
+	// returns the parsed events for this test's schema.
+	capture := func(serverID uint32, file string, pos uint32) []parser.Event {
+		t.Helper()
+		syncer := replication.NewBinlogSyncer(replication.BinlogSyncerConfig{
+			ServerID: serverID, Flavor: gomysql.MariaDBFlavor,
+			Host: hostStr, Port: uint16(portN), User: mc.User, Password: mc.Passwd,
+			FillZeroLogPos: true, // #1117 — mirrors the production syncer
+		})
+		defer syncer.Close()
+
+		streamer, syncErr := syncer.StartSync(gomysql.Position{Name: file, Pos: pos})
+		if syncErr != nil {
+			testutil.SkipOrFailMariaDB(t, "StartSync against MariaDB failed: %v", syncErr)
+		}
+
+		sp := parser.NewStreamParser(resolver, parser.Filters{Schemas: map[string]bool{sourceName: true}}, nil)
+		sp.SetFlavor(gomysql.MariaDBFlavor)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		events := make(chan parser.Event, 100)
+		parseErrCh := make(chan error, 1)
+		go func() {
+			defer close(events)
+			parseErrCh <- sp.Run(ctx, streamer, events)
+		}()
+		var got []parser.Event
+		for ev := range events {
+			got = append(got, ev)
+		}
+		if parseErr := <-parseErrCh; parseErr != nil &&
+			!errors.Is(parseErr, context.DeadlineExceeded) &&
+			!errors.Is(parseErr, context.Canceled) {
+			// Before the corrector, the mid-transaction pass died here with
+			// the wraparound false-trip.
+			t.Fatalf("StreamParser error: %v", parseErr)
+		}
+		return got
+	}
+
+	inserts := func(evs []parser.Event) []parser.Event {
+		var rows []parser.Event
+		for _, ev := range evs {
+			if ev.EventType == parser.EventInsert {
+				rows = append(rows, ev)
+			}
+		}
+		return rows
+	}
+
+	// Pass 1: from the pre-transaction boundary — known-good positions.
+	pass1 := inserts(capture(99993, binlogFile, binlogPos))
+	if len(pass1) != 3 {
+		t.Fatalf("pass 1: expected the 3 transaction rows, got %d", len(pass1))
+	}
+	for i := 1; i < 3; i++ {
+		if pass1[i].StartPos < pass1[i-1].EndPos {
+			t.Fatalf("pass 1 rows not contiguous/increasing: %+v", pass1)
+		}
+	}
+
+	// Pass 2: resume from the SECOND statement's end — mid-transaction.
+	midPos := uint32(pass1[1].EndPos)
+	pass2 := inserts(capture(99992, pass1[1].BinlogFile, midPos))
+	if len(pass2) != 1 {
+		t.Fatalf("pass 2 (mid-transaction resume): expected exactly the tail row, got %d rows", len(pass2))
+	}
+	// THE exactness anchor: the tail row's positions after a mid-transaction
+	// resume must byte-for-byte equal the positions a boundary start produced.
+	if pass2[0].StartPos != pass1[2].StartPos || pass2[0].EndPos != pass1[2].EndPos {
+		t.Errorf("mid-transaction resume stored tail row at [%d, %d], want exactly [%d, %d] (constant-offset inflation)",
+			pass2[0].StartPos, pass2[0].EndPos, pass1[2].StartPos, pass1[2].EndPos)
+	}
+	if pass2[0].PKValues != pass1[2].PKValues {
+		t.Errorf("mid-transaction resume replayed pk %q, want %q", pass2[0].PKValues, pass1[2].PKValues)
+	}
+}
+
 // TestDetectMariaDBGTIDGap_livePurge is the discriminator for real MariaDB GTID
 // gap detection. The sqlmock unit tests pin the decision tree; this proves the
 // three live queries (SHOW BINARY LOGS, BINLOG_GTID_POS, @@gtid_binlog_pos)

--- a/internal/streamrun/streamrun.go
+++ b/internal/streamrun/streamrun.go
@@ -2208,6 +2208,19 @@ func One(ctx context.Context, cfg Config) error {
 		// when binlog_annotate_row_events=ON wrote them to the binlog (#699).
 		// Harmless when the source has annotation off: no events, no cost.
 		syncerCfg.DumpCommandFlag |= replication.BINLOG_SEND_ANNOTATE_ROWS_EVENT
+		// MariaDB 11.4+ writes events that pass through the transaction or
+		// statement cache (TABLE_MAP, row events, ANNOTATE) with LogPos=0 in
+		// the binlog itself — only directly-written events (GTID, XID) carry a
+		// real end position. Without this, every captured row stores
+		// start_pos = 2^64-EventSize (underflow) and end_pos = 0, and the
+		// resume-time dedup (deleteEventsSinceCheckpoint's start_pos >= pos
+		// cut) then deletes every already-indexed row in the checkpoint's file
+		// on every restart (#1117). FillZeroLogPos makes go-mysql recompute
+		// LogPos for those events from the running position (exact, because it
+		// also forces BINLOG_SEND_ANNOTATE_ROWS_EVENT so no in-file event is
+		// missing from the wire). The option is library-gated to the MariaDB
+		// flavor and inert elsewhere.
+		syncerCfg.FillZeroLogPos = true
 	}
 
 	// Use a closure defer so the active syncer is always closed on exit,


### PR DESCRIPTION
closes #1117

## Problem

MariaDB 11.4+ writes events that pass through the transaction or statement cache (TABLE_MAP, row events, ANNOTATE) with `end_log_pos=0` — in the binlog file itself and on the wire. Only directly-written events (GTID, XID) carry a real position. Every captured row was therefore stored with `start_pos = 2^64-EventSize` (uint64 underflow) and `end_pos = 0`, and the resume-time dedup (`deleteEventsSinceCheckpoint`, predicate `binlog_file = ? AND start_pos >= ?`) matched every already-indexed row in the checkpoint's file and deleted it on **every** stream restart. Both resume modes are affected (the GTID path delegates the positional cut to the same function).

Reproduced live against MariaDB 11.4.12 (`mariadb:11.4`, the CI flags) with the pre-fix binary:

```
pk  binlog_file          start_pos             end_pos
4   mariadb-bin.000002   18446744073709551533  0
...
```

then on restart: `rows_deleted=5`, `SELECT COUNT(*) FROM binlog_events` → 0.

## Fix (four pieces)

**1. `FillZeroLogPos` on both syncer sites** (`internal/streamrun/streamrun.go`, `cliapp/agent.go`). go-mysql recomputes LogPos for zero, non-artificial events from the running position; the computation is exact because the option also forces `BINLOG_SEND_ANNOTATE_ROWS_EVENT`, so no in-file event is missing from the wire. The option is library-gated to the MariaDB flavor and inert elsewhere — the agent's flavor is fixed `"mysql"` today, so the site is set for correctness if a flavor flag is ever added, and placed inside the existing MariaDB block in streamrun.

**2. Wraparound guard reconciliation** (`internal/parser/stream.go`). With the fill enabled, every mid-file MariaDB resume killed the stream: the server re-sends the file's FDE with LogPos zeroed at connect, go-mysql fills it to `resumePos+EventSize` — a synthetic value that overshoots the next transaction's real positions. Verified live: resume at 938 → FDE filled to 1190 → next GTID event real 980 → guard read 1190→980 as a same-file backward jump. The FORMAT_DESCRIPTION event now neither trips the guard nor advances its high-water mark. No detection power is lost: a genuine 4GiB wrap can never first manifest on an FDE, because in-file FDEs sit at offset 4, immediately after a RotateEvent that already reset the tracker.

**3. File-parser fill** (`internal/parser/parser.go`). The zeros are in the file itself, so file-based `bintrail index` over a MariaDB 11.4+ binlog stored the same corrupt positions (confirmed by parsing a copied 11.4.12 binlog: rows events read back `LogPos=0`). `ParseFile` now tracks the running end offset and reconstructs `LogPos = lastEnd + EventSize` for zero, non-artificial events — exact, since parsing always starts at the file head; binlog files are contiguous. Transaction_payload inner events are unaffected (`rewriteInnerHeader` stamps them with the outer coordinates before they recurse).

**4. Fail-loud belt** (`handleRows`). A row event whose `LogPos < EventSize` now aborts with an actionable error instead of being indexed with an underflowed `start_pos` that the resume dedup treats as beyond every checkpoint. With 1–3 in place this only fires on a regression or an unforeseen zero-position source.

## Tests

- Unit: `TestStreamParser_filledFDEDoesNotFalseTripWraparound` (the live-verified 938/1190/980 sequence), `TestStreamParser_zeroLogPosRowFailsLoud`; the three pre-existing #845 wraparound guards still pass unchanged.
- Integration (MariaDB job): `TestStreamLoop_mariadbRowPositionsSaneAndMonotonic` (checklist a — also exercises the FDE exemption end-to-end, since it starts mid-file), `TestStreamLoop_mariadbResumeDedupDoesNotDeleteIndexedRows` (checklist b — runs the exact GTID-mode resume cut `One` performs and asserts zero deletions), position/monotonicity assertions added to `TestParseFile_realBinlog_mariadb` for the file path.
- All four fail on the previous commit — the file test with the underflow shape (`start_pos 18446744073709551566 >= end_pos 0`), the stream tests with the wraparound false-trip — and pass with the fix.
- The two pre-existing MariaDB streamLoop tests now set `FillZeroLogPos` to mirror the production syncer (without it the new belt correctly rejects the zero-position rows).

Verified with the built binary against MariaDB 11.4.12: sane positions (`start_pos=10069 end_pos=10152`), restart deletes nothing, prior rows retained, new traffic captured with monotonic positions and no duplicates.

Note: `TestDetectMariaDBGTIDGap_livePurge` fails locally against a long-lived MariaDB container with stale binlog state; it fails identically on `origin/main` and passes against a fresh `mariadb:11.4` container (what CI provides) — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)