### PR TITLE
query: widen start_pos/end_pos scan to uint64; drop the dead #986 typematrix workaround

### DIFF
--- a/internal/parser/typematrix_mariadb_integration_test.go
+++ b/internal/parser/typematrix_mariadb_integration_test.go
@@ -139,18 +139,23 @@ func TestParseFile_typeCorruptionMatrix_mariadb(t *testing.T) {
 		t.Fatalf("expected 1 UPDATE for table tm, got %d", len(upd))
 	}
 
-	// #986 workaround: MariaDB defers end_log_pos stamping for every
-	// non-terminal event inside a GTID-tracked transaction (Table_map,
-	// Write_rows/Update_rows all carry end_log_pos=0 on the wire — verified
-	// against mariadb-binlog directly, not a go-mysql artifact), which
-	// underflows handleRows' StartPos/EndPos computation for a MariaDB
-	// source. That is a real, separately-filed position-tracking bug,
-	// orthogonal to the column-VALUE fidelity this test sweeps (#620).
-	// Stamp safe placeholder positions here so the rest of this test
-	// exercises the real index-write and recover pipeline on otherwise
-	// unmodified, real MariaDB-decoded row values.
-	ins[0].StartPos, ins[0].EndPos = 100, 200
-	upd[0].StartPos, upd[0].EndPos = 200, 300
+	// #1117/#1180: MariaDB writes cache-buffered events (Table_map, row
+	// events) with end_log_pos=0 in the file itself; ParseFile's running-
+	// offset fill now reconstructs real positions, so the old "#986
+	// workaround" (stamping placebo 100/200 positions before indexing) is
+	// gone — the index-write and recover stages below run on the genuine
+	// parser-emitted positions. Pin their shape here: a fill regression
+	// re-emits the underflow (StartPos = 2^64-EventSize, EndPos = 0), which
+	// EndPos > StartPos catches. Exact ground-truth position equality is
+	// asserted by TestParseFile_realBinlog_mariadb; this sweep only needs
+	// the positions to be real and ordered.
+	if ins[0].StartPos < 4 || ins[0].EndPos <= ins[0].StartPos {
+		t.Fatalf("INSERT positions not filled: [%d, %d)", ins[0].StartPos, ins[0].EndPos)
+	}
+	if upd[0].StartPos < ins[0].EndPos || upd[0].EndPos <= upd[0].StartPos {
+		t.Fatalf("UPDATE positions not filled or not after INSERT: insert [%d, %d), update [%d, %d)",
+			ins[0].StartPos, ins[0].EndPos, upd[0].StartPos, upd[0].EndPos)
+	}
 
 	// ─── Stage 1: parser decode (go-mysql TABLE_MAP/ROWS_EVENT over MariaDB) ──
 

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -694,10 +694,17 @@ func scanRows(rows *sql.Rows) ([]ResultRow, error) {
 		// on the same byos-202 tenant. Defending the entire Scan closes
 		// the pattern. event_id stays a bare uint64 because
 		// AUTO_INCREMENT cannot return NULL on read.
+		// start_pos/end_pos are BIGINT UNSIGNED: scanned through the generic
+		// sql.Null[uint64], not sql.NullInt64 — a legitimate position above
+		// 2^63 (the #986/#1117 MariaDB underflow shape stored by pre-#1180
+		// builds, or any future >8EiB offset) would be a hard Scan failure
+		// through the int64 path. The mysql driver returns uint64 for
+		// unsigned BIGINT on the binary protocol and []byte on the text
+		// protocol; convertAssign handles both losslessly into uint64.
 		var (
 			binlogFile     sql.NullString
-			startPos       sql.NullInt64
-			endPos         sql.NullInt64
+			startPos       sql.Null[uint64]
+			endPos         sql.Null[uint64]
 			eventTimestamp sql.NullTime
 			gtid           sql.NullString
 			connID         sql.NullInt64
@@ -724,10 +731,10 @@ func scanRows(rows *sql.Rows) ([]ResultRow, error) {
 			r.BinlogFile = binlogFile.String
 		}
 		if startPos.Valid {
-			r.StartPos = uint64(startPos.Int64)
+			r.StartPos = startPos.V
 		}
 		if endPos.Valid {
-			r.EndPos = uint64(endPos.Int64)
+			r.EndPos = endPos.V
 		}
 		if eventTimestamp.Valid {
 			r.EventTimestamp = eventTimestamp.Time

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -699,8 +699,11 @@ func scanRows(rows *sql.Rows) ([]ResultRow, error) {
 		// 2^63 (the #986/#1117 MariaDB underflow shape stored by pre-#1180
 		// builds, or any future >8EiB offset) would be a hard Scan failure
 		// through the int64 path. The mysql driver returns uint64 for
-		// unsigned BIGINT on the binary protocol and []byte on the text
-		// protocol; convertAssign handles both losslessly into uint64.
+		// unsigned BIGINT on the TEXT protocol (ParseUint in textRows) and,
+		// above 2^63, []byte on the BINARY protocol (binaryRows falls back to
+		// uint64ToString; below 2^63 it is int64) — both shapes are reachable
+		// (parameterized queries use binary, argument-free ones text);
+		// convertAssign handles all of them losslessly into uint64.
 		var (
 			binlogFile     sql.NullString
 			startPos       sql.Null[uint64]

--- a/internal/query/scanrows_test.go
+++ b/internal/query/scanrows_test.go
@@ -14,7 +14,8 @@ import (
 // A minimal database/sql/driver implementation serving one canned resultset,
 // so scanRows can be exercised without a MySQL instance. Rows.Next hands back
 // driver values exactly as go-sql-driver would: uint64 for BIGINT UNSIGNED on
-// the binary protocol, []byte for everything on the text protocol.
+// the TEXT protocol (ParseUint), and on the BINARY protocol []byte above 2^63
+// (uint64ToString fallback) / int64 below it.
 
 type stubRows struct {
 	cols []string
@@ -103,14 +104,14 @@ func TestScanRows_positionAbove2to63(t *testing.T) {
 		}
 	}
 
-	t.Run("binary protocol uint64", func(t *testing.T) {
+	t.Run("text protocol uint64", func(t *testing.T) {
 		r := scanOneRow(t, base(bigStart, bigEnd))
 		if r.StartPos != bigStart || r.EndPos != bigEnd {
 			t.Errorf("positions [%d, %d], want [%d, %d]", r.StartPos, r.EndPos, bigStart, bigEnd)
 		}
 	})
 
-	t.Run("text protocol bytes", func(t *testing.T) {
+	t.Run("binary protocol bytes (>2^63)", func(t *testing.T) {
 		r := scanOneRow(t, base([]byte("9223372036854775850"), []byte("9223372036854775908")))
 		if r.StartPos != bigStart || r.EndPos != bigEnd {
 			t.Errorf("positions [%d, %d], want [%d, %d]", r.StartPos, r.EndPos, bigStart, bigEnd)

--- a/internal/query/scanrows_test.go
+++ b/internal/query/scanrows_test.go
@@ -1,0 +1,126 @@
+package query
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"io"
+	"testing"
+	"time"
+)
+
+// ─── Stub driver ─────────────────────────────────────────────────────────────
+//
+// A minimal database/sql/driver implementation serving one canned resultset,
+// so scanRows can be exercised without a MySQL instance. Rows.Next hands back
+// driver values exactly as go-sql-driver would: uint64 for BIGINT UNSIGNED on
+// the binary protocol, []byte for everything on the text protocol.
+
+type stubRows struct {
+	cols []string
+	vals [][]driver.Value
+	i    int
+}
+
+func (r *stubRows) Columns() []string { return r.cols }
+func (r *stubRows) Close() error      { return nil }
+func (r *stubRows) Next(dest []driver.Value) error {
+	if r.i >= len(r.vals) {
+		return io.EOF
+	}
+	copy(dest, r.vals[r.i])
+	r.i++
+	return nil
+}
+
+type stubStmt struct{ rows *stubRows }
+
+func (s *stubStmt) Close() error  { return nil }
+func (s *stubStmt) NumInput() int { return 0 }
+func (s *stubStmt) Exec([]driver.Value) (driver.Result, error) {
+	return nil, driver.ErrSkip
+}
+func (s *stubStmt) Query([]driver.Value) (driver.Rows, error) { return s.rows, nil }
+
+type stubConn struct{ rows *stubRows }
+
+func (c *stubConn) Prepare(string) (driver.Stmt, error) { return &stubStmt{c.rows}, nil }
+func (c *stubConn) Close() error                        { return nil }
+func (c *stubConn) Begin() (driver.Tx, error)           { return nil, driver.ErrSkip }
+
+type stubConnector struct{ rows *stubRows }
+
+func (c stubConnector) Connect(context.Context) (driver.Conn, error) {
+	return &stubConn{c.rows}, nil
+}
+func (c stubConnector) Driver() driver.Driver { return nil }
+
+// scanRowsColumns matches the SELECT order scanRows expects.
+var scanRowsColumns = []string{
+	"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp",
+	"gtid", "connection_id", "schema_name", "table_name", "event_type",
+	"pk_values", "changed_columns", "row_before", "row_after",
+	"schema_version", "query_text", "query_hash", "commit_ts_us",
+}
+
+func scanOneRow(t *testing.T, vals []driver.Value) ResultRow {
+	t.Helper()
+	db := sql.OpenDB(stubConnector{rows: &stubRows{
+		cols: scanRowsColumns,
+		vals: [][]driver.Value{vals},
+	}})
+	defer db.Close()
+	rows, err := db.Query("SELECT stub")
+	if err != nil {
+		t.Fatalf("stub query: %v", err)
+	}
+	defer rows.Close()
+	results, err := scanRows(rows)
+	if err != nil {
+		t.Fatalf("scanRows: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("scanRows returned %d rows, want 1", len(results))
+	}
+	return results[0]
+}
+
+// TestScanRows_positionAbove2to63 pins the #1202 widening: start_pos/end_pos
+// are BIGINT UNSIGNED, and a stored position above 2^63 (the #986/#1117
+// underflow shape written by pre-#1180 builds, still present in customer
+// indexes) must scan losslessly instead of failing the whole resultset
+// through sql.NullInt64.
+func TestScanRows_positionAbove2to63(t *testing.T) {
+	const bigStart = uint64(1)<<63 + 42
+	const bigEnd = uint64(1)<<63 + 100
+
+	base := func(start, end driver.Value) []driver.Value {
+		return []driver.Value{
+			int64(7), []byte("mariadb-bin.000001"), start, end,
+			time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC),
+			nil, nil, []byte("s"), []byte("t"), int64(1), []byte("1"),
+			nil, nil, nil, int64(0), nil, nil, nil,
+		}
+	}
+
+	t.Run("binary protocol uint64", func(t *testing.T) {
+		r := scanOneRow(t, base(bigStart, bigEnd))
+		if r.StartPos != bigStart || r.EndPos != bigEnd {
+			t.Errorf("positions [%d, %d], want [%d, %d]", r.StartPos, r.EndPos, bigStart, bigEnd)
+		}
+	})
+
+	t.Run("text protocol bytes", func(t *testing.T) {
+		r := scanOneRow(t, base([]byte("9223372036854775850"), []byte("9223372036854775908")))
+		if r.StartPos != bigStart || r.EndPos != bigEnd {
+			t.Errorf("positions [%d, %d], want [%d, %d]", r.StartPos, r.EndPos, bigStart, bigEnd)
+		}
+	})
+
+	t.Run("NULL positions stay zero", func(t *testing.T) {
+		r := scanOneRow(t, base(nil, nil))
+		if r.StartPos != 0 || r.EndPos != 0 {
+			t.Errorf("positions [%d, %d], want [0, 0]", r.StartPos, r.EndPos)
+		}
+	})
+}


### PR DESCRIPTION
Two residuals from the #1117/#1180 MariaDB position fix. closes #1202

## 1. `scanRows` position scan widened to uint64

`internal/query/query.go` scanned `start_pos`/`end_pos` (`BIGINT UNSIGNED`) through `sql.NullInt64`: a legitimate stored position above 2^63 — the #986/#1117 underflow shape written by pre-#1180 builds, still present in customer indexes — was a hard Scan failure for the whole resultset. Both columns now scan through the generic `sql.Null[uint64]`; the mysql driver returns `uint64` on the binary protocol and `[]byte` on the text protocol, and `convertAssign` handles both losslessly.

Checked the rest of the same SELECT: `commit_ts_us` already documents its lossless signed hop (epoch µs fits int64 until year 294247), `connection_id` is `INT UNSIGNED` and fits `int64`. No other position columns affected.

New `internal/query/scanrows_test.go`: a minimal stub `database/sql/driver` (no MySQL needed) drives the real `scanRows` with positions >2^63 in both driver shapes (`uint64` and `[]byte`) plus the NULL case.

## 2. Dead "#986 workaround" removed from the MariaDB typematrix test

`internal/parser/typematrix_mariadb_integration_test.go` still stamped placebo positions (`100, 200`) before indexing. The #1180 running-offset fill in `ParseFile` reconstructs real positions from a MariaDB 11.4+ binlog, so the workaround is deleted; the index-write and recover stages now run on the genuine parser-emitted positions, and the test pins their shape (no underflow — `EndPos > StartPos >= 4` — and the UPDATE strictly after the INSERT). Exact ground-truth position equality remains asserted by `TestParseFile_realBinlog_mariadb`.

## Tests

- `gofmt -l` clean on touched files; `go vet ./...` and `go vet -tags integration ./...` clean
- `go test ./... -count=1` green; `go test ./internal/query/ ./internal/parser/ -count=1 -race` green
- `go test -tags integration ./internal/query/ -count=1` green (MySQL 13306)
- MariaDB 11.4 container (CI recipe, port 13307): `go test -tags integration ./internal/parser/ -run mariadb -p 1` — including the reworked `TestParseFile_typeCorruptionMatrix_mariadb` against real filled positions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
