### PR TITLE
tests: de-flake port/timing tests that fail under load

### DIFF
--- a/cliapp/dump_test.go
+++ b/cliapp/dump_test.go
@@ -580,6 +580,16 @@ exit 1
 	dmpFormat = "text"
 	stubPingSource(t)
 
+	// runDump reaches acquireDumpLock, which without this override uses the
+	// REAL os.TempDir() lockfile — machine-global, shared with every other
+	// bintrail test process. A second suite running concurrently on the same
+	// machine turns this test's assertions into "another dump is already
+	// running" failures (#1164). Same pattern as
+	// TestRunDump_localDeliversPasswordViaEnvNotArgv.
+	savedLock := dumpLockDir
+	dumpLockDir = func() string { return dir }
+	t.Cleanup(func() { dumpLockDir = savedLock })
+
 	dumpCmd.SetContext(context.Background())
 	err := runDump(dumpCmd, nil)
 	if err == nil {

--- a/consoleapp/flashback_test.go
+++ b/consoleapp/flashback_test.go
@@ -119,13 +119,17 @@ func TestServeFlashbackDrainsActiveConn(t *testing.T) {
 	go func() { done <- serveFlashback(ctx, srv, ln, flashbackConfig{}) }()
 
 	// Read the server's handshake greeting to confirm the accept loop spawned an
-	// in-flight handler goroutine (wg > 0) before cancelling.
+	// in-flight handler goroutine (wg > 0) before cancelling. The deadline and
+	// the drain wait below are failure detectors only — on the green path both
+	// resolve immediately — so they are generous: at 5s a machine loaded with a
+	// full parallel suite plus build/vet starved them into spurious failures
+	// (#1164).
 	conn, err := net.Dial("tcp", ln.Addr().String())
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer conn.Close()
-	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	_ = conn.SetReadDeadline(time.Now().Add(30 * time.Second))
 	if _, err := conn.Read(make([]byte, 1)); err != nil {
 		t.Fatalf("expected a handshake greeting from the flashback port: %v", err)
 	}
@@ -133,7 +137,7 @@ func TestServeFlashbackDrainsActiveConn(t *testing.T) {
 	cancel()
 	select {
 	case <-done:
-	case <-time.After(5 * time.Second):
+	case <-time.After(30 * time.Second):
 		t.Fatal("serveFlashback did not drain the in-flight connection on ctx cancel")
 	}
 }
@@ -217,7 +221,9 @@ func TestStartFlashbackPortBindAndDrain(t *testing.T) {
 	go func() { stop(); close(drained) }()
 	select {
 	case <-drained:
-	case <-time.After(5 * time.Second):
+	// Failure detector, not a paced wait — generous so machine load cannot
+	// starve the drain into a spurious failure (#1164).
+	case <-time.After(30 * time.Second):
 		t.Fatal("flashback drain did not return after ctx cancel (shutdown would hang)")
 	}
 }

--- a/consoleapp/monitor_integration_test.go
+++ b/consoleapp/monitor_integration_test.go
@@ -411,8 +411,15 @@ func TestIntegrationMonitorSupervisor(t *testing.T) {
 	if st := sup.Status(entry.ID); st.State != "stopped" {
 		t.Errorf("after Stop: state=%+v, want stopped", st)
 	}
+	// Stop returns once the run goroutine has closed lockDB on the client
+	// side, but mysqld releases a GET_LOCK held by a closing session only
+	// when it finishes tearing the session down — asynchronously. A
+	// zero-timeout probe raced that teardown and flaked under CI load
+	// (#1164, twice on main with this exact assertion). GET_LOCK's own
+	// timeout is the event-driven wait: it returns 1 the moment the lock
+	// frees and 0 only if the lock is genuinely still held after 10s.
 	var got int
-	if err := idxDB.QueryRow("SELECT GET_LOCK(?, 0)", "bintrail_monitor_"+entry.ID).Scan(&got); err != nil {
+	if err := idxDB.QueryRow("SELECT GET_LOCK(?, 10)", "bintrail_monitor_"+entry.ID).Scan(&got); err != nil {
 		t.Fatal(err)
 	}
 	if got != 1 {

--- a/internal/parser/committs_integration_test.go
+++ b/internal/parser/committs_integration_test.go
@@ -106,11 +106,20 @@ func TestParseFile_commitTimestampCapture(t *testing.T) {
 				i, ev.CommitTsUS, before, after)
 		}
 		// The whole point of the column: sub-second resolution the
-		// one-second common header cannot express.
-		if sec := uint64(ev.Timestamp.Unix()); ev.CommitTsUS/1_000_000 != sec {
+		// one-second common header cannot express — so both values must be
+		// readings of the same clock. Exact same-second equality is too
+		// strict: the header timestamp is stamped at statement execution
+		// and the commit timestamp at commit, so a transaction that
+		// straddles a second boundary legitimately truncates to a later
+		// second (observed on a loaded CI runner: commit second N+1 vs
+		// header second N, #1164). Allow a small forward-only skew; a unit
+		// error (ms/ns) misses by orders of magnitude and is already
+		// pinned by the [before, after] window above.
+		sec := uint64(ev.Timestamp.Unix())
+		if commitSec := ev.CommitTsUS / 1_000_000; commitSec < sec || commitSec-sec > 5 {
 			t.Errorf("event[%d]: CommitTsUS %d truncates to epoch second %d, but the event's own "+
 				"timestamp is %d — the two clocks disagree",
-				i, ev.CommitTsUS, ev.CommitTsUS/1_000_000, sec)
+				i, ev.CommitTsUS, commitSec, sec)
 		}
 	}
 

--- a/internal/shim/handler_test.go
+++ b/internal/shim/handler_test.go
@@ -1929,7 +1929,12 @@ func runHandshakeTest(t *testing.T, serverUser, serverPass, clientUser, clientPa
 	// Server side: accept one connection, perform handshake, then loop
 	// HandleCommand until the client disconnects. SetReadDeadline
 	// guarantees the loop unblocks even if the client's TCP close does
-	// not propagate immediately, so the test can never hang.
+	// not propagate immediately, so the test can never hang. It is a
+	// BACKSTOP only — the normal exit is the EOF from the client's close —
+	// but it also covers every read of the handshake itself, so it must be
+	// generous: at 3s a loaded machine could stall the multi-round-trip
+	// auth past the deadline, aborting the handshake server-side and
+	// handing the client an I/O error instead of "Access denied" (#1164).
 	serverErr := make(chan error, 1)
 	go func() {
 		c, err := listener.Accept()
@@ -1938,7 +1943,7 @@ func runHandshakeTest(t *testing.T, serverUser, serverPass, clientUser, clientPa
 			return
 		}
 		defer c.Close()
-		c.SetReadDeadline(time.Now().Add(3 * time.Second))
+		c.SetReadDeadline(time.Now().Add(30 * time.Second))
 		h := NewHandler(nil, nil)
 		h.UseDB("myapp")
 		srv := server.NewDefaultServer()
@@ -1965,17 +1970,21 @@ func runHandshakeTest(t *testing.T, serverUser, serverPass, clientUser, clientPa
 		clientErr <- driveClient(host+":"+port, clientUser, clientPass)
 	}()
 
+	// Both waits are failure detectors, not paced waits: on the green path
+	// the channels are signalled as soon as the handshake resolves. Keep
+	// them generous (30s) so a loaded machine cannot turn scheduling delay
+	// into a spurious failure (#1164).
 	var pingErr error
 	select {
 	case pingErr = <-clientErr:
-	case <-time.After(5 * time.Second):
+	case <-time.After(30 * time.Second):
 		t.Fatal("client timed out")
 	}
 
 	listener.Close()
 	select {
 	case <-serverErr:
-	case <-time.After(5 * time.Second):
+	case <-time.After(30 * time.Second):
 		t.Fatal("server goroutine did not exit")
 	}
 	return pingErr


### PR DESCRIPTION
closes #1164

## Diagnosis first

The two CI matrix failures on 2026-07-27 (run 30285538729, main) were pulled from the failed-run logs, and neither is oversubscription — the integration job already runs `-p 1` (packages serialized). Each is a precise race:

- **`integration (8.4)` — `TestIntegrationMonitorSupervisor`**: failed at `monitor_integration_test.go:419: advisory lock must be free after Stop`, not on the 30s state wait. `Stop` returns once the run goroutine has closed `lockDB` client-side, but mysqld releases a `GET_LOCK` held by a closing session only when the server-side session teardown finishes — asynchronously. The `GET_LOCK(name, 0)` probe raced that teardown. The same assertion also failed run 30211038774 on `integration (8.0)` (2026-07-26) — two independent occurrences of the identical line.
- **`integration (8.0)` — `TestParseFile_commitTimestampCapture`**: `CommitTsUS 1785171260041230 truncates to epoch second 1785171260, but the event's own timestamp is 1785171259`. The event-header timestamp is stamped at statement execution, the commit timestamp at commit; a transaction straddling a second boundary legitimately truncates one second later. The exact same-second equality was over-strict.

The locally-reproduced unit failures (`TestServeFlashbackDrainsActiveConn`, `TestStartFlashbackPortBindAndDrain`, `TestEndToEndHandshake_RejectsWrongPassword`) already use ephemeral ports (`127.0.0.1:0`); their mechanism is fixed **backstop** deadlines (3–5s) that double as failure detectors. Under a machine running a full parallel suite plus `go build`/`go vet`, goroutine scheduling delay can eat those budgets; the shim case is the sharpest — its 3s server-side read deadline also covers every read of the multi-round-trip handshake, so under load the server aborts mid-auth and the client observes an I/O error instead of `Access denied`.

## Fixes (all test-only; no production or workflow changes)

| Test | Mechanism | Fix |
|---|---|---|
| `consoleapp/TestIntegrationMonitorSupervisor` | mysqld frees `GET_LOCK` asynchronously after session close | probe with `GET_LOCK(name, 10)` — returns 1 the moment the lock frees, 0 only if genuinely leaked after 10s |
| `parser/TestParseFile_commitTimestampCapture` | second-boundary straddle between header and commit clocks | forward-only skew bound (≤5s) instead of exact second equality; unit errors (×1000) still caught by both the bound and the existing `[before, after]` window |
| `shim/runHandshakeTest` (both `TestEndToEndHandshake_*`) | 3s read deadline covered the whole handshake | 30s; also the two 5s result waits → 30s (failure detectors, resolve immediately when green) |
| `consoleapp` flashback drain tests | 5s greeting-read deadline / drain waits under load | 30s; the waits are event-driven (channel close), the timeout only detects failure |
| `cliapp/TestRunDump_capturesStderrOnFailure` | takes the real machine-global `os.TempDir()` dump lockfile; a concurrent bintrail test process collides ("another dump is already running") | redirect `dumpLockDir` to the test's own dir — the pattern the sibling lock tests already use |

Neighbors audited in the same files: the other lock tests already override `dumpLockDir`; `waitStreamLive`/`waitState` poll with generous budgets and were not the failing lines; `monitor_test.go`'s millisecond-scale breaker test only gets *more* robust under load (delays make runs look healthier).

`internal/parser` #415 (cross-package DDL leaking into count assertions) is a different shape and is already mitigated by DML-only counting plus `-p 1` in CI — the parser failure in this run was the commit-ts straddle above, not #415.

## Repro evidence

- Before, issue's combination (full unit suite + concurrent `go build` + `go vet`), 3 rounds: green on an otherwise idle 10-core box — the original local repro depended on ambient load. Stress attempt (24 CPU burners, `GOMAXPROCS=2`, `-race -count=40` on the named tests): also green. The timeout bumps are therefore justified at mechanism level (backstops only; zero cost when green), while the two CI shapes are justified directly from the failed-run logs.
- The dump-lock collision **was** observed once during these rounds (a concurrent test process on the same machine held the lock), confirming that mechanism live.
- After: 5 total rounds of the issue's combination green; `-race -count=5` on `consoleapp` + `internal/shim` green; `-tags integration -race` `TestIntegrationMonitorSupervisor -count=3` and `TestParseFile_commitTimestampCapture -count=10` green against the live container; full `-tags integration` `internal/shim` green; `go vet` with and without `-tags integration` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)