### PR TITLE
status: every capture-skip reason joins the --fail-on-gap contract

### DIFF
--- a/docs/rotation-and-status.md
+++ b/docs/rotation-and-status.md
@@ -347,8 +347,9 @@ PostgreSQL replication slot (#532) after the capture process has exited.
 code — `status` is a report. Pass `--fail-on-gap` to exit non-zero when continuity
 is `gap_lost` **or** `unknown`; it **fails closed**, so an un-migrated legacy index
 or an unloadable stream state also trips it. It also exits non-zero when the
-capture ledger records in-scope `statement_format_dml` drops — those changes are
-permanently absent from the index, the same loss class as `gap_lost`. A **NULL**
+capture ledger records **any** dropped events — `statement_format_dml`,
+`column_count_mismatch`, and the rest — those changes are permanently absent
+from the index, the same loss class as `gap_lost`. A **NULL**
 capture ledger does not trip it (the column post-dates the flag, and alerting on
 its absence would fail every pre-existing deployment) — but a ledger that is
 *present and unreadable* does fail closed: a skip-aware daemon wrote it, and it

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -29,9 +30,10 @@ The Stream section also reports continuity — the cheap "did I lose any events?
 verdict: "no gaps in the captured range" (a contiguity check, not a liveness
 one), or a loud "GAP LOST" when an unfillable gap forced an auto-advance with
 permanent loss. Pass --fail-on-gap to exit non-zero on that loss — or when
-continuity can't be confirmed (fails closed), or when in-scope statement-format
-DML drops were recorded (the same permanent-loss class) — for CI/cron alerting;
-by default a gap never changes the exit code.
+continuity can't be confirmed (fails closed), or when the capture ledger
+records ANY dropped events (statement-format DML, column-count mismatches, …;
+all the same permanent-loss class) — for CI/cron alerting; by default a gap
+never changes the exit code.
 
 Partition row counts are estimates read from information_schema (no table scan).
 
@@ -51,7 +53,7 @@ func init() {
 	statusCmd.Flags().StringVar(&stIndexDSN, "index-dsn", "", "DSN for the index MySQL database (required)")
 	statusCmd.Flags().StringVar(&stFormat, "format", "text", "Output format: text or json")
 	statusCmd.Flags().StringVar(&stBaselineDir, "baseline-dir", "", "Local directory of baseline Parquet snapshots (optional, shows baseline binlog positions)")
-	statusCmd.Flags().BoolVar(&stFailOnGap, "fail-on-gap", false, "Exit non-zero if the stream lost data (a binlog gap or statement-format DML drops), or its continuity can't be confirmed (fails closed); for CI/cron alerting. By default a gap never changes the exit code")
+	statusCmd.Flags().BoolVar(&stFailOnGap, "fail-on-gap", false, "Exit non-zero if the stream lost data (a binlog gap or any recorded capture drops), or its continuity can't be confirmed (fails closed); for CI/cron alerting. By default a gap never changes the exit code")
 	_ = statusCmd.MarkFlagRequired("index-dsn")
 	BindCommandEnv(statusCmd)
 	// Registration on a root command happens via AddReadCommands(root), which
@@ -175,6 +177,24 @@ func runStatus(cmd *cobra.Command, args []string) error {
 			// must not read as "fine".
 			if st := skips[status.CaptureSkipReasonUnreadablePreviousLedger]; st.Count > 0 {
 				return fmt.Errorf("capture health: a previous capture ledger was unreadable at daemon restart and its tally is lost — permanent loss may be unrecorded; acknowledge by clearing stream_state.capture_skips with the daemon stopped; failing closed under --fail-on-gap")
+			}
+			// #1207: every remaining reason is the same permanent-loss class —
+			// an event read from the stream and dropped is absent from the
+			// index whatever the reason (the #1034 real-world case: a stale
+			// snapshot dropping 100% of rows for days) — so ANY non-zero
+			// count fails closed, not just the two named above. The two
+			// specific branches stay first for their sharper remediation.
+			var dropped int64
+			var reasons []string
+			for r, st := range skips {
+				if st.Count > 0 {
+					dropped += st.Count
+					reasons = append(reasons, r)
+				}
+			}
+			if dropped > 0 {
+				sort.Strings(reasons)
+				return fmt.Errorf("capture health: %d event(s) read from the stream and permanently dropped (%s); most often the schema snapshot is stale or corrupt — run `bintrail snapshot` against the source and restart the stream, then acknowledge by clearing stream_state.capture_skips with the daemon stopped (the counter is monotonic); failing closed under --fail-on-gap", dropped, strings.Join(reasons, ", "))
 			}
 		} else if data.Stream.CaptureSkips.Valid && strings.TrimSpace(data.Stream.CaptureSkips.String) != "" {
 			return fmt.Errorf("capture health: capture_skips ledger present but unreadable; cannot confirm statement-format DML drops; failing closed under --fail-on-gap")

--- a/internal/cli/status_fail_on_gap_integration_test.go
+++ b/internal/cli/status_fail_on_gap_integration_test.go
@@ -194,6 +194,25 @@ func TestRunStatus_failOnGap_exitCode(t *testing.T) {
 		}
 	})
 
+	// #1207: any other reason with a non-zero count is the same loss class →
+	// fail closed with the reason named (the #1034 case: stale snapshot).
+	if _, err := db.ExecContext(ctx,
+		`UPDATE stream_state SET capture_skips='{"column_count_mismatch":{"count":41203,"last_at":"2026-07-17T12:24:12Z"}}' WHERE id=1`); err != nil {
+		t.Fatalf("seed column_count_mismatch: %v", err)
+	}
+	captureStdout(t, func() {
+		if err := runStatus(statusCmd, nil); err == nil || !strings.Contains(err.Error(), "permanently dropped") || !strings.Contains(err.Error(), "column_count_mismatch") {
+			t.Errorf("want a fail-closed error naming the drop reason, got: %v", err)
+		}
+	})
+	stFailOnGap = false
+	captureStdout(t, func() {
+		if err := runStatus(statusCmd, nil); err != nil {
+			t.Errorf("default (no --fail-on-gap) must exit 0 with generic drops too, got: %v", err)
+		}
+	})
+	stFailOnGap = true
+
 	// An evaluated-and-clean ledger ("{}") → no alert.
 	if _, err := db.ExecContext(ctx, `UPDATE stream_state SET capture_skips='{}' WHERE id=1`); err != nil {
 		t.Fatalf("clear capture_skips: %v", err)


### PR DESCRIPTION
closes #1207

## Summary
- `--fail-on-gap` now fails closed on **any** non-zero capture-skip count, not just `statement_format_dml`: an event read from the stream and dropped is permanently absent from the index whatever the reason. The motivating asymmetry: the #1034 real-world failure (stale snapshot dropping 100% of rows for ~2 days, `column_count_mismatch: 41203`) exited 0 while `statement_format_dml: 1` exited 1.
- The statement-DML and unreadable-previous-ledger branches stay first for their sharper remediation; the generic catch-all names the reasons (sorted) and carries the stale-snapshot remediation plus the monotonic-counter acknowledgement runbook from #1204/#1208 (stop daemon → clear ledger → restart).
- Flag help, command Long text, and `docs/rotation-and-status.md` updated to say "any dropped events".
- Break-nothing preserved: flag off still exits 0 with recorded drops; NULL ledger still exempt (grandfathering); based on #1208 so the unreadable-ledger paths are unchanged.

## Test plan
- [x] Integration extended and run green vs Docker MySQL: `column_count_mismatch` drops → non-zero exit naming the reason; flag off → 0; clean `{}` → 0 (existing phases unchanged)
- [x] `go build` / `go vet` (±integration) / `go test ./internal/cli/ -race`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
