### PR TITLE
status: attribute statement-format DML drops and wire them into --fail-on-gap

### DIFF
--- a/docs/rotation-and-status.md
+++ b/docs/rotation-and-status.md
@@ -346,7 +346,11 @@ PostgreSQL replication slot (#532) after the capture process has exited.
 **`--fail-on-gap` (for CI / cron).** By default a gap **never** changes the exit
 code — `status` is a report. Pass `--fail-on-gap` to exit non-zero when continuity
 is `gap_lost` **or** `unknown`; it **fails closed**, so an un-migrated legacy index
-or an unloadable stream state also trips it:
+or an unloadable stream state also trips it. It also exits non-zero when the
+capture ledger records in-scope `statement_format_dml` drops — those changes are
+permanently absent from the index, the same loss class as `gap_lost` (an
+*unknown* capture ledger does not trip it: the column post-dates the flag, and
+alerting on its absence would fail every pre-existing deployment):
 
 ```sh
 bintrail status --index-dsn "$IDX" --fail-on-gap || alert "dbtrail lost events"
@@ -400,6 +404,12 @@ the binlog — requires `binlog_format=ROW`). Routine skips of system schemas
 the snapshot deliberately excludes (e.g. RDS's `mysql.rds_heartbeat2`) are
 **not** counted.
 
+For `statement_format_dml` the daemon also stamps the most recent drop's
+**attribution** — binlog file:pos, statement keyword, and connection id, enough
+to hunt the offending client without ever storing the statement text (it embeds
+row values). The DEGRADED block then adds a `Last drop:` line, e.g.
+`Last drop:       binlog.000042:99012 (UPDATE, connection id 55)`.
+
 In the daemon log, each skip still emits its per-event `WARN`; after 100
 **consecutive** skipped events one `ERROR` with remediation is emitted (once
 per degraded episode — it re-arms when an event is captured again).
@@ -407,7 +417,9 @@ per degraded episode — it re-arms when an event is captured again).
 Under `--format json` the verdict is `stream.capture_health`:
 `{"status": "ok"}` or `{"status": "degraded", "total_skipped": N,
 "last_skip_at": "...", "skipped": {"<reason>": {"count": N, "last_at": "..."}}}`;
-the key is omitted when the verdict is unknown. The [web console](console.md)
+the key is omitted when the verdict is unknown. Attributed reasons additionally
+carry `last_file`, `last_pos`, `last_statement_type`, `last_connection_id`
+(omitted when absent). The [web console](console.md)
 Overview shows an orange "Capture degraded" box in the same states.
 
 ### Sections in detail

--- a/docs/rotation-and-status.md
+++ b/docs/rotation-and-status.md
@@ -348,9 +348,18 @@ code — `status` is a report. Pass `--fail-on-gap` to exit non-zero when contin
 is `gap_lost` **or** `unknown`; it **fails closed**, so an un-migrated legacy index
 or an unloadable stream state also trips it. It also exits non-zero when the
 capture ledger records in-scope `statement_format_dml` drops — those changes are
-permanently absent from the index, the same loss class as `gap_lost` (an
-*unknown* capture ledger does not trip it: the column post-dates the flag, and
-alerting on its absence would fail every pre-existing deployment):
+permanently absent from the index, the same loss class as `gap_lost`. A **NULL**
+capture ledger does not trip it (the column post-dates the flag, and alerting on
+its absence would fail every pre-existing deployment) — but a ledger that is
+*present and unreadable* does fail closed: a skip-aware daemon wrote it, and it
+may be hiding a loss count.
+
+The drop counter is **monotonic for the life of the index** — fixing
+`binlog_format` stops new drops but does not clear the count (the dropped
+changes stay lost). To acknowledge after remediation: stop the capture daemon,
+clear the ledger (`UPDATE stream_state SET capture_skips = '{}' WHERE id = 1` on
+your index), and restart — clearing it with the daemon running is ineffective,
+the next checkpoint re-persists the in-memory tallies.
 
 ```sh
 bintrail status --index-dsn "$IDX" --fail-on-gap || alert "dbtrail lost events"

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/go-sql-driver/mysql"
@@ -146,21 +147,30 @@ func runStatus(cmd *cobra.Command, args []string) error {
 		}
 		// #999: a non-zero IN-SCOPE statement-format DML count is the same loss
 		// class as gap_lost — those changes are permanently absent from the
-		// index — so it joins the fail-closed contract. An UNKNOWN capture
-		// health (legacy index / no skip-aware daemon) deliberately does NOT
-		// alert here: unlike the gap columns above, capture_skips post-dates
-		// this flag, and failing every pre-#1034 deployment's cron would bury
-		// the signal in false alarms (the gap-column unknowns already alerted
+		// index — so it joins the fail-closed contract. A NULL/empty ledger
+		// (legacy index / no skip-aware daemon) deliberately does NOT alert
+		// here: unlike the gap columns above, capture_skips post-dates this
+		// flag, and failing every pre-#1034 deployment's cron would bury the
+		// signal in false alarms (the gap-column unknowns already alerted
 		// before capture_skips existed, so their fail-closed stance breaks no
-		// one).
+		// one). A ledger that IS present but unreadable gets no such pass —
+		// a skip-aware daemon wrote it, it may be hiding a loss count, and
+		// "couldn't check" must not read as "fine" (the sibling branches'
+		// stance).
 		if skips, ok := data.Stream.ParseCaptureSkips(); ok {
 			if st := skips[status.CaptureSkipReasonStatementFormatDML]; st.Count > 0 {
 				loc := ""
 				if st.LastFile != "" || st.LastStatementType != "" {
-					loc = fmt.Sprintf(" (last: %s at %s:%d, connection id %d)", st.LastStatementType, st.LastFile, st.LastPos, st.LastConnectionID)
+					file := st.LastFile
+					if file == "" {
+						file = "?"
+					}
+					loc = fmt.Sprintf(" (last: %s at %s:%d, connection id %d)", st.LastStatementType, file, st.LastPos, st.LastConnectionID)
 				}
-				return fmt.Errorf("capture health: %d statement-format DML event(s) permanently uncaptured%s; set binlog_format=ROW server-wide on the source; failing closed under --fail-on-gap", st.Count, loc)
+				return fmt.Errorf("capture health: %d statement-format DML event(s) permanently uncaptured%s; set binlog_format=ROW server-wide on the source, then acknowledge by clearing stream_state.capture_skips with the daemon stopped (the counter is monotonic); failing closed under --fail-on-gap", st.Count, loc)
 			}
+		} else if data.Stream.CaptureSkips.Valid && strings.TrimSpace(data.Stream.CaptureSkips.String) != "" {
+			return fmt.Errorf("capture health: capture_skips ledger present but unreadable; cannot confirm statement-format DML drops; failing closed under --fail-on-gap")
 		}
 	}
 	return nil

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -28,8 +28,9 @@ The Stream section also reports continuity — the cheap "did I lose any events?
 verdict: "no gaps in the captured range" (a contiguity check, not a liveness
 one), or a loud "GAP LOST" when an unfillable gap forced an auto-advance with
 permanent loss. Pass --fail-on-gap to exit non-zero on that loss — or when
-continuity can't be confirmed (fails closed) — for CI/cron alerting; by default
-a gap never changes the exit code.
+continuity can't be confirmed (fails closed), or when in-scope statement-format
+DML drops were recorded (the same permanent-loss class) — for CI/cron alerting;
+by default a gap never changes the exit code.
 
 Partition row counts are estimates read from information_schema (no table scan).
 
@@ -49,7 +50,7 @@ func init() {
 	statusCmd.Flags().StringVar(&stIndexDSN, "index-dsn", "", "DSN for the index MySQL database (required)")
 	statusCmd.Flags().StringVar(&stFormat, "format", "text", "Output format: text or json")
 	statusCmd.Flags().StringVar(&stBaselineDir, "baseline-dir", "", "Local directory of baseline Parquet snapshots (optional, shows baseline binlog positions)")
-	statusCmd.Flags().BoolVar(&stFailOnGap, "fail-on-gap", false, "Exit non-zero if the stream lost data, or its continuity can't be confirmed (fails closed); for CI/cron alerting. By default a gap never changes the exit code")
+	statusCmd.Flags().BoolVar(&stFailOnGap, "fail-on-gap", false, "Exit non-zero if the stream lost data (a binlog gap or statement-format DML drops), or its continuity can't be confirmed (fails closed); for CI/cron alerting. By default a gap never changes the exit code")
 	_ = statusCmd.MarkFlagRequired("index-dsn")
 	BindCommandEnv(statusCmd)
 	// Registration on a root command happens via AddReadCommands(root), which
@@ -142,6 +143,24 @@ func runStatus(cmd *cobra.Command, args []string) error {
 		case data.Stream.GapLostAt.Valid:
 			return fmt.Errorf("stream continuity: events permanently lost (gap detected at %s); index is valid only up to the gap, resume requires re-baseline",
 				data.Stream.GapLostAt.Time.Format(status.TSFmt))
+		}
+		// #999: a non-zero IN-SCOPE statement-format DML count is the same loss
+		// class as gap_lost — those changes are permanently absent from the
+		// index — so it joins the fail-closed contract. An UNKNOWN capture
+		// health (legacy index / no skip-aware daemon) deliberately does NOT
+		// alert here: unlike the gap columns above, capture_skips post-dates
+		// this flag, and failing every pre-#1034 deployment's cron would bury
+		// the signal in false alarms (the gap-column unknowns already alerted
+		// before capture_skips existed, so their fail-closed stance breaks no
+		// one).
+		if skips, ok := data.Stream.ParseCaptureSkips(); ok {
+			if st := skips[status.CaptureSkipReasonStatementFormatDML]; st.Count > 0 {
+				loc := ""
+				if st.LastFile != "" || st.LastStatementType != "" {
+					loc = fmt.Sprintf(" (last: %s at %s:%d, connection id %d)", st.LastStatementType, st.LastFile, st.LastPos, st.LastConnectionID)
+				}
+				return fmt.Errorf("capture health: %d statement-format DML event(s) permanently uncaptured%s; set binlog_format=ROW server-wide on the source; failing closed under --fail-on-gap", st.Count, loc)
+			}
 		}
 	}
 	return nil

--- a/internal/cli/status_fail_on_gap_integration_test.go
+++ b/internal/cli/status_fail_on_gap_integration_test.go
@@ -139,6 +139,39 @@ func TestRunStatus_failOnGap_exitCode(t *testing.T) {
 		}
 	})
 
+	// Drops AND a stamped gap: the gap error wins (its remediation —
+	// re-baseline — subsumes the drop one).
+	if _, err := db.ExecContext(ctx,
+		`UPDATE stream_state SET gap_lost_at=UTC_TIMESTAMP(), gap_lost_detail='unfillable binlog gap' WHERE id=1`); err != nil {
+		t.Fatalf("re-stamp gap: %v", err)
+	}
+	captureStdout(t, func() {
+		if err := runStatus(statusCmd, nil); err == nil || !strings.Contains(err.Error(), "events permanently lost") {
+			t.Errorf("with both a gap and drops, the gap error must win, got: %v", err)
+		}
+	})
+	if _, err := db.ExecContext(ctx,
+		"UPDATE stream_state SET gap_lost_at=NULL, gap_lost_detail=NULL WHERE id=1"); err != nil {
+		t.Fatalf("clear gap again: %v", err)
+	}
+
+	// A ledger that is PRESENT but unreadable (valid JSON, wrong shape) gets
+	// no grandfathering pass: a skip-aware daemon wrote it and it may hide a
+	// loss count — fail closed, like the sibling can't-confirm branches.
+	if _, err := db.ExecContext(ctx,
+		`UPDATE stream_state SET capture_skips='{"statement_format_dml": 3}' WHERE id=1`); err != nil {
+		t.Fatalf("seed unreadable capture_skips: %v", err)
+	}
+	captureStdout(t, func() {
+		if err := runStatus(statusCmd, nil); err == nil || !strings.Contains(err.Error(), "unreadable") {
+			t.Errorf("want a fail-closed error for a present-but-unreadable ledger, got: %v", err)
+		}
+	})
+	if _, err := db.ExecContext(ctx,
+		`UPDATE stream_state SET capture_skips='{"statement_format_dml":{"count":3,"last_at":"2026-07-18T01:00:00Z","last_file":"binlog.000042","last_pos":99012,"last_statement_type":"UPDATE","last_connection_id":55}}' WHERE id=1`); err != nil {
+		t.Fatalf("restore capture_skips: %v", err)
+	}
+
 	// Flag OFF + the same drops → exit 0 (break-nothing for existing scripts).
 	stFailOnGap = false
 	captureStdout(t, func() {

--- a/internal/cli/status_fail_on_gap_integration_test.go
+++ b/internal/cli/status_fail_on_gap_integration_test.go
@@ -124,6 +124,40 @@ func TestRunStatus_failOnGap_exitCode(t *testing.T) {
 		}
 	})
 
+	// #999: in-scope statement-format DML drops in the ledger → fail closed
+	// (same permanent-loss class as gap_lost), with the last-drop attribution
+	// in the error.
+	if _, err := db.ExecContext(ctx,
+		`UPDATE stream_state SET capture_skips='{"statement_format_dml":{"count":3,"last_at":"2026-07-18T01:00:00Z","last_file":"binlog.000042","last_pos":99012,"last_statement_type":"UPDATE","last_connection_id":55}}' WHERE id=1`); err != nil {
+		t.Fatalf("seed capture_skips: %v", err)
+	}
+	captureStdout(t, func() {
+		if err := runStatus(statusCmd, nil); err == nil {
+			t.Error("want a non-zero exit for statement-format DML drops under --fail-on-gap, got nil")
+		} else if !strings.Contains(err.Error(), "statement-format DML") || !strings.Contains(err.Error(), "binlog.000042:99012") {
+			t.Errorf("want a capture-health error with the last-drop attribution, got: %v", err)
+		}
+	})
+
+	// Flag OFF + the same drops → exit 0 (break-nothing for existing scripts).
+	stFailOnGap = false
+	captureStdout(t, func() {
+		if err := runStatus(statusCmd, nil); err != nil {
+			t.Errorf("default (no --fail-on-gap) must exit 0 even with recorded drops, got: %v", err)
+		}
+	})
+	stFailOnGap = true
+
+	// An evaluated-and-clean ledger ("{}") → no alert.
+	if _, err := db.ExecContext(ctx, `UPDATE stream_state SET capture_skips='{}' WHERE id=1`); err != nil {
+		t.Fatalf("clear capture_skips: %v", err)
+	}
+	captureStdout(t, func() {
+		if err := runStatus(statusCmd, nil); err != nil {
+			t.Errorf("a clean capture ledger must not alert under --fail-on-gap, got: %v", err)
+		}
+	})
+
 	// No stream row at all + --fail-on-gap ON → fail closed (cannot confirm).
 	if _, err := db.ExecContext(ctx, "DELETE FROM stream_state WHERE id=1"); err != nil {
 		t.Fatalf("delete stream row: %v", err)

--- a/internal/console/api.go
+++ b/internal/console/api.go
@@ -513,8 +513,13 @@ func (s *Server) handleRecover(w http.ResponseWriter, r *http.Request) {
 
 // handleStatus serves GET /api/status — index health, partitions, coverage,
 // stream lag, archives. Reuses status.CollectStatus + WriteJSON verbatim;
-// that surface exposes only aggregate server metadata, never per-event actor
-// attribution, so it stays inside the free query_explorer boundary.
+// that surface exposes only aggregate server metadata — never per-event actor
+// attribution for INDEXED row history (the paid forensics surface) — so it
+// stays inside the free query_explorer boundary. The one deliberate carve-out
+// (#999): capture_health may carry the last DROPPED statement's file/pos/
+// keyword/connection id. That event is NOT in the index — the datum exists to
+// debug capture configuration (binlog_format), not to query row history, and
+// the issue's acceptance placed it in OSS `status` explicitly.
 func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 	b := s.resolveOr(w, r)
 	if b == nil {

--- a/internal/parser/skips.go
+++ b/internal/parser/skips.go
@@ -58,17 +58,20 @@ type SkipStat struct {
 	// Last-seen attribution (#999): where the most recent skip happened, enough
 	// to hunt the source without ever storing statement text (a DML statement
 	// embeds row VALUES — same reason the per-event WARN omits it). Optional —
-	// only the statement-DML site stamps these today; omitempty keeps documents
-	// persisted before this change (and reasons without attribution) unchanged.
+	// only the STREAMING statement-DML site stamps these today (file-mode
+	// `bintrail index` detects the same drops but persists no ledger at all);
+	// omitempty keeps documents persisted before this change (and reasons
+	// without attribution) unchanged.
 	LastFile          string `json:"last_file,omitempty"`
 	LastPos           uint64 `json:"last_pos,omitempty"`
 	LastStatementType string `json:"last_statement_type,omitempty"`
 	LastConnectionID  uint32 `json:"last_connection_id,omitempty"`
 }
 
-// SkipAttribution locates one skipped event: binlog file/pos plus the statement
-// keyword and connection id from the QUERY event header. Never carries the
-// statement text.
+// SkipAttribution locates one skipped event: binlog file/pos, the statement
+// keyword (derived from the statement text, which is then discarded), and the
+// connection id from the QUERY event post-header. Never carries the statement
+// text itself.
 type SkipAttribution struct {
 	File          string
 	Pos           uint64
@@ -124,7 +127,9 @@ func (c *SkipCounters) RecordSkip(reason string) {
 
 // RecordSkipAttributed is RecordSkip carrying the skipped event's location
 // (#999). A zero attribution leaves any previously stamped attribution for the
-// reason in place — an unattributed count must not erase the last useful lead.
+// reason in place — an unattributed count must not erase the last useful lead
+// (consequence: the attribution can lag last_at if a caller mixes attributed
+// and unattributed skips of one reason).
 func (c *SkipCounters) RecordSkipAttributed(reason string, attr SkipAttribution) {
 	if c == nil {
 		return

--- a/internal/parser/skips.go
+++ b/internal/parser/skips.go
@@ -55,6 +55,25 @@ const SkipEscalationThreshold = 100
 type SkipStat struct {
 	Count  int64     `json:"count"`
 	LastAt time.Time `json:"last_at"`
+	// Last-seen attribution (#999): where the most recent skip happened, enough
+	// to hunt the source without ever storing statement text (a DML statement
+	// embeds row VALUES — same reason the per-event WARN omits it). Optional —
+	// only the statement-DML site stamps these today; omitempty keeps documents
+	// persisted before this change (and reasons without attribution) unchanged.
+	LastFile          string `json:"last_file,omitempty"`
+	LastPos           uint64 `json:"last_pos,omitempty"`
+	LastStatementType string `json:"last_statement_type,omitempty"`
+	LastConnectionID  uint32 `json:"last_connection_id,omitempty"`
+}
+
+// SkipAttribution locates one skipped event: binlog file/pos plus the statement
+// keyword and connection id from the QUERY event header. Never carries the
+// statement text.
+type SkipAttribution struct {
+	File          string
+	Pos           uint64
+	StatementType string
+	ConnectionID  uint32
 }
 
 // SkipCounters aggregates capture-time skips by reason. Safe for concurrent
@@ -100,6 +119,13 @@ func (c *SkipCounters) Seed(raw string) error {
 // When SkipEscalationThreshold consecutive events have been skipped it emits
 // ONE ERROR with remediation (re-armed by the next RecordCaptured).
 func (c *SkipCounters) RecordSkip(reason string) {
+	c.RecordSkipAttributed(reason, SkipAttribution{})
+}
+
+// RecordSkipAttributed is RecordSkip carrying the skipped event's location
+// (#999). A zero attribution leaves any previously stamped attribution for the
+// reason in place — an unattributed count must not erase the last useful lead.
+func (c *SkipCounters) RecordSkipAttributed(reason string, attr SkipAttribution) {
 	if c == nil {
 		return
 	}
@@ -108,6 +134,10 @@ func (c *SkipCounters) RecordSkip(reason string) {
 	st := c.byReason[reason]
 	st.Count++
 	st.LastAt = time.Now().UTC()
+	if attr != (SkipAttribution{}) {
+		st.LastFile, st.LastPos = attr.File, attr.Pos
+		st.LastStatementType, st.LastConnectionID = attr.StatementType, attr.ConnectionID
+	}
 	c.byReason[reason] = st
 	c.consecutive++
 	if c.consecutive >= SkipEscalationThreshold && !c.escalated {

--- a/internal/parser/skips_test.go
+++ b/internal/parser/skips_test.go
@@ -292,7 +292,9 @@ func TestStreamParser_statementDMLCountsSkip(t *testing.T) {
 	qev.Event.(*replication.QueryEvent).SlaveProxyID = 77
 
 	ctx, cancel := context.WithCancel(context.Background())
-	feedThenCancel(t, streamer, cancel, qev)
+	// The rotate precedes the drop, as on a real stream — pinning that Run
+	// plumbs currentFile into the attribution, not just pos/keyword/conn id.
+	feedThenCancel(t, streamer, cancel, makeRotate("binlog.000123"), qev)
 	if err := sp.Run(ctx, streamer, out); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -307,7 +309,7 @@ func TestStreamParser_statementDMLCountsSkip(t *testing.T) {
 		t.Fatalf("decode snapshot: %v", err)
 	}
 	st := m[SkipStatementFormatDML]
-	if st.LastPos != 4242 || st.LastStatementType != "UPDATE" || st.LastConnectionID != 77 {
+	if st.LastFile != "binlog.000123" || st.LastPos != 4242 || st.LastStatementType != "UPDATE" || st.LastConnectionID != 77 {
 		t.Fatalf("statement-DML site did not stamp attribution: %+v", st)
 	}
 	if strings.Contains(snap, "amount") {

--- a/internal/parser/skips_test.go
+++ b/internal/parser/skips_test.go
@@ -50,6 +50,47 @@ func TestSkipCounters_snapshotSeedRoundTrip(t *testing.T) {
 	}
 }
 
+// Attribution (#999): RecordSkipAttributed stamps file/pos/keyword/connection
+// id into the persisted stat, an unattributed skip must not erase the last
+// lead, and the document round-trips through Seed. Reasons that never carried
+// attribution serialize none of the last_* keys (pre-#999 shape preserved).
+func TestSkipCounters_attributionRoundTrip(t *testing.T) {
+	c := NewSkipCounters(newTestLogger(&bytes.Buffer{}))
+	c.RecordSkipAttributed(SkipStatementFormatDML, SkipAttribution{
+		File: "binlog.000042", Pos: 99012, StatementType: "UPDATE", ConnectionID: 55,
+	})
+	c.RecordSkip(SkipStatementFormatDML)
+	c.RecordSkip(SkipColumnCountMismatch)
+
+	snap, err := c.Snapshot()
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	m := map[string]SkipStat{}
+	if err := json.Unmarshal([]byte(snap), &m); err != nil {
+		t.Fatalf("decode snapshot: %v", err)
+	}
+	st := m[SkipStatementFormatDML]
+	if st.Count != 2 || st.LastFile != "binlog.000042" || st.LastPos != 99012 ||
+		st.LastStatementType != "UPDATE" || st.LastConnectionID != 55 {
+		t.Fatalf("attribution lost or wiped by the unattributed skip: %+v", st)
+	}
+	if cc := m[SkipColumnCountMismatch]; cc.LastFile != "" || cc.LastStatementType != "" {
+		t.Fatalf("unattributed reason must not carry attribution: %+v", cc)
+	}
+
+	restarted := NewSkipCounters(newTestLogger(&bytes.Buffer{}))
+	if err := restarted.Seed(snap); err != nil {
+		t.Fatalf("Seed: %v", err)
+	}
+	snap2, _ := restarted.Snapshot()
+	for _, want := range []string{`"last_file":"binlog.000042"`, `"last_pos":99012`, `"last_statement_type":"UPDATE"`, `"last_connection_id":55`} {
+		if !strings.Contains(snap2, want) {
+			t.Errorf("attribution must survive the restart round-trip; missing %q: %s", want, snap2)
+		}
+	}
+}
+
 func TestSkipCounters_seedEmptyAndInvalid(t *testing.T) {
 	c := NewSkipCounters(newTestLogger(&bytes.Buffer{}))
 	if err := c.Seed(""); err != nil {
@@ -246,14 +287,31 @@ func TestStreamParser_statementDMLCountsSkip(t *testing.T) {
 	streamer := replication.NewBinlogStreamer()
 	out := make(chan Event, 10)
 
+	qev := makeQueryEvent("UPDATE shop.orders SET amount = 1")
+	qev.Header.LogPos = 4242
+	qev.Event.(*replication.QueryEvent).SlaveProxyID = 77
+
 	ctx, cancel := context.WithCancel(context.Background())
-	feedThenCancel(t, streamer, cancel, makeQueryEvent("UPDATE shop.orders SET amount = 1"))
+	feedThenCancel(t, streamer, cancel, qev)
 	if err := sp.Run(ctx, streamer, out); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
 	snap, _ := skips.Snapshot()
 	if !strings.Contains(snap, SkipStatementFormatDML) || skips.Total() != 1 {
 		t.Fatalf("statement-format DML drop not counted (total=%d): %s", skips.Total(), snap)
+	}
+	// The production site must stamp the attribution (#999) — the same fields
+	// the per-event WARN carries, minus the statement text.
+	m := map[string]SkipStat{}
+	if err := json.Unmarshal([]byte(snap), &m); err != nil {
+		t.Fatalf("decode snapshot: %v", err)
+	}
+	st := m[SkipStatementFormatDML]
+	if st.LastPos != 4242 || st.LastStatementType != "UPDATE" || st.LastConnectionID != 77 {
+		t.Fatalf("statement-DML site did not stamp attribution: %+v", st)
+	}
+	if strings.Contains(snap, "amount") {
+		t.Fatalf("statement text must NEVER be persisted: %s", snap)
 	}
 }
 

--- a/internal/parser/stream.go
+++ b/internal/parser/stream.go
@@ -411,7 +411,12 @@ func (sp *StreamParser) Run(ctx context.Context, streamer *replication.BinlogStr
 						"statement_type", kw,
 						"connection_id", ev.SlaveProxyID)
 					observe.StatementDMLDropped()
-					sp.skips.RecordSkip(SkipStatementFormatDML)
+					sp.skips.RecordSkipAttributed(SkipStatementFormatDML, SkipAttribution{
+						File:          currentFile,
+						Pos:           uint64(binlogEv.Header.LogPos),
+						StatementType: kw,
+						ConnectionID:  ev.SlaveProxyID,
+					})
 				}
 			}
 

--- a/internal/status/capture_health_test.go
+++ b/internal/status/capture_health_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/dbtrail/dbtrail/internal/parser"
 )
 
 // ─── Capture health verdict (#1034) ───────────────────────────────────────────
@@ -79,6 +81,37 @@ func TestWriteStatus_captureHealthAttribution(t *testing.T) {
 	WriteStatus(&buf, nil, nil, nil, nil, nil, captureStream(degradedSkips))
 	if strings.Contains(buf.String(), "Last drop") {
 		t.Errorf("unattributed ledger must omit the Last drop line:\n%s", buf.String())
+	}
+}
+
+// Partial-attribution rendering: file-only drops the keyword segment, an empty
+// file renders "?" (a drop before the first rotate — reachable in production),
+// full attribution renders both halves.
+func TestLastCaptureSkipAttribution_partial(t *testing.T) {
+	at := time.Date(2026, 7, 18, 1, 0, 0, 0, time.UTC)
+	for name, tc := range map[string]struct {
+		st   CaptureSkipStat
+		want string
+	}{
+		"full":         {CaptureSkipStat{LastAt: at, LastFile: "binlog.000042", LastPos: 99012, LastStatementType: "UPDATE", LastConnectionID: 55}, "binlog.000042:99012 (UPDATE, connection id 55)"},
+		"file-only":    {CaptureSkipStat{LastAt: at, LastFile: "binlog.000042", LastPos: 99012}, "binlog.000042:99012"},
+		"keyword-only": {CaptureSkipStat{LastAt: at, LastPos: 4242, LastStatementType: "UPDATE", LastConnectionID: 77}, "?:4242 (UPDATE, connection id 77)"},
+	} {
+		if got := lastCaptureSkipAttribution(map[string]CaptureSkipStat{"statement_format_dml": tc.st}); got != tc.want {
+			t.Errorf("%s: got %q, want %q", name, got, tc.want)
+		}
+	}
+	if got := lastCaptureSkipAttribution(map[string]CaptureSkipStat{"column_count_mismatch": {LastAt: at, Count: 5}}); got != "" {
+		t.Errorf("unattributed-only ledger must render no attribution, got %q", got)
+	}
+}
+
+// The reason key is a persistence contract shared by two deliberately
+// unlinked decls — pin the mirror so a rename in one side fails here instead
+// of silently splitting the ledger.
+func TestCaptureSkipReasonMirrorsParser(t *testing.T) {
+	if CaptureSkipReasonStatementFormatDML != parser.SkipStatementFormatDML {
+		t.Fatalf("status reason %q != parser reason %q", CaptureSkipReasonStatementFormatDML, parser.SkipStatementFormatDML)
 	}
 }
 

--- a/internal/status/capture_health_test.go
+++ b/internal/status/capture_health_test.go
@@ -34,6 +34,11 @@ func captureStream(captureSkips any) *StreamStateInfo {
 
 const degradedSkips = `{"column_count_mismatch":{"count":41203,"last_at":"2026-07-17T12:24:12Z"}}`
 
+// attributedSkips carries the #999 last-seen attribution the capture daemon
+// stamps for statement-format DML drops.
+const attributedSkips = `{"statement_format_dml":{"count":7,"last_at":"2026-07-18T01:00:00Z",` +
+	`"last_file":"binlog.000042","last_pos":99012,"last_statement_type":"UPDATE","last_connection_id":55}}`
+
 func TestWriteStatus_captureHealthDegraded(t *testing.T) {
 	var buf bytes.Buffer
 	WriteStatus(&buf, nil, nil, nil, nil, nil, captureStream(degradedSkips))
@@ -58,6 +63,22 @@ func TestWriteStatus_captureHealthMultipleReasons(t *testing.T) {
 	// Reasons sorted by count descending; the overall "last" is the max last_at.
 	if !strings.Contains(out, "1,207 events skipped (column_count_mismatch: 1,200, statement_format_dml: 7), last 2026-07-18 01:00:00") {
 		t.Errorf("multi-reason summary wrong:\n%s", out)
+	}
+}
+
+// #999: the DEGRADED block renders the last attributed drop; a pre-#999 ledger
+// without attribution must not render an empty "Last drop" line.
+func TestWriteStatus_captureHealthAttribution(t *testing.T) {
+	var buf bytes.Buffer
+	WriteStatus(&buf, nil, nil, nil, nil, nil, captureStream(attributedSkips))
+	if !strings.Contains(buf.String(), "Last drop:       binlog.000042:99012 (UPDATE, connection id 55)") {
+		t.Errorf("attributed degraded status missing the Last drop line:\n%s", buf.String())
+	}
+
+	buf.Reset()
+	WriteStatus(&buf, nil, nil, nil, nil, nil, captureStream(degradedSkips))
+	if strings.Contains(buf.String(), "Last drop") {
+		t.Errorf("unattributed ledger must omit the Last drop line:\n%s", buf.String())
 	}
 }
 
@@ -125,6 +146,29 @@ func TestWriteStatusJSON_captureHealthDegraded(t *testing.T) {
 	reason := skipped["column_count_mismatch"].(map[string]any)
 	if reason["count"] != float64(41203) {
 		t.Errorf("per-reason count = %v, want 41203", reason["count"])
+	}
+}
+
+// #999: the JSON per-reason stat carries the attribution fields; a ledger
+// without them omits the keys (omitempty — pre-#999 consumers see no change).
+func TestWriteStatusJSON_captureHealthAttribution(t *testing.T) {
+	out := decodeStatusJSON(t, captureStream(attributedSkips))
+	reason := out["stream"].(map[string]any)["capture_health"].(map[string]any)["skipped"].(map[string]any)["statement_format_dml"].(map[string]any)
+	for key, want := range map[string]any{
+		"last_file": "binlog.000042", "last_pos": float64(99012),
+		"last_statement_type": "UPDATE", "last_connection_id": float64(55),
+	} {
+		if reason[key] != want {
+			t.Errorf("%s = %v, want %v", key, reason[key], want)
+		}
+	}
+
+	out = decodeStatusJSON(t, captureStream(degradedSkips))
+	reason = out["stream"].(map[string]any)["capture_health"].(map[string]any)["skipped"].(map[string]any)["column_count_mismatch"].(map[string]any)
+	for _, key := range []string{"last_file", "last_pos", "last_statement_type", "last_connection_id"} {
+		if _, present := reason[key]; present {
+			t.Errorf("unattributed reason must omit %s: %v", key, reason)
+		}
 	}
 }
 

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -124,7 +124,8 @@ type CaptureSkipStat struct {
 	Count  int64     `json:"count"`
 	LastAt time.Time `json:"last_at"`
 	// Last-seen attribution (#999), stamped by the capture daemon for the most
-	// recent skip of this reason (today only statement-format DML carries it).
+	// recent skip of a reason — present only for reasons whose detection site
+	// stamps it (see parser.SkipStat, the single source of truth for which do).
 	LastFile          string `json:"last_file,omitempty"`
 	LastPos           uint64 `json:"last_pos,omitempty"`
 	LastStatementType string `json:"last_statement_type,omitempty"`
@@ -920,8 +921,11 @@ func lastCaptureSkip(skips map[string]CaptureSkipStat) time.Time {
 }
 
 // lastCaptureSkipAttribution formats the newest attributed skip (#999) for the
-// DEGRADED block: "file:pos (STATEMENT_TYPE, connection id N)". "" when no stat
-// carries attribution (pre-#999 ledger, or only unattributed reasons).
+// DEGRADED block: "file:pos" plus, when a statement keyword was stamped, a
+// " (STATEMENT_TYPE, connection id N)" segment. An empty file (a drop before
+// the first rotate event) renders as "?" rather than a malformed ":pos". ""
+// when no stat carries attribution (pre-#999 ledger, or only unattributed
+// reasons).
 func lastCaptureSkipAttribution(skips map[string]CaptureSkipStat) string {
 	var best CaptureSkipStat
 	found := false
@@ -936,7 +940,11 @@ func lastCaptureSkipAttribution(skips map[string]CaptureSkipStat) string {
 	if !found {
 		return ""
 	}
-	s := fmt.Sprintf("%s:%d", best.LastFile, best.LastPos)
+	file := best.LastFile
+	if file == "" {
+		file = "?"
+	}
+	s := fmt.Sprintf("%s:%d", file, best.LastPos)
 	if best.LastStatementType != "" {
 		s += fmt.Sprintf(" (%s, connection id %d)", best.LastStatementType, best.LastConnectionID)
 	}
@@ -1069,7 +1077,7 @@ func writeStatusJSONFull(w io.Writer, files []IndexStateRow, parts []PartitionSt
 		Count  int64  `json:"count"`
 		LastAt string `json:"last_at"`
 		// Last-seen attribution (#999); present only for reasons the capture
-		// daemon stamps (today statement_format_dml).
+		// daemon stamps (see parser.SkipStat for which do).
 		LastFile          string `json:"last_file,omitempty"`
 		LastPos           uint64 `json:"last_pos,omitempty"`
 		LastStatementType string `json:"last_statement_type,omitempty"`

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -123,7 +123,19 @@ type StreamStateInfo struct {
 type CaptureSkipStat struct {
 	Count  int64     `json:"count"`
 	LastAt time.Time `json:"last_at"`
+	// Last-seen attribution (#999), stamped by the capture daemon for the most
+	// recent skip of this reason (today only statement-format DML carries it).
+	LastFile          string `json:"last_file,omitempty"`
+	LastPos           uint64 `json:"last_pos,omitempty"`
+	LastStatementType string `json:"last_statement_type,omitempty"`
+	LastConnectionID  uint32 `json:"last_connection_id,omitempty"`
 }
+
+// CaptureSkipReasonStatementFormatDML mirrors parser.SkipStatementFormatDML —
+// the persisted reason key for STATEMENT/MIXED-format DML drops (#999). Kept as
+// an independent decl for the same reason CaptureSkipStat is: this display
+// package deliberately does not import the binlog parser.
+const CaptureSkipReasonStatementFormatDML = "statement_format_dml"
 
 // ParseCaptureSkips decodes the persisted capture_skips document. ok is false
 // when the verdict is not evaluable (no column / no skip-aware daemon /
@@ -683,6 +695,9 @@ func WriteStatus(w io.Writer, files []IndexStateRow, parts []PartitionStat, arch
 			if total := totalCaptureSkips(skips); total > 0 {
 				fmt.Fprintf(w, "  Capture health:  ⚠ DEGRADED — %s events skipped (%s), last %s\n",
 					commaGroup(total), captureSkipReasons(skips), lastCaptureSkip(skips).Format(TSFmt))
+				if attr := lastCaptureSkipAttribution(skips); attr != "" {
+					fmt.Fprintf(w, "  Last drop:       %s\n", attr)
+				}
 				fmt.Fprintln(w, "  Skipped events were read from the stream but NOT indexed — a restore window")
 				fmt.Fprintln(w, "  over them is incomplete. Most often the schema snapshot is stale or corrupt:")
 				fmt.Fprintln(w, "  run `bintrail snapshot` against the source, then check the daemon log.")
@@ -904,6 +919,30 @@ func lastCaptureSkip(skips map[string]CaptureSkipStat) time.Time {
 	return last
 }
 
+// lastCaptureSkipAttribution formats the newest attributed skip (#999) for the
+// DEGRADED block: "file:pos (STATEMENT_TYPE, connection id N)". "" when no stat
+// carries attribution (pre-#999 ledger, or only unattributed reasons).
+func lastCaptureSkipAttribution(skips map[string]CaptureSkipStat) string {
+	var best CaptureSkipStat
+	found := false
+	for _, st := range skips {
+		if st.LastFile == "" && st.LastStatementType == "" {
+			continue
+		}
+		if !found || st.LastAt.After(best.LastAt) {
+			best, found = st, true
+		}
+	}
+	if !found {
+		return ""
+	}
+	s := fmt.Sprintf("%s:%d", best.LastFile, best.LastPos)
+	if best.LastStatementType != "" {
+		s += fmt.Sprintf(" (%s, connection id %d)", best.LastStatementType, best.LastConnectionID)
+	}
+	return s
+}
+
 // captureSkipReasons renders the non-zero reasons for the DEGRADED line: the
 // bare reason when there is one ("column_count_mismatch", the #1034 wording),
 // else "reason: count" pairs sorted by count descending (ties alphabetical).
@@ -1029,6 +1068,12 @@ func writeStatusJSONFull(w io.Writer, files []IndexStateRow, parts []PartitionSt
 	type jsonSkipStat struct {
 		Count  int64  `json:"count"`
 		LastAt string `json:"last_at"`
+		// Last-seen attribution (#999); present only for reasons the capture
+		// daemon stamps (today statement_format_dml).
+		LastFile          string `json:"last_file,omitempty"`
+		LastPos           uint64 `json:"last_pos,omitempty"`
+		LastStatementType string `json:"last_statement_type,omitempty"`
+		LastConnectionID  uint32 `json:"last_connection_id,omitempty"`
 	}
 	type jsonCaptureHealth struct {
 		Status       string                  `json:"status"`
@@ -1176,7 +1221,14 @@ func writeStatusJSONFull(w io.Writer, files []IndexStateRow, parts []PartitionSt
 				ch.Skipped = make(map[string]jsonSkipStat, len(skips))
 				for r, st := range skips {
 					if st.Count > 0 {
-						ch.Skipped[r] = jsonSkipStat{Count: st.Count, LastAt: st.LastAt.Format(TSFmt)}
+						ch.Skipped[r] = jsonSkipStat{
+							Count:             st.Count,
+							LastAt:            st.LastAt.Format(TSFmt),
+							LastFile:          st.LastFile,
+							LastPos:           st.LastPos,
+							LastStatementType: st.LastStatementType,
+							LastConnectionID:  st.LastConnectionID,
+						}
 					}
 				}
 			}


### PR DESCRIPTION
closes #999

## Summary
- `parser.SkipStat` gains optional last-seen attribution (`last_file`, `last_pos`, `last_statement_type`, `last_connection_id`, all `omitempty` — old persisted ledgers decode unchanged); new `RecordSkipAttributed` stamps it, `RecordSkip` stays as an unattributed wrapper that never wipes a previous lead. Statement text is never stored (it embeds row VALUES).
- The statement-DML detection site in `StreamParser.Run` (already #1000-scoped) now stamps the same four fields the ephemeral WARN carries.
- `status` renders the attribution: text adds a `Last drop: binlog.000042:99012 (UPDATE, connection id 55)` line inside the DEGRADED block; JSON mirrors the fields per reason (`omitempty`).
- `--fail-on-gap` now also fails closed on a non-zero in-scope `statement_format_dml` count — the same permanent-loss class as `gap_lost`, with the last-drop attribution in the error. An **unknown** capture ledger deliberately does NOT alert (the column post-dates the flag; alerting on absence would fail every pre-#1034 deployment's cron overnight — the break-nothing line).
- Docs: `rotation-and-status.md` covers the attribution and the new exit condition.

## Caveat
Ledgers persisted BEFORE #1000 (PR #1185) may carry `rdsadmin` noise already accumulated in `statement_format_dml`; under this change those deployments alert until the operator resolves/resets the ledger. Post-#1000 daemons only count in-scope drops, so the alert is genuine going forward.

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`; parser/status/cli also with `-race`)
- [x] `go vet ./...` and `go vet -tags integration ./...`
- [x] Integration: `TestRunStatus_failOnGap_exitCode` extended (drop → non-zero exit with attribution; flag off → 0; clean `{}` ledger → 0) and run green against Docker MySQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)
