### PR TITLE
verify: honest wrong-path verdict for a PostgreSQL-shaped snapshot on the MySQL path

### DIFF
--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -110,7 +110,7 @@ func VerifyTable(ctx context.Context, cfg Config, schema, table string) (TableRe
 	}
 	for _, c := range pkCols {
 		if !reconstruct.SupportedPKType(c.DataType) {
-			return inconclusive(res, fmt.Sprintf("primary-key column %q has type %q unsupported by the baseline canonicalizer", c.Name, c.DataType)), nil
+			return inconclusive(res, pkTypeGateReason(c)), nil
 		}
 	}
 
@@ -323,6 +323,33 @@ func inconclusive(res TableResult, detail string) TableResult {
 	res.Status = StatusInconclusive
 	res.Detail = detail
 	return res
+}
+
+// pkTypeGateReason renders the inconclusive detail for a primary-key column
+// the MySQL-path type gate rejected. Two physically different causes reach it,
+// and they must not share a message (#1009):
+//
+//   - A real MySQL DATA_TYPE token the baseline canonicalizer does not handle
+//     (float, bit, ...): a genuine per-table limitation the operator can
+//     reason about, reported as such.
+//   - An EMPTY DataType: MySQL's information_schema always records a
+//     DATA_TYPE, so an empty token is the PostgreSQL snapshot shape
+//     (WritePGSnapshot stores pg_type_oid, never a MySQL type token).
+//     Reaching the MySQL-path gate with it means the run selected the MySQL
+//     path for a PostgreSQL-shaped index — the source flavor recorded in
+//     stream_state did not read "postgres" (unreadable stream_state, or the
+//     wrong index database). Blaming the PK type there sends the operator
+//     chasing a fixable-looking column problem that nothing they do to the
+//     table can fix; the honest verdict names the wrong-path cause.
+//
+// Shared by VerifyTable (live-source) and VerifyBaselinePair (baseline-
+// anchored) so the two modes cannot drift. No CLI flag names in the text: the
+// console's verify engine emits it too.
+func pkTypeGateReason(c metadata.ColumnMeta) string {
+	if c.DataType == "" {
+		return fmt.Sprintf("schema snapshot records no MySQL type for primary-key column %q — this is the PostgreSQL snapshot shape, but the index's stream_state flavor did not read \"postgres\", so verify took its MySQL path, which cannot verify a PostgreSQL-sourced table; check that the index database is the one the PostgreSQL stream writes", c.Name)
+	}
+	return fmt.Sprintf("primary-key column %q has type %q unsupported by the baseline canonicalizer", c.Name, c.DataType)
 }
 
 // deferredReprUnresolved reports whether some change's row image carries a

--- a/internal/verify/verify_baseline.go
+++ b/internal/verify/verify_baseline.go
@@ -139,12 +139,14 @@ func VerifyBaselinePair(ctx context.Context, cfg BaselineConfig, p BaselinePair)
 	// MySQL's PK canonicalizer only handles a known type surface. PostgreSQL
 	// stores every PK column as raw text on BOTH the baseline (COPY text) and
 	// delta (pgoutput text) sides, so the match is string-identity — the
-	// canonicalizer, and this type gate, are bypassed. A genuinely unhandled PG
-	// type is #1009's message concern, not a false inconclusive here.
+	// canonicalizer, and this type gate, are bypassed. A PostgreSQL-shaped
+	// snapshot that still reaches this MySQL-path gate (flavor did not read
+	// "postgres") gets the honest wrong-path verdict from pkTypeGateReason,
+	// never the misleading per-table PK-type one (#1009).
 	if !pg {
 		for _, c := range pkCols {
 			if !reconstruct.SupportedPKType(c.DataType) {
-				return inconclusive(res, fmt.Sprintf("primary-key column %q has type %q unsupported by the baseline canonicalizer", c.Name, c.DataType)), nil
+				return inconclusive(res, pkTypeGateReason(c)), nil
 			}
 		}
 	}

--- a/internal/verify/verify_baseline_pg_test.go
+++ b/internal/verify/verify_baseline_pg_test.go
@@ -2,6 +2,7 @@ package verify
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
@@ -51,7 +52,11 @@ func TestVerifyBaselinePair_pgBypassesPKTypeGate(t *testing.T) {
 
 // TestVerifyBaselinePair_mysqlKeepsPKTypeGate is the contrast: the SAME
 // empty-DATA_TYPE PK on the MySQL path still trips the SupportedPKType gate, so
-// the flag — not some unrelated change — is what gates B1.
+// the flag — not some unrelated change — is what gates B1. Since #1009 the
+// gate's MESSAGE discriminates the empty-DATA_TYPE (PostgreSQL snapshot shape)
+// case: the verdict names the wrong-path cause plainly instead of blaming the
+// PK type — the misleading `has type "" unsupported by the baseline
+// canonicalizer` the issue reproduced.
 func TestVerifyBaselinePair_mysqlKeepsPKTypeGate(t *testing.T) {
 	cfg := BaselineConfig{Resolver: pgResolver(), SourceFlavor: ""} // "" == mysql
 	res, err := VerifyBaselinePair(context.Background(), cfg, BaselinePair{Schema: "app", Table: "orders"})
@@ -61,8 +66,93 @@ func TestVerifyBaselinePair_mysqlKeepsPKTypeGate(t *testing.T) {
 	if res.Status != StatusInconclusive {
 		t.Fatalf("status = %q, want inconclusive", res.Status)
 	}
-	if !strings.Contains(res.Detail, "unsupported by the baseline canonicalizer") {
-		t.Errorf("MySQL must keep the PK-type gate, got: %q", res.Detail)
+	if strings.Contains(res.Detail, "unsupported by the baseline canonicalizer") {
+		t.Errorf("empty DATA_TYPE must get the PostgreSQL-shape verdict, not the misleading PK-type one: %q", res.Detail)
+	}
+	if !strings.Contains(res.Detail, "PostgreSQL snapshot shape") {
+		t.Errorf("want the PostgreSQL-shape wrong-path reason, got: %q", res.Detail)
+	}
+}
+
+// TestVerifyBaselinePair_mysqlUnsupportedTypeKeepsHonestTypeMessage pins the
+// other half of the discrimination: a REAL MySQL type the canonicalizer does
+// not handle keeps the per-table PK-type message — that one is accurate, and
+// the #1009 fix must not blur it into the PostgreSQL verdict.
+func TestVerifyBaselinePair_mysqlUnsupportedTypeKeepsHonestTypeMessage(t *testing.T) {
+	resolver := metadata.NewResolverFromTables(1, map[string]*metadata.TableMeta{
+		"app.orders": {Schema: "app", Table: "orders", Columns: []metadata.ColumnMeta{
+			{Name: "id", OrdinalPosition: 1, IsPK: true, DataType: "float"},
+		}},
+	})
+	cfg := BaselineConfig{Resolver: resolver, SourceFlavor: ""}
+	res, err := VerifyBaselinePair(context.Background(), cfg, BaselinePair{Schema: "app", Table: "orders"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Status != StatusInconclusive {
+		t.Fatalf("status = %q, want inconclusive", res.Status)
+	}
+	if !strings.Contains(res.Detail, `primary-key column "id" has type "float" unsupported by the baseline canonicalizer`) {
+		t.Errorf("a real unsupported MySQL type must keep the PK-type message, got: %q", res.Detail)
+	}
+	if strings.Contains(res.Detail, "PostgreSQL") {
+		t.Errorf("a real MySQL type must not get the PostgreSQL verdict: %q", res.Detail)
+	}
+}
+
+// TestVerifyTable_pgShapedSnapshotGetsWrongPathVerdict drives the SAME
+// discrimination through the live-source mode's gate (VerifyTable shares
+// pkTypeGateReason with the baseline path). The gate fires before any DB is
+// touched, so SourceDB/IndexDB stay nil.
+func TestVerifyTable_pgShapedSnapshotGetsWrongPathVerdict(t *testing.T) {
+	res, err := VerifyTable(context.Background(), Config{Resolver: pgResolver()}, "app", "orders")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Status != StatusInconclusive {
+		t.Fatalf("status = %q, want inconclusive", res.Status)
+	}
+	if strings.Contains(res.Detail, "unsupported by the baseline canonicalizer") {
+		t.Errorf("live mode must also drop the misleading PK-type message: %q", res.Detail)
+	}
+	if !strings.Contains(res.Detail, "PostgreSQL snapshot shape") {
+		t.Errorf("want the PostgreSQL-shape wrong-path reason, got: %q", res.Detail)
+	}
+}
+
+// TestReport_pgShapedVerdictFailsRunInBothFormats runs the real verify path for
+// the PG-shaped/wrong-path case end to end into the report: the honest reason
+// survives into the JSON shape (TableReport.Reason via NewReport), and the run
+// FAILS via Report.ExitError — the single exit decision both the text and JSON
+// renderings share — so a cron/CI gate cannot read "nothing proven" as success
+// in either format.
+func TestReport_pgShapedVerdictFailsRunInBothFormats(t *testing.T) {
+	cfg := BaselineConfig{Resolver: pgResolver(), SourceFlavor: ""}
+	res, err := VerifyBaselinePair(context.Background(), cfg, BaselinePair{Schema: "app", Table: "orders"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	rep := NewReport(ModeBaselinePair, []TableResult{res})
+	if rep.Verdict != VerdictUnproven {
+		t.Fatalf("verdict = %q, want %q", rep.Verdict, VerdictUnproven)
+	}
+	if got := rep.Tables[0].Reason; !strings.Contains(got, "PostgreSQL snapshot shape") {
+		t.Errorf("report reason lost the honest verdict: %q", got)
+	}
+	exitErr := rep.ExitError()
+	if exitErr == nil {
+		t.Fatal("ExitError = nil; an all-inconclusive PG-shaped run must fail the run in both formats")
+	}
+	if !strings.Contains(exitErr.Error(), "nothing proven") {
+		t.Errorf("exit error = %q, want the nothing-proven contract", exitErr)
+	}
+	// The JSON document a --format json consumer reads carries the same reason.
+	b, err := json.Marshal(rep)
+	if err != nil {
+		t.Fatalf("marshal report: %v", err)
+	}
+	if !strings.Contains(string(b), "PostgreSQL snapshot shape") {
+		t.Errorf("JSON report lost the honest verdict: %s", b)
 	}
 }
 


### PR DESCRIPTION
closes #1009

## Summary

Since #1009 was filed, the console PG-parity work (#1023) landed most of its prescription: live-source verify now refuses a PostgreSQL source with an explicit message, and baseline-anchored verify is genuinely supported for PG (LSN anchor, text-identity PK, type gate bypassed) when the source flavor resolves to `postgres`. What remained — deferred to #1009 by the comment at the baseline gate — was the misleading message itself: a PostgreSQL-shaped snapshot (PK `DataType` empty, because `WritePGSnapshot` records `pg_type_oid`, never a MySQL `DATA_TYPE` token) that still reaches the **MySQL-path** type gate (flavor not readable as `postgres`: unreadable `stream_state`, or the wrong index database) reported

```
primary-key column "id" has type "" unsupported by the baseline canonicalizer
```

— the exact repro in the issue, dressing a structural wrong-path condition as a fixable per-table PK problem.

- New shared helper `pkTypeGateReason` (used by both `VerifyTable` and `VerifyBaselinePair`, so the two modes cannot drift) discriminates the two causes: empty `DataType` → an explicit "PostgreSQL snapshot shape / verify took its MySQL path, which cannot verify a PostgreSQL-sourced table" verdict pointing at the flavor signal; a real unsupported MySQL type (`float`, …) keeps the accurate PK-type message.
- No flag names in the engine text (the console verify engine emits it too).
- Exit semantics deliberately unchanged and stay in `Report.ExitError`, the single decision shared by the text and JSON renderings: the case is still `inconclusive`, and an all-inconclusive run already fails with "nothing proven" in both formats.

## Test plan

Ran locally (macOS, Docker MySQL 8.0 on 13306):

- `go test ./... -count=1` — green (two `consoleapp` flashback-port tests flaked once under full-parallel load with i/o timeouts; both pass in isolation and are untouched by this change).
- `go vet ./...` and `go vet -tags integration ./...` — clean.
- `go test -tags integration ./internal/verify/... -count=1` — green (113s).
- New/updated unit tests in `internal/verify/verify_baseline_pg_test.go`, all live-DB-free, driving the real verify path:
  - empty-`DataType` PK on the MySQL path gets the PostgreSQL-shape verdict and NOT the canonicalizer message, in both `VerifyBaselinePair` and `VerifyTable`;
  - a real unsupported MySQL type (`float`) keeps the canonicalizer message (no blur into the PG verdict);
  - end-to-end into the report: the reason survives `NewReport` into `TableReport.Reason` and the marshaled JSON document, verdict is `unproven`, and `Report.ExitError()` is non-nil with the "nothing proven" contract — the one exit decision both formats share.

Not run: anything needing a live PostgreSQL source (the fixed path is precisely the one taken when no live PG flavor signal is available, so it is fully exercisable without one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)