### PR TITLE
console: surface restore coverage as a live RPO card on the overview

### DIFF
--- a/docs/console.md
+++ b/docs/console.md
@@ -94,7 +94,9 @@ and searching events:
    wall clock; the capture-lag chip says how close to now that edge is), the
    continuity verdict, and — with a baseline source configured — the
    full-table restore window plus any table whose newest baseline predates
-   coverage. It degrades loudly on `gap_lost`/`unknown`/an empty index.
+   coverage. It degrades loudly on `gap_lost`/`unavailable`/`unknown`/an
+   empty index, and full-table coverage that could not be evaluated says so
+   instead of rendering as "nothing broken".
    Below it: headline counts (changes indexed, deletes, tables touched, most
    recent change), a **Recent changes** list (each row opens Events, with an
    inline **Undo**), and an **Activity by table** breakdown. The starting
@@ -870,7 +872,7 @@ All endpoints return JSON. `/api/*` (except `healthz`) require
 | `POST /api/auth/logout` | Revoke the presented session (static token → 204 no-op). |
 | `POST /api/auth/password` | Set (first time; requires static-token auth) or rotate (`current_password` verified) the console password. Revokes all sessions and returns a fresh one. |
 | `GET /api/status` | Index status (same payload as `bintrail status --format json`). |
-| `GET /api/coverage` | Live RPO summary: restorable delta window `[delta_from, delta_to]`, `lag_seconds`, `continuity`, full-table window and `broken_tables` when a baseline source is configured. |
+| `GET /api/coverage` | Live RPO summary: restorable delta window `[delta_from, delta_to]`, `lag_seconds`, `continuity`; with a baseline source, `full_table_status` (`ok`/`unknown`), `full_table_from` and `broken_tables` (profile-restricted sessions get the delta half only). |
 | `GET /api/schemas` | Schemas known to the index: those observed in `binlog_events` **plus** those in the latest schema snapshot, so a schema whose partitions have all been rotated out to Parquet/S3 is still listed (the archives still answer `/api/events` and `/api/recover`). `schemas` is that full union; `snapshot_only` (when present) is the subset with no live events observed — the UI labels these "snapshot only" since queries against them may return nothing; `snapshot_unavailable: true` means the snapshot half was skipped because the schema resolver failed to load (check the server log), so archive-only schemas may be missing from the list. The snapshot half is skipped under `--no-archive` or an active `--profile`, where archived data is unreachable anyway. Note this answers *which schemas this index knows of*, not *which have data in a given window* — for that, see `bintrail status`'s continuity verdict. `?schema=<name>` → that schema's tables. |
 | `GET /api/events` | Event browser. Query params: `schema, table, pk, event_type, gtid, since, until, changed_column, order, limit`. |
 | `POST /api/recover` | Undo-SQL generation. JSON body with the same filter fields (requires at least `schema`; an `order` field is accepted but ignored — recover always processes oldest-first). Returns `{sql, statement_count, row_count, warnings}`. When the target is a foreign-key **parent** whose `DELETE` cascaded below the binlog (MySQL/MariaDB index only), cascade victims are **auto-detected** and folded into the same script; the response then also carries `{cascade_detected, victim_count, set_null_count}` (see [Recover and cascade](#cascade-recovery)). |

--- a/docs/console.md
+++ b/docs/console.md
@@ -88,10 +88,17 @@ top (see [Managing servers](#managing-servers)) and a **⌘K command palette**
 (also reachable from the "Search & commands" button) for jumping between views
 and searching events:
 
-1. **Overview** (landing) — what changed recently and where: headline counts
-   (changes indexed, deletes, tables touched, most recent change), a **Recent
-   changes** list (each row opens Events, with an inline **Undo**), and an
-   **Activity by table** breakdown. The starting point for "what happened?".
+1. **Overview** (landing) — what changed recently and where: a **Restore
+   coverage** card answering "to when can I restore, right now?" — any point
+   between the delta-coverage floor and the last *indexed* event (never the
+   wall clock; the capture-lag chip says how close to now that edge is), the
+   continuity verdict, and — with a baseline source configured — the
+   full-table restore window plus any table whose newest baseline predates
+   coverage. It degrades loudly on `gap_lost`/`unknown`/an empty index.
+   Below it: headline counts (changes indexed, deletes, tables touched, most
+   recent change), a **Recent changes** list (each row opens Events, with an
+   inline **Undo**), and an **Activity by table** breakdown. The starting
+   point for "what happened?".
 2. **Events** — a smart search box (free text plus `type:`, `pk:`, `col:`, and
    `schema.table` tokens) with an expandable **Filters** panel. Each row expands
    in place to a before→after diff; `j`/`k` move the cursor, `↵` expands, `u`
@@ -863,6 +870,7 @@ All endpoints return JSON. `/api/*` (except `healthz`) require
 | `POST /api/auth/logout` | Revoke the presented session (static token → 204 no-op). |
 | `POST /api/auth/password` | Set (first time; requires static-token auth) or rotate (`current_password` verified) the console password. Revokes all sessions and returns a fresh one. |
 | `GET /api/status` | Index status (same payload as `bintrail status --format json`). |
+| `GET /api/coverage` | Live RPO summary: restorable delta window `[delta_from, delta_to]`, `lag_seconds`, `continuity`, full-table window and `broken_tables` when a baseline source is configured. |
 | `GET /api/schemas` | Schemas known to the index: those observed in `binlog_events` **plus** those in the latest schema snapshot, so a schema whose partitions have all been rotated out to Parquet/S3 is still listed (the archives still answer `/api/events` and `/api/recover`). `schemas` is that full union; `snapshot_only` (when present) is the subset with no live events observed — the UI labels these "snapshot only" since queries against them may return nothing; `snapshot_unavailable: true` means the snapshot half was skipped because the schema resolver failed to load (check the server log), so archive-only schemas may be missing from the list. The snapshot half is skipped under `--no-archive` or an active `--profile`, where archived data is unreachable anyway. Note this answers *which schemas this index knows of*, not *which have data in a given window* — for that, see `bintrail status`'s continuity verdict. `?schema=<name>` → that schema's tables. |
 | `GET /api/events` | Event browser. Query params: `schema, table, pk, event_type, gtid, since, until, changed_column, order, limit`. |
 | `POST /api/recover` | Undo-SQL generation. JSON body with the same filter fields (requires at least `schema`; an `order` field is accepted but ignored — recover always processes oldest-first). Returns `{sql, statement_count, row_count, warnings}`. When the target is a foreign-key **parent** whose `DELETE` cascaded below the binlog (MySQL/MariaDB index only), cascade victims are **auto-detected** and folded into the same script; the response then also carries `{cascade_detected, victim_count, set_null_count}` (see [Recover and cascade](#cascade-recovery)). |

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -668,7 +668,9 @@ function covCard(c) {
   if (typeof c.lag_seconds === "number") {
     chips.append(el("span", { class: "cov-chip" + (c.lag_seconds > 300 ? " warn" : " ok"), text: "capture lag " + c.lag_seconds + "s" }));
   }
-  chips.append(el("span", { class: "cov-chip " + (bad ? "bad" : warn ? "warn" : "ok"), text: "continuity " + cont }));
+  // "none" (file-mode: no capture ran) stays NEUTRAL — green would paint a
+  // non-claim as assurance.
+  chips.append(el("span", { class: "cov-chip" + (bad ? " bad" : warn ? " warn" : cont === "ok" ? " ok" : ""), text: "continuity " + cont }));
   card.append(chips);
   if (cont === "gap_lost") {
     card.append(el("p", { class: "cov-line bad", text: "Events were permanently lost — the window has a hole; points beyond the gap need a fresh baseline." }));

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -646,16 +646,59 @@ function setActiveNav(route) {
 
 // ── Overview ─────────────────────────────────────────────────────────────────
 
+// covCard renders the live RPO statement (#1194). The window's upper edge is
+// the last INDEXED event on purpose — "restorable up to now" with a dead
+// stream would be false assurance; the lag chip is what says "now". Degrades
+// loudly: gap_lost/unavailable red, unknown amber, empty index explicit.
+function covCard(c) {
+  const card = el("section", { class: "ov-panel cov-card" });
+  card.append(el("div", { class: "ov-panel-head" },
+    el("h2", { class: "ov-panel-title", text: "Restore coverage" })));
+  const cont = c.continuity || "unknown";
+  const bad = cont === "gap_lost" || cont === "unavailable";
+  const warn = cont === "unknown";
+  if (!c.delta_to) {
+    card.append(el("p", { class: "cov-line warn", text: "No indexed events yet — nothing to restore from." }));
+  } else {
+    card.append(el("p", { class: "cov-line" },
+      "Any point between ", el("b", { text: c.delta_from || "(unknown)" }),
+      " and ", el("b", { text: c.delta_to }), " is restorable."));
+  }
+  const chips = el("div", { class: "cov-chips" });
+  if (typeof c.lag_seconds === "number") {
+    chips.append(el("span", { class: "cov-chip" + (c.lag_seconds > 300 ? " warn" : " ok"), text: "capture lag " + c.lag_seconds + "s" }));
+  }
+  chips.append(el("span", { class: "cov-chip " + (bad ? "bad" : warn ? "warn" : "ok"), text: "continuity " + cont }));
+  card.append(chips);
+  if (cont === "gap_lost") {
+    card.append(el("p", { class: "cov-line bad", text: "Events were permanently lost — the window has a hole; points beyond the gap need a fresh baseline." }));
+  } else if (cont === "unavailable") {
+    card.append(el("p", { class: "cov-line bad", text: "Continuity could not be read — treat the window as unverified." }));
+  } else if (warn) {
+    card.append(el("p", { class: "cov-line warn", text: "Continuity is not evaluable on this index — the window may have undetected holes." }));
+  }
+  if (c.baseline_configured) {
+    if (c.full_table_from) {
+      card.append(el("p", { class: "cov-line", text: "Full-table restore: any point from " + c.full_table_from + " onwards." }));
+    }
+    if (c.broken_tables && c.broken_tables.length) {
+      card.append(el("p", { class: "cov-line bad", text: "Not fully restorable (newest baseline predates coverage): " + c.broken_tables.join(", ") + " — take a fresh baseline." }));
+    }
+  }
+  return card;
+}
+
 async function renderOverview() {
   const gen = serverGen;
   viewLoading();
   try {
-    const [status, eventsData] = await Promise.all([
+    const [status, eventsData, coverage] = await Promise.all([
       api("/api/status").catch(() => null),
       api("/api/events?limit=200&order=DESC"),
+      api("/api/coverage").catch(() => null), // best-effort like status
     ]);
     if (gen !== serverGen) return;
-    buildOverview(status, eventsData); // render INSIDE the try: a throw here shows an error, never a stuck "Loading…"
+    buildOverview(status, eventsData, coverage); // render INSIDE the try: a throw here shows an error, never a stuck "Loading…"
   } catch (err) {
     if (gen !== serverGen) return;
     const v = VIEW(); clear(v); v.append(pageHead("Overview", null)); renderError(v, err);
@@ -665,7 +708,7 @@ async function renderOverview() {
 // buildOverview renders the dashboard from the two fetched payloads. status may
 // be null (its fetch is best-effort); when it is, we do NOT claim a global
 // total — `events` is only the fetched window (limit 200), never the index size.
-function buildOverview(status, eventsData) {
+function buildOverview(status, eventsData, coverage) {
   if (status) updateSideMeta(status);
 
   const events = (eventsData && eventsData.events) || [];
@@ -695,6 +738,10 @@ function buildOverview(status, eventsData) {
     el("b", { text: deletes + " delete(s)" }),
     " in the last " + events.length + " event(s): the ones worth a look first.");
   v.append(pageHead("Overview", sub));
+
+  // Restore coverage — the live RPO statement (#1194). Best-effort: no card
+  // when the fetch failed, never a fabricated window.
+  if (coverage) v.append(covCard(coverage));
 
   // stats
   const stats = el("div", { class: "ov-stats" });

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -657,11 +657,18 @@ function covCard(c) {
   const cont = c.continuity || "unknown";
   const bad = cont === "gap_lost" || cont === "unavailable";
   const warn = cont === "unknown";
-  if (!c.delta_to) {
+  if (bad && !c.delta_to) {
+    // Unreachable/broken backend: say nothing about the window — "no events
+    // yet" would be a positive factual claim about an index we couldn't read.
+  } else if (!c.delta_to) {
     card.append(el("p", { class: "cov-line warn", text: "No indexed events yet — nothing to restore from." }));
+  } else if (!c.delta_from) {
+    // Unknown floor: don't assert a bounded window whose start we don't know.
+    card.append(el("p", { class: "cov-line" },
+      "Restorable up to ", el("b", { text: c.delta_to }), "; the window start could not be determined."));
   } else {
     card.append(el("p", { class: "cov-line" },
-      "Any point between ", el("b", { text: c.delta_from || "(unknown)" }),
+      "Any point between ", el("b", { text: c.delta_from }),
       " and ", el("b", { text: c.delta_to }), " is restorable."));
   }
   const chips = el("div", { class: "cov-chips" });
@@ -680,8 +687,13 @@ function covCard(c) {
     card.append(el("p", { class: "cov-line warn", text: "Continuity is not evaluable on this index — the window may have undetected holes." }));
   }
   if (c.baseline_configured) {
+    if (c.full_table_status === "unknown") {
+      // An error must never render like "nothing broken" — the broken-table
+      // warning would silently vanish behind a failed listing.
+      card.append(el("p", { class: "cov-line warn", text: "Full-table coverage could not be evaluated — check the daemon log." }));
+    }
     if (c.full_table_from) {
-      card.append(el("p", { class: "cov-line", text: "Full-table restore: any point from " + c.full_table_from + " onwards." }));
+      card.append(el("p", { class: "cov-line", text: "Full-table restore for tables with a baseline: any point from " + c.full_table_from + " onwards." }));
     }
     if (c.broken_tables && c.broken_tables.length) {
       card.append(el("p", { class: "cov-line bad", text: "Not fully restorable (newest baseline predates coverage): " + c.broken_tables.join(", ") + " — take a fresh baseline." }));
@@ -697,7 +709,10 @@ async function renderOverview() {
     const [status, eventsData, coverage] = await Promise.all([
       api("/api/status").catch(() => null),
       api("/api/events?limit=200&order=DESC"),
-      api("/api/coverage").catch(() => null), // best-effort like status
+      // A failed fetch must render the same red "unavailable" card the
+      // nil-db path gets — a swallowed null would make a broken endpoint
+      // indistinguishable from a console without the feature.
+      api("/api/coverage").catch((err) => { console.error("coverage fetch failed", err); return { continuity: "unavailable" }; }),
     ]);
     if (gen !== serverGen) return;
     buildOverview(status, eventsData, coverage); // render INSIDE the try: a throw here shows an error, never a stuck "Loading…"

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -1414,3 +1414,14 @@ button { font-family: inherit; }
    mount; reserve a minimum height so an empty/slow module doesn't collapse the
    view region to a bare page head. */
 .ext-view-mount { min-height: 240px; }
+
+/* ── restore-coverage card (#1194) ─────────────────────────────────────── */
+.cov-card { margin-bottom: 14px; }
+.cov-line { margin: 6px 0 0; font-size: 14px; color: var(--ink); }
+.cov-line.bad { color: var(--delete); font-weight: 600; }
+.cov-line.warn { color: var(--ink-2); }
+.cov-chips { display: flex; gap: 8px; margin-top: 8px; flex-wrap: wrap; }
+.cov-chip { font-family: var(--f-mono); font-size: 12px; padding: 2px 9px; border: 1px solid var(--line); border-radius: 10px; color: var(--ink-2); }
+.cov-chip.ok { color: var(--insert); border-color: var(--insert); }
+.cov-chip.warn { color: var(--update); border-color: var(--update); }
+.cov-chip.bad { color: var(--delete); border-color: var(--delete); font-weight: 600; }

--- a/internal/console/coverage_api.go
+++ b/internal/console/coverage_api.go
@@ -1,0 +1,109 @@
+package console
+
+import (
+	"log/slog"
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/reconstruct"
+	"github.com/dbtrail/dbtrail/internal/status"
+)
+
+// coverageResponse is GET /api/coverage — the live RPO statement behind the
+// overview card (#1194): "any point between delta_from and delta_to is
+// restorable", plus how far behind capture is and whether the range has
+// holes. Metadata-only (timestamps and verdicts, no row data), so like
+// /api/status it carries no profile gate — unlike /api/baselines, nothing
+// here bypasses redaction.
+type coverageResponse struct {
+	// Delta window: any row/point in [delta_from, delta_to] is recoverable
+	// from indexed deltas. delta_from omitted = unknown floor (never
+	// assumed); delta_to omitted = empty index.
+	DeltaFrom string `json:"delta_from,omitempty"`
+	DeltaTo   string `json:"delta_to,omitempty"`
+	// LagSeconds = now − delta_to, present only when a capture stream exists.
+	// The window's upper edge is the last INDEXED event, never the wall
+	// clock — the lag is what says how close to "now" that edge is.
+	LagSeconds *int64 `json:"lag_seconds,omitempty"`
+	// Continuity: ok | gap_lost | unknown | unavailable | none — the exact
+	// status.ContinuityStatus rule, never recomputed here.
+	Continuity         string `json:"continuity"`
+	BaselineConfigured bool   `json:"baseline_configured"`
+	// FullTableFrom: from this instant onwards EVERY table with a baseline
+	// is fully reconstructable (the latest usable newest-per-table anchor).
+	// Omitted when no baseline is configured, the floor is unknown, or no
+	// table has a usable newest baseline.
+	FullTableFrom string `json:"full_table_from,omitempty"`
+	// BrokenTables: tables whose NEWEST baseline predates the delta floor —
+	// full-table restore through that hole is impossible (#1193's verdict).
+	BrokenTables []string `json:"broken_tables,omitempty"`
+}
+
+func (s *Server) handleCoverage(w http.ResponseWriter, r *http.Request) {
+	b := s.resolveOr(w, r)
+	if b == nil {
+		return
+	}
+	resp := coverageResponse{BaselineConfigured: b.baselineSrc != ""}
+	if b.db == nil {
+		// An unopened bundle connection degrades to an explicit
+		// "unavailable" card, never a fabricated window.
+		slog.Warn("console: coverage not evaluated — the server's index connection is not open")
+		resp.Continuity = "unavailable"
+		writeJSON(w, http.StatusOK, resp)
+		return
+	}
+	now := time.Now().UTC()
+	sum, err := status.CollectCoverageSummary(r.Context(), b.db, b.dbName, now)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	resp.Continuity = sum.Continuity
+	resp.LagSeconds = sum.LagSeconds
+	if !sum.DeltaFrom.IsZero() {
+		resp.DeltaFrom = sum.DeltaFrom.Format(consoleTSFormat)
+	}
+	if !sum.DeltaTo.IsZero() {
+		resp.DeltaTo = sum.DeltaTo.Format(consoleTSFormat)
+	}
+	// Full-table half: newest-per-table baseline anchors graded against the
+	// floor — #1193's verdict via the status package, no second
+	// implementation. Best-effort: a listing failure degrades to the delta
+	// half, loudly. Skipped whole on an unknown floor — grading anchors
+	// against an unknown floor can neither claim a window nor name a broken
+	// table.
+	if b.baselineSrc != "" && !sum.DeltaFrom.IsZero() {
+		files, err := reconstruct.ListBaselines(r.Context(), b.baselineSrc)
+		if err != nil {
+			slog.Warn("console: coverage card could not list baselines", "source", b.baselineSrc, "error", err)
+		} else {
+			newest := make(map[string]time.Time, len(files))
+			for _, f := range files {
+				k := f.Schema + "." + f.Table
+				if f.SnapshotTime.After(newest[k]) {
+					newest[k] = f.SnapshotTime
+				}
+			}
+			var from time.Time
+			for k, ts := range newest {
+				if status.BaselineStalenessFor(ts, sum.DeltaFrom, now) == status.BaselineBroken {
+					resp.BrokenTables = append(resp.BrokenTables, k)
+					continue
+				}
+				// The window covering ALL tables starts at the LATEST usable
+				// anchor: table i is reconstructable for points >= its own
+				// anchor, so "every table" holds only past the newest one.
+				if ts.After(from) {
+					from = ts
+				}
+			}
+			sort.Strings(resp.BrokenTables)
+			if !from.IsZero() {
+				resp.FullTableFrom = from.Format(consoleTSFormat)
+			}
+		}
+	}
+	writeJSON(w, http.StatusOK, resp)
+}

--- a/internal/console/coverage_api.go
+++ b/internal/console/coverage_api.go
@@ -13,31 +13,56 @@ import (
 // coverageResponse is GET /api/coverage — the live RPO statement behind the
 // overview card (#1194): "any point between delta_from and delta_to is
 // restorable", plus how far behind capture is and whether the range has
-// holes. Metadata-only (timestamps and verdicts, no row data), so like
-// /api/status it carries no profile gate — unlike /api/baselines, nothing
-// here bypasses redaction.
+// holes. The DELTA half is metadata-only (timestamps and verdicts, no row
+// data) and carries no profile gate, like /api/status. The FULL-TABLE half
+// is derived from the baseline listing — the surface /api/baselines refuses
+// to a profiled session (#1075: baseline reads aren't redacted, and
+// broken_tables is a table-name inventory) — so it is gated by the SAME
+// sessionRestricted rule. Capture-health drops (#1034) are deliberately not
+// consulted — they have their own surface (status, --fail-on-gap).
 type coverageResponse struct {
 	// Delta window: any row/point in [delta_from, delta_to] is recoverable
 	// from indexed deltas. delta_from omitted = unknown floor (never
 	// assumed); delta_to omitted = empty index.
 	DeltaFrom string `json:"delta_from,omitempty"`
 	DeltaTo   string `json:"delta_to,omitempty"`
-	// LagSeconds = now − delta_to, present only when a capture stream exists.
-	// The window's upper edge is the last INDEXED event, never the wall
-	// clock — the lag is what says how close to "now" that edge is.
+	// LagSeconds = now − delta_to, present only when a capture stream exists
+	// AND at least one event is indexed. The window's upper edge is the last
+	// INDEXED event, never the wall clock — the lag is what says how close
+	// to "now" that edge is.
 	LagSeconds *int64 `json:"lag_seconds,omitempty"`
 	// Continuity: ok | gap_lost | unknown | unavailable | none — the exact
 	// status.ContinuityStatus rule, never recomputed here.
-	Continuity         string `json:"continuity"`
-	BaselineConfigured bool   `json:"baseline_configured"`
-	// FullTableFrom: from this instant onwards EVERY table with a baseline
-	// is fully reconstructable (the latest usable newest-per-table anchor).
-	// Omitted when no baseline is configured, the floor is unknown, or no
-	// table has a usable newest baseline.
+	Continuity string `json:"continuity"`
+	// BaselineConfigured mirrors /api/baselines' "configured" — a baseline
+	// SOURCE exists. It is NOT the reconstruct gate (/api/capabilities), the
+	// same configured-vs-reconstruct split baselines_api documents.
+	BaselineConfigured bool `json:"baseline_configured"`
+	// FullTableStatus discriminates the full-table half when a source is
+	// configured: "ok" = evaluated (fields below are meaningful, possibly
+	// empty because no usable baseline exists yet), "unknown" = could NOT be
+	// evaluated (unknown floor or a failed listing) — absent fields must
+	// never read as "nothing broken". Omitted when no source is configured
+	// or the session is profile-restricted.
+	FullTableStatus string `json:"full_table_status,omitempty"`
+	// FullTableFrom: from this instant onwards every table WITH A USABLE
+	// baseline is fully reconstructable (the latest usable newest-per-table
+	// anchor). Tables in broken_tables are excluded — they are not
+	// reconstructable at all; never-baselined tables are invisible here.
+	// Omitted when full_table_status != "ok" or no usable baseline exists.
 	FullTableFrom string `json:"full_table_from,omitempty"`
 	// BrokenTables: tables whose NEWEST baseline predates the delta floor —
 	// full-table restore through that hole is impossible (#1193's verdict).
 	BrokenTables []string `json:"broken_tables,omitempty"`
+}
+
+// serverID labels log lines with the request's selected server — a
+// multi-server console emitting unattributed warns is undebuggable.
+func serverID(r *http.Request) string {
+	if id := r.Header.Get(serverHeader); id != "" {
+		return id
+	}
+	return "default"
 }
 
 func (s *Server) handleCoverage(w http.ResponseWriter, r *http.Request) {
@@ -49,7 +74,7 @@ func (s *Server) handleCoverage(w http.ResponseWriter, r *http.Request) {
 	if b.db == nil {
 		// An unopened bundle connection degrades to an explicit
 		// "unavailable" card, never a fabricated window.
-		slog.Warn("console: coverage not evaluated — the server's index connection is not open")
+		slog.Warn("console: coverage not evaluated — the server's index connection is not open", "server", serverID(r))
 		resp.Continuity = "unavailable"
 		writeJSON(w, http.StatusOK, resp)
 		return
@@ -70,39 +95,48 @@ func (s *Server) handleCoverage(w http.ResponseWriter, r *http.Request) {
 	}
 	// Full-table half: newest-per-table baseline anchors graded against the
 	// floor — #1193's verdict via the status package, no second
-	// implementation. Best-effort: a listing failure degrades to the delta
-	// half, loudly. Skipped whole on an unknown floor — grading anchors
-	// against an unknown floor can neither claim a window nor name a broken
-	// table.
-	if b.baselineSrc != "" && !sum.DeltaFrom.IsZero() {
+	// implementation. Gated exactly like /api/baselines (#1075): the listing
+	// this is derived from bypasses redaction, and broken_tables is a
+	// table-name inventory a deny-profile withholds elsewhere. A failed
+	// listing or an unknown floor is "unknown", never a silently-empty "ok"
+	// — a broken-table warning must not vanish because of an error.
+	switch {
+	case b.baselineSrc == "":
+	case sessionRestricted(r):
+		recordProfileGateDeny(r, "coverage")
+	case sum.DeltaFrom.IsZero():
+		resp.FullTableStatus = "unknown"
+	default:
 		files, err := reconstruct.ListBaselines(r.Context(), b.baselineSrc)
 		if err != nil {
-			slog.Warn("console: coverage card could not list baselines", "source", b.baselineSrc, "error", err)
-		} else {
-			newest := make(map[string]time.Time, len(files))
-			for _, f := range files {
-				k := f.Schema + "." + f.Table
-				if f.SnapshotTime.After(newest[k]) {
-					newest[k] = f.SnapshotTime
-				}
+			slog.Warn("console: coverage card could not list baselines", "server", serverID(r), "source", b.baselineSrc, "error", err)
+			resp.FullTableStatus = "unknown"
+			break
+		}
+		resp.FullTableStatus = "ok"
+		newest := make(map[string]time.Time, len(files))
+		for _, f := range files {
+			k := f.Schema + "." + f.Table
+			if f.SnapshotTime.After(newest[k]) {
+				newest[k] = f.SnapshotTime
 			}
-			var from time.Time
-			for k, ts := range newest {
-				if status.BaselineStalenessFor(ts, sum.DeltaFrom, now) == status.BaselineBroken {
-					resp.BrokenTables = append(resp.BrokenTables, k)
-					continue
-				}
-				// The window covering ALL tables starts at the LATEST usable
-				// anchor: table i is reconstructable for points >= its own
-				// anchor, so "every table" holds only past the newest one.
-				if ts.After(from) {
-					from = ts
-				}
+		}
+		var from time.Time
+		for k, ts := range newest {
+			if status.BaselineStalenessFor(ts, sum.DeltaFrom, now) == status.BaselineBroken {
+				resp.BrokenTables = append(resp.BrokenTables, k)
+				continue
 			}
-			sort.Strings(resp.BrokenTables)
-			if !from.IsZero() {
-				resp.FullTableFrom = from.Format(consoleTSFormat)
+			// The window covering ALL usable tables starts at the LATEST
+			// usable anchor: table i is reconstructable for points >= its
+			// own anchor, so "every table" holds only past the newest one.
+			if ts.After(from) {
+				from = ts
 			}
+		}
+		sort.Strings(resp.BrokenTables)
+		if !from.IsZero() {
+			resp.FullTableFrom = from.Format(consoleTSFormat)
 		}
 	}
 	writeJSON(w, http.StatusOK, resp)

--- a/internal/console/coverage_api_test.go
+++ b/internal/console/coverage_api_test.go
@@ -1,0 +1,74 @@
+package console
+
+import (
+	"database/sql"
+	"encoding/json"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+)
+
+// TestCoverageAPI pins the live-RPO statement (#1194): the delta window from
+// the strict floor, the full-table window from the latest usable baseline
+// anchor, broken tables named, and the nil-db degrade to "unavailable".
+func TestCoverageAPI(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now().UTC().Truncate(time.Second)
+	anchor := now.Add(-time.Hour)
+	// orders: usable newest anchor. legacy: newest predates the floor → broken.
+	writeBaselineFixture(t, dir, anchor.Format("2006-01-02T15-04-05Z"), "shop", "orders.parquet")
+	writeBaselineFixture(t, dir, now.Add(-150*time.Hour).Format("2006-01-02T15-04-05Z"), "shop", "legacy.parquet")
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	latest := now.Add(-30 * time.Second)
+	mock.ExpectQuery("PARTITION_NAME FROM information_schema.PARTITIONS").
+		WillReturnRows(sqlmock.NewRows([]string{"PARTITION_NAME"}).AddRow(now.Add(-100 * time.Hour).Format("p_2006010215")))
+	mock.ExpectQuery(`MIN\(partition_name\)`).
+		WillReturnRows(sqlmock.NewRows([]string{"min", "max"}).AddRow(nil, nil))
+	mock.ExpectQuery(`MAX\(event_timestamp\)`).
+		WillReturnRows(sqlmock.NewRows([]string{"max"}).AddRow(latest))
+	mock.ExpectQuery("FROM stream_state").WillReturnError(sql.ErrNoRows)
+
+	srv := newBaselineServer(t, dir, true)
+	srv.cm.boot.db = db
+	srv.cm.boot.dbName = "binlog_index"
+	rec, body := doServersReq(t, srv, "GET", "/api/coverage", "")
+	if rec.Code != 200 {
+		t.Fatalf("code = %d, body = %s", rec.Code, body)
+	}
+	var got coverageResponse
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.DeltaFrom == "" || got.DeltaTo != latest.Format(consoleTSFormat) {
+		t.Fatalf("delta window = [%q, %q]", got.DeltaFrom, got.DeltaTo)
+	}
+	if got.Continuity != "none" || got.LagSeconds != nil {
+		t.Fatalf("file-mode index: continuity=%q lag=%v", got.Continuity, got.LagSeconds)
+	}
+	if !got.BaselineConfigured || got.FullTableFrom != anchor.Format(consoleTSFormat) {
+		t.Fatalf("full_table_from = %q, want %q", got.FullTableFrom, anchor.Format(consoleTSFormat))
+	}
+	if len(got.BrokenTables) != 1 || got.BrokenTables[0] != "shop.legacy" {
+		t.Fatalf("broken_tables = %v", got.BrokenTables)
+	}
+
+	// No index connection: an explicit "unavailable", never a window.
+	srvNil := newBaselineServer(t, dir, true)
+	rec, body = doServersReq(t, srvNil, "GET", "/api/coverage", "")
+	if rec.Code != 200 {
+		t.Fatalf("code = %d, body = %s", rec.Code, body)
+	}
+	got = coverageResponse{}
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Continuity != "unavailable" || got.DeltaTo != "" || got.FullTableFrom != "" {
+		t.Fatalf("nil db must degrade to unavailable with no window: %+v", got)
+	}
+}

--- a/internal/console/coverage_api_test.go
+++ b/internal/console/coverage_api_test.go
@@ -7,36 +7,38 @@ import (
 	"time"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/go-sql-driver/mysql"
 )
 
-// TestCoverageAPI pins the live-RPO statement (#1194): the delta window from
-// the strict floor, the full-table window from the latest usable baseline
-// anchor, broken tables named, and the nil-db degrade to "unavailable".
-func TestCoverageAPI(t *testing.T) {
-	dir := t.TempDir()
-	now := time.Now().UTC().Truncate(time.Second)
-	anchor := now.Add(-time.Hour)
-	// orders: usable newest anchor. legacy: newest predates the floor → broken.
-	writeBaselineFixture(t, dir, anchor.Format("2006-01-02T15-04-05Z"), "shop", "orders.parquet")
-	writeBaselineFixture(t, dir, now.Add(-150*time.Hour).Format("2006-01-02T15-04-05Z"), "shop", "legacy.parquet")
-
+// coverageMockDB wires the CollectCoverageSummary query sequence: floor
+// partitions → archive MIN/MAX → walk partitions → one per-partition MAX
+// probe → stream_state (no row = file-mode). archErr != nil makes the floor
+// unknown.
+func coverageMockDB(t *testing.T, part string, latest time.Time, archErr error) *sql.DB {
+	t.Helper()
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer db.Close()
-	latest := now.Add(-30 * time.Second)
+	t.Cleanup(func() { db.Close() })
 	mock.ExpectQuery("PARTITION_NAME FROM information_schema.PARTITIONS").
-		WillReturnRows(sqlmock.NewRows([]string{"PARTITION_NAME"}).AddRow(now.Add(-100 * time.Hour).Format("p_2006010215")))
-	mock.ExpectQuery(`MIN\(partition_name\)`).
-		WillReturnRows(sqlmock.NewRows([]string{"min", "max"}).AddRow(nil, nil))
-	mock.ExpectQuery(`MAX\(event_timestamp\)`).
+		WillReturnRows(sqlmock.NewRows([]string{"PARTITION_NAME"}).AddRow(part))
+	if archErr != nil {
+		mock.ExpectQuery(`MIN\(partition_name\)`).WillReturnError(archErr)
+	} else {
+		mock.ExpectQuery(`MIN\(partition_name\)`).
+			WillReturnRows(sqlmock.NewRows([]string{"min", "max"}).AddRow(nil, nil))
+	}
+	mock.ExpectQuery("PARTITION_NAME FROM information_schema.PARTITIONS").
+		WillReturnRows(sqlmock.NewRows([]string{"PARTITION_NAME"}).AddRow(part))
+	mock.ExpectQuery(`MAX\(event_timestamp\) FROM binlog_events PARTITION`).
 		WillReturnRows(sqlmock.NewRows([]string{"max"}).AddRow(latest))
 	mock.ExpectQuery("FROM stream_state").WillReturnError(sql.ErrNoRows)
+	return db
+}
 
-	srv := newBaselineServer(t, dir, true)
-	srv.cm.boot.db = db
-	srv.cm.boot.dbName = "binlog_index"
+func coverageGet(t *testing.T, srv *Server) coverageResponse {
+	t.Helper()
 	rec, body := doServersReq(t, srv, "GET", "/api/coverage", "")
 	if rec.Code != 200 {
 		t.Fatalf("code = %d, body = %s", rec.Code, body)
@@ -45,30 +47,100 @@ func TestCoverageAPI(t *testing.T) {
 	if err := json.Unmarshal(body, &got); err != nil {
 		t.Fatal(err)
 	}
-	if got.DeltaFrom == "" || got.DeltaTo != latest.Format(consoleTSFormat) {
-		t.Fatalf("delta window = [%q, %q]", got.DeltaFrom, got.DeltaTo)
-	}
-	if got.Continuity != "none" || got.LagSeconds != nil {
-		t.Fatalf("file-mode index: continuity=%q lag=%v", got.Continuity, got.LagSeconds)
-	}
-	if !got.BaselineConfigured || got.FullTableFrom != anchor.Format(consoleTSFormat) {
-		t.Fatalf("full_table_from = %q, want %q", got.FullTableFrom, anchor.Format(consoleTSFormat))
-	}
-	if len(got.BrokenTables) != 1 || got.BrokenTables[0] != "shop.legacy" {
-		t.Fatalf("broken_tables = %v", got.BrokenTables)
-	}
+	return got
+}
 
-	// No index connection: an explicit "unavailable", never a window.
-	srvNil := newBaselineServer(t, dir, true)
-	rec, body = doServersReq(t, srvNil, "GET", "/api/coverage", "")
-	if rec.Code != 200 {
-		t.Fatalf("code = %d, body = %s", rec.Code, body)
-	}
-	got = coverageResponse{}
-	if err := json.Unmarshal(body, &got); err != nil {
-		t.Fatal(err)
-	}
-	if got.Continuity != "unavailable" || got.DeltaTo != "" || got.FullTableFrom != "" {
-		t.Fatalf("nil db must degrade to unavailable with no window: %+v", got)
-	}
+// TestCoverageAPI pins the live-RPO statement (#1194): the delta window from
+// the strict floor, the full-table window from the LATEST usable anchor,
+// broken tables named, and the degraded states each keeping their identity.
+func TestCoverageAPI(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	latest := now.Add(-30 * time.Second)
+	part := now.Add(-100 * time.Hour).Format("p_2006010215")
+	tsDir := func(age time.Duration) string { return now.Add(-age).Format("2006-01-02T15-04-05Z") }
+	anchorNew := now.Add(-time.Hour)
+	anchorOld := now.Add(-10 * time.Hour)
+
+	dir := t.TempDir()
+	// orders: usable newest anchor (-1h, plus a superseded -200h). users:
+	// usable at -10h. legacy: newest -150h predates the floor → broken.
+	writeBaselineFixture(t, dir, tsDir(time.Hour), "shop", "orders.parquet")
+	writeBaselineFixture(t, dir, tsDir(200*time.Hour), "shop", "orders.parquet")
+	writeBaselineFixture(t, dir, tsDir(10*time.Hour), "shop", "users.parquet")
+	writeBaselineFixture(t, dir, tsDir(150*time.Hour), "shop", "legacy.parquet")
+
+	t.Run("window, latest usable anchor, broken named", func(t *testing.T) {
+		srv := newBaselineServer(t, dir, true)
+		srv.cm.boot.db = coverageMockDB(t, part, latest, nil)
+		srv.cm.boot.dbName = "binlog_index"
+		got := coverageGet(t, srv)
+		if got.DeltaFrom == "" || got.DeltaTo != latest.Format(consoleTSFormat) {
+			t.Fatalf("delta window = [%q, %q]", got.DeltaFrom, got.DeltaTo)
+		}
+		if got.Continuity != "none" || got.LagSeconds != nil {
+			t.Fatalf("file-mode index: continuity=%q lag=%v", got.Continuity, got.LagSeconds)
+		}
+		if got.FullTableStatus != "ok" {
+			t.Fatalf("full_table_status = %q", got.FullTableStatus)
+		}
+		// LATEST usable anchor wins — the -10h users anchor must not widen
+		// the all-tables claim past orders' -1h anchor.
+		if got.FullTableFrom != anchorNew.Format(consoleTSFormat) {
+			t.Fatalf("full_table_from = %q, want %q (not %q)", got.FullTableFrom,
+				anchorNew.Format(consoleTSFormat), anchorOld.Format(consoleTSFormat))
+		}
+		if len(got.BrokenTables) != 1 || got.BrokenTables[0] != "shop.legacy" {
+			t.Fatalf("broken_tables = %v", got.BrokenTables)
+		}
+	})
+
+	t.Run("all tables broken: no window claim, all named", func(t *testing.T) {
+		dir2 := t.TempDir()
+		writeBaselineFixture(t, dir2, tsDir(150*time.Hour), "shop", "legacy.parquet")
+		writeBaselineFixture(t, dir2, tsDir(200*time.Hour), "shop", "carts.parquet")
+		srv := newBaselineServer(t, dir2, true)
+		srv.cm.boot.db = coverageMockDB(t, part, latest, nil)
+		srv.cm.boot.dbName = "binlog_index"
+		got := coverageGet(t, srv)
+		if got.FullTableStatus != "ok" || got.FullTableFrom != "" {
+			t.Fatalf("all-broken must claim NO window: %+v", got)
+		}
+		if len(got.BrokenTables) != 2 || got.BrokenTables[0] != "shop.carts" || got.BrokenTables[1] != "shop.legacy" {
+			t.Fatalf("broken_tables = %v", got.BrokenTables)
+		}
+	})
+
+	t.Run("unknown floor suppresses the full-table half as unknown", func(t *testing.T) {
+		srv := newBaselineServer(t, dir, true)
+		srv.cm.boot.db = coverageMockDB(t, part, latest, &mysql.MySQLError{Number: 1045, Message: "access denied"})
+		srv.cm.boot.dbName = "binlog_index"
+		got := coverageGet(t, srv)
+		if got.DeltaFrom != "" || got.DeltaTo == "" {
+			t.Fatalf("floor must be unknown, edge present: %+v", got)
+		}
+		if got.FullTableStatus != "unknown" || got.FullTableFrom != "" || len(got.BrokenTables) != 0 {
+			t.Fatalf("unknown floor must be 'unknown', never a silently-empty ok: %+v", got)
+		}
+	})
+
+	t.Run("listing failure is unknown, not silently-empty", func(t *testing.T) {
+		srv := newBaselineServer(t, dir+"/does-not-exist", true)
+		srv.cm.boot.db = coverageMockDB(t, part, latest, nil)
+		srv.cm.boot.dbName = "binlog_index"
+		got := coverageGet(t, srv)
+		if got.DeltaTo == "" {
+			t.Fatalf("delta half must survive a listing failure: %+v", got)
+		}
+		if got.FullTableStatus != "unknown" || got.FullTableFrom != "" || len(got.BrokenTables) != 0 {
+			t.Fatalf("a failed listing must not render as 'nothing broken': %+v", got)
+		}
+	})
+
+	t.Run("nil db degrades to unavailable with no window", func(t *testing.T) {
+		srv := newBaselineServer(t, dir, true)
+		got := coverageGet(t, srv)
+		if got.Continuity != "unavailable" || got.DeltaTo != "" || got.FullTableFrom != "" || got.FullTableStatus != "" {
+			t.Fatalf("nil db must degrade to unavailable with no window: %+v", got)
+		}
+	})
 }

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -442,6 +442,7 @@ func (s *Server) selectedEntry(r *http.Request) (ServerEntry, bool) {
 func (s *Server) buildHandler() http.Handler {
 	api := http.NewServeMux()
 	api.HandleFunc("GET /api/status", s.handleStatus)
+	api.HandleFunc("GET /api/coverage", s.handleCoverage)
 	api.HandleFunc("GET /api/schemas", s.handleSchemas)
 	api.HandleFunc("GET /api/events", s.handleEvents)
 	api.HandleFunc("POST /api/recover", s.recordAction("recover", s.handleRecover))

--- a/internal/status/coverage.go
+++ b/internal/status/coverage.go
@@ -5,12 +5,16 @@ import (
 	"database/sql"
 	"fmt"
 	"log/slog"
+	"sort"
 	"time"
 )
 
-// ContinuityStatus is the ONE continuity-verdict rule — the status JSON and
-// GET /api/coverage (#1194) both call it, so the two surfaces can never
-// disagree on what a gap state means (the Report.ExitError() discipline).
+// ContinuityStatus is the single rule for the machine-readable continuity
+// verdict STRINGS — the status JSON and GET /api/coverage (#1194) both call
+// it, so those two surfaces can never disagree (the Report.ExitError()
+// discipline). The text renderer and --fail-on-gap re-derive equivalent
+// buckets from the same StreamStateInfo fields for their own wording/exit
+// concerns; the wire vocabulary lives here.
 //
 //	"ok"          — no gap in the captured range (NOT a liveness assertion)
 //	"gap_lost"    — an unfillable gap was stamped: events permanently lost
@@ -35,8 +39,10 @@ func ContinuityStatus(stream *StreamStateInfo, streamErr error) string {
 
 // CoverageSummary is the lean live-RPO view behind the console's coverage
 // card (#1194): the reconstructable delta window, capture lag, and the
-// continuity verdict. Deliberately CHEAP — no COUNT(*), no index-size scan —
-// it loads on every server switch; CollectStatus stays the full report.
+// continuity verdict. Deliberately cheap — no COUNT(*), no index-size scan,
+// and the upper edge comes from per-partition MAX probes (see
+// newestIndexedEvent) rather than a whole-table MAX — because it loads on
+// every server switch; CollectStatus stays the full report.
 type CoverageSummary struct {
 	// DeltaFrom is the delta-coverage floor (OldestDeltaFromDB — the #1213
 	// strict rule). Zero = unknown, never assumed.
@@ -45,33 +51,40 @@ type CoverageSummary struct {
 	// restorability "up to now" while the stream is down would be unearned
 	// assurance. LagSeconds is what says how close to now the edge is.
 	DeltaTo time.Time
-	// LagSeconds = now − DeltaTo, present only when a stream row exists — a
-	// file-mode index has no liveness to measure.
+	// LagSeconds = now − DeltaTo, present only when a stream row exists AND
+	// at least one event is indexed — a file-mode index has no liveness to
+	// measure, and an empty index has no edge to measure from.
 	LagSeconds *int64
 	Continuity string
+	// Note: capture-health drops (#1034 capture_skips) are deliberately NOT
+	// folded into this summary — they are a capture-plane verdict with their
+	// own surface (status Capture health, --fail-on-gap). The delta window
+	// here is about what the index CONTAINS.
+	//
+	// Multi-source caveat: like the staleness floor, the window is not
+	// scoped per bintrail_id (#1219).
 }
 
 // CollectCoverageSummary computes the summary against one index. The floor
-// degrades to unknown on error (warn-and-degrade, CollectStatus's stance);
-// a failure to read the newest event is fatal — without the window's upper
-// edge there is nothing to state.
+// degrades to unknown on error (warn-and-degrade, CollectStatus's stance),
+// as does a stream_state read failure ("unavailable"); a failure to read the
+// newest event is fatal — without the window's upper edge there is nothing
+// to state.
 func CollectCoverageSummary(ctx context.Context, db *sql.DB, dbName string, now time.Time) (*CoverageSummary, error) {
 	sum := &CoverageSummary{}
 	if floor, err := OldestDeltaFromDB(ctx, db, dbName); err != nil {
-		slog.Warn("could not determine the delta-coverage floor; coverage window start is unknown", "error", err)
+		slog.Warn("could not determine the delta-coverage floor; coverage window start is unknown", "db", dbName, "error", err)
 	} else {
 		sum.DeltaFrom = floor
 	}
-	var latest sql.NullTime
-	if err := db.QueryRowContext(ctx, `SELECT MAX(event_timestamp) FROM binlog_events`).Scan(&latest); err != nil {
-		return nil, fmt.Errorf("read newest indexed event: %w", err)
+	latest, err := newestIndexedEvent(ctx, db, dbName)
+	if err != nil {
+		return nil, err
 	}
-	if latest.Valid {
-		sum.DeltaTo = latest.Time
-	}
+	sum.DeltaTo = latest
 	stream, streamErr := LoadStreamState(ctx, db)
 	if streamErr != nil {
-		slog.Warn("could not load stream state for the coverage summary", "error", streamErr)
+		slog.Warn("could not load stream state for the coverage summary", "db", dbName, "error", streamErr)
 	}
 	sum.Continuity = ContinuityStatus(stream, streamErr)
 	if stream != nil && !sum.DeltaTo.IsZero() {
@@ -82,4 +95,57 @@ func CollectCoverageSummary(ctx context.Context, db *sql.DB, dbName string, now 
 		sum.LagSeconds = &lag
 	}
 	return sum, nil
+}
+
+// newestIndexedEvent finds the newest event_timestamp with per-partition MAX
+// probes, newest partition first, stopping at the first non-empty one. A
+// whole-table MAX(event_timestamp) would be a full index scan — no index
+// leads with event_timestamp (the PK leads with event_id) — which is exactly
+// the O(rows) cost this summary exists to avoid. p_future is probed FIRST:
+// it is the catch-all that holds the NEWEST rows whenever the future-
+// partition horizon lags. Cost: one probe per empty trailing partition, one
+// probe on the first non-empty — each bounded by a single hourly partition.
+func newestIndexedEvent(ctx context.Context, db *sql.DB, dbName string) (time.Time, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT PARTITION_NAME FROM information_schema.PARTITIONS
+		WHERE TABLE_SCHEMA = ? AND TABLE_NAME = 'binlog_events' AND PARTITION_NAME IS NOT NULL`, dbName)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("list partitions for newest event: %w", err)
+	}
+	defer rows.Close()
+	var future bool
+	var dated []string
+	byName := map[string]time.Time{}
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return time.Time{}, err
+		}
+		if name == "p_future" {
+			future = true
+			continue
+		}
+		if t, ok := parsePartitionName(name); ok {
+			dated = append(dated, name)
+			byName[name] = t
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return time.Time{}, err
+	}
+	sort.Slice(dated, func(i, j int) bool { return byName[dated[i]].After(byName[dated[j]]) })
+	probe := dated
+	if future {
+		probe = append([]string{"p_future"}, dated...)
+	}
+	for _, name := range probe {
+		var maxTS sql.NullTime
+		if err := db.QueryRowContext(ctx, "SELECT MAX(event_timestamp) FROM binlog_events PARTITION (`"+name+"`)").Scan(&maxTS); err != nil {
+			return time.Time{}, fmt.Errorf("read newest indexed event (partition %s): %w", name, err)
+		}
+		if maxTS.Valid {
+			return maxTS.Time, nil
+		}
+	}
+	return time.Time{}, nil // empty index — an honest zero, not an error
 }

--- a/internal/status/coverage.go
+++ b/internal/status/coverage.go
@@ -1,0 +1,85 @@
+package status
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+// ContinuityStatus is the ONE continuity-verdict rule — the status JSON and
+// GET /api/coverage (#1194) both call it, so the two surfaces can never
+// disagree on what a gap state means (the Report.ExitError() discipline).
+//
+//	"ok"          — no gap in the captured range (NOT a liveness assertion)
+//	"gap_lost"    — an unfillable gap was stamped: events permanently lost
+//	"unknown"     — legacy index without the gap columns; never a false "ok"
+//	"unavailable" — stream_state could not be read; never a false "ok"
+//	"none"        — no stream row (file-mode index): no capture ran, so no
+//	                continuity could break — a genuine no-claim, not a hole
+func ContinuityStatus(stream *StreamStateInfo, streamErr error) string {
+	switch {
+	case stream == nil && streamErr != nil:
+		return "unavailable"
+	case stream == nil:
+		return "none"
+	case stream.GapLostAt.Valid:
+		return "gap_lost"
+	case !stream.GapColumnsPresent:
+		return "unknown"
+	default:
+		return "ok"
+	}
+}
+
+// CoverageSummary is the lean live-RPO view behind the console's coverage
+// card (#1194): the reconstructable delta window, capture lag, and the
+// continuity verdict. Deliberately CHEAP — no COUNT(*), no index-size scan —
+// it loads on every server switch; CollectStatus stays the full report.
+type CoverageSummary struct {
+	// DeltaFrom is the delta-coverage floor (OldestDeltaFromDB — the #1213
+	// strict rule). Zero = unknown, never assumed.
+	DeltaFrom time.Time
+	// DeltaTo is the newest INDEXED event — never the wall clock: claiming
+	// restorability "up to now" while the stream is down would be unearned
+	// assurance. LagSeconds is what says how close to now the edge is.
+	DeltaTo time.Time
+	// LagSeconds = now − DeltaTo, present only when a stream row exists — a
+	// file-mode index has no liveness to measure.
+	LagSeconds *int64
+	Continuity string
+}
+
+// CollectCoverageSummary computes the summary against one index. The floor
+// degrades to unknown on error (warn-and-degrade, CollectStatus's stance);
+// a failure to read the newest event is fatal — without the window's upper
+// edge there is nothing to state.
+func CollectCoverageSummary(ctx context.Context, db *sql.DB, dbName string, now time.Time) (*CoverageSummary, error) {
+	sum := &CoverageSummary{}
+	if floor, err := OldestDeltaFromDB(ctx, db, dbName); err != nil {
+		slog.Warn("could not determine the delta-coverage floor; coverage window start is unknown", "error", err)
+	} else {
+		sum.DeltaFrom = floor
+	}
+	var latest sql.NullTime
+	if err := db.QueryRowContext(ctx, `SELECT MAX(event_timestamp) FROM binlog_events`).Scan(&latest); err != nil {
+		return nil, fmt.Errorf("read newest indexed event: %w", err)
+	}
+	if latest.Valid {
+		sum.DeltaTo = latest.Time
+	}
+	stream, streamErr := LoadStreamState(ctx, db)
+	if streamErr != nil {
+		slog.Warn("could not load stream state for the coverage summary", "error", streamErr)
+	}
+	sum.Continuity = ContinuityStatus(stream, streamErr)
+	if stream != nil && !sum.DeltaTo.IsZero() {
+		lag := int64(now.Sub(sum.DeltaTo) / time.Second)
+		if lag < 0 {
+			lag = 0
+		}
+		sum.LagSeconds = &lag
+	}
+	return sum, nil
+}

--- a/internal/status/coverage_test.go
+++ b/internal/status/coverage_test.go
@@ -31,14 +31,34 @@ func TestContinuityStatus(t *testing.T) {
 	}
 }
 
+// Query shapes shared by the CollectCoverageSummary tests. The summary hits,
+// in order: partition listing (floor) → archive_state MIN/MAX → partition
+// listing (walk) → per-partition MAX probes (newest first, p_future first) →
+// stream_state.
+var (
+	covPartsQ  = regexp.QuoteMeta("SELECT PARTITION_NAME FROM information_schema.PARTITIONS")
+	covArchQ   = regexp.QuoteMeta("SELECT MIN(partition_name), MAX(partition_name) FROM archive_state")
+	covProbeQ  = `MAX\(event_timestamp\) FROM binlog_events PARTITION`
+	covStreamQ = "FROM stream_state"
+)
+
+var covStreamCols = []string{"mode", "binlog_file", "binlog_position", "gtid_set",
+	"events_indexed", "last_event_time", "last_checkpoint",
+	"server_id", "bintrail_id", "gap_lost_at", "gap_lost_detail"}
+
+func covPartRows(names ...string) *sqlmock.Rows {
+	r := sqlmock.NewRows([]string{"PARTITION_NAME"})
+	for _, n := range names {
+		r.AddRow(n)
+	}
+	return r
+}
+
+func covProbeRow(ts any) *sqlmock.Rows {
+	return sqlmock.NewRows([]string{"max"}).AddRow(ts)
+}
+
 func TestCollectCoverageSummary(t *testing.T) {
-	partsQ := regexp.QuoteMeta("SELECT PARTITION_NAME FROM information_schema.PARTITIONS")
-	archQ := regexp.QuoteMeta("SELECT MIN(partition_name), MAX(partition_name) FROM archive_state")
-	maxQ := regexp.QuoteMeta("SELECT MAX(event_timestamp) FROM binlog_events")
-	streamQ := "FROM stream_state"
-	streamCols := []string{"mode", "binlog_file", "binlog_position", "gtid_set",
-		"events_indexed", "last_event_time", "last_checkpoint",
-		"server_id", "bintrail_id", "gap_lost_at", "gap_lost_detail"}
 	newDB := func(t *testing.T) (*sql.DB, sqlmock.Sqlmock) {
 		t.Helper()
 		db, mock, err := sqlmock.New()
@@ -50,13 +70,20 @@ func TestCollectCoverageSummary(t *testing.T) {
 	}
 	latest := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
 	now := latest.Add(42 * time.Second)
+	// Standard prologue: floor = p_2026080110; walk probes p_future (empty)
+	// then p_2026080110 (holds latest).
+	expectWindow := func(mock sqlmock.Sqlmock) {
+		mock.ExpectQuery(covPartsQ).WillReturnRows(covPartRows("p_2026080110", "p_future"))
+		mock.ExpectQuery(covArchQ).WillReturnRows(sqlmock.NewRows([]string{"min", "max"}).AddRow(nil, nil))
+		mock.ExpectQuery(covPartsQ).WillReturnRows(covPartRows("p_2026080110", "p_future"))
+		mock.ExpectQuery(covProbeQ).WillReturnRows(covProbeRow(nil)) // p_future first, empty
+		mock.ExpectQuery(covProbeQ).WillReturnRows(covProbeRow(latest))
+	}
 
 	t.Run("streaming index: window, lag, ok", func(t *testing.T) {
 		db, mock := newDB(t)
-		mock.ExpectQuery(partsQ).WillReturnRows(sqlmock.NewRows([]string{"PARTITION_NAME"}).AddRow("p_2026080110"))
-		mock.ExpectQuery(archQ).WillReturnRows(sqlmock.NewRows([]string{"min", "max"}).AddRow(nil, nil))
-		mock.ExpectQuery(maxQ).WillReturnRows(sqlmock.NewRows([]string{"max"}).AddRow(latest))
-		mock.ExpectQuery(streamQ).WillReturnRows(sqlmock.NewRows(streamCols).
+		expectWindow(mock)
+		mock.ExpectQuery(covStreamQ).WillReturnRows(sqlmock.NewRows(covStreamCols).
 			AddRow("gtid", "", 0, "uuid:1-9", 100, latest, latest, 7, "id-1", nil, nil))
 		sum, err := CollectCoverageSummary(context.Background(), db, "binlog_index", now)
 		if err != nil {
@@ -72,10 +99,8 @@ func TestCollectCoverageSummary(t *testing.T) {
 
 	t.Run("file-mode index: no stream row, no lag claim", func(t *testing.T) {
 		db, mock := newDB(t)
-		mock.ExpectQuery(partsQ).WillReturnRows(sqlmock.NewRows([]string{"PARTITION_NAME"}).AddRow("p_2026080110"))
-		mock.ExpectQuery(archQ).WillReturnRows(sqlmock.NewRows([]string{"min", "max"}).AddRow(nil, nil))
-		mock.ExpectQuery(maxQ).WillReturnRows(sqlmock.NewRows([]string{"max"}).AddRow(latest))
-		mock.ExpectQuery(streamQ).WillReturnError(sql.ErrNoRows)
+		expectWindow(mock)
+		mock.ExpectQuery(covStreamQ).WillReturnError(sql.ErrNoRows)
 		sum, err := CollectCoverageSummary(context.Background(), db, "binlog_index", now)
 		if err != nil {
 			t.Fatal(err)
@@ -87,10 +112,8 @@ func TestCollectCoverageSummary(t *testing.T) {
 
 	t.Run("stamped gap surfaces as gap_lost", func(t *testing.T) {
 		db, mock := newDB(t)
-		mock.ExpectQuery(partsQ).WillReturnRows(sqlmock.NewRows([]string{"PARTITION_NAME"}).AddRow("p_2026080110"))
-		mock.ExpectQuery(archQ).WillReturnRows(sqlmock.NewRows([]string{"min", "max"}).AddRow(nil, nil))
-		mock.ExpectQuery(maxQ).WillReturnRows(sqlmock.NewRows([]string{"max"}).AddRow(latest))
-		mock.ExpectQuery(streamQ).WillReturnRows(sqlmock.NewRows(streamCols).
+		expectWindow(mock)
+		mock.ExpectQuery(covStreamQ).WillReturnRows(sqlmock.NewRows(covStreamCols).
 			AddRow("gtid", "", 0, "uuid:1-9", 100, latest, latest, 7, "id-1", latest.Add(-time.Hour), "auto-advance"))
 		sum, err := CollectCoverageSummary(context.Background(), db, "binlog_index", now)
 		if err != nil || sum.Continuity != "gap_lost" {
@@ -98,12 +121,44 @@ func TestCollectCoverageSummary(t *testing.T) {
 		}
 	})
 
+	t.Run("stream read failure degrades to unavailable, not an error", func(t *testing.T) {
+		db, mock := newDB(t)
+		expectWindow(mock)
+		mock.ExpectQuery(covStreamQ).WillReturnError(errors.New("conn reset"))
+		sum, err := CollectCoverageSummary(context.Background(), db, "binlog_index", now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if sum.Continuity != "unavailable" || sum.LagSeconds != nil {
+			t.Fatalf("continuity=%q lag=%v — a read failure must degrade, never fabricate", sum.Continuity, sum.LagSeconds)
+		}
+	})
+
+	t.Run("empty index with a live stream: no window edge, no fabricated lag", func(t *testing.T) {
+		db, mock := newDB(t)
+		mock.ExpectQuery(covPartsQ).WillReturnRows(covPartRows("p_2026080110", "p_future"))
+		mock.ExpectQuery(covArchQ).WillReturnRows(sqlmock.NewRows([]string{"min", "max"}).AddRow(nil, nil))
+		mock.ExpectQuery(covPartsQ).WillReturnRows(covPartRows("p_2026080110", "p_future"))
+		mock.ExpectQuery(covProbeQ).WillReturnRows(covProbeRow(nil)) // p_future empty
+		mock.ExpectQuery(covProbeQ).WillReturnRows(covProbeRow(nil)) // dated empty too
+		mock.ExpectQuery(covStreamQ).WillReturnRows(sqlmock.NewRows(covStreamCols).
+			AddRow("gtid", "", 0, "uuid:1-9", 0, nil, latest, 7, "id-1", nil, nil))
+		sum, err := CollectCoverageSummary(context.Background(), db, "binlog_index", now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !sum.DeltaTo.IsZero() || sum.LagSeconds != nil {
+			t.Fatalf("empty index must have zero edge and NO lag (now−zero would be astronomical): %+v", sum)
+		}
+	})
+
 	t.Run("floor failure degrades from to unknown, not the endpoint", func(t *testing.T) {
 		db, mock := newDB(t)
-		mock.ExpectQuery(partsQ).WillReturnRows(sqlmock.NewRows([]string{"PARTITION_NAME"}).AddRow("p_2026080110"))
-		mock.ExpectQuery(archQ).WillReturnError(&mysql.MySQLError{Number: 1045, Message: "access denied"})
-		mock.ExpectQuery(maxQ).WillReturnRows(sqlmock.NewRows([]string{"max"}).AddRow(latest))
-		mock.ExpectQuery(streamQ).WillReturnError(sql.ErrNoRows)
+		mock.ExpectQuery(covPartsQ).WillReturnRows(covPartRows("p_2026080110"))
+		mock.ExpectQuery(covArchQ).WillReturnError(&mysql.MySQLError{Number: 1045, Message: "access denied"})
+		mock.ExpectQuery(covPartsQ).WillReturnRows(covPartRows("p_2026080110"))
+		mock.ExpectQuery(covProbeQ).WillReturnRows(covProbeRow(latest))
+		mock.ExpectQuery(covStreamQ).WillReturnError(sql.ErrNoRows)
 		sum, err := CollectCoverageSummary(context.Background(), db, "binlog_index", now)
 		if err != nil {
 			t.Fatal(err)
@@ -113,11 +168,12 @@ func TestCollectCoverageSummary(t *testing.T) {
 		}
 	})
 
-	t.Run("newest-event failure is fatal", func(t *testing.T) {
+	t.Run("newest-event probe failure is fatal", func(t *testing.T) {
 		db, mock := newDB(t)
-		mock.ExpectQuery(partsQ).WillReturnRows(sqlmock.NewRows([]string{"PARTITION_NAME"}).AddRow("p_2026080110"))
-		mock.ExpectQuery(archQ).WillReturnRows(sqlmock.NewRows([]string{"min", "max"}).AddRow(nil, nil))
-		mock.ExpectQuery(maxQ).WillReturnError(errors.New("boom"))
+		mock.ExpectQuery(covPartsQ).WillReturnRows(covPartRows("p_2026080110"))
+		mock.ExpectQuery(covArchQ).WillReturnRows(sqlmock.NewRows([]string{"min", "max"}).AddRow(nil, nil))
+		mock.ExpectQuery(covPartsQ).WillReturnRows(covPartRows("p_2026080110"))
+		mock.ExpectQuery(covProbeQ).WillReturnError(errors.New("boom"))
 		if _, err := CollectCoverageSummary(context.Background(), db, "binlog_index", now); err == nil {
 			t.Fatal("a window without an upper edge must be an error")
 		}

--- a/internal/status/coverage_test.go
+++ b/internal/status/coverage_test.go
@@ -1,0 +1,125 @@
+package status
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"regexp"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/go-sql-driver/mysql"
+)
+
+func TestContinuityStatus(t *testing.T) {
+	if got := ContinuityStatus(nil, errors.New("boom")); got != "unavailable" {
+		t.Fatalf("read failure = %q, want unavailable", got)
+	}
+	if got := ContinuityStatus(nil, nil); got != "none" {
+		t.Fatalf("no stream row = %q, want none", got)
+	}
+	if got := ContinuityStatus(&StreamStateInfo{GapColumnsPresent: false}, nil); got != "unknown" {
+		t.Fatalf("legacy index = %q, want unknown", got)
+	}
+	gapped := &StreamStateInfo{GapColumnsPresent: true, GapLostAt: sql.NullTime{Time: time.Now(), Valid: true}}
+	if got := ContinuityStatus(gapped, nil); got != "gap_lost" {
+		t.Fatalf("stamped gap = %q, want gap_lost", got)
+	}
+	if got := ContinuityStatus(&StreamStateInfo{GapColumnsPresent: true}, nil); got != "ok" {
+		t.Fatalf("clean stream = %q, want ok", got)
+	}
+}
+
+func TestCollectCoverageSummary(t *testing.T) {
+	partsQ := regexp.QuoteMeta("SELECT PARTITION_NAME FROM information_schema.PARTITIONS")
+	archQ := regexp.QuoteMeta("SELECT MIN(partition_name), MAX(partition_name) FROM archive_state")
+	maxQ := regexp.QuoteMeta("SELECT MAX(event_timestamp) FROM binlog_events")
+	streamQ := "FROM stream_state"
+	streamCols := []string{"mode", "binlog_file", "binlog_position", "gtid_set",
+		"events_indexed", "last_event_time", "last_checkpoint",
+		"server_id", "bintrail_id", "gap_lost_at", "gap_lost_detail"}
+	newDB := func(t *testing.T) (*sql.DB, sqlmock.Sqlmock) {
+		t.Helper()
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { db.Close() })
+		return db, mock
+	}
+	latest := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	now := latest.Add(42 * time.Second)
+
+	t.Run("streaming index: window, lag, ok", func(t *testing.T) {
+		db, mock := newDB(t)
+		mock.ExpectQuery(partsQ).WillReturnRows(sqlmock.NewRows([]string{"PARTITION_NAME"}).AddRow("p_2026080110"))
+		mock.ExpectQuery(archQ).WillReturnRows(sqlmock.NewRows([]string{"min", "max"}).AddRow(nil, nil))
+		mock.ExpectQuery(maxQ).WillReturnRows(sqlmock.NewRows([]string{"max"}).AddRow(latest))
+		mock.ExpectQuery(streamQ).WillReturnRows(sqlmock.NewRows(streamCols).
+			AddRow("gtid", "", 0, "uuid:1-9", 100, latest, latest, 7, "id-1", nil, nil))
+		sum, err := CollectCoverageSummary(context.Background(), db, "binlog_index", now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !sum.DeltaFrom.Equal(time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)) || !sum.DeltaTo.Equal(latest) {
+			t.Fatalf("window = [%v, %v]", sum.DeltaFrom, sum.DeltaTo)
+		}
+		if sum.Continuity != "ok" || sum.LagSeconds == nil || *sum.LagSeconds != 42 {
+			t.Fatalf("continuity=%q lag=%v", sum.Continuity, sum.LagSeconds)
+		}
+	})
+
+	t.Run("file-mode index: no stream row, no lag claim", func(t *testing.T) {
+		db, mock := newDB(t)
+		mock.ExpectQuery(partsQ).WillReturnRows(sqlmock.NewRows([]string{"PARTITION_NAME"}).AddRow("p_2026080110"))
+		mock.ExpectQuery(archQ).WillReturnRows(sqlmock.NewRows([]string{"min", "max"}).AddRow(nil, nil))
+		mock.ExpectQuery(maxQ).WillReturnRows(sqlmock.NewRows([]string{"max"}).AddRow(latest))
+		mock.ExpectQuery(streamQ).WillReturnError(sql.ErrNoRows)
+		sum, err := CollectCoverageSummary(context.Background(), db, "binlog_index", now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if sum.Continuity != "none" || sum.LagSeconds != nil {
+			t.Fatalf("continuity=%q lag=%v — file mode must claim neither", sum.Continuity, sum.LagSeconds)
+		}
+	})
+
+	t.Run("stamped gap surfaces as gap_lost", func(t *testing.T) {
+		db, mock := newDB(t)
+		mock.ExpectQuery(partsQ).WillReturnRows(sqlmock.NewRows([]string{"PARTITION_NAME"}).AddRow("p_2026080110"))
+		mock.ExpectQuery(archQ).WillReturnRows(sqlmock.NewRows([]string{"min", "max"}).AddRow(nil, nil))
+		mock.ExpectQuery(maxQ).WillReturnRows(sqlmock.NewRows([]string{"max"}).AddRow(latest))
+		mock.ExpectQuery(streamQ).WillReturnRows(sqlmock.NewRows(streamCols).
+			AddRow("gtid", "", 0, "uuid:1-9", 100, latest, latest, 7, "id-1", latest.Add(-time.Hour), "auto-advance"))
+		sum, err := CollectCoverageSummary(context.Background(), db, "binlog_index", now)
+		if err != nil || sum.Continuity != "gap_lost" {
+			t.Fatalf("continuity=%q err=%v", sum.Continuity, err)
+		}
+	})
+
+	t.Run("floor failure degrades from to unknown, not the endpoint", func(t *testing.T) {
+		db, mock := newDB(t)
+		mock.ExpectQuery(partsQ).WillReturnRows(sqlmock.NewRows([]string{"PARTITION_NAME"}).AddRow("p_2026080110"))
+		mock.ExpectQuery(archQ).WillReturnError(&mysql.MySQLError{Number: 1045, Message: "access denied"})
+		mock.ExpectQuery(maxQ).WillReturnRows(sqlmock.NewRows([]string{"max"}).AddRow(latest))
+		mock.ExpectQuery(streamQ).WillReturnError(sql.ErrNoRows)
+		sum, err := CollectCoverageSummary(context.Background(), db, "binlog_index", now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !sum.DeltaFrom.IsZero() || !sum.DeltaTo.Equal(latest) {
+			t.Fatalf("unknown floor must stay zero: %+v", sum)
+		}
+	})
+
+	t.Run("newest-event failure is fatal", func(t *testing.T) {
+		db, mock := newDB(t)
+		mock.ExpectQuery(partsQ).WillReturnRows(sqlmock.NewRows([]string{"PARTITION_NAME"}).AddRow("p_2026080110"))
+		mock.ExpectQuery(archQ).WillReturnRows(sqlmock.NewRows([]string{"min", "max"}).AddRow(nil, nil))
+		mock.ExpectQuery(maxQ).WillReturnError(errors.New("boom"))
+		if _, err := CollectCoverageSummary(context.Background(), db, "binlog_index", now); err == nil {
+			t.Fatal("a window without an upper edge must be an error")
+		}
+	})
+}

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -1224,14 +1224,9 @@ func writeStatusJSONFull(w io.Writer, files []IndexStateRow, parts []PartitionSt
 			s := stream.LastEventTime.Time.Format(TSFmt)
 			jstr.LastEventTime = &s
 		}
-		switch {
-		case stream.GapLostAt.Valid:
-			jstr.Continuity.Status = "gap_lost"
+		jstr.Continuity.Status = ContinuityStatus(stream, nil)
+		if stream.GapLostAt.Valid {
 			jstr.GapLost = &jsonGapLost{At: stream.GapLostAt.Time.Format(TSFmt), Detail: stream.GapLostDetail.String}
-		case !stream.GapColumnsPresent:
-			jstr.Continuity.Status = "unknown"
-		default:
-			jstr.Continuity.Status = "ok"
 		}
 		if stream.SourceHealth.Valid && stream.SourceHealth.String != "" {
 			jstr.SourceHealth = json.RawMessage(stream.SourceHealth.String)
@@ -1263,7 +1258,7 @@ func writeStatusJSONFull(w io.Writer, files []IndexStateRow, parts []PartitionSt
 		// stream_state could not be READ (nil stream + error) — surface it as a distinct
 		// "unavailable" verdict so the omitted Stream section is not misread as "no loss".
 		out.StreamError = &jsonStreamError{
-			Continuity: jsonContinuity{Status: "unavailable"},
+			Continuity: jsonContinuity{Status: ContinuityStatus(nil, streamErr)},
 			Error:      streamErr.Error(),
 		}
 	}


### PR DESCRIPTION
closes #1194 · part of the continuous backup assurance epic #1189

## Summary
- **`GET /api/coverage`** (per selected server): the live RPO statement — restorable delta window `[delta_from, delta_to]`, `lag_seconds`, `continuity`, and (with a baseline source) `full_table_from` + `broken_tables` (#1193's staleness verdict, computed by the status package — no second implementation).
- **Overview card**: "Any point between **X** and **Y** is restorable" with lag and continuity chips; degrades loudly on `gap_lost`/`unavailable` (red, consequence spelled out), `unknown` (amber), or an empty index.
- **`status.CollectCoverageSummary`**: deliberately cheap (no `COUNT(*)`); floor = `OldestDeltaFromDB` (strict #1213 rule); the window's upper edge is the last **indexed** event, never the wall clock — the lag chip is what says "now". Lag only claimed when a stream row exists.
- **`status.ContinuityStatus`** extracted as the single continuity-verdict rule; `status` JSON now calls it too, so the two surfaces can never disagree (the `Report.ExitError()` discipline the issue asks for).

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`, ALL-GREEN)
- [x] `go test -race` on `internal/status` + `internal/console`
- [x] `go vet -tags integration ./...`
- [x] `node --check` on `app.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
