### PR TITLE
assurance: exported read-only accessors for the backup-assurance signals

### DIFF
--- a/assurance/assurance.go
+++ b/assurance/assurance.go
@@ -8,17 +8,24 @@
 // one-line wrappers over the internal entry points. It adds no computation of
 // its own, and deliberately so — every verdict here has exactly one
 // implementation in the core, and an embedder that rendered its own would
-// contradict `bintrail status` about the same index. Aliases, not wrapper
-// structs, are what make that structural rather than a matter of discipline.
+// contradict `bintrail status` about the same index.
 //
-// Read-only: nothing here writes to the index, the archives, or the console's
-// local files.
+// What the aliases buy is narrow and worth stating exactly: they make a
+// FORKED STRUCT impossible, because an alias is the internal type rather than
+// a copy of it. They do not make a forked COMPUTATION impossible — DeltaFloor
+// exposes Hour, so "grade through Grade, never through Hour alone" stays a
+// rule a caller must follow. Where such a rule exists, the doc says so.
+//
+// Read-only, with one exception worth naming rather than glossing: no
+// function here writes anything, but VerifyHistory is an alias, so its whole
+// method set travels — including Append, which rewrites the console's history
+// file. That is the watch daemon's write path; an embedder must not call it
+// (see OpenVerifyHistory).
 //
 // Note for callers inside this repo: this package imports internal/console
 // (the verify history is console-local state on disk), so importing assurance
-// from a core command would trip the decouple guard in cliapp/uifree_test.go
-// — cmd/bintrail must not link the console, however indirectly. This facade
-// is for embedders, not for the core CLI.
+// from anything cmd/bintrail links would trip the decouple guard in
+// cliapp/uifree_test.go. This facade is for embedders, not for the core CLI.
 package assurance
 
 import (
@@ -29,23 +36,25 @@ import (
 	"github.com/dbtrail/dbtrail/internal/console"
 	"github.com/dbtrail/dbtrail/internal/reconstruct"
 	"github.com/dbtrail/dbtrail/internal/status"
+	"github.com/dbtrail/dbtrail/internal/verify"
 )
 
-// Aliases to the internal assurance types.
 type (
 	// CoverageSummary is the live restore-coverage window (#1194).
 	CoverageSummary = status.CoverageSummary
 	// StreamStateInfo is the capture checkpoint ContinuityStatus grades.
 	StreamStateInfo = status.StreamStateInfo
 	// DeltaFloor is the delta-coverage floor and whether values below it can
-	// be attributed to a source at all (#1213/#1219). Grade THROUGH it; using
+	// be attributed to a source at all (#1193/#1219). Grade THROUGH it; using
 	// Hour alone on a multi-source index manufactures false "broken".
 	DeltaFloor = status.DeltaFloor
 	// BaselineInfo is one baseline snapshot as graded by staleness (#1193).
 	BaselineInfo = status.BaselineInfo
-	// BaselineStalenessVerdict is ok / aging / broken / unknown.
+	// BaselineStalenessVerdict is ok / aging / broken / unknown — plus the
+	// empty string, which OverallBaselineStaleness can return; see there.
 	BaselineStalenessVerdict = status.BaselineStalenessVerdict
-	// BaselineFile is one table's Parquet file in a baseline listing.
+	// BaselineFile is one table's Parquet file in a baseline listing. Its
+	// Schema field is BaselineInfo's Database under another name.
 	BaselineFile = reconstruct.BaselineFile
 
 	// VerifyHistory is the persisted scheduled-verify run history (#1191).
@@ -58,7 +67,11 @@ type (
 	VerifyTableResult = console.VerifyTableResult
 	// VerifySummary is a run's match/mismatch/inconclusive tally.
 	VerifySummary = console.VerifySummary
-	// VerifyMode is the verify mode a run used.
+	// VerifyMode is which engine path a run used: baseline-anchored (compare
+	// the two newest baselines), live-source (compare against production) or
+	// recover-inputs (index-only chain walk). They assert different things —
+	// a summary that renders them alike lets the weakest inherit the
+	// strongest's meaning.
 	VerifyMode = console.VerifyMode
 )
 
@@ -71,81 +84,186 @@ const (
 	BaselineUnknown = status.BaselineUnknown
 )
 
-// Verify run triggers, plus the history-only "skipped" state.
+// Continuity verdicts, as returned by ContinuityStatus and carried in
+// CoverageSummary.Continuity:
+//
+//	ContinuityOK          — no gap in the captured range. NOT a liveness
+//	                        claim: it says nothing about the stream running
+//	                        now (CoverageSummary.LagSeconds is that signal).
+//	ContinuityGapLost     — an unfillable gap was stamped: events are
+//	                        permanently lost.
+//	ContinuityUnknown     — a legacy index without the gap columns: whether a
+//	                        gap happened is unevaluable, never a false "ok".
+//	ContinuityUnavailable — stream_state could not be read, likewise.
+//	ContinuityNone        — no stream row (file-mode index): no capture ran,
+//	                        so no continuity could break. A genuine no-claim.
+//
+// Branching on "not gap_lost" folds the two unevaluable verdicts into a pass,
+// which is the error this vocabulary exists to prevent.
+const (
+	ContinuityOK          = status.ContinuityOK
+	ContinuityGapLost     = status.ContinuityGapLost
+	ContinuityUnknown     = status.ContinuityUnknown
+	ContinuityUnavailable = status.ContinuityUnavailable
+	ContinuityNone        = status.ContinuityNone
+)
+
+// Verify run triggers and the VerifyStatus.State vocabulary. "Not skipped" is
+// not "verified" — it also admits failed and the two transient states.
 const (
 	VerifyTriggerManual    = console.VerifyTriggerManual
 	VerifyTriggerScheduled = console.VerifyTriggerScheduled
 	VerifyStateSkipped     = console.VerifyStateSkipped
+	VerifyStateIdle        = console.VerifyStateIdle
+	VerifyStateRunning     = console.VerifyStateRunning
+	VerifyStateSucceeded   = console.VerifyStateSucceeded
+	VerifyStateFailed      = console.VerifyStateFailed
 )
+
+// Verify modes (VerifyStatus.Mode).
+const (
+	VerifyModeBaselineAnchored = console.VerifyModeBaselineAnchored
+	VerifyModeLiveSource       = console.VerifyModeLiveSource
+	VerifyModeRecoverInputs    = console.VerifyModeRecoverInputs
+)
+
+// Per-table verify outcomes (VerifyTableResult.Status), sourced from the
+// engine's own vocabulary so they cannot drift from it.
+//
+// VerifyTableInconclusive is NOT a failure — the comparison could not be made
+// meaningfully — and is equally not a match. VerifyTableError is what an
+// unrecognized engine status normalizes to, so it is never a benign value
+// (#1127). A consumer that only looks for mismatch misses both.
+const (
+	VerifyTableMatch        = string(verify.StatusMatch)
+	VerifyTableMismatch     = string(verify.StatusMismatch)
+	VerifyTableInconclusive = string(verify.StatusInconclusive)
+	VerifyTableError        = string(verify.StatusError)
+)
+
+// VerifyHistoryCap is how many runs the history keeps per server. Eviction is
+// SILENT, so a List of exactly this length must be reported as a possibly
+// truncated window — otherwise a summary states "no failed runs" about a
+// period whose failures fell off the front.
+const VerifyHistoryCap = console.VerifyHistoryCap
 
 // CollectCoverageSummary computes the restore-coverage window for one index:
 // the delta floor, the newest indexed event, capture lag, and the continuity
 // verdict. Cheap by construction (no COUNT(*), no whole-table MAX).
+//
+// It warns-and-degrades rather than failing: only the newest-event read is
+// fatal. A failed floor query leaves Floor zero and a failed stream read
+// yields ContinuityUnavailable, both with a nil error — so read a zero
+// Floor.Hour as "the floor is unknown", never as "coverage starts at the
+// epoch". Call OldestDeltaFromDB directly when an unknown floor and a failed
+// query have to be told apart.
 func CollectCoverageSummary(ctx context.Context, db *sql.DB, dbName string, now time.Time) (*CoverageSummary, error) {
 	return status.CollectCoverageSummary(ctx, db, dbName, now)
 }
 
 // ContinuityStatus is the single rule that turns a stream checkpoint into a
-// continuity verdict: ok / gap_lost / unknown / unavailable / none. Pass the
-// error from LoadStreamState alongside the value — a read failure is
-// "unavailable", never a silent "ok".
+// continuity verdict (see the Continuity* constants). Pass the error from
+// LoadStreamState alongside the value — ContinuityUnavailable is reachable
+// only through that error, so dropping it renders an unreadable checkpoint as
+// ContinuityNone, a genuine no-claim.
 func ContinuityStatus(stream *StreamStateInfo, streamErr error) string {
 	return status.ContinuityStatus(stream, streamErr)
 }
 
 // LoadStreamState reads the single-row capture checkpoint. A nil value with a
 // nil error means no stream row at all (a file-mode index).
+//
+// On an index predating the gap columns it falls back to the older column set
+// and returns GapColumnsPresent false with a nil error — which is why such an
+// index grades ContinuityUnknown. The console never migrates registry-
+// configured indexes, so an embedder reading one hits this routinely; it is
+// not evidence of a gap, nor evidence against one.
 func LoadStreamState(ctx context.Context, db *sql.DB) (*StreamStateInfo, error) {
 	return status.LoadStreamState(ctx, db)
 }
 
 // OldestDeltaFromDB determines how far back the index can restore: the oldest
-// live partition, extended backwards only across CONTIGUOUS archived hours,
-// and only when those archives can be attributed to a single source.
+// live partition, extended backwards across archived hours that reach it, and
+// only when those archives can be attributed to a single source.
+//
+// It is a lower bound on where coverage STARTS, not a promise the range is
+// hole-free: interior holes inside the archived range are invisible to it.
 func OldestDeltaFromDB(ctx context.Context, db *sql.DB, dbName string) (DeltaFloor, error) {
 	return status.OldestDeltaFromDB(ctx, db, dbName)
 }
 
 // AnnotateBaselineStaleness grades each baseline in place against the floor.
+// OverallBaselineStaleness reads the verdicts this writes, so it has to run
+// first — an ungraded slice reduces to the empty verdict.
 func AnnotateBaselineStaleness(baselines []BaselineInfo, floor DeltaFloor, now time.Time) {
 	status.AnnotateBaselineStaleness(baselines, floor, now)
 }
 
-// OverallBaselineStaleness reduces per-baseline verdicts to one, worst-first
-// (broken > unknown > aging > ok).
+// OverallBaselineStaleness reduces to one verdict, worst-first (broken >
+// unknown > aging > ok), over each TABLE'S NEWEST snapshot — an old snapshot
+// does not outvote a fresh one for the same table.
+//
+// It returns the empty verdict, which is none of the four constants, when the
+// input is empty or ungraded. Empty input is the worst baseline posture there
+// is (no full-table reconstruct is possible at all), so it must not fall
+// through a consumer's switch as "no finding".
 func OverallBaselineStaleness(baselines []BaselineInfo) BaselineStalenessVerdict {
 	return status.OverallBaselineStaleness(baselines)
 }
 
 // ListBaselines enumerates the baseline snapshot files under source (a local
 // directory or an s3:// prefix), newest snapshot first. Path-derived only —
-// no Parquet contents are read.
+// no Parquet contents are read, so BaselineFile carries no binlog coordinates
+// and no file size, and this listing is narrower than `bintrail status`'s.
+//
+// It can come back short without an error: snapshots marked incomplete are
+// excluded by design (#467), and an unreadable snapshot or schema directory
+// is skipped with a log warning. An empty result means "nothing readable was
+// found", not "no baselines exist" — and feeding it to
+// OverallBaselineStaleness yields the empty verdict, so the two silent paths
+// converge unless the caller checks.
 func ListBaselines(ctx context.Context, source string) ([]BaselineFile, error) {
 	return reconstruct.ListBaselines(ctx, source)
 }
 
-// DefaultRegistryPath returns the console server-registry path the console
-// uses when --servers-file is not set. Re-exported because the history is
-// located relative to it: without this a caller would hardcode the path, and
-// a relocated or later-moved registry would silently read no history at all.
+// DefaultRegistryPath returns the console server-registry path used when
+// neither --servers-file (serve) nor --console-servers-file (watch) is set.
+// Re-exported because the history is located relative to it: without this a
+// caller would hardcode the path and silently read no history once an
+// operator configured one.
+//
+// It cannot fail, which is itself the caveat: with no usable HOME — a daemon
+// under a hardened unit, a scratch container — it falls back to a
+// CWD-RELATIVE path, so which file it names depends on the working directory.
+// A caller that must not read the wrong history should take the path from its
+// own configuration rather than defaulting.
 func DefaultRegistryPath() string {
 	return console.DefaultRegistryPath()
 }
 
 // DefaultVerifyHistoryPath returns the verify-history file path for a given
-// console server-registry path (the history lives beside the registry). For
-// a console running on defaults that is
+// console server-registry path (the history lives beside the registry). For a
+// console on defaults that is
 // DefaultVerifyHistoryPath(DefaultRegistryPath()); pass the operator's
 // --servers-file / --console-servers-file value when one is configured.
 func DefaultVerifyHistoryPath(serversPath string) string {
 	return console.DefaultVerifyHistoryPath(serversPath)
 }
 
-// OpenVerifyHistory loads the verify-run history at path for reading. A
-// missing file yields an empty history whose Found reports false — check it:
-// the history is written only by `bintrail-console watch`, so "absent" and
-// "present with no failures" are different facts and must not render alike.
-// A corrupt or newer-versioned file is an error rather than a silent empty.
+// OpenVerifyHistory loads the verify-run history at path. A corrupt or
+// newer-versioned file is an error rather than a silent empty history.
+//
+// A missing file yields an empty history whose Found reports false — check
+// it. The file is written only by `bintrail-console watch`: a CLI-only or
+// `bintrail-console serve` deployment has none, and watch itself records
+// nothing when the file was unreadable at startup. Found false therefore
+// means "no runs were ever RECORDED here", which must not render like
+// "nothing failed".
+//
+// The returned value is the daemon's own handle: Append is reachable on it
+// and rewrites the whole file from that instance's in-memory state, so an
+// embedder calling it while watch runs would discard the daemon's records.
+// Read through Found, ServerIDs and List; never write.
 func OpenVerifyHistory(path string) (*VerifyHistory, error) {
 	return console.OpenVerifyHistory(path)
 }

--- a/assurance/assurance.go
+++ b/assurance/assurance.go
@@ -1,0 +1,140 @@
+// Package assurance exposes read-only access to the backup-assurance signals
+// — restore coverage, the capture-continuity verdict, baseline staleness, and
+// the scheduled-verify run history — for tooling and embedding distributions
+// that import the core as a module.
+//
+// It is a thin facade, the same shape as indexquery: type aliases to the
+// internal types (usable across module boundaries through the alias) plus
+// one-line wrappers over the internal entry points. It adds no computation of
+// its own, and deliberately so — every verdict here has exactly one
+// implementation in the core, and an embedder that rendered its own would
+// contradict `bintrail status` about the same index. Aliases, not wrapper
+// structs, are what make that structural rather than a matter of discipline.
+//
+// Read-only: nothing here writes to the index, the archives, or the console's
+// local files.
+//
+// Note for callers inside this repo: this package imports internal/console
+// (the verify history is console-local state on disk), so importing assurance
+// from a core command would trip the decouple guard in cliapp/uifree_test.go
+// — cmd/bintrail must not link the console, however indirectly. This facade
+// is for embedders, not for the core CLI.
+package assurance
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/console"
+	"github.com/dbtrail/dbtrail/internal/reconstruct"
+	"github.com/dbtrail/dbtrail/internal/status"
+)
+
+// Aliases to the internal assurance types.
+type (
+	// CoverageSummary is the live restore-coverage window (#1194).
+	CoverageSummary = status.CoverageSummary
+	// StreamStateInfo is the capture checkpoint ContinuityStatus grades.
+	StreamStateInfo = status.StreamStateInfo
+	// DeltaFloor is the delta-coverage floor and whether values below it can
+	// be attributed to a source at all (#1213/#1219). Grade THROUGH it; using
+	// Hour alone on a multi-source index manufactures false "broken".
+	DeltaFloor = status.DeltaFloor
+	// BaselineInfo is one baseline snapshot as graded by staleness (#1193).
+	BaselineInfo = status.BaselineInfo
+	// BaselineStalenessVerdict is ok / aging / broken / unknown.
+	BaselineStalenessVerdict = status.BaselineStalenessVerdict
+	// BaselineFile is one table's Parquet file in a baseline listing.
+	BaselineFile = reconstruct.BaselineFile
+
+	// VerifyHistory is the persisted scheduled-verify run history (#1191).
+	VerifyHistory = console.VerifyHistory
+	// VerifyRunRecord is one completed or skipped run.
+	VerifyRunRecord = console.VerifyRunRecord
+	// VerifyStatus is the per-run verdict embedded in VerifyRunRecord.
+	VerifyStatus = console.VerifyStatus
+	// VerifyTableResult is one table's outcome within a run.
+	VerifyTableResult = console.VerifyTableResult
+	// VerifySummary is a run's match/mismatch/inconclusive tally.
+	VerifySummary = console.VerifySummary
+	// VerifyMode is the verify mode a run used.
+	VerifyMode = console.VerifyMode
+)
+
+// Baseline staleness verdicts. Unknown means the check could not be
+// evaluated — never treat it as either healthy or broken.
+const (
+	BaselineOK      = status.BaselineOK
+	BaselineAging   = status.BaselineAging
+	BaselineBroken  = status.BaselineBroken
+	BaselineUnknown = status.BaselineUnknown
+)
+
+// Verify run triggers, plus the history-only "skipped" state.
+const (
+	VerifyTriggerManual    = console.VerifyTriggerManual
+	VerifyTriggerScheduled = console.VerifyTriggerScheduled
+	VerifyStateSkipped     = console.VerifyStateSkipped
+)
+
+// CollectCoverageSummary computes the restore-coverage window for one index:
+// the delta floor, the newest indexed event, capture lag, and the continuity
+// verdict. Cheap by construction (no COUNT(*), no whole-table MAX).
+func CollectCoverageSummary(ctx context.Context, db *sql.DB, dbName string, now time.Time) (*CoverageSummary, error) {
+	return status.CollectCoverageSummary(ctx, db, dbName, now)
+}
+
+// ContinuityStatus is the single rule that turns a stream checkpoint into a
+// continuity verdict: ok / gap_lost / unknown / unavailable / none. Pass the
+// error from LoadStreamState alongside the value — a read failure is
+// "unavailable", never a silent "ok".
+func ContinuityStatus(stream *StreamStateInfo, streamErr error) string {
+	return status.ContinuityStatus(stream, streamErr)
+}
+
+// LoadStreamState reads the single-row capture checkpoint. A nil value with a
+// nil error means no stream row at all (a file-mode index).
+func LoadStreamState(ctx context.Context, db *sql.DB) (*StreamStateInfo, error) {
+	return status.LoadStreamState(ctx, db)
+}
+
+// OldestDeltaFromDB determines how far back the index can restore: the oldest
+// live partition, extended backwards only across CONTIGUOUS archived hours,
+// and only when those archives can be attributed to a single source.
+func OldestDeltaFromDB(ctx context.Context, db *sql.DB, dbName string) (DeltaFloor, error) {
+	return status.OldestDeltaFromDB(ctx, db, dbName)
+}
+
+// AnnotateBaselineStaleness grades each baseline in place against the floor.
+func AnnotateBaselineStaleness(baselines []BaselineInfo, floor DeltaFloor, now time.Time) {
+	status.AnnotateBaselineStaleness(baselines, floor, now)
+}
+
+// OverallBaselineStaleness reduces per-baseline verdicts to one, worst-first
+// (broken > unknown > aging > ok).
+func OverallBaselineStaleness(baselines []BaselineInfo) BaselineStalenessVerdict {
+	return status.OverallBaselineStaleness(baselines)
+}
+
+// ListBaselines enumerates the baseline snapshot files under source (a local
+// directory or an s3:// prefix), newest snapshot first. Path-derived only —
+// no Parquet contents are read.
+func ListBaselines(ctx context.Context, source string) ([]BaselineFile, error) {
+	return reconstruct.ListBaselines(ctx, source)
+}
+
+// DefaultVerifyHistoryPath returns the verify-history file path for a given
+// console server-registry path (the history lives beside the registry).
+func DefaultVerifyHistoryPath(serversPath string) string {
+	return console.DefaultVerifyHistoryPath(serversPath)
+}
+
+// OpenVerifyHistory loads the verify-run history at path for reading. A
+// missing file yields an empty history whose Found reports false — check it:
+// the history is written only by `bintrail-console watch`, so "absent" and
+// "present with no failures" are different facts and must not render alike.
+// A corrupt or newer-versioned file is an error rather than a silent empty.
+func OpenVerifyHistory(path string) (*VerifyHistory, error) {
+	return console.OpenVerifyHistory(path)
+}

--- a/assurance/assurance.go
+++ b/assurance/assurance.go
@@ -124,8 +124,19 @@ func ListBaselines(ctx context.Context, source string) ([]BaselineFile, error) {
 	return reconstruct.ListBaselines(ctx, source)
 }
 
+// DefaultRegistryPath returns the console server-registry path the console
+// uses when --servers-file is not set. Re-exported because the history is
+// located relative to it: without this a caller would hardcode the path, and
+// a relocated or later-moved registry would silently read no history at all.
+func DefaultRegistryPath() string {
+	return console.DefaultRegistryPath()
+}
+
 // DefaultVerifyHistoryPath returns the verify-history file path for a given
-// console server-registry path (the history lives beside the registry).
+// console server-registry path (the history lives beside the registry). For
+// a console running on defaults that is
+// DefaultVerifyHistoryPath(DefaultRegistryPath()); pass the operator's
+// --servers-file / --console-servers-file value when one is configured.
 func DefaultVerifyHistoryPath(serversPath string) string {
 	return console.DefaultVerifyHistoryPath(serversPath)
 }

--- a/assurance/assurance_test.go
+++ b/assurance/assurance_test.go
@@ -1,7 +1,9 @@
 package assurance
 
 import (
+	"context"
 	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -9,6 +11,7 @@ import (
 	"github.com/dbtrail/dbtrail/internal/console"
 	"github.com/dbtrail/dbtrail/internal/reconstruct"
 	"github.com/dbtrail/dbtrail/internal/status"
+	"github.com/dbtrail/dbtrail/internal/verify"
 )
 
 // The facade must ALIAS the internal types, never restate them. A separately
@@ -16,6 +19,11 @@ import (
 // package and still give an embedder its own copy to drift with — and these
 // types carry verdicts (`bintrail status` renders the same ones). Assignment
 // between two distinct named types does not compile, so this pins it.
+//
+// The named non-struct types use `*new(T)`: `var _ status.BaselineStalenessVerdict
+// = BaselineUnknown` would type the CONSTANT, not the type, and compiles
+// whether or not the type is an alias. VerifyHistory is pinned in pointer
+// form — the value form compiles but trips go vet's copylocks (sync.Mutex).
 func TestFacadeTypesAreTheInternalTypes(t *testing.T) {
 	var (
 		_ status.CoverageSummary          = CoverageSummary{}
@@ -25,28 +33,69 @@ func TestFacadeTypesAreTheInternalTypes(t *testing.T) {
 		_ status.BaselineInfo             = BaselineInfo{}
 		_ BaselineInfo                    = status.BaselineInfo{}
 		_ status.StreamStateInfo          = StreamStateInfo{}
-		_ status.BaselineStalenessVerdict = BaselineUnknown
+		_ status.BaselineStalenessVerdict = *new(BaselineStalenessVerdict)
 		_ reconstruct.BaselineFile        = BaselineFile{}
 		_ BaselineFile                    = reconstruct.BaselineFile{}
+		_ *console.VerifyHistory          = (*VerifyHistory)(nil)
 		_ console.VerifyRunRecord         = VerifyRunRecord{}
 		_ VerifyRunRecord                 = console.VerifyRunRecord{}
 		_ console.VerifyStatus            = VerifyStatus{}
 		_ console.VerifySummary           = VerifySummary{}
 		_ console.VerifyTableResult       = VerifyTableResult{}
+		_ console.VerifyMode              = *new(VerifyMode)
 	)
-	if VerifyTriggerScheduled != console.VerifyTriggerScheduled || VerifyStateSkipped != console.VerifyStateSkipped {
-		t.Fatal("re-exported verify constants drifted from the core's")
+}
+
+// Every re-exported constant must carry the core's value. These can only fail
+// if someone replaces a `= pkg.X` re-export with a hand-written literal, which
+// is exactly how a wire vocabulary drifts.
+func TestConstantsMatchTheCore(t *testing.T) {
+	pairs := []struct {
+		name      string
+		got, want string
+	}{
+		{"ContinuityOK", ContinuityOK, status.ContinuityOK},
+		{"ContinuityGapLost", ContinuityGapLost, status.ContinuityGapLost},
+		{"ContinuityUnknown", ContinuityUnknown, status.ContinuityUnknown},
+		{"ContinuityUnavailable", ContinuityUnavailable, status.ContinuityUnavailable},
+		{"ContinuityNone", ContinuityNone, status.ContinuityNone},
+		{"VerifyTriggerManual", VerifyTriggerManual, console.VerifyTriggerManual},
+		{"VerifyTriggerScheduled", VerifyTriggerScheduled, console.VerifyTriggerScheduled},
+		{"VerifyStateSkipped", VerifyStateSkipped, console.VerifyStateSkipped},
+		{"VerifyStateIdle", VerifyStateIdle, console.VerifyStateIdle},
+		{"VerifyStateRunning", VerifyStateRunning, console.VerifyStateRunning},
+		{"VerifyStateSucceeded", VerifyStateSucceeded, console.VerifyStateSucceeded},
+		{"VerifyStateFailed", VerifyStateFailed, console.VerifyStateFailed},
+		{"VerifyTableMatch", VerifyTableMatch, string(verify.StatusMatch)},
+		{"VerifyTableMismatch", VerifyTableMismatch, string(verify.StatusMismatch)},
+		{"VerifyTableInconclusive", VerifyTableInconclusive, string(verify.StatusInconclusive)},
+		{"VerifyTableError", VerifyTableError, string(verify.StatusError)},
+		{"VerifyModeBaselineAnchored", string(VerifyModeBaselineAnchored), string(console.VerifyModeBaselineAnchored)},
+		{"VerifyModeLiveSource", string(VerifyModeLiveSource), string(console.VerifyModeLiveSource)},
+		{"VerifyModeRecoverInputs", string(VerifyModeRecoverInputs), string(console.VerifyModeRecoverInputs)},
+		{"BaselineOK", string(BaselineOK), string(status.BaselineOK)},
+		{"BaselineAging", string(BaselineAging), string(status.BaselineAging)},
+		{"BaselineBroken", string(BaselineBroken), string(status.BaselineBroken)},
+		{"BaselineUnknown", string(BaselineUnknown), string(status.BaselineUnknown)},
+	}
+	for _, p := range pairs {
+		if p.got != p.want {
+			t.Errorf("%s = %q, core has %q", p.name, p.got, p.want)
+		}
+	}
+	if VerifyHistoryCap != console.VerifyHistoryCap {
+		t.Errorf("VerifyHistoryCap = %d, core has %d", VerifyHistoryCap, console.VerifyHistoryCap)
 	}
 }
 
 func TestContinuityStatusReachesTheOneRule(t *testing.T) {
 	// The two verdicts a facade is most likely to get wrong by re-deriving:
 	// no stream row is a genuine no-claim, an unreadable one is not "ok".
-	if got := ContinuityStatus(nil, nil); got != "none" {
-		t.Fatalf("no stream row = %q, want none", got)
+	if got := ContinuityStatus(nil, nil); got != ContinuityNone {
+		t.Fatalf("no stream row = %q, want %q", got, ContinuityNone)
 	}
-	if got := ContinuityStatus(nil, errors.New("boom")); got != "unavailable" {
-		t.Fatalf("unreadable stream state = %q, want unavailable", got)
+	if got := ContinuityStatus(nil, errors.New("boom")); got != ContinuityUnavailable {
+		t.Fatalf("unreadable stream state = %q, want %q", got, ContinuityUnavailable)
 	}
 }
 
@@ -60,44 +109,155 @@ func TestStalenessGradingKeepsTheAmbiguityDemotion(t *testing.T) {
 	attributable := DeltaFloor{Hour: now.Add(-24 * time.Hour)}
 	AnnotateBaselineStaleness(below, attributable, now)
 	if below[0].Staleness != BaselineBroken {
-		t.Fatalf("below an attributable floor = %q, want broken", below[0].Staleness)
+		t.Fatalf("below an attributable floor = %q, want %q", below[0].Staleness, BaselineBroken)
 	}
 
 	ambiguous := DeltaFloor{Hour: now.Add(-24 * time.Hour), BelowIsUnknown: true}
 	AnnotateBaselineStaleness(below, ambiguous, now)
 	if below[0].Staleness != BaselineUnknown {
-		t.Fatalf("below an unattributable floor = %q, want unknown", below[0].Staleness)
+		t.Fatalf("below an unattributable floor = %q, want %q", below[0].Staleness, BaselineUnknown)
 	}
 	if got := OverallBaselineStaleness(below); got != BaselineUnknown {
-		t.Fatalf("overall = %q, want unknown", got)
+		t.Fatalf("overall = %q, want %q", got, BaselineUnknown)
 	}
 }
 
-// A caller reporting on verification activity must be able to see that there
-// is no history at all — the file is written only by `bintrail-console
-// watch`, so an empty List on a CLI-only deployment means "never verified",
-// not "nothing failed".
-func TestVerifyHistoryAbsenceIsVisibleThroughTheFacade(t *testing.T) {
-	path := DefaultVerifyHistoryPath(filepath.Join(t.TempDir(), "console-servers.yaml"))
+// End-to-end through the facade: absent, existing-but-empty, and populated.
+// The populated leg is what pins that OpenVerifyHistory reads the file the
+// path names — pointing it at a sibling path (or any wrong file) satisfies
+// every "absent" assertion forever, and a consumer wired that way reports
+// "never verified" for a deployment that verifies nightly.
+func TestVerifyHistoryRoundTripThroughTheFacade(t *testing.T) {
+	dir := t.TempDir()
+	path := DefaultVerifyHistoryPath(filepath.Join(dir, "console-servers.yaml"))
 	if base := filepath.Base(path); base != "console-verify-history.json" {
 		t.Fatalf("history path = %q", base)
 	}
-	// The default location has to be derivable through the facade too, or a
-	// caller hardcodes it and reads nothing once the registry moves.
-	if got, want := DefaultRegistryPath(), console.DefaultRegistryPath(); got != want {
-		t.Fatalf("DefaultRegistryPath() = %q, want %q", got, want)
+
+	absent, err := OpenVerifyHistory(path)
+	if err != nil {
+		t.Fatal(err)
 	}
-	if filepath.Dir(DefaultVerifyHistoryPath(DefaultRegistryPath())) != filepath.Dir(DefaultRegistryPath()) {
-		t.Fatal("the default history does not sit beside the default registry")
+	if absent.Found() {
+		t.Fatal("Found() true with no history file on disk")
 	}
+	if ids := absent.ServerIDs(); len(ids) != 0 {
+		t.Fatalf("server ids from an absent history: %v", ids)
+	}
+	if recs := absent.List("srv1"); len(recs) != 0 {
+		t.Fatalf("records from an absent history: %v", recs)
+	}
+
+	// Written by the daemon side, deliberately not through the facade — the
+	// facade's contract is read-only.
+	writer, err := console.OpenVerifyHistory(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec := console.VerifyRunRecord{
+		ServerID: "srv1", ServerName: "wp", Trigger: console.VerifyTriggerScheduled,
+		VerifyStatus: console.VerifyStatus{
+			State: console.VerifyStateSucceeded, Mode: console.VerifyModeRecoverInputs,
+			Summary: console.VerifySummary{Match: 3, Total: 3},
+		},
+	}
+	if err := writer.Append(rec); err != nil {
+		t.Fatal(err)
+	}
+
 	h, err := OpenVerifyHistory(path)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if h.Found() {
-		t.Fatal("Found() true with no history file on disk")
+	if !h.Found() {
+		t.Fatal("Found() false after a run was recorded")
 	}
-	if ids := h.ServerIDs(); len(ids) != 0 {
-		t.Fatalf("server ids from an absent history: %v", ids)
+	ids := h.ServerIDs()
+	if len(ids) != 1 || ids[0] != "srv1" {
+		t.Fatalf("ServerIDs() = %v, want [srv1]", ids)
+	}
+	got := h.List("srv1")
+	if len(got) != 1 {
+		t.Fatalf("List() returned %d records, want 1", len(got))
+	}
+	if got[0].State != VerifyStateSucceeded || got[0].Trigger != VerifyTriggerScheduled ||
+		got[0].Mode != VerifyModeRecoverInputs || got[0].Summary.Match != 3 {
+		t.Fatalf("record did not survive the facade: %+v", got[0])
+	}
+}
+
+// A corrupt history must not degrade into an empty one: through the facade
+// that would be indistinguishable from "this deployment never verified".
+func TestOpenVerifyHistoryForwardsTheCorruptFileError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "console-verify-history.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	h, err := OpenVerifyHistory(path)
+	if err == nil {
+		t.Fatalf("corrupt history opened cleanly: found=%v", h.Found())
+	}
+}
+
+// Presence in ServerIDs is not evidence that a server was verified: a
+// scheduled cycle that could not run is recorded rather than dropped, so a
+// server can appear with nothing but skips behind it.
+func TestSkippedOnlyServerIsDistinguishable(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "console-verify-history.json")
+	writer, err := console.OpenVerifyHistory(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Append(console.VerifyRunRecord{
+		ServerID: "srv1", Trigger: console.VerifyTriggerScheduled,
+		SkipReason:   "a manual run was already in flight",
+		VerifyStatus: console.VerifyStatus{State: console.VerifyStateSkipped},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	h, err := OpenVerifyHistory(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ids := h.ServerIDs(); len(ids) != 1 {
+		t.Fatalf("ServerIDs() = %v, want the skipped server listed", ids)
+	}
+	recs := h.List("srv1")
+	if len(recs) != 1 || recs[0].State != VerifyStateSkipped || recs[0].SkipReason == "" {
+		t.Fatalf("skip not legible through the facade: %+v", recs)
+	}
+}
+
+func TestListBaselinesThroughTheFacade(t *testing.T) {
+	dir := t.TempDir()
+	snap := filepath.Join(dir, "2026-08-03T12-00-00Z", "shop")
+	if err := os.MkdirAll(snap, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(snap, "orders.parquet"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ListBaselines(context.Background(), dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("ListBaselines() returned %d entries, want 1: %+v", len(got), got)
+	}
+	if got[0].Schema != "shop" || got[0].Table != "orders" {
+		t.Fatalf("wrong entry: %+v", got[0])
+	}
+	if want := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC); !got[0].SnapshotTime.Equal(want) {
+		t.Fatalf("SnapshotTime = %s, want %s", got[0].SnapshotTime, want)
+	}
+}
+
+func TestDefaultRegistryPathIsTheCoreDefault(t *testing.T) {
+	// The default location has to be derivable through the facade, or a
+	// caller hardcodes it and reads nothing once the registry moves.
+	if got, want := DefaultRegistryPath(), console.DefaultRegistryPath(); got != want {
+		t.Fatalf("DefaultRegistryPath() = %q, want %q", got, want)
 	}
 }

--- a/assurance/assurance_test.go
+++ b/assurance/assurance_test.go
@@ -82,6 +82,14 @@ func TestVerifyHistoryAbsenceIsVisibleThroughTheFacade(t *testing.T) {
 	if base := filepath.Base(path); base != "console-verify-history.json" {
 		t.Fatalf("history path = %q", base)
 	}
+	// The default location has to be derivable through the facade too, or a
+	// caller hardcodes it and reads nothing once the registry moves.
+	if got, want := DefaultRegistryPath(), console.DefaultRegistryPath(); got != want {
+		t.Fatalf("DefaultRegistryPath() = %q, want %q", got, want)
+	}
+	if filepath.Dir(DefaultVerifyHistoryPath(DefaultRegistryPath())) != filepath.Dir(DefaultRegistryPath()) {
+		t.Fatal("the default history does not sit beside the default registry")
+	}
 	h, err := OpenVerifyHistory(path)
 	if err != nil {
 		t.Fatal(err)

--- a/assurance/assurance_test.go
+++ b/assurance/assurance_test.go
@@ -1,0 +1,95 @@
+package assurance
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/console"
+	"github.com/dbtrail/dbtrail/internal/reconstruct"
+	"github.com/dbtrail/dbtrail/internal/status"
+)
+
+// The facade must ALIAS the internal types, never restate them. A separately
+// declared struct with identical fields would satisfy every call in this
+// package and still give an embedder its own copy to drift with — and these
+// types carry verdicts (`bintrail status` renders the same ones). Assignment
+// between two distinct named types does not compile, so this pins it.
+func TestFacadeTypesAreTheInternalTypes(t *testing.T) {
+	var (
+		_ status.CoverageSummary          = CoverageSummary{}
+		_ CoverageSummary                 = status.CoverageSummary{}
+		_ status.DeltaFloor               = DeltaFloor{}
+		_ DeltaFloor                      = status.DeltaFloor{}
+		_ status.BaselineInfo             = BaselineInfo{}
+		_ BaselineInfo                    = status.BaselineInfo{}
+		_ status.StreamStateInfo          = StreamStateInfo{}
+		_ status.BaselineStalenessVerdict = BaselineUnknown
+		_ reconstruct.BaselineFile        = BaselineFile{}
+		_ BaselineFile                    = reconstruct.BaselineFile{}
+		_ console.VerifyRunRecord         = VerifyRunRecord{}
+		_ VerifyRunRecord                 = console.VerifyRunRecord{}
+		_ console.VerifyStatus            = VerifyStatus{}
+		_ console.VerifySummary           = VerifySummary{}
+		_ console.VerifyTableResult       = VerifyTableResult{}
+	)
+	if VerifyTriggerScheduled != console.VerifyTriggerScheduled || VerifyStateSkipped != console.VerifyStateSkipped {
+		t.Fatal("re-exported verify constants drifted from the core's")
+	}
+}
+
+func TestContinuityStatusReachesTheOneRule(t *testing.T) {
+	// The two verdicts a facade is most likely to get wrong by re-deriving:
+	// no stream row is a genuine no-claim, an unreadable one is not "ok".
+	if got := ContinuityStatus(nil, nil); got != "none" {
+		t.Fatalf("no stream row = %q, want none", got)
+	}
+	if got := ContinuityStatus(nil, errors.New("boom")); got != "unavailable" {
+		t.Fatalf("unreadable stream state = %q, want unavailable", got)
+	}
+}
+
+// The #1219 demotion has to survive the trip through the facade: below an
+// unattributable floor a snapshot grades unknown, not broken. An embedder
+// that got "broken" here would page an operator whose archives are fine.
+func TestStalenessGradingKeepsTheAmbiguityDemotion(t *testing.T) {
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	below := []BaselineInfo{{Database: "shop", Table: "orders", SnapshotTime: now.Add(-72 * time.Hour)}}
+
+	attributable := DeltaFloor{Hour: now.Add(-24 * time.Hour)}
+	AnnotateBaselineStaleness(below, attributable, now)
+	if below[0].Staleness != BaselineBroken {
+		t.Fatalf("below an attributable floor = %q, want broken", below[0].Staleness)
+	}
+
+	ambiguous := DeltaFloor{Hour: now.Add(-24 * time.Hour), BelowIsUnknown: true}
+	AnnotateBaselineStaleness(below, ambiguous, now)
+	if below[0].Staleness != BaselineUnknown {
+		t.Fatalf("below an unattributable floor = %q, want unknown", below[0].Staleness)
+	}
+	if got := OverallBaselineStaleness(below); got != BaselineUnknown {
+		t.Fatalf("overall = %q, want unknown", got)
+	}
+}
+
+// A caller reporting on verification activity must be able to see that there
+// is no history at all — the file is written only by `bintrail-console
+// watch`, so an empty List on a CLI-only deployment means "never verified",
+// not "nothing failed".
+func TestVerifyHistoryAbsenceIsVisibleThroughTheFacade(t *testing.T) {
+	path := DefaultVerifyHistoryPath(filepath.Join(t.TempDir(), "console-servers.yaml"))
+	if base := filepath.Base(path); base != "console-verify-history.json" {
+		t.Fatalf("history path = %q", base)
+	}
+	h, err := OpenVerifyHistory(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h.Found() {
+		t.Fatal("Found() true with no history file on disk")
+	}
+	if ids := h.ServerIDs(); len(ids) != 0 {
+		t.Fatalf("server ids from an absent history: %v", ids)
+	}
+}

--- a/assurance/external_test.go
+++ b/assurance/external_test.go
@@ -1,0 +1,92 @@
+package assurance_test
+
+// This file compiles the facade from an EMBEDDER's vantage: it imports only
+// github.com/dbtrail/dbtrail/assurance and never an internal package, the way
+// a consumer in another module must. Nothing else in the repo does that — the
+// in-package tests can always name the internal types, so a wrapper that
+// returned an un-aliased internal type would compile there and be unusable
+// everywhere it matters. It breaks here and nowhere else.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/assurance"
+)
+
+// Names every exported type and calls every wrapper that needs no database,
+// building a plausible report shape end to end.
+func TestFacadeIsUsableWithoutInternalPackages(t *testing.T) {
+	var (
+		sum      assurance.CoverageSummary
+		floor    assurance.DeltaFloor
+		stream   *assurance.StreamStateInfo
+		verdict  assurance.BaselineStalenessVerdict
+		file     assurance.BaselineFile
+		rec      assurance.VerifyRunRecord
+		tableRes assurance.VerifyTableResult
+		tally    assurance.VerifySummary
+		st       assurance.VerifyStatus
+		mode     assurance.VerifyMode
+	)
+	_, _, _ = sum, st, tally
+
+	if got := assurance.ContinuityStatus(stream, nil); got != assurance.ContinuityNone {
+		t.Fatalf("continuity of a missing checkpoint = %q, want %q", got, assurance.ContinuityNone)
+	}
+
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	file = assurance.BaselineFile{SnapshotTime: now.Add(-72 * time.Hour), Schema: "shop", Table: "orders"}
+	// The one conversion a consumer writes by hand — BaselineFile names the
+	// schema "Schema", BaselineInfo names it "Database".
+	infos := []assurance.BaselineInfo{{
+		Database: file.Schema, Table: file.Table, SnapshotTime: file.SnapshotTime,
+	}}
+	floor = assurance.DeltaFloor{Hour: now.Add(-24 * time.Hour), BelowIsUnknown: true}
+	assurance.AnnotateBaselineStaleness(infos, floor, now)
+	verdict = assurance.OverallBaselineStaleness(infos)
+	if verdict != assurance.BaselineUnknown {
+		t.Fatalf("overall staleness = %q, want %q", verdict, assurance.BaselineUnknown)
+	}
+
+	// The absent-history path, which is what a CLI-only deployment hits.
+	path := assurance.DefaultVerifyHistoryPath(assurance.DefaultRegistryPath())
+	if path == "" {
+		t.Fatal("no default history path")
+	}
+	h, err := assurance.OpenVerifyHistory(t.TempDir() + "/console-verify-history.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h.Found() {
+		t.Fatal("Found() true for a history that does not exist")
+	}
+	for _, id := range h.ServerIDs() {
+		for _, r := range h.List(id) {
+			rec, mode = r, r.Mode
+			if len(r.Results) > 0 {
+				tableRes = r.Results[0]
+			}
+		}
+	}
+	_, _, _ = rec, mode, tableRes
+
+	// The verdict vocabularies a summary has to branch on must all be
+	// nameable from out here — hardcoding them is the drift this prevents.
+	for _, s := range []string{
+		assurance.ContinuityOK, assurance.ContinuityGapLost, assurance.ContinuityUnknown,
+		assurance.ContinuityUnavailable, assurance.ContinuityNone,
+		assurance.VerifyStateSucceeded, assurance.VerifyStateFailed, assurance.VerifyStateSkipped,
+		assurance.VerifyStateIdle, assurance.VerifyStateRunning,
+		assurance.VerifyTriggerManual, assurance.VerifyTriggerScheduled,
+		assurance.VerifyTableMatch, assurance.VerifyTableMismatch,
+		assurance.VerifyTableInconclusive, assurance.VerifyTableError,
+	} {
+		if s == "" {
+			t.Fatal("an exported verdict constant is empty")
+		}
+	}
+	if assurance.VerifyHistoryCap <= 0 {
+		t.Fatal("VerifyHistoryCap is not a usable bound")
+	}
+}

--- a/consoleapp/verify.go
+++ b/consoleapp/verify.go
@@ -115,7 +115,7 @@ func (s *verifySupervisor) RunScheduled(req console.VerifyRequest) error {
 // the one-at-a-time-per-server rule cannot drift between them.
 func (s *verifySupervisor) begin(req console.VerifyRequest, trigger string) (string, error) {
 	s.mu.Lock()
-	if j, ok := s.jobs[req.ServerID]; ok && j.status.State == "running" {
+	if j, ok := s.jobs[req.ServerID]; ok && j.status.State == console.VerifyStateRunning {
 		s.mu.Unlock()
 		return "", console.ErrVerifyRunning
 	}
@@ -124,7 +124,7 @@ func (s *verifySupervisor) begin(req console.VerifyRequest, trigger string) (str
 		baselineSrc = req.BaselineS3
 	}
 	s.jobs[req.ServerID] = &verifyJob{
-		status:     console.VerifyStatus{State: "running", Mode: req.Mode, Since: nowStamp()},
+		status:     console.VerifyStatus{State: console.VerifyStateRunning, Mode: req.Mode, Since: nowStamp()},
 		mode:       req.Mode,
 		serverName: req.ServerName,
 		trigger:    trigger,
@@ -144,7 +144,7 @@ func (s *verifySupervisor) Status(serverID string) console.VerifyStatus {
 	if j, ok := s.jobs[serverID]; ok {
 		return j.status
 	}
-	return console.VerifyStatus{State: "idle"}
+	return console.VerifyStatus{State: console.VerifyStateIdle}
 }
 
 // Explain re-runs the row-level drill-down for one table the last completed
@@ -577,10 +577,10 @@ func (s *verifySupervisor) finish(serverID string, err error) {
 	}
 	j.status.FinishedAt = nowStamp()
 	if err != nil {
-		j.status.State = "failed"
+		j.status.State = console.VerifyStateFailed
 		j.status.LastError = err.Error()
 	} else {
-		j.status.State = "succeeded"
+		j.status.State = console.VerifyStateSucceeded
 	}
 	rec := console.VerifyRunRecord{
 		ServerID:     serverID,

--- a/internal/console/verify_history.go
+++ b/internal/console/verify_history.go
@@ -3,6 +3,7 @@ package console
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -63,6 +64,7 @@ const verifyHistoryVersion = 1
 type VerifyHistory struct {
 	mu      sync.Mutex
 	path    string
+	found   bool
 	servers map[string][]VerifyRunRecord
 }
 
@@ -85,6 +87,7 @@ func OpenVerifyHistory(path string) (*VerifyHistory, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read verify history %s: %w", path, err)
 	}
+	h.found = true
 	if len(data) == 0 {
 		return h, nil
 	}
@@ -141,6 +144,23 @@ func (h *VerifyHistory) List(serverID string) []VerifyRunRecord {
 		out[len(recs)-1-i] = r
 	}
 	return out
+}
+
+// Found reports whether a history file existed when this history was opened.
+// A consumer that reports on verification activity MUST keep this distinct
+// from an opened-but-empty history: the file is written only by
+// `bintrail-console watch`, so a CLI-only deployment has no history at all,
+// and rendering that absence like "no failed runs" would state a clean
+// verification record for a period nothing ever verified.
+func (h *VerifyHistory) Found() bool { return h.found }
+
+// ServerIDs returns the server ids present in the history, sorted, so a
+// consumer can enumerate what was recorded without access to the server
+// registry (a run's server may since have been removed from it).
+func (h *VerifyHistory) ServerIDs() []string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return slices.Sorted(maps.Keys(h.servers))
 }
 
 // save writes the file atomically. Callers hold h.mu. Same temp-file + fsync

--- a/internal/console/verify_history.go
+++ b/internal/console/verify_history.go
@@ -10,10 +10,16 @@ import (
 	"sync"
 )
 
-// verifyHistoryCap is how many runs are kept per server. Old records fall off
+// VerifyHistoryCap is how many runs are kept per server. Old records fall off
 // the front — the history answers "when did this last verify, and how has it
 // been trending", not "archive every run forever".
-const verifyHistoryCap = 20
+//
+// Exported because eviction is SILENT: a consumer summarizing the history has
+// no other way to tell "these are all the runs there ever were" from "these
+// are the newest VerifyHistoryCap of them". A server whose List is exactly
+// this long must be reported as a possibly-truncated window, or a summary
+// says "no failed runs" about a period whose failures fell off the front.
+const VerifyHistoryCap = 20
 
 // VerifyRunRecord is one completed (or skipped) verify run as stored in the
 // history file and served by GET /api/servers/{id}/verify/history. It embeds
@@ -41,6 +47,17 @@ const (
 	VerifyTriggerManual    = "manual"
 	VerifyTriggerScheduled = "scheduled"
 	VerifyStateSkipped     = "skipped"
+)
+
+// The rest of the VerifyStatus.State vocabulary. Named alongside
+// VerifyStateSkipped because a consumer summarizing the history has to branch
+// on all of them: "not skipped" is NOT "verified" — it also admits failed,
+// and the two transient states a run can be caught in.
+const (
+	VerifyStateIdle      = "idle"
+	VerifyStateRunning   = "running"
+	VerifyStateSucceeded = "succeeded"
+	VerifyStateFailed    = "failed"
 )
 
 // verifyHistoryFile is the on-disk envelope: versioned like the server
@@ -115,8 +132,8 @@ func (h *VerifyHistory) Append(rec VerifyRunRecord) error {
 	// Clone before appending: an in-place append could write into old's spare
 	// capacity, which would corrupt the rollback below.
 	recs := append(slices.Clone(old), rec)
-	if len(recs) > verifyHistoryCap {
-		recs = recs[len(recs)-verifyHistoryCap:]
+	if len(recs) > VerifyHistoryCap {
+		recs = recs[len(recs)-VerifyHistoryCap:]
 	}
 	h.servers[rec.ServerID] = recs
 	if err := h.save(); err != nil {

--- a/internal/console/verify_history_test.go
+++ b/internal/console/verify_history_test.go
@@ -61,17 +61,17 @@ func TestVerifyHistory_CapDropsOldest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for i := range verifyHistoryCap + 5 {
+	for i := range VerifyHistoryCap + 5 {
 		if err := h.Append(VerifyRunRecord{ServerID: "s", VerifyStatus: VerifyStatus{Summary: VerifySummary{Total: i}}}); err != nil {
 			t.Fatal(err)
 		}
 	}
 	got := h.List("s")
-	if len(got) != verifyHistoryCap {
-		t.Fatalf("want cap of %d records, got %d", verifyHistoryCap, len(got))
+	if len(got) != VerifyHistoryCap {
+		t.Fatalf("want cap of %d records, got %d", VerifyHistoryCap, len(got))
 	}
 	// Newest first: got[0] is the last appended, the tail is the oldest kept.
-	if got[0].Summary.Total != verifyHistoryCap+4 || got[len(got)-1].Summary.Total != 5 {
+	if got[0].Summary.Total != VerifyHistoryCap+4 || got[len(got)-1].Summary.Total != 5 {
 		t.Fatalf("cap dropped the wrong end: newest=%d oldest=%d", got[0].Summary.Total, got[len(got)-1].Summary.Total)
 	}
 }

--- a/internal/console/verify_history_test.go
+++ b/internal/console/verify_history_test.go
@@ -127,6 +127,69 @@ func TestOpenVerifyHistory_RefusesCorruptAndNewer(t *testing.T) {
 	}
 }
 
+// Found is about the FILE, not the records: "this deployment never ran the
+// scheduled verifier" and "it ran and nothing failed" are both an empty
+// List, and a consumer that reports on verification activity has to tell them
+// apart or it states a clean record for a period nothing ever verified.
+func TestVerifyHistory_FoundSeparatesAbsentFromEmpty(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "console-verify-history.json")
+
+	h, err := OpenVerifyHistory(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h.Found() {
+		t.Fatal("Found() is true for a history file that does not exist")
+	}
+	if ids := h.ServerIDs(); len(ids) != 0 {
+		t.Fatalf("absent history has server ids: %v", ids)
+	}
+
+	// An existing file with zero records still counts as found — the history
+	// is present, it simply has nothing in this window.
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	empty, err := OpenVerifyHistory(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !empty.Found() {
+		t.Fatal("Found() is false for an existing (empty) history file")
+	}
+
+	if err := h.Append(VerifyRunRecord{
+		ServerID: "srv1", Trigger: VerifyTriggerScheduled,
+		VerifyStatus: VerifyStatus{State: "succeeded"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := OpenVerifyHistory(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reopened.Found() {
+		t.Fatal("Found() is false after a run was recorded")
+	}
+}
+
+func TestVerifyHistory_ServerIDsEnumeratesSorted(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "h.json")
+	h, err := OpenVerifyHistory(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"srv2", "srv1", "srv2"} {
+		if err := h.Append(VerifyRunRecord{ServerID: id, VerifyStatus: VerifyStatus{State: "succeeded"}}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got := h.ServerIDs()
+	if len(got) != 2 || got[0] != "srv1" || got[1] != "srv2" {
+		t.Fatalf("ServerIDs() = %v, want [srv1 srv2]", got)
+	}
+}
+
 func TestDefaultVerifyHistoryPath_SiblingOfRegistry(t *testing.T) {
 	got := DefaultVerifyHistoryPath("/etc/bintrail/console-servers.yaml")
 	if got != "/etc/bintrail/console-verify-history.json" {

--- a/internal/status/coverage.go
+++ b/internal/status/coverage.go
@@ -25,17 +25,30 @@ import (
 func ContinuityStatus(stream *StreamStateInfo, streamErr error) string {
 	switch {
 	case stream == nil && streamErr != nil:
-		return "unavailable"
+		return ContinuityUnavailable
 	case stream == nil:
-		return "none"
+		return ContinuityNone
 	case stream.GapLostAt.Valid:
-		return "gap_lost"
+		return ContinuityGapLost
 	case !stream.GapColumnsPresent:
-		return "unknown"
+		return ContinuityUnknown
 	default:
-		return "ok"
+		return ContinuityOK
 	}
 }
+
+// The continuity verdict vocabulary, named so a consumer branches on a symbol
+// instead of a literal. Only ContinuityGapLost and ContinuityOK are claims
+// about the captured range; a consumer that treats everything-but-gap_lost as
+// healthy folds the two "never a false ok" verdicts into a pass, which is the
+// error this vocabulary exists to prevent.
+const (
+	ContinuityOK          = "ok"
+	ContinuityGapLost     = "gap_lost"
+	ContinuityUnknown     = "unknown"
+	ContinuityUnavailable = "unavailable"
+	ContinuityNone        = "none"
+)
 
 // CoverageSummary is the lean live-RPO view behind the console's coverage
 // card (#1194): the reconstructable delta window, capture lag, and the


### PR DESCRIPTION
closes #1233 · follows the `indexquery` facade precedent

## Summary
- New top-level `assurance` package: the #1189 signals (restore coverage, continuity verdict, baseline staleness, scheduled-verify history) reachable from code that imports the core as a module. Type aliases + one-line wrappers; **no computation of its own**.
- **Aliases, not wrapper structs**, and that is the point: these types carry verdicts `bintrail status` renders too. A restated struct would compile everywhere and still let an embedder's rendering drift from the CLI's on the same index. `TestFacadeTypesAreTheInternalTypes` pins it — assignment between two distinct named types does not compile.
- **`console.VerifyHistory` gained two read accessors**: `ServerIDs()` (enumerate recorded runs without the server registry — a removed server is no longer in it) and `Found()`. `Found` is the load-bearing one: the history file is written **only** by `bintrail-console watch`, so on a CLI-only deployment `List` returns empty for a deployment that never verified once. Without it a consumer reports that absence as a clean verification record — the same absence-of-evidence error #1193/#1219 fixed in the delta floor. `Found` is about the FILE, not the record count, so an existing-but-empty history still reads as present.
- Staleness travels through the facade **with the #1219 demotion intact**: below an unattributable floor a snapshot grades `unknown`, never `broken`.
- The package imports `internal/console`, so it must stay out of the core CLI's import graph; `cliapp/uifree_test.go` remains the guard and still passes (`go list -deps ./cmd/bintrail` has zero console packages).

## Test plan
- [x] `TestFacadeTypesAreTheInternalTypes` — alias identity for every exported type, plus constant re-export drift
- [x] Continuity through the facade: `none` (no stream row) vs `unavailable` (unreadable) — the two a re-derivation gets wrong
- [x] Staleness: attributable floor → `broken`, unattributable → `unknown`, overall → `unknown`
- [x] `Found` separates absent / existing-but-empty / written; `ServerIDs` sorted and deduplicated
- [x] `go vet -tags integration ./...`, `go test -race` on `assurance` + `internal/console`, full unit suite ALL-GREEN
- [ ] Integration suite NOT run locally (no Docker daemon on this machine) — the tagged build compiles and CI runs it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
