### PR TITLE
doctor: S3 Object Lock posture check + ransomware-hardening docs

### DIFF
--- a/cliapp/doctor.go
+++ b/cliapp/doctor.go
@@ -55,7 +55,7 @@ func init() {
 	doctorCmd.Flags().StringVar(&docIndexDSN, "index-dsn", "", "DSN for the index MySQL database (optional; verifies write access when provided)")
 	doctorCmd.Flags().StringVar(&docSchemas, "schemas", "", "Comma-separated schemas to check (default: all user schemas)")
 	doctorCmd.Flags().StringVar(&docFormat, "format", "text", "Output format: text or json")
-	doctorCmd.Flags().StringVar(&docRetain, "retain", "30d", "Retention window assumed by the index capacity projection (Nd/Nh; \"off\" if you don't rotate)")
+	doctorCmd.Flags().StringVar(&docRetain, "retain", "30d", "Retention window assumed by the index capacity projection and the --archive-s3 Object Lock retention comparison (Nd/Nh; \"off\" if you don't rotate)")
 	doctorCmd.Flags().StringVar(&docProxySQLAdmin, "proxysql-admin", "", "ProxySQL admin DSN, e.g. admin:pass@tcp(127.0.0.1:6032)/ (optional; verifies the dbtrail time-travel routing rules are live — advisory WARN only)")
 	doctorCmd.Flags().StringVar(&docArchiveS3, "archive-s3", "", "S3 archive destination, e.g. s3://bucket/prefix (optional; reports the bucket's Object Lock ransomware posture — advisory WARN only)")
 	doctorCmd.Flags().StringVar(&docArchiveS3Reg, "archive-s3-region", "", "AWS region for --archive-s3 (optional; the SDK resolves it when empty)")

--- a/cliapp/doctor.go
+++ b/cliapp/doctor.go
@@ -34,7 +34,8 @@ Examples:
 
   bintrail doctor --source-dsn "user:pass@tcp(source:3306)/"
   bintrail doctor --source-dsn "$SRC" --index-dsn "$IDX" --schemas mydb
-  bintrail doctor --source-dsn "$SRC" --proxysql-admin "admin:admin@tcp(127.0.0.1:6032)/"`,
+  bintrail doctor --source-dsn "$SRC" --proxysql-admin "admin:admin@tcp(127.0.0.1:6032)/"
+  bintrail doctor --source-dsn "$SRC" --archive-s3 s3://my-bucket/archives/`,
 	RunE: runDoctor,
 }
 
@@ -45,6 +46,8 @@ var (
 	docFormat        string
 	docRetain        string
 	docProxySQLAdmin string
+	docArchiveS3     string
+	docArchiveS3Reg  string
 )
 
 func init() {
@@ -54,6 +57,8 @@ func init() {
 	doctorCmd.Flags().StringVar(&docFormat, "format", "text", "Output format: text or json")
 	doctorCmd.Flags().StringVar(&docRetain, "retain", "30d", "Retention window assumed by the index capacity projection (Nd/Nh; \"off\" if you don't rotate)")
 	doctorCmd.Flags().StringVar(&docProxySQLAdmin, "proxysql-admin", "", "ProxySQL admin DSN, e.g. admin:pass@tcp(127.0.0.1:6032)/ (optional; verifies the dbtrail time-travel routing rules are live — advisory WARN only)")
+	doctorCmd.Flags().StringVar(&docArchiveS3, "archive-s3", "", "S3 archive destination, e.g. s3://bucket/prefix (optional; reports the bucket's Object Lock ransomware posture — advisory WARN only)")
+	doctorCmd.Flags().StringVar(&docArchiveS3Reg, "archive-s3-region", "", "AWS region for --archive-s3 (optional; the SDK resolves it when empty)")
 	_ = doctorCmd.MarkFlagRequired("source-dsn")
 	bindCommandEnv(doctorCmd)
 	rootCmd.AddCommand(doctorCmd)
@@ -67,7 +72,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return runDoctorTo(cmd.Context(), os.Stdout, docFormat, docSourceDSN, docIndexDSN, docSchemas, retain, docProxySQLAdmin)
+	return runDoctorTo(cmd.Context(), os.Stdout, docFormat, docSourceDSN, docIndexDSN, docSchemas, retain, docProxySQLAdmin, docArchiveS3, docArchiveS3Reg)
 }
 
 // parseDocRetain maps doctor's --retain value to the capacity projection's
@@ -94,10 +99,13 @@ func parseDocRetain(s string) (time.Duration, error) {
 // code). Callers wanting to route output (e.g. `bintrail
 // up` sending preflight output to stderr to keep stdout clean for streaming)
 // pass their own writer here instead of going through the cobra entry point.
-func runDoctorTo(parent context.Context, w io.Writer, format, sourceDSN, indexDSN, schemasCSV string, indexRetain time.Duration, proxysqlAdminDSN string) error {
+func runDoctorTo(parent context.Context, w io.Writer, format, sourceDSN, indexDSN, schemasCSV string, indexRetain time.Duration, proxysqlAdminDSN, archiveS3, archiveS3Region string) error {
 	report := doctor.Build(parent, sourceDSN, indexDSN, schemasCSV, indexRetain)
 	if proxysqlAdminDSN != "" {
 		report.Add(doctor.CheckProxySQLRules(parent, proxysqlAdminDSN))
+	}
+	if archiveS3 != "" {
+		report.Add(doctor.CheckArchiveObjectLock(parent, archiveS3, archiveS3Region, indexRetain))
 	}
 	appendExtDoctorChecks(parent, report, sourceDSN, indexDSN)
 	if err := report.Write(w, format); err != nil {

--- a/cliapp/doctor_ext_test.go
+++ b/cliapp/doctor_ext_test.go
@@ -118,7 +118,7 @@ func TestRunDoctorToRendersRegisteredCheck(t *testing.T) {
 		var buf bytes.Buffer
 		// The built-in checks fail against the unreachable DSN, so the
 		// returned error is expected; the rendered report is what matters.
-		_ = runDoctorTo(context.Background(), &buf, format, badDSN, "", "", 0, "")
+		_ = runDoctorTo(context.Background(), &buf, format, badDSN, "", "", 0, "", "", "")
 		if !strings.Contains(buf.String(), name) {
 			t.Errorf("%s output does not contain the registered check %q:\n%s", format, name, buf.String())
 		}

--- a/cliapp/doctor_objectlock_test.go
+++ b/cliapp/doctor_objectlock_test.go
@@ -31,3 +31,15 @@ func TestRunDoctorToWiresObjectLockCheck(t *testing.T) {
 		t.Fatalf("check present without --archive-s3:\n%s", without.String())
 	}
 }
+
+// TestDoctorObjectLockFlagNames pins the flag names to the ones bound in
+// internal/cli/env.go — renaming either silently disconnects
+// BINTRAIL_ARCHIVE_S3/_REGION from doctor while the generic env-binding
+// resolve test stays green (agent/rotate still register the old names).
+func TestDoctorObjectLockFlagNames(t *testing.T) {
+	for _, name := range []string{"archive-s3", "archive-s3-region"} {
+		if doctorCmd.Flags().Lookup(name) == nil {
+			t.Fatalf("doctor is missing the --%s flag (env binding depends on the name)", name)
+		}
+	}
+}

--- a/cliapp/doctor_objectlock_test.go
+++ b/cliapp/doctor_objectlock_test.go
@@ -1,0 +1,33 @@
+package cliapp
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/doctor"
+)
+
+// TestRunDoctorToWiresObjectLockCheck pins the runDoctorTo wiring: a non-empty
+// --archive-s3 adds the Object Lock check to the report, and an empty one does
+// not. The invalid-URL path returns before any AWS call, so no network or
+// credentials are involved.
+func TestRunDoctorToWiresObjectLockCheck(t *testing.T) {
+	badDSN := "nouser:nopass@tcp(127.0.0.1:1)/"
+
+	var with bytes.Buffer
+	_ = runDoctorTo(context.Background(), &with, "text", badDSN, "", "", 0, "", "not-an-s3-url", "")
+	if !strings.Contains(with.String(), doctor.ObjectLockCheckName) {
+		t.Fatalf("report does not contain %q:\n%s", doctor.ObjectLockCheckName, with.String())
+	}
+	if !strings.Contains(with.String(), "invalid --archive-s3") {
+		t.Fatalf("report does not carry the invalid-URL detail:\n%s", with.String())
+	}
+
+	var without bytes.Buffer
+	_ = runDoctorTo(context.Background(), &without, "text", badDSN, "", "", 0, "", "", "")
+	if strings.Contains(without.String(), doctor.ObjectLockCheckName) {
+		t.Fatalf("check present without --archive-s3:\n%s", without.String())
+	}
+}

--- a/docs/index-recovery.md
+++ b/docs/index-recovery.md
@@ -1,5 +1,9 @@
 # Index loss and recovery — `bintrail restore-index`
 
+> This runbook assumes the S3 archive tier survived the incident. To make
+> that assumption hold against ransomware or a stolen credential, put the
+> archives on an S3 Object Lock bucket — see [object-lock.md](object-lock.md).
+
 The index database is the system of record, but it is also just a MySQL
 database — disks die, volumes get deleted. The archive tier is the answer to
 "who backs up the backup": `bintrail restore-index` turns the Parquet

--- a/docs/object-lock.md
+++ b/docs/object-lock.md
@@ -1,0 +1,94 @@
+# Ransomware-proof archives — S3 Object Lock
+
+After `bintrail rotate` drops a partition from the live index, its Parquet
+archive in S3 is the **only copy** of those events. Anyone — or anything —
+holding credentials that can delete S3 objects can erase your recovery
+safety net: a compromised access key, a ransomware operator, or a fat-fingered
+cleanup script. The index itself can be rebuilt from the archives
+([index-recovery.md](index-recovery.md)); the archives cannot be rebuilt from
+anything.
+
+S3 Object Lock closes that hole: with a default retention rule, every object
+becomes **immutable for the retention period** the moment it is written. No
+new bintrail flags are needed — uploads work on a locked bucket out of the
+box.
+
+## Threat model
+
+| Threat | Without Object Lock | With Object Lock (COMPLIANCE) |
+|---|---|---|
+| Stolen AWS key deletes the bucket contents | Archives gone | Deletes fail until retention expires |
+| Ransomware encrypts/deletes index **and** S3 | Total loss | Archive tier survives; `bintrail restore-index` rebuilds |
+| Buggy cleanup script | Archives gone | Deletes fail |
+| Malicious insider with root | Archives gone | COMPLIANCE binds **every** principal, including root |
+
+GOVERNANCE mode is weaker: principals holding `s3:BypassGovernanceRetention`
+can still delete. Use COMPLIANCE unless you specifically need the escape
+hatch — but note COMPLIANCE is irreversible: nothing shortens the retention
+of an already-written object.
+
+## Bucket recipe
+
+Object Lock can only be enabled **when the bucket is created** — it cannot be
+turned on later. (Versioning is enabled automatically and cannot be
+suspended on a locked bucket.)
+
+```bash
+# 1. Create the bucket with Object Lock enabled
+aws s3api create-bucket --bucket my-bintrail-archives \
+  --object-lock-enabled-for-bucket \
+  --region us-west-2 --create-bucket-configuration LocationConstraint=us-west-2
+
+# 2. Default retention: every uploaded object is locked automatically.
+#    bintrail sets no per-object retention — WITHOUT this rule nothing is locked.
+aws s3api put-object-lock-configuration --bucket my-bintrail-archives \
+  --object-lock-configuration \
+  'ObjectLockEnabled=Enabled,Rule={DefaultRetention={Mode=COMPLIANCE,Days=90}}'
+
+# 3. Lifecycle: expire noncurrent versions and stray delete markers AFTER the
+#    lock expires, so storage does not grow forever.
+aws s3api put-bucket-lifecycle-configuration --bucket my-bintrail-archives \
+  --lifecycle-configuration '{"Rules":[{"ID":"reap-after-lock","Status":"Enabled",
+    "Filter":{},"NoncurrentVersionExpiration":{"NoncurrentDays":91},
+    "Expiration":{"ExpiredObjectDeleteMarker":true}}]}'
+```
+
+**Choosing the retention period**: at least your `rotate --retain` window —
+if the lock expires while the partition is still in the live index, the
+object is already deletable by the time it becomes the only copy — plus
+however long you want deletion protection after that. `bintrail doctor`
+checks this arithmetic for you:
+
+```bash
+bintrail doctor --source-dsn "$SRC" --retain 30d \
+  --archive-s3 s3://my-bintrail-archives/prod/
+```
+
+The check is advisory (WARN, never a failing exit code) and reports: lock
+disabled, lock enabled but no default rule (uploads land **unlocked**),
+retention shorter than `--retain`, and the mode/period on PASS. It needs the
+`s3:GetBucketObjectLockConfiguration` permission; without it the check SKIPs.
+
+## What works on a locked bucket — verified
+
+- **Uploads** (`rotate --archive-s3`, `upload`, `baseline --upload`): Object
+  Lock requires a content checksum on every write; the pinned AWS SDK
+  computes one (CRC32) by default on both single-part and multipart uploads.
+  Nothing to configure.
+- **Reads** (`query`/`recover`/`reconstruct`/`restore-index`, the shim, the
+  console): read-only GETs, unaffected.
+- **`archive reconcile --prune`**: deletes **registry rows only** — it never
+  touches data files, locked or not.
+- **Baseline local prune** (`rotate` with `--baseline-*`): deletes **local**
+  directories after confirming a durable S3 copy; it never deletes from S3.
+- The one S3 delete bintrail ever performs is the best-effort `_INCOMPLETE`
+  marker cleanup after a baseline upload. On a locked (hence versioned)
+  bucket this places a *delete marker* — a logical delete that retention
+  permits — so discovery behaves normally and the lifecycle rule above reaps
+  the leftovers. If it ever fails it was already harmless: `_SUCCESS`
+  decides completeness.
+
+There is **no** code path in bintrail that permanently deletes archived data
+from S3. Reclaiming aged archives is deliberately left to your bucket
+lifecycle policy — which on a locked bucket can only act after retention
+expires, exactly the guarantee you asked Object Lock for.

--- a/docs/object-lock.md
+++ b/docs/object-lock.md
@@ -29,9 +29,23 @@ of an already-written object.
 
 ## Bucket recipe
 
-Object Lock can only be enabled **when the bucket is created** — it cannot be
-turned on later. (Versioning is enabled automatically and cannot be
-suspended on a locked bucket.)
+On AWS, Object Lock can be enabled on a **new** bucket at creation (versioning
+comes with it and cannot be suspended afterwards) or — since Nov 2023 — on an
+**existing** bucket: enable versioning first, then apply the lock
+configuration. Either way, objects already in the bucket are **not**
+retroactively locked; only writes after the default retention rule exists get
+locked. Some S3-compatible stores still require enabling the lock at bucket
+creation.
+
+Existing bucket:
+
+```bash
+aws s3api put-bucket-versioning --bucket my-bintrail-archives \
+  --versioning-configuration Status=Enabled
+# then apply step 2 and step 3 below
+```
+
+New bucket:
 
 ```bash
 # 1. Create the bucket with Object Lock enabled
@@ -53,11 +67,12 @@ aws s3api put-bucket-lifecycle-configuration --bucket my-bintrail-archives \
     "Expiration":{"ExpiredObjectDeleteMarker":true}}]}'
 ```
 
-**Choosing the retention period**: at least your `rotate --retain` window —
-if the lock expires while the partition is still in the live index, the
-object is already deletable by the time it becomes the only copy — plus
-however long you want deletion protection after that. `bintrail doctor`
-checks this arithmetic for you:
+**Choosing the retention period**: rotation archives a partition at the
+moment it drops it from the live index, so the retention clock starts exactly
+when the archive becomes the only copy. Your `rotate --retain` window is the
+sensible floor — data you considered worth keeping live for N days should
+stay immutable at least that long as an archive — plus however long you want
+deletion protection beyond it. `bintrail doctor` checks that floor for you:
 
 ```bash
 bintrail doctor --source-dsn "$SRC" --retain 30d \
@@ -67,7 +82,9 @@ bintrail doctor --source-dsn "$SRC" --retain 30d \
 The check is advisory (WARN, never a failing exit code) and reports: lock
 disabled, lock enabled but no default rule (uploads land **unlocked**),
 retention shorter than `--retain`, and the mode/period on PASS. It needs the
-`s3:GetBucketObjectLockConfiguration` permission; without it the check SKIPs.
+`s3:GetBucketObjectLockConfiguration` permission — **not** part of the
+baseline [IAM policy](s3-iam-policy.md); add it as a bucket-level action —
+and without it the check SKIPs.
 
 ## What works on a locked bucket — verified
 
@@ -79,14 +96,16 @@ retention shorter than `--retain`, and the mode/period on PASS. It needs the
   console): read-only GETs, unaffected.
 - **`archive reconcile --prune`**: deletes **registry rows only** — it never
   touches data files, locked or not.
-- **Baseline local prune** (`rotate` with `--baseline-*`): deletes **local**
+- **Baseline local prune** (`baseline --baseline-retain`): deletes **local**
   directories after confirming a durable S3 copy; it never deletes from S3.
-- The one S3 delete bintrail ever performs is the best-effort `_INCOMPLETE`
-  marker cleanup after a baseline upload. On a locked (hence versioned)
-  bucket this places a *delete marker* — a logical delete that retention
-  permits — so discovery behaves normally and the lifecycle rule above reaps
-  the leftovers. If it ever fails it was already harmless: `_SUCCESS`
-  decides completeness.
+- The only S3 deletes bintrail ever performs are the best-effort
+  `_INCOMPLETE` marker cleanup after a baseline upload and `agent --validate`
+  removing its own connectivity-probe object — never archive data. On a
+  locked (hence versioned) bucket both are *delete markers* — logical
+  deletes that retention permits — so discovery behaves normally and the
+  lifecycle rule above reaps the leftovers. (The probe object's noncurrent
+  version stays billed until its retention expires.) If the marker cleanup
+  ever fails it was already harmless: `_SUCCESS` decides completeness.
 
 There is **no** code path in bintrail that permanently deletes archived data
 from S3. Reclaiming aged archives is deliberately left to your bucket

--- a/docs/s3-iam-policy.md
+++ b/docs/s3-iam-policy.md
@@ -48,10 +48,15 @@ safe; add that action per the table below.
 | `s3:PutObject` | `bintrail rotate --archive-s3`, `bintrail baseline --upload`, `bintrail upload` — writing Parquet archives/baselines to the bucket. Large files stream as S3 multipart uploads, and the `CreateMultipartUpload`/`UploadPart`/`CompleteMultipartUpload` calls are all authorized by `s3:PutObject` — successful uploads of any size need nothing extra |
 | `s3:GetObject` | `bintrail query`/`recover --archive-s3`, `--baseline-s3`/`reconstruct` reads, and the `HeadObject` existence check `bintrail upload --retry` issues (S3 authorizes `HeadObject` under `s3:GetObject` — there's no separate `s3:HeadObject` action) |
 | `s3:ListBucket` | Enumerating archived partitions/baseline snapshots (`ListObjectsV2`), and the bucket-reachability check (`HeadBucket`) `bintrail init --s3-bucket` and `bintrail rotate` run |
-| `s3:DeleteObject` | Removing superseded archives during `archive reconcile --repair --prune`, and baseline upload's own cleanup of its in-progress marker. Optional but recommended — omit it if you'd rather archives/baselines only ever be deleted manually |
+| `s3:DeleteObject` | Baseline upload's own cleanup of its in-progress `_INCOMPLETE` marker, and `agent --validate` removing its connectivity-probe object. No bintrail command deletes archive data from S3 (`archive reconcile --prune` deletes registry rows only). Optional but recommended — omit it if you'd rather nothing in the bucket ever be deleted by bintrail |
 | `s3:AbortMultipartUpload` | Cleaning up after a **failed or interrupted** large upload: the SDK automatically aborts the in-progress multipart upload, and without this permission that abort is `AccessDenied` — the orphaned parts stay in the bucket, invisible in listings but billed as storage. Never used on the success path. Pair it with an [`AbortIncompleteMultipartUpload` lifecycle rule](deployment.md#s3-archive-bucket-abort-orphaned-multipart-uploads) on the bucket as the backstop for uploads that die before the abort can run (crash, `SIGKILL`) |
 
-## One thing this policy deliberately leaves out
+## Two things this policy deliberately leaves out
+
+**`s3:GetBucketObjectLockConfiguration`** is only needed by the advisory
+`bintrail doctor --archive-s3` posture check ([object-lock.md](object-lock.md));
+without it that check reports SKIP and everything else works. Add it as a
+bucket-level action (alongside `s3:ListBucket`) if you use the check.
 
 **`s3:GetBucketLocation`** is not in the policy above. It's only needed if
 your archive/baseline bucket lives in a **different AWS region** than the

--- a/docs/upload.md
+++ b/docs/upload.md
@@ -31,6 +31,11 @@ This recursively walks the source directory and uploads every `*.parquet` file t
 
 ## AWS Credentials
 
+> Uploading to an S3 **Object Lock** bucket (ransomware-proof archives) works
+> with no extra flags — see [object-lock.md](object-lock.md) for the bucket
+> recipe and the `bintrail doctor --archive-s3` posture check.
+
+
 `bintrail upload` uses the standard AWS SDK credential chain. The SDK checks these sources **in order** — the first one that provides valid credentials wins:
 
 ### 1. Environment variables (recommended for CI/CD and automation)

--- a/internal/doctor/objectlock.go
+++ b/internal/doctor/objectlock.go
@@ -67,6 +67,10 @@ func fetchObjectLockState(ctx context.Context, client objectLockAPI, bucket stri
 	if cfg.Rule != nil && cfg.Rule.DefaultRetention != nil {
 		dr := cfg.Rule.DefaultRetention
 		st.mode = string(dr.Mode)
+		// Years are approximated as 365d (S3 adds calendar years, so a leap year
+		// can differ by a day — acceptable for an advisory check whose failure
+		// direction is a spurious WARN). AWS forbids setting both Days and Years;
+		// if a non-AWS store ever returns both, Days wins.
 		if dr.Years != nil {
 			st.retention = time.Duration(*dr.Years) * 365 * 24 * time.Hour
 		}
@@ -80,13 +84,16 @@ func fetchObjectLockState(ctx context.Context, client objectLockAPI, bucket stri
 // objectLockVerdict turns the fetched posture into the check outcome:
 //   - configuration unreadable: SKIP — posture UNKNOWN, never reported as
 //     either safe or unsafe (the anti-cry-wolf rule).
-//   - lock disabled: WARN — archives are deletable; remediation says out
-//     loud that Object Lock can only be enabled at bucket CREATION.
+//   - lock disabled: WARN — archives are deletable; remediation carries the
+//     enable-on-existing-bucket steps (AWS supports that since Nov 2023;
+//     existing objects are NOT retroactively locked).
 //   - lock enabled but no default retention rule: WARN — bintrail uploads
 //     set no per-object retention, so new archives land UNLOCKED.
-//   - default retention shorter than the index retention window: WARN — the
-//     lock expires while the partition is still live, so the object is
-//     already deletable by the time rotation makes it the only copy.
+//   - default retention shorter than the index retention window: WARN —
+//     rotation archives a partition at the moment it drops it, so data the
+//     operator evidently still relies on (it was worth keeping live for the
+//     whole --retain window) would lose deletion protection sooner than
+//     that same window once the archive becomes the only copy.
 //   - otherwise PASS, with the mode and period in the detail (GOVERNANCE
 //     notes its s3:BypassGovernanceRetention escape hatch).
 func objectLockVerdict(bucket string, st objectLockState, retain time.Duration) CheckResult {
@@ -105,11 +112,14 @@ func objectLockVerdict(bucket string, st objectLockState, retain time.Duration) 
 			Name:   ObjectLockCheckName,
 			Status: StatusWarn,
 			Detail: fmt.Sprintf("bucket %q does not have S3 Object Lock enabled — after rotation the Parquet archive is the ONLY copy of a partition, and any credential that can delete S3 objects can erase it (ransomware / compromised key)", bucket),
-			Remediation: "Object Lock can only be enabled when a bucket is CREATED — it cannot be turned on later.\n" +
-				"Create a locked bucket and point --archive-s3 at it (recipe: docs/object-lock.md):\n" +
-				"  aws s3api create-bucket --bucket <name> --object-lock-enabled-for-bucket ...\n" +
-				"  aws s3api put-object-lock-configuration --bucket <name> \\\n" +
-				"    --object-lock-configuration 'ObjectLockEnabled=Enabled,Rule={DefaultRetention={Mode=COMPLIANCE,Days=<retention>}}'",
+			Remediation: "On AWS, Object Lock can be enabled on an EXISTING bucket (since Nov 2023): enable\n" +
+				"versioning first, then apply the lock configuration. Objects already in the bucket\n" +
+				"are NOT retroactively locked — only new writes get the default retention. (Some\n" +
+				"S3-compatible stores still require enabling the lock at bucket creation.)\n" +
+				"  aws s3api put-bucket-versioning --bucket " + bucket + " --versioning-configuration Status=Enabled\n" +
+				"  aws s3api put-object-lock-configuration --bucket " + bucket + " \\\n" +
+				"    --object-lock-configuration 'ObjectLockEnabled=Enabled,Rule={DefaultRetention={Mode=COMPLIANCE,Days=<retention>}}'\n" +
+				"Recipe and threat model: docs/object-lock.md",
 		}
 	}
 	if st.retention <= 0 {
@@ -124,13 +134,17 @@ func objectLockVerdict(bucket string, st objectLockState, retain time.Duration) 
 		}
 	}
 	if retain > 0 && st.retention < retain {
+		mode := st.mode
+		if mode == "" {
+			mode = "COMPLIANCE" // non-AWS stores can omit it; never emit a broken Mode=
+		}
 		return CheckResult{
 			Name:   ObjectLockCheckName,
 			Status: StatusWarn,
-			Detail: fmt.Sprintf("bucket %q default retention %s is SHORTER than the index retention window %s — an archive's lock expires while its partition is still in the live index, so the object is already deletable by the time rotation makes it the only copy", bucket, fmtLockDuration(st.retention), fmtLockDuration(retain)),
+			Detail: fmt.Sprintf("bucket %q default retention %s is SHORTER than the index retention window %s (doctor's --retain — pass your real rotation window if you haven't) — rotation archives a partition at the moment it drops it, so data you kept live for %s stays deletion-protected for only %s once the archive becomes the only copy", bucket, fmtLockDuration(st.retention), fmtLockDuration(retain), fmtLockDuration(retain), fmtLockDuration(st.retention)),
 			Remediation: "Raise the default retention to at least the rotation window:\n" +
 				"  aws s3api put-object-lock-configuration --bucket " + bucket + " \\\n" +
-				"    --object-lock-configuration 'ObjectLockEnabled=Enabled,Rule={DefaultRetention={Mode=" + st.mode + ",Days=" + fmt.Sprintf("%d", int(retain.Hours()/24)+1) + "}}'",
+				"    --object-lock-configuration 'ObjectLockEnabled=Enabled,Rule={DefaultRetention={Mode=" + mode + ",Days=" + fmt.Sprintf("%d", int(retain.Hours()/24)+1) + "}}'",
 		}
 	}
 	detail := fmt.Sprintf("bucket %q: Object Lock enabled, default retention %s %s", bucket, st.mode, fmtLockDuration(st.retention))
@@ -156,9 +170,10 @@ func CheckArchiveObjectLock(ctx context.Context, archiveS3, region string, retai
 	bucket, _, err := storage.ParseS3URL(archiveS3)
 	if err != nil {
 		return CheckResult{
-			Name:   ObjectLockCheckName,
-			Status: StatusWarn,
-			Detail: fmt.Sprintf("invalid --archive-s3 URL %q: %v", archiveS3, err),
+			Name:        ObjectLockCheckName,
+			Status:      StatusWarn,
+			Detail:      fmt.Sprintf("invalid --archive-s3 URL %q: %v", archiveS3, err),
+			Remediation: "Pass an s3:// URL, e.g. s3://my-bucket/archives/",
 		}
 	}
 	ctx, cancel := context.WithTimeout(ctx, objectLockBudget)

--- a/internal/doctor/objectlock.go
+++ b/internal/doctor/objectlock.go
@@ -96,6 +96,7 @@ func objectLockVerdict(bucket string, st objectLockState, retain time.Duration) 
 			Status: StatusSkip,
 			Detail: fmt.Sprintf("could not read the Object Lock configuration of bucket %q: %v", bucket, st.queryErr),
 			Remediation: "The check needs the s3:GetBucketObjectLockConfiguration permission on the bucket.\n" +
+				"A PermanentRedirect means the bucket lives in a different region — pass --archive-s3-region.\n" +
 				"If the endpoint was unreachable, retry once before investigating further.",
 		}
 	}

--- a/internal/doctor/objectlock.go
+++ b/internal/doctor/objectlock.go
@@ -1,0 +1,170 @@
+package doctor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
+
+	"github.com/dbtrail/dbtrail/internal/storage"
+)
+
+// The Object Lock check reports the ransomware posture of the S3 archive
+// bucket (#1197). After rotation drops a partition from the live index, its
+// Parquet archive is the ONLY copy — a credential that can delete S3 objects
+// can erase the recovery safety net. S3 Object Lock with a default retention
+// rule makes archived objects immutable for the retention period, and this
+// check tells the operator whether that protection is actually in force.
+//
+// The check is ADVISORY (WARN/SKIP only, never FAIL): running without Object
+// Lock is a legitimate posture, and doctor must stay safe as a CI smoke test.
+
+// ObjectLockCheckName is the check's display name.
+const ObjectLockCheckName = "Archive S3 Object Lock"
+
+// objectLockBudget bounds the S3 round trip so an unreachable endpoint cannot
+// stall the report (same rationale as doctor.Build's internal budget).
+const objectLockBudget = 10 * time.Second
+
+// objectLockState is the fetched bucket posture, separated from the verdict
+// so the WARN thresholds are unit-testable without a live bucket (the
+// capacity.go pattern).
+type objectLockState struct {
+	queryErr   error         // the configuration could not be read (network/permission)
+	notEnabled bool          // the bucket has Object Lock disabled
+	mode       string        // default-retention mode (GOVERNANCE/COMPLIANCE); "" = no default rule
+	retention  time.Duration // default-retention period; 0 = no default rule
+}
+
+// objectLockAPI is the one S3 operation the check performs — an interface so
+// the error classification is testable with a mock.
+type objectLockAPI interface {
+	GetObjectLockConfiguration(ctx context.Context, params *s3.GetObjectLockConfigurationInput, optFns ...func(*s3.Options)) (*s3.GetObjectLockConfigurationOutput, error)
+}
+
+// fetchObjectLockState reads the bucket's Object Lock configuration and
+// classifies the outcome. A disabled bucket surfaces as the API error
+// ObjectLockConfigurationNotFoundError, not as an empty configuration.
+func fetchObjectLockState(ctx context.Context, client objectLockAPI, bucket string) objectLockState {
+	out, err := client.GetObjectLockConfiguration(ctx, &s3.GetObjectLockConfigurationInput{Bucket: aws.String(bucket)})
+	if err != nil {
+		var ae smithy.APIError
+		if errors.As(err, &ae) && ae.ErrorCode() == "ObjectLockConfigurationNotFoundError" {
+			return objectLockState{notEnabled: true}
+		}
+		return objectLockState{queryErr: err}
+	}
+	cfg := out.ObjectLockConfiguration
+	if cfg == nil || cfg.ObjectLockEnabled != types.ObjectLockEnabledEnabled {
+		return objectLockState{notEnabled: true}
+	}
+	var st objectLockState
+	if cfg.Rule != nil && cfg.Rule.DefaultRetention != nil {
+		dr := cfg.Rule.DefaultRetention
+		st.mode = string(dr.Mode)
+		if dr.Years != nil {
+			st.retention = time.Duration(*dr.Years) * 365 * 24 * time.Hour
+		}
+		if dr.Days != nil {
+			st.retention = time.Duration(*dr.Days) * 24 * time.Hour
+		}
+	}
+	return st
+}
+
+// objectLockVerdict turns the fetched posture into the check outcome:
+//   - configuration unreadable: SKIP — posture UNKNOWN, never reported as
+//     either safe or unsafe (the anti-cry-wolf rule).
+//   - lock disabled: WARN — archives are deletable; remediation says out
+//     loud that Object Lock can only be enabled at bucket CREATION.
+//   - lock enabled but no default retention rule: WARN — bintrail uploads
+//     set no per-object retention, so new archives land UNLOCKED.
+//   - default retention shorter than the index retention window: WARN — the
+//     lock expires while the partition is still live, so the object is
+//     already deletable by the time rotation makes it the only copy.
+//   - otherwise PASS, with the mode and period in the detail (GOVERNANCE
+//     notes its s3:BypassGovernanceRetention escape hatch).
+func objectLockVerdict(bucket string, st objectLockState, retain time.Duration) CheckResult {
+	if st.queryErr != nil {
+		return CheckResult{
+			Name:   ObjectLockCheckName,
+			Status: StatusSkip,
+			Detail: fmt.Sprintf("could not read the Object Lock configuration of bucket %q: %v", bucket, st.queryErr),
+			Remediation: "The check needs the s3:GetBucketObjectLockConfiguration permission on the bucket.\n" +
+				"If the endpoint was unreachable, retry once before investigating further.",
+		}
+	}
+	if st.notEnabled {
+		return CheckResult{
+			Name:   ObjectLockCheckName,
+			Status: StatusWarn,
+			Detail: fmt.Sprintf("bucket %q does not have S3 Object Lock enabled — after rotation the Parquet archive is the ONLY copy of a partition, and any credential that can delete S3 objects can erase it (ransomware / compromised key)", bucket),
+			Remediation: "Object Lock can only be enabled when a bucket is CREATED — it cannot be turned on later.\n" +
+				"Create a locked bucket and point --archive-s3 at it (recipe: docs/object-lock.md):\n" +
+				"  aws s3api create-bucket --bucket <name> --object-lock-enabled-for-bucket ...\n" +
+				"  aws s3api put-object-lock-configuration --bucket <name> \\\n" +
+				"    --object-lock-configuration 'ObjectLockEnabled=Enabled,Rule={DefaultRetention={Mode=COMPLIANCE,Days=<retention>}}'",
+		}
+	}
+	if st.retention <= 0 {
+		return CheckResult{
+			Name:   ObjectLockCheckName,
+			Status: StatusWarn,
+			Detail: fmt.Sprintf("bucket %q has Object Lock enabled but NO default retention rule — bintrail uploads set no per-object retention, so new archives are written unlocked", bucket),
+			Remediation: "Set a default retention rule so every uploaded archive is locked automatically:\n" +
+				"  aws s3api put-object-lock-configuration --bucket " + bucket + " \\\n" +
+				"    --object-lock-configuration 'ObjectLockEnabled=Enabled,Rule={DefaultRetention={Mode=COMPLIANCE,Days=<retention>}}'\n" +
+				"Pick Days to cover at least your index retention window (rotate --retain) plus the window you want deletion protection for. See docs/object-lock.md.",
+		}
+	}
+	if retain > 0 && st.retention < retain {
+		return CheckResult{
+			Name:   ObjectLockCheckName,
+			Status: StatusWarn,
+			Detail: fmt.Sprintf("bucket %q default retention %s is SHORTER than the index retention window %s — an archive's lock expires while its partition is still in the live index, so the object is already deletable by the time rotation makes it the only copy", bucket, fmtLockDuration(st.retention), fmtLockDuration(retain)),
+			Remediation: "Raise the default retention to at least the rotation window:\n" +
+				"  aws s3api put-object-lock-configuration --bucket " + bucket + " \\\n" +
+				"    --object-lock-configuration 'ObjectLockEnabled=Enabled,Rule={DefaultRetention={Mode=" + st.mode + ",Days=" + fmt.Sprintf("%d", int(retain.Hours()/24)+1) + "}}'",
+		}
+	}
+	detail := fmt.Sprintf("bucket %q: Object Lock enabled, default retention %s %s", bucket, st.mode, fmtLockDuration(st.retention))
+	if st.mode == string(types.ObjectLockRetentionModeGovernance) {
+		detail += " (GOVERNANCE mode: principals holding s3:BypassGovernanceRetention can still delete; COMPLIANCE binds every principal including root)"
+	}
+	return CheckResult{Name: ObjectLockCheckName, Status: StatusPass, Detail: detail}
+}
+
+// fmtLockDuration renders whole days as "Nd" and falls back to the standard
+// duration string otherwise.
+func fmtLockDuration(d time.Duration) string {
+	if d > 0 && d%(24*time.Hour) == 0 {
+		return fmt.Sprintf("%dd", int(d/(24*time.Hour)))
+	}
+	return d.String()
+}
+
+// CheckArchiveObjectLock reports the Object Lock posture of the --archive-s3
+// bucket. retain is doctor's --retain window (0 = no rotation configured —
+// the retention comparison is skipped, the posture checks still run).
+func CheckArchiveObjectLock(ctx context.Context, archiveS3, region string, retain time.Duration) CheckResult {
+	bucket, _, err := storage.ParseS3URL(archiveS3)
+	if err != nil {
+		return CheckResult{
+			Name:   ObjectLockCheckName,
+			Status: StatusWarn,
+			Detail: fmt.Sprintf("invalid --archive-s3 URL %q: %v", archiveS3, err),
+		}
+	}
+	ctx, cancel := context.WithTimeout(ctx, objectLockBudget)
+	defer cancel()
+	client, err := storage.NewS3Client(ctx, region)
+	if err != nil {
+		return objectLockVerdict(bucket, objectLockState{queryErr: err}, retain)
+	}
+	return objectLockVerdict(bucket, fetchObjectLockState(ctx, client, bucket), retain)
+}

--- a/internal/doctor/objectlock_test.go
+++ b/internal/doctor/objectlock_test.go
@@ -1,0 +1,171 @@
+package doctor
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
+)
+
+func day(n int) time.Duration { return time.Duration(n) * 24 * time.Hour }
+
+func TestObjectLockVerdict(t *testing.T) {
+	tests := []struct {
+		name       string
+		st         objectLockState
+		retain     time.Duration
+		wantStatus CheckStatus
+		wantDetail string // substring
+	}{
+		{
+			name:       "unreadable config is SKIP, never a posture claim",
+			st:         objectLockState{queryErr: errors.New("api error AccessDenied")},
+			retain:     day(30),
+			wantStatus: StatusSkip,
+			wantDetail: "could not read",
+		},
+		{
+			name:       "lock disabled warns",
+			st:         objectLockState{notEnabled: true},
+			retain:     day(30),
+			wantStatus: StatusWarn,
+			wantDetail: "does not have S3 Object Lock enabled",
+		},
+		{
+			name:       "enabled without default rule warns (uploads set no per-object retention)",
+			st:         objectLockState{},
+			retain:     day(30),
+			wantStatus: StatusWarn,
+			wantDetail: "NO default retention rule",
+		},
+		{
+			name:       "retention shorter than the rotation window warns",
+			st:         objectLockState{mode: "COMPLIANCE", retention: day(7)},
+			retain:     day(30),
+			wantStatus: StatusWarn,
+			wantDetail: "SHORTER than the index retention window",
+		},
+		{
+			name:       "retention covering the window passes",
+			st:         objectLockState{mode: "COMPLIANCE", retention: day(30)},
+			retain:     day(30),
+			wantStatus: StatusPass,
+			wantDetail: "default retention COMPLIANCE 30d",
+		},
+		{
+			name:       "no rotation configured skips the comparison but still passes on posture",
+			st:         objectLockState{mode: "COMPLIANCE", retention: day(7)},
+			retain:     0,
+			wantStatus: StatusPass,
+			wantDetail: "7d",
+		},
+		{
+			name:       "governance pass names its bypass escape hatch",
+			st:         objectLockState{mode: "GOVERNANCE", retention: day(90)},
+			retain:     day(30),
+			wantStatus: StatusPass,
+			wantDetail: "s3:BypassGovernanceRetention",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := objectLockVerdict("my-bucket", tt.st, tt.retain)
+			if got.Name != ObjectLockCheckName {
+				t.Fatalf("Name = %q", got.Name)
+			}
+			if got.Status != tt.wantStatus {
+				t.Fatalf("Status = %q, want %q (detail: %s)", got.Status, tt.wantStatus, got.Detail)
+			}
+			if !strings.Contains(got.Detail, tt.wantDetail) {
+				t.Fatalf("Detail %q does not contain %q", got.Detail, tt.wantDetail)
+			}
+		})
+	}
+}
+
+// mockLockAPI returns a fixed response or error.
+type mockLockAPI struct {
+	out *s3.GetObjectLockConfigurationOutput
+	err error
+}
+
+func (m mockLockAPI) GetObjectLockConfiguration(context.Context, *s3.GetObjectLockConfigurationInput, ...func(*s3.Options)) (*s3.GetObjectLockConfigurationOutput, error) {
+	return m.out, m.err
+}
+
+func TestFetchObjectLockState(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("NotFound API error means lock disabled, not a query failure", func(t *testing.T) {
+		st := fetchObjectLockState(ctx, mockLockAPI{err: &smithy.GenericAPIError{Code: "ObjectLockConfigurationNotFoundError"}}, "b")
+		if !st.notEnabled || st.queryErr != nil {
+			t.Fatalf("got %+v, want notEnabled", st)
+		}
+	})
+
+	t.Run("other errors are query failures, never a posture claim", func(t *testing.T) {
+		st := fetchObjectLockState(ctx, mockLockAPI{err: &smithy.GenericAPIError{Code: "AccessDenied"}}, "b")
+		if st.queryErr == nil || st.notEnabled {
+			t.Fatalf("got %+v, want queryErr", st)
+		}
+	})
+
+	t.Run("enabled with a Days default rule", func(t *testing.T) {
+		st := fetchObjectLockState(ctx, mockLockAPI{out: &s3.GetObjectLockConfigurationOutput{
+			ObjectLockConfiguration: &types.ObjectLockConfiguration{
+				ObjectLockEnabled: types.ObjectLockEnabledEnabled,
+				Rule: &types.ObjectLockRule{DefaultRetention: &types.DefaultRetention{
+					Mode: types.ObjectLockRetentionModeCompliance,
+					Days: aws.Int32(30),
+				}},
+			},
+		}}, "b")
+		if st.retention != day(30) || st.mode != "COMPLIANCE" {
+			t.Fatalf("got %+v", st)
+		}
+	})
+
+	t.Run("enabled with a Years default rule", func(t *testing.T) {
+		st := fetchObjectLockState(ctx, mockLockAPI{out: &s3.GetObjectLockConfigurationOutput{
+			ObjectLockConfiguration: &types.ObjectLockConfiguration{
+				ObjectLockEnabled: types.ObjectLockEnabledEnabled,
+				Rule: &types.ObjectLockRule{DefaultRetention: &types.DefaultRetention{
+					Mode:  types.ObjectLockRetentionModeGovernance,
+					Years: aws.Int32(1),
+				}},
+			},
+		}}, "b")
+		if st.retention != day(365) || st.mode != "GOVERNANCE" {
+			t.Fatalf("got %+v", st)
+		}
+	})
+
+	t.Run("enabled without a rule", func(t *testing.T) {
+		st := fetchObjectLockState(ctx, mockLockAPI{out: &s3.GetObjectLockConfigurationOutput{
+			ObjectLockConfiguration: &types.ObjectLockConfiguration{ObjectLockEnabled: types.ObjectLockEnabledEnabled},
+		}}, "b")
+		if st.notEnabled || st.queryErr != nil || st.retention != 0 || st.mode != "" {
+			t.Fatalf("got %+v, want enabled with zero rule", st)
+		}
+	})
+
+	t.Run("nil configuration counts as disabled", func(t *testing.T) {
+		st := fetchObjectLockState(ctx, mockLockAPI{out: &s3.GetObjectLockConfigurationOutput{}}, "b")
+		if !st.notEnabled {
+			t.Fatalf("got %+v, want notEnabled", st)
+		}
+	})
+}
+
+func TestCheckArchiveObjectLockBadURL(t *testing.T) {
+	got := CheckArchiveObjectLock(context.Background(), "not-an-s3-url", "", day(30))
+	if got.Status != StatusWarn || !strings.Contains(got.Detail, "invalid --archive-s3") {
+		t.Fatalf("got %+v", got)
+	}
+}

--- a/internal/doctor/objectlock_test.go
+++ b/internal/doctor/objectlock_test.go
@@ -89,6 +89,29 @@ func TestObjectLockVerdict(t *testing.T) {
 	}
 }
 
+// TestObjectLockVerdictNeverFails sweeps a grid of states and pins the
+// advisory contract: no combination may return StatusFail — doctor must stay
+// safe as a CI smoke test for operators who legitimately run without Object
+// Lock. Unlike the per-case table, this survives future branch additions.
+func TestObjectLockVerdictNeverFails(t *testing.T) {
+	states := []objectLockState{
+		{},
+		{queryErr: errors.New("boom")},
+		{notEnabled: true},
+		{mode: "COMPLIANCE"},
+		{mode: "GOVERNANCE", retention: day(7)},
+		{mode: "COMPLIANCE", retention: day(30)},
+		{retention: day(7)}, // non-AWS: retention without a mode
+	}
+	for _, st := range states {
+		for _, retain := range []time.Duration{0, day(7), day(30)} {
+			if got := objectLockVerdict("b", st, retain); got.Status == StatusFail {
+				t.Fatalf("state %+v retain %v returned StatusFail — the check is advisory", st, retain)
+			}
+		}
+	}
+}
+
 // mockLockAPI returns a fixed response or error.
 type mockLockAPI struct {
 	out *s3.GetObjectLockConfigurationOutput
@@ -111,6 +134,13 @@ func TestFetchObjectLockState(t *testing.T) {
 
 	t.Run("other errors are query failures, never a posture claim", func(t *testing.T) {
 		st := fetchObjectLockState(ctx, mockLockAPI{err: &smithy.GenericAPIError{Code: "AccessDenied"}}, "b")
+		if st.queryErr == nil || st.notEnabled {
+			t.Fatalf("got %+v, want queryErr", st)
+		}
+	})
+
+	t.Run("plain non-API errors (network/timeout) are query failures, never lock-disabled", func(t *testing.T) {
+		st := fetchObjectLockState(ctx, mockLockAPI{err: errors.New("dial tcp: i/o timeout")}, "b")
 		if st.queryErr == nil || st.notEnabled {
 			t.Fatalf("got %+v, want queryErr", st)
 		}


### PR DESCRIPTION
closes #1197 · part of the continuous backup assurance epic #1189

## Summary
- **Finding first**: bintrail already works on an S3 Object Lock bucket with zero code changes. Writes carry the checksum Object Lock requires (SDK default CRC32, single-part and multipart); and there is **no code path that permanently deletes archived data from S3** — `reconcile --prune` deletes registry rows only, the baseline prune deletes local directories only, and the one `DeleteObject` (best-effort `_INCOMPLETE` marker cleanup) is a versionless delete that places a delete marker, which retention permits. The issue's "classify locked deletes as `retained`" scenario has no delete site to attach to — verified and documented instead of coded.
- **`bintrail doctor --archive-s3 s3://bucket/prefix`**: advisory Object Lock posture check (WARN/SKIP only — doctor stays CI-safe). Warns on: lock disabled (remediation says lock is creation-time only), enabled without a default retention rule (bintrail sets no per-object retention → new archives land **unlocked**), and default retention shorter than `--retain` (the lock expires while the partition is still live — the object is deletable exactly when it becomes the only copy). Unreadable config → SKIP: posture UNKNOWN is never reported as safe or unsafe. GOVERNANCE PASS names its `s3:BypassGovernanceRetention` escape hatch. Flag names ride the existing `BINTRAIL_ARCHIVE_S3`/`_REGION` env bindings.
- **`docs/object-lock.md`**: threat model, creation-time bucket recipe (COMPLIANCE default retention + lifecycle reaping noncurrent versions and delete markers after the lock expires), retention-vs-retain arithmetic, and the verified out-of-the-box list. Linked from `index-recovery.md` and `upload.md`.

## Test plan
- [x] Unit tests: verdict table (disabled / no-rule / short-retention / pass / retain=0 / GOVERNANCE note / SKIP), fetch error classification (NotFound=disabled vs AccessDenied=queryErr), Days/Years rules, bad URL
- [x] `go build ./...`, `go vet -tags integration ./...`, `go test -race` on touched packages
- [x] Full unit suite ALL-GREEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)
