### PR TITLE
parser: scope the statement-format DML alarm to captured schemas

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -220,16 +220,29 @@ func (p *Parser) ParseFile(ctx context.Context, filename string, events chan<- E
 			} else if kw, isDML := statementDML(string(ev.Query)); isDML {
 				// STATEMENT/MIXED-format DML (or a session flip off ROW): the row
 				// image is not in the binlog, so this change cannot be captured.
-				// Fail LOUD + metric, symmetric to the partial-image guard (#493).
+				// Fail LOUD + metric, symmetric to the partial-image guard (#493) —
+				// but only when the statement's schema is in capture scope; an
+				// out-of-scope drop (system schema, or excluded by the configured
+				// filters) is not a coverage gap and must not raise the alarm
+				// (#1000: RDS's rdsadmin writes mysql.* in STATEMENT format).
 				// NOTE: never log the statement text — a DML statement embeds row
 				// VALUES; keyword + file/pos + connection_id locate it without
 				// leaking data into operator logs.
-				p.logger.Warn("statement-format DML in binlog — event NOT captured (bintrail requires binlog_format=ROW; a STATEMENT/MIXED format or a session-level override produced this)",
-					"file", filename,
-					"pos", binlogEv.Header.LogPos,
-					"statement_type", kw,
-					"connection_id", ev.SlaveProxyID)
-				observe.StatementDMLDropped()
+				if schema := string(ev.Schema); !statementDMLInScope(schema, &p.filters) {
+					p.logger.Debug("statement-format DML for out-of-scope schema — not captured, not a coverage gap",
+						"file", filename,
+						"pos", binlogEv.Header.LogPos,
+						"schema", schema,
+						"statement_type", kw,
+						"connection_id", ev.SlaveProxyID)
+				} else {
+					p.logger.Warn("statement-format DML in binlog — event NOT captured (bintrail requires binlog_format=ROW; a STATEMENT/MIXED format or a session-level override produced this)",
+						"file", filename,
+						"pos", binlogEv.Header.LogPos,
+						"statement_type", kw,
+						"connection_id", ev.SlaveProxyID)
+					observe.StatementDMLDropped()
+				}
 			}
 
 		case *replication.RowsQueryEvent:
@@ -389,7 +402,9 @@ func eventPredatesSnapshot(binlogEv *replication.BinlogEvent, resolver *metadata
 // mysql.rds_heartbeat2 UPDATEs with ~now timestamps) is a routine, permanent
 // skip with NO converging remediation — re-snapshotting still excludes them.
 // It must NOT escalate a file to 'failed' via the gap tracker (#778 regression),
-// only ever warn-and-skip. Keep this list byte-identical to the TakeSnapshot
+// only ever warn-and-skip. statementDMLInScope leans on the same fact: a
+// statement-format DML whose default DB is one of these schemas cannot be a
+// capture gap (#1000). Keep this list byte-identical to the TakeSnapshot
 // NOT IN clause.
 func isSnapshotExcludedSchema(schema string) bool {
 	switch strings.ToLower(schema) {
@@ -913,6 +928,52 @@ func statementDML(queryStr string) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+// statementDMLInScope reports whether a statement-format DML with the given
+// session default database warrants the operator-facing coverage-gap signal
+// (WARN + statement_dml_dropped metric + capture-skip ledger). The statement's
+// target schema is approximated by the QUERY_EVENT's default DB (a bare
+// `INSERT INTO t ...` resolves against it) — a statement CAN qualify a
+// different schema explicitly, so this is a heuristic and the bias is
+// fail-loud: only a schema PROVABLY outside capture scope is silenced (#1000).
+//
+//   - Empty schema (no session default DB): ambiguous → in scope, warn.
+//   - System schema (isSnapshotExcludedSchema): snapshots always exclude
+//     these, so nothing capturable was lost. This is the RDS/Aurora false
+//     alarm: `rdsadmin@localhost` writes mysql.* heartbeat/bookkeeping rows
+//     in STATEMENT format as routine housekeeping on every deployment;
+//     counting those marked Capture health DEGRADED — and, on an idle
+//     source, tripped the consecutive-skip escalation ERROR — with no real
+//     gap anywhere.
+//   - Schema not in the configured --schemas filter: the operator asked not
+//     to capture it.
+//   - --tables filter configured and no filtered table lives in the schema:
+//     same reasoning per-table. When at least one filtered table IS in the
+//     schema, the statement might target it → in scope, warn.
+func statementDMLInScope(schema string, filters *Filters) bool {
+	if schema == "" {
+		return true
+	}
+	if isSnapshotExcludedSchema(schema) {
+		return false
+	}
+	if filters == nil {
+		return true
+	}
+	if filters.Schemas != nil && !filters.Schemas[schema] {
+		return false
+	}
+	if filters.Tables != nil {
+		prefix := schema + "."
+		for key := range filters.Tables {
+			if strings.HasPrefix(key, prefix) {
+				return true
+			}
+		}
+		return false
+	}
+	return true
 }
 
 // stripLeadingSQLComments removes leading whitespace and SQL comments so the

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -932,11 +932,14 @@ func statementDML(queryStr string) (string, bool) {
 
 // statementDMLInScope reports whether a statement-format DML with the given
 // session default database warrants the operator-facing coverage-gap signal
-// (WARN + statement_dml_dropped metric + capture-skip ledger). The statement's
-// target schema is approximated by the QUERY_EVENT's default DB (a bare
-// `INSERT INTO t ...` resolves against it) — a statement CAN qualify a
-// different schema explicitly, so this is a heuristic and the bias is
-// fail-loud: only a schema PROVABLY outside capture scope is silenced (#1000).
+// (WARN + statement_dml_dropped metric + capture-skip ledger). The gate keys
+// on the QUERY_EVENT's session default DB — the schema a bare
+// `INSERT INTO t ...` resolves against — which is a HEURISTIC, not proof: a
+// statement can qualify a different schema explicitly, so
+// `USE legacy; UPDATE shop.orders ...` is silenced under `--schemas shop`
+// even though its target is captured. That is issue #1000's accepted
+// tradeoff (the default DB is the only scope key available in the
+// QUERY_EVENT); genuine ambiguity — an empty default DB — errs loud.
 //
 //   - Empty schema (no session default DB): ambiguous → in scope, warn.
 //   - System schema (isSnapshotExcludedSchema): snapshots always exclude

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -559,6 +559,54 @@ func TestStatementDML(t *testing.T) {
 	}
 }
 
+// TestStatementDMLInScope pins the #1000 scope decision: the coverage-gap
+// signal (WARN + metric + skip ledger) fires only for a schema the operator
+// actually captures. The bias is fail-loud — an empty/unknown default DB
+// warns — while system schemas and filter-excluded schemas are provably out
+// of scope and stay silent.
+func TestStatementDMLInScope(t *testing.T) {
+	shopOnly := &Filters{Schemas: map[string]bool{"shop": true}}
+	ordersOnly := &Filters{Tables: map[string]bool{"shop.orders": true}}
+	both := &Filters{Schemas: map[string]bool{"shop": true}, Tables: map[string]bool{"shop.orders": true}}
+
+	tests := []struct {
+		name    string
+		schema  string
+		filters *Filters
+		want    bool
+	}{
+		// Empty/ambiguous default DB: fail-loud.
+		{"empty schema, no filters", "", &Filters{}, true},
+		{"empty schema, filters configured", "", shopOnly, true},
+		// System schemas: never captured, never a gap — case-insensitive,
+		// matching isSnapshotExcludedSchema/TakeSnapshot.
+		{"mysql", "mysql", &Filters{}, false},
+		{"mysql uppercase", "MySQL", &Filters{}, false},
+		{"sys", "sys", &Filters{}, false},
+		{"performance_schema", "performance_schema", &Filters{}, false},
+		{"information_schema", "information_schema", &Filters{}, false},
+		{"system schema even when explicitly filtered in", "mysql", &Filters{Schemas: map[string]bool{"mysql": true}}, false},
+		// No filters: every user schema is captured.
+		{"user schema, no filters", "shop", &Filters{}, true},
+		{"user schema, nil filters", "shop", nil, true},
+		// --schemas filter.
+		{"schema in filter", "shop", shopOnly, true},
+		{"schema not in filter", "analytics", shopOnly, false},
+		// --tables filter: in scope iff some filtered table lives in the schema.
+		{"tables filter, schema hosts a filtered table", "shop", ordersOnly, true},
+		{"tables filter, schema hosts none", "reporting", ordersOnly, false},
+		{"tables filter, prefix must not cross the dot", "shopify", ordersOnly, false},
+		// Both dimensions configured.
+		{"both filters, in scope", "shop", both, true},
+		{"both filters, out of scope", "analytics", both, false},
+	}
+	for _, tt := range tests {
+		if got := statementDMLInScope(tt.schema, tt.filters); got != tt.want {
+			t.Errorf("%s: statementDMLInScope(%q) = %v, want %v", tt.name, tt.schema, got, tt.want)
+		}
+	}
+}
+
 // ─── SwapResolver + schemaVersion ──────────────────────────────────────────────
 
 func TestParser_SwapResolver_updatesSchemaVersion(t *testing.T) {

--- a/internal/parser/skips_test.go
+++ b/internal/parser/skips_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/go-mysql-org/go-mysql/replication"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // ─── Capture-skip counters (#1034) ────────────────────────────────────────────
@@ -235,7 +236,9 @@ func TestHandleRows_captureBreaksEscalationRun(t *testing.T) {
 	}
 }
 
-// The #999 statement-format DML drop site inside StreamParser.Run.
+// The #999 statement-format DML drop site inside StreamParser.Run. The event
+// carries NO session default DB (QueryEvent.Schema empty) — the ambiguous case
+// the #1000 scoping must keep fail-loud.
 func TestStreamParser_statementDMLCountsSkip(t *testing.T) {
 	skips := NewSkipCounters(newTestLogger(&bytes.Buffer{}))
 	sp := NewStreamParser(makeOrdersResolver(), Filters{}, newTestLogger(&bytes.Buffer{}))
@@ -251,6 +254,143 @@ func TestStreamParser_statementDMLCountsSkip(t *testing.T) {
 	snap, _ := skips.Snapshot()
 	if !strings.Contains(snap, SkipStatementFormatDML) || skips.Total() != 1 {
 		t.Fatalf("statement-format DML drop not counted (total=%d): %s", skips.Total(), snap)
+	}
+}
+
+// ─── Statement-DML capture scoping (#1000) ────────────────────────────────────
+//
+// The coverage-gap signal (WARN + bintrail_statement_dml_dropped_total +
+// capture-skip ledger) must fire only for schemas in capture scope. Each test
+// drives the REAL stream path: QueryEvents through StreamParser.Run.
+
+// readStatementDMLDropped reads bintrail_statement_dml_dropped_total from the
+// default Prometheus registry. It is a process-global singleton other tests
+// may touch, so callers assert before/after deltas, never absolute values.
+func readStatementDMLDropped(t *testing.T) float64 {
+	t.Helper()
+	mfs, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+	for _, mf := range mfs {
+		if mf.GetName() == "bintrail_statement_dml_dropped_total" {
+			return mf.GetMetric()[0].GetCounter().GetValue()
+		}
+	}
+	return 0
+}
+
+// runStatementDMLStream feeds the given QueryEvents through a real
+// StreamParser.Run and returns the recorded skips and the parser's log output.
+func runStatementDMLStream(t *testing.T, filters Filters, evs ...*replication.BinlogEvent) (*SkipCounters, string) {
+	t.Helper()
+	var logBuf bytes.Buffer
+	skips := NewSkipCounters(newTestLogger(&logBuf))
+	sp := NewStreamParser(makeOrdersResolver(), filters, newTestLogger(&logBuf))
+	sp.SetSkipCounters(skips)
+	streamer := replication.NewBinlogStreamer()
+	out := make(chan Event, 10)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	feedThenCancel(t, streamer, cancel, evs...)
+	if err := sp.Run(ctx, streamer, out); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	return skips, logBuf.String()
+}
+
+// The rdsadmin false alarm: RDS's maintenance connection writes mysql.*
+// heartbeats in STATEMENT format with session default DB "mysql". More than
+// SkipEscalationThreshold consecutive ones — an idle overnight source — must
+// produce no WARN, no metric increment, no skip record, and no
+// "capture is effectively stopped" escalation ERROR.
+func TestStreamParser_statementDMLSystemSchemaSilent(t *testing.T) {
+	evs := make([]*replication.BinlogEvent, 0, SkipEscalationThreshold+5)
+	for i := 0; i < SkipEscalationThreshold+5; i++ {
+		evs = append(evs, makeQueryEventWithSchema("mysql",
+			"INSERT INTO mysql.rds_heartbeat2(id, value) values (1,1753921394003) ON DUPLICATE KEY UPDATE value = 1753921394003"))
+	}
+	before := readStatementDMLDropped(t)
+	skips, logs := runStatementDMLStream(t, Filters{}, evs...)
+
+	if got := skips.Total(); got != 0 {
+		t.Fatalf("system-schema statement DML must not count toward capture health, got total=%d", got)
+	}
+	if got := readStatementDMLDropped(t); got != before {
+		t.Fatalf("statement_dml_dropped_total moved %v -> %v for a system schema", before, got)
+	}
+	if strings.Contains(logs, "level=WARN") || strings.Contains(logs, "NOT captured") {
+		t.Errorf("system-schema statement DML must not WARN:\n%s", logs)
+	}
+	if strings.Contains(logs, "level=ERROR") {
+		t.Errorf("idle heartbeat traffic must never trip the consecutive-skip escalation:\n%s", logs)
+	}
+	// The Debug trace proves the events actually reached the detection branch
+	// (guards against this test passing vacuously).
+	if !strings.Contains(logs, "out-of-scope schema") {
+		t.Errorf("expected the Debug out-of-scope trace:\n%s", logs)
+	}
+}
+
+// A schema excluded by the configured --schemas filter is out of scope: the
+// operator asked not to capture it, so its statement-format DML is silent.
+func TestStreamParser_statementDMLFilteredSchemaSilent(t *testing.T) {
+	before := readStatementDMLDropped(t)
+	skips, logs := runStatementDMLStream(t,
+		Filters{Schemas: map[string]bool{"shop": true}},
+		makeQueryEventWithSchema("analytics", "INSERT INTO events VALUES (1)"))
+
+	if got := skips.Total(); got != 0 {
+		t.Fatalf("filter-excluded schema must not count, got total=%d", got)
+	}
+	if got := readStatementDMLDropped(t); got != before {
+		t.Fatalf("statement_dml_dropped_total moved %v -> %v for a filter-excluded schema", before, got)
+	}
+	if strings.Contains(logs, "level=WARN") {
+		t.Errorf("filter-excluded schema must not WARN:\n%s", logs)
+	}
+	if !strings.Contains(logs, "out-of-scope schema") {
+		t.Errorf("expected the Debug out-of-scope trace:\n%s", logs)
+	}
+}
+
+// A statement-format DML into a captured user schema is the REAL coverage gap:
+// it must still warn, increment the metric, and record the skip — unchanged.
+func TestStreamParser_statementDMLInScopeSchemaWarns(t *testing.T) {
+	before := readStatementDMLDropped(t)
+	skips, logs := runStatementDMLStream(t,
+		Filters{Schemas: map[string]bool{"shop": true}},
+		makeQueryEventWithSchema("shop", "UPDATE orders SET amount = 1"))
+
+	snap, _ := skips.Snapshot()
+	if !strings.Contains(snap, SkipStatementFormatDML) || skips.Total() != 1 {
+		t.Fatalf("in-scope statement DML not counted (total=%d): %s", skips.Total(), snap)
+	}
+	if got := readStatementDMLDropped(t); got != before+1 {
+		t.Fatalf("statement_dml_dropped_total = %v, want %v", got, before+1)
+	}
+	if !strings.Contains(logs, "level=WARN") || !strings.Contains(logs, "NOT captured") {
+		t.Errorf("in-scope statement DML must keep the operator-facing WARN:\n%s", logs)
+	}
+}
+
+// An empty session default DB is ambiguous — the statement may target a
+// captured schema via a qualified name — so the scoping errs toward warning
+// even with filters configured (fail-loud).
+func TestStreamParser_statementDMLEmptySchemaWarns(t *testing.T) {
+	before := readStatementDMLDropped(t)
+	skips, logs := runStatementDMLStream(t,
+		Filters{Schemas: map[string]bool{"shop": true}},
+		makeQueryEvent("DELETE FROM shop.orders WHERE id = 1"))
+
+	if skips.Total() != 1 {
+		t.Fatalf("empty-schema statement DML must stay fail-loud, got total=%d", skips.Total())
+	}
+	if got := readStatementDMLDropped(t); got != before+1 {
+		t.Fatalf("statement_dml_dropped_total = %v, want %v", got, before+1)
+	}
+	if !strings.Contains(logs, "level=WARN") {
+		t.Errorf("empty-schema statement DML must WARN:\n%s", logs)
 	}
 }
 

--- a/internal/parser/stream.go
+++ b/internal/parser/stream.go
@@ -387,17 +387,32 @@ func (sp *StreamParser) Run(ctx context.Context, streamer *replication.BinlogStr
 			} else if kw, isDML := statementDML(string(ev.Query)); isDML {
 				// STATEMENT/MIXED-format DML (or a session flip off ROW): the row
 				// image is not in the binlog, so this change cannot be captured.
-				// Fail LOUD + metric, symmetric to the partial-image guard (#493).
+				// Fail LOUD + metric + skip ledger, symmetric to the partial-image
+				// guard (#493) — but only when the statement's schema is in capture
+				// scope; an out-of-scope drop (system schema, or excluded by the
+				// configured filters) is not a coverage gap and must not raise the
+				// alarm, mark Capture health DEGRADED, or feed the consecutive-skip
+				// escalation (#1000: RDS's rdsadmin writes mysql.* heartbeats in
+				// STATEMENT format — a constant false alarm otherwise).
 				// NOTE: never log the statement text — a DML statement embeds row
 				// VALUES; keyword + file/pos + connection_id locate it without
 				// leaking data into operator logs.
-				sp.logger.Warn("statement-format DML in binlog — event NOT captured (bintrail requires binlog_format=ROW; a STATEMENT/MIXED format or a session-level override produced this)",
-					"file", currentFile,
-					"pos", binlogEv.Header.LogPos,
-					"statement_type", kw,
-					"connection_id", ev.SlaveProxyID)
-				observe.StatementDMLDropped()
-				sp.skips.RecordSkip(SkipStatementFormatDML)
+				if schema := string(ev.Schema); !statementDMLInScope(schema, &sp.filters) {
+					sp.logger.Debug("statement-format DML for out-of-scope schema — not captured, not a coverage gap",
+						"file", currentFile,
+						"pos", binlogEv.Header.LogPos,
+						"schema", schema,
+						"statement_type", kw,
+						"connection_id", ev.SlaveProxyID)
+				} else {
+					sp.logger.Warn("statement-format DML in binlog — event NOT captured (bintrail requires binlog_format=ROW; a STATEMENT/MIXED format or a session-level override produced this)",
+						"file", currentFile,
+						"pos", binlogEv.Header.LogPos,
+						"statement_type", kw,
+						"connection_id", ev.SlaveProxyID)
+					observe.StatementDMLDropped()
+					sp.skips.RecordSkip(SkipStatementFormatDML)
+				}
 			}
 
 		case *replication.XIDEvent:

--- a/internal/parser/stream_test.go
+++ b/internal/parser/stream_test.go
@@ -64,12 +64,22 @@ func makeAnonymousGTIDEvent(gno int64) *replication.BinlogEvent {
 	}
 }
 
-// makeQueryEvent builds a BinlogEvent wrapping a QueryEvent.
+// makeQueryEvent builds a BinlogEvent wrapping a QueryEvent with no session
+// default DB (QueryEvent.Schema empty).
 func makeQueryEvent(query string) *replication.BinlogEvent {
 	return &replication.BinlogEvent{
 		Header: &replication.EventHeader{EventType: replication.QUERY_EVENT},
 		Event:  &replication.QueryEvent{Query: []byte(query)},
 	}
+}
+
+// makeQueryEventWithSchema is makeQueryEvent with the session default DB set —
+// how a real server stamps QUERY_EVENTs (e.g. rdsadmin's mysql.* housekeeping
+// arrives with Schema="mysql").
+func makeQueryEventWithSchema(schema, query string) *replication.BinlogEvent {
+	ev := makeQueryEvent(query)
+	ev.Event.(*replication.QueryEvent).Schema = []byte(schema)
+	return ev
 }
 
 // makeXIDEvent builds a BinlogEvent wrapping an XIDEvent (InnoDB commit).


### PR DESCRIPTION
closes #1000

## Summary

The statement-format DML detection fired unconditionally: every statement-format DML in the binlog produced the operator-facing WARN, incremented `bintrail_statement_dml_dropped_total`, and (stream path) recorded a `statement_format_dml` capture skip — without consulting capture scope. On RDS/Aurora, `rdsadmin@localhost` writes `mysql.*` heartbeats in STATEMENT format as normal housekeeping, so every deployment got a constant false coverage-gap WARN, a durable DEGRADED "Capture health" verdict in `status`, and (on an idle source) a false "capture is effectively stopped" escalation ERROR after ~100 consecutive heartbeats.

Fix: both detection sites — `internal/parser/stream.go` and `internal/parser/parser.go` — now gate the alarm on a shared `statementDMLInScope(schema, filters)` helper, keyed on the QUERY_EVENT's session default DB:

- **System schemas** (`mysql`, `sys`, `performance_schema`, `information_schema`) are never captured — the check reuses `isSnapshotExcludedSchema`, whose list is kept byte-identical to `TakeSnapshot`'s `NOT IN` clause — so their drops emit a Debug trace only: no WARN, no metric, no skip record, no escalation.
- **Filter-excluded schemas** (`--schemas` not containing the schema, or `--tables` configured with no filtered table in the schema) are likewise silent.
- **Empty/ambiguous default DB stays fail-loud**: a bare statement may target a captured schema via a qualified name, so the alarm is kept (unchanged behavior).
- **A statement-format DML into a captured user schema still warns + counts + records** — the real coverage gap is preserved, including with no filters configured.

This also unblocks #999: its remaining `--fail-on-gap` wiring depends on this counter being scoped, otherwise every RDS cron check would fail perpetually on benign heartbeat noise.

## Test plan

New tests drive the real stream path (`QueryEvent`s fed through `StreamParser.Run` via `BinlogStreamer`), plus a table test for the scope matrix:

- `TestStreamParser_statementDMLSystemSchemaSilent` — rdsadmin-style `mysql.*` statement DML, `SkipEscalationThreshold+5` consecutive events: no WARN, no metric delta, no skip, no escalation ERROR (asserts the Debug trace so the test can't pass vacuously).
- `TestStreamParser_statementDMLFilteredSchemaSilent` — schema outside `--schemas`: silent.
- `TestStreamParser_statementDMLInScopeSchemaWarns` — captured user schema: WARN + metric +1 + skip recorded.
- `TestStreamParser_statementDMLEmptySchemaWarns` — empty default DB with filters configured: still fail-loud.
- `TestStatementDMLInScope` — scope decision matrix (system schemas case-insensitive, schema/table filter dimensions, dot-boundary prefix, nil filters).

Ran in the worktree:
- `go build ./...`, `go vet ./...` — clean
- `go test ./... -count=1` — all packages pass
- `go test -race ./internal/parser/... -count=1` — pass

Not run: `go test -tags integration ./internal/parser/...` — no Docker MySQL on 13306 in this environment. The file-parser site shares the same helper and gating shape as the unit-tested stream site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)