### PR TITLE
status: exclude by-design TRUNCATE rows from the uncovered-DDL warning and stop mislabeling it as file mode

### DIFF
--- a/docs/ddl-tracking.md
+++ b/docs/ddl-tracking.md
@@ -14,7 +14,7 @@ DDL tracking solves three problems:
 
 1. **Detection**: The parser identifies DDL statements (`ALTER TABLE`, `CREATE TABLE`, `DROP TABLE`, `RENAME TABLE`, `TRUNCATE TABLE`) and emits them as events instead of just logging warnings.
 2. **Auto-snapshot**: When a DDL is detected and a source database connection is available, dbtrail automatically takes a new snapshot and hot-swaps the resolver — no manual intervention needed. This works in both stream mode (always has source connection) and file mode (when `--source-dsn` is provided).
-3. **Restore coverage**: The `status` command shows the time range of indexed events and warns about DDLs that weren't followed by a snapshot (file mode), so you know where recovery gaps might exist.
+3. **Restore coverage**: The `status` command shows the time range of indexed events and warns about DDLs that weren't followed by a snapshot — whether from file-mode indexing without `--source-dsn` or from a failed auto-snapshot — so you know where recovery gaps might exist.
 
 ---
 
@@ -85,7 +85,7 @@ Key fields:
 |---|---|
 | `ddl_type` | One of `ALTER TABLE`, `CREATE TABLE`, `DROP TABLE`, `RENAME TABLE`, `TRUNCATE TABLE` |
 | `ddl_query` | The full DDL statement from the binlog |
-| `snapshot_id` | The snapshot taken after this DDL, or NULL if no source connection was available |
+| `snapshot_id` | The snapshot taken after this DDL. NULL when none was taken: file mode without `--source-dsn`, a failed auto-snapshot, or `TRUNCATE TABLE` (which changes no table structure, so no snapshot is needed — by design, in every mode) |
 
 This table is created by `bintrail init` and must exist in the index database. Older index databases (created before this feature) won't have it — the status command handles this gracefully by treating a missing table as zero schema changes.
 
@@ -112,10 +112,10 @@ The `status` command includes a "Restore Coverage" section that answers the ques
   Latest event:       2026-03-02 09:45:00 UTC
   Total events:       1,284,567
   Schema changes:     3 detected
-  Warning: 1 DDL(s) detected without snapshot — recovery across these DDLs may be incomplete
+  Warning: 1 DDL(s) detected without auto-snapshot (file-mode indexing without --source-dsn, or a failed auto-snapshot) — recovery across these DDLs may require manual snapshot
 ```
 
-The warning appears when any `schema_changes` rows have `snapshot_id = NULL` — meaning a DDL was detected in file mode without a subsequent snapshot. Recovery SQL generated for events spanning such a DDL boundary may use incorrect column names.
+The warning appears when `schema_changes` rows have `snapshot_id = NULL` for a DDL type that needs a snapshot — either a DDL detected in file mode without `--source-dsn`, or an auto-snapshot that failed (in any mode). `TRUNCATE TABLE` rows are excluded from the count: they record `snapshot_id = NULL` by design (a truncate changes no table structure, so no snapshot is taken) and are not a coverage gap. Recovery SQL generated for events spanning a genuinely uncovered DDL boundary may use incorrect column names.
 
 ### JSON output
 
@@ -142,3 +142,5 @@ The warning appears when any `schema_changes` rows have `snapshot_id = NULL` —
 | schema_changes record | Yes, with `snapshot_id` | Yes, with `snapshot_id` | Yes, with `snapshot_id = NULL` |
 | User action needed | None | None | Run `bintrail snapshot` after DDL |
 | Restore coverage warning | No (snapshot covers the DDL) | No (snapshot covers the DDL) | Yes (warns about uncovered DDLs) |
+
+Two cases sit outside this happy-path table: a **failed auto-snapshot** (any mode) records the DDL with `snapshot_id = NULL` and counts toward the restore coverage warning; a **`TRUNCATE TABLE`** records `snapshot_id = NULL` by design in every mode and is excluded from the warning.

--- a/internal/status/load_coverage_integration_test.go
+++ b/internal/status/load_coverage_integration_test.go
@@ -1,0 +1,52 @@
+//go:build integration
+
+package status_test
+
+import (
+	"context"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/dbtrail/dbtrail/internal/status"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestLoadCoverage_uncoveredDDLs_integration proves the UncoveredDDLs counter
+// against the real schema_changes rows the capture paths write (#1049):
+//   - a TRUNCATE TABLE row records snapshot_id = NULL by design (no structure
+//     change; every mode deliberately skips the snapshot) and must NOT count;
+//   - an ALTER TABLE row with snapshot_id = NULL (file mode without
+//     --source-dsn, or a failed auto-snapshot) MUST count;
+//   - an ALTER TABLE row with a snapshot_id must not count.
+func TestLoadCoverage_uncoveredDDLs_integration(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	insert := `INSERT INTO schema_changes
+		(detected_at, binlog_file, binlog_pos, schema_name, table_name, ddl_type, ddl_query, snapshot_id)
+		VALUES (?, 'mysql-bin.000001', ?, 'shop', ?, ?, ?, ?)`
+
+	// By-design NULL: TRUNCATE skips the auto-snapshot in every mode.
+	testutil.MustExec(t, db, insert,
+		"2026-02-18 10:00:00", 100, "orders", "TRUNCATE TABLE", "TRUNCATE TABLE orders", nil)
+	// Genuinely uncovered: an ALTER whose auto-snapshot was skipped or failed.
+	testutil.MustExec(t, db, insert,
+		"2026-02-18 11:00:00", 200, "orders", "ALTER TABLE", "ALTER TABLE orders ADD COLUMN note TEXT", nil)
+	// Covered: an ALTER with its auto-snapshot recorded.
+	testutil.MustExec(t, db, insert,
+		"2026-02-18 12:00:00", 300, "users", "ALTER TABLE", "ALTER TABLE users ADD COLUMN note TEXT", 5)
+
+	coverage, err := status.LoadCoverage(context.Background(), db)
+	if err != nil {
+		t.Fatalf("LoadCoverage failed: %v", err)
+	}
+
+	if coverage.SchemaChanges != 3 {
+		t.Errorf("SchemaChanges = %d, want 3 (all rows, including TRUNCATE)", coverage.SchemaChanges)
+	}
+	if coverage.UncoveredDDLs != 1 {
+		t.Errorf("UncoveredDDLs = %d, want 1 (only the NULL-snapshot ALTER; TRUNCATE is by design, snapshot-carrying rows are covered)",
+			coverage.UncoveredDDLs)
+	}
+}

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -148,7 +148,13 @@ type CoverageInfo struct {
 	LatestEvent   sql.NullTime
 	TotalEvents   int64
 	SchemaChanges int
-	UncoveredDDLs int // DDLs without a snapshot (file mode, or failed auto-snapshot in stream mode)
+	// UncoveredDDLs counts schema_changes rows with snapshot_id IS NULL whose
+	// DDL type NEEDS a snapshot — i.e. file-mode indexing without --source-dsn,
+	// or a failed auto-snapshot (any mode). TRUNCATE TABLE rows are excluded:
+	// they record snapshot_id = NULL by design (no structure change, so both
+	// the stream DDL hook and the file-mode handler deliberately skip the
+	// snapshot), and counting them would permanently inflate the warning.
+	UncoveredDDLs int
 
 	// Archive-derived fields (from archive_state partition names and row counts).
 	ArchiveEarliestHour sql.NullTime // earliest hour derived from MIN(partition_name)
@@ -271,8 +277,12 @@ func LoadCoverage(ctx context.Context, db *sql.DB) (*CoverageInfo, error) {
 		return nil, fmt.Errorf("query schema_changes count: %w", err)
 	}
 
+	// TRUNCATE TABLE is excluded: it does not change table structure, so every
+	// capture path records it with snapshot_id = NULL on purpose ("DDL detected
+	// (no snapshot needed)") — a NULL there is not a coverage gap.
 	err = db.QueryRowContext(ctx,
-		`SELECT COUNT(*) FROM schema_changes WHERE snapshot_id IS NULL`).Scan(&c.UncoveredDDLs)
+		`SELECT COUNT(*) FROM schema_changes
+		 WHERE snapshot_id IS NULL AND ddl_type <> 'TRUNCATE TABLE'`).Scan(&c.UncoveredDDLs)
 	if err != nil {
 		return nil, fmt.Errorf("query uncovered DDLs: %w", err)
 	}
@@ -799,7 +809,7 @@ func WriteStatus(w io.Writer, files []IndexStateRow, parts []PartitionStat, arch
 		}
 		fmt.Fprintf(w, "  Schema changes: %d\n", coverage.SchemaChanges)
 		if coverage.UncoveredDDLs > 0 {
-			fmt.Fprintf(w, "  Warning: %d DDL(s) detected without auto-snapshot (file mode) — recovery across these DDLs may require manual snapshot\n",
+			fmt.Fprintf(w, "  Warning: %d DDL(s) detected without auto-snapshot (file-mode indexing without --source-dsn, or a failed auto-snapshot) — recovery across these DDLs may require manual snapshot\n",
 				coverage.UncoveredDDLs)
 		}
 	}

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -574,6 +574,13 @@ func TestWriteStatus_withCoverage(t *testing.T) {
 	assertContains(t, out, "42000")
 	assertContains(t, out, "3")
 	assertContains(t, out, "Warning")
+	// The warning must name both origins of a missing snapshot (#1049) —
+	// the old text hardcoded "(file mode)", mislabeling stream-mode
+	// auto-snapshot failures.
+	assertContains(t, out, "file-mode indexing without --source-dsn, or a failed auto-snapshot")
+	if strings.Contains(out, "(file mode)") {
+		t.Errorf("warning still carries the misleading '(file mode)' label:\n%s", out)
+	}
 }
 
 func TestWriteStatus_nilCoverage_omitsSection(t *testing.T) {


### PR DESCRIPTION
closes #1049

## Summary

`bintrail status` counted every `schema_changes` row with `snapshot_id IS NULL` as a "DDL without auto-snapshot" and attributed all of them to "(file mode)". Both were wrong:

- **TRUNCATE is by design.** TRUNCATE TABLE changes no table structure, so every capture path deliberately records it with `snapshot_id = NULL` ("DDL detected (no snapshot needed)"): the stream DDL hook (`internal/streamrun`), the file-mode handler (`cliapp/index.go`), and the PostgreSQL TRUNCATE audit marker (`internal/pgstreamrun`). Each TRUNCATE permanently inflated the warning. `LoadCoverage` now excludes `ddl_type = 'TRUNCATE TABLE'` from `UncoveredDDLs` — the minimal fix from the issue's suggested options. The JSON `uncovered_ddls` field uses the same counter, so it follows automatically.
- **The "(file mode)" label was hardcoded.** NULL rows are also produced by a failed auto-snapshot in stream mode, so the warning now names both origins: *"file-mode indexing without --source-dsn, or a failed auto-snapshot"*.

Of the issue's suggested fixes, this takes the minimal ones (count exclusion + reword). The richer options — a persisted `snapshot_state` enum and listing affected `schema_changes.id`s — are left out on purpose: they overlap with the coverage-state surfacing tracked in #1050, and the minimal change is what makes the warning truthful today. #1051 (the stream-mode crash-loop origin) is untouched.

## Test plan

- New `TestLoadCoverage_uncoveredDDLs_integration` drives the real `LoadCoverage` SQL against seeded `schema_changes` rows: a TRUNCATE/NULL row no longer counts, an ALTER/NULL row still counts, an ALTER with a `snapshot_id` never counted. **Ran against Docker MySQL 8.0 on 13306: PASS.**
- Tightened `TestWriteStatus_withCoverage` to pin the new wording and reject the old "(file mode)" label.
- `go test ./... -count=1` — pass (two `consoleapp` flashback/monitor failures appeared only in the full parallel run, are unrelated to this change, and pass in isolation — the known full-parallel flake).
- `go vet ./...` — pass (also with `-tags integration` for `internal/status`).
- `go test -tags integration ./internal/status/... -count=1` — 71 pass, 0 fail, 0 skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)