### PR TITLE
query: filter events by statement digest (--query-hash)

### DIFF
--- a/demo/image/my.cnf
+++ b/demo/image/my.cnf
@@ -10,6 +10,12 @@ server-id               = 1
 log-bin                 = mysql-bin
 binlog-format           = ROW
 binlog-row-image        = FULL
+# Log the originating SQL statement alongside each transaction's row events
+# (ROWS_QUERY_EVENT). bintrail indexes it into binlog_events.query_text +
+# query_hash. Without it the demo shows every forensic surface with an empty
+# statement column, which reads as "bintrail cannot capture this" rather than
+# "this server was not asked to log it".
+binlog-rows-query-log-events = ON
 binlog-expire-logs-seconds = 0
 
 # GTID — enables --start-gtid in bintrail stream

--- a/demo/image/my.cnf
+++ b/demo/image/my.cnf
@@ -10,11 +10,13 @@ server-id               = 1
 log-bin                 = mysql-bin
 binlog-format           = ROW
 binlog-row-image        = FULL
-# Log the originating SQL statement alongside each transaction's row events
-# (ROWS_QUERY_EVENT). bintrail indexes it into binlog_events.query_text +
-# query_hash. Without it the demo shows every forensic surface with an empty
-# statement column, which reads as "bintrail cannot capture this" rather than
-# "this server was not asked to log it".
+# Log the originating SQL statement alongside each STATEMENT's row events
+# (one ROWS_QUERY_EVENT per statement, not per transaction). bintrail indexes it
+# into binlog_events.query_text + query_hash. Without it the demo's CLI and shim
+# surfaces show an empty statement column, which reads as "bintrail cannot
+# capture this" rather than "this server was not asked to log it". (The web
+# console withholds both columns regardless — that is the open-core boundary,
+# not a capture gap.)
 binlog-rows-query-log-events = ON
 binlog-expire-logs-seconds = 0
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -236,6 +236,15 @@ both accept:
 - `profile` — RBAC table-deny + column-redaction
 - `no_archive` — disable Parquet archive auto-routing (see below)
 
+`query` also takes `query_hash` — the 64-character statement digest of an event
+you already have, returning every event that statement produced across every
+table it touched. It selects a statement *shape* (literals are normalised
+away), so it is a read filter only: `recover` does not accept it, because a
+reversal scoped to a shape would undo executions nobody named. It is refused on
+surfaces that withhold statement text (the console's `/mcp`) and whenever a
+`profile` is active — the digest is blanked on every returned event there, so
+filtering on it would confirm what is withheld.
+
 The `pk` parameter takes the stored `pk_values` spelling — for a binary PK
 whose bytes are not valid UTF-8 that is `0x` + uppercase hex, see
 [Binary primary keys](query-and-recovery.md#binary-primary-keys-the-0x-hex-spelling).

--- a/docs/query-and-recovery.md
+++ b/docs/query-and-recovery.md
@@ -127,6 +127,20 @@ When the source logs the original SQL statement alongside row events, `bintrail`
 - **`query_text`** — the literal statement that produced the row event (`UPDATE users SET ...`), as the application sent it (subject to the sanitization notes below). One statement covers all of its rows: a 500-row bulk `DELETE` yields 500 events sharing the same text, and each statement in a multi-statement transaction carries its own.
 - **`query_hash`** — MySQL's `STATEMENT_DIGEST()` of that text, computed against the **index** server at index time. Statements that differ only in literal values share one hash, so you can group by it to find the query patterns mutating a table ("which statement shape is behind this DELETE volume?").
 
+**Filtering by statement** — pass a digest you already have back as a filter to see everything that statement did:
+
+```bash
+# every event the statement produced, across every table it touched
+bintrail query --index-dsn "..." --query-hash 3f2a...e91 --format json
+```
+
+`--query-hash` is a **read** filter and exists only on `query` — not on `recover`. The digest names a statement *shape*, not one execution: `WHERE id=1` and `WHERE id=999` share it, so the filter returns every execution of that statement inside the window. That is the right answer for "what does this query pattern touch?" and the wrong basis for a reversal, which would undo executions you never named. Reverse a specific blast radius with the PK/time filters `recover` already has.
+
+Two more things it will not do:
+
+- It is refused, not silently ignored, when `--profile` is set. Under a profile the digest is blanked on every returned row, so filtering on it would confirm the statement the redaction hides — one guessed digest at a time.
+- Archives written before statement capture existed have no digest column; those files are reported (`archive predates statement capture`) and contribute no rows, rather than failing the query.
+
 Capture is **opt-in at the source** — off by default on MySQL, on by default on MariaDB 10.2.4+:
 
 ```sql

--- a/docs/query-and-recovery.md
+++ b/docs/query-and-recovery.md
@@ -136,10 +136,13 @@ bintrail query --index-dsn "..." --query-hash 3f2a...e91 --format json
 
 `--query-hash` is a **read** filter and exists only on `query` — not on `recover`. The digest names a statement *shape*, not one execution: `WHERE id=1` and `WHERE id=999` share it, so the filter returns every execution of that statement inside the window. That is the right answer for "what does this query pattern touch?" and the wrong basis for a reversal, which would undo executions you never named. Reverse a specific blast radius with the PK/time filters `recover` already has.
 
-Two more things it will not do:
+Three more things it will not do:
 
 - It is refused, not silently ignored, when `--profile` is set. Under a profile the digest is blanked on every returned row, so filtering on it would confirm the statement the redaction hides — one guessed digest at a time.
-- Archives written before statement capture existed have no digest column; those files are reported (`archive predates statement capture`) and contribute no rows, rather than failing the query.
+- Archives written before statement capture existed have no digest column and contribute no rows. That is reported per source (`predate statement capture`, with a file count when only *part* of a source is affected), rather than failing the query — but the report is a log line, not an error, so an answer over a half-upgraded archive is narrower than it looks.
+- **Statements over 16 KiB are unreachable by digest.** They are stored truncated and truncated statements are never digested (see the note below), so `query_hash` stays `NULL` on every row a giant bulk `UPDATE`/`DELETE` produced — which is often exactly the statement worth chasing after an incident. You can still see its `query_text`; you cannot filter by it.
+
+When a digest filter returns nothing from a window where **no** event carries a digest at all, `bintrail query` says so on stderr instead of leaving you with a bare empty table: an empty result there means "this source was not logging statements", not "that statement touched nothing".
 
 Capture is **opt-in at the source** — off by default on MySQL, on by default on MariaDB 10.2.4+:
 

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -171,7 +172,7 @@ func (b *Buffer) Fetch(_ context.Context, opts query.Options) []query.ResultRow 
 		// profiles today), but if profile options ever reach it, statement
 		// text must not be the surface that leaks. The stored entry is
 		// untouched — row is a copy, and QueryText is only niled on it.
-		if opts.ProfileActive || len(opts.RedactColumns) > 0 || len(opts.DenyTables) > 0 {
+		if opts.RedactionActive() {
 			row.QueryText = nil
 			row.QueryHash = nil
 		}
@@ -282,6 +283,18 @@ func matchesOpts(e *entry, opts query.Options) bool {
 	}
 	if opts.Until != nil && r.EventTimestamp.After(*opts.Until) {
 		return false
+	}
+	if opts.QueryHash != "" {
+		// A buffered event NEVER carries a digest: STATEMENT_DIGEST is computed
+		// on the index connection when the batch is inserted, and these events
+		// have not been inserted yet (see Insert). So a digest filter excludes
+		// the whole buffer — stated as a rule rather than left to the nil
+		// comparison below, because the failure mode of omitting this branch is
+		// not an empty result, it is buffered rows flowing UNFILTERED into a
+		// digest-scoped answer and being read as that statement's work.
+		if r.QueryHash == nil || !strings.EqualFold(*r.QueryHash, opts.QueryHash) {
+			return false
+		}
 	}
 	if opts.ChangedColumn != "" && !slices.Contains(r.ChangedColumns, opts.ChangedColumn) {
 		return false

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -286,8 +286,10 @@ func matchesOpts(e *entry, opts query.Options) bool {
 	}
 	if opts.QueryHash != "" {
 		// A buffered event NEVER carries a digest: STATEMENT_DIGEST is computed
-		// on the index connection when the batch is inserted, and these events
-		// have not been inserted yet (see Insert). So a digest filter excludes
+		// on the index connection at insert time, and a buffered event has not
+		// reached one — in BYOS mode it may never reach one at all (payload to
+		// the customer's S3, metadata to the API; no digest is computed on
+		// either path). See Insert. So a digest filter excludes
 		// the whole buffer — stated as a rule rather than left to the nil
 		// comparison below, because the failure mode of omitting this branch is
 		// not an empty result, it is buffered rows flowing UNFILTERED into a

--- a/internal/buffer/queryhash_test.go
+++ b/internal/buffer/queryhash_test.go
@@ -1,0 +1,45 @@
+package buffer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/parser"
+	"github.com/dbtrail/dbtrail/internal/query"
+)
+
+// TestFetch_queryHashFilterExcludesTheWholeBuffer pins the BYOS agent's half of
+// the statement-digest filter.
+//
+// A buffered event never carries a digest: STATEMENT_DIGEST is computed on the
+// index connection when a batch is inserted, and these events have not been
+// inserted yet. So the correct answer is "no rows" — and the reason this needs
+// a test is the failure mode of leaving the filter out. It is not an empty
+// result; it is buffered rows flowing UNFILTERED into a digest-scoped answer,
+// where MergeResults folds them in beside genuinely matching MySQL rows and the
+// operator reads them as that statement's work.
+func TestFetch_queryHashFilterExcludesTheWholeBuffer(t *testing.T) {
+	const digest = "3f2a1b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f708"
+
+	buf := New(Config{MaxAge: time.Hour})
+	buf.Insert([]parser.Event{{
+		BinlogFile: "binlog.000001", StartPos: 100, EndPos: 200,
+		Timestamp: time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+		Schema:    "mydb", Table: "orders",
+		EventType: parser.EventInsert, PKValues: "1",
+		RowAfter:  map[string]any{"id": 1},
+		QueryText: "INSERT INTO mydb.orders (id) VALUES (1)",
+	}})
+
+	// Control: every other filter matches, so nothing but the digest can be
+	// responsible for the difference below.
+	if got := buf.Fetch(context.Background(), query.Options{Schema: "mydb", Table: "orders"}); len(got) != 1 {
+		t.Fatalf("unfiltered rows = %d, want 1", len(got))
+	}
+
+	got := buf.Fetch(context.Background(), query.Options{Schema: "mydb", Table: "orders", QueryHash: digest})
+	if len(got) != 0 {
+		t.Fatalf("rows = %d, want 0 — a buffered event carries no digest and must never satisfy a digest filter", len(got))
+	}
+}

--- a/internal/cli/pk_escape_seam_integration_test.go
+++ b/internal/cli/pk_escape_seam_integration_test.go
@@ -120,6 +120,7 @@ func resetQueryGlobals(t *testing.T) {
 	qIndexDSN, qSchema, qTable, qPK = "", "", "", ""
 	qPKs, qLimitPerPK, qEventType, qGTID = nil, 0, "", ""
 	qSince, qUntil, qChangedCol, qColumnEq = "", "", "", nil
+	qQueryHash = ""
 	qFlag, qFormat, qLimit, qOrder = "", "table", 100, "ASC"
 	qArchiveDir, qArchiveS3, qBintrailID, qProfile = "", "", "", ""
 	qNoArchive, qIncludeSnapshot, qBaseline = true, false, ""

--- a/internal/cli/query.go
+++ b/internal/cli/query.go
@@ -93,7 +93,7 @@ func init() {
 	queryCmd.Flags().StringVar(&qSince, "since", "", "Filter events at or after this time (2006-01-02 15:04:05, interpreted as UTC; use RFC3339 with an explicit offset, e.g. 2006-01-02T15:04:05-05:00, for another zone)")
 	queryCmd.Flags().StringVar(&qUntil, "until", "", "Filter events at or before this time (2006-01-02 15:04:05, interpreted as UTC; use RFC3339 with an explicit offset, e.g. 2006-01-02T15:04:05-05:00, for another zone)")
 	queryCmd.Flags().StringVar(&qChangedCol, "changed-column", "", "Filter UPDATEs that modified this column")
-	queryCmd.Flags().StringVar(&qQueryHash, "query-hash", "", "Filter to the events produced by one statement digest (the 64-char query_hash from a previous result; needs binlog_rows_query_log_events=ON at capture time). Matches every execution of that statement shape in the window")
+	queryCmd.Flags().StringVar(&qQueryHash, "query-hash", "", "Filter to the events produced by one statement digest (the 64-char query_hash from a previous result; MySQL/MariaDB sources only, and only while the source logs statements: binlog_rows_query_log_events / binlog_annotate_row_events). Matches every execution of that statement shape in the window")
 	queryCmd.Flags().StringArrayVar(&qColumnEq, "column-eq", nil, "Filter events where a column in row_after or row_before equals the given value (format: column=value, repeat for AND; literal NULL matches JSON null)")
 	queryCmd.Flags().StringVar(&qFlag, "flag", "", "Filter events from tables or columns carrying this flag (see 'bintrail flag list')")
 	queryCmd.Flags().StringVar(&qFormat, "format", "table", "Output format: table, json, or csv")

--- a/internal/cli/query.go
+++ b/internal/cli/query.go
@@ -47,7 +47,10 @@ Examples:
 
   # Rows where 'status' changed
   bintrail query --index-dsn "..." --schema mydb --table orders \
-    --changed-column status --since "2026-02-19 14:00:00"`,
+    --changed-column status --since "2026-02-19 14:00:00"
+
+  # Everything one statement did, across every table it touched
+  bintrail query --index-dsn "..." --query-hash 9c1e...  # from a previous result's query_hash`,
 	RunE: runQuery,
 }
 
@@ -63,6 +66,7 @@ var (
 	qSince           string
 	qUntil           string
 	qChangedCol      string
+	qQueryHash       string
 	qColumnEq        []string
 	qFlag            string
 	qFormat          string
@@ -89,6 +93,7 @@ func init() {
 	queryCmd.Flags().StringVar(&qSince, "since", "", "Filter events at or after this time (2006-01-02 15:04:05, interpreted as UTC; use RFC3339 with an explicit offset, e.g. 2006-01-02T15:04:05-05:00, for another zone)")
 	queryCmd.Flags().StringVar(&qUntil, "until", "", "Filter events at or before this time (2006-01-02 15:04:05, interpreted as UTC; use RFC3339 with an explicit offset, e.g. 2006-01-02T15:04:05-05:00, for another zone)")
 	queryCmd.Flags().StringVar(&qChangedCol, "changed-column", "", "Filter UPDATEs that modified this column")
+	queryCmd.Flags().StringVar(&qQueryHash, "query-hash", "", "Filter to the events produced by one statement digest (the 64-char query_hash from a previous result; needs binlog_rows_query_log_events=ON at capture time). Matches every execution of that statement shape in the window")
 	queryCmd.Flags().StringArrayVar(&qColumnEq, "column-eq", nil, "Filter events where a column in row_after or row_before equals the given value (format: column=value, repeat for AND; literal NULL matches JSON null)")
 	queryCmd.Flags().StringVar(&qFlag, "flag", "", "Filter events from tables or columns carrying this flag (see 'bintrail flag list')")
 	queryCmd.Flags().StringVar(&qFormat, "format", "table", "Output format: table, json, or csv")
@@ -151,6 +156,17 @@ func runQuery(cmd *cobra.Command, args []string) error {
 	}
 	if len(qColumnEq) > 0 && (qSchema == "" || qTable == "") {
 		return fmt.Errorf("--column-eq requires both --schema and --table")
+	}
+	queryHash, err := query.NormalizeQueryHash(qQueryHash)
+	if err != nil {
+		return fmt.Errorf("--query-hash: %w", err)
+	}
+	// Refused here as well as in the engine so the operator gets the flag names
+	// back. Under a profile the digest is blanked on every returned row, so
+	// filtering on it would confirm the statement the redaction hides — see
+	// query.ErrQueryHashUnderProfile.
+	if queryHash != "" && qProfile != "" {
+		return fmt.Errorf("--query-hash cannot be combined with --profile: the statement digest is withheld from every row under a profile, so filtering on it would confirm what the profile hides")
 	}
 	columnEq, err := query.ParseColumnEqs(qColumnEq)
 	if err != nil {
@@ -224,6 +240,7 @@ func runQuery(cmd *cobra.Command, args []string) error {
 		Since:         since,
 		Until:         until,
 		ChangedColumn: qChangedCol,
+		QueryHash:     queryHash,
 		ColumnEq:      columnEq,
 		Flag:          qFlag,
 		Limit:         qLimit,

--- a/internal/cli/query.go
+++ b/internal/cli/query.go
@@ -93,7 +93,7 @@ func init() {
 	queryCmd.Flags().StringVar(&qSince, "since", "", "Filter events at or after this time (2006-01-02 15:04:05, interpreted as UTC; use RFC3339 with an explicit offset, e.g. 2006-01-02T15:04:05-05:00, for another zone)")
 	queryCmd.Flags().StringVar(&qUntil, "until", "", "Filter events at or before this time (2006-01-02 15:04:05, interpreted as UTC; use RFC3339 with an explicit offset, e.g. 2006-01-02T15:04:05-05:00, for another zone)")
 	queryCmd.Flags().StringVar(&qChangedCol, "changed-column", "", "Filter UPDATEs that modified this column")
-	queryCmd.Flags().StringVar(&qQueryHash, "query-hash", "", "Filter to the events produced by one statement digest (the 64-char query_hash from a previous result; MySQL/MariaDB sources only, and only while the source logs statements: binlog_rows_query_log_events / binlog_annotate_row_events). Matches every execution of that statement shape in the window")
+	queryCmd.Flags().StringVar(&qQueryHash, "query-hash", "", "Filter to the events produced by one statement digest (the 64-char query_hash from a previous result; MySQL/MariaDB sources only, and only while the source logs statements: binlog_rows_query_log_events, or binlog_annotate_row_events plus --source-flavor mariadb when streaming). Matches every execution of that statement shape in the window")
 	queryCmd.Flags().StringArrayVar(&qColumnEq, "column-eq", nil, "Filter events where a column in row_after or row_before equals the given value (format: column=value, repeat for AND; literal NULL matches JSON null)")
 	queryCmd.Flags().StringVar(&qFlag, "flag", "", "Filter events from tables or columns carrying this flag (see 'bintrail flag list')")
 	queryCmd.Flags().StringVar(&qFormat, "format", "table", "Output format: table, json, or csv")
@@ -246,6 +246,14 @@ func runQuery(cmd *cobra.Command, args []string) error {
 		Limit:         qLimit,
 		LimitPerPK:    qLimitPerPK,
 		Order:         qOrder,
+	}
+
+	// The engine validates this too, but a fully-archived window skips
+	// Engine.Fetch (see plan.SkipMySQL below) and the archive engine carries no
+	// policy check of its own — so on that path this call is the only one that
+	// runs.
+	if err := opts.ValidateStatementFilter(); err != nil {
+		return err
 	}
 
 	// ── Connect and fetch from the index ─────────────────────────────────────
@@ -444,6 +452,25 @@ func runQuery(cmd *cobra.Command, args []string) error {
 	}
 	if n >= qLimit {
 		fmt.Fprintf(os.Stderr, "Warning: results truncated at %d rows. Use a narrower time range or --limit to adjust.\n", qLimit)
+	}
+	// An empty digest-filtered result means one of two opposite things. Probe
+	// only here — after the answer came back empty — so the cost lands on the
+	// query that needs the disambiguation and on no other. Both channels, per
+	// the archive-visibility invariant: a --log-level change must not be able
+	// to silence the line that says the answer is structurally narrower than it
+	// looks. A failed probe is itself reported: falling back to silence would
+	// restore exactly the ambiguity this exists to remove.
+	if opts.QueryHash != "" && n == 0 {
+		captured, probeErr := query.DigestCaptureInWindow(cmd.Context(), db, opts)
+		switch {
+		case probeErr != nil:
+			fmt.Fprintf(os.Stderr, "Warning: could not determine whether this window carries statement digests: %s\n", probeErr)
+			slog.Warn("statement-digest capture probe failed", "error", probeErr)
+		case !captured:
+			fmt.Fprintln(os.Stderr, query.NoDigestCaptureWarning)
+			slog.Warn("no statement digests in window; empty result is not evidence the statement touched nothing",
+				"query_hash", opts.QueryHash)
+		}
 	}
 	return nil
 }

--- a/internal/cli/queryhash_integration_test.go
+++ b/internal/cli/queryhash_integration_test.go
@@ -1,0 +1,95 @@
+//go:build integration
+
+package cli
+
+import (
+	"database/sql"
+	"encoding/json"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestQueryHashSeam_CLI closes the gap every unit test in this feature leaves
+// open: they all build query.Options by hand or assert a refusal, so NONE of
+// them touches the one line that connects --query-hash to the engine
+// (`QueryHash: queryHash` in runQuery's Options literal). Deleting that line
+// keeps the entire suite green while `bintrail query --query-hash <digest>`
+// returns EVERY event in the window — an unfiltered answer presented under the
+// documented promise "everything that statement did". A silent over-return on a
+// forensic question is worse than the empty-result failures the rest of this
+// feature is written against: there is no missing output to be suspicious of.
+//
+// So this asserts through the real command entry point, on a real index, on the
+// count: 2 of 4 seeded events.
+func TestQueryHashSeam_CLI(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	target := "UPDATE app.orders SET status = 'shipped' WHERE id = 1"
+	other := "DELETE FROM app.orders WHERE id = 9"
+	targetDigest := cliStatementDigest(t, db, target)
+	otherDigest := cliStatementDigest(t, db, other)
+
+	ts := "2026-06-01 12:00:00"
+	insertCLIStatementEvent(t, db, ts, 100, "1", target, targetDigest)
+	insertCLIStatementEvent(t, db, ts, 200, "2", target, targetDigest)
+	insertCLIStatementEvent(t, db, ts, 300, "9", other, otherDigest)
+	// Captured while the source was not logging statements: no text, no digest.
+	testutil.InsertEvent(t, db, "bin.000001", 400, 500, ts, nil, "app", "orders", 1, "42", nil, nil, []byte(`{"id":42}`))
+
+	resetQueryGlobals(t)
+	qIndexDSN, qFormat, qNoArchive = testutil.IntegrationDSN(dbName), "json", true
+	qQueryHash = targetDigest
+
+	var runErr error
+	out := captureStdout(t, func() { runErr = runQuery(newQueryTestCmd(), nil) })
+	if runErr != nil {
+		t.Fatalf("runQuery: %v", runErr)
+	}
+
+	var rows []struct {
+		PKValues  string  `json:"pk_values"`
+		QueryHash *string `json:"query_hash"`
+	}
+	if err := json.Unmarshal([]byte(out), &rows); err != nil {
+		t.Fatalf("unmarshal %q: %v", out, err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("rows = %d, want 2 — the filter is not reaching the engine (output: %s)", len(rows), out)
+	}
+	for _, r := range rows {
+		if r.QueryHash == nil || *r.QueryHash != targetDigest {
+			t.Errorf("row pk=%s carries query_hash %v, want %q", r.PKValues, r.QueryHash, targetDigest)
+		}
+	}
+}
+
+func cliStatementDigest(t *testing.T, db *sql.DB, stmt string) string {
+	t.Helper()
+	var d sql.NullString
+	if err := db.QueryRow("SELECT STATEMENT_DIGEST(?)", stmt).Scan(&d); err != nil {
+		t.Fatalf("STATEMENT_DIGEST: %v", err)
+	}
+	if !d.Valid || len(d.String) != 64 {
+		t.Fatalf("STATEMENT_DIGEST(%q) = %v, want a 64-char digest", stmt, d)
+	}
+	return d.String
+}
+
+func insertCLIStatementEvent(t *testing.T, db *sql.DB, ts string, pos uint64, pk, stmt, digest string) {
+	t.Helper()
+	_, err := db.Exec(`INSERT INTO binlog_events
+		(binlog_file, start_pos, end_pos, event_timestamp,
+		 schema_name, table_name, event_type, pk_values, row_after, query_text, query_hash)
+		VALUES ('bin.000001', ?, ?, ?, 'app', 'orders', 2, ?, ?, ?, ?)`,
+		pos, pos+100, ts, pk, `{"id":1}`, stmt, digest)
+	if err != nil {
+		t.Fatalf("insert event: %v", err)
+	}
+}

--- a/internal/cli/queryhash_test.go
+++ b/internal/cli/queryhash_test.go
@@ -1,0 +1,71 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+const testQueryDigest = "3f2a1b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f708"
+
+// setQueryHashFlags sets the package-level flag vars runQuery reads and restores
+// them afterwards — cobra's flag variables are process-global, so a test that
+// leaked one would change what the NEXT test's runQuery does.
+func setQueryHashFlags(t *testing.T, hash, profile string) {
+	t.Helper()
+	oldHash, oldProfile := qQueryHash, qProfile
+	qQueryHash, qProfile = hash, profile
+	t.Cleanup(func() { qQueryHash, qProfile = oldHash, oldProfile })
+}
+
+// newQueryHashTestCmd is the minimal cobra command runQuery needs. Kept local
+// because the fuller newQueryTestCmd lives behind the integration build tag.
+func newQueryHashTestCmd() *cobra.Command {
+	c := &cobra.Command{}
+	c.SetContext(context.Background())
+	AddDuckDBTuningFlags(c)
+	return c
+}
+
+func TestQueryCmd_queryHashFlagRegistered(t *testing.T) {
+	f := queryCmd.Flags().Lookup("query-hash")
+	if f == nil {
+		t.Fatal("--query-hash is not registered on the query command")
+	}
+	// Registered on query ONLY: a digest names a statement SHAPE, so a reversal
+	// scoped to one would undo executions the operator never named.
+	if recoverCmd.Flags().Lookup("query-hash") != nil {
+		t.Error("--query-hash must not exist on recover: it selects every execution of a statement shape, which is not a blast radius anyone chose")
+	}
+}
+
+// TestRunQuery_refusesQueryHashWithProfile keeps the refusal at the CLI, where
+// the operator gets both flag names back. The engine refuses too
+// (query.ErrQueryHashUnderProfile); that copy covers library and MCP callers,
+// this one covers the person typing.
+func TestRunQuery_refusesQueryHashWithProfile(t *testing.T) {
+	setQueryHashFlags(t, testQueryDigest, "analyst")
+
+	err := runQuery(newQueryHashTestCmd(), nil)
+	if err == nil {
+		t.Fatal("query ran with both --query-hash and --profile")
+	}
+	if !strings.Contains(err.Error(), "--query-hash") || !strings.Contains(err.Error(), "--profile") {
+		t.Errorf("error must name both flags, got: %v", err)
+	}
+}
+
+// TestRunQuery_rejectsMalformedDigest: the natural mistake is pasting the
+// statement instead of its hash. That must be loud — a bad digest matches no
+// row on any engine, which is indistinguishable from a correct filter over a
+// statement that touched nothing.
+func TestRunQuery_rejectsMalformedDigest(t *testing.T) {
+	setQueryHashFlags(t, "UPDATE mydb.orders SET status = 'shipped'", "")
+
+	err := runQuery(newQueryHashTestCmd(), nil)
+	if err == nil || !strings.Contains(err.Error(), "--query-hash") {
+		t.Fatalf("err = %v, want a --query-hash validation error", err)
+	}
+}

--- a/internal/mcptools/mcptools.go
+++ b/internal/mcptools/mcptools.go
@@ -455,6 +455,7 @@ type QueryArgs struct {
 	Since         string   `json:"since,omitempty" jsonschema:"Filter events at or after this time (YYYY-MM-DD HH:MM:SS or RFC 3339)"`
 	Until         string   `json:"until,omitempty" jsonschema:"Filter events at or before this time (YYYY-MM-DD HH:MM:SS or RFC 3339)"`
 	ChangedColumn string   `json:"changed_column,omitempty" jsonschema:"Filter UPDATE events that modified this column"`
+	QueryHash     string   `json:"query_hash,omitempty" jsonschema:"Filter to the events produced by one statement digest: the 64-character query_hash of an event you already have. It identifies a statement SHAPE so every execution of that statement in the window matches. Unavailable on surfaces that withhold statement text."`
 	ColumnEq      []string `json:"column_eq,omitempty" jsonschema:"Filter events where a column in row_after or row_before equals the given value. Each entry is column=value. Repeat for AND. Literal NULL matches JSON null."`
 	Flag          string   `json:"flag,omitempty" jsonschema:"Filter events from tables or columns carrying this flag"`
 	Format        string   `json:"format,omitempty" jsonschema:"Output format: json table or csv (default: json)"`
@@ -549,6 +550,22 @@ func MakeQueryTool(cfg Config) func(context.Context, *mcp.CallToolRequest, Query
 		if err != nil {
 			return ErrorResult(err), nil, nil
 		}
+
+		// Set after BuildQueryOptions rather than through it: the recover tool
+		// shares that builder and must NOT gain this filter (a digest names a
+		// statement shape, so a reversal scoped to one would undo executions
+		// nobody asked about — see query.Options.QueryHash).
+		queryHash, err := query.NormalizeQueryHash(args.QueryHash)
+		if err != nil {
+			return ErrorResult(err), nil, nil
+		}
+		if queryHash != "" && t.RedactStatementText {
+			// A surface that strips the digest from every event it returns
+			// cannot also let a client test candidate digests against it: that
+			// hands back the withheld association one guess at a time.
+			return ErrorResult(errors.New("query_hash filtering is unavailable on this surface: the statement digest is withheld from every returned event, so filtering on it would confirm what is withheld")), nil, nil
+		}
+		opts.QueryHash = queryHash
 
 		// Hard ceiling on an explicit, oversized limit (#654). BuildQueryOptions
 		// already coerces limit<=0 to the default, so this only bounds a large

--- a/internal/mcptools/queryhash_integration_test.go
+++ b/internal/mcptools/queryhash_integration_test.go
@@ -1,0 +1,106 @@
+//go:build integration
+
+package mcptools
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestQueryHashSeam_MCP is the MCP half of the wiring gap: the unit tests here
+// only reach refusal paths, all of which return BEFORE `opts.QueryHash =
+// queryHash` runs. Deleting that assignment leaves them green while an agent
+// asking for one statement's events receives the entire window and summarises
+// it as that statement's work — the operator never sees the query, only the
+// agent's conclusion, so there is nothing to be suspicious of.
+func TestQueryHashSeam_MCP(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	target := "UPDATE app.orders SET status = 'shipped' WHERE id = 1"
+	targetDigest := mcpStatementDigest(t, db, target)
+	otherDigest := mcpStatementDigest(t, db, "DELETE FROM app.orders WHERE id = 9")
+
+	ts := "2026-06-01 12:00:00"
+	insertMCPStatementEvent(t, db, ts, 100, "1", target, targetDigest)
+	insertMCPStatementEvent(t, db, ts, 200, "2", target, targetDigest)
+	insertMCPStatementEvent(t, db, ts, 300, "9", "DELETE FROM app.orders WHERE id = 9", otherDigest)
+	testutil.InsertEvent(t, db, "bin.000001", 400, 500, ts, nil, "app", "orders", 1, "42", nil, nil, []byte(`{"id":42}`))
+
+	// A surface that does NOT withhold statement text — the standalone
+	// bintrail-mcp posture. The console's is covered by the refusal unit test.
+	cfg := Config{
+		Resolve: func(context.Context, string) (*Target, error) {
+			return &Target{DB: db, NoArchive: true}, nil
+		},
+	}
+	res, _, err := MakeQueryTool(cfg)(context.Background(), &mcp.CallToolRequest{}, QueryArgs{
+		QueryHash: targetDigest,
+		Format:    "json",
+	})
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("query refused: %s", resultText(res))
+	}
+
+	// The payload is JSON followed by an optional trailing notice; cut at the
+	// closing bracket rather than assuming the notice is absent.
+	body := resultText(res)
+	end := strings.LastIndex(body, "]")
+	if end < 0 {
+		t.Fatalf("no JSON array in result: %s", body)
+	}
+	var rows []struct {
+		PKValues  string  `json:"pk_values"`
+		QueryHash *string `json:"query_hash"`
+	}
+	if err := json.Unmarshal([]byte(body[:end+1]), &rows); err != nil {
+		t.Fatalf("unmarshal %q: %v", body[:end+1], err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("rows = %d, want 2 — the digest filter is not reaching the engine (result: %s)", len(rows), body)
+	}
+	for _, r := range rows {
+		if r.QueryHash == nil || *r.QueryHash != targetDigest {
+			t.Errorf("row pk=%s carries query_hash %v, want %q", r.PKValues, r.QueryHash, targetDigest)
+		}
+	}
+}
+
+func mcpStatementDigest(t *testing.T, db *sql.DB, stmt string) string {
+	t.Helper()
+	var d sql.NullString
+	if err := db.QueryRow("SELECT STATEMENT_DIGEST(?)", stmt).Scan(&d); err != nil {
+		t.Fatalf("STATEMENT_DIGEST: %v", err)
+	}
+	if !d.Valid || len(d.String) != 64 {
+		t.Fatalf("STATEMENT_DIGEST(%q) = %v, want a 64-char digest", stmt, d)
+	}
+	return d.String
+}
+
+func insertMCPStatementEvent(t *testing.T, db *sql.DB, ts string, pos uint64, pk, stmt, digest string) {
+	t.Helper()
+	_, err := db.Exec(`INSERT INTO binlog_events
+		(binlog_file, start_pos, end_pos, event_timestamp,
+		 schema_name, table_name, event_type, pk_values, row_after, query_text, query_hash)
+		VALUES ('bin.000001', ?, ?, ?, 'app', 'orders', 2, ?, ?, ?, ?)`,
+		pos, pos+100, ts, pk, `{"id":1}`, stmt, digest)
+	if err != nil {
+		t.Fatalf("insert event: %v", err)
+	}
+}

--- a/internal/mcptools/queryhash_test.go
+++ b/internal/mcptools/queryhash_test.go
@@ -3,6 +3,7 @@ package mcptools
 import (
 	"context"
 	"database/sql"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -76,5 +77,23 @@ func TestQueryTool_queryHashRefusedWhenStatementTextIsWithheld(t *testing.T) {
 				t.Fatalf("unfiltered query refused by the digest gate: %s", resultText(res))
 			}
 		})
+	}
+}
+
+// TestRecoverArgs_hasNoQueryHashParam enforces on the MCP surface the rule the
+// CLI test enforces on cobra: a digest names a statement SHAPE, so a reversal
+// scoped to one would undo every execution of that shape in the window — none
+// of which the operator named.
+//
+// The realistic regression is not the shared BuildQueryOptions (its positional
+// signature makes leakage hard) but someone adding QueryHash to RecoverArgs
+// "for symmetry" with QueryArgs. The blast radius of that mistake is generated
+// reversal SQL, so it gets its own assertion rather than a comment.
+func TestRecoverArgs_hasNoQueryHashParam(t *testing.T) {
+	rt := reflect.TypeOf(RecoverArgs{})
+	for i := range rt.NumField() {
+		if tag := rt.Field(i).Tag.Get("json"); strings.HasPrefix(tag, "query_hash") {
+			t.Fatalf("RecoverArgs.%s exposes %q: recover must never be scoped by statement digest", rt.Field(i).Name, tag)
+		}
 	}
 }

--- a/internal/mcptools/queryhash_test.go
+++ b/internal/mcptools/queryhash_test.go
@@ -1,0 +1,80 @@
+package mcptools
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+const testDigest = "3f2a1b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f708"
+
+// TestQueryTool_queryHashRefusedWhenStatementTextIsWithheld pins the surface
+// gate. A surface that strips query_text/query_hash from every event it returns
+// (the console's /mcp) must not let a client filter on the digest either:
+// answering that filter hands back the withheld association one candidate at a
+// time, which is what the stripping exists to prevent.
+//
+// The Target's DB points at an unreachable address: a refusal must land before
+// any query runs, while the control case (no digest) is free to fail on the
+// connection instead — which is what tells the two apart.
+func TestQueryTool_queryHashRefusedWhenStatementTextIsWithheld(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		redact    bool
+		queryHash string
+		// wantMsg is asserted on the refusal text, not merely on IsError: the
+		// call fails anyway once it reaches the unreachable DB, so a test that
+		// only checked IsError would pass with the gate deleted (verified by
+		// mutation).
+		wantMsg string
+	}{
+		{"withholding surface refuses the filter", true, testDigest, "query_hash filtering is unavailable"},
+		{"withholding surface still serves unfiltered queries", true, "", ""},
+		{"malformed digest is rejected everywhere", false, "not-a-digest", "statement digest must be"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db, err := sql.Open("mysql", "root:none@tcp(127.0.0.1:1)/none")
+			if err != nil {
+				t.Fatalf("open placeholder db: %v", err)
+			}
+			t.Cleanup(func() { db.Close() })
+
+			resolved := false
+			cfg := Config{
+				Resolve: func(context.Context, string) (*Target, error) {
+					resolved = true
+					return &Target{DB: db, RedactStatementText: tc.redact, NoArchive: true}, nil
+				},
+			}
+			res, _, err := MakeQueryTool(cfg)(context.Background(), &mcp.CallToolRequest{}, QueryArgs{
+				Schema:    "mydb",
+				Table:     "orders",
+				QueryHash: tc.queryHash,
+			})
+			if err != nil {
+				t.Fatalf("handler error: %v", err)
+			}
+			if !resolved {
+				t.Fatal("target was never resolved; the test is not exercising the handler")
+			}
+			if tc.wantMsg != "" {
+				if !res.IsError {
+					t.Fatalf("call succeeded, want a refusal")
+				}
+				if got := resultText(res); !strings.Contains(got, tc.wantMsg) {
+					t.Fatalf("refusal text = %q, want it to contain %q — the call also fails at the DB, so only the message proves the gate fired", got, tc.wantMsg)
+				}
+				return
+			}
+			// The no-filter case must fail for a DIFFERENT reason (the nil DB),
+			// never for the digest gate — otherwise this test would pass even if
+			// the gate rejected every query.
+			if res.IsError && strings.Contains(resultText(res), "query_hash") {
+				t.Fatalf("unfiltered query refused by the digest gate: %s", resultText(res))
+			}
+		})
+	}
+}

--- a/internal/parquetquery/parquetquery.go
+++ b/internal/parquetquery/parquetquery.go
@@ -1027,7 +1027,9 @@ func buildFilters(opts query.Options, cols map[string]bool) ([]string, []any) {
 			// from it is the correct answer, not a dropped filter. Warned, not
 			// silent: the operator's window is being answered by a source that
 			// predates statement capture, and only they can tell whether that
-			// makes the overall answer incomplete.
+			// makes the overall answer incomplete. One line per scanned FILE —
+			// noisy over a wide window of old archives, and kept at Warn anyway,
+			// because the alternative is a quietly narrower answer.
 			slog.Warn("parquetquery: archive predates statement capture; it cannot match a statement-digest filter",
 				"query_hash", opts.QueryHash)
 			where = append(where, "1=0")

--- a/internal/parquetquery/parquetquery.go
+++ b/internal/parquetquery/parquetquery.go
@@ -177,6 +177,7 @@ func FetchWithTuning(ctx context.Context, opts query.Options, source string, tun
 	if colErr != nil {
 		return nil, fmt.Errorf("read parquet schema: %w", colErr)
 	}
+	reportDigestCoverage(ctx, db, "'"+strings.ReplaceAll(glob, "'", "''")+"'", source, opts)
 	q, args := buildQueryForFile(glob, opts, cols)
 	rows, err := db.QueryContext(ctx, q, args...)
 	if err != nil {
@@ -243,6 +244,7 @@ func queryFileList(ctx context.Context, db *sql.DB, files []string, opts query.O
 	if err != nil {
 		return nil, fmt.Errorf("read parquet schema: %w", err)
 	}
+	reportDigestCoverage(ctx, db, fileArrayLiteral(files), "s3-direct", opts)
 	q, args := buildQueryFromFiles(files, opts, cols)
 	rows, err := db.QueryContext(ctx, q, args...)
 	if err != nil {
@@ -708,6 +710,7 @@ func queryLocalFile(ctx context.Context, db *sql.DB, path, srcURL string, opts q
 	if colErr != nil {
 		return nil, fmt.Errorf("read parquet schema %s: %w", srcURL, colErr)
 	}
+	reportDigestCoverage(ctx, db, "'"+strings.ReplaceAll(path, "'", "''")+"'", srcURL, opts)
 	q, args := buildQueryForFile(path, opts, cols)
 	rows, err := db.QueryContext(ctx, q, args...)
 	if err != nil {
@@ -1019,19 +1022,19 @@ func buildFilters(opts query.Options, cols map[string]bool) ([]string, []any) {
 	}
 	if opts.QueryHash != "" {
 		if cols != nil && !cols["query_hash"] {
-			// Pre-#699 archive: the column exists in NONE of the scanned files,
-			// and parquet_scan errors on a predicate over a column it cannot
-			// resolve — the same trap optionalCol handles for the SELECT list,
-			// which is why this cannot be left to the projection. Such a file
-			// provably holds no event carrying any digest, so an empty result
-			// from it is the correct answer, not a dropped filter. Warned, not
-			// silent: the operator's window is being answered by a source that
-			// predates statement capture, and only they can tell whether that
-			// makes the overall answer incomplete. One line per scanned FILE —
-			// noisy over a wide window of old archives, and kept at Warn anyway,
-			// because the alternative is a quietly narrower answer.
-			slog.Warn("parquetquery: archive predates statement capture; it cannot match a statement-digest filter",
-				"query_hash", opts.QueryHash)
+			// The column exists in NONE of the scanned files, and parquet_scan
+			// errors on a predicate over a column it cannot resolve — the same
+			// trap optionalCol handles for the SELECT list, which is why this
+			// cannot be left to the projection. Such a file provably holds no
+			// event carrying any digest, so contributing nothing is the correct
+			// answer, not a dropped filter.
+			//
+			// Reporting deliberately does NOT live here. cols is a UNION over
+			// the scanned set on two of the three entry paths, so this branch
+			// says nothing about the case that actually matters — a set MIXED
+			// across the #699 upgrade, where the predicate IS emitted and the
+			// older files quietly pad to NULL. reportDigestCoverage is where
+			// that distinction is visible; see it for what the operator is told.
 			where = append(where, "1=0")
 		} else {
 			// Lowercased because DuckDB compares strings case-sensitively while
@@ -1093,6 +1096,56 @@ func parquetColumns(ctx context.Context, db *sql.DB, path string) (map[string]bo
 		cols[n] = true
 	}
 	return cols, nil
+}
+
+// digestCoverageWarning renders what an operator must be told when only part of
+// the scanned archive set can carry a statement digest. Pure so the wording and
+// the boundaries are testable without DuckDB.
+//
+// Both non-empty verdicts describe the SAME row-level outcome — those files
+// contribute nothing — and that outcome is correct. What is not acceptable is
+// it happening silently: a narrower answer that looks identical to "the
+// statement touched nothing" is the failure this whole filter is written
+// against. Returns "" when every scanned file can answer, which is the steady
+// state once every archive postdates the upgrade.
+func digestCoverageWarning(withDigest, total int) string {
+	switch {
+	case total == 0 || withDigest >= total:
+		return ""
+	case withDigest == 0:
+		return fmt.Sprintf("no archive file in this source has a statement-digest column (%d file(s), all written before statement capture); this source contributes no rows to a --query-hash answer", total)
+	default:
+		return fmt.Sprintf("%d of %d archive file(s) in this source predate statement capture and contribute no rows to a --query-hash answer", total-withDigest, total)
+	}
+}
+
+// reportDigestCoverage probes how many of the scanned parquet files carry
+// query_hash and warns when some or all of them cannot.
+//
+// scanTarget is the parquet_schema() argument the caller would pass to
+// parquet_scan (a quoted glob, or an array literal from fileArrayLiteral);
+// source names it in the warning, because a query can span several registered
+// archive sources and "some files are old" is useless without knowing which.
+//
+// Best-effort by construction: it reads footers only, it runs ONLY under a
+// digest filter, and a probe failure downgrades to a warning about the probe
+// rather than failing a query whose rows are already correct.
+func reportDigestCoverage(ctx context.Context, db *sql.DB, scanTarget, source string, opts query.Options) {
+	if opts.QueryHash == "" {
+		return
+	}
+	var total, withDigest int
+	err := db.QueryRowContext(ctx,
+		"SELECT count(DISTINCT file_name), count(DISTINCT CASE WHEN name = 'query_hash' THEN file_name END) FROM parquet_schema("+scanTarget+")").
+		Scan(&total, &withDigest)
+	if err != nil {
+		slog.Warn("could not determine statement-digest coverage of this archive source; a narrower answer would go unreported",
+			"source", source, "error", err)
+		return
+	}
+	if w := digestCoverageWarning(withDigest, total); w != "" {
+		slog.Warn("parquetquery: "+w, "source", source, "query_hash", opts.QueryHash)
+	}
 }
 
 // optionalCol returns the bare column name when the scanned parquet source has

--- a/internal/parquetquery/parquetquery.go
+++ b/internal/parquetquery/parquetquery.go
@@ -834,7 +834,7 @@ func fileArrayLiteral(files []string) string {
 // connection_id when it is absent from every file, matching buildQueryForFile
 // so archives written before that column read back correctly.
 func buildQueryFromFiles(files []string, opts query.Options, cols map[string]bool) (string, []any) {
-	where, args := buildFilters(opts)
+	where, args := buildFilters(opts, cols)
 
 	q := "SELECT event_id, binlog_file, start_pos, end_pos, event_timestamp," +
 		" gtid, " + optionalCol(cols, "connection_id", "INT32") + ", schema_name, table_name, event_type, pk_values," +
@@ -875,7 +875,7 @@ func buildGlob(source string) string {
 // sorting after collecting all results. Skipping ORDER BY lets DuckDB stream
 // rows without buffering the full result set, dramatically reducing memory.
 func buildUnsortedQuery(path string, opts query.Options) (string, []any) {
-	where, args := buildFilters(opts)
+	where, args := buildFilters(opts, nil)
 	safePath := strings.ReplaceAll(path, "'", "''")
 
 	q := "SELECT event_id, binlog_file, start_pos, end_pos, event_timestamp," +
@@ -897,7 +897,7 @@ func buildUnsortedQuery(path string, opts query.Options) (string, []any) {
 // The glob is embedded directly in the SQL because DuckDB table functions do not
 // support bind parameters for the file path argument.
 func buildQuery(glob string, opts query.Options) (string, []any) {
-	where, args := buildFilters(opts)
+	where, args := buildFilters(opts, nil)
 
 	// Escape single quotes in the glob path to prevent SQL injection.
 	safeGlob := strings.ReplaceAll(glob, "'", "''")
@@ -937,7 +937,7 @@ func limitPerPKClause(opts query.Options) (string, []any) {
 }
 
 // buildFilters extracts WHERE clause fragments and bind args from query options.
-func buildFilters(opts query.Options) ([]string, []any) {
+func buildFilters(opts query.Options, cols map[string]bool) ([]string, []any) {
 	var where []string
 	var args []any
 
@@ -1017,6 +1017,30 @@ func buildFilters(opts query.Options) ([]string, []any) {
 		where = append(where, "json_contains(changed_columns, ?)")
 		args = append(args, string(needle))
 	}
+	if opts.QueryHash != "" {
+		if cols != nil && !cols["query_hash"] {
+			// Pre-#699 archive: the column exists in NONE of the scanned files,
+			// and parquet_scan errors on a predicate over a column it cannot
+			// resolve — the same trap optionalCol handles for the SELECT list,
+			// which is why this cannot be left to the projection. Such a file
+			// provably holds no event carrying any digest, so an empty result
+			// from it is the correct answer, not a dropped filter. Warned, not
+			// silent: the operator's window is being answered by a source that
+			// predates statement capture, and only they can tell whether that
+			// makes the overall answer incomplete.
+			slog.Warn("parquetquery: archive predates statement capture; it cannot match a statement-digest filter",
+				"query_hash", opts.QueryHash)
+			where = append(where, "1=0")
+		} else {
+			// Lowercased because DuckDB compares strings case-sensitively while
+			// MySQL's default collation does not: without this the same filter
+			// would return live rows and drop their archived counterparts,
+			// which reads as "the statement stopped touching rows" at exactly
+			// the rotation boundary.
+			where = append(where, "query_hash = ?")
+			args = append(args, strings.ToLower(opts.QueryHash))
+		}
+	}
 	for _, ce := range opts.ColumnEq {
 		// DuckDB does not bind JSON paths either, so the column name is
 		// interpolated; re-validate via the shared allowlist for the same
@@ -1085,7 +1109,7 @@ func optionalCol(cols map[string]bool, name, sqlType string) string {
 // buildQueryForFile constructs a DuckDB query for a single parquet file,
 // substituting typed NULLs for optional columns not present in the file.
 func buildQueryForFile(path string, opts query.Options, cols map[string]bool) (string, []any) {
-	where, args := buildFilters(opts)
+	where, args := buildFilters(opts, cols)
 	safePath := strings.ReplaceAll(path, "'", "''")
 
 	q := "SELECT event_id, binlog_file, start_pos, end_pos, event_timestamp," +

--- a/internal/parquetquery/queryhash_test.go
+++ b/internal/parquetquery/queryhash_test.go
@@ -1,0 +1,60 @@
+package parquetquery
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/query"
+)
+
+const testDigest = "3f2a1b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f708"
+
+// TestBuildFilters_queryHash covers the archive half of the statement-digest
+// filter, including the case that is not symmetric with MySQL: an archive
+// written before #699 has no query_hash column in ANY scanned file, and
+// parquet_scan errors on a predicate over a column it cannot resolve — the same
+// trap optionalCol handles for the SELECT list. Such a file provably holds no
+// event carrying a digest, so it must contribute an empty result, not an error
+// and not unfiltered rows.
+func TestBuildFilters_queryHash(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		cols     map[string]bool
+		wantPred string
+		wantArgs int
+	}{
+		{"column present", map[string]bool{"query_hash": true}, "query_hash = ?", 1},
+		{"pre-#699 archive", map[string]bool{"event_id": true}, "1=0", 0},
+		{"cols unknown (legacy builders project it unconditionally)", nil, "query_hash = ?", 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			where, args := buildFilters(query.Options{QueryHash: strings.ToUpper(testDigest)}, tc.cols)
+
+			joined := strings.Join(where, " AND ")
+			if !strings.Contains(joined, tc.wantPred) {
+				t.Fatalf("where = %q, want it to contain %q", joined, tc.wantPred)
+			}
+			// A stray arg is worse than a wrong predicate here: DuckDB binds
+			// positionally, so an unmatched value shifts every later filter's
+			// parameter onto the wrong placeholder.
+			if len(args) != tc.wantArgs {
+				t.Fatalf("args = %v, want %d", args, tc.wantArgs)
+			}
+			if tc.wantArgs == 1 && args[0] != testDigest {
+				t.Errorf("bound arg = %v, want the lowercased digest %q — DuckDB compares case-sensitively where MySQL does not", args[0], testDigest)
+			}
+		})
+	}
+}
+
+// TestBuildFilters_queryHashUnsetEmitsNothing guards the default path: every
+// query that does not ask for a digest must keep the SQL it had before, or the
+// predicate would silently exclude every event captured without statement
+// logging.
+func TestBuildFilters_queryHashUnsetEmitsNothing(t *testing.T) {
+	where, args := buildFilters(query.Options{Schema: "mydb"}, map[string]bool{"event_id": true})
+	joined := strings.Join(where, " AND ")
+	if strings.Contains(joined, "query_hash") || strings.Contains(joined, "1=0") {
+		t.Fatalf("unset filter still shaped the query: %q (args %v)", joined, args)
+	}
+}

--- a/internal/parquetquery/queryhash_test.go
+++ b/internal/parquetquery/queryhash_test.go
@@ -10,12 +10,11 @@ import (
 const testDigest = "3f2a1b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f708"
 
 // TestBuildFilters_queryHash covers the archive half of the statement-digest
-// filter, including the case that is not symmetric with MySQL: an archive
-// written before #699 has no query_hash column in ANY scanned file, and
-// parquet_scan errors on a predicate over a column it cannot resolve — the same
-// trap optionalCol handles for the SELECT list. Such a file provably holds no
-// event carrying a digest, so it must contribute an empty result, not an error
-// and not unfiltered rows.
+// filter, including the case that is not symmetric with MySQL: when no scanned
+// file has a query_hash column, parquet_scan errors on a predicate over a
+// column it cannot resolve — the same trap optionalCol handles for the SELECT
+// list. Such a set provably holds no event carrying a digest, so it must
+// contribute an empty result — not an error, and not unfiltered rows.
 func TestBuildFilters_queryHash(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
@@ -25,7 +24,7 @@ func TestBuildFilters_queryHash(t *testing.T) {
 	}{
 		{"column present", map[string]bool{"query_hash": true}, "query_hash = ?", 1},
 		{"pre-#699 archive", map[string]bool{"event_id": true}, "1=0", 0},
-		{"cols unknown (legacy builders project it unconditionally)", nil, "query_hash = ?", 1},
+		{"cols unknown (test-only builders, which project the column unconditionally)", nil, "query_hash = ?", 1},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			where, args := buildFilters(query.Options{QueryHash: strings.ToUpper(testDigest)}, tc.cols)
@@ -56,5 +55,40 @@ func TestBuildFilters_queryHashUnsetEmitsNothing(t *testing.T) {
 	joined := strings.Join(where, " AND ")
 	if strings.Contains(joined, "query_hash") || strings.Contains(joined, "1=0") {
 		t.Fatalf("unset filter still shaped the query: %q (args %v)", joined, args)
+	}
+}
+
+// TestDigestCoverageWarning pins the boundaries of what an operator is told
+// about an archive set that can only partly answer a digest filter.
+//
+// The middle case is the one this exists for: cols is a UNION over the scanned
+// set, so a set MIXED across the #699 upgrade emits the predicate normally and
+// the older files pad to NULL — correct rows, silently narrower window. Before
+// this, only the all-old set said anything, which is the case that matters
+// least (it also returns nothing at all, so the operator has something to be
+// suspicious of).
+func TestDigestCoverageWarning(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		with, tot  int
+		wantSubstr string
+	}{
+		{"fully covered", 5, 5, ""},
+		{"empty scan", 0, 0, ""},
+		{"none covered", 0, 4, "no archive file"},
+		{"mixed across the upgrade", 3, 5, "2 of 5"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := digestCoverageWarning(tc.with, tc.tot)
+			if tc.wantSubstr == "" {
+				if got != "" {
+					t.Fatalf("warning = %q, want silence", got)
+				}
+				return
+			}
+			if !strings.Contains(got, tc.wantSubstr) {
+				t.Fatalf("warning = %q, want it to contain %q", got, tc.wantSubstr)
+			}
+		})
 	}
 }

--- a/internal/query/fetchmerged.go
+++ b/internal/query/fetchmerged.go
@@ -139,6 +139,14 @@ func (o FetchMergedOptions) validate() error {
 	if !o.AllowGaps && o.DBName == "" && (o.Opts.Since != nil || o.Opts.Until != nil) {
 		return errors.New("FetchMerged: AllowGaps=false requires a non-empty DBName when a time range is set; gap detection cannot run without it")
 	}
+	// Checked here as well as in Engine.Fetch: a plan whose window is fully
+	// covered by archives skips the MySQL fetch entirely (QueryPlan.SkipMySQL),
+	// and the archive engine builds its own predicate with no policy check of
+	// its own. Asserting it at the entry point costs one call and does not
+	// depend on which tiers happen to run.
+	if err := o.Opts.ValidateStatementFilter(); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -253,10 +253,29 @@ type Options struct {
 	// MySQL engine ignores it. Populated from QueryPlan.MisfiledArchiveHours
 	// (or query.MisfiledArchiveHours) by callers that prune archives by time.
 	ExtraArchiveHours []time.Time
-	ChangedColumn     string     // column name; matched via JSON_CONTAINS
-	ColumnEq          []ColumnEq // match against values inside row_after / row_before
-	Flag              string     // return events from tables/columns carrying this flag
-	Limit             int        // 0 → no limit (no LIMIT clause emitted)
+	ChangedColumn     string // column name; matched via JSON_CONTAINS
+	// QueryHash restricts results to the events produced by ONE statement
+	// digest: the 64-char hex STATEMENT_DIGEST() stored in
+	// binlog_events.query_hash at index time (#699). It is populated only while
+	// the source logs the originating statement
+	// (binlog_rows_query_log_events=ON, or MariaDB's
+	// binlog_annotate_row_events) — against an index captured without it the
+	// column is NULL everywhere and this filter correctly matches nothing.
+	//
+	// The digest identifies a statement SHAPE, not one execution: literals are
+	// normalised away, so `WHERE id=1` and `WHERE id=999` share a digest and
+	// every execution of that shape inside the window matches. That is why this
+	// is a READ filter and is deliberately not offered on recover — a reversal
+	// scoped to a shape would undo executions the operator never named. Pinning
+	// one execution needs connection_id + digest + time, which is a separate
+	// correlation problem.
+	//
+	// Matched case-sensitively on the archive side (DuckDB), so the canonical
+	// lowercase form is required — NormalizeQueryHash produces it.
+	QueryHash string
+	ColumnEq  []ColumnEq // match against values inside row_after / row_before
+	Flag      string     // return events from tables/columns carrying this flag
+	Limit     int        // 0 → no limit (no LIMIT clause emitted)
 	// LimitPerPK caps the number of latest events returned per pk_values value.
 	// 0 = unlimited. Applied via ROW_NUMBER OVER (PARTITION BY pk_values
 	// ORDER BY event_timestamp DESC, event_id DESC) so the kept events are
@@ -338,6 +357,9 @@ func (e *Engine) Fetch(ctx context.Context, opts Options) ([]ResultRow, error) {
 	if err := opts.validateCursor(); err != nil {
 		return nil, err
 	}
+	if err := opts.ValidateStatementFilter(); err != nil {
+		return nil, err
+	}
 	q, args := buildQuery(opts)
 	rows, err := e.db.QueryContext(ctx, q, args...)
 	if err != nil {
@@ -359,10 +381,69 @@ func (e *Engine) Fetch(ctx context.Context, opts Options) ([]ResultRow, error) {
 	// profile with ZERO rules (ProfileActive): query_text is per-STATEMENT,
 	// so rows of an ALLOWED table can carry a statement whose literals
 	// belong to a denied sibling table — see applyRedaction (#699).
-	if opts.ProfileActive || len(opts.RedactColumns) > 0 || len(opts.DenyTables) > 0 {
+	if opts.RedactionActive() {
 		applyRedaction(results, opts.RedactColumns)
 	}
 	return results, nil
+}
+
+// RedactionActive reports whether an RBAC policy is in force for these options.
+// It is the single predicate every surface must consult: the redaction pass
+// fires on a NAMED profile even when it resolved to zero rules (#838), and on
+// deny/redact rules supplied without one. Two copies of this condition would
+// drift, and the drift is silent — see ValidateStatementFilter.
+func (o Options) RedactionActive() bool {
+	return o.ProfileActive || len(o.RedactColumns) > 0 || len(o.DenyTables) > 0
+}
+
+// ErrQueryHashUnderProfile is returned when a statement-digest filter is
+// combined with an active RBAC policy.
+//
+// The digest is blanked on EVERY returned row under a policy (see
+// applyRedaction) precisely because a stable digest leaks statement shape and
+// permits dictionary confirmation of the literals it carried. Honouring a
+// filter over that same column would hand back the answer the blanking
+// withholds — "these rows came from the statement you guessed" — one candidate
+// digest at a time. Refusing is the only consistent option: silently dropping
+// the filter would over-return, and an empty result set would read as "that
+// statement touched nothing", a false negative on a forensic question.
+//
+// The message names no CLI flag: this error reaches MCP clients too, and an
+// agent handed a --flag it cannot type will invent one.
+var ErrQueryHashUnderProfile = errors.New(
+	"statement-digest filter unavailable while an RBAC profile is active: the digest is withheld from every returned row, so filtering on it would confirm the statement that redaction hides")
+
+// ValidateStatementFilter rejects option combinations the redaction contract
+// cannot honour. Called by Fetch, so every engine path is covered.
+func (o Options) ValidateStatementFilter() error {
+	if o.QueryHash != "" && o.RedactionActive() {
+		return ErrQueryHashUnderProfile
+	}
+	return nil
+}
+
+// NormalizeQueryHash canonicalises a user-supplied statement digest to the form
+// stored in binlog_events.query_hash: 64 lowercase hex characters, as produced
+// by MySQL's STATEMENT_DIGEST(). An empty input stays empty (no filter).
+//
+// Validating the SHAPE here is what keeps a mistake loud. The natural error —
+// pasting the statement TEXT, or a truncated digest — would otherwise match no
+// row on either engine and be indistinguishable from a correct filter over a
+// statement that genuinely touched nothing.
+func NormalizeQueryHash(s string) (string, error) {
+	s = strings.ToLower(strings.TrimSpace(s))
+	if s == "" {
+		return "", nil
+	}
+	if len(s) != 64 {
+		return "", fmt.Errorf("statement digest must be the 64-character hex STATEMENT_DIGEST stored in query_hash, got %d characters", len(s))
+	}
+	for _, c := range s {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return "", fmt.Errorf("statement digest must be hexadecimal, found %q", c)
+		}
+	}
+	return s, nil
 }
 
 // sortResults orders rows by (event_timestamp, event_id) in dir ("ASC"/"DESC"),
@@ -542,6 +623,14 @@ func buildQuery(opts Options) (string, []any) {
 		needle, _ := json.Marshal(opts.ChangedColumn)
 		where = append(where, "JSON_CONTAINS(changed_columns, ?)")
 		args = append(args, string(needle))
+	}
+	if opts.QueryHash != "" {
+		// Lowercased for parity with the archive side: MySQL's CHAR(64) compares
+		// case-insensitively under the default collation, DuckDB does not, and a
+		// filter that matches live rows but not archived ones would report a
+		// statement as having stopped touching rows at the rotation boundary.
+		where = append(where, "query_hash = ?")
+		args = append(args, strings.ToLower(opts.QueryHash))
 	}
 	for _, ce := range opts.ColumnEq {
 		// Defense-in-depth: ParseColumnEq is the canonical entry, but

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -260,7 +260,11 @@ type Options struct {
 	// the source logs the originating statement
 	// (binlog_rows_query_log_events=ON, or MariaDB's
 	// binlog_annotate_row_events) — against an index captured without it the
-	// column is NULL everywhere and this filter correctly matches nothing.
+	// column is NULL everywhere and this filter matches nothing. That empty
+	// result is ambiguous on its own, which is what DigestCaptureInWindow is
+	// for. (A pre-#699 index that never ran EnsureSchema lacks the COLUMN, not
+	// just the values; that is a 1054 from the SELECT list, filter or no
+	// filter.)
 	//
 	// The digest identifies a statement SHAPE, not one execution: literals are
 	// normalised away, so `WHERE id=1` and `WHERE id=999` share a digest and
@@ -388,10 +392,14 @@ func (e *Engine) Fetch(ctx context.Context, opts Options) ([]ResultRow, error) {
 }
 
 // RedactionActive reports whether an RBAC policy is in force for these options.
-// It is the single predicate every surface must consult: the redaction pass
+// It is the single predicate every OPTIONS-level surface must consult: the
+// redaction pass
 // fires on a NAMED profile even when it resolved to zero rules (#838), and on
 // deny/redact rules supplied without one. Two copies of this condition would
-// drift, and the drift is silent — see ValidateStatementFilter.
+// drift, and the drift is silent — see ValidateStatementFilter. (Two sibling
+// copies of the same three terms survive over OTHER receivers — console
+// Server.rbacActive and mcptools recover-cascade — which cannot call this
+// method; they are known, not overlooked.)
 func (o Options) RedactionActive() bool {
 	return o.ProfileActive || len(o.RedactColumns) > 0 || len(o.DenyTables) > 0
 }
@@ -421,6 +429,62 @@ func (o Options) ValidateStatementFilter() error {
 	}
 	return nil
 }
+
+// DigestCaptureInWindow reports whether the index holds at least ONE event
+// carrying a statement digest inside the window opts describes.
+//
+// It exists to disambiguate the one result a digest filter cannot explain by
+// itself: ZERO rows. That is either "this statement touched nothing" or "no
+// event here could have carried a digest" — the source was not logging
+// statements (MySQL defaults binlog_rows_query_log_events OFF), a MariaDB
+// stream ran without --source-flavor mariadb, the window predates #699, or the
+// source is Postgres, whose capture plane writes the column never. Those are
+// opposite answers to a forensic question and they print identically.
+//
+// Cost is why this is a separate call rather than part of every fetch: there is
+// no index on query_hash, so an all-NULL window scans its partitions to prove
+// the negative. Callers must invoke it ONLY after a digest-filtered fetch came
+// back empty — never on the hot path — and it is bounded by the same
+// schema/table/time predicates the query itself used.
+func DigestCaptureInWindow(ctx context.Context, db *sql.DB, opts Options) (bool, error) {
+	where := []string{"query_hash IS NOT NULL"}
+	var args []any
+	if opts.Schema != "" {
+		where = append(where, "schema_name = ?")
+		args = append(args, opts.Schema)
+	}
+	if opts.Table != "" {
+		where = append(where, "table_name = ?")
+		args = append(args, opts.Table)
+	}
+	// Hour-aligned TO_SECONDS literals for partition pruning, same as
+	// buildQuery: a parameterised datetime comparison prunes nothing, and
+	// pruning is the entire cost control here.
+	if opts.Since != nil {
+		where = append(where, fmt.Sprintf("TO_SECONDS(event_timestamp) >= %d", mysqlToSeconds(opts.Since.Truncate(time.Hour))))
+	}
+	if opts.Until != nil {
+		where = append(where, fmt.Sprintf("TO_SECONDS(event_timestamp) < %d", mysqlToSeconds(opts.Until.Truncate(time.Hour).Add(time.Hour))))
+	}
+	q := "SELECT 1 FROM binlog_events WHERE " + strings.Join(where, " AND ") + " LIMIT 1"
+
+	var one int
+	err := db.QueryRowContext(ctx, q, args...).Scan(&one)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("probe statement-digest capture: %w", err)
+	}
+	return true, nil
+}
+
+// NoDigestCaptureWarning is the operator-facing text for a digest-filtered
+// query that returned nothing from a window where nothing COULD have matched.
+// Shared so the CLI's stderr line and the MCP notice cannot drift into saying
+// different things about the same finding.
+const NoDigestCaptureWarning = "Warning: no event in this window carries a statement digest, so this empty result does NOT mean the statement touched nothing. " +
+	"The source was not logging statements when these events were captured (MySQL: binlog_rows_query_log_events, MariaDB: binlog_annotate_row_events + --source-flavor mariadb; PostgreSQL sources never populate it)."
 
 // NormalizeQueryHash canonicalises a user-supplied statement digest to the form
 // stored in binlog_events.query_hash: 64 lowercase hex characters, as produced
@@ -625,8 +689,9 @@ func buildQuery(opts Options) (string, []any) {
 		args = append(args, string(needle))
 	}
 	if opts.QueryHash != "" {
-		// Lowercased for parity with the archive side: MySQL's CHAR(64) compares
-		// case-insensitively under the default collation, DuckDB does not, and a
+		// Lowercased for parity with the archive side: under a stock
+		// case-insensitive default collation (binlog_events declares none of its
+		// own) MySQL compares query_hash case-insensitively, DuckDB never does, and a
 		// filter that matches live rows but not archived ones would report a
 		// statement as having stopped touching rows at the rotation boundary.
 		where = append(where, "query_hash = ?")

--- a/internal/query/queryhash_integration_test.go
+++ b/internal/query/queryhash_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/dbtrail/dbtrail/internal/indexer"
 	"github.com/dbtrail/dbtrail/internal/testutil"
@@ -71,9 +72,9 @@ func TestFetch_queryHashFilter(t *testing.T) {
 		t.Errorf("table spread = %v, want 2 orders + 1 order_lines", tables)
 	}
 
-	// Case is the trap: MySQL's default collation compares CHAR(64)
-	// case-insensitively, DuckDB does not, so the engines only agree on a
-	// canonicalised digest. Passing the un-normalised form must not change the
+	// Case is the trap: under a stock case-insensitive default collation MySQL
+	// compares query_hash case-insensitively while DuckDB never does, so the
+	// engines only agree on a canonicalised digest. Passing the un-normalised form must not change the
 	// answer here either.
 	upper, err := e.Fetch(context.Background(), Options{QueryHash: strings.ToUpper(digestA), Limit: 100})
 	if err != nil {
@@ -121,5 +122,55 @@ func insertWithStatement(t *testing.T, db *sql.DB, ts string, pos uint64, schema
 		pos, pos+100, ts, schema, table, pk, `{"id":1}`, stmt, digest)
 	if err != nil {
 		t.Fatalf("insert event: %v", err)
+	}
+}
+
+// TestDigestCaptureInWindow is the probe that makes an empty digest-filtered
+// result readable. Zero rows means either "this statement touched nothing" or
+// "nothing here could have carried a digest", and those print identically —
+// the second is the one that ends an investigation early.
+//
+// The window scoping is asserted, not just the boolean: a probe that ignored
+// --since/--until would answer about the wrong hours and report capture the
+// operator's window never had.
+func TestDigestCaptureInWindow(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	captureOff := "2026-02-19 10:00:00"
+	captureOn := "2026-02-19 14:00:00"
+	// The hour the operator was blind: statements were not being logged.
+	testutil.InsertEvent(t, db, "binlog.000001", 100, 200, captureOff, nil, "mydb", "orders", 1, "1", nil, nil, []byte(`{"id":1}`))
+	// The hour after someone turned it on.
+	stmt := "UPDATE mydb.orders SET status = 'shipped' WHERE id = 1"
+	insertWithStatement(t, db, captureOn, 300, "mydb", "orders", "1", stmt, statementDigest(t, db, stmt))
+
+	blindStart := time.Date(2026, 2, 19, 10, 0, 0, 0, time.UTC)
+	blindEnd := time.Date(2026, 2, 19, 10, 59, 59, 0, time.UTC)
+	seeingStart := time.Date(2026, 2, 19, 14, 0, 0, 0, time.UTC)
+	seeingEnd := time.Date(2026, 2, 19, 14, 59, 59, 0, time.UTC)
+
+	for _, tc := range []struct {
+		name string
+		opts Options
+		want bool
+	}{
+		{"whole index", Options{}, true},
+		{"window where capture was off", Options{Since: &blindStart, Until: &blindEnd}, false},
+		{"window where capture was on", Options{Since: &seeingStart, Until: &seeingEnd}, true},
+		{"table that has no digested events", Options{Schema: "mydb", Table: "nothing_here"}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := DigestCaptureInWindow(context.Background(), db, tc.opts)
+			if err != nil {
+				t.Fatalf("DigestCaptureInWindow: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/query/queryhash_integration_test.go
+++ b/internal/query/queryhash_integration_test.go
@@ -1,0 +1,125 @@
+//go:build integration
+
+package query
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestFetch_queryHashFilter runs the statement-digest filter against a real
+// MySQL index. The unit test pins the SQL string; this pins the behaviour that
+// string is supposed to produce, including the property the whole filter exists
+// for: one digest covers several EXECUTIONS of the same statement shape, and
+// nothing else.
+//
+// The digests are computed by the server via STATEMENT_DIGEST(), the same
+// function the indexer uses (#699) — hardcoding a hex constant here would test
+// the test's arithmetic rather than MySQL's.
+func TestFetch_queryHashFilter(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	// query_text / query_hash arrived after the initial schema; EnsureSchema is
+	// what a real index gets on every command startup.
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	stmtA1 := "UPDATE mydb.orders SET status = 'shipped' WHERE id = 1"
+	stmtA2 := "UPDATE mydb.orders SET status = 'shipped' WHERE id = 999" // same SHAPE
+	stmtB := "DELETE FROM mydb.orders WHERE id = 7"
+
+	digestA := statementDigest(t, db, stmtA1)
+	if digestA != statementDigest(t, db, stmtA2) {
+		t.Fatal("premise broken: two executions of one statement shape must share a digest")
+	}
+	digestB := statementDigest(t, db, stmtB)
+
+	ts := "2026-02-19 14:00:00"
+	insertWithStatement(t, db, ts, 100, "mydb", "orders", "1", stmtA1, digestA)
+	insertWithStatement(t, db, ts, 200, "mydb", "orders", "999", stmtA2, digestA)
+	// Same statement text, a DIFFERENT table: a multi-table statement stamps
+	// every table it touched, and the filter must follow it there.
+	insertWithStatement(t, db, ts, 300, "mydb", "order_lines", "1", stmtA1, digestA)
+	insertWithStatement(t, db, ts, 400, "mydb", "orders", "7", stmtB, digestB)
+	// Captured while binlog_rows_query_log_events was OFF: no text, no digest.
+	testutil.InsertEvent(t, db, "binlog.000001", 500, 600, ts, nil, "mydb", "orders", 1, "42", nil, nil, []byte(`{"id":42}`))
+
+	e := New(db)
+
+	rows, err := e.Fetch(context.Background(), Options{QueryHash: digestA, Limit: 100})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("rows = %d, want 3 (both executions of the shape, across both tables)", len(rows))
+	}
+	tables := map[string]int{}
+	for _, r := range rows {
+		if r.QueryHash == nil || *r.QueryHash != digestA {
+			t.Fatalf("row %d came back with query_hash %v, want %q", r.EventID, r.QueryHash, digestA)
+		}
+		tables[r.TableName]++
+	}
+	if tables["orders"] != 2 || tables["order_lines"] != 1 {
+		t.Errorf("table spread = %v, want 2 orders + 1 order_lines", tables)
+	}
+
+	// Case is the trap: MySQL's default collation compares CHAR(64)
+	// case-insensitively, DuckDB does not, so the engines only agree on a
+	// canonicalised digest. Passing the un-normalised form must not change the
+	// answer here either.
+	upper, err := e.Fetch(context.Background(), Options{QueryHash: strings.ToUpper(digestA), Limit: 100})
+	if err != nil {
+		t.Fatalf("Fetch (uppercase digest): %v", err)
+	}
+	if len(upper) != 3 {
+		t.Errorf("rows for the uppercase digest = %d, want 3", len(upper))
+	}
+
+	// The other statement's events, and the events captured without statement
+	// logging, must not leak in.
+	other, err := e.Fetch(context.Background(), Options{QueryHash: digestB, Limit: 100})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(other) != 1 || other[0].PKValues != "7" {
+		t.Fatalf("second digest returned %d rows, want exactly the DELETE", len(other))
+	}
+
+	// Under a policy the digest is blanked on every returned row, so filtering
+	// on it is refused rather than answered.
+	if _, err := e.Fetch(context.Background(), Options{QueryHash: digestA, ProfileActive: true, Limit: 100}); !errors.Is(err, ErrQueryHashUnderProfile) {
+		t.Errorf("err = %v, want ErrQueryHashUnderProfile", err)
+	}
+}
+
+func statementDigest(t *testing.T, db *sql.DB, stmt string) string {
+	t.Helper()
+	var d sql.NullString
+	if err := db.QueryRow("SELECT STATEMENT_DIGEST(?)", stmt).Scan(&d); err != nil {
+		t.Fatalf("STATEMENT_DIGEST(%q): %v", stmt, err)
+	}
+	if !d.Valid || len(d.String) != 64 {
+		t.Fatalf("STATEMENT_DIGEST(%q) = %v, want a 64-char digest", stmt, d)
+	}
+	return d.String
+}
+
+func insertWithStatement(t *testing.T, db *sql.DB, ts string, pos uint64, schema, table, pk, stmt, digest string) {
+	t.Helper()
+	_, err := db.Exec(`INSERT INTO binlog_events
+		(binlog_file, start_pos, end_pos, event_timestamp,
+		 schema_name, table_name, event_type, pk_values, row_after, query_text, query_hash)
+		VALUES ('binlog.000001', ?, ?, ?, ?, ?, 2, ?, ?, ?, ?)`,
+		pos, pos+100, ts, schema, table, pk, `{"id":1}`, stmt, digest)
+	if err != nil {
+		t.Fatalf("insert event: %v", err)
+	}
+}

--- a/internal/query/queryhash_test.go
+++ b/internal/query/queryhash_test.go
@@ -1,0 +1,147 @@
+package query
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+const testDigest = "3f2a1b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f708"
+
+// TestBuildQuery_queryHashPredicate pins the live-MySQL half of the
+// statement-digest filter: the predicate is emitted, bound (never
+// interpolated), and lowercased so it agrees with the case-SENSITIVE archive
+// engine on the same input.
+func TestBuildQuery_queryHashPredicate(t *testing.T) {
+	q, args := buildQuery(Options{QueryHash: strings.ToUpper(testDigest)})
+
+	if !strings.Contains(q, "query_hash = ?") {
+		t.Fatalf("predicate missing from SQL:\n%s", q)
+	}
+	if len(args) != 1 {
+		t.Fatalf("args = %v, want exactly the digest", args)
+	}
+	if args[0] != testDigest {
+		t.Errorf("bound arg = %v, want the lowercased digest %q", args[0], testDigest)
+	}
+}
+
+// TestBuildQuery_queryHashInsideKeysSubquery is the one placement that is not
+// obvious from reading the predicate: buildQuery selects narrow keys in an
+// inner subquery and JOINs binlog_events back for the wide columns (#1038). A
+// filter that landed only on the outer JOIN would still return the right rows
+// for a plain query but would let the per-PK window see — and cap against —
+// events the filter should have removed.
+func TestBuildQuery_queryHashInsideKeysSubquery(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		opts Options
+	}{
+		{"plain", Options{QueryHash: testDigest}},
+		{"limit-per-pk", Options{QueryHash: testDigest, PKValues: "1", LimitPerPK: 3}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			q, _ := buildQuery(tc.opts)
+			hashAt := strings.Index(q, "query_hash = ?")
+			joinAt := strings.Index(q, "JOIN (")
+			if hashAt < 0 || joinAt < 0 {
+				t.Fatalf("unexpected query shape:\n%s", q)
+			}
+			if hashAt < joinAt {
+				t.Errorf("filter sits on the outer SELECT, not in the keys subquery:\n%s", q)
+			}
+		})
+	}
+}
+
+// TestValidateStatementFilter_refusesUnderEveryRedactionShape walks all three
+// ways a policy becomes active. They are enumerated deliberately: applyRedaction
+// blanks the digest under ANY of them, so a validator that only checked
+// ProfileActive would leave the deny/redact callers filtering on a column their
+// rows come back without.
+func TestValidateStatementFilter_refusesUnderEveryRedactionShape(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		opts    Options
+		wantErr bool
+	}{
+		{"no policy", Options{QueryHash: testDigest}, false},
+		{"named profile", Options{QueryHash: testDigest, ProfileActive: true}, true},
+		{"redact rules only", Options{QueryHash: testDigest, RedactColumns: []SchemaTableColumn{{Schema: "d", Table: "t", Column: "c"}}}, true},
+		{"deny rules only", Options{QueryHash: testDigest, DenyTables: []SchemaTable{{Schema: "d", Table: "t"}}}, true},
+		{"policy without the filter", Options{ProfileActive: true}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.opts.ValidateStatementFilter()
+			if tc.wantErr && !errors.Is(err, ErrQueryHashUnderProfile) {
+				t.Fatalf("err = %v, want ErrQueryHashUnderProfile", err)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("err = %v, want nil", err)
+			}
+		})
+	}
+}
+
+// TestFetch_refusesQueryHashUnderProfileBeforeTouchingTheDB proves the refusal
+// is on the engine path and not merely available to callers who remember it.
+// The nil *sql.DB is the assertion: reaching the query would panic, so a pass
+// means the check fired first.
+func TestFetch_refusesQueryHashUnderProfileBeforeTouchingTheDB(t *testing.T) {
+	e := New(nil)
+	_, err := e.Fetch(context.Background(), Options{QueryHash: testDigest, ProfileActive: true})
+	if !errors.Is(err, ErrQueryHashUnderProfile) {
+		t.Fatalf("err = %v, want ErrQueryHashUnderProfile", err)
+	}
+}
+
+// TestNormalizeQueryHash pins the shape check. Its value is entirely in the
+// failure cases: a digest that is silently wrong matches no row on any engine,
+// which is indistinguishable from a correct filter over a statement that
+// touched nothing — a false negative on a forensic question.
+func TestNormalizeQueryHash(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"empty is no filter", "", "", false},
+		{"canonical", testDigest, testDigest, false},
+		{"uppercase is canonicalised", strings.ToUpper(testDigest), testDigest, false},
+		{"surrounding space", "  " + testDigest + "\n", testDigest, false},
+		{"truncated", testDigest[:63], "", true},
+		{"the statement text instead of its digest", "UPDATE mydb.orders SET status = 'shipped' WHERE id = 1", "", true},
+		{"non-hex of the right length", strings.Repeat("z", 64), "", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := NormalizeQueryHash(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("got %q, want an error", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestShouldSkipSnapshot_queryHash: a baseline row is a materialised row image,
+// not a statement's effect. Letting one survive a digest-scoped query would
+// claim provenance it does not have.
+func TestShouldSkipSnapshot_queryHash(t *testing.T) {
+	reason, skip := shouldSkipSnapshot(Options{QueryHash: testDigest})
+	if !skip {
+		t.Fatal("snapshot source not skipped under a statement-digest filter")
+	}
+	if !strings.Contains(reason, "query-hash") {
+		t.Errorf("reason = %q, want it to name the filter", reason)
+	}
+}

--- a/internal/query/queryhash_test.go
+++ b/internal/query/queryhash_test.go
@@ -96,6 +96,30 @@ func TestFetch_refusesQueryHashUnderProfileBeforeTouchingTheDB(t *testing.T) {
 	}
 }
 
+// TestFetchMergedOptions_validateRefusesQueryHashUnderProfile pins the check at
+// the ENTRY point rather than only inside Engine.Fetch. A window fully covered
+// by archives skips the MySQL fetch (QueryPlan.SkipMySQL), and the archive
+// engine builds its own predicate with no policy check of its own — so
+// "Engine.Fetch validates" is not by itself a guarantee about which tiers ran.
+//
+// validate() is called directly, not through FetchMerged: with a nil engine
+// FetchMerged reaches Engine.Fetch and returns the same error anyway, so the
+// public path cannot tell the two checks apart.
+func TestFetchMergedOptions_validateRefusesQueryHashUnderProfile(t *testing.T) {
+	o := FetchMergedOptions{
+		NoArchive: true,
+		AllowGaps: true,
+		Opts:      Options{QueryHash: testDigest, ProfileActive: true},
+	}
+	if err := o.validate(); !errors.Is(err, ErrQueryHashUnderProfile) {
+		t.Fatalf("err = %v, want ErrQueryHashUnderProfile", err)
+	}
+	o.Opts.ProfileActive = false
+	if err := o.validate(); err != nil {
+		t.Fatalf("err = %v, want the same options without a policy to validate cleanly", err)
+	}
+}
+
 // TestNormalizeQueryHash pins the shape check. Its value is entirely in the
 // failure cases: a digest that is silently wrong matches no row on any engine,
 // which is indistinguishable from a correct filter over a statement that

--- a/internal/query/snapshot.go
+++ b/internal/query/snapshot.go
@@ -163,6 +163,14 @@ func shouldSkipSnapshot(opts Options) (string, bool) {
 	if opts.ChangedColumn != "" {
 		return "--changed-column set (baseline rows have no changed-columns metadata)", true
 	}
+	if opts.QueryHash != "" {
+		// A baseline row is a materialised row image, not a statement's effect:
+		// no statement produced it, so it can never carry the digest asked for.
+		// Skipping the whole source is what the other always-excluders do, and
+		// it keeps the filter honest — a snapshot row surviving a
+		// statement-scoped query would claim provenance it does not have.
+		return "--query-hash set (baseline rows carry no statement digest)", true
+	}
 	if opts.Flag != "" {
 		return "--flag set (baseline rows do not carry table_flags)", true
 	}

--- a/internal/query/snapshot.go
+++ b/internal/query/snapshot.go
@@ -147,8 +147,8 @@ func FetchSnapshot(ctx context.Context, path string, opts Options) ([]ResultRow,
 
 // shouldSkipSnapshot reports whether any filter in opts rules out the entire
 // snapshot source before the DuckDB query runs. It is the unit-testable
-// truth table for the four always-excluder filters: wrong event-type, gtid,
-// changed-column, flag. Extracted so the branches are testable without
+// truth table for the five always-excluder filters: wrong event-type, gtid,
+// changed-column, flag, query-hash. Extracted so the branches are testable without
 // standing up DuckDB.
 //
 // Returns (reason, true) when the source must be skipped, with a


### PR DESCRIPTION
## What

`bintrail query --query-hash <digest>` — filter events to the ones one statement produced.

The index has stored `STATEMENT_DIGEST()` in `binlog_events.query_hash` since #699 and **nothing has ever read it**: no filter, no grouping, no consumer in this repo or downstream. We pay a round trip per batch to compute it. This makes the column answerable: *"show me everything this statement did, across every table it touched"* — which is what capturing the statement was for.

Not a new forensics surface: `query` already serves `query_text`/`query_hash` in `json`/`csv` (#733 was never reverted). This filters an already-visible column.

## Every tier filters, because a tier that didn't wouldn't return nothing

It would return **unfiltered** rows into a digest-scoped answer, where `MergeResults` folds them in beside genuinely matching rows:

| tier | behaviour |
|---|---|
| live MySQL | predicate inside the narrow **keys subquery** — on the outer JOIN the per-PK window would cap against rows the filter should have removed |
| Parquet archives | same predicate, **lowercased**: DuckDB compares case-sensitively where MySQL's collation does not, so only a canonical digest makes the tiers agree |
| pre-#699 archives | the column is in no file and `parquet_scan` errors on a predicate it cannot resolve (the trap `optionalCol` handles for the SELECT list) → warned, contributes no rows, never fails the query |
| baseline snapshot rows | always excluded — a materialised row image was produced by no statement |
| BYOS agent buffer | always excluded — the digest is an index-side enrichment a buffered event has not received yet |

## Query-only, on purpose

A digest names a statement **shape** (literals normalised away), so `--query-hash` on `recover` would reverse *every execution of that shape* in the window, not the one the operator meant — widening blast radius by construction. Pinning an execution needs `connection_id` + digest + time. A test asserts the flag is absent from `recover`.

## Refused under RBAC, never silently dropped

`applyRedaction` blanks the digest on every row under any policy because "a stable digest leaks statement shape and permits dictionary confirmation of embedded values". Answering a filter over it hands that association back one guess at a time. So:

- engine: `query.ErrQueryHashUnderProfile` from `Fetch` (covers library + MCP callers), keyed on the **same** three-way condition as the redaction pass (`RedactionActive()`, now one predicate instead of two copies that could drift)
- CLI: refused with both flag names, before connecting
- console `/mcp` (`RedactStatementText: true`): rejects the parameter — a surface that strips the digest from output can't let a client test candidates against it

An empty result set would have been the wrong shape here: it reads as "that statement touched nothing", a false negative on a forensic question. `NormalizeQueryHash` rejects a malformed digest for the same reason (the natural mistake is pasting the statement text).

## Demo image

`binlog-rows-query-log-events = ON` in `demo/image/my.cnf`. The eval image shipped showing every forensic surface with an empty statement column, which reads as "bintrail cannot capture this" rather than "this server was not asked to log it".

## Tests

- unit per tier (live SQL shape + keys-subquery placement, archive incl. the pre-#699 arg-count case, snapshot skip, buffer exclusion, normalisation, refusal across all three redaction shapes, `Fetch` refusing before touching a nil DB)
- **integration against real MySQL** (`TestFetch_queryHashFilter`): digests computed by `STATEMENT_DIGEST()` on the server, two executions of one shape + a second table + a different statement + an event captured with logging off; asserts the spread, case-insensitive input, no leakage, and the profile refusal. Verified it RAN (not skipped)
- each filter site mutation-checked individually — dropping any one of the four makes its test fail
- `go test ./...`, `go vet -tags integration ./...`, `-race` on all touched packages, integration suites for query/parquetquery/buffer all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
