### PR TITLE
mcp: expose snapshot_id in list_schema_changes and add uncovered_only filter

### DIFF
--- a/docs/ddl-tracking.md
+++ b/docs/ddl-tracking.md
@@ -94,8 +94,11 @@ This table is created by `bintrail init` and must exist in the index database. O
 The MCP server exposes this table as the `list_schema_changes` tool, so an AI
 assistant can answer "what ALTERs hit the orders table this month?" directly.
 Filters: `schema`, `table`, `ddl_type` (prefix-matched — `ALTER` matches
-`ALTER TABLE`), `since`, `until`, `limit`. Each result carries the full DDL
-statement, binlog coordinates, and detection timestamp. See
+`ALTER TABLE`), `since`, `until`, `limit`, and `uncovered_only` (only rows
+where `snapshot_id` is NULL). Each result carries the full DDL statement,
+binlog coordinates, detection timestamp, and the covering `snapshot_id`
+(`null` = uncovered), so an agent can go from the status warning about
+uncovered DDLs straight to the exact rows. See
 [mcp-server.md](./mcp-server.md).
 
 ---

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -191,7 +191,7 @@ automatically.
 | `recover_cascade` | `bintrail recover-cascade --dry-run` | Generate reversal SQL for foreign-key `ON DELETE`/`ON UPDATE` cascade side effects InnoDB ran below the binlog — the child rows plain `recover` cannot see. Fails with the reasons when the synthesis is provably partial, unless `allow_incomplete` is set |
 | `reconstruct` | `bintrail reconstruct` | A single row's full state at a point in time (needs a baseline) |
 | `status` | `bintrail status` | Indexed files, partitions, and summary |
-| `list_schema_changes` | reads `schema_changes` (see [DDL tracking](./ddl-tracking.md)) | DDL changes recorded while indexing/streaming, with the full statement and binlog coordinates |
+| `list_schema_changes` | reads `schema_changes` (see [DDL tracking](./ddl-tracking.md)) | DDL changes recorded while indexing/streaming, with the full statement, binlog coordinates, and the covering `snapshot_id` (`null` = no auto-snapshot) |
 
 All six are read-only — annotated `ReadOnlyHint: true` and `IdempotentHint: true`,
 so the client knows they're safe to call repeatedly and never modify state.
@@ -209,7 +209,9 @@ HTTP, console-token auth, per-server routing by URL path) — if you already run
 [console.md](console.md#mcp-endpoint).
 `list_schema_changes` accepts `schema`, `table`, `ddl_type`
 (`CREATE`/`ALTER`/`DROP`/`RENAME`/`TRUNCATE`, prefix-matched so `ALTER` matches
-`ALTER TABLE`), `since`, `until`, and `limit` (default 100); results come back
+`ALTER TABLE`), `since`, `until`, `limit` (default 100), and `uncovered_only`
+(only changes whose `snapshot_id` is `null` — the rows behind the `status`
+tool's "DDL(s) detected without auto-snapshot" warning); results come back
 newest-first.
 
 Prompts that work well:

--- a/internal/mcptools/mcptools.go
+++ b/internal/mcptools/mcptools.go
@@ -311,7 +311,9 @@ func NewServer(cfg Config) *mcp.Server {
 		Name: "list_schema_changes",
 		Description: "List DDL schema changes (CREATE, ALTER, DROP, RENAME, TRUNCATE) " +
 			"recorded during binlog indexing or streaming. " +
-			"Returns the full DDL statement, binlog coordinates, and timestamp for each change.",
+			"Returns the full DDL statement, binlog coordinates, timestamp, and the " +
+			"covering snapshot_id (null = no schema snapshot was taken after the DDL) " +
+			"for each change; set uncovered_only to list just the changes without a snapshot.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:          "List schema changes",
 			ReadOnlyHint:   true,
@@ -493,6 +495,10 @@ type SchemaChangesArgs struct {
 	Since    string `json:"since,omitempty" jsonschema:"Filter changes at or after this time (YYYY-MM-DD HH:MM:SS or RFC 3339)"`
 	Until    string `json:"until,omitempty" jsonschema:"Filter changes at or before this time (YYYY-MM-DD HH:MM:SS or RFC 3339)"`
 	Limit    int    `json:"limit,omitempty" jsonschema:"Maximum number of changes to return (default: 100)"`
+	// UncoveredOnly narrows results to DDLs with no covering snapshot — the
+	// rows the status tool's "N DDL(s) detected without auto-snapshot" warning
+	// counts, so an agent can go straight from that warning to the exact rows.
+	UncoveredOnly bool `json:"uncovered_only,omitempty" jsonschema:"Return only changes with no covering schema snapshot (snapshot_id is null) — the ones counted by the status tool's uncovered-DDL warning"`
 }
 
 // rejectSurfaceParams enforces the surface's parameter policy: a non-nil
@@ -891,7 +897,7 @@ func MakeSchemaChangesTool(cfg Config) func(context.Context, *mcp.CallToolReques
 		}
 		defer t.release()
 
-		q := "SELECT id, detected_at, schema_name, table_name, ddl_type, ddl_query, binlog_file, binlog_pos, gtid FROM schema_changes WHERE 1=1"
+		q := "SELECT id, detected_at, schema_name, table_name, ddl_type, ddl_query, binlog_file, binlog_pos, gtid, snapshot_id FROM schema_changes WHERE 1=1"
 		var params []any
 
 		if args.Schema != "" {
@@ -915,6 +921,9 @@ func MakeSchemaChangesTool(cfg Config) func(context.Context, *mcp.CallToolReques
 			q += " AND detected_at <= ?"
 			params = append(params, *untilT)
 		}
+		if args.UncoveredOnly {
+			q += " AND snapshot_id IS NULL"
+		}
 		q += " ORDER BY detected_at DESC LIMIT ?"
 		params = append(params, limit)
 
@@ -937,6 +946,10 @@ func MakeSchemaChangesTool(cfg Config) func(context.Context, *mcp.CallToolReques
 			BinlogFile string `json:"binlog_file"`
 			BinlogPos  int64  `json:"binlog_pos"`
 			GTID       string `json:"gtid,omitempty"`
+			// SnapshotID is the auto-snapshot taken after this DDL. Deliberately
+			// NOT omitempty: an explicit null is the "uncovered DDL" signal the
+			// status tool's warning points at (#1050).
+			SnapshotID *int64 `json:"snapshot_id"`
 		}
 
 		var results []schemaChange
@@ -944,12 +957,16 @@ func MakeSchemaChangesTool(cfg Config) func(context.Context, *mcp.CallToolReques
 			var sc schemaChange
 			var detectedAt time.Time
 			var gtid sql.NullString
-			if err := rows.Scan(&sc.ID, &detectedAt, &sc.Schema, &sc.Table, &sc.DDLType, &sc.Statement, &sc.BinlogFile, &sc.BinlogPos, &gtid); err != nil {
+			var snapshotID sql.NullInt64
+			if err := rows.Scan(&sc.ID, &detectedAt, &sc.Schema, &sc.Table, &sc.DDLType, &sc.Statement, &sc.BinlogFile, &sc.BinlogPos, &gtid, &snapshotID); err != nil {
 				return ErrorResult(fmt.Errorf("scan: %w", err)), nil, nil
 			}
 			sc.DetectedAt = detectedAt.UTC().Format("2006-01-02 15:04:05")
 			if gtid.Valid {
 				sc.GTID = gtid.String
+			}
+			if snapshotID.Valid {
+				sc.SnapshotID = &snapshotID.Int64
 			}
 			results = append(results, sc)
 		}

--- a/internal/mcptools/mcptools_test.go
+++ b/internal/mcptools/mcptools_test.go
@@ -301,3 +301,86 @@ func TestStripStatementText(t *testing.T) {
 		}
 	}
 }
+
+// ─── list_schema_changes: snapshot_id coverage (#1050) ───────────────────────
+
+// schemaChangesMockCols matches the tool's schema_changes SELECT column list.
+var schemaChangesMockCols = []string{
+	"id", "detected_at", "schema_name", "table_name", "ddl_type", "ddl_query",
+	"binlog_file", "binlog_pos", "gtid", "snapshot_id",
+}
+
+// newSchemaChangesTarget builds a Config around a sqlmock DB so
+// MakeSchemaChangesTool exercises its real SELECT → scan → JSON path.
+func newSchemaChangesTarget(db *sql.DB) Config {
+	return Config{
+		Resolve: func(ctx context.Context, _ string) (*Target, error) {
+			return &Target{DB: db}, nil
+		},
+	}
+}
+
+func TestSchemaChangesTool_snapshotIDRoundTrip(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	detected := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	mock.ExpectQuery("FROM schema_changes WHERE 1=1 ORDER BY detected_at DESC").
+		WillReturnRows(sqlmock.NewRows(schemaChangesMockCols).
+			// Covered DDL: auto-snapshot 7 was taken after it.
+			AddRow(1, detected, "shop", "orders", "ALTER TABLE",
+				"ALTER TABLE orders ADD COLUMN note TEXT", "binlog.000001", 4, "uuid:1", 7).
+			// Uncovered DDL: snapshot_id is NULL — must surface as explicit null.
+			AddRow(2, detected, "shop", "orders", "TRUNCATE TABLE",
+				"TRUNCATE TABLE orders", "binlog.000001", 900, nil, nil))
+
+	res, _, err := MakeSchemaChangesTool(newSchemaChangesTarget(db))(context.Background(), nil, SchemaChangesArgs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected tool error: %s", resultText(res))
+	}
+	text := resultText(res)
+	if !strings.Contains(text, `"snapshot_id": 7`) {
+		t.Errorf("covered DDL must carry its snapshot_id, got:\n%s", text)
+	}
+	if !strings.Contains(text, `"snapshot_id": null`) {
+		t.Errorf("uncovered DDL must carry an explicit null snapshot_id, got:\n%s", text)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestSchemaChangesTool_uncoveredOnlyFilter(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	detected := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	// The expectation only matches when the SQL carries the IS NULL predicate.
+	mock.ExpectQuery("FROM schema_changes WHERE 1=1 AND snapshot_id IS NULL ORDER BY detected_at DESC").
+		WillReturnRows(sqlmock.NewRows(schemaChangesMockCols).
+			AddRow(2, detected, "shop", "orders", "TRUNCATE TABLE",
+				"TRUNCATE TABLE orders", "binlog.000001", 900, nil, nil))
+
+	res, _, err := MakeSchemaChangesTool(newSchemaChangesTarget(db))(context.Background(), nil, SchemaChangesArgs{UncoveredOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected tool error: %s", resultText(res))
+	}
+	if !strings.Contains(resultText(res), `"snapshot_id": null`) {
+		t.Errorf("uncovered row must round-trip a null snapshot_id, got:\n%s", resultText(res))
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
closes #1050

## Summary

`status` warns "N DDL(s) detected without auto-snapshot", but `list_schema_changes` returned every change indistinguishably — identifying the uncovered DDLs required direct SQL against the index, defeating the read-only MCP surface. This lands in `internal/mcptools`, so both consumers (the standalone `bintrail-mcp` binary and the console's `/mcp` endpoint) get it.

- `snapshot_id` added to the tool's SELECT and response DTO. Nullable and deliberately **not** `omitempty`: an explicit `"snapshot_id": null` is the "uncovered DDL" signal.
- New `uncovered_only` (bool) parameter appends `AND snapshot_id IS NULL`, so an agent can go from the status warning straight to the exact rows.
- Tool description updated; `docs/mcp-server.md` and `docs/ddl-tracking.md` field/filter lists updated.
- The issue's `snapshot_state` (taken / not_needed / failed) mention is conditional on that distinction landing first — it has not, so it is out of scope here.

## Test plan

- New unit tests (`internal/mcptools/mcptools_test.go`) drive the real `MakeSchemaChangesTool` handler over sqlmock: covered row round-trips `"snapshot_id": 7`, NULL row round-trips an explicit `"snapshot_id": null`, and `uncovered_only` only matches SQL carrying the `IS NULL` predicate.
- `go vet ./...` — pass.
- `go test ./... -count=1` — pass (one pre-existing full-parallel flake, `consoleapp` `TestMonitorRun_healthyRunResetsBreaker`, passes 3/3 in isolation and is untouched by this diff).
- `go test -tags integration ./internal/mcptools/... ./cmd/bintrail-mcp/... -count=1` against Docker MySQL on 13306 — pass. Existing tool-count assertions (six tools) unaffected: this adds a field, not a tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)