### PR TITLE
Baseline staleness verdict: detect a shrinking or broken full-restore window

### DIFF
--- a/consoleapp/notify.go
+++ b/consoleapp/notify.go
@@ -14,6 +14,8 @@ import (
 	"github.com/dbtrail/dbtrail/internal/console"
 	"github.com/dbtrail/dbtrail/internal/notify"
 	"github.com/dbtrail/dbtrail/internal/observe"
+	"github.com/dbtrail/dbtrail/internal/reconstruct"
+	"github.com/dbtrail/dbtrail/internal/status"
 )
 
 // continuityPollInterval is how often the continuity watcher re-reads each
@@ -197,6 +199,159 @@ func (n *watchNotifier) Continuity(server, edgeKey string, gapLost bool, detail 
 // bootContinuityName labels the command-line boot index in continuity/verify
 // gauges and webhook events.
 const bootContinuityName = "cli index"
+
+// BaselineStale reports one server's staleness verdict (#1193). Only broken
+// notifies — aging stays visible in status/console; the channel carries the
+// transition that means "full-table restore is impossible NOW".
+func (n *watchNotifier) BaselineStale(server string, broken bool, detail string) {
+	key := "baseline:" + server
+	if !broken {
+		if n.edge.Resolve(key) {
+			n.send.Notify(notify.Event{
+				Event: notify.EventBaselineStale, Severity: notify.SeverityInfo, Server: server, Resolved: true,
+				Summary: "the newest baseline is inside delta coverage again — full-table restore is possible",
+			})
+		}
+		return
+	}
+	if !n.edge.Fire(key, detail) {
+		return
+	}
+	ev := notify.Event{
+		Event: notify.EventBaselineStale, Severity: notify.SeverityCritical, Server: server,
+		Summary: "the newest baseline predates available delta coverage — full-table restore through the missing window is impossible; take a fresh baseline (bintrail dump + bintrail baseline)",
+	}
+	if detail != "" {
+		ev.Details = map[string]string{"detail": detail}
+	}
+	n.send.Notify(ev)
+}
+
+// stalenessPollInterval: staleness moves with rotation cycles (hourly by
+// default), and each check lists the baseline source — an S3 LIST every few
+// minutes would buy nothing.
+const stalenessPollInterval = time.Hour
+
+// stalenessWatcher evaluates each server's baseline staleness (#1193) and
+// feeds the webhook channel on the broken transition. Webhook-gated only:
+// status and the console carry the full ok/aging verdicts.
+type stalenessWatcher struct {
+	n         *watchNotifier
+	registry  *console.Registry
+	bootDSN   string
+	globalDir string
+	globalS3  string
+
+	// Injectable for tests — no ticker, no real DB, no real S3.
+	listBaselines func(ctx context.Context, source string) ([]reconstruct.BaselineFile, error)
+	oldestDelta   func(ctx context.Context, dsn string) (time.Time, error)
+}
+
+func startStalenessWatch(ctx context.Context, n *watchNotifier, registry *console.Registry, bootDSN, globalDir, globalS3 string) {
+	w := &stalenessWatcher{
+		n: n, registry: registry, bootDSN: bootDSN, globalDir: globalDir, globalS3: globalS3,
+		listBaselines: reconstruct.ListBaselines,
+		oldestDelta:   oldestDeltaByDSN,
+	}
+	go func() {
+		if ctx.Err() == nil {
+			w.runCycle(ctx)
+		}
+		tick := time.NewTicker(stalenessPollInterval)
+		defer tick.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-tick.C:
+				w.runCycle(ctx)
+			}
+		}
+	}()
+}
+
+// stalenessTarget is one server with a baseline source to grade.
+type stalenessTarget struct{ name, dsn, source string }
+
+// targets applies the same all-or-nothing baseline fallback as
+// withBaselineDefaults (#1010): an entry with its OWN dir or S3 chose its
+// location; only a fully unset entry inherits the process-wide one. Servers
+// with no baseline anywhere have nothing to grade and are skipped.
+func (w *stalenessWatcher) targets() []stalenessTarget {
+	globalSrc := w.globalDir
+	if globalSrc == "" {
+		globalSrc = w.globalS3
+	}
+	var out []stalenessTarget
+	if w.bootDSN != "" && globalSrc != "" {
+		out = append(out, stalenessTarget{name: bootContinuityName, dsn: w.bootDSN, source: globalSrc})
+	}
+	if w.registry != nil {
+		for _, e := range w.registry.List() {
+			src := e.BaselineDir
+			if src == "" {
+				src = e.BaselineS3
+			}
+			if src == "" {
+				src = globalSrc
+			}
+			if src == "" {
+				continue
+			}
+			out = append(out, stalenessTarget{name: e.Name, dsn: e.DSN, source: src})
+		}
+	}
+	return out
+}
+
+func (w *stalenessWatcher) runCycle(ctx context.Context) {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("baseline staleness cycle panicked; checking continues next tick", "panic", r)
+		}
+	}()
+	for _, t := range w.targets() {
+		if ctx.Err() != nil {
+			return
+		}
+		files, err := w.listBaselines(ctx, t.source)
+		if err != nil || len(files) == 0 {
+			continue // unreadable source or no baselines yet: nothing gradable
+		}
+		oldest, err := w.oldestDelta(ctx, t.dsn)
+		if err != nil || oldest.IsZero() {
+			// Unknown floor is never a verdict — and must never RESOLVE an
+			// active broken alert either, so the target is skipped whole.
+			continue
+		}
+		now := time.Now().UTC()
+		newest := make(map[string]time.Time, len(files))
+		for _, f := range files {
+			k := f.Schema + "." + f.Table
+			if f.SnapshotTime.After(newest[k]) {
+				newest[k] = f.SnapshotTime
+			}
+		}
+		broken, detail := false, ""
+		for k, ts := range newest {
+			if status.BaselineStalenessFor(ts, oldest, now) == status.BaselineBroken {
+				broken = true
+				detail = k + ": newest baseline " + ts.UTC().Format(time.RFC3339) + " predates delta coverage starting " + oldest.UTC().Format(time.RFC3339)
+				break
+			}
+		}
+		w.n.BaselineStale(t.name, broken, detail)
+	}
+}
+
+func oldestDeltaByDSN(ctx context.Context, dsn string) (time.Time, error) {
+	db, err := config.Connect(dsn)
+	if err != nil {
+		return time.Time{}, err
+	}
+	defer db.Close()
+	return status.OldestDeltaFromDB(ctx, db)
+}
 
 // continuityTarget is one index DB the watcher polls.
 type continuityTarget struct {

--- a/consoleapp/notify.go
+++ b/consoleapp/notify.go
@@ -207,8 +207,12 @@ const bootContinuityName = "cli index"
 // bootstrap artifact; alerting on it would cry wolf — see
 // status.baselineAgingFraction's comment); the channel carries the transition
 // that means "full-table restore is impossible NOW". edgeKey identifies the
-// index (the DSN — display names can collide with the reserved boot label,
-// same rule as Continuity). brokenTables must be a STABLE identity (sorted
+// (index DSN, baseline source) PAIR — never the display name (it can collide
+// with the reserved boot label), and never the DSN alone: staleness is a
+// property of the pair, so unlike the continuity poller (which dedups by DSN
+// because gap_lost is per-index) two sources graded against one index are
+// distinct conditions and must not Fire/Resolve against each other.
+// brokenTables must be a STABLE identity (sorted
 // table list) — never a clock- or floor-derived string: the coverage floor
 // advances with every rotation cycle, and a volatile edge detail would bypass
 // the repeat window and page every hour.
@@ -326,34 +330,47 @@ func (w *stalenessWatcher) runCycle(ctx context.Context) {
 		if ctx.Err() != nil {
 			return
 		}
+		// The edge identity is the (dsn, source) pair — see BaselineStale's
+		// doc. \x1f as separator: a control char no DSN or path contains.
+		edgeID := t.dsn + "\x1f" + t.source
 		files, err := w.listBaselines(ctx, t.source)
 		if err != nil {
 			// A configured-but-unreadable source (broken mount, revoked S3
 			// credentials, deleted bucket) disarms this whole check — that
 			// must never be silent: a broken window would go undetected, and
 			// an active alert freezes with a dead evaluator.
-			if w.unknownEdge.Fire("staleness-source:"+t.dsn, "") {
+			if w.unknownEdge.Fire("staleness-source:"+edgeID, "") {
 				slog.Warn("baseline staleness cannot be evaluated — the baseline source is unreadable; a broken restore window would go UNDETECTED for this server",
 					"server", t.name, "source", t.source, "error", err)
 			}
 			continue
 		}
-		w.unknownEdge.Resolve("staleness-source:" + t.dsn)
+		w.unknownEdge.Resolve("staleness-source:" + edgeID)
 		if len(files) == 0 {
-			continue // no baselines yet — routine on fresh installs, nothing to grade
+			// Routine on fresh installs — but while a broken alert is ACTIVE
+			// it means the stale snapshots vanished without replacement
+			// (prune loop, lifecycle rule, emptied mount): restore is still
+			// impossible and the alert would silently freeze, so warn.
+			// Never a Resolve — nothing was fixed.
+			if w.n.edge.Active("baseline:"+edgeID) && w.unknownEdge.Fire("staleness-empty:"+edgeID, "") {
+				slog.Warn("baseline source lists NO snapshots while a baseline_stale alert is active — restore is still impossible and the alert is frozen; take a fresh baseline",
+					"server", t.name, "source", t.source)
+			}
+			continue
 		}
+		w.unknownEdge.Resolve("staleness-empty:" + edgeID)
 		oldest, err := w.oldestDelta(ctx, t.dsn)
 		if err != nil || oldest.IsZero() {
 			// Unknown floor is never a verdict — and must never RESOLVE an
 			// active broken alert either, so the target is skipped whole.
 			// Skipped, not silent: same rule as the unreadable source above.
-			if w.unknownEdge.Fire("staleness-floor:"+t.dsn, "") {
+			if w.unknownEdge.Fire("staleness-floor:"+edgeID, "") {
 				slog.Warn("baseline staleness cannot be evaluated — the delta-coverage floor is unknown (index unreachable or unpartitioned)",
 					"server", t.name, "error", err)
 			}
 			continue
 		}
-		w.unknownEdge.Resolve("staleness-floor:" + t.dsn)
+		w.unknownEdge.Resolve("staleness-floor:" + edgeID)
 		now := time.Now().UTC()
 		newest := make(map[string]time.Time, len(files))
 		for _, f := range files {
@@ -372,7 +389,7 @@ func (w *stalenessWatcher) runCycle(ctx context.Context) {
 			}
 		}
 		sort.Strings(brokenTables)
-		w.n.BaselineStale(t.name, t.dsn, len(brokenTables) > 0,
+		w.n.BaselineStale(t.name, edgeID, len(brokenTables) > 0,
 			strings.Join(brokenTables, ", "), oldest.UTC().Format(time.RFC3339))
 	}
 }

--- a/consoleapp/notify.go
+++ b/consoleapp/notify.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"log/slog"
 	"net/url"
+	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/dbtrail/dbtrail/internal/config"
@@ -201,30 +203,34 @@ func (n *watchNotifier) Continuity(server, edgeKey string, gapLost bool, detail 
 const bootContinuityName = "cli index"
 
 // BaselineStale reports one server's staleness verdict (#1193). Only broken
-// notifies — aging stays visible in status/console; the channel carries the
-// transition that means "full-table restore is impossible NOW".
-func (n *watchNotifier) BaselineStale(server string, broken bool, detail string) {
-	key := "baseline:" + server
+// notifies — aging stays visible in status/console (pre-saturation aging is a
+// bootstrap artifact; alerting on it would cry wolf — see
+// status.baselineAgingFraction's comment); the channel carries the transition
+// that means "full-table restore is impossible NOW". edgeKey identifies the
+// index (the DSN — display names can collide with the reserved boot label,
+// same rule as Continuity). brokenTables must be a STABLE identity (sorted
+// table list) — never a clock- or floor-derived string: the coverage floor
+// advances with every rotation cycle, and a volatile edge detail would bypass
+// the repeat window and page every hour.
+func (n *watchNotifier) BaselineStale(server, edgeKey string, broken bool, brokenTables, coverageFloor string) {
+	key := "baseline:" + edgeKey
 	if !broken {
 		if n.edge.Resolve(key) {
 			n.send.Notify(notify.Event{
 				Event: notify.EventBaselineStale, Severity: notify.SeverityInfo, Server: server, Resolved: true,
-				Summary: "the newest baseline is inside delta coverage again — full-table restore is possible",
+				Summary: "every table's newest baseline is inside delta coverage again — full-table restore is possible",
 			})
 		}
 		return
 	}
-	if !n.edge.Fire(key, detail) {
+	if !n.edge.Fire(key, brokenTables) {
 		return
 	}
-	ev := notify.Event{
+	n.send.Notify(notify.Event{
 		Event: notify.EventBaselineStale, Severity: notify.SeverityCritical, Server: server,
 		Summary: "the newest baseline predates available delta coverage — full-table restore through the missing window is impossible; take a fresh baseline (bintrail dump + bintrail baseline)",
-	}
-	if detail != "" {
-		ev.Details = map[string]string{"detail": detail}
-	}
-	n.send.Notify(ev)
+		Details: map[string]string{"tables": brokenTables, "coverage_floor": coverageFloor},
+	})
 }
 
 // stalenessPollInterval: staleness moves with rotation cycles (hourly by
@@ -242,6 +248,11 @@ type stalenessWatcher struct {
 	globalDir string
 	globalS3  string
 
+	// unknownEdge rate-limits the cannot-evaluate warnings to one per day per
+	// index — a watcher that cannot watch is itself a coverage hole and must
+	// never go silent (the continuity poller's rule).
+	unknownEdge *notify.Edge
+
 	// Injectable for tests — no ticker, no real DB, no real S3.
 	listBaselines func(ctx context.Context, source string) ([]reconstruct.BaselineFile, error)
 	oldestDelta   func(ctx context.Context, dsn string) (time.Time, error)
@@ -250,6 +261,7 @@ type stalenessWatcher struct {
 func startStalenessWatch(ctx context.Context, n *watchNotifier, registry *console.Registry, bootDSN, globalDir, globalS3 string) {
 	w := &stalenessWatcher{
 		n: n, registry: registry, bootDSN: bootDSN, globalDir: globalDir, globalS3: globalS3,
+		unknownEdge:   notify.NewEdge(0),
 		listBaselines: reconstruct.ListBaselines,
 		oldestDelta:   oldestDeltaByDSN,
 	}
@@ -315,15 +327,33 @@ func (w *stalenessWatcher) runCycle(ctx context.Context) {
 			return
 		}
 		files, err := w.listBaselines(ctx, t.source)
-		if err != nil || len(files) == 0 {
-			continue // unreadable source or no baselines yet: nothing gradable
+		if err != nil {
+			// A configured-but-unreadable source (broken mount, revoked S3
+			// credentials, deleted bucket) disarms this whole check — that
+			// must never be silent: a broken window would go undetected, and
+			// an active alert freezes with a dead evaluator.
+			if w.unknownEdge.Fire("staleness-source:"+t.dsn, "") {
+				slog.Warn("baseline staleness cannot be evaluated — the baseline source is unreadable; a broken restore window would go UNDETECTED for this server",
+					"server", t.name, "source", t.source, "error", err)
+			}
+			continue
+		}
+		w.unknownEdge.Resolve("staleness-source:" + t.dsn)
+		if len(files) == 0 {
+			continue // no baselines yet — routine on fresh installs, nothing to grade
 		}
 		oldest, err := w.oldestDelta(ctx, t.dsn)
 		if err != nil || oldest.IsZero() {
 			// Unknown floor is never a verdict — and must never RESOLVE an
 			// active broken alert either, so the target is skipped whole.
+			// Skipped, not silent: same rule as the unreadable source above.
+			if w.unknownEdge.Fire("staleness-floor:"+t.dsn, "") {
+				slog.Warn("baseline staleness cannot be evaluated — the delta-coverage floor is unknown (index unreachable or unpartitioned)",
+					"server", t.name, "error", err)
+			}
 			continue
 		}
+		w.unknownEdge.Resolve("staleness-floor:" + t.dsn)
 		now := time.Now().UTC()
 		newest := make(map[string]time.Time, len(files))
 		for _, f := range files {
@@ -332,15 +362,18 @@ func (w *stalenessWatcher) runCycle(ctx context.Context) {
 				newest[k] = f.SnapshotTime
 			}
 		}
-		broken, detail := false, ""
+		// ALL broken tables, sorted — the edge detail must be a stable
+		// identity, and a map-iteration-ordered single pick would flip
+		// between cycles and re-fire through the repeat window.
+		var brokenTables []string
 		for k, ts := range newest {
 			if status.BaselineStalenessFor(ts, oldest, now) == status.BaselineBroken {
-				broken = true
-				detail = k + ": newest baseline " + ts.UTC().Format(time.RFC3339) + " predates delta coverage starting " + oldest.UTC().Format(time.RFC3339)
-				break
+				brokenTables = append(brokenTables, k)
 			}
 		}
-		w.n.BaselineStale(t.name, broken, detail)
+		sort.Strings(brokenTables)
+		w.n.BaselineStale(t.name, t.dsn, len(brokenTables) > 0,
+			strings.Join(brokenTables, ", "), oldest.UTC().Format(time.RFC3339))
 	}
 }
 
@@ -350,7 +383,7 @@ func oldestDeltaByDSN(ctx context.Context, dsn string) (time.Time, error) {
 		return time.Time{}, err
 	}
 	defer db.Close()
-	return status.OldestDeltaFromDB(ctx, db)
+	return status.OldestDeltaFromDB(ctx, db, indexDBName(dsn))
 }
 
 // continuityTarget is one index DB the watcher polls.

--- a/consoleapp/staleness_test.go
+++ b/consoleapp/staleness_test.go
@@ -79,7 +79,7 @@ func TestStalenessWatcher_runCycle(t *testing.T) {
 
 	files := []reconstruct.BaselineFile{
 		{Schema: "shop", Table: "orders", SnapshotTime: oldest.Add(-time.Hour)}, // superseded, broken
-		{Schema: "shop", Table: "orders", SnapshotTime: now.Add(-time.Hour)},   // newest, fine
+		{Schema: "shop", Table: "orders", SnapshotTime: now.Add(-time.Hour)},    // newest, fine
 	}
 	w := &stalenessWatcher{
 		n: n, registry: reg,
@@ -126,7 +126,9 @@ func TestStalenessWatcher_runCycle(t *testing.T) {
 
 	// Unreadable baseline source: same skip-whole rule.
 	w.oldestDelta = func(context.Context, string) (time.Time, error) { return oldestAdvanced, nil }
-	w.listBaselines = func(context.Context, string) ([]reconstruct.BaselineFile, error) { return nil, errors.New("bucket gone") }
+	w.listBaselines = func(context.Context, string) ([]reconstruct.BaselineFile, error) {
+		return nil, errors.New("bucket gone")
+	}
 	w.runCycle(context.Background())
 	if len(f.events) != 1 {
 		t.Fatalf("unreadable source must neither fire nor resolve: %+v", f.events)
@@ -141,5 +143,112 @@ func TestStalenessWatcher_runCycle(t *testing.T) {
 	w.runCycle(context.Background())
 	if len(f.events) != 2 || !f.events[1].Resolved {
 		t.Fatalf("fresh baseline must resolve the alert: %+v", f.events)
+	}
+}
+
+// TestStalenessWatcher_agingNeverFires pins the PR's core alerting decision:
+// aging is informational (a bootstrap artifact on young installs — see
+// status.baselineAgingFraction) and must never reach the webhook channel.
+func TestStalenessWatcher_agingNeverFires(t *testing.T) {
+	reg := testRegistryWithEntries(t, console.ServerEntry{Name: "wp", DSN: "d1", BaselineDir: "/b"})
+	now := time.Now().UTC()
+	oldest := now.Add(-100 * time.Hour)
+	n, f := testNotifier()
+	// Inside coverage but past 80% of the span: verdict is aging, not broken.
+	files := []reconstruct.BaselineFile{{Schema: "shop", Table: "orders", SnapshotTime: oldest.Add(10 * time.Hour)}}
+	w := &stalenessWatcher{
+		n: n, registry: reg, unknownEdge: notify.NewEdge(0),
+		listBaselines: func(context.Context, string) ([]reconstruct.BaselineFile, error) { return files, nil },
+		oldestDelta:   func(context.Context, string) (time.Time, error) { return oldest, nil },
+	}
+	w.runCycle(context.Background())
+	if len(f.events) != 0 {
+		t.Fatalf("aging must never fire the webhook: %+v", f.events)
+	}
+}
+
+// TestStalenessWatcher_targetIsolation: a failing first target must not
+// disarm checking for the rest — the skip is per-target, never per-cycle.
+func TestStalenessWatcher_targetIsolation(t *testing.T) {
+	reg := testRegistryWithEntries(t,
+		console.ServerEntry{Name: "a", DSN: "d1", BaselineDir: "/a"},
+		console.ServerEntry{Name: "b", DSN: "d2", BaselineDir: "/b"},
+	)
+	now := time.Now().UTC()
+	oldest := now.Add(-100 * time.Hour)
+	n, f := testNotifier()
+	w := &stalenessWatcher{
+		n: n, registry: reg, unknownEdge: notify.NewEdge(0),
+		listBaselines: func(_ context.Context, source string) ([]reconstruct.BaselineFile, error) {
+			if source == "/a" {
+				return nil, errors.New("bucket gone")
+			}
+			return []reconstruct.BaselineFile{{Schema: "shop", Table: "orders", SnapshotTime: oldest.Add(-time.Hour)}}, nil
+		},
+		oldestDelta: func(context.Context, string) (time.Time, error) { return oldest, nil },
+	}
+	w.runCycle(context.Background())
+	if len(f.events) != 1 || f.events[0].Server != "b" || f.events[0].Severity != "critical" {
+		t.Fatalf("second target must still be graded when the first errors: %+v", f.events)
+	}
+}
+
+// TestStalenessWatcher_sameDSNDifferentSources: two targets on ONE index with
+// different baseline locations are distinct conditions — the healthy one must
+// never Resolve (falsely all-clear) the broken one's alert.
+func TestStalenessWatcher_sameDSNDifferentSources(t *testing.T) {
+	reg := testRegistryWithEntries(t,
+		console.ServerEntry{Name: "a", DSN: "d1", BaselineDir: "/stale"},
+		console.ServerEntry{Name: "b", DSN: "d1", BaselineDir: "/fresh"},
+	)
+	now := time.Now().UTC()
+	oldest := now.Add(-100 * time.Hour)
+	n, f := testNotifier()
+	w := &stalenessWatcher{
+		n: n, registry: reg, unknownEdge: notify.NewEdge(0),
+		listBaselines: func(_ context.Context, source string) ([]reconstruct.BaselineFile, error) {
+			ts := now.Add(-time.Hour)
+			if source == "/stale" {
+				ts = oldest.Add(-time.Hour)
+			}
+			return []reconstruct.BaselineFile{{Schema: "shop", Table: "orders", SnapshotTime: ts}}, nil
+		},
+		oldestDelta: func(context.Context, string) (time.Time, error) { return oldest, nil },
+	}
+	w.runCycle(context.Background())
+	w.runCycle(context.Background())
+	if len(f.events) != 1 || f.events[0].Resolved || f.events[0].Severity != "critical" {
+		t.Fatalf("want exactly one standing critical (no cross-resolve, no flap): %+v", f.events)
+	}
+}
+
+// TestStalenessWatcher_emptyListingKeepsAlert: baselines vanishing without
+// replacement is NOT a recovery — the active alert must neither resolve nor
+// re-fire while the source lists nothing.
+func TestStalenessWatcher_emptyListingKeepsAlert(t *testing.T) {
+	reg := testRegistryWithEntries(t, console.ServerEntry{Name: "wp", DSN: "d1", BaselineDir: "/b"})
+	now := time.Now().UTC()
+	oldest := now.Add(-100 * time.Hour)
+	n, f := testNotifier()
+	files := []reconstruct.BaselineFile{{Schema: "shop", Table: "orders", SnapshotTime: oldest.Add(-time.Hour)}}
+	w := &stalenessWatcher{
+		n: n, registry: reg, unknownEdge: notify.NewEdge(0),
+		listBaselines: func(context.Context, string) ([]reconstruct.BaselineFile, error) { return files, nil },
+		oldestDelta:   func(context.Context, string) (time.Time, error) { return oldest, nil },
+	}
+	w.runCycle(context.Background())
+	if len(f.events) != 1 {
+		t.Fatalf("setup: want the broken alert active, got %+v", f.events)
+	}
+	files = nil
+	w.runCycle(context.Background())
+	if len(f.events) != 1 {
+		t.Fatalf("empty listing must neither fire nor resolve: %+v", f.events)
+	}
+	// Snapshots reappear, still broken: the edge stayed active, so no re-fire.
+	files = []reconstruct.BaselineFile{{Schema: "shop", Table: "orders", SnapshotTime: oldest.Add(-time.Hour)}}
+	w.runCycle(context.Background())
+	if len(f.events) != 1 {
+		t.Fatalf("unchanged broken condition must not re-fire after the gap: %+v", f.events)
 	}
 }

--- a/consoleapp/staleness_test.go
+++ b/consoleapp/staleness_test.go
@@ -1,0 +1,102 @@
+package consoleapp
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/console"
+	"github.com/dbtrail/dbtrail/internal/reconstruct"
+)
+
+func TestWatchNotifier_BaselineStale(t *testing.T) {
+	n, f := testNotifier()
+	n.BaselineStale("wp", true, "shop.legacy: newest baseline predates coverage")
+	n.BaselineStale("wp", true, "shop.legacy: newest baseline predates coverage")
+	if len(f.events) != 1 || f.events[0].Event != "baseline_stale" || f.events[0].Severity != "critical" {
+		t.Fatalf("want one critical baseline_stale, got %+v", f.events)
+	}
+	n.BaselineStale("wp", false, "")
+	if len(f.events) != 2 || !f.events[1].Resolved {
+		t.Fatalf("recovery must resolve once, got %+v", f.events)
+	}
+	n.BaselineStale("wp", false, "")
+	if len(f.events) != 2 {
+		t.Fatalf("healthy with no prior alert must stay silent, got %+v", f.events)
+	}
+}
+
+// TestStalenessWatcher_targets pins the all-or-nothing baseline fallback and
+// the skip of servers with no baseline anywhere.
+func TestStalenessWatcher_targets(t *testing.T) {
+	reg := testRegistryWithEntries(t,
+		console.ServerEntry{Name: "own-dir", DSN: "d1", BaselineDir: "/own"},
+		console.ServerEntry{Name: "own-s3", DSN: "d2", BaselineS3: "s3://own"},
+		console.ServerEntry{Name: "inherits", DSN: "d3"},
+	)
+	w := &stalenessWatcher{registry: reg, bootDSN: "boot-dsn", globalDir: "/global"}
+	got := w.targets()
+	if len(got) != 4 {
+		t.Fatalf("want boot + 3 entries, got %+v", got)
+	}
+	bySrc := map[string]string{}
+	for _, tg := range got {
+		bySrc[tg.name] = tg.source
+	}
+	if bySrc["cli index"] != "/global" || bySrc["own-dir"] != "/own" || bySrc["own-s3"] != "s3://own" || bySrc["inherits"] != "/global" {
+		t.Fatalf("fallback wrong: %+v", bySrc)
+	}
+
+	// No global baseline: boot and the inheriting entry drop out.
+	w = &stalenessWatcher{registry: reg, bootDSN: "boot-dsn"}
+	if got := w.targets(); len(got) != 2 {
+		t.Fatalf("without a global source only own-baseline entries remain, got %+v", got)
+	}
+}
+
+func TestStalenessWatcher_runCycle(t *testing.T) {
+	reg := testRegistryWithEntries(t, console.ServerEntry{Name: "wp", DSN: "d1", BaselineDir: "/b"})
+	now := time.Now().UTC()
+	oldest := now.Add(-100 * time.Hour)
+	n, f := testNotifier()
+
+	files := []reconstruct.BaselineFile{
+		{Schema: "shop", Table: "orders", SnapshotTime: oldest.Add(-time.Hour)}, // superseded, broken
+		{Schema: "shop", Table: "orders", SnapshotTime: now.Add(-time.Hour)},   // newest, fine
+	}
+	w := &stalenessWatcher{
+		n: n, registry: reg,
+		listBaselines: func(context.Context, string) ([]reconstruct.BaselineFile, error) { return files, nil },
+		oldestDelta:   func(context.Context, string) (time.Time, error) { return oldest, nil },
+	}
+
+	// Newest per table is fine: no event.
+	w.runCycle(context.Background())
+	if len(f.events) != 0 {
+		t.Fatalf("healthy newest snapshot must not alert: %+v", f.events)
+	}
+
+	// The newest snapshot for a table slides past coverage: critical fires.
+	files = append(files, reconstruct.BaselineFile{Schema: "shop", Table: "legacy", SnapshotTime: oldest.Add(-2 * time.Hour)})
+	w.runCycle(context.Background())
+	if len(f.events) != 1 || f.events[0].Event != "baseline_stale" || f.events[0].Severity != "critical" {
+		t.Fatalf("broken newest snapshot must alert: %+v", f.events)
+	}
+
+	// Unknown floor: the target is skipped whole — no fire, and crucially NO
+	// resolve of the active alert.
+	w.oldestDelta = func(context.Context, string) (time.Time, error) { return time.Time{}, errors.New("index down") }
+	w.runCycle(context.Background())
+	if len(f.events) != 1 {
+		t.Fatalf("unknown floor must neither fire nor resolve: %+v", f.events)
+	}
+
+	// Fresh baseline lands: the alert resolves once.
+	w.oldestDelta = func(context.Context, string) (time.Time, error) { return oldest, nil }
+	files = append(files, reconstruct.BaselineFile{Schema: "shop", Table: "legacy", SnapshotTime: now.Add(-time.Minute)})
+	w.runCycle(context.Background())
+	if len(f.events) != 2 || !f.events[1].Resolved {
+		t.Fatalf("fresh baseline must resolve the alert: %+v", f.events)
+	}
+}

--- a/consoleapp/staleness_test.go
+++ b/consoleapp/staleness_test.go
@@ -7,22 +7,38 @@ import (
 	"time"
 
 	"github.com/dbtrail/dbtrail/internal/console"
+	"github.com/dbtrail/dbtrail/internal/notify"
 	"github.com/dbtrail/dbtrail/internal/reconstruct"
 )
 
 func TestWatchNotifier_BaselineStale(t *testing.T) {
 	n, f := testNotifier()
-	n.BaselineStale("wp", true, "shop.legacy: newest baseline predates coverage")
-	n.BaselineStale("wp", true, "shop.legacy: newest baseline predates coverage")
+	n.BaselineStale("wp", "dsn1", true, "shop.legacy", "2026-07-28T00:00:00Z")
+	n.BaselineStale("wp", "dsn1", true, "shop.legacy", "2026-07-28T00:00:00Z")
 	if len(f.events) != 1 || f.events[0].Event != "baseline_stale" || f.events[0].Severity != "critical" {
 		t.Fatalf("want one critical baseline_stale, got %+v", f.events)
 	}
-	n.BaselineStale("wp", false, "")
-	if len(f.events) != 2 || !f.events[1].Resolved {
+	if f.events[0].Details["tables"] != "shop.legacy" || f.events[0].Details["coverage_floor"] != "2026-07-28T00:00:00Z" {
+		t.Fatalf("details wrong: %+v", f.events[0].Details)
+	}
+	// The coverage floor advances every rotation cycle while the SAME tables
+	// stay broken — the edge detail is the table list precisely so this does
+	// not re-page hourly.
+	n.BaselineStale("wp", "dsn1", true, "shop.legacy", "2026-07-28T01:00:00Z")
+	if len(f.events) != 1 {
+		t.Fatalf("advancing floor with unchanged broken tables must not re-fire: %+v", f.events)
+	}
+	// A NEW table joining the broken set IS a new condition: immediate re-fire.
+	n.BaselineStale("wp", "dsn1", true, "shop.legacy, shop.orders", "2026-07-28T01:00:00Z")
+	if len(f.events) != 2 {
+		t.Fatalf("a new broken table must fire through the repeat window: %+v", f.events)
+	}
+	n.BaselineStale("wp", "dsn1", false, "", "")
+	if len(f.events) != 3 || !f.events[2].Resolved {
 		t.Fatalf("recovery must resolve once, got %+v", f.events)
 	}
-	n.BaselineStale("wp", false, "")
-	if len(f.events) != 2 {
+	n.BaselineStale("wp", "dsn1", false, "", "")
+	if len(f.events) != 3 {
 		t.Fatalf("healthy with no prior alert must stay silent, got %+v", f.events)
 	}
 }
@@ -67,6 +83,7 @@ func TestStalenessWatcher_runCycle(t *testing.T) {
 	}
 	w := &stalenessWatcher{
 		n: n, registry: reg,
+		unknownEdge:   notify.NewEdge(0),
 		listBaselines: func(context.Context, string) ([]reconstruct.BaselineFile, error) { return files, nil },
 		oldestDelta:   func(context.Context, string) (time.Time, error) { return oldest, nil },
 	}
@@ -77,11 +94,26 @@ func TestStalenessWatcher_runCycle(t *testing.T) {
 		t.Fatalf("healthy newest snapshot must not alert: %+v", f.events)
 	}
 
-	// The newest snapshot for a table slides past coverage: critical fires.
-	files = append(files, reconstruct.BaselineFile{Schema: "shop", Table: "legacy", SnapshotTime: oldest.Add(-2 * time.Hour)})
+	// The newest snapshots of two tables slide past coverage: ONE critical,
+	// carrying the full sorted broken set.
+	files = append(files,
+		reconstruct.BaselineFile{Schema: "shop", Table: "legacy", SnapshotTime: oldest.Add(-2 * time.Hour)},
+		reconstruct.BaselineFile{Schema: "shop", Table: "carts", SnapshotTime: oldest.Add(-3 * time.Hour)},
+	)
 	w.runCycle(context.Background())
 	if len(f.events) != 1 || f.events[0].Event != "baseline_stale" || f.events[0].Severity != "critical" {
-		t.Fatalf("broken newest snapshot must alert: %+v", f.events)
+		t.Fatalf("broken newest snapshots must alert once: %+v", f.events)
+	}
+	if f.events[0].Details["tables"] != "shop.carts, shop.legacy" {
+		t.Fatalf("detail must list ALL broken tables sorted: %+v", f.events[0].Details)
+	}
+
+	// Same broken set on the next cycle, floor advanced by rotation: silent.
+	oldestAdvanced := oldest.Add(time.Hour)
+	w.oldestDelta = func(context.Context, string) (time.Time, error) { return oldestAdvanced, nil }
+	w.runCycle(context.Background())
+	if len(f.events) != 1 {
+		t.Fatalf("unchanged broken set with an advanced floor must not re-fire: %+v", f.events)
 	}
 
 	// Unknown floor: the target is skipped whole — no fire, and crucially NO
@@ -92,9 +124,20 @@ func TestStalenessWatcher_runCycle(t *testing.T) {
 		t.Fatalf("unknown floor must neither fire nor resolve: %+v", f.events)
 	}
 
-	// Fresh baseline lands: the alert resolves once.
-	w.oldestDelta = func(context.Context, string) (time.Time, error) { return oldest, nil }
-	files = append(files, reconstruct.BaselineFile{Schema: "shop", Table: "legacy", SnapshotTime: now.Add(-time.Minute)})
+	// Unreadable baseline source: same skip-whole rule.
+	w.oldestDelta = func(context.Context, string) (time.Time, error) { return oldestAdvanced, nil }
+	w.listBaselines = func(context.Context, string) ([]reconstruct.BaselineFile, error) { return nil, errors.New("bucket gone") }
+	w.runCycle(context.Background())
+	if len(f.events) != 1 {
+		t.Fatalf("unreadable source must neither fire nor resolve: %+v", f.events)
+	}
+
+	// Fresh baselines land for both tables: the alert resolves once.
+	files = append(files,
+		reconstruct.BaselineFile{Schema: "shop", Table: "legacy", SnapshotTime: now.Add(-time.Minute)},
+		reconstruct.BaselineFile{Schema: "shop", Table: "carts", SnapshotTime: now.Add(-time.Minute)},
+	)
+	w.listBaselines = func(context.Context, string) ([]reconstruct.BaselineFile, error) { return files, nil }
 	w.runCycle(context.Background())
 	if len(f.events) != 2 || !f.events[1].Resolved {
 		t.Fatalf("fresh baseline must resolve the alert: %+v", f.events)

--- a/consoleapp/watch.go
+++ b/consoleapp/watch.go
@@ -439,6 +439,11 @@ func runUpConsoleOnly(cmd *cobra.Command) error {
 	if notifier != nil || upMetricsAddr != "" {
 		startContinuityWatch(ctx, notifier, registry, upIndexDSN)
 	}
+	// Baseline staleness (#1193) is webhook-only: status/console carry the
+	// full verdict; the channel gets the broken transition.
+	if notifier != nil {
+		startStalenessWatch(ctx, notifier, registry, upIndexDSN, upConsoleBaselineDir, upConsoleBaselineS3)
+	}
 
 	// Built-in rotation covers the boot index plus every per-source database
 	// the control plane provisions — the unattended quickstart's real data
@@ -603,6 +608,11 @@ func runUpStreamWithConsole(cmd *cobra.Command, args []string) error {
 	// neither, nothing runs.
 	if notifier != nil || upMetricsAddr != "" {
 		startContinuityWatch(ctx, notifier, registry, upIndexDSN)
+	}
+	// Baseline staleness (#1193) is webhook-only: status/console carry the
+	// full verdict; the channel gets the broken transition.
+	if notifier != nil {
+		startStalenessWatch(ctx, notifier, registry, upIndexDSN, upConsoleBaselineDir, upConsoleBaselineS3)
 	}
 
 	// Built-in rotation: boot index + every per-source database the control

--- a/docs/console.md
+++ b/docs/console.md
@@ -459,6 +459,10 @@ restore time:
 - `rotation_unhealthy` (**warning**) — a built-in rotation cycle failed or
   kept deferring unarchived partitions; either way the index is not
   shrinking when it should.
+- `baseline_stale` (**critical**) — a table's newest baseline predates the
+  oldest available delta coverage: full-table restore through the missing
+  window is impossible until a fresh baseline is taken. Checked hourly for
+  every server with a baseline location configured.
 
 The payload is `{event, severity, server, summary, details, timestamp}` —
 generic JSON, no per-vendor adapters: Slack, PagerDuty, ntfy etc. all accept

--- a/docs/rotation-and-status.md
+++ b/docs/rotation-and-status.md
@@ -605,3 +605,17 @@ bintrail rotate \
 This is the standalone equivalent of the rotation loop that `bintrail up` / `bintrail-console watch` run built-in — use it when you rotate a BYO index on a process separate from streaming.
 
 Schedule the timer to run once per hour. The drop operation is instant, but `REORGANIZE PARTITION` on a partition containing data does a full table scan of `p_future` to redistribute rows — if your `p_future` is empty (because you add future partitions frequently), the reorganize is also instant.
+
+## Baseline staleness
+
+With `--baseline-dir`, `bintrail status` grades every baseline snapshot
+against the oldest available delta coverage (live partitions plus archives):
+`ok`, `aging` (the snapshot is older than 80% of the coverage span — the
+restore window is shrinking), or `broken` (the anchor predates coverage —
+full-table reconstruct through that window is impossible). A table whose
+**newest** snapshot is broken trips a loud banner, and the JSON output
+carries per-baseline `staleness` plus a top-level `baseline_staleness`.
+The `watch` daemon's webhook channel sends a critical `baseline_stale`
+event on the transition into broken (see
+[console.md](console.md#webhook-notifications)). The fix is always the
+same: take a fresh baseline (`bintrail dump` + `bintrail baseline`).

--- a/docs/rotation-and-status.md
+++ b/docs/rotation-and-status.md
@@ -613,8 +613,9 @@ against the oldest available delta coverage — the oldest **live partition**
 hour (partition existence is coverage, even if the hour recorded no writes)
 extended backwards by archives:
 `ok`, `aging` (the snapshot is older than 80% of the coverage span — the
-restore window is shrinking), or `broken` (the anchor predates coverage —
-full-table reconstruct through that window is impossible). A table whose
+restore window is shrinking), `broken` (the anchor predates coverage —
+full-table reconstruct through that window is impossible), or `unknown`
+(the floor could not be evaluated — never reported as a false `ok`). A table whose
 **newest** snapshot is broken trips a loud banner, and the JSON output
 carries per-baseline `staleness` plus a top-level `baseline_staleness`.
 The `watch` daemon's webhook channel sends a critical `baseline_stale`

--- a/docs/rotation-and-status.md
+++ b/docs/rotation-and-status.md
@@ -609,7 +609,9 @@ Schedule the timer to run once per hour. The drop operation is instant, but `REO
 ## Baseline staleness
 
 With `--baseline-dir`, `bintrail status` grades every baseline snapshot
-against the oldest available delta coverage (live partitions plus archives):
+against the oldest available delta coverage — the oldest **live partition**
+hour (partition existence is coverage, even if the hour recorded no writes)
+extended backwards by archives:
 `ok`, `aging` (the snapshot is older than 80% of the coverage span — the
 restore window is shrinking), or `broken` (the anchor predates coverage —
 full-table reconstruct through that window is impossible). A table whose

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -114,6 +114,9 @@ func runStatus(cmd *cobra.Command, args []string) error {
 					Size:         size,
 				})
 			}
+			// Staleness (#1193): grade every snapshot against the oldest
+			// available delta coverage the sections above already loaded.
+			status.AnnotateBaselineStaleness(data.Baselines, data.Coverage.OldestDelta(), time.Now().UTC())
 		}
 	}
 

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -95,6 +95,10 @@ func runStatus(cmd *cobra.Command, args []string) error {
 		baselines, bErr := baseline.DiscoverBaselines(stBaselineDir)
 		if bErr != nil {
 			slog.Warn("could not discover baselines", "dir", stBaselineDir, "error", bErr)
+			// A configured-but-unreadable dir must not render like "no
+			// baselines configured" in JSON — a monitor watching
+			// baseline_staleness would read absence as healthy.
+			data.BaselinesUnavailable = true
 		} else {
 			for _, b := range baselines {
 				var size int64
@@ -116,8 +120,17 @@ func runStatus(cmd *cobra.Command, args []string) error {
 			}
 			// Staleness (#1193): grade every snapshot against the oldest
 			// available delta coverage — the live-partition floor (partition
-			// existence = coverage) extended backwards by archives.
-			status.AnnotateBaselineStaleness(data.Baselines, status.DeltaFloor(data.Parts, data.Coverage), time.Now().UTC())
+			// existence = coverage) extended backwards by archives. The floor
+			// comes from OldestDeltaFromDB, NOT data.Coverage: coverage is
+			// best-effort display data that swallows archive_state errors,
+			// and a floor built on it would fabricate "broken" on healthy
+			// archives whenever that one read fails. A floor error degrades
+			// every verdict to unknown.
+			floor, fErr := status.OldestDeltaFromDB(cmd.Context(), db, dbName)
+			if fErr != nil {
+				slog.Warn("could not determine the delta-coverage floor; baseline staleness is unknown", "error", fErr)
+			}
+			status.AnnotateBaselineStaleness(data.Baselines, floor, time.Now().UTC())
 		}
 	}
 

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -115,8 +115,9 @@ func runStatus(cmd *cobra.Command, args []string) error {
 				})
 			}
 			// Staleness (#1193): grade every snapshot against the oldest
-			// available delta coverage the sections above already loaded.
-			status.AnnotateBaselineStaleness(data.Baselines, data.Coverage.OldestDelta(), time.Now().UTC())
+			// available delta coverage — the live-partition floor (partition
+			// existence = coverage) extended backwards by archives.
+			status.AnnotateBaselineStaleness(data.Baselines, status.DeltaFloor(data.Parts, data.Coverage), time.Now().UTC())
 		}
 	}
 

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -2104,14 +2104,21 @@ function baselinesPanel(b, servers) {
       el("code", { class: "stg-code", text: b.source }),
       el("p", { class: "stg-empty-sub", text: "Run bintrail dump and bintrail baseline to create your first snapshot. The path must point at the folder that contains the snapshots, not a specific file (<timestamp>/<schema>/<table>.parquet)." })));
   } else {
-    b.snapshots.forEach((sn) => {
+    // Panel headline: the newest-per-table rollup. Older snapshots being past
+    // coverage is routine (superseded) — only the headline and the newest
+    // row's verdict are actionable, so only those get a chip.
+    if (b.staleness && b.staleness !== "ok") {
+      list.append(el("div", { class: "vfy-summary" },
+        el("span", { class: "chip chip-mon", text: b.staleness === "broken"
+          ? "⚠ BASELINE STALE — full-table restore broken; take a fresh baseline"
+          : "BASELINE " + b.staleness.toUpperCase() })));
+    }
+    b.snapshots.forEach((sn, idx) => {
       const row = el("div", { class: "stg-row" });
       row.append(el("span", { class: "stg-name mono", text: sn.time }));
       row.append(el("span", { class: "stg-dest", text:
         (sn.tables || []).length + " table(s)" + (sn.binlog_file ? " · " + sn.binlog_file + ":" + sn.binlog_pos : "") }));
-      // Staleness verdict vs delta coverage — "ok" stays quiet; "broken"
-      // means this snapshot can no longer anchor a full-table restore.
-      if (sn.staleness && sn.staleness !== "ok") {
+      if (idx === 0 && sn.staleness && sn.staleness !== "ok") {
         row.append(el("span", { class: "chip chip-mon", text:
           sn.staleness === "broken" ? "⚠ STALE — restore broken" : sn.staleness.toUpperCase() }));
       }

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -2109,6 +2109,12 @@ function baselinesPanel(b, servers) {
       row.append(el("span", { class: "stg-name mono", text: sn.time }));
       row.append(el("span", { class: "stg-dest", text:
         (sn.tables || []).length + " table(s)" + (sn.binlog_file ? " · " + sn.binlog_file + ":" + sn.binlog_pos : "") }));
+      // Staleness verdict vs delta coverage — "ok" stays quiet; "broken"
+      // means this snapshot can no longer anchor a full-table restore.
+      if (sn.staleness && sn.staleness !== "ok") {
+        row.append(el("span", { class: "chip chip-mon", text:
+          sn.staleness === "broken" ? "⚠ STALE — restore broken" : sn.staleness.toUpperCase() }));
+      }
       row.append(el("span", { class: "stg-age", text: formatAge(sn.age_hours) + " ago" }));
       list.append(row);
     });

--- a/internal/console/baselines_api.go
+++ b/internal/console/baselines_api.go
@@ -31,8 +31,8 @@ type baselineSnapshotDTO struct {
 	GTIDSet    string `json:"gtid_set,omitempty"`
 	// Staleness grades this snapshot's anchor against the oldest available
 	// delta coverage of the selected server's index (#1193):
-	// ok | aging | broken | unknown. Empty when the floor query failed —
-	// never reported as ok.
+	// ok | aging | broken | unknown. "unknown" when the coverage floor could
+	// not be read — never reported as ok.
 	Staleness string `json:"staleness,omitempty"`
 }
 
@@ -100,10 +100,14 @@ func (s *Server) handleBaselines(w http.ResponseWriter, r *http.Request) {
 	// fabricated verdict — an unopened bundle connection or an unreadable
 	// index yields the explicit "unknown".
 	var oldestDelta time.Time
+	serverID := r.Header.Get("X-Bintrail-Server")
+	if serverID == "" {
+		serverID = "default"
+	}
 	if b.db == nil {
-		slog.Warn("console: baseline staleness not evaluated — the server's index connection is not open")
+		slog.Warn("console: baseline staleness not evaluated — the server's index connection is not open", "server", serverID)
 	} else if od, err := status.OldestDeltaFromDB(r.Context(), b.db, b.dbName); err != nil {
-		slog.Warn("console: could not load delta-coverage floor for baseline staleness", "error", err)
+		slog.Warn("console: could not load delta-coverage floor for baseline staleness", "server", serverID, "error", err)
 	} else {
 		oldestDelta = od
 	}
@@ -139,20 +143,14 @@ func (s *Server) handleBaselines(w http.ResponseWriter, r *http.Request) {
 		}
 		cur.Tables = append(cur.Tables, f.Schema+"."+f.Table)
 	}
-	// Headline over ALL files (not just the listed page): newest per table.
-	newestPerTable := make(map[string]time.Time, len(files))
-	for _, f := range files {
-		k := f.Schema + "." + f.Table
-		if f.SnapshotTime.After(newestPerTable[k]) {
-			newestPerTable[k] = f.SnapshotTime
-		}
+	// Headline over ALL files (not just the listed page), delegated to the
+	// status package's newest-per-table rollup so the console and the CLI can
+	// never rank verdicts differently.
+	infos := make([]status.BaselineInfo, len(files))
+	for i, f := range files {
+		infos[i] = status.BaselineInfo{Database: f.Schema, Table: f.Table, SnapshotTime: f.SnapshotTime}
 	}
-	rank := map[string]int{"ok": 1, "unknown": 2, "aging": 3, "broken": 4}
-	for _, ts := range newestPerTable {
-		v := string(status.BaselineStalenessFor(ts, oldestDelta, now))
-		if rank[v] > rank[resp.Staleness] {
-			resp.Staleness = v
-		}
-	}
+	status.AnnotateBaselineStaleness(infos, oldestDelta, now)
+	resp.Staleness = string(status.OverallBaselineStaleness(infos))
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/internal/console/baselines_api.go
+++ b/internal/console/baselines_api.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/dbtrail/dbtrail/internal/baseline"
 	"github.com/dbtrail/dbtrail/internal/reconstruct"
+	"github.com/dbtrail/dbtrail/internal/status"
 )
 
 // baselinesMaxSnapshots caps the snapshots GET /api/baselines returns — the
@@ -28,6 +29,11 @@ type baselineSnapshotDTO struct {
 	BinlogFile string `json:"binlog_file,omitempty"`
 	BinlogPos  int64  `json:"binlog_pos,omitempty"`
 	GTIDSet    string `json:"gtid_set,omitempty"`
+	// Staleness grades this snapshot's anchor against the oldest available
+	// delta coverage of the selected server's index (#1193):
+	// ok | aging | broken | unknown. Empty when the floor query failed —
+	// never reported as ok.
+	Staleness string `json:"staleness,omitempty"`
 }
 
 type baselinesResponse struct {
@@ -85,6 +91,14 @@ func (s *Server) handleBaselines(w http.ResponseWriter, r *http.Request) {
 	}
 
 	now := time.Now().UTC()
+	// Staleness floor (#1193): best-effort — an unreadable index leaves the
+	// verdict empty (unknown-shaped), never a fabricated "ok".
+	var oldestDelta time.Time
+	if od, err := status.OldestDeltaFromDB(r.Context(), b.db); err != nil {
+		slog.Warn("console: could not load delta-coverage floor for baseline staleness", "error", err)
+	} else {
+		oldestDelta = od
+	}
 	var cur *baselineSnapshotDTO
 	var curTime time.Time
 	for _, f := range files {
@@ -97,6 +111,9 @@ func (s *Server) handleBaselines(w http.ResponseWriter, r *http.Request) {
 			dto := baselineSnapshotDTO{
 				Time:     f.SnapshotTime.Format(consoleTSFormat),
 				AgeHours: now.Sub(f.SnapshotTime).Hours(),
+			}
+			if !oldestDelta.IsZero() {
+				dto.Staleness = string(status.BaselineStalenessFor(f.SnapshotTime, oldestDelta, now))
 			}
 			if resp.Kind == "dir" {
 				if meta, err := baseline.ReadParquetMetadata(f.Path); err == nil {

--- a/internal/console/baselines_api.go
+++ b/internal/console/baselines_api.go
@@ -91,13 +91,16 @@ func (s *Server) handleBaselines(w http.ResponseWriter, r *http.Request) {
 	}
 
 	now := time.Now().UTC()
-	// Staleness floor (#1193): best-effort — an unreadable index leaves the
-	// verdict empty (unknown-shaped), never a fabricated "ok".
+	// Staleness floor (#1193): best-effort — an unopened bundle connection or
+	// an unreadable index leaves the verdict empty (unknown-shaped), never a
+	// fabricated "ok".
 	var oldestDelta time.Time
-	if od, err := status.OldestDeltaFromDB(r.Context(), b.db); err != nil {
-		slog.Warn("console: could not load delta-coverage floor for baseline staleness", "error", err)
-	} else {
-		oldestDelta = od
+	if b.db != nil {
+		if od, err := status.OldestDeltaFromDB(r.Context(), b.db); err != nil {
+			slog.Warn("console: could not load delta-coverage floor for baseline staleness", "error", err)
+		} else {
+			oldestDelta = od
+		}
 	}
 	var cur *baselineSnapshotDTO
 	var curTime time.Time

--- a/internal/console/baselines_api.go
+++ b/internal/console/baselines_api.go
@@ -47,6 +47,11 @@ type baselinesResponse struct {
 	Reconstruct bool                  `json:"reconstruct"`
 	Snapshots   []baselineSnapshotDTO `json:"snapshots"`
 	Truncated   bool                  `json:"truncated,omitempty"`
+	// Staleness is the panel headline: the worst verdict across each table's
+	// NEWEST snapshot (#1193). An old superseded snapshot being past coverage
+	// is routine — grading every row red on a healthy retention cadence would
+	// cry wolf, so the per-row verdicts inform and this field decides.
+	Staleness string `json:"staleness,omitempty"`
 }
 
 // handleBaselines serves GET /api/baselines: a read-only listing of the
@@ -91,16 +96,16 @@ func (s *Server) handleBaselines(w http.ResponseWriter, r *http.Request) {
 	}
 
 	now := time.Now().UTC()
-	// Staleness floor (#1193): best-effort — an unopened bundle connection or
-	// an unreadable index leaves the verdict empty (unknown-shaped), never a
-	// fabricated "ok".
+	// Staleness floor (#1193): best-effort but never silent and never a
+	// fabricated verdict — an unopened bundle connection or an unreadable
+	// index yields the explicit "unknown".
 	var oldestDelta time.Time
-	if b.db != nil {
-		if od, err := status.OldestDeltaFromDB(r.Context(), b.db); err != nil {
-			slog.Warn("console: could not load delta-coverage floor for baseline staleness", "error", err)
-		} else {
-			oldestDelta = od
-		}
+	if b.db == nil {
+		slog.Warn("console: baseline staleness not evaluated — the server's index connection is not open")
+	} else if od, err := status.OldestDeltaFromDB(r.Context(), b.db, b.dbName); err != nil {
+		slog.Warn("console: could not load delta-coverage floor for baseline staleness", "error", err)
+	} else {
+		oldestDelta = od
 	}
 	var cur *baselineSnapshotDTO
 	var curTime time.Time
@@ -115,9 +120,7 @@ func (s *Server) handleBaselines(w http.ResponseWriter, r *http.Request) {
 				Time:     f.SnapshotTime.Format(consoleTSFormat),
 				AgeHours: now.Sub(f.SnapshotTime).Hours(),
 			}
-			if !oldestDelta.IsZero() {
-				dto.Staleness = string(status.BaselineStalenessFor(f.SnapshotTime, oldestDelta, now))
-			}
+			dto.Staleness = string(status.BaselineStalenessFor(f.SnapshotTime, oldestDelta, now))
 			if resp.Kind == "dir" {
 				if meta, err := baseline.ReadParquetMetadata(f.Path); err == nil {
 					dto.BinlogFile = meta.BinlogFile
@@ -135,6 +138,21 @@ func (s *Server) handleBaselines(w http.ResponseWriter, r *http.Request) {
 			cur = &resp.Snapshots[len(resp.Snapshots)-1]
 		}
 		cur.Tables = append(cur.Tables, f.Schema+"."+f.Table)
+	}
+	// Headline over ALL files (not just the listed page): newest per table.
+	newestPerTable := make(map[string]time.Time, len(files))
+	for _, f := range files {
+		k := f.Schema + "." + f.Table
+		if f.SnapshotTime.After(newestPerTable[k]) {
+			newestPerTable[k] = f.SnapshotTime
+		}
+	}
+	rank := map[string]int{"ok": 1, "unknown": 2, "aging": 3, "broken": 4}
+	for _, ts := range newestPerTable {
+		v := string(status.BaselineStalenessFor(ts, oldestDelta, now))
+		if rank[v] > rank[resp.Staleness] {
+			resp.Staleness = v
+		}
 	}
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/internal/console/baselines_staleness_test.go
+++ b/internal/console/baselines_staleness_test.go
@@ -1,0 +1,70 @@
+package console
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+)
+
+// TestBaselinesAPI_staleness pins the console's staleness surface: per-row
+// verdicts, the newest-per-table headline (a superseded broken snapshot must
+// not drive it), and the shared rollup with the status package.
+func TestBaselinesAPI_staleness(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now().UTC()
+	ts := func(age time.Duration) string { return now.Add(-age).Format("2006-01-02T15-04-05Z") }
+	// Floor = 100h ago. orders: newest 1h ago (ok) + superseded 200h ago
+	// (broken, routine). legacy: newest 150h ago (broken — drives headline).
+	writeBaselineFixture(t, dir, ts(time.Hour), "shop", "orders.parquet")
+	writeBaselineFixture(t, dir, ts(200*time.Hour), "shop", "orders.parquet")
+	writeBaselineFixture(t, dir, ts(150*time.Hour), "shop", "legacy.parquet")
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	mock.ExpectQuery("PARTITION_NAME FROM information_schema.PARTITIONS").
+		WillReturnRows(sqlmock.NewRows([]string{"PARTITION_NAME"}).AddRow(now.Add(-100 * time.Hour).Format("p_2006010215")))
+	mock.ExpectQuery(`MIN\(partition_name\)`).
+		WillReturnRows(sqlmock.NewRows([]string{"min", "max"}).AddRow(nil, nil))
+
+	srv := newBaselineServer(t, dir, true)
+	srv.cm.boot.db = db
+	srv.cm.boot.dbName = "binlog_index"
+	rec, body := doServersReq(t, srv, "GET", "/api/baselines", "")
+	if rec.Code != 200 {
+		t.Fatalf("code = %d, body = %s", rec.Code, body)
+	}
+	var got baselinesResponse
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Staleness != "broken" {
+		t.Fatalf("headline = %q, want broken (legacy's newest predates coverage)", got.Staleness)
+	}
+	if len(got.Snapshots) != 3 {
+		t.Fatalf("snapshots = %+v, want 3", got.Snapshots)
+	}
+	// Newest first: orders(1h)=ok, legacy(150h)=broken, orders(200h)=broken.
+	if got.Snapshots[0].Staleness != "ok" || got.Snapshots[1].Staleness != "broken" || got.Snapshots[2].Staleness != "broken" {
+		t.Fatalf("per-row verdicts wrong: %+v", got.Snapshots)
+	}
+
+	// No index connection: every verdict — including the headline — is the
+	// explicit "unknown", never "ok".
+	srvNil := newBaselineServer(t, dir, true)
+	rec, body = doServersReq(t, srvNil, "GET", "/api/baselines", "")
+	if rec.Code != 200 {
+		t.Fatalf("code = %d, body = %s", rec.Code, body)
+	}
+	got = baselinesResponse{}
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Staleness != "unknown" || got.Snapshots[0].Staleness != "unknown" {
+		t.Fatalf("nil db must yield explicit unknown everywhere: headline %q, rows %+v", got.Staleness, got.Snapshots)
+	}
+}

--- a/internal/notify/edge.go
+++ b/internal/notify/edge.go
@@ -60,6 +60,16 @@ func (e *Edge) Fire(key, detail string) bool {
 	return true
 }
 
+// Active reports whether key has fired and not yet resolved — for callers
+// that must treat "cannot re-evaluate" differently while an alert is standing
+// (e.g. a baseline source that now lists nothing).
+func (e *Edge) Active(key string) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	_, ok := e.active[key]
+	return ok
+}
+
 // Resolve reports whether the caller should send a recovery notification:
 // true only if key was active (fired at least once and not yet resolved).
 func (e *Edge) Resolve(key string) bool {

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -45,6 +45,7 @@ const (
 	EventContinuityGapLost = "continuity_gap_lost"
 	EventVerifyProblem     = "verify_problem"
 	EventRotationUnhealthy = "rotation_unhealthy"
+	EventBaselineStale     = "baseline_stale"
 
 	SeverityInfo     = "info"
 	SeverityWarning  = "warning"

--- a/internal/reconstruct/eventfold.go
+++ b/internal/reconstruct/eventfold.go
@@ -3,8 +3,10 @@ package reconstruct
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/dbtrail/dbtrail/internal/metadata"
 	"github.com/dbtrail/dbtrail/internal/query"
@@ -293,6 +295,15 @@ func foldEventWindow(ctx context.Context, fc foldConfig) (*foldResult, error) {
 		// connectivity instead of reading the actionable message underneath.
 		if foldErr != nil {
 			return nil, foldErr
+		}
+		// A coverage gap in a window anchored at the baseline usually means
+		// the baseline went STALE — its anchor slid past rotation retention.
+		// Name the fix (#1193): no flag recovers hours that were rotated out
+		// unarchived.
+		var gapErr *query.GapError
+		if errors.As(err, &gapErr) && fc.Opts.Since != nil {
+			return nil, fmt.Errorf("fetch events: %w — the delta window starts at this table's newest usable baseline anchor (%s); if the missing hours were rotated out unarchived, take a fresh baseline (bintrail dump + bintrail baseline)",
+				err, fc.Opts.Since.UTC().Format(time.RFC3339))
 		}
 		return nil, fmt.Errorf("fetch events: %w", err)
 	}

--- a/internal/reconstruct/eventfold.go
+++ b/internal/reconstruct/eventfold.go
@@ -302,7 +302,7 @@ func foldEventWindow(ctx context.Context, fc foldConfig) (*foldResult, error) {
 		// unarchived.
 		var gapErr *query.GapError
 		if errors.As(err, &gapErr) && fc.Opts.Since != nil {
-			return nil, fmt.Errorf("fetch events: %w — the delta window starts at this table's newest usable baseline anchor (%s); if the missing hours were rotated out unarchived, take a fresh baseline (bintrail dump + bintrail baseline)",
+			return nil, fmt.Errorf("fetch events: %w — the delta window starts at this table's newest usable baseline anchor (%s); if archive_state drifted, `bintrail archive reconcile --repair` is the cheap fix, and if the missing hours were rotated out unarchived, take a fresh baseline (bintrail dump + bintrail baseline)",
 				err, fc.Opts.Since.UTC().Format(time.RFC3339))
 		}
 		return nil, fmt.Errorf("fetch events: %w", err)

--- a/internal/status/staleness.go
+++ b/internal/status/staleness.go
@@ -1,0 +1,111 @@
+package status
+
+import (
+	"context"
+	"database/sql"
+	"time"
+)
+
+// Baseline staleness (#1193): full-table reconstruct = newest usable baseline
+// + deltas since it. Deltas are bounded by rotation retention plus archives;
+// when a baseline's anchor slides toward — or past — the oldest available
+// delta, the restore window is shrinking or already broken, and the operator
+// must learn that from status/console/alerts NOW, not at restore time.
+type BaselineStalenessVerdict string
+
+const (
+	BaselineOK     BaselineStalenessVerdict = "ok"
+	BaselineAging  BaselineStalenessVerdict = "aging"
+	BaselineBroken BaselineStalenessVerdict = "broken"
+	// BaselineUnknown = no evaluable delta floor (empty index, no archives).
+	// Unknown is never "ok" — the same rule every other verdict here follows.
+	BaselineUnknown BaselineStalenessVerdict = "unknown"
+)
+
+// baselineAgingFraction: a baseline older than this fraction of the delta
+// coverage span is "aging" — the restore window is shrinking, and continued
+// rotation will eventually break it.
+const baselineAgingFraction = 0.8
+
+// BaselineStalenessFor grades one snapshot anchor against the oldest instant
+// deltas are available from.
+func BaselineStalenessFor(snapshotTime, oldestDelta, now time.Time) BaselineStalenessVerdict {
+	if snapshotTime.IsZero() || oldestDelta.IsZero() {
+		return BaselineUnknown
+	}
+	if snapshotTime.Before(oldestDelta) {
+		return BaselineBroken
+	}
+	span := now.Sub(oldestDelta)
+	if span <= 0 {
+		return BaselineOK
+	}
+	if float64(now.Sub(snapshotTime)) >= baselineAgingFraction*float64(span) {
+		return BaselineAging
+	}
+	return BaselineOK
+}
+
+// OldestDelta is the earliest instant deltas are available from — archived
+// partitions extend live coverage backwards. Zero = unknown.
+func (c *CoverageInfo) OldestDelta() time.Time {
+	if c == nil {
+		return time.Time{}
+	}
+	var out time.Time
+	if c.EarliestEvent.Valid {
+		out = c.EarliestEvent.Time
+	}
+	if c.ArchiveEarliestHour.Valid && (out.IsZero() || c.ArchiveEarliestHour.Time.Before(out)) {
+		out = c.ArchiveEarliestHour.Time
+	}
+	return out
+}
+
+// OldestDeltaFromDB is the lean two-query sibling of LoadCoverage for callers
+// (the console baselines API, the watch staleness check) that need only the
+// floor. A missing archive_state table (older indexes) degrades to live
+// coverage alone, mirroring LoadCoverage's tolerance.
+func OldestDeltaFromDB(ctx context.Context, db *sql.DB) (time.Time, error) {
+	var c CoverageInfo
+	if err := db.QueryRowContext(ctx, `SELECT MIN(event_timestamp) FROM binlog_events`).Scan(&c.EarliestEvent); err != nil {
+		return time.Time{}, err
+	}
+	var minPartition sql.NullString
+	if err := db.QueryRowContext(ctx, `SELECT MIN(partition_name) FROM archive_state`).Scan(&minPartition); err == nil && minPartition.Valid {
+		if t, ok := parsePartitionName(minPartition.String); ok {
+			c.ArchiveEarliestHour = sql.NullTime{Time: t, Valid: true}
+		}
+	}
+	return c.OldestDelta(), nil
+}
+
+// AnnotateBaselineStaleness stamps each entry's verdict in place. Every entry
+// is graded on its own anchor — a superseded old snapshot showing "broken" is
+// honest (it IS unusable); what decides the headline is
+// OverallBaselineStaleness, which only looks at each table's newest snapshot.
+func AnnotateBaselineStaleness(baselines []BaselineInfo, oldestDelta, now time.Time) {
+	for i := range baselines {
+		baselines[i].Staleness = BaselineStalenessFor(baselines[i].SnapshotTime, oldestDelta, now)
+	}
+}
+
+// OverallBaselineStaleness is the worst verdict across each table's NEWEST
+// snapshot. "" when the list is empty or unannotated.
+func OverallBaselineStaleness(baselines []BaselineInfo) BaselineStalenessVerdict {
+	rank := map[BaselineStalenessVerdict]int{BaselineOK: 1, BaselineUnknown: 2, BaselineAging: 3, BaselineBroken: 4}
+	newest := make(map[string]BaselineInfo, len(baselines))
+	for _, b := range baselines {
+		k := b.Database + "." + b.Table
+		if cur, ok := newest[k]; !ok || cur.SnapshotTime.Before(b.SnapshotTime) {
+			newest[k] = b
+		}
+	}
+	var out BaselineStalenessVerdict
+	for _, b := range newest {
+		if rank[b.Staleness] > rank[out] {
+			out = b.Staleness
+		}
+	}
+	return out
+}

--- a/internal/status/staleness.go
+++ b/internal/status/staleness.go
@@ -22,8 +22,8 @@ const (
 	BaselineAging  BaselineStalenessVerdict = "aging"
 	BaselineBroken BaselineStalenessVerdict = "broken"
 	// BaselineUnknown = no evaluable delta floor (unpartitioned/unreachable
-	// index, no archives). Unknown is never "ok" — the same rule every other
-	// verdict here follows.
+	// index, no archives). Unknown is never "ok" — the same fail-closed rule
+	// as continuity's "unknown" verdict.
 	BaselineUnknown BaselineStalenessVerdict = "unknown"
 )
 
@@ -77,23 +77,15 @@ func OldestLivePartitionHour(parts []PartitionStat) time.Time {
 	return out
 }
 
-// DeltaFloor combines the live-partition floor with the archive floor —
-// archives extend coverage backwards. Zero = unknown.
-func DeltaFloor(parts []PartitionStat, cov *CoverageInfo) time.Time {
-	out := OldestLivePartitionHour(parts)
-	if cov != nil && cov.ArchiveEarliestHour.Valid &&
-		(out.IsZero() || cov.ArchiveEarliestHour.Time.Before(out)) {
-		out = cov.ArchiveEarliestHour.Time
-	}
-	return out
-}
-
-// OldestDeltaFromDB computes the same floor for callers without a collected
-// StatusData (the console baselines API, the watch staleness check). Error
-// semantics are strict in the anti-cry-wolf direction: any failure that could
-// make the floor read LATER than reality — and so fabricate "broken" on
-// healthy archives — is returned (the caller degrades to unknown), never
-// swallowed. Only a missing archive_state table (older indexes) is tolerated.
+// OldestDeltaFromDB computes the delta-coverage floor: the live-partition
+// floor extended backwards by contiguous archives. It is the ONLY floor
+// implementation — the CLI, console, and watcher all use it (CoverageInfo's
+// ArchiveEarliestHour is a best-effort DISPLAY figure whose errors are
+// swallowed, which a verdict must never be built on). Error semantics are
+// strict in the anti-cry-wolf direction: any failure that could make the
+// floor read LATER than reality — and so fabricate "broken" on healthy
+// archives — is returned (the caller degrades to unknown), never swallowed.
+// Only a missing archive_state table (older indexes) is tolerated.
 func OldestDeltaFromDB(ctx context.Context, db *sql.DB, dbName string) (time.Time, error) {
 	rows, err := db.QueryContext(ctx, `
 		SELECT PARTITION_NAME FROM information_schema.PARTITIONS
@@ -115,8 +107,8 @@ func OldestDeltaFromDB(ctx context.Context, db *sql.DB, dbName string) (time.Tim
 	}
 	floor := OldestLivePartitionHour(parts)
 
-	var minPartition sql.NullString
-	if err := db.QueryRowContext(ctx, `SELECT MIN(partition_name) FROM archive_state`).Scan(&minPartition); err != nil {
+	var minPartition, maxPartition sql.NullString
+	if err := db.QueryRowContext(ctx, `SELECT MIN(partition_name), MAX(partition_name) FROM archive_state`).Scan(&minPartition, &maxPartition); err != nil {
 		var myErr *mysql.MySQLError
 		if errors.As(err, &myErr) && myErr.Number == 1146 {
 			return floor, nil // archive_state absent on older indexes — live floor only
@@ -124,14 +116,27 @@ func OldestDeltaFromDB(ctx context.Context, db *sql.DB, dbName string) (time.Tim
 		return time.Time{}, fmt.Errorf("read archive floor: %w", err)
 	}
 	if minPartition.Valid {
-		t, ok := parsePartitionName(minPartition.String)
+		minT, ok := parsePartitionName(minPartition.String)
 		if !ok {
 			// Our own naming scheme failing to parse is drift, and silently
 			// dropping the archive floor would fabricate "broken".
 			return time.Time{}, fmt.Errorf("archive_state MIN(partition_name) %q is unparseable", minPartition.String)
 		}
-		if floor.IsZero() || t.Before(floor) {
-			floor = t
+		maxT, ok := parsePartitionName(maxPartition.String)
+		if !ok {
+			return time.Time{}, fmt.Errorf("archive_state MAX(partition_name) %q is unparseable", maxPartition.String)
+		}
+		// Archives extend the floor backwards ONLY when their range reaches
+		// the live partitions: if the newest archived hour ends before the
+		// oldest live partition begins (archiving stopped, middle range
+		// pruned), every restore anchored before the live floor crosses that
+		// hole — so the live floor IS the coverage floor, and extending it
+		// would grade those baselines with an unearned "ok". Interior holes
+		// within the archive range are still invisible here; reconstruct's
+		// planner gap check catches those at restore time.
+		contiguous := floor.IsZero() || !maxT.Add(time.Hour).Before(floor)
+		if contiguous && (floor.IsZero() || minT.Before(floor)) {
+			floor = minT
 		}
 	}
 	return floor, nil

--- a/internal/status/staleness.go
+++ b/internal/status/staleness.go
@@ -3,7 +3,11 @@ package status
 import (
 	"context"
 	"database/sql"
+	"errors"
+	"fmt"
 	"time"
+
+	"github.com/go-sql-driver/mysql"
 )
 
 // Baseline staleness (#1193): full-table reconstruct = newest usable baseline
@@ -17,14 +21,21 @@ const (
 	BaselineOK     BaselineStalenessVerdict = "ok"
 	BaselineAging  BaselineStalenessVerdict = "aging"
 	BaselineBroken BaselineStalenessVerdict = "broken"
-	// BaselineUnknown = no evaluable delta floor (empty index, no archives).
-	// Unknown is never "ok" — the same rule every other verdict here follows.
+	// BaselineUnknown = no evaluable delta floor (unpartitioned/unreachable
+	// index, no archives). Unknown is never "ok" — the same rule every other
+	// verdict here follows.
 	BaselineUnknown BaselineStalenessVerdict = "unknown"
 )
 
 // baselineAgingFraction: a baseline older than this fraction of the delta
-// coverage span is "aging" — the restore window is shrinking, and continued
-// rotation will eventually break it.
+// coverage span is "aging" — the restore window is shrinking.
+//
+// Known bootstrap artifact: until rotation saturates retention, the span is
+// the install's age, so a young install reads "aging" within hours of its
+// first baseline. That is why "aging" stays an informational verdict on
+// status/console and is deliberately NOT wired to the webhook channel — an
+// alert that fires on every fresh install would be cried-wolf into a mute
+// before it ever mattered.
 const baselineAgingFraction = 0.8
 
 // BaselineStalenessFor grades one snapshot anchor against the oldest instant
@@ -46,38 +57,84 @@ func BaselineStalenessFor(snapshotTime, oldestDelta, now time.Time) BaselineStal
 	return BaselineOK
 }
 
-// OldestDelta is the earliest instant deltas are available from — archived
-// partitions extend live coverage backwards. Zero = unknown.
-func (c *CoverageInfo) OldestDelta() time.Time {
-	if c == nil {
-		return time.Time{}
-	}
+// OldestLivePartitionHour is the live half of the delta floor: the hour of
+// the oldest non-future binlog_events partition. Partition EXISTENCE is
+// coverage — the planner's own rule. MIN(event_timestamp) must NOT be used
+// here: it is the first WRITE, not the coverage start, and on a quiet
+// database it would fabricate a "broken" verdict (baseline taken before the
+// first write) on a perfectly restorable index.
+func OldestLivePartitionHour(parts []PartitionStat) time.Time {
 	var out time.Time
-	if c.EarliestEvent.Valid {
-		out = c.EarliestEvent.Time
-	}
-	if c.ArchiveEarliestHour.Valid && (out.IsZero() || c.ArchiveEarliestHour.Time.Before(out)) {
-		out = c.ArchiveEarliestHour.Time
+	for _, p := range parts {
+		t, ok := parsePartitionName(p.Name)
+		if !ok {
+			continue // p_future / malformed
+		}
+		if out.IsZero() || t.Before(out) {
+			out = t
+		}
 	}
 	return out
 }
 
-// OldestDeltaFromDB is the lean two-query sibling of LoadCoverage for callers
-// (the console baselines API, the watch staleness check) that need only the
-// floor. A missing archive_state table (older indexes) degrades to live
-// coverage alone, mirroring LoadCoverage's tolerance.
-func OldestDeltaFromDB(ctx context.Context, db *sql.DB) (time.Time, error) {
-	var c CoverageInfo
-	if err := db.QueryRowContext(ctx, `SELECT MIN(event_timestamp) FROM binlog_events`).Scan(&c.EarliestEvent); err != nil {
+// DeltaFloor combines the live-partition floor with the archive floor —
+// archives extend coverage backwards. Zero = unknown.
+func DeltaFloor(parts []PartitionStat, cov *CoverageInfo) time.Time {
+	out := OldestLivePartitionHour(parts)
+	if cov != nil && cov.ArchiveEarliestHour.Valid &&
+		(out.IsZero() || cov.ArchiveEarliestHour.Time.Before(out)) {
+		out = cov.ArchiveEarliestHour.Time
+	}
+	return out
+}
+
+// OldestDeltaFromDB computes the same floor for callers without a collected
+// StatusData (the console baselines API, the watch staleness check). Error
+// semantics are strict in the anti-cry-wolf direction: any failure that could
+// make the floor read LATER than reality — and so fabricate "broken" on
+// healthy archives — is returned (the caller degrades to unknown), never
+// swallowed. Only a missing archive_state table (older indexes) is tolerated.
+func OldestDeltaFromDB(ctx context.Context, db *sql.DB, dbName string) (time.Time, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT PARTITION_NAME FROM information_schema.PARTITIONS
+		WHERE TABLE_SCHEMA = ? AND TABLE_NAME = 'binlog_events' AND PARTITION_NAME IS NOT NULL`, dbName)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("list live partitions: %w", err)
+	}
+	defer rows.Close()
+	var parts []PartitionStat
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return time.Time{}, err
+		}
+		parts = append(parts, PartitionStat{Name: name})
+	}
+	if err := rows.Err(); err != nil {
 		return time.Time{}, err
 	}
+	floor := OldestLivePartitionHour(parts)
+
 	var minPartition sql.NullString
-	if err := db.QueryRowContext(ctx, `SELECT MIN(partition_name) FROM archive_state`).Scan(&minPartition); err == nil && minPartition.Valid {
-		if t, ok := parsePartitionName(minPartition.String); ok {
-			c.ArchiveEarliestHour = sql.NullTime{Time: t, Valid: true}
+	if err := db.QueryRowContext(ctx, `SELECT MIN(partition_name) FROM archive_state`).Scan(&minPartition); err != nil {
+		var myErr *mysql.MySQLError
+		if errors.As(err, &myErr) && myErr.Number == 1146 {
+			return floor, nil // archive_state absent on older indexes — live floor only
+		}
+		return time.Time{}, fmt.Errorf("read archive floor: %w", err)
+	}
+	if minPartition.Valid {
+		t, ok := parsePartitionName(minPartition.String)
+		if !ok {
+			// Our own naming scheme failing to parse is drift, and silently
+			// dropping the archive floor would fabricate "broken".
+			return time.Time{}, fmt.Errorf("archive_state MIN(partition_name) %q is unparseable", minPartition.String)
+		}
+		if floor.IsZero() || t.Before(floor) {
+			floor = t
 		}
 	}
-	return c.OldestDelta(), nil
+	return floor, nil
 }
 
 // AnnotateBaselineStaleness stamps each entry's verdict in place. Every entry

--- a/internal/status/staleness_test.go
+++ b/internal/status/staleness_test.go
@@ -2,10 +2,15 @@ package status
 
 import (
 	"bytes"
+	"context"
 	"database/sql"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/go-sql-driver/mysql"
 )
 
 func TestBaselineStalenessFor(t *testing.T) {
@@ -35,30 +40,116 @@ func TestBaselineStalenessFor(t *testing.T) {
 	}
 }
 
-func TestCoverageOldestDelta(t *testing.T) {
-	at := func(h int) sql.NullTime {
-		return sql.NullTime{Time: time.Date(2026, 8, 1, h, 0, 0, 0, time.UTC), Valid: true}
+func TestOldestLivePartitionHour(t *testing.T) {
+	if got := OldestLivePartitionHour(nil); !got.IsZero() {
+		t.Fatalf("no partitions must be unknown, got %v", got)
 	}
-	var nilCov *CoverageInfo
-	if !nilCov.OldestDelta().IsZero() {
-		t.Fatal("nil coverage must be unknown")
+	// Only p_future / malformed names: still unknown, never a fabricated floor.
+	parts := []PartitionStat{{Name: "p_future"}, {Name: "garbage"}}
+	if got := OldestLivePartitionHour(parts); !got.IsZero() {
+		t.Fatalf("unparseable-only partitions must be unknown, got %v", got)
 	}
-	if got := (&CoverageInfo{}).OldestDelta(); !got.IsZero() {
-		t.Fatalf("empty coverage must be unknown, got %v", got)
+	parts = append(parts, PartitionStat{Name: "p_2026080103"}, PartitionStat{Name: "p_2026080101"})
+	want := time.Date(2026, 8, 1, 1, 0, 0, 0, time.UTC)
+	if got := OldestLivePartitionHour(parts); !got.Equal(want) {
+		t.Fatalf("oldest live partition hour = %v, want %v", got, want)
+	}
+}
+
+func TestDeltaFloor(t *testing.T) {
+	at := func(h int) time.Time { return time.Date(2026, 8, 1, h, 0, 0, 0, time.UTC) }
+	live := []PartitionStat{{Name: "p_2026080110"}, {Name: "p_future"}}
+	arch := func(h int) *CoverageInfo {
+		return &CoverageInfo{ArchiveEarliestHour: sql.NullTime{Time: at(h), Valid: true}}
+	}
+	if got := DeltaFloor(nil, nil); !got.IsZero() {
+		t.Fatalf("no partitions, no coverage must be unknown, got %v", got)
 	}
 	// Archives extend live coverage backwards; the earlier of the two wins.
-	c := &CoverageInfo{EarliestEvent: at(10), ArchiveEarliestHour: at(3)}
-	if got := c.OldestDelta(); got != at(3).Time {
+	if got := DeltaFloor(live, arch(3)); !got.Equal(at(3)) {
 		t.Fatalf("archive floor must win when earlier: %v", got)
 	}
-	c = &CoverageInfo{EarliestEvent: at(2), ArchiveEarliestHour: at(5)}
-	if got := c.OldestDelta(); got != at(2).Time {
+	if got := DeltaFloor(live, arch(12)); !got.Equal(at(10)) {
 		t.Fatalf("live floor must win when earlier: %v", got)
 	}
-	c = &CoverageInfo{ArchiveEarliestHour: at(7)}
-	if got := c.OldestDelta(); got != at(7).Time {
+	if got := DeltaFloor(nil, arch(7)); !got.Equal(at(7)) {
 		t.Fatalf("archive-only coverage must count: %v", got)
 	}
+	if got := DeltaFloor(live, &CoverageInfo{}); !got.Equal(at(10)) {
+		t.Fatalf("live-only coverage must count: %v", got)
+	}
+}
+
+func TestOldestDeltaFromDB(t *testing.T) {
+	partsQ := regexp.QuoteMeta("SELECT PARTITION_NAME FROM information_schema.PARTITIONS")
+	archQ := regexp.QuoteMeta("SELECT MIN(partition_name) FROM archive_state")
+	partRows := func(names ...string) *sqlmock.Rows {
+		r := sqlmock.NewRows([]string{"PARTITION_NAME"})
+		for _, n := range names {
+			r.AddRow(n)
+		}
+		return r
+	}
+	newDB := func(t *testing.T) (*sql.DB, sqlmock.Sqlmock) {
+		t.Helper()
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { db.Close() })
+		return db, mock
+	}
+
+	t.Run("archive floor wins when earlier", func(t *testing.T) {
+		db, mock := newDB(t)
+		mock.ExpectQuery(partsQ).WillReturnRows(partRows("p_2026080110", "p_future"))
+		mock.ExpectQuery(archQ).WillReturnRows(sqlmock.NewRows([]string{"min"}).AddRow("p_2026080103"))
+		got, err := OldestDeltaFromDB(context.Background(), db, "binlog_index")
+		if err != nil || !got.Equal(time.Date(2026, 8, 1, 3, 0, 0, 0, time.UTC)) {
+			t.Fatalf("got %v, %v", got, err)
+		}
+	})
+
+	t.Run("missing archive_state table is tolerated (older index)", func(t *testing.T) {
+		db, mock := newDB(t)
+		mock.ExpectQuery(partsQ).WillReturnRows(partRows("p_2026080110"))
+		mock.ExpectQuery(archQ).WillReturnError(&mysql.MySQLError{Number: 1146, Message: "Table 'binlog_index.archive_state' doesn't exist"})
+		got, err := OldestDeltaFromDB(context.Background(), db, "binlog_index")
+		if err != nil || !got.Equal(time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)) {
+			t.Fatalf("got %v, %v", got, err)
+		}
+	})
+
+	t.Run("any other archive_state error propagates", func(t *testing.T) {
+		// The anti-cry-wolf direction: a swallowed archive error would make the
+		// floor read LATER than reality and fabricate "broken" on healthy
+		// archives. The caller must degrade to unknown instead.
+		db, mock := newDB(t)
+		mock.ExpectQuery(partsQ).WillReturnRows(partRows("p_2026080110"))
+		mock.ExpectQuery(archQ).WillReturnError(&mysql.MySQLError{Number: 1045, Message: "access denied"})
+		if _, err := OldestDeltaFromDB(context.Background(), db, "binlog_index"); err == nil {
+			t.Fatal("non-1146 archive error must propagate")
+		}
+	})
+
+	t.Run("unparseable archive partition name propagates", func(t *testing.T) {
+		db, mock := newDB(t)
+		mock.ExpectQuery(partsQ).WillReturnRows(partRows("p_2026080110"))
+		mock.ExpectQuery(archQ).WillReturnRows(sqlmock.NewRows([]string{"min"}).AddRow("weird"))
+		if _, err := OldestDeltaFromDB(context.Background(), db, "binlog_index"); err == nil {
+			t.Fatal("unparseable archive floor must propagate, not silently drop")
+		}
+	})
+
+	t.Run("empty index and empty archive is unknown, not an error", func(t *testing.T) {
+		db, mock := newDB(t)
+		mock.ExpectQuery(partsQ).WillReturnRows(partRows())
+		mock.ExpectQuery(archQ).WillReturnRows(sqlmock.NewRows([]string{"min"}).AddRow(nil))
+		got, err := OldestDeltaFromDB(context.Background(), db, "binlog_index")
+		if err != nil || !got.IsZero() {
+			t.Fatalf("got %v, %v — want zero, nil", got, err)
+		}
+	})
 }
 
 func TestOverallBaselineStaleness_newestPerTable(t *testing.T) {

--- a/internal/status/staleness_test.go
+++ b/internal/status/staleness_test.go
@@ -30,7 +30,8 @@ func TestBaselineStalenessFor(t *testing.T) {
 		{"anchor predates coverage", oldest.Add(-time.Minute), oldest, BaselineBroken},
 		{"no evaluable floor", now.Add(-1 * time.Hour), time.Time{}, BaselineUnknown},
 		{"zero snapshot time", time.Time{}, oldest, BaselineUnknown},
-		// Degenerate: coverage starting now (span <= 0) must not divide by it.
+		// Degenerate: a non-positive span must not be graded against (it
+		// would mark everything aging).
 		{"coverage starts now", now, now, BaselineOK},
 	}
 	for _, tc := range cases {
@@ -56,33 +57,9 @@ func TestOldestLivePartitionHour(t *testing.T) {
 	}
 }
 
-func TestDeltaFloor(t *testing.T) {
-	at := func(h int) time.Time { return time.Date(2026, 8, 1, h, 0, 0, 0, time.UTC) }
-	live := []PartitionStat{{Name: "p_2026080110"}, {Name: "p_future"}}
-	arch := func(h int) *CoverageInfo {
-		return &CoverageInfo{ArchiveEarliestHour: sql.NullTime{Time: at(h), Valid: true}}
-	}
-	if got := DeltaFloor(nil, nil); !got.IsZero() {
-		t.Fatalf("no partitions, no coverage must be unknown, got %v", got)
-	}
-	// Archives extend live coverage backwards; the earlier of the two wins.
-	if got := DeltaFloor(live, arch(3)); !got.Equal(at(3)) {
-		t.Fatalf("archive floor must win when earlier: %v", got)
-	}
-	if got := DeltaFloor(live, arch(12)); !got.Equal(at(10)) {
-		t.Fatalf("live floor must win when earlier: %v", got)
-	}
-	if got := DeltaFloor(nil, arch(7)); !got.Equal(at(7)) {
-		t.Fatalf("archive-only coverage must count: %v", got)
-	}
-	if got := DeltaFloor(live, &CoverageInfo{}); !got.Equal(at(10)) {
-		t.Fatalf("live-only coverage must count: %v", got)
-	}
-}
-
 func TestOldestDeltaFromDB(t *testing.T) {
 	partsQ := regexp.QuoteMeta("SELECT PARTITION_NAME FROM information_schema.PARTITIONS")
-	archQ := regexp.QuoteMeta("SELECT MIN(partition_name) FROM archive_state")
+	archQ := regexp.QuoteMeta("SELECT MIN(partition_name), MAX(partition_name) FROM archive_state")
 	partRows := func(names ...string) *sqlmock.Rows {
 		r := sqlmock.NewRows([]string{"PARTITION_NAME"})
 		for _, n := range names {
@@ -100,10 +77,38 @@ func TestOldestDeltaFromDB(t *testing.T) {
 		return db, mock
 	}
 
-	t.Run("archive floor wins when earlier", func(t *testing.T) {
+	archRows := func(min, max any) *sqlmock.Rows {
+		return sqlmock.NewRows([]string{"min", "max"}).AddRow(min, max)
+	}
+
+	t.Run("contiguous archive floor wins when earlier", func(t *testing.T) {
 		db, mock := newDB(t)
 		mock.ExpectQuery(partsQ).WillReturnRows(partRows("p_2026080110", "p_future"))
-		mock.ExpectQuery(archQ).WillReturnRows(sqlmock.NewRows([]string{"min"}).AddRow("p_2026080103"))
+		mock.ExpectQuery(archQ).WillReturnRows(archRows("p_2026080103", "p_2026080109"))
+		got, err := OldestDeltaFromDB(context.Background(), db, "binlog_index")
+		if err != nil || !got.Equal(time.Date(2026, 8, 1, 3, 0, 0, 0, time.UTC)) {
+			t.Fatalf("got %v, %v", got, err)
+		}
+	})
+
+	t.Run("non-contiguous archives do not extend the floor", func(t *testing.T) {
+		// Archives end at 05:00, live partitions start at 10:00: the 4-hour
+		// hole breaks every restore anchored before the live floor, so
+		// extending the floor to 01:00 would grade those baselines with an
+		// unearned "ok".
+		db, mock := newDB(t)
+		mock.ExpectQuery(partsQ).WillReturnRows(partRows("p_2026080110"))
+		mock.ExpectQuery(archQ).WillReturnRows(archRows("p_2026080101", "p_2026080105"))
+		got, err := OldestDeltaFromDB(context.Background(), db, "binlog_index")
+		if err != nil || !got.Equal(time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)) {
+			t.Fatalf("got %v, %v — want the live floor, not the archive one", got, err)
+		}
+	})
+
+	t.Run("archive-only coverage counts when no live partitions exist", func(t *testing.T) {
+		db, mock := newDB(t)
+		mock.ExpectQuery(partsQ).WillReturnRows(partRows())
+		mock.ExpectQuery(archQ).WillReturnRows(archRows("p_2026080103", "p_2026080105"))
 		got, err := OldestDeltaFromDB(context.Background(), db, "binlog_index")
 		if err != nil || !got.Equal(time.Date(2026, 8, 1, 3, 0, 0, 0, time.UTC)) {
 			t.Fatalf("got %v, %v", got, err)
@@ -120,6 +125,15 @@ func TestOldestDeltaFromDB(t *testing.T) {
 		}
 	})
 
+	t.Run("unparseable archive MAX propagates", func(t *testing.T) {
+		db, mock := newDB(t)
+		mock.ExpectQuery(partsQ).WillReturnRows(partRows("p_2026080110"))
+		mock.ExpectQuery(archQ).WillReturnRows(archRows("p_2026080103", "weird"))
+		if _, err := OldestDeltaFromDB(context.Background(), db, "binlog_index"); err == nil {
+			t.Fatal("unparseable MAX must propagate — contiguity cannot be judged")
+		}
+	})
+
 	t.Run("any other archive_state error propagates", func(t *testing.T) {
 		// The anti-cry-wolf direction: a swallowed archive error would make the
 		// floor read LATER than reality and fabricate "broken" on healthy
@@ -132,10 +146,10 @@ func TestOldestDeltaFromDB(t *testing.T) {
 		}
 	})
 
-	t.Run("unparseable archive partition name propagates", func(t *testing.T) {
+	t.Run("unparseable archive MIN propagates", func(t *testing.T) {
 		db, mock := newDB(t)
 		mock.ExpectQuery(partsQ).WillReturnRows(partRows("p_2026080110"))
-		mock.ExpectQuery(archQ).WillReturnRows(sqlmock.NewRows([]string{"min"}).AddRow("weird"))
+		mock.ExpectQuery(archQ).WillReturnRows(archRows("weird", "p_2026080105"))
 		if _, err := OldestDeltaFromDB(context.Background(), db, "binlog_index"); err == nil {
 			t.Fatal("unparseable archive floor must propagate, not silently drop")
 		}
@@ -144,12 +158,47 @@ func TestOldestDeltaFromDB(t *testing.T) {
 	t.Run("empty index and empty archive is unknown, not an error", func(t *testing.T) {
 		db, mock := newDB(t)
 		mock.ExpectQuery(partsQ).WillReturnRows(partRows())
-		mock.ExpectQuery(archQ).WillReturnRows(sqlmock.NewRows([]string{"min"}).AddRow(nil))
+		mock.ExpectQuery(archQ).WillReturnRows(archRows(nil, nil))
 		got, err := OldestDeltaFromDB(context.Background(), db, "binlog_index")
 		if err != nil || !got.IsZero() {
 			t.Fatalf("got %v, %v — want zero, nil", got, err)
 		}
 	})
+}
+
+// TestWriteJSON_staleness pins the machine-consumed contract: per-baseline
+// "staleness", the top-level "baseline_staleness", and the
+// configured-but-unreadable case surfacing as "unknown" instead of vanishing.
+func TestWriteJSON_staleness(t *testing.T) {
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	oldest := now.Add(-100 * time.Hour)
+	d := &StatusData{Baselines: []BaselineInfo{
+		{Database: "shop", Table: "orders", SnapshotTime: now.Add(-2 * time.Hour)},
+		{Database: "shop", Table: "legacy", SnapshotTime: oldest.Add(-time.Hour)},
+	}}
+	AnnotateBaselineStaleness(d.Baselines, oldest, now)
+	var buf bytes.Buffer
+	if err := d.WriteJSON(&buf); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, `"staleness": "broken"`) || !strings.Contains(out, `"staleness": "ok"`) {
+		t.Fatalf("per-baseline staleness missing:\n%s", out)
+	}
+	if !strings.Contains(out, `"baseline_staleness": "broken"`) {
+		t.Fatalf("top-level baseline_staleness missing:\n%s", out)
+	}
+
+	// Configured-but-unreadable baseline dir: the field must read "unknown",
+	// not be omitted — a monitor watching it would read absence as healthy.
+	d = &StatusData{BaselinesUnavailable: true}
+	buf.Reset()
+	if err := d.WriteJSON(&buf); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), `"baseline_staleness": "unknown"`) {
+		t.Fatalf("unreadable baseline dir must yield unknown:\n%s", buf.String())
+	}
 }
 
 func TestOverallBaselineStaleness_newestPerTable(t *testing.T) {
@@ -184,6 +233,7 @@ func TestWriteBaselines_stalenessColumnAndBanner(t *testing.T) {
 	oldest := now.Add(-100 * time.Hour)
 	baselines := []BaselineInfo{
 		{Database: "shop", Table: "orders", SnapshotTime: now.Add(-2 * time.Hour)},
+		{Database: "shop", Table: "orders", SnapshotTime: oldest.Add(-time.Hour)}, // superseded
 		{Database: "shop", Table: "legacy", SnapshotTime: oldest.Add(-time.Hour)},
 	}
 	AnnotateBaselineStaleness(baselines, oldest, now)
@@ -192,6 +242,12 @@ func TestWriteBaselines_stalenessColumnAndBanner(t *testing.T) {
 	out := buf.String()
 	if !strings.Contains(out, "STALENESS") || !strings.Contains(out, "⚠ broken") {
 		t.Fatalf("staleness column missing:\n%s", out)
+	}
+	// The ⚠ glyph is reserved for the newest-per-table rows the banner keys
+	// on; the superseded orders row renders plain "broken" (routine on a
+	// healthy retention cadence — the console's rule).
+	if strings.Count(out, "⚠ broken") != 1 || strings.Count(out, "broken") != 2 {
+		t.Fatalf("glyph must mark only the newest broken row (superseded rows plain):\n%s", out)
 	}
 	if !strings.Contains(out, "BASELINE STALE — FULL-TABLE RESTORE BROKEN") {
 		t.Fatalf("broken banner missing:\n%s", out)

--- a/internal/status/staleness_test.go
+++ b/internal/status/staleness_test.go
@@ -1,0 +1,117 @@
+package status
+
+import (
+	"bytes"
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBaselineStalenessFor(t *testing.T) {
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	oldest := now.Add(-100 * time.Hour) // coverage span = 100h; aging floor = 80h ago
+	cases := []struct {
+		name     string
+		snapshot time.Time
+		oldest   time.Time
+		want     BaselineStalenessVerdict
+	}{
+		{"fresh snapshot", now.Add(-1 * time.Hour), oldest, BaselineOK},
+		{"just inside the aging floor", now.Add(-79 * time.Hour), oldest, BaselineOK},
+		{"exactly at 80% of the span", now.Add(-80 * time.Hour), oldest, BaselineAging},
+		{"old but still covered", now.Add(-99 * time.Hour), oldest, BaselineAging},
+		{"anchor equals the floor", oldest, oldest, BaselineAging},
+		{"anchor predates coverage", oldest.Add(-time.Minute), oldest, BaselineBroken},
+		{"no evaluable floor", now.Add(-1 * time.Hour), time.Time{}, BaselineUnknown},
+		{"zero snapshot time", time.Time{}, oldest, BaselineUnknown},
+		// Degenerate: coverage starting now (span <= 0) must not divide by it.
+		{"coverage starts now", now, now, BaselineOK},
+	}
+	for _, tc := range cases {
+		if got := BaselineStalenessFor(tc.snapshot, tc.oldest, now); got != tc.want {
+			t.Errorf("%s: got %s, want %s", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestCoverageOldestDelta(t *testing.T) {
+	at := func(h int) sql.NullTime {
+		return sql.NullTime{Time: time.Date(2026, 8, 1, h, 0, 0, 0, time.UTC), Valid: true}
+	}
+	var nilCov *CoverageInfo
+	if !nilCov.OldestDelta().IsZero() {
+		t.Fatal("nil coverage must be unknown")
+	}
+	if got := (&CoverageInfo{}).OldestDelta(); !got.IsZero() {
+		t.Fatalf("empty coverage must be unknown, got %v", got)
+	}
+	// Archives extend live coverage backwards; the earlier of the two wins.
+	c := &CoverageInfo{EarliestEvent: at(10), ArchiveEarliestHour: at(3)}
+	if got := c.OldestDelta(); got != at(3).Time {
+		t.Fatalf("archive floor must win when earlier: %v", got)
+	}
+	c = &CoverageInfo{EarliestEvent: at(2), ArchiveEarliestHour: at(5)}
+	if got := c.OldestDelta(); got != at(2).Time {
+		t.Fatalf("live floor must win when earlier: %v", got)
+	}
+	c = &CoverageInfo{ArchiveEarliestHour: at(7)}
+	if got := c.OldestDelta(); got != at(7).Time {
+		t.Fatalf("archive-only coverage must count: %v", got)
+	}
+}
+
+func TestOverallBaselineStaleness_newestPerTable(t *testing.T) {
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	oldest := now.Add(-100 * time.Hour)
+	baselines := []BaselineInfo{
+		// A superseded broken snapshot must NOT drive the headline…
+		{Database: "shop", Table: "orders", SnapshotTime: oldest.Add(-24 * time.Hour)},
+		{Database: "shop", Table: "orders", SnapshotTime: now.Add(-2 * time.Hour)},
+		// …but a table whose NEWEST snapshot is broken must.
+		{Database: "shop", Table: "legacy", SnapshotTime: oldest.Add(-time.Hour)},
+	}
+	AnnotateBaselineStaleness(baselines, oldest, now)
+	if baselines[0].Staleness != BaselineBroken || baselines[1].Staleness != BaselineOK {
+		t.Fatalf("per-entry annotation wrong: %+v", baselines)
+	}
+	if got := OverallBaselineStaleness(baselines); got != BaselineBroken {
+		t.Fatalf("overall = %s, want broken (legacy's newest is broken)", got)
+	}
+
+	// Without the broken table, the superseded broken snapshot is ignored.
+	if got := OverallBaselineStaleness(baselines[:2]); got != BaselineOK {
+		t.Fatalf("overall = %s, want ok (orders' newest is fresh)", got)
+	}
+	if got := OverallBaselineStaleness(nil); got != "" {
+		t.Fatalf("empty list must have no verdict, got %q", got)
+	}
+}
+
+func TestWriteBaselines_stalenessColumnAndBanner(t *testing.T) {
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	oldest := now.Add(-100 * time.Hour)
+	baselines := []BaselineInfo{
+		{Database: "shop", Table: "orders", SnapshotTime: now.Add(-2 * time.Hour)},
+		{Database: "shop", Table: "legacy", SnapshotTime: oldest.Add(-time.Hour)},
+	}
+	AnnotateBaselineStaleness(baselines, oldest, now)
+	var buf bytes.Buffer
+	writeBaselines(&buf, baselines)
+	out := buf.String()
+	if !strings.Contains(out, "STALENESS") || !strings.Contains(out, "⚠ broken") {
+		t.Fatalf("staleness column missing:\n%s", out)
+	}
+	if !strings.Contains(out, "BASELINE STALE — FULL-TABLE RESTORE BROKEN") {
+		t.Fatalf("broken banner missing:\n%s", out)
+	}
+
+	// All fresh: no banner, quiet "ok" verdicts.
+	fresh := []BaselineInfo{{Database: "shop", Table: "orders", SnapshotTime: now.Add(-2 * time.Hour)}}
+	AnnotateBaselineStaleness(fresh, oldest, now)
+	buf.Reset()
+	writeBaselines(&buf, fresh)
+	if strings.Contains(buf.String(), "BASELINE STALE") {
+		t.Fatalf("banner must not fire without a broken newest snapshot:\n%s", buf.String())
+	}
+}

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -525,7 +525,10 @@ type BaselineInfo struct {
 	BinlogFile   string
 	BinlogPos    int64
 	GTIDSet      string
-	Path         string // filesystem path; ignored by display/JSON output
+	// Staleness is this snapshot's #1193 verdict against the oldest available
+	// delta coverage ("" until AnnotateBaselineStaleness runs).
+	Staleness BaselineStalenessVerdict
+	Path      string // filesystem path; ignored by display/JSON output
 	// Size is the Parquet file size in bytes (0 = unknown). Surfaced so an
 	// operator can see per-table baseline size — the signal that tells whether
 	// a single-table baseline has grown into the large regime.
@@ -1121,6 +1124,7 @@ func writeStatusJSONFull(w io.Writer, files []IndexStateRow, parts []PartitionSt
 		GTIDSet      *string `json:"gtid_set,omitempty"`
 		Size         int64   `json:"size_bytes,omitempty"`
 		SizeHuman    string  `json:"size_human,omitempty"`
+		Staleness    string  `json:"staleness,omitempty"`
 	}
 	// jsonStreamError is emitted (under a distinct key, never a fake `stream` object —
 	// jsonStream's non-omitempty events_indexed:0/mode:"" would read as a real empty
@@ -1141,6 +1145,9 @@ func writeStatusJSONFull(w io.Writer, files []IndexStateRow, parts []PartitionSt
 		Archives    *jsonArchives    `json:"archives,omitempty"`
 		Coverage    *jsonCoverage    `json:"coverage,omitempty"`
 		Baselines   []jsonBaseline   `json:"baselines,omitempty"`
+		// BaselineStaleness is the worst per-table-newest verdict — the same
+		// headline the text banner keys on (#1193).
+		BaselineStaleness string `json:"baseline_staleness,omitempty"`
 	}
 
 	jf := make([]jsonFile, len(files))
@@ -1320,8 +1327,10 @@ func writeStatusJSONFull(w io.Writer, files []IndexStateRow, parts []PartitionSt
 		if b.GTIDSet != "" {
 			jb.GTIDSet = &b.GTIDSet
 		}
+		jb.Staleness = string(b.Staleness)
 		out.Baselines = append(out.Baselines, jb)
 	}
+	out.BaselineStaleness = string(OverallBaselineStaleness(baselines))
 
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
@@ -1336,8 +1345,8 @@ func writeBaselines(w io.Writer, baselines []BaselineInfo) {
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "=== Baselines ===")
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(tw, "SNAPSHOT\tDATABASE\tTABLE\tSIZE\tBINLOG_FILE\tBINLOG_POS\tGTID")
-	fmt.Fprintln(tw, "────────\t────────\t─────\t────\t───────────\t──────────\t────")
+	fmt.Fprintln(tw, "SNAPSHOT\tDATABASE\tTABLE\tSIZE\tBINLOG_FILE\tBINLOG_POS\tGTID\tSTALENESS")
+	fmt.Fprintln(tw, "────────\t────────\t─────\t────\t───────────\t──────────\t────\t─────────")
 	for _, b := range baselines {
 		binlogFile := "-"
 		if b.BinlogFile != "" {
@@ -1355,10 +1364,29 @@ func writeBaselines(w io.Writer, baselines []BaselineInfo) {
 		if b.Size > 0 {
 			size = formatBytes(b.Size)
 		}
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+		staleness := "-"
+		if b.Staleness != "" {
+			staleness = string(b.Staleness)
+			if b.Staleness == BaselineBroken {
+				staleness = "⚠ broken"
+			}
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 			b.SnapshotTime.Format(TSFmt),
 			b.Database, b.Table, size,
-			binlogFile, binlogPos, gtid)
+			binlogFile, binlogPos, gtid, staleness)
 	}
 	tw.Flush()
+
+	// Continuity-banner-style loud line: a table whose NEWEST baseline
+	// predates delta coverage cannot be fully restored through that hole, and
+	// waiting for restore time to find out is the failure mode #1193 exists
+	// to remove.
+	if OverallBaselineStaleness(baselines) == BaselineBroken {
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "=== ⚠ BASELINE STALE — FULL-TABLE RESTORE BROKEN ===")
+		fmt.Fprintln(w, "The newest baseline for at least one table predates the oldest available")
+		fmt.Fprintln(w, "delta coverage: reconstructing those tables through the missing window is")
+		fmt.Fprintln(w, "impossible. Take a fresh baseline (bintrail dump + bintrail baseline).")
+	}
 }

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -506,6 +506,10 @@ type StatusData struct {
 	Servers   []ServerInfo
 	Stream    *StreamStateInfo
 	Baselines []BaselineInfo
+	// BaselinesUnavailable: a baseline location was configured but could not
+	// be read, so Baselines is empty for a BAD reason — JSON must report
+	// baseline_staleness "unknown", not omit it as if nothing were configured.
+	BaselinesUnavailable bool
 	// StreamErr records a failure to READ stream_state (transient timeout, revoked
 	// permission, an unexpected loadSourceHealth error) — as distinct from an empty
 	// table (Stream==nil, StreamErr==nil = no active stream). When set, the continuity
@@ -630,7 +634,7 @@ func writeStreamUnavailable(w io.Writer, err error) {
 
 // WriteJSON writes the status data as JSON to w.
 func (d *StatusData) WriteJSON(w io.Writer) error {
-	return writeStatusJSONFull(w, d.Files, d.Parts, d.Archives, d.Coverage, d.Servers, d.Stream, d.Baselines, d.StreamErr)
+	return writeStatusJSONFull(w, d.Files, d.Parts, d.Archives, d.Coverage, d.Servers, d.Stream, d.Baselines, d.BaselinesUnavailable, d.StreamErr)
 }
 
 // WriteStatus writes a multi-section status report (Servers, Stream, Indexed Files, Partitions, Archives, Coverage, Summary) to w.
@@ -1011,10 +1015,10 @@ func Truncate(s string, n int) string {
 
 // WriteStatusJSON writes the status data as a JSON object to w.
 func WriteStatusJSON(w io.Writer, files []IndexStateRow, parts []PartitionStat, archives *ArchiveStats, coverage *CoverageInfo, servers []ServerInfo, stream *StreamStateInfo) error {
-	return writeStatusJSONFull(w, files, parts, archives, coverage, servers, stream, nil, nil)
+	return writeStatusJSONFull(w, files, parts, archives, coverage, servers, stream, nil, false, nil)
 }
 
-func writeStatusJSONFull(w io.Writer, files []IndexStateRow, parts []PartitionStat, archives *ArchiveStats, coverage *CoverageInfo, servers []ServerInfo, stream *StreamStateInfo, baselines []BaselineInfo, streamErr error) error {
+func writeStatusJSONFull(w io.Writer, files []IndexStateRow, parts []PartitionStat, archives *ArchiveStats, coverage *CoverageInfo, servers []ServerInfo, stream *StreamStateInfo, baselines []BaselineInfo, baselinesUnavailable bool, streamErr error) error {
 	type jsonFile struct {
 		BinlogFile    string  `json:"binlog_file"`
 		Status        string  `json:"status"`
@@ -1331,6 +1335,9 @@ func writeStatusJSONFull(w io.Writer, files []IndexStateRow, parts []PartitionSt
 		out.Baselines = append(out.Baselines, jb)
 	}
 	out.BaselineStaleness = string(OverallBaselineStaleness(baselines))
+	if out.BaselineStaleness == "" && baselinesUnavailable {
+		out.BaselineStaleness = string(BaselineUnknown)
+	}
 
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
@@ -1347,6 +1354,17 @@ func writeBaselines(w io.Writer, baselines []BaselineInfo) {
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
 	fmt.Fprintln(tw, "SNAPSHOT\tDATABASE\tTABLE\tSIZE\tBINLOG_FILE\tBINLOG_POS\tGTID\tSTALENESS")
 	fmt.Fprintln(tw, "────────\t────────\t─────\t────\t───────────\t──────────\t────\t─────────")
+	// The ⚠ glyph is reserved for rows the banner keys on — each table's
+	// NEWEST snapshot. A superseded snapshot past coverage is routine on a
+	// healthy retention cadence (the console's rule too); it still reads
+	// "broken" honestly, just not as an alarm.
+	newestOf := make(map[string]time.Time, len(baselines))
+	for _, b := range baselines {
+		k := b.Database + "." + b.Table
+		if b.SnapshotTime.After(newestOf[k]) {
+			newestOf[k] = b.SnapshotTime
+		}
+	}
 	for _, b := range baselines {
 		binlogFile := "-"
 		if b.BinlogFile != "" {
@@ -1367,7 +1385,7 @@ func writeBaselines(w io.Writer, baselines []BaselineInfo) {
 		staleness := "-"
 		if b.Staleness != "" {
 			staleness = string(b.Staleness)
-			if b.Staleness == BaselineBroken {
+			if b.Staleness == BaselineBroken && newestOf[b.Database+"."+b.Table].Equal(b.SnapshotTime) {
 				staleness = "⚠ broken"
 			}
 		}


### PR DESCRIPTION
closes #1193

## Summary
- **`internal/status/staleness.go`**: `BaselineStalenessFor(snapshot, oldestDelta, now)` → `ok | aging | broken | unknown`. The floor is live `MIN(event_timestamp)` extended backwards by the oldest archived partition; `aging` = the snapshot is older than 80% of the coverage span (the issue's threshold); `broken` = the anchor predates coverage — full-table reconstruct through the hole is impossible; `unknown` is never "ok". The **headline** verdict (`OverallBaselineStaleness`) looks only at each table's NEWEST snapshot — a superseded old snapshot being unusable is expected and must not cry wolf.
- **`status`**: STALENESS column in the Baselines table + a continuity-banner-style loud line when any table's newest snapshot is broken; JSON gets per-baseline `staleness` and a top-level `baseline_staleness`. Exit code untouched.
- **Console**: `/api/baselines` snapshots carry `staleness` (floor via the new lean `status.OldestDeltaFromDB` on the bundle's index; an unreadable index leaves it empty — never a fabricated ok); the Storage panel chips anything not-ok, with `⚠ STALE — restore broken` for broken.
- **`reconstruct` full-table**: the coverage-gap abort in `foldEventWindow` now names the baseline anchor and the fix ("take a fresh baseline") — the gap error and the stale baseline are usually the same fact wearing two hats.
- **Webhook**: `startStalenessWatch` in `watch` (hourly — each check lists the baseline source, and S3 LISTs every 5 minutes buy nothing) sends a critical **`baseline_stale`** on the transition into broken and one resolve on recovery; `aging` deliberately does not notify (status/console carry it). Per-server all-or-nothing baseline fallback (same rule as `withBaselineDefaults`); an unknown floor skips the target whole so it can never resolve an active alert.
- Docs: staleness section in `rotation-and-status.md`, `baseline_stale` bullet in `console.md`'s webhook list.
- Non-goal honored: **no automatic refresh** — that's #1171 (epic #1165). Prometheus gauge for staleness: one-line follow-up candidate for the #1203 family, not taken here.

## Test plan
- [x] `go test ./... -count=1` all green; `go vet -tags integration` clean; `node --check` on app.js
- New tests: verdict table incl. the exact 80% boundary and span-zero degeneracy; floor combination (archive-extends-live, both directions); newest-per-table headline (superseded broken ignored, broken-newest wins); text render (column + banner presence/absence); `BaselineStale` edge semantics; watcher targets (all-or-nothing fallback, skip-no-baseline) and cycle (healthy silent → broken fires → unknown floor neither fires nor resolves → fresh baseline resolves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
