### PR TITLE
verify: collapse the status→bucket classification into one exported home

### DIFF
--- a/consoleapp/verify.go
+++ b/consoleapp/verify.go
@@ -272,10 +272,10 @@ func (s *verifySupervisor) runBaselineAnchored(req console.VerifyRequest, baseli
 			continue
 		}
 		delete(seen, key)
-		s.appendResult(req.ServerID, console.VerifyTableResult{
-			Schema: st.Schema, Table: st.Table, Status: string(verify.StatusInconclusive),
+		s.appendResult(req.ServerID, toWireResult(verify.TableResult{
+			Schema: st.Schema, Table: st.Table, Status: verify.StatusInconclusive,
 			Detail: "new since the previous baseline — no predecessor image to reconstruct from",
-		})
+		}, false))
 	}
 	for _, st := range prevOnly {
 		key := st.Schema + "." + st.Table
@@ -283,17 +283,17 @@ func (s *verifySupervisor) runBaselineAnchored(req console.VerifyRequest, baseli
 			continue
 		}
 		delete(seen, key)
-		s.appendResult(req.ServerID, console.VerifyTableResult{
-			Schema: st.Schema, Table: st.Table, Status: string(verify.StatusInconclusive),
+		s.appendResult(req.ServerID, toWireResult(verify.TableResult{
+			Schema: st.Schema, Table: st.Table, Status: verify.StatusInconclusive,
 			Detail: "absent from the newest baseline (dropped, or the newest baseline was a --tables subset)",
-		})
+		}, false))
 	}
 	for key := range seen {
 		schema, table, _ := strings.Cut(key, ".")
-		s.appendResult(req.ServerID, console.VerifyTableResult{
-			Schema: schema, Table: table, Status: string(verify.StatusError),
+		s.appendResult(req.ServerID, toWireResult(verify.TableResult{
+			Schema: schema, Table: table, Status: verify.StatusError,
 			Detail: "requested via the tables filter but not present in the latest baseline pair",
-		})
+		}, false))
 	}
 	return nil
 }
@@ -390,9 +390,17 @@ func tableFilter(tables []string) (filter map[string]bool, seen map[string]bool)
 	return filter, seen
 }
 
+// toWireResult maps the engine's TableResult onto the console DTO. Every
+// result — engine-produced or synthesized by the run loop — funnels through
+// here, so the status is always normalized by the one classification the CLI
+// report also uses (verify.NormalizeStatus; #1127). Reason and Detail carry
+// the same value: Reason matches the CLI JSON field name, Detail is the
+// legacy #677 alias.
 func toWireResult(res verify.TableResult, explainable bool) console.VerifyTableResult {
+	status, reason := verify.NormalizeStatus(res.Status, res.Detail)
 	return console.VerifyTableResult{
-		Schema: res.Schema, Table: res.Table, Status: string(res.Status), Detail: res.Detail,
+		Schema: res.Schema, Table: res.Table, Status: string(status),
+		Reason: reason, Detail: reason,
 		SourceRows: res.SourceRows, ReconstructRows: res.ReconstructRows, Anchor: res.Anchor,
 		Explainable: explainable,
 	}
@@ -409,16 +417,13 @@ func (s *verifySupervisor) appendResult(serverID string, tr console.VerifyTableR
 		return // job was cleared out from under us; drop (defensive, shouldn't happen)
 	}
 	j.status.Results = append(j.status.Results, tr)
-	switch verify.Status(tr.Status) {
-	case verify.StatusMatch:
-		j.status.Summary.Match++
-	case verify.StatusMismatch:
-		j.status.Summary.Mismatch++
-	case verify.StatusInconclusive:
-		j.status.Summary.Inconclusive++
-	default:
-		j.status.Summary.Error++
-	}
+	// One classification for every surface: verify.Summary.Count applies the
+	// same buckets (and unknown→Error rule) the CLI's JSON report uses (#1127).
+	// The round-trip struct conversion is the drift guard: it stops compiling
+	// the moment console.VerifySummary and verify.Summary diverge.
+	sum := verify.Summary(j.status.Summary)
+	sum.Count(verify.Status(tr.Status))
+	j.status.Summary = console.VerifySummary(sum)
 }
 
 // cachePair records the BaselinePair behind a mismatched table for a later

--- a/consoleapp/verify_test.go
+++ b/consoleapp/verify_test.go
@@ -3,6 +3,7 @@ package consoleapp
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/dbtrail/dbtrail/internal/console"
@@ -37,7 +38,8 @@ func TestToWireResult(t *testing.T) {
 	}
 	got := toWireResult(res, true)
 	want := console.VerifyTableResult{
-		Schema: "wp", Table: "posts", Status: "mismatch", Detail: "row count differs",
+		Schema: "wp", Table: "posts", Status: "mismatch",
+		Reason: "row count differs", Detail: "row count differs",
 		SourceRows: 10, ReconstructRows: 9, Anchor: "mysql-bin.000123:456", Explainable: true,
 	}
 	if got != want {
@@ -45,6 +47,21 @@ func TestToWireResult(t *testing.T) {
 	}
 	if got := toWireResult(res, false); got.Explainable {
 		t.Error("explainable must be exactly what the caller passed, not re-derived from Status")
+	}
+
+	// An unrecognized engine status is normalized BEFORE it reaches the wire —
+	// the same verify.NormalizeStatus decision the CLI's JSON report applies,
+	// so the console can never serialize a status a consumer's switch would
+	// fall through (#1127).
+	bad := toWireResult(verify.TableResult{Schema: "wp", Table: "x", Status: "bogus", Detail: "who knows"}, false)
+	if bad.Status != string(verify.StatusError) {
+		t.Errorf("unknown status serialized as %q, want %q", bad.Status, verify.StatusError)
+	}
+	if !strings.Contains(bad.Reason, "unrecognized verify status") || !strings.Contains(bad.Reason, "who knows") {
+		t.Errorf("unknown status reason lost the cause: %q", bad.Reason)
+	}
+	if bad.Detail != bad.Reason {
+		t.Errorf("detail (legacy alias) = %q, must equal reason %q", bad.Detail, bad.Reason)
 	}
 }
 
@@ -88,9 +105,9 @@ func TestVerifySupervisor_Trigger_collision(t *testing.T) {
 
 // TestVerifySupervisor_appendResult_accumulatesSummary: results grow in
 // call order and each status bucket (including an unrecognized status
-// falling through to Error, mirroring the CLI's anti-false-assurance
-// classification in verify.normalizeStatus) is tallied correctly — this is the
-// exact bookkeeping "as they land" polling depends on.
+// falling through to Error — the tally goes through verify.Summary.Count,
+// the same classification the CLI's JSON report uses) is tallied correctly —
+// this is the exact bookkeeping "as they land" polling depends on.
 func TestVerifySupervisor_appendResult_accumulatesSummary(t *testing.T) {
 	s := newVerifySupervisor(context.Background())
 	s.jobs["srv1"] = &verifyJob{status: console.VerifyStatus{State: "running"}}
@@ -104,7 +121,7 @@ func TestVerifySupervisor_appendResult_accumulatesSummary(t *testing.T) {
 	if len(got.Results) != 4 || got.Results[0].Table != "posts" || got.Results[3].Table != "bad" {
 		t.Fatalf("Results = %+v, want 4 entries in append order", got.Results)
 	}
-	want := console.VerifySummary{Match: 1, Mismatch: 1, Inconclusive: 1, Error: 1}
+	want := console.VerifySummary{Match: 1, Mismatch: 1, Inconclusive: 1, Error: 1, Total: 4}
 	if got.Summary != want {
 		t.Errorf("Summary = %+v, want %+v (an unrecognized status must fall through to Error)", got.Summary, want)
 	}

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -2315,11 +2315,13 @@ function renderVerifyResults(container, status, id) {
 
   const cards = el("div", { class: "doctor-cards" });
   (status.results || []).forEach((r) => {
-    const cls = VFY_STATUS_CLASS[r.status] || "warn";
+    // Statuses are normalized server-side (verify.NormalizeStatus), so only
+    // the four keys above can arrive; if that ever breaks, fail — never reassure.
+    const cls = VFY_STATUS_CLASS[r.status] || "fail";
     const card = el("div", { class: "doctor-card " + cls });
     card.append(el("span", { class: "dc-mark", text: VFY_STATUS_MARK[cls] || "?" }));
     const body = el("div", { class: "dc-body" },
-      el("div", { class: "dc-name", text: r.schema + "." + r.table + " — " + r.status + (r.detail ? " — " + r.detail : "") }));
+      el("div", { class: "dc-name", text: r.schema + "." + r.table + " — " + r.status + (r.reason ? " — " + r.reason : "") }));
     if (r.explainable) {
       const explainBtn = el("button", { class: "btn btn-sm btn-ghost", type: "button", text: "Explain" });
       explainBtn.onclick = () => openVerifyExplain(id, r.schema, r.table);

--- a/internal/console/verify_trigger.go
+++ b/internal/console/verify_trigger.go
@@ -99,7 +99,10 @@ type VerifyTableResult struct {
 // Its fields mirror verify.Summary EXACTLY — same names, types and order —
 // because consoleapp's supervisor tallies through verify.Summary.Count (the
 // one bucket classification, #1127) and publishes here via a struct
-// conversion, which the compiler rejects the moment the two shapes drift.
+// conversion. The compiler rejects that conversion when field names, order,
+// or types drift; struct TAGS are ignored by conversion identity, so a JSON
+// tag rename on either side would NOT be caught — keep the tags in sync by
+// hand.
 // It stays a distinct type only because this package must not import
 // internal/verify (the read layer must not link the capture library —
 // see internal/event's dep guard).

--- a/internal/console/verify_trigger.go
+++ b/internal/console/verify_trigger.go
@@ -73,9 +73,18 @@ type VerifyRequest struct {
 
 // VerifyTableResult is the wire view of one table's verify.TableResult.
 type VerifyTableResult struct {
-	Schema          string `json:"schema"`
-	Table           string `json:"table"`
-	Status          string `json:"status"` // match | mismatch | inconclusive | error
+	Schema string `json:"schema"`
+	Table  string `json:"table"`
+	// Status is normalized through verify.NormalizeStatus before it reaches
+	// the wire — the same status→bucket decision the CLI's JSON report uses,
+	// so an unrecognized engine status surfaces as "error", never as a benign
+	// value (#1127).
+	Status string `json:"status"` // match | mismatch | inconclusive | error
+	// Reason is the detail behind the verdict — the same datum, under the same
+	// name, as the CLI's `verify --format json` per-table `reason`.
+	Reason string `json:"reason,omitempty"`
+	// Detail is the legacy alias for Reason, kept for consumers of the
+	// original #677 wire shape. Always carries the same value as Reason.
 	Detail          string `json:"detail,omitempty"`
 	SourceRows      int64  `json:"source_rows,omitempty"`
 	ReconstructRows int64  `json:"reconstruct_rows,omitempty"`
@@ -87,11 +96,21 @@ type VerifyTableResult struct {
 }
 
 // VerifySummary tallies VerifyStatus.Results by status, for a run's headline.
+// Its fields mirror verify.Summary EXACTLY — same names, types and order —
+// because consoleapp's supervisor tallies through verify.Summary.Count (the
+// one bucket classification, #1127) and publishes here via a struct
+// conversion, which the compiler rejects the moment the two shapes drift.
+// It stays a distinct type only because this package must not import
+// internal/verify (the read layer must not link the capture library —
+// see internal/event's dep guard).
 type VerifySummary struct {
 	Match        int `json:"match"`
 	Mismatch     int `json:"mismatch"`
 	Inconclusive int `json:"inconclusive"`
 	Error        int `json:"error"`
+	// Total is the number of results tallied — the same `total` the CLI's
+	// `verify --format json` summary carries.
+	Total int `json:"total"`
 }
 
 // VerifyStatus is the pollable state of a server's most recent verify run.

--- a/internal/verify/report.go
+++ b/internal/verify/report.go
@@ -40,12 +40,15 @@ const (
 // the per-table Anchor the text table has no column for.
 //
 // It is the payload of `bintrail verify --format json`, and ONLY that. The
-// console's verify surface (#677) already shipped with a wire shape of its own
-// — console.VerifyTableResult/VerifySummary/VerifyStatus, fed by consoleapp's
-// verifySupervisor, which classifies statuses into buckets itself (including
-// the same default→Error rule normalizeStatus owns here). The two shapes are
-// deliberately NOT unified today; unifying them is follow-up work, not an
-// assumption anything here may rely on.
+// console's verify surface (#677) shipped with a per-table wire shape of its
+// own — console.VerifyTableResult/VerifyStatus, fed by consoleapp's
+// verifySupervisor — but both surfaces share this package's classification:
+// NormalizeStatus decides every table's bucket and Summary.Count tallies it,
+// so the CLI and the console can never disagree on whether a status counts as
+// a pass, a failure, or "couldn't tell" (#1127). The console's summary mirrors
+// this package's Summary field-for-field (console cannot import this package —
+// it must not link the capture library — so consoleapp publishes the tally via
+// a compile-checked struct conversion).
 //
 // It is still built in this package rather than in the command layer so the
 // construction stays pure — NewReport does no IO, reads no flags, writes no
@@ -110,13 +113,34 @@ type TableReport struct {
 	ChainsInconclusive int `json:"chains_inconclusive,omitempty"`
 }
 
-// Summary is the run's per-status counts.
+// Summary is the run's per-status counts. The console's VerifySummary mirrors
+// it field-for-field (enforced by a struct conversion in consoleapp), so both
+// machine-readable surfaces tally with the same buckets and field names.
 type Summary struct {
 	Match        int `json:"match"`
 	Mismatch     int `json:"mismatch"`
 	Inconclusive int `json:"inconclusive"`
 	Error        int `json:"error"`
 	Total        int `json:"total"`
+}
+
+// Count files one table's status under its summary bucket and bumps Total.
+// The status is normalized first, so an unrecognized value lands in Error —
+// every summary, CLI or console, applies the default-to-failure rule from the
+// one place that owns it (NormalizeStatus) instead of re-deciding it locally.
+func (s *Summary) Count(status Status) {
+	normalized, _ := NormalizeStatus(status, "")
+	switch normalized {
+	case StatusMatch:
+		s.Match++
+	case StatusMismatch:
+		s.Mismatch++
+	case StatusInconclusive:
+		s.Inconclusive++
+	case StatusError:
+		s.Error++
+	}
+	s.Total++
 }
 
 // ExplainReport is the JSON-facing form of a MismatchExplanation. The internal
@@ -172,17 +196,8 @@ func NewReport(mode string, results []TableResult) *Report {
 
 	rep := &Report{Mode: mode, Tables: make([]TableReport, 0, len(sorted))}
 	for _, r := range sorted {
-		status, reason := normalizeStatus(r.Status, r.Detail)
-		switch status {
-		case StatusMatch:
-			rep.Summary.Match++
-		case StatusMismatch:
-			rep.Summary.Mismatch++
-		case StatusInconclusive:
-			rep.Summary.Inconclusive++
-		default:
-			rep.Summary.Error++
-		}
+		status, reason := NormalizeStatus(r.Status, r.Detail)
+		rep.Summary.Count(status)
 		rep.Tables = append(rep.Tables, TableReport{
 			Schema:            r.Schema,
 			Table:             r.Table,
@@ -199,7 +214,6 @@ func NewReport(mode string, results []TableResult) *Report {
 			ChainsInconclusive: r.ChainsInconclusive,
 		})
 	}
-	rep.Summary.Total = len(rep.Tables)
 	rep.Verdict = verdictOf(rep.Summary)
 	return rep
 }
@@ -217,12 +231,14 @@ func NewNoPredecessorReport(mode, baselineSource, message string) *Report {
 	}
 }
 
-// normalizeStatus maps a TableResult status onto the canonical status a
-// consumer sees. An unrecognized status (including the zero value) is reported
-// as an error, never filed under the benign inconclusive bucket — a verify
-// tool's job is to not hand out false assurance — and the raw value is kept in
-// the reason so the cause is not lost.
-func normalizeStatus(s Status, detail string) (Status, string) {
+// NormalizeStatus maps a TableResult status onto the canonical status a
+// consumer sees — the ONE status→bucket decision every verify surface uses
+// (the CLI report here, the console wire path in consoleapp; #1127). An
+// unrecognized status (including the zero value) is reported as an error,
+// never filed under the benign inconclusive bucket — a verify tool's job is
+// to not hand out false assurance — and the raw value is kept in the reason
+// so the cause is not lost.
+func NormalizeStatus(s Status, detail string) (Status, string) {
 	switch s {
 	case StatusMatch, StatusMismatch, StatusInconclusive, StatusError:
 		return s, detail

--- a/internal/verify/report_test.go
+++ b/internal/verify/report_test.go
@@ -65,6 +65,41 @@ func TestNewReportUnknownStatus(t *testing.T) {
 	}
 }
 
+// TestNormalizeStatusBuckets pins the single status→bucket decision (#1127)
+// shared by the CLI report and the console wire path: every canonical status
+// passes through unchanged, and anything else — including the zero value —
+// lands in Error, never in a benign bucket.
+func TestNormalizeStatusBuckets(t *testing.T) {
+	for _, s := range []Status{StatusMatch, StatusMismatch, StatusInconclusive, StatusError} {
+		got, reason := NormalizeStatus(s, "note")
+		if got != s || reason != "note" {
+			t.Errorf("NormalizeStatus(%q) = (%q, %q), want passed through unchanged", s, got, reason)
+		}
+	}
+	for _, raw := range []Status{"", "bogus", "MATCH"} {
+		got, reason := NormalizeStatus(raw, "ctx")
+		if got != StatusError {
+			t.Errorf("NormalizeStatus(%q) = %q, want %q", raw, got, StatusError)
+		}
+		if !strings.Contains(reason, "unrecognized verify status") || !strings.Contains(reason, "ctx") {
+			t.Errorf("NormalizeStatus(%q) reason = %q, want the raw value and detail kept", raw, reason)
+		}
+	}
+}
+
+// TestSummaryCount: Count normalizes before tallying, so a caller feeding it
+// raw wire strings (the console supervisor) can never file an unknown status
+// outside Error, and Total always equals the number of Count calls.
+func TestSummaryCount(t *testing.T) {
+	var s Summary
+	for _, st := range []Status{StatusMatch, StatusMismatch, StatusInconclusive, StatusError, "", "bogus"} {
+		s.Count(st)
+	}
+	if s != (Summary{Match: 1, Mismatch: 1, Inconclusive: 1, Error: 3, Total: 6}) {
+		t.Errorf("summary = %+v, want 1/1/1/3 with total 6", s)
+	}
+}
+
 // TestReportExitError locks the exit contract and its precedence.
 func TestReportExitError(t *testing.T) {
 	r := func(s Status) TableResult { return TableResult{Schema: "db", Table: "t", Status: s} }


### PR DESCRIPTION
closes #1127

## What

The status→bucket classification ("does this table's status count as a pass, a failure, or couldn't-tell") existed in three places and could diverge — and on `verify`, a divergence is false assurance. This PR collapses it to one home in `internal/verify`:

- **`verify.NormalizeStatus`** (exported rename of `normalizeStatus`) is now THE status→bucket decision. Unknown or zero-value statuses land in `error`, never a benign bucket, with the raw value preserved in the reason.
- **`verify.Summary.Count`** normalizes before tallying and bumps `Total`, so every summary applies the rule from the one place that owns it. `NewReport` uses both; `Report.ExitError()` remains the single exit decision, untouched.
- **consoleapp**: the `appendResult` bucket switch is deleted — it tallies through `verify.Summary.Count`. All synthesized results (unpaired / prev-only / filter-miss) now funnel through `toWireResult`, which normalizes via `verify.NormalizeStatus`, so no unnormalized status can reach the wire.
- **internal/console**: `VerifySummary` cannot alias `verify.Summary` directly — the read layer must not link the capture library (`internal/event`'s dep guard fails if `internal/console` transitively links go-mysql, which `internal/verify` imports). It stays a distinct struct mirroring `verify.Summary` field-for-field; consoleapp publishes the tally via a round-trip struct conversion (`verify.Summary(j.status.Summary)` / back), which stops compiling the moment the two shapes drift. That conversion is the drift guard.
- The stale premise comment in `internal/verify/report.go` ("a future console /api/verify (#677)…") is rewritten to describe the real, shipped situation.

## Wire shape (additive only — no breaking change)

Consumers inspected: the embedded frontend (`internal/console/assets/app.js`) reads `status.summary.{match,mismatch,inconclusive,error}`, `r.status`, `r.detail`, `r.explainable`. `/api/verify` is a shipped HTTP API, so external scripted consumers may exist — field renames are off the table.

- `VerifySummary` gains `total` (additive; matches the CLI JSON summary).
- `VerifyTableResult` gains `reason` — the same field name `verify --format json` emits for the same datum — and keeps `detail` as a documented legacy alias always carrying the same value.
- The embedded frontend now reads `reason`, and its unknown-status fallback class changed from `warn` to `fail` (it was a fourth copy of the classification, and it resolved unknown toward reassurance; it is dead-code defense now that the backend normalizes, but if it ever fires it should fail).

## Tests

- `TestNormalizeStatusBuckets` + `TestSummaryCount` pin the single home: every canonical status passes through unchanged; `""`, `"bogus"`, `"MATCH"` → `error` with the cause kept in the reason.
- `TestToWireResult` extended: unknown engine status is normalized before the wire; `detail == reason`.
- `TestVerifySupervisor_appendResult_accumulatesSummary` updated for `Total`.
- Existing verify report/exit tests pass unmodified.

Ran: `go build ./...`, `go vet ./...`, `go vet -tags integration ./...`, `go test ./... -count=1`, `go test -race -count=1 ./internal/verify/ ./internal/console/ ./consoleapp/`, `go test -tags integration -count=1` on the same three packages — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)