### PR TITLE
streamrun: preserve an unreadable capture_skips ledger instead of laundering it to a clean OK

### DIFF
--- a/docs/rotation-and-status.md
+++ b/docs/rotation-and-status.md
@@ -352,7 +352,10 @@ permanently absent from the index, the same loss class as `gap_lost`. A **NULL**
 capture ledger does not trip it (the column post-dates the flag, and alerting on
 its absence would fail every pre-existing deployment) — but a ledger that is
 *present and unreadable* does fail closed: a skip-aware daemon wrote it, and it
-may be hiding a loss count.
+may be hiding a loss count. If the daemon restarts while the ledger is
+unreadable, it preserves that fact under the `unreadable_previous_ledger`
+meta-reason instead of overwriting the evidence with a clean document — which
+also fails closed until acknowledged (same runbook as below).
 
 The drop counter is **monotonic for the life of the index** — fixing
 `binlog_format` stops new drops but does not clear the count (the dropped

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -169,6 +169,13 @@ func runStatus(cmd *cobra.Command, args []string) error {
 				}
 				return fmt.Errorf("capture health: %d statement-format DML event(s) permanently uncaptured%s; set binlog_format=ROW server-wide on the source, then acknowledge by clearing stream_state.capture_skips with the daemon stopped (the counter is monotonic); failing closed under --fail-on-gap", st.Count, loc)
 			}
+			// #1206: the restart path stamps this meta-reason when the
+			// previously persisted ledger could not be parsed — a loss tally
+			// may have been destroyed, so a now-readable ledger carrying it
+			// must not read as "fine".
+			if st := skips[status.CaptureSkipReasonUnreadablePreviousLedger]; st.Count > 0 {
+				return fmt.Errorf("capture health: a previous capture ledger was unreadable at daemon restart and its tally is lost — permanent loss may be unrecorded; acknowledge by clearing stream_state.capture_skips with the daemon stopped; failing closed under --fail-on-gap")
+			}
 		} else if data.Stream.CaptureSkips.Valid && strings.TrimSpace(data.Stream.CaptureSkips.String) != "" {
 			return fmt.Errorf("capture health: capture_skips ledger present but unreadable; cannot confirm statement-format DML drops; failing closed under --fail-on-gap")
 		}

--- a/internal/cli/status_fail_on_gap_integration_test.go
+++ b/internal/cli/status_fail_on_gap_integration_test.go
@@ -181,6 +181,19 @@ func TestRunStatus_failOnGap_exitCode(t *testing.T) {
 	})
 	stFailOnGap = true
 
+	// #1206: a readable ledger carrying the unreadable-previous-ledger
+	// meta-reason (stamped by the restart path) → fail closed; a restart must
+	// not launder the fail-closed unreadable state into exit 0.
+	if _, err := db.ExecContext(ctx,
+		`UPDATE stream_state SET capture_skips='{"unreadable_previous_ledger":{"count":1,"last_at":"2026-07-18T02:00:00Z"}}' WHERE id=1`); err != nil {
+		t.Fatalf("seed meta-reason: %v", err)
+	}
+	captureStdout(t, func() {
+		if err := runStatus(statusCmd, nil); err == nil || !strings.Contains(err.Error(), "previous capture ledger was unreadable") {
+			t.Errorf("want a fail-closed error for the unreadable-previous-ledger meta-reason, got: %v", err)
+		}
+	})
+
 	// An evaluated-and-clean ledger ("{}") → no alert.
 	if _, err := db.ExecContext(ctx, `UPDATE stream_state SET capture_skips='{}' WHERE id=1`); err != nil {
 		t.Fatalf("clear capture_skips: %v", err)

--- a/internal/parser/skips.go
+++ b/internal/parser/skips.go
@@ -40,6 +40,14 @@ const (
 	// SkipStatementFormatDML — a STATEMENT/MIXED-format DML whose row image
 	// is not in the binlog (#999); the change cannot be captured.
 	SkipStatementFormatDML = "statement_format_dml"
+	// SkipUnreadablePreviousLedger — meta-reason (#1206): the previous run's
+	// persisted ledger existed but could not be parsed at restart. Not an
+	// event skip — it preserves the FACT that a loss tally may have been
+	// destroyed, so `status` stays non-clean (and --fail-on-gap keeps failing
+	// closed) instead of the next checkpoint silently laundering the evidence
+	// into "{}" = OK. Cleared only by the operator acknowledgement runbook
+	// (clear the ledger with the daemon stopped).
+	SkipUnreadablePreviousLedger = "unreadable_previous_ledger"
 )
 
 // SkipEscalationThreshold is the number of CONSECUTIVE skipped events (no
@@ -116,6 +124,19 @@ func (c *SkipCounters) Seed(raw string) error {
 	defer c.mu.Unlock()
 	c.byReason = m
 	return nil
+}
+
+// SeedPreserving is Seed for the daemon restart path (#1206). A document that
+// fails to parse is NOT discarded into fresh counters: the failure itself is
+// recorded under SkipUnreadablePreviousLedger, so the next checkpoint persists
+// a non-clean ledger instead of overwriting possible loss evidence with the
+// affirmative "{}". The parse error is returned for the caller to log.
+func (c *SkipCounters) SeedPreserving(raw string) error {
+	err := c.Seed(raw)
+	if err != nil {
+		c.RecordSkip(SkipUnreadablePreviousLedger)
+	}
+	return err
 }
 
 // RecordSkip notes one skipped event under reason, stamping the current time.

--- a/internal/parser/skips_test.go
+++ b/internal/parser/skips_test.go
@@ -91,6 +91,29 @@ func TestSkipCounters_attributionRoundTrip(t *testing.T) {
 	}
 }
 
+// #1206: the restart path must never launder an unreadable ledger into fresh
+// counters — SeedPreserving stamps the failure under the meta-reason so the
+// next Snapshot persists a non-clean document; a readable document seeds
+// normally with no meta-reason.
+func TestSkipCounters_seedPreservingStampsUnreadable(t *testing.T) {
+	c := NewSkipCounters(newTestLogger(&bytes.Buffer{}))
+	if err := c.SeedPreserving(`{"statement_format_dml": 3}`); err == nil {
+		t.Fatal("SeedPreserving must return the parse error")
+	}
+	snap, _ := c.Snapshot()
+	if !strings.Contains(snap, SkipUnreadablePreviousLedger) || c.Total() != 1 {
+		t.Fatalf("unreadable ledger not preserved as meta-reason (total=%d): %s", c.Total(), snap)
+	}
+
+	ok := NewSkipCounters(newTestLogger(&bytes.Buffer{}))
+	if err := ok.SeedPreserving(`{"column_count_mismatch":{"count":2,"last_at":"2026-07-17T12:24:12Z"}}`); err != nil {
+		t.Fatalf("SeedPreserving on a readable document: %v", err)
+	}
+	if snap2, _ := ok.Snapshot(); strings.Contains(snap2, SkipUnreadablePreviousLedger) {
+		t.Fatalf("readable seed must not stamp the meta-reason: %s", snap2)
+	}
+}
+
 func TestSkipCounters_seedEmptyAndInvalid(t *testing.T) {
 	c := NewSkipCounters(newTestLogger(&bytes.Buffer{}))
 	if err := c.Seed(""); err != nil {

--- a/internal/status/capture_health_test.go
+++ b/internal/status/capture_health_test.go
@@ -113,6 +113,9 @@ func TestCaptureSkipReasonMirrorsParser(t *testing.T) {
 	if CaptureSkipReasonStatementFormatDML != parser.SkipStatementFormatDML {
 		t.Fatalf("status reason %q != parser reason %q", CaptureSkipReasonStatementFormatDML, parser.SkipStatementFormatDML)
 	}
+	if CaptureSkipReasonUnreadablePreviousLedger != parser.SkipUnreadablePreviousLedger {
+		t.Fatalf("status reason %q != parser reason %q", CaptureSkipReasonUnreadablePreviousLedger, parser.SkipUnreadablePreviousLedger)
+	}
 }
 
 func TestWriteStatus_captureHealthOK(t *testing.T) {

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -138,6 +138,11 @@ type CaptureSkipStat struct {
 // package deliberately does not import the binlog parser.
 const CaptureSkipReasonStatementFormatDML = "statement_format_dml"
 
+// CaptureSkipReasonUnreadablePreviousLedger mirrors
+// parser.SkipUnreadablePreviousLedger — the meta-reason a restarting daemon
+// stamps when the previously persisted ledger could not be parsed (#1206).
+const CaptureSkipReasonUnreadablePreviousLedger = "unreadable_previous_ledger"
+
 // ParseCaptureSkips decodes the persisted capture_skips document. ok is false
 // when the verdict is not evaluable (no column / no skip-aware daemon /
 // unparseable payload) — callers must then omit the Capture health verdict

--- a/internal/streamrun/capture_skips_integration_test.go
+++ b/internal/streamrun/capture_skips_integration_test.go
@@ -86,6 +86,37 @@ func TestIntegrationCaptureSkipsPersistAndSurviveRestart(t *testing.T) {
 		t.Fatalf("a nil-skips checkpoint wiped the counters:\n was: %s\n now: %s", raw2, raw3)
 	}
 
+	// ── #1206: an unreadable persisted ledger is preserved, not laundered ──
+	// Corrupt the column (valid JSON, wrong shape — what version skew
+	// produces), restart through the production seed path, and re-persist:
+	// the meta-reason must survive the round trip instead of "{}" = OK.
+	if _, err := db.Exec(`UPDATE stream_state SET capture_skips='{"statement_format_dml": 3}' WHERE id=1`); err != nil {
+		t.Fatalf("corrupt capture_skips: %v", err)
+	}
+	rawBad, err := loadCaptureSkips(db)
+	if err != nil {
+		t.Fatalf("loadCaptureSkips (corrupt): %v", err)
+	}
+	postCrash := parser.NewSkipCounters(nil)
+	if err := postCrash.SeedPreserving(rawBad); err == nil {
+		t.Fatal("SeedPreserving must surface the parse error")
+	}
+	state.skips = postCrash
+	if err := saveCheckpoint(db, state); err != nil {
+		t.Fatalf("saveCheckpoint after unreadable seed: %v", err)
+	}
+	rawAfter, err := loadCaptureSkips(db)
+	if err != nil {
+		t.Fatalf("loadCaptureSkips after re-persist: %v", err)
+	}
+	if !strings.Contains(rawAfter, parser.SkipUnreadablePreviousLedger) {
+		t.Fatalf("unreadable-ledger evidence was laundered away: %s", rawAfter)
+	}
+	// Restore the readable multi-reason document for the render assertions.
+	if _, err := db.Exec(`UPDATE stream_state SET capture_skips=? WHERE id=1`, raw2); err != nil {
+		t.Fatalf("restore capture_skips: %v", err)
+	}
+
 	// ── `status` renders DEGRADED from the same row (production read path) ──
 	ctx := context.Background()
 	stream, err := status.LoadStreamState(ctx, db)

--- a/internal/streamrun/streamrun.go
+++ b/internal/streamrun/streamrun.go
@@ -2163,14 +2163,17 @@ func One(ctx context.Context, cfg Config) error {
 	// Capture-skip counters (#1034): shared between the StreamParser (which
 	// records each discarded event) and saveCheckpoint (which persists them).
 	// Re-seeded from the previous run's persisted document so a restart never
-	// silently zeroes the DEGRADED verdict `status` renders from them. A
-	// failed load/parse degrades to fresh counters with a warning — never a
-	// startup abort — since the tallies are observability, not correctness.
+	// silently zeroes the DEGRADED verdict `status` renders from them. Since
+	// #999 the ledger is exit-code-bearing (--fail-on-gap), so an unreadable
+	// document must not be laundered into fresh counters + a clean "{}" at the
+	// next checkpoint: SeedPreserving records the failure itself under the
+	// unreadable_previous_ledger meta-reason (#1206) — status stays non-clean
+	// until the operator acknowledges. Never a startup abort either way.
 	skips := parser.NewSkipCounters(nil)
 	if raw, err := loadCaptureSkips(indexDB); err != nil {
 		slog.Warn("could not load persisted capture-skip counters; starting from zero", "error", err)
-	} else if err := skips.Seed(raw); err != nil {
-		slog.Warn("could not parse persisted capture-skip counters; starting from zero", "error", err)
+	} else if err := skips.SeedPreserving(raw); err != nil {
+		slog.Error("could not parse persisted capture-skip counters — the previous ledger may have recorded permanent loss; preserving the fact under reason unreadable_previous_ledger", "error", err)
 	}
 	state.skips = skips
 


### PR DESCRIPTION
closes #1206

## Summary
- `parser.SeedPreserving` (#1206): a persisted ledger that fails to parse at daemon restart is no longer discarded into fresh counters — the failure itself is recorded under the new `unreadable_previous_ledger` meta-reason, so the next checkpoint persists a non-clean document instead of overwriting possible loss evidence with `"{}"` (which `status` renders as the affirmative `Capture health: OK`).
- The restart log line is upgraded Warn → Error; the stale "the tallies are observability, not correctness" comment (invalidated when #999 made the ledger exit-code-bearing) is rewritten.
- `--fail-on-gap` gains a fail-closed branch for the meta-reason: without it, a restart would launder the (already fail-closed) unreadable state into a readable ledger that exits 0.
- `status` renders the meta-reason through the existing generic DEGRADED path — no render changes needed.
- Docs: the acknowledgement runbook (stop daemon → clear ledger → restart) covers this state too.

## Test plan
- [x] Unit: `SeedPreserving` stamps the meta-reason on unreadable input, not on readable input; mirror-guard test extended to the new reason key
- [x] Integration (run green vs Docker MySQL): corrupt ledger → production seed path → re-persist → meta-reason survives the round trip; `--fail-on-gap` fails closed on a ledger carrying the meta-reason
- [x] `go build` / `go vet` (±integration) / unit with `-race`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
