### PR TITLE
drill: automated restore rehearsal into an operator-provided scratch MySQL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,10 @@ volumes:
   drill-scratch-data:     # THROWAWAY datadir for the `drill` profile's scratch
                           # MySQL. Never holds anything worth keeping — wipe it
                           # between drills with:
-                          #   docker compose --profile drill down -v
+                          #   docker compose --profile drill rm -sf drill-mysql
+                          #   docker volume rm <project>_drill-scratch-data
+                          # NEVER `docker compose down -v` — it also removes
+                          # the INDEX volumes above (your system of record).
 
 services:
 
@@ -592,7 +595,10 @@ services:
   # never launches or supervises it — it only loads into the DSN:
   #   docker compose --profile drill up -d drill-mysql
   #   bintrail drill --target-dsn "root:${DRILL_MYSQL_PASSWORD:-drill}@tcp(127.0.0.1:13307)/" ...
-  #   docker compose --profile drill down -v   # wipe the scratch afterwards
+  #   # wipe ONLY the scratch afterwards (never `down -v`: that also removes
+  #   # the index volumes — the system of record):
+  #   docker compose --profile drill rm -sf drill-mysql
+  #   docker volume rm <project>_drill-scratch-data
   drill-mysql:
     profiles: ["drill"]
     image: mysql:8.4.9

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,10 @@ volumes:
   bintrail-dump:          # transient mydumper output for the `baseline`
                           # profile (its snapshot/ dir is recreated from
                           # scratch every run — never store anything here).
+  drill-scratch-data:     # THROWAWAY datadir for the `drill` profile's scratch
+                          # MySQL. Never holds anything worth keeping — wipe it
+                          # between drills with:
+                          #   docker compose --profile drill down -v
 
 services:
 
@@ -581,3 +585,21 @@ services:
     depends_on:
       baseline-dump:
         condition: service_completed_successfully
+
+  # ── `drill` profile: scratch MySQL for `bintrail drill` (#1195) ──────────
+  # An opt-in THROWAWAY server the restore rehearsal loads into. Same pinned
+  # MySQL 8.4 as the bundled index (the SHIP carve-out); the bintrail binary
+  # never launches or supervises it — it only loads into the DSN:
+  #   docker compose --profile drill up -d drill-mysql
+  #   bintrail drill --target-dsn "root:${DRILL_MYSQL_PASSWORD:-drill}@tcp(127.0.0.1:13307)/" ...
+  #   docker compose --profile drill down -v   # wipe the scratch afterwards
+  drill-mysql:
+    profiles: ["drill"]
+    image: mysql:8.4.9
+    environment:
+      # Scratch-only credential — loopback-mapped below, holds throwaway data.
+      MYSQL_ROOT_PASSWORD: ${DRILL_MYSQL_PASSWORD:-drill}
+    ports:
+      - "127.0.0.1:13307:3306"
+    volumes:
+      - drill-scratch-data:/var/lib/mysql

--- a/docs/drill.md
+++ b/docs/drill.md
@@ -25,11 +25,17 @@ The intermediate dump lives in a temp directory: removed on success, **kept
 on failure** so you can inspect exactly what didn't load. `--output DIR`
 pins it and always keeps it.
 
+A table with **no usable baseline** (drill would fall back to binlog-only
+reconstruction, i.e. an empty starting table) always **fails** with an
+explicit reason — a rehearsal that never touched a baseline must not read
+PASS.
+
 ## What drill proves — and what it doesn't
 
-Drill proves the **restore pipeline**: the dump is loadable, complete, and
-you know its duration. Value-level fidelity of reconstructed content against
-the source is [`verify`](query-and-recovery.md)'s job — it compares
+Drill proves the **restore pipeline**: the dump loads, it contains exactly
+what the dump writer emitted, and you know the duration. Value-level
+fidelity of reconstructed content against
+the source is [`verify`](verify.md)'s job — it compares
 normalized content digests and explains mismatches row by row. The two are
 complementary: `verify` says *the data is right*, `drill` says *the restore
 works and takes N seconds*.
@@ -49,7 +55,11 @@ bintrail drill \
   --tables shop.orders,shop.users \
   --target-dsn "root:${DRILL_MYSQL_PASSWORD:-drill}@tcp(127.0.0.1:13307)/"
 
-docker compose --profile drill down -v   # wipe the scratch afterwards
+# Wipe ONLY the scratch afterwards. NEVER `docker compose down -v` here —
+# that removes every volume in the compose file, INCLUDING the index
+# datadir (your system of record).
+docker compose --profile drill rm -sf drill-mysql
+docker volume rm "$(basename "$PWD")_drill-scratch-data"
 ```
 
 ## The monthly runbook
@@ -72,7 +82,7 @@ RTO trend, not a hope.
 | Flag | Meaning |
 |---|---|
 | `--index-dsn` | The bintrail index (required). |
-| `--target-dsn` | The scratch MySQL to load into (required; refused unless the drilled schemas are absent there). |
+| `--target-dsn` | The scratch MySQL to load into (required; refused if the target already holds any table in the drilled schemas). |
 | `--tables` | Comma-separated `schema.table` list (required). |
 | `--at` | Point in time to restore to (default now; accepts the same forms as `reconstruct --at`). |
 | `--baseline-dir` / `--baseline-s3` | Where baselines live (one required — a full-table restore starts from a baseline). |

--- a/docs/drill.md
+++ b/docs/drill.md
@@ -1,0 +1,81 @@
+# Restore drills — `bintrail drill`
+
+`verify` proves your index and baselines are consistent **without** doing a
+restore. `drill` goes one level up: it performs an *actual* restore into a
+scratch MySQL and checks it — a fire drill. Run it monthly and you always
+know two things a backup tool must be able to answer: *does my restore
+actually work*, and *how long does it take* (a measured RTO, not a guessed
+one).
+
+## What one run does
+
+1. **Reconstruct** the selected tables at `--at` (default: now) into a
+   mydumper-format dump — baseline snapshot + indexed binlog deltas, the
+   same engine as `reconstruct --output-format mydumper`.
+2. **Load** the dump into the scratch server given by `--target-dsn`. The
+   load is refused if the target already has ANY table in the drilled
+   schemas — that makes pointing it at a real server hard by default.
+3. **Check**: each loaded table's `COUNT(*)` must equal the exact number of
+   rows the dump writer emitted. Any load error or count mismatch fails the
+   table.
+4. **Report** per-table pass/fail with reconstruct and load timings, and
+   exit non-zero on any failure. `--format json` for cron/automation.
+
+The intermediate dump lives in a temp directory: removed on success, **kept
+on failure** so you can inspect exactly what didn't load. `--output DIR`
+pins it and always keeps it.
+
+## What drill proves — and what it doesn't
+
+Drill proves the **restore pipeline**: the dump is loadable, complete, and
+you know its duration. Value-level fidelity of reconstructed content against
+the source is [`verify`](query-and-recovery.md)'s job — it compares
+normalized content digests and explains mismatches row by row. The two are
+complementary: `verify` says *the data is right*, `drill` says *the restore
+works and takes N seconds*.
+
+## The scratch server
+
+`drill` never launches or supervises a MySQL itself — it only loads into a
+DSN you provide. Any throwaway instance works. The repo ships an opt-in
+compose profile with the pinned MySQL 8.4 and a disposable volume:
+
+```bash
+docker compose --profile drill up -d drill-mysql
+
+bintrail drill \
+  --index-dsn  "root:pw@tcp(127.0.0.1:3306)/bintrail_index" \
+  --baseline-dir /var/lib/bintrail/baselines \
+  --tables shop.orders,shop.users \
+  --target-dsn "root:${DRILL_MYSQL_PASSWORD:-drill}@tcp(127.0.0.1:13307)/"
+
+docker compose --profile drill down -v   # wipe the scratch afterwards
+```
+
+## The monthly runbook
+
+```bash
+# cron: first Sunday, 04:00 — non-zero exit means the drill FAILED
+bintrail drill --format json \
+  --index-dsn "$INDEX_DSN" --baseline-dir /var/lib/bintrail/baselines \
+  --tables shop.orders,shop.users,shop.payments \
+  --target-dsn "root:drill@tcp(scratch:3306)/" \
+  || notify-oncall "restore drill failed"
+```
+
+The JSON carries `rows_written`/`rows_loaded`, `reconstruct_seconds` and
+`load_seconds` per table — chart the durations over time and you have an
+RTO trend, not a hope.
+
+## Flags
+
+| Flag | Meaning |
+|---|---|
+| `--index-dsn` | The bintrail index (required). |
+| `--target-dsn` | The scratch MySQL to load into (required; refused unless the drilled schemas are absent there). |
+| `--tables` | Comma-separated `schema.table` list (required). |
+| `--at` | Point in time to restore to (default now; accepts the same forms as `reconstruct --at`). |
+| `--baseline-dir` / `--baseline-s3` | Where baselines live (one required — a full-table restore starts from a baseline). |
+| `--output` | Keep the dump here (default: temp dir, removed on success, kept on failure). |
+| `--format` | `text` (default) or `json`. |
+| `--ultrafast`, `--duckdb-threads`, `--duckdb-memory-limit` | The shared DuckDB tuning budget (see [query-and-recovery.md](query-and-recovery.md)). |

--- a/internal/audittest/audittest.go
+++ b/internal/audittest/audittest.go
@@ -113,6 +113,11 @@ var Required = []Requirement{
 		Why:   "the only verify output that prints row-level data (the differing rows of a mismatch)",
 	},
 	{
+		Pair:  Pair{Surface: "cli", Action: "drill.run"},
+		Owner: OwnerCLI,
+		Why:   "materializing historical row state into an operator-provided scratch server (a rehearsed restore)",
+	},
+	{
 		Pair:  Pair{Surface: "mcp", Action: "query.run"},
 		Owner: OwnerMCP,
 		Why:   "an LLM client reading indexed row images",

--- a/internal/audittest/callsites_test.go
+++ b/internal/audittest/callsites_test.go
@@ -33,6 +33,7 @@ var recordCallSites = map[string]int{
 	"internal/cli/recover_cascade.go":      1, // cli/recover.cascade
 	"internal/cli/reconstruct.go":          1, // cli/reconstruct.run (auditReconstruct — all five modes)
 	"internal/cli/verify.go":               1, // cli/verify.explain
+	"internal/cli/drill.go":                1, // cli/drill.run (auditDrill — per rehearsed table)
 	"internal/console/audit.go":            1, // console data reads (recordConsoleAudit helper)
 	"internal/console/authz.go":            1, // console/authz.denied + console/profile.denied
 	"internal/console/mcp.go":              1, // console/authz.denied for /mcp tool-permission denials (#1124)

--- a/internal/cli/audit_contract_integration_test.go
+++ b/internal/cli/audit_contract_integration_test.go
@@ -5,8 +5,10 @@ package cli
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -212,6 +214,31 @@ func TestIntegrationAuditContract_CLI(t *testing.T) {
 				}
 			},
 		},
+		{
+			// drill materializes historical row state into an external scratch
+			// server — the newest data-serving mode (#1195), emitted per table.
+			name:   "drill",
+			action: "drill.run",
+			table:  "orders",
+			call: func(t *testing.T) {
+				srcSchema := fmt.Sprintf("drillsrc_%d", time.Now().UnixNano())
+				dsn, baseDir, at := drillContractFixture(t, srcSchema)
+				resetDrillGlobals(t)
+				drlIndexDSN, drlBaselineDir = dsn, baseDir
+				drlTables = srcSchema + ".orders"
+				// Inside the fixture's partition coverage — the default (now)
+				// would trip the strict gap check on hours that never existed.
+				drlAt = at.Format("2006-01-02 15:04:05")
+				// The scratch is the SAME test server: srcSchema does not exist
+				// there, so the emptiness guard passes; drill creates and loads
+				// it, and the cleanup below drops it.
+				drlTargetDSN = testutil.BaseDSN() + "/"
+				drlFormat = "json"
+				if err := runDrill(newQueryTestCmd(), nil); err != nil {
+					t.Fatalf("runDrill: %v", err)
+				}
+			},
+		},
 	}
 
 	var observed []audittest.Pair
@@ -246,4 +273,86 @@ func TestIntegrationAuditContract_CLI(t *testing.T) {
 	}
 
 	audittest.CheckCoverage(t, audittest.OwnerCLI, observed)
+}
+
+// resetDrillGlobals saves and clears the drill command's flag globals.
+func resetDrillGlobals(t *testing.T) {
+	t.Helper()
+	sIdx, sTgt, sTables, sAt := drlIndexDSN, drlTargetDSN, drlTables, drlAt
+	sDir, sS3, sOut, sFmt := drlBaselineDir, drlBaselineS3, drlOutput, drlFormat
+	t.Cleanup(func() {
+		drlIndexDSN, drlTargetDSN, drlTables, drlAt = sIdx, sTgt, sTables, sAt
+		drlBaselineDir, drlBaselineS3, drlOutput, drlFormat = sDir, sS3, sOut, sFmt
+	})
+	drlIndexDSN, drlTargetDSN, drlTables, drlAt = "", "", "", ""
+	drlBaselineDir, drlBaselineS3, drlOutput, drlFormat = "", "", "", "text"
+}
+
+// drillContractFixture seeds a full-table-reconstructable index for a
+// SYNTHETIC source schema that does not exist as a database on the shared
+// test server — so the same server can serve as drill's scratch target. It
+// registers a cleanup dropping the database drill creates there.
+func drillContractFixture(t *testing.T, srcSchema string) (dsn, baselineDir string, at time.Time) {
+	t.Helper()
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	t.Cleanup(func() {
+		testutil.MustExec(t, db, "DROP DATABASE IF EXISTS `"+srcSchema+"`")
+	})
+
+	testutil.MustExec(t, db, `INSERT INTO schema_snapshots
+		(snapshot_id, snapshot_time, schema_name, table_name, column_name, ordinal_position, column_key, data_type, is_nullable, is_generated)
+		VALUES (1, UTC_TIMESTAMP(), ?, 'orders', 'id', 1, 'PRI', 'int', 'NO', 0)`, srcSchema)
+	testutil.MustExec(t, db, `INSERT INTO schema_snapshots
+		(snapshot_id, snapshot_time, schema_name, table_name, column_name, ordinal_position, column_key, data_type, is_nullable, is_generated)
+		VALUES (1, UTC_TIMESTAMP(), ?, 'orders', 'status', 2, '', 'varchar', 'NO', 0)`, srcSchema)
+
+	createSQL := "CREATE TABLE `orders` (\n  `id` INT NOT NULL,\n  `status` VARCHAR(64) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;\n"
+	baselineDir = t.TempDir()
+	h1 := time.Now().UTC().Add(-48 * time.Hour).Truncate(time.Hour)
+	h2 := h1.Add(time.Hour)
+	snapshotTSDir := strings.ReplaceAll(h1.Format(time.RFC3339), ":", "-")
+	parquetDir := filepath.Join(baselineDir, snapshotTSDir, srcSchema)
+	if err := os.MkdirAll(parquetDir, 0o755); err != nil {
+		t.Fatalf("mkdir baseline: %v", err)
+	}
+	cols := []baseline.Column{
+		{Name: "id", MySQLType: "int", ParquetType: baseline.MysqlToParquetNode("int")},
+		{Name: "status", MySQLType: "varchar", ParquetType: baseline.MysqlToParquetNode("varchar")},
+	}
+	bw, err := baseline.NewWriter(filepath.Join(parquetDir, "orders.parquet"), cols, baseline.WriterConfig{
+		Compression:  "zstd",
+		RowGroupSize: 100,
+		Metadata:     map[string]string{baseline.MetaKeyCreateTableSQL: createSQL},
+	})
+	if err != nil {
+		t.Fatalf("baseline.NewWriter: %v", err)
+	}
+	for _, row := range [][]string{{"1", "start-1"}, {"2", "start-2"}, {"3", "start-3"}} {
+		if err := bw.WriteRow(row, []bool{false, false}); err != nil {
+			t.Fatalf("WriteRow: %v", err)
+		}
+	}
+	if err := bw.Close(); err != nil {
+		t.Fatalf("writer close: %v", err)
+	}
+
+	// Deltas: update id=2, delete id=3, insert id=4 → final rows {1,2,4}.
+	testutil.SetupPartitionedTable(t, db, dbName, []time.Time{h1, h2})
+	ts1 := h1.Add(30 * time.Minute).Format("2006-01-02 15:04:05")
+	ts2 := h2.Add(30 * time.Minute).Format("2006-01-02 15:04:05")
+	testutil.InsertEvent(t, db, "binlog.000001", 100, 200, ts1, nil,
+		srcSchema, "orders", 2, "2", nil,
+		[]byte(`{"id":2,"status":"start-2"}`), []byte(`{"id":2,"status":"paid"}`))
+	testutil.InsertEvent(t, db, "binlog.000001", 200, 300, ts1, nil,
+		srcSchema, "orders", 3, "3", nil,
+		[]byte(`{"id":3,"status":"start-3"}`), nil)
+	testutil.InsertEvent(t, db, "binlog.000001", 300, 400, ts2, nil,
+		srcSchema, "orders", 1, "4", nil,
+		nil, []byte(`{"id":4,"status":"new-4"}`))
+
+	return testutil.IntegrationDSN(dbName), baselineDir, h2.Add(45 * time.Minute)
 }

--- a/internal/cli/audit_contract_integration_test.go
+++ b/internal/cli/audit_contract_integration_test.go
@@ -310,7 +310,11 @@ func drillContractFixture(t *testing.T, srcSchema string) (dsn, baselineDir stri
 		(snapshot_id, snapshot_time, schema_name, table_name, column_name, ordinal_position, column_key, data_type, is_nullable, is_generated)
 		VALUES (1, UTC_TIMESTAMP(), ?, 'orders', 'status', 2, '', 'varchar', 'NO', 0)`, srcSchema)
 
-	createSQL := "CREATE TABLE `orders` (\n  `id` INT NOT NULL,\n  `status` VARCHAR(64) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;\n"
+	// VERBATIM mydumper shape — the /*!…*/ SET preamble makes the schema
+	// file multi-statement, exactly what a real `bintrail baseline` stores
+	// (a single-statement synthetic here would hide load-session bugs; it
+	// did once).
+	createSQL := "/*!40101 SET NAMES binary*/;\n/*!40014 SET FOREIGN_KEY_CHECKS=0*/;\nCREATE TABLE `orders` (\n  `id` INT NOT NULL,\n  `status` VARCHAR(64) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;\n"
 	baselineDir = t.TempDir()
 	h1 := time.Now().UTC().Add(-48 * time.Hour).Truncate(time.Hour)
 	h2 := h1.Add(time.Hour)

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -21,6 +21,7 @@ func AddReadCommands(root *cobra.Command) {
 	root.AddCommand(recoverCascadeCmd)
 	root.AddCommand(reconstructCmd)
 	root.AddCommand(verifyCmd)
+	root.AddCommand(drillCmd)
 	root.AddCommand(shimCmd)
 }
 

--- a/internal/cli/drill.go
+++ b/internal/cli/drill.go
@@ -1,0 +1,395 @@
+package cli
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dbtrail/dbtrail/ext"
+	"github.com/dbtrail/dbtrail/internal/cliutil"
+	"github.com/dbtrail/dbtrail/internal/config"
+	"github.com/dbtrail/dbtrail/internal/reconstruct"
+)
+
+var drillCmd = &cobra.Command{
+	Use:   "drill",
+	Short: "Rehearse a real restore into a scratch MySQL and check it (a fire drill)",
+	Long: `Performs an actual restore end to end and reports whether it worked:
+
+  1. Reconstructs the selected tables at --at (default now) into a
+     mydumper-format dump (baseline + indexed deltas).
+  2. Loads the dump into the SCRATCH MySQL given by --target-dsn. The load
+     is refused unless the target schemas are absent from the target server
+     — pointing drill at a server that already holds those schemas is
+     assumed to be a mistake.
+  3. Checks each loaded table's row count against the exact number of rows
+     the dump writer emitted, and reports per-table timings — a measured
+     restore duration is an RTO data point.
+
+Exit is non-zero if any table fails. The intermediate dump lives in a temp
+directory, removed on success and KEPT on failure for inspection (--output
+pins it somewhere and always keeps it).
+
+What drill proves: the restore pipeline — the dump is loadable and complete,
+and how long it takes. Value-level fidelity of reconstructed content against
+the source is verify's job ('bintrail verify'), not re-proven here.
+
+The binary never launches or supervises a MySQL server: the scratch comes
+from you (any throwaway instance), e.g. the opt-in compose profile:
+  docker compose --profile drill up -d drill-mysql
+
+Example:
+  bintrail drill --index-dsn "root:pw@tcp(127.0.0.1:3306)/bintrail_index" \
+    --baseline-dir /var/lib/bintrail/baselines \
+    --tables shop.orders,shop.users \
+    --target-dsn "root:drill@tcp(127.0.0.1:13307)/"`,
+	RunE: runDrill,
+}
+
+var (
+	drlIndexDSN    string
+	drlTargetDSN   string
+	drlTables      string
+	drlAt          string
+	drlBaselineDir string
+	drlBaselineS3  string
+	drlOutput      string
+	drlFormat      string
+)
+
+func init() {
+	f := drillCmd.Flags()
+	f.StringVar(&drlIndexDSN, "index-dsn", "", "DSN for the index MySQL database (required)")
+	f.StringVar(&drlTargetDSN, "target-dsn", "", "DSN of the SCRATCH MySQL to load the rehearsal into (required; refused unless the target schemas are absent there)")
+	f.StringVar(&drlTables, "tables", "", "Comma-separated schema.table list to rehearse (required)")
+	f.StringVar(&drlAt, "at", "", "Point in time to restore to (default now)")
+	f.StringVar(&drlBaselineDir, "baseline-dir", "", "Local directory of baseline Parquet snapshots")
+	f.StringVar(&drlBaselineS3, "baseline-s3", "", "S3 URL of baseline Parquet snapshots (s3://bucket/prefix)")
+	f.StringVar(&drlOutput, "output", "", "Write the intermediate dump here and keep it (default: temp dir — removed on success, kept on failure)")
+	f.StringVar(&drlFormat, "format", "text", "Output format: text or json")
+	_ = drillCmd.MarkFlagRequired("index-dsn")
+	_ = drillCmd.MarkFlagRequired("target-dsn")
+	_ = drillCmd.MarkFlagRequired("tables")
+	AddDuckDBTuningFlags(drillCmd)
+	BindCommandEnv(drillCmd)
+}
+
+// drillTableResult is one table's rehearsal outcome. ReconstructSeconds and
+// LoadSeconds are separate on purpose: the first is bounded by index/archive
+// read speed, the second by the scratch server — an operator sizing a real
+// recovery needs both numbers.
+type drillTableResult struct {
+	Schema             string  `json:"schema"`
+	Table              string  `json:"table"`
+	Status             string  `json:"status"` // "pass" | "fail"
+	RowsWritten        int64   `json:"rows_written"`
+	RowsLoaded         int64   `json:"rows_loaded"`
+	ReconstructSeconds float64 `json:"reconstruct_seconds"`
+	LoadSeconds        float64 `json:"load_seconds"`
+	Error              string  `json:"error,omitempty"`
+}
+
+type drillReport struct {
+	At time.Time `json:"at"`
+	// DumpDir is present when the intermediate dump was kept (always under
+	// --output; on failure otherwise).
+	DumpDir string             `json:"dump_dir,omitempty"`
+	Tables  []drillTableResult `json:"tables"`
+}
+
+// ExitError is the single exit decision for both output formats — add a
+// verdict path here, not in a renderer (the Report.ExitError discipline).
+func (r *drillReport) ExitError() error {
+	failed := 0
+	for _, t := range r.Tables {
+		if t.Status != "pass" {
+			failed++
+		}
+	}
+	if failed == 0 {
+		return nil
+	}
+	msg := fmt.Sprintf("drill: %d of %d table(s) FAILED the restore rehearsal", failed, len(r.Tables))
+	if r.DumpDir != "" {
+		msg += "; dump kept at " + r.DumpDir
+	}
+	return fmt.Errorf("%s", msg)
+}
+
+// parseDrillTables validates and dedupes the --tables list, returning the
+// entries and the distinct schemas (both order-preserving). Identifiers are
+// rejected if they carry a backtick — they are interpolated into backtick-
+// quoted SQL against the scratch server.
+func parseDrillTables(list string) (tables []string, schemas []string, err error) {
+	seenT := map[string]bool{}
+	seenS := map[string]bool{}
+	for _, entry := range strings.Split(list, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		parts := strings.SplitN(entry, ".", 2)
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" || strings.Contains(parts[1], ".") {
+			return nil, nil, fmt.Errorf("--tables entry %q is not schema.table", entry)
+		}
+		if strings.ContainsAny(entry, "`\"'") {
+			return nil, nil, fmt.Errorf("--tables entry %q carries a quote character", entry)
+		}
+		if seenT[entry] {
+			continue
+		}
+		seenT[entry] = true
+		tables = append(tables, entry)
+		if !seenS[parts[0]] {
+			seenS[parts[0]] = true
+			schemas = append(schemas, parts[0])
+		}
+	}
+	if len(tables) == 0 {
+		return nil, nil, fmt.Errorf("--tables is empty")
+	}
+	return tables, schemas, nil
+}
+
+// drillTargetEmpty refuses a target that already holds ANY table in one of
+// the drill's schemas — the guard that makes pointing --target-dsn at a real
+// server hard. It deliberately checks schema-wide, not just the drilled
+// tables: a schema with unrelated tables is not a scratch.
+func drillTargetEmpty(ctx context.Context, db *sql.DB, schemas []string) error {
+	for _, s := range schemas {
+		var name string
+		err := db.QueryRowContext(ctx,
+			`SELECT TABLE_NAME FROM information_schema.TABLES WHERE TABLE_SCHEMA = ? LIMIT 1`, s).Scan(&name)
+		switch {
+		case err == sql.ErrNoRows:
+		case err != nil:
+			return fmt.Errorf("probe target schema %s: %w", s, err)
+		default:
+			return fmt.Errorf("target already has table %s.%s — drill refuses a non-empty target; point --target-dsn at a THROWAWAY server (e.g. `docker compose --profile drill up -d drill-mysql`)", s, name)
+		}
+	}
+	return nil
+}
+
+// drillLoadTable applies one table's dump files to the scratch server on a
+// single pinned connection: CREATE DATABASE, USE, the schema file, then the
+// chunk files in the writer's order (each chunk is one multi-row INSERT —
+// the MydumperWriter contract).
+func drillLoadTable(ctx context.Context, db *sql.DB, outDir string, rep *reconstruct.TableReport) error {
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("target connection: %w", err)
+	}
+	defer conn.Close()
+	if _, err := conn.ExecContext(ctx, "CREATE DATABASE IF NOT EXISTS `"+rep.Schema+"`"); err != nil {
+		return fmt.Errorf("create database %s: %w", rep.Schema, err)
+	}
+	// The schema file's CREATE TABLE is unqualified (mydumper convention), so
+	// the pinned connection selects the database first.
+	if _, err := conn.ExecContext(ctx, "USE `"+rep.Schema+"`"); err != nil {
+		return fmt.Errorf("use %s: %w", rep.Schema, err)
+	}
+	apply := func(name string) error {
+		content, err := os.ReadFile(filepath.Join(outDir, name))
+		if err != nil {
+			return fmt.Errorf("read dump file %s: %w", name, err)
+		}
+		if _, err := conn.ExecContext(ctx, string(content)); err != nil {
+			return fmt.Errorf("apply %s: %w", name, err)
+		}
+		return nil
+	}
+	for _, name := range rep.Files {
+		if strings.HasSuffix(name, "-schema.sql") {
+			if err := apply(name); err != nil {
+				return err
+			}
+		}
+	}
+	for _, name := range rep.Files {
+		if name == "metadata" || strings.HasSuffix(name, "-schema.sql") {
+			continue
+		}
+		if err := apply(name); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// auditDrill reports one rehearsed table to the audit seam: drill
+// materializes historical row state into an external server — the same
+// data-serving class as reconstruct's mydumper mode, with the extra fact
+// that the rows now live OUTSIDE the index. ext.Record cannot fail the
+// command (see ext/audit.go).
+func auditDrill(ctx context.Context, schema, table string, rows int64) {
+	ext.Record(ctx, ext.AuditEvent{
+		Surface: "cli",
+		Action:  "drill.run",
+		Actor:   ext.ProcessActor(""),
+		Schema:  schema,
+		Table:   table,
+		Detail:  map[string]string{"target": "scratch", "rows": fmt.Sprintf("%d", rows)},
+	})
+}
+
+func runDrill(cmd *cobra.Command, args []string) error {
+	if !cliutil.IsValidOutputFormat(drlFormat) {
+		return fmt.Errorf("invalid --format %q; must be text or json", drlFormat)
+	}
+	if drlBaselineDir == "" && drlBaselineS3 == "" {
+		return fmt.Errorf("one of --baseline-dir or --baseline-s3 is required — drill rehearses a full-table restore, which starts from a baseline")
+	}
+	tables, schemas, err := parseDrillTables(drlTables)
+	if err != nil {
+		return err
+	}
+	at := time.Now().UTC()
+	if drlAt != "" {
+		parsed, err := cliutil.ParseTime(drlAt)
+		if err != nil {
+			return fmt.Errorf("--at: %w", err)
+		}
+		if parsed != nil {
+			at = *parsed
+		}
+	}
+	baselineSrc := drlBaselineDir
+	if baselineSrc == "" {
+		baselineSrc = drlBaselineS3
+	}
+
+	ctx := cmd.Context()
+	target, err := config.Connect(drlTargetDSN)
+	if err != nil {
+		return fmt.Errorf("connect to --target-dsn: %w", err)
+	}
+	defer target.Close()
+	// Fail BEFORE the expensive reconstruct, and before anything touches the
+	// target.
+	if err := drillTargetEmpty(ctx, target, schemas); err != nil {
+		return err
+	}
+
+	outDir := drlOutput
+	tempDir := false
+	if outDir == "" {
+		outDir, err = os.MkdirTemp("", "bintrail-drill-*")
+		if err != nil {
+			return fmt.Errorf("create dump temp dir: %w", err)
+		}
+		tempDir = true
+	} else if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return fmt.Errorf("create --output dir: %w", err)
+	}
+
+	duckTuning, err := DuckDBTuningFromFlags(cmd)
+	if err != nil {
+		return err
+	}
+	reports, err := reconstruct.ReconstructTables(ctx, reconstruct.FullTableConfig{
+		IndexDSN:           drlIndexDSN,
+		BaselineSrc:        baselineSrc,
+		Tables:             tables,
+		At:                 at,
+		OutputDir:          outDir,
+		WarnEventThreshold: 5_000_000,
+		ArchiveFetcher:     TunedArchiveFetcher(duckTuning),
+		DuckDBTuning:       duckTuning,
+	})
+	if err != nil {
+		if tempDir {
+			// Keep the partial output for inspection — a failed drill IS the
+			// signal the command exists to produce.
+			return fmt.Errorf("reconstruct failed (partial dump kept at %s): %w", outDir, err)
+		}
+		return fmt.Errorf("reconstruct: %w", err)
+	}
+
+	report := &drillReport{At: at}
+	for _, rep := range reports {
+		res := drillTableResult{
+			Schema:             rep.Schema,
+			Table:              rep.Table,
+			Status:             "fail",
+			RowsWritten:        rep.RowsWritten,
+			ReconstructSeconds: rep.Duration.Seconds(),
+		}
+		loadStart := time.Now()
+		if err := drillLoadTable(ctx, target, outDir, rep); err != nil {
+			res.Error = err.Error()
+			res.LoadSeconds = time.Since(loadStart).Seconds()
+			report.Tables = append(report.Tables, res)
+			continue
+		}
+		res.LoadSeconds = time.Since(loadStart).Seconds()
+		auditDrill(ctx, rep.Schema, rep.Table, rep.RowsWritten)
+		var loaded int64
+		if err := target.QueryRowContext(ctx,
+			"SELECT COUNT(*) FROM `"+rep.Schema+"`.`"+rep.Table+"`").Scan(&loaded); err != nil {
+			res.Error = fmt.Sprintf("count loaded rows: %v", err)
+			report.Tables = append(report.Tables, res)
+			continue
+		}
+		res.RowsLoaded = loaded
+		if loaded == rep.RowsWritten {
+			res.Status = "pass"
+		} else {
+			res.Error = fmt.Sprintf("loaded %d rows, dump wrote %d", loaded, rep.RowsWritten)
+		}
+		report.Tables = append(report.Tables, res)
+	}
+
+	exitErr := report.ExitError()
+	if !tempDir || exitErr != nil {
+		report.DumpDir = outDir
+	}
+	if tempDir && exitErr == nil {
+		if rmErr := os.RemoveAll(outDir); rmErr != nil {
+			fmt.Fprintf(os.Stderr, "warning: could not remove temp dump dir %s: %v\n", outDir, rmErr)
+		}
+	}
+
+	if drlFormat == "json" {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(report); err != nil {
+			return err
+		}
+	} else {
+		writeDrillText(report)
+	}
+	cmd.SilenceUsage = true
+	return exitErr
+}
+
+func writeDrillText(r *drillReport) {
+	fmt.Printf("=== Restore drill @ %s ===\n", r.At.Format("2006-01-02 15:04:05"))
+	pass := 0
+	var totalLoad float64
+	for _, t := range r.Tables {
+		status := "PASS"
+		if t.Status != "pass" {
+			status = "FAIL"
+		} else {
+			pass++
+		}
+		fmt.Printf("  %-4s %s.%s  rows=%d  reconstruct=%.1fs load=%.1fs", status, t.Schema, t.Table, t.RowsLoaded, t.ReconstructSeconds, t.LoadSeconds)
+		if t.Error != "" {
+			fmt.Printf("  (%s)", t.Error)
+		}
+		fmt.Println()
+		totalLoad += t.ReconstructSeconds + t.LoadSeconds
+	}
+	fmt.Printf("Summary: %d pass, %d fail — measured restore time %.1fs (an RTO data point)\n", pass, len(r.Tables)-pass, totalLoad)
+	if r.DumpDir != "" {
+		fmt.Printf("Dump kept at: %s\n", r.DumpDir)
+	}
+}

--- a/internal/cli/drill.go
+++ b/internal/cli/drill.go
@@ -295,11 +295,16 @@ func runDrill(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	reports, err := reconstruct.ReconstructTables(ctx, reconstruct.FullTableConfig{
-		IndexDSN:           drlIndexDSN,
-		BaselineSrc:        baselineSrc,
-		Tables:             tables,
-		At:                 at,
-		OutputDir:          outDir,
+		IndexDSN:    drlIndexDSN,
+		BaselineSrc: baselineSrc,
+		Tables:      tables,
+		At:          at,
+		OutputDir:   outDir,
+		// Each chunk is applied to the scratch as ONE statement, so it must
+		// fit the target's max_allowed_packet — 16MiB stays well under the
+		// stock 64M default (reconstruct's own 256MiB default assumes
+		// myloader, which the operator tunes).
+		ChunkSize:          16 << 20,
 		WarnEventThreshold: 5_000_000,
 		ArchiveFetcher:     TunedArchiveFetcher(duckTuning),
 		DuckDBTuning:       duckTuning,

--- a/internal/cli/drill.go
+++ b/internal/cli/drill.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
+	drivermysql "github.com/go-sql-driver/mysql"
 	"github.com/spf13/cobra"
 
 	"github.com/dbtrail/dbtrail/ext"
@@ -23,23 +25,26 @@ var drillCmd = &cobra.Command{
 	Short: "Rehearse a real restore into a scratch MySQL and check it (a fire drill)",
 	Long: `Performs an actual restore end to end and reports whether it worked:
 
-  1. Reconstructs the selected tables at --at (default now) into a
+  1. Probes the SCRATCH target first: the run is refused if the target
+     already holds ANY table in the drilled schemas — pointing drill at a
+     server that already has data there is assumed to be a mistake.
+  2. Reconstructs the selected tables at --at (default now) into a
      mydumper-format dump (baseline + indexed deltas).
-  2. Loads the dump into the SCRATCH MySQL given by --target-dsn. The load
-     is refused unless the target schemas are absent from the target server
-     — pointing drill at a server that already holds those schemas is
-     assumed to be a mistake.
-  3. Checks each loaded table's row count against the exact number of rows
-     the dump writer emitted, and reports per-table timings — a measured
-     restore duration is an RTO data point.
+  3. Loads the dump into the target and checks each loaded table's row
+     count against the exact number of rows the dump writer emitted,
+     reporting per-table timings — a measured restore duration is an RTO
+     data point. A table that fell back to binlog-only reconstruction (no
+     usable baseline) FAILS: that rehearsal would start from an empty
+     table, and passing it would be false assurance.
 
 Exit is non-zero if any table fails. The intermediate dump lives in a temp
 directory, removed on success and KEPT on failure for inspection (--output
 pins it somewhere and always keeps it).
 
-What drill proves: the restore pipeline — the dump is loadable and complete,
-and how long it takes. Value-level fidelity of reconstructed content against
-the source is verify's job ('bintrail verify'), not re-proven here.
+What drill proves: the restore pipeline — the dump loads, it contains
+exactly what the dump writer emitted, and how long the restore takes.
+Value-level fidelity of reconstructed content against the source is
+verify's job ('bintrail verify'), not re-proven here.
 
 The binary never launches or supervises a MySQL server: the scratch comes
 from you (any throwaway instance), e.g. the opt-in compose profile:
@@ -67,7 +72,7 @@ var (
 func init() {
 	f := drillCmd.Flags()
 	f.StringVar(&drlIndexDSN, "index-dsn", "", "DSN for the index MySQL database (required)")
-	f.StringVar(&drlTargetDSN, "target-dsn", "", "DSN of the SCRATCH MySQL to load the rehearsal into (required; refused unless the target schemas are absent there)")
+	f.StringVar(&drlTargetDSN, "target-dsn", "", "DSN of the SCRATCH MySQL to load the rehearsal into (required; refused if the target already holds any table in the drilled schemas)")
 	f.StringVar(&drlTables, "tables", "", "Comma-separated schema.table list to rehearse (required)")
 	f.StringVar(&drlAt, "at", "", "Point in time to restore to (default now)")
 	f.StringVar(&drlBaselineDir, "baseline-dir", "", "Local directory of baseline Parquet snapshots")
@@ -86,9 +91,14 @@ func init() {
 // read speed, the second by the scratch server — an operator sizing a real
 // recovery needs both numbers.
 type drillTableResult struct {
-	Schema             string  `json:"schema"`
-	Table              string  `json:"table"`
-	Status             string  `json:"status"` // "pass" | "fail"
+	Schema string `json:"schema"`
+	Table  string `json:"table"`
+	Status string `json:"status"` // "pass" | "fail"
+	// BinlogOnly marks a table whose dump was rebuilt from binlog deltas
+	// alone (no usable baseline). Always a FAIL: the rehearsal would start
+	// from an EMPTY table, and an unmarked PASS here would be exactly the
+	// false restorability assurance drill exists to prevent.
+	BinlogOnly         bool    `json:"binlog_only,omitempty"`
 	RowsWritten        int64   `json:"rows_written"`
 	RowsLoaded         int64   `json:"rows_loaded"`
 	ReconstructSeconds float64 `json:"reconstruct_seconds"`
@@ -125,8 +135,9 @@ func (r *drillReport) ExitError() error {
 
 // parseDrillTables validates and dedupes the --tables list, returning the
 // entries and the distinct schemas (both order-preserving). Identifiers are
-// rejected if they carry a backtick — they are interpolated into backtick-
-// quoted SQL against the scratch server.
+// rejected if they carry any quote character: backticks would break the
+// backtick-quoted interpolation into scratch-server SQL; the other quotes
+// are refused as cheap insurance.
 func parseDrillTables(list string) (tables []string, schemas []string, err error) {
 	seenT := map[string]bool{}
 	seenS := map[string]bool{}
@@ -188,6 +199,21 @@ func drillLoadTable(ctx context.Context, db *sql.DB, outDir string, rep *reconst
 		return fmt.Errorf("target connection: %w", err)
 	}
 	defer conn.Close()
+	// The session myloader (or `cat *.sql | mysql`) would get from the
+	// dump's own /*!…*/ preamble, established explicitly: raw-bytes charset
+	// (baseline string values are the source's STORED bytes, not
+	// necessarily valid utf8mb4), FK checks off (tables load in arbitrary
+	// order without their referenced parents), and strict mode ON so a
+	// lenient scratch cannot silently mangle values into a false PASS.
+	for _, stmt := range []string{
+		"SET NAMES binary",
+		"SET FOREIGN_KEY_CHECKS = 0",
+		"SET SESSION sql_mode = CONCAT(@@SESSION.sql_mode, ',STRICT_ALL_TABLES')",
+	} {
+		if _, err := conn.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("prepare load session: %w", err)
+		}
+	}
 	if _, err := conn.ExecContext(ctx, "CREATE DATABASE IF NOT EXISTS `"+rep.Schema+"`"); err != nil {
 		return fmt.Errorf("create database %s: %w", rep.Schema, err)
 	}
@@ -214,6 +240,9 @@ func drillLoadTable(ctx context.Context, db *sql.DB, outDir string, rep *reconst
 		}
 	}
 	for _, name := range rep.Files {
+		// The metadata skip is purely defensive — MydumperWriter.Files()
+		// tracks only schema + chunk files; the shared metadata file is
+		// written outside the writer and never appears here.
 		if name == "metadata" || strings.HasSuffix(name, "-schema.sql") {
 			continue
 		}
@@ -227,8 +256,10 @@ func drillLoadTable(ctx context.Context, db *sql.DB, outDir string, rep *reconst
 // auditDrill reports one rehearsed table to the audit seam: drill
 // materializes historical row state into an external server — the same
 // data-serving class as reconstruct's mydumper mode, with the extra fact
-// that the rows now live OUTSIDE the index. ext.Record cannot fail the
-// command (see ext/audit.go).
+// that the rows now live OUTSIDE the index. Emitted once per table right
+// after its dump is durable on disk, BEFORE the load — so a partial load or
+// a kept failure dump is never unaudited served data. ext.Record cannot
+// fail the command (see ext/audit.go).
 func auditDrill(ctx context.Context, schema, table string, rows int64) {
 	ext.Record(ctx, ext.AuditEvent{
 		Surface: "cli",
@@ -267,7 +298,16 @@ func runDrill(cmd *cobra.Command, args []string) error {
 	}
 
 	ctx := cmd.Context()
-	target, err := config.Connect(drlTargetDSN)
+	tcfg, err := drivermysql.ParseDSN(drlTargetDSN)
+	if err != nil {
+		return fmt.Errorf("invalid --target-dsn: %w", err)
+	}
+	// A real baseline's -schema.sql is VERBATIM mydumper output: a /*!…*/
+	// SET preamble plus the CREATE TABLE — several statements in one file.
+	// The load connection must accept that blob whole; without this every
+	// drill against a real baseline dies on the schema file with a 1064.
+	tcfg.MultiStatements = true
+	target, err := config.Connect(tcfg.FormatDSN())
 	if err != nil {
 		return fmt.Errorf("connect to --target-dsn: %w", err)
 	}
@@ -301,9 +341,11 @@ func runDrill(cmd *cobra.Command, args []string) error {
 		At:          at,
 		OutputDir:   outDir,
 		// Each chunk is applied to the scratch as ONE statement, so it must
-		// fit the target's max_allowed_packet — 16MiB stays well under the
-		// stock 64M default (reconstruct's own 256MiB default assumes
-		// myloader, which the operator tunes).
+		// fit the target's max_allowed_packet. Chunks can overshoot by one
+		// row tuple (rotation triggers after the threshold), so the ~48MiB
+		// headroom under the stock 64M default is the real margin
+		// (reconstruct's own 256MiB default assumes myloader, which the
+		// operator tunes).
 		ChunkSize:          16 << 20,
 		WarnEventThreshold: 5_000_000,
 		ArchiveFetcher:     TunedArchiveFetcher(duckTuning),
@@ -319,60 +361,85 @@ func runDrill(cmd *cobra.Command, args []string) error {
 	}
 
 	report := &drillReport{At: at}
+	anyFail := false
 	for _, rep := range reports {
-		res := drillTableResult{
-			Schema:             rep.Schema,
-			Table:              rep.Table,
-			Status:             "fail",
-			RowsWritten:        rep.RowsWritten,
-			ReconstructSeconds: rep.Duration.Seconds(),
-		}
-		loadStart := time.Now()
-		if err := drillLoadTable(ctx, target, outDir, rep); err != nil {
-			res.Error = err.Error()
-			res.LoadSeconds = time.Since(loadStart).Seconds()
-			report.Tables = append(report.Tables, res)
-			continue
-		}
-		res.LoadSeconds = time.Since(loadStart).Seconds()
+		// Audit BEFORE the load: the dump on disk is already served
+		// historical row state, and a partial or failed load must not leave
+		// rows in an external server (or a kept dump) unaudited.
 		auditDrill(ctx, rep.Schema, rep.Table, rep.RowsWritten)
-		var loaded int64
-		if err := target.QueryRowContext(ctx,
-			"SELECT COUNT(*) FROM `"+rep.Schema+"`.`"+rep.Table+"`").Scan(&loaded); err != nil {
-			res.Error = fmt.Sprintf("count loaded rows: %v", err)
-			report.Tables = append(report.Tables, res)
-			continue
-		}
-		res.RowsLoaded = loaded
-		if loaded == rep.RowsWritten {
-			res.Status = "pass"
-		} else {
-			res.Error = fmt.Sprintf("loaded %d rows, dump wrote %d", loaded, rep.RowsWritten)
+		res := drillTable(ctx, target, outDir, rep)
+		if res.Status != "pass" {
+			anyFail = true
 		}
 		report.Tables = append(report.Tables, res)
 	}
 
-	exitErr := report.ExitError()
-	if !tempDir || exitErr != nil {
+	// DumpDir must be decided BEFORE ExitError builds its message — the
+	// "dump kept at" suffix is the one pointer a cron log captures.
+	if !tempDir || anyFail {
 		report.DumpDir = outDir
 	}
-	if tempDir && exitErr == nil {
+	if tempDir && !anyFail {
 		if rmErr := os.RemoveAll(outDir); rmErr != nil {
 			fmt.Fprintf(os.Stderr, "warning: could not remove temp dump dir %s: %v\n", outDir, rmErr)
 		}
 	}
+	exitErr := report.ExitError()
 
 	if drlFormat == "json" {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
 		if err := enc.Encode(report); err != nil {
-			return err
+			// The encode failure must not REPLACE the drill verdict in the
+			// recorded error.
+			return errors.Join(err, exitErr)
 		}
 	} else {
 		writeDrillText(report)
 	}
 	cmd.SilenceUsage = true
 	return exitErr
+}
+
+// drillTable runs one table's load-and-check half and produces its verdict —
+// extracted so the verdict wiring (fail-by-default, binlog-only refusal,
+// count comparison) is unit-testable without a real reconstruct.
+func drillTable(ctx context.Context, target *sql.DB, outDir string, rep *reconstruct.TableReport) drillTableResult {
+	res := drillTableResult{
+		Schema:             rep.Schema,
+		Table:              rep.Table,
+		Status:             "fail",
+		BinlogOnly:         rep.BinlogOnly,
+		RowsWritten:        rep.RowsWritten,
+		ReconstructSeconds: rep.Duration.Seconds(),
+	}
+	if rep.BinlogOnly {
+		// Not even loaded: a rehearsal that never touched a baseline starts
+		// from an EMPTY table — passing it would be false assurance, and
+		// loading it would leave misleading partial data on the scratch.
+		res.Error = "no usable baseline for this table — the dump was rebuilt from binlog deltas alone (an EMPTY starting table); a real restore would lose every never-touched row. Take a baseline (bintrail dump + bintrail baseline)"
+		return res
+	}
+	loadStart := time.Now()
+	if err := drillLoadTable(ctx, target, outDir, rep); err != nil {
+		res.Error = err.Error()
+		res.LoadSeconds = time.Since(loadStart).Seconds()
+		return res
+	}
+	res.LoadSeconds = time.Since(loadStart).Seconds()
+	var loaded int64
+	if err := target.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM `"+rep.Schema+"`.`"+rep.Table+"`").Scan(&loaded); err != nil {
+		res.Error = fmt.Sprintf("count loaded rows: %v", err)
+		return res
+	}
+	res.RowsLoaded = loaded
+	if loaded == rep.RowsWritten {
+		res.Status = "pass"
+	} else {
+		res.Error = fmt.Sprintf("loaded %d rows, dump wrote %d", loaded, rep.RowsWritten)
+	}
+	return res
 }
 
 func writeDrillText(r *drillReport) {

--- a/internal/cli/drill_integration_test.go
+++ b/internal/cli/drill_integration_test.go
@@ -1,0 +1,36 @@
+//go:build integration
+
+package cli
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestIntegrationDrill_guardRefusesSecondRun proves the emptiness guard is
+// actually WIRED into runDrill (not just unit-tested in isolation): the
+// first rehearsal populates the scratch schema, so a second run against the
+// same target must be refused before touching anything.
+func TestIntegrationDrill_guardRefusesSecondRun(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	srcSchema := fmt.Sprintf("drillsrc2_%d", time.Now().UnixNano())
+	dsn, baseDir, at := drillContractFixture(t, srcSchema)
+	resetDrillGlobals(t)
+	drlIndexDSN, drlBaselineDir = dsn, baseDir
+	drlTables = srcSchema + ".orders"
+	drlTargetDSN = testutil.BaseDSN() + "/"
+	drlAt = at.Format("2006-01-02 15:04:05")
+	drlFormat = "json"
+
+	if err := runDrill(newQueryTestCmd(), nil); err != nil {
+		t.Fatalf("first drill must pass: %v", err)
+	}
+	err := runDrill(newQueryTestCmd(), nil)
+	if err == nil || !strings.Contains(err.Error(), "already has table") {
+		t.Fatalf("second run against the now-populated target must be refused by the guard: %v", err)
+	}
+}

--- a/internal/cli/drill_test.go
+++ b/internal/cli/drill_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"database/sql"
 	"os"
 	"path/filepath"
 	"strings"
@@ -65,8 +66,10 @@ func TestDrillLoadTable_ordersSchemaBeforeChunks(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer db.Close()
-	// Ordered: database, USE, schema file, then chunks in Files order —
-	// and the metadata file is never applied.
+	// Ordered (sqlmock's default ordered matching IS the assertion here):
+	// session setup, database, USE, schema file, then chunks in Files order
+	// — and the metadata file is never applied.
+	expectLoadSession(mock)
 	mock.ExpectExec("CREATE DATABASE IF NOT EXISTS `shop`").WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec("USE `shop`").WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec("CREATE TABLE").WillReturnResult(sqlmock.NewResult(0, 0))
@@ -79,6 +82,70 @@ func TestDrillLoadTable_ordersSchemaBeforeChunks(t *testing.T) {
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func expectLoadSession(mock sqlmock.Sqlmock) {
+	mock.ExpectExec("SET NAMES binary").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("FOREIGN_KEY_CHECKS").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("sql_mode").WillReturnResult(sqlmock.NewResult(0, 0))
+}
+
+// TestDrillTable_verdicts pins the verdict wiring itself: fail-by-default,
+// the count comparison, and the binlog-only refusal — the halves a
+// regression could quietly turn into a rubber stamp.
+func TestDrillTable_verdicts(t *testing.T) {
+	dir := t.TempDir()
+	files := map[string]string{
+		"shop.orders-schema.sql": "CREATE TABLE `orders` (id INT PRIMARY KEY)",
+		"shop.orders.00000.sql":  "INSERT INTO `shop`.`orders` (`id`) VALUES (1), (2), (3);\n",
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	rep := func() *reconstruct.TableReport {
+		return &reconstruct.TableReport{Schema: "shop", Table: "orders", RowsWritten: 3,
+			Files: []string{"shop.orders-schema.sql", "shop.orders.00000.sql"}}
+	}
+	newDB := func(t *testing.T, count int64) *sql.DB {
+		t.Helper()
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { db.Close() })
+		expectLoadSession(mock)
+		mock.ExpectExec("CREATE DATABASE").WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectExec("USE").WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectExec("CREATE TABLE").WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectExec("VALUES").WillReturnResult(sqlmock.NewResult(0, 3))
+		mock.ExpectQuery(`COUNT\(\*\)`).WillReturnRows(sqlmock.NewRows([]string{"c"}).AddRow(count))
+		return db
+	}
+
+	got := drillTable(context.Background(), newDB(t, 3), dir, rep())
+	if got.Status != "pass" || got.RowsLoaded != 3 || got.Error != "" {
+		t.Fatalf("matching count must pass: %+v", got)
+	}
+
+	got = drillTable(context.Background(), newDB(t, 2), dir, rep())
+	if got.Status != "fail" || !strings.Contains(got.Error, "loaded 2 rows, dump wrote 3") {
+		t.Fatalf("count mismatch must fail with both numbers: %+v", got)
+	}
+
+	// Binlog-only: refused up front — no statement ever reaches the target.
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	r := rep()
+	r.BinlogOnly = true
+	got = drillTable(context.Background(), db, dir, r)
+	if got.Status != "fail" || !got.BinlogOnly || !strings.Contains(got.Error, "baseline") {
+		t.Fatalf("binlog-only must fail without loading: %+v", got)
 	}
 }
 

--- a/internal/cli/drill_test.go
+++ b/internal/cli/drill_test.go
@@ -1,0 +1,99 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/dbtrail/dbtrail/internal/reconstruct"
+)
+
+func TestParseDrillTables(t *testing.T) {
+	tables, schemas, err := parseDrillTables(" shop.orders, shop.users ,hr.people,shop.orders")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tables) != 3 || tables[0] != "shop.orders" || tables[2] != "hr.people" {
+		t.Fatalf("tables = %v", tables)
+	}
+	if len(schemas) != 2 || schemas[0] != "shop" || schemas[1] != "hr" {
+		t.Fatalf("schemas = %v", schemas)
+	}
+	for _, bad := range []string{"", "noschema", "a.b.c", ".t", "s.", "s.`t`"} {
+		if _, _, err := parseDrillTables(bad); err == nil {
+			t.Fatalf("entry %q must be rejected", bad)
+		}
+	}
+}
+
+func TestDrillTargetEmpty(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	// First schema empty, second holds a table → refuse naming it.
+	mock.ExpectQuery("information_schema.TABLES").WithArgs("shop").
+		WillReturnRows(sqlmock.NewRows([]string{"TABLE_NAME"}))
+	mock.ExpectQuery("information_schema.TABLES").WithArgs("hr").
+		WillReturnRows(sqlmock.NewRows([]string{"TABLE_NAME"}).AddRow("salaries"))
+	err = drillTargetEmpty(context.Background(), db, []string{"shop", "hr"})
+	if err == nil || !strings.Contains(err.Error(), "hr.salaries") {
+		t.Fatalf("non-empty target must be refused with the table named: %v", err)
+	}
+}
+
+func TestDrillLoadTable_ordersSchemaBeforeChunks(t *testing.T) {
+	dir := t.TempDir()
+	files := map[string]string{
+		"shop.orders-schema.sql": "CREATE TABLE `orders` (id INT PRIMARY KEY)",
+		"shop.orders.00000.sql":  "INSERT INTO `shop`.`orders` (`id`) VALUES\n(1),\n(2);\n",
+		"shop.orders.00001.sql":  "INSERT INTO `shop`.`orders` (`id`) VALUES\n(3);\n",
+		"metadata":               "started: now",
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	// Ordered: database, USE, schema file, then chunks in Files order —
+	// and the metadata file is never applied.
+	mock.ExpectExec("CREATE DATABASE IF NOT EXISTS `shop`").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("USE `shop`").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("CREATE TABLE").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(`VALUES \(1\), \(2\)`).WillReturnResult(sqlmock.NewResult(0, 2))
+	mock.ExpectExec(`VALUES \(3\)`).WillReturnResult(sqlmock.NewResult(0, 1))
+	rep := &reconstruct.TableReport{Schema: "shop", Table: "orders",
+		Files: []string{"metadata", "shop.orders-schema.sql", "shop.orders.00000.sql", "shop.orders.00001.sql"}}
+	if err := drillLoadTable(context.Background(), db, dir, rep); err != nil {
+		t.Fatal(err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDrillReportExitError(t *testing.T) {
+	r := &drillReport{Tables: []drillTableResult{
+		{Schema: "s", Table: "a", Status: "pass"},
+		{Schema: "s", Table: "b", Status: "pass"},
+	}}
+	if err := r.ExitError(); err != nil {
+		t.Fatalf("all-pass must exit clean: %v", err)
+	}
+	r.Tables[1].Status = "fail"
+	r.DumpDir = "/tmp/d"
+	err := r.ExitError()
+	if err == nil || !strings.Contains(err.Error(), "1 of 2") || !strings.Contains(err.Error(), "/tmp/d") {
+		t.Fatalf("failure must name counts and the kept dump: %v", err)
+	}
+}

--- a/internal/reconstruct/fulltable.go
+++ b/internal/reconstruct/fulltable.go
@@ -159,8 +159,13 @@ type TableReport struct {
 	InsertsEmitted int64 // rows appended after the baseline pass (new PKs)
 	UpdatesApplied int64 // baseline rows whose PK matched an UPDATE/INSERT event
 	DeletesSkipped int64 // baseline rows whose PK matched a DELETE event
-	Files          []string
-	Duration       time.Duration
+	// RowsWritten counts the row tuples actually written into chunk files —
+	// the writer's own tally, exact by construction (not derived from the
+	// baseline/insert/delete counters). `bintrail drill` loads the dump and
+	// checks COUNT(*) against it.
+	RowsWritten int64
+	Files       []string
+	Duration    time.Duration
 	// BinlogOnly is true when the table had no baseline at all and was
 	// recovered entirely from the binlog (#766's ErrNoBaseline fallback,
 	// reconstructBinlogOnly). Files is non-empty in this case too, so
@@ -930,6 +935,7 @@ func mergeBaselineIntoWriter(ctx context.Context, in mergeInput, rep *TableRepor
 		return fmt.Errorf("close mydumper writer: %w", err)
 	}
 	rep.Files = mw.Files()
+	rep.RowsWritten = mw.Rows()
 	return nil
 }
 
@@ -1621,6 +1627,7 @@ func writeBinlogOnlyChanges(
 		return fmt.Errorf("close mydumper writer: %w", err)
 	}
 	rep.Files = mw.Files()
+	rep.RowsWritten = mw.Rows()
 	return nil
 }
 

--- a/internal/reconstruct/mydumper_writer.go
+++ b/internal/reconstruct/mydumper_writer.go
@@ -43,7 +43,8 @@ type MydumperWriter struct {
 	// cols is the column name list in the order WriteRow receives values.
 	cols []string
 
-	files []string // written file names, for TableReport
+	files       []string // written file names, for TableReport
+	rowsWritten int64    // row tuples written across all chunks — the load expectation drill checks against
 
 	curFile         *os.File
 	curBuf          *bufio.Writer
@@ -163,6 +164,8 @@ func (w *MydumperWriter) WriteRow(values []any) error {
 		w.curBytes += int64(len(tuple)) + 2
 	}
 
+	w.rowsWritten++
+
 	// Rotate if the chunk has grown past the threshold.
 	if w.curBytes >= w.chunkSize {
 		if err := w.finishChunk(); err != nil {
@@ -171,6 +174,10 @@ func (w *MydumperWriter) WriteRow(values []any) error {
 	}
 	return nil
 }
+
+// Rows returns how many row tuples WriteRow has accepted. Exact by
+// construction — `bintrail drill` compares the loaded COUNT(*) against it.
+func (w *MydumperWriter) Rows() int64 { return w.rowsWritten }
 
 // Close terminates the in-progress INSERT (if any), flushes and closes the
 // current chunk file, and marks the writer terminal so subsequent WriteRow

--- a/internal/reconstruct/mydumper_writer_rows_test.go
+++ b/internal/reconstruct/mydumper_writer_rows_test.go
@@ -1,0 +1,53 @@
+package reconstruct
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestMydumperWriterRowsAcrossRotation pins the "exact by construction"
+// claim where it could actually drift: chunk rotation. A tiny chunkSize
+// forces a rotation on every row; Rows() must equal both the tuples
+// accepted AND the tuples present on disk across all chunks.
+func TestMydumperWriterRowsAcrossRotation(t *testing.T) {
+	dir := t.TempDir()
+	w, err := NewMydumperWriter(dir, "s", "t", []string{"id"}, 4 /* bytes: rotate every row */)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const n = 5
+	for i := 0; i < n; i++ {
+		if err := w.WriteRow([]any{int64(i)}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if w.Rows() != n {
+		t.Fatalf("Rows() = %d, want %d", w.Rows(), n)
+	}
+	chunks := 0
+	tuples := 0
+	for _, name := range w.Files() {
+		if strings.HasSuffix(name, "-schema.sql") {
+			continue
+		}
+		chunks++
+		b, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Each chunk holds one "(`id`) VALUES" header paren plus one paren
+		// per tuple.
+		tuples += strings.Count(string(b), "(") - 1
+	}
+	if chunks < 2 {
+		t.Fatalf("chunkSize=4 must force rotation, got %d chunk(s)", chunks)
+	}
+	if tuples != n {
+		t.Fatalf("tuples on disk = %d, want %d (counter drifted from disk)", tuples, n)
+	}
+}


### PR DESCRIPTION
closes #1195 · part of the continuous backup assurance epic #1189

## Summary
- **`bintrail drill`**: one command rehearses a real restore end to end — reconstruct the selected tables at `--at` into a mydumper dump, load it into the **scratch** MySQL at `--target-dsn`, check each loaded `COUNT(*)` against the exact rows the dump writer emitted, report per-table pass/fail with reconstruct/load timings (a measured **RTO** data point). `--format json` for cron; exit non-zero on any failure (single `ExitError` decision).
- **Safety**: the load is refused if the target already holds any table in the drilled schemas — pointing it at a real server is hard by default. The dump is a temp dir, removed on success, **kept on failure** for inspection.
- **Scope stated, not implied**: drill proves the restore *pipeline* (loadability, completeness, duration); value-level fidelity stays `verify`'s job — its digest machinery is not duplicated.
- **Red line intact**: the binary never launches a mysqld — the scratch is operator-provided; the new opt-in compose profile `drill` ships the pinned `mysql:8.4.9` with a throwaway volume (SHIP carve-out).
- **Audit**: new `cli/drill.run` pair in `audittest.Required` + call-site ledger, exercised end-to-end in the CLI audit contract test (green against the integration MySQL locally).
- `MydumperWriter` gained an exact `Rows()` counter, exposed as `TableReport.RowsWritten`.
- Docs: `docs/drill.md` (monthly runbook).

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`, ALL-GREEN)
- [x] `go test -race` on touched packages
- [x] `go vet -tags integration ./...`
- [x] `TestIntegrationAuditContract_CLI` (incl. the new drill case: real reconstruct → load → count → emission) green against Docker MySQL
- [x] `docker compose config -q` valid with the new profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)
