### PR TITLE
status: scope the baseline-staleness floor per source on multi-source indexes

### DIFF
--- a/consoleapp/notify.go
+++ b/consoleapp/notify.go
@@ -259,7 +259,7 @@ type stalenessWatcher struct {
 
 	// Injectable for tests — no ticker, no real DB, no real S3.
 	listBaselines func(ctx context.Context, source string) ([]reconstruct.BaselineFile, error)
-	oldestDelta   func(ctx context.Context, dsn string) (time.Time, error)
+	oldestDelta   func(ctx context.Context, dsn string) (status.DeltaFloor, error)
 }
 
 func startStalenessWatch(ctx context.Context, n *watchNotifier, registry *console.Registry, bootDSN, globalDir, globalS3 string) {
@@ -359,8 +359,8 @@ func (w *stalenessWatcher) runCycle(ctx context.Context) {
 			continue
 		}
 		w.unknownEdge.Resolve("staleness-empty:" + edgeID)
-		oldest, err := w.oldestDelta(ctx, t.dsn)
-		if err != nil || oldest.IsZero() {
+		floor, err := w.oldestDelta(ctx, t.dsn)
+		if err != nil || floor.Hour.IsZero() {
 			// Unknown floor is never a verdict — and must never RESOLVE an
 			// active broken alert either, so the target is skipped whole.
 			// Skipped, not silent: same rule as the unreadable source above.
@@ -383,21 +383,40 @@ func (w *stalenessWatcher) runCycle(ctx context.Context) {
 		// identity, and a map-iteration-ordered single pick would flip
 		// between cycles and re-fire through the repeat window.
 		var brokenTables []string
+		var ungradable bool
 		for k, ts := range newest {
-			if status.BaselineStalenessFor(ts, oldest, now) == status.BaselineBroken {
+			switch floor.Grade(ts, now) {
+			case status.BaselineBroken:
 				brokenTables = append(brokenTables, k)
+			case status.BaselineUnknown:
+				ungradable = ungradable || floor.BelowIsUnknown
 			}
 		}
+		if ungradable {
+			// #1219: on a multi-source index the archives cannot be attributed
+			// to the source that owns these baselines, so a snapshot older than
+			// the live window is unknowable. It must NOT fall through to the
+			// call below: with no broken table left, that call reports
+			// broken=false and RESOLVES an active alert — adding a second
+			// source to an index would silently clear a real broken-baseline
+			// alert. Skip the target whole, exactly like an unknown floor.
+			if w.unknownEdge.Fire("staleness-attribution:"+edgeID, "") {
+				slog.Warn("baseline staleness cannot be evaluated for snapshots older than the live index window — this index serves more than one source and archive coverage cannot be attributed to one of them; a broken restore window would go UNDETECTED for this server",
+					"server", t.name, "source", t.source, "live_floor", floor.Hour.UTC().Format(time.RFC3339))
+			}
+			continue
+		}
+		w.unknownEdge.Resolve("staleness-attribution:" + edgeID)
 		sort.Strings(brokenTables)
 		w.n.BaselineStale(t.name, edgeID, len(brokenTables) > 0,
-			strings.Join(brokenTables, ", "), oldest.UTC().Format(time.RFC3339))
+			strings.Join(brokenTables, ", "), floor.Hour.UTC().Format(time.RFC3339))
 	}
 }
 
-func oldestDeltaByDSN(ctx context.Context, dsn string) (time.Time, error) {
+func oldestDeltaByDSN(ctx context.Context, dsn string) (status.DeltaFloor, error) {
 	db, err := config.Connect(dsn)
 	if err != nil {
-		return time.Time{}, err
+		return status.DeltaFloor{}, err
 	}
 	defer db.Close()
 	return status.OldestDeltaFromDB(ctx, db, indexDBName(dsn))

--- a/consoleapp/notify.go
+++ b/consoleapp/notify.go
@@ -389,7 +389,10 @@ func (w *stalenessWatcher) runCycle(ctx context.Context) {
 			case status.BaselineBroken:
 				brokenTables = append(brokenTables, k)
 			case status.BaselineUnknown:
-				ungradable = ungradable || floor.BelowIsUnknown
+				// Keyed on the VERDICT, not on the floor flag: whatever makes
+				// a table ungradable, grading the rest and reporting
+				// broken=false below would resolve on partial evidence.
+				ungradable = true
 			}
 		}
 		if ungradable {
@@ -400,9 +403,14 @@ func (w *stalenessWatcher) runCycle(ctx context.Context) {
 			// broken=false and RESOLVES an active alert — adding a second
 			// source to an index would silently clear a real broken-baseline
 			// alert. Skip the target whole, exactly like an unknown floor.
+			reason := "a baseline snapshot carries no usable timestamp"
+			if floor.BelowIsUnknown {
+				reason = "this index serves more than one source, so archived coverage below the live index window cannot be attributed to the source that owns these baselines"
+			}
 			if w.unknownEdge.Fire("staleness-attribution:"+edgeID, "") {
-				slog.Warn("baseline staleness cannot be evaluated for snapshots older than the live index window — this index serves more than one source and archive coverage cannot be attributed to one of them; a broken restore window would go UNDETECTED for this server",
-					"server", t.name, "source", t.source, "live_floor", floor.Hour.UTC().Format(time.RFC3339))
+				slog.Warn("baseline staleness cannot be evaluated for at least one table; a broken restore window would go UNDETECTED for this server",
+					"server", t.name, "source", t.source, "reason", reason,
+					"live_floor", floor.Hour.UTC().Format(time.RFC3339))
 			}
 			continue
 		}

--- a/consoleapp/staleness_test.go
+++ b/consoleapp/staleness_test.go
@@ -42,12 +42,21 @@ func TestStalenessWatcher_unattributableFloorNeverResolves(t *testing.T) {
 		t.Fatalf("an unattributable floor must neither resolve nor re-fire: %+v", f.events)
 	}
 
+	if !w.unknownEdge.Active("staleness-attribution:d1\x1f/b") {
+		t.Fatal("the cannot-evaluate condition must be latched, or it re-warns every cycle")
+	}
+
 	// Attribution is restored and the baseline is still broken: the edge was
 	// never resolved, so the standing alert must not re-fire either.
 	floor.BelowIsUnknown = false
 	w.runCycle(context.Background())
 	if len(f.events) != 1 {
 		t.Fatalf("unchanged broken condition must not re-fire: %+v", f.events)
+	}
+	// ...and the cannot-evaluate latch must be RELEASED, or a later relapse
+	// would be swallowed by the repeat window and never warned about again.
+	if w.unknownEdge.Active("staleness-attribution:d1\x1f/b") {
+		t.Fatal("attribution recovered: the unknown edge must be resolved")
 	}
 }
 

--- a/consoleapp/staleness_test.go
+++ b/consoleapp/staleness_test.go
@@ -9,7 +9,71 @@ import (
 	"github.com/dbtrail/dbtrail/internal/console"
 	"github.com/dbtrail/dbtrail/internal/notify"
 	"github.com/dbtrail/dbtrail/internal/reconstruct"
+	"github.com/dbtrail/dbtrail/internal/status"
 )
+
+// TestStalenessWatcher_unattributableFloorNeverResolves is the load-bearing
+// half of #1219: on a multi-source index a snapshot older than the live
+// window grades UNKNOWN, and an unknown verdict must never travel the
+// broken=false path — that call RESOLVES. Without the skip, adding a second
+// source to an index would silently clear a standing broken-baseline alert
+// while the restore window is just as broken as before.
+func TestStalenessWatcher_unattributableFloorNeverResolves(t *testing.T) {
+	reg := testRegistryWithEntries(t, console.ServerEntry{Name: "wp", DSN: "d1", BaselineDir: "/b"})
+	now := time.Now().UTC()
+	oldest := now.Add(-100 * time.Hour)
+	n, f := testNotifier()
+	files := []reconstruct.BaselineFile{{Schema: "shop", Table: "orders", SnapshotTime: oldest.Add(-time.Hour)}}
+	floor := status.DeltaFloor{Hour: oldest}
+	w := &stalenessWatcher{
+		n: n, registry: reg, unknownEdge: notify.NewEdge(0),
+		listBaselines: func(context.Context, string) ([]reconstruct.BaselineFile, error) { return files, nil },
+		oldestDelta:   func(context.Context, string) (status.DeltaFloor, error) { return floor, nil },
+	}
+	w.runCycle(context.Background())
+	if len(f.events) != 1 || f.events[0].Resolved {
+		t.Fatalf("setup: want the broken alert active, got %+v", f.events)
+	}
+
+	// A second source appears: the archive floor is no longer attributable.
+	floor.BelowIsUnknown = true
+	w.runCycle(context.Background())
+	if len(f.events) != 1 {
+		t.Fatalf("an unattributable floor must neither resolve nor re-fire: %+v", f.events)
+	}
+
+	// Attribution is restored and the baseline is still broken: the edge was
+	// never resolved, so the standing alert must not re-fire either.
+	floor.BelowIsUnknown = false
+	w.runCycle(context.Background())
+	if len(f.events) != 1 {
+		t.Fatalf("unchanged broken condition must not re-fire: %+v", f.events)
+	}
+}
+
+// TestStalenessWatcher_unattributableStillGradesInWindow: ambiguity only
+// disarms grading BELOW the live floor. Snapshots inside the live window need
+// no attribution (every source writes the same partitions), so a healthy
+// multi-source index still gets a real verdict instead of a permanent
+// cannot-evaluate.
+func TestStalenessWatcher_unattributableStillGradesInWindow(t *testing.T) {
+	reg := testRegistryWithEntries(t, console.ServerEntry{Name: "wp", DSN: "d1", BaselineDir: "/b"})
+	now := time.Now().UTC()
+	oldest := now.Add(-100 * time.Hour)
+	n, f := testNotifier()
+	files := []reconstruct.BaselineFile{{Schema: "shop", Table: "orders", SnapshotTime: now.Add(-time.Hour)}}
+	w := &stalenessWatcher{
+		n: n, registry: reg, unknownEdge: notify.NewEdge(0),
+		listBaselines: func(context.Context, string) ([]reconstruct.BaselineFile, error) { return files, nil },
+		oldestDelta: func(context.Context, string) (status.DeltaFloor, error) {
+			return status.DeltaFloor{Hour: oldest, BelowIsUnknown: true}, nil
+		},
+	}
+	w.runCycle(context.Background())
+	if len(f.events) != 0 {
+		t.Fatalf("a fresh baseline on a multi-source index must grade clean: %+v", f.events)
+	}
+}
 
 func TestWatchNotifier_BaselineStale(t *testing.T) {
 	n, f := testNotifier()
@@ -85,7 +149,7 @@ func TestStalenessWatcher_runCycle(t *testing.T) {
 		n: n, registry: reg,
 		unknownEdge:   notify.NewEdge(0),
 		listBaselines: func(context.Context, string) ([]reconstruct.BaselineFile, error) { return files, nil },
-		oldestDelta:   func(context.Context, string) (time.Time, error) { return oldest, nil },
+		oldestDelta:   func(context.Context, string) (status.DeltaFloor, error) { return status.DeltaFloor{Hour: oldest}, nil },
 	}
 
 	// Newest per table is fine: no event.
@@ -110,7 +174,9 @@ func TestStalenessWatcher_runCycle(t *testing.T) {
 
 	// Same broken set on the next cycle, floor advanced by rotation: silent.
 	oldestAdvanced := oldest.Add(time.Hour)
-	w.oldestDelta = func(context.Context, string) (time.Time, error) { return oldestAdvanced, nil }
+	w.oldestDelta = func(context.Context, string) (status.DeltaFloor, error) {
+		return status.DeltaFloor{Hour: oldestAdvanced}, nil
+	}
 	w.runCycle(context.Background())
 	if len(f.events) != 1 {
 		t.Fatalf("unchanged broken set with an advanced floor must not re-fire: %+v", f.events)
@@ -118,14 +184,18 @@ func TestStalenessWatcher_runCycle(t *testing.T) {
 
 	// Unknown floor: the target is skipped whole — no fire, and crucially NO
 	// resolve of the active alert.
-	w.oldestDelta = func(context.Context, string) (time.Time, error) { return time.Time{}, errors.New("index down") }
+	w.oldestDelta = func(context.Context, string) (status.DeltaFloor, error) {
+		return status.DeltaFloor{}, errors.New("index down")
+	}
 	w.runCycle(context.Background())
 	if len(f.events) != 1 {
 		t.Fatalf("unknown floor must neither fire nor resolve: %+v", f.events)
 	}
 
 	// Unreadable baseline source: same skip-whole rule.
-	w.oldestDelta = func(context.Context, string) (time.Time, error) { return oldestAdvanced, nil }
+	w.oldestDelta = func(context.Context, string) (status.DeltaFloor, error) {
+		return status.DeltaFloor{Hour: oldestAdvanced}, nil
+	}
 	w.listBaselines = func(context.Context, string) ([]reconstruct.BaselineFile, error) {
 		return nil, errors.New("bucket gone")
 	}
@@ -159,7 +229,7 @@ func TestStalenessWatcher_agingNeverFires(t *testing.T) {
 	w := &stalenessWatcher{
 		n: n, registry: reg, unknownEdge: notify.NewEdge(0),
 		listBaselines: func(context.Context, string) ([]reconstruct.BaselineFile, error) { return files, nil },
-		oldestDelta:   func(context.Context, string) (time.Time, error) { return oldest, nil },
+		oldestDelta:   func(context.Context, string) (status.DeltaFloor, error) { return status.DeltaFloor{Hour: oldest}, nil },
 	}
 	w.runCycle(context.Background())
 	if len(f.events) != 0 {
@@ -185,7 +255,7 @@ func TestStalenessWatcher_targetIsolation(t *testing.T) {
 			}
 			return []reconstruct.BaselineFile{{Schema: "shop", Table: "orders", SnapshotTime: oldest.Add(-time.Hour)}}, nil
 		},
-		oldestDelta: func(context.Context, string) (time.Time, error) { return oldest, nil },
+		oldestDelta: func(context.Context, string) (status.DeltaFloor, error) { return status.DeltaFloor{Hour: oldest}, nil },
 	}
 	w.runCycle(context.Background())
 	if len(f.events) != 1 || f.events[0].Server != "b" || f.events[0].Severity != "critical" {
@@ -213,7 +283,7 @@ func TestStalenessWatcher_sameDSNDifferentSources(t *testing.T) {
 			}
 			return []reconstruct.BaselineFile{{Schema: "shop", Table: "orders", SnapshotTime: ts}}, nil
 		},
-		oldestDelta: func(context.Context, string) (time.Time, error) { return oldest, nil },
+		oldestDelta: func(context.Context, string) (status.DeltaFloor, error) { return status.DeltaFloor{Hour: oldest}, nil },
 	}
 	w.runCycle(context.Background())
 	w.runCycle(context.Background())
@@ -234,7 +304,7 @@ func TestStalenessWatcher_emptyListingKeepsAlert(t *testing.T) {
 	w := &stalenessWatcher{
 		n: n, registry: reg, unknownEdge: notify.NewEdge(0),
 		listBaselines: func(context.Context, string) ([]reconstruct.BaselineFile, error) { return files, nil },
-		oldestDelta:   func(context.Context, string) (time.Time, error) { return oldest, nil },
+		oldestDelta:   func(context.Context, string) (status.DeltaFloor, error) { return status.DeltaFloor{Hour: oldest}, nil },
 	}
 	w.runCycle(context.Background())
 	if len(f.events) != 1 {

--- a/docs/rotation-and-status.md
+++ b/docs/rotation-and-status.md
@@ -633,7 +633,12 @@ coverage for another would hide a genuinely broken restore window, and
 declaring it broken would page you over archives that are perfectly fine.
 The `watch` daemon reports those servers as *cannot be evaluated* (rate
 limited to one warning per day) and — deliberately — never resolves a
-standing `baseline_stale` alert on that basis. To grade them, keep one
-source per index database, or verify the window directly with
-`bintrail reconstruct` (its planner gap check is source-exact at restore
-time).
+standing `baseline_stale` alert on that basis. The way to get a graded
+verdict is to keep one source per index database.
+
+Do **not** read reconstruct's gap check as the source-exact fallback: its
+planner classifies an hour as covered when *any* source archived it
+(`archive_state` is scanned unscoped), so on a multi-source index it can
+pass a window the graded source does not actually have. The honest check
+there is to restore into a scratch target and compare — see
+[drill.md](drill.md).

--- a/docs/rotation-and-status.md
+++ b/docs/rotation-and-status.md
@@ -622,3 +622,18 @@ The `watch` daemon's webhook channel sends a critical `baseline_stale`
 event on the transition into broken (see
 [console.md](console.md#webhook-notifications)). The fix is always the
 same: take a fresh baseline (`bintrail dump` + `bintrail baseline`).
+
+**Indexes capturing more than one source**: live partitions are shared by
+every source, so the live floor needs no attribution — but archived
+partitions are per-source, and a baseline snapshot carries no source
+identity. On a multi-source index the archives therefore do **not** extend
+the floor, and any snapshot older than the oldest live partition grades
+`unknown` instead of `ok` or `broken`: claiming one source's archive
+coverage for another would hide a genuinely broken restore window, and
+declaring it broken would page you over archives that are perfectly fine.
+The `watch` daemon reports those servers as *cannot be evaluated* (rate
+limited to one warning per day) and — deliberately — never resolves a
+standing `baseline_stale` alert on that basis. To grade them, keep one
+source per index database, or verify the window directly with
+`bintrail reconstruct` (its planner gap check is source-exact at restore
+time).

--- a/internal/console/baselines_api.go
+++ b/internal/console/baselines_api.go
@@ -99,17 +99,17 @@ func (s *Server) handleBaselines(w http.ResponseWriter, r *http.Request) {
 	// Staleness floor (#1193): best-effort but never silent and never a
 	// fabricated verdict — an unopened bundle connection or an unreadable
 	// index yields the explicit "unknown".
-	var oldestDelta time.Time
+	var floor status.DeltaFloor
 	serverID := r.Header.Get("X-Bintrail-Server")
 	if serverID == "" {
 		serverID = "default"
 	}
 	if b.db == nil {
 		slog.Warn("console: baseline staleness not evaluated — the server's index connection is not open", "server", serverID)
-	} else if od, err := status.OldestDeltaFromDB(r.Context(), b.db, b.dbName); err != nil {
+	} else if f, err := status.OldestDeltaFromDB(r.Context(), b.db, b.dbName); err != nil {
 		slog.Warn("console: could not load delta-coverage floor for baseline staleness", "server", serverID, "error", err)
 	} else {
-		oldestDelta = od
+		floor = f
 	}
 	var cur *baselineSnapshotDTO
 	var curTime time.Time
@@ -124,7 +124,7 @@ func (s *Server) handleBaselines(w http.ResponseWriter, r *http.Request) {
 				Time:     f.SnapshotTime.Format(consoleTSFormat),
 				AgeHours: now.Sub(f.SnapshotTime).Hours(),
 			}
-			dto.Staleness = string(status.BaselineStalenessFor(f.SnapshotTime, oldestDelta, now))
+			dto.Staleness = string(floor.Grade(f.SnapshotTime, now))
 			if resp.Kind == "dir" {
 				if meta, err := baseline.ReadParquetMetadata(f.Path); err == nil {
 					dto.BinlogFile = meta.BinlogFile
@@ -150,7 +150,7 @@ func (s *Server) handleBaselines(w http.ResponseWriter, r *http.Request) {
 	for i, f := range files {
 		infos[i] = status.BaselineInfo{Database: f.Schema, Table: f.Table, SnapshotTime: f.SnapshotTime}
 	}
-	status.AnnotateBaselineStaleness(infos, oldestDelta, now)
+	status.AnnotateBaselineStaleness(infos, floor, now)
 	resp.Staleness = string(status.OverallBaselineStaleness(infos))
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/internal/console/baselines_staleness_test.go
+++ b/internal/console/baselines_staleness_test.go
@@ -29,7 +29,7 @@ func TestBaselinesAPI_staleness(t *testing.T) {
 	mock.ExpectQuery("PARTITION_NAME FROM information_schema.PARTITIONS").
 		WillReturnRows(sqlmock.NewRows([]string{"PARTITION_NAME"}).AddRow(now.Add(-100 * time.Hour).Format("p_2006010215")))
 	mock.ExpectQuery(`MIN\(partition_name\)`).
-		WillReturnRows(sqlmock.NewRows([]string{"min", "max"}).AddRow(nil, nil))
+		WillReturnRows(sqlmock.NewRows([]string{"min", "max", "sources"}).AddRow(nil, nil, 0))
 
 	srv := newBaselineServer(t, dir, true)
 	srv.cm.boot.db = db

--- a/internal/console/coverage_api.go
+++ b/internal/console/coverage_api.go
@@ -87,8 +87,8 @@ func (s *Server) handleCoverage(w http.ResponseWriter, r *http.Request) {
 	}
 	resp.Continuity = sum.Continuity
 	resp.LagSeconds = sum.LagSeconds
-	if !sum.DeltaFrom.IsZero() {
-		resp.DeltaFrom = sum.DeltaFrom.Format(consoleTSFormat)
+	if !sum.Floor.Hour.IsZero() {
+		resp.DeltaFrom = sum.Floor.Hour.Format(consoleTSFormat)
 	}
 	if !sum.DeltaTo.IsZero() {
 		resp.DeltaTo = sum.DeltaTo.Format(consoleTSFormat)
@@ -104,7 +104,7 @@ func (s *Server) handleCoverage(w http.ResponseWriter, r *http.Request) {
 	case b.baselineSrc == "":
 	case sessionRestricted(r):
 		recordProfileGateDeny(r, "coverage")
-	case sum.DeltaFrom.IsZero():
+	case sum.Floor.Hour.IsZero():
 		resp.FullTableStatus = "unknown"
 	default:
 		files, err := reconstruct.ListBaselines(r.Context(), b.baselineSrc)
@@ -121,20 +121,36 @@ func (s *Server) handleCoverage(w http.ResponseWriter, r *http.Request) {
 				newest[k] = f.SnapshotTime
 			}
 		}
+		// Graded THROUGH the floor, never against its hour alone: on a
+		// multi-source index the hour is the live floor and an anchor below
+		// it is unattributable, not broken (#1219). Grading with the bare
+		// hour would name healthy tables in broken_tables — the false alarm
+		// the floor's own narrowing exists to avoid.
 		var from time.Time
+		var unevaluable bool
 		for k, ts := range newest {
-			if status.BaselineStalenessFor(ts, sum.DeltaFrom, now) == status.BaselineBroken {
+			switch sum.Floor.Grade(ts, now) {
+			case status.BaselineBroken:
 				resp.BrokenTables = append(resp.BrokenTables, k)
-				continue
-			}
-			// The window covering ALL usable tables starts at the LATEST
-			// usable anchor: table i is reconstructable for points >= its
-			// own anchor, so "every table" holds only past the newest one.
-			if ts.After(from) {
-				from = ts
+			case status.BaselineUnknown:
+				// Neither broken nor usable: it must not join broken_tables
+				// AND must not define the window below, or "ok" would assert
+				// restorability from an anchor whose coverage is unknown.
+				unevaluable = true
+			default:
+				// The window covering ALL usable tables starts at the LATEST
+				// usable anchor: table i is reconstructable for points >= its
+				// own anchor, so "every table" holds only past the newest one.
+				if ts.After(from) {
+					from = ts
+				}
 			}
 		}
 		sort.Strings(resp.BrokenTables)
+		if unevaluable {
+			resp.FullTableStatus = "unknown"
+			break
+		}
 		if !from.IsZero() {
 			resp.FullTableFrom = from.Format(consoleTSFormat)
 		}

--- a/internal/console/coverage_api_test.go
+++ b/internal/console/coverage_api_test.go
@@ -15,6 +15,13 @@ import (
 // probe → stream_state (no row = file-mode). archErr != nil makes the floor
 // unknown.
 func coverageMockDB(t *testing.T, part string, latest time.Time, archErr error) *sql.DB {
+	return coverageMockDBArchives(t, part, latest, archErr, nil, nil, 0)
+}
+
+// coverageMockDBArchives is coverageMockDB with an archive_state row: archMin/
+// archMax name the archived range and sources is COUNT(DISTINCT bintrail_id),
+// so a caller can build the multi-source (unattributable) floor.
+func coverageMockDBArchives(t *testing.T, part string, latest time.Time, archErr error, archMin, archMax any, sources int) *sql.DB {
 	t.Helper()
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -27,7 +34,7 @@ func coverageMockDB(t *testing.T, part string, latest time.Time, archErr error) 
 		mock.ExpectQuery(`MIN\(partition_name\)`).WillReturnError(archErr)
 	} else {
 		mock.ExpectQuery(`MIN\(partition_name\)`).
-			WillReturnRows(sqlmock.NewRows([]string{"min", "max", "sources"}).AddRow(nil, nil, 0))
+			WillReturnRows(sqlmock.NewRows([]string{"min", "max", "sources"}).AddRow(archMin, archMax, sources))
 	}
 	mock.ExpectQuery("PARTITION_NAME FROM information_schema.PARTITIONS").
 		WillReturnRows(sqlmock.NewRows([]string{"PARTITION_NAME"}).AddRow(part))
@@ -68,6 +75,32 @@ func TestCoverageAPI(t *testing.T) {
 	writeBaselineFixture(t, dir, tsDir(200*time.Hour), "shop", "orders.parquet")
 	writeBaselineFixture(t, dir, tsDir(10*time.Hour), "shop", "users.parquet")
 	writeBaselineFixture(t, dir, tsDir(150*time.Hour), "shop", "legacy.parquet")
+
+	// #1219: the archives reach back 300h but belong to two sources, so the
+	// floor collapses to the live partitions (-100h) and the -150h `legacy`
+	// anchor becomes UNATTRIBUTABLE. Grading it against the bare floor hour
+	// would name a table whose archives are intact in broken_tables — the
+	// false alarm the narrowed floor exists to avoid — and letting it define
+	// the window would assert restorability it cannot prove. Neither: the
+	// full-table half reports "unknown" and claims no anchor.
+	t.Run("unattributable floor: no broken claim and no window claim", func(t *testing.T) {
+		srv := newBaselineServer(t, dir, true)
+		srv.cm.boot.db = coverageMockDBArchives(t, part, latest, nil,
+			now.Add(-300*time.Hour).Format("p_2006010215"),
+			now.Add(-101*time.Hour).Format("p_2006010215"), 2)
+		srv.cm.boot.dbName = "binlog_index"
+		got := coverageGet(t, srv)
+		if len(got.BrokenTables) != 0 {
+			t.Fatalf("unattributable anchors must not be named broken: %+v", got.BrokenTables)
+		}
+		if got.FullTableStatus != "unknown" || got.FullTableFrom != "" {
+			t.Fatalf("want unknown with no window, got status=%q from=%q", got.FullTableStatus, got.FullTableFrom)
+		}
+		// The delta half still states the window every source provably has.
+		if got.DeltaFrom == "" {
+			t.Fatal("the live floor is still a real window and must be reported")
+		}
+	})
 
 	t.Run("window, latest usable anchor, broken named", func(t *testing.T) {
 		srv := newBaselineServer(t, dir, true)

--- a/internal/console/coverage_api_test.go
+++ b/internal/console/coverage_api_test.go
@@ -27,7 +27,7 @@ func coverageMockDB(t *testing.T, part string, latest time.Time, archErr error) 
 		mock.ExpectQuery(`MIN\(partition_name\)`).WillReturnError(archErr)
 	} else {
 		mock.ExpectQuery(`MIN\(partition_name\)`).
-			WillReturnRows(sqlmock.NewRows([]string{"min", "max"}).AddRow(nil, nil))
+			WillReturnRows(sqlmock.NewRows([]string{"min", "max", "sources"}).AddRow(nil, nil, 0))
 	}
 	mock.ExpectQuery("PARTITION_NAME FROM information_schema.PARTITIONS").
 		WillReturnRows(sqlmock.NewRows([]string{"PARTITION_NAME"}).AddRow(part))

--- a/internal/status/coverage.go
+++ b/internal/status/coverage.go
@@ -45,7 +45,10 @@ func ContinuityStatus(stream *StreamStateInfo, streamErr error) string {
 // every server switch; CollectStatus stays the full report.
 type CoverageSummary struct {
 	// DeltaFrom is the delta-coverage floor (OldestDeltaFromDB — the #1213
-	// strict rule). Zero = unknown, never assumed.
+	// strict rule). Zero = unknown, never assumed. On a multi-source index
+	// this is the LIVE-partition floor: archives are per-source and cannot be
+	// attributed here (#1219), so the window shown is the one every source
+	// provably has, never a union that would overstate it.
 	DeltaFrom time.Time
 	// DeltaTo is the newest INDEXED event — never the wall clock: claiming
 	// restorability "up to now" while the stream is down would be unearned
@@ -60,9 +63,6 @@ type CoverageSummary struct {
 	// folded into this summary — they are a capture-plane verdict with their
 	// own surface (status Capture health, --fail-on-gap). The delta window
 	// here is about what the index CONTAINS.
-	//
-	// Multi-source caveat: like the staleness floor, the window is not
-	// scoped per bintrail_id (#1219).
 }
 
 // CollectCoverageSummary computes the summary against one index. The floor
@@ -75,7 +75,7 @@ func CollectCoverageSummary(ctx context.Context, db *sql.DB, dbName string, now 
 	if floor, err := OldestDeltaFromDB(ctx, db, dbName); err != nil {
 		slog.Warn("could not determine the delta-coverage floor; coverage window start is unknown", "db", dbName, "error", err)
 	} else {
-		sum.DeltaFrom = floor
+		sum.DeltaFrom = floor.Hour
 	}
 	latest, err := newestIndexedEvent(ctx, db, dbName)
 	if err != nil {

--- a/internal/status/coverage.go
+++ b/internal/status/coverage.go
@@ -44,12 +44,18 @@ func ContinuityStatus(stream *StreamStateInfo, streamErr error) string {
 // newestIndexedEvent) rather than a whole-table MAX — because it loads on
 // every server switch; CollectStatus stays the full report.
 type CoverageSummary struct {
-	// DeltaFrom is the delta-coverage floor (OldestDeltaFromDB — the #1213
-	// strict rule). Zero = unknown, never assumed. On a multi-source index
-	// this is the LIVE-partition floor: archives are per-source and cannot be
-	// attributed here (#1219), so the window shown is the one every source
-	// provably has, never a union that would overstate it.
-	DeltaFrom time.Time
+	// Floor is the delta-coverage floor (OldestDeltaFromDB — the #1213 strict
+	// rule); Floor.Hour zero = unknown, never assumed. The whole DeltaFloor
+	// travels, not just the hour: on a multi-source index Hour is the
+	// LIVE-partition floor and BelowIsUnknown says so, and a consumer that
+	// grades baselines against the hour ALONE turns this narrower floor into
+	// false "broken" verdicts (#1219). Grade through Floor, never through
+	// BaselineStalenessFor with Floor.Hour.
+	//
+	// Caveat that outlives this field: partition existence is the coverage
+	// rule, so a source that started capturing after the oldest live
+	// partition reads a wider window here than it can actually restore.
+	Floor DeltaFloor
 	// DeltaTo is the newest INDEXED event — never the wall clock: claiming
 	// restorability "up to now" while the stream is down would be unearned
 	// assurance. LagSeconds is what says how close to now the edge is.
@@ -75,7 +81,7 @@ func CollectCoverageSummary(ctx context.Context, db *sql.DB, dbName string, now 
 	if floor, err := OldestDeltaFromDB(ctx, db, dbName); err != nil {
 		slog.Warn("could not determine the delta-coverage floor; coverage window start is unknown", "db", dbName, "error", err)
 	} else {
-		sum.DeltaFrom = floor.Hour
+		sum.Floor = floor
 	}
 	latest, err := newestIndexedEvent(ctx, db, dbName)
 	if err != nil {

--- a/internal/status/coverage_test.go
+++ b/internal/status/coverage_test.go
@@ -89,8 +89,8 @@ func TestCollectCoverageSummary(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if !sum.DeltaFrom.Equal(time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)) || !sum.DeltaTo.Equal(latest) {
-			t.Fatalf("window = [%v, %v]", sum.DeltaFrom, sum.DeltaTo)
+		if !sum.Floor.Hour.Equal(time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)) || !sum.DeltaTo.Equal(latest) {
+			t.Fatalf("window = [%v, %v]", sum.Floor.Hour, sum.DeltaTo)
 		}
 		if sum.Continuity != "ok" || sum.LagSeconds == nil || *sum.LagSeconds != 42 {
 			t.Fatalf("continuity=%q lag=%v", sum.Continuity, sum.LagSeconds)
@@ -163,7 +163,7 @@ func TestCollectCoverageSummary(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if !sum.DeltaFrom.IsZero() || !sum.DeltaTo.Equal(latest) {
+		if !sum.Floor.Hour.IsZero() || !sum.DeltaTo.Equal(latest) {
 			t.Fatalf("unknown floor must stay zero: %+v", sum)
 		}
 	})

--- a/internal/status/coverage_test.go
+++ b/internal/status/coverage_test.go
@@ -32,12 +32,12 @@ func TestContinuityStatus(t *testing.T) {
 }
 
 // Query shapes shared by the CollectCoverageSummary tests. The summary hits,
-// in order: partition listing (floor) → archive_state MIN/MAX → partition
+// in order: partition listing (floor) → archive_state MIN/MAX/sources → partition
 // listing (walk) → per-partition MAX probes (newest first, p_future first) →
 // stream_state.
 var (
 	covPartsQ  = regexp.QuoteMeta("SELECT PARTITION_NAME FROM information_schema.PARTITIONS")
-	covArchQ   = regexp.QuoteMeta("SELECT MIN(partition_name), MAX(partition_name) FROM archive_state")
+	covArchQ   = regexp.QuoteMeta("SELECT MIN(partition_name), MAX(partition_name), COUNT(DISTINCT bintrail_id) FROM archive_state")
 	covProbeQ  = `MAX\(event_timestamp\) FROM binlog_events PARTITION`
 	covStreamQ = "FROM stream_state"
 )
@@ -74,7 +74,7 @@ func TestCollectCoverageSummary(t *testing.T) {
 	// then p_2026080110 (holds latest).
 	expectWindow := func(mock sqlmock.Sqlmock) {
 		mock.ExpectQuery(covPartsQ).WillReturnRows(covPartRows("p_2026080110", "p_future"))
-		mock.ExpectQuery(covArchQ).WillReturnRows(sqlmock.NewRows([]string{"min", "max"}).AddRow(nil, nil))
+		mock.ExpectQuery(covArchQ).WillReturnRows(sqlmock.NewRows([]string{"min", "max", "sources"}).AddRow(nil, nil, 0))
 		mock.ExpectQuery(covPartsQ).WillReturnRows(covPartRows("p_2026080110", "p_future"))
 		mock.ExpectQuery(covProbeQ).WillReturnRows(covProbeRow(nil)) // p_future first, empty
 		mock.ExpectQuery(covProbeQ).WillReturnRows(covProbeRow(latest))
@@ -137,7 +137,7 @@ func TestCollectCoverageSummary(t *testing.T) {
 	t.Run("empty index with a live stream: no window edge, no fabricated lag", func(t *testing.T) {
 		db, mock := newDB(t)
 		mock.ExpectQuery(covPartsQ).WillReturnRows(covPartRows("p_2026080110", "p_future"))
-		mock.ExpectQuery(covArchQ).WillReturnRows(sqlmock.NewRows([]string{"min", "max"}).AddRow(nil, nil))
+		mock.ExpectQuery(covArchQ).WillReturnRows(sqlmock.NewRows([]string{"min", "max", "sources"}).AddRow(nil, nil, 0))
 		mock.ExpectQuery(covPartsQ).WillReturnRows(covPartRows("p_2026080110", "p_future"))
 		mock.ExpectQuery(covProbeQ).WillReturnRows(covProbeRow(nil)) // p_future empty
 		mock.ExpectQuery(covProbeQ).WillReturnRows(covProbeRow(nil)) // dated empty too
@@ -171,7 +171,7 @@ func TestCollectCoverageSummary(t *testing.T) {
 	t.Run("newest-event probe failure is fatal", func(t *testing.T) {
 		db, mock := newDB(t)
 		mock.ExpectQuery(covPartsQ).WillReturnRows(covPartRows("p_2026080110"))
-		mock.ExpectQuery(covArchQ).WillReturnRows(sqlmock.NewRows([]string{"min", "max"}).AddRow(nil, nil))
+		mock.ExpectQuery(covArchQ).WillReturnRows(sqlmock.NewRows([]string{"min", "max", "sources"}).AddRow(nil, nil, 0))
 		mock.ExpectQuery(covPartsQ).WillReturnRows(covPartRows("p_2026080110"))
 		mock.ExpectQuery(covProbeQ).WillReturnError(errors.New("boom"))
 		if _, err := CollectCoverageSummary(context.Background(), db, "binlog_index", now); err == nil {

--- a/internal/status/staleness.go
+++ b/internal/status/staleness.go
@@ -63,6 +63,36 @@ func BaselineStalenessFor(snapshotTime, oldestDelta, now time.Time) BaselineStal
 // here: it is the first WRITE, not the coverage start, and on a quiet
 // database it would fabricate a "broken" verdict (baseline taken before the
 // first write) on a perfectly restorable index.
+// DeltaFloor is the delta-coverage floor plus how to read a snapshot older
+// than it. It exists because the two halves of the floor have different
+// scopes (#1219): the live partitions are SHARED — every source writes into
+// the same range-partitioned binlog_events, so their oldest hour is a valid
+// floor for every source without attributing anything — while archive_state
+// rows are PER-SOURCE. Extending the floor backwards with the union MIN of a
+// multi-source index hands source A's archive coverage to source B.
+type DeltaFloor struct {
+	// Hour is the floor to grade against; zero = unknown, never assumed.
+	Hour time.Time
+	// BelowIsUnknown marks Hour as the LIVE-partition floor only, because the
+	// archives could not be attributed to the source that owns the graded
+	// baselines. A snapshot older than Hour may still be covered by that
+	// source's own archives, so it grades unknown rather than broken —
+	// reporting "broken" on an unattributable snapshot is a false alarm, and
+	// a false alarm is worse than no check at all.
+	BelowIsUnknown bool
+}
+
+// Grade returns the staleness verdict of one snapshot against this floor. It
+// is the single place the ambiguity demotion lives: below an unattributable
+// floor, "broken" becomes "unknown".
+func (f DeltaFloor) Grade(snapshotTime, now time.Time) BaselineStalenessVerdict {
+	v := BaselineStalenessFor(snapshotTime, f.Hour, now)
+	if v == BaselineBroken && f.BelowIsUnknown {
+		return BaselineUnknown
+	}
+	return v
+}
+
 func OldestLivePartitionHour(parts []PartitionStat) time.Time {
 	var out time.Time
 	for _, p := range parts {
@@ -86,69 +116,116 @@ func OldestLivePartitionHour(parts []PartitionStat) time.Time {
 // floor read LATER than reality — and so fabricate "broken" on healthy
 // archives — is returned (the caller degrades to unknown), never swallowed.
 // Only a missing archive_state table (older indexes) is tolerated.
-func OldestDeltaFromDB(ctx context.Context, db *sql.DB, dbName string) (time.Time, error) {
+func OldestDeltaFromDB(ctx context.Context, db *sql.DB, dbName string) (DeltaFloor, error) {
 	rows, err := db.QueryContext(ctx, `
 		SELECT PARTITION_NAME FROM information_schema.PARTITIONS
 		WHERE TABLE_SCHEMA = ? AND TABLE_NAME = 'binlog_events' AND PARTITION_NAME IS NOT NULL`, dbName)
 	if err != nil {
-		return time.Time{}, fmt.Errorf("list live partitions: %w", err)
+		return DeltaFloor{}, fmt.Errorf("list live partitions: %w", err)
 	}
 	defer rows.Close()
 	var parts []PartitionStat
 	for rows.Next() {
 		var name string
 		if err := rows.Scan(&name); err != nil {
-			return time.Time{}, err
+			return DeltaFloor{}, err
 		}
 		parts = append(parts, PartitionStat{Name: name})
 	}
 	if err := rows.Err(); err != nil {
-		return time.Time{}, err
+		return DeltaFloor{}, err
 	}
-	floor := OldestLivePartitionHour(parts)
+	floor := DeltaFloor{Hour: OldestLivePartitionHour(parts)}
 
+	// COUNT(DISTINCT bintrail_id) rides the query that was already here — no
+	// extra round trip, and no NULL bucket to reason about: rotate refuses to
+	// archive without an id (errNoArchiveBintrailID), so every row has one.
 	var minPartition, maxPartition sql.NullString
-	if err := db.QueryRowContext(ctx, `SELECT MIN(partition_name), MAX(partition_name) FROM archive_state`).Scan(&minPartition, &maxPartition); err != nil {
+	var archivedSources int
+	if err := db.QueryRowContext(ctx, `SELECT MIN(partition_name), MAX(partition_name), COUNT(DISTINCT bintrail_id) FROM archive_state`).Scan(&minPartition, &maxPartition, &archivedSources); err != nil {
 		var myErr *mysql.MySQLError
 		if errors.As(err, &myErr) && myErr.Number == 1146 {
 			return floor, nil // archive_state absent on older indexes — live floor only
 		}
-		return time.Time{}, fmt.Errorf("read archive floor: %w", err)
+		return DeltaFloor{}, fmt.Errorf("read archive floor: %w", err)
 	}
-	if minPartition.Valid {
-		minT, ok := parsePartitionName(minPartition.String)
-		if !ok {
-			// Our own naming scheme failing to parse is drift, and silently
-			// dropping the archive floor would fabricate "broken".
-			return time.Time{}, fmt.Errorf("archive_state MIN(partition_name) %q is unparseable", minPartition.String)
+	if !minPartition.Valid {
+		return floor, nil // no archives: nothing to extend, nothing to attribute
+	}
+	minT, ok := parsePartitionName(minPartition.String)
+	if !ok {
+		// Our own naming scheme failing to parse is drift, and silently
+		// dropping the archive floor would fabricate "broken".
+		return DeltaFloor{}, fmt.Errorf("archive_state MIN(partition_name) %q is unparseable", minPartition.String)
+	}
+	maxT, ok := parsePartitionName(maxPartition.String)
+	if !ok {
+		return DeltaFloor{}, fmt.Errorf("archive_state MAX(partition_name) %q is unparseable", maxPartition.String)
+	}
+
+	// Per-source scoping (#1219). Two signals, because either alone leaves a
+	// hole: more than one ARCHIVED source is the direct evidence, and more
+	// than one KNOWN source catches the case where only one of them has
+	// archived so far — whose union MIN would still be handed to the other's
+	// baselines. Neither identifies WHICH source owns a given baseline (a
+	// baseline snapshot carries no source identity), so the answer here can
+	// only be "attributable" or "not".
+	multiSource := archivedSources > 1
+	if !multiSource {
+		known, err := knownSourceCount(ctx, db)
+		if err != nil {
+			return DeltaFloor{}, err
 		}
-		maxT, ok := parsePartitionName(maxPartition.String)
-		if !ok {
-			return time.Time{}, fmt.Errorf("archive_state MAX(partition_name) %q is unparseable", maxPartition.String)
-		}
-		// Archives extend the floor backwards ONLY when their range reaches
-		// the live partitions: if the newest archived hour ends before the
-		// oldest live partition begins (archiving stopped, middle range
-		// pruned), every restore anchored before the live floor crosses that
-		// hole — so the live floor IS the coverage floor, and extending it
-		// would grade those baselines with an unearned "ok". Interior holes
-		// within the archive range are still invisible here; reconstruct's
-		// planner gap check catches those at restore time.
-		contiguous := floor.IsZero() || !maxT.Add(time.Hour).Before(floor)
-		if contiguous && (floor.IsZero() || minT.Before(floor)) {
-			floor = minT
-		}
+		multiSource = known > 1
+	}
+	if multiSource {
+		// Archives belonging to sources this call cannot tell apart never
+		// extend the floor: the live partitions (shared by every source) stay
+		// the floor, and everything below becomes unknowable rather than
+		// either covered or broken.
+		floor.BelowIsUnknown = true
+		return floor, nil
+	}
+
+	// Archives extend the floor backwards ONLY when their range reaches
+	// the live partitions: if the newest archived hour ends before the
+	// oldest live partition begins (archiving stopped, middle range
+	// pruned), every restore anchored before the live floor crosses that
+	// hole — so the live floor IS the coverage floor, and extending it
+	// would grade those baselines with an unearned "ok". Interior holes
+	// within the archive range are still invisible here; reconstruct's
+	// planner gap check catches those at restore time.
+	contiguous := floor.Hour.IsZero() || !maxT.Add(time.Hour).Before(floor.Hour)
+	if contiguous && (floor.Hour.IsZero() || minT.Before(floor.Hour)) {
+		floor.Hour = minT
 	}
 	return floor, nil
+}
+
+// knownSourceCount counts the source servers this index has ever identified.
+// Decommissioned rows count: their archives still sit in archive_state and
+// would extend another source's floor just the same. A missing table (1146)
+// is a legacy or file-mode index — zero known sources, single-source
+// semantics preserved.
+func knownSourceCount(ctx context.Context, db *sql.DB) (int, error) {
+	var n int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM bintrail_servers`).Scan(&n); err != nil {
+		var myErr *mysql.MySQLError
+		if errors.As(err, &myErr) && myErr.Number == 1146 {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("count known sources: %w", err)
+	}
+	return n, nil
 }
 
 // AnnotateBaselineStaleness stamps each entry's verdict in place. Every entry
 // is graded on its own anchor — a superseded old snapshot showing "broken" is
 // honest (it IS unusable); what decides the headline is
 // OverallBaselineStaleness, which only looks at each table's newest snapshot.
-func AnnotateBaselineStaleness(baselines []BaselineInfo, oldestDelta, now time.Time) {
+func AnnotateBaselineStaleness(baselines []BaselineInfo, floor DeltaFloor, now time.Time) {
 	for i := range baselines {
-		baselines[i].Staleness = BaselineStalenessFor(baselines[i].SnapshotTime, oldestDelta, now)
+		baselines[i].Staleness = floor.Grade(baselines[i].SnapshotTime, now)
 	}
 }
 

--- a/internal/status/staleness.go
+++ b/internal/status/staleness.go
@@ -57,12 +57,6 @@ func BaselineStalenessFor(snapshotTime, oldestDelta, now time.Time) BaselineStal
 	return BaselineOK
 }
 
-// OldestLivePartitionHour is the live half of the delta floor: the hour of
-// the oldest non-future binlog_events partition. Partition EXISTENCE is
-// coverage — the planner's own rule. MIN(event_timestamp) must NOT be used
-// here: it is the first WRITE, not the coverage start, and on a quiet
-// database it would fabricate a "broken" verdict (baseline taken before the
-// first write) on a perfectly restorable index.
 // DeltaFloor is the delta-coverage floor plus how to read a snapshot older
 // than it. It exists because the two halves of the floor have different
 // scopes (#1219): the live partitions are SHARED — every source writes into
@@ -85,6 +79,14 @@ type DeltaFloor struct {
 // Grade returns the staleness verdict of one snapshot against this floor. It
 // is the single place the ambiguity demotion lives: below an unattributable
 // floor, "broken" becomes "unknown".
+//
+// Only "broken" is demoted, deliberately. A snapshot ABOVE the floor is
+// covered by the live partitions every source shares, so ok/aging need no
+// attribution — and an unattributable floor makes the span shorter, so
+// "aging" fires earlier than it would against the archive-extended floor.
+// That reads as a conservative "your provable window is shrinking", which is
+// the honest thing to say; demoting it too would erase the one signal still
+// standing on those indexes.
 func (f DeltaFloor) Grade(snapshotTime, now time.Time) BaselineStalenessVerdict {
 	v := BaselineStalenessFor(snapshotTime, f.Hour, now)
 	if v == BaselineBroken && f.BelowIsUnknown {
@@ -93,6 +95,12 @@ func (f DeltaFloor) Grade(snapshotTime, now time.Time) BaselineStalenessVerdict 
 	return v
 }
 
+// OldestLivePartitionHour is the live half of the delta floor: the hour of
+// the oldest non-future binlog_events partition. Partition EXISTENCE is
+// coverage — the planner's own rule. MIN(event_timestamp) must NOT be used
+// here: it is the first WRITE, not the coverage start, and on a quiet
+// database it would fabricate a "broken" verdict (baseline taken before the
+// first write) on a perfectly restorable index.
 func OldestLivePartitionHour(parts []PartitionStat) time.Time {
 	var out time.Time
 	for _, p := range parts {
@@ -138,8 +146,13 @@ func OldestDeltaFromDB(ctx context.Context, db *sql.DB, dbName string) (DeltaFlo
 	floor := DeltaFloor{Hour: OldestLivePartitionHour(parts)}
 
 	// COUNT(DISTINCT bintrail_id) rides the query that was already here — no
-	// extra round trip, and no NULL bucket to reason about: rotate refuses to
-	// archive without an id (errNoArchiveBintrailID), so every row has one.
+	// extra round trip. Every writer stamps a non-empty id (CLI rotate via
+	// errNoArchiveBintrailID, the watch control plane via its own empty-id
+	// drop-only branch, and reconcile --repair / restore-index from the
+	// bintrail_id=<id> path segment), but the COLUMN is nullable: a NULL row
+	// would drop out of the COUNT while still feeding MIN(partition_name), so
+	// the count is treated as evidence of attribution, never as proof — see
+	// the archivedSources == 0 branch below.
 	var minPartition, maxPartition sql.NullString
 	var archivedSources int
 	if err := db.QueryRowContext(ctx, `SELECT MIN(partition_name), MAX(partition_name), COUNT(DISTINCT bintrail_id) FROM archive_state`).Scan(&minPartition, &maxPartition, &archivedSources); err != nil {
@@ -170,6 +183,15 @@ func OldestDeltaFromDB(ctx context.Context, db *sql.DB, dbName string) (DeltaFlo
 	// baselines. Neither identifies WHICH source owns a given baseline (a
 	// baseline snapshot carries no source identity), so the answer here can
 	// only be "attributable" or "not".
+	if archivedSources == 0 {
+		// Archived hours exist but carry NO source identity (only reachable
+		// through a hand-written or pre-identity row, since the column is
+		// nullable). Rows that name no source are the strongest case of
+		// "cannot attribute", so they must not extend anyone's floor — the
+		// count reading 0 while MIN is valid is exactly that.
+		floor.BelowIsUnknown = true
+		return floor, nil
+	}
 	multiSource := archivedSources > 1
 	if !multiSource {
 		known, err := knownSourceCount(ctx, db)
@@ -232,7 +254,12 @@ func AnnotateBaselineStaleness(baselines []BaselineInfo, floor DeltaFloor, now t
 // OverallBaselineStaleness is the worst verdict across each table's NEWEST
 // snapshot. "" when the list is empty or unannotated.
 func OverallBaselineStaleness(baselines []BaselineInfo) BaselineStalenessVerdict {
-	rank := map[BaselineStalenessVerdict]int{BaselineOK: 1, BaselineUnknown: 2, BaselineAging: 3, BaselineBroken: 4}
+	// Unknown outranks aging: aging is informational (it fires on every young
+	// install and never alerts), while unknown means the restore window could
+	// not be established at all. #1219 makes unknown the ROUTINE verdict for
+	// below-floor snapshots on multi-source indexes, so ranking it under
+	// aging would headline "mildly old" over "could not be checked".
+	rank := map[BaselineStalenessVerdict]int{BaselineOK: 1, BaselineAging: 2, BaselineUnknown: 3, BaselineBroken: 4}
 	newest := make(map[string]BaselineInfo, len(baselines))
 	for _, b := range baselines {
 		k := b.Database + "." + b.Table

--- a/internal/status/staleness_test.go
+++ b/internal/status/staleness_test.go
@@ -57,9 +57,31 @@ func TestOldestLivePartitionHour(t *testing.T) {
 	}
 }
 
+func TestDeltaFloorGrade(t *testing.T) {
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	live := now.Add(-10 * time.Hour)
+	older := live.Add(-time.Hour)
+
+	// Attributable floor: below it is broken, the verdict callers act on.
+	if got := (DeltaFloor{Hour: live}).Grade(older, now); got != BaselineBroken {
+		t.Fatalf("attributable floor: got %s, want broken", got)
+	}
+	// Unattributable floor: the same snapshot may still be covered by its own
+	// source's archives, so it is unknown — reporting broken would cry wolf.
+	if got := (DeltaFloor{Hour: live, BelowIsUnknown: true}).Grade(older, now); got != BaselineUnknown {
+		t.Fatalf("unattributable floor: got %s, want unknown", got)
+	}
+	// Above the floor the ambiguity is irrelevant: the live partitions are
+	// shared by every source, so those verdicts need no attribution.
+	if got := (DeltaFloor{Hour: live, BelowIsUnknown: true}).Grade(now.Add(-time.Hour), now); got != BaselineOK {
+		t.Fatalf("in-window snapshot: got %s, want ok", got)
+	}
+}
+
 func TestOldestDeltaFromDB(t *testing.T) {
 	partsQ := regexp.QuoteMeta("SELECT PARTITION_NAME FROM information_schema.PARTITIONS")
-	archQ := regexp.QuoteMeta("SELECT MIN(partition_name), MAX(partition_name) FROM archive_state")
+	archQ := regexp.QuoteMeta("SELECT MIN(partition_name), MAX(partition_name), COUNT(DISTINCT bintrail_id) FROM archive_state")
+	srvQ := regexp.QuoteMeta("SELECT COUNT(*) FROM bintrail_servers")
 	partRows := func(names ...string) *sqlmock.Rows {
 		r := sqlmock.NewRows([]string{"PARTITION_NAME"})
 		for _, n := range names {
@@ -67,27 +89,40 @@ func TestOldestDeltaFromDB(t *testing.T) {
 		}
 		return r
 	}
+	// ExpectationsWereMet on every subtest pins the QUERY SET, not just the
+	// result: the single-source path must keep costing exactly two queries
+	// (plus the sources probe), and an extra round trip in the common case
+	// would fail here.
 	newDB := func(t *testing.T) (*sql.DB, sqlmock.Sqlmock) {
 		t.Helper()
 		db, mock, err := sqlmock.New()
 		if err != nil {
 			t.Fatal(err)
 		}
-		t.Cleanup(func() { db.Close() })
+		t.Cleanup(func() {
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("unmet or unexpected queries: %v", err)
+			}
+			db.Close()
+		})
 		return db, mock
 	}
 
-	archRows := func(min, max any) *sqlmock.Rows {
-		return sqlmock.NewRows([]string{"min", "max"}).AddRow(min, max)
+	archRows := func(min, max any, sources int) *sqlmock.Rows {
+		return sqlmock.NewRows([]string{"min", "max", "sources"}).AddRow(min, max, sources)
+	}
+	srvRows := func(n int) *sqlmock.Rows {
+		return sqlmock.NewRows([]string{"n"}).AddRow(n)
 	}
 
 	t.Run("contiguous archive floor wins when earlier", func(t *testing.T) {
 		db, mock := newDB(t)
 		mock.ExpectQuery(partsQ).WillReturnRows(partRows("p_2026080110", "p_future"))
-		mock.ExpectQuery(archQ).WillReturnRows(archRows("p_2026080103", "p_2026080109"))
+		mock.ExpectQuery(archQ).WillReturnRows(archRows("p_2026080103", "p_2026080109", 1))
+		mock.ExpectQuery(srvQ).WillReturnRows(srvRows(1))
 		got, err := OldestDeltaFromDB(context.Background(), db, "binlog_index")
-		if err != nil || !got.Equal(time.Date(2026, 8, 1, 3, 0, 0, 0, time.UTC)) {
-			t.Fatalf("got %v, %v", got, err)
+		if err != nil || !got.Hour.Equal(time.Date(2026, 8, 1, 3, 0, 0, 0, time.UTC)) || got.BelowIsUnknown {
+			t.Fatalf("got %+v, %v", got, err)
 		}
 	})
 
@@ -98,20 +133,77 @@ func TestOldestDeltaFromDB(t *testing.T) {
 		// unearned "ok".
 		db, mock := newDB(t)
 		mock.ExpectQuery(partsQ).WillReturnRows(partRows("p_2026080110"))
-		mock.ExpectQuery(archQ).WillReturnRows(archRows("p_2026080101", "p_2026080105"))
+		mock.ExpectQuery(archQ).WillReturnRows(archRows("p_2026080101", "p_2026080105", 1))
+		mock.ExpectQuery(srvQ).WillReturnRows(srvRows(1))
 		got, err := OldestDeltaFromDB(context.Background(), db, "binlog_index")
-		if err != nil || !got.Equal(time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)) {
-			t.Fatalf("got %v, %v — want the live floor, not the archive one", got, err)
+		if err != nil || !got.Hour.Equal(time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)) {
+			t.Fatalf("got %+v, %v — want the live floor, not the archive one", got, err)
 		}
 	})
 
 	t.Run("archive-only coverage counts when no live partitions exist", func(t *testing.T) {
 		db, mock := newDB(t)
 		mock.ExpectQuery(partsQ).WillReturnRows(partRows())
-		mock.ExpectQuery(archQ).WillReturnRows(archRows("p_2026080103", "p_2026080105"))
+		mock.ExpectQuery(archQ).WillReturnRows(archRows("p_2026080103", "p_2026080105", 1))
+		mock.ExpectQuery(srvQ).WillReturnRows(srvRows(1))
 		got, err := OldestDeltaFromDB(context.Background(), db, "binlog_index")
-		if err != nil || !got.Equal(time.Date(2026, 8, 1, 3, 0, 0, 0, time.UTC)) {
-			t.Fatalf("got %v, %v", got, err)
+		if err != nil || !got.Hour.Equal(time.Date(2026, 8, 1, 3, 0, 0, 0, time.UTC)) {
+			t.Fatalf("got %+v, %v", got, err)
+		}
+	})
+
+	t.Run("archives from several sources never extend the floor", func(t *testing.T) {
+		// #1219: archive_state rows are per-source. Source A archived back to
+		// 01:00; a baseline of a table that lives on source B must not inherit
+		// A's coverage. The live floor stands and everything below it is
+		// unknowable — not "ok" (missed alarm) and not "broken" (false alarm).
+		db, mock := newDB(t)
+		mock.ExpectQuery(partsQ).WillReturnRows(partRows("p_2026080110"))
+		mock.ExpectQuery(archQ).WillReturnRows(archRows("p_2026080101", "p_2026080109", 2))
+		// No bintrail_servers probe: the archive rows already answered it.
+		got, err := OldestDeltaFromDB(context.Background(), db, "binlog_index")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !got.Hour.Equal(time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)) || !got.BelowIsUnknown {
+			t.Fatalf("got %+v — want the live floor with BelowIsUnknown", got)
+		}
+	})
+
+	t.Run("one archived source but several known ones is still unattributable", func(t *testing.T) {
+		// The half the archive rows cannot see: source B exists and simply has
+		// not archived yet, so a B baseline would inherit A's floor.
+		db, mock := newDB(t)
+		mock.ExpectQuery(partsQ).WillReturnRows(partRows("p_2026080110"))
+		mock.ExpectQuery(archQ).WillReturnRows(archRows("p_2026080101", "p_2026080109", 1))
+		mock.ExpectQuery(srvQ).WillReturnRows(srvRows(2))
+		got, err := OldestDeltaFromDB(context.Background(), db, "binlog_index")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !got.Hour.Equal(time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)) || !got.BelowIsUnknown {
+			t.Fatalf("got %+v — want the live floor with BelowIsUnknown", got)
+		}
+	})
+
+	t.Run("missing bintrail_servers table is tolerated (legacy/file-mode index)", func(t *testing.T) {
+		db, mock := newDB(t)
+		mock.ExpectQuery(partsQ).WillReturnRows(partRows("p_2026080110"))
+		mock.ExpectQuery(archQ).WillReturnRows(archRows("p_2026080103", "p_2026080109", 1))
+		mock.ExpectQuery(srvQ).WillReturnError(&mysql.MySQLError{Number: 1146, Message: "Table 'binlog_index.bintrail_servers' doesn't exist"})
+		got, err := OldestDeltaFromDB(context.Background(), db, "binlog_index")
+		if err != nil || !got.Hour.Equal(time.Date(2026, 8, 1, 3, 0, 0, 0, time.UTC)) || got.BelowIsUnknown {
+			t.Fatalf("got %+v, %v — a legacy index keeps single-source semantics", got, err)
+		}
+	})
+
+	t.Run("any other bintrail_servers error propagates", func(t *testing.T) {
+		db, mock := newDB(t)
+		mock.ExpectQuery(partsQ).WillReturnRows(partRows("p_2026080110"))
+		mock.ExpectQuery(archQ).WillReturnRows(archRows("p_2026080103", "p_2026080109", 1))
+		mock.ExpectQuery(srvQ).WillReturnError(&mysql.MySQLError{Number: 1045, Message: "access denied"})
+		if _, err := OldestDeltaFromDB(context.Background(), db, "binlog_index"); err == nil {
+			t.Fatal("an unreadable source registry must propagate: it decides whether the floor is attributable")
 		}
 	})
 
@@ -120,15 +212,15 @@ func TestOldestDeltaFromDB(t *testing.T) {
 		mock.ExpectQuery(partsQ).WillReturnRows(partRows("p_2026080110"))
 		mock.ExpectQuery(archQ).WillReturnError(&mysql.MySQLError{Number: 1146, Message: "Table 'binlog_index.archive_state' doesn't exist"})
 		got, err := OldestDeltaFromDB(context.Background(), db, "binlog_index")
-		if err != nil || !got.Equal(time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)) {
-			t.Fatalf("got %v, %v", got, err)
+		if err != nil || !got.Hour.Equal(time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)) {
+			t.Fatalf("got %+v, %v", got, err)
 		}
 	})
 
 	t.Run("unparseable archive MAX propagates", func(t *testing.T) {
 		db, mock := newDB(t)
 		mock.ExpectQuery(partsQ).WillReturnRows(partRows("p_2026080110"))
-		mock.ExpectQuery(archQ).WillReturnRows(archRows("p_2026080103", "weird"))
+		mock.ExpectQuery(archQ).WillReturnRows(archRows("p_2026080103", "weird", 1))
 		if _, err := OldestDeltaFromDB(context.Background(), db, "binlog_index"); err == nil {
 			t.Fatal("unparseable MAX must propagate — contiguity cannot be judged")
 		}
@@ -149,7 +241,7 @@ func TestOldestDeltaFromDB(t *testing.T) {
 	t.Run("unparseable archive MIN propagates", func(t *testing.T) {
 		db, mock := newDB(t)
 		mock.ExpectQuery(partsQ).WillReturnRows(partRows("p_2026080110"))
-		mock.ExpectQuery(archQ).WillReturnRows(archRows("weird", "p_2026080105"))
+		mock.ExpectQuery(archQ).WillReturnRows(archRows("weird", "p_2026080105", 1))
 		if _, err := OldestDeltaFromDB(context.Background(), db, "binlog_index"); err == nil {
 			t.Fatal("unparseable archive floor must propagate, not silently drop")
 		}
@@ -158,10 +250,10 @@ func TestOldestDeltaFromDB(t *testing.T) {
 	t.Run("empty index and empty archive is unknown, not an error", func(t *testing.T) {
 		db, mock := newDB(t)
 		mock.ExpectQuery(partsQ).WillReturnRows(partRows())
-		mock.ExpectQuery(archQ).WillReturnRows(archRows(nil, nil))
+		mock.ExpectQuery(archQ).WillReturnRows(archRows(nil, nil, 0))
 		got, err := OldestDeltaFromDB(context.Background(), db, "binlog_index")
-		if err != nil || !got.IsZero() {
-			t.Fatalf("got %v, %v — want zero, nil", got, err)
+		if err != nil || !got.Hour.IsZero() || got.BelowIsUnknown {
+			t.Fatalf("got %+v, %v — want zero, nil", got, err)
 		}
 	})
 }
@@ -176,7 +268,7 @@ func TestWriteJSON_staleness(t *testing.T) {
 		{Database: "shop", Table: "orders", SnapshotTime: now.Add(-2 * time.Hour)},
 		{Database: "shop", Table: "legacy", SnapshotTime: oldest.Add(-time.Hour)},
 	}}
-	AnnotateBaselineStaleness(d.Baselines, oldest, now)
+	AnnotateBaselineStaleness(d.Baselines, DeltaFloor{Hour: oldest}, now)
 	var buf bytes.Buffer
 	if err := d.WriteJSON(&buf); err != nil {
 		t.Fatal(err)
@@ -211,7 +303,7 @@ func TestOverallBaselineStaleness_newestPerTable(t *testing.T) {
 		// …but a table whose NEWEST snapshot is broken must.
 		{Database: "shop", Table: "legacy", SnapshotTime: oldest.Add(-time.Hour)},
 	}
-	AnnotateBaselineStaleness(baselines, oldest, now)
+	AnnotateBaselineStaleness(baselines, DeltaFloor{Hour: oldest}, now)
 	if baselines[0].Staleness != BaselineBroken || baselines[1].Staleness != BaselineOK {
 		t.Fatalf("per-entry annotation wrong: %+v", baselines)
 	}
@@ -236,7 +328,7 @@ func TestWriteBaselines_stalenessColumnAndBanner(t *testing.T) {
 		{Database: "shop", Table: "orders", SnapshotTime: oldest.Add(-time.Hour)}, // superseded
 		{Database: "shop", Table: "legacy", SnapshotTime: oldest.Add(-time.Hour)},
 	}
-	AnnotateBaselineStaleness(baselines, oldest, now)
+	AnnotateBaselineStaleness(baselines, DeltaFloor{Hour: oldest}, now)
 	var buf bytes.Buffer
 	writeBaselines(&buf, baselines)
 	out := buf.String()
@@ -255,7 +347,7 @@ func TestWriteBaselines_stalenessColumnAndBanner(t *testing.T) {
 
 	// All fresh: no banner, quiet "ok" verdicts.
 	fresh := []BaselineInfo{{Database: "shop", Table: "orders", SnapshotTime: now.Add(-2 * time.Hour)}}
-	AnnotateBaselineStaleness(fresh, oldest, now)
+	AnnotateBaselineStaleness(fresh, DeltaFloor{Hour: oldest}, now)
 	buf.Reset()
 	writeBaselines(&buf, fresh)
 	if strings.Contains(buf.String(), "BASELINE STALE") {

--- a/internal/status/staleness_test.go
+++ b/internal/status/staleness_test.go
@@ -76,6 +76,31 @@ func TestDeltaFloorGrade(t *testing.T) {
 	if got := (DeltaFloor{Hour: live, BelowIsUnknown: true}).Grade(now.Add(-time.Hour), now); got != BaselineOK {
 		t.Fatalf("in-window snapshot: got %s, want ok", got)
 	}
+	// Aging is deliberately NOT demoted: it is a true statement about the
+	// window that IS provable, and demoting it would erase the only signal
+	// left on a multi-source index.
+	if got := (DeltaFloor{Hour: live, BelowIsUnknown: true}).Grade(now.Add(-9*time.Hour), now); got != BaselineAging {
+		t.Fatalf("in-window aging snapshot: got %s, want aging", got)
+	}
+}
+
+// TestOverallBaselineStalenessRanksUnknownOverAging: #1219 makes unknown the
+// routine below-floor verdict, and aging is the one verdict the codebase
+// treats as ignorable (it never alerts). A table that CANNOT be evaluated
+// must not hide behind a merely-old one in the headline.
+func TestOverallBaselineStalenessRanksUnknownOverAging(t *testing.T) {
+	baselines := []BaselineInfo{
+		{Database: "shop", Table: "orders", SnapshotTime: time.Unix(2000, 0), Staleness: BaselineAging},
+		{Database: "shop", Table: "legacy", SnapshotTime: time.Unix(1000, 0), Staleness: BaselineUnknown},
+	}
+	if got := OverallBaselineStaleness(baselines); got != BaselineUnknown {
+		t.Fatalf("got %s, want unknown", got)
+	}
+	// Broken still outranks everything: a known-broken table is actionable.
+	baselines[0].Staleness = BaselineBroken
+	if got := OverallBaselineStaleness(baselines); got != BaselineBroken {
+		t.Fatalf("got %s, want broken", got)
+	}
 }
 
 func TestOldestDeltaFromDB(t *testing.T) {
@@ -89,10 +114,11 @@ func TestOldestDeltaFromDB(t *testing.T) {
 		}
 		return r
 	}
-	// ExpectationsWereMet on every subtest pins the QUERY SET, not just the
-	// result: the single-source path must keep costing exactly two queries
-	// (plus the sources probe), and an extra round trip in the common case
-	// would fail here.
+	// Two mechanisms pin the QUERY SET, not just the result: sqlmock's
+	// ordered mode rejects an UNEXPECTED query at call time (that is what
+	// catches a new round trip on the single-source path), and
+	// ExpectationsWereMet catches the converse — a query the code stopped
+	// issuing, e.g. the sources probe silently skipped.
 	newDB := func(t *testing.T) (*sql.DB, sqlmock.Sqlmock) {
 		t.Helper()
 		db, mock, err := sqlmock.New()
@@ -244,6 +270,23 @@ func TestOldestDeltaFromDB(t *testing.T) {
 		mock.ExpectQuery(archQ).WillReturnRows(archRows("weird", "p_2026080105", 1))
 		if _, err := OldestDeltaFromDB(context.Background(), db, "binlog_index"); err == nil {
 			t.Fatal("unparseable archive floor must propagate, not silently drop")
+		}
+	})
+
+	t.Run("archived hours naming no source are unattributable", func(t *testing.T) {
+		// COUNT(DISTINCT bintrail_id) == 0 with a valid MIN means every
+		// archive row has a NULL id (the column is nullable). Rows naming no
+		// source are the strongest case of "cannot attribute" — reading the
+		// zero as single-source would extend the floor with them.
+		db, mock := newDB(t)
+		mock.ExpectQuery(partsQ).WillReturnRows(partRows("p_2026080110"))
+		mock.ExpectQuery(archQ).WillReturnRows(archRows("p_2026080101", "p_2026080109", 0))
+		got, err := OldestDeltaFromDB(context.Background(), db, "binlog_index")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !got.Hour.Equal(time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)) || !got.BelowIsUnknown {
+			t.Fatalf("got %+v — want the live floor with BelowIsUnknown", got)
 		}
 	})
 

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -1395,6 +1395,20 @@ func writeBaselines(w io.Writer, baselines []BaselineInfo) {
 	// predates delta coverage cannot be fully restored through that hole, and
 	// waiting for restore time to find out is the failure mode #1193 exists
 	// to remove.
+	// The check being DISARMED is itself a finding: a bare "unknown" in the
+	// column reads as a cosmetic gap, while it actually means a broken
+	// restore window would not be detected here (#1219 makes this the routine
+	// verdict for below-floor snapshots on multi-source indexes; an
+	// unreadable floor lands here too).
+	if OverallBaselineStaleness(baselines) == BaselineUnknown {
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "=== ⚠ BASELINE STALENESS NOT EVALUABLE ===")
+		fmt.Fprintln(w, "The delta-coverage floor could not be established for at least one table:")
+		fmt.Fprintln(w, "an index serving more than one source cannot attribute archived coverage to")
+		fmt.Fprintln(w, "the source that owns a baseline, and an unreadable index yields the same.")
+		fmt.Fprintln(w, "A broken restore window would NOT be detected here — see")
+		fmt.Fprintln(w, "docs/rotation-and-status.md (Baseline staleness).")
+	}
 	if OverallBaselineStaleness(baselines) == BaselineBroken {
 		fmt.Fprintln(w)
 		fmt.Fprintln(w, "=== ⚠ BASELINE STALE — FULL-TABLE RESTORE BROKEN ===")


### PR DESCRIPTION
closes #1219 · part of the continuous backup assurance epic #1189

## Summary
- **The split that fixes it**: live partitions are SHARED across sources (every source writes the same range-partitioned `binlog_events`, so their oldest hour is a valid floor for everyone with no attribution), `archive_state` rows are not. The live floor stands; only the backwards extension needs a source identity — and a baseline snapshot carries none.
- **`status.DeltaFloor{Hour, BelowIsUnknown}`** replaces the bare `time.Time`. When the archives cannot be attributed, `Hour` stays at the live partitions and `Grade` demotes what would have been `broken` to `unknown` — one place, one rule. `broken` there would page an operator whose archives genuinely cover the snapshot (two sources both archiving since May); `ok` is the missed alarm the issue reports. Snapshots **inside** the live window keep a real verdict.
- **Attribution uses two cheap signals**, because either alone leaves a hole: `COUNT(DISTINCT bintrail_id)` rides the archive query that was already there (no extra round trip; no NULL bucket to reason about — `rotate` refuses to archive without an id), plus a `COUNT(*) FROM bintrail_servers` probe for the case the archive rows cannot see — a second source that has not archived yet, whose baselines would still inherit the first one's floor. `1146` on either table keeps single-source semantics (legacy / file-mode indexes); any other registry error propagates.
- **The watcher is the load-bearing half**: an `unknown` verdict falls out of the broken-tables set, and the call below reports `broken=false`, which **resolves** — adding a second source to an index would have silently cleared a standing `baseline_stale` alert. Ambiguity now skips the target behind a `staleness-attribution:` unknown edge, the same shape as the unknown-floor skip, never a `Resolve`.
- `CoverageSummary.DeltaFrom` carries the live floor on those indexes and its stale `#1219` caveat comment is gone; `docs/rotation-and-status.md` states the multi-source behavior and the two ways out.

## Test plan
- [x] Query set pinned per subtest with `ExpectationsWereMet` — the single-source path cannot silently grow a round trip
- [x] Multi-source by archives (short-circuits the registry probe) and by registry; `1146` tolerance on both tables; non-1146 registry error propagates
- [x] `Grade` demotion incl. the in-window case that must stay graded
- [x] Watcher: fire → ambiguous (no resolve, no re-fire) → attributable again (still no re-fire), across three cycles
- [x] `go vet -tags integration ./...`, `go test -race` on `internal/status` + `consoleapp`, full unit suite ALL-GREEN
- [ ] Integration suite NOT run locally (no Docker daemon on this machine) — the tagged build compiles and CI runs it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
