### PR TITLE
mcp: add a recover_cascade tool

### DIFF
--- a/cmd/bintrail-mcp/bridge_integration_test.go
+++ b/cmd/bintrail-mcp/bridge_integration_test.go
@@ -94,9 +94,9 @@ func TestIntegrationBridgePassthrough(t *testing.T) {
 		}
 	}
 	sort.Strings(names)
-	// reconstruct (#953) is part of the standalone posture, so the bridge must
-	// mirror it like every other tool.
-	want := []string{"list_schema_changes", "query", "reconstruct", "recover", "status"}
+	// reconstruct (#953) and recover_cascade (#1128) are part of the standalone
+	// posture, so the bridge must mirror them like every other tool.
+	want := []string{"list_schema_changes", "query", "reconstruct", "recover", "recover_cascade", "status"}
 	if strings.Join(names, ",") != strings.Join(want, ",") {
 		t.Fatalf("mirrored tools = %v, want %v", names, want)
 	}

--- a/cmd/bintrail-mcp/e2e_test.go
+++ b/cmd/bintrail-mcp/e2e_test.go
@@ -104,11 +104,12 @@ func TestMCPE2E(t *testing.T) {
 		t.Fatalf("tools/list: expected result object, got: %v", listResp)
 	}
 	tools, _ := listResult["tools"].([]any)
-	// The standalone server opts into reconstruct (#953) on top of the four
-	// always-on tools; its baseline source is per-call, so it is advertised
-	// regardless of whether a baseline is configured.
-	if len(tools) != 5 {
-		t.Errorf("tools/list: expected 5 tools, got %d", len(tools))
+	// The standalone server opts into reconstruct (#953) and recover_cascade
+	// (#1128) on top of the four always-on tools; its baseline source is
+	// per-call, so both are advertised regardless of whether a baseline is
+	// configured.
+	if len(tools) != 6 {
+		t.Errorf("tools/list: expected 6 tools, got %d", len(tools))
 	}
 
 	toolNames := make(map[string]bool)
@@ -117,7 +118,7 @@ func TestMCPE2E(t *testing.T) {
 			toolNames[m["name"].(string)] = true
 		}
 	}
-	for _, want := range []string{"query", "recover", "status", "list_schema_changes", "reconstruct"} {
+	for _, want := range []string{"query", "recover", "recover_cascade", "status", "list_schema_changes", "reconstruct"} {
 		if !toolNames[want] {
 			t.Errorf("tool %q not found in list", want)
 		}

--- a/cmd/bintrail-mcp/integration_test.go
+++ b/cmd/bintrail-mcp/integration_test.go
@@ -76,16 +76,17 @@ func TestListTools(t *testing.T) {
 		names[tool.Name] = true
 	}
 
-	// reconstruct (#953) is opted into by the standalone posture on top of the
-	// four always-on tools — its baseline source is resolved per call, so it is
-	// advertised whether or not one is configured.
-	for _, want := range []string{"query", "recover", "status", "list_schema_changes", "reconstruct"} {
+	// reconstruct (#953) and recover_cascade (#1128) are opted into by the
+	// standalone posture on top of the four always-on tools — reconstruct's
+	// baseline source is resolved per call, and recover_cascade needs no
+	// baseline at all (Phase-1), so both are advertised unconditionally.
+	for _, want := range []string{"query", "recover", "recover_cascade", "status", "list_schema_changes", "reconstruct"} {
 		if !names[want] {
 			t.Errorf("tool %q not found; got: %v", want, names)
 		}
 	}
-	if len(result.Tools) != 5 {
-		t.Errorf("expected 5 tools, got %d", len(result.Tools))
+	if len(result.Tools) != 6 {
+		t.Errorf("expected 6 tools, got %d", len(result.Tools))
 	}
 }
 

--- a/cmd/bintrail-mcp/main.go
+++ b/cmd/bintrail-mcp/main.go
@@ -1,6 +1,6 @@
 // bintrail-mcp is an MCP (Model Context Protocol) server that exposes
-// read-only Bintrail operations as tools: query, recover, reconstruct,
-// status, and list_schema_changes.
+// read-only Bintrail operations as tools: query, recover, recover_cascade,
+// reconstruct, status, and list_schema_changes.
 //
 // By default it communicates over stdio (for use as a subprocess by Claude
 // Code, Cursor, etc.). Pass --http <addr> to start an HTTP server instead,
@@ -92,8 +92,8 @@ func standaloneConfig(resolve mcptools.ResolveTarget) mcptools.Config {
 	return mcptools.Config{
 		Version: mcpVersion,
 		Instructions: "Bintrail MCP server for querying indexed MySQL binlog events, " +
-			"generating recovery SQL, reconstructing a row's state at a point in time, " +
-			"and viewing index status. " +
+			"generating recovery SQL (including reversal of foreign-key cascade side effects), " +
+			"reconstructing a row's state at a point in time, and viewing index status. " +
 			"Set BINTRAIL_INDEX_DSN environment variable or pass index_dsn on each tool call.",
 		Resolve:           resolve,
 		AllowDSNParam:     true,
@@ -105,6 +105,11 @@ func standaloneConfig(resolve mcptools.ResolveTarget) mcptools.Config {
 		// long-lived per-server configuration.
 		Reconstruct:         true,
 		AllowBaselineParams: true,
+		// FK-cascade recovery (#1128). Registered unconditionally — unlike
+		// reconstruct it needs no baseline (Phase-1 window-only synthesis);
+		// the tool's baseline_dir/baseline_s3 parameters (or the env vars
+		// above) merely enable the Phase-2 fallback per call.
+		RecoverCascade: true,
 	}
 }
 

--- a/docs/connect-ai.md
+++ b/docs/connect-ai.md
@@ -89,8 +89,8 @@ That's it. No config files were harmed.
 
 ## Step 3 — ask something
 
-Open a new Claude Desktop conversation. The `query`, `recover`, `status`,
-`list_schema_changes`, and `reconstruct` tools are now available. Try:
+Open a new Claude Desktop conversation. The `query`, `recover`, `recover_cascade`,
+`status`, `list_schema_changes`, and `reconstruct` tools are now available. Try:
 
 > "Show me the last 20 changes in the `wordpress` schema."
 >

--- a/docs/connect-ai.md
+++ b/docs/connect-ai.md
@@ -12,9 +12,10 @@ plain English — from **Claude Desktop**, claude.ai, or any MCP-capable client:
 This page is the shortest path there. No JSON files, no DSNs, no SSH gymnastics.
 (If you want every option and knob instead, that's [mcp-server.md](mcp-server.md).)
 
-**What the AI can and cannot do, up front:** it gets five **read-only** tools —
-search changes, draft reversal SQL, reconstruct a row's state at a point in time,
-show index status, list schema changes. It sees exactly what the web console
+**What the AI can and cannot do, up front:** it gets six **read-only** tools —
+search changes, draft reversal SQL (including for foreign-key cascade side
+effects), reconstruct a row's state at a point in time, show index status, list
+schema changes. It sees exactly what the web console
 shows you, with the same result caps and the same redactions. It **never executes
 SQL** and never connects to your source database — recovery SQL is text you review
 and run yourself. (Time travel needs a baseline snapshot configured for that
@@ -145,7 +146,7 @@ directly with a DSN — see [mcp-server.md](mcp-server.md).
 
 - The endpoint requires the console token on **every** request; unknown hosts
   are rejected by the same host-header allowlist as the rest of the console.
-- The five tools are read-only and annotated as such (`ReadOnlyHint`); the AI
+- The six tools are read-only and annotated as such (`ReadOnlyHint`); the AI
   cannot write to the index, the source, or anywhere else through them.
 - Responses carry the console's field redactions — e.g. captured SQL statement
   text is withheld, same as the console UI.

--- a/docs/console.md
+++ b/docs/console.md
@@ -689,10 +689,10 @@ per server as `source` in [`/api/capabilities`](#api), derived from
 
 ## MCP endpoint
 
-The console serves the same five read-only MCP tools as
-[`bintrail-mcp`](mcp-server.md) — `query`, `recover`, `reconstruct`, `status`,
-`list_schema_changes` — over **Streamable HTTP**, on both `bintrail-console
-serve` and `bintrail-console watch`:
+The console serves the same six read-only MCP tools as
+[`bintrail-mcp`](mcp-server.md) — `query`, `recover`, `recover_cascade`,
+`reconstruct`, `status`, `list_schema_changes` — over **Streamable HTTP**, on
+both `bintrail-console serve` and `bintrail-console watch`:
 
 | URL | Target |
 |---|---|

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -372,7 +372,7 @@ bintrail up \
 
 **Situation:** You want to investigate database changes in natural language from Claude — Claude Code, Claude Desktop, or claude.ai — instead of typing CLI commands.
 
-dbtrail ships an MCP server that exposes `query`, `recover`, `status`, `list_schema_changes`, and `reconstruct` as AI tools. Once connected, you can ask:
+dbtrail ships an MCP server that exposes `query`, `recover`, `recover_cascade`, `status`, `list_schema_changes`, and `reconstruct` as AI tools. Once connected, you can ask:
 
 ```
 "What tables had deletions in the last hour?"

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -12,8 +12,9 @@ recoveries in plain English. Once connected, you can ask:
 >
 > "What schema changes happened this week?"
 
-It exposes five **read-only** tools — `query`, `recover` (generates reversal SQL,
-never runs it), `reconstruct` (a row's state at a point in time), `status`, and
+It exposes six **read-only** tools — `query`, `recover` (generates reversal SQL,
+never runs it), `recover_cascade` (reversal SQL for foreign-key cascade side
+effects), `reconstruct` (a row's state at a point in time), `status`, and
 `list_schema_changes` — and never writes to your database.
 
 > **First time?** If you run the web console, the shortest path is the
@@ -176,32 +177,33 @@ endpoint at all.
 Once such a gateway is reachable at a public URL: in **claude.ai → Settings →
 Integrations → Add custom integration**, enter the gateway URL (your domain, or
 `https://mcp.dbtrail.com/mcp` for managed customers), complete the OAuth login,
-and the five tools appear. Works from web, Desktop, and mobile; tokens refresh
+and the six tools appear. Works from web, Desktop, and mobile; tokens refresh
 automatically.
 
 ---
 
-## The five tools
+## The six tools
 
 | Tool | CLI equivalent | What it does |
 |---|---|---|
 | `query` | `bintrail query` | Search indexed row changes with filters |
 | `recover` | `bintrail recover --dry-run` | Generate reversal SQL (never executes it) |
+| `recover_cascade` | `bintrail recover-cascade --dry-run` | Generate reversal SQL for foreign-key `ON DELETE`/`ON UPDATE` cascade side effects InnoDB ran below the binlog — the child rows plain `recover` cannot see. Fails with the reasons when the synthesis is provably partial, unless `allow_incomplete` is set |
 | `reconstruct` | `bintrail reconstruct` | A single row's full state at a point in time (needs a baseline) |
 | `status` | `bintrail status` | Indexed files, partitions, and summary |
 | `list_schema_changes` | reads `schema_changes` (see [DDL tracking](./ddl-tracking.md)) | DDL changes recorded while indexing/streaming, with the full statement and binlog coordinates |
 
-All five are read-only — annotated `ReadOnlyHint: true` and `IdempotentHint: true`,
+All six are read-only — annotated `ReadOnlyHint: true` and `IdempotentHint: true`,
 so the client knows they're safe to call repeatedly and never modify state.
 
-If your client lists tools beyond these five, you are running a build that
+If your client lists tools beyond these six, you are running a build that
 registers extras through the extension seam (`ext/mcpext`) — a distribution
 that wraps this core, not the stock binary. Such tools resolve their index
-through the same routing as the built-in five, so they read the server you
+through the same routing as the built-in six, so they read the server you
 selected and inherit its posture, including the console's refusal of a
 tool-level `index_dsn`.
 
-The same five tools are also served by the web console at `/mcp` (Streamable
+The same six tools are also served by the web console at `/mcp` (Streamable
 HTTP, console-token auth, per-server routing by URL path) — if you already run
 `bintrail-console`, you may not need this binary at all; see
 [console.md](console.md#mcp-endpoint).

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -63,8 +63,8 @@ everywhere):
 }
 ```
 
-Restart Claude Code. The `query`, `recover`, `status`, `list_schema_changes`,
-and `reconstruct` tools appear — now ask: *"What changed in the orders table in the last hour?"*
+Restart Claude Code. The `query`, `recover`, `recover_cascade`, `status`,
+`list_schema_changes`, and `reconstruct` tools appear — now ask: *"What changed in the orders table in the last hour?"*
 
 > Working inside the dbtrail **source repo**? Use
 > `"command": "go", "args": ["run", "./cmd/bintrail-mcp"]` instead — no separate

--- a/ext/audit.go
+++ b/ext/audit.go
@@ -21,9 +21,9 @@ import (
 //     reconstruct.run, verify.explain. bintrail-pg shares
 //     these command implementations (internal/cli) and so
 //     reports the same "cli" surface; there is no "pg" surface.
-//   - "mcp"     — query.run, recover.generate, reconstruct.row
-//     (internal/mcptools; the console's /mcp endpoint reuses the
-//     same handlers with Surface "console").
+//   - "mcp"     — query.run, recover.generate, recover.cascade,
+//     reconstruct.row (internal/mcptools; the console's /mcp
+//     endpoint reuses the same handlers with Surface "console").
 //   - "shim"    — timetravel.query, for every virtual schema that returns
 //     row images (_flashback, _snapshot, _diff), from all THREE
 //     serving layers: the standalone `bintrail shim`, the

--- a/internal/audittest/audittest.go
+++ b/internal/audittest/audittest.go
@@ -123,6 +123,11 @@ var Required = []Requirement{
 		Why:   "an LLM client generating a reversal script",
 	},
 	{
+		Pair:  Pair{Surface: "mcp", Action: "recover.cascade"},
+		Owner: OwnerMCP,
+		Why:   "an LLM client generating a cascade reversal script with SYNTHESIZED child rows",
+	},
+	{
 		Pair:  Pair{Surface: "mcp", Action: "reconstruct.row"},
 		Owner: OwnerMCPIntegration,
 		Why:   "an LLM client reading point-in-time row state (baseline + deltas)",

--- a/internal/audittest/callsites_test.go
+++ b/internal/audittest/callsites_test.go
@@ -28,16 +28,17 @@ import (
 // (reconstruct --baseline-only's original bug). That class has no
 // mechanical guard — adding a mode means adding the emission by hand.
 var recordCallSites = map[string]int{
-	"internal/cli/query.go":            1, // cli/query.run
-	"internal/cli/recover.go":          1, // cli/recover.generate
-	"internal/cli/recover_cascade.go":  1, // cli/recover.cascade
-	"internal/cli/reconstruct.go":      1, // cli/reconstruct.run (auditReconstruct — all five modes)
-	"internal/cli/verify.go":           1, // cli/verify.explain
-	"internal/console/audit.go":        1, // console data reads (recordConsoleAudit helper)
-	"internal/console/authz.go":        1, // console/authz.denied + console/profile.denied
-	"internal/mcptools/mcptools.go":    2, // mcp|console query.run + recover.generate
-	"internal/mcptools/reconstruct.go": 1, // mcp|console reconstruct.row
-	"internal/shim/handler.go":         1, // shim/timetravel.query (recordTimeTravel — all three serving layers)
+	"internal/cli/query.go":                1, // cli/query.run
+	"internal/cli/recover.go":              1, // cli/recover.generate
+	"internal/cli/recover_cascade.go":      1, // cli/recover.cascade
+	"internal/cli/reconstruct.go":          1, // cli/reconstruct.run (auditReconstruct — all five modes)
+	"internal/cli/verify.go":               1, // cli/verify.explain
+	"internal/console/audit.go":            1, // console data reads (recordConsoleAudit helper)
+	"internal/console/authz.go":            1, // console/authz.denied + console/profile.denied
+	"internal/mcptools/mcptools.go":        2, // mcp|console query.run + recover.generate
+	"internal/mcptools/reconstruct.go":     1, // mcp|console reconstruct.row
+	"internal/mcptools/recover_cascade.go": 1, // mcp|console recover.cascade
+	"internal/shim/handler.go":             1, // shim/timetravel.query (recordTimeTravel — all three serving layers)
 }
 
 // TestAuditRecordCallSitesAccounted walks the module source tree and asserts

--- a/internal/console/mcp.go
+++ b/internal/console/mcp.go
@@ -10,8 +10,9 @@ import (
 	"github.com/dbtrail/dbtrail/internal/mcptools"
 )
 
-// The console serves the read-only MCP tools (query, recover, status,
-// list_schema_changes, reconstruct) over Streamable HTTP (#1039, #953):
+// The console serves the read-only MCP tools (query, recover, recover_cascade,
+// status, list_schema_changes, reconstruct) over Streamable HTTP (#1039, #953,
+// #1128):
 //
 //	/mcp                → the default server (same selection rules as the
 //	                      rest of the console, including HideBoot semantics)
@@ -110,8 +111,8 @@ func (s *Server) newMCPServer(id string) *mcp.Server {
 	return mcptools.NewServer(mcptools.Config{
 		Version: "console",
 		Instructions: "Bintrail console MCP endpoint for querying indexed binlog events, " +
-			"generating recovery SQL, reconstructing a row's state at a point in time, " +
-			"and viewing index status. " +
+			"generating recovery SQL (including reversal of foreign-key cascade side effects), " +
+			"reconstructing a row's state at a point in time, and viewing index status. " +
 			"The target server is chosen by URL path: /mcp for the console's default server, " +
 			"/mcp/{id-or-name} for a named server from the console registry.",
 		Resolve: func(ctx context.Context, _ string) (*mcptools.Target, error) {
@@ -170,6 +171,16 @@ func (s *Server) newMCPServer(id string) *mcp.Server {
 		// storage.
 		Reconstruct:         true,
 		AllowBaselineParams: false,
+		// recover_cascade (#1128) is served because the console serves
+		// recover-cascade (free tier, like recover). Its gate is NOT
+		// baselineConfigured — cascade recovery works without a baseline
+		// (Phase-1) — but the same RBAC guard as /api/recover-cascade: the
+		// tool refuses per call under an active profile/deny/redact posture
+		// (cascade synthesis cannot honor redaction). Phase-2 engages per
+		// call from the bundle's FindBaseline exactly like the handler's
+		// cascadeProviderFor(b), baseline parameters rejected like
+		// reconstruct's.
+		RecoverCascade: true,
 		QueryMaxLimit:       func() int { return eventsMaxLimit },
 		RecoverMaxLimit:     recoverMaxLimit,
 		// #849: the console's /mcp recover tool renders the same reversal

--- a/internal/console/mcp_integration_test.go
+++ b/internal/console/mcp_integration_test.go
@@ -109,13 +109,13 @@ func TestIntegrationMCPEndpoint(t *testing.T) {
 	for _, tool := range tools.Tools {
 		names[tool.Name] = true
 	}
-	for _, want := range []string{"query", "recover", "status", "list_schema_changes", "reconstruct"} {
+	for _, want := range []string{"query", "recover", "recover_cascade", "status", "list_schema_changes", "reconstruct"} {
 		if !names[want] {
 			t.Errorf("tool %q not listed; got %v", want, names)
 		}
 	}
-	if len(tools.Tools) != 5 {
-		t.Errorf("expected 5 tools, got %d", len(tools.Tools))
+	if len(tools.Tools) != 6 {
+		t.Errorf("expected 6 tools, got %d", len(tools.Tools))
 	}
 
 	// This console was seeded with NoArchive (no baseline), so the per-server

--- a/internal/mcptools/audit_contract_test.go
+++ b/internal/mcptools/audit_contract_test.go
@@ -72,6 +72,32 @@ func TestAuditContract_MCP(t *testing.T) {
 				}
 			},
 		},
+		{
+			name:   "recover_cascade tool",
+			action: "recover.cascade",
+			call: func(t *testing.T) {
+				db, mock, err := sqlmock.New()
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer db.Close()
+				// The handler's real call sequence over an empty window: the
+				// parent DELETE fetch, the parent UPDATE fetch, then the
+				// archive-coverage probe (which must succeed and be empty, or
+				// the coverage-unknown caveat makes the call refuse and no
+				// script — hence no emission — is served).
+				mock.ExpectQuery("FROM binlog_events").WillReturnRows(sqlmock.NewRows(recoverToolMockCols))
+				mock.ExpectQuery("FROM binlog_events").WillReturnRows(sqlmock.NewRows(recoverToolMockCols))
+				mock.ExpectQuery("FROM archive_state").WillReturnRows(
+					sqlmock.NewRows([]string{"bintrail_id", "sample_local", "sample_bucket", "sample_key"}))
+				cfg := newRecoverToolTarget(db, 0)
+				cfg.RecoverCascade = true
+				res, _, _ := MakeRecoverCascadeTool(cfg)(ctx, nil, RecoverCascadeArgs{Schema: "app", Table: "users"})
+				if res.IsError {
+					t.Fatalf("recover_cascade tool failed: %s", resultText(res))
+				}
+			},
+		},
 	}
 
 	var observed []audittest.Pair

--- a/internal/mcptools/mcptools.go
+++ b/internal/mcptools/mcptools.go
@@ -1,6 +1,7 @@
 // Package mcptools implements the read-only Bintrail MCP tools — query,
-// recover, status, list_schema_changes, and the opt-in reconstruct (#953) —
-// decoupled from how the index connection is obtained.
+// recover, status, list_schema_changes, and the opt-in reconstruct (#953) and
+// recover_cascade (#1128) — decoupled from how the index connection is
+// obtained.
 //
 // Two surfaces consume it:
 //
@@ -182,6 +183,15 @@ type Config struct {
 	// baseline_dir/baseline_s3 parameters) would otherwise advertise a tool
 	// that can only ever error.
 	Reconstruct bool
+	// RecoverCascade registers the recover_cascade tool (#1128). Opt-in per
+	// surface like Reconstruct, but the condition is NOT baseline presence:
+	// cascade recovery degrades meaningfully without a baseline (Phase-1
+	// window-only synthesis still recovers children with an indexed event in
+	// the lookback window), so every surface that serves recover-cascade at
+	// all registers it, and the Phase-2 baseline fallback engages per call
+	// only when a baseline is available (Target.FindBaseline on routed
+	// surfaces; the baseline parameters/environment on the standalone one).
+	RecoverCascade bool
 	// AllowBaselineParams accepts the reconstruct tool's baseline_dir /
 	// baseline_s3 parameters, with BINTRAIL_BASELINE_DIR / BINTRAIL_BASELINE_S3
 	// as the fallback (standalone). When false they are rejected exactly like
@@ -250,7 +260,8 @@ func (c Config) scriptBudgetOverride() (int64, bool) {
 
 // NewServer builds an MCP server exposing the read-only tools bound to cfg:
 // query, recover, status and list_schema_changes always, plus reconstruct when
-// cfg.Reconstruct is set. All tools are annotated read-only + idempotent.
+// cfg.Reconstruct is set and recover_cascade when cfg.RecoverCascade is set.
+// All tools are annotated read-only + idempotent.
 func NewServer(cfg Config) *mcp.Server {
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    "bintrail",
@@ -324,6 +335,27 @@ func NewServer(cfg Config) *mcp.Server {
 				IdempotentHint: true,
 			},
 		}, MakeReconstructTool(cfg))
+	}
+
+	// Opt-in (#1128): registered by every surface that serves recover-cascade.
+	// Unlike reconstruct this does NOT depend on a baseline — Phase-1
+	// window-only synthesis works without one — see Config.RecoverCascade.
+	if cfg.RecoverCascade {
+		mcp.AddTool(server, &mcp.Tool{
+			Name: "recover_cascade",
+			Description: "Generate reversal SQL for rows hit by a foreign-key ON DELETE / ON UPDATE " +
+				"CASCADE or SET NULL (dry-run only). InnoDB runs FK cascades below the binlog, so the plain " +
+				"`recover` tool reverses only the parent change and silently misses the cascade-deleted child " +
+				"rows and rewritten/nulled child FKs — this tool synthesizes those from the index and reverses " +
+				"them too. If the synthesis is provably partial the call fails with the reasons unless " +
+				"allow_incomplete is set; always check the `incomplete` list in the result. " +
+				"Review carefully before applying to production.",
+			Annotations: &mcp.ToolAnnotations{
+				Title:          "Generate FK-cascade recovery SQL",
+				ReadOnlyHint:   true,
+				IdempotentHint: true,
+			},
+		}, MakeRecoverCascadeTool(cfg))
 	}
 
 	// Extension tools (mcpext.Register) are added AFTER the built-ins, so a

--- a/internal/mcptools/reconstruct.go
+++ b/internal/mcptools/reconstruct.go
@@ -34,9 +34,9 @@ import (
 // local dir has no baseline for the table (#766). Binding
 // reconstruct.FindBaseline directly on the console surface would silently lose
 // that fallback — the exact regression #1102 fixed for cascade recovery, whose
-// cascadebaseline.FindBaselineFunc this mirrors. The type is redeclared here
-// rather than imported so mcptools does not pull the cascade engine into its
-// import graph.
+// cascadebaseline.FindBaselineFunc this mirrors (the recover_cascade tool
+// converts between the two identical signatures where it builds its Phase-2
+// provider).
 type FindBaselineFunc func(ctx context.Context, schema, table string, at time.Time) (string, time.Time, reconstruct.StaleWarning, error)
 
 // BaselineSource binds a single baseline source (a local directory or an s3://

--- a/internal/mcptools/recover_cascade.go
+++ b/internal/mcptools/recover_cascade.go
@@ -1,0 +1,483 @@
+package mcptools
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/dbtrail/dbtrail/ext"
+	"github.com/dbtrail/dbtrail/internal/cascade"
+	"github.com/dbtrail/dbtrail/internal/cascadebaseline"
+	"github.com/dbtrail/dbtrail/internal/cascaderecover"
+	"github.com/dbtrail/dbtrail/internal/cliutil"
+	"github.com/dbtrail/dbtrail/internal/event"
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/query"
+	"github.com/dbtrail/dbtrail/internal/recovery"
+)
+
+// RecoverCascadeArgs are the recover_cascade tool's parameters. They mirror the
+// `bintrail recover-cascade` CLI flags and the console's POST
+// /api/recover-cascade body — the same synthesis engine sits behind all three.
+type RecoverCascadeArgs struct {
+	IndexDSN string   `json:"index_dsn,omitempty" jsonschema:"MySQL DSN for the index database. Overrides BINTRAIL_INDEX_DSN env var. Rejected on servers that route connections themselves (the console /mcp endpoint)."`
+	Schema   string   `json:"schema" jsonschema:"Schema of the parent table whose change cascaded (required)"`
+	Table    string   `json:"table" jsonschema:"Parent table whose ON DELETE / ON UPDATE cascade touched children (required)"`
+	PK       string   `json:"pk,omitempty" jsonschema:"Restrict to a single changed parent primary key (pipe-delimited for composite keys)"`
+	PKs      []string `json:"pks,omitempty" jsonschema:"Restrict to multiple changed parent primary keys; mutually exclusive with pk"`
+	Since    string   `json:"since,omitempty" jsonschema:"Only parent changes at or after this time (YYYY-MM-DD HH:MM:SS or RFC 3339)"`
+	Until    string   `json:"until,omitempty" jsonschema:"Only parent changes at or before this time (YYYY-MM-DD HH:MM:SS or RFC 3339)"`
+	Lookback string   `json:"lookback,omitempty" jsonschema:"How far before each parent change to search for child state (e.g. 30d, 24h; default 30d)"`
+	MaxDepth int      `json:"max_depth,omitempty" jsonschema:"Maximum cascade recursion depth, parent -> child -> grandchild (default 5)"`
+	Limit    int      `json:"limit,omitempty" jsonschema:"Maximum number of parent events to process, applied separately to the DELETE and the UPDATE scan (default 1000)"`
+	// AllowIncomplete mirrors the CLI's exit-code contract in tool terms: a
+	// provably partial synthesis is an ERROR (carrying the reasons) unless the
+	// caller explicitly opts into receiving the partial script.
+	AllowIncomplete bool   `json:"allow_incomplete,omitempty" jsonschema:"Return the reversal script even when the synthesis is provably partial. Defaults to false: any coverage caveat makes the call fail, with the caveats reported in the error. When set, the caveats come back in the result's incomplete list instead."`
+	BaselineDir     string `json:"baseline_dir,omitempty" jsonschema:"Local directory of baseline Parquet snapshots for Phase-2 fallback (also recovers children untouched within the lookback window). Overrides BINTRAIL_BASELINE_DIR env var. Rejected on servers that configure the baseline themselves (the console /mcp endpoint)."`
+	BaselineS3      string `json:"baseline_s3,omitempty" jsonschema:"S3 prefix of baseline Parquet snapshots (s3://bucket/prefix) for Phase-2 fallback. Overrides BINTRAIL_BASELINE_S3 env var. Used only when baseline_dir is unset. Rejected on servers that configure the baseline themselves."`
+}
+
+// recoverCascadeResult is the tool's JSON payload: the reversal script plus the
+// structured coverage report. Incomplete carries every reason the recovery is
+// PROVABLY PARTIAL (cascade.Result.Incomplete plus the surface's own coverage
+// caveats); Warnings are advisory notes about an otherwise-complete recovery
+// (#618) — the two channels are never merged, exactly like the CLI's JSON
+// output and the console's recoverCascadeResponse. Complete is exactly
+// "Incomplete is empty". Like the sibling recover surfaces this carries SQL
+// text and counts only — never event rows — so there is no statement-text or
+// connection-id field to redact.
+type recoverCascadeResult struct {
+	Schema         string `json:"schema"`
+	Table          string `json:"table"`
+	SQL            string `json:"sql"`
+	StatementCount int    `json:"statement_count"`
+	// Parents is the number of parent rows whose own change is reversed:
+	// ParentDeletes plus the parent-key UPDATEs the synthesis confirmed as
+	// cascading (ParentKeyUpdates); an UPDATE of unrelated columns is never
+	// reversed.
+	Parents          int `json:"parents"`
+	ParentDeletes    int `json:"parent_deletes"`
+	ParentKeyUpdates int `json:"parent_key_updates"`
+	// Children is the number of cascade-deleted child rows re-INSERTed.
+	Children        int `json:"children"`
+	SetNullRestores int `json:"set_null_restores"`
+	// KeyRestores is the ON UPDATE CASCADE / SET NULL half, counted separately
+	// so a script full of FK restorations is never read as "0 rows recovered"
+	// off the child count alone.
+	KeyRestores    int      `json:"key_restores"`
+	Complete       bool     `json:"complete"`
+	Incomplete     []string `json:"incomplete,omitempty"`
+	Warnings       []string `json:"warnings,omitempty"`
+	BaselineActive bool     `json:"baseline_active"`
+}
+
+// resolveCascadeBaseline picks the Phase-2 baseline provider for this call, or
+// nil for Phase-1-only synthesis — which, unlike reconstruct, is a fully
+// supported mode, not a refusal: cascade recovery degrades meaningfully
+// without a baseline (children with an indexed event inside the lookback
+// window are still recovered), so "no baseline" must never gate the tool.
+//
+// On a surface that owns baseline routing (the console) the Target supplies
+// the lookup and the gate mirrors the console handler's own Phase-2 condition:
+// a configured baseline AND a schema snapshot (the resolver encodes each
+// baseline row's PK to match binlog pk_values). On the standalone surface the
+// parameters win over the environment, a local directory over an S3 prefix —
+// the same precedence the reconstruct tool uses. A degraded case (baseline
+// available but no resolver) returns a warning instead of failing: the CLI and
+// console degrade to Phase-1 there too, but an MCP client reads no server log,
+// so the degradation must land in the payload.
+func resolveCascadeBaseline(cfg Config, t *Target, resolver *metadata.Resolver, args RecoverCascadeArgs) (cascade.BaselineProvider, string) {
+	const noSnapshotWarn = "a baseline location is configured but no schema snapshot is available, so the Phase-2 baseline fallback is disabled " +
+		"(only children with an indexed event inside the lookback window are recovered); run `bintrail snapshot` to enable it"
+	if !cfg.AllowBaselineParams {
+		if !t.BaselineConfigured || t.FindBaseline == nil {
+			return nil, ""
+		}
+		if resolver == nil {
+			return nil, noSnapshotWarn
+		}
+		// The Target's lookup, not a raw source string: on the console that is
+		// the bundle's findBaseline, which carries the local-to-S3 fallback the
+		// rest of the console gets (#1102).
+		return cascadebaseline.New(cascadebaseline.FindBaselineFunc(t.FindBaseline), resolver), ""
+	}
+	src := args.BaselineDir
+	if src == "" {
+		src = args.BaselineS3
+	}
+	if src == "" {
+		src = os.Getenv("BINTRAIL_BASELINE_DIR")
+	}
+	if src == "" {
+		src = os.Getenv("BINTRAIL_BASELINE_S3")
+	}
+	if src == "" {
+		return nil, ""
+	}
+	if resolver == nil {
+		return nil, noSnapshotWarn
+	}
+	return cascadebaseline.New(cascadebaseline.Source(src), resolver), ""
+}
+
+// MakeRecoverCascadeTool returns the recover_cascade tool handler: reversal
+// SQL for the child-side effects of a foreign-key ON DELETE / ON UPDATE
+// CASCADE or SET NULL that InnoDB ran below the binlog (MySQL Bug #32506) and
+// that the plain recover tool therefore cannot see. It generates SQL only —
+// never executes it — mirroring the `bintrail recover-cascade` CLI and the
+// console's POST /api/recover-cascade call sequence exactly: fetch the parent
+// DELETE and UPDATE roots (live index only), probe archive coverage,
+// synthesize the invisible victims per FK-graph group, then stable-merge the
+// confirmed roots chronologically (cascaderecover.MergeParentRoots — the
+// generator has no sort of its own) before emitting.
+//
+// The incompleteness contract is the tool's reason to exist on this surface: a
+// partial cascade reversal presented as complete is worst on the AI surface,
+// where nobody eyeballs the script. A provably partial synthesis is an ERROR
+// carrying every caveat unless allow_incomplete is set, in which case the
+// caveats come back in the payload's `incomplete` list AND inside the script's
+// own INCOMPLETE RECOVERY banner. An operational synthesis failure is always
+// an error — allow_incomplete opts into known coverage gaps, never into a
+// half-run query plan.
+func MakeRecoverCascadeTool(cfg Config) func(context.Context, *mcp.CallToolRequest, RecoverCascadeArgs) (*mcp.CallToolResult, any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, args RecoverCascadeArgs) (*mcp.CallToolResult, any, error) {
+		if res := rejectSurfaceParams(cfg, args.IndexDSN, ""); res != nil {
+			return res, nil, nil
+		}
+		if res := rejectBaselineParams(cfg, args.BaselineDir, args.BaselineS3); res != nil {
+			return res, nil, nil
+		}
+		if args.Schema == "" || args.Table == "" {
+			return ErrorResult(errors.New("schema and table are required (the parent table whose delete or key update cascaded)")), nil, nil
+		}
+		if args.PK != "" && len(args.PKs) > 0 {
+			return ErrorResult(errors.New("pk and pks are mutually exclusive; use one or the other")), nil, nil
+		}
+		maxDepth := args.MaxDepth
+		if maxDepth == 0 {
+			maxDepth = 5
+		}
+		if maxDepth < 1 {
+			return ErrorResult(errors.New("max_depth must be >= 1")), nil, nil
+		}
+		limit := args.Limit
+		if limit <= 0 {
+			limit = DefaultRecoverLimit
+		}
+		// The surface's hard cap on the parent scan (console: the same cap as
+		// /api/recover). Capping is safe here because a clipped scan is never
+		// silent: the "capped at the limit" caveat below fires when the fetch
+		// fills the capped budget.
+		if cfg.RecoverMaxLimit > 0 && limit > cfg.RecoverMaxLimit {
+			limit = cfg.RecoverMaxLimit
+		}
+		lookbackStr := args.Lookback
+		if lookbackStr == "" {
+			lookbackStr = "30d"
+		}
+		lookback, err := cliutil.ParseRetain(lookbackStr)
+		if err != nil {
+			return ErrorResult(fmt.Errorf("invalid lookback: %w", err)), nil, nil
+		}
+		since, err := cliutil.ParseTime(args.Since)
+		if err != nil {
+			return ErrorResult(fmt.Errorf("invalid since: %w", err)), nil, nil
+		}
+		until, err := cliutil.ParseTime(args.Until)
+		if err != nil {
+			return ErrorResult(fmt.Errorf("invalid until: %w", err)), nil, nil
+		}
+
+		t, err := cfg.Resolve(ctx, args.IndexDSN)
+		if err != nil {
+			return ErrorResult(err), nil, nil
+		}
+		defer t.release()
+
+		// Cascade victim synthesis fetches child rows internally without
+		// carrying deny/redact rules, so a redacted column or denied table
+		// could surface in a victim's reversal SQL. Refuse under any active
+		// RBAC posture — the same guard the console's /api/recover-cascade
+		// endpoint enforces (its handleRecoverCascade 403), and the reason
+		// this tool has no per-call profile parameter (the CLI command has
+		// none either).
+		if t.ProfileActive || len(t.DenyTables) > 0 || len(t.RedactColumns) > 0 {
+			return ErrorResult(errors.New(
+				"recover_cascade is unavailable while an access-control profile is active " +
+					"(cascade victim synthesis cannot honor column redaction / table deny)")), nil, nil
+		}
+
+		// Same idempotent migration as the query/recover tools: the fetches
+		// below SELECT post-initial-schema binlog_events columns, and
+		// metadata.NewResolver reads schema_snapshots.column_type.
+		// Standalone-only — see Target.EnsureSchema.
+		if t.EnsureSchema {
+			if err := indexer.EnsureSchema(t.DB); err != nil {
+				return ErrorResult(indexer.WrapSchemaMigrationErr(err)), nil, nil
+			}
+		}
+
+		// Advisory notes for the payload. Unlike the CLI, whose operator sees
+		// slog on stderr, an MCP client sees nothing but the result — so every
+		// degradation the CLI logs must land here instead.
+		var toolWarnings []string
+
+		// Schema resolver: best-effort for the CASCADE path (INSERTs fall back
+		// to full row images), required by EmitSQL only when SET NULL /
+		// ON UPDATE restorations exist (it fails loud there, before writing).
+		resolver := t.Resolver
+		if !t.ResolverLoaded {
+			r, rerr := metadata.NewResolver(t.DB, 0)
+			if rerr != nil {
+				toolWarnings = append(toolWarnings,
+					"no schema snapshot is available ("+rerr.Error()+"); recovery INSERTs use full row images, and any FK restorations would fail — run `bintrail snapshot`")
+				r = nil
+			}
+			resolver = r
+		}
+
+		eng := query.New(t.DB)
+		del := event.EventDelete
+		upd := event.EventUpdate
+
+		// TWO fetches, not one un-filtered one (mirrors the CLI and console):
+		// query.Options.EventType holds a single type, and an all-types fetch
+		// would let INSERTs (which never cascade) eat the limit budget the
+		// DELETE/UPDATE roots need. Live index only — cascade recovery never
+		// searches archives; the probe below turns that into caveats instead.
+		fetchRoots := func(et *event.EventType) ([]query.ResultRow, error) {
+			return eng.Fetch(ctx, query.Options{
+				Schema:     args.Schema,
+				Table:      args.Table,
+				PKValues:   args.PK,
+				PKValuesIn: args.PKs,
+				EventType:  et,
+				Since:      since,
+				Until:      until,
+				Order:      "ASC",
+				Limit:      limit,
+			})
+		}
+		parentDeletes, err := fetchRoots(&del)
+		if err != nil {
+			return ErrorResult(fmt.Errorf("fetch parent deletes: %w", err)), nil, nil
+		}
+		// Candidates only: the synthesis keeps just the UPDATEs that actually
+		// moved a referenced key under an ON UPDATE CASCADE / SET NULL edge.
+		parentUpdates, err := fetchRoots(&upd)
+		if err != nil {
+			return ErrorResult(fmt.Errorf("fetch parent updates: %w", err)), nil, nil
+		}
+		parentEvents := append(append([]query.ResultRow{}, parentDeletes...), parentUpdates...)
+
+		// Coverage caveats (detectable gaps that gate the allow_incomplete
+		// contract) accumulate here.
+		var caveats []string
+
+		// A plain empty match is legitimately "complete", but an agent must not
+		// read an empty script as "nothing was changed" — it could be a wrong
+		// filter. Advisory, not a caveat.
+		if len(parentEvents) == 0 {
+			toolWarnings = append(toolWarnings,
+				"no parent DELETE or UPDATE events matched in the live index; verify schema/table/pk/since/until")
+		}
+
+		// Live-only trap (mirrors the CLI and console; the probe runs
+		// UNCONDITIONALLY, never gated on the target's archive posture):
+		//   - probe failure → coverage unknown (hard caveat)
+		//   - archives exist AND nothing matched live → the changed parent may
+		//     itself be archived (hard caveat: the dangerous "nothing found" case)
+		//   - archives exist AND parents found → a child whose events were
+		//     archived could be missed → advisory only, or every archived
+		//     deployment would trip INCOMPLETE on every run.
+		archivesExist := false
+		if archives, aerr := query.ResolveArchiveSources(ctx, t.DB); aerr != nil {
+			caveats = append(caveats, "could not determine whether archived partitions exist (probe failed: "+aerr.Error()+"); coverage is unknown")
+		} else if len(archives) > 0 {
+			archivesExist = true
+			if len(parentEvents) == 0 {
+				caveats = append(caveats, "no parent DELETE or UPDATE matched in the live index, but the index has archived partitions (cascade recovery does NOT search them); the changed parent may be archived")
+			} else {
+				toolWarnings = append(toolWarnings,
+					"the index has archived partitions, which cascade recovery does NOT search (live index only); a child whose events were archived may be missed")
+			}
+		}
+
+		if len(parentDeletes) >= limit {
+			caveats = append(caveats, fmt.Sprintf("parent DELETE events were capped at the limit (%d); narrow pk/since/until or raise the limit parameter", limit))
+		}
+		if len(parentUpdates) >= limit {
+			caveats = append(caveats, fmt.Sprintf("parent UPDATE events were capped at the limit (%d); narrow pk/since/until or raise the limit parameter", limit))
+		}
+
+		baselineProvider, baselineWarn := resolveCascadeBaseline(cfg, t, resolver, args)
+		if baselineWarn != "" {
+			toolWarnings = append(toolWarnings, baselineWarn)
+		}
+
+		// Synthesize the invisible cascade victims. FK graph resolved PER ROOT,
+		// not batch-anchored on the earliest root: a batch can span an FK
+		// topology change, and a single earliest-anchored graph would silently
+		// mis-recover a later root (#834 applied per-root).
+		var res cascade.Result
+		var synthErr error
+		if len(parentEvents) > 0 {
+			groups, fkCaveats, lerr := cascade.GroupParentDeletesByFKGraph(ctx, t.DB, args.Schema, parentEvents)
+			if lerr != nil {
+				return ErrorResult(fmt.Errorf("load FK graph: %w", lerr)), nil, nil
+			}
+			caveats = append(caveats, fkCaveats...)
+			results := make([]cascade.Result, 0, len(groups))
+			for _, g := range groups {
+				r, serr := cascade.SynthesizeVictims(ctx, eng, g.FKs, g.Roots, cascade.Options{
+					Lookback:        lookback,
+					MaxDepth:        maxDepth,
+					Baseline:        baselineProvider,
+					ArchivesPresent: archivesExist,
+				})
+				results = append(results, r)
+				if serr != nil {
+					synthErr = errors.Join(synthErr, serr)
+				}
+			}
+			res = cascade.MergeResults(results...)
+		}
+		caveats = append(caveats, res.Incomplete...)
+
+		// An operational failure is never overridable: allow_incomplete opts
+		// into KNOWN coverage gaps, not into a query plan that half-ran.
+		if synthErr != nil {
+			return ErrorResult(fmt.Errorf(
+				"cascade synthesis hit an operational failure and the result would be partial (no script generated): %v%s",
+				synthErr, formatCascadeCaveats(caveats))), nil, nil
+		}
+		// The allow_incomplete contract (the CLI's --dry-run-independent exit
+		// gate, in tool terms): a provably partial synthesis is an error that
+		// CARRIES the reasons, so the agent can decide — not a script whose
+		// gaps hide in a comment banner it may never read.
+		if len(caveats) > 0 && !args.AllowIncomplete {
+			return ErrorResult(fmt.Errorf(
+				"the cascade recovery is INCOMPLETE — the synthesized reversal is provably partial (no script generated):%s\n"+
+					"Review the reasons above, then re-run with allow_incomplete: true to receive the partial script; "+
+					"the caveats are reported back in the result's `incomplete` list and inside the script's INCOMPLETE RECOVERY banner",
+				formatCascadeCaveats(caveats))), nil, nil
+		}
+
+		// Only the parent UPDATEs the synthesis confirmed as cascading join the
+		// DELETE roots. Merged chronologically, NOT concatenated: the generator
+		// reverses its input order without sorting, so DELETEs-then-UPDATEs
+		// would undo a key UPDATE before re-inserting the parent that UPDATE's
+		// row belongs to (see cascaderecover.MergeParentRoots).
+		parents := cascaderecover.MergeParentRoots(parentDeletes, res.KeyUpdateParents)
+		rows := append(append([]query.ResultRow{}, parents...), res.Victims...)
+
+		gen := recovery.NewForDialect(t.DB, resolver, recovery.DialectForIndex(t.DB))
+		// #849: same "only call when set" gate as the recover tool — see
+		// Config.scriptBudgetOverride for why this must never become an
+		// unconditional SetMaxScriptBytes(cfg.MaxScriptBytes).
+		if v, ok := cfg.scriptBudgetOverride(); ok {
+			gen.SetMaxScriptBytes(v)
+		}
+		var buf bytes.Buffer
+		n, err := cascaderecover.EmitSQL(&buf, gen, rows, res.SetNullRows, res.KeyUpdates, resolver, cascaderecover.Header{
+			Schema:         args.Schema,
+			Table:          args.Table,
+			Parents:        len(parents),
+			Children:       len(res.Victims),
+			Caveats:        caveats,
+			Warnings:       res.Warnings,
+			BaselineActive: baselineProvider != nil,
+		})
+		if err != nil {
+			// Same rewrite as the recover tool: the ScriptBudgetError's own text
+			// presumes a Go caller of SetMaxScriptBytes. The reachable escape
+			// hatch from either surface is the CLI, which runs outside any
+			// shared-daemon budget.
+			var be *recovery.ScriptBudgetError
+			if errors.As(err, &be) {
+				return ErrorResult(fmt.Errorf(
+					"refusing to generate the cascade reversal script — the matched events hold ~%.1f MiB of row data, "+
+						"over the %.0f MiB budget for a single recovery. Narrow the filter (pk/since/until) to shrink "+
+						"the window, or use `bintrail recover-cascade` from the CLI for large cascades",
+					float64(be.EstimatedBytes)/(1<<20), float64(be.Budget)/(1<<20))), nil, nil
+			}
+			return ErrorResult(err), nil, nil
+		}
+
+		// Payload warnings = the engine's advisory notes (also rendered in the
+		// script preamble, exactly as the CLI and console pass them) plus the
+		// tool-surface advisories accumulated above — which stay OUT of the
+		// script so it remains byte-comparable with the other surfaces'.
+		warnings := append(append([]string{}, res.Warnings...), toolWarnings...)
+
+		out := recoverCascadeResult{
+			Schema:           args.Schema,
+			Table:            args.Table,
+			SQL:              buf.String(),
+			StatementCount:   n,
+			Parents:          len(parents),
+			ParentDeletes:    len(parentDeletes),
+			ParentKeyUpdates: len(res.KeyUpdateParents),
+			Children:         len(res.Victims),
+			SetNullRestores:  len(res.SetNullRows),
+			KeyRestores:      len(res.KeyUpdates),
+			Complete:         len(caveats) == 0,
+			Incomplete:       caveats,
+			Warnings:         warnings,
+			BaselineActive:   baselineProvider != nil,
+		}
+		payload, err := json.MarshalIndent(out, "", "  ")
+		if err != nil {
+			return ErrorResult(fmt.Errorf("encode recover_cascade result: %w", err)), nil, nil
+		}
+
+		// Recorded when (and only when) a script is actually returned to the
+		// client — the refusal paths above serve no historical row data. The
+		// CLI and console record before their exit-code / complete-flag
+		// decision because their script is already durable by then; here an
+		// incomplete-but-allowed script reaches the client, so it is recorded
+		// with its completeness.
+		ext.Record(ctx, ext.AuditEvent{
+			Surface: cfg.auditSurface(),
+			Action:  "recover.cascade",
+			Actor:   ext.ProcessActor(""),
+			Schema:  args.Schema,
+			Table:   args.Table,
+			Detail: map[string]string{
+				"statements": strconv.Itoa(n),
+				"parents":    strconv.Itoa(len(parentDeletes)),
+				"children":   strconv.Itoa(len(res.Victims)),
+				"complete":   strconv.FormatBool(len(caveats) == 0),
+				"dry_run":    "true", // MCP recover_cascade always returns the script, never applies it
+			},
+		})
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: string(payload)},
+			},
+		}, nil, nil
+	}
+}
+
+// formatCascadeCaveats renders the caveat list for an error message, one
+// bullet per line, or "" when there are none.
+func formatCascadeCaveats(caveats []string) string {
+	if len(caveats) == 0 {
+		return ""
+	}
+	var b bytes.Buffer
+	for _, c := range caveats {
+		b.WriteString("\n  - ")
+		b.WriteString(c)
+	}
+	return b.String()
+}

--- a/internal/mcptools/recover_cascade_integration_test.go
+++ b/internal/mcptools/recover_cascade_integration_test.go
@@ -1,0 +1,173 @@
+//go:build integration
+
+package mcptools
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// seedCascadeIndex builds an index holding an ON DELETE CASCADE topology: two
+// child INSERTs (id=10,11 → pid=1) followed by the parent DELETE (id=1), with
+// the FK snapshot and a schema snapshot — the same fixture shape the console's
+// recover-cascade endpoint tests use, so the two surfaces are proven over the
+// same topology.
+func seedCascadeIndex(t *testing.T) (*sql.DB, string) {
+	t.Helper()
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	h := time.Now().UTC().Add(-1 * time.Hour).Truncate(time.Hour)
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{h})
+	childTs := h.Add(10 * time.Minute).Format("2006-01-02 15:04:05")
+	parentTs := h.Add(20 * time.Minute).Format("2006-01-02 15:04:05")
+
+	testutil.InsertEvent(t, db, "binlog.000001", 100, 200, childTs, nil,
+		dbName, "child", 1 /*INSERT*/, "10", nil, nil, []byte(`{"id":10,"pid":1}`))
+	testutil.InsertEvent(t, db, "binlog.000001", 200, 300, childTs, nil,
+		dbName, "child", 1 /*INSERT*/, "11", nil, nil, []byte(`{"id":11,"pid":1}`))
+	testutil.InsertEvent(t, db, "binlog.000001", 300, 400, parentTs, nil,
+		dbName, "parent", 3 /*DELETE*/, "1", nil, []byte(`{"id":1}`), nil)
+
+	testutil.MustExec(t, db, `INSERT INTO fk_constraints
+		(snapshot_id, constraint_name, schema_name, table_name, column_name, ordinal_position,
+		 referenced_schema_name, referenced_table_name, referenced_column_name, delete_rule, update_rule)
+		VALUES (1, 'fk_child', ?, 'child', 'pid', 1, ?, 'parent', 'id', 'CASCADE', 'RESTRICT')`,
+		dbName, dbName)
+
+	snapTs := h.Format("2006-01-02 15:04:05")
+	testutil.InsertSnapshot(t, db, 1, snapTs, dbName, "parent", "id", 1, "PRI", "int", "NO")
+	testutil.InsertSnapshot(t, db, 1, snapTs, dbName, "child", "id", 1, "PRI", "int", "NO")
+	testutil.InsertSnapshot(t, db, 1, snapTs, dbName, "child", "pid", 2, "", "int", "YES")
+	return db, dbName
+}
+
+// cascadeSession connects an in-memory MCP client over the standalone posture
+// with recover_cascade registered.
+func cascadeSession(t *testing.T, db *sql.DB, dbName string) *mcp.ClientSession {
+	t.Helper()
+	resolver, err := metadata.NewResolver(db, 0)
+	if err != nil {
+		t.Fatalf("load resolver: %v", err)
+	}
+	cfg := Config{
+		Version:             "test",
+		RecoverCascade:      true,
+		AllowBaselineParams: true,
+		Resolve: func(ctx context.Context, _ string) (*Target, error) {
+			return &Target{DB: db, DBName: dbName, Resolver: resolver, ResolverLoaded: true}, nil
+		},
+	}
+
+	ctx := context.Background()
+	clientT, serverT := mcp.NewInMemoryTransports()
+	ss, err := NewServer(cfg).Connect(ctx, serverT, nil)
+	if err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	t.Cleanup(func() { _ = ss.Close() })
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test", Version: "2025-06-18"}, nil)
+	cs, err := client.Connect(ctx, clientT, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+	return cs
+}
+
+// TestIntegrationRecoverCascadeTool drives the tool end-to-end over a seeded
+// ON DELETE CASCADE: the payload must re-insert the parent and both
+// cascade-deleted children inside the FK-checks wrapper, report complete, and
+// carry the structured counts an agent needs to sanity-check the script.
+func TestIntegrationRecoverCascadeTool(t *testing.T) {
+	db, dbName := seedCascadeIndex(t)
+	cs := cascadeSession(t, db, dbName)
+
+	res, err := cs.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "recover_cascade",
+		Arguments: map[string]any{"schema": dbName, "table": "parent"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool recover_cascade: %v", err)
+	}
+	text := resultText(res)
+	if res.IsError {
+		t.Fatalf("recover_cascade returned a tool error: %s", text)
+	}
+	var out recoverCascadeResult
+	if err := json.Unmarshal([]byte(text), &out); err != nil {
+		t.Fatalf("decode payload: %v (payload=%s)", err, text)
+	}
+
+	for _, want := range []string{
+		"SET FOREIGN_KEY_CHECKS=0;",
+		"SET FOREIGN_KEY_CHECKS=1;",
+		"Phase-1",
+		"`" + dbName + "`.`parent`",
+		"`" + dbName + "`.`child`",
+	} {
+		if !strings.Contains(out.SQL, want) {
+			t.Errorf("SQL missing %q\n---\n%s", want, out.SQL)
+		}
+	}
+	if c := strings.Count(out.SQL, "`"+dbName+"`.`child`"); c != 2 {
+		t.Errorf("want 2 child INSERTs, got %d\n---\n%s", c, out.SQL)
+	}
+	if out.Children != 2 || out.ParentDeletes != 1 || out.Parents != 1 {
+		t.Errorf("children=%d parent_deletes=%d parents=%d, want 2/1/1", out.Children, out.ParentDeletes, out.Parents)
+	}
+	if out.StatementCount != 3 {
+		t.Errorf("statement_count = %d, want 3 (parent + 2 children)", out.StatementCount)
+	}
+	if !out.Complete || len(out.Incomplete) != 0 {
+		t.Errorf("a clean cascade with no archives must be complete; incomplete=%v", out.Incomplete)
+	}
+	if out.BaselineActive {
+		t.Error("baseline_active must be false without a configured baseline")
+	}
+}
+
+// TestIntegrationRecoverCascadeToolPKFilter pins that the pk filter scopes the
+// parent scan: a pk that matches no parent change produces a complete, empty
+// script plus the empty-match advisory.
+func TestIntegrationRecoverCascadeToolPKFilter(t *testing.T) {
+	db, dbName := seedCascadeIndex(t)
+	cs := cascadeSession(t, db, dbName)
+
+	res, err := cs.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "recover_cascade",
+		Arguments: map[string]any{"schema": dbName, "table": "parent", "pk": "999"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool recover_cascade: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("tool error: %s", resultText(res))
+	}
+	var out recoverCascadeResult
+	if err := json.Unmarshal([]byte(resultText(res)), &out); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	if out.StatementCount != 0 || !out.Complete {
+		t.Errorf("statement_count=%d complete=%v, want 0/true", out.StatementCount, out.Complete)
+	}
+	advisory := false
+	for _, w := range out.Warnings {
+		if strings.Contains(w, "no parent DELETE or UPDATE events matched") {
+			advisory = true
+		}
+	}
+	if !advisory {
+		t.Errorf("warnings must carry the empty-match advisory, got %v", out.Warnings)
+	}
+}

--- a/internal/mcptools/recover_cascade_test.go
+++ b/internal/mcptools/recover_cascade_test.go
@@ -1,0 +1,296 @@
+package mcptools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func callRecoverCascade(t *testing.T, cfg Config, args RecoverCascadeArgs) *mcp.CallToolResult {
+	t.Helper()
+	res, _, err := MakeRecoverCascadeTool(cfg)(context.Background(), nil, args)
+	if err != nil {
+		t.Fatalf("handler returned a protocol error: %v", err)
+	}
+	return res
+}
+
+// TestRecoverCascadeToolRegistration pins that recover_cascade is opt-in per
+// surface via Config.RecoverCascade — and that, unlike reconstruct, the flag is
+// the ONLY gate: no baseline lookup is needed to advertise it (Phase-1
+// window-only synthesis works without one).
+func TestRecoverCascadeToolRegistration(t *testing.T) {
+	listTools := func(t *testing.T, cfg Config) map[string]*mcp.Tool {
+		t.Helper()
+		ctx := context.Background()
+		clientT, serverT := mcp.NewInMemoryTransports()
+		ss, err := NewServer(cfg).Connect(ctx, serverT, nil)
+		if err != nil {
+			t.Fatalf("server connect: %v", err)
+		}
+		defer ss.Close()
+
+		client := mcp.NewClient(&mcp.Implementation{Name: "test", Version: "2025-06-18"}, nil)
+		cs, err := client.Connect(ctx, clientT, nil)
+		if err != nil {
+			t.Fatalf("client connect: %v", err)
+		}
+		defer cs.Close()
+
+		res, err := cs.ListTools(ctx, nil)
+		if err != nil {
+			t.Fatalf("ListTools: %v", err)
+		}
+		out := map[string]*mcp.Tool{}
+		for _, tool := range res.Tools {
+			out[tool.Name] = tool
+		}
+		return out
+	}
+
+	t.Run("opt-out surface omits it", func(t *testing.T) {
+		tools := listTools(t, Config{Resolve: unreachableResolve(t)})
+		if _, ok := tools["recover_cascade"]; ok {
+			t.Error("recover_cascade must not be advertised when Config.RecoverCascade is false")
+		}
+	})
+
+	t.Run("opt-in surface advertises it without any baseline", func(t *testing.T) {
+		tools := listTools(t, Config{Resolve: unreachableResolve(t), RecoverCascade: true})
+		tool, ok := tools["recover_cascade"]
+		if !ok {
+			t.Fatalf("recover_cascade not advertised; got %v", tools)
+		}
+		if tool.Annotations == nil || !tool.Annotations.ReadOnlyHint || !tool.Annotations.IdempotentHint {
+			t.Errorf("recover_cascade must be annotated read-only + idempotent, got %+v", tool.Annotations)
+		}
+		if tool.InputSchema == nil {
+			t.Fatal("recover_cascade has no input schema")
+		}
+		raw, err := json.Marshal(tool.InputSchema)
+		if err != nil {
+			t.Fatalf("marshal input schema: %v", err)
+		}
+		for _, want := range []string{"schema", "table", "pk", "pks", "since", "until",
+			"lookback", "max_depth", "limit", "allow_incomplete", "baseline_dir", "baseline_s3"} {
+			if !strings.Contains(string(raw), `"`+want+`"`) {
+				t.Errorf("input schema is missing property %q: %s", want, raw)
+			}
+		}
+	})
+}
+
+// TestRecoverCascadeRejectsRoutedSurfaceParams pins that a surface owning its
+// own routing (the console) refuses the client-supplied DSN and baseline
+// location BEFORE resolving a connection — an authenticated MCP client must
+// not be able to point the console at arbitrary storage.
+func TestRecoverCascadeRejectsRoutedSurfaceParams(t *testing.T) {
+	cfg := Config{
+		Resolve:             unreachableResolve(t),
+		AllowDSNParam:       false,
+		AllowBaselineParams: false,
+		RecoverCascade:      true,
+	}
+	base := RecoverCascadeArgs{Schema: "app", Table: "orders"}
+
+	dsn := base
+	dsn.IndexDSN = "u:p@tcp(1.2.3.4:3306)/x"
+	assertToolError(t, callRecoverCascade(t, cfg, dsn), "index_dsn is not accepted")
+
+	dir := base
+	dir.BaselineDir = "/tmp/baselines"
+	assertToolError(t, callRecoverCascade(t, cfg, dir), "baseline_dir/baseline_s3 are not accepted")
+
+	s3 := base
+	s3.BaselineS3 = "s3://bucket/prefix"
+	assertToolError(t, callRecoverCascade(t, cfg, s3), "baseline_dir/baseline_s3 are not accepted")
+}
+
+// TestRecoverCascadeValidation pins the pre-connection argument checks: they
+// must all refuse before Resolve is ever called.
+func TestRecoverCascadeValidation(t *testing.T) {
+	cfg := Config{Resolve: unreachableResolve(t), AllowDSNParam: true, AllowBaselineParams: true, RecoverCascade: true}
+
+	assertToolError(t, callRecoverCascade(t, cfg, RecoverCascadeArgs{Table: "orders"}), "schema and table are required")
+	assertToolError(t, callRecoverCascade(t, cfg, RecoverCascadeArgs{Schema: "app"}), "schema and table are required")
+	assertToolError(t, callRecoverCascade(t, cfg,
+		RecoverCascadeArgs{Schema: "app", Table: "orders", PK: "1", PKs: []string{"2"}}), "mutually exclusive")
+	assertToolError(t, callRecoverCascade(t, cfg,
+		RecoverCascadeArgs{Schema: "app", Table: "orders", MaxDepth: -1}), "max_depth must be >= 1")
+	assertToolError(t, callRecoverCascade(t, cfg,
+		RecoverCascadeArgs{Schema: "app", Table: "orders", Lookback: "not-a-duration"}), "invalid lookback")
+	assertToolError(t, callRecoverCascade(t, cfg,
+		RecoverCascadeArgs{Schema: "app", Table: "orders", Since: "not-a-time"}), "invalid since")
+}
+
+// TestRecoverCascadeRefusesActiveProfile pins the RBAC guard: cascade victim
+// synthesis fetches child rows without carrying deny/redact rules, so any
+// active profile posture on the Target must refuse — the same enforcement the
+// console's /api/recover-cascade endpoint applies.
+func TestRecoverCascadeRefusesActiveProfile(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	cfg := Config{
+		Resolve: func(ctx context.Context, _ string) (*Target, error) {
+			return &Target{DB: db, ProfileActive: true, ResolverLoaded: true}, nil
+		},
+		RecoverCascade: true,
+	}
+	res := callRecoverCascade(t, cfg, RecoverCascadeArgs{Schema: "app", Table: "orders"})
+	assertToolError(t, res, "access-control profile is active")
+}
+
+// cascadeMockConfig wires a sqlmock DB with the handler's real query sequence:
+// the parent DELETE fetch, the parent UPDATE fetch (both empty), then the
+// archive-coverage probe, whose outcome the caller picks — probeErr non-nil
+// makes coverage unknown, the one caveat class reachable without a live FK
+// topology.
+func cascadeMockConfig(t *testing.T, probeErr error) (Config, sqlmock.Sqlmock) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	mock.ExpectQuery("FROM binlog_events").WillReturnRows(sqlmock.NewRows(recoverToolMockCols))
+	mock.ExpectQuery("FROM binlog_events").WillReturnRows(sqlmock.NewRows(recoverToolMockCols))
+	probe := mock.ExpectQuery("FROM archive_state")
+	if probeErr != nil {
+		probe.WillReturnError(probeErr)
+	} else {
+		probe.WillReturnRows(sqlmock.NewRows([]string{"bintrail_id", "sample_local", "sample_bucket", "sample_key"}))
+	}
+	cfg := Config{
+		Resolve: func(ctx context.Context, _ string) (*Target, error) {
+			return &Target{DB: db, ResolverLoaded: true}, nil
+		},
+		RecoverCascade: true,
+	}
+	return cfg, mock
+}
+
+// TestRecoverCascadeIncompleteWithoutAllow pins the fail-closed default: a
+// provably partial synthesis is an ERROR that carries the caveats and the
+// tool-parameter remediation — never a script whose gaps hide in a comment
+// banner, and never CLI flag spellings an MCP client cannot use.
+func TestRecoverCascadeIncompleteWithoutAllow(t *testing.T) {
+	cfg, _ := cascadeMockConfig(t, errors.New("archive_state probe down"))
+	res := callRecoverCascade(t, cfg, RecoverCascadeArgs{Schema: "app", Table: "orders"})
+	assertToolError(t, res, "INCOMPLETE")
+	text := resultText(res)
+	if !strings.Contains(text, "coverage is unknown") {
+		t.Errorf("error must carry the caveat itself, got: %s", text)
+	}
+	if !strings.Contains(text, "allow_incomplete: true") {
+		t.Errorf("error must name the tool parameter that overrides it, got: %s", text)
+	}
+	// The #1114 precedent: never leak a CLI flag to an MCP client.
+	for _, flag := range []string{"--allow-incomplete", "--lookback", "--limit"} {
+		if strings.Contains(text, flag) {
+			t.Errorf("error leaks CLI flag %q: %s", flag, text)
+		}
+	}
+}
+
+// TestRecoverCascadeIncompleteWithAllow pins the opt-in: the same partial
+// synthesis returns the script, with the caveats surfaced in the payload's
+// incomplete list and complete=false — an incomplete synthesis must never be
+// presented as complete.
+func TestRecoverCascadeIncompleteWithAllow(t *testing.T) {
+	cfg, _ := cascadeMockConfig(t, errors.New("archive_state probe down"))
+	res := callRecoverCascade(t, cfg, RecoverCascadeArgs{Schema: "app", Table: "orders", AllowIncomplete: true})
+	if res.IsError {
+		t.Fatalf("allow_incomplete must return the partial script, got error: %s", resultText(res))
+	}
+	var out recoverCascadeResult
+	if err := json.Unmarshal([]byte(resultText(res)), &out); err != nil {
+		t.Fatalf("decode payload: %v (payload=%s)", err, resultText(res))
+	}
+	if out.Complete {
+		t.Error("complete must be false for a partial synthesis")
+	}
+	if len(out.Incomplete) == 0 || !strings.Contains(out.Incomplete[0], "coverage is unknown") {
+		t.Errorf("incomplete must carry the caveats, got %v", out.Incomplete)
+	}
+	if !strings.Contains(out.SQL, "INCOMPLETE RECOVERY") {
+		t.Errorf("the script's own banner must flag the partial recovery:\n%s", out.SQL)
+	}
+	if !strings.Contains(out.SQL, "SET FOREIGN_KEY_CHECKS=0;") || !strings.Contains(out.SQL, "SET FOREIGN_KEY_CHECKS=1;") {
+		t.Errorf("script must be FK-checks wrapped:\n%s", out.SQL)
+	}
+	// Empty window: an advisory (never a caveat) tells the agent the filter
+	// may be wrong rather than letting silence read as "nothing was changed".
+	found := false
+	for _, w := range out.Warnings {
+		if strings.Contains(w, "no parent DELETE or UPDATE events matched") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("warnings must carry the empty-match advisory, got %v", out.Warnings)
+	}
+}
+
+// TestRecoverCascadeCompleteEmptyWindow pins the clean-empty case: no parents,
+// no archives, no caveats — complete=true with an empty (but well-formed)
+// script and the audit-free advisory in warnings.
+func TestRecoverCascadeCompleteEmptyWindow(t *testing.T) {
+	cfg, _ := cascadeMockConfig(t, nil)
+	res := callRecoverCascade(t, cfg, RecoverCascadeArgs{Schema: "app", Table: "orders"})
+	if res.IsError {
+		t.Fatalf("clean empty window must succeed, got: %s", resultText(res))
+	}
+	var out recoverCascadeResult
+	if err := json.Unmarshal([]byte(resultText(res)), &out); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	if !out.Complete || len(out.Incomplete) != 0 {
+		t.Errorf("complete=%v incomplete=%v, want complete with no caveats", out.Complete, out.Incomplete)
+	}
+	if out.StatementCount != 0 || out.Parents != 0 || out.Children != 0 {
+		t.Errorf("counts = %d/%d/%d, want all zero", out.StatementCount, out.Parents, out.Children)
+	}
+}
+
+// TestRecoverCascadeRoutedSurfaceNoBaseline pins that on a routed surface
+// (console posture) WITHOUT a configured baseline the tool still serves —
+// Phase-1 — instead of copying reconstruct's baselineConfigured refusal, and
+// reports the phase honestly (baseline_active=false).
+func TestRecoverCascadeRoutedSurfaceNoBaseline(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	mock.ExpectQuery("FROM binlog_events").WillReturnRows(sqlmock.NewRows(recoverToolMockCols))
+	mock.ExpectQuery("FROM binlog_events").WillReturnRows(sqlmock.NewRows(recoverToolMockCols))
+	mock.ExpectQuery("FROM archive_state").WillReturnRows(
+		sqlmock.NewRows([]string{"bintrail_id", "sample_local", "sample_bucket", "sample_key"}))
+	cfg := Config{
+		Resolve: func(ctx context.Context, _ string) (*Target, error) {
+			return &Target{DB: db, ResolverLoaded: true, BaselineConfigured: false}, nil
+		},
+		AllowDSNParam:       false,
+		AllowBaselineParams: false,
+		RecoverCascade:      true,
+	}
+	res := callRecoverCascade(t, cfg, RecoverCascadeArgs{Schema: "app", Table: "orders"})
+	if res.IsError {
+		t.Fatalf("Phase-1 without a baseline must serve, got: %s", resultText(res))
+	}
+	var out recoverCascadeResult
+	if err := json.Unmarshal([]byte(resultText(res)), &out); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	if out.BaselineActive {
+		t.Error("baseline_active must be false when the surface has no baseline configured")
+	}
+}

--- a/packaging/mcpb/manifest.template.json
+++ b/packaging/mcpb/manifest.template.json
@@ -40,6 +40,10 @@
       "description": "Generate reversal SQL for matching events (never executes it)"
     },
     {
+      "name": "recover_cascade",
+      "description": "Generate reversal SQL for foreign-key ON DELETE / ON UPDATE cascade side effects (never executes it)"
+    },
+    {
       "name": "status",
       "description": "Show index status: files, partitions, continuity, summary"
     },


### PR DESCRIPTION
closes #1128

## What

Adds a `recover_cascade` MCP tool (deferred from #953) to `internal/mcptools`, served by both the standalone `bintrail-mcp` binary and the console's `/mcp` endpoint. It generates reversal SQL for foreign-key `ON DELETE`/`ON UPDATE` CASCADE / SET NULL side effects that InnoDB runs below the binlog — the child rows the delta-only `recover` tool silently misses.

## Design decisions

- **Registration gate**: per surface via `Config.RecoverCascade`, mirroring `Config.Reconstruct` (#1114) — but deliberately NOT gated on `baselineConfigured`. Cascade recovery degrades meaningfully without a baseline (Phase-1 window-only synthesis still works), so both surfaces register the tool unconditionally and the Phase-2 baseline fallback engages per call: from the `baseline_dir`/`baseline_s3` parameters or `BINTRAIL_BASELINE_DIR`/`_S3` on the standalone surface; from the Target's `FindBaseline` (the bundle lookup that carries the #766 local→S3 fallback, per #1102) on the console, which rejects the baseline parameters exactly like `reconstruct` does.
- **Same call sequence as the CLI and console**: two root fetches (DELETE + UPDATE candidates, live index only), unconditional archive-coverage probe with the same three-bucket caveat policy, `GroupParentDeletesByFKGraph` → per-group `SynthesizeVictims` → `MergeResults`, then `cascaderecover.MergeParentRoots` before `EmitSQL` (the generator does not sort). The emitted script is byte-comparable with the other two surfaces'.
- **Incompleteness is the contract**: a provably partial synthesis is a tool ERROR carrying every caveat unless `allow_incomplete: true`, in which case the caveats come back in the payload's `incomplete` list (with `complete: false`) and inside the script's `!!! INCOMPLETE RECOVERY` banner. An operational synthesis failure is never overridable. Advisory notes (`warnings`) stay a separate channel (#618).
- **No CLI flags in errors** (#1114 precedent): `--allow-incomplete` is spoken as `allow_incomplete: true`; the `recovery.ScriptBudgetError` is rewritten like the recover tool's.
- **RBAC**: refused under any active profile/deny/redact posture — the same guard as `POST /api/recover-cascade` (cascade victim synthesis cannot honor redaction); no per-call `profile` parameter, matching the CLI command.
- **Audit**: emits `recover.cascade` on the surface's audit tag when (and only when) a script is returned; the `mcp/recover.cascade` pair is declared in `internal/audittest.Required` (OwnerMCP) and driven in the mcptools contract test; `ext/audit.go`'s docstring updated. The audittest edit is a single additive row to merge cleanly with in-flight work.
- **Annotations**: `ReadOnlyHint: true`, `IdempotentHint: true` — the tool only generates SQL, never executes it.

## Tool-count updates (now six)

- `cmd/bintrail-mcp/e2e_test.go`, `integration_test.go`, `bridge_integration_test.go`
- `internal/console/mcp_integration_test.go`
- `packaging/mcpb/manifest.template.json` (pinned by the existing manifest-sync unit test)
- `docs/mcp-server.md`, `docs/connect-ai.md`, `docs/guide.md`, `docs/console.md`

## Tests

- Unit (`internal/mcptools/recover_cascade_test.go`): registration opt-in/opt-out + annotations + input-schema properties; console-posture rejection of `index_dsn`/`baseline_dir`/`baseline_s3` before any connection resolve; argument validation; RBAC refusal; incomplete-without-allow → error carrying the caveats and the tool-parameter remediation (and no CLI flag spellings); incomplete-with-allow → partial script with `complete: false`, caveats in `incomplete`, and the banner in the SQL; clean empty window → complete.
- Audit contract: new `recover_cascade` case in `TestAuditContract_MCP` driving the real handler over sqlmock.
- Integration (`recover_cascade_integration_test.go`): end-to-end ON DELETE CASCADE over a seeded index (same topology as the console endpoint tests) — parent + 2 children re-inserted inside the FK-checks wrapper, counts and completeness asserted; pk-filter empty-match advisory.
- Full suite: `go test ./... -count=1`, `go vet` (both tag sets), `-race` on mcptools/bintrail-mcp/ext/console, and the integration tier for mcptools, cmd/bintrail-mcp, and internal/console — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)