### PR TITLE
stream: measure read→queryable, the lag that decides recovery readiness

### DIFF
--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -127,6 +127,23 @@ type Event struct {
 	// "invalid table id, no corresponding table map event" (#775). Transient:
 	// never written to binlog_events.
 	StmtEnd bool
+	// ReadAt is when the replication client delivered the binlog event this row
+	// came out of — T1 in the availability-lag design (#1223). Transient: it is
+	// in-memory only, never written to binlog_events and never to the archive
+	// Parquet, so nothing about it is a persistence contract.
+	//
+	// It is stamped at the PARSER, deliberately, not where the stream consumer
+	// receives the event off the channel: the channel is buffered, so a consumer
+	// stamp would fold the queue wait into T1 and hide exactly the backlog that
+	// T2−T1 exists to measure — when the indexer falls behind, that wait IS the
+	// lag.
+	//
+	// ZERO on the file path (`bintrail index`) and on any consumer that builds
+	// events itself: lag is meaningless for backfill re-indexing. Consumers must
+	// SKIP the observation on zero rather than observing a 0-second latency — a
+	// fabricated zero reads as "perfectly fresh", the most misleading value this
+	// field could produce.
+	ReadAt time.Time
 }
 
 // Filters controls which schemas and tables produce events.

--- a/internal/observe/metrics.go
+++ b/internal/observe/metrics.go
@@ -59,6 +59,48 @@ var (
 		Help:      "Seconds between now and the timestamp of the last processed binlog event.",
 	}, []string{"source"})
 
+	// streamIndexCommitLatency is T2−T1 (#1223): the seconds between the
+	// replication client delivering an event and that event being committed to
+	// the index — i.e. how long a change existed but was NOT yet queryable or
+	// recoverable. Both ends are the same process's clock, so it is skew-free
+	// and sub-second-accurate, which is why it and not the availability gauge is
+	// the metric to alert on. Observed PER EVENT: the point of a histogram here
+	// is the tail (the slowest event in a batch is the one that defines the real
+	// RPO), and a per-flush maximum would hide how many events waited.
+	streamIndexCommitLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "bintrail",
+		Subsystem: "stream",
+		Name:      "index_commit_latency_seconds",
+		Help:      "Seconds from replication read to the event being committed to the index (queryable/recoverable).",
+		Buckets:   prometheus.ExponentialBuckets(0.005, 2, 14), // 5ms … ~40s
+	}, []string{"source"})
+
+	// streamAvailabilityLag is T2−T0: source commit → queryable, the effective
+	// RPO. APPROXIMATE by construction — it subtracts the SOURCE's clock from
+	// the local one, so it carries any skew between them, and the binlog header
+	// timestamp it starts from has one-SECOND resolution. Negatives (a source
+	// clock ahead of ours) are clamped to 0 rather than reported: a negative
+	// availability lag is not a real state and would poison a rate/avg panel.
+	streamAvailabilityLag = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "bintrail",
+		Subsystem: "stream",
+		Name:      "availability_lag_seconds",
+		Help:      "Approximate seconds from source commit to queryable in the index (crosses source and local clocks; 1s source resolution; clamped at 0).",
+	}, []string{"source"})
+
+	// streamLastFlushTimestamp exists because every gauge above is only moved BY
+	// TRAFFIC: under an idle source they all freeze at their last value and a
+	// dashboard reads "caught up" forever, including when the stream died. Alert
+	// on `time() - bintrail_stream_last_flush_timestamp_seconds` instead, and use
+	// checkpoint recency (the checkpoint ticker runs with or without traffic) to
+	// tell IDLE from STALLED.
+	streamLastFlushTimestamp = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "bintrail",
+		Subsystem: "stream",
+		Name:      "last_flush_timestamp_seconds",
+		Help:      "Unix timestamp of the last batch successfully committed to the index.",
+	}, []string{"source"})
+
 	streamErrors = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "bintrail",
 		Subsystem: "stream",
@@ -107,12 +149,23 @@ type StreamMetrics struct {
 	BatchFlushes       prometheus.Counter
 	CheckpointSaves    prometheus.Counter
 	LastEventTimestamp prometheus.Gauge
-	ReplicationLag     prometheus.Gauge
+	// ReplicationLag keeps its RECEIVE-time semantics (source commit → read off
+	// the stream channel), deliberately unchanged: it is set before batching, so
+	// it can read "caught up" while events sit in an unflushed batch. The
+	// commit-side handles below are what close that window; existing dashboards
+	// built on this gauge keep meaning what they meant.
+	ReplicationLag prometheus.Gauge
+	// AvailabilityLag and LastFlushTimestamp are COMMIT-side (#1223): set only
+	// after a batch is durably in the index.
+	AvailabilityLag    prometheus.Gauge
+	LastFlushTimestamp prometheus.Gauge
 	// Errors keeps its remaining "type" dimension (batch_flush, checkpoint,
 	// gtid_update).
 	Errors *prometheus.CounterVec
 	// BatchSize is the per-source histogram handle.
 	BatchSize prometheus.Observer
+	// IndexCommitLatency is the per-source read→queryable histogram handle.
+	IndexCommitLatency prometheus.Observer
 }
 
 // ForSource returns the stream metrics curried to the given source label.
@@ -129,8 +182,11 @@ func ForSource(source string) *StreamMetrics {
 		CheckpointSaves:    streamCheckpointSaves.WithLabelValues(source),
 		LastEventTimestamp: streamLastEventTimestamp.WithLabelValues(source),
 		ReplicationLag:     streamReplicationLag.WithLabelValues(source),
+		AvailabilityLag:    streamAvailabilityLag.WithLabelValues(source),
+		LastFlushTimestamp: streamLastFlushTimestamp.WithLabelValues(source),
 		Errors:             streamErrors.MustCurryWith(prometheus.Labels{"source": source}),
 		BatchSize:          streamBatchSize.WithLabelValues(source),
+		IndexCommitLatency: streamIndexCommitLatency.WithLabelValues(source),
 	}
 }
 

--- a/internal/parser/drift_test.go
+++ b/internal/parser/drift_test.go
@@ -67,7 +67,7 @@ func runHandleRowsWith(t *testing.T, resolver *metadata.Resolver, binlogEv *repl
 	t.Helper()
 	rowsEv := binlogEv.Event.(*replication.RowsEvent)
 	out := make(chan Event, 4)
-	err := handleRows(context.Background(), newTestLogger(logBuf), resolver, &Filters{}, binlogEv, rowsEv, "binlog.000001", "", 0, 0, "", 9, out, nil, nil)
+	err := handleRows(context.Background(), newTestLogger(logBuf), resolver, &Filters{}, binlogEv, rowsEv, "binlog.000001", "", 0, 0, "", 9, emitTo(out), nil, nil)
 	close(out)
 	var evs []Event
 	for ev := range out {
@@ -397,7 +397,7 @@ func TestHandleRows_schemaGapTrackerFileMode(t *testing.T) {
 			rowsEv := tc.ev.Event.(*replication.RowsEvent)
 			out := make(chan Event, 4)
 			err := handleRows(context.Background(), newTestLogger(&bytes.Buffer{}), timedOrdersResolver(snapT),
-				&Filters{}, tc.ev, rowsEv, "binlog.000007", "", 0, 0, "", 9, out, tracker, nil)
+				&Filters{}, tc.ev, rowsEv, "binlog.000007", "", 0, 0, "", 9, emitTo(out), tracker, nil)
 			close(out)
 			// A skip is never a hard error at the handleRows layer — the
 			// file-level failure is decided by ParseFile from the tracker.

--- a/internal/parser/excluded_table_gap_test.go
+++ b/internal/parser/excluded_table_gap_test.go
@@ -53,7 +53,7 @@ func TestHandleRows_validationExcludedTableFileMode(t *testing.T) {
 		tracker := &schemaGapTracker{}
 		out := make(chan Event, 4)
 		err := handleRows(context.Background(), newTestLogger(&logBuf), excludedScratchResolver(snapT),
-			&Filters{}, ev, rowsEv, "binlog.000007", "", 0, 0, "", 9, out, tracker, nil)
+			&Filters{}, ev, rowsEv, "binlog.000007", "", 0, 0, "", 9, emitTo(out), tracker, nil)
 		close(out)
 		if err != nil {
 			t.Fatalf("handleRows returned a hard error on an excluded-table skip: %v", err)
@@ -85,7 +85,7 @@ func TestHandleRows_validationExcludedTableFileMode(t *testing.T) {
 		tracker := &schemaGapTracker{}
 		out := make(chan Event, 4)
 		err := handleRows(context.Background(), newTestLogger(&bytes.Buffer{}), excludedScratchResolver(snapT),
-			&Filters{}, ev, rowsEv, "binlog.000007", "", 0, 0, "", 9, out, tracker, nil)
+			&Filters{}, ev, rowsEv, "binlog.000007", "", 0, 0, "", 9, emitTo(out), tracker, nil)
 		close(out)
 		if err != nil {
 			t.Fatalf("handleRows: %v", err)
@@ -110,7 +110,7 @@ func TestHandleRows_validationExcludedTableFileMode(t *testing.T) {
 		tracker := &schemaGapTracker{}
 		out := make(chan Event, 4)
 		err := handleRows(context.Background(), newTestLogger(&logBuf), excludedScratchResolver(snapT),
-			&Filters{}, ev, rowsEv, "binlog.000007", "", 0, 0, "", 9, out, tracker, skips)
+			&Filters{}, ev, rowsEv, "binlog.000007", "", 0, 0, "", 9, emitTo(out), tracker, skips)
 		close(out)
 		if err != nil {
 			t.Fatalf("handleRows: %v", err)

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -40,6 +40,33 @@ const (
 // Aliased here so the binlog parser and existing callers keep using parser.Event.
 type Event = event.Event
 
+// emitter is the parser's only way out to a consumer. It exists so the read
+// timestamp (#1223 T1) is stamped STRUCTURALLY: every event leaves through
+// send, so a new emit path cannot forget to stamp the way it could if ReadAt
+// were just another field each Event literal had to remember to set.
+//
+// readAt is the zero Time on the file path — see event.Event.ReadAt for why
+// consumers must skip, not observe, a zero.
+type emitter struct {
+	ch     chan<- Event
+	readAt time.Time
+}
+
+// emitTo builds an unstamped emitter, for the file path and for tests.
+func emitTo(ch chan<- Event) emitter { return emitter{ch: ch} }
+
+// send stamps and delivers one event, honouring cancellation exactly as the
+// bare channel sends it replaced.
+func (e emitter) send(ctx context.Context, ev Event) error {
+	ev.ReadAt = e.readAt
+	select {
+	case e.ch <- ev:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 // ─── Filters ─────────────────────────────────────────────────────────────────
 
 // Filters is the source-agnostic schema/table filter, moved to internal/event
@@ -149,6 +176,10 @@ func (p *Parser) ParseFile(ctx context.Context, filename string, events chan<- E
 	// 'completed' with an undetected gap (#778).
 	var gaps schemaGapTracker
 
+	// The file path never stamps a read time: re-indexing a binlog from disk
+	// has no availability lag to measure (#1224).
+	em := emitTo(events)
+
 	bp := replication.NewBinlogParser()
 	// Pin TIMESTAMP-column string rendering to UTC. go-mysql's default (nil
 	// location) formats fracTime.String() using the raw time.Unix(...) value,
@@ -222,10 +253,8 @@ func (p *Parser) ParseFile(ctx context.Context, filename string, events chan<- E
 			currentQueryText = ""
 			ts := time.Unix(int64(binlogEv.Header.Timestamp), 0).UTC()
 			if ddlEv, ok := parseDDL(p.logger, filename, binlogEv.Header.LogPos, ts, currentGTID, string(ev.Query), p.schemaVersion.Load()); ok {
-				select {
-				case events <- ddlEv:
-				case <-ctx.Done():
-					return ctx.Err()
+				if err := em.send(ctx, ddlEv); err != nil {
+					return err
 				}
 			} else if kw, isDML := statementDML(string(ev.Query)); isDML {
 				// STATEMENT/MIXED-format DML (or a session flip off ROW): the row
@@ -269,7 +298,7 @@ func (p *Parser) ParseFile(ctx context.Context, filename string, events chan<- E
 			currentQueryText = event.SanitizeQueryText(string(ev.Query))
 
 		case *replication.RowsEvent:
-			err := handleRows(ctx, p.logger, p.resolver.Load(), &p.filters, binlogEv, ev, filename, currentGTID, currentConnectionID, currentCommitTsUS, currentQueryText, p.schemaVersion.Load(), events, &gaps, p.skips)
+			err := handleRows(ctx, p.logger, p.resolver.Load(), &p.filters, binlogEv, ev, filename, currentGTID, currentConnectionID, currentCommitTsUS, currentQueryText, p.schemaVersion.Load(), em, &gaps, p.skips)
 			// The LAST rows event of a statement carries STMT_END_F — the
 			// actual statement boundary. Clearing here keeps one statement's
 			// text alive across its chained/split rows events, while a later
@@ -454,7 +483,7 @@ func handleRows(
 	commitTsUS uint64,
 	queryText string,
 	schemaVersion uint32,
-	out chan<- Event,
+	out emitter,
 	gapTracker *schemaGapTracker,
 	skips *SkipCounters,
 ) error {
@@ -718,7 +747,7 @@ func emitInserts(
 	pkCols []metadata.ColumnMeta,
 	schemaVersion uint32,
 	stmtEnd bool,
-	out chan<- Event,
+	out emitter,
 ) error {
 	for _, row := range rows {
 		named, err := resolver.MapRow(schema, table, row)
@@ -736,10 +765,8 @@ func emitInserts(
 			SchemaVersion: schemaVersion,
 			StmtEnd:       stmtEnd,
 		}
-		select {
-		case out <- ev:
-		case <-ctx.Done():
-			return ctx.Err()
+		if err := out.send(ctx, ev); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -759,7 +786,7 @@ func emitDeletes(
 	pkCols []metadata.ColumnMeta,
 	schemaVersion uint32,
 	stmtEnd bool,
-	out chan<- Event,
+	out emitter,
 ) error {
 	for _, row := range rows {
 		named, err := resolver.MapRow(schema, table, row)
@@ -777,10 +804,8 @@ func emitDeletes(
 			SchemaVersion: schemaVersion,
 			StmtEnd:       stmtEnd,
 		}
-		select {
-		case out <- ev:
-		case <-ctx.Done():
-			return ctx.Err()
+		if err := out.send(ctx, ev); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -800,7 +825,7 @@ func emitUpdates(
 	pkCols []metadata.ColumnMeta,
 	schemaVersion uint32,
 	stmtEnd bool,
-	out chan<- Event,
+	out emitter,
 ) error {
 	// go-mysql delivers UPDATE rows as interleaved before/after pairs:
 	//   rows[0]=before0, rows[1]=after0, rows[2]=before1, rows[3]=after1, ...
@@ -827,10 +852,8 @@ func emitUpdates(
 			SchemaVersion: schemaVersion,
 			StmtEnd:       stmtEnd,
 		}
-		select {
-		case out <- ev:
-		case <-ctx.Done():
-			return ctx.Err()
+		if err := out.send(ctx, ev); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -207,7 +207,7 @@ func TestHandleRows_unhandledEventTypeLogsNotSilent(t *testing.T) {
 	rowsEv := binlogEv.Event.(*replication.RowsEvent)
 
 	out := make(chan Event, 4)
-	if err := handleRows(context.Background(), logger, resolver, &Filters{}, binlogEv, rowsEv, "mariadb-bin.000001", "0-1-1", 0, 0, "", 1, out, nil, nil); err != nil {
+	if err := handleRows(context.Background(), logger, resolver, &Filters{}, binlogEv, rowsEv, "mariadb-bin.000001", "0-1-1", 0, 0, "", 1, emitTo(out), nil, nil); err != nil {
 		t.Fatalf("handleRows: %v", err)
 	}
 
@@ -318,7 +318,7 @@ func TestHandleRows_mariadbCompressedRowTypes(t *testing.T) {
 			rowsEv := binlogEv.Event.(*replication.RowsEvent)
 
 			out := make(chan Event, 4)
-			if err := handleRows(context.Background(), logger, resolver, &Filters{}, binlogEv, rowsEv, "mariadb-bin.000001", "0-1-1", 0, 0, "", 1, out, nil, nil); err != nil {
+			if err := handleRows(context.Background(), logger, resolver, &Filters{}, binlogEv, rowsEv, "mariadb-bin.000001", "0-1-1", 0, 0, "", 1, emitTo(out), nil, nil); err != nil {
 				t.Fatalf("handleRows: %v", err)
 			}
 
@@ -736,7 +736,7 @@ func TestHandleRows_partialImageFailsLoud(t *testing.T) {
 	rowsEv := binlogEv.Event.(*replication.RowsEvent)
 
 	out := make(chan Event, 4)
-	err := handleRows(context.Background(), newTestLogger(&bytes.Buffer{}), resolver, &Filters{}, binlogEv, rowsEv, "binlog.000001", "0-1-1", 0, 0, "", 1, out, nil, nil)
+	err := handleRows(context.Background(), newTestLogger(&bytes.Buffer{}), resolver, &Filters{}, binlogEv, rowsEv, "binlog.000001", "0-1-1", 0, 0, "", 1, emitTo(out), nil, nil)
 	if err == nil {
 		t.Fatal("expected handleRows to fail loud on a partial row image, got nil")
 	}
@@ -788,7 +788,7 @@ func TestHandleRows_fullImagePasses(t *testing.T) {
 	rowsEv := binlogEv.Event.(*replication.RowsEvent)
 
 	out := make(chan Event, 4)
-	if err := handleRows(context.Background(), newTestLogger(&bytes.Buffer{}), resolver, &Filters{}, binlogEv, rowsEv, "binlog.000001", "0-1-1", 0, 0, "", 1, out, nil, nil); err != nil {
+	if err := handleRows(context.Background(), newTestLogger(&bytes.Buffer{}), resolver, &Filters{}, binlogEv, rowsEv, "binlog.000001", "0-1-1", 0, 0, "", 1, emitTo(out), nil, nil); err != nil {
 		t.Fatalf("handleRows must not fail on a FULL image, got: %v", err)
 	}
 	select {

--- a/internal/parser/skips_test.go
+++ b/internal/parser/skips_test.go
@@ -219,7 +219,7 @@ func TestHandleRows_columnCountMismatchCountsSkip(t *testing.T) {
 	rowsEv := binlogEv.Event.(*replication.RowsEvent)
 	out := make(chan Event, 4)
 	logBuf := &bytes.Buffer{}
-	err := handleRows(context.Background(), newTestLogger(logBuf), driftResolver(), &Filters{}, binlogEv, rowsEv, "binlog.000001", "", 0, 0, "", 9, out, nil, skips)
+	err := handleRows(context.Background(), newTestLogger(logBuf), driftResolver(), &Filters{}, binlogEv, rowsEv, "binlog.000001", "", 0, 0, "", 9, emitTo(out), nil, skips)
 	if err != nil {
 		t.Fatalf("a column-count mismatch is warn-and-skip on the stream path, got error: %v", err)
 	}
@@ -241,7 +241,7 @@ func TestHandleRows_tableNotInSnapshotCountsSkip(t *testing.T) {
 	rowsEv := binlogEv.Event.(*replication.RowsEvent)
 	rowsEv.Table.Schema = []byte("unknowndb")
 	out := make(chan Event, 4)
-	err := handleRows(context.Background(), newTestLogger(&bytes.Buffer{}), driftResolver(), &Filters{}, binlogEv, rowsEv, "binlog.000001", "", 0, 0, "", 9, out, nil, skips)
+	err := handleRows(context.Background(), newTestLogger(&bytes.Buffer{}), driftResolver(), &Filters{}, binlogEv, rowsEv, "binlog.000001", "", 0, 0, "", 9, emitTo(out), nil, skips)
 	if err != nil {
 		t.Fatalf("handleRows: %v", err)
 	}
@@ -261,7 +261,7 @@ func TestHandleRows_excludedSchemaSkipNotCounted(t *testing.T) {
 	rowsEv.Table.Schema = []byte("mysql")
 	rowsEv.Table.Table = []byte("rds_heartbeat2")
 	out := make(chan Event, 4)
-	err := handleRows(context.Background(), newTestLogger(&bytes.Buffer{}), driftResolver(), &Filters{}, binlogEv, rowsEv, "binlog.000001", "", 0, 0, "", 9, out, nil, skips)
+	err := handleRows(context.Background(), newTestLogger(&bytes.Buffer{}), driftResolver(), &Filters{}, binlogEv, rowsEv, "binlog.000001", "", 0, 0, "", 9, emitTo(out), nil, skips)
 	if err != nil {
 		t.Fatalf("handleRows: %v", err)
 	}
@@ -282,7 +282,7 @@ func TestHandleRows_captureBreaksEscalationRun(t *testing.T) {
 		t.Helper()
 		rowsEv := binlogEv.Event.(*replication.RowsEvent)
 		out := make(chan Event, 4)
-		if err := handleRows(context.Background(), newTestLogger(&bytes.Buffer{}), driftResolver(), &Filters{}, binlogEv, rowsEv, "binlog.000001", "", 0, 0, "", 9, out, nil, skips); err != nil {
+		if err := handleRows(context.Background(), newTestLogger(&bytes.Buffer{}), driftResolver(), &Filters{}, binlogEv, rowsEv, "binlog.000001", "", 0, 0, "", 9, emitTo(out), nil, skips); err != nil {
 			t.Fatalf("handleRows: %v", err)
 		}
 	}

--- a/internal/parser/stream.go
+++ b/internal/parser/stream.go
@@ -173,6 +173,12 @@ func (sp *StreamParser) Run(ctx context.Context, streamer *replication.BinlogStr
 	// see the file parser's currentQueryText for the full contract.
 	var currentQueryText string
 
+	// em is the stamped way out (#1223 T1). It is REBUILT on every delivered
+	// binlog event, just below, so each emitted row carries the time go-mysql
+	// handed us the event it came from. The closures below close over the
+	// variable, not over a value, so they always send through the current stamp.
+	var em emitter
+
 	// emitCommit signals a transaction commit boundary so the stream consumer can
 	// advance the durable GTID checkpoint only after the transaction's rows have
 	// been received (#491). It commits the in-flight transaction (currentGTID) and
@@ -191,13 +197,11 @@ func (sp *StreamParser) Run(ctx context.Context, streamer *replication.BinlogStr
 			GTID:       currentGTID,
 			EventType:  EventCommit,
 		}
-		select {
-		case out <- commitEv:
-			currentGTID = "" // committed; the next-GTID fallback must not re-commit it
-			return nil
-		case <-ctx.Done():
-			return ctx.Err()
+		if err := em.send(ctx, commitEv); err != nil {
+			return err
 		}
+		currentGTID = "" // committed; the next-GTID fallback must not re-commit it
+		return nil
 	}
 
 	// emitGTIDTracking emits an EventGTID for the in-flight currentGTID so the
@@ -215,12 +219,7 @@ func (sp *StreamParser) Run(ctx context.Context, streamer *replication.BinlogStr
 			GTID:       currentGTID,
 			EventType:  EventGTID,
 		}
-		select {
-		case out <- gtidEv:
-			return nil
-		case <-ctx.Done():
-			return ctx.Err()
-		}
+		return em.send(ctx, gtidEv)
 	}
 
 	// handleEvent processes one binlog event. It is recursive: with
@@ -372,10 +371,8 @@ func (sp *StreamParser) Run(ctx context.Context, streamer *replication.BinlogStr
 						return fmt.Errorf("sync DDL hook: %w", err)
 					}
 				}
-				select {
-				case out <- ddlEv:
-				case <-ctx.Done():
-					return ctx.Err()
+				if err := em.send(ctx, ddlEv); err != nil {
+					return err
 				}
 				// Table DDL auto-commits its own GTID; EventDDL is the commit
 				// boundary the consumer acts on, so clear the in-flight GTID to keep
@@ -446,7 +443,7 @@ func (sp *StreamParser) Run(ctx context.Context, streamer *replication.BinlogStr
 			// nil gapTracker: the stream keeps its warn-and-continue skip
 			// behavior (the synchronous DDL hook, SetSyncDDLHook, is the
 			// stream's post-DDL correctness mechanism, not file-level failure).
-			err := handleRows(ctx, sp.logger, sp.resolver.Load(), &sp.filters, binlogEv, ev, currentFile, currentGTID, currentConnectionID, currentCommitTsUS, currentQueryText, sp.schemaVersion.Load(), out, nil, sp.skips)
+			err := handleRows(ctx, sp.logger, sp.resolver.Load(), &sp.filters, binlogEv, ev, currentFile, currentGTID, currentConnectionID, currentCommitTsUS, currentQueryText, sp.schemaVersion.Load(), em, nil, sp.skips)
 			// Statement boundary — see the file parser's RowsEvent case: the
 			// STMT_END_F clear prevents a ROWS_QUERY-less later statement in
 			// the same transaction from inheriting this statement's text.
@@ -488,6 +485,13 @@ func (sp *StreamParser) Run(ctx context.Context, streamer *replication.BinlogStr
 			}
 			return err
 		}
+
+		// T1 (#1223): the moment the replication client delivered this event.
+		// Everything emitted while handling it carries this stamp — taken HERE
+		// and not where the consumer receives off `out`, because `out` is
+		// buffered and a receive-side stamp would swallow the queue wait, which
+		// is the largest part of the lag precisely when the indexer is behind.
+		em = emitter{ch: out, readAt: time.Now()}
 
 		if err := handleEvent(binlogEv); err != nil {
 			if ctx.Err() != nil {

--- a/internal/parser/stream_test.go
+++ b/internal/parser/stream_test.go
@@ -1111,3 +1111,67 @@ func TestStreamParser_emptyPayloadNoEffect(t *testing.T) {
 		t.Errorf("expected 0 events from empty/ignored payloads, got %d", len(out))
 	}
 }
+
+// TestStreamParser_stampsReadAt pins T1 (#1224): every event leaving the stream
+// parser carries the time the replication client delivered the binlog event it
+// came from. The assertion is bracketed by wall-clock reads taken around Run, so
+// it fails both on a missing stamp (zero) and on a stamp taken from the wrong
+// clock or the wrong moment.
+func TestStreamParser_stampsReadAt(t *testing.T) {
+	sp := NewStreamParser(nil, Filters{}, nil)
+	streamer := replication.NewBinlogStreamer()
+	out := make(chan Event, 10)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	before := time.Now()
+	feedThenCancel(t, streamer, cancel, makeGTIDEvent(42))
+	if err := sp.Run(ctx, streamer, out); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	after := time.Now()
+
+	if len(out) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(out))
+	}
+	ev := <-out
+	if ev.ReadAt.IsZero() {
+		t.Fatal("ReadAt is zero on a streamed event — the T1 stamp never landed")
+	}
+	if ev.ReadAt.Before(before) || ev.ReadAt.After(after) {
+		t.Errorf("ReadAt %v outside the run window [%v, %v]", ev.ReadAt, before, after)
+	}
+}
+
+// TestEmitter_filePathLeavesReadAtZero pins the other half of the contract: the
+// unstamped emitter the file path uses must never fabricate a read time. A zero
+// ReadAt is the signal consumers key off to SKIP the observation — a stamped
+// file-mode event would report a re-index of month-old binlogs as fresh.
+func TestEmitter_filePathLeavesReadAtZero(t *testing.T) {
+	ch := make(chan Event, 1)
+	if err := emitTo(ch).send(context.Background(), Event{EventType: EventInsert}); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if got := (<-ch).ReadAt; !got.IsZero() {
+		t.Errorf("emitTo stamped ReadAt = %v, want zero", got)
+	}
+}
+
+// TestEmitter_sendStampsAndHonoursCancellation covers the two behaviours send
+// took over from the bare channel sends it replaced.
+func TestEmitter_sendStampsAndHonoursCancellation(t *testing.T) {
+	want := time.Now().Add(-3 * time.Second)
+	ch := make(chan Event, 1)
+	if err := (emitter{ch: ch, readAt: want}).send(context.Background(), Event{}); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if got := (<-ch).ReadAt; !got.Equal(want) {
+		t.Errorf("ReadAt = %v, want %v", got, want)
+	}
+
+	// Unbuffered channel with no reader: send must return ctx.Err(), not block.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := (emitter{ch: make(chan Event), readAt: want}).send(ctx, Event{}); !errors.Is(err, context.Canceled) {
+		t.Errorf("send on a cancelled ctx = %v, want context.Canceled", err)
+	}
+}

--- a/internal/streamrun/commit_lag.go
+++ b/internal/streamrun/commit_lag.go
@@ -1,0 +1,61 @@
+package streamrun
+
+import (
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/observe"
+	"github.com/dbtrail/dbtrail/internal/parser"
+)
+
+// observeCommitLag publishes the commit-side availability metrics for a batch
+// that has just landed in the index (#1223/#1225). now is T2 — the moment the
+// INSERT committed and the batch became queryable and recoverable.
+//
+// Pure apart from the metric writes and separated from flush() so the decisions
+// below are testable without a MySQL round trip; the caller has already
+// established that the flush SUCCEEDED.
+//
+// Three rules the tests pin, each of which is a way this could lie:
+//
+//   - A zero ReadAt is SKIPPED, never observed as 0. Zero means the event was
+//     built by something that does not read replication (file-mode re-index, a
+//     synthesized event); recording it would report a re-index of month-old
+//     binlogs as a 0-second latency, the most convincing possible "everything
+//     is fresh". Per event, so a mixed batch cannot contaminate the histogram.
+//   - The availability lag is the batch MAXIMUM, not the last event's: the
+//     oldest change in the batch defines the recovery point, and a lag gauge
+//     that reports anything better than its worst event is not a safety signal.
+//   - LastFlushTimestamp is set for EVERY successful non-empty flush, including
+//     one where every ReadAt was zero. It answers "when did this process last
+//     make anything queryable", which is exactly the question the other two
+//     gauges cannot answer once traffic stops.
+func observeCommitLag(m *observe.StreamMetrics, batch []parser.Event, now time.Time) {
+	if m == nil || len(batch) == 0 {
+		return
+	}
+	maxLag, haveLag := 0.0, false
+	for i := range batch {
+		ev := &batch[i]
+		if ev.ReadAt.IsZero() {
+			continue
+		}
+		m.IndexCommitLatency.Observe(now.Sub(ev.ReadAt).Seconds())
+		if ev.Timestamp.IsZero() {
+			continue
+		}
+		// T2−T0 crosses the source's clock and ours. A source clock running
+		// ahead yields a negative, which is not a state that exists: clamp to 0
+		// rather than publish a number that would drag an average below zero.
+		lag := now.Sub(ev.Timestamp).Seconds()
+		if lag < 0 {
+			lag = 0
+		}
+		if !haveLag || lag > maxLag {
+			maxLag, haveLag = lag, true
+		}
+	}
+	if haveLag {
+		m.AvailabilityLag.Set(maxLag)
+	}
+	m.LastFlushTimestamp.Set(float64(now.Unix()))
+}

--- a/internal/streamrun/commit_lag_integration_test.go
+++ b/internal/streamrun/commit_lag_integration_test.go
@@ -1,0 +1,117 @@
+//go:build integration
+
+package streamrun
+
+import (
+	"context"
+	"database/sql"
+	"strconv"
+	"testing"
+	"time"
+
+	promtest "github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/observe"
+	"github.com/dbtrail/dbtrail/internal/parser"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// lagEvents builds n synthetic INSERTs for testdb.orders, each stamped as read
+// readAgo ago and committed at the source commitAgo ago.
+func lagEvents(n int, readAgo, commitAgo time.Duration) []parser.Event {
+	now := time.Now().UTC()
+	evs := make([]parser.Event, 0, n)
+	for i := range n {
+		evs = append(evs, parser.Event{
+			BinlogFile: "binlog.000001",
+			StartPos:   uint64(i * 100),
+			EndPos:     uint64((i + 1) * 100),
+			Timestamp:  now.Add(-commitAgo),
+			ReadAt:     now.Add(-readAgo),
+			Schema:     "testdb",
+			Table:      "orders",
+			EventType:  parser.EventInsert,
+			PKValues:   strconv.Itoa(i + 1),
+			RowAfter:   map[string]any{"id": int64(i + 1), "amount": 9.99},
+		})
+	}
+	return evs
+}
+
+// lagTestIndex stands up the same minimal index TestStreamLoop_flushAndCheckpoint uses.
+func lagTestIndex(t *testing.T) (*indexer.Indexer, *sql.DB) {
+	t.Helper()
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	testutil.InsertSnapshot(t, db, 1, "2026-01-01 00:00:00",
+		"testdb", "orders", "id", 1, "PRI", "int", "NO")
+	testutil.InsertSnapshot(t, db, 1, "2026-01-01 00:00:00",
+		"testdb", "orders", "amount", 2, "", "decimal", "YES")
+	return indexer.New(db, 10), db
+}
+
+func feedClosed(evs []parser.Event) chan parser.Event {
+	ch := make(chan parser.Event, len(evs)+1)
+	for _, ev := range evs {
+		ch <- ev
+	}
+	close(ch)
+	return ch
+}
+
+// TestStreamLoop_commitLagMetricsWired covers the WIRING, which the pure
+// observeCommitLag unit tests cannot: that flush() actually calls it after a
+// successful InsertBatch. Deleting that call leaves every unit test in
+// commit_lag_test.go green while shipping a build that publishes no
+// availability signal at all.
+func TestStreamLoop_commitLagMetricsWired(t *testing.T) {
+	idx, db := lagTestIndex(t)
+	m := observe.ForSource("wired-ok")
+
+	before := histCount(t, m.IndexCommitLatency)
+	err := streamLoop(context.Background(), feedClosed(lagEvents(3, 2*time.Second, 30*time.Second)),
+		idx, db, time.Hour, &streamState{mode: "position", serverID: 1}, m, nil)
+	if err != nil {
+		t.Fatalf("streamLoop: %v", err)
+	}
+
+	if got := histCount(t, m.IndexCommitLatency) - before; got != 3 {
+		t.Errorf("index_commit_latency observations = %d, want 3 — flush() never called observeCommitLag", got)
+	}
+	if got := promtest.ToFloat64(m.LastFlushTimestamp); got == 0 {
+		t.Error("last_flush_timestamp is 0 after a successful flush")
+	}
+	// ~30s behind at the source; a clamp or a wrong subtraction shows up here.
+	if got := promtest.ToFloat64(m.AvailabilityLag); got < 25 || got > 60 {
+		t.Errorf("availability_lag = %v, want ≈30", got)
+	}
+}
+
+// TestStreamLoop_commitLagSilentOnFlushFailure pins the other half: a FAILED
+// InsertBatch must publish nothing. A flush timestamp advanced by a failed write
+// is the worst possible reading — it claims data became queryable at exactly the
+// moment data did not.
+func TestStreamLoop_commitLagSilentOnFlushFailure(t *testing.T) {
+	idx, db := lagTestIndex(t)
+	m := observe.ForSource("wired-fail")
+
+	// Force the INSERT to fail, the same way TestStreamLoop_flushFailurePropagates does.
+	if _, err := db.Exec("DROP TABLE binlog_events"); err != nil {
+		t.Fatalf("DROP TABLE: %v", err)
+	}
+
+	before := histCount(t, m.IndexCommitLatency)
+	err := streamLoop(context.Background(), feedClosed(lagEvents(2, time.Second, 10*time.Second)),
+		idx, db, time.Hour, &streamState{mode: "position", serverID: 1}, m, nil)
+	if err == nil {
+		t.Fatal("expected streamLoop to propagate the flush failure")
+	}
+
+	if got := histCount(t, m.IndexCommitLatency) - before; got != 0 {
+		t.Errorf("index_commit_latency observations = %d after a FAILED flush, want 0", got)
+	}
+	if got := promtest.ToFloat64(m.LastFlushTimestamp); got != 0 {
+		t.Errorf("last_flush_timestamp = %v after a FAILED flush, want 0 — nothing became queryable", got)
+	}
+}

--- a/internal/streamrun/commit_lag_test.go
+++ b/internal/streamrun/commit_lag_test.go
@@ -1,0 +1,127 @@
+package streamrun
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/dbtrail/dbtrail/internal/observe"
+	"github.com/dbtrail/dbtrail/internal/parser"
+)
+
+// histCount reads a histogram child's sample count. testutil.ToFloat64 refuses
+// histograms, so go through the Metric interface the observer also implements.
+func histCount(t *testing.T, o prometheus.Observer) uint64 {
+	t.Helper()
+	c, ok := o.(prometheus.Metric)
+	if !ok {
+		t.Fatalf("observer %T is not a prometheus.Metric", o)
+	}
+	var m dto.Metric
+	if err := c.Write(&m); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	return m.GetHistogram().GetSampleCount()
+}
+
+func TestObserveCommitLag_observesPerEventAndTakesTheWorstLag(t *testing.T) {
+	m := observe.ForSource("commit-lag-basic")
+	now := time.Date(2026, 8, 7, 12, 0, 30, 0, time.UTC)
+	read := now.Add(-2 * time.Second)
+
+	batch := []parser.Event{
+		// Committed at the source 10s before T2.
+		{ReadAt: read, Timestamp: now.Add(-10 * time.Second)},
+		// The OLDEST source commit in the batch — this is the one the gauge must
+		// report, not the newest and not the last.
+		{ReadAt: read, Timestamp: now.Add(-45 * time.Second)},
+		{ReadAt: read, Timestamp: now.Add(-3 * time.Second)},
+	}
+	before := histCount(t, m.IndexCommitLatency)
+	observeCommitLag(m, batch, now)
+
+	if got := histCount(t, m.IndexCommitLatency) - before; got != 3 {
+		t.Errorf("histogram observations = %d, want 3 (one per event, not one per flush)", got)
+	}
+	if got := testutil.ToFloat64(m.AvailabilityLag); got != 45 {
+		t.Errorf("availability_lag = %v, want 45 (the batch maximum)", got)
+	}
+	if got := testutil.ToFloat64(m.LastFlushTimestamp); got != float64(now.Unix()) {
+		t.Errorf("last_flush_timestamp = %v, want %v", got, now.Unix())
+	}
+}
+
+// A zero ReadAt must be skipped, not observed as a 0-second latency: file-mode
+// re-indexing of old binlogs would otherwise publish the most convincing
+// possible "everything is perfectly fresh".
+func TestObserveCommitLag_skipsZeroReadAtPerEvent(t *testing.T) {
+	m := observe.ForSource("commit-lag-zero")
+	now := time.Date(2026, 8, 7, 12, 0, 30, 0, time.UTC)
+
+	batch := []parser.Event{
+		{Timestamp: now.Add(-90 * time.Second)},                               // zero ReadAt: skipped entirely
+		{ReadAt: now.Add(-time.Second), Timestamp: now.Add(-5 * time.Second)}, // the only observable event
+	}
+	before := histCount(t, m.IndexCommitLatency)
+	observeCommitLag(m, batch, now)
+
+	if got := histCount(t, m.IndexCommitLatency) - before; got != 1 {
+		t.Errorf("histogram observations = %d, want 1 — a zero ReadAt must not be observed", got)
+	}
+	// The skipped event is 90s old at the source; folding it in would report 90.
+	if got := testutil.ToFloat64(m.AvailabilityLag); got != 5 {
+		t.Errorf("availability_lag = %v, want 5 — a zero-ReadAt event must not reach the gauge", got)
+	}
+}
+
+// An all-zero batch (every event from a non-replication producer) must leave the
+// lag gauges untouched rather than resetting them to 0 — but the flush DID make
+// data queryable, so the flush timestamp still advances.
+func TestObserveCommitLag_allZeroLeavesLagGaugesButStampsFlush(t *testing.T) {
+	m := observe.ForSource("commit-lag-allzero")
+	m.AvailabilityLag.Set(123)
+	now := time.Date(2026, 8, 7, 12, 0, 30, 0, time.UTC)
+
+	before := histCount(t, m.IndexCommitLatency)
+	observeCommitLag(m, []parser.Event{{Timestamp: now}, {Timestamp: now}}, now)
+
+	if got := histCount(t, m.IndexCommitLatency) - before; got != 0 {
+		t.Errorf("histogram observations = %d, want 0", got)
+	}
+	if got := testutil.ToFloat64(m.AvailabilityLag); got != 123 {
+		t.Errorf("availability_lag = %v, want the untouched 123 — never reset to a fabricated 0", got)
+	}
+	if got := testutil.ToFloat64(m.LastFlushTimestamp); got != float64(now.Unix()) {
+		t.Errorf("last_flush_timestamp = %v, want %v — the flush happened regardless", got, now.Unix())
+	}
+}
+
+// A source clock running ahead of ours produces a negative T2−T0. Publishing it
+// would drag any average or rate panel below zero for a state that does not
+// exist.
+func TestObserveCommitLag_clampsNegativeLagToZero(t *testing.T) {
+	m := observe.ForSource("commit-lag-skew")
+	now := time.Date(2026, 8, 7, 12, 0, 30, 0, time.UTC)
+
+	observeCommitLag(m, []parser.Event{
+		{ReadAt: now.Add(-time.Second), Timestamp: now.Add(30 * time.Second)},
+	}, now)
+
+	if got := testutil.ToFloat64(m.AvailabilityLag); got != 0 {
+		t.Errorf("availability_lag = %v, want 0 (clamped)", got)
+	}
+}
+
+func TestObserveCommitLag_emptyBatchIsANoOp(t *testing.T) {
+	m := observe.ForSource("commit-lag-empty")
+	m.LastFlushTimestamp.Set(7)
+
+	observeCommitLag(m, nil, time.Now())
+
+	if got := testutil.ToFloat64(m.LastFlushTimestamp); got != 7 {
+		t.Errorf("last_flush_timestamp = %v, want the untouched 7", got)
+	}
+}

--- a/internal/streamrun/streamrun.go
+++ b/internal/streamrun/streamrun.go
@@ -1469,6 +1469,14 @@ func streamLoop(
 		state.eventsIndexed += n
 		m.EventsIndexed.Add(float64(n))
 		m.BatchFlushes.Inc()
+		if err == nil {
+			// T2 (#1225): the batch is durable, so its events are queryable and
+			// recoverable NOW. Only on success — a failed InsertBatch may have
+			// written some rows, but nothing about that partial state is an
+			// availability guarantee worth publishing. Read the batch before the
+			// truncation below.
+			observeCommitLag(m, batch, time.Now())
+		}
 		batch = batch[:0]
 		if err != nil {
 			m.Errors.WithLabelValues("batch_flush").Inc()


### PR DESCRIPTION
closes #1224
closes #1225

First PR of #1223. `ReadAt` and its only consumer ship together — landing the field alone would put a struct member nothing reads on `main`.

## The problem

`bintrail_stream_replication_lag` is set when an event comes **off** the stream channel, before batching. An event can sit in an unflushed batch — up to a full batch or a checkpoint interval — while the gauge reads "caught up", though the event is not queryable and not recoverable. Nothing measured receive→committed, the window that decides whether a recovery can reach a given point in time.

## #1224 — `ReadAt` (T1)

`event.Event` gains `ReadAt`, stamped when the replication client delivers the binlog event. In-memory only: never written to `binlog_events`, never to the archive Parquet.

**Stamped at the parser, not at `streamLoop`'s receive.** This is a correctness point, not a style one: the channel is buffered, so a receive-side stamp folds the queue wait into T1 and hides exactly the backlog T2−T1 exists to measure. When the indexer falls behind, that wait *is* the lag.

The stamp is **structural rather than conventional**: `out chan<- Event` becomes an `emitter{ch, readAt}` whose `send()` is the only way an event reaches a consumer. A future emit path cannot forget to stamp the way it could if `ReadAt` were one more field every `Event` literal had to remember. The file path builds an unstamped `emitTo()` — re-indexing binlogs from disk has no availability lag, and its events stay zero.

## #1225 — the three commit-side metrics

After a **successful** `InsertBatch` (T2), `observeCommitLag` publishes:

| Metric | Type | Meaning |
|---|---|---|
| `bintrail_stream_index_commit_latency_seconds` | histogram | T2−T1, **per event**. Same-process clock: skew-free, sub-second. The one to alert on. |
| `bintrail_stream_availability_lag_seconds` | gauge | T2−T0, batch maximum. The effective RPO; approximate (two clocks, 1s source resolution). |
| `bintrail_stream_last_flush_timestamp_seconds` | gauge | Unix seconds. What alerting divides on. |

Per event, not per flush: the tail defines the real RPO and a per-flush maximum hides how many events waited. The label set is `{source}` either way, so there is no cardinality cost.

Four rules, each a distinct way this metric could **lie**:

- **A zero `ReadAt` is skipped, never observed as 0.** A file-mode re-index of month-old binlogs would otherwise publish the most convincing possible "everything is perfectly fresh". Per event, so a mixed batch cannot contaminate the histogram.
- **The availability gauge takes the batch maximum.** The oldest change defines the recovery point; a lag gauge that reports better than its worst event is not a safety signal.
- **Negative T2−T0 clamps to 0.** It crosses the source's clock and ours; a source running ahead is not a real state and would drag an average below zero.
- **`last_flush` advances on every successful non-empty flush and never on a failed one.** Every other gauge freezes under idle traffic and a frozen gauge reads identical to a healthy one — this is what makes `time() - metric` work, and checkpoint recency is what separates *idle* from *stalled*.

`replication_lag` keeps its receive-time semantics untouched; existing dashboards keep meaning what they meant.

## Test plan

- [x] `go test ./... -count=1` and `go vet ./...` clean; `go vet -tags integration` clean
- [x] `-race` on `internal/parser`, `internal/streamrun`, `internal/observe`
- [x] Integration tests **ran** against the Docker MySQL (0.41s / 0.44s), not skipped
- [x] Every invariant mutation-verified — see below

Each rule was proven covered by breaking it and watching the specific test fail:

| Mutation | Result |
|---|---|
| drop the zero-`ReadAt` skip | 2 tests fail |
| batch maximum → last event | fails |
| drop the negative clamp | fails |
| delete `observeCommitLag` from `flush()` | integration test fails on all 3 assertions |

That last one is the important one: the pure unit tests all stay **green** when the call is deleted from `flush()`, so without the integration test a build publishing no availability signal at all would ship clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
