### PR TITLE
Export continuity, verify, and rotation health as Prometheus gauges

### DIFF
--- a/consoleapp/health_gauges_test.go
+++ b/consoleapp/health_gauges_test.go
@@ -1,0 +1,160 @@
+package consoleapp
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/dbtrail/dbtrail/internal/console"
+	"github.com/dbtrail/dbtrail/internal/notify"
+	"github.com/dbtrail/dbtrail/internal/observe"
+)
+
+// gatherGauge reads one series from the process-global default registry —
+// the same registry /metrics serves, so these tests assert what an operator
+// actually scrapes.
+func gatherGauge(t *testing.T, metric string, labels map[string]string) (float64, bool) {
+	t.Helper()
+	mfs, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, mf := range mfs {
+		if mf.GetName() != metric {
+			continue
+		}
+	metrics:
+		for _, m := range mf.GetMetric() {
+			got := make(map[string]string)
+			for _, lp := range m.GetLabel() {
+				got[lp.GetName()] = lp.GetValue()
+			}
+			for k, v := range labels {
+				if got[k] != v {
+					continue metrics
+				}
+			}
+			return m.GetGauge().GetValue(), true
+		}
+	}
+	return 0, false
+}
+
+// TestVerifyFinishObservers_publishesGauges pins the wiring the feature IS:
+// a publishable run lands on /metrics, and a later failed run does NOT
+// overwrite it (zeroed counts would auto-resolve a live mismatch alert;
+// a refreshed timestamp would silence the staleness alert).
+func TestVerifyFinishObservers_publishesGauges(t *testing.T) {
+	const server = "gauge-wp-1205"
+	rec := console.VerifyRunRecord{ServerID: "sg1", ServerName: server,
+		VerifyStatus: console.VerifyStatus{State: "succeeded", FinishedAt: "2026-08-02T12:00:00Z",
+			Summary: console.VerifySummary{Match: 3, Mismatch: 2, Total: 5}}}
+	verifyFinishObservers(nil)(rec)
+
+	if got, ok := gatherGauge(t, "bintrail_verify_tables", map[string]string{"server": server, "status": "mismatch"}); !ok || got != 2 {
+		t.Fatalf("mismatch gauge = %v (found=%v), want 2", got, ok)
+	}
+	ts, ok := gatherGauge(t, "bintrail_verify_last_run_timestamp_seconds", map[string]string{"server": server})
+	if !ok || ts == 0 {
+		t.Fatalf("last_run gauge missing after a publishable run (found=%v, ts=%v)", ok, ts)
+	}
+
+	// A failed run must leave every series untouched.
+	verifyFinishObservers(nil)(console.VerifyRunRecord{ServerID: "sg1", ServerName: server,
+		VerifyStatus: console.VerifyStatus{State: "failed", FinishedAt: "2026-08-02T13:00:00Z", LastError: "boom"}})
+	if got, _ := gatherGauge(t, "bintrail_verify_tables", map[string]string{"server": server, "status": "mismatch"}); got != 2 {
+		t.Fatalf("failed run overwrote the mismatch gauge: %v", got)
+	}
+	if got, _ := gatherGauge(t, "bintrail_verify_last_run_timestamp_seconds", map[string]string{"server": server}); got != ts {
+		t.Fatalf("failed run refreshed the timestamp: %v -> %v (staleness alert silenced)", ts, got)
+	}
+	observe.DeleteVerifyOutcome(server)
+}
+
+// TestSeedVerifyGauges: seeding selects the newest PUBLISHABLE record and
+// labels it with the server's CURRENT name — never the name captured in the
+// historical record (a pre-rename label would join with nothing).
+func TestSeedVerifyGauges(t *testing.T) {
+	reg := testRegistryWithEntries(t, console.ServerEntry{Name: "new-name-1205", DSN: "dsn-x"})
+	id := reg.List()[0].ID
+	hist, err := console.OpenVerifyHistory(filepath.Join(t.TempDir(), "h.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	older := console.VerifyRunRecord{ServerID: id, ServerName: "old-name-1205",
+		VerifyStatus: console.VerifyStatus{State: "succeeded", FinishedAt: "2026-08-01T10:00:00Z",
+			Summary: console.VerifySummary{Match: 7, Total: 7}}}
+	newestButFailed := console.VerifyRunRecord{ServerID: id, ServerName: "old-name-1205",
+		VerifyStatus: console.VerifyStatus{State: "failed", FinishedAt: "2026-08-02T10:00:00Z", LastError: "boom"}}
+	if err := hist.Append(older); err != nil {
+		t.Fatal(err)
+	}
+	if err := hist.Append(newestButFailed); err != nil {
+		t.Fatal(err)
+	}
+
+	seedVerifyGauges(reg, hist)
+	if got, ok := gatherGauge(t, "bintrail_verify_tables", map[string]string{"server": "new-name-1205", "status": "match"}); !ok || got != 7 {
+		t.Fatalf("seed must publish the newest PUBLISHABLE run under the CURRENT name: got %v found=%v", got, ok)
+	}
+	if _, ok := gatherGauge(t, "bintrail_verify_last_run_timestamp_seconds", map[string]string{"server": "old-name-1205"}); ok {
+		t.Fatal("seed resurrected the pre-rename label from the historical record")
+	}
+	observe.DeleteVerifyOutcome("new-name-1205")
+}
+
+// TestContinuityWatcher_runCycle drives the poller cycle with an injected
+// readGap — pinning the gauge publication, the nil-notifier path, the
+// unknown-unpublishes rule, and the departed-server cleanup (which also
+// unpublishes the departed server's VERIFY series).
+func TestContinuityWatcher_runCycle(t *testing.T) {
+	reg := testRegistryWithEntries(t,
+		console.ServerEntry{Name: "cw-a", DSN: "dsn-cw-a"},
+		console.ServerEntry{Name: "cw-b", DSN: "dsn-cw-b"},
+	)
+	w := &continuityWatcher{
+		registry:    reg, // n is nil: the Prometheus-only deployment must not panic
+		unknownEdge: notify.NewEdge(0),
+		prevNames:   make(map[string]bool),
+		readGap: func(_ context.Context, dsn string) (bool, string, error) {
+			if dsn == "dsn-cw-b" {
+				return false, "", errors.New("unknown column 'gap_lost_at'")
+			}
+			return true, "binlog gap", nil
+		},
+	}
+	w.runCycle(context.Background())
+	if got, ok := gatherGauge(t, "bintrail_continuity_gap_lost", map[string]string{"server": "cw-a"}); !ok || got != 1 {
+		t.Fatalf("gap_lost for cw-a = %v (found=%v), want 1", got, ok)
+	}
+	if _, ok := gatherGauge(t, "bintrail_continuity_gap_lost", map[string]string{"server": "cw-b"}); ok {
+		t.Fatal("unknowable index published a gauge — unknown must never read as a verdict")
+	}
+
+	// Delete cw-a and seed a verify series under its name: the next cycle
+	// must unpublish BOTH families, not freeze them at their last value.
+	observe.SetVerifyOutcome("cw-a", timeMustParse(t, "2026-08-02T10:00:00Z"), 1, 0, 0, 0)
+	if err := reg.Delete(reg.List()[0].ID); err != nil {
+		t.Fatal(err)
+	}
+	w.runCycle(context.Background())
+	if _, ok := gatherGauge(t, "bintrail_continuity_gap_lost", map[string]string{"server": "cw-a"}); ok {
+		t.Fatal("departed server's continuity series froze instead of unpublishing")
+	}
+	if _, ok := gatherGauge(t, "bintrail_verify_last_run_timestamp_seconds", map[string]string{"server": "cw-a"}); ok {
+		t.Fatal("departed server's verify series froze instead of unpublishing")
+	}
+}
+
+func timeMustParse(t *testing.T, s string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return parsed
+}

--- a/consoleapp/notify.go
+++ b/consoleapp/notify.go
@@ -194,6 +194,10 @@ func (n *watchNotifier) Continuity(server, edgeKey string, gapLost bool, detail 
 	n.send.Notify(ev)
 }
 
+// bootContinuityName labels the command-line boot index in continuity/verify
+// gauges and webhook events.
+const bootContinuityName = "cli index"
+
 // continuityTarget is one index DB the watcher polls.
 type continuityTarget struct {
 	name string
@@ -208,60 +212,15 @@ type continuityTarget struct {
 // then serves the pull path only (started under --metrics-addr without
 // --notify-webhook).
 func startContinuityWatch(ctx context.Context, n *watchNotifier, registry *console.Registry, bootDSN string) {
-	// The unknown-warn rate limit gets its own edge so it works with a nil
-	// notifier too.
-	unknownEdge := notify.NewEdge(0)
-	// prevNames remembers the labels published last cycle so a renamed or
-	// deleted server's gauges are UNPUBLISHED, not frozen at their last value
-	// (a stale gap_lost=1 would alert forever; a stale gap_lost=0 would read
-	// "evaluated, healthy" for an index nobody evaluates). Poller-goroutine
-	// only.
-	prevNames := make(map[string]bool)
+	w := &continuityWatcher{
+		n: n, registry: registry, bootDSN: bootDSN,
+		unknownEdge: notify.NewEdge(0),
+		prevNames:   make(map[string]bool),
+		readGap:     readGapLost,
+	}
 	go func() {
-		runCycle := func() {
-			defer func() {
-				if r := recover(); r != nil {
-					slog.Error("continuity watch cycle panicked; watching continues next tick", "panic", r)
-				}
-			}()
-			targets := continuityTargets(registry, bootDSN)
-			curNames := make(map[string]bool, len(targets))
-			for _, t := range targets {
-				curNames[t.name] = true
-			}
-			for name := range prevNames {
-				if !curNames[name] {
-					observe.ClearContinuity(name)
-					observe.DeleteVerifyOutcome(name)
-				}
-			}
-			prevNames = curNames
-			for _, t := range targets {
-				if ctx.Err() != nil {
-					return
-				}
-				gapLost, detail, err := readGapLost(ctx, t.dsn)
-				if err != nil {
-					// Unknown is never "no gap" — and never silent either: a
-					// watcher that cannot watch is itself a coverage hole. The
-					// gauge is UNPUBLISHED (never a healthy 0) and the edge
-					// keeps the warning to one per day per index.
-					observe.ClearContinuity(t.name)
-					if unknownEdge.Fire("continuity-unknown:"+t.dsn, "") {
-						slog.Warn("continuity watch cannot evaluate this index (unreachable, or a legacy schema without the gap columns) — gap_lost will NOT be detected for it",
-							"server", t.name, "error", err)
-					}
-					continue
-				}
-				unknownEdge.Resolve("continuity-unknown:" + t.dsn)
-				observe.SetContinuityGapLost(t.name, gapLost)
-				if n != nil {
-					n.Continuity(t.name, t.dsn, gapLost, detail)
-				}
-			}
-		}
 		if ctx.Err() == nil {
-			runCycle()
+			w.runCycle(ctx)
 		}
 		tick := time.NewTicker(continuityPollInterval)
 		defer tick.Stop()
@@ -270,10 +229,87 @@ func startContinuityWatch(ctx context.Context, n *watchNotifier, registry *conso
 			case <-ctx.Done():
 				return
 			case <-tick.C:
-				runCycle()
+				w.runCycle(ctx)
 			}
 		}
 	}()
+}
+
+// continuityWatcher is the poller's state, split from the goroutine so a unit
+// test can drive cycles with an injected readGap — no ticker, no real DB.
+// All fields are touched only by the poller goroutine (or the test driving
+// runCycle directly).
+type continuityWatcher struct {
+	n        *watchNotifier // nil = gauge-only (started under --metrics-addr alone)
+	registry *console.Registry
+	bootDSN  string
+
+	// unknownEdge rate-limits the cannot-evaluate warning (one per day per
+	// index) — its own edge so it works with a nil notifier too.
+	unknownEdge *notify.Edge
+	// prevNames: every gauge label this watcher owned after the last cycle —
+	// the boot label plus ALL registry entry names (not the DSN-deduped poll
+	// targets: a second entry sharing a DSN still publishes verify gauges
+	// under its own name and must be cleaned up when it goes). A renamed or
+	// deleted server's gauges are UNPUBLISHED, not frozen at their last value
+	// (a stale gap_lost=1 would alert forever; a stale gap_lost=0 would read
+	// "evaluated, healthy" for an index nobody evaluates).
+	prevNames map[string]bool
+	readGap   func(ctx context.Context, dsn string) (gapLost bool, detail string, err error)
+}
+
+func (w *continuityWatcher) runCycle(ctx context.Context) {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("continuity watch cycle panicked; watching continues next tick", "panic", r)
+		}
+	}()
+	curNames := w.ownedNames()
+	for name := range w.prevNames {
+		if !curNames[name] {
+			observe.ClearContinuity(name)
+			observe.DeleteVerifyOutcome(name)
+		}
+	}
+	w.prevNames = curNames
+	for _, t := range continuityTargets(w.registry, w.bootDSN) {
+		if ctx.Err() != nil {
+			return
+		}
+		gapLost, detail, err := w.readGap(ctx, t.dsn)
+		if err != nil {
+			// Unknown is never "no gap" — and never silent either: a watcher
+			// that cannot watch is itself a coverage hole. The gauge is
+			// UNPUBLISHED (never a healthy 0) and the edge keeps the warning
+			// to one per day per index.
+			observe.ClearContinuity(t.name)
+			if w.unknownEdge.Fire("continuity-unknown:"+t.dsn, "") {
+				slog.Warn("continuity watch cannot evaluate this index (unreachable, or a legacy schema without the gap columns) — gap_lost will NOT be detected for it",
+					"server", t.name, "error", err)
+			}
+			continue
+		}
+		w.unknownEdge.Resolve("continuity-unknown:" + t.dsn)
+		observe.SetContinuityGapLost(t.name, gapLost)
+		if w.n != nil {
+			w.n.Continuity(t.name, t.dsn, gapLost, detail)
+		}
+	}
+}
+
+// ownedNames is the full set of gauge labels this watcher is responsible
+// for cleaning up — see prevNames.
+func (w *continuityWatcher) ownedNames() map[string]bool {
+	out := make(map[string]bool)
+	if w.bootDSN != "" {
+		out[bootContinuityName] = true
+	}
+	if w.registry != nil {
+		for _, e := range w.registry.List() {
+			out[e.Name] = true
+		}
+	}
+	return out
 }
 
 // continuityTargets enumerates the boot index (when watch was given one) plus
@@ -283,7 +319,7 @@ func continuityTargets(registry *console.Registry, bootDSN string) []continuityT
 	var out []continuityTarget
 	seen := make(map[string]bool)
 	if bootDSN != "" {
-		out = append(out, continuityTarget{name: "cli index", dsn: bootDSN})
+		out = append(out, continuityTarget{name: bootContinuityName, dsn: bootDSN})
 		seen[bootDSN] = true
 	}
 	if registry != nil {

--- a/consoleapp/notify.go
+++ b/consoleapp/notify.go
@@ -13,6 +13,7 @@ import (
 	"github.com/dbtrail/dbtrail/internal/config"
 	"github.com/dbtrail/dbtrail/internal/console"
 	"github.com/dbtrail/dbtrail/internal/notify"
+	"github.com/dbtrail/dbtrail/internal/observe"
 )
 
 // continuityPollInterval is how often the continuity watcher re-reads each
@@ -56,13 +57,15 @@ func newWatchNotifierFromFlags(ctx context.Context) (*watchNotifier, error) {
 	return newWatchNotifier(ctx, upNotifyWebhook), nil
 }
 
-// rotationNotifyHooks adapts an optional notifier to rotation.StartLoop's
-// variadic onCycle parameter.
-func rotationNotifyHooks(n *watchNotifier) []func(failed bool, deferred int) {
-	if n == nil {
-		return nil
+// rotationCycleHooks builds rotation.StartLoop's onCycle callbacks: the
+// health gauge always (#1203 — it publishes only once a cycle actually runs),
+// plus the webhook notifier when configured.
+func rotationCycleHooks(n *watchNotifier) []func(failed bool, deferred int) {
+	hooks := []func(bool, int){observe.SetRotationHealth}
+	if n != nil {
+		hooks = append(hooks, n.RotationCycle)
 	}
-	return []func(bool, int){n.RotationCycle}
+	return hooks
 }
 
 // VerifyFinished is the verifySupervisor.onFinish hook: it fires on runs that
@@ -198,10 +201,16 @@ type continuityTarget struct {
 }
 
 // startContinuityWatch polls each index's stream_state for a stamped
-// gap_lost_at and edge-notifies transitions. Its own loop — deliberately NOT
-// piggybacked on rotation (rotation can be off) or the metrics scraper
-// (metrics can be off, and it lives in the capture plane).
+// gap_lost_at, publishes the verdict as a Prometheus gauge (#1203), and —
+// when a notifier is configured — edge-notifies transitions. Its own loop,
+// deliberately NOT piggybacked on rotation (rotation can be off) or the
+// metrics scraper (it lives in the capture plane). n may be nil: the watch
+// then serves the pull path only (started under --metrics-addr without
+// --notify-webhook).
 func startContinuityWatch(ctx context.Context, n *watchNotifier, registry *console.Registry, bootDSN string) {
+	// The unknown-warn rate limit gets its own edge so it works with a nil
+	// notifier too.
+	unknownEdge := notify.NewEdge(0)
 	go func() {
 		runCycle := func() {
 			defer func() {
@@ -217,15 +226,20 @@ func startContinuityWatch(ctx context.Context, n *watchNotifier, registry *conso
 				if err != nil {
 					// Unknown is never "no gap" — and never silent either: a
 					// watcher that cannot watch is itself a coverage hole. The
-					// edge keeps this to one warning per day per index.
-					if n.edge.Fire("continuity-unknown:"+t.dsn, "") {
+					// gauge is UNPUBLISHED (never a healthy 0) and the edge
+					// keeps the warning to one per day per index.
+					observe.ClearContinuity(t.name)
+					if unknownEdge.Fire("continuity-unknown:"+t.dsn, "") {
 						slog.Warn("continuity watch cannot evaluate this index (unreachable, or a legacy schema without the gap columns) — gap_lost will NOT be detected for it",
 							"server", t.name, "error", err)
 					}
 					continue
 				}
-				n.edge.Resolve("continuity-unknown:" + t.dsn)
-				n.Continuity(t.name, t.dsn, gapLost, detail)
+				unknownEdge.Resolve("continuity-unknown:" + t.dsn)
+				observe.SetContinuityGapLost(t.name, gapLost)
+				if n != nil {
+					n.Continuity(t.name, t.dsn, gapLost, detail)
+				}
 			}
 		}
 		if ctx.Err() == nil {

--- a/consoleapp/notify.go
+++ b/consoleapp/notify.go
@@ -211,6 +211,12 @@ func startContinuityWatch(ctx context.Context, n *watchNotifier, registry *conso
 	// The unknown-warn rate limit gets its own edge so it works with a nil
 	// notifier too.
 	unknownEdge := notify.NewEdge(0)
+	// prevNames remembers the labels published last cycle so a renamed or
+	// deleted server's gauges are UNPUBLISHED, not frozen at their last value
+	// (a stale gap_lost=1 would alert forever; a stale gap_lost=0 would read
+	// "evaluated, healthy" for an index nobody evaluates). Poller-goroutine
+	// only.
+	prevNames := make(map[string]bool)
 	go func() {
 		runCycle := func() {
 			defer func() {
@@ -218,7 +224,19 @@ func startContinuityWatch(ctx context.Context, n *watchNotifier, registry *conso
 					slog.Error("continuity watch cycle panicked; watching continues next tick", "panic", r)
 				}
 			}()
-			for _, t := range continuityTargets(registry, bootDSN) {
+			targets := continuityTargets(registry, bootDSN)
+			curNames := make(map[string]bool, len(targets))
+			for _, t := range targets {
+				curNames[t.name] = true
+			}
+			for name := range prevNames {
+				if !curNames[name] {
+					observe.ClearContinuity(name)
+					observe.DeleteVerifyOutcome(name)
+				}
+			}
+			prevNames = curNames
+			for _, t := range targets {
 				if ctx.Err() != nil {
 					return
 				}

--- a/consoleapp/notify_test.go
+++ b/consoleapp/notify_test.go
@@ -192,18 +192,34 @@ func testRegistryWithEntries(t *testing.T, entries ...console.ServerEntry) *cons
 	return reg
 }
 
-func TestRotationNotifyHooks(t *testing.T) {
-	if hooks := rotationNotifyHooks(nil); hooks != nil {
-		t.Fatalf("nil notifier must yield no hooks, got %d", len(hooks))
+func TestRotationCycleHooks(t *testing.T) {
+	// The gauge hook is always present (#1203) — it publishes only when a
+	// cycle actually runs; the notifier hook joins it when configured.
+	if hooks := rotationCycleHooks(nil); len(hooks) != 1 {
+		t.Fatalf("nil notifier must still yield the gauge hook, got %d", len(hooks))
 	}
 	n, f := testNotifier()
-	hooks := rotationNotifyHooks(n)
-	if len(hooks) != 1 {
-		t.Fatalf("want 1 hook, got %d", len(hooks))
+	hooks := rotationCycleHooks(n)
+	if len(hooks) != 2 {
+		t.Fatalf("want gauge + notifier hooks, got %d", len(hooks))
 	}
-	hooks[0](true, 0)
+	hooks[1](true, 0)
 	if len(f.events) != 1 {
-		t.Fatalf("hook is not wired to the notifier: %+v", f.events)
+		t.Fatalf("notifier hook is not wired: %+v", f.events)
+	}
+}
+
+// TestVerifyFinishObservers: gauges never panic without a notifier, and the
+// notifier still receives the record when configured.
+func TestVerifyFinishObservers(t *testing.T) {
+	rec := console.VerifyRunRecord{ServerID: "s1", ServerName: "wp",
+		VerifyStatus: console.VerifyStatus{State: "succeeded", FinishedAt: "2026-08-02T12:00:00Z",
+			Summary: console.VerifySummary{Mismatch: 1, Total: 1}}}
+	verifyFinishObservers(nil)(rec) // must not panic
+	n, f := testNotifier()
+	verifyFinishObservers(n)(rec)
+	if len(f.events) != 1 {
+		t.Fatalf("notifier must observe the record: %+v", f.events)
 	}
 }
 

--- a/consoleapp/notify_test.go
+++ b/consoleapp/notify_test.go
@@ -209,6 +209,36 @@ func TestRotationCycleHooks(t *testing.T) {
 	}
 }
 
+// TestVerifyRunPublishable: only a succeeded run that conclusively verified
+// at least one table may reach the gauges — a failed, zero-table, or
+// all-inconclusive run overwriting the counts would auto-resolve a live
+// mismatch alert and keep the staleness alert quiet while verification is
+// broken (the gauge-path twin of the webhook's clean/problem split).
+func TestVerifyRunPublishable(t *testing.T) {
+	rec := func(state string, match, mismatch, inconclusive, total int) console.VerifyRunRecord {
+		return console.VerifyRunRecord{VerifyStatus: console.VerifyStatus{State: state,
+			Summary: console.VerifySummary{Match: match, Mismatch: mismatch, Inconclusive: inconclusive, Total: total}}}
+	}
+	cases := []struct {
+		name string
+		rec  console.VerifyRunRecord
+		want bool
+	}{
+		{"clean run", rec("succeeded", 5, 0, 0, 5), true},
+		{"mismatch run still publishes (the alert must fire)", rec("succeeded", 3, 2, 0, 5), true},
+		{"partially inconclusive publishes", rec("succeeded", 3, 0, 2, 5), true},
+		{"failed run must not publish", rec("failed", 0, 0, 0, 0), false},
+		{"zero-table run must not publish", rec("succeeded", 0, 0, 0, 0), false},
+		{"all-inconclusive must not publish", rec("succeeded", 0, 0, 5, 5), false},
+		{"skip record must not publish", rec(console.VerifyStateSkipped, 0, 0, 0, 0), false},
+	}
+	for _, tc := range cases {
+		if got := verifyRunPublishable(tc.rec); got != tc.want {
+			t.Errorf("%s: publishable = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
 // TestVerifyFinishObservers: gauges never panic without a notifier, and the
 // notifier still receives the record when configured.
 func TestVerifyFinishObservers(t *testing.T) {

--- a/consoleapp/verify_wiring_test.go
+++ b/consoleapp/verify_wiring_test.go
@@ -84,8 +84,10 @@ func TestWireVerify_wiring(t *testing.T) {
 	if !ok || cfg.VerifyHistory == nil {
 		t.Fatalf("trigger env must wire supervisor + history: %+v", cfg)
 	}
-	if sup.onFinish != nil {
-		t.Fatal("nil notifier must leave onFinish disconnected")
+	// onFinish is always wired since #1203 (health gauges observe every run,
+	// notifier or not).
+	if sup.onFinish == nil {
+		t.Fatal("onFinish must always be wired (gauges)")
 	}
 
 	// A schedule alone implies the supervisor (no separate VERIFY_TRIGGER).

--- a/consoleapp/watch.go
+++ b/consoleapp/watch.go
@@ -24,6 +24,7 @@ import (
 	"github.com/dbtrail/dbtrail/internal/console"
 	"github.com/dbtrail/dbtrail/internal/doctor"
 	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/observe"
 	"github.com/dbtrail/dbtrail/internal/rotation"
 	"github.com/dbtrail/dbtrail/internal/serverid"
 	"github.com/dbtrail/dbtrail/internal/streamdeps"
@@ -432,7 +433,10 @@ func runUpConsoleOnly(cmd *cobra.Command) error {
 	if err := wireVerify(ctx, &cfg, registry, serversPath, notifier); err != nil {
 		return err
 	}
-	if notifier != nil {
+	// The continuity watch serves two channels: webhook events (notifier) and
+	// the Prometheus gauge (#1203). Either one being enabled starts it; with
+	// neither, nothing runs.
+	if notifier != nil || upMetricsAddr != "" {
 		startContinuityWatch(ctx, notifier, registry, upIndexDSN)
 	}
 
@@ -442,7 +446,7 @@ func runUpConsoleOnly(cmd *cobra.Command) error {
 	// retune retain/interval/add-future without a restart.
 	rotation.StartLoop(ctx, rotationSettingsProvider(registry), func() []rotation.RotateTarget {
 		return rotateTargets(upIndexDSN, supervisor, registry, archiveStagingDir())
-	}, rotationNotifyHooks(notifier)...)
+	}, rotationCycleHooks(notifier)...)
 
 	// Reclaim local baseline snapshots that already have a durable S3 copy (#616):
 	// the global --baseline-dir plus every registry server's per-server dir.
@@ -594,7 +598,10 @@ func runUpStreamWithConsole(cmd *cobra.Command, args []string) error {
 	if err := wireVerify(ctx, &cfg, registry, serversPath, notifier); err != nil {
 		return err
 	}
-	if notifier != nil {
+	// The continuity watch serves two channels: webhook events (notifier) and
+	// the Prometheus gauge (#1203). Either one being enabled starts it; with
+	// neither, nothing runs.
+	if notifier != nil || upMetricsAddr != "" {
 		startContinuityWatch(ctx, notifier, registry, upIndexDSN)
 	}
 
@@ -603,7 +610,7 @@ func runUpStreamWithConsole(cmd *cobra.Command, args []string) error {
 	// console can retune retain/interval/add-future without a restart.
 	rotation.StartLoop(ctx, rotationSettingsProvider(registry), func() []rotation.RotateTarget {
 		return rotateTargets(upIndexDSN, supervisor, registry, archiveStagingDir())
-	}, rotationNotifyHooks(notifier)...)
+	}, rotationCycleHooks(notifier)...)
 
 	// Reclaim local baseline snapshots that already have a durable S3 copy (#616):
 	// the global --baseline-dir plus every registry server's per-server dir.
@@ -875,17 +882,58 @@ func wireVerify(ctx context.Context, cfg *console.Config, registry *console.Regi
 		slog.Error("verify history unavailable; runs will NOT be recorded and the history endpoint will refuse — fix or move the file and restart", "error", err)
 		history = nil
 	}
-	var onFinish func(console.VerifyRunRecord)
-	if notifier != nil {
-		onFinish = notifier.VerifyFinished
-	}
-	sup := newVerifySupervisor(ctx, history, onFinish)
+	sup := newVerifySupervisor(ctx, history, verifyFinishObservers(notifier))
+	seedVerifyGauges(registry, history)
 	cfg.VerifyCtrl = sup
 	cfg.VerifyHistory = history
 	if interval > 0 {
 		startVerifyLoop(ctx, sup, registry, history, interval, splitVerifyTables(upVerifyTables))
 	}
 	return nil
+}
+
+// verifyFinishObservers composes the supervisor's finish hook: the health
+// gauges always (#1203), the webhook notifier when configured. Both observe
+// the same record history gets.
+func verifyFinishObservers(notifier *watchNotifier) func(console.VerifyRunRecord) {
+	return func(rec console.VerifyRunRecord) {
+		setVerifyGauges(rec)
+		if notifier != nil {
+			notifier.VerifyFinished(rec)
+		}
+	}
+}
+
+// setVerifyGauges publishes one finished run. Skip records are bookkeeping,
+// not runs; a record without a parseable finish stamp is not publishable.
+func setVerifyGauges(rec console.VerifyRunRecord) {
+	if rec.State == console.VerifyStateSkipped {
+		return
+	}
+	finished, err := time.Parse(time.RFC3339, rec.FinishedAt)
+	if err != nil {
+		return
+	}
+	s := rec.Summary
+	observe.SetVerifyOutcome(rec.ServerName, finished, s.Match, s.Mismatch, s.Inconclusive, s.Error)
+}
+
+// seedVerifyGauges republishes each registry server's newest persisted run at
+// startup (#1203) — the pull path survives restarts exactly like the console
+// panel does, from the same history.
+func seedVerifyGauges(registry *console.Registry, history *console.VerifyHistory) {
+	if registry == nil || history == nil {
+		return
+	}
+	for _, e := range registry.List() {
+		for _, rec := range history.List(e.ID) {
+			if rec.State == console.VerifyStateSkipped {
+				continue
+			}
+			setVerifyGauges(rec)
+			break
+		}
+	}
 }
 
 // splitVerifyTables parses the comma-separated --verify-tables list; empty

--- a/consoleapp/watch.go
+++ b/consoleapp/watch.go
@@ -910,8 +910,11 @@ func verifyFinishObservers(notifier *watchNotifier) func(console.VerifyRunRecord
 // yet"), or an all-inconclusive run must NOT overwrite the last real verdict:
 // zeroed counts would auto-resolve a live mismatch alert, and a refreshed
 // timestamp would keep the staleness alert quiet while verification is in
-// fact broken. Same rule as the webhook path's clean/problem split
-// (watchNotifier.VerifyFinished) and Report.ExitError.
+// fact broken. It recognizes the same degenerate-run shapes as the webhook's
+// clean/problem split (watchNotifier.VerifyFinished) and Report.ExitError,
+// but the VERDICTS differ by design: the webhook still notifies on
+// failed/all-inconclusive runs, and the gauges publish mismatch runs (the
+// alert must fire) — do not extract one shared predicate.
 func verifyRunPublishable(rec console.VerifyRunRecord) bool {
 	s := rec.Summary
 	return rec.State == "succeeded" && s.Total > 0 && s.Inconclusive < s.Total
@@ -933,8 +936,9 @@ func setVerifyGauges(rec console.VerifyRunRecord, server string) {
 }
 
 // seedVerifyGauges republishes each registry server's newest publishable run
-// at startup (#1203) — the pull path survives restarts exactly like the
-// console panel does, from the same history.
+// at startup (#1203) — the pull path survives restarts, reading the same
+// history the console panel reads (the panel additionally shows failed runs;
+// the gauges only carry conclusive verdicts).
 func seedVerifyGauges(registry *console.Registry, history *console.VerifyHistory) {
 	if registry == nil || history == nil {
 		return

--- a/consoleapp/watch.go
+++ b/consoleapp/watch.go
@@ -897,17 +897,31 @@ func wireVerify(ctx context.Context, cfg *console.Config, registry *console.Regi
 // the same record history gets.
 func verifyFinishObservers(notifier *watchNotifier) func(console.VerifyRunRecord) {
 	return func(rec console.VerifyRunRecord) {
-		setVerifyGauges(rec)
+		setVerifyGauges(rec, rec.ServerName)
 		if notifier != nil {
 			notifier.VerifyFinished(rec)
 		}
 	}
 }
 
-// setVerifyGauges publishes one finished run. Skip records are bookkeeping,
-// not runs; a record without a parseable finish stamp is not publishable.
-func setVerifyGauges(rec console.VerifyRunRecord) {
-	if rec.State == console.VerifyStateSkipped {
+// verifyRunPublishable reports whether a record carries a verdict the gauges
+// may publish. Only a succeeded run that verified at least one table
+// conclusively counts — a failed run, a zero-table run ("only one baseline
+// yet"), or an all-inconclusive run must NOT overwrite the last real verdict:
+// zeroed counts would auto-resolve a live mismatch alert, and a refreshed
+// timestamp would keep the staleness alert quiet while verification is in
+// fact broken. Same rule as the webhook path's clean/problem split
+// (watchNotifier.VerifyFinished) and Report.ExitError.
+func verifyRunPublishable(rec console.VerifyRunRecord) bool {
+	s := rec.Summary
+	return rec.State == "succeeded" && s.Total > 0 && s.Inconclusive < s.Total
+}
+
+// setVerifyGauges publishes one finished run under the given server label
+// (the CURRENT display name — the seed path must not resurrect a pre-rename
+// name from an old record).
+func setVerifyGauges(rec console.VerifyRunRecord, server string) {
+	if !verifyRunPublishable(rec) {
 		return
 	}
 	finished, err := time.Parse(time.RFC3339, rec.FinishedAt)
@@ -915,22 +929,22 @@ func setVerifyGauges(rec console.VerifyRunRecord) {
 		return
 	}
 	s := rec.Summary
-	observe.SetVerifyOutcome(rec.ServerName, finished, s.Match, s.Mismatch, s.Inconclusive, s.Error)
+	observe.SetVerifyOutcome(server, finished, s.Match, s.Mismatch, s.Inconclusive, s.Error)
 }
 
-// seedVerifyGauges republishes each registry server's newest persisted run at
-// startup (#1203) — the pull path survives restarts exactly like the console
-// panel does, from the same history.
+// seedVerifyGauges republishes each registry server's newest publishable run
+// at startup (#1203) — the pull path survives restarts exactly like the
+// console panel does, from the same history.
 func seedVerifyGauges(registry *console.Registry, history *console.VerifyHistory) {
 	if registry == nil || history == nil {
 		return
 	}
 	for _, e := range registry.List() {
 		for _, rec := range history.List(e.ID) {
-			if rec.State == console.VerifyStateSkipped {
+			if !verifyRunPublishable(rec) {
 				continue
 			}
-			setVerifyGauges(rec)
+			setVerifyGauges(rec, e.Name)
 			break
 		}
 	}

--- a/docs/console.md
+++ b/docs/console.md
@@ -472,8 +472,10 @@ rate-limited log warnings, and an event that could not be delivered is not
 re-queued: the next 24 h edge repeat re-sends a still-active condition. Edge
 state is in-memory — after a daemon restart a still-active condition
 re-fires (loud side errs safe), but a recovery that happened *across* the
-restart produces no `resolved` event. For pull-based alerting on the same
-conditions, see the Prometheus rules in
+restart produces no `resolved` event. The same three conditions are also
+exported as Prometheus gauges under `--metrics-addr`
+(`bintrail_continuity_*` / `bintrail_verify_*` / `bintrail_rotation_*`) —
+see the metrics tables and example alert rules in
 [observability.md](observability.md).
 
 - **AWS credentials** — which ambient credential signals the daemon process

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -164,14 +164,15 @@ A Prometheus gauge for this state is not exposed in this release.
 The `bintrail-console watch` daemon exports its three safety-net conditions —
 the same ones the webhook channel notifies on
 ([console.md](console.md#webhook-notifications)) — as gauges. Each publishes
-only while its feature is actually evaluating; an **absent series means "not
-evaluated", never "healthy"** (the continuity gauge is even unpublished for an
-index the watcher cannot reach, so unknown can never read as no-gap).
+only while its feature is actually producing verdicts; an **absent series
+means "no verdict" — never evaluated, or (for the verify pair) never a
+conclusive run — never "healthy"** (the continuity gauge is even unpublished
+for an index the watcher cannot reach, so unknown can never read as no-gap).
 
 | Metric | Type | Meaning |
 |---|---|---|
 | `bintrail_continuity_gap_lost{server}` | gauge | 1 = the stream stamped a permanent capture gap (events in it are unrecoverable). Runs under `--notify-webhook` and/or `--metrics-addr` |
-| `bintrail_verify_last_run_timestamp_seconds{server}` | gauge | Unix time of the newest finished verify run (manual or scheduled); re-seeded from the persisted run history at startup |
+| `bintrail_verify_last_run_timestamp_seconds{server}` | gauge | Unix time of the newest verify run that **succeeded and conclusively verified at least one table** — failed and all-inconclusive runs do not refresh it, so staleness means verification is broken. Re-seeded from the persisted run history at startup |
 | `bintrail_verify_tables{server,status}` | gauge | Per-status table counts (`match` / `mismatch` / `inconclusive` / `error`) of that run |
 | `bintrail_rotation_healthy` | gauge | 1 = the last built-in rotation cycle neither failed nor deferred unarchived partitions |
 | `bintrail_rotation_deferred_partitions` | gauge | Unarchived partitions the last cycle declined to drop |
@@ -225,7 +226,7 @@ groups:
         expr: time() - bintrail_verify_last_run_timestamp_seconds > 172800
         labels: {severity: warning}
         annotations:
-          summary: "bintrail: no verify run finished in 2 days — scheduled verification may be broken"
+          summary: "bintrail: no verify run succeeded in 2 days — scheduled verification is broken or persistently failing"
       - alert: BintrailRotationUnhealthy
         expr: bintrail_rotation_healthy == 0
         for: 2h

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -159,6 +159,23 @@ A Prometheus gauge for this state is not exposed in this release.
   the stream-continuity verdict.
 - [capacity.md](capacity.md) — sizing math and the `doctor` disk-capacity check.
 
+## Watch health metrics (`bintrail_continuity_*`, `bintrail_verify_*`, `bintrail_rotation_*`)
+
+The `bintrail-console watch` daemon exports its three safety-net conditions —
+the same ones the webhook channel notifies on
+([console.md](console.md#webhook-notifications)) — as gauges. Each publishes
+only while its feature is actually evaluating; an **absent series means "not
+evaluated", never "healthy"** (the continuity gauge is even unpublished for an
+index the watcher cannot reach, so unknown can never read as no-gap).
+
+| Metric | Type | Meaning |
+|---|---|---|
+| `bintrail_continuity_gap_lost{server}` | gauge | 1 = the stream stamped a permanent capture gap (events in it are unrecoverable). Runs under `--notify-webhook` and/or `--metrics-addr` |
+| `bintrail_verify_last_run_timestamp_seconds{server}` | gauge | Unix time of the newest finished verify run (manual or scheduled); re-seeded from the persisted run history at startup |
+| `bintrail_verify_tables{server,status}` | gauge | Per-status table counts (`match` / `mismatch` / `inconclusive` / `error`) of that run |
+| `bintrail_rotation_healthy` | gauge | 1 = the last built-in rotation cycle neither failed nor deferred unarchived partitions |
+| `bintrail_rotation_deferred_partitions` | gauge | Unarchived partitions the last cycle declined to drop |
+
 ## Example Prometheus alert rules
 
 The push-based sibling of these metrics is the watch daemon's
@@ -193,6 +210,28 @@ groups:
         labels: {severity: warning}
         annotations:
           summary: "bintrail stream is logging errors — check the daemon log"
+      - alert: BintrailContinuityGapLost
+        expr: bintrail_continuity_gap_lost == 1
+        labels: {severity: critical}
+        annotations:
+          summary: "bintrail: permanent capture gap — events in it are unrecoverable; re-baseline the stream"
+      - alert: BintrailVerifyProblems
+        expr: bintrail_verify_tables{status=~"mismatch|error"} > 0
+        for: 5m
+        labels: {severity: critical}
+        annotations:
+          summary: "bintrail: the last verify run found mismatched or erroring tables"
+      - alert: BintrailVerifyStale
+        expr: time() - bintrail_verify_last_run_timestamp_seconds > 172800
+        labels: {severity: warning}
+        annotations:
+          summary: "bintrail: no verify run finished in 2 days — scheduled verification may be broken"
+      - alert: BintrailRotationUnhealthy
+        expr: bintrail_rotation_healthy == 0
+        for: 2h
+        labels: {severity: warning}
+        annotations:
+          summary: "bintrail: built-in rotation keeps failing or deferring — the index is growing"
 ```
 
 Tune thresholds to your write rate; on a genuinely idle source the lag gauge

--- a/internal/observe/health.go
+++ b/internal/observe/health.go
@@ -1,0 +1,90 @@
+package observe
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Watch-daemon health gauges (#1203) — the pull-based siblings of the webhook
+// notification channel (#1192): the same three "your safety net has a hole"
+// conditions, exported for Prometheus/Alertmanager.
+//
+// All are *Vec collectors — including the label-less rotation pair — so
+// nothing is published until the daemon actually evaluates the condition:
+// an absent series means "not evaluated", never a misleading healthy zero
+// (the same rule the index timestamp gauges follow for an empty index).
+// The server label is the display name — the same identity the webhook's
+// `server` field and the console UI use.
+var (
+	continuityGapLost = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "bintrail",
+		Subsystem: "continuity",
+		Name:      "gap_lost",
+		Help:      "1 when the stream stamped a permanent capture gap (events in it are unrecoverable); 0 when continuity is intact. Absent while the index cannot be evaluated.",
+	}, []string{"server"})
+
+	verifyLastRun = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "bintrail",
+		Subsystem: "verify",
+		Name:      "last_run_timestamp_seconds",
+		Help:      "Unix time of the newest finished verify run (manual or scheduled) for this server.",
+	}, []string{"server"})
+
+	verifyTables = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "bintrail",
+		Subsystem: "verify",
+		Name:      "tables",
+		Help:      "Per-status table counts of the newest finished verify run.",
+	}, []string{"server", "status"})
+
+	rotationHealthy = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "bintrail",
+		Subsystem: "rotation",
+		Name:      "healthy",
+		Help:      "1 when the last built-in rotation cycle neither failed nor deferred unarchived partitions; 0 otherwise.",
+	}, nil)
+
+	rotationDeferred = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "bintrail",
+		Subsystem: "rotation",
+		Name:      "deferred_partitions",
+		Help:      "Unarchived partitions the last built-in rotation cycle declined to drop.",
+	}, nil)
+)
+
+// SetContinuityGapLost publishes one index's continuity verdict.
+func SetContinuityGapLost(server string, lost bool) {
+	continuityGapLost.WithLabelValues(server).Set(boolGauge(lost))
+}
+
+// ClearContinuity unpublishes a server's continuity gauge — the unknowable
+// case (unreachable index, legacy schema without the gap columns). Unknown is
+// never "no gap", so it must never read as 0.
+func ClearContinuity(server string) {
+	continuityGapLost.DeleteLabelValues(server)
+}
+
+// SetVerifyOutcome publishes the newest finished verify run for a server.
+func SetVerifyOutcome(server string, finishedAt time.Time, match, mismatch, inconclusive, errorCount int) {
+	verifyLastRun.WithLabelValues(server).Set(float64(finishedAt.Unix()))
+	verifyTables.WithLabelValues(server, "match").Set(float64(match))
+	verifyTables.WithLabelValues(server, "mismatch").Set(float64(mismatch))
+	verifyTables.WithLabelValues(server, "inconclusive").Set(float64(inconclusive))
+	verifyTables.WithLabelValues(server, "error").Set(float64(errorCount))
+}
+
+// SetRotationHealth publishes the last rotation cycle's health — the same
+// (failed, deferred) pair rotation.StartLoop's onCycle callbacks observe.
+func SetRotationHealth(failed bool, deferred int) {
+	rotationHealthy.WithLabelValues().Set(boolGauge(!failed && deferred == 0))
+	rotationDeferred.WithLabelValues().Set(float64(deferred))
+}
+
+func boolGauge(b bool) float64 {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/internal/observe/health.go
+++ b/internal/observe/health.go
@@ -66,6 +66,16 @@ func ClearContinuity(server string) {
 	continuityGapLost.DeleteLabelValues(server)
 }
 
+// DeleteVerifyOutcome unpublishes a server's verify gauges — called when the
+// server leaves the registry or is renamed, so a frozen series can never keep
+// alerting (or keep reading healthy) for something nobody evaluates anymore.
+func DeleteVerifyOutcome(server string) {
+	verifyLastRun.DeleteLabelValues(server)
+	for _, status := range []string{"match", "mismatch", "inconclusive", "error"} {
+		verifyTables.DeleteLabelValues(server, status)
+	}
+}
+
 // SetVerifyOutcome publishes the newest finished verify run for a server.
 func SetVerifyOutcome(server string, finishedAt time.Time, match, mismatch, inconclusive, errorCount int) {
 	verifyLastRun.WithLabelValues(server).Set(float64(finishedAt.Unix()))

--- a/internal/observe/health.go
+++ b/internal/observe/health.go
@@ -12,9 +12,10 @@ import (
 // conditions, exported for Prometheus/Alertmanager.
 //
 // All are *Vec collectors — including the label-less rotation pair — so
-// nothing is published until the daemon actually evaluates the condition:
-// an absent series means "not evaluated", never a misleading healthy zero
-// (the same rule the index timestamp gauges follow for an empty index).
+// nothing is published until the daemon actually has a verdict: an absent
+// series means "no verdict" — never evaluated, or (for the verify pair)
+// never a conclusive run — and NEVER a misleading healthy zero (the same
+// rule the index timestamp gauges follow for an empty index).
 // The server label is the display name — the same identity the webhook's
 // `server` field and the console UI use.
 var (
@@ -29,14 +30,14 @@ var (
 		Namespace: "bintrail",
 		Subsystem: "verify",
 		Name:      "last_run_timestamp_seconds",
-		Help:      "Unix time of the newest finished verify run (manual or scheduled) for this server.",
+		Help:      "Unix time of the newest verify run that succeeded and conclusively verified at least one table. Failed and all-inconclusive runs do not refresh it - staleness means verification is broken.",
 	}, []string{"server"})
 
 	verifyTables = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "bintrail",
 		Subsystem: "verify",
 		Name:      "tables",
-		Help:      "Per-status table counts of the newest finished verify run.",
+		Help:      "Per-status table counts of the newest conclusive verify run (see last_run_timestamp_seconds for what counts as one).",
 	}, []string{"server", "status"})
 
 	rotationHealthy = promauto.NewGaugeVec(prometheus.GaugeOpts{

--- a/internal/observe/health_test.go
+++ b/internal/observe/health_test.go
@@ -1,0 +1,59 @@
+package observe
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestContinuityGauge_SetAndClear(t *testing.T) {
+	SetContinuityGapLost("srv-a", true)
+	if got := testutil.ToFloat64(continuityGapLost.WithLabelValues("srv-a")); got != 1 {
+		t.Fatalf("gap_lost after Set(true) = %v, want 1", got)
+	}
+	SetContinuityGapLost("srv-a", false)
+	if got := testutil.ToFloat64(continuityGapLost.WithLabelValues("srv-a")); got != 0 {
+		t.Fatalf("gap_lost after Set(false) = %v, want 0", got)
+	}
+
+	// Clear unpublishes the series: unknown must never read as a healthy 0.
+	ClearContinuity("srv-a")
+	if n := testutil.CollectAndCount(continuityGapLost); n != 0 {
+		t.Fatalf("after Clear the series must be absent, found %d", n)
+	}
+}
+
+func TestVerifyGauges(t *testing.T) {
+	at := time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC)
+	SetVerifyOutcome("wp", at, 12, 1, 2, 0)
+	if got := testutil.ToFloat64(verifyLastRun.WithLabelValues("wp")); got != float64(at.Unix()) {
+		t.Fatalf("last_run = %v, want %v", got, at.Unix())
+	}
+	for _, tc := range []struct {
+		status string
+		want   float64
+	}{{"match", 12}, {"mismatch", 1}, {"inconclusive", 2}, {"error", 0}} {
+		if got := testutil.ToFloat64(verifyTables.WithLabelValues("wp", tc.status)); got != tc.want {
+			t.Fatalf("tables{status=%q} = %v, want %v", tc.status, got, tc.want)
+		}
+	}
+}
+
+func TestRotationGauges(t *testing.T) {
+	SetRotationHealth(false, 0)
+	if got := testutil.ToFloat64(rotationHealthy.WithLabelValues()); got != 1 {
+		t.Fatalf("healthy cycle: gauge = %v, want 1", got)
+	}
+	SetRotationHealth(false, 3)
+	if got := testutil.ToFloat64(rotationHealthy.WithLabelValues()); got != 0 {
+		t.Fatalf("deferring cycle must read unhealthy, got %v", got)
+	}
+	if got := testutil.ToFloat64(rotationDeferred.WithLabelValues()); got != 3 {
+		t.Fatalf("deferred = %v, want 3", got)
+	}
+	SetRotationHealth(true, 0)
+	if got := testutil.ToFloat64(rotationHealthy.WithLabelValues()); got != 0 {
+		t.Fatalf("failed cycle must read unhealthy, got %v", got)
+	}
+}

--- a/internal/observe/health_test.go
+++ b/internal/observe/health_test.go
@@ -41,24 +41,23 @@ func TestVerifyGauges(t *testing.T) {
 }
 
 func TestDeleteVerifyOutcome_unpublishes(t *testing.T) {
+	// Count-delta against the shared default registry: sibling tests may own
+	// other labels, but Delete must remove exactly this label's series —
+	// ABSENCE, not a zeroed value, is the invariant the alert rules and the
+	// Help text promise.
+	before := testutil.CollectAndCount(verifyLastRun)
+	beforeTables := testutil.CollectAndCount(verifyTables)
 	SetVerifyOutcome("gone", time.Now(), 1, 2, 3, 4)
+	if n := testutil.CollectAndCount(verifyLastRun); n != before+1 {
+		t.Fatalf("Set did not add a last_run series: %d -> %d", before, n)
+	}
 	DeleteVerifyOutcome("gone")
-	if n := testutil.CollectAndCount(verifyLastRun); n != 0 {
-		// Other tests publish under different labels; count only after
-		// isolating — reset by deleting the known label and asserting the
-		// specific series is gone via a fresh set/delete cycle.
-		t.Logf("registry still has %d verify_last_run series from sibling tests", n)
+	if n := testutil.CollectAndCount(verifyLastRun); n != before {
+		t.Fatalf("Delete left last_run series behind: want %d, got %d", before, n)
 	}
-	// The concrete assertion: re-reading the deleted label creates a NEW
-	// zero-valued child, proving the old values did not linger.
-	if got := testutil.ToFloat64(verifyLastRun.WithLabelValues("gone")); got != 0 {
-		t.Fatalf("deleted series lingered with value %v", got)
+	if n := testutil.CollectAndCount(verifyTables); n != beforeTables {
+		t.Fatalf("Delete left tables series behind: want %d, got %d", beforeTables, n)
 	}
-	verifyLastRun.DeleteLabelValues("gone")
-	if got := testutil.ToFloat64(verifyTables.WithLabelValues("gone", "mismatch")); got != 0 {
-		t.Fatalf("deleted tables series lingered with value %v", got)
-	}
-	verifyTables.DeleteLabelValues("gone", "mismatch")
 }
 
 func TestRotationGauges(t *testing.T) {

--- a/internal/observe/health_test.go
+++ b/internal/observe/health_test.go
@@ -40,6 +40,27 @@ func TestVerifyGauges(t *testing.T) {
 	}
 }
 
+func TestDeleteVerifyOutcome_unpublishes(t *testing.T) {
+	SetVerifyOutcome("gone", time.Now(), 1, 2, 3, 4)
+	DeleteVerifyOutcome("gone")
+	if n := testutil.CollectAndCount(verifyLastRun); n != 0 {
+		// Other tests publish under different labels; count only after
+		// isolating — reset by deleting the known label and asserting the
+		// specific series is gone via a fresh set/delete cycle.
+		t.Logf("registry still has %d verify_last_run series from sibling tests", n)
+	}
+	// The concrete assertion: re-reading the deleted label creates a NEW
+	// zero-valued child, proving the old values did not linger.
+	if got := testutil.ToFloat64(verifyLastRun.WithLabelValues("gone")); got != 0 {
+		t.Fatalf("deleted series lingered with value %v", got)
+	}
+	verifyLastRun.DeleteLabelValues("gone")
+	if got := testutil.ToFloat64(verifyTables.WithLabelValues("gone", "mismatch")); got != 0 {
+		t.Fatalf("deleted tables series lingered with value %v", got)
+	}
+	verifyTables.DeleteLabelValues("gone", "mismatch")
+}
+
 func TestRotationGauges(t *testing.T) {
 	SetRotationHealth(false, 0)
 	if got := testutil.ToFloat64(rotationHealthy.WithLabelValues()); got != 1 {


### PR DESCRIPTION
closes #1203

## Summary
- **`internal/observe/health.go`**: five new gauges — `bintrail_continuity_gap_lost{server}`, `bintrail_verify_last_run_timestamp_seconds{server}`, `bintrail_verify_tables{server,status}`, `bintrail_rotation_healthy`, `bintrail_rotation_deferred_partitions`. All are `*Vec` collectors (including the label-less rotation pair) so **nothing publishes until the condition is actually evaluated** — an absent series means "not evaluated", never a misleading healthy zero, mirroring the index timestamp gauges. `ClearContinuity` unpublishes an unevaluable index: unknown can never read as no-gap.
- **Continuity**: the #1192 poller now starts under `--notify-webhook` **or** `--metrics-addr` — a Prometheus-only operator gets the gauge without configuring a webhook (the whole point of the issue). The notifier may be nil (gauge-only mode); the unknown-warn rate limit moved onto the poller's own edge so it keeps working without one.
- **Verify**: the supervisor's finish hook is composed (gauges always, webhook when configured), and at startup each registry server's newest persisted history record (#1191) re-seeds the gauges — the pull path survives restarts exactly like the console panel, from the same file. Skip records never publish.
- **Rotation**: a gauge callback joins the `onCycle` list (`rotationNotifyHooks` → `rotationCycleHooks`); it publishes only once a rotation cycle actually runs.
- **Docs**: watch-health metrics table + four new example alert rules (gap_lost critical, verify problems critical, verify staleness, unhealthy rotation) in `observability.md`, so the pull-based recipe matches the webhook's coverage 1:1; cross-reference in `console.md`.

## Test plan
- [x] `go test ./... -count=1` all green; `-race` on observe + consoleapp
- [x] `go vet -tags integration ./...` clean
- New tests: gauge set/clear semantics (incl. unpublish-on-unknown and unhealthy-on-defer), verify-gauge value mapping, hook composition never panics with nil notifier, rotation hook list shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
