### PR TITLE
Scheduled verification with persisted run history in bintrail-console watch

### DIFF
--- a/consoleapp/verify.go
+++ b/consoleapp/verify.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/go-sql-driver/mysql"
 
@@ -34,6 +35,10 @@ import (
 // loses it (mirrors BaselineStatus's "idle if never run in this process").
 type verifySupervisor struct {
 	ctx context.Context // daemon lifecycle; cancels an in-flight run on shutdown
+	// history, when non-nil, receives one VerifyRunRecord per finished run
+	// (#1191) — manual and scheduled alike, so the history is the one place
+	// "when did this last verify" is answered.
+	history *console.VerifyHistory
 
 	mu   sync.Mutex
 	jobs map[string]*verifyJob
@@ -56,6 +61,11 @@ type verifyJob struct {
 	status console.VerifyStatus
 	mode   console.VerifyMode
 
+	// serverName and trigger ("manual" | "scheduled") only feed the history
+	// record written at finish; neither is part of the pollable status.
+	serverName string
+	trigger    string
+
 	indexDSN  string
 	noArchive bool
 
@@ -66,33 +76,61 @@ type verifyJob struct {
 }
 
 // newVerifySupervisor builds a supervisor bound to the daemon context.
-func newVerifySupervisor(ctx context.Context) *verifySupervisor {
-	return &verifySupervisor{ctx: ctx, jobs: make(map[string]*verifyJob)}
+// history may be nil (runs are then not recorded).
+func newVerifySupervisor(ctx context.Context, history *console.VerifyHistory) *verifySupervisor {
+	return &verifySupervisor{ctx: ctx, history: history, jobs: make(map[string]*verifyJob)}
 }
 
 // Trigger starts a verify run in the background; returns
 // console.ErrVerifyRunning if one is already in flight for this server.
 func (s *verifySupervisor) Trigger(req console.VerifyRequest) error {
+	baselineSrc, err := s.begin(req, "manual")
+	if err != nil {
+		return err
+	}
+	go s.run(req, baselineSrc)
+	return nil
+}
+
+// RunScheduled runs one verify synchronously on the caller's goroutine — the
+// watch daemon's --verify-interval loop (#1191), which paces servers one at a
+// time so scheduled cycles never stack DuckDB work. Same admission rule as
+// Trigger: a run already in flight wins and this returns
+// console.ErrVerifyRunning for the scheduler to record as a skip.
+func (s *verifySupervisor) RunScheduled(req console.VerifyRequest) error {
+	baselineSrc, err := s.begin(req, "scheduled")
+	if err != nil {
+		return err
+	}
+	s.run(req, baselineSrc)
+	return nil
+}
+
+// begin admits a run — refusing a concurrent one per server — and publishes
+// the fresh "running" job state. Shared by the manual and scheduled paths so
+// the one-at-a-time-per-server rule cannot drift between them.
+func (s *verifySupervisor) begin(req console.VerifyRequest, trigger string) (string, error) {
 	s.mu.Lock()
 	if j, ok := s.jobs[req.ServerID]; ok && j.status.State == "running" {
 		s.mu.Unlock()
-		return console.ErrVerifyRunning
+		return "", console.ErrVerifyRunning
 	}
 	baselineSrc := req.BaselineDir
 	if baselineSrc == "" {
 		baselineSrc = req.BaselineS3
 	}
 	s.jobs[req.ServerID] = &verifyJob{
-		status:    console.VerifyStatus{State: "running", Mode: req.Mode, Since: nowStamp()},
-		mode:      req.Mode,
-		indexDSN:  req.IndexDSN,
-		noArchive: req.NoArchive,
+		status:     console.VerifyStatus{State: "running", Mode: req.Mode, Since: nowStamp()},
+		mode:       req.Mode,
+		serverName: req.ServerName,
+		trigger:    trigger,
+		indexDSN:   req.IndexDSN,
+		noArchive:  req.NoArchive,
 	}
 	s.mu.Unlock()
 
-	slog.Info("verify: starting in-process run", "server", req.ServerName, "id", req.ServerID, "mode", req.Mode)
-	go s.run(req, baselineSrc)
-	return nil
+	slog.Info("verify: starting in-process run", "server", req.ServerName, "id", req.ServerID, "mode", req.Mode, "trigger", trigger)
+	return baselineSrc, nil
 }
 
 // Status returns a copy of the latest known run state (idle if never run here).
@@ -214,6 +252,8 @@ func (s *verifySupervisor) run(req console.VerifyRequest, baselineSrc string) {
 		} else {
 			runErr = s.runLiveSource(req, db, resolver, dbName)
 		}
+	case console.VerifyModeRecoverInputs:
+		runErr = s.runRecoverInputs(req, db, resolver, dbName)
 	default:
 		runErr = s.runBaselineAnchored(req, baselineSrc, db, resolver, dbName, flavor)
 	}
@@ -326,6 +366,42 @@ func (s *verifySupervisor) runLiveSource(req console.VerifyRequest, indexDB *sql
 			res = verify.TableResult{Schema: st.Schema, Table: st.Table, Status: verify.StatusError, Detail: err.Error()}
 		}
 		// Live-source mismatches have no explain support in the engine.
+		s.appendResult(req.ServerID, toWireResult(res, false))
+	}
+	return nil
+}
+
+// recoverInputsLookback is how far back a console recover-inputs run walks
+// each primary key's event chain — the CLI's --lookback default (30d). Fixed
+// rather than configurable here: the scheduled runner is a background health
+// check, and an operator who wants a different window has the CLI.
+const recoverInputsLookback = 30 * 24 * time.Hour
+
+// runRecoverInputs is the console face of `bintrail verify --check recover`
+// (#1001): index-only — no baseline, no source read — which is why the
+// scheduled runner (#1191) falls back to it for servers with no baseline
+// configured. Window and per-table cap are the CLI's defaults; the
+// conservative archive fetcher is deliberate (this shares the daemon with the
+// stream — #510/#511 keep --ultrafast off daemons).
+func (s *verifySupervisor) runRecoverInputs(req console.VerifyRequest, indexDB *sql.DB, resolver *metadata.Resolver, dbName string) error {
+	ctx := s.ctx
+	tables, err := liveSourceTargetTables(ctx, indexDB, req.Tables)
+	if err != nil {
+		return fmt.Errorf("resolve target tables: %w", err)
+	}
+	now := time.Now().UTC()
+	cfg := verify.RecoverInputsConfig{
+		IndexDB: indexDB, Resolver: resolver, IndexDBName: dbName,
+		NoArchive: req.NoArchive, ArchiveFetcher: parquetquery.Fetch,
+		Since: now.Add(-recoverInputsLookback), Until: now,
+	}
+	for _, st := range tables {
+		res, err := verify.VerifyRecoverInputs(ctx, cfg, st.Schema, st.Table)
+		if err != nil {
+			res = verify.TableResult{Schema: st.Schema, Table: st.Table, Status: verify.StatusError, Detail: err.Error()}
+		}
+		// No explain support — the drill-down exists only for baseline-anchored
+		// content mismatches, same as the CLI's --explain scope rule.
 		s.appendResult(req.ServerID, toWireResult(res, false))
 	}
 	return nil
@@ -469,7 +545,6 @@ func (s *verifySupervisor) setNote(serverID, note string) {
 // internal/cli/verify.go's per-table error isolation.
 func (s *verifySupervisor) finish(serverID string, err error) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	j, ok := s.jobs[serverID]
 	if !ok {
 		j = &verifyJob{status: console.VerifyStatus{}}
@@ -479,13 +554,32 @@ func (s *verifySupervisor) finish(serverID string, err error) {
 	if err != nil {
 		j.status.State = "failed"
 		j.status.LastError = err.Error()
-		slog.Error("verify: run failed", "server", serverID, "error", err)
-		return
+	} else {
+		j.status.State = "succeeded"
 	}
-	j.status.State = "succeeded"
-	slog.Info("verify: run complete", "server", serverID,
-		"match", j.status.Summary.Match, "mismatch", j.status.Summary.Mismatch,
-		"inconclusive", j.status.Summary.Inconclusive, "error", j.status.Summary.Error)
+	rec := console.VerifyRunRecord{
+		ServerID:     serverID,
+		ServerName:   j.serverName,
+		Trigger:      j.trigger,
+		VerifyStatus: j.status,
+	}
+	s.mu.Unlock()
+
+	if err != nil {
+		slog.Error("verify: run failed", "server", serverID, "error", err)
+	} else {
+		slog.Info("verify: run complete", "server", serverID,
+			"match", rec.Summary.Match, "mismatch", rec.Summary.Mismatch,
+			"inconclusive", rec.Summary.Inconclusive, "error", rec.Summary.Error)
+	}
+	// History is written OUTSIDE the job lock — Append does file IO, and a
+	// concurrent Status poll must never block on the disk. The run is terminal
+	// at this point, so rec's Results slice can no longer grow under it.
+	if s.history != nil {
+		if herr := s.history.Append(rec); herr != nil {
+			slog.Warn("verify: could not persist run to history", "server", serverID, "error", herr)
+		}
+	}
 }
 
 // indexDBName extracts the database name from an index DSN, mirroring

--- a/consoleapp/verify.go
+++ b/consoleapp/verify.go
@@ -292,6 +292,13 @@ func (s *verifySupervisor) runBaselineAnchored(req console.VerifyRequest, baseli
 	}
 
 	for _, p := range pairs {
+		// A daemon shutdown mid-run must fail the run, not let the remaining
+		// tables degrade into synthetic per-table errors under a "succeeded"
+		// state — with #1191 that verdict is persisted, so the misreport would
+		// outlive the restart.
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("verify interrupted: %w", err)
+		}
 		key := p.Schema + "." + p.Table
 		if filter != nil && !filter[key] {
 			continue
@@ -361,6 +368,10 @@ func (s *verifySupervisor) runLiveSource(req console.VerifyRequest, indexDB *sql
 		NoArchive: req.NoArchive, ArchiveFetcher: parquetquery.Fetch,
 	}
 	for _, st := range tables {
+		// See runBaselineAnchored: a shutdown mid-run fails the run loudly.
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("verify interrupted: %w", err)
+		}
 		res, err := verify.VerifyTable(ctx, cfg, st.Schema, st.Table)
 		if err != nil {
 			res = verify.TableResult{Schema: st.Schema, Table: st.Table, Status: verify.StatusError, Detail: err.Error()}
@@ -396,6 +407,10 @@ func (s *verifySupervisor) runRecoverInputs(req console.VerifyRequest, indexDB *
 		Since: now.Add(-recoverInputsLookback), Until: now,
 	}
 	for _, st := range tables {
+		// See runBaselineAnchored: a shutdown mid-run fails the run loudly.
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("verify interrupted: %w", err)
+		}
 		res, err := verify.VerifyRecoverInputs(ctx, cfg, st.Schema, st.Table)
 		if err != nil {
 			res = verify.TableResult{Schema: st.Schema, Table: st.Table, Status: verify.StatusError, Detail: err.Error()}

--- a/consoleapp/verify_scheduled_test.go
+++ b/consoleapp/verify_scheduled_test.go
@@ -108,6 +108,16 @@ func TestRecordVerifySkip(t *testing.T) {
 	if len(recs) != 1 || recs[0].State != "skipped" || recs[0].SkipReason == "" || recs[0].Trigger != "scheduled" {
 		t.Fatalf("skip not recorded: %+v", recs)
 	}
+	// Consecutive identical skips collapse into one record — a wedged run must
+	// not flood the capped history and evict the real verdicts.
+	recordVerifySkip(hist, console.ServerEntry{ID: "s1", Name: "wp"}, "a verify run was already in flight when the schedule fired")
+	if recs = hist.List("s1"); len(recs) != 1 {
+		t.Fatalf("identical consecutive skip was appended: %+v", recs)
+	}
+	recordVerifySkip(hist, console.ServerEntry{ID: "s1", Name: "wp"}, "another reason")
+	if recs = hist.List("s1"); len(recs) != 2 {
+		t.Fatalf("skip with a new reason must append: %+v", recs)
+	}
 	// nil history is a no-op, never a panic (history can be unavailable).
 	recordVerifySkip(nil, console.ServerEntry{ID: "s1"}, "x")
 }

--- a/consoleapp/verify_scheduled_test.go
+++ b/consoleapp/verify_scheduled_test.go
@@ -1,0 +1,113 @@
+package consoleapp
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/console"
+)
+
+func TestScheduledVerifyRequest_modeSelection(t *testing.T) {
+	entry := func(dir, s3 string) console.ServerEntry {
+		return console.ServerEntry{ID: "id1", Name: "wp", DSN: "dsn", BaselineDir: dir, BaselineS3: s3}
+	}
+	cases := []struct {
+		name             string
+		e                console.ServerEntry
+		globalDir, globS string
+		wantMode         console.VerifyMode
+		wantDir, wantS3  string
+	}{
+		{"own baseline dir", entry("/b", ""), "/g", "s3://g", console.VerifyModeBaselineAnchored, "/b", ""},
+		{"global fallback", entry("", ""), "/g", "s3://g", console.VerifyModeBaselineAnchored, "/g", "s3://g"},
+		// All-or-nothing like withBaselineDefaults (#1010): an entry with its
+		// own S3 must not inherit the global dir on top.
+		{"own S3 never mixes with global dir", entry("", "s3://own"), "/g", "", console.VerifyModeBaselineAnchored, "", "s3://own"},
+		{"no baseline anywhere → recover-inputs", entry("", ""), "", "", console.VerifyModeRecoverInputs, "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := scheduledVerifyRequest(tc.e, []string{"s.t"}, tc.globalDir, tc.globS)
+			if req.Mode != tc.wantMode || req.BaselineDir != tc.wantDir || req.BaselineS3 != tc.wantS3 {
+				t.Fatalf("got mode=%s dir=%q s3=%q, want mode=%s dir=%q s3=%q",
+					req.Mode, req.BaselineDir, req.BaselineS3, tc.wantMode, tc.wantDir, tc.wantS3)
+			}
+			if req.ServerID != "id1" || req.IndexDSN != "dsn" || len(req.Tables) != 1 {
+				t.Fatalf("request lost entry fields: %+v", req)
+			}
+		})
+	}
+}
+
+func TestSplitVerifyTables(t *testing.T) {
+	if got := splitVerifyTables(""); got != nil {
+		t.Fatalf("empty flag must mean no filter (nil), got %v", got)
+	}
+	got := splitVerifyTables(" a.b, ,c.d ")
+	if len(got) != 2 || got[0] != "a.b" || got[1] != "c.d" {
+		t.Fatalf("got %v", got)
+	}
+}
+
+// TestVerifySupervisor_finishRecordsHistory drives begin→appendResult→finish
+// (the exact path both manual and scheduled runs take) and asserts the run
+// lands in the persisted history with its trigger and summary.
+func TestVerifySupervisor_finishRecordsHistory(t *testing.T) {
+	hist, err := console.OpenVerifyHistory(filepath.Join(t.TempDir(), "h.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := newVerifySupervisor(context.Background(), hist)
+	req := console.VerifyRequest{ServerID: "srv1", ServerName: "wp", Mode: console.VerifyModeRecoverInputs}
+	if _, err := s.begin(req, "scheduled"); err != nil {
+		t.Fatal(err)
+	}
+
+	// While the run is in flight, a second admission — scheduled or manual —
+	// must be refused, not stacked.
+	if _, err := s.begin(req, "manual"); !errors.Is(err, console.ErrVerifyRunning) {
+		t.Fatalf("concurrent begin: got %v, want ErrVerifyRunning", err)
+	}
+	if err := s.RunScheduled(req); !errors.Is(err, console.ErrVerifyRunning) {
+		t.Fatalf("concurrent RunScheduled: got %v, want ErrVerifyRunning", err)
+	}
+
+	s.appendResult("srv1", console.VerifyTableResult{Schema: "a", Table: "b", Status: "match"})
+	s.finish("srv1", nil)
+
+	recs := hist.List("srv1")
+	if len(recs) != 1 {
+		t.Fatalf("want 1 history record, got %d", len(recs))
+	}
+	r := recs[0]
+	if r.Trigger != "scheduled" || r.ServerName != "wp" || r.State != "succeeded" ||
+		r.Mode != console.VerifyModeRecoverInputs || r.Summary.Match != 1 || len(r.Results) != 1 {
+		t.Fatalf("history record incomplete: %+v", r)
+	}
+
+	// A failed run records its error too.
+	if _, err := s.begin(req, "manual"); err != nil {
+		t.Fatal(err)
+	}
+	s.finish("srv1", errors.New("connect index: boom"))
+	recs = hist.List("srv1")
+	if len(recs) != 2 || recs[0].State != "failed" || recs[0].LastError == "" || recs[0].Trigger != "manual" {
+		t.Fatalf("failed run not recorded: %+v", recs)
+	}
+}
+
+func TestRecordVerifySkip(t *testing.T) {
+	hist, err := console.OpenVerifyHistory(filepath.Join(t.TempDir(), "h.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	recordVerifySkip(hist, console.ServerEntry{ID: "s1", Name: "wp"}, "a verify run was already in flight when the schedule fired")
+	recs := hist.List("s1")
+	if len(recs) != 1 || recs[0].State != "skipped" || recs[0].SkipReason == "" || recs[0].Trigger != "scheduled" {
+		t.Fatalf("skip not recorded: %+v", recs)
+	}
+	// nil history is a no-op, never a panic (history can be unavailable).
+	recordVerifySkip(nil, console.ServerEntry{ID: "s1"}, "x")
+}

--- a/consoleapp/verify_test.go
+++ b/consoleapp/verify_test.go
@@ -80,7 +80,7 @@ func TestIndexDBName(t *testing.T) {
 // TestVerifySupervisor_Status_idleDefault: a server never triggered here
 // reports idle, never a zero-value State.
 func TestVerifySupervisor_Status_idleDefault(t *testing.T) {
-	s := newVerifySupervisor(context.Background())
+	s := newVerifySupervisor(context.Background(), nil)
 	if got := s.Status("never-triggered"); got.State != "idle" {
 		t.Errorf("Status = %+v, want State=idle", got)
 	}
@@ -91,7 +91,7 @@ func TestVerifySupervisor_Status_idleDefault(t *testing.T) {
 // untouched — exercises the exact single-flight guard the whole "one run at
 // a time per server" invariant depends on.
 func TestVerifySupervisor_Trigger_collision(t *testing.T) {
-	s := newVerifySupervisor(context.Background())
+	s := newVerifySupervisor(context.Background(), nil)
 	s.jobs["srv1"] = &verifyJob{status: console.VerifyStatus{State: "running", Since: "t0"}}
 
 	err := s.Trigger(console.VerifyRequest{ServerID: "srv1"})
@@ -109,7 +109,7 @@ func TestVerifySupervisor_Trigger_collision(t *testing.T) {
 // the same classification the CLI's JSON report uses) is tallied correctly —
 // this is the exact bookkeeping "as they land" polling depends on.
 func TestVerifySupervisor_appendResult_accumulatesSummary(t *testing.T) {
-	s := newVerifySupervisor(context.Background())
+	s := newVerifySupervisor(context.Background(), nil)
 	s.jobs["srv1"] = &verifyJob{status: console.VerifyStatus{State: "running"}}
 
 	s.appendResult("srv1", console.VerifyTableResult{Schema: "wp", Table: "posts", Status: "match"})
@@ -137,7 +137,7 @@ func TestVerifySupervisor_appendResult_accumulatesSummary(t *testing.T) {
 // second concurrent Trigger in before the goroutine's own finish() ran,
 // which could suppress that second run's real failure.
 func TestVerifySupervisor_setNote_doesNotChangeState(t *testing.T) {
-	s := newVerifySupervisor(context.Background())
+	s := newVerifySupervisor(context.Background(), nil)
 	s.jobs["srv1"] = &verifyJob{status: console.VerifyStatus{State: "running"}}
 
 	s.setNote("srv1", "only one baseline exists for this server yet — nothing to compare")
@@ -161,7 +161,7 @@ func TestVerifySupervisor_setNote_doesNotChangeState(t *testing.T) {
 // for the server, a live-source run (no explain support in the engine), and
 // a baseline-anchored run where the requested table was never a mismatch.
 func TestVerifySupervisor_Explain_preconditions(t *testing.T) {
-	s := newVerifySupervisor(context.Background())
+	s := newVerifySupervisor(context.Background(), nil)
 
 	if _, err := s.Explain("no-such-server", "wp", "posts"); !errors.Is(err, console.ErrExplainUnavailable) {
 		t.Errorf("no job: err = %v, want ErrExplainUnavailable", err)

--- a/consoleapp/watch.go
+++ b/consoleapp/watch.go
@@ -847,7 +847,7 @@ func wireVerify(ctx context.Context, cfg *console.Config, registry *console.Regi
 		// Run without history rather than refusing to start the daemon — the
 		// file is an observability aid, and NOT opening a store means nothing
 		// ever overwrites the unreadable file it might still describe.
-		slog.Warn("verify history unavailable; runs will not be recorded", "error", err)
+		slog.Error("verify history unavailable; runs will NOT be recorded and the history endpoint will refuse — fix or move the file and restart", "error", err)
 		history = nil
 	}
 	sup := newVerifySupervisor(ctx, history)
@@ -890,6 +890,13 @@ func startVerifyLoop(ctx context.Context, sup *verifySupervisor, registry *conso
 			var entries []console.ServerEntry
 			if registry != nil {
 				entries = registry.List()
+			}
+			if len(entries) == 0 {
+				// Loud, every cycle: "loop running, verifying nothing" must not
+				// look like "verifying everything". The schedule covers registry
+				// servers; the command-line boot stream is not in the registry.
+				slog.Warn("scheduled verify: no registry servers to verify — the schedule covers servers added in the console UI; a source configured only via command-line flags/env is not covered")
+				return
 			}
 			for _, e := range entries {
 				if ctx.Err() != nil {
@@ -943,6 +950,13 @@ func scheduledVerifyRequest(e console.ServerEntry, tables []string, globalDir, g
 // to run stays visible in the history instead of silent.
 func recordVerifySkip(history *console.VerifyHistory, e console.ServerEntry, reason string) {
 	if history == nil {
+		return
+	}
+	// One consecutive skip per cause: a wedged run plus a short interval would
+	// otherwise append an identical skip every cycle, and the capped history
+	// would evict the real verdicts — erasing exactly the "when did this last
+	// actually verify" answer the history exists to keep.
+	if recs := history.List(e.ID); len(recs) > 0 && recs[0].State == "skipped" && recs[0].SkipReason == reason {
 		return
 	}
 	err := history.Append(console.VerifyRunRecord{

--- a/consoleapp/watch.go
+++ b/consoleapp/watch.go
@@ -112,6 +112,16 @@ var (
 	// no subprocess and reads no live source in its default (baseline-anchored)
 	// mode, so the bundled compose stack defaults it ON (see docker-compose.yml).
 	upConsoleVerifyTrigger bool
+	// upVerifyInterval enables the scheduled verification loop (#1191): every
+	// interval, each registry server is verified in-process — baseline-anchored
+	// when a baseline location is configured, the index-only recover-inputs
+	// check otherwise — and the outcome lands in the persisted history.
+	// Empty = off; setting it implies the verify supervisor (no separate
+	// BINTRAIL_CONSOLE_VERIFY_TRIGGER needed).
+	upVerifyInterval string
+	// upVerifyTables optionally narrows scheduled verification to a
+	// comma-separated schema.table list.
+	upVerifyTables string
 
 	upRotateRetain    string
 	upRotateInterval  string
@@ -205,6 +215,8 @@ func init() {
 	watchCmd.Flags().StringVar(&upArchiveStageDir, "archive-staging-dir", "", "Local staging directory for S3 archive uploads (default: OS temp dir). Rotated Parquet is written here, uploaded to a source's configured Archive S3 bucket, then pruned.")
 	watchCmd.Flags().StringVar(&upRotateRetain, "rotate-retain", "30d", "Built-in rotation: drop index partitions older than this (Nd/Nh; \"off\" disables)")
 	watchCmd.Flags().StringVar(&upRotateInterval, "rotate-interval", "1h", "Built-in rotation: how often to run a rotation cycle")
+	watchCmd.Flags().StringVar(&upVerifyInterval, "verify-interval", "", "Scheduled verification: how often to verify every registry server (e.g. 24h, 7d); empty disables")
+	watchCmd.Flags().StringVar(&upVerifyTables, "verify-tables", "", "Scheduled verification: comma-separated schema.table filter (default: all tables)")
 	watchCmd.Flags().IntVar(&upRotateAddFuture, "rotate-add-future", 3, "Built-in rotation: keep at least N future hourly partitions ready")
 	// --source-dsn is deliberately NOT required: the daemon may start
 	// source-less (zero-config install) and sources are added from the UI.
@@ -407,8 +419,8 @@ func runUpConsoleOnly(cmd *cobra.Command) error {
 	if upConsoleBaselineTrigger {
 		cfg.BaselineCtrl = newBaselineSupervisor(ctx, baselineStagingDir(), upConsoleBaselinePointConsistent)
 	}
-	if upConsoleVerifyTrigger {
-		cfg.VerifyCtrl = newVerifySupervisor(ctx)
+	if err := wireVerify(ctx, &cfg, registry, serversPath); err != nil {
+		return err
 	}
 
 	// Built-in rotation covers the boot index plus every per-source database
@@ -562,8 +574,8 @@ func runUpStreamWithConsole(cmd *cobra.Command, args []string) error {
 	if upConsoleBaselineTrigger {
 		cfg.BaselineCtrl = newBaselineSupervisor(ctx, baselineStagingDir(), upConsoleBaselinePointConsistent)
 	}
-	if upConsoleVerifyTrigger {
-		cfg.VerifyCtrl = newVerifySupervisor(ctx)
+	if err := wireVerify(ctx, &cfg, registry, serversPath); err != nil {
+		return err
 	}
 
 	// Built-in rotation: boot index + every per-source database the control
@@ -790,6 +802,16 @@ func resolveUpConsoleEnv(cmd *cobra.Command) {
 	if v := os.Getenv("BINTRAIL_CONSOLE_VERIFY_TRIGGER"); v == "1" || v == "true" {
 		upConsoleVerifyTrigger = true
 	}
+	if !cmd.Flags().Changed("verify-interval") {
+		if v := os.Getenv("BINTRAIL_CONSOLE_VERIFY_INTERVAL"); v != "" {
+			upVerifyInterval = v
+		}
+	}
+	if !cmd.Flags().Changed("verify-tables") {
+		if v := os.Getenv("BINTRAIL_CONSOLE_VERIFY_TABLES"); v != "" {
+			upVerifyTables = v
+		}
+	}
 }
 
 // baselineStagingDir resolves the local staging base for baselines destined for
@@ -801,6 +823,135 @@ func baselineStagingDir() string {
 		return upBaselineStageDir
 	}
 	return filepath.Join(os.TempDir(), "bintrail-baseline-staging")
+}
+
+// wireVerify wires the in-process verify supervisor and, when
+// --verify-interval is set, the scheduled verification loop (#1191). The
+// supervisor (and with it the manual trigger endpoints) is enabled by either
+// opt-in — BINTRAIL_CONSOLE_VERIFY_TRIGGER=1 or a schedule: scheduling verify
+// implies wanting verify.
+func wireVerify(ctx context.Context, cfg *console.Config, registry *console.Registry, serversPath string) error {
+	var interval time.Duration
+	if upVerifyInterval != "" {
+		var err error
+		interval, err = cliutil.ParseRetain(upVerifyInterval)
+		if err != nil {
+			return fmt.Errorf("--verify-interval: %w", err)
+		}
+	}
+	if !upConsoleVerifyTrigger && interval == 0 {
+		return nil
+	}
+	history, err := console.OpenVerifyHistory(console.DefaultVerifyHistoryPath(serversPath))
+	if err != nil {
+		// Run without history rather than refusing to start the daemon — the
+		// file is an observability aid, and NOT opening a store means nothing
+		// ever overwrites the unreadable file it might still describe.
+		slog.Warn("verify history unavailable; runs will not be recorded", "error", err)
+		history = nil
+	}
+	sup := newVerifySupervisor(ctx, history)
+	cfg.VerifyCtrl = sup
+	cfg.VerifyHistory = history
+	if interval > 0 {
+		startVerifyLoop(ctx, sup, registry, history, interval, splitVerifyTables(upVerifyTables))
+	}
+	return nil
+}
+
+// splitVerifyTables parses the comma-separated --verify-tables list; empty
+// entries are dropped, an empty flag means no filter (nil).
+func splitVerifyTables(raw string) []string {
+	var out []string
+	for _, t := range strings.Split(raw, ",") {
+		if t = strings.TrimSpace(t); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// startVerifyLoop runs one scheduled verification cycle per interval (#1191):
+// every registry server, sequentially — one verify (one DuckDB budget) at a
+// time. Mirrors startBaselinePruneLoop's shape: recover-guarded, first cycle
+// shortly after startup, stops with the daemon context.
+func startVerifyLoop(ctx context.Context, sup *verifySupervisor, registry *console.Registry, history *console.VerifyHistory, interval time.Duration, tables []string) {
+	slog.Info("scheduled verification enabled", "interval", interval)
+	go func() {
+		runCycle := func() {
+			// A panic must NEVER take down the daemon's primary capture — this
+			// background check shares the process with the stream. Mirrors the
+			// baseline-prune loop's guard.
+			defer func() {
+				if r := recover(); r != nil {
+					slog.Error("scheduled verify cycle panicked; verification continues next tick", "panic", r)
+				}
+			}()
+			var entries []console.ServerEntry
+			if registry != nil {
+				entries = registry.List()
+			}
+			for _, e := range entries {
+				if ctx.Err() != nil {
+					return
+				}
+				err := sup.RunScheduled(scheduledVerifyRequest(e, tables, upConsoleBaselineDir, upConsoleBaselineS3))
+				if errors.Is(err, console.ErrVerifyRunning) {
+					slog.Info("scheduled verify: skipped, a run is already in flight", "server", e.Name)
+					recordVerifySkip(history, e, "a verify run was already in flight when the schedule fired")
+				}
+			}
+		}
+		if ctx.Err() == nil {
+			runCycle()
+		}
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				runCycle()
+			}
+		}
+	}()
+}
+
+// scheduledVerifyRequest picks the check a scheduled cycle runs for one
+// server: baseline-anchored where a baseline location is configured — the
+// entry's own, or the process-wide fallback, all-or-nothing exactly like
+// withBaselineDefaults (#1010) — and the index-only recover-inputs check
+// otherwise, so a server with no baseline is still verified rather than
+// silently skipped.
+func scheduledVerifyRequest(e console.ServerEntry, tables []string, globalDir, globalS3 string) console.VerifyRequest {
+	dir, s3 := e.BaselineDir, e.BaselineS3
+	if dir == "" && s3 == "" {
+		dir, s3 = globalDir, globalS3
+	}
+	mode := console.VerifyModeBaselineAnchored
+	if dir == "" && s3 == "" {
+		mode = console.VerifyModeRecoverInputs
+	}
+	return console.VerifyRequest{
+		ServerID: e.ID, ServerName: e.Name, Mode: mode, Tables: tables,
+		IndexDSN: e.DSN, BaselineDir: dir, BaselineS3: s3, NoArchive: e.NoArchive,
+	}
+}
+
+// recordVerifySkip persists a "skipped" record so a schedule that never gets
+// to run stays visible in the history instead of silent.
+func recordVerifySkip(history *console.VerifyHistory, e console.ServerEntry, reason string) {
+	if history == nil {
+		return
+	}
+	err := history.Append(console.VerifyRunRecord{
+		ServerID: e.ID, ServerName: e.Name, Trigger: "scheduled", SkipReason: reason,
+		VerifyStatus: console.VerifyStatus{State: "skipped", Since: nowStamp(), FinishedAt: nowStamp()},
+	})
+	if err != nil {
+		slog.Warn("scheduled verify: could not persist skip to history", "server", e.Name, "error", err)
+	}
 }
 
 // baselinePruneTarget is one (local dir, durable S3) pair the prune loop reclaims.

--- a/docs/console.md
+++ b/docs/console.md
@@ -413,12 +413,33 @@ results a `verify` cron/CI run produced elsewhere:
   never-precomputed row-level drill-down (`--explain`'s console equivalent),
   re-run only when clicked. Live-source mismatches have no explain support
   (mirroring the CLI).
-- One run at a time per server (409 while one is in flight). Like baseline
-  jobs, a run's result lives only in the daemon's memory — restarting the
-  console loses it; there is no persisted run history.
+- **Check recovery inputs** is the console face of
+  [`bintrail verify --check recover`](verify.md): index-only — no baseline
+  and no source read — walking each primary key's event chain over the last
+  30 days. It is the one mode that works on a server with no baseline
+  location configured.
+- One run at a time per server (409 while one is in flight). The live,
+  pollable result is in-memory, but every finished run also lands in a
+  persisted **run history** (`console-verify-history.json` next to the server
+  registry file, last 20 runs per server, served at
+  `GET /api/servers/{id}/verify/history`) — the panel shows "last verified"
+  and the recent trend from it across restarts.
 - Verify's baseline/live-source reads carry no RBAC redaction (like Time-travel's),
   so the panel and its endpoints are unavailable whenever an RBAC profile
   (`--profile`) is active.
+
+**Scheduled verification** runs the same engine on a timer, so backups
+re-prove themselves without external cron glue: start the daemon with
+`--verify-interval 24h` (or `BINTRAIL_CONSOLE_VERIFY_INTERVAL`) and every
+cycle verifies each registry server, sequentially — baseline-anchored where a
+baseline location is configured (the server's own, or the process-wide
+`--baseline-dir`/`--baseline-s3`), the index-only recovery-inputs check
+otherwise, so no server is silently skipped. `--verify-tables a.b,c.d`
+narrows every scheduled run to those tables. Setting an interval implies the
+Verification panel (no separate `BINTRAIL_CONSOLE_VERIFY_TRIGGER` needed),
+and one cycle also runs shortly after startup. Every outcome — including
+cycles skipped because a run was already in flight — lands in the run
+history above.
 
 - **AWS credentials** — which ambient credential signals the daemon process
   can see: env keys (presence only, never values), `AWS_PROFILE`,
@@ -490,6 +511,11 @@ results a `verify` cron/CI run produced elsewhere:
   combination doesn't fail cleanly, it crashes the pinned mydumper build). No
   effect unless `BINTRAIL_CONSOLE_BASELINE_TRIGGER` is also on, and no effect
   on PostgreSQL sources.
+- `BINTRAIL_CONSOLE_VERIFY_INTERVAL` (`watch` only) — same as
+  `--verify-interval`: enables scheduled verification on that cadence
+  (e.g. `24h`, `7d`; see
+  [Running verification from the console](#running-verification-from-the-console)).
+- `BINTRAIL_CONSOLE_VERIFY_TABLES` (`watch` only) — same as `--verify-tables`.
 - `BINTRAIL_CONSOLE_VERIFY_TRIGGER` (`watch` only) — `1`/`true` enables the
   Storage page's **Verification** panel (runs `bintrail verify` in-process;
   see [Running verification from the console](#running-verification-from-the-console)).

--- a/docs/console.md
+++ b/docs/console.md
@@ -439,7 +439,10 @@ narrows every scheduled run to those tables. Setting an interval implies the
 Verification panel (no separate `BINTRAIL_CONSOLE_VERIFY_TRIGGER` needed),
 and one cycle also runs shortly after startup. Every outcome — including
 cycles skipped because a run was already in flight — lands in the run
-history above.
+history above. The schedule covers **registry servers** (added from the
+console UI); a source configured only through command-line flags/env is not
+in the registry and is not covered — the daemon warns every cycle it finds
+nothing to verify.
 
 - **AWS credentials** — which ambient credential signals the daemon process
   can see: env keys (presence only, never values), `AWS_PROFILE`,

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -2325,7 +2325,9 @@ async function loadVerifyHistory(id, box) {
       el("span", { class: "chip chip-mon", text: "LAST VERIFIED " + agoText(sec) }),
       el("span", { class: "stg-age", text: latest.state === "failed"
         ? "failed — " + (latest.last_error || "unknown error")
-        : s.match + "/" + s.total + " match" })));
+        : ((s.mismatch || s.error)
+          ? s.match + " match · " + s.mismatch + " mismatch · " + s.error + " error"
+          : s.match + "/" + s.total + " match") })));
   }
   recs.slice(0, 8).forEach((r) => {
     const s = r.summary || {};

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -2200,14 +2200,19 @@ function verifyPanel(servers) {
   if (capsCache.verify_live_source) {
     modeSel.append(el("option", { value: "live-source", text: "Compare against your live database (slower)" }));
   }
+  modeSel.append(el("option", { value: "recover-inputs", text: "Check recovery inputs (no snapshot needed)" }));
   const warn = el("p", { class: "form-hint vfy-livewarn", hidden: true, text:
     "This reads your entire live table — it can take a while and adds load on your database. Best run outside busy hours." });
-  modeSel.onchange = () => { warn.hidden = modeSel.value !== "live-source"; };
 
   const results = el("div", { class: "vfy-results" });
   const btn = el("button", { class: "btn btn-sm", type: "button", text: "Run verification" });
   const configured = !!capsCache.verify;
-  btn.disabled = !configured;
+  // The snapshot-comparison modes need a baseline location; the
+  // recover-inputs check reads only the index, so it stays runnable on a
+  // server with no baseline configured.
+  const updateBtn = () => { btn.disabled = !configured && modeSel.value !== "recover-inputs"; };
+  modeSel.onchange = () => { warn.hidden = modeSel.value !== "live-source"; updateBtn(); };
+  updateBtn();
   btn.onclick = () => createVerify(cur.id, modeSel.value, btn, results);
   head.append(el("div", { class: "vfy-actions" }, modeSel, btn));
   panel.append(head);
@@ -2216,12 +2221,15 @@ function verifyPanel(servers) {
     list.append(el("div", { class: "stg-empty" },
       el("p", { class: "stg-empty-lead", text: "No baseline set up for this server yet." }),
       el("p", { class: "stg-empty-sub", text:
-        "This checks your two most recent snapshots against each other. Set a baseline location (Manage servers → Edit → Advanced) and create at least two snapshots to use it." })));
+        "Snapshot comparison checks your two most recent snapshots against each other — set a baseline location (Manage servers → Edit → Advanced) and create at least two to use it. \"Check recovery inputs\" works without one: it only reads the index." })));
   } else {
     list.append(warn);
-    renderVerifyResults(results, null, cur.id);
-    list.append(results);
   }
+  renderVerifyResults(results, null, cur.id);
+  list.append(results);
+  const history = el("div", { class: "vfy-history" });
+  list.append(history);
+  loadVerifyHistory(cur.id, history);
   panel.append(list);
   return panel;
 }
@@ -2247,6 +2255,9 @@ async function createVerify(id, mode, btn, resultsEl) {
   const done = await pollVerify(id, (st) => renderVerifyResults(resultsEl, st, id));
   restore();
   if (done) renderVerifyResults(resultsEl, done, id);
+  // The finished run is now in the persisted history too — refresh the list.
+  const histBox = document.querySelector(".vfy-history");
+  if (histBox) loadVerifyHistory(id, histBox);
   if (done && done.state === "succeeded") {
     const s = done.summary || {};
     toast(done.note || ("Verification complete: " + s.match + " match, " + s.mismatch + " mismatch, " +
@@ -2289,7 +2300,48 @@ async function pollVerify(id, onTick) {
 
 const VFY_STATUS_CLASS = { match: "pass", mismatch: "fail", error: "fail", inconclusive: "warn" };
 const VFY_STATUS_MARK = { pass: "✓", fail: "✗", warn: "!" };
-const VFY_MODE_LABEL = { "baseline-anchored": "compared two saved snapshots", "live-source": "compared against the live database" };
+const VFY_MODE_LABEL = { "baseline-anchored": "compared two saved snapshots", "live-source": "compared against the live database", "recover-inputs": "checked recovery inputs in the index" };
+
+// loadVerifyHistory renders the persisted run history into box: a "last
+// verified" headline plus one line per stored run (newest first, capped
+// server-side). Manual runs, scheduled runs and scheduled skips all appear —
+// the daemon's --verify-interval loop writes the same store. A 403 (feature
+// off) or any fetch error leaves the box empty; the trigger UI above already
+// explains how to enable verification.
+async function loadVerifyHistory(id, box) {
+  let recs;
+  try {
+    recs = (await api("/api/servers/" + encodeURIComponent(id) + "/verify/history")).history || [];
+  } catch (err) {
+    return;
+  }
+  clear(box);
+  if (!recs.length) return;
+  const latest = recs.find((r) => r.state === "succeeded" || r.state === "failed");
+  if (latest && latest.finished_at) {
+    const sec = (Date.now() - Date.parse(latest.finished_at)) / 1000;
+    const s = latest.summary || {};
+    box.append(el("div", { class: "vfy-summary" },
+      el("span", { class: "chip chip-mon", text: "LAST VERIFIED " + agoText(sec) }),
+      el("span", { class: "stg-age", text: latest.state === "failed"
+        ? "failed — " + (latest.last_error || "unknown error")
+        : s.match + "/" + s.total + " match" })));
+  }
+  recs.slice(0, 8).forEach((r) => {
+    const s = r.summary || {};
+    let outcome;
+    if (r.state === "skipped") outcome = "skipped — " + (r.skip_reason || "");
+    else if (r.state === "failed") outcome = "failed — " + (r.last_error || "unknown error");
+    else outcome = s.match + " match · " + s.mismatch + " mismatch · " + s.inconclusive + " inconclusive · " + s.error + " error";
+    const when = (r.finished_at || r.since || "").replace("T", " ").replace("Z", " UTC");
+    const row = el("div", { class: "stg-row" });
+    row.append(
+      el("span", { class: "stg-age", text: when }),
+      el("span", { text: (VFY_MODE_LABEL[r.mode] || r.mode || "") + (r.trigger === "scheduled" ? " (scheduled)" : "") }),
+      el("span", { class: "stg-age", text: outcome }));
+    box.append(row);
+  });
+}
 
 // renderVerifyResults draws the current run's summary + per-table cards into
 // container, reusing the doctor preflight card styling (pass/fail/warn) since

--- a/internal/console/authz.go
+++ b/internal/console/authz.go
@@ -74,6 +74,7 @@ var apiRoutePerms = []routePerm{
 	{"GET", "/api/servers/{}/baseline", ext.PermServersRead},
 	{"GET", "/api/servers/{}/verify", ext.PermServersRead},
 	{"GET", "/api/servers/{}/verify/explain", ext.PermServersRead},
+	{"GET", "/api/servers/{}/verify/history", ext.PermServersRead},
 	{"POST", "/api/servers/{}/test", ext.PermServersRead},
 	{"GET", "/api/servers/{}", ext.PermServersRead},
 	{"PUT", "/api/servers/{}", ext.PermServersWrite},

--- a/internal/console/authz_test.go
+++ b/internal/console/authz_test.go
@@ -45,6 +45,7 @@ var registeredAPIPatterns = []struct{ method, pattern string }{
 	{"POST", "/api/servers/{}/verify"},
 	{"GET", "/api/servers/{}/verify"},
 	{"GET", "/api/servers/{}/verify/explain"},
+	{"GET", "/api/servers/{}/verify/history"},
 	{"GET", "/api/rotation"},
 	{"PUT", "/api/rotation"},
 	{"POST", "/api/auth/logout"},

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -95,6 +95,10 @@ type Config struct {
 	// where the trigger endpoint refuses with 403 and /api/capabilities reports
 	// verify_trigger:false. Set together with MonitorCtrl (both control-plane).
 	VerifyCtrl VerifyController
+	// VerifyHistory is the persisted verify-run history store (#1191), wired
+	// in by `bintrail-console watch` together with VerifyCtrl. nil elsewhere;
+	// the history endpoint then refuses with 403 like the other verify verbs.
+	VerifyHistory *VerifyHistory
 	// Telemetry is the live usage-telemetry client, wired in by
 	// `bintrail-console watch` so the UI opt-out toggle stops the running
 	// daemon's beacons immediately. nil on the read-only console (serve), where
@@ -178,6 +182,8 @@ type Server struct {
 	// verifyCtrl: non-nil only when the watch daemon opted into in-process
 	// verify runs (see Config.VerifyCtrl).
 	verifyCtrl VerifyController
+	// verifyHistory: the persisted run history, set with verifyCtrl (#1191).
+	verifyHistory *VerifyHistory
 	// telemetry: non-nil only when a long-running console wired its live
 	// telemetry client (see Config.Telemetry), so the UI opt-out reaches it.
 	telemetry TelemetryController
@@ -344,6 +350,7 @@ func New(cfg Config) (*Server, error) {
 		monitorCtrl:      cfg.MonitorCtrl,
 		baselineCtrl:     cfg.BaselineCtrl,
 		verifyCtrl:       cfg.VerifyCtrl,
+		verifyHistory:    cfg.VerifyHistory,
 		telemetry:        cfg.Telemetry,
 		rotationDefaults: cfg.RotationDefaults,
 		version:          cfg.Version,
@@ -474,6 +481,7 @@ func (s *Server) buildHandler() http.Handler {
 	api.HandleFunc("POST /api/servers/{id}/verify", s.recordAction("verify", s.handleVerifyTrigger))
 	api.HandleFunc("GET /api/servers/{id}/verify", s.handleVerifyStatus)
 	api.HandleFunc("GET /api/servers/{id}/verify/explain", s.handleVerifyExplain)
+	api.HandleFunc("GET /api/servers/{id}/verify/history", s.handleVerifyHistory)
 	// Global built-in-rotation policy: read the effective settings; PUT an
 	// override (refused on the read-only console — only the watch daemon runs
 	// the loop that consumes it).

--- a/internal/console/verify_history.go
+++ b/internal/console/verify_history.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sync"
 )
 
@@ -96,12 +97,26 @@ func OpenVerifyHistory(path string) (*VerifyHistory, error) {
 func (h *VerifyHistory) Append(rec VerifyRunRecord) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	recs := append(h.servers[rec.ServerID], rec)
+	old, hadOld := h.servers[rec.ServerID]
+	// Clone before appending: an in-place append could write into old's spare
+	// capacity, which would corrupt the rollback below.
+	recs := append(slices.Clone(old), rec)
 	if len(recs) > verifyHistoryCap {
 		recs = recs[len(recs)-verifyHistoryCap:]
 	}
 	h.servers[rec.ServerID] = recs
-	return h.save()
+	if err := h.save(); err != nil {
+		// Roll back so memory keeps matching the persisted file — otherwise
+		// List (and the API) would serve "history" that a restart silently
+		// rewinds, masking a permanent write failure behind a healthy panel.
+		if hadOld {
+			h.servers[rec.ServerID] = old
+		} else {
+			delete(h.servers, rec.ServerID)
+		}
+		return err
+	}
+	return nil
 }
 
 // List returns the recorded runs for a server, newest first. The returned

--- a/internal/console/verify_history.go
+++ b/internal/console/verify_history.go
@@ -1,0 +1,153 @@
+package console
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// verifyHistoryCap is how many runs are kept per server. Old records fall off
+// the front — the history answers "when did this last verify, and how has it
+// been trending", not "archive every run forever".
+const verifyHistoryCap = 20
+
+// VerifyRunRecord is one completed (or skipped) verify run as stored in the
+// history file and served by GET /api/servers/{id}/verify/history. It embeds
+// the same VerifyStatus shape the live status endpoint serves, so a consumer
+// renders a historical run and the current one with the same code.
+type VerifyRunRecord struct {
+	ServerID   string `json:"server_id"`
+	ServerName string `json:"server_name,omitempty"`
+	// Trigger records who started the run: "manual" (the POST endpoint) or
+	// "scheduled" (the watch daemon's --verify-interval loop, #1191).
+	Trigger string `json:"trigger"`
+	// SkipReason is set only on records with State "skipped" — a scheduled
+	// cycle that could not run this server (e.g. a manual run was already in
+	// flight). Recorded rather than dropped so a schedule that never actually
+	// verifies is visible in the history, not silent.
+	SkipReason string `json:"skip_reason,omitempty"`
+	VerifyStatus
+}
+
+// verifyHistoryFile is the on-disk envelope: versioned like the server
+// registry so a future shape change can be detected instead of misparsed.
+type verifyHistoryFile struct {
+	Version int                          `json:"version"`
+	Servers map[string][]VerifyRunRecord `json:"servers"`
+}
+
+const verifyHistoryVersion = 1
+
+// VerifyHistory is the persisted verify-run history (#1191): one JSON file,
+// capped per server, written atomically (temp file + fsync + rename, 0600)
+// like the server registry. Together with the registry it is the ONLY state
+// the console writes — keep it that way.
+//
+// It deliberately lives in a console-local file rather than a table in the
+// index database: scheduled verify covers registry servers, and registry DSNs
+// never receive EnsureSchema/DDL (an existing invariant this must not bend).
+type VerifyHistory struct {
+	mu      sync.Mutex
+	path    string
+	servers map[string][]VerifyRunRecord
+}
+
+// DefaultVerifyHistoryPath returns the history file path as a sibling of the
+// server registry file, so `--console-servers-file` relocations carry both.
+func DefaultVerifyHistoryPath(serversPath string) string {
+	return filepath.Join(filepath.Dir(serversPath), "console-verify-history.json")
+}
+
+// OpenVerifyHistory loads the history at path. A missing file is an empty
+// history. A corrupt or newer-versioned file is reported as an error — the
+// caller decides whether to run without history rather than silently
+// truncating a file a newer binary may still want.
+func OpenVerifyHistory(path string) (*VerifyHistory, error) {
+	h := &VerifyHistory{path: path, servers: make(map[string][]VerifyRunRecord)}
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return h, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read verify history %s: %w", path, err)
+	}
+	if len(data) == 0 {
+		return h, nil
+	}
+	var f verifyHistoryFile
+	if err := json.Unmarshal(data, &f); err != nil {
+		return nil, fmt.Errorf("parse verify history %s: %w", path, err)
+	}
+	if f.Version > verifyHistoryVersion {
+		return nil, fmt.Errorf("verify history %s has version %d, newer than this binary supports (%d)", path, f.Version, verifyHistoryVersion)
+	}
+	if f.Servers != nil {
+		h.servers = f.Servers
+	}
+	return h, nil
+}
+
+// Append records one run and saves the file. The per-server cap is enforced
+// here (oldest dropped). Called from the supervisor's finish path and the
+// scheduler's skip path; a save failure is returned for the caller to log —
+// history is an observability aid and must never fail a verify run.
+func (h *VerifyHistory) Append(rec VerifyRunRecord) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	recs := append(h.servers[rec.ServerID], rec)
+	if len(recs) > verifyHistoryCap {
+		recs = recs[len(recs)-verifyHistoryCap:]
+	}
+	h.servers[rec.ServerID] = recs
+	return h.save()
+}
+
+// List returns the recorded runs for a server, newest first. The returned
+// slice is a copy — callers can hold it across later Appends.
+func (h *VerifyHistory) List(serverID string) []VerifyRunRecord {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	recs := h.servers[serverID]
+	out := make([]VerifyRunRecord, len(recs))
+	for i, r := range recs {
+		out[len(recs)-1-i] = r
+	}
+	return out
+}
+
+// save writes the file atomically. Callers hold h.mu. Same temp-file + fsync
+// + rename shape as Registry.save; 0600 because run notes/errors can quote
+// operator table names and error strings.
+func (h *VerifyHistory) save() error {
+	data, err := json.MarshalIndent(verifyHistoryFile{Version: verifyHistoryVersion, Servers: h.servers}, "", "  ")
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(h.path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".console-verify-history-*.json")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmp.Name()) // no-op after a successful rename
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmp.Name(), h.path)
+}

--- a/internal/console/verify_history_api_test.go
+++ b/internal/console/verify_history_api_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"path/filepath"
 	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/query"
 )
 
 // TestVerifyHistoryEndpoint_disabledWithoutStore: a console with the verify
@@ -60,6 +62,33 @@ func TestVerifyHistoryEndpoint_servesRecordsNewestFirst(t *testing.T) {
 	rec, _ = doServersReqHeader(t, srv, "GET", "/api/servers/nope/verify/history", "", id)
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("unknown server: got %d, want 404", rec.Code)
+	}
+}
+
+// TestVerifyHistoryEndpoint_rbacBlocked: history carries the same per-table
+// verdicts as the live status and spans restarts — unavailable under an
+// active RBAC profile like the other verify verbs.
+func TestVerifyHistoryEndpoint_rbacBlocked(t *testing.T) {
+	reg, err := LoadRegistry(filepath.Join(t.TempDir(), "console-servers.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	hist, err := OpenVerifyHistory(filepath.Join(t.TempDir(), "console-verify-history.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv, err := New(Config{
+		Listen: "127.0.0.1:8090", Token: "t", Registry: reg,
+		MonitorCtrl: &stubMonitorCtrl{}, VerifyCtrl: &stubVerifyCtrl{}, VerifyHistory: hist,
+		DenyTables: []query.SchemaTable{{Schema: "a", Table: "b"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := addVerifyEntry(t, srv, "", "s3://b/base", "")
+	rec, _ := doServersReqHeader(t, srv, "GET", "/api/servers/"+id+"/verify/history", "", id)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("history under an active RBAC profile: got %d, want 403", rec.Code)
 	}
 }
 

--- a/internal/console/verify_history_api_test.go
+++ b/internal/console/verify_history_api_test.go
@@ -1,0 +1,86 @@
+package console
+
+import (
+	"encoding/json"
+	"net/http"
+	"path/filepath"
+	"testing"
+)
+
+// TestVerifyHistoryEndpoint_disabledWithoutStore: a console with the verify
+// controller but no history store (or neither) refuses like the other verify
+// verbs — 403, not an empty 200 that reads as "no runs ever".
+func TestVerifyHistoryEndpoint_disabledWithoutStore(t *testing.T) {
+	srv, _ := newVerifyTriggerServer(t)
+	id := addVerifyEntry(t, srv, "", "s3://b/base", "")
+	rec, _ := doServersReqHeader(t, srv, "GET", "/api/servers/"+id+"/verify/history", "", id)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("history without a store: got %d, want 403", rec.Code)
+	}
+}
+
+func TestVerifyHistoryEndpoint_servesRecordsNewestFirst(t *testing.T) {
+	reg, err := LoadRegistry(filepath.Join(t.TempDir(), "console-servers.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	hist, err := OpenVerifyHistory(filepath.Join(t.TempDir(), "console-verify-history.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv, err := New(Config{
+		Listen: "127.0.0.1:8090", Token: "t", Registry: reg,
+		MonitorCtrl: &stubMonitorCtrl{}, VerifyCtrl: &stubVerifyCtrl{}, VerifyHistory: hist,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := addVerifyEntry(t, srv, "", "s3://b/base", "")
+	for _, state := range []string{"succeeded", "failed"} {
+		if err := hist.Append(VerifyRunRecord{ServerID: id, Trigger: "scheduled", VerifyStatus: VerifyStatus{State: state}}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	rec, body := doServersReqHeader(t, srv, "GET", "/api/servers/"+id+"/verify/history", "", id)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got %d: %s", rec.Code, body)
+	}
+	var resp struct {
+		History []VerifyRunRecord `json:"history"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.History) != 2 || resp.History[0].State != "failed" || resp.History[1].State != "succeeded" {
+		t.Fatalf("want newest-first [failed succeeded], got %+v", resp.History)
+	}
+
+	// Unknown server id: 404, mirroring the other verify verbs.
+	rec, _ = doServersReqHeader(t, srv, "GET", "/api/servers/nope/verify/history", "", id)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("unknown server: got %d, want 404", rec.Code)
+	}
+}
+
+// TestVerifyTrigger_recoverInputsNeedsNoBaseline: the recover-inputs check is
+// index-only (the console face of `verify --check recover`), so — unlike the
+// content modes — an entry with no baseline location must be accepted.
+func TestVerifyTrigger_recoverInputsNeedsNoBaseline(t *testing.T) {
+	srv, ctrl := newVerifyTriggerServer(t)
+	id := addVerifyEntry(t, srv, "", "", "")
+
+	rec, body := doServersReqHeader(t, srv, "POST", "/api/servers/"+id+"/verify", `{"mode":"recover-inputs"}`, id)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("recover-inputs without baseline: got %d (%s), want 202", rec.Code, body)
+	}
+	if len(ctrl.triggered) != 1 || ctrl.triggered[0].Mode != VerifyModeRecoverInputs {
+		t.Fatalf("controller saw %+v, want one recover-inputs request", ctrl.triggered)
+	}
+
+	// The content default still requires a baseline location.
+	rec, _ = doServersReqHeader(t, srv, "POST", "/api/servers/"+id+"/verify", `{"mode":"baseline-anchored"}`, id)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("baseline-anchored without baseline: got %d, want 400", rec.Code)
+	}
+}

--- a/internal/console/verify_history_test.go
+++ b/internal/console/verify_history_test.go
@@ -76,6 +76,38 @@ func TestVerifyHistory_CapDropsOldest(t *testing.T) {
 	}
 }
 
+// TestVerifyHistory_AppendRollsBackOnSaveFailure: a failed save must not
+// leave the record in memory — List would then serve "history" that a restart
+// silently rewinds, masking a permanent write failure behind a healthy panel.
+func TestVerifyHistory_AppendRollsBackOnSaveFailure(t *testing.T) {
+	base := t.TempDir()
+	sub := filepath.Join(base, "sub")
+	path := filepath.Join(sub, "h.json")
+	h, err := OpenVerifyHistory(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := h.Append(VerifyRunRecord{ServerID: "s", VerifyStatus: VerifyStatus{State: "succeeded"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Make the next save fail: replace the parent directory with a plain file
+	// so MkdirAll/CreateTemp cannot succeed.
+	if err := os.RemoveAll(sub); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(sub, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := h.Append(VerifyRunRecord{ServerID: "s", VerifyStatus: VerifyStatus{State: "failed"}}); err == nil {
+		t.Fatal("Append with an unwritable path reported success")
+	}
+	got := h.List("s")
+	if len(got) != 1 || got[0].State != "succeeded" {
+		t.Fatalf("failed Append leaked into memory: %+v", got)
+	}
+}
+
 func TestOpenVerifyHistory_RefusesCorruptAndNewer(t *testing.T) {
 	dir := t.TempDir()
 	corrupt := filepath.Join(dir, "corrupt.json")

--- a/internal/console/verify_history_test.go
+++ b/internal/console/verify_history_test.go
@@ -1,0 +1,103 @@
+package console
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestVerifyHistory_RoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "console-verify-history.json")
+	h, err := OpenVerifyHistory(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := h.List("srv1"); len(got) != 0 {
+		t.Fatalf("fresh history not empty: %v", got)
+	}
+	for i := range 2 {
+		err := h.Append(VerifyRunRecord{
+			ServerID: "srv1", ServerName: "wp", Trigger: "scheduled",
+			VerifyStatus: VerifyStatus{State: "succeeded", Since: fmt.Sprintf("2026-08-02T0%d:00:00Z", i),
+				Summary: VerifySummary{Match: i, Total: i}},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Reopen from disk: the records survive the process, newest first.
+	h2, err := OpenVerifyHistory(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := h2.List("srv1")
+	if len(got) != 2 {
+		t.Fatalf("want 2 records after reopen, got %d", len(got))
+	}
+	if got[0].Summary.Match != 1 || got[1].Summary.Match != 0 {
+		t.Fatalf("List is not newest-first: %+v", got)
+	}
+	if got[0].Trigger != "scheduled" || got[0].ServerName != "wp" {
+		t.Fatalf("record fields lost in round-trip: %+v", got[0])
+	}
+	if got := h2.List("other"); len(got) != 0 {
+		t.Fatalf("history leaked across servers: %v", got)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("history file mode = %o, want 0600", perm)
+	}
+}
+
+func TestVerifyHistory_CapDropsOldest(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "h.json")
+	h, err := OpenVerifyHistory(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range verifyHistoryCap + 5 {
+		if err := h.Append(VerifyRunRecord{ServerID: "s", VerifyStatus: VerifyStatus{Summary: VerifySummary{Total: i}}}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got := h.List("s")
+	if len(got) != verifyHistoryCap {
+		t.Fatalf("want cap of %d records, got %d", verifyHistoryCap, len(got))
+	}
+	// Newest first: got[0] is the last appended, the tail is the oldest kept.
+	if got[0].Summary.Total != verifyHistoryCap+4 || got[len(got)-1].Summary.Total != 5 {
+		t.Fatalf("cap dropped the wrong end: newest=%d oldest=%d", got[0].Summary.Total, got[len(got)-1].Summary.Total)
+	}
+}
+
+func TestOpenVerifyHistory_RefusesCorruptAndNewer(t *testing.T) {
+	dir := t.TempDir()
+	corrupt := filepath.Join(dir, "corrupt.json")
+	if err := os.WriteFile(corrupt, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := OpenVerifyHistory(corrupt); err == nil {
+		t.Fatal("corrupt history opened without error; a later save would silently truncate it")
+	}
+
+	newer := filepath.Join(dir, "newer.json")
+	if err := os.WriteFile(newer, fmt.Appendf(nil, `{"version": %d, "servers": {}}`, verifyHistoryVersion+1), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := OpenVerifyHistory(newer); err == nil {
+		t.Fatal("newer-versioned history opened without error")
+	}
+}
+
+func TestDefaultVerifyHistoryPath_SiblingOfRegistry(t *testing.T) {
+	got := DefaultVerifyHistoryPath("/etc/bintrail/console-servers.yaml")
+	if got != "/etc/bintrail/console-verify-history.json" {
+		t.Fatalf("got %q", got)
+	}
+}

--- a/internal/console/verify_trigger.go
+++ b/internal/console/verify_trigger.go
@@ -54,6 +54,12 @@ const (
 	// the whole table off production — the console warns to run it off-peak,
 	// matching docs/verify.md.
 	VerifyModeLiveSource VerifyMode = "live-source"
+	// VerifyModeRecoverInputs walks each primary key's event chain and asserts
+	// the before/after images recover consumes are internally consistent — the
+	// console face of `bintrail verify --check recover` (#1191). Index-only:
+	// needs no baseline and no source DSN, which is why the scheduled runner
+	// falls back to it for servers with no baseline configured.
+	VerifyModeRecoverInputs VerifyMode = "recover-inputs"
 )
 
 // VerifyRequest is the in-process job description the endpoint hands the
@@ -212,18 +218,21 @@ func (s *Server) handleVerifyTrigger(w http.ResponseWriter, r *http.Request) {
 		mode = VerifyMode(body.Mode)
 	}
 	switch mode {
-	case VerifyModeBaselineAnchored, VerifyModeLiveSource:
+	case VerifyModeBaselineAnchored, VerifyModeLiveSource, VerifyModeRecoverInputs:
 	default:
-		writeJSONError(w, http.StatusBadRequest, "unknown mode (want baseline-anchored or live-source)")
+		writeJSONError(w, http.StatusBadRequest, "unknown mode (want baseline-anchored, live-source or recover-inputs)")
 		return
 	}
-	// Both modes need a baseline destination — mirrors internal/cli/verify.go,
-	// which requires --baseline-dir/--baseline-s3 before the mode split, not
-	// just for baseline-anchored. Live-source still reconstructs each table
-	// from baseline + deltas (internal/verify.VerifyTable); without one every
-	// table degrades to inconclusive AFTER a full off-peak read of the live
-	// table, which the CLI refuses up front instead of wasting that read.
-	if e.BaselineDir == "" && e.BaselineS3 == "" {
+	// Both content modes need a baseline destination — mirrors
+	// internal/cli/verify.go, which requires --baseline-dir/--baseline-s3
+	// before the mode split, not just for baseline-anchored. Live-source still
+	// reconstructs each table from baseline + deltas
+	// (internal/verify.VerifyTable); without one every table degrades to
+	// inconclusive AFTER a full off-peak read of the live table, which the CLI
+	// refuses up front instead of wasting that read. The recover-inputs check
+	// is exempt for the same reason the CLI exempts --check recover: it reads
+	// binlog_events and nothing else.
+	if mode != VerifyModeRecoverInputs && e.BaselineDir == "" && e.BaselineS3 == "" {
 		writeJSONError(w, http.StatusBadRequest,
 			"this server has no baseline location set up; set a baseline directory or S3 location first (Edit → Advanced)")
 		return
@@ -316,4 +325,21 @@ func (s *Server) handleVerifyExplain(w http.ResponseWriter, r *http.Request) {
 	recordConsoleAccess(r, "verify.explain", schema, table, map[string]string{
 		"mode": "baseline-anchored",
 	})
+}
+
+// handleVerifyHistory serves GET /api/servers/{id}/verify/history — the
+// persisted run history for one server, newest first (#1191). Gated exactly
+// like the live status endpoint: history is only ever written by the watch
+// daemon's supervisor, so a console without VerifyCtrl has none to serve.
+func (s *Server) handleVerifyHistory(w http.ResponseWriter, r *http.Request) {
+	if s.verifyCtrl == nil || s.verifyHistory == nil {
+		writeJSONError(w, http.StatusForbidden,
+			"verify from the console is not enabled; start the watch daemon with BINTRAIL_CONSOLE_VERIFY_TRIGGER=1")
+		return
+	}
+	e, ok := s.requireMonitorEntry(w, r.PathValue("id"))
+	if !ok {
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"history": s.verifyHistory.List(e.ID)})
 }

--- a/internal/console/verify_trigger.go
+++ b/internal/console/verify_trigger.go
@@ -332,9 +332,29 @@ func (s *Server) handleVerifyExplain(w http.ResponseWriter, r *http.Request) {
 // like the live status endpoint: history is only ever written by the watch
 // daemon's supervisor, so a console without VerifyCtrl has none to serve.
 func (s *Server) handleVerifyHistory(w http.ResponseWriter, r *http.Request) {
-	if s.verifyCtrl == nil || s.verifyHistory == nil {
+	if s.verifyCtrl == nil {
 		writeJSONError(w, http.StatusForbidden,
 			"verify from the console is not enabled; start the watch daemon with BINTRAIL_CONSOLE_VERIFY_TRIGGER=1")
+		return
+	}
+	if s.verifyHistory == nil {
+		// Distinct from the disabled case: verify IS enabled but the daemon
+		// could not open the history file at startup — telling the operator to
+		// set VERIFY_TRIGGER here would send them chasing a setting that is
+		// already on.
+		writeJSONError(w, http.StatusForbidden,
+			"verify is enabled but the run-history file could not be opened at daemon startup — check the watch daemon's logs")
+		return
+	}
+	// History carries the same per-table verdicts/reasons as the live status —
+	// unavailable under an RBAC profile like the other verify verbs (and it
+	// spans restarts, so it can cover tables a profile has since withheld).
+	if s.rbacActiveFor(r) {
+		if sessionRestricted(r) {
+			recordProfileGateDeny(r, "verify-history")
+		}
+		writeJSONError(w, http.StatusForbidden,
+			"verification isn't available while an access-control profile is active — baseline and live-source reads aren't redacted")
 		return
 	}
 	e, ok := s.requireMonitorEntry(w, r.PathValue("id"))


### PR DESCRIPTION
closes #1191

## Summary
- **Scheduled verification** in `bintrail-console watch`: `--verify-interval 24h` / `BINTRAIL_CONSOLE_VERIFY_INTERVAL` runs one verification cycle per interval (plus one shortly after startup, mirroring the baseline-prune loop). Each cycle walks the registry servers **sequentially** — one verify, one DuckDB budget at a time, on the conservative fetcher (#510/#511 keep `--ultrafast` off daemons). `--verify-tables` narrows scope; setting an interval implies the verify supervisor (no separate `BINTRAIL_CONSOLE_VERIFY_TRIGGER` needed).
- **Mode selection per server** (pure, tested): baseline-anchored where a baseline location is configured (the entry's own or the process-wide fallback, all-or-nothing exactly like `withBaselineDefaults`/#1010); otherwise the new **`recover-inputs`** mode — the console face of `bintrail verify --check recover` (index-only, CLI defaults: 30d lookback, 200k cap) — so a server with no baseline is verified, not silently skipped.
- **Persisted verdict history**: `internal/console.VerifyHistory` — a JSON file next to the server registry (`console-verify-history.json`, 0600, atomic tmp+fsync+rename like `Registry.save`, capped 20 runs/server). Deliberately a console-local file and NOT an index-DB table: registry DSNs never receive `EnsureSchema` (existing invariant). The supervisor records every finished run — manual and scheduled — at `finish()`, outside the job lock; a scheduled cycle refused by an in-flight run records a `skipped` entry instead of vanishing.
- **API + UI**: `GET /api/servers/{id}/verify/history` (same gating as the other verify verbs); the Verification panel shows a "LAST VERIFIED \<ago\>" headline plus the recent runs, adds the recover-inputs option to the mode selector (runnable without a baseline), and refreshes the history after a manual run.
- Docs: scheduled-verification section, the new env vars, and a correction — `docs/console.md` claimed "there is no persisted run history", which this PR makes false.

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] `go vet -tags integration ./...` clean
- [x] `node --check` on `app.js`
- New tests: history store round-trip/cap/corrupt-refusal/perms, newest-first API endpoint + 403/404 gates, recover-inputs accepted without baseline (and content mode still 400), scheduled mode selection incl. the all-or-nothing baseline fallback, `finish()`→history for success/failure/skip, concurrent-admission refusal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
