### PR TITLE
reconstruct: warn on a mismatched render-GUCs stamp in shim and console folds

### DIFF
--- a/internal/console/reconstruct.go
+++ b/internal/console/reconstruct.go
@@ -332,7 +332,10 @@ func (s *Server) handleReconstruct(w http.ResponseWriter, r *http.Request) {
 	// (deltas anchor on snapshotTime).
 	bmeta, bmetaErr := baseline.ReadParquetMetadataAny(ctx, path)
 	if bmetaErr != nil {
-		slog.Debug("reconstruct: could not read baseline metadata for the render-GUCs check",
+		// Warn, not Debug: a PG baseline whose metadata cannot be read loses
+		// the render-GUCs mismatch warning silently otherwise (parity with the
+		// shim's failure log level).
+		slog.Warn("reconstruct: could not read baseline metadata for the render-GUCs check",
 			"path", path, "error", bmetaErr)
 	}
 	// PK column metadata from the snapshot in effect when the baseline was

--- a/internal/console/reconstruct.go
+++ b/internal/console/reconstruct.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/dbtrail/dbtrail/ext"
+	"github.com/dbtrail/dbtrail/internal/baseline"
 	"github.com/dbtrail/dbtrail/internal/cliutil"
 	"github.com/dbtrail/dbtrail/internal/parquetquery"
 	"github.com/dbtrail/dbtrail/internal/query"
@@ -325,6 +326,15 @@ func (s *Server) handleReconstruct(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusInternalServerError, "find baseline: "+err.Error())
 		return
 	}
+	// Read the baseline's Parquet metadata for the rendering-GUC stamp check
+	// (#921). Best-effort: on a read failure bmeta stays zero (LSN 0) and the
+	// warning is simply not raised — the fold below never needs this metadata
+	// (deltas anchor on snapshotTime).
+	bmeta, bmetaErr := baseline.ReadParquetMetadataAny(ctx, path)
+	if bmetaErr != nil {
+		slog.Debug("reconstruct: could not read baseline metadata for the render-GUCs check",
+			"path", path, "error", bmetaErr)
+	}
 	// PK column metadata from the snapshot in effect when the baseline was
 	// taken (#1159), enabling the fixed BINARY(n) pad-and-retry inside
 	// ReadBaselineRow (#1155/#1157): a key copied out of the events view
@@ -412,11 +422,10 @@ func (s *Server) handleReconstruct(w http.ResponseWriter, r *http.Request) {
 		At:           atTime.Format(consoleTSFormat),
 		BaselineTime: snapshotTime.Format(consoleTSFormat),
 		EventCount:   len(rows),
-		// Surface a stale-baseline fallback (#466) alongside coverage-gap
-		// warnings: the table is absent from a newer snapshot, so Time-travel is
-		// reconstructing from an older one. The server already logged it; this
-		// puts it in front of the operator.
-		Warnings: appendStaleWarning(gapWarnings(plan), stale),
+		// Surface a stale-baseline fallback (#466) and a rendering-GUC stamp
+		// mismatch (#921) alongside coverage-gap warnings: the server already
+		// logs these; this puts them in front of the operator.
+		Warnings: appendRenderGUCsWarning(appendStaleWarning(gapWarnings(plan), stale), bmeta),
 	}
 
 	// 3. Fold baseline + deltas. baselineRow may be nil. "existed" = the row was
@@ -521,6 +530,24 @@ func appendStaleWarning(warnings []string, stale reconstruct.StaleWarning) []str
 		return warnings
 	}
 	return append(warnings, "stale_baseline: "+stale.Message)
+}
+
+// appendRenderGUCsWarning adds a "render_gucs_mismatch: …" entry when the
+// baseline is a PostgreSQL one (LSN anchor present) whose rendering-GUC stamp
+// is absent (pre-pin) or differs from the current pin (#593/#921) — the same
+// predicate as the CLI single-row warn (internal/cli/reconstruct.go). The
+// baseline↔delta merge is an exact text join, so a mismatched stamp means the
+// baseline's GUC-sensitive text may not join post-pin deltas. In-band like the
+// stale_baseline entry (#466). A no-op for MySQL baselines (LSN 0, which also
+// covers a failed metadata read) and matching stamps, so callers can wire it
+// unconditionally.
+func appendRenderGUCsWarning(warnings []string, bmeta baseline.DumpMetadata) []string {
+	if bmeta.LSN == 0 || bmeta.RenderGUCs == baseline.RenderGUCsPinned {
+		return warnings
+	}
+	return append(warnings, fmt.Sprintf(
+		"render_gucs_mismatch: this baseline's rendering-GUC stamp (%q) does not match the current pin — it predates GUC pinning or was produced under a different pin; its GUC-sensitive text (timestamps, floats, bytea, intervals) may not match newer deltas; re-run `bintrail-pg baseline` to refresh it",
+		bmeta.RenderGUCs))
 }
 
 // isTrue reports whether a query-param flag is set to a truthy value.

--- a/internal/console/reconstruct_gucs_test.go
+++ b/internal/console/reconstruct_gucs_test.go
@@ -37,8 +37,11 @@ func TestAppendRenderGUCsWarning(t *testing.T) {
 	}
 }
 
-// TestRenderGUCsMismatchReachesWarningsDTO drives a REAL mismatched stamp
-// end-to-end on the surfacing path (#921), mirroring the #466 stale_baseline
+// TestRenderGUCsMismatchReachesWarningsDTO pins the read+predicate+append
+// contract on a REAL mismatched stamp (#921). It does NOT drive
+// handleReconstruct — the handler wiring (bmeta reaching the response
+// Warnings) is pinned by TestIntegrationReconstructRenderGUCsWarning in
+// reconstruct_integration_test.go. Original framing, kept for the helper half: #466 stale_baseline
 // test: a baseline Parquet whose metadata carries an LSN anchor and an old
 // rendering-GUC stamp is read with the same ReadParquetMetadataAny call
 // handleReconstruct uses, and appendRenderGUCsWarning lands the entry in the

--- a/internal/console/reconstruct_gucs_test.go
+++ b/internal/console/reconstruct_gucs_test.go
@@ -1,0 +1,93 @@
+package console
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/baseline"
+)
+
+// TestAppendRenderGUCsWarning pins the console-side predicate (#921): only a
+// PostgreSQL baseline (LSN anchor) with an absent or mismatched rendering-GUC
+// stamp adds a "render_gucs_mismatch:" entry; MySQL baselines (LSN 0 — which
+// also covers a failed metadata read) and matching stamps are no-ops, and
+// existing warnings are preserved.
+func TestAppendRenderGUCsWarning(t *testing.T) {
+	if got := appendRenderGUCsWarning(nil, baseline.DumpMetadata{}); got != nil {
+		t.Errorf("MySQL baseline (LSN 0) must not add a warning, got %v", got)
+	}
+	if got := appendRenderGUCsWarning(nil, baseline.DumpMetadata{LSN: 42, RenderGUCs: baseline.RenderGUCsPinned}); got != nil {
+		t.Errorf("matching stamp must not add a warning, got %v", got)
+	}
+	base := []string{"gap warning"}
+	got := appendRenderGUCsWarning(base, baseline.DumpMetadata{LSN: 42, RenderGUCs: "TimeZone=America/New_York"})
+	if len(got) != 2 || got[0] != "gap warning" || !strings.HasPrefix(got[1], "render_gucs_mismatch: ") {
+		t.Fatalf("mismatched stamp not appended correctly: %v", got)
+	}
+	if !strings.Contains(got[1], "TimeZone=America/New_York") || !strings.Contains(got[1], "bintrail-pg baseline") {
+		t.Errorf("warning lacks the stamp or the remediation: %q", got[1])
+	}
+	// Pre-pin PG baseline: LSN anchor present, stamp absent.
+	if got := appendRenderGUCsWarning(nil, baseline.DumpMetadata{LSN: 42}); len(got) != 1 || !strings.HasPrefix(got[0], "render_gucs_mismatch: ") {
+		t.Errorf("pre-pin PG baseline must warn, got %v", got)
+	}
+}
+
+// TestRenderGUCsMismatchReachesWarningsDTO drives a REAL mismatched stamp
+// end-to-end on the surfacing path (#921), mirroring the #466 stale_baseline
+// test: a baseline Parquet whose metadata carries an LSN anchor and an old
+// rendering-GUC stamp is read with the same ReadParquetMetadataAny call
+// handleReconstruct uses, and appendRenderGUCsWarning lands the entry in the
+// reconstructResponse the Time-travel UI renders.
+func TestRenderGUCsMismatchReachesWarningsDTO(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "2026-01-01T00-00-00Z", "shop", "orders.parquet")
+	cols := []baseline.Column{
+		{Name: "id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
+	}
+	w, err := baseline.NewWriter(path, cols, baseline.WriterConfig{
+		Compression:  "none",
+		RowGroupSize: 10,
+		Metadata: map[string]string{
+			baseline.MetaKeyLSN:        "42",
+			baseline.MetaKeyRenderGUCs: "TimeZone=America/New_York;DateStyle=SQL;extra_float_digits=0;bytea_output=escape;IntervalStyle=sql_standard",
+		},
+	})
+	if err != nil {
+		t.Fatalf("baseline.NewWriter: %v", err)
+	}
+	if err := w.WriteRow([]string{"1"}, []bool{false}); err != nil {
+		t.Fatalf("WriteRow: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("writer close: %v", err)
+	}
+
+	// Same read handleReconstruct performs after findBaseline.
+	bmeta, err := baseline.ReadParquetMetadataAny(context.Background(), path)
+	if err != nil {
+		t.Fatalf("ReadParquetMetadataAny: %v", err)
+	}
+
+	at := time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC)
+	resp := reconstructResponse{
+		Schema: "shop", Table: "orders", PK: "1",
+		At:       at.Format(consoleTSFormat),
+		Warnings: appendRenderGUCsWarning(nil, bmeta),
+	}
+	if len(resp.Warnings) != 1 || !strings.HasPrefix(resp.Warnings[0], "render_gucs_mismatch: ") {
+		t.Fatalf("Warnings DTO missing the render_gucs_mismatch entry: %v", resp.Warnings)
+	}
+
+	// And it survives JSON encoding (what the UI receives).
+	b, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), "render_gucs_mismatch") {
+		t.Fatalf("encoded response lacks render_gucs_mismatch: %s", b)
+	}
+}

--- a/internal/console/reconstruct_integration_test.go
+++ b/internal/console/reconstruct_integration_test.go
@@ -19,7 +19,7 @@ import (
 
 // writeBaselineParquet writes a one-row baseline snapshot in the layout
 // FindBaseline expects: <baseDir>/<RFC3339-with-hyphens>/<schema>/<table>.parquet.
-func writeBaselineParquet(t *testing.T, baseDir, schema, table string, at time.Time, idVal, nameVal string) {
+func writeBaselineParquet(t *testing.T, baseDir, schema, table string, at time.Time, idVal, nameVal string, meta ...map[string]string) {
 	t.Helper()
 	tsDir := strings.ReplaceAll(at.UTC().Format(time.RFC3339), ":", "-")
 	dir := filepath.Join(baseDir, tsDir, schema)
@@ -30,8 +30,11 @@ func writeBaselineParquet(t *testing.T, baseDir, schema, table string, at time.T
 		{Name: "id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
 		{Name: "name", MySQLType: "varchar", ParquetType: baseline.MysqlToParquetNode("varchar")},
 	}
-	w, err := baseline.NewWriter(filepath.Join(dir, table+".parquet"), cols,
-		baseline.WriterConfig{Compression: "none", RowGroupSize: 100})
+	cfg := baseline.WriterConfig{Compression: "none", RowGroupSize: 100}
+	if len(meta) > 0 {
+		cfg.Metadata = meta[0]
+	}
+	w, err := baseline.NewWriter(filepath.Join(dir, table+".parquet"), cols, cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -46,7 +49,11 @@ func writeBaselineParquet(t *testing.T, baseDir, schema, table string, at time.T
 // seedReconstruct builds an index with a snapshot (id is PK), a baseline row
 // (id=1, name=alice at 00:00), and three deltas: UPDATE→alicia (12:00),
 // UPDATE→alex (13:00), DELETE (14:00).
-func seedReconstruct(t *testing.T) *Server {
+func seedReconstruct(t *testing.T) *Server { return seedReconstructMeta(t, nil) }
+
+// seedReconstructMeta is seedReconstruct with optional key-value metadata
+// stamped into the baseline Parquet footer (#921: LSN + render-GUCs stamp).
+func seedReconstructMeta(t *testing.T, baselineMeta map[string]string) *Server {
 	t.Helper()
 	db, dbName := testutil.CreateTestDB(t)
 	testutil.InitIndexTables(t, db)
@@ -71,7 +78,7 @@ func seedReconstruct(t *testing.T) *Server {
 		nil, nil, []byte(`{"id":3,"name":{"__bintrail_unchanged_toast__":true}}`))
 
 	baseDir := t.TempDir()
-	writeBaselineParquet(t, baseDir, "app", "users", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC), "1", "alice")
+	writeBaselineParquet(t, baseDir, "app", "users", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC), "1", "alice", baselineMeta)
 
 	srv, err := New(Config{DB: db, DBName: dbName, Listen: "127.0.0.1:8090", Token: intToken, BaselineDir: baseDir})
 	if err != nil {
@@ -100,6 +107,36 @@ func reconstructAt(t *testing.T, srv *Server, qs string) reconstructResponse {
 // only p_future, so the planner classifies the whole window as a coverage gap.
 // A real deployment with hourly partitions would not need it. The gap-refusal
 // behavior itself is asserted separately below.
+// #921: the render_gucs_mismatch warning must reach the response through the
+// REAL handler path (handleReconstruct → ReadParquetMetadataAny →
+// appendRenderGUCsWarning) — the unit test pins only the helper contract, so
+// unwiring the append in handleReconstruct must go red HERE.
+func TestIntegrationReconstructRenderGUCsWarning(t *testing.T) {
+	srv := seedReconstructMeta(t, map[string]string{
+		baseline.MetaKeyLSN:        "42",
+		baseline.MetaKeyRenderGUCs: "TimeZone=America/New_York;DateStyle=SQL;extra_float_digits=0;bytea_output=escape;IntervalStyle=sql_standard",
+	})
+	r := reconstructAt(t, srv, "schema=app&table=users&pk=1&at=2026-06-01%2000:00:01&allow_gaps=true")
+	found := false
+	for _, wmsg := range r.Warnings {
+		if strings.HasPrefix(wmsg, "render_gucs_mismatch: ") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("render_gucs_mismatch warning missing from the handler response: %v", r.Warnings)
+	}
+
+	// A MySQL baseline (no LSN anchor) must not raise it.
+	srv2 := seedReconstruct(t)
+	r2 := reconstructAt(t, srv2, "schema=app&table=users&pk=1&at=2026-06-01%2000:00:01&allow_gaps=true")
+	for _, wmsg := range r2.Warnings {
+		if strings.HasPrefix(wmsg, "render_gucs_mismatch") {
+			t.Fatalf("MySQL baseline must not raise the GUC warning: %v", r2.Warnings)
+		}
+	}
+}
+
 func TestIntegrationReconstructValueAsOf(t *testing.T) {
 	srv := seedReconstruct(t)
 

--- a/internal/shim/snapshot.go
+++ b/internal/shim/snapshot.go
@@ -33,10 +33,31 @@ func snapshotSincePos(ctx context.Context, baselinePath string, logger *slog.Log
 			"schema", schema, "table", table, "path", baselinePath, "error", err)
 		return nil
 	}
+	// Rendering-GUC stamp check (#921) rides the metadata read both _snapshot
+	// paths (single-row and full-table) already pay here — no second read. It
+	// must run BEFORE the MySQL-anchor early return below: a PostgreSQL
+	// baseline records an LSN anchor and no binlog file/pos.
+	warnRenderGUCsMismatch(bmeta, logger, schema, table, baselinePath)
 	if bmeta.BinlogFile == "" || bmeta.BinlogPos <= 0 {
 		return nil
 	}
 	return &query.BinlogPos{File: bmeta.BinlogFile, Pos: uint64(bmeta.BinlogPos)}
+}
+
+// warnRenderGUCsMismatch flags a PostgreSQL baseline (LSN anchor present)
+// whose rendering-GUC stamp is absent (pre-pin) or differs from the current
+// pin (#593/#921): the baseline↔delta merge is an exact text join, so on a
+// server whose TimeZone/DateStyle/extra_float_digits/bytea_output/
+// IntervalStyle defaults differ from the pinned values its GUC-sensitive text
+// will not join post-pin deltas. Same predicate as the CLI single-row warn
+// (internal/cli/reconstruct.go). Warn-only server-side, consistent with how
+// the shim handles FindBaseline's StaleWarning (#466) — an in-band MySQL
+// signal is deferred.
+func warnRenderGUCsMismatch(bmeta baseline.DumpMetadata, logger *slog.Logger, schema, table, baselinePath string) {
+	if bmeta.LSN != 0 && bmeta.RenderGUCs != baseline.RenderGUCsPinned {
+		logger.Warn("shim: _snapshot baseline's rendering-GUC stamp does not match the current pin (#593) — it predates GUC pinning or was produced under a different pin; its GUC-sensitive text (timestamps, floats, bytea, intervals) may not match newer deltas; re-run `bintrail-pg baseline` to refresh it",
+			"schema", schema, "table", table, "path", baselinePath, "baseline_render_gucs", bmeta.RenderGUCs)
+	}
 }
 
 // runSnapshot resolves a _snapshot query. _snapshot is the

--- a/internal/shim/snapshot_gucs_test.go
+++ b/internal/shim/snapshot_gucs_test.go
@@ -1,0 +1,99 @@
+package shim
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/baseline"
+)
+
+// writeGUCsBaseline writes a minimal real baseline Parquet file with the given
+// key-value metadata and returns its path — the same shape FindBaseline hands
+// to snapshotSincePos.
+func writeGUCsBaseline(t *testing.T, meta map[string]string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "2026-01-01T00-00-00Z", "shop", "orders.parquet")
+	cols := []baseline.Column{
+		{Name: "id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
+	}
+	w, err := baseline.NewWriter(path, cols, baseline.WriterConfig{
+		Compression:  "none",
+		RowGroupSize: 10,
+		Metadata:     meta,
+	})
+	if err != nil {
+		t.Fatalf("baseline.NewWriter: %v", err)
+	}
+	if err := w.WriteRow([]string{"1"}, []bool{false}); err != nil {
+		t.Fatalf("WriteRow: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("writer close: %v", err)
+	}
+	return path
+}
+
+// TestSnapshotSincePosRenderGUCsWarn pins the #921 shim-side warning through
+// the real metadata-read path both _snapshot folds pay (snapshotSincePos): a
+// PostgreSQL baseline (LSN anchor) whose rendering-GUC stamp is absent or
+// differs from the current pin logs a server-side Warn; a matching stamp or a
+// MySQL baseline (no LSN) stays silent. The check must fire even though a PG
+// baseline has no binlog file/pos anchor (the early-return below the read).
+func TestSnapshotSincePosRenderGUCsWarn(t *testing.T) {
+	cases := []struct {
+		name     string
+		meta     map[string]string
+		wantWarn bool
+	}{
+		{
+			name: "pg mismatched stamp warns",
+			meta: map[string]string{
+				baseline.MetaKeyLSN:        "42",
+				baseline.MetaKeyRenderGUCs: "TimeZone=America/New_York;DateStyle=SQL;extra_float_digits=0;bytea_output=escape;IntervalStyle=sql_standard",
+			},
+			wantWarn: true,
+		},
+		{
+			name:     "pg pre-pin baseline (no stamp) warns",
+			meta:     map[string]string{baseline.MetaKeyLSN: "42"},
+			wantWarn: true,
+		},
+		{
+			name: "pg matching stamp is silent",
+			meta: map[string]string{
+				baseline.MetaKeyLSN:        "42",
+				baseline.MetaKeyRenderGUCs: baseline.RenderGUCsPinned,
+			},
+			wantWarn: false,
+		},
+		{
+			name:     "mysql baseline (no LSN) is silent",
+			meta:     map[string]string{},
+			wantWarn: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeGUCsBaseline(t, tc.meta)
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewTextHandler(&buf, nil))
+
+			pos := snapshotSincePos(context.Background(), path, logger, "shop", "orders")
+			if pos != nil {
+				// None of the cases record a binlog file/pos anchor.
+				t.Errorf("unexpected binlog anchor: %+v", pos)
+			}
+			gotWarn := strings.Contains(buf.String(), "rendering-GUC stamp does not match the current pin")
+			if gotWarn != tc.wantWarn {
+				t.Errorf("warn logged=%v, want %v; log output:\n%s", gotWarn, tc.wantWarn, buf.String())
+			}
+			if tc.wantWarn && !strings.Contains(buf.String(), "bintrail-pg baseline") {
+				t.Errorf("warning lacks the remediation; log output:\n%s", buf.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The CLI single-row reconstruct warns when folding a PG baseline whose rendering-GUC stamp is missing or differs from the pin (`internal/cli/reconstruct.go`). This brings the same check to the other two surfaces of the fold:

- **shim `_snapshot`** (single-row and full-table): the check rides the metadata read both paths already pay in `snapshotSincePos` — no second read, and it runs before the MySQL-anchor early return (a PG baseline has an LSN anchor, no binlog file/pos). Server-side `slog.Warn` only, consistent with how the shim handles `FindBaseline`'s `StaleWarning` (#466); an in-band MySQL signal stays deferred.
- **console reconstruct**: best-effort `baseline.ReadParquetMetadataAny` after `findBaseline` feeds a new `appendRenderGUCsWarning`, landing a `render_gucs_mismatch: …` entry in the response `Warnings` — the `stale_baseline` precedent (#466). A failed metadata read leaves `DumpMetadata` zero (LSN 0) and simply suppresses the warning.

Both use the CLI's exact predicate: `bmeta.LSN != 0 && bmeta.RenderGUCs != baseline.RenderGUCsPinned` (value comparison, so a baseline produced under a *different* pinned set is also caught).

### Placement decision

Per the issue's guidance ("if the fold already pays a metadata read, add the check there"): the shim gets it for free inside `snapshotSincePos` (both `_snapshot` folds call it, #797); no cache added — the console pays one Parquet footer read per request, marginal next to the DuckDB baseline-row scan the same request already performs.

## Tests

- `TestSnapshotSincePosRenderGUCsWarn` (shim): real Parquet files through the real metadata-read path — mismatched stamp and pre-pin baselines warn (with remediation), matching pin and MySQL baselines stay silent.
- `TestAppendRenderGUCsWarning` + `TestRenderGUCsMismatchReachesWarningsDTO` (console): predicate unit coverage plus end-to-end surfacing via the same `ReadParquetMetadataAny` call the handler uses, down to the JSON the UI receives — mirroring the #466 stale-baseline test.
- `go test ./... -count=1` green; `-race` green on shim/console/cli/baseline; `-tags integration` green on shim/console/cli (MySQL 13306); `go vet` and `go vet -tags integration` clean; gofmt clean on touched files.

closes #921

🤖 Generated with [Claude Code](https://claude.com/claude-code)
